### PR TITLE
Exclude Play generated files from scalariform

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -71,4 +71,10 @@ import scalariform.formatter.preferences.SpacesAroundMultiImports
 ScalariformKeys.preferences := ScalariformKeys.preferences.value
   .setPreference(SpacesAroundMultiImports, false)
 
+excludeFilter in scalariformFormat := (excludeFilter in scalariformFormat).value ||
+  "Routes.scala" ||
+  "ReverseRoutes.scala" ||
+  "JavaScriptReverseRoutes.scala" ||
+  "RoutesPrefix.scala"
+
 addCommandAlias("devrun", "run 9000")


### PR DESCRIPTION
This stops the scala sources being recompiled every time you make a frontend change, making development more pleasant