### PR TITLE
Avoid using -- in package.json's scripts

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -23,8 +23,8 @@ $ sbt devrun
 
 ## Starting `webpack-dev-server`
 
-Install [yarn](https://yarnpkg.com/lang/en/docs/install/) and download client-side
-dependencies with:
+Install [yarn](https://yarnpkg.com/lang/en/docs/install/). In order to run support-frontend, you need at least yarn version `1.0`.
+Once yarn is installed, download client-side dependencies with:
 
 ```
 yarn install

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "flow": "flow",
     "lint": "eslint --ext .js --ext .jsx .",
     "build-dev": "webpack --config webpack.config.js --env.dev",
-    "build-prod": "npm-run-all clean validate test 'webpack -- --config webpack.config.js --env.prod'",
+    "build-prod": "npm-run-all clean validate test 'webpack --config webpack.config.js --env.prod'",
     "webpack": "webpack",
     "webpack-dev-server": "webpack-dev-server --port 9211 --public support.thegulocal.com",
     "devrun": "npm-run-all clean webpack-dev-server",


### PR DESCRIPTION
## Why are you doing this?

To avoid this message in TeamCity:
` warning From Yarn 1.0 onwards, scripts don't require "--" for options to be forwarded. In a future version, any explicit "--" will be forwarded as-is to the scripts.`



## Changes

* Updated `package.json`
