### PR TITLE
Minifying CSS in PROD.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -96,6 +96,9 @@ module.exports = (env) => {
             use: [
               {
                 loader: 'css-loader',
+                options: {
+                  minimize: isProd,
+                },
               },
               {
                 loader: 'postcss-loader',


### PR DESCRIPTION
## Why are you doing this?

We weren't minifying CSS before, now we are (only for PROD). Related docs [here](https://github.com/webpack-contrib/css-loader).

## Changes

* `webpack.config.js`
