### PR TITLE
Garnett The Footer

### DIFF
--- a/assets/components/footer/footer.scss
+++ b/assets/components/footer/footer.scss
@@ -1,5 +1,5 @@
 .component-footer {
-  background-color: gu-colour(multimedia-support-4);
+  background-color: gu-colour(garnett-neutral-1);
   font-family: $gu-text-sans-web;
   font-size: 12px;
   line-height: 16px;

--- a/assets/pages/bundles-landing/bundlesLanding.scss
+++ b/assets/pages/bundles-landing/bundlesLanding.scss
@@ -957,8 +957,4 @@
   .component-double-heading--variant-a {
     margin-bottom: 0;
   }
-
-  .component-footer {
-    background-color: #121212;
-  }
 }


### PR DESCRIPTION
## Why are you doing this?

To make the footer fit the garnett palette.

## Changes

- Made the default footer background colour `garnett-neutral-1`.
- Stopped overriding the footer colour in the bundles landing page.

## Screenshots

![garnett-footer](https://user-images.githubusercontent.com/5131341/35291840-8ca1f536-0066-11e8-9b39-9c106616cd29.png)
