### PR TITLE
Tweak PayPal Button Arrow Size

### DIFF
--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -256,9 +256,9 @@
       }
 
       .svg-arrow-right-straight {
-          height: 37%;
-          right: 6px;
-        }
+        height: 37%;
+        right: 6px;
+      }
     }
 
     .component-bundle--digital, .component-bundle--paper {

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -254,6 +254,11 @@
         bottom: $gu-v-spacing;
         position: absolute;
       }
+
+      .svg-arrow-right-straight {
+          height: 37%;
+          right: 6px;
+        }
     }
 
     .component-bundle--digital, .component-bundle--paper {


### PR DESCRIPTION
## Why are you doing this?

On the bundles landing page, the PayPal button arrow doesn't match the other CTA. This brings it in line.

## Changes

- Tweaked the arrow svg size and position.

## Screenshots

|**Before**| **After** |
|--------|-------|
| ![paypal-before](https://user-images.githubusercontent.com/5131341/32945273-ac0c0ba2-cb8a-11e7-88ea-212a8047f67e.png)     |      ![paypal-after](https://user-images.githubusercontent.com/5131341/32945285-b2c3afcc-cb8a-11e7-8c49-5a9856b70cae.png) |