### PR TITLE
Fix Error On Incorrect 'Other Amount' for Contributions

### DIFF
--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -222,11 +222,14 @@ const getContributionComponent = (props: PropTypes,
   const variant = participation.SupportFrontEndContribution;
   const onClick = (url: string, testVariant: string): (() => void) =>
     () => {
-      if (testVariant && testVariant !== 'notintest') {
-        trackOphan('SupportFrontEndContribution', testVariant, true);
-        trackEventGA('SupportFrontEndContribution', 'clicked', testVariant);
+      // WARNING: Don't delete this check when removing the AB test!!!
+      if (!props.contribError) {
+        if (testVariant && testVariant !== 'notintest') {
+          trackOphan('SupportFrontEndContribution', testVariant, true);
+          trackEventGA('SupportFrontEndContribution', 'clicked', testVariant);
+        }
+        window.location = url;
       }
-      window.location = url;
     };
 
   let response = null;
@@ -285,6 +288,7 @@ function mapStateToProps(state) {
   return {
     contribType: state.contribution.type,
     contribAmount: state.contribution.amount,
+    contribError: state.contribution.error,
     intCmp: state.intCmp,
     abTests: state.abTests,
   };


### PR DESCRIPTION
## Why are you doing this?

On the bundles landing page we have the option of entering a user-defined amount. There are restrictions on this amount, and we display an error message if the value entered is not allowed.

This PR blocks the CTA if an error occurs.

[**Trello Card**](https://trello.com/c/3eGhPY7R/606-stop-other-amount-contribution-flow-from-giving-error-400-bad-request)

## Changes

- In the CTA onClick callback, if there is an error in user input, don't run the tracking code or redirect the user.

## Screenshots

![other-amount-error](https://trello-attachments.s3.amazonaws.com/57f61bbc38fc029c0eee67e8/5937d4c64b3ccee5131689b2/24d3e3f35264ef126e0bf7c4220e1f1b/image.png)