### PR TITLE
Fix PayPal Pages CSS

### DIFF
--- a/assets/pages/paypal-error/payPalError.jsx
+++ b/assets/pages/paypal-error/payPalError.jsx
@@ -24,8 +24,8 @@ pageInit();
 const content = (
   <div className="gu-content">
     <SimpleHeader />
-    <section className="paypal-error gu-content">
-      <div className="paypal-error__content gu-content-margin">
+    <section className="paypal-error gu-content-filler">
+      <div className="paypal-error__content gu-content-filler__inner">
         <div className="paypal-error__wrapper">
           <h1 className="paypal-error__heading">PayPal Error!</h1>
           <h2 className="paypal-error__subheading">

--- a/assets/pages/paypal-error/payPalError.scss
+++ b/assets/pages/paypal-error/payPalError.scss
@@ -65,12 +65,7 @@
     }
 
     &:hover {
-      border-color: #000;
-      color: #000;
-
-      svg {
-        fill: #000;
-      }
+      background: darken(gu-colour(neutral-1), 10%);
     }
   }
 


### PR DESCRIPTION
## Why are you doing this?

The PayPal return and cancel pages were created ages ago and not updated with the new flexbox-based sticky footer. Consequently they look a bit broken. This PR fixes this.

[**Trello Card**](https://trello.com/c/g5590PzH/911-tidy-up-wonky-paypal-error-pages)

## Changes

- Made use of the filler class to push the short page down.
- Fixed the hover state of the CTA.

## Screenshots

**Before**

![paypal-broken](https://user-images.githubusercontent.com/5131341/30656019-9846ce8c-9e2a-11e7-8c1a-96f81049efd7.png)

**After**

![paypal-fixed](https://user-images.githubusercontent.com/5131341/30656025-9e41c7f6-9e2a-11e7-935b-1d5ed44c6c59.png)
