### PR TITLE
Allow contribute.theguardian.com to set cookies

### DIFF
--- a/assets/pages/oneoff-contributions/helpers/ajax.js
+++ b/assets/pages/oneoff-contributions/helpers/ajax.js
@@ -55,6 +55,7 @@ function requestData(paymentToken: string, getState: Function) {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(oneoffContribFields),
+    credentials: 'include',
   };
 
 }


### PR DESCRIPTION
## Why are you doing this?

So that the contributions 6month cookie is dropped when users oneoff-contribute from support.theguardian.com.  Dependant on https://github.com/guardian/contributions-frontend/pull/317.  Do not merge until contributions is deployed.

[**Trello Card**](https://trello.com/c/CKfct7nX/754-figure-out-how-the-contributions-6month-cookie-is-dropped-and-drop-in-for-one-off-contributions-in-support)
