### PR TITLE
Structure Test - With T&Cs

### DIFF
--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -274,6 +274,16 @@
     .component-bundle--contributions.component-bundle--structure-test {
       border-top: 2px gu-colour(neutral-1) solid;
 
+      .component-bundle__content {
+        p {
+          font-family: $gu-text-sans-web;
+        }
+      }
+
+      .component-terms-privacy {
+        margin-top: $gu-v-spacing;
+      }
+
       @include mq($from: desktop) {
         margin-right: $gu-h-spacing/2;
         width: 920px;
@@ -287,9 +297,14 @@
 
         .component-bundle__content {
           p {
-            float: left;
-            width: 400px;
+            margin-bottom: 0;
           }
+        }
+
+        .component-terms-privacy {
+          font-size: 16px;
+          width: 500px;
+          margin-top: 0;
         }
 
         .component-contrib-amounts {

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -296,20 +296,20 @@
           position: absolute;
           top: $gu-v-spacing/2;
           right: $gu-h-spacing/2;
-          width: 500px;
+          width: 280px;
         }
 
         .component-cta-link {
-          margin-left: 415px;
-          width: 465px;
+          margin-left: 640px;
+          width: 240px;
           svg {
-            left: 479px;
+            left: 250px;
           }
         }
 
         .component-paypal-contribution-button {
-          margin-left: 415px;
-          width: 507px;
+          margin-left: 640px;
+          width: 280px;
         }
 
       }

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -287,7 +287,7 @@
       @include mq($from: desktop) {
         margin-right: $gu-h-spacing/2;
         width: 920px;
-        height: 270px;
+        height: 286px;
 
         .component-double-heading {
           margin-bottom: 0;

--- a/assets/pages/bundles-landing/components/bundlesGBStructureTest.jsx
+++ b/assets/pages/bundles-landing/components/bundlesGBStructureTest.jsx
@@ -10,6 +10,7 @@ import CtaLink from 'components/ctaLink/ctaLink';
 import Bundle from 'components/bundle/bundle';
 import ContribAmounts from 'components/contribAmounts/contribAmounts';
 import PayPalContributionButton from 'components/payPalContributionButton/payPalContributionButton';
+import TermsPrivacy from 'components/legal/termsPrivacy/termsPrivacy';
 import { routes } from 'helpers/routes';
 import { contribCamelCase } from 'helpers/contributions';
 
@@ -288,6 +289,8 @@ function ContributionBundle(props: PropTypes) {
         canClick={!props.contribError}
       />
       }
+
+      <TermsPrivacy country={props.isoCountry} />
 
     </Bundle>
   );


### PR DESCRIPTION
## Why are you doing this?

Adding the T&Cs to the contribute bundle, in part to solve the whitespace issue. This also moves the contribution toggles and CTAs back to the right. It also makes the bundle slightly taller to fit a longer version of the error message.

[**Trello Card**](https://trello.com)

## Changes

- Made the contribution amounts narrower again, so they fit into the right column.
- Added the terms and conditions to the contribution bundle in the variant.
- Made the bundle slightly taller to fit the long error message.

## Screenshots

**Desktop:**

![desktop-contribute](https://user-images.githubusercontent.com/5131341/33212004-fdbbb374-d118-11e7-8d8c-ee4e2142af2b.png)

**Mobile:**

![mobile-contribute](https://user-images.githubusercontent.com/5131341/33212008-060da442-d119-11e7-8df5-489c0153534c.png)
