### PR TITLE
Better Error Messages

### DIFF
--- a/assets/components/directDebit/directDebitForm/directDebitForm.jsx
+++ b/assets/components/directDebit/directDebitForm/directDebitForm.jsx
@@ -73,67 +73,62 @@ function mapDispatchToProps(dispatch) {
 
 // ----- Component ----- //
 
-const DirectDebitForm = (props: PropTypes) => {
-  let errorMessage = null;
-  if (props.formError) {
-    errorMessage = <ErrorMessage message={props.formError} />;
-  }
-  return (
-    <div className="component-direct-debit-form">
-      <SortCodeInput
-        onChange={props.updateSortCode}
-        value={props.sortCode}
-      />
+const DirectDebitForm = (props: PropTypes) => (
+  <div className="component-direct-debit-form">
+    <SortCodeInput
+      onChange={props.updateSortCode}
+      value={props.sortCode}
+    />
 
-      <AccountNumberInput
-        onChange={props.updateAccountNumber}
-        value={props.accountNumber}
-      />
+    <AccountNumberInput
+      onChange={props.updateAccountNumber}
+      value={props.accountNumber}
+    />
 
-      <AccountHolderNameInput
-        onChange={props.updateAccountHolderName}
-        value={props.accountHolderName}
-      />
+    <AccountHolderNameInput
+      onChange={props.updateAccountHolderName}
+      value={props.accountHolderName}
+    />
 
-      <ConfirmationInput
-        onChange={props.updateAccountHolderConfirmation}
-        checked={props.accountHolderConfirmation}
-      />
+    <ConfirmationInput
+      onChange={props.updateAccountHolderConfirmation}
+      checked={props.accountHolderConfirmation}
+    />
 
-      {errorMessage}
-      <button
-        id="qa-pay-with-direct-debit-pay"
-        className="component-direct-debit-form__pay-button"
-        onClick={() => props.payDirectDebitClicked(props.callback)}
-      >
-        Pay with Direct Debit
-      </button>
+    <ErrorMessage message={props.formError} />
+    <button
+      id="qa-pay-with-direct-debit-pay"
+      className="component-direct-debit-form__pay-button"
+      onClick={() => props.payDirectDebitClicked(props.callback)}
+    >
+      Pay with Direct Debit
+    </button>
 
-      <div className="component-direct-debit-form__legal__title">
-        Advance notice
-      </div>
+    <div className="component-direct-debit-form__legal__title">
+      Advance notice
+    </div>
 
-      <div className="component-direct-debit-form__legal__content">
-        <p>The details of your Direct Debit instruction including payment schedule, due date,
-          frequency and amount will be sent to you within three working days. All the normal
-          Direct Debit safeguards and guarantees apply.
-        </p>
-        <p>
-          Your payments are protected by the&nbsp;
-          <a target="_blank" rel="noopener noreferrer" href="https://www.directdebit.co.uk/DirectDebitExplained/pages/directdebitguarantee.aspx">
-            Direct Debit guarantee
-          </a>.
-        </p>
-        <div>
-          <div>The Guardian, Unit 16, Coalfield Way, Ashby Park, Ashby-De-La-Zouch, LE65 1JT
-            United Kingdom
-          </div>
-          <div><a href="tel:+443303336767">Tel: +44 (0) 330 333 6767</a></div>
-          <div><a href="mailto:support@theguardian.com">support@theguardian.com</a></div>
+    <div className="component-direct-debit-form__legal__content">
+      <p>The details of your Direct Debit instruction including payment schedule, due date,
+        frequency and amount will be sent to you within three working days. All the normal
+        Direct Debit safeguards and guarantees apply.
+      </p>
+      <p>
+        Your payments are protected by the&nbsp;
+        <a target="_blank" rel="noopener noreferrer" href="https://www.directdebit.co.uk/DirectDebitExplained/pages/directdebitguarantee.aspx">
+          Direct Debit guarantee
+        </a>.
+      </p>
+      <div>
+        <div>The Guardian, Unit 16, Coalfield Way, Ashby Park, Ashby-De-La-Zouch, LE65 1JT
+          United Kingdom
         </div>
+        <div><a href="tel:+443303336767">Tel: +44 (0) 330 333 6767</a></div>
+        <div><a href="mailto:support@theguardian.com">support@theguardian.com</a></div>
       </div>
-    </div>);
-};
+    </div>
+  </div>
+);
 
 
 // ----- Auxiliary components ----- //

--- a/assets/components/errorMessage/errorMessage.jsx
+++ b/assets/components/errorMessage/errorMessage.jsx
@@ -9,7 +9,7 @@ import { SvgExclamation } from 'components/svg/svg';
 // ---- Types ----- //
 
 type PropTypes = {
-  error?: boolean,
+  showError?: boolean,
   message: ?string,
 };
 
@@ -18,7 +18,7 @@ type PropTypes = {
 
 export default function ErrorMessage(props: PropTypes) {
 
-  if (props.error && props.message) {
+  if (props.showError && props.message) {
 
     return (
       <div className="component-error-message">
@@ -36,5 +36,5 @@ export default function ErrorMessage(props: PropTypes) {
 // ----- Default Props ----- //
 
 ErrorMessage.defaultProps = {
-  error: true,
+  showError: true,
 };

--- a/assets/components/errorMessage/errorMessage.jsx
+++ b/assets/components/errorMessage/errorMessage.jsx
@@ -9,17 +9,32 @@ import { SvgExclamation } from 'components/svg/svg';
 // ---- Types ----- //
 
 type PropTypes = {
-  message: string,
+  error?: boolean,
+  message: ?string,
 };
 
 
 // ----- Component ----- //
 
-
 export default function ErrorMessage(props: PropTypes) {
-  return (
-    <div className="component-error-message">
-      <SvgExclamation /><span>{props.message}</span>
-    </div>
-  );
+
+  if (props.error && props.message) {
+
+    return (
+      <div className="component-error-message">
+        <SvgExclamation /><span>{props.message}</span>
+      </div>
+    );
+
+  }
+
+  return null;
+
 }
+
+
+// ----- Default Props ----- //
+
+ErrorMessage.defaultProps = {
+  error: true,
+};

--- a/assets/components/errorMessage/errorMessage.jsx
+++ b/assets/components/errorMessage/errorMessage.jsx
@@ -22,7 +22,7 @@ export default function ErrorMessage(props: PropTypes) {
 
     return (
       <div className="component-error-message">
-        <SvgExclamation /><span>{props.message}</span>
+        <SvgExclamation /><span className="component-error-message__message">{props.message}</span>
       </div>
     );
 

--- a/assets/components/errorMessage/errorMessage.scss
+++ b/assets/components/errorMessage/errorMessage.scss
@@ -20,7 +20,7 @@
     width: 404px;
   }
 
-  svg {
+  .svg-exclamation {
     position: absolute;
     height: 16px;
     fill: #fff;
@@ -28,10 +28,11 @@
     transform: translateY(-50%);
   }
 
-  span {
-    position: absolute;
-    top: 50%;
-    transform: translateY(-50%);
-    left: 10%;
-  }
+}
+
+.component-error-message__message {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  left: 10%;
 }

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/contributionSelectionNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/contributionSelectionNewDesign.jsx
@@ -55,27 +55,10 @@ function getClassName(contributionType: ContributionType) {
 
 }
 
-function showError(
-  error: ContributionError,
-  currency: Currency,
-  contributionType: ContributionType,
-) {
 
-  if (error) {
+// ----- Component ----- //
 
-    const message = contributionsErrorMessage(error, currency, contributionType);
-    return <ErrorMessage message={message} />;
-
-  }
-
-  return null;
-
-}
-
-
-// ----- Exports ----- //
-
-export default function ContributionSelection(props: PropTypes) {
+function ContributionSelection(props: PropTypes) {
 
   return (
     <div className={getClassName(props.contributionType)}>
@@ -108,9 +91,37 @@ export default function ContributionSelection(props: PropTypes) {
         <p className="accessibility-hint" id="component-contribution-selection__custom-amount-a11y">
           {getCustomAmountA11yHint(props.contributionType, props.country, props.currency)}
         </p>
-        {showError(props.contributionError, props.currency, props.contributionType)}
+        <Error
+          error={props.contributionError}
+          currency={props.currency}
+          contributionType={props.contributionType}
+        />
       </div>
     </div>
   );
 
 }
+
+
+// ----- Auxiliary Components ----- //
+
+function Error(props: {
+  error: ContributionError,
+  currency: Currency,
+  contributionType: ContributionType,
+}) {
+
+  let message = null;
+
+  if (props.error) {
+    message = contributionsErrorMessage(props.error, props.currency, props.contributionType);
+  }
+
+  return <ErrorMessage message={message} />;
+
+}
+
+
+// ----- Exports ----- //
+
+export default ContributionSelection;

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -143,13 +143,6 @@ function showPayPal(props: PropTypes) {
   return null;
 }
 
-function showPayPalError(props: PropTypes) {
-  if (props.contribType === 'ONE_OFF') {
-    return (props.payPalError ? <ErrorMessage message={props.payPalError} /> : null);
-  }
-  return null;
-}
-
 const ctaLinks = {
   annual: routes.recurringContribCheckout,
   monthly: routes.recurringContribCheckout,
@@ -251,7 +244,7 @@ function ContributionsBundle(props: PropTypes) {
         accessibilityHint={accessibilityHint}
       />
       {showPayPal(props)}
-      {showPayPalError(props)}
+      <ErrorMessage showError={props.contribType === 'ONE_OFF'} message={props.payPalError} />
       <TermsAndPrivacy country={props.isoCountry} contribType={props.contribType} />
     </Bundle>
   );

--- a/assets/pages/contributions-thankyou/components/marketingConsent.jsx
+++ b/assets/pages/contributions-thankyou/components/marketingConsent.jsx
@@ -27,12 +27,6 @@ type PropTypes = {
 
 function MarketingConsent(props: PropTypes) {
 
-  const showError = (consentApiError: boolean) => {
-    if (consentApiError) {
-      return <ErrorMessage message="Error confirming selection. Please try again later" />;
-    }
-    return null;
-  };
   if (props.email) {
     return (
       <div>
@@ -50,7 +44,10 @@ function MarketingConsent(props: PropTypes) {
                 labelCopy="Get related news and offers - whether you are a subscriber, member, supporter or would like to become one."
               />
             </h2>
-            {showError(props.consentApiError)}
+            <ErrorMessage
+              showError={props.consentApiError}
+              message="Error confirming selection. Please try again later"
+            />
             <CtaLink
               onClick={
                 () => props.onClick(props.marketingPreferencesOptIn, props.email, props.csrf)

--- a/assets/pages/oneoff-contributions/components/oneoffContributionsPayment.jsx
+++ b/assets/pages/oneoff-contributions/components/oneoffContributionsPayment.jsx
@@ -42,17 +42,6 @@ type PropTypes = {
 
 // ----- Functions ----- //
 
-// Shows a message about the status of the form or the payment.
-function getStatusMessage(isFormEmpty: boolean, error: ?string): Node {
-
-  if (error !== null && error !== undefined) {
-    return <ErrorMessage message={error} />;
-  }
-
-  return null;
-
-}
-
 // If the form is valid, calls the given callback, otherwise sets an error.
 function formValidation(
   isFormEmpty: boolean,
@@ -96,7 +85,7 @@ function OneoffContributionsPayment(props: PropTypes, context) {
 
   return (
     <section className="oneoff-contribution-payment">
-      {getStatusMessage(props.isFormEmpty, props.error)}
+      <ErrorMessage message={props.error} />
 
       <StripePopUpButton
         email={props.email}

--- a/assets/pages/oneoff-contributions/components/oneoffContributionsPayment.jsx
+++ b/assets/pages/oneoff-contributions/components/oneoffContributionsPayment.jsx
@@ -11,7 +11,6 @@ import ErrorMessage from 'components/errorMessage/errorMessage';
 
 import { validateEmailAddress } from 'helpers/utilities';
 
-import type { Node } from 'react';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import type { Participations } from 'helpers/abTests/abtest';

--- a/assets/pages/regular-contributions/components/regularContributionsPayment.jsx
+++ b/assets/pages/regular-contributions/components/regularContributionsPayment.jsx
@@ -57,11 +57,9 @@ function getStatusMessage(
     return <ProgressMessage message={['Processing transaction', 'Please wait']} />;
   } else if (hide) {
     return <ErrorMessage message="Please fill in all the fields above." />;
-  } else if (error !== null && error !== undefined) {
-    return <ErrorMessage message={error} />;
   }
 
-  return null;
+  return <ErrorMessage message={error} />;
 
 }
 


### PR DESCRIPTION
## Why are you doing this?

Every time we use the `ErrorMessage` component we write a bunch of boilerplate to check whether it should be shown or not. Why not let the component do that for you? This concept came out of our codebase best practices meeting the other day.

cc @JustinPinner 

## Changes

- Rewrote the `ErrorMessage` component to now show based upon whether there is a message. Also contains an additional prop that can be used to hide it (for example, if the message is static and you're deciding whether to show it based on another condition).
- Updated the following places to use the new format:
  + `ContributionSelection` component.
  + The one-off contributions bundle.
  + `MarketingConsent` component.
  + The one-off contribution checkout page.
  + The regular contribution checkout page.
- Tweaked the `ContributionSelection` component to use the new 'auxiliary components' style.
- Fixed up the CSS to follow best practices.
