### PR TITLE
Add State for US

### DIFF
--- a/app/controllers/MonthlyContributions.scala
+++ b/app/controllers/MonthlyContributions.scala
@@ -79,6 +79,7 @@ class MonthlyContributions(
       firstName = request.firstName,
       lastName = request.lastName,
       country = request.country,
+      state = request.state,
       allowMembershipMail = false,
       allowThirdPartyMail = user.statusFields.flatMap(_.receive3rdPartyMarketing).getOrElse(false),
       allowGURelatedMail = user.statusFields.flatMap(_.receiveGnmMarketing).getOrElse(false),

--- a/app/services/stepfunctions/MonthlyContributionsClient.scala
+++ b/app/services/stepfunctions/MonthlyContributionsClient.scala
@@ -34,6 +34,7 @@ case class CreateMonthlyContributorRequest(
   firstName: String,
   lastName: String,
   country: Country,
+  state: Option[String],
   contribution: Contribution,
   paymentFields: Either[StripePaymentToken, PayPalPaymentFields]
 )

--- a/app/services/stepfunctions/StateWrapper.scala
+++ b/app/services/stepfunctions/StateWrapper.scala
@@ -2,16 +2,18 @@ package services.stepfunctions
 
 import java.util.Base64
 
-import com.gu.support.workers.model.JsonWrapper
+import com.gu.support.workers.model.{ExecutionError, JsonWrapper}
 import io.circe.Encoder
 import io.circe.generic.semiauto.deriveEncoder
 import io.circe.syntax._
 
 class StateWrapper(encryption: EncryptionProvider) {
+  implicit private val executionErrorEncoder = deriveEncoder[ExecutionError]
+
   implicit private val wrapperEncoder = deriveEncoder[JsonWrapper]
 
   def wrap[T](state: T)(implicit encoder: Encoder[T]): String = {
-    JsonWrapper(encodeState(state)).asJson.noSpaces
+    JsonWrapper(encodeState(state), None).asJson.noSpaces
   }
 
   private def encodeState[T](state: T)(implicit encoder: Encoder[T]): String = encodeToBase64String(encryption.encrypt(state.asJson.noSpaces))

--- a/assets/components/selectInput/selectInput.jsx
+++ b/assets/components/selectInput/selectInput.jsx
@@ -1,0 +1,53 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+
+// ----- Types ----- //
+
+// Disabling the linter here because it's just buggy...
+// It can't handle props being passed to another function.
+/* eslint-disable react/no-unused-prop-types, react/require-default-props */
+
+export type SelectOption = {
+  text: string,
+  value: string,
+};
+
+/* eslint-enable react/no-unused-prop-types, react/require-default-props */
+
+type PropTypes = {
+  options: SelectOption[],
+  onChange: (value: string) => void,
+  required?: boolean,
+};
+
+
+// ----- Component ----- //
+
+export default function SelectInput(props: PropTypes) {
+
+  const options = props.options.map((option: SelectOption) =>
+    <option value={option.value}>{option.text}</option>,
+  );
+
+  return (
+    <select
+      className="component-select-input"
+      required={props.required}
+      onChange={event => props.onChange(event.target.value)}
+    >
+      {options}
+    </select>
+  );
+
+}
+
+
+// ----- Proptypes ----- //
+
+SelectInput.defaultProps = {
+  required: false,
+};

--- a/assets/components/selectInput/selectInput.scss
+++ b/assets/components/selectInput/selectInput.scss
@@ -1,0 +1,23 @@
+.component-select-input {
+	font-family: $gu-sans-web;
+	font-size: 14px;
+	color: gu-colour(neutral-1);
+	margin: 0 -2px 20px;
+	border: none;
+	border-radius: 600px;
+	height: $gu-v-spacing * 4;
+	padding: 0 $gu-h-spacing;
+	appearance: none;
+	background-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 7 14.13"><style>.st0{fill:#333333;}</style><path class="st0" d="M.55 3.84L0 3.29 3.28 0h.45L7 3.29l-.55.55-2.31-1.77v3.71H2.86V2.07L.55 3.84zM7 10.85l-3.28 3.28h-.44L0 10.85l.55-.58 2.31 1.77V8.35h1.28v3.69l2.31-1.77.55.58z"/></svg>');
+    background-repeat: no-repeat;
+    background-position: right 20px top 15px;
+    background-size: 9px;
+    // Fix for Safari 8.
+    background-color: #fff;
+
+	// Fix for IE.
+    &::-ms-expand {
+	    border: none;
+	    background-color: #fff;
+	}
+}

--- a/assets/components/textInput/textInput.scss
+++ b/assets/components/textInput/textInput.scss
@@ -2,8 +2,7 @@
 	font-family: $gu-sans-web;
 	font-size: 14px;
 	color: gu-colour(neutral-1);
-	margin-bottom: 20px;
-	margin: 0 -2px $gu-h-spacing;
+	margin: 0 -2px 20px;
 
 	input {
 		border: none;

--- a/assets/helpers/internationalisation/country.js
+++ b/assets/helpers/internationalisation/country.js
@@ -1,11 +1,87 @@
 // @flow
 
+// ----- Imports ----- //
+
 import { getQueryParameter } from 'helpers/url';
 import * as cookie from './../cookie';
+
+
+// ----- Types ----- //
 
 export type IsoCountry =
   | 'GB'
   | 'US';
+
+type usState = {
+  code: string,
+  name: string,
+};
+
+
+// ----- Setup ----- //
+
+const usStates: usState[] = [
+  { code: 'AA', name: 'Armed Forces America' },
+  { code: 'AE', name: 'Armed Forces' },
+  { code: 'AP', name: 'Armed Forces Pacific' },
+  { code: 'AK', name: 'Alaska' },
+  { code: 'AL', name: 'Alabama' },
+  { code: 'AR', name: 'Arkansas' },
+  { code: 'AZ', name: 'Arizona' },
+  { code: 'CA', name: 'California' },
+  { code: 'CO', name: 'Colorado' },
+  { code: 'CT', name: 'Connecticut' },
+  { code: 'DC', name: 'Washington DC (District of Columbia)' },
+  { code: 'DE', name: 'Delaware' },
+  { code: 'FL', name: 'Florida' },
+  { code: 'GA', name: 'Georgia' },
+  { code: 'GU', name: 'Guam' },
+  { code: 'HI', name: 'Hawaii' },
+  { code: 'IA', name: 'Iowa' },
+  { code: 'ID', name: 'Idaho' },
+  { code: 'IL', name: 'Illinois' },
+  { code: 'IN', name: 'Indiana' },
+  { code: 'KS', name: 'Kansas' },
+  { code: 'KY', name: 'Kentucky' },
+  { code: 'LA', name: 'Louisiana' },
+  { code: 'MA', name: 'Massachusetts' },
+  { code: 'MD', name: 'Maryland' },
+  { code: 'ME', name: 'Maine' },
+  { code: 'MI', name: 'Michigan' },
+  { code: 'MN', name: 'Minnesota' },
+  { code: 'MO', name: 'Missouri' },
+  { code: 'MS', name: 'Mississippi' },
+  { code: 'MT', name: 'Montana' },
+  { code: 'NC', name: 'North Carolina' },
+  { code: 'ND', name: 'North Dakota' },
+  { code: 'NE', name: 'Nebraska' },
+  { code: 'NH', name: 'New Hampshire' },
+  { code: 'NJ', name: 'New Jersey' },
+  { code: 'NM', name: 'New Mexico' },
+  { code: 'NV', name: 'Nevada' },
+  { code: 'NY', name: 'New York' },
+  { code: 'OH', name: 'Ohio' },
+  { code: 'OK', name: 'Oklahoma' },
+  { code: 'OR', name: 'Oregon' },
+  { code: 'PA', name: 'Pennsylvania' },
+  { code: 'PR', name: 'Puerto Rico' },
+  { code: 'RI', name: 'Rhode Island' },
+  { code: 'SC', name: 'South Carolina' },
+  { code: 'SD', name: 'South Dakota' },
+  { code: 'TN', name: 'Tennessee' },
+  { code: 'TX', name: 'Texas' },
+  { code: 'UT', name: 'Utah' },
+  { code: 'VA', name: 'Virginia' },
+  { code: 'VI', name: 'Virgin Islands' },
+  { code: 'VT', name: 'Vermont' },
+  { code: 'WA', name: 'Washington' },
+  { code: 'WI', name: 'Wisconsin' },
+  { code: 'WV', name: 'West Virginia' },
+  { code: 'WY', name: 'Wyoming' },
+];
+
+
+// ----- Functions ----- /
 
 function fromString(s: string): ?IsoCountry {
   switch (s.toLowerCase()) {
@@ -49,10 +125,17 @@ function fromGeolocation(): ?IsoCountry {
   return null;
 }
 
-export function detect(): IsoCountry {
+function detect(): IsoCountry {
   const country = fromPath() || fromQueryParameter() || fromCookie() || fromGeolocation() || 'GB';
   // cookie.set('GU_country', country, 7);
   // Always return GB because we aren't ready to support US quite yet
-  return 'GB' || country;
+  return country;
 }
 
+
+// ----- Exports ----- //
+
+export {
+  detect,
+  usStates,
+};

--- a/assets/helpers/internationalisation/country.js
+++ b/assets/helpers/internationalisation/country.js
@@ -11,9 +11,6 @@ import * as cookie from './../cookie';
 const usStates: {
   [string]: string,
 } = {
-  AA: 'Armed Forces America',
-  AE: 'Armed Forces',
-  AP: 'Armed Forces Pacific',
   AK: 'Alaska',
   AL: 'Alabama',
   AR: 'Arkansas',
@@ -68,6 +65,9 @@ const usStates: {
   WI: 'Wisconsin',
   WV: 'West Virginia',
   WY: 'Wyoming',
+  AA: 'Armed Forces America',
+  AE: 'Armed Forces',
+  AP: 'Armed Forces Pacific',
 };
 
 

--- a/assets/helpers/internationalisation/country.js
+++ b/assets/helpers/internationalisation/country.js
@@ -128,7 +128,7 @@ function detect(): IsoCountry {
   const country = fromPath() || fromQueryParameter() || fromCookie() || fromGeolocation() || 'GB';
   // cookie.set('GU_country', country, 7);
   // Always return GB because we aren't ready to support US quite yet
-  return country;
+  return 'GB' || country;
 }
 
 

--- a/assets/helpers/internationalisation/country.js
+++ b/assets/helpers/internationalisation/country.js
@@ -6,79 +6,78 @@ import { getQueryParameter } from 'helpers/url';
 import * as cookie from './../cookie';
 
 
+// ----- Setup ----- //
+
+const usStates: {
+  [string]: string,
+} = {
+  AA: 'Armed Forces America',
+  AE: 'Armed Forces',
+  AP: 'Armed Forces Pacific',
+  AK: 'Alaska',
+  AL: 'Alabama',
+  AR: 'Arkansas',
+  AZ: 'Arizona',
+  CA: 'California',
+  CO: 'Colorado',
+  CT: 'Connecticut',
+  DC: 'Washington DC (District of Columbia)',
+  DE: 'Delaware',
+  FL: 'Florida',
+  GA: 'Georgia',
+  GU: 'Guam',
+  HI: 'Hawaii',
+  IA: 'Iowa',
+  ID: 'Idaho',
+  IL: 'Illinois',
+  IN: 'Indiana',
+  KS: 'Kansas',
+  KY: 'Kentucky',
+  LA: 'Louisiana',
+  MA: 'Massachusetts',
+  MD: 'Maryland',
+  ME: 'Maine',
+  MI: 'Michigan',
+  MN: 'Minnesota',
+  MO: 'Missouri',
+  MS: 'Mississippi',
+  MT: 'Montana',
+  NC: 'North Carolina',
+  ND: 'North Dakota',
+  NE: 'Nebraska',
+  NH: 'New Hampshire',
+  NJ: 'New Jersey',
+  NM: 'New Mexico',
+  NV: 'Nevada',
+  NY: 'New York',
+  OH: 'Ohio',
+  OK: 'Oklahoma',
+  OR: 'Oregon',
+  PA: 'Pennsylvania',
+  PR: 'Puerto Rico',
+  RI: 'Rhode Island',
+  SC: 'South Carolina',
+  SD: 'South Dakota',
+  TN: 'Tennessee',
+  TX: 'Texas',
+  UT: 'Utah',
+  VA: 'Virginia',
+  VI: 'Virgin Islands',
+  VT: 'Vermont',
+  WA: 'Washington',
+  WI: 'Wisconsin',
+  WV: 'West Virginia',
+  WY: 'Wyoming',
+};
+
+
 // ----- Types ----- //
 
 export type IsoCountry =
   | 'GB'
   | 'US';
 
-type usState = {
-  code: string,
-  name: string,
-};
-
-
-// ----- Setup ----- //
-
-const usStates: usState[] = [
-  { code: 'AA', name: 'Armed Forces America' },
-  { code: 'AE', name: 'Armed Forces' },
-  { code: 'AP', name: 'Armed Forces Pacific' },
-  { code: 'AK', name: 'Alaska' },
-  { code: 'AL', name: 'Alabama' },
-  { code: 'AR', name: 'Arkansas' },
-  { code: 'AZ', name: 'Arizona' },
-  { code: 'CA', name: 'California' },
-  { code: 'CO', name: 'Colorado' },
-  { code: 'CT', name: 'Connecticut' },
-  { code: 'DC', name: 'Washington DC (District of Columbia)' },
-  { code: 'DE', name: 'Delaware' },
-  { code: 'FL', name: 'Florida' },
-  { code: 'GA', name: 'Georgia' },
-  { code: 'GU', name: 'Guam' },
-  { code: 'HI', name: 'Hawaii' },
-  { code: 'IA', name: 'Iowa' },
-  { code: 'ID', name: 'Idaho' },
-  { code: 'IL', name: 'Illinois' },
-  { code: 'IN', name: 'Indiana' },
-  { code: 'KS', name: 'Kansas' },
-  { code: 'KY', name: 'Kentucky' },
-  { code: 'LA', name: 'Louisiana' },
-  { code: 'MA', name: 'Massachusetts' },
-  { code: 'MD', name: 'Maryland' },
-  { code: 'ME', name: 'Maine' },
-  { code: 'MI', name: 'Michigan' },
-  { code: 'MN', name: 'Minnesota' },
-  { code: 'MO', name: 'Missouri' },
-  { code: 'MS', name: 'Mississippi' },
-  { code: 'MT', name: 'Montana' },
-  { code: 'NC', name: 'North Carolina' },
-  { code: 'ND', name: 'North Dakota' },
-  { code: 'NE', name: 'Nebraska' },
-  { code: 'NH', name: 'New Hampshire' },
-  { code: 'NJ', name: 'New Jersey' },
-  { code: 'NM', name: 'New Mexico' },
-  { code: 'NV', name: 'Nevada' },
-  { code: 'NY', name: 'New York' },
-  { code: 'OH', name: 'Ohio' },
-  { code: 'OK', name: 'Oklahoma' },
-  { code: 'OR', name: 'Oregon' },
-  { code: 'PA', name: 'Pennsylvania' },
-  { code: 'PR', name: 'Puerto Rico' },
-  { code: 'RI', name: 'Rhode Island' },
-  { code: 'SC', name: 'South Carolina' },
-  { code: 'SD', name: 'South Dakota' },
-  { code: 'TN', name: 'Tennessee' },
-  { code: 'TX', name: 'Texas' },
-  { code: 'UT', name: 'Utah' },
-  { code: 'VA', name: 'Virginia' },
-  { code: 'VI', name: 'Virgin Islands' },
-  { code: 'VT', name: 'Vermont' },
-  { code: 'WA', name: 'Washington' },
-  { code: 'WI', name: 'Wisconsin' },
-  { code: 'WV', name: 'West Virginia' },
-  { code: 'WY', name: 'Wyoming' },
-];
+export type UsState = $Keys<typeof usStates>;
 
 
 // ----- Functions ----- /

--- a/assets/helpers/internationalisation/legal.js
+++ b/assets/helpers/internationalisation/legal.js
@@ -1,0 +1,22 @@
+// @flow
+
+// ----- Imports ----- //
+
+import type { IsoCountry } from './country';
+
+
+// ----- Terms & Conditions ----- //
+
+const termsLinks: {
+  [IsoCountry]: string,
+} = {
+  GB: 'https://www.theguardian.com/info/2016/apr/04/contribution-terms-and-conditions',
+  US: 'https://www.theguardian.com/info/2016/apr/07/us-contribution-terms-and-conditions',
+};
+
+
+// ----- Exports ----- //
+
+export {
+  termsLinks,
+};

--- a/assets/pages/monthly-contributions/components/formFields.jsx
+++ b/assets/pages/monthly-contributions/components/formFields.jsx
@@ -15,7 +15,7 @@ import {
 } from 'helpers/user/userActions';
 import { usStates } from 'helpers/internationalisation/country';
 
-import type { IsoCountry } from 'helpers/internationalisation/country';
+import type { IsoCountry, UsState } from 'helpers/internationalisation/country';
 import type { SelectOption } from 'components/selectInput/selectInput';
 
 
@@ -24,7 +24,7 @@ import type { SelectOption } from 'components/selectInput/selectInput';
 type PropTypes = {
   firstNameUpdate: (name: string) => void,
   lastNameUpdate: (name: string) => void,
-  stateUpdate: (value: string) => void,
+  stateUpdate: (value: UsState) => void,
   firstName: string,
   lastName: string,
   country: IsoCountry,
@@ -33,13 +33,16 @@ type PropTypes = {
 
 // ----- Functions ----- //
 
-function stateDropdown(country: IsoCountry, stateUpdate: string => void) {
+function stateDropdown(country: IsoCountry, stateUpdate: UsState => void) {
 
   if (country === 'US') {
 
-    const options: SelectOption[] = usStates.map(usState =>
-      ({ value: usState.code, text: usState.name }),
+    const options: SelectOption[] = Object.keys(usStates).map((stateCode: UsState) =>
+      ({ value: stateCode, text: usStates[stateCode] }),
     );
+
+    // Sets the initial state to the first in the dropdown.
+    stateUpdate(options[0].value);
 
     return <SelectInput onChange={stateUpdate} options={options} />;
 
@@ -98,7 +101,7 @@ function mapDispatchToProps(dispatch) {
     lastNameUpdate: (name: string) => {
       dispatch(setLastName(name));
     },
-    stateUpdate: (value: string) => {
+    stateUpdate: (value: UsState) => {
       dispatch(setStateField(value));
     },
   };

--- a/assets/pages/monthly-contributions/components/formFields.jsx
+++ b/assets/pages/monthly-contributions/components/formFields.jsx
@@ -6,11 +6,17 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import TextInput from 'components/textInput/textInput';
+import SelectInput from 'components/selectInput/selectInput';
 
 import {
   setFirstName,
   setLastName,
+  setStateField,
 } from 'helpers/user/userActions';
+import { usStates } from 'helpers/internationalisation/country';
+
+import type { IsoCountry } from 'helpers/internationalisation/country';
+import type { SelectOption } from 'components/selectInput/selectInput';
 
 
 // ----- Types ----- //
@@ -18,9 +24,30 @@ import {
 type PropTypes = {
   firstNameUpdate: (name: string) => void,
   lastNameUpdate: (name: string) => void,
+  stateUpdate: (value: string) => void,
   firstName: string,
   lastName: string,
+  country: IsoCountry,
 };
+
+
+// ----- Functions ----- //
+
+function stateDropdown(country: IsoCountry, stateUpdate: string => void) {
+
+  if (country === 'US') {
+
+    const options: SelectOption[] = usStates.map(usState =>
+      ({ value: usState.code, text: usState.name }),
+    );
+
+    return <SelectInput onChange={stateUpdate} options={options} />;
+
+  }
+
+  return null;
+
+}
 
 
 // ----- Component ----- //
@@ -43,6 +70,7 @@ function NameForm(props: PropTypes) {
         onChange={props.lastNameUpdate}
         required
       />
+      {stateDropdown(props.country, props.stateUpdate)}
     </form>
   );
 
@@ -56,6 +84,7 @@ function mapStateToProps(state) {
   return {
     firstName: state.user.firstName,
     lastName: state.user.lastName,
+    country: state.monthlyContrib.country,
   };
 
 }
@@ -68,6 +97,9 @@ function mapDispatchToProps(dispatch) {
     },
     lastNameUpdate: (name: string) => {
       dispatch(setLastName(name));
+    },
+    stateUpdate: (value: string) => {
+      dispatch(setStateField(value));
     },
   };
 

--- a/assets/pages/monthly-contributions/helpers/ajax.js
+++ b/assets/pages/monthly-contributions/helpers/ajax.js
@@ -4,6 +4,7 @@
 
 import { addQueryParamToURL } from 'helpers/url';
 import { routes } from 'helpers/routes';
+import type { IsoCountry, UsState } from 'helpers/internationalisation/country';
 import type { CombinedState } from '../reducers/reducers';
 
 import { checkoutError } from '../actions/monthlyContributionsActions';
@@ -19,8 +20,8 @@ type MonthlyContribFields = {
   paymentFields: {
     stripeToken: string,
   },
-  country: string,
-  state?: string,
+  country: IsoCountry,
+  state?: UsState,
   firstName: string,
   lastName: string,
 };

--- a/assets/pages/monthly-contributions/helpers/ajax.js
+++ b/assets/pages/monthly-contributions/helpers/ajax.js
@@ -20,6 +20,7 @@ type MonthlyContribFields = {
     stripeToken: string,
   },
   country: string,
+  state?: string,
   firstName: string,
   lastName: string,
 };
@@ -48,6 +49,10 @@ function requestData(paymentFieldName: PaymentField, token: string, getState: ()
       firstName: state.user.firstName,
       lastName: state.user.lastName,
     };
+
+    if (state.user.stateField) {
+      monthlyContribFields.state = state.user.stateField;
+    }
 
     return {
       method: 'POST',

--- a/assets/pages/monthly-contributions/monthlyContributions.jsx
+++ b/assets/pages/monthly-contributions/monthlyContributions.jsx
@@ -21,6 +21,7 @@ import ContribLegal from 'components/legal/contribLegal/contribLegal';
 import pageStartup from 'helpers/pageStartup';
 import { forCountry as currencyForCountry } from 'helpers/internationalisation/currency';
 import { detect as detectCountry } from 'helpers/internationalisation/country';
+import { termsLinks } from 'helpers/internationalisation/legal';
 import * as user from 'helpers/user/user';
 import { getQueryParameter } from 'helpers/url';
 import { parse as parseContrib } from 'helpers/contributions';
@@ -89,7 +90,7 @@ const content = (
         </InfoSection>
         <InfoSection className="monthly-contrib__payment-methods">
           <TermsPrivacy
-            termsLink="https://www.theguardian.com/info/2016/apr/04/contribution-terms-and-conditions"
+            termsLink={termsLinks[country]}
             privacyLink="https://www.theguardian.com/help/privacy-policy"
           />
           <ContribLegal />

--- a/assets/pages/monthly-contributions/monthlyContributions.jsx
+++ b/assets/pages/monthly-contributions/monthlyContributions.jsx
@@ -26,7 +26,7 @@ import { getQueryParameter } from 'helpers/url';
 import { parse as parseContrib } from 'helpers/contributions';
 
 import postCheckout from './helpers/ajax';
-import NameForm from './components/nameForm';
+import FormFields from './components/formFields';
 import PaymentMethodsContainer from './components/paymentMethodsContainer';
 import reducer from './reducers/reducers';
 import type { CombinedState } from './reducers/reducers';
@@ -78,7 +78,7 @@ const content = (
         </InfoSection>
         <InfoSection heading="Your details" className="monthly-contrib__your-details">
           <DisplayName />
-          <NameForm />
+          <FormFields />
         </InfoSection>
         <InfoSection heading="Payment methods" className="monthly-contrib__payment-methods">
           <PaymentMethodsContainer

--- a/assets/pages/monthly-contributions/monthlyContributions.scss
+++ b/assets/pages/monthly-contributions/monthlyContributions.scss
@@ -92,6 +92,17 @@
 				width: 304px;
 			}
 		}
+
+		.component-select-input {
+			width: 100%;
+			margin-top: 20px;
+			margin-bottom: 0;
+
+			@include mq($from: desktop) {
+				width: 304px;
+			}
+		}
+
 	}
 
 	// ----- Payment methods

--- a/assets/stylesheets/main.scss
+++ b/assets/stylesheets/main.scss
@@ -34,6 +34,7 @@
 @import '../components/textInput/textInput';
 @import '../components/testUserBanner/testUserBanner';
 @import '../components/secure/secure';
+@import '../components/selectInput/selectInput';
 @import '../components/socialShare/socialShare';
 @import '../components/svg/svg';
 @import '../components/video/video';

--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-stepfunctions" % "1.11.128",
   "org.typelevel" %% "cats" % "0.9.0",
   "play-circe" %% "play-circe" % "2.6-0.8.0",
-  "com.gu" %% "support-models" % "0.5",
+  "com.gu" %% "support-models" % "0.9",
   "com.gu" %% "support-config" % "0.7",
   "com.gu" %% "support-internationalisation" % "0.2",
   "io.circe" %% "circe-core" % circeVersion,


### PR DESCRIPTION
## Why are you doing this?

A requirement for having recurring contributions in the US is the addition of a state field. This PR adds the server-side code needed to send this field through to support-workers, and the client-side work that adds this field to the US version of the recurring contributions checkout. It also flips the terms and conditions back and forth between the US and UK.

cc: @Amohkhan

[**Trello Card**](https://trello.com/c/Rqfs2OJi/798-test-3-add-support-for-us-states)

## Changes

- Added `state` to the user fields sent through to Zuora.
- Updated the `support-models` library and fixed bugs caused by new version.
- Added a `selectInput` shared component for the state dropdown.
- Dropped redundant CSS rule from `textInput`.
- Added list of US states to the country helper and refactored to use the export convention we're now using.
- Added the state dropdown to the form fields.
- Updated the monthly contrib post to optional include state.

## Screenshots

**US Desktop:**

![recurring-us](https://user-images.githubusercontent.com/5131341/29621735-823f7e62-8819-11e7-9c5c-a4d66a15268f.png)

**US Mobile:**

![recurring-us-mobile](https://user-images.githubusercontent.com/5131341/29621747-89fdb024-8819-11e7-9235-63195458b8dd.png)

**UK:**

![recurring-uk](https://user-images.githubusercontent.com/5131341/29621762-8fa4c9e0-8819-11e7-89fe-d96a6e6db733.png)
