### PR TITLE
No js message

### DIFF
--- a/app/views/react.scala.html
+++ b/app/views/react.scala.html
@@ -6,5 +6,16 @@
 }
 
 @main(title = title, scripts = scripts) {
-    <main id="@id"></main>
+    <main id="@id">
+        <noscript>
+            <div style="text-align: center;
+                        font-size: 30px;
+                        padding-left: 20px;
+                        padding-right: 20px;
+                        background-color: #e9e939;">
+                Please enable JavaScript – we use it to enhance behaviour for Guardian Supporters.
+                <a href="http://www.enable-javascript.com/">Click here for instructions to do so in your browser</a>
+            </div>
+        </noscript>
+    </main>
 }


### PR DESCRIPTION
## Why are you doing this?

Currently, the users that don't js in their browser see an white page. In this PR we add a default message asking them to turn on javascript. 
The style of this message is in line because we don't want to mix it with the style that is generated via sass.

[**Trello Card**](https://trello.com/c/UQTJvBGz/509-add-a-no-javascript-message)

## Changes

* Add a no js message in the react template.

## Screenshots

### Without JS
<img width="1261" alt="picture 262" src="https://cloud.githubusercontent.com/assets/825398/26364464/51cc2d78-3fdc-11e7-946f-b59f3ef1bbfa.png">


