### PR TITLE
Add Context Version Of Contributions Landing

### DIFF
--- a/assets/helpers/utilities.js
+++ b/assets/helpers/utilities.js
@@ -45,7 +45,7 @@ export function clickSubstituteKeyPressHandler(handler?: () => void = () => {}) 
 // Attempts to parse a boolean from a string.
 export function parseBoolean(boolString: string, fallback: boolean): boolean {
 
-  switch (boolString) {
+  switch (boolString.toLowerCase()) {
     case 'true':
       return true;
     case 'false':

--- a/assets/helpers/utilities.js
+++ b/assets/helpers/utilities.js
@@ -43,7 +43,7 @@ export function clickSubstituteKeyPressHandler(handler?: () => void = () => {}) 
 }
 
 // Attempts to parse a boolean from a string.
-export function parseBoolean(boolString: ?string): ?boolean {
+export function parseBoolean(boolString: string, fallback: boolean): boolean {
 
   switch (boolString) {
     case 'true':
@@ -51,7 +51,7 @@ export function parseBoolean(boolString: ?string): ?boolean {
     case 'false':
       return false;
     default:
-      return null;
+      return fallback;
   }
 
 }

--- a/assets/helpers/utilities.js
+++ b/assets/helpers/utilities.js
@@ -42,3 +42,16 @@ export function clickSubstituteKeyPressHandler(handler?: () => void = () => {}) 
   };
 }
 
+// Attempts to parse a boolean from a string.
+export function parseBoolean(boolString: ?string): ?boolean {
+
+  switch (boolString) {
+    case 'true':
+      return true;
+    case 'false':
+      return false;
+    default:
+      return null;
+  }
+
+}

--- a/assets/pages/contributions-landing/actions/contributionsLandingActions.js
+++ b/assets/pages/contributions-landing/actions/contributionsLandingActions.js
@@ -13,6 +13,7 @@ export type Action =
   | { type: 'CHANGE_CONTRIB_AMOUNT_RECURRING', amount: Amount }
   | { type: 'CHANGE_CONTRIB_AMOUNT_ONEOFF', amount: Amount }
   | { type: 'PAYPAL_ERROR', message: string }
+  | { type: 'SET_CONTEXT', context: boolean }
   ;
 
 
@@ -36,4 +37,8 @@ export function changeContribAmountOneOff(amount: Amount): Action {
 
 export function payPalError(message: string): Action {
   return { type: 'PAYPAL_ERROR', message };
+}
+
+export function setContext(context: boolean) {
+  return { type: 'SET_CONTEXT', context };
 }

--- a/assets/pages/contributions-landing/components/contributionsBundleContent.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundleContent.jsx
@@ -1,0 +1,52 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+import { connect } from 'react-redux';
+
+import ContributionsIntroduction from './contributionsIntroduction';
+import ContributionsContext from './contributionsContext';
+import ContributionsContextIntro from './contributionsContextIntro';
+import ContributionsBundle from './contributionsBundle';
+
+
+// ----- Types ----- //
+
+type PropTypes = {
+  context: ?boolean,
+};
+
+
+// ----- Component ----- //
+
+function ContributionsBundleContent(props: PropTypes) {
+
+  return (
+    <div className="contributions-bundle__content gu-content-margin">
+      {props.context
+        ? <ContributionsContext />
+        : <ContributionsIntroduction />
+      }
+      {props.context ? <ContributionsContextIntro /> : null}
+      <ContributionsBundle />
+    </div>
+  );
+
+}
+
+
+// ----- Map State/Props ----- //
+
+function mapStateToProps(state) {
+
+  return {
+    context: state.contribution.context,
+  };
+
+}
+
+
+// ----- Exports ----- //
+
+export default connect(mapStateToProps)(ContributionsBundleContent);

--- a/assets/pages/contributions-landing/components/contributionsBundleContent.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundleContent.jsx
@@ -14,7 +14,7 @@ import ContributionsBundle from './contributionsBundle';
 // ----- Types ----- //
 
 type PropTypes = {
-  context: ?boolean,
+  context: boolean,
 };
 
 

--- a/assets/pages/contributions-landing/components/contributionsContext.jsx
+++ b/assets/pages/contributions-landing/components/contributionsContext.jsx
@@ -5,13 +5,13 @@
 import React from 'react';
 
 
-// ----- Componenent ----- //
+// ----- Component ----- //
 
 export default function ContributionsContext() {
 
   return (
     <div className="contributions-context">
-      <h2 className="contributions-context__heading">Now is the time...</h2>
+      <h2 className="contributions-context__heading">Now that you&#39;re here...</h2>
       <p className="contributions-context__copy">
         ... we’d like to explain why we need your support. Advertising revenues
         across the media are falling fast. And unlike many news organisations,
@@ -23,15 +23,6 @@ export default function ContributionsContext() {
         If everyone who reads our reporting, who likes it, helps to support it,
         our future would be much more secure.
       </p>
-      <h1 className="contributions-context__subheading">
-        support the Guardian&#39;s quality journalism
-      </h1>
-      <h1 className="contributions-context__subheading">
-        and independent voice
-      </h1>
-      <h1 className="contributions-context__subheading">
-        make a contribution today
-      </h1>
     </div>
   );
 

--- a/assets/pages/contributions-landing/components/contributionsContext.jsx
+++ b/assets/pages/contributions-landing/components/contributionsContext.jsx
@@ -1,0 +1,32 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+
+// ----- Componenent ----- //
+
+export default function ContributionsContext() {
+
+  return (
+    <div className="contributions-context">
+      <h2 className="contributions-context__heading">Now is the time...</h2>
+      <p className="contributions-context__copy">
+        ... we’d like to explain why we need your support. Advertising revenues
+        across the media are falling fast. And unlike many news organisations,
+        we haven’t put up a paywall – we want to keep our journalism as open
+        as we can. The Guardian&#39;s independent, investigative journalism takes
+        a lot of time, money and hard work to produce.
+      </p>
+      <p className="contributions-context__copy">
+        If everyone who reads our reporting, who likes it, helps to support it,
+        our future would be much more secure.
+      </p>
+      <h1 className="contributions-context__subheading">support the Guardian&#39;s</h1>
+      <h1 className="contributions-context__subheading">quality and independent voice</h1>
+      <h1 className="contributions-context__subheading">make a contribution today</h1>
+    </div>
+  );
+
+}

--- a/assets/pages/contributions-landing/components/contributionsContext.jsx
+++ b/assets/pages/contributions-landing/components/contributionsContext.jsx
@@ -23,9 +23,15 @@ export default function ContributionsContext() {
         If everyone who reads our reporting, who likes it, helps to support it,
         our future would be much more secure.
       </p>
-      <h1 className="contributions-context__subheading">support the Guardian&#39;s</h1>
-      <h1 className="contributions-context__subheading">quality and independent voice</h1>
-      <h1 className="contributions-context__subheading">make a contribution today</h1>
+      <h1 className="contributions-context__subheading">
+        support the Guardian&#39;s quality journalism
+      </h1>
+      <h1 className="contributions-context__subheading">
+        and independent voice
+      </h1>
+      <h1 className="contributions-context__subheading">
+        make a contribution today
+      </h1>
     </div>
   );
 

--- a/assets/pages/contributions-landing/components/contributionsContextIntro.jsx
+++ b/assets/pages/contributions-landing/components/contributionsContextIntro.jsx
@@ -1,0 +1,26 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+
+// ----- Component ----- //
+
+export default function ContributionsContextIntro() {
+
+  return (
+    <div className="contributions-context-intro">
+      <h1 className="contributions-context__subheading">
+        support the&nbsp;Guardian&#39;s quality journalism
+      </h1>
+      <h1 className="contributions-context__subheading">
+        and independent voice
+      </h1>
+      <h1 className="contributions-context__subheading">
+        make a contribution today
+      </h1>
+    </div>
+  );
+
+}

--- a/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/assets/pages/contributions-landing/contributionsLanding.scss
@@ -212,7 +212,7 @@
 		background-color: darken(gu-colour(multimedia-main-2), 5%);
 
 		@include mq($from: mobileLandscape) {
-			height: 700px;
+			height: 620px;
 		}
 
 		@include mq($from: phablet) {
@@ -221,6 +221,16 @@
 
 		@include mq($from: desktop) {
 			height: 450px;
+		}
+	}
+
+	.contributions-bundle--context {
+		@include mq($from: mobileLandscape, $until: phablet) {
+			height: 840px;
+		}
+
+		@include mq($from: phablet, $until: desktop) {
+			height: auto;
 		}
 	}
 

--- a/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/assets/pages/contributions-landing/contributionsLanding.scss
@@ -130,17 +130,35 @@
 		vertical-align: top;
 		color: gu-colour(neutral-1);
 		padding-left: $gu-h-spacing / 2;
-
-		@include mq($from: phablet, $until: desktop) {
-			width: 320px;
-		}
+		padding-right: $gu-h-spacing / 2;
 
 		@include mq($from: desktop) {
-			width: 550px;
+			width: 540px;
 		}
 
 		@include mq($from: leftCol) {
-			width: 670px;
+			width: 660px;
+		}
+	}
+
+	.contributions-context-intro {
+		display: inline-block;
+		vertical-align: top;
+		padding-left: $gu-h-spacing / 2;
+		padding-right: $gu-h-spacing / 2;
+
+		@include mq($from: phablet) {
+			width: 300px;
+			margin-top: 49px;
+		}
+
+		@include mq($from: desktop) {
+			width: 540px;
+			margin-top: 20px;
+		}
+
+		@include mq($from: leftCol) {
+			width: 660px;
 		}
 	}
 
@@ -148,8 +166,8 @@
 		font-weight: bold;
 		margin-top: 49px;
 		margin-bottom: 20px;
-		font-size: 22px;
-		line-height: 22px;
+		font-size: 24px;
+		line-height: 30px;
 		font-family: $gu-egyptian-web;
 
 		@include mq($from: desktop) {
@@ -169,17 +187,27 @@
 		line-height: 24px;
 		font-family: $gu-text-egyptian-web;
 		margin-bottom: $gu-v-spacing;
+
+		@include mq($from: phablet) {
+			width: 620px;
+		}
 	}
 
 	.contributions-context__subheading {
 		font-weight: bold;
-		font-size: 28px;
-		line-height: 32px;
+		font-size: 32px;
+		line-height: 36px;
 		color: #fff;
 		font-family: $gu-egyptian-web;
 
-		&:first-of-type {
-			margin-top: 20px;
+		@include mq($from: phablet) {
+			font-size: 36px;
+			line-height: 40px;
+		}
+
+		@include mq($from: desktop) {
+			font-size: 24px;
+			line-height: 28px;
 		}
 
 		&:nth-of-type(2) {
@@ -211,12 +239,20 @@
 	.contributions-bundle {
 		background-color: darken(gu-colour(multimedia-main-2), 5%);
 
-		@include mq($from: mobileLandscape) {
-			height: 620px;
+		@include mq($from: desktop) {
+			height: 450px;
+			position: relative;
 		}
+	}
 
-		@include mq($from: phablet) {
-			height: 420px;
+	.contributions-bundle__content {
+		background-color: gu-colour(multimedia-main-2);
+		padding: 0;
+
+		@include mq($from: mobileLandscape) {
+			padding-left: 10px;
+			padding-right: 10px;
+			padding-bottom: $gu-v-spacing;
 		}
 
 		@include mq($from: desktop) {
@@ -224,29 +260,7 @@
 		}
 	}
 
-	.contributions-bundle--context {
-		@include mq($from: mobileLandscape, $until: phablet) {
-			height: 840px;
-		}
-
-		@include mq($from: phablet, $until: desktop) {
-			height: auto;
-		}
-	}
-
-	.contributions-bundle__content {
-		background-color: gu-colour(multimedia-main-2);
-		padding: 0;
-		padding: 0;
-
-		@include mq($from: mobileLandscape) {
-			padding-left: 10px;
-			padding-right: 10px;
-		}
-	}
-
 	.component-bundle {
-		position: relative;
 		display: inline-block;
 		vertical-align: top;
 		padding: ($gu-v-spacing / 2) ($gu-h-spacing / 2) $gu-v-spacing;
@@ -265,8 +279,10 @@
 		}
 
 		@include mq($from: desktop) {
-			margin-top: 80px;
+			margin-top: 0px;
 			margin-left: 85px;
+			position: absolute;
+			top: 80px;
 		}
 
 		@include mq($from: wide) {
@@ -297,7 +313,7 @@
 
 	.component-double-heading__heading {
 		font-size: 24px;
-		line-height: 30px;
+		line-height: 24px;
 	}
 
 	.component-double-heading__subheading {
@@ -386,10 +402,6 @@
 		padding-top: $gu-v-spacing * 3;
 		padding-bottom: $gu-v-spacing;
 
-		@include mq($from: mobileLandscape, $until: phablet) {
-			padding-top: 95px;
-		}
-
 		@include mq($from: desktop) {
 			padding-top: $gu-v-spacing * 2;
 		}
@@ -405,8 +417,8 @@
 	}
 
 	.component-contrib-legal {
-		@include mq($from: phablet) {
-			width: 300px;
+		@include mq($from: tablet) {
+			width: 620px;
 		}
 
 		@include mq($from: desktop) {

--- a/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/assets/pages/contributions-landing/contributionsLanding.scss
@@ -123,6 +123,89 @@
 		}
 	}
 
+	// ----- Context ----- //
+
+	.contributions-context {
+		display: inline-block;
+		vertical-align: top;
+		color: gu-colour(neutral-1);
+		padding-left: $gu-h-spacing / 2;
+
+		@include mq($from: phablet, $until: desktop) {
+			width: 320px;
+		}
+
+		@include mq($from: desktop) {
+			width: 550px;
+		}
+
+		@include mq($from: leftCol) {
+			width: 670px;
+		}
+	}
+
+	.contributions-context__heading {
+		font-weight: bold;
+		margin-top: 49px;
+		margin-bottom: 20px;
+		font-size: 22px;
+		line-height: 22px;
+		font-family: $gu-egyptian-web;
+
+		@include mq($from: desktop) {
+			margin-top: 80px;
+		}
+
+		&::before {
+			content: " ";
+			border: 1px solid gu-colour(neutral-1);
+			width: 44px;
+		    display: block;
+		}
+	}
+
+	.contributions-context__copy {
+		font-size: 16px;
+		line-height: 24px;
+		font-family: $gu-text-egyptian-web;
+		margin-bottom: $gu-v-spacing;
+	}
+
+	.contributions-context__subheading {
+		font-weight: bold;
+		font-size: 28px;
+		line-height: 32px;
+		color: #fff;
+		font-family: $gu-egyptian-web;
+
+		&:first-of-type {
+			margin-top: 20px;
+		}
+
+		&:nth-of-type(2) {
+			@include mq($from: desktop) {
+				margin-left: 255px;
+			}
+
+			@include mq($from: leftCol) {
+				margin-left: 330px;
+			}
+		}
+
+		&:last-of-type {
+			margin-bottom: 40px;
+			color: gu-colour(neutral-1);
+
+			@include mq($from: desktop) {
+				margin-left: 170px;
+			}
+
+			@include mq($from: leftCol) {
+				margin-left: 255px;
+			}
+		}
+	}
+
 	// ----- Bundle ----- //
 
 	.contributions-bundle {

--- a/assets/pages/contributions-landing/contributionsLandingUK.jsx
+++ b/assets/pages/contributions-landing/contributionsLandingUK.jsx
@@ -14,10 +14,10 @@ import ContribLegal from 'components/legal/contribLegal/contribLegal';
 
 import pageStartup from 'helpers/pageStartup';
 import { getQueryParameter } from 'helpers/url';
+import { parseBoolean } from 'helpers/utilities';
 
 import reducer from './reducers/reducers';
-import ContributionsIntroduction from './components/contributionsIntroduction';
-import ContributionsBundle from './components/contributionsBundle';
+import ContributionsBundleContent from './components/contributionsBundleContent';
 
 
 // ----- Page Startup ----- //
@@ -33,6 +33,10 @@ const store = createStore(reducer, {
 }, applyMiddleware(thunkMiddleware));
 
 store.dispatch({ type: 'SET_AB_TEST_PARTICIPATION', payload: participation });
+store.dispatch({
+  type: 'SET_CONTEXT',
+  context: parseBoolean(getQueryParameter('context', 'false')),
+});
 
 
 // ----- Render ----- //
@@ -42,10 +46,7 @@ const content = (
     <div className="gu-content">
       <SimpleHeader />
       <section className="contributions-bundle">
-        <div className="contributions-bundle__content gu-content-margin">
-          <ContributionsIntroduction />
-          <ContributionsBundle />
-        </div>
+        <ContributionsBundleContent />
       </section>
       <section className="contributions-legal gu-content-filler">
         <div className="contributions-legal__content gu-content-filler__inner">

--- a/assets/pages/contributions-landing/contributionsLandingUK.jsx
+++ b/assets/pages/contributions-landing/contributionsLandingUK.jsx
@@ -14,9 +14,9 @@ import ContribLegal from 'components/legal/contribLegal/contribLegal';
 
 import pageStartup from 'helpers/pageStartup';
 import { getQueryParameter } from 'helpers/url';
-import { parseBoolean } from 'helpers/utilities';
 
 import reducer from './reducers/reducers';
+import { saveContext } from './helpers/context';
 import ContributionsBundleContent from './components/contributionsBundleContent';
 
 
@@ -33,10 +33,7 @@ const store = createStore(reducer, {
 }, applyMiddleware(thunkMiddleware));
 
 store.dispatch({ type: 'SET_AB_TEST_PARTICIPATION', payload: participation });
-store.dispatch({
-  type: 'SET_CONTEXT',
-  context: parseBoolean(getQueryParameter('context', 'false')),
-});
+saveContext(store.dispatch);
 
 
 // ----- Render ----- //

--- a/assets/pages/contributions-landing/contributionsLandingUS.jsx
+++ b/assets/pages/contributions-landing/contributionsLandingUS.jsx
@@ -14,7 +14,7 @@ import ContribLegal from 'components/legal/contribLegal/contribLegal';
 
 import pageStartup from 'helpers/pageStartup';
 import { getQueryParameter } from 'helpers/url';
-import { parseBoolean } from 'helpers/utilities';
+import { parseBoolean, generateClassName } from 'helpers/utilities';
 
 import reducer from './reducers/reducers';
 import ContributionsIntroduction from './components/contributionsIntroduction';
@@ -44,7 +44,7 @@ const content = (
   <Provider store={store}>
     <div className="gu-content">
       <SimpleHeader />
-      <section className="contributions-bundle">
+      <section className={generateClassName('contributions-bundle', store.getState().contribution.context ? 'context' : null)}>
         <div className="contributions-bundle__content gu-content-margin">
           {store.getState().contribution.context
             ? <ContributionsContext />

--- a/assets/pages/contributions-landing/contributionsLandingUS.jsx
+++ b/assets/pages/contributions-landing/contributionsLandingUS.jsx
@@ -17,10 +17,7 @@ import { getQueryParameter } from 'helpers/url';
 import { parseBoolean } from 'helpers/utilities';
 
 import reducer from './reducers/reducers';
-import ContributionsIntroduction from './components/contributionsIntroduction';
-import ContributionsContext from './components/contributionsContext';
-import ContributionsContextIntro from './components/contributionsContextIntro';
-import ContributionsBundle from './components/contributionsBundle';
+import ContributionsBundleContent from './components/contributionsBundleContent';
 
 
 // ----- Page Startup ----- //
@@ -49,14 +46,7 @@ const content = (
     <div className="gu-content">
       <SimpleHeader />
       <section className="contributions-bundle">
-        <div className="contributions-bundle__content gu-content-margin">
-          {store.getState().contribution.context
-            ? <ContributionsContext />
-            : <ContributionsIntroduction />
-          }
-          {store.getState().contribution.context ? <ContributionsContextIntro /> : null}
-          <ContributionsBundle />
-        </div>
+        <ContributionsBundleContent />
       </section>
       <section className="contributions-legal gu-content-filler">
         <div className="contributions-legal__content gu-content-filler__inner">

--- a/assets/pages/contributions-landing/contributionsLandingUS.jsx
+++ b/assets/pages/contributions-landing/contributionsLandingUS.jsx
@@ -14,9 +14,9 @@ import ContribLegal from 'components/legal/contribLegal/contribLegal';
 
 import pageStartup from 'helpers/pageStartup';
 import { getQueryParameter } from 'helpers/url';
-import { parseBoolean } from 'helpers/utilities';
 
 import reducer from './reducers/reducers';
+import { saveContext } from './helpers/context';
 import ContributionsBundleContent from './components/contributionsBundleContent';
 
 
@@ -33,10 +33,7 @@ const store = createStore(reducer, {
 }, applyMiddleware(thunkMiddleware));
 
 store.dispatch({ type: 'SET_AB_TEST_PARTICIPATION', payload: participation });
-store.dispatch({
-  type: 'SET_CONTEXT',
-  context: parseBoolean(getQueryParameter('context', 'false')),
-});
+saveContext(store.dispatch);
 
 
 // ----- Render ----- //

--- a/assets/pages/contributions-landing/contributionsLandingUS.jsx
+++ b/assets/pages/contributions-landing/contributionsLandingUS.jsx
@@ -14,11 +14,12 @@ import ContribLegal from 'components/legal/contribLegal/contribLegal';
 
 import pageStartup from 'helpers/pageStartup';
 import { getQueryParameter } from 'helpers/url';
-import { parseBoolean, generateClassName } from 'helpers/utilities';
+import { parseBoolean } from 'helpers/utilities';
 
 import reducer from './reducers/reducers';
 import ContributionsIntroduction from './components/contributionsIntroduction';
 import ContributionsContext from './components/contributionsContext';
+import ContributionsContextIntro from './components/contributionsContextIntro';
 import ContributionsBundle from './components/contributionsBundle';
 
 
@@ -35,7 +36,10 @@ const store = createStore(reducer, {
 }, applyMiddleware(thunkMiddleware));
 
 store.dispatch({ type: 'SET_AB_TEST_PARTICIPATION', payload: participation });
-store.dispatch({ type: 'SET_CONTEXT', context: parseBoolean(getQueryParameter('context', 'false')) });
+store.dispatch({
+  type: 'SET_CONTEXT',
+  context: parseBoolean(getQueryParameter('context', 'false')),
+});
 
 
 // ----- Render ----- //
@@ -44,12 +48,13 @@ const content = (
   <Provider store={store}>
     <div className="gu-content">
       <SimpleHeader />
-      <section className={generateClassName('contributions-bundle', store.getState().contribution.context ? 'context' : null)}>
+      <section className="contributions-bundle">
         <div className="contributions-bundle__content gu-content-margin">
           {store.getState().contribution.context
             ? <ContributionsContext />
             : <ContributionsIntroduction />
           }
+          {store.getState().contribution.context ? <ContributionsContextIntro /> : null}
           <ContributionsBundle />
         </div>
       </section>

--- a/assets/pages/contributions-landing/contributionsLandingUS.jsx
+++ b/assets/pages/contributions-landing/contributionsLandingUS.jsx
@@ -14,9 +14,11 @@ import ContribLegal from 'components/legal/contribLegal/contribLegal';
 
 import pageStartup from 'helpers/pageStartup';
 import { getQueryParameter } from 'helpers/url';
+import { parseBoolean } from 'helpers/utilities';
 
 import reducer from './reducers/reducers';
 import ContributionsIntroduction from './components/contributionsIntroduction';
+import ContributionsContext from './components/contributionsContext';
 import ContributionsBundle from './components/contributionsBundle';
 
 
@@ -33,6 +35,7 @@ const store = createStore(reducer, {
 }, applyMiddleware(thunkMiddleware));
 
 store.dispatch({ type: 'SET_AB_TEST_PARTICIPATION', payload: participation });
+store.dispatch({ type: 'SET_CONTEXT', context: parseBoolean(getQueryParameter('context', 'false')) });
 
 
 // ----- Render ----- //
@@ -43,7 +46,10 @@ const content = (
       <SimpleHeader />
       <section className="contributions-bundle">
         <div className="contributions-bundle__content gu-content-margin">
-          <ContributionsIntroduction />
+          {store.getState().contribution.context
+            ? <ContributionsContext />
+            : <ContributionsIntroduction />
+          }
           <ContributionsBundle />
         </div>
       </section>

--- a/assets/pages/contributions-landing/helpers/context.js
+++ b/assets/pages/contributions-landing/helpers/context.js
@@ -1,0 +1,29 @@
+// @flow
+
+// ----- Imports ----- //
+
+import { getQueryParameter } from 'helpers/url';
+import { parseBoolean } from 'helpers/utilities';
+
+import { setContext } from '../actions/contributionsLandingActions';
+import type { Action } from '../actions/contributionsLandingActions';
+
+
+// ----- Functions ----- //
+
+function saveContext(dispatch: Action => void) {
+
+  const context = getQueryParameter('context', 'false');
+
+  if (context) {
+    dispatch(setContext(parseBoolean(context, false)));
+  }
+
+}
+
+
+// ----- Exports ----- //
+
+export {
+  saveContext,
+};

--- a/assets/pages/contributions-landing/reducers/__tests__/__snapshots__/reducersTest.js.snap
+++ b/assets/pages/contributions-landing/reducers/__tests__/__snapshots__/reducersTest.js.snap
@@ -55,6 +55,7 @@ Object {
         "value": "10",
       },
     },
+    "context": false,
     "error": null,
     "payPalError": null,
     "type": "RECURRING",

--- a/assets/pages/contributions-landing/reducers/reducers.js
+++ b/assets/pages/contributions-landing/reducers/reducers.js
@@ -20,6 +20,7 @@ export type ContribState = {
   error: ?ContribError,
   amount: Amounts,
   payPalError: ?string,
+  context: ?boolean,
 };
 
 
@@ -39,6 +40,7 @@ const initialContrib: ContribState = {
     },
   },
   payPalError: null,
+  context: false,
 };
 
 
@@ -93,6 +95,10 @@ function contribution(
       return Object.assign({}, state, {
         payPalError: action.message,
       });
+
+    case 'SET_CONTEXT':
+
+      return Object.assign({}, state, { context: action.context });
 
     default:
       return state;


### PR DESCRIPTION
## Why are you doing this?

The Epic has some context (paragraphs of copy) for why you might want to support the guardian/make a contribution. The engagement banner doesn't, so contributions use an alternate landing page that includes this copy. We're going to do the same. It could be argued that we should show this page for header traffic as well, as there's no context there either.

I've done this by adding a query parameter to the URL called `context`, which can be either true or false (or missing, 3VL all the way!). This will trigger the context version of the page with extra copy (see screenshots below). This applies to both the UK and US versions of the page.

cc: @Amohkhan

[**Trello Card**](https://trello.com/c/d0jVHDB1/815-engagement-banner-header-version-of-contributions-landing-page)

## Changes

- Added a utility function for parsing a boolean from a string (JavaScript doesn't have a standard library).
- Added a new action for setting the context in the reducer.
- Added components for the context text and the context intro.
- Styled the new context, and tweaked the styling of the default page to only use the bundle overlay on desktop and above.
- Added the context logic to the US contributions landing page.
- Updated the reducer to take the new `context`, and the tweaked the corresponding tests.

## Screenshots

**Default:**

`support.theguardian.com/uk/contribute`
`support.theguardian.com/us/contribute`

![landing-default](https://user-images.githubusercontent.com/5131341/29868420-bc7bab16-8d76-11e7-8a30-83cad7b8796b.png)

**Context:**

`support.theguardian.com/uk/contribute?context=true`
`support.theguardian.com/us/contribute?context=true`

![landing-context](https://user-images.githubusercontent.com/5131341/29868432-c8e09ca4-8d76-11e7-91a7-d9bdd1959e79.png)

