### PR TITLE
Flip-Flop One-Off Terms For US

### DIFF
--- a/assets/pages/oneoff-contributions/oneoffContributions.jsx
+++ b/assets/pages/oneoff-contributions/oneoffContributions.jsx
@@ -20,6 +20,7 @@ import ContribLegal from 'components/legal/contribLegal/contribLegal';
 import pageStartup from 'helpers/pageStartup';
 import { forCountry as currencyForCountry } from 'helpers/internationalisation/currency';
 import { detect as detectCountry } from 'helpers/internationalisation/country';
+import { termsLinks } from 'helpers/internationalisation/legal';
 import * as user from 'helpers/user/user';
 import { getQueryParameter } from 'helpers/url';
 import { parse as parseContrib } from 'helpers/contributions';
@@ -89,7 +90,7 @@ const content = (
         </InfoSection>
         <InfoSection className="oneoff-contrib__payment-methods">
           <TermsPrivacy
-            termsLink="https://www.theguardian.com/info/2016/apr/04/contribution-terms-and-conditions"
+            termsLink={termsLinks[country]}
             privacyLink="https://www.theguardian.com/help/privacy-policy"
           />
           <ContribLegal />


### PR DESCRIPTION
## Why are you doing this?

The contributions terms for the US are different and sit on a different URL. This changes the link on the one-off contributions checkout page based upon country.

[**Trello Card**](https://trello.com/c/Y3N3ePg2/824-flip-flop-one-off-terms-for-us)

## Changes

- Flipped contributions terms link based on country.