### PR TITLE
Add request id to support workers requests

### DIFF
--- a/app/codecs/CirceDecoders.scala
+++ b/app/codecs/CirceDecoders.scala
@@ -1,23 +1,46 @@
 package codecs
 
 import com.gu.i18n.{Country, CountryGroup, Currency}
-import com.gu.support.workers.model.{PayPalPaymentFields, StripePaymentFields}
-import io.circe.Decoder
+import com.gu.support.workers.model.{Contribution, PayPalPaymentFields, StripePaymentFields, User}
+import io.circe.{Decoder, Encoder, Json}
 import cats.implicits._
-import io.circe.generic.auto._
+import com.gu.support.workers.model.state.CreatePaymentMethodState
+import io.circe.generic.decoding.DerivedDecoder
+import io.circe.generic.encoding.DerivedObjectEncoder
+import io.circe.generic.semiauto._
+import shapeless.Lazy
 
 object CirceDecoders {
   type PaymentFields = Either[StripePaymentFields, PayPalPaymentFields]
 
+  def deriveCodec[A](implicit decode: Lazy[DerivedDecoder[A]], encode: Lazy[DerivedObjectEncoder[A]]): Codec[A] =
+    new Codec(deriveEncoder, deriveDecoder)
+
+  implicit val encodeCurrency: Encoder[Currency] = Encoder.encodeString.contramap[Currency](_.iso)
+
   implicit val decodeCurrency: Decoder[Currency] =
     Decoder.decodeString.emap { code => Currency.fromString(code).toRight(s"Unrecognised currency code '$code'") }
+
+  implicit val encodeCountryAsAlpha2: Encoder[Country] = Encoder.encodeString.contramap[Country](_.alpha2)
 
   implicit val decodeCountry: Decoder[Country] =
     Decoder.decodeString.emap { code => CountryGroup.countryByCode(code).toRight(s"Unrecognised country code '$code'") }
 
+  implicit val encodePaymentFields: Encoder[PaymentFields] = new Encoder[PaymentFields] {
+    val stripeEncoder = deriveEncoder[StripePaymentFields]
+    val paypalEncoder = deriveEncoder[PayPalPaymentFields]
+    override def apply(a: PaymentFields): Json = {
+      a.fold(stripeEncoder.apply, paypalEncoder.apply)
+    }
+  }
+
   implicit val paymentFields: Decoder[PaymentFields] = {
-    val stripeFields = Decoder[StripePaymentFields].map(_.asLeft[PayPalPaymentFields])
-    val payPalFields = Decoder[PayPalPaymentFields].map(_.asRight[StripePaymentFields])
+    val stripeFields = deriveDecoder[StripePaymentFields].map(_.asLeft[PayPalPaymentFields])
+    val payPalFields = deriveDecoder[PayPalPaymentFields].map(_.asRight[StripePaymentFields])
     stripeFields or payPalFields
   }
+
+  implicit val userCodec: Codec[User] = deriveCodec
+  implicit val contributionCodec: Codec[Contribution] = deriveCodec
+  implicit val createPaymentMethodStateCodec: Codec[CreatePaymentMethodState] = deriveCodec
 }

--- a/app/codecs/Codec.scala
+++ b/app/codecs/Codec.scala
@@ -1,0 +1,10 @@
+package codecs
+
+import io.circe.Decoder._
+import io.circe.{Decoder, Encoder, HCursor, Json}
+
+class Codec[T](enc: Encoder[T], dec: Decoder[T]) extends Encoder[T] with Decoder[T] {
+  override def apply(a: T): Json = enc.apply(a)
+
+  override def apply(c: HCursor): Result[T] = dec.apply(c)
+}

--- a/app/controllers/MonthlyContributions.scala
+++ b/app/controllers/MonthlyContributions.scala
@@ -1,19 +1,17 @@
 package controllers
 
 import lib.actions.PrivateAction
-import lib.stepfunctions.MonthlyContributionsClient
-import lib.stepfunctions.MonthlyContributionsClient._
+import lib.stepfunctions.{CreateMonthlyContributorRequest, MonthlyContributionsClient}
 import play.api.mvc.{Action, Controller}
-import io.circe.generic.auto._
 import play.api.libs.circe.Circe
 import scala.concurrent.ExecutionContext
-import codecs.CirceDecoders._
 import cats.implicits._
