### PR TITLE
Updated Stripe image to use S3

### DIFF
--- a/assets/helpers/stripeCheckout/stripeCheckout.js
+++ b/assets/helpers/stripeCheckout/stripeCheckout.js
@@ -44,7 +44,7 @@ export const setupStripeCheckout = (
     description: 'Please enter your card details.',
     allowRememberMe: false,
     key: isTestUser ? window.guardian.stripeKey.uat : window.guardian.stripeKey.default,
-    image: 'https://d24w1tjgih0o9s.cloudfront.net/gu.png',
+    image: 'https://uploads.guim.co.uk/2018/01/10/gu.png',
     locale: 'auto',
     currency,
     token: handleToken,


### PR DESCRIPTION
## Why are you doing this?

Currently the image is hosted in CloudFront, I am changing to one that is hosted in S3. During Garnett, the logo in S3 will be updated and as a result, all the stripe integration that points to S3 will be updated.


## Screenshots

<img width="335" alt="picture 509" src="https://user-images.githubusercontent.com/825398/34785991-a28bc8ea-f62a-11e7-8012-6009738f74d3.png">


