### PR TITLE
Allow non-test users to access monthly contributions

### DIFF
--- a/app/controllers/MonthlyContributions.scala
+++ b/app/controllers/MonthlyContributions.scala
@@ -33,7 +33,7 @@ class MonthlyContributions(
 
   implicit val ar = assets
 
-  def displayForm(paypal: Option[Boolean] = Some(false)): Action[AnyContent] = AuthenticatedTestUserAction.async { implicit request =>
+  def displayForm(paypal: Option[Boolean] = Some(false)): Action[AnyContent] = AuthenticatedAction.async { implicit request =>
     identityService.getUser(request.user).semiflatMap { fullUser =>
       isMonthlyContributor(request.user.credentials) map {
         case Some(true) => Redirect("/monthly-contributions/existing-contributor")


### PR DESCRIPTION
## Why are you doing this?

So that real users can use support.theguardian.com to become recurring contributors

[**Trello Card**](https://trello.com/c/LZvTv3a0/658-q2-test-2-make-monthly-contributions-available-for-real-users)
