### PR TITLE
Show a custom message when Prout sees new builds in production

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -3,6 +3,9 @@
         "PROD": {
             "url": "https://support.theguardian.com/uk",
             "overdue": "14M",
+            "messages": {
+                "seen": "prout/seen.md"
+            },
             "afterSeen": {
                 "travis": {
                     "config": {

--- a/prout/seen.md
+++ b/prout/seen.md
@@ -1,0 +1,3 @@
+Prout is currently unable to run our post-deployment tests - we're working on fixing this.
+
+In the meantime, please start a new Travis build [here](https://travis-ci.org/guardian/support-tests) and keep an eye on the results.


### PR DESCRIPTION
## Why are you doing this?

Prout is currently unable to run our post-deployment tests in Travis (because we made this repo private). This PR uses the functionality added [here](https://github.com/guardian/prout/pull/54) to ask people to kick the tests off manually (in a separate tests repo) as an interim measure.

The proper fix will require a change to Prout which allows us to run tests against Private repos, or run tests in a separate (public) repo, but report the results back onto a Private repo. I'll have a look at these options when I have some more time.

[**Trello Card**](https://trello.com/c/q6HI2nD3/1149-find-a-way-to-run-post-deployment-tests-against-a-private-repo-using-prout)

## Changes

* Add seen message and configure Prout to use it.

