### PR TITLE
Improving paypal testing developer experience

### DIFF
--- a/app/controllers/TestUsersManagement.scala
+++ b/app/controllers/TestUsersManagement.scala
@@ -11,13 +11,16 @@ import views.html.{testUsers => testUsersView}
 class TestUsersManagement(
     authAction: AuthAction[AnyContent],
     components: ControllerComponents,
-    testUsers: TestUserService
+    testUsers: TestUserService,
+    supportUrl: String
 )(implicit val ec: ExecutionContext) extends AbstractController(components) {
+
+  private val cookieDomain = supportUrl.stripPrefix("https://").stripPrefix("support")
 
   def createTestUser: Action[AnyContent] = authAction {
     val testUser = testUsers.testUsers.generate()
     Ok(testUsersView(testUser))
       .withHeaders(CacheControl.noCache)
-      .withCookies(Cookie("_test_username", testUser, httpOnly = false))
+      .withCookies(Cookie("_test_username", testUser, httpOnly = false, domain = Some(cookieDomain)))
   }
 }

--- a/app/wiring/Controllers.scala
+++ b/app/wiring/Controllers.scala
@@ -51,6 +51,7 @@ trait Controllers {
   lazy val testUsersContoller = new TestUsersManagement(
     authAction,
     controllerComponents,
-    testUsers
+    testUsers,
+    appConfig.supportUrl
   )
 }


### PR DESCRIPTION
## Why are you doing this?

Avoid manual step of creating cookie on contribute.theguardian.com by changing support.theguardian.com cookie scope to .theguardian.com

## Changes

* Add cookie domain so that test_user is visible on contribute.theguardian.com

## Screenshots

