### PR TITLE
Expand Utilities Tests

### DIFF
--- a/assets/helpers/__tests__/utilitiesTest.js
+++ b/assets/helpers/__tests__/utilitiesTest.js
@@ -9,6 +9,7 @@ import {
   generateClassName,
   clickSubstituteKeyPressHandler,
   parseBoolean,
+  deserialiseJsonObject,
 } from '../utilities';
 
 
@@ -133,6 +134,35 @@ describe('utilities', () => {
     it('should produce the correct fallbacks on failure to parse', () => {
       expect(parseBoolean('notaboolean', true)).toBe(true);
       expect(parseBoolean('notaboolean', false)).toBe(false);
+    });
+
+  });
+
+  describe('deserialiseJsonObject', () => {
+
+    it('should deserialise a valid JSON object', () => {
+
+      const serialised = '{"a": 1, "b": "hello world"}';
+      const deserialised = { a: 1, b: 'hello world' };
+
+      expect(deserialiseJsonObject(serialised)).toEqual(deserialised);
+
+    });
+
+    it('should return null for JSON that is not an object', () => {
+
+      const serialised = '[1, 2, 3]';
+
+      expect(deserialiseJsonObject(serialised)).toBeNull;
+
+    });
+
+    it('should return null for JSON that is malformed', () => {
+
+      const serialised = '{{notvalidJSON';
+
+      expect(deserialiseJsonObject(serialised)).toBeNull;
+
     });
 
   });

--- a/assets/helpers/__tests__/utilitiesTest.js
+++ b/assets/helpers/__tests__/utilitiesTest.js
@@ -7,6 +7,7 @@ import {
   descending,
   roundDp,
   generateClassName,
+  parseBoolean,
 } from '../utilities';
 
 
