### PR TITLE
Move bundles landing page to /uk to for backwards compatibility

### DIFF
--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -16,5 +16,5 @@ trait AppComponents extends PlayComponents {
   lazy val applicationController = new Application()
 
   override lazy val httpFilters: Seq[EssentialFilter] = Seq(new CheckCacheHeadersFilter())
-  override lazy val router: Router = new Routes(httpErrorHandler, assetController, applicationController, prefix = "/")
+  override lazy val router: Router = new Routes(httpErrorHandler, assetController, applicationController, controllers.Default, prefix = "/")
 }

--- a/conf/routes
+++ b/conf/routes
@@ -7,4 +7,6 @@ GET /healthcheck                controllers.Application.healthcheck
 # ----- Pages ----- #
 
 GET /hello                      controllers.Application.helloWorld
-GET /                           controllers.Application.bundlesLanding
+GET /uk                         controllers.Application.bundlesLanding
+GET /                           controllers.Default.redirect(to = "/uk")
+


### PR DESCRIPTION
## Why are you doing this?

The existing live bundles landing page is served from /uk, so the new one needs to as well so that it is a drop in replacement.  I've added a redirect from '/' for convenience.