### PR TITLE
Workaround for payment failure email

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -19,6 +19,10 @@ class Application(
   import actionRefiners._
 
   implicit val ar = assets
+  def contributionsRedirect(): Action[AnyContent] = CachedAction() {
+    Ok(views.html.contributionsRedirect())
+  }
+
   def contributionsLanding(title: String, id: String, js: String): Action[AnyContent] = CachedAction() {
     Ok(views.html.contributionsLanding(title, id, js, contributionsPayPalEndpoint))
   }

--- a/app/views/contributionsRedirect.scala.html
+++ b/app/views/contributionsRedirect.scala.html
@@ -32,7 +32,7 @@
         function getCookie(name) {
             var cookies = document.cookie.split('; ');
             for (var i = cookies.length - 1; i >= 0; i -= 1) {
-                if (cookies[i].startsWith(name)) {
+                if (cookies[i].indexOf(name) === 0) {
                     return cookies[i].substr(cookies[i].indexOf('=') + 1);
                 }
             }

--- a/app/views/contributionsRedirect.scala.html
+++ b/app/views/contributionsRedirect.scala.html
@@ -1,0 +1,50 @@
+@import assets.AssetsResolver
+@()(implicit assets: AssetsResolver)
+
+
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Support the Guardian</title>
+        <link rel="stylesheet" href="@assets("styles.css")">
+        <link rel="shortcut icon" type="image/png" href="@assets("images/favicons/32x32.ico")">
+        <link rel="apple-touch-icon" sizes="152x152" href="@assets("images/favicons/152x152.png")">
+        <link rel="apple-touch-icon" sizes="144x144" href="@assets("images/favicons/144x144.png")">
+        <link rel="apple-touch-icon" sizes="120x120" href="@assets("images/favicons/120x120.png")">
+        <link rel="apple-touch-icon" sizes="114x114" href="@assets("images/favicons/114x114.png")">
+        <link rel="apple-touch-icon" sizes="72x72" href="@assets("images/favicons/72x72.png")">
+        <link rel="apple-touch-icon-precomposed" href="@assets("images/favicons/57x57.png")">
+    </head>
+    <body>
+        <noscript>
+            <div style="text-align: center;
+                font-size: 30px;
+                padding-left: 20px;
+                padding-right: 20px;
+                background-color: #e9e939;">
+                Please enable JavaScript - we use it to provide the best experience for Guardian&nbsp;Supporters.<br/>
+                <a href="http://www.enable-javascript.com/">Click here for instructions to do so in your browser.</a>
+            </div>
+        </noscript>
+        <script type="text/javascript">
+        function getCookie(name) {
+            var cookies = document.cookie.split('; ');
+            for (var i = cookies.length - 1; i >= 0; i -= 1) {
+                if (cookies[i].startsWith(name)) {
+                    return cookies[i].substr(cookies[i].indexOf('=') + 1);
+                }
+            }
+            return null;
+        }
+
+        if (getCookie('GU_geo_country') === 'US') {
+          window.location.href = '/us/contribute'
+        } else {
+          window.location.href = '/uk/contribute'
+        }
+	    </script>
+        <!-- build-commit-id: @app.BuildInfo.gitCommitId -->
+    </body>
+</html>

--- a/app/views/contributionsRedirect.scala.html
+++ b/app/views/contributionsRedirect.scala.html
@@ -44,7 +44,7 @@
         } else {
           window.location.href = '/uk/contribute'
         }
-	    </script>
+        </script>
         <!-- build-commit-id: @app.BuildInfo.gitCommitId -->
     </body>
 </html>

--- a/conf/routes
+++ b/conf/routes
@@ -11,6 +11,7 @@ GET /                                               controllers.Default.redirect
 
 # ----- Contributions ----- #
 
+GET  /monthly-contributions                         controllers.Application.contributionsRedirect()
 GET  /uk/contribute                                 controllers.Application.contributionsLanding(title="Support the Guardian | Make a Contribution", id="contributions-landing-page-uk", js="contributionsLandingPageUK.js")
 GET  /us/contribute                                 controllers.Application.contributionsLanding(title="Support the Guardian | Make a Contribution", id="contributions-landing-page-us", js="contributionsLandingPageUS.js")
 

--- a/conf/routes
+++ b/conf/routes
@@ -9,9 +9,14 @@ GET /uk                                             controllers.Application.reac
 GET /                                               controllers.Default.redirect(to = "/uk")
 
 
-# ----- Contributions ----- #
+
+# This is a temporary client-side redirect based on geo-location
+# Once we have a separate payment failure email for US and UK we can consider removing it
 
 GET  /monthly-contributions                         controllers.Application.contributionsRedirect()
+
+# ----- Contributions ----- #
+
 GET  /uk/contribute                                 controllers.Application.contributionsLanding(title="Support the Guardian | Make a Contribution", id="contributions-landing-page-uk", js="contributionsLandingPageUK.js")
 GET  /us/contribute                                 controllers.Application.contributionsLanding(title="Support the Guardian | Make a Contribution", id="contributions-landing-page-us", js="contributionsLandingPageUS.js")
 


### PR DESCRIPTION
## Why are you doing this?

Payment failure sends uk and us to /monthly-contributions which doesn’t
exist anymore. This reinstates it, redirecting US and UK contributors
to the correct place.  We should replace this workaround with separate
failure emails for UK and US so that we don’t need to rely on
geolocation