### PR TITLE
New font-family for the contribute bundle

### DIFF
--- a/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/assets/pages/contributions-landing/contributionsLanding.scss
@@ -242,6 +242,11 @@
 
 	.contributions-bundle__content {
 		background-color: gu-colour(multimedia-main-2);
+
+        p {
+          font-family: $gu-text-egyptian-web;
+        }
+
 		padding: 0;
 
 		@include mq($from: mobileLandscape) {


### PR DESCRIPTION
## Why are you doing this?

To make the style consistent with the bundle landing page.

## Screenshots

| Before | After |
|--------|-------|
| <img width="329" alt="picture 424" src="https://user-images.githubusercontent.com/825398/31710427-e91d8d0a-b3ec-11e7-8bb3-9758da28fe4b.png"> | <img width="324" alt="picture 423" src="https://user-images.githubusercontent.com/825398/31710405-d3926c44-b3ec-11e7-8511-c9ddd7d84ba0.png"> |