### PR TITLE
Increased the timeout for PostDeploy test

### DIFF
--- a/test/selenium/util/Config.scala
+++ b/test/selenium/util/Config.scala
@@ -18,7 +18,7 @@ object Config {
 
   val contributionFrontend = conf.getString("contribution.url")
 
-  val waitTimeout = 40
+  val waitTimeout = 45
 
   val paypalSandbox = conf.getString("paypal.sandbox.url")
 


### PR DESCRIPTION
## Why are you doing this?

The current timeout for showing the *pending* thank you page is 30 seconds. Therefore, after at most (approximately) 33 seconds, we should be able to see the pending thank you page. Nevertheless, using a timeout of 40 seconds for waiting for this page to load when the test is running in Saucelabs, it seems it is not enough. Therefore, this PR increase the timeout to 45 seconds. After running, the tests against Sauelabs PROD, it seems a prudent amount of time to wait.   


