### PR TITLE
Initial application of US contribution page

### DIFF
--- a/assets/components/radioToggle/radioToggle.jsx
+++ b/assets/components/radioToggle/radioToggle.jsx
@@ -28,7 +28,6 @@ type PropTypes = {
 // ----- Component ----- //
 
 export default function RadioToggle(props: PropTypes) {
-
   const radioButtons = props.radios.map((radio: Radio, idx: number) => {
 
     const radioId = `${props.name}-${idx}`;

--- a/assets/helpers/internationalisation/country.js
+++ b/assets/helpers/internationalisation/country.js
@@ -53,6 +53,6 @@ export function detect(): IsoCountry {
   const country = fromPath() || fromQueryParameter() || fromCookie() || fromGeolocation() || 'GB';
   // cookie.set('GU_country', country, 7);
   // Always return GB because we aren't ready to support US quite yet
-  return country;
+  return 'GB' || country;
 }
 

--- a/assets/helpers/internationalisation/country.js
+++ b/assets/helpers/internationalisation/country.js
@@ -53,6 +53,6 @@ export function detect(): IsoCountry {
   const country = fromPath() || fromQueryParameter() || fromCookie() || fromGeolocation() || 'GB';
   // cookie.set('GU_country', country, 7);
   // Always return GB because we aren't ready to support US quite yet
-  return 'GB' || country;
+  return country;
 }
 

--- a/assets/helpers/isoCountry.js
+++ b/assets/helpers/isoCountry.js
@@ -1,0 +1,10 @@
+// @flow
+
+// ----- Reducer ----- //
+
+// Since nothing (currently) can change the isoCountry, this reducer does not handle any actions.
+const isoCountryReducer = (state: ?string = null): ?string => state;
+
+export {
+  isoCountryReducer,
+};

--- a/assets/helpers/user/userActions.js
+++ b/assets/helpers/user/userActions.js
@@ -8,6 +8,7 @@ export type Action =
   | { type: 'SET_LAST_NAME', name: string }
   | { type: 'SET_FULL_NAME', name: string }
   | { type: 'SET_EMAIL', email: string }
+  | { type: 'SET_STATEFIELD', stateField: string }
   | { type: 'SET_POSTCODE', postcode: string }
   | { type: 'SET_TEST_USER', testUser: boolean }
   ;
@@ -33,6 +34,10 @@ export function setFullName(name: string): Action {
 
 export function setEmail(email: string): Action {
   return { type: 'SET_EMAIL', email };
+}
+
+export function setStateField(stateField: string): Action {
+  return { type: 'SET_STATEFIELD', stateField };
 }
 
 export function setPostcode(postcode: string): Action {

--- a/assets/helpers/user/userReducer.js
+++ b/assets/helpers/user/userReducer.js
@@ -14,6 +14,7 @@ export type User = {
   lastName: ?string,
   isTestUser: ?boolean,
   fullName?: string,
+  stateField?: string,
   postcode?: string,
 };
 
@@ -54,6 +55,9 @@ export default function userReducer(
 
     case 'SET_EMAIL':
       return Object.assign({}, state, { email: action.email });
+
+    case 'SET-STATEFIELD':
+      return Object.assign({}, state, { stateField: action.stateField });
 
     case 'SET_POSTCODE':
       return Object.assign({}, state, { postcode: action.postcode });

--- a/assets/helpers/user/userReducer.js
+++ b/assets/helpers/user/userReducer.js
@@ -56,7 +56,7 @@ export default function userReducer(
     case 'SET_EMAIL':
       return Object.assign({}, state, { email: action.email });
 
-    case 'SET-STATEFIELD':
+    case 'SET_STATEFIELD':
       return Object.assign({}, state, { stateField: action.stateField });
 
     case 'SET_POSTCODE':

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -11,6 +11,7 @@ import CtaLink from 'components/ctaLink/ctaLink';
 import Bundle from 'components/bundle/bundle';
 import ContribAmounts from 'components/contribAmounts/contribAmounts';
 import type { Contrib, Amounts, ContribError } from 'helpers/contributions';
+import type { IsoCountry } from 'helpers/internationalisation/country';
 
 import {
   changeContribType,
@@ -37,6 +38,7 @@ type PropTypes = {
   changeContribRecurringAmount: (string) => void,
   changeContribOneOffAmount: (string) => void,
   changeContribAmount: (string) => void,
+  isoCountry: IsoCountry
 };
 
 type ContribAttrs = {
@@ -258,6 +260,7 @@ function mapStateToProps(state) {
     contribAmount: state.contribution.amount,
     contribError: state.contribution.error,
     intCmp: state.intCmp,
+    isoCountry: state.isoCountry,
   };
 }
 

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -11,7 +11,6 @@ import { routes } from 'helpers/routes';
 import ContribAmounts from 'components/contribAmounts/contribAmounts';
 import type { Contrib, Amounts, ContribError } from 'helpers/contributions';
 import type { IsoCountry } from 'helpers/internationalisation/country';
-import { forCountry } from 'helpers/internationalisation/currency';
 
 import {
   changeContribType,
@@ -92,7 +91,7 @@ const getContribAttrs = ({
   const params = new URLSearchParams();
 
   params.append('contributionValue', contribAmount[contType].value);
-  params.append('currency', forCountry(isoCountry).iso);
+  params.append('country', isoCountry);
 
   if (intCmp) {
     params.append('INTCMP', intCmp);

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -10,6 +10,7 @@ import Bundle from 'components/bundle/bundle';
 import { routes } from 'helpers/routes';
 import ContribAmounts from 'components/contribAmounts/contribAmounts';
 import type { Contrib, Amounts, ContribError } from 'helpers/contributions';
+import type { IsoCountry } from 'helpers/internationalisation/country';
 
 import {
   changeContribType,
@@ -34,6 +35,7 @@ type PropTypes = {
   changeContribRecurringAmount: (string) => void,
   changeContribOneOffAmount: (string) => void,
   changeContribAmount: (string) => void,
+  isoCountry: IsoCountry,
 };
 
 /* eslint-enable react/no-unused-prop-types */
@@ -50,15 +52,28 @@ type ContribAttrs = {
 
 // ----- Copy ----- //
 
-const contribAttrs: ContribAttrs = {
-  heading: 'contribute',
-  subheading: `Support the Guardian’s editorial operations by making a
+const subHeadingText = {
+  GB: `Support the Guardian’s editorial operations by making a
     monthly or one-off contribution today`,
-  ctaText: 'Contribute',
-  modifierClass: 'contributions',
-  ctaLink: '',
-  showPaymentLogos: false,
+  US: `Support the Guardian’s editorial operations by making a
+    regular or one-time contribution today`,
 };
+
+const oneOffSubHeadingText = {
+  GB: 'Support the Guardian’s editorial operations by making a one-off contribution today',
+  US: 'Support the Guardian’s editorial operations by making a one-time contribution today',
+};
+
+function contribAttrs(isoCountry: IsoCountry): ContribAttrs {
+  return {
+    heading: 'contribute',
+    subheading: subHeadingText[isoCountry],
+    ctaText: 'Contribute',
+    modifierClass: 'contributions',
+    ctaLink: '',
+    showPaymentLogos: false,
+  };
+}
 
 const ctaLinks = {
   recurring: routes.recurringContribCheckout,
@@ -69,7 +84,7 @@ const ctaLinks = {
 // ----- Functions ----- //
 
 const getContribAttrs = ({
-  contribType, contribAmount, intCmp, showMonthly,
+  contribType, contribAmount, intCmp, showMonthly, isoCountry,
 }): ContribAttrs => {
 
   const contType = contribType === 'RECURRING' ? 'recurring' : 'oneOff';
@@ -85,12 +100,12 @@ const getContribAttrs = ({
 
   if (!showMonthly) {
 
-    const subheading = 'Support the Guardian’s editorial operations by making a one-off contribution today';
-    return Object.assign({}, contribAttrs, { ctaLink, subheading });
+    const subheading = oneOffSubHeadingText[isoCountry];
+    return Object.assign({}, contribAttrs(isoCountry), { ctaLink, subheading });
 
   }
 
-  return Object.assign({}, contribAttrs, { ctaLink });
+  return Object.assign({}, contribAttrs(isoCountry), { ctaLink });
 
 };
 
@@ -135,6 +150,7 @@ function mapStateToProps(state) {
     contribError: state.contribution.error,
     intCmp: state.intCmp,
     showMonthly,
+    isoCountry: state.isoCountry,
   };
 }
 

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -11,6 +11,7 @@ import { routes } from 'helpers/routes';
 import ContribAmounts from 'components/contribAmounts/contribAmounts';
 import type { Contrib, Amounts, ContribError } from 'helpers/contributions';
 import type { IsoCountry } from 'helpers/internationalisation/country';
+import { forCountry } from 'helpers/internationalisation/currency';
 
 import {
   changeContribType,
@@ -91,6 +92,7 @@ const getContribAttrs = ({
   const params = new URLSearchParams();
 
   params.append('contributionValue', contribAmount[contType].value);
+  params.append('currency', forCountry(isoCountry).iso);
 
   if (intCmp) {
     params.append('INTCMP', intCmp);

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -91,7 +91,8 @@ const getContribAttrs = ({
   const params = new URLSearchParams();
 
   params.append('contributionValue', contribAmount[contType].value);
-  params.append('country', isoCountry);
+  // TODO: uncomment when ready for US traffic
+  // params.append('country', isoCountry);
 
   if (intCmp) {
     params.append('INTCMP', intCmp);

--- a/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/assets/pages/contributions-landing/contributionsLanding.scss
@@ -1,4 +1,5 @@
-#contributions-landing-page-uk {
+#contributions-landing-page-uk,
+#contributions-landing-page-us {
 
 	// ----- General ----- //
 

--- a/assets/pages/contributions-landing/contributionsLandingUS.jsx
+++ b/assets/pages/contributions-landing/contributionsLandingUS.jsx
@@ -28,7 +28,7 @@ const participation = pageStartup.start();
 
 const store = createStore(reducer, {
   intCmp: getQueryParameter('INTCMP'),
-  isoCountry: 'GB',
+  isoCountry: 'US',
 });
 
 store.dispatch({ type: 'SET_AB_TEST_PARTICIPATION', payload: participation });
@@ -61,4 +61,4 @@ const content = (
   </Provider>
 );
 
-ReactDOM.render(content, document.getElementById('contributions-landing-page-uk'));
+ReactDOM.render(content, document.getElementById('contributions-landing-page-us'));

--- a/assets/pages/contributions-landing/reducers/__tests__/__snapshots__/reducersTest.js.snap
+++ b/assets/pages/contributions-landing/reducers/__tests__/__snapshots__/reducersTest.js.snap
@@ -59,5 +59,6 @@ Object {
     "type": "RECURRING",
   },
   "intCmp": null,
+  "isoCountry": null,
 }
 `;

--- a/assets/pages/contributions-landing/reducers/reducers.js
+++ b/assets/pages/contributions-landing/reducers/reducers.js
@@ -6,6 +6,7 @@ import { combineReducers } from 'redux';
 
 import type { Contrib, ContribError, Amounts } from 'helpers/contributions';
 import { intCmpReducer as intCmp } from 'helpers/intCmp';
+import { isoCountryReducer as isoCountry } from 'helpers/isoCountry';
 
 import { parse as parseContribution } from 'helpers/contributions';
 import { abTestReducer as abTests } from 'helpers/abtest';
@@ -98,4 +99,5 @@ export default combineReducers({
   contribution,
   intCmp,
   abTests,
+  isoCountry,
 });

--- a/assets/pages/oneoff-contributions/components/formFields.jsx
+++ b/assets/pages/oneoff-contributions/components/formFields.jsx
@@ -4,13 +4,15 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
-
+import type { IsoCountry } from 'helpers/internationalisation/country';
+import { detect as detectCountry } from 'helpers/internationalisation/country';
 import TextInput from 'components/textInput/textInput';
 
 import {
   setFullName,
   setEmail,
   setPostcode,
+  setStateField,
 } from 'helpers/user/userActions';
 
 
@@ -20,11 +22,42 @@ type PropTypes = {
   nameUpdate: (name: string) => void,
   emailUpdate: (email: string) => void,
   postcodeUpdate: (postcode: string) => void,
+  stateFieldUpdate: (stateField: string) => void,
   name: string,
   email: string,
   postcode: ?string,
+  stateField: string,
+  isoCountry: IsoCountry,
 };
 
+
+// ----- Functions ----- //
+
+function postcodeFieldFor(props: PropTypes) {
+  return (
+    <TextInput
+      id="postcode"
+      placeholder={props.isoCountry === 'US' ? 'Zip' : 'Postcode (optional)'}
+      value={props.postcode || ''}
+      onChange={props.postcodeUpdate}
+    />
+  );
+}
+
+function stateFieldIfRequiredFor(props: PropTypes) {
+  if (props.isoCountry === 'US') {
+    return (
+      <TextInput
+        id="state"
+        placeholder="State"
+        value={props.stateField || ''}
+        onChange={props.stateFieldUpdate}
+        required
+      />
+    );
+  }
+  return null;
+}
 
 // ----- Component ----- //
 
@@ -46,12 +79,8 @@ function FormFields(props: PropTypes) {
         onChange={props.emailUpdate}
         required
       />
-      <TextInput
-        id="postcode"
-        placeholder="Postcode (optional)"
-        value={props.postcode || ''}
-        onChange={props.postcodeUpdate}
-      />
+      {stateFieldIfRequiredFor(props)}
+      {postcodeFieldFor(props)}
     </form>
   );
 
@@ -65,7 +94,9 @@ function mapStateToProps(state) {
   return {
     name: state.user.fullName,
     email: state.user.email,
+    stateField: state.user.stateField,
     postcode: state.user.postcode,
+    isoCountry: detectCountry(),
   };
 
 }
@@ -78,6 +109,9 @@ function mapDispatchToProps(dispatch) {
     },
     emailUpdate: (email: string) => {
       dispatch(setEmail(email));
+    },
+    stateFieldUpdate: (stateField: string) => {
+      dispatch(setStateField(stateField));
     },
     postcodeUpdate: (postcode: string) => {
       dispatch(setPostcode(postcode));

--- a/assets/pages/oneoff-contributions/components/formFields.jsx
+++ b/assets/pages/oneoff-contributions/components/formFields.jsx
@@ -31,34 +31,6 @@ type PropTypes = {
 };
 
 
-// ----- Functions ----- //
-
-function postcodeFieldFor(props: PropTypes) {
-  return (
-    <TextInput
-      id="postcode"
-      placeholder={props.isoCountry === 'US' ? 'Zip' : 'Postcode (optional)'}
-      value={props.postcode || ''}
-      onChange={props.postcodeUpdate}
-    />
-  );
-}
-
-function stateFieldIfRequiredFor(props: PropTypes) {
-  if (props.isoCountry === 'US') {
-    return (
-      <TextInput
-        id="state"
-        placeholder="State"
-        value={props.stateField || ''}
-        onChange={props.stateFieldUpdate}
-        required
-      />
-    );
-  }
-  return null;
-}
-
 // ----- Component ----- //
 
 function FormFields(props: PropTypes) {
@@ -79,8 +51,21 @@ function FormFields(props: PropTypes) {
         onChange={props.emailUpdate}
         required
       />
-      {stateFieldIfRequiredFor(props)}
-      {postcodeFieldFor(props)}
+      {props.isoCountry === 'US' ?
+        <TextInput
+          id="state"
+          placeholder="State"
+          value={props.stateField || ''}
+          onChange={props.stateFieldUpdate}
+          required
+        /> : null
+      }
+      <TextInput
+        id="postcode"
+        placeholder={`${props.isoCountry === 'US' ? 'Zip' : 'Postcode'} (optional)`}
+        value={props.postcode || ''}
+        onChange={props.postcodeUpdate}
+      />
     </form>
   );
 
@@ -96,7 +81,7 @@ function mapStateToProps(state) {
     email: state.user.email,
     stateField: state.user.stateField,
     postcode: state.user.postcode,
-    isoCountry: detectCountry(),
+    isoCountry: state.isoCountry || detectCountry(),
   };
 
 }

--- a/assets/pages/oneoff-contributions/oneoffContributions.jsx
+++ b/assets/pages/oneoff-contributions/oneoffContributions.jsx
@@ -57,6 +57,8 @@ store.dispatch(setPayPalButton(window.guardian.payPalType));
 
 const state: CombinedState = store.getState();
 
+const contribDescription: string = (country === 'US' ? 'one-time' : 'one-off');
+
 // ----- Render ----- //
 
 const content = (
@@ -66,10 +68,10 @@ const content = (
       <SimpleHeader />
       <div className="oneoff-contrib gu-content-filler__inner">
         <InfoSection className="oneoff-contrib__header">
-          <h1 className="oneoff-contrib__heading">Make a one-off contribution</h1>
+          <h1 className="oneoff-contrib__heading">{`Make a ${contribDescription} contribution`}</h1>
           <Secure />
         </InfoSection>
-        <InfoSection heading="Your one-off contribution" className="oneoff-contrib__your-contrib">
+        <InfoSection heading={`Your ${contribDescription} contribution`} className="oneoff-contrib__your-contrib">
           <PaymentAmount
             amount={state.oneoffContrib.amount}
             currency={state.oneoffContrib.currency}

--- a/conf/routes
+++ b/conf/routes
@@ -12,6 +12,7 @@ GET /                                               controllers.Default.redirect
 # ----- Contributions ----- #
 
 GET  /uk/contribute                                 controllers.Application.reactTemplate(title="Support the Guardian | Make a Contribution", id="contributions-landing-page-uk", js="contributionsLandingPageUK.js")
+GET  /us/contribute                                 controllers.Application.reactTemplate(title="Support the Guardian | Make a Contribution", id="contributions-landing-page-us", js="contributionsLandingPageUS.js")
 
 GET  /contribute/recurring                          controllers.MonthlyContributions.displayForm(paypal : Option[Boolean])
 GET  /contribute/recurring/thankyou                 controllers.Application.reactTemplate(title="Support the Guardian | Thank You", id="monthly-contributions-thankyou-page", js="monthlyContributionsThankyouPage.js")

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,5 +2,6 @@ User-agent: *
 
 Disallow: /uk/contribute
 Disallow: /contribute
+Disallow: /us/contribute
 
 Allow: /

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -49,6 +49,7 @@ module.exports = (env) => {
       styles: 'stylesheets/main.scss',
       bundlesLandingPage: 'pages/bundles-landing/bundlesLanding.jsx',
       contributionsLandingPageUK: 'pages/contributions-landing/contributionsLandingUK.jsx',
+      contributionsLandingPageUS: 'pages/contributions-landing/contributionsLandingUS.jsx',
       monthlyContributionsPage: 'pages/monthly-contributions/monthlyContributions.jsx',
       monthlyContributionsThankyouPage: 'pages/contributions-thankyou/monthlyContributionsThankyou.jsx',
       oneoffContributionsPage: 'pages/oneoff-contributions/oneoffContributions.jsx',


### PR DESCRIPTION
## Opening this PR early for feedback

## Why are you doing this?
We're going to have to accept US dollars for an up-coming test. Here, we're beginning to make use of the support code that came along in the `dollars` branch, from the UI's perspective.

Specifically, we're going to set the `isoCountry` page state property to `US` for the US contributions page, which will use existing shared components that are themselves able to change their appearance to confirm to US-centric expectations. To this end, we also set `isoCountry` to `GB` for the UK contribution page to ensure the same components work for the UK audience.

We'll expose the ~currency~ `isoCountry` value as a parameter to pages downstream from the landing page (primarily checkouts), and they can perform their own UI adaptations as a result.

Some of this will look _remarkably_ similar to the 'editionalisation' exploration PR here: https://github.com/guardian/support-frontend/pull/177
  
[**test-3-us-recurring-update-frontend-for-dollars**](https://trello.com/c/t4L9DPtI/699-test-3-us-recurring-update-frontend-for-dollars)

## Screenshots
![supportfrontenduscontribute720](https://user-images.githubusercontent.com/690395/29421301-8c63fc44-836c-11e7-85f5-9b54f355d6a5.gif)

