### PR TITLE
Tidy Routes - Remove Deprecated

### DIFF
--- a/conf/routes
+++ b/conf/routes
@@ -23,20 +23,6 @@ GET  /contribute/one-off/thankyou                   controllers.Application.reac
 GET  /contribute/one-off/test-user                  controllers.OneOffContributions.displayFormTestUser(paypal: Option[Boolean])
 GET  /contribute/one-off/autofill                   controllers.OneOffContributions.autofill
 
-# DEPRECATED ROUTES (START)
-
-GET  /monthly-contributions                         controllers.MonthlyContributions.displayForm(paypal : Option[Boolean])
-GET  /monthly-contributions/thankyou                controllers.Application.reactTemplate(title="Support the Guardian | Thank You", id="monthly-contributions-thankyou-page", js="monthlyContributionsThankyouPage.js")
-GET  /monthly-contributions/existing-contributor    controllers.Application.reactTemplate(title="Support the Guardian | Existing Contributor", id="monthly-contributions-existing-page", js="monthlyContributionsExistingPage.js")
-POST /monthly-contributions/create                  controllers.MonthlyContributions.create
-
-GET  /oneoff-contributions                          controllers.OneOffContributions.displayForm(paypal: Option[Boolean])
-GET  /oneoff-contributions/test-user                controllers.OneOffContributions.displayFormTestUser(paypal: Option[Boolean])
-GET  /oneoff-contributions/thankyou                 controllers.Application.reactTemplate(title="Support the Guardian | Thank You", id="oneoff-contributions-thankyou-page", js="oneoffContributionsThankyouPage.js")
-GET  /oneoff-contributions/autofill                 controllers.OneOffContributions.autofill
-
-# DEPRECATED ROUTES (END)
-
 
 # ----- Authentication ----- #
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,7 +1,5 @@
 User-agent: *
 
-Disallow: /monthly-contributions
-Disallow: /oneoff-contributions
 Disallow: /uk/contribute
 Disallow: /contribute
 

--- a/test/controllers/MonthlyContributionsTest.scala
+++ b/test/controllers/MonthlyContributionsTest.scala
@@ -26,7 +26,7 @@ import fixtures.TestCSRFComponents
 
 class MonthlyContributionsTest extends WordSpec with MustMatchers with TestCSRFComponents {
 
-  "GET /monthly-contributors" should {
+  "GET /contribute/recurring" should {
 
     "redirect unauthenticated user to signup page" in new DisplayForm {
       val result = fakeRequestWith(actionRefiner = loggedOutActionRefiner)

--- a/test/controllers/OneOffContributionsTest.scala
+++ b/test/controllers/OneOffContributionsTest.scala
@@ -25,7 +25,7 @@ import play.api.libs.json.JsString
 
 class OneOffContributionsTest extends WordSpec with MustMatchers with TestCSRFComponents {
 
-  "GET /oneoff-contributions" should {
+  "GET /contribute/one-off" should {
 
     "return email address" in new AutoFillScope {
       val result = fakeRequest()


### PR DESCRIPTION
## Why are you doing this?

Final instalment of the journey that began with #176, and continued with #180. This deletes the deprecated routes from the `routes` file and the `robots.txt`. It also updates some test descriptions to better reflect the new routes.

[**Trello Card**](https://trello.com/c/nywxMPr4/725-tidy-up-our-routes)

## Changes

- Removed deprecated routes.
- Removed deprecated routes from `robots.txt`.
- Updated test descriptions.
