### PR TITLE
Gzip non-image responses

### DIFF
--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -9,6 +9,7 @@ import filters.CheckCacheHeadersFilter
 import lib.CustomHttpErrorHandler
 import monitoring.SentryLogging
 import play.api.mvc.EssentialFilter
+import play.filters.gzip.GzipFilter
 
 trait AppComponents extends PlayComponents {
 
@@ -19,7 +20,10 @@ trait AppComponents extends PlayComponents {
   lazy val assetController = new Assets(httpErrorHandler)
   lazy val applicationController = new Application()
 
-  override lazy val httpFilters: Seq[EssentialFilter] = Seq(new CheckCacheHeadersFilter())
+  override lazy val httpFilters: Seq[EssentialFilter] = Seq(
+    new CheckCacheHeadersFilter(),
+    new GzipFilter(shouldGzip = (req, _) => !req.path.startsWith("/assets/images"))
+  )
   override lazy val router: Router = new Routes(httpErrorHandler, assetController, applicationController, controllers.Default, prefix = "/")
 
   config.sentryDsn foreach { dsn => new SentryLogging(dsn, config.stage) }

--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,8 @@ libraryDependencies ++= Seq(
   "com.typesafe.scala-logging" % "scala-logging_2.11" % "3.4.0",
   "com.amazonaws" % "aws-java-sdk-stepfunctions" % "1.11.128",
   "com.typesafe.akka" %% "akka-agent" % "2.4.12",
-  "org.typelevel" %% "cats" % "0.9.0"
+  "org.typelevel" %% "cats" % "0.9.0",
+  filters
 )
 
 sources in (Compile,doc) := Seq.empty


### PR DESCRIPTION
## Why are you doing this?

Smaller file sizes costs us and our users less in bandwidth.  Also loads faster.

[**Trello Card**](https://trello.com/c/ecVxSQj7/579-enable-gzip-for-support-frontend)