### PR TITLE
Update circe plugin to Play 2.6 version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-stepfunctions" % "1.11.128",
   "com.typesafe.akka" %% "akka-agent" % "2.4.12",
   "org.typelevel" %% "cats" % "0.9.0",
-  "play-circe" %% "play-circe" % "2.5-0.8.0",
+  "play-circe" %% "play-circe" % "2.6-0.8.0",
   "com.gu" %% "support-models" % "0.5",
   "com.gu" %% "support-internationalisation" % "0.2",
   "io.circe" %% "circe-core" % circeVersion,


### PR DESCRIPTION
## Why are you doing this?

To fix `[NoSuchMethodError: play.api.mvc.BodyParsers$.parse()Lplay/api/mvc/BodyParsers$parse$;]` when `POST`ing to `/monthly-contributions/create`.

## Changes

* Upgrade to Play 2.6 version of play-circe
