### PR TITLE
Refactor Routes

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -3,34 +3,44 @@
 GET /healthcheck                                    controllers.Application.healthcheck
 
 
-# ----- Pages ----- #
-
-# ----- Support Landing Page
+# ----- Bundles Landing Page ----- #
 
 GET /uk                                             controllers.Application.reactTemplate(title="Support the Guardian", id="bundles-landing-page", js="bundlesLandingPage.js")
 GET /                                               controllers.Default.redirect(to = "/uk")
 
-# ----- Contributions
+
+# ----- Contributions ----- #
+
+GET  /uk/contribute                                 controllers.Application.reactTemplate(title="Support the Guardian | Make a Contribution", id="contributions-landing-page-uk", js="contributionsLandingPageUK.js")
+
+GET  /contribute/recurring                          controllers.MonthlyContributions.displayForm(paypal : Option[Boolean])
+GET  /contribute/recurring/thankyou                 controllers.Application.reactTemplate(title="Support the Guardian | Thank You", id="monthly-contributions-thankyou-page", js="monthlyContributionsThankyouPage.js")
+GET  /contribute/recurring/existing                 controllers.Application.reactTemplate(title="Support the Guardian | Existing Contributor", id="monthly-contributions-existing-page", js="monthlyContributionsExistingPage.js")
+POST /contribute/recurring/create                   controllers.MonthlyContributions.create
+
+GET  /contribute/one-off                            controllers.OneOffContributions.displayForm(paypal: Option[Boolean])
+GET  /contribute/one-off/thankyou                   controllers.Application.reactTemplate(title="Support the Guardian | Thank You", id="oneoff-contributions-thankyou-page", js="oneoffContributionsThankyouPage.js")
+GET  /contribute/one-off/test-user                  controllers.OneOffContributions.displayFormTestUser(paypal: Option[Boolean])
+GET  /contribute/one-off/autofill                   controllers.OneOffContributions.autofill
+
+# DEPRECATED ROUTES (START)
 
 GET  /monthly-contributions                         controllers.MonthlyContributions.displayForm(paypal : Option[Boolean])
 GET  /monthly-contributions/thankyou                controllers.Application.reactTemplate(title="Support the Guardian | Thank You", id="monthly-contributions-thankyou-page", js="monthlyContributionsThankyouPage.js")
 GET  /monthly-contributions/existing-contributor    controllers.Application.reactTemplate(title="Support the Guardian | Existing Contributor", id="monthly-contributions-existing-page", js="monthlyContributionsExistingPage.js")
 POST /monthly-contributions/create                  controllers.MonthlyContributions.create
 
-GET  /uk/contribute                                 controllers.Application.reactTemplate(title="Support the Guardian | Make a Contribution", id="contributions-landing-page-uk", js="contributionsLandingPageUK.js")
-
 GET  /oneoff-contributions                          controllers.OneOffContributions.displayForm(paypal: Option[Boolean])
 GET  /oneoff-contributions/test-user                controllers.OneOffContributions.displayFormTestUser(paypal: Option[Boolean])
 GET  /oneoff-contributions/thankyou                 controllers.Application.reactTemplate(title="Support the Guardian | Thank You", id="oneoff-contributions-thankyou-page", js="oneoffContributionsThankyouPage.js")
 GET  /oneoff-contributions/autofill                 controllers.OneOffContributions.autofill
 
-# ----- Misc
-
-GET  /test-users                                    controllers.TestUsersManagement.createTestUser
+# DEPRECATED ROUTES (END)
 
 
 # ----- Authentication ----- #
 
+GET  /test-users                                    controllers.TestUsersManagement.createTestUser
 GET  /login                                         controllers.Login.login
 GET  /loginAction                                   controllers.Login.loginAction
 GET  /oauth2callback                                controllers.Login.oauth2Callback

--- a/conf/routes
+++ b/conf/routes
@@ -17,7 +17,6 @@ GET  /monthly-contributions/thankyou                controllers.Application.reac
 GET  /monthly-contributions/existing-contributor    controllers.Application.reactTemplate(title="Support the Guardian | Existing Contributor", id="monthly-contributions-existing-page", js="monthlyContributionsExistingPage.js")
 POST /monthly-contributions/create                  controllers.MonthlyContributions.create
 
