### PR TITLE
Support Landing Page - Part 3 - Contribute

### DIFF
--- a/assets/components/errorMessage/errorMessage.scss
+++ b/assets/components/errorMessage/errorMessage.scss
@@ -26,8 +26,6 @@
     fill: #fff;
     top: 50%;
     transform: translateY(-50%);
-
-
   }
 
   span {

--- a/assets/components/svg/svg.jsx
+++ b/assets/components/svg/svg.jsx
@@ -71,7 +71,7 @@ function SvgExclamation() {
 
   return (
     <svg
-      className="svg-credit-card"
+      className="svg-exclamation"
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 2.2 8.9"
       preserveAspectRatio="xMinYMid"

--- a/assets/components/svg/svg.jsx
+++ b/assets/components/svg/svg.jsx
@@ -617,6 +617,21 @@ function SvgGasParticles() {
 
 }
 
+function SvgCross() {
+
+  return (
+    <svg
+      className="svg-cross"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 36 24"
+      preserveAspectRatio="xMinYMid"
+    >
+      <path d="M16.525 19.87L30.865 33 33 30.87 19.9 16.5 33 2.13 30.866 0l-14.34 13.13L2.133.05 0 2.18 13.15 16.5 0 30.82l2.134 2.13" fillRule="evenodd" />
+    </svg>
+  );
+
+}
+
 
 // ----- Exports ----- //
 
@@ -642,4 +657,5 @@ export {
   SvgWallDesktop,
   SvgWallMobile,
   SvgGasParticles,
+  SvgCross,
 };

--- a/assets/helpers/__tests__/contributionsTest.js
+++ b/assets/helpers/__tests__/contributionsTest.js
@@ -1,0 +1,20 @@
+// @flow
+
+// ----- Imports ----- //
+
+import { contribCamelCase } from '../contributions';
+
+
+// ----- Tests ----- //
+
+describe('theGrid', () => {
+
+  it('should correctly return camelCase versions of contributions', () => {
+
+    expect(contribCamelCase('ANNUAL')).toEqual('annual');
+    expect(contribCamelCase('MONTHLY')).toEqual('monthly');
+    expect(contribCamelCase('ONE_OFF')).toEqual('oneOff');
+
+  });
+
+});

--- a/assets/helpers/contributions.js
+++ b/assets/helpers/contributions.js
@@ -145,6 +145,7 @@ function contribCamelCase(contrib: Contrib) {
 // ----- Exports ----- //
 
 export {
+  config,
   parse,
   parseContrib,
   billingPeriodFromContrib,

--- a/assets/helpers/contributions.js
+++ b/assets/helpers/contributions.js
@@ -37,9 +37,9 @@ export type ParsedContrib = {
 type Config = {
   [Contrib]: {
     min: number,
-    spokenMin: string,
+    minInWords: string,
     max: number,
-    spokenMax: string,
+    maxInWords: string,
     default: number,
   }
 }
@@ -50,23 +50,23 @@ type Config = {
 const config: Config = {
   ANNUAL: {
     min: 50,
-    spokenMin: 'fifty',
+    minInWords: 'fifty',
     max: 2000,
-    spokenMax: 'two thousand',
+    maxInWords: 'two thousand',
     default: 75,
   },
   MONTHLY: {
     min: 5,
-    spokenMin: 'five',
+    minInWords: 'five',
     max: 166,
-    spokenMax: 'one hundred and sixty six',
+    maxInWords: 'one hundred and sixty six',
     default: 10,
   },
   ONE_OFF: {
     min: 1,
-    spokenMin: 'one',
+    minInWords: 'one',
     max: 2000,
-    spokenMax: 'two thousand',
+    maxInWords: 'two thousand',
     default: 50,
   },
 };

--- a/assets/helpers/contributions.js
+++ b/assets/helpers/contributions.js
@@ -66,7 +66,7 @@ const config: Config = {
 
 // ----- Functions ----- //
 
-export function parse(input: ?string, contrib: Contrib): ParsedContrib {
+function parse(input: ?string, contrib: Contrib): ParsedContrib {
 
   let error = null;
   const numericAmount = Number(input);
@@ -85,7 +85,7 @@ export function parse(input: ?string, contrib: Contrib): ParsedContrib {
 
 }
 
-export function parseContrib(s: ?string, contrib: Contrib): Contrib {
+function parseContrib(s: ?string, contrib: Contrib): Contrib {
   switch ((s || contrib).toUpperCase()) {
     case 'ANNUAL': return 'ANNUAL';
     case 'MONTHLY': return 'MONTHLY';
@@ -94,14 +94,14 @@ export function parseContrib(s: ?string, contrib: Contrib): Contrib {
   }
 }
 
-export function billingPeriodFromContrib(contrib: Contrib): BillingPeriod {
+function billingPeriodFromContrib(contrib: Contrib): BillingPeriod {
   switch (contrib) {
     case 'ANNUAL': return 'Annual';
     default: return 'Monthly';
   }
 }
 
-export function errorMessage(
+function errorMessage(
   error: ContribError,
   currency: Currency,
   contributionType: Contrib,
@@ -122,3 +122,24 @@ export function errorMessage(
   }
 
 }
+
+function contribCamelCase(contrib: Contrib) {
+
+  switch (contrib) {
+    case 'ANNUAL': return 'annual';
+    case 'MONTHLY': return 'monthly';
+    default: return 'oneOff';
+  }
+
+}
+
+
+// ----- Exports ----- //
+
+export {
+  parse,
+  parseContrib,
+  billingPeriodFromContrib,
+  errorMessage,
+  contribCamelCase,
+};

--- a/assets/helpers/contributions.js
+++ b/assets/helpers/contributions.js
@@ -131,7 +131,7 @@ function errorMessage(
 
 }
 
-function contribCamelCase(contrib: Contrib) {
+function contribCamelCase(contrib: Contrib): string {
 
   switch (contrib) {
     case 'ANNUAL': return 'annual';

--- a/assets/helpers/contributions.js
+++ b/assets/helpers/contributions.js
@@ -37,7 +37,9 @@ export type ParsedContrib = {
 type Config = {
   [Contrib]: {
     min: number,
+    spokenMin: string,
     max: number,
+    spokenMax: string,
     default: number,
   }
 }
@@ -48,17 +50,23 @@ type Config = {
 const config: Config = {
   ANNUAL: {
     min: 50,
+    spokenMin: 'fifty',
     max: 2000,
+    spokenMax: 'two thousand',
     default: 75,
   },
   MONTHLY: {
     min: 5,
+    spokenMin: 'five',
     max: 166,
+    spokenMax: 'one hundred and sixty six',
     default: 10,
   },
   ONE_OFF: {
     min: 1,
+    spokenMin: 'one',
     max: 2000,
+    spokenMax: 'two thousand',
     default: 50,
   },
 };

--- a/assets/pages/bundles-landing/__tests__/__snapshots__/bundlesLandingReducersTest.js.snap
+++ b/assets/pages/bundles-landing/__tests__/__snapshots__/bundlesLandingReducersTest.js.snap
@@ -111,6 +111,7 @@ Object {
     },
   },
   "error": null,
+  "payPalError": "",
   "type": "MONTHLY",
 }
 `;

--- a/assets/pages/bundles-landing/__tests__/__snapshots__/bundlesLandingReducersTest.js.snap
+++ b/assets/pages/bundles-landing/__tests__/__snapshots__/bundlesLandingReducersTest.js.snap
@@ -94,6 +94,17 @@ Object {
 }
 `;
 
+exports[`reducer tests should handle SET_PAYPAL_ERROR 1`] = `"MONTHLY"`;
+
+exports[`reducer tests should handle SET_PAYPAL_ERROR 2`] = `null`;
+
+exports[`reducer tests should handle SET_PAYPAL_ERROR 3`] = `
+Object {
+  "userDefined": false,
+  "value": "10",
+}
+`;
+
 exports[`reducer tests should return the initial state 1`] = `
 Object {
   "amount": Object {

--- a/assets/pages/bundles-landing/__tests__/bundlesLandingReducersTest.js
+++ b/assets/pages/bundles-landing/__tests__/bundlesLandingReducersTest.js
@@ -138,4 +138,19 @@ describe('reducer tests', () => {
     expect(newState.amount.oneOff).toEqual(amount);
     expect(newState.amount.monthly).toMatchSnapshot();
   });
+
+  it('should handle SET_PAYPAL_ERROR', () => {
+
+    const action = {
+      type: 'SET_PAYPAL_ERROR',
+      error: 'I am an error!',
+    };
+
+    const newState = reducer(undefined, action);
+
+    expect(newState.type).toMatchSnapshot();
+    expect(newState.error).toMatchSnapshot();
+    expect(newState.payPalError).toEqual(action.error);
+    expect(newState.amount.monthly).toMatchSnapshot();
+  });
 });

--- a/assets/pages/bundles-landing/bundlesLandingActions.js
+++ b/assets/pages/bundles-landing/bundlesLandingActions.js
@@ -13,7 +13,7 @@ export type Action =
   | { type: 'CHANGE_CONTRIB_AMOUNT_ANNUAL', amount: Amount }
   | { type: 'CHANGE_CONTRIB_AMOUNT_MONTHLY', amount: Amount }
   | { type: 'CHANGE_CONTRIB_AMOUNT_ONEOFF', amount: Amount }
-  | { type: 'SET_PAYPAL_ERROR', error: boolean };
+  | { type: 'SET_PAYPAL_ERROR', error: string };
 
 
 // ----- Actions ----- //
@@ -38,6 +38,6 @@ export function changeContribAmountOneOff(amount: Amount): Action {
   return { type: 'CHANGE_CONTRIB_AMOUNT_ONEOFF', amount };
 }
 
-export function setPayPalError(error: boolean): Action {
+export function setPayPalError(error: string): Action {
   return { type: 'SET_PAYPAL_ERROR', error };
 }

--- a/assets/pages/bundles-landing/bundlesLandingActions.js
+++ b/assets/pages/bundles-landing/bundlesLandingActions.js
@@ -12,7 +12,8 @@ export type Action =
   | { type: 'CHANGE_CONTRIB_AMOUNT', amount: Amount }
   | { type: 'CHANGE_CONTRIB_AMOUNT_ANNUAL', amount: Amount }
   | { type: 'CHANGE_CONTRIB_AMOUNT_MONTHLY', amount: Amount }
-  | { type: 'CHANGE_CONTRIB_AMOUNT_ONEOFF', amount: Amount };
+  | { type: 'CHANGE_CONTRIB_AMOUNT_ONEOFF', amount: Amount }
+  | { type: 'SET_PAYPAL_ERROR', error: boolean };
 
 
 // ----- Actions ----- //
@@ -35,4 +36,8 @@ export function changeContribAmountMonthly(amount: Amount): Action {
 
 export function changeContribAmountOneOff(amount: Amount): Action {
   return { type: 'CHANGE_CONTRIB_AMOUNT_ONEOFF', amount };
+}
+
+export function setPayPalError(error: boolean): Action {
+  return { type: 'SET_PAYPAL_ERROR', error };
 }

--- a/assets/pages/bundles-landing/bundlesLandingReducers.js
+++ b/assets/pages/bundles-landing/bundlesLandingReducers.js
@@ -14,6 +14,7 @@ export type ContribState = {
   type: Contrib,
   error: ?ContribError,
   amount: Amounts,
+  payPalError: boolean,
 };
 
 
@@ -36,6 +37,7 @@ const initialContrib: ContribState = {
       userDefined: false,
     },
   },
+  payPalError: false,
 };
 
 
@@ -106,6 +108,9 @@ function contributionReducer(
         },
         error: parseContribution(action.amount.value, state.type).error,
       });
+
+    case 'SET_PAYPAL_ERROR':
+      return Object.assign({}, state, { payPalError: action.payPalError });
 
     default:
       return state;

--- a/assets/pages/bundles-landing/bundlesLandingReducers.js
+++ b/assets/pages/bundles-landing/bundlesLandingReducers.js
@@ -110,7 +110,7 @@ function contributionReducer(
       });
 
     case 'SET_PAYPAL_ERROR':
-      return Object.assign({}, state, { payPalError: action.payPalError });
+      return Object.assign({}, state, { payPalError: action.error });
 
     default:
       return state;

--- a/assets/pages/bundles-landing/bundlesLandingReducers.js
+++ b/assets/pages/bundles-landing/bundlesLandingReducers.js
@@ -14,7 +14,7 @@ export type ContribState = {
   type: Contrib,
   error: ?ContribError,
   amount: Amounts,
-  payPalError: boolean,
+  payPalError: string,
 };
 
 
@@ -37,7 +37,7 @@ const initialContrib: ContribState = {
       userDefined: false,
     },
   },
-  payPalError: false,
+  payPalError: '',
 };
 
 

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -6,11 +6,14 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import FeatureList from 'components/featureList/featureList';
-import type { ListItem } from 'components/featureList/featureList';
 import CtaLink from 'components/ctaLink/ctaLink';
 import Bundle from 'components/bundle/bundle';
 import ContribAmounts from 'components/contribAmounts/contribAmounts';
 import PayPalContributionButton from 'components/payPalContributionButton/payPalContributionButton';
+import { routes } from 'helpers/routes';
+import { contribCamelCase } from 'helpers/contributions';
+
+import type { ListItem } from 'components/featureList/featureList';
 import type { Contrib, Amounts, ContribError } from 'helpers/contributions';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { IsoCurrency, Currency } from 'helpers/internationalisation/currency';
@@ -18,10 +21,7 @@ import type { Campaign } from 'helpers/tracking/acquisitions';
 import type { Participations } from 'helpers/abtest';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 
-import { routes } from 'helpers/routes';
-
 import CrossProduct from './crossProduct';
-
 import {
   changeContribType,
   changeContribAmount,
@@ -212,14 +212,6 @@ const ctaLinks = {
 
 // ----- Functions ----- //
 
-function getContribKey(contribType: Contrib) {
-  switch (contribType) {
-    case 'ANNUAL': return 'annual';
-    case 'MONTHLY': return 'monthly';
-    default: return 'oneOff';
-  }
-}
-
 const getContribAttrs = (
   contribType: Contrib,
   contribAmount: Amounts,
@@ -228,7 +220,7 @@ const getContribAttrs = (
   intCmp: ?string,
 ): ContribAttrs => {
 
-  const contType = getContribKey(contribType);
+  const contType = contribCamelCase(contribType);
   const params = new URLSearchParams();
 
   params.append('contributionValue', contribAmount[contType].value);

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/contributeNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/contributeNewDesign.jsx
@@ -30,6 +30,7 @@ import {
   changeContribAmountMonthly,
   changeContribAmountOneOff,
   changeContribAmount,
+  setPayPalError,
 } from '../../bundlesLandingActions';
 import {
   getCardLink,
@@ -51,11 +52,13 @@ type PropTypes = {
   contributionError: ContributionError,
   abTests: Participations,
   referrerAcquisitionData: ReferrerAcquisitionData,
+  payPalError: boolean,
   changeContributionType: string => void,
   changeContributionAmountAnnual: string => void,
   changeContributionAmountMonthly: string => void,
   changeContributionAmountOneOff: string => void,
   setContributionCustomAmount: string => void,
+  setPayPalError: boolean => void,
 };
 
 /* eslint-enable react/no-unused-prop-types */
@@ -70,6 +73,9 @@ function mapStateToProps(state) {
     currency: state.common.currency,
     selectedAmount: state.page.amount[contributionTypeCamelCase],
     contributionError: state.page.error,
+    referrerAcquisitionData: state.common.referrerAcquisitionData,
+    abTests: state.common.abParticipations,
+    payPalError: state.page.payPalError,
   };
 
 }
@@ -91,6 +97,9 @@ function mapDispatchToProps(dispatch) {
     },
     setContributionCustomAmount: (value: string) => {
       dispatch(changeContribAmount({ value, userDefined: true }));
+    },
+    setPayPalError: (error: boolean) => {
+      dispatch(setPayPalError(error));
     },
   };
 
@@ -125,7 +134,7 @@ function ctaClick(props: PropTypes) {
 
 }
 
-function paypalButton(props: PropTypes) {
+function payPalButton(props: PropTypes) {
 
   if (props.contributionType === 'ONE_OFF') {
 
@@ -138,6 +147,25 @@ function paypalButton(props: PropTypes) {
       canClick={!props.contributionError}
       buttonText="Contribute with PayPal"
     />);
+
+  }
+
+  return null;
+
+}
+
+function payPalErrorMessage(error: boolean) {
+
+  if (error) {
+
+    return (
+      <div className="payPalErrorDialog">
+        <p className="payPalErrorDialog__message">
+          Sorry, an error occurred, please try again or use another payment
+          method.
+        </p>
+      </div>
+    );
 
   }
 
@@ -179,7 +207,8 @@ function Contribute(props: PropTypes) {
           id="qa-contribute-button"
           accessibilityHint={getCardA11yText(props.contributionType)}
         />
-        {paypalButton(props)}
+        {payPalButton(props)}
+        {payPalErrorMessage(props.payPalError)}
       </InfoSection>
     </div>
   );

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/contributeNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/contributeNewDesign.jsx
@@ -136,7 +136,7 @@ function paypalButton(props: PropTypes) {
       isoCountry={props.country}
       errorHandler={() => {}}
       canClick={!props.contributionError}
-      buttonText="contribute with PayPal"
+      buttonText="Contribute with PayPal"
     />);
 
   }
@@ -167,7 +167,6 @@ function Contribute(props: PropTypes) {
           toggleType={props.changeContributionType}
           setCustomAmount={props.setContributionCustomAmount}
         />
-        {paypalButton(props)}
         <CtaLink
           ctaId="contribute"
           text={getCardCtaText(props.contributionType)}
@@ -175,6 +174,7 @@ function Contribute(props: PropTypes) {
           id="qa-contribute-button"
           accessibilityHint={getCardA11yText(props.contributionType)}
         />
+        {paypalButton(props)}
       </InfoSection>
     </div>
   );

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/contributeNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/contributeNewDesign.jsx
@@ -158,6 +158,10 @@ function Contribute(props: PropTypes) {
         headingContent={<div><Secure /><InlinePaymentLogos /></div>}
       >
         <Secure />
+        <p className="contribute-new-design__description">
+          Support the Guardian&#39;s editorial operations by making a monthly,
+          or one-off contribution today
+        </p>
         <ContributionSelection
           contributionType={props.contributionType}
           country={props.country}

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/contributeNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/contributeNewDesign.jsx
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 
 import InfoSection from 'components/infoSection/infoSection';
 import InlinePaymentLogos from 'components/inlinePaymentLogos/inlinePaymentLogos';
+import Secure from 'components/secure/secure';
 import { contribCamelCase } from 'helpers/contributions';
 
 import type {
@@ -103,8 +104,9 @@ function Contribute(props: PropTypes) {
       <InfoSection
         heading="contribute"
         className="contribute-new-design__content gu-content-margin"
-        headingContent={<InlinePaymentLogos />}
+        headingContent={<div><Secure /><InlinePaymentLogos /></div>}
       >
+        <Secure />
         <ContributionSelection
           contributionType={props.contributionType}
           country={props.country}

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/contributeNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/contributeNewDesign.jsx
@@ -8,7 +8,10 @@ import { connect } from 'react-redux';
 import InfoSection from 'components/infoSection/infoSection';
 import { contribCamelCase } from 'helpers/contributions';
 
-import type { Contrib as ContributionType } from 'helpers/contributions';
+import type {
+  Amount,
+  Contrib as ContributionType,
+} from 'helpers/contributions';
 import type { Currency } from 'helpers/internationalisation/currency';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 
@@ -18,6 +21,7 @@ import {
   changeContribAmountAnnual,
   changeContribAmountMonthly,
   changeContribAmountOneOff,
+  changeContribAmount,
 } from '../../bundlesLandingActions';
 
 
@@ -30,11 +34,12 @@ type PropTypes = {
   contributionType: ContributionType,
   country: IsoCountry,
   currency: Currency,
-  selectedAmount: string,
+  selectedAmount: Amount,
   changeContributionType: string => void,
   changeContributionAmountAnnual: string => void,
   changeContributionAmountMonthly: string => void,
   changeContributionAmountOneOff: string => void,
+  setContributionCustomAmount: string => void,
 };
 
 /* eslint-enable react/no-unused-prop-types */
@@ -47,7 +52,7 @@ function mapStateToProps(state) {
     contributionType: state.page.type,
     country: state.common.country,
     currency: state.common.currency,
-    selectedAmount: state.page.amount[contributionTypeCamelCase].value,
+    selectedAmount: state.page.amount[contributionTypeCamelCase],
   };
 
 }
@@ -66,6 +71,9 @@ function mapDispatchToProps(dispatch) {
     },
     changeContributionAmountOneOff: (value: string) => {
       dispatch(changeContribAmountOneOff({ value, userDefined: false }));
+    },
+    setContributionCustomAmount: (value: string) => {
+      dispatch(changeContribAmount({ value, userDefined: true }));
     },
   };
 
@@ -102,6 +110,7 @@ function Contribute(props: PropTypes) {
           selectedAmount={props.selectedAmount}
           toggleAmount={getAmountToggle(props)}
           toggleType={props.changeContributionType}
+          setCustomAmount={props.setContributionCustomAmount}
         />
       </InfoSection>
     </div>

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/contributeNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/contributeNewDesign.jsx
@@ -6,28 +6,73 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import InfoSection from 'components/infoSection/infoSection';
+import { contribCamelCase } from 'helpers/contributions';
 
 import type { Contrib as ContributionType } from 'helpers/contributions';
 import type { Currency } from 'helpers/internationalisation/currency';
 
 import ContributionSelection from './contributionSelectionNewDesign';
+import {
+  changeContribAmountAnnual,
+  changeContribAmountMonthly,
+  changeContribAmountOneOff,
+} from '../../bundlesLandingActions';
 
 
 // ----- Props ----- //
+
+// Disabling the linter here because it's just buggy...
+/* eslint-disable react/no-unused-prop-types */
 
 type PropTypes = {
   contributionType: ContributionType,
   currency: Currency,
   selectedAmount: string,
+  changeContribAmountAnnual: string => void,
+  changeContribAmountMonthly: string => void,
+  changeContribAmountOneOff: string => void,
 };
 
+/* eslint-enable react/no-unused-prop-types */
+
 function mapStateToProps(state) {
+
+  const contributionTypeCamelCase = contribCamelCase(state.page.type);
 
   return {
     contributionType: state.page.type,
     currency: state.common.currency,
-    selectedAmount: state.page.amount.monthly.value,
+    selectedAmount: state.page.amount[contributionTypeCamelCase].value,
   };
+
+}
+
+function mapDispatchToProps(dispatch) {
+
+  return {
+    changeContribAmountAnnual: (value: string) => {
+      dispatch(changeContribAmountAnnual({ value, userDefined: false }));
+    },
+    changeContribAmountMonthly: (value: string) => {
+      dispatch(changeContribAmountMonthly({ value, userDefined: false }));
+    },
+    changeContribAmountOneOff: (value: string) => {
+      dispatch(changeContribAmountOneOff({ value, userDefined: false }));
+    },
+  };
+
+}
+
+
+// ----- Functions ----- //
+
+function getAmountToggle(props: PropTypes) {
+
+  switch (props.contributionType) {
+    case 'ANNUAL': return props.changeContribAmountAnnual;
+    case 'MONTHLY': return props.changeContribAmountMonthly;
+    default: return props.changeContribAmountOneOff;
+  }
 
 }
 
@@ -38,11 +83,15 @@ function Contribute(props: PropTypes) {
 
   return (
     <div className="contribute-new-design">
-      <InfoSection heading="contribute" className="contribute-new-design__content gu-content-margin">
+      <InfoSection
+        heading="contribute"
+        className="contribute-new-design__content gu-content-margin"
+      >
         <ContributionSelection
           currency={props.currency}
           contributionType={props.contributionType}
           selectedAmount={props.selectedAmount}
+          toggleAmount={getAmountToggle(props)}
         />
       </InfoSection>
     </div>
@@ -53,4 +102,4 @@ function Contribute(props: PropTypes) {
 
 // ----- Exports ----- //
 
-export default connect(mapStateToProps)(Contribute);
+export default connect(mapStateToProps, mapDispatchToProps)(Contribute);

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/contributeNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/contributeNewDesign.jsx
@@ -8,11 +8,13 @@ import { connect } from 'react-redux';
 import InfoSection from 'components/infoSection/infoSection';
 import InlinePaymentLogos from 'components/inlinePaymentLogos/inlinePaymentLogos';
 import Secure from 'components/secure/secure';
+import CtaLink from 'components/ctaLink/ctaLink';
 import { contribCamelCase } from 'helpers/contributions';
 
 import type {
   Amount,
   Contrib as ContributionType,
+  ContribError as ContributionError,
 } from 'helpers/contributions';
 import type { Currency } from 'helpers/internationalisation/currency';
 import type { IsoCountry } from 'helpers/internationalisation/country';
@@ -25,6 +27,7 @@ import {
   changeContribAmountOneOff,
   changeContribAmount,
 } from '../../bundlesLandingActions';
+import { getCardLink } from '../helpers/contributionLinks';
 
 
 // ----- Props ----- //
@@ -37,6 +40,7 @@ type PropTypes = {
   country: IsoCountry,
   currency: Currency,
   selectedAmount: Amount,
+  contributionError: ContributionError,
   changeContributionType: string => void,
   changeContributionAmountAnnual: string => void,
   changeContributionAmountMonthly: string => void,
@@ -55,6 +59,7 @@ function mapStateToProps(state) {
     country: state.common.country,
     currency: state.common.currency,
     selectedAmount: state.page.amount[contributionTypeCamelCase],
+    contributionError: state.page.error,
   };
 
 }
@@ -94,6 +99,22 @@ function getAmountToggle(props: PropTypes) {
 
 }
 
+function ctaClick(props: PropTypes) {
+
+  const linkLocation = getCardLink(
+    props.contributionType,
+    props.selectedAmount,
+    props.currency,
+  );
+
+  return () => {
+    if (!props.contributionError) {
+      window.location = linkLocation;
+    }
+  };
+
+}
+
 
 // ----- Component ----- //
 
@@ -115,6 +136,13 @@ function Contribute(props: PropTypes) {
           toggleAmount={getAmountToggle(props)}
           toggleType={props.changeContributionType}
           setCustomAmount={props.setContributionCustomAmount}
+        />
+        <CtaLink
+          ctaId="contribute"
+          text="contribute with credit/debit"
+          onClick={ctaClick(props)}
+          id="qa-contribute-button"
+          accessibilityHint="contribute with credit or debit card"
         />
       </InfoSection>
     </div>

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/contributeNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/contributeNewDesign.jsx
@@ -3,22 +3,54 @@
 // ----- Imports ----- //
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import InfoSection from 'components/infoSection/infoSection';
+
+import type { Contrib as ContributionType } from 'helpers/contributions';
+import type { Currency } from 'helpers/internationalisation/currency';
 
 import ContributionSelection from './contributionSelectionNewDesign';
 
 
+// ----- Props ----- //
+
+type PropTypes = {
+  contributionType: ContributionType,
+  currency: Currency,
+  selectedAmount: string,
+};
+
+function mapStateToProps(state) {
+
+  return {
+    contributionType: state.page.type,
+    currency: state.common.currency,
+    selectedAmount: state.page.amount.monthly.value,
+  };
+
+}
+
+
 // ----- Component ----- //
 
-export default function Contribute() {
+function Contribute(props: PropTypes) {
 
   return (
     <div className="contribute-new-design">
       <InfoSection heading="contribute" className="contribute-new-design__content gu-content-margin">
-        <ContributionSelection currency={{ iso: 'GBP', glyph: '£' }} contributionType="MONTHLY" />
+        <ContributionSelection
+          currency={props.currency}
+          contributionType={props.contributionType}
+          selectedAmount={props.selectedAmount}
+        />
       </InfoSection>
     </div>
   );
 
 }
+
+
+// ----- Exports ----- //
+
+export default connect(mapStateToProps)(Contribute);

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/contributeNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/contributeNewDesign.jsx
@@ -170,6 +170,7 @@ function Contribute(props: PropTypes) {
           toggleAmount={getAmountToggle(props)}
           toggleType={props.changeContributionType}
           setCustomAmount={props.setContributionCustomAmount}
+          contributionError={props.contributionError}
         />
         <CtaLink
           ctaId="contribute"

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/contributeNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/contributeNewDesign.jsx
@@ -6,6 +6,8 @@ import React from 'react';
 
 import InfoSection from 'components/infoSection/infoSection';
 
+import ContributionSelection from './contributionSelectionNewDesign';
+
 
 // ----- Component ----- //
 
@@ -14,10 +16,7 @@ export default function Contribute() {
   return (
     <div className="contribute-new-design">
       <InfoSection heading="contribute" className="contribute-new-design__content gu-content-margin">
-        <p className="contribute-new-design__copy">
-          Support the Guardian by making a regular or one-off contribution.
-          Every penny funds our fearless, quality journalism
-        </p>
+        <ContributionSelection currency={{ iso: 'GBP', glyph: '£' }} contributionType="MONTHLY" />
       </InfoSection>
     </div>
   );

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/contributeNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/contributeNewDesign.jsx
@@ -24,6 +24,7 @@ import type { Participations } from 'helpers/abtest';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 
 import ContributionSelection from './contributionSelectionNewDesign';
+import GraveError from './graveErrorNewDesign';
 import {
   changeContribType,
   changeContribAmountAnnual,
@@ -58,7 +59,7 @@ type PropTypes = {
   changeContributionAmountMonthly: string => void,
   changeContributionAmountOneOff: string => void,
   setContributionCustomAmount: string => void,
-  setPayPalError: boolean => void,
+  setPayPalError: string => void,
 };
 
 /* eslint-enable react/no-unused-prop-types */
@@ -98,7 +99,7 @@ function mapDispatchToProps(dispatch) {
     setContributionCustomAmount: (value: string) => {
       dispatch(changeContribAmount({ value, userDefined: true }));
     },
-    setPayPalError: (error: boolean) => {
+    setPayPalError: (error: string) => {
       dispatch(setPayPalError(error));
     },
   };
@@ -134,6 +135,20 @@ function ctaClick(props: PropTypes) {
 
 }
 
+function cardButton(props: PropTypes, includeQaId: boolean = true) {
+
+  return (
+    <CtaLink
+      ctaId="contribute"
+      text={getCardCtaText(props.contributionType)}
+      onClick={ctaClick(props)}
+      id={includeQaId ? 'qa-contribute-button' : null}
+      accessibilityHint={getCardA11yText(props.contributionType)}
+    />
+  );
+
+}
+
 function payPalButton(props: PropTypes) {
 
   if (props.contributionType === 'ONE_OFF') {
@@ -143,7 +158,7 @@ function payPalButton(props: PropTypes) {
       abParticipations={props.abTests}
       referrerAcquisitionData={props.referrerAcquisitionData}
       isoCountry={props.country}
-      errorHandler={() => {}}
+      errorHandler={props.setPayPalError}
       canClick={!props.contributionError}
       buttonText="Contribute with PayPal"
     />);
@@ -154,19 +169,15 @@ function payPalButton(props: PropTypes) {
 
 }
 
-function payPalErrorMessage(error: boolean) {
+function payPalErrorMessage(props: PropTypes) {
 
-  if (error) {
-
+  if (props.payPalError) {
     return (
-      <div className="payPalErrorDialog">
-        <p className="payPalErrorDialog__message">
-          Sorry, an error occurred, please try again or use another payment
-          method.
-        </p>
-      </div>
+      <GraveError
+        ctaLink={cardButton(props, false)}
+        onClose={() => props.setPayPalError('')}
+      />
     );
-
   }
 
   return null;
@@ -200,15 +211,9 @@ function Contribute(props: PropTypes) {
           setCustomAmount={props.setContributionCustomAmount}
           contributionError={props.contributionError}
         />
-        <CtaLink
-          ctaId="contribute"
-          text={getCardCtaText(props.contributionType)}
-          onClick={ctaClick(props)}
-          id="qa-contribute-button"
-          accessibilityHint={getCardA11yText(props.contributionType)}
-        />
+        {cardButton(props)}
         {payPalButton(props)}
-        {payPalErrorMessage(props.payPalError)}
+        {payPalErrorMessage(props)}
       </InfoSection>
     </div>
   );

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/contributeNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/contributeNewDesign.jsx
@@ -53,7 +53,7 @@ type PropTypes = {
   contributionError: ContributionError,
   abTests: Participations,
   referrerAcquisitionData: ReferrerAcquisitionData,
-  payPalError: boolean,
+  payPalError: string,
   changeContributionType: string => void,
   changeContributionAmountAnnual: string => void,
   changeContributionAmountMonthly: string => void,

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/contributeNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/contributeNewDesign.jsx
@@ -10,9 +10,11 @@ import { contribCamelCase } from 'helpers/contributions';
 
 import type { Contrib as ContributionType } from 'helpers/contributions';
 import type { Currency } from 'helpers/internationalisation/currency';
+import type { IsoCountry } from 'helpers/internationalisation/country';
 
 import ContributionSelection from './contributionSelectionNewDesign';
 import {
+  changeContribType,
   changeContribAmountAnnual,
   changeContribAmountMonthly,
   changeContribAmountOneOff,
@@ -26,11 +28,13 @@ import {
 
 type PropTypes = {
   contributionType: ContributionType,
+  country: IsoCountry,
   currency: Currency,
   selectedAmount: string,
-  changeContribAmountAnnual: string => void,
-  changeContribAmountMonthly: string => void,
-  changeContribAmountOneOff: string => void,
+  changeContributionType: string => void,
+  changeContributionAmountAnnual: string => void,
+  changeContributionAmountMonthly: string => void,
+  changeContributionAmountOneOff: string => void,
 };
 
 /* eslint-enable react/no-unused-prop-types */
@@ -41,6 +45,7 @@ function mapStateToProps(state) {
 
   return {
     contributionType: state.page.type,
+    country: state.common.country,
     currency: state.common.currency,
     selectedAmount: state.page.amount[contributionTypeCamelCase].value,
   };
@@ -50,13 +55,16 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
 
   return {
-    changeContribAmountAnnual: (value: string) => {
+    changeContributionType: (contributionType: ContributionType) => {
+      dispatch(changeContribType(contributionType));
+    },
+    changeContributionAmountAnnual: (value: string) => {
       dispatch(changeContribAmountAnnual({ value, userDefined: false }));
     },
-    changeContribAmountMonthly: (value: string) => {
+    changeContributionAmountMonthly: (value: string) => {
       dispatch(changeContribAmountMonthly({ value, userDefined: false }));
     },
-    changeContribAmountOneOff: (value: string) => {
+    changeContributionAmountOneOff: (value: string) => {
       dispatch(changeContribAmountOneOff({ value, userDefined: false }));
     },
   };
@@ -69,9 +77,9 @@ function mapDispatchToProps(dispatch) {
 function getAmountToggle(props: PropTypes) {
 
   switch (props.contributionType) {
-    case 'ANNUAL': return props.changeContribAmountAnnual;
-    case 'MONTHLY': return props.changeContribAmountMonthly;
-    default: return props.changeContribAmountOneOff;
+    case 'ANNUAL': return props.changeContributionAmountAnnual;
+    case 'MONTHLY': return props.changeContributionAmountMonthly;
+    default: return props.changeContributionAmountOneOff;
   }
 
 }
@@ -88,10 +96,12 @@ function Contribute(props: PropTypes) {
         className="contribute-new-design__content gu-content-margin"
       >
         <ContributionSelection
-          currency={props.currency}
           contributionType={props.contributionType}
+          country={props.country}
+          currency={props.currency}
           selectedAmount={props.selectedAmount}
           toggleAmount={getAmountToggle(props)}
+          toggleType={props.changeContributionType}
         />
       </InfoSection>
     </div>

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/contributeNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/contributeNewDesign.jsx
@@ -9,6 +9,8 @@ import InfoSection from 'components/infoSection/infoSection';
 import InlinePaymentLogos from 'components/inlinePaymentLogos/inlinePaymentLogos';
 import Secure from 'components/secure/secure';
 import CtaLink from 'components/ctaLink/ctaLink';
+import PayPalContributionButton
+  from 'components/payPalContributionButton/payPalContributionButton';
 import { contribCamelCase } from 'helpers/contributions';
 
 import type {
@@ -18,6 +20,8 @@ import type {
 } from 'helpers/contributions';
 import type { Currency } from 'helpers/internationalisation/currency';
 import type { IsoCountry } from 'helpers/internationalisation/country';
+import type { Participations } from 'helpers/abtest';
+import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 
 import ContributionSelection from './contributionSelectionNewDesign';
 import {
@@ -27,7 +31,11 @@ import {
   changeContribAmountOneOff,
   changeContribAmount,
 } from '../../bundlesLandingActions';
-import { getCardLink } from '../helpers/contributionLinks';
+import {
+  getCardLink,
+  getCardCtaText,
+  getCardA11yText,
+} from '../helpers/contributionLinks';
 
 
 // ----- Props ----- //
@@ -41,6 +49,8 @@ type PropTypes = {
   currency: Currency,
   selectedAmount: Amount,
   contributionError: ContributionError,
+  abTests: Participations,
+  referrerAcquisitionData: ReferrerAcquisitionData,
   changeContributionType: string => void,
   changeContributionAmountAnnual: string => void,
   changeContributionAmountMonthly: string => void,
@@ -115,6 +125,26 @@ function ctaClick(props: PropTypes) {
 
 }
 
+function paypalButton(props: PropTypes) {
+
+  if (props.contributionType === 'ONE_OFF') {
+
+    return (<PayPalContributionButton
+      amount={Number(props.selectedAmount.value)}
+      abParticipations={props.abTests}
+      referrerAcquisitionData={props.referrerAcquisitionData}
+      isoCountry={props.country}
+      errorHandler={() => {}}
+      canClick={!props.contributionError}
+      buttonText="contribute with PayPal"
+    />);
+
+  }
+
+  return null;
+
+}
+
 
 // ----- Component ----- //
 
@@ -137,12 +167,13 @@ function Contribute(props: PropTypes) {
           toggleType={props.changeContributionType}
           setCustomAmount={props.setContributionCustomAmount}
         />
+        {paypalButton(props)}
         <CtaLink
           ctaId="contribute"
-          text="contribute with credit/debit"
+          text={getCardCtaText(props.contributionType)}
           onClick={ctaClick(props)}
           id="qa-contribute-button"
-          accessibilityHint="contribute with credit or debit card"
+          accessibilityHint={getCardA11yText(props.contributionType)}
         />
       </InfoSection>
     </div>

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/contributeNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/contributeNewDesign.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import InfoSection from 'components/infoSection/infoSection';
+import InlinePaymentLogos from 'components/inlinePaymentLogos/inlinePaymentLogos';
 import { contribCamelCase } from 'helpers/contributions';
 
 import type {
@@ -102,6 +103,7 @@ function Contribute(props: PropTypes) {
       <InfoSection
         heading="contribute"
         className="contribute-new-design__content gu-content-margin"
+        headingContent={<InlinePaymentLogos />}
       >
         <ContributionSelection
           contributionType={props.contributionType}

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/contributionSelectionNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/contributionSelectionNewDesign.jsx
@@ -6,9 +6,11 @@ import React from 'react';
 
 import RadioToggle from 'components/radioToggle/radioToggle';
 
+import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { Currency } from 'helpers/internationalisation/currency';
 import type { Contrib as ContributionType } from 'helpers/contributions';
 
+import { getContributionTypes } from '../helpers/contributionTypes';
 import { getContributionAmounts } from '../helpers/contributionAmounts';
 
 
@@ -16,9 +18,11 @@ import { getContributionAmounts } from '../helpers/contributionAmounts';
 
 type PropTypes = {
   contributionType: ContributionType,
+  country: IsoCountry,
   currency: Currency,
   selectedAmount: string,
   toggleAmount: string => void,
+  toggleType: string => void,
 };
 
 
@@ -30,7 +34,15 @@ export default function ContributionSelection(props: PropTypes) {
     <div className="component-contribution-selection">
       <div className="component-contribution-selection__contribution-type">
         <RadioToggle
-          name="contributions-amount-toggle"
+          name="contribution-type-toggle"
+          radios={getContributionTypes(props.country)}
+          checked={props.contributionType}
+          toggleAction={props.toggleType}
+        />
+      </div>
+      <div className="component-contribution-selection__contribution-amount">
+        <RadioToggle
+          name="contribution-amount-toggle"
           radios={getContributionAmounts(props.contributionType, props.currency)}
           checked={props.selectedAmount}
           toggleAction={props.toggleAmount}

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/contributionSelectionNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/contributionSelectionNewDesign.jsx
@@ -1,0 +1,34 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+import type { Currency } from 'helpers/internationalisation/currency';
+import type { Contrib as ContributionType } from 'helpers/contributions';
+
+import { getContributionAmounts } from '../helpers/contributionAmounts';
+
+
+// ----- Types ----- //
+
+type PropTypes = {
+  contributionType: ContributionType,
+  currency: Currency,
+};
+
+
+// ----- Exports ----- //
+
+export default function ContributionSelection(props: PropTypes) {
+
+  return (
+    <div className="component-contribution-selection">
+      <div className="component-contribution-selection__contribution-type">
+        {getContributionAmounts(props.contributionType, props.currency).map(amount =>
+          <p>{amount.text}</p>)}
+      </div>
+    </div>
+  );
+
+}

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/contributionSelectionNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/contributionSelectionNewDesign.jsx
@@ -14,8 +14,12 @@ import type {
   Amount,
   Contrib as ContributionType,
 } from 'helpers/contributions';
+import { generateClassName } from 'helpers/utilities';
 
-import { getContributionTypes } from '../helpers/contributionTypes';
+import {
+  getClassName as getContributionTypeClassName,
+  getContributionTypes,
+} from '../helpers/contributionTypes';
 import {
   getCustomAmountA11yHint,
   getContributionAmounts,
@@ -35,12 +39,24 @@ type PropTypes = {
 };
 
 
+// ----- Functions ----- //
+
+function getClassName(contributionType: ContributionType) {
+
+  return generateClassName(
+    'component-contribution-selection',
+    getContributionTypeClassName(contributionType),
+  );
+
+}
+
+
 // ----- Exports ----- //
 
 export default function ContributionSelection(props: PropTypes) {
 
   return (
-    <div className="component-contribution-selection">
+    <div className={getClassName(props.contributionType)}>
       <div className="component-contribution-selection__type">
         <RadioToggle
           name="contribution-type-toggle"

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/contributionSelectionNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/contributionSelectionNewDesign.jsx
@@ -17,6 +17,7 @@ import { getContributionAmounts } from '../helpers/contributionAmounts';
 type PropTypes = {
   contributionType: ContributionType,
   currency: Currency,
+  selectedAmount: string,
 };
 
 
@@ -30,7 +31,7 @@ export default function ContributionSelection(props: PropTypes) {
         <RadioToggle
           name="contributions-amount-toggle"
           radios={getContributionAmounts(props.contributionType, props.currency)}
-          checked={null}
+          checked={props.selectedAmount}
           toggleAction={() => {}}
         />
       </div>

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/contributionSelectionNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/contributionSelectionNewDesign.jsx
@@ -4,6 +4,8 @@
 
 import React from 'react';
 
+import RadioToggle from 'components/radioToggle/radioToggle';
+
 import type { Currency } from 'helpers/internationalisation/currency';
 import type { Contrib as ContributionType } from 'helpers/contributions';
 
@@ -25,8 +27,12 @@ export default function ContributionSelection(props: PropTypes) {
   return (
     <div className="component-contribution-selection">
       <div className="component-contribution-selection__contribution-type">
-        {getContributionAmounts(props.contributionType, props.currency).map(amount =>
-          <p>{amount.text}</p>)}
+        <RadioToggle
+          name="contributions-amount-toggle"
+          radios={getContributionAmounts(props.contributionType, props.currency)}
+          checked={null}
+          toggleAction={() => {}}
+        />
       </div>
     </div>
   );

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/contributionSelectionNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/contributionSelectionNewDesign.jsx
@@ -6,13 +6,15 @@ import React from 'react';
 
 import RadioToggle from 'components/radioToggle/radioToggle';
 import NumberInput from 'components/numberInput/numberInput';
-import { clickSubstituteKeyPressHandler } from 'helpers/utilities';
+import ErrorMessage from 'components/errorMessage/errorMessage';
 
+import { clickSubstituteKeyPressHandler } from 'helpers/utilities';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { Currency } from 'helpers/internationalisation/currency';
 import type {
   Amount,
   Contrib as ContributionType,
+  ContribError as ContributionError,
 } from 'helpers/contributions';
 import { generateClassName } from 'helpers/utilities';
 
@@ -36,6 +38,7 @@ type PropTypes = {
   toggleAmount: string => void,
   toggleType: string => void,
   setCustomAmount: string => void,
+  contributionError: ContributionError,
 };
 
 
@@ -47,6 +50,16 @@ function getClassName(contributionType: ContributionType) {
     'component-contribution-selection',
     getContributionTypeClassName(contributionType),
   );
+
+}
+
+function showError(error: ContributionError) {
+
+  if (error) {
+    return <ErrorMessage message={error} />;
+  }
+
+  return null;
 
 }
 
@@ -85,6 +98,7 @@ export default function ContributionSelection(props: PropTypes) {
         <p className="accessibility-hint" id="component-contribution-selection__custom-amount-a11y">
           {getCustomAmountA11yHint(props.contributionType, props.country, props.currency)}
         </p>
+        {showError(props.contributionError)}
       </div>
     </div>
   );

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/contributionSelectionNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/contributionSelectionNewDesign.jsx
@@ -5,13 +5,21 @@
 import React from 'react';
 
 import RadioToggle from 'components/radioToggle/radioToggle';
+import NumberInput from 'components/numberInput/numberInput';
+import { clickSubstituteKeyPressHandler } from 'helpers/utilities';
 
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { Currency } from 'helpers/internationalisation/currency';
-import type { Contrib as ContributionType } from 'helpers/contributions';
+import type {
+  Amount,
+  Contrib as ContributionType,
+} from 'helpers/contributions';
 
 import { getContributionTypes } from '../helpers/contributionTypes';
-import { getContributionAmounts } from '../helpers/contributionAmounts';
+import {
+  getCustomAmountA11yHint,
+  getContributionAmounts,
+} from '../helpers/contributionAmounts';
 
 
 // ----- Types ----- //
@@ -20,9 +28,10 @@ type PropTypes = {
   contributionType: ContributionType,
   country: IsoCountry,
   currency: Currency,
-  selectedAmount: string,
+  selectedAmount: Amount,
   toggleAmount: string => void,
   toggleType: string => void,
+  setCustomAmount: string => void,
 };
 
 
@@ -32,7 +41,7 @@ export default function ContributionSelection(props: PropTypes) {
 
   return (
     <div className="component-contribution-selection">
-      <div className="component-contribution-selection__contribution-type">
+      <div className="component-contribution-selection__type">
         <RadioToggle
           name="contribution-type-toggle"
           radios={getContributionTypes(props.country)}
@@ -40,13 +49,26 @@ export default function ContributionSelection(props: PropTypes) {
           toggleAction={props.toggleType}
         />
       </div>
-      <div className="component-contribution-selection__contribution-amount">
+      <div className="component-contribution-selection__amount">
         <RadioToggle
           name="contribution-amount-toggle"
           radios={getContributionAmounts(props.contributionType, props.currency)}
-          checked={props.selectedAmount}
+          checked={props.selectedAmount.value}
           toggleAction={props.toggleAmount}
         />
+      </div>
+      <div className="component-contribution-selection__custom-amount">
+        <NumberInput
+          onFocus={props.setCustomAmount}
+          onInput={props.setCustomAmount}
+          selected={props.selectedAmount.userDefined}
+          placeholder={`Other amount (${props.currency.glyph})`}
+          onKeyPress={clickSubstituteKeyPressHandler(() => {})}
+          ariaDescribedBy="component-contribution-selection__custom-amount-a11y"
+        />
+        <p className="accessibility-hint" id="component-contribution-selection__custom-amount-a11y">
+          {getCustomAmountA11yHint(props.contributionType, props.country, props.currency)}
+        </p>
       </div>
     </div>
   );

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/contributionSelectionNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/contributionSelectionNewDesign.jsx
@@ -18,6 +18,7 @@ type PropTypes = {
   contributionType: ContributionType,
   currency: Currency,
   selectedAmount: string,
+  toggleAmount: string => void,
 };
 
 
@@ -32,7 +33,7 @@ export default function ContributionSelection(props: PropTypes) {
           name="contributions-amount-toggle"
           radios={getContributionAmounts(props.contributionType, props.currency)}
           checked={props.selectedAmount}
-          toggleAction={() => {}}
+          toggleAction={props.toggleAmount}
         />
       </div>
     </div>

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/contributionSelectionNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/contributionSelectionNewDesign.jsx
@@ -9,6 +9,8 @@ import NumberInput from 'components/numberInput/numberInput';
 import ErrorMessage from 'components/errorMessage/errorMessage';
 
 import { clickSubstituteKeyPressHandler } from 'helpers/utilities';
+import { errorMessage as contributionsErrorMessage } from 'helpers/contributions';
+
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { Currency } from 'helpers/internationalisation/currency';
 import type {
@@ -53,10 +55,17 @@ function getClassName(contributionType: ContributionType) {
 
 }
 
-function showError(error: ContributionError) {
+function showError(
+  error: ContributionError,
+  currency: Currency,
+  contributionType: ContributionType,
+) {
 
   if (error) {
-    return <ErrorMessage message={error} />;
+
+    const message = contributionsErrorMessage(error, currency, contributionType);
+    return <ErrorMessage message={message} />;
+
   }
 
   return null;
@@ -91,14 +100,15 @@ export default function ContributionSelection(props: PropTypes) {
           onFocus={props.setCustomAmount}
           onInput={props.setCustomAmount}
           selected={props.selectedAmount.userDefined}
-          placeholder={`Other amount (${props.currency.glyph})`}
+          placeholder="Other amount"
           onKeyPress={clickSubstituteKeyPressHandler(() => {})}
           ariaDescribedBy="component-contribution-selection__custom-amount-a11y"
+          labelText={props.currency.glyph}
         />
         <p className="accessibility-hint" id="component-contribution-selection__custom-amount-a11y">
           {getCustomAmountA11yHint(props.contributionType, props.country, props.currency)}
         </p>
-        {showError(props.contributionError)}
+        {showError(props.contributionError, props.currency, props.contributionType)}
       </div>
     </div>
   );

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/graveErrorNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/graveErrorNewDesign.jsx
@@ -1,0 +1,40 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+import { SvgCross } from 'components/svg/svg';
+
+import type { Node } from 'react';
+
+
+// ----- Props ----- //
+
+type PropTypes = {
+  ctaLink: Node,
+  onClose: () => void,
+};
+
+
+// ----- Component ----- //
+
+export default function GraveError(props: PropTypes) {
+
+  return (
+    <div className="grave-error">
+      <div className="grave-error__message">
+        <div className="grave-error__close" onClick={props.onClose}>
+          <SvgCross />
+        </div>
+        <h1 className="grave-error__heading">We&#39;re sorry</h1>
+        <p className="grave-error__copy">
+          Your contribution using PayPal could not be processed.
+          Please try again or contribute by credit/debit card.
+        </p>
+        {props.ctaLink}
+      </div>
+    </div>
+  );
+
+}

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/graveErrorNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/graveErrorNewDesign.jsx
@@ -24,9 +24,9 @@ export default function GraveError(props: PropTypes) {
   return (
     <div className="grave-error">
       <div className="grave-error__message">
-        <div className="grave-error__close" onClick={props.onClose}>
+        <button className="grave-error__close" onClick={props.onClose}>
           <SvgCross />
-        </div>
+        </button>
         <h1 className="grave-error__heading">We&#39;re sorry</h1>
         <p className="grave-error__copy">
           Your contribution using PayPal could not be processed.

--- a/assets/pages/bundles-landing/support-landing-ab-test/helpers/contributionAmounts.js
+++ b/assets/pages/bundles-landing/support-landing-ab-test/helpers/contributionAmounts.js
@@ -87,7 +87,7 @@ function getContributionAmounts(
   return amounts[contributionType][currency.iso].map(amount => ({
     value: amount.value,
     text: `${currency.glyph}${amount.value}`,
-    a11yHint: getA11yHint(contributionType, currency.iso, amount.spoken),
+    accessibilityHint: getA11yHint(contributionType, currency.iso, amount.spoken),
   }));
 
 }

--- a/assets/pages/bundles-landing/support-landing-ab-test/helpers/contributionAmounts.js
+++ b/assets/pages/bundles-landing/support-landing-ab-test/helpers/contributionAmounts.js
@@ -2,19 +2,27 @@
 
 // ----- Imports ----- //
 
+import { CONFIG as contributionConfig } from 'helpers/contributions';
+
 import type { Contrib as ContributionType } from 'helpers/contributions';
 import type { Radio } from 'components/radioToggle/radioToggle';
-import type {
-  Currency,
-  IsoCurrency,
-} from 'helpers/internationalisation/currency';
+import type { Currency } from 'helpers/internationalisation/currency';
+import type { IsoCountry } from 'helpers/internationalisation/country';
+
+import { getSpokenType } from './contributionTypes';
 
 
 // ----- Setup ----- //
 
 const spokenCurrencies = {
-  GBP: 'pounds',
-  USD: 'dollars',
+  GBP: {
+    singular: 'pound',
+    plural: 'pounds',
+  },
+  USD: {
+    singular: 'dollar',
+    plural: 'dollars',
+  },
 };
 
 const amounts = {
@@ -63,11 +71,11 @@ const amounts = {
 
 function getA11yHint(
   contributionType: ContributionType,
-  currency: IsoCurrency,
+  currency: Currency,
   spokenAmount: string,
 ): string {
 
-  const spokenCurrency = spokenCurrencies[currency];
+  const spokenCurrency = spokenCurrencies[currency.iso].plural;
 
   if (contributionType === 'ONE_OFF') {
     return `make a one-off contribution of ${spokenAmount} ${spokenCurrency}`;
@@ -79,6 +87,24 @@ function getA11yHint(
 
 }
 
+function getCustomAmountA11yHint(
+  contributionType: ContributionType,
+  country: IsoCountry,
+  currency: Currency,
+): string {
+
+  let spokenCurrency = spokenCurrencies[currency.iso].plural;
+
+  if (contributionType === 'ONE_OFF') {
+    spokenCurrency = spokenCurrencies[currency.iso].singular;
+  }
+
+  return `Enter an amount of ${contributionConfig[contributionType].spokenMin} 
+    ${spokenCurrency} or more for your 
+    ${getSpokenType(contributionType, country)} contribution.`;
+
+}
+
 function getContributionAmounts(
   contributionType: ContributionType,
   currency: Currency,
@@ -87,7 +113,7 @@ function getContributionAmounts(
   return amounts[contributionType][currency.iso].map(amount => ({
     value: amount.value,
     text: `${currency.glyph}${amount.value}`,
-    accessibilityHint: getA11yHint(contributionType, currency.iso, amount.spoken),
+    accessibilityHint: getA11yHint(contributionType, currency, amount.spoken),
   }));
 
 }
@@ -96,5 +122,6 @@ function getContributionAmounts(
 // ----- Exports ----- //
 
 export {
+  getCustomAmountA11yHint,
   getContributionAmounts,
 };

--- a/assets/pages/bundles-landing/support-landing-ab-test/helpers/contributionAmounts.js
+++ b/assets/pages/bundles-landing/support-landing-ab-test/helpers/contributionAmounts.js
@@ -99,7 +99,7 @@ function getCustomAmountA11yHint(
     spokenCurrency = spokenCurrencies[currency.iso].singular;
   }
 
-  return `Enter an amount of ${contributionConfig[contributionType].spokenMin} 
+  return `Enter an amount of ${contributionConfig[contributionType].minInWords}
     ${spokenCurrency} or more for your 
     ${getSpokenType(contributionType, country)} contribution.`;
 

--- a/assets/pages/bundles-landing/support-landing-ab-test/helpers/contributionAmounts.js
+++ b/assets/pages/bundles-landing/support-landing-ab-test/helpers/contributionAmounts.js
@@ -2,7 +2,7 @@
 
 // ----- Imports ----- //
 
-import { CONFIG as contributionConfig } from 'helpers/contributions';
+import { config as contributionConfig } from 'helpers/contributions';
 
 import type { Contrib as ContributionType } from 'helpers/contributions';
 import type { Radio } from 'components/radioToggle/radioToggle';

--- a/assets/pages/bundles-landing/support-landing-ab-test/helpers/contributionAmounts.js
+++ b/assets/pages/bundles-landing/support-landing-ab-test/helpers/contributionAmounts.js
@@ -3,6 +3,7 @@
 // ----- Imports ----- //
 
 import type { Contrib as ContributionType } from 'helpers/contributions';
+import type { Radio } from 'components/radioToggle/radioToggle';
 import type {
   Currency,
   IsoCurrency,
@@ -81,7 +82,7 @@ function getA11yHint(
 function getContributionAmounts(
   contributionType: ContributionType,
   currency: Currency,
-) {
+): Radio[] {
 
   return amounts[contributionType][currency.iso].map(amount => ({
     value: amount.value,

--- a/assets/pages/bundles-landing/support-landing-ab-test/helpers/contributionAmounts.js
+++ b/assets/pages/bundles-landing/support-landing-ab-test/helpers/contributionAmounts.js
@@ -1,0 +1,99 @@
+// @flow
+
+// ----- Imports ----- //
+
+import type { Contrib as ContributionType } from 'helpers/contributions';
+import type {
+  Currency,
+  IsoCurrency,
+} from 'helpers/internationalisation/currency';
+
+
+// ----- Setup ----- //
+
+const spokenCurrencies = {
+  GBP: 'pounds',
+  USD: 'dollars',
+};
+
+const amounts = {
+  ONE_OFF: {
+    GBP: [
+      { value: '25', spoken: 'twenty five' },
+      { value: '50', spoken: 'fifty' },
+      { value: '100', spoken: 'one hundred' },
+      { value: '250', spoken: 'two hundred and fifty' },
+    ],
+    USD: [
+      { value: '25', spoken: 'twenty five' },
+      { value: '50', spoken: 'fifty' },
+      { value: '100', spoken: 'one hundred' },
+      { value: '250', spoken: 'two hundred and fifty' },
+    ],
+  },
+  MONTHLY: {
+    GBP: [
+      { value: '5', spoken: 'five' },
+      { value: '10', spoken: 'ten' },
+      { value: '20', spoken: 'twenty' },
+    ],
+    USD: [
+      { value: '5', spoken: 'five' },
+      { value: '10', spoken: 'ten' },
+      { value: '20', spoken: 'twenty' },
+    ],
+  },
+  ANNUAL: {
+    GBP: [
+      { value: '50', spoken: 'fifty' },
+      { value: '75', spoken: 'seventy five' },
+      { value: '100', spoken: 'one hundred' },
+    ],
+    USD: [
+      { value: '50', spoken: 'fifty' },
+      { value: '75', spoken: 'seventy five' },
+      { value: '100', spoken: 'one hundred' },
+    ],
+  },
+};
+
+
+// ----- Functions ----- //
+
+function getA11yHint(
+  contributionType: ContributionType,
+  currency: IsoCurrency,
+  spokenAmount: string,
+): string {
+
+  const spokenCurrency = spokenCurrencies[currency];
+
+  if (contributionType === 'ONE_OFF') {
+    return `make a one-off contribution of ${spokenAmount} ${spokenCurrency}`;
+  } else if (contributionType === 'MONTHLY') {
+    return `contribute ${spokenAmount} ${spokenCurrency} per month`;
+  }
+
+  return `contribute ${spokenAmount} ${spokenCurrency} annually`;
+
+}
+
+function getContributionAmounts(
+  contributionType: ContributionType,
+  currency: Currency,
+) {
+
+  return amounts[contributionType][currency.iso].map(amount => ({
+    value: amount.value,
+    text: `${currency.glyph}${amount.value}`,
+    a11yHint: getA11yHint(contributionType, currency.iso, amount.spoken),
+  }));
+
+}
+
+
+// ----- Exports ----- //
+
+export {
+  getContributionAmounts,
+};

--- a/assets/pages/bundles-landing/support-landing-ab-test/helpers/contributionLinks.js
+++ b/assets/pages/bundles-landing/support-landing-ab-test/helpers/contributionLinks.js
@@ -1,0 +1,47 @@
+// @flow
+
+// ----- Imports ----- //
+
+import { routes } from 'helpers/routes';
+
+import type {
+  Amount,
+  Contrib as ContributionType,
+} from 'helpers/contributions';
+import type { Currency } from 'helpers/internationalisation/currency';
+
+
+// ----- Functions ----- //
+
+function getCheckoutUrl(contributionType: ContributionType) {
+
+  if (contributionType === 'ONE_OFF') {
+    return routes.oneOffContribCheckout;
+  }
+
+  return routes.recurringContribCheckout;
+
+}
+
+function getCardLink(
+  contributionType: ContributionType,
+  amount: Amount,
+  currency: Currency,
+) {
+
+  const params = new URLSearchParams();
+
+  params.append('contributionValue', amount.value);
+  params.append('contribType', contributionType);
+  params.append('currency', currency.iso);
+
+  return `${getCheckoutUrl(contributionType)}?${params.toString()}`;
+
+}
+
+
+// ----- Exports ----- //
+
+export {
+  getCardLink,
+};

--- a/assets/pages/bundles-landing/support-landing-ab-test/helpers/contributionLinks.js
+++ b/assets/pages/bundles-landing/support-landing-ab-test/helpers/contributionLinks.js
@@ -42,10 +42,10 @@ function getCardLink(
 function getCardCtaText(contributionType: ContributionType) {
 
   if (contributionType === 'ONE_OFF') {
-    return 'contribute with credit/debit';
+    return 'Contribute with credit/debit';
   }
 
-  return 'contribute with credit/debit or PayPal';
+  return 'Contribute with credit/debit or PayPal';
 
 }
 

--- a/assets/pages/bundles-landing/support-landing-ab-test/helpers/contributionLinks.js
+++ b/assets/pages/bundles-landing/support-landing-ab-test/helpers/contributionLinks.js
@@ -39,9 +39,31 @@ function getCardLink(
 
 }
 
+function getCardCtaText(contributionType: ContributionType) {
+
+  if (contributionType === 'ONE_OFF') {
+    return 'contribute with credit/debit';
+  }
+
+  return 'contribute with credit/debit or PayPal';
+
+}
+
+function getCardA11yText(contributionType: ContributionType) {
+
+  if (contributionType === 'ONE_OFF') {
+    return 'contribute with credit or debit card';
+  }
+
+  return 'contribute with credit or debit card, or with PayPal';
+
+}
+
 
 // ----- Exports ----- //
 
 export {
   getCardLink,
+  getCardCtaText,
+  getCardA11yText,
 };

--- a/assets/pages/bundles-landing/support-landing-ab-test/helpers/contributionTypes.js
+++ b/assets/pages/bundles-landing/support-landing-ab-test/helpers/contributionTypes.js
@@ -3,24 +3,46 @@
 // ----- Imports ----- //
 
 import type { IsoCountry } from 'helpers/internationalisation/country';
+import type { Contrib as ContributionType } from 'helpers/contributions';
 
 
 // ----- Functions ----- //
 
-function getContributionTypes(country: IsoCountry) {
+function getOneOffName(country: IsoCountry) {
+  return country === 'US' ? 'One-time' : 'One-off';
+}
 
-  const oneOffName = country === 'US' ? 'One-time' : 'One-off';
+function getOneOffSpokenName(country: IsoCountry) {
+  return country === 'US' ? 'one time' : 'one off';
+}
+
+function getSpokenType(
+  contributionType: ContributionType,
+  country: IsoCountry,
+) {
+
+  if (contributionType === 'ONE_OFF') {
+    return getOneOffSpokenName(country);
+  } else if (contributionType === 'MONTHLY') {
+    return 'monthly';
+  }
+
+  return 'annual';
+
+}
+
+function getContributionTypes(country: IsoCountry) {
 
   return [
     {
       value: 'MONTHLY',
       text: 'Monthly',
-      accessibilityHint: 'Make a regular Monthly contribution',
+      accessibilityHint: 'Make a regular monthly contribution',
     },
     {
       value: 'ONE_OFF',
-      text: oneOffName,
-      accessibilityHint: `Make a ${oneOffName} contribution`,
+      text: getOneOffName(country),
+      accessibilityHint: `Make a ${getOneOffSpokenName(country)} contribution`,
     },
   ];
 
@@ -30,5 +52,6 @@ function getContributionTypes(country: IsoCountry) {
 // ----- Exports ----- //
 
 export {
+  getSpokenType,
   getContributionTypes,
 };

--- a/assets/pages/bundles-landing/support-landing-ab-test/helpers/contributionTypes.js
+++ b/assets/pages/bundles-landing/support-landing-ab-test/helpers/contributionTypes.js
@@ -1,0 +1,34 @@
+// @flow
+
+// ----- Imports ----- //
+
+import type { IsoCountry } from 'helpers/internationalisation/country';
+
+
+// ----- Functions ----- //
+
+function getContributionTypes(country: IsoCountry) {
+
+  const oneOffName = country === 'US' ? 'One-time' : 'One-off';
+
+  return [
+    {
+      value: 'MONTHLY',
+      text: 'Monthly',
+      accessibilityHint: 'Make a regular Monthly contribution',
+    },
+    {
+      value: 'ONE_OFF',
+      text: oneOffName,
+      accessibilityHint: `Make a ${oneOffName} contribution`,
+    },
+  ];
+
+}
+
+
+// ----- Exports ----- //
+
+export {
+  getContributionTypes,
+};

--- a/assets/pages/bundles-landing/support-landing-ab-test/helpers/contributionTypes.js
+++ b/assets/pages/bundles-landing/support-landing-ab-test/helpers/contributionTypes.js
@@ -31,6 +31,18 @@ function getSpokenType(
 
 }
 
+function getClassName(contributionType: ContributionType) {
+
+  if (contributionType === 'ONE_OFF') {
+    return 'one-off';
+  } else if (contributionType === 'MONTHLY') {
+    return 'monthly';
+  }
+
+  return 'annual';
+
+}
+
 function getContributionTypes(country: IsoCountry) {
 
   return [
@@ -53,5 +65,6 @@ function getContributionTypes(country: IsoCountry) {
 
 export {
   getSpokenType,
+  getClassName,
   getContributionTypes,
 };

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -374,7 +374,7 @@
     .component-contribution-selection__custom-amount {
       vertical-align: top;
       margin-top: $gu-v-spacing * 2;
-      margin-bottom: $gu-v-spacing * 2;
+      margin-bottom: $gu-v-spacing * 4;
       display: block;
       position: relative;
 
@@ -382,6 +382,7 @@
         display: inline-block;
         margin-left: 24px;
         margin-top: $gu-v-spacing;
+        margin-bottom: $gu-v-spacing * 2;
       }
 
       .component-number-input {
@@ -411,12 +412,16 @@
       }
 
       .component-error-message {
+        position: absolute;
         background-color: inherit;
         color: gu-colour(error);
-        height: 20px;
-        margin-top: 3px;
-        margin-bottom: 0;
-        position: absolute;
+        height: 36px;
+        box-sizing: border-box;
+        padding: 0;
+
+        span {
+          left: 40px;
+        }
       }
 
       .svg-exclamation {
@@ -424,17 +429,18 @@
         border-radius: 600px;
         height: 13px;
         padding: 3px 8px;
+        left: 15px;
       }
     }
 
     .component-contribution-selection--monthly {
-      .component-number-input {
+      .component-number-input, .component-error-message {
         width: 305px;
       }
     }
 
     .component-contribution-selection--one-off {
-      .component-number-input {
+      .component-number-input, .component-error-message {
         width: 249px;
       }
     }

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -213,7 +213,7 @@
 
     .contribute-new-design__content {
       background-color: #fff;
-      border-top: none;
+      border-color: gu-colour(light-yellow);
       color: gu-colour(neutral-2);
 
       .component-secure {

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -296,6 +296,13 @@
       }
     }
 
+    .contribute-new-design__description {
+      font-family: $gu-text-egyptian-web;
+      font-size: 18px;
+      line-height: 22px;
+      width: 600px;
+    }
+
     .component-inline-payment-logos {
       float: none;
       height: 25px;
@@ -323,7 +330,7 @@
       font-size: 14px;
       line-height: 14px;
       padding: 15px 0;
-      margin: $gu-v-spacing 0;
+      margin: ($gu-v-spacing * 2) 0 $gu-v-spacing;
 
       .component-radio-toggle {
         display: inline;

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -216,10 +216,6 @@
       border-color: gu-colour(light-yellow);
       color: gu-colour(neutral-2);
 
-      .component-secure {
-        
-      }
-
       .component-info-section__header {
         position: relative;
 
@@ -239,6 +235,31 @@
 
         @include mq($until: desktop) {
           display: none;
+        }
+      }
+
+      .component-cta-link {
+        height: 60px;
+        line-height: 60px;
+        background-color: gu-colour(comment-main-2);
+        color: gu-colour(neutral-1);
+        font-size: 16px;
+        font-weight: bold;
+        padding-left: 28px;
+
+        &:hover {
+          background-color: darken(gu-colour(comment-main-2), 5%);
+        }
+
+        @include mq($from: tablet) {
+          width: 600px;
+        }
+
+        .svg-arrow-right-straight {
+          top: 22px;
+          right: 22px;
+          height: 38%;
+          fill: gu-colour(neutral-1);
         }
       }
     }
@@ -312,6 +333,7 @@
       font-size: 16px;
       line-height: 16px;
       margin-top: $gu-v-spacing;
+      margin-bottom: $gu-v-spacing * 3;
       display: block;
 
       @include mq($from: phablet) {

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -373,7 +373,6 @@
 
     .component-contribution-selection__custom-amount {
       vertical-align: top;
-      font-size: 14px;
       margin-top: $gu-v-spacing * 2;
       margin-bottom: $gu-v-spacing * 2;
       display: block;
@@ -388,14 +387,27 @@
       .component-number-input {
         background-color: #fff;
         border: 1px solid gu-colour(comment-main-2);
-        font-size: 14px;
         padding: 0;
         margin: 0;
         height: 42px;
       }
 
+      .component-number-input__input {
+        font-size: 14px;
+        line-height: 36px;
+        color: gu-colour(neutral-1);
+      }
+
+      .component-number-input__label {
+        line-height: 28px;
+      }
+
       .component-number-input--selected {
         background-color: gu-colour(comment-main-2);
+
+        .component-number-input__label {
+          color: gu-colour(neutral-1);
+        }
       }
 
       .component-error-message {

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -208,11 +208,38 @@
     // ----- Contribute
 
     .contribute-new-design {
-      background-color: darken(gu-colour(multimedia-main-2), 5%);
+      background-color: darken(#fff, 5%);
     }
 
     .contribute-new-design__content {
-      background-color: gu-colour(multimedia-main-2);
+      background-color: #fff;
+      border-top: none;
+    }
+
+    .component-contribution-selection__amount, .component-contribution-selection__type {
+
+      .component-radio-toggle label {
+        border: 1px solid gu-colour(comment-main-2);
+        background-color: gu-colour(comment-main-2);
+      }
+
+      .component-radio-toggle input:not(:checked)+label {
+        background-color: #fff;
+      }
+
+    }
+
+    .component-contribution-selection__custom-amount {
+
+      .component-number-input {
+        background-color: #fff;
+        border: 1px solid gu-colour(comment-main-2);
+      }
+
+      .component-number-input--selected {
+        background-color: gu-colour(comment-main-2);
+      }
+
     }
 
     // ----- Subscribe

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -217,6 +217,14 @@
       color: gu-colour(neutral-2);
     }
 
+    .component-inline-payment-logos {
+      float: none;
+
+      svg {
+        margin: 0 ($gu-h-spacing / 2) 0 0;
+      }
+    }
+
     .component-contribution-selection__amount, .component-contribution-selection__type {
       .component-radio-toggle__label {
         background-color: #fff;
@@ -234,7 +242,7 @@
       font-size: 16px;
       line-height: 16px;
       padding: ($gu-v-spacing + 1) 0;
-      margin-bottom: $gu-v-spacing;
+      margin: $gu-v-spacing 0;
 
       .component-radio-toggle {
         display: inline;

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -295,9 +295,11 @@
 
     .component-inline-payment-logos {
       float: none;
+      height: 25px;
+      margin-top: 8px;
 
       svg {
-        margin: 0 ($gu-h-spacing / 2) 0 0;
+        width: 36px;
       }
     }
 

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -462,6 +462,9 @@
       right: 8px;
       height: 34px;
       width: 30px;
+      border: none;
+      background: transparent;
+      padding: 0;
       fill: #fff;
 
       &:hover {

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -239,13 +239,16 @@
       }
 
       .component-cta-link {
-        height: 60px;
-        line-height: 60px;
+        height: 62px;
+        line-height: 62px;
         background-color: gu-colour(comment-main-2);
         color: gu-colour(neutral-1);
         font-size: 16px;
         font-weight: bold;
         padding-left: 28px;
+        padding-top: 0;
+        padding-bottom: 0;
+        box-sizing: border-box;
 
         &:hover {
           background-color: darken(gu-colour(comment-main-2), 5%);
@@ -256,10 +259,36 @@
         }
 
         .svg-arrow-right-straight {
-          top: 22px;
-          right: 22px;
-          height: 38%;
+          top: 20px;
+          right: 16px;
+          height: 35%;
           fill: gu-colour(neutral-1);
+        }
+      }
+
+      .component-paypal-contribution-button {
+        height: 60px;
+        border-color: #012169;
+        color: #012169;
+        font-size: 16px;
+        font-family: $gu-text-sans-web;
+        width: 100%;
+        margin-top: $gu-v-spacing;
+
+        @include mq($from: tablet) {
+          width: 600px;
+        }
+
+        .svg-arrow-right-straight {
+          fill: #012169;
+        }
+
+        .paypal-p-logo-0, .paypal-p-logo-2 {
+          fill: #012169;
+        }
+
+        .paypal-p-logo-1 {
+          fill: #009cde;
         }
       }
     }

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -219,7 +219,6 @@
 
     .component-contribution-selection__amount, .component-contribution-selection__type {
       .component-radio-toggle__label {
-        border: 1px solid gu-colour(comment-main-2);
         background-color: #fff;
       }
 
@@ -234,6 +233,19 @@
     .component-contribution-selection__type {
       font-size: 16px;
       line-height: 16px;
+      padding: ($gu-v-spacing + 1) 0;
+      margin-bottom: $gu-v-spacing;
+
+      .component-radio-toggle {
+        display: inline;
+        border: 1px solid gu-colour(comment-main-2);
+        border-radius: 600px;
+        padding: $gu-v-spacing 0;
+      }
+
+      .component-radio-toggle__label {
+        padding: $gu-v-spacing $gu-h-spacing;
+      }
     }
 
     .component-contribution-selection__amount {
@@ -241,16 +253,19 @@
       vertical-align: top;
       font-size: 18px;
       line-height: 18px;
+      margin-top: $gu-v-spacing;
 
       @include mq($until: phablet) {
-        border-top: 2px dotted gu-colour(neutral-2);
+        border-top: 2px dotted gu-colour(neutral-3);
         width: 100%;
         padding-top: $gu-v-spacing;
+        margin-top: $gu-v-spacing * 2;
       }
 
       .component-radio-toggle__label {
         display: inline-block;
         text-align: center;
+        border: 1px solid gu-colour(comment-main-2);
         line-height: 60px;
         width: 60px;
         height: 60px;
@@ -268,7 +283,6 @@
       @include mq($from: phablet) {
         display: inline-block;
         margin-left: $gu-h-spacing / 2;
-        margin-top: 0;
       }
 
       .component-number-input {

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -476,9 +476,19 @@
     }
 
     .grave-error__message {
-      width: 40%;
-      margin-left: 21%;
-      margin-top: 100px;
+      margin-top: 120px;
+      padding: 0 ($gu-h-spacing / 2);
+
+      @include mq($from: mobileLandscape) {
+        padding: 0 $gu-h-spacing;
+      }
+
+      @include mq($from: desktop) {
+        margin-top: 100px;
+        padding: 0;
+        width: 40%;
+        margin-left: 21%;
+      }
     }
 
     .grave-error__heading {

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -255,7 +255,7 @@
         }
 
         @include mq($from: tablet) {
-          width: 600px;
+          width: 620px;
         }
 
         .svg-arrow-right-straight {
@@ -276,7 +276,7 @@
         margin-top: $gu-v-spacing;
 
         @include mq($from: tablet) {
-          width: 600px;
+          width: 620px;
         }
 
         .svg-arrow-right-straight {

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -300,7 +300,10 @@
       font-family: $gu-text-egyptian-web;
       font-size: 18px;
       line-height: 22px;
-      width: 600px;
+
+      @include mq($from: tablet) {
+        width: 600px;
+      }
     }
 
     .component-inline-payment-logos {
@@ -371,12 +374,13 @@
     .component-contribution-selection__custom-amount {
       vertical-align: top;
       font-size: 14px;
-      margin-top: $gu-v-spacing;
+      margin-top: $gu-v-spacing * 2;
       display: block;
 
       @include mq($from: phablet) {
         display: inline-block;
         margin-left: 24px;
+        margin-top: $gu-v-spacing;
       }
 
       .component-number-input {

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -375,7 +375,9 @@
       vertical-align: top;
       font-size: 14px;
       margin-top: $gu-v-spacing * 2;
+      margin-bottom: $gu-v-spacing * 2;
       display: block;
+      position: relative;
 
       @include mq($from: phablet) {
         display: inline-block;
@@ -396,6 +398,21 @@
         background-color: gu-colour(comment-main-2);
       }
 
+      .component-error-message {
+        background-color: inherit;
+        color: gu-colour(error);
+        height: 20px;
+        margin-top: 3px;
+        margin-bottom: 0;
+        position: absolute;
+      }
+
+      .svg-exclamation {
+        background-color: gu-colour(error);
+        border-radius: 600px;
+        height: 13px;
+        padding: 3px 8px;
+      }
     }
 
     .component-contribution-selection--monthly {

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -239,48 +239,51 @@
       }
 
       .component-cta-link {
-        height: 62px;
-        line-height: 62px;
+        height: 54px;
+        line-height: 54px;
         background-color: gu-colour(comment-main-2);
         color: gu-colour(neutral-1);
-        font-size: 16px;
+        font-size: 14px;
         font-weight: bold;
-        padding-left: 28px;
+        padding-left: 20px;
         padding-top: 0;
         padding-bottom: 0;
         box-sizing: border-box;
+        margin-top: $gu-v-spacing * 2;
 
         &:hover {
           background-color: darken(gu-colour(comment-main-2), 5%);
         }
 
         @include mq($from: tablet) {
-          width: 620px;
+          width: 500px;
         }
 
         .svg-arrow-right-straight {
-          top: 20px;
+          top: 18px;
           right: 16px;
-          height: 35%;
+          height: 33%;
           fill: gu-colour(neutral-1);
         }
       }
 
       .component-paypal-contribution-button {
-        height: 60px;
+        height: 52px;
         border-color: #012169;
         color: #012169;
-        font-size: 16px;
+        font-size: 14px;
         font-family: $gu-text-sans-web;
         width: 100%;
         margin-top: $gu-v-spacing;
 
         @include mq($from: tablet) {
-          width: 620px;
+          width: 500px;
         }
 
         .svg-arrow-right-straight {
           fill: #012169;
+          height: 35%;
+          right: 11px;
         }
 
         .paypal-p-logo-0, .paypal-p-logo-2 {
@@ -317,28 +320,27 @@
     }
 
     .component-contribution-selection__type {
-      font-size: 16px;
-      line-height: 16px;
-      padding: ($gu-v-spacing + 1) 0;
+      font-size: 14px;
+      line-height: 14px;
+      padding: 15px 0;
       margin: $gu-v-spacing 0;
 
       .component-radio-toggle {
         display: inline;
         border: 1px solid gu-colour(comment-main-2);
         border-radius: 600px;
-        padding: $gu-v-spacing 0;
+        padding: 13px 0;
       }
 
       .component-radio-toggle__label {
-        padding: $gu-v-spacing $gu-h-spacing;
+        padding: 13px $gu-h-spacing;
       }
     }
 
     .component-contribution-selection__amount {
       display: inline-block;
       vertical-align: top;
-      font-size: 18px;
-      line-height: 18px;
+      font-size: 14px;
       margin-top: $gu-v-spacing;
 
       @include mq($until: phablet) {
@@ -352,39 +354,49 @@
         display: inline-block;
         text-align: center;
         border: 1px solid gu-colour(comment-main-2);
-        line-height: 60px;
-        width: 60px;
-        height: 60px;
-        margin-right: $gu-h-spacing / 2;
+        line-height: 42px;
+        width: 42px;
+        height: 42px;
+        margin-right: 12px;
       }
     }
 
     .component-contribution-selection__custom-amount {
       vertical-align: top;
-      font-size: 16px;
-      line-height: 16px;
+      font-size: 14px;
       margin-top: $gu-v-spacing;
-      margin-bottom: $gu-v-spacing * 3;
       display: block;
 
       @include mq($from: phablet) {
         display: inline-block;
-        margin-left: $gu-h-spacing / 2;
+        margin-left: 24px;
       }
 
       .component-number-input {
         background-color: #fff;
         border: 1px solid gu-colour(comment-main-2);
-        font-size: 16px;
+        font-size: 14px;
         padding: 0;
         margin: 0;
-        height: 60px;
+        height: 42px;
       }
 
       .component-number-input--selected {
         background-color: gu-colour(comment-main-2);
       }
 
+    }
+
+    .component-contribution-selection--monthly {
+      .component-number-input {
+        width: 305px;
+      }
+    }
+
+    .component-contribution-selection--one-off {
+      .component-number-input {
+        width: 249px;
+      }
     }
 
     // ----- Subscribe

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -214,26 +214,70 @@
     .contribute-new-design__content {
       background-color: #fff;
       border-top: none;
+      color: gu-colour(neutral-2);
     }
 
     .component-contribution-selection__amount, .component-contribution-selection__type {
-
-      .component-radio-toggle label {
+      .component-radio-toggle__label {
         border: 1px solid gu-colour(comment-main-2);
-        background-color: gu-colour(comment-main-2);
+        background-color: #fff;
       }
 
-      .component-radio-toggle input:not(:checked)+label {
-        background-color: #fff;
+      .component-radio-toggle__input:checked+.component-radio-toggle__label {
+        background-color: gu-colour(comment-main-2);
+        font-weight: bold;
+        color: gu-colour(neutral-1);
       }
 
     }
 
+    .component-contribution-selection__type {
+      font-size: 16px;
+      line-height: 16px;
+    }
+
+    .component-contribution-selection__amount {
+      display: inline-block;
+      vertical-align: top;
+      font-size: 18px;
+      line-height: 18px;
+
+      @include mq($until: phablet) {
+        border-top: 2px dotted gu-colour(neutral-2);
+        width: 100%;
+        padding-top: $gu-v-spacing;
+      }
+
+      .component-radio-toggle__label {
+        display: inline-block;
+        text-align: center;
+        line-height: 60px;
+        width: 60px;
+        height: 60px;
+        margin-right: $gu-h-spacing / 2;
+      }
+    }
+
     .component-contribution-selection__custom-amount {
+      vertical-align: top;
+      font-size: 16px;
+      line-height: 16px;
+      margin-top: $gu-v-spacing;
+      display: block;
+
+      @include mq($from: phablet) {
+        display: inline-block;
+        margin-left: $gu-h-spacing / 2;
+        margin-top: 0;
+      }
 
       .component-number-input {
         background-color: #fff;
         border: 1px solid gu-colour(comment-main-2);
+        font-size: 16px;
+        padding: 0;
+        margin: 0;
+        height: 60px;
       }
 
       .component-number-input--selected {

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -215,6 +215,32 @@
       background-color: #fff;
       border-top: none;
       color: gu-colour(neutral-2);
+
+      .component-secure {
+        
+      }
+
+      .component-info-section__header {
+        position: relative;
+
+        .component-secure {
+          position: absolute;
+          top: 10px;
+          right: 0;
+
+          @include mq($from: desktop) {
+            display: none;
+          }
+        }
+      }
+
+      .component-info-section__content .component-secure {
+        float: right;
+
+        @include mq($until: desktop) {
+          display: none;
+        }
+      }
     }
 
     .component-inline-payment-logos {

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -215,6 +215,7 @@
       background-color: #fff;
       border-color: gu-colour(light-yellow);
       color: gu-colour(neutral-2);
+      position: relative;
 
       .component-info-section__header {
         position: relative;
@@ -443,6 +444,56 @@
       .component-number-input, .component-error-message {
         width: 249px;
       }
+    }
+
+    .grave-error {
+      position: absolute;
+      top: 0;
+      left: 0;
+      height: 100%;
+      width: 100%;
+      background-color: rgba(black, 0.98);
+      color: #fff;
+    }
+
+    .grave-error__close {
+      position: absolute;
+      top: 5px;
+      right: 8px;
+      height: 34px;
+      width: 30px;
+      fill: #fff;
+
+      &:hover {
+        fill: darken(#fff, 10%);
+        cursor: pointer;
+      }
+
+      .svg-cross {
+        height: 100%;
+        width: 100%;
+      }
+    }
+
+    .grave-error__message {
+      width: 40%;
+      margin-left: 21%;
+      margin-top: 100px;
+    }
+
+    .grave-error__heading {
+      font-size: 36px;
+      line-height: 36px;
+      font-family: $gu-egyptian-web;
+      font-weight: bold;
+    }
+
+    .grave-error__copy {
+      font-size: 18px;
+      line-height: 20px;
+      font-family: $gu-text-egyptian-web;
+      margin: $gu-v-spacing 0;
+      width: 80%;
     }
 
     // ----- Subscribe


### PR DESCRIPTION
## Why are you doing this?

This is the next instalment of the support landing page, following on from #299 and #312. This time I'm adding the contribute section, the last major component to go in. It takes a lot of functionality from the existing contribute component in the current bundles landing page (actions, reducers etc.).

[**Trello Card**](https://trello.com/c/UNAXgpkS/1030-support-landing-contribute-bundle)

cc: @Amohkhan

## Changes (In Diff Order)

- Fixed an incorrectly named svg (`svg-exclamation`).
- Added a new `cross` svg.
- Added spoken versions of the max and min contributions, for a11y.
- Switched the `contributions` helper to the new export format.
- Added new function for retrieving contribution types in camelCase.
- Created new piece of state on the bundles landing page for handling a PayPal error, because we have the PayPal button for one-off contributions now.
- Tidied up the `Bundles` component, and made use of the new camelCase helper.
- Added `contributeNewDesign` as the component that displays the 'contribute' section.
- Added `contributionSelectionNewDesign` for managing the amount selection within the contribution component.
- Added a `graveError` component for showing the PayPal error.
- Added a helper (`contributionAmounts`) for managing the contribution amounts and their corresponding a11y messages.
- Added a helper (`contributionLinks`) for managing the contribution CTA links and their corresponding a11y messages.
- Added a helper (`contributionTypes`) for managing the craziness around contributions types and their a11y messages.
- Styled it all with a bunch of CSS.

## Screenshots

### Desktop

 ![contribute-monthly](https://user-images.githubusercontent.com/5131341/32740810-0bda50f8-c89c-11e7-96db-f8c3d02c5d47.png)

![contribute-oneoff](https://user-images.githubusercontent.com/5131341/32740817-10925226-c89c-11e7-8578-3b8cf005bec2.png)

### Mobile

Monthly | One-off
-- | --
![mobile-monthly](https://user-images.githubusercontent.com/5131341/32778094-8304cf02-c930-11e7-9c7c-5821cebca535.png) | ![mobile-oneoff](https://user-images.githubusercontent.com/5131341/32778095-8325c568-c930-11e7-878f-edcd195ba260.png)

### Error States

![contribute-grave](https://user-images.githubusercontent.com/5131341/32740888-546c3d40-c89c-11e7-956c-4139bd3e5530.png)
![contribute-notnumeric](https://user-images.githubusercontent.com/5131341/32740891-54c3a18e-c89c-11e7-9dfe-61a6654e0a63.png)
![contribute-lowerror](https://user-images.githubusercontent.com/5131341/32740890-54ae0ab8-c89c-11e7-8fa1-bf268eebf5fa.png)
![contribute-higherror](https://user-images.githubusercontent.com/5131341/32740889-54907f7a-c89c-11e7-9def-7e2c719c9b96.png)
