### PR TITLE
Revert "Add two new fields to the data layer to help with Krux targeting"

### DIFF
--- a/assets/helpers/tracking/googleTagManager.js
+++ b/assets/helpers/tracking/googleTagManager.js
@@ -58,8 +58,5 @@ export function init() {
     orderId: getDataValue('orderId', uuidv4),
     currency: getDataValue('currency', getCurrency),
     value: getContributionValue(),
-    // Used by Krux for targeting
-    site: 'Support',
-    path: window.location.pathname,
   });
 }


### PR DESCRIPTION
Reverts guardian/support-frontend#360

It turns out that this wasn't needed after all, Krux can extract this information without an explicit data layer