### PR TITLE
Save contribute only information to session storage

### DIFF
--- a/assets/helpers/abTests/abtest.js
+++ b/assets/helpers/abTests/abtest.js
@@ -10,6 +10,7 @@ import * as ophan from 'ophan';
 import * as cookie from 'helpers/cookie';
 import * as storage from 'helpers/storage';
 import { tests } from './abtestDefinitions';
+import { getQueryParameter } from '../url';
 
 
 // ----- Types ----- //
@@ -78,6 +79,12 @@ function getLocalStorageParticipation(): Participations {
 
   return abTests ? JSON.parse(abTests) : {};
 
+}
+
+function setContributeOnlyLocalStorageParameter(): void {
+  if (getQueryParameter('bundle') === 'contribute') {
+    storage.setSession('gu.contributeOnly', 'true');
+  }
 }
 
 function setLocalStorageParticipations(participations: Participations): void {
@@ -180,7 +187,7 @@ const init = (country: IsoCountry, abTests: Tests = tests): Participations => {
   const mvt: number = getMvtId();
   const participations: Participations = getParticipations(abTests, mvt, country);
   const urlParticipations: ?Participations = getParticipationsFromUrl();
-
+  setContributeOnlyLocalStorageParameter();
   setLocalStorageParticipations(Object.assign({}, participations, urlParticipations));
   trackABOphan(participations, false);
 

--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -1,6 +1,7 @@
 // @flow
 import { getQueryParameter } from '../url';
 import type { Tests } from './abtest';
+import * as storage from '../storage';
 
 // ----- Tests ----- //
 
@@ -41,7 +42,8 @@ export const tests: Tests = {
     },
     isActive: true,
     independent: true,
-    customSegmentCondition: () => getQueryParameter('bundle') === 'contribute',
+    customSegmentCondition: () =>
+      storage.getSession('gu.contributeOnly') === 'true' || getQueryParameter('bundle') === 'contribute',
     seed: 7,
   },
 


### PR DESCRIPTION
## Why are you doing this?

In order for tests running exclusivly on the contribute-only segment of the audience (currently those in the UK from the Epic and Banner) to track recurring contributions properly, we need to persist the fact that the reader saw the contribute only page through their journey through to payment. 

This currently doesn't work properly because the test segmentation works by looking at the url to determine if they are on the contribute only page. This becomes an issue for recurring payments, because the user is re-assigned to their test segments on their return from identity frontend where they sign in. At this point, the bundle=contribute parameter is no longer in the url. 

The solution is to store this information in session storage, so that when the reassignment happens on the users return from identity, they are tracked as being part of the test. 

  