### PR TITLE
Added campaign codes for test 4

### DIFF
--- a/assets/pages/bundles-landing/helpers/subscriptionsLinks.js
+++ b/assets/pages/bundles-landing/helpers/subscriptionsLinks.js
@@ -27,9 +27,9 @@ const tests = [
   {
     name: 'baseline',
     intCmps: [
+      'gdnwb_copts_memco_sandc_support_baseline_support_banner',
       'gdnwb_copts_memco_sandc_support_baseline_support_epic',
-      'gdnwb_copts_memco_sandc_support_baseline_support_header',
-      'gdnwb_copts_memco_sandc_engagement_banner_baseline_support_proposition',
+      'gdnwb_copts_memco_sandc_support_baseline_support_liveblog',
     ],
     promoCodes: {
       digital: 'p/DJ6CCJZLL',

--- a/assets/pages/bundles-landing/helpers/subscriptionsLinks.js
+++ b/assets/pages/bundles-landing/helpers/subscriptionsLinks.js
@@ -27,8 +27,8 @@ const tests = [
   {
     name: 'baseline',
     intCmps: [
-      'gdnwb_copts_memco_sandc_epic_baseline_support_proposition',
-      'gdnwb_copts_memco_sandc_header_baseline_support_proposition',
+      'gdnwb_copts_memco_sandc_support_baseline_support_epic',
+      'gdnwb_copts_memco_sandc_support_baseline_support_header',
       'gdnwb_copts_memco_sandc_engagement_banner_baseline_support_proposition',
     ],
     promoCodes: {

--- a/assets/pages/bundles-landing/helpers/subscriptionsLinks.js
+++ b/assets/pages/bundles-landing/helpers/subscriptionsLinks.js
@@ -25,14 +25,16 @@ const defaultPromos: PromoCodes = {
 
 const tests = [
   {
-    name: 'rebaseline',
+    name: 'baseline',
     intCmps: [
-      'gdnwb_copts_memco_sandc_epic_rebaseline_support_proposition_support_proposition',
+      'gdnwb_copts_memco_sandc_epic_baseline_support_proposition',
+      'gdnwb_copts_memco_sandc_header_baseline_support_proposition',
+      'gdnwb_copts_memco_sandc_engagement_banner_baseline_support_proposition',
     ],
     promoCodes: {
-      digital: 'p/DP83X',
-      paper: 'p/VHD83P',
-      paperDig: 'p/VHD83X',
+      digital: 'p/DJ6CCJZLL',
+      paper: 'p/NJ6CCQLD4',
+      paperDig: 'p/NJ6CCSVMC',
     },
   },
 ];


### PR DESCRIPTION
## Why are you doing this?

Setup the logic for setting up the promo codes for test 4.

## Campaign codes of support variant:

| Channel | Campaign Code |
|---------|---------------|
| **Engagement Banner** | gdnwb_copts_memco_sandc_support_baseline_support_banner  |
| **Epic**  | gdnwb_copts_memco_sandc_support_baseline_support_epic |
| **Liveblog** | gdnwb_copts_memco_sandc_support_baseline_support_liveblog |

## Promo codes:
| Channel | Promo Code |
|---------|---------------|
| **Digital** | DJ6CCJZLL
| **Paper + Digital**| NJ6CCSVMC|
| **Paper** | NJ6CCQLD4|

## Related PR:

https://github.com/guardian/frontend/pull/17650

## Screen casts
### No campaign code 

![defaultpromocodes](https://user-images.githubusercontent.com/825398/29559166-351e1632-8726-11e7-8cb3-309b95d744ce.gif)

### Random campaign code
![supportrandom](https://user-images.githubusercontent.com/825398/29559689-b01b048e-8727-11e7-9215-cb8b1983b088.gif)

### Engagement banner campaign code
![supportbanner](https://user-images.githubusercontent.com/825398/29559328-ba18cdc8-8726-11e7-8b14-44006be87046.gif)

### Epic campaign code
![supportepic](https://user-images.githubusercontent.com/825398/29559455-1490f82a-8727-11e7-873a-55c224a6ba22.gif)

### Liveblog campaign code
![supportlivablog](https://user-images.githubusercontent.com/825398/29559539-4c027bee-8727-11e7-917b-a00dd1658885.gif)






