### PR TITLE
Implementation of Stripe Checkout in the monthly contribution page

### DIFF
--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -24,6 +24,7 @@
 <body>
 	@content
 	<script src="https://polyfill.guim.co.uk/v2/polyfill.min.js?features=default,Array.prototype.find"></script>
+	<script defer src="https://js.stripe.com/v3/"></script>
 	@scripts
 	<!-- build-commit-id: @app.BuildInfo.gitCommitId -->
 </body>

--- a/app/views/react.scala.html
+++ b/app/views/react.scala.html
@@ -13,7 +13,7 @@
                         padding-left: 20px;
                         padding-right: 20px;
                         background-color: #e9e939;">
-                Please enable JavaScript - we use it to provide the best experience for Guardian&nbspSupporters.<br/>
+                Please enable JavaScript - we use it to provide the best experience for Guardian Supporters.<br/>
                 <a href="http://www.enable-javascript.com/">Click here for instructions to do so in your browser.</a>
             </div>
         </noscript>

--- a/app/views/react.scala.html
+++ b/app/views/react.scala.html
@@ -13,7 +13,7 @@
                         padding-left: 20px;
                         padding-right: 20px;
                         background-color: #e9e939;">
-                Please enable JavaScript - we use it to provide the best experience for Guardian Supporters.<br/>
+                Please enable JavaScript - we use it to provide the best experience for Guardian&nbsp;Supporters.<br/>
                 <a href="http://www.enable-javascript.com/">Click here for instructions to do so in your browser.</a>
             </div>
         </noscript>

--- a/assets/components/stripePopUpButton/stripePopUpButton.jsx
+++ b/assets/components/stripePopUpButton/stripePopUpButton.jsx
@@ -17,6 +17,8 @@ type PropTypes = {
   stripeLoaded: boolean,
   setupStripeCheckout: Function,
   onStripeClick: Function,
+  amount: number,
+  email: string,
 };
 
 
@@ -28,7 +30,9 @@ const StripePopUpButton = (props: PropTypes) => {
     props.setupStripeCheckout();
   }
 
-  return <button onClick={props.onStripeClick}>Add CC</button>;
+  const stripeClick = () => props.onStripeClick(props.amount, props.email);
+
+  return <button onClick={stripeClick}>Add CC</button>;
 
 };
 
@@ -37,6 +41,8 @@ function mapStateToProps(state) {
   return {
     overlayOpen: state.stripeCheckout.overlay,
     stripeLoaded: state.stripeCheckout.loaded,
+    amount: state.stripeCheckout.amount,
+    email: 'notarealuser@gu.com',
   };
 
 }
