### PR TITLE
Checkout Legal Copy Design Tweaks

### DIFF
--- a/assets/pages/monthly-contributions/monthlyContributions.jsx
+++ b/assets/pages/monthly-contributions/monthlyContributions.jsx
@@ -63,10 +63,10 @@ const state: CombinedState = store.getState();
 
 const content = (
   <Provider store={store}>
-    <div className="gu-content gu-content-filler">
+    <div className="gu-content">
       <TestUserBanner />
       <SimpleHeader />
-      <div className="monthly-contrib gu-content-filler__inner">
+      <div className="monthly-contrib gu-content-margin">
         <InfoSection className="monthly-contrib__header">
           <h1 className="monthly-contrib__heading">Make a monthly contribution</h1>
           <Secure />
@@ -88,7 +88,9 @@ const content = (
             payPalType={state.monthlyContrib.payPalType}
           />
         </InfoSection>
-        <InfoSection className="monthly-contrib__payment-methods">
+      </div>
+      <div className="terms-privacy gu-content-filler">
+        <InfoSection className="terms-privacy__content gu-content-filler__inner">
           <TermsPrivacy
             termsLink={termsLinks[country]}
             privacyLink="https://www.theguardian.com/help/privacy-policy"

--- a/assets/pages/monthly-contributions/monthlyContributions.scss
+++ b/assets/pages/monthly-contributions/monthlyContributions.scss
@@ -120,8 +120,24 @@
 
 	// ----- Legal ----- //
 
+	.terms-privacy {
+		background-color: darken(#fff, 5%);
+
+		.component-info-section__content {
+			@include mq($from: desktop) {
+				width: 550px;
+			}
+		}
+	}
+
+	.terms-privacy__content {
+		background-color: #fff;
+		padding-top: $gu-v-spacing;
+	}
+
 	.component-contrib-legal {
 		padding-top: $gu-v-spacing;
+		padding-bottom: $gu-v-spacing * 2;
 	}
 
 }

--- a/assets/pages/oneoff-contributions/oneoffContributions.jsx
+++ b/assets/pages/oneoff-contributions/oneoffContributions.jsx
@@ -66,7 +66,7 @@ const content = (
     <div className="gu-content">
       <TestUserBanner />
       <SimpleHeader />
-      <div className="oneoff-contrib gu-content-filler__inner">
+      <div className="oneoff-contrib gu-content-margin">
         <InfoSection className="oneoff-contrib__header">
           <h1 className="oneoff-contrib__heading">{`Make a ${contribDescription} contribution`}</h1>
           <Secure />
@@ -87,7 +87,9 @@ const content = (
             payPalType={store.getState().oneoffContrib.payPalType}
           />
         </InfoSection>
-        <InfoSection className="oneoff-contrib__payment-methods">
+      </div>
+      <div className="terms-privacy gu-content-filler">
+        <InfoSection className="terms-privacy__content gu-content-filler__inner">
           <TermsPrivacy
             termsLink="https://www.theguardian.com/info/2016/apr/04/contribution-terms-and-conditions"
             privacyLink="https://www.theguardian.com/help/privacy-policy"

--- a/assets/pages/oneoff-contributions/oneoffContributions.scss
+++ b/assets/pages/oneoff-contributions/oneoffContributions.scss
@@ -90,8 +90,24 @@
 
 	// ----- Legal ----- //
 
+	.terms-privacy {
+		background-color: darken(#fff, 5%);
+
+		.component-info-section__content {
+			@include mq($from: desktop) {
+				width: 550px;
+			}
+		}
+	}
+
+	.terms-privacy__content {
+		background-color: #fff;
+		padding-top: $gu-v-spacing;
+	}
+
 	.component-contrib-legal {
 		padding-top: $gu-v-spacing;
+		padding-bottom: $gu-v-spacing * 2;
 	}
 
 }


### PR DESCRIPTION
## Why are you doing this?

The legal copy on the checkouts was too wide. This narrows it and changes the background to white. It also reworks the use of `gu-content-filler` as introduced in #133.

cc: @Amohkhan

[**Trello Card**](https://trello.com/c/4CBfzocI/763-contributions-legal-copy)

## Changes

- Narrowed the contributions legal copy.
- Made the legal copy background white.
- Properly applied `gu-content-filler`.

## Screenshots

**One-Off Desktop:**

![oneoff-desktop](https://user-images.githubusercontent.com/5131341/29676433-fab1e6ec-88ef-11e7-8eb0-40edff7b2f66.png)

**One-Off Tablet:**

![oneoff-tablet](https://user-images.githubusercontent.com/5131341/29676458-0b5deae0-88f0-11e7-96b7-f2f7649d327a.png)

**One-Off Mobile:**

![oneoff-mobile](https://user-images.githubusercontent.com/5131341/29676468-14589438-88f0-11e7-9878-bb11addae821.png)

**Recurring Desktop:**

![recurring-desktop](https://user-images.githubusercontent.com/5131341/29676519-35600756-88f0-11e7-9716-5a77c05ac379.png)

**Recurring Tablet:**

![recurring-tablet](https://user-images.githubusercontent.com/5131341/29676533-3c6f6564-88f0-11e7-97f9-8473299b4253.png)

**Recurring Mobile:**

![recurring-mobile](https://user-images.githubusercontent.com/5131341/29676542-429bf9c0-88f0-11e7-9ba9-d32519059826.png)