### PR TITLE
Add server-side sentry logging

### DIFF
--- a/app/config/ConfigImplicits.scala
+++ b/app/config/ConfigImplicits.scala
@@ -1,0 +1,13 @@
+package config
+
+import com.typesafe.config.Config
+
+object ConfigImplicits {
+  implicit class RichConfig(val underlying: Config) extends AnyVal {
+    def getOptionalString(path: String): Option[String] = if (underlying.hasPath(path)) {
+      Some(underlying.getString(path))
+    } else {
+      None
+    }
+  }
+}

--- a/app/config/Configuration.scala
+++ b/app/config/Configuration.scala
@@ -1,0 +1,12 @@
+package config
+
+import com.typesafe.config.ConfigFactory
+import ConfigImplicits._
+
+class Configuration {
+  val config = ConfigFactory.load()
+
+  lazy val stage = Stage.fromString(config.getString("stage")).get
+
+  lazy val sentryDsn = config.getOptionalString("sentry.dsn")
+}

--- a/app/config/Stages.scala
+++ b/app/config/Stages.scala
@@ -1,0 +1,20 @@
+package config
+
+import PartialFunction.condOpt
+import Stages._
+
+sealed trait Stage
+
+object Stages {
+  case object DEV extends Stage
+  case object CODE extends Stage
+  case object PROD extends Stage
+}
+
+object Stage {
+  def fromString(s: String): Option[Stage] = condOpt(s) {
+    case "DEV" => DEV
+    case "CODE" => CODE
+    case "PROD" => PROD
+  }
+}

--- a/app/monitoring/SentryLogging.scala
+++ b/app/monitoring/SentryLogging.scala
@@ -1,0 +1,34 @@
+package monitoring
+
+import ch.qos.logback.classic.filter.ThresholdFilter
+import ch.qos.logback.classic.{Logger, LoggerContext}
+import com.getsentry.raven.RavenFactory
+import com.getsentry.raven.dsn.Dsn
+import com.getsentry.raven.logback.SentryAppender
+import org.slf4j.Logger.ROOT_LOGGER_NAME
+import org.slf4j.LoggerFactory
+import config.Stage
+import app.BuildInfo
+import com.typesafe.scalalogging.LazyLogging
+
+object SentryLogging {
+  val AllMDCTags = Seq()
+}
+
+class SentryLogging(dsnConfig: String, stage: Stage) extends LazyLogging {
+  val dsn = new Dsn(dsnConfig)
+  logger.info(s"Initialising Sentry logging for ${dsn.getHost}")
+  val tags = Map("stage" -> stage.toString) ++ BuildInfo.toMap
+  val tagsString = tags.map { case (k, v) => s"$k:$v" }.mkString(",")
+  val filter = new ThresholdFilter { setLevel("ERROR") }
+  filter.start()
+  val sentryAppender = new SentryAppender(RavenFactory.ravenInstance(dsn)) {
+    addFilter(filter)
+    setTags(tagsString)
+    setRelease(BuildInfo.gitCommitId)
+    setExtraTags(SentryLogging.AllMDCTags.mkString(","))
+    setContext(LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext])
+  }
+  sentryAppender.start()
+  LoggerFactory.getLogger(ROOT_LOGGER_NAME).asInstanceOf[Logger].addAppender(sentryAppender)
+}

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -1,14 +1,18 @@
 package wiring
 
 import assets.AssetsResolver
+import config.Configuration
 import play.api.routing.Router
 import router.Routes
 import controllers.{Application, Assets}
 import filters.CheckCacheHeadersFilter
 import lib.CustomHttpErrorHandler
+import monitoring.SentryLogging
 import play.api.mvc.EssentialFilter
 
 trait AppComponents extends PlayComponents {
+
+  val config = new Configuration()
 
   override lazy val httpErrorHandler = new CustomHttpErrorHandler(environment, configuration, sourceMapper, Some(router))
   implicit lazy val assetsResolver = new AssetsResolver("/assets/", "assets.map", environment)
@@ -17,4 +21,6 @@ trait AppComponents extends PlayComponents {
 
   override lazy val httpFilters: Seq[EssentialFilter] = Seq(new CheckCacheHeadersFilter())
   override lazy val router: Router = new Routes(httpErrorHandler, assetController, applicationController, controllers.Default, prefix = "/")
+
+  config.sentryDsn foreach { dsn => new SentryLogging(dsn, config.stage) }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -32,6 +32,7 @@ lazy val root = (project in file(".")).enablePlugins(PlayScala, BuildInfoPlugin,
 
 libraryDependencies ++= Seq(
   "org.scalatestplus.play" %% "scalatestplus-play" % "2.0.0" % Test,
+  "org.mockito" % "mockito-core" % "2.7.22" % Test,
   "com.getsentry.raven" % "raven-logback" % "8.0.3",
   "com.typesafe.scala-logging" % "scala-logging_2.11" % "3.4.0"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,8 @@ lazy val root = (project in file(".")).enablePlugins(PlayScala, BuildInfoPlugin,
 
 libraryDependencies ++= Seq(
   "org.scalatestplus.play" %% "scalatestplus-play" % "2.0.0" % Test,
-  "org.mockito" % "mockito-core" % "2.7.22" % Test
+  "com.getsentry.raven" % "raven-logback" % "8.0.3",
+  "com.typesafe.scala-logging" % "scala-logging_2.11" % "3.4.0"
 )
 
 sources in (Compile,doc) := Seq.empty

--- a/conf/CODE.public.conf
+++ b/conf/CODE.public.conf
@@ -1,0 +1,8 @@
+# NO SECRETS (ie credentials) SHOULD GO IN THIS FILE
+#
+# The secrets file is stored in S3 - it's called 'support.private.conf' and will pull in the
+# correct "[STAGE].public.conf" file with an include.
+#
+# This file should be line-for-line comparable with other "[STAGE].public.conf" files
+
+stage="CODE"

--- a/conf/DEV.public.conf
+++ b/conf/DEV.public.conf
@@ -1,0 +1,8 @@
+# NO SECRETS (ie credentials) SHOULD GO IN THIS FILE
+#
+# The secrets file is stored in S3 - it's called 'support.private.conf' and will pull in the
+# correct "[STAGE].public.conf" file with an include.
+#
+# This file should be line-for-line comparable with other "[STAGE].public.conf" files
+
+stage="DEV"

--- a/conf/PROD.public.conf
+++ b/conf/PROD.public.conf
@@ -1,0 +1,8 @@
+# NO SECRETS (ie credentials) SHOULD GO IN THIS FILE
+#
+# The secrets file is stored in S3 - it's called 'support.private.conf' and will pull in the
+# correct "[STAGE].public.conf" file with an include.
+#
+# This file should be line-for-line comparable with other "[STAGE].public.conf" files
+
+stage="PROD"


### PR DESCRIPTION
## Why are you doing this?

So that we receive notifications of server-side errors on support-frontend

[**Trello Card**](https://trello.com/c/zVixRLyG/525-add-sentry-logging-to-support-frontend-server-side)

