### PR TITLE
Update selenium-test libraries and allow for use of latest ChromeDriver

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -61,8 +61,8 @@ libraryDependencies ++= Seq(
   "com.google.guava" % "guava" % "22.0",
   "com.netaporter" %% "scala-uri" % "0.4.16",
   "com.gu" %% "play-googleauth" % "0.7.0",
-  "io.github.bonigarcia" % "webdrivermanager" % "1.4.10" % "test",
-  "org.seleniumhq.selenium" % "selenium-java" % "3.0.1" % "test",
+  "io.github.bonigarcia" % "webdrivermanager" % "1.7.2" % "test",
+  "org.seleniumhq.selenium" % "selenium-java" % "3.6.0" % "test",
   "com.squareup.okhttp3" % "okhttp" % "3.8.1",
   filters,
   ws

--- a/test/selenium/util/Driver.scala
+++ b/test/selenium/util/Driver.scala
@@ -30,7 +30,6 @@ object Driver {
     val caps = DesiredCapabilities.chrome()
     caps.setCapability("platform", "Windows 8.1")
     caps.setCapability("name", "support-frontend")
-    caps.setCapability("version", "60")
     new RemoteWebDriver(new URL(Config.webDriverRemoteUrl), caps)
   }
 


### PR DESCRIPTION
## Why are you doing this?

The post-deployment tests are unstable, so I'm updating the relevant libraries and removing a line which hardcodes an older version of Chrome in the PROD config.

Note that I'm not sure exactly how much impact this will have, but it seems like a sensible place to start.

I've confirmed that these changes work with our SauceLabs config.

[**Trello Card**](https://trello.com/c/hMA6lSdY/927-sort-out-selenium-test-flakiness)

## Changes

* Update Selenium library
* Update WebDriver library
* Undo hardcoding of Chrome version - see https://github.com/guardian/support-frontend/pull/225

## Screenshots

Surely my luck is going to run out:
![image](https://user-images.githubusercontent.com/19384074/31829631-cc51c2a2-b5b5-11e7-8cf7-e9042e34cc69.png)

