### PR TITLE
Adding Jest tests for reducers and actions

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["react", "es2015"]
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,7 @@
         "amd": true,
         "browser": true,
         "node": true,
+        "jest": true,
     },
     "parserOptions": {
         "ecmaVersion": 6,

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,4 +1,5 @@
 [ignore]
+.*/__tests__/.*
 
 [include]
 assets

--- a/assets/pages/bundles-landing/actions/__tests__/bundlesLandingActionsTest.js
+++ b/assets/pages/bundles-landing/actions/__tests__/bundlesLandingActionsTest.js
@@ -1,0 +1,69 @@
+// @flow
+import type { Contrib, PaperBundle } from '../../reducers/reducers';
+import { changePaperBundle, changeContribType, changeContribAmountRecurring, changeContribAmountOneOff } from '../bundlesLandingActions';
+
+
+describe('actions', () => {
+
+  it('should create an action to change to paper+digital bundle', () => {
+    const paperBundle: PaperBundle = 'PAPER+DIGITAL';
+    const expectedAction = {
+      type: 'CHANGE_PAPER_BUNDLE',
+      bundle: paperBundle,
+    };
+    expect(changePaperBundle(paperBundle)).toEqual(expectedAction);
+  });
+
+  it('should create an action to change to paper bundle', () => {
+    const paperBundle: PaperBundle = 'PAPER';
+    const expectedAction = {
+      type: 'CHANGE_PAPER_BUNDLE',
+      bundle: paperBundle,
+    };
+    expect(changePaperBundle(paperBundle)).toEqual(expectedAction);
+  });
+
+  it('should create an action to change to one off contribution type', () => {
+
+    const contribType: Contrib = 'ONE_OFF';
+    const expectedAction = {
+      type: 'CHANGE_CONTRIB_TYPE',
+      contribType,
+    };
+    expect(changeContribType(contribType)).toEqual(expectedAction);
+  });
+
+  it('should create an action to change to recurring contribution type', () => {
+    const contribType: Contrib = 'RECURRING';
+    const expectedAction = {
+      type: 'CHANGE_CONTRIB_TYPE',
+      contribType,
+    };
+    expect(changeContribType(contribType)).toEqual(expectedAction);
+  });
+
+  it('should create an action to change the amount of a recurring contribution', () => {
+    const contribAmount: Contrib = {
+      value: '5',
+      userDefined: false,
+    };
+    const expectedAction = {
+      type: 'CHANGE_CONTRIB_AMOUNT_RECURRING',
+      amount: contribAmount,
+    };
+    expect(changeContribAmountRecurring(contribAmount)).toEqual(expectedAction);
+  });
+
+  it('should create an action to change the amount of a one off contribution', () => {
+    const contribAmount: Contrib = {
+      value: '5',
+      userDefined: false,
+    };
+    const expectedAction = {
+      type: 'CHANGE_CONTRIB_AMOUNT_ONEOFF',
+      amount: contribAmount,
+    };
+    expect(changeContribAmountOneOff(contribAmount)).toEqual(expectedAction);
+  });
+});
+

--- a/assets/pages/bundles-landing/reducers/__tests__/__snapshots__/reducersTest.js.snap
+++ b/assets/pages/bundles-landing/reducers/__tests__/__snapshots__/reducersTest.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`reducer tests should return the initial state 1`] = `
+Object {
+  "contribution": Object {
+    "amount": Object {
+      "oneOff": Object {
+        "userDefined": false,
+        "value": "25",
+      },
+      "recurring": Object {
+        "userDefined": false,
+        "value": "5",
+      },
+    },
+    "error": null,
+    "type": "RECURRING",
+  },
+  "paperBundle": "PAPER+DIGITAL",
+}
+`;

