### PR TITLE
Add cache headers to errors

### DIFF
--- a/app/lib/CustomHttpErrorHandler.scala
+++ b/app/lib/CustomHttpErrorHandler.scala
@@ -1,0 +1,31 @@
+package lib
+
+import lib.httpheaders.CacheControl
+import play.api.{Configuration, Environment, UsefulException}
+import play.api.http.DefaultHttpErrorHandler
+import play.api.routing.Router
+import play.api.mvc.{RequestHeader, Result}
+import play.core.SourceMapper
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration._
+
+class CustomHttpErrorHandler(
+  env: Environment,
+  config: Configuration,
+  sourceMapper: Option[SourceMapper],
+  router: => Option[Router]
+)(implicit val ec: ExecutionContext) extends DefaultHttpErrorHandler(env, config, sourceMapper, router) {
+
+  override def onClientError(request: RequestHeader, statusCode: Int, message: String = ""): Future[Result] =
+    super.onClientError(request, statusCode, message).map(_.withHeaders(CacheControl.defaultCacheHeaders(30.seconds, 30.seconds): _*))
+
+  override protected def onNotFound(request: RequestHeader, message: String): Future[Result] =
+    super.onNotFound(request, message).map(_.withHeaders(CacheControl.defaultCacheHeaders(30.seconds, 30.seconds): _*))
+
+  override protected def onProdServerError(request: RequestHeader, exception: UsefulException): Future[Result] =
+    super.onProdServerError(request, exception).map(_.withHeaders(CacheControl.noCache))
+
+  override protected def onBadRequest(request: RequestHeader, message: String): Future[Result] =
+    super.onBadRequest(request, message).map(_.withHeaders(CacheControl.noCache))
+}

--- a/app/lib/actions/CachedAction.scala
+++ b/app/lib/actions/CachedAction.scala
@@ -26,14 +26,7 @@ object CachedAction {
 
   private def cacheHeaders(maxAge: FiniteDuration, now: DateTime = DateTime.now): List[(String, String)] = {
     val browserAge = maximumBrowserAge min maxAge
-    val expires = now.plusSeconds(browserAge.toSeconds.toInt)
-
-    List(
-      CacheControl.cdn(maxAge),
-      CacheControl.browser(browserAge),
-      "Expires" -> expires.toHttpDateTimeString,
-      "Date" -> now.toHttpDateTimeString
-    )
+    CacheControl.defaultCacheHeaders(maxAge, browserAge, now)
   }
 
 }

--- a/app/lib/httpheaders/CacheControl.scala
+++ b/app/lib/httpheaders/CacheControl.scala
@@ -1,5 +1,7 @@
 package lib.httpheaders
 
+import org.joda.time.DateTime
+
 import scala.concurrent.duration._
 
 object CacheControl {
@@ -18,4 +20,15 @@ object CacheControl {
 
   private def standardDirectives(maxAge: FiniteDuration, staleWhileRevalidate: FiniteDuration, staleIfErrors: FiniteDuration) =
     s"max-age=${maxAge.toSeconds}, stale-while-revalidate=${staleWhileRevalidate.toSeconds}, stale-if-error=${staleIfErrors.toSeconds}"
+
+  def defaultCacheHeaders(maxAge: FiniteDuration, browserAge: FiniteDuration, now: DateTime = DateTime.now): List[(String, String)] = {
+    val expires = now.plusSeconds(browserAge.toSeconds.toInt)
+
+    List(
+      CacheControl.cdn(maxAge),
+      CacheControl.browser(browserAge),
+      "Expires" -> expires.toHttpDateTimeString,
+      "Date" -> now.toHttpDateTimeString
+    )
+  }
 }

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -5,10 +5,12 @@ import play.api.routing.Router
 import router.Routes
 import controllers.{Application, Assets}
 import filters.CheckCacheHeadersFilter
+import lib.CustomHttpErrorHandler
 import play.api.mvc.EssentialFilter
 
 trait AppComponents extends PlayComponents {
 
+  override lazy val httpErrorHandler = new CustomHttpErrorHandler(environment, configuration, sourceMapper, Some(router))
   implicit lazy val assetsResolver = new AssetsResolver("/assets/", "assets.map", environment)
   lazy val assetController = new Assets(httpErrorHandler)
   lazy val applicationController = new Application()


### PR DESCRIPTION
## Why are you doing this?

We have a filter that throws an exception if a Result doesn't have cache headers.  HTTP errors don't currently have cache headers so all return 500 Internal server error. 

This change means that we serve a 404 if a file isn't found instead of a 500, with a cache time of 30s