### PR TITLE
Do not chown/chmod the private config

### DIFF
--- a/cloud-formation/cfn.yaml
+++ b/cloud-formation/cfn.yaml
@@ -77,8 +77,6 @@ Resources:
           aws --region ${AWS::Region} s3 cp s3://membership-dist/${Stack}/${Stage}/${App}/support-frontend_1.0-SNAPSHOT_all.deb /tmp
           dpkg -i /tmp/support-frontend_1.0-SNAPSHOT_all.deb
           /opt/cloudwatch-logs/configure-logs application ${Stack} ${Stage} ${App} /var/log/support-frontend/application.log
-          chown ${App} /etc/gu/support-frontend.private.conf
-          chmod 0600 /etc/gu/support-frontend.private.conf
   AppRole:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
## Why are you doing this?

1) the system is not multi-user so changing the permissions on this file seems a bit pointless
2) the permissions are being changed after the app launches
3) the user `${App}` (frontend) does not exist, so these lines fail anyway.  The app runs as support-frontend.



<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->
