### PR TITLE
Run selenium tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ cache:
 before_cache:
   - find $HOME/.sbt -name "*.lock" -type f -delete -print
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" -type f -delete -print
-script: sbt ++$TRAVIS_SCALA_VERSION selenium-test
+script: sbt ++$TRAVIS_SCALA_VERSION selenium:test

--- a/docs/development.md
+++ b/docs/development.md
@@ -162,13 +162,13 @@ yarn run test
 
 To run server-side unit tests:
 ```
-sbt fast-test
+sbt test
 ```
 
 To run end-to-end browser-driven tests:
 
 ```
-sbt selenium-test
+sbt selenium:test
 ```
 
 **Note** that you need to run *identity-frontend*, *contributions-frontend* and *support-frontend* locally before running the end-to-end tests.

--- a/test/selenium/ContributorSpec.scala
+++ b/test/selenium/ContributorSpec.scala
@@ -32,7 +32,7 @@ class ContributorSpec extends FeatureSpec with Browser with GivenWhenThen with B
 
   feature("Sign up for a Monthly Contribution") {
 
-    scenario("Monthly contribution sign-up with Stripe - GBP", SeleniumTag) {
+    scenario("Monthly contribution sign-up with Stripe - GBP") {
 
       val landingPage = ContributionsLanding("uk")
 
@@ -84,7 +84,7 @@ class ContributorSpec extends FeatureSpec with Browser with GivenWhenThen with B
 
     }
 
-    scenario("Monthly contribution sign-up with PayPal - USD", SeleniumTag) {
+    scenario("Monthly contribution sign-up with PayPal - USD") {
 
       val landingPage = ContributionsLanding("us")
       val expectedPayment = "10.00"
@@ -146,7 +146,7 @@ class ContributorSpec extends FeatureSpec with Browser with GivenWhenThen with B
 
   feature("Perform a one-off contribution") {
 
-    scenario("One-off contribution with PayPal - USD", SeleniumTag) {
+    scenario("One-off contribution with PayPal - USD") {
 
       val testUser = new TestUser
       val landingPage = ContributionsLanding("us")

--- a/test/selenium/util/SeleniumTag.scala
+++ b/test/selenium/util/SeleniumTag.scala
@@ -1,5 +1,0 @@
-package selenium.util
-
-import org.scalatest.Tag
-
-object SeleniumTag extends Tag("Selenium")


### PR DESCRIPTION
## Why are you doing this?

So that the selenium tests run.  Include/exclude tags do not work quite the way we want to instead we're now running selenium tests with a separate test config.  To run selenium tests `sbt selenium:test`.  All tests starting with ‘selenium’ will be run.  To run the non selenium tests `sbt test`