### PR TITLE
Support Landing Page - Part 4 - Tweak Links

### DIFF
--- a/assets/pages/bundles-landing/support-landing-ab-test/components/contributeNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/contributeNewDesign.jsx
@@ -12,7 +12,7 @@ import InfoSection from 'components/infoSection/infoSection';
 export default function Contribute() {
 
   return (
-    <div className="contribute-new-design">
+    <div className="contribute-new-design" id="contribute">
       <InfoSection heading="contribute" className="contribute-new-design__content gu-content-margin">
         <p className="contribute-new-design__copy">
           Support the Guardian by making a regular or one-off contribution.

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/readyNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/readyNewDesign.jsx
@@ -19,7 +19,7 @@ export default function Ready() {
         <h2 className="ready-new-design__heading">ready to support the&nbsp;Guardian?</h2>
         <CtaLink
           text="see supporter options"
-          url="#"
+          url="#contribute"
           ctaId="see-supporter-options"
           accessibilityHint="See the options for becoming a supporter"
           svg={<SvgChevronUp />}

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/whySupportNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/whySupportNewDesign.jsx
@@ -5,7 +5,6 @@
 import React from 'react';
 
 import InfoSection from 'components/infoSection/infoSection';
-import CtaCircle from 'components/ctaCircle/ctaCircle';
 import {
   SvgScribble,
   SvgGraphLine,
@@ -34,7 +33,6 @@ export default function WhySupport() {
             With no billionaire owner pulling our strings, nobody, be they
             shareholders or advertisers, can tell us to censor or drop a story.
           </p>
-          <CtaCircle text="Find out more about our independence" />
           <h1 className="why-support-new-design__heading why-support-new-design__heading--advertising">
             <span>advertising revenues</span>
             <span>are falling</span>
@@ -50,7 +48,6 @@ export default function WhySupport() {
             With ad revenues falling across the media, we need our readers&#39;
             support to secure our future.
           </p>
-          <CtaCircle text="Find out more about the Scott Trust" />
           <h1 className="why-support-new-design__heading why-support-new-design__heading--paywall">
             <span>we haven&#39;t put up </span>
             <span>a paywall</span>

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -316,50 +316,6 @@
 
     .why-support-new-design {
       background-color: darken(#fff, 5%);
-
-      .component-cta-circle {
-        margin-left: 0;
-
-        button {
-          vertical-align: middle;
-          background-color: #fff;
-          border: 1px solid gu-colour(neutral-1);
-          width: 30px;
-          height: 30px;
-          margin-right: 10px;
-
-          svg {
-            fill: gu-colour(neutral-1);
-          }
-        }
-
-        span {
-          vertical-align: middle;
-          font-weight: normal;
-        }
-
-        &:hover {
-          cursor: pointer;
-          text-decoration: none;
-
-          button {
-            background-color: gu-colour(guardian-brand-dark);
-            border-color: gu-colour(guardian-brand-dark);
-
-            svg {
-              fill: #fff;
-            }
-          }
-        }
-
-        &::before {
-          content: " ";
-          border-top: 1px solid gu-colour(multimedia-main-2);
-          width: 65px;
-          display: block;
-          padding-bottom: $gu-v-spacing;
-        }
-      }
     }
 
     .why-support-new-design__content {
@@ -486,6 +442,7 @@
 
     .why-support-new-design__heading--advertising {
       padding: $gu-v-spacing 0 150px;
+      margin-top: $gu-v-spacing * 4;
       position: relative;
 
       span:nth-of-type(2) {
@@ -555,6 +512,7 @@
       padding-top: 80px;
       padding-bottom: 100px;
       padding-left: 50px;
+      margin-top: $gu-v-spacing * 4;
 
       span:nth-of-type(2) {
         margin-left: 60px;
@@ -567,7 +525,9 @@
       }
 
       @include mq($from: mobileLandscape) {
-        margin: 0;
+        margin-left: 0;
+        margin-right: 0;
+        margin-bottom: 0;
         padding-top: 92px;
         padding-bottom: 140px;
         padding-left: 80px;


### PR DESCRIPTION
## Why are you doing this?

Couple things with the links on the page that aren't part of the contribute or subscribe sections. We're removing the 'find out more' links because there's nowhere really for them to point to. Also, the 'see supporter options' internal link at the bottom of the page now jumps to the contribute section, rather than to the top.

[**Trello Card**](https://trello.com/c/VvfDFmtn/1091-support-landing-update-the-links)

cc: @Amohkhan

## Changes

- Gave contribute section an `id` for the internal link to jump to, and updated that link.
- Removed the 'find out more' CtaCircles and their corresponding styles.
- Added some spacing where the 'find out more' links used to be.

## Screenshots

![without-links](https://user-images.githubusercontent.com/5131341/32792071-609f1b0a-c95a-11e7-853b-b48561039443.png)