### PR TITLE
Fix Contributions Landing Pricing Wrap And Jump

### DIFF
--- a/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/assets/pages/contributions-landing/contributionsLanding.scss
@@ -322,6 +322,11 @@
 
 	.component-double-heading__subheading {
 		padding-top: 4px;
+		height: 24px;
+
+		@include mq($from: phablet) {
+			height: 28px;
+		}
 	}
 
 	.component-radio-toggle input:not(:checked)+label, .component-number-input {

--- a/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/assets/pages/contributions-landing/contributionsLanding.scss
@@ -318,6 +318,10 @@
 	.component-double-heading__heading {
 		font-size: 24px;
 		line-height: 24px;
+
+		@include mq($from: desktop, $until: wide) {
+			padding-bottom: 1px;
+		}
 	}
 
 	.component-double-heading__subheading {


### PR DESCRIPTION
## Why are you doing this?

Couple of small CSS fixes here.

First, in Firefox, the 'from $5 a month' text wraps on the `desktop` and `leftCol` breakpoints, because the bundle is narrower and it seems to conflict with the payment logos. Adding a tiny bit of padding fixes this.

Second, switching between the two contribution types ('monthly' and 'one-off') causes the whole bundle to jump up and down, because the 'from $5 a month' text is dropped for one-off. Setting a fixed height for this element regardless of whether there's any text stops this from happening.

[**Trello Card**](https://trello.com/c/p3pg3MZz/1013-wrapping-on-contributions-landing-page)

## Changes

- Added a tiny bit of padding when the bundle is narrow, to prevent text wrapping.
- Set a fixed height on the bundle subheading, to stop the bundle jumping around.

## Screenshots

**Before:**

![before-wrap](https://user-images.githubusercontent.com/5131341/31780274-2d9479ac-b4ed-11e7-8b42-4d27e177df2c.png)
![before-jump](https://user-images.githubusercontent.com/5131341/31780273-2d7b57ec-b4ed-11e7-8238-4c4debcb822e.png)

**After:**

![after-wrap](https://user-images.githubusercontent.com/5131341/31780292-334f25ea-b4ed-11e7-8515-75bab5390ea0.png)
![after-jump](https://user-images.githubusercontent.com/5131341/31780290-33392a56-b4ed-11e7-809a-709e07c1773c.png)
