### PR TITLE
Fix the payment amount width for several type of numbers.

### DIFF
--- a/assets/components/paymentAmount/paymentAmount.jsx
+++ b/assets/components/paymentAmount/paymentAmount.jsx
@@ -7,6 +7,8 @@ import React from 'react';
 
 // ----- Setup ----- //
 
+const baseClass = 'component-payment-amount';
+const wideModifier = 'component-payment-amount--wide';
 const wideClass = 'component-payment-amount--wide-value';
 
 
@@ -21,9 +23,19 @@ type PropTypes = {
 
 export default function PaymentAmount(props: PropTypes) {
 
-  const wideValue = props.amount.toString().length > 2;
-  const className = `component-payment-amount ${wideValue ? wideClass : ''}`;
-  const printedAmount = wideValue ? props.amount.toFixed(2) : props.amount;
+  const addDecimal = props.amount % 1 > 0;
+  const printedAmount = addDecimal ? props.amount.toFixed(2) : props.amount;
+  const printedLength = printedAmount.toString().length;
+
+  let className = '';
+
+  if (printedLength <= 2) {
+    className = baseClass;
+  } else if (printedLength > 2 && printedLength < 8) {
+    className = `${baseClass} ${wideModifier} ${wideClass}-${printedLength}`;
+  } else {
+    className = `${baseClass} ${wideModifier} ${wideClass}`;
+  }
 
   return (
     <div className={className}>£{printedAmount}</div>

--- a/assets/components/paymentAmount/paymentAmount.scss
+++ b/assets/components/paymentAmount/paymentAmount.scss
@@ -11,20 +11,19 @@
 
 .component-payment-amount--wide {
   padding-left: 1em;
-  padding-right: 1em;
+  padding-right: 1.3em;
 }
 
 .component-payment-amount--wide-value-3 {
-  padding-right: 1.3em;
   width: 50px;
 }
 
 .component-payment-amount--wide-value-4 {
-  padding-right: 1.3em;
   width: 60px;
 }
 
 .component-payment-amount--wide-value-5 {
+  padding-right: 1em;
   width: 70px;
 }
 
@@ -37,5 +36,6 @@
 }
 
 .component-payment-amount--wide-value {
+  padding-right: 1em;
   width: unset;
 }

--- a/assets/components/paymentAmount/paymentAmount.scss
+++ b/assets/components/paymentAmount/paymentAmount.scss
@@ -1,16 +1,41 @@
 .component-payment-amount {
-	border-radius: 1000px;
-	font-size: 24px;
-	color: #fff;
-	width: 60px;
-	height: 60px;
-	text-align: center;
-	background-color: gu-colour(neutral-1);
-	line-height: 60px;
+  border-radius: 1000px;
+  font-size: 24px;
+  color: #fff;
+  width: 60px;
+  height: 60px;
+  text-align: center;
+  background-color: gu-colour(neutral-1);
+  line-height: 60px;
+}
+
+.component-payment-amount--wide {
+  padding-left: 1em;
+  padding-right: 1em;
+}
+
+.component-payment-amount--wide-value-3 {
+  padding-right: 1.3em;
+  width: 50px;
+}
+
+.component-payment-amount--wide-value-4 {
+  padding-right: 1.3em;
+  width: 60px;
+}
+
+.component-payment-amount--wide-value-5 {
+  width: 70px;
+}
+
+.component-payment-amount--wide-value-6 {
+  width: 80px;
+}
+
+.component-payment-amount--wide-value-7 {
+  width: 90px;
 }
 
 .component-payment-amount--wide-value {
-	padding-left: 1em;
-	padding-right: 1em;
-	width: unset;
+  width: unset;
 }

--- a/assets/pages/monthly-contributions/monthlyContributions.jsx
+++ b/assets/pages/monthly-contributions/monthlyContributions.jsx
@@ -44,7 +44,7 @@ const store = createStore(reducer, {
 
 // Retrieves the contrib amount from the url and sends it to the redux store.
 const contributionAmount = getQueryParameter('contributionValue', '5');
-
+console.log(contributionAmount);
 if (contributionAmount !== undefined && contributionAmount !== null) {
   store.dispatch(setContribAmount(contributionAmount));
 }

--- a/assets/pages/monthly-contributions/monthlyContributions.jsx
+++ b/assets/pages/monthly-contributions/monthlyContributions.jsx
@@ -44,7 +44,7 @@ const store = createStore(reducer, {
 
 // Retrieves the contrib amount from the url and sends it to the redux store.
 const contributionAmount = getQueryParameter('contributionValue', '5');
-console.log(contributionAmount);
+
 if (contributionAmount !== undefined && contributionAmount !== null) {
   store.dispatch(setContribAmount(contributionAmount));
 }


### PR DESCRIPTION
## Why are you doing this?

We used to handle correctly the amount between £1 - £99. This PR adds the more cases.

## Screenshots

### Before
<img width="304" alt="picture 344" src="https://user-images.githubusercontent.com/825398/29215222-10976eb2-7ea2-11e7-88c8-616cd2c158fb.png">

<img width="1127" alt="picture 345" src="https://user-images.githubusercontent.com/825398/29215250-28c2c662-7ea2-11e7-983d-e5f1ca430967.png">

### After

#### £5
<img width="329" alt="picture 347" src="https://user-images.githubusercontent.com/825398/29215323-77dbb830-7ea2-11e7-9824-b3b99d75f915.png">

#### £50
<img width="319" alt="picture 348" src="https://user-images.githubusercontent.com/825398/29215342-8eab746a-7ea2-11e7-9751-40281054fccd.png">

#### £500
<img width="391" alt="picture 349" src="https://user-images.githubusercontent.com/825398/29215354-a513d3e6-7ea2-11e7-9be3-678ab359bbab.png">

#### £500.20
<img width="409" alt="picture 350" src="https://user-images.githubusercontent.com/825398/29215371-b6bf7c94-7ea2-11e7-801c-35012248db32.png">

#### £1000

<img width="388" alt="picture 351" src="https://user-images.githubusercontent.com/825398/29215398-ca453538-7ea2-11e7-8b6f-c3cfdd986386.png">

#### £1000.20
<img width="420" alt="picture 352" src="https://user-images.githubusercontent.com/825398/29215421-d987b304-7ea2-11e7-8706-bcfb94a70063.png">

