### PR TITLE
Restrict egress traffic to allow only https

### DIFF
--- a/cloud-formation/cfn.yaml
+++ b/cloud-formation/cfn.yaml
@@ -224,3 +224,8 @@ Resources:
           FromPort: 9000
           ToPort: 9000
           SourceSecurityGroupId: !Ref LoadBalancerSecurityGroup
+      SecurityGroupEgress:
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 0.0.0.0/0


### PR DESCRIPTION
## Why are you doing this?

To ensure that all the outgoing connections from our EC2 instances are under `https`

[**Trello Card**](https://trello.com/c/05jyLRpI/1015-check-that-all-outgoing-connections-from-support-frontend-and-membership-frontend-use-https-or-other-encrypted-connection)

## Changes

* Add an egress policy to `cfn.yaml`

