### PR TITLE
Add referrer data to landing page upsell cta

### DIFF
--- a/assets/components/ctaLink/ctaLink.jsx
+++ b/assets/components/ctaLink/ctaLink.jsx
@@ -6,8 +6,10 @@ import React from 'react';
 import { SvgArrowRightStraight } from 'components/svg/svg';
 import { clickSubstituteKeyPressHandler } from 'helpers/utilities';
 import uuidv4 from 'uuid';
+import { addQueryParamToURL } from 'helpers/url';
 
 import type { Node } from 'react';
+import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 
 
 // ----- Types ----- //
@@ -23,6 +25,7 @@ type PropTypes = {
   id?: ?string,
   svg?: Node,
   dataLinkName?: ?string,
+  acquisitionData?: ?ReferrerAcquisitionData,
 };
 
 // ----- Component ----- //
@@ -31,12 +34,16 @@ export default function CtaLink(props: PropTypes) {
 
   const accessibilityHintId = props.id ? `accessibility-hint-${props.id}` : uuidv4();
   const ctaUniqueClassName = `component-cta-link ${props.ctaId}`;
+  const urlString = props.url || '';
 
   return (
     <a
       id={props.id}
       className={ctaUniqueClassName}
-      href={props.url}
+      href={props.acquisitionData ?
+        addQueryParamToURL(urlString, 'acquisitionData', JSON.stringify(props.acquisitionData))
+         : props.url
+      }
       onClick={
         () => {
           if (props.trackComponentEvent) {
@@ -71,4 +78,5 @@ CtaLink.defaultProps = {
   id: null,
   dataLinkName: null,
   svg: <SvgArrowRightStraight />,
+  acquisitionData: null,
 };

--- a/assets/components/trackedComponent/trackedComponent.jsx
+++ b/assets/components/trackedComponent/trackedComponent.jsx
@@ -5,6 +5,7 @@
 import * as React from 'react';
 import { trackComponentEvents } from 'helpers/tracking/ophanComponentEventTracking';
 import type { OphanComponent, OphanAction } from 'helpers/tracking/ophanComponentEventTracking';
+import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 
 // ----- Prop Types ----- //
 
@@ -31,11 +32,22 @@ class TrackedComponent extends React.Component<Props> {
 
   render() {
 
+    const acquisitionData: ReferrerAcquisitionData = {
+      referrerPageviewId: undefined,
+      referrerUrl: undefined,
+      campaignCode: this.props.component.campaignCode,
+      componentId: this.props.component.id,
+      componentType: 'ACQUISITIONS_OTHER',
+      source: 'GUARDIAN_WEB',
+      abTest: undefined,
+    };
+
     const childrenWithProps = React.Children.map(
       this.props.children,
       child => React.cloneElement(child, {
         trackComponentEvent: (eventName: OphanAction, id: string) =>
           trackComponentEvents(eventName, this.props.component, id),
+        acquisitionData,
       }),
     );
 

--- a/assets/components/trackedComponent/trackedComponent.jsx
+++ b/assets/components/trackedComponent/trackedComponent.jsx
@@ -34,7 +34,7 @@ class TrackedComponent extends React.Component<Props> {
 
     const acquisitionData: ReferrerAcquisitionData = {
       referrerPageviewId: undefined,
-      referrerUrl: undefined,
+      referrerUrl: window.location.href,
       campaignCode: this.props.component.campaignCode,
       componentId: this.props.component.id,
       componentType: 'ACQUISITIONS_OTHER',

--- a/assets/pages/contributions-thankyou/oneoffContributionsThankyou.jsx
+++ b/assets/pages/contributions-thankyou/oneoffContributionsThankyou.jsx
@@ -15,7 +15,7 @@ import { renderPage } from 'helpers/render';
 import { detect as detectCountry } from 'helpers/internationalisation/country';
 import { detect as detectCurrency } from 'helpers/internationalisation/currency';
 import TrackedComponent from 'components/trackedComponent/trackedComponent';
-import { getAcquisition } from 'helpers/tracking/acquisitions';
+import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 
 // ----- Page Startup ----- //
 
@@ -26,7 +26,6 @@ const upSellCampaignCode = 'oneoff-thankyou-page-recurring-upsell';
 const country = detectCountry();
 const currency = detectCurrency(country);
 
-const acquisitionData = getAcquisition()
 
 // ----- Render ----- //
 
@@ -58,7 +57,7 @@ const content = (
             <CtaLink
               ctaId="make-a-recurring-contribution"
               text={`Contribute ${currency.glyph}5 a month`}
-              url={`/contribute/recurring?contributionValue=5&contribType=MONTHLY&currency=${currency.iso}&INTCMP=${upSellCampaignCode}&acquisitionData=${JSON.stringify(acquisitionData)}`}
+              url={`/contribute/recurring?contributionValue=5&contribType=MONTHLY&currency=${currency.iso}&INTCMP=${upSellCampaignCode}`}
               accessibilityHint={`Contribute from ${currency.glyph}5 a month`}
             />
           </TrackedComponent>

--- a/assets/pages/contributions-thankyou/oneoffContributionsThankyou.jsx
+++ b/assets/pages/contributions-thankyou/oneoffContributionsThankyou.jsx
@@ -48,7 +48,7 @@ const content = (
             componentType: 'ACQUISITIONS_OTHER',
             id: 'oneoff-thankyou-page-recurring-upsell',
             products: ['RECURRING_CONTRIBUTION'],
-            upSellCampaignCode,
+            campaignCode: upSellCampaignCode,
             labels: [],
           }}
           >

--- a/assets/pages/contributions-thankyou/oneoffContributionsThankyou.jsx
+++ b/assets/pages/contributions-thankyou/oneoffContributionsThankyou.jsx
@@ -15,7 +15,6 @@ import { renderPage } from 'helpers/render';
 import { detect as detectCountry } from 'helpers/internationalisation/country';
 import { detect as detectCurrency } from 'helpers/internationalisation/currency';
 import TrackedComponent from 'components/trackedComponent/trackedComponent';
-import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 
 // ----- Page Startup ----- //
 
@@ -25,7 +24,6 @@ const upSellCampaignCode = 'oneoff-thankyou-page-recurring-upsell';
 
 const country = detectCountry();
 const currency = detectCurrency(country);
-
 
 // ----- Render ----- //
 

--- a/assets/pages/contributions-thankyou/oneoffContributionsThankyou.jsx
+++ b/assets/pages/contributions-thankyou/oneoffContributionsThankyou.jsx
@@ -15,7 +15,7 @@ import { renderPage } from 'helpers/render';
 import { detect as detectCountry } from 'helpers/internationalisation/country';
 import { detect as detectCurrency } from 'helpers/internationalisation/currency';
 import TrackedComponent from 'components/trackedComponent/trackedComponent';
-
+import { getAcquisition } from 'helpers/tracking/acquisitions';
 
 // ----- Page Startup ----- //
 
@@ -25,6 +25,8 @@ const upSellCampaignCode = 'oneoff-thankyou-page-recurring-upsell';
 
 const country = detectCountry();
 const currency = detectCurrency(country);
+
+const acquisitionData = getAcquisition()
 
 // ----- Render ----- //
 
@@ -56,7 +58,7 @@ const content = (
             <CtaLink
               ctaId="make-a-recurring-contribution"
               text={`Contribute ${currency.glyph}5 a month`}
-              url={`/contribute/recurring?contributionValue=5&contribType=MONTHLY&currency=${currency.iso}&INTCMP=${upSellCampaignCode}`}
+              url={`/contribute/recurring?contributionValue=5&contribType=MONTHLY&currency=${currency.iso}&INTCMP=${upSellCampaignCode}&acquisitionData=${JSON.stringify(acquisitionData)}`}
               accessibilityHint={`Contribute from ${currency.glyph}5 a month`}
             />
           </TrackedComponent>


### PR DESCRIPTION
## Why are you doing this?

This adds `acquisitionsData` parameter in the outbound link on the thank you page component.

Here is an example of the link
```
https://support.thegulocal.com/contribute/recurring?contributionValue=5&contribType=MONTHLY&currency=GBP&INTCMP=oneoff-thankyou-page-recurring-upsell&acquisitionData=%7B%22campaignCode%22%3A%22oneoff-thankyou-page-recurring-upsell%22%2C%22componentId%22%3A%22oneoff-thankyou-page-recurring-upsell%22%2C%22componentType%22%3A%22ACQUISITIONS_OTHER%22%2C%22source%22%3A%22GUARDIAN_WEB%22%7D
```
and in `json`
```
{
  "campaignCode":"oneoff-thankyou-page-recurring-upsell",
  "componentId":"oneoff-thankyou-page-recurring-upsell",
  "componentType":"ACQUISITIONS_OTHER",
  "source":"GUARDIAN_WEB"
}

```
@guardian/contributions 
<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->


