### PR TITLE
Update Flow to v0.54.1

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,5 +1,6 @@
 [ignore]
 .*/__tests__/.*
+.*/node_modules/preact/.*
 
 [include]
 assets

--- a/assets/components/bundle/bundle.jsx
+++ b/assets/components/bundle/bundle.jsx
@@ -8,7 +8,7 @@ import DoubleHeading from 'components/doubleHeading/doubleHeading';
 import InlinePaymentLogos from 'components/inlinePaymentLogos/inlinePaymentLogos';
 import { generateClassName } from 'helpers/utilities';
 
-import type { Children } from 'react';
+import type { Node } from 'react';
 
 
 // ----- Types ----- //
@@ -17,7 +17,7 @@ type PropTypes = {
   heading: string,
   subheading: string,
   modifierClass: ?string,
-  children?: Children,
+  children?: Node,
   doubleHeadingModifierClass?: string,
   showPaymentLogos?: boolean,
 };
@@ -58,6 +58,6 @@ Bundle.defaultProps = {
   infoText: '',
   modifierClass: null,
   children: null,
-  doubleHeadingModifierClass: null,
+  doubleHeadingModifierClass: '',
   showPaymentLogos: false,
 };

--- a/assets/components/ctaCircle/ctaCircle.jsx
+++ b/assets/components/ctaCircle/ctaCircle.jsx
@@ -12,7 +12,7 @@ import { clickSubstituteKeyPressHandler } from 'helpers/utilities';
 type PropTypes = {
   text: string,
   modifierClass: ?string,
-  url?: string,
+  url?: ?string,
   onClick?: () => void,
   tabIndex?: number,
 };

--- a/assets/components/ctaLink/ctaLink.jsx
+++ b/assets/components/ctaLink/ctaLink.jsx
@@ -11,17 +11,24 @@ import { clickSubstituteKeyPressHandler } from 'helpers/utilities';
 
 type PropTypes = {
   text: string,
-  url?: string,
-  onClick?: () => void,
+  url?: ?string,
+  onClick?: ?Function,
   tabIndex?: number,
-  id?: string,
+  id?: ?string,
 };
 
 // ----- Component ----- //
 
 export default function CtaLink(props: PropTypes) {
   return (
-    <a id={props.id} className="component-cta-link" href={props.url} onClick={props.onClick} onKeyPress={clickSubstituteKeyPressHandler(props.onClick)} tabIndex={props.tabIndex}>
+    <a
+      id={props.id}
+      className="component-cta-link"
+      href={props.url}
+      onClick={props.onClick}
+      onKeyPress={props.onClick ? clickSubstituteKeyPressHandler(props.onClick) : null}
+      tabIndex={props.tabIndex}
+    >
       <span>{props.text}</span>
       <Svg svgName="arrow-right-straight" />
     </a>
@@ -38,4 +45,3 @@ CtaLink.defaultProps = {
   tabIndex: 0,
   id: null,
 };
-

--- a/assets/components/doubleHeading/doubleHeading.jsx
+++ b/assets/components/doubleHeading/doubleHeading.jsx
@@ -10,7 +10,7 @@ import { generateClassName } from 'helpers/utilities';
 
 type PropTypes = {
   heading: string,
-  subheading: ?string,
+  subheading?: string,
   modifierClass?: string,
 };
 
@@ -39,5 +39,5 @@ export default function DoubleHeading(props: PropTypes) {
 
 DoubleHeading.defaultProps = {
   subheading: '',
-  modifierClass: null,
+  modifierClass: '',
 };

--- a/assets/components/infoSection/infoSection.jsx
+++ b/assets/components/infoSection/infoSection.jsx
@@ -4,15 +4,15 @@
 
 import React from 'react';
 
-import type { Children } from 'react';
+import type { Node } from 'react';
 
 
 // ---- Types ----- //
 
 type PropTypes = {
-  heading?: string,
+  heading?: ?string,
   className?: string,
-  children?: Children,
+  children?: Node,
 };
 
 

--- a/assets/components/payPalContributionButton/payPalContributionButton.jsx
+++ b/assets/components/payPalContributionButton/payPalContributionButton.jsx
@@ -13,8 +13,8 @@ import { paypalContributionsRedirect } from 'helpers/payPalContributionsCheckout
 /* eslint-disable react/no-unused-prop-types */
 type PropTypes = {
   amount: string,
-  intCmp?: string,
-  refpvid?: string,
+  intCmp?: ?string,
+  refpvid?: ?string,
   isoCountry: IsoCountry,
   errorHandler: (string) => void,
   canClick?: boolean,

--- a/assets/components/textInput/textInput.jsx
+++ b/assets/components/textInput/textInput.jsx
@@ -83,7 +83,7 @@ export default function TextInput(props: PropTypes) {
 
 TextInput.defaultProps = {
   placeholder: null,
-  labelText: null,
+  labelText: '',
   id: null,
   onChange: null,
   value: '',

--- a/assets/helpers/payPalExpressCheckout/payPalExpressCheckout.js
+++ b/assets/helpers/payPalExpressCheckout/payPalExpressCheckout.js
@@ -88,7 +88,9 @@ function createAgreement(payPalData: Object, state: CombinedState) {
     .then(response => response.json());
 }
 
-function setup(dispatch: Function, getState: () => PageState, callback: Function) {
+function setup(
+  dispatch: Function,
+  getState: () => PageState, callback: Function): Promise<void> {
 
   return loadPayPalExpress()
     .then(() => {

--- a/assets/helpers/stripeCheckout/stripeCheckout.js
+++ b/assets/helpers/stripeCheckout/stripeCheckout.js
@@ -35,7 +35,7 @@ export const setup = (
   state: StripeState,
   token: Function,
   closed: Function,
-) => loadStripe().then(() => {
+): Promise<void> => loadStripe().then(() => {
 
   stripeHandler = window.StripeCheckout.configure({
     name: 'Guardian',

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "eslint-plugin-react": "^7.1.0",
     "extract-text-webpack-plugin": "^3.0.0",
     "file-loader": "^0.11.2",
-    "flow-bin": "^0.49.1",
+    "flow-bin": "^0.54.1",
     "jest": "^21.1.0",
     "node-sass": "^4.5.3",
     "npm-run-all": "^4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2498,9 +2498,9 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-bin@^0.49.1:
-  version "0.49.1"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.49.1.tgz#c9e456b3173a7535a4ffaf28956352c63bb8e3e9"
+flow-bin@^0.54.1:
+  version "0.54.1"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.54.1.tgz#7101bcccf006dc0652714a8aef0c72078a760510"
 
 for-in@^0.1.3:
   version "0.1.8"


### PR DESCRIPTION
## Why are you doing this?

We were a few versions old, and lots of improvements have been made, particularly where handling React types is concerned (v0.53). The changelog is [here](https://github.com/facebook/flow/blob/master/Changelog.md). I came across what I think is a bug in some code I'm working on for the landing page, so I figured it was time to update.

**P.S.:** Thanks @gustavpursche for helping out when flow was being super-demanding around promise types 🐰.

## Changes

- Update flow to `0.54.1` from `0.49.1`.
- Update our type definitions to meet the more rigorous current flow spec.
- Ignore preact in flow typing because there are some errors against the current version of flow.