@@ -83,13 +84,34 @@ describe('utilities', () => {
 
   describe('generateClassName', () => {
 
-    it('create the same classname if no modifier is passed', () => {
+    it('should create the same classname if no modifier is passed', () => {
       expect(generateClassName('made-up-class')).toEqual('made-up-class');
     });
 
-    it('return a classname with a modifier attached', () => {
+    it('should return a classname with a modifier attached', () => {
       expect(generateClassName('made-up-class', 'fake-modifier'))
         .toEqual('made-up-class made-up-class--fake-modifier');
+    });
+
+  });
+
+  describe('parseBoolean', () => {
+
+    it('should parse all variations of true', () => {
+      expect(parseBoolean('true', false)).toBe(true);
+      expect(parseBoolean('TRUE', false)).toBe(true);
+      expect(parseBoolean('True', false)).toBe(true);
+    });
+
+    it('should parse all variations of false', () => {
+      expect(parseBoolean('false', true)).toBe(false);
+      expect(parseBoolean('FALSE', true)).toBe(false);
+      expect(parseBoolean('False', true)).toBe(false);
+    });
+
+    it('should produce the correct fallbacks on failure to parse', () => {
+      expect(parseBoolean('notaboolean', true)).toBe(true);
+      expect(parseBoolean('notaboolean', false)).toBe(false);
     });
 
   });

--- a/assets/helpers/__tests__/utilitiesTest.js
+++ b/assets/helpers/__tests__/utilitiesTest.js
@@ -88,6 +88,7 @@ describe('utilities', () => {
 
     it('should round to a given number of decimal places', () => {
       expect(roundDp(12.3456789, 5)).toBe(12.34568);
+      expect(roundDp(12.34, 5)).toBe(12.34);
     });
 
   });

--- a/assets/helpers/__tests__/utilitiesTest.js
+++ b/assets/helpers/__tests__/utilitiesTest.js
@@ -7,8 +7,17 @@ import {
   descending,
   roundDp,
   generateClassName,
+  clickSubstituteKeyPressHandler,
   parseBoolean,
 } from '../utilities';
+
+
+// ----- Functions ----- //
+
+// Returns a mocked keypress event.
+function getMockedKeypress(key: number) {
+  return { keyCode: key, preventDefault: () => {} };
+}
 
 
 // ----- Tests ----- //
@@ -91,6 +100,18 @@ describe('utilities', () => {
     it('should return a classname with a modifier attached', () => {
       expect(generateClassName('made-up-class', 'fake-modifier'))
         .toEqual('made-up-class made-up-class--fake-modifier');
+    });
+
+  });
+
+  describe('clickSubstituteKeyPressHandler', () => {
+
+    it('should call callback if return is pressed', (done) => {
+      clickSubstituteKeyPressHandler(done)(getMockedKeypress(13));
+    });
+
+    it('should call callback if space is pressed', (done) => {
+      clickSubstituteKeyPressHandler(done)(getMockedKeypress(32));
     });
 
   });

--- a/assets/helpers/__tests__/utilitiesTest.js
+++ b/assets/helpers/__tests__/utilitiesTest.js
@@ -2,7 +2,11 @@
 
 // ----- Imports ----- //
 
-import { ascending, descending } from '../utilities';
+import {
+  ascending,
+  descending,
+  roundDp,
+} from '../utilities';
 
 
 // ----- Tests ----- //
@@ -55,6 +59,23 @@ describe('utilities', () => {
 
       expect(unsorted.sort(descending)).toEqual(sorted);
 
+    });
+
+  });
+
+  describe('roundDp', () => {
+
+    it('should by default round to two decimal places', () => {
+      expect(roundDp(1234.5678)).toEqual(1234.57);
+    });
+
+    it('should round, not floor or ceil', () => {
+      expect(roundDp(12.345)).toEqual(12.35);
+      expect(roundDp(12.344)).toEqual(12.34);
+    });
+
+    it('should round to a given number of decimal places', () => {
+      expect(roundDp(12.3456789, 5)).toEqual(12.34568);
     });
 
   });

--- a/assets/helpers/__tests__/utilitiesTest.js
+++ b/assets/helpers/__tests__/utilitiesTest.js
@@ -153,7 +153,7 @@ describe('utilities', () => {
 
       const serialised = '[1, 2, 3]';
 
-      expect(deserialiseJsonObject(serialised)).toBeNull;
+      expect(deserialiseJsonObject(serialised)).toBeNull();
 
     });
 
@@ -161,7 +161,7 @@ describe('utilities', () => {
 
       const serialised = '{{notvalidJSON';
 
-      expect(deserialiseJsonObject(serialised)).toBeNull;
+      expect(deserialiseJsonObject(serialised)).toBeNull();
 
     });
 

--- a/assets/helpers/__tests__/utilitiesTest.js
+++ b/assets/helpers/__tests__/utilitiesTest.js
@@ -6,6 +6,7 @@ import {
   ascending,
   descending,
   roundDp,
+  generateClassName,
 } from '../utilities';
 
 
@@ -76,6 +77,19 @@ describe('utilities', () => {
 
     it('should round to a given number of decimal places', () => {
       expect(roundDp(12.3456789, 5)).toEqual(12.34568);
+    });
+
+  });
+
+  describe('generateClassName', () => {
+
+    it('create the same classname if no modifier is passed', () => {
+      expect(generateClassName('made-up-class')).toEqual('made-up-class');
+    });
+
+    it('return a classname with a modifier attached', () => {
+      expect(generateClassName('made-up-class', 'fake-modifier'))
+        .toEqual('made-up-class made-up-class--fake-modifier');
     });
 
   });

--- a/assets/helpers/__tests__/utilitiesTest.js
+++ b/assets/helpers/__tests__/utilitiesTest.js
@@ -77,16 +77,16 @@ describe('utilities', () => {
   describe('roundDp', () => {
 
     it('should by default round to two decimal places', () => {
-      expect(roundDp(1234.5678)).toEqual(1234.57);
+      expect(roundDp(1234.5678)).toBe(1234.57);
     });
 
     it('should round, not floor or ceil', () => {
-      expect(roundDp(12.345)).toEqual(12.35);
-      expect(roundDp(12.344)).toEqual(12.34);
+      expect(roundDp(12.345)).toBe(12.35);
+      expect(roundDp(12.344)).toBe(12.34);
     });
 
     it('should round to a given number of decimal places', () => {
-      expect(roundDp(12.3456789, 5)).toEqual(12.34568);
+      expect(roundDp(12.3456789, 5)).toBe(12.34568);
     });
 
   });
@@ -94,12 +94,12 @@ describe('utilities', () => {
   describe('generateClassName', () => {
 
     it('should create the same classname if no modifier is passed', () => {
-      expect(generateClassName('made-up-class')).toEqual('made-up-class');
+      expect(generateClassName('made-up-class')).toBe('made-up-class');
     });
 
     it('should return a classname with a modifier attached', () => {
       expect(generateClassName('made-up-class', 'fake-modifier'))
-        .toEqual('made-up-class made-up-class--fake-modifier');
+        .toBe('made-up-class made-up-class--fake-modifier');
     });
 
   });

--- a/assets/helpers/utilities.js
+++ b/assets/helpers/utilities.js
@@ -57,10 +57,6 @@ function parseBoolean(boolString: string, fallback: boolean): boolean {
 
 }
 
-function titleCase(s: string) {
-  return s.charAt(0).toUpperCase() + s.toLowerCase().substring(1);
-}
-
 // Deserialises a JSON object from a string.
 function deserialiseJsonObject(serialised: string): ?Object {
 
@@ -90,6 +86,5 @@ export {
   generateClassName,
   clickSubstituteKeyPressHandler,
   parseBoolean,
-  titleCase,
   deserialiseJsonObject,
 };

--- a/assets/helpers/utilities.js
+++ b/assets/helpers/utilities.js
@@ -58,13 +58,13 @@ function parseBoolean(boolString: string, fallback: boolean): boolean {
 }
 
 // Deserialises a JSON object from a string.
-function deserialiseJsonObject(serialised: string): ?Object {
+function deserialiseJsonObject(serialised: string): any {
 
   try {
 
     const deserialised = JSON.parse(serialised);
 
-    if (deserialised && typeof deserialised === 'object') {
+    if (deserialised instanceof Object && !(deserialised instanceof Array)) {
       return deserialised;
     }
 

--- a/assets/helpers/utilities.js
+++ b/assets/helpers/utilities.js
@@ -58,7 +58,7 @@ function parseBoolean(boolString: string, fallback: boolean): boolean {
 }
 
 // Deserialises a JSON object from a string.
-function deserialiseJsonObject(serialised: string): any {
+function deserialiseJsonObject(serialised: string): ?Object {
 
   try {
 


### PR DESCRIPTION
## Why are you doing this?

The utilities module didn't have full test coverage. Now it does. Also, I deleted a `titleCase` function that wasn't being used anywhere. In addition, believing I'd be able to use JavaScript's type system for `deserialiseJsonObject` was a fool's hope...

[**Trello Card**](https://trello.com/c/FjrpCO4i/943-add-tests-for-utilities)

## Changes

- Added tests for:
  + `roundDp`
  + `generateClassName`
  + `clickSubstituteKeyPressHandler`
  + `parseBoolean`
  + `deserialiseJson`
- Removed unused `titleCase` function.
- Added `getMockedKeypress` helper to mock keypress events.
- Stopped checking for 'object' type in `deserialiseJsonObject`, renamed it to `deserialiseJson`.
