### PR TITLE
Add abtests to subs links

### DIFF
--- a/assets/helpers/page/page.js
+++ b/assets/helpers/page/page.js
@@ -79,9 +79,9 @@ function buildInitialState(
   country: IsoCountry,
   currency: Currency,
 ): CommonState {
-
-  const acquisition = getAcquisition();
-  const otherQueryParams = getQueryParams(['REFPVID', 'INTCMP']);
+  const acquisition = getAcquisition(abParticipations);
+  // note: getQueryParams takes a list of parameters to exclude
+  const otherQueryParams = getQueryParams(['REFPVID', 'INTCMP', 'acquisitionData']);
 
   return Object.assign({}, {
     campaign: acquisition ? getCampaign(acquisition) : null,

--- a/assets/helpers/tracking/acquisitions.js
+++ b/assets/helpers/tracking/acquisitions.js
@@ -24,7 +24,7 @@ export type OphanIds = {|
   browserId: ?string,
 |};
 
-export type ReferrerAcquisitionData = {|
+export type AcquisitionData = {|
   campaignCode: ?string,
   referrerPageviewId: ?string,
   referrerUrl: ?string,
@@ -81,7 +81,7 @@ export type Campaign = $Keys<typeof campaigns>;
 // ----- Functions ----- //
 
 // Retrieves the user's campaign, if known, from the campaign code.
-function getCampaign(acquisition: ReferrerAcquisitionData): ?Campaign {
+function getCampaign(acquisition: AcquisitionData): ?Campaign {
 
   const { campaignCode } = acquisition;
 
@@ -95,7 +95,7 @@ function getCampaign(acquisition: ReferrerAcquisitionData): ?Campaign {
 }
 
 // Stores the acquisition data in sessionStorage.
-function storeAcquisition(referrerAcquisitionData: ReferrerAcquisitionData): boolean {
+function storeAcquisition(referrerAcquisitionData: AcquisitionData): boolean {
 
   try {
 
@@ -111,7 +111,7 @@ function storeAcquisition(referrerAcquisitionData: ReferrerAcquisitionData): boo
 }
 
 // Reads the acquisition data from sessionStorage.
-function readAcquisition(): ?ReferrerAcquisitionData {
+function readAcquisition(): ?AcquisitionData {
 
   const stored = storage.getSession(ACQUISITIONS_STORAGE_KEY);
   return stored ? deserialiseJsonObject(stored) : null;
@@ -135,7 +135,7 @@ const participationsToAcquisitionABTest = (participations: Participations): Acqu
 function buildAcquisition(
   acquisitionData: Object = {},
   abParticipations: Participations,
-): ReferrerAcquisitionData {
+): AcquisitionData {
 
   const referrerPageviewId = acquisitionData.referrerPageviewId ||
     getQueryParameter('REFPVID');
@@ -164,7 +164,7 @@ function buildAcquisition(
 
 // Returns the acquisition metadata, either from query param or sessionStorage.
 // Also stores in sessionStorage if not present or new from param.
-function getAcquisition(abParticipations: Participations): ReferrerAcquisitionData {
+function getAcquisition(abParticipations: Participations): AcquisitionData {
 
   const paramData = deserialiseJsonObject(getQueryParameter(ACQUISITIONS_PARAM) || '');
 

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -361,8 +361,13 @@ function PaperBundle(props: PaperAttrs) {
 
 function Bundles(props: PropTypes) {
 
-  const subsLinks: SubsUrls =
-      getSubsLinks(props.intCmp, props.campaign, props.otherQueryParams, props.abTests);
+  const subsLinks: SubsUrls = getSubsLinks(
+    props.intCmp,
+    props.campaign,
+    props.otherQueryParams,
+    props.abTests,
+    props.referrerAcquisitionData,
+  );
   const paperAttrs: PaperAttrs = getPaperAttrs(subsLinks);
   const digitalAttrs: DigitalAttrs = getDigitalAttrs(subsLinks);
 

--- a/assets/pages/bundles-landing/helpers/externalLinks.js
+++ b/assets/pages/bundles-landing/helpers/externalLinks.js
@@ -4,6 +4,7 @@
 
 import type { Campaign } from 'helpers/tracking/acquisitions';
 import type { Participations } from 'helpers/abtest';
+import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 
 // ----- Types ----- //
 
@@ -100,18 +101,19 @@ function getMemLink(product: MemProduct, intCmp: ?string): string {
 
 }
 
-
 // Creates URLs for the subs site from promo codes and intCmp.
 function buildSubsUrls(
   promoCodes: PromoCodes,
   intCmp: ?string,
   otherQueryParams: Array<[string, string]>,
   abTests: Participations,
+  referrerAcquisitionData: ReferrerAcquisitionData,
 ): SubsUrls {
 
   const params = new URLSearchParams();
   params.append('INTCMP', intCmp || defaultIntCmp);
   otherQueryParams.forEach(p => params.append(p[0], p[1]));
+  params.append('acquisitionsData', JSON.stringify(referrerAcquisitionData));
 
   const paper = `${subsUrl}/${promoCodes.paper}?${params.toString()}`;
   const paperDig = `${subsUrl}/${promoCodes.paperDig}?${params.toString()}`;
@@ -134,13 +136,19 @@ function getSubsLinks(
   campaign: ?Campaign,
   otherQueryParams: Array<[string, string]>,
   abTests: Participations,
+  referrerAcquisitionData: ReferrerAcquisitionData,
 ): SubsUrls {
-
   if (campaign && customPromos[campaign]) {
-    return buildSubsUrls(customPromos[campaign], intCmp, otherQueryParams, abTests);
+    return buildSubsUrls(
+      customPromos[campaign],
+      intCmp,
+      otherQueryParams,
+      abTests,
+      referrerAcquisitionData,
+    );
   }
 
-  return buildSubsUrls(defaultPromos, intCmp, otherQueryParams, abTests);
+  return buildSubsUrls(defaultPromos, intCmp, otherQueryParams, abTests, referrerAcquisitionData);
 
 }
 


### PR DESCRIPTION
## Why are you doing this?

. Renames `ReferrerAcquisitionData` to `AcquisitionData`

. Adds a new attribute `abTests` to the `AcquisitionData` type. 

.When creating the initial state, we populate this new `abTests` attribute with a combination of the the referrer AB test (if one exists) and all the native AB tests

. When creating the links for subs, we no longer pass through the acquisitionsData parameter directly from the url. Rather, we read the data from the state, where it has already been parsed

. The subs links now have both `abTest` and `abTests` attributes within the `acquisitionData` attribute

@guardian/contributions 