### PR TITLE
Support Landing Page - Part 7 - Other Ways

### DIFF
--- a/assets/components/ctaCircle/ctaCircle.scss
+++ b/assets/components/ctaCircle/ctaCircle.scss
@@ -4,6 +4,7 @@
   margin: $gu-v-spacing ($gu-h-spacing/2);
   text-decoration: none;
   color: inherit;
+  cursor: pointer;
 
   @include mq($until: mobileLandscape) {
     margin-bottom: 0;

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/otherWaysCardNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/otherWaysCardNewDesign.jsx
@@ -1,0 +1,46 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+import CtaCircle from 'components/ctaCircle/ctaCircle';
+import GridImage from 'components/gridImage/gridImage';
+
+import type { ImageId } from 'helpers/theGrid';
+
+
+// ----- Props ----- //
+
+type PropTypes = {
+  heading: string,
+  copy: string,
+  ctaText: string,
+  gridImg: ImageId,
+  imgAlt: ?string,
+};
+
+
+// ----- Component ----- //
+
+export default function OtherWaysCard(props: PropTypes) {
+
+  return (
+    <div className="other-ways-new-design gu-content-filler">
+      <div>
+        <GridImage
+          gridId={props.gridImg}
+          srcSizes={[1000, 500, 140]}
+          sizes="(max-width: 480px) 100vw, (max-width: 740px) 210px, (max-width: 980px) 220px, 300px"
+          altText={props.imgAlt}
+        />
+      </div>
+      <div>
+        <h1 className="other-ways-card-new-design__heading">{props.heading}</h1>
+        <p className="other-ways-card-new-design__copy">{props.copy}</p>
+        <CtaCircle text={props.ctaText} />
+      </div>
+    </div>
+  );
+
+}

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/otherWaysCardNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/otherWaysCardNewDesign.jsx
@@ -31,7 +31,7 @@ export default function OtherWaysCard(props: PropTypes) {
         <GridImage
           gridId={props.gridImg}
           srcSizes={[1000, 500, 140]}
-          sizes="(max-width: 480px) 100vw, (max-width: 740px) 210px, (max-width: 980px) 220px, 300px"
+          sizes="(max-width: 480px) 90vw, (max-width: 660px) 400px, 270px"
           altText={props.imgAlt}
         />
       </div>

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/otherWaysCardNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/otherWaysCardNewDesign.jsx
@@ -18,6 +18,7 @@ type PropTypes = {
   ctaText: string,
   gridImg: ImageId,
   imgAlt: ?string,
+  ctaUrl: string,
 };
 
 
@@ -38,7 +39,7 @@ export default function OtherWaysCard(props: PropTypes) {
       <div className="other-ways-card-new-design__description">
         <h1 className="other-ways-card-new-design__heading">{props.heading}</h1>
         <p className="other-ways-card-new-design__copy">{props.copy}</p>
-        <CtaCircle text={props.ctaText} />
+        <CtaCircle text={props.ctaText} url={props.ctaUrl} />
       </div>
     </div>
   );

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/otherWaysCardNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/otherWaysCardNewDesign.jsx
@@ -26,8 +26,8 @@ type PropTypes = {
 export default function OtherWaysCard(props: PropTypes) {
 
   return (
-    <div className="other-ways-new-design gu-content-filler">
-      <div>
+    <div className="other-ways-card-new-design gu-content-filler">
+      <div className="other-ways-card-new-design__image">
         <GridImage
           gridId={props.gridImg}
           srcSizes={[1000, 500, 140]}
@@ -35,7 +35,7 @@ export default function OtherWaysCard(props: PropTypes) {
           altText={props.imgAlt}
         />
       </div>
-      <div>
+      <div className="other-ways-card-new-design__description">
         <h1 className="other-ways-card-new-design__heading">{props.heading}</h1>
         <p className="other-ways-card-new-design__copy">{props.copy}</p>
         <CtaCircle text={props.ctaText} />

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/otherWaysNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/otherWaysNewDesign.jsx
@@ -20,7 +20,7 @@ export default function OtherWays() {
         className="other-ways-new-design__content gu-content-filler__inner"
       >
         <OtherWaysCard
-          heading="patrons"
+          heading="Patrons"
           copy="The Patron tier is for those who want a deeper relationship with the Guardian and its journalists"
           ctaText="Find out more"
           gridImg="guardianObserverOffice"

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/otherWaysNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/otherWaysNewDesign.jsx
@@ -29,7 +29,7 @@ export default function OtherWays() {
         <OtherWaysCard
           heading="Live events"
           copy="Meet Guardian journalists and readers at our events, debates, interviews and festivals"
-          ctaText="Find out more"
+          ctaText="Find out about events"
           gridImg="liveEvent"
           imgAlt="live event"
         />

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/otherWaysNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/otherWaysNewDesign.jsx
@@ -3,15 +3,30 @@
 // ----- Imports ----- //
 
 import React from 'react';
+import { connect } from 'react-redux';
 
 import InfoSection from 'components/infoSection/infoSection';
+import { getMemLink } from '../../helpers/externalLinks';
 
 import OtherWaysCard from './otherWaysCardNewDesign';
 
 
+// ----- Types ----- //
+
+type PropTypes = {
+  intCmp: ?string,
+};
+
+function mapStateToProps(state) {
+  return {
+    intCmp: state.common.referrerAcquisitionData.campaignCode,
+  };
+}
+
+
 // ----- Component ----- //
 
-export default function OtherWays() {
+function OtherWays(props: PropTypes) {
 
   return (
     <div className="other-ways-new-design gu-content-filler">
@@ -25,6 +40,7 @@ export default function OtherWays() {
           ctaText="Find out more"
           gridImg="guardianObserverOffice"
           imgAlt="the Guardian and the Observer"
+          ctaUrl={getMemLink('patrons', props.intCmp)}
         />
         <OtherWaysCard
           heading="Live events"
@@ -32,9 +48,15 @@ export default function OtherWays() {
           ctaText="Find out about events"
           gridImg="liveEvent"
           imgAlt="live event"
+          ctaUrl={getMemLink('events', props.intCmp)}
         />
       </InfoSection>
     </div>
   );
 
 }
+
+
+// ----- Exports ----- //
+
+export default connect(mapStateToProps)(OtherWays);

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/otherWaysNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/otherWaysNewDesign.jsx
@@ -1,0 +1,33 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+import InfoSection from 'components/infoSection/infoSection';
+
+import OtherWaysCard from './otherWaysCardNewDesign';
+
+
+// ----- Component ----- //
+
+export default function OtherWays() {
+
+  return (
+    <div className="other-ways-new-design gu-content-filler">
+      <InfoSection
+        heading="other ways you can support us"
+        className="other-ways-new-design__content gu-content-filler__inner"
+      >
+        <OtherWaysCard
+          heading="patrons"
+          copy="The Patron tier is for those who want a deeper relationship with the Guardian and its journalists"
+          ctaText="Find out more"
+          gridImg="guardianObserverOffice"
+          imgAlt="the Guardian and the Observer"
+        />
+      </InfoSection>
+    </div>
+  );
+
+}

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/otherWaysNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/otherWaysNewDesign.jsx
@@ -26,6 +26,13 @@ export default function OtherWays() {
           gridImg="guardianObserverOffice"
           imgAlt="the Guardian and the Observer"
         />
+        <OtherWaysCard
+          heading="Live events"
+          copy="Meet Guardian journalists and readers at our events, debates, interviews and festivals"
+          ctaText="Find out more"
+          gridImg="liveEvent"
+          imgAlt="live event"
+        />
       </InfoSection>
     </div>
   );

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/readyNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/readyNewDesign.jsx
@@ -14,8 +14,8 @@ import { SvgChevronUp } from 'components/svg/svg';
 export default function Ready() {
 
   return (
-    <div className="ready-new-design gu-content-filler">
-      <InfoSection className="ready-new-design__content gu-content-filler__inner">
+    <div className="ready-new-design">
+      <InfoSection className="ready-new-design__content gu-content-margin">
         <h2 className="ready-new-design__heading">ready to support the&nbsp;Guardian?</h2>
         <CtaLink
           text="see supporter options"

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.jsx
@@ -15,6 +15,7 @@ import BehindTheScenes from './components/behindTheScenesNewDesign';
 import Subscribe from './components/subscribeNewDesign';
 import WhySupport from './components/whySupportNewDesign';
 import Ready from './components/readyNewDesign';
+import OtherWays from './components/otherWaysNewDesign';
 
 
 // ----- Render ----- //
@@ -31,6 +32,7 @@ export default function supportLanding(store: Store) {
         <BehindTheScenes />
         <WhySupport />
         <Ready />
+        <OtherWays />
         <SimpleFooter />
       </div>
     </Provider>

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -1117,10 +1117,60 @@
 
     .other-ways-new-design__content {
       background-color: gu-colour(neutral-1);
+      padding-bottom: $gu-v-spacing * 4;
 
       .component-info-section__heading {
         color: #fff;
       }
+
+      .component-info-section__content {
+        padding-top: $gu-v-spacing * 4;
+      }
+    }
+
+    .other-ways-card-new-design {
+      width: 300px;
+      color: #fff;
+    }
+
+    .other-ways-card-new-design__image {
+      border-bottom: 2px solid gu-colour(comment-main-2);
+
+      .component-grid-image {
+        display: block;
+        width: 90%;
+        margin: 0 5%;
+      }
+    }
+
+    .other-ways-card-new-design__description {
+      .component-cta-circle {
+        margin-left: 0;
+        margin-top: $gu-v-spacing * 2;
+      }
+
+      button {
+        background-color: gu-colour(comment-main-2);
+        margin-right: $gu-h-spacing / 2;
+      }
+
+      .svg-arrow-right-straight {
+        fill: gu-colour(neutral-1);
+      }
+    }
+
+    .other-ways-card-new-design__heading {
+      font-size: 36px;
+      line-height: 40px;
+      font-family: $gu-egyptian-web;
+      font-weight: bold;
+      margin-bottom: $gu-v-spacing * 2;
+    }
+
+    .other-ways-card-new-design__copy {
+      font-size: 16px;
+      line-height: 20px;
+      font-family: $gu-text-egyptian-web;
     }
 
   }

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -1131,6 +1131,11 @@
     .other-ways-card-new-design {
       width: 300px;
       color: #fff;
+      display: inline-block;
+
+      &:first-of-type {
+        margin-right: $gu-h-spacing;
+      }
     }
 
     .other-ways-card-new-design__image {

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -1122,6 +1122,10 @@
 
       .component-info-section__heading {
         color: #fff;
+
+        @include mq($from: leftCol) {
+          width: 80%;
+        }
       }
 
       .component-info-section__content {

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -1109,6 +1109,20 @@
       }
     }
 
+    // ----- Other Ways
+
+    .other-ways-new-design {
+      background-color: darken(#fff, 5%);
+    }
+
+    .other-ways-new-design__content {
+      background-color: gu-colour(neutral-1);
+
+      .component-info-section__heading {
+        color: #fff;
+      }
+    }
+
   }
 
 }

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -1118,6 +1118,7 @@
     .other-ways-new-design__content {
       background-color: gu-colour(neutral-1);
       padding-bottom: $gu-v-spacing * 4;
+      border: none;
 
       .component-info-section__heading {
         color: #fff;
@@ -1129,12 +1130,25 @@
     }
 
     .other-ways-card-new-design {
-      width: 300px;
       color: #fff;
       display: inline-block;
 
-      &:first-of-type {
-        margin-right: $gu-h-spacing;
+      @include mq($until: phablet) {
+        &:first-of-type {
+          margin-bottom: $gu-v-spacing * 4;
+        }
+      }
+
+      @include mq($from: phablet) {
+        width: 300px;
+
+        &:first-of-type {
+          margin-right: $gu-h-spacing;
+        }
+      }
+
+      @include mq($from: tablet, $until: desktop) {
+        margin: 0 25px;
       }
     }
 


### PR DESCRIPTION
## Why are you doing this?

In the world where we switch over to support entirely, we still need a route to those products on membership that we plan to keep: patrons and events. This adds a section to the bottom of the support landing page showing these products.

[**Trello Card**](https://trello.com/c/K2kWxYLG/1101-support-landing-other-ways)

cc: @Amohkhan

## Changes

- Added an `OtherWays` component to show information about other ways of support.
- Added an `OtherWaysCard` component to show the individual cards in the other ways section.
- Styled the new component.
- Added `cursor: pointer` to the `CtaCircle` component.

## Screenshots

**Desktop:**

![other-desktop](https://user-images.githubusercontent.com/5131341/33023881-773abf9e-ce01-11e7-929a-7ab0fd51d33b.png)

**Tablet:**

![other-tablet](https://user-images.githubusercontent.com/5131341/33023893-7ba0e9f0-ce01-11e7-9eae-103b63f0cce0.png)

**Mobile:**

![other-mobile](https://user-images.githubusercontent.com/5131341/33023984-b76e123c-ce01-11e7-951b-ea4c136a39a2.png)

**In The Page:**

![other-page](https://user-images.githubusercontent.com/5131341/33023874-72ab0a2e-ce01-11e7-8924-d7399b225f53.png)
