### PR TITLE
Add T&Cs To Pages With Payment Options

### DIFF
--- a/assets/pages/bundles-landing/bundlesLanding.jsx
+++ b/assets/pages/bundles-landing/bundlesLanding.jsx
@@ -43,7 +43,7 @@ const content = (
       <Bundles />
       <WhySupport />
       <WaysOfSupport />
-      <Footer privacyPolicy />
+      <Footer privacyPolicy disclaimer />
     </div>
   </Provider>
 );
@@ -58,6 +58,5 @@ const content = (
     }));
   } catch (e) { return null; }
 }());
-
 
 renderPage(content, 'bundles-landing-page');

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -126,7 +126,7 @@
       @include mq($from: desktop) {
         margin: 0 ($gu-h-spacing / 2);
         width: 280px;
-        height: 480px;
+        height: 484px;
         display: inline-block;
         vertical-align: top;
         position: relative;
@@ -150,7 +150,11 @@
         }
 
         &.contribute-one_off {
-          bottom: 122px;
+          bottom: 130px;
+        }
+
+        &.contribute-monthly {
+          bottom: 72px;
         }
       }
 
@@ -245,7 +249,7 @@
 
       @include mq($from: desktop) {
         width: 280px;
-        bottom: 64px;
+        bottom: 72px;
         position: absolute;
       }
 

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -126,7 +126,7 @@
       @include mq($from: desktop) {
         margin: 0 ($gu-h-spacing / 2);
         width: 280px;
-        height: 434px;
+        height: 480px;
         display: inline-block;
         vertical-align: top;
         position: relative;
@@ -150,7 +150,7 @@
         }
 
         &.contribute-one_off {
-          bottom: 72px;
+          bottom: 122px;
         }
       }
 
@@ -227,6 +227,16 @@
           opacity: 0.4;
         }
       }
