### PR TITLE
Support Landing Page - Part 5 - Subscribe Tweaks

### DIFF
--- a/assets/pages/bundles-landing/helpers/externalLinks.js
+++ b/assets/pages/bundles-landing/helpers/externalLinks.js
@@ -8,7 +8,7 @@ import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 
 // ----- Types ----- //
 
-type SubsProduct = 'paper' | 'digital' | 'paperDig';
+export type SubsProduct = 'paper' | 'digital' | 'paperDig';
 export type MemProduct = 'patrons' | 'events';
 
 type PromoCodes = {

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/subscribeNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/subscribeNewDesign.jsx
@@ -3,16 +3,55 @@
 // ----- Imports ----- //
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import InfoSection from 'components/infoSection/infoSection';
 
+import type { Campaign } from 'helpers/tracking/acquisitions';
+import type { Participations } from 'helpers/abtest';
+import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
+
 import SubscriptionBundle from './subscriptionBundleNewDesign';
 import { features as subscriptionFeatures } from '../helpers/subscriptionFeatures';
+import { getSubsLinks } from '../../helpers/externalLinks';
+
+import type { SubsUrls } from '../../helpers/externalLinks';
+
+
+// ----- Props ----- //
+
+type PropTypes = {
+  intCmp: ?string,
+  campaign: ?Campaign,
+  otherQueryParams: Array<[string, string]>,
+  abTests: Participations,
+  referrerAcquisitionData: ReferrerAcquisitionData,
+};
+
+function mapStateToProps(state) {
+
+  return {
+    intCmp: state.common.referrerAcquisitionData.campaignCode,
+    campaign: state.common.campaign,
+    otherQueryParams: state.common.otherQueryParams,
+    abTests: state.common.abParticipations,
+    referrerAcquisitionData: state.common.referrerAcquisitionData,
+  };
+
+}
 
 
 // ----- Component ----- //
 
-export default function Subscribe() {
+function Subscribe(props: PropTypes) {
+
+  const subsLinks: SubsUrls = getSubsLinks(
+    props.intCmp,
+    props.campaign,
+    props.otherQueryParams,
+    props.abTests,
+    props.referrerAcquisitionData,
+  );
 
   return (
     <div className="subscribe-new-design">
@@ -25,6 +64,7 @@ export default function Subscribe() {
             copy={subscriptionFeatures.digital}
             ctaText="Start your free trial"
             image="digitalBundle"
+            ctaUrl={subsLinks.digital}
           />
           <SubscriptionBundle
             heading="paper"
@@ -33,6 +73,7 @@ export default function Subscribe() {
             copy={subscriptionFeatures.paper}
             ctaText="Get paper"
             image="paperBundle"
+            ctaUrl={subsLinks.paper}
           />
           <SubscriptionBundle
             heading="paper & digital"
@@ -41,6 +82,7 @@ export default function Subscribe() {
             copy={subscriptionFeatures.paperDig}
             ctaText="Get paper + digital"
             image="paperDigitalBundle"
+            ctaUrl={subsLinks.paperDig}
           />
         </div>
       </InfoSection>
@@ -48,3 +90,8 @@ export default function Subscribe() {
   );
 
 }
+
+
+// ----- Export ----- //
+
+export default connect(mapStateToProps)(Subscribe);

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/subscribeNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/subscribeNewDesign.jsx
@@ -23,7 +23,7 @@ export default function Subscribe() {
             price="11.99"
             from={false}
             copy={subscriptionFeatures.digital}
-            ctaText="Start 14-day trial"
+            ctaText="Start your free trial"
             image="digitalBundle"
           />
           <SubscriptionBundle
@@ -31,7 +31,7 @@ export default function Subscribe() {
             price="10.79"
             from
             copy={subscriptionFeatures.paper}
-            ctaText="Choose paper"
+            ctaText="Get paper"
             image="paperBundle"
           />
           <SubscriptionBundle
@@ -39,7 +39,7 @@ export default function Subscribe() {
             price="22.06"
             from
             copy={subscriptionFeatures.paperDig}
-            ctaText="Choose paper & digital"
+            ctaText="Get paper+digital"
             image="paperDigitalBundle"
           />
         </div>

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/subscribeNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/subscribeNewDesign.jsx
@@ -39,7 +39,7 @@ export default function Subscribe() {
             price="22.06"
             from
             copy={subscriptionFeatures.paperDig}
-            ctaText="Get paper+digital"
+            ctaText="Get paper + digital"
             image="paperDigitalBundle"
           />
         </div>

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/subscribeNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/subscribeNewDesign.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import InfoSection from 'components/infoSection/infoSection';
 
 import SubscriptionBundle from './subscriptionBundleNewDesign';
+import { features as subscriptionFeatures } from '../helpers/subscriptionFeatures';
 
 
 // ----- Component ----- //
@@ -21,7 +22,7 @@ export default function Subscribe() {
             heading="digital"
             price="11.99"
             from={false}
-            copy="Get our journalism across up to 10 devices, to enjoy wherever you go"
+            copy={subscriptionFeatures.digital}
             ctaText="Start 14-day trial"
             image="digitalBundle"
           />
@@ -29,7 +30,7 @@ export default function Subscribe() {
             heading="paper"
             price="10.79"
             from
-            copy="With six day, weekend and everyday options, you can choose the package that suits you"
+            copy={subscriptionFeatures.paper}
             ctaText="Choose paper"
             image="paperBundle"
           />
@@ -37,7 +38,7 @@ export default function Subscribe() {
             heading="paper & digital"
             price="22.06"
             from
-            copy="Enjoy the Guardian at your leisure, whether it's on your tablet on the go, or reading the paper at home"
+            copy={subscriptionFeatures.paperDig}
             ctaText="Choose paper & digital"
             image="paperDigitalBundle"
           />

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/subscriptionBundleNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/subscriptionBundleNewDesign.jsx
@@ -20,6 +20,7 @@ type PropTypes = {
   copy: ListItem[],
   ctaText: string,
   image: string,
+  ctaUrl: string,
 };
 
 
@@ -45,7 +46,10 @@ export default function SubscriptionBundle(props: PropTypes) {
       <p className="subscription-bundle__copy">
         <FeatureList listItems={props.copy} />
       </p>
-      <CtaCircle text={props.ctaText} />
+      <CtaCircle
+        text={props.ctaText}
+        url={props.ctaUrl}
+      />
     </div>
   );
 

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/subscriptionBundleNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/subscriptionBundleNewDesign.jsx
@@ -6,6 +6,9 @@ import React from 'react';
 
 import CtaCircle from 'components/ctaCircle/ctaCircle';
 import GridImage from 'components/gridImage/gridImage';
+import FeatureList from 'components/featureList/featureList';
+
+import type { ListItem } from 'components/featureList/featureList';
 
 
 // ----- Types ----- //
@@ -14,7 +17,7 @@ type PropTypes = {
   heading: string,
   price: string,
   from: boolean,
-  copy: string,
+  copy: ListItem[],
   ctaText: string,
   image: string,
 };
@@ -39,7 +42,9 @@ export default function SubscriptionBundle(props: PropTypes) {
         <span className="subscription-bundle__price-amount">£{props.price}</span>
         <span className="subscription-bundle__price-period"> /&nbsp;month</span>
       </h4>
-      <p className="subscription-bundle__copy">{props.copy}</p>
+      <p className="subscription-bundle__copy">
+        <FeatureList listItems={props.copy} />
+      </p>
       <CtaCircle text={props.ctaText} />
     </div>
   );

--- a/assets/pages/bundles-landing/support-landing-ab-test/helpers/subscriptionFeatures.js
+++ b/assets/pages/bundles-landing/support-landing-ab-test/helpers/subscriptionFeatures.js
@@ -34,6 +34,13 @@ const features: {
   ],
   paperDig: [
     {
+      heading: 'Choose your package and delivery method',
+      text: 'Everyday+, Sixday+, Weekend+ and Sunday+; redeem paper vouchers or get home delivery',
+    },
+    {
+      heading: 'Save money on the retail price',
+    },
+    {
       heading: 'Get all the benefits of a digital subscription with paper + digital',
     },
   ],

--- a/assets/pages/bundles-landing/support-landing-ab-test/helpers/subscriptionFeatures.js
+++ b/assets/pages/bundles-landing/support-landing-ab-test/helpers/subscriptionFeatures.js
@@ -34,7 +34,7 @@ const features: {
   ],
   paperDig: [
     {
-      heading: 'Get all the benefits of a digital subscription with paper+digital',
+      heading: 'Get all the benefits of a digital subscription with paper + digital',
     },
   ],
 };

--- a/assets/pages/bundles-landing/support-landing-ab-test/helpers/subscriptionFeatures.js
+++ b/assets/pages/bundles-landing/support-landing-ab-test/helpers/subscriptionFeatures.js
@@ -35,7 +35,7 @@ const features: {
   paperDig: [
     {
       heading: 'Choose your package and delivery method',
-      text: 'Everyday+, Sixday+, Weekend+ and Sunday+; redeem paper vouchers or get home delivery',
+      text: 'Everyday, Sixday, Weekend and Sunday; redeem paper vouchers or get home delivery',
     },
     {
       heading: 'Save money on the retail price',

--- a/assets/pages/bundles-landing/support-landing-ab-test/helpers/subscriptionFeatures.js
+++ b/assets/pages/bundles-landing/support-landing-ab-test/helpers/subscriptionFeatures.js
@@ -1,0 +1,47 @@
+// @flow
+
+// ----- Imports ----- //
+
+import type { ListItem } from 'components/featureList/featureList';
+import type { SubsProduct } from '../../helpers/externalLinks';
+
+
+// ----- Features ----- //
+
+const features: {
+  [SubsProduct]: ListItem[],
+} = {
+  digital: [
+    {
+      heading: 'Premium experience on the Guardian app',
+      text: `No adverts means faster loading pages and a clearer reading experience.
+        Play our daily crosswords offline wherever you are`,
+    },
+    {
+      heading: 'Daily Tablet Edition app',
+      text: `Read the Guardian, the Observer and all the Weekend supplements in an
+        optimised tablet app; available on iPad, Android and Kindle Fire tablets`,
+    },
+  ],
+  paper: [
+    {
+      heading: 'Choose your package and delivery method',
+      text: 'Everyday, Sixday, Weekend and Sunday; redeem paper vouchers or get home delivery',
+    },
+    {
+      heading: 'Save money on the retail price',
+    },
+  ],
+  paperDig: [
+    {
+      heading: 'Get all the benefits of a digital subscription with paper+digital',
+    },
+  ],
+};
+
+
+// ----- Exports ----- //
+
+export {
+  features,
+};

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -296,7 +296,7 @@
       line-height: 28px;
       padding: $gu-v-spacing 0;
       color: gu-colour(neutral-1);
-      font-weight: bold;
+      font-weight: 500;
     }
 
     .subscription-bundle__price-amount {

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -222,7 +222,7 @@
     }
 
     .subscribe-new-design__content {
-      background-color: #fff;
+      background-color: gu-colour(neutral-6);
       border-color: gu-colour(light-yellow);
     }
 
@@ -260,7 +260,7 @@
         }
 
         button {
-          background-color: gu-colour(neutral-6);
+          background-color: #fff;
           vertical-align: middle;
 
           svg {

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -291,25 +291,38 @@
     }
 
     .subscription-bundle__price {
-      font-family: $gu-text-sans-web;
+      font-family: $gu-egyptian-web;
       font-size: 24px;
       line-height: 28px;
       padding: $gu-v-spacing 0;
       color: gu-colour(neutral-1);
+      font-weight: bold;
     }
 
     .subscription-bundle__price-amount {
       font-size: 36px;
       line-height: 28px;
-      font-weight: bold;
     }
 
     .subscription-bundle__copy {
-      font-family: $gu-text-egyptian-web;
-      font-size: 18px;
-      line-height: 24px;
       color: gu-colour(neutral-2);
       flex-grow: 1;
+
+      .component-feature-list {
+        list-style-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 28 28"><style>.st0{fill:#333;}</style><path class="st0" d="M7.885 25.74L0 14.82l3.22-3.217L8.3 16.74 24.695 2.26 28 5.565"/></svg>');
+        padding-left: 0;
+        
+        h3, p {
+          font-family: $gu-text-egyptian-web;
+          font-weight: normal;
+          font-size: 16px;
+          line-height: 22px;
+        }
+
+        h3 {
+          color: gu-colour(neutral-1);
+        }
+      }
     }
 
     // ----- Why Support


### PR DESCRIPTION
## Why are you doing this?

The subscribe section was only half-finished before, missing the correct copy and links etc. This brings it in line with the functionality of the subscribe bundles on the current landing page.

[**Trello Card**](https://trello.com/c/pADcFz7O/1093-support-landing-subscribe-tweaks)

cc: @Amohkhan

## Changes

- Connected it to redux to retrieve all the information that needs to be passed through to the subs site in the URL.
- Updated the copy of the bundles to display lists of features, with ticks!
- Updated the CTA labels.
- Added the links on the CTAs, with the same functionality as the current bundles page, i.e. promo codes, acquisition data etc.
- Created a helper to manage the lists of subs bundle features.
- Added a background colour to differentiate from the contribute section in #366.
- Tweaked the fonts.

## Screenshots

**Desktop:**

![subs-desktop](https://user-images.githubusercontent.com/5131341/32796319-53e7e9ee-c966-11e7-8010-1bd86eacadcb.png)

**Mobile:**

![subs-mobile](https://user-images.githubusercontent.com/5131341/32796330-597c4f6c-c966-11e7-9d8b-0eefff41e0af.png)