### PR TITLE
Added two missing return statements.

### DIFF
--- a/assets/pages/monthly-contributions/helpers/ajax.js
+++ b/assets/pages/monthly-contributions/helpers/ajax.js
@@ -70,6 +70,7 @@ export default function postCheckout(paymentFieldName: PaymentField): Function {
 
       if (response.ok) {
         window.location.assign(url);
+        return;
       }
 
       response.text().then(err => dispatch(checkoutError(err)));

--- a/assets/pages/oneoff-contributions/helpers/ajax.js
+++ b/assets/pages/oneoff-contributions/helpers/ajax.js
@@ -73,6 +73,7 @@ export default function postCheckout(
 
     if (response.ok) {
       window.location.assign(url);
+      return;
     }
 
     response.text().then(err => dispatch(checkoutError(err)));


### PR DESCRIPTION
## Why are you doing this?

Bug in the payment flow fixed for recurring and one off contributions. The bug consisted of the error message being displayed before going to the next page.

[**Trello Card**](https://trello.com/c/VHzbSw0d/758-in-the-process-of-submitting-the-monthly-contributions-the-error-message-flashes-up)

## Screenshots

### Before
![paymentbug](https://user-images.githubusercontent.com/825398/28779988-1270d33e-75fd-11e7-986d-e8ef2333f6ec.gif)

### After
![paymentfix](https://user-images.githubusercontent.com/825398/28779997-1e0722fc-75fd-11e7-959b-8e18100bb5db.gif)







