### PR TITLE
Stop Hardcoding 'GB' For Country Detection

### DIFF
--- a/assets/helpers/internationalisation/country.js
+++ b/assets/helpers/internationalisation/country.js
@@ -134,8 +134,7 @@ function fromGeolocation(): ?IsoCountry {
 function detect(): IsoCountry {
   const country = fromPath() || fromQueryParameter() || fromCookie() || fromGeolocation() || 'GB';
   // cookie.set('GU_country', country, 7);
-  // Always return GB because we aren't ready to support US quite yet
-  return 'GB' || country;
+  return country;
 }
 
 

--- a/assets/helpers/internationalisation/country.js
+++ b/assets/helpers/internationalisation/country.js
@@ -131,9 +131,13 @@ function fromGeolocation(): ?IsoCountry {
   return null;
 }
 
+function setCountry(country: IsoCountry) {
+  cookie.set('GU_country', country, 7);
+}
+
 function detect(): IsoCountry {
   const country = fromPath() || fromQueryParameter() || fromCookie() || fromGeolocation() || 'GB';
-  // cookie.set('GU_country', country, 7);
+  setCountry(country);
   return country;
 }
 
@@ -142,5 +146,6 @@ function detect(): IsoCountry {
 
 export {
   detect,
+  setCountry,
   usStates,
 };

--- a/assets/pages/bundles-landing/bundlesLanding.jsx
+++ b/assets/pages/bundles-landing/bundlesLanding.jsx
@@ -12,6 +12,7 @@ import SimpleFooter from 'components/footers/simpleFooter/simpleFooter';
 
 import pageStartup from 'helpers/pageStartup';
 import { getQueryParameter } from 'helpers/url';
+import { setCountry } from 'helpers/internationalisation/country';
 import Introduction from './components/Introduction';
 import Bundles from './components/Bundles';
 import WhySupport from './components/WhySupport';
@@ -23,9 +24,11 @@ import { belongToTest } from './helpers/subscriptionsLinks';
 // ----- Page Startup ----- //
 
 const participation = pageStartup.start();
+setCountry('GB');
 
 
 // ----- Redux Store ----- //
+
 const intCmp = getQueryParameter('INTCMP', 'gdnwb_copts_bundles_landing_default');
 
 const store = createStore(reducer, {
@@ -38,6 +41,7 @@ let waysOfSupport = <WaysOfSupport />;
 if (intCmp && belongToTest(intCmp, 'baseline')) {
   waysOfSupport = '';
 }
+
 
 // ----- Render ----- //
 

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -115,7 +115,6 @@ const getContribAttrs = ({
   const params = new URLSearchParams();
 
   params.append('contributionValue', contribAmount[contType].value);
-  params.append('country', isoCountry);
 
   if (intCmp) {
     params.append('INTCMP', intCmp);

--- a/assets/pages/contributions-landing/contributionsLandingUK.jsx
+++ b/assets/pages/contributions-landing/contributionsLandingUK.jsx
@@ -14,6 +14,7 @@ import ContribLegal from 'components/legal/contribLegal/contribLegal';
 
 import pageStartup from 'helpers/pageStartup';
 import { getQueryParameter } from 'helpers/url';
+import { setCountry } from 'helpers/internationalisation/country';
 
 import reducer from './reducers/reducers';
 import { saveContext } from './helpers/context';
@@ -27,9 +28,12 @@ const participation = pageStartup.start();
 
 // ----- Redux Store ----- //
 
+const country = 'GB';
+setCountry(country);
+
 const store = createStore(reducer, {
   intCmp: getQueryParameter('INTCMP'),
-  isoCountry: 'GB',
+  isoCountry: country,
 }, applyMiddleware(thunkMiddleware));
 
 store.dispatch({ type: 'SET_AB_TEST_PARTICIPATION', payload: participation });

--- a/assets/pages/contributions-landing/contributionsLandingUS.jsx
+++ b/assets/pages/contributions-landing/contributionsLandingUS.jsx
@@ -14,6 +14,7 @@ import ContribLegal from 'components/legal/contribLegal/contribLegal';
 
 import pageStartup from 'helpers/pageStartup';
 import { getQueryParameter } from 'helpers/url';
+import { setCountry } from 'helpers/internationalisation/country';
 
 import reducer from './reducers/reducers';
 import { saveContext } from './helpers/context';
@@ -23,13 +24,15 @@ import ContributionsBundleContent from './components/contributionsBundleContent'
 // ----- Page Startup ----- //
 
 const participation = pageStartup.start();
+const country = 'US';
+setCountry(country);
 
 
 // ----- Redux Store ----- //
 
 const store = createStore(reducer, {
   intCmp: getQueryParameter('INTCMP'),
-  isoCountry: 'US',
+  isoCountry: country,
 }, applyMiddleware(thunkMiddleware));
 
 store.dispatch({ type: 'SET_AB_TEST_PARTICIPATION', payload: participation });


### PR DESCRIPTION
## Why are you doing this?

**DO NOT MERGE**

When we go live in the US we want to be able to properly detect country ('GB' *or* 'US'), rather than hardcoding everything to 'GB' as we're doing at the moment. This is the last thing to change when we're ready to go live with Test 3.

This also switches to recording the country in a cookie, for use on the checkout pages, rather than passing it through as a query param.

[**Trello Card**](https://trello.com/c/jyV8afjI/856-turn-off-gb-default)

## Changes

- Removed hard-coding of 'GB' in country detection.
- Created new `setCountry` helper to set the country cookie.
- Stopped passing country through to checkouts as query param.
- Applied country cookie to contributions landing and bundles landing pages.