### PR TITLE
Add Video Component

### DIFF
--- a/assets/components/gridImage/gridImage.jsx
+++ b/assets/components/gridImage/gridImage.jsx
@@ -15,12 +15,14 @@ const MIN_IMG_WIDTH = 300;
 
 // ----- Types ----- //
 
-type PropTypes = {
+export type GridImg = {
   gridId: string,
   srcSizes: number[],
   sizes: string,
   altText: ?string,
-};
+}
+
+type PropTypes = GridImg;
 
 
 // ----- Component ----- //

--- a/assets/components/svg/svg.jsx
+++ b/assets/components/svg/svg.jsx
@@ -71,10 +71,10 @@ const svgsCatalog: {
 // ----- Types ----- //
 
 // Utility type: https://flow.org/en/docs/types/utilities/#toc-keys
-export type svgName = $Keys<typeof svgsCatalog>;
+export type SvgName = $Keys<typeof svgsCatalog>;
 
 type PropTypes = {
-  svgName: svgName,
+  svgName: SvgName,
 };
 
 

--- a/assets/components/video/video.jsx
+++ b/assets/components/video/video.jsx
@@ -26,17 +26,17 @@ const videoCatalogue: {
 // ----- Types ----- //
 
 // Utility type: https://flow.org/en/docs/types/utilities/#toc-keys
-export type videoName = $Keys<typeof videoCatalogue>;
+export type VideoName = $Keys<typeof videoCatalogue>;
 
 type PropTypes = {
-  name: videoName,
+  name: VideoName,
   poster: ?GridImg,
 };
 
 
 // ----- Functions ----- //
 
-function youtubeUrl(name: videoName) {
+function youtubeUrl(name: VideoName): string {
 
   const youtubeId = videoCatalogue[name];
   const url = new URL(youtubeId, YOUTUBE_BASE);

--- a/assets/components/video/video.jsx
+++ b/assets/components/video/video.jsx
@@ -1,0 +1,68 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+import type { GridImg } from '../gridImage/gridImage';
+import GridImage from '../gridImage/gridImage';
+
+
+// ----- Constants ----- //
+
+const YOUTUBE_BASE = 'https://www.youtube.com/embed/';
+const YOUTUBE_PARAMS = 'enablejsapi=1&wmode=transparent&rel=0';
+
+
+// ----- Catalogue ----- //
+
+const videoCatalogue: {
+  scottTrustExplained: string,
+} = {
+  scottTrustExplained: 'jn4wAy1Xs5M',
+};
+
+
+// ----- Types ----- //
+
+// Utility type: https://flow.org/en/docs/types/utilities/#toc-keys
+export type videoName = $Keys<typeof videoCatalogue>;
+
+type PropTypes = {
+  name: videoName,
+  poster: ?GridImg,
+};
+
+
+// ----- Functions ----- //
+
+function youtubeUrl(name: videoName) {
+
+  const youtubeId = videoCatalogue[name];
+  const url = new URL(youtubeId, YOUTUBE_BASE);
+
+  return `${url.toString()}?${YOUTUBE_PARAMS}`;
+
+}
+
+
+// ----- Component ----- //
+
+export default function Video(props: PropTypes) {
+
+  const poster = props.poster ? <GridImage {...props.poster} /> : null;
+
+  return (
+    <div className="component-video">
+      <iframe
+        src={youtubeUrl(props.name)}
+        frameBorder="0"
+        width="560"
+        height="315"
+        allowFullScreen
+      />
+      {poster}
+    </div>
+  );
+
+}

--- a/assets/components/video/video.scss
+++ b/assets/components/video/video.scss
@@ -1,0 +1,15 @@
+// Make the video resize proportionally
+// https://alistapart.com/article/creating-intrinsic-ratios-for-video
+.component-video {
+	position: relative;
+	padding-bottom: 56.25%;
+	height: 0;
+
+	iframe {
+		position: absolute;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+	}
+}

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -290,10 +290,6 @@
     }
 
     .why-support__bottom-content {
-      @include mq($until: mobileLandscape) {
-        padding-left: $gu-h-spacing / 2;
-        padding-right: $gu-h-spacing / 2;
-      }
 
       @include mq($from: tablet) {
         padding-top: $gu-v-spacing;
@@ -324,6 +320,14 @@
           max-width: 380px;
           margin-left: $gu-h-spacing;
         }
+      }
+    }
+
+    // Breaks the video out of 'gu-content-margin' to make it full width.
+    .component-video {
+      @include mq($until: mobileLandscape) {
+        width: 100vw;
+        margin-left: - $gu-h-spacing / 2;
       }
     }
 

--- a/assets/pages/bundles-landing/components/WhySupport.jsx
+++ b/assets/pages/bundles-landing/components/WhySupport.jsx
@@ -8,6 +8,7 @@ import Svg from 'components/svg/svg';
 
 import BodyCopy from 'components/bodyCopy/bodyCopy';
 import GridPicture from 'components/gridPicture/gridPicture';
+import Video from 'components/video/video';
 
 
 // ----- Copy ----- //
@@ -60,7 +61,7 @@ export default function WhySupport() {
             <h1 className="why-support__heading">why do we need your support?</h1>
             <BodyCopy copy={copy.top} />
           </div>
-          <div className="why-support__video-preview">I am a video!</div>
+          <Video name="scottTrustExplained" poster={null} />
         </div>
         <div className="why-support__bottom-content">
           <p className="why-support__video-caption">

--- a/assets/stylesheets/gu-sass/layout.scss
+++ b/assets/stylesheets/gu-sass/layout.scss
@@ -40,9 +40,7 @@ $gu-v-spacing: 12px;
 
 // The paddings at different breakpoints for the content.
 .gu-content-margin {
-  @include mq($from: mobile) {
-    padding: 0 ($gu-h-spacing / 2);
-  }
+  padding: 0 ($gu-h-spacing / 2);
 
   @include mq($from: mobileLandscape) {
     padding: 0 $gu-h-spacing;

--- a/assets/stylesheets/main.scss
+++ b/assets/stylesheets/main.scss
@@ -18,6 +18,7 @@
 @import '../components/numberInput/numberInput';
 @import '../components/radioToggle/radioToggle';
 @import '../components/svg/svg';
+@import '../components/video/video';
 
 // ----- Pages ----- //
 


### PR DESCRIPTION
## Why are you doing this?

This adds a video component to allow the embedding of youtube videos on the site. It's fairly minimal at the moment, simply creating a standard iframe embed, as we're still thinking about what the final design for videos will be (whether they will include a poster, whether to use the yellow/black styling from dotcom, etc). I've included some basic functionality for adding a poster, but it may require some tweaking (particularly the styling).

[**Trello Card**](https://trello.com/c/qXeCj16v/530-add-videos-to-new-site)

cc: @superfrank

## Changes

- Made `GridImg` available as a type to other components.
- Added a `Video` component to embed youtube videos.
- Added a video to the bundles landing page.
- Tweaked the content margins for very narrow (sub `mobile` breakpoints).

## Screenshots

![video-embed](https://cloud.githubusercontent.com/assets/5131341/25812852/869e1792-340f-11e7-9db5-f9784e0a5f9b.jpg)