### PR TITLE
Display friendly error message if oneoff-contributions post fails

### DIFF
--- a/assets/pages/oneoff-contributions/helpers/ajax.js
+++ b/assets/pages/oneoff-contributions/helpers/ajax.js
@@ -76,8 +76,9 @@ export default function postCheckout(
       return;
     }
 
-    response.text().then(err => dispatch(checkoutError(err)));
-
+    dispatch(checkoutError('Error'));
+  }).catch(() => {
+    dispatch(checkoutError('Error'));
   });
 
 }


### PR DESCRIPTION
## Why are you doing this?

Visual indication of failure (rather than just a message in the console) so that users know what has happened if contributions-frontend is down/rejects their payment

[**Trello Card**](https://trello.com/c/HoNu0JLS/733-error-handling-for-one-off-contributions-post)
