### PR TITLE
Rebuild The Circles Page - Part III - Ready To Support

### DIFF
--- a/assets/components/patronsEvents/patronsEvents.scss
+++ b/assets/components/patronsEvents/patronsEvents.scss
@@ -3,6 +3,13 @@
   background-color: gu-colour(garnett-neutral-3);
   padding-bottom: $gu-v-spacing * 4;
 
+  &:before {
+    @include multiline(4, gu-colour(garnett-neutral-4));
+    background-color: #fff;
+    display: block;
+    content: '';
+  }
+
   .component-page-section__header {
     @include mq($from: desktop) {
       position: relative;

--- a/assets/components/readyToSupport/readyToSupport.jsx
+++ b/assets/components/readyToSupport/readyToSupport.jsx
@@ -21,9 +21,10 @@ export default function ReadyToSupport(props: PropTypes) {
 
   return (
     <section className="component-ready-to-support">
-      <div className="component-ready-to-support__content">
+      <div className="component-ready-to-support__content gu-content-margin">
         <h1 className="component-ready-to-support__heading">
-          Ready to support The&nbsp;Guardian
+          <span className="component-ready-to-support__heading-line">Ready to support</span>
+          <span className="component-ready-to-support__heading-line">The&nbsp;Guardian?</span>
         </h1>
         <CtaLink
           text="See supporter options"

--- a/assets/components/readyToSupport/readyToSupport.jsx
+++ b/assets/components/readyToSupport/readyToSupport.jsx
@@ -1,0 +1,39 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+import CtaLink from 'components/ctaLink/ctaLink';
+import { SvgChevronUp } from 'components/svg/svg';
+
+
+// ----- Props ----- //
+
+type PropTypes = {
+  ctaUrl: string,
+};
+
+
+// ----- Component ----- //
+
+export default function ReadyToSupport(props: PropTypes) {
+
+  return (
+    <section className="component-ready-to-support">
+      <div className="component-ready-to-support__content">
+        <h1 className="component-ready-to-support__heading">
+          Ready to support The&nbsp;Guardian
+        </h1>
+        <CtaLink
+          text="See supporter options"
+          url={props.ctaUrl}
+          ctaId="see-supporter-options"
+          accessibilityHint="See the options for becoming a supporter"
+          svg={<SvgChevronUp />}
+        />
+      </div>
+    </section>
+  );
+
+}

--- a/assets/components/readyToSupport/readyToSupport.scss
+++ b/assets/components/readyToSupport/readyToSupport.scss
@@ -1,0 +1,82 @@
+.component-ready-to-support {
+  border-top: 1px solid gu-colour(garnett-neutral-4);
+}
+
+.component-ready-to-support__content {
+  padding-bottom: $gu-v-spacing * 4;
+  position: relative;
+
+  @include mq($from: desktop) {
+    padding-left: 260px;
+  }
+
+  // The floating semicircle.
+  &:before {
+    content: "";
+    position: absolute;
+    right: 10px;
+    background-color: gu-colour(lifestyle-garnett-main-1);
+    border-bottom-left-radius: 600px;
+    border-bottom-right-radius: 600px;
+    width: 50px;
+    height: 25px;
+
+    @include mq($from: mobileLandscape) {
+      right: 20px;
+    }
+
+    @include mq($from: tablet) {
+      height: 30px;
+      width: 60px;
+    }
+
+    @include mq($from: desktop) {
+      left: 180px;
+    }
+  }
+}
+
+.component-ready-to-support__heading {
+  font-size: 36px;
+  line-height: 1;
+  color: gu-colour(garnett-neutral-1);
+  font-family: $gu-egyptian-web;
+  font-weight: bold;
+  margin-bottom: $gu-v-spacing * 2;
+
+  @include mq($until: mobileMedium) {
+    width: 80%;
+  }
+
+  @include mq($from: desktop) {
+    font-size: 56px;
+    margin-bottom: $gu-v-spacing * 5;
+  }
+}
+
+.component-ready-to-support__heading-line {
+  display: block;
+}
+
+.component-cta-link--see-supporter-options {
+  height: 54px;
+  padding: 0 30px;
+  font-size: 14px;
+  line-height: 54px;
+  background-color: gu-colour(lifestyle-garnett-main-1);
+  transition: background-color .3s;
+
+  @include mq($from: tablet) {
+    width: 500px;
+  }
+
+  &:hover {
+    background-color: darken(gu-colour(lifestyle-garnett-main-1), 5%);
+  }
+
+  .svg-chevron-up {
+    height: 70%;
+    top: 8px;
+    right: 15px;
+  }
+}

--- a/assets/pages/support-landing/supportLanding.jsx
+++ b/assets/pages/support-landing/supportLanding.jsx
@@ -9,6 +9,7 @@ import Footer from 'components/footer/footer';
 import CirclesIntroduction from 'components/circlesIntroduction/circlesIntroduction';
 import ThreeSubscriptions from 'components/threeSubscriptions/threeSubscriptions';
 import WhySupport from 'components/whySupport/whySupport';
+import ReadyToSupport from 'components/readyToSupport/readyToSupport';
 import PatronsEvents from 'components/patronsEvents/patronsEvents';
 
 import { renderPage } from 'helpers/render';
@@ -22,6 +23,7 @@ const content = (
     <CirclesIntroduction />
     <ThreeSubscriptions />
     <WhySupport />
+    <ReadyToSupport ctaUrl="#" />
     <PatronsEvents />
     <Footer />
   </div>

--- a/assets/stylesheets/main.scss
+++ b/assets/stylesheets/main.scss
@@ -38,6 +38,7 @@
 @import '../components/paymentButtons/stripePopUpButton/stripePopUpButton';
 @import '../components/paymentButtons/directDebitPopUpButton/directDebitPopUpButton';
 @import '../components/legal/termsPrivacy/termsPrivacy';
+@import '../components/readyToSupport/readyToSupport';
 @import '../components/signout/signout';
 @import '../components/textInput/textInput';
 @import '../components/testUserBanner/testUserBanner';


### PR DESCRIPTION
## Why are you doing this?

Creates a component for the "Ready To Support?" section, and adds it to the Support Landing Page.

[**Trello Card**](https://trello.com/c/Zanpiip9/1175-support-circles)

cc @JustinPinner 

## Changes

- Added a multiline to the top of the Patrons and Events section.
- Created a ReadyToSupport shared component.
- Dropped the component into the support landing page.

## Screenshots

**Desktop:**

![ready-support-desktop](https://user-images.githubusercontent.com/5131341/35344460-189f63a2-0125-11e8-8f3f-fc82c410214a.png)

**Mobile:**

![ready-support-mobile](https://user-images.githubusercontent.com/5131341/35344467-1dd809aa-0125-11e8-9e75-6c1e0e4f649d.png)
