### PR TITLE
Stop Wrapping CtaLink In A Div

### DIFF
--- a/assets/components/ctaLink/ctaLink.jsx
+++ b/assets/components/ctaLink/ctaLink.jsx
@@ -31,21 +31,19 @@ export default function CtaLink(props: PropTypes) {
   const ctaUniqueClassName = `component-cta-link ${props.ctaId}`;
 
   return (
-    <div>
-      <a
-        id={props.id}
-        className={ctaUniqueClassName}
-        href={props.url}
-        onClick={props.onClick}
-        onKeyPress={props.onClick ? clickSubstituteKeyPressHandler(props.onClick) : null}
-        tabIndex={props.tabIndex}
-        aria-describedby={accessibilityHintId}
-      >
-        <span>{props.text}</span>
-        {props.svg}
-      </a>
+    <a
+      id={props.id}
+      className={ctaUniqueClassName}
+      href={props.url}
+      onClick={props.onClick}
+      onKeyPress={props.onClick ? clickSubstituteKeyPressHandler(props.onClick) : null}
+      tabIndex={props.tabIndex}
+      aria-describedby={accessibilityHintId}
+    >
+      <span>{props.text}</span>
+      {props.svg}
       <p id={accessibilityHintId} className="accessibility-hint">{props.accessibilityHint}</p>
-    </div>
+    </a>
   );
 
 }


### PR DESCRIPTION
## Why are you doing this?

To simplify our markup for the circles work.

## Changes

- Stopped wrapping CtaLink in a div.
- Put the accessibility hint inside the `a` tag.