--- a/assets/pages/bundles-landing/reducers/__tests__/reducersTest.js
+++ b/assets/pages/bundles-landing/reducers/__tests__/reducersTest.js
@@ -1,5 +1,6 @@
-import reducer from '../reducers'
-import { changePaperBundle, changeContribType, changeContribAmountRecurring, changeContribAmountOneOff } from '../../actions/bundlesLandingActions';
+// @flow
+import reducer from '../reducers';
+import type { Contrib, PaperBundle, ContribState } from '../reducers';
 
 describe('reducer tests', () => {
 
@@ -17,13 +18,32 @@ describe('reducer tests', () => {
       },
     },
   };
-  const intialPaperBundle: PaperBundle = 'PAPER+DIGITAL';
-  const intialState = { paperBundle: intialPaperBundle, contribution: initialContrib };
+  const initialPaperBundle: PaperBundle = 'PAPER+DIGITAL';
+  const initialState = { paperBundle: initialPaperBundle, contribution: initialContrib };
 
   it('should return the initial state', () => {
-    expect(
-      reducer(undefined, {})
-    ).toMatchSnapshot();
-  })
-  
+    expect(reducer(undefined, {})).toMatchSnapshot();
+  });
+
+  it('should handle CHANGE_PAPER_BUNDLE', () => {
+
+    const paperBundle: PaperBundle = 'PAPER';
+    const action = {
+      type: 'CHANGE_PAPER_BUNDLE',
+      bundle: paperBundle,
+    };
+
+    expect(reducer(initialState, action).paperBundle).toEqual(paperBundle);
+  });
+
+  it('should handle CHANGE_CONTRIB_TYPE', () => {
+
+    const contribType: Contrib = 'ONE_OFF';
+    const action = {
+      type: 'CHANGE_CONTRIB_TYPE',
+      contribType,
+    };
+
+    expect(reducer(initialState, action).contribution.type).toEqual(contribType);
+  });
 });

--- a/assets/pages/bundles-landing/reducers/__tests__/reducersTest.js
+++ b/assets/pages/bundles-landing/reducers/__tests__/reducersTest.js
@@ -1,0 +1,29 @@
+import reducer from '../reducers'
+import { changePaperBundle, changeContribType, changeContribAmountRecurring, changeContribAmountOneOff } from '../../actions/bundlesLandingActions';
+
+describe('reducer tests', () => {
+
+  const initialContrib: ContribState = {
+    type: 'RECURRING',
+    error: null,
+    amount: {
+      recurring: {
+        value: '5',
+        userDefined: false,
+      },
+      oneOff: {
+        value: '25',
+        userDefined: false,
+      },
+    },
+  };
+  const intialPaperBundle: PaperBundle = 'PAPER+DIGITAL';
+  const intialState = { paperBundle: intialPaperBundle, contribution: initialContrib };
+
+  it('should return the initial state', () => {
+    expect(
+      reducer(undefined, {})
+    ).toEqual(intialState)
+  })
+  
+});

--- a/assets/pages/bundles-landing/reducers/__tests__/reducersTest.js
+++ b/assets/pages/bundles-landing/reducers/__tests__/reducersTest.js
@@ -62,4 +62,20 @@ describe('reducer tests', () => {
     expect(reducer(initialState, action).contribution.amount.recurring).toEqual(amount);
     expect(reducer(initialState, action).contribution.amount.oneOff).toEqual(amount);
   });
+
+  it('should handle CHANGE_CONTRIB_AMOUNT_RECURRING', () => {
+
+    const amount: Amount = {
+      value: '45',
+      userDefined: true
+    };
+    const action = {
+      type: 'CHANGE_CONTRIB_AMOUNT_RECURRING',
+      amount,
+    };
+
+    expect(reducer(initialState, action).contribution.amount.recurring).toEqual(amount);
+    expect(reducer(initialState, action).contribution.amount.oneOff.value).toEqual('25');
+  });
+  
 });

--- a/assets/pages/bundles-landing/reducers/__tests__/reducersTest.js
+++ b/assets/pages/bundles-landing/reducers/__tests__/reducersTest.js
@@ -1,6 +1,6 @@
 // @flow
 import reducer from '../reducers';
-import type { Contrib, PaperBundle, ContribState } from '../reducers';
+import type { Contrib, PaperBundle, ContribState, Amount } from '../reducers';
 
 describe('reducer tests', () => {
 
@@ -22,6 +22,7 @@ describe('reducer tests', () => {
   const initialState = { paperBundle: initialPaperBundle, contribution: initialContrib };
 
   it('should return the initial state', () => {
+
     expect(reducer(undefined, {})).toMatchSnapshot();
   });
 
@@ -45,5 +46,20 @@ describe('reducer tests', () => {
     };
 
     expect(reducer(initialState, action).contribution.type).toEqual(contribType);
+  });
+
+  it('should handle CHANGE_CONTRIB_AMOUNT', () => {
+
+    const amount: Amount = {
+      value: '45',
+      userDefined: true
+    };
+    const action = {
+      type: 'CHANGE_CONTRIB_AMOUNT',
+      amount,
+    };
+
+    expect(reducer(initialState, action).contribution.amount.recurring).toEqual(amount);
+    expect(reducer(initialState, action).contribution.amount.oneOff).toEqual(amount);
   });
 });

--- a/assets/pages/bundles-landing/reducers/__tests__/reducersTest.js
+++ b/assets/pages/bundles-landing/reducers/__tests__/reducersTest.js
@@ -23,7 +23,7 @@ describe('reducer tests', () => {
   it('should return the initial state', () => {
     expect(
       reducer(undefined, {})
-    ).toEqual(intialState)
+    ).toMatchSnapshot();
   })
   
 });

