### PR TITLE
rename canRun to customSegmentCondition

### DIFF
--- a/assets/helpers/abTests/__tests__/abtestTest.js
+++ b/assets/helpers/abTests/__tests__/abtestTest.js
@@ -127,7 +127,7 @@ describe('Correct allocation in a multi test environment', () => {
   US: |  20%   |        60%                |   20%   |
         Test 1         Test 2              Not in Test
 
-  Test 3 is 100% GB, but canRun is false
+  Test 3 is 100% GB, but customSegmentCondition is false
    */
 
   const tests = {
@@ -170,7 +170,7 @@ describe('Correct allocation in a multi test environment', () => {
         },
       },
       isActive: true,
-      canRun: () => false,
+      customSegmentCondition: () => false,
       independent: false,
       seed: 0,
     },

--- a/assets/helpers/abTests/abtest.js
+++ b/assets/helpers/abTests/abtest.js
@@ -41,7 +41,7 @@ export type Test = {|
   variants: string[],
   audiences: Audiences,
   isActive: boolean,
-  canRun?: () => boolean,
+  customSegmentCondition?: () => boolean,
   independent: boolean,
   seed: number,
 |};
@@ -144,7 +144,7 @@ function getParticipations(abTests: Tests, mvtId: number, country: IsoCountry): 
       return;
     }
 
-    if (test.canRun && !test.canRun()) {
+    if (test.customSegmentCondition && !test.customSegmentCondition()) {
       participations[testId] = notintest;
     } else if (testId in currentParticipation) {
       participations[testId] = currentParticipation[testId];


### PR DESCRIPTION
## Why are you doing this?
The name `customSegmentCondition` better describes it's behaviour than `canRun`