### PR TITLE
Send off-platform campaign codes to GA

### DIFF
--- a/assets/helpers/page/page.js
+++ b/assets/helpers/page/page.js
@@ -14,7 +14,7 @@ import { detect } from 'helpers/internationalisation/country';
 import type { Campaign, ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { Participations } from 'helpers/abtest';
-import { getQueryParams } from 'helpers/url';
+import { getQueryParams, getQueryParameter } from 'helpers/url';
 
 import type { Action } from './pageActions';
 
@@ -44,6 +44,8 @@ function analyticsInitialisation(participations: Participations): void {
 
   // Google analytics.
   ga.init();
+  ga.setDimension('campaignCodeBusinessUnit', getQueryParameter('CMP_BUNIT'));
+  ga.setDimension('campaignCodeTeam', getQueryParameter('CMP_TU'));
   ga.setDimension('experience', abTest.getVariantsAsString(participations));
   ga.trackPageview();
 

--- a/assets/helpers/tracking/ga.js
+++ b/assets/helpers/tracking/ga.js
@@ -1,6 +1,6 @@
 const dimensions = {
-  campaignCodeBusinessUnit: 'dimension14',
-  campaignCodeTeam: 'dimension15',
+  campaignCodeBusinessUnit: 'dimension14', // helps us to filter marketing campaign reports by business unit
+  campaignCodeTeam: 'dimension15', // campaign team
   experience: 'dimension16',
 };
 

--- a/assets/helpers/tracking/ga.js
+++ b/assets/helpers/tracking/ga.js
@@ -1,4 +1,6 @@
 const dimensions = {
+  campaignCodeBusinessUnit: 'dimension14',
+  campaignCodeTeam: 'dimension15',
   experience: 'dimension16',
 };
 


### PR DESCRIPTION
## Why are you doing this?

There are two off-platform tracking params that we are currently not doing anything with. These need to be sent to GA in the same way that Membership and Subscriptions do.

[**Trello Card**](https://trello.com/c/GQW0IYsC/1004-implement-off-platform-tracking-codes)