### PR TITLE
Direct debit phase 3/6

### DIFF
--- a/app/codecs/CirceDecoders.scala
+++ b/app/codecs/CirceDecoders.scala
@@ -41,7 +41,6 @@ object CirceDecoders {
   implicit val stripePaymentFieldsCodec: Codec[StripePaymentFields] = deriveCodec
   implicit val directDebitPaymentFieldsCodec: Codec[DirectDebitPaymentFields] = deriveCodec
 
-  //noinspection ConvertExpressionToSAM
   implicit val encodePaymentFields: Encoder[PaymentFields] = new Encoder[PaymentFields] {
     override final def apply(a: PaymentFields): Json = a match {
       case p: PayPalPaymentFields => Encoder[PayPalPaymentFields].apply(p)

--- a/app/models/DirectDebitDetails.scala
+++ b/app/models/DirectDebitDetails.scala
@@ -32,12 +32,6 @@ object SortCode {
   implicit val encodeSortCode: Encoder[SortCode] = Encoder.encodeString.contramap[SortCode](_.value)
 }
 
-case class DirectDebitDetails(accountNumber: AccountNumber, sortCode: SortCode, accountHolderName: String)
-
-object DirectDebitDetails {
-  implicit val codec: Codec[DirectDebitDetails] = deriveCodec
-}
-
 case class CheckBankAccountDetails(accountNumber: AccountNumber, sortCode: SortCode)
 
 object CheckBankAccountDetails {

--- a/app/services/stepfunctions/RegularContributionsClient.scala
+++ b/app/services/stepfunctions/RegularContributionsClient.scala
@@ -1,13 +1,14 @@
 package services.stepfunctions
 
 import java.util.UUID
+
 import scala.concurrent.Future
 import akka.actor.ActorSystem
 import cats.data.EitherT
 import cats.implicits._
 import com.gu.support.config.Stage
 import RegularContributionsClient._
-import com.gu.support.workers.model.{AcquisitionData, PayPalPaymentFields, StripePaymentFields, User}
+import com.gu.support.workers.model._
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.{Decoder, Encoder}
 import codecs.CirceDecoders._
@@ -39,7 +40,7 @@ case class CreateRegularContributorRequest(
     country: Country,
     state: Option[String],
     contribution: Contribution,
-    paymentFields: Either[StripePaymentToken, PayPalPaymentFields],
+    paymentFields: PaymentFields,
     ophanIds: OphanIds,
     referrerAcquisitionData: ReferrerAcquisitionData,
     supportAbTests: Set[AbTest]

--- a/app/services/stepfunctions/RegularContributionsClient.scala
+++ b/app/services/stepfunctions/RegularContributionsClient.scala
@@ -21,16 +21,6 @@ import play.api.mvc.Call
 import com.gu.support.workers.model.monthlyContributions.Status
 import ophan.thrift.event.AbTest
 
-object StripePaymentToken {
-  implicit val decoder: Decoder[StripePaymentToken] = deriveDecoder
-}
-case class StripePaymentToken(stripeToken: String) {
-  def stripePaymentFields(userId: String): StripePaymentFields = StripePaymentFields(
-    userId = userId,
-    stripeToken = stripeToken
-  )
-}
-
 object CreateRegularContributorRequest {
   implicit val decoder: Decoder[CreateRegularContributorRequest] = deriveDecoder
 }
@@ -74,7 +64,7 @@ class RegularContributionsClient(
       requestId = requestId,
       user = user,
       contribution = request.contribution,
-      paymentFields = request.paymentFields.leftMap(_.stripePaymentFields(user.id)),
+      paymentFields = request.paymentFields,
       acquisitionData = Some(AcquisitionData(
         ophanIds = request.ophanIds,
         referrerAcquisitionData = request.referrerAcquisitionData,

--- a/assets/components/directDebit/directDebitActions.js
+++ b/assets/components/directDebit/directDebitActions.js
@@ -67,7 +67,7 @@ function payDirectDebitClicked(callback: Function): Function {
     }
 
     checkAccount(bankSortCode, bankAccountNumber, isTestUser, csrf)
-      .then(response=> {
+      .then((response) => {
         if (!response.ok) {
           throw new Error('code1');
         }
@@ -79,7 +79,8 @@ function payDirectDebitClicked(callback: Function): Function {
         }
       }).then(() => {
         callback(undefined, bankAccountNumber, bankSortCode, accountHolderName);
-      }).catch((e) => {
+      })
+      .catch((e) => {
         let msg = '';
         switch (e.message) {
           case 'code1': msg = 'Your payment details are invalid. Please check them and try again';

--- a/assets/components/directDebit/directDebitActions.js
+++ b/assets/components/directDebit/directDebitActions.js
@@ -67,6 +67,12 @@ function payDirectDebitClicked(callback: Function): Function {
     }
 
     checkAccount(bankSortCode, bankAccountNumber, isTestUser, csrf)
+      .then(response=> {
+        if (!response.ok) {
+          throw new Error('code1');
+        }
+        return response.json();
+      })
       .then((response) => {
         if (!response.accountValid) {
           throw new Error('code1');

--- a/assets/components/directDebit/directDebitActions.js
+++ b/assets/components/directDebit/directDebitActions.js
@@ -86,7 +86,7 @@ function payDirectDebitClicked(callback: Function): Function {
           case 'code1': msg = 'Your payment details are invalid. Please check them and try again';
             break;
 
-          default: msg = 'Your payment details are invalid. Please check them and try again.';
+          default: msg = 'Oops, something went wrong, please try again later';
 
         }
         dispatch(setDirectDebitFormError(msg));

--- a/assets/components/directDebit/helpers/ajax.js
+++ b/assets/components/directDebit/helpers/ajax.js
@@ -5,6 +5,11 @@
 import { routes } from 'helpers/routes';
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 
+type CheckBankAccountDetails = {
+  accountNumber: string,
+  sortCode: string,
+};
+
 const checkAccount = (
   sortCode: string,
   accountNumber: string,
@@ -12,7 +17,7 @@ const checkAccount = (
   csrf: CsrfState,
 ) => {
 
-  const bankAccountInformation = {
+  const bankAccountDetails: CheckBankAccountDetails = {
     sortCode,
     accountNumber,
   };
@@ -21,7 +26,7 @@ const checkAccount = (
     method: 'POST',
     headers: { 'Content-Type': 'application/json', 'Csrf-Token': csrf.token || '' },
     credentials: 'same-origin',
-    body: JSON.stringify(bankAccountInformation),
+    body: JSON.stringify(bankAccountDetails),
   };
 
   return fetch(routes.directDebitCheckAccount, requestData);

--- a/assets/pages/regular-contributions/helpers/ajax.js
+++ b/assets/pages/regular-contributions/helpers/ajax.js
@@ -78,11 +78,9 @@ const getPaymentFields =
       accountNumber !== undefined) {
 
       return {
-        [paymentFieldName]: {
-          accountHolderName,
-          sortCode,
-          accountNumber,
-        },
+        accountHolderName,
+        sortCode,
+        accountNumber,
       };
     }
     return null;

--- a/assets/pages/regular-contributions/helpers/ajax.js
+++ b/assets/pages/regular-contributions/helpers/ajax.js
@@ -76,7 +76,8 @@ const getPaymentFields =
     accountHolderName?: string,
     paymentFieldName: string,
     userId: string,
-  ) => {
+  ): ?(PayPalDetails | StripeDetails | DirectDebitDetails
+    ) => {
     let response = null;
     switch (paymentFieldName) {
       case 'baid':

--- a/assets/pages/regular-contributions/helpers/ajax.js
+++ b/assets/pages/regular-contributions/helpers/ajax.js
@@ -47,8 +47,8 @@ type RegularContribFields = {|
   state?: UsState,
   contribution: ContributionRequest,
   paymentFields: {
-    [PaymentFieldName]: string | DirectDebitDetails,
-  },
+    [PaymentFieldName]: string,
+  } | DirectDebitDetails,
   ophanIds: OphanIds,
   referrerAcquisitionData: ReferrerAcquisitionData,
   supportAbTests: AcquisitionABTest[],

--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-sts" % awsVersion,
   "org.typelevel" %% "cats" % "0.9.0",
   "com.dripower" %% "play-circe" % "2608.5",
-  "com.gu" %% "support-models" % "0.18",
+  "com.gu" %% "support-models" % "0.20-SNAPSHOT",
   "com.gu" %% "support-config" % "0.7",
   "com.gu" %% "fezziwig" % "0.7",
   "com.typesafe.akka" %% "akka-agent" % "2.5.6",

--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-sts" % awsVersion,
   "org.typelevel" %% "cats" % "0.9.0",
   "com.dripower" %% "play-circe" % "2608.5",
-  "com.gu" %% "support-models" % "0.20-SNAPSHOT",
+  "com.gu" %% "support-models" % "0.21",
   "com.gu" %% "support-config" % "0.7",
   "com.gu" %% "fezziwig" % "0.7",
   "com.typesafe.akka" %% "akka-agent" % "2.5.6",

--- a/test/codecs/CirceDecodersTest.scala
+++ b/test/codecs/CirceDecodersTest.scala
@@ -6,11 +6,8 @@ import io.circe.Json
 import io.circe.parser.parse
 import cats.syntax.either._
 import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
-<<<<<<< HEAD
+
 import models.{CheckBankAccountDetails, DirectDebitDetails}
-=======
-import com.gu.support.workers.model.PayPalPaymentFields
->>>>>>> [direct-debit-phase-3] Adding first approach to circe decoders
 import ophan.thrift.componentEvent.ComponentType.{AcquisitionsEpic, EnumUnknownComponentType}
 import ophan.thrift.event.AbTest
 import ophan.thrift.event.AcquisitionSource.GuardianWeb

--- a/test/codecs/CirceDecodersTest.scala
+++ b/test/codecs/CirceDecodersTest.scala
@@ -1,16 +1,15 @@
 package codecs
 
-import org.scalatest.{MustMatchers, WordSpec}
-import codecs.CirceDecoders.{abTestDecoder, decodePaymentFields, encodePaymentFields, ophanIdsCodec, referrerAcquisitionDataCodec}
-import io.circe.Json
-import io.circe.parser.parse
 import cats.syntax.either._
+import codecs.CirceDecoders._
 import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
-
-import models.{CheckBankAccountDetails, DirectDebitDetails}
+import com.gu.support.workers.model.DirectDebitPaymentFields
+import io.circe.parser.parse
+import models.CheckBankAccountDetails
 import ophan.thrift.componentEvent.ComponentType.{AcquisitionsEpic, EnumUnknownComponentType}
 import ophan.thrift.event.AbTest
 import ophan.thrift.event.AcquisitionSource.GuardianWeb
+import org.scalatest.{MustMatchers, WordSpec}
 class CirceDecodersTest extends WordSpec with MustMatchers {
 
   "referrerAcquisitionDataCodec" should {
@@ -116,10 +115,10 @@ class CirceDecodersTest extends WordSpec with MustMatchers {
 
       val parsedJson = parse(json).toOption.get
 
-      val directDebitData: DirectDebitDetails = DirectDebitDetails.codec.decodeJson(parsedJson).right.get
+      val directDebitData: DirectDebitPaymentFields = directDebitPaymentFieldsCodec.decodeJson(parsedJson).right.get
 
-      directDebitData.sortCode.value mustBe "121212"
-      directDebitData.accountNumber.value mustBe "12121212"
+      directDebitData.sortCode mustBe "121212"
+      directDebitData.accountNumber mustBe "12121212"
       directDebitData.accountHolderName mustBe "Example Name"
     }
   }

--- a/test/codecs/CirceDecodersTest.scala
+++ b/test/codecs/CirceDecodersTest.scala
@@ -1,12 +1,16 @@
 package codecs
 
 import org.scalatest.{MustMatchers, WordSpec}
-import codecs.CirceDecoders.{abTestDecoder, ophanIdsCodec, referrerAcquisitionDataCodec}
+import codecs.CirceDecoders.{abTestDecoder, decodePaymentFields, encodePaymentFields, ophanIdsCodec, referrerAcquisitionDataCodec}
 import io.circe.Json
 import io.circe.parser.parse
 import cats.syntax.either._
 import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
+<<<<<<< HEAD
 import models.{CheckBankAccountDetails, DirectDebitDetails}
+=======
+import com.gu.support.workers.model.PayPalPaymentFields
+>>>>>>> [direct-debit-phase-3] Adding first approach to circe decoders
 import ophan.thrift.componentEvent.ComponentType.{AcquisitionsEpic, EnumUnknownComponentType}
 import ophan.thrift.event.AbTest
 import ophan.thrift.event.AcquisitionSource.GuardianWeb
@@ -141,6 +145,5 @@ class CirceDecodersTest extends WordSpec with MustMatchers {
       checkBankAccountData.accountNumber.value mustBe "12121212"
     }
   }
-
 }
 


### PR DESCRIPTION
## Why are you doing this?

This PR adds the Direct Debit (phase 3) functionality to support frontend.

The different phases are:

1.- Added DirectDebit components to support-frontend (#448)
2.- Connect support-frontend with gocardless (#456)
3.- Integrate direct debit with step-functions/Zuora (#460, https://github.com/guardian/support-models/pull/29, https://github.com/guardian/support-models/pull/28 and https://github.com/guardian/support-workers/pull/91)
4.- Implement a GoCardLess provider.
5.- Apply styles to support frontend.
6.- Build an A/B Test


[**Trello Card**](https://trello.com/c/nOdfGQgS/254-direct-debit-as-a-payment-mechanism)

## Screenshots

![directdebit](https://user-images.githubusercontent.com/825398/35385413-19d830e6-01c0-11e8-8d25-f4a30d3dbc5c.gif)
