### PR TITLE
Refactor ab test framework logic

### DIFF
--- a/assets/helpers/abTests/__tests__/abtestTest.js
+++ b/assets/helpers/abTests/__tests__/abtestTest.js
@@ -69,7 +69,8 @@ describe('basic behaviour of init', () => {
     const tests = {
       mockTest: {
         variants: ['control', 'variant'],
-        independence: 2,
+        independent: true,
+        seed: 2,
         audiences: {
           GB: {
             offset: 0,

--- a/assets/helpers/abTests/__tests__/abtestTest.js
+++ b/assets/helpers/abTests/__tests__/abtestTest.js
@@ -28,6 +28,8 @@ describe('basic behaviour of init', () => {
           },
         },
         isActive: true,
+        independent: false,
+        seed: 0,
       },
     };
 
@@ -52,6 +54,8 @@ describe('basic behaviour of init', () => {
           },
         },
         isActive: true,
+        independent: false,
+        seed: 0,
       },
     };
 
@@ -69,8 +73,6 @@ describe('basic behaviour of init', () => {
     const tests = {
       mockTest: {
         variants: ['control', 'variant'],
-        independent: true,
-        seed: 2,
         audiences: {
           GB: {
             offset: 0,
@@ -78,6 +80,8 @@ describe('basic behaviour of init', () => {
           },
         },
         isActive: true,
+        independent: true,
+        seed: 2,
       },
     };
 
@@ -102,6 +106,8 @@ describe('basic behaviour of init', () => {
           },
         },
         isActive: true,
+        independent: false,
+        seed: 0,
       },
     };
 
@@ -136,6 +142,8 @@ describe('Correct allocation in a multi test environment', () => {
         },
       },
       isActive: true,
+      independent: false,
+      seed: 0,
     },
 
     mockTest2: {
@@ -147,6 +155,8 @@ describe('Correct allocation in a multi test environment', () => {
         },
       },
       isActive: true,
+      independent: false,
+      seed: 0,
     },
   };
 

--- a/assets/helpers/abTests/abtest.js
+++ b/assets/helpers/abTests/abtest.js
@@ -41,7 +41,8 @@ export type Test = {
   variants: string[],
   audiences: Audiences,
   isActive: boolean,
-  independence?: number,
+  independent: boolean,
+  seed: number,
 };
 
 export type Tests = { [testId: string]: Test }
@@ -112,19 +113,19 @@ function userInTest(audiences: Audiences, mvtId: number, country: IsoCountry) {
   return (mvtId > testMin) && (mvtId < testMax);
 }
 
-function randomNumber(seed: number, independence: number): number {
-  if (independence === 0) {
-    return seed;
+function randomNumber(mvtId: number, independent: boolean, seed: number): number {
+  if (!independent) {
+    return mvtId;
   }
 
-  const rng = seedrandom(seed + independence);
+  const rng = seedrandom(mvtId + seed);
   return Math.abs(rng.int32());
 }
 
 function assignUserToVariant(mvtId: number, test: Test): string {
-  const independence = test.independence || 0;
+  const { independent, seed } = test;
 
-  const variantIndex = randomNumber(mvtId, independence) % test.variants.length;
+  const variantIndex = randomNumber(mvtId, independent, seed) % test.variants.length;
 
   return test.variants[variantIndex];
 }

--- a/assets/helpers/abTests/abtest.js
+++ b/assets/helpers/abTests/abtest.js
@@ -37,13 +37,13 @@ type Audiences = {
   },
 };
 
-export type Test = {
+export type Test = {|
   variants: string[],
   audiences: Audiences,
   isActive: boolean,
   independent: boolean,
   seed: number,
-};
+|};
 
 export type Tests = { [testId: string]: Test }
 

--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -13,7 +13,8 @@ export const tests: Tests = {
       },
     },
     isActive: true,
-    independence: 3,
+    independent: true,
+    seed: 3,
   },
 
   ukRecurringAmountsTest: {
@@ -25,7 +26,8 @@ export const tests: Tests = {
       },
     },
     isActive: true,
-    independence: 4,
+    independent: true,
+    seed: 4,
   },
 
   usRecurringAmountsTest: {
@@ -37,6 +39,7 @@ export const tests: Tests = {
       },
     },
     isActive: true,
-    independence: 5,
+    independent: true,
+    seed: 5,
   },
 };


### PR DESCRIPTION
## Why are you doing this?

After https://github.com/guardian/support-frontend/pull/345 we split the `independence` field into two fields. `independent` and `seed`.
  
## Changes

* Updated `abtests.js`
* Updated test definitions

## Screenshots
N/A
