### PR TITLE
Bundles Landing Page - Fixes For Old Browsers

### DIFF
--- a/assets/components/headers/simpleHeader/simpleHeader.jsx
+++ b/assets/components/headers/simpleHeader/simpleHeader.jsx
@@ -14,7 +14,9 @@ export default function SimpleHeader() {
   return (
     <header className="component-simple-header">
       <div className="component-simple-header__content gu-header-margin">
-        <Svg svgName="guardian-titlepiece" />
+        <a href="https://www.theguardian.com">
+          <Svg svgName="guardian-titlepiece" />
+        </a>
       </div>
     </header>
   );

--- a/assets/components/svg/svg.jsx
+++ b/assets/components/svg/svg.jsx
@@ -93,6 +93,7 @@ const Svg = (props: PropTypes) => {
       className={svgClass}
       xmlns="http://www.w3.org/2000/svg"
       viewBox={svgsCatalog[props.svgName].viewBox}
+      preserveAspectRatio="xMinYMid"
     >
       {paths}
     </svg>

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -258,10 +258,6 @@
     }
 
     .contrib-amounts {
-      // display: flex;
-      // flex-wrap: wrap;
-      // width: 100%;
-
       .contrib-amounts__error-message {
         font-family: $gu-text-sans-web;
         font-size: 13px;
@@ -269,10 +265,6 @@
         line-height: 15px;
         color: gu-colour(live-support-2);
       }
-
-      // > * {
-      //   flex-basis: 100%;
-      // }
 
       @include mq($from: desktop) {
         .component-number-input {

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -17,7 +17,7 @@
         padding-left: 100px;
       }
 
-      @include mq($from: leftCol) {
+      @include mq($from: wide) {
         padding-left: 180px;
       }
     }

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -212,6 +212,8 @@
         display: flex;
         flex-direction: row;
         flex-wrap: wrap;
+        flex-basis: 100%;
+        flex-grow: 1;
         justify-content: space-between;
       }
 
@@ -256,8 +258,9 @@
     }
 
     .contrib-amounts {
-      display: flex;
-      flex-wrap: wrap;
+      // display: flex;
+      // flex-wrap: wrap;
+      // width: 100%;
 
       .contrib-amounts__error-message {
         font-family: $gu-text-sans-web;
@@ -267,14 +270,23 @@
         color: gu-colour(live-support-2);
       }
 
-      > * {
-        flex-basis: 100%;
-      }
+      // > * {
+      //   flex-basis: 100%;
+      // }
 
       @include mq($from: desktop) {
         .component-number-input {
           max-width: 93%;
         }
+      }
+    }
+
+    .contrib-amounts__other-amount {
+      display: flex;
+
+      .component-number-input {
+        flex-basis: 100%;
+        flex-grow: 1;
       }
     }
 

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -180,6 +180,11 @@
         bottom: $gu-v-spacing;
         right: $gu-h-spacing / 2;
         left: $gu-h-spacing / 2;
+
+        // Fix for IE.
+        svg {
+          left: 250px;
+        }
       }
     }
 

--- a/assets/pages/bundles-landing/components/ContribAmounts.jsx
+++ b/assets/pages/bundles-landing/components/ContribAmounts.jsx
@@ -139,12 +139,14 @@ function ContribAmounts(props: PropTypes) {
         toggleAction={attrs.toggleAction}
         checked={attrs.checked}
       />
-      <NumberInput
-        onFocus={props.userDefinedAmount}
-        onInput={props.userDefinedAmount}
-        selected={attrs.selected}
-        placeholder="Other amount (£)"
-      />
+      <div className="contrib-amounts__other-amount">
+        <NumberInput
+          onFocus={props.userDefinedAmount}
+          onInput={props.userDefinedAmount}
+          selected={attrs.selected}
+          placeholder="Other amount (£)"
+        />
+      </div>
       {errorMessage(props.contribError)}
     </div>
   );


### PR DESCRIPTION
## Why are you doing this?

We want the bundles landing page to work in old browsers from which we still get reasonable amounts of traffic, specifically Internet Explorer 10+ and Safari 8.

[**Trello Card**](https://trello.com/c/no7qELSS/580-fix-ie-and-safari-8-graphical-bugs)

## Changes

- Fixed an issue in IE where SVGs weren't aligning correctly. They're still a little wonky (the header appears on the left instead of the right), but they're no longer appearing in the middle of text as before.
- Reworked the use of flexbox in contribution amounts, so that it looks alright (not perfect) in Safari 8.
- Fixed an alignment issue in the introduction copy.
- Made the logo a link back to dotcom.

## Screenshots

**IE10**:

![ie10-fixes](https://cloud.githubusercontent.com/assets/5131341/26456924/74fe679e-4166-11e7-8492-b9a19d65be7c.jpg)

**Safari 8**:

![safari8-fixes](https://cloud.githubusercontent.com/assets/5131341/26456935/7c5fca14-4166-11e7-9b3a-1909ee88100f.png)
