### PR TITLE
Redux Setup Refactor - Part 1

### DIFF
--- a/assets/helpers/internationalisation/country.js
+++ b/assets/helpers/internationalisation/country.js
@@ -99,9 +99,9 @@ export function toCountryGroup(isoCountry: IsoCountry): string {
 }
 
 function fromPath(path: string = window.location.pathname): ?IsoCountry {
-  if (path.startsWith('/uk/')) {
+  if (path === '/uk' || path.startsWith('/uk/')) {
     return 'GB';
-  } else if (path.startsWith('/us/')) {
+  } else if (path === '/us' || path.startsWith('/us/')) {
     return 'US';
   }
   return null;

--- a/assets/helpers/page/__tests__/__snapshots__/pageTest.js.snap
+++ b/assets/helpers/page/__tests__/__snapshots__/pageTest.js.snap
@@ -2,7 +2,7 @@
 
 exports[`reducer tests should handle SET_COUNTRY to US 1`] = `null`;
 
-exports[`reducer tests should handle SET_COUNTRY to US 2`] = `null`;
+exports[`reducer tests should handle SET_COUNTRY to US 2`] = `"dummy_campaign"`;
 
 exports[`reducer tests should handle SET_COUNTRY to US 3`] = `null`;
 
@@ -17,7 +17,7 @@ exports[`reducer tests should handle SET_INTCMP to "dummy_intcmp" 3`] = `Object 
 exports[`reducer tests should return the initial state 1`] = `
 Object {
   "abParticipations": Object {},
-  "campaign": null,
+  "campaign": "dummy_campaign",
   "country": "GB",
   "intCmp": null,
   "refpvid": null,

--- a/assets/helpers/page/__tests__/__snapshots__/pageTest.js.snap
+++ b/assets/helpers/page/__tests__/__snapshots__/pageTest.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`reducer tests should handle SET_COUNTRY to US 1`] = `null`;
+
+exports[`reducer tests should handle SET_COUNTRY to US 2`] = `null`;
+
+exports[`reducer tests should handle SET_COUNTRY to US 3`] = `null`;
+
+exports[`reducer tests should handle SET_COUNTRY to US 4`] = `Object {}`;
+
+exports[`reducer tests should handle SET_INTCMP to "dummy_intcmp" 1`] = `null`;
+
+exports[`reducer tests should handle SET_INTCMP to "dummy_intcmp" 2`] = `"GB"`;
+
+exports[`reducer tests should handle SET_INTCMP to "dummy_intcmp" 3`] = `Object {}`;
+
+exports[`reducer tests should return the initial state 1`] = `
+Object {
+  "abParticipations": Object {},
+  "campaign": null,
+  "country": "GB",
+  "intCmp": null,
+  "refpvid": null,
+}
+`;

--- a/assets/helpers/page/__tests__/pageTest.js
+++ b/assets/helpers/page/__tests__/pageTest.js
@@ -19,7 +19,7 @@ describe('reducer tests', () => {
 
     const initialState = {
       intCmp: null,
-      campaign: null,
+      campaign: 'dummy_campaign',
       refpvid: null,
       country: 'GB',
       abParticipations: {},

--- a/assets/helpers/page/__tests__/pageTest.js
+++ b/assets/helpers/page/__tests__/pageTest.js
@@ -60,7 +60,7 @@ describe('reducer tests', () => {
 
     const newState = reducer(undefined, action);
 
-    expect(newState.country).toEqual('US');
+    expect(newState.country).toEqual(country);
     expect(newState.intCmp).toMatchSnapshot();
     expect(newState.campaign).toMatchSnapshot();
     expect(newState.refpvid).toMatchSnapshot();

--- a/assets/helpers/page/__tests__/pageTest.js
+++ b/assets/helpers/page/__tests__/pageTest.js
@@ -1,0 +1,70 @@
+// @flow
+
+// ----- Imports ----- //
+
+import type { Country } from 'helpers/internationalisation/country';
+
+import { createCommonReducer } from '../page';
+
+
+// ----- Tests ----- //
+
+jest.mock('ophan', () => {});
+
+describe('reducer tests', () => {
+
+  let reducer = () => {};
+
+  beforeEach(() => {
+
+    const initialState = {
+      intCmp: null,
+      campaign: null,
+      refpvid: null,
+      country: 'GB',
+      abParticipations: {},
+    };
+
+    reducer = createCommonReducer(initialState);
+
+  });
+
+  it('should return the initial state', () => {
+    expect(reducer(undefined, {})).toMatchSnapshot();
+  });
+
+  it('should handle SET_INTCMP to "dummy_intcmp"', () => {
+
+    const intCmp = 'dummy_intcmp';
+    const action = {
+      type: 'SET_INTCMP',
+      intCmp,
+    };
+
+    const newState = reducer(undefined, action);
+
+    expect(newState.intCmp).toEqual(intCmp);
+    expect(newState.campaign).toBeNull();
+    expect(newState.refpvid).toMatchSnapshot();
+    expect(newState.country).toMatchSnapshot();
+    expect(newState.abParticipations).toMatchSnapshot();
+  });
+
+  it('should handle SET_COUNTRY to US', () => {
+
+    const country: Country = 'US';
+    const action = {
+      type: 'SET_COUNTRY',
+      country,
+    };
+
+    const newState = reducer(undefined, action);
+
+    expect(newState.country).toEqual('US');
+    expect(newState.intCmp).toMatchSnapshot();
+    expect(newState.campaign).toMatchSnapshot();
+    expect(newState.refpvid).toMatchSnapshot();
+    expect(newState.abParticipations).toMatchSnapshot();
+  });
+
+});

--- a/assets/helpers/page/page.js
+++ b/assets/helpers/page/page.js
@@ -32,6 +32,7 @@ type CommonState = {
 
 // ----- Functions ----- //
 
+// Sets up GA and logging.
 function analyticsInitialisation(participations: Participations): void {
 
   // Google analytics.
@@ -44,8 +45,8 @@ function analyticsInitialisation(participations: Participations): void {
 
 }
 
-function createCommonReducer(
-  abParticipations: Participations): (CommonState, Action) => CommonState {
+// Creates the initial state for the common reducer.
+function buildInitialState(abParticipations: Participations) {
 
   const intCmp = getQueryParameter('INTCMP');
 
@@ -56,6 +57,14 @@ function createCommonReducer(
     country: detect(),
     abParticipations,
   };
+
+  return initialState;
+
+}
+
+// Sets up the common reducer with its initial state.
+function createCommonReducer(
+  initialState: CommonState): (CommonState, Action) => CommonState {
 
   function commonReducer(
     state: CommonState = initialState,
@@ -83,11 +92,13 @@ function createCommonReducer(
 
 }
 
+// Initialises the page.
 function init(pageReducer: Object, preloadedState: ?Object, middleware: ?Function) {
 
-  const participations = abTest.init();
+  const participations: Participations = abTest.init();
   analyticsInitialisation(participations);
-  const commonReducer = createCommonReducer(participations);
+  const initialState: CommonState = buildInitialState(participations);
+  const commonReducer = createCommonReducer(initialState);
 
   return createStore(
     combineReducers({ page: pageReducer, common: commonReducer }),
@@ -101,5 +112,6 @@ function init(pageReducer: Object, preloadedState: ?Object, middleware: ?Functio
 // ----- Exports ----- //
 
 export {
+  createCommonReducer,
   init,
 };

--- a/assets/helpers/page/page.js
+++ b/assets/helpers/page/page.js
@@ -32,10 +32,7 @@ type CommonState = {
 
 // ----- Functions ----- //
 
-function pageInitialisation() {
-
-  // AB tests.
-  const participations = abTest.init();
+function analyticsInitialisation(participations: Participations): void {
 
   // Google analytics.
   ga.init();
@@ -45,11 +42,10 @@ function pageInitialisation() {
   // Logging.
   logger.init();
 
-  return participations;
-
 }
 
-function createCommonReducer(abParticipations: Participations) {
+function createCommonReducer(
+  abParticipations: Participations): (CommonState, Action) => CommonState {
 
   const intCmp = getQueryParameter('INTCMP');
 
@@ -89,8 +85,9 @@ function createCommonReducer(abParticipations: Participations) {
 
 function init(pageReducer: Object, preloadedState: ?Object, middleware: ?Function) {
 
-  const abParticipations = pageInitialisation();
-  const commonReducer = createCommonReducer(abParticipations);
+  const participations = abTest.init();
+  analyticsInitialisation(participations);
+  const commonReducer = createCommonReducer(participations);
 
   return createStore(
     combineReducers({ page: pageReducer, common: commonReducer }),

--- a/assets/helpers/page/page.js
+++ b/assets/helpers/page/page.js
@@ -21,7 +21,7 @@ import type { Action } from './pageActions';
 
 // ----- Types ----- //
 
-type PageState = {
+type CommonState = {
   intCmp: ?string,
   campaign: ?Campaign,
   refpvid: ?string,
@@ -49,11 +49,11 @@ function pageInitialisation() {
 
 }
 
-function createPageReducer(abParticipations: Participations) {
+function createCommonReducer(abParticipations: Participations) {
 
   const intCmp = getQueryParameter('INTCMP');
 
-  const initialState: PageState = {
+  const initialState: CommonState = {
     intCmp,
     campaign: intCmp ? getCampaign(intCmp) : null,
     refpvid: getQueryParameter('REFPVID'),
@@ -61,9 +61,9 @@ function createPageReducer(abParticipations: Participations) {
     abParticipations,
   };
 
-  function pageReducer(
-    state: PageState = initialState,
-    action: Action): PageState {
+  function commonReducer(
+    state: CommonState = initialState,
+    action: Action): CommonState {
 
     switch (action.type) {
 
@@ -80,17 +80,17 @@ function createPageReducer(abParticipations: Participations) {
 
   }
 
-  return pageReducer;
+  return commonReducer;
 
 }
 
-function init(reducers: Object, preloadedState: ?Object, middleware: ?Function) {
+function init(pageReducer: Object, preloadedState: ?Object, middleware: ?Function) {
 
   const abParticipations = pageInitialisation();
-  const pageReducer = createPageReducer(abParticipations);
+  const commonReducer = createCommonReducer(abParticipations);
 
   return createStore(
-    combineReducers(Object.assign(reducers, { page: pageReducer })),
+    combineReducers({ page: pageReducer, common: commonReducer }),
     preloadedState,
     middleware,
   );

--- a/assets/helpers/page/page.js
+++ b/assets/helpers/page/page.js
@@ -68,7 +68,10 @@ function createCommonReducer(abParticipations: Participations) {
     switch (action.type) {
 
       case 'SET_INTCMP':
-        return Object.assign({}, state, { intCmp: action.intCmp });
+        return Object.assign({}, state, {
+          intCmp: action.intCmp,
+          campaign: getCampaign(action.intCmp),
+        });
 
       case 'SET_COUNTRY':
         return Object.assign({}, state, { country: action.country });

--- a/assets/helpers/page/page.js
+++ b/assets/helpers/page/page.js
@@ -1,0 +1,105 @@
+// @flow
+
+// ----- Imports ----- //
+
+import { createStore, combineReducers } from 'redux';
+import 'ophan';
+
+import * as ga from 'helpers/tracking/ga';
+import * as abTest from 'helpers/abtest';
+import * as logger from 'helpers/logger';
+import { getCampaign } from 'helpers/tracking/guTracking';
+import { getQueryParameter } from 'helpers/url';
+import { detect } from 'helpers/internationalisation/country';
+
+import type { Campaign } from 'helpers/tracking/guTracking';
+import type { IsoCountry } from 'helpers/internationalisation/country';
+import type { Participations } from 'helpers/abtest';
+
+import type { Action } from './pageActions';
+
+
+// ----- Types ----- //
+
+type PageState = {
+  intCmp: ?string,
+  campaign: ?Campaign,
+  refpvid: ?string,
+  country: IsoCountry,
+  abParticipations: Participations,
+};
+
+
+// ----- Functions ----- //
+
+function pageInitialisation() {
+
+  // AB tests.
+  const participations = abTest.init();
+
+  // Google analytics.
+  ga.init();
+  ga.setDimension('experience', abTest.getVariantsAsString(participations));
+  ga.trackPageview();
+
+  // Logging.
+  logger.init();
+
+  return participations;
+
+}
+
+function createPageReducer(abParticipations: Participations) {
+
+  const intCmp = getQueryParameter('INTCMP');
+
+  const initialState: PageState = {
+    intCmp,
+    campaign: intCmp ? getCampaign(intCmp) : null,
+    refpvid: getQueryParameter('REFPVID'),
+    country: detect(),
+    abParticipations,
+  };
+
+  function pageReducer(
+    state: PageState = initialState,
+    action: Action): PageState {
+
+    switch (action.type) {
+
+      case 'SET_INTCMP':
+        return Object.assign({}, state, { intCmp: action.intCmp });
+
+      case 'SET_COUNTRY':
+        return Object.assign({}, state, { country: action.country });
+
+      default:
+        return state;
+
+    }
+
+  }
+
+  return pageReducer;
+
+}
+
+function init(reducers: Object, preloadedState: ?Object, middleware: ?Function) {
+
+  const abParticipations = pageInitialisation();
+  const pageReducer = createPageReducer(abParticipations);
+
+  return createStore(
+    combineReducers(Object.assign(reducers, { page: pageReducer })),
+    preloadedState,
+    middleware,
+  );
+
+}
+
+
+// ----- Exports ----- //
+
+export {
+  init,
+};

--- a/assets/helpers/page/pageActions.js
+++ b/assets/helpers/page/pageActions.js
@@ -1,0 +1,24 @@
+// @flow
+
+// ----- Imports ----- //
+
+import type { IsoCountry } from 'helpers/internationalisation/country';
+
+
+// ----- Types ----- //
+
+export type Action =
+  | { type: 'SET_INTCMP', intCmp: string }
+  | { type: 'SET_COUNTRY', country: IsoCountry }
+  ;
+
+
+// ----- Action Creators ----- //
+
+export function setIntCmp(intCmp: string): Action {
+  return { type: 'SET_INTCMP', intCmp };
+}
+
+export function setCountry(country: IsoCountry): Action {
+  return { type: 'SET_COUNTRY', country };
+}

--- a/assets/helpers/tracking/guTracking.js
+++ b/assets/helpers/tracking/guTracking.js
@@ -23,13 +23,6 @@ export type Campaign = $Keys<typeof campaigns>;
 
 // ----- Functions ----- //
 
-// Checks if a user is in a known campaign based upon their intCmp.
-function inCampaign(campaign: Campaign, intCmp: string): boolean {
-
-  return campaigns[campaign] && campaigns[campaign].includes(intCmp);
-
-}
-
 // Retrieves the user's campaign, if known, from the intCmp.
 function getCampaign(intCmp: string): ?Campaign {
 
@@ -53,7 +46,6 @@ const refpvidReducer = (state: ?string = null): ?string => state;
 export {
   intCmpReducer,
   refpvidReducer,
-  inCampaign,
   getCampaign,
 };
 

--- a/assets/pages/bundles-landing/bundlesLanding.jsx
+++ b/assets/pages/bundles-landing/bundlesLanding.jsx
@@ -4,43 +4,34 @@
 
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { createStore } from 'redux';
 import { Provider } from 'react-redux';
 
 import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
 import SimpleFooter from 'components/footers/simpleFooter/simpleFooter';
 
-import pageStartup from 'helpers/pageStartup';
-import { getQueryParameter } from 'helpers/url';
-import { setCountry } from 'helpers/internationalisation/country';
+import { init as pageInit } from 'helpers/page/page';
+import { setIntCmp } from 'helpers/page/pageActions';
 import { inCampaign } from 'helpers/tracking/guTracking';
 
 import Introduction from './components/Introduction';
 import Bundles from './components/Bundles';
 import WhySupport from './components/WhySupport';
 import WaysOfSupport from './components/WaysOfSupport';
-import reducer from './reducers/reducers';
-
-
-// ----- Page Startup ----- //
-
-const participation = pageStartup.start();
-setCountry('GB');
+import reducers from './reducers/reducers';
 
 
 // ----- Redux Store ----- //
 
-const intCmp = getQueryParameter('INTCMP', 'gdnwb_copts_bundles_landing_default');
+const store = pageInit(reducers);
 
-const store = createStore(reducer, {
-  intCmp,
-});
 
-store.dispatch({ type: 'SET_AB_TEST_PARTICIPATION', payload: participation });
-let waysOfSupport = <WaysOfSupport />;
+// ----- Setup ----- //
 
-if (intCmp && inCampaign('baseline_test', intCmp)) {
-  waysOfSupport = '';
+let intCmp = store.getState().page.intCmp;
+
+if (!intCmp) {
+  intCmp = 'gdnwb_copts_bundles_landing_default';
+  store.dispatch(setIntCmp(intCmp));
 }
 
 
@@ -53,7 +44,7 @@ const content = (
       <Introduction />
       <Bundles />
       <WhySupport />
-      {waysOfSupport}
+      {inCampaign('baseline_test', intCmp) ? '' : <WaysOfSupport />}
       <SimpleFooter />
     </div>
   </Provider>

--- a/assets/pages/bundles-landing/bundlesLanding.jsx
+++ b/assets/pages/bundles-landing/bundlesLanding.jsx
@@ -11,7 +11,6 @@ import SimpleFooter from 'components/footers/simpleFooter/simpleFooter';
 
 import { init as pageInit } from 'helpers/page/page';
 import { setIntCmp } from 'helpers/page/pageActions';
-import { inCampaign } from 'helpers/tracking/guTracking';
 
 import Introduction from './components/Introduction';
 import Bundles from './components/Bundles';
@@ -44,7 +43,7 @@ const content = (
       <Introduction />
       <Bundles />
       <WhySupport />
-      {inCampaign('baseline_test', intCmp) ? '' : <WaysOfSupport />}
+      {store.getState().common.campaign === 'baseline_test' ? '' : <WaysOfSupport />}
       <SimpleFooter />
     </div>
   </Provider>

--- a/assets/pages/bundles-landing/bundlesLanding.jsx
+++ b/assets/pages/bundles-landing/bundlesLanding.jsx
@@ -17,17 +17,17 @@ import Introduction from './components/Introduction';
 import Bundles from './components/Bundles';
 import WhySupport from './components/WhySupport';
 import WaysOfSupport from './components/WaysOfSupport';
-import reducers from './reducers/reducers';
+import reducer from './reducers/reducers';
 
 
 // ----- Redux Store ----- //
 
-const store = pageInit(reducers);
+const store = pageInit(reducer);
 
 
 // ----- Setup ----- //
 
-let intCmp = store.getState().page.intCmp;
+let intCmp = store.getState().common.intCmp;
 
 if (!intCmp) {
   intCmp = 'gdnwb_copts_bundles_landing_default';

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -12,6 +12,7 @@ import Bundle from 'components/bundle/bundle';
 import ContribAmounts from 'components/contribAmounts/contribAmounts';
 import type { Contrib, Amounts, ContribError } from 'helpers/contributions';
 import type { IsoCountry } from 'helpers/internationalisation/country';
+import type { Campaign } from 'helpers/tracking/guTracking';
 import { routes } from 'helpers/routes';
 
 import {
@@ -36,6 +37,7 @@ type PropTypes = {
   contribAmount: Amounts,
   contribError: ContribError,
   intCmp: string,
+  campaign: ?Campaign,
   toggleContribType: (string) => void,
   changeContribAnnualAmount: (string) => void,
   changeContribMonthlyAmount: (string) => void,
@@ -243,7 +245,7 @@ function PaperBundle(props: PaperAttrs) {
 
 function Bundles(props: PropTypes) {
 
-  const subsLinks: SubsUrls = getSubsLinks(props.intCmp);
+  const subsLinks: SubsUrls = getSubsLinks(props.intCmp, props.campaign);
   const paperAttrs: PaperAttrs = getPaperAttrs(subsLinks);
   const digitalAttrs: DigitalAttrs = getDigitalAttrs(subsLinks);
 
@@ -273,6 +275,7 @@ function mapStateToProps(state) {
     contribAmount: state.page.amount,
     contribError: state.page.error,
     intCmp: state.common.intCmp,
+    campaign: state.common.campaign,
     isoCountry: state.common.country,
   };
 }

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -272,8 +272,8 @@ function mapStateToProps(state) {
     contribType: state.contribution.type,
     contribAmount: state.contribution.amount,
     contribError: state.contribution.error,
-    intCmp: state.intCmp,
-    isoCountry: state.isoCountry,
+    intCmp: state.page.intCmp,
+    isoCountry: state.page.country,
   };
 }
 

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -269,11 +269,11 @@ function Bundles(props: PropTypes) {
 
 function mapStateToProps(state) {
   return {
-    contribType: state.contribution.type,
-    contribAmount: state.contribution.amount,
-    contribError: state.contribution.error,
-    intCmp: state.page.intCmp,
-    isoCountry: state.page.country,
+    contribType: state.page.type,
+    contribAmount: state.page.amount,
+    contribError: state.page.error,
+    intCmp: state.common.intCmp,
+    isoCountry: state.common.country,
   };
 }
 

--- a/assets/pages/bundles-landing/helpers/subscriptionsLinks.js
+++ b/assets/pages/bundles-landing/helpers/subscriptionsLinks.js
@@ -2,7 +2,6 @@
 
 // ----- Imports ----- //
 
-import { getCampaign } from 'helpers/tracking/guTracking';
 import type { Campaign } from 'helpers/tracking/guTracking';
 
 
@@ -57,9 +56,7 @@ function buildUrls(promoCodes: PromoCodes, intCmp: string): SubsUrls {
 }
 
 // Creates links to subscriptions, tailored to the user's campaign.
-function getSubsLinks(intCmp: string): SubsUrls {
-
-  const campaign = getCampaign(intCmp);
+function getSubsLinks(intCmp: string, campaign: ?Campaign): SubsUrls {
 
   if (campaign && customPromos[campaign]) {
     return buildUrls(customPromos[campaign], intCmp);

--- a/assets/pages/bundles-landing/reducers/__tests__/__snapshots__/reducersTest.js.snap
+++ b/assets/pages/bundles-landing/reducers/__tests__/__snapshots__/reducersTest.js.snap
@@ -96,25 +96,21 @@ Object {
 
 exports[`reducer tests should return the initial state 1`] = `
 Object {
-  "abTests": Object {},
-  "contribution": Object {
-    "amount": Object {
-      "annual": Object {
-        "userDefined": false,
-        "value": "75",
-      },
-      "monthly": Object {
-        "userDefined": false,
-        "value": "10",
-      },
-      "oneOff": Object {
-        "userDefined": false,
-        "value": "50",
-      },
+  "amount": Object {
+    "annual": Object {
+      "userDefined": false,
+      "value": "75",
     },
-    "error": null,
-    "type": "MONTHLY",
+    "monthly": Object {
+      "userDefined": false,
+      "value": "10",
+    },
+    "oneOff": Object {
+      "userDefined": false,
+      "value": "50",
+    },
   },
-  "intCmp": null,
+  "error": null,
+  "type": "MONTHLY",
 }
 `;

--- a/assets/pages/bundles-landing/reducers/__tests__/reducersTest.js
+++ b/assets/pages/bundles-landing/reducers/__tests__/reducersTest.js
@@ -28,9 +28,9 @@ describe('reducer tests', () => {
 
     const newState = reducer(undefined, action);
 
-    expect(newState.contribution.type).toEqual(contribType);
-    expect(newState.contribution.error).toMatchSnapshot();
-    expect(newState.contribution.amount).toMatchSnapshot();
+    expect(newState.type).toEqual(contribType);
+    expect(newState.error).toMatchSnapshot();
+    expect(newState.amount).toMatchSnapshot();
   });
 
   it('should handle CHANGE_CONTRIB_TYPE to MONTHLY', () => {
@@ -76,10 +76,10 @@ describe('reducer tests', () => {
 
     const newState = reducer(undefined, action);
 
-    expect(newState.contribution.type).toMatchSnapshot();
-    expect(newState.contribution.error).toMatchSnapshot();
-    expect(newState.contribution.amount.monthly).toEqual(amount);
-    expect(newState.contribution.amount.oneOff).toEqual(amount);
+    expect(newState.type).toMatchSnapshot();
+    expect(newState.error).toMatchSnapshot();
+    expect(newState.amount.monthly).toEqual(amount);
+    expect(newState.amount.oneOff).toEqual(amount);
   });
 
   it('should handle CHANGE_CONTRIB_AMOUNT_MONTHLY', () => {
@@ -114,10 +114,10 @@ describe('reducer tests', () => {
 
     const newState = reducer(undefined, action);
 
-    expect(newState.contribution.type).toMatchSnapshot();
-    expect(newState.contribution.error).toMatchSnapshot();
-    expect(newState.contribution.amount.annual).toEqual(amount);
-    expect(newState.contribution.amount.oneOff).toMatchSnapshot();
+    expect(newState.type).toMatchSnapshot();
+    expect(newState.error).toMatchSnapshot();
+    expect(newState.amount.annual).toEqual(amount);
+    expect(newState.amount.oneOff).toMatchSnapshot();
   });
 
   it('should handle CHANGE_CONTRIB_AMOUNT_ONEOFF', () => {
@@ -133,9 +133,9 @@ describe('reducer tests', () => {
 
     const newState = reducer(undefined, action);
 
-    expect(newState.contribution.type).toMatchSnapshot();
-    expect(newState.contribution.error).toMatchSnapshot();
-    expect(newState.contribution.amount.oneOff).toEqual(amount);
-    expect(newState.contribution.amount.monthly).toMatchSnapshot();
+    expect(newState.type).toMatchSnapshot();
+    expect(newState.error).toMatchSnapshot();
+    expect(newState.amount.oneOff).toEqual(amount);
+    expect(newState.amount.monthly).toMatchSnapshot();
   });
 });

--- a/assets/pages/bundles-landing/reducers/__tests__/reducersTest.js
+++ b/assets/pages/bundles-landing/reducers/__tests__/reducersTest.js
@@ -43,9 +43,9 @@ describe('reducer tests', () => {
 
     const newState = reducer(undefined, action);
 
-    expect(newState.contribution.type).toEqual(contribType);
-    expect(newState.contribution.error).toMatchSnapshot();
-    expect(newState.contribution.amount).toMatchSnapshot();
+    expect(newState.type).toEqual(contribType);
+    expect(newState.error).toMatchSnapshot();
+    expect(newState.amount).toMatchSnapshot();
   });
 
   it('should handle CHANGE_CONTRIB_TYPE to ANNUAL', () => {
@@ -58,9 +58,9 @@ describe('reducer tests', () => {
 
     const newState = reducer(undefined, action);
 
-    expect(newState.contribution.type).toEqual(contribType);
-    expect(newState.contribution.error).toMatchSnapshot();
-    expect(newState.contribution.amount).toMatchSnapshot();
+    expect(newState.type).toEqual(contribType);
+    expect(newState.error).toMatchSnapshot();
+    expect(newState.amount).toMatchSnapshot();
   });
 
   it('should handle CHANGE_CONTRIB_AMOUNT', () => {
@@ -95,10 +95,10 @@ describe('reducer tests', () => {
 
     const newState = reducer(undefined, action);
 
-    expect(newState.contribution.type).toMatchSnapshot();
-    expect(newState.contribution.error).toMatchSnapshot();
-    expect(newState.contribution.amount.monthly).toEqual(amount);
-    expect(newState.contribution.amount.oneOff).toMatchSnapshot();
+    expect(newState.type).toMatchSnapshot();
+    expect(newState.error).toMatchSnapshot();
+    expect(newState.amount.monthly).toEqual(amount);
+    expect(newState.amount.oneOff).toMatchSnapshot();
   });
 
   it('should handle CHANGE_CONTRIB_AMOUNT_ANNUAL', () => {

--- a/assets/pages/bundles-landing/reducers/reducers.js
+++ b/assets/pages/bundles-landing/reducers/reducers.js
@@ -2,10 +2,6 @@
 
 // ----- Imports ----- //
 
-import { combineReducers } from 'redux';
-
-import { abTestReducer as abTests } from 'helpers/abtest';
-import { intCmpReducer as intCmp } from 'helpers/tracking/guTracking';
 import type { Contrib, ContribError, Amounts } from 'helpers/contributions';
 
 import { parse as parseContribution } from 'helpers/contributions';
@@ -45,7 +41,7 @@ const initialContrib: ContribState = {
 
 // ----- Reducers ----- //
 
-function contribution(
+function contributionReducer(
   state: ContribState = initialContrib,
   action: Action): ContribState {
 
@@ -117,10 +113,7 @@ function contribution(
 
 }
 
+
 // ----- Exports ----- //
 
-export default combineReducers({
-  contribution,
-  intCmp,
-  abTests,
-});
+export default { contribution: contributionReducer };

--- a/assets/pages/bundles-landing/reducers/reducers.js
+++ b/assets/pages/bundles-landing/reducers/reducers.js
@@ -116,4 +116,4 @@ function contributionReducer(
 
 // ----- Exports ----- //
 
-export default { contribution: contributionReducer };
+export default contributionReducer;


### PR DESCRIPTION
## Why are you doing this?

With the rollout of Tests 2, 3 and 4 we've generated a lot of tech debt in how we handle page initialisation. We currently setup the store in various different ways on multiple pages:

- Hydrating from an object (probably wrong).
- Initial state using higher-order reducer (probably the correct option, but confusing to parse).
- Post-creation actions (reasonable, but semantically debatable if they're never going to change after first render).

This PR simplifies page setup by pulling it into a `page.js` shared helper. This module takes on the initialisation previously handled in `pageStartup`, and creates a 'common' reducer for handling state that is likely to exist in multiple pages. It also handles creation of the redux store.

### State Structure

The 'common' state includes tracking information such as `INTCMP` and REFPVID, the country, AB test participations, etc. The state that's local to a specific page is then contained in the 'page' section of the state. The structure of the overall state now looks like this:

```js
{
  common: {
    intCmp: ?string,
    campaign: ?Campaign,
    refpvid: ?string,
    country: IsoCountry,
    abParticipations: Participations,
  },
  page: {
    // The rest of the redux state, specific to the current page.
  },
}
```

I have applied this to the bundles landing page as a first pass, to make sure that:

1) It works.
2) We're happy with this approach.

If we're confident on these points, I'll do a follow-up PR to apply it to the other pages, or add some tweaks/improvements if needed.

[**Trello Card**](https://trello.com/c/QTW8gmx0/829-refactor-the-way-we-handle-initial-state-and-setup-of-redux-on-the-page)

## Changes

- Update the `fromPath` function for obtaining the country to work for the bundles landing page (`/uk`).
- Added a new `page.js` shared helper for initialising page state.
- Added actions for changing country (not used now, but useful in the future when we allow users to do this) and intcmp.
- Applied these changes to the bundles landing page.