@@ -47,8 +53,8 @@ function mapDispatchToProps(dispatch) {
     setupStripeCheckout: () => {
       dispatch(setupStripeCheckout());
     },
-    onStripeClick: () => {
-      dispatch(openStripeOverlay());
+    onStripeClick: (amount: number, email: string) => {
+      dispatch(openStripeOverlay(amount, email));
     },
   };
 

--- a/assets/components/stripePopUpButton/stripePopUpButton.jsx
+++ b/assets/components/stripePopUpButton/stripePopUpButton.jsx
@@ -42,6 +42,8 @@ function mapStateToProps(state) {
     overlayOpen: state.stripeCheckout.overlay,
     stripeLoaded: state.stripeCheckout.loaded,
     amount: state.stripeCheckout.amount,
+    // We need to create a User reducer to inject user data
+    // inside the Redux State.
     email: 'notarealuser@gu.com',
   };
 

--- a/assets/components/stripePopUpButton/stripePopUpButton.jsx
+++ b/assets/components/stripePopUpButton/stripePopUpButton.jsx
@@ -1,35 +1,26 @@
-//@flow
+// @flow
 
 import React from 'react';
-
-import * as stripeCheckout from 'helpers/stripeCheckout/stripeCheckout';
-import { openStripeOverlay, setupStripeCheckout } from 'helpers/stripeCheckout/stripeCheckoutActions';
-
 import { connect } from 'react-redux';
+
+import { openStripeOverlay, setupStripeCheckout } from 'helpers/stripeCheckout/stripeCheckoutActions';
 
 
 // ----- Functions ----- //
 
-const StripePopUpButton = (props : Props) => {
+const StripePopUpButton = (props: Props) => {
 
   props.setupStripeCheckout();
 
-  console.log("render");
-  return (
-    <div>
-      {( props.loading || props.stripeLoading )
-        ? <p>loading..</p>
-        : <button onClick={props.onStripeClick}>Add CC</button>
-      }
-    </div>
-  );
+  return <button onClick={() => props.onStripeClick(props.amount)}>Add CC</button>;
+
 };
 
 function mapStateToProps(state) {
 
   return {
-    stripeLoading: state.stripe.loading,
-    loading: state
+    overlayOpen: state.stripe.overlay,
+    stripeLoaded: state.stripe.loaded,
   };
 
 }
@@ -40,10 +31,10 @@ function mapDispatchToProps(dispatch) {
     setupStripeCheckout: () => {
       dispatch(setupStripeCheckout());
     },
-    onStripeClick: () => {
-      dispatch(openStripeOverlay());
+    onStripeClick: (amount) => {
+      dispatch(openStripeOverlay(amount));
     },
-  }
+  };
 
 }
 

--- a/assets/components/stripePopUpButton/stripePopUpButton.jsx
+++ b/assets/components/stripePopUpButton/stripePopUpButton.jsx
@@ -1,26 +1,42 @@
 // @flow
 
+// ----- Imports ----- //
+
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { openStripeOverlay, setupStripeCheckout } from 'helpers/stripeCheckout/stripeCheckoutActions';
+import {
+  openStripeOverlay,
+  setupStripeCheckout,
+} from 'helpers/stripeCheckout/stripeCheckoutActions';
+
+
+// ---- Types ----- //
+
+type PropTypes = {
+  stripeLoaded: boolean,
+  setupStripeCheckout: Function,
+  onStripeClick: Function,
+};
 
 
 // ----- Functions ----- //
 
-const StripePopUpButton = (props: Props) => {
+const StripePopUpButton = (props: PropTypes) => {
 
-  props.setupStripeCheckout();
+  if (!props.stripeLoaded) {
+    props.setupStripeCheckout();
+  }
 
-  return <button onClick={() => props.onStripeClick(props.amount)}>Add CC</button>;
+  return <button onClick={props.onStripeClick}>Add CC</button>;
 
 };
 
 function mapStateToProps(state) {
 
   return {
-    overlayOpen: state.stripe.overlay,
-    stripeLoaded: state.stripe.loaded,
+    overlayOpen: state.stripeCheckout.overlay,
+    stripeLoaded: state.stripeCheckout.loaded,
   };
 
 }
@@ -31,8 +47,8 @@ function mapDispatchToProps(dispatch) {
     setupStripeCheckout: () => {
       dispatch(setupStripeCheckout());
     },
-    onStripeClick: (amount) => {
-      dispatch(openStripeOverlay(amount));
+    onStripeClick: () => {
+      dispatch(openStripeOverlay());
     },
   };
 

--- a/assets/components/stripePopUpButton/stripePopUpButton.jsx
+++ b/assets/components/stripePopUpButton/stripePopUpButton.jsx
@@ -1,0 +1,53 @@
+//@flow
+
+import React from 'react';
+
+import * as stripeCheckout from 'helpers/stripeCheckout/stripeCheckout';
+import { openStripeOverlay, setupStripeCheckout } from 'helpers/stripeCheckout/stripeCheckoutActions';
+
+import { connect } from 'react-redux';
+
+
+// ----- Functions ----- //
+
+const StripePopUpButton = (props : Props) => {
+
+  props.setupStripeCheckout();
+
+  console.log("render");
+  return (
+    <div>
+      {( props.loading || props.stripeLoading )
+        ? <p>loading..</p>
+        : <button onClick={props.onStripeClick}>Add CC</button>
+      }
+    </div>
+  );
+};
+
+function mapStateToProps(state) {
+
+  return {
+    stripeLoading: state.stripe.loading,
+    loading: state
+  };
+
+}
+
+function mapDispatchToProps(dispatch) {
+
+  return {
+    setupStripeCheckout: () => {
+      dispatch(setupStripeCheckout());
+    },
+    onStripeClick: () => {
+      dispatch(openStripeOverlay());
+    },
+  }
+
+}
+
+
+// ----- Exports ----- //
+
+export default connect(mapStateToProps, mapDispatchToProps)(StripePopUpButton);

--- a/assets/helpers/stripeCheckout/stripeCheckout.js
+++ b/assets/helpers/stripeCheckout/stripeCheckout.js
@@ -1,74 +1,48 @@
 // @flow
 
-const stripeHandler = null;
+// ----- Setup ----- //
 
-const loadStripe = () => {
+let stripeHandler = null;
 
-  return new Promise((resolve) => {
 
-    if(! window.StripeCheckout) {
+// ----- Functions ----- //
 
-      const script = document.createElement('script');
+const loadStripe = () => new Promise((resolve) => {
 
-      script.onload = function () {
-        console.info("Stripe script loaded");
-        resolve();
-      };
+  if (!window.StripeCheckout) {
 
-      script.src = 'https://checkout.stripe.com/checkout.js';
+    const script = document.createElement('script');
+
+    script.onload = resolve;
+    script.src = 'https://checkout.stripe.com/checkout.js';
+
+    if (document.head) {
       document.head.appendChild(script);
-
-    } else {
-      resolve();
     }
 
-  );
+  } else {
+    resolve();
+  }
 
-}
+});
 
-export const setup = (token) => {
+export const setup = (token: Function, closed: Function) => loadStripe.then(() => {
 
-  return loadStripe.then(() => {
-
-    stripeHandler = window.StripeCheckout.configure({
-      key: 'pk_test_Qm3CGRdrV4WfGYCpm0sftR0f',
-      image: 'https://stripe.com/img/documentation/checkout/marketplace.png',
-      locale: 'auto',
-      token,
-    });
-
+  stripeHandler = window.StripeCheckout.configure({
+    key: 'pk_test_Qm3CGRdrV4WfGYCpm0sftR0f',
+    image: 'https://stripe.com/img/documentation/checkout/marketplace.png',
+    locale: 'auto',
+    token,
+    closed,
   });
 
-};
+});
+
 
 export const openDialogBox = () => {
-  stripeHandler.open();
-}
 
-
-export const stripeCheckoutReducer = (
-  state: Participations = {},
-  action: Action): Participations => {
-
-  switch (action.type) {
-
-    case 'SETUP_STRIPE_CHECKOUT' : {
-
-    }
-
-    case 'STRIPE_CHECKOUT_LOADED': {
-      return Object.assign({}, state, action.payload);
-    }
-
-    case 'OPEN_STRIPE_OVERLAY' : {
-
-    }
-
-    default:
-      return state;
+  if (stripeHandler) {
+    stripeHandler.open();
   }
+
 };
-
-
-
-

--- a/assets/helpers/stripeCheckout/stripeCheckout.js
+++ b/assets/helpers/stripeCheckout/stripeCheckout.js
@@ -26,7 +26,7 @@ const loadStripe = () => new Promise((resolve) => {
 
 });
 
-export const setup = (token: Function, closed: Function) => loadStripe.then(() => {
+export const setup = (token: Function, closed: Function) => loadStripe().then(() => {
 
   stripeHandler = window.StripeCheckout.configure({
     key: 'pk_test_Qm3CGRdrV4WfGYCpm0sftR0f',

--- a/assets/helpers/stripeCheckout/stripeCheckout.js
+++ b/assets/helpers/stripeCheckout/stripeCheckout.js
@@ -1,0 +1,74 @@
+// @flow
+
+const stripeHandler = null;
+
+const loadStripe = () => {
+
+  return new Promise((resolve) => {
+
+    if(! window.StripeCheckout) {
+
+      const script = document.createElement('script');
+
+      script.onload = function () {
+        console.info("Stripe script loaded");
+        resolve();
+      };
+
+      script.src = 'https://checkout.stripe.com/checkout.js';
+      document.head.appendChild(script);
+
+    } else {
+      resolve();
+    }
+
+  );
+
+}
+
+export const setup = (token) => {
+
+  return loadStripe.then(() => {
+
+    stripeHandler = window.StripeCheckout.configure({
+      key: 'pk_test_Qm3CGRdrV4WfGYCpm0sftR0f',
+      image: 'https://stripe.com/img/documentation/checkout/marketplace.png',
+      locale: 'auto',
+      token,
+    });
+
+  });
+
+};
+
+export const openDialogBox = () => {
+  stripeHandler.open();
+}
+
+
+export const stripeCheckoutReducer = (
+  state: Participations = {},
+  action: Action): Participations => {
+
+  switch (action.type) {
+
+    case 'SETUP_STRIPE_CHECKOUT' : {
+
+    }
+
+    case 'STRIPE_CHECKOUT_LOADED': {
+      return Object.assign({}, state, action.payload);
+    }
+
+    case 'OPEN_STRIPE_OVERLAY' : {
+
+    }
+
+    default:
+      return state;
+  }
+};
+
+
+
+

--- a/assets/helpers/stripeCheckout/stripeCheckout.js
+++ b/assets/helpers/stripeCheckout/stripeCheckout.js
@@ -29,9 +29,12 @@ const loadStripe = () => new Promise((resolve) => {
 export const setup = (token: Function, closed: Function) => loadStripe().then(() => {
 
   stripeHandler = window.StripeCheckout.configure({
+    name: 'Guardian',
+    description: 'Please enter your card details.',
     key: 'pk_test_Qm3CGRdrV4WfGYCpm0sftR0f',
-    image: 'https://stripe.com/img/documentation/checkout/marketplace.png',
+    image: 'https://d24w1tjgih0o9s.cloudfront.net/gu.png',
     locale: 'auto',
+    currency: 'GBP',
     token,
     closed,
   });
@@ -39,10 +42,14 @@ export const setup = (token: Function, closed: Function) => loadStripe().then(()
 });
 
 
-export const openDialogBox = () => {
+export const openDialogBox = (amount: number, email: string) => {
 
   if (stripeHandler) {
-    stripeHandler.open();
+    stripeHandler.open({
+      // Must be passed in pence.
+      amount: amount * 100,
+      email,
+    });
   }
 
 };

--- a/assets/helpers/stripeCheckout/stripeCheckoutActions.js
+++ b/assets/helpers/stripeCheckout/stripeCheckoutActions.js
@@ -2,43 +2,59 @@
 
 // ----- Imports ----- //
 
-import * as stripeCheckout from '';
-import type { Contrib, Amount } from '../reducers/reducers';
+import * as stripeCheckout from './stripeCheckout';
 
 
 // ----- Types ----- //
 
 export type Action =
-  | { type: 'CHANGE_CONTRIB_TYPE', contribType: Contrib }
-  | { type: 'CHANGE_CONTRIB_AMOUNT', amount: Amount }
-  | { type: 'CHANGE_CONTRIB_AMOUNT_RECURRING', amount: Amount }
-  | { type: 'CHANGE_CONTRIB_AMOUNT_ONEOFF', amount: Amount }
+  | { type: 'START_STRIPE_CHECKOUT' }
+  | { type: 'STRIPE_CHECKOUT_LOADED' }
+  | { type: 'SET_STRIPE_CHECKOUT_TOKEN', token: string }
+  | { type: 'CLOSE_STRIPE_OVERLAY' }
+  | { type: 'OPEN_STRIPE_OVERLAY', amount: number }
   ;
 
 
 // ----- Actions ----- //
 
-const startStripeCheckout = () => {
-  return { type: 'START_STRIPE_CHECKOUT'};
+function startStripeCheckout(): Action {
+  return { type: 'START_STRIPE_CHECKOUT' };
 }
 
-const stripeCheckoutLoaded = () => {
-  return { type: 'STRIPE_CHECKOUT_LOADED'};
+function stripeCheckoutLoaded(): Action {
+  return { type: 'STRIPE_CHECKOUT_LOADED' };
 }
 
-export function openStripeOverlay(): Action {
-  openDialogBox();
-  return { type: 'OPEN_STRIPE_OVERLAY' };
+function setStripeCheckoutToken(token: string): Action {
+  return { type: 'SET_STRIPE_CHECKOUT_TOKEN', token };
 }
 
-export function setupStripeCheckout(): Action {
+function closeStripeOverlay(): Action {
+  return { type: 'CLOSE_STRIPE_OVERLAY' };
+}
 
-  return dispatch => {
-    dispatch(startStripeCheckout())
-    return stripeCheckout.setup().then(() => {
+export function openStripeOverlay(amount: number): Action {
+  stripeCheckout.openDialogBox();
+  return { type: 'OPEN_STRIPE_OVERLAY', amount };
+}
+
+export function setupStripeCheckout(): Function {
+
+  return (dispatch) => {
+
+    const handleToken = (token) => {
+      dispatch(setStripeCheckoutToken(token));
+    };
+
+    const handleCloseOverlay = () => dispatch(closeStripeOverlay());
+
+    dispatch(startStripeCheckout());
+
+    return stripeCheckout.setup(handleToken, handleCloseOverlay).then(() => {
       dispatch(stripeCheckoutLoaded());
-    })
+    });
 
-  }
+  };
 
 }

--- a/assets/helpers/stripeCheckout/stripeCheckoutActions.js
+++ b/assets/helpers/stripeCheckout/stripeCheckoutActions.js
@@ -1,0 +1,44 @@
+// @flow
+
+// ----- Imports ----- //
+
+import * as stripeCheckout from '';
+import type { Contrib, Amount } from '../reducers/reducers';
+
+
+// ----- Types ----- //
+
+export type Action =
+  | { type: 'CHANGE_CONTRIB_TYPE', contribType: Contrib }
+  | { type: 'CHANGE_CONTRIB_AMOUNT', amount: Amount }
+  | { type: 'CHANGE_CONTRIB_AMOUNT_RECURRING', amount: Amount }
+  | { type: 'CHANGE_CONTRIB_AMOUNT_ONEOFF', amount: Amount }
+  ;
+
+
+// ----- Actions ----- //
+
+const startStripeCheckout = () => {
+  return { type: 'START_STRIPE_CHECKOUT'};
+}
+
+const stripeCheckoutLoaded = () => {
+  return { type: 'STRIPE_CHECKOUT_LOADED'};
+}
+
+export function openStripeOverlay(): Action {
+  openDialogBox();
+  return { type: 'OPEN_STRIPE_OVERLAY' };
+}
+
+export function setupStripeCheckout(): Action {
+
+  return dispatch => {
+    dispatch(startStripeCheckout())
+    return stripeCheckout.setup().then(() => {
+      dispatch(stripeCheckoutLoaded());
+    })
+
+  }
+
+}

--- a/assets/helpers/stripeCheckout/stripeCheckoutActions.js
+++ b/assets/helpers/stripeCheckout/stripeCheckoutActions.js
@@ -35,8 +35,8 @@ function closeStripeOverlay(): Action {
   return { type: 'CLOSE_STRIPE_OVERLAY' };
 }
 
-export function openStripeOverlay(): Action {
-  stripeCheckout.openDialogBox();
+export function openStripeOverlay(amount: number, email: string): Action {
+  stripeCheckout.openDialogBox(amount, email);
   return { type: 'OPEN_STRIPE_OVERLAY' };
 }
 

--- a/assets/helpers/stripeCheckout/stripeCheckoutActions.js
+++ b/assets/helpers/stripeCheckout/stripeCheckoutActions.js
@@ -12,7 +12,8 @@ export type Action =
   | { type: 'STRIPE_CHECKOUT_LOADED' }
   | { type: 'SET_STRIPE_CHECKOUT_TOKEN', token: string }
   | { type: 'CLOSE_STRIPE_OVERLAY' }
-  | { type: 'OPEN_STRIPE_OVERLAY', amount: number }
+  | { type: 'OPEN_STRIPE_OVERLAY' }
+  | { type: 'SET_STRIPE_AMOUNT', amount: number }
   ;
 
 
@@ -34,9 +35,13 @@ function closeStripeOverlay(): Action {
   return { type: 'CLOSE_STRIPE_OVERLAY' };
 }
 
-export function openStripeOverlay(amount: number): Action {
+export function openStripeOverlay(): Action {
   stripeCheckout.openDialogBox();
-  return { type: 'OPEN_STRIPE_OVERLAY', amount };
+  return { type: 'OPEN_STRIPE_OVERLAY' };
+}
+
+export function setStripeAmount(amount: number): Action {
+  return { type: 'SET_STRIPE_AMOUNT', amount };
 }
 
 export function setupStripeCheckout(): Function {

--- a/assets/helpers/stripeCheckout/stripeCheckoutReducer.js
+++ b/assets/helpers/stripeCheckout/stripeCheckoutReducer.js
@@ -9,7 +9,6 @@ import type { Action } from './stripeCheckoutActions';
 
 type State = {
   loaded: boolean,
-  overlay: boolean,
   amount: ?number,
   token: ?string,
 };
@@ -19,7 +18,6 @@ type State = {
 
 const initialState: State = {
   loaded: false,
-  overlay: false,
   amount: null,
   token: null,
 };
@@ -36,8 +34,8 @@ export default function stripeCheckoutReducer(
     case 'STRIPE_CHECKOUT_LOADED':
       return Object.assign({}, state, { loaded: true });
 
-    case 'OPEN_STRIPE_OVERLAY':
-      return Object.assign({}, state, { overlay: true, amount: action.amount });
+    case 'SET_STRIPE_AMOUNT':
+      return Object.assign({}, state, { amount: action.amount });
 
     default:
       return state;

--- a/assets/helpers/stripeCheckout/stripeCheckoutReducer.js
+++ b/assets/helpers/stripeCheckout/stripeCheckoutReducer.js
@@ -1,0 +1,47 @@
+// @flow
+
+// ----- Imports ----- //
+
+import type { Action } from './stripeCheckoutActions';
+
+
+// ----- Types ----- //
+
+type State = {
+  loaded: boolean,
+  overlay: boolean,
+  amount: ?number,
+  token: ?string,
+};
+
+
+// ----- Setup ----- //
+
+const initialState: State = {
+  loaded: false,
+  overlay: false,
+  amount: null,
+  token: null,
+};
+
+
+// ----- Exports ----- //
+
+export default function stripeCheckoutReducer(
+  state: State = initialState,
+  action: Action): State {
+
+  switch (action.type) {
+
+    case 'STRIPE_CHECKOUT_LOADED':
+      return Object.assign({}, state, { loaded: true });
+
+    case 'OPEN_STRIPE_OVERLAY':
+      return Object.assign({}, state, { overlay: true, amount: action.amount });
+
+    default:
+      return state;
+
+  }
+
+}

--- a/assets/pages/monthly-contributions/actions/monthlyContributionsActions.js
+++ b/assets/pages/monthly-contributions/actions/monthlyContributionsActions.js
@@ -6,12 +6,24 @@ import { setStripeAmount } from 'helpers/stripeCheckout/stripeCheckoutActions';
 import validateContribution from '../helpers/validation';
 
 
+// ----- Types ----- //
+
+export type Action = { type: 'SET_CONTRIB_VALUE', value: number };
+
+
 // ----- Actions ----- //
+
+function setContribValue(value: number): Action {
+  return { type: 'SET_CONTRIB_VALUE', value };
+}
 
 export default function setContribAmount(amount: string): Function {
 
+  const value = validateContribution(amount);
+
   return (dispatch) => {
-    dispatch(setStripeAmount(validateContribution(amount)));
+    dispatch(setContribValue(value));
+    dispatch(setStripeAmount(value));
   };
 
 }

--- a/assets/pages/monthly-contributions/actions/monthlyContributionsActions.js
+++ b/assets/pages/monthly-contributions/actions/monthlyContributionsActions.js
@@ -1,12 +1,17 @@
 // @flow
 
-// ----- Types ----- //
+// ----- Imports ----- //
 
-export type Action = { type: 'SET_CONTRIB_AMOUNT', amount: string };
+import { setStripeAmount } from 'helpers/stripeCheckout/stripeCheckoutActions';
+import validateContribution from '../helpers/validation';
 
 
 // ----- Actions ----- //
 
-export default function setContribAmount(amount: string): Action {
-  return { type: 'SET_CONTRIB_AMOUNT', amount };
+export default function setContribAmount(amount: string): Function {
+
+  return (dispatch) => {
+    dispatch(setStripeAmount(validateContribution(amount)));
+  };
+
 }

--- a/assets/pages/monthly-contributions/components/paymentMethods.jsx
+++ b/assets/pages/monthly-contributions/components/paymentMethods.jsx
@@ -4,6 +4,8 @@
 
 import React from 'react';
 
+import StripePopUpButton from 'components/stripePopUpButton/stripePopUpButton';
+
 
 // ----- Setup ----- //
 
@@ -18,7 +20,7 @@ function PaymentMethods() {
   return (
     <section className="payment-methods">
       <h2>Payment methods</h2>
-      <button>Stripe</button>
+      <StripePopUpButton />
       <button>PayPal</button>
       <div>
         By proceeding, you are agreeing to our {terms} and {privacy}.

--- a/assets/pages/monthly-contributions/monthlyContributions.jsx
+++ b/assets/pages/monthly-contributions/monthlyContributions.jsx
@@ -5,8 +5,9 @@
 import 'ophan';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { createStore } from 'redux';
+import { createStore, applyMiddleware } from 'redux';
 import { Provider } from 'react-redux';
+import thunkMiddleware from 'redux-thunk';
 
 import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
 import SimpleFooter from 'components/footers/simpleFooter/simpleFooter';
@@ -41,7 +42,7 @@ logger.init();
 
 // ----- Redux Store ----- //
 
-const store = createStore(reducer);
+const store = createStore(reducer, applyMiddleware(thunkMiddleware));
 
 // Retrieves the contrib amount from the url and sends it to the redux store.
 store.dispatch(setContribAmount(getQueryParameter('contributionValue', '5')));
@@ -56,7 +57,7 @@ const content = (
       <h1>Make a monthly contribution</h1>
       <NameForm />
       <h2>Your contribution</h2>
-      <div>{store.getState()}</div>
+      <div>{store.getState().monthlyContrib}</div>
       <PaymentMethods />
       <SimpleFooter />
     </div>

--- a/assets/pages/monthly-contributions/monthlyContributions.jsx
+++ b/assets/pages/monthly-contributions/monthlyContributions.jsx
@@ -11,8 +11,6 @@ import { Provider } from 'react-redux';
 import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
 import SimpleFooter from 'components/footers/simpleFooter/simpleFooter';
 
-import stripePopUpButton from 'components/stripePopUpButton/stripePopUpButton';
-
 import * as ga from 'helpers/ga';
 import * as abTest from 'helpers/abtest';
 import * as logger from 'helpers/logger';
@@ -20,6 +18,8 @@ import getQueryParameter from 'helpers/url';
 import PaymentMethods from './components/paymentMethods';
 import NameForm from './components/nameForm';
 import reducer from './reducers/reducers';
+
+import setContribAmount from './actions/monthlyContributionsActions';
 
 
 // ----- AB Tests ----- //
@@ -44,10 +44,7 @@ logger.init();
 const store = createStore(reducer);
 
 // Retrieves the contrib amount from the url and sends it to the redux store.
-store.dispatch({
-  type: 'SET_CONTRIB_AMOUNT',
-  amount: getQueryParameter('contributionValue', '5'),
-});
+store.dispatch(setContribAmount(getQueryParameter('contributionValue', '5')));
 
 
 // ----- Render ----- //

--- a/assets/pages/monthly-contributions/monthlyContributions.jsx
+++ b/assets/pages/monthly-contributions/monthlyContributions.jsx
@@ -11,6 +11,8 @@ import { Provider } from 'react-redux';
 import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
 import SimpleFooter from 'components/footers/simpleFooter/simpleFooter';
 
+import stripePopUpButton from 'components/stripePopUpButton/stripePopUpButton';
+
 import * as ga from 'helpers/ga';
 import * as abTest from 'helpers/abtest';
 import * as logger from 'helpers/logger';

--- a/assets/pages/monthly-contributions/reducers/reducers.js
+++ b/assets/pages/monthly-contributions/reducers/reducers.js
@@ -2,22 +2,13 @@
 
 // ----- Imports ----- //
 
-import validateContribution from '../helpers/validation';
-import type { Action } from '../actions/monthlyContributionsActions';
+import { combineReducers } from 'redux';
+
+import stripeCheckout from 'helpers/stripeCheckout/stripeCheckoutReducer';
 
 
-// ----- Reducers ----- //
+// ----- Exports ----- //
 
-export default function reducer(state: number = 5, action: Action): number {
-
-  switch (action.type) {
-
-    case 'SET_CONTRIB_AMOUNT':
-      return validateContribution(action.amount);
-
-    default:
-      return state;
-
-  }
-
-}
+export default combineReducers({
+  stripeCheckout,
+});

--- a/assets/pages/monthly-contributions/reducers/reducers.js
+++ b/assets/pages/monthly-contributions/reducers/reducers.js
@@ -5,10 +5,31 @@
 import { combineReducers } from 'redux';
 
 import stripeCheckout from 'helpers/stripeCheckout/stripeCheckoutReducer';
+import type { Action } from '../actions/monthlyContributionsActions';
+
+
+// ----- Reducers ----- //
+
+function monthlyContrib(
+  state: number = 5,
+  action: Action): number {
+
+  switch (action.type) {
+
+    case 'SET_CONTRIB_VALUE':
+      return action.value;
+
+    default:
+      return state;
+
+  }
+
+}
 
 
 // ----- Exports ----- //
 
 export default combineReducers({
+  monthlyContrib,
   stripeCheckout,
 });

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
       "json",
       "es6"
     ],
-    "modulePaths": ["assets"],
+    "modulePaths": [
+      "assets"
+    ],
     "moduleNameMapper": {
       "ophan(.*)": "<rootDir>/node_modules/ophan-tracker-js/build/ophan.support"
     },
@@ -39,7 +41,8 @@
   "dependencies": {
     "raven-js": "^3.15.0",
     "react-redux": "^5.0.5",
-    "redux": "^3.6.0"
+    "redux": "^3.6.0",
+    "redux-thunk": "^2.2.0"
   },
   "devDependencies": {
     "autoprefixer": "^7.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4930,6 +4930,10 @@ reduce-function-call@^1.0.1:
   dependencies:
     balanced-match "^0.4.2"
 
+redux-thunk@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.2.0.tgz#e615a16e16b47a19a515766133d1e3e99b7852e5"
+
 redux@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/redux/-/redux-3.6.0.tgz#887c2b3d0b9bd86eca2be70571c27654c19e188d"


### PR DESCRIPTION
## Why are you doing this?

We want to be able to charge our readers with Stripe.

There are two ways of implementing Stripe,  using Stripe Checkout (Stripe's pop up box) and using Stripe Elements (custom implementation). This PR, implements the Stripe Checkout version. In order to achieve it, we created a stripeCheckout module which is in charge of injecting the script tag to load the Stripe checkout script. In addition, we created the presentational component called StripePopUpButton which is using the StripeCheckout module. 

In order to be able to interact with the rest of the application, StripeCheckout also defines the StripeCheckout reducer and StripeCheckout Actions. The page that wants to include a `StripePopUpButton` has to import that element and add to the redux state the `stripeCheckoutReducer`.

[**Trello Card**](https://trello.com/c/smabw1ak/603-connect-monthly-contribution-stripe)

## Changes

- Added [redux thunk](https://github.com/gaearon/redux-thunk) for async action creators (for dynamically retrieving the stripe-hosted checkout script, among other things).
- Added a shared stripe helper directory, and a shared component for the stripe button.
- Added a stripe section to the redux store, containing information about the stripe status and a copy of the amount.