--- a/assets/pages/bundles-landing/reducers/__tests__/reducersTest.js
+++ b/assets/pages/bundles-landing/reducers/__tests__/reducersTest.js
@@ -52,7 +52,7 @@ describe('reducer tests', () => {
 
     const amount: Amount = {
       value: '45',
-      userDefined: true
+      userDefined: true,
     };
     const action = {
       type: 'CHANGE_CONTRIB_AMOUNT',
@@ -67,7 +67,7 @@ describe('reducer tests', () => {
 
     const amount: Amount = {
       value: '45',
-      userDefined: true
+      userDefined: true,
     };
     const action = {
       type: 'CHANGE_CONTRIB_AMOUNT_RECURRING',
@@ -77,5 +77,19 @@ describe('reducer tests', () => {
     expect(reducer(initialState, action).contribution.amount.recurring).toEqual(amount);
     expect(reducer(initialState, action).contribution.amount.oneOff.value).toEqual('25');
   });
-  
+
+  it('should handle CHANGE_CONTRIB_AMOUNT_ONEOFF', () => {
+
+    const amount: Amount = {
+      value: '45',
+      userDefined: true,
+    };
+    const action = {
+      type: 'CHANGE_CONTRIB_AMOUNT_ONEOFF',
+      amount,
+    };
+
+    expect(reducer(initialState, action).contribution.amount.oneOff).toEqual(amount);
+    expect(reducer(initialState, action).contribution.amount.recurring.value).toEqual('5');
+  });
 });

--- a/assets/pages/bundles-landing/reducers/reducers.js
+++ b/assets/pages/bundles-landing/reducers/reducers.js
@@ -31,7 +31,7 @@ export type Amounts = {
 
 export type PaperBundle = 'PAPER+DIGITAL' | 'PAPER';
 
-type ContribState = {
+export type ContribState = {
   type: Contrib,
   error: ?ContribError,
   amount: Amounts,

--- a/package.json
+++ b/package.json
@@ -14,6 +14,17 @@
     "devrun": "npm-run-all clean webpack-dev-server",
     "test": "echo 'Running JS tests' && jest"
   },
+  "jest": {
+    "transform": {
+      ".*": "./node_modules/babel-jest"
+    },
+    "moduleFileExtensions": [
+      "js",
+      "json",
+      "es6"
+    ],
+    "verbose": true
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/guardian/support-frontend.git"
@@ -28,6 +39,7 @@
   "devDependencies": {
     "autoprefixer": "^6.7.7",
     "babel-eslint": "^7.2.2",
+    "babel-jest": "^19.0.0",
     "babel-loader": "^6.4.1",
     "babel-preset-es2015": "^6.24.0",
     "babel-preset-react": "^6.23.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -70,10 +70,6 @@ module.exports = (env) => {
           test: /\.(js|jsx)$/,
           exclude: /node_modules/,
           loader: 'babel-loader',
-          options: {
-            presets: ['react', 'es2015'],
-            cacheDirectory: '',
-          },
         },
         {
           test: /\.scss$/,


### PR DESCRIPTION
## Why are you doing this?

In order to improve our code quality, we decided to add tests for redux's actions and reducers. Therefore in this PR we are:
* Setting up Jest as our test framework.
* Adding tests for actions and reducers.
* Removing babel's configuration from webpack.config.js and putting it inside .babelrc

[**Trello Card**](https://trello.com/c/bkkhsfXD/520-writing-jest-tests-for-support-frontend)

## Screenshots

![picture 251](https://cloud.githubusercontent.com/assets/825398/25529235/2dbdbc2a-2c19-11e7-9eeb-433074363fd1.png)

