### PR TITLE
Adding preload

### DIFF
--- a/app/views/bundleLanding.scala.html
+++ b/app/views/bundleLanding.scala.html
@@ -8,6 +8,7 @@
 )(implicit assets: AssetsResolver, request: RequestHeader)
 
 @scripts = {
+    <link rel="preload"  as="script" href="@assets(js)">
     <script type="text/javascript" src="@assets(js)"></script>
     <script type="text/javascript">
         window.guardian = window.guardian || {};

--- a/app/views/bundleLanding.scala.html
+++ b/app/views/bundleLanding.scala.html
@@ -8,7 +8,6 @@
 )(implicit assets: AssetsResolver, request: RequestHeader)
 
 @scripts = {
-    <link rel="preload"  as="script" href="@assets(js)">
     <script type="text/javascript" src="@assets(js)"></script>
     <script type="text/javascript">
         window.guardian = window.guardian || {};
@@ -16,6 +15,6 @@
     </script>
 }
 
-@main(title = title, description = description, scripts = scripts) {
+@main(title = title, description = description, scripts = scripts, mainJs = Some(js)) {
     <main id="@id" class="gu-content-wrapper"></main>
 }

--- a/app/views/bundleLanding.scala.html
+++ b/app/views/bundleLanding.scala.html
@@ -8,13 +8,12 @@
 )(implicit assets: AssetsResolver, request: RequestHeader)
 
 @scripts = {
-    <script type="text/javascript" src="@assets(js)"></script>
     <script type="text/javascript">
         window.guardian = window.guardian || {};
         window.guardian.contributionsPayPalEndpoint = "@contributionsPayPalEndpoint";
     </script>
 }
 
-@main(title = title, description = description, scripts = scripts, mainJs = Some(js)) {
+@main(title = title, description = description, scripts = scripts, mainBundleJs = js) {
     <main id="@id" class="gu-content-wrapper"></main>
 }

--- a/app/views/contributionsLanding.scala.html
+++ b/app/views/contributionsLanding.scala.html
@@ -9,6 +9,6 @@
     <script type="text/javascript" src="@assets(js)"></script>
 }
 
-@main(title = title, scripts = scripts, description = description, mainJs = Some(js)) {
+@main(title = title, scripts = scripts, description = description, mainBundleJs = js) {
     <main id="@id" class="gu-content-wrapper"></main>
 }

--- a/app/views/contributionsLanding.scala.html
+++ b/app/views/contributionsLanding.scala.html
@@ -6,6 +6,7 @@
         window.guardian = window.guardian || {};
         window.guardian.contributionsPayPalEndpoint = "@contributionsPayPalEndpoint";
     </script>
+    <link rel="preload"  as="script" href="@assets(js)">
     <script type="text/javascript" src="@assets(js)"></script>
 }
 

--- a/app/views/contributionsLanding.scala.html
+++ b/app/views/contributionsLanding.scala.html
@@ -6,10 +6,9 @@
         window.guardian = window.guardian || {};
         window.guardian.contributionsPayPalEndpoint = "@contributionsPayPalEndpoint";
     </script>
-    <link rel="preload"  as="script" href="@assets(js)">
     <script type="text/javascript" src="@assets(js)"></script>
 }
 
-@main(title = title, scripts = scripts, description = description) {
+@main(title = title, scripts = scripts, description = description, mainJs = Some(js)) {
     <main id="@id" class="gu-content-wrapper"></main>
 }

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -70,8 +70,10 @@
 		window.guardian = window.guardian || {};
         window.guardian.gitCommitId = '@app.BuildInfo.gitCommitId';
 	</script>
-	<script type="text/javascript" src="@assets(mainBundleJs)"></script>
 	@scripts
+	 <!-- This script is intentional at the bottom of the file. Please check
+	      all the critical flows work correctly if you change its position -->
+	<script type="text/javascript" src="@assets(mainBundleJs)"></script>
 	<!-- build-commit-id: @app.BuildInfo.gitCommitId -->
 </body>
 </html>

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -71,7 +71,7 @@
         window.guardian.gitCommitId = '@app.BuildInfo.gitCommitId';
 	</script>
 	@scripts
-	 <!-- This script is intentional at the bottom of the file. Please check
+	 <!-- This script is intentionally at the bottom of the file. Please check
 	      all the critical flows work correctly if you change its position -->
 	<script type="text/javascript" src="@assets(mainBundleJs)"></script>
 	<!-- build-commit-id: @app.BuildInfo.gitCommitId -->

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -4,7 +4,8 @@
 	title: String,
 	description: Option[String] = None,
 	styles: Html = Html(""),
-	scripts: Html = Html("")
+	scripts: Html = Html(""),
+	mainJs: Option[String] = None
 )(content: Html)(implicit assets: AssetsResolver, request: RequestHeader)
 
 <!DOCTYPE html>
