### PR TITLE
Fix Header Logo on IE

### DIFF
--- a/assets/components/headers/simpleHeader/simpleHeader.jsx
+++ b/assets/components/headers/simpleHeader/simpleHeader.jsx
@@ -14,7 +14,7 @@ export default function SimpleHeader() {
   return (
     <header className="component-simple-header">
       <div className="component-simple-header__content gu-header-margin">
-        <a href="https://www.theguardian.com">
+        <a className="component-simple-header__link" href="https://www.theguardian.com">
           <Svg svgName="guardian-titlepiece" />
         </a>
       </div>

--- a/assets/components/headers/simpleHeader/simpleHeader.scss
+++ b/assets/components/headers/simpleHeader/simpleHeader.scss
@@ -1,8 +1,12 @@
 .component-simple-header {
 	background-color: gu-colour(guardian-brand);
 
-	.svg-guardian-titlepiece {
+	.component-simple-header__link {
 		float: right;
+		height: 100%;
+	}
+
+	.svg-guardian-titlepiece {
 		height: 100%;
 	}
 


### PR DESCRIPTION
## Why are you doing this?

To keep @superfrank happy.

*or*

The logo in the header is stuck on the left in IE, but appears on the right in all other browsers. It should be on the right. It's a quick fix, simply moved the float to the enclosing link instead of applying it directly to the SVG. If only all CSS/IE issues were this straightforward.

**Note:** The logo now appears slightly smaller than it should on IE (looks fine in other browsers).

[**Trello Card**](https://trello.com/c/CEPJp5Lv/670-fix-logo-on-ie-to-make-frank-happy-size)

## Changes

- Move the `float: right` to the enclosing anchor tag, because IE doesn't like SVGs.

## Screenshots

**Before:**

![ie-before](https://user-images.githubusercontent.com/5131341/28024754-7ce3ac3e-6589-11e7-9720-e2681b27d76a.jpg)

**After:**

![ie-after](https://user-images.githubusercontent.com/5131341/28024742-754ea5dc-6589-11e7-809f-0b80dc58a8b2.jpg)
