### PR TITLE
Rebuild The Circles Page - Part II - Patrons And Events

### DIFF
--- a/assets/components/otherProduct/otherProduct.jsx
+++ b/assets/components/otherProduct/otherProduct.jsx
@@ -5,6 +5,7 @@
 import React from 'react';
 
 import CtaLink from 'components/ctaLink/ctaLink';
+import GridImage from 'components/gridImage/gridImage';
 
 import { generateClassName } from 'helpers/utilities';
 
@@ -13,6 +14,8 @@ import { generateClassName } from 'helpers/utilities';
 
 type PropTypes = {
   modifierClass?: string,
+  gridImg: string,
+  imgAlt: string,
   heading: string,
   copy: string,
   ctaText: string,
@@ -28,6 +31,14 @@ export default function OtherProduct(props: PropTypes) {
 
   return (
     <div className={generateClassName('component-other-product', props.modifierClass)}>
+      <div className="component-other-product__image">
+        <GridImage
+          gridId={props.gridImg}
+          srcSizes={[1000, 500, 140]}
+          sizes="(max-width: 480px) 90vw, (max-width: 660px) 400px, 270px"
+          altText={props.imgAlt}
+        />
+      </div>
       <h2 className="component-other-product__heading">{props.heading}</h2>
       <p className="component-other-product__copy">{props.copy}</p>
       <CtaLink

--- a/assets/components/otherProduct/otherProduct.jsx
+++ b/assets/components/otherProduct/otherProduct.jsx
@@ -1,0 +1,49 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+import CtaLink from 'components/ctaLink/ctaLink';
+
+import { generateClassName } from 'helpers/utilities';
+
+
+// ----- Props ----- //
+
+type PropTypes = {
+  modifierClass?: string,
+  heading: string,
+  copy: string,
+  ctaText: string,
+  ctaUrl: string,
+  ctaId: string,
+  ctaAccessibilityHint: string,
+};
+
+
+// ----- Component ----- //
+
+export default function OtherProduct(props: PropTypes) {
+
+  return (
+    <div className={generateClassName('component-other-product', props.modifierClass)}>
+      <h2 className="component-other-product__heading">{props.heading}</h2>
+      <p className="component-other-product__copy">{props.copy}</p>
+      <CtaLink
+        text={props.ctaText}
+        url={props.ctaUrl}
+        ctaId={props.ctaId}
+        accessibilityHint={props.ctaAccessibilityHint}
+      />
+    </div>
+  );
+
+}
+
+
+// ----- Default Props ----- //
+
+OtherProduct.defaultProps = {
+  modifierClass: '',
+};

--- a/assets/components/patronsEvents/patronsEvents.jsx
+++ b/assets/components/patronsEvents/patronsEvents.jsx
@@ -16,6 +16,8 @@ export default function PatronsEvents() {
     <PageSection heading="Other ways you can support us" modifierClass="patrons-events">
       <OtherProduct
         modifierClass="patrons"
+        gridImg="newsroom"
+        imgAlt="newsroom"
         heading="Patrons"
         copy="The Patron tier is for those who want a deeper relationship with the Guardian and its journalists"
         ctaText="Find out more"
@@ -25,6 +27,8 @@ export default function PatronsEvents() {
       />
       <OtherProduct
         modifierClass="live-events"
+        gridImg="liveEvent"
+        imgAlt="live event"
         heading="Live events"
         copy="Meet Guardian journalists and readers at our events, debates, interviews and festivals"
         ctaText="Find out more"

--- a/assets/components/patronsEvents/patronsEvents.jsx
+++ b/assets/components/patronsEvents/patronsEvents.jsx
@@ -1,0 +1,38 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+import PageSection from 'components/pageSection/pageSection';
+import OtherProduct from 'components/otherProduct/otherProduct';
+
+
+// ----- Component ----- //
+
+export default function PatronsEvents() {
+
+  return (
+    <PageSection heading="Other ways you can support us" modifierClass="patrons-events">
+      <OtherProduct
+        modifierClass="patrons"
+        heading="Patrons"
+        copy="The Patron tier is for those who want a deeper relationship with the Guardian and its journalists"
+        ctaText="Find out more"
+        ctaUrl="https://membership.theguardian.com/patrons"
+        ctaId="patrons"
+        ctaAccessibilityHint="Find out more about becoming a Patron"
+      />
+      <OtherProduct
+        modifierClass="live-events"
+        heading="Live events"
+        copy="Meet Guardian journalists and readers at our events, debates, interviews and festivals"
+        ctaText="Find out more"
+        ctaUrl="https://membership.theguardian.com/events"
+        ctaId="live-events"
+        ctaAccessibilityHint="Find out more about Guardian live events"
+      />
+    </PageSection>
+  );
+
+}

--- a/assets/components/patronsEvents/patronsEvents.scss
+++ b/assets/components/patronsEvents/patronsEvents.scss
@@ -1,0 +1,69 @@
+.component-page-section--patrons-events {
+  color: gu-colour(garnett-neutral-1);
+  background-color: gu-colour(garnett-neutral-3);
+  padding-bottom: $gu-v-spacing * 4;
+
+  .component-page-section__heading {
+    font-family: $gu-egyptian-web;
+    font-size: 24px;
+    line-height: 1.17;
+    font-weight: bold;
+  }
+
+  .component-other-product {
+    display: inline-block;
+
+    @include mq($from: phablet) {
+      width: 300px;
+    }
+
+    @include mq($from: tablet, $until: desktop) {
+      margin: 0 25px;
+    }
+  }
+
+  .component-other-product--patrons {
+    @include mq($from: phablet) {
+      margin-right: $gu-h-spacing;
+    }
+  }
+
+  .component-other-product__heading {
+    font-family: $gu-egyptian-web;
+    font-size: 36px;
+    line-height: 1;
+    font-weight: bold;
+  }
+
+  .component-other-product__copy {
+    margin-bottom: $gu-v-spacing * 2;
+    font-size: 16px;
+    line-height: 1.25;
+  }
+
+  .component-cta-link {
+    background: transparent;
+    color: gu-colour(garnett-neutral-1);
+    border: 1px solid gu-colour(garnett-neutral-1);
+    height: 54px;
+    line-height: 54px;
+    padding: 0 30px 0 25px;
+    transition: background-color .3s;
+
+    &:hover {
+      background-color: gu-colour(garnett-neutral-1);
+      color: #fff;
+
+      .svg-arrow-right-straight {
+        fill: #fff;
+      }
+    }
+  }
+
+  .svg-arrow-right-straight {
+    fill: gu-colour(garnett-neutral-1);
+    height: 35%;
+    top: 17px;
+    right: 13px;
+  }
+}

--- a/assets/components/patronsEvents/patronsEvents.scss
+++ b/assets/components/patronsEvents/patronsEvents.scss
@@ -3,29 +3,78 @@
   background-color: gu-colour(garnett-neutral-3);
   padding-bottom: $gu-v-spacing * 4;
 
+  .component-page-section__header {
+    @include mq($from: desktop) {
+      position: relative;
+
+      &:after {
+        border-right: 1px solid gu-colour(garnett-neutral-4);
+        content: "";
+        display: inline-block;
+        height: 36px;
+        position: absolute;
+        top: 0;
+        right: 0;
+      }
+    }
+  }
+
   .component-page-section__heading {
     font-family: $gu-egyptian-web;
     font-size: 24px;
     line-height: 1.17;
     font-weight: bold;
+
+    @include mq($until: phablet) {
+      width: 70%;
+    }
+
+    @include mq($from: phablet, $until: desktop) {
+      width: 40%;
+    }
   }
 
   .component-other-product {
     display: inline-block;
+    padding-top: $gu-v-spacing * 3;
 
     @include mq($from: phablet) {
       width: 300px;
-    }
-
-    @include mq($from: tablet, $until: desktop) {
-      margin: 0 25px;
+      padding-left: $gu-h-spacing / 2;
     }
   }
 
   .component-other-product--patrons {
     @include mq($from: phablet) {
-      margin-right: $gu-h-spacing;
+      padding-right: $gu-h-spacing;
+      padding-left: $gu-h-spacing;
     }
+
+    .component-grid-image {
+      margin-left: -90px;
+    }
+  }
+
+  .component-other-product--live-events {
+    @include mq($from: phablet) {
+      border-left: 1px solid gu-colour(garnett-neutral-4);
+    }
+
+    .component-grid-image {
+      margin-left: -120px;
+    }
+  }
+
+  .component-other-product__image {
+    overflow: hidden;
+    width: 165px;
+    height: 165px;
+    border-radius: 50%;
+    margin-bottom: $gu-v-spacing;
+  }
+
+  .component-grid-image {
+    height: 100%;
   }
 
   .component-other-product__heading {
@@ -33,12 +82,17 @@
     font-size: 36px;
     line-height: 1;
     font-weight: bold;
+    margin-bottom: $gu-v-spacing;
   }
 
   .component-other-product__copy {
     margin-bottom: $gu-v-spacing * 2;
     font-size: 16px;
     line-height: 1.25;
+
+    @include mq($until: phablet) {
+      width: 85%;
+    }
   }
 
   .component-cta-link {

--- a/assets/helpers/theGrid.js
+++ b/assets/helpers/theGrid.js
@@ -12,6 +12,7 @@ export const GRID_DOMAIN = 'https://media.guim.co.uk';
 export const imageCatalogue: {
   [string]: string,
 } = {
+  newsroom: '8caacf301dd036a2bbb1b458cf68b637d3c55e48/0_0_1140_683',
   guardianObserverOffice: '137d6b217a27acddf85512657d04f6490b9e0bb1/1638_0_3571_2009',
   liveEvent: '5f18c6428e9f31394b14215fe3c395b8f7b4238a/500_386_2373_1335',
   digitalBundle: '7c7b9580924281914e82dc163bf716ede52daa8b/0_0_600_360',

--- a/assets/pages/support-landing/supportLanding.jsx
+++ b/assets/pages/support-landing/supportLanding.jsx
@@ -9,6 +9,7 @@ import Footer from 'components/footer/footer';
 import CirclesIntroduction from 'components/circlesIntroduction/circlesIntroduction';
 import ThreeSubscriptions from 'components/threeSubscriptions/threeSubscriptions';
 import WhySupport from 'components/whySupport/whySupport';
+import PatronsEvents from 'components/patronsEvents/patronsEvents';
 
 import { renderPage } from 'helpers/render';
 
@@ -21,6 +22,7 @@ const content = (
     <CirclesIntroduction />
     <ThreeSubscriptions />
     <WhySupport />
+    <PatronsEvents />
     <Footer />
   </div>
 );

--- a/assets/stylesheets/main.scss
+++ b/assets/stylesheets/main.scss
@@ -32,6 +32,7 @@
 @import '../components/paymentAmount/paymentAmount';
 @import '../components/radioToggle/radioToggle';
 @import '../components/pageSection/pageSection';
+@import '../components/patronsEvents/patronsEvents';
 @import '../components/paymentButtons/payPalContributionButton/payPalContributionButton';
 @import '../components/paymentButtons/payPalExpressButton/payPalExpressButton';
 @import '../components/paymentButtons/stripePopUpButton/stripePopUpButton';


### PR DESCRIPTION
## Why are you doing this?

Creates a component for the Patrons and Events section, and adds it to the Support Landing Page.

**Note:** I've opened this PR against the branch used in #459, so that the diff makes sense, but once that goes in I'll switch to PRing this against master.

cc @JustinPinner 

[**Trello Card**](https://trello.com/c/Zanpiip9/1175-support-circles)

## Changes

- Created an OtherProduct component, to show the cards for Patrons and Events.
- Created a PatronsEvents component, to drop into any page as a self-contained section.
- Added the Patrons image (the one used [on the Patrons page](https://membership.theguardian.com/patrons) from the Grid.
- Added the new PatronsEvents component to the Support Landing page.

## Screenshots

![patrons-events-desktop](https://user-images.githubusercontent.com/5131341/35292561-cb710fde-0068-11e8-8cc6-4c6404592ad3.png)

![patrons-events-mobile](https://user-images.githubusercontent.com/5131341/35292567-cec97c7a-0068-11e8-80c8-d755f2b3ba33.png)
