### PR TITLE
Country for ABTest framework

### DIFF
--- a/assets/helpers/__tests__/abtestTest.js
+++ b/assets/helpers/__tests__/abtestTest.js
@@ -1,0 +1,45 @@
+// @flow
+
+// ----- Imports ----- //
+
+import {getVariantsAsString, init as abInit } from '../abtest';
+import type {Participations}  from '../abtest';
+
+jest.mock('ophan', () => {});
+
+
+
+// ----- Tests ----- //
+
+
+describe('abTest init function', () => {
+
+  it('should return user in test', () => {
+
+    document.cookie = "GU_mvt_id=12345";
+    console.log(global);
+    console.log("------------");
+    global.tests = [
+      {
+        testId: 'mockTest',
+        variants: ['control', 'variant'],
+        audiences: {
+          GB: {
+            offset: 0,
+            size: 1,
+          },
+        },
+        isActive: true,
+      }];
+
+    console.log(global.tests);
+    const country = 'GB';
+
+    const participations: Participations = abInit(country);
+    const expectedParticipations: Participations = {};
+
+    expect(participations).toEqual(expectedParticipations);
+
+  });
+
+});

--- a/assets/helpers/__tests__/abtestTest.js
+++ b/assets/helpers/__tests__/abtestTest.js
@@ -190,7 +190,7 @@ describe('Correct allocation in a multi test environment', () => {
     expect(participations).toEqual(expectedParticipations);
   });
 
