### PR TITLE
Change Default One-Off Contrib To 50

### DIFF
--- a/assets/pages/bundles-landing/reducers/__tests__/__snapshots__/reducersTest.js.snap
+++ b/assets/pages/bundles-landing/reducers/__tests__/__snapshots__/reducersTest.js.snap
@@ -7,7 +7,7 @@ Object {
     "amount": Object {
       "oneOff": Object {
         "userDefined": false,
-        "value": "25",
+        "value": "50",
       },
       "recurring": Object {
         "userDefined": false,

--- a/assets/pages/bundles-landing/reducers/reducers.js
+++ b/assets/pages/bundles-landing/reducers/reducers.js
@@ -49,7 +49,7 @@ const initialContrib: ContribState = {
       userDefined: false,
     },
     oneOff: {
-      value: '25',
+      value: '50',
       userDefined: false,
     },
   },


### PR DESCRIPTION
## Why are you doing this?

The preselected amount on the [contributions site](https://contribute.theguardian.com/uk) is £50, we should make it the same on support.

[**Trello Card**](https://trello.com/c/FLZ4gFH5/625-highlight-50-instead-of-20-on-supporttheguardian)

## Changes

- Set default one-off contribution state to have a value of £50.

## Screenshots

![contrib-amount](https://user-images.githubusercontent.com/5131341/27093306-19039af2-505e-11e7-828e-848df2120dba.png)
