### PR TITLE
Button should say "or PayPal" for recurring contributions

### DIFF
--- a/assets/pages/bundles-landing/components/bundles.jsx
+++ b/assets/pages/bundles-landing/components/bundles.jsx
@@ -73,6 +73,7 @@ type ContribAttrs = {
   heading: string,
   subheading?: string,
   ctaText: string,
+  cardText?: string,
   modifierClass: string,
   ctaId: string,
   ctaLink: string,
@@ -242,12 +243,13 @@ const getContribAttrs = (
   }
   const ctaId = `contribute-${contribType}`;
   const ctaLink = `${ctaLinks[contType]}?${params.toString()}`;
-  const ctaText = `Contribute ${currency.glyph}${contribAmount[contType].value} with card`;
+  const ctaText = `Contribute ${currency.glyph}${contribAmount[contType].value} with card or PayPal`;
   const localisedOneOffContType = isoCountry === 'us' ? 'one time' : 'one-off';
   const ctaAccessibilityHint = `proceed to make your ${contType.toLowerCase() === 'oneoff' ? localisedOneOffContType : contType.toLowerCase()} contribution`;
+  const cardText = `Contribute ${currency.glyph}${contribAmount[contType].value} with card`;
   const paypalCta = Object.assign({}, { text: `Contribute ${currency.glyph}${contribAmount[contType].value} with PayPal` });
   return Object.assign({}, bundles(abTests).contrib[contType], {
-    ctaText, ctaId, ctaLink, ctaAccessibilityHint, paypalCta,
+    ctaText, ctaId, ctaLink, ctaAccessibilityHint, cardText, paypalCta,
   });
 
 };
@@ -296,7 +298,7 @@ function ContributionBundle(props: PropTypes) {
       />
       <CtaLink
         ctaId={contribAttrs.ctaId.toLowerCase()}
-        text={contribAttrs.ctaText}
+        text={props.contribType === 'ONE_OFF' && contribAttrs.cardText ? contribAttrs.cardText : contribAttrs.ctaText}
         accessibilityHint={contribAttrs.ctaAccessibilityHint}
         onClick={onClick}
       />

--- a/assets/pages/bundles-landing/components/stackedBundle.jsx
+++ b/assets/pages/bundles-landing/components/stackedBundle.jsx
@@ -66,6 +66,7 @@ type ContribAttrs = {
   heading: string,
   subheading?: string,
   ctaText: string,
+  cardText: string,
   modifierClass: string,
   ctaId: string,
   ctaLink: string,
@@ -213,13 +214,14 @@ const getContribAttrs = (
   }
   const ctaId = `contribute-${contribType}`;
   const ctaLink = `${ctaLinks[contType]}?${params.toString()}`;
-  const ctaText = `Contribute ${currency.glyph}${contribAmount[contType].value} with card`;
+  const ctaText = `Contribute ${currency.glyph}${contribAmount[contType].value} with card or PayPal`;
   const localisedOneOffContType = isoCountry === 'us' ? 'one time' : 'one-off';
   const ctaAccessibilityHint = `proceed to make your ${contType.toLowerCase() === 'oneoff' ? localisedOneOffContType : contType.toLowerCase()} contribution`;
+  const cardText = `Contribute ${currency.glyph}${contribAmount[contType].value} with card`;
   const paypalCta = Object.assign({}, { text: `Contribute ${currency.glyph}${contribAmount[contType].value} with PayPal` });
 
   return Object.assign({}, getBundles().contrib[contType], {
-    ctaId, ctaLink, ctaText, ctaAccessibilityHint, paypalCta,
+    ctaId, ctaLink, ctaText, ctaAccessibilityHint, cardText, paypalCta,
   });
 
 };
@@ -265,7 +267,7 @@ function ContributionBundle(props: PropTypes) {
 
       <CtaLink
         ctaId={contribAttrs.ctaId.toLowerCase()}
-        text={contribAttrs.ctaText}
+        text={props.contribType === 'ONE_OFF' ? contribAttrs.cardText : contribAttrs.ctaText}
         accessibilityHint={contribAttrs.ctaAccessibilityHint}
         onClick={onClick}
       />

--- a/assets/pages/bundles-landing/components/stackedBundle.jsx
+++ b/assets/pages/bundles-landing/components/stackedBundle.jsx
@@ -66,7 +66,7 @@ type ContribAttrs = {
   heading: string,
   subheading?: string,
   ctaText: string,
-  cardText: string,
+  cardText?: string,
   modifierClass: string,
   ctaId: string,
   ctaLink: string,
@@ -267,7 +267,7 @@ function ContributionBundle(props: PropTypes) {
 
       <CtaLink
         ctaId={contribAttrs.ctaId.toLowerCase()}
-        text={props.contribType === 'ONE_OFF' ? contribAttrs.cardText : contribAttrs.ctaText}
+        text={props.contribType === 'ONE_OFF' && contribAttrs.cardText ? contribAttrs.cardText : contribAttrs.ctaText}
         accessibilityHint={contribAttrs.ctaAccessibilityHint}
         onClick={onClick}
       />


### PR DESCRIPTION
## Why are you doing this?

So that users know that they can contribute using PayPal.  NB - this bug was introduced before Garnett

**Before**

<img width="957" alt="screen shot 2018-01-15 at 07 48 24" src="https://user-images.githubusercontent.com/2619836/34931877-a8b334dc-f9c8-11e7-91ef-bbd090e16d93.png">

**After**

<img width="962" alt="screen shot 2018-01-15 at 07 48 10" src="https://user-images.githubusercontent.com/2619836/34931876-a89fd3ec-f9c8-11e7-8cb7-21ccda20c177.png">