+import lib.PlayImplicits._
 
 class MonthlyContributions(client: MonthlyContributionsClient)(implicit exec: ExecutionContext) extends Controller with Circe {
 
   def create: Action[CreateMonthlyContributorRequest] = PrivateAction.async(circe.json[CreateMonthlyContributorRequest]) { implicit request =>
-    client.createContributor(request.body).fold(
+    client.createContributor(request.body, request.uuid).fold(
       { _ => InternalServerError },
       { _ => Accepted }
     )

--- a/app/lib/PlayImplicits.scala
+++ b/app/lib/PlayImplicits.scala
@@ -1,0 +1,15 @@
+package lib
+
+import java.util.UUID
+
+import play.api.mvc.Request
+import scala.util.Random
+
+object PlayImplicits {
+
+  private lazy val serverIdentifier = new Random().nextLong()
+
+  implicit class RichRequest[T](request: Request[T]) {
+    def uuid: UUID = new UUID(serverIdentifier, request.id)
+  }
+}

--- a/app/lib/aws/package.scala
+++ b/app/lib/aws/package.scala
@@ -8,7 +8,6 @@ package object aws {
 
   lazy val CredentialsProvider = new AWSCredentialsProviderChain(
     new ProfileCredentialsProvider(ProfileName),
-    new InstanceProfileCredentialsProvider(false),
-    new EnvironmentVariableCredentialsProvider()
+    new InstanceProfileCredentialsProvider(false)
   )
 }

--- a/app/lib/stepfunctions/MonthlyContributionsClient.scala
+++ b/app/lib/stepfunctions/MonthlyContributionsClient.scala
@@ -1,28 +1,46 @@
 package lib.stepfunctions
 
+import java.util.UUID
+
 import scala.concurrent.Future
 import akka.actor.ActorSystem
 import cats.data.EitherT
 import cats.implicits._
-import com.gu.support.workers.model.state.CreatePaymentMethodState
+import com.gu.support.workers.model.state.{CreatePaymentMethodState, StepFunctionUserState}
 import config.Stage
 import MonthlyContributionsClient._
-import io.circe.generic.auto._
+import com.gu.support.workers.model.{Contribution, PayPalPaymentFields, StripePaymentFields, User}
+import io.circe.generic.semiauto.deriveDecoder
+import io.circe.Decoder
+import codecs.CirceDecoders._
+
+object CreateMonthlyContributorRequest {
+  implicit val decoder: Decoder[CreateMonthlyContributorRequest] = deriveDecoder
+}
+case class CreateMonthlyContributorRequest(
+  user: User,
+  contribution: Contribution,
+  paymentFields: Either[StripePaymentFields, PayPalPaymentFields]
+)
 
 object MonthlyContributionsClient {
   sealed trait MonthlyContributionError
   case object StateMachineFailure extends MonthlyContributionError
-
-  type CreateMonthlyContributorRequest = CreatePaymentMethodState
 }
 
 class MonthlyContributionsClient(stage: Stage)(implicit system: ActorSystem) {
   private implicit val ec = system.dispatcher
   private val underlying = Client("MonthlyContributions", stage.toString)
 
-  def createContributor(request: CreateMonthlyContributorRequest): EitherT[Future, MonthlyContributionError, Unit] =
-    underlying.triggerExecution(request).bimap(
-      { _ => StateMachineFailure: MonthlyContributionError },
-      { _ => () }
+  def createContributor(request: CreateMonthlyContributorRequest, requestId: UUID): EitherT[Future, MonthlyContributionError, Unit] = {
+    val createPaymentMethodState = CreatePaymentMethodState(
+      requestId = requestId,
+      user = request.user,
+      contribution = request.contribution,
+      paymentFields = request.paymentFields
     )
+    underlying.triggerExecution(createPaymentMethodState).bimap(
+      { _ => StateMachineFailure: MonthlyContributionError }, { _ => () }
+    )
+  }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-agent" % "2.4.12",
   "org.typelevel" %% "cats" % "0.9.0",
   "play-circe" %% "play-circe" % "2.5-0.8.0",
-  "com.gu" %% "support-models" % "0.1",
+  "com.gu" %% "support-models" % "0.2",
   "com.gu" %% "support-internationalisation" % "0.2",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,


### PR DESCRIPTION
## Why are you doing this?

So that we can trace logging data from support-frontend through each support-worker lambda execution

(needs new release of support-models)