### PR TITLE
Change Copy On PayPal Button

### DIFF
--- a/assets/components/payPalContributionButton/payPalContributionButton.jsx
+++ b/assets/components/payPalContributionButton/payPalContributionButton.jsx
@@ -22,7 +22,7 @@ type PropTypes = {
   isoCountry: IsoCountry,
   errorHandler: (string) => void,
   canClick?: boolean,
-  copy?: string,
+  buttonText?: string,
 };
 /* eslint-enable react/no-unused-prop-types */
 
@@ -54,7 +54,7 @@ const PayPalContributionButton = (props: PropTypes) =>
     >
 
       <Svg svgName="paypal-p-logo" />
-      <span>{props.copy}</span>
+      <span>{props.buttonText}</span>
       <Svg svgName="arrow-right-straight" />
     </button>
   );
@@ -66,7 +66,7 @@ PayPalContributionButton.defaultProps = {
   intCmp: null,
   refpvid: null,
   canClick: true,
-  copy: 'Pay with PayPal',
+  buttonText: 'Pay with PayPal',
 };
 
 

--- a/assets/components/payPalContributionButton/payPalContributionButton.jsx
+++ b/assets/components/payPalContributionButton/payPalContributionButton.jsx
@@ -22,6 +22,7 @@ type PropTypes = {
   isoCountry: IsoCountry,
   errorHandler: (string) => void,
   canClick?: boolean,
+  copy?: string,
 };
 /* eslint-enable react/no-unused-prop-types */
 
@@ -53,7 +54,7 @@ const PayPalContributionButton = (props: PropTypes) =>
     >
 
       <Svg svgName="paypal-p-logo" />
-      <span>contribute with PayPal</span>
+      <span>{props.copy}</span>
       <Svg svgName="arrow-right-straight" />
     </button>
   );
@@ -65,6 +66,7 @@ PayPalContributionButton.defaultProps = {
   intCmp: null,
   refpvid: null,
   canClick: true,
+  copy: 'Pay with PayPal',
 };
 
 

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -94,6 +94,7 @@ function showPayPal(props: PropTypes) {
       isoCountry={props.isoCountry}
       errorHandler={props.payPalErrorHandler}
       canClick={!props.contribError}
+      copy="Contribute with PayPal"
     />);
   }
   return null;

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -94,7 +94,7 @@ function showPayPal(props: PropTypes) {
       isoCountry={props.isoCountry}
       errorHandler={props.payPalErrorHandler}
       canClick={!props.contribError}
-      copy="Contribute with PayPal"
+      buttonText="Contribute with PayPal"
     />);
   }
   return null;


### PR DESCRIPTION
## Why are you doing this?

The PayPal contributions button currently uses 'contribute' where it should use 'pay', and the casing is incorrect (it doesn't match its surroundings). This changes the default copy to say 'Pay with PayPal', and allows the copy to be overridden. It's overridden on the contributions landing page to say 'Contribute with PayPal'.

[**Trello Card**](https://trello.com/c/CAP2KK22/950-change-copy-on-paypal-contributions-button)

## Changes

- Set default props on the PayPal button.
- Overrode button copy on contributions landing page.

## Screenshots

**One-Off Checkout Page:**

![checkout](https://user-images.githubusercontent.com/5131341/31187909-2938658a-a92b-11e7-833a-ca928eb8c772.png)

**Contributions Landing Page:**

![landing](https://user-images.githubusercontent.com/5131341/31187913-2d732c16-a92b-11e7-98f4-94c67abc18ac.png)
