### PR TITLE
Currency On Number Input

### DIFF
--- a/assets/components/contribAmounts/contribAmounts.jsx
+++ b/assets/components/contribAmounts/contribAmounts.jsx
@@ -378,9 +378,10 @@ export default function ContribAmounts(props: PropTypes) {
             onFocus={props.changeContribAmount}
             onInput={props.changeContribAmount}
             selected={attrs.selected}
-            placeholder={`Other amount (${props.currency.glyph})`}
+            placeholder="Other amount"
             onKeyPress={clickSubstituteKeyPressHandler(props.onNumberInputKeyPress)}
             ariaDescribedBy={contribOtherAmountAccessibilityHintId}
+            labelText={props.currency.glyph}
           />
 
           <p className="accessibility-hint" id={contribOtherAmountAccessibilityHintId}>

--- a/assets/components/contribAmounts/contribAmounts.scss
+++ b/assets/components/contribAmounts/contribAmounts.scss
@@ -74,6 +74,10 @@
         flex-grow: 1;
         border: 1px solid gu-colour(neutral-1);
       }
+
+      .component-number-input__input {
+        font-size: 14px;
+      }
     }
 
     .component-contrib-amounts__amounts--recurring {

--- a/assets/components/numberInput/numberInput.jsx
+++ b/assets/components/numberInput/numberInput.jsx
@@ -40,7 +40,7 @@ export default function NumberInput(props: PropTypes) {
   const selectedClass = props.selected ? ' component-number-input--selected' : '';
 
   return (
-    <span className={generateClassName('component-number-input', selectedClass)}>
+    <div className={generateClassName('component-number-input', selectedClass)}>
       {getLabel(props.labelText)}
       <input
         className="component-number-input__input"
@@ -51,7 +51,7 @@ export default function NumberInput(props: PropTypes) {
         onKeyPress={props.onKeyPress}
         aria-describedby={props.ariaDescribedBy}
       />
-    </span>
+    </div>
   );
 
 }

--- a/assets/components/numberInput/numberInput.jsx
+++ b/assets/components/numberInput/numberInput.jsx
@@ -4,6 +4,8 @@
 
 import React from 'react';
 
+import { generateClassName } from 'helpers/utilities';
+
 
 // ----- Types ----- //
 
@@ -14,7 +16,21 @@ type PropTypes = {
   placeholder: ?string,
   onKeyPress: ?(event: Object) => void,
   ariaDescribedBy: ?string,
+  labelText?: ?string,
 };
+
+
+// ----- Functions ----- //
+
+function getLabel(labelText: ?string) {
+
+  if (labelText) {
+    return <span className="component-number-input__label">{labelText}</span>;
+  }
+
+  return null;
+
+}
 
 
 // ----- Component ----- //
@@ -24,15 +40,25 @@ export default function NumberInput(props: PropTypes) {
   const selectedClass = props.selected ? ' component-number-input--selected' : '';
 
   return (
-    <input
-      className={`component-number-input${selectedClass}`}
-      type="number"
-      placeholder={props.placeholder}
-      onFocus={e => props.onFocus(e.target.value || '')}
-      onInput={e => props.onInput(e.target.value || '')}
-      onKeyPress={props.onKeyPress}
-      aria-describedby={props.ariaDescribedBy}
-    />
+    <span className={generateClassName('component-number-input', selectedClass)}>
+      {getLabel(props.labelText)}
+      <input
+        className="component-number-input__input"
+        type="number"
+        placeholder={props.placeholder}
+        onFocus={e => props.onFocus(e.target.value || '')}
+        onInput={e => props.onInput(e.target.value || '')}
+        onKeyPress={props.onKeyPress}
+        aria-describedby={props.ariaDescribedBy}
+      />
+    </span>
   );
 
 }
+
+
+// ----- Default Props ----- //
+
+NumberInput.defaultProps = {
+  labelText: null,
+};

--- a/assets/components/numberInput/numberInput.scss
+++ b/assets/components/numberInput/numberInput.scss
@@ -1,27 +1,40 @@
 .component-number-input {
 	background-color: #fff;
 	border-radius: 600px;
-	border: none;
 	padding: 6px 0;
 	margin: 3px 0;
 	height: 24px;
-	text-align: center;
 	font-size: 14px;
 	font-family: $gu-text-sans-web;
+	position: relative;
 
 	&::placeholder {
 		color: gu-colour(neutral-1);
 	}
 
-	&:focus {
-		outline: none;
+	.component-number-input__label {
+		position: absolute;
+		top: 7px;
+		left: $gu-h-spacing;
 	}
 
-	// Hides the number spinners.
-	-moz-appearance: textfield;
-	&::-webkit-outer-spin-button,
-	&::-webkit-inner-spin-button {
-		-webkit-appearance: none;
-		margin: 0;
+	.component-number-input__input {
+		border: none;
+		background: transparent;
+		text-align: center;
+		width: 100%;
+		padding: 2px 0;
+
+		&:focus {
+			outline: none;
+		}
+
+		// Hides the number spinners.
+		-moz-appearance: textfield;
+		&::-webkit-outer-spin-button,
+		&::-webkit-inner-spin-button {
+			-webkit-appearance: none;
+			margin: 0;
+		}
 	}
 }

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -215,8 +215,11 @@
 
       .component-number-input--selected {
         background-color: gu-colour(neutral-1);
-        color: #fff;
         font-weight: bold;
+
+        .component-number-input__input, .component-number-input__label {
+          color: #fff;
+        }
 
         &::placeholder {
           font-weight: normal;

--- a/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/assets/pages/contributions-landing/contributionsLanding.scss
@@ -344,7 +344,7 @@
 	.component-number-input--selected {
 		background-color: gu-colour(neutral-1);
 
-	 .component-number-input__input, .component-number-input__label {
+    .component-number-input__input, .component-number-input__label {
 			color: #fff;
 		}
 	}

--- a/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/assets/pages/contributions-landing/contributionsLanding.scss
@@ -334,12 +334,19 @@
 	}
 
 	.component-radio-toggle input:not(:checked)+label, .component-number-input {
-        background-color: gu-colour(comment-support-3);
+    background-color: gu-colour(comment-support-3);
+	}
+
+	.component-number-input__label {
+		top: 11px;
 	}
 
 	.component-number-input--selected {
 		background-color: gu-colour(neutral-1);
-		color: #fff;
+
+	 .component-number-input__input, .component-number-input__label {
+			color: #fff;
+		}
 	}
 
 	.component-cta-link {


### PR DESCRIPTION
## Why are you doing this?

To allow the number input component to have an overlay label, primarily to show currencies. This is best understood with pictures 🖼, please check out the screenshots below.

cc: @Amohkhan

## Changes

- Wrapped the `NumberInput` component in a div, and added an optional span for the overlay.
- Added a `labelText` prop to `NumberInput`.
- Stopped showing the currency in the placeholder.
- Passed through currencies from the files where `NumberInput` is used.
- Updated a bunch of styles to make it look ok across browsers.

## Screenshots

| | Before | After
-|-|-
Bundles Landing | ![bundlanding-before](https://user-images.githubusercontent.com/5131341/32561978-75fe540c-c4a5-11e7-8c60-4c20106b4e81.png) | ![bundlanding-after](https://user-images.githubusercontent.com/5131341/32561987-7cab758c-c4a5-11e7-872e-16fea1b57808.png)
Contributions Landing | ![contlanding-before](https://user-images.githubusercontent.com/5131341/32563245-a5eb0d74-c4a8-11e7-93d3-952bd1ded4eb.png) | ![contlanding-after](https://user-images.githubusercontent.com/5131341/32563251-ab44938a-c4a8-11e7-828c-d3fa02eeea23.png)