### PR TITLE
Refactor abtest.js to automatically submit A/B impressions to Ophan

### DIFF
--- a/assets/helpers/__tests__/abtestTest.js
+++ b/assets/helpers/__tests__/abtestTest.js
@@ -5,8 +5,9 @@
 import { getVariantsAsString, init as abInit } from '../abtest';
 import type { Participations } from '../abtest';
 
-jest.mock('ophan', () => {});
-
+jest.mock('ophan', () => ({
+  record: () => null,
+}));
 
 // ----- Tests ----- //
 
@@ -17,9 +18,8 @@ describe('basic behaviour of init', () => {
 
     document.cookie = 'GU_mvt_id=12346';
 
-    const tests = [
-      {
-        testId: 'mockTest',
+    const tests = {
+      mockTest: {
         variants: ['control', 'variant'],
         audiences: {
           GB: {
@@ -28,7 +28,8 @@ describe('basic behaviour of init', () => {
           },
         },
         isActive: true,
-      }];
+      },
+    };
 
     const country = 'GB';
     const participations: Participations = abInit(country, tests);
@@ -41,9 +42,8 @@ describe('basic behaviour of init', () => {
 
     document.cookie = 'GU_mvt_id=12345';
 
-    const tests = [
-      {
-        testId: 'mockTest',
+    const tests = {
+      mockTest: {
         variants: ['control', 'variant'],
         audiences: {
           GB: {
@@ -52,7 +52,8 @@ describe('basic behaviour of init', () => {
           },
         },
         isActive: true,
-      }];
+      },
+    };
 
     const country = 'GB';
     const participations: Participations = abInit(country, tests);
@@ -65,11 +66,10 @@ describe('basic behaviour of init', () => {
 
     document.cookie = 'GU_mvt_id=12346';
 
-    const tests = [
-      {
-        testId: 'mockTest',
-        independence: 1,
+    const tests = {
+      mockTest: {
         variants: ['control', 'variant'],
+        independence: 1,
         audiences: {
           GB: {
             offset: 0,
@@ -77,7 +77,8 @@ describe('basic behaviour of init', () => {
           },
         },
         isActive: true,
-      }];
+      },
+    };
 
     const country = 'GB';
     const participations: Participations = abInit(country, tests);
@@ -90,9 +91,8 @@ describe('basic behaviour of init', () => {
 
     document.cookie = 'GU_mvt_id=12346';
 
-    const tests = [
-      {
-        testId: 'mockTest',
+    const tests = {
+      mockTest: {
         variants: ['control', 'variant'],
         audiences: {
           GB: {
@@ -101,7 +101,8 @@ describe('basic behaviour of init', () => {
           },
         },
         isActive: true,
-      }];
+      },
+    };
 
     const country = 'US';
     const participations: Participations = abInit(country, tests);
@@ -120,9 +121,8 @@ describe('Correct allocation in a multi test environment', () => {
         Test 1         Test 2              Not in Test
    */
 
-  const tests = [
-    {
-      testId: 'mockTest',
+  const tests = {
+    mockTest: {
       variants: ['control', 'variant'],
       audiences: {
         GB: {
@@ -136,8 +136,8 @@ describe('Correct allocation in a multi test environment', () => {
       },
       isActive: true,
     },
-    {
-      testId: 'mockTest2',
+
+    mockTest2: {
       variants: ['control', 'variant'],
       audiences: {
         US: {
@@ -147,7 +147,7 @@ describe('Correct allocation in a multi test environment', () => {
       },
       isActive: true,
     },
-  ];
+  };
 
   it('It correctly segments a user who has a cookie in the top 80% in GB', () => {
 

--- a/assets/helpers/abtest.js
+++ b/assets/helpers/abtest.js
@@ -3,14 +3,13 @@
 // ----- Imports ----- //
 
 import type { IsoCountry } from 'helpers/internationalisation/country';
-import type { Tests } from 'helpers/abtests';
 
 import shajs from 'sha.js';
 
 import * as ophan from 'ophan';
 import * as cookie from './cookie';
 import * as storage from './storage';
-import { tests } from './abtests';
+import { tests } from './abtestDefinitions';
 
 // ----- Types ----- //
 
@@ -43,6 +42,8 @@ export type Test = {
   isActive: boolean,
   independence?: number,
 };
+
+export type Tests = { [testId: string]: Test }
 
 // ----- Setup ----- //
 
@@ -171,7 +172,7 @@ const init = (country: IsoCountry, abTests: Tests = tests): Participations => {
 
   const mvt: number = getMvtId();
   const participations: Participations = getParticipations(abTests, mvt, country);
-  const urlParticipations = getParticipationsFromUrl();
+  const urlParticipations: ?Participations = getParticipationsFromUrl();
 
   setLocalStorageParticipations(Object.assign({}, participations, urlParticipations));
   trackAB(participations, false);

--- a/assets/helpers/abtest.js
+++ b/assets/helpers/abtest.js
@@ -162,7 +162,7 @@ const buildOphanPayload = (participations: Participations, complete: boolean): O
 
 // ----- Exports ----- //
 
-const trackAB = (participations: Participations, complete: boolean): void => {
+const trackABOphan = (participations: Participations, complete: boolean): void => {
   ophan.record({
     abTestRegister: buildOphanPayload(participations, complete),
   });
@@ -175,7 +175,7 @@ const init = (country: IsoCountry, abTests: Tests = tests): Participations => {
   const urlParticipations: ?Participations = getParticipationsFromUrl();
 
   setLocalStorageParticipations(Object.assign({}, participations, urlParticipations));
-  trackAB(participations, false);
+  trackABOphan(participations, false);
 
   return participations;
 };

--- a/assets/helpers/abtest.js
+++ b/assets/helpers/abtest.js
@@ -2,22 +2,33 @@
 
 // ----- Imports ----- //
 
-import shajs from 'sha.js';
-
 import type { IsoCountry } from 'helpers/internationalisation/country';
+import type { Tests } from 'helpers/abtests';
+
+import shajs from 'sha.js';
 
 import * as ophan from 'ophan';
 import * as cookie from './cookie';
 import * as storage from './storage';
-
-
-// ----- Setup ----- //
-
-const MVT_COOKIE: string = 'GU_mvt_id';
-const MVT_MAX: number = 1000000;
-
+import { tests } from './abtests';
 
 // ----- Types ----- //
+
+type TestId = $Keys<typeof tests>;
+
+type OphanABEvent = {
+  variantName: string,
+  complete: boolean,
+  campaignCodes?: string[],
+};
+
+export type Participations = {
+  [TestId]: string,
+}
+
+type OphanABPayload = {
+  [TestId]: OphanABEvent,
+};
 
 type Audiences = {
   [IsoCountry]: {
@@ -26,61 +37,17 @@ type Audiences = {
   },
 };
 
-type TestId = 'addAnnualContributions' | 'usMonthlyVsOneOff';
-
-export type Participations = {
-  [TestId]: string,
-}
-
-type Test = {
-  testId: TestId,
+export type Test = {
   variants: string[],
   audiences: Audiences,
   isActive: boolean,
   independence?: number,
 };
 
+// ----- Setup ----- //
 
-type OphanABEvent = {
-  variantName: string,
-  complete: boolean,
-  campaignCodes?: string[],
-};
-
-
-type OphanABPayload = {
-  [TestId]: OphanABEvent,
-};
-
-
-// ----- Tests ----- //
-
-const tests: Test[] = [
-  {
-    testId: 'addAnnualContributions',
-    variants: ['control', 'variant'],
-    audiences: {
-      GB: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: false,
-  },
-
-  {
-    testId: 'usMonthlyVsOneOff',
-    variants: ['one_off', 'monthly'],
-    audiences: {
-      US: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: true,
-  },
-];
-
+const MVT_COOKIE: string = 'GU_mvt_id';
+const MVT_MAX: number = 1000000;
 
 // ----- Functions ----- //
 
@@ -107,11 +74,11 @@ function getLocalStorageParticipation(): Participations {
 
 }
 
-function setLocalStorageParticipation(participation): void {
-  storage.setLocal('gu.support.abTests', JSON.stringify(participation));
+function setLocalStorageParticipations(participations: Participations): void {
+  storage.setLocal('gu.support.abTests', JSON.stringify(participations));
 }
 
-function getUrlParticipation(): ?Participations {
+function getParticipationsFromUrl(): ?Participations {
 
   const hashUrl = (new URL(document.URL)).hash;
 
@@ -157,46 +124,59 @@ function assignUserToVariant(mvtId: number, test: Test): string {
   return test.variants[variantIndex];
 }
 
-function getParticipation(abTests: Test[], mvtId: number, country: IsoCountry): Participations {
+function getParticipations(abTests: Tests, mvtId: number, country: IsoCountry): Participations {
 
   const currentParticipation = getLocalStorageParticipation();
-  const participation:Participations = {};
+  const participations: Participations = {};
 
-  abTests.forEach((test) => {
+  Object.keys(abTests).forEach((testId) => {
+    const test = abTests[testId];
 
     if (!test.isActive) {
       return;
     }
 
-    if (test.testId in currentParticipation) {
-      participation[test.testId] = currentParticipation[test.testId];
+    if (testId in currentParticipation) {
+      participations[testId] = currentParticipation[testId];
     } else if (userInTest(test.audiences, mvtId, country)) {
-      participation[test.testId] = assignUserToVariant(mvtId, test);
+      participations[testId] = assignUserToVariant(mvtId, test);
     } else {
-      participation[test.testId] = 'notintest';
+      participations[testId] = 'notintest';
     }
-
   });
 
-  return participation;
-
+  return participations;
 }
 
+const buildOphanPayload = (participations: Participations, complete: boolean): OphanABPayload =>
+  Object.keys(participations).reduce((payload, participation) => {
+    const ophanABEvent: OphanABEvent = {
+      variantName: participations[participation],
+      complete,
+      campaignCodes: [],
+    };
+
+    return Object.assign({}, payload, { [participation]: ophanABEvent });
+  }, {});
 
 // ----- Exports ----- //
 
-const init = (country: IsoCountry, abTests: Test[] = tests): Participations => {
+const trackAB = (participations: Participations, complete: boolean): void => {
+  ophan.record({
+    abTestRegister: buildOphanPayload(participations, complete),
+  });
+};
+
+const init = (country: IsoCountry, abTests: Tests = tests): Participations => {
 
   const mvt: number = getMvtId();
-  let participation: Participations = getParticipation(abTests, mvt, country);
+  const participations: Participations = getParticipations(abTests, mvt, country);
+  const urlParticipations = getParticipationsFromUrl();
 
-  const urlParticipation = getUrlParticipation();
-  participation = Object.assign({}, participation, urlParticipation);
+  setLocalStorageParticipations(Object.assign({}, participations, urlParticipations));
+  trackAB(participations, false);
 
-  setLocalStorageParticipation(participation);
-
-  return participation;
-
+  return participations;
 };
 
 const getVariantsAsString = (participation: Participations): string => {
@@ -211,29 +191,8 @@ const getVariantsAsString = (participation: Participations): string => {
 
 const getCurrentParticipations = (): Participations => getLocalStorageParticipation();
 
-const trackOphan = (
-  testId: TestId,
-  variant: string,
-  complete?: boolean = false,
-  campaignCodes?: string[] = [],
-): void => {
-
-  const payload: OphanABPayload = {
-    [testId]: {
-      variantName: variant,
-      complete,
-      campaignCodes,
-    },
-  };
-
-  ophan.record({
-    abTestRegister: payload,
-  });
-};
-
 export {
   init,
   getVariantsAsString,
   getCurrentParticipations,
-  trackOphan,
 };

--- a/assets/helpers/abtestDefinitions.js
+++ b/assets/helpers/abtestDefinitions.js
@@ -1,9 +1,7 @@
 // @flow
-import type { Test } from './abtest';
+import type { Tests } from './abtest';
 
 // ----- Tests ----- //
-
-export type Tests = { [testId: string]: Test }
 
 export const tests: Tests = {
   addAnnualContributions: {

--- a/assets/helpers/abtests.js
+++ b/assets/helpers/abtests.js
@@ -1,0 +1,30 @@
+// @flow
+import type { Test } from './abtest';
+
+// ----- Tests ----- //
+
+export type Tests = { [testId: string]: Test }
+
+export const tests: Tests = {
+  addAnnualContributions: {
+    variants: ['control', 'variant'],
+    audiences: {
+      GB: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: false,
+  },
+
+  usMonthlyVsOneOff: {
+    variants: ['one_off', 'monthly'],
+    audiences: {
+      US: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: true,
+  },
+};

--- a/assets/pages/bundles-landing/bundlesLanding.jsx
+++ b/assets/pages/bundles-landing/bundlesLanding.jsx
@@ -9,7 +9,6 @@ import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
 import LinksFooter from 'components/footers/linksFooter/linksFooter';
 
 import { getQueryParameter } from 'helpers/url';
-import { trackOphan } from 'helpers/abtest';
 import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
 
@@ -32,14 +31,6 @@ const store = pageInit(
   window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__(),
 );
 /* eslint-enable */
-
-// ----- Setup ----- //
-
-const participations = store.getState().common.abParticipations;
-if (participations.addAnnualContributions) {
-  trackOphan('addAnnualContributions', participations.addAnnualContributions);
-}
-
 
 // ----- Render ----- //
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -234,7 +234,7 @@ he has to set up the custom dimension called `experiment` with the value of the 
 found [here](https://github.com/guardian/support-frontend/pull/68/files#diff-bdf2dc8b3411cc1e5f83ca22c698e7b3R31).  
 
 
-#### `trackOphan(participation: Participations, complete: boolean)`
+#### `trackABOphan(participation: Participations, complete: boolean)`
 Track event using `tracker-js` from Ophan. 
 
 #### `abTestReducer(state: Participations = {}, action: Action)`
@@ -351,10 +351,10 @@ Now that you are rendering the correct component depending on the variant, the f
 a button click, whether the user writes something in a text field, etc. Basically, it can be any event that the user can produce. 
 Test displays are automatically tracked to Ophan, but in order to use abacus as your test tool, you have to track the test's conversion action.
   
-This tracking can be done using the [`trackAB`](#71-api) function from the ABtest framework. This function 
+This tracking can be done using the [`trackABOphan`](#71-api) function from the ABtest framework. This function 
 receives an A/B participation and a flag indicating whether is a complete event or not (which should be `true` in the case of conversions).
 
-If you are firing a conversion event for a specific test, be sure that the `participations` parameter you provide to `trackOphan` only contains your test.
+If you are firing a conversion event for a specific test, be sure that the `participations` parameter you provide to `trackABOphan` only contains your test.
 
 ## 9 Test Environments
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -320,6 +320,7 @@ compute the sample size of your experiment, from the sample size, you can then e
        },
      },
      isActive: true,
+     independence: 1,
    },
  };
  ```


### PR DESCRIPTION
This required a little reworking of some of the A/B test types, mainly
removing the hardcoded enum and instead using `$Keys<T>`
(https://flow.org/en/docs/types/utilities/) from the A/B
definition (which is now an object keyed by test ID rather than an
array).

The result of this is hopefully a simpler process for adding A/B tests:
just add them to abtests.js and they'll be fired to Ophan automatically.
There's no need to add the IDs as enum values anymore, as `TestId` 
is derived from the keys in the `tests` object. 

## Why are you doing this?
To simplify creating new tests and avoid a situation where Ophan impressions aren't registered because someone forgets to explicitly do that for their test. 