### PR TITLE
Redirect users who are already recurring to existing-contributor page

### DIFF
--- a/app/config/Configuration.scala
+++ b/app/config/Configuration.scala
@@ -13,4 +13,6 @@ class Configuration {
   lazy val identity = new Identity(config.getConfig("identity"))
 
   lazy val supportUrl = config.getString("support.url")
+
+  lazy val membersDataServiceApiUrl = config.getString("membersDataService.api.url")
 }

--- a/app/controllers/MonthlyContributions.scala
+++ b/app/controllers/MonthlyContributions.scala
@@ -30,7 +30,7 @@ class MonthlyContributions(
 
   import actionRefiners._
 
-  def displayForm: Action[AnyContent] = AuthenticatedAction.async { implicit request =>
+  def displayForm: Action[AnyContent] = AuthenticatedTestUserAction.async { implicit request =>
     identityService.getUser(request.user).semiflatMap { fullUser =>
       isMonthlyContributor(request.user.credentials) map {
         case Some(true) => Redirect("/monthly-contributions/existing-contributor")

--- a/app/controllers/MonthlyContributions.scala
+++ b/app/controllers/MonthlyContributions.scala
@@ -1,31 +1,51 @@
 package controllers
 
+import assets.AssetsResolver
 import lib.actions.ActionRefiners
 import lib.stepfunctions.{CreateMonthlyContributorRequest, MonthlyContributionsClient}
-import play.api.mvc.{Action, Controller}
+import play.api.mvc.{Action, AnyContent, Controller}
 import play.api.libs.circe.Circe
-
 import scala.concurrent.ExecutionContext
 import cats.implicits._
-import com.typesafe.scalalogging.LazyLogging
-import com.gu.identity.play.IdUser
+import com.gu.identity.play.{AccessCredentials, IdUser}
 import lib.PlayImplicits._
-import services.IdentityService
+import services.{IdentityService, MembersDataService}
+import services.MembersDataService.UserNotFound
 import com.gu.support.workers.model.User
 import com.typesafe.scalalogging.LazyLogging
-
 import lib.TestUsers
+import scala.concurrent.Future
+import views.html.authenticatedFullUserReactTemplate
 
 class MonthlyContributions(
     implicit
     client: MonthlyContributionsClient,
+    val assets: AssetsResolver,
     actionRefiners: ActionRefiners,
     exec: ExecutionContext,
+    membersDataService: MembersDataService,
     identityService: IdentityService,
     testUsers: TestUsers
 ) extends Controller with Circe with LazyLogging {
 
   import actionRefiners._
+
+  def displayForm: Action[AnyContent] = AuthenticatedAction.async { implicit request =>
+    identityService.getUser(request.user).semiflatMap { fullUser =>
+      isMonthlyContributor(request.user.credentials) map {
+        case Some(true) => Redirect("/monthly-contributions/existing-contributor")
+        case Some(false) | None =>
+          Ok(
+            authenticatedFullUserReactTemplate(
+              title = "Support the Guardian | Monthly Contributions",
+              id = "monthly-contributions-page",
+              js = "monthlyContributionsPage.js",
+              user = fullUser
+            )
+          )
+      }
+    } getOrElse InternalServerError
+  }
 
   def create: Action[CreateMonthlyContributorRequest] = AuthenticatedAction.async(circe.json[CreateMonthlyContributorRequest]) { implicit request =>
     logger.info(s"[${request.uuid}] User ${request.user.id} is attempting to create a new monthly contribution")
@@ -56,5 +76,19 @@ class MonthlyContributions(
       allowGURelatedMail = user.statusFields.flatMap(_.receiveGnmMarketing).getOrElse(false),
       isTestUser = testUsers.isTestUser(user.publicFields.displayName)
     )
+  }
+
+  private def isMonthlyContributor(credentials: AccessCredentials) = credentials match {
+    case cookies: AccessCredentials.Cookies =>
+      membersDataService.userAttributes(cookies).fold(
+        {
+          case UserNotFound => Some(false)
+          case error =>
+            logger.error(s"Failed to fetch user attributes from members data service: $error")
+            None
+        },
+        { response => Some(response.contentAccess.recurringContributor) }
+      )
+    case _ => Future.successful(None)
   }
 }

--- a/app/services/MembersDataService.scala
+++ b/app/services/MembersDataService.scala
@@ -1,0 +1,83 @@
+package services
+
+import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.control.NonFatal
+import play.api.data.validation.ValidationError
+import play.api.libs.ws.{WSClient, WSResponse}
+import play.api.libs.json.{JsPath, JsValue, Json, Reads}
+import play.api.http.Status
+import cats.data.EitherT
+import cats.syntax.either._
+import com.gu.identity.play.AccessCredentials
+
+import scala.util.{Failure, Success, Try}
+
+object MembersDataService {
+
+  object ContentAccess {
+    implicit val jf = Json.format[ContentAccess]
+  }
+
+  case class ContentAccess(recurringContributor: Boolean)
+
+  object UserAttributes {
+    implicit val jf = Json.format[UserAttributes]
+  }
+
+  case class UserAttributes(userId: String, contentAccess: ContentAccess)
+
+  trait MembersDataServiceError
+
+  object UserNotFound extends MembersDataServiceError
+
+  case class JsonValidationError(errors: Seq[(JsPath, Seq[ValidationError])]) extends MembersDataServiceError
+
+  case class UnexpectedResponseStatus(statusCode: Int) extends MembersDataServiceError
+
+  case class JsonParseError(e: Throwable) extends MembersDataServiceError
+
+  case class WSClientError(e: Throwable) extends MembersDataServiceError
+
+}
+
+class MembersDataService(apiUrl: String)(implicit val ec: ExecutionContext, wsClient: WSClient) {
+
+  import MembersDataService._
+
+  def userAttributes(implicit accessCredentials: AccessCredentials.Cookies): EitherT[Future, MembersDataServiceError, UserAttributes] =
+    get[UserAttributes](s"$apiUrl/user-attributes/me")
+
+  private def get[T](url: String)(implicit credentials: AccessCredentials.Cookies, reader: Reads[T]): EitherT[Future, MembersDataServiceError, T] = EitherT {
+    wsClient
+      .url(url)
+      .withHeaders("Cookie" -> credentials.cookies.map(c => s"${c.name}=${c.value}").mkString("; "))
+      .withRequestTimeout(1.second)
+      .get()
+      .map(responseAsJson[T])
+      .recover {
+        case NonFatal(e) => WSClientError(e).asLeft
+      }
+  }
+
+  private def responseAsJson[T](response: WSResponse)(implicit reader: Reads[T]) = response.status match {
+    case Status.OK =>
+      for {
+        json <- parseJson(response)
+        obj <- validateJson[T](json)
+      } yield obj
+
+    case Status.NOT_FOUND => UserNotFound.asLeft
+
+    case _ => UnexpectedResponseStatus(response.status).asLeft
+  }
+
+  private def parseJson(response: WSResponse) = Try { response.json } match {
+    case Success(json) => json.asRight
+    case Failure(e) => JsonParseError(e).asLeft
+  }
+
+  private def validateJson[T](json: JsValue)(implicit reader: Reads[T]) =
+    json.validate[T].asEither.leftMap(JsonValidationError.apply)
+
+}

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -13,7 +13,7 @@ import monitoring.SentryLogging
 import play.api.libs.ws.ahc.AhcWSComponents
 import play.api.mvc.EssentialFilter
 import play.filters.gzip.GzipFilter
-import services.{AuthenticationService, IdentityService}
+import services.{AuthenticationService, IdentityService, MembersDataService}
 import lib.TestUsers
 
 trait AppComponents extends PlayComponents with AhcWSComponents {
@@ -24,6 +24,7 @@ trait AppComponents extends PlayComponents with AhcWSComponents {
 
   implicit lazy val assetsResolver = new AssetsResolver("/assets/", "assets.map", environment)
 
+  implicit lazy val membersDataService = new MembersDataService(config.membersDataServiceApiUrl)
   implicit lazy val identityService = new IdentityService(config.identity.apiUrl, config.identity.apiClientToken)
 
   implicit lazy val actionRefiners = new ActionRefiners(

--- a/conf/CODE.public.conf
+++ b/conf/CODE.public.conf
@@ -11,3 +11,4 @@ identity.webapp.url="https://profile.code.dev-theguardian.com"
 identity.api.url="https://idapi.code.dev-theguardian.com"
 identity.production.keys=false
 support.url="https://support.code.dev-theguardian.com"
+membersDataService.api.url="https://members-data-api.code.dev-theguardian.com"

--- a/conf/DEV.public.conf
+++ b/conf/DEV.public.conf
@@ -11,3 +11,4 @@ identity.webapp.url="https://profile-origin.thegulocal.com"
 identity.api.url="https://idapi.code.dev-theguardian.com"
 identity.production.keys=false
 support.url="https://support.thegulocal.com"
+membersDataService.api.url="https://members-data-api.thegulocal.com"

--- a/conf/PROD.public.conf
+++ b/conf/PROD.public.conf
@@ -11,3 +11,4 @@ identity.webapp.url="https://profile.theguardian.com"
 identity.api.url="https://idapi.theguardian.com"
 identity.production.keys=true
 support.url="https://support.theguardian.com"
+membersDataService.api.url="https://members-data-api.theguardian.com"

--- a/conf/routes
+++ b/conf/routes
@@ -8,7 +8,7 @@ GET /healthcheck                controllers.Application.healthcheck
 GET /uk                         controllers.Application.reactTemplate(title="Support the Guardian", id="bundles-landing-page", js="bundlesLandingPage.js")
 GET /                           controllers.Default.redirect(to = "/uk")
 
-GET /monthly-contributions      controllers.Application.authenticatedFullUserReactTemplate(title="Support the Guardian | Monthly Contributions", id="monthly-contributions-page", js="monthlyContributionsPage.js")
+GET /monthly-contributions           controllers.MonthlyContributions.displayForm
 GET /monthly-contributions/thankyou  controllers.Application.reactTemplate(title="Support the Guardian | Thank You", id="monthly-contributions-thankyou-page", js="monthlyContributionsThankyouPage.js")
 POST /monthly-contributions/create   controllers.MonthlyContributions.create
 

--- a/test/controllers/MonthlyContributionsTest.scala
+++ b/test/controllers/MonthlyContributionsTest.scala
@@ -1,0 +1,128 @@
+package controllers
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
+import cats.data.EitherT
+import cats.implicits._
+import org.scalatest.mockito.MockitoSugar._
+import org.scalatest.{MustMatchers, WordSpec}
+import org.scalatest.OptionValues._
+import org.mockito.Mockito.when
+import org.mockito.ArgumentMatchers.{any, eq => argEq}
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import play.api.mvc.{RequestHeader, Result}
+import play.api.Environment
+import assets.AssetsResolver
+import com.gu.identity.play.PublicFields
+import com.gu.identity.play.{AccessCredentials, AuthenticatedIdUser, IdMinimalUser, IdUser}
+import lib.TestUsers
+import lib.actions.ActionRefiners
+import lib.stepfunctions.MonthlyContributionsClient
+import services.{IdentityService, MembersDataService}
+import services.MembersDataService._
+
+class MonthlyContributionsTest extends WordSpec with MustMatchers {
+
+  "GET /monthly-contributors" should {
+
+    "redirect unauthenticated user to signup page" in new DisplayForm {
+      val result = fakeRequestWith(actionRefiner = loggedOutActionRefiner)
+      status(result) mustBe 303
+      header("Location", result).value must startWith("https://identity-url.local")
+    }
+
+    "return internal server error if identity does not return user info" in new DisplayForm {
+      val result = fakeRequestWith(
+        identityService = mockedIdentityService(authenticatedIdUser.user -> "not found".asLeft)
+      )
+      status(result) mustBe 500
+    }
+
+    "redirect to existing-contributor page if user is already a contributor" in new DisplayForm {
+      val attributes = UserAttributes("123", ContentAccess(recurringContributor = true))
+      val result = fakeRequestWith(
+        membersDataService = mockedMembersDataService(credentials -> attributes.asRight)
+      )
+      status(result) mustBe 303
+      header("Location", result) mustBe Some("/monthly-contributions/existing-contributor")
+    }
+
+    "return form if user is not in members api" in new DisplayForm {
+      val result = fakeRequestWith(
+        membersDataService = mockedMembersDataService(credentials -> (UserNotFound: MembersDataServiceError).asLeft)
+      )
+      status(result) mustBe 200
+      contentAsString(result) must include("monthlyContributionsPage.js")
+    }
+
+    "return form if members api fails" in new DisplayForm {
+      val result = fakeRequestWith(
+        membersDataService = mockedMembersDataService(credentials -> (UnexpectedResponseStatus(100): MembersDataServiceError).asLeft)
+      )
+      status(result) mustBe 200
+      contentAsString(result) must include("monthlyContributionsPage.js")
+    }
+
+    "return form if user is not a recurring contributor" in new DisplayForm {
+      val attributes = UserAttributes("123", ContentAccess(recurringContributor = false))
+      val result = fakeRequestWith(
+        membersDataService = mockedMembersDataService(credentials -> attributes.asRight)
+      )
+      status(result) mustBe 200
+      contentAsString(result) must include("monthlyContributionsPage.js")
+    }
+
+    trait DisplayForm {
+      val credentials = AccessCredentials.Cookies("", None)
+
+      val authenticatedIdUser = AuthenticatedIdUser(credentials, IdMinimalUser("123", Some("test-user")))
+
+      private val testUsers = new TestUsers("test") {
+        override def isTestUser(displayName: Option[String]): Boolean = displayName.exists(_.startsWith("test"))
+      }
+
+      private val assetResolver = new AssetsResolver("", "", mock[Environment]) {
+        override def apply(path: String): String = path
+      }
+
+      private val idUser = IdUser("123", "test@gu.com", PublicFields(Some("test-user")), None, None)
+
+      private val loggedInActionRefiner = new ActionRefiners(_ => Some(authenticatedIdUser), "", "", testUsers)
+
+      val loggedOutActionRefiner = new ActionRefiners(_ => None, "https://identity-url.local", "", testUsers)
+
+      def mockedMembersDataService(data: (AccessCredentials.Cookies, Either[MembersDataServiceError, UserAttributes])): MembersDataService = {
+        val membersDataService = mock[MembersDataService]
+        when(
+          membersDataService.userAttributes(data._1)
+        ).thenReturn(EitherT.fromEither[Future](data._2))
+        membersDataService
+      }
+
+      def mockedIdentityService(data: (IdMinimalUser, Either[String, IdUser])): IdentityService = {
+        val m = mock[IdentityService]
+        when(
+          m.getUser(argEq(data._1))(any[RequestHeader], any[ExecutionContext])
+        ).thenReturn(EitherT.fromEither[Future](data._2))
+        m
+      }
+
+      def fakeRequestWith(
+        actionRefiner: ActionRefiners = loggedInActionRefiner,
+        identityService: IdentityService = mockedIdentityService(authenticatedIdUser.user -> idUser.asRight[String]),
+        membersDataService: MembersDataService = mock[MembersDataService]
+      ): Future[Result] = {
+        new MonthlyContributions()(
+          mock[MonthlyContributionsClient],
+          assetResolver,
+          actionRefiner,
+          global,
+          membersDataService,
+          identityService,
+          testUsers
+        ).displayForm(FakeRequest())
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Why are you doing this?

So that existing recurring contributors can't make another recurring contribution

[**Trello Card**](https://trello.com/c/MKT0NGtF/608-implement-the-redirect-mechanism-for-handling-existing-contributors)

## Changes

## Screenshots

