### PR TITLE
Campaign code logic

### DIFF
--- a/assets/pages/bundles-landing/bundlesLanding.jsx
+++ b/assets/pages/bundles-landing/bundlesLanding.jsx
@@ -10,6 +10,7 @@ import { Provider } from 'react-redux';
 import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
 import SimpleFooter from 'components/footers/simpleFooter/simpleFooter';
 
+import getQueryParameter from './helpers/queryParameter';
 import Introduction from './components/Introduction';
 import Bundles from './components/Bundles';
 import WaysOfSupport from './components/WaysOfSupport';
@@ -18,7 +19,7 @@ import reducer from './reducers/reducers';
 
 // ----- Redux Store ----- //
 
-const store = createStore(reducer);
+const store = createStore(reducer, { intCmp: getQueryParameter('INTCMP', 'gdnwb_copts_bundles_landing_default') });
 
 
 // ----- Render ----- //

--- a/assets/pages/bundles-landing/components/WaysOfSupport.jsx
+++ b/assets/pages/bundles-landing/components/WaysOfSupport.jsx
@@ -3,6 +3,7 @@
 // ----- Imports ----- //
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import WayOfSupport from './WayOfSupport';
 
@@ -14,25 +15,35 @@ const waysOfSupport = [
     heading: 'Patrons',
     infoText: 'The Patrons tier for those who care deeply about the the Guardian\'s journalism and the imact is has on th world',
     ctaText: 'Become a Patron',
-    ctaLink: 'https://membership.theguardian.com/patrons?INTCMP=gdnwb_copts_bundles_landing_default',
+    ctaLink: 'https://membership.theguardian.com/patrons',
     modifierClass: 'patron',
   },
   {
     heading: 'Guardian Live events',
     infoText: 'Events, discussions, debates, interviews, festivals, dinners and private views exclusively for Guardian members',
     ctaText: 'Find out about events',
-    ctaLink: 'https://membership.theguardian.com/events?INTCMP=gdnwb_copts_bundles_landing_default',
+    ctaLink: 'https://membership.theguardian.com/events',
     modifierClass: 'gu-events',
   },
 ];
 
+type PropTypes = {
+  intCmp: string
+};
+
 
 // ----- Component ----- //
 
