### PR TITLE
Tweak Contributions Bundle Copy

### DIFF
--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -53,7 +53,6 @@ type PropTypes = {
 type ContribAttrs = {
   heading: string,
   subheading: string,
-  tagline: string,
   ctaText: string,
   modifierClass: string,
   ctaLink: string,
@@ -93,7 +92,6 @@ type BundlesType = {
 const contribCopy: ContribAttrs = {
   heading: 'contribute',
   subheading: 'from £5/month',
-  tagline: 'Your contribution directly funds our journalism',
   ctaText: 'Contribute with card or PayPal',
   modifierClass: 'contributions',
   ctaLink: '',
@@ -220,7 +218,9 @@ function ContributionBundle(props: PropTypes) {
 
   return (
     <Bundle {...contribAttrs}>
-      <p>{bundles.contrib.tagline}</p>
+      <p>
+        Your contribution funds and supports the&nbsp;Guardian&#39;s journalism
+      </p>
       <ContribAmounts
         onNumberInputKeyPress={onClick}
         {...props}


### PR DESCRIPTION
## Why are you doing this?

The new copy is more accurate.

## Changes

- Changed the contributions bundle copy.

## Screenshots

**Before:**

![contrib-before](https://user-images.githubusercontent.com/5131341/31443865-72bec8c2-ae92-11e7-84c4-4064fd179419.png)

**After:**

![contrib-after](https://user-images.githubusercontent.com/5131341/31443878-78bbccde-ae92-11e7-9c2f-9a45f188133c.png)
