### PR TITLE
Add new dates and promo codes for the Christmas flash sale

### DIFF
--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -196,7 +196,7 @@
       }
     }
 
-    .component-bundle--stacked.component-bundle--black-friday {
+    .component-bundle--stacked.component-bundle--flash-sale {
       @include mq($from: desktop) {
         height: 440px;
       }

--- a/assets/pages/bundles-landing/components/bundles.jsx
+++ b/assets/pages/bundles-landing/components/bundles.jsx
@@ -34,7 +34,7 @@ import {
 import { getSubsLinks } from '../helpers/externalLinks';
 
 import type { SubsUrls } from '../helpers/externalLinks';
-import { getDigiPackItems, getPaperItems } from '../helpers/blackFriday';
+import { getDigiPackItems, getPaperItems } from '../helpers/flashSale';
 
 
 // ----- Types ----- //

--- a/assets/pages/bundles-landing/components/stackedBundle.jsx
+++ b/assets/pages/bundles-landing/components/stackedBundle.jsx
@@ -23,7 +23,7 @@ import type { Participations } from 'helpers/abTests/abtest';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import type { Product } from './bundles';
 
-import { getDigiPackItems, getPaperItemsForStackedBundle, getPaperDigitalItemsForStackedBundle, inOfferPeriod } from '../helpers/blackFriday';
+import { getDigiPackItems, getPaperItemsForStackedBundle, getPaperDigitalItemsForStackedBundle, inOfferPeriod } from '../helpers/flashSale';
 
 import CrossProduct from './crossProduct';
 import {
@@ -128,7 +128,7 @@ const monthlyContribCopy: ContribAttrs = {
 };
 
 
-const componentBundleModifierClass = `component-bundle--stacked ${inOfferPeriod() ? 'component-bundle--black-friday' : ''}`;
+const componentBundleModifierClass = `component-bundle--stacked ${inOfferPeriod() ? 'component-bundle--flash-sale' : ''}`;
 
 const digitalCopy: SubscribeAttrs = {
   heading: 'digital subscription',

--- a/assets/pages/bundles-landing/helpers/externalLinks.js
+++ b/assets/pages/bundles-landing/helpers/externalLinks.js
@@ -4,7 +4,7 @@
 
 import type { Campaign } from 'helpers/tracking/acquisitions';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
-import { inOfferPeriod as inBlackFridayPeriod } from './blackFriday';
+import { inOfferPeriod } from './flashSale';
 
 // ----- Types ----- //
 
@@ -86,8 +86,8 @@ const customPromos : {
     paper: 'p/NBANJUSTONE',
     paperDig: 'p/NDBANJUSTONE',
   },
-  black_friday: {
-    digital: 'p/DBQ80M',
+  flash_sale: {
+    digital: 'p/DBR80H',
     paper: 'p/GBQ80N',
     paperDig: 'p/GBQ80O',
   },
@@ -138,9 +138,9 @@ function getSubsLinks(
   otherQueryParams: Array<[string, string]>,
   referrerAcquisitionData: ReferrerAcquisitionData,
 ): SubsUrls {
-  if ((campaign && customPromos[campaign]) || (!campaign && inBlackFridayPeriod())) {
+  if ((campaign && customPromos[campaign]) || (!campaign && inOfferPeriod())) {
     return buildSubsUrls(
-      customPromos[campaign || 'black_friday'],
+      customPromos[campaign || 'flash_sale'],
       intCmp,
       otherQueryParams,
       referrerAcquisitionData,

--- a/assets/pages/bundles-landing/helpers/flashSale.js
+++ b/assets/pages/bundles-landing/helpers/flashSale.js
@@ -3,13 +3,13 @@
 import { getQueryParameter } from 'helpers/url';
 
 function inOfferPeriod(): boolean {
-  // The offer is valid between 24th November & 3rd December 2017
   const now = Date.now();
-  // Days are 1 based, months are 0 based - WHY??
-  const startTime = new Date(2017, 10, 24, 0, 0).getTime();
-  const endTime = new Date(2017, 11, 4, 0, 0).getTime();
+  // Days are 1 based, months are 0 based
+  // The offer is valid between 19th December 2017 & 3rd January 2018
+  const startTime = new Date(2017, 11, 19, 0, 0).getTime();
+  const endTime = new Date(2018, 0, 4, 0, 0).getTime();
 
-  return (now > startTime && now < endTime) || getQueryParameter('black_friday') === 'true' || false;
+  return (now > startTime && now < endTime) || getQueryParameter('flash_sale') === 'true' || false;
 }
 
 const offerItem = { heading: 'Subscribe today and save 50% for your first three months' };
@@ -40,8 +40,6 @@ function getDigiPackItems() {
 }
 
 function getPaperItems() {
-  if (inOfferPeriod()) { return [offerItem, chooseYourPackage, getAllBenefitsWithPaperPlus]; }
-
   return [chooseYourPackage, saveMoneyOnRetailPrice, getAllBenefitsWithPaperPlus];
 }
 
@@ -49,14 +47,10 @@ function getPaperItems() {
 // So in the paper only box, we don't mention the digital benefits.
 // And in the paper+digital box, we do
 function getPaperItemsForStackedBundle() {
-  if (inOfferPeriod()) { return [offerItem, chooseYourPackage]; }
-
   return [chooseYourPackage, saveMoneyOnRetailPrice];
 }
 
 function getPaperDigitalItemsForStackedBundle() {
-  if (inOfferPeriod()) { return [offerItem, chooseYourPackage, getAllBenefits]; }
-
   return [chooseYourPackage, saveMoneyOnRetailPrice, getAllBenefits];
 }
 


### PR DESCRIPTION
## Why are you doing this?

We are running another 'flash sale' over Christmas, similar to the one we ran for Black Friday except that this time the offer only applies to the digital pack.

Copy and promo codes [here](https://docs.google.com/spreadsheets/d/1MT9jjT2K6kpPUxR1yzwHrfC9-ckQrUCbSwzwatvAosg/edit#gid=2065203659)

[**Trello Card**](https://trello.com/c/7cnOUDIF/1152-christmas-flash-sale-on-support-and-subs)

## Changes

* Rename 'black friday' to 'flash sale' throughout the code to make it more generic. 
* Update the inOfferPeriod() dates.
* Remove that code that changed paper & paper + digital copy during the offer period.

## Screenshots
### During offer period:
<img width="320" alt="screen shot 2017-12-12 at 12 40 03" src="https://user-images.githubusercontent.com/181371/33884965-a79098aa-df39-11e7-824d-1e2b22a14a1c.png">

### Outside offer period:
<img width="314" alt="screen shot 2017-12-12 at 12 39 46" src="https://user-images.githubusercontent.com/181371/33884966-a7a668ce-df39-11e7-8fc3-13af792bcf10.png">

