### PR TITLE
Retrieve Query Params in lowercase.

### DIFF
--- a/assets/helpers/url.js
+++ b/assets/helpers/url.js
@@ -4,9 +4,9 @@
 
 const getQueryParameter = (paramName: string, defaultValue?: string): ?string => {
 
-  const params = new URLSearchParams(window.location.search);
+  const params = new URLSearchParams(window.location.search.toLowerCase());
 
-  return params.get(paramName) || defaultValue;
+  return params.get(paramName.toLowerCase()) || defaultValue;
 
 };
 


### PR DESCRIPTION
## Why are you doing this?
We want to pick up query params even if they are in lowercase.

## Changes
* Update URL helper.
