### PR TITLE
Contributions Landing Design Updates

### DIFF
--- a/assets/components/legal/contribLegal/contribLegal.jsx
+++ b/assets/components/legal/contribLegal/contribLegal.jsx
@@ -10,24 +10,17 @@ import React from 'react';
 export default function ContribLegal() {
 
   return (
-    <div className="component-contrib-legal">
-      <p className="component-contrib-legal__text">
-        The ultimate owner of the Guardian is The Scott Trust Limited,
-        whose role it is to secure the editorial and financial independence
-        of the Guardian in perpetuity. Reader contributions support the
-        Guardian’s journalism.&nbsp;
-      </p>
-      <p className="component-contrib-legal__text">
-        Please note that your support of the Guardian’s journalism does not
-        constitute a charitable donation, as such your contribution is not
-        eligible for Gift Aid in the UK nor a tax-deduction elsewhere.&nbsp;
-      </p>
-      <p className="component-contrib-legal__text">
-        If you have any questions about contributing to the Guardian,
-        please <a href="mailto:contribution.support@theguardian.com">
-        contact us here</a>.&nbsp;
-      </p>
-    </div>
+    <p className="component-contrib-legal">
+      The ultimate owner of the Guardian is The Scott Trust Limited,
+      whose role it is to secure the editorial and financial independence
+      of the Guardian in perpetuity. Reader contributions support the
+      Guardian’s journalism. Please note that your support of the Guardian’s
+      journalism does not constitute a charitable donation, as such your
+      contribution is not eligible for Gift Aid in the UK nor a tax-deduction
+      elsewhere. If you have any questions about contributing to the Guardian,
+      please <a href="mailto:contribution.support@theguardian.com">
+      contact us here</a>.
+    </p>
   );
 
 }

--- a/assets/components/legal/contribLegal/contribLegal.scss
+++ b/assets/components/legal/contribLegal/contribLegal.scss
@@ -4,16 +4,6 @@
 	font-size: 12px;
 	color: gu-colour(neutral-1);
 
