### PR TITLE
Remove line from UK landing page

### DIFF
--- a/assets/pages/bundles-landing/components/stackedBundle.jsx
+++ b/assets/pages/bundles-landing/components/stackedBundle.jsx
@@ -255,7 +255,6 @@ function ContributionBundle(props: PropTypes) {
     <Bundle {...contribAttrs}>
       <p>
         Your contribution funds and supports the&nbsp;Guardian&#39;s journalism.
-        All profit is reinvested to safeguard the quality of our journalism.
       </p>
       <ContribAmounts
         onNumberInputKeyPress={onClick}


### PR DESCRIPTION
## Why are you doing this?
It has been requested that we remove the ' All profit is reinvested to safeguard the quality of our journalism.' line from the UK page.

Before:
![cibtrik](https://user-images.githubusercontent.com/2844554/34253182-73bb203e-e63e-11e7-95b4-3df2ee4abba8.png)

After:
![new](https://user-images.githubusercontent.com/2844554/34253183-73cee68c-e63e-11e7-9d51-92f5a33ddfc0.png)
