### PR TITLE
Sticky Support Footer - Part 2

### DIFF
--- a/app/views/authenticatedFullUserReactTemplate.scala.html
+++ b/app/views/authenticatedFullUserReactTemplate.scala.html
@@ -20,5 +20,5 @@
 }
 
 @main(title = title, scripts = scripts) {
-    <main id="@id"></main>
+    <main id="@id" class="gu-content-wrapper"></main>
 }

--- a/assets/pages/monthly-contributions-thankyou/monthlyContributionsThankyou.jsx
+++ b/assets/pages/monthly-contributions-thankyou/monthlyContributionsThankyou.jsx
@@ -22,9 +22,9 @@ pageStartup.start();
 // ----- Render ----- //
 
 const content = (
-  <div>
+  <div className="gu-content">
     <SimpleHeader />
-    <section className="thankyou">
+    <section className="thankyou gu-content">
       <div className="thankyou__content gu-content-margin">
         <div className="thankyou__wrapper">
           <h1 className="thankyou__heading">Thank you!</h1>

--- a/assets/pages/monthly-contributions/monthlyContributions.jsx
+++ b/assets/pages/monthly-contributions/monthlyContributions.jsx
@@ -41,7 +41,7 @@ store.dispatch(setContribAmount(getQueryParameter('contributionValue', '5')));
 
 const content = (
   <Provider store={store}>
-    <div>
+    <div className="gu-content">
       <SimpleHeader />
       <div className="monthly-contrib gu-content-margin">
         <CheckoutSection className="monthly-contrib__header">

--- a/assets/stylesheets/gu-sass/layout.scss
+++ b/assets/stylesheets/gu-sass/layout.scss
@@ -50,7 +50,6 @@ $gu-v-spacing: 12px;
 // The paddings at different breakpoints for the content.
 .gu-content-margin {
   padding: 0 ($gu-h-spacing / 2);
-  height: 100%;
 
   @include mq($from: mobileLandscape) {
     padding: 0 $gu-h-spacing;
@@ -65,21 +64,27 @@ $gu-v-spacing: 12px;
   }
 }
 
-// The element into which React content is injected.
 .gu-content-wrapper {
   height: 100%;
 
   > div {
-    display: flex;
     height: 100%;
+  }
+
+  .gu-content {
+    @supports (display: flex) {
+      display: flex;
+    }
+    // height: 100%;
     flex-direction: column;
-  }
-
-  header {
-    flex: 0 0 auto;
-  }
-
-  section {
     flex: 1 0 auto;
+
+    .gu-content-margin {
+      flex: 1 0 auto;
+    }
+
+    header, footer {
+      flex: 0 0 auto;
+    }
   }
 }

--- a/assets/stylesheets/gu-sass/layout.scss
+++ b/assets/stylesheets/gu-sass/layout.scss
@@ -74,17 +74,16 @@ $gu-v-spacing: 12px;
   .gu-content {
     @supports (display: flex) {
       display: flex;
-    }
-    // height: 100%;
-    flex-direction: column;
-    flex: 1 0 auto;
-
-    .gu-content-margin {
+      flex-direction: column;
       flex: 1 0 auto;
-    }
 
-    header, footer {
-      flex: 0 0 auto;
+      .gu-content-margin {
+        flex: 1 0 auto;
+      }
+
+      header, footer {
+        flex: 0 0 auto;
+      }
     }
   }
 }


### PR DESCRIPTION
## Why are you doing this?

The first attempt at doing this, in #103, resulted in some issues, the worst of which was Safari 8:

![safari-8](https://trello-attachments.s3.amazonaws.com/57f61bbc38fc029c0eee67e8/59512906650ee70134d32f64/c2e8a631d7f4580e5fb848c13721bfde/safari-bug.png)

In brief, the implementation of flexbox in Safari 8 is terrible. It also looked a little wonky in modern Safari and Chrome (although fine in Firefox for some reason):

![previous-safari-chrome](https://user-images.githubusercontent.com/5131341/27585710-410557e8-5b35-11e7-9021-f77d70b502a6.png)

This PR tweaks the implementation, and uses the `@supports` CSS rule to apply flexbox only if it is supported. In practice, because the `@supports` rule itself is not supported on the oldest browsers (IE and Safari 8), flexbox is turned off for all of these (even though it was actually ok in IE in this case). In summary, the sticky footer works in Firefox, Chrome, Edge and Safari 9+, and falls back to not being sticky in anything older.

[**Trello Card**](https://trello.com/c/0XbFCzkt/661-fix-support-footer-on-safari-8)

## Changes

- Applied `.gu-content-wrapper` to the main react element.
- Created a new `.gu-content` class that applies flexbox to page content.

## Screenshots

**Modern Browsers:**

![modern](https://user-images.githubusercontent.com/5131341/27585744-55184344-5b35-11e7-8222-d25b9cafa93a.png)

**Older Browsers:**

![older-browsers](https://user-images.githubusercontent.com/5131341/27585756-608d3072-5b35-11e7-8993-8653fd1c5037.png)
