### PR TITLE
Use seeded random number instead of ha-256 for independent a/b

### DIFF
--- a/assets/helpers/__tests__/abtestTest.js
+++ b/assets/helpers/__tests__/abtestTest.js
@@ -69,7 +69,7 @@ describe('basic behaviour of init', () => {
     const tests = {
       mockTest: {
         variants: ['control', 'variant'],
-        independence: 1,
+        independence: 2,
         audiences: {
           GB: {
             offset: 0,

--- a/assets/helpers/abtest.js
+++ b/assets/helpers/abtest.js
@@ -4,7 +4,7 @@
 
 import type { IsoCountry } from 'helpers/internationalisation/country';
 
-import shajs from 'sha.js';
+import seedrandom from 'seedrandom';
 
 import * as ophan from 'ophan';
 import * as cookie from './cookie';
@@ -114,7 +114,8 @@ function randomNumber(seed: number, independence: number): number {
     return seed;
   }
 
-  return Math.abs(shajs('sha256').update(String(seed + independence)).digest().readInt32BE(0));
+  const rng = seedrandom(seed + independence);
+  return Math.abs(rng.int32());
 }
 
 function assignUserToVariant(mvtId: number, test: Test): string {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "react-redux": "^5.0.5",
     "redux": "^3.7.1",
     "redux-thunk": "^2.2.0",
-    "sha.js": "^2.4.9",
+    "seedrandom": "^2.4.3",
     "uuid": "^3.1.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5469,6 +5469,10 @@ scss-tokenizer@^0.2.3:
     js-base64 "^2.1.8"
     source-map "^0.4.2"
 
+seedrandom@^2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/seedrandom/-/seedrandom-2.4.3.tgz#2438504dad33917314bff18ac4d794f16d6aaecc"
+
 select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
@@ -5547,13 +5551,6 @@ sha.js@^2.4.0, sha.js@^2.4.8:
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.8.tgz#37068c2c476b6baf402d14a49c67f597921f634f"
   dependencies:
     inherits "^2.0.1"
-
-sha.js@^2.4.9:
-  version "2.4.9"
-  resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.9.tgz#98f64880474b74f4a38b8da9d3c0f2d104633e7d"
-  dependencies:
-    inherits "^2.0.1"
-    safe-buffer "^5.0.1"
 
 shallow-clone@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Why are you doing this?

To reduce the bundle size.

[**Trello Card**](https://trello.com/c/G5CyJpH3/1059-replace-the-sha-256-library-used-in-support-frontend-with-something-lighter-weight)

## Webpack output:

### After this PR
<img width="625" alt="picture 441" src="https://user-images.githubusercontent.com/825398/32387843-99520430-c0bd-11e7-9a0e-14a5d35129b3.png">

### Before this PR
<img width="954" alt="picture 443" src="https://user-images.githubusercontent.com/825398/32436445-fd451c5a-c2db-11e7-9dea-09cc64cc3682.png">

### After sha-js

<img width="720" alt="picture 445" src="https://user-images.githubusercontent.com/825398/32437099-27c70e50-c2de-11e7-83de-3cd29f7244c3.png">

### Before sha-js commit (https://github.com/guardian/support-frontend/pull/284):

<img width="940" alt="picture 444" src="https://user-images.githubusercontent.com/825398/32436638-9c7a30da-c2dc-11e7-8f8f-a58f650ff291.png">


