### PR TITLE
Simple Header Tweaks

### DIFF
--- a/assets/components/headers/simpleHeader/simpleHeader.scss
+++ b/assets/components/headers/simpleHeader/simpleHeader.scss
@@ -1,34 +1,32 @@
 .component-simple-header {
 	background-color: gu-colour(guardian-brand);
-	height: 44px;
 
 	.svg-guardian-titlepiece {
-		display: block;
-		height: 32px;
 		float: right;
+		height: 100%;
 	}
 
-	@include mq($from: mobileMedium) {
-		height: 54px;
+	.component-simple-header__content {
+		height: 50px;
+		padding: ($gu-v-spacing / 2) ($gu-h-spacing / 2) $gu-v-spacing;
 
-		.svg-guardian-titlepiece {
-			height: 42px;
+		@include mq($from: mobileMedium) {
+			height: 60px;
 		}
-	}
 
-	@include mq($from: mobileLandscape) {
-		height: 73px;
-
-		.svg-guardian-titlepiece {
-			height: 49px;
+		@include mq($from: mobileLandscape) {
+			height: 67px;
+			padding-left: $gu-h-spacing;
+			padding-right: $gu-h-spacing;
 		}
-	}
 
-	@include mq($from: tablet) {
-		height: 92px;
+		@include mq($from: tablet) {
+			height: 86px;
+		}
 
-		.svg-guardian-titlepiece {
-			height: 68px;
+		@include mq($from: desktop) {
+			padding-left: 0;
+			padding-right: 0;
 		}
 	}
 }

--- a/assets/components/headers/simpleHeader/simpleHeader.scss
+++ b/assets/components/headers/simpleHeader/simpleHeader.scss
@@ -20,13 +20,13 @@
 			padding-right: $gu-h-spacing;
 		}
 
-		@include mq($from: tablet) {
-			height: 86px;
-		}
-
-		@include mq($from: desktop) {
+		@include mq($from: phablet) {
 			padding-left: 0;
 			padding-right: 0;
+		}
+
+		@include mq($from: tablet) {
+			height: 86px;
 		}
 	}
 }

--- a/assets/stylesheets/gu-sass/layout.scss
+++ b/assets/stylesheets/gu-sass/layout.scss
@@ -56,12 +56,3 @@ $gu-v-spacing: 12px;
     padding: 0 $gu-h-spacing;
   }
 }
-
-// The paddings at different breakpoints for the headers.
-.gu-header-margin {
-  padding: ($gu-v-spacing / 2) ($gu-h-spacing / 2);
-
-  @include mq($from: mobileLandscape) {
-    padding: $gu-v-spacing $gu-h-spacing;
-  }
-}


### PR DESCRIPTION
## Why are you doing this?

There were some issues with the layout of the simple header, mainly paddings. This adjusts those paddings. It also moves some code out of the shared `layout.scss` file and into the sass file for the simple header, as it's unlikely to be shareable between different headers.

[**Trello Card**](https://trello.com/c/kVzFOSqn/535-header-tweaks)

## Changes

- Made the padding above the header 6px and below 12px.
- Reworked the way the heights and paddings are handled, some of them were displaying things incorrectly.
- Moved header paddings out of the shared layout file.

cc: @superfrank

## Screenshots

**Narrow:**

![header-narrow](https://cloud.githubusercontent.com/assets/5131341/25657427/c0f530a6-2ff5-11e7-800e-76173db853e2.png)

**Medium:**

![header-medium](https://cloud.githubusercontent.com/assets/5131341/25657433/c77b91f4-2ff5-11e7-8d21-2bc6b49c6b5a.png)

**Wide:**

![header-wide](https://cloud.githubusercontent.com/assets/5131341/25657440/cd3c3652-2ff5-11e7-8c04-ab2ab6dba34e.png)
