### PR TITLE
New copy and promocodes for the 'Black Friday' promotion

### DIFF
--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -32,6 +32,7 @@ import {
 import { getSubsLinks } from '../helpers/externalLinks';
 
 import type { SubsUrls } from '../helpers/externalLinks';
+import { getDigiPackItems, getPaperItems } from '../helpers/blackFriday';
 
 
 // ----- Types ----- //
@@ -169,16 +170,7 @@ const annualContribCopy: ContribAttrs = {
 const digitalCopy: DigitalAttrs = {
   heading: 'digital subscription',
   subheading: '£11.99/month',
-  listItems: [
-    {
-      heading: 'Premium experience on the Guardian app',
-      text: 'No adverts means faster loading pages and a clearer reading experience. Play our daily crosswords offline wherever you are',
-    },
-    {
-      heading: 'Daily Tablet Edition app',
-      text: 'Read the Guardian, the Observer and all the Weekend supplements in an optimised tablet app; available on iPad, Android and Kindle Fire tablets',
-    },
-  ],
+  listItems: getDigiPackItems(),
   ctaText: 'Start your free trial',
   ctaId: 'start-digi-trial',
   modifierClass: 'digital',
@@ -189,18 +181,7 @@ const digitalCopy: DigitalAttrs = {
 const paperCopy: PaperAttrs = {
   heading: 'paper subscription',
   subheading: 'from £10.79/month',
-  listItems: [
-    {
-      heading: 'Choose your package and delivery method',
-      text: 'Everyday, Sixday, Weekend and Sunday; redeem paper vouchers or get home delivery',
-    },
-    {
-      heading: 'Save money on the retail price',
-    },
-    {
-      heading: 'Get all the benefits of a digital subscription with paper+digital',
-    },
-  ],
+  listItems: getPaperItems(),
   paperCtaText: 'Get a paper subscription',
   paperDigCtaText: 'Get a paper+digital subscription',
   modifierClass: 'paper',

--- a/assets/pages/bundles-landing/helpers/blackFriday.js
+++ b/assets/pages/bundles-landing/helpers/blackFriday.js
@@ -1,0 +1,52 @@
+import { getQueryParameter } from '../../../helpers/url'
+
+function inOfferPeriod() {
+  // The offer is valid between 24th November & 3rd December 2017
+  const now = new Date().getTime();
+  const startTime = new Date(2017, 11, 24, 0, 0).getTime();
+  const endTime = new Date(2017, 12, 4, 0, 0).getTime();
+
+  return (now > startTime && now < endTime) || getQueryParameter('black_friday', false);
+}
+
+const offerItem = { heading: 'Subscribe today and save 50% for your first three months' };
+
+function getDigiPackItems() {
+  const originalList = [
+    {
+      heading: 'Premium experience on the Guardian app',
+      text: 'No adverts means faster loading pages and a clearer reading experience. Play our daily crosswords offline wherever you are',
+    },
+    {
+      heading: 'Daily Tablet Edition app',
+      text: 'Read the Guardian, the Observer and all the Weekend supplements in an optimised tablet app; available on iPad, Android and Kindle Fire tablets',
+    },
+  ];
+
+  if (inOfferPeriod()) {
+    return [offerItem, ...originalList];
+  }
+  return originalList;
+}
+
+function getPaperItems() {
+  const items = [
+    {
+      heading: 'Choose your package and delivery method',
+      text: 'Everyday, Sixday, Weekend and Sunday; redeem paper vouchers or get home delivery',
+    },
+    {
+      heading: 'Get all the benefits of a digital subscription with paper+digital',
+    },
+  ];
+
+  if (inOfferPeriod()) { return [offerItem, ...items]; }
+
+  return [items[0], { heading: 'Save money on the retail price' }, items[1]];
+}
+
+export {
+  inOfferPeriod,
+  getDigiPackItems,
+  getPaperItems,
+};

--- a/assets/pages/bundles-landing/helpers/blackFriday.js
+++ b/assets/pages/bundles-landing/helpers/blackFriday.js
@@ -1,4 +1,4 @@
-import { getQueryParameter } from '../../../helpers/url'
+import { getQueryParameter } from '../../../helpers/url';
 
 function inOfferPeriod() {
   // The offer is valid between 24th November & 3rd December 2017

--- a/assets/pages/bundles-landing/helpers/externalLinks.js
+++ b/assets/pages/bundles-landing/helpers/externalLinks.js
@@ -4,6 +4,7 @@
 
 import type { Campaign } from 'helpers/tracking/acquisitions';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
+import { inOfferPeriod as inBlackFridayPeriod } from './blackFriday';
 
 // ----- Types ----- //
 
@@ -85,6 +86,11 @@ const customPromos : {
     paper: 'p/NBANJUSTONE',
     paperDig: 'p/NDBANJUSTONE',
   },
+  black_friday: {
+    digital: 'p/DBQ80M',
+    paper: 'p/GBQ80N',
+    paperDig: 'p/GBQ80N',
+  },
 };
 
 
@@ -132,9 +138,9 @@ function getSubsLinks(
   otherQueryParams: Array<[string, string]>,
   referrerAcquisitionData: ReferrerAcquisitionData,
 ): SubsUrls {
-  if (campaign && customPromos[campaign]) {
+  if ((campaign && customPromos[campaign]) || (!campaign && inBlackFridayPeriod())) {
     return buildSubsUrls(
-      customPromos[campaign],
+      customPromos[campaign || 'black_friday'],
       intCmp,
       otherQueryParams,
       referrerAcquisitionData,

--- a/assets/pages/bundles-landing/helpers/externalLinks.js
+++ b/assets/pages/bundles-landing/helpers/externalLinks.js
@@ -89,7 +89,7 @@ const customPromos : {
   black_friday: {
     digital: 'p/DBQ80M',
     paper: 'p/GBQ80N',
-    paperDig: 'p/GBQ80N',
+    paperDig: 'p/GBQ80O',
   },
 };
 


### PR DESCRIPTION
## Why are you doing this?
To provide new copy and promocodes for the 'Black Friday' promotion which runs from the 24th November to the 3rd December 2017

[**Trello Card**](https://trello.com/c/q2BGAVpY/1102-black-friday-promotions)

## Screenshots
Normal page copy:
<img width="637" alt="screen shot 2017-11-22 at 17 49 43" src="https://user-images.githubusercontent.com/181371/33142269-bed7e05e-cfad-11e7-9e14-45a4f71f443f.png">

During the 'Black Friday' period:
<img width="634" alt="screen shot 2017-11-22 at 17 49 25" src="https://user-images.githubusercontent.com/181371/33142286-ccf8056a-cfad-11e7-8781-d5697bbbb488.png">


