### PR TITLE
Add Robots.txt (And Mix Up Public Assets Handling)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ conf/assets.map
 
 assets/images/inline-svgs/*.svg
 /assets/images/svg-sprite.svg
+/public/compiled-assets/
 /public/dist/
 /public/webpack/
 /public/images/

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -30,10 +30,10 @@ trait AppComponents extends PlayComponents {
 
   override lazy val router: Router = new Routes(
     httpErrorHandler,
-    assetController,
     applicationController,
     controllers.Default,
     monthlyContributionsController,
+    assetController,
     prefix = "/"
   )
 

--- a/conf/routes
+++ b/conf/routes
@@ -1,6 +1,5 @@
 # ----- System ----- #
 
-GET /assets/*file               controllers.Assets.at(path="/public", file)
 GET /healthcheck                controllers.Application.healthcheck
 
 
@@ -11,3 +10,6 @@ GET /                           controllers.Default.redirect(to = "/uk")
 
 GET /monthly-contributions      controllers.Application.reactTemplate(title="Support the Guardian | Monthly Contributions", id="monthly-contributions-page", js="monthlyContributionsPage.js")
 POST /monthly-contributions/create   controllers.MonthlyContributions.create
+
+GET /assets/*file               controllers.Assets.at(path="/public/compiled-assets", file)
+GET /*file                      controllers.Assets.at(path="/public", file)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Frontend for the supporter platform.",
   "scripts": {
-    "clean": "echo 'Cleaning Public Folder' && rimraf public/*",
+    "clean": "echo 'Cleaning Public Folder' && rimraf public/compiled-assets",
     "validate": "echo 'Validating JS' && npm-run-all lint flow",
     "flow": "flow",
     "lint": "eslint --ext .js --ext .jsx .",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+
+Disallow: /monthly-contributions
+
+Allow: /

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = (env) => {
 
   const plugins = [
     new ManifestPlugin({
-      fileName: '../conf/assets.map',
+      fileName: '../../conf/assets.map',
       writeToFileEmit: true,
     }),
     new ExtractTextPlugin({
@@ -52,7 +52,7 @@ module.exports = (env) => {
     },
 
     output: {
-      path: path.resolve(__dirname, 'public'),
+      path: path.resolve(__dirname, 'public/compiled-assets'),
       chunkFilename: 'webpack/[chunkhash].js',
       filename: `javascripts/[name]${isProd ? '.[chunkhash]' : ''}.js`,
       publicPath: '/assets/',


### PR DESCRIPTION
## Why are you doing this?

We would like a `robots.txt` file for all the robots.

Although the diff is fairly minimal, there are some changes here to how we handle our public assets:

- From now on, the `public` directory is version controlled, and can contain files like `robots.txt`.
- Webpack now builds to the `compiled-assets` subdirectory in public.
- Play will now serve anything on the url `/assets` from the `compiled-assets` directory, and will attempt to serve any other unmatched path from `public`.

[**Trello Card**](https://trello.com/c/MG3B00EU/600-we-need-a-robots.txt)

## Changes

- Ignored the `compiled-assets` directory.
- Tweaked the `/assets` route so that it serves from `compiled-assets`.
- Added a new `/*file` route that attempts to serve from `public`.
- Set up webpack to output to `public/compiled-assets`, and updated the path to the assets map.
- Added `robots.txt`.
