### PR TITLE
Change paper subs price to read 'from £10.79/month'

### DIFF
--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -118,7 +118,7 @@ const digitalCopy: DigitalAttrs = {
 
 const paperCopy: PaperAttrs = {
   heading: 'paper subscription',
-  subheading: 'from £22.06/month',
+  subheading: 'from £10.79/month',
   listItems: [
     {
       heading: 'Newspaper',


### PR DESCRIPTION
## Why are you doing this?
It currently says 'from £22.06/month' which is weird. It should be £10.79 to match the lowest figure on https://subscribe.theguardian.com/collection/paper

Trello card: [**update-pricing-on-3-offer-landing-page**](https://trello.com/c/65dKaumX/869-update-pricing-on-3-offer-landing-page-to-provide-accurate-sensible-wording-pricing-of-subs)

## Screenshots
Before:
![screen shot 2017-09-14 at 13 46 53](https://user-images.githubusercontent.com/690395/30430498-569501ba-9953-11e7-87b6-73245e337510.png)

After:
![screen shot 2017-09-14 at 13 43 50](https://user-images.githubusercontent.com/690395/30430405-0d11827a-9953-11e7-8ee6-fd007a5a1a02.png)


