### PR TITLE
Annual contributions ab test

### DIFF
--- a/assets/components/contribAmounts/contribAmounts.jsx
+++ b/assets/components/contribAmounts/contribAmounts.jsx
@@ -15,7 +15,7 @@ import type { Contrib, ContribError, Amounts } from 'helpers/contributions';
 import type { Radio } from 'components/radioToggle/radioToggle';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import { forCountry } from 'helpers/internationalisation/currency';
-import { getQueryParameter } from '../../helpers/url';
+import type { Participations } from '../../helpers/abtest';
 
 
 // ----- Types ----- //
@@ -34,6 +34,7 @@ type PropTypes = {
   toggleContribType: (string) => void,
   onNumberInputKeyPress: () => void,
   isoCountry: IsoCountry,
+  abTests: Participations,
 };
 
 /* eslint-enable react/no-unused-prop-types */
@@ -161,6 +162,20 @@ const amountRadiosOneOff = {
 };
 
 const contribCaptionRadios = {
+  GB_WITH_ANNUAL: [
+    {
+      value: 'ANNUAL',
+      text: 'Annual',
+    },
+    {
+      value: 'MONTHLY',
+      text: 'Monthly',
+    },
+    {
+      value: 'ONE_OFF',
+      text: 'One-off',
+    },
+  ],
   GB: [
     {
       value: 'MONTHLY',
@@ -183,18 +198,6 @@ const contribCaptionRadios = {
   ],
 };
 
-const showAnnual = getQueryParameter('showAnnual', 'false');
-if (showAnnual === 'true') {
-  contribCaptionRadios.GB.unshift({
-    value: 'ANNUAL',
-    text: 'Annual',
-  });
-  contribCaptionRadios.US.unshift({
-    value: 'ANNUAL',
-    text: 'Annual',
-  });
-}
-
 // ----- Functions ----- //
 
 function amountToggles(isoCountry: IsoCountry = 'GB'): AmountToggle {
@@ -214,10 +217,10 @@ function amountToggles(isoCountry: IsoCountry = 'GB'): AmountToggle {
   };
 }
 
-function contribToggle(isoCountry: IsoCountry = 'GB'): Toggle {
+function contribToggle(isoCountry: IsoCountry = 'GB', showAnnual: boolean): Toggle {
   return {
     name: 'contributions-period-toggle',
-    radios: contribCaptionRadios[isoCountry],
+    radios: showAnnual ? contribCaptionRadios.GB_WITH_ANNUAL : contribCaptionRadios[isoCountry],
   };
 }
 
@@ -245,6 +248,7 @@ function errorMessage(error: ?ContribError,
 }
 
 function getAttrs(props: PropTypes): ContribAttrs {
+
 
   if (props.contribType === 'ANNUAL') {
 
@@ -294,6 +298,7 @@ function getClassName(contribType: Contrib): string {
 
 export default function ContribAmounts(props: PropTypes) {
 
+  const showAnnual = props.abTests && props.abTests.annualContributions && props.abTests.annualContributions === 'variant';
   const attrs = getAttrs(props);
   const className = getClassName(attrs.contribType);
 
@@ -301,9 +306,10 @@ export default function ContribAmounts(props: PropTypes) {
     <div className="component-contrib-amounts">
       <div className="contrib-type">
         <RadioToggle
-          {...contribToggle(props.isoCountry)}
+          {...contribToggle(props.isoCountry, showAnnual)}
           toggleAction={props.toggleContribType}
           checked={props.contribType}
+          showAnnual={showAnnual}
         />
       </div>
       <div className={className}>
@@ -311,6 +317,7 @@ export default function ContribAmounts(props: PropTypes) {
           {...attrs.toggles}
           toggleAction={attrs.toggleAction}
           checked={attrs.checked}
+          showAnnual={showAnnual}
         />
         <div className="component-contrib-amounts__other-amount">
           <NumberInput

--- a/assets/components/contribAmounts/contribAmounts.jsx
+++ b/assets/components/contribAmounts/contribAmounts.jsx
@@ -295,9 +295,10 @@ function getClassName(contribType: Contrib): string {
 // ----- Component ----- //
 
 function getShowAnnual(props): boolean {
-  return props.abTests !== undefined &&
-    props.abTests.annualContributions !== undefined &&
-    props.abTests.annualContributions === 'variant';
+  return props.isoCountry === 'GB' &&
+    props.abTests !== undefined &&
+    props.abTests.addAnnualContributions !== undefined &&
+    props.abTests.addAnnualContributions === 'variant';
 }
 
 export default function ContribAmounts(props: PropTypes) {

--- a/assets/components/contribAmounts/contribAmounts.jsx
+++ b/assets/components/contribAmounts/contribAmounts.jsx
@@ -17,7 +17,6 @@ import type { IsoCountry } from 'helpers/internationalisation/country';
 import { forCountry } from 'helpers/internationalisation/currency';
 import type { Participations } from '../../helpers/abtest';
 
-
 // ----- Types ----- //
 
 // Disabling the linter here because it's just buggy...
@@ -249,7 +248,6 @@ function errorMessage(error: ?ContribError,
 
 function getAttrs(props: PropTypes): ContribAttrs {
 
-
   if (props.contribType === 'ANNUAL') {
 
     const userDefined = props.contribAmount.annual.userDefined;
@@ -296,9 +294,15 @@ function getClassName(contribType: Contrib): string {
 
 // ----- Component ----- //
 
+function getShowAnnual(props): boolean {
+  return props.abTests !== undefined &&
+    props.abTests.annualContributions !== undefined &&
+    props.abTests.annualContributions === 'variant';
+}
+
 export default function ContribAmounts(props: PropTypes) {
 
-  const showAnnual = props.abTests && props.abTests.annualContributions && props.abTests.annualContributions === 'variant';
+  const showAnnual: boolean = getShowAnnual(props);
   const attrs = getAttrs(props);
   const className = getClassName(attrs.contribType);
 

--- a/assets/components/radioToggle/radioToggle.jsx
+++ b/assets/components/radioToggle/radioToggle.jsx
@@ -3,8 +3,6 @@
 // ----- Imports ----- //
 
 import React from 'react';
-import type { Participations } from '../../helpers/abtest';
-
 
 // ----- Types ----- //
 

--- a/assets/components/radioToggle/radioToggle.jsx
+++ b/assets/components/radioToggle/radioToggle.jsx
@@ -3,7 +3,7 @@
 // ----- Imports ----- //
 
 import React from 'react';
-import { getQueryParameter } from '../../helpers/url';
+import type { Participations } from '../../helpers/abtest';
 
 
 // ----- Types ----- //
@@ -21,19 +21,21 @@ type PropTypes = {
   radios: Radio[],
   checked: ?string,
   toggleAction: (string) => void,
+  showAnnual: boolean,
 };
 
 /* eslint-enable react/no-unused-prop-types */
 
-
+function getClassName(props: PropTypes) {
+  return props.showAnnual === true ? 'component-radio-toggle__button--with-annual' : 'component-radio-toggle__button--without-annual';
+}
 // ----- Component ----- //
 
 export default function RadioToggle(props: PropTypes) {
   const radioButtons = props.radios.map((radio: Radio, idx: number) => {
 
     const radioId = `${props.name}-${idx}`;
-    const showAnnual = getQueryParameter('showAnnual', 'false');
-    const className = showAnnual === 'true' ? 'component-radio-toggle__button--with-annual' : 'component-radio-toggle__button--without-annual';
+    const className = getClassName(props);
 
     return (
       <span className={`component-radio-toggle__button ${className}`} key={radioId}>

--- a/assets/helpers/abtest.js
+++ b/assets/helpers/abtest.js
@@ -20,7 +20,7 @@ type Audience = {
   size: number,
 };
 
-type TestId = 'noTestDefined';
+type TestId = 'annualContributions';
 
 export type Participations = {
   [TestId]: string,
@@ -53,22 +53,17 @@ type OphanABPayload = {
 
 // ----- Tests ----- //
 
-/*
- * Test Example:
-
- {
-    testId: 'uniqueID',
-    variants: ['control', 'variantA'],
+const tests: Test[] = [
+  {
+    testId: 'annualContributions',
+    variants: ['control', 'variant'],
     audience: {
       offset: 0,
       size: 1,
     },
     isActive: true,
- }
-
- */
-
-const tests: Test[] = [];
+  },
+];
 
 
 // ----- Functions ----- //

--- a/assets/helpers/abtest.js
+++ b/assets/helpers/abtest.js
@@ -61,7 +61,7 @@ const tests: Test[] = [
       offset: 0,
       size: 1,
     },
-    isActive: true,
+    isActive: false,
   },
 ];
 

--- a/assets/helpers/abtest.js
+++ b/assets/helpers/abtest.js
@@ -20,7 +20,7 @@ type Audience = {
   size: number,
 };
 
-type TestId = 'annualContributions';
+type TestId = 'addAnnualContributions';
 
 export type Participations = {
   [TestId]: string,
@@ -55,7 +55,7 @@ type OphanABPayload = {
 
 const tests: Test[] = [
   {
-    testId: 'annualContributions',
+    testId: 'addAnnualContributions',
     variants: ['control', 'variant'],
     audience: {
       offset: 0,

--- a/assets/pages/bundles-landing/bundlesLanding.jsx
+++ b/assets/pages/bundles-landing/bundlesLanding.jsx
@@ -35,8 +35,8 @@ if (!intCmp) {
 }
 
 const participations = store.getState().common.abParticipations;
-if (participations.annualContributions) {
-  trackOphan('annualContributions', participations.annualContributions);
+if (participations.addAnnualContributions) {
+  trackOphan('addAnnualContributions', participations.addAnnualContributions);
 }
 
 

--- a/assets/pages/bundles-landing/bundlesLanding.jsx
+++ b/assets/pages/bundles-landing/bundlesLanding.jsx
@@ -20,12 +20,6 @@ import reducer from './reducers/reducers';
 import { trackOphan } from '../../helpers/abtest';
 
 
-// ----- Page Startup ----- //
-
-const participation = pageStartup.start();
-setCountry('GB');
-
-
 // ----- Redux Store ----- //
 
 const store = pageInit(reducer);
@@ -40,7 +34,7 @@ if (!intCmp) {
   store.dispatch(setIntCmp(intCmp));
 }
 
-let participations = store.getState().common.abParticipations;
+const participations = store.getState().common.abParticipations;
 if (participations.annualContributions) {
   trackOphan('annualContributions', participations.annualContributions);
 }

--- a/assets/pages/bundles-landing/bundlesLanding.jsx
+++ b/assets/pages/bundles-landing/bundlesLanding.jsx
@@ -17,6 +17,13 @@ import Bundles from './components/Bundles';
 import WhySupport from './components/WhySupport';
 import WaysOfSupport from './components/WaysOfSupport';
 import reducer from './reducers/reducers';
+import { trackOphan } from '../../helpers/abtest';
+
+
+// ----- Page Startup ----- //
+
+const participation = pageStartup.start();
+setCountry('GB');
 
 
 // ----- Redux Store ----- //
@@ -31,6 +38,11 @@ let intCmp = store.getState().common.intCmp;
 if (!intCmp) {
   intCmp = 'gdnwb_copts_bundles_landing_default';
   store.dispatch(setIntCmp(intCmp));
+}
+
+let participations = store.getState().common.abParticipations;
+if (participations.annualContributions) {
+  trackOphan('annualContributions', participations.annualContributions);
 }
 
 

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -25,6 +25,7 @@ import {
 import { getSubsLinks } from '../helpers/subscriptionsLinks';
 
 import type { SubsUrls } from '../helpers/subscriptionsLinks';
+import type { Participations } from '../../../helpers/abtest';
 
 
 // ----- Types ----- //
@@ -43,7 +44,8 @@ type PropTypes = {
   changeContribMonthlyAmount: (string) => void,
   changeContribOneOffAmount: (string) => void,
   changeContribAmount: (string) => void,
-  isoCountry: IsoCountry
+  isoCountry: IsoCountry,
+  abTests: Participations
 };
 
 type ContribAttrs = {
@@ -277,6 +279,7 @@ function mapStateToProps(state) {
     intCmp: state.common.intCmp,
     campaign: state.common.campaign,
     isoCountry: state.common.country,
+    abTests: state.abTests,
   };
 }
 

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -45,7 +45,7 @@ type PropTypes = {
   changeContribOneOffAmount: (string) => void,
   changeContribAmount: (string) => void,
   isoCountry: IsoCountry,
-  abTests: Participations
+  abTests: Participations,
 };
 
 type ContribAttrs = {
@@ -279,7 +279,7 @@ function mapStateToProps(state) {
     intCmp: state.common.intCmp,
     campaign: state.common.campaign,
     isoCountry: state.common.country,
-    abTests: state.abTests,
+    abTests: state.common.abParticipations,
   };
 }
 

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -22,6 +22,7 @@ import {
   changeContribAmountOneOff,
   payPalError,
 } from '../actions/contributionsLandingActions';
+import type { Participations } from '../../../helpers/abtest';
 
 
 // ----- Types ----- //
@@ -43,6 +44,7 @@ type PropTypes = {
   isoCountry: IsoCountry,
   payPalErrorHandler: (string) => void,
   payPalError: ?string,
+  abTests: Participations,
 };
 
 /* eslint-enable react/no-unused-prop-types */


### PR DESCRIPTION
## Why are you doing this?

Currently the annual payment option for regular contributions is hidden behind a query string parameter. This PR makes it available through a variant in the `annualContributions` ab test.

[**Trello Card**](https://trello.com/c/mxWzhDt2/882-update-support-frontend-to-allow-users-to-make-annual-regular-contributions)

## Changes

* Introduce a new AB test `annualContributions` with 2 variants; control and variant. This test is currently inactive.
* Assign all visitors to the UK bundles landing page to a variant and track that variant in Ophan.

## Screenshots

See: https://github.com/guardian/support-frontend/pull/211