### PR TITLE
Add promo codes for just one banner test

### DIFF
--- a/assets/helpers/tracking/acquisitions.js
+++ b/assets/helpers/tracking/acquisitions.js
@@ -42,24 +42,9 @@ const ACQUISITIONS_STORAGE_KEY = 'acquisitionData';
 
 
 // ----- Campaigns ----- //
-
-const easeOfPaymentTestPrefix = 'gdnwb_copts_memco_epic_ease_of_payment';
-
 const campaigns : {
   [string]: string[],
 } = {
-  ease_of_payment_test_currency_symbol_in_cta: [
-    `${easeOfPaymentTestPrefix}_currency_symbol_in_cta`,
-  ],
-  ease_of_payment_test_just_a_minute: [
-    `${easeOfPaymentTestPrefix}_just_a_minute`,
-  ],
-  ease_of_payment_test_just_one_pound: [
-    `${easeOfPaymentTestPrefix}_just_one_pound`,
-  ],
-  ease_of_payment_test_control: [
-    `${easeOfPaymentTestPrefix}_control`,
-  ],
   seven_fifty_middle: [
     'gdnwb_copts_editorial_memco_seven_fifty_middle',
   ],
@@ -68,15 +53,6 @@ const campaigns : {
   ],
   seven_fifty_email: [
     'gdnwb_copts_email_memco_seven_fifty',
-  ],
-  big_long_banner_two_control: [
-    'banner_big_long_two_control',
-  ],
-  big_long_banner_two_big: [
-    'banner_big_long_two_big',
-  ],
-  big_long_banner_two_long: [
-    'banner_big_long_two_long',
   ],
   epic_paradise_paradise_highlight: [
     'gdnwb_copts_memco_epic_paradise_paradise_highlight',
@@ -89,6 +65,12 @@ const campaigns : {
   ],
   epic_paradise_standfirst: [
     'gdnwb_copts_memco_epic_paradise_standfirst',
+  ],
+  banner_just_one_control: [
+    'banner_just_one_control',
+  ],
+  banner_just_one_just_one: [
+    'banner_just_one_just_one',
   ],
 };
 

--- a/assets/pages/bundles-landing/helpers/externalLinks.js
+++ b/assets/pages/bundles-landing/helpers/externalLinks.js
@@ -40,26 +40,6 @@ const defaultPromos: PromoCodes = {
 const customPromos : {
   [Campaign]: PromoCodes,
 } = {
-  ease_of_payment_test_currency_symbol_in_cta: {
-    digital: 'p/DEOPCSICTA',
-    paper: 'p/NEOPCSICTA',
-    paperDig: 'p/NDEOPCSICTA',
-  },
-  ease_of_payment_test_just_a_minute: {
-    digital: 'p/DEOPJAM',
-    paper: 'p/NEOPJAM',
-    paperDig: 'p/NDEOPJAM',
-  },
-  ease_of_payment_test_just_one_pound: {
-    digital: 'p/DEOPJOP',
-    paper: 'p/NEOPJOP',
-    paperDig: 'p/NDEOPJOP',
-  },
-  ease_of_payment_test_control: {
-    digital: 'p/DEOPC',
-    paper: 'p/NEOPC',
-    paperDig: 'p/NDEOPC',
-  },
   seven_fifty_middle: {
     digital: 'p/D750MIDDLE',
     paper: 'p/N750MIDDLE',
@@ -74,21 +54,6 @@ const customPromos : {
     digital: 'p/D750EMAIL',
     paper: 'p/N750EMAIL',
     paperDig: 'p/ND750EMAIL',
-  },
-  big_long_banner_two_control: {
-    digital: 'p/DBIGBANCONT2',
-    paper: 'p/NBIGBANCONT2',
-    paperDig: 'p/NDBIGBANCONT2',
-  },
-  big_long_banner_two_big: {
-    digital: 'p/DBIGBANBIG2',
-    paper: 'p/NBIGBANBIG2',
-    paperDig: 'p/NDBIGBANBIG2',
-  },
-  big_long_banner_two_long: {
-    digital: 'p/DBIGBANLONG2',
-    paper: 'p/NBIGBANLONG2',
-    paperDig: 'p/NDBIGBANLONG2',
   },
   epic_paradise_paradise_highlight: {
     digital: 'p/DPARAHIGH',
@@ -109,6 +74,16 @@ const customPromos : {
     digital: 'p/DPARASTAND',
     paper: 'p/NPARASTAND',
     paperDig: 'p/NDPARASTAND',
+  },
+  banner_just_one_control: {
+    digital: 'p/DBANJUSTCON',
+    paper: 'p/NBANJUSTCON',
+    paperDig: 'p/NDBANJUSTCON',
+  },
+  banner_just_one_just_one: {
+    digital: 'p/DBANJUSTONE',
+    paper: 'p/NBANJUSTONE',
+    paperDig: 'p/NDBANJUSTONE',
   },
 };
 


### PR DESCRIPTION
## Why are you doing this?

To track the Just One Pound banner test.
This PR also clears up some old, unused promo codes

@guardian/contributions 