### PR TITLE
User Reducer

### DIFF
--- a/assets/components/displayName/displayName.jsx
+++ b/assets/components/displayName/displayName.jsx
@@ -3,6 +3,7 @@
 // ----- Imports ----- //
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import Svg from 'components/svg/svg';
 
@@ -16,7 +17,7 @@ type PropTypes = {
 
 // ----- Component ----- //
 
-export default function DisplayName(props: PropTypes) {
+function DisplayName(props: PropTypes) {
 
   return (
     <div className="component-display-name">
@@ -26,3 +27,19 @@ export default function DisplayName(props: PropTypes) {
   );
 
 }
+
+
+// ----- Map State/Props ----- //
+
+function mapStateToProps(state) {
+
+  return {
+    name: state.user.displayName,
+  };
+
+}
+
+
+// ----- Exports ----- //
+
+export default connect(mapStateToProps)(DisplayName);

--- a/assets/components/stripePopUpButton/stripePopUpButton.jsx
+++ b/assets/components/stripePopUpButton/stripePopUpButton.jsx
@@ -23,7 +23,7 @@ type PropTypes = {
 };
 
 
-// ----- Functions ----- //
+// ----- Component ----- //
 
 const StripePopUpButton = (props: PropTypes) => {
 
@@ -41,6 +41,9 @@ const StripePopUpButton = (props: PropTypes) => {
   );
 
 };
+
+
+// ----- Map State/Props ----- //
 
 function mapStateToProps(state) {
 

--- a/assets/helpers/user.js
+++ b/assets/helpers/user.js
@@ -1,12 +1,63 @@
 // @flow
 
+// ----- Types ----- //
+
 type User = {
-  email: string,
+  email: ?string,
   displayName: ?string,
   firstName: ?string,
   lastName: ?string,
 };
 
-const user: ?User = (window.guardian || {}).user;
+type Action =
+  | { type: 'SET_FIRST_NAME', name: string }
+  | { type: 'SET_LAST_NAME', name: string }
+  ;
 
-export default user;
+
+// ----- Setup ----- //
+
+const initialState: User = window.guardian && window.guardian.user ? {
+  email: window.guardian.user.email,
+  displayName: window.guardian.user.displayName,
+  firstName: window.guardian.user.firstName,
+  lastName: window.guardian.user.lastName,
+} : {
+  email: null,
+  displayName: null,
+  firstName: null,
+  lastName: null,
+};
+
+
+// ----- Actions ----- //
+
+export function setFirstName(name: string): Action {
+  return { type: 'SET_FIRST_NAME', name };
+}
+
+export function setLastName(name: string): Action {
+  return { type: 'SET_LAST_NAME', name };
+}
+
+
+// ----- Exports ----- //
+
+export default function userReducer(
+  state: User = initialState,
+  action: Action): User {
+
+  switch (action.type) {
+
+    case 'SET_FIRST_NAME':
+      return Object.assign({}, state, { firstName: action.name });
+
+    case 'SET_LAST_NAME':
+      return Object.assign({}, state, { lastName: action.name });
+
+    default:
+      return state;
+
+  }
+
+}

--- a/assets/helpers/user/userActions.js
+++ b/assets/helpers/user/userActions.js
@@ -1,0 +1,20 @@
+// @flow
+
+// ----- Types ----- //
+
+export type Action =
+  | { type: 'SET_FIRST_NAME', name: string }
+  | { type: 'SET_LAST_NAME', name: string }
+  ;
+
+
+// ----- Actions Creators ----- //
+
+export function setFirstName(name: string): Action {
+  return { type: 'SET_FIRST_NAME', name };
+}
+
+export function setLastName(name: string): Action {
+  return { type: 'SET_LAST_NAME', name };
+}
+

--- a/assets/helpers/user/userReducer.js
+++ b/assets/helpers/user/userReducer.js
@@ -1,5 +1,10 @@
 // @flow
 
+// ----- Imports ----- //
+
+import type { Action } from './userActions';
+
+
 // ----- Types ----- //
 
 type User = {
@@ -8,11 +13,6 @@ type User = {
   firstName: ?string,
   lastName: ?string,
 };
-
-type Action =
-  | { type: 'SET_FIRST_NAME', name: string }
-  | { type: 'SET_LAST_NAME', name: string }
-  ;
 
 
 // ----- Setup ----- //
@@ -30,18 +30,7 @@ const initialState: User = window.guardian && window.guardian.user ? {
 };
 
 
-// ----- Actions ----- //
-
-export function setFirstName(name: string): Action {
-  return { type: 'SET_FIRST_NAME', name };
-}
-
-export function setLastName(name: string): Action {
-  return { type: 'SET_LAST_NAME', name };
-}
-
-
-// ----- Exports ----- //
+// ----- Reducer ----- //
 
 export default function userReducer(
   state: User = initialState,

--- a/assets/pages/monthly-contributions/actions/monthlyContributionsActions.js
+++ b/assets/pages/monthly-contributions/actions/monthlyContributionsActions.js
@@ -10,8 +10,6 @@ import validateContribution from '../helpers/validation';
 
 export type Action =
   | { type: 'SET_CONTRIB_VALUE', value: number }
-  | { type: 'SET_FIRST_NAME', name: string }
-  | { type: 'SET_LAST_NAME', name: string }
   | { type: 'CHECKOUT_ERROR', message: string }
   ;
 
@@ -24,14 +22,6 @@ function setContribValue(value: number): Action {
 
 export function checkoutError(message: string): Action {
   return { type: 'CHECKOUT_ERROR', message };
-}
-
-export function setFirstName(name: string): Action {
-  return { type: 'SET_FIRST_NAME', name };
-}
-
-export function setLastName(name: string): Action {
-  return { type: 'SET_LAST_NAME', name };
 }
 
 export function setContribAmount(amount: string): Function {

--- a/assets/pages/monthly-contributions/components/nameForm.jsx
+++ b/assets/pages/monthly-contributions/components/nameForm.jsx
@@ -10,7 +10,7 @@ import TextInput from 'components/textInput/textInput';
 import {
   setFirstName,
   setLastName,
-} from 'helpers/user';
+} from 'helpers/user/userActions';
 
 
 // ----- Types ----- //

--- a/assets/pages/monthly-contributions/components/nameForm.jsx
+++ b/assets/pages/monthly-contributions/components/nameForm.jsx
@@ -10,7 +10,7 @@ import TextInput from 'components/textInput/textInput';
 import {
   setFirstName,
   setLastName,
-} from '../actions/monthlyContributionsActions';
+} from 'helpers/user';
 
 
 // ----- Types ----- //
@@ -52,8 +52,8 @@ function NameForm(props: PropTypes) {
 function mapStateToProps(state) {
 
   return {
-    firstName: state.monthlyContrib.firstName,
-    lastName: state.monthlyContrib.lastName,
+    firstName: state.user.firstName,
+    lastName: state.user.lastName,
   };
 
 }

--- a/assets/pages/monthly-contributions/components/paymentMethods.jsx
+++ b/assets/pages/monthly-contributions/components/paymentMethods.jsx
@@ -3,13 +3,18 @@
 // ----- Imports ----- //
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import StripePopUpButton from 'components/stripePopUpButton/stripePopUpButton';
 import postCheckout from '../helpers/ajax';
 
+
+// ----- Types ----- //
+
 type PropTypes = {
-    email: string,
-}
+  email: string,
+};
+
 
 // ----- Component ----- //
 
@@ -24,6 +29,17 @@ function PaymentMethods(props: PropTypes) {
 }
 
 
+// ----- Map State/Props ----- //
+
+function mapStateToProps(state) {
+
+  return {
+    email: state.user.email,
+  };
+
+}
+
+
 // ----- Exports ----- //
 
-export default PaymentMethods;
+export default connect(mapStateToProps)(PaymentMethods);

--- a/assets/pages/monthly-contributions/helpers/ajax.js
+++ b/assets/pages/monthly-contributions/helpers/ajax.js
@@ -42,8 +42,8 @@ function requestData(paymentToken: string, getState: Function) {
       stripeToken: paymentToken,
     },
     country: state.monthlyContrib.country,
-    firstName: state.monthlyContrib.firstName,
-    lastName: state.monthlyContrib.lastName,
+    firstName: state.user.firstName,
+    lastName: state.user.lastName,
   };
 
   return {

--- a/assets/pages/monthly-contributions/monthlyContributions.jsx
+++ b/assets/pages/monthly-contributions/monthlyContributions.jsx
@@ -20,13 +20,12 @@ import * as ga from 'helpers/ga';
 import * as abTest from 'helpers/abtest';
 import * as logger from 'helpers/logger';
 import getQueryParameter from 'helpers/url';
-import user from 'helpers/user';
 import PaymentMethods from './components/paymentMethods';
 import NameForm from './components/nameForm';
 import ContribAmount from './components/contribAmount';
 import reducer from './reducers/reducers';
 
-import { setContribAmount, setFirstName, setLastName } from './actions/monthlyContributionsActions';
+import { setContribAmount } from './actions/monthlyContributionsActions';
 
 // ----- AB Tests ----- //
 
@@ -51,8 +50,7 @@ const store = createStore(reducer, applyMiddleware(thunkMiddleware));
 
 // Retrieves the contrib amount from the url and sends it to the redux store.
 store.dispatch(setContribAmount(getQueryParameter('contributionValue', '5')));
-store.dispatch(setFirstName((user || {}).firstName || ''));
-store.dispatch(setLastName((user || {}).lastName || ''));
+
 
 // ----- Render ----- //
 
@@ -69,11 +67,11 @@ const content = (
           <ContribAmount />
         </CheckoutSection>
         <CheckoutSection heading="Your details" className="monthly-contrib__your-details">
-          <DisplayName name={(user || {}).displayName || 'SignedInUser'} />
+          <DisplayName />
           <NameForm />
         </CheckoutSection>
         <CheckoutSection heading="Payment methods" className="monthly-contrib__payment-methods">
-          <PaymentMethods email={(user || {}).email || ''} />
+          <PaymentMethods />
         </CheckoutSection>
         <CheckoutSection className="monthly-contrib__payment-methods">
           <TermsPrivacy

--- a/assets/pages/monthly-contributions/reducers/reducers.js
+++ b/assets/pages/monthly-contributions/reducers/reducers.js
@@ -5,7 +5,7 @@
 import { combineReducers } from 'redux';
 
 import stripeCheckout from 'helpers/stripeCheckout/stripeCheckoutReducer';
-import user from 'helpers/user';
+import user from 'helpers/user/userReducer';
 
 import type { Action } from '../actions/monthlyContributionsActions';
 

--- a/assets/pages/monthly-contributions/reducers/reducers.js
+++ b/assets/pages/monthly-contributions/reducers/reducers.js
@@ -5,6 +5,8 @@
 import { combineReducers } from 'redux';
 
 import stripeCheckout from 'helpers/stripeCheckout/stripeCheckoutReducer';
+import user from 'helpers/user';
+
 import type { Action } from '../actions/monthlyContributionsActions';
 
 
@@ -13,8 +15,6 @@ import type { Action } from '../actions/monthlyContributionsActions';
 export type State = {
   amount: number,
   country: string,
-  firstName: ?string,
-  lastName: ?string,
   error: ?string,
 };
 
@@ -24,8 +24,6 @@ export type State = {
 const initialState: State = {
   amount: 5,
   country: 'GB',
-  firstName: null,
-  lastName: null,
   error: null,
 };
 
@@ -40,12 +38,6 @@ function monthlyContrib(
 
     case 'SET_CONTRIB_VALUE':
       return Object.assign({}, state, { amount: action.value });
-
-    case 'SET_FIRST_NAME':
-      return Object.assign({}, state, { firstName: action.name });
-
-    case 'SET_LAST_NAME':
-      return Object.assign({}, state, { lastName: action.name });
 
     case 'CHECKOUT_ERROR':
       return Object.assign({}, state, { error: action.message });
@@ -62,5 +54,6 @@ function monthlyContrib(
 
 export default combineReducers({
   monthlyContrib,
+  user,
   stripeCheckout,
 });


### PR DESCRIPTION
## Why are you doing this?

Where possible, we'd like to consolidate our state in the redux store. This turns the user object into a reusable state object in the store, and moves management of first and last name under the same object.

This will hopefully make more of our user-related code reusable across pages.

[**Trello Card**](https://trello.com/c/k3rPcOZR/611-create-a-user-reducer-to-populate-user-data-from-play-backend)

## Changes

- Hooked `displayName` and `paymentMethods` up to redux store, to read from the user state object.
- Built out actions and a reducer for the user state in the `user` module. Set initial state from the guardian window object.
- Moved `firstName` and `lastName` update management out of `monthlyContributions` and into the `user` modules.
- Wired up the rest of monthly contributions (`nameForm.jsx`, `monthlyContributions.jsx`) to use the new redux-based user object.
- Updated `ajax` code to use new user state object.
- Stripped user-related code out of the monthly contributions reducer, and included the user reducer instead.

## Screenshots

If this is successful, nothing should be different...
