### PR TITLE
Px to Rem fixed

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -89,7 +89,7 @@ module.exports = (env) => {
               {
                 loader: 'postcss-loader',
                 options: {
-                  plugins: [pxtorem(), autoprefixer()],
+                  plugins: [pxtorem({ propList: ['*'] }), autoprefixer()],
                 },
               },
               {


### PR DESCRIPTION
## Why are you doing this?

If the default font is not 16 px we want to be able to render everything correctly. Therefore, we change all the `px` values to `rem` values in compiling time.

## Changes

* webpack conf.

## Screenshots

### Landing page with default font-size: `34px`
![screencapture-localhost-9111-uk-1495553355985](https://cloud.githubusercontent.com/assets/825398/26362149/0b665914-3fd5-11e7-9c5a-57f8b018cd97.png)