### PR TITLE
Acquisition tracking for one-off contributions with PayPal

### DIFF
--- a/assets/components/payPalContributionButton/payPalContributionButton.jsx
+++ b/assets/components/payPalContributionButton/payPalContributionButton.jsx
@@ -10,6 +10,8 @@ import {
 } from 'helpers/payPalContributionsCheckout/payPalContributionsCheckout';
 
 import type { IsoCountry } from 'helpers/internationalisation/country';
+import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
+import type { Participations } from 'helpers/abtest';
 
 
 // ---- Types ----- //
@@ -17,8 +19,8 @@ import type { IsoCountry } from 'helpers/internationalisation/country';
 /* eslint-disable react/no-unused-prop-types */
 type PropTypes = {
   amount: string,
-  intCmp?: ?string,
-  refpvid?: ?string,
+  referrerAcquisitionData: ReferrerAcquisitionData,
+  abParticipations: Participations,
   isoCountry: IsoCountry,
   errorHandler: (string) => void,
   canClick?: boolean,
@@ -34,10 +36,10 @@ function payWithPayPal(props: PropTypes) {
     if (props.canClick) {
       paypalContributionsRedirect(
         Number(props.amount),
-        props.intCmp,
-        props.refpvid,
+        props.referrerAcquisitionData,
         props.isoCountry,
-        props.errorHandler);
+        props.errorHandler,
+        props.abParticipations);
     }
   };
 }
@@ -63,8 +65,6 @@ const PayPalContributionButton = (props: PropTypes) =>
 // ----- Default Props ----- //
 
 PayPalContributionButton.defaultProps = {
-  intCmp: null,
-  refpvid: null,
   canClick: true,
   buttonText: 'Pay with PayPal',
 };

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -198,6 +198,7 @@ function mapStateToProps(state) {
     referrerAcquisitionData: state.common.referrerAcquisitionData,
     isoCountry: state.common.country,
     payPalError: state.page.payPalError,
+    abTests: state.common.abParticipations,
   };
 }
 

--- a/assets/pages/oneoff-contributions/components/oneoffContributionsPayment.jsx
+++ b/assets/pages/oneoff-contributions/components/oneoffContributionsPayment.jsx
@@ -11,6 +11,8 @@ import ErrorMessage from 'components/errorMessage/errorMessage';
 
 import type { Node } from 'react';
 import type { IsoCountry } from 'helpers/internationalisation/country';
+import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
+import type { Participations } from 'helpers/abtest';
 
 import { checkoutError } from '../oneoffContributionsActions';
 import postCheckout from '../helpers/ajax';
@@ -25,10 +27,10 @@ type PropTypes = {
   error: ?string,
   isFormEmpty: boolean,
   amount: string,
-  intCmp?: string,
-  refpvid?: string,
+  referrerAcquisitionData: ReferrerAcquisitionData,
   isoCountry: IsoCountry,
   checkoutError: (?string) => void,
+  abParticipations: Participations,
 };
 
 
@@ -79,10 +81,10 @@ function OneoffContributionsPayment(props: PropTypes) {
       />
       <PayPalContributionButton
         amount={props.amount}
-        intCmp={props.intCmp}
-        refpvid={props.refpvid}
+        referrerAcquisitionData={props.referrerAcquisitionData}
         isoCountry={props.isoCountry}
         errorHandler={props.checkoutError}
+        abParticipations={props.abParticipations}
       />
     </section>
   );
@@ -99,9 +101,9 @@ function mapStateToProps(state) {
     error: state.page.oneoffContrib.error,
     isFormEmpty: state.page.user.email === '' || state.page.user.fullName === '',
     amount: state.page.oneoffContrib.amount,
-    intCmp: state.common.intCmp,
-    refpvid: state.common.refpvid,
+    referrerAcquisitionData: state.common.referrerAcquisitionData,
     isoCountry: state.common.country,
+    abParticipations: state.common.abParticipations,
   };
 
 }
@@ -115,14 +117,6 @@ function mapDispatchToProps(dispatch) {
   };
 
 }
-
-
-// ----- Default Props ----- //
-
-OneoffContributionsPayment.defaultProps = {
-  intCmp: null,
-  refpvid: null,
-};
 
 
 // ----- Exports ----- //

--- a/assets/pages/oneoff-contributions/helpers/ajax.js
+++ b/assets/pages/oneoff-contributions/helpers/ajax.js
@@ -2,10 +2,9 @@
 
 // ----- Imports ----- //
 
-import { getOphanIds } from 'helpers/tracking/acquisitions';
 import { addQueryParamToURL } from 'helpers/url';
 import { routes } from 'helpers/routes';
-import { participationsToAcquisitionABTest } from 'helpers/tracking/acquisitions';
+import { participationsToAcquisitionABTest, getOphanIds } from 'helpers/tracking/acquisitions';
 
 import type { OphanIds, AcquisitionABTest } from 'helpers/tracking/acquisitions';
 


### PR DESCRIPTION
## Why are you doing this?

To correctly track, using the acquisition/contributions backend, the one-off contributions with PayPal.

The scala class in Contributions:
```
case class AuthRequest private (
  countryGroup: CountryGroup,
  amount: BigDecimal,
  cmp: Option[String],
  intCmp: Option[String],
  refererPageviewId: Option[String],
  refererUrl: Option[String],
  ophanPageviewId: Option[String],
  ophanBrowserId: Option[String],
  ophanVisitId: Option[String],
  supportRedirect: Option[Boolean],
  componentId: Option[String],
  componentType: Option[ComponentType],
  source: Option[AcquisitionSource],
  abTest: Option[AbTest], // Deprecated,
  refererAbTest: Option[AbTest],
  nativeAbTests: Option[Set[AbTest]]
)
```

[**Trello Card**](https://trello.com/c/59xhYpwY/960-adding-acquisition-tracking-for-one-off-with-paypal)

## Screenshots
### Bundle Landing Page flow
#### auth request payload
<img width="559" alt="picture 417" src="https://user-images.githubusercontent.com/825398/31543506-4a731b02-b00e-11e7-88be-de368388d027.png">


### PayPal Button from Contribution Landing Page
#### auth request payload
<img width="568" alt="picture 418" src="https://user-images.githubusercontent.com/825398/31543697-49bc31fc-b00f-11e7-870f-92b887ca330f.png">


### PayPal Button from checkout page after contributions landing page
#### auth request payload
<img width="570" alt="picture 420" src="https://user-images.githubusercontent.com/825398/31543869-1a37ae7e-b010-11e7-8774-6ddf648e71f1.png">

