### PR TITLE
Set default test allocation method to random  [need to fix tests before merging]

### DIFF
--- a/assets/helpers/__tests__/abtestTest.js
+++ b/assets/helpers/__tests__/abtestTest.js
@@ -135,6 +135,7 @@ describe('Correct allocation in a multi test environment', () => {
         },
       },
       isActive: true,
+      independence: 0,
     },
 
     mockTest2: {
@@ -146,6 +147,7 @@ describe('Correct allocation in a multi test environment', () => {
         },
       },
       isActive: true,
+      independence: 0,
     },
   };
 

--- a/assets/helpers/abtest.js
+++ b/assets/helpers/abtest.js
@@ -119,7 +119,7 @@ function randomNumber(seed: number, independence: number): number {
 }
 
 function assignUserToVariant(mvtId: number, test: Test): string {
-  const independence = test.independence || 0;
+  const independence = test.independence || 1;
 
   const variantIndex = randomNumber(mvtId, independence) % test.variants.length;
 


### PR DESCRIPTION
## Why are you doing this?
As tests on support frontend are further downstream than tests on gu.com, and with the frequency of testing on gu.com, there is a high chance that whenever there is a test running on support frontend, there will be one running on gu.com. This means that if both sites use the same GU_MVT_id based test allocation, we run the risk of spoiling both tests by putting all the people from one variant on gu.com into one variant on support frontend. For a detailed explanation of the dangers of this, see my comment on [this PR](https://github.com/guardian/support-frontend/pull/284). 

With the risk involved, it seems sensible to default to the safest way, which is to randomise the test allocation independently from the test allocation on gu.com. This PR implements this.



