### PR TITLE
Alert on high 500 rate sooner

### DIFF
--- a/cloud-formation/cfn.yaml
+++ b/cloud-formation/cfn.yaml
@@ -277,7 +277,7 @@ Resources:
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Threshold: 3
       Period: 60
-      EvaluationPeriods: 10
+      EvaluationPeriods: 2
       Statistic: Sum
     DependsOn:
     - TargetGroup


### PR DESCRIPTION
## Why are you doing this?

I noticed that there was quite a long lag between a spike in 500s and us receiving an alert for this project. I think this is (at least partly) because of the number of evaluation periods being used. Currently support-frontend is pretty stable, so I think this alarm will be more useful if we make it more sensitive.

More info here: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html#Statistic

> Not only can you specify the period over which the comparison is made, but you can also specify how many evaluation periods are used to arrive at a conclusion. For example, if you specify three evaluation periods, CloudWatch compares a window of three data points. CloudWatch only notifies you if the oldest data point is breaching and the others are breaching or missing. For metrics that are continuously emitted, CloudWatch doesn't notify you until three failures are found.



