### PR TITLE
Add PayPal test for monthly contributions

### DIFF
--- a/assets/components/selectInput/selectInput.jsx
+++ b/assets/components/selectInput/selectInput.jsx
@@ -22,6 +22,7 @@ type PropTypes = {
   options: SelectOption[],
   onChange: (value: string) => void,
   required?: boolean,
+  id?: string
 };
 
 
@@ -35,6 +36,7 @@ export default function SelectInput(props: PropTypes) {
 
   return (
     <select
+      id={props.id}
       className="component-select-input"
       required={props.required}
       onChange={event => props.onChange(event.target.value)}

--- a/assets/components/selectInput/selectInput.jsx
+++ b/assets/components/selectInput/selectInput.jsx
@@ -52,4 +52,5 @@ export default function SelectInput(props: PropTypes) {
 
 SelectInput.defaultProps = {
   required: false,
+  id: null,
 };

--- a/assets/pages/monthly-contributions/components/formFields.jsx
+++ b/assets/pages/monthly-contributions/components/formFields.jsx
@@ -44,7 +44,7 @@ function stateDropdown(country: IsoCountry, stateUpdate: UsState => void) {
     // Sets the initial state to the first in the dropdown.
     stateUpdate(options[0].value);
 
-    return <SelectInput onChange={stateUpdate} options={options} />;
+    return <SelectInput id={"qa-state-dropdown"} onChange={stateUpdate} options={options} />;
 
   }
 

--- a/assets/pages/monthly-contributions/components/formFields.jsx
+++ b/assets/pages/monthly-contributions/components/formFields.jsx
@@ -44,7 +44,7 @@ function stateDropdown(country: IsoCountry, stateUpdate: UsState => void) {
     // Sets the initial state to the first in the dropdown.
     stateUpdate(options[0].value);
 
-    return <SelectInput id={"qa-state-dropdown"} onChange={stateUpdate} options={options} />;
+    return <SelectInput id={'qa-state-dropdown'} onChange={stateUpdate} options={options} />;
 
   }
 

--- a/test/selenium/conf/selenium-test.conf
+++ b/test/selenium/conf/selenium-test.conf
@@ -8,3 +8,9 @@ identity {
 }
 support.url = ${?SUPPORT_URL}
 web.driver.remote.url = ${?WEBDRIVER_REMOTE_URL}
+
+// Uses details from support-frontend.private.conf when running locally
+paypal.sandbox {
+  buyer.email = ${?PAYPAL_SANDBOX_EMAIL}
+  buyer.password = ${?PAYPAL_SANDBOX_PASSWORD}
+}

--- a/test/selenium/pages/ContributionsLanding.scala
+++ b/test/selenium/pages/ContributionsLanding.scala
@@ -3,9 +3,9 @@ package selenium.pages
 import org.scalatest.selenium.Page
 import selenium.util.{Browser, Config}
 
-object ContributionsLanding extends Page with Browser {
+case class ContributionsLanding(region: String) extends Page with Browser {
 
-  val url = s"${Config.supportFrontendUrl}/uk/contribute"
+  val url = s"${Config.supportFrontendUrl}/$region/contribute"
 
   private val contributeButton = id("qa-contribute-button")
 

--- a/test/selenium/util/Config.scala
+++ b/test/selenium/util/Config.scala
@@ -21,6 +21,10 @@ object Config {
     case Failure(_) => ""
   }
 
+  val paypalBuyerEmail = conf.getString("paypal.sandbox.buyer.email")
+
+  val paypalBuyerPassword = conf.getString("paypal.sandbox.buyer.password")
+
   def printSummary(): Unit = {
     logger.info("Selenium Test Configuration")
     logger.info("=============================")


### PR DESCRIPTION
## Why are you doing this?

We don't currently have an automated test which signs up for a monthly contribution with PayPal. I consider this to be a critical flow, so this PR adds the missing test. 

I've configured the test to run against the US form to get coverage of that too.

[**Trello Card**](https://trello.com/c/BwKkbrMA/455-post-deployment-tests-for-monthly-contributions-support-frontend)

## Changes

* Adds id to state-dropdown in order to make it easier to test this component with Selenium.
* Adds new methods required for PayPal test
* Adds PayPal scenario
* Configures Stripe test to run against the UK flow, and the PayPal test to run against the US flow, for better coverage.

_Note: to run these tests locally you will need to grab the latest support-frontend.private.conf, which includes test credentials for the PayPal sandbox._

## Screenshots

N/A