### PR TITLE
Existing Contributor Page

### DIFF
--- a/assets/pages/monthly-contributions-existing/monthlyContributionsExisting.jsx
+++ b/assets/pages/monthly-contributions-existing/monthlyContributionsExisting.jsx
@@ -1,0 +1,55 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
+import SimpleFooter from 'components/footers/simpleFooter/simpleFooter';
+import CtaLink from 'components/ctaLink/ctaLink';
+import InfoSection from 'components/infoSection/infoSection';
+
+import pageStartup from 'helpers/pageStartup';
+
+
+// ----- Page Startup ----- //
+
+pageStartup.start();
+
+
+// ----- Render ----- //
+
+const content = (
+  <div>
+    <SimpleHeader />
+    <section className="existing">
+      <div className="existing__content gu-content-margin">
+        <div className="existing__wrapper">
+          <h1 className="existing__heading">Existing Contributor</h1>
+          <h2 className="existing__subheading">
+            You&#39;re already making a vital monthly contribution that will help
+            us maintain our independent, investigative journalism
+          </h2>
+          <CtaLink
+            text="One-off contribution"
+            url="https://contribute.theguardian.com"
+          />
+          <InfoSection heading="Questions?" className="existing__questions">
+            <p>
+              If you have any questions about contributing to the Guardian,
+              please <a href="mailto:contribution.support@theguardian.com">
+              contact us</a>
+            </p>
+          </InfoSection>
+        </div>
+      </div>
+    </section>
+    <SimpleFooter />
+  </div>
+);
+
+ReactDOM.render(
+  content,
+  document.getElementById('monthly-contributions-existing-page'),
+);

--- a/assets/pages/monthly-contributions-existing/monthlyContributionsExisting.scss
+++ b/assets/pages/monthly-contributions-existing/monthlyContributionsExisting.scss
@@ -1,0 +1,68 @@
+#monthly-contributions-existing-page {
+
+	a {
+		color: gu-colour(neutral-1);
+	}
+
+	// ----- Headings
+
+	.existing {
+		background-color: darken(gu-colour(multimedia-main-2), 5%);
+	}
+
+	.existing__content {
+		background-color: gu-colour(multimedia-main-2);
+		padding: $gu-v-spacing $gu-h-spacing;
+	}
+
+	.existing__wrapper {
+
+		@include mq($from: desktop) {
+			margin-left: 20%;
+			margin-right: 20%;
+		}
+	}
+
+	.existing__heading {
+		font-family: $gu-egyptian-web;
+		color: gu-colour(neutral-1);
+		font-size: 44px;
+		line-height: 46px;
+		font-weight: bold;
+	}
+
+	.existing__subheading {
+		font-family: $gu-egyptian-web;
+		font-size: 40px;
+		line-height: 42px;
+		font-weight: lighter;
+		color: gu-colour(neutral-1);
+	}
+
+	.component-cta-link {
+		color: gu-colour(neutral-1);
+		background: transparent;
+		display: inline-block;
+		width: 180px;
+		border: 1px solid gu-colour(neutral-1);
+		font-weight: normal;
+		margin-bottom: $gu-v-spacing * 4;
+		margin-top: 4 * $gu-v-spacing;
+
+		svg {
+			fill: gu-colour(neutral-1);
+			// Fix for IE10.
+			left: 190px;
+		}
+
+		&:hover {
+			border-color: #000;
+			color: #000;
+
+			svg {
+				fill: #000;
+			}
+		}
+	}
+
+}

--- a/assets/stylesheets/main.scss
+++ b/assets/stylesheets/main.scss
@@ -35,3 +35,4 @@
 @import '../pages/bundles-landing/bundlesLanding';
 @import '../pages/monthly-contributions/monthlyContributions';
 @import '../pages/monthly-contributions-thankyou/monthlyContributionsThankyou';
+@import '../pages/monthly-contributions-existing/monthlyContributionsExisting';

--- a/conf/routes
+++ b/conf/routes
@@ -8,9 +8,10 @@ GET /healthcheck                controllers.Application.healthcheck
 GET /uk                         controllers.Application.reactTemplate(title="Support the Guardian", id="bundles-landing-page", js="bundlesLandingPage.js")
 GET /                           controllers.Default.redirect(to = "/uk")
 
-GET /monthly-contributions           controllers.MonthlyContributions.displayForm
-GET /monthly-contributions/thankyou  controllers.Application.reactTemplate(title="Support the Guardian | Thank You", id="monthly-contributions-thankyou-page", js="monthlyContributionsThankyouPage.js")
-POST /monthly-contributions/create   controllers.MonthlyContributions.create
+GET /monthly-contributions                         controllers.MonthlyContributions.displayForm
+GET /monthly-contributions/thankyou                controllers.Application.reactTemplate(title="Support the Guardian | Thank You", id="monthly-contributions-thankyou-page", js="monthlyContributionsThankyouPage.js")
+GET /monthly-contributions/existing-contributor    controllers.Application.reactTemplate(title="Support the Guardian | Existing Contributor", id="monthly-contributions-existing-page", js="monthlyContributionsExistingPage.js")
+POST /monthly-contributions/create                 controllers.MonthlyContributions.create
 
 GET /assets/*file               controllers.Assets.at(path="/public/compiled-assets", file)
 GET /*file                      controllers.Assets.at(path="/public", file)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,6 +50,7 @@ module.exports = (env) => {
       bundlesLandingPage: 'pages/bundles-landing/bundlesLanding.jsx',
       monthlyContributionsPage: 'pages/monthly-contributions/monthlyContributions.jsx',
       monthlyContributionsThankyouPage: 'pages/monthly-contributions-thankyou/monthlyContributionsThankyou.jsx',
+      monthlyContributionsExistingPage: 'pages/monthly-contributions-existing/monthlyContributionsExisting.jsx',
     },
 
     output: {


### PR DESCRIPTION
## Why are you doing this?

Users cannot become recurring contributors twice. If they arrive on the checkout page and they are already a contributor, we want to redirect them to a page explaining the situation. The redirect logic was implemented in #95, directing them to `monthly-contributions/existing-contributor` on the server-side.

This PR adds a new page to sit on this URL, with some copy that I've made up and a link to one-off contributions. There's some new copy coming down the pipeline that we'll add in a future PR.

[**Trello Card**](https://trello.com/c/CP9COwnQ/609-create-an-existing-contributor-page)

## Changes

- Added a page and stylesheet for existing contributions.
- Added a route and webpack config entry for the new page.

## Screenshots

![existing-contributor-page](https://trello-attachments.s3.amazonaws.com/57f61bbc38fc029c0eee67e8/5937e38ae90c8b50a0c8cd24/2e748f51442e4562f07c56303e046852/existing-contrib.png)