-GET  /oneoff-contributions/thankyou                 controllers.Application.reactTemplate(title="Support the Guardian | Thank You", id="oneoff-contributions-thankyou-page", js="oneoffContributionsThankyouPage.js")
 GET  /uk/contribute                                 controllers.Application.reactTemplate(title="Support the Guardian | Make a Contribution", id="contributions-landing-page-uk", js="contributionsLandingPageUK.js")
 
 GET  /oneoff-contributions                          controllers.OneOffContributions.displayForm(paypal: Option[Boolean])

--- a/conf/routes
+++ b/conf/routes
@@ -1,38 +1,52 @@
 # ----- System ----- #
 
-GET /healthcheck                controllers.Application.healthcheck
+GET /healthcheck                                    controllers.Application.healthcheck
 
 
 # ----- Pages ----- #
-GET /uk                        controllers.Application.reactTemplate(title="Support the Guardian", id="bundles-landing-page", js="bundlesLandingPage.js")
-GET /                          controllers.Default.redirect(to = "/uk")
+
+# ----- Support Landing Page
+
+GET /uk                                             controllers.Application.reactTemplate(title="Support the Guardian", id="bundles-landing-page", js="bundlesLandingPage.js")
+GET /                                               controllers.Default.redirect(to = "/uk")
+
+# ----- Contributions
 
 GET  /monthly-contributions                         controllers.MonthlyContributions.displayForm(paypal : Option[Boolean])
 GET  /monthly-contributions/thankyou                controllers.Application.reactTemplate(title="Support the Guardian | Thank You", id="monthly-contributions-thankyou-page", js="monthlyContributionsThankyouPage.js")
 GET  /monthly-contributions/existing-contributor    controllers.Application.reactTemplate(title="Support the Guardian | Existing Contributor", id="monthly-contributions-existing-page", js="monthlyContributionsExistingPage.js")
 POST /monthly-contributions/create                  controllers.MonthlyContributions.create
 
-GET /oneoff-contributions/thankyou                  controllers.Application.reactTemplate(title="Support the Guardian | Thank You", id="oneoff-contributions-thankyou-page", js="oneoffContributionsThankyouPage.js")
-GET /uk/contribute              controllers.Application.reactTemplate(title="Support the Guardian | Make a Contribution", id="contributions-landing-page-uk", js="contributionsLandingPageUK.js")
+GET  /oneoff-contributions/thankyou                 controllers.Application.reactTemplate(title="Support the Guardian | Thank You", id="oneoff-contributions-thankyou-page", js="oneoffContributionsThankyouPage.js")
+GET  /uk/contribute                                 controllers.Application.reactTemplate(title="Support the Guardian | Make a Contribution", id="contributions-landing-page-uk", js="contributionsLandingPageUK.js")
 
-GET /oneoff-contributions                         controllers.OneOffContributions.displayForm(paypal: Option[Boolean])
-GET /oneoff-contributions/test-user               controllers.OneOffContributions.displayFormTestUser(paypal: Option[Boolean])
-GET /oneoff-contributions/thankyou                controllers.Application.reactTemplate(title="Support the Guardian | Thank You", id="oneoff-contributions-thankyou-page", js="oneoffContributionsThankyouPage.js")
-GET /oneoff-contributions/autofill                controllers.OneOffContributions.autofill
+GET  /oneoff-contributions                          controllers.OneOffContributions.displayForm(paypal: Option[Boolean])
+GET  /oneoff-contributions/test-user                controllers.OneOffContributions.displayFormTestUser(paypal: Option[Boolean])
+GET  /oneoff-contributions/thankyou                 controllers.Application.reactTemplate(title="Support the Guardian | Thank You", id="oneoff-contributions-thankyou-page", js="oneoffContributionsThankyouPage.js")
+GET  /oneoff-contributions/autofill                 controllers.OneOffContributions.autofill
 
-GET  /login                    controllers.Login.login
-GET  /loginAction              controllers.Login.loginAction
-GET  /oauth2callback           controllers.Login.oauth2Callback
-GET  /logout                   controllers.Login.logout
+# ----- Misc
 
-GET  /test-users               controllers.TestUsersManagement.createTestUser
+GET  /test-users                                    controllers.TestUsersManagement.createTestUser
 
