### PR TITLE
Add first browser-driven test

### DIFF
--- a/assets/components/ctaLink/ctaLink.jsx
+++ b/assets/components/ctaLink/ctaLink.jsx
@@ -14,13 +14,14 @@ type PropTypes = {
   url?: string,
   onClick?: () => void,
   tabIndex?: number,
+  id?: string,
 };
 
 // ----- Component ----- //
 
 export default function CtaLink(props: PropTypes) {
   return (
-    <a className="component-cta-link" href={props.url} onClick={props.onClick} onKeyPress={clickSubstituteKeyPressHandler(props.onClick)} tabIndex={props.tabIndex}>
+    <a id={props.id} className="component-cta-link" href={props.url} onClick={props.onClick} onKeyPress={clickSubstituteKeyPressHandler(props.onClick)} tabIndex={props.tabIndex}>
       <span>{props.text}</span>
       <Svg svgName="arrow-right-straight" />
     </a>
@@ -35,5 +36,6 @@ CtaLink.defaultProps = {
   url: null,
   onClick: null,
   tabIndex: 0,
+  id: null,
 };
 

--- a/assets/components/stripePopUpButton/stripePopUpButton.jsx
+++ b/assets/components/stripePopUpButton/stripePopUpButton.jsx
@@ -36,6 +36,7 @@ const StripePopUpButton = (props: PropTypes) => {
 
   return (
     <button
+      id="qa-pay-with-card"
       className="component-stripe-pop-up-button"
       onClick={stripeClick}
     >Pay with debit/credit card <Svg svgName="credit-card" /></button>

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -114,7 +114,7 @@ function ContributionsBundle(props: PropTypes) {
         onNumberInputKeyPress={onClick}
         {...props}
       />
-      <CtaLink text={attrs.ctaText} onClick={onClick} />
+      <CtaLink text={attrs.ctaText} onClick={onClick} id="qa-contribute-button"/>
     </Bundle>
   );
 

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -114,7 +114,7 @@ function ContributionsBundle(props: PropTypes) {
         onNumberInputKeyPress={onClick}
         {...props}
       />
-      <CtaLink text={attrs.ctaText} onClick={onClick} id="qa-contribute-button"/>
+      <CtaLink text={attrs.ctaText} onClick={onClick} id="qa-contribute-button" />
     </Bundle>
   );
 

--- a/assets/pages/contributions-thankyou/monthlyContributionsThankyou.jsx
+++ b/assets/pages/contributions-thankyou/monthlyContributionsThankyou.jsx
@@ -28,7 +28,7 @@ const content = (
       <div className="thankyou__content gu-content-filler__inner">
         <div className="thankyou__wrapper">
           <h1 className="thankyou__heading">Thank you!</h1>
-          <h2 className="thankyou__subheading">
+          <h2 id="qa-thank-you-message" className="thankyou__subheading">
             <p>You have helped to make the Guardian&#39;s future more secure.
             Look out for an email confirming your recurring
             payment.</p>

--- a/build.sbt
+++ b/build.sbt
@@ -58,6 +58,9 @@ libraryDependencies ++= Seq(
   "com.google.guava" % "guava" % "22.0",
   "com.netaporter" %% "scala-uri" % "0.4.16",
   "com.gu" %% "play-googleauth" % "0.7.0",
+  "io.github.bonigarcia" % "webdrivermanager" % "1.4.10" % "test",
+  "org.seleniumhq.selenium" % "selenium-java" % "3.0.1" % "test",
+  "com.squareup.okhttp3" % "okhttp" % "3.8.1",
   filters,
   ws
 )
@@ -104,3 +107,5 @@ excludeFilter in scalariformFormat := (excludeFilter in scalariformFormat).value
   "RoutesPrefix.scala"
 
 addCommandAlias("devrun", "run 9210") // Chosen to not clash with other Guardian projects - we can't all use the Play default of 9000!
+addCommandAlias("fast-test", "test-only -- -l Selenium")
+addCommandAlias("selenium-test", "test-only -- -n Selenium")

--- a/conf/DEV.public.conf
+++ b/conf/DEV.public.conf
@@ -14,3 +14,4 @@ support.url="https://support.thegulocal.com"
 googleAuth.redirectUrl = "https://support.thegulocal.com/oauth2callback"
 membersDataService.api.url="https://members-data-api.thegulocal.com"
 play.filters.headers.contentSecurityPolicy = "default-src 'self' polyfill.guim.co.uk www.paypalobjects.com www.paypal.com www.sandbox.paypal.com js.stripe.com pasteup.guim.co.uk ophan.theguardian.com www.google-analytics.com media.guim.co.uk stats.g.doubleclick.net www.youtube.com checkout.stripe.com data: wss: 'unsafe-inline' q.stripe.com contribute.thegulocal.com"
+selenium.wait.timeout=30

--- a/test/selenium/ContributorSpec.scala
+++ b/test/selenium/ContributorSpec.scala
@@ -1,17 +1,19 @@
 package selenium
 
-import org.scalatest.{FeatureSpec, GivenWhenThen, Tag}
+import org.scalatest.{BeforeAndAfterAll, FeatureSpec, GivenWhenThen, Tag}
 import _root_.selenium.pages.{ContributionsLanding, MonthlyContribution, Register, ThankYou}
 import _root_.selenium.util._
 
 object Selenium extends Tag("Selenium")
 
-class ContributorSpec extends FeatureSpec with Browser with GivenWhenThen {
+class ContributorSpec extends FeatureSpec with Browser with GivenWhenThen with BeforeAndAfterAll {
 
   def prepareForSeleniumTest: Unit = {
     Driver.reset()
     dependencyCheck
   }
+
+  override def afterAll(): Unit = { Driver.quit() }
 
   def dependencyCheck: Unit = {
     assume(
@@ -23,8 +25,6 @@ class ContributorSpec extends FeatureSpec with Browser with GivenWhenThen {
       s"- ${Dependencies.IdentityFrontend.url} is unavailable! Please run identity-frontend locally before running these tests."
     )
   }
-
-  def cleanUp: Unit = Driver.quit()
 
   feature("Sign up for a Monthly Contribution") {
 
@@ -77,8 +77,6 @@ class ContributorSpec extends FeatureSpec with Browser with GivenWhenThen {
       Then("the thankyou page should display")
       ThankYou.focusOnDefaultFrame // ensure that we are looking at the main page, and not the Stripe iFrame that may have just closed
       assert(ThankYou.pageHasLoaded)
-
-      cleanUp
 
     }
 

--- a/test/selenium/ContributorSpec.scala
+++ b/test/selenium/ContributorSpec.scala
@@ -8,7 +8,7 @@ object Selenium extends Tag("Selenium")
 
 class ContributorSpec extends FeatureSpec with Browser with GivenWhenThen with BeforeAndAfterAll {
 
-  def prepareForSeleniumTest: Unit = {
+  override def beforeAll: Unit = {
     Driver.reset()
     dependencyCheck
   }
@@ -29,8 +29,6 @@ class ContributorSpec extends FeatureSpec with Browser with GivenWhenThen with B
   feature("Sign up for a Monthly Contribution") {
 
     scenario("Monthly contribution sign-up with Stripe", Selenium) {
-
-      prepareForSeleniumTest
 
       Given("that a test user goes to the contributions landing page")
       val testUser = new TestUser

--- a/test/selenium/ContributorSpec.scala
+++ b/test/selenium/ContributorSpec.scala
@@ -1,0 +1,87 @@
+package selenium
+
+import org.scalatest.{FeatureSpec, GivenWhenThen, Tag}
+import _root_.selenium.pages.{ContributionsLanding, MonthlyContribution, Register, ThankYou}
+import _root_.selenium.util._
+
+object Selenium extends Tag("Selenium")
+
+class ContributorSpec extends FeatureSpec with Browser with GivenWhenThen {
+
+  def prepareForSeleniumTest: Unit = {
+    Driver.reset()
+    dependencyCheck
+  }
+
+  def dependencyCheck: Unit = {
+    assume(
+      Dependencies.SupportFrontend.isAvailable,
+      s"${Dependencies.SupportFrontend.url} is unavailable! Please run support-frontend locally before running these tests."
+    )
+    assume(
+      Dependencies.IdentityFrontend.isAvailable,
+      s"- ${Dependencies.IdentityFrontend.url} is unavailable! Please run identity-frontend locally before running these tests."
+    )
+  }
+
+  def cleanUp: Unit = Driver.quit()
+
+  feature("Sign up for a Monthly Contribution") {
+
+    scenario("Monthly contribution sign-up with Stripe", Selenium) {
+
+      prepareForSeleniumTest
+
+      Given("that a test user goes to the contributions landing page")
+      val testUser = new TestUser
+      goTo(ContributionsLanding)
+      assert(ContributionsLanding.pageHasLoaded)
+
+      When("they select to contribute the default amount")
+      ContributionsLanding.clickContribute
+
+      Then("they should be redirected to register as an Identity user")
+      val register = Register(testUser, 5)
+      assert(register.pageHasLoaded)
+
+      Given("that the user fills in their personal details correctly")
+      register.fillInPersonalDetails()
+
+      When("they submit the form to create their Identity account")
+      register.submit()
+
+      Then("they should be redirected to the Monthly Contributions page")
+      assert(MonthlyContribution.pageHasLoaded)
+
+      Given("that the user selects to pay with Stripe")
+
+      When("they press the Stripe payment button")
+      MonthlyContribution.selectStripePayment()
+
+      Then("the Stripe Checkout iFrame should display")
+      assert(MonthlyContribution.stripeCheckoutHasLoaded)
+
+      Given("that the Stripe Checkout iFrame has the expected fields")
+      MonthlyContribution.switchToStripe()
+      assert(MonthlyContribution.stripeCheckoutHasCardNumberField)
+      assert(MonthlyContribution.stripeCheckoutHasExpiryField)
+      assert(MonthlyContribution.stripeCheckoutHasCvcField)
+      assert(MonthlyContribution.stripeCheckoutHasSubmitButton)
+
+      When("they fill in valid credit card payment details")
+      MonthlyContribution.fillInCreditCardPaymentDetailsStripe
+
+      And("they click on the pay button")
+      MonthlyContribution.clickStripePayButton()
+
+      Then("the thankyou page should display")
+      ThankYou.focusOnDefaultFrame // ensure that we are looking at the main page, and not the Stripe iFrame that may have just closed
+      assert(ThankYou.pageHasLoaded)
+
+      cleanUp
+
+    }
+
+  }
+
+}

--- a/test/selenium/pages/ContributionsLanding.scala
+++ b/test/selenium/pages/ContributionsLanding.scala
@@ -1,0 +1,16 @@
+package selenium.pages
+
+import org.scalatest.selenium.Page
+import selenium.util.{Browser, Config}
+
+object ContributionsLanding extends Page with Browser {
+
+  val url = s"${Config.supportFrontendUrl}/uk/contribute"
+
+  private val contributeButton = id("qa-contribute-button")
+
+  def pageHasLoaded: Boolean = pageHasElement(contributeButton)
+
+  def clickContribute: Unit = clickOn(contributeButton)
+
+}

--- a/test/selenium/pages/MonthlyContribution.scala
+++ b/test/selenium/pages/MonthlyContribution.scala
@@ -1,0 +1,55 @@
+package selenium.pages
+
+import org.scalatest.selenium.Page
+import selenium.util.{Browser, Config}
+
+object MonthlyContribution extends Page with Browser {
+
+  val url = s"${Config.supportFrontendUrl}/monthly-contributions"
+
+  private val stripeButton = id("qa-pay-with-card")
+
+  def pageHasLoaded: Boolean = pageHasElement(stripeButton)
+
+  // ----- Stripe ----- //
+
+  def stripeCheckoutHasLoaded: Boolean = pageHasElement(StripeCheckout.container)
+
+  def stripeCheckoutHasCardNumberField: Boolean = pageHasElement(StripeCheckout.cardNumber)
+
+  def stripeCheckoutHasCvcField: Boolean = pageHasElement(StripeCheckout.cardCvc)
+
+  def stripeCheckoutHasExpiryField: Boolean = pageHasElement(StripeCheckout.cardExp)
+
+  def stripeCheckoutHasSubmitButton: Boolean = pageHasElement(StripeCheckout.submitButton)
+
+  def switchToStripe(): Unit = switchFrame(StripeCheckout.container)
+
+  def fillInCreditCardPaymentDetailsStripe(): Unit = StripeCheckout.fillIn
+
+  def selectStripePayment(): Unit = clickOn(stripeButton)
+
+  def clickStripePayButton(): Unit = StripeCheckout.acceptPayment
+
+  // Handles interaction with the Stripe Checkout iFrame.
+  private object StripeCheckout {
+
+    val container = name("stripe_checkout_app")
+
+    // Unfortunately Stripe do not expose reliable ids on Checkout, so we currently use the following xpath:
+    val cardNumber = xpath("//div[label/text() = \"Card number\"]/input")
+    val cardExp = xpath("//div[label/text() = \"Expiry\"]/input")
+    val cardCvc = xpath("//div[label/text() = \"CVC\"]/input")
+    val submitButton = xpath("//div[button]")
+
+    def fillIn(): Unit = {
+      setValueSlowly(cardNumber, "4242 4242 4242 4242")
+      setValueSlowly(cardExp, "1021")
+      setValueSlowly(cardCvc, "111")
+    }
+
+    def acceptPayment(): Unit = clickOn(submitButton)
+
+  }
+
+}

--- a/test/selenium/pages/MonthlyContribution.scala
+++ b/test/selenium/pages/MonthlyContribution.scala
@@ -5,7 +5,7 @@ import selenium.util.{Browser, Config}
 
 object MonthlyContribution extends Page with Browser {
 
-  val url = s"${Config.supportFrontendUrl}/monthly-contributions"
+  val url = s"${Config.supportFrontendUrl}/contribute/recurring"
 
   private val stripeButton = id("qa-pay-with-card")
 

--- a/test/selenium/pages/Register.scala
+++ b/test/selenium/pages/Register.scala
@@ -1,0 +1,32 @@
+package selenium.pages
+
+import org.scalatest.selenium.Page
+import java.net.URLEncoder
+import selenium.util.{Browser, TestUser, Config}
+
+case class Register(testUser: TestUser, amount: Int) extends Page with Browser {
+  private val returnUrlParam = URLEncoder.encode(s"${Config.supportFrontendUrl}/monthly-contributions?contributionValue%3D${amount}", "UTF-8")
+  val url = s"${Config.identityFrontendUrl}/register?returnUrl=${returnUrlParam}&skipConfirmation=true&clientId=members"
+
+  def fillInPersonalDetails() { RegisterFields.fillIn() }
+
+  def submit() { clickOn(submitButton) }
+
+  def pageHasLoaded: Boolean = pageHasElement(submitButton)
+
+  private object RegisterFields {
+    val firstName = id("register_field_firstname")
+    val lastName = id("register_field_lastname")
+    val email = id("register_field_email")
+    val password = id("register_field_password")
+
+    def fillIn() {
+      setValue(firstName, testUser.username, clear = true)
+      setValue(lastName, testUser.username, clear = true)
+      setValue(email, s"${testUser.username}@gu.com", clear = true)
+      setValue(password, testUser.username, clear = true)
+    }
+  }
+
+  private val submitButton = id("register_submit")
+}

--- a/test/selenium/pages/Register.scala
+++ b/test/selenium/pages/Register.scala
@@ -5,7 +5,7 @@ import java.net.URLEncoder
 import selenium.util.{Browser, TestUser, Config}
 
 case class Register(testUser: TestUser, amount: Int) extends Page with Browser {
-  private val returnUrlParam = URLEncoder.encode(s"${Config.supportFrontendUrl}/monthly-contributions?contributionValue%3D${amount}", "UTF-8")
+  private val returnUrlParam = URLEncoder.encode(s"${Config.supportFrontendUrl}/contribute/recurring?contributionValue%3D${amount}", "UTF-8")
   val url = s"${Config.identityFrontendUrl}/register?returnUrl=${returnUrlParam}&skipConfirmation=true&clientId=members"
 
   def fillInPersonalDetails() { RegisterFields.fillIn() }

--- a/test/selenium/pages/ThankYou.scala
+++ b/test/selenium/pages/ThankYou.scala
@@ -1,0 +1,16 @@
+package selenium.pages
+
+import org.scalatest.selenium.Page
+import selenium.util.{Browser, Config}
+
+object ThankYou extends Page with Browser {
+
+  val url = s"${Config.supportFrontendUrl}/monthly-contributions/thankyou"
+
+  private val thankYouHeader = id("qa-thank-you-message")
+
+  def focusOnDefaultFrame: Unit = revertToDefaultFrame
+
+  def pageHasLoaded: Boolean = pageHasElement(thankYouHeader) && pageHasUrl("/monthly-contributions/thankyou")
+
+}

--- a/test/selenium/pages/ThankYou.scala
+++ b/test/selenium/pages/ThankYou.scala
@@ -5,12 +5,12 @@ import selenium.util.{Browser, Config}
 
 object ThankYou extends Page with Browser {
 
-  val url = s"${Config.supportFrontendUrl}/monthly-contributions/thankyou"
+  val url = s"${Config.supportFrontendUrl}/contribute/recurring/thankyou"
 
   private val thankYouHeader = id("qa-thank-you-message")
 
   def focusOnDefaultFrame: Unit = revertToDefaultFrame
 
-  def pageHasLoaded: Boolean = pageHasElement(thankYouHeader) && pageHasUrl("/monthly-contributions/thankyou")
+  def pageHasLoaded: Boolean = pageHasElement(thankYouHeader) && pageHasUrl("/contribute/recurring/thankyou")
 
 }

--- a/test/selenium/util/Browser.scala
+++ b/test/selenium/util/Browser.scala
@@ -1,0 +1,62 @@
+package selenium.util
+
+import org.openqa.selenium.support.ui.{ExpectedCondition, ExpectedConditions, WebDriverWait}
+import org.scalatest.selenium.WebBrowser
+import scala.util.Try
+
+trait Browser extends WebBrowser {
+
+  lazy implicit val webDriver = Driver()
+
+  // Stores a handle to the first window opened by the driver.
+  lazy val parentWindow = webDriver.getWindowHandle
+
+  def pageHasElement(q: Query): Boolean =
+    waitUntil(ExpectedConditions.visibilityOfElementLocated(q.by))
+
+  def pageHasUrl(urlFraction: String): Boolean =
+    waitUntil(ExpectedConditions.urlContains(urlFraction))
+
+  def clickOn(q: Query) {
+    if (pageHasElement(q))
+      click.on(q)
+    else
+      throw new MissingPageElementException(q)
+  }
+
+  def setValue(q: Query, value: String, clear: Boolean = false) {
+    if (pageHasElement(q)) {
+
+      if (clear) q.webElement.clear
+      q.webElement.sendKeys(value)
+
+    } else
+      throw new MissingPageElementException(q)
+  }
+
+  // Unfortunately this seems to be required in order to complete 3rd party payment forms
+  def setValueSlowly(q: Query, value: String): Unit = {
+    for {
+      c <- value
+    } yield {
+      setValue(q, c.toString)
+      Thread.sleep(100)
+    }
+  }
+
+  // Switches to a new iframe specified by the Query, q.
+  def switchFrame(q: Query) {
+    if (pageHasElement(q))
+      webDriver.switchTo().frame(q.webElement)
+    else
+      throw new MissingPageElementException(q)
+  }
+
+  def revertToDefaultFrame: Unit = webDriver.switchTo().defaultContent()
+
+  private def waitUntil[T](pred: ExpectedCondition[T]): Boolean =
+    Try(new WebDriverWait(webDriver, Config.waitTimeout).until(pred)).isSuccess
+
+  private case class MissingPageElementException(q: Query)
+    extends Exception(s"Could not find WebElement with locator: ${q.queryString}")
+}

--- a/test/selenium/util/Config.scala
+++ b/test/selenium/util/Config.scala
@@ -1,0 +1,20 @@
+package selenium.util
+
+import com.typesafe.config.ConfigFactory
+import org.slf4j.LoggerFactory
+
+object Config {
+
+  private def logger = LoggerFactory.getLogger(this.getClass)
+
+  private val conf = ConfigFactory.load()
+
+  val supportFrontendUrl = conf.getString("support.url")
+
+  val identityFrontendUrl = conf.getString("identity.webapp.url")
+
+  val testUsersSecret = conf.getString("identity.test.users.secret")
+
+  val waitTimeout = conf.getInt("selenium.wait.timeout")
+
+}

--- a/test/selenium/util/Dependencies.scala
+++ b/test/selenium/util/Dependencies.scala
@@ -1,0 +1,26 @@
+package selenium.util
+
+import okhttp3.OkHttpClient
+import okhttp3.Request.Builder
+
+object Dependencies {
+
+  private val client = new OkHttpClient()
+
+  trait Availability {
+    val url: String
+    def isAvailable: Boolean = {
+      val request = new Builder().url(url).build()
+      client.newCall(request).execute.isSuccessful
+    }
+  }
+
+  object SupportFrontend extends Availability {
+    val url = s"${Config.supportFrontendUrl}"
+  }
+
+  object IdentityFrontend extends Availability {
+    val url = s"${Config.identityFrontendUrl}/signin"
+  }
+
+}

--- a/test/selenium/util/Driver.scala
+++ b/test/selenium/util/Driver.scala
@@ -1,0 +1,25 @@
+package selenium.util
+
+import io.github.bonigarcia.wdm.ChromeDriverManager
+import org.openqa.selenium.chrome.ChromeDriver
+import org.openqa.selenium.{Cookie, WebDriver}
+
+object Driver {
+
+  def apply(): WebDriver = driver
+
+  private val driver: WebDriver = {
+    ChromeDriverManager.getInstance().setup()
+    new ChromeDriver()
+  }
+
+  def reset(): Unit = {
+    driver.manage.deleteAllCookies()
+    driver.get(Config.supportFrontendUrl)
+  }
+
+  def quit(): Unit = driver.quit()
+
+  def addCookie(name: String, value: String): Unit = driver.manage.addCookie(new Cookie(name, value))
+
+}

--- a/test/selenium/util/TestUser.scala
+++ b/test/selenium/util/TestUser.scala
@@ -1,0 +1,21 @@
+package selenium.util
+
+import java.time.Duration.ofDays
+
+import com.gu.identity.testing.usernames.TestUsernames
+
+class TestUser {
+
+  private val testUsers = TestUsernames(
+    com.gu.identity.testing.usernames.Encoder.withSecret(Config.testUsersSecret),
+    recency = ofDays(2)
+  )
+
+  private def addTestUserCookies(testUsername: String) = {
+    Driver.addCookie("ANALYTICS_OFF_KEY", "true")
+    Driver.addCookie("pre-signin-test-user", testUsername)
+  }
+
+  val username = testUsers.generate()
+  addTestUserCookies(username)
+}

--- a/test/selenium/util/TestUser.scala
+++ b/test/selenium/util/TestUser.scala
@@ -12,7 +12,6 @@ class TestUser {
   )
 
   private def addTestUserCookies(testUsername: String) = {
-    Driver.addCookie("ANALYTICS_OFF_KEY", "true")
     Driver.addCookie("pre-signin-test-user", testUsername)
   }
 


### PR DESCRIPTION
## Why are you doing this?

On membership/subscriptions/contributions frontend, we run some end-to-end browser-driven tests after every deployment. These run against production servers to confirm that the most critical flows have not been regressed by new changes.

This approach has many benefits, and therefore we would like to replicate this setup on support-frontend, at least in the short term. That said, having these type of tests introduces another maintenance burden, so all developers working on this project should be happy with this before we merge this PR. 

As for the PR itself - it's already getting bigger than I'd like, so I would like to get this code in as a first step. It adds the Selenium boilerplate and a single test. It means any developer in the team should be able to run these browser driven tests locally, using the command:

```sbt selenium-test```

We will need future PRs to:

1. Wire up the config so that these tests are actually run against the prod stack post-deployment.
2. Add additional tests for other critical paths (e.g. PayPal).
3. Add all of this information to the README.

[**Trello Card**](https://trello.com/c/BwKkbrMA/455-post-deployment-tests-for-monthly-contributions-support-frontend)

## Changes

* Adds ids to a few client-side elements to make the site more testable
* Adds dependencies required for Selenium tests
* Adds command aliases so developers (or CI systems) can run unit tests or Selenium tests in isolation
* Adds Selenium boilerplate, closely mirroring the setup on subscriptions and membership frontend
* Adds a test for Monthly Contributions with Stripe

## Screenshots

N/A

cc @davidfurey @JustinPinner @rupertbates @svillafe @Ap0c 