### PR TITLE
Add US recurring vs one-off A/B test

### DIFF
--- a/assets/helpers/abtest.js
+++ b/assets/helpers/abtest.js
@@ -26,7 +26,7 @@ type Audiences = {
   },
 };
 
-type TestId = 'addAnnualContributions';
+type TestId = 'addAnnualContributions' | 'usMonthlyVsOneOff';
 
 export type Participations = {
   [TestId]: string,
@@ -66,7 +66,20 @@ const tests: Test[] = [
       },
     },
     isActive: false,
-  }];
+  },
+
+  {
+    testId: 'usMonthlyVsOneOff',
+    variants: ['one_off', 'monthly'],
+    audiences: {
+      US: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: true,
+  },
+];
 
 
 // ----- Functions ----- //

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -218,11 +218,8 @@ function ContributionsBundle(props: PropTypes) {
 // ----- Map State/Props ----- //
 
 function mapStateToProps(state) {
-  const contribType = (state.common.abParticipations && state.common.abParticipations.usMonthlyVsOneOff === 'monthly'
-    ? 'MONTHLY' : 'ONE_OFF') || state.page.type;
-
   return {
-    contribType,
+    contribType: state.page.type,
     contribAmount: state.page.amount,
     contribError: state.page.error,
     referrerAcquisitionData: state.common.referrerAcquisitionData,

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -218,9 +218,11 @@ function ContributionsBundle(props: PropTypes) {
 // ----- Map State/Props ----- //
 
 function mapStateToProps(state) {
+  const contribType = (state.common.abParticipations && state.common.abParticipations.usMonthlyVsOneOff === 'monthly'
+    ? 'MONTHLY' : 'ONE_OFF') || state.page.type;
 
   return {
-    contribType: state.page.type,
+    contribType,
     contribAmount: state.page.amount,
     contribError: state.page.error,
     referrerAcquisitionData: state.common.referrerAcquisitionData,

--- a/assets/pages/contributions-landing/contributionsLandingUS.jsx
+++ b/assets/pages/contributions-landing/contributionsLandingUS.jsx
@@ -2,6 +2,8 @@
 
 // ----- Imports ----- //
 
+import type { Contrib } from 'helpers/contributions';
+
 import React from 'react';
 import { applyMiddleware, compose } from 'redux';
 import thunkMiddleware from 'redux-thunk';
@@ -17,7 +19,7 @@ import { renderPage } from 'helpers/render';
 import reducer from './contributionsLandingReducers';
 import { saveContext } from './helpers/context';
 import ContributionsBundleContent from './components/contributionsBundleContent';
-
+import { changeContribType } from './contributionsLandingActions';
 
 // ----- Page Startup ----- //
 
@@ -29,6 +31,14 @@ const store = pageInit(reducer, undefined, composeEnhancers(applyMiddleware(thun
 
 saveContext(store.dispatch);
 
+(function initialiseMonthlyVsOneOffTest() {
+  try {
+    const contribType: Contrib =
+        store.getState().common.abParticipations.usMonthlyVsOneOff.toUpperCase();
+
+    return store.dispatch(changeContribType(contribType));
+  } catch (e) { return null; }
+}());
 
 // ----- Render ----- //
 


### PR DESCRIPTION
## Why are you doing this?
To compare the performance of contributions in the US when either one-off or recurring is  selected as the default option.

## Changes

* adds a new A/B test
* changes the logic to determine `contribType` in `ContributionsBundle` 
