### PR TITLE
Cache headers

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -1,18 +1,19 @@
 package controllers
 
+import lib.actions.{CachedAction, PrivateAction}
 import play.api.mvc.{Action, AnyContent, Controller}
 
 class Application extends Controller {
 
-  def helloWorld: Action[AnyContent] = Action {
+  def helloWorld: Action[AnyContent] = CachedAction {
     Ok(views.html.index())
   }
 
-  def bundlesLanding: Action[AnyContent] = Action {
+  def bundlesLanding: Action[AnyContent] = CachedAction {
     Ok(views.html.bundlesLanding())
   }
 
-  def healthcheck: Action[AnyContent] = Action {
+  def healthcheck: Action[AnyContent] = PrivateAction {
     Ok("healthy")
   }
 

--- a/app/filters/CheckCacheHeadersFilter.scala
+++ b/app/filters/CheckCacheHeadersFilter.scala
@@ -1,0 +1,27 @@
+package filters
+
+import scala.concurrent.Future
+import akka.stream.Materializer
+import play.api.mvc._
+import play.api.libs.concurrent.Execution.Implicits.defaultContext
+import play.api.http.Status.{MOVED_PERMANENTLY, NOT_FOUND, OK}
+
+class CheckCacheHeadersFilter(implicit val mat: Materializer) extends Filter {
+
+  private val cacheableStatusCodes = Seq(OK, MOVED_PERMANENTLY, NOT_FOUND)
+
+  private def suitableForCaching(result: Result) =
+    cacheableStatusCodes.contains(result.header.status)
+
+  def apply(nextFilter: RequestHeader => Future[Result])(requestHeader: RequestHeader): Future[Result] = {
+    nextFilter(requestHeader).map { result =>
+      if (suitableForCaching(result)) {
+        assert(
+          assertion = result.header.headers.contains("Cache-Control"),
+          message = s"Cache-Control not set. Ensure controller response has Cache-Control header set for ${requestHeader.path}"
+        )
+      }
+      result
+    }
+  }
+}

--- a/app/lib/actions/CachedAction.scala
+++ b/app/lib/actions/CachedAction.scala
@@ -1,0 +1,39 @@
+package lib.actions
+
+import org.joda.time.DateTime
+import play.api.libs.concurrent.Execution.Implicits._
+import play.api.mvc.{Action, AnyContent, Result}
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import lib.httpheaders._
+
+object CachedAction {
+
+  val defaultMaxAge = 1.minute
+  val maximumBrowserAge = 1.minute
+
+  def async[T](block: => Future[Result]): Action[AnyContent] = async(defaultMaxAge)(block)
+
+  def apply[T](block: => Result): Action[AnyContent] = apply(defaultMaxAge)(block)
+
+  def async[T](maxAge: FiniteDuration)(block: => Future[Result]): Action[AnyContent] = Action.async {
+    block.map(_.withHeaders(cacheHeaders(maxAge): _*))
+  }
+
+  def apply[T](maxAge: FiniteDuration)(block: => Result): Action[AnyContent] = Action {
+    block.withHeaders(cacheHeaders(maxAge): _*)
+  }
+
+  private def cacheHeaders(maxAge: FiniteDuration, now: DateTime = DateTime.now): List[(String, String)] = {
+    val browserAge = maximumBrowserAge min maxAge
+    val expires = now.plusSeconds(browserAge.toSeconds.toInt)
+
+    List(
+      CacheControl.cdn(maxAge),
+      CacheControl.browser(browserAge),
+      "Expires" -> expires.toHttpDateTimeString,
+      "Date" -> now.toHttpDateTimeString
+    )
+  }
+
+}

--- a/app/lib/actions/PrivateAction.scala
+++ b/app/lib/actions/PrivateAction.scala
@@ -1,0 +1,17 @@
+package lib.actions
+
+import play.api.libs.concurrent.Execution.Implicits._
+import play.api.mvc.{Action, AnyContent, Result}
+import scala.concurrent.Future
+import lib.httpheaders.CacheControl
+
+object PrivateAction {
+
+  def async[T](block: => Future[Result]): Action[AnyContent] = Action.async {
+    block.map(_.withHeaders(CacheControl.noCache))
+  }
+
+  def apply[T](block: => Result): Action[AnyContent] = Action {
+    block.withHeaders(CacheControl.noCache)
+  }
+}

--- a/app/lib/httpheaders/CacheControl.scala
+++ b/app/lib/httpheaders/CacheControl.scala
@@ -1,0 +1,21 @@
+package lib.httpheaders
+
+import scala.concurrent.duration._
+
+object CacheControl {
+
+  val defaultStaleIfErrors = 10.days
+
+  def browser(maxAge: FiniteDuration): (String, String) = {
+    "Cache-Control" -> standardDirectives(maxAge, 1.second max (maxAge / 10), defaultStaleIfErrors)
+  }
+
+  def cdn(maxAge: FiniteDuration): (String, String) = {
+    "Surrogate-Control" -> standardDirectives(maxAge, 1.second max (maxAge / 10), defaultStaleIfErrors)
+  }
+
+  val noCache: (String, String) = "Cache-Control" -> "private"
+
+  private def standardDirectives(maxAge: FiniteDuration, staleWhileRevalidate: FiniteDuration, staleIfErrors: FiniteDuration) =
+    s"max-age=${maxAge.toSeconds}, stale-while-revalidate=${staleWhileRevalidate.toSeconds}, stale-if-error=${staleIfErrors.toSeconds}"
+}

--- a/app/lib/httpheaders/package.scala
+++ b/app/lib/httpheaders/package.scala
@@ -1,0 +1,20 @@
+package lib
+
+import org.joda.time.{DateTime, DateTimeZone}
+import org.joda.time.format.DateTimeFormat
+
+package object httpheaders {
+
+  trait HttpHeader {
+    def key: String
+    def value: String
+    def header: (String, String) = key -> value
+  }
+
+  //http://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3.1
+  private val HTTPDateFormat = DateTimeFormat.forPattern("EEE, dd MMM yyyy HH:mm:ss 'GMT'").withZone(DateTimeZone.UTC)
+
+  implicit class DateTime2ToHttpDateFormat(date: DateTime) {
+    def toHttpDateTimeString: String = date.toString(HTTPDateFormat)
+  }
+}

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -3,11 +3,14 @@ package wiring
 import play.api.routing.Router
 import router.Routes
 import controllers.{Application, Assets}
+import filters.CheckCacheHeadersFilter
+import play.api.mvc.EssentialFilter
 
 trait AppComponents extends PlayComponents {
 
   lazy val assetController = new Assets(httpErrorHandler)
   lazy val applicationController = new Application()
 
+  override lazy val httpFilters: Seq[EssentialFilter] = Seq(new CheckCacheHeadersFilter())
   override lazy val router: Router = new Routes(httpErrorHandler, assetController, applicationController, prefix = "/")
 }

--- a/build.sbt
+++ b/build.sbt
@@ -31,7 +31,7 @@ lazy val root = (project in file(".")).enablePlugins(PlayScala, BuildInfoPlugin,
 )
 
 libraryDependencies ++= Seq(
-  "org.scalatestplus.play" %% "scalatestplus-play" % "1.5.1" % Test
+  "org.scalatestplus.play" %% "scalatestplus-play" % "2.0.0" % Test
 )
 
 sources in (Compile,doc) := Seq.empty

--- a/test/controllers/ApplicationTest.scala
+++ b/test/controllers/ApplicationTest.scala
@@ -3,7 +3,7 @@ package controllers
 import org.scalatest.WordSpec
 import org.scalatest.MustMatchers
 import play.api.test.FakeRequest
-import play.api.test.Helpers.contentAsString
+import play.api.test.Helpers.{contentAsString, header}
 import akka.util.Timeout
 import scala.concurrent.duration._
 
@@ -14,8 +14,12 @@ class ApplicationTest extends WordSpec with MustMatchers {
   "/healthcheck" should {
     "return healthy" in {
       val result = new Application().healthcheck.apply(FakeRequest())
-      val body = contentAsString(result)
-      body mustBe "healthy"
+      contentAsString(result) mustBe "healthy"
+    }
+
+    "not be cached" in {
+      val result = new Application().healthcheck.apply(FakeRequest())
+      header("Cache-Control", result) mustBe Some("private")
     }
   }
 }

--- a/test/lib/actions/CachedActionTest.scala
+++ b/test/lib/actions/CachedActionTest.scala
@@ -1,0 +1,54 @@
+package lib.actions
+
+import scala.concurrent.duration._
+import org.scalatest.{MustMatchers, WordSpec}
+import play.api.mvc.Results.Ok
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import org.joda.time.format.DateTimeFormat
+import org.joda.time.{DateTime, Seconds}
+
+class CachedActionTest extends WordSpec with MustMatchers {
+
+  "with no arguments" should {
+    "expire in 60 seconds" in {
+      val result = CachedAction(Ok("")).apply(FakeRequest())
+      val Some(date) = header("Date", result)
+      val Some(expiry) = header("Expires", result)
+      Seconds.secondsBetween(parseHttpDate(date), parseHttpDate(expiry)).getSeconds mustEqual 60
+    }
+
+    "browser cache control max-age of 60 seconds with 10% time for revalidation and 10 days stale on error" in {
+      val result = CachedAction(Ok("")).apply(FakeRequest())
+      header("Cache-Control", result) mustEqual Some("max-age=60, stale-while-revalidate=6, stale-if-error=864000")
+    }
+
+    "cdn cache control max-age of 60 seconds with 10% time for revalidation and 10 days stale on error" in {
+      val result = CachedAction(Ok("")).apply(FakeRequest())
+      header("Surrogate-Control", result) mustEqual Some("max-age=60, stale-while-revalidate=6, stale-if-error=864000")
+    }
+  }
+
+  "with maxAge of 1 hour" should {
+    "expire in 60 seconds" in {
+      val result = CachedAction(1.hour)(Ok("")).apply(FakeRequest())
+      val Some(date) = header("Date", result)
+      val Some(expiry) = header("Expires", result)
+      Seconds.secondsBetween(parseHttpDate(date), parseHttpDate(expiry)).getSeconds mustEqual 60
+    }
+
+    "browser cache control max-age of 60 seconds with 10% time for revalidation and 10 days stale on error" in {
+      val result = CachedAction(1.hour)(Ok("")).apply(FakeRequest())
+      header("Cache-Control", result) mustEqual Some("max-age=60, stale-while-revalidate=6, stale-if-error=864000")
+    }
+
+    "cdn cache control max-age of 3600 seconds with 10% time for revalidation and 10 days stale on error" in {
+      val result = CachedAction(1.hour)(Ok("")).apply(FakeRequest())
+      header("Surrogate-Control", result) mustEqual Some("max-age=3600, stale-while-revalidate=360, stale-if-error=864000")
+    }
+  }
+
+  private val httpDateFormatter = DateTimeFormat.forPattern("EEE, dd MMM yyyy HH:mm:ss 'GMT'")
+
+  private def parseHttpDate(d: String): DateTime = DateTime.parse(d, httpDateFormatter)
+}

--- a/test/lib/actions/PrivateActionTest.scala
+++ b/test/lib/actions/PrivateActionTest.scala
@@ -1,0 +1,14 @@
+package lib.actions
+
+import org.scalatest.{MustMatchers, WordSpec}
+import play.api.mvc.Results._
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+
+class PrivateActionTest extends WordSpec with MustMatchers {
+
+  "include Cache-control: private" in {
+    val result = PrivateAction(Ok("")).apply(FakeRequest())
+    header("Cache-Control", result) mustBe Some("private")
+  }
+}

--- a/test/lib/httpheaders/DateTime2ToHttpDateFormatTest.scala
+++ b/test/lib/httpheaders/DateTime2ToHttpDateFormatTest.scala
@@ -1,0 +1,13 @@
+package lib.httpheaders
+
+import org.joda.time.{DateTime, DateTimeZone}
+import org.scalatest.{MustMatchers, WordSpec}
+
+class DateTime2ToHttpDateFormatTest extends WordSpec with MustMatchers {
+  import lib.httpheaders._
+
+  "correctly format the example date from https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3.1" in {
+    val timestamp = new DateTime(1994, 11, 6, 8, 49, 37, DateTimeZone.UTC) // scalastyle:off magic.number
+    timestamp.toHttpDateTimeString mustEqual "Sun, 06 Nov 1994 08:49:37 GMT"
+  }
+}


### PR DESCRIPTION
## Why are you doing this?

Current cache time of 1 hour is too long.  This PR makes it easy to adjust the cache time of each route.

[**Trello Card**](https://trello.com/c/32Fj8QEk/476-sort-out-caching-and-asset-hashing-for-support-frontend)

## Screenshots

