### PR TITLE
Fix incorrectly named acquisitionsData

### DIFF
--- a/assets/pages/bundles-landing/helpers/externalLinks.js
+++ b/assets/pages/bundles-landing/helpers/externalLinks.js
@@ -113,7 +113,7 @@ function buildSubsUrls(
   const params = new URLSearchParams();
   params.append('INTCMP', intCmp || defaultIntCmp);
   otherQueryParams.forEach(p => params.append(p[0], p[1]));
-  params.append('acquisitionsData', JSON.stringify(referrerAcquisitionData));
+  params.append('acquisitionData', JSON.stringify(referrerAcquisitionData));
 
   const paper = `${subsUrl}/${promoCodes.paper}?${params.toString()}`;
   const paperDig = `${subsUrl}/${promoCodes.paperDig}?${params.toString()}`;


### PR DESCRIPTION
## Why are you doing this?

The query string parameter `acquisitionsData` should be `aquisitionData` in order for the subs site to read it correctly 