### PR TITLE
Fix Form Validation On One-Off Checkout With Stripe

### DIFF
--- a/assets/pages/oneoff-contributions/components/oneoffContributionsPayment.jsx
+++ b/assets/pages/oneoff-contributions/components/oneoffContributionsPayment.jsx
@@ -100,7 +100,7 @@ function OneoffContributionsPayment(props: PropTypes, context) {
           props.referrerAcquisitionData,
           context.store.getState,
         )}
-        isValid={formValidation(props.isFormEmpty, props.checkoutError)}
+        canOpen={formValidation(props.isFormEmpty, props.checkoutError)}
         currency={props.currency}
         isTestUser={props.isTestUser}
         amount={props.amount}


### PR DESCRIPTION
## Why are you doing this?

Somewhere along the way, form validation on the one-off checkout was broken. It should prevent the user from opening the Stripe overlay if they've not entered their name and email address. However, currently it doesn't, which is bad because this information is needed by the contributions backend. The request actually fails if the email address is missing!

It looks like the prop that needs to be passed to `StripePopUpButton`, `canOpen`, has been named incorrectly in `oneOffContributionsPayment`. I've updated this and it looks like it's validating correctly again.

## Changes

- Changed `isValid` to `canOpen`.
