### PR TITLE
Add Production Stripe

### DIFF
--- a/app/config/Configuration.scala
+++ b/app/config/Configuration.scala
@@ -15,4 +15,9 @@ class Configuration {
   lazy val supportUrl = config.getString("support.url")
 
   lazy val membersDataServiceApiUrl = config.getString("membersDataService.api.url")
+
+  lazy val touchpointConfigProvider = new TouchpointConfigProvider(
+    config.getConfig("touchpoint.backend.environments"),
+    stage
+  )
 }

--- a/app/config/TouchpointConfigProvider.scala
+++ b/app/config/TouchpointConfigProvider.scala
@@ -1,0 +1,33 @@
+package config
+
+import com.typesafe.config.Config
+
+case class StripeConfig(publicKey: String)
+
+object StripeConfig {
+
+  def fromConfig(config: Config): StripeConfig = {
+    StripeConfig(config.getString("api.key.public"))
+  }
+
+}
+
+class TouchpointConfigProvider(config: Config, defaultStage: Stage) {
+
+  lazy val defaultStripeConfig = StripeConfig.fromConfig(
+    config.getConfig(s"${defaultStage.toString}.stripe")
+  )
+
+  lazy val uatStripeConfig = StripeConfig.fromConfig(
+    config.getConfig("UAT.stripe")
+  )
+
+  def getStripeConfig(isTestUser: Boolean): StripeConfig = {
+    if (isTestUser) {
+      uatStripeConfig
+    } else {
+      defaultStripeConfig
+    }
+  }
+
+}

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -25,13 +25,6 @@ class Application(
     Ok(views.html.react(title, id, js))
   }
 
-  def authenticatedFullUserReactTemplate(title: String, id: String, js: String): Action[AnyContent] = AuthenticatedTestUserAction.async { implicit request =>
-
-    identityService.getUser(request.user).map { user =>
-      Ok(views.html.authenticatedFullUserReactTemplate(title, id, js, user))
-    } getOrElse InternalServerError
-  }
-
   def healthcheck: Action[AnyContent] = PrivateAction {
     Ok("healthy")
   }

--- a/app/controllers/MonthlyContributions.scala
+++ b/app/controllers/MonthlyContributions.scala
@@ -15,7 +15,8 @@ import com.gu.support.workers.model.User
 import com.typesafe.scalalogging.LazyLogging
 import lib.TestUsers
 import scala.concurrent.Future
