### PR TITLE
Revert "Show a custom message when Prout sees new builds in production"

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -3,9 +3,6 @@
         "PROD": {
             "url": "https://support.theguardian.com/uk",
             "overdue": "14M",
-            "messages": {
-                "seen": "prout/seen.md"
-            },
             "afterSeen": {
                 "travis": {
                     "config": {

--- a/prout/seen.md
+++ b/prout/seen.md
@@ -1,3 +1,0 @@
-Prout is currently unable to run our post-deployment tests - we're working on fixing this.
-
-In the meantime, please start a new Travis build [here](https://travis-ci.org/guardian/support-tests) and keep an eye on the results.


### PR DESCRIPTION
Reverts guardian/support-frontend#416

This repo is public again, so we don't need this message (or the support-tests repo) any more.