### PR TITLE
Add sbt dependency graph plugin so that we can run snyk cli

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -17,3 +17,6 @@ addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.3")
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.3")
 
 addSbtPlugin("net.vonbuchholtz" % "sbt-dependency-check" % "0.2.0")
+
+// dependency tracker plugin - needed for snyk cli integration
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.0")


### PR DESCRIPTION
I am evaluating the snyk cli as an alternative way to manage our dependencies through snyk.
This enables more options such as testing dev dependencies for vulnerabilities.

To run the Snyk cli on sbt dependencies you need thethe sbt-dependency-graph plugin to be present in the project.