### PR TITLE
Direct debit phase 2/6

### DIFF
--- a/app/config/Configuration.scala
+++ b/app/config/Configuration.scala
@@ -1,5 +1,6 @@
 package config
 
+import com.gocardless.GoCardlessClient
 import com.gu.support.config.{PayPalConfigProvider, Stage, StripeConfigProvider}
 import com.typesafe.config.ConfigFactory
 import config.ConfigImplicits._
@@ -19,6 +20,13 @@ class Configuration {
   lazy val aws = new AwsConfig(config.getConfig("aws"))
 
   lazy val guardianDomain = config.getString("guardianDomain")
+
+  lazy val goCardlessToken = config.getString("gocardless.token")
+
+  lazy val goCardlessEnvironment = config.getString("gocardless.environment") match {
+    case "LIVE" => GoCardlessClient.Environment.LIVE
+    case "SANDBOX" => GoCardlessClient.Environment.SANDBOX
+  }
 
   lazy val supportUrl = config.getString("support.url")
 

--- a/app/controllers/DirectDebit.scala
+++ b/app/controllers/DirectDebit.scala
@@ -3,7 +3,7 @@ package controllers
 import actions.CustomActionBuilders
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.syntax._
-import models.CheckBankAccountData
+import models.CheckBankAccountDetails
 import play.api.libs.circe.Circe
 import play.api.mvc._
 import services.paypal.PayPalBillingDetails.codec
@@ -20,8 +20,8 @@ class DirectDebit(
 
   import actionBuilders._
 
-  def checkAccount: Action[CheckBankAccountData] =
-    PrivateAction.async(circe.json[CheckBankAccountData]) { implicit request =>
+  def checkAccount: Action[CheckBankAccountDetails] =
+    PrivateAction.async(circe.json[CheckBankAccountDetails]) { implicit request =>
       goCardlessService.checkBankDetails(request.body).map { isAccountValid =>
         Ok(Map("accountValid" -> isAccountValid).asJson)
       }

--- a/app/controllers/DirectDebit.scala
+++ b/app/controllers/DirectDebit.scala
@@ -4,11 +4,10 @@ import actions.CustomActionBuilders
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.syntax._
 import models.DirectDebitData
-
 import play.api.libs.circe.Circe
 import play.api.mvc._
 import services.paypal.PayPalBillingDetails.codec
-import services.{GoCardlessService}
+import services.GoCardlessService
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -16,15 +15,16 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class DirectDebit(
   actionBuilders: CustomActionBuilders,
-  components: ControllerComponents
+  components: ControllerComponents,
+  goCardlessService: GoCardlessService
 )(implicit val ec: ExecutionContext) extends AbstractController(components) with Circe with LazyLogging {
 
   import actionBuilders._
 
-  def checkAccount: Action[AnyContent]  =
-    CachedAction().async(circe.json[DirectDebitData]) { implicit request =>
-      for {
-        isAccountValid <- GoCardlessService.checkBankDetails(request)
-      } yield Ok(("accountValid" -> isAccountValid).asJson)
+  def checkAccount: Action[DirectDebitData]  =
+    PrivateAction.async(circe.json[DirectDebitData]) { implicit request =>
+      goCardlessService.checkBankDetails(request.body).map { isAccountValid =>
+        Ok(("accountValid" -> isAccountValid).asJson)
+      }
     }
 }

--- a/app/controllers/DirectDebit.scala
+++ b/app/controllers/DirectDebit.scala
@@ -3,7 +3,7 @@ package controllers
 import actions.CustomActionBuilders
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.syntax._
-import models.DirectDebitData
+import models.CheckBankAccountData
 import play.api.libs.circe.Circe
 import play.api.mvc._
 import services.paypal.PayPalBillingDetails.codec
@@ -20,8 +20,8 @@ class DirectDebit(
 
   import actionBuilders._
 
-  def checkAccount: Action[DirectDebitData] =
-    PrivateAction.async(circe.json[DirectDebitData]) { implicit request =>
+  def checkAccount: Action[CheckBankAccountData] =
+    PrivateAction.async(circe.json[CheckBankAccountData]) { implicit request =>
       goCardlessService.checkBankDetails(request.body).map { isAccountValid =>
         Ok(Map("accountValid" -> isAccountValid).asJson)
       }

--- a/app/controllers/DirectDebit.scala
+++ b/app/controllers/DirectDebit.scala
@@ -12,16 +12,15 @@ import services.GoCardlessService
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.Implicits.global
 
-
 class DirectDebit(
-  actionBuilders: CustomActionBuilders,
-  components: ControllerComponents,
-  goCardlessService: GoCardlessService
+    actionBuilders: CustomActionBuilders,
+    components: ControllerComponents,
+    goCardlessService: GoCardlessService
 )(implicit val ec: ExecutionContext) extends AbstractController(components) with Circe with LazyLogging {
 
   import actionBuilders._
 
-  def checkAccount: Action[DirectDebitData]  =
+  def checkAccount: Action[DirectDebitData] =
     PrivateAction.async(circe.json[DirectDebitData]) { implicit request =>
       goCardlessService.checkBankDetails(request.body).map { isAccountValid =>
         Ok(("accountValid" -> isAccountValid).asJson)

--- a/app/controllers/DirectDebit.scala
+++ b/app/controllers/DirectDebit.scala
@@ -1,0 +1,30 @@
+package controllers
+
+import actions.CustomActionBuilders
+import com.typesafe.scalalogging.LazyLogging
+import io.circe.syntax._
+import models.DirectDebitData
+
+import play.api.libs.circe.Circe
+import play.api.mvc._
+import services.paypal.PayPalBillingDetails.codec
+import services.{GoCardlessService}
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContext.Implicits.global
+
+
+class DirectDebit(
+  actionBuilders: CustomActionBuilders,
+  components: ControllerComponents
+)(implicit val ec: ExecutionContext) extends AbstractController(components) with Circe with LazyLogging {
+
+  import actionBuilders._
+
+  def checkAccount: Action[AnyContent]  =
+    CachedAction().async(circe.json[DirectDebitData]) { implicit request =>
+      for {
+        isAccountValid <- GoCardlessService.checkBankDetails(request)
+      } yield Ok(("accountValid" -> isAccountValid).asJson)
+    }
+}

--- a/app/controllers/DirectDebit.scala
+++ b/app/controllers/DirectDebit.scala
@@ -23,7 +23,7 @@ class DirectDebit(
   def checkAccount: Action[DirectDebitData] =
     PrivateAction.async(circe.json[DirectDebitData]) { implicit request =>
       goCardlessService.checkBankDetails(request.body).map { isAccountValid =>
-        Ok(("accountValid" -> isAccountValid).asJson)
+        Ok(Map("accountValid" -> isAccountValid).asJson)
       }
     }
 }

--- a/app/models/DirectDebitData.scala
+++ b/app/models/DirectDebitData.scala
@@ -1,0 +1,8 @@
+package models
+
+/**
+  * Created by santiago_fernandez on 18/01/2018.
+  */
+class DirectDebitData {
+
+}

--- a/app/models/DirectDebitData.scala
+++ b/app/models/DirectDebitData.scala
@@ -1,5 +1,12 @@
 package models
 
+import codecs.CirceDecoders.deriveCodec
+import codecs.Codec
+
 case class DirectDebitData(accountNumber: String, sortCodeValue: String, accountHolderName: String) {
   val sortCode = sortCodeValue.filter(_.isDigit)
+}
+
+object DirectDebitData {
+  implicit val codec: Codec[DirectDebitData] = deriveCodec
 }

--- a/app/models/DirectDebitData.scala
+++ b/app/models/DirectDebitData.scala
@@ -1,8 +1,5 @@
 package models
 
-/**
-  * Created by santiago_fernandez on 18/01/2018.
-  */
-class DirectDebitData {
-
+case class DirectDebitData(accountNumber: String, sortCodeValue: String, accountHolderName: String) {
+  val sortCode = sortCodeValue.filter(_.isDigit)
 }

--- a/app/models/DirectDebitData.scala
+++ b/app/models/DirectDebitData.scala
@@ -2,10 +2,37 @@ package models
 
 import codecs.CirceDecoders.deriveCodec
 import codecs.Codec
+import io.circe.{Decoder, Encoder}
 
-case class DirectDebitData(accountNumber: String, sortCodeValue: String, accountHolderName: String) {
-  val sortCode = sortCodeValue.filter(_.isDigit)
+case class AccountNumber(private val underlying: String) {
+  def value: String = underlying
 }
+
+object AccountNumber {
+  def fromString(s: String): Option[AccountNumber] = {
+    if (s.length == 8 && s.forall(_.isDigit)) Some(AccountNumber(s)) else None
+  }
+
+  implicit val decodeAccountNumber: Decoder[AccountNumber] =
+    Decoder.decodeString.emap(accountNumber => fromString(accountNumber).toRight(s"Invalid account number'$accountNumber'"))
+  implicit val encodeAccountNumber: Encoder[AccountNumber] = Encoder.encodeString.contramap[AccountNumber](_.value)
+}
+
+case class SortCode(private val underlying: String) {
+  def value: String = underlying
+}
+
+object SortCode {
+  def fromString(s: String): Option[SortCode] = {
+    if (s.length == 6 && s.forall(_.isDigit)) Some(SortCode(s)) else None
+  }
+
+  implicit val decodeSortCode: Decoder[SortCode] =
+    Decoder.decodeString.emap(sortCode => fromString(sortCode).toRight(s"Invalid sort code'$sortCode'"))
+  implicit val encodeSortCode: Encoder[SortCode] = Encoder.encodeString.contramap[SortCode](_.value)
+}
+
+case class DirectDebitData(accountNumber: AccountNumber, sortCode: SortCode, accountHolderName: String)
 
 object DirectDebitData {
   implicit val codec: Codec[DirectDebitData] = deriveCodec

--- a/app/models/DirectDebitData.scala
+++ b/app/models/DirectDebitData.scala
@@ -37,3 +37,9 @@ case class DirectDebitData(accountNumber: AccountNumber, sortCode: SortCode, acc
 object DirectDebitData {
   implicit val codec: Codec[DirectDebitData] = deriveCodec
 }
+
+case class CheckBankAccountData(accountNumber: AccountNumber, sortCode: SortCode)
+
+object CheckBankAccountData {
+  implicit val codec: Codec[CheckBankAccountData] = deriveCodec
+}

--- a/app/models/DirectDebitDetails.scala
+++ b/app/models/DirectDebitDetails.scala
@@ -14,7 +14,7 @@ object AccountNumber {
   }
 
   implicit val decodeAccountNumber: Decoder[AccountNumber] =
-    Decoder.decodeString.emap(accountNumber => fromString(accountNumber).toRight(s"Invalid account number'$accountNumber'"))
+    Decoder.decodeString.emap(accountNumber => fromString(accountNumber).toRight(s"Invalid account number '$accountNumber'"))
   implicit val encodeAccountNumber: Encoder[AccountNumber] = Encoder.encodeString.contramap[AccountNumber](_.value)
 }
 
@@ -28,7 +28,7 @@ object SortCode {
   }
 
   implicit val decodeSortCode: Decoder[SortCode] =
-    Decoder.decodeString.emap(sortCode => fromString(sortCode).toRight(s"Invalid sort code'$sortCode'"))
+    Decoder.decodeString.emap(sortCode => fromString(sortCode).toRight(s"Invalid sort code '$sortCode'"))
   implicit val encodeSortCode: Encoder[SortCode] = Encoder.encodeString.contramap[SortCode](_.value)
 }
 

--- a/app/models/DirectDebitDetails.scala
+++ b/app/models/DirectDebitDetails.scala
@@ -32,14 +32,14 @@ object SortCode {
   implicit val encodeSortCode: Encoder[SortCode] = Encoder.encodeString.contramap[SortCode](_.value)
 }
 
-case class DirectDebitData(accountNumber: AccountNumber, sortCode: SortCode, accountHolderName: String)
+case class DirectDebitDetails(accountNumber: AccountNumber, sortCode: SortCode, accountHolderName: String)
 
-object DirectDebitData {
-  implicit val codec: Codec[DirectDebitData] = deriveCodec
+object DirectDebitDetails {
+  implicit val codec: Codec[DirectDebitDetails] = deriveCodec
 }
 
-case class CheckBankAccountData(accountNumber: AccountNumber, sortCode: SortCode)
+case class CheckBankAccountDetails(accountNumber: AccountNumber, sortCode: SortCode)
 
-object CheckBankAccountData {
-  implicit val codec: Codec[CheckBankAccountData] = deriveCodec
+object CheckBankAccountDetails {
+  implicit val codec: Codec[CheckBankAccountDetails] = deriveCodec
 }

--- a/app/services/GoCardlessService.scala
+++ b/app/services/GoCardlessService.scala
@@ -5,7 +5,7 @@ import com.gocardless.GoCardlessClient.Environment
 import com.gocardless.errors.GoCardlessApiException
 import com.gocardless.resources.BankDetailsLookup.AvailableDebitScheme
 import com.typesafe.scalalogging.LazyLogging
-import models.DirectDebitData
+import models.CheckBankAccountData
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -19,11 +19,11 @@ class GoCardlessService(token: String, environment: Environment) extends LazyLog
    * @return true if either the bank details are correct, or the rate limit for this enpoint is reached.
    *         In the latter case an error is logged.
    */
-  def checkBankDetails(paymentData: DirectDebitData): Future[Boolean] = {
+  def checkBankDetails(bankAccountData: CheckBankAccountData): Future[Boolean] = {
     Future {
       client.bankDetailsLookups().create()
-        .withAccountNumber(paymentData.accountNumber.value)
-        .withBranchCode(paymentData.sortCode.value)
+        .withAccountNumber(bankAccountData.accountNumber.value)
+        .withBranchCode(bankAccountData.sortCode.value)
         .withCountryCode("GB")
         .execute()
     } map { bdl =>

--- a/app/services/GoCardlessService.scala
+++ b/app/services/GoCardlessService.scala
@@ -5,7 +5,7 @@ import com.gocardless.GoCardlessClient.Environment
 import com.gocardless.errors.GoCardlessApiException
 import com.gocardless.resources.BankDetailsLookup.AvailableDebitScheme
 import com.typesafe.scalalogging.LazyLogging
-import models.CheckBankAccountData
+import models.CheckBankAccountDetails
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -19,7 +19,7 @@ class GoCardlessService(token: String, environment: Environment) extends LazyLog
    * @return true if either the bank details are correct, or the rate limit for this enpoint is reached.
    *         In the latter case an error is logged.
    */
-  def checkBankDetails(bankAccountData: CheckBankAccountData): Future[Boolean] = {
+  def checkBankDetails(bankAccountData: CheckBankAccountDetails): Future[Boolean] = {
     Future {
       client.bankDetailsLookups().create()
         .withAccountNumber(bankAccountData.accountNumber.value)

--- a/app/services/GoCardlessService.scala
+++ b/app/services/GoCardlessService.scala
@@ -1,24 +1,27 @@
 package services
 
-import scala.concurrent.Future
+import com.gocardless.GoCardlessClient
+import com.gocardless.GoCardlessClient.Environment
+import com.gocardless.errors.GoCardlessApiException
+import com.gocardless.resources.BankDetailsLookup.AvailableDebitScheme
 import com.typesafe.scalalogging.LazyLogging
+import models.DirectDebitData
 
-trait GoCardlessService {
-  def checkBankDetails(paymentData: DirectDebitData): Future[Boolean]
-}
+import scala.concurrent.Future
 
-object GoCardlessService extends GoCardlessService with LazyLogging {
-  lazy val client = Config.GoCardless.client
+class GoCardlessService(token: String, environment: Environment) extends LazyLogging {
+
+  lazy val client = GoCardlessClient.create(token, environment)
 
   /**
    *
    * @return true if either the bank details are correct, or the rate limit for this enpoint is reached.
    *         In the latter case an error is logged.
    */
-  override def checkBankDetails(paymentData: DirectDebitData): Future[Boolean] = {
+  def checkBankDetails(paymentData: DirectDebitData): Future[Boolean] = {
     Future {
       client.bankDetailsLookups().create()
-        .withAccountNumber(paymentData.account)
+        .withAccountNumber(paymentData.accountNumber)
         .withBranchCode(paymentData.sortCode)
         .withCountryCode("GB")
         .execute()
@@ -27,7 +30,8 @@ object GoCardlessService extends GoCardlessService with LazyLogging {
     } recover {
       case e: GoCardlessApiException =>
         if (e.getCode == 429) {
-          logger.error("Bypassing preliminary bank account check because the GoCardless rate limit has been reached for this endpoint. Someone might be using our website to proxy to GoCardless")
+          logger.error("Bypassing preliminary bank account check because the GoCardless rate limit" +
+            " has been reached for this endpoint. Someone might be using our website to proxy to GoCardless")
           true
         } else {
           false

--- a/app/services/GoCardlessService.scala
+++ b/app/services/GoCardlessService.scala
@@ -1,0 +1,37 @@
+package services
+
+import scala.concurrent.Future
+import com.typesafe.scalalogging.LazyLogging
+
+trait GoCardlessService {
+  def checkBankDetails(paymentData: DirectDebitData): Future[Boolean]
+}
+
+object GoCardlessService extends GoCardlessService with LazyLogging {
+  lazy val client = Config.GoCardless.client
+
+  /**
+   *
+   * @return true if either the bank details are correct, or the rate limit for this enpoint is reached.
+   *         In the latter case an error is logged.
+   */
+  override def checkBankDetails(paymentData: DirectDebitData): Future[Boolean] = {
+    Future {
+      client.bankDetailsLookups().create()
+        .withAccountNumber(paymentData.account)
+        .withBranchCode(paymentData.sortCode)
+        .withCountryCode("GB")
+        .execute()
+    } map { bdl =>
+      bdl.getAvailableDebitSchemes.contains(AvailableDebitScheme.BACS)
+    } recover {
+      case e: GoCardlessApiException =>
+        if (e.getCode == 429) {
+          logger.error("Bypassing preliminary bank account check because the GoCardless rate limit has been reached for this endpoint. Someone might be using our website to proxy to GoCardless")
+          true
+        } else {
+          false
+        }
+    }
+  }
+}

--- a/app/services/GoCardlessService.scala
+++ b/app/services/GoCardlessService.scala
@@ -7,6 +7,7 @@ import com.gocardless.resources.BankDetailsLookup.AvailableDebitScheme
 import com.typesafe.scalalogging.LazyLogging
 import models.DirectDebitData
 
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
 class GoCardlessService(token: String, environment: Environment) extends LazyLogging {

--- a/app/services/GoCardlessService.scala
+++ b/app/services/GoCardlessService.scala
@@ -22,8 +22,8 @@ class GoCardlessService(token: String, environment: Environment) extends LazyLog
   def checkBankDetails(paymentData: DirectDebitData): Future[Boolean] = {
     Future {
       client.bankDetailsLookups().create()
-        .withAccountNumber(paymentData.accountNumber)
-        .withBranchCode(paymentData.sortCode)
+        .withAccountNumber(paymentData.accountNumber.value)
+        .withBranchCode(paymentData.sortCode.value)
         .withCountryCode("GB")
         .execute()
     } map { bdl =>

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -42,6 +42,7 @@ trait AppComponents extends PlayComponents
     loginController,
     testUsersController,
     payPalController,
+    directDebitController,
     assetController
   )
 

--- a/app/wiring/Controllers.scala
+++ b/app/wiring/Controllers.scala
@@ -62,9 +62,16 @@ trait Controllers {
     controllerComponents
   )
 
+
   lazy val identityController = new IdentityController(
     identityService,
     controllerComponents,
     actionRefiners
+  )
+
+  lazy val DirectDebitController = new DirectDebit(
+    actionRefiners,
+    controllerComponents,
+    goCardlessService
   )
 }

--- a/app/wiring/Controllers.scala
+++ b/app/wiring/Controllers.scala
@@ -62,14 +62,13 @@ trait Controllers {
     controllerComponents
   )
 
-
   lazy val identityController = new IdentityController(
     identityService,
     controllerComponents,
     actionRefiners
   )
 
-  lazy val DirectDebitController = new DirectDebit(
+  lazy val directDebitController = new DirectDebit(
     actionRefiners,
     controllerComponents,
     goCardlessService

--- a/app/wiring/Services.scala
+++ b/app/wiring/Services.scala
@@ -18,6 +18,8 @@ trait Services {
 
   lazy val identityService = IdentityService(appConfig.identity)
 
+  lazy val goCardlessService = GoCardlessService(appConfig.goCardlessToken, appConfig.goCardlessEnvironment)
+
   lazy val regularContributionsClient = {
     val stateWrapper = new StateWrapper(Encryption.getProvider(appConfig.aws), appConfig.aws.useEncryption)
     val regularContributionsStage = if (appConfig.stage == Stages.DEV) Stages.CODE else appConfig.stage

--- a/app/wiring/Services.scala
+++ b/app/wiring/Services.scala
@@ -18,7 +18,7 @@ trait Services {
 
   lazy val identityService = IdentityService(appConfig.identity)
 
-  lazy val goCardlessService = GoCardlessService(appConfig.goCardlessToken, appConfig.goCardlessEnvironment)
+  lazy val goCardlessService = new GoCardlessService(appConfig.goCardlessToken, appConfig.goCardlessEnvironment)
 
   lazy val regularContributionsClient = {
     val stateWrapper = new StateWrapper(Encryption.getProvider(appConfig.aws), appConfig.aws.useEncryption)

--- a/assets/components/directDebit/__tests__/__snapshots__/directDebitReducerTest.js.snap
+++ b/assets/components/directDebit/__tests__/__snapshots__/directDebitReducerTest.js.snap
@@ -6,6 +6,7 @@ Object {
   "accountHolderName": "",
   "bankAccountNumber": "",
   "bankSortCode": "",
+  "formError": "",
   "isPopUpOpen": false,
 }
 `;

--- a/assets/components/directDebit/__tests__/directDebitActionsTest.js
+++ b/assets/components/directDebit/__tests__/directDebitActionsTest.js
@@ -6,6 +6,8 @@ import {
   updateAccountNumber,
   updateAccountHolderName,
   updateAccountHolderConfirmation,
+  setDirectDebitFormError,
+  resetDirectDebitFormError,
 } from '../directDebitActions';
 
 
@@ -59,6 +61,22 @@ describe('actions', () => {
       accountHolderConfirmation,
     };
     expect(updateAccountHolderConfirmation(accountHolderConfirmation)).toEqual(expectedAction);
+  });
+
+  it('should create an action to set the error message in the direct debit form', () => {
+    const message: string = 'this is an error';
+    const expectedAction = {
+      type: 'DIRECT_DEBIT_SET_FORM_ERROR',
+      message,
+    };
+    expect(setDirectDebitFormError(message)).toEqual(expectedAction);
+  });
+
+  it('should create an action to reset the error message in the direct debit form', () => {
+    const expectedAction = {
+      type: 'DIRECT_DEBIT_RESET_FORM_ERROR',
+    };
+    expect(resetDirectDebitFormError()).toEqual(expectedAction);
   });
 });
 

--- a/assets/components/directDebit/__tests__/directDebitReducerTest.js
+++ b/assets/components/directDebit/__tests__/directDebitReducerTest.js
@@ -82,5 +82,29 @@ describe('direct debit reducer tests', () => {
 
     expect(newState.accountHolderConfirmation).toEqual(accountHolderConfirmation);
   });
+
+  it('should handle DIRECT_DEBIT_SET_FORM_ERROR', () => {
+
+    const message = 'this is an error';
+    const action = {
+      type: 'DIRECT_DEBIT_SET_FORM_ERROR',
+      message,
+    };
+
+    const newState = reducer(undefined, action);
+
+    expect(newState.formError).toEqual(message);
+  });
+
+  it('should handle DIRECT_DEBIT_RESET_FORM_ERROR', () => {
+
+    const action = {
+      type: 'DIRECT_DEBIT_RESET_FORM_ERROR',
+    };
+
+    const newState = reducer(undefined, action);
+
+    expect(newState.formError).toEqual('');
+  });
 });
 

--- a/assets/components/directDebit/directDebitActions.js
+++ b/assets/components/directDebit/directDebitActions.js
@@ -66,7 +66,7 @@ function payDirectDebitClicked(callback: Function): Function {
       return;
     }
 
-    checkAccount(bankSortCode, bankAccountNumber, accountHolderName, isTestUser, csrf)
+    checkAccount(bankSortCode, bankAccountNumber, isTestUser, csrf)
       .then((response) => {
         if (!response.accountValid) {
           throw new Error('code1');

--- a/assets/components/directDebit/directDebitActions.js
+++ b/assets/components/directDebit/directDebitActions.js
@@ -1,6 +1,8 @@
 // @flow
 
 import * as storage from 'helpers/storage';
+import { checkAccount } from './helpers/ajax';
+import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 
 // ----- Types ----- //
 
@@ -10,7 +12,9 @@ export type Action =
   | { type: 'DIRECT_DEBIT_UPDATE_SORT_CODE', sortCode: string }
   | { type: 'DIRECT_DEBIT_UPDATE_ACCOUNT_NUMBER', accountNumber: string }
   | { type: 'DIRECT_DEBIT_UPDATE_ACCOUNT_HOLDER_NAME', accountHolderName: string }
-  | { type: 'DIRECT_DEBIT_UPDATE_ACCOUNT_HOLDER_CONFIRMATION', accountHolderConfirmation: boolean };
+  | { type: 'DIRECT_DEBIT_UPDATE_ACCOUNT_HOLDER_CONFIRMATION', accountHolderConfirmation: boolean }
+  | { type: 'DIRECT_DEBIT_SET_FORM_ERROR', message: string }
+  | { type: 'DIRECT_DEBIT_RESET_FORM_ERROR' };
 
 
 // ----- Actions ----- //
@@ -33,6 +37,13 @@ const updateAccountHolderName = (accountHolderName: string): Action =>
 const updateAccountHolderConfirmation = (accountHolderConfirmation: boolean): Action =>
   ({ type: 'DIRECT_DEBIT_UPDATE_ACCOUNT_HOLDER_CONFIRMATION', accountHolderConfirmation });
 
+const setDirectDebitFormError = (message: string): Action =>
+  ({ type: 'DIRECT_DEBIT_SET_FORM_ERROR', message });
+
+const resetDirectDebitFormError = (): Action =>
+  ({ type: 'DIRECT_DEBIT_RESET_FORM_ERROR' });
+
+
 // ----- Exports ----//
 
 export {
@@ -42,4 +53,6 @@ export {
   updateAccountNumber,
   updateAccountHolderName,
   updateAccountHolderConfirmation,
+  setDirectDebitFormError,
+  resetDirectDebitFormError,
 };

--- a/assets/components/directDebit/directDebitActions.js
+++ b/assets/components/directDebit/directDebitActions.js
@@ -44,6 +44,46 @@ const resetDirectDebitFormError = (): Action =>
   ({ type: 'DIRECT_DEBIT_RESET_FORM_ERROR' });
 
 
+const payDirectDebitClicked: (callback) => Function = () => {
+
+  return function (dispatch, getState) {
+    const {
+      bankSortCode,
+      bankAccountNumber,
+      accountHolderName,
+      accountHolderConfirmation,
+    } = getState().page.directDebit;
+
+    const isTestUser: boolean = getState().page.user.isTestUser || false;
+    const { csrf }: CsrfState = getState().page;
+
+    dispatch(resetDirectDebitFormError());
+
+    if (!accountHolderConfirmation) {
+      dispatch(setDirectDebitFormError('You need to confirm that you are the account holder.'));
+      return;
+    }
+
+    return checkAccount(bankSortCode, bankAccountNumber, accountHolderName, isTestUser, csrf)
+      .then((response) => {
+        if (!response.accountValid) {
+          throw new Error('code1');
+        }
+      }).then(() => {
+        callback();
+      }).catch((e) => {
+        let msg = '';
+        switch(e.message) {
+          case 'code1': msg = 'Your bank data is not ok, please check it and try again.';
+          default:  msg = 'Your bank data is not ok, please check it and try again.';
+
+        }
+        dispatch(setDirectDebitFormError(msg));
+      });
+
+  };
+};
+
 // ----- Exports ----//
 
 export {
@@ -55,4 +95,5 @@ export {
   updateAccountHolderConfirmation,
   setDirectDebitFormError,
   resetDirectDebitFormError,
+  payDirectDebitClicked,
 };

--- a/assets/components/directDebit/directDebitActions.js
+++ b/assets/components/directDebit/directDebitActions.js
@@ -76,10 +76,10 @@ function payDirectDebitClicked(callback: Function): Function {
       }).catch((e) => {
         let msg = '';
         switch (e.message) {
-          case 'code1': msg = 'Your bank data is not ok, please check it and try again.';
+          case 'code1': msg = 'Your payment details are invalid. Please check them and try again';
             break;
 
-          default: msg = 'Your bank data is not ok, please check it and try again.';
+          default: msg = 'Your payment details are invalid. Please check them and try again.';
 
         }
         dispatch(setDirectDebitFormError(msg));

--- a/assets/components/directDebit/directDebitActions.js
+++ b/assets/components/directDebit/directDebitActions.js
@@ -1,8 +1,9 @@
 // @flow
 
 import * as storage from 'helpers/storage';
+
 import { checkAccount } from './helpers/ajax';
-import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
+
 
 // ----- Types ----- //
 
@@ -44,9 +45,10 @@ const resetDirectDebitFormError = (): Action =>
   ({ type: 'DIRECT_DEBIT_RESET_FORM_ERROR' });
 
 
-const payDirectDebitClicked: (callback) => Function = () => {
+function payDirectDebitClicked(callback: Function): Function {
 
-  return function (dispatch, getState) {
+  return (dispatch: Function, getState: Function) => {
+
     const {
       bankSortCode,
       bankAccountNumber,
@@ -55,7 +57,7 @@ const payDirectDebitClicked: (callback) => Function = () => {
     } = getState().page.directDebit;
 
     const isTestUser: boolean = getState().page.user.isTestUser || false;
-    const { csrf }: CsrfState = getState().page;
+    const { csrf } = getState().page;
 
     dispatch(resetDirectDebitFormError());
 
@@ -64,25 +66,26 @@ const payDirectDebitClicked: (callback) => Function = () => {
       return;
     }
 
-    return checkAccount(bankSortCode, bankAccountNumber, accountHolderName, isTestUser, csrf)
+    checkAccount(bankSortCode, bankAccountNumber, accountHolderName, isTestUser, csrf)
       .then((response) => {
         if (!response.accountValid) {
           throw new Error('code1');
         }
       }).then(() => {
-        callback();
+        callback(undefined, bankAccountNumber, bankSortCode, accountHolderName);
       }).catch((e) => {
         let msg = '';
-        switch(e.message) {
+        switch (e.message) {
           case 'code1': msg = 'Your bank data is not ok, please check it and try again.';
-          default:  msg = 'Your bank data is not ok, please check it and try again.';
+            break;
+
+          default: msg = 'Your bank data is not ok, please check it and try again.';
 
         }
         dispatch(setDirectDebitFormError(msg));
       });
-
   };
-};
+}
 
 // ----- Exports ----//
 

--- a/assets/components/directDebit/directDebitForm/directDebitForm.jsx
+++ b/assets/components/directDebit/directDebitForm/directDebitForm.jsx
@@ -12,17 +12,12 @@ import {
   payDirectDebitClicked,
 } from 'components/directDebit/directDebitActions';
 
-import type { Currency } from 'helpers/internationalisation/currency';
-
 
 // ---- Types ----- //
 
 /* eslint-disable react/no-unused-prop-types */
 type PropTypes = {
-  amount: number,
   callback: Function,
-  currency: Currency,
-  isTestUser: boolean,
   sortCode: string,
   accountNumber: string,
   accountHolderName: string,
@@ -106,7 +101,7 @@ const DirectDebitForm = (props: PropTypes) => (
     <button
       id="qa-pay-with-direct-debit-close-pop-up"
       className="component-direct-debit-pop-up-form"
-      onClick={props.payDirectDebitClicked}
+      onClick={() => props.payDirectDebitClicked(props.callback)}
     >
       Pay
     </button>

--- a/assets/components/directDebit/directDebitForm/directDebitForm.jsx
+++ b/assets/components/directDebit/directDebitForm/directDebitForm.jsx
@@ -53,16 +53,20 @@ function mapDispatchToProps(dispatch) {
     payDirectDebitClicked: (callback) => {
       dispatch(payDirectDebitClicked(callback));
     },
-    updateSortCode: (sortCode: string) => {
+    updateSortCode: (event: SyntheticInputEvent<HTMLInputElement>) => {
+      const sortCode: string = event.target.value;
       dispatch(updateSortCode(sortCode));
     },
-    updateAccountNumber: (accountNumber: string) => {
+    updateAccountNumber: (event: SyntheticInputEvent<HTMLInputElement>) => {
+      const accountNumber: string = event.target.value;
       dispatch(updateAccountNumber(accountNumber));
     },
-    updateAccountHolderName: (accountHolderName: string) => {
+    updateAccountHolderName: (event: SyntheticInputEvent<HTMLInputElement>) => {
+      const accountHolderName: string = event.target.value;
       dispatch(updateAccountHolderName(accountHolderName));
     },
-    updateAccountHolderConfirmation: (accountHolderConfirmation: boolean) => {
+    updateAccountHolderConfirmation: (event: SyntheticInputEvent<HTMLInputElement>) => {
+      const accountHolderConfirmation: boolean = event.target.checked;
       dispatch(updateAccountHolderConfirmation(accountHolderConfirmation));
     },
   };
@@ -78,8 +82,8 @@ const DirectDebitForm = (props: PropTypes) => (
 
 
     <SortCodeInput
-      value={props.sortCode}
       onChange={props.updateSortCode}
+      value={props.sortCode}
     />
 
     <AccountNumberInput
@@ -93,8 +97,8 @@ const DirectDebitForm = (props: PropTypes) => (
     />
 
     <ConfirmationInput
-      checked={props.accountHolderConfirmation}
       onChange={props.updateAccountHolderConfirmation}
+      checked={props.accountHolderConfirmation}
     />
 
     <div className="component-direct-debit-form__advance-notice__title">

--- a/assets/components/directDebit/directDebitForm/directDebitForm.jsx
+++ b/assets/components/directDebit/directDebitForm/directDebitForm.jsx
@@ -32,6 +32,7 @@ type PropTypes = {
   updateAccountHolderName: (accountHolderName: string) => void,
   updateAccountHolderConfirmation: (accountHolderConfirmation: boolean) => void,
   payDirectDebitClicked: (callback: Function) => void,
+  formError: string,
 };
 /* eslint-enable react/no-unused-prop-types */
 
@@ -44,6 +45,7 @@ function mapStateToProps(state) {
     accountNumber: state.page.directDebit.bankAccountNumber,
     accountHolderName: state.page.directDebit.accountHolderName,
     accountHolderConfirmation: state.page.directDebit.accountHolderConfirmation,
+    formError: state.page.directDebit.formError,
   };
 }
 
@@ -80,7 +82,6 @@ const DirectDebitForm = (props: PropTypes) => (
 
     <img className="component-direct-debit-form__direct-debit-logo" src="#" alt="The Direct Debit logo" />
 
-
     <SortCodeInput
       onChange={props.updateSortCode}
       value={props.sortCode}
@@ -101,10 +102,7 @@ const DirectDebitForm = (props: PropTypes) => (
       checked={props.accountHolderConfirmation}
     />
 
-    <div className="component-direct-debit-form__advance-notice__title">
-        Advance notice
-    </div>
-
+    <p>{props.formError}</p>
     <button
       id="qa-pay-with-direct-debit-close-pop-up"
       className="component-direct-debit-pop-up-form"
@@ -112,6 +110,11 @@ const DirectDebitForm = (props: PropTypes) => (
     >
       Pay
     </button>
+
+    <div className="component-direct-debit-form__advance-notice__title">
+        Advance notice
+    </div>
+
     <div className="component-direct-debit-form__advance-notice__content">
       <p>The details of your Direct Debit instruction including payment schedule, due date,
         frequency and amount will be sent to you within three working days. All the normal

--- a/assets/components/directDebit/directDebitForm/directDebitForm.jsx
+++ b/assets/components/directDebit/directDebitForm/directDebitForm.jsx
@@ -4,8 +4,15 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
+import {
+  updateSortCode,
+  updateAccountNumber,
+  updateAccountHolderName,
+  updateAccountHolderConfirmation,
+  payDirectDebitClicked,
+} from 'components/directDebit/directDebitActions';
+
 import type { Currency } from 'helpers/internationalisation/currency';
-import { updateSortCode, updateAccountNumber, updateAccountHolderName, updateAccountHolderConfirmation } from 'components/directDebit/directDebitActions';
 
 
 // ---- Types ----- //
@@ -24,6 +31,7 @@ type PropTypes = {
   updateAccountNumber: (accountNumber: string) => void,
   updateAccountHolderName: (accountHolderName: string) => void,
   updateAccountHolderConfirmation: (accountHolderConfirmation: boolean) => void,
+  payDirectDebitClicked: (callback: Function) => void,
 };
 /* eslint-enable react/no-unused-prop-types */
 
@@ -42,6 +50,9 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
 
   return {
+    payDirectDebitClicked: (callback) => {
+      dispatch(payDirectDebitClicked(callback));
+    },
     updateSortCode: (sortCode: string) => {
       dispatch(updateSortCode(sortCode));
     },
@@ -89,6 +100,14 @@ const DirectDebitForm = (props: PropTypes) => (
     <div className="component-direct-debit-form__advance-notice__title">
         Advance notice
     </div>
+
+    <button
+      id="qa-pay-with-direct-debit-close-pop-up"
+      className="component-direct-debit-pop-up-form"
+      onClick={props.payDirectDebitClicked}
+    >
+      Pay
+    </button>
     <div className="component-direct-debit-form__advance-notice__content">
       <p>The details of your Direct Debit instruction including payment schedule, due date,
         frequency and amount will be sent to you within three working days. All the normal

--- a/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.jsx
+++ b/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.jsx
@@ -4,7 +4,6 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
-import type { Currency } from 'helpers/internationalisation/currency';
 import { closeDirectDebitPopUp } from 'components/directDebit/directDebitActions';
 import DirectDebitForm from 'components/directDebit/directDebitForm/directDebitForm';
 
@@ -13,11 +12,7 @@ import DirectDebitForm from 'components/directDebit/directDebitForm/directDebitF
 
 /* eslint-disable react/no-unused-prop-types */
 type PropTypes = {
-  amount: number,
   callback: Function,
-  currency: Currency,
-  email: string,
-  isTestUser: boolean,
   isPopUpOpen: boolean,
   closeDirectDebitPopUp: () => void,
 };
@@ -58,18 +53,12 @@ const DirectDebitPopUpForm = (props: PropTypes) => {
           Close form
         </button>
 
-        <DirectDebitForm />
+        <DirectDebitForm callback={props.callback} />
       </div>
     );
   }
 
   return content;
-
-};
-
-// ----- Default Props ----- //
-
-DirectDebitPopUpForm.defaultProps = {
 
 };
 

--- a/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.jsx
+++ b/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.jsx
@@ -51,7 +51,7 @@ const DirectDebitPopUpForm = (props: PropTypes) => {
     content = (
       <div>
         <button
-          id="qa-pay-with-direct-debit"
+          id="qa-pay-with-direct-debit-close-pop-up"
           className="component-direct-debit-pop-up-form"
           onClick={props.closeDirectDebitPopUp}
         >

--- a/assets/components/directDebit/directDebitReducer.js
+++ b/assets/components/directDebit/directDebitReducer.js
@@ -70,12 +70,12 @@ const directDebitReducer = (
         accountHolderConfirmation: action.accountHolderConfirmation,
       });
 
-    case: 'DIRECT_DEBIT_SET_FORM_ERROR':
+    case 'DIRECT_DEBIT_SET_FORM_ERROR':
       return Object.assign({}, state, {
         formError: action.message,
       });
 
-    case: 'DIRECT_DEBIT_RESET_FORM_ERROR': {
+    case 'DIRECT_DEBIT_RESET_FORM_ERROR': {
       return Object.assign({}, state, {
         formError: '',
       });

--- a/assets/components/directDebit/directDebitReducer.js
+++ b/assets/components/directDebit/directDebitReducer.js
@@ -12,6 +12,7 @@ export type DirectDebitState = {
   bankAccountNumber: string,
   accountHolderName: string,
   accountHolderConfirmation: boolean,
+  formError: string
 };
 
 
@@ -21,6 +22,7 @@ const initialState: DirectDebitState = {
   bankAccountNumber: '',
   accountHolderName: '',
   accountHolderConfirmation: false,
+  formError: '',
 };
 
 
@@ -67,6 +69,17 @@ const directDebitReducer = (
       return Object.assign({}, state, {
         accountHolderConfirmation: action.accountHolderConfirmation,
       });
+
+    case: 'DIRECT_DEBIT_SET_FORM_ERROR':
+      return Object.assign({}, state, {
+        formError: action.message,
+      });
+
+    case: 'DIRECT_DEBIT_RESET_FORM_ERROR': {
+      return Object.assign({}, state, {
+        formError: '',
+      });
+    }
 
     default:
       return state;

--- a/assets/components/directDebit/helpers/ajax.js
+++ b/assets/components/directDebit/helpers/ajax.js
@@ -5,7 +5,13 @@
 import { routes } from 'helpers/routes';
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 
-const checkAccount = (sortCode: string, accountNumber: string, accountHolderName: string, isTestUser: boolean, csrf: CsrfState) => {
+const checkAccount = (
+  sortCode: string,
+  accountNumber: string,
+  accountHolderName: string,
+  isTestUser: boolean,
+  csrf: CsrfState,
+) => {
 
   const bankAccountInformation = {
     sortCodeValue: sortCode,
@@ -25,4 +31,4 @@ const checkAccount = (sortCode: string, accountNumber: string, accountHolderName
 
 export {
   checkAccount,
-}
+};

--- a/assets/components/directDebit/helpers/ajax.js
+++ b/assets/components/directDebit/helpers/ajax.js
@@ -8,7 +8,6 @@ import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 const checkAccount = (
   sortCode: string,
   accountNumber: string,
-  accountHolderName: string,
   isTestUser: boolean,
   csrf: CsrfState,
 ) => {
@@ -16,7 +15,6 @@ const checkAccount = (
   const bankAccountInformation = {
     sortCode,
     accountNumber,
-    accountHolderName,
   };
 
   const requestData = {

--- a/assets/components/directDebit/helpers/ajax.js
+++ b/assets/components/directDebit/helpers/ajax.js
@@ -2,9 +2,26 @@
 
 // ----- Imports ----- //
 
-const checkAccount = () => {
+import { routes } from 'helpers/routes';
+import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 
-}
+const checkAccount = (sortCode: string, accountNumber: string, accountHolderName: string, isTestUser: boolean, csrf: CsrfState) => {
+
+  const bankAccountInformation = {
+    sortCodeValue: sortCode,
+    accountNumber,
+    accountHolderName,
+  };
+
+  const requestData = {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'Csrf-Token': csrf.token || '' },
+    credentials: 'same-origin',
+    body: JSON.stringify(bankAccountInformation),
+  };
+
+  return fetch(routes.directDebitCheckAccount, requestData);
+};
 
 export {
   checkAccount,

--- a/assets/components/directDebit/helpers/ajax.js
+++ b/assets/components/directDebit/helpers/ajax.js
@@ -14,7 +14,7 @@ const checkAccount = (
 ) => {
 
   const bankAccountInformation = {
-    sortCodeValue: sortCode,
+    sortCode,
     accountNumber,
     accountHolderName,
   };

--- a/assets/components/directDebit/helpers/ajax.js
+++ b/assets/components/directDebit/helpers/ajax.js
@@ -1,0 +1,11 @@
+// @flow
+
+// ----- Imports ----- //
+
+const checkAccount = () => {
+
+}
+
+export {
+  checkAccount,
+}

--- a/assets/components/paymentButtons/directDebitPopUpButton/directDebitPopUpButton.jsx
+++ b/assets/components/paymentButtons/directDebitPopUpButton/directDebitPopUpButton.jsx
@@ -4,19 +4,17 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
-import type { Currency } from 'helpers/internationalisation/currency';
 import { openDirectDebitPopUp } from 'components/directDebit/directDebitActions';
 import DirectDebitPopUpForm from 'components/directDebit/directDebitPopUpForm/directDebitPopUpForm';
+
 
 // ---- Types ----- //
 
 /* eslint-disable react/no-unused-prop-types */
 type PropTypes = {
-  amount: number,
   callback: Function,
-  currency: Currency,
-  email: string,
   isTestUser: boolean,
+  isPostDeploymentTestUser: boolean,
   isPopUpOpen: boolean,
   openDirectDebitPopUp: () => void,
 };
@@ -47,7 +45,10 @@ const DirectDebitPopUpButton = (props: PropTypes) => {
   let content = null;
 
   if (props.isPopUpOpen) {
-    content = <DirectDebitPopUpForm />;
+    content = <DirectDebitPopUpForm
+                amount={props.amount}
+                currency={props.currency}
+              />;
   } else {
     content = (
       <button

--- a/assets/components/paymentButtons/directDebitPopUpButton/directDebitPopUpButton.jsx
+++ b/assets/components/paymentButtons/directDebitPopUpButton/directDebitPopUpButton.jsx
@@ -13,8 +13,6 @@ import DirectDebitPopUpForm from 'components/directDebit/directDebitPopUpForm/di
 /* eslint-disable react/no-unused-prop-types */
 type PropTypes = {
   callback: Function,
-  isTestUser: boolean,
-  isPostDeploymentTestUser: boolean,
   isPopUpOpen: boolean,
   openDirectDebitPopUp: () => void,
 };
@@ -45,10 +43,7 @@ const DirectDebitPopUpButton = (props: PropTypes) => {
   let content = null;
 
   if (props.isPopUpOpen) {
-    content = <DirectDebitPopUpForm
-                amount={props.amount}
-                currency={props.currency}
-              />;
+    content = <DirectDebitPopUpForm callback={props.callback} />;
   } else {
     content = (
       <button
@@ -62,12 +57,6 @@ const DirectDebitPopUpButton = (props: PropTypes) => {
   }
 
   return content;
-
-};
-
-// ----- Default Props ----- //
-
-DirectDebitPopUpButton.defaultProps = {
 
 };
 

--- a/assets/helpers/routes.js
+++ b/assets/helpers/routes.js
@@ -16,7 +16,7 @@ const routes: {
   contributionsMarketingConfirm: '/contribute/marketing-confirm',
   payPalSetupPayment: '/paypal/setup-payment',
   payPalCreateAgreement: '/paypal/create-agreement',
-  directDebitCheckAccount: '/directDebit/check-account',
+  directDebitCheckAccount: '/direct-debit/check-account',
 };
 
 

--- a/assets/helpers/routes.js
+++ b/assets/helpers/routes.js
@@ -16,7 +16,7 @@ const routes: {
   contributionsMarketingConfirm: '/contribute/marketing-confirm',
   payPalSetupPayment: '/paypal/setup-payment',
   payPalCreateAgreement: '/paypal/create-agreement',
-  directDebitCheckAccount: '/directDebit/checkAccount',
+  directDebitCheckAccount: '/directDebit/check-account',
 };
 
 

--- a/assets/helpers/routes.js
+++ b/assets/helpers/routes.js
@@ -16,6 +16,7 @@ const routes: {
   contributionsMarketingConfirm: '/contribute/marketing-confirm',
   payPalSetupPayment: '/paypal/setup-payment',
   payPalCreateAgreement: '/paypal/create-agreement',
+  directDebitCheckAccount: '/directDebit/checkAccount',
 };
 
 

--- a/assets/pages/regular-contributions/__tests__/__snapshots__/regularContributionsReducersTest.js.snap
+++ b/assets/pages/regular-contributions/__tests__/__snapshots__/regularContributionsReducersTest.js.snap
@@ -16,6 +16,7 @@ Object {
     "accountHolderName": "",
     "bankAccountNumber": "",
     "bankSortCode": "",
+    "formError": "",
     "isPopUpOpen": false,
   },
   "regularContrib": Object {

--- a/assets/pages/regular-contributions/components/regularContributionsPayment.jsx
+++ b/assets/pages/regular-contributions/components/regularContributionsPayment.jsx
@@ -79,21 +79,21 @@ function RegularContributionsPayment(props: PropTypes, context) {
   const isDirectDebitEnable = window.guardian && window.guardian.directDebitEnable;
 
   if (props.country === 'GB' && isDirectDebitEnable) {
-    directDebitButton = (<DirectDebitPopUpButton
-      callback={postCheckout(
-        props.abParticipations,
-        props.amount,
-        props.csrf,
-        props.currency,
-        props.contributionType,
-        props.country,
-        props.dispatch,
-        'directDebitData',
-        props.referrerAcquisitionData,
-        context.store.getState,
+    directDebitButton = (
+      <DirectDebitPopUpButton
+        callback={postCheckout(
+          props.abParticipations,
+          props.amount,
+          props.csrf,
+          props.currency,
+          props.contributionType,
+          props.country,
+          props.dispatch,
+          'directDebitData',
+          props.referrerAcquisitionData,
+          context.store.getState,
       )}
-      isTestUser={props.isTestUser}
-      isPostDeploymentTestUser={props.isPostDeploymentTestUser} />);
+      />);
   }
 
   let stripeButton = (<StripePopUpButton

--- a/assets/pages/regular-contributions/components/regularContributionsPayment.jsx
+++ b/assets/pages/regular-contributions/components/regularContributionsPayment.jsx
@@ -79,7 +79,21 @@ function RegularContributionsPayment(props: PropTypes, context) {
   const isDirectDebitEnable = window.guardian && window.guardian.directDebitEnable;
 
   if (props.country === 'GB' && isDirectDebitEnable) {
-    directDebitButton = <DirectDebitPopUpButton />;
+    directDebitButton = (<DirectDebitPopUpButton
+      callback={postCheckout(
+        props.abParticipations,
+        props.amount,
+        props.csrf,
+        props.currency,
+        props.contributionType,
+        props.country,
+        props.dispatch,
+        'directDebitData',
+        props.referrerAcquisitionData,
+        context.store.getState,
+      )}
+      isTestUser={props.isTestUser}
+      isPostDeploymentTestUser={props.isPostDeploymentTestUser} />);
   }
 
   let stripeButton = (<StripePopUpButton

--- a/assets/pages/regular-contributions/helpers/ajax.js
+++ b/assets/pages/regular-contributions/helpers/ajax.js
@@ -195,7 +195,12 @@ export default function postCheckout(
   referrerAcquisitionData: ReferrerAcquisitionData,
   getState: Function,
 ): Function {
-  return (token: string) => {
+  return (
+    token?: string,
+    bankAccountNumber?: string,
+    bankSortCodeValue?: string,
+    bankAccountHolderName?: string,
+  ) => {
 
     pollCount = 0;
     dispatch(creatingContributor());

--- a/assets/pages/regular-contributions/helpers/ajax.js
+++ b/assets/pages/regular-contributions/helpers/ajax.js
@@ -46,7 +46,7 @@ type RegularContribFields = {|
   supportAbTests: AcquisitionABTest[],
 |};
 
-type PaymentField = 'baid' | 'stripeToken';
+type PaymentField = 'baid' | 'stripeToken' | 'directDebitData';
 
 
 // ----- Functions ----- //
@@ -199,11 +199,14 @@ export default function postCheckout(
     token?: string,
     bankAccountNumber?: string,
     bankSortCodeValue?: string,
-    bankAccountHolderName?: string,
+    bankAccountHolderName?: string, // eslint-disable-line no-unused-vars
   ) => {
 
     pollCount = 0;
     dispatch(creatingContributor());
+
+    // When implementing the phase 3 of direct debit the line below needs to be removed.
+    const myToken = token || '';
 
     const request = requestData(
       abParticipations,
@@ -213,7 +216,7 @@ export default function postCheckout(
       currency.iso,
       csrf,
       paymentFieldName,
-      token,
+      myToken,
       referrerAcquisitionData,
       getState,
     );

--- a/build.sbt
+++ b/build.sbt
@@ -81,6 +81,7 @@ libraryDependencies ++= Seq(
   "io.github.bonigarcia" % "webdrivermanager" % "1.7.2" % "test",
   "org.seleniumhq.selenium" % "selenium-java" % "3.6.0" % "test",
   "com.squareup.okhttp3" % "okhttp" % "3.9.0",
+  "com.gocardless" % "gocardless-pro" % "2.7.0",
   filters,
   ws
 )

--- a/build.sbt
+++ b/build.sbt
@@ -81,7 +81,7 @@ libraryDependencies ++= Seq(
   "io.github.bonigarcia" % "webdrivermanager" % "1.7.2" % "test",
   "org.seleniumhq.selenium" % "selenium-java" % "3.6.0" % "test",
   "com.squareup.okhttp3" % "okhttp" % "3.9.0",
-  "com.gocardless" % "gocardless-pro" % "2.7.0",
+  "com.gocardless" % "gocardless-pro" % "2.8.0",
   filters,
   ws
 )

--- a/conf/routes
+++ b/conf/routes
@@ -63,7 +63,7 @@ GET  /paypal/cancel                                 controllers.PayPal.cancelUrl
 
 # ----- Direct Debit ----- #
 
-POST /directDebit/check-account                      controllers.DirectDebit.checkAccount
+POST /direct-debit/check-account                      controllers.DirectDebit.checkAccount
 
 # ----- Assets ----- #
 

--- a/conf/routes
+++ b/conf/routes
@@ -61,6 +61,9 @@ POST /paypal/create-agreement                       controllers.PayPal.createAgr
 GET  /paypal/return                                 controllers.PayPal.returnUrl
 GET  /paypal/cancel                                 controllers.PayPal.cancelUrl
 
+# ----- Direct Debit ----- #
+
+
 
 # ----- Assets ----- #
 

--- a/conf/routes
+++ b/conf/routes
@@ -63,7 +63,7 @@ GET  /paypal/cancel                                 controllers.PayPal.cancelUrl
 
 # ----- Direct Debit ----- #
 
-
+POST /directDebit/checkAccount                      controllers.DirectDebit.checkAccount
 
 # ----- Assets ----- #
 

--- a/conf/routes
+++ b/conf/routes
@@ -63,7 +63,7 @@ GET  /paypal/cancel                                 controllers.PayPal.cancelUrl
 
 # ----- Direct Debit ----- #
 
-POST /directDebit/checkAccount                      controllers.DirectDebit.checkAccount
+POST /directDebit/check-account                      controllers.DirectDebit.checkAccount
 
 # ----- Assets ----- #
 

--- a/test/codecs/CirceDecodersTest.scala
+++ b/test/codecs/CirceDecodersTest.scala
@@ -6,6 +6,7 @@ import io.circe.Json
 import io.circe.parser.parse
 import cats.syntax.either._
 import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
+import models.DirectDebitData
 import ophan.thrift.componentEvent.ComponentType.{AcquisitionsEpic, EnumUnknownComponentType}
 import ophan.thrift.event.AbTest
 import ophan.thrift.event.AcquisitionSource.GuardianWeb
@@ -101,6 +102,26 @@ class CirceDecodersTest extends WordSpec with MustMatchers {
     }
   }
 
+  "DirectDebitDataDecoder" should {
+    "decode json" in {
+      val json =
+        """
+        |{
+        |   "sortCode": "121212",
+        |   "accountNumber": "12121212",
+        |   "accountHolderName": "Example Name"
+        |}
+      """.stripMargin
+
+      val parsedJson = parse(json).toOption.get
+
+      val directDebitData: DirectDebitData = DirectDebitData.codec.decodeJson(parsedJson).right.get
+
+      directDebitData.sortCode.value mustBe "121212"
+      directDebitData.accountNumber.value mustBe "12121212"
+      directDebitData.accountHolderName mustBe "Example Name"
+    }
+  }
 
 }
 

--- a/test/codecs/CirceDecodersTest.scala
+++ b/test/codecs/CirceDecodersTest.scala
@@ -6,7 +6,7 @@ import io.circe.Json
 import io.circe.parser.parse
 import cats.syntax.either._
 import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
-import models.{CheckBankAccountData, DirectDebitData}
+import models.{CheckBankAccountDetails, DirectDebitDetails}
 import ophan.thrift.componentEvent.ComponentType.{AcquisitionsEpic, EnumUnknownComponentType}
 import ophan.thrift.event.AbTest
 import ophan.thrift.event.AcquisitionSource.GuardianWeb
@@ -115,7 +115,7 @@ class CirceDecodersTest extends WordSpec with MustMatchers {
 
       val parsedJson = parse(json).toOption.get
 
-      val directDebitData: DirectDebitData = DirectDebitData.codec.decodeJson(parsedJson).right.get
+      val directDebitData: DirectDebitDetails = DirectDebitDetails.codec.decodeJson(parsedJson).right.get
 
       directDebitData.sortCode.value mustBe "121212"
       directDebitData.accountNumber.value mustBe "12121212"
@@ -135,7 +135,7 @@ class CirceDecodersTest extends WordSpec with MustMatchers {
 
       val parsedJson = parse(json).toOption.get
 
-      val checkBankAccountData: CheckBankAccountData = CheckBankAccountData.codec.decodeJson(parsedJson).right.get
+      val checkBankAccountData: CheckBankAccountDetails = CheckBankAccountDetails.codec.decodeJson(parsedJson).right.get
 
       checkBankAccountData.sortCode.value mustBe "121212"
       checkBankAccountData.accountNumber.value mustBe "12121212"

--- a/test/codecs/CirceDecodersTest.scala
+++ b/test/codecs/CirceDecodersTest.scala
@@ -100,5 +100,7 @@ class CirceDecodersTest extends WordSpec with MustMatchers {
       abtest.variant mustBe "variant_34"
     }
   }
+
+
 }
 

--- a/test/codecs/CirceDecodersTest.scala
+++ b/test/codecs/CirceDecodersTest.scala
@@ -6,7 +6,7 @@ import io.circe.Json
 import io.circe.parser.parse
 import cats.syntax.either._
 import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
-import models.DirectDebitData
+import models.{CheckBankAccountData, DirectDebitData}
 import ophan.thrift.componentEvent.ComponentType.{AcquisitionsEpic, EnumUnknownComponentType}
 import ophan.thrift.event.AbTest
 import ophan.thrift.event.AcquisitionSource.GuardianWeb
@@ -120,6 +120,25 @@ class CirceDecodersTest extends WordSpec with MustMatchers {
       directDebitData.sortCode.value mustBe "121212"
       directDebitData.accountNumber.value mustBe "12121212"
       directDebitData.accountHolderName mustBe "Example Name"
+    }
+  }
+
+  "CheckBankAccountDecoder" should {
+    "decode json" in {
+      val json =
+        """
+          |{
+          |   "sortCode": "121212",
+          |   "accountNumber": "12121212",
+          |}
+        """.stripMargin
+
+      val parsedJson = parse(json).toOption.get
+
+      val checkBankAccountData: CheckBankAccountData = CheckBankAccountData.codec.decodeJson(parsedJson).right.get
+
+      checkBankAccountData.sortCode.value mustBe "121212"
+      checkBankAccountData.accountNumber.value mustBe "12121212"
     }
   }
 

--- a/test/codecs/CirceDecodersTest.scala
+++ b/test/codecs/CirceDecodersTest.scala
@@ -129,7 +129,7 @@ class CirceDecodersTest extends WordSpec with MustMatchers {
         """
           |{
           |   "sortCode": "121212",
-          |   "accountNumber": "12121212",
+          |   "accountNumber": "12121212"
           |}
         """.stripMargin
 

--- a/test/controllers/RegularContributionsTest.scala
+++ b/test/controllers/RegularContributionsTest.scala
@@ -155,7 +155,7 @@ class RegularContributionsTest extends WordSpec with MustMatchers with TestCSRFC
           stripeConfigProvider,
           payPalConfigProvider,
           stubControllerComponents()
-        ).displayForm(paypal = None,directDebit = None)(FakeRequest())
+        ).displayForm(paypal = None, directDebit = None)(FakeRequest())
       }
     }
   }


### PR DESCRIPTION
## Why are you doing this?

This PR adds the Direct Debit (phase 2) functionality to support frontend.

The different phases are:

1.- Added DirectDebit components to support-frontend (https://github.com/guardian/support-frontend/pull/448)
2.- Connect support-frontend with gocardless (https://github.com/guardian/support-frontend/pull/456)
3.- Integrate direct debit with step-functions/Zuora
4.- Implement a GoCardLess provider.
5.- Apply styles to support frontend.
6.- Build an A/B Test
[**Trello Card**](https://trello.com)

## Changes

* Creation and wiring of the DirectDebitController
* First approach of the GoCardLess Service (this will change in the 4th phase)
* Added formError to the state of the directDebit Component
* Added more action and reducers tests

## Screenshots

### Invalid acccount:
<img width="640" alt="picture 518" src="https://user-images.githubusercontent.com/825398/35226618-c28b77d2-ff83-11e7-9743-926db1662ed8.png">

### Using Go Card Less test account

<img width="721" alt="picture 519" src="https://user-images.githubusercontent.com/825398/35226660-ec44bee4-ff83-11e7-8158-f5c1be01a250.png">