-	.component-contrib-legal__text {
-		@include mq($from: phablet) {
-			display: inline;
-		}
-
-		@include mq($until: phablet) {
-			padding-bottom: $gu-v-spacing;
-		}
-	}
-
 	a {
 		color: inherit;
 	}

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -49,7 +49,7 @@ type ContribAttrs = {
 // ----- Copy ----- //
 
 const contribAttrs: ContribAttrs = {
-  heading: 'Contribute',
+  heading: 'contribute',
   subheading: `Support the Guardian’s editorial operations by making a
     monthly, or one-off contribution today`,
   ctaText: 'Contribute',

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -51,7 +51,7 @@ type ContribAttrs = {
 const contribAttrs: ContribAttrs = {
   heading: 'contribute',
   subheading: `Support the Guardian’s editorial operations by making a
-    monthly, or one-off contribution today`,
+    monthly or one-off contribution today`,
   ctaText: 'Contribute',
   modifierClass: 'contributions',
   ctaLink: '',

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -49,7 +49,7 @@ type ContribAttrs = {
 // ----- Copy ----- //
 
 const contribAttrs: ContribAttrs = {
-  heading: 'contribute',
+  heading: 'Contribute',
   subheading: `Support the Guardian’s editorial operations by making a
     monthly, or one-off contribution today`,
   ctaText: 'Contribute',

--- a/assets/pages/contributions-landing/components/contributionsIntroduction.jsx
+++ b/assets/pages/contributions-landing/components/contributionsIntroduction.jsx
@@ -1,0 +1,26 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+
+// ----- Componenent ----- //
+
+export default function ContributionsIntroduction() {
+
+  return (
+    <div className="contributions-introduction">
+      <div className="contributions-introduction__primary">
+        <h1>support the Guardian&#39;s</h1>
+        <h1>quality journalism</h1>
+        <h1>and independent voice</h1>
+      </div>
+      <div className="contributions-introduction__secondary">
+        <h1>make a one-off</h1>
+        <h1>contribution today</h1>
+      </div>
+    </div>
+  );
+
+}

--- a/assets/pages/contributions-landing/components/contributionsIntroduction.jsx
+++ b/assets/pages/contributions-landing/components/contributionsIntroduction.jsx
@@ -17,7 +17,7 @@ export default function ContributionsIntroduction() {
         <h1>and independent voice</h1>
       </div>
       <div className="contributions-introduction__secondary">
-        <h1>make a one-off</h1>
+        <h1>make a </h1>
         <h1>contribution <span className="contributions-introduction__indent">today</span></h1>
       </div>
     </div>

--- a/assets/pages/contributions-landing/components/contributionsIntroduction.jsx
+++ b/assets/pages/contributions-landing/components/contributionsIntroduction.jsx
@@ -12,13 +12,13 @@ export default function ContributionsIntroduction() {
   return (
     <div className="contributions-introduction">
       <div className="contributions-introduction__primary">
-        <h1>support the Guardian&#39;s</h1>
-        <h1>quality journalism</h1>
+        <h1>support the&nbsp;Guardian&#39;s</h1>
+        <h1>quality&nbsp;journalism</h1>
         <h1>and independent voice</h1>
       </div>
       <div className="contributions-introduction__secondary">
         <h1>make a one-off</h1>
-        <h1>contribution today</h1>
+        <h1>contribution <span className="contributions-introduction__indent">today</span></h1>
       </div>
     </div>
   );

--- a/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/assets/pages/contributions-landing/contributionsLanding.scss
@@ -9,8 +9,8 @@
 
 	.contributions-introduction {
 		display: inline-block;
+		vertical-align: top;
 		margin-bottom: $gu-v-spacing * 1.5;
-		margin-top: $gu-v-spacing;
 	}
 
 	.contributions-introduction__primary, .contributions-introduction__secondary {
@@ -21,17 +21,58 @@
 		font-weight: 600;
 		padding-left: $gu-h-spacing / 2;
 		padding-right: $gu-h-spacing / 2;
+
+		@include mq($from: desktop) {
+			padding: 0;
+			font-size: 44px;
+			line-height: 46px;
+		}
+	}
+
+	.contributions-introduction__primary {
+		margin-bottom: 111px;
+		margin-top: $gu-v-spacing;
+
+		@include mq($from: desktop) {
+			margin-bottom: 45px;
+			margin-top: 64px;
+
+			h1:nth-child(1) {
+				margin-left: $gu-h-spacing;
+			}
+
+			h1:nth-child(2) {
+				margin-left: 160px;
+			}
+
+			h1:nth-child(3) {
+				margin-left: 60px;
+			}
+		}
 	}
 
 	.contributions-introduction__secondary {
 		color: gu-colour(neutral-1);
-		margin-top: 111px;
+
+		@include mq($from: desktop) {
+			h1:nth-child(1) {
+				margin-left: 147px;
+			}
+
+			h1:nth-child(2) {
+				margin-left: 187px;
+			}
+		}
 	}
 
 	// ----- Bundle ----- //
 
 	.contributions-bundle {
 		background-color: darken(gu-colour(multimedia-main-2), 5%);
+
+		@include mq($from: desktop) {
+			height: 420px;
+		}
 	}
 
 	.contributions-bundle__content {
@@ -41,19 +82,18 @@
 	}
 
 	.component-bundle {
+		position: relative;
 		display: inline-block;
+		vertical-align: top;
 		padding: ($gu-v-spacing / 2) ($gu-h-spacing / 2) $gu-v-spacing;
 		border-top: 2px solid gu-colour(neutral-1);
 		background-color: gu-colour(comment-support-3);
 		font-family: $gu-text-sans-web;
 
-		.component-double-heading, .component-bundle__content {
-
-			@include mq($from: phablet) {
-				display: inline-block;
-				width: 50%;
-				vertical-align: top;
-			}
+		@include mq($from: desktop) {
+			width: 280px;
+			margin-top: 80px;
+			margin-left: 92px;
 		}
 	}
 
@@ -87,24 +127,10 @@
 		padding-bottom: $gu-v-spacing;
 		margin-top: $gu-v-spacing * 4;
 
-		@include mq($from: phablet) {
-			// Fix for IE.
-	        svg {
-	          left: 270px;
-	        }
-		}
-
-		@include mq($from: tablet) {
-			// Fix for IE.
-	        svg {
-	          left: 310px;
-	        }
-		}
-
 		@include mq($from: desktop) {
 			// Fix for IE.
 	        svg {
-	          left: 430px;
+	          left: 248px;
 	        }
 		}
 
@@ -125,18 +151,16 @@
 		background-color: #fff;
 		padding-top: $gu-v-spacing * 3;
 		padding-bottom: $gu-v-spacing;
+
+		@include mq($from: desktop) {
+			padding-top: $gu-v-spacing * 2;
+		}
 	}
 
 	.component-contrib-legal {
-		@include mq($from: leftCol) {
-	      margin-left: 80px;
-	      margin-right: 80px;
-	    }
-
-	    @include mq($from: wide) {
-	      margin-left: 160px;
-	      margin-right: 160px;
-	    }
+		@include mq($from: desktop) {
+			width: 540px;
+		}
 	}
 
 	// ----- AB Test ----- //

--- a/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/assets/pages/contributions-landing/contributionsLanding.scss
@@ -11,6 +11,10 @@
 		display: inline-block;
 		vertical-align: top;
 		margin-bottom: $gu-v-spacing * 1.5;
+
+		@include mq($from: phablet, $until: desktop) {
+			width: 320px;
+		}
 	}
 
 	.contributions-introduction__primary, .contributions-introduction__secondary {
@@ -32,6 +36,11 @@
 	.contributions-introduction__primary {
 		margin-bottom: 111px;
 		margin-top: $gu-v-spacing;
+
+		@include mq($from: phablet) {
+			margin-bottom: $gu-v-spacing;
+			margin-top: 34px;
+		}
 
 		@include mq($from: desktop) {
 			margin-bottom: 45px;
@@ -64,6 +73,12 @@
 	.contributions-introduction__secondary {
 		color: gu-colour(neutral-1);
 
+		@include mq($from: phablet) {
+			h1:nth-child(2) {
+				margin-left: 55px;
+			}
+		}
+
 		@include mq($from: desktop) {
 			h1:nth-child(1) {
 				margin-left: 147px;
@@ -85,20 +100,35 @@
 		}
 	}
 
+	.contributions-introduction__indent {
+		@include mq($from: phablet, $until: desktop) {
+			margin-left: 85px;
+		}
+	}
+
 	// ----- Bundle ----- //
 
 	.contributions-bundle {
 		background-color: darken(gu-colour(multimedia-main-2), 5%);
 
-		@include mq($from: desktop) {
+		@include mq($from: mobileLandscape) {
+			height: 700px;
+		}
+
+		@include mq($from: phablet) {
 			height: 420px;
 		}
 	}
 
 	.contributions-bundle__content {
 		background-color: gu-colour(multimedia-main-2);
-		padding-left: 0;
-		padding-right: 0;
+		padding: 0;
+		padding: 0;
+
+		@include mq($from: mobileLandscape) {
+			padding-left: 10px;
+			padding-right: 10px;
+		}
 	}
 
 	.component-bundle {
@@ -110,10 +140,19 @@
 		background-color: gu-colour(comment-support-3);
 		font-family: $gu-text-sans-web;
 
-		@include mq($from: desktop) {
+		@include mq($from: phablet) {
 			width: 280px;
+			margin-top: 49px;
+			margin-left: 10px;
+		}
+
+		@include mq($from: tablet, $until: desktop) {
+			width: 360px;
+		}
+
+		@include mq($from: desktop) {
 			margin-top: 80px;
-			margin-left: 92px;
+			margin-left: 85px;
 		}
 
 		@include mq($from: wide) {
@@ -200,12 +239,20 @@
 		padding-top: $gu-v-spacing * 3;
 		padding-bottom: $gu-v-spacing;
 
+		@include mq($from: mobileLandscape, $until: phablet) {
+			padding-top: 95px;
+		}
+
 		@include mq($from: desktop) {
 			padding-top: $gu-v-spacing * 2;
 		}
 	}
 
 	.component-contrib-legal {
+		@include mq($from: phablet) {
+			width: 300px;
+		}
+
 		@include mq($from: desktop) {
 			width: 540px;
 		}

--- a/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/assets/pages/contributions-landing/contributionsLanding.scss
@@ -7,62 +7,45 @@
 
 	// ----- Introduction ----- //
 
-	.component-introduction-text {
-		background-color: darken(gu-colour(multimedia-main-2), 5%);
+	.contributions-introduction {
+		display: inline-block;
+		margin-bottom: $gu-v-spacing;
+		margin-top: $gu-v-spacing;
+	}
 
-		.component-introduction-text__content {
-			background-color: gu-colour(multimedia-main-2);
-		}
+	.contributions-introduction__primary, .contributions-introduction__secondary {
+		font-size: 40px;
+		line-height: 44px;
+		color: #fff;
+		font-family: $gu-egyptian-web;
+		font-weight: 600;
+		padding-left: $gu-h-spacing / 2;
+		padding-right: $gu-h-spacing / 2;
+	}
 
-		h1 {
-			color: gu-colour(neutral-1);
-		}
+	.contributions-introduction__secondary {
+		color: gu-colour(neutral-1);
+		margin-top: 45px;
 	}
 
 	// ----- Bundle ----- //
 
 	.contributions-bundle {
-		background-color: darken(#fff, 5%);
+		background-color: darken(gu-colour(multimedia-main-2), 5%);
 	}
 
 	.contributions-bundle__content {
-		background-color: #fff;
-		position: relative;
+		background-color: gu-colour(multimedia-main-2);
+		padding-left: 0;
+		padding-right: 0;
 	}
 
-	.introduction-bleed, .introduction-bleed-margins {
-      height: 180px;
-      background-color: darken(gu-colour(multimedia-main-2), 5%);
-      position: absolute;
-      left: 0;
-      width: 100%;
-
-      @include mq($from: phablet) {
-        height: 130px;
-      }
-
-    }
-
-    .introduction-bleed {
-      background-color: gu-colour(multimedia-main-2);
-    }
-
 	.component-bundle {
-		position: relative;
+		display: inline-block;
 		padding: ($gu-v-spacing / 2) ($gu-h-spacing / 2) $gu-v-spacing;
-		border-top: 1px solid gu-colour(neutral-1);
+		border-top: 2px solid gu-colour(neutral-1);
 		background-color: gu-colour(comment-support-3);
 		font-family: $gu-text-sans-web;
-
-		@include mq($from: leftCol) {
-	      margin-left: 80px;
-	      margin-right: 80px;
-	    }
-
-	    @include mq($from: wide) {
-	      margin-left: 160px;
-	      margin-right: 160px;
-	    }
 
 		.component-double-heading, .component-bundle__content {
 
@@ -79,20 +62,9 @@
 	}
 
 	.component-double-heading__subheading {
+		margin-top: $gu-v-spacing;
 		font-size: 16px;
 		line-height: 20px;
-
-		@include mq($from: phablet) {
-			padding-right: 20%;
-		}
-
-		@include mq($from: tablet) {
-			padding-right: 30%;
-		}
-
-		@include mq($from: desktop) {
-			padding-right: 20%;
-		}
 	}
 
 	.component-radio-toggle input:not(:checked)+label, .component-number-input {
@@ -145,12 +117,8 @@
 
 	.contributions-legal__content {
 		background-color: #fff;
-		padding-top: $gu-v-spacing * 2;
-		padding-bottom: $gu-v-spacing * 4;
-
-		@include mq($until: phablet) {
-			padding: $gu-v-spacing $gu-h-spacing;
-		}
+		padding-top: $gu-v-spacing * 3;
+		padding-bottom: $gu-v-spacing;
 	}
 
 	.component-contrib-legal {

--- a/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/assets/pages/contributions-landing/contributionsLanding.scss
@@ -18,13 +18,18 @@
 	}
 
 	.contributions-introduction__primary, .contributions-introduction__secondary {
-		font-size: 36px;
-		line-height: 40px;
+		font-size: 32px;
+		line-height: 36px;
 		color: #fff;
 		font-family: $gu-egyptian-web;
 		font-weight: 600;
 		padding-left: $gu-h-spacing / 2;
 		padding-right: $gu-h-spacing / 2;
+
+		@include mq($from: mobileMedium) {
+			font-size: 36px;
+			line-height: 40px;
+		}
 
 		@include mq($from: desktop) {
 			padding: 0;

--- a/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/assets/pages/contributions-landing/contributionsLanding.scss
@@ -49,6 +49,16 @@
 				margin-left: 60px;
 			}
 		}
+
+		@include mq($from: leftCol) {
+			h1:nth-child(2) {
+				margin-left: 267px;
+			}
+
+			h1:nth-child(3) {
+				margin-left: 116px;
+			}
+		}
 	}
 
 	.contributions-introduction__secondary {
@@ -61,6 +71,16 @@
 
 			h1:nth-child(2) {
 				margin-left: 187px;
+			}
+		}
+
+		@include mq($from: leftCol) {
+			h1:nth-child(1) {
+				margin-left: 254px;
+			}
+
+			h1:nth-child(2) {
+				margin-left: 319px;
 			}
 		}
 	}
@@ -94,6 +114,27 @@
 			width: 280px;
 			margin-top: 80px;
 			margin-left: 92px;
+		}
+
+		@include mq($from: wide) {
+			width: 360px;
+			margin-left: 120px;
+		}
+
+		label, .component-number-input {
+			margin-top: 5px;
+			margin-bottom: 5px;
+			padding-top: 10px;
+			padding-bottom: 10px;
+		}
+
+		.component-cta-link {
+			padding-top: 17px;
+			padding-bottom: 17px;
+
+			svg {
+				top: 18px;
+			}
 		}
 	}
 
@@ -130,7 +171,14 @@
 		@include mq($from: desktop) {
 			// Fix for IE.
 	        svg {
-	          left: 248px;
+	          left: 245px;
+	        }
+		}
+
+		@include mq($from: wide) {
+			// Fix for IE.
+	        svg {
+	          left: 325px;
 	        }
 		}
 
@@ -160,6 +208,14 @@
 	.component-contrib-legal {
 		@include mq($from: desktop) {
 			width: 540px;
+		}
+
+		@include mq($from: leftCol) {
+			width: 670px;
+		}
+
+		@include mq($from: wide) {
+			width: 700px;
 		}
 	}
 

--- a/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/assets/pages/contributions-landing/contributionsLanding.scss
@@ -82,10 +82,12 @@
 		@include mq($from: desktop) {
 			h1:nth-child(1) {
 				margin-left: 147px;
+				display: inline;
 			}
 
 			h1:nth-child(2) {
-				margin-left: 187px;
+				margin-left: 0;
+				display: inline;
 			}
 		}
 
@@ -95,7 +97,7 @@
 			}
 
 			h1:nth-child(2) {
-				margin-left: 319px;
+				margin-left: 0;
 			}
 		}
 	}
@@ -103,6 +105,15 @@
 	.contributions-introduction__indent {
 		@include mq($from: phablet, $until: desktop) {
 			margin-left: 85px;
+		}
+
+		@include mq($from: desktop) {
+			display: block;
+			margin-left: 420px;
+		}
+
+		@include mq($from: leftCol) {
+			margin-left: 525px;
 		}
 	}
 
@@ -117,6 +128,10 @@
 
 		@include mq($from: phablet) {
 			height: 420px;
+		}
+
+		@include mq($from: desktop) {
+			height: 450px;
 		}
 	}
 
@@ -271,6 +286,19 @@
 	.hide-monthly {
 		.contrib-type {
 			display: none;
+		}
+
+		.component-double-heading__subheading {
+			margin-bottom: $gu-v-spacing * 3;
+
+			@include mq($from: mobileLandscape) {
+				margin-bottom: 100px;
+			}
+		}
+
+		.component-contrib-amounts {
+			border-top: 1px dotted gu-colour(neutral-1);
+			padding-top: 7px;
 		}
 	}
 

--- a/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/assets/pages/contributions-landing/contributionsLanding.scss
@@ -9,13 +9,13 @@
 
 	.contributions-introduction {
 		display: inline-block;
-		margin-bottom: $gu-v-spacing;
+		margin-bottom: $gu-v-spacing * 1.5;
 		margin-top: $gu-v-spacing;
 	}
 
 	.contributions-introduction__primary, .contributions-introduction__secondary {
-		font-size: 40px;
-		line-height: 44px;
+		font-size: 36px;
+		line-height: 40px;
 		color: #fff;
 		font-family: $gu-egyptian-web;
 		font-weight: 600;
@@ -25,7 +25,7 @@
 
 	.contributions-introduction__secondary {
 		color: gu-colour(neutral-1);
-		margin-top: 45px;
+		margin-top: 111px;
 	}
 
 	// ----- Bundle ----- //
@@ -61,10 +61,16 @@
     	margin-bottom: (2 * $gu-v-spacing);
 	}
 
+	.component-double-heading__heading {
+		font-size: 24px;
+		line-height: 30px;
+	}
+
 	.component-double-heading__subheading {
 		margin-top: $gu-v-spacing;
 		font-size: 16px;
 		line-height: 20px;
+		font-family: $gu-text-egyptian-web;
 	}
 
 	.component-radio-toggle input:not(:checked)+label, .component-number-input {

--- a/assets/pages/contributions-landing/contributionsLandingUK.jsx
+++ b/assets/pages/contributions-landing/contributionsLandingUK.jsx
@@ -9,13 +9,13 @@ import { Provider } from 'react-redux';
 
 import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
 import SimpleFooter from 'components/footers/simpleFooter/simpleFooter';
-import IntroductionText from 'components/introductionText/introductionText';
 import ContribLegal from 'components/legal/contribLegal/contribLegal';
 
 import pageStartup from 'helpers/pageStartup';
 import { getQueryParameter } from 'helpers/url';
 
 import reducer from './reducers/reducers';
+import ContributionsIntroduction from './components/contributionsIntroduction';
 import ContributionsBundle from './components/contributionsBundle';
 
 
@@ -38,31 +38,15 @@ store.dispatch({ type: 'SET_AB_TEST_PARTICIPATION', payload: participation });
 const showMonthly = participation.contributionsLandingAddingMonthly !== 'control';
 
 
-// ----- Copy ----- //
-
-const introductionCopy = [
-  {
-    heading: 'support the Guardian',
-    copy: ['be part of our future', 'by helping to secure it'],
-  },
-  {
-    heading: 'hold power to account',
-    copy: ['by funding quality,', 'independent journalism'],
-  },
-];
-
-
 // ----- Render ----- //
 
 const content = (
   <Provider store={store}>
     <div className="gu-content">
       <SimpleHeader />
-      <IntroductionText messages={introductionCopy} />
       <section className="contributions-bundle">
-        <div className="introduction-bleed-margins" />
         <div className={`contributions-bundle__content gu-content-margin ${showMonthly ? '' : 'hide-monthly'}`}>
-          <div className="introduction-bleed" />
+          <ContributionsIntroduction />
           <ContributionsBundle />
         </div>
       </section>


### PR DESCRIPTION
## Why are you doing this?

To make the contributions landing page look fancier before we go live with the recurring contributions test. Also, to make sure we move the text around the page as much as possible at different breakpoints, because that's a key feature of this page 🙈.

[**Trello Card**](https://trello.com/c/nVhp7sX5/762-contributions-landing-page-tweaks)

cc: @amohkhan

## Changes

- Made the contributions legal copy a single blob of text, no paragraphs here.
- Added a custom chunk of introduction text, and made sure the words do something new and exciting with every breakpoint we support.
- Moved the contribution card up to the right on wider breakpoints.
- Dropped a rogue comma!

## Screenshots

### Mobile

![contrib-landing-mobile](https://user-images.githubusercontent.com/5131341/28977202-046c76c8-7939-11e7-89c8-8867cc2f9f38.png)

### Mobile Medium

![contrib-landing-mobile-medium](https://user-images.githubusercontent.com/5131341/28977212-09443ef6-7939-11e7-8974-0750d2ac26df.png)

### Mobile Landscape

![contrib-landing-mobile-landscape](https://user-images.githubusercontent.com/5131341/28977218-0eb13362-7939-11e7-9c8f-ee79350dd368.png)

### Phablet

![contrib-landing-phablet](https://user-images.githubusercontent.com/5131341/28977223-127be514-7939-11e7-822d-158daab553ba.png)

### Tablet

![contrib-landing-tablet](https://user-images.githubusercontent.com/5131341/28977233-18a540a2-7939-11e7-87c4-58a9d0672212.png)

### Desktop

![contrib-landing-desktop](https://user-images.githubusercontent.com/5131341/28977338-8d5e8610-7939-11e7-84bc-c4f96b76aca7.png)

### Left Col

![contrib-landing-left-col](https://user-images.githubusercontent.com/5131341/28977345-90c7bbaa-7939-11e7-8e81-9b10d788f9c9.png)

### Wide

![contrib-landing-wide](https://user-images.githubusercontent.com/5131341/28977509-3299acae-793a-11e7-882a-386c112d71ab.png)