### PR TITLE
Deleting a double counting ophan.

### DIFF
--- a/app/views/contributionsLanding.scala.html
+++ b/app/views/contributionsLanding.scala.html
@@ -6,7 +6,6 @@
         window.guardian = window.guardian || {};
         window.guardian.contributionsPayPalEndpoint = "@contributionsPayPalEndpoint";
     </script>
-    <script type="text/javascript" src="@assets(js)"></script>
 }
 
 @main(title = title, scripts = scripts, description = description, mainBundleJs = js) {


### PR DESCRIPTION
## Why are you doing this?

To fix a bug introduced in : https://github.com/guardian/support-frontend/pull/376
The js script was included twice for the contributions landing pages (UK and US), which cause a double execution of the init function and therefore a double tracking.

