### PR TITLE
Add digipack flow optimisation test

### DIFF
--- a/assets/components/ctaLink/ctaLink.jsx
+++ b/assets/components/ctaLink/ctaLink.jsx
@@ -21,6 +21,7 @@ type PropTypes = {
   tabIndex?: number,
   id?: ?string,
   svg?: Node,
+  dataLinkName?: ?string,
 };
 
 // ----- Component ----- //
@@ -38,6 +39,7 @@ export default function CtaLink(props: PropTypes) {
       onClick={props.onClick}
       onKeyPress={props.onClick ? clickSubstituteKeyPressHandler(props.onClick) : null}
       tabIndex={props.tabIndex}
+      data-link-name={props.dataLinkName}
       aria-describedby={accessibilityHintId}
     >
       <span>{props.text}</span>
@@ -56,5 +58,6 @@ CtaLink.defaultProps = {
   onClick: null,
   tabIndex: 0,
   id: null,
+  dataLinkName: null,
   svg: <SvgArrowRightStraight />,
 };

--- a/assets/helpers/abtestDefinitions.js
+++ b/assets/helpers/abtestDefinitions.js
@@ -14,4 +14,16 @@ export const tests: Tests = {
     },
     isActive: false,
   },
+
+  digipackFlowOptimisationTest: {
+    variants: ['control', 'variant'],
+    audiences: {
+      GB: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: true,
+    independence: 1,
+  },
 };

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -325,6 +325,7 @@ function DigitalBundle(props: DigitalAttrs) {
       <CtaLink
         ctaId={props.ctaId}
         text={props.ctaText}
+        dataLinkName="bundlesLandingPageDigipackLink"
         accessibilityHint={props.ctaAccessibilityHint}
         url={props.ctaLink}
       />
@@ -360,7 +361,8 @@ function PaperBundle(props: PaperAttrs) {
 
 function Bundles(props: PropTypes) {
 
-  const subsLinks: SubsUrls = getSubsLinks(props.intCmp, props.campaign, props.otherQueryParams);
+  const subsLinks: SubsUrls =
+      getSubsLinks(props.intCmp, props.campaign, props.otherQueryParams, props.abTests);
   const paperAttrs: PaperAttrs = getPaperAttrs(subsLinks);
   const digitalAttrs: DigitalAttrs = getDigitalAttrs(subsLinks);
 


### PR DESCRIPTION
## Why are you doing this?

This PR adds a new test to support frontend. 

People in the control, when they click the "Start free trial" option, go to the following page, as normal:

![control](https://user-images.githubusercontent.com/2844554/32560991-fce009d2-c4a2-11e7-9c49-e1b16f2ec985.png)

Those in the variant will skip this step and proceed directly to this page:
![variant](https://user-images.githubusercontent.com/2844554/32560992-fcfa6016-c4a2-11e7-85f8-b74faff0a6f6.png)

In order to track participants in the test, we will look at clicks on the button from people in either test variant. To be able to do this, I have added the `data-link-name` attribute to the button html, which means that clicks will be tracked through ophan. We can then look at the test participation of people who clicked on the button to get the true participation of the test. 

@guardian/contributions 
