### PR TITLE
Re-jig payment CTAs on contribution landing page

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -7,20 +7,20 @@ import services.IdentityService
 
 import scala.concurrent.ExecutionContext
 import cats.implicits._
-import wiring.ApplicationConfiguration
 
 class Application(
     actionRefiners: CustomActionBuilders,
     val assets: AssetsResolver,
     identityService: IdentityService,
-    components: ControllerComponents
-)(implicit val ec: ExecutionContext) extends AbstractController(components) with ApplicationConfiguration {
+    components: ControllerComponents,
+    contributionsPayPalEndpoint: String
+)(implicit val ec: ExecutionContext) extends AbstractController(components) {
 
   import actionRefiners._
 
   implicit val ar = assets
   def contributionsLanding(title: String, id: String, js: String): Action[AnyContent] = CachedAction() {
-    Ok(views.html.contributionsLanding(title, id, js, appConfig.contributionsPayPalEndpoint))
+    Ok(views.html.contributionsLanding(title, id, js, contributionsPayPalEndpoint))
   }
 
   def reactTemplate(title: String, id: String, js: String): Action[AnyContent] = CachedAction() {

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -7,17 +7,22 @@ import services.IdentityService
 
 import scala.concurrent.ExecutionContext
 import cats.implicits._
+import wiring.ApplicationConfiguration
 
 class Application(
     actionRefiners: CustomActionBuilders,
     val assets: AssetsResolver,
     identityService: IdentityService,
     components: ControllerComponents
-)(implicit val ec: ExecutionContext) extends AbstractController(components) {
+)(implicit val ec: ExecutionContext) extends AbstractController(components) with ApplicationConfiguration {
 
   import actionRefiners._
 
   implicit val ar = assets
+  def contributionsLanding(title: String, id: String, js: String): Action[AnyContent] = CachedAction() {
+    Ok(views.html.contributionsLanding(title, id, js, appConfig.contributionsPayPalEndpoint))
+  }
+
   def reactTemplate(title: String, id: String, js: String): Action[AnyContent] = CachedAction() {
     Ok(views.html.react(title, id, js))
   }

--- a/app/views/contributionsLanding.scala.html
+++ b/app/views/contributionsLanding.scala.html
@@ -1,0 +1,14 @@
+@import assets.AssetsResolver
+@(title: String, id: String, js: String, contributionsPayPalEndpoint: String)(implicit assets: AssetsResolver)
+
+@scripts = {
+    <script type="text/javascript">
+        window.guardian = window.guardian || {};
+        window.guardian.contributionsPayPalEndpoint = "@contributionsPayPalEndpoint";
+    </script>
+    <script type="text/javascript" src="@assets(js)"></script>
+}
+
+@main(title = title, scripts = scripts) {
+    <main id="@id" class="gu-content-wrapper"></main>
+}

--- a/app/wiring/Controllers.scala
+++ b/app/wiring/Controllers.scala
@@ -12,7 +12,8 @@ trait Controllers {
     actionRefiners,
     assetsResolver,
     identityService,
-    controllerComponents
+    controllerComponents,
+    appConfig.contributionsPayPalEndpoint
   )
 
   lazy val monthlyContributionsController = new MonthlyContributions(

--- a/assets/components/payPalContributionButton/payPalContributionButton.jsx
+++ b/assets/components/payPalContributionButton/payPalContributionButton.jsx
@@ -15,15 +15,18 @@ type PropTypes = {
   intCmp?: string,
   isoCountry: IsoCountry,
   errorHandler: (string) => void,
+  canClick?: boolean,
 };
 
 function payWithPayPal(props: PropTypes) {
   return () => {
-    paypalContributionsRedirect(
-      Number(props.amount),
-      props.intCmp,
-      props.isoCountry,
-      props.errorHandler);
+    if (props.canClick) {
+      paypalContributionsRedirect(
+        Number(props.amount),
+        props.intCmp,
+        props.isoCountry,
+        props.errorHandler);
+    }
   };
 }
 
@@ -43,6 +46,7 @@ const PayPalContributionButton = (props: PropTypes) =>
 
 PayPalContributionButton.defaultProps = {
   intCmp: null,
+  canClick: true,
 };
 
 

--- a/assets/components/payPalContributionButton/payPalContributionButton.jsx
+++ b/assets/components/payPalContributionButton/payPalContributionButton.jsx
@@ -3,31 +3,32 @@
 // ----- Imports ----- //
 
 import React from 'react';
-import { connect } from 'react-redux';
 import Svg from 'components/svg/svg';
-
-import { payPalContributionsButtonClicked, paypalContributionsRedirect } from 'helpers/payPalContributionsCheckout/payPalContributionsCheckoutActions';
+import type { IsoCountry } from 'helpers/internationalisation/country';
+import { paypalContributionsRedirect } from 'helpers/payPalContributionsCheckout/payPalContributionsCheckout';
 
 
 // ---- Types ----- //
 
 type PropTypes = {
-  payWithPayPal: Function,
-  payPalPayClicked: boolean,
-  paypalContributionsRedirect: Function,
+  amount: string,
+  intCmp?: string,
+  isoCountry: IsoCountry,
+  errorHandler: (string) => void,
 };
 
+function payWithPayPal(props: PropTypes) {
+  return () => {
+    paypalContributionsRedirect(Number(props.amount), props.intCmp, props.isoCountry, props.errorHandler);
+  }
+}
 
 // ----- Component ----- //
 
 const PayPalContributionButton = (props: PropTypes) => {
 
-  if (props.payPalPayClicked) {
-    props.paypalContributionsRedirect();
-  }
-
   return (
-    <button className={'component-paypal-contribution-button'} onClick={props.payWithPayPal}>
+    <button className={'component-paypal-contribution-button'} onClick={payWithPayPal(props)}>
       <Svg svgName="paypal-p-logo" />
       <span>contribute with PayPal</span>
       <Svg svgName="arrow-right-straight" />
@@ -35,30 +36,13 @@ const PayPalContributionButton = (props: PropTypes) => {
 };
 
 
-// ----- Map State/Props ----- //
+// ----- Defaults ----- //
 
-function mapStateToProps(state) {
-
-  return {
-    payPalPayClicked: state.payPalContributionsCheckout.payPalPayClicked,
-  };
-
-}
-
-function mapDispatchToProps(dispatch) {
-
-  return {
-    payWithPayPal: () => {
-      dispatch(payPalContributionsButtonClicked());
-    },
-    paypalContributionsRedirect: () => {
-      dispatch(paypalContributionsRedirect());
-    },
-  };
-
-}
+PayPalContributionButton.defaultProps = {
+  intCmp: null,
+};
 
 
 // ----- Exports ----- //
 
-export default connect(mapStateToProps, mapDispatchToProps)(PayPalContributionButton);
+export default PayPalContributionButton;

--- a/assets/components/payPalContributionButton/payPalContributionButton.jsx
+++ b/assets/components/payPalContributionButton/payPalContributionButton.jsx
@@ -19,21 +19,24 @@ type PropTypes = {
 
 function payWithPayPal(props: PropTypes) {
   return () => {
-    paypalContributionsRedirect(Number(props.amount), props.intCmp, props.isoCountry, props.errorHandler);
-  }
+    paypalContributionsRedirect(
+      Number(props.amount),
+      props.intCmp,
+      props.isoCountry,
+      props.errorHandler);
+  };
 }
 
 // ----- Component ----- //
 
-const PayPalContributionButton = (props: PropTypes) => {
-
-  return (
+const PayPalContributionButton = (props: PropTypes) =>
+  (
     <button className={'component-paypal-contribution-button'} onClick={payWithPayPal(props)}>
       <Svg svgName="paypal-p-logo" />
       <span>contribute with PayPal</span>
       <Svg svgName="arrow-right-straight" />
-    </button>);
-};
+    </button>
+  );
 
 
 // ----- Defaults ----- //

--- a/assets/components/paymentMethods/paymentMethods.jsx
+++ b/assets/components/paymentMethods/paymentMethods.jsx
@@ -8,6 +8,7 @@ import StripePopUpButton from 'components/stripePopUpButton/stripePopUpButton';
 import PayPalExpressButton from 'components/payPalExpressButton/payPalExpressButton';
 import PayPalContributionButton from 'components/payPalContributionButton/payPalContributionButton';
 import ErrorMessage from 'components/errorMessage/errorMessage';
+import type { IsoCountry } from 'helpers/internationalisation/country';
 
 
 // ----- Types ----- //
@@ -25,6 +26,10 @@ type PropTypes = {
   payPalType: PayPalButtonType,
   stripeCallback: Function,
   payPalCallback: Function,
+  amount: string,
+  intCmp?: string,
+  isoCountry: IsoCountry,
+  payPalErrorHandler: (string) => void,
 };
 
 
@@ -41,7 +46,12 @@ export default function PaymentMethods(props: PropTypes) {
       payPalButton = <PayPalExpressButton callback={props.payPalCallback} />;
       break;
     case 'ContributionsCheckout':
-      payPalButton = <PayPalContributionButton callback={props.payPalCallback} />;
+      payPalButton = (<PayPalContributionButton
+        amount={props.amount}
+        intCmp={props.intCmp}
+        isoCountry={props.isoCountry}
+        errorHandler={props.payPalErrorHandler}
+      />);
       break;
     default:
       payPalButton = '';
@@ -64,3 +74,7 @@ export default function PaymentMethods(props: PropTypes) {
     </section>
   );
 }
+
+PaymentMethods.defaultProps = {
+  intCmp: null,
+};

--- a/assets/helpers/internationalisation/country.js
+++ b/assets/helpers/internationalisation/country.js
@@ -91,7 +91,7 @@ function fromString(s: string): ?IsoCountry {
   }
 }
 
-export function toGuCountryCode(isoCountry: IsoCountry): string {
+export function toCountryGroup(isoCountry: IsoCountry): string {
   switch (isoCountry) {
     case 'US': return 'us';
     default: return 'uk';

--- a/assets/helpers/internationalisation/country.js
+++ b/assets/helpers/internationalisation/country.js
@@ -16,6 +16,13 @@ function fromString(s: string): ?IsoCountry {
   }
 }
 
+export function toGuCountryCode(isoCountry: IsoCountry): string {
+  switch (isoCountry) {
+    case 'US': return 'us';
+    default: return 'uk';
+  }
+}
+
 function fromPath(path: string = window.location.pathname): ?IsoCountry {
   if (path.startsWith('/uk/')) {
     return 'GB';

--- a/assets/helpers/payPalContributionsCheckout/payPalContributionsCheckout.js
+++ b/assets/helpers/payPalContributionsCheckout/payPalContributionsCheckout.js
@@ -1,15 +1,12 @@
 // @flow
 
+// ----- Imports ----- //
+
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import { toGuCountryCode } from 'helpers/internationalisation/country';
 
-// ----- Types ----- //
 
-export type Action =
-  | { type: 'PAYPAL_PAY_CONTRIBUTIONS_CLICKED' }
-  | { type: 'PAYPAL_CONTRIBUTIONS_ERROR', message: string }
-  | { type: 'PAYPAL_CONTRIBUTIONS_SUBMIT' }
-  ;
+// ----- Types ----- //
 
 type PayPalPostData = {
   countryGroup: string,
@@ -18,21 +15,8 @@ type PayPalPostData = {
   supportRedirect: boolean,
 }
 
-// ----- Actions ----- //
 
-export function payPalContributionsButtonClicked(): Action {
-  return { type: 'PAYPAL_PAY_CONTRIBUTIONS_CLICKED' };
-}
-
-export function payPalContributionsSubmitPayment(): Action {
-  return { type: 'PAYPAL_CONTRIBUTIONS_SUBMIT' };
-}
-
-
-export function payPalContributionsError(message: string): Action {
-  return { type: 'PAYPAL_CONTRIBUTIONS_ERROR', message };
-}
-
+// ----- Functions ----- //
 
 export function paypalContributionsRedirect(
   amount: number,
@@ -58,7 +42,7 @@ export function paypalContributionsRedirect(
      ophanPageviewId: state.data.ophan.pageviewId,
      ophanBrowserId: state.data.ophan.browserId,
      ophanVisitId: state.data.ophan.visitId
-    */
+     */
   };
 
   const fetchOptions: Object = {

--- a/assets/helpers/payPalContributionsCheckout/payPalContributionsCheckout.js
+++ b/assets/helpers/payPalContributionsCheckout/payPalContributionsCheckout.js
@@ -3,7 +3,7 @@
 // ----- Imports ----- //
 
 import type { IsoCountry } from 'helpers/internationalisation/country';
-import { toGuCountryCode } from 'helpers/internationalisation/country';
+import { toCountryGroup } from 'helpers/internationalisation/country';
 
 
 // ----- Types ----- //
@@ -26,9 +26,9 @@ export function paypalContributionsRedirect(
 
   const PAYPAL_CONTRIBUTION_ENDPOINT:string = window.guardian.contributionsPayPalEndpoint;
 
-  const guCountry = toGuCountryCode(isoCountry);
+  const country = toCountryGroup(isoCountry);
   const postData: PayPalPostData = {
-    countryGroup: guCountry,
+    countryGroup: country,
     amount,
     intCmp,
     supportRedirect: true,

--- a/assets/helpers/payPalContributionsCheckout/payPalContributionsCheckoutActions.js
+++ b/assets/helpers/payPalContributionsCheckout/payPalContributionsCheckoutActions.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type { IsoCountry } from 'helpers/internationalisation/country';
-import { toGuCountryCode } from 'helpers/internationalisation/country';
+import { toCountryGroup } from 'helpers/internationalisation/country';
 
 // ----- Types ----- //
 
@@ -42,9 +42,9 @@ export function paypalContributionsRedirect(
 
   const PAYPAL_CONTRIBUTION_ENDPOINT:string = window.guardian.contributionsPayPalEndpoint;
 
-  const guCountry = toGuCountryCode(isoCountry);
+  const country = toCountryGroup(isoCountry);
   const postData: PayPalPostData = {
-    countryGroup: guCountry,
+    countryGroup: country,
     amount,
     intCmp,
     supportRedirect: true,

--- a/assets/pages/contributions-landing/actions/contributionsLandingActions.js
+++ b/assets/pages/contributions-landing/actions/contributionsLandingActions.js
@@ -12,6 +12,7 @@ export type Action =
   | { type: 'CHANGE_CONTRIB_AMOUNT', amount: Amount }
   | { type: 'CHANGE_CONTRIB_AMOUNT_RECURRING', amount: Amount }
   | { type: 'CHANGE_CONTRIB_AMOUNT_ONEOFF', amount: Amount }
+  | { type: 'PAYPAL_ERROR', message: string }
   ;
 
 
@@ -31,4 +32,8 @@ export function changeContribAmountRecurring(amount: Amount): Action {
 
 export function changeContribAmountOneOff(amount: Amount): Action {
   return { type: 'CHANGE_CONTRIB_AMOUNT_ONEOFF', amount };
+}
+
+export function payPalError(message: string): Action {
+  return { type: 'PAYPAL_ERROR', message };
 }

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -11,6 +11,7 @@ import { routes } from 'helpers/routes';
 import ContribAmounts from 'components/contribAmounts/contribAmounts';
 import type { Contrib, Amounts, ContribError } from 'helpers/contributions';
 import type { IsoCountry } from 'helpers/internationalisation/country';
+import PayPalContributionButton from 'components/payPalContributionButton/payPalContributionButton';
 
 import {
   changeContribType,
@@ -64,15 +65,31 @@ const oneOffSubHeadingText = {
   US: 'Support the Guardian’s editorial operations by making a one-time contribution today',
 };
 
-function contribAttrs(isoCountry: IsoCountry): ContribAttrs {
+function contribCtaText(contribType: Contrib): string {
+  switch (contribType) {
+    case 'RECURRING':
+      return 'Contribute with card or PayPal';
+    default:
+      return 'Contribute with credit/debit card';
+  }
+}
+
+function contribAttrs(isoCountry: IsoCountry, contribType: Contrib): ContribAttrs {
   return {
     heading: 'contribute',
     subheading: subHeadingText[isoCountry],
-    ctaText: 'Contribute',
+    ctaText: contribCtaText(contribType),
     modifierClass: 'contributions',
     ctaLink: '',
     showPaymentLogos: false,
   };
+}
+
+function showPayPal(props: PropTypes) {
+  switch (props.contribType) {
+    case 'ONE_OFF': return <PayPalContributionButton />;
+    default: return null;
+  }
 }
 
 const ctaLinks = {
@@ -103,11 +120,11 @@ const getContribAttrs = ({
   if (!showMonthly) {
 
     const subheading = oneOffSubHeadingText[isoCountry];
-    return Object.assign({}, contribAttrs(isoCountry), { ctaLink, subheading });
+    return Object.assign({}, contribAttrs(isoCountry, contribType), { ctaLink, subheading });
 
   }
 
-  return Object.assign({}, contribAttrs(isoCountry), { ctaLink });
+  return Object.assign({}, contribAttrs(isoCountry, contribType), { ctaLink });
 
 };
 
@@ -125,7 +142,6 @@ function ContributionsBundle(props: PropTypes) {
       window.location = attrs.ctaLink;
     }
   };
-
   return (
     <Bundle {...attrs}>
       <ContribAmounts
@@ -133,6 +149,7 @@ function ContributionsBundle(props: PropTypes) {
         {...props}
       />
       <CtaLink text={attrs.ctaText} onClick={onClick} id="qa-contribute-button" />
+      {showPayPal(props)}
     </Bundle>
   );
 

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -63,20 +63,16 @@ const subHeadingText = {
     monthly or one-time contribution today`,
 };
 
-function contribCtaText(contribType: Contrib): string {
-  switch (contribType) {
-    case 'RECURRING':
-      return 'Contribute with card or PayPal';
-    default:
-      return 'Contribute with credit/debit card';
-  }
-}
+const contribCtaText = {
+  RECURRING: 'Contribute with card or PayPal',
+  ONE_OFF: 'Contribute with debit/credit card',
+};
 
 function contribAttrs(isoCountry: IsoCountry, contribType: Contrib): ContribAttrs {
   return {
     heading: 'contribute',
     subheading: subHeadingText[isoCountry],
-    ctaText: contribCtaText(contribType),
+    ctaText: contribCtaText[contribType],
     modifierClass: 'contributions',
     ctaLink: '',
     showPaymentLogos: false,

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -115,8 +115,7 @@ const getContribAttrs = ({
   const params = new URLSearchParams();
 
   params.append('contributionValue', contribAmount[contType].value);
-  // TODO: uncomment when ready for US traffic
-  // params.append('country', isoCountry);
+  params.append('country', isoCountry);
 
   if (intCmp) {
     params.append('INTCMP', intCmp);

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -97,6 +97,14 @@ function showPayPal(props: PropTypes) {
   }
 }
 
+function showPayPalError(props: PropTypes) {
+  switch (props.contribType) {
+    case 'ONE_OFF':
+      return (props.payPalError ? <ErrorMessage message={props.payPalError} /> : null);
+    default: return null;
+  }
+}
+
 const ctaLinks = {
   recurring: routes.recurringContribCheckout,
   oneOff: routes.oneOffContribCheckout,
@@ -149,7 +157,7 @@ function ContributionsBundle(props: PropTypes) {
       />
       <CtaLink text={attrs.ctaText} onClick={onClick} id="qa-contribute-button" />
       {showPayPal(props)}
-      {props.payPalError ? <ErrorMessage message={props.payPalError} /> : null}
+      {showPayPalError(props)}
     </Bundle>
   );
 

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -85,12 +85,14 @@ function contribAttrs(isoCountry: IsoCountry, contribType: Contrib): ContribAttr
 
 function showPayPal(props: PropTypes) {
   switch (props.contribType) {
-    case 'ONE_OFF': return (<PayPalContributionButton
-      amount={props.contribAmount.oneOff.value}
-      intCmp={props.intCmp}
-      isoCountry={props.isoCountry}
-      errorHandler={props.payPalErrorHandler}
-    />);
+    case 'ONE_OFF':
+      return (<PayPalContributionButton
+        amount={props.contribAmount.oneOff.value}
+        intCmp={props.intCmp}
+        isoCountry={props.isoCountry}
+        errorHandler={props.payPalErrorHandler}
+        canClick={!props.contribError}
+      />);
     default: return null;
   }
 }

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 
 import CtaLink from 'components/ctaLink/ctaLink';
 import Bundle from 'components/bundle/bundle';
+import ErrorMessage from 'components/errorMessage/errorMessage';
 import { routes } from 'helpers/routes';
 import ContribAmounts from 'components/contribAmounts/contribAmounts';
 import type { Contrib, Amounts, ContribError } from 'helpers/contributions';
@@ -18,6 +19,7 @@ import {
   changeContribAmount,
   changeContribAmountRecurring,
   changeContribAmountOneOff,
+  payPalError,
 } from '../actions/contributionsLandingActions';
 
 
@@ -36,6 +38,8 @@ type PropTypes = {
   changeContribOneOffAmount: (string) => void,
   changeContribAmount: (string) => void,
   isoCountry: IsoCountry,
+  payPalErrorHandler: (string) => void,
+  payPalError: ?string,
 };
 
 /* eslint-enable react/no-unused-prop-types */
@@ -81,7 +85,12 @@ function contribAttrs(isoCountry: IsoCountry, contribType: Contrib): ContribAttr
 
 function showPayPal(props: PropTypes) {
   switch (props.contribType) {
-    case 'ONE_OFF': return <PayPalContributionButton />;
+    case 'ONE_OFF': return (<PayPalContributionButton
+      amount={props.contribAmount.oneOff.value}
+      intCmp={props.intCmp}
+      isoCountry={props.isoCountry}
+      errorHandler={props.payPalErrorHandler}
+    />);
     default: return null;
   }
 }
@@ -138,6 +147,7 @@ function ContributionsBundle(props: PropTypes) {
       />
       <CtaLink text={attrs.ctaText} onClick={onClick} id="qa-contribute-button" />
       {showPayPal(props)}
+      {props.payPalError ? <ErrorMessage message={props.payPalError} /> : null}
     </Bundle>
   );
 
@@ -154,6 +164,7 @@ function mapStateToProps(state) {
     contribError: state.contribution.error,
     intCmp: state.intCmp,
     isoCountry: state.isoCountry,
+    payPalError: state.contribution.payPalError,
   };
 }
 
@@ -171,6 +182,9 @@ function mapDispatchToProps(dispatch) {
     },
     changeContribAmount: (value: string) => {
       dispatch(changeContribAmount({ value, userDefined: true }));
+    },
+    payPalErrorHandler: (message: string) => {
+      dispatch(payPalError(message));
     },
   };
 

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -80,25 +80,23 @@ function contribAttrs(isoCountry: IsoCountry, contribType: Contrib): ContribAttr
 }
 
 function showPayPal(props: PropTypes) {
-  switch (props.contribType) {
-    case 'ONE_OFF':
-      return (<PayPalContributionButton
-        amount={props.contribAmount.oneOff.value}
-        intCmp={props.intCmp}
-        isoCountry={props.isoCountry}
-        errorHandler={props.payPalErrorHandler}
-        canClick={!props.contribError}
-      />);
-    default: return null;
+  if (props.contribType === 'ONE_OFF') {
+    return (<PayPalContributionButton
+      amount={props.contribAmount.oneOff.value}
+      intCmp={props.intCmp}
+      isoCountry={props.isoCountry}
+      errorHandler={props.payPalErrorHandler}
+      canClick={!props.contribError}
+    />);
   }
+  return null;
 }
 
 function showPayPalError(props: PropTypes) {
-  switch (props.contribType) {
-    case 'ONE_OFF':
-      return (props.payPalError ? <ErrorMessage message={props.payPalError} /> : null);
-    default: return null;
+  if (props.contribType === 'ONE_OFF') {
+    return (props.payPalError ? <ErrorMessage message={props.payPalError} /> : null);
   }
+  return null;
 }
 
 const ctaLinks = {

--- a/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/assets/pages/contributions-landing/contributionsLanding.scss
@@ -262,7 +262,7 @@
 		height: auto;
 		width: 100%;
 		line-height: 180%;
-		margin-top: 12px;
+		margin-top: $gu-v-spacing;
 		position: relative;
 		text-align: left;
 		text-decoration: none;

--- a/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/assets/pages/contributions-landing/contributionsLanding.scss
@@ -249,6 +249,39 @@
 	    }
 	}
 
+	// ----- PayPal button & error message ----- //
+
+	.component-paypal-contribution-button {
+		padding-top: 17px;
+		padding-bottom: 17px;
+		cursor: pointer;
+		display: block;
+		font-family: $gu-text-sans-web;
+		font-size: 14px;
+		font-weight: bold;
+		height: auto;
+		width: 100%;
+		line-height: 180%;
+		margin-top: 12px;
+		position: relative;
+		text-align: left;
+		text-decoration: none;
+		vertical-align: bottom;
+		margin-bottom: $gu-v-spacing;
+	}
+
+	.component-error-message {
+		height: auto;
+		width: auto;
+		background-color: gu-colour(error);
+		padding-top: $gu-v-spacing * 2.5;
+		padding-bottom: $gu-v-spacing * 2.5;
+
+		span {
+			margin-right: $gu-h-spacing;
+		}
+	}
+
 	// ----- Legal Copy ----- //
 
 	.contributions-legal {
@@ -267,6 +300,15 @@
 		@include mq($from: desktop) {
 			padding-top: $gu-v-spacing * 2;
 		}
+
+		@include mq($from: desktop, $until: leftCol) {
+			padding-bottom: $gu-v-spacing * 9;
+		}
+
+		@include mq($from: leftCol) {
+			padding-bottom: $gu-v-spacing * 12;
+		}
+
 	}
 
 	.component-contrib-legal {

--- a/assets/pages/contributions-landing/contributionsLandingUK.jsx
+++ b/assets/pages/contributions-landing/contributionsLandingUK.jsx
@@ -4,7 +4,8 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { createStore } from 'redux';
+import { createStore, applyMiddleware } from 'redux';
+import thunkMiddleware from 'redux-thunk';
 import { Provider } from 'react-redux';
 
 import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
@@ -29,7 +30,7 @@ const participation = pageStartup.start();
 const store = createStore(reducer, {
   intCmp: getQueryParameter('INTCMP'),
   isoCountry: 'GB',
-});
+}, applyMiddleware(thunkMiddleware));
 
 store.dispatch({ type: 'SET_AB_TEST_PARTICIPATION', payload: participation });
 

--- a/assets/pages/contributions-landing/contributionsLandingUS.jsx
+++ b/assets/pages/contributions-landing/contributionsLandingUS.jsx
@@ -4,7 +4,8 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { createStore } from 'redux';
+import { createStore, applyMiddleware } from 'redux';
+import thunkMiddleware from 'redux-thunk';
 import { Provider } from 'react-redux';
 
 import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
@@ -29,7 +30,7 @@ const participation = pageStartup.start();
 const store = createStore(reducer, {
   intCmp: getQueryParameter('INTCMP'),
   isoCountry: 'US',
-});
+}, applyMiddleware(thunkMiddleware));
 
 store.dispatch({ type: 'SET_AB_TEST_PARTICIPATION', payload: participation });
 

--- a/assets/pages/contributions-landing/reducers/__tests__/__snapshots__/reducersTest.js.snap
+++ b/assets/pages/contributions-landing/reducers/__tests__/__snapshots__/reducersTest.js.snap
@@ -56,6 +56,7 @@ Object {
       },
     },
     "error": null,
+    "payPalError": null,
     "type": "RECURRING",
   },
   "intCmp": null,

--- a/assets/pages/contributions-landing/reducers/reducers.js
+++ b/assets/pages/contributions-landing/reducers/reducers.js
@@ -19,6 +19,7 @@ export type ContribState = {
   type: Contrib,
   error: ?ContribError,
   amount: Amounts,
+  payPalError: ?string,
 };
 
 
@@ -37,6 +38,7 @@ const initialContrib: ContribState = {
       userDefined: false,
     },
   },
+  payPalError: null,
 };
 
 
@@ -84,6 +86,12 @@ function contribution(
       return Object.assign({}, state, {
         amount: { recurring: state.amount.recurring, oneOff: action.amount },
         error: parseContribution(action.amount.value, state.type).error,
+      });
+
+    case 'PAYPAL_ERROR':
+
+      return Object.assign({}, state, {
+        payPalError: action.message,
       });
 
     default:

--- a/assets/pages/oneoff-contributions/components/paymentMethodsContainer.jsx
+++ b/assets/pages/oneoff-contributions/components/paymentMethodsContainer.jsx
@@ -4,6 +4,8 @@
 
 import { connect } from 'react-redux';
 import PaymentMethods from 'components/paymentMethods/paymentMethods';
+import { checkoutError } from '../actions/oneoffContributionsActions';
+
 
 // ----- Map State/Props ----- //
 
@@ -13,11 +15,21 @@ function mapStateToProps(state) {
     email: state.user.email,
     error: state.oneoffContrib.error,
     hide: state.user.email === '' || state.user.fullName === '',
+    amount: state.oneoffContrib.amount,
+    intCmp: state.intCmp,
+    isoCountry: state.oneoffContrib.country,
   };
 
 }
 
+function mapDispatchToProps(dispatch) {
+  return {
+    payPalErrorHandler: (message: string) => {
+      dispatch(checkoutError(message));
+    },
+  };
+}
 
 // ----- Exports ----- //
 
-export default connect(mapStateToProps)(PaymentMethods);
+export default connect(mapStateToProps, mapDispatchToProps)(PaymentMethods);

--- a/conf/routes
+++ b/conf/routes
@@ -11,8 +11,8 @@ GET /                                               controllers.Default.redirect
 
 # ----- Contributions ----- #
 
-GET  /uk/contribute                                 controllers.Application.reactTemplate(title="Support the Guardian | Make a Contribution", id="contributions-landing-page-uk", js="contributionsLandingPageUK.js")
-GET  /us/contribute                                 controllers.Application.reactTemplate(title="Support the Guardian | Make a Contribution", id="contributions-landing-page-us", js="contributionsLandingPageUS.js")
+GET  /uk/contribute                                 controllers.Application.contributionsLanding(title="Support the Guardian | Make a Contribution", id="contributions-landing-page-uk", js="contributionsLandingPageUK.js")
+GET  /us/contribute                                 controllers.Application.contributionsLanding(title="Support the Guardian | Make a Contribution", id="contributions-landing-page-us", js="contributionsLandingPageUS.js")
 
 GET  /contribute/recurring                          controllers.MonthlyContributions.displayForm(paypal : Option[Boolean])
 GET  /contribute/recurring/thankyou                 controllers.Application.reactTemplate(title="Support the Guardian | Thank You", id="monthly-contributions-thankyou-page", js="monthlyContributionsThankyouPage.js")

--- a/test/controllers/ApplicationTest.scala
+++ b/test/controllers/ApplicationTest.scala
@@ -31,17 +31,19 @@ class ApplicationTest extends WordSpec with MustMatchers with TestCSRFComponents
     csrfConfig = csrfConfig
   )
 
+  val contributionsPayPalEndpoint = ""
+
   "/healthcheck" should {
     "return healthy" in {
       val result = new Application(
-        actionRefiner, mock[AssetsResolver], mock[IdentityService], stubControllerComponents()
+        actionRefiner, mock[AssetsResolver], mock[IdentityService], stubControllerComponents(), contributionsPayPalEndpoint
       )(mock[ExecutionContext]).healthcheck.apply(FakeRequest())
       contentAsString(result) mustBe "healthy"
     }
 
     "not be cached" in {
       val result = new Application(
-        actionRefiner, mock[AssetsResolver], mock[IdentityService], stubControllerComponents()
+        actionRefiner, mock[AssetsResolver], mock[IdentityService], stubControllerComponents(), contributionsPayPalEndpoint
       )(mock[ExecutionContext]).healthcheck.apply(FakeRequest())
       header("Cache-Control", result) mustBe Some("no-cache, private")
     }


### PR DESCRIPTION
## Why are you doing this?
Primarily for the up-coming US test (test 3) and for one-off contributions only. PayPal is popular with US readers, and eliminating an unnecessary trip to a checkout page will likely help boost conversions.

Trello: [**re-jig-payment-ctas-on-contributions-landing-page**](https://trello.com/c/WFb6grJY/816-re-jig-payment-ctas-on-contributions-landing-page)

## Screenshots
![supportfrontend-us-contributelandingpaypal720](https://user-images.githubusercontent.com/690395/29621581-1b446650-8819-11e7-8a9d-782301219d13.gif)

cc @Ap0c @svillafe 