### PR TITLE
Modernise Bundles Landing Page

### DIFF
--- a/assets/components/doubleHeading/doubleHeading.scss
+++ b/assets/components/doubleHeading/doubleHeading.scss
@@ -1,6 +1,6 @@
 .component-double-heading {
-	line-height: 27px;
 	font-size: 28px;
+	line-height: 32px;
 
 	.component-double-heading__heading {
 		font-weight: 900;
@@ -14,6 +14,12 @@
 		margin: 0;
 		font-family: $gu-text-sans-web;
 		font-weight: normal;
-		line-height: 30px;
+		font-size: 20px;
+		line-height: 24px;
+
+		@include mq($from: phablet) {
+			font-size: 24px;
+			line-height: 28px;
+		}
 	}
 }

--- a/assets/components/featureList/featureList.scss
+++ b/assets/components/featureList/featureList.scss
@@ -2,7 +2,7 @@
 	margin: 0;
 	padding: 0;
 	padding-left: 10px;
-	
+
 
 	h3, p {
 		margin: 0;
@@ -11,8 +11,8 @@
 	h3 {
 		font-family: $gu-text-sans-web;
 		font-weight: 900;
-		font-size: 18px;
-		line-height: 22px;
+		font-size: 16px;
+		line-height: 20px;
 	}
 
 	p {

--- a/assets/components/numberInput/numberInput.scss
+++ b/assets/components/numberInput/numberInput.scss
@@ -7,6 +7,11 @@
 	height: 24px;
 	text-align: center;
 	font-size: 14px;
+	font-family: $gu-text-sans-web;
+
+	&::placeholder {
+		color: gu-colour(neutral-1);
+	}
 
 	&:focus {
 		outline: none;

--- a/assets/components/termsPrivacy/termsPrivacy.scss
+++ b/assets/components/termsPrivacy/termsPrivacy.scss
@@ -1,3 +1,3 @@
 .component-terms-privacy {
-	font-size: 15px;
+	font-size: 14px;
 }

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -9,7 +9,7 @@
     background-color: darken(gu-colour(comment-support-2), 5%);
 
     .introduction__content {
-      padding-top: $gu-v-spacing / 2;
+      padding-top: $gu-v-spacing;
       padding-bottom: $gu-v-spacing;
       background-color: gu-colour(comment-support-2);
 
@@ -23,100 +23,62 @@
     }
 
     h1 {
-      color: gu-colour(news-support-2);
-      font-family: 'Guardian Titlepiece Web', sans-serif;
-      font-weight: 400;
-      font-size: 28px;
-      line-height: 32px;
+      color: gu-colour(news-support-1);
+      font-family: $gu-egyptian-web;
+      font-weight: bold;
+      font-size: 22px;
+      line-height: 26px;
       word-spacing: -0.08em;
 
-      @include mq($from: mobileLandscape) {
+      @include mq($from: mobileMedium) {
+        font-size: 24px;
+        line-height: 28px;
+      }
+
+      @include mq($from: phablet) {
         font-size: 36px;
         line-height: 40px;
       }
 
-      @include mq($from: phablet) {
-        font-size: 40px;
-        line-height: 44px;
-      }
-
       @include mq($from: desktop) {
-        font-size: 48px;
-        line-height: 52px;
+        font-size: 44px;
+        line-height: 48px;
       }
     }
 
     p {
       font-family: $gu-egyptian-web;
-      font-weight: normal;
-      font-size: 16px;
-      line-height: 20px;
-      color: gu-colour(neutral-1);
-
-      &:nth-of-type(1) {
-        margin-left: 80px;
-      }
+      font-weight: bold;
+      font-size: 22px;
+      line-height: 26px;
+      color: #ffffff;
+      margin-left: 40px;
 
       &:nth-of-type(2) {
-        margin-left: 120px;
+        margin-bottom: $gu-v-spacing * 2;
       }
 
-      &:nth-of-type(3) {
-        margin-left: 40px;
+      &:nth-of-type(4) {
+        margin-bottom: $gu-v-spacing * 4;
       }
 
       @include mq($from: mobileMedium) {
-        font-size: 19px;
-        line-height: 23px;
-      }
-
-      @include mq($from: mobileLandscape) {
-        font-size: 23px;
-        line-height: 27px;
+        font-size: 24px;
+        line-height: 28px;
+        margin-left: 88px;
       }
 
       @include mq($from: phablet) {
-        font-size: 28px;
-        line-height: 32px;
-
-        &:nth-of-type(1) {
-          margin-left: 240px;
-        }
-
-        &:nth-of-type(2) {
-          margin-left: 320px;
-        }
-
-        &:nth-of-type(3) {
-          margin-left: 160px;
-        }
-
-        &:nth-of-type(4) {
-          margin-left: 80px;
-        }
+        font-size: 36px;
+        line-height: 40px;
+        margin-left: 128px;
       }
 
-      @include mq($from: tablet) {
-        &:nth-of-type(1) {
-          margin-left: 320px;
-        }
-
-        &:nth-of-type(2) {
-          margin-left: 400px;
-        }
-
-        &:nth-of-type(3) {
-          margin-left: 240px;
-        }
-
-        &:nth-of-type(4) {
-          margin-left: 160px;
-        }
-      }
 
       @include mq($from: desktop) {
-        font-size: 32px;
-        line-height: 36px;
+        font-size: 44px;
+        line-height: 48px;
+        margin-left: 160px;
       }
     }
   }
@@ -601,7 +563,7 @@
 
 
   // ----- Ways Of Support
-  
+
   .ways-of-support {
 
     @include mq($from: mobileLandscape) {
@@ -642,7 +604,7 @@
       @include mq($until: tablet) {
         h1 {
           width: 240px;
-        }        
+        }
       }
 
       @include mq($until: mobileLandscape) {
@@ -754,7 +716,7 @@
   .component-double-heading--variant-a {
     margin-bottom: 0;
   }
-  
+
   input:checked+label {
     background-color: gu-colour(guardian-brand-dark);
     color: #fff;

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -6,12 +6,12 @@
 
   .introduction {
 
-    background-color: darken(gu-colour(comment-support-2), 5%);
+    background-color: darken(gu-colour(guardian-brand-dark), 5%);
 
     .introduction__content {
       padding-top: $gu-v-spacing;
       padding-bottom: $gu-v-spacing;
-      background-color: gu-colour(comment-support-2);
+      background-color: gu-colour(guardian-brand-dark);
 
       @include mq($from: leftCol) {
         padding-left: 100px;
@@ -90,8 +90,29 @@
 
     background-color: darken(gu-colour(comment-support-2), 5%);
 
+    .bundles__introduction-bleed, .bundles__introduction-bleed-margins {
+      height: 180px;
+      background-color: darken(gu-colour(guardian-brand-dark), 5%);
+      position: absolute;
+      left: 0;
+      width: 100%;
+
+      @include mq($from: phablet) {
+        height: 130px;
+      }
+
+      @include mq($from: desktop) {
+        height: 210px;
+      }
+    }
+
+    .bundles__introduction-bleed {
+      background-color: gu-colour(guardian-brand-dark);
+    }
+
     .bundles__content {
       background-color: gu-colour(comment-support-2);
+      position: relative;
 
       @include mq($until: desktop) {
         padding-bottom: ($gu-v-spacing * 8);
@@ -104,6 +125,8 @@
     }
 
     .bundles__wrapper {
+      position: relative;
+
       @include mq($from: phablet, $until: desktop) {
         width: 100%;
       }

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -94,12 +94,12 @@
       background-color: gu-colour(comment-support-2);
 
       @include mq($until: desktop) {
-        padding-bottom: $gu-v-spacing;
+        padding-bottom: ($gu-v-spacing * 8);
       }
 
       @include mq($from: desktop) {
         padding: 0 0;
-        padding-bottom: ($gu-v-spacing * 2);
+        padding-bottom: ($gu-v-spacing * 8);
       }
     }
 
@@ -124,7 +124,7 @@
     }
 
     .bundles__bundle {
-      padding: 8px ($gu-h-spacing / 2) $gu-v-spacing;
+      padding: ($gu-v-spacing / 2) ($gu-h-spacing / 2) $gu-v-spacing;
 
       @include mq($from: desktop) {
         margin: 0 ($gu-h-spacing / 2);
@@ -213,7 +213,7 @@
     }
 
     .contrib-type {
-      margin-bottom: 17px;
+      margin-bottom: 10px;
 
       input:checked+label:before {
         content: '';
@@ -263,9 +263,9 @@
 
     .contrib-amounts__error-message {
       font-family: $gu-text-sans-web;
-      font-size: 13px;
+      font-size: 14px;
       font-weight: bold;
-      line-height: 15px;
+      line-height: 16px;
       color: gu-colour(neutral-1);
     }
 
@@ -304,13 +304,13 @@
       .component-cta-link:first-of-type {
         @include mq($from: desktop) {
           bottom: $gu-v-spacing * 6;
-        }        
+        }
       }
     }
 
     .component-feature-list {
       padding-left: 0;
-      list-style-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 28 28"><style>.st0{fill:#4a7801;}</style><path class="st0" d="M7.885 25.74L0 14.82l3.22-3.217L8.3 16.74 24.695 2.26 28 5.565"/></svg>');
+      list-style-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 28 28"><style>.st0{fill:#005689;}</style><path class="st0" d="M7.885 25.74L0 14.82l3.22-3.217L8.3 16.74 24.695 2.26 28 5.565"/></svg>');
 
       h3 {
         color: gu-colour(guardian-brand);

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -139,6 +139,7 @@
     .component-cta-link {
       padding-top: $gu-v-spacing;
       padding-bottom: $gu-v-spacing;
+      margin-top: $gu-v-spacing * 4;
 
       @include mq($from: desktop) {
         position: absolute;
@@ -305,6 +306,10 @@
         @include mq($from: desktop) {
           bottom: $gu-v-spacing * 6;
         }
+      }
+
+      .component-cta-link:nth-of-type(2) {
+        margin-top: $gu-v-spacing;
       }
     }
 
@@ -739,7 +744,7 @@
 
       &::placeholder {
           font-weight: normal;
-          color: #fff;
+          color: #ffffff;
           opacity: 0.4;
       }
   }

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -261,7 +261,9 @@ function Bundles(props: PropTypes) {
 
   return (
     <section className="bundles">
+      <div className="bundles__introduction-bleed-margins" />
       <div className="bundles__content gu-content-margin">
+        <div className="bundles__introduction-bleed" />
         <div className="bundles__wrapper">
           {contributionComponent}
           <div className="bundles__divider" />

--- a/assets/pages/bundles-landing/components/Introduction.jsx
+++ b/assets/pages/bundles-landing/components/Introduction.jsx
@@ -12,11 +12,12 @@ export default function Introduction() {
   return (
     <section className="introduction">
       <div className="introduction__content gu-content-margin">
-        <h1 className="introduction__heading">support the guardian</h1>
-        <p>Be part of our future</p>
+        <h1 className="introduction__heading">support the Guardian</h1>
+        <p>be part of our future</p>
         <p>by helping to secure it</p>
-        <p>Hold power to account</p>
-        <p>by funding quality, independent journalism</p>
+        <h1 className="introduction__heading__two">hold power to account</h1>
+        <p>by funding quality,</p>
+        <p>independent journalism</p>
       </div>
     </section>
   );


### PR DESCRIPTION
## Why are you doing this?

To make the bundles landing page look good before we go live with the baseline test. This PR only modifies the introduction and bundles sections.

[**Trello Card**](https://trello.com/c/uE8jYPo2/671-style-changes-on-shopfront-page)

cc: @superfrank

## Changes

- Made the print bundles white with blue highlights.
- Made the contributions bundle yellow and black, dropped the orange.
- Tweaked the layout and copy for the introduction text.
- Made the introduction blue with a bleed into the bundles section.
- Miscellaneous other style tweaks.

## Screenshots

**Desktop:**

![bundles-desktop](https://user-images.githubusercontent.com/5131341/27802349-3d28ef78-601b-11e7-9850-64eb87433ae8.png)

**Tablet:**

![bundles-tablet](https://user-images.githubusercontent.com/5131341/27802353-42b8fe10-601b-11e7-9d09-14860c834c88.png)

**Mobile:**

![bundles-mobile](https://user-images.githubusercontent.com/5131341/27802358-48118760-601b-11e7-96ad-3a291484b82b.png)
