### PR TITLE
remove digipack test and remove header copy test

### DIFF
--- a/assets/components/ctaLink/ctaLink.jsx
+++ b/assets/components/ctaLink/ctaLink.jsx
@@ -24,7 +24,6 @@ type PropTypes = {
   tabIndex?: number,
   id?: ?string,
   svg?: Node,
-  dataLinkName?: ?string,
   acquisitionData?: ?ReferrerAcquisitionData,
 };
 
@@ -56,7 +55,6 @@ export default function CtaLink(props: PropTypes) {
       }
       onKeyPress={props.onClick ? clickSubstituteKeyPressHandler(props.onClick) : null}
       tabIndex={props.tabIndex}
-      data-link-name={props.dataLinkName}
       aria-describedby={accessibilityHintId}
     >
       <span>{props.text}</span>
@@ -76,7 +74,6 @@ CtaLink.defaultProps = {
   onClick: null,
   tabIndex: 0,
   id: null,
-  dataLinkName: null,
   svg: <SvgArrowRightStraight />,
   acquisitionData: null,
 };

--- a/assets/helpers/abtestDefinitions.js
+++ b/assets/helpers/abtestDefinitions.js
@@ -4,41 +4,6 @@ import type { Tests } from './abtest';
 // ----- Tests ----- //
 
 export const tests: Tests = {
-  addAnnualContributions: {
-    variants: ['control', 'variant'],
-    audiences: {
-      GB: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: false,
-  },
-
-  digipackFlowOptimisationTest: {
-    variants: ['control', 'variant'],
-    audiences: {
-      GB: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: true,
-    independence: 1,
-  },
-
-  headerCopyTest: {
-    variants: ['control', 'howAndWhy', 'numberOfSupporters'],
-    audiences: {
-      GB: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: true,
-    independence: 2,
-  },
-
   usRecurringCopyTest: {
     variants: ['control', 'subtitle', 'contributeBox'],
     audiences: {

--- a/assets/pages/bundles-landing/bundlesLanding.jsx
+++ b/assets/pages/bundles-landing/bundlesLanding.jsx
@@ -39,7 +39,7 @@ const content = (
   <Provider store={store}>
     <div>
       <SimpleHeader />
-      <Introduction abTests={store.getState().common.abParticipations} />
+      <Introduction />
       <Bundles />
       <WhySupport />
       <WaysOfSupport />

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -79,22 +79,6 @@
         line-height: 48px;
         margin-left: 160px;
       }
-
-      &.introduction-text__paragraph {
-        margin-left: 0;
-        font-weight: 400;
-        font-size: 16px;
-        line-height: 20px;
-        max-width: 460px;
-        font-family: $gu-text-egyptian-web;
-
-        @include mq($from: desktop) {
-          font-weight: 200;
-          font-size: 18px;
-          line-height: 22px;
-          max-width: 620px;
-        }
-      }
     }
   }
 

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -380,7 +380,6 @@ function Bundles(props: PropTypes) {
     props.intCmp,
     props.campaign,
     props.otherQueryParams,
-    props.abTests,
     props.referrerAcquisitionData,
   );
   const paperAttrs: PaperAttrs = getPaperAttrs(subsLinks);

--- a/assets/pages/bundles-landing/components/Introduction.jsx
+++ b/assets/pages/bundles-landing/components/Introduction.jsx
@@ -3,52 +3,17 @@
 // ----- Imports ----- //
 
 import React from 'react';
-import type { Participations } from 'helpers/abtest';
-
-type PropTypes = {
-    abTests: Participations,
-}
-
 
 // ----- Component ----- //
 
-export default function Introduction(props: PropTypes) {
-
-  const headerCopyOptions = {
-    control: {
-      line1: (<span>help us deliver the</span>),
-      line2: (<span>independent journalism the world&#160;needs</span>),
-    },
-    numberOfSupporters: {
-      line1: (<span>over 800,000 readers <br /> now help fund the&#160;Guardian </span>),
-      line2: (
-        <span>join them today and support&#160;the
-          <br />independent journalism the world needs
-        </span>
-      ),
-    },
-  };
-
-  const introParagraphMarkup = (
-    <p className="introduction-text__paragraph">
-      Your support helps to make our journalism possible.
-      We don&#39;t have a billionaire owner pulling the strings and we
-      haven&#39;t put up a paywall. Fund independent, quality journalism
-      and help us keep it open for all by making a contribution or getting a subscription.
-    </p>);
-  const introParagraph = props.abTests.headerCopyTest === 'howAndWhy'
-    ? introParagraphMarkup
-    : '';
-  const headerCopy = props.abTests.headerCopyTest === 'numberOfSupporters'
-    ? headerCopyOptions.numberOfSupporters
-    : headerCopyOptions.control;
+export default function Introduction() {
   return (
     <section className="introduction-text">
       <div className="introduction-text__content gu-content-margin">
-        <h1 className="introduction-text__heading">{headerCopy.line1}</h1>
-        <p>{headerCopy.line2}</p>
+        <h1 className="introduction-text__heading">help us deliver the</h1>
+        <p>independent journalism the world&nbsp;needs</p>
         <h1 className="introduction-text__heading">support the Guardian</h1>
-        <p>contribute or subscribe</p>{introParagraph}
+        <p>contribute or subscribe</p>
       </div>
     </section>
   );

--- a/assets/pages/bundles-landing/helpers/externalLinks.js
+++ b/assets/pages/bundles-landing/helpers/externalLinks.js
@@ -3,7 +3,6 @@
 // ----- Imports ----- //
 
 import type { Campaign } from 'helpers/tracking/acquisitions';
-import type { Participations } from 'helpers/abtest';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 
 // ----- Types ----- //
@@ -106,7 +105,6 @@ function buildSubsUrls(
   promoCodes: PromoCodes,
   intCmp: ?string,
   otherQueryParams: Array<[string, string]>,
-  abTests: Participations,
   referrerAcquisitionData: ReferrerAcquisitionData,
 ): SubsUrls {
 
@@ -118,12 +116,9 @@ function buildSubsUrls(
   const paper = `${subsUrl}/${promoCodes.paper}?${params.toString()}`;
   const paperDig = `${subsUrl}/${promoCodes.paperDig}?${params.toString()}`;
   const digital = `${subsUrl}/${promoCodes.digital}?${params.toString()}`;
-  params.append('promocode', promoCodes.digital.replace('p/', ''));
-  const digitalDigipackTestLink = `${subsUrl}/checkout?${params.toString()}`;
-  const shouldGetAlternativeDigipackLink = abTests.digipackFlowOptimisationTest === 'variant';
 
   return {
-    digital: shouldGetAlternativeDigipackLink ? digitalDigipackTestLink : digital,
+    digital,
     paper,
     paperDig,
   };
@@ -135,7 +130,6 @@ function getSubsLinks(
   intCmp: ?string,
   campaign: ?Campaign,
   otherQueryParams: Array<[string, string]>,
-  abTests: Participations,
   referrerAcquisitionData: ReferrerAcquisitionData,
 ): SubsUrls {
   if (campaign && customPromos[campaign]) {
@@ -143,12 +137,11 @@ function getSubsLinks(
       customPromos[campaign],
       intCmp,
       otherQueryParams,
-      abTests,
       referrerAcquisitionData,
     );
   }
 
-  return buildSubsUrls(defaultPromos, intCmp, otherQueryParams, abTests, referrerAcquisitionData);
+  return buildSubsUrls(defaultPromos, intCmp, otherQueryParams, referrerAcquisitionData);
 
 }
 

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/subscribeNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/subscribeNewDesign.jsx
@@ -8,7 +8,6 @@ import { connect } from 'react-redux';
 import InfoSection from 'components/infoSection/infoSection';
 
 import type { Campaign } from 'helpers/tracking/acquisitions';
-import type { Participations } from 'helpers/abtest';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 
 import SubscriptionBundle from './subscriptionBundleNewDesign';
@@ -24,7 +23,6 @@ type PropTypes = {
   intCmp: ?string,
   campaign: ?Campaign,
   otherQueryParams: Array<[string, string]>,
-  abTests: Participations,
   referrerAcquisitionData: ReferrerAcquisitionData,
 };
 
@@ -49,7 +47,6 @@ function Subscribe(props: PropTypes) {
     props.intCmp,
     props.campaign,
     props.otherQueryParams,
-    props.abTests,
     props.referrerAcquisitionData,
   );
 


### PR DESCRIPTION
This PR removes 2 UK landing page tests. 

1) The digipack flow test (https://github.com/guardian/support-frontend/pull/349). This test tried cutting out the second step from the digipack flow. It didn't succeed

2) The header copy test (https://github.com/guardian/support-frontend/pull/362). It tried 2 variants, one that added some explainer copy to the header, and one that changed the copy headline to a line about the number of supporters we have. Both variants failed to beat the control significantly. 

It also removed a test definition for an `addAnnualContributions` test, which is not active. 