### PR TITLE
Better Storage Wrapping

### DIFF
--- a/assets/helpers/abtest.js
+++ b/assets/helpers/abtest.js
@@ -1,11 +1,13 @@
 // @flow
 
 // ----- Imports ----- //
+
 import type { IsoCountry } from 'helpers/internationalisation/country';
 
 import * as ophan from 'ophan';
 import * as cookie from './cookie';
 import * as storage from './storage';
+
 
 // ----- Setup ----- //
 
@@ -84,14 +86,14 @@ function getMvtId(): number {
 
 function getLocalStorageParticipation(): Participations {
 
-  const abTests = storage.getItem('gu.support.abTests');
+  const abTests = storage.getLocal('gu.support.abTests');
 
   return abTests ? JSON.parse(abTests) : {};
 
 }
 
 function setLocalStorageParticipation(participation): void {
-  storage.setItem('gu.support.abTests', JSON.stringify(participation));
+  storage.setLocal('gu.support.abTests', JSON.stringify(participation));
 }
 
 function getUrlParticipation(): ?Participations {

--- a/assets/helpers/storage.js
+++ b/assets/helpers/storage.js
@@ -5,12 +5,18 @@
 // Checks if local/sessionStorage is usable. Need to do more than check if
 // 'window.localStorage' is defined, because Safari <11 in private browsing
 // mode is weird and sets the storage size to 0.
-function isStorageAvailable(storage) {
+function isStorageAvailable(storage): boolean {
 
   try {
 
     storage.setItem('storageTest', 'testValue');
-    return storage.getItem('storageTest') === 'testValue';
+
+    if (storage.getItem('storageTest') === 'testValue') {
+      storage.removeItem('storageTest');
+      return true;
+    }
+
+    return false;
 
   } catch (e) {
     return false;

--- a/assets/helpers/storage.js
+++ b/assets/helpers/storage.js
@@ -24,8 +24,8 @@ function isStorageAvailable(storage): boolean {
 
 }
 
-const SESSION_AVAILABLE = isStorageAvailable(sessionStorage);
-const LOCAL_AVAILABLE = isStorageAvailable(localStorage);
+const SESSION_AVAILABLE = isStorageAvailable(window.sessionStorage);
+const LOCAL_AVAILABLE = isStorageAvailable(window.localStorage);
 
 
 // ----- Functions ----- //

--- a/assets/helpers/storage.js
+++ b/assets/helpers/storage.js
@@ -3,35 +3,30 @@
 // ----- Setup ----- //
 
 // Checks if local/sessionStorage is usable. Need to do more than check if
-// 'window.localStorage' is defined, because Safari in private browsing
+// 'window.localStorage' is defined, because Safari <11 in private browsing
 // mode is weird and sets the storage size to 0.
-let localAvailable = false;
-let sessionAvailable = false;
+function isStorageAvailable(storage) {
 
-try {
+  try {
 
-  localStorage.setItem('storageTest', 'testValue');
-  localAvailable = localStorage.getItem('storageTest') === 'testValue';
+    storage.setItem('storageTest', 'testValue');
+    return storage.getItem('storageTest') === 'testValue';
 
-} catch (e) {
-  localAvailable = false;
+  } catch (e) {
+    return false;
+  }
+
 }
 
-try {
-
-  sessionStorage.setItem('storageTest', 'testValue');
-  sessionAvailable = sessionStorage.getItem('storageTest') === 'testValue';
-
-} catch (e) {
-  sessionAvailable = false;
-}
+const SESSION_AVAILABLE = isStorageAvailable(sessionStorage);
+const LOCAL_AVAILABLE = isStorageAvailable(localStorage);
 
 
-// ----- Exports ----- //
+// ----- Functions ----- //
 
 function setLocal(key: string, item: string): void {
 
-  if (localAvailable) {
+  if (LOCAL_AVAILABLE) {
     localStorage.setItem(key, item);
   }
 
@@ -39,7 +34,7 @@ function setLocal(key: string, item: string): void {
 
 function getLocal(key: string): ?string {
 
-  if (localAvailable) {
+  if (LOCAL_AVAILABLE) {
     return localStorage.getItem(key);
   }
 
@@ -49,7 +44,7 @@ function getLocal(key: string): ?string {
 
 function setSession(key: string, item: string): void {
 
-  if (sessionAvailable) {
+  if (SESSION_AVAILABLE) {
     sessionStorage.setItem(key, item);
   }
 
@@ -57,7 +52,7 @@ function setSession(key: string, item: string): void {
 
 function getSession(key: string): ?string {
 
-  if (sessionAvailable) {
+  if (SESSION_AVAILABLE) {
     return sessionStorage.getItem(key);
   }
 

--- a/assets/helpers/storage.js
+++ b/assets/helpers/storage.js
@@ -2,37 +2,75 @@
 
 // ----- Setup ----- //
 
-// Checks if localStorage is usable. Need to do more than check if
+// Checks if local/sessionStorage is usable. Need to do more than check if
 // 'window.localStorage' is defined, because Safari in private browsing
 // mode is weird and sets the storage size to 0.
-let localStorageAvailable = false;
+let localAvailable = false;
+let sessionAvailable = false;
 
 try {
 
   localStorage.setItem('storageTest', 'testValue');
-  localStorageAvailable = localStorage.getItem('storageTest') === 'testValue';
+  localAvailable = localStorage.getItem('storageTest') === 'testValue';
 
 } catch (e) {
-  localStorageAvailable = false;
+  localAvailable = false;
+}
+
+try {
+
+  sessionStorage.setItem('storageTest', 'testValue');
+  sessionAvailable = sessionStorage.getItem('storageTest') === 'testValue';
+
+} catch (e) {
+  sessionAvailable = false;
 }
 
 
 // ----- Exports ----- //
 
-export function setItem(key: string, item: string): void {
+function setLocal(key: string, item: string): void {
 
-  if (localStorageAvailable) {
+  if (localAvailable) {
     localStorage.setItem(key, item);
   }
 
 }
 
-export function getItem(key: string): ?string {
+function getLocal(key: string): ?string {
 
-  if (localStorageAvailable) {
+  if (localAvailable) {
     return localStorage.getItem(key);
   }
 
   return null;
 
 }
+
+function setSession(key: string, item: string): void {
+
+  if (sessionAvailable) {
+    sessionStorage.setItem(key, item);
+  }
+
+}
+
+function getSession(key: string): ?string {
+
+  if (sessionAvailable) {
+    return sessionStorage.getItem(key);
+  }
+
+  return null;
+
+}
+
+
+// ----- Exports ----- //
+
+export {
+  setLocal,
+  getLocal,
+  setSession,
+  getSession,
+};

--- a/assets/helpers/tracking/googleTagManager.js
+++ b/assets/helpers/tracking/googleTagManager.js
@@ -1,13 +1,21 @@
+// @flow
+
+// ----- Imports ----- //
+
 import uuidv4 from 'uuid';
+import * as storage from 'helpers/storage';
 import { forCountry } from '../internationalisation/currency';
 import { getQueryParameter } from '../url';
 import { detect as detectCountry } from '../internationalisation/country';
 
+
+// ----- Functions ----- //
+
 function getDataValue(name, generator) {
-  let value = sessionStorage.getItem(name);
+  let value = storage.getSession(name);
   if (value === null) {
     value = generator();
-    sessionStorage.setItem(name, value);
+    storage.setSession(name, value);
   }
   return value;
 }
@@ -19,10 +27,13 @@ function getCurrency() {
 function getContributionValue() {
   const param = getQueryParameter('contributionValue');
   if (param) {
-    sessionStorage.setItem('contributionValue', parseInt(param, 10));
+    storage.setSession('contributionValue', String(parseInt(param, 10)));
   }
-  return sessionStorage.getItem('contributionValue') || 0;
+  return storage.getSession('contributionValue') || 0;
 }
+
+
+// ----- Run ----- //
 
 window.googleTagManagerDataLayer = [{
   // orderId anonymously identifies this user in this session.
@@ -38,6 +49,7 @@ window.googleTagManagerDataLayer = [{
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
   new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
   j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+// $FlowFixMe
   'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 })(window,document,'script','googleTagManagerDataLayer','GTM-5PKPPQZ');
 /* eslint-enable */


### PR DESCRIPTION
## Why are you doing this?

To extend the `storage` module in order to provide wrappers for `sessionStorage` in addition to `localStorage`. This avoids a [bug](https://bugs.webkit.org/show_bug.cgi?id=157010) that exists in older versions of webkit.

[**Trello Card**](https://trello.com/c/Z05AK8SU/942-provide-better-storage-module-to-wrap-calls-to-sessionstorage-and-localstorage)

## Changes

- Updated `storage` module to wrap `sessionStorage`, allowing a check to see if it's available.
- Updated storage usages across the codebase to make use of this.
- Added flow checking to `googleTagManager`.
