### PR TITLE
Fix Placeholder Colour Weirdness In Safari

### DIFF
--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -276,18 +276,23 @@
         background-color: gu-colour(multimedia-main-2);
       }
 
+      .component-number-input__input::placeholder {
+        color: gu-colour(neutral-1);
+        opacity: 0.6;
+      }
+
       .component-number-input--selected {
         background-color: gu-colour(neutral-1);
         font-weight: bold;
 
         .component-number-input__input, .component-number-input__label {
           color: #fff;
-        }
 
-        &::placeholder {
-          font-weight: normal;
-          color: #fff;
-          opacity: 0.4;
+          &::placeholder {
+            font-weight: normal;
+            color: #fff;
+            opacity: 0.4;
+          }
         }
       }
 

--- a/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/assets/pages/contributions-landing/contributionsLanding.scss
@@ -370,6 +370,11 @@ strong {
     background-color: gu-colour(comment-support-3);
 	}
 
+	.component-number-input__input::placeholder {
+    color: gu-colour(neutral-1);
+    opacity: 0.6;
+  }
+
 	.component-number-input__label {
 		top: 11px;
 	}
@@ -379,6 +384,11 @@ strong {
 
     .component-number-input__input, .component-number-input__label {
 			color: #fff;
+			&::placeholder {
+        font-weight: normal;
+        color: #fff;
+        opacity: 0.4;
+      }
 		}
 	}
 


### PR DESCRIPTION
## Why are you doing this?

On input elements, other browsers seem to inherit the placeholder colour from the main text colour. Safari doesn't, which causes a legibility problem (see screenshots below). This PR addresses that.

cc: @Amohkhan

## Changes

- Fix the placeholder colour of the 'other amount' input on the bundles landing page.
- Fix the placeholder colour of the 'other amount' input on the contributions landing page.

## Screenshots

**Before - Bundles Landing:**

![screen shot 2017-11-30 at 12 16 07](https://user-images.githubusercontent.com/5131341/33430419-5fedca88-d5c8-11e7-8ede-d83140dd439a.png)

**After - Bundles Landing:**

![screen shot 2017-11-30 at 12 16 19](https://user-images.githubusercontent.com/5131341/33430425-65d0061e-d5c8-11e7-9311-e6d0c23c0eeb.png)

**Before - Contributions Landing:**

![screen shot 2017-11-30 at 12 16 38](https://user-images.githubusercontent.com/5131341/33430435-6ee71288-d5c8-11e7-877c-7eaf83d016f5.png)

**After - Contributions Landing:**

![screen shot 2017-11-30 at 12 16 29](https://user-images.githubusercontent.com/5131341/33430444-7619f4f8-d5c8-11e7-87aa-24a31c4e3b98.png)