### PR TITLE
Webpack Tree Shaking

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,9 @@
 {
-  "presets": ["react", "es2015"],
+  "presets": ["react", ["es2015", {"modules": false}]],
   "plugins": ["babel-plugin-transform-exponentiation-operator"],
+  "env": {
+    "test": {
+      "presets": ["es2015"]
+    }
+  }
 }


### PR DESCRIPTION
## Why are you doing this?

Been meaning to do this for ages, but now there's a specific reason in #277. Previously babel was handling our ES6 `import`s and `export`s. Now webpack handles them. This allows us to take advantage of tree shaking, as first introduced by [rollup](https://rollupjs.org/#tree-shaking) and made available since [webpack 2](https://webpack.js.org/guides/tree-shaking/).

The main reason for doing this? Smaller bundle sizes:

Page                   | Size Before | Size After | Saving
-----------------------|-------------|------------|-------
Regular Contributions  | 140 kB      | 132 kB     | 8 kB
One-off Contributions  | 136 kB      | 128 kB     | 8 kB
Bundles Landing        | 139 kB      | 132 kB     | 7 kB
Contributions Landing  | 135 kB      | 128 kB     | 7 kB
Thank You Pages        | 102 kB      | 99 kB      | 3 kB

## Changes

- Updated babelrc to turn off ES6 module handling in babel.
- Created a test env to switch it back on for jest tests (for which we don't use webpack).
