### PR TITLE
Contributions Landing AB Test

### DIFF
--- a/assets/helpers/abtest.js
+++ b/assets/helpers/abtest.js
@@ -20,7 +20,7 @@ type Audience = {
   size: number,
 };
 
-type TestId = 'noTestDefined';
+type TestId = 'noTestDefined' | 'contributionsLandingAddingMonthly';
 
 export type Participations = {
   [TestId]: string,
@@ -68,7 +68,17 @@ type OphanABPayload = {
 
  */
 
-const tests: Test[] = [];
+const tests: Test[] = [
+  {
+    testId: 'contributionsLandingAddingMonthly',
+    variants: ['control', 'oneoffAndMonthly'],
+    audience: {
+      offset: 0,
+      size: 1,
+    },
+    isActive: false,
+  },
+];
 
 
 // ----- Functions ----- //

--- a/assets/helpers/abtest.js
+++ b/assets/helpers/abtest.js
@@ -20,7 +20,7 @@ type Audience = {
   size: number,
 };
 
-type TestId = 'noTestDefined' | 'contributionsLandingAddingMonthly';
+type TestId = 'contributionsLandingAddingMonthly';
 
 export type Participations = {
   [TestId]: string,

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -121,13 +121,14 @@ function ContributionsBundle(props: PropTypes) {
 
 function mapStateToProps(state) {
 
-  const inVariant = state.abTests.contributionsLandingAddingMonthly === 'oneoffAndMonthly';
+  const oneoffAndMonthlyVariant =
+    state.abTests.contributionsLandingAddingMonthly === 'oneoffAndMonthly';
 
   return {
-    contribType: inVariant ? state.contribution.type : 'ONE_OFF',
+    contribType: oneoffAndMonthlyVariant ? state.contribution.type : 'ONE_OFF',
     contribAmount: state.contribution.amount,
     contribError: state.contribution.error,
-    oneoffAndMonthlyVariant: inVariant,
+    oneoffAndMonthlyVariant,
   };
 }
 

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -27,7 +27,7 @@ type PropTypes = {
   contribType: Contrib,
   contribAmount: Amounts,
   contribError: ContribError,
-  addingMonthlyTest: boolean,
+  oneoffAndMonthlyVariant: boolean,
   intCmp: string,
   toggleContribType: (string) => void,
   changeContribRecurringAmount: (string) => void,
@@ -66,7 +66,7 @@ const ctaLinks = {
 // ----- Functions ----- //
 
 const getContribAttrs = ({
-  contribType, contribAmount, intCmp, addingMonthlyTest,
+  contribType, contribAmount, intCmp, oneoffAndMonthlyVariant,
 }): ContribAttrs => {
 
   const contType = contribType === 'RECURRING' ? 'recurring' : 'oneOff';
@@ -80,7 +80,7 @@ const getContribAttrs = ({
 
   const ctaLink = `${ctaLinks[contType]}?${params.toString()}`;
 
-  if (!addingMonthlyTest) {
+  if (!oneoffAndMonthlyVariant) {
 
     const subheading = 'Support the Guardian’s editorial operations by making a one-off contribution today';
     return Object.assign({}, contribAttrs, { ctaLink, subheading });
@@ -121,13 +121,13 @@ function ContributionsBundle(props: PropTypes) {
 
 function mapStateToProps(state) {
 
-  const inTest = state.abTests.contributionsLandingAddingMonthly === 'oneoffAndMonthly';
+  const inVariant = state.abTests.contributionsLandingAddingMonthly === 'oneoffAndMonthly';
 
   return {
-    contribType: inTest ? state.contribution.type : 'ONE_OFF',
+    contribType: inVariant ? state.contribution.type : 'ONE_OFF',
     contribAmount: state.contribution.amount,
     contribError: state.contribution.error,
-    addingMonthlyTest: inTest,
+    oneoffAndMonthlyVariant: inVariant,
   };
 }
 

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -27,6 +27,7 @@ type PropTypes = {
   contribType: Contrib,
   contribAmount: Amounts,
   contribError: ContribError,
+  addingMonthlyTest: boolean,
   intCmp: string,
   toggleContribType: (string) => void,
   changeContribRecurringAmount: (string) => void,
@@ -64,7 +65,9 @@ const ctaLinks = {
 
 // ----- Functions ----- //
 
-const getContribAttrs = ({ contribType, contribAmount, intCmp }): ContribAttrs => {
+const getContribAttrs = ({
+  contribType, contribAmount, intCmp, addingMonthlyTest,
+}): ContribAttrs => {
 
   const contType = contribType === 'RECURRING' ? 'recurring' : 'oneOff';
   const params = new URLSearchParams();
@@ -76,6 +79,13 @@ const getContribAttrs = ({ contribType, contribAmount, intCmp }): ContribAttrs =
   }
 
   const ctaLink = `${ctaLinks[contType]}?${params.toString()}`;
+
+  if (!addingMonthlyTest) {
+
+    const subheading = 'Support the Guardian’s editorial operations by making a one-off contribution today';
+    return Object.assign({}, contribAttrs, { ctaLink, subheading });
+
+  }
 
   return Object.assign({}, contribAttrs, { ctaLink });
 
@@ -110,10 +120,14 @@ function ContributionsBundle(props: PropTypes) {
 // ----- Map State/Props ----- //
 
 function mapStateToProps(state) {
+
+  const inTest = state.abTests.contributionsLandingAddingMonthly === 'oneoffAndMonthly';
+
   return {
-    contribType: state.contribution.type,
+    contribType: inTest ? state.contribution.type : 'ONE_OFF',
     contribAmount: state.contribution.amount,
     contribError: state.contribution.error,
+    addingMonthlyTest: inTest,
   };
 }
 

--- a/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/assets/pages/contributions-landing/contributionsLanding.scss
@@ -178,4 +178,12 @@
 		}
 	}
 
+	// ----- AB Test ----- //
+
+	.hide-monthly {
+		.contrib-type {
+			display: none;
+		}
+	}
+
 }

--- a/assets/pages/contributions-landing/contributionsLandingUK.jsx
+++ b/assets/pages/contributions-landing/contributionsLandingUK.jsx
@@ -20,7 +20,7 @@ import ContributionsBundle from './components/contributionsBundle';
 
 // ----- Page Startup ----- //
 
-pageStartup.start();
+const participation = pageStartup.start();
 
 
 // ----- Redux Store ----- //
@@ -28,6 +28,13 @@ pageStartup.start();
 const store = createStore(reducer, {
   intCmp: getQueryParameter('INTCMP', 'gdnwb_copts_bundles_landing_default'),
 });
+
+store.dispatch({ type: 'SET_AB_TEST_PARTICIPATION', payload: participation });
+
+
+// ----- AB Test ----- //
+
+const inTest = participation.contributionsLandingAddingMonthly === 'oneoffAndMonthly';
 
 
 // ----- Copy ----- //
@@ -53,7 +60,7 @@ const content = (
       <IntroductionText messages={introductionCopy} />
       <section className="contributions-bundle">
         <div className="introduction-bleed-margins" />
-        <div className="contributions-bundle__content gu-content-margin">
+        <div className={`contributions-bundle__content gu-content-margin ${inTest ? '' : 'hide-monthly'}`}>
           <div className="introduction-bleed" />
           <ContributionsBundle />
         </div>

--- a/assets/pages/contributions-landing/contributionsLandingUK.jsx
+++ b/assets/pages/contributions-landing/contributionsLandingUK.jsx
@@ -34,7 +34,7 @@ store.dispatch({ type: 'SET_AB_TEST_PARTICIPATION', payload: participation });
 
 // ----- AB Test ----- //
 
-const inTest = participation.contributionsLandingAddingMonthly === 'oneoffAndMonthly';
+const inVariant = participation.contributionsLandingAddingMonthly === 'oneoffAndMonthly';
 
 
 // ----- Copy ----- //
@@ -60,7 +60,7 @@ const content = (
       <IntroductionText messages={introductionCopy} />
       <section className="contributions-bundle">
         <div className="introduction-bleed-margins" />
-        <div className={`contributions-bundle__content gu-content-margin ${inTest ? '' : 'hide-monthly'}`}>
+        <div className={`contributions-bundle__content gu-content-margin ${inVariant ? '' : 'hide-monthly'}`}>
           <div className="introduction-bleed" />
           <ContributionsBundle />
         </div>

--- a/assets/pages/contributions-landing/reducers/__tests__/__snapshots__/reducersTest.js.snap
+++ b/assets/pages/contributions-landing/reducers/__tests__/__snapshots__/reducersTest.js.snap
@@ -43,6 +43,7 @@ Object {
 
 exports[`reducer tests should return the initial state 1`] = `
 Object {
+  "abTests": Object {},
   "contribution": Object {
     "amount": Object {
       "oneOff": Object {

--- a/assets/pages/contributions-landing/reducers/reducers.js
+++ b/assets/pages/contributions-landing/reducers/reducers.js
@@ -7,6 +7,7 @@ import { combineReducers } from 'redux';
 import type { Contrib, ContribError, Amounts } from 'helpers/contributions';
 
 import { parse as parseContribution } from 'helpers/contributions';
+import { abTestReducer as abTests } from 'helpers/abtest';
 import type { Action } from '../actions/contributionsLandingActions';
 
 
@@ -100,4 +101,5 @@ function intCmp(state: string = ''): string {
 export default combineReducers({
   contribution,
   intCmp,
+  abTests,
 });


### PR DESCRIPTION
## Why are you doing this?

For Test 2 (looking at the value of adding recurring contributions in the UK), we're driving traffic to support-frontend and dropping users into an AB test when they arrive there. This AB test will show two versions of the contributions landing page:

- **Control:** One-off contributions only.
- **Variant:** One-off and monthly contributions.

This PR introduces this test, and applies the changes needed to show these two variants of the page.

**Note:** Don't know if the places I have applied some of these changes are the best, we haven't really settled on a convention for this yet.

[**Trello Card**](https://trello.com/c/7NhmhzZX/734-q2-test-2-create-ab-test-in-support-frontend)

## Changes
 
- Added a new test for 100% of the audience, switched off for now.
- Changed the copy on the contributions landing page based on whether in test or not.
- Set the contribution type to 'one-off' for people who are in `control`.
- Initialised the `abTests` state for the contributions landing page.
- Hid the contribution type toggle for people in `control`.

## Screenshots

**Control:**

![landing-control](https://user-images.githubusercontent.com/5131341/28580152-9a660a76-7156-11e7-8968-11b2555f0671.png)

**Variant:**

![landing-variant](https://user-images.githubusercontent.com/5131341/28580164-a07e1e9e-7156-11e7-8a21-49724d656407.png)
