### PR TITLE
PayPal Contributions Integration

### DIFF
--- a/app/config/Configuration.scala
+++ b/app/config/Configuration.scala
@@ -20,7 +20,9 @@ class Configuration {
 
   lazy val supportUrl = config.getString("support.url")
 
-  lazy val contributionsEndpoint = config.getString("contributions.stripe.url")
+  lazy val contributionsStripeEndpoint = config.getString("contributions.stripe.url")
+
+  lazy val contributionsPayPalEndpoint = config.getString("contributions.paypal.url")
 
   lazy val membersDataServiceApiUrl = config.getString("membersDataService.api.url")
 

--- a/app/controllers/OneOffContributions.scala
+++ b/app/controllers/OneOffContributions.scala
@@ -32,7 +32,7 @@ class OneOffContributions(
 
   implicit val ar = assets
 
-  def displayForm(paypal: Option[Boolean] = Some(false)): Action[AnyContent] = CachedAction() {
+  def displayForm(paypal: Option[Boolean]): Action[AnyContent] = CachedAction() {
     form(uatMode = false, paypal)
   }
 

--- a/app/controllers/OneOffContributions.scala
+++ b/app/controllers/OneOffContributions.scala
@@ -22,7 +22,8 @@ class OneOffContributions(
     identityService: IdentityService,
     testUsers: TestUserService,
     stripeConfigProvider: StripeConfigProvider,
-    contributionsEndpoint: String,
+    contributionsStripeEndpoint: String,
+    contributionsPayPalEndpoint: String,
     authAction: AuthAction[AnyContent],
     components: ControllerComponents
 )(implicit val exec: ExecutionContext) extends AbstractController(components) with Circe with LazyLogging {
@@ -54,7 +55,8 @@ class OneOffContributions(
       uatMode = uatMode,
       payPalButton = paypal.getOrElse(false),
       stripeConfig = stripeConfigProvider.get(uatMode),
-      contributionsEnpoint = contributionsEndpoint
+      contributionsStripeEndpoint = contributionsStripeEndpoint,
+      contributionsPayPalEndpoint = contributionsPayPalEndpoint
     )
   )
 

--- a/app/controllers/OneOffContributions.scala
+++ b/app/controllers/OneOffContributions.scala
@@ -31,12 +31,12 @@ class OneOffContributions(
 
   implicit val ar = assets
 
-  def displayForm: Action[AnyContent] = CachedAction() {
-    form(uatMode = false)
+  def displayForm(paypal: Option[Boolean] = Some(false)): Action[AnyContent] = CachedAction() {
+    form(uatMode = false, paypal)
   }
 
-  def displayFormTestUser: Action[AnyContent] = authAction {
-    form(uatMode = true).withHeaders(CacheControl.noCache)
+  def displayFormTestUser(paypal: Option[Boolean]): Action[AnyContent] = authAction {
+    form(uatMode = true, paypal).withHeaders(CacheControl.noCache)
   }
 
   def autofill: Action[AnyContent] = AuthenticatedAction.async { implicit request =>
@@ -46,12 +46,13 @@ class OneOffContributions(
     )
   }
 
-  private def form(uatMode: Boolean): Result = Ok(
+  private def form(uatMode: Boolean, paypal: Option[Boolean]): Result = Ok(
     oneOffContributions(
       title = "Support the Guardian | One-off Contribution",
       id = "oneoff-contributions-page",
       js = "oneoffContributionsPage.js",
       uatMode = uatMode,
+      payPalButton = paypal.getOrElse(false),
       stripeConfig = stripeConfigProvider.get(uatMode),
       contributionsEnpoint = contributionsEndpoint
     )

--- a/app/views/monthlyContributions.scala.html
+++ b/app/views/monthlyContributions.scala.html
@@ -28,7 +28,7 @@
                 lastName: "@lastName",
             }
         };
-        window.guardian.payPalButtonExists = @payPalButton;
+        window.guardian.payPalType = @payPalButton? 'ExpressCheckout' : 'NotSet';
         window.guardian.stripeKey = "@stripeConfig.publicKey";
         window.guardian.payPalEnvironment = "@payPalConfig.payPalEnvironment";
         window.guardian.csrf = { token: "@CSRF.getToken.value" };

--- a/app/views/oneOffContributions.scala.html
+++ b/app/views/oneOffContributions.scala.html
@@ -9,15 +9,17 @@
         uatMode: Boolean,
         payPalButton: Boolean,
         stripeConfig: StripeConfig,
-        contributionsEnpoint: String
+        contributionsStripeEndpoint: String,
+        contributionsPayPalEndpoint: String
 )(implicit assets: AssetsResolver)
 
 @scripts = {
     <script type="text/javascript">
         window.guardian = window.guardian || {};
         window.guardian.stripeKey = "@stripeConfig.publicKey";
-        window.guardian.contributionsStripeEndpoint = "@contributionsEnpoint";
-        window.guardian.payPalType = @payPalButton ? 'ExpressCheckout' : 'NotSet';
+        window.guardian.contributionsStripeEndpoint = "@contributionsStripeEndpoint";
+        window.guardian.contributionsPayPalEndpoint = "@contributionsPayPalEndpoint";
+        window.guardian.payPalType = @payPalButton ? 'ContributionsCheckout' : 'NotSet';
         window.guardian.uatMode = @uatMode;
     </script>
     <script type="text/javascript" src="@assets(js)"></script>

--- a/app/views/oneOffContributions.scala.html
+++ b/app/views/oneOffContributions.scala.html
@@ -7,6 +7,7 @@
         id: String,
         js: String,
         uatMode: Boolean,
+        payPalButton: Boolean,
         stripeConfig: StripeConfig,
         contributionsEnpoint: String
 )(implicit assets: AssetsResolver)
@@ -16,6 +17,7 @@
         window.guardian = window.guardian || {};
         window.guardian.stripeKey = "@stripeConfig.publicKey";
         window.guardian.contributionsStripeEndpoint = "@contributionsEnpoint";
+        window.guardian.payPalType = @payPalButton ? 'ExpressCheckout' : 'NotSet';
         window.guardian.uatMode = @uatMode;
     </script>
     <script type="text/javascript" src="@assets(js)"></script>

--- a/app/wiring/Controllers.scala
+++ b/app/wiring/Controllers.scala
@@ -41,7 +41,8 @@ trait Controllers {
     identityService,
     testUsers,
     appConfig.oneOffStripeConfigProvider,
-    appConfig.contributionsEndpoint,
+    appConfig.contributionsStripeEndpoint,
+    appConfig.contributionsPayPalEndpoint,
     authAction,
     controllerComponents
   )

--- a/assets/components/payPalContributionButton/payPalContributionButton.jsx
+++ b/assets/components/payPalContributionButton/payPalContributionButton.jsx
@@ -1,0 +1,63 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+import { connect } from 'react-redux';
+
+import { payPalContributionsButtonClicked, paypalContributionsRedirect } from 'helpers/payPalContributionsCheckout/payPalContributionsCheckoutActions';
+
+
+// ---- Types ----- //
+
+type PropTypes = {
+  payWithPayPal: Function,
+  payPalPayClicked: boolean,
+  paypalContributionsRedirect: Function,
+};
+
+
+// ----- Component ----- //
+
+const PayPalContributionButton = (props: PropTypes) => {
+
+  if (props.payPalPayClicked) {
+    props.paypalContributionsRedirect();
+  }
+
+  return (
+    <button className={'action action--button action--button--forward'} onClick={props.payWithPayPal}>
+      <svg className="action--button__arrow" xmlns="http://www.w3.org/2000/svg" width="20" height="17.89" viewBox="0 0 20 17.89">
+        <path d="M20 9.35l-9.08 8.54-.86-.81 6.54-7.31H0V8.12h16.6L10.06.81l.86-.81L20 8.51v.84zm20-.81L49.08 0l.86.81-6.54 7.31H60v1.65H43.4l6.54 7.31-.86.81L40 9.39v-.85z" />
+      </svg>
+    </button>);
+};
+
+
+// ----- Map State/Props ----- //
+
+function mapStateToProps(state) {
+
+  return {
+    payPalPayClicked: state.payPalContributionsCheckout.payPalPayClicked,
+  };
+
+}
+
+function mapDispatchToProps(dispatch) {
+
+  return {
+    payWithPayPal: () => {
+      dispatch(payPalContributionsButtonClicked());
+    },
+    paypalContributionsRedirect: () => {
+      dispatch(paypalContributionsRedirect());
+    },
+  };
+
+}
+
+
+// ----- Exports ----- //
+
+export default connect(mapStateToProps, mapDispatchToProps)(PayPalContributionButton);

--- a/assets/components/paymentMethods/paymentMethods.jsx
+++ b/assets/components/paymentMethods/paymentMethods.jsx
@@ -14,7 +14,7 @@ import ErrorMessage from 'components/errorMessage/errorMessage';
 
 export type PayPalButtonType =
   'ExpressCheckout' |
-  'ContributionsIntegration' |
+  'ContributionsCheckout' |
   'NotSet';
 
 
@@ -37,10 +37,10 @@ export default function PaymentMethods(props: PropTypes) {
   let payPalButton = '';
 
   switch (props.payPalType) {
-    case 'ExpressCheckout' :
+    case 'ExpressCheckout':
       payPalButton = <PayPalExpressButton callback={props.payPalCallback} />;
       break;
-    case 'ContributionsIntegration' :
+    case 'ContributionsCheckout':
       payPalButton = <PayPalContributionButton callback={props.payPalCallback} />;
       break;
     default:

--- a/assets/components/paymentMethods/paymentMethods.jsx
+++ b/assets/components/paymentMethods/paymentMethods.jsx
@@ -6,16 +6,23 @@ import React from 'react';
 
 import StripePopUpButton from 'components/stripePopUpButton/stripePopUpButton';
 import PayPalExpressButton from 'components/payPalExpressButton/payPalExpressButton';
+import PayPalContributionButton from 'components/payPalContributionButton/payPalContributionButton';
 import ErrorMessage from 'components/errorMessage/errorMessage';
 
 
 // ----- Types ----- //
 
+export type PayPalButtonType =
+  'ExpressCheckout' |
+  'ContributionsIntegration' |
+  'NotSet';
+
+
 type PropTypes = {
   email: string,
   hide: boolean,
   error: ?string,
-  payPalButtonExists: boolean,
+  payPalType: PayPalButtonType,
   stripeCallback: Function,
   payPalCallback: Function,
 };
@@ -29,8 +36,16 @@ export default function PaymentMethods(props: PropTypes) {
   let stripeButton = <StripePopUpButton email={props.email} callback={props.stripeCallback} />;
   let payPalButton = '';
 
-  if (props.payPalButtonExists) {
-    payPalButton = <PayPalExpressButton callback={props.payPalCallback} />;
+  switch (props.payPalType) {
+    case 'ExpressCheckout' :
+      payPalButton = <PayPalExpressButton callback={props.payPalCallback} />;
+      break;
+    case 'ContributionsIntegration' :
+      payPalButton = <PayPalContributionButton callback={props.payPalCallback} />;
+      break;
+    default:
+      payPalButton = '';
+      break;
   }
 
   if (props.hide) {

--- a/assets/helpers/payPalContributionsCheckout/__tests__/__snapshots__/payPalContributionsCheckoutReducerTests.js.snap
+++ b/assets/helpers/payPalContributionsCheckout/__tests__/__snapshots__/payPalContributionsCheckoutReducerTests.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`PayPal Contribution Reducer Tests should handle PAYPAL_PAY_CONTRIBUTIONS_CLICKED 1`] = `null`;
+
+exports[`PayPal Contribution Reducer Tests should handle PAYPAL_PAY_CONTRIBUTIONS_CLICKED 2`] = `"GBP"`;
+
+exports[`PayPal Contribution Reducer Tests should handle SET_PAYPAL_CONTRIBUTIONS_AMOUNT 1`] = `"GBP"`;
+
+exports[`PayPal Contribution Reducer Tests should handle SET_PAYPAL_CONTRIBUTIONS_AMOUNT 2`] = `false`;
+
+exports[`PayPal Contribution Reducer Tests should return the initial state 1`] = `
+Object {
+  "amount": null,
+  "currency": "GBP",
+  "payPalPayClicked": false,
+}
+`;

--- a/assets/helpers/payPalContributionsCheckout/__tests__/payPalContributionsCheckoutActionsTests.js
+++ b/assets/helpers/payPalContributionsCheckout/__tests__/payPalContributionsCheckoutActionsTests.js
@@ -1,0 +1,44 @@
+// @flow
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+
+import {
+  payPalContributionsButtonClicked,
+  payPalContributionsSubmitPayment,
+  setPayPalContributionsAmount,
+  payPalContributionsError,
+  paypalContributionsRedirect,
+} from '../payPalContributionsCheckoutActions';
+
+describe('PayPal Contributions Checkout\'s actions', () => {
+
+  it('should create PAYPAL_PAY_CONTRIBUTIONS_CLICKED action', () => {
+    const expectedAction = {
+      type: 'PAYPAL_PAY_CONTRIBUTIONS_CLICKED',
+    };
+    expect(payPalContributionsButtonClicked()).toEqual(expectedAction);
+  });
+
+  it('should create PAYPAL_CONTRIBUTIONS_SUBMIT action', () => {
+    const expectedAction = {
+      type: 'PAYPAL_CONTRIBUTIONS_SUBMIT',
+    };
+    expect(payPalContributionsSubmitPayment()).toEqual(expectedAction);
+  });
+  it('should create SET_PAYPAL_CONTRIBUTIONS_AMOUNT action', () => {
+    const amount: number = 6;
+    const expectedAction = {
+      type: 'SET_PAYPAL_CONTRIBUTIONS_AMOUNT',
+      amount,
+    };
+    expect(setPayPalContributionsAmount(amount)).toEqual(expectedAction);
+  });
+  it('should create PAYPAL_CONTRIBUTIONS_ERROR action', () => {
+    const message: string = 'This is an error';
+    const expectedAction = {
+      type: 'PAYPAL_CONTRIBUTIONS_ERROR',
+      message,
+    };
+    expect(payPalContributionsError(message)).toEqual(expectedAction);
+  });
+});

--- a/assets/helpers/payPalContributionsCheckout/__tests__/payPalContributionsCheckoutActionsTests.js
+++ b/assets/helpers/payPalContributionsCheckout/__tests__/payPalContributionsCheckoutActionsTests.js
@@ -1,13 +1,9 @@
 // @flow
-import configureMockStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
-
 import {
   payPalContributionsButtonClicked,
   payPalContributionsSubmitPayment,
   setPayPalContributionsAmount,
   payPalContributionsError,
-  paypalContributionsRedirect,
 } from '../payPalContributionsCheckoutActions';
 
 describe('PayPal Contributions Checkout\'s actions', () => {

--- a/assets/helpers/payPalContributionsCheckout/__tests__/payPalContributionsCheckoutReducerTests.js
+++ b/assets/helpers/payPalContributionsCheckout/__tests__/payPalContributionsCheckoutReducerTests.js
@@ -1,0 +1,43 @@
+// @flow
+
+// ----- Imports ----- //
+
+import reducer from '../payPalContributionsCheckoutReducer';
+
+
+// ----- Tests ----- //
+
+describe('PayPal Contribution Reducer Tests', () => {
+
+  it('should return the initial state', () => {
+    expect(reducer(undefined, {})).toMatchSnapshot();
+  });
+
+  it('should handle PAYPAL_PAY_CONTRIBUTIONS_CLICKED', () => {
+
+    const action = {
+      type: 'PAYPAL_PAY_CONTRIBUTIONS_CLICKED',
+      payPalPayClicked: true,
+    };
+    const newState = reducer(undefined, action);
+
+    expect(newState.payPalPayClicked).toEqual(true);
+    expect(newState.amount).toMatchSnapshot();
+    expect(newState.currency).toMatchSnapshot();
+  });
+
+  it('should handle SET_PAYPAL_CONTRIBUTIONS_AMOUNT', () => {
+
+    const action = {
+      type: 'SET_PAYPAL_CONTRIBUTIONS_AMOUNT',
+      amount: 33.34,
+    };
+
+    const newState = reducer(undefined, action);
+
+    expect(newState.amount).toEqual(33.34);
+    expect(newState.currency).toMatchSnapshot();
+    expect(newState.payPalPayClicked).toMatchSnapshot();
+  });
+
+});

--- a/assets/helpers/payPalContributionsCheckout/payPalContributionsCheckoutActions.js
+++ b/assets/helpers/payPalContributionsCheckout/payPalContributionsCheckoutActions.js
@@ -70,9 +70,8 @@ export function paypalContributionsRedirect(): Function {
       .then((response) => {
         if (response.ok) {
           return response.json();
-        } else {
-          throw response;
         }
+        throw response;
       })
       .then((res) => { window.location = res.approvalUrl; })
       .catch(() => dispatch(payPalContributionsError('Sorry, an error occurred, please try again or use another payment method.')));

--- a/assets/helpers/payPalContributionsCheckout/payPalContributionsCheckoutActions.js
+++ b/assets/helpers/payPalContributionsCheckout/payPalContributionsCheckoutActions.js
@@ -1,0 +1,80 @@
+// @flow
+
+// ----- Types ----- //
+
+export type Action =
+  | { type: 'PAYPAL_PAY_CONTRIBUTIONS_CLICKED' }
+  | { type: 'SET_PAYPAL_CONTRIBUTIONS_AMOUNT', amount: number }
+  | { type: 'PAYPAL_CONTRIBUTIONS_ERROR', message: string }
+  | { type: 'PAYPAL_CONTRIBUTIONS_SUBMIT' }
+  ;
+
+// ----- Actions ----- //
+
+export function payPalContributionsButtonClicked(): Action {
+  return { type: 'PAYPAL_PAY_CONTRIBUTIONS_CLICKED' };
+}
+
+export function payPalContributionsSubmitPayment(): Action {
+  return { type: 'PAYPAL_CONTRIBUTIONS_SUBMIT' };
+}
+
+
+export function payPalContributionsError(message: string): Action {
+  return { type: 'PAYPAL_CONTRIBUTIONS_ERROR', message };
+}
+
+export function setPayPalContributionsAmount(amount: number): Action {
+  return { type: 'SET_PAYPAL_CONTRIBUTIONS_AMOUNT', amount };
+}
+
+export function paypalContributionsRedirect(): Function {
+
+  const PAYPAL_CONTRIBUTION_ENDPOINT:string = window.guardian.contributionsPayPalEndpoint;
+
+  return (dispatch, getState) => {
+
+    const state = getState();
+
+    dispatch(payPalContributionsSubmitPayment());
+
+    const postData: Object = {
+      countryGroup: 'uk',
+      amount: state.payPalContributionsCheckout.amount,
+      intCmp: state.intCmp,
+      supportRedirect: true,
+      /*
+       TODO: pass these argument to contributions in order to improve
+       the tracking of one-off contributions.
+
+       cmp: state.data.cmpCode,
+       refererPageviewId: state.data.refererPageviewId,
+       refererUrl: state.data.refererUrl,
+       ophanPageviewId: state.data.ophan.pageviewId,
+       ophanBrowserId: state.data.ophan.browserId,
+       ophanVisitId: state.data.ophan.visitId
+      */
+    };
+
+    const fetchOptions: Object = {
+      credentials: 'same-origin',
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(postData),
+    };
+
+    fetch(PAYPAL_CONTRIBUTION_ENDPOINT, fetchOptions)
+      .then((response) => {
+        if (response.ok) {
+          return response.json();
+        } else {
+          throw response;
+        }
+      })
+      .then((res) => { window.location = res.approvalUrl; })
+      .catch(() => dispatch(payPalContributionsError('Sorry, an error occurred, please try again or use another payment method.')));
+  };
+}

--- a/assets/helpers/payPalContributionsCheckout/payPalContributionsCheckoutReducer.js
+++ b/assets/helpers/payPalContributionsCheckout/payPalContributionsCheckoutReducer.js
@@ -1,0 +1,45 @@
+// @flow
+
+// ----- Imports ----- //
+
+import type { Action } from './payPalContributionsCheckoutActions';
+
+
+// ----- Types ----- //
+
+export type State = {
+  payPalPayClicked: boolean,
+  amount: ?number,
+
+  currency: string,
+};
+
+
+// ----- Setup ----- //
+
+const initialState: State = {
+  payPalPayClicked: false,
+  currency: 'GBP',
+  amount: null,
+};
+
+
+// ----- Exports ----- //
+
+export default function payPalContributionsCheckoutReducer(
+  state: State = initialState,
+  action: Action): State {
+
+  switch (action.type) {
+
+    case 'PAYPAL_PAY_CONTRIBUTIONS_CLICKED':
+      return Object.assign({}, state, { payPalPayClicked: true });
+
+    case 'SET_PAYPAL_CONTRIBUTIONS_AMOUNT':
+      return Object.assign({}, state, { amount: action.amount });
+
+    default:
+      return state;
+
+  }
+}

--- a/assets/helpers/payPalContributionsCheckout/payPalContributionsCheckoutReducer.js
+++ b/assets/helpers/payPalContributionsCheckout/payPalContributionsCheckoutReducer.js
@@ -8,10 +8,9 @@ import type { Action } from './payPalContributionsCheckoutActions';
 // ----- Types ----- //
 
 export type State = {
-  payPalPayClicked: boolean,
   amount: ?number,
-
   currency: string,
+  payPalPayClicked: boolean,
 };
 
 

--- a/assets/pages/monthly-contributions/actions/monthlyContributionsActions.js
+++ b/assets/pages/monthly-contributions/actions/monthlyContributionsActions.js
@@ -7,14 +7,14 @@ import {
   setPayPalExpressAmount,
 } from 'helpers/payPalExpressCheckout/payPalExpressCheckoutActions';
 import { parse as parseContribution } from 'helpers/contributions';
-
+import type { PayPalButtonType } from 'components/paymentMethods/paymentMethods';
 
 // ----- Types ----- //
 
 export type Action =
   | { type: 'SET_CONTRIB_VALUE', value: number }
   | { type: 'CHECKOUT_ERROR', message: string }
-  | { type: 'SET_PAYPAL_BUTTON', value: boolean }
+  | { type: 'SET_PAYPAL_BUTTON', value: PayPalButtonType }
   ;
 
 
@@ -28,7 +28,7 @@ export function checkoutError(message: string): Action {
   return { type: 'CHECKOUT_ERROR', message };
 }
 
-export function setPayPalButton(value: boolean): Action {
+export function setPayPalButton(value: PayPalButtonType): Action {
   return { type: 'SET_PAYPAL_BUTTON', value };
 }
 

--- a/assets/pages/monthly-contributions/components/paymentMethodsContainer.jsx
+++ b/assets/pages/monthly-contributions/components/paymentMethodsContainer.jsx
@@ -5,7 +5,6 @@
 import { connect } from 'react-redux';
 import PaymentMethods from 'components/paymentMethods/paymentMethods';
 
-
 // ----- Map State/Props ----- //
 
 function mapStateToProps(state) {

--- a/assets/pages/monthly-contributions/monthlyContributions.jsx
+++ b/assets/pages/monthly-contributions/monthlyContributions.jsx
@@ -51,7 +51,7 @@ if (contributionAmount !== undefined && contributionAmount !== null) {
 
 
 user.init(store.dispatch);
-store.dispatch(setPayPalButton(window.guardian.payPalButtonExists));
+store.dispatch(setPayPalButton(window.guardian.payPalType));
 
 // ----- Render ----- //
 
@@ -76,7 +76,7 @@ const content = (
           <PaymentMethodsContainer
             stripeCallback={postCheckout('stripeToken')}
             payPalCallback={postCheckout('baid')}
-            payPalButtonExists={store.getState().monthlyContrib.payPalButtonExists}
+            payPalType={store.getState().monthlyContrib.payPalType}
           />
         </InfoSection>
         <InfoSection className="monthly-contrib__payment-methods">

--- a/assets/pages/monthly-contributions/reducers/reducers.js
+++ b/assets/pages/monthly-contributions/reducers/reducers.js
@@ -49,8 +49,7 @@ function monthlyContrib(
       return Object.assign({}, state, { error: action.message });
 
     case 'SET_PAYPAL_BUTTON' :
-      const a = Object.assign({}, state, { payPalType: action.value });
-      return a;
+      return Object.assign({}, state, { payPalType: action.value });
 
     default:
       return state;

--- a/assets/pages/monthly-contributions/reducers/reducers.js
+++ b/assets/pages/monthly-contributions/reducers/reducers.js
@@ -10,6 +10,7 @@ import payPalExpressCheckout from 'helpers/payPalExpressCheckout/payPalExpressCh
 import user from 'helpers/user/userReducer';
 import csrf from 'helpers/csrf/csrfReducer';
 
+import type { PayPalButtonType } from 'components/paymentMethods/paymentMethods';
 import type { Action } from '../actions/monthlyContributionsActions';
 
 
@@ -19,7 +20,7 @@ export type State = {
   amount: number,
   country: string,
   error: ?string,
-  payPalButtonExists: boolean,
+  payPalType: PayPalButtonType,
 };
 
 
@@ -29,7 +30,7 @@ const initialState: State = {
   amount: 5,
   country: 'GB',
   error: null,
-  payPalButtonExists: false,
+  payPalType: 'NotSet',
 };
 
 
@@ -48,7 +49,8 @@ function monthlyContrib(
       return Object.assign({}, state, { error: action.message });
 
     case 'SET_PAYPAL_BUTTON' :
-      return Object.assign({}, state, { payPalButtonExists: action.value });
+      const a = Object.assign({}, state, { payPalType: action.value });
+      return a;
 
     default:
       return state;

--- a/assets/pages/oneoff-contributions/actions/oneoffContributionsActions.js
+++ b/assets/pages/oneoff-contributions/actions/oneoffContributionsActions.js
@@ -4,6 +4,7 @@
 
 import { setStripeAmount } from 'helpers/stripeCheckout/stripeCheckoutActions';
 import { setPayPalExpressAmount } from 'helpers/payPalExpressCheckout/payPalExpressCheckoutActions';
+import { setPayPalContributionsAmount } from 'helpers/payPalContributionsCheckout/payPalContributionsCheckoutActions';
 import { parse as parseContribution } from 'helpers/contributions';
 import type { PayPalButtonType } from 'components/paymentMethods/paymentMethods';
 
@@ -38,6 +39,7 @@ export function setContribAmount(amount: string): Function {
     dispatch(setContribValue(value));
     dispatch(setStripeAmount(value));
     dispatch(setPayPalExpressAmount(value));
+    dispatch(setPayPalContributionsAmount(value));
   };
 
 }

--- a/assets/pages/oneoff-contributions/actions/oneoffContributionsActions.js
+++ b/assets/pages/oneoff-contributions/actions/oneoffContributionsActions.js
@@ -5,13 +5,14 @@
 import { setStripeAmount } from 'helpers/stripeCheckout/stripeCheckoutActions';
 import { setPayPalExpressAmount } from 'helpers/payPalExpressCheckout/payPalExpressCheckoutActions';
 import { parse as parseContribution } from 'helpers/contributions';
-
+import type { PayPalButtonType } from 'components/paymentMethods/paymentMethods';
 
 // ----- Types ----- //
 
 export type Action =
   | { type: 'SET_CONTRIB_VALUE', value: number }
   | { type: 'CHECKOUT_ERROR', message: string }
+  | { type: 'SET_PAYPAL_BUTTON', value: PayPalButtonType }
   ;
 
 
@@ -23,6 +24,10 @@ function setContribValue(value: number): Action {
 
 export function checkoutError(message: string): Action {
   return { type: 'CHECKOUT_ERROR', message };
+}
+
+export function setPayPalButton(value: PayPalButtonType): Action {
+  return { type: 'SET_PAYPAL_BUTTON', value };
 }
 
 export function setContribAmount(amount: string): Function {

--- a/assets/pages/oneoff-contributions/oneoffContributions.jsx
+++ b/assets/pages/oneoff-contributions/oneoffContributions.jsx
@@ -26,7 +26,7 @@ import FormFields from './components/formFields';
 import reducer from './reducers/reducers';
 import postCheckout from './helpers/ajax';
 
-import { setContribAmount } from './actions/oneoffContributionsActions';
+import { setContribAmount, setPayPalButton } from './actions/oneoffContributionsActions';
 
 
 // ----- Page Startup ----- //
@@ -49,6 +49,7 @@ if (contributionAmount !== undefined && contributionAmount !== null) {
   store.dispatch(setContribAmount(contributionAmount));
 }
 
+store.dispatch(setPayPalButton(window.guardian.payPalType));
 
 // ----- Render ----- //
 
@@ -72,7 +73,7 @@ const content = (
           <PaymentMethodsContainer
             stripeCallback={postCheckout}
             payPalCallback={postCheckout}
-            payPalButtonExists={false}
+            payPalType={store.getState().oneoffContrib.payPalType}
           />
         </InfoSection>
         <InfoSection className="oneoff-contrib__payment-methods">

--- a/assets/pages/oneoff-contributions/reducers/reducers.js
+++ b/assets/pages/oneoff-contributions/reducers/reducers.js
@@ -6,9 +6,11 @@ import { combineReducers } from 'redux';
 
 import { intCmpReducer as intCmp } from 'helpers/intCmp';
 import stripeCheckout from 'helpers/stripeCheckout/stripeCheckoutReducer';
+import payPalExpressCheckout from 'helpers/payPalExpressCheckout/payPalExpressCheckoutReducer';
 import user from 'helpers/user/userReducer';
 import csrf from 'helpers/csrf/csrfReducer';
 
+import type { PayPalButtonType } from 'components/paymentMethods/paymentMethods';
 import type { Action } from '../actions/oneoffContributionsActions';
 
 
@@ -18,6 +20,7 @@ export type State = {
   amount: number,
   country: string,
   error: ?string,
+  payPalType: PayPalButtonType,
 };
 
 
@@ -27,6 +30,7 @@ const initialState: State = {
   amount: 50,
   country: 'GB',
   error: null,
+  payPalType: 'NotSet',
 };
 
 
@@ -44,6 +48,9 @@ function oneoffContrib(
     case 'CHECKOUT_ERROR':
       return Object.assign({}, state, { error: action.message });
 
+    case 'SET_PAYPAL_BUTTON' :
+      return Object.assign({}, state, { payPalType: action.value });
+
     default:
       return state;
 
@@ -59,5 +66,6 @@ export default combineReducers({
   intCmp,
   user,
   stripeCheckout,
+  payPalExpressCheckout,
   csrf,
 });

--- a/assets/pages/oneoff-contributions/reducers/reducers.js
+++ b/assets/pages/oneoff-contributions/reducers/reducers.js
@@ -7,6 +7,7 @@ import { combineReducers } from 'redux';
 import { intCmpReducer as intCmp } from 'helpers/intCmp';
 import stripeCheckout from 'helpers/stripeCheckout/stripeCheckoutReducer';
 import payPalExpressCheckout from 'helpers/payPalExpressCheckout/payPalExpressCheckoutReducer';
+import payPalContributionsCheckout from 'helpers/payPalContributionsCheckout/payPalContributionsCheckoutReducer';
 import user from 'helpers/user/userReducer';
 import csrf from 'helpers/csrf/csrfReducer';
 
@@ -67,5 +68,6 @@ export default combineReducers({
   user,
   stripeCheckout,
   payPalExpressCheckout,
+  payPalContributionsCheckout,
   csrf,
 });

--- a/conf/routes
+++ b/conf/routes
@@ -15,8 +15,8 @@ POST /monthly-contributions/create                  controllers.MonthlyContribut
 GET /oneoff-contributions/thankyou                  controllers.Application.reactTemplate(title="Support the Guardian | Thank You", id="oneoff-contributions-thankyou-page", js="oneoffContributionsThankyouPage.js")
 GET /uk/contribute              controllers.Application.reactTemplate(title="Support the Guardian | Make a Contribution", id="contributions-landing-page-uk", js="contributionsLandingPageUK.js")
 
-GET /oneoff-contributions                         controllers.OneOffContributions.displayForm(paypal : Option[Boolean])
-GET /oneoff-contributions/test-user               controllers.OneOffContributions.displayFormTestUser(paypal : Option[Boolean])
+GET /oneoff-contributions                         controllers.OneOffContributions.displayForm(paypal: Option[Boolean])
+GET /oneoff-contributions/test-user               controllers.OneOffContributions.displayFormTestUser(paypal: Option[Boolean])
 GET /oneoff-contributions/thankyou                controllers.Application.reactTemplate(title="Support the Guardian | Thank You", id="oneoff-contributions-thankyou-page", js="oneoffContributionsThankyouPage.js")
 GET /oneoff-contributions/autofill                controllers.OneOffContributions.autofill
 

--- a/conf/routes
+++ b/conf/routes
@@ -15,8 +15,8 @@ POST /monthly-contributions/create                  controllers.MonthlyContribut
 GET /oneoff-contributions/thankyou                  controllers.Application.reactTemplate(title="Support the Guardian | Thank You", id="oneoff-contributions-thankyou-page", js="oneoffContributionsThankyouPage.js")
 GET /uk/contribute              controllers.Application.reactTemplate(title="Support the Guardian | Make a Contribution", id="contributions-landing-page-uk", js="contributionsLandingPageUK.js")
 
-GET /oneoff-contributions                         controllers.OneOffContributions.displayForm
-GET /oneoff-contributions/test-user               controllers.OneOffContributions.displayFormTestUser
+GET /oneoff-contributions                         controllers.OneOffContributions.displayForm(paypal : Option[Boolean])
+GET /oneoff-contributions/test-user               controllers.OneOffContributions.displayFormTestUser(paypal : Option[Boolean])
 GET /oneoff-contributions/thankyou                controllers.Application.reactTemplate(title="Support the Guardian | Thank You", id="oneoff-contributions-thankyou-page", js="oneoffContributionsThankyouPage.js")
 GET /oneoff-contributions/autofill                controllers.OneOffContributions.autofill
 


### PR DESCRIPTION
## Why are you doing this?

We would like to have PayPal button in one off contributions.

[**Trello Card**](https://trello.com/c/YIRjPpFe/765-spike-add-paypal-to-the-one-off-contribution)

In a future PR, design changes will be introduced to improve the current button. 

## Screenshots
![paypaloneoff](https://user-images.githubusercontent.com/825398/29084787-12150e32-7c65-11e7-83af-da8c9797c587.gif)

## Related PR:
https://github.com/guardian/contributions-frontend/pull/323
