### PR TITLE
Drop the lower half of the page for users from the banner

### DIFF
--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -1,7 +1,5 @@
 // @flow
-import { getQueryParameter } from '../url';
 import type { Tests } from './abtest';
-import * as storage from '../storage';
 
 // ----- Tests ----- //
 
@@ -31,21 +29,5 @@ export const tests: Tests = {
     independent: true,
     seed: 6,
   },
-
-  ukDropBottomTest: {
-    variants: ['control', 'no_bottom'],
-    audiences: {
-      GB: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: true,
-    independent: true,
-    customSegmentCondition: () =>
-      storage.getSession('gu.contributeOnly') === 'true' || getQueryParameter('bundle') === 'contribute',
-    seed: 7,
-  },
-
 };
 

--- a/assets/pages/bundles-landing/bundlesLanding.jsx
+++ b/assets/pages/bundles-landing/bundlesLanding.jsx
@@ -33,7 +33,6 @@ const store = pageInit(
 // ----- Render ----- //
 
 const bundle: ?string = getQueryParameter('bundle');
-const bottomTest = store.getState().common.abParticipations.ukDropBottomTest;
 
 let bundlesSelected;
 let showContributeOrSubscribe = false;
@@ -50,7 +49,7 @@ if (bundle === 'contribute') {
   showContributeOrSubscribe = true;
 }
 
-const whyAndWaysOfSupport = (bundle === 'contribute' && bottomTest === 'no_bottom')
+const whyAndWaysOfSupport = (bundle === 'contribute')
   ? ''
   : (
     [<WhySupport />, <WaysOfSupport />]


### PR DESCRIPTION
## Why are you doing this?
https://github.com/guardian/support-frontend/pull/428 showed that the lower half of the page adds no value to the page for people hitting support.theguardian.com (in the UK, off the banner and epic). 

Therefore, we are going to default to the version without the lower half of the page. 

The page previously would have looked like this for UK Epic and Banner readers:
![screenshot at jan 15 11-46-55](https://user-images.githubusercontent.com/2844554/34941094-30f0fdb8-f9ea-11e7-8b2f-51947ad87b9f.png)



Now it will look like this: 
![screenshot at jan 15 13-37-18](https://user-images.githubusercontent.com/2844554/34944911-4a5cb1c0-f9f9-11e7-94fb-53b038aafbdb.png)


