### PR TITLE
Pass Through REFPVID

### DIFF
--- a/assets/components/payPalContributionButton/payPalContributionButton.jsx
+++ b/assets/components/payPalContributionButton/payPalContributionButton.jsx
@@ -13,6 +13,7 @@ import { paypalContributionsRedirect } from 'helpers/payPalContributionsCheckout
 type PropTypes = {
   amount: string,
   intCmp?: string,
+  refpvid?: string,
   isoCountry: IsoCountry,
   errorHandler: (string) => void,
   canClick?: boolean,
@@ -24,6 +25,7 @@ function payWithPayPal(props: PropTypes) {
       paypalContributionsRedirect(
         Number(props.amount),
         props.intCmp,
+        props.refpvid,
         props.isoCountry,
         props.errorHandler);
     }
@@ -46,6 +48,7 @@ const PayPalContributionButton = (props: PropTypes) =>
 
 PayPalContributionButton.defaultProps = {
   intCmp: null,
+  refpvid: null,
   canClick: true,
 };
 

--- a/assets/components/paymentMethods/paymentMethods.jsx
+++ b/assets/components/paymentMethods/paymentMethods.jsx
@@ -28,6 +28,7 @@ type PropTypes = {
   payPalCallback: Function,
   amount: string,
   intCmp?: string,
+  refpvid?: string,
   isoCountry: IsoCountry,
   payPalErrorHandler: (string) => void,
 };
@@ -49,6 +50,7 @@ export default function PaymentMethods(props: PropTypes) {
       payPalButton = (<PayPalContributionButton
         amount={props.amount}
         intCmp={props.intCmp}
+        refpvid={props.refpvid}
         isoCountry={props.isoCountry}
         errorHandler={props.payPalErrorHandler}
       />);
@@ -77,4 +79,5 @@ export default function PaymentMethods(props: PropTypes) {
 
 PaymentMethods.defaultProps = {
   intCmp: null,
+  refpvid: null,
 };

--- a/assets/helpers/payPalContributionsCheckout/payPalContributionsCheckout.js
+++ b/assets/helpers/payPalContributionsCheckout/payPalContributionsCheckout.js
@@ -21,6 +21,7 @@ type PayPalPostData = {
 export function paypalContributionsRedirect(
   amount: number,
   intCmp: ?string,
+  refpvid: ?string,
   isoCountry: IsoCountry,
   errorHandler: (string) => void): void {
 
@@ -31,13 +32,13 @@ export function paypalContributionsRedirect(
     countryGroup: country,
     amount,
     intCmp,
+    refererPageviewId: refpvid,
     supportRedirect: true,
     /*
      TODO: pass these argument to contributions in order to improve
      the tracking of one-off contributions.
 
      cmp: state.data.cmpCode,
-     refererPageviewId: state.data.refererPageviewId,
      refererUrl: state.data.refererUrl,
      ophanPageviewId: state.data.ophan.pageviewId,
      ophanBrowserId: state.data.ophan.browserId,

--- a/assets/helpers/refpvid.js
+++ b/assets/helpers/refpvid.js
@@ -1,0 +1,9 @@
+// @flow
+
+// ----- Reducer ----- //
+
+const refpvidReducer = (state: ?string = null): ?string => state;
+
+export {
+  refpvidReducer,
+};

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -85,6 +85,7 @@ function showPayPal(props: PropTypes) {
     return (<PayPalContributionButton
       amount={props.contribAmount.oneOff.value}
       intCmp={props.intCmp}
+      refpvid={props.refpvid}
       isoCountry={props.isoCountry}
       errorHandler={props.payPalErrorHandler}
       canClick={!props.contribError}

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -33,6 +33,7 @@ type PropTypes = {
   contribAmount: Amounts,
   contribError: ContribError,
   intCmp: string,
+  refpvid: string,
   toggleContribType: (string) => void,
   changeContribRecurringAmount: (string) => void,
   changeContribOneOffAmount: (string) => void,
@@ -108,7 +109,7 @@ const ctaLinks = {
 // ----- Functions ----- //
 
 const getContribAttrs = ({
-  contribType, contribAmount, intCmp, isoCountry,
+  contribType, contribAmount, intCmp, refpvid, isoCountry,
 }): ContribAttrs => {
 
   const contType = contribType === 'RECURRING' ? 'recurring' : 'oneOff';
@@ -118,6 +119,10 @@ const getContribAttrs = ({
 
   if (intCmp) {
     params.append('INTCMP', intCmp);
+  }
+
+  if (refpvid) {
+    params.append('REFPVID', refpvid);
   }
 
   const ctaLink = `${ctaLinks[contType]}?${params.toString()}`;
@@ -165,6 +170,7 @@ function mapStateToProps(state) {
     contribAmount: state.contribution.amount,
     contribError: state.contribution.error,
     intCmp: state.intCmp,
+    refpvid: state.refpvid,
     isoCountry: state.isoCountry,
     payPalError: state.contribution.payPalError,
   };

--- a/assets/pages/contributions-landing/contributionsLandingUK.jsx
+++ b/assets/pages/contributions-landing/contributionsLandingUK.jsx
@@ -34,6 +34,7 @@ setCountry(country);
 const store = createStore(reducer, {
   intCmp: getQueryParameter('INTCMP'),
   isoCountry: country,
+  refpvid: getQueryParameter('REFPVID'),
 }, applyMiddleware(thunkMiddleware));
 
 store.dispatch({ type: 'SET_AB_TEST_PARTICIPATION', payload: participation });

--- a/assets/pages/contributions-landing/contributionsLandingUS.jsx
+++ b/assets/pages/contributions-landing/contributionsLandingUS.jsx
@@ -33,6 +33,7 @@ setCountry(country);
 const store = createStore(reducer, {
   intCmp: getQueryParameter('INTCMP'),
   isoCountry: country,
+  refpvid: getQueryParameter('REFPVID'),
 }, applyMiddleware(thunkMiddleware));
 
 store.dispatch({ type: 'SET_AB_TEST_PARTICIPATION', payload: participation });

--- a/assets/pages/contributions-landing/reducers/__tests__/__snapshots__/reducersTest.js.snap
+++ b/assets/pages/contributions-landing/reducers/__tests__/__snapshots__/reducersTest.js.snap
@@ -62,5 +62,6 @@ Object {
   },
   "intCmp": null,
   "isoCountry": null,
+  "refpvid": null,
 }
 `;

--- a/assets/pages/contributions-landing/reducers/reducers.js
+++ b/assets/pages/contributions-landing/reducers/reducers.js
@@ -6,6 +6,7 @@ import { combineReducers } from 'redux';
 
 import type { Contrib, ContribError, Amounts } from 'helpers/contributions';
 import { intCmpReducer as intCmp } from 'helpers/intCmp';
+import { refpvidReducer as refpvid } from 'helpers/refpvid';
 import { isoCountryReducer as isoCountry } from 'helpers/isoCountry';
 
 import { parse as parseContribution } from 'helpers/contributions';
@@ -112,6 +113,7 @@ function contribution(
 export default combineReducers({
   contribution,
   intCmp,
+  refpvid,
   abTests,
   isoCountry,
 });

--- a/assets/pages/oneoff-contributions/components/paymentMethodsContainer.jsx
+++ b/assets/pages/oneoff-contributions/components/paymentMethodsContainer.jsx
@@ -17,6 +17,7 @@ function mapStateToProps(state) {
     hide: state.user.email === '' || state.user.fullName === '',
     amount: state.oneoffContrib.amount,
     intCmp: state.intCmp,
+    refpvid: state.refpvid,
     isoCountry: state.oneoffContrib.country,
   };
 

--- a/assets/pages/oneoff-contributions/helpers/ajax.js
+++ b/assets/pages/oneoff-contributions/helpers/ajax.js
@@ -55,6 +55,10 @@ function requestData(paymentToken: string, getState: () => CombinedState) {
       ophanPageviewId: 'dummy', // todo: correct ophan pageview id
     };
 
+    if (state.refpvid) {
+      oneoffContribFields.refererPageviewId = state.refpvid;
+    }
+
     return {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },

--- a/assets/pages/oneoff-contributions/oneoffContributions.jsx
+++ b/assets/pages/oneoff-contributions/oneoffContributions.jsx
@@ -50,6 +50,7 @@ const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
 const store = createStore(reducer(contributionAmount, currency, country), {
   intCmp: getQueryParameter('INTCMP'),
+  refpvid: getQueryParameter('REFPVID'),
 }, composeEnhancers(applyMiddleware(thunkMiddleware)));
 
 user.init(store.dispatch);

--- a/assets/pages/oneoff-contributions/reducers/reducers.js
+++ b/assets/pages/oneoff-contributions/reducers/reducers.js
@@ -8,6 +8,7 @@ import type { State as StripeCheckoutState } from 'helpers/stripeCheckout/stripe
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 
 import { intCmpReducer as intCmp } from 'helpers/intCmp';
+import { refpvidReducer as refpvid } from 'helpers/refpvid';
 import createStripeCheckoutReducer from 'helpers/stripeCheckout/stripeCheckoutReducer';
 import createPayPalContributionsCheckoutReducer from 'helpers/payPalContributionsCheckout/payPalContributionsCheckoutReducer';
 import user from 'helpers/user/userReducer';
@@ -32,6 +33,7 @@ export type State = {
 export type CombinedState = {
   oneoffContrib: State,
   intCmp: string,
+  refpvid: string,
   user: UserState,
   stripeCheckout: StripeCheckoutState,
   csrf: CsrfState,
@@ -77,6 +79,7 @@ export default function createRootOneOffContribReducer(
   return combineReducers({
     oneoffContrib: createOneOffContribReducer(amount, currency, country),
     intCmp,
+    refpvid,
     user,
     stripeCheckout: createStripeCheckoutReducer(amount, currency.iso),
     payPalContributionsCheckout: createPayPalContributionsCheckoutReducer(amount, currency.iso),


### PR DESCRIPTION
## Why are you doing this?

Contributions use this for their data analysis, and we already pass it through from dotcom to our landing pages (as a query parameter). This PR passes this through from the contributions landing page to the checkout pages. It also updates the POST requests to contributions for Stripe and PayPal, to include the REFPVID if it is present.

[**Trello Card**](https://trello.com/c/NmghNCjy/681-pass-through-refpvid-to-contributions-from-bundles-landing-page)

## Changes

- Created a shared reducer for REFPVID.
- Captured REFPVID from a query param on both versions of the contributions landing page.
- Sent it through in the PayPal POST request.
- Sent it through in the Stripe POST request.
