### PR TITLE
Show a default error message on sign-up failure

### DIFF
--- a/assets/pages/regular-contributions/helpers/ajax.js
+++ b/assets/pages/regular-contributions/helpers/ajax.js
@@ -178,7 +178,7 @@ function handleStatus(
   } else if (trackingURI) {
     delayedStatusPoll(dispatch, csrf, referrerAcquisitionData);
   } else {
-    dispatch(checkoutError('There was an error processing your payment. Please\u00a0try\u00a0again\u00a0later.'));
+    dispatch(checkoutError());
   }
 }
 

--- a/assets/pages/regular-contributions/regularContributionsActions.js
+++ b/assets/pages/regular-contributions/regularContributionsActions.js
@@ -16,7 +16,9 @@ export type Action =
 
 // ----- Actions ----- //
 
-function checkoutError(message: string): Action {
+function checkoutError(specificError: ?string): Action {
+  const defaultError = 'There was an error processing your payment. Please\u00a0try\u00a0again\u00a0later.';
+  const message = specificError || defaultError;
   return { type: 'CHECKOUT_ERROR', message };
 }
 


### PR DESCRIPTION
## Why are you doing this?

We don't currently show an error message to the user if the status polling endpoint returns 'message:null'. This happens when the message in Scala is a None - [e.g. here](https://github.com/guardian/support-frontend/blob/b07d3b3484dd5b9f915f25dfaee0b6bbfb7a4760/app/services/stepfunctions/RegularContributionsClient.scala#L126).

[**Trello Card**](https://trello.com/c/ObCbjY1R/1151-fix-error-handling-for-status-polling-functionality)

## Changes

* Make the error message optional client-side, and provide a default if it is undefined.

