### PR TITLE
Paypal refactor

### DIFF
--- a/assets/components/payPalExpressButton/payPalExpressButton.jsx
+++ b/assets/components/payPalExpressButton/payPalExpressButton.jsx
@@ -43,8 +43,8 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
 
   return {
-    setupPayPalCheckout: () => {
-      dispatch(setupPayPalExpressCheckout());
+    setupPayPalCheckout: (callback: Function) => {
+      dispatch(setupPayPalExpressCheckout(callback));
     },
   };
 

--- a/assets/helpers/payPalExpressCheckout/payPalExpressCheckout.js
+++ b/assets/helpers/payPalExpressCheckout/payPalExpressCheckout.js
@@ -2,7 +2,7 @@
 
 // ----- Imports ----- //
 
-import type { State as PaypalState } from './payPalExpressCheckoutReducer';
+import type { State as PayPalState } from './payPalExpressCheckoutReducer';
 
 
 // ----- Functions ----- //
@@ -27,7 +27,7 @@ const loadPayPalExpress = () => new Promise((resolve) => {
 });
 
 const setup = (
-  state: PaypalState,
+  state: PayPalState,
   setupPayment: Function,
   onAuthorize: Function,
 ) => loadPayPalExpress().then(() => {

--- a/assets/helpers/payPalExpressCheckout/payPalExpressCheckout.js
+++ b/assets/helpers/payPalExpressCheckout/payPalExpressCheckout.js
@@ -2,7 +2,12 @@
 
 // ----- Imports ----- //
 
-import type { State as PayPalState } from './payPalExpressCheckoutReducer';
+import { payPalExpressError } from 'helpers/payPalExpressCheckout/payPalExpressCheckoutActions';
+
+// ----- Setup ----- //
+
+const SETUP_PAYMENT_URL = '/paypal/setup-payment';
+const CREATE_AGREEMENT_URL = '/paypal/create-agreement';
 
 
 // ----- Functions ----- //
@@ -26,30 +31,99 @@ const loadPayPalExpress = () => new Promise((resolve) => {
 
 });
 
-const setup = (
-  state: PayPalState,
-  setupPayment: Function,
-  onAuthorize: Function,
-) => loadPayPalExpress().then(() => {
+// ----- Auxiliary Functions -----//
 
+function handleSetupResponse(response: Object) {
+  let resp = null;
+  if (response.status === 200) {
+    resp = response.json();
+  }
 
-  const payPalOptions: Object = {
-    env: window.guardian.payPalEnvironment,
-    style: { color: 'blue', size: 'responsive' },
+  return resp;
+}
 
-    // Defines whether user sees 'continue' or 'pay now' in overlay.
-    commit: true,
+function payPalRequestData(bodyObj: Object, csrfToken: string) {
 
-    // This function is called when user clicks the PayPal button.
-    payment: setupPayment,
+  const body = JSON.stringify(bodyObj);
 
-    // This function is called when the user finishes with PayPal interface (approves payment).
-    onAuthorize,
+  return {
+    credentials: 'include',
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'Csrf-Token': csrfToken },
+    body,
   };
+}
 
-  window.paypal.Button.render(payPalOptions, '#component-paypal-button-checkout');
-});
+function setupPayment(dispatch: Function, state: Object) {
 
+  const payPalState = state.payPalExpressCheckout;
+  const csrfToken = state.csrf.token;
+
+  return (resolve, reject) => {
+
+    const requestBody = {
+      amount: payPalState.amount,
+      billingPeriod: payPalState.billingPeriod,
+      currency: payPalState.currency,
+    };
+
+    fetch(SETUP_PAYMENT_URL, payPalRequestData(requestBody, csrfToken))
+      .then(handleSetupResponse)
+      .then((token) => {
+        if (token) {
+          resolve(token.token);
+        } else {
+          dispatch(payPalExpressError('PayPal token came back blank.'));
+        }
+      }).catch((err) => {
+        dispatch(payPalExpressError(err.message));
+        reject(err);
+      });
+  };
+}
+
+function createAgreement(payPalData: Object, state: Object) {
+  const body = { token: payPalData.paymentToken };
+  const csrfToken = state.csrf.token;
+
+  return fetch(CREATE_AGREEMENT_URL, payPalRequestData(body, csrfToken))
+            .then(response => response.json());
+}
+
+function setup(dispatch: Function, getState: Function, callback: Function) {
+
+  return loadPayPalExpress()
+    .then(() => {
+
+      const handleBaId = (baid: Object) => {
+        callback(baid.token, dispatch, getState);
+      };
+
+      const onAuthorize = (data) => {
+        createAgreement(data, getState())
+          .then(handleBaId)
+          .catch((err) => {
+            dispatch(payPalExpressError(err));
+          });
+      };
+
+      const payPalOptions: Object = {
+        env: window.guardian.payPalEnvironment,
+        style: { color: 'blue', size: 'responsive' },
+
+        // Defines whether user sees 'continue' or 'pay now' in overlay.
+        commit: true,
+
+        // This function is called when user clicks the PayPal button.
+        payment: setupPayment(dispatch, getState()),
+
+        // This function is called when the user finishes with PayPal interface (approves payment).
+        onAuthorize,
+      };
+
+      window.paypal.Button.render(payPalOptions, '#component-paypal-button-checkout');
+    });
+}
 
 export {
   setup, // eslint-disable-line import/prefer-default-export

--- a/assets/helpers/payPalExpressCheckout/payPalExpressCheckoutActions.js
+++ b/assets/helpers/payPalExpressCheckout/payPalExpressCheckoutActions.js
@@ -13,12 +13,6 @@ export type Action =
   | { type: 'PAYPAL_EXPRESS_ERROR', message: string }
   ;
 
-// ----- Setup ----- //
-
-const SETUP_PAYMENT_URL = '/paypal/setup-payment';
-const CREATE_AGREEMENT_URL = '/paypal/create-agreement';
-
-
 // ----- Actions ----- //
 
 function startPayPalExpressCheckout(): Action {
@@ -37,62 +31,6 @@ export function payPalExpressError(message: string): Action {
   return { type: 'PAYPAL_EXPRESS_ERROR', message };
 }
 
-// ----- Auxiliary Functions -----//
-
-function handleSetupResponse(response: Object) {
-  let resp = null;
-  if (response.status === 200) {
-    resp = response.json();
-  }
-
-  return resp;
-}
-
-function payPalRequestData(bodyObj: Object, state: Object) {
-
-  const body = JSON.stringify(bodyObj);
-
-  return {
-    credentials: 'include',
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'Csrf-Token': state.csrf.token },
-    body,
-  };
-}
-
-function setupPayment(dispatch, state) {
-
-  const payPalState = state.payPalExpressCheckout;
-
-  return (resolve, reject) => {
-
-    const requestBody = {
-      amount: payPalState.amount,
-      billingPeriod: payPalState.billingPeriod,
-      currency: payPalState.currency,
-    };
-
-    fetch(SETUP_PAYMENT_URL, payPalRequestData(requestBody, state))
-      .then(handleSetupResponse)
-      .then((token) => {
-        if (token) {
-          resolve(token.token);
-        } else {
-          dispatch(payPalExpressError('PayPal token came back blank.'));
-        }
-      }).catch((err) => {
-        dispatch(payPalExpressError(err.message));
-        reject(err);
-      });
-  };
-}
-
-function createAgreement(payPalData, state: Object) {
-  const body = { token: payPalData.paymentToken };
-
-  return fetch(CREATE_AGREEMENT_URL, payPalRequestData(body, state))
-    .then(response => response.json());
-}
 
 // ----- Functions -----//
 
@@ -100,25 +38,10 @@ export function setupPayPalExpressCheckout(callback: Function): Function {
 
   return (dispatch, getState) => {
 
-    const state = getState();
-    const payPalState = state.payPalExpressCheckout;
-
-    const handleBaId = (baid: Object) => {
-      callback(baid.token, dispatch, getState);
-    };
-
-    const onAuthorize = (data) => {
-      createAgreement(data, getState())
-        .then(handleBaId)
-        .catch((err) => {
-          dispatch(payPalExpressError(err));
-        });
-    };
-
     dispatch(startPayPalExpressCheckout());
 
     return payPalExpressCheckout
-      .setup(payPalState, setupPayment(dispatch, state), onAuthorize)
+      .setup(dispatch, getState, callback)
       .then(() => dispatch(payPalExpressCheckoutLoaded()));
   };
 }

--- a/assets/helpers/stripeCheckout/stripeCheckoutActions.js
+++ b/assets/helpers/stripeCheckout/stripeCheckoutActions.js
@@ -14,7 +14,6 @@ export type Action =
   | { type: 'CLOSE_STRIPE_OVERLAY' }
   | { type: 'OPEN_STRIPE_OVERLAY' }
   | { type: 'SET_STRIPE_AMOUNT', amount: number }
-  | { type: 'STRIPE_ERROR', message: string }
   ;
 
 

--- a/assets/pages/monthly-contributions/components/paymentMethods.jsx
+++ b/assets/pages/monthly-contributions/components/paymentMethods.jsx
@@ -27,11 +27,11 @@ type PropTypes = {
 function PaymentMethods(props: PropTypes) {
 
   let errorMessage = '';
-  let stripeButton = <StripePopUpButton email={props.email} callback={postCheckout} />;
+  let stripeButton = <StripePopUpButton email={props.email} callback={postCheckout('stripeToken')} />;
   let payPalButton = '';
 
   if (props.payPalButtonExists) {
-    payPalButton = <PaypalExpressButton />;
+    payPalButton = <PaypalExpressButton callback={postCheckout('baid')} />;
   }
 
   if (props.firstName === '' || props.lastName === '') {

--- a/assets/pages/monthly-contributions/helpers/ajax.js
+++ b/assets/pages/monthly-contributions/helpers/ajax.js
@@ -26,10 +26,12 @@ type MonthlyContribFields = {
   lastName: string,
 };
 
+type PaymentField = 'baid' | 'stripeToken';
+
 
 // ----- Functions ----- //
 
-function requestData(paymentToken: string, getState: Function) {
+function requestData(paymentFieldName: PaymentField, token: string, getState: Function) {
 
   const state = getState();
 
@@ -39,7 +41,7 @@ function requestData(paymentToken: string, getState: Function) {
       currency: state.stripeCheckout.currency,
     },
     paymentFields: {
-      stripeToken: paymentToken,
+      [paymentFieldName]: token,
     },
     country: state.monthlyContrib.country,
     firstName: state.user.firstName,
@@ -55,22 +57,19 @@ function requestData(paymentToken: string, getState: Function) {
 
 }
 
-export default function postCheckout(
-  paymentToken: string,
-  dispatch: Function,
-  getState: Function,
-) {
+export default function postCheckout(paymentFieldName: PaymentField): Function {
+  return (token: string, dispatch: Function, getState: Function) => {
 
-  const request = requestData(paymentToken, getState);
+    const request = requestData(paymentFieldName, token, getState);
 
-  return fetch(MONTHLY_CONTRIB_ENDPOINT, request).then((response) => {
+    return fetch(MONTHLY_CONTRIB_ENDPOINT, request).then((response) => {
 
-    if (response.ok) {
-      window.location.assign(MONTHLY_CONTRIB_THANKYOU);
-    }
+      if (response.ok) {
+        window.location.assign(MONTHLY_CONTRIB_THANKYOU);
+      }
 
-    response.text().then(err => dispatch(checkoutError(err)));
+      response.text().then(err => dispatch(checkoutError(err)));
 
-  });
-
+    });
+  };
 }


### PR DESCRIPTION
## Why are you doing this?

In https://github.com/guardian/support-frontend/pull/129 there is a lot of similar code between PayPal and Stripe's checkout flows. This PR tries to merge the shared behaviour.

[**Trello Card**](https://trello.com/c/bOff46wP/726-refactor-paypal)

## Changes

* The last step of the PayPal process was removed from `PayPalExpressCheckoutActions`, in this way we can reuse in the future the PayPal button for other flows, not only the ~~monthly~~ **recurring** contribution flow.
* Removed an unused Stripe's action.
* The `postCheckout` function in `ajax.js`, now works for Stripe and PayPal.



