### PR TITLE
Style The Bundles On The Landing Page, And Apply Design Changes

### DIFF
--- a/assets/components/ctaLink/ctaLink.jsx
+++ b/assets/components/ctaLink/ctaLink.jsx
@@ -3,6 +3,7 @@
 // ----- Imports ----- //
 
 import React from 'react';
+import Svg from 'components/svg/svg';
 
 
 // ----- Types ----- //
@@ -19,7 +20,8 @@ export default function CtaLink(props: PropTypes) {
 
   return (
     <a className="component-cta-link" href={props.url}>
-      {props.text}
+      <span>{props.text}</span>
+      <Svg svgName="arrow-right-straight" />
     </a>
   );
 

--- a/assets/components/ctaLink/ctaLink.scss
+++ b/assets/components/ctaLink/ctaLink.scss
@@ -6,11 +6,14 @@
 	padding: 6px 20px;
 	margin-top: 12px;
 	text-align: left;
-	height: 36px;
+	height: $gu-v-spacing * 2;
 	vertical-align: bottom;
 	display: block;
 	line-height: 180%;
 	text-decoration: none;
+	font-size: 14px;
+	font-weight: bold;
+	font-family: $gu-text-sans-web;
 
 	&:hover {
 		background-color: #000;

--- a/assets/components/ctaLink/ctaLink.scss
+++ b/assets/components/ctaLink/ctaLink.scss
@@ -14,8 +14,17 @@
 	font-size: 14px;
 	font-weight: bold;
 	font-family: $gu-text-sans-web;
+	position: relative;
 
 	&:hover {
 		background-color: #000;
+	}
+
+	svg {
+		height: 50%;
+		position: absolute;
+		right: 8px;
+		top: 9px;
+		fill: #fff;
 	}
 }

--- a/assets/components/doubleHeading/doubleHeading.scss
+++ b/assets/components/doubleHeading/doubleHeading.scss
@@ -11,7 +11,7 @@
 
 	.component-double-heading__subheading {
 		font-weight: 300;
-		color: #333;
+		color: gu-colour(neutral-1);
 		margin: 0;
 		font-family: $gu-text-sans-web;
 

--- a/assets/components/doubleHeading/doubleHeading.scss
+++ b/assets/components/doubleHeading/doubleHeading.scss
@@ -1,18 +1,19 @@
 .component-double-heading {
-	@include gu-font(copy, 18);
-
-	font-weight: 900;
 	line-height: 27px;
+	font-size: 28px;
 
 	.component-double-heading__heading {
-		font-size: 28px;
-		color: #000;
+		font-weight: 900;
+		font-family: $gu-egyptian-web;
+		color: #fff;
 		margin: 0;
 	}
 
 	.component-double-heading__subheading {
-		font-size: 28px;
-		color: #fff;
+		font-weight: 300;
+		color: #333;
 		margin: 0;
+		font-family: $gu-text-sans-web;
+
 	}
 }

--- a/assets/components/featureList/featureList.scss
+++ b/assets/components/featureList/featureList.scss
@@ -2,8 +2,26 @@
 	margin: 0;
 	padding: 0;
 	padding-left: 10px;
+	font-size: 15px;
 
 	h3, p {
 		margin: 0;
+	}
+
+	h3 {
+		font-family: $gu-egyptian-web;
+		font-weight: bold;
+		line-height: 15px;
+	}
+
+	p {
+		font-family: $gu-text-sans-web;
+		font-weight: 300;
+		line-height: 20px;
+	}
+
+	li {
+		margin-bottom: $gu-v-spacing;
+		margin-left: 19px;
 	}
 }

--- a/assets/components/featureList/featureList.scss
+++ b/assets/components/featureList/featureList.scss
@@ -22,6 +22,6 @@
 
 	li {
 		margin-bottom: $gu-v-spacing;
-		margin-left: 19px;
+		margin-left: $gu-h-spacing;
 	}
 }

--- a/assets/components/numberInput/numberInput.scss
+++ b/assets/components/numberInput/numberInput.scss
@@ -5,7 +5,6 @@
 	padding: 6px 10px;
 	margin: 3px 0;
 	height: 24px;
-	min-width: 100%;
 	text-align: center;
 	font-size: 14px;
 	font-weight: bold;

--- a/assets/components/numberInput/numberInput.scss
+++ b/assets/components/numberInput/numberInput.scss
@@ -7,8 +7,18 @@
 	height: 24px;
 	min-width: 100%;
 	text-align: center;
+	font-size: 14px;
+	font-weight: bold;
 
 	&:focus {
 		outline: none;
+	}
+
+	// Hides the number spinners.
+	-moz-appearance: textfield;
+	&::-webkit-outer-spin-button,
+	&::-webkit-inner-spin-button {
+		-webkit-appearance: none;
+		margin: 0;
 	}
 }