@@ -45,6 +46,11 @@
 	@if(!doNotTrack) {
 		<script async type="text/javascript" src="@assets("googleTagManagerScript.js")"></script>
 	}
+
+	@if(mainJs.isDefined) {
+		<link rel="preload"  as="script" href="@assets(mainJs.get)">
+	}
+
 	@styles
 </head>
 <body>

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -5,7 +5,7 @@
 	description: Option[String] = None,
 	styles: Html = Html(""),
 	scripts: Html = Html(""),
-	mainJs: Option[String] = None
+	mainBundleJs: String
 )(content: Html)(implicit assets: AssetsResolver, request: RequestHeader)
 
 <!DOCTYPE html>
@@ -47,9 +47,8 @@
 		<script async type="text/javascript" src="@assets("googleTagManagerScript.js")"></script>
 	}
 
-	@if(mainJs.isDefined) {
-		<link rel="preload"  as="script" href="@assets(mainJs.get)">
-	}
+	<link rel="preload"  as="script" href="@assets(mainBundleJs)">
+
 
 	@styles
 </head>
@@ -71,6 +70,7 @@
 		window.guardian = window.guardian || {};
         window.guardian.gitCommitId = '@app.BuildInfo.gitCommitId';
 	</script>
+	<script type="text/javascript" src="@assets(mainBundleJs)"></script>
 	@scripts
 	<!-- build-commit-id: @app.BuildInfo.gitCommitId -->
 </body>

--- a/app/views/monthlyContributions.scala.html
+++ b/app/views/monthlyContributions.scala.html
@@ -38,9 +38,8 @@
         window.guardian.payPalEnvironment = "@payPalConfig.payPalEnvironment";
         window.guardian.csrf = { token: "@CSRF.getToken.value" };
     </script>
-    <script type="text/javascript" src="@assets(js)"></script>
 }
 
-@main(title = title, scripts = scripts) {
+@main(title = title, scripts = scripts, mainBundleJs = js) {
     <main id="@id" class="gu-content-wrapper"></main>
 }

--- a/app/views/oneOffContributions.scala.html
+++ b/app/views/oneOffContributions.scala.html
@@ -24,9 +24,8 @@
         window.guardian.contributionsPayPalEndpoint = "@contributionsPayPalEndpoint";
         window.guardian.payPalType = @payPalButton ? 'ContributionsCheckout' : 'NotSet';
     </script>
-    <script type="text/javascript" src="@assets(js)"></script>
 }
 
-@main(title = title, scripts = scripts) {
+@main(title = title, scripts = scripts, mainBundleJs = js) {
     <main id="@id" class="gu-content-wrapper"></main>
 }

--- a/app/views/react.scala.html
+++ b/app/views/react.scala.html
@@ -6,10 +6,6 @@
     description: Option[String] = None
 )(implicit assets: AssetsResolver, request: RequestHeader)
 
-@scripts = {
-    <script type="text/javascript" src="@assets(js)"></script>
-}
-
-@main(title = title, description = description, scripts = scripts) {
+@main(title = title, description = description, mainBundleJs = js) {
     <main id="@id" class="gu-content-wrapper"></main>
 }


### PR DESCRIPTION
## Why are you doing this?

To load the important scripts as soon as possible, currently supported in Chrome, Opera and Safari. ([preload spec](https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content))

## Changes

* Added preload tag for the main scripts

## Screenshots

Page | Before | After |
|-----|--------|-------|
Bundle Landing Page|   <img width="1256" alt="picture 450" src="https://user-images.githubusercontent.com/825398/32946543-d93dcf2a-cb8f-11e7-898e-d8f7953cfb06.png">|    <img width="1243" alt="picture 452" src="https://user-images.githubusercontent.com/825398/32946504-b506d05c-cb8f-11e7-9d2b-51574538ef13.png">  |
Contribution Landing Page|  <img width="1255" alt="picture 451" src="https://user-images.githubusercontent.com/825398/32946561-f77dccc4-cb8f-11e7-861f-193a76c56eba.png">|  <img width="1242" alt="picture 453" src="https://user-images.githubusercontent.com/825398/32946577-0051195a-cb90-11e7-8e8d-ced411a3cf4a.png">|

