### PR TITLE
Adding a sitemap to improve SEO

### DIFF
--- a/app/controllers/SiteMap.scala
+++ b/app/controllers/SiteMap.scala
@@ -16,16 +16,6 @@ class SiteMap(
     val sitemapResponse = <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
                             { supportLandingPages }
                             { contributeLandingPages }
-                            <url>
-                              <loc>{
-                                routes.Application.reactTemplate(
-                                  title = "Support the Guardian",
-                                  id = "bundles-landing-page",
-                                  js = "bundlesLandingPage.js"
-                                ).absoluteURL(secure = true)
-                              }</loc>
-                              <priority>0.8</priority>
-                            </url>
                           </urlset>
 
     Ok(sitemapResponse)
@@ -59,8 +49,9 @@ class SiteMap(
 
   private def contributeLandingPages()(implicit req: RequestHeader) = {
     <url>
-      <loc>{ routes.Application.contributionsLanding(id = "contributions-landing-page-us", js = "contributionsLandingPageUS.js").absoluteURL(secure = true)
-        }</loc>
+      <loc>{
+        routes.Application.contributionsLanding(id = "contributions-landing-page-us", js = "contributionsLandingPageUS.js").absoluteURL(secure = true)
+      }</loc>
       <xhtml:link rel="alternate" hreflang="en-us" href={
         routes.Application.contributionsLanding(
           id = "contributions-landing-page-us",

--- a/app/controllers/SiteMap.scala
+++ b/app/controllers/SiteMap.scala
@@ -17,11 +17,13 @@ class SiteMap(
                             { supportLandingPages }
                             { contributeLandingPages }
                             <url>
-                              <loc>{ routes.Application.reactTemplate(
-                                title = "Support the Guardian",
-                                id = "bundles-landing-page",
-                                js = "bundlesLandingPage.js"
-                              ).absoluteURL(secure = true) }</loc>
+                              <loc>{
+                                routes.Application.reactTemplate(
+                                  title = "Support the Guardian",
+                                  id = "bundles-landing-page",
+                                  js = "bundlesLandingPage.js"
+                                ).absoluteURL(secure = true)
+                              }</loc>
                               <priority>0.8</priority>
                             </url>
                           </urlset>
@@ -57,9 +59,8 @@ class SiteMap(
 
   private def contributeLandingPages()(implicit req: RequestHeader) = {
     <url>
-      <loc>
-        { routes.Application.contributionsLanding(id = "contributions-landing-page-us", js = "contributionsLandingPageUS.js").absoluteURL(secure = true) }
-      </loc>
+      <loc>{ routes.Application.contributionsLanding(id = "contributions-landing-page-us", js = "contributionsLandingPageUS.js").absoluteURL(secure = true)
+        }</loc>
       <xhtml:link rel="alternate" hreflang="en-us" href={
         routes.Application.contributionsLanding(
           id = "contributions-landing-page-us",

--- a/app/controllers/SiteMap.scala
+++ b/app/controllers/SiteMap.scala
@@ -1,0 +1,46 @@
+package controllers
+
+import actions.CustomActionBuilders
+import play.api.mvc._
+
+import scala.concurrent.ExecutionContext
+
+class SiteMap(
+    actionRefiners: CustomActionBuilders,
+    components: ControllerComponents
+)(implicit val ec: ExecutionContext) extends AbstractController(components) {
+
+  import actionRefiners._
+
+  def sitemap: Action[AnyContent] = CachedAction() { implicit request =>
+    val sitemapResponse = <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+                { supportLandingPages }
+                { contributeLandingPages }
+                <url>
+                  <loc>{ routes.Application.indexRedirect.absoluteURL(secure = true) }</loc>
+                  <priority>0.8</priority>
+                </url>
+              </urlset>
+
+    Ok(sitemapResponse)
+  }
+
+  private def supportLandingPages()(implicit req: RequestHeader) = {
+    <url>
+      <loc>
+        { routes.Application.reactTemplate(title = "Support the Guardian", id = "bundles-landing-page", js = "bundlesLandingPage.js").absoluteURL(secure = true) }
+      </loc>
+      <priority>1.0</priority>
+    </url>
+  }
+
+  private def contributeLandingPages()(implicit req: RequestHeader) = {
+    <url>
+      <loc>
+        { routes.Application.contributionsLanding(id = "contributions-landing-page-us", js = "contributionsLandingPageUS.js").absoluteURL(secure = true) }
+      </loc>
+      <priority>1.0</priority>
+    </url>
+  }
+
+}

--- a/app/controllers/SiteMap.scala
+++ b/app/controllers/SiteMap.scala
@@ -27,12 +27,26 @@ class SiteMap(
 
   private def supportLandingPages()(implicit req: RequestHeader) = {
     <url>
-      <loc>
-        { routes.Application.reactTemplate(
-            title = "Support the Guardian",
-            id = "bundles-landing-page",
-            js = "bundlesLandingPage.js").absoluteURL(secure = true) }
-      </loc>
+      <loc>{
+        routes.Application.reactTemplate(
+          title = "Support the Guardian",
+          id = "bundles-landing-page",
+          js = "bundlesLandingPage.js"
+        ).absoluteURL(secure = true)
+      }</loc>
+      <xhtml:link rel="alternate" hreflang="en-us" href={
+        routes.Application.contributionsLanding(
+          id = "contributions-landing-page-us",
+          js = "contributionsLandingPageUS.js"
+        ).absoluteURL(secure = true)
+      }/>
+      <xhtml:link rel="alternate" hreflang="en" href={
+        routes.Application.reactTemplate(
+          title = "Support the Guardian",
+          id = "bundles-landing-page",
+          js = "bundlesLandingPage.js"
+        ).absoluteURL(secure = true)
+      }/>
       <priority>1.0</priority>
     </url>
   }
@@ -42,6 +56,19 @@ class SiteMap(
       <loc>
         { routes.Application.contributionsLanding(id = "contributions-landing-page-us", js = "contributionsLandingPageUS.js").absoluteURL(secure = true) }
       </loc>
+      <xhtml:link rel="alternate" hreflang="en-us" href={
+        routes.Application.contributionsLanding(
+          id = "contributions-landing-page-us",
+          js = "contributionsLandingPageUS.js"
+        ).absoluteURL(secure = true)
+      }/>
+      <xhtml:link rel="alternate" hreflang="en" href={
+        routes.Application.reactTemplate(
+          title = "Support the Guardian",
+          id = "bundles-landing-page",
+          js = "bundlesLandingPage.js"
+        ).absoluteURL(secure = true)
+      }/>
       <priority>1.0</priority>
     </url>
   }

--- a/app/controllers/SiteMap.scala
+++ b/app/controllers/SiteMap.scala
@@ -17,7 +17,11 @@ class SiteMap(
                             { supportLandingPages }
                             { contributeLandingPages }
                             <url>
-                              <loc>{ routes.Application.indexRedirect.absoluteURL(secure = true) }</loc>
+                              <loc>{ routes.Application.reactTemplate(
+                                title = "Support the Guardian",
+                                id = "bundles-landing-page",
+                                js = "bundlesLandingPage.js"
+                              ).absoluteURL(secure = true) }</loc>
                               <priority>0.8</priority>
                             </url>
                           </urlset>

--- a/app/controllers/SiteMap.scala
+++ b/app/controllers/SiteMap.scala
@@ -14,13 +14,13 @@ class SiteMap(
 
   def sitemap: Action[AnyContent] = CachedAction() { implicit request =>
     val sitemapResponse = <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
-                { supportLandingPages }
-                { contributeLandingPages }
-                <url>
-                  <loc>{ routes.Application.indexRedirect.absoluteURL(secure = true) }</loc>
-                  <priority>0.8</priority>
-                </url>
-              </urlset>
+                            { supportLandingPages }
+                            { contributeLandingPages }
+                            <url>
+                              <loc>{ routes.Application.indexRedirect.absoluteURL(secure = true) }</loc>
+                              <priority>0.8</priority>
+                            </url>
+                          </urlset>
 
     Ok(sitemapResponse)
   }
@@ -28,7 +28,10 @@ class SiteMap(
   private def supportLandingPages()(implicit req: RequestHeader) = {
     <url>
       <loc>
-        { routes.Application.reactTemplate(title = "Support the Guardian", id = "bundles-landing-page", js = "bundlesLandingPage.js").absoluteURL(secure = true) }
+        { routes.Application.reactTemplate(
+            title = "Support the Guardian",
+            id = "bundles-landing-page",
+            js = "bundlesLandingPage.js").absoluteURL(secure = true) }
       </loc>
       <priority>1.0</priority>
     </url>

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -35,10 +35,11 @@ trait AppComponents extends PlayComponents
   override lazy val router: Router = new _root_.router.Routes(
     httpErrorHandler,
     applicationController,
+    siteMapController,
     regularContributionsController,
     oneOffContributions,
     loginController,
-    testUsersContoller,
+    testUsersController,
     payPalController,
     assetController
   )

--- a/app/wiring/Controllers.scala
+++ b/app/wiring/Controllers.scala
@@ -48,11 +48,16 @@ trait Controllers {
     controllerComponents
   )
 
-  lazy val testUsersContoller = new TestUsersManagement(
+  lazy val testUsersController = new TestUsersManagement(
     authAction,
     controllerComponents,
     testUsers,
     appConfig.supportUrl,
     appConfig.guardianDomain
+  )
+
+  lazy val siteMapController = new SiteMap(
+    actionRefiners,
+    controllerComponents
   )
 }

--- a/conf/routes
+++ b/conf/routes
@@ -9,7 +9,7 @@ GET /uk                                             controllers.Application.reac
 GET /us                                             controllers.Application.redirect(location="/us/contribute")
 GET /                                               controllers.Application.indexRedirect
 
-
+GET /sitemap.xml                                    controllers.SiteMap.sitemap
 
 # This is a temporary client-side redirect based on geo-location
 # Once we have a separate payment failure email for US and UK we can consider removing it

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -4,3 +4,5 @@ Disallow: /uk/contribute
 Disallow: /contribute
 
 Allow: /
+
+Sitemap: https://support.theguardian.com/sitemap.xml


### PR DESCRIPTION
## Why are you doing this?

Sitemaps are useful for search engines to know about the organization of a site. Search engine web crawlers like Googlebot read this file to more intelligently crawl your site.

Sitemap's protocol: https://www.sitemaps.org/protocol.html

This PR is inspired by @rtyley's PR in membership: https://github.com/guardian/membership-frontend/pull/1351

[**Trello Card**](https://trello.com/c/FiEiovzZ/974-add-sitemap)

## Changes

* Added `/sitemap.xml`

## Response

```xml

 <urlset xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
    <url>
      <loc>https://support.thegulocal.com/uk</loc>
       <xhtml:link rel="alternate" hreflang="en-us"    href="https://support.thegulocal.com/us/contribute"/>
       <xhtml:link rel="alternate" hreflang="en" href="https://support.thegulocal.com/uk"/>
       <priority>1.0</priority>
   </url>
   <url>
       <loc>
           https://support.thegulocal.com/us/contribute
       </loc>
       <xhtml:link rel="alternate" hreflang="en-us" href="https://support.thegulocal.com/us/contribute"/>
       <xhtml:link rel="alternate" hreflang="en" href="https://support.thegulocal.com/uk"/>
       <priority>1.0</priority>
   </url>
</urlset>
```








