### PR TITLE
Add new dates and promo codes for the January flash sale

### DIFF
--- a/assets/pages/bundles-landing/components/stackedBundle.jsx
+++ b/assets/pages/bundles-landing/components/stackedBundle.jsx
@@ -22,7 +22,7 @@ import type { Campaign } from 'helpers/tracking/acquisitions';
 import type { Participations } from 'helpers/abTests/abtest';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 
-import { getDigiPackItems, getPaperItemsForStackedBundle, getPaperDigitalItemsForStackedBundle, inOfferPeriod } from '../helpers/flashSale';
+import { getDigiPackItems, getPaperItems, getPaperDigitalItems } from '../helpers/flashSale';
 
 import {
   changeContribType,
@@ -129,15 +129,13 @@ const monthlyContribCopy: ContribAttrs = {
 };
 
 
-const componentBundleModifierClass = `component-bundle--stacked ${inOfferPeriod() ? 'component-bundle--flash-sale' : ''}`;
-
 const digitalCopy: SubscribeAttrs = {
   heading: 'Digital subscription',
   subheading: '£11.99/month',
   listItems: getDigiPackItems(),
   ctaText: 'Start your 14 day trial',
   ctaId: 'digital-sub',
-  modifierClass: `digital ${componentBundleModifierClass}`,
+  modifierClass: 'digital component-bundle--stacked',
   ctaLink: 'https://subscribe.theguardian.com/uk/digital',
   ctaAccessibilityHint: 'The Guardian\'s digital subscription is available for eleven pounds and ninety nine pence per month. Find out how to sign up for a free trial.',
 };
@@ -145,10 +143,10 @@ const digitalCopy: SubscribeAttrs = {
 const paperCopy: SubscribeAttrs = {
   heading: 'Paper subscription',
   subheading: 'from £10.79/month',
-  listItems: getPaperItemsForStackedBundle(),
+  listItems: getPaperItems(),
   ctaText: 'Get a paper subscription',
   ctaId: 'paper-sub structure-test',
-  modifierClass: `paper ${componentBundleModifierClass}`,
+  modifierClass: 'paper component-bundle--stacked',
   ctaLink: 'https://subscribe.theguardian.com/collection/paper',
   ctaAccessibilityHint: 'Proceed to paper subscription options, starting at ten pounds seventy nine pence per month.',
 };
@@ -156,10 +154,10 @@ const paperCopy: SubscribeAttrs = {
 const paperDigitalCopy: SubscribeAttrs = {
   heading: 'Paper+digital',
   subheading: 'from £22.06/month',
-  listItems: getPaperDigitalItemsForStackedBundle(),
+  listItems: getPaperDigitalItems(),
   ctaText: 'Get a paper + digital subscription',
   ctaId: 'paper-digi-sub',
-  modifierClass: `paperDigital ${componentBundleModifierClass}`,
+  modifierClass: 'paperDigital component-bundle--stacked',
   ctaLink: 'https://subscribe.theguardian.com/collection/paper-digital',
   ctaAccessibilityHint: 'Proceed to choose which days you would like to regularly receive the newspaper in conjunction with a digital subscription',
 };

--- a/assets/pages/bundles-landing/helpers/externalLinks.js
+++ b/assets/pages/bundles-landing/helpers/externalLinks.js
@@ -4,7 +4,7 @@
 
 import type { Campaign } from 'helpers/tracking/acquisitions';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
-import { inOfferPeriod } from './flashSale';
+import { getPromoCode } from './flashSale';
 
 // ----- Types ----- //
 
@@ -33,9 +33,9 @@ const memUrls: {
 };
 
 const defaultPromos: PromoCodes = {
-  digital: 'p/DXX83X',
-  paper: 'p/GXX83P',
-  paperDig: 'p/GXX83X',
+  digital: getPromoCode('digital', 'p/DXX83X'),
+  paper: getPromoCode('paper', 'p/GXX83P'),
+  paperDig: getPromoCode('paperAndDigital', 'p/GXX83X'),
 };
 
 const customPromos : {
@@ -86,11 +86,6 @@ const customPromos : {
     paper: 'p/NBANJUSTONE',
     paperDig: 'p/NDBANJUSTONE',
   },
-  flash_sale: {
-    digital: 'p/DBR80H',
-    paper: 'p/GBQ80N',
-    paperDig: 'p/GBQ80O',
-  },
 };
 
 
@@ -138,9 +133,9 @@ function getSubsLinks(
   otherQueryParams: Array<[string, string]>,
   referrerAcquisitionData: ReferrerAcquisitionData,
 ): SubsUrls {
-  if ((campaign && customPromos[campaign]) || (!campaign && inOfferPeriod())) {
+  if ((campaign && customPromos[campaign])) {
     return buildSubsUrls(
-      customPromos[campaign || 'flash_sale'],
+      customPromos[campaign],
       intCmp,
       otherQueryParams,
       referrerAcquisitionData,

--- a/assets/pages/bundles-landing/helpers/flashSale.js
+++ b/assets/pages/bundles-landing/helpers/flashSale.js
@@ -17,7 +17,8 @@ function inOfferPeriod(product: ProductType): boolean {
   };
 
   const now = Date.now();
-  return (now > startTime && now < endTime && included[product]) || (included[product] && getQueryParameter('flash_sale') === 'true') || false;
+  return (now > startTime && now < endTime && included[product]) ||
+    (included[product] && getQueryParameter('flash_sale') === 'true');
 }
 
 // Promo codes

--- a/assets/pages/bundles-landing/helpers/flashSale.js
+++ b/assets/pages/bundles-landing/helpers/flashSale.js
@@ -2,20 +2,42 @@
 
 import { getQueryParameter } from 'helpers/url';
 
-function inOfferPeriod(): boolean {
-  const now = Date.now();
-  // Days are 1 based, months are 0 based
-  // The offer is valid between 19th December 2017 & 3rd January 2018
-  const startTime = new Date(2017, 11, 19, 0, 0).getTime();
-  const endTime = new Date(2018, 0, 4, 0, 0).getTime();
+type ProductType = 'digital' | 'paper' | 'paperAndDigital';
 
-  return (now > startTime && now < endTime) || getQueryParameter('flash_sale') === 'true' || false;
+function inOfferPeriod(product: ProductType): boolean {
+  // Days are 1 based, months are 0 based
+  const startTime = new Date(2018, 0, 29, 0, 0).getTime(); // 29th Jan 2018
+  const endTime = new Date(2018, 1, 25, 0, 0).getTime(); // 25th Feb 2018
+
+  // The current sale is paper & paper + digital only, digital is unaffected
+  const included = {
+    digital: false,
+    paper: true,
+    paperAndDigital: true,
+  };
+
+  const now = Date.now();
+  return (now > startTime && now < endTime && included[product]) || (included[product] && getQueryParameter('flash_sale') === 'true') || false;
 }
 
+// Promo codes
+const promoCodes = {
+  digital: 'p/DXX83X',
+  paper: 'p/GRB80P',
+  paperAndDigital: 'p/GRB80X',
+};
+
+function getPromoCode(product: ProductType, defaultCode: string) {
+  if (inOfferPeriod(product)) {
+    return promoCodes[product];
+  }
+  return defaultCode;
+}
+
+// Copy text
 const offerItem = { heading: 'Subscribe today and save 50% for your first three months' };
 const saveMoneyOnRetailPrice = { heading: 'Save money on the retail price' };
 const getAllBenefits = { heading: 'Get all the benefits of a digital subscription' };
-const getAllBenefitsWithPaperPlus = { heading: 'Get all the benefits of a digital subscription with paper+digital' };
 const chooseYourPackage = {
   heading: 'Choose your package and delivery method',
   text: 'Everyday, Sixday, Weekend and Sunday; redeem paper vouchers or get home delivery',
@@ -33,31 +55,29 @@ function getDigiPackItems() {
     },
   ];
 
-  if (inOfferPeriod()) {
+  if (inOfferPeriod('digital')) {
     return [offerItem, ...items];
   }
   return items;
 }
 
 function getPaperItems() {
-  return [chooseYourPackage, saveMoneyOnRetailPrice, getAllBenefitsWithPaperPlus];
-}
-
-// In the stacked bundle, paper and paper+digital are in separate boxes.
-// So in the paper only box, we don't mention the digital benefits.
-// And in the paper+digital box, we do
-function getPaperItemsForStackedBundle() {
+  if (inOfferPeriod('paper')) {
+    return [offerItem, chooseYourPackage];
+  }
   return [chooseYourPackage, saveMoneyOnRetailPrice];
 }
 
-function getPaperDigitalItemsForStackedBundle() {
+function getPaperDigitalItems() {
+  if (inOfferPeriod('paperAndDigital')) {
+    return [offerItem, chooseYourPackage, getAllBenefits];
+  }
   return [chooseYourPackage, saveMoneyOnRetailPrice, getAllBenefits];
 }
 
 export {
-  inOfferPeriod,
   getDigiPackItems,
   getPaperItems,
-  getPaperItemsForStackedBundle,
-  getPaperDigitalItemsForStackedBundle,
+  getPaperDigitalItems,
+  getPromoCode,
 };


### PR DESCRIPTION
## Why are you doing this?

Marketing want to run another 'Flash sale' to coincide with the launch of the tabloid format.

This PR contains the new dates, promo codes and copy for the sale.

I've also refactored the code slightly to make it easier to deal with sales where not all products are included.

[**Trello Card**](https://trello.com/c/FLWKXsML/1248-january-flash-sale-on-subs-support)

## Screenshots
### Outside the offer period:
![screen shot 2018-01-25 at 16 56 13](https://user-images.githubusercontent.com/181371/35401194-bcdeb17c-01f0-11e8-915c-007ad8072956.png)

### During the offer period:
![screen shot 2018-01-25 at 16 56 27](https://user-images.githubusercontent.com/181371/35401193-bcb6a808-01f0-11e8-8b7b-5e95fcf1b412.png)
