### PR TITLE
Re-configure Sentry

### DIFF
--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -8,6 +8,7 @@ import play.api.mvc.EssentialFilter
 import play.filters.gzip.GzipFilter
 import play.api.BuiltInComponentsFromContext
 import controllers.AssetsComponents
+import monitoring.SentryLogging
 import play.filters.HttpFiltersComponents
 
 trait AppComponents extends PlayComponents
@@ -42,5 +43,7 @@ trait AppComponents extends PlayComponents
     payPalController,
     assetController
   )
+
+  appConfig.sentryDsn foreach { dsn => new SentryLogging(dsn, appConfig.stage) }
 
 }


### PR DESCRIPTION
## Why are you doing this?
This line was accidentally dropped during a merge, so we haven't been sending our errors to Sentry. The sentry.dsn also needs to be defined in the private conf file before this will start working.

## Changes
* Configure Sentry logging if 'sentry.dsn' is defined in the private conf file.

## Screenshots
N/A
