### PR TITLE
Make sbt project name more distinct: 'support-frontend' vs 'frontend'

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-name := "frontend"
+name := "support-frontend"
 
 version := "1.0-SNAPSHOT"
 

--- a/build.sbt
+++ b/build.sbt
@@ -68,7 +68,7 @@ packageDescription := """Frontend for the new supporter platform"""
 maintainer := "Membership <membership.dev@theguardian.com>"
 
 riffRaffPackageType := (packageBin in Debian).value
-riffRaffManifestProjectName := s"support:${name.value}"
+riffRaffManifestProjectName := "support:frontend"
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffArtifactResources += (file("cloud-formation/cfn.yaml"), "cfn/cfn.yaml")

--- a/cloud-formation/cfn.yaml
+++ b/cloud-formation/cfn.yaml
@@ -18,7 +18,7 @@ Parameters:
   App:
     Description: Applied directly as a tag
     Type: String
-    Default: frontend
+    Default: support-frontend
   AMI:
     Description: AMI ID
     Type: String

--- a/cloud-formation/cfn.yaml
+++ b/cloud-formation/cfn.yaml
@@ -72,9 +72,9 @@ Resources:
           #!/bin/bash -ev
           mkdir /etc/gu
           aws --region ${AWS::Region} s3 cp s3://membership-private/${Stage}/support.private.conf /etc/gu
-          aws --region ${AWS::Region} s3 cp s3://membership-dist/${Stack}/${Stage}/${App}/${App}_1.0-SNAPSHOT_all.deb /tmp
-          dpkg -i /tmp/${App}_1.0-SNAPSHOT_all.deb
-          /opt/cloudwatch-logs/configure-logs application ${Stack} ${Stage} ${App} /var/log/${App}/application.log
+          aws --region ${AWS::Region} s3 cp s3://membership-dist/${Stack}/${Stage}/${App}/support-frontend_1.0-SNAPSHOT_all.deb /tmp
+          dpkg -i /tmp/support-frontend_1.0-SNAPSHOT_all.deb
+          /opt/cloudwatch-logs/configure-logs application ${Stack} ${Stage} ${App} /var/log/support-frontend/application.log
           chown ${App} /etc/gu/support.private.conf
           chmod 0600 /etc/gu/support.private.conf
   AppRole:

--- a/conf/riff-raff.yaml
+++ b/conf/riff-raff.yaml
@@ -14,7 +14,7 @@ deployments:
         Recipe: xenial-membership
         AmigoStage: PROD
     dependencies: [cfn]
-  frontend:
+  support-frontend:
     type: autoscaling
     dependencies: [cfn, ami]
     parameters:


### PR DESCRIPTION
## Why are you doing this?

With the old project name of 'frontend', there was the potential for confusion with DotCom frontend :)

This gives us two improvements, one on the sbt console, where the prompt now says `support-frontend` rather than `frontend`:

```
$ sbt
[info] Loading global plugins from /home/roberto/.sbt/0.13/plugins
[info] Loading project definition from /home/roberto/development/support-frontend/project
[info] Set current project to support-frontend (in build file:/home/roberto/development/support-frontend/)
[support-frontend] $
```

The other improvement is with IntelliJ, which will give a more meaningful name for the project under 'Open Recent'.

![image](https://user-images.githubusercontent.com/52038/26875370-6a3dbe46-4b79-11e7-9368-f5b9de02dde1.png)
