### PR TITLE
Fix Safari LocalStorage Bug

### DIFF
--- a/assets/helpers/abtest.js
+++ b/assets/helpers/abtest.js
@@ -4,11 +4,15 @@
 
 import * as ophan from 'ophan';
 import * as cookie from './cookie';
+import { localStorageAvailable } from './utilities';
+
 
 // ----- Setup ----- //
 
 const MVT_COOKIE: string = 'GU_mvt_id';
 const MVT_MAX: number = 1000000;
+
+const localStorageExists = localStorageAvailable();
 
 
 // ----- Types ----- //
@@ -89,14 +93,22 @@ function getMvtId(): number {
 
 function getLocalStorageParticipation(): Participations {
 
-  const abTests = localStorage.getItem('gu.support.abTests');
+  let abTests = null;
+
+  if (localStorageExists) {
+    abTests = localStorage.getItem('gu.support.abTests');
+  }
 
   return abTests ? JSON.parse(abTests) : {};
 
 }
 
 function setLocalStorageParticipation(participation): void {
-  localStorage.setItem('gu.support.abTests', JSON.stringify(participation));
+
+  if (localStorageExists) {
+    localStorage.setItem('gu.support.abTests', JSON.stringify(participation));
+  }
+
 }
 
 function getUrlParticipation(): ?Participations {

--- a/assets/helpers/abtest.js
+++ b/assets/helpers/abtest.js
@@ -4,15 +4,13 @@
 
 import * as ophan from 'ophan';
 import * as cookie from './cookie';
-import { localStorageAvailable } from './utilities';
+import * as storage from './storage';
 
 
 // ----- Setup ----- //
 
 const MVT_COOKIE: string = 'GU_mvt_id';
 const MVT_MAX: number = 1000000;
-
-const localStorageExists = localStorageAvailable();
 
 
 // ----- Types ----- //
@@ -93,22 +91,14 @@ function getMvtId(): number {
 
 function getLocalStorageParticipation(): Participations {
 
-  let abTests = null;
-
-  if (localStorageExists) {
-    abTests = localStorage.getItem('gu.support.abTests');
-  }
+  const abTests = storage.getItem('gu.support.abTests');
 
   return abTests ? JSON.parse(abTests) : {};
 
 }
 
 function setLocalStorageParticipation(participation): void {
-
-  if (localStorageExists) {
-    localStorage.setItem('gu.support.abTests', JSON.stringify(participation));
-  }
-
+  storage.setItem('gu.support.abTests', JSON.stringify(participation));
 }
 
 function getUrlParticipation(): ?Participations {

--- a/assets/helpers/storage.js
+++ b/assets/helpers/storage.js
@@ -1,0 +1,38 @@
+// @flow
+
+// ----- Setup ----- //
+
+// Checks if localStorage is usable. Need to do more than check if
+// 'window.localStorage' is defined, because Safari in private browsing
+// mode is weird and sets the storage size to 0.
+let localStorageAvailable = false;
+
+try {
+
+  localStorage.setItem('storageTest', 'testValue');
+  localStorageAvailable = localStorage.getItem('storageTest') === 'testValue';
+
+} catch (e) {
+  localStorageAvailable = false;
+}
+
+
+// ----- Exports ----- //
+
+export function setItem(key: string, item: string): void {
+
+  if (localStorageAvailable) {
+    localStorage.setItem(key, item);
+  }
+
+}
+
+export function getItem(key: string): ?string {
+
+  if (localStorageAvailable) {
+    return localStorage.getItem(key);
+  }
+
+  return null;
+
+}

--- a/assets/helpers/utilities.js
+++ b/assets/helpers/utilities.js
@@ -25,8 +25,7 @@ export function localStorageAvailable(): boolean {
   try {
 
     localStorage.setItem('storageTest', 'testValue');
-    localStorage.getItem('storageTest');
-    return true;
+    return localStorage.getItem('storageTest') === 'testValue';
 
   } catch (e) {
     return false;

--- a/assets/helpers/utilities.js
+++ b/assets/helpers/utilities.js
@@ -16,3 +16,20 @@ export function descending(a: number, b: number): number {
 export function roundDp(num: number, dps: number = 2) {
   return Math.round(num * (10 ** dps)) / (10 ** dps);
 }
+
+// Checks if localStorage is usable. Need to do more than check if
+// 'window.localStorage' is defined, because Safari in private browsing
+// mode is weird and sets the storage size to 0.
+export function localStorageAvailable(): boolean {
+
+  try {
+
+    localStorage.setItem('storageTest', 'testValue');
+    localStorage.getItem('storageTest');
+    return true;
+
+  } catch (e) {
+    return false;
+  }
+
+}

--- a/assets/helpers/utilities.js
+++ b/assets/helpers/utilities.js
@@ -16,19 +16,3 @@ export function descending(a: number, b: number): number {
 export function roundDp(num: number, dps: number = 2) {
   return Math.round(num * (10 ** dps)) / (10 ** dps);
 }
-
-// Checks if localStorage is usable. Need to do more than check if
-// 'window.localStorage' is defined, because Safari in private browsing
-// mode is weird and sets the storage size to 0.
-export function localStorageAvailable(): boolean {
-
-  try {
-
-    localStorage.setItem('storageTest', 'testValue');
-    return localStorage.getItem('storageTest') === 'testValue';
-
-  } catch (e) {
-    return false;
-  }
-
-}


### PR DESCRIPTION
## Why are you doing this?

In Private Browsing mode, Safari does weird things to localStorage. It's still available on the window object, but it has a quota of 0 (meaning 0 space to store things in, rather than the default 5MB). This was breaking our JavaScript, since we assumed up until now that if it was available then it was usable.

The code making use of localStorage was in the `abtest` module. This PR adds a utility function to check for a functioning implementation of localStorage, and only attempts to use it in the abtests module if it exists.

I think our abtests should still work fine in this case, thoughts @svillafe?

[**Trello Card**](https://trello.com/c/riIg2iXz/627-safari-private-browsing-localstorage-fallback)

## Changes

- Added utility function to check for functioning localStorage.
- Only use localStorage in `abtest` module if it's available.
