### PR TITLE
Add Polyfills

### DIFF
--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -16,6 +16,7 @@
 </head>
 <body>
 	@content
+	<script src="https://polyfill.guim.co.uk/v2/polyfill.min.js?features=default,Array.prototype.find"></script>
 	@scripts
 </body>
 </html>


### PR DESCRIPTION
## Why are you doing this?

We would like our site to work in older browsers. This adds the polyfill service with the [default bundle](https://polyfill.io/v2/docs/features/#default-sets) plus [`Array.prototype.find`](https://polyfill.io/v2/docs/features/#Array_prototype_find).

This is an initial implementation so that we can go live. As with a few other things, we will probably come back to this later with a view to improving performance (e.g. [async loading](https://polyfill.io/v2/docs/examples#feature-detection)).

[**Trello Card**](https://trello.com/c/U8UJfmkI/485-add-polyfill-for-old-browsers)

cc: @janua

## Changes

- Added script tag for the polyfill service to the main template, loading before the rest of the scripts on the page.

## Screenshots

The polyfill download sizes relative to our own (non-gzipped) js bundle on the landing page.

**Firefox Developer Edition (v54):**

This shows transferred (i.e. gzipped) size, and then actual size.

![network-ff](https://cloud.githubusercontent.com/assets/5131341/25901689/6d356e14-358f-11e7-80e3-484729c18517.png)

**Safari 10:**

This shows actual size, and then transferred (i.e. gzipped) size. *Note: somehow here the transferred size of our bundle is shown as being larger, this appears to be an anomaly (a.k.a. a bug).*

![network-safari10](https://cloud.githubusercontent.com/assets/5131341/25901777/af008252-358f-11e7-87ea-bb45a0e74de3.png)

**IE 10:**

The devtools here don't specify what the size field is (they just say `Received`), but I'm going to assume this is actual size (i.e. non-gzipped), as this is about right for what the polyfill service [reports](https://polyfill.io/v2/docs/features/#understanding-polyfill-sizes) as actual size for IE10.

![network-ie10](https://cloud.githubusercontent.com/assets/5131341/25902045/51b365aa-3590-11e7-8d69-c688d5262465.png)

**Chrome 56:**

This, I believe, shows actual size.

![network-chrome](https://cloud.githubusercontent.com/assets/5131341/25902196/ca2d31e6-3590-11e7-8942-c8303e1f6669.png)
