### PR TITLE
Update identity url in DEV

### DIFF
--- a/conf/DEV.public.conf
+++ b/conf/DEV.public.conf
@@ -7,7 +7,7 @@
 
 stage="DEV"
 
-identity.webapp.url="https://profile-origin.thegulocal.com"
+identity.webapp.url="https://profile.thegulocal.com"
 identity.api.url="https://idapi.code.dev-theguardian.com"
 identity.production.keys=false
 support.url="https://support.thegulocal.com"


### PR DESCRIPTION
## Why are you doing this?

For the rational, or if you are wondering if this will cause conflicts with Dotcom Identity Frontend, please see the following pull request:

https://github.com/guardian/identity-platform/pull/170

Please note that [Identity Frontend](https://github.com/guardian/identity-frontend) should now be accessible in DEV at 
```
profile.thegulocal.com
```
instead of 
```
profile-origin.thegulocal.com
```

May I ask you please to fresh pull `identity-frontend` and `identity-platform` and update your bookmarks to point to the new domain. You may also wish to remove profile-origin from `/etc/hosts`

Also reload Nginx config with

```
sudo nginx -s reload
```

cc @mario-galic 