### PR TITLE
Remove akka-agent dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,6 @@ libraryDependencies ++= Seq(
   "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0",
   "com.amazonaws" % "aws-java-sdk-kms" % "1.11.128",
   "com.amazonaws" % "aws-java-sdk-stepfunctions" % "1.11.128",
-  "com.typesafe.akka" %% "akka-agent" % "2.4.12",
   "org.typelevel" %% "cats" % "0.9.0",
   "play-circe" %% "play-circe" % "2.6-0.8.0",
   "com.gu" %% "support-models" % "0.5",


### PR DESCRIPTION
1) we aren’t using it
2) akka are deprecating it so we shouldn’t start using it