-  it('It correctly segment the user a user who has a cookie between 0 and 20% in US', () => {
+  it('It correctly segments the user a user who has a cookie between 0 and 20% in US', () => {
 
     document.cookie = 'GU_mvt_id=150000';
     const country = 'US';

--- a/assets/helpers/__tests__/abtestTest.js
+++ b/assets/helpers/__tests__/abtestTest.js
@@ -2,24 +2,22 @@
 
 // ----- Imports ----- //
 
-import {getVariantsAsString, init as abInit } from '../abtest';
-import type {Participations}  from '../abtest';
+import { getVariantsAsString, init as abInit } from '../abtest';
+import type { Participations } from '../abtest';
 
 jest.mock('ophan', () => {});
-
 
 
 // ----- Tests ----- //
 
 
-describe('abTest init function', () => {
+describe('basic behaviour of init', () => {
 
-  it('should return user in test', () => {
+  it('The user should be allocated in the control bucket', () => {
 
-    document.cookie = "GU_mvt_id=12345";
-    console.log(global);
-    console.log("------------");
-    global.tests = [
+    document.cookie = 'GU_mvt_id=12346';
+
+    const tests = [
       {
         testId: 'mockTest',
         variants: ['control', 'variant'],
@@ -32,14 +30,179 @@ describe('abTest init function', () => {
         isActive: true,
       }];
 
-    console.log(global.tests);
     const country = 'GB';
-
-    const participations: Participations = abInit(country);
-    const expectedParticipations: Participations = {};
+    const participations: Participations = abInit(country, tests);
+    const expectedParticipations: Participations = { mockTest: 'control' };
 
     expect(participations).toEqual(expectedParticipations);
+  });
 
+  it('The user should be allocated in the variant bucket', () => {
+
+    document.cookie = 'GU_mvt_id=12345';
+
+    const tests = [
+      {
+        testId: 'mockTest',
+        variants: ['control', 'variant'],
+        audiences: {
+          GB: {
+            offset: 0,
+            size: 1,
+          },
+        },
+        isActive: true,
+      }];
+
+    const country = 'GB';
+    const participations: Participations = abInit(country, tests);
+    const expectedParticipations: Participations = { mockTest: 'variant' };
+
+    expect(participations).toEqual(expectedParticipations);
+  });
+
+  it('The user should not be allocated in a test for a different country', () => {
+
+    document.cookie = 'GU_mvt_id=12346';
+
+    const tests = [
+      {
+        testId: 'mockTest',
+        variants: ['control', 'variant'],
+        audiences: {
+          GB: {
+            offset: 0,
+            size: 1,
+          },
+        },
+        isActive: true,
+      }];
+
+    const country = 'US';
+    const participations: Participations = abInit(country, tests);
+    const expectedParticipations: Participations = { mockTest: 'notintest' };
+
+    expect(participations).toEqual(expectedParticipations);
+  });
+});
+
+describe('Correct allocation in a multi test environment', () => {
+  /*
+  GB: |                    100%                      |
+                           Test1
+
+  US: |  20%   |        60%                |   20%   |
+        Test 1         Test 2              Not in Test
+   */
+
+  const tests = [
+    {
+      testId: 'mockTest',
+      variants: ['control', 'variant'],
+      audiences: {
+        GB: {
+          offset: 0,
+          size: 1,
+        },
+        US: {
+          offset: 0,
+          size: 0.2,
+        },
+      },
+      isActive: true,
+    },
+    {
+      testId: 'mockTest2',
+      variants: ['control', 'variant'],
+      audiences: {
+        US: {
+          offset: 0.2,
+          size: 0.6,
+        },
+      },
+      isActive: true,
+    },
+  ];
+
+  it('It correctly segment the user a user who has a cookie in the top 80% in GB', () => {
+
+    document.cookie = 'GU_mvt_id=810000';
+    const country = 'GB';
+
+    const participations: Participations = abInit(country, tests);
+    const expectedParticipations: Participations = { mockTest: 'control', mockTest2: 'notintest' };
+    expect(participations).toEqual(expectedParticipations);
+  });
+
+  it('It correctly segment the user a user who has a cookie above 80% in US', () => {
+
+    document.cookie = 'GU_mvt_id=810000';
+    const country = 'US';
+
+    const participations: Participations = abInit(country, tests);
+    const expectedParticipations: Participations = { mockTest: 'notintest', mockTest2: 'notintest' };
+    expect(participations).toEqual(expectedParticipations);
+  });
+
+  it('It correctly segment the user a user who has a cookie between 20% and 80% in GB', () => {
+
+    document.cookie = 'GU_mvt_id=510000';
+    const country = 'GB';
+
+    let participations: Participations = abInit(country, tests);
+    let expectedParticipations: Participations = { mockTest: 'control', mockTest2: 'notintest' };
+    expect(participations).toEqual(expectedParticipations);
+
+    document.cookie = 'GU_mvt_id=510001';
+    participations = abInit(country, tests);
+    expectedParticipations = { mockTest: 'variant', mockTest2: 'notintest' };
+    expect(participations).toEqual(expectedParticipations);
+  });
+
+  it('It correctly segment the user a user who has a cookie between 20% and 80% in US', () => {
+
+    document.cookie = 'GU_mvt_id=510000';
+    const country = 'US';
+
+    let participations: Participations = abInit(country, tests);
+    let expectedParticipations: Participations = { mockTest: 'notintest', mockTest2: 'control' };
+    expect(participations).toEqual(expectedParticipations);
+
+    document.cookie = 'GU_mvt_id=510001';
+    participations = abInit(country, tests);
+    expectedParticipations = { mockTest: 'notintest', mockTest2: 'variant' };
+    expect(participations).toEqual(expectedParticipations);
+    expect(getVariantsAsString(participations)).toEqual('mockTest=notintest; mockTest2=variant');
+  });
+
+  it('It correctly segment the user a user who has a cookie between 0 and 20% in GB', () => {
+
+    document.cookie = 'GU_mvt_id=150000';
+    const country = 'GB';
+
+    let participations: Participations = abInit(country, tests);
+    let expectedParticipations: Participations = { mockTest: 'control', mockTest2: 'notintest' };
+    expect(participations).toEqual(expectedParticipations);
+
+    document.cookie = 'GU_mvt_id=150001';
+    participations = abInit(country, tests);
+    expectedParticipations = { mockTest: 'variant', mockTest2: 'notintest' };
+    expect(participations).toEqual(expectedParticipations);
+  });
+
+  it('It correctly segment the user a user who has a cookie between 0 and 20% in US', () => {
+
+    document.cookie = 'GU_mvt_id=150000';
+    const country = 'US';
+
+    let participations: Participations = abInit(country, tests);
+    let expectedParticipations: Participations = { mockTest: 'control', mockTest2: 'notintest' };
+    expect(participations).toEqual(expectedParticipations);
+
+    document.cookie = 'GU_mvt_id=150001';
+    participations = abInit(country, tests);
+    expectedParticipations = { mockTest: 'variant', mockTest2: 'notintest' };
+    expect(participations).toEqual(expectedParticipations);
   });
 
 });

--- a/assets/helpers/__tests__/abtestTest.js
+++ b/assets/helpers/__tests__/abtestTest.js
@@ -124,7 +124,7 @@ describe('Correct allocation in a multi test environment', () => {
     },
   ];
 
-  it('It correctly segment the user a user who has a cookie in the top 80% in GB', () => {
+  it('It correctly segments a user who has a cookie in the top 80% in GB', () => {
 
     document.cookie = 'GU_mvt_id=810000';
     const country = 'GB';
@@ -134,7 +134,7 @@ describe('Correct allocation in a multi test environment', () => {
     expect(participations).toEqual(expectedParticipations);
   });
 
-  it('It correctly segment the user a user who has a cookie above 80% in US', () => {
+  it('It correctly segments a user who has a cookie above 80% in US', () => {
 
     document.cookie = 'GU_mvt_id=810000';
     const country = 'US';
@@ -144,7 +144,7 @@ describe('Correct allocation in a multi test environment', () => {
     expect(participations).toEqual(expectedParticipations);
   });
 
-  it('It correctly segment the user a user who has a cookie between 20% and 80% in GB', () => {
+  it('It correctly segments a user who has a cookie between 20% and 80% in GB', () => {
 
     document.cookie = 'GU_mvt_id=510000';
     const country = 'GB';
@@ -159,7 +159,7 @@ describe('Correct allocation in a multi test environment', () => {
     expect(participations).toEqual(expectedParticipations);
   });
 
-  it('It correctly segment the user a user who has a cookie between 20% and 80% in US', () => {
+  it('It correctly segments a user who has a cookie between 20% and 80% in US', () => {
 
     document.cookie = 'GU_mvt_id=510000';
     const country = 'US';
@@ -175,7 +175,7 @@ describe('Correct allocation in a multi test environment', () => {
     expect(getVariantsAsString(participations)).toEqual('mockTest=notintest; mockTest2=variant');
   });
 
-  it('It correctly segment the user a user who has a cookie between 0 and 20% in GB', () => {
+  it('It correctly segments a user who has a cookie between 0 and 20% in GB', () => {
 
     document.cookie = 'GU_mvt_id=150000';
     const country = 'GB';

--- a/assets/helpers/abtest.js
+++ b/assets/helpers/abtest.js
@@ -28,10 +28,6 @@ export type Participations = {
   [TestId]: string,
 }
 
-type Action = {
-  type: 'SET_AB_TEST_PARTICIPATION',
-  payload: Participations,
-};
 
 type Test = {
   testId: TestId,
@@ -84,7 +80,6 @@ function getMvtId(): number {
   }
 
   return Number(mvtId);
-
 }
 
 function getLocalStorageParticipation(): Participations {
@@ -110,11 +105,9 @@ function getUrlParticipation(): ?Participations {
     test[testId] = variant;
 
     return test;
-
   }
 
   return null;
-
 }
 
 function userInTest(audiences: Audiences, mvtId: number, country: IsoCountry) {
@@ -137,12 +130,12 @@ function assignUserToVariant(mvtId: number, test: Test): string {
   return test.variants[variantIndex];
 }
 
-function getParticipation(mvtId: number, country: IsoCountry): Participations {
+function getParticipation(abTests: Test[], mvtId: number, country: IsoCountry): Participations {
 
   const currentParticipation = getLocalStorageParticipation();
   const participation:Participations = {};
 
-  tests.forEach((test) => {
+  abTests.forEach((test) => {
 
     if (!test.isActive) {
       return;
@@ -165,12 +158,10 @@ function getParticipation(mvtId: number, country: IsoCountry): Participations {
 
 // ----- Exports ----- //
 
-export const init = (country: IsoCountry) => {
+export const init = (country: IsoCountry, abTests: Test[] = tests): Participations => {
 
   const mvt: number = getMvtId();
-
-
-  let participation: Participations = getParticipation(mvt, country);
+  let participation: Participations = getParticipation(abTests, mvt, country);
 
   const urlParticipation = getUrlParticipation();
   participation = Object.assign({}, participation, urlParticipation);
@@ -205,24 +196,7 @@ export const trackOphan = (
     },
   };
 
-
   ophan.record({
     abTestRegister: payload,
   });
 };
-
-export const abTestReducer = (
-  state: Participations = {},
-  action: Action): Participations => {
-
-  switch (action.type) {
-
-    case 'SET_AB_TEST_PARTICIPATION': {
-      return Object.assign({}, state, action.payload);
-    }
-
-    default:
-      return state;
-  }
-};
-

--- a/assets/helpers/abtest.js
+++ b/assets/helpers/abtest.js
@@ -19,7 +19,7 @@ type Audiences = {
   [IsoCountry]: {
     offset: number,
     size: number,
-  }
+  },
 };
 
 type TestId = 'addAnnualContributions';

--- a/assets/helpers/abtest.js
+++ b/assets/helpers/abtest.js
@@ -1,12 +1,11 @@
 // @flow
 
 // ----- Imports ----- //
+import type { IsoCountry } from 'helpers/internationalisation/country';
 
 import * as ophan from 'ophan';
 import * as cookie from './cookie';
 import * as storage from './storage';
-
-import type { IsoCountry } from 'helpers/internationalisation/country';
 
 // ----- Setup ----- //
 
@@ -17,7 +16,7 @@ const MVT_MAX: number = 1000000;
 // ----- Types ----- //
 
 type Audiences = {
-  [IsoCountry] :{
+  [IsoCountry]: {
     offset: number,
     size: number,
   }
@@ -60,14 +59,14 @@ const tests: Test[] = [
   {
     testId: 'addAnnualContributions',
     variants: ['control', 'variant'],
-    audiences: [{
-      country: 'GB',
-      offset: 0,
-      size: 1,
-    }],
+    audiences: {
+      GB: {
+        offset: 0,
+        size: 1,
+      },
+    },
     isActive: false,
-  },
-];
+  }];
 
 
 // ----- Functions ----- //

--- a/assets/helpers/page/page.js
+++ b/assets/helpers/page/page.js
@@ -45,7 +45,7 @@ function analyticsInitialisation(participations: Participations): void {
 }
 
 // Creates the initial state for the common reducer.
-function buildInitialState(abParticipations: Participations) {
+function buildInitialState(abParticipations: Participations, country: IsoCountry) {
 
   const intCmp = getQueryParameter('INTCMP');
 
@@ -53,7 +53,7 @@ function buildInitialState(abParticipations: Participations) {
     intCmp,
     campaign: intCmp ? getCampaign(intCmp) : null,
     refpvid: getQueryParameter('REFPVID'),
-    country: detect(),
+    country,
     abParticipations,
   };
 
@@ -99,10 +99,10 @@ function statelessInit() {
 
 // Initialises the page.
 function init(pageReducer: Object, preloadedState: ?Object, middleware: ?Function) {
-
-  const participations: Participations = abTest.init();
+  const country: IsoCountry = detect();
+  const participations: Participations = abTest.init(country);
   analyticsInitialisation(participations);
-  const initialState: CommonState = buildInitialState(participations);
+  const initialState: CommonState = buildInitialState(participations, country);
   const commonReducer = createCommonReducer(initialState);
 
   return createStore(

--- a/assets/helpers/page/page.js
+++ b/assets/helpers/page/page.js
@@ -91,8 +91,8 @@ function createCommonReducer(
 
 // For pages that don't need Redux.
 function statelessInit() {
-
-  const participations: Participations = abTest.init();
+  const country: IsoCountry = detect();
+  const participations: Participations = abTest.init(country);
   analyticsInitialisation(participations);
 
 }

--- a/assets/pages/contributions-landing/__tests__/__snapshots__/contributionsLandingReducersTest.js.snap
+++ b/assets/pages/contributions-landing/__tests__/__snapshots__/contributionsLandingReducersTest.js.snap
@@ -96,26 +96,23 @@ Object {
 
 exports[`reducer tests should return the initial state 1`] = `
 Object {
-  "abTests": Object {},
-  "contribution": Object {
-    "amount": Object {
-      "annual": Object {
-        "userDefined": false,
-        "value": "75",
-      },
-      "monthly": Object {
-        "userDefined": false,
-        "value": "10",
-      },
-      "oneOff": Object {
-        "userDefined": false,
-        "value": "50",
-      },
+  "amount": Object {
+    "annual": Object {
+      "userDefined": false,
+      "value": "75",
     },
-    "context": false,
-    "error": null,
-    "payPalError": null,
-    "type": "MONTHLY",
+    "monthly": Object {
+      "userDefined": false,
+      "value": "10",
+    },
+    "oneOff": Object {
+      "userDefined": false,
+      "value": "50",
+    },
   },
+  "context": false,
+  "error": null,
+  "payPalError": null,
+  "type": "MONTHLY",
 }
 `;

--- a/assets/pages/contributions-landing/__tests__/contributionsLandingReducersTest.js
+++ b/assets/pages/contributions-landing/__tests__/contributionsLandingReducersTest.js
@@ -28,9 +28,9 @@ describe('reducer tests', () => {
 
     const newState = reducer(undefined, action);
 
-    expect(newState.contribution.type).toEqual(contribType);
-    expect(newState.contribution.error).toMatchSnapshot();
-    expect(newState.contribution.amount).toMatchSnapshot();
+    expect(newState.type).toEqual(contribType);
+    expect(newState.error).toMatchSnapshot();
+    expect(newState.amount).toMatchSnapshot();
   });
 
   it('should handle CHANGE_CONTRIB_TYPE to MONTHLY', () => {
@@ -43,9 +43,9 @@ describe('reducer tests', () => {
 
     const newState = reducer(undefined, action);
 
-    expect(newState.contribution.type).toEqual(contribType);
-    expect(newState.contribution.error).toMatchSnapshot();
-    expect(newState.contribution.amount).toMatchSnapshot();
+    expect(newState.type).toEqual(contribType);
+    expect(newState.error).toMatchSnapshot();
+    expect(newState.amount).toMatchSnapshot();
   });
 
   it('should handle CHANGE_CONTRIB_TYPE to ANNUAL', () => {
@@ -58,9 +58,9 @@ describe('reducer tests', () => {
 
     const newState = reducer(undefined, action);
 
-    expect(newState.contribution.type).toEqual(contribType);
-    expect(newState.contribution.error).toMatchSnapshot();
-    expect(newState.contribution.amount).toMatchSnapshot();
+    expect(newState.type).toEqual(contribType);
+    expect(newState.error).toMatchSnapshot();
+    expect(newState.amount).toMatchSnapshot();
   });
 
   it('should handle CHANGE_CONTRIB_AMOUNT', () => {
@@ -76,10 +76,10 @@ describe('reducer tests', () => {
 
     const newState = reducer(undefined, action);
 
-    expect(newState.contribution.type).toMatchSnapshot();
-    expect(newState.contribution.error).toMatchSnapshot();
-    expect(newState.contribution.amount.monthly).toEqual(amount);
-    expect(newState.contribution.amount.oneOff).toEqual(amount);
+    expect(newState.type).toMatchSnapshot();
+    expect(newState.error).toMatchSnapshot();
+    expect(newState.amount.monthly).toEqual(amount);
+    expect(newState.amount.oneOff).toEqual(amount);
   });
 
   it('should handle CHANGE_CONTRIB_AMOUNT_MONTHLY', () => {
@@ -95,10 +95,10 @@ describe('reducer tests', () => {
 
     const newState = reducer(undefined, action);
 
-    expect(newState.contribution.type).toMatchSnapshot();
-    expect(newState.contribution.error).toMatchSnapshot();
-    expect(newState.contribution.amount.monthly).toEqual(amount);
-    expect(newState.contribution.amount.oneOff).toMatchSnapshot();
+    expect(newState.type).toMatchSnapshot();
+    expect(newState.error).toMatchSnapshot();
+    expect(newState.amount.monthly).toEqual(amount);
+    expect(newState.amount.oneOff).toMatchSnapshot();
   });
 
   it('should handle CHANGE_CONTRIB_AMOUNT_ANNUAL', () => {
@@ -114,10 +114,10 @@ describe('reducer tests', () => {
 
     const newState = reducer(undefined, action);
 
-    expect(newState.contribution.type).toMatchSnapshot();
-    expect(newState.contribution.error).toMatchSnapshot();
-    expect(newState.contribution.amount.annual).toEqual(amount);
-    expect(newState.contribution.amount.oneOff).toMatchSnapshot();
+    expect(newState.type).toMatchSnapshot();
+    expect(newState.error).toMatchSnapshot();
+    expect(newState.amount.annual).toEqual(amount);
+    expect(newState.amount.oneOff).toMatchSnapshot();
   });
 
   it('should handle CHANGE_CONTRIB_AMOUNT_ONEOFF', () => {
@@ -133,9 +133,9 @@ describe('reducer tests', () => {
 
     const newState = reducer(undefined, action);
 
-    expect(newState.contribution.type).toMatchSnapshot();
-    expect(newState.contribution.error).toMatchSnapshot();
-    expect(newState.contribution.amount.oneOff).toEqual(amount);
-    expect(newState.contribution.amount.monthly).toMatchSnapshot();
+    expect(newState.type).toMatchSnapshot();
+    expect(newState.error).toMatchSnapshot();
+    expect(newState.amount.oneOff).toEqual(amount);
+    expect(newState.amount.monthly).toMatchSnapshot();
   });
 });

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -182,13 +182,13 @@ function ContributionsBundle(props: PropTypes) {
 function mapStateToProps(state) {
 
   return {
-    contribType: state.page.contribution.type,
-    contribAmount: state.page.contribution.amount,
-    contribError: state.page.contribution.error,
+    contribType: state.page.type,
+    contribAmount: state.page.amount,
+    contribError: state.page.error,
     intCmp: state.common.intCmp,
     refpvid: state.common.refpvid,
     isoCountry: state.common.country,
-    payPalError: state.page.contribution.payPalError,
+    payPalError: state.page.payPalError,
   };
 }
 

--- a/assets/pages/contributions-landing/components/contributionsBundleContent.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundleContent.jsx
@@ -41,7 +41,7 @@ function ContributionsBundleContent(props: PropTypes) {
 function mapStateToProps(state) {
 
   return {
-    context: state.page.contribution.context,
+    context: state.page.context,
   };
 
 }

--- a/assets/pages/contributions-landing/contributionsLandingReducers.js
+++ b/assets/pages/contributions-landing/contributionsLandingReducers.js
@@ -2,12 +2,9 @@
 
 // ----- Imports ----- //
 
-import { combineReducers } from 'redux';
-
 import type { Contrib, ContribError, Amounts } from 'helpers/contributions';
 
 import { parse as parseContribution } from 'helpers/contributions';
-import { abTestReducer as abTests } from 'helpers/abtest';
 import type { Action } from './contributionsLandingActions';
 
 
@@ -133,7 +130,4 @@ function contribution(
 
 // ----- Exports ----- //
 
-export default combineReducers({
-  contribution,
-  abTests,
-});
+export default contribution;

--- a/assets/pages/regular-contributions/components/formFields.jsx
+++ b/assets/pages/regular-contributions/components/formFields.jsx
@@ -2,16 +2,16 @@
 
 // ----- Imports ----- //
 
-import React from 'react'
-import { connect } from 'react-redux'
+import React from 'react';
+import { connect } from 'react-redux';
 
-import TextInput from 'components/textInput/textInput'
-import type { SelectOption } from 'components/selectInput/selectInput'
-import SelectInput from 'components/selectInput/selectInput'
+import TextInput from 'components/textInput/textInput';
+import type { SelectOption } from 'components/selectInput/selectInput';
+import SelectInput from 'components/selectInput/selectInput';
 
-import { setFirstName, setLastName, setStateField } from 'helpers/user/userActions'
-import type { IsoCountry, UsState } from 'helpers/internationalisation/country'
-import { usStates } from 'helpers/internationalisation/country'
+import { setFirstName, setLastName, setStateField } from 'helpers/user/userActions';
+import type { IsoCountry, UsState } from 'helpers/internationalisation/country';
+import { usStates } from 'helpers/internationalisation/country';
 
 // ----- Types ----- //
 

--- a/assets/pages/regular-contributions/components/formFields.jsx
+++ b/assets/pages/regular-contributions/components/formFields.jsx
@@ -2,22 +2,16 @@
 
 // ----- Imports ----- //
 
-import React from 'react';
-import { connect } from 'react-redux';
+import React from 'react'
+import { connect } from 'react-redux'
 
-import TextInput from 'components/textInput/textInput';
-import SelectInput from 'components/selectInput/selectInput';
+import TextInput from 'components/textInput/textInput'
+import type { SelectOption } from 'components/selectInput/selectInput'
+import SelectInput from 'components/selectInput/selectInput'
 
-import {
-  setFirstName,
-  setLastName,
-  setStateField,
-} from 'helpers/user/userActions';
-import { usStates } from 'helpers/internationalisation/country';
-
-import type { IsoCountry, UsState } from 'helpers/internationalisation/country';
-import type { SelectOption } from 'components/selectInput/selectInput';
-
+import { setFirstName, setLastName, setStateField } from 'helpers/user/userActions'
+import type { IsoCountry, UsState } from 'helpers/internationalisation/country'
+import { usStates } from 'helpers/internationalisation/country'
 
 // ----- Types ----- //
 

--- a/assets/pages/regular-contributions/components/formFields.jsx
+++ b/assets/pages/regular-contributions/components/formFields.jsx
@@ -6,12 +6,18 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import TextInput from 'components/textInput/textInput';
-import type { SelectOption } from 'components/selectInput/selectInput';
 import SelectInput from 'components/selectInput/selectInput';
 
-import { setFirstName, setLastName, setStateField } from 'helpers/user/userActions';
-import type { IsoCountry, UsState } from 'helpers/internationalisation/country';
+import {
+  setFirstName,
+  setLastName,
+  setStateField,
+} from 'helpers/user/userActions';
 import { usStates } from 'helpers/internationalisation/country';
+
+import type { IsoCountry, UsState } from 'helpers/internationalisation/country';
+import type { SelectOption } from 'components/selectInput/selectInput';
+
 
 // ----- Types ----- //
 


### PR DESCRIPTION
## Why are you doing this?

This PR adds the notion of a country to the ABTest framework.


[**Trello Card**](https://trello.com/c/l0fEidly/897-add-country-to-the-abtest-framework)

## Changes

* Added country to the Audiences type.
```jsx
type Audiences = {
   [IsoCountry]: {
    offset: number,
    size: number,
   }
 };
```
* Added tests for abTest helper.
* Removed the AbTestReducer since it was not being used since: https://github.com/guardian/support-frontend/pull/215
* Removed combine reducers from Contributions Landing page. (change chained from the point above)

## Screenshots

N/A

