### PR TITLE
Bundles Landing Page - Added Paper Bundle With Redux

### DIFF
--- a/assets/components/radioToggle/radioToggle.jsx
+++ b/assets/components/radioToggle/radioToggle.jsx
@@ -12,7 +12,7 @@ export default function RadioToggle(props) {
     const radioId = `${props.name}-${idx}`;
 
     return (
-      <label htmlFor={radioId}>
+      <span>
         <input
           type="radio"
           name={props.name}
@@ -21,8 +21,8 @@ export default function RadioToggle(props) {
           onChange={props.toggleAction(radio.value)}
           checked={radio.value === props.checked}
         />
-        {radio.text}
-      </label>
+        <label htmlFor={radioId}>{radio.text}</label>
+      </span>
     );
 
   });

--- a/assets/components/radioToggle/radioToggle.jsx
+++ b/assets/components/radioToggle/radioToggle.jsx
@@ -1,0 +1,43 @@
+// ----- Imports ----- //
+
+import React from 'react';
+
+
+// ----- Component ----- //
+
+export default function RadioToggle(props) {
+
+  const radioButtons = props.radios.map((radio, idx) => {
+
+    const radioId = `${props.name}-${idx}`;
+
+    return (
+      <label htmlFor={radioId}>
+        <input
+          type="radio"
+          name={props.name}
+          value={radio.value}
+          id={radioId}
+          onChange={props.toggleAction(radio.value)}
+          checked={radio.value === props.checked}
+        />
+        {radio.text}
+      </label>
+    );
+
+  });
+
+  return <div className="component-radio-toggle">{radioButtons}</div>;
+
+}
+
+
+// ----- Proptypes ----- //
+
+RadioToggle.propTypes = {
+  radios: React.PropTypes.arrayOf(React.PropTypes.shape({
+    value: React.PropTypes.string,
+    text: React.PropTypes.string,
+  })).isRequired,
+  checked: React.PropTypes.string.isRequired,
+};

--- a/assets/components/radioToggle/radioToggle.scss
+++ b/assets/components/radioToggle/radioToggle.scss
@@ -1,0 +1,17 @@
+.component-radio-toggle {
+
+	input[type="radio"] {
+		display: none;
+	}
+
+	label {
+		background-color: #fff;
+		border-radius: 600px;
+		border: none;
+		padding: 6px 10px;
+		margin: 3px 0;
+		height: 36px;
+		cursor: pointer;
+	}
+
+}

--- a/assets/pages/bundles-landing/actions/bundlesLandingActions.js
+++ b/assets/pages/bundles-landing/actions/bundlesLandingActions.js
@@ -1,0 +1,5 @@
+// ----- Actions ----- //
+
+export default function changePaperBundle(bundle) {
+  return { type: 'CHANGE_PAPER_BUNDLE', payload: bundle };
+}

--- a/assets/pages/bundles-landing/bundlesLanding.jsx
+++ b/assets/pages/bundles-landing/bundlesLanding.jsx
@@ -2,12 +2,24 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
+import { createStore } from 'redux';
+import { Provider } from 'react-redux';
 
 import Bundles from './components/Bundles';
+import reducer from './reducers/paperBundle';
+
+
+// ----- Redux Store ----- //
+
+const store = createStore(reducer);
 
 
 // ----- Render ----- //
 
-const content = <Bundles />;
+const content = (
+  <Provider store={store}>
+    <Bundles />
+  </Provider>
+);
 
 ReactDOM.render(content, document.getElementById('bundles-landing-page'));

--- a/assets/pages/bundles-landing/bundlesLanding.jsx
+++ b/assets/pages/bundles-landing/bundlesLanding.jsx
@@ -11,7 +11,7 @@ import reducer from './reducers/paperBundle';
 
 // ----- Redux Store ----- //
 
-const store = createStore(reducer);
+const store = createStore(reducer, 'PAPER+DIGITAL');
 
 
 // ----- Render ----- //

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -1,11 +1,19 @@
 #bundles-landing-page {
