### PR TITLE
Record events with ophan

### DIFF
--- a/assets/components/ctaCircle/ctaCircle.jsx
+++ b/assets/components/ctaCircle/ctaCircle.jsx
@@ -10,8 +10,8 @@ import Svg from 'components/svg/svg';
 
 type PropTypes = {
   text: string,
-  url: string,
   modifierClass: ?string,
+  onClick: () => void,
 };
 
 
@@ -25,7 +25,7 @@ const CtaCircle = (props: PropTypes) => {
     className = `${className} ${className}--${props.modifierClass}`;
   }
   return (
-    <a className={className} href={props.url}>
+    <a className={className} onClick={props.onClick} role="link" tabIndex={0}>
       <button><Svg svgName="arrow-right-straight" /></button>
       <span>{props.text}</span>
     </a>

--- a/assets/helpers/abtest.js
+++ b/assets/helpers/abtest.js
@@ -54,12 +54,12 @@ type OphanABPayload = {
 const tests: Test[] = [
   {
     testId: 'otherWaysOfContribute',
-    variants: ['control', 'variantA', 'variantB'],
+    variants: ['control', 'variantA'],
     audience: {
-      offset: 0.2,
-      size: 0.4,
+      offset: 0,
+      size: 1,
     },
-    isActive: false,
+    isActive: true,
   },
 ];
 
@@ -84,9 +84,9 @@ function getMvtId(): number {
 
 function getLocalStorageParticipation(): Participations {
 
-  const abtests = localStorage.getItem('gu.support.abTests');
+  const abTests = localStorage.getItem('gu.support.abTests');
 
-  return abtests ? JSON.parse(abtests) : {};
+  return abTests ? JSON.parse(abTests) : {};
 
 }
 

--- a/assets/helpers/abtest.js
+++ b/assets/helpers/abtest.js
@@ -2,8 +2,8 @@
 
 // ----- Imports ----- //
 
+import * as ophan from 'ophan';
 import * as cookie from './cookie';
-
 
 // ----- Setup ----- //
 
@@ -34,6 +34,18 @@ type Test = {
   variants: string[],
   audience: Audience,
   isActive: boolean,
+};
+
+
+type OphanABEvent = {
+  variantName: string,
+  complete: boolean,
+  campaignCodes?: string[],
+};
+
+
+type OphanABPayload = {
+  [TestId]: OphanABEvent,
 };
 
 
@@ -163,6 +175,26 @@ export const getVariantsAsString = (participation: Participations): string => {
   });
 
   return variants.join('; ');
+};
+
+export const trackOphan = (
+  testId: TestId,
+  variant: string,
+  complete?: boolean = false,
+  campaignCodes?: string[] = []): void => {
+
+  const payload: OphanABPayload = {};
+
+  payload[testId] = {
+    variantName: variant,
+    complete,
+    campaignCodes,
+  };
+
+
+  ophan.record({
+    abTestRegister: payload,
+  });
 };
 
 export const abTestReducer = (

--- a/assets/helpers/abtest.js
+++ b/assets/helpers/abtest.js
@@ -183,12 +183,12 @@ export const trackOphan = (
   complete?: boolean = false,
   campaignCodes?: string[] = []): void => {
 
-  const payload: OphanABPayload = {};
-
-  payload[testId] = {
-    variantName: variant,
-    complete,
-    campaignCodes,
+  const payload: OphanABPayload = {
+    [testId]: {
+      variantName: variant,
+      complete,
+      campaignCodes,
+    },
   };
 
 

--- a/assets/helpers/abtest.js
+++ b/assets/helpers/abtest.js
@@ -155,8 +155,8 @@ function getParticipation(mvtId: number): Participations {
 
 export const init = () => {
 
-  const mvt = getMvtId();
-  let participation = getParticipation(mvt);
+  const mvt: number = getMvtId();
+  let participation: Participations = getParticipation(mvt);
 
   const urlParticipation = getUrlParticipation();
   participation = Object.assign({}, participation, urlParticipation);

--- a/assets/pages/bundles-landing/bundlesLanding.jsx
+++ b/assets/pages/bundles-landing/bundlesLanding.jsx
@@ -25,6 +25,7 @@ import reducer from './reducers/reducers';
 
 const participation = abTest.init();
 
+
 // ----- Tracking ----- //
 
 ga.init();

--- a/assets/pages/bundles-landing/components/WayOfSupport.jsx
+++ b/assets/pages/bundles-landing/components/WayOfSupport.jsx
@@ -13,7 +13,7 @@ type PropTypes = {
   heading: string,
   infoText: string,
   ctaText: string,
-  ctaLink: string,
+  onClick: () => void,
   modifierClass: ?string,
   gridImg: string,
   imgAlt: ?string,
@@ -41,7 +41,7 @@ const WayOfSupport = (props: PropTypes) => {
       />
       <h1 className={`${className}__heading`}>{props.heading}</h1>
       <p className={`${className}__info-text`}>{props.infoText}</p>
-      <CtaCircle text={props.ctaText} modifierClass={props.modifierClass} url={props.ctaLink} />
+      <CtaCircle text={props.ctaText} modifierClass={props.modifierClass} onClick={props.onClick} />
     </div>
   );
 };

--- a/assets/pages/bundles-landing/components/WaysOfSupport.jsx
+++ b/assets/pages/bundles-landing/components/WaysOfSupport.jsx
@@ -5,11 +5,26 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
+import type { Participations } from 'helpers/abtest';
+import { trackOphan } from 'helpers/abtest';
+
 import otherWaysOfContribute from '../helpers/abtest';
 import WayOfSupport from './WayOfSupport';
 
 
 // ----- Copy ----- //
+
+const generateOnClick = (baseURL: string, intcmp: string, variant: string): () => void => {
+  const params = new URLSearchParams();
+  params.append('INTCMP', intcmp);
+  const ctaLink = `${baseURL}?${params.toString()}`;
+
+  return () => {
+    trackOphan('otherWaysOfContribute', variant, true);
+    window.location = ctaLink;
+  };
+};
+
 
 const waysOfSupport = [
   {
@@ -34,7 +49,7 @@ const waysOfSupport = [
 
 type PropTypes = {
   intCmp: string,
-  abTests: Object
+  abTests: Participations
 };
 
 
@@ -47,12 +62,13 @@ const WaysOfSupport = (props: PropTypes) => {
   const params = new URLSearchParams();
   params.append('INTCMP', props.intCmp);
 
+
   const waysOfSupportRendered = waysOfSupport.map((way) => {
 
-    const ctaLink = `${way.ctaLink}?${params.toString()}`;
-    const attrs = Object.assign({}, way, { ctaLink });
-    return <WayOfSupport {...attrs} />;
+    const onClick = generateOnClick(way.ctaLink, props.intCmp, props.abTests.otherWaysOfContribute);
+    const attrs = Object.assign({}, way, { onClick });
 
+    return <WayOfSupport {...attrs} />;
   });
 
   const title = otherWaysOfContribute(props.abTests);

--- a/assets/pages/bundles-landing/helpers/abtest.js
+++ b/assets/pages/bundles-landing/helpers/abtest.js
@@ -3,13 +3,15 @@
 // ----- Imports ----- //
 
 import type { Participations } from 'helpers/abtest';
-
+import { trackOphan } from 'helpers/abtest';
 
 // ----- Functions ----- //
 
 const otherWaysOfContribute = (participation: Participations): string => {
 
   const variant = participation.otherWaysOfContribute;
+
+  trackOphan('otherWaysOfContribute', variant);
 
   switch (variant) {
     case 'control' : return 'other ways you can support us';

--- a/assets/pages/bundles-landing/helpers/abtest.js
+++ b/assets/pages/bundles-landing/helpers/abtest.js
@@ -15,8 +15,7 @@ const otherWaysOfContribute = (participation: Participations): string => {
 
   switch (variant) {
     case 'control' : return 'other ways you can support us';
-    case 'variantA' : return 'other ways you can contribute';
-    case 'variantB' : return 'other ways you can give us money';
+    case 'variantA' : return 'other ways you can support us';
     default : return 'other ways you can support us';
   }
 };

--- a/assets/pages/bundles-landing/reducers/__tests__/reducersTest.js
+++ b/assets/pages/bundles-landing/reducers/__tests__/reducersTest.js
@@ -2,6 +2,8 @@
 import reducer from '../reducers';
 import type { Contrib, ContribState, Amount } from '../reducers';
 
+jest.mock('ophan', () => {});
+
 describe('reducer tests', () => {
 
   const initialContrib: ContribState = {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
       "es6"
     ],
     "modulePaths": ["assets"],
+    "moduleNameMapper": {
+      "ophan(.*)": "<rootDir>/node_modules/ophan-tracker-js/build/ophan.support"
+    },
     "verbose": true
   },
   "repository": {


### PR DESCRIPTION
## Why are you doing this?

We set up an example test in order to test the abacus stack for support frontend. In order to send an Ophan event when we click the link, I had to replace the `href` attribute from the `ctaCircle` component and pass an `onClick` function instead.

## Test set:
### Name: **otherWaysOfContribute**  
### Variants:
* control
* variantA


[**Trello Card**](https://trello.com/c/LgEpY7Ok/559-send-a%2Fb-test-results-to-ophan)

## Screenshots
### First event
![picture 269](https://cloud.githubusercontent.com/assets/825398/26723194/43ecbbd0-478b-11e7-815d-58a6d55f9281.png)

### Complete event
![picture 271](https://cloud.githubusercontent.com/assets/825398/26723221/5c785aec-478b-11e7-96cc-8dac11e5140e.png)





