### PR TITLE
Fix Hide Payments On Empty Form

### DIFF
--- a/assets/components/paymentMethods/paymentMethods.jsx
+++ b/assets/components/paymentMethods/paymentMethods.jsx
@@ -13,8 +13,7 @@ import ErrorMessage from 'components/errorMessage/errorMessage';
 
 type PropTypes = {
   email: string,
-  firstName: string,
-  lastName: string,
+  hide: boolean,
   error: ?string,
   payPalButtonExists: boolean,
   stripeCallback: Function,
@@ -34,7 +33,7 @@ export default function PaymentMethods(props: PropTypes) {
     payPalButton = <PayPalExpressButton callback={props.payPalCallback} />;
   }
 
-  if (props.firstName === '' || props.lastName === '') {
+  if (props.hide) {
     errorMessage = <ErrorMessage message={'Please fill in all the fields above.'} />;
     stripeButton = '';
     payPalButton = '';

--- a/assets/helpers/user/userReducer.js
+++ b/assets/helpers/user/userReducer.js
@@ -21,10 +21,10 @@ type User = {
 // ----- Setup ----- //
 
 const initialState: User = {
-  email: null,
-  displayName: null,
-  firstName: null,
-  lastName: null,
+  email: '',
+  displayName: '',
+  firstName: '',
+  lastName: '',
   isTestUser: null,
 };
 

--- a/assets/pages/monthly-contributions/components/paymentMethodsContainer.jsx
+++ b/assets/pages/monthly-contributions/components/paymentMethodsContainer.jsx
@@ -12,9 +12,8 @@ function mapStateToProps(state) {
 
   return {
     email: state.user.email,
-    firstName: state.user.firstName,
-    lastName: state.user.lastName,
     error: state.monthlyContrib.error,
+    hide: state.user.firstName === '' || state.user.lastName === '',
   };
 
 }

--- a/assets/pages/oneoff-contributions/components/paymentMethodsContainer.jsx
+++ b/assets/pages/oneoff-contributions/components/paymentMethodsContainer.jsx
@@ -11,9 +11,8 @@ function mapStateToProps(state) {
 
   return {
     email: state.user.email,
-    firstName: state.user.firstName,
-    lastName: state.user.lastName,
     error: state.oneoffContrib.error,
+    hide: state.user.email === '' || state.user.fullName === '',
   };
 
 }


### PR DESCRIPTION
## Why are you doing this?

For the one-off and monthly contributions checkouts, if mandatory fields are not filled in then the payment buttons should be hidden. This was happening for monthly but not for one-off. The reason is that the payment methods component was hard-coded to checking for first and last name, whereas one-off uses full name and email.

This PR pulls the validation check out of the payment methods component, doing it at the page level and then passing in a `hide` prop determining whether the payment buttons should be visible or not.

[**Trello Card**](https://trello.com/c/1wIBXPHU/760-one-off-checkout-hide-payment-broken)

## Changes

- Added a `hide` prop to the `paymentMethods` component, to hide the buttons.
- Set monthly contributions to check for first and last name.
- Set one-off contributions to check for full name and email.

## Screenshots

![oneoff-error](https://user-images.githubusercontent.com/5131341/28822619-dc88ffd4-76b1-11e7-8a2e-a79299714dbe.png)