-	width: 300px;
-	background-color: #1db7d7;
 
 	// ----- Page Components ----- //
 
-	.bundles {
+	.bundles__bundle {
+		width: 300px;
 		padding: 8px 10px 12px;
+		float: left;
+	}
+
+	.bundles__bundle--digital {
+		background-color: #1db7d7;
+	}
+
+	.bundles__bundle--paper {
+		background-color: #58a1ce;
 	}
 
 	// ----- Shared Components ----- //

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -22,4 +22,9 @@
 		margin-bottom: 24px;
 	}
 
+	input:checked+label {
+		background-color: gu-colour(guardian-brand-dark);
+		color: #fff;
+	}
+
 }

--- a/assets/pages/bundles-landing/components/Bundle.jsx
+++ b/assets/pages/bundles-landing/components/Bundle.jsx
@@ -1,21 +1,22 @@
 // ----- Imports ----- //
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import DoubleHeading from 'components/doubleHeading/doubleHeading';
-import FeatureList from 'components/featureList/featureList';
 import InfoText from 'components/infoText/infoText';
 import CtaLink from 'components/ctaLink/ctaLink';
 
 
 // ----- Component ----- //
 
-export default function Bundle(props) {
+function Bundle(props) {
 
-  const modifierClass = props.modifierClass ?
-    `bundles__bundle--${props.modifierClass}` : '';
+  let className = 'bundles__bundle';
 
-  const className = `bundles__bundle ${modifierClass}`;
+  if (props.modifierClass) {
+    className = `${className} bundles__bundle--${props.modifierClass}`;
+  }
 
   return (
     <div className={className}>
@@ -23,7 +24,7 @@ export default function Bundle(props) {
         heading={props.heading}
         subheading={props.subheading}
       />
-      <FeatureList listItems={props.listItems} />
+      {props.children}
       {props.infoText ? <InfoText text={props.infoText} /> : ''}
       <CtaLink text={props.ctaText} url={props.ctaLink} />
     </div>
@@ -36,18 +37,22 @@ export default function Bundle(props) {
 
 Bundle.defaultProps = {
   subheading: '',
-  listItems: [],
   infoText: '',
+  modifierClass: '',
+  children: null,
 };
 
 Bundle.propTypes = {
   heading: React.PropTypes.string.isRequired,
   subheading: React.PropTypes.string,
-  listItems: React.PropTypes.arrayOf(React.PropTypes.shape({
-    heading: React.PropTypes.string,
-    text: React.PropTypes.string,
-  })),
   infoText: React.PropTypes.string,
   ctaText: React.PropTypes.string.isRequired,
   ctaLink: React.PropTypes.string.isRequired,
+  modifierClass: React.PropTypes.string,
+  children: React.PropTypes.element,
 };
+
+
+// ----- Exports ----- //
+
+export default connect()(Bundle);

--- a/assets/pages/bundles-landing/components/Bundle.jsx
+++ b/assets/pages/bundles-landing/components/Bundle.jsx
@@ -12,8 +12,13 @@ import CtaLink from 'components/ctaLink/ctaLink';
 
 export default function Bundle(props) {
 
+  const modifierClass = props.modifierClass ?
+    `bundles__bundle--${props.modifierClass}` : '';
+
+  const className = `bundles__bundle ${modifierClass}`;
+
   return (
-    <div className="bundles__bundle">
+    <div className={className}>
       <DoubleHeading
         heading={props.heading}
         subheading={props.subheading}

--- a/assets/pages/bundles-landing/components/Bundle.jsx
+++ b/assets/pages/bundles-landing/components/Bundle.jsx
@@ -49,7 +49,7 @@ Bundle.propTypes = {
   ctaText: React.PropTypes.string.isRequired,
   ctaLink: React.PropTypes.string.isRequired,
   modifierClass: React.PropTypes.string,
-  children: React.PropTypes.element,
+  children: React.PropTypes.elements,
 };
 
 

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -35,7 +35,7 @@ const bundles = {
     modifierClass: 'digital',
   },
   paperDigital: {
-    heading: 'From £10.79/month',
+    heading: 'From £22.06/month',
     subheading: 'Become a paper subscriber',
     listItems: [
       {

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -1,8 +1,12 @@
 // ----- Imports ----- //
 
 import React from 'react';
+import { connect } from 'react-redux';
 
+import FeatureList from 'components/featureList/featureList';
+import RadioToggle from 'components/radioToggle/radioToggle';
 import Bundle from './Bundle';
+import changePaperBundle from '../actions/bundlesLandingActions';
 
 
 // ----- Copy ----- //
@@ -30,7 +34,7 @@ const bundles = {
     ctaLink: 'https://subscribe.theguardian.com/p/DXX83X?INTCMP=gdnwb_copts_bundles_landing_default',
     modifierClass: 'digital',
   },
-  paper: {
+  paperDigital: {
     heading: 'From £10.79/month',
     subheading: 'Become a paper subscriber',
     listItems: [
@@ -52,18 +56,97 @@ const bundles = {
     ctaLink: 'https://subscribe.theguardian.com/p/GXX83X?INTCMP=gdnwb_copts_bundles_landing_default',
     modifierClass: 'paper',
   },
+  paperOnly: {
+    heading: 'From £10.79/month',
+    subheading: 'Become a paper subscriber',
+    listItems: [
+      {
+        heading: 'Newspaper',
+        text: 'Choose the package you want: Everyday+, Sixday+, Weekend+ and Sunday+',
+      },
+      {
+        heading: 'Save money',
+        text: 'Up to 36% off the retail price',
+      },
+    ],
+    infoText: 'Support the Guardian and enjoy a subscription to the Guardian and the Observer newspapers.',
+    ctaText: 'Become a paper subscriber',
+    ctaLink: 'https://subscribe.theguardian.com/p/GXX83P?INTCMP=gdnwb_copts_bundles_landing_default',
+    modifierClass: 'paper',
+  },
 };
+
+const paperToggles = {
+  name: 'paper-toggle',
+  radios: [
+    {
+      value: 'PAPER+DIGITAL',
+      text: 'Paper + digital',
+    },
+    {
+      value: 'PAPER',
+      text: 'Paper',
+    },
+  ],
+};
+
+
+// ----- Functions ----- //
+
+function getPaperAttrs(bundle) {
+
+  if (bundle === 'PAPER+DIGITAL') {
+    return bundles.paperDigital;
+  }
+
+  return bundles.paperOnly;
+
+}
 
 
 // ----- Component ----- //
 
-export default function Bundles() {
+function Bundles(props) {
+
+  const paperAttrs = getPaperAttrs(props.paperBundle);
+
+  function togglePaperBundle(bundle) {
+    return () => props.dispatch(changePaperBundle(bundle));
+  }
 
   return (
     <div className="bundles">
-      <Bundle {...bundles.digital} />
-      <Bundle {...bundles.paper} />
+      <Bundle {...bundles.digital}>
+        <FeatureList listItems={bundles.digital.listItems} />
+      </Bundle>
+      <Bundle {...paperAttrs}>
+        <RadioToggle
+          {...paperToggles}
+          toggleAction={togglePaperBundle}
+          checked={props.paperBundle}
+        />
+        <FeatureList listItems={paperAttrs.listItems} />
+      </Bundle>
     </div>
   );
 
 }
+
+
+// ----- Proptypes ----- //
+
+Bundles.propTypes = {
+  paperBundle: React.PropTypes.string.isRequired,
+};
+
+
+// ----- Map State/Props ----- //
+
+function mapStateToProps(state) {
+  return { paperBundle: state };
+}
+
+
+// ----- Exports ----- //
+
+export default connect(mapStateToProps)(Bundles);

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -25,9 +25,32 @@ const bundles = {
         text: 'For 14 days, enjoy on up to 10 devices',
       },
     ],
-    infoText: 'Support the Guardian and enjoy a subscription to our digital Daily Edition and the premium tier of our app',
+    infoText: 'Support the Guardian and enjoy a subscription to our digital Daily Edition and the premium tier of our app.',
     ctaText: 'Become a digital subscriber',
     ctaLink: 'https://subscribe.theguardian.com/p/DXX83X?INTCMP=gdnwb_copts_bundles_landing_default',
+    modifierClass: 'digital',
+  },
+  paper: {
+    heading: 'From £10.79/month',
+    subheading: 'Become a paper subscriber',
+    listItems: [
+      {
+        heading: 'Newspaper',
+        text: 'Choose the package you want: Everyday+, Sixday+, Weekend+ and Sunday+',
+      },
+      {
+        heading: 'Digital',
+        text: 'All the benefits of the digital subscription',
+      },
+      {
+        heading: 'Save money',
+        text: 'Up to 36% off the retail price',
+      },
+    ],
+    infoText: 'Support the Guardian and enjoy a subscription to the Guardian and the Observer newspapers.',
+    ctaText: 'Become a paper subscriber',
+    ctaLink: 'https://subscribe.theguardian.com/p/GXX83X?INTCMP=gdnwb_copts_bundles_landing_default',
+    modifierClass: 'paper',
   },
 };
 
@@ -39,6 +62,7 @@ export default function Bundles() {
   return (
     <div className="bundles">
       <Bundle {...bundles.digital} />
+      <Bundle {...bundles.paper} />
     </div>
   );
 

--- a/assets/pages/bundles-landing/reducers/paperBundle.js
+++ b/assets/pages/bundles-landing/reducers/paperBundle.js
@@ -1,6 +1,6 @@
 // ----- Reducers ----- //
 
-export default function reducer(state = 'PAPER+DIGITAL', action) {
+export default function reducer(state, action) {
 
   switch (action.type) {
     case 'CHANGE_PAPER_BUNDLE':

--- a/assets/pages/bundles-landing/reducers/paperBundle.js
+++ b/assets/pages/bundles-landing/reducers/paperBundle.js
@@ -1,0 +1,12 @@
+// ----- Reducers ----- //
+
+export default function reducer(state = 'PAPER+DIGITAL', action) {
+
+  switch (action.type) {
+    case 'CHANGE_PAPER_BUNDLE':
+      return action.payload;
+    default:
+      return state;
+  }
+
+}

--- a/assets/stylesheets/main.scss
+++ b/assets/stylesheets/main.scss
@@ -11,6 +11,7 @@
 @import '../components/featureList/featureList';
 @import '../components/infoText/infoText';
 @import '../components/ctaLink/ctaLink';
+@import '../components/radioToggle/radioToggle';
 
 
 // ----- Pages ----- //

--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
   "bugs": {
     "url": "https://github.com/guardian/support-frontend/issues"
   },
+  "dependencies": {
+    "react-redux": "^5.0.4",
+    "redux": "^3.6.0"
+  },
   "devDependencies": {
     "babel-loader": "^6.4.1",
     "babel-preset-es2015": "^6.24.0",


### PR DESCRIPTION
## Why are you doing this?

Continuing to flesh out the bundles landing page and experiment with modular components. This adds the second bundle, print/print+digital, and makes use of redux for user interaction.

**Note**: Putting all the copy in an object (in `Bundles.jsx`) may not be the best approach, let me know if you think there's a better way.

[**Trello Card**](https://trello.com/c/1KImhpNA/471-flesh-out-modular-design-architecture)

## Changes

- Added redux.
- Added a radio toggle shared component.
- Added reducers and actions to bundles landing page.
- Added paper bundle.

## Screenshots

![second-bundle](https://cloud.githubusercontent.com/assets/5131341/24919804/be92c26c-1edc-11e7-8121-a4ce443853c6.png)
