### PR TITLE
UK and US Recurring amounts tests

### DIFF
--- a/assets/components/contribAmounts/contribAmounts.jsx
+++ b/assets/components/contribAmounts/contribAmounts.jsx
@@ -12,7 +12,7 @@ import {
   clickSubstituteKeyPressHandler,
 } from 'helpers/utilities';
 import { errorMessage as contributionErrorMessage } from 'helpers/contributions';
-import { amountRadiosMonthlyLower, amountRadiosMonthlyWildcard } from 'helpers/amountsTest';
+import { amountRadiosMonthlyHigher, amountRadiosMonthlyLower, amountRadiosMonthlyWildcard } from 'helpers/amountsTest';
 
 
 import type { Contrib, ContribError, Amounts } from 'helpers/contributions';
@@ -252,8 +252,8 @@ function getMonthlyAmount(abTests: Participations, currency: IsoCurrency) {
     if (abTests.usRecurringAmountsTest === 'lower') {
       return amountRadiosMonthlyLower[currency];
     }
-    if (abTests.uRecurringAmountsTest === 'wildcard') {
-      return amountRadiosMonthlyWildcard[currency];
+    if (abTests.usRecurringAmountsTest === 'higher') {
+      return amountRadiosMonthlyHigher[currency];
     }
   }
 

--- a/assets/components/contribAmounts/contribAmounts.jsx
+++ b/assets/components/contribAmounts/contribAmounts.jsx
@@ -12,6 +12,8 @@ import {
   clickSubstituteKeyPressHandler,
 } from 'helpers/utilities';
 import { errorMessage as contributionErrorMessage } from 'helpers/contributions';
+import { amountRadiosMonthlyHigher, amountRadiosMonthlyLower, amountRadiosMonthlyWildcard } from 'helpers/amountsTest';
+
 
 import type { Contrib, ContribError, Amounts } from 'helpers/contributions';
 import type { IsoCountry } from 'helpers/internationalisation/country';
@@ -62,8 +64,6 @@ type ContribAttrs = {
   contribType: Contrib,
   accessibilityHint: string,
 };
-
-
 
 // ----- Setup ----- //
 
@@ -136,123 +136,6 @@ const amountRadiosMonthlyControl: {
       value: '10',
       text: '$10',
       accessibilityHint: 'contribute ten dollars per month',
-    },
-    {
-      value: '20',
-      text: '$20',
-      accessibilityHint: 'contribute twenty dollars per month',
-    },
-  ],
-};
-
-const amountRadiosMonthlyHigher: {
-  [IsoCurrency]: Radio[]
-} = {
-  GBP: [
-    {
-      value: '10',
-      text: '£10',
-      accessibilityHint: 'contribute ten pounds per month',
-    },
-    {
-      value: '20',
-      text: '£20',
-      accessibilityHint: 'contribute twenty pounds per month',
-    },
-    {
-      value: '50',
-      text: '£50',
-      accessibilityHint: 'contribute fifty pounds per month',
-    },
-  ],
-  USD: [
-    {
-      value: '10',
-      text: '$10',
-      accessibilityHint: 'contribute ten dollars per month',
-    },
-    {
-      value: '20',
-      text: '$20',
-      accessibilityHint: 'contribute twenty dollars per month',
-    },
-    {
-      value: '50',
-      text: '$50',
-      accessibilityHint: 'contribute fifty dollars per month',
-    },
-  ],
-};
-
-const amountRadiosMonthlyLower: {
-  [IsoCurrency]: Radio[]
-} = {
-  GBP: [
-    {
-      value: '2',
-      text: '£2',
-      accessibilityHint: 'contribute two pounds per month',
-    },
-    {
-      value: '5',
-      text: '£5',
-      accessibilityHint: 'contribute five pounds per month',
-    },
-    {
-      value: '10',
-      text: '£10',
-      accessibilityHint: 'contribute ten pounds per month',
-    },
-  ],
-  USD: [
-    {
-      value: '2',
-      text: '$2',
-      accessibilityHint: 'contribute two dollars per month',
-    },
-    {
-      value: '5',
-      text: '$5',
-      accessibilityHint: 'contribute five dollars per month',
-    },
-    {
-      value: '10',
-      text: '$10',
-      accessibilityHint: 'contribute ten dollars per month',
-    },
-  ],
-};
-
-const amountRadiosMonthlyWildcard: {
-  [IsoCurrency]: Radio[]
-} = {
-  GBP: [
-    {
-      value: '5',
-      text: '£5',
-      accessibilityHint: 'contribute five pounds per month',
-    },
-    {
-      value: '7',
-      text: '£7',
-      accessibilityHint: 'contribute seven pounds per month',
-    },
-    {
-      value: '20',
-      text: '£20',
-      accessibilityHint: 'contribute twenty pounds per month',
-    },
-  ],
-  USD: [
-    {
-      value: '5',
-      text: '$5',
-      accessibilityHint: 'contribute five dollars per month',
-    },
-    {
-      value: '7',
-      text: '$7',
-      accessibilityHint: 'contribute seven dollars per month',
     },
     {
       value: '20',

--- a/assets/components/contribAmounts/contribAmounts.jsx
+++ b/assets/components/contribAmounts/contribAmounts.jsx
@@ -12,7 +12,7 @@ import {
   clickSubstituteKeyPressHandler,
 } from 'helpers/utilities';
 import { errorMessage as contributionErrorMessage } from 'helpers/contributions';
-import { amountRadiosMonthlyHigher, amountRadiosMonthlyLower, amountRadiosMonthlyWildcard } from 'helpers/amountsTest';
+import { amountRadiosMonthlyLower, amountRadiosMonthlyWildcard } from 'helpers/amountsTest';
 
 
 import type { Contrib, ContribError, Amounts } from 'helpers/contributions';
@@ -241,9 +241,6 @@ const contribCaptionRadios = {
 
 function getMonthlyAmount(abTests: Participations, currency: IsoCurrency) {
   if (currency === 'GBP') {
-    if (abTests.ukRecurringAmountsTest === 'higher') {
-      return amountRadiosMonthlyHigher[currency];
-    }
     if (abTests.ukRecurringAmountsTest === 'lower') {
       return amountRadiosMonthlyLower[currency];
     }
@@ -252,9 +249,6 @@ function getMonthlyAmount(abTests: Participations, currency: IsoCurrency) {
     }
   }
   if (currency === 'USD') {
-    if (abTests.usRecurringAmountsTest === 'higher') {
-      return amountRadiosMonthlyHigher[currency];
-    }
     if (abTests.usRecurringAmountsTest === 'lower') {
       return amountRadiosMonthlyLower[currency];
     }

--- a/assets/components/contribAmounts/contribAmounts.jsx
+++ b/assets/components/contribAmounts/contribAmounts.jsx
@@ -240,16 +240,27 @@ const contribCaptionRadios = {
 };
 
 function getMonthlyAmount(abTests: Participations, currency: IsoCurrency) {
-  if (abTests.ukRecurringAmountsTest === 'higher' || abTests.usRecurringAmountsTest === 'higher') {
-    return amountRadiosMonthlyHigher[currency];
+  if (currency === 'GBP') {
+    if (abTests.ukRecurringAmountsTest === 'higher') {
+      return amountRadiosMonthlyHigher[currency];
+    }
+    if (abTests.ukRecurringAmountsTest === 'lower') {
+      return amountRadiosMonthlyLower[currency];
+    }
+    if (abTests.ukRecurringAmountsTest === 'wildcard') {
+      return amountRadiosMonthlyWildcard[currency];
+    }
   }
-
-  if (abTests.ukRecurringAmountsTest === 'lower' || abTests.usRecurringAmountsTest === 'lower') {
-    return amountRadiosMonthlyLower[currency];
-  }
-
-  if (abTests.ukRecurringAmountsTest === 'wildcard' || abTests.usRecurringAmountsTest === 'wildcard') {
-    return amountRadiosMonthlyWildcard[currency];
+  if (currency === 'USD') {
+    if (abTests.usRecurringAmountsTest === 'higher') {
+      return amountRadiosMonthlyHigher[currency];
+    }
+    if (abTests.usRecurringAmountsTest === 'lower') {
+      return amountRadiosMonthlyLower[currency];
+    }
+    if (abTests.uRecurringAmountsTest === 'wildcard') {
+      return amountRadiosMonthlyWildcard[currency];
+    }
   }
 
   return amountRadiosMonthlyControl[currency];

--- a/assets/components/contribAmounts/contribAmounts.jsx
+++ b/assets/components/contribAmounts/contribAmounts.jsx
@@ -64,6 +64,7 @@ type ContribAttrs = {
 };
 
 
+
 // ----- Setup ----- //
 
 const amountRadiosAnnual: {
@@ -105,7 +106,7 @@ const amountRadiosAnnual: {
   ],
 };
 
-const amountRadiosMonthly: {
+const amountRadiosMonthlyControl: {
   [IsoCurrency]: Radio[]
 } = {
   GBP: [
@@ -135,6 +136,123 @@ const amountRadiosMonthly: {
       value: '10',
       text: '$10',
       accessibilityHint: 'contribute ten dollars per month',
+    },
+    {
+      value: '20',
+      text: '$20',
+      accessibilityHint: 'contribute twenty dollars per month',
+    },
+  ],
+};
+
+const amountRadiosMonthlyHigher: {
+  [IsoCurrency]: Radio[]
+} = {
+  GBP: [
+    {
+      value: '10',
+      text: '£10',
+      accessibilityHint: 'contribute ten pounds per month',
+    },
+    {
+      value: '20',
+      text: '£20',
+      accessibilityHint: 'contribute twenty pounds per month',
+    },
+    {
+      value: '50',
+      text: '£50',
+      accessibilityHint: 'contribute fifty pounds per month',
+    },
+  ],
+  USD: [
+    {
+      value: '10',
+      text: '$10',
+      accessibilityHint: 'contribute ten dollars per month',
+    },
+    {
+      value: '20',
+      text: '$20',
+      accessibilityHint: 'contribute twenty dollars per month',
+    },
+    {
+      value: '50',
+      text: '$50',
+      accessibilityHint: 'contribute fifty dollars per month',
+    },
+  ],
+};
+
+const amountRadiosMonthlyLower: {
+  [IsoCurrency]: Radio[]
+} = {
+  GBP: [
+    {
+      value: '2',
+      text: '£2',
+      accessibilityHint: 'contribute two pounds per month',
+    },
+    {
+      value: '5',
+      text: '£5',
+      accessibilityHint: 'contribute five pounds per month',
+    },
+    {
+      value: '10',
+      text: '£10',
+      accessibilityHint: 'contribute ten pounds per month',
+    },
+  ],
+  USD: [
+    {
+      value: '2',
+      text: '$2',
+      accessibilityHint: 'contribute two dollars per month',
+    },
+    {
+      value: '5',
+      text: '$5',
+      accessibilityHint: 'contribute five dollars per month',
+    },
+    {
+      value: '10',
+      text: '$10',
+      accessibilityHint: 'contribute ten dollars per month',
+    },
+  ],
+};
+
+const amountRadiosMonthlyWildcard: {
+  [IsoCurrency]: Radio[]
+} = {
+  GBP: [
+    {
+      value: '5',
+      text: '£5',
+      accessibilityHint: 'contribute five pounds per month',
+    },
+    {
+      value: '7',
+      text: '£7',
+      accessibilityHint: 'contribute seven pounds per month',
+    },
+    {
+      value: '20',
+      text: '£20',
+      accessibilityHint: 'contribute twenty pounds per month',
+    },
+  ],
+  USD: [
+    {
+      value: '5',
+      text: '$5',
+      accessibilityHint: 'contribute five dollars per month',
+    },
+    {
+      value: '7',
+      text: '$7',
+      accessibilityHint: 'contribute seven dollars per month',
     },
     {
       value: '20',
@@ -238,9 +356,26 @@ const contribCaptionRadios = {
   ],
 };
 
+function getMonthlyAmount(abTests: Participations, currency: IsoCurrency) {
+  if (abTests.ukRecurringAmountsTest === 'higher' || abTests.usRecurringAmountsTest === 'higher') {
+    return amountRadiosMonthlyHigher[currency];
+  }
+
+  if (abTests.ukRecurringAmountsTest === 'lower' || abTests.usRecurringAmountsTest === 'lower') {
+    return amountRadiosMonthlyLower[currency];
+  }
+
+  if (abTests.ukRecurringAmountsTest === 'wildcard' || abTests.usRecurringAmountsTest === 'wildcard') {
+    return amountRadiosMonthlyWildcard[currency];
+  }
+
+  return amountRadiosMonthlyControl[currency];
+
+}
+
 // ----- Functions ----- //
 
-function amountToggles(currency: IsoCurrency = 'GBP'): AmountToggle {
+function amountToggles(abTests: Participations, currency: IsoCurrency = 'GBP'): AmountToggle {
   return {
     ANNUAL: {
       name: 'contributions-amount-annual-toggle',
@@ -248,7 +383,7 @@ function amountToggles(currency: IsoCurrency = 'GBP'): AmountToggle {
     },
     MONTHLY: {
       name: 'contributions-amount-monthly-toggle',
-      radios: amountRadiosMonthly[currency],
+      radios: getMonthlyAmount(abTests, currency),
     },
     ONE_OFF: {
       name: 'contributions-amount-oneoff-toggle',
@@ -290,7 +425,7 @@ function getAttrs(props: PropTypes): ContribAttrs {
     return {
       toggleAction: props.changeContribAnnualAmount,
       checked: !userDefined ? props.contribAmount.annual.value : null,
-      toggles: amountToggles(props.currency.iso).ANNUAL,
+      toggles: amountToggles(props.abTests, props.currency.iso).ANNUAL,
       selected: userDefined,
       contribType: props.contribType,
       accessibilityHint: 'Annual contribution',
@@ -301,7 +436,7 @@ function getAttrs(props: PropTypes): ContribAttrs {
     return {
       toggleAction: props.changeContribMonthlyAmount,
       checked: !userDefined ? props.contribAmount.monthly.value : null,
-      toggles: amountToggles(props.currency.iso).MONTHLY,
+      toggles: amountToggles(props.abTests, props.currency.iso).MONTHLY,
       selected: userDefined,
       contribType: props.contribType,
       accessibilityHint: 'Monthly contribution',
@@ -313,7 +448,7 @@ function getAttrs(props: PropTypes): ContribAttrs {
   return {
     toggleAction: props.changeContribOneOffAmount,
     checked: !userDefined ? props.contribAmount.oneOff.value : null,
-    toggles: amountToggles(props.currency.iso).ONE_OFF,
+    toggles: amountToggles(props.abTests, props.currency.iso).ONE_OFF,
     selected: userDefined,
     contribType: props.contribType,
     accessibilityHint: `${props.isoCountry === 'us' ? 'one time' : 'one-off'} contribution`,

--- a/assets/helpers/abtestDefinitions.js
+++ b/assets/helpers/abtestDefinitions.js
@@ -66,7 +66,7 @@ export const tests: Tests = {
   usRecurringAmountsTest: {
     variants: ['control', 'higher', 'lower', 'wildcard'],
     audiences: {
-      GB: {
+      US: {
         offset: 0,
         size: 1,
       },

--- a/assets/helpers/abtestDefinitions.js
+++ b/assets/helpers/abtestDefinitions.js
@@ -64,7 +64,7 @@ export const tests: Tests = {
   },
 
   usRecurringAmountsTest: {
-    variants: ['control', 'lower', 'wildcard'],
+    variants: ['control', 'lower', 'higher'],
     audiences: {
       US: {
         offset: 0,

--- a/assets/helpers/abtestDefinitions.js
+++ b/assets/helpers/abtestDefinitions.js
@@ -52,7 +52,7 @@ export const tests: Tests = {
   },
 
   ukRecurringAmountsTest: {
-    variants: ['control', 'higher', 'lower', 'wildcard'],
+    variants: ['control', 'lower', 'wildcard'],
     audiences: {
       GB: {
         offset: 0,
@@ -64,7 +64,7 @@ export const tests: Tests = {
   },
 
   usRecurringAmountsTest: {
-    variants: ['control', 'higher', 'lower', 'wildcard'],
+    variants: ['control', 'lower', 'wildcard'],
     audiences: {
       US: {
         offset: 0,

--- a/assets/helpers/abtestDefinitions.js
+++ b/assets/helpers/abtestDefinitions.js
@@ -50,4 +50,28 @@ export const tests: Tests = {
     isActive: true,
     independence: 3,
   },
+
+  ukRecurringAmountsTest: {
+    variants: ['control', 'higher', 'lower', 'wildcard'],
+    audiences: {
+      GB: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: true,
+    independence: 4,
+  },
+
+  usRecurringAmountsTest: {
+    variants: ['control', 'higher', 'lower', 'wildcard'],
+    audiences: {
+      GB: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: true,
+    independence: 5,
+  },
 };

--- a/assets/helpers/amountsTest.js
+++ b/assets/helpers/amountsTest.js
@@ -1,0 +1,132 @@
+// @flow
+
+// ----- Imports --- //
+import type { Radio } from 'components/radioToggle/radioToggle';
+import type { IsoCurrency } from './internationalisation/currency';
+
+
+export const defaultAmounts = {
+  control: '10',
+  higher: '20',
+  lower: '5',
+  wildcard: '7',
+  notintest: '10',
+};
+
+
+export const amountRadiosMonthlyHigher: {
+  [IsoCurrency]: Radio[]
+} = {
+  GBP: [
+    {
+      value: '10',
+      text: '£10',
+      accessibilityHint: 'contribute ten pounds per month',
+    },
+    {
+      value: '20',
+      text: '£20',
+      accessibilityHint: 'contribute twenty pounds per month',
+    },
+    {
+      value: '50',
+      text: '£50',
+      accessibilityHint: 'contribute fifty pounds per month',
+    },
+  ],
+  USD: [
+    {
+      value: '10',
+      text: '$10',
+      accessibilityHint: 'contribute ten dollars per month',
+    },
+    {
+      value: '20',
+      text: '$20',
+      accessibilityHint: 'contribute twenty dollars per month',
+    },
+    {
+      value: '50',
+      text: '$50',
+      accessibilityHint: 'contribute fifty dollars per month',
+    },
+  ],
+};
+
+export const amountRadiosMonthlyLower: {
+  [IsoCurrency]: Radio[]
+} = {
+  GBP: [
+    {
+      value: '2',
+      text: '£2',
+      accessibilityHint: 'contribute two pounds per month',
+    },
+    {
+      value: '5',
+      text: '£5',
+      accessibilityHint: 'contribute five pounds per month',
+    },
+    {
+      value: '10',
+      text: '£10',
+      accessibilityHint: 'contribute ten pounds per month',
+    },
+  ],
+  USD: [
+    {
+      value: '2',
+      text: '$2',
+      accessibilityHint: 'contribute two dollars per month',
+    },
+    {
+      value: '5',
+      text: '$5',
+      accessibilityHint: 'contribute five dollars per month',
+    },
+    {
+      value: '10',
+      text: '$10',
+      accessibilityHint: 'contribute ten dollars per month',
+    },
+  ],
+};
+
+export const amountRadiosMonthlyWildcard: {
+  [IsoCurrency]: Radio[]
+} = {
+  GBP: [
+    {
+      value: '5',
+      text: '£5',
+      accessibilityHint: 'contribute five pounds per month',
+    },
+    {
+      value: '7',
+      text: '£7',
+      accessibilityHint: 'contribute seven pounds per month',
+    },
+    {
+      value: '20',
+      text: '£20',
+      accessibilityHint: 'contribute twenty pounds per month',
+    },
+  ],
+  USD: [
+    {
+      value: '5',
+      text: '$5',
+      accessibilityHint: 'contribute five dollars per month',
+    },
+    {
+      value: '7',
+      text: '$7',
+      accessibilityHint: 'contribute seven dollars per month',
+    },
+    {
+      value: '20',
+      text: '$20',
+      accessibilityHint: 'contribute twenty dollars per month',
+    },
+  ],
+};

--- a/assets/helpers/amountsTest.js
+++ b/assets/helpers/amountsTest.js
@@ -5,12 +5,41 @@ import type { Radio } from 'components/radioToggle/radioToggle';
 import type { IsoCurrency } from './internationalisation/currency';
 
 
-export const defaultAmounts = {
+export const defaultAmountsUK = {
   control: '10',
-  higher: '20',
   lower: '5',
   wildcard: '7',
   notintest: '10',
+};
+
+export const defaultAmountsUS = {
+  control: '10',
+  higher: '15',
+  lower: '5',
+  notintest: '10',
+};
+
+
+export const amountRadiosMonthlyHigher: {
+  [IsoCurrency]: Radio[]
+} = {
+  USD: [
+    {
+      value: '7',
+      text: '$7',
+      accessibilityHint: 'contribute seven dollars per month',
+    },
+    {
+      value: '15',
+      text: '$15',
+      accessibilityHint: 'contribute fifteen dollars per month',
+    },
+    {
+      value: '30',
+      text: '$30',
+      accessibilityHint: 'contribute thirty dollars per month',
+    },
+  ],
 };
 
 export const amountRadiosMonthlyLower: {
@@ -70,23 +99,6 @@ export const amountRadiosMonthlyWildcard: {
       value: '20',
       text: '£20',
       accessibilityHint: 'contribute twenty pounds per month',
-    },
-  ],
-  USD: [
-    {
-      value: '7',
-      text: '$7',
-      accessibilityHint: 'contribute seven dollars per month',
-    },
-    {
-      value: '15',
-      text: '$15',
-      accessibilityHint: 'contribute fifteen dollars per month',
-    },
-    {
-      value: '30',
-      text: '$30',
-      accessibilityHint: 'contribute thirty dollars per month',
     },
   ],
 };

--- a/assets/helpers/amountsTest.js
+++ b/assets/helpers/amountsTest.js
@@ -13,46 +13,6 @@ export const defaultAmounts = {
   notintest: '10',
 };
 
-
-export const amountRadiosMonthlyHigher: {
-  [IsoCurrency]: Radio[]
-} = {
-  GBP: [
-    {
-      value: '10',
-      text: '£10',
-      accessibilityHint: 'contribute ten pounds per month',
-    },
-    {
-      value: '20',
-      text: '£20',
-      accessibilityHint: 'contribute twenty pounds per month',
-    },
-    {
-      value: '50',
-      text: '£50',
-      accessibilityHint: 'contribute fifty pounds per month',
-    },
-  ],
-  USD: [
-    {
-      value: '10',
-      text: '$10',
-      accessibilityHint: 'contribute ten dollars per month',
-    },
-    {
-      value: '20',
-      text: '$20',
-      accessibilityHint: 'contribute twenty dollars per month',
-    },
-    {
-      value: '50',
-      text: '$50',
-      accessibilityHint: 'contribute fifty dollars per month',
-    },
-  ],
-};
-
 export const amountRadiosMonthlyLower: {
   [IsoCurrency]: Radio[]
 } = {
@@ -114,19 +74,19 @@ export const amountRadiosMonthlyWildcard: {
   ],
   USD: [
     {
-      value: '5',
-      text: '$5',
-      accessibilityHint: 'contribute five dollars per month',
-    },
-    {
       value: '7',
       text: '$7',
       accessibilityHint: 'contribute seven dollars per month',
     },
     {
-      value: '20',
-      text: '$20',
-      accessibilityHint: 'contribute twenty dollars per month',
+      value: '15',
+      text: '$15',
+      accessibilityHint: 'contribute fifteen dollars per month',
+    },
+    {
+      value: '30',
+      text: '$30',
+      accessibilityHint: 'contribute thirty dollars per month',
     },
   ],
 };

--- a/assets/pages/bundles-landing/bundlesLanding.jsx
+++ b/assets/pages/bundles-landing/bundlesLanding.jsx
@@ -8,6 +8,7 @@ import { Provider } from 'react-redux';
 import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
 import LinksFooter from 'components/footers/linksFooter/linksFooter';
 
+import { defaultAmounts } from 'helpers/amountsTest';
 import { getQueryParameter } from 'helpers/url';
 import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
@@ -20,6 +21,9 @@ import reducer from './bundlesLandingReducers';
 
 // New Design Test
 import supportLanding from './support-landing-ab-test/supportLanding';
+
+// Amounts test
+import { changeContribAmountMonthly } from './bundlesLandingActions';
 
 
 // ----- Redux Store ----- //
@@ -53,5 +57,16 @@ if (getQueryParameter('newDesigns', 'false') === 'true') {
     </Provider>
   );
 }
+
+(function initialiseAmountsTest() {
+  try {
+    const defaultSelectedAmount =
+      defaultAmounts[store.getState().common.abParticipations.ukRecurringAmountsTest];
+    return store.dispatch(changeContribAmountMonthly({
+      value: defaultSelectedAmount, userDefined: false,
+    }));
+  } catch (e) { return null; }
+}());
+
 
 renderPage(content, 'bundles-landing-page');

--- a/assets/pages/bundles-landing/bundlesLanding.jsx
+++ b/assets/pages/bundles-landing/bundlesLanding.jsx
@@ -8,7 +8,7 @@ import { Provider } from 'react-redux';
 import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
 import LinksFooter from 'components/footers/linksFooter/linksFooter';
 
-import { defaultAmounts } from 'helpers/amountsTest';
+import { defaultAmountsUK } from 'helpers/amountsTest';
 import { getQueryParameter } from 'helpers/url';
 import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
@@ -61,7 +61,8 @@ if (getQueryParameter('newDesigns', 'false') === 'true') {
 (function initialiseAmountsTest() {
   try {
     const defaultSelectedAmount =
-      defaultAmounts[store.getState().common.abParticipations.ukRecurringAmountsTest];
+      defaultAmountsUK[store.getState().common.abParticipations.ukRecurringAmountsTest]
+      || defaultAmountsUK.control;
     return store.dispatch(changeContribAmountMonthly({
       value: defaultSelectedAmount, userDefined: false,
     }));

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -137,6 +137,25 @@ const monthlyContribCopy: ContribAttrs = {
   ctaAccessibilityHint: 'Proceed to make a monthly contribution',
 };
 
+const monthlyContribCopyTwo: ContribAttrs = {
+  heading: 'contribute',
+  subheading: 'from £2/month',
+  ctaText: 'Contribute with card or PayPal',
+  ctaId: 'contribute',
+  modifierClass: 'contributions',
+  ctaLink: '',
+  ctaAccessibilityHint: 'Proceed to make a monthly contribution',
+};
+
+function getMonthlyContribCopy(abTests: ?Participations) {
+  if (abTests) {
+    return abTests.ukRecurringAmountsTest === 'lower'
+      ? monthlyContribCopyTwo
+      : monthlyContribCopy;
+  }
+  return monthlyContribCopy;
+}
+
 const annualContribCopy: ContribAttrs = {
   heading: 'contribute',
   subheading: 'from £50/year',
@@ -193,15 +212,17 @@ const paperCopy: PaperAttrs = {
   paperCtaAccessibilityHint: 'Proceed to paper subscription options, starting at ten pounds seventy nine pence per month.',
 };
 
-const bundles: BundlesType = {
-  contrib: {
-    oneOff: oneOffContribCopy,
-    monthly: monthlyContribCopy,
-    annual: annualContribCopy,
-  },
-  digital: digitalCopy,
-  paper: paperCopy,
-};
+function bundles(abTests: ?Participations): BundlesType {
+  return {
+    contrib: {
+      oneOff: oneOffContribCopy,
+      monthly: getMonthlyContribCopy(abTests),
+      annual: annualContribCopy,
+    },
+    digital: digitalCopy,
+    paper: paperCopy,
+  };
+}
 
 const ctaLinks = {
   annual: routes.recurringContribCheckout,
@@ -218,6 +239,7 @@ const getContribAttrs = (
   currency: IsoCurrency,
   isoCountry: string,
   intCmp: ?string,
+  abTests: Participations,
 ): ContribAttrs => {
 
   const contType = contribCamelCase(contribType);
@@ -235,7 +257,7 @@ const getContribAttrs = (
   const localisedOneOffContType = isoCountry === 'us' ? 'one time' : 'one-off';
   const ctaAccessibilityHint = `proceed to make your ${contType.toLowerCase() === 'oneoff' ? localisedOneOffContType : contType.toLowerCase()} contribution`;
 
-  return Object.assign({}, bundles.contrib[contType], {
+  return Object.assign({}, bundles(abTests).contrib[contType], {
     ctaId, ctaLink, ctaAccessibilityHint,
   });
 
@@ -243,7 +265,7 @@ const getContribAttrs = (
 
 function getPaperAttrs(subsLinks: SubsUrls): PaperAttrs {
 
-  return Object.assign({}, bundles.paper, {
+  return Object.assign({}, bundles().paper, {
     paperCtaId: 'paper-sub',
     paperCtaLink: subsLinks.paper,
     paperDigCtaId: 'paper-digital-sub',
@@ -253,7 +275,7 @@ function getPaperAttrs(subsLinks: SubsUrls): PaperAttrs {
 }
 
 function getDigitalAttrs(subsLinks: SubsUrls): DigitalAttrs {
-  return Object.assign({}, bundles.digital, { ctaLink: subsLinks.digital });
+  return Object.assign({}, bundles().digital, { ctaLink: subsLinks.digital });
 }
 
 function ContributionBundle(props: PropTypes) {
@@ -265,6 +287,7 @@ function ContributionBundle(props: PropTypes) {
       props.currency.iso,
       props.isoCountry,
       props.intCmp,
+      props.abTests,
     );
 
   const onClick = () => {
@@ -313,7 +336,7 @@ function DigitalBundle(props: DigitalAttrs) {
 
   return (
     <Bundle {...props}>
-      <FeatureList listItems={bundles.digital.listItems} />
+      <FeatureList listItems={bundles().digital.listItems} />
       <CtaLink
         ctaId={props.ctaId}
         text={props.ctaText}

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -69,6 +69,18 @@ const subHeadingMonthlyText = {
   US: 'from $5 a month',
 };
 
+const subHeadingMonthlyTextTwo = {
+  GB: 'from £2 a month',
+  US: 'from $2 a month',
+};
+
+function getSubHeadingMonthly(abTests: Participations, isoCountry: IsoCountry) {
+  return abTests.usRecurringAmountsTest === 'lower'
+    ? subHeadingMonthlyTextTwo[isoCountry]
+    : subHeadingMonthlyText[isoCountry];
+}
+
+
 const subHeadingOneOffText = {
   GB: '',
   US: '',
@@ -87,15 +99,20 @@ function ContentText(props: PropTypes) {
   }
 }
 
-
 const contribCtaText = {
   ANNUAL: 'Contribute with card or PayPal',
   MONTHLY: 'Contribute with card or PayPal',
   ONE_OFF: 'Contribute with debit/credit card',
 };
 
-function contribAttrs(isoCountry: IsoCountry, contribType: Contrib): ContribAttrs {
-  const subHeadingText = contribType === 'ONE_OFF' ? subHeadingOneOffText[isoCountry] : subHeadingMonthlyText[isoCountry];
+function contribAttrs(
+  isoCountry: IsoCountry,
+  contribType: Contrib,
+  abTests: Participations,
+): ContribAttrs {
+  const subHeadingText = contribType === 'ONE_OFF'
+    ? subHeadingOneOffText[isoCountry]
+    : getSubHeadingMonthly(abTests, isoCountry);
 
   return {
     heading: 'contribute',
@@ -152,6 +169,7 @@ const getContribAttrs = (
   referrerAcquisitionData: ReferrerAcquisitionData,
   isoCountry: IsoCountry,
   currency: IsoCurrency,
+  abTests: Participations,
 ): ContribAttrs => {
 
   const contType = getContribKey(contribType);
@@ -173,7 +191,7 @@ const getContribAttrs = (
 
   const ctaLink = `${ctaLinks[contType]}?${params.toString()}`;
 
-  return Object.assign({}, contribAttrs(isoCountry, contribType), { ctaLink });
+  return Object.assign({}, contribAttrs(isoCountry, contribType, abTests), { ctaLink });
 
 };
 
@@ -188,6 +206,7 @@ function ContributionsBundle(props: PropTypes) {
     props.referrerAcquisitionData,
     props.isoCountry,
     props.currency.iso,
+    props.abTests,
   );
 
   attrs.showPaymentLogos = true;

--- a/assets/pages/contributions-landing/contributionsLandingUS.jsx
+++ b/assets/pages/contributions-landing/contributionsLandingUS.jsx
@@ -7,6 +7,8 @@ import { applyMiddleware, compose } from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import { Provider } from 'react-redux';
 
+import { defaultAmounts } from 'helpers/amountsTest';
+
 import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
 import LinksFooter from 'components/footers/linksFooter/linksFooter';
 import ContribLegal from 'components/legal/contribLegal/contribLegal';
@@ -18,6 +20,8 @@ import reducer from './contributionsLandingReducers';
 import { saveContext } from './helpers/context';
 import ContributionsBundleContent from './components/contributionsBundleContent';
 
+import { changeContribAmountMonthly } from './contributionsLandingActions';
+
 // ----- Page Startup ----- //
 
 /* eslint-disable no-underscore-dangle */
@@ -27,6 +31,18 @@ const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 const store = pageInit(reducer, undefined, composeEnhancers(applyMiddleware(thunkMiddleware)));
 
 saveContext(store.dispatch);
+
+(function initialiseAmountsTest() {
+  try {
+    const defaultSelectedAmount =
+      defaultAmounts[store.getState().common.abParticipations.usRecurringAmountsTest];
+
+    return store.dispatch(changeContribAmountMonthly({
+      value: defaultSelectedAmount, userDefined: false,
+    }));
+  } catch (e) { return null; }
+}());
+
 
 // ----- Render ----- //
 

--- a/assets/pages/contributions-landing/contributionsLandingUS.jsx
+++ b/assets/pages/contributions-landing/contributionsLandingUS.jsx
@@ -7,7 +7,7 @@ import { applyMiddleware, compose } from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import { Provider } from 'react-redux';
 
-import { defaultAmounts } from 'helpers/amountsTest';
+import { defaultAmountsUS } from 'helpers/amountsTest';
 
 import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
 import LinksFooter from 'components/footers/linksFooter/linksFooter';
@@ -35,8 +35,8 @@ saveContext(store.dispatch);
 (function initialiseAmountsTest() {
   try {
     const defaultSelectedAmount =
-      defaultAmounts[store.getState().common.abParticipations.usRecurringAmountsTest];
-
+      defaultAmountsUS[store.getState().common.abParticipations.usRecurringAmountsTest]
+      || defaultAmountsUS.control;
     return store.dispatch(changeContribAmountMonthly({
       value: defaultSelectedAmount, userDefined: false,
     }));


### PR DESCRIPTION
This PR is a combination of 2 tests which tests different suggested amounts for US and UK recurring contributions.

The UK has the following amount variants:
Control: 5, 10, 20
Lower: 2, 5, 10
Wildcard: 5, 7 20

The US has the following variants:
Control: 5, 10, 20
Lower: 2, 5, 10
Higher: 7, 15, 30


 @guardian/contributions 
Screenshots:

Control UK
![ukcontrol](https://user-images.githubusercontent.com/2844554/33032505-57763ea0-ce19-11e7-900d-6cc9579ebb76.png)

Lower UK:
![loweruknew](https://user-images.githubusercontent.com/2844554/33123680-b82b04e2-cf72-11e7-9568-f870f16a1191.png)


Wildcard UK:
![wildcarduk](https://user-images.githubusercontent.com/2844554/33122812-32701e34-cf70-11e7-84bc-ef1aabcf0464.png)



Control US:
![uscontrol](https://user-images.githubusercontent.com/2844554/33032507-57a1d402-ce19-11e7-8285-774695336d41.png)

Lower US:
![uslowernew](https://user-images.githubusercontent.com/2844554/33123718-d1fdd2dc-cf72-11e7-84e0-5372916a2c88.png)

Higher US:

![ushigher](https://user-images.githubusercontent.com/2844554/33122847-4b093e1c-cf70-11e7-8bff-9d6cb4351e49.png)

