### PR TITLE
Changed Font Colour From Black To neutral-1

### DIFF
--- a/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/assets/pages/contributions-landing/contributionsLanding.scss
@@ -358,7 +358,7 @@ strong {
 
 	.component-bundle__content-intro {
 		line-height: 20px;
-		margin-bottom: 24px;
+		margin-bottom: $gu-v-spacing * 2;
 		color: gu-colour(neutral-1);
 	}
 

--- a/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/assets/pages/contributions-landing/contributionsLanding.scss
@@ -109,6 +109,7 @@ strong {
 		max-width: 100%;
 		margin: $gu-h-spacing / 2;
 		line-height: 20px;
+		color: gu-colour(neutral-1);
 
 		@include mq($from: desktop) {
 			margin-left: 24px;
@@ -356,8 +357,9 @@ strong {
 	}
 
 	.component-bundle__content-intro {
-		line-height:20px;
-		margin-bottom:24px;
+		line-height: 20px;
+		margin-bottom: 24px;
+		color: gu-colour(neutral-1);
 	}
 
 	.component-radio-toggle input:not(:checked)+label, .component-number-input {


### PR DESCRIPTION
## Why are you doing this?

Just noticed that some of the font colours on the contributions landing page are in true black rather than `neutral-1`.

cc: @Amohkhan

## Changes

- Changed font colour from true black to `neutral-1`.

## Screenshots

**Before:**

![fontcolour-before](https://user-images.githubusercontent.com/5131341/33185266-5b2a4372-d079-11e7-92b4-cb1673788528.png)

**After:**

![fontcolour-after](https://user-images.githubusercontent.com/5131341/33185267-61116824-d079-11e7-95ab-2a1495ccb07f.png)