### PR TITLE
Configure Prout to run post-deployment tests

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -3,6 +3,13 @@
         "PROD": {
             "url": "https://support.theguardian.com/uk",
             "overdue": "14M"
+            "afterSeen": {
+                "travis": {
+                    "config": {
+                        "script": "sbt ++$TRAVIS_SCALA_VERSION selenium-test"
+                    }
+                }
+            }
         }
     },
     "sentry": {

--- a/.prout.json
+++ b/.prout.json
@@ -2,7 +2,7 @@
     "checkpoints": {
         "PROD": {
             "url": "https://support.theguardian.com/uk",
-            "overdue": "14M"
+            "overdue": "14M",
             "afterSeen": {
                 "travis": {
                     "config": {


### PR DESCRIPTION
## Why are you doing this?

We added a post-deployment test in https://github.com/guardian/support-frontend/pull/184, and then made it configurable, such that it could be run locally by developers, or by Travis (see https://github.com/guardian/support-frontend/pull/186).

I've tried triggering the tests in Travis using the API - [in order to replicate the behaviour of Prout](https://github.com/guardian/prout/blob/master/app/lib/travis/TravisApiClient.scala#L86) - and everything worked (after a bit of trial and error).

So now we can allow Prout to trigger the test automatically after every release!

Note that this will currently only run a single test - sign-up for monthly contributions with Stripe.

[**Trello Card**](https://trello.com/c/BwKkbrMA/455-post-deployment-tests-for-monthly-contributions-support-frontend)

## Changes

* Add afterSeen config to Prout so that it runs post-deployment tests against prod whenever it sees a new build.

## Screenshots
N/A

cc @svillafe @Ap0c @JustinPinner 