### PR TITLE
Add route for 750,000 supporters campaign

### DIFF
--- a/app/actions/CustomActionBuilders.scala
+++ b/app/actions/CustomActionBuilders.scala
@@ -54,4 +54,7 @@ class CustomActionBuilders(
   val AuthenticatedTestUserAction = PrivateAction andThen authenticatedTestUser()
 
   val CachedAction = new CachedAction(cc.parsers.defaultBodyParser, cc.executionContext)
+
+  val NoCacheAction = new NoCacheAction(cc.parsers.defaultBodyParser, cc.executionContext)
+
 }

--- a/app/actions/NoCacheAction.scala
+++ b/app/actions/NoCacheAction.scala
@@ -1,0 +1,14 @@
+package actions
+
+import play.api.mvc._
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+class NoCacheAction(
+    parser: BodyParser[AnyContent],
+    executionContext: ExecutionContext
+)(implicit val ec: ExecutionContext) {
+  def apply(): ActionBuilder[Request, AnyContent] =
+    new NoCacheActionBuilder(parser, executionContext)
+}

--- a/app/actions/NoCacheActionBuilder.scala
+++ b/app/actions/NoCacheActionBuilder.scala
@@ -12,6 +12,6 @@ class NoCacheActionBuilder(
   implicit private val ec = executionContext
 
   override def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]): Future[Result] =
-    block(request).map(_.withHeaders("Cache-Control" -> "no-cache, private", "Pragma" -> "no-cache"))
+    block(request).map(_.withHeaders("Cache-Control" -> "no-cache, private", "Pragma" -> "no-cache", "Expires" -> "0"))
 
 }

--- a/app/actions/NoCacheActionBuilder.scala
+++ b/app/actions/NoCacheActionBuilder.scala
@@ -1,0 +1,17 @@
+package actions
+
+import play.api.mvc._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class NoCacheActionBuilder(
+  val parser: BodyParser[AnyContent],
+  val executionContext: ExecutionContext
+)
+    extends ActionBuilder[Request, AnyContent] {
+  implicit private val ec = executionContext
+
+  override def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]): Future[Result] =
+    block(request).map(_.withHeaders("Cache-Control" -> "no-cache, private", "Pragma" -> "no-cache"))
+
+}

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -1,9 +1,12 @@
 package controllers
 
+import actions.NoCacheAction
 import actions.CustomActionBuilders
 import assets.AssetsResolver
+import com.gu.i18n.CountryGroup._
 import play.api.mvc._
 import services.IdentityService
+import utils.RequestCountry._
 
 import scala.concurrent.ExecutionContext
 
@@ -24,6 +27,17 @@ class Application(
 
   def indexRedirect: Action[AnyContent] = CachedAction() { implicit request =>
     Redirect("/uk", request.queryString)
+  }
+
+  def geoRedirect: Action[AnyContent] = NoCacheAction() { implicit request =>
+
+    val redirectUrl = request.getFastlyCountry match {
+      case Some(UK) => "/uk"
+      case Some(US) => "/us"
+      case _ => "https://membership.theguardian.com/supporter"
+    }
+
+    Redirect(redirectUrl, request.queryString)
   }
 
   def redirect(location: String): Action[AnyContent] = CachedAction() { implicit request =>

--- a/app/utils/RequestCountry.scala
+++ b/app/utils/RequestCountry.scala
@@ -1,0 +1,11 @@
+package utils
+
+import com.gu.i18n.CountryGroup
+import play.api.mvc.Request
+
+object RequestCountry {
+  implicit class RequestWithFastlyCountry(r: Request[_]) {
+    def getFastlyCountry: Option[CountryGroup] = r.headers.get("X-GU-GeoIP-Country-Code").flatMap(CountryGroup.byFastlyCountryCode)
+  }
+  implicit class AuthenticatedRequestWithIdentity(r: /*Auth*/ Request[_])
+}

--- a/conf/routes
+++ b/conf/routes
@@ -16,6 +16,8 @@ GET /                                               controllers.Application.inde
 
 GET  /monthly-contributions                         controllers.Application.contributionsRedirect()
 
+GET /geo-redirect                                     controllers.Application.geoRedirect()
+
 # ----- Contributions ----- #
 
 GET  /uk/contribute                                 controllers.Application.contributionsLanding(title="Support the Guardian | Make a Contribution", id="contributions-landing-page-uk", js="contributionsLandingPageUK.js")


### PR DESCRIPTION
## Why are you doing this?
Our impending acquisition piece about our 750,000 supporters will contain a single link which needs to send people to the following sites depending on their location:

UK -> UK new proposition
US -> US new proposition
Everywhere else -> Become a supporter page

This PR adds this functionality, behind the path `/geo-redirect`

The action is a non-cached action, as to accurately get the geolocation from Fastly, we can't use a cached result. As this will only be from one article, and will only get any traffic for the next week or so, so this should be fine


