### PR TITLE
Removing US contribute from robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,6 +2,5 @@ User-agent: *
 
 Disallow: /uk/contribute
 Disallow: /contribute
-Disallow: /us/contribute
 
 Allow: /


### PR DESCRIPTION
## Why are you doing this?

To allow the search engine to find the US contribute page
