### PR TITLE
Added user actions tests.

### DIFF
--- a/assets/helpers/user/__tests__/userActionsTest.js
+++ b/assets/helpers/user/__tests__/userActionsTest.js
@@ -1,0 +1,97 @@
+// @flow
+import {
+  setDisplayName,
+  setFirstName,
+  setLastName,
+  setFullName,
+  setEmail,
+  setStateField,
+  setPostcode,
+  setTestUser,
+  setGnmMarketing,
+} from '../userActions';
+
+
+describe('actions', () => {
+
+  it('should create SET_DISPLAY_NAME action', () => {
+    const name:string = 'My Name';
+    const expectedAction = {
+      type: 'SET_DISPLAY_NAME',
+      name,
+    };
+    expect(setDisplayName(name)).toEqual(expectedAction);
+  });
+
+  it('should create SET_FIRST_NAME action', () => {
+    const name:string = 'John';
+    const expectedAction = {
+      type: 'SET_FIRST_NAME',
+      name,
+    };
+    expect(setFirstName(name)).toEqual(expectedAction);
+  });
+
+  it('should create SET_LAST_NAME action', () => {
+    const name:string = 'Doe';
+    const expectedAction = {
+      type: 'SET_LAST_NAME',
+      name,
+    };
+    expect(setLastName(name)).toEqual(expectedAction);
+  });
+
+  it('should create SET_FULL_NAME action', () => {
+    const name:string = 'John Doe';
+    const expectedAction = {
+      type: 'SET_FULL_NAME',
+      name,
+    };
+    expect(setFullName(name)).toEqual(expectedAction);
+  });
+
+  it('should create SET_EMAIL action', () => {
+    const email:string = 'johndoe@example.com';
+    const expectedAction = {
+      type: 'SET_EMAIL',
+      email,
+    };
+    expect(setEmail(email)).toEqual(expectedAction);
+  });
+
+  it('should create SET_STATEFIELD action', () => {
+    const stateField:string = 'CA';
+    const expectedAction = {
+      type: 'SET_STATEFIELD',
+      stateField,
+    };
+    expect(setStateField(stateField)).toEqual(expectedAction);
+  });
+
+  it('should create SET_POSTCODE action', () => {
+    const postcode:string = 'N123';
+    const expectedAction = {
+      type: 'SET_POSTCODE',
+      postcode,
+    };
+    expect(setPostcode(postcode)).toEqual(expectedAction);
+  });
+
+  it('should create SET_TEST_USER action', () => {
+    const testUser:boolean = true;
+    const expectedAction = {
+      type: 'SET_TEST_USER',
+      testUser,
+    };
+    expect(setTestUser(testUser)).toEqual(expectedAction);
+  });
+
+  it('should create SET_GNM_MARKETING action', () => {
+    const preference:boolean = false;
+    const expectedAction = {
+      type: 'SET_GNM_MARKETING',
+      preference,
+    };
+    expect(setGnmMarketing(preference)).toEqual(expectedAction);
+  });
+});

--- a/assets/helpers/user/__tests__/userActionsTest.js
+++ b/assets/helpers/user/__tests__/userActionsTest.js
@@ -15,7 +15,7 @@ import {
 describe('actions', () => {
 
   it('should create SET_DISPLAY_NAME action', () => {
-    const name:string = 'My Name';
+    const name: string = 'My Name';
     const expectedAction = {
       type: 'SET_DISPLAY_NAME',
       name,
@@ -24,7 +24,7 @@ describe('actions', () => {
   });
 
   it('should create SET_FIRST_NAME action', () => {
-    const name:string = 'John';
+    const name: string = 'John';
     const expectedAction = {
       type: 'SET_FIRST_NAME',
       name,
@@ -33,7 +33,7 @@ describe('actions', () => {
   });
 
   it('should create SET_LAST_NAME action', () => {
-    const name:string = 'Doe';
+    const name: string = 'Doe';
     const expectedAction = {
       type: 'SET_LAST_NAME',
       name,
@@ -42,7 +42,7 @@ describe('actions', () => {
   });
 
   it('should create SET_FULL_NAME action', () => {
-    const name:string = 'John Doe';
+    const name: string = 'John Doe';
     const expectedAction = {
       type: 'SET_FULL_NAME',
       name,
@@ -51,7 +51,7 @@ describe('actions', () => {
   });
 
   it('should create SET_EMAIL action', () => {
-    const email:string = 'johndoe@example.com';
+    const email: string = 'johndoe@example.com';
     const expectedAction = {
       type: 'SET_EMAIL',
       email,
@@ -60,7 +60,7 @@ describe('actions', () => {
   });
 
   it('should create SET_STATEFIELD action', () => {
-    const stateField:string = 'CA';
+    const stateField: string = 'CA';
     const expectedAction = {
       type: 'SET_STATEFIELD',
       stateField,
@@ -69,7 +69,7 @@ describe('actions', () => {
   });
 
   it('should create SET_POSTCODE action', () => {
-    const postcode:string = 'N123';
+    const postcode: string = 'N123';
     const expectedAction = {
       type: 'SET_POSTCODE',
       postcode,
@@ -78,7 +78,7 @@ describe('actions', () => {
   });
 
   it('should create SET_TEST_USER action', () => {
-    const testUser:boolean = true;
+    const testUser: boolean = true;
     const expectedAction = {
       type: 'SET_TEST_USER',
       testUser,
@@ -87,7 +87,7 @@ describe('actions', () => {
   });
 
   it('should create SET_GNM_MARKETING action', () => {
-    const preference:boolean = false;
+    const preference: boolean = false;
     const expectedAction = {
       type: 'SET_GNM_MARKETING',
       preference,


### PR DESCRIPTION
## Why are you doing this?

This PR completes the refactor/adding tests started [here](https://github.com/guardian/support-frontend/pull/126#discussion_r127266482). Now the `user` helper has tests for all the components (reducer and actions).

## Changes

* Added user actions tests.

