### PR TITLE
Support Landing Page - Part 10 - Little Tweaks

### DIFF
--- a/assets/helpers/contributions.js
+++ b/assets/helpers/contributions.js
@@ -122,8 +122,7 @@ function errorMessage(
     case 'tooLittle':
       return `Please enter at least ${currency.glyph}${minContrib}`;
     case 'tooMuch':
-      return `We are presently only able to accept contributions of
-        ${currency.glyph}${maxContrib} or less`;
+      return `${currency.glyph}${maxContrib} is the maximum we can accept`;
     case 'invalidEntry':
     default:
       return 'Please enter a numeric amount';

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/subscribeNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/subscribeNewDesign.jsx
@@ -73,7 +73,7 @@ function Subscribe(props: PropTypes) {
             ctaUrl={subsLinks.paper}
           />
           <SubscriptionBundle
-            heading="paper & digital"
+            heading="paper + digital"
             price="22.06"
             from
             copy={subscriptionFeatures.paperDig}

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/subscriptionBundleNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/subscriptionBundleNewDesign.jsx
@@ -40,8 +40,7 @@ export default function SubscriptionBundle(props: PropTypes) {
       <h3 className="subscription-bundle__heading">{props.heading}</h3>
       <h4 className="subscription-bundle__price">
         {props.from ? 'from ' : ''}
-        <span className="subscription-bundle__price-amount">£{props.price}</span>
-        <span className="subscription-bundle__price-period"> /&nbsp;month</span>
+        £{props.price}/month
       </h4>
       <p className="subscription-bundle__copy">
         <FeatureList listItems={props.copy} />

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -211,6 +211,7 @@
 
   .contribute-new-design__content {
     background-color: #fff;
+    font-family: $gu-text-sans-web;
     border-color: gu-colour(light-yellow);
     color: gu-colour(neutral-2);
     position: relative;
@@ -397,6 +398,7 @@
       font-size: 14px;
       line-height: 36px;
       color: gu-colour(neutral-1);
+      font-family: $gu-text-sans-web;
     }
 
     .component-number-input__label {

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -649,25 +649,21 @@
 
   .subscription-bundle__heading {
     font-family: $gu-egyptian-web;
-    font-weight: 100;
-    font-size: 36px;
-    line-height: 44px;
+    font-weight: bold;
+    font-size: 30px;
+    line-height: 30px;
+    padding-top: 2px;
     color: gu-colour(neutral-1);
     border-top: 1px solid gu-colour(light-yellow);
   }
 
   .subscription-bundle__price {
-    font-family: $gu-egyptian-web;
+    font-family: $gu-text-sans-web;
     font-size: 24px;
-    line-height: 28px;
-    padding: $gu-v-spacing 0;
+    line-height: 24px;
+    padding: ($gu-v-spacing / 2) 0 ($gu-v-spacing * 2);
     color: gu-colour(neutral-1);
     font-weight: 500;
-  }
-
-  .subscription-bundle__price-amount {
-    font-size: 36px;
-    line-height: 28px;
   }
 
   .subscription-bundle__copy {

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -392,7 +392,7 @@
 
     @include mq($from: phablet) {
       display: inline-block;
-      margin-left: 24px;
+      margin-left: $gu-v-spacing;
       margin-top: $gu-v-spacing;
       margin-bottom: $gu-v-spacing * 2;
     }
@@ -448,13 +448,13 @@
 
   .component-contribution-selection--monthly {
     .component-number-input, .component-error-message {
-      width: 305px;
+      width: 317px;
     }
   }
 
   .component-contribution-selection--one-off {
     .component-number-input, .component-error-message {
-      width: 249px;
+      width: 261px;
     }
   }
 

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -517,13 +517,13 @@
   // ----- Behind The Scenes
 
   .behind-the-scenes-new-design {
-    background-color: darken(#fff, 5%);
+    background-color: darken(gu-colour(neutral-6), 5%);
   }
 
   .behind-the-scenes-new-design__content {
     background-color: gu-colour(neutral-6);
     color: gu-colour(neutral-1);
-    border-top: 1px solid gu-colour(neutral-4);
+    border-top: none;
     padding-bottom: $gu-v-spacing * 2;
     position: relative;
     overflow: hidden;
@@ -688,7 +688,7 @@
 
   .why-support-new-design__content {
     background-color: #fff;
-    border-top: 1px solid gu-colour(neutral-4);
+    border-top: none;
   }
 
   .why-support-new-design__wrapper {

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -1134,7 +1134,7 @@
   // ----- Other Ways
 
   .other-ways-new-design {
-    background-color: darken(#fff, 5%);
+    background-color: darken(gu-colour(neutral-1), 5%);
   }
 
   .other-ways-new-design__content {

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -269,8 +269,8 @@
 
     .component-paypal-contribution-button {
       height: 52px;
-      border-color: #012169;
-      color: #012169;
+      border-color: gu-colour(guardian-brand);
+      color: gu-colour(guardian-brand);
       font-size: 14px;
       font-family: $gu-text-sans-web;
       width: 100%;
@@ -292,6 +292,19 @@
 
       .paypal-p-logo-1 {
         fill: #009cde;
+      }
+
+      &:hover {
+        color: gu-colour(guardian-brand-light);
+        border-color: gu-colour(guardian-brand-light);
+
+        .svg-arrow-right-straight {
+          fill: gu-colour(guardian-brand-light);
+        }
+
+        .paypal-p-logo-0, .paypal-p-logo-1, .paypal-p-logo-2 {
+          opacity: 0.6;
+        }
       }
     }
   }

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -628,6 +628,7 @@
       button {
         background-color: gu-colour(multimedia-main-2);
         vertical-align: middle;
+        margin-right: 12px;
 
         svg {
           fill: gu-colour(neutral-1);

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -1082,11 +1082,11 @@
         @extend .floating-semicircle;
         content: " ";
         position: absolute;
-        top: -27px;
+        top: -26px;
         right: 0;
 
         @include mq($from: tablet) {
-          top: -32px;
+          top: -31px;
         }
 
         @include mq($from: desktop) {
@@ -1112,6 +1112,7 @@
 
   .ready-new-design__content {
     background-color: #fff;
+    padding-top: 0;
     padding-bottom: $gu-v-spacing * 3;
   }
 
@@ -1129,6 +1130,10 @@
     @include mq($from: tablet) {
       font-size: 36px;
       line-height: 40px;
+    }
+
+    @include mq($from: desktop) {
+      padding-top: $gu-v-spacing / 2;
     }
   }
 

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -240,7 +240,7 @@
     .component-cta-link {
       height: 54px;
       line-height: 54px;
-      background-color: gu-colour(comment-main-2);
+      background-color: gu-colour(multimedia-main-2);
       color: gu-colour(neutral-1);
       font-size: 14px;
       font-weight: bold;
@@ -251,7 +251,7 @@
       margin-top: $gu-v-spacing * 2;
 
       &:hover {
-        background-color: darken(gu-colour(comment-main-2), 5%);
+        background-color: gu-colour(light-yellow);
       }
 
       @include mq($from: tablet) {
@@ -322,7 +322,7 @@
     }
 
     .component-radio-toggle__input:checked+.component-radio-toggle__label {
-      background-color: gu-colour(comment-main-2);
+      background-color: gu-colour(multimedia-main-2);
       font-weight: bold;
       color: gu-colour(neutral-1);
     }
@@ -337,7 +337,7 @@
 
     .component-radio-toggle {
       display: inline;
-      border: 1px solid gu-colour(comment-main-2);
+      border: 1px solid gu-colour(multimedia-main-2);
       border-radius: 600px;
       padding: 13px 0;
     }
@@ -363,7 +363,7 @@
     .component-radio-toggle__label {
       display: inline-block;
       text-align: center;
-      border: 1px solid gu-colour(comment-main-2);
+      border: 1px solid gu-colour(multimedia-main-2);
       line-height: 42px;
       width: 42px;
       height: 42px;
@@ -387,7 +387,7 @@
 
     .component-number-input {
       background-color: #fff;
-      border: 1px solid gu-colour(comment-main-2);
+      border: 1px solid gu-colour(multimedia-main-2);
       padding: 0;
       margin: 0;
       height: 42px;
@@ -404,7 +404,7 @@
     }
 
     .component-number-input--selected {
-      background-color: gu-colour(comment-main-2);
+      background-color: gu-colour(multimedia-main-2);
 
       .component-number-input__label {
         color: gu-colour(neutral-1);
@@ -613,7 +613,7 @@
       }
 
       button {
-        background-color: gu-colour(neutral-6);
+        background-color: gu-colour(multimedia-main-2);
         vertical-align: middle;
 
         svg {
@@ -628,7 +628,7 @@
         text-decoration: none;
 
         button {
-          background-color: gu-colour(multimedia-main-2);
+          background-color: gu-colour(light-yellow);
         }
       }
     }
@@ -1179,7 +1179,7 @@
   }
 
   .other-ways-card-new-design__image {
-    border-bottom: 2px solid gu-colour(comment-main-2);
+    border-bottom: 2px solid gu-colour(multimedia-main-2);
 
     .component-grid-image {
       display: block;
@@ -1195,7 +1195,7 @@
     }
 
     button {
-      background-color: gu-colour(comment-main-2);
+      background-color: gu-colour(multimedia-main-2);
       margin-right: $gu-h-spacing / 2;
     }
 

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -662,7 +662,7 @@
     flex-grow: 1;
 
     .component-feature-list {
-      list-style-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 28 28"><style>.st0{fill:#333;}</style><path class="st0" d="M7.885 25.74L0 14.82l3.22-3.217L8.3 16.74 24.695 2.26 28 5.565"/></svg>');
+      list-style-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 28 28"><style>.st0{fill:#ffbb00;}</style><path class="st0" d="M7.885 25.74L0 14.82l3.22-3.217L8.3 16.74 24.695 2.26 28 5.565"/></svg>');
       padding-left: 0;
       
       h3, p {

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -915,6 +915,7 @@
 
     @include mq($from: desktop) {
       padding-top: 120px;
+      padding-bottom: 180px;
       padding-left: 0;
     }
 

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -249,7 +249,7 @@
       padding-top: 0;
       padding-bottom: 0;
       box-sizing: border-box;
-      margin-top: $gu-v-spacing * 2;
+      margin-top: $gu-v-spacing;
 
       &:hover {
         background-color: gu-colour(light-yellow);
@@ -368,10 +368,8 @@
     margin-top: $gu-v-spacing;
 
     @include mq($until: phablet) {
-      border-top: 2px dotted gu-colour(neutral-3);
       width: 100%;
-      padding-top: $gu-v-spacing;
-      margin-top: $gu-v-spacing * 2;
+      margin-top: $gu-v-spacing;
     }
 
     .component-radio-toggle__label {
@@ -388,7 +386,7 @@
   .component-contribution-selection__custom-amount {
     vertical-align: top;
     margin-top: $gu-v-spacing * 2;
-    margin-bottom: $gu-v-spacing * 4;
+    margin-bottom: $gu-v-spacing * 3;
     display: block;
     position: relative;
 
@@ -461,7 +459,7 @@
   }
 
   .component-terms-privacy {
-    margin-top: $gu-v-spacing * 2;
+    margin-top: $gu-v-spacing;
   }
 
   .grave-error {

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -3,7 +3,7 @@
   // ----- General
 
   .component-info-section {
-    border-top: 2px solid gu-colour(light-blue);
+    border-top: 1px solid gu-colour(light-blue);
   }
 
   .component-info-section__heading {
@@ -640,7 +640,7 @@
     font-size: 36px;
     line-height: 44px;
     color: gu-colour(neutral-1);
-    border-top: 2px solid gu-colour(light-yellow);
+    border-top: 1px solid gu-colour(light-yellow);
   }
 
   .subscription-bundle__price {
@@ -1043,7 +1043,7 @@
     font-size: 18px;
     line-height: 24px;
     color: gu-colour(neutral-1);
-    border-top: 1px dotted gu-colour(multimedia-main-2);
+    border-top: 1px solid gu-colour(light-yellow);
   }
 
   .why-support-new-design__copy--no-border {
@@ -1179,7 +1179,7 @@
   }
 
   .other-ways-card-new-design__image {
-    border-bottom: 2px solid gu-colour(multimedia-main-2);
+    border-bottom: 1px solid gu-colour(multimedia-main-2);
 
     .component-grid-image {
       display: block;

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -1059,14 +1059,15 @@
 
     .component-cta-link {
       background-color: gu-colour(guardian-brand-dark);
-      width: 250px;
-      padding: 18px 24px;
-      padding-top: 18px;
-      padding-bottom: 18px;
+      padding: 15px 24px;
+
+      @include mq($from: tablet) {
+        width: 250px;
+      }
 
       svg {
-        left: 250px;
         top: 12px;
+        right: 12px;
         height: 60%;
       }
 

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLanding.scss
@@ -679,10 +679,12 @@
         font-weight: normal;
         font-size: 16px;
         line-height: 22px;
+        display: inline;
       }
 
       h3 {
         color: gu-colour(neutral-1);
+        padding-right: 5px;
       }
     }
   }


### PR DESCRIPTION
## Why are you doing this?

Tidying up the designs for this page, because it's become a little messy with some of the tweaks we've been making.

[**Trello Card**](https://trello.com/b/TjUElW0B/simple-and-coherent-product-supporting-the-guardian)

cc: @Amohkhan

## Changes

- Shorted the error message for contributing too much, to stop it line-wrapping (note this will also change it on the existing bundles landing page).
- Tweaked colours and hover states on CTAs.
- Changed 'paper & digital' to 'paper + digital'.
- Stopped making the price on the subscription bundles vary in size.
- Made sure the subscription headings work across all breakpoints.
- Tweaked some of the borders to make them more consistent, at 1px.
- Tweaked the padding in the contribute and subscribe sections.
- Tweaked fonts and colours to make them more consistent across the page.

## Screenshots

Spot the difference...

x | Before | After
-|-|-
Desktop | ![circles-before-desktop](https://user-images.githubusercontent.com/5131341/33443570-d2e675ae-d5ef-11e7-9da8-7cdc04dbe53c.png) | ![circles-after-desktop](https://user-images.githubusercontent.com/5131341/33443580-dbb4b510-d5ef-11e7-9382-dfb81c96f950.png)
Mobile | ![circles-before-mobile](https://user-images.githubusercontent.com/5131341/33443619-fa212038-d5ef-11e7-9d3e-c863941b37ba.png) | ![circles-after-mobile](https://user-images.githubusercontent.com/5131341/33443646-08ad90f0-d5f0-11e7-9a05-1290aa75fe94.png)