### PR TITLE
Polyfill window.location.origin

### DIFF
--- a/assets/helpers/url.js
+++ b/assets/helpers/url.js
@@ -62,7 +62,9 @@ const addQueryParamToURL = (urlOrPath: string, paramsKey: string, paramsValue: ?
 // Retrieves the domain for the given env, e.g. guardian.com/gulocal.com.
 function getBaseDomain(): Domain {
 
-  const { origin } = window.location;
+  const loc = window.location;
+  const origin = window.location.origin ||
+    `${loc.protocol}'//'${loc.hostname}${loc.port ? `:${loc.port}` : ''}`;
 
   if (origin.includes(DOMAINS.DEV)) {
     return DOMAINS.DEV;

--- a/assets/helpers/url.js
+++ b/assets/helpers/url.js
@@ -64,7 +64,7 @@ function getBaseDomain(): Domain {
 
   const loc = window.location;
   const origin = window.location.origin ||
-    `${loc.protocol}'//'${loc.hostname}${loc.port ? `:${loc.port}` : ''}`;
+    `${loc.protocol}//${loc.hostname}${loc.port ? `:${loc.port}` : ''}`;
 
   if (origin.includes(DOMAINS.DEV)) {
     return DOMAINS.DEV;


### PR DESCRIPTION
## Why are you doing this?

There is a very specific version of IE11 on Windows 10 that doesn't support `window.location.origin` natively, and which isn't handled by polyfill.io. It's a [bug](https://connect.microsoft.com/IE/feedback/details/1763802/location-origin-is-undefined-in-ie-11-on-windows-10-but-works-on-windows-7) that was fixed in later versions.

This adds a polyfill for our usage, scope to a single function, so it should only get included when used (thanks tree-shaking) and shouldn't bloat every bundle.

This likely affects a tiny fraction of users, but I can't see a straightforward way of testing that it solves the problem, as getting access to a specific very old version of IE11 is tricky. Question is, is it worth merging this at all?

## Changes

- Added inline polyfill for `window.location.origin`.
