### PR TITLE
Stop Lowercasing Query Params

### DIFF
--- a/assets/helpers/url.js
+++ b/assets/helpers/url.js
@@ -4,9 +4,12 @@
 
 const getQueryParameter = (paramName: string, defaultValue?: string): ?string => {
 
-  const params = new URLSearchParams(window.location.search.toLowerCase());
+  const params = new URLSearchParams(window.location.search);
 
-  return params.get(paramName.toLowerCase()) || defaultValue;
+  return params.get(paramName) ||
+    params.get(paramName.toLowerCase()) ||
+    params.get(paramName.toUpperCase()) ||
+    defaultValue;
 
 };
 


### PR DESCRIPTION
## Why are you doing this?

Our `getQueryParameter` utility function currently lowercases everything in the querystring. This was implemented to handle the fact that the `INTCMP` param can turn up in different formats (lowercased as 'intcmp' for example). However, it's started to cause problems in cases where querystring values aren't necessarily lowercase, e.g. [here](https://github.com/guardian/support-frontend/pull/211#discussion_r137788368), and for the [new acquisition data](https://github.com/guardian/frontend/pull/17840).

This PR stops this behaviour, but tries to do as much as possible by falling back to checking for uppercase and lowercase versions of a parameter. However, we really shouldn't be using multiple formats of a given query parameter, we should standardise on, for example, `INTCMP`. As it is, it looks like the major dotcom channels (epic, banner, header) all pass `INTCMP` through in uppercase, so this should have minimal impact.

## Changes

- Stopped lowercasing querystring.
- Added fallback checks for a query param being in uppercase or lowercase format.