-const WaysOfSupport = () => {
+const WaysOfSupport = (props: PropTypes) => {
 
   const className = 'ways-of-support';
-  const waysOfSupportRendered = waysOfSupport.map(x => <WayOfSupport {...x} />);
+
+  const params = new URLSearchParams();
+  params.append('INTCMP', props.intCmp);
+
+  const waysOfSupportIntCmp = waysOfSupport.map(x => Object.assign({}, x, { ctaLink: `${x.ctaLink}?${params.toString()}` }));
+  const waysOfSupportRendered = waysOfSupportIntCmp.map(x => <WayOfSupport {...x} />);
+
 
   return (
     <section className={className}>
@@ -44,4 +55,14 @@ const WaysOfSupport = () => {
   );
 };
 
-export default WaysOfSupport;
+
+// ----- Map State/Props ----- //
+
+function mapStateToProps(state) {
+  return {
+    intCmp: state.intCmp,
+  };
+}
+
+
+export default connect(mapStateToProps)(WaysOfSupport);

--- a/assets/pages/bundles-landing/components/WaysOfSupport.jsx
+++ b/assets/pages/bundles-landing/components/WaysOfSupport.jsx
@@ -28,7 +28,7 @@ const waysOfSupport = [
 ];
 
 type PropTypes = {
-  intCmp: string
+  intCmp: string,
 };
 
 
@@ -41,9 +41,14 @@ const WaysOfSupport = (props: PropTypes) => {
   const params = new URLSearchParams();
   params.append('INTCMP', props.intCmp);
 
-  const waysOfSupportIntCmp = waysOfSupport.map(x => Object.assign({}, x, { ctaLink: `${x.ctaLink}?${params.toString()}` }));
-  const waysOfSupportRendered = waysOfSupportIntCmp.map(x => <WayOfSupport {...x} />);
 
+  const waysOfSupportRendered = waysOfSupport.map((way) => {
+
+    const ctaLink = `${way.ctaLink}?${params.toString()}`;
+    const attrs = Object.assign({}, way, { ctaLink });
+    return <WayOfSupport {...attrs} />;
+
+  });
 
   return (
     <section className={className}>

--- a/assets/pages/bundles-landing/helpers/queryParameter.js
+++ b/assets/pages/bundles-landing/helpers/queryParameter.js
@@ -1,7 +1,7 @@
 // @flow
 
 // ----- Functions ----- //
-const getQueryParameter = (paramName: string, defaultValue: string) => {
+const getQueryParameter = (paramName: string, defaultValue: string): string => {
   const params = new URLSearchParams(window.location.search);
   return params.get(paramName) || defaultValue;
 };

--- a/assets/pages/bundles-landing/helpers/queryParameter.js
+++ b/assets/pages/bundles-landing/helpers/queryParameter.js
@@ -1,0 +1,11 @@
+// @flow
+
+// ----- Functions ----- //
+const getQueryParameter = (paramName: string, defaultValue: string) => {
+  const params = new URLSearchParams(window.location.search);
+  return params.get(paramName) || defaultValue;
+};
+
+// ----- Exports ----- //
+
+export default getQueryParameter;

--- a/assets/pages/bundles-landing/reducers/__tests__/__snapshots__/reducersTest.js.snap
+++ b/assets/pages/bundles-landing/reducers/__tests__/__snapshots__/reducersTest.js.snap
@@ -16,6 +16,7 @@ Object {
     "error": null,
     "type": "RECURRING",
   },
+  "intCmp": "",
   "paperBundle": "PAPER+DIGITAL",
 }
 `;

--- a/assets/pages/bundles-landing/reducers/reducers.js
+++ b/assets/pages/bundles-landing/reducers/reducers.js
@@ -55,6 +55,11 @@ const initialContrib: ContribState = {
   },
 };
 
+// ----- Functions ----//
+function getQueryParameter(paramName: string, defaultValue: string): string {
+  const params = new URLSearchParams(window.location.search);
+  return params.get(paramName) || defaultValue;
+}
 
 // ----- Reducers ----- //
 
@@ -122,10 +127,15 @@ function contribution(
 
 }
 
+function intCmp(state: string = getQueryParameter('INTCMP', 'gdnwb_copts_bundles_landing_default')): string {
+  // Since nothing change the intcmp, this reducer does not handle any action.
+  return state;
+}
 
 // ----- Exports ----- //
 
 export default combineReducers({
   paperBundle,
   contribution,
+  intCmp,
 });

--- a/assets/pages/bundles-landing/reducers/reducers.js
+++ b/assets/pages/bundles-landing/reducers/reducers.js
@@ -55,6 +55,8 @@ const initialContrib: ContribState = {
   },
 };
 
+const defaultIntCmp:string = 'gdnwb_copts_bundles_landing_default';
+
 // ----- Functions ----//
 function getQueryParameter(paramName: string, defaultValue: string): string {
   const params = new URLSearchParams(window.location.search);
@@ -127,7 +129,7 @@ function contribution(
 
 }
 
-function intCmp(state: string = getQueryParameter('INTCMP', 'gdnwb_copts_bundles_landing_default')): string {
+function intCmp(state: string = getQueryParameter('INTCMP', defaultIntCmp)): string {
   // Since nothing change the intcmp, this reducer does not handle any action.
   return state;
 }

--- a/assets/pages/bundles-landing/reducers/reducers.js
+++ b/assets/pages/bundles-landing/reducers/reducers.js
@@ -55,14 +55,6 @@ const initialContrib: ContribState = {
   },
 };
 
-const defaultIntCmp:string = 'gdnwb_copts_bundles_landing_default';
-
-// ----- Functions ----//
-function getQueryParameter(paramName: string, defaultValue: string): string {
-  const params = new URLSearchParams(window.location.search);
-  return params.get(paramName) || defaultValue;
-}
-
 // ----- Reducers ----- //
 
 function paperBundle(
@@ -129,7 +121,7 @@ function contribution(
 
 }
 
-function intCmp(state: string = getQueryParameter('INTCMP', defaultIntCmp)): string {
+function intCmp(state: string = ''): string {
   // Since nothing change the intcmp, this reducer does not handle any action.
   return state;
 }


### PR DESCRIPTION
## Why are you doing this?

We want to be able to propagate the INTCMP (internal campaign code) through the different links in the bundle landing page.

[**Trello Card**](https://trello.com/c/X9DH7Kzl/536-ways-of-support-passes-through-correct-intcmp)

## Changes

* Add the INTCMP to the state.
* WaysOfSupport and Bundles components are able to understand intcmp state.



