### PR TITLE
Pass incoming query params on to Subscriptions

### DIFF
--- a/assets/helpers/page/page.js
+++ b/assets/helpers/page/page.js
@@ -24,7 +24,7 @@ import type { Action } from './pageActions';
 export type CommonState = {
   campaign: ?Campaign,
   referrerAcquisitionData: ReferrerAcquisitionData,
-  otherQueryParams: [string, string][],
+  otherQueryParams: Array<string, string>,
   country: IsoCountry,
   abParticipations: Participations,
 };

--- a/assets/helpers/page/page.js
+++ b/assets/helpers/page/page.js
@@ -14,6 +14,7 @@ import { detect } from 'helpers/internationalisation/country';
 import type { Campaign, ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { Participations } from 'helpers/abtest';
+import { getQueryParams } from 'helpers/url';
 
 import type { Action } from './pageActions';
 
@@ -23,6 +24,7 @@ import type { Action } from './pageActions';
 export type CommonState = {
   campaign: ?Campaign,
   referrerAcquisitionData: ReferrerAcquisitionData,
+  otherQueryParams: [string, string][],
   country: IsoCountry,
   abParticipations: Participations,
 };
@@ -58,10 +60,12 @@ function buildInitialState(
 ): CommonState {
 
   const acquisition = getAcquisition();
+  const otherQueryParams = getQueryParams(['REFPVID', 'INTCMP']);
 
   return Object.assign({}, {
     campaign: acquisition ? getCampaign(acquisition) : null,
     referrerAcquisitionData: acquisition,
+    otherQueryParams,
     country,
     abParticipations,
   }, preloadedState);

--- a/assets/helpers/page/page.js
+++ b/assets/helpers/page/page.js
@@ -24,7 +24,7 @@ import type { Action } from './pageActions';
 export type CommonState = {
   campaign: ?Campaign,
   referrerAcquisitionData: ReferrerAcquisitionData,
-  otherQueryParams: Array<string, string>,
+  otherQueryParams: Array<[string, string]>,
   country: IsoCountry,
   abParticipations: Participations,
 };

--- a/assets/helpers/page/page.js
+++ b/assets/helpers/page/page.js
@@ -23,7 +23,6 @@ import type { Action } from './pageActions';
 export type CommonState = {
   campaign: ?Campaign,
   referrerAcquisitionData: ReferrerAcquisitionData,
-
   country: IsoCountry,
   abParticipations: Participations,
 };

--- a/assets/helpers/tracking/acquisitions.js
+++ b/assets/helpers/tracking/acquisitions.js
@@ -5,7 +5,7 @@
 
 import * as ophan from 'ophan';
 import { get as getCookie } from 'helpers/cookie';
-import { getQueryParameter, getQueryParams } from 'helpers/url';
+import { getQueryParameter } from 'helpers/url';
 import { deserialiseJsonObject } from 'helpers/utilities';
 import type { Participations } from 'helpers/abtest';
 import * as storage from 'helpers/storage';
@@ -27,7 +27,6 @@ export type OphanIds = {|
 export type ReferrerAcquisitionData = {|
   campaignCode: ?string,
   referrerPageviewId: ?string,
-  otherQueryParams: [string, string][],
   referrerUrl: ?string,
   componentId: ?string,
   componentType: ?string,
@@ -115,13 +114,9 @@ function buildAcquisition(acquisitionData: Object = {}): ReferrerAcquisitionData
     getQueryParameter('INTCMP') ||
     null;
 
-  const otherQueryParams = acquisitionData.otherQueryParams ||
-    getQueryParams(['REFPVID', 'INTCMP']);
-
   return {
     referrerPageviewId,
     campaignCode,
-    otherQueryParams,
     referrerUrl: acquisitionData.referrerUrl || null,
     componentId: acquisitionData.componentId || null,
     componentType: acquisitionData.componentType || null,

--- a/assets/helpers/tracking/acquisitions.js
+++ b/assets/helpers/tracking/acquisitions.js
@@ -5,7 +5,7 @@
 
 import * as ophan from 'ophan';
 import { get as getCookie } from 'helpers/cookie';
-import { getQueryParameter } from 'helpers/url';
+import { getQueryParameter, getQueryParams } from 'helpers/url';
 import { deserialiseJsonObject } from 'helpers/utilities';
 import type { Participations } from 'helpers/abtest';
 import * as storage from 'helpers/storage';
@@ -27,6 +27,7 @@ export type OphanIds = {|
 export type ReferrerAcquisitionData = {|
   campaignCode: ?string,
   referrerPageviewId: ?string,
+  otherQueryParams: [string, string][],
   referrerUrl: ?string,
   componentId: ?string,
   componentType: ?string,
@@ -114,9 +115,13 @@ function buildAcquisition(acquisitionData: Object = {}): ReferrerAcquisitionData
     getQueryParameter('INTCMP') ||
     null;
 
+  const otherQueryParams = acquisitionData.otherQueryParams ||
+    getQueryParams(['REFPVID', 'INTCMP']);
+
   return {
     referrerPageviewId,
     campaignCode,
+    otherQueryParams,
     referrerUrl: acquisitionData.referrerUrl || null,
     componentId: acquisitionData.componentId || null,
     componentType: acquisitionData.componentType || null,

--- a/assets/helpers/url.js
+++ b/assets/helpers/url.js
@@ -36,7 +36,7 @@ const getQueryParameter = (paramName: string, defaultValue?: string): ?string =>
 };
 
 const getQueryParams = (excluded: string[]): [string, string][] => Array
-  .from(new URLSearchParams(window.location.search))
+  .from(new URLSearchParams(window.location.search).entries())
   .filter(p => excluded.indexOf(p[0]) === -1);
 
 const addQueryParamToURL = (urlOrPath: string, paramsKey: string, paramsValue: ?string): string => {

--- a/assets/helpers/url.js
+++ b/assets/helpers/url.js
@@ -35,6 +35,10 @@ const getQueryParameter = (paramName: string, defaultValue?: string): ?string =>
 
 };
 
+const getQueryParams = (excluded: string[]): [string, string][] => Array
+  .from(new URLSearchParams(window.location.search))
+  .filter(p => excluded.indexOf(p[0]) === -1);
+
 const addQueryParamToURL = (urlOrPath: string, paramsKey: string, paramsValue: ?string): string => {
 
   // We are interested in the query params i.e. the part after the '?'
@@ -76,6 +80,7 @@ function getBaseDomain(): Domain {
 
 export {
   getQueryParameter,
+  getQueryParams,
   addQueryParamToURL,
   getBaseDomain,
 };

--- a/assets/helpers/url.js
+++ b/assets/helpers/url.js
@@ -35,7 +35,7 @@ const getQueryParameter = (paramName: string, defaultValue?: string): ?string =>
 
 };
 
-const getQueryParams = (excluded: string[]): [string, string][] => Array
+const getQueryParams = (excluded: string[]): Array<string, string> => Array
   .from(new URLSearchParams(window.location.search).entries())
   .filter(p => excluded.indexOf(p[0]) === -1);
 

--- a/assets/helpers/url.js
+++ b/assets/helpers/url.js
@@ -35,7 +35,7 @@ const getQueryParameter = (paramName: string, defaultValue?: string): ?string =>
 
 };
 
-const getQueryParams = (excluded: string[]): Array<string, string> => Array
+const getQueryParams = (excluded: string[]): Array<[string, string]> => Array
   .from(new URLSearchParams(window.location.search).entries())
   .filter(p => excluded.indexOf(p[0]) === -1);
 

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -12,7 +12,7 @@ import Bundle from 'components/bundle/bundle';
 import ContribAmounts from 'components/contribAmounts/contribAmounts';
 import type { Contrib, Amounts, ContribError } from 'helpers/contributions';
 import type { IsoCountry } from 'helpers/internationalisation/country';
-import type { Campaign, ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
+import type { Campaign } from 'helpers/tracking/acquisitions';
 import { routes } from 'helpers/routes';
 
 import CrossProduct from './crossProduct';
@@ -283,7 +283,7 @@ function Bundles(props: PropTypes) {
 
 // ----- Map State/Props ----- //
 
-function mapStateToProps(state): ReferrerAcquisitionData {
+function mapStateToProps(state) {
   return {
     contribType: state.page.type,
     contribAmount: state.page.amount,

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -41,7 +41,7 @@ type PropTypes = {
   contribError: ContribError,
   intCmp: ?string,
   campaign: ?Campaign,
-  otherQueryParams: Array<string, string>,
+  otherQueryParams: Array<[string, string]>,
   toggleContribType: (string) => void,
   changeContribAnnualAmount: (string) => void,
   changeContribMonthlyAmount: (string) => void,

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -12,7 +12,7 @@ import Bundle from 'components/bundle/bundle';
 import ContribAmounts from 'components/contribAmounts/contribAmounts';
 import type { Contrib, Amounts, ContribError } from 'helpers/contributions';
 import type { IsoCountry } from 'helpers/internationalisation/country';
-import type { Campaign } from 'helpers/tracking/acquisitions';
+import type { Campaign, ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import { routes } from 'helpers/routes';
 
 import CrossProduct from './crossProduct';
@@ -41,6 +41,7 @@ type PropTypes = {
   contribError: ContribError,
   intCmp: ?string,
   campaign: ?Campaign,
+  otherQueryParams: [string, string][],
   toggleContribType: (string) => void,
   changeContribAnnualAmount: (string) => void,
   changeContribMonthlyAmount: (string) => void,
@@ -259,7 +260,7 @@ function PaperBundle(props: PaperAttrs) {
 
 function Bundles(props: PropTypes) {
 
-  const subsLinks: SubsUrls = getSubsLinks(props.intCmp, props.campaign);
+  const subsLinks: SubsUrls = getSubsLinks(props.intCmp, props.campaign, props.otherQueryParams);
   const paperAttrs: PaperAttrs = getPaperAttrs(subsLinks);
   const digitalAttrs: DigitalAttrs = getDigitalAttrs(subsLinks);
 
@@ -282,13 +283,14 @@ function Bundles(props: PropTypes) {
 
 // ----- Map State/Props ----- //
 
-function mapStateToProps(state) {
+function mapStateToProps(state): ReferrerAcquisitionData {
   return {
     contribType: state.page.type,
     contribAmount: state.page.amount,
     contribError: state.page.error,
     intCmp: state.common.referrerAcquisitionData.campaignCode,
     campaign: state.common.campaign,
+    otherQueryParams: state.common.referrerAcquisitionData.otherQueryParams,
     isoCountry: state.common.country,
     abTests: state.common.abParticipations,
   };

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -290,7 +290,7 @@ function mapStateToProps(state) {
     contribError: state.page.error,
     intCmp: state.common.referrerAcquisitionData.campaignCode,
     campaign: state.common.campaign,
-    otherQueryParams: state.common.referrerAcquisitionData.otherQueryParams,
+    otherQueryParams: state.common.otherQueryParams,
     isoCountry: state.common.country,
     abTests: state.common.abParticipations,
   };

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -41,7 +41,7 @@ type PropTypes = {
   contribError: ContribError,
   intCmp: ?string,
   campaign: ?Campaign,
-  otherQueryParams: [string, string][],
+  otherQueryParams: Array<string, string>,
   toggleContribType: (string) => void,
   changeContribAnnualAmount: (string) => void,
   changeContribMonthlyAmount: (string) => void,

--- a/assets/pages/bundles-landing/helpers/externalLinks.js
+++ b/assets/pages/bundles-landing/helpers/externalLinks.js
@@ -61,10 +61,12 @@ function getMemLink(product: MemProduct, intCmp: ?string): string {
 }
 
 // Creates URLs for the subs site from promo codes and intCmp.
-function buildSubsUrls(promoCodes: PromoCodes, intCmp: ?string): SubsUrls {
+function buildSubsUrls(promoCodes: PromoCodes, intCmp: ?string,
+  otherQueryParams: [string, string][]): SubsUrls {
 
   const params = new URLSearchParams();
   params.append('INTCMP', intCmp || defaultIntCmp);
+  otherQueryParams.forEach(p => params.append(p[0], p[1]));
 
   return {
     digital: `${subsUrl}/${promoCodes.digital}?${params.toString()}`,
@@ -75,13 +77,14 @@ function buildSubsUrls(promoCodes: PromoCodes, intCmp: ?string): SubsUrls {
 }
 
 // Creates links to subscriptions, tailored to the user's campaign.
-function getSubsLinks(intCmp: ?string, campaign: ?Campaign): SubsUrls {
+function getSubsLinks(intCmp: ?string, campaign: ?Campaign,
+  otherQueryParams: [string, string][]): SubsUrls {
 
   if (campaign && customPromos[campaign]) {
-    return buildSubsUrls(customPromos[campaign], intCmp);
+    return buildSubsUrls(customPromos[campaign], intCmp, otherQueryParams);
   }
 
-  return buildSubsUrls(defaultPromos, intCmp);
+  return buildSubsUrls(defaultPromos, intCmp, otherQueryParams);
 
 }
 

--- a/assets/pages/bundles-landing/helpers/externalLinks.js
+++ b/assets/pages/bundles-landing/helpers/externalLinks.js
@@ -62,7 +62,7 @@ function getMemLink(product: MemProduct, intCmp: ?string): string {
 
 // Creates URLs for the subs site from promo codes and intCmp.
 function buildSubsUrls(promoCodes: PromoCodes, intCmp: ?string,
-  otherQueryParams: Array<string, string>): SubsUrls {
+  otherQueryParams: Array<[string, string]>): SubsUrls {
 
   const params = new URLSearchParams();
   params.append('INTCMP', intCmp || defaultIntCmp);
@@ -78,7 +78,7 @@ function buildSubsUrls(promoCodes: PromoCodes, intCmp: ?string,
 
 // Creates links to subscriptions, tailored to the user's campaign.
 function getSubsLinks(intCmp: ?string, campaign: ?Campaign,
-  otherQueryParams: Array<string, string>): SubsUrls {
+  otherQueryParams: Array<[string, string]>): SubsUrls {
 
   if (campaign && customPromos[campaign]) {
     return buildSubsUrls(customPromos[campaign], intCmp, otherQueryParams);

--- a/assets/pages/bundles-landing/helpers/externalLinks.js
+++ b/assets/pages/bundles-landing/helpers/externalLinks.js
@@ -62,7 +62,7 @@ function getMemLink(product: MemProduct, intCmp: ?string): string {
 
 // Creates URLs for the subs site from promo codes and intCmp.
 function buildSubsUrls(promoCodes: PromoCodes, intCmp: ?string,
-  otherQueryParams: [string, string][]): SubsUrls {
+  otherQueryParams: Array<string, string>): SubsUrls {
 
   const params = new URLSearchParams();
   params.append('INTCMP', intCmp || defaultIntCmp);
@@ -78,7 +78,7 @@ function buildSubsUrls(promoCodes: PromoCodes, intCmp: ?string,
 
 // Creates links to subscriptions, tailored to the user's campaign.
 function getSubsLinks(intCmp: ?string, campaign: ?Campaign,
-  otherQueryParams: [string, string][]): SubsUrls {
+  otherQueryParams: Array<string, string>): SubsUrls {
 
   if (campaign && customPromos[campaign]) {
     return buildSubsUrls(customPromos[campaign], intCmp, otherQueryParams);

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-kms" % "1.11.128",
   "com.amazonaws" % "aws-java-sdk-stepfunctions" % "1.11.128",
   "org.typelevel" %% "cats" % "0.9.0",
-  "play-circe" %% "play-circe" % "2.6-0.8.0",
+  "com.dripower" %% "play-circe" % "2608.5",
   "com.gu" %% "support-models" % "0.15",
   "com.gu" %% "support-config" % "0.7",
   "com.gu" %% "fezziwig" % "0.6",


### PR DESCRIPTION
## Why are you doing this?
There are number of query params which are passed into the site by off platform marketing channels which allow us to measure their effectiveness, currently we are not passing these through to subscriptions if the user chooses that option.

This PR retains any incoming query params in the ReferrerAcquisitionData object and passes them on to subscriptions.
 
[**Trello Card**](https://trello.com/c/GQW0IYsC/1004-implement-off-platform-tracking-codes)
Before (the subs destination url does not include the incoming query params):
<img width="1088" alt="screen shot 2017-10-18 at 16 34 16" src="https://user-images.githubusercontent.com/181371/31727738-472630a2-b422-11e7-9ddd-45477ca82457.png">
After (the subs destination url includes the incoming query params):
<img width="1119" alt="screen shot 2017-10-18 at 16 33 39" src="https://user-images.githubusercontent.com/181371/31727743-47b355b8-b422-11e7-9d89-d380b181179b.png">