--- a/assets/components/radioToggle/radioToggle.jsx
+++ b/assets/components/radioToggle/radioToggle.jsx
@@ -34,8 +34,9 @@ export default function RadioToggle(props: PropTypes) {
     const radioId = `${props.name}-${idx}`;
 
     return (
-      <span key={radioId}>
+      <span className="component-radio-toggle__button" key={radioId}>
         <input
+          className="component-radio-toggle__input"
           type="radio"
           name={props.name}
           value={radio.value}
@@ -43,7 +44,9 @@ export default function RadioToggle(props: PropTypes) {
           onChange={() => props.toggleAction(radio.value)}
           checked={radio.value === props.checked}
         />
-        <label htmlFor={radioId}>{radio.text}</label>
+        <label className="component-radio-toggle__label"htmlFor={radioId}>
+          {radio.text}
+        </label>
       </span>
     );
 

--- a/assets/pages/bundles-landing/actions/__tests__/bundlesLandingActionsTest.js
+++ b/assets/pages/bundles-landing/actions/__tests__/bundlesLandingActionsTest.js
@@ -1,27 +1,13 @@
 // @flow
-import type { Contrib, PaperBundle } from '../../reducers/reducers';
-import { changePaperBundle, changeContribType, changeContribAmountRecurring, changeContribAmountOneOff } from '../bundlesLandingActions';
+import type { Contrib } from '../../reducers/reducers';
+import {
+  changeContribType,
+  changeContribAmountRecurring,
+  changeContribAmountOneOff,
+} from '../bundlesLandingActions';
 
 
 describe('actions', () => {
-
-  it('should create an action to change to paper+digital bundle', () => {
-    const paperBundle: PaperBundle = 'PAPER+DIGITAL';
-    const expectedAction = {
-      type: 'CHANGE_PAPER_BUNDLE',
-      bundle: paperBundle,
-    };
-    expect(changePaperBundle(paperBundle)).toEqual(expectedAction);
-  });
-
-  it('should create an action to change to paper bundle', () => {
-    const paperBundle: PaperBundle = 'PAPER';
-    const expectedAction = {
-      type: 'CHANGE_PAPER_BUNDLE',
-      bundle: paperBundle,
-    };
-    expect(changePaperBundle(paperBundle)).toEqual(expectedAction);
-  });
 
   it('should create an action to change to one off contribution type', () => {
 

--- a/assets/pages/bundles-landing/actions/bundlesLandingActions.js
+++ b/assets/pages/bundles-landing/actions/bundlesLandingActions.js
@@ -2,13 +2,12 @@
 
 // ----- Imports ----- //
 
-import type { Contrib, Amount, PaperBundle } from '../reducers/reducers';
+import type { Contrib, Amount } from '../reducers/reducers';
 
 
 // ----- Types ----- //
 
 export type Action =
-  | { type: 'CHANGE_PAPER_BUNDLE', bundle: PaperBundle }
   | { type: 'CHANGE_CONTRIB_TYPE', contribType: Contrib }
   | { type: 'CHANGE_CONTRIB_AMOUNT', amount: Amount }
   | { type: 'CHANGE_CONTRIB_AMOUNT_RECURRING', amount: Amount }
@@ -17,10 +16,6 @@ export type Action =
 
 
 // ----- Actions ----- //
-
-export function changePaperBundle(bundle: PaperBundle): Action {
-  return { type: 'CHANGE_PAPER_BUNDLE', bundle };
-}
 
 export function changeContribType(contribType: Contrib): Action {
   return { type: 'CHANGE_CONTRIB_TYPE', contribType };

--- a/assets/pages/bundles-landing/bundlesLanding.jsx
+++ b/assets/pages/bundles-landing/bundlesLanding.jsx
@@ -32,7 +32,6 @@ const content = (
       <SimpleHeader />
       <Introduction />
       <Bundles />
-      <br style={{ clear: 'both' }} />
       <WhySupport />
       <WaysOfSupport />
       <SimpleFooter />

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -188,7 +188,7 @@
         text-align: center;
       }
 
-      .contrib-amounts {
+      .contrib-amounts--recurring {
         .component-radio-toggle__button {
           flex-basis: calc(33.3% - 3.3px);
           // Fix for Safari 8.
@@ -199,6 +199,14 @@
           //   flex-basis: ((gs-span(4) - $gs-gutter) / 3) - 3.3px;
           //   max-width: ((gs-span(4) - $gs-gutter) / 3) - 3.3px;
           // }
+        }
+      }
+
+      .contrib-amounts--one-off {
+        .component-radio-toggle__button {
+          flex-basis: calc(25% - 4px);
+          // Fix for Safari 8.
+          // min-width: 24%;
         }
       }
 

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -138,16 +138,22 @@
 
     .bundles__content {
       background-color: gu-colour(comment-support-2);
-      padding-bottom: $gu-v-spacing * 2;
+      padding: 0 0 ($gu-v-spacing * 2);
+    }
+
+    .bundles__wrapper {
+      width: 960px;
+      margin: 0 auto;
     }
 
     .bundles__bundle {
-      width: 300px;
+      width: 280px;
       height: 400px;
       padding: 8px 10px 12px;
       display: inline-block;
       vertical-align: top;
       position: relative;
+      margin: 0 ($gu-h-spacing / 2);
     }
 
     .component-cta-link {

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -149,9 +149,12 @@
 
     .bundles__bundle--contributions {
       background-color: gu-colour(multimedia-main-2);
+      font-size: 14px;
+      font-weight: bold;
+      font-family: $gu-text-sans-web;
 
       input:checked+label {
-        background-color: gu-colour(comment-main-1);
+        background-color: gu-colour(neutral-1);
         color: #fff;
       }
 
@@ -545,7 +548,7 @@
   }
 
   .component-number-input--selected {
-      background-color: gu-colour(comment-main-1);
+      background-color: gu-colour(neutral-1);
       color: #fff;
 
       &::placeholder {

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -170,6 +170,14 @@
 
     .bundles__bundle--digital {
         background-color: #1db7d7;
+
+        .component-cta-link {
+          background-color: gu-colour(guardian-brand-dark);
+
+          &:hover {
+            background-color: darken(gu-colour(guardian-brand-dark), 5%);
+          }
+        }
     }
 
     .bundles__bundle--paper {
@@ -179,6 +187,23 @@
   			background-color: gu-colour(guardian-brand-dark);
   			color: #fff;
   		}
+
+      .component-cta-link:first-of-type {
+        background-color: gu-colour(guardian-brand-dark);
+
+        &:hover {
+          background-color: darken(gu-colour(guardian-brand-dark), 5%);
+        }
+      }
+
+      .component-cta-link+.component-cta-link {
+        background-color: #58a1ce;
+        border: 1px solid gu-colour(guardian-brand-dark);
+
+        &:hover {
+          background-color: gu-colour(guardian-brand-dark);
+        }
+      }
     }
 
   }

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -143,8 +143,18 @@
 
     .bundles__bundle {
       width: 300px;
+      height: 400px;
       padding: 8px 10px 12px;
       display: inline-block;
+      vertical-align: top;
+      position: relative;
+    }
+
+    .component-cta-link {
+      position: absolute;
+      bottom: $gu-v-spacing;
+      right: $gu-h-spacing / 2;
+      left: $gu-h-spacing / 2;
     }
 
     .bundles__bundle--contributions {
@@ -152,6 +162,45 @@
       font-size: 14px;
       font-weight: bold;
       font-family: $gu-text-sans-web;
+
+      .component-radio-toggle {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        justify-content: space-between;
+      }
+
+      .component-radio-toggle__button {
+        flex-basis: calc(50% - 2.5px);
+        // Fix for Safari 8.
+        // min-width: 48%;
+
+        // Fix for IE10.
+        // @include mq($from: desktop) {
+        //   flex-basis: ((gs-span(4) - $gs-gutter) / 2) - 2.5px;
+        //   max-width: ((gs-span(4) - $gs-gutter) / 2) - 2.5px;
+        // }
+      }
+
+      .component-radio-toggle__label {
+        display: block;
+        height: $gu-v-spacing * 2;
+        text-align: center;
+      }
+
+      .contrib-amounts {
+        .component-radio-toggle__button {
+          flex-basis: calc(33.3% - 3.3px);
+          // Fix for Safari 8.
+          // min-width: 32%;
+
+          // Fix for IE10.
+          // @include mq($from: desktop) {
+          //   flex-basis: ((gs-span(4) - $gs-gutter) / 3) - 3.3px;
+          //   max-width: ((gs-span(4) - $gs-gutter) / 3) - 3.3px;
+          // }
+        }
+      }
 
       .component-double-heading__heading {
         color: gu-colour(neutral-1);
@@ -199,6 +248,7 @@
       .component-cta-link+.component-cta-link {
         background-color: #58a1ce;
         border: 1px solid gu-colour(guardian-brand-dark);
+        bottom: $gu-v-spacing * 5;
 
         &:hover {
           background-color: gu-colour(guardian-brand-dark);

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -287,6 +287,24 @@
       }
     }
 
+    .component-feature-list {
+      padding-left: 0;
+
+      li > * {
+        display: inline-block;
+      }
+
+      li:before {
+        content: '✔';
+        display: inline-block;
+        font-size: 20px;
+        margin-left: -19px;
+        line-height: 0;
+        width: 19px;
+        color: #fff;
+      }
+    }
+
   }
 
 

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -134,15 +134,17 @@
 
   .bundles {
 
+    background-color: darken(gu-colour(comment-support-2), 5%);
+
+    .bundles__content {
+      background-color: gu-colour(comment-support-2);
+      padding-bottom: $gu-v-spacing * 2;
+    }
+
     .bundles__bundle {
       width: 300px;
       padding: 8px 10px 12px;
-      float: left;
-    }
-
-    .bundle__info-text {
-      @include gu-font(copy, 16);
-      color: gu-colour(neutral-1);
+      display: inline-block;
     }
 
     .bundles__bundle--contributions {

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -188,6 +188,23 @@
         text-align: center;
       }
 
+      .contrib-amounts {
+        display: flex;
+        flex-wrap: wrap;
+
+        .contrib-amounts__error-message {
+          font-family: $gu-text-sans-web;
+          font-size: 13px;
+          font-weight: bold;
+          line-height: 15px;
+          color: gu-colour(live-support-2);
+        }
+
+        > * {
+          flex-basis: 100%;
+        }
+      }
+
       .contrib-amounts--recurring {
         .component-radio-toggle__button {
           flex-basis: calc(33.3% - 3.3px);

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -138,29 +138,81 @@
 
     .bundles__content {
       background-color: gu-colour(comment-support-2);
-      padding: 0 0 ($gu-v-spacing * 2);
+      padding: 0 0;
+
+      @include mq($until: desktop) {
+        padding-bottom: $gu-v-spacing;
+      }
+
+      @include mq($from: desktop) {
+        padding-bottom: ($gu-v-spacing * 2);
+      }
     }
 
     .bundles__wrapper {
-      width: 960px;
-      margin: 0 auto;
+      @include mq($from: mobileLandscape) {
+        width: 500px;
+        margin: 0 auto;
+      }
+
+      @include mq($from: phablet, $until: desktop) {
+        width: 100%;
+      }
+
+      @include mq($from: desktop) {
+        width: 960px;
+        margin: 0 auto;
+      }
+    }
+
+    .bundles__divider {
+      height: $gu-v-spacing;
+      width: 100%;
+
+      @include mq($from: desktop) {
+        display: none;
+      }
     }
 
     .bundles__bundle {
-      width: 280px;
-      height: 400px;
-      padding: 8px 10px 12px;
-      display: inline-block;
-      vertical-align: top;
-      position: relative;
+      padding: 8px ($gu-h-spacing / 2) $gu-v-spacing;
       margin: 0 ($gu-h-spacing / 2);
+
+      @include mq($from: mobileLandscape, $until: desktop) {
+        padding-left: $gu-h-spacing;
+        padding-right: $gu-h-spacing;
+      }
+
+      @include mq($from: desktop) {
+        width: 280px;
+        height: 400px;
+        display: inline-block;
+        vertical-align: top;
+        position: relative;
+      }
     }
 
     .component-cta-link {
-      position: absolute;
-      bottom: $gu-v-spacing;
-      right: $gu-h-spacing / 2;
-      left: $gu-h-spacing / 2;
+      @include mq($from: desktop) {
+        position: absolute;
+        bottom: $gu-v-spacing;
+        right: $gu-h-spacing / 2;
+        left: $gu-h-spacing / 2;        
+      }
+    }
+
+    @include mq($from: phablet, $until: desktop) {
+      .component-double-heading {
+        width: 50%;
+        display: inline-block;
+        vertical-align: top;
+      }
+
+      .bundle__content {
+        width: 50%;
+        display: inline-block;
+        vertical-align: top;
+      }
     }
 
     .bundles__bundle--contributions {
@@ -279,7 +331,10 @@
       .component-cta-link+.component-cta-link {
         background-color: #58a1ce;
         border: 1px solid gu-colour(guardian-brand-dark);
-        bottom: $gu-v-spacing * 5;
+
+        @include mq($from: desktop) {
+          bottom: $gu-v-spacing * 5;
+        }
 
         &:hover {
           background-color: gu-colour(guardian-brand-dark);
@@ -292,6 +347,7 @@
 
       li > * {
         display: inline-block;
+        margin-left: 10px;
       }
 
       li:before {

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -241,45 +241,6 @@
         text-align: center;
       }
 
-      .contrib-amounts {
-        display: flex;
-        flex-wrap: wrap;
-
-        .contrib-amounts__error-message {
-          font-family: $gu-text-sans-web;
-          font-size: 13px;
-          font-weight: bold;
-          line-height: 15px;
-          color: gu-colour(live-support-2);
-        }
-
-        > * {
-          flex-basis: 100%;
-        }
-
-        @include mq($from: desktop) {
-          .component-number-input {
-            max-width: 93%;
-          }
-        }
-      }
-
-      .contrib-amounts--recurring {
-        .component-radio-toggle__button {
-          flex-basis: calc(33.3% - 3.3px);
-          // Fix for IE10 and possibly Safari 8.
-          min-width: 32%;
-        }
-      }
-
-      .contrib-amounts--one-off {
-        .component-radio-toggle__button {
-          flex-basis: calc(25% - 4px);
-          // Fix for IE10 and possibly Safari 8.
-          min-width: 23%;
-        }
-      }
-
       .component-double-heading__heading {
         color: gu-colour(neutral-1);
       }
@@ -292,6 +253,45 @@
       .contrib-amounts__error-message {
         @include gu-font(copy, 16);
         color: gu-colour(neutral-1);
+      }
+    }
+
+    .contrib-amounts {
+      display: flex;
+      flex-wrap: wrap;
+
+      .contrib-amounts__error-message {
+        font-family: $gu-text-sans-web;
+        font-size: 13px;
+        font-weight: bold;
+        line-height: 15px;
+        color: gu-colour(live-support-2);
+      }
+
+      > * {
+        flex-basis: 100%;
+      }
+
+      @include mq($from: desktop) {
+        .component-number-input {
+          max-width: 93%;
+        }
+      }
+    }
+
+    .contrib-amounts--recurring {
+      .component-radio-toggle__button {
+        flex-basis: calc(33.3% - 3.3px);
+        // Fix for IE10 and possibly Safari 8.
+        min-width: 32%;
+      }
+    }
+
+    .contrib-amounts--one-off {
+      .component-radio-toggle__button {
+        flex-basis: calc(25% - 4px);
+        // Fix for IE10 and possibly Safari 8.
+        min-width: 23%;
       }
     }
 

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -153,6 +153,10 @@
       font-weight: bold;
       font-family: $gu-text-sans-web;
 
+      .component-double-heading__heading {
+        color: gu-colour(neutral-1);
+      }
+
       input:checked+label {
         background-color: gu-colour(neutral-1);
         color: #fff;

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -197,7 +197,7 @@
         position: absolute;
         bottom: $gu-v-spacing;
         right: $gu-h-spacing / 2;
-        left: $gu-h-spacing / 2;        
+        left: $gu-h-spacing / 2;
       }
     }
 
@@ -230,14 +230,9 @@
 
       .component-radio-toggle__button {
         flex-basis: calc(50% - 2.5px);
-        // Fix for Safari 8.
-        // min-width: 48%;
-
-        // Fix for IE10.
-        // @include mq($from: desktop) {
-        //   flex-basis: ((gs-span(4) - $gs-gutter) / 2) - 2.5px;
-        //   max-width: ((gs-span(4) - $gs-gutter) / 2) - 2.5px;
-        // }
+        // Fix for IE10 and possibly Safari 8.
+        display: block;
+        min-width: 49%;
       }
 
       .component-radio-toggle__label {
@@ -261,27 +256,27 @@
         > * {
           flex-basis: 100%;
         }
+
+        @include mq($from: desktop) {
+          .component-number-input {
+            max-width: 93%;
+          }
+        }
       }
 
       .contrib-amounts--recurring {
         .component-radio-toggle__button {
           flex-basis: calc(33.3% - 3.3px);
-          // Fix for Safari 8.
-          // min-width: 32%;
-
-          // Fix for IE10.
-          // @include mq($from: desktop) {
-          //   flex-basis: ((gs-span(4) - $gs-gutter) / 3) - 3.3px;
-          //   max-width: ((gs-span(4) - $gs-gutter) / 3) - 3.3px;
-          // }
+          // Fix for IE10 and possibly Safari 8.
+          min-width: 32%;
         }
       }
 
       .contrib-amounts--one-off {
         .component-radio-toggle__button {
           flex-basis: calc(25% - 4px);
-          // Fix for Safari 8.
-          // min-width: 24%;
+          // Fix for IE10 and possibly Safari 8.
+          min-width: 23%;
         }
       }
 
@@ -347,15 +342,15 @@
 
       li > * {
         display: inline-block;
+        vertical-align: middle;
         margin-left: 10px;
       }
 
       li:before {
         content: '✔';
         display: inline-block;
-        font-size: 20px;
+        font-size: 18px;
         margin-left: -19px;
-        line-height: 0;
         width: 19px;
         color: #fff;
       }

--- a/assets/pages/bundles-landing/components/Bundle.jsx
+++ b/assets/pages/bundles-landing/components/Bundle.jsx
@@ -6,7 +6,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import DoubleHeading from 'components/doubleHeading/doubleHeading';
-import CtaLink from 'components/ctaLink/ctaLink';
 
 import type { Children } from 'react';
 
@@ -16,8 +15,6 @@ import type { Children } from 'react';
 type PropTypes = {
   heading: string,
   subheading: string,
-  ctaText: string,
-  ctaLink: string,
   modifierClass: string,
   children?: Children,
 };
@@ -40,7 +37,6 @@ function Bundle(props: PropTypes) {
         subheading={props.subheading}
       />
       {props.children}
-      <CtaLink text={props.ctaText} url={props.ctaLink} />
     </div>
   );
 

--- a/assets/pages/bundles-landing/components/Bundle.jsx
+++ b/assets/pages/bundles-landing/components/Bundle.jsx
@@ -36,7 +36,9 @@ function Bundle(props: PropTypes) {
         heading={props.heading}
         subheading={props.subheading}
       />
-      {props.children}
+      <div className="bundle__content">
+        {props.children}
+      </div>
     </div>
   );
 

--- a/assets/pages/bundles-landing/components/Bundle.jsx
+++ b/assets/pages/bundles-landing/components/Bundle.jsx
@@ -16,7 +16,6 @@ import type { Children } from 'react';
 type PropTypes = {
   heading: string,
   subheading: string,
-  infoText: string,
   ctaText: string,
   ctaLink: string,
   modifierClass: string,
@@ -29,7 +28,6 @@ type PropTypes = {
 function Bundle(props: PropTypes) {
 
   let className = 'bundles__bundle';
-  const infoTextElement = <p className="bundle__info-text">{props.infoText}</p>;
 
   if (props.modifierClass) {
     className = `${className} ${className}--${props.modifierClass}`;
@@ -42,7 +40,6 @@ function Bundle(props: PropTypes) {
         subheading={props.subheading}
       />
       {props.children}
-      {props.infoText ? infoTextElement : ''}
       <CtaLink text={props.ctaText} url={props.ctaLink} />
     </div>
   );

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -148,24 +148,26 @@ function Bundles(props: PropTypes) {
   return (
     <section className="bundles">
       <div className="bundles__content gu-content-margin">
-        <Bundle {...contribAttrs}>
-          <RadioToggle
-            {...contribToggle}
-            toggleAction={props.toggleContribType}
-            checked={props.contribType}
-          />
-          <ContribAmounts />
-          <CtaLink text={contribAttrs.ctaText} url={contribAttrs.ctaLink} />
-        </Bundle>
-        <Bundle {...digitalAttrs}>
-          <FeatureList listItems={bundles.digital.listItems} />
-          <CtaLink text={digitalAttrs.ctaText} url={digitalAttrs.ctaLink} />
-        </Bundle>
-        <Bundle {...paperAttrs}>
-          <FeatureList listItems={paperAttrs.listItems} />
-          <CtaLink text={paperAttrs.paperCtaText} url={paperAttrs.paperCtaLink} />
-          <CtaLink text={paperAttrs.paperDigCtaText} url={paperAttrs.paperDigCtaLink} />
-        </Bundle>
+        <div className="bundles__wrapper">
+          <Bundle {...contribAttrs}>
+            <RadioToggle
+              {...contribToggle}
+              toggleAction={props.toggleContribType}
+              checked={props.contribType}
+            />
+            <ContribAmounts />
+            <CtaLink text={contribAttrs.ctaText} url={contribAttrs.ctaLink} />
+          </Bundle>
+          <Bundle {...digitalAttrs}>
+            <FeatureList listItems={bundles.digital.listItems} />
+            <CtaLink text={digitalAttrs.ctaText} url={digitalAttrs.ctaLink} />
+          </Bundle>
+          <Bundle {...paperAttrs}>
+            <FeatureList listItems={paperAttrs.listItems} />
+            <CtaLink text={paperAttrs.paperCtaText} url={paperAttrs.paperCtaLink} />
+            <CtaLink text={paperAttrs.paperDigCtaText} url={paperAttrs.paperDigCtaLink} />
+          </Bundle>
+        </div>
       </div>
     </section>
   );

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -70,6 +70,7 @@ const bundles = {
       },
       {
         heading: 'All the benefits of a digital subscription',
+        text: 'Avaliable with paper+digital',
       },
     ],
   },

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -29,66 +29,59 @@ const ctaLinks = {
 
 const bundles = {
   allContrib: {
-    heading: 'From £5/month',
-    subheading: 'Make a contribution',
-    infoText: 'Support the Guardian. Every penny of your contribution goes to support our fearless, quality journalism.',
+    heading: 'contribute',
+    subheading: 'from £5/month',
     ctaText: 'Contribute with credit/debit card',
     modifierClass: 'contributions',
   },
   digital: {
-    heading: '£11.99/month',
-    subheading: 'Become a digital subscriber',
+    heading: 'digital subscription',
+    subheading: '£11.99/month',
     listItems: [
       {
         heading: 'Ad-free mobile app',
-        text: 'Faster pages and a clearer reading experience',
+        text: 'No interruptions means pages load quicker for a clearer reading experience',
       },
       {
         heading: 'Daily tablet edition',
         text: 'Daily newspaper optimised for tablet; available on Apple, Android and Kindle Fire',
       },
       {
-        heading: 'Free trial',
-        text: 'For 14 days, enjoy on up to 10 devices',
+        heading: 'Enjoy on up to 10 devices',
       },
     ],
-    infoText: 'Support the Guardian and enjoy a subscription to our digital Daily Edition and the premium tier of our app.',
     ctaText: 'Become a digital subscriber',
     modifierClass: 'digital',
   },
   allPaper: {
-    subheading: 'Become a paper subscriber',
-    infoText: 'Support the Guardian and enjoy a subscription to the Guardian and the Observer newspapers.',
+    heading: 'print subscription',
     ctaText: 'Become a paper subscriber',
     modifierClass: 'paper',
   },
   paperDigital: {
-    heading: 'From £22.06/month',
+    subheading: 'from £22.06/month',
     listItems: [
       {
         heading: 'Newspaper',
         text: 'Choose the package you want: Everyday+, Sixday+, Weekend+ and Sunday+',
       },
       {
-        heading: 'Digital',
-        text: 'All the benefits of the digital subscription',
+        heading: 'Save money off the retail price',
       },
       {
-        heading: 'Save money',
-        text: 'Up to 36% off the retail price',
+        heading: 'All the benefits of a digital subscription',
       },
     ],
   },
   paperOnly: {
-    heading: 'From £10.79/month',
+    subheading: 'from £10.79/month',
     listItems: [
       {
         heading: 'Newspaper',
-        text: 'Choose the package you want: Everyday+, Sixday+, Weekend+ and Sunday+',
+        text: 'Choose the package you want: Everyday, Sixday, Weekend or Sunday',
       },
       {
-        heading: 'Save money',
-        text: 'Up to 36% off the retail price',
+        heading: 'Save money off the retail price',
       },
     ],
   },
@@ -190,26 +183,28 @@ function Bundles(props: PropTypes) {
   const digitalAttrs = getDigitalAttrs(props);
 
   return (
-    <section className="bundles gu-content-margin">
-      <Bundle {...contribAttrs}>
-        <RadioToggle
-          {...toggles.contribType}
-          toggleAction={props.toggleContribType}
-          checked={props.contribType}
-        />
-        <ContribAmounts />
-      </Bundle>
-      <Bundle {...digitalAttrs}>
-        <FeatureList listItems={bundles.digital.listItems} />
-      </Bundle>
-      <Bundle {...paperAttrs}>
-        <RadioToggle
-          {...toggles.paper}
-          toggleAction={props.togglePaperBundle}
-          checked={props.paperBundle}
-        />
-        <FeatureList listItems={paperAttrs.listItems} />
-      </Bundle>
+    <section className="bundles">
+      <div className="bundles__content gu-content-margin">
+        <Bundle {...contribAttrs}>
+          <RadioToggle
+            {...toggles.contribType}
+            toggleAction={props.toggleContribType}
+            checked={props.contribType}
+          />
+          <ContribAmounts />
+        </Bundle>
+        <Bundle {...digitalAttrs}>
+          <FeatureList listItems={bundles.digital.listItems} />
+        </Bundle>
+        <Bundle {...paperAttrs}>
+          <RadioToggle
+            {...toggles.paper}
+            toggleAction={props.togglePaperBundle}
+            checked={props.paperBundle}
+          />
+          <FeatureList listItems={paperAttrs.listItems} />
+        </Bundle>
+      </div>
     </section>
   );
 

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -48,7 +48,7 @@ const bundles = {
         heading: 'Enjoy on up to 10 devices',
       },
     ],
-    ctaText: 'Become a digital subscriber',
+    ctaText: 'Start your 14 day trial',
     modifierClass: 'digital',
   },
   paper: {

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -158,10 +158,12 @@ function Bundles(props: PropTypes) {
             <ContribAmounts />
             <CtaLink text={contribAttrs.ctaText} url={contribAttrs.ctaLink} />
           </Bundle>
+          <div className="bundles__divider" />
           <Bundle {...digitalAttrs}>
             <FeatureList listItems={bundles.digital.listItems} />
             <CtaLink text={digitalAttrs.ctaText} url={digitalAttrs.ctaLink} />
           </Bundle>
+          <div className="bundles__divider" />
           <Bundle {...paperAttrs}>
             <FeatureList listItems={paperAttrs.listItems} />
             <CtaLink text={paperAttrs.paperCtaText} url={paperAttrs.paperCtaLink} />

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -7,14 +7,12 @@ import { connect } from 'react-redux';
 
 import FeatureList from 'components/featureList/featureList';
 import RadioToggle from 'components/radioToggle/radioToggle';
+import CtaLink from 'components/ctaLink/ctaLink';
 import Bundle from './Bundle';
 import ContribAmounts from './ContribAmounts';
-import {
-  changePaperBundle,
-  changeContribType,
-} from '../actions/bundlesLandingActions';
+import { changeContribType } from '../actions/bundlesLandingActions';
 
-import type { Contrib, Amounts, PaperBundle } from '../reducers/reducers';
+import type { Contrib, Amounts } from '../reducers/reducers';
 
 
 // ----- Copy ----- //
@@ -28,7 +26,7 @@ const ctaLinks = {
 };
 
 const bundles = {
-  allContrib: {
+  contrib: {
     heading: 'contribute',
     subheading: 'from £5/month',
     ctaText: 'Contribute with credit/debit card',
@@ -53,17 +51,13 @@ const bundles = {
     ctaText: 'Become a digital subscriber',
     modifierClass: 'digital',
   },
-  allPaper: {
+  paper: {
     heading: 'print subscription',
-    ctaText: 'Become a paper subscriber',
-    modifierClass: 'paper',
-  },
-  paperDigital: {
     subheading: 'from £22.06/month',
     listItems: [
       {
         heading: 'Newspaper',
-        text: 'Choose the package you want: Everyday+, Sixday+, Weekend+ and Sunday+',
+        text: 'Choose the package you want: Everyday, Sixday, Weekend and Sunday',
       },
       {
         heading: 'Save money off the retail price',
@@ -73,59 +67,33 @@ const bundles = {
         text: 'Avaliable with paper+digital',
       },
     ],
-  },
-  paperOnly: {
-    subheading: 'from £10.79/month',
-    listItems: [
-      {
-        heading: 'Newspaper',
-        text: 'Choose the package you want: Everyday, Sixday, Weekend or Sunday',
-      },
-      {
-        heading: 'Save money off the retail price',
-      },
-    ],
+    paperCtaText: 'Become a paper subscriber',
+    paperDigCtaText: 'Become a paper+digital subscriber',
+    modifierClass: 'paper',
   },
 };
 
-const toggles = {
-  paper: {
-    name: 'paper-toggle',
-    radios: [
-      {
-        value: 'PAPER+DIGITAL',
-        text: 'Paper + digital',
-      },
-      {
-        value: 'PAPER',
-        text: 'Paper',
-      },
-    ],
-  },
-  contribType: {
-    name: 'contributions-period-toggle',
-    radios: [
-      {
-        value: 'RECURRING',
-        text: 'Monthly',
-      },
-      {
-        value: 'ONE_OFF',
-        text: 'One-off',
-      },
-    ],
-  },
+const contribToggle = {
+  name: 'contributions-period-toggle',
+  radios: [
+    {
+      value: 'RECURRING',
+      text: 'Monthly',
+    },
+    {
+      value: 'ONE_OFF',
+      text: 'One-off',
+    },
+  ],
 };
 
 
 // ----- Types ----- //
 
 type PropTypes = {
-  paperBundle: PaperBundle,
   contribType: Contrib,
   contribAmount: Amounts, // eslint-disable-line react/no-unused-prop-types
   intCmp: string, // eslint-disable-line react/no-unused-prop-types
-  togglePaperBundle: (string) => void,
   toggleContribType: (string) => void,
 };
 
@@ -142,27 +110,20 @@ function getContribAttrs({ contribType, contribAmount, intCmp }) {
   params.append('INTCMP', intCmp);
   const ctaLink = `${ctaLinks[contType]}?${params.toString()}`;
 
-  return Object.assign({}, bundles.allContrib, { ctaLink });
+  return Object.assign({}, bundles.contrib, { ctaLink });
 
 }
 
-function getPaperAttrs({ paperBundle, intCmp }) {
+function getPaperAttrs({ intCmp }) {
 
-  let ctaLink = null;
-  let selectedBundle = null;
   const params = new URLSearchParams();
 
   params.append('INTCMP', intCmp);
+  const paperCtaLink = `${ctaLinks.paperOnly}?${params.toString()}`;
+  const paperDigCtaLink = `${ctaLinks.paperDigital}?${params.toString()}`;
 
-  if (paperBundle === 'PAPER+DIGITAL') {
-    ctaLink = `${ctaLinks.paperDigital}?${params.toString()}`;
-    selectedBundle = bundles.paperDigital;
-  } else {
-    ctaLink = `${ctaLinks.paperOnly}?${params.toString()}`;
-    selectedBundle = bundles.paperOnly;
-  }
+  return Object.assign({}, bundles.paper, { paperCtaLink, paperDigCtaLink });
 
-  return Object.assign({}, bundles.allPaper, selectedBundle, { ctaLink });
 }
 
 function getDigitalAttrs({ intCmp }) {
@@ -172,6 +133,7 @@ function getDigitalAttrs({ intCmp }) {
   const ctaLink = `${ctaLinks.digital}?${params.toString()}`;
 
   return Object.assign({}, bundles.digital, { ctaLink });
+
 }
 
 
@@ -188,22 +150,21 @@ function Bundles(props: PropTypes) {
       <div className="bundles__content gu-content-margin">
         <Bundle {...contribAttrs}>
           <RadioToggle
-            {...toggles.contribType}
+            {...contribToggle}
             toggleAction={props.toggleContribType}
             checked={props.contribType}
           />
           <ContribAmounts />
+          <CtaLink text={contribAttrs.ctaText} url={contribAttrs.ctaLink} />
         </Bundle>
         <Bundle {...digitalAttrs}>
           <FeatureList listItems={bundles.digital.listItems} />
+          <CtaLink text={digitalAttrs.ctaText} url={digitalAttrs.ctaLink} />
         </Bundle>
         <Bundle {...paperAttrs}>
-          <RadioToggle
-            {...toggles.paper}
-            toggleAction={props.togglePaperBundle}
-            checked={props.paperBundle}
-          />
           <FeatureList listItems={paperAttrs.listItems} />
+          <CtaLink text={paperAttrs.paperCtaText} url={paperAttrs.paperCtaLink} />
+          <CtaLink text={paperAttrs.paperDigCtaText} url={paperAttrs.paperDigCtaLink} />
         </Bundle>
       </div>
     </section>
@@ -216,7 +177,6 @@ function Bundles(props: PropTypes) {
 
 function mapStateToProps(state) {
   return {
-    paperBundle: state.paperBundle,
     contribType: state.contribution.type,
     contribAmount: state.contribution.amount,
     intCmp: state.intCmp,
@@ -226,9 +186,6 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
 
   return {
-    togglePaperBundle: (bundle: PaperBundle) => {
-      dispatch(changePaperBundle(bundle));
-    },
     toggleContribType: (period: Contrib) => {
       dispatch(changeContribType(period));
     },

--- a/assets/pages/bundles-landing/components/ContribAmounts.jsx
+++ b/assets/pages/bundles-landing/components/ContribAmounts.jsx
@@ -140,7 +140,7 @@ function ContribAmounts(props: PropTypes) {
         onFocus={props.userDefinedAmount}
         onInput={props.userDefinedAmount}
         selected={attrs.selected}
-        placeholder="Other Amount (£)"
+        placeholder="Other amount (£)"
       />
       {errorMessage(props.contribError)}
     </div>

--- a/assets/pages/bundles-landing/components/ContribAmounts.jsx
+++ b/assets/pages/bundles-landing/components/ContribAmounts.jsx
@@ -107,6 +107,7 @@ function getAttrs(props: PropTypes) {
       checked: !userDefined ? props.contrib.recurring.value : null,
       toggles: amountToggles.recurring,
       selected: props.contrib.recurring.userDefined,
+      contribType: 'recurring',
     };
 
   }
@@ -118,6 +119,7 @@ function getAttrs(props: PropTypes) {
     checked: !userDefined ? props.contrib.oneOff.value : null,
     toggles: amountToggles.oneOff,
     selected: props.contrib.oneOff.userDefined,
+    contribType: 'one-off',
   };
 
 }
@@ -128,9 +130,10 @@ function getAttrs(props: PropTypes) {
 function ContribAmounts(props: PropTypes) {
 
   const attrs = getAttrs(props);
+  const className = `contrib-amounts contrib-amounts--${attrs.contribType}`;
 
   return (
-    <div className="contrib-amounts">
+    <div className={className}>
       <RadioToggle
         {...attrs.toggles}
         toggleAction={attrs.toggleAction}

--- a/assets/pages/bundles-landing/components/Introduction.jsx
+++ b/assets/pages/bundles-landing/components/Introduction.jsx
@@ -13,23 +13,8 @@ export default function Introduction() {
     <section className="introduction">
       <div className="introduction__content gu-content-margin">
         <h1 className="introduction__heading-one">support the guardian</h1>
-        <p>
-          Our quality journalism takes time and money to produce.
-          But ad revenues are falling, so we need your help to
-        </p>
-        <h1 className="introduction__heading-two">secure our future</h1>
-        <p>
-          <span className="introduction__wrap-line">
-            Subscribe or make a regular or one-off contribution&nbsp;
-          </span>
-          today and together we can
-        </p>
-        <h1 className="introduction__heading-three">hold power to account</h1>
-        <p>
-          <span className="introduction__wrap-line">
-            As an independent voice, our most important&nbsp;
-          </span>relationship is with our readers
-        </p>
+        <p>Be part of our future by helping to secure it.</p>
+        <p>Hold power to account by funding quality, independent journalism.</p>
       </div>
     </section>
   );

--- a/assets/pages/bundles-landing/reducers/__tests__/__snapshots__/reducersTest.js.snap
+++ b/assets/pages/bundles-landing/reducers/__tests__/__snapshots__/reducersTest.js.snap
@@ -17,6 +17,5 @@ Object {
     "type": "RECURRING",
   },
   "intCmp": "",
-  "paperBundle": "PAPER+DIGITAL",
 }
 `;

--- a/assets/pages/bundles-landing/reducers/__tests__/reducersTest.js
+++ b/assets/pages/bundles-landing/reducers/__tests__/reducersTest.js
@@ -1,6 +1,6 @@
 // @flow
 import reducer from '../reducers';
-import type { Contrib, PaperBundle, ContribState, Amount } from '../reducers';
+import type { Contrib, ContribState, Amount } from '../reducers';
 
 describe('reducer tests', () => {
 
@@ -18,23 +18,11 @@ describe('reducer tests', () => {
       },
     },
   };
-  const initialPaperBundle: PaperBundle = 'PAPER+DIGITAL';
-  const initialState = { paperBundle: initialPaperBundle, contribution: initialContrib };
+  const initialState = { contribution: initialContrib };
 
   it('should return the initial state', () => {
 
     expect(reducer(undefined, {})).toMatchSnapshot();
-  });
-
-  it('should handle CHANGE_PAPER_BUNDLE', () => {
-
-    const paperBundle: PaperBundle = 'PAPER';
-    const action = {
-      type: 'CHANGE_PAPER_BUNDLE',
-      bundle: paperBundle,
-    };
-
-    expect(reducer(initialState, action).paperBundle).toEqual(paperBundle);
   });
 
   it('should handle CHANGE_CONTRIB_TYPE', () => {

--- a/assets/pages/bundles-landing/reducers/reducers.js
+++ b/assets/pages/bundles-landing/reducers/reducers.js
@@ -29,8 +29,6 @@ export type Amounts = {
   oneOff: Amount,
 };
 
-export type PaperBundle = 'PAPER+DIGITAL' | 'PAPER';
-
 export type ContribState = {
   type: Contrib,
   error: ?ContribError,
@@ -56,19 +54,6 @@ const initialContrib: ContribState = {
 };
 
 // ----- Reducers ----- //
-
-function paperBundle(
-  state: PaperBundle = 'PAPER+DIGITAL',
-  action: Action): PaperBundle {
-
-  switch (action.type) {
-    case 'CHANGE_PAPER_BUNDLE':
-      return action.bundle;
-    default:
-      return state;
-  }
-
-}
 
 function contribution(
   state: ContribState = initialContrib,
@@ -129,7 +114,6 @@ function intCmp(state: string = ''): string {
 // ----- Exports ----- //
 
 export default combineReducers({
-  paperBundle,
   contribution,
   intCmp,
 });

--- a/assets/pages/bundles-landing/reducers/reducers.js
+++ b/assets/pages/bundles-landing/reducers/reducers.js
@@ -53,6 +53,7 @@ const initialContrib: ContribState = {
   },
 };
 
+
 // ----- Reducers ----- //
 
 function contribution(


### PR DESCRIPTION
## Why are you doing this?

a) The bundles on the landing page need some styling applied to them.
b) There are some updated designs for the bundles, which are applied here.

This is mostly heavy on the CSS, to apply styling to the bundles across the breakpoints, and there a couple of React/JSX tweaks to go with this. The layouts at narrower breakpoints don't quite match what this page looks like in membership-frontend, because some of our breakpoints and margins don't quite match up.

There are still a couple of bugs in IE10 and Safari 8 (sigh), which can be fixed in a later PR when we're sure that we won't be making more design changes before going live.

[**Trello Card**](https://trello.com/c/52DEBiP3/573-style-the-bundles-section-of-the-landing-page), and [another](https://trello.com/c/zpuu7hjY/550-change-the-become-a-digital-subscriber-to-start-your-14-day-trial), and [one more](https://trello.com/c/6W4rSo7L/551-swap-the-headers-round-on-the-benefits).

FYI: @superfrank

## Changes

### Design Changes

- Swapped the bundle headers around and changed the copy.
- Changed the colour scheme of the contributions toggles to match the CTA.
- Dropped the paper bundle toggle in favour of dual-CTAs.
- Updated the features copy for the digital and paper bundles.
- Simplified the copy in the introduction to bring in line with changes made in [membership-frontend](https://github.com/guardian/membership-frontend/pull/1632).

### General Styling

- Added a right arrow to the bundles CTAs.
- Applied fonts to the bundles.
- Made layouts for the different breakpoints.

## Screenshots

I'll fill this out with screenshots across the breakpoints, but the easiest way to see it is probably just to pull it down and look at it.