### PR TITLE
Ensure we're using HTTPS in dev so we catch related browser security problems

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,78 +1,11 @@
 # support.theguardian.com
 
-Frontend for the new supporter platform
+Frontend for the new supporter platform: https//support.theguardian.com/
 
-You can find more details about the architecture of the project in our [**`development guide`**](https://github.com/guardian/support-frontend/blob/master/docs/development.md).
+## Getting started
 
-## Installing dependencies
+Follow the instructions in [**setup.md**](setup.md) to setup your dev environment and
+get `support-frontend` running locally.
 
-Install yarn in your machine, follow the correct tutorial according to your environment:
-
-[https://yarnpkg.com/en/docs/install](https://yarnpkg.com/en/docs/install)
-
-Go to the root of the project and run
-
-`yarn install`
-
-## Running the project in DEV Mode
-
-In order to run the server in your machine, you have to run the Play/Scala server and in another tab the webpack-dev-sever.
-
-**Running Play/Scala Dev Server:**
-
-`sbt devrun`
-
-This command will start the Play/Scala server listening on port 9000 of your computer. If you go to localhost:9000 at this moment you 
-will see a blank page. This is because the assets have not been generated yet. In order to do so, see the following step.  
-
-**Running Client-Side Dev Server:**
-
-`yarn devrun`
-
-The command above, build the assets and serve them using the `webpack-dev-server` listening on port 9111. This server (port 9111) 
-provides a hot-reload feature, which is really useful for client side development.
-
-Go to localhost:9111 to see the support site.
-
-## Running the project in PROD Mode
-
-**Generate the assets**
-
-`yarn build-prod`
-
-This command will generate the assets using PROD environment.
-
-**Running Play/Scala Server:**
-
-`sbt run`
-
-This command will start the Play/Scala server listening on port 9000 of your computer.   
-
-
-Go to localhost:9000 to see the support site.
-
-## Available yarn commands
-
-In order to run a yarn command you should run:
-
-`yarn run [name_command]`
-
-| Command              | Functionality |
-|----------------------|---------------|
-| `clean`              | Cleans the `public` folder. |
-| `validate`           | Validates the JS files (`.js` and `.jsx`), using eslint and flow. |
-| `lint`               | Runs eslint. |
-| `flow`               | Runs the flow type check. |
-| `build-dev`          | Builds the files for the `DEV` environment |
-| `build-prod`         | Builds the files for the `PROD` environment. It runs `clean`, `lint`, `test`, `build:css` and `build:js`. |
-| `build:css`          | Builds the CSS files. |
-| `build:css:sass`     | Builds the CSS using sass. |
-| `build:css:postcss`  | Runs the postCSS tasks (autoprefixer and pxtorem). |
-| `build:js`           | Builds the JS files using `DEV` environment. |
-| `watch`              | Watches for changes in any CSS or JS files and recompiles everything. |
-| `watch:js`           | Watches for changes in any JS file. |
-| `watch:css`          | Watches for changes in any CSS file. |
-| `watch:css:sass`     | Run watch task for sass command. |
-| `devrun`             | Cleans, transpiles, runs and watches the webpack-dev-server using `DEV` environment. |
-| `webpack-dev-server` | Runs the webpack-dev-server in port `9111`. |
-| `test`               | Runs the client side tests built using Jest.  |
+You can find more details about the architecture of the project in our
+[development guide](docs/development.md).

--- a/build.sbt
+++ b/build.sbt
@@ -82,4 +82,4 @@ excludeFilter in scalariformFormat := (excludeFilter in scalariformFormat).value
   "JavaScriptReverseRoutes.scala" ||
   "RoutesPrefix.scala"
 
-addCommandAlias("devrun", "run 9000")
+addCommandAlias("devrun", "run 9110") // Chosen to not clash with other Guardian projects - we can't all use the Play default of 9000!

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,7 +1,7 @@
 # Development in Support The Guardian frontend
 
- Welcome to Support Frontend. In this document we will go through the elements that conform 
- Support Frontend, how they interact and how you can start adding code to this repository.
+Welcome to Support Frontend. In this document we will go through the elements that form 
+Support Frontend, how they interact and how you can start adding code to this repository.
   
 ## Table of contents
 
@@ -13,7 +13,8 @@
 
 ## Getting started
 
-In order to set up the project correctly, please follow the instructions of the [README file](https://github.com/guardian/support-frontend/blob/master/README.md).
+Follow the instructions in [**setup.md**](setup.md) to setup your dev environment and
+get `support-frontend` running locally.
 
 ## Introduction to the technological stack
 
@@ -121,7 +122,7 @@ The pieces that make up `support-frontend` are:
 * The CSS for a non-shareable component is located inside the `page.scss` file.  
  
 
-## Building process
+## CI build process
 
 In order to build the project, team city runs a series of steps. The first step installs node js, the second build the 
 assets by executing the script [`build-tc`](https://github.com/guardian/support-frontend/blob/master/build-tc). 
@@ -146,4 +147,29 @@ As an example, in order to build the assets for production, the step `build-prod
    * asset hashing: Additionally, since the site has a [caching layer](https://app.fastly.com) sitting in front of it, 
    we append a hash to the name of the asset in order to invalidate the cache every time we make a release of the site. The configuration 
     is done [here](https://github.com/guardian/support-frontend/blob/master/webpack.config.js#L56). 
- 
+
+## Available yarn commands
+
+In order to run a yarn command you should run:
+
+`yarn run [name_command]`
+
+| Command              | Functionality |
+|----------------------|---------------|
+| `clean`              | Cleans the `public` folder. |
+| `validate`           | Validates the JS files (`.js` and `.jsx`), using eslint and flow. |
+| `lint`               | Runs eslint. |
+| `flow`               | Runs the flow type check. |
+| `build-dev`          | Builds the files for the `DEV` environment |
+| `build-prod`         | Builds the files for the `PROD` environment. It runs `clean`, `lint`, `test`, `build:css` and `build:js`. |
+| `build:css`          | Builds the CSS files. |
+| `build:css:sass`     | Builds the CSS using sass. |
+| `build:css:postcss`  | Runs the postCSS tasks (autoprefixer and pxtorem). |
+| `build:js`           | Builds the JS files using `DEV` environment. |
+| `watch`              | Watches for changes in any CSS or JS files and recompiles everything. |
+| `watch:js`           | Watches for changes in any JS file. |
+| `watch:css`          | Watches for changes in any CSS file. |
+| `watch:css:sass`     | Run watch task for sass command. |
+| `devrun`             | Cleans, transpiles, runs and watches the webpack-dev-server using `DEV` environment. |
+| `webpack-dev-server` | Runs the webpack-dev-server in port `9111`. |
+| `test`               | Runs the client side tests built using Jest.  |

--- a/docs/development.md
+++ b/docs/development.md
@@ -9,7 +9,8 @@ Support Frontend, how they interact and how you can start adding code to this re
 2. [Introduction to the technological stack](#introduction-to-the-technological-stack)
 3. [Architecture](#architecture)
 4. [Project's structure](#projects-structure) 
-5. [Building process](#building-process)
+5. [CI Build process](#ci-build-process)
+6. [Yarn commands](#yarn-commands)
 
 ## Getting started
 
@@ -148,11 +149,13 @@ As an example, in order to build the assets for production, the step `build-prod
    we append a hash to the name of the asset in order to invalidate the cache every time we make a release of the site. The configuration 
     is done [here](https://github.com/guardian/support-frontend/blob/master/webpack.config.js#L56). 
 
-## Available yarn commands
+## Yarn commands
 
 In order to run a yarn command you should run:
 
-`yarn run [name_command]`
+```
+$ yarn run [name_command]
+```
 
 | Command              | Functionality |
 |----------------------|---------------|

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -2,9 +2,9 @@
 
 In local development, the base app server has two layers of proxy sitting on top it:
 
-1. Play/Scala appserver _(base server)_ - http://sup.thegulocal.com:9110/
-2. `webpack-dev-server` _(proxy providing hot-reloading of client-side code)_ - http://sup.thegulocal.com:9111/
-3. Nginx _(proxy adding HTTPS and a unified `.thegulocal.com` domain with other Guardian projects)_ - **https://sup.thegulocal.com/ ⬅ USE THIS IN YOUR WEB BROWSER**
+1. Play/Scala appserver _(base server)_ - http://support.thegulocal.com:9110/
+2. `webpack-dev-server` _(proxy providing hot-reloading of client-side code)_ - http://support.thegulocal.com:9111/
+3. Nginx _(proxy adding HTTPS and a unified `.thegulocal.com` domain with other Guardian projects)_ - **https://support.thegulocal.com/ ⬅ USE THIS IN YOUR WEB BROWSER**
 
 You need all 3 of these running to have a working development environment.
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,44 @@
+# Local Development Setup
+
+In local development, the base app server has two layers of proxy sitting on top it:
+
+1. Play/Scala appserver _(base server)_ - http://sup.thegulocal.com:9110/
+2. `webpack-dev-server` _(proxy providing hot-reloading of client-side code)_ - http://sup.thegulocal.com:9111/
+3. Nginx _(proxy adding HTTPS and a unified `.thegulocal.com` domain with other Guardian projects)_ - **https://sup.thegulocal.com/ ⬅ USE THIS IN YOUR WEB BROWSER**
+
+You need all 3 of these running to have a working development environment.
+
+## Starting Play
+
+Install [sbt](http://www.scala-sbt.org/download.html), and start the [Play server](https://www.playframework.com/)
+running on port 9110, hot-reloading the server-side code:
+
+```
+$ sbt devrun
+```
+
+## Starting `webpack-dev-server`
+
+Install [yarn](https://yarnpkg.com/lang/en/docs/install/) and download client-side
+dependencies with:
+
+```
+yarn install
+```
+ 
+You can then start the `webpack-dev-server` proxy on port 9111, hot-reloading the client-side code:
+
+```
+$ yarn devrun
+```
+
+If you want to serve the assets without the `webpack-dev-server` proxy (to closer match Production)
+you can run this instead:
+
+```
+$ yarn build-prod
+```
+
+## Setting up NGINX
+
+Follow the setup instructions in [`/nginx/README.md`](../nginx/README.md).

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -1,0 +1,47 @@
+# Support™ NGINX
+
+## Setup Nginx for `Identity-Platform`
+
+Support™ depends on Identity, so **you'll need to perform the**
+[**Nginx setup for identity-platform**](https://github.com/guardian/identity-platform/blob/master/README.md#setup-nginx-for-local-development)
+**first**, before you do anything else.
+
+## Support-specific setup
+
+#### Update your hosts file
+
+Add the following local development domain to your hosts file in `/etc/hosts`:
+
+```
+127.0.0.1   sup.thegulocal.com
+```
+
+#### Run Support's Nginx setup script
+
+Run the Support-specific [setup.sh](setup.sh) script from the root
+of the `support-frontend` project:
+
+```
+./nginx/setup.sh
+```
+
+The script doesn't start Nginx. To manually start it run `sudo nginx` or `sudo systemctl start nginx`
+depending on your system.
+
+#### NGINX error messages
+
+nginx has some unhelpful error messages. Here are some translations:
+
+###### When stopping/reloading nginx
+```
+nginx: [error] open() "/usr/local/var/run/nginx.pid" failed (2: No such file or directory)
+```
+
+This means nginx is **not running**. And `nginx -s reload` will not automatically start nginx if it's not running.
+
+###### When starting nginx
+```
+nginx: [emerg] bind() to 0.0.0.0:8080 failed (48: Address already in use)
+```
+
+This means nginx is **already running**.

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -13,7 +13,7 @@ Support™ depends on Identity, so **you'll need to perform the**
 Add the following local development domain to your hosts file in `/etc/hosts`:
 
 ```
-127.0.0.1   sup.thegulocal.com
+127.0.0.1   support.thegulocal.com
 ```
 
 #### Run Support's Nginx setup script

--- a/nginx/setup.sh
+++ b/nginx/setup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -x
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NGINX_HOME=$(nginx -V 2>&1 | grep 'configure arguments:' | sed 's#.*conf-path=\([^ ]*\)/nginx\.conf.*#\1#g')
+
+echo "\n\nUsing NGINX_HOME=$NGINX_HOME"
+
+sudo mkdir -p $NGINX_HOME/sites-enabled
+sudo ln -fs $DIR/support.conf $NGINX_HOME/sites-enabled/support.conf

--- a/nginx/support.conf
+++ b/nginx/support.conf
@@ -1,6 +1,6 @@
 server {
     listen 443;
-    server_name sup.thegulocal.com;
+    server_name support.thegulocal.com;
 
     ssl on;
     ssl_certificate wildcard-thegulocal-com-exp2019-01-09.crt; ## Supplied by https://github.com/guardian/identity-platform#setup-nginx-for-local-development
@@ -14,7 +14,7 @@ server {
         proxy_set_header X-Forwarded-For $remote_addr;
         proxy_set_header Host $host;
 
-        proxy_pass http://sup.thegulocal.com:9111; ## webpack-dev-server proxy
+        proxy_pass http://support.thegulocal.com:9111; ## webpack-dev-server proxy
 
         proxy_redirect off;
 

--- a/nginx/support.conf
+++ b/nginx/support.conf
@@ -1,0 +1,30 @@
+server {
+    listen 443;
+    server_name sup.thegulocal.com;
+
+    ssl on;
+    ssl_certificate wildcard-thegulocal-com-exp2019-01-09.crt; ## Supplied by https://github.com/guardian/identity-platform#setup-nginx-for-local-development
+    ssl_certificate_key wildcard-thegulocal-com-exp2019-01-09.key; ## ditto
+
+    ssl_prefer_server_ciphers on;
+
+    # Proxy the Websocket connection to the Webpack server - see https://stackoverflow.com/a/40549432/438886
+    location /sockjs-node/ {
+        proxy_set_header X-Real-IP  $remote_addr;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header Host $host;
+
+        proxy_pass http://sup.thegulocal.com:9111; ## webpack-dev-server proxy
+
+        proxy_redirect off;
+
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+
+    location / {
+        proxy_pass http://localhost:9111/; ## webpack-dev-server proxy
+        proxy_set_header Host $http_host;
+    }
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build-dev": "webpack --config webpack.config.js --env.dev",
     "build-prod": "npm-run-all clean validate test 'webpack -- --config webpack.config.js --env.prod'",
     "webpack": "webpack",
-    "webpack-dev-server": "webpack-dev-server --port 9111 --public sup.thegulocal.com",
+    "webpack-dev-server": "webpack-dev-server --port 9111 --public support.thegulocal.com",
     "devrun": "npm-run-all clean webpack-dev-server",
     "test": "echo 'Running JS tests' && jest"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build-dev": "webpack --config webpack.config.js --env.dev",
     "build-prod": "npm-run-all clean validate test 'webpack -- --config webpack.config.js --env.prod'",
     "webpack": "webpack",
-    "webpack-dev-server": "webpack-dev-server --port 9111",
+    "webpack-dev-server": "webpack-dev-server --port 9111 --public sup.thegulocal.com",
     "devrun": "npm-run-all clean webpack-dev-server",
     "test": "echo 'Running JS tests' && jest"
   },
@@ -69,7 +69,7 @@
     "sass-loader": "^6.0.5",
     "sass-mq": "^3.3.2",
     "webpack": "^2.6.0",
-    "webpack-dev-server": "^2.4.2",
+    "webpack-dev-server": "^2.4.3",
     "webpack-manifest-plugin": "^1.1.0"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,7 +34,7 @@ module.exports = (env) => {
     devServer = {
       proxy: {
         '**': {
-          target: 'http://localhost:9000',
+          target: 'http://sup.thegulocal.com:9110',
           secure: false,
         },
       },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,7 +34,7 @@ module.exports = (env) => {
     devServer = {
       proxy: {
         '**': {
-          target: 'http://sup.thegulocal.com:9110',
+          target: 'http://support.thegulocal.com:9110',
           secure: false,
         },
       },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5943,7 +5943,7 @@ webpack-dev-middleware@^1.10.2:
     path-is-absolute "^1.0.0"
     range-parser "^1.0.3"
 
-webpack-dev-server@^2.4.2:
+webpack-dev-server@^2.4.3:
   version "2.4.5"
   resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-2.4.5.tgz#31384ce81136be1080b4b4cde0eb9b90e54ee6cf"
   dependencies:


### PR DESCRIPTION
## Why are you doing this?

1. Working with HTTPS in dev means we're more likely to catch browser-security related issues early
2. Using Nginx gives us a common domain of `.thegulocal.com`, which means Identity cookies etc are shared correctly, CORS issues are more realistic, etc.

The Nginx config is mostly copied from `membership-frontend`:

https://github.com/guardian/membership-frontend/tree/cf07a5791/nginx

...with a few redundant or obsolete ssl settings removed from the Nginx config.

It's necessary to pass `--public sup.thegulocal.com:9111` to the `webpack-dev-server`, otherwise I got a plain "Invalid Host header" response on hitting https://sup.thegulocal.com/uk . The update of `webpack-dev-server` is due to various related-sounding security bugs:

* https://github.com/webpack/webpack-dev-server/issues/882#issuecomment-296436511
* https://github.com/webpack/webpack-dev-server/releases/tag/v2.4.3
* https://webpack.js.org/configuration/dev-server/#devserver-public-cli-only

I've moved a lot of the initial-setup documentation into `docs/setup.md`.