### PR TITLE
Add test user creation with Google auth

### DIFF
--- a/app/config/Configuration.scala
+++ b/app/config/Configuration.scala
@@ -13,6 +13,8 @@ class Configuration {
 
   lazy val identity = new Identity(config.getConfig("identity"))
 
+  lazy val googleAuth = new GoogleAuth(config.getConfig("googleAuth"))
+
   lazy val aws = new AwsConfig(config.getConfig("aws"))
 
   lazy val supportUrl = config.getString("support.url")

--- a/app/config/GoogleAuth.scala
+++ b/app/config/GoogleAuth.scala
@@ -1,0 +1,13 @@
+package config
+
+import com.typesafe.config.Config
+
+class GoogleAuth(config: Config) {
+  lazy val clientId = config.getString("clientId")
+
+  lazy val clientSecret = config.getString("clientSecret")
+
+  lazy val redirectUrl = config.getString("redirectUrl")
+
+  lazy val domain = config.getString("domain")
+}

--- a/app/controllers/Login.scala
+++ b/app/controllers/Login.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import actions.CacheControl
 import com.gu.googleauth.{GoogleAuthConfig, LoginSupport}
 import play.api.libs.ws.WSClient
 import play.api.mvc._
@@ -17,7 +18,7 @@ class Login(
    */
   def login: Action[AnyContent] = Action { request =>
     val error = request.flash.get("error")
-    Ok(views.html.login(error))
+    Ok(views.html.login(error)).withHeaders(CacheControl.noCache)
   }
 
   /*

--- a/app/controllers/Login.scala
+++ b/app/controllers/Login.scala
@@ -1,0 +1,45 @@
+package controllers
+
+import com.gu.googleauth.{GoogleAuthConfig, LoginSupport}
+import play.api.libs.ws.WSClient
+import play.api.mvc._
+
+import scala.concurrent.ExecutionContext
+
+class Login(
+  val authConfig: GoogleAuthConfig,
+  override val wsClient: WSClient,
+  val controllerComponents: ControllerComponents
+)(implicit executionContext: ExecutionContext)
+    extends LoginSupport with BaseController {
+  /**
+   * Shows UI for login button and logout error feedback
+   */
+  def login: Action[AnyContent] = Action { request =>
+    val error = request.flash.get("error")
+    Ok(views.html.login(error))
+  }
+
+  /*
+   * Redirect to Google with anti forgery token (that we keep in session storage - note that flashing is NOT secure).
+   */
+  def loginAction: Action[AnyContent] = Action.async { implicit request =>
+    startGoogleLogin()
+  }
+
+  /*
+   * Looks up user's identity via Google
+   */
+  def oauth2Callback: Action[AnyContent] = Action.async { implicit request =>
+    processOauth2Callback()
+  }
+
+  def logout: Action[AnyContent] = Action { implicit request =>
+    Redirect("/").withNewSession
+  }
+
+  override val failureRedirectTarget: Call = routes.Login.login()
+
+  override val defaultRedirectTarget: Call =
+    routes.TestUsersManagement.createTestUser()
+}

--- a/app/controllers/TestUsersManagement.scala
+++ b/app/controllers/TestUsersManagement.scala
@@ -1,0 +1,20 @@
+package controllers
+
+import actions.CacheControl
+import play.api.mvc._
+import services.TestUserService
+import com.gu.googleauth.AuthAction
+
+import scala.concurrent.ExecutionContext
+import views.html.{testUsers => testUsersView}
+
+class TestUsersManagement(
+    authAction: AuthAction[AnyContent],
+    components: ControllerComponents,
+    testUsers: TestUserService
+)(implicit val ec: ExecutionContext) extends AbstractController(components) {
+
+  def createTestUser: Action[AnyContent] = authAction {
+    Ok(testUsersView(testUsers.testUsers.generate())).withHeaders(CacheControl.noCache)
+  }
+}

--- a/app/views/login.scala.html
+++ b/app/views/login.scala.html
@@ -1,0 +1,16 @@
+@(error: Option[String] = None)
+
+<html>
+    <head><title>Login</title></head>
+    <body>
+        <h1>Login Page</h1>
+        <p>Click the button below to login.</p>
+        <p>This page is used to redirect failed login attempts and display any errors.</p>
+        @error.map { message =>
+            <p>The error was: @message</p>
+        }
+        <form action="@routes.Login.loginAction()" method="get">
+            <input value="Log In" type="submit">
+        </form>
+    </body>
+</html>

--- a/app/views/testUsers.scala.html
+++ b/app/views/testUsers.scala.html
@@ -1,0 +1,22 @@
+@(
+        key: String
+)
+
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Test Users</title>
+    </head>
+    <body>
+        <h1>New Test User key: @key</h1>
+        Your user will be valid for the next 48H. When registering please populate the following fields with your new test user key.
+        <ul>
+            <li><strong>First Name:</strong> @key</li>
+            <li><strong>Username:</strong> @key</li>
+            <li><strong>Email:</strong> @{key}@@gu.com</li>
+        </ul>
+        <!-- build-commit-id: @app.BuildInfo.gitCommitId -->
+    </body>
+</html>

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -8,6 +8,7 @@ import play.api.mvc.EssentialFilter
 import play.filters.gzip.GzipFilter
 import play.api.BuiltInComponentsFromContext
 import controllers.AssetsComponents
+import play.filters.HttpFiltersComponents
 
 trait AppComponents extends PlayComponents
     with AhcWSComponents
@@ -16,12 +17,14 @@ trait AppComponents extends PlayComponents
     with Services
     with ApplicationConfiguration
     with ActionBuilders
-    with Assets {
+    with Assets
+    with GoogleAuth
+    with HttpFiltersComponents {
   self: BuiltInComponentsFromContext =>
 
   override lazy val httpErrorHandler = new CustomHttpErrorHandler(environment, configuration, sourceMapper, Some(router))
 
-  override lazy val httpFilters: Seq[EssentialFilter] = Seq(
+  override lazy val httpFilters: Seq[EssentialFilter] = super.httpFilters ++ Seq(
     new CacheHeadersCheck(),
     new GzipFilter(shouldGzip = (req, _) => !req.path.startsWith("/assets/images"))
   )
@@ -31,6 +34,8 @@ trait AppComponents extends PlayComponents
     applicationController,
     new controllers.Default,
     monthlyContributionsController,
+    loginController,
+    testUsersContoller,
     assetController
   )
 

--- a/app/wiring/Controllers.scala
+++ b/app/wiring/Controllers.scala
@@ -1,11 +1,10 @@
 package wiring
 
-import controllers.{Application, MonthlyContributions}
+import controllers.{Application, AssetsComponents, MonthlyContributions, TestUsersManagement}
 import play.api.BuiltInComponentsFromContext
-import controllers.AssetsComponents
 
 trait Controllers {
-  self: AssetsComponents with Services with BuiltInComponentsFromContext with ApplicationConfiguration with ActionBuilders with Assets =>
+  self: AssetsComponents with Services with BuiltInComponentsFromContext with ApplicationConfiguration with ActionBuilders with Assets with GoogleAuth =>
 
   lazy val assetController = new controllers.Assets(httpErrorHandler, assetsMetadata)
 
@@ -25,5 +24,11 @@ trait Controllers {
     testUsers,
     appConfig.touchpointConfigProvider,
     controllerComponents
+  )
+
+  lazy val testUsersContoller = new TestUsersManagement(
+    authAction,
+    controllerComponents,
+    testUsers
   )
 }

--- a/app/wiring/GoogleAuth.scala
+++ b/app/wiring/GoogleAuth.scala
@@ -1,0 +1,23 @@
+package wiring
+
+import com.gu.googleauth.{AuthAction, GoogleAuthConfig}
+import play.api.BuiltInComponentsFromContext
+import play.api.libs.ws.ahc.AhcWSComponents
+import play.filters.HttpFiltersComponents
+
+import controllers.{Login, routes}
+import play.api.mvc.AnyContent
+
+trait GoogleAuth { self: BuiltInComponentsFromContext with AhcWSComponents with HttpFiltersComponents with ApplicationConfiguration =>
+
+  private val googleAuthConfig = GoogleAuthConfig(
+    appConfig.googleAuth.clientId,
+    appConfig.googleAuth.clientSecret,
+    appConfig.googleAuth.redirectUrl,
+    appConfig.googleAuth.domain
+  )
+
+  val authAction = new AuthAction[AnyContent](googleAuthConfig, routes.Login.loginAction(), controllerComponents.parsers.default)
+
+  val loginController = new Login(googleAuthConfig, wsClient, controllerComponents)
+}

--- a/build.sbt
+++ b/build.sbt
@@ -57,6 +57,7 @@ libraryDependencies ++= Seq(
   "com.gu" %% "identity-test-users" % "0.6",
   "com.google.guava" % "guava" % "22.0",
   "com.netaporter" %% "scala-uri" % "0.4.16",
+  "com.gu" %% "play-googleauth" % "0.7.0",
   filters,
   ws
 )

--- a/conf/CODE.public.conf
+++ b/conf/CODE.public.conf
@@ -11,4 +11,6 @@ identity.webapp.url="https://profile.code.dev-theguardian.com"
 identity.api.url="https://idapi.code.dev-theguardian.com"
 identity.production.keys=false
 support.url="https://support.code.dev-theguardian.com"
+googleAuth.redirectUrl = "https://support.code.dev-theguardian.com/oauth2callback"
 membersDataService.api.url="https://members-data-api.code.dev-theguardian.com"
+play.filters.hosts.allowed=["support.code.dev-theguardian.com"]

--- a/conf/DEV.public.conf
+++ b/conf/DEV.public.conf
@@ -11,4 +11,6 @@ identity.webapp.url="https://profile-origin.thegulocal.com"
 identity.api.url="https://idapi.code.dev-theguardian.com"
 identity.production.keys=false
 support.url="https://support.thegulocal.com"
+googleAuth.redirectUrl = "https://support.thegulocal.com/oauth2callback"
 membersDataService.api.url="https://members-data-api.thegulocal.com"
+play.filters.hosts.allowed=["localhost", "support.thegulocal.com"]

--- a/conf/PROD.public.conf
+++ b/conf/PROD.public.conf
@@ -11,4 +11,6 @@ identity.webapp.url="https://profile.theguardian.com"
 identity.api.url="https://idapi.theguardian.com"
 identity.production.keys=true
 support.url="https://support.theguardian.com"
+googleAuth.redirectUrl = "https://support.theguardian.com/oauth2callback"
 membersDataService.api.url="https://members-data-api.theguardian.com"
+play.filters.hosts.allowed=["support.theguardian.com"]

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -2,3 +2,7 @@ play.application.loader = "wiring.AppLoader"
 
 #### Import private keys
 include file("/etc/gu/support-frontend.private.conf")
+
+play.filters.headers.contentSecurityPolicy = "default-src 'self' polyfill.guim.co.uk js.stripe.com pasteup.guim.co.uk ophan.theguardian.com www.google-analytics.com media.guim.co.uk stats.g.doubleclick.net;"
+
+googleAuth.domain = "guardian.co.uk"

--- a/conf/routes
+++ b/conf/routes
@@ -13,5 +13,12 @@ GET /monthly-contributions/thankyou                controllers.Application.react
 GET /monthly-contributions/existing-contributor    controllers.Application.reactTemplate(title="Support the Guardian | Existing Contributor", id="monthly-contributions-existing-page", js="monthlyContributionsExistingPage.js")
 POST /monthly-contributions/create                 controllers.MonthlyContributions.create
 
+GET /login                 controllers.Login.login
+GET /loginAction           controllers.Login.loginAction
+GET /oauth2callback        controllers.Login.oauth2Callback
+GET /logout                controllers.Login.logout
+
+GET /test-users            controllers.TestUsersManagement.createTestUser
+
 GET /assets/*file               controllers.Assets.at(path="/public/compiled-assets", file)
 GET /*file                      controllers.Assets.at(path="/public", file)


### PR DESCRIPTION
## Why are you doing this?

So that you don't need to access or run membership-frontend to generate test users for support-frontend.

[**Trello Card**](https://trello.com/c/aaVGGDea/647-add-test-users-page-into-support-frontend)

## Changes

Adds endpoint requiring google auth that generates a new test user.

This will require additional private configuration:
* googleAuth.clientId
* googleAuth.clientSecret

Also adds additional headers from Play (csrfFilter, securityHeadersFilter, allowedHostsFilter) to improve security.

## Screenshots

<img width="824" alt="screen shot 2017-07-12 at 10 53 20" src="https://user-images.githubusercontent.com/2619836/28112381-b7ec04da-66f0-11e7-8623-85dce4cbd113.png">
