### PR TITLE
Rename the private conf file

### DIFF
--- a/cloud-formation/cfn.yaml
+++ b/cloud-formation/cfn.yaml
@@ -71,12 +71,12 @@ Resources:
         Fn::Base64: !Sub |
           #!/bin/bash -ev
           mkdir /etc/gu
-          aws --region ${AWS::Region} s3 cp s3://membership-private/${Stage}/support.private.conf /etc/gu
+          aws --region ${AWS::Region} s3 cp s3://membership-private/${Stage}/support-frontend.private.conf /etc/gu
           aws --region ${AWS::Region} s3 cp s3://membership-dist/${Stack}/${Stage}/${App}/support-frontend_1.0-SNAPSHOT_all.deb /tmp
           dpkg -i /tmp/support-frontend_1.0-SNAPSHOT_all.deb
           /opt/cloudwatch-logs/configure-logs application ${Stack} ${Stage} ${App} /var/log/support-frontend/application.log
-          chown ${App} /etc/gu/support.private.conf
-          chmod 0600 /etc/gu/support.private.conf
+          chown ${App} /etc/gu/support-frontend.private.conf
+          chmod 0600 /etc/gu/support-frontend.private.conf
   AppRole:
     Type: AWS::IAM::Role
     Properties:
@@ -96,7 +96,7 @@ Resources:
             Statement:
               - Effect: Allow
                 Action: s3:GetObject
-                Resource: !Sub arn:aws:s3:::membership-private/${Stage}/support.private.conf
+                Resource: !Sub arn:aws:s3:::membership-private/${Stage}/support-frontend.private.conf
         - PolicyName: UpdateSSHKeys
           PolicyDocument:
             Version: 2012-10-17

--- a/conf/CODE.public.conf
+++ b/conf/CODE.public.conf
@@ -1,6 +1,6 @@
 # NO SECRETS (ie credentials) SHOULD GO IN THIS FILE
 #
-# The secrets file is stored in S3 - it's called 'support.private.conf' and will pull in the
+# The secrets file is stored in S3 - it's called 'support-frontend.private.conf' and will pull in the
 # correct "[STAGE].public.conf" file with an include.
 #
 # This file should be line-for-line comparable with other "[STAGE].public.conf" files

--- a/conf/DEV.public.conf
+++ b/conf/DEV.public.conf
@@ -1,6 +1,6 @@
 # NO SECRETS (ie credentials) SHOULD GO IN THIS FILE
 #
-# The secrets file is stored in S3 - it's called 'support.private.conf' and will pull in the
+# The secrets file is stored in S3 - it's called 'support-frontend.private.conf' and will pull in the
 # correct "[STAGE].public.conf" file with an include.
 #
 # This file should be line-for-line comparable with other "[STAGE].public.conf" files

--- a/conf/PROD.public.conf
+++ b/conf/PROD.public.conf
@@ -1,6 +1,6 @@
 # NO SECRETS (ie credentials) SHOULD GO IN THIS FILE
 #
-# The secrets file is stored in S3 - it's called 'support.private.conf' and will pull in the
+# The secrets file is stored in S3 - it's called 'support-frontend.private.conf' and will pull in the
 # correct "[STAGE].public.conf" file with an include.
 #
 # This file should be line-for-line comparable with other "[STAGE].public.conf" files

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,4 +1,4 @@
 play.application.loader = "wiring.AppLoader"
 
 #### Import private keys
-include file("/etc/gu/support.private.conf")
+include file("/etc/gu/support-frontend.private.conf")

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -12,7 +12,7 @@ You need all 3 of these running to have a working development environment.
 
 Download config from S3: 
 
-```$ aws s3 cp s3://membership-private/DEV/support.private.conf /etc/gu/support.private.conf --profile membership```
+```$ aws s3 cp s3://membership-private/DEV/support-frontend.private.conf /etc/gu/support-frontend.private.conf --profile membership```
 
 Install [sbt](http://www.scala-sbt.org/download.html), and start the [Play server](https://www.playframework.com/)
 running on port 9110, hot-reloading the server-side code:


### PR DESCRIPTION
## Why are you doing this?

Currently support-workers and support-frontend both have a private conf file called support.private.conf which means that it is difficult to work on them both locally as the conf files either overwrite each other or have to be merged

[Trello card here](https://trello.com/c/kMjYGnXa/649-rename-private-conf-file-for-support-projects-to-allow-local-development-on-both-projects)