### PR TITLE
Add CloudFormation policy to allow access to the support-workers state machine

### DIFF
--- a/cloud-formation/cfn.yaml
+++ b/cloud-formation/cfn.yaml
@@ -115,6 +115,15 @@ Resources:
                 - logs:PutLogEvents
                 - logs:DescribeLogStreams
                 Resource: arn:aws:logs:*:*:*
+        - PolicyName: StateMachines
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                - states:ListStateMachines
+                - states:StartExecution
+                Resource: arn:aws:states:*:*:*
 
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile

--- a/cloud-formation/validate.sh
+++ b/cloud-formation/validate.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+aws --region eu-west-1 cloudformation validate-template --template-body file://cfn.yaml


### PR DESCRIPTION
And add a validation script for the CloudFormation template

## Why are you doing this?
To enable support-frontend to discover the support-workers step function and trigger an execution.

[**Trello Card**](https://trello.com/c/uyoRAM2L/643-add-necessary-policies-to-support-frontend-to-allow-it-to-call-support-workers)

