### PR TITLE
Adding extra timeout and recovering request.

### DIFF
--- a/app/controllers/RegularContributions.scala
+++ b/app/controllers/RegularContributions.scala
@@ -36,7 +36,7 @@ class RegularContributions(
 
   def displayForm(paypal: Option[Boolean]): Action[AnyContent] = AuthenticatedAction.async { implicit request =>
     identityService.getUser(request.user).semiflatMap { fullUser =>
-      isMonthlyContributor(request.user.credentials) map {
+      isMonthlyContributor(request.user.credentials).recoverWith(None) map {
         case Some(true) => Redirect("/contribute/recurring/existing")
         case Some(false) | None =>
           val uatMode = testUsers.isTestUser(fullUser.publicFields.displayName)

--- a/app/controllers/RegularContributions.scala
+++ b/app/controllers/RegularContributions.scala
@@ -36,7 +36,7 @@ class RegularContributions(
 
   def displayForm(paypal: Option[Boolean]): Action[AnyContent] = AuthenticatedAction.async { implicit request =>
     identityService.getUser(request.user).semiflatMap { fullUser =>
-      isMonthlyContributor(request.user.credentials).recoverWith(None) map {
+      isMonthlyContributor(request.user.credentials).recover({ case _ => None }) map {
         case Some(true) => Redirect("/contribute/recurring/existing")
         case Some(false) | None =>
           val uatMode = testUsers.isTestUser(fullUser.publicFields.displayName)

--- a/app/services/MembersDataService.scala
+++ b/app/services/MembersDataService.scala
@@ -52,7 +52,7 @@ class MembersDataService(apiUrl: String)(implicit val ec: ExecutionContext, wsCl
     wsClient
       .url(url)
       .withHttpHeaders("Cookie" -> credentials.cookies.map(c => s"${c.name}=${c.value}").mkString("; "))
-      .withRequestTimeout(1.second)
+      .withRequestTimeout(2.second)
       .get()
       .map(responseAsJson[T])
       .recover {


### PR DESCRIPTION
## Why are you doing this?

Currently we have a timeout of 1 second. Since the Members Data API access Zuora this timeout is not enough. Therefore in this PR we are increasing the timeout to two seconds (enough for the 95% of the members data api requests) and we are also recovering in case of a timeout so we don't show an error to the end user.

## Sentry related issue:
https://sentry.io/the-guardian/support/issues/364543311/

## Changes

* Increase members data api timeout.
* Recover in case of failed request.

## Screenshots
N/a

