### PR TITLE
Contributions Landing Test - Only Hide Monthly For Control

### DIFF
--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -27,7 +27,7 @@ type PropTypes = {
   contribType: Contrib,
   contribAmount: Amounts,
   contribError: ContribError,
-  oneoffAndMonthlyVariant: boolean,
+  showMonthly: boolean,
   intCmp: string,
   toggleContribType: (string) => void,
   changeContribRecurringAmount: (string) => void,
@@ -66,7 +66,7 @@ const ctaLinks = {
 // ----- Functions ----- //
 
 const getContribAttrs = ({
-  contribType, contribAmount, intCmp, oneoffAndMonthlyVariant,
+  contribType, contribAmount, intCmp, showMonthly,
 }): ContribAttrs => {
 
   const contType = contribType === 'RECURRING' ? 'recurring' : 'oneOff';
@@ -80,7 +80,7 @@ const getContribAttrs = ({
 
   const ctaLink = `${ctaLinks[contType]}?${params.toString()}`;
 
-  if (!oneoffAndMonthlyVariant) {
+  if (!showMonthly) {
 
     const subheading = 'Support the Guardian’s editorial operations by making a one-off contribution today';
     return Object.assign({}, contribAttrs, { ctaLink, subheading });
@@ -121,14 +121,14 @@ function ContributionsBundle(props: PropTypes) {
 
 function mapStateToProps(state) {
 
-  const oneoffAndMonthlyVariant =
-    state.abTests.contributionsLandingAddingMonthly === 'oneoffAndMonthly';
+  const showMonthly =
+    state.abTests.contributionsLandingAddingMonthly !== 'control';
 
   return {
-    contribType: oneoffAndMonthlyVariant ? state.contribution.type : 'ONE_OFF',
+    contribType: showMonthly ? state.contribution.type : 'ONE_OFF',
     contribAmount: state.contribution.amount,
     contribError: state.contribution.error,
-    oneoffAndMonthlyVariant,
+    showMonthly,
   };
 }
 

--- a/assets/pages/contributions-landing/contributionsLandingUK.jsx
+++ b/assets/pages/contributions-landing/contributionsLandingUK.jsx
@@ -34,7 +34,7 @@ store.dispatch({ type: 'SET_AB_TEST_PARTICIPATION', payload: participation });
 
 // ----- AB Test ----- //
 
-const inVariant = participation.contributionsLandingAddingMonthly === 'oneoffAndMonthly';
+const showMonthly = participation.contributionsLandingAddingMonthly !== 'control';
 
 
 // ----- Copy ----- //
@@ -60,7 +60,7 @@ const content = (
       <IntroductionText messages={introductionCopy} />
       <section className="contributions-bundle">
         <div className="introduction-bleed-margins" />
-        <div className={`contributions-bundle__content gu-content-margin ${inVariant ? '' : 'hide-monthly'}`}>
+        <div className={`contributions-bundle__content gu-content-margin ${showMonthly ? '' : 'hide-monthly'}`}>
           <div className="introduction-bleed" />
           <ContributionsBundle />
         </div>


### PR DESCRIPTION
## Why are you doing this?

Tweak for the work done in #143. Normally you would only make changes for users who are in the variant of an AB test, so control and notintest see the same thing. In this case that would be one-off contributions only.

However, the notintest view for this page is actually supposed to include both one-off and monthly, as this is what e.g. apps are expecting when they drive traffic to this page. It's only the control group in this test who should see one-off only. This PR updates the check to reflect that.

[**Trello Card**](https://trello.com/c/VIKQsLn0/743-show-both-one-off-and-monthly-if-notintest)

## Changes

- Renamed flag for showing monthly content to `showMonthly`.
- Hide monthly content only for people who are in the control of this test.

## Screenshots

**Control:**

![test2-control](https://user-images.githubusercontent.com/5131341/28667613-359c2f0c-72c4-11e7-856b-27fd4f606a25.png)

**Variant & Notintest:**

![test2-variant-notintest](https://user-images.githubusercontent.com/5131341/28667624-3e6ee1ce-72c4-11e7-8df7-9cc678e6b5d6.png)
