### PR TITLE
Use h2 tags for intro sub text on bundles landing page

### DIFF
--- a/assets/components/introductionText/introductionText.jsx
+++ b/assets/components/introductionText/introductionText.jsx
@@ -25,7 +25,7 @@ type PropTypes = {
 // ----- Functions ----- //
 
 function messageCopy(copy: string[]) {
-  return copy.map(paragraph => <h2>{paragraph}</h2>);
+  return copy.map(paragraph => <p className="component-introduction-text__sub-heading">{paragraph}</p>);
 }
 
 
@@ -35,7 +35,7 @@ export default function IntroductionText(props: PropTypes) {
 
   const messages = props.messages.map((message: Message) => (
     <div>
-      <h1 className="component-introduction-text__heading">{message.heading}</h1>
+      <p className="component-introduction-text__heading">{message.heading}</p>
       {messageCopy(message.copy)}
     </div>
   ));

--- a/assets/components/introductionText/introductionText.jsx
+++ b/assets/components/introductionText/introductionText.jsx
@@ -25,7 +25,7 @@ type PropTypes = {
 // ----- Functions ----- //
 
 function messageCopy(copy: string[]) {
-  return copy.map(paragraph => <p>{paragraph}</p>);
+  return copy.map(paragraph => <h2>{paragraph}</h2>);
 }
 
 

--- a/assets/components/introductionText/introductionText.scss
+++ b/assets/components/introductionText/introductionText.scss
@@ -40,7 +40,7 @@
     }
   }
 
-  p {
+  h2 {
     font-family: $gu-egyptian-web;
     font-weight: bold;
     font-size: 22px;

--- a/assets/components/introductionText/introductionText.scss
+++ b/assets/components/introductionText/introductionText.scss
@@ -16,7 +16,7 @@
     }
   }
 
-  h1 {
+  .component-introduction-text__heading {
     color: gu-colour(news-support-1);
     font-family: $gu-egyptian-web;
     font-weight: bold;
@@ -40,7 +40,7 @@
     }
   }
 
-  h2 {
+  .component-introduction-text__sub-heading {
     font-family: $gu-egyptian-web;
     font-weight: bold;
     font-size: 22px;
@@ -48,7 +48,7 @@
     color: #ffffff;
     margin-left: 40px;
 
-    &:nth-of-type(2) {
+    &:nth-of-type(3) {
       margin-bottom: $gu-v-spacing * 2;
     }
 


### PR DESCRIPTION
## Why are you doing this?
We use text that looks like a heading, but isn't marked as such. That confuses screen readers;

> **Why It Matters**
Heading elements (`<h1>-<h6>`) provide important document structure, outlines, and navigation functionality to assistive technology users. If heading text is not a true heading, this information and functionality will not be available for that text.

[**Trello Card**](https://trello.com/c/stCZQ7wp/933-accessibility-text-that-looks-like-a-heading-is-not-tagged-with-heading-values)

## Changes
* Swap `<p>` for `<h2>` tags in the introduction text
* Adjust CSS for the same, to retain desired styling

## Screenshots
**Before**
![screen shot 2017-09-27 at 17 44 28](https://user-images.githubusercontent.com/690395/30926084-f2ba8fe4-a3ab-11e7-89ff-14f71f82fe1c.png)

**After**
![screen shot 2017-09-27 at 17 44 46](https://user-images.githubusercontent.com/690395/30926093-f92dc8d2-a3ab-11e7-9aa3-c82dfde804da.png)

