### PR TITLE
Adding missed type

### DIFF
--- a/assets/components/trackedComponent/trackedComponent.jsx
+++ b/assets/components/trackedComponent/trackedComponent.jsx
@@ -40,6 +40,7 @@ class TrackedComponent extends React.Component<Props> {
       componentType: 'ACQUISITIONS_OTHER',
       source: 'GUARDIAN_WEB',
       abTest: undefined,
+      abTests: undefined,
     };
 
     const childrenWithProps = React.Children.map(


### PR DESCRIPTION
## Why are you doing this?
This fixes type collision in the current the master build.
https://teamcity-aws.gutools.co.uk/viewLog.html?buildId=99569&buildTypeId=memsub_Support_SupportFrontend&tab=buildLog

This was caused by conflicts between #369 and #365

@guardian/contributions 

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->