-import views.html.authenticatedFullUserReactTemplate
+import views.html.monthlyContributions
+import config.TouchpointConfigProvider
 
 class MonthlyContributions(
     implicit
@@ -25,7 +26,8 @@ class MonthlyContributions(
     exec: ExecutionContext,
     membersDataService: MembersDataService,
     identityService: IdentityService,
-    testUsers: TestUsers
+    testUsers: TestUsers,
+    touchpointConfigProvider: TouchpointConfigProvider
 ) extends Controller with Circe with LazyLogging {
 
   import actionRefiners._
@@ -36,11 +38,14 @@ class MonthlyContributions(
         case Some(true) => Redirect("/monthly-contributions/existing-contributor")
         case Some(false) | None =>
           Ok(
-            authenticatedFullUserReactTemplate(
+            monthlyContributions(
               title = "Support the Guardian | Monthly Contributions",
               id = "monthly-contributions-page",
               js = "monthlyContributionsPage.js",
-              user = fullUser
+              user = fullUser,
+              stripeConfig = touchpointConfigProvider.getStripeConfig(
+                testUsers.isTestUser(fullUser.publicFields.displayName)
+              )
             )
           )
       }

--- a/app/views/monthlyContributions.scala.html
+++ b/app/views/monthlyContributions.scala.html
@@ -1,6 +1,13 @@
 @import assets.AssetsResolver
 @import com.gu.identity.play.IdUser
-@(title: String, id: String, js: String, user: IdUser)(implicit assets: AssetsResolver)
+@import config.StripeConfig
+@(
+  title: String,
+  id: String,
+  js: String,
+  user: IdUser,
+  stripeConfig: StripeConfig
+)(implicit assets: AssetsResolver)
 
 @scripts = {
     <script type="text/javascript">
@@ -15,6 +22,7 @@
             lastName: "@lastName",
             }
         };
+        window.guardian.stripeKey = "@stripeConfig.publicKey";
     </script>
     <script type="text/javascript" src="@assets(js)"></script>
 }

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -15,6 +15,7 @@ import play.api.mvc.EssentialFilter
 import play.filters.gzip.GzipFilter
 import services.{AuthenticationService, IdentityService, MembersDataService}
 import lib.TestUsers
+import config.Stages
 
 trait AppComponents extends PlayComponents with AhcWSComponents {
 
@@ -34,8 +35,9 @@ trait AppComponents extends PlayComponents with AhcWSComponents {
     testUsers = testUsers
   )
 
-  implicit lazy val monthlyContributionsClient = new MonthlyContributionsClient(config.stage)
+  implicit lazy val monthlyContributionsClient = new MonthlyContributionsClient(if (config.stage == Stages.DEV) Stages.CODE else config.stage)
   implicit lazy val testUsers = new TestUsers(config.identity.testUserSecret)
+  implicit lazy val touchpointConfigProvider = config.touchpointConfigProvider
 
   lazy val assetController = new Assets(httpErrorHandler)
   lazy val applicationController = new Application

--- a/assets/helpers/stripeCheckout/stripeCheckout.js
+++ b/assets/helpers/stripeCheckout/stripeCheckout.js
@@ -41,7 +41,7 @@ export const setup = (
     name: 'Guardian',
     description: 'Please enter your card details.',
     allowRememberMe: false,
-    key: 'pk_test_Qm3CGRdrV4WfGYCpm0sftR0f',
+    key: window.guardian.stripeKey,
     image: 'https://d24w1tjgih0o9s.cloudfront.net/gu.png',
     locale: 'auto',
     currency: state.currency,

--- a/conf/DEV.public.conf
+++ b/conf/DEV.public.conf
@@ -5,7 +5,7 @@
 #
 # This file should be line-for-line comparable with other "[STAGE].public.conf" files
 
-stage="CODE"
+stage="DEV"
 
 identity.webapp.url="https://profile-origin.thegulocal.com"
 identity.api.url="https://idapi.code.dev-theguardian.com"

--- a/test/controllers/MonthlyContributionsTest.scala
+++ b/test/controllers/MonthlyContributionsTest.scala
@@ -21,6 +21,7 @@ import lib.actions.ActionRefiners
 import lib.stepfunctions.MonthlyContributionsClient
 import services.{IdentityService, MembersDataService}
 import services.MembersDataService._
+import config.{StripeConfig, TouchpointConfigProvider}
 
 class MonthlyContributionsTest extends WordSpec with MustMatchers {
 
@@ -113,6 +114,8 @@ class MonthlyContributionsTest extends WordSpec with MustMatchers {
         identityService: IdentityService = mockedIdentityService(authenticatedIdUser.user -> idUser.asRight[String]),
         membersDataService: MembersDataService = mock[MembersDataService]
       ): Future[Result] = {
+        val touchpointConfigProvider = mock[TouchpointConfigProvider]
+        when(touchpointConfigProvider.getStripeConfig(any[Boolean])).thenReturn(StripeConfig("test-key"))
         new MonthlyContributions()(
           mock[MonthlyContributionsClient],
           assetResolver,
@@ -120,7 +123,8 @@ class MonthlyContributionsTest extends WordSpec with MustMatchers {
           global,
           membersDataService,
           identityService,
-          testUsers
+          testUsers,
+          touchpointConfigProvider
         ).displayForm(FakeRequest())
       }
     }


### PR DESCRIPTION
## Why are you doing this?

Currently Stripe is hardcoded to run with the test public key, but we want to use the production one in PROD. This PR selects the appropriate key based upon stage (DEV/UAT/PROD), and makes it available on the guardian window object. It stores the key in the private config in S3.

We have three stages, DEV, UAT and PROD. Stripe has two, Test and Production. These line up as follows:

- In **DEV** we use **Stripe Test**.
- In **UAT** we use **Stripe Test**.
- In **PROD** we use **Stripe Production**.

This PR also sets the DEV stage back to DEV in the config, it was temporarily set to CODE a little while ago to allow a developer running locally to still hit the CODE step functions. Instead we've tweaked things in `AppComponents` so that even if the stage is DEV, we're still hitting the CODE step functions.

**Note:** Following this PR we will be updating both the PROD and DEV private config to include the Stripe keys, you'll need to pull down a fresh copy of the DEV config when running support-frontend locally in future.

cc: @davidfurey

[**Trello Card**](https://trello.com/c/5Ia1MLsz/656-stripe-production-sandbox-keys)

## Changes

- Added `touchpointConfigProvider` to `Configuration`.
- Added new `TouchpointConfigProvider` class, with `StripeConfig`, for retrieving the Stripe key from config. We're sticking with the touchpoint nomenclature for consistency with support-workers and the other membership codebases (e.g. subs, mem-common).
- Removed an unused method from `Application` controller.
- Passed the `touchpointConfigProvider` through the monthly contributions controller, to make it available to the template.
- Renamed the `authenticatedFullUserReactTemplate` to `monthlyContributions`, as that's all it's being used for at the moment. Also updated it to make the stripe key available on the guardian window object.
- Set the `MonthlyContributionsClient` to take CODE as the stage when in DEV, in `AppComponents`. Also made `TouchpointConfigProvider` available.
- Updated `stripeCheckout` to use the Stripe key on the guardian window object.
- Switched back to DEV stage in the DEV config.
- Updated the tests to allow for `TouchpointConfigProvider`.
