### PR TITLE
Fix Ways Of Support INTCMP

### DIFF
--- a/assets/pages/bundles-landing/components/WaysOfSupport.jsx
+++ b/assets/pages/bundles-landing/components/WaysOfSupport.jsx
@@ -82,7 +82,7 @@ const WaysOfSupport = (props: PropTypes) => {
 
 function mapStateToProps(state) {
   return {
-    intCmp: state.intCmp,
+    intCmp: state.common.intCmp,
   };
 }
 


### PR DESCRIPTION
## Why are you doing this?

The campaign code we pass through for the Patrons and Events links on the bundles landing page was being passed through as `undefined`. I think this probably happened in #215, when I refactored the redux store to use the common state. This PR switches to using that common state to look up the `intCmp`.

## Changes

- Switched to using common state to look up `intCmp` in state-props mapping.
