### PR TITLE
[fix-browser-version] Fix chrome version to 60

### DIFF
--- a/test/selenium/util/Driver.scala
+++ b/test/selenium/util/Driver.scala
@@ -30,6 +30,7 @@ object Driver {
     val caps = DesiredCapabilities.chrome()
     caps.setCapability("platform", "Windows 8.1")
     caps.setCapability("name", "support-frontend")
+    caps.setCapability("version", "60")
     new RemoteWebDriver(new URL(Config.webDriverRemoteUrl), caps)
   }
 


### PR DESCRIPTION
## Why are you doing this?

The post-deployment tests are failing in Saucelabs. This is generated because Saucelabs updated its chrome to version 61 but it is not compatible with its chromedriver. This PR fixes the version to 60. 