### PR TITLE
Rebuild The Circles Page - Part I

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -45,12 +45,20 @@ class Application(
     Redirect(location + path, request.queryString)
   }
 
-  def bundleLanding(title: String, id: String, js: String, newDesigns: Boolean): Action[AnyContent] = CachedAction() { implicit request =>
-    if (newDesigns) {
+  def bundleLanding(title: String, id: String, js: String, newDesigns: String): Action[AnyContent] = CachedAction() { implicit request =>
+    if (newDesigns == "circles") {
       Ok(views.html.bundleLanding(
         title,
         "support-landing-page-old",
         "supportLandingPageOld.js",
+        contributionsPayPalEndpoint,
+        description = Some(stringsConfig.bundleLandingDescription)
+      ))
+    } else if (newDesigns == "circles-garnett") {
+      Ok(views.html.bundleLanding(
+        title,
+        "support-landing-page",
+        "supportLandingPage.js",
         contributionsPayPalEndpoint,
         description = Some(stringsConfig.bundleLandingDescription)
       ))

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -49,8 +49,8 @@ class Application(
     if (newDesigns) {
       Ok(views.html.bundleLanding(
         title,
-        "support-landing-page",
-        "supportLandingPage.js",
+        "support-landing-page-old",
+        "supportLandingPageOld.js",
         contributionsPayPalEndpoint,
         description = Some(stringsConfig.bundleLandingDescription)
       ))

--- a/assets/components/circlesIntroduction/circlesIntroduction.jsx
+++ b/assets/components/circlesIntroduction/circlesIntroduction.jsx
@@ -1,0 +1,31 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+
+// ----- Component ----- //
+
+export default function CirclesIntroduction() {
+  return (
+    <section className="component-circles-introduction">
+      <div className="component-circles-introduction__content gu-content-margin">
+        <h1 className="component-circles-introduction__heading">
+          <span className="component-circles-introduction__heading-line">Help us deliver</span>
+          <span className="component-circles-introduction__heading-line">the independent</span>
+          <span className="component-circles-introduction__heading-line">journalism the</span>
+          <span className="component-circles-introduction__heading-line">world needs</span>
+        </h1>
+        <h2 className="component-circles-introduction__heading">
+          <span className="component-circles-introduction__heading-line">
+            <span className="component-circles-introduction__highlight">Support</span>
+          </span>
+          <span className="component-circles-introduction__heading-line">
+            <span className="component-circles-introduction__highlight">The&nbsp;Guardian</span>
+          </span>
+        </h2>
+      </div>
+    </section>
+  );
+}

--- a/assets/components/circlesIntroduction/circlesIntroduction.scss
+++ b/assets/components/circlesIntroduction/circlesIntroduction.scss
@@ -1,0 +1,38 @@
+.component-circles-introduction {
+  background-color: gu-colour(nav-background-colour);
+  color: gu-colour(garnett-neutral-1);
+}
+
+.component-circles-introduction__heading {
+  font-family: $gu-egyptian-web;
+  font-weight: bold;
+  font-size: 28px;
+  line-height: 30px;
+  padding-bottom: $gu-v-spacing * 4;
+
+  @include mq($from: mobileMedium) {
+    font-size: 30px;
+    line-height: 32px;
+  }
+
+  @include mq($from: phablet) {
+    font-size: 46px;
+    line-height: 50px;
+  }
+
+  @include mq($from: desktop) {
+    font-size: 48px;
+    line-height: 52px;
+  }
+}
+
+.component-circles-introduction__heading-line {
+  display: block;
+}
+
+.component-circles-introduction__highlight {
+  display: inline-block;
+  vertical-align: top;
+  padding: 4px;
+  background-color: gu-colour(news-garnett-highlight);
+}

--- a/assets/components/ctaLink/ctaLink.jsx
+++ b/assets/components/ctaLink/ctaLink.jsx
@@ -69,7 +69,6 @@ export default function CtaLink(props: PropTypes) {
 // ----- Default Props ----- //
 
 CtaLink.defaultProps = {
-  modifierClass: null,
   url: null,
   trackComponentEvent: () => {},
   onClick: null,

--- a/assets/components/ctaLink/ctaLink.jsx
+++ b/assets/components/ctaLink/ctaLink.jsx
@@ -7,6 +7,7 @@ import { SvgArrowRightStraight } from 'components/svg/svg';
 import { clickSubstituteKeyPressHandler } from 'helpers/utilities';
 import uuidv4 from 'uuid';
 import { addQueryParamToURL } from 'helpers/url';
+import { generateClassName } from 'helpers/utilities';
 
 import type { Node } from 'react';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
@@ -32,13 +33,12 @@ type PropTypes = {
 export default function CtaLink(props: PropTypes) {
 
   const accessibilityHintId = props.id ? `accessibility-hint-${props.id}` : uuidv4();
-  const ctaUniqueClassName = `component-cta-link ${props.ctaId}`;
   const urlString = props.url || '';
 
   return (
     <a
       id={props.id}
-      className={ctaUniqueClassName}
+      className={generateClassName('component-cta-link', props.ctaId)}
       href={props.acquisitionData ?
         addQueryParamToURL(urlString, 'acquisitionData', JSON.stringify(props.acquisitionData))
          : props.url
@@ -69,6 +69,7 @@ export default function CtaLink(props: PropTypes) {
 // ----- Default Props ----- //
 
 CtaLink.defaultProps = {
+  modifierClass: null,
   url: null,
   trackComponentEvent: () => {},
   onClick: null,

--- a/assets/components/doubleHeading/doubleHeading.scss
+++ b/assets/components/doubleHeading/doubleHeading.scss
@@ -1,25 +1,10 @@
-.component-double-heading {
-	font-size: 28px;
-	line-height: 32px;
+.component-double-heading__heading {
+	font-weight: bold;
+	font-family: $gu-egyptian-web;
+	margin: 0;
+}
 
-	.component-double-heading__heading {
-		font-weight: 900;
-		font-family: $gu-egyptian-web;
-		color: gu-colour(neutral-1);
-		margin: 0;
-	}
-
-	.component-double-heading__subheading {
-		color: gu-colour(neutral-1);
-		margin: 0;
-		font-family: $gu-text-sans-web;
-		font-weight: normal;
-		font-size: 20px;
-		line-height: 24px;
-
-		@include mq($from: phablet) {
-			font-size: 24px;
-			line-height: 28px;
-		}
-	}
+.component-double-heading__subheading {
+	color: gu-colour(neutral-1);
+	margin: 0;
 }

--- a/assets/components/doubleHeading/doubleHeading.scss
+++ b/assets/components/doubleHeading/doubleHeading.scss
@@ -5,6 +5,5 @@
 }
 
 .component-double-heading__subheading {
-	color: gu-colour(neutral-1);
 	margin: 0;
 }

--- a/assets/components/featureList/featureList.jsx
+++ b/assets/components/featureList/featureList.jsx
@@ -24,22 +24,43 @@ type PropTypes = {
 
 // ----- Component ----- //
 
-export default function FeatureList(props: PropTypes) {
+function FeatureList(props: PropTypes) {
 
-  const items = props.listItems.map((item: ListItem) => {
-
-    const itemHeading = item.heading ? <h3>{ item.heading }</h3> : null;
-    const itemText = item.text ? <p>{ item.text }</p> : null;
-
-    return (
-      <li>
-        {itemHeading}
-        {itemText}
-      </li>
-    );
-
-  });
+  const items = props.listItems.map((item: ListItem) => (
+    <li className="component-feature-list__item">
+      <ItemHeading heading={item.heading ? item.heading : null} />
+      <ItemText text={item.text ? item.text : null} />
+    </li>
+  ));
 
   return <ul className="component-feature-list">{ items }</ul>;
 
 }
+
+
+// ----- Auxiliary Components ----- //
+
+function ItemHeading(props: { heading: ?string }) {
+
+  if (props.heading) {
+    return <h3 className="component-feature-list__heading">{props.heading}</h3>;
+  }
+
+  return null;
+
+}
+
+function ItemText(props: { text: ?string }) {
+
+  if (props.text) {
+    return <p className="component-feature-list__text">{props.text}</p>;
+  }
+
+  return null;
+
+}
+
+
+// ----- Exports ----- //
+
+export default FeatureList;

--- a/assets/components/featureList/featureList.jsx
+++ b/assets/components/featureList/featureList.jsx
@@ -4,6 +4,8 @@
 
 import React from 'react';
 
+import { generateClassName } from 'helpers/utilities';
+
 
 // ----- Types ----- //
 
@@ -18,6 +20,7 @@ export type ListItem =
 /* eslint-enable react/no-unused-prop-types */
 
 type PropTypes = {
+  modifierClass?: string,
   listItems: ListItem[],
 };
 
@@ -33,7 +36,11 @@ function FeatureList(props: PropTypes) {
     </li>
   ));
 
-  return <ul className="component-feature-list">{ items }</ul>;
+  return (
+    <ul className={generateClassName('component-feature-list', props.modifierClass)}>
+      { items }
+    </ul>
+  );
 
 }
 
@@ -59,6 +66,13 @@ function ItemText(props: { text: ?string }) {
   return null;
 
 }
+
+
+// ----- Default Props ----- //
+
+FeatureList.defaultProps = {
+  modifierClass: '',
+};
 
 
 // ----- Exports ----- //

--- a/assets/components/featureList/featureList.scss
+++ b/assets/components/featureList/featureList.scss
@@ -2,7 +2,6 @@
 	margin: 0;
 	padding: 0;
 	padding-left: 10px;
-  list-style-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 28 28"><path class="st0" d="M7.885 25.74L0 14.82l3.22-3.217L8.3 16.74 24.695 2.26 28 5.565"/></svg>');
 
 	h3, p {
 		margin: 0;

--- a/assets/components/featureList/featureList.scss
+++ b/assets/components/featureList/featureList.scss
@@ -2,7 +2,7 @@
 	margin: 0;
 	padding: 0;
 	padding-left: 10px;
-
+  list-style-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 28 28"><path class="st0" d="M7.885 25.74L0 14.82l3.22-3.217L8.3 16.74 24.695 2.26 28 5.565"/></svg>');
 
 	h3, p {
 		margin: 0;

--- a/assets/components/featureList/featureList.scss
+++ b/assets/components/featureList/featureList.scss
@@ -2,27 +2,19 @@
 	margin: 0;
 	padding: 0;
 	padding-left: 10px;
+}
 
-	h3, p {
-		margin: 0;
-	}
+.component-feature-list__heading {
+	font-weight: 900;
+	margin: 0;
+}
 
-	h3 {
-		font-family: $gu-text-sans-web;
-		font-weight: 900;
-		font-size: 16px;
-		line-height: 20px;
-	}
+.component-feature-list__text {
+	font-weight: 300;
+	margin: 0;
+}
 
-	p {
-		font-family: $gu-text-sans-web;
-		font-weight: 300;
-		font-size: 14px;
-		line-height: 18px;
-	}
-
-	li {
-		margin-bottom: $gu-v-spacing;
-		margin-left: $gu-h-spacing;
-	}
+.component-feature-list__item {
+	margin-bottom: $gu-v-spacing;
+	margin-left: $gu-h-spacing;
 }

--- a/assets/components/pageSection/pageSection.jsx
+++ b/assets/components/pageSection/pageSection.jsx
@@ -1,0 +1,66 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+import { generateClassName } from 'helpers/utilities';
+
+import type { Node } from 'react';
+
+
+// ----- Props ----- //
+
+type PropTypes = {
+  modifierClass?: string,
+  heading?: string,
+  headingChildren?: Node,
+  children?: Node,
+};
+
+
+// ----- Component ----- //
+
+function PageSection(props: PropTypes) {
+
+  return (
+    <section className={generateClassName('component-page-section', props.modifierClass)}>
+      <div className="component-page-section__content gu-content-margin">
+        <div className="component-page-section__header">
+          <Heading heading={props.heading} />
+          {props.headingChildren}
+        </div>
+        <div className="component-page-section__body">{props.children}</div>
+      </div>
+    </section>
+  );
+
+}
+
+
+// ----- Auxiliary Components ----- //
+
+function Heading(props: { heading: ?string }) {
+
+  if (props.heading) {
+    return <h2 className="component-page-section__heading">{props.heading}</h2>;
+  }
+
+  return null;
+
+}
+
+
+// ----- Default Props ----- //
+
+PageSection.defaultProps = {
+  modifierClass: '',
+  heading: '',
+  headingChildren: null,
+  children: null,
+};
+
+
+// ----- Exports ----- //
+
+export default PageSection;

--- a/assets/components/pageSection/pageSection.scss
+++ b/assets/components/pageSection/pageSection.scss
@@ -1,0 +1,13 @@
+.component-page-section__header {
+  @include mq($from: desktop) {
+    display: inline-block;
+    vertical-align: top;
+    width: 220px;
+  }
+}
+
+.component-page-section__body {
+  @include mq($from: desktop) {
+    display: inline-block;
+  }
+}

--- a/assets/components/subscriptionBundle/subscriptionBundle.jsx
+++ b/assets/components/subscriptionBundle/subscriptionBundle.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 import DoubleHeading from 'components/doubleHeading/doubleHeading';
 import FeatureList from 'components/featureList/featureList';
-import CtaCircle from 'components/ctaCircle/ctaCircle';
+import CtaLink from 'components/ctaLink/ctaLink';
 
 import { generateClassName } from 'helpers/utilities';
 
@@ -21,7 +21,9 @@ type PropTypes = {
   subheading: string,
   benefits: ListItem[],
   ctaText: string,
-  ctaLink: string,
+  ctaUrl: string,
+  ctaId: string,
+  ctaAccessibilityHint: string,
 };
 
 
@@ -36,7 +38,12 @@ export default function SubscriptionBundle(props: PropTypes) {
         subheading={props.subheading}
       />
       <FeatureList listItems={props.benefits} modifierClass={props.modifierClass} />
-      <CtaCircle text={props.ctaText} url={props.ctaLink} />
+      <CtaLink
+        text={props.ctaText}
+        url={props.ctaUrl}
+        ctaId={props.ctaId}
+        accessibilityHint={props.ctaAccessibilityHint}
+      />
     </div>
   );
 

--- a/assets/components/subscriptionBundle/subscriptionBundle.jsx
+++ b/assets/components/subscriptionBundle/subscriptionBundle.jsx
@@ -35,7 +35,7 @@ export default function SubscriptionBundle(props: PropTypes) {
         heading={props.heading}
         subheading={props.subheading}
       />
-      <FeatureList listItems={props.benefits} />
+      <FeatureList listItems={props.benefits} modifierClass={props.modifierClass} />
       <CtaCircle text={props.ctaText} url={props.ctaLink} />
     </div>
   );
@@ -46,5 +46,5 @@ export default function SubscriptionBundle(props: PropTypes) {
 // ----- Default Props ----- //
 
 SubscriptionBundle.defaultProps = {
-  modifierClass: null,
+  modifierClass: '',
 };

--- a/assets/components/subscriptionBundle/subscriptionBundle.jsx
+++ b/assets/components/subscriptionBundle/subscriptionBundle.jsx
@@ -1,0 +1,50 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+import DoubleHeading from 'components/doubleHeading/doubleHeading';
+import FeatureList from 'components/featureList/featureList';
+import CtaCircle from 'components/ctaCircle/ctaCircle';
+
+import { generateClassName } from 'helpers/utilities';
+
+import type { ListItem } from 'components/featureList/featureList';
+
+
+// ----- Props ----- //
+
+type PropTypes = {
+  modifierClass?: string,
+  heading: string,
+  subheading: string,
+  benefits: ListItem[],
+  ctaText: string,
+  ctaLink: string,
+};
+
+
+// ----- Component ----- //
+
+export default function SubscriptionBundle(props: PropTypes) {
+
+  return (
+    <div className={generateClassName('component-subscription-bundle', props.modifierClass)}>
+      <DoubleHeading
+        heading={props.heading}
+        subheading={props.subheading}
+      />
+      <FeatureList listItems={props.benefits} />
+      <CtaCircle text={props.ctaText} url={props.ctaLink} />
+    </div>
+  );
+
+}
+
+
+// ----- Default Props ----- //
+
+SubscriptionBundle.defaultProps = {
+  modifierClass: null,
+};

--- a/assets/components/threeSubscriptions/threeSubscriptions.jsx
+++ b/assets/components/threeSubscriptions/threeSubscriptions.jsx
@@ -1,0 +1,20 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+import PageSection from 'components/pageSection/pageSection';
+
+
+// ----- Component ----- //
+
+export default function ThreeSubscriptions() {
+
+  return (
+    <PageSection heading="Subscribe">
+      Hello
+    </PageSection>
+  );
+
+}

--- a/assets/components/threeSubscriptions/threeSubscriptions.jsx
+++ b/assets/components/threeSubscriptions/threeSubscriptions.jsx
@@ -31,7 +31,9 @@ export default function ThreeSubscriptions() {
           },
         ]}
         ctaText="Start your 14 day trial"
-        ctaLink="https://subscribe.theguardian.com/p/DXX83X"
+        ctaUrl="https://subscribe.theguardian.com/p/DXX83X"
+        ctaId="digital-sub"
+        ctaAccessibilityHint="The Guardian\'s digital subscription is available for eleven pounds and ninety nine pence per month. Find out how to sign up for a free trial."
       />
       <SubscriptionBundle
         modifierClass="paper"
@@ -47,7 +49,9 @@ export default function ThreeSubscriptions() {
           },
         ]}
         ctaText="Get a paper subscription"
-        ctaLink="https://subscribe.theguardian.com/p/GXX83P"
+        ctaUrl="https://subscribe.theguardian.com/p/GXX83P"
+        ctaId="paper-sub"
+        ctaAccessibilityHint="Proceed to paper subscription options, starting at ten pounds seventy nine pence per month."
       />
       <SubscriptionBundle
         modifierClass="paper-digital"
@@ -66,7 +70,9 @@ export default function ThreeSubscriptions() {
           },
         ]}
         ctaText="Get a paper + digital subscription"
-        ctaLink="https://subscribe.theguardian.com/p/GXX83X"
+        ctaUrl="https://subscribe.theguardian.com/p/GXX83X"
+        ctaId="paper-digi-sub"
+        ctaAccessibilityHint="Proceed to choose which days you would like to regularly receive the newspaper in conjunction with a digital subscription"
       />
     </PageSection>
   );

--- a/assets/components/threeSubscriptions/threeSubscriptions.jsx
+++ b/assets/components/threeSubscriptions/threeSubscriptions.jsx
@@ -5,6 +5,7 @@
 import React from 'react';
 
 import PageSection from 'components/pageSection/pageSection';
+import SubscriptionBundle from 'components/subscriptionBundle/subscriptionBundle';
 
 
 // ----- Component ----- //
@@ -12,8 +13,61 @@ import PageSection from 'components/pageSection/pageSection';
 export default function ThreeSubscriptions() {
 
   return (
-    <PageSection heading="Subscribe">
-      Hello
+    <PageSection heading="Subscribe" modifierClass="three-subscriptions">
+      <SubscriptionBundle
+        modifierClass="digital"
+        heading="Digital subscription"
+        subheading="£11.99/month"
+        benefits={[
+          {
+            heading: 'Premium experience on the Guardian app',
+            text: `No adverts means faster loading pages and a clearer reading experience.
+              Play our daily crosswords offline wherever you are`,
+          },
+          {
+            heading: 'Daily Tablet Edition app',
+            text: `Read the Guardian, the Observer and all the Weekend supplements in an
+              optimised tablet app; available on iPad`,
+          },
+        ]}
+        ctaText="Start your 14 day trial"
+        ctaLink="https://subscribe.theguardian.com/p/DXX83X"
+      />
+      <SubscriptionBundle
+        modifierClass="paper"
+        heading="Paper subscription"
+        subheading="£10.79/month"
+        benefits={[
+          {
+            heading: 'Choose your package and delivery method',
+            text: 'Everyday, Sixday, Weekend and Sunday; redeem paper vouchers or get home delivery',
+          },
+          {
+            heading: 'Save money on the retail price',
+          },
+        ]}
+        ctaText="Get a paper subscription"
+        ctaLink="https://subscribe.theguardian.com/p/GXX83P"
+      />
+      <SubscriptionBundle
+        modifierClass="paper-digital"
+        heading="Paper+digital"
+        subheading="£22.06/month"
+        benefits={[
+          {
+            heading: 'Choose your package and delivery method',
+            text: 'Everyday, Sixday, Weekend and Sunday; redeem paper vouchers or get home delivery',
+          },
+          {
+            heading: 'Save money on the retail price',
+          },
+          {
+            heading: 'Get all the benefits of a digital subscription with paper + digital',
+          },
+        ]}
+        ctaText="Get a paper + digital subscription"
+        ctaLink="https://subscribe.theguardian.com/p/GXX83X"
+      />
     </PageSection>
   );
 

--- a/assets/components/threeSubscriptions/threeSubscriptions.scss
+++ b/assets/components/threeSubscriptions/threeSubscriptions.scss
@@ -1,4 +1,11 @@
 .component-page-section--three-subscriptions {
+  .component-page-section__heading {
+    font-family: $gu-egyptian-web;
+    font-size: 24px;
+    line-height: 1.17;
+    font-weight: bold;
+  }
+
   .component-double-heading {
     margin-bottom: $gu-v-spacing * 2;
   }
@@ -11,8 +18,13 @@
   .component-double-heading__subheading {
     font-size: 30px;
     line-height: 1;
-    font-weight: 500;
+    font-weight: 200;
     font-family: $gu-egyptian-web;
+  }
+
+  .component-feature-list {
+    font-size: 16px;
+    line-height: 1.25;
   }
 
   .component-feature-list--digital {
@@ -25,5 +37,12 @@
 
   .component-feature-list--paper-digital {
     list-style-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 28 28"><path fill="#ed6300" d="M7.885 25.74L0 14.82l3.22-3.217L8.3 16.74 24.695 2.26 28 5.565"/></svg>');
-  }  
+  }
+
+  .component-cta-link {
+    height: 54px;
+    padding: 0 30px;
+    font-size: 14px;
+    line-height: 54px;
+  }
 }

--- a/assets/components/threeSubscriptions/threeSubscriptions.scss
+++ b/assets/components/threeSubscriptions/threeSubscriptions.scss
@@ -1,0 +1,29 @@
+.component-page-section--three-subscriptions {
+  .component-double-heading {
+    margin-bottom: $gu-v-spacing * 2;
+  }
+
+  .component-double-heading__heading {
+    font-size: 36px;
+    line-height: 1;
+  }
+
+  .component-double-heading__subheading {
+    font-size: 30px;
+    line-height: 1;
+    font-weight: 500;
+    font-family: $gu-egyptian-web;
+  }
+
+  .component-feature-list--digital {
+    list-style-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 28 28"><path fill="#bb3b80" d="M7.885 25.74L0 14.82l3.22-3.217L8.3 16.74 24.695 2.26 28 5.565"/></svg>');
+  }
+
+  .component-feature-list--paper {
+    list-style-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 28 28"><path fill="#0084c6" d="M7.885 25.74L0 14.82l3.22-3.217L8.3 16.74 24.695 2.26 28 5.565"/></svg>');
+  }
+
+  .component-feature-list--paper-digital {
+    list-style-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 28 28"><path fill="#ed6300" d="M7.885 25.74L0 14.82l3.22-3.217L8.3 16.74 24.695 2.26 28 5.565"/></svg>');
+  }  
+}

--- a/assets/components/whySupport/whySupport.jsx
+++ b/assets/components/whySupport/whySupport.jsx
@@ -1,0 +1,69 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+import PageSection from 'components/pageSection/pageSection';
+import {
+  SvgScribble,
+  SvgGraphLine,
+  SvgGraphLineMobile,
+  SvgWallDesktop,
+  SvgWallMobile,
+} from 'components/svg/svg';
+
+
+// ----- Component ----- //
+
+export default function WhySupport() {
+
+  return (
+    <PageSection heading="Why support?" modifierClass="why-support">
+      <div className="component-why-support">
+        <h1 className="component-why-support__heading component-why-support__heading--edits">
+          <SvgScribble />
+          <div className="component-why-support__heading-text-wrapper">
+            <span className="component-why-support__subheading">No one edits</span>
+            <span className="component-why-support__subheading component-why-support__subheading--edits-indented">
+              our editor
+            </span>
+          </div>
+        </h1>
+        <p className="component-why-support__copy">
+          Your support is vital in helping the Guardian do the most important
+          journalism of all: that which takes time and effort. More people
+          than ever now read and support the Guardian&#39;s independent,
+          quality and investigative journalism.
+        </p>
+        <h1 className="component-why-support__heading component-why-support__heading--advertising">
+          <span className="component-why-support__subheading">Advertising revenues</span>
+          <span className="component-why-support__subheading component-why-support__subheading--advertising-indented">
+            are falling
+          </span>
+          <SvgGraphLine />
+          <SvgGraphLineMobile />
+        </h1>
+        <p className="component-why-support__copy">
+          Like many media organisations, the Guardian is operating in an
+          incredibly challenging commercial environment, and the advertising
+          that we used to rely on to fund our work continues to fall.
+        </p>
+        <h1 className="component-why-support__heading component-why-support__heading--paywall">
+          <span className="component-why-support__subheading">We haven&#39;t put up </span>
+          <span className="component-why-support__subheading component-why-support__subheading--paywall-indented">
+            a paywall
+          </span>
+          <div className="component-why-support__paywall-svg ">
+            <SvgWallDesktop />
+            <SvgWallMobile />
+          </div>
+        </h1>
+        <p className="component-why-support__copy">
+          We want to keep our journalism as open as we can.
+        </p>
+      </div>
+    </PageSection>
+  );
+
+}

--- a/assets/components/whySupport/whySupport.scss
+++ b/assets/components/whySupport/whySupport.scss
@@ -1,0 +1,350 @@
+.component-why-support {
+  @include mq($from: desktop) {
+    width: 700px;
+  }
+
+  .svg-scribble {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 305px;
+
+    @include mq($from: mobileMedium) {
+      width: 355px;
+    }
+
+    @include mq($from: mobileLandscape) {
+      width: unset;
+    }
+  }
+
+  .scribble-0, .scribble-1 {
+    fill: none;
+    stroke: gu-colour(neutral-1);
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 6px;
+  }
+
+  .scribble-2 {
+    fill:#fff;
+  }
+
+  .svg-graph-line {
+    stroke: gu-colour(neutral-1);
+    fill: none;
+    stroke-width: 8;
+    stroke-linecap: round;
+    position: absolute;
+    top: 18px;
+    left: 20px;
+
+    @include mq($until: phablet) {
+      display: none;
+    }
+  }
+
+  .svg-graph-line-mobile {
+    stroke: gu-colour(neutral-1);
+    fill: none;
+    stroke-width: 6;
+    stroke-linecap: round;
+    position: absolute;
+    top: $gu-v-spacing;
+    left: -20px;
+    width: 290px;
+
+    @include mq($from: phablet) {
+      display: none;
+    }
+  }
+
+  .svg-wall-mobile {
+    width: gu-breakpoint(mobileMedium) + 40px;
+    margin-left: -30px;
+
+    @include mq($from: mobileMedium) {
+      width: gu-breakpoint(mobileLandscape) + 20px;
+      margin-left: -50px;
+    }
+
+    @include mq($from: mobileLandscape) {
+      width: gu-breakpoint(mobileLandscape);
+      margin-left: 0;
+    }
+
+    @include mq($from: phablet) {
+      width: gu-breakpoint(phablet);
+    }
+
+    @include mq($from: tablet) {
+      width: gu-breakpoint(tablet) + 120px;
+      margin-left: - ((gu-breakpoint(tablet) + 120px) - gu-breakpoint(tablet)) / 2;
+    }
+
+    @include mq($from: desktop) {
+      display: none;
+    }
+  }
+
+  .svg-wall-desktop {
+    display: none;
+
+    @include mq($from: desktop) {
+      display: block;
+      width: gu-breakpoint(wide);
+      margin-left: - (gu-breakpoint(wide) - gu-breakpoint(desktop)) / 2;
+    }
+
+    @include mq($from: leftCol) {
+      margin-left: - (gu-breakpoint(wide) - gu-breakpoint(leftCol)) / 2;
+    }
+
+    @include mq($from: wide) {
+      margin-left: 0;
+    }
+  }
+}
+
+.component-why-support__floating-circle {
+  border-radius: 600px;
+  background-color: gu-colour(multimedia-main-2);
+  width: 50px;
+  height: 50px;
+
+  @include mq($from: tablet) {
+    width: 60px;
+    height: 60px;
+  }
+}
+
+.component-why-support__heading {
+  font-family: $gu-egyptian-web;
+  font-weight: bold;
+  font-size: 30px;
+  line-height: 34px;
+  color: gu-colour(neutral-1);
+
+  @include mq($from: mobileMedium) {
+    font-size: 36px;
+    line-height: 36px;
+  }
+
+  @include mq($from: tablet) {
+    font-size: 60px;
+    line-height: 60px;
+  }
+}
+
+.component-why-support__subheading {
+  display: block;
+}
+
+.component-why-support__heading--edits {
+  position: relative;
+  margin-top: $gu-v-spacing * 3;
+  height: 180px;
+
+  @include mq($from: mobileLandscape) {
+    height: 200px;
+  }
+
+  @include mq($from: phablet) {
+    height: 300px;
+  }
+
+  @include mq($from: phablet) {
+    padding-left: 180px;
+  }
+
+  @include mq($from: tablet) {
+    padding-left: 140px;
+  }
+
+  &::after {
+    @extend .component-why-support__floating-circle;
+    content: " ";
+    position: absolute;
+    left: 230px;
+    bottom: $gu-v-spacing;
+
+    @include mq($from: phablet) {
+      left: 170px;
+      bottom: $gu-v-spacing * 3;
+    }
+  }
+}
+
+.component-why-support__subheading--edits-indented {
+  margin-left: 50px;
+
+  @include mq($from: tablet) {
+    margin-left: 95px;
+  }
+}
+
+.component-why-support__heading-text-wrapper {
+  position: absolute;
+  top: 26px;
+  left: 48px;
+
+  @include mq($from: mobileMedium) {
+    top: 32px;
+    left: 60px;
+  }
+
+  @include mq($from: mobileLandscape) {
+    top: 50px;
+    left: 100px;
+  }
+
+  @include mq($from: phablet) {
+    top: 80px;
+    left: unset;
+  }
+}
+
+.component-why-support__heading--advertising {
+  padding: $gu-v-spacing 0 150px;
+  margin-top: $gu-v-spacing * 4;
+  position: relative;
+
+  @include mq($from: phablet) {
+    padding: $gu-v-spacing 0 152px 80px;
+  }
+
+  @include mq($from: tablet) {
+    padding-bottom: 132px;
+  }
+
+  &::after {
+    @extend .component-why-support__floating-circle;
+    content: " ";
+    position: absolute;
+    bottom: $gu-v-spacing;
+    left: 250px;
+
+    @include mq($from: phablet) {
+      right: 0;
+      left: unset;
+    }
+  }
+}
+
+.component-why-support__subheading--advertising-indented {
+  margin-left: 140px;
+
+  @include mq($from: tablet) {
+    margin-left: 235px;
+  }
+}
+
+.component-why-support__heading--paywall {
+  width: 100%;
+  box-sizing: border-box;
+  margin: 0;
+  position: relative;
+  padding-top: 80px;
+  padding-bottom: 100px;
+  padding-left: 50px;
+  margin-top: $gu-v-spacing * 4;
+
+  @include mq($from: mobileMedium) {
+    padding-bottom: 150px;
+    padding-top: 100px;
+    padding-left: 50px;
+  }
+
+  @include mq($from: mobileLandscape) {
+    margin-left: 0;
+    margin-right: 0;
+    margin-bottom: 0;
+    padding-top: 92px;
+    padding-bottom: 140px;
+    padding-left: 80px;
+    width: auto;
+  }
+
+  @include mq($from: phablet) {
+    padding-top: 150px;
+    padding-bottom: 200px;
+    padding-left: 150px;
+  }
+
+  @include mq($from: tablet) {
+    padding-top: 180px;
+    padding-bottom: 260px;
+    padding-left: 110px;
+  }
+
+  @include mq($from: desktop) {
+    padding-top: 120px;
+    padding-bottom: 180px;
+    padding-left: 0;
+  }
+
+  @include mq($from: leftCol) {
+    padding-left: $gu-h-spacing * 2;
+  }
+
+  @include mq($from: wide) {
+    padding-left: 90px;
+  }
+}
+
+.component-why-support__subheading--paywall-indented {
+  margin-left: 60px;
+}
+
+.component-why-support__paywall-svg {
+  position: absolute;
+  overflow: hidden;
+  width: 100vw;
+  top: 0;
+  left: - $gu-h-spacing / 2;
+
+  @include mq($from: mobileMedium) {
+    width: 100vw;
+  }
+
+  @include mq($from: mobileLandscape) {
+    width: gu-breakpoint(mobileLandscape);
+    left: - $gu-h-spacing;
+  }
+
+  @include mq($from: phablet) {
+    width: gu-breakpoint(phablet);
+  }
+
+  @include mq($from: tablet) {
+    width: gu-breakpoint(tablet);
+  }
+
+  @include mq($from: desktop) {
+    padding-left: 0;
+    padding-bottom: 140px;
+  }
+
+  @include mq($from: desktop) {
+    width: gu-breakpoint(desktop);
+    left: -208px;
+  }
+
+  @include mq($from: leftCol) {
+    width: gu-breakpoint(leftCol);
+    left: -240px;
+  }
+
+  @include mq($from: wide) {
+    left: -272px;
+    width: gu-breakpoint(wide);
+  }
+}
+
+.component-why-support__copy {
+  font-family: $gu-text-egyptian-web;
+  font-size: 18px;
+  line-height: 24px;
+  color: gu-colour(neutral-1);
+  border-top: 1px solid gu-colour(light-yellow);
+}

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -210,19 +210,6 @@
           left: 250px;
         }
 
-        &.contribute-one_off {
-          bottom: 130px;
-        }
-
-        &.contribute-monthly {
-          bottom: 72px;
-        }
-      }
-
-      &.contribute-one_off {
-        @include mq($until: desktop) {
-          margin-top: 48px;
-        }
       }
 
       svg {
@@ -420,11 +407,7 @@
           }
         }
 
-        .component-cta-link.contribute-monthly {
-          bottom: $gu-v-spacing;
-        }
-
-        .component-cta-link.contribute-one_off {
+        .component-cta-link--contribute-one_off {
           bottom: $gu-v-spacing * 6;
         }
 

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -526,6 +526,15 @@
 
       h3 {
         color: gu-colour(sport-garnett-main-1);
+        font-family: $gu-text-sans-web;
+        font-size: 16px;
+        line-height: 20px;
+      }
+
+      p {
+        font-family: $gu-text-sans-web;
+        font-size: 14px;
+        line-height: 18px;
       }
 
       li {

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -951,7 +951,21 @@
   // ----- Shared Components ----- //
 
   .component-double-heading {
-      margin-bottom: (2 * $gu-v-spacing);
+    font-size: 28px;
+    line-height: 32px;
+    margin-bottom: (2 * $gu-v-spacing);
+
+    .component-double-heading__subheading {
+      font-family: $gu-text-sans-web;
+      font-size: 20px;
+      color: gu-colour(neutral-1);
+      line-height: 24px;
+
+      @include mq($from: phablet) {
+        font-size: 24px;
+        line-height: 28px;
+      }
+    }
   }
 
   .component-double-heading--variant-a {

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLandingOld.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLandingOld.jsx
@@ -50,4 +50,4 @@ const content = (
   </Provider>
 );
 
-renderPage(content, 'support-landing-page');
+renderPage(content, 'support-landing-page-old');

--- a/assets/pages/bundles-landing/support-landing-ab-test/supportLandingOld.scss
+++ b/assets/pages/bundles-landing/support-landing-ab-test/supportLandingOld.scss
@@ -1,4 +1,4 @@
-#support-landing-page {
+#support-landing-page-old {
 
   // ----- General
 

--- a/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/assets/pages/contributions-landing/contributionsLanding.scss
@@ -339,7 +339,8 @@ strong {
 	}
 
 	.component-double-heading {
-    	margin-bottom: (2 * $gu-v-spacing);
+  	margin-bottom: (2 * $gu-v-spacing);
+  	color: gu-colour(neutral-1);
 	}
 
 	.component-double-heading__heading {
@@ -354,9 +355,13 @@ strong {
 	.component-double-heading__subheading {
 		padding-top: 4px;
 		height: 24px;
+		font-size: 20px;
+		line-height: 24px;
 
 		@include mq($from: phablet) {
 			height: 28px;
+			font-size: 24px;
+			line-height: 28px;
 		}
 	}
 

--- a/assets/pages/support-landing/supportLanding.jsx
+++ b/assets/pages/support-landing/supportLanding.jsx
@@ -1,0 +1,22 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
+import Footer from 'components/footer/footer';
+
+import { renderPage } from 'helpers/render';
+
+
+// ----- Render ----- //
+
+const content = (
+  <div>
+    <SimpleHeader />
+    <Footer />
+  </div>
+);
+
+renderPage(content, 'support-landing-page');

--- a/assets/pages/support-landing/supportLanding.jsx
+++ b/assets/pages/support-landing/supportLanding.jsx
@@ -8,6 +8,7 @@ import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
 import Footer from 'components/footer/footer';
 import CirclesIntroduction from 'components/circlesIntroduction/circlesIntroduction';
 import ThreeSubscriptions from 'components/threeSubscriptions/threeSubscriptions';
+import WhySupport from 'components/whySupport/whySupport';
 
 import { renderPage } from 'helpers/render';
 
@@ -19,6 +20,7 @@ const content = (
     <SimpleHeader />
     <CirclesIntroduction />
     <ThreeSubscriptions />
+    <WhySupport />
     <Footer />
   </div>
 );

--- a/assets/pages/support-landing/supportLanding.jsx
+++ b/assets/pages/support-landing/supportLanding.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 
 import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
 import Footer from 'components/footer/footer';
+import CirclesIntroduction from 'components/circlesIntroduction/circlesIntroduction';
 
 import { renderPage } from 'helpers/render';
 
@@ -15,6 +16,7 @@ import { renderPage } from 'helpers/render';
 const content = (
   <div>
     <SimpleHeader />
+    <CirclesIntroduction />
     <Footer />
   </div>
 );

--- a/assets/pages/support-landing/supportLanding.jsx
+++ b/assets/pages/support-landing/supportLanding.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
 import Footer from 'components/footer/footer';
 import CirclesIntroduction from 'components/circlesIntroduction/circlesIntroduction';
+import ThreeSubscriptions from 'components/threeSubscriptions/threeSubscriptions';
 
 import { renderPage } from 'helpers/render';
 
@@ -17,6 +18,7 @@ const content = (
   <div>
     <SimpleHeader />
     <CirclesIntroduction />
+    <ThreeSubscriptions />
     <Footer />
   </div>
 );

--- a/assets/stylesheets/main.scss
+++ b/assets/stylesheets/main.scss
@@ -45,6 +45,7 @@
 @import '../components/socialShare/socialShare';
 @import '../components/svg/svg';
 @import '../components/video/video';
+@import '../components/whySupport/whySupport';
 
 // ----- Pages ----- //
 

--- a/assets/stylesheets/main.scss
+++ b/assets/stylesheets/main.scss
@@ -47,7 +47,7 @@
 // ----- Pages ----- //
 
 @import '../pages/bundles-landing/bundlesLanding';
-@import '../pages/bundles-landing/support-landing-ab-test/supportLanding';
+@import '../pages/bundles-landing/support-landing-ab-test/supportLandingOld';
 @import '../pages/contributions-landing/contributionsLanding';
 @import '../pages/regular-contributions/regularContributions';
 @import '../pages/oneoff-contributions/oneoffContributions';

--- a/assets/stylesheets/main.scss
+++ b/assets/stylesheets/main.scss
@@ -31,6 +31,7 @@
 @import '../components/numberInput/numberInput';
 @import '../components/paymentAmount/paymentAmount';
 @import '../components/radioToggle/radioToggle';
+@import '../components/pageSection/pageSection';
 @import '../components/paymentButtons/payPalContributionButton/payPalContributionButton';
 @import '../components/paymentButtons/payPalExpressButton/payPalExpressButton';
 @import '../components/paymentButtons/stripePopUpButton/stripePopUpButton';

--- a/assets/stylesheets/main.scss
+++ b/assets/stylesheets/main.scss
@@ -13,6 +13,7 @@
 
 @import '../components/bodyCopy/bodyCopy';
 @import '../components/checkboxInput/checkboxInput';
+@import '../components/circlesIntroduction/circlesIntroduction';
 @import '../components/contribAmounts/contribAmounts';
 @import '../components/legal/contribLegal/contribLegal';
 @import '../components/ctaCircle/ctaCircle';

--- a/assets/stylesheets/main.scss
+++ b/assets/stylesheets/main.scss
@@ -38,7 +38,6 @@
 @import '../components/paymentButtons/directDebitPopUpButton/directDebitPopUpButton';
 @import '../components/legal/termsPrivacy/termsPrivacy';
 @import '../components/signout/signout';
-@import '../components/subscriptionBundle/subscriptionBundle';
 @import '../components/textInput/textInput';
 @import '../components/testUserBanner/testUserBanner';
 @import '../components/threeSubscriptions/threeSubscriptions';

--- a/assets/stylesheets/main.scss
+++ b/assets/stylesheets/main.scss
@@ -41,6 +41,7 @@
 @import '../components/subscriptionBundle/subscriptionBundle';
 @import '../components/textInput/textInput';
 @import '../components/testUserBanner/testUserBanner';
+@import '../components/threeSubscriptions/threeSubscriptions';
 @import '../components/secure/secure';
 @import '../components/selectInput/selectInput';
 @import '../components/socialShare/socialShare';

--- a/assets/stylesheets/main.scss
+++ b/assets/stylesheets/main.scss
@@ -37,6 +37,7 @@
 @import '../components/paymentButtons/directDebitPopUpButton/directDebitPopUpButton';
 @import '../components/legal/termsPrivacy/termsPrivacy';
 @import '../components/signout/signout';
+@import '../components/subscriptionBundle/subscriptionBundle';
 @import '../components/textInput/textInput';
 @import '../components/testUserBanner/testUserBanner';
 @import '../components/secure/secure';

--- a/conf/routes
+++ b/conf/routes
@@ -3,6 +3,11 @@
 GET /healthcheck                                    controllers.Application.healthcheck
 
 
+# ----- Landing Pages ----- #
+
+GET /circles/uk                                     controllers.Application.reactTemplate(title="Support the Guardian", id="support-landing-page", js="supportLandingPage.js")
+
+
 # ----- Bundles Landing Page ----- #
 
 GET /uk                                             controllers.Application.bundleLanding(title="Support the Guardian", id="bundles-landing-page", js="bundlesLandingPage.js", newDesigns: Boolean ?= false)

--- a/conf/routes
+++ b/conf/routes
@@ -3,14 +3,9 @@
 GET /healthcheck                                    controllers.Application.healthcheck
 
 
-# ----- Landing Pages ----- #
-
-GET /circles/uk                                     controllers.Application.reactTemplate(title="Support the Guardian", id="support-landing-page", js="supportLandingPage.js")
-
-
 # ----- Bundles Landing Page ----- #
 
-GET /uk                                             controllers.Application.bundleLanding(title="Support the Guardian", id="bundles-landing-page", js="bundlesLandingPage.js", newDesigns: Boolean ?= false)
+GET /uk                                             controllers.Application.bundleLanding(title="Support the Guardian", id="bundles-landing-page", js="bundlesLandingPage.js", newDesigns: String ?= "")
 GET /us                                             controllers.Application.redirect(location="/us/contribute")
 GET /                                               controllers.Application.geoRedirect()
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,7 +48,7 @@ module.exports = (env) => {
       favicons: 'images/favicons.js',
       styles: 'stylesheets/garnett.scss',
       bundlesLandingPage: 'pages/bundles-landing/bundlesLanding.jsx',
-      supportLandingPage: 'pages/bundles-landing/support-landing-ab-test/supportLanding.jsx',
+      supportLandingPageOld: 'pages/bundles-landing/support-landing-ab-test/supportLandingOld.jsx',
       contributionsLandingPageUK: 'pages/contributions-landing/contributionsLandingUK.jsx',
       contributionsLandingPageUS: 'pages/contributions-landing/contributionsLandingUS.jsx',
       regularContributionsPage: 'pages/regular-contributions/regularContributions.jsx',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,6 +47,7 @@ module.exports = (env) => {
     entry: {
       favicons: 'images/favicons.js',
       styles: 'stylesheets/garnett.scss',
+      supportLandingPage: 'pages/support-landing/supportLanding.jsx',
       bundlesLandingPage: 'pages/bundles-landing/bundlesLanding.jsx',
       supportLandingPageOld: 'pages/bundles-landing/support-landing-ab-test/supportLandingOld.jsx',
       contributionsLandingPageUK: 'pages/contributions-landing/contributionsLandingUK.jsx',


### PR DESCRIPTION
## Why are you doing this?

Firstly, I would like to apologise for this PR. I suddenly realised that my changes were spiralling into a refactor, and that if I didn't merge some of them in soon things would get really out of hand. Therefore this isn't the most coherent PR, but I'll try to explain the changes below. There is a long-term plan!

cc: @Amohkhan

[**Trello Card**](https://trello.com/b/TjUElW0B/simple-and-coherent-product-supporting-the-guardian)

## Changes

### Support Landing Page

The Garnett Circles page is intended to be a modular redesign, so that we can iterate rapidly in multiple territories. Therefore I've created a completely new page (again!), which is called the 'Support Landing Page'. The interim (read: pre-Garnett) circles page I have renamed the 'Old' Support Landing Page. I would delete it, but I need it around to refer to while I'm doing this work; I'll delete it when this is done.

- Kept the old circles page available on the `newDesign` query param, but now passing the value `circles` to access (`Application.scala`, `supportLandingOld.jsx`, `supportLandingOld.scss`, `main.scss`, `webpack.config.js`).
- Created a new (final final final) Support Landing Page, and put it temporarily on the same query param, passing the value `circles-garnett` to access (**note:** I'm happy to be told this is a terrible idea) (`supportLanding.jsx`, `routes`).

### Tidying Shared Components

Some of our shared components have not got particularly sharing-friendly CSS in them. I've done my best to minimise the CSS that's shared, limiting it to stuff that we're confident we'll want available everywhere that component is used. I've also done my best to flatten the CSS as I go, after agreeing with @joelochlann that this makes things more maintainable. I've also applied some of our more recent conventions to the code where it was missing, e.g. `generateClassName`.

- Switched CtaLink over to using `generateClassName` (`ctaLink.jsx`).
- Pared down and flattened the CSS in DoubleHeading (`doubleHeading.scss`).
- Applied BEM conventions to FeatureList, and made use of the auxiliary components style first introduced in #448 (`featureList.jsx`, `featureList.scss`).
- Moved styles to the page level for the bundles and contributions landing pages, to keep them out of the shared component stylesheets (`bundlesLanding.scss`, `contributionsLanding.scss`).

### New Shared Landing Page Sections

We've decided that the best way we can make rapid changes to the various landing pages in different territories is to create modular, swappable page sections. These will then be shared between different region and product landing pages. I've begun this by adding some new shared components.

- **CirclesIntroduction**, the bit full of circles that sits at the top of all (or perhaps most) of the landing pages (`circlesIntroduction.jsx`, `circlesIntroduction.scss`).
- **PageSection**, the successor to InfoSection (which I plan to phase out). This contains all the code necessary to drop a new section into any page, including the margins and heading transition at different breakpoints (`pageSection.jsx`, `pageSection.scss`).
- **SubscriptionBundle**, an individual subscription product, essentially one of the rectangles from the current bundles landing page (`subscriptionBundle.jsx`, `subscriptionBundle.scss`).
- **ThreeSubscriptions**, the 'paper', 'digital' and 'paper+digital' bundles side-by-side in a single component, ready to drop into any given landing page (`threeSubscriptions.jsx`, threeSubscriptions.scss`).
- **WhySupport**, the definitive component to insert the 'Why support?' section, complete with circles (and, one day, animations) (`whySupport.jsx`, `whySupport.scss`).

**Note:** Once we've switched over wholesale to this new landing page approach I'm going to purge the unused pages and components that are left over from earlier iterations.

## Screenshots

And for all of that, you get this lovely page:

![circles-mess](https://user-images.githubusercontent.com/5131341/35229619-c0160eba-ff8b-11e7-91c5-b201030c0bb9.png)

