### PR TITLE
Validate Monthly Contrib

### DIFF
--- a/assets/components/infoSection/infoSection.jsx
+++ b/assets/components/infoSection/infoSection.jsx
@@ -40,6 +40,6 @@ export default function InfoSection(props: PropTypes) {
 
 InfoSection.defaultProps = {
   heading: null,
-  className: '',
+  className: null,
   children: null,
 };

--- a/assets/components/textInput/textInput.jsx
+++ b/assets/components/textInput/textInput.jsx
@@ -7,13 +7,20 @@ import React from 'react';
 
 // ----- Types ----- //
 
+// Disabling the linter here because it's just buggy...
+// It can't handle props being passed to another function.
+/* eslint-disable react/no-unused-prop-types, react/require-default-props */
+
 type PropTypes = {
   placeholder?: string,
   labelText?: string,
   id?: string,
   onChange?: (name: string) => void,
   value?: string,
+  required?: boolean,
 };
+
+/* eslint-enable react/no-unused-prop-types, react/require-default-props */
 
 
 // ----- Functions ----- //
@@ -28,33 +35,21 @@ function inputClass(hasLabel: boolean): string {
 
 }
 
-function buildInput(
-  labelText: ?string,
-  id: ?string,
-  placeholder: ?string,
-  onChange: ?Function,
-  value: ?string,
-) {
+function buildInput(props: PropTypes): React$Element<any> {
 
-  const attrs: {
-    className: string,
-    id: ?string,
-    type: string,
-    placeholder: ?string,
-    value: string,
-    onChange?: Function,
-  } = {
-    className: inputClass(!!labelText),
-    id,
+  const attrs = {
+    className: inputClass(!!props.labelText),
+    id: props.id,
     type: 'text',
-    placeholder,
-    value: value || '',
+    placeholder: props.placeholder,
+    value: props.value || '',
+    required: props.required,
   };
 
   // Keeps flow happy (https://github.com/facebook/flow/issues/2819).
-  if (typeof onChange === 'function') {
-    const change = onChange;
-    attrs.onChange = event => change(event.target.value || '');
+  if (typeof props.onChange === 'function') {
+    const change = props.onChange;
+    return <input {...attrs} onChange={event => change(event.target.value || '')} />;
   }
 
   return <input {...attrs} />;
@@ -66,13 +61,7 @@ function buildInput(
 
 export default function TextInput(props: PropTypes) {
 
-  const input = buildInput(
-    props.labelText,
-    props.id,
-    props.placeholder,
-    props.onChange,
-    props.value,
-  );
+  const input = buildInput(props);
 
   if (!props.labelText) {
     return input;
@@ -98,4 +87,5 @@ TextInput.defaultProps = {
   id: null,
   onChange: null,
   value: '',
+  required: false,
 };

--- a/assets/pages/monthly-contributions/components/nameForm.jsx
+++ b/assets/pages/monthly-contributions/components/nameForm.jsx
@@ -34,12 +34,14 @@ function NameForm(props: PropTypes) {
         placeholder="First name"
         value={props.firstName}
         onChange={props.firstNameUpdate}
+        required
       />
       <TextInput
         id="last-name"
         placeholder="Last name"
         value={props.lastName}
         onChange={props.lastNameUpdate}
+        required
       />
     </form>
   );

--- a/assets/pages/monthly-contributions/components/paymentMethods.jsx
+++ b/assets/pages/monthly-contributions/components/paymentMethods.jsx
@@ -13,6 +13,8 @@ import postCheckout from '../helpers/ajax';
 
 type PropTypes = {
   email: string,
+  firstName: string,
+  lastName: string,
 };
 
 
@@ -20,9 +22,15 @@ type PropTypes = {
 
 function PaymentMethods(props: PropTypes) {
 
+  let content = 'Please fill in all the fields above.';
+
+  if (props.firstName !== '' && props.lastName !== '') {
+    content = <StripePopUpButton email={props.email} callback={postCheckout} />;
+  }
+
   return (
     <section className="payment-methods">
-      <StripePopUpButton email={props.email} callback={postCheckout} />
+      {content}
     </section>
   );
 
@@ -35,6 +43,8 @@ function mapStateToProps(state) {
 
   return {
     email: state.user.email,
+    firstName: state.user.firstName,
+    lastName: state.user.lastName,
   };
 
 }


### PR DESCRIPTION
## Why are you doing this?

The monthly contributions checkout page is authenticated, which means that user credentials are available, which means that we can pre-fill the two form fields (first name and last name). However, we need to allow users to update this, in case the information they entered when they signed up is not appropriate for taking payments. This opens up the possibility of those fields becoming empty, which is not acceptable when the information is posted to the backend.

One solution to this would be to run validation when the payment button is clicked, and prevent payment if it fails. However, this will only work for the Stripe button. We don't have control over the PayPal button that is soon to be added to this page, and so we cannot go with this approach.

Instead, what this PR does is check the validity of the fields while the user is typing, using the React `onChange` attribute, which actually [acts](https://facebook.github.io/react/docs/forms.html) more like the listener for the HTML [`input`](https://developer.mozilla.org/en-US/docs/Web/Events/input) event. If the form is invalid, the payment buttons are hidden, and a message asking for all fields to be filled in is displayed instead.

[**Trello Card**](https://trello.com/c/5Y181eWL/635-validate-monthly-contrib-checkout-form)

## Changes

- Made the default `className` null in `infoSection`, unrelated to this PR.
- Updated `textInput` to include an option for the field to be `required`, and simplified the `buildInput` function.
- Made first name and last name required.
- Set up payment methods to hide the payment buttons if the form fields are empty.

## Screenshots

![form-error](https://user-images.githubusercontent.com/5131341/27493391-a2eaf8ce-5841-11e7-93df-8913f6e3ee1c.png)

