### PR TITLE
Allow Signout

### DIFF
--- a/assets/components/displayName/displayName.jsx
+++ b/assets/components/displayName/displayName.jsx
@@ -6,7 +6,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import Svg from 'components/svg/svg';
-import Signout from 'components/signout/signout';
 
 
 // ---- Types ----- //
@@ -24,7 +23,6 @@ function DisplayName(props: PropTypes) {
     <div className="component-display-name">
       <Svg svgName="user" />
       <span className="component-display-name__name">{props.name}</span>
-      <Signout />
     </div>
   );
 

--- a/assets/components/displayName/displayName.jsx
+++ b/assets/components/displayName/displayName.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import Svg from 'components/svg/svg';
+import Signout from 'components/signout/signout';
 
 
 // ---- Types ----- //
@@ -23,6 +24,7 @@ function DisplayName(props: PropTypes) {
     <div className="component-display-name">
       <Svg svgName="user" />
       <span className="component-display-name__name">{props.name}</span>
+      <Signout />
     </div>
   );
 

--- a/assets/components/displayName/displayName.scss
+++ b/assets/components/displayName/displayName.scss
@@ -1,5 +1,4 @@
 .component-display-name {
-	height: 40px;
 	margin-bottom: $gu-v-spacing;
 
 	.component-display-name__name {
@@ -14,7 +13,7 @@
 	}
 
 	svg {
-		height: 50%;
+		height: 20px;
 		// Fix for IE.
 		width: 20px;
 		fill: gu-colour(neutral-1);

--- a/assets/components/infoSection/infoSection.jsx
+++ b/assets/components/infoSection/infoSection.jsx
@@ -13,6 +13,7 @@ type PropTypes = {
   heading?: ?string,
   className?: string,
   children?: Node,
+  headingContent?: Node,
 };
 
 
@@ -20,14 +21,15 @@ type PropTypes = {
 
 export default function InfoSection(props: PropTypes) {
 
-  const headerContent = (
+  const heading = (
     <h2 className="component-info-section__heading">{props.heading}</h2>
   );
 
   return (
     <section className={`component-info-section ${props.className || ''}`}>
       <div className="component-info-section__header">
-        {props.heading ? headerContent : null}
+        {props.heading ? heading : null}
+        {props.headingContent}
       </div>
       <div className="component-info-section__content">{props.children}</div>
     </section>
@@ -42,4 +44,5 @@ InfoSection.defaultProps = {
   heading: null,
   className: '',
   children: null,
+  headingContent: null,
 };

--- a/assets/components/signout/signout.jsx
+++ b/assets/components/signout/signout.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 
-import { getDomain } from 'helpers/url';
+import { getBaseDomain } from 'helpers/url';
 
 
 // ---- Types ----- //
@@ -21,7 +21,7 @@ function buildUrl(returnUrl: ?string): string {
 
   const encodedReturn = encodeURIComponent(returnUrl || window.location);
 
-  return `https://profile.${getDomain()}/signout?returnUrl=${encodedReturn}`;
+  return `https://profile.${getBaseDomain()}/signout?returnUrl=${encodedReturn}`;
 
 }
 

--- a/assets/components/signout/signout.jsx
+++ b/assets/components/signout/signout.jsx
@@ -1,0 +1,39 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+import { getDomain } from 'helpers/url';
+
+
+// ---- Types ----- //
+
+type PropTypes = {
+  returnUrl: ?string,
+};
+
+
+// ----- Functions ----- //
+
+// Build signout URL from given return URL or current location.
+function buildUrl(returnUrl: ?string): string {
+
+  const encodedReturn = encodeURIComponent(returnUrl || window.location);
+
+  return `https://profile.${getDomain()}?returnUrl=${encodedReturn}`;
+
+}
+
+
+// ----- Component ----- //
+
+export default function Signout(props: PropTypes) {
+
+  return (
+    <a className="component-signout" href={buildUrl(props.returnUrl)}>
+      Sign out
+    </a>
+  );
+
+}

--- a/assets/components/signout/signout.jsx
+++ b/assets/components/signout/signout.jsx
@@ -21,7 +21,7 @@ function buildUrl(returnUrl: ?string): string {
 
   const encodedReturn = encodeURIComponent(returnUrl || window.location);
 
-  return `https://profile.${getDomain()}?returnUrl=${encodedReturn}`;
+  return `https://profile.${getDomain()}/signout?returnUrl=${encodedReturn}`;
 
 }
 

--- a/assets/components/signout/signout.jsx
+++ b/assets/components/signout/signout.jsx
@@ -10,7 +10,7 @@ import { getDomain } from 'helpers/url';
 // ---- Types ----- //
 
 type PropTypes = {
-  returnUrl: ?string,
+  returnUrl?: string,
 };
 
 
@@ -37,3 +37,10 @@ export default function Signout(props: PropTypes) {
   );
 
 }
+
+
+// ----- Default Props ----- //
+
+Signout.defaultProps = {
+  returnUrl: '',
+};

--- a/assets/components/signout/signout.jsx
+++ b/assets/components/signout/signout.jsx
@@ -32,7 +32,7 @@ export default function Signout(props: PropTypes) {
 
   return (
     <a className="component-signout" href={buildUrl(props.returnUrl)}>
-      Sign out
+      Not you?
     </a>
   );
 

--- a/assets/components/signout/signout.jsx
+++ b/assets/components/signout/signout.jsx
@@ -32,7 +32,7 @@ export default function Signout(props: PropTypes) {
 
   return (
     <a className="component-signout" href={buildUrl(props.returnUrl)}>
-      Not you?
+      Not you? Sign out
     </a>
   );
 

--- a/assets/components/signout/signout.scss
+++ b/assets/components/signout/signout.scss
@@ -1,4 +1,5 @@
 .component-signout {
   font-size: 14px;
-  display: block;
+  font-family: $gu-text-sans-web;
+  font-weight: 300;
 }

--- a/assets/components/signout/signout.scss
+++ b/assets/components/signout/signout.scss
@@ -1,0 +1,4 @@
+.component-signout {
+  font-size: 14px;
+  display: block;
+}

--- a/assets/helpers/url.js
+++ b/assets/helpers/url.js
@@ -1,5 +1,27 @@
 // @flow
 
+// ----- Types ----- //
+
+export type Domain
+  = 'thegulocal.com'
+  | 'code.dev-theguardian.com'
+  | 'theguardian.com'
+  ;
+
+export type Env = 'DEV' | 'CODE' | 'PROD';
+
+
+// ----- Setup ----- //
+
+const DOMAINS: {
+  [Env]: Domain,
+} = {
+  DEV: 'thegulocal.com',
+  CODE: 'code.dev-theguardian.com',
+  PROD: 'theguardian.com',
+};
+
+
 // ----- Functions ----- //
 
 const getQueryParameter = (paramName: string, defaultValue?: string): ?string => {
@@ -34,10 +56,25 @@ const addQueryParamToURL = (urlOrPath: string, paramsKey: string, paramsValue: ?
   return `${strInit}?${paramsObj.toString()}`;
 };
 
+function getDomain(): Domain {
+
+  const origin = window.location.origin;
+
+  if (origin.includes(DOMAINS.DEV)) {
+    return DOMAINS.DEV;
+  } else if (origin.includes(DOMAINS.CODE)) {
+    return DOMAINS.CODE;
+  }
+
+  return DOMAINS.PROD;
+
+}
+
 
 // ----- Exports ----- //
 
 export {
   getQueryParameter,
   addQueryParamToURL,
+  getDomain,
 };

--- a/assets/helpers/url.js
+++ b/assets/helpers/url.js
@@ -56,7 +56,8 @@ const addQueryParamToURL = (urlOrPath: string, paramsKey: string, paramsValue: ?
   return `${strInit}?${paramsObj.toString()}`;
 };
 
-function getDomain(): Domain {
+// Retrieves the domain for the given env, e.g. guardian.com/gulocal.com.
+function getBaseDomain(): Domain {
 
   const origin = window.location.origin;
 
@@ -76,5 +77,5 @@ function getDomain(): Domain {
 export {
   getQueryParameter,
   addQueryParamToURL,
-  getDomain,
+  getBaseDomain,
 };

--- a/assets/pages/regular-contributions/regularContributions.jsx
+++ b/assets/pages/regular-contributions/regularContributions.jsx
@@ -17,6 +17,7 @@ import TermsPrivacy from 'components/legal/termsPrivacy/termsPrivacy';
 import TestUserBanner from 'components/testUserBanner/testUserBanner';
 import PaymentAmount from 'components/paymentAmount/paymentAmount';
 import ContribLegal from 'components/legal/contribLegal/contribLegal';
+import Signout from 'components/signout/signout';
 
 import { forCountry as currencyForCountry } from 'helpers/internationalisation/currency';
 import { detect as detectCountry } from 'helpers/internationalisation/country';
@@ -81,7 +82,7 @@ const content = (
             currency={state.page.regularContrib.currency}
           />
         </InfoSection>
-        <InfoSection heading="Your details" className="regular-contrib__your-details">
+        <InfoSection heading="Your details" headingContent={<Signout />} className="regular-contrib__your-details">
           <DisplayName />
           <FormFields />
         </InfoSection>

--- a/assets/pages/regular-contributions/regularContributions.scss
+++ b/assets/pages/regular-contributions/regularContributions.scss
@@ -79,6 +79,15 @@
 	// ----- Your details
 
 	.regular-contrib__your-details {
+		position: relative;
+
+		@include mq($until: desktop) {
+			.component-signout {
+				position: absolute;
+				top: 0;
+				right: 0;
+			}
+		}
 
 		#last-name {
 			margin-bottom: 0px;

--- a/assets/stylesheets/main.scss
+++ b/assets/stylesheets/main.scss
@@ -36,6 +36,7 @@
 @import '../components/payPalExpressButton/payPalExpressButton';
 @import '../components/stripePopUpButton/stripePopUpButton';
 @import '../components/legal/termsPrivacy/termsPrivacy';
+@import '../components/signout/signout';
 @import '../components/textInput/textInput';
 @import '../components/testUserBanner/testUserBanner';
 @import '../components/secure/secure';


### PR DESCRIPTION
## Why are you doing this?

To allow users to sign out on the regular contributions checkout, in case they are signed in with the wrong account.

Clicking 'sign out' sends you to the identity sign-up page, which returns you to the same checkout page once you've signed-up/signed-in.

[**Trello Card**](https://trello.com/c/8s9BzPmO/947-allow-people-to-sign-out)

cc: @elvisr

## Changes

- Fixed a wonky IE10 workaround in `displayName`.
- Allowed passing React components into the heading part of `infoSection`.
- Added a signout component.
- Added a url helper function to retrieve the correct domain for the env (DEV, CODE, PROD).
- Added signout to the regular contributions checkout.

## Screenshots

**Desktop:**

![new-signout-desktop](https://user-images.githubusercontent.com/5131341/31186841-bf58f542-a927-11e7-857d-11dd960380c2.png)

**Mobile:**

![new-signout-mob](https://user-images.githubusercontent.com/5131341/31186851-c561b03c-a927-11e7-801b-ea84901ffa5f.png)
