### PR TITLE
Go back to using 'frontend' as the AWS App tag name

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,6 +69,7 @@ maintainer := "Membership <membership.dev@theguardian.com>"
 
 riffRaffPackageType := (packageBin in Debian).value
 riffRaffManifestProjectName := "support:frontend"
+riffRaffPackageName := "frontend"
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")
 riffRaffArtifactResources += (file("cloud-formation/cfn.yaml"), "cfn/cfn.yaml")

--- a/cloud-formation/cfn.yaml
+++ b/cloud-formation/cfn.yaml
@@ -18,7 +18,7 @@ Parameters:
   App:
     Description: Applied directly as a tag
     Type: String
-    Default: support-frontend
+    Default: frontend
   AMI:
     Description: AMI ID
     Type: String

--- a/conf/riff-raff.yaml
+++ b/conf/riff-raff.yaml
@@ -6,16 +6,11 @@ deployments:
     app: frontend
     parameters:
       templatePath: cfn.yaml
-  ami:
-    type: ami-cloudformation-parameter
-    app: frontend
-    parameters:
       amiTags:
         Recipe: xenial-membership
         AmigoStage: PROD
-    dependencies: [cfn]
-  support-frontend:
+  frontend:
     type: autoscaling
-    dependencies: [cfn, ami]
+    dependencies: [cfn]
     parameters:
       bucket: membership-dist


### PR DESCRIPTION
## Why are you doing this?

Setting `riffRaffPackageName := "frontend"` is a better solution than changing the RiffRaff deployment name from `frontend` to `support-frontend` which I unwisely did in a0f1f98 as part of #77. The ELB ended up being called `support-PROD-support-frontend` - awful repetition of 'support', yuck!

This commit also includes an improving RiffRaff config change suggested in passing by Simon Hildrew: `amiTags` are a valid parameter for [`cloud-formation`](https://riffraff.gutools.co.uk/docs/magenta-lib/types#cloudformation) types, so you don't need a separate `ami-cloudformation-parameter` entry - thus saving several lines of config!



