### PR TITLE
Fix test_username cookie

### DIFF
--- a/app/controllers/TestUsersManagement.scala
+++ b/app/controllers/TestUsersManagement.scala
@@ -18,6 +18,6 @@ class TestUsersManagement(
     val testUser = testUsers.testUsers.generate()
     Ok(testUsersView(testUser))
       .withHeaders(CacheControl.noCache)
-      .withCookies(Cookie("_test_username", testUser))
+      .withCookies(Cookie("_test_username", testUser, httpOnly = false))
   }
 }

--- a/app/views/testUsers.scala.html
+++ b/app/views/testUsers.scala.html
@@ -11,7 +11,7 @@
     </head>
     <body>
         <h1>New Test User key: @key</h1>
-        Your user will be valid for the next 48H. When registering please populate the following fields with your new test user key.
+        Your user will be valid for the next 48H. When registering please populate the following fields with your new test user key.<br/>
         This test username has also been added as the session cookie _test_username for testing one-off paypal contributions.
         <ul>
             <li><strong>First Name:</strong> @key</li>


### PR DESCRIPTION
Cookie needs to NOT be http only so that JS can send to contribute.theguardian.com