### PR TITLE
Remove State For One-Off Contributions

### DIFF
--- a/assets/pages/oneoff-contributions/components/formFields.jsx
+++ b/assets/pages/oneoff-contributions/components/formFields.jsx
@@ -5,14 +5,12 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import type { IsoCountry } from 'helpers/internationalisation/country';
-import { detect as detectCountry } from 'helpers/internationalisation/country';
 import TextInput from 'components/textInput/textInput';
 
 import {
   setFullName,
   setEmail,
   setPostcode,
-  setStateField,
 } from 'helpers/user/userActions';
 
 
@@ -22,11 +20,9 @@ type PropTypes = {
   nameUpdate: (name: string) => void,
   emailUpdate: (email: string) => void,
   postcodeUpdate: (postcode: string) => void,
-  stateFieldUpdate: (stateField: string) => void,
   name: string,
   email: string,
   postcode: ?string,
-  stateField: string,
   isoCountry: IsoCountry,
 };
 
@@ -51,15 +47,6 @@ function FormFields(props: PropTypes) {
         onChange={props.emailUpdate}
         required
       />
-      {props.isoCountry === 'US' ?
-        <TextInput
-          id="state"
-          placeholder="State"
-          value={props.stateField || ''}
-          onChange={props.stateFieldUpdate}
-          required
-        /> : null
-      }
       <TextInput
         id="postcode"
         placeholder={`${props.isoCountry === 'US' ? 'Zip' : 'Postcode'} (optional)`}
@@ -79,9 +66,8 @@ function mapStateToProps(state) {
   return {
     name: state.user.fullName,
     email: state.user.email,
-    stateField: state.user.stateField,
     postcode: state.user.postcode,
-    isoCountry: state.isoCountry || detectCountry(),
+    isoCountry: state.isoCountry,
   };
 
 }
@@ -94,9 +80,6 @@ function mapDispatchToProps(dispatch) {
     },
     emailUpdate: (email: string) => {
       dispatch(setEmail(email));
-    },
-    stateFieldUpdate: (stateField: string) => {
-      dispatch(setStateField(stateField));
     },
     postcodeUpdate: (postcode: string) => {
       dispatch(setPostcode(postcode));


### PR DESCRIPTION
## Why are you doing this?

This isn't required for one-off, and we want to have as few fields as possible on the checkouts. However, the rest of the code managing US state is used for recurring contributions as of #189, so this PR just modifies the component that displays it for the one-off checkout.

[**Trello Card**](https://trello.com/c/c175orpo/827-remove-state-for-one-off-contributions)

## Changes

- Removed state for one-off contributions form fields.

## Screenshots

**Before (US):**

![state-before](https://user-images.githubusercontent.com/5131341/29626778-c65746a8-8827-11e7-9c9b-754086f1773a.png)

**After (US):**

![state-after](https://user-images.githubusercontent.com/5131341/29626782-ca34baee-8827-11e7-8928-f3a841b99f7d.png)
