### PR TITLE
Add support for US dollars

### DIFF
--- a/assets/components/paymentAmount/paymentAmount.jsx
+++ b/assets/components/paymentAmount/paymentAmount.jsx
@@ -3,7 +3,7 @@
 // ----- Imports ----- //
 
 import React from 'react';
-
+import type { Currency } from 'helpers/internationalisation/currency';
 
 // ----- Setup ----- //
 
@@ -14,6 +14,7 @@ const wideClass = 'component-payment-amount--wide-value';
 
 type PropTypes = {
   amount: number,
+  currency: Currency,
 };
 
 
@@ -26,7 +27,7 @@ export default function PaymentAmount(props: PropTypes) {
   const printedAmount = wideValue ? props.amount.toFixed(2) : props.amount;
 
   return (
-    <div className={className}>£{printedAmount}</div>
+    <div className={className}>{props.currency.glyph}{printedAmount}</div>
   );
 
 }

--- a/assets/helpers/contributions.js
+++ b/assets/helpers/contributions.js
@@ -57,12 +57,12 @@ export const CONFIG: Config = {
 
 // ----- Functions ----- //
 
-export function parse(input: string, contrib: Contrib): ParsedContrib {
+export function parse(input: ?string, contrib: Contrib): ParsedContrib {
 
   let error = null;
   const numericAmount = Number(input);
 
-  if (input === '' || isNaN(numericAmount)) {
+  if (input === undefined || input === null || input === '' || isNaN(numericAmount)) {
     error = 'invalidEntry';
   } else if (numericAmount < CONFIG[contrib].min) {
     error = 'tooLittle';

--- a/assets/helpers/csrf/csrfReducer.js
+++ b/assets/helpers/csrf/csrfReducer.js
@@ -7,7 +7,7 @@ import type { Action } from './csrfActions';
 
 // ----- Types ----- //
 
-type Csrf = {
+export type Csrf = {
     token: ?string,
 };
 

--- a/assets/helpers/internationalisation/country.js
+++ b/assets/helpers/internationalisation/country.js
@@ -17,7 +17,6 @@ function fromString(s: string): ?IsoCountry {
 }
 
 function fromPath(path: string = window.location.pathname): ?IsoCountry {
-  console.log('path' + path);
   if (path.startsWith('/uk/')) {
     return 'GB';
   } else if (path.startsWith('/us/')) {
@@ -28,7 +27,6 @@ function fromPath(path: string = window.location.pathname): ?IsoCountry {
 
 function fromQueryParameter(): ?IsoCountry {
   const country = getQueryParameter('country');
-  console.log('qp:' + country);
   if (country) {
     return fromString(country);
   }
@@ -37,7 +35,6 @@ function fromQueryParameter(): ?IsoCountry {
 
 function fromCookie(): ?IsoCountry {
   const country = cookie.get('GU_country');
-  console.log('cookie:' + country);
   if (country) {
     return fromString(country);
   }

--- a/assets/helpers/internationalisation/country.js
+++ b/assets/helpers/internationalisation/country.js
@@ -41,9 +41,16 @@ function fromCookie(): ?IsoCountry {
   return null;
 }
 
+function fromGeolocation(): ?IsoCountry {
+  const country = cookie.get('GU_geo_country');
+  if (country) {
+    return fromString(country);
+  }
+  return null;
+}
+
 export function detect(): IsoCountry {
-  const country = fromPath() || fromQueryParameter() || fromCookie() || 'GB';
-  console.log('detect:' + country);
+  const country = fromPath() || fromQueryParameter() || fromCookie() || fromGeolocation() || 'GB';
   cookie.set('GU_country', country, 7);
   return country;
 }

--- a/assets/helpers/internationalisation/country.js
+++ b/assets/helpers/internationalisation/country.js
@@ -51,7 +51,8 @@ function fromGeolocation(): ?IsoCountry {
 
 export function detect(): IsoCountry {
   const country = fromPath() || fromQueryParameter() || fromCookie() || fromGeolocation() || 'GB';
-  cookie.set('GU_country', country, 7);
-  return country;
+  // cookie.set('GU_country', country, 7);
+  // Always return GB because we aren't ready to support US quite yet
+  return 'GB' || country;
 }
 

--- a/assets/helpers/internationalisation/country.js
+++ b/assets/helpers/internationalisation/country.js
@@ -1,0 +1,53 @@
+// @flow
+
+import { getQueryParameter } from 'helpers/url';
+import * as cookie from './../cookie';
+
+export type IsoCountry =
+  | 'GB'
+  | 'US';
+
+function fromString(s: string): ?IsoCountry {
+  switch (s.toLowerCase()) {
+    case 'gb': return 'GB';
+    case 'uk': return 'GB';
+    case 'us': return 'US';
+    default: return null;
+  }
+}
+
+function fromPath(path: string = window.location.pathname): ?IsoCountry {
+  console.log('path' + path);
+  if (path.startsWith('/uk/')) {
+    return 'GB';
+  } else if (path.startsWith('/us/')) {
+    return 'US';
+  }
+  return null;
+}
+
+function fromQueryParameter(): ?IsoCountry {
+  const country = getQueryParameter('country');
+  console.log('qp:' + country);
+  if (country) {
+    return fromString(country);
+  }
+  return null;
+}
+
+function fromCookie(): ?IsoCountry {
+  const country = cookie.get('GU_country');
+  console.log('cookie:' + country);
+  if (country) {
+    return fromString(country);
+  }
+  return null;
+}
+
+export function detect(): IsoCountry {
+  const country = fromPath() || fromQueryParameter() || fromCookie() || 'GB';
+  console.log('detect:' + country);
+  cookie.set('GU_country', country, 7);
+  return country;
+}
+

--- a/assets/helpers/internationalisation/currency.js
+++ b/assets/helpers/internationalisation/currency.js
@@ -22,10 +22,9 @@ export const USD: Currency = {
 };
 
 export function forCountry(country: IsoCountry): Currency {
-  console.log('detecting currency for ' + country);
   switch (country) {
-    case 'US': console.log('USD'); return USD;
-    case 'GB': console.log('GBP'); return GBP;
+    case 'US': return USD;
+    case 'GB': return GBP;
     default: return GBP;
   }
 }

--- a/assets/helpers/internationalisation/currency.js
+++ b/assets/helpers/internationalisation/currency.js
@@ -1,0 +1,31 @@
+// @flow
+
+import type { IsoCountry } from './country';
+
+export type IsoCurrency =
+  | 'GBP'
+  | 'USD';
+
+export type Currency = {
+  iso: IsoCurrency,
+  glyph: string,
+};
+
+export const GBP: Currency = {
+  iso: 'GBP',
+  glyph: '£',
+};
+
+export const USD: Currency = {
+  iso: 'USD',
+  glyph: '$',
+};
+
+export function forCountry(country: IsoCountry): Currency {
+  console.log('detecting currency for ' + country);
+  switch (country) {
+    case 'US': console.log('USD'); return USD;
+    case 'GB': console.log('GBP'); return GBP;
+    default: return GBP;
+  }
+}

--- a/assets/helpers/payPalExpressCheckout/__tests__/__snapshots__/payPalExpressReducersTest.js.snap
+++ b/assets/helpers/payPalExpressCheckout/__tests__/__snapshots__/payPalExpressReducersTest.js.snap
@@ -4,17 +4,11 @@ exports[`PayPal Reducer Tests should handle PAYPAL_EXPRESS_CHECKOUT_LOADED 1`] =
 
 exports[`PayPal Reducer Tests should handle PAYPAL_EXPRESS_CHECKOUT_LOADED 2`] = `"GBP"`;
 
-exports[`PayPal Reducer Tests should handle PAYPAL_EXPRESS_CHECKOUT_LOADED 3`] = `null`;
-
-exports[`PayPal Reducer Tests should handle SET_PAYPAL_EXPRESS_AMOUNT 1`] = `"monthly"`;
-
-exports[`PayPal Reducer Tests should handle SET_PAYPAL_EXPRESS_AMOUNT 2`] = `"GBP"`;
-
-exports[`PayPal Reducer Tests should handle SET_PAYPAL_EXPRESS_AMOUNT 3`] = `false`;
+exports[`PayPal Reducer Tests should handle PAYPAL_EXPRESS_CHECKOUT_LOADED 3`] = `13`;
 
 exports[`PayPal Reducer Tests should return the initial state 1`] = `
 Object {
-  "amount": null,
+  "amount": 13,
   "billingPeriod": "monthly",
   "currency": "GBP",
   "loaded": false,

--- a/assets/helpers/payPalExpressCheckout/__tests__/payPalExpressCheckoutActionsTest.js
+++ b/assets/helpers/payPalExpressCheckout/__tests__/payPalExpressCheckoutActionsTest.js
@@ -4,7 +4,6 @@ import thunk from 'redux-thunk';
 
 import {
   startPayPalExpressCheckout,
-  setPayPalExpressAmount,
   payPalExpressCheckoutLoaded,
   payPalExpressError,
   setupPayPalExpressCheckout,
@@ -18,15 +17,6 @@ describe('PayPal Express Checkout\'s actions', () => {
       type: 'START_PAYPAL_EXPRESS_CHECKOUT',
     };
     expect(startPayPalExpressCheckout()).toEqual(expectedAction);
-  });
-
-  it('should create SET_PAYPAL_EXPRESS_AMOUNT action', () => {
-    const amount: number = 6;
-    const expectedAction = {
-      type: 'SET_PAYPAL_EXPRESS_AMOUNT',
-      amount,
-    };
-    expect(setPayPalExpressAmount(amount)).toEqual(expectedAction);
   });
 
   it('should create PAYPAL_EXPRESS_CHECKOUT_LOADED action', () => {

--- a/assets/helpers/payPalExpressCheckout/__tests__/payPalExpressReducersTest.js
+++ b/assets/helpers/payPalExpressCheckout/__tests__/payPalExpressReducersTest.js
@@ -11,7 +11,7 @@ describe('PayPal Reducer Tests', () => {
 
   it('should return the initial state', () => {
 
-    expect(reducer(undefined, {})).toMatchSnapshot();
+    expect(reducer(13, 'GBP')(undefined, {})).toMatchSnapshot();
   });
 
   it('should handle PAYPAL_EXPRESS_CHECKOUT_LOADED', () => {
@@ -21,7 +21,7 @@ describe('PayPal Reducer Tests', () => {
       loaded: true,
     };
 
-    const newState = reducer(undefined, action);
+    const newState = reducer(13, 'GBP')(undefined, action);
 
     expect(newState.loaded).toEqual(true);
     expect(newState.billingPeriod).toMatchSnapshot();

--- a/assets/helpers/payPalExpressCheckout/__tests__/payPalExpressReducersTest.js
+++ b/assets/helpers/payPalExpressCheckout/__tests__/payPalExpressReducersTest.js
@@ -2,7 +2,7 @@
 
 // ----- Imports ----- //
 
-import reducer from '../payPalExpressCheckoutReducer';
+import createReducer from '../payPalExpressCheckoutReducer';
 
 
 // ----- Tests ----- //
@@ -10,8 +10,8 @@ import reducer from '../payPalExpressCheckoutReducer';
 describe('PayPal Reducer Tests', () => {
 
   it('should return the initial state', () => {
-
-    expect(reducer(13, 'GBP')(undefined, {})).toMatchSnapshot();
+    const reducer = createReducer(13, 'GBP');
+    expect(reducer(undefined, {})).toMatchSnapshot();
   });
 
   it('should handle PAYPAL_EXPRESS_CHECKOUT_LOADED', () => {
@@ -21,7 +21,8 @@ describe('PayPal Reducer Tests', () => {
       loaded: true,
     };
 
-    const newState = reducer(13, 'GBP')(undefined, action);
+    const reducer = createReducer(13, 'GBP');
+    const newState = reducer(undefined, action);
 
     expect(newState.loaded).toEqual(true);
     expect(newState.billingPeriod).toMatchSnapshot();

--- a/assets/helpers/payPalExpressCheckout/__tests__/payPalExpressReducersTest.js
+++ b/assets/helpers/payPalExpressCheckout/__tests__/payPalExpressReducersTest.js
@@ -29,19 +29,4 @@ describe('PayPal Reducer Tests', () => {
     expect(newState.amount).toMatchSnapshot();
   });
 
-  it('should handle SET_PAYPAL_EXPRESS_AMOUNT', () => {
-
-    const action = {
-      type: 'SET_PAYPAL_EXPRESS_AMOUNT',
-      amount: 33.34,
-    };
-
-    const newState = reducer(undefined, action);
-
-    expect(newState.amount).toEqual(33.34);
-    expect(newState.billingPeriod).toMatchSnapshot();
-    expect(newState.currency).toMatchSnapshot();
-    expect(newState.loaded).toMatchSnapshot();
-  });
-
 });

--- a/assets/helpers/payPalExpressCheckout/payPalExpressCheckout.js
+++ b/assets/helpers/payPalExpressCheckout/payPalExpressCheckout.js
@@ -3,12 +3,19 @@
 // ----- Imports ----- //
 
 import { payPalExpressError } from 'helpers/payPalExpressCheckout/payPalExpressCheckoutActions';
+import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
+import type { State as PayPalExpressCheckoutState } from 'helpers/payPalExpressCheckout/payPalExpressCheckoutReducer';
 
 // ----- Setup ----- //
 
 const SETUP_PAYMENT_URL = '/paypal/setup-payment';
 const CREATE_AGREEMENT_URL = '/paypal/create-agreement';
 
+
+type CombinedState = {
+  csrf: CsrfState,
+  payPalExpressCheckout: PayPalExpressCheckoutState,
+};
 
 // ----- Functions ----- //
 
@@ -54,7 +61,7 @@ function payPalRequestData(bodyObj: Object, csrfToken: string) {
   };
 }
 
-function setupPayment(dispatch: Function, state: Object) {
+function setupPayment(dispatch: Function, state: CombinedState) {
 
   const payPalState = state.payPalExpressCheckout;
   const csrfToken = state.csrf.token;
@@ -67,7 +74,7 @@ function setupPayment(dispatch: Function, state: Object) {
       currency: payPalState.currency,
     };
 
-    fetch(SETUP_PAYMENT_URL, payPalRequestData(requestBody, csrfToken))
+    fetch(SETUP_PAYMENT_URL, payPalRequestData(requestBody, csrfToken || ''))
       .then(handleSetupResponse)
       .then((token) => {
         if (token) {
@@ -82,15 +89,15 @@ function setupPayment(dispatch: Function, state: Object) {
   };
 }
 
-function createAgreement(payPalData: Object, state: Object) {
+function createAgreement(payPalData: Object, state: CombinedState) {
   const body = { token: payPalData.paymentToken };
   const csrfToken = state.csrf.token;
 
-  return fetch(CREATE_AGREEMENT_URL, payPalRequestData(body, csrfToken))
+  return fetch(CREATE_AGREEMENT_URL, payPalRequestData(body, csrfToken || ''))
     .then(response => response.json());
 }
 
-function setup(dispatch: Function, getState: Function, callback: Function) {
+function setup(dispatch: Function, getState: () => CombinedState, callback: Function) {
 
   return loadPayPalExpress()
     .then(() => {

--- a/assets/helpers/payPalExpressCheckout/payPalExpressCheckout.js
+++ b/assets/helpers/payPalExpressCheckout/payPalExpressCheckout.js
@@ -3,19 +3,13 @@
 // ----- Imports ----- //
 
 import { payPalExpressError } from 'helpers/payPalExpressCheckout/payPalExpressCheckoutActions';
-import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
-import type { State as PayPalExpressCheckoutState } from 'helpers/payPalExpressCheckout/payPalExpressCheckoutReducer';
+import type { CombinedState } from 'helpers/payPalExpressCheckout/payPalExpressCheckoutReducer';
 
 // ----- Setup ----- //
 
 const SETUP_PAYMENT_URL = '/paypal/setup-payment';
 const CREATE_AGREEMENT_URL = '/paypal/create-agreement';
 
-
-type CombinedState = {
-  csrf: CsrfState,
-  payPalExpressCheckout: PayPalExpressCheckoutState,
-};
 
 // ----- Functions ----- //
 

--- a/assets/helpers/payPalExpressCheckout/payPalExpressCheckoutActions.js
+++ b/assets/helpers/payPalExpressCheckout/payPalExpressCheckoutActions.js
@@ -2,13 +2,14 @@
 
 // ----- Imports ----- //
 
+import type { Currency } from 'helpers/internationalisation/currency';
 import * as payPalExpressCheckout from './payPalExpressCheckout';
 
 // ----- Types ----- //
 
 export type Action =
   | { type: 'START_PAYPAL_EXPRESS_CHECKOUT' }
-  | { type: 'SET_PAYPAL_EXPRESS_AMOUNT', amount: number }
+  | { type: 'SET_PAYPAL_EXPRESS_AMOUNT', amount: number, currency: Currency }
   | { type: 'PAYPAL_EXPRESS_CHECKOUT_LOADED' }
   | { type: 'PAYPAL_EXPRESS_ERROR', message: string }
   ;
@@ -19,8 +20,8 @@ export function startPayPalExpressCheckout(): Action {
   return { type: 'START_PAYPAL_EXPRESS_CHECKOUT' };
 }
 
-export function setPayPalExpressAmount(amount: number): Action {
-  return { type: 'SET_PAYPAL_EXPRESS_AMOUNT', amount };
+export function setPayPalExpressAmount(amount: number, currency: Currency): Action {
+  return { type: 'SET_PAYPAL_EXPRESS_AMOUNT', amount, currency };
 }
 
 export function payPalExpressCheckoutLoaded(): Action {

--- a/assets/helpers/payPalExpressCheckout/payPalExpressCheckoutActions.js
+++ b/assets/helpers/payPalExpressCheckout/payPalExpressCheckoutActions.js
@@ -2,14 +2,12 @@
 
 // ----- Imports ----- //
 
-import type { Currency } from 'helpers/internationalisation/currency';
 import * as payPalExpressCheckout from './payPalExpressCheckout';
 
 // ----- Types ----- //
 
 export type Action =
   | { type: 'START_PAYPAL_EXPRESS_CHECKOUT' }
-  | { type: 'SET_PAYPAL_EXPRESS_AMOUNT', amount: number, currency: Currency }
   | { type: 'PAYPAL_EXPRESS_CHECKOUT_LOADED' }
   | { type: 'PAYPAL_EXPRESS_ERROR', message: string }
   ;
@@ -18,10 +16,6 @@ export type Action =
 
 export function startPayPalExpressCheckout(): Action {
   return { type: 'START_PAYPAL_EXPRESS_CHECKOUT' };
-}
-
-export function setPayPalExpressAmount(amount: number, currency: Currency): Action {
-  return { type: 'SET_PAYPAL_EXPRESS_AMOUNT', amount, currency };
 }
 
 export function payPalExpressCheckoutLoaded(): Action {

--- a/assets/helpers/payPalExpressCheckout/payPalExpressCheckoutReducer.js
+++ b/assets/helpers/payPalExpressCheckout/payPalExpressCheckoutReducer.js
@@ -2,6 +2,7 @@
 
 // ----- Imports ----- //
 
+import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import type { Action } from './payPalExpressCheckoutActions';
 
 
@@ -10,7 +11,7 @@ import type { Action } from './payPalExpressCheckoutActions';
 export type State = {
   amount: ?number,
   billingPeriod: string,
-  currency: string,
+  currency: ?IsoCurrency,
   loaded: boolean,
 };
 
@@ -20,7 +21,7 @@ export type State = {
 const initialState: State = {
   amount: null,
   billingPeriod: 'monthly',
-  currency: 'GBP',
+  currency: null,
   loaded: false,
 };
 
@@ -37,7 +38,7 @@ export default function payPalExpressCheckoutReducer(
       return Object.assign({}, state, { loaded: true });
 
     case 'SET_PAYPAL_EXPRESS_AMOUNT':
-      return Object.assign({}, state, { amount: action.amount });
+      return Object.assign({}, state, { amount: action.amount, currency: action.currency.iso });
 
     default:
       return state;

--- a/assets/helpers/payPalExpressCheckout/payPalExpressCheckoutReducer.js
+++ b/assets/helpers/payPalExpressCheckout/payPalExpressCheckoutReducer.js
@@ -2,9 +2,10 @@
 
 // ----- Imports ----- //
 
+import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
+import type { State as PayPalExpressCheckoutState } from 'helpers/payPalExpressCheckout/payPalExpressCheckoutReducer';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import type { Action } from './payPalExpressCheckoutActions';
-
 
 // ----- Types ----- //
 
@@ -15,6 +16,10 @@ export type State = {
   loaded: boolean,
 };
 
+export type CombinedState = {
+  csrf: CsrfState,
+  payPalExpressCheckout: PayPalExpressCheckoutState,
+};
 
 // ----- Exports ----- //
 

--- a/assets/helpers/payPalExpressCheckout/payPalExpressCheckoutReducer.js
+++ b/assets/helpers/payPalExpressCheckout/payPalExpressCheckoutReducer.js
@@ -9,40 +9,34 @@ import type { Action } from './payPalExpressCheckoutActions';
 // ----- Types ----- //
 
 export type State = {
-  amount: ?number,
+  amount: number,
   billingPeriod: string,
-  currency: ?IsoCurrency,
+  currency: IsoCurrency,
   loaded: boolean,
-};
-
-
-// ----- Setup ----- //
-
-const initialState: State = {
-  amount: null,
-  billingPeriod: 'monthly',
-  currency: null,
-  loaded: false,
 };
 
 
 // ----- Exports ----- //
 
-export default function payPalExpressCheckoutReducer(
-  state: State = initialState,
-  action: Action): State {
+export default function payPalExpressCheckoutReducer(amount: number, currency: IsoCurrency) {
 
-  switch (action.type) {
+  const initialState: State = {
+    amount,
+    billingPeriod: 'monthly',
+    currency,
+    loaded: false,
+  };
 
-    case 'PAYPAL_EXPRESS_CHECKOUT_LOADED':
-      return Object.assign({}, state, { loaded: true });
+  return (state: State = initialState, action: Action): State => {
 
-    case 'SET_PAYPAL_EXPRESS_AMOUNT':
-      return Object.assign({}, state, { amount: action.amount, currency: action.currency.iso });
+    switch (action.type) {
 
-    default:
-      return state;
+      case 'PAYPAL_EXPRESS_CHECKOUT_LOADED':
+        return Object.assign({}, state, { loaded: true });
 
-  }
+      default:
+        return state;
 
+    }
+  };
 }

--- a/assets/helpers/payPalExpressCheckout/payPalExpressCheckoutReducer.js
+++ b/assets/helpers/payPalExpressCheckout/payPalExpressCheckoutReducer.js
@@ -23,7 +23,7 @@ export type CombinedState = {
 
 // ----- Exports ----- //
 
-export default function payPalExpressCheckoutReducer(amount: number, currency: IsoCurrency) {
+export default function createPayPalExpressCheckoutReducer(amount: number, currency: IsoCurrency) {
 
   const initialState: State = {
     amount,
@@ -32,7 +32,7 @@ export default function payPalExpressCheckoutReducer(amount: number, currency: I
     loaded: false,
   };
 
-  return (state: State = initialState, action: Action): State => {
+  return function payPalExpressCheckoutReducer(state: State = initialState, action: Action): State {
 
     switch (action.type) {
 

--- a/assets/helpers/stripeCheckout/stripeCheckoutActions.js
+++ b/assets/helpers/stripeCheckout/stripeCheckoutActions.js
@@ -2,7 +2,6 @@
 
 // ----- Imports ----- //
 
-import type { Currency } from 'helpers/internationalisation/currency';
 import * as stripeCheckout from './stripeCheckout';
 import type { State as StripeCheckoutState } from './stripeCheckoutReducer';
 
@@ -14,7 +13,6 @@ export type Action =
   | { type: 'SET_STRIPE_CHECKOUT_TOKEN', token: string }
   | { type: 'CLOSE_STRIPE_OVERLAY' }
   | { type: 'OPEN_STRIPE_OVERLAY' }
-  | { type: 'SET_STRIPE_AMOUNT', amount: number, currency: Currency }
   ;
 
 type CombinedState = {
@@ -42,10 +40,6 @@ function closeStripeOverlay(): Action {
 export function openStripeOverlay(amount: number, email: string): Action {
   stripeCheckout.openDialogBox(amount, email);
   return { type: 'OPEN_STRIPE_OVERLAY' };
-}
-
-export function setStripeAmount(amount: number, currency: Currency): Action {
-  return { type: 'SET_STRIPE_AMOUNT', amount, currency };
 }
 
 export function setupStripeCheckout(callback: Function): Function {

--- a/assets/helpers/stripeCheckout/stripeCheckoutActions.js
+++ b/assets/helpers/stripeCheckout/stripeCheckoutActions.js
@@ -3,7 +3,7 @@
 // ----- Imports ----- //
 
 import * as stripeCheckout from './stripeCheckout';
-import type { State as StripeCheckoutState } from './stripeCheckoutReducer';
+import type { CombinedState } from './stripeCheckoutReducer';
 
 // ----- Types ----- //
 
@@ -14,10 +14,6 @@ export type Action =
   | { type: 'CLOSE_STRIPE_OVERLAY' }
   | { type: 'OPEN_STRIPE_OVERLAY' }
   ;
-
-type CombinedState = {
-  stripeCheckout: StripeCheckoutState,
-};
 
 // ----- Actions ----- //
 

--- a/assets/helpers/stripeCheckout/stripeCheckoutActions.js
+++ b/assets/helpers/stripeCheckout/stripeCheckoutActions.js
@@ -2,8 +2,8 @@
 
 // ----- Imports ----- //
 
+import type { Currency } from 'helpers/internationalisation/currency';
 import * as stripeCheckout from './stripeCheckout';
-
 
 // ----- Types ----- //
 
@@ -13,7 +13,7 @@ export type Action =
   | { type: 'SET_STRIPE_CHECKOUT_TOKEN', token: string }
   | { type: 'CLOSE_STRIPE_OVERLAY' }
   | { type: 'OPEN_STRIPE_OVERLAY' }
-  | { type: 'SET_STRIPE_AMOUNT', amount: number }
+  | { type: 'SET_STRIPE_AMOUNT', amount: number, currency: Currency }
   ;
 
 
@@ -40,8 +40,8 @@ export function openStripeOverlay(amount: number, email: string): Action {
   return { type: 'OPEN_STRIPE_OVERLAY' };
 }
 
-export function setStripeAmount(amount: number): Action {
-  return { type: 'SET_STRIPE_AMOUNT', amount };
+export function setStripeAmount(amount: number, currency: Currency): Action {
+  return { type: 'SET_STRIPE_AMOUNT', amount, currency };
 }
 
 export function setupStripeCheckout(callback: Function): Function {

--- a/assets/helpers/stripeCheckout/stripeCheckoutActions.js
+++ b/assets/helpers/stripeCheckout/stripeCheckoutActions.js
@@ -4,6 +4,7 @@
 
 import type { Currency } from 'helpers/internationalisation/currency';
 import * as stripeCheckout from './stripeCheckout';
+import type { State as StripeCheckoutState } from './stripeCheckoutReducer';
 
 // ----- Types ----- //
 
@@ -16,6 +17,9 @@ export type Action =
   | { type: 'SET_STRIPE_AMOUNT', amount: number, currency: Currency }
   ;
 
+type CombinedState = {
+  stripeCheckout: StripeCheckoutState,
+};
 
 // ----- Actions ----- //
 
@@ -46,7 +50,7 @@ export function setStripeAmount(amount: number, currency: Currency): Action {
 
 export function setupStripeCheckout(callback: Function): Function {
 
-  return (dispatch, getState) => {
+  return (dispatch, getState: () => CombinedState) => {
 
     const handleToken = (token) => {
       dispatch(setStripeCheckoutToken(token.id));

--- a/assets/helpers/stripeCheckout/stripeCheckoutReducer.js
+++ b/assets/helpers/stripeCheckout/stripeCheckoutReducer.js
@@ -10,39 +10,33 @@ import type { Action } from './stripeCheckoutActions';
 
 export type State = {
   loaded: boolean,
-  amount: ?number,
+  amount: number,
   token: ?string,
-  currency: ?IsoCurrency,
-};
-
-
-// ----- Setup ----- //
-
-const initialState: State = {
-  loaded: false,
-  amount: null,
-  token: null,
-  currency: null,
+  currency: IsoCurrency,
 };
 
 
 // ----- Exports ----- //
 
-export default function stripeCheckoutReducer(
-  state: State = initialState,
-  action: Action): State {
+export default function stripeCheckoutReducer(amount: number, currency: IsoCurrency) {
 
-  switch (action.type) {
+  const initialState: State = {
+    loaded: false,
+    amount,
+    token: null,
+    currency,
+  };
 
-    case 'STRIPE_CHECKOUT_LOADED':
-      return Object.assign({}, state, { loaded: true });
+  return (state: State = initialState, action: Action): State => {
 
-    case 'SET_STRIPE_AMOUNT':
-      return Object.assign({}, state, { amount: action.amount, currency: action.currency.iso });
+    switch (action.type) {
 
-    default:
-      return state;
+      case 'STRIPE_CHECKOUT_LOADED':
+        return Object.assign({}, state, { loaded: true });
 
-  }
+      default:
+        return state;
 
+    }
+  };
 }

--- a/assets/helpers/stripeCheckout/stripeCheckoutReducer.js
+++ b/assets/helpers/stripeCheckout/stripeCheckoutReducer.js
@@ -2,6 +2,7 @@
 
 // ----- Imports ----- //
 
+import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import type { Action } from './stripeCheckoutActions';
 
 
@@ -11,7 +12,7 @@ export type State = {
   loaded: boolean,
   amount: ?number,
   token: ?string,
-  currency: string,
+  currency: ?IsoCurrency,
 };
 
 
@@ -21,7 +22,7 @@ const initialState: State = {
   loaded: false,
   amount: null,
   token: null,
-  currency: 'GBP',
+  currency: null,
 };
 
 
@@ -37,7 +38,7 @@ export default function stripeCheckoutReducer(
       return Object.assign({}, state, { loaded: true });
 
     case 'SET_STRIPE_AMOUNT':
-      return Object.assign({}, state, { amount: action.amount });
+      return Object.assign({}, state, { amount: action.amount, currency: action.currency.iso });
 
     default:
       return state;

--- a/assets/helpers/stripeCheckout/stripeCheckoutReducer.js
+++ b/assets/helpers/stripeCheckout/stripeCheckoutReducer.js
@@ -4,7 +4,7 @@
 
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import type { Action } from './stripeCheckoutActions';
-
+import type { State as StripeCheckoutState } from './stripeCheckoutReducer';
 
 // ----- Types ----- //
 
@@ -15,6 +15,9 @@ export type State = {
   currency: IsoCurrency,
 };
 
+export type CombinedState = {
+  stripeCheckout: StripeCheckoutState,
+};
 
 // ----- Exports ----- //
 

--- a/assets/helpers/stripeCheckout/stripeCheckoutReducer.js
+++ b/assets/helpers/stripeCheckout/stripeCheckoutReducer.js
@@ -21,7 +21,7 @@ export type CombinedState = {
 
 // ----- Exports ----- //
 
-export default function stripeCheckoutReducer(amount: number, currency: IsoCurrency) {
+export default function createStripeCheckoutReducer(amount: number, currency: IsoCurrency) {
 
   const initialState: State = {
     loaded: false,
@@ -30,7 +30,7 @@ export default function stripeCheckoutReducer(amount: number, currency: IsoCurre
     currency,
   };
 
-  return (state: State = initialState, action: Action): State => {
+  return function stripeCheckoutReducer(state: State = initialState, action: Action): State {
 
     switch (action.type) {
 

--- a/assets/helpers/user/userReducer.js
+++ b/assets/helpers/user/userReducer.js
@@ -7,7 +7,7 @@ import type { Action } from './userActions';
 
 // ----- Types ----- //
 
-type User = {
+export type User = {
   email: ?string,
   displayName: ?string,
   firstName: ?string,

--- a/assets/pages/monthly-contributions/actions/monthlyContributionsActions.js
+++ b/assets/pages/monthly-contributions/actions/monthlyContributionsActions.js
@@ -1,21 +1,8 @@
 // @flow
 
-// ----- Imports ----- //
-
-import type { Currency } from 'helpers/internationalisation/currency';
-import type { IsoCountry } from 'helpers/internationalisation/country';
-import { setStripeAmount } from 'helpers/stripeCheckout/stripeCheckoutActions';
-import {
-  setPayPalExpressAmount,
-} from 'helpers/payPalExpressCheckout/payPalExpressCheckoutActions';
-import { parse as parseContribution } from 'helpers/contributions';
-
-
 // ----- Types ----- //
 
 export type Action =
-  | { type: 'SET_COUNTRY', value: IsoCountry }
-  | { type: 'SET_CONTRIB_VALUE', value: number, currency: Currency }
   | { type: 'CHECKOUT_ERROR', message: string }
   | { type: 'SET_PAYPAL_BUTTON', value: boolean }
   ;
@@ -23,30 +10,10 @@ export type Action =
 
 // ----- Actions ----- //
 
-export function setCountry(value: IsoCountry): Action {
-  return { type: 'SET_COUNTRY', value };
-}
-
-function setContribValue(value: number, currency: Currency): Action {
-  return { type: 'SET_CONTRIB_VALUE', value, currency };
-}
-
 export function checkoutError(message: string): Action {
   return { type: 'CHECKOUT_ERROR', message };
 }
 
 export function setPayPalButton(value: boolean): Action {
   return { type: 'SET_PAYPAL_BUTTON', value };
-}
-
-export function setContribAmount(amount: string, currency: Currency): Function {
-
-  const value = parseContribution(amount, 'RECURRING').amount;
-
-  return (dispatch) => {
-    dispatch(setContribValue(value, currency));
-    dispatch(setStripeAmount(value, currency));
-    dispatch(setPayPalExpressAmount(value, currency));
-  };
-
 }

--- a/assets/pages/monthly-contributions/actions/monthlyContributionsActions.js
+++ b/assets/pages/monthly-contributions/actions/monthlyContributionsActions.js
@@ -2,6 +2,8 @@
 
 // ----- Imports ----- //
 
+import type { Currency } from 'helpers/internationalisation/currency';
+import type { IsoCountry } from 'helpers/internationalisation/country';
 import { setStripeAmount } from 'helpers/stripeCheckout/stripeCheckoutActions';
 import {
   setPayPalExpressAmount,
@@ -12,7 +14,8 @@ import { parse as parseContribution } from 'helpers/contributions';
 // ----- Types ----- //
 
 export type Action =
-  | { type: 'SET_CONTRIB_VALUE', value: number }
+  | { type: 'SET_COUNTRY', value: IsoCountry }
+  | { type: 'SET_CONTRIB_VALUE', value: number, currency: Currency }
   | { type: 'CHECKOUT_ERROR', message: string }
   | { type: 'SET_PAYPAL_BUTTON', value: boolean }
   ;
@@ -20,8 +23,12 @@ export type Action =
 
 // ----- Actions ----- //
 
-function setContribValue(value: number): Action {
-  return { type: 'SET_CONTRIB_VALUE', value };
+export function setCountry(value: IsoCountry): Action {
+  return { type: 'SET_COUNTRY', value };
+}
+
+function setContribValue(value: number, currency: Currency): Action {
+  return { type: 'SET_CONTRIB_VALUE', value, currency };
 }
 
 export function checkoutError(message: string): Action {
@@ -32,14 +39,14 @@ export function setPayPalButton(value: boolean): Action {
   return { type: 'SET_PAYPAL_BUTTON', value };
 }
 
-export function setContribAmount(amount: string): Function {
+export function setContribAmount(amount: string, currency: Currency): Function {
 
   const value = parseContribution(amount, 'RECURRING').amount;
 
   return (dispatch) => {
-    dispatch(setContribValue(value));
-    dispatch(setStripeAmount(value));
-    dispatch(setPayPalExpressAmount(value));
+    dispatch(setContribValue(value, currency));
+    dispatch(setStripeAmount(value, currency));
+    dispatch(setPayPalExpressAmount(value, currency));
   };
 
 }

--- a/assets/pages/monthly-contributions/helpers/ajax.js
+++ b/assets/pages/monthly-contributions/helpers/ajax.js
@@ -40,9 +40,6 @@ function requestData(paymentFieldName: PaymentField, token: string, getState: ()
 
   if (state.user.firstName !== null && state.user.firstName !== undefined
     && state.user.lastName !== null && state.user.lastName !== undefined
-    && state.monthlyContrib.country !== null && state.monthlyContrib.country !== undefined
-    && state.stripeCheckout.currency !== null && state.stripeCheckout.currency !== undefined
-    && state.stripeCheckout.amount !== null && state.stripeCheckout.amount !== undefined
     && state.user.email !== null && state.user.email !== undefined) {
     const monthlyContribFields: MonthlyContribFields = {
       contribution: {

--- a/assets/pages/monthly-contributions/helpers/ajax.js
+++ b/assets/pages/monthly-contributions/helpers/ajax.js
@@ -38,26 +38,37 @@ function requestData(paymentFieldName: PaymentField, token: string, getState: ()
 
   const state = getState();
 
-  const monthlyContribFields: MonthlyContribFields = {
-    contribution: {
-      amount: state.stripeCheckout.amount || 0,
-      currency: state.stripeCheckout.currency || '',
-    },
-    paymentFields: {
-      [paymentFieldName]: token || '',
-    },
-    country: state.monthlyContrib.country || '',
-    firstName: state.user.firstName || '',
-    lastName: state.user.lastName || '',
-  };
+  if (state.user.firstName !== null && state.user.firstName !== undefined
+    && state.user.lastName !== null && state.user.lastName !== undefined
+    && state.monthlyContrib.country !== null && state.monthlyContrib.country !== undefined
+    && state.stripeCheckout.currency !== null && state.stripeCheckout.currency !== undefined
+    && state.stripeCheckout.amount !== null && state.stripeCheckout.amount !== undefined
+    && state.user.email !== null && state.user.email !== undefined) {
+    const monthlyContribFields: MonthlyContribFields = {
+      contribution: {
+        amount: state.stripeCheckout.amount,
+        currency: state.stripeCheckout.currency,
+      },
+      paymentFields: {
+        [paymentFieldName]: token,
+      },
+      country: state.monthlyContrib.country,
+      firstName: state.user.firstName,
+      lastName: state.user.lastName,
+    };
 
-  return {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'Csrf-Token': state.csrf.token || '' },
-    credentials: 'same-origin',
-    body: JSON.stringify(monthlyContribFields),
-  };
+    return {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'Csrf-Token': state.csrf.token || '' },
+      credentials: 'same-origin',
+      body: JSON.stringify(monthlyContribFields),
+    };
+  }
 
+  return Promise.resolve({
+    ok: false,
+    text: () => 'Failed to process payment - missing fields',
+  });
 }
 
 export default function postCheckout(paymentFieldName: PaymentField): Function {

--- a/assets/pages/monthly-contributions/helpers/ajax.js
+++ b/assets/pages/monthly-contributions/helpers/ajax.js
@@ -3,6 +3,7 @@
 // ----- Imports ----- //
 
 import { addQueryParamToURL } from 'helpers/url';
+import type { CombinedState } from '../reducers/reducers';
 
 import { checkoutError } from '../actions/monthlyContributionsActions';
 
@@ -33,26 +34,26 @@ type PaymentField = 'baid' | 'stripeToken';
 
 // ----- Functions ----- //
 
-function requestData(paymentFieldName: PaymentField, token: string, getState: Function) {
+function requestData(paymentFieldName: PaymentField, token: string, getState: () => CombinedState) {
 
   const state = getState();
 
   const monthlyContribFields: MonthlyContribFields = {
     contribution: {
-      amount: state.stripeCheckout.amount,
-      currency: state.stripeCheckout.currency,
+      amount: state.stripeCheckout.amount || 0,
+      currency: state.stripeCheckout.currency || '',
     },
     paymentFields: {
-      [paymentFieldName]: token,
+      [paymentFieldName]: token || '',
     },
-    country: state.monthlyContrib.country,
-    firstName: state.user.firstName,
-    lastName: state.user.lastName,
+    country: state.monthlyContrib.country || '',
+    firstName: state.user.firstName || '',
+    lastName: state.user.lastName || '',
   };
 
   return {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'Csrf-Token': state.csrf.token },
+    headers: { 'Content-Type': 'application/json', 'Csrf-Token': state.csrf.token || '' },
     credentials: 'same-origin',
     body: JSON.stringify(monthlyContribFields),
   };
@@ -60,7 +61,7 @@ function requestData(paymentFieldName: PaymentField, token: string, getState: Fu
 }
 
 export default function postCheckout(paymentFieldName: PaymentField): Function {
-  return (token: string, dispatch: Function, getState: Function) => {
+  return (token: string, dispatch: Function, getState: () => CombinedState) => {
 
     const request = requestData(paymentFieldName, token, getState);
 

--- a/assets/pages/monthly-contributions/monthlyContributions.jsx
+++ b/assets/pages/monthly-contributions/monthlyContributions.jsx
@@ -19,6 +19,8 @@ import PaymentAmount from 'components/paymentAmount/paymentAmount';
 import ContribLegal from 'components/legal/contribLegal/contribLegal';
 
 import pageStartup from 'helpers/pageStartup';
+import * as Currency from 'helpers/internationalisation/currency';
+import * as Country from 'helpers/internationalisation/country';
 import * as user from 'helpers/user/user';
 import { getQueryParameter } from 'helpers/url';
 
@@ -27,7 +29,7 @@ import NameForm from './components/nameForm';
 import PaymentMethodsContainer from './components/paymentMethodsContainer';
 import reducer from './reducers/reducers';
 
-import { setContribAmount, setPayPalButton } from './actions/monthlyContributionsActions';
+import { setCountry, setContribAmount, setPayPalButton } from './actions/monthlyContributionsActions';
 
 
 // ----- Page Startup ----- //
@@ -42,13 +44,12 @@ const store = createStore(reducer, {
 }, applyMiddleware(thunkMiddleware));
 
 
-// Retrieves the contrib amount from the url and sends it to the redux store.
-const contributionAmount = getQueryParameter('contributionValue', '5');
+const contributionAmount = getQueryParameter('contributionValue') || '5';
+const country = Country.detect();
+const currency = Currency.forCountry(country);
 
-if (contributionAmount !== undefined && contributionAmount !== null) {
-  store.dispatch(setContribAmount(contributionAmount));
-}
-
+store.dispatch(setCountry(country));
+store.dispatch(setContribAmount(contributionAmount, currency));
 
 user.init(store.dispatch);
 store.dispatch(setPayPalButton(window.guardian.payPalButtonExists));
@@ -66,7 +67,10 @@ const content = (
           <Secure />
         </InfoSection>
         <InfoSection heading="Your monthly contribution" className="monthly-contrib__your-contrib">
-          <PaymentAmount amount={store.getState().monthlyContrib.amount} />
+          <PaymentAmount
+            amount={store.getState().monthlyContrib.amount}
+            currency={store.getState().monthlyContrib.currency}
+          />
         </InfoSection>
         <InfoSection heading="Your details" className="monthly-contrib__your-details">
           <DisplayName />

--- a/assets/pages/monthly-contributions/monthlyContributions.jsx
+++ b/assets/pages/monthly-contributions/monthlyContributions.jsx
@@ -23,6 +23,7 @@ import * as Currency from 'helpers/internationalisation/currency';
 import * as Country from 'helpers/internationalisation/country';
 import * as user from 'helpers/user/user';
 import { getQueryParameter } from 'helpers/url';
+import { parse as parseContrib } from 'helpers/contributions';
 
 import postCheckout from './helpers/ajax';
 import NameForm from './components/nameForm';
@@ -40,7 +41,7 @@ pageStartup.start();
 
 // ----- Redux Store ----- //
 
-const contributionAmount = Number(getQueryParameter('contributionValue')) || 5;
+const contributionAmount = parseContrib(getQueryParameter('contributionValue'), 'RECURRING').amount;
 const country = Country.detect();
 const currency = Currency.forCountry(country);
 

--- a/assets/pages/monthly-contributions/monthlyContributions.jsx
+++ b/assets/pages/monthly-contributions/monthlyContributions.jsx
@@ -19,8 +19,8 @@ import PaymentAmount from 'components/paymentAmount/paymentAmount';
 import ContribLegal from 'components/legal/contribLegal/contribLegal';
 
 import pageStartup from 'helpers/pageStartup';
-import * as Currency from 'helpers/internationalisation/currency';
-import * as Country from 'helpers/internationalisation/country';
+import { forCountry as currencyForCountry } from 'helpers/internationalisation/currency';
+import { detect as detectCountry } from 'helpers/internationalisation/country';
 import * as user from 'helpers/user/user';
 import { getQueryParameter } from 'helpers/url';
 import { parse as parseContrib } from 'helpers/contributions';
@@ -42,8 +42,8 @@ pageStartup.start();
 // ----- Redux Store ----- //
 
 const contributionAmount = parseContrib(getQueryParameter('contributionValue'), 'RECURRING').amount;
-const country = Country.detect();
-const currency = Currency.forCountry(country);
+const country = detectCountry();
+const currency = currencyForCountry(country);
 
 /* eslint-disable no-underscore-dangle */
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;

--- a/assets/pages/monthly-contributions/monthlyContributions.jsx
+++ b/assets/pages/monthly-contributions/monthlyContributions.jsx
@@ -28,6 +28,7 @@ import postCheckout from './helpers/ajax';
 import NameForm from './components/nameForm';
 import PaymentMethodsContainer from './components/paymentMethodsContainer';
 import reducer from './reducers/reducers';
+import type { CombinedState } from './reducers/reducers';
 
 import { setCountry, setContribAmount, setPayPalButton } from './actions/monthlyContributionsActions';
 
@@ -54,6 +55,8 @@ store.dispatch(setContribAmount(contributionAmount, currency));
 user.init(store.dispatch);
 store.dispatch(setPayPalButton(window.guardian.payPalButtonExists));
 
+const state: CombinedState = store.getState();
+
 // ----- Render ----- //
 
 const content = (
@@ -68,8 +71,8 @@ const content = (
         </InfoSection>
         <InfoSection heading="Your monthly contribution" className="monthly-contrib__your-contrib">
           <PaymentAmount
-            amount={store.getState().monthlyContrib.amount}
-            currency={store.getState().monthlyContrib.currency}
+            amount={state.monthlyContrib.amount}
+            currency={state.monthlyContrib.currency || Currency.GBP}
           />
         </InfoSection>
         <InfoSection heading="Your details" className="monthly-contrib__your-details">
@@ -80,7 +83,7 @@ const content = (
           <PaymentMethodsContainer
             stripeCallback={postCheckout('stripeToken')}
             payPalCallback={postCheckout('baid')}
-            payPalButtonExists={store.getState().monthlyContrib.payPalButtonExists}
+            payPalButtonExists={state.monthlyContrib.payPalButtonExists}
           />
         </InfoSection>
         <InfoSection className="monthly-contrib__payment-methods">

--- a/assets/pages/monthly-contributions/reducers/reducers.js
+++ b/assets/pages/monthly-contributions/reducers/reducers.js
@@ -4,6 +4,11 @@
 
 import { combineReducers } from 'redux';
 
+import type { User as UserState } from 'helpers/user/userReducer';
+import type { State as StripeCheckoutState } from 'helpers/stripeCheckout/stripeCheckoutReducer';
+import type { State as PayPalExpressCheckoutState } from 'helpers/payPalExpressCheckout/payPalExpressCheckoutReducer';
+import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
+
 import { intCmpReducer as intCmp } from 'helpers/intCmp';
 import stripeCheckout from 'helpers/stripeCheckout/stripeCheckoutReducer';
 import payPalExpressCheckout from 'helpers/payPalExpressCheckout/payPalExpressCheckoutReducer';
@@ -11,7 +16,6 @@ import user from 'helpers/user/userReducer';
 import csrf from 'helpers/csrf/csrfReducer';
 import type { Currency } from 'helpers/internationalisation/currency';
 import type { IsoCountry } from 'helpers/internationalisation/country';
-import { GBP } from 'helpers/internationalisation/currency';
 
 import type { Action } from '../actions/monthlyContributionsActions';
 
@@ -20,12 +24,20 @@ import type { Action } from '../actions/monthlyContributionsActions';
 
 export type State = {
   amount: number,
-  currency: Currency,
-  country: IsoCountry,
+  currency: ?Currency,
+  country: ?IsoCountry,
   error: ?string,
   payPalButtonExists: boolean,
 };
 
+export type CombinedState = {
+  monthlyContrib: State,
+  intCmp: string,
+  user: UserState,
+  stripeCheckout: StripeCheckoutState,
+  payPalExpressCheckout: PayPalExpressCheckoutState,
+  csrf: CsrfState,
+};
 
 // ----- Setup ----- //
 

--- a/assets/pages/monthly-contributions/reducers/reducers.js
+++ b/assets/pages/monthly-contributions/reducers/reducers.js
@@ -24,8 +24,8 @@ import type { Action } from '../actions/monthlyContributionsActions';
 
 export type State = {
   amount: number,
-  currency: ?Currency,
-  country: ?IsoCountry,
+  currency: Currency,
+  country: IsoCountry,
   error: ?string,
   payPalButtonExists: boolean,
 };
@@ -39,52 +39,43 @@ export type CombinedState = {
   csrf: CsrfState,
 };
 
-// ----- Setup ----- //
-
-const initialState: State = {
-  amount: 5,
-  currency: GBP,
-  country: 'GB',
-  error: null,
-  payPalButtonExists: false,
-};
-
-
 // ----- Reducers ----- //
 
-function monthlyContrib(
-  state: State = initialState,
-  action: Action): State {
+function monthlyContrib(amount: number, currency: Currency, country: IsoCountry) {
 
-  switch (action.type) {
+  const initialState: State = {
+    amount,
+    currency,
+    country,
+    error: null,
+    payPalButtonExists: false,
+  };
 
-    case 'SET_COUNTRY':
-      return Object.assign({}, state, { country: action.value });
+  return (state: State = initialState, action: Action): State => {
+    switch (action.type) {
 
-    case 'SET_CONTRIB_VALUE':
-      return Object.assign({}, state, { amount: action.value, currency: action.currency });
+      case 'CHECKOUT_ERROR':
+        return Object.assign({}, state, { error: action.message });
 
-    case 'CHECKOUT_ERROR':
-      return Object.assign({}, state, { error: action.message });
+      case 'SET_PAYPAL_BUTTON' :
+        return Object.assign({}, state, { payPalButtonExists: action.value });
 
-    case 'SET_PAYPAL_BUTTON' :
-      return Object.assign({}, state, { payPalButtonExists: action.value });
+      default:
+        return state;
 
-    default:
-      return state;
-
-  }
-
+    }
+  };
 }
 
 
 // ----- Exports ----- //
 
-export default combineReducers({
-  monthlyContrib,
-  intCmp,
-  user,
-  stripeCheckout,
-  payPalExpressCheckout,
-  csrf,
-});
+export default (amount: number, currency: Currency, country: IsoCountry) =>
+  combineReducers({
+    monthlyContrib: monthlyContrib(amount, currency, country),
+    intCmp,
+    user,
+    stripeCheckout: stripeCheckout(amount, currency.iso),
+    payPalExpressCheckout: payPalExpressCheckout(amount, currency.iso),
+    csrf,
+  });

--- a/assets/pages/monthly-contributions/reducers/reducers.js
+++ b/assets/pages/monthly-contributions/reducers/reducers.js
@@ -77,7 +77,7 @@ export default function createRootMonthlyContributionsReducer(
   currency: Currency,
   country: IsoCountry,
 ) {
-  combineReducers({
+  return combineReducers({
     monthlyContrib: createMonthlyContribReducer(amount, currency, country),
     intCmp,
     user,

--- a/assets/pages/monthly-contributions/reducers/reducers.js
+++ b/assets/pages/monthly-contributions/reducers/reducers.js
@@ -9,6 +9,9 @@ import stripeCheckout from 'helpers/stripeCheckout/stripeCheckoutReducer';
 import payPalExpressCheckout from 'helpers/payPalExpressCheckout/payPalExpressCheckoutReducer';
 import user from 'helpers/user/userReducer';
 import csrf from 'helpers/csrf/csrfReducer';
+import type { Currency } from 'helpers/internationalisation/currency';
+import type { IsoCountry } from 'helpers/internationalisation/country';
+import { GBP } from 'helpers/internationalisation/currency';
 
 import type { Action } from '../actions/monthlyContributionsActions';
 
@@ -17,7 +20,8 @@ import type { Action } from '../actions/monthlyContributionsActions';
 
 export type State = {
   amount: number,
-  country: string,
+  currency: Currency,
+  country: IsoCountry,
   error: ?string,
   payPalButtonExists: boolean,
 };
@@ -27,6 +31,7 @@ export type State = {
 
 const initialState: State = {
   amount: 5,
+  currency: GBP,
   country: 'GB',
   error: null,
   payPalButtonExists: false,
@@ -41,8 +46,11 @@ function monthlyContrib(
 
   switch (action.type) {
 
+    case 'SET_COUNTRY':
+      return Object.assign({}, state, { country: action.value });
+
     case 'SET_CONTRIB_VALUE':
-      return Object.assign({}, state, { amount: action.value });
+      return Object.assign({}, state, { amount: action.value, currency: action.currency });
 
     case 'CHECKOUT_ERROR':
       return Object.assign({}, state, { error: action.message });

--- a/assets/pages/monthly-contributions/reducers/reducers.js
+++ b/assets/pages/monthly-contributions/reducers/reducers.js
@@ -10,8 +10,8 @@ import type { State as PayPalExpressCheckoutState } from 'helpers/payPalExpressC
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 
 import { intCmpReducer as intCmp } from 'helpers/intCmp';
-import stripeCheckout from 'helpers/stripeCheckout/stripeCheckoutReducer';
-import payPalExpressCheckout from 'helpers/payPalExpressCheckout/payPalExpressCheckoutReducer';
+import createStripeCheckoutReducer from 'helpers/stripeCheckout/stripeCheckoutReducer';
+import createPayPalExpressCheckout from 'helpers/payPalExpressCheckout/payPalExpressCheckoutReducer';
 import user from 'helpers/user/userReducer';
 import csrf from 'helpers/csrf/csrfReducer';
 import type { Currency } from 'helpers/internationalisation/currency';
@@ -42,7 +42,7 @@ export type CombinedState = {
 
 // ----- Reducers ----- //
 
-function monthlyContrib(amount: number, currency: Currency, country: IsoCountry) {
+function createMonthlyContribReducer(amount: number, currency: Currency, country: IsoCountry) {
 
   const initialState: State = {
     amount,
@@ -53,7 +53,7 @@ function monthlyContrib(amount: number, currency: Currency, country: IsoCountry)
     payPalType: 'NotSet',
   };
 
-  return (state: State = initialState, action: Action): State => {
+  return function monthlyContrib(state: State = initialState, action: Action): State {
     switch (action.type) {
 
       case 'CHECKOUT_ERROR':
@@ -72,12 +72,17 @@ function monthlyContrib(amount: number, currency: Currency, country: IsoCountry)
 
 // ----- Exports ----- //
 
-export default (amount: number, currency: Currency, country: IsoCountry) =>
+export default function createRootMonthlyContributionsReducer(
+  amount: number,
+  currency: Currency,
+  country: IsoCountry,
+) {
   combineReducers({
-    monthlyContrib: monthlyContrib(amount, currency, country),
+    monthlyContrib: createMonthlyContribReducer(amount, currency, country),
     intCmp,
     user,
-    stripeCheckout: stripeCheckout(amount, currency.iso),
-    payPalExpressCheckout: payPalExpressCheckout(amount, currency.iso),
+    stripeCheckout: createStripeCheckoutReducer(amount, currency.iso),
+    payPalExpressCheckout: createPayPalExpressCheckout(amount, currency.iso),
     csrf,
   });
+}

--- a/assets/pages/oneoff-contributions/actions/oneoffContributionsActions.js
+++ b/assets/pages/oneoff-contributions/actions/oneoffContributionsActions.js
@@ -2,7 +2,8 @@
 
 // ----- Imports ----- //
 
-import type { IsoCurrency } from 'helpers/internationalisation/currency';
+import type { Currency } from 'helpers/internationalisation/currency';
+import type { IsoCountry } from 'helpers/internationalisation/country';
 import { setStripeAmount } from 'helpers/stripeCheckout/stripeCheckoutActions';
 import { setPayPalExpressAmount } from 'helpers/payPalExpressCheckout/payPalExpressCheckoutActions';
 import { parse as parseContribution } from 'helpers/contributions';
@@ -11,27 +12,32 @@ import { parse as parseContribution } from 'helpers/contributions';
 // ----- Types ----- //
 
 export type Action =
-  | { type: 'SET_CONTRIB_VALUE', value: number }
+  | { type: 'SET_COUNTRY', value: IsoCountry }
+  | { type: 'SET_CONTRIB_VALUE', value: number, currency: Currency }
   | { type: 'CHECKOUT_ERROR', message: string }
   ;
 
 
 // ----- Actions ----- //
 
-function setContribValue(value: number): Action {
-  return { type: 'SET_CONTRIB_VALUE', value };
+export function setCountry(value: IsoCountry): Action {
+  return { type: 'SET_COUNTRY', value };
+}
+
+function setContribValue(value: number, currency: Currency): Action {
+  return { type: 'SET_CONTRIB_VALUE', value, currency };
 }
 
 export function checkoutError(message: string): Action {
   return { type: 'CHECKOUT_ERROR', message };
 }
 
-export function setContribAmount(amount: string, currency: IsoCurrency): Function {
+export function setContribAmount(amount: string, currency: Currency): Function {
 
   const value = parseContribution(amount, 'ONE_OFF').amount;
 
   return (dispatch) => {
-    dispatch(setContribValue(value));
+    dispatch(setContribValue(value, currency));
     dispatch(setStripeAmount(value, currency));
     dispatch(setPayPalExpressAmount(value, currency));
   };

--- a/assets/pages/oneoff-contributions/actions/oneoffContributionsActions.js
+++ b/assets/pages/oneoff-contributions/actions/oneoffContributionsActions.js
@@ -2,6 +2,7 @@
 
 // ----- Imports ----- //
 
+import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import { setStripeAmount } from 'helpers/stripeCheckout/stripeCheckoutActions';
 import { setPayPalExpressAmount } from 'helpers/payPalExpressCheckout/payPalExpressCheckoutActions';
 import { parse as parseContribution } from 'helpers/contributions';
@@ -25,14 +26,14 @@ export function checkoutError(message: string): Action {
   return { type: 'CHECKOUT_ERROR', message };
 }
 
-export function setContribAmount(amount: string): Function {
+export function setContribAmount(amount: string, currency: IsoCurrency): Function {
 
   const value = parseContribution(amount, 'ONE_OFF').amount;
 
   return (dispatch) => {
     dispatch(setContribValue(value));
-    dispatch(setStripeAmount(value));
-    dispatch(setPayPalExpressAmount(value));
+    dispatch(setStripeAmount(value, currency));
+    dispatch(setPayPalExpressAmount(value, currency));
   };
 
 }

--- a/assets/pages/oneoff-contributions/actions/oneoffContributionsActions.js
+++ b/assets/pages/oneoff-contributions/actions/oneoffContributionsActions.js
@@ -1,45 +1,14 @@
 // @flow
 
-// ----- Imports ----- //
-
-import type { Currency } from 'helpers/internationalisation/currency';
-import type { IsoCountry } from 'helpers/internationalisation/country';
-import { setStripeAmount } from 'helpers/stripeCheckout/stripeCheckoutActions';
-import { setPayPalExpressAmount } from 'helpers/payPalExpressCheckout/payPalExpressCheckoutActions';
-import { parse as parseContribution } from 'helpers/contributions';
-
-
 // ----- Types ----- //
 
 export type Action =
-  | { type: 'SET_COUNTRY', value: IsoCountry }
-  | { type: 'SET_CONTRIB_VALUE', value: number, currency: Currency }
   | { type: 'CHECKOUT_ERROR', message: string }
   ;
 
 
 // ----- Actions ----- //
 
-export function setCountry(value: IsoCountry): Action {
-  return { type: 'SET_COUNTRY', value };
-}
-
-function setContribValue(value: number, currency: Currency): Action {
-  return { type: 'SET_CONTRIB_VALUE', value, currency };
-}
-
 export function checkoutError(message: string): Action {
   return { type: 'CHECKOUT_ERROR', message };
-}
-
-export function setContribAmount(amount: string, currency: Currency): Function {
-
-  const value = parseContribution(amount, 'ONE_OFF').amount;
-
-  return (dispatch) => {
-    dispatch(setContribValue(value, currency));
-    dispatch(setStripeAmount(value, currency));
-    dispatch(setPayPalExpressAmount(value, currency));
-  };
-
 }

--- a/assets/pages/oneoff-contributions/helpers/ajax.js
+++ b/assets/pages/oneoff-contributions/helpers/ajax.js
@@ -5,7 +5,7 @@
 import { addQueryParamToURL } from 'helpers/url';
 
 import { checkoutError } from '../actions/oneoffContributionsActions';
-
+import type { CombinedState } from '../reducers/reducers';
 
 // ----- Setup ----- //
 
@@ -36,18 +36,18 @@ type OneoffContribFields = {
 
 // ----- Functions ----- //
 
-function requestData(paymentToken: string, getState: Function) {
+function requestData(paymentToken: string, getState: () => CombinedState) {
 
   const state = getState();
 
   const oneoffContribFields: OneoffContribFields = {
-    name: state.user.fullName,
-    currency: state.stripeCheckout.currency,
-    amount: state.stripeCheckout.amount,
-    email: state.user.email,
-    token: paymentToken,
+    name: state.user.fullName || '',
+    currency: state.stripeCheckout.currency || '',
+    amount: state.stripeCheckout.amount || 0,
+    email: state.user.email || '',
+    token: paymentToken || '',
     marketing: false, // todo: collect marketing preference
-    postcode: state.user.postcode,
+    postcode: state.user.postcode || '',
     ophanPageviewId: 'dummy', // todo: correct ophan pageview id
   };
 
@@ -63,7 +63,7 @@ function requestData(paymentToken: string, getState: Function) {
 export default function postCheckout(
   paymentToken: string,
   dispatch: Function,
-  getState: Function,
+  getState: () => CombinedState,
 ) {
 
   const request = requestData(paymentToken, getState);

--- a/assets/pages/oneoff-contributions/helpers/ajax.js
+++ b/assets/pages/oneoff-contributions/helpers/ajax.js
@@ -40,24 +40,33 @@ function requestData(paymentToken: string, getState: () => CombinedState) {
 
   const state = getState();
 
-  const oneoffContribFields: OneoffContribFields = {
-    name: state.user.fullName || '',
-    currency: state.stripeCheckout.currency || '',
-    amount: state.stripeCheckout.amount || 0,
-    email: state.user.email || '',
-    token: paymentToken || '',
-    marketing: false, // todo: collect marketing preference
-    postcode: state.user.postcode || '',
-    ophanPageviewId: 'dummy', // todo: correct ophan pageview id
-  };
+  if (state.user.fullName !== null && state.user.fullName !== undefined
+    && state.stripeCheckout.currency !== null && state.stripeCheckout.currency !== undefined
+    && state.stripeCheckout.amount !== null && state.stripeCheckout.amount !== undefined
+    && state.user.email !== null && state.user.email !== undefined) {
+    const oneoffContribFields: OneoffContribFields = {
+      name: state.user.fullName,
+      currency: state.stripeCheckout.currency,
+      amount: state.stripeCheckout.amount,
+      email: state.user.email,
+      token: paymentToken,
+      marketing: false, // todo: collect marketing preference
+      postcode: state.user.postcode,
+      ophanPageviewId: 'dummy', // todo: correct ophan pageview id
+    };
 
-  return {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(oneoffContribFields),
-    credentials: 'include',
-  };
+    return {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(oneoffContribFields),
+      credentials: 'include',
+    };
+  }
 
+  return Promise.resolve({
+    ok: false,
+    text: () => 'Failed to process payment - missing fields',
+  });
 }
 
 export default function postCheckout(

--- a/assets/pages/oneoff-contributions/helpers/ajax.js
+++ b/assets/pages/oneoff-contributions/helpers/ajax.js
@@ -41,8 +41,6 @@ function requestData(paymentToken: string, getState: () => CombinedState) {
   const state = getState();
 
   if (state.user.fullName !== null && state.user.fullName !== undefined
-    && state.stripeCheckout.currency !== null && state.stripeCheckout.currency !== undefined
-    && state.stripeCheckout.amount !== null && state.stripeCheckout.amount !== undefined
     && state.user.email !== null && state.user.email !== undefined) {
     const oneoffContribFields: OneoffContribFields = {
       name: state.user.fullName,

--- a/assets/pages/oneoff-contributions/oneoffContributions.jsx
+++ b/assets/pages/oneoff-contributions/oneoffContributions.jsx
@@ -18,7 +18,8 @@ import PaymentAmount from 'components/paymentAmount/paymentAmount';
 import ContribLegal from 'components/legal/contribLegal/contribLegal';
 
 import pageStartup from 'helpers/pageStartup';
-import { GBP } from 'helpers/internationalisation/currency';
+import * as Currency from 'helpers/internationalisation/currency';
+import * as Country from 'helpers/internationalisation/country';
 import * as user from 'helpers/user/user';
 import { getQueryParameter } from 'helpers/url';
 
@@ -27,7 +28,7 @@ import FormFields from './components/formFields';
 import reducer from './reducers/reducers';
 import postCheckout from './helpers/ajax';
 
-import { setContribAmount } from './actions/oneoffContributionsActions';
+import { setContribAmount, setCountry } from './actions/oneoffContributionsActions';
 
 
 // ----- Page Startup ----- //
@@ -43,13 +44,12 @@ const store = createStore(reducer, {
 
 user.init(store.dispatch);
 
-// Retrieves the contrib amount from the url and sends it to the redux store.
-const contributionAmount = getQueryParameter('contributionValue', '50');
+const contributionAmount = getQueryParameter('contributionValue') || '50';
+const country = Country.detect();
+const currency = Currency.forCountry(country);
 
-if (contributionAmount !== undefined && contributionAmount !== null) {
-  store.dispatch(setContribAmount(contributionAmount, GBP.iso));
-}
-
+store.dispatch(setCountry(country));
+store.dispatch(setContribAmount(contributionAmount, currency));
 
 // ----- Render ----- //
 
@@ -66,7 +66,7 @@ const content = (
         <InfoSection heading="Your one-off contribution" className="oneoff-contrib__your-contrib">
           <PaymentAmount
             amount={store.getState().oneoffContrib.amount}
-            currency={store.getState().oneOffContrib.currency}
+            currency={store.getState().oneoffContrib.currency}
           />
         </InfoSection>
         <InfoSection heading="Your details" className="oneoff-contrib__your-details">

--- a/assets/pages/oneoff-contributions/oneoffContributions.jsx
+++ b/assets/pages/oneoff-contributions/oneoffContributions.jsx
@@ -22,6 +22,7 @@ import * as Currency from 'helpers/internationalisation/currency';
 import * as Country from 'helpers/internationalisation/country';
 import * as user from 'helpers/user/user';
 import { getQueryParameter } from 'helpers/url';
+import { parse as parseContrib } from 'helpers/contributions';
 
 import PaymentMethodsContainer from './components/paymentMethodsContainer';
 import FormFields from './components/formFields';
@@ -38,7 +39,7 @@ pageStartup.start();
 
 // ----- Redux Store ----- //
 
-const contributionAmount = Number(getQueryParameter('contributionValue')) || 5;
+const contributionAmount = parseContrib(getQueryParameter('contributionValue'), 'ONE_OFF').amount;
 const country = Country.detect();
 const currency = Currency.forCountry(country);
 

--- a/assets/pages/oneoff-contributions/oneoffContributions.jsx
+++ b/assets/pages/oneoff-contributions/oneoffContributions.jsx
@@ -18,8 +18,8 @@ import PaymentAmount from 'components/paymentAmount/paymentAmount';
 import ContribLegal from 'components/legal/contribLegal/contribLegal';
 
 import pageStartup from 'helpers/pageStartup';
-import * as Currency from 'helpers/internationalisation/currency';
-import * as Country from 'helpers/internationalisation/country';
+import { forCountry as currencyForCountry } from 'helpers/internationalisation/currency';
+import { detect as detectCountry } from 'helpers/internationalisation/country';
 import * as user from 'helpers/user/user';
 import { getQueryParameter } from 'helpers/url';
 import { parse as parseContrib } from 'helpers/contributions';
@@ -40,8 +40,8 @@ pageStartup.start();
 // ----- Redux Store ----- //
 
 const contributionAmount = parseContrib(getQueryParameter('contributionValue'), 'ONE_OFF').amount;
-const country = Country.detect();
-const currency = Currency.forCountry(country);
+const country = detectCountry();
+const currency = currencyForCountry(country);
 
 /* eslint-disable no-underscore-dangle */
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;

--- a/assets/pages/oneoff-contributions/oneoffContributions.jsx
+++ b/assets/pages/oneoff-contributions/oneoffContributions.jsx
@@ -29,7 +29,7 @@ import reducer from './reducers/reducers';
 import type { CombinedState } from './reducers/reducers';
 import postCheckout from './helpers/ajax';
 
-import { setContribAmount, setPayPalButton } from './actions/oneoffContributionsActions';
+import { setPayPalButton } from './actions/oneoffContributionsActions';
 
 // ----- Page Startup ----- //
 

--- a/assets/pages/oneoff-contributions/oneoffContributions.jsx
+++ b/assets/pages/oneoff-contributions/oneoffContributions.jsx
@@ -18,6 +18,7 @@ import PaymentAmount from 'components/paymentAmount/paymentAmount';
 import ContribLegal from 'components/legal/contribLegal/contribLegal';
 
 import pageStartup from 'helpers/pageStartup';
+import { GBP } from 'helpers/internationalisation/currency';
 import * as user from 'helpers/user/user';
 import { getQueryParameter } from 'helpers/url';
 
@@ -46,7 +47,7 @@ user.init(store.dispatch);
 const contributionAmount = getQueryParameter('contributionValue', '50');
 
 if (contributionAmount !== undefined && contributionAmount !== null) {
-  store.dispatch(setContribAmount(contributionAmount));
+  store.dispatch(setContribAmount(contributionAmount, GBP.iso));
 }
 
 
@@ -63,7 +64,10 @@ const content = (
           <Secure />
         </InfoSection>
         <InfoSection heading="Your one-off contribution" className="oneoff-contrib__your-contrib">
-          <PaymentAmount amount={store.getState().oneoffContrib.amount} />
+          <PaymentAmount
+            amount={store.getState().oneoffContrib.amount}
+            currency={store.getState().oneOffContrib.currency}
+          />
         </InfoSection>
         <InfoSection heading="Your details" className="oneoff-contrib__your-details">
           <FormFields />

--- a/assets/pages/oneoff-contributions/oneoffContributions.jsx
+++ b/assets/pages/oneoff-contributions/oneoffContributions.jsx
@@ -26,6 +26,7 @@ import { getQueryParameter } from 'helpers/url';
 import PaymentMethodsContainer from './components/paymentMethodsContainer';
 import FormFields from './components/formFields';
 import reducer from './reducers/reducers';
+import type { CombinedState } from './reducers/reducers';
 import postCheckout from './helpers/ajax';
 
 import { setContribAmount, setCountry } from './actions/oneoffContributionsActions';
@@ -51,6 +52,8 @@ const currency = Currency.forCountry(country);
 store.dispatch(setCountry(country));
 store.dispatch(setContribAmount(contributionAmount, currency));
 
+const state: CombinedState = store.getState();
+
 // ----- Render ----- //
 
 const content = (
@@ -65,8 +68,8 @@ const content = (
         </InfoSection>
         <InfoSection heading="Your one-off contribution" className="oneoff-contrib__your-contrib">
           <PaymentAmount
-            amount={store.getState().oneoffContrib.amount}
-            currency={store.getState().oneoffContrib.currency}
+            amount={state.oneoffContrib.amount}
+            currency={state.oneoffContrib.currency || Currency.GBP}
           />
         </InfoSection>
         <InfoSection heading="Your details" className="oneoff-contrib__your-details">

--- a/assets/pages/oneoff-contributions/reducers/reducers.js
+++ b/assets/pages/oneoff-contributions/reducers/reducers.js
@@ -39,7 +39,7 @@ export type CombinedState = {
 
 // ----- Reducers ----- //
 
-function oneoffContrib(amount: number, currency: Currency, country: IsoCountry) {
+function createOneOffContribReducer(amount: number, currency: Currency, country: IsoCountry) {
 
   const initialState: State = {
     amount,
@@ -49,7 +49,7 @@ function oneoffContrib(amount: number, currency: Currency, country: IsoCountry) 
     payPalType: 'NotSet',
   };
 
-  return (state: State = initialState, action: Action): State => {
+  return function oneOffContribReducer(state: State = initialState, action: Action): State {
 
     switch (action.type) {
 
@@ -72,12 +72,17 @@ function oneoffContrib(amount: number, currency: Currency, country: IsoCountry) 
 
 // ----- Exports ----- //
 
-export default (amount: number, currency: Currency, country: IsoCountry) =>
-  combineReducers({
-    oneoffContrib: oneoffContrib(amount, currency, country),
+export default function createRootOneOffContribReducer(
+  amount: number,
+  currency: Currency,
+  country: IsoCountry,
+) {
+  return combineReducers({
+    oneoffContrib: createOneOffContribReducer(amount, currency, country),
     intCmp,
     user,
     stripeCheckout: createStripeCheckoutReducer(amount, currency.iso),
     payPalContributionsCheckout,
     csrf,
   });
+}

--- a/assets/pages/oneoff-contributions/reducers/reducers.js
+++ b/assets/pages/oneoff-contributions/reducers/reducers.js
@@ -9,7 +9,7 @@ import stripeCheckout from 'helpers/stripeCheckout/stripeCheckoutReducer';
 import user from 'helpers/user/userReducer';
 import csrf from 'helpers/csrf/csrfReducer';
 import type { Currency } from 'helpers/internationalisation/currency';
-import { GBP } from 'helpers/internationalisation/currency';
+import type { IsoCountry } from 'helpers/internationalisation/country';
 
 import type { Action } from '../actions/oneoffContributionsActions';
 
@@ -18,8 +18,8 @@ import type { Action } from '../actions/oneoffContributionsActions';
 
 export type State = {
   amount: number,
-  currency: Currency,
-  country: string,
+  currency: ?Currency,
+  country: ?IsoCountry,
   error: ?string,
 };
 
@@ -28,8 +28,8 @@ export type State = {
 
 const initialState: State = {
   amount: 50,
-  currency: GBP,
-  country: 'GB',
+  currency: null,
+  country: null,
   error: null,
 };
 
@@ -42,8 +42,11 @@ function oneoffContrib(
 
   switch (action.type) {
 
+    case 'SET_COUNTRY':
+      return Object.assign({}, state, { country: action.value });
+
     case 'SET_CONTRIB_VALUE':
-      return Object.assign({}, state, { amount: action.value });
+      return Object.assign({}, state, { amount: action.value, currency: action.currency });
 
     case 'CHECKOUT_ERROR':
       return Object.assign({}, state, { error: action.message });

--- a/assets/pages/oneoff-contributions/reducers/reducers.js
+++ b/assets/pages/oneoff-contributions/reducers/reducers.js
@@ -3,6 +3,9 @@
 // ----- Imports ----- //
 
 import { combineReducers } from 'redux';
+import type { User as UserState } from 'helpers/user/userReducer';
+import type { State as StripeCheckoutState } from 'helpers/stripeCheckout/stripeCheckoutReducer';
+import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 
 import { intCmpReducer as intCmp } from 'helpers/intCmp';
 import stripeCheckout from 'helpers/stripeCheckout/stripeCheckoutReducer';
@@ -23,6 +26,13 @@ export type State = {
   error: ?string,
 };
 
+export type CombinedState = {
+  oneoffContrib: State,
+  intCmp: string,
+  user: UserState,
+  stripeCheckout: StripeCheckoutState,
+  csrf: CsrfState,
+};
 
 // ----- Setup ----- //
 

--- a/assets/pages/oneoff-contributions/reducers/reducers.js
+++ b/assets/pages/oneoff-contributions/reducers/reducers.js
@@ -21,8 +21,8 @@ import type { Action } from '../actions/oneoffContributionsActions';
 
 export type State = {
   amount: number,
-  currency: ?Currency,
-  country: ?IsoCountry,
+  currency: Currency,
+  country: IsoCountry,
   error: ?string,
 };
 
@@ -34,47 +34,42 @@ export type CombinedState = {
   csrf: CsrfState,
 };
 
-// ----- Setup ----- //
-
-const initialState: State = {
-  amount: 50,
-  currency: null,
-  country: null,
-  error: null,
-};
-
-
 // ----- Reducers ----- //
 
-function oneoffContrib(
-  state: State = initialState,
-  action: Action): State {
+function oneoffContrib(amount: number, currency: Currency, country: IsoCountry) {
 
-  switch (action.type) {
+  const initialState: State = {
+    amount,
+    currency,
+    country,
+    error: null,
+  };
 
-    case 'SET_COUNTRY':
-      return Object.assign({}, state, { country: action.value });
+  return (state: State = initialState, action: Action): State => {
 
-    case 'SET_CONTRIB_VALUE':
-      return Object.assign({}, state, { amount: action.value, currency: action.currency });
+    switch (action.type) {
 
-    case 'CHECKOUT_ERROR':
-      return Object.assign({}, state, { error: action.message });
+      case 'SET_CONTRIB_VALUE':
+        return Object.assign({}, state, { amount: action.value });
 
-    default:
-      return state;
+      case 'CHECKOUT_ERROR':
+        return Object.assign({}, state, { error: action.message });
 
-  }
+      default:
+        return state;
 
+    }
+  };
 }
 
 
 // ----- Exports ----- //
 
-export default combineReducers({
-  oneoffContrib,
-  intCmp,
-  user,
-  stripeCheckout,
-  csrf,
-});
+export default (amount: number, currency: Currency, country: IsoCountry) =>
+  combineReducers({
+    oneoffContrib: oneoffContrib(amount, currency, country),
+    intCmp,
+    user,
+    stripeCheckout: stripeCheckout(amount, currency.iso),
+    csrf,
+  });

--- a/assets/pages/oneoff-contributions/reducers/reducers.js
+++ b/assets/pages/oneoff-contributions/reducers/reducers.js
@@ -8,6 +8,8 @@ import { intCmpReducer as intCmp } from 'helpers/intCmp';
 import stripeCheckout from 'helpers/stripeCheckout/stripeCheckoutReducer';
 import user from 'helpers/user/userReducer';
 import csrf from 'helpers/csrf/csrfReducer';
+import type { Currency } from 'helpers/internationalisation/currency';
+import { GBP } from 'helpers/internationalisation/currency';
 
 import type { Action } from '../actions/oneoffContributionsActions';
 
@@ -16,6 +18,7 @@ import type { Action } from '../actions/oneoffContributionsActions';
 
 export type State = {
   amount: number,
+  currency: Currency,
   country: string,
   error: ?string,
 };
@@ -25,6 +28,7 @@ export type State = {
 
 const initialState: State = {
   amount: 50,
+  currency: GBP,
   country: 'GB',
   error: null,
 };

--- a/assets/pages/oneoff-contributions/reducers/reducers.js
+++ b/assets/pages/oneoff-contributions/reducers/reducers.js
@@ -8,7 +8,7 @@ import type { State as StripeCheckoutState } from 'helpers/stripeCheckout/stripe
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 
 import { intCmpReducer as intCmp } from 'helpers/intCmp';
-import stripeCheckout from 'helpers/stripeCheckout/stripeCheckoutReducer';
+import createStripeCheckoutReducer from 'helpers/stripeCheckout/stripeCheckoutReducer';
 import payPalContributionsCheckout from 'helpers/payPalContributionsCheckout/payPalContributionsCheckoutReducer';
 import user from 'helpers/user/userReducer';
 import csrf from 'helpers/csrf/csrfReducer';
@@ -77,7 +77,7 @@ export default (amount: number, currency: Currency, country: IsoCountry) =>
     oneoffContrib: oneoffContrib(amount, currency, country),
     intCmp,
     user,
-    stripeCheckout: stripeCheckout(amount, currency.iso),
+    stripeCheckout: createStripeCheckoutReducer(amount, currency.iso),
     payPalContributionsCheckout,
     csrf,
   });


### PR DESCRIPTION
## Why are you doing this?

To allow US users to make recurring contributions

Follow-up PR needed to add a "State" field since Zuora insist on this for US/Canada customs for tax reasons.

[**Trello Card**](https://trello.com/c/t4L9DPtI/699-test-3-us-recurring-update-frontend-for-dollars)