### PR TITLE
A11y input field 

### DIFF
--- a/assets/components/ctaCircle/ctaCircle.jsx
+++ b/assets/components/ctaCircle/ctaCircle.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import Svg from 'components/svg/svg';
 import { generateClassName } from 'helpers/utilities';
-import { clickSubstitueKeyPressHandler } from 'helpers/utilities';
+import { clickSubstituteKeyPressHandler } from 'helpers/utilities';
 
 // ----- Types ----- //
 
@@ -30,7 +30,7 @@ const CtaCircle = (props: PropTypes) => {
       className={className}
       onClick={props.onClick}
       href={props.url}
-      onKeyPress={clickSubstitueKeyPressHandler(props.onClick)}
+      onKeyPress={clickSubstituteKeyPressHandler(props.onClick)}
       tabIndex={props.tabIndex}
     >
 

--- a/assets/components/ctaLink/ctaLink.jsx
+++ b/assets/components/ctaLink/ctaLink.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import Svg from 'components/svg/svg';
-import { clickSubstitueKeyPressHandler } from 'helpers/utilities';
+import { clickSubstituteKeyPressHandler } from 'helpers/utilities';
 
 
 // ----- Types ----- //
@@ -20,7 +20,7 @@ type PropTypes = {
 
 export default function CtaLink(props: PropTypes) {
   return (
-    <a className="component-cta-link" href={props.url} onClick={props.onClick} onKeyPress={clickSubstitueKeyPressHandler(props.onClick)} tabIndex={props.tabIndex}>
+    <a className="component-cta-link" href={props.url} onClick={props.onClick} onKeyPress={clickSubstituteKeyPressHandler(props.onClick)} tabIndex={props.tabIndex}>
       <span>{props.text}</span>
       <Svg svgName="arrow-right-straight" />
     </a>

--- a/assets/components/numberInput/numberInput.jsx
+++ b/assets/components/numberInput/numberInput.jsx
@@ -12,7 +12,7 @@ type PropTypes = {
   onInput: (string) => void,
   selected: ?boolean,
   placeholder: ?string,
-  onKeyPress: ?() => void,
+  onKeyPress: ?(event: Object) => void,
 };
 
 
@@ -29,7 +29,7 @@ export default function NumberInput(props: PropTypes) {
       placeholder={props.placeholder}
       onFocus={e => props.onFocus(e.target.value || '')}
       onInput={e => props.onInput(e.target.value || '')}
-      onKeyPress={ props.onKeyPress }
+      onKeyPress={props.onKeyPress}
     />
   );
 

--- a/assets/components/numberInput/numberInput.jsx
+++ b/assets/components/numberInput/numberInput.jsx
@@ -12,6 +12,7 @@ type PropTypes = {
   onInput: (string) => void,
   selected: ?boolean,
   placeholder: ?string,
+  onKeyPress: ?() => void,
 };
 
 
@@ -28,6 +29,7 @@ export default function NumberInput(props: PropTypes) {
       placeholder={props.placeholder}
       onFocus={e => props.onFocus(e.target.value || '')}
       onInput={e => props.onInput(e.target.value || '')}
+      onKeyPress={ props.onKeyPress }
     />
   );
 
@@ -39,4 +41,5 @@ export default function NumberInput(props: PropTypes) {
 NumberInput.defaultProps = {
   selected: false,
   placeholder: null,
+  onKeyPress: null,
 };

--- a/assets/helpers/utilities.js
+++ b/assets/helpers/utilities.js
@@ -30,7 +30,7 @@ export function generateClassName(className: string, modifierClass: ?string): st
 
 // Generates a key handler that only trigger a function if the
 // CarriageReturnCode and SpaceCode are pressed
-export function clickSubstitueKeyPressHandler(handler?: () => void = () => {}) {
+export function clickSubstituteKeyPressHandler(handler?: () => void = () => {}) {
   return (event: Object) => {
     const CarriageReturnCode = 13;
     const SpaceCode = 32;

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -198,7 +198,7 @@ const getControlVariant = (props: PropTypes, attrs: ContribBundle, onClick: () =
         checked={props.contribType}
       />
     </div>
-    <ContribAmounts />
+    <ContribAmounts onNumberInputKeyPress={onClick} />
     <CtaLink text={attrs.ctaText} onClick={onClick} />
   </Bundle>
 );
@@ -213,7 +213,7 @@ const getVariantA = (props: PropTypes, attrs: ContribBundle, onClick: () => void
         checked={props.contribType}
       />
     </div>
-    <ContribAmounts />
+    <ContribAmounts onNumberInputKeyPress={onClick} />
     <CtaLink text={attrs.ctaText} onClick={onClick} />
   </Bundle>
 );

--- a/assets/pages/bundles-landing/components/ContribAmounts.jsx
+++ b/assets/pages/bundles-landing/components/ContribAmounts.jsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 
 import RadioToggle from 'components/radioToggle/radioToggle';
 import NumberInput from 'components/numberInput/numberInput';
-import { clickSubstitueKeyPressHandler } from 'helpers/utilities';
+import { clickSubstituteKeyPressHandler } from 'helpers/utilities';
 import {
   changeContribAmount,
   changeContribAmountRecurring,
@@ -146,7 +146,7 @@ function ContribAmounts(props: PropTypes) {
           onInput={props.userDefinedAmount}
           selected={attrs.selected}
           placeholder="Other amount (£)"
-          onKeyPress={clickSubstitueKeyPressHandler(props.onNumberInputKeyPress)}
+          onKeyPress={clickSubstituteKeyPressHandler(props.onNumberInputKeyPress)}
         />
       </div>
       {errorMessage(props.contribError)}

--- a/assets/pages/bundles-landing/components/ContribAmounts.jsx
+++ b/assets/pages/bundles-landing/components/ContribAmounts.jsx
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 
 import RadioToggle from 'components/radioToggle/radioToggle';
 import NumberInput from 'components/numberInput/numberInput';
+import { clickSubstitueKeyPressHandler } from 'helpers/utilities';
 import {
   changeContribAmount,
   changeContribAmountRecurring,
@@ -79,6 +80,7 @@ type PropTypes = {
   predefinedRecurringAmount: (string) => void,
   predefinedOneOffAmount: (string) => void,
   userDefinedAmount: (string) => void,
+  onNumberInputKeyPress: () => void,
 };
 
 /* eslint-enable react/no-unused-prop-types */
@@ -128,7 +130,6 @@ function getAttrs(props: PropTypes) {
 // ----- Component ----- //
 
 function ContribAmounts(props: PropTypes) {
-
   const attrs = getAttrs(props);
   const className = `contrib-amounts contrib-amounts--${attrs.contribType}`;
 
@@ -145,6 +146,7 @@ function ContribAmounts(props: PropTypes) {
           onInput={props.userDefinedAmount}
           selected={attrs.selected}
           placeholder="Other amount (£)"
+          onKeyPress={clickSubstitueKeyPressHandler(props.onNumberInputKeyPress)}
         />
       </div>
       {errorMessage(props.contribError)}

--- a/assets/stylesheets/main.scss
+++ b/assets/stylesheets/main.scss
@@ -15,6 +15,7 @@
 @import '../components/ctaLink/ctaLink';
 @import '../components/displayName/displayName';
 @import '../components/doubleHeading/doubleHeading';
+@import '../components/errorMessage/errorMessage';
 @import '../components/featureList/featureList';
 @import '../components/footers/simpleFooter/simpleFooter';
 @import '../components/headers/simpleHeader/simpleHeader';


### PR DESCRIPTION
## Why are you doing this?

In order to improve the a11y of our site, we add the behaviour of the click on the button when the user press enter or spacebar on the input field.

[**Trello Card**](https://trello.com/c/IyG06KgO/654-accessibility-issue-not-possible-to-navigate-properly-on-supporttheguardiancom-without-a-mouse)

## Screenshots
![enter](https://user-images.githubusercontent.com/825398/28063673-d536704c-6629-11e7-9201-69a7ec424d96.gif)