+
+      .component-terms-privacy {
+        margin-top: $gu-v-spacing;
+
+        @include mq($from: desktop) {
+          margin-top: 0;
+          position: absolute;
+          bottom: $gu-v-spacing;
+        }
+      }
     }
 
     .component-paypal-contribution-button {
@@ -235,7 +245,7 @@
 
       @include mq($from: desktop) {
         width: 280px;
-        bottom: $gu-v-spacing;
+        bottom: 64px;
         position: absolute;
       }
 

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -10,6 +10,7 @@ import CtaLink from 'components/ctaLink/ctaLink';
 import Bundle from 'components/bundle/bundle';
 import ContribAmounts from 'components/contribAmounts/contribAmounts';
 import PayPalContributionButton from 'components/payPalContributionButton/payPalContributionButton';
+import TermsPrivacy from 'components/legal/termsPrivacy/termsPrivacy';
 import { routes } from 'helpers/routes';
 import { contribCamelCase } from 'helpers/contributions';
 
@@ -259,6 +260,16 @@ function getDigitalAttrs(subsLinks: SubsUrls): DigitalAttrs {
   return Object.assign({}, bundles().digital, { ctaLink: subsLinks.digital });
 }
 
+function TermsAndPrivacy(props: { country: IsoCountry, contribType: Contrib }) {
+
+  if (props.contribType === 'ONE_OFF') {
+    return <TermsPrivacy country={props.country} />;
+  }
+
+  return null;
+
+}
+
 function ContributionBundle(props: PropTypes) {
 
   const contribAttrs: ContribAttrs =
@@ -307,6 +318,8 @@ function ContributionBundle(props: PropTypes) {
           canClick={!props.contribError}
         />
       }
+
+      <TermsAndPrivacy country={props.isoCountry} contribType={props.contribType} />
 
     </Bundle>
   );

--- a/assets/pages/bundles-landing/components/Bundles.jsx
+++ b/assets/pages/bundles-landing/components/Bundles.jsx
@@ -260,16 +260,6 @@ function getDigitalAttrs(subsLinks: SubsUrls): DigitalAttrs {
   return Object.assign({}, bundles().digital, { ctaLink: subsLinks.digital });
 }
 
-function TermsAndPrivacy(props: { country: IsoCountry, contribType: Contrib }) {
-
-  if (props.contribType === 'ONE_OFF') {
-    return <TermsPrivacy country={props.country} />;
-  }
-
-  return null;
-
-}
-
 function ContributionBundle(props: PropTypes) {
 
   const contribAttrs: ContribAttrs =
@@ -297,14 +287,12 @@ function ContributionBundle(props: PropTypes) {
         onNumberInputKeyPress={onClick}
         {...props}
       />
-
       <CtaLink
         ctaId={contribAttrs.ctaId.toLowerCase()}
         text={contribAttrs.ctaText}
         accessibilityHint={contribAttrs.ctaAccessibilityHint}
         onClick={onClick}
       />
-
       {props.contribType === 'ONE_OFF' && !!contribAttrs.paypalCta &&
         <PayPalContributionButton
           buttonText={contribAttrs.paypalCta.text}
@@ -318,9 +306,7 @@ function ContributionBundle(props: PropTypes) {
           canClick={!props.contribError}
         />
       }
-
-      <TermsAndPrivacy country={props.isoCountry} contribType={props.contribType} />
-
+      <TermsPrivacy country={props.isoCountry} />
     </Bundle>
   );
 

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -11,6 +11,7 @@ import ErrorMessage from 'components/errorMessage/errorMessage';
 import { routes } from 'helpers/routes';
 import ContribAmounts from 'components/contribAmounts/contribAmounts';
 import PayPalContributionButton from 'components/payPalContributionButton/payPalContributionButton';
+import TermsPrivacy from 'components/legal/termsPrivacy/termsPrivacy';
 
 import type { Contrib, Amounts, ContribError } from 'helpers/contributions';
 import type { IsoCountry } from 'helpers/internationalisation/country';
@@ -195,6 +196,16 @@ const getContribAttrs = (
 
 };
 
+function TermsAndPrivacy(props: { country: IsoCountry, contribType: Contrib }) {
+
+  if (props.contribType === 'ONE_OFF') {
+    return <TermsPrivacy country={props.country} />;
+  }
+
+  return null;
+
+}
+
 
 // ----- Component ----- //
 
@@ -237,6 +248,7 @@ function ContributionsBundle(props: PropTypes) {
       />
       {showPayPal(props)}
       {showPayPalError(props)}
+      <TermsAndPrivacy country={props.isoCountry} contribType={props.contribType} />
     </Bundle>
   );
 

--- a/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/assets/pages/contributions-landing/contributionsLanding.scss
@@ -260,6 +260,10 @@ strong {
 			height: 450px;
 			position: relative;
 		}
+
+		.component-terms-privacy {
+			color: #333;
+		}
 	}
 
 	.contributions-bundle__content {


### PR DESCRIPTION
## Why are you doing this?

It's important that we're clear about the terms and conditions on pages where people are able to make payments. This tweaks a couple of the contribute bundles where the direct link to PayPal payment is available, and adds some additional copy to a footer.

cc: @Amohkhan

[**Trello Card**](https://trello.com/c/DyC89q1D/1106-add-tcs-where-we-have-direct-paypal-button)

## Changes

- Added a disclaimer to the footer on the bundles landing page.
- Added T&Cs to the contribute bundle on the bundles landing page.
- Added T&Cs to the contribute bundle on the contributions landing page.

## Screenshots

**Bundles Landing - Monthly:**

![t c-monthly-bundle](https://user-images.githubusercontent.com/5131341/33215125-858eb55a-d126-11e7-819b-65be5523c0ca.png)

![t c-monthly-full](https://user-images.githubusercontent.com/5131341/33215114-7fb4af4a-d126-11e7-9bcb-3edb162afded.png)

**Bundles Landing - One-off:**

![t c-oneoff-bundle](https://user-images.githubusercontent.com/5131341/33215147-9b55ebc4-d126-11e7-8f5b-e9025539827e.png)

![t c-oneoff-full](https://user-images.githubusercontent.com/5131341/33215159-a00a572c-d126-11e7-8d80-0585150d37f8.png)

**US:**

![t c-bundle-us](https://user-images.githubusercontent.com/5131341/33215167-a7b2daa8-d126-11e7-8615-c99b909fb5d8.png)

**Bundles Landing - Footer:**

![t c-footer](https://user-images.githubusercontent.com/5131341/33215181-b0684c64-d126-11e7-88d2-aa809cb183b0.png)