-# Paypal NVP endpoints.
-POST /paypal/setup-payment     controllers.PayPal.setupPayment
-POST /paypal/create-agreement  controllers.PayPal.createAgreement
-GET  /paypal/return            controllers.PayPal.returnUrl
-GET  /paypal/cancel            controllers.PayPal.cancelUrl
 
-# Assets
-GET  /assets/*file             controllers.Assets.at(path="/public/compiled-assets", file)
-GET  /*file                    controllers.Assets.at(path="/public", file)
+# ----- Authentication ----- #
+
+GET  /login                                         controllers.Login.login
+GET  /loginAction                                   controllers.Login.loginAction
+GET  /oauth2callback                                controllers.Login.oauth2Callback
+GET  /logout                                        controllers.Login.logout
+
+
+# ----- PayPal (NVP Endpoints) ----- #
+
+POST /paypal/setup-payment                          controllers.PayPal.setupPayment
+POST /paypal/create-agreement                       controllers.PayPal.createAgreement
+GET  /paypal/return                                 controllers.PayPal.returnUrl
+GET  /paypal/cancel                                 controllers.PayPal.cancelUrl
+
+
+# ----- Assets ----- #
+
+GET  /assets/*file                                  controllers.Assets.at(path="/public/compiled-assets", file)
+GET  /*file                                         controllers.Assets.at(path="/public", file)

--- a/conf/routes
+++ b/conf/routes
@@ -40,11 +40,11 @@ GET  /oneoff-contributions/autofill                 controllers.OneOffContributi
 
 # ----- Authentication ----- #
 
-GET  /test-users                                    controllers.TestUsersManagement.createTestUser
 GET  /login                                         controllers.Login.login
 GET  /loginAction                                   controllers.Login.loginAction
 GET  /oauth2callback                                controllers.Login.oauth2Callback
 GET  /logout                                        controllers.Login.logout
+GET  /test-users                                    controllers.TestUsersManagement.createTestUser
 
 
 # ----- PayPal (NVP Endpoints) ----- #


### PR DESCRIPTION
## Why are you doing this?

The routes for our project are becoming inconsistent, both semantically and in terms of code cleanliness (we have a duplicate entry, probably left over from a rebase). We're also getting to the point where we're looking at internationalisation and thinking a bit more about the structure of our site. These changes tidy up the routes file, and attempt to semantically structure it in accordance with our probable future site layout:

```
/$country                            -> bundles landing page

/$country/contribute                 -> contributions landing page
/contribute/one-off                  -> one-off contrib checkout
/contribute/one-off/thankyou         -> one-off contrib thank you
/contribute/one-off/test-user        -> one-off contrib test users
/contribute/one-off/autofill         -> one-off contrib autofill
/contribute/recurring                -> recurring contrib checkout
/contribute/recurring/thankyou       -> recurring contrib thank you
/contribute/recurring/create         -> [POST] ajax endpoint to create contributor
/contribute/recurring/existing       -> existing contributor explanation page

/$country/subscribe                  -> future subs landing page
/subscribe/digital                   -> future digipack landing/checkout
/subscribe/digital/thankyou          -> future digipack thank you
/subscribe/paper                     -> future paper landing/checkout
/subscribe/paper/thankyou            -> future paper thank you
/subscribe/paper-plus                -> future paper+digital landing/checkout
/subscribe/paper-plus/thankyou       -> future paper+digital thank you
```

We have the bundles landing page, which displays all our products, as the main landing page for the site, under `/`. Below that, we split into the two parts of the support proposition: the contribute/subscribe (give/get):

- All contributions-specific URLs live under `/contribute`
- All subscriptions-specific URLs live under `/subscribe`.

In addition, internationalised URLs for which we have different pages (different entry points in webpack) pick up a `/$country` prefix in the path. For example, the contributions/subs landing pages.

Also, all URLs that have been changed are disallowed in the `robots.txt` at the moment, so we shouldn't have any search engine/crawler issues.

**Note:** The diff is pretty confusing, you may want to look at the raw files. Not much has actually changed, but some things have been moved around/whitespace has been added.

[**Trello Card**](https://trello.com/c/nywxMPr4/725-tidy-up-our-routes)

## Changes

- Dropped duplicate `/oneoff-contributions/thankyou` entry.
- Refactored the contributions routes, kept old routes as deprecated for now.
- Tidied up the file (whitespace/comments/order).
