### PR TITLE
Garnett - The Header Lines

### DIFF
--- a/assets/components/headers/simpleHeader/simpleHeader.scss
+++ b/assets/components/headers/simpleHeader/simpleHeader.scss
@@ -1,36 +1,44 @@
 .component-simple-header {
   background-color: gu-colour(nav-background-colour);
 
-  .component-simple-header__link {
-    float: right;
-    height: 100%;
-  }
-
   .svg-guardian-logo {
     height: 100%;
   }
 
-  .component-simple-header__content {
-    padding: ($gu-v-spacing / 2) 0 $gu-v-spacing;
-    height: 68px;
+  // The quadruple lines under the header.
+  &:after {
+    @include multiline(4, gu-colour(garnett-neutral-4));
+    background-color: #fff;
+    display: block;
+    content: '';
+  }
+}
 
-    @include mq($from: mobileMedium) {
-      height: 78px;
-    }
+.component-simple-header__link {
+  float: right;
+  height: 100%;
+}
 
-    @include mq($from: mobileLandscape) {
-      height: 85px;
-      padding-left: $gu-h-spacing;
-      padding-right: $gu-h-spacing;
-    }
+.component-simple-header__content {
+  padding: ($gu-v-spacing / 2) 0 $gu-v-spacing;
+  height: 68px;
 
-    @include mq($from: phablet) {
-      padding-left: 0;
-      padding-right: 0;
-    }
+  @include mq($from: mobileMedium) {
+    height: 78px;
+  }
 
-    @include mq($from: tablet) {
-      height: 104px;
-    }
+  @include mq($from: mobileLandscape) {
+    height: 85px;
+    padding-left: $gu-h-spacing;
+    padding-right: $gu-h-spacing;
+  }
+
+  @include mq($from: phablet) {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
+  @include mq($from: tablet) {
+    height: 104px;
   }
 }

--- a/assets/stylesheets/gu-sass/helpers.scss
+++ b/assets/stylesheets/gu-sass/helpers.scss
@@ -4,50 +4,50 @@
 //
 //
 @function svg-url($svg){
+  //
+  //  Chunk up string in order to avoid
+  //  "stack level too deep" error
+  //
+  $encoded:'';
+  $slice: 2000;
+  $index: 0;
+  $loops: ceil(str-length($svg)/$slice);
+  @for $i from 1 through $loops {
+    $chunk: str-slice($svg, $index, $index + $slice - 1);
     //
-    //  Chunk up string in order to avoid
-    //  "stack level too deep" error
+    //   Encode (may need a few extra replacements)
     //
-    $encoded:'';
-    $slice: 2000;
-    $index: 0;
-    $loops: ceil(str-length($svg)/$slice);
-    @for $i from 1 through $loops {
-        $chunk: str-slice($svg, $index, $index + $slice - 1);
-        //
-        //   Encode (may need a few extra replacements)
-        //
-        $chunk: str-replace($chunk,'"','\'');
-        $chunk: str-replace($chunk,'<','%3C');
-        $chunk: str-replace($chunk,'>','%3E');
-        $chunk: str-replace($chunk,'&','%26');
-        $chunk: str-replace($chunk,'#','%23');
-        $encoded: #{$encoded}#{$chunk};
-        $index: $index + $slice;
-    }
-    @return url("data:image/svg+xml;charset=utf8,#{$encoded}");
+    $chunk: str-replace($chunk,'"','\'');
+    $chunk: str-replace($chunk,'<','%3C');
+    $chunk: str-replace($chunk,'>','%3E');
+    $chunk: str-replace($chunk,'&','%26');
+    $chunk: str-replace($chunk,'#','%23');
+    $encoded: #{$encoded}#{$chunk};
+    $index: $index + $slice;
+  }
+  @return url("data:image/svg+xml;charset=utf8,#{$encoded}");
 }
 
 //  Helper function to replace characters in a string
 @function str-replace($string, $search, $replace: '') {
-    $index: str-index($string, $search);
-    @if $index {
-        @return str-slice($string, 1, $index - 1) + $replace +
-            str-replace(str-slice($string, $index +
-            str-length($search)), $search, $replace);
-    }
-    @return $string;
+  $index: str-index($string, $search);
+  @if $index {
+    @return str-slice($string, 1, $index - 1) + $replace +
+      str-replace(str-slice($string, $index +
+      str-length($search)), $search, $replace);
+  }
+  @return $string;
 }
 
 // Helper to create the multilines used in e.g. the header.
 // $number - the number of lines
 // $colour - the colour of the lines
 @mixin multiline($number, $colour, $position: bottom) {
-    $bgSize: $number * 4 - 3;
+  $bgSize: $number * 4 - 3;
 
-    background-image: repeating-linear-gradient(to bottom, $colour, $colour 1px, transparent 1px, transparent 4px);
-    background-repeat: repeat-x;
-    background-position: $position;
-    background-size: 1px #{$bgSize}px;
-    height: #{$bgSize}px;
+  background-image: repeating-linear-gradient(to bottom, $colour, $colour 1px, transparent 1px, transparent 4px);
+  background-repeat: repeat-x;
+  background-position: $position;
+  background-size: 1px #{$bgSize}px;
+  height: #{$bgSize}px;
 }

--- a/assets/stylesheets/gu-sass/helpers.scss
+++ b/assets/stylesheets/gu-sass/helpers.scss
@@ -38,3 +38,16 @@
     }
     @return $string;
 }
+
+// Helper to create the multilines used in e.g. the header.
+// $number - the number of lines
+// $colour - the colour of the lines
+@mixin multiline($number, $colour, $position: bottom) {
+    $bgSize: $number * 4 - 3;
+
+    background-image: repeating-linear-gradient(to bottom, $colour, $colour 1px, transparent 1px, transparent 4px);
+    background-repeat: repeat-x;
+    background-position: $position;
+    background-size: 1px #{$bgSize}px;
+    height: #{$bgSize}px;
+}


### PR DESCRIPTION
## Why are you doing this?

This brings the multilines to support-frontend, to bring it inline with dotcom. The technique I've applied here is a lightly modified version of the one used in frontend, which uses a [mixin](https://github.com/guardian/frontend/blob/a3a1559c870c5f7b16985b8513159f72d1db958a/static/src/stylesheets/_mixins.scss#L278) for the lines. This applies to the header across the site.

cc @JustinPinner 

## Changes

- Created a SASS mixin for the multilines.
- Flattened the header CSS (the diff is confusing, but I've just moved the nested styles out into their own rules).
- Added the multilines to the header.

## Screenshots

**Before:**

![lines-before](https://user-images.githubusercontent.com/5131341/35330933-56cf6abe-00fd-11e8-9cba-193823af8731.png)

**After:**

![lines-after](https://user-images.githubusercontent.com/5131341/35330938-5b9d2da6-00fd-11e8-81cd-c1f9af96dd88.png)

**US Landing Page:**

![lines-after-alt](https://user-images.githubusercontent.com/5131341/35330946-649f5a50-00fd-11e8-94b9-ca942c0ff644.png)
