### PR TITLE
Pass INTCMP To Contributions For Stripe

### DIFF
--- a/assets/pages/oneoff-contributions/helpers/ajax.js
+++ b/assets/pages/oneoff-contributions/helpers/ajax.js
@@ -27,7 +27,7 @@ type OneoffContribFields = {
   ophanPageviewId: string,
   ophanBrowserId?: string,
   cmp?: string,
-  intcmp?: string,
+  intcmp: ?string,
   refererPageviewId?: string,
   refererUrl?: string,
   idUser?: string,
@@ -53,6 +53,7 @@ function requestData(paymentToken: string, getState: () => PageState) {
       marketing: state.page.user.gnmMarketing,
       postcode: state.page.user.postcode,
       ophanPageviewId: 'dummy', // todo: correct ophan pageview id
+      intcmp: state.common.intCmp,
     };
 
     if (state.common.refpvid) {


### PR DESCRIPTION
## Why are you doing this?

For one-off contributions, for both Stripe and PayPal, we POST the information to contributions-frontend and allow it to handle the payment. In order to correctly keep track of users in various tests we should be passing INTCMP through as well. However, until this point we've only been passing this through for PayPal, which has affected the results of some AB tests (notably tests 3 and 4).

This PR fixes the problem by passing the INTCMP through for Stripe as well.

cc: @jranks123 

## Changes

- Made `intcmp` a compulsory maybe type, instead of an optional string type.
- Included `intcmp` in the Stripe POST to contributions.
