### PR TITLE
Exclude automated post-deployment test runs from AB tests

### DIFF
--- a/assets/helpers/abTests/__tests__/abtestTest.js
+++ b/assets/helpers/abTests/__tests__/abtestTest.js
@@ -117,6 +117,43 @@ describe('basic behaviour of init', () => {
 
     expect(participations).toEqual(expectedParticipations);
   });
+
+  it('A post-deployment test user should not be allocated into a test', () => {
+
+    const postDeploymentTestCookie = '_post_deploy_user=true; path=/;';
+
+    function deleteCookie() {
+      document.cookie = `${postDeploymentTestCookie} expires=Thu, 01 Jan 1970 00:00:00 GMT;`;
+    }
+
+    document.cookie = postDeploymentTestCookie;
+
+    document.cookie = 'GU_mvt_id=12346';
+
+    const tests = {
+      mockTest: {
+        variants: ['control', 'variant'],
+        audiences: {
+          GB: {
+            offset: 0,
+            size: 1,
+          },
+        },
+        isActive: true,
+        independent: true,
+        seed: 2,
+      },
+    };
+
+    const country = 'GB';
+    const participations: Participations = abInit(country, tests);
+    const expectedParticipations: Participations = { mockTest: 'notintest' };
+
+    expect(participations).toEqual(expectedParticipations);
+
+    deleteCookie();
+  });
+
 });
 
 describe('Correct allocation in a multi test environment', () => {

--- a/assets/helpers/abTests/abtest.js
+++ b/assets/helpers/abTests/abtest.js
@@ -109,6 +109,10 @@ function getParticipationsFromUrl(): ?Participations {
 
 function userInTest(audiences: Audiences, mvtId: number, country: IsoCountry) {
 
+  if (cookie.get('_post_deploy_user')) {
+    return false;
+  }
+
   const audience = audiences[country];
 
   if (!audience) {

--- a/test/selenium/ContributorSpec.scala
+++ b/test/selenium/ContributorSpec.scala
@@ -72,7 +72,7 @@ class ContributorSpec extends FeatureSpec with Browser with GivenWhenThen with B
     scenario("Monthly contribution sign-up with PayPal - USD") {
 
       val landingPage = ContributionsLanding("us")
-      val expectedPayment = "10.00"
+      val expectedPayment = "15.00"
 
       Given("that a test user goes to the contributions landing page")
       val testUser = new TestUser
@@ -83,7 +83,7 @@ class ContributorSpec extends FeatureSpec with Browser with GivenWhenThen with B
       landingPage.clickContribute
 
       Then("they should be redirected to register as an Identity user")
-      val register = Register(testUser, 10)
+      val register = Register(testUser, 15)
       assert(register.pageHasLoaded)
 
       Given("that the user fills in their personal details correctly")

--- a/test/selenium/util/Driver.scala
+++ b/test/selenium/util/Driver.scala
@@ -45,10 +45,6 @@ object Driver {
 
     driver.get(Config.supportFrontendUrl + "/uk")
     driver.manage.deleteAllCookies()
-
-    // This enables the tests to use the mocked payment services
-    addCookie(name = "_post_deploy_user", value = "true")
-
   }
 
   def quit(): Unit = driver.quit()

--- a/test/selenium/util/TestUser.scala
+++ b/test/selenium/util/TestUser.scala
@@ -14,6 +14,7 @@ class TestUser {
   private def addTestUserCookies(testUsername: String) = {
     Driver.addCookie(name = "pre-signin-test-user", value = testUsername)
     Driver.addCookie(name = "_test_username", value = testUsername, domain = Some(Config.guardianDomain))
+    Driver.addCookie(name = "_post_deploy_user", value = "true") // This enables the tests to use the mocked payment services
   }
 
   val username = testUsers.generate()


### PR DESCRIPTION
## Why are you doing this?

The post-deployment tests should be excluded from any AB tests running on support. The purpose of these tests is to check that core functionality is working after a deployment. They rely on a specific version of the flow, and are not designed to cope with multiple variants. We also don't want automated test runs to be counted in our results (although the numbers are going to be tiny, so I doubt it actually matters much).

Also, these tests always fail at the moment, because the default amounts have been changed (and they currently rely on an expected default in order to validate that we're charging the user the correct amount).

## Changes

* Use existing '_post_deploy_user' cookie to exclude test runs from AB tests (and add a test for this new aspect of test allocation)
* Amend default amounts in test
* Set cookie in a more sensible place