### PR TITLE
Add new email consent for One Off Contributions[2]

### DIFF
--- a/app/controllers/IdentityController.scala
+++ b/app/controllers/IdentityController.scala
@@ -1,0 +1,34 @@
+package controllers
+
+import actions.CustomActionBuilders
+import com.typesafe.scalalogging.LazyLogging
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+import play.api.mvc._
+import services.IdentityService
+import play.api.libs.circe.Circe
+import scala.concurrent.ExecutionContext
+
+class IdentityController(
+    identityService: IdentityService,
+    components: ControllerComponents,
+    actionRefiners: CustomActionBuilders
+)(implicit ec: ExecutionContext)
+  extends AbstractController(components) with Circe with LazyLogging {
+
+  import actionRefiners._
+
+  def submitMarketing(): Action[SendMarketingRequest] = PrivateAction.async(circe.json[SendMarketingRequest]) { implicit request =>
+    val result = identityService.sendConsentPreferencesEmail(request.body.email)
+    result.map { res =>
+      if (res) Ok
+      else InternalServerError
+    }
+  }
+}
+
+object SendMarketingRequest {
+  implicit val decoder: Decoder[SendMarketingRequest] = deriveDecoder
+}
+case class SendMarketingRequest(email: String)
+

--- a/app/controllers/OneOffContributions.scala
+++ b/app/controllers/OneOffContributions.scala
@@ -54,6 +54,10 @@ class OneOffContributions(
     )
   }
 
+  def thankYouPage(): Action[AnyContent] = PrivateAction { implicit request =>
+    Ok(views.html.thankYou("Support the Guardian | Thank You", "oneoff-contributions-thankyou-page", "oneoffContributionsThankyouPage.js"))
+  }
+
   private def fullNameFor(user: IdUser): Option[String] = {
     for {
       privateFields <- user.privateFields

--- a/app/services/IdentityService.scala
+++ b/app/services/IdentityService.scala
@@ -12,7 +12,6 @@ import java.net.URI
 
 import com.google.common.net.InetAddresses
 import config.Identity
-import com.gu.identity.model.Consent.Supporter
 import play.api.Logger
 import play.api.libs.json.Json
 
@@ -59,7 +58,7 @@ class IdentityService(apiUrl: String, apiClientToken: String)(implicit wsClient:
   }
 
   def sendConsentPreferencesEmail(email: String)(implicit ec: ExecutionContext): Future[Boolean] = {
-    val payload = Json.obj("email" -> email, "set-consents" -> Json.arr(Supporter.id))
+    val payload = Json.obj("email" -> email, "set-consents" -> Json.arr("supporter"))
     request(s"consent-email").post(payload).map { response =>
       val validResponse = response.status >= 200 && response.status < 300
       val logMessage = "Response from Identity Consent API: " + response.toString

--- a/app/services/IdentityService.scala
+++ b/app/services/IdentityService.scala
@@ -12,8 +12,12 @@ import java.net.URI
 
 import com.google.common.net.InetAddresses
 import config.Identity
+import com.gu.identity.model.Consent.Supporter
+import play.api.Logger
+import play.api.libs.json.Json
 
 import scala.util.Try
+import scala.concurrent.{ExecutionContext, Future}
 
 object IdentityServiceEnrichers {
 
@@ -48,6 +52,26 @@ object IdentityService {
 class IdentityService(apiUrl: String, apiClientToken: String)(implicit wsClient: WSClient) {
 
   import IdentityServiceEnrichers._
+
+  private def request(path: String): WSRequest = {
+    wsClient.url(s"$apiUrl/$path")
+      .withHttpHeaders("Authorization" -> s"Bearer $apiClientToken")
+  }
+
+  def sendConsentPreferencesEmail(email: String)(implicit ec: ExecutionContext): Future[Boolean] = {
+    val payload = Json.obj("email" -> email, "set-consents" -> Json.arr(Supporter.id))
+    request(s"consent-email").post(payload).map { response =>
+      val validResponse = response.status >= 200 && response.status < 300
+      val logMessage = "Response from Identity Consent API: " + response.toString
+      if (validResponse) Logger.info(logMessage)
+      else Logger.error(logMessage)
+      validResponse
+    } recover {
+      case e: Exception =>
+        Logger.error("Impossible to update the user's marketing preferences", e)
+        false
+    }
+  }
 
   private def headers(request: RequestHeader): List[(String, String)] = List(
     "X-GU-ID-Client-Access-Token" -> Some(s"Bearer $apiClientToken"),

--- a/app/views/thankYou.scala.html
+++ b/app/views/thankYou.scala.html
@@ -1,0 +1,21 @@
+@import assets.AssetsResolver
+@import helper.CSRF
+
+@(
+    title: String,
+    id: String,
+    js: String,
+    description: Option[String] = None
+)(implicit assets: AssetsResolver, request: RequestHeader)
+
+@scripts = {
+    <script type="text/javascript">
+        window.guardian = window.guardian || {};
+        window.guardian.csrf = { token: "@CSRF.getToken.value" };
+    </script>
+}
+
+
+@main(title = title, description = description, mainBundleJs = js, scripts = scripts) {
+    <main id="@id" class="gu-content-wrapper"></main>
+}

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -37,6 +37,7 @@ trait AppComponents extends PlayComponents
     applicationController,
     siteMapController,
     regularContributionsController,
+    identityController,
     oneOffContributions,
     loginController,
     testUsersController,

--- a/app/wiring/Controllers.scala
+++ b/app/wiring/Controllers.scala
@@ -61,4 +61,10 @@ trait Controllers {
     actionRefiners,
     controllerComponents
   )
+
+  lazy val identityController = new IdentityController(
+    identityService,
+    controllerComponents,
+    actionRefiners
+  )
 }

--- a/assets/components/checkboxInput/checkboxInput.jsx
+++ b/assets/components/checkboxInput/checkboxInput.jsx
@@ -11,32 +11,41 @@ type PropTypes = {
   id: ?string,
   onChange: (preference: boolean) => void,
   checked: boolean,
-  labelText?: string,
+  labelTitle?: string,
+  labelCopy?: string,
 };
 
 
 // ----- Component ----- //
 
 export default function CheckboxInput(props: PropTypes) {
-  let label = '';
+  let labelTitle = '';
+  let labelCopy = '';
 
-  if (props.labelText && props.id) {
-    // eslint-disable-next-line jsx-a11y/label-has-for
-    label = <label htmlFor={props.id}>{props.labelText}</label>;
+  if (props.labelTitle) {
+    labelTitle = <p className="component-checkbox__title">{props.labelTitle}</p>;
   }
+  if (props.labelCopy) {
+    labelCopy = <p className="component-checkbox__copy" >{props.labelCopy}</p>;
+  }
+
   return (
-    <div className="component-checkbox">
+    // eslint-disable-next-line jsx-a11y/label-has-for
+    <label className="component-checkbox">
       <input
+        className="component-checkbox__checkbox"
         id={props.id}
         type="checkbox"
         onChange={e => props.onChange(e.target.checked)}
         checked={props.checked}
       />
-      {label}
-    </div>
+      {labelTitle}
+      {labelCopy}
+    </label>
   );
 }
 
 CheckboxInput.defaultProps = {
-  labelText: '',
+  labelCopy: '',
+  labelTitle: '',
 };

--- a/assets/components/checkboxInput/checkboxInput.scss
+++ b/assets/components/checkboxInput/checkboxInput.scss
@@ -1,10 +1,33 @@
 .component-checkbox {
-  input {
-    margin-left: 0;
-  }
+  margin-top: 20px;
+  display: flex;
+  flex-direction: column;
+  position: relative;
+}
 
-  label {
-    font-size: 14px;
-    margin-left: 3px;
-  }
+.component-checkbox__checkbox {
+  position: absolute;
+  padding-top: 3px;
+  top: 0;
+  left: 0;
+}
+
+.component-checkbox__title {
+  font-size: 18px;
+  line-height: 20px;
+  padding-left: 24px;
+  font-weight: 500;
+  margin-bottom: 4px;
+  cursor: pointer;
+  display: block;
+  font-family: $gu-egyptian-web
+
+}
+
+.component-checkbox__copy {
+  padding-left: 24px;
+  font-size: 14px;
+  line-height: 16px;
+  cursor: pointer;
+
 }

--- a/assets/helpers/routes.js
+++ b/assets/helpers/routes.js
@@ -9,9 +9,11 @@ const routes: {
   recurringContribThankyou: '/contribute/recurring/thankyou',
   recurringContribCreate: '/contribute/recurring/create',
   recurringContribPending: '/contribute/recurring/pending',
+  contributionsSendMarketing: '/contribute/send-marketing',
   oneOffContribCheckout: '/contribute/one-off',
   oneOffContribThankyou: '/contribute/one-off/thankyou',
   oneOffContribAutofill: '/contribute/one-off/autofill',
+  contributionsMarketingConfirm: '/contribute/marketing-confirm',
   payPalSetupPayment: '/paypal/setup-payment',
   payPalCreateAgreement: '/paypal/create-agreement',
 };

--- a/assets/helpers/user/user.js
+++ b/assets/helpers/user/user.js
@@ -4,6 +4,7 @@
 
 import { routes } from 'helpers/routes';
 import * as cookie from 'helpers/cookie';
+import { getSession } from 'helpers/storage';
 
 import {
   setId,
@@ -25,6 +26,8 @@ const init = (dispatch: Function) => {
   const userAppearsLoggedIn = cookie.get('GU_U');
 
   const uatMode = window.guardian && window.guardian.uatMode;
+
+  const emailFromSession: ?string = getSession('gu.email');
 
   const isUndefinedOrNull = x => x === null || x === undefined;
 
@@ -61,6 +64,8 @@ const init = (dispatch: Function) => {
         });
       }
     });
+  } else if (emailFromSession) {
+    dispatch(setEmail(emailFromSession));
   }
 };
 

--- a/assets/helpers/user/userActions.js
+++ b/assets/helpers/user/userActions.js
@@ -2,6 +2,8 @@
 
 // ----- Types ----- //
 
+import { setSession } from 'helpers/storage';
+
 export type Action =
   | { type: 'SET_USER_ID', id: string }
   | { type: 'SET_DISPLAY_NAME', name: string }
@@ -39,6 +41,7 @@ export function setFullName(name: string): Action {
 }
 
 export function setEmail(email: string): Action {
+  setSession('gu.email', email);
   return { type: 'SET_EMAIL', email };
 }
 

--- a/assets/pages/contributions-thankyou/__tests__/__snapshots__/contributionsThankYouReducersTest.js.snap
+++ b/assets/pages/contributions-thankyou/__tests__/__snapshots__/contributionsThankYouReducersTest.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Thank you Reducer should return the initial state 1`] = `
+Object {
+  "csrf": Object {
+    "token": null,
+  },
+  "thankYouState": Object {
+    "consentApiError": false,
+  },
+  "user": Object {
+    "displayName": "",
+    "email": "",
+    "firstName": "",
+    "gnmMarketing": false,
+    "id": "",
+    "isPostDeploymentTestUser": false,
+    "isTestUser": null,
+    "lastName": "",
+  },
+}
+`;

--- a/assets/pages/contributions-thankyou/__tests__/contributionsThankYouActionsTest.js
+++ b/assets/pages/contributions-thankyou/__tests__/contributionsThankYouActionsTest.js
@@ -1,0 +1,18 @@
+// @flow
+import {
+  setConsentApiError,
+} from '../contributionsThankYouActions';
+
+
+describe('Contributions Thank You actions', () => {
+
+  it('should create an action to flag a checkout error', () => {
+    const consentApiError:boolean = true;
+    const expectedAction = {
+      type: 'CONSENT_API_ERROR',
+      consentApiError,
+    };
+    expect(setConsentApiError(consentApiError)).toEqual(expectedAction);
+  });
+
+});

--- a/assets/pages/contributions-thankyou/__tests__/contributionsThankYouReducersTest.js
+++ b/assets/pages/contributions-thankyou/__tests__/contributionsThankYouReducersTest.js
@@ -1,0 +1,24 @@
+// @flow
+import reducer from '../contributionsThankYouReducer';
+
+
+describe('Thank you Reducer', () => {
+
+  it('should return the initial state', () => {
+    console.log(reducer(undefined, {}));
+    expect(reducer(undefined, {})).toMatchSnapshot();
+  });
+
+  it('should handle CONSENT_API_ERROR', () => {
+
+    const consentApiError = true;
+    const action = {
+      type: 'CONSENT_API_ERROR',
+      consentApiError,
+    };
+
+    const newState = reducer(undefined, action);
+
+    expect(newState.thankYouState.consentApiError).toEqual(consentApiError);
+  });
+});

--- a/assets/pages/contributions-thankyou/components/marketingConsent.jsx
+++ b/assets/pages/contributions-thankyou/components/marketingConsent.jsx
@@ -1,0 +1,99 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+import CtaLink from 'components/ctaLink/ctaLink';
+import CheckboxInput from 'components/checkboxInput/checkboxInput';
+
+import { connect } from 'react-redux';
+import ErrorMessage from 'components/errorMessage/errorMessage';
+import { setGnmMarketing } from 'helpers/user/userActions';
+import { sendMarketingPreferencesToIdentity } from '../helpers/consent-api';
+import type { Csrf as CsrfState } from '../../../helpers/csrf/csrfReducer';
+
+// ----- Types ----- //
+
+type PropTypes = {
+  consentApiError: boolean,
+  onClick: (marketingPreferencesOptIn: boolean, email?: string, csfr: CsrfState) => void,
+  marketingPreferencesOptIn: boolean,
+  marketingPreferenceUpdate: (preference: boolean) => void,
+  email?: string,
+  csrf: CsrfState,
+};
+
+// ----- Component ----- //
+
+function MarketingConsent(props: PropTypes) {
+
+  const showError = (consentApiError: boolean) => {
+    if (consentApiError) {
+      return <ErrorMessage message="Error confirming selection. Please try again later" />;
+    }
+    return null;
+  };
+  if (props.email) {
+    return (
+      <div>
+        <section className="component-info-section marketing-opt-in">
+          <div className="component-info-section__header">
+            Stay in touch
+          </div>
+          <div className="thankyou__wrapper marketing-opt-in__wrapper">
+            <h2 id="qa-thank-you-message" className="thankyou__subheading">
+              <CheckboxInput
+                id="gnm-marketing-preference"
+                checked={props.marketingPreferencesOptIn || false}
+                onChange={props.marketingPreferenceUpdate}
+                labelTitle="Subscriptions, membership and supporting The&nbsp;Guardian"
+                labelCopy="Get related news and offers - whether you are a subscriber, member, supporter or would like to become one."
+              />
+            </h2>
+            {showError(props.consentApiError)}
+            <CtaLink
+              onClick={
+                () => props.onClick(props.marketingPreferencesOptIn, props.email, props.csrf)
+              }
+              ctaId="Next"
+              text="Next"
+              accessibilityHint="Go to the guardian dot com front page"
+            />
+          </div>
+        </section>
+      </div>
+    );
+  }
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    onClick: (marketingPreferencesOptIn: boolean, email: string, csfr: CsrfState) => {
+      sendMarketingPreferencesToIdentity(
+        marketingPreferencesOptIn,
+        email,
+        dispatch,
+        csfr,
+      );
+    },
+    marketingPreferenceUpdate: (preference: boolean) => {
+      dispatch(setGnmMarketing(preference));
+    },
+  };
+}
+
+function mapStateToProps(state) {
+  return {
+    email: state.page.user.email,
+    marketingPreferencesOptIn: state.page.user.gnmMarketing,
+    consentApiError: state.page.thankYouState.consentApiError,
+    csrf: state.page.csrf,
+  };
+}
+
+
+MarketingConsent.defaultProps = {
+  email: '',
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(MarketingConsent);

--- a/assets/pages/contributions-thankyou/components/questionsAndSocial.jsx
+++ b/assets/pages/contributions-thankyou/components/questionsAndSocial.jsx
@@ -1,0 +1,40 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+import InfoSection from 'components/infoSection/infoSection';
+import SocialShare from 'components/socialShare/socialShare';
+
+// ----- Component ----- //
+
+
+function QuestionsAndSocial() {
+  return (
+    <div className="questions-and-social">
+      <InfoSection heading="Questions?" className="questions-and-social__questions">
+        <p>
+          If you have any questions about contributing to the Guardian,
+          please <a href="mailto:contribution.support@theguardian.com">contact us</a>
+        </p>
+      </InfoSection>
+      <InfoSection
+        heading="Spread the word"
+        className="questions-and-social__spread-the-word"
+      >
+        <p>
+          We report for everyone. Let your friends and followers know that
+          you support independent journalism.
+        </p>
+        <SocialShare name="facebook" />
+        <SocialShare name="twitter" />
+      </InfoSection>
+    </div>
+  );
+}
+
+// ----- Exports ----- //
+
+export default QuestionsAndSocial;
+

--- a/assets/pages/contributions-thankyou/components/thankYouIntroduction.jsx
+++ b/assets/pages/contributions-thankyou/components/thankYouIntroduction.jsx
@@ -1,0 +1,28 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+// ----- Component ----- //
+
+type PropTypes = {
+  thankYouMessage: string,
+};
+
+function ThankYouIntroduction(props: PropTypes) {
+  return (
+    <section className="component-info-section__heading thankyou__component">
+      <div className="thankyou__wrapper">
+        <h3 className="thankyou__heading">Thank you!</h3>
+        <h2 id="qa-thank-you-message" className="thankyou__subheading">
+          <p>{props.thankYouMessage}</p>
+        </h2>
+      </div>
+    </section>
+  );
+}
+
+// ----- Exports ----- //
+
+export default ThankYouIntroduction;
+

--- a/assets/pages/contributions-thankyou/contributionsMarketingConfirm.jsx
+++ b/assets/pages/contributions-thankyou/contributionsMarketingConfirm.jsx
@@ -1,0 +1,47 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+import { getQueryParameter } from 'helpers/url';
+import { renderPage } from 'helpers/render';
+import CtaLink from 'components/ctaLink/ctaLink';
+import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
+import Footer from 'components/footer/footer';
+import { statelessInit as pageInit } from 'helpers/page/page';
+import ThankYouIntroduction from './components/thankYouIntroduction';
+import QuestionsAndSocial from './components/questionsAndSocial';
+
+
+// ----- Page Startup ----- //
+pageInit();
+
+// ----- Render ----- //
+
+const copy = getQueryParameter('optIn') === 'yes'
+  ? 'We\'ll be in touch. Check your inbox for a confirmation link.'
+  : 'Your preference has been recorded.';
+
+const content = (
+  <div className="gu-content">
+    <SimpleHeader />
+    <section className="thankyou gu-content-filler">
+      <div className="thankyou__content gu-content-filler__inner">
+        <ThankYouIntroduction thankYouMessage={copy} />
+        <div className="thankyou__wrapper">
+          <CtaLink
+            ctaId="return-to-the-guardian"
+            text="Return to the Guardian"
+            url="https://theguardian.com"
+            accessibilityHint="Go to the guardian dot com front page"
+          />
+        </div>
+        <QuestionsAndSocial />
+      </div>
+    </section>
+    <Footer />
+  </div>
+);
+
+
+renderPage(content, 'contributions-confirm-marketing');

--- a/assets/pages/contributions-thankyou/contributionsThankYouActions.js
+++ b/assets/pages/contributions-thankyou/contributionsThankYouActions.js
@@ -1,0 +1,19 @@
+// @flow
+
+
+// ----- Actions ----- //
+
+
+export type Action = { type: 'CONSENT_API_ERROR', consentApiError: boolean }
+
+
+function setConsentApiError(consentApiError: boolean): Action {
+  return { type: 'CONSENT_API_ERROR', consentApiError };
+
+}
+
+// ----- Exports ----- //
+
+export {
+  setConsentApiError,
+};

--- a/assets/pages/contributions-thankyou/contributionsThankYouReducer.js
+++ b/assets/pages/contributions-thankyou/contributionsThankYouReducer.js
@@ -1,0 +1,65 @@
+// @flow
+
+// ----- Imports ----- //
+
+import { combineReducers } from 'redux';
+import type { User as UserState } from 'helpers/user/userReducer';
+
+import { userReducer as user } from 'helpers/user/userReducer';
+import csrfReducer from 'helpers/csrf/csrfReducer';
+
+import type { CommonState } from 'helpers/page/page';
+
+import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
+import type { Action } from './contributionsThankYouActions';
+
+
+// ----- Types ----- //
+
+export type State = {
+  consentApiError: boolean,
+};
+
+export type CombinedState = {
+  thankYouState: State,
+  user: UserState,
+  csrf: CsrfState,
+};
+
+export type PageState = {
+  common: CommonState,
+  page: CombinedState,
+}
+
+
+// ----- Reducers ----- //
+
+function createThankYouReducer() {
+
+  const initialState: State = {
+    consentApiError: false,
+  };
+
+  return function thankYouReducer(state: State = initialState, action: Action): State {
+
+    switch (action.type) {
+
+      case 'CONSENT_API_ERROR':
+        return Object.assign({}, state, { consentApiError: action.consentApiError });
+      default:
+        return state;
+
+    }
+  };
+}
+
+
+// ----- Exports ----- //
+
+
+export default combineReducers({
+  thankYouState: createThankYouReducer(),
+  user,
+  csrf: csrfReducer,
+});
+

--- a/assets/pages/contributions-thankyou/contributionsThankyou.scss
+++ b/assets/pages/contributions-thankyou/contributionsThankyou.scss
@@ -1,4 +1,4 @@
-#regular-contributions-thankyou-page, #oneoff-contributions-thankyou-page, #regular-contributions-pending-page {
+#regular-contributions-thankyou-page, #oneoff-contributions-thankyou-page, #regular-contributions-pending-page, #contributions-confirm-marketing {
 
 	a {
 		color: gu-colour(neutral-1);
@@ -23,6 +23,40 @@
 		}
 	}
 
+	.marketing-opt-in {
+		.marketing-opt-in__wrapper {
+			max-width: 450px;
+			padding-bottom: 0;
+		}
+
+		.component-cta-link {
+			margin-top: 0;
+			margin-bottom: 0;
+		}
+
+		.component-checkbox {
+			margin-top: 0;
+			margin-bottom: 20px;
+		}
+
+		.component-info-section__header {
+			@include mq($from: desktop) {
+				position: absolute;
+			}
+		}
+
+		.component-error-message {
+			margin-top: 12px;
+			margin-bottom: 5px;
+		}
+	}
+
+
+	.thankyou__component {
+		margin-bottom: 45px;
+	}
+
+
 	.thankyou__heading {
 		font-family: $gu-egyptian-web;
 		color: gu-colour(neutral-1);
@@ -36,7 +70,7 @@
 		}
 	}
 
-	.thankyou__subheading {
+	.thankyou__subheading, .marketing-opt-in__subheading {
 		font-family: $gu-text-egyptian-web;
 		font-size: 22px;
 		line-height: 24px;
@@ -95,3 +129,4 @@
 	}
 
 }
+

--- a/assets/pages/contributions-thankyou/helpers/consent-api.js
+++ b/assets/pages/contributions-thankyou/helpers/consent-api.js
@@ -1,0 +1,52 @@
+// @flow
+
+// ----- Imports ----- //
+import { routes } from 'helpers/routes';
+import { setConsentApiError } from '../contributionsThankYouActions';
+import type { Csrf as CsrfState } from '../../../helpers/csrf/csrfReducer';
+
+// ----- Functions ----- //
+
+const marketingConfirmUrl = (marketingPreferencesOptIn: boolean) => {
+  const params = new URLSearchParams();
+  const optInParam = marketingPreferencesOptIn === true ? 'yes' : 'no';
+  params.append('optIn', optInParam);
+  return `${routes.contributionsMarketingConfirm}?${params.toString()}`;
+};
+
+const requestData = (email: string, csrf: CsrfState) => ({
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json', 'Csrf-Token': csrf.token || '' },
+  credentials: 'same-origin',
+  body: JSON.stringify({ email }),
+});
+
+// Fire and forget, as we don't want to interupt the flow
+function sendMarketingPreferencesToIdentity(
+  optIn: boolean,
+  email: string,
+  dispatch: Function,
+  csrf: CsrfState,
+) {
+  if (optIn) {
+    fetch(`${routes.contributionsSendMarketing}`, requestData(email, csrf))
+      .then((response) => {
+        if (response.status === 200) {
+          window.location = marketingConfirmUrl(optIn);
+        } else {
+          dispatch(setConsentApiError(true));
+        }
+      })
+      .catch(() => {
+        dispatch(setConsentApiError(true));
+      });
+  } else {
+    window.location = marketingConfirmUrl(optIn);
+  }
+}
+
+// ----- Exports ----- //
+
+export {
+  sendMarketingPreferencesToIdentity,
+};

--- a/assets/pages/contributions-thankyou/regularContributionsPending.jsx
+++ b/assets/pages/contributions-thankyou/regularContributionsPending.jsx
@@ -3,16 +3,12 @@
 // ----- Imports ----- //
 
 import React from 'react';
-
-import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
-import Footer from 'components/footer/footer';
-import CtaLink from 'components/ctaLink/ctaLink';
-import InfoSection from 'components/infoSection/infoSection';
-import SocialShare from 'components/socialShare/socialShare';
-
 import { statelessInit as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
-
+import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
+import Footer from 'components/footer/footer';
+import ThankYouIntroduction from './components/thankYouIntroduction';
+import QuestionsAndSocial from './components/questionsAndSocial';
 
 // ----- Page Startup ----- //
 
@@ -26,38 +22,11 @@ const content = (
     <SimpleHeader />
     <section className="thankyou gu-content-filler">
       <div className="thankyou__content gu-content-filler__inner">
-        <div className="thankyou__wrapper">
-          <h1 className="thankyou__heading">Thank you!</h1>
-          <h2 id="qa-thank-you-message" className="thankyou__subheading">
-            <p>You have helped to make the Guardian&#39;s future more secure.
-              Look out for an email confirming your recurring
-              payment.
-            </p>
-          </h2>
-          <CtaLink
-            ctaId="return-to-the-guardian"
-            text="Return to the Guardian"
-            url="https://theguardian.com"
-            accessibilityHint="Go to the guardian dot com front page"
-          />
-        </div>
-        <InfoSection heading="Questions?" className="thankyou__questions">
-          <p>
-            If you have any questions about contributing to the Guardian,
-            please <a href="mailto:contribution.support@theguardian.com">contact us</a>
-          </p>
-        </InfoSection>
-        <InfoSection
-          heading="Spread the word"
-          className="thankyou__spread-the-word"
-        >
-          <p>
-            We report for everyone. Let your friends and followers know that
-            you support independent journalism.
-          </p>
-          <SocialShare name="facebook" />
-          <SocialShare name="twitter" />
-        </InfoSection>
+        <ThankYouIntroduction thankYouMessage="You have helped to make the Guardian&#39;s future more secure.
+            Look out for an email confirming your recurring
+            payment."
+        />
+        <QuestionsAndSocial />
       </div>
     </section>
     <Footer />

--- a/assets/pages/contributions-thankyou/regularContributionsThankyou.jsx
+++ b/assets/pages/contributions-thankyou/regularContributionsThankyou.jsx
@@ -3,16 +3,12 @@
 // ----- Imports ----- //
 
 import React from 'react';
-
-import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
-import Footer from 'components/footer/footer';
-import CtaLink from 'components/ctaLink/ctaLink';
-import InfoSection from 'components/infoSection/infoSection';
-import SocialShare from 'components/socialShare/socialShare';
-
 import { statelessInit as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
-
+import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
+import Footer from 'components/footer/footer';
+import ThankYouIntroduction from './components/thankYouIntroduction';
+import QuestionsAndSocial from './components/questionsAndSocial';
 
 // ----- Page Startup ----- //
 
@@ -26,38 +22,11 @@ const content = (
     <SimpleHeader />
     <section className="thankyou gu-content-filler">
       <div className="thankyou__content gu-content-filler__inner">
-        <div className="thankyou__wrapper">
-          <h1 className="thankyou__heading">Thank you!</h1>
-          <h2 id="qa-thank-you-message" className="thankyou__subheading">
-            <p>You have helped to make the Guardian&#39;s future more secure.
+        <ThankYouIntroduction thankYouMessage="You have helped to make the Guardian&#39;s future more secure.
             Look out for an email confirming your recurring
-            payment.
-            </p>
-          </h2>
-          <CtaLink
-            ctaId="return-to-the-guardian"
-            text="Return to the Guardian"
-            url="https://theguardian.com"
-            accessibilityHint="Go to the guardian dot com front page"
-          />
-        </div>
-        <InfoSection heading="Questions?" className="thankyou__questions">
-          <p>
-            If you have any questions about contributing to the Guardian,
-            please <a href="mailto:contribution.support@theguardian.com">contact us</a>
-          </p>
-        </InfoSection>
-        <InfoSection
-          heading="Spread the word"
-          className="thankyou__spread-the-word"
-        >
-          <p>
-            We report for everyone. Let your friends and followers know that
-            you support independent journalism.
-          </p>
-          <SocialShare name="facebook" />
-          <SocialShare name="twitter" />
-        </InfoSection>
+            payment."
+        />
+        <QuestionsAndSocial />
       </div>
     </section>
     <Footer />

--- a/assets/pages/oneoff-contributions/components/formFields.jsx
+++ b/assets/pages/oneoff-contributions/components/formFields.jsx
@@ -6,13 +6,11 @@ import React from 'react';
 import { connect } from 'react-redux';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import TextInput from 'components/textInput/textInput';
-import CheckboxInput from 'components/checkboxInput/checkboxInput';
 
 import {
   setFullName,
   setEmail,
   setPostcode,
-  setGnmMarketing,
 } from 'helpers/user/userActions';
 
 
@@ -22,11 +20,9 @@ type PropTypes = {
   nameUpdate: (name: string) => void,
   emailUpdate: (email: string) => void,
   postcodeUpdate: (postcode: string) => void,
-  gnmMarketingPreferenceUpdate: (preference: boolean) => void,
   name: string,
   email: string,
   postcode: ?string,
-  gnmMarketingPreference: boolean,
   isoCountry: IsoCountry,
 };
 
@@ -57,12 +53,6 @@ function FormFields(props: PropTypes) {
         value={props.postcode || ''}
         onChange={props.postcodeUpdate}
       />
-      <CheckboxInput
-        id="gnm-marketing-preference"
-        checked={props.gnmMarketingPreference || false}
-        onChange={props.gnmMarketingPreferenceUpdate}
-        labelText="Keep me up to date with offers from the Guardian"
-      />
     </form>
   );
 
@@ -73,12 +63,10 @@ function FormFields(props: PropTypes) {
 
 function mapStateToProps(state) {
   const { user } = state.page;
-
   return {
     name: user.fullName,
     email: user.email,
     postcode: user.postcode,
-    gnmMarketingPreference: user.gnmMarketing,
     isoCountry: state.common.country,
   };
 
@@ -95,9 +83,6 @@ function mapDispatchToProps(dispatch) {
     },
     postcodeUpdate: (postcode: string) => {
       dispatch(setPostcode(postcode));
-    },
-    gnmMarketingPreferenceUpdate: (preference: boolean) => {
-      dispatch(setGnmMarketing(preference));
     },
   };
 

--- a/build.sbt
+++ b/build.sbt
@@ -74,7 +74,6 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-parser" % circeVersion,
   "joda-time" % "joda-time" % "2.9.9",
   "com.gu.identity" %% "identity-play-auth" % "2.1",
-  "com.gu.identity" %% "identity-model" % "3.100",
   "com.gu" %% "identity-test-users" % "0.6",
   "com.google.guava" % "guava" % "23.0",
   "com.netaporter" %% "scala-uri" % "0.4.16",

--- a/build.sbt
+++ b/build.sbt
@@ -74,6 +74,7 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-parser" % circeVersion,
   "joda-time" % "joda-time" % "2.9.9",
   "com.gu.identity" %% "identity-play-auth" % "2.1",
+  "com.gu.identity" %% "identity-model" % "3.100",
   "com.gu" %% "identity-test-users" % "0.6",
   "com.google.guava" % "guava" % "23.0",
   "com.netaporter" %% "scala-uri" % "0.4.16",

--- a/conf/routes
+++ b/conf/routes
@@ -32,10 +32,16 @@ GET  /contribute/recurring/thankyou                 controllers.Application.reac
 GET  /contribute/recurring/existing                 controllers.Application.reactTemplate(title="Support the Guardian | Existing Contributor", id="regular-contributions-existing-page", js="regularContributionsExistingPage.js")
 POST /contribute/recurring/create                   controllers.RegularContributions.create
 GET  /contribute/recurring/status                   controllers.RegularContributions.status(jobId: String)
-GET  /contribute/recurring/pending                 controllers.Application.reactTemplate(title="Support the Guardian | Thank You", id="regular-contributions-pending-page", js="regularContributionsPendingPage.js")
+GET  /contribute/recurring/pending                  controllers.Application.reactTemplate(title="Support the Guardian | Thank You", id="regular-contributions-pending-page", js="regularContributionsPendingPage.js")
+GET  /contribute/marketing-confirm                  controllers.Application.reactTemplate(title="Support the Guardian | Thank You", id="contributions-confirm-marketing", js="contributionsMarketingConfirmPage.js")
+
+# this endpoint should be removed once identity remove
+# the need for a client token
+POST  /contribute/send-marketing                     controllers.IdentityController.submitMarketing
+
 
 GET  /contribute/one-off                            controllers.OneOffContributions.displayForm(paypal: Option[Boolean])
-GET  /contribute/one-off/thankyou                   controllers.Application.reactTemplate(title="Support the Guardian | Thank You", id="oneoff-contributions-thankyou-page", js="oneoffContributionsThankyouPage.js")
+GET  /contribute/one-off/thankyou                   controllers.OneOffContributions.thankYouPage
 GET  /contribute/one-off/autofill                   controllers.OneOffContributions.autofill
 
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -56,6 +56,7 @@ module.exports = (env) => {
       regularContributionsPendingPage: 'pages/contributions-thankyou/regularContributionsPending.jsx',
       oneoffContributionsPage: 'pages/oneoff-contributions/oneoffContributions.jsx',
       oneoffContributionsThankyouPage: 'pages/contributions-thankyou/oneoffContributionsThankyou.jsx',
+      contributionsMarketingConfirmPage: 'pages/contributions-thankyou/contributionsMarketingConfirm.jsx',
       regularContributionsExistingPage: 'pages/regular-contributions-existing/regularContributionsExisting.jsx',
       payPalErrorPage: 'pages/paypal-error/payPalError.jsx',
       googleTagManagerScript: 'helpers/tracking/googleTagManagerScript.js',


### PR DESCRIPTION
The same as https://github.com/guardian/support-frontend/pull/435, except we don't use the Identity Model import to get the string "supporter", as this was causing issues in PROD