### PR TITLE
Improve accessibility

### DIFF
--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -6,7 +6,7 @@
 )(content: Html)(implicit assets: AssetsResolver)
 
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/assets/components/accessibility/accessibility.scss
+++ b/assets/components/accessibility/accessibility.scss
@@ -1,0 +1,8 @@
+.accessibilityHint {
+  position:absolute;
+  left:-10000px;
+  top:auto;
+  width:1px;
+  height:1px;
+  overflow:hidden;
+}

--- a/assets/components/headers/simpleHeader/simpleHeader.jsx
+++ b/assets/components/headers/simpleHeader/simpleHeader.jsx
@@ -15,6 +15,7 @@ export default function SimpleHeader() {
     <header className="component-simple-header">
       <div className="component-simple-header__content gu-header-margin">
         <a className="component-simple-header__link" href="https://www.theguardian.com">
+          <div className="accessibilityHint">The guardian logo</div>
           <Svg svgName="guardian-titlepiece" />
         </a>
       </div>

--- a/assets/components/headers/simpleHeader/simpleHeader.jsx
+++ b/assets/components/headers/simpleHeader/simpleHeader.jsx
@@ -15,7 +15,7 @@ export default function SimpleHeader() {
     <header className="component-simple-header">
       <div className="component-simple-header__content gu-header-margin">
         <a className="component-simple-header__link" href="https://www.theguardian.com">
-          <div className="accessibilityHint">The guardian logo</div>
+          <div className="accessibility-hint">The guardian logo</div>
           <Svg svgName="guardian-titlepiece" />
         </a>
       </div>

--- a/assets/stylesheets/gu-sass/accessibility.scss
+++ b/assets/stylesheets/gu-sass/accessibility.scss
@@ -1,6 +1,6 @@
 // ----- Assistive technologies guidance (non-visible) ----- //
 
-.accessibilityHint {
+.accessibility-hint {
   position:absolute;
   left:-10000px;
   top:auto;

--- a/assets/stylesheets/gu-sass/accessibility.scss
+++ b/assets/stylesheets/gu-sass/accessibility.scss
@@ -1,3 +1,5 @@
+// ----- Assistive technologies guidance (non-visible) ----- //
+
 .accessibilityHint {
   position:absolute;
   left:-10000px;

--- a/assets/stylesheets/main.scss
+++ b/assets/stylesheets/main.scss
@@ -7,10 +7,10 @@
 @import 'gu-sass/webfonts';
 @import 'gu-sass/typography';
 @import 'gu-sass/helpers';
+@import 'gu-sass/accessibility';
 
 // ----- Shared Components ----- //
 
-@import '../components/accessibility/accessibility';
 @import '../components/bodyCopy/bodyCopy';
 @import '../components/checkboxInput/checkboxInput';
 @import '../components/contribAmounts/contribAmounts';

--- a/assets/stylesheets/main.scss
+++ b/assets/stylesheets/main.scss
@@ -10,6 +10,7 @@
 
 // ----- Shared Components ----- //
 
+@import '../components/accessibility/accessibility';
 @import '../components/bodyCopy/bodyCopy';
 @import '../components/checkboxInput/checkboxInput';
 @import '../components/contribAmounts/contribAmounts';


### PR DESCRIPTION
## Why are you doing this?
Accessibility tests highlighted some issues. Let's patch 'em up.

Normally, we'd have a trello card-to-PR ratio of 1:1 but these were so tiny that I rolled two into one. Sorry.

[**Card 1 (no language):**](https://trello.com/c/YGDAllz6/931-accessibility-specify-language-in-document)
[**Card 2 (no text in header link):**](https://trello.com/c/nFcYhOop/932-accessibility-the-guardian-header-link-contains-no-text)

## Screenshots
If I've done this right, there will be no differences visually, but from the reporting site:
**Before**
![screen shot 2017-09-27 at 14 48 05](https://user-images.githubusercontent.com/690395/30917244-796b6496-a393-11e7-98f0-da63e9eb2dad.png)

**After**
![screen shot 2017-09-27 at 14 48 19](https://user-images.githubusercontent.com/690395/30917270-8608c220-a393-11e7-8d8f-a3013a45efff.png)

