### PR TITLE
Add "independence" option for ab tests

### DIFF
--- a/assets/helpers/__tests__/abtestTest.js
+++ b/assets/helpers/__tests__/abtestTest.js
@@ -61,6 +61,31 @@ describe('basic behaviour of init', () => {
     expect(participations).toEqual(expectedParticipations);
   });
 
+  it('The user should be allocated in the variant bucket', () => {
+
+    document.cookie = 'GU_mvt_id=12346';
+
+    const tests = [
+      {
+        testId: 'mockTest',
+        independence: 1,
+        variants: ['control', 'variant'],
+        audiences: {
+          GB: {
+            offset: 0,
+            size: 1,
+          },
+        },
+        isActive: true,
+      }];
+
+    const country = 'GB';
+    const participations: Participations = abInit(country, tests);
+    const expectedParticipations: Participations = { mockTest: 'variant' };
+
+    expect(participations).toEqual(expectedParticipations);
+  });
+
   it('The user should not be allocated in a test for a different country', () => {
 
     document.cookie = 'GU_mvt_id=12346';

--- a/assets/helpers/abtest.js
+++ b/assets/helpers/abtest.js
@@ -2,6 +2,8 @@
 
 // ----- Imports ----- //
 
+import shajs from 'sha.js';
+
 import type { IsoCountry } from 'helpers/internationalisation/country';
 
 import * as ophan from 'ophan';
@@ -35,6 +37,7 @@ type Test = {
   variants: string[],
   audiences: Audiences,
   isActive: boolean,
+  independence?: number,
 };
 
 
@@ -125,8 +128,18 @@ function userInTest(audiences: Audiences, mvtId: number, country: IsoCountry) {
   return (mvtId > testMin) && (mvtId < testMax);
 }
 
+function randomNumber(seed: number, rounds: number): number {
+  if (rounds === 0) {
+    return seed;
+  }
+
+  return Math.abs(shajs('sha256').update(String(seed + rounds)).digest().readInt32BE(0));
+}
+
 function assignUserToVariant(mvtId: number, test: Test): string {
-  const variantIndex = mvtId % test.variants.length;
+  const independence = test.independence || 0;
+
+  const variantIndex = randomNumber(mvtId, independence) % test.variants.length;
 
   return test.variants[variantIndex];
 }

--- a/assets/helpers/abtest.js
+++ b/assets/helpers/abtest.js
@@ -128,12 +128,12 @@ function userInTest(audiences: Audiences, mvtId: number, country: IsoCountry) {
   return (mvtId > testMin) && (mvtId < testMax);
 }
 
-function randomNumber(seed: number, rounds: number): number {
-  if (rounds === 0) {
+function randomNumber(seed: number, independence: number): number {
+  if (independence === 0) {
     return seed;
   }
 
-  return Math.abs(shajs('sha256').update(String(seed + rounds)).digest().readInt32BE(0));
+  return Math.abs(shajs('sha256').update(String(seed + independence)).digest().readInt32BE(0));
 }
 
 function assignUserToVariant(mvtId: number, test: Test): string {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "react-redux": "^5.0.5",
     "redux": "^3.7.1",
     "redux-thunk": "^2.2.0",
+    "sha.js": "^2.4.9",
     "uuid": "^3.1.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5304,6 +5304,13 @@ sha.js@^2.4.0, sha.js@^2.4.8:
   dependencies:
     inherits "^2.0.1"
 
+sha.js@^2.4.9:
+  version "2.4.9"
+  resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.9.tgz#98f64880474b74f4a38b8da9d3c0f2d104633e7d"
+  dependencies:
+    inherits "^2.0.1"
+    safe-buffer "^5.0.1"
+
 shallow-clone@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/shallow-clone/-/shallow-clone-0.1.2.tgz#5909e874ba77106d73ac414cfec1ffca87d97060"


### PR DESCRIPTION
## Why are you doing this?

This allows the randomness of test allocation between tests to be independent of each other which in theory should all us to run multiple a/b tests on the same audience segment