### PR TITLE
Run `yarn devrun` as part of `sbt devrun`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,6 +36,8 @@ val circeVersion = "0.8.0"
 
 resolvers ++= Seq(Resolver.sonatypeRepo("releases"), Resolver.bintrayRepo("guardian", "ophan"))
 
+PlayKeys.playRunHooks += new AssetWatch(baseDirectory.value)
+
 libraryDependencies ++= Seq(
   "org.scalatestplus.play" %% "scalatestplus-play" % "2.0.0" % Test,
   "org.mockito" % "mockito-core" % "2.7.22" % Test,

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -8,33 +8,27 @@ In local development, the base app server has two layers of proxy sitting on top
 
 You need all 3 of these running to have a working development environment.
 
-## Starting Play
+## Installing client-side dependencies
+Install [yarn](https://yarnpkg.com/lang/en/docs/install/) and download client-side dependencies with:
+
+```
+yarn install
+```
+
+## Running the app
 
 Download config from S3: 
 
 ```$ aws s3 cp s3://membership-private/DEV/support-frontend.private.conf /etc/gu/support-frontend.private.conf --profile membership```
 
-Install [sbt](http://www.scala-sbt.org/download.html), and start the [Play server](https://www.playframework.com/)
-running on port 9110, hot-reloading the server-side code:
+Install [sbt](http://www.scala-sbt.org/download.html). Start the [Play server](https://www.playframework.com/)
+running on port 9110, hot-reloading the server-side code, and `webpack-dev-server` on port 9111, hot-reloading the client-side code with:
 
 ```
 $ sbt devrun
 ```
 
-## Starting `webpack-dev-server`
-
-Install [yarn](https://yarnpkg.com/lang/en/docs/install/) and download client-side
-dependencies with:
-
-```
-yarn install
-```
- 
-You can then start the `webpack-dev-server` proxy on port 9111, hot-reloading the client-side code:
-
-```
-$ yarn devrun
-```
+## Compiling client-side assets in production mode
 
 If you want to serve the assets without the `webpack-dev-server` proxy (to closer match Production)
 you can run this instead:

--- a/project/AssetWatch.scala
+++ b/project/AssetWatch.scala
@@ -1,0 +1,15 @@
+import java.net.InetSocketAddress
+
+import sbt.File
+import play.sbt.PlayRunHook
+import scala.sys.process._
+
+class AssetWatch(basePath: File) extends PlayRunHook {
+  private var yarnWatch: Option[Process] = None
+
+  override def afterStarted(addr: InetSocketAddress): Unit =
+    yarnWatch = Some(Process("yarn devrun", basePath).run)
+
+  override def afterStopped(): Unit =
+    yarnWatch.foreach(_.destroy)
+}


### PR DESCRIPTION
## Why are you doing this?
To reduce the amount of commands needed to run support locally – after this change, `sbt devrun` triggers `yarn devrun`.
