### PR TITLE
Types definition for bundles

### DIFF
--- a/assets/components/featureList/featureList.jsx
+++ b/assets/components/featureList/featureList.jsx
@@ -10,7 +10,7 @@ import React from 'react';
 // Disabling the linter here because it's just buggy...
 /* eslint-disable react/no-unused-prop-types */
 
-type listItem =
+export type ListItem =
   | {| heading: string, text: string |}
   | {| heading: string |}
   | {| text: string |}
@@ -19,7 +19,7 @@ type listItem =
 /* eslint-enable react/no-unused-prop-types */
 
 type PropTypes = {
-  listItems: listItem[],
+  listItems: ListItem[],
 };
 
 
@@ -27,7 +27,7 @@ type PropTypes = {
 
 export default function FeatureList(props: PropTypes) {
 
-  const items = props.listItems.map((item: listItem) => {
+  const items = props.listItems.map((item: ListItem) => {
 
     const itemHeading = item.heading ? <h3>{ item.heading }</h3> : null;
     const itemText = item.text ? <p>{ item.text }</p> : null;

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -7,12 +7,14 @@ import { connect } from 'react-redux';
 
 import FeatureList from 'components/featureList/featureList';
 import RadioToggle from 'components/radioToggle/radioToggle';
+import type { ListItem } from 'components/featureList/featureList';
 import CtaLink from 'components/ctaLink/ctaLink';
 import Bundle from './Bundle';
 import ContribAmounts from './ContribAmounts';
 import { changeContribType } from '../actions/bundlesLandingActions';
 
 import type { Contrib, Amounts } from '../reducers/reducers';
+
 
 // ----- Types ----- //
 
@@ -23,12 +25,49 @@ type PropTypes = {
   toggleContribType: (string) => void,
 };
 
+type ContribBundle = {
+  heading: string,
+  subheading: string,
+  ctaText: string,
+  modifierClass: string,
+  ctaLink: string,
+}
+
+type DigitalBundle = {
+  heading: string,
+  subheading: string,
+  listItems: ListItem[],
+  ctaText: string,
+  modifierClass: string,
+  ctaLink: string,
+}
+
+type PaperBundle = {
+  heading: string,
+  subheading: string,
+  listItems: ListItem[],
+  paperCtaText: string,
+  paperDigCtaText: string,
+  modifierClass: string,
+  paperDigCtaLink: string,
+  paperCtaLink: string,
+}
+
+type BundlesType = {
+  contrib: ContribBundle,
+  digital: DigitalBundle,
+  paper: PaperBundle
+}
+
+
+// ----- Copy ----- //
 
 const contribCopy: ContribBundle = {
   heading: 'contribute',
   subheading: 'from £5/month',
   ctaText: 'Contribute with credit/debit card',
   modifierClass: 'contributions',
+  ctaLink: '',
 };
 
 const digitalCopy: DigitalBundle = {
@@ -49,6 +88,7 @@ const digitalCopy: DigitalBundle = {
   ],
   ctaText: 'Start your 14 day trial',
   modifierClass: 'digital',
+  ctaLink: 'https://subscribe.theguardian.com/p/DXX83X',
 };
 
 const paperCopy: PaperBundle = {
@@ -64,80 +104,26 @@ const paperCopy: PaperBundle = {
     },
     {
       heading: 'All the benefits of a digital subscription',
-      text: 'Avaliable with paper+digital',
+      text: 'Available with paper+digital',
     },
   ],
   paperCtaText: 'Become a paper subscriber',
   paperDigCtaText: 'Become a paper+digital subscriber',
   modifierClass: 'paper',
+  ctaLink: '',
+  paperDigCtaLink: 'https://subscribe.theguardian.com/p/GXX83X',
+  paperCtaLink: 'https://subscribe.theguardian.com/p/GXX83P',
 };
 
-const bundles: Bundles = {
+const bundles: BundlesType = {
   contrib: contribCopy,
   digital: digitalCopy,
   paper: paperCopy,
-}
 };
-
-
-
-
-// ----- Copy ----- //
 
 const ctaLinks = {
   recurring: 'https://membership.theguardian.com/monthly-contribution',
   oneOff: 'https://contribute.theguardian.com/uk',
-  paperOnly: 'https://subscribe.theguardian.com/p/GXX83P',
-  paperDigital: 'https://subscribe.theguardian.com/p/GXX83X',
-  digital: 'https://subscribe.theguardian.com/p/DXX83X',
-};
-
-const bundles = {
-  contrib: {
-    heading: 'contribute',
-    subheading: 'from £5/month',
-    ctaText: 'Contribute with credit/debit card',
-    modifierClass: 'contributions',
-  },
-  digital: {
-    heading: 'digital subscription',
-    subheading: '£11.99/month',
-    listItems: [
-      {
-        heading: 'Ad-free mobile app',
-        text: 'No interruptions means pages load quicker for a clearer reading experience',
-      },
-      {
-        heading: 'Daily tablet edition',
-        text: 'Daily newspaper optimised for tablet; available on Apple, Android and Kindle Fire',
-      },
-      {
-        heading: 'Enjoy on up to 10 devices',
-      },
-    ],
-    ctaText: 'Start your 14 day trial',
-    modifierClass: 'digital',
-  },
-  paper: {
-    heading: 'paper subscription',
-    subheading: 'from £22.06/month',
-    listItems: [
-      {
-        heading: 'Newspaper',
-        text: 'Choose the package you want: Everyday, Sixday, Weekend and Sunday',
-      },
-      {
-        heading: 'Save money off the retail price',
-      },
-      {
-        heading: 'All the benefits of a digital subscription',
-        text: 'Avaliable with paper+digital',
-      },
-    ],
-    paperCtaText: 'Become a paper subscriber',
-    paperDigCtaText: 'Become a paper+digital subscriber',
-    modifierClass: 'paper',
-  },
 };
 
 const contribToggle = {
@@ -156,7 +142,7 @@ const contribToggle = {
 
 // ----- Functions ----- //
 
-function getContribAttrs({ contribType, contribAmount, intCmp }) {
+function getContribAttrs({ contribType, contribAmount, intCmp }): ContribBundle {
 
   const contType = contribType === 'RECURRING' ? 'recurring' : 'oneOff';
   const amountParam = contType === 'recurring' ? 'contributionValue' : 'amount';
@@ -170,23 +156,23 @@ function getContribAttrs({ contribType, contribAmount, intCmp }) {
 
 }
 
-function getPaperAttrs({ intCmp }) {
+function getPaperAttrs({ intCmp }): PaperBundle {
 
   const params = new URLSearchParams();
 
   params.append('INTCMP', intCmp);
-  const paperCtaLink = `${ctaLinks.paperOnly}?${params.toString()}`;
-  const paperDigCtaLink = `${ctaLinks.paperDigital}?${params.toString()}`;
+  const paperCtaLink = `${bundles.paper.paperCtaLink}?${params.toString()}`;
+  const paperDigCtaLink = `${bundles.paper.paperDigCtaLink}?${params.toString()}`;
 
   return Object.assign({}, bundles.paper, { paperCtaLink, paperDigCtaLink });
 
 }
 
-function getDigitalAttrs({ intCmp }) {
+function getDigitalAttrs({ intCmp }): DigitalBundle {
 
   const params = new URLSearchParams();
   params.append('INTCMP', intCmp);
-  const ctaLink = `${ctaLinks.digital}?${params.toString()}`;
+  const ctaLink = `${bundles.digital.ctaLink}?${params.toString()}`;
 
   return Object.assign({}, bundles.digital, { ctaLink });
 
@@ -197,9 +183,9 @@ function getDigitalAttrs({ intCmp }) {
 
 function Bundles(props: PropTypes) {
 
-  const contribAttrs = getContribAttrs(props);
-  const paperAttrs = getPaperAttrs(props);
-  const digitalAttrs = getDigitalAttrs(props);
+  const contribAttrs: ContribBundle = getContribAttrs(props);
+  const paperAttrs: PaperBundle = getPaperAttrs(props);
+  const digitalAttrs: DigitalBundle = getDigitalAttrs(props);
 
   return (
     <section className="bundles">

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -14,6 +14,73 @@ import { changeContribType } from '../actions/bundlesLandingActions';
 
 import type { Contrib, Amounts } from '../reducers/reducers';
 
+// ----- Types ----- //
+
+type PropTypes = {
+  contribType: Contrib,
+  contribAmount: Amounts, // eslint-disable-line react/no-unused-prop-types
+  intCmp: string, // eslint-disable-line react/no-unused-prop-types
+  toggleContribType: (string) => void,
+};
+
+
+const contribCopy: ContribBundle = {
+  heading: 'contribute',
+  subheading: 'from £5/month',
+  ctaText: 'Contribute with credit/debit card',
+  modifierClass: 'contributions',
+};
+
+const digitalCopy: DigitalBundle = {
+  heading: 'digital subscription',
+  subheading: '£11.99/month',
+  listItems: [
+    {
+      heading: 'Ad-free mobile app',
+      text: 'No interruptions means pages load quicker for a clearer reading experience',
+    },
+    {
+      heading: 'Daily tablet edition',
+      text: 'Daily newspaper optimised for tablet; available on Apple, Android and Kindle Fire',
+    },
+    {
+      heading: 'Enjoy on up to 10 devices',
+    },
+  ],
+  ctaText: 'Start your 14 day trial',
+  modifierClass: 'digital',
+};
+
+const paperCopy: PaperBundle = {
+  heading: 'paper subscription',
+  subheading: 'from £22.06/month',
+  listItems: [
+    {
+      heading: 'Newspaper',
+      text: 'Choose the package you want: Everyday, Sixday, Weekend and Sunday',
+    },
+    {
+      heading: 'Save money off the retail price',
+    },
+    {
+      heading: 'All the benefits of a digital subscription',
+      text: 'Avaliable with paper+digital',
+    },
+  ],
+  paperCtaText: 'Become a paper subscriber',
+  paperDigCtaText: 'Become a paper+digital subscriber',
+  modifierClass: 'paper',
+};
+
+const bundles: Bundles = {
+  contrib: contribCopy,
+  digital: digitalCopy,
+  paper: paperCopy,
+}
+};
+
+
+
 
 // ----- Copy ----- //
 
@@ -86,17 +153,6 @@ const contribToggle = {
     },
   ],
 };
-
-
-// ----- Types ----- //
-
-type PropTypes = {
-  contribType: Contrib,
-  contribAmount: Amounts, // eslint-disable-line react/no-unused-prop-types
-  intCmp: string, // eslint-disable-line react/no-unused-prop-types
-  toggleContribType: (string) => void,
-};
-
 
 // ----- Functions ----- //
 


### PR DESCRIPTION
## Why are you doing this?

The bundles used to be defined in a huge object, now we created types so it is easier to specify the return values of different functions.


