### PR TITLE
Send the new RequestInfo object to the step functions

### DIFF
--- a/app/services/stepfunctions/Client.scala
+++ b/app/services/stepfunctions/Client.scala
@@ -42,14 +42,14 @@ class Client(client: AWSStepFunctionsAsync, stateMachineWrapper: StateMachineCon
     AwsAsync(client.startExecutionAsync, new StartExecutionRequest().withStateMachineArn(arn).withInput(input))
   }
 
-  def triggerExecution[T](input: T)(
+  def triggerExecution[T](input: T, isTestUser: Boolean)(
     implicit
     ec: ExecutionContext,
     encoder: Encoder[T],
     stateWrapper: StateWrapper
   ): Response[StateMachineExecution] = {
     stateMachineWrapper
-      .map(machine => startExecution(machine.arn, stateWrapper.wrap(input)))
+      .map(machine => startExecution(machine.arn, stateWrapper.wrap(input, isTestUser)))
       .map(StateMachineExecution.fromStartExecution)
   }
 

--- a/app/services/stepfunctions/RegularContributionsClient.scala
+++ b/app/services/stepfunctions/RegularContributionsClient.scala
@@ -81,7 +81,7 @@ class RegularContributionsClient(
         supportAbTests = request.supportAbTests
       ))
     )
-    underlying.triggerExecution(createPaymentMethodState).bimap(
+    underlying.triggerExecution(createPaymentMethodState, user.isTestUser).bimap(
       { error =>
         logger.error(s"[$requestId] Failed to create regular contribution - $error")
         StateMachineFailure: RegularContributionError

--- a/app/services/stepfunctions/StateWrapper.scala
+++ b/app/services/stepfunctions/StateWrapper.scala
@@ -2,7 +2,7 @@ package services.stepfunctions
 
 import java.util.Base64
 
-import com.gu.support.workers.model.{ExecutionError, JsonWrapper}
+import com.gu.support.workers.model.{ExecutionError, JsonWrapper, RequestInfo}
 import cats.syntax.either._
 import io.circe.{Decoder, Encoder}
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
@@ -15,11 +15,14 @@ class StateWrapper(encryption: EncryptionProvider, useEncryption: Boolean) {
   implicit private val executionErrorEncoder = deriveEncoder[ExecutionError]
   implicit private val executionErrorDecoder = deriveDecoder[ExecutionError]
 
+  implicit private val requestInfoEncoder = deriveEncoder[RequestInfo]
+  implicit private val requestInfoDecoder = deriveDecoder[RequestInfo]
+
   implicit private val wrapperEncoder = deriveEncoder[JsonWrapper]
   implicit private val wrapperDecoder = deriveDecoder[JsonWrapper]
 
-  def wrap[T](state: T)(implicit encoder: Encoder[T]): String = {
-    JsonWrapper(encodeState(state), None, useEncryption).asJson.noSpaces
+  def wrap[T](state: T, isTestUser: Boolean)(implicit encoder: Encoder[T]): String = {
+    JsonWrapper(encodeState(state), None, RequestInfo(useEncryption, isTestUser, failed = false, Nil)).asJson.noSpaces
   }
 
   def unWrap[T](s: String)(implicit decoder: Decoder[T]): Try[T] =

--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-sts" % awsVersion,
   "org.typelevel" %% "cats" % "0.9.0",
   "com.dripower" %% "play-circe" % "2608.5",
-  "com.gu" %% "support-models" % "0.16",
+  "com.gu" %% "support-models" % "0.18",
   "com.gu" %% "support-config" % "0.7",
   "com.gu" %% "fezziwig" % "0.7",
   "com.typesafe.akka" %% "akka-agent" % "2.5.6",


### PR DESCRIPTION
## Why are you doing this?
The support-workers project now expects a RequestInfo object to be passed into new executions., this PR adds it.

[**Trello Card**](https://trello.com/c/woFAILTI/1090-make-it-easier-to-spot-failures-in-the-monthly-contributions-step-function-executions)

Depends on https://github.com/guardian/support-workers/pull/77

