### PR TITLE
Sticky Support Footer

### DIFF
--- a/app/views/react.scala.html
+++ b/app/views/react.scala.html
@@ -6,5 +6,5 @@
 }
 
 @main(title = title, scripts = scripts) {
-    <main id="@id"></main>
+    <main id="@id" class="gu-content-wrapper"></main>
 }

--- a/assets/stylesheets/gu-sass/layout.scss
+++ b/assets/stylesheets/gu-sass/layout.scss
@@ -1,6 +1,10 @@
 // This file contains variable and classes definition related to the layout of
 // the project.
 
+html, body {
+  height: 100%;
+}
+
 // Spacing variables
 // h stands for horizontal
 // v stands for vertical
@@ -46,6 +50,7 @@ $gu-v-spacing: 12px;
 // The paddings at different breakpoints for the content.
 .gu-content-margin {
   padding: 0 ($gu-h-spacing / 2);
+  height: 100%;
 
   @include mq($from: mobileLandscape) {
     padding: 0 $gu-h-spacing;
@@ -57,5 +62,24 @@ $gu-v-spacing: 12px;
 
   @include mq($from: tablet) {
     padding: 0 $gu-h-spacing;
+  }
+}
+
+// The element into which React content is injected.
+.gu-content-wrapper {
+  height: 100%;
+
+  > div {
+    display: flex;
+    height: 100%;
+    flex-direction: column;
+  }
+
+  header {
+    flex: 0 0 auto;
+  }
+
+  section {
+    flex: 1 0 auto;
   }
 }


### PR DESCRIPTION
## Why are you doing this?

Classic problem. For pages that are shorter than the viewport there's a bunch of whitespace below the footer. This forces the footer to the bottom using flexbox (and actually works in IE!). Inspiration [here](https://css-tricks.com/couple-takes-sticky-footer/#article-header-id-3).

[**Trello Card**](https://trello.com/c/vPF3XIzw/650-sort-the-support-footer-out)

## Changes

- Created a new class for the wrapping main element (the one that we inject our React into).
- Applied `100%` height to the `html` and `body` tags, and the `gu-content-margin` class.

## Screenshots

**Before:**

![footer-before](https://user-images.githubusercontent.com/5131341/27545132-f71e217c-5a86-11e7-84b4-c50afbb16060.png)

**After:**

![footer-after](https://user-images.githubusercontent.com/5131341/27545137-fca72d96-5a86-11e7-8638-ce513b48f428.png)