### PR TITLE
First draft of the other ways of support component

### DIFF
--- a/assets/components/ctaCircle/ctaCircle.jsx
+++ b/assets/components/ctaCircle/ctaCircle.jsx
@@ -1,0 +1,22 @@
+// ----- Imports ----- //
+
+import React from 'react';
+
+// ----- Component ----- //
+
+const CtaLink = props => (
+  <a className="component-cta-circle" href={props.url}>
+    {props.text}
+  </a>
+);
+
+// ----- Proptypes ----- //
+
+CtaLink.propTypes = {
+  text: React.PropTypes.string.isRequired,
+  url: React.PropTypes.string.isRequired,
+};
+
+// ----- Exports ----- //
+
+export default CtaLink;

--- a/assets/components/ctaCircle/ctaCircle.jsx
+++ b/assets/components/ctaCircle/ctaCircle.jsx
@@ -1,22 +1,24 @@
 // ----- Imports ----- //
 
 import React from 'react';
+import SVG from 'components/svg/svg';
 
 // ----- Component ----- //
 
-const CtaLink = props => (
+const CtaCircle = props => (
   <a className="component-cta-circle" href={props.url}>
-    {props.text}
+    <button><SVG svgName="arrow-right-straight" /></button>
+    <span>{props.text}</span>
   </a>
 );
 
 // ----- Proptypes ----- //
 
-CtaLink.propTypes = {
+CtaCircle.propTypes = {
   text: React.PropTypes.string.isRequired,
   url: React.PropTypes.string.isRequired,
 };
 
 // ----- Exports ----- //
 
-export default CtaLink;
+export default CtaCircle;

--- a/assets/components/ctaCircle/ctaCircle.scss
+++ b/assets/components/ctaCircle/ctaCircle.scss
@@ -1,0 +1,40 @@
+.component-cta-circle {
+
+  display: block;
+  margin: 12px 10px;
+  text-decoration: none;
+  color: inherit;
+
+  @include mq($until: mobileLandscape) {
+    margin-bottom: 0;
+  }
+
+  button {
+    background-color: gu-colour(neutral-1);
+    border-radius: 600px;
+    border: none;
+    color: #fff;
+    padding: 7px 8px;
+    height: 36px;
+    width: 36px;
+    margin-right: 5px;
+
+    svg {
+      fill: white;
+      height: 105%;
+      width: 105%;
+    }
+  }
+
+  span {
+    font-size: 14px;
+    line-height: 20px;
+    font-family: "Guardian Text Sans Web","Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;
+    font-weight: bold;
+  }
+}
+
+.component-cta-circle:hover {
+  text-decoration: underline;
+}
+

--- a/assets/components/ctaCircle/ctaCircle.scss
+++ b/assets/components/ctaCircle/ctaCircle.scss
@@ -29,7 +29,7 @@
   span {
     font-size: 14px;
     line-height: 20px;
-    font-family: "Guardian Text Sans Web","Helvetica Neue",Helvetica,Arial,"Lucida Grande",sans-serif;
+    font-family: $gu-text-sans-web;
     font-weight: bold;
   }
 }

--- a/assets/components/infoText/infoText.scss
+++ b/assets/components/infoText/infoText.scss
@@ -1,3 +1,4 @@
 .component-info-text {
-	color: #000;
+  @include gu-font(copy, 16);
+  color: gu-colour(neutral-1);
 }

--- a/assets/components/simpleHeading/simpleHeading.jsx
+++ b/assets/components/simpleHeading/simpleHeading.jsx
@@ -1,0 +1,24 @@
+// ----- Imports ----- //
+
+import React from 'react';
+
+
+// ----- Component ----- //
+
+const SimpleHeading = props => (
+  <div className="component-simple-heading">
+    <h1 className="component-simple-heading__heading">
+      { props.heading }
+    </h1>
+  </div>
+);
+
+// ----- Proptypes ----- //
+
+SimpleHeading.propTypes = {
+  heading: React.PropTypes.string.isRequired,
+};
+
+// ----- Exports ----- //
+
+export default SimpleHeading;

--- a/assets/components/simpleHeading/simpleHeading.scss
+++ b/assets/components/simpleHeading/simpleHeading.scss
@@ -1,12 +1,8 @@
-.component-simple-heading {
-  @include gu-font(copy, 18);
-
+.component-simple-heading__heading {
+  color: gu-colour(neutral-1);
+  font-family: $gu-egyptian-web;
   font-weight: 900;
-  line-height: 27px;
-
-  .component-simple-heading__heading {
-    font-size: 28px;
-    color: #000;
-    margin: 0;
-  }
+  font-size: 23px;
+  line-height: 26px;
 }
+

--- a/assets/components/simpleHeading/simpleHeading.scss
+++ b/assets/components/simpleHeading/simpleHeading.scss
@@ -1,0 +1,12 @@
+.component-simple-heading {
+  @include gu-font(copy, 18);
+
+  font-weight: 900;
+  line-height: 27px;
+
+  .component-simple-heading__heading {
+    font-size: 28px;
+    color: #000;
+    margin: 0;
+  }
+}

--- a/assets/components/svg/svg.jsx
+++ b/assets/components/svg/svg.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+const svgsCatalog = {
+  'arrow-right-straight': {
+      path : 'M20 9.35l-9.08 8.54-.86-.81 6.54-7.31H0V8.12h16.6L10.06.81l.86-.81L20 8.51v.84z',
+      viewBox: '0 0 20 17.89'
+  }
+};
+
+const svgs = props => (
+  <svg viewBox={svgsCatalog[props.svgName].viewBox}>
+    <path d={svgsCatalog[props.svgName].path}></path>
+  </svg>
+);
+
+export default svgs

--- a/assets/components/svg/svg.jsx
+++ b/assets/components/svg/svg.jsx
@@ -2,15 +2,27 @@ import React from 'react';
 
 const svgsCatalog = {
   'arrow-right-straight': {
-      path : 'M20 9.35l-9.08 8.54-.86-.81 6.54-7.31H0V8.12h16.6L10.06.81l.86-.81L20 8.51v.84z',
-      viewBox: '0 0 20 17.89'
-  }
+    path: 'M20 9.35l-9.08 8.54-.86-.81 6.54-7.31H0V8.12h16.6L10.06.81l.86-.81L20 8.51v.84z',
+    viewBox: '0 0 20 17.89',
+  },
 };
 
 const svgs = props => (
   <svg viewBox={svgsCatalog[props.svgName].viewBox}>
-    <path d={svgsCatalog[props.svgName].path}></path>
+    <path d={svgsCatalog[props.svgName].path} />
   </svg>
 );
 
-export default svgs
+// ----- Proptypes ----- //
+
+svgs.defaultProps = {
+
+};
+
+svgs.propTypes = {
+  svgName: React.PropTypes.string.isRequired,
+};
+
+// ----- Exports ----- //
+
+export default svgs;

--- a/assets/components/svg/svg.jsx
+++ b/assets/components/svg/svg.jsx
@@ -14,11 +14,6 @@ const svgs = props => (
 );
 
 // ----- Proptypes ----- //
-
-svgs.defaultProps = {
-
-};
-
 svgs.propTypes = {
   svgName: React.PropTypes.string.isRequired,
 };

--- a/assets/pages/bundles-landing/bundlesLanding.jsx
+++ b/assets/pages/bundles-landing/bundlesLanding.jsx
@@ -21,8 +21,8 @@ const content = (
   <Provider store={store}>
     <div>
       <Bundles />
-      <br style="clear:both;"/>
-      <WaysOfSupport/>
+      <br style={{ clear: 'both' }} />
+      <WaysOfSupport />
     </div>
   </Provider>
 );

--- a/assets/pages/bundles-landing/bundlesLanding.jsx
+++ b/assets/pages/bundles-landing/bundlesLanding.jsx
@@ -19,8 +19,11 @@ const store = createStore(reducer, 'PAPER+DIGITAL');
 
 const content = (
   <Provider store={store}>
-    <Bundles />
-    <WaysOfSupport />	
+    <div>
+      <Bundles />
+      <br style="clear:both;"/>
+      <WaysOfSupport/>
+    </div>
   </Provider>
 );
 

--- a/assets/pages/bundles-landing/bundlesLanding.jsx
+++ b/assets/pages/bundles-landing/bundlesLanding.jsx
@@ -6,6 +6,7 @@ import { createStore } from 'redux';
 import { Provider } from 'react-redux';
 
 import Bundles from './components/Bundles';
+import WaysOfSupport from './components/WaysOfSupport';
 import reducer from './reducers/paperBundle';
 
 
@@ -19,6 +20,7 @@ const store = createStore(reducer, 'PAPER+DIGITAL');
 const content = (
   <Provider store={store}>
     <Bundles />
+    <WaysOfSupport />	
   </Provider>
 );
 

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -1,30 +1,38 @@
 #bundles-landing-page {
 
-	// ----- Page Components ----- //
+  // ----- Page Components ----- //
 
-	.bundles__bundle {
-		width: 300px;
-		padding: 8px 10px 12px;
-		float: left;
-	}
+  .bundles__bundle {
+    width: 300px;
+    padding: 8px 10px 12px;
+    float: left;
+  }
 
-	.bundles__bundle--digital {
-		background-color: #1db7d7;
-	}
+  .bundles__bundle--digital {
+      background-color: #1db7d7;
+  }
 
-	.bundles__bundle--paper {
-		background-color: #58a1ce;
-	}
+  .bundles__bundle--paper {
+      background-color: #58a1ce;
+  }
 
-	// ----- Shared Components ----- //
+  .ways-of-support {
 
-	.component-double-heading {
-		margin-bottom: 24px;
-	}
+  }
 
-	input:checked+label {
-		background-color: gu-colour(guardian-brand-dark);
-		color: #fff;
-	}
+  .way-of-support {
+
+  }
+
+  // ----- Shared Components ----- //
+
+  .component-double-heading {
+      margin-bottom: 24px;
+  }
+
+  input:checked+label {
+    background-color: gu-colour(guardian-brand-dark);
+    color: #fff;
+  }
 
 }

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -17,7 +17,7 @@
   }
 
   .ways-of-support {
-    max-width: 980px;
+    max-width: gu-breakpoint(desktop);;
 
     > .component-simple-heading {
       padding-top: 6px;

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -74,7 +74,7 @@
 
   .ways-of-support__way {
     background: gu-colour(comment-support-2);
-    color: guss-colour(neutral-1);
+    color: gu-colour(neutral-1);
     float: left;
     max-width: 300px;
     margin: 0 0 6px;

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -17,11 +17,104 @@
   }
 
   .ways-of-support {
+    max-width: 980px;
 
+    > .component-simple-heading {
+      padding-top: 6px;
+
+      @include mq($until: mobileLandscape) {
+        border-top: 1px solid gu-colour(news-support-1);
+      }
+
+      @include mq($from: tablet) {
+        max-width: 210px;
+        margin-left: 10px;
+        margin-right: 10px;
+        padding-top: 0;
+      }
+
+      @include mq($from: desktop) {
+        max-width: 300px;
+        text-align: center;
+        border: none;
+        float: right;
+      }
+    }
+
+    > .component-simple-heading .component-simple-heading__heading {
+      word-spacing: -0.08em;
+
+      color: gu-colour(news-support-2);
+      font-family: 'Guardian Titlepiece Web', sans-serif;
+      font-weight: 400;
+      padding-top: 2px;
+      font-size: 28px;
+      line-height: 28px;
+      width: 220px;
+      margin: 0 10px 24px;
+
+      @include mq($from: tablet) {
+        width: gs-span(3);
+        margin: 0;
+        font-size: 40px;
+        line-height: 37px;
+        text-align: center;
+      }
+
+      @include mq($from: desktop) {
+        font-size: 48px;
+        line-height: 44px;
+      }
+
+      @include mq($from: desktop) {
+        width: 100%;
+      }
+    }
   }
 
-  .way-of-support {
+  .ways-of-support__way {
+    background: gu-colour(comment-support-2);
+    color: guss-colour(neutral-1);
+    float: left;
+    max-width: 300px;
+    margin: 0 0 6px;
+    padding-bottom: 12px;
 
+    @include mq($from: mobileLandscape) {
+      background-color: #fff;
+      padding-bottom: 0;
+      position: relative;
+      margin-left: 10px;
+      margin-right: 10px;
+      max-width: 210px;
+    }
+
+    @include mq($from: tablet) {
+      max-width: 220px;
+      margin-top: 12px;
+    }
+
+    @include mq($from: desktop) {
+      max-width: 300px;
+      margin-bottom: 0;
+    }
+
+    img {
+      width: 100%;
+      display: block;
+    }
+  }
+
+  .ways-of-support__way--orange {
+    background: gu-colour(comment-main-2);
+  }
+
+  .ways-of-support__way .component-simple-heading__heading {
+    margin: 4px 10px 12px;
+  }
+
+  .ways-of-support__way .component-info-text {
+    margin: 0 10px
   }
 
   // ----- Shared Components ----- //

--- a/assets/pages/bundles-landing/components/WayOfSupport.jsx
+++ b/assets/pages/bundles-landing/components/WayOfSupport.jsx
@@ -2,21 +2,30 @@
 
 import React from 'react';
 
-import SimpleHeading from 'components/simpleHeading/simpleHeading';
-import InfoText from 'components/infoText/infoText';
 import CtaCircle from 'components/ctaCircle/ctaCircle';
+import InfoText from 'components/infoText/infoText';
+import SimpleHeading from 'components/simpleHeading/simpleHeading';
 
 
 // ----- Component ----- //
 
-const WayOfSupport = props => (
+const WayOfSupport = props => {
 
-  <div className="ways-of-support__way">
-    <SimpleHeading heading={props.heading} />
-    <InfoText text={props.infoText} />
-    <CtaCircle text={props.ctaText} url={props.ctaLink} />
-  </div>
-);
+  let className = 'ways-of-support__way';
+
+  if (props.modifierClass) {
+    className = `${className} ${className}--${props.modifierClass}`;
+  }
+
+  return (
+    <div className={className}>
+      <img src="http://placehold.it/300x170"/>
+      <SimpleHeading heading={props.heading}/>
+      <InfoText text={props.infoText}/>
+      <CtaCircle text={props.ctaText} url={props.ctaLink}/>
+    </div>
+  );
+}
 
 
 // ----- Proptypes ----- //

--- a/assets/pages/bundles-landing/components/WayOfSupport.jsx
+++ b/assets/pages/bundles-landing/components/WayOfSupport.jsx
@@ -9,7 +9,7 @@ import SimpleHeading from 'components/simpleHeading/simpleHeading';
 
 // ----- Component ----- //
 
-const WayOfSupport = props => {
+const WayOfSupport = (props) => {
 
   let className = 'ways-of-support__way';
 
@@ -19,19 +19,20 @@ const WayOfSupport = props => {
 
   return (
     <div className={className}>
-      <img src="http://placehold.it/300x170"/>
-      <SimpleHeading heading={props.heading}/>
-      <InfoText text={props.infoText}/>
-      <CtaCircle text={props.ctaText} url={props.ctaLink}/>
+      <img src="http://placehold.it/300x170" alt="Example" />
+      <SimpleHeading heading={props.heading} />
+      <InfoText text={props.infoText} />
+      <CtaCircle text={props.ctaText} url={props.ctaLink} />
     </div>
   );
-}
+};
 
 
 // ----- Proptypes ----- //
 
 WayOfSupport.defaultProps = {
   infoText: '',
+  modifierClass: '',
 };
 
 WayOfSupport.propTypes = {
@@ -39,6 +40,7 @@ WayOfSupport.propTypes = {
   infoText: React.PropTypes.string,
   ctaText: React.PropTypes.string.isRequired,
   ctaLink: React.PropTypes.string.isRequired,
+  modifierClass: React.PropTypes.string,
 };
 
 // ----- Exports ----- //

--- a/assets/pages/bundles-landing/components/WayOfSupport.jsx
+++ b/assets/pages/bundles-landing/components/WayOfSupport.jsx
@@ -1,0 +1,37 @@
+// ----- Imports ----- //
+
+import React from 'react';
+
+import SimpleHeading from 'components/simpleHeading/simpleHeading';
+import InfoText from 'components/infoText/infoText';
+import CtaCircle from 'components/ctaCircle/ctaCircle';
+
+
+// ----- Component ----- //
+
+const WayOfSupport = props => (
+
+  <div className="ways-of-support__way">
+    <SimpleHeading heading={props.heading} />
+    <InfoText text={props.infoText} />
+    <CtaCircle text={props.ctaText} url={props.ctaLink} />
+  </div>
+);
+
+
+// ----- Proptypes ----- //
+
+WayOfSupport.defaultProps = {
+  infoText: '',
+};
+
+WayOfSupport.propTypes = {
+  heading: React.PropTypes.string.isRequired,
+  infoText: React.PropTypes.string,
+  ctaText: React.PropTypes.string.isRequired,
+  ctaLink: React.PropTypes.string.isRequired,
+};
+
+// ----- Exports ----- //
+
+export default WayOfSupport;

--- a/assets/pages/bundles-landing/components/WaysOfSupport.jsx
+++ b/assets/pages/bundles-landing/components/WaysOfSupport.jsx
@@ -1,0 +1,40 @@
+// ----- Imports ----- //
+
+import React from 'react';
+
+import WayOfSupport from './WayOfSupport';
+
+
+// ----- Copy ----- //
+
+const waysOfSupport = [
+  {
+    heading: 'Patrons',
+    infoText: 'The Patrons tier for those who care deeply about the the Guardian\'s journalism and the imact is has on th world',
+    ctaText: 'Become a Patron',
+    ctaLink: 'https://membership.theguardian.com/patrons?INTCMP=gdnwb_copts_bundles_landing_default',
+  },
+  {
+    heading: 'Guardian Live events',
+    infoText: 'Events, discussions, debates, interviews, festivals, dinners and private views exclusively for Guardian members',
+    ctaText: 'Find out about events',
+    ctaLink: 'https://membership.theguardian.com/events?INTCMP=gdnwb_copts_bundles_landing_default',
+  },
+];
+
+
+// ----- Component ----- //
+
+const WaysOfSupport = () => {
+
+  const waysOfSupportRendered = waysOfSupport.map(x => <WayOfSupport {...x} />);
+
+  return (
+    <div className="ways-of-support">
+      {waysOfSupportRendered}
+    </div>
+  );
+};
+
+export default WaysOfSupport;
+

--- a/assets/pages/bundles-landing/components/WaysOfSupport.jsx
+++ b/assets/pages/bundles-landing/components/WaysOfSupport.jsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 
+import SimpleHeading from 'components/simpleHeading/simpleHeading';
 import WayOfSupport from './WayOfSupport';
 
 
@@ -13,12 +14,14 @@ const waysOfSupport = [
     infoText: 'The Patrons tier for those who care deeply about the the Guardian\'s journalism and the imact is has on th world',
     ctaText: 'Become a Patron',
     ctaLink: 'https://membership.theguardian.com/patrons?INTCMP=gdnwb_copts_bundles_landing_default',
+    modifierClass: '',
   },
   {
     heading: 'Guardian Live events',
     infoText: 'Events, discussions, debates, interviews, festivals, dinners and private views exclusively for Guardian members',
     ctaText: 'Find out about events',
     ctaLink: 'https://membership.theguardian.com/events?INTCMP=gdnwb_copts_bundles_landing_default',
+    modifierClass: 'orange',
   },
 ];
 
@@ -31,6 +34,7 @@ const WaysOfSupport = () => {
 
   return (
     <div className="ways-of-support">
+      <SimpleHeading heading="other ways you can support us" />
       {waysOfSupportRendered}
     </div>
   );

--- a/assets/stylesheets/gu-sass/breakpoints.scss
+++ b/assets/stylesheets/gu-sass/breakpoints.scss
@@ -28,3 +28,7 @@ $mq-breakpoints: (
 );
 
 @import 'node_modules/sass-mq/_mq';
+
+@function gu-breakpoint($name) {
+	@return map-get($mq-breakpoints, $name);
+}

--- a/assets/stylesheets/gu-sass/typography.scss
+++ b/assets/stylesheets/gu-sass/typography.scss
@@ -21,7 +21,7 @@ $gu-fonts: (
 		font-weight: normal,
 		sizes: (
 			14: 20px,
-			16: 24px,
+			16: 20px,
 			18: 28px
 		)
 	)

--- a/assets/stylesheets/main.scss
+++ b/assets/stylesheets/main.scss
@@ -8,8 +8,10 @@
 // ----- Shared Components ----- //
 
 @import '../components/doubleHeading/doubleHeading';
+@import '../components/simpleHeading/simpleHeading';
 @import '../components/featureList/featureList';
 @import '../components/infoText/infoText';
+@import '../components/ctaCircle/ctaCircle';
 @import '../components/ctaLink/ctaLink';
 @import '../components/radioToggle/radioToggle';
 


### PR DESCRIPTION
## Why are you doing this?

This is the first attempt at implementing a section of the bundle landing page in the new support project.

### About SVGs
Since our SVGs are not complicated, we decided to use a component with all the SVGs inline. Alternately, we could put all the SVGs in separated files, create a build step and use a webpack's SVG loader or file loader to load the SVG in the corresponding component. Nevertheless, considering our SVGs are simple (so far) we decided to go with the approach of the SVG component. Therefore, the developer whenever wants to add a new SVG, she or he must copy the content of the path tag inside the SVG component.    

[**Trello Card**](https://trello.com/c/oviKRuM6/483-other-ways-of-contribute-component)

## Changes

* Defined an SVG component with the first SVGs.
* Created the other ways of support component.
* Created Simple Header component.

## Future considerations and TODOs
* Define a way of using BEM style in shared components. 
* Import The Guardian's fonts.
* Define a class that handle the outer box of the page.

## Screenshots

<img width="968" alt="picture 247" src="https://cloud.githubusercontent.com/assets/825398/25014620/73073220-2070-11e7-8bbd-67ad11f501bc.png">


