### PR TITLE
Fix PayPal Error Message Overlap

### DIFF
--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -126,7 +126,7 @@
       @include mq($from: desktop) {
         margin: 0 ($gu-h-spacing / 2);
         width: 280px;
-        height: 410px;
+        height: 434px;
         display: inline-block;
         vertical-align: top;
         position: relative;
@@ -150,14 +150,13 @@
         }
 
         &.contribute-one_off {
-          bottom: 70px;
+          bottom: 72px;
         }
       }
 
       &.contribute-one_off {
         @include mq($until: desktop) {
-          margin-top: 0;
-          top: 50px;
+          margin-top: 48px;
         }
       }
 
@@ -185,6 +184,7 @@
     .component-bundle--contributions {
       background-color: gu-colour(multimedia-main-2);
       font-size: 14px;
+      position: relative;
       font-family: $gu-text-sans-web;
       color: gu-colour(neutral-1);
 
@@ -226,6 +226,17 @@
           color: #fff;
           opacity: 0.4;
         }
+      }
+    }
+
+    .component-paypal-contribution-button {
+      width: 100%;
+      margin-top: $gu-v-spacing;
+
+      @include mq($from: desktop) {
+        width: 280px;
+        bottom: $gu-v-spacing;
+        position: absolute;
       }
     }
 
@@ -740,18 +751,5 @@
 
   .component-double-heading--variant-a {
     margin-bottom: 0;
-  }
-
-  .component-paypal-contribution-button {
-    margin-top: 64px;
-    width: 100%;
-
-    @include mq(desktop) {
-      margin-top: 80px;
-    }
-  }
-
-  .component-paypal-contribution-button--contrib-error {
-    top: -16px;
   }
 }


### PR DESCRIPTION
## Why are you doing this?

To fix overlapping with the PayPal button, on the bundles landing page, when there's a contribution error. The error messages when the user makes use of the 'other amount' field vary a bit in length, and line wrapping pushes the PayPal button down.

[**Trello Card**](https://trello.com/c/sEmVxXbu/1078-fix-paypal-button-with-long-error-message)

## Changes

- Made the bundles a bit taller on desktop to leave room for the error message.
- Tweaked the PayPal button positioning across the breakpoints to put it in the right place.
- Tweaked the card CTA positioning to work with the new PayPal button.

## Screenshots

| | Before | After
--|--------|-----
Desktop | ![paypal-broken](https://user-images.githubusercontent.com/5131341/32669969-31e1f062-c63a-11e7-9030-febe79049515.png) | ![paypal-fixed](https://user-images.githubusercontent.com/5131341/32670015-565c4d52-c63a-11e7-9c17-8d57e9607fcc.png)
Bundles | ![paypal-broken-wide](https://user-images.githubusercontent.com/5131341/32670233-1388c7d4-c63b-11e7-91c3-afcf7c318357.png) | ![paypal-fixed-wide](https://user-images.githubusercontent.com/5131341/32670246-1dfda810-c63b-11e7-8a36-1e74aa82c1e5.png)
Mobile | ![paypal-broken-mobile](https://user-images.githubusercontent.com/5131341/32670294-446a4b02-c63b-11e7-89d8-3355a77ada12.png) | ![paypal-fixed-mobile](https://user-images.githubusercontent.com/5131341/32670314-4cd8dc04-c63b-11e7-9bf3-cf7d492ea25f.png)