### PR TITLE
Purge Contributions Landing AB Test

### DIFF
--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -29,7 +29,6 @@ type PropTypes = {
   contribType: Contrib,
   contribAmount: Amounts,
   contribError: ContribError,
-  showMonthly: boolean,
   intCmp: string,
   toggleContribType: (string) => void,
   changeContribRecurringAmount: (string) => void,
@@ -56,12 +55,7 @@ const subHeadingText = {
   GB: `Support the Guardian’s editorial operations by making a
     monthly or one-off contribution today`,
   US: `Support the Guardian’s editorial operations by making a
-    regular or one-time contribution today`,
-};
-
-const oneOffSubHeadingText = {
-  GB: 'Support the Guardian’s editorial operations by making a one-off contribution today',
-  US: 'Support the Guardian’s editorial operations by making a one-time contribution today',
+    monthly or one-time contribution today`,
 };
 
 function contribAttrs(isoCountry: IsoCountry): ContribAttrs {
@@ -84,7 +78,7 @@ const ctaLinks = {
 // ----- Functions ----- //
 
 const getContribAttrs = ({
-  contribType, contribAmount, intCmp, showMonthly, isoCountry,
+  contribType, contribAmount, intCmp, isoCountry,
 }): ContribAttrs => {
 
   const contType = contribType === 'RECURRING' ? 'recurring' : 'oneOff';
@@ -99,13 +93,6 @@ const getContribAttrs = ({
   }
 
   const ctaLink = `${ctaLinks[contType]}?${params.toString()}`;
-
-  if (!showMonthly) {
-
-    const subheading = oneOffSubHeadingText[isoCountry];
-    return Object.assign({}, contribAttrs(isoCountry), { ctaLink, subheading });
-
-  }
 
   return Object.assign({}, contribAttrs(isoCountry), { ctaLink });
 
@@ -143,15 +130,11 @@ function ContributionsBundle(props: PropTypes) {
 
 function mapStateToProps(state) {
 
-  const showMonthly =
-    state.abTests.contributionsLandingAddingMonthly !== 'control';
-
   return {
-    contribType: showMonthly ? state.contribution.type : 'ONE_OFF',
+    contribType: state.contribution.type,
     contribAmount: state.contribution.amount,
     contribError: state.contribution.error,
     intCmp: state.intCmp,
-    showMonthly,
     isoCountry: state.isoCountry,
   };
 }

--- a/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/assets/pages/contributions-landing/contributionsLanding.scss
@@ -287,25 +287,4 @@
 		}
 	}
 
-	// ----- AB Test ----- //
-
-	.hide-monthly {
-		.contrib-type {
-			display: none;
-		}
-
-		.component-double-heading__subheading {
-			margin-bottom: $gu-v-spacing * 3;
-
-			@include mq($from: mobileLandscape) {
-				margin-bottom: 100px;
-			}
-		}
-
-		.component-contrib-amounts {
-			border-top: 1px dotted gu-colour(neutral-1);
-			padding-top: 7px;
-		}
-	}
-
 }

--- a/assets/pages/contributions-landing/contributionsLandingUK.jsx
+++ b/assets/pages/contributions-landing/contributionsLandingUK.jsx
@@ -34,11 +34,6 @@ const store = createStore(reducer, {
 store.dispatch({ type: 'SET_AB_TEST_PARTICIPATION', payload: participation });
 
 
-// ----- AB Test ----- //
-
-const showMonthly = participation.contributionsLandingAddingMonthly !== 'control';
-
-
 // ----- Render ----- //
 
 const content = (
@@ -46,7 +41,7 @@ const content = (
     <div className="gu-content">
       <SimpleHeader />
       <section className="contributions-bundle">
-        <div className={`contributions-bundle__content gu-content-margin ${showMonthly ? '' : 'hide-monthly'}`}>
+        <div className="contributions-bundle__content gu-content-margin">
           <ContributionsIntroduction />
           <ContributionsBundle />
         </div>

--- a/assets/pages/contributions-landing/contributionsLandingUS.jsx
+++ b/assets/pages/contributions-landing/contributionsLandingUS.jsx
@@ -34,11 +34,6 @@ const store = createStore(reducer, {
 store.dispatch({ type: 'SET_AB_TEST_PARTICIPATION', payload: participation });
 
 
-// ----- AB Test ----- //
-
-const showMonthly = participation.contributionsLandingAddingMonthly !== 'control';
-
-
 // ----- Render ----- //
 
 const content = (
@@ -46,7 +41,7 @@ const content = (
     <div className="gu-content">
       <SimpleHeader />
       <section className="contributions-bundle">
-        <div className={`contributions-bundle__content gu-content-margin ${showMonthly ? '' : 'hide-monthly'}`}>
+        <div className="contributions-bundle__content gu-content-margin">
           <ContributionsIntroduction />
           <ContributionsBundle />
         </div>


### PR DESCRIPTION
## Why are you doing this?

For Q2 Test 2 we were going to run an AB test on the contributions landing page as described in #143 and #147. This test would hide monthly contributions for the variant and show it for the control. We subsequently changed the parameters of that test, and didn't use this code. It's possible we might want to run a similar test in the future, but this test code is currently just hanging around and is starting to get duplicated for other versions of this page (see #185). Therefore, this PR removes it.

[**Trello Card**](https://trello.com/c/Ij2K9Wsz/821-remove-old-test-2-source-code-from-support-frontend)

## Changes

- Stopped using the `showMonthly` prop to hide and show content.
- Removed the CSS used to hide monthly contributions.
