### PR TITLE
Add the encryption parameter to the support workers request

### DIFF
--- a/app/services/stepfunctions/StateWrapper.scala
+++ b/app/services/stepfunctions/StateWrapper.scala
@@ -11,7 +11,7 @@ import io.circe.syntax._
 
 import scala.util.Try
 
-class StateWrapper(encryption: EncryptionProvider) {
+class StateWrapper(encryption: EncryptionProvider, useEncryption: Boolean) {
   implicit private val executionErrorEncoder = deriveEncoder[ExecutionError]
   implicit private val executionErrorDecoder = deriveDecoder[ExecutionError]
 
@@ -19,7 +19,7 @@ class StateWrapper(encryption: EncryptionProvider) {
   implicit private val wrapperDecoder = deriveDecoder[JsonWrapper]
 
   def wrap[T](state: T)(implicit encoder: Encoder[T]): String = {
-    JsonWrapper(encodeState(state), None).asJson.noSpaces
+    JsonWrapper(encodeState(state), None, useEncryption).asJson.noSpaces
   }
 
   def unWrap[T](s: String)(implicit decoder: Decoder[T]): Try[T] =

--- a/app/wiring/Services.scala
+++ b/app/wiring/Services.scala
@@ -19,7 +19,7 @@ trait Services {
   lazy val identityService = IdentityService(appConfig.identity)
 
   lazy val regularContributionsClient = {
-    val stateWrapper = new StateWrapper(Encryption.getProvider(appConfig.aws))
+    val stateWrapper = new StateWrapper(Encryption.getProvider(appConfig.aws), appConfig.aws.useEncryption)
     val regularContributionsStage = if (appConfig.stage == Stages.DEV) Stages.CODE else appConfig.stage
     RegularContributionsClient(
       regularContributionsStage,

--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-stepfunctions" % "1.11.128",
   "org.typelevel" %% "cats" % "0.9.0",
   "play-circe" %% "play-circe" % "2.6-0.8.0",
-  "com.gu" %% "support-models" % "0.10",
+  "com.gu" %% "support-models" % "0.11-SNAPSHOT",
   "com.gu" %% "support-config" % "0.7",
   "com.amazonaws" % "aws-java-sdk-sts" % "1.11.128",
   "com.typesafe.akka" %% "akka-agent" % "2.4.12",

--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-stepfunctions" % "1.11.128",
   "org.typelevel" %% "cats" % "0.9.0",
   "play-circe" %% "play-circe" % "2.6-0.8.0",
-  "com.gu" %% "support-models" % "0.11-SNAPSHOT",
+  "com.gu" %% "support-models" % "0.14",
   "com.gu" %% "support-config" % "0.7",
   "com.amazonaws" % "aws-java-sdk-sts" % "1.11.128",
   "com.typesafe.akka" %% "akka-agent" % "2.4.12",


### PR DESCRIPTION
## Why are you doing this?

To support this PR https://github.com/guardian/support-workers/pull/62

"To make it easier to switch encryption on and off without a risk of support-frontend and support-workers getting out of sync, this PR moves the setting which determines whether a request is encrypted or not into the request state rather than the config setting.

This means that support-frontend is now the only place where we need to update the encryption setting and support-workers will handle whatever it is sent. This would also allow us to send a mix of encrypted and unencrypted requests if for instance we wanted to keep test user requests unencrypted"

[**Trello Card**](https://trello.com/b/TjUElW0B/simple-and-coherent-product-supporting-the-guardian)
