### PR TITLE
Override Common State Fields Individually

### DIFF
--- a/assets/helpers/page/page.js
+++ b/assets/helpers/page/page.js
@@ -29,6 +29,15 @@ export type CommonState = {
   abParticipations: Participations,
 };
 
+export type PreloadedState = {
+  intCmp?: $PropertyType<CommonState, 'intCmp'>,
+  campaign?: $PropertyType<CommonState, 'campaign'>,
+  refpvid?: $PropertyType<CommonState, 'refpvid'>,
+  country?: $PropertyType<CommonState, 'country'>,
+  abParticipations?: $PropertyType<CommonState, 'abParticipations'>,
+};
+
+
 // ----- Functions ----- //
 
 // Sets up GA and logging.
@@ -45,17 +54,21 @@ function analyticsInitialisation(participations: Participations): void {
 }
 
 // Creates the initial state for the common reducer.
-function buildInitialState(abParticipations: Participations, country: IsoCountry) {
+function buildInitialState(
+  abParticipations: Participations,
+  preloadedState: PreloadedState = {},
+  country: IsoCountry,
+) {
 
   const intCmp = getQueryParameter('INTCMP');
 
-  return {
+  return Object.assign({}, {
     intCmp,
     campaign: intCmp ? getCampaign(intCmp) : null,
     refpvid: getQueryParameter('REFPVID'),
     country,
     abParticipations,
-  };
+  }, preloadedState);
 
 }
 
@@ -98,16 +111,21 @@ function statelessInit() {
 }
 
 // Initialises the page.
-function init(pageReducer: Object, preloadedState: ?Object, middleware: ?Function) {
+function init(
+  pageReducer: Object,
+  preloadedState?: PreloadedState,
+  middleware: ?Function,
+) {
+
   const country: IsoCountry = detect();
   const participations: Participations = abTest.init(country);
   analyticsInitialisation(participations);
-  const initialState: CommonState = buildInitialState(participations, country);
+  const initialState: CommonState = buildInitialState(participations, preloadedState, country);
   const commonReducer = createCommonReducer(initialState);
 
   return createStore(
     combineReducers({ page: pageReducer, common: commonReducer }),
-    preloadedState,
+    undefined,
     middleware,
   );
 

--- a/assets/pages/contributions-landing/contributionsLandingUK.jsx
+++ b/assets/pages/contributions-landing/contributionsLandingUK.jsx
@@ -19,10 +19,12 @@ import { saveContext } from './helpers/context';
 import ContributionsBundleContent from './components/contributionsBundleContent';
 
 
-// ----- Redux Store ----- //
-const store = pageInit(reducer, {}, applyMiddleware(thunkMiddleware));
+// ----- Page Startup ----- //
+
+const store = pageInit(reducer, undefined, applyMiddleware(thunkMiddleware));
 
 saveContext(store.dispatch);
+
 
 // ----- Render ----- //
 

--- a/assets/pages/contributions-landing/contributionsLandingUS.jsx
+++ b/assets/pages/contributions-landing/contributionsLandingUS.jsx
@@ -19,10 +19,12 @@ import { saveContext } from './helpers/context';
 import ContributionsBundleContent from './components/contributionsBundleContent';
 
 
-// ----- Redux Store ----- //
-const store = pageInit(reducer, {}, applyMiddleware(thunkMiddleware));
+// ----- Page Startup ----- //
+
+const store = pageInit(reducer, undefined, applyMiddleware(thunkMiddleware));
 
 saveContext(store.dispatch);
+
 
 // ----- Render ----- //
 

--- a/assets/pages/oneoff-contributions/oneoffContributions.jsx
+++ b/assets/pages/oneoff-contributions/oneoffContributions.jsx
@@ -33,10 +33,8 @@ import postCheckout from './helpers/ajax';
 
 import { setPayPalButton } from './oneoffContributionsActions';
 
+
 // ----- Page Startup ----- //
-
-
-// ----- Redux Store ----- //
 
 const contributionAmount = parseContrib(getQueryParameter('contributionValue'), 'ONE_OFF').amount;
 const country = detectCountry();
@@ -46,16 +44,18 @@ const currency = currencyForCountry(country);
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 /* eslint-enable */
 
-const store = pageInit(reducer(contributionAmount, currency), {},
-  composeEnhancers(applyMiddleware(thunkMiddleware)));
+const store = pageInit(
+  reducer(contributionAmount, currency),
+  undefined,
+  composeEnhancers(applyMiddleware(thunkMiddleware)),
+);
 
 user.init(store.dispatch);
-
 store.dispatch(setPayPalButton(window.guardian.payPalType));
 
 const state: PageState = store.getState();
-
 const contribDescription: string = (country === 'US' ? 'one-time' : 'one-off');
+
 
 // ----- Render ----- //
 

--- a/assets/pages/regular-contributions/regularContributions.jsx
+++ b/assets/pages/regular-contributions/regularContributions.jsx
@@ -36,7 +36,7 @@ import { setPayPalButton } from './regularContributionsActions';
 import { parseContrib } from '../../helpers/contributions';
 
 
-// ----- Redux Store ----- //
+// ----- Page Startup ----- //
 
 const contributionType = parseContrib(getQueryParameter('contribType'), 'MONTHLY');
 const contributionAmount = parseAmount(getQueryParameter('contributionValue'), contributionType).amount;
@@ -52,14 +52,17 @@ const title = {
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 /* eslint-enable */
 
-const store = pageInit(reducer(contributionAmount, currency), {},
-  composeEnhancers(applyMiddleware(thunkMiddleware)));
+const store = pageInit(
+  reducer(contributionAmount, currency),
+  undefined,
+  composeEnhancers(applyMiddleware(thunkMiddleware)),
+);
 
 user.init(store.dispatch);
-
 store.dispatch(setPayPalButton(window.guardian.payPalType));
 
 const state: PageState = store.getState();
+
 
 // ----- Render ----- //
 


### PR DESCRIPTION
## Why are you doing this?

Changes made in #215 involved moving creation of the Redux store to `page.js`, and introduced the concept of a common state, which was populated automatically. The process for manually overwriting individual elements of this common state, however, was not great. It made use of Redux's `preloadedState`, but this would overwrite the entire 'common' section of the state (as flagged [here](https://github.com/guardian/support-frontend/pull/223#discussion_r138906706)).

This PR alters the method for overwriting the common state, allowing for only a subset of the fields to be updated. Instead of using the Redux `preloadedState`, it uses Object.assign to overwrite individual `initialState` fields.

[**Trello Card**](https://trello.com/c/GOcdh5k9/912-do-a-better-job-of-overriding-common-state)

## Changes

- Added `PreloadedState` type.
- Used Object.assign to merge the initial state and the preloaded state.
- Stop used the Redux `preloadedState`.
