### PR TITLE
Allow instance to access state machine execution history

### DIFF
--- a/cloud-formation/cfn.yaml
+++ b/cloud-formation/cfn.yaml
@@ -123,6 +123,7 @@ Resources:
                 Action:
                 - states:ListStateMachines
                 - states:StartExecution
+                - states:GetExecutionHistory
                 Resource: arn:aws:states:*:*:*
         - PolicyName: KMSEncryption
           PolicyDocument:


### PR DESCRIPTION
So that in-browser payment failure notification works