### PR TITLE
Contribution A/B test

### DIFF
--- a/assets/components/ctaCircle/ctaCircle.jsx
+++ b/assets/components/ctaCircle/ctaCircle.jsx
@@ -4,6 +4,7 @@
 
 import React from 'react';
 import Svg from 'components/svg/svg';
+import { generateClassName } from 'helpers/utilities';
 
 
 // ----- Types ----- //
@@ -19,11 +20,9 @@ type PropTypes = {
 
 
 const CtaCircle = (props: PropTypes) => {
-  let className = 'component-cta-circle';
 
-  if (props.modifierClass) {
-    className = `${className} ${className}--${props.modifierClass}`;
-  }
+  const className = generateClassName('component-cta-circle', props.modifierClass);
+
   return (
     <a className={className} onClick={props.onClick} role="link" tabIndex={0}>
       <button><Svg svgName="arrow-right-straight" /></button>

--- a/assets/components/ctaLink/ctaLink.jsx
+++ b/assets/components/ctaLink/ctaLink.jsx
@@ -29,7 +29,7 @@ export default function CtaLink(props: PropTypes) {
 
 
 CtaLink.defaultProps = {
-  url: undefined,
-  onClick: undefined,
+  url: null,
+  onClick: null,
 };
 

--- a/assets/components/ctaLink/ctaLink.jsx
+++ b/assets/components/ctaLink/ctaLink.jsx
@@ -26,3 +26,10 @@ export default function CtaLink(props: PropTypes) {
   );
 
 }
+
+
+CtaLink.defaultProps = {
+  url: undefined,
+  onClick: undefined,
+};
+

--- a/assets/components/ctaLink/ctaLink.jsx
+++ b/assets/components/ctaLink/ctaLink.jsx
@@ -10,16 +10,16 @@ import Svg from 'components/svg/svg';
 
 type PropTypes = {
   text: string,
-  url: string,
+  url?: string,
+  onClick?: () => void,
 };
 
 
 // ----- Component ----- //
 
 export default function CtaLink(props: PropTypes) {
-
   return (
-    <a className="component-cta-link" href={props.url}>
+    <a className="component-cta-link" href={props.url} onClick={props.onClick}>
       <span>{props.text}</span>
       <Svg svgName="arrow-right-straight" />
     </a>

--- a/assets/components/ctaLink/ctaLink.scss
+++ b/assets/components/ctaLink/ctaLink.scss
@@ -1,30 +1,31 @@
 .component-cta-link {
-	border-radius: 600px;
-	border: none;
-	background-color: gu-colour(neutral-1);
-	color: #fff;
-	padding: 6px 20px;
-	margin-top: 12px;
-	text-align: left;
-	height: $gu-v-spacing * 2;
-	vertical-align: bottom;
-	display: block;
-	line-height: 180%;
-	text-decoration: none;
-	font-size: 14px;
-	font-weight: bold;
-	font-family: $gu-text-sans-web;
-	position: relative;
+  background-color: gu-colour(neutral-1);
+  border: none;
+  border-radius: 600px;
+  color: #fff;
+  cursor: pointer;
+  display: block;
+  font-family: $gu-text-sans-web;
+  font-size: 14px;
+  font-weight: bold;
+  height: $gu-v-spacing * 2;
+  line-height: 180%;
+  margin-top: 12px;
+  padding: 6px 20px;
+  position: relative;
+  text-align: left;
+  text-decoration: none;
+  vertical-align: bottom;
 
-	&:hover {
-		background-color: #000;
-	}
+  &:hover {
+    background-color: #000;
+  }
 
-	svg {
-		height: 50%;
-		position: absolute;
-		right: 8px;
-		top: 9px;
-		fill: #fff;
-	}
+  svg {
+    height: 50%;
+    position: absolute;
+    right: 8px;
+    top: 9px;
+    fill: #fff;
+  }
 }

--- a/assets/components/doubleHeading/doubleHeading.jsx
+++ b/assets/components/doubleHeading/doubleHeading.jsx
@@ -3,6 +3,7 @@
 // ----- Imports ----- //
 
 import React from 'react';
+import { generateClassName } from 'helpers/utilities';
 
 
 // ---- Types ----- //
@@ -10,7 +11,7 @@ import React from 'react';
 type PropTypes = {
   heading: string,
   subheading: ?string,
-  modifierClass: ?string,
+  modifierClass?: string,
 };
 
 
@@ -18,11 +19,7 @@ type PropTypes = {
 
 export default function DoubleHeading(props: PropTypes) {
 
-  let className = 'component-double-heading';
-
-  if (props.modifierClass) {
-    className = `${className} ${className}--${props.modifierClass}`;
-  }
+  const className = generateClassName('component-double-heading', props.modifierClass);
 
   const subhead = (
     <h2 className="component-double-heading__subheading">
@@ -46,4 +43,5 @@ export default function DoubleHeading(props: PropTypes) {
 
 DoubleHeading.defaultProps = {
   subheading: '',
+  modifierClass: null,
 };

--- a/assets/components/doubleHeading/doubleHeading.jsx
+++ b/assets/components/doubleHeading/doubleHeading.jsx
@@ -10,12 +10,19 @@ import React from 'react';
 type PropTypes = {
   heading: string,
   subheading: ?string,
+  modifierClass: ?string,
 };
 
 
 // ----- Component ----- //
 
 export default function DoubleHeading(props: PropTypes) {
+
+  let className = 'component-double-heading';
+
+  if (props.modifierClass) {
+    className = `${className} ${className}--${props.modifierClass}`;
+  }
 
   const subhead = (
     <h2 className="component-double-heading__subheading">
@@ -24,7 +31,7 @@ export default function DoubleHeading(props: PropTypes) {
   );
 
   return (
-    <div className="component-double-heading">
+    <div className={className}>
       <h1 className="component-double-heading__heading">
         { props.heading }
       </h1>

--- a/assets/helpers/abtest.js
+++ b/assets/helpers/abtest.js
@@ -20,7 +20,7 @@ type Audience = {
   size: number,
 };
 
-type TestId = 'noTestDefined';
+type TestId = 'SupportFrontEndContribution';
 
 export type Participations = {
   [TestId]: string,

--- a/assets/helpers/abtest.js
+++ b/assets/helpers/abtest.js
@@ -68,7 +68,17 @@ type OphanABPayload = {
 
  */
 
-const tests: Test[] = [];
+const tests: Test[] = [
+  {
+    testId: 'SupportFrontEndContribution',
+    variants: ['control', 'variantA'],
+    audience: {
+      offset: 0,
+      size: 1,
+    },
+    isActive: true,
+  },
+];
 
 
 // ----- Functions ----- //

--- a/assets/helpers/utilities.js
+++ b/assets/helpers/utilities.js
@@ -16,3 +16,15 @@ export function descending(a: number, b: number): number {
 export function roundDp(num: number, dps: number = 2) {
   return Math.round(num * (10 ** dps)) / (10 ** dps);
 }
+
+// Generates the "class modifier-class" string for HTML elements
+export function generateClassName(className: string, modifierClass: ?string): string {
+  let response = className;
+
+  if (modifierClass) {
+    response = `${className} ${className}--${modifierClass}`;
+  }
+
+  return response;
+}
+

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -359,6 +359,10 @@
       }
     }
 
+    .contrib-explainer {
+      margin-bottom: 2 * $gu-v-spacing;
+    }
+
   }
 
 
@@ -744,9 +748,13 @@
   // ----- Shared Components ----- //
 
   .component-double-heading {
-      margin-bottom: 24px;
+      margin-bottom: (2 * $gu-v-spacing);
   }
 
+  .component-double-heading--variant-a {
+    margin-bottom: 0;
+  }
+  
   input:checked+label {
     background-color: gu-colour(guardian-brand-dark);
     color: #fff;

--- a/assets/pages/bundles-landing/components/Bundle.jsx
+++ b/assets/pages/bundles-landing/components/Bundle.jsx
@@ -17,6 +17,7 @@ type PropTypes = {
   subheading: string,
   modifierClass: string,
   children?: Children,
+  doubleHeadingModifierClass?: string,
 };
 
 
@@ -35,6 +36,7 @@ function Bundle(props: PropTypes) {
       <DoubleHeading
         heading={props.heading}
         subheading={props.subheading}
+        modifierClass={props.doubleHeadingModifierClass}
       />
       <div className="bundle__content">
         {props.children}

--- a/assets/pages/bundles-landing/components/Bundle.jsx
+++ b/assets/pages/bundles-landing/components/Bundle.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import DoubleHeading from 'components/doubleHeading/doubleHeading';
+import { generateClassName } from 'helpers/utilities';
 
 import type { Children } from 'react';
 
@@ -15,7 +16,7 @@ import type { Children } from 'react';
 type PropTypes = {
   heading: string,
   subheading: string,
-  modifierClass: string,
+  modifierClass: ?string,
   children?: Children,
   doubleHeadingModifierClass?: string,
 };
@@ -25,11 +26,7 @@ type PropTypes = {
 
 function Bundle(props: PropTypes) {
 
-  let className = 'bundles__bundle';
-
-  if (props.modifierClass) {
-    className = `${className} ${className}--${props.modifierClass}`;
-  }
+  const className = generateClassName('bundles__bundle', props.modifierClass);
 
   return (
     <div className={className}>
@@ -52,7 +49,7 @@ function Bundle(props: PropTypes) {
 Bundle.defaultProps = {
   subheading: '',
   infoText: '',
-  modifierClass: '',
+  modifierClass: null,
   children: null,
   doubleHeadingModifierClass: null,
 };

--- a/assets/pages/bundles-landing/components/Bundle.jsx
+++ b/assets/pages/bundles-landing/components/Bundle.jsx
@@ -54,6 +54,7 @@ Bundle.defaultProps = {
   infoText: '',
   modifierClass: '',
   children: null,
+  doubleHeadingModifierClass: null,
 };
 
 

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -10,9 +10,12 @@ import FeatureList from 'components/featureList/featureList';
 import RadioToggle from 'components/radioToggle/radioToggle';
 import type { ListItem } from 'components/featureList/featureList';
 import CtaLink from 'components/ctaLink/ctaLink';
+import { trackOphan } from 'helpers/abtest';
+
 import Bundle from './Bundle';
 import ContribAmounts from './ContribAmounts';
 import { changeContribType } from '../actions/bundlesLandingActions';
+
 
 import type { Contrib, Amounts } from '../reducers/reducers';
 
@@ -180,8 +183,9 @@ const getDigitalAttrs = ({ intCmp }): DigitalBundle => {
 
 };
 
+// ----- A/B Test components ----- //
 
-const getControlVariant = (props: PropTypes, attrs: ContribBundle) => (
+const getControlVariant = (props: PropTypes, attrs: ContribBundle, onClick: () => void) => (
   <Bundle {...attrs}>
     <div className="contrib-type">
       <RadioToggle
@@ -191,11 +195,11 @@ const getControlVariant = (props: PropTypes, attrs: ContribBundle) => (
       />
     </div>
     <ContribAmounts />
-    <CtaLink text={attrs.ctaText} url={attrs.ctaLink} />
+    <CtaLink text={attrs.ctaText} onClick={onClick} />
   </Bundle>
 );
 
-const getVariantA = (props: PropTypes, attrs: ContribBundle) => (
+const getVariantA = (props: PropTypes, attrs: ContribBundle, onClick: () => void) => (
   <Bundle {...attrs} doubleHeadingModifierClass="variant-a">
     <div className="contrib-type">
       <p className="contrib-explainer">Every penny funds our fearless, quality journalism</p>
@@ -206,7 +210,7 @@ const getVariantA = (props: PropTypes, attrs: ContribBundle) => (
       />
     </div>
     <ContribAmounts />
-    <CtaLink text={attrs.ctaText} url={attrs.ctaLink} />
+    <CtaLink text={attrs.ctaText} onClick={onClick} />
   </Bundle>
 );
 
@@ -215,22 +219,29 @@ const getContributionComponent = (props: PropTypes,
 
   const participation: Participations = props.abTests;
   const variant = participation.SupportFrontEndContribution;
-  let response = null;
+  const onClick = (url: string, testVariant: string): (() => void) =>
+    () => {
+      trackOphan('SupportFrontEndContribution', testVariant, true);
+      window.location = url;
+    };
 
+  let response = null;
   switch (variant) {
     case 'control' :
-      response = getControlVariant(props, contribAttrs);
+      trackOphan('SupportFrontEndContribution', variant);
+      response = getControlVariant(props, contribAttrs, onClick(contribAttrs.ctaLink, variant));
       break;
 
     case 'variantA' :
-      response = getVariantA(props, contribAttrs);
+      trackOphan('SupportFrontEndContribution', variant);
+      response = getVariantA(props, contribAttrs, onClick(contribAttrs.ctaLink, variant));
       break;
-    default : response = getControlVariant(props, contribAttrs);
+    default :
+      response = getControlVariant(props, contribAttrs, onClick(contribAttrs.ctaLink, variant));
   }
 
   return response;
 };
-
 
 // ----- Component ----- //
 

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -195,7 +195,20 @@ const getControlVariant = (props: PropTypes, attrs: ContribBundle) => (
   </Bundle>
 );
 
-const getVariantA = () => null;
+const getVariantA = (props: PropTypes, attrs: ContribBundle) => (
+  <Bundle {...attrs} doubleHeadingModifierClass="variant-a">
+    <div className="contrib-type">
+      <p class="contrib-explainer">Every penny funds our fearless, quality journalism</p>
+      <RadioToggle
+        {...contribToggle}
+        toggleAction={props.toggleContribType}
+        checked={props.contribType}
+      />
+    </div>
+    <ContribAmounts />
+    <CtaLink text={attrs.ctaText} url={attrs.ctaLink} />
+  </Bundle>
+);
 
 const getContributionComponent = (props: PropTypes,
                                   contribAttrs: ContribBundle) => {
@@ -210,7 +223,7 @@ const getContributionComponent = (props: PropTypes,
       break;
 
     case 'variantA' :
-      response = getVariantA();
+      response = getVariantA(props, contribAttrs);
       break;
     default : response = getControlVariant(props, contribAttrs);
   }
@@ -271,7 +284,6 @@ function mapDispatchToProps(dispatch) {
   };
 
 }
-
 
 // ----- Exports ----- //
 

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -28,7 +28,7 @@ type PropTypes = {
   contribAmount: Amounts, // eslint-disable-line react/no-unused-prop-types
   intCmp: string, // eslint-disable-line react/no-unused-prop-types
   toggleContribType: (string) => void,
-  abTests: Object, // eslint-disable-line react/no-unused-prop-types
+  abTests: Participations, // eslint-disable-line react/no-unused-prop-types
 };
 
 type ContribBundle = {

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -11,6 +11,7 @@ import RadioToggle from 'components/radioToggle/radioToggle';
 import type { ListItem } from 'components/featureList/featureList';
 import CtaLink from 'components/ctaLink/ctaLink';
 import { trackOphan } from 'helpers/abtest';
+import { trackEvent as trackEventGA } from 'helpers/ga';
 
 import Bundle from './Bundle';
 import ContribAmounts from './ContribAmounts';
@@ -222,6 +223,7 @@ const getContributionComponent = (props: PropTypes,
   const onClick = (url: string, testVariant: string): (() => void) =>
     () => {
       trackOphan('SupportFrontEndContribution', testVariant, true);
+      trackEventGA('SupportFrontEndContribution', 'clicked', testVariant);
       window.location = url;
     };
 

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -13,6 +13,51 @@ import ContribAmounts from './ContribAmounts';
 import { changeContribType } from '../actions/bundlesLandingActions';
 
 import type { Contrib, Amounts } from '../reducers/reducers';
+import type { Participations } from 'helpers/abtest';
+
+// ----- Types ----- //
+
+type PropTypes = {
+  contribType: Contrib,
+  contribAmount: Amounts, // eslint-disable-line react/no-unused-prop-types
+  intCmp: string, // eslint-disable-line react/no-unused-prop-types
+  toggleContribType: (string) => void,
+};
+
+type ContribBundle = {
+  heading: string,
+  subheading: string,
+  ctaText: string,
+  modifierClass: string,
+}
+
+type DigitalBundle = {
+  heading: string,
+  subheading: string,
+  listItems: Array<BundleItem>,
+  ctaText: string,
+  modifierClass: string,
+}
+
+type BundleItem = {
+  heading: string,
+  text: string,
+}
+
+type PaperBundle = {
+  heading: string,
+  subheading: string,
+  listItems: Array<BundleItem>,
+  paperCtaText: string,
+  paperDigCtaText: string,
+  modifierClass: string,
+}
+
+type Bundles = {
+  contrib: ContribBundle,
+  digital: DigitalBundle,
+  paper: PaperBundle
+}
 
 
 // ----- Copy ----- //
@@ -25,52 +70,59 @@ const ctaLinks = {
   digital: 'https://subscribe.theguardian.com/p/DXX83X',
 };
 
-const bundles = {
-  contrib: {
-    heading: 'contribute',
-    subheading: 'from £5/month',
-    ctaText: 'Contribute with credit/debit card',
-    modifierClass: 'contributions',
-  },
-  digital: {
-    heading: 'digital subscription',
-    subheading: '£11.99/month',
-    listItems: [
-      {
-        heading: 'Ad-free mobile app',
-        text: 'No interruptions means pages load quicker for a clearer reading experience',
-      },
-      {
-        heading: 'Daily tablet edition',
-        text: 'Daily newspaper optimised for tablet; available on Apple, Android and Kindle Fire',
-      },
-      {
-        heading: 'Enjoy on up to 10 devices',
-      },
-    ],
-    ctaText: 'Start your 14 day trial',
-    modifierClass: 'digital',
-  },
-  paper: {
-    heading: 'paper subscription',
-    subheading: 'from £22.06/month',
-    listItems: [
-      {
-        heading: 'Newspaper',
-        text: 'Choose the package you want: Everyday, Sixday, Weekend and Sunday',
-      },
-      {
-        heading: 'Save money off the retail price',
-      },
-      {
-        heading: 'All the benefits of a digital subscription',
-        text: 'Avaliable with paper+digital',
-      },
-    ],
-    paperCtaText: 'Become a paper subscriber',
-    paperDigCtaText: 'Become a paper+digital subscriber',
-    modifierClass: 'paper',
-  },
+const contribCopy: ContribBundle = {
+  heading: 'contribute',
+  subheading: 'from £5/month',
+  ctaText: 'Contribute with credit/debit card',
+  modifierClass: 'contributions',
+};
+
+const digitalCopy: DigitalBundle = {
+  heading: 'digital subscription',
+  subheading: '£11.99/month',
+  listItems: [
+    {
+      heading: 'Ad-free mobile app',
+      text: 'No interruptions means pages load quicker for a clearer reading experience',
+    },
+    {
+      heading: 'Daily tablet edition',
+      text: 'Daily newspaper optimised for tablet; available on Apple, Android and Kindle Fire',
+    },
+    {
+      heading: 'Enjoy on up to 10 devices',
+    },
+  ],
+  ctaText: 'Start your 14 day trial',
+  modifierClass: 'digital',
+};
+
+const paperCopy: PaperBundle = {
+  heading: 'paper subscription',
+  subheading: 'from £22.06/month',
+  listItems: [
+    {
+      heading: 'Newspaper',
+      text: 'Choose the package you want: Everyday, Sixday, Weekend and Sunday',
+    },
+    {
+      heading: 'Save money off the retail price',
+    },
+    {
+      heading: 'All the benefits of a digital subscription',
+      text: 'Avaliable with paper+digital',
+    },
+  ],
+  paperCtaText: 'Become a paper subscriber',
+  paperDigCtaText: 'Become a paper+digital subscriber',
+  modifierClass: 'paper',
+};
+
+const bundles: Bundles = {
+  contrib: contribCopy,
+  digital: digitalCopy,
+  paper: paperCopy,
+  }
 };
 
 const contribToggle = {
@@ -88,19 +140,9 @@ const contribToggle = {
 };
 
 
-// ----- Types ----- //
-
-type PropTypes = {
-  contribType: Contrib,
-  contribAmount: Amounts, // eslint-disable-line react/no-unused-prop-types
-  intCmp: string, // eslint-disable-line react/no-unused-prop-types
-  toggleContribType: (string) => void,
-};
-
-
 // ----- Functions ----- //
 
-function getContribAttrs({ contribType, contribAmount, intCmp }) {
+function getContribAttrs({ contribType, contribAmount, intCmp }): ContribBundle {
 
   const contType = contribType === 'RECURRING' ? 'recurring' : 'oneOff';
   const amountParam = contType === 'recurring' ? 'contributionValue' : 'amount';
@@ -114,7 +156,7 @@ function getContribAttrs({ contribType, contribAmount, intCmp }) {
 
 }
 
-function getPaperAttrs({ intCmp }) {
+function getPaperAttrs({ intCmp }): PaperBundle {
 
   const params = new URLSearchParams();
 
@@ -126,7 +168,7 @@ function getPaperAttrs({ intCmp }) {
 
 }
 
-function getDigitalAttrs({ intCmp }) {
+function getDigitalAttrs({ intCmp }): DigitalBundle {
 
   const params = new URLSearchParams();
   params.append('INTCMP', intCmp);
@@ -135,6 +177,44 @@ function getDigitalAttrs({ intCmp }) {
   return Object.assign({}, bundles.digital, { ctaLink });
 
 }
+
+const getContributionComponent = (participation: Participations, contribAttrs: ContribBundle) => {
+
+  const variant = participation.SupportFrontEndContribution;
+
+  const getControlVariant = (attrs) => {
+    return <Bundle {...attrs}>
+      <div className="contrib-type">
+        <RadioToggle
+          {...contribToggle}
+          toggleAction={props.toggleContribType}
+          checked={props.contribType}
+        />
+      </div>
+      <ContribAmounts />
+      <CtaLink text={attrs.ctaText} url={attrs.ctaLink} />
+    </Bundle>
+  };
+
+  const getVariantA = (attrs) => {
+    return null;
+  };
+
+  let response = null;
+
+  switch (variant) {
+    case 'control' :
+      response = getControlVariant(contribAttrs);
+      break;
+
+    case 'variantA' :
+      response = getVariantA(contribAttrs);
+      break;
+    default : response = getControlVariant(contribAttrs);
+  }
+
+  return response;
+};
 
 
 // ----- Component ----- //
@@ -145,21 +225,13 @@ function Bundles(props: PropTypes) {
   const paperAttrs = getPaperAttrs(props);
   const digitalAttrs = getDigitalAttrs(props);
 
+  const contributionComponent = getContributionComponent(props.abTests, contribAttrs);
+
   return (
     <section className="bundles">
       <div className="bundles__content gu-content-margin">
         <div className="bundles__wrapper">
-          <Bundle {...contribAttrs}>
-            <div className="contrib-type">
-              <RadioToggle
-                {...contribToggle}
-                toggleAction={props.toggleContribType}
-                checked={props.contribType}
-              />
-            </div>
-            <ContribAmounts />
-            <CtaLink text={contribAttrs.ctaText} url={contribAttrs.ctaLink} />
-          </Bundle>
+          <contributionComponent />
           <div className="bundles__divider" />
           <Bundle {...digitalAttrs}>
             <FeatureList listItems={bundles.digital.listItems} />
@@ -175,7 +247,6 @@ function Bundles(props: PropTypes) {
       </div>
     </section>
   );
-
 }
 
 
@@ -186,6 +257,7 @@ function mapStateToProps(state) {
     contribType: state.contribution.type,
     contribAmount: state.contribution.amount,
     intCmp: state.intCmp,
+    abTests: state.abTests,
   };
 }
 

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -198,7 +198,7 @@ const getControlVariant = (props: PropTypes, attrs: ContribBundle) => (
 const getVariantA = (props: PropTypes, attrs: ContribBundle) => (
   <Bundle {...attrs} doubleHeadingModifierClass="variant-a">
     <div className="contrib-type">
-      <p class="contrib-explainer">Every penny funds our fearless, quality journalism</p>
+      <p className="contrib-explainer">Every penny funds our fearless, quality journalism</p>
       <RadioToggle
         {...contribToggle}
         toggleAction={props.toggleContribType}


### PR DESCRIPTION
## Why are you doing this?
This PR implements the first A/B Test. It is intended not only test the proposed change, but also the entire A/B test framework.

[**Trello Card**](https://trello.com/c/OcvCFZw9/645-implement-a-simple-title-ab-test)

## Test:

### Name: 
Line added to contribute section of support.theguardian.com (bundle landing page).

### Id:
**SupportFrontEndContribution** 

### Hypothesis: 
> By adding a sentence to persuade users to the contributions section we can increase click through to contribute with credit/ debit card 

### Variants:

| Control | VariantA |
|---------|----------|
|   <img width="316" alt="picture 285" src="https://user-images.githubusercontent.com/825398/27481946-3bdcc6f0-5817-11e7-8dc4-ccf0d4d7212c.png">  |    <img width="313" alt="picture 284" src="https://user-images.githubusercontent.com/825398/27481958-47967fea-5817-11e7-989e-2cd534aca538.png"> |

### Tracking:

Tracking using Ophan via tracker-js and GA.

#### Variant loaded:

##### GA
![picture 288](https://user-images.githubusercontent.com/825398/27534160-f3d8e2e6-5a5d-11e7-9d7c-69fda6b7cc48.png)

#### Ophan
![picture 289](https://user-images.githubusercontent.com/825398/27534220-2817f2a4-5a5e-11e7-8312-4e466b483b7c.png)

#### Conversion

##### GA
![picture 291](https://user-images.githubusercontent.com/825398/27534789-14b833e8-5a60-11e7-8834-1a2102b33014.png)


##### Ophan
![picture 290](https://user-images.githubusercontent.com/825398/27534375-aa54fe88-5a5e-11e7-9f5b-20fe46764d9d.png)









