### PR TITLE
Add Image Components

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 public/**/*.js
 target/**/*.js
 tools/**/*.js
+coverage/

--- a/.flowconfig
+++ b/.flowconfig
@@ -8,3 +8,4 @@ assets
 
 [options]
 module.name_mapper='^components/' -> '<PROJECT_ROOT>/assets/components/'
+module.name_mapper='^helpers/' -> '<PROJECT_ROOT>/assets/helpers/'

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 node_modules
 npm-debug.log
 app/npm-debug.log
+coverage/
 
 dev
 dist

--- a/assets/components/gridImage/gridImage.jsx
+++ b/assets/components/gridImage/gridImage.jsx
@@ -2,6 +2,8 @@
 
 // ----- Imports ----- //
 
+import React from 'react';
+
 import { gridUrl, gridSrcset } from 'helpers/theGrid';
 import { ascending } from 'helpers/utilities';
 
@@ -37,6 +39,7 @@ export default function GridImage(props: PropTypes) {
 
   return (
     <img
+      className="component-grid-image"
       sizes={props.sizes}
       srcSet={srcSet}
       src={fallbackSrc}

--- a/assets/components/gridImage/gridImage.jsx
+++ b/assets/components/gridImage/gridImage.jsx
@@ -1,0 +1,47 @@
+// @flow
+
+// ----- Imports ----- //
+
+import { gridUrl, gridSrcset } from 'helpers/theGrid';
+import { ascending } from 'helpers/utilities';
+
+
+// ----- Constants ----- //
+
+const MIN_IMG_WIDTH = 300;
+
+
+// ----- Types ----- //
+
+type PropTypes = {
+  gridId: string,
+  srcSizes: number[],
+  sizes: string,
+  altText: ?string,
+};
+
+
+// ----- Component ----- //
+
+export default function GridImage(props: PropTypes) {
+
+  if (props.srcSizes.length < 1) {
+    return null;
+  }
+
+  const sorted = props.srcSizes.sort(ascending);
+  const srcSet = gridSrcset(props.gridId, sorted);
+
+  const fallbackSize = sorted.find(_ => _ > MIN_IMG_WIDTH) || sorted[0];
+  const fallbackSrc = gridUrl(props.gridId, fallbackSize);
+
+  return (
+    <img
+      sizes={props.sizes}
+      srcSet={srcSet}
+      src={fallbackSrc}
+      alt={props.altText}
+    />
+  );
+
+}

--- a/assets/components/gridPicture/gridPicture.jsx
+++ b/assets/components/gridPicture/gridPicture.jsx
@@ -1,0 +1,50 @@
+// @flow
+
+// ----- Imports ----- //
+
+import { gridSrcset } from 'helpers/theGrid';
+
+
+// ----- Types ----- //
+
+// Disabling the linter here because it's just buggy...
+/* eslint-disable react/no-unused-prop-types */
+
+type Source = {
+  gridId: string,
+  media: string,
+  srcSizes: number[],
+};
+
+/* eslint-enable react/no-unused-prop-types */
+
+type PropTypes = {
+  sources: Source[],
+  fallback: string,
+  altText: ?string,
+};
+
+
+// ----- Component ----- //
+
+export default function GridPicture(props: PropTypes) {
+
+  const sources = props.sources.map((source) => {
+
+    const srcSet = gridSrcset(source.gridId, source.srcSizes);
+    return <source media={source.media} srcSet={srcSet} />;
+
+  });
+
+  return (
+    <picture className="component-picture">
+      {sources}
+      <img
+        className="component-picture__image"
+        src={props.fallback}
+        alt={props.altText}
+      />
+    </picture>
+  );
+
+}

--- a/assets/components/gridPicture/gridPicture.jsx
+++ b/assets/components/gridPicture/gridPicture.jsx
@@ -2,7 +2,9 @@
 
 // ----- Imports ----- //
 
-import { gridSrcset } from 'helpers/theGrid';
+import React from 'react';
+
+import { GRID_DOMAIN, gridSrcset } from 'helpers/theGrid';
 
 
 // ----- Types ----- //
@@ -12,6 +14,7 @@ import { gridSrcset } from 'helpers/theGrid';
 
 type Source = {
   gridId: string,
+  sizes: string,
   media: string,
   srcSizes: number[],
 };
@@ -32,16 +35,16 @@ export default function GridPicture(props: PropTypes) {
   const sources = props.sources.map((source) => {
 
     const srcSet = gridSrcset(source.gridId, source.srcSizes);
-    return <source media={source.media} srcSet={srcSet} />;
+    return <source sizes={source.sizes} media={source.media} srcSet={srcSet} />;
 
   });
 
   return (
-    <picture className="component-picture">
+    <picture className="component-grid-picture">
       {sources}
       <img
-        className="component-picture__image"
-        src={props.fallback}
+        className="component-grid-picture__image"
+        src={`${GRID_DOMAIN}/${props.fallback}`}
         alt={props.altText}
       />
     </picture>

--- a/assets/helpers/__tests__/theGridTest.js
+++ b/assets/helpers/__tests__/theGridTest.js
@@ -1,0 +1,34 @@
+// @flow
+
+// ----- Imports ----- //
+
+import { gridUrl, gridSrcset, GRID_DOMAIN } from '../theGrid';
+
+
+// ----- Tests ----- //
+
+describe('theGrid', () => {
+
+  it('should construct a grid url', () => {
+
+    const gridId = 'not_a_real_id';
+    const size = 333;
+    const expectedUrl = `${GRID_DOMAIN}/${gridId}/333.jpg`;
+
+    expect(gridUrl(gridId, size)).toEqual(expectedUrl);
+
+  });
+
+  it('should construct a srcset of grid urls', () => {
+
+    const gridId = 'not_a_real_id';
+    const sizes = [300, 500];
+    const urlPath = `${GRID_DOMAIN}/${gridId}`;
+
+    const expectedSrcset = `${urlPath}/300.jpg 300w, ${urlPath}/500.jpg 500w`;
+
+    expect(gridSrcset(gridId, sizes)).toEqual(expectedSrcset);
+
+  });
+
+});

--- a/assets/helpers/__tests__/utilitiesTest.js
+++ b/assets/helpers/__tests__/utilitiesTest.js
@@ -1,0 +1,62 @@
+// @flow
+
+// ----- Imports ----- //
+
+import { ascending, descending } from '../utilities';
+
+
+// ----- Tests ----- //
+
+describe('utilities', () => {
+
+  describe('ascending', () => {
+
+    it('should return a 1 if a > b', () => {
+      expect(ascending(3, 2)).toEqual(1);
+    });
+
+    it('should return a 0 if a < b', () => {
+      expect(ascending(2, 3)).toEqual(0);
+    });
+
+    it('should return a 1 if a === b', () => {
+      expect(ascending(2, 2)).toEqual(0);
+    });
+
+    it('should sort an array in ascending order', () => {
+
+      const unsorted = [100, 2, 2, 46.78, 54, 67, 54, 0.3, -3];
+      const sorted = [-3, 0.3, 2, 2, 46.78, 54, 54, 67, 100];
+
+      expect(unsorted.sort(ascending)).toEqual(sorted);
+
+    });
+
+  });
+
+  describe('descending', () => {
+
+    it('should return a 0 if a > b', () => {
+      expect(ascending(3, 2)).toEqual(1);
+    });
+
+    it('should return a 1 if a < b', () => {
+      expect(ascending(2, 3)).toEqual(0);
+    });
+
+    it('should return a 0 if a === b', () => {
+      expect(ascending(2, 2)).toEqual(0);
+    });
+
+    it('should sort an array in descending order', () => {
+
+      const unsorted = [100, 2, 2, 46.78, 54, 67, 54, 0.3, -3];
+      const sorted = [100, 67, 54, 54, 46.78, 2, 2, 0.3, -3];
+
+      expect(unsorted.sort(descending)).toEqual(sorted);
+
+    });
+
+  });
+
+});

--- a/assets/helpers/theGrid.js
+++ b/assets/helpers/theGrid.js
@@ -2,7 +2,7 @@
 
 // ----- Constants ----- //
 
-const GRID_DOMAIN = 'https://media.guim.co.uk';
+export const GRID_DOMAIN = 'https://media.guim.co.uk';
 
 
 // ----- Functions ----- //

--- a/assets/helpers/theGrid.js
+++ b/assets/helpers/theGrid.js
@@ -1,0 +1,31 @@
+// @flow
+
+// ----- Constants ----- //
+
+const GRID_DOMAIN = 'https://media.guim.co.uk';
+
+
+// ----- Functions ----- //
+
+// Builds a grid url from and id and an image size.
+// Example: https://media.guim.co.uk/g65756g5/300.jpg
+export function gridUrl(gridId: string, size: number): string {
+
+  const path = `${gridId}/${size}.jpg`;
+  const url = new URL(path, GRID_DOMAIN);
+
+  return url.toString();
+
+}
+
+// Returns a series of grid urls and their corresponding sizes.
+// Example:
+//   "https://media.guim.co.uk/g65756g5/300.jpg 300w,
+//    https://media.guim.co.uk/g65756g5/500.jpg 500w,
+//    https://media.guim.co.uk/g65756g5/700.jpg 700w"
+export function gridSrcset(gridId: string, sizes: number[]): string {
+
+  const sources = sizes.map(size => `${gridUrl(gridId, size)} ${size}w`);
+  return sources.join(', ');
+
+}

--- a/assets/helpers/utilities.js
+++ b/assets/helpers/utilities.js
@@ -1,0 +1,13 @@
+// @flow
+// A series of general purpose helper functions.
+
+// Ascending comparison function for use with Array.prototype.sort.
+export function ascending(a: number, b: number): number {
+  return a > b ? 1 : 0;
+}
+
+
+// Descending comparison function for use with Array.prototype.sort.
+export function descending(a: number, b: number): number {
+  return a < b ? 1 : 0;
+}

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -239,6 +239,32 @@
       }
     }
 
+    .why-support__image {
+      width: 100%;
+      overflow: hidden;
+      position: relative;
+
+      @include mq($from: tablet) {
+        height: 240px;
+      }
+
+      @include mq($from: desktop) {
+        height: 360px;
+      }
+
+      .component-grid-picture__image {
+        @include mq($from: tablet) {
+          position: absolute;
+          top: -100%;
+          bottom: -100%;
+          left: -100%;
+          right: -100%;
+          margin: auto;
+          height: 100%;
+        }
+      }
+    }
+
     .why-support__top-content, .why-support__bottom-content {
       flex-basis: 300px;
       flex-grow: 1;

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -253,6 +253,8 @@
       }
 
       .component-grid-picture__image {
+        display: block;
+
         @include mq($from: tablet) {
           position: absolute;
           top: -100%;

--- a/assets/pages/bundles-landing/components/WayOfSupport.jsx
+++ b/assets/pages/bundles-landing/components/WayOfSupport.jsx
@@ -5,6 +5,7 @@
 import React from 'react';
 
 import CtaCircle from 'components/ctaCircle/ctaCircle';
+import GridImage from 'components/gridImage/gridImage';
 
 // ----- Types ----- //
 
@@ -14,6 +15,8 @@ type PropTypes = {
   ctaText: string,
   ctaLink: string,
   modifierClass: ?string,
+  gridImg: string,
+  imgAlt: ?string,
 };
 
 
@@ -30,7 +33,12 @@ const WayOfSupport = (props: PropTypes) => {
 
   return (
     <div className={rootClassName}>
-      <img src="https://placehold.it/300x170" alt="Example" />
+      <GridImage
+        gridId={props.gridImg}
+        srcSizes={[1000, 500, 140]}
+        sizes="(max-width: 480px) 100vw, (max-width: 740px) 210px, (max-width: 980px) 220px, 300px"
+        altText={props.imgAlt}
+      />
       <h1 className={`${className}__heading`}>{props.heading}</h1>
       <p className={`${className}__info-text`}>{props.infoText}</p>
       <CtaCircle text={props.ctaText} modifierClass={props.modifierClass} url={props.ctaLink} />

--- a/assets/pages/bundles-landing/components/WaysOfSupport.jsx
+++ b/assets/pages/bundles-landing/components/WaysOfSupport.jsx
@@ -17,6 +17,8 @@ const waysOfSupport = [
     ctaText: 'Become a Patron',
     ctaLink: 'https://membership.theguardian.com/patrons',
     modifierClass: 'patron',
+    gridImg: '137d6b217a27acddf85512657d04f6490b9e0bb1/1638_0_3571_2009',
+    imgAlt: 'the Guardian and the Observer',
   },
   {
     heading: 'Guardian Live events',
@@ -24,6 +26,8 @@ const waysOfSupport = [
     ctaText: 'Find out about events',
     ctaLink: 'https://membership.theguardian.com/events',
     modifierClass: 'gu-events',
+    gridImg: '5f18c6428e9f31394b14215fe3c395b8f7b4238a/500_386_2373_1335',
+    imgAlt: 'live event',
   },
 ];
 
@@ -40,7 +44,6 @@ const WaysOfSupport = (props: PropTypes) => {
 
   const params = new URLSearchParams();
   params.append('INTCMP', props.intCmp);
-
 
   const waysOfSupportRendered = waysOfSupport.map((way) => {
 
@@ -69,5 +72,7 @@ function mapStateToProps(state) {
   };
 }
 
+
+// ----- Exports ----- //
 
 export default connect(mapStateToProps)(WaysOfSupport);

--- a/assets/pages/bundles-landing/components/WhySupport.jsx
+++ b/assets/pages/bundles-landing/components/WhySupport.jsx
@@ -7,9 +7,29 @@ import React from 'react';
 import Svg from 'components/svg/svg';
 
 import BodyCopy from 'components/bodyCopy/bodyCopy';
+import GridPicture from 'components/gridPicture/gridPicture';
 
 
 // ----- Copy ----- //
+
+const heroImage = {
+  sources: [
+    {
+      gridId: 'bce7d14f7f837a4f6c854d95efc4b1eab93a8c65/0_0_5200_720',
+      srcSizes: [2000, 1000],
+      media: '(min-width: 740px)',
+      sizes: '(max-width: 980px) 1734px, 2600px',
+    },
+    {
+      gridId: 'd1a7088f8f2a367b0321528f081777c9b5618412/0_0_3578_2013',
+      srcSizes: [2000, 1000, 500],
+      media: '(max-width: 740px)',
+      sizes: '100vw',
+    },
+  ],
+  fallback: 'bce7d14f7f837a4f6c854d95efc4b1eab93a8c65/0_0_5200_720/1000.jpg',
+  altText: 'Guardian supporters',
+};
 
 const copy = {
   top: [
@@ -31,7 +51,9 @@ export default function WhySupport() {
 
   return (
     <section className="why-support">
-      <div className="why-support__image">I am an image!</div>
+      <div className="why-support__image">
+        <GridPicture {...heroImage} />
+      </div>
       <div className="why-support__content gu-content-margin">
         <div className="why-support__top-content">
           <div className="why-support__top-copy">

--- a/assets/pages/hello-world/helloWorld.jsx
+++ b/assets/pages/hello-world/helloWorld.jsx
@@ -6,7 +6,7 @@ import GridImage from 'components/gridImage/gridImage';
 const app = document.getElementById('app');
 
 const page = (
-   <div>
+  <div>
     <h1>Hello World!!!</h1>
     <GridImage
       gridId="137d6b217a27acddf85512657d04f6490b9e0bb1/1638_0_3571_2009"

--- a/assets/pages/hello-world/helloWorld.jsx
+++ b/assets/pages/hello-world/helloWorld.jsx
@@ -1,8 +1,20 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import GridImage from 'components/gridImage/gridImage';
+
 const app = document.getElementById('app');
 
-ReactDOM.render(
-  <div>Hello World!!!</div>
-  , app);
+const page = (
+   <div>
+    <h1>Hello World!!!</h1>
+    <GridImage
+      gridId="137d6b217a27acddf85512657d04f6490b9e0bb1/1638_0_3571_2009"
+      altText="the Guardian and the Observer"
+      srcSizes={[1000, 500, 140]}
+      sizes="(min-width: 800px) 50vw, 100vw"
+    />
+  </div>
+);
+
+ReactDOM.render(page, app);


### PR DESCRIPTION
## Why are you doing this?

We'd like to display images from the Grid on the site, and we'd like them to be responsive because it's 2017! The focus of this PR is the addition of two new React components, and `theGrid` helper module, to achieve this:

### `GridImage`

A responsive image tag with `srcset` and `sizes`. Example:

```html
<img
  srcset="https://media.guim.co.uk/grid_id/200.jpg 200w"
  sizes="(max-width: 480px) 100vw, 50vw"
  src="https://media.guim.co.uk/grid_id/500.jpg"
  alt="description"
>
```

### `GridPicture`

A responsive picture tag, supporting multiple `<source>` elements and a fallback `src`. Example:

```html
<picture>
  <source
    srcset="https://media.guim.co.uk/grid_id_1/200.jpg 200w"
    sizes="(max-width: 480px) 100vw, 50vw"
    media="(max-width: 980px)"
  >
  <source
    srcset="https://media.guim.co.uk/grid_id_2/1000.jpg 1000w,
            https://media.guim.co.uk/grid_id_2/1500.jpg 1500w"
    sizes="(max-width: 1140px) 100vw, 50vw"
    media="(min-width: 980px)"
  >
  <img
    src="https://media.guim.co.uk/grid_id_1/500.jpg"
    alt="description"
  >
</picture>
```

**Note:** These examples don't necessarily make sense, they're just to demonstrate possible output 🐰.

This PR also uses these components to add images to the bundles landing page.

[**Trello Card**](https://trello.com/c/VoYUaWPc/527-add-images-to-new-site)

## Changes

- Updated `.flowconfig` so that flow can resolve the helper modules.
- Added the `GridImage` and `GridPicture` components.
- Added `theGrid` and `utilities` helper modules.
- Updated the bundles landing page components and css to make use of these new components.
- Added an image to the hello world page as a demo.

FYI @SiAdcock @NataliaLKB

## Screenshots

**Bundles Landing Hero Image (`GridPicture`):**

![bundles-hero](https://cloud.githubusercontent.com/assets/5131341/25742946/d4b437d2-3189-11e7-8374-81d454f5a7e2.jpg)

**Bundles Landing 'Other Ways' Images (`GridImage`):**

![bundles-other-images](https://cloud.githubusercontent.com/assets/5131341/25742956/e48ea250-3189-11e7-8901-e214d041bfe8.jpg)
