### PR TITLE
Bundles Landing Page - Copy Changes

### DIFF
--- a/assets/components/introductionText/introductionText.scss
+++ b/assets/components/introductionText/introductionText.scss
@@ -22,7 +22,6 @@
     font-weight: bold;
     font-size: 22px;
     line-height: 26px;
-    word-spacing: -0.08em;
 
     @include mq($from: mobileMedium) {
       font-size: 24px;

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -286,34 +286,6 @@
       }
     }
 
-    .why-support__image {
-      width: 100%;
-      overflow: hidden;
-      position: relative;
-
-      @include mq($from: tablet) {
-        height: 240px;
-      }
-
-      @include mq($from: desktop) {
-        height: 360px;
-      }
-
-      .component-grid-picture__image {
-        display: block;
-
-        @include mq($from: tablet) {
-          position: absolute;
-          top: -100%;
-          bottom: -100%;
-          left: -100%;
-          right: -100%;
-          margin: auto;
-          height: 100%;
-        }
-      }
-    }
-
     .why-support__top-content, .why-support__bottom-content {
       flex-basis: 300px;
       flex-grow: 1;

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -231,6 +231,11 @@
     vertical-align: top;
     margin-right: $gu-h-spacing / 2;
 
+    @include mq($from: tablet) {
+      width: 220px;
+      margin-right: $gu-h-spacing;
+    }
+
     @include mq($from: desktop) {
       width: 300px;
       margin-right: $gu-h-spacing;

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -531,6 +531,7 @@
         flex-basis: 300px;
         // Fix for Safari 8.
         max-width: 300px;
+        height: 340px;
         margin-bottom: 0;
       }
 
@@ -558,6 +559,13 @@
       font-size: 16px;
       margin: 0 ($gu-h-spacing / 2);
       line-height: 20px;
+    }
+
+    .component-cta-circle {
+      @include mq($from: desktop) {
+        position: absolute;
+        bottom: 0;
+      }
     }
 
     .component-cta-circle--patron {

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -226,7 +226,7 @@
     line-height: 32px;
     font-weight: 900;
     font-family: $gu-egyptian-web;
-    color: gu-colour(guardian-brand);
+    color: gu-colour(guardian-brand-dark);
     display: inline-block;
     vertical-align: top;
     margin-right: $gu-h-spacing / 2;
@@ -521,7 +521,7 @@
 
     .ways-of-support__heading {
       flex-basis: 100%;
-      color: gu-colour(news-support-2);
+      color: gu-colour(guardian-brand-dark);
       font-family: 'Guardian Titlepiece Web', sans-serif;
       font-weight: 400;
       padding-top: 2px;

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -70,7 +70,7 @@
       @include mq($from: desktop) {
         margin: 0 ($gu-h-spacing / 2);
         width: 280px;
-        height: 400px;
+        height: 430px;
         display: inline-block;
         vertical-align: top;
         position: relative;

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -131,6 +131,12 @@
           height: 32px;
         }
       }
+
+      p {
+        font-size: 16px;
+        line-height: 20px;
+        margin-bottom: $gu-v-spacing;
+      }
     }
 
     .component-bundle--digital, .component-bundle--paper {

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -70,7 +70,7 @@
       @include mq($from: desktop) {
         margin: 0 ($gu-h-spacing / 2);
         width: 280px;
-        height: 430px;
+        height: 410px;
         display: inline-block;
         vertical-align: top;
         position: relative;

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -31,14 +31,10 @@
     .bundles__content {
       background-color: gu-colour(comment-support-2);
       position: relative;
-
-      @include mq($until: desktop) {
-        padding-bottom: ($gu-v-spacing * 8);
-      }
+      padding-bottom: ($gu-v-spacing * 6);
 
       @include mq($from: desktop) {
-        padding: 0 0;
-        padding-bottom: ($gu-v-spacing * 8);
+        padding: 0 0 ($gu-v-spacing * 6);
       }
     }
 
@@ -214,6 +210,73 @@
       margin-bottom: 2 * $gu-v-spacing;
     }
 
+  }
+
+  .bundles__cross-product {
+    margin: 0 auto;
+    padding-top: $gu-v-spacing * 2;
+
+    @include mq($from: desktop) {
+      width: 940px;
+    }
+  }
+
+  .bundles__cross-product-header {
+    font-size: 28px;
+    line-height: 32px;
+    font-weight: 900;
+    font-family: $gu-egyptian-web;
+    color: gu-colour(guardian-brand);
+    display: inline-block;
+    vertical-align: top;
+    margin-right: $gu-h-spacing / 2;
+
+    @include mq($from: desktop) {
+      width: 300px;
+      margin-right: $gu-h-spacing;
+    }
+  }
+
+  .bundles__cross-product-heading {
+    display: block;
+
+    &:nth-of-type(2) {
+      margin-left: $gu-h-spacing * 2;
+
+      @include mq($from: mobileMedium) {
+        margin-left: $gu-h-spacing * 5;
+      }
+
+      @include mq($from: tablet) {
+        margin-left: 0;
+      }
+
+      @include mq($from: desktop) {
+        margin-left: $gu-h-spacing * 2;
+      }
+    }
+  }
+
+  .bundles__cross-product-copy {
+    display: inline-block;
+    vertical-align: top;
+    font-size: 16px;
+    line-height: 20px;
+    color: gu-colour(neutral-1);
+
+    @include mq($until: tablet) {
+      padding-top: $gu-v-spacing;
+    }
+
+    @include mq($from: tablet) {
+      width: 450px;
+      font-size: 18px;
+      line-height: 22px;
+    }
+
+    @include mq($from: desktop) {
+      width: 620px;
+    }
   }
 
 

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -90,7 +90,7 @@ type BundlesType = {
 const contribCopy: ContribAttrs = {
   heading: 'contribute',
   subheading: 'from £5/month',
-  ctaText: 'Contribute',
+  ctaText: 'Contribute with card or PayPal',
   modifierClass: 'contributions',
   ctaLink: '',
 };
@@ -100,12 +100,12 @@ const digitalCopy: DigitalAttrs = {
   subheading: '£11.99/month',
   listItems: [
     {
-      heading: 'Ad-free mobile app',
-      text: 'No interruptions means pages load quicker for a clearer reading experience',
+      heading: 'Premium experience on the Guardian app',
+      text: 'Get faster loading pages and a clearer reading experience without adverts. Play our daily crosswords offline wherever you are',
     },
     {
-      heading: 'Daily tablet edition',
-      text: 'Daily newspaper optimised for tablet; available on Apple, Android and Kindle Fire',
+      heading: 'Daily Tablet Edition app',
+      text: 'Read the Guardian, the Observer and all the Weekend supplements in an optimised tablet app; available on iPad, Android and Kindle Fire tablets',
     },
   ],
   ctaText: 'Start your 14 day trial',
@@ -118,19 +118,18 @@ const paperCopy: PaperAttrs = {
   subheading: 'from £10.79/month',
   listItems: [
     {
-      heading: 'Newspaper',
-      text: 'Choose the package you want: Everyday, Sixday, Weekend and Sunday',
+      heading: 'Choose your package and delivery method',
+      text: 'Everyday, Sixday, Weekend and Sunday; redeem paper vouchers or get home delivery',
     },
     {
       heading: 'Save money off the retail price',
     },
     {
-      heading: 'All the benefits of a digital subscription',
-      text: 'Available with paper+digital',
+      heading: 'Get all the benefits of a digital subscription with a paper+digital subscription',
     },
   ],
-  paperCtaText: 'Become a paper subscriber',
-  paperDigCtaText: 'Become a paper+digital subscriber',
+  paperCtaText: 'Get a paper subscription',
+  paperDigCtaText: 'Get a paper+digital subscription',
   modifierClass: 'paper',
   paperDigCtaLink: 'https://subscribe.theguardian.com/collection/paper-digital',
   paperCtaLink: 'https://subscribe.theguardian.com/collection/paper',

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -127,7 +127,7 @@ const paperCopy: PaperAttrs = {
       heading: 'Save money off the retail price',
     },
     {
-      heading: 'Get all the benefits of a digital subscription with a paper+digital subscription',
+      heading: 'Get all the benefits of a digital subscription with paper+digital',
     },
   ],
   paperCtaText: 'Get a paper subscription',

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -15,6 +15,8 @@ import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { Campaign } from 'helpers/tracking/acquisitions';
 import { routes } from 'helpers/routes';
 
+import CrossProduct from './crossProduct';
+
 import {
   changeContribType,
   changeContribAmount,
@@ -262,6 +264,7 @@ function Bundles(props: PropTypes) {
           <div className="bundles__divider" />
           <PaperBundle {...paperAttrs} />
         </div>
+        <CrossProduct />
       </div>
     </section>
   );

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -51,6 +51,7 @@ type PropTypes = {
 type ContribAttrs = {
   heading: string,
   subheading: string,
+  tagline: string,
   ctaText: string,
   modifierClass: string,
   ctaLink: string,
@@ -90,6 +91,7 @@ type BundlesType = {
 const contribCopy: ContribAttrs = {
   heading: 'contribute',
   subheading: 'from £5/month',
+  tagline: 'Your contribution directly funds our journalism',
   ctaText: 'Contribute with card or PayPal',
   modifierClass: 'contributions',
   ctaLink: '',
@@ -205,6 +207,7 @@ function ContributionBundle(props: PropTypes) {
 
   return (
     <Bundle {...contribAttrs}>
+      <p>{bundles.contrib.tagline}</p>
       <ContribAmounts
         onNumberInputKeyPress={onClick}
         {...props}

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -112,7 +112,7 @@ const digitalCopy: DigitalAttrs = {
       text: 'Read the Guardian, the Observer and all the Weekend supplements in an optimised tablet app; available on iPad, Android and Kindle Fire tablets',
     },
   ],
-  ctaText: 'Start your 14 day trial',
+  ctaText: 'Start your free trial',
   modifierClass: 'digital',
   ctaLink: 'https://subscribe.theguardian.com/uk/digital',
 };

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -105,7 +105,7 @@ const digitalCopy: DigitalAttrs = {
   listItems: [
     {
       heading: 'Premium experience on the Guardian app',
-      text: 'Get faster loading pages and a clearer reading experience without adverts. Play our daily crosswords offline wherever you are',
+      text: 'No adverts means faster loading pages and a clearer reading experience. Play our daily crosswords offline wherever you are',
     },
     {
       heading: 'Daily Tablet Edition app',

--- a/assets/pages/bundles-landing/components/Introduction.jsx
+++ b/assets/pages/bundles-landing/components/Introduction.jsx
@@ -10,12 +10,12 @@ import IntroductionText from 'components/introductionText/introductionText';
 
 const copy = [
   {
-    heading: 'support the Guardian',
-    copy: ['be part of our future', 'by helping to secure it'],
+    heading: 'help us deliver the',
+    copy: ['independent journalism', 'the world needs'],
   },
   {
-    heading: 'hold power to account',
-    copy: ['by funding quality,', 'independent journalism'],
+    heading: 'support the Guardian',
+    copy: ['contribute or subscribe'],
   },
 ];
 

--- a/assets/pages/bundles-landing/components/WaysOfSupport.jsx
+++ b/assets/pages/bundles-landing/components/WaysOfSupport.jsx
@@ -33,7 +33,7 @@ const waysOfSupport = [
   },
   {
     heading: 'Guardian Live events',
-    infoText: 'Events, discussions, debates, interviews, festivals, dinners and private views',
+    infoText: 'Meet Guardian journalists and readers at our events, debates, interviews and festivals',
     ctaText: 'Find out about events',
     product: 'events',
     modifierClass: 'gu-events',

--- a/assets/pages/bundles-landing/components/WaysOfSupport.jsx
+++ b/assets/pages/bundles-landing/components/WaysOfSupport.jsx
@@ -24,8 +24,8 @@ function generateOnClick(product: MemProduct, intCmp: ?string): () => void {
 const waysOfSupport = [
   {
     heading: 'Patrons',
-    infoText: 'The Patron tier is for those who care deeply about the Guardian\'s journalism and the impact it has on the world',
-    ctaText: 'Become a Patron',
+    infoText: 'The Patron tier is for those who want a deeper relationship with the Guardian and its journalists',
+    ctaText: 'Find out more',
     product: 'patrons',
     modifierClass: 'patron',
     gridImg: '137d6b217a27acddf85512657d04f6490b9e0bb1/1638_0_3571_2009',
@@ -33,7 +33,7 @@ const waysOfSupport = [
   },
   {
     heading: 'Guardian Live events',
-    infoText: 'Events, discussions, debates, interviews, festivals, dinners and private views exclusively for Guardian members',
+    infoText: 'Events, discussions, debates, interviews, festivals, dinners and private views',
     ctaText: 'Find out about events',
     product: 'events',
     modifierClass: 'gu-events',

--- a/assets/pages/bundles-landing/components/WhySupport.jsx
+++ b/assets/pages/bundles-landing/components/WhySupport.jsx
@@ -14,12 +14,13 @@ import Video from 'components/video/video';
 
 const copy = {
   top: [
-    'With no billionaire owner pulling our strings, nobody, be they shareholders or advertisers, can tell us to censor or drop a story.',
-    'Our quality investigative journalism takes a lot of time and money to produce. And while the Scott Trust safeguards our independence, its funds are limited.',
+    'Your support is vital in helping the Guardian do the most important journalism of all: that which takes time and effort. Hundreds of thousands of readers now support the Guardian\'s independent, quality and investigative journalism.',
+    'This is crucial, when like many media organisations, the Guardian is operating in an incredibly challenging commercial environment, and the advertising that we used to rely on to fund our work continues to fall.',
   ],
   bottom: [
-    'With ad revenues falling across the media, we need our readers\' support to secure our future and help hold power to account.',
-    'Independent, progressive journalism benefits everyone. And if that\'s a view you share, join us today and help ensure our voice continues to be heard.',
+    'We haven\'t put up a paywall – we want to keep our journalism as open as we can.',
+    'We don’t have a billionaire owner pulling our strings. Our owner, the Scott Trust, safeguards our editorial independence from commercial or political interference and reinvests revenue into our journalism, as opposed to into shareholders\' pockets.',
+    'Help to make the Guardian\'s journalism possible: by funding it, by reading it, by sharing it, and by participating in it so that together we can continue to tell the stories that matter, to inform the world and to make it a better place. ',
   ],
   videoCaption: 'Katharine Viner, editor-in-chief, explains the Guardian\'s unique ownership model',
 };

--- a/assets/pages/bundles-landing/components/WhySupport.jsx
+++ b/assets/pages/bundles-landing/components/WhySupport.jsx
@@ -7,30 +7,10 @@ import React from 'react';
 import Svg from 'components/svg/svg';
 
 import BodyCopy from 'components/bodyCopy/bodyCopy';
-import GridPicture from 'components/gridPicture/gridPicture';
 import Video from 'components/video/video';
 
 
 // ----- Copy ----- //
-
-const heroImage = {
-  sources: [
-    {
-      gridId: 'bce7d14f7f837a4f6c854d95efc4b1eab93a8c65/0_0_5200_720',
-      srcSizes: [2000, 1000],
-      media: '(min-width: 740px)',
-      sizes: '(max-width: 980px) 1734px, 2600px',
-    },
-    {
-      gridId: 'd1a7088f8f2a367b0321528f081777c9b5618412/0_0_3578_2013',
-      srcSizes: [2000, 1000, 500],
-      media: '(max-width: 740px)',
-      sizes: '100vw',
-    },
-  ],
-  fallback: 'bce7d14f7f837a4f6c854d95efc4b1eab93a8c65/0_0_5200_720/1000.jpg',
-  altText: 'Guardian supporters',
-};
 
 const copy = {
   top: [
@@ -51,9 +31,6 @@ export default function WhySupport() {
 
   return (
     <section className="why-support">
-      <div className="why-support__image">
-        <GridPicture {...heroImage} />
-      </div>
       <div className="why-support__content gu-content-margin">
         <div className="why-support__top-content">
           <div className="why-support__top-copy">

--- a/assets/pages/bundles-landing/components/WhySupport.jsx
+++ b/assets/pages/bundles-landing/components/WhySupport.jsx
@@ -34,13 +34,12 @@ const heroImage = {
 
 const copy = {
   top: [
-    'Like many other media organisations, the Guardian is operating in an incredibly challenging financial climate. Our advertising revenues are falling fast. We have huge numbers of readers, and we are increasingly reliant upon their financial support.',
-    'We don’t have a wealthy owner pulling the strings. No shareholders, advertisers or billionaire owners can edit our editor.',
+    'With no billionaire owner pulling our strings, nobody, be they shareholders or advertisers, can tell us to censor or drop a story.',
+    'Our quality investigative journalism takes a lot of time and money to produce. And while the Scott Trust safeguards our independence, its funds are limited.',
   ],
   bottom: [
-    'Our owner, the Scott Trust, safeguards our editorial independence from commercial or political interference. It reinvests revenue into our journalism, as opposed to into shareholders\' pockets.',
-    'But while the Scott Trust ensures our independence, we need our readers, now more than ever before, to help secure our future.',
-    'We know that not everyone is in a position to fund our journalism. But if you can, you’ll be an integral part of our mission to make the world a better, fairer place, for everyone.',
+    'With ad revenues falling across the media, we need our readers\' support to secure our future and help hold power to account.',
+    'Independent, progressive journalism benefits everyone. And if that\'s a view you share, join us today and help ensure our voice continues to be heard.',
   ],
   videoCaption: 'Katharine Viner, editor-in-chief, explains the Guardian\'s unique ownership model',
 };

--- a/assets/pages/bundles-landing/components/crossProduct.jsx
+++ b/assets/pages/bundles-landing/components/crossProduct.jsx
@@ -1,0 +1,26 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+
+// ----- Component ----- //
+
+export default function CrossProduct() {
+
+  return (
+    <div className="bundles__cross-product">
+      <h1 className="bundles__cross-product-header">
+        <span className="bundles__cross-product-heading">...and take a look</span>
+        <span className="bundles__cross-product-heading">behind the scenes</span>
+      </h1>
+      <p className="bundles__cross-product-copy">
+        Everyone who supports the Guardian can experience our journalism up
+        close with behind the scenes emails from our newsroom and the
+        opportunity to take part in our podcast for supporters.
+      </p>
+    </div>
+  );
+
+}


### PR DESCRIPTION
## Why are you doing this?

We want the copy to say slightly different things before we launch in the UK. This PR updates the bundles landing page to incorporate those changes.

[**Trello Card**](https://trello.com/c/U7WR2JsC/952-update-bundles-landing-page-language-structure)

cc: @patstirling @amohkhan @elvisr

## Changes

- Added a new `crossProduct` component for the new benefit.
- Tweaked the copy across:
  + Introduction text
  + Lists of bundle features (inc. for patrons and events)
  + Some of the CTAs
  + The why support paragraphs
- Added some copy to the contributions bundle.
- Dropped the hero image for the why support section.
- Changed some colours.

## Screenshots

**Desktop:**

![tweaked-desktop](https://user-images.githubusercontent.com/5131341/31348622-294985c2-ad18-11e7-8cfe-069578261110.png)

**Tablet:**

![tweaked-tablet](https://user-images.githubusercontent.com/5131341/31348632-32ea292e-ad18-11e7-9f51-c813b0a8ab77.png)

**Mobile:**

![tweaked-mobile](https://user-images.githubusercontent.com/5131341/31348641-38973222-ad18-11e7-99f0-d3a9dee4338c.png)
