### PR TITLE
Bundles Landing - Minor Design Tweaks

### DIFF
--- a/assets/components/doubleHeading/doubleHeading.jsx
+++ b/assets/components/doubleHeading/doubleHeading.jsx
@@ -21,18 +21,14 @@ export default function DoubleHeading(props: PropTypes) {
 
   const className = generateClassName('component-double-heading', props.modifierClass);
 
-  const subhead = (
-    <h2 className="component-double-heading__subheading">
-      { props.subheading }
-    </h2>
-  );
-
   return (
     <div className={className}>
       <h1 className="component-double-heading__heading">
         { props.heading }
       </h1>
-      { props.subheading ? subhead : '' }
+      <h2 className="component-double-heading__subheading">
+        { props.subheading }
+      </h2>
     </div>
   );
 

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -228,6 +228,14 @@
         color: gu-colour(neutral-1);
       }
 
+      .component-double-heading__subheading {
+        height: 24px;
+
+        @include mq($from: phablet) {
+          height: 32px;
+        }
+      }
+
       input:checked+label {
         background-color: gu-colour(neutral-1);
         color: #fff;

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -333,6 +333,16 @@
 
       .component-cta-link:nth-of-type(2) {
         margin-top: $gu-v-spacing;
+        background-color: gu-colour(guardian-brand);
+        color: #fff;
+
+        &:hover {
+          background-color: darken(gu-colour(guardian-brand), 10%);
+        }
+
+        svg {
+          fill: #fff;
+        }
       }
     }
 

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -132,6 +132,11 @@ const ctaLinks = {
   oneOff: 'https://contribute.theguardian.com/uk',
 };
 
+const contribSubheading = {
+  recurring: 'from £5/month',
+  oneOff: '',
+};
+
 const contribToggle = {
   name: 'contributions-period-toggle',
   radios: [
@@ -152,13 +157,14 @@ const getContribAttrs = ({ contribType, contribAmount, intCmp }): ContribBundle 
 
   const contType = contribType === 'RECURRING' ? 'recurring' : 'oneOff';
   const amountParam = contType === 'recurring' ? 'contributionValue' : 'amount';
+  const subheading = contribSubheading[contType];
   const params = new URLSearchParams();
 
   params.append(amountParam, contribAmount[contType].value);
   params.append('INTCMP', intCmp);
   const ctaLink = `${ctaLinks[contType]}?${params.toString()}`;
 
-  return Object.assign({}, bundles.contrib, { ctaLink });
+  return Object.assign({}, bundles.contrib, { ctaLink, subheading });
 
 };
 

--- a/assets/pages/bundles-landing/reducers/__tests__/__snapshots__/reducersTest.js.snap
+++ b/assets/pages/bundles-landing/reducers/__tests__/__snapshots__/reducersTest.js.snap
@@ -11,7 +11,7 @@ Object {
       },
       "recurring": Object {
         "userDefined": false,
-        "value": "5",
+        "value": "10",
       },
     },
     "error": null,

--- a/assets/pages/bundles-landing/reducers/reducers.js
+++ b/assets/pages/bundles-landing/reducers/reducers.js
@@ -45,7 +45,7 @@ const initialContrib: ContribState = {
   error: null,
   amount: {
     recurring: {
-      value: '5',
+      value: '10',
       userDefined: false,
     },
     oneOff: {


### PR DESCRIPTION
## Why are you doing this?

Follow-up to #108, this makes another couple of tweaks to the designs:

1. Made the CTA for paper+digital blue instead of white.
2. Hide the 'from £5/month' subheading on the contributions bundle when the user selects one-off contribution.
3. Make £10 the default recurring contribution.

cc: @Elvis-Rimdap

## Changes

- Made the doubleHeading component still render an h2 even when there is no subheading.
- Make the empty subheading the same height to stop jumping.
- Made the paper+digital cat blue with white highlights, darkens on hover.
- Passed through an empty subheading for one-off contributions.
- Made £10 the default recurring contrib in the reducer initial state.

## Screenshots

**One-off subheading:**

![empty-subheading](https://user-images.githubusercontent.com/5131341/27829189-29c78d84-60b8-11e7-8634-c950ed846632.png)

**Blue CTA:**

![blue-cta](https://user-images.githubusercontent.com/5131341/27829196-315b008a-60b8-11e7-9bb0-12da02837593.png)

**£10 Recurring:**

![10-default](https://user-images.githubusercontent.com/5131341/27838389-487fe904-60e2-11e7-86c7-038770775a40.png)
