### PR TITLE
Fix typo on new landing page

### DIFF
--- a/assets/pages/bundles-landing/components/WaysOfSupport.jsx
+++ b/assets/pages/bundles-landing/components/WaysOfSupport.jsx
@@ -13,7 +13,7 @@ import WayOfSupport from './WayOfSupport';
 const waysOfSupport = [
   {
     heading: 'Patrons',
-    infoText: 'The Patrons tier for those who care deeply about the Guardian\'s journalism and the impact it has on the world',
+    infoText: 'The Patron tier is for those who care deeply about the Guardian\'s journalism and the impact it has on the world',
     ctaText: 'Become a Patron',
     ctaLink: 'https://membership.theguardian.com/patrons',
     modifierClass: 'patron',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1649,11 +1649,7 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
-electron-to-chromium@^1.2.7:
-  version "1.3.8"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.8.tgz#b2c8a2c79bb89fbbfd3724d9555e15095b5f5fb6"
-
-electron-to-chromium@^1.3.11:
+electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.11:
   version "1.3.11"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.11.tgz#744761df1d67b492b322ce9aa0aba5393260eb61"
 
@@ -4726,18 +4722,12 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10:
+prop-types@^15.5.10, prop-types@^15.5.8:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
-
-prop-types@^15.5.8:
-  version "15.5.8"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.8.tgz#6b7b2e141083be38c8595aa51fc55775c7199394"
-  dependencies:
-    fbjs "^0.8.9"
 
 proper-lockfile@^1.1.2:
   version "1.2.0"
@@ -5769,16 +5759,7 @@ ua-parser-js@^0.7.9:
   version "0.7.12"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"
 
-uglify-js@^2.6, uglify-js@^2.6.1:
-  version "2.8.22"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.22.tgz#d54934778a8da14903fa29a326fb24c0ab51a1a0"
-  dependencies:
-    source-map "~0.5.1"
-    yargs "~3.10.0"
-  optionalDependencies:
-    uglify-to-browserify "~1.0.0"
-
-uglify-js@^2.8.27:
+uglify-js@^2.6, uglify-js@^2.6.1, uglify-js@^2.8.27:
   version "2.8.27"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.27.tgz#47787f912b0f242e5b984343be8e35e95f694c9c"
   dependencies:


### PR DESCRIPTION
## Why are you doing this?
I noticed a small copy error; this change corrects it.

## Changes

* Fix typo, using original copy from: https://membership.theguardian.com/patrons
* Note that this seems to have made some changes to yarn.lock, even though I haven't amended any dependencies.

## Screenshots

Before:
![image](https://cloud.githubusercontent.com/assets/19384074/26495732/a2899448-421c-11e7-88dc-c0a577122403.png)

After:
![image](https://cloud.githubusercontent.com/assets/19384074/26495575/0c919990-421c-11e7-8a5f-4de69f247bcc.png)

cc @svillafe 