### PR TITLE
Shared Contributions Error Message

### DIFF
--- a/assets/components/contribAmounts/contribAmounts.jsx
+++ b/assets/components/contribAmounts/contribAmounts.jsx
@@ -6,16 +6,19 @@ import React from 'react';
 
 import RadioToggle from 'components/radioToggle/radioToggle';
 import NumberInput from 'components/numberInput/numberInput';
+import type { Radio } from 'components/radioToggle/radioToggle';
 import {
   generateClassName,
   clickSubstituteKeyPressHandler,
 } from 'helpers/utilities';
-import { CONFIG as contribConfig } from 'helpers/contributions';
+import { errorMessage as contributionErrorMessage } from 'helpers/contributions';
+
 import type { Contrib, ContribError, Amounts } from 'helpers/contributions';
-import type { Radio } from 'components/radioToggle/radioToggle';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { Currency, IsoCurrency } from 'helpers/internationalisation/currency';
+
 import type { Participations } from '../../helpers/abtest';
+
 
 // ----- Types ----- //
 
@@ -60,7 +63,9 @@ type ContribAttrs = {
   accessibilityHint: string,
 };
 
+
 // ----- Setup ----- //
+
 const amountRadiosAnnual: {
   [IsoCurrency]: Radio[]
 } = {
@@ -266,18 +271,11 @@ function errorMessage(
   currency: Currency,
 ): ?React$Element<any> {
 
-  const limits = contribConfig[contribType];
-
-  const contribErrors: {
-    [ContribError]: string,
-  } = {
-    tooLittle: `Please enter at least ${currency.glyph}${limits.min}`,
-    tooMuch: `We are presently only able to accept contributions of ${currency.glyph}${limits.max} or less`,
-    invalidEntry: 'Please enter a numeric amount',
-  };
-
   if (error) {
-    return <p className="component-contrib-amounts__error-message">{contribErrors[error]}</p>;
+
+    const message = contributionErrorMessage(error, currency, contribType);
+    return <p className="component-contrib-amounts__error-message">{message}</p>;
+
   }
 
   return null;
@@ -332,6 +330,7 @@ function getClassName(contribType: Contrib): string {
       return generateClassName('component-contrib-amounts__amounts', 'one-off');
   }
 }
+
 
 // ----- Component ----- //
 

--- a/assets/helpers/contributions.js
+++ b/assets/helpers/contributions.js
@@ -4,6 +4,9 @@
 
 import { roundDp } from 'helpers/utilities';
 
+import type { Currency } from 'helpers/internationalisation/currency';
+
+
 // ----- Types ----- //
 
 export type Contrib = 'ANNUAL' | 'MONTHLY' | 'ONE_OFF';
@@ -96,4 +99,26 @@ export function billingPeriodFromContrib(contrib: Contrib): BillingPeriod {
     case 'ANNUAL': return 'Annual';
     default: return 'Monthly';
   }
+}
+
+export function errorMessage(
+  error: ContribError,
+  currency: Currency,
+  contributionType: Contrib,
+): string {
+
+  const minContrib = CONFIG[contributionType].min;
+  const maxContrib = CONFIG[contributionType].max;
+
+  switch (error) {
+    case 'tooLittle':
+      return `Please enter at least ${currency.glyph}${minContrib}`;
+    case 'tooMuch':
+      return `We are presently only able to accept contributions of
+        ${currency.glyph}${maxContrib} or less`;
+    case 'invalidEntry':
+    default:
+      return 'Please enter a numeric amount';
+  }
+
 }

--- a/assets/helpers/contributions.js
+++ b/assets/helpers/contributions.js
@@ -45,7 +45,7 @@ type Config = {
 
 // ----- Setup ----- //
 
-export const CONFIG: Config = {
+const config: Config = {
   ANNUAL: {
     min: 50,
     max: 2000,
@@ -73,13 +73,13 @@ export function parse(input: ?string, contrib: Contrib): ParsedContrib {
 
   if (input === undefined || input === null || input === '' || Number.isNaN(numericAmount)) {
     error = 'invalidEntry';
-  } else if (numericAmount < CONFIG[contrib].min) {
+  } else if (numericAmount < config[contrib].min) {
     error = 'tooLittle';
-  } else if (numericAmount > CONFIG[contrib].max) {
+  } else if (numericAmount > config[contrib].max) {
     error = 'tooMuch';
   }
 
-  const amount = error ? CONFIG[contrib].default : roundDp(numericAmount);
+  const amount = error ? config[contrib].default : roundDp(numericAmount);
 
   return { error, amount };
 
@@ -107,8 +107,8 @@ export function errorMessage(
   contributionType: Contrib,
 ): string {
 
-  const minContrib = CONFIG[contributionType].min;
-  const maxContrib = CONFIG[contributionType].max;
+  const minContrib = config[contributionType].min;
+  const maxContrib = config[contributionType].max;
 
   switch (error) {
     case 'tooLittle':


### PR DESCRIPTION
## Why are you doing this?

For Circles we need to be able to re-use the contributions error messages. In the spirit of trying not to touch other parts of the site in the main Circles PRs, this is another side-PR. It pulls the error messages out into the `contributions` shared helper.

## Changes

- Extract contributions error messages out into a function in the `contributions` helper.
- Applied the function in `contribAmounts`.
