### PR TITLE
Fix bundles landing accessibility

### DIFF
--- a/assets/components/ctaCircle/ctaCircle.jsx
+++ b/assets/components/ctaCircle/ctaCircle.jsx
@@ -5,14 +5,16 @@
 import React from 'react';
 import Svg from 'components/svg/svg';
 import { generateClassName } from 'helpers/utilities';
-
+import { clickSubstitueKeyPressHandler } from 'helpers/utilities';
 
 // ----- Types ----- //
 
 type PropTypes = {
   text: string,
   modifierClass: ?string,
-  onClick: () => void,
+  url?: string,
+  onClick?: () => void,
+  tabIndex?: number,
 };
 
 
@@ -24,8 +26,15 @@ const CtaCircle = (props: PropTypes) => {
   const className = generateClassName('component-cta-circle', props.modifierClass);
 
   return (
-    <a className={className} onClick={props.onClick} role="link" tabIndex={0}>
-      <button><Svg svgName="arrow-right-straight" /></button>
+    <a
+      className={className}
+      onClick={props.onClick}
+      href={props.url}
+      onKeyPress={clickSubstitueKeyPressHandler(props.onClick)}
+      tabIndex={props.tabIndex}
+    >
+
+      <button tabIndex={-1}><Svg svgName="arrow-right-straight" /></button>
       <span>{props.text}</span>
     </a>
   );
@@ -34,6 +43,9 @@ const CtaCircle = (props: PropTypes) => {
 
 CtaCircle.defaultProps = {
   modifierClass: '',
+  url: null,
+  onClick: null,
+  tabIndex: 0,
 };
 
 

--- a/assets/components/ctaLink/ctaLink.jsx
+++ b/assets/components/ctaLink/ctaLink.jsx
@@ -12,6 +12,7 @@ type PropTypes = {
   text: string,
   url?: string,
   onClick?: () => void,
+  tabIndex?: number,
 };
 
 
@@ -19,7 +20,7 @@ type PropTypes = {
 
 export default function CtaLink(props: PropTypes) {
   return (
-    <a className="component-cta-link" href={props.url} onClick={props.onClick}>
+    <a className="component-cta-link" href={props.url} onClick={props.onClick} tabIndex={props.tabIndex}>
       <span>{props.text}</span>
       <Svg svgName="arrow-right-straight" />
     </a>
@@ -31,5 +32,6 @@ export default function CtaLink(props: PropTypes) {
 CtaLink.defaultProps = {
   url: null,
   onClick: null,
+  tabIndex: 0,
 };
 

--- a/assets/components/ctaLink/ctaLink.jsx
+++ b/assets/components/ctaLink/ctaLink.jsx
@@ -15,12 +15,24 @@ type PropTypes = {
   tabIndex?: number,
 };
 
+// ----- Functions ----- //
+
+const onKeyPressHandler = (handler?: () => void): (event: Object) => void =>
+(event: Object) => {
+  // Check to see if space or enter were pressed
+  if (event.keyCode === 32 || event.keyCode === 13) {
+    event.preventDefault();
+    if (handler) {
+      handler();
+    }
+  }
+};
 
 // ----- Component ----- //
 
 export default function CtaLink(props: PropTypes) {
   return (
-    <a className="component-cta-link" href={props.url} onClick={props.onClick} tabIndex={props.tabIndex}>
+    <a className="component-cta-link" href={props.url} onClick={props.onClick} onKeyPress={onKeyPressHandler(props.onClick)} tabIndex={props.tabIndex}>
       <span>{props.text}</span>
       <Svg svgName="arrow-right-straight" />
     </a>

--- a/assets/components/ctaLink/ctaLink.jsx
+++ b/assets/components/ctaLink/ctaLink.jsx
@@ -17,12 +17,12 @@ type PropTypes = {
 
 // ----- Functions ----- //
 
-const onKeyPressHandler = (handler?: () => void = () => {}) =>
+const clickSubstitueKeyPressHandler = (handler?: () => void = () => {}) =>
   (event: Object) => {
     const CarriageReturnCode = 13;
     const SpaceCode = 32;
 
-    if ([CarriageReturnCode, SpaceCode].includes(event.keyCode)) {
+    if (event.keyCode === CarriageReturnCode || event.keyCode === SpaceCode) {
       event.preventDefault();
       handler();
     }
@@ -32,7 +32,7 @@ const onKeyPressHandler = (handler?: () => void = () => {}) =>
 
 export default function CtaLink(props: PropTypes) {
   return (
-    <a className="component-cta-link" href={props.url} onClick={props.onClick} onKeyPress={onKeyPressHandler(props.onClick)} tabIndex={props.tabIndex}>
+    <a className="component-cta-link" href={props.url} onClick={props.onClick} onKeyPress={clickSubstitueKeyPressHandler(props.onClick)} tabIndex={props.tabIndex}>
       <span>{props.text}</span>
       <Svg svgName="arrow-right-straight" />
     </a>

--- a/assets/components/ctaLink/ctaLink.jsx
+++ b/assets/components/ctaLink/ctaLink.jsx
@@ -4,6 +4,7 @@
 
 import React from 'react';
 import Svg from 'components/svg/svg';
+import { clickSubstitueKeyPressHandler } from 'helpers/utilities';
 
 
 // ----- Types ----- //
@@ -14,19 +15,6 @@ type PropTypes = {
   onClick?: () => void,
   tabIndex?: number,
 };
-
-// ----- Functions ----- //
-
-const clickSubstitueKeyPressHandler = (handler?: () => void = () => {}) =>
-  (event: Object) => {
-    const CarriageReturnCode = 13;
-    const SpaceCode = 32;
-
-    if (event.keyCode === CarriageReturnCode || event.keyCode === SpaceCode) {
-      event.preventDefault();
-      handler();
-    }
-  };
 
 // ----- Component ----- //
 

--- a/assets/components/ctaLink/ctaLink.jsx
+++ b/assets/components/ctaLink/ctaLink.jsx
@@ -17,16 +17,16 @@ type PropTypes = {
 
 // ----- Functions ----- //
 
-const onKeyPressHandler = (handler?: () => void): (event: Object) => void =>
-(event: Object) => {
-  // Check to see if space or enter were pressed
-  if (event.keyCode === 32 || event.keyCode === 13) {
-    event.preventDefault();
-    if (handler) {
+const onKeyPressHandler = (handler?: () => void = () => {}) =>
+  (event: Object) => {
+    const CarriageReturnCode = 13;
+    const SpaceCode = 32;
+
+    if ([CarriageReturnCode, SpaceCode].includes(event.keyCode)) {
+      event.preventDefault();
       handler();
     }
-  }
-};
+  };
 
 // ----- Component ----- //
 

--- a/assets/components/radioToggle/radioToggle.scss
+++ b/assets/components/radioToggle/radioToggle.scss
@@ -1,7 +1,8 @@
 .component-radio-toggle {
 
 	input[type="radio"] {
-		display: none;
+		position: absolute;
+		opacity: 0;
 	}
 
 	label {

--- a/assets/helpers/utilities.js
+++ b/assets/helpers/utilities.js
@@ -28,3 +28,17 @@ export function generateClassName(className: string, modifierClass: ?string): st
   return response;
 }
 
+// Generates a key handler that only trigger a function if the
+// CarriageReturnCode and SpaceCode are pressed
+export function clickSubstitueKeyPressHandler(handler?: () => void = () => {}) {
+  return (event: Object) => {
+    const CarriageReturnCode = 13;
+    const SpaceCode = 32;
+
+    if (event.keyCode === CarriageReturnCode || event.keyCode === SpaceCode) {
+      event.preventDefault();
+      handler();
+    }
+  };
+}
+

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -266,6 +266,11 @@
           max-width: 93%;
         }
       }
+
+      .component-radio-toggle__input {
+        display: none;
+      }
+
     }
 
     .contrib-amounts__other-amount {


### PR DESCRIPTION
## Why are you doing this?
We need the bundle landing page to as accessible as possible. Therefore, in this PR we fix the tab flow of the page and additionally we add the onKeyBehaviour for the links that are using onClick functions.

[**Trello Card**](https://trello.com/c/IyG06KgO/654-accessibility-issue-not-possible-to-navigate-properly-on-supporttheguardiancom-without-a-mouse)


## Screenshots

### Contribute with the keyboard
![contribute](https://user-images.githubusercontent.com/825398/27955362-6152c95c-630c-11e7-8539-96aeec2480e7.gif)


### Tab flow
![tabflow](https://user-images.githubusercontent.com/825398/27955260-f13d232e-630b-11e7-88ba-6829825844a7.gif)







