### PR TITLE
Tidy Up Radio Toggle

### DIFF
--- a/assets/components/contribAmounts/contribAmounts.jsx
+++ b/assets/components/contribAmounts/contribAmounts.jsx
@@ -354,6 +354,8 @@ export default function ContribAmounts(props: PropTypes) {
   const contribAmountHint = `Enter an amount of ${props.contribType === 'MONTHLY' ? contribMinMonthlyAmountHint : 'your choice'}`;
   const contribOtherAmountAccessibilityHintId = `accessibility-hint-other-amount-${props.contribType.toLowerCase()}`;
   const contribOtherAmountAccessibilityHint = `${contribAmountHint} for your ${contribTypeDescription} contribution.`;
+  const radioModifier = showAnnual ? 'with-annual' : 'without-annual';
+
   return (
     <div className="component-contrib-amounts">
       <div className="contrib-type">
@@ -361,7 +363,7 @@ export default function ContribAmounts(props: PropTypes) {
           {...contribToggle(props.isoCountry, showAnnual, contribGroupAccessibilityHint)}
           toggleAction={props.toggleContribType}
           checked={props.contribType}
-          showAnnual={showAnnual}
+          modifierClass={radioModifier}
         />
       </div>
       <div className={className}>
@@ -369,7 +371,7 @@ export default function ContribAmounts(props: PropTypes) {
           {...attrs.toggles}
           toggleAction={attrs.toggleAction}
           checked={attrs.checked}
-          showAnnual={showAnnual}
+          modifierClass={radioModifier}
         />
         <div className="component-contrib-amounts__other-amount">
           <NumberInput

--- a/assets/components/radioToggle/radioToggle.jsx
+++ b/assets/components/radioToggle/radioToggle.jsx
@@ -5,6 +5,8 @@
 import React from 'react';
 import uuidv4 from 'uuid';
 
+import { generateClassName } from 'helpers/utilities';
+
 
 // ----- Types ----- //
 
@@ -23,7 +25,7 @@ type PropTypes = {
   radios: Radio[],
   checked: ?string,
   toggleAction: (string) => void,
-  showAnnual: boolean,
+  modifierClass?: ?string,
   accessibilityHint?: ?string,
 };
 
@@ -32,10 +34,7 @@ type PropTypes = {
 
 // ----- Functions ----- //
 
-function getClassName(props: PropTypes) {
-  return props.showAnnual === true ? 'component-radio-toggle__button--with-annual' : 'component-radio-toggle__button--without-annual';
-}
-
+// Builds an accessibility hint for the button.
 function getA11yHint(id: string, hint: ?string) {
 
   return (
@@ -52,12 +51,15 @@ function getRadioButtons(props: PropTypes) {
   return props.radios.map((radio: Radio, idx: number) => {
 
     const radioId = `${props.name}-${idx}`;
-    const className = getClassName(props);
     const a11yHintId = `accessibility-hint-${radioId}`;
 
     /* eslint-disable jsx-a11y/label-has-for */
     return (
-      <span id={radio.id} className={`component-radio-toggle__button ${className}`} key={radioId}>
+      <span
+        id={radio.id}
+        className={generateClassName('component-radio-toggle__button', props.modifierClass)}
+        key={radioId}
+      >
         {getA11yHint(a11yHintId, radio.accessibilityHint)}
         <input
           className="component-radio-toggle__input"
@@ -103,4 +105,5 @@ export default function RadioToggle(props: PropTypes) {
 
 RadioToggle.defaultProps = {
   accessibilityHint: '',
+  modifierClass: null,
 };

--- a/assets/components/radioToggle/radioToggle.jsx
+++ b/assets/components/radioToggle/radioToggle.jsx
@@ -5,10 +5,8 @@
 import React from 'react';
 import uuidv4 from 'uuid';
 
-// ----- Types ----- //
 
-// Disabling the linter here because it's just buggy...
-/* eslint-disable react/no-unused-prop-types */
+// ----- Types ----- //
 
 export type Radio = {
   id?: string,
@@ -16,6 +14,9 @@ export type Radio = {
   text: string,
   accessibilityHint?: ?string,
 };
+
+// Disabling the linter here because it's just buggy...
+/* eslint-disable react/no-unused-prop-types */
 
 type PropTypes = {
   name: string,
@@ -28,22 +29,36 @@ type PropTypes = {
 
 /* eslint-enable react/no-unused-prop-types */
 
+
+// ----- Functions ----- //
+
 function getClassName(props: PropTypes) {
   return props.showAnnual === true ? 'component-radio-toggle__button--with-annual' : 'component-radio-toggle__button--without-annual';
 }
-// ----- Component ----- //
 
-export default function RadioToggle(props: PropTypes) {
-  const radioButtons = props.radios.map((radio: Radio, idx: number) => {
+function getA11yHint(id: string, hint: ?string) {
+
+  return (
+    <p id={id} className="accessibility-hint">
+      {hint}
+    </p>
+  );
+
+}
+
+// Returns a list of the radio button elements.
+function getRadioButtons(props: PropTypes) {
+
+  return props.radios.map((radio: Radio, idx: number) => {
 
     const radioId = `${props.name}-${idx}`;
     const className = getClassName(props);
-    const accessibilityHintId = `accessibility-hint-${radioId}`;
-    const accessibilityHint = <p id={accessibilityHintId} className="accessibility-hint">{radio.accessibilityHint}</p>;
+    const a11yHintId = `accessibility-hint-${radioId}`;
+
     /* eslint-disable jsx-a11y/label-has-for */
     return (
       <span id={radio.id} className={`component-radio-toggle__button ${className}`} key={radioId}>
-        {accessibilityHint}
+        {getA11yHint(a11yHintId, radio.accessibilityHint)}
         <input
           className="component-radio-toggle__input"
           type="radio"
@@ -53,17 +68,25 @@ export default function RadioToggle(props: PropTypes) {
           onChange={() => props.toggleAction(radio.value)}
           checked={radio.value === props.checked}
           tabIndex="0"
-          aria-describedby={accessibilityHintId}
+          aria-describedby={a11yHintId}
         />
         <label htmlFor={radioId} className="component-radio-toggle__label">
           {radio.text}
         </label>
       </span>
-      /* eslint-enable jsx-a11y/label-has-for */
     );
+    /* eslint-enable jsx-a11y/label-has-for */
 
   });
 
+}
+
+
+// ----- Component ----- //
+
+export default function RadioToggle(props: PropTypes) {
+
+  const radioButtons = getRadioButtons(props);
   const radioGroupId = uuidv4();
 
   return (


### PR DESCRIPTION
## Why are you doing this?

I'm going to make use of this component for the landing page changes, and I thought it would be good to give it some TLC. I'm doing it in a separate PR because I would like to minimise the impact of changes to other parts of the site in the main Support Landing PRs.

This is a refactor to (hopefully) make it easier to read the code. I've also pulled the `showAnnual` prop out (it's a shared component, ideally it shouldn't know anything about contributions), and replaced it with `modifierClass`, pushing the `with-annual`/`without-annual` choice further up the component tree.

**Note:** It may be easier to just look at the file, rather than read the diff, in places.

## Changes

- Refactored the component, pulling some of the code out into functions.
- Replaced `showAnnual` prop with `modifierClass`, making use of `generateClassName`.
