### PR TITLE
Pending thank you page is a valid end step for a test

### DIFF
--- a/assets/pages/contributions-thankyou/monthlyContributionsPending.jsx
+++ b/assets/pages/contributions-thankyou/monthlyContributionsPending.jsx
@@ -28,7 +28,7 @@ const content = (
       <div className="thankyou__content gu-content-filler__inner">
         <div className="thankyou__wrapper">
           <h1 className="thankyou__heading">Thank you!</h1>
-          <h2 className="thankyou__subheading">
+          <h2 id="qa-thank-you-message" className="thankyou__subheading">
             <p>You have helped to make the Guardian&#39;s future more secure.
               Look out for an email confirming your recurring
               payment.</p>

--- a/test/selenium/pages/RecurringContributionThankYou.scala
+++ b/test/selenium/pages/RecurringContributionThankYou.scala
@@ -11,6 +11,6 @@ object RecurringContributionThankYou extends Page with Browser {
 
   def focusOnDefaultFrame: Unit = revertToDefaultFrame
 
-  def pageHasLoaded: Boolean = pageHasElement(thankYouHeader) && pageHasUrl("/contribute/recurring/thankyou")
+  def pageHasLoaded: Boolean = pageHasElement(thankYouHeader) && (pageHasUrl("/contribute/recurring/thankyou") || pageHasUrl("/contribute/recurring/pending"))
 
 }


### PR DESCRIPTION

## Why are you doing this?
Currently, we are accepting as a valid execution only the ones which are process during the session. This is not always the case since there are executions that returns a pending status and we shouldn't flag this execution as errors since they aren't. This PR adds the logic to consider the pending thank you page in the recurring flow as a valid end step in a post-deploy test.

## Changes

* Post deploy test.

