### PR TITLE
Events redirect

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -41,7 +41,7 @@ class Application(
   }
 
   def redirectPath(location: String, path: String): Action[AnyContent] = CachedAction() { implicit request =>
-    Redirect(location.concat(path), request.queryString)
+    Redirect(location + path, request.queryString)
   }
 
   def contributionsLanding(title: String, id: String, js: String): Action[AnyContent] = CachedAction() { implicit request =>

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -40,6 +40,10 @@ class Application(
     Redirect(location, request.queryString)
   }
 
+  def redirectPath(location: String, path: String): Action[AnyContent] = CachedAction() { implicit request =>
+    Redirect(location.concat(path), request.queryString)
+  }
+
   def contributionsLanding(title: String, id: String, js: String): Action[AnyContent] = CachedAction() { implicit request =>
     Ok(views.html.contributionsLanding(title, id, js, contributionsPayPalEndpoint))
   }

--- a/conf/routes
+++ b/conf/routes
@@ -11,6 +11,10 @@ GET /                                               controllers.Application.geoR
 
 GET /sitemap.xml                                    controllers.SiteMap.sitemap
 
+# ----- Events Redirect ----- #
+GET /events/archive                                 controllers.Application.redirect(location="https://membership.theguardian.com/events/archive")
+GET /event/*eventId                                 controllers.Application.redirectPath(location="https://membership.theguardian.com/event/", eventId)
+
 # This is a temporary client-side redirect based on geo-location
 # Once we have a separate payment failure email for US and UK we can consider removing it
 

--- a/conf/routes
+++ b/conf/routes
@@ -13,7 +13,9 @@ GET /sitemap.xml                                    controllers.SiteMap.sitemap
 
 # ----- Events Redirect ----- #
 GET /events/archive                                 controllers.Application.redirect(location="https://membership.theguardian.com/events/archive")
+GET /masterclasses                                  controllers.Application.redirect(location="https://membership.theguardian.com/masterclasses")
 GET /event/*eventId                                 controllers.Application.redirectPath(location="https://membership.theguardian.com/event/", eventId)
+
 
 # This is a temporary client-side redirect based on geo-location
 # Once we have a separate payment failure email for US and UK we can consider removing it


### PR DESCRIPTION
## Why are you doing this?

According to webmaster tools, we are getting crawls errors because the robot is trying to access `/events/archive` and `events/:idOfEvent`.  Therefore, I looked through the codebase and I was not able to find the place where these links are being set up. Additionally, webtools says that source which links this URL are other events in support platform (we don't have events in support). Therefore in this PR I am setting a redirect from support events to membership events and avoid these eventual crawls errors.

[**Trello Card**](https://trello.com/c/p8dtuArF/975-investigate-crawl-errors-which-are-linking-events)

## Changes

* Added two new routes.

## Screenshots
![picture 437](https://user-images.githubusercontent.com/825398/32054142-5c4c7b24-ba55-11e7-8f3f-d2b72cc9d936.png)

