### PR TITLE
Credit card SVG renders correctly across different browsers 

### DIFF
--- a/assets/components/stripePopUpButton/stripePopUpButton.scss
+++ b/assets/components/stripePopUpButton/stripePopUpButton.scss
@@ -1,32 +1,30 @@
 .component-stripe-pop-up-button {
+  background-color: gu-colour(neutral-1);
+  border: none;
+  border-radius: 600px;
+  color: #fff;
+  cursor: pointer;
   display: block;
   font-family: $gu-sans-web;
   font-size: 14px;
   font-weight: bold;
-  text-align: left;
-  border-radius: 600px;
   height: $gu-v-spacing * 4;
-  background-color: gu-colour(neutral-1);
   padding-left: $gu-h-spacing;
-  border: none;
-  color: #fff;
+  position: relative;
+  text-align: left;
   width: 100%;
 
   @include mq($from: mobileMedium) {
     width: 304px;
   }
 
-  cursor: pointer;
-
   svg {
     width: 24px;
     fill: #fff;
-    vertical-align: middle;
-    margin-left: 50px;
-
-    @include mq($from:mobileMedium) {
-      margin-left: 55px;
-    }
+    position: absolute;
+    right: 15px;
+    top: 50%;
+    transform: translateY(-50%);
   }
 
   &:hover {


### PR DESCRIPTION
## Why are you doing this?
The credit card inside the Stripe button was not rendering correctly. This PR fix that across different browsers that detail.

## Screenshots

### Before

| Chrome | IE 10 | Safari | Firefox |
|--------|-------|--------|---------|
| <img width="561" alt="picture 313" src="https://user-images.githubusercontent.com/825398/28122341-d6e203ec-6715-11e7-9acb-2e7f72476a06.png"> |    <img width="541" alt="picture 316" src="https://user-images.githubusercontent.com/825398/28124587-fa87e770-671b-11e7-8284-315b92bfc06e.png">   | <img width="568" alt="picture 314" src="https://user-images.githubusercontent.com/825398/28122406-0bc28ab4-6716-11e7-8909-06e4e9d1a35b.png">  |   <img width="546" alt="picture 315" src="https://user-images.githubusercontent.com/825398/28122483-3974a596-6716-11e7-8f0c-d65944e7d767.png">     |

### After

| Chrome | IE 10 | Safari | Firefox |
|--------|-------|--------|---------|
| <img width="546" alt="picture 317" src="https://user-images.githubusercontent.com/825398/28124623-2631ed08-671c-11e7-8b2b-24ef04910967.png">  |  <img width="554" alt="picture 320" src="https://user-images.githubusercontent.com/825398/28124817-ab87bc1c-671c-11e7-988b-492a549e140b.png">    |   <img width="571" alt="picture 318" src="https://user-images.githubusercontent.com/825398/28124667-44b7f9c0-671c-11e7-871c-1a9ad6f7c02a.png">     |     ![picture 319](https://user-images.githubusercontent.com/825398/28124736-76fc44cc-671c-11e7-8c65-307522f9ea64.png)    |
