### PR TITLE
Fixed Font On Contributions Error Message

### DIFF
--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -190,10 +190,12 @@
       }
 
       p {
-        font-size: 16px;
-        line-height: 20px;
-        margin-bottom: $gu-v-spacing;
-        font-family: $gu-text-egyptian-web;
+        &:first-child {
+          font-size: 16px;
+          line-height: 20px;
+          margin-bottom: $gu-v-spacing;
+          font-family: $gu-text-egyptian-web;
+        }
       }
     }
 


### PR DESCRIPTION
## Why are you doing this?

I accidentally broke it in #269, applying a CSS rule to the contributions bundle that affected the new tagline *and* the error message. This updates the CSS to only touch the tagline.

## Changes

- Applied CSS to only the tagline.

## Screenshots

**Before:**

![tagline-before](https://user-images.githubusercontent.com/5131341/31454076-2664804c-aeac-11e7-9770-d31b020dcbfa.png)

**After:**

![tagline-after](https://user-images.githubusercontent.com/5131341/31454083-2cd2a2ec-aeac-11e7-8a87-f624be090608.png)
