### PR TITLE
Adding ga reporting for ab test framework

### DIFF
--- a/assets/helpers/abtest.js
+++ b/assets/helpers/abtest.js
@@ -116,7 +116,7 @@ function assignUserToVariant(mvtId: number, test: Test): string {
 function getParticipation(mvtId: number): Object {
 
   const currentParticipation = getLocalStorageParticipation();
-  const participation = {};
+  const participation:Participations = {};
 
   tests.forEach((test) => {
 
@@ -155,6 +155,15 @@ export const init = () => {
 
 };
 
+export const getVariantsAsString = (participation: Participations): string => {
+  const variants: string[] = [];
+
+  Object.keys(participation).forEach((testId) => {
+    variants.push(`${testId}=${participation[(testId: any)]}`);
+  });
+
+  return variants.join('; ');
+};
 
 export const abTestReducer = (
   state: Participations = {},

--- a/assets/helpers/abtest.js
+++ b/assets/helpers/abtest.js
@@ -113,7 +113,7 @@ function assignUserToVariant(mvtId: number, test: Test): string {
   return test.variants[variantIndex];
 }
 
-function getParticipation(mvtId: number): Object {
+function getParticipation(mvtId: number): Participations {
 
   const currentParticipation = getLocalStorageParticipation();
   const participation:Participations = {};

--- a/assets/helpers/ga.js
+++ b/assets/helpers/ga.js
@@ -1,3 +1,6 @@
+const dimensions = {
+  experience: 'dimension16',
+};
 
 const create = () => {
 
@@ -13,6 +16,10 @@ const create = () => {
 
 export const init = () => {
   create();
+};
+
+export const setDimension = (name, value) => {
+  ga('set', dimensions[name], value);
 };
 
 export const trackPageview = () => {

--- a/assets/pages/bundles-landing/bundlesLanding.jsx
+++ b/assets/pages/bundles-landing/bundlesLanding.jsx
@@ -28,6 +28,7 @@ const participation = abTest.init();
 // ----- Tracking ----- //
 
 ga.init();
+ga.setDimension('experience', abTest.getVariantsAsString(participation));
 ga.trackPageview();
 
 // ----- Logging ----- //


### PR DESCRIPTION
## Why are you doing this?

We would like to track the experience of the user in GA, therefore we set the variants of the A/B tests in the experience dimension.

[**Trello Card**](https://trello.com/c/5H9yXN3H/560-send-a%2Fb-test-results-to-ga)

## Changes

* Added `setDimension` method to `ga.js`.
* Added method to transform participation to string.

## Screenshots
<img width="555" alt="picture 268" src="https://cloud.githubusercontent.com/assets/825398/26678040/7aa100ca-46c6-11e7-89a9-2105e2c152ae.png">



