### PR TITLE
Added basic styling to Direct Debit and improved error handling

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -34,7 +34,14 @@
     "import/no-duplicates": "off",
     "import/no-extraneous-dependencies": "off",
     "padded-blocks": "off",
-    "import/prefer-default-export": "off"
+    "import/prefer-default-export": "off",
+    "jsx-a11y/label-has-for": [ 2, {
+      "components": [ "Label" ],
+      "required": {
+        "some": [ "nesting", "id" ]
+      },
+      "allowChildren": false
+    }]
   },
   "settings": {
     "import/resolver": "webpack",

--- a/assets/components/directDebit/directDebitActions.js
+++ b/assets/components/directDebit/directDebitActions.js
@@ -69,23 +69,23 @@ function payDirectDebitClicked(callback: Function): Function {
     checkAccount(bankSortCode, bankAccountNumber, isTestUser, csrf)
       .then((response) => {
         if (!response.ok) {
-          throw new Error('code1');
+          throw new Error('invalid_input');
         }
         return response.json();
       })
       .then((response) => {
         if (!response.accountValid) {
-          throw new Error('code1');
+          throw new Error('incorrect_input');
         }
-      }).then(() => {
         callback(undefined, bankAccountNumber, bankSortCode, accountHolderName);
       })
       .catch((e) => {
         let msg = '';
         switch (e.message) {
-          case 'code1': msg = 'Your payment details are invalid. Please check them and try again';
+          case 'invalid_input': msg = 'Your bank details are invalid. Please check them and try again';
             break;
-
+          case 'incorrect_input': msg = 'Your bank details are not correct. Please check them and try again';
+            break;
           default: msg = 'Oops, something went wrong, please try again later';
 
         }

--- a/assets/components/directDebit/directDebitForm/directDebitForm.jsx
+++ b/assets/components/directDebit/directDebitForm/directDebitForm.jsx
@@ -4,6 +4,7 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
+import ErrorMessage from 'components/errorMessage/errorMessage'
 import {
   updateSortCode,
   updateAccountNumber,
@@ -72,63 +73,65 @@ function mapDispatchToProps(dispatch) {
 
 // ----- Component ----- //
 
-const DirectDebitForm = (props: PropTypes) => (
-  <div className="component-direct-debit-form">
-    <SortCodeInput
-      onChange={props.updateSortCode}
-      value={props.sortCode}
-    />
+const DirectDebitForm = (props: PropTypes) => {
+  let errorMessage = null;
+  if (props.formError) {
+    errorMessage = <ErrorMessage message={props.formError} />;
+  }
+  return (
+    <div className="component-direct-debit-form">
+      <SortCodeInput
+        onChange={props.updateSortCode}
+        value={props.sortCode}
+      />
 
-    <AccountNumberInput
-      onChange={props.updateAccountNumber}
-      value={props.accountNumber}
-    />
+      <AccountNumberInput
+        onChange={props.updateAccountNumber}
+        value={props.accountNumber}
+      />
 
-    <AccountHolderNameInput
-      onChange={props.updateAccountHolderName}
-      value={props.accountHolderName}
-    />
+      <AccountHolderNameInput
+        onChange={props.updateAccountHolderName}
+        value={props.accountHolderName}
+      />
 
-    <ConfirmationInput
-      onChange={props.updateAccountHolderConfirmation}
-      checked={props.accountHolderConfirmation}
-    />
+      <ConfirmationInput
+        onChange={props.updateAccountHolderConfirmation}
+        checked={props.accountHolderConfirmation}
+      />
 
-    <p>{props.formError}</p>
-    <button
-      id="qa-pay-with-direct-debit-close-pop-up"
-      className="component-direct-debit-form__pay-button"
-      onClick={() => props.payDirectDebitClicked(props.callback)}
-    >
-      Pay with Direct Debit
-    </button>
+      {errorMessage}
+      <button
+        id="qa-pay-with-direct-debit-pay"
+        className="component-direct-debit-form__pay-button"
+        onClick={() => props.payDirectDebitClicked(props.callback)}
+      >
+        Pay with Direct Debit
+      </button>
 
-    <div className="component-direct-debit-form__legal__title">
+      <div className="component-direct-debit-form__legal__title">
         Advance notice
-    </div>
-
-    <div className="component-direct-debit-form__legal__content">
-      <p>The details of your Direct Debit instruction including payment schedule, due date,
-        frequency and amount will be sent to you within three working days. All the normal
-        Direct Debit safeguards and guarantees apply.
-      </p>
-      <p>
-        Your payments are protected by the <a target="_blank" rel="noopener noreferrer" href="https://www.directdebit.co.uk/DirectDebitExplained/pages/directdebitguarantee.aspx">Direct Debit guarantee</a>.
-      </p>
-      <div>
-        <div>The Guardian, Unit 16, Coalfield Way, Ashby Park, Ashby-De-La-Zouch, LE65 1JT
-          United Kingdom
-        </div>
-        <div><a href="tel:+443303336767">Tel: +44 (0) 330 333 6767</a></div>
-        <div><a href="mailto:support@theguardian.com">support@theguardian.com</a></div>
       </div>
-    </div>
-  </div>);
 
-// ----- Default Props ----- //
-
-DirectDebitForm.defaultProps = {
-
+      <div className="component-direct-debit-form__legal__content">
+        <p>The details of your Direct Debit instruction including payment schedule, due date,
+          frequency and amount will be sent to you within three working days. All the normal
+          Direct Debit safeguards and guarantees apply.
+        </p>
+        <p>
+          Your payments are protected by the <a target="_blank" rel="noopener noreferrer"
+                                                href="https://www.directdebit.co.uk/DirectDebitExplained/pages/directdebitguarantee.aspx">Direct
+          Debit guarantee</a>.
+        </p>
+        <div>
+          <div>The Guardian, Unit 16, Coalfield Way, Ashby Park, Ashby-De-La-Zouch, LE65 1JT
+            United Kingdom
+          </div>
+          <div><a href="tel:+443303336767">Tel: +44 (0) 330 333 6767</a></div>
+          <div><a href="mailto:support@theguardian.com">support@theguardian.com</a></div>
+        </div>
+      </div>
+    </div>)
 };
 
 

--- a/assets/components/directDebit/directDebitForm/directDebitForm.jsx
+++ b/assets/components/directDebit/directDebitForm/directDebitForm.jsx
@@ -74,9 +74,6 @@ function mapDispatchToProps(dispatch) {
 
 const DirectDebitForm = (props: PropTypes) => (
   <div className="component-direct-debit-form">
-
-    <img className="component-direct-debit-form__direct-debit-logo" src="#" alt="The Direct Debit logo" />
-
     <SortCodeInput
       onChange={props.updateSortCode}
       value={props.sortCode}
@@ -100,17 +97,17 @@ const DirectDebitForm = (props: PropTypes) => (
     <p>{props.formError}</p>
     <button
       id="qa-pay-with-direct-debit-close-pop-up"
-      className="component-direct-debit-pop-up-form"
+      className="component-direct-debit-form__pay-button"
       onClick={() => props.payDirectDebitClicked(props.callback)}
     >
-      Pay
+      Pay with Direct Debit
     </button>
 
-    <div className="component-direct-debit-form__advance-notice__title">
+    <div className="component-direct-debit-form__legal__title">
         Advance notice
     </div>
 
-    <div className="component-direct-debit-form__advance-notice__content">
+    <div className="component-direct-debit-form__legal__content">
       <p>The details of your Direct Debit instruction including payment schedule, due date,
         frequency and amount will be sent to you within three working days. All the normal
         Direct Debit safeguards and guarantees apply.
@@ -140,16 +137,18 @@ DirectDebitForm.defaultProps = {
 function SortCodeInput(props: {value: string, onChange: Function}) {
   return (
     <div className="component-direct-debit-form__sort-code">
-      <label htmlFor="sort-code-input">
-        Sort code
-        <input
-          id="sort-code-input"
-          value={props.value}
-          onChange={props.onChange}
-          type="text"
-          placeholder="00-00-00"
-        />
+      <label htmlFor="sort-code-input" className="component-direct-debit-form__field-label">
+        Bank sort code
       </label>
+      <input
+        id="sort-code-input"
+        value={props.value}
+        onChange={props.onChange}
+        type="text"
+        placeholder="00-00-00"
+        className="component-direct-debit-form__sort-code-field"
+      />
+
     </div>
   );
 }
@@ -158,40 +157,42 @@ function SortCodeInput(props: {value: string, onChange: Function}) {
 function AccountNumberInput(props: {onChange: Function, value: string}) {
   return (
     <div className="component-direct-debit-form__account-number">
-      <label htmlFor="account-number-input">
-        Account number
-        <input
-          id="account-number-input"
-          value={props.value}
-          onChange={props.onChange}
-          pattern="[0-9]*"
-          minLength="6"
-          maxLength="10"
-        />
+      <label htmlFor="account-number-input" className="component-direct-debit-form__field-label">
+        Bank account number
       </label>
+      <input
+        id="account-number-input"
+        value={props.value}
+        onChange={props.onChange}
+        pattern="[0-9]*"
+        minLength="6"
+        maxLength="10"
+        className="component-direct-debit-form__text-field"
+      />
     </div>
   );
 }
 
 /*
  * BACS requirement:
- "The payer’s account name (maximum of 18 characters).
- This must be the name of the person who is paying the Direct Debit
- and has signed the Direct Debit Instruction (DDI)."
- http://www.bacs.co.uk/Bacs/Businesses/Resources/Pages/Glossary.aspx
+ "Name of the account holder, as known by the bank. Usually this is the
+ same as the name stored with the linked creditor. This field will be
+ transliterated, upcased and truncated to 18 characters."
+ https://developer.gocardless.com/api-reference/
  * */
 function AccountHolderNameInput(props: {value: string, onChange: Function}) {
   return (
     <div className="component-direct-debit-form__account-holder-name">
-      <label htmlFor="account-holder-name-input">
-        Account holder name
-        <input
-          id="account-holder-name-input"
-          value={props.value}
-          onChange={props.onChange}
-          maxLength="18"
-        />
+      <label htmlFor="account-holder-name-input" className="component-direct-debit-form__field-label">
+        Name of account holder
       </label>
+      <input
+        id="account-holder-name-input"
+        value={props.value}
+        onChange={props.onChange}
+        maxLength="18"
+        className="component-direct-debit-form__text-field"
+      />
     </div>
   );
 }
@@ -199,7 +200,6 @@ function AccountHolderNameInput(props: {value: string, onChange: Function}) {
 function ConfirmationInput(props: { checked: boolean, onChange: Function }) {
   return (
     <div className="component-direct-debit-form__account-holder-confirmation">
-      Confirmation
       <div>
         <label htmlFor="confirmation-input">
           <span>
@@ -210,7 +210,7 @@ function ConfirmationInput(props: { checked: boolean, onChange: Function }) {
               checked={props.checked}
             />
           </span>
-          <span>
+          <span className="component-direct-debit-form__account-holder-confirmation__text">
             I confirm that I am the account holder and I am solely able to authorise debit from
             the account
           </span>

--- a/assets/components/directDebit/directDebitForm/directDebitForm.jsx
+++ b/assets/components/directDebit/directDebitForm/directDebitForm.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
-import ErrorMessage from 'components/errorMessage/errorMessage'
+import ErrorMessage from 'components/errorMessage/errorMessage';
 import {
   updateSortCode,
   updateAccountNumber,
@@ -119,9 +119,10 @@ const DirectDebitForm = (props: PropTypes) => {
           Direct Debit safeguards and guarantees apply.
         </p>
         <p>
-          Your payments are protected by the <a target="_blank" rel="noopener noreferrer"
-                                                href="https://www.directdebit.co.uk/DirectDebitExplained/pages/directdebitguarantee.aspx">Direct
-          Debit guarantee</a>.
+          Your payments are protected by the&nbsp;
+          <a target="_blank" rel="noopener noreferrer" href="https://www.directdebit.co.uk/DirectDebitExplained/pages/directdebitguarantee.aspx">
+            Direct Debit guarantee
+          </a>.
         </p>
         <div>
           <div>The Guardian, Unit 16, Coalfield Way, Ashby Park, Ashby-De-La-Zouch, LE65 1JT
@@ -131,7 +132,7 @@ const DirectDebitForm = (props: PropTypes) => {
           <div><a href="mailto:support@theguardian.com">support@theguardian.com</a></div>
         </div>
       </div>
-    </div>)
+    </div>);
 };
 
 

--- a/assets/components/directDebit/directDebitForm/directDebitForm.scss
+++ b/assets/components/directDebit/directDebitForm/directDebitForm.scss
@@ -13,7 +13,7 @@
 .component-direct-debit-form__sort-code-field {
   font-family: $gu-sans-web;
   font-size: 14px;
-  color: gu-colour(neutral-1);
+  color: gu-colour(garnett-neutral-1);
   margin: 0 -2px 20px;
   border: none;
   border-radius: 600px;
@@ -25,7 +25,7 @@
 .component-direct-debit-form__text-field {
   font-family: $gu-sans-web;
   font-size: 14px;
-  color: gu-colour(neutral-1);
+  color: gu-colour(garnett-neutral-1);
   margin: 0 -2px 20px;
   border: none;
   border-radius: 600px;
@@ -62,7 +62,7 @@
   }
 
   &:hover {
-    background-color: #000;
+    background-color: darken(gu-colour(neutral-1), 10%);
   }
 }
 .component-direct-debit-form__legal__title {

--- a/assets/components/directDebit/directDebitForm/directDebitForm.scss
+++ b/assets/components/directDebit/directDebitForm/directDebitForm.scss
@@ -1,0 +1,79 @@
+.component-direct-debit-form {
+  width: 500px;
+  padding: $gu-h-spacing/2;
+}
+
+.component-direct-debit-form__field-label {
+  display: block;
+  font-family: $gu-sans-web;
+  font-size: 16px;
+  line-height: 24px;
+}
+
+.component-direct-debit-form__sort-code-field {
+  font-family: $gu-sans-web;
+  font-size: 14px;
+  color: gu-colour(neutral-1);
+  margin: 0 -2px 20px;
+  border: none;
+  border-radius: 600px;
+  height: $gu-v-spacing * 4;
+  padding: 0 $gu-h-spacing;
+  width: 70px;
+}
+
+.component-direct-debit-form__text-field {
+  font-family: $gu-sans-web;
+  font-size: 14px;
+  color: gu-colour(neutral-1);
+  margin: 0 -2px 20px;
+  border: none;
+  border-radius: 600px;
+  height: $gu-v-spacing * 4;
+  padding: 0 $gu-h-spacing;
+  width: 100px;
+}
+
+.component-direct-debit-form__account-holder-confirmation__text {
+  font-family: $gu-sans-web;
+  font-size: 14px;
+  color: gu-colour(neutral-1);
+}
+
+.component-direct-debit-form__pay-button {
+  background-color: gu-colour(neutral-1);
+  border: none;
+  border-radius: 600px;
+  color: #fff;
+  cursor: pointer;
+  display: block;
+  font-family: $gu-sans-web;
+  font-size: 14px;
+  font-weight: bold;
+  height: $gu-v-spacing * 4;
+  padding-left: $gu-h-spacing;
+  position: relative;
+  text-align: left;
+  width: 100%;
+  margin-top: $gu-v-spacing;
+
+  @include mq($from: mobileMedium) {
+    width: 175px;
+  }
+
+  &:hover {
+    background-color: #000;
+  }
+}
+.component-direct-debit-form__legal__title {
+  font-family: $gu-text-sans-web;
+  font-size: 14px;
+  color: gu-colour(neutral-1);
+  padding-top: $gu-v-spacing;
+}
+.component-direct-debit-form__legal__content {
+
+  font-family: $gu-text-sans-web;
+  font-size: 12px;
+  color: gu-colour(neutral-1);
+}

--- a/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.jsx
+++ b/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.jsx
@@ -51,7 +51,7 @@ const DirectDebitPopUpForm = (props: PropTypes) => {
             className="component-direct-debit-pop-up-form__close-button"
             onClick={props.closeDirectDebitPopUp}
           >
-            Close form
+            X
           </button>
           <DirectDebitForm callback={props.callback} />
         </div>

--- a/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.jsx
+++ b/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.jsx
@@ -44,16 +44,18 @@ const DirectDebitPopUpForm = (props: PropTypes) => {
 
   if (props.isPopUpOpen) {
     content = (
-      <div>
-        <button
-          id="qa-pay-with-direct-debit-close-pop-up"
-          className="component-direct-debit-pop-up-form"
-          onClick={props.closeDirectDebitPopUp}
-        >
-          Close form
-        </button>
-
-        <DirectDebitForm callback={props.callback} />
+      <div className="component-direct-debit-pop-up-form">
+        <div className="component-direct-debit-pop-up-form__content">
+          <button
+            id="qa-pay-with-direct-debit-close-pop-up"
+            className="component-direct-debit-pop-up-form__close-button"
+            onClick={props.closeDirectDebitPopUp}
+          >
+            Close form
+          </button>
+          <DirectDebitForm callback={props.callback} />
+        </div>
+        <div className="component-direct-debit-pop-up-form__background" />
       </div>
     );
   }

--- a/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.scss
+++ b/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.scss
@@ -1,0 +1,37 @@
+.component-direct-debit-pop-up-form {
+  z-index: 10000;
+  display: block;
+  border: 0 none transparent;
+  overflow-x: hidden;
+  overflow-y: auto;
+  visibility: visible;
+  margin: 0;
+  padding: 0;
+  -webkit-tap-highlight-color: transparent;
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  text-align: center;
+}
+
+.component-direct-debit-pop-up-form__content {
+  position: relative;
+  display: inline-block;
+  top: 50%;
+  transform: translateY(-50%);
+  background-color: gu-colour(nav-background-colour);
+  text-align: left;
+}
+
+.component-direct-debit-pop-up-form__background {
+  z-index: -1;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background:rgba(0,0,0,0.6);
+}
+

--- a/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.scss
+++ b/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.scss
@@ -23,6 +23,14 @@
   transform: translateY(-50%);
   background-color: gu-colour(nav-background-colour);
   text-align: left;
+  border-radius: 5px;
+}
+
+.component-direct-debit-pop-up-form__close-button {
+  border-radius: 800px;
+  height: 20px;
+  margin-left: 480px;
+  margin-top: $gu-v-spacing/2;
 }
 
 .component-direct-debit-pop-up-form__background {
@@ -34,4 +42,3 @@
   right: 0;
   background:rgba(0,0,0,0.6);
 }
-

--- a/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.scss
+++ b/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.scss
@@ -1,5 +1,5 @@
 .component-direct-debit-pop-up-form {
-  z-index: 10000;
+  z-index: 7500;
   display: block;
   border: 0 none transparent;
   overflow-x: hidden;

--- a/assets/stylesheets/main.scss
+++ b/assets/stylesheets/main.scss
@@ -11,6 +11,8 @@
 
 // ----- Shared Components ----- //
 
+@import '../components/directDebit/directDebitPopUpForm/directDebitPopUpForm';
+@import '../components/directDebit/directDebitForm/directDebitForm';
 @import '../components/bodyCopy/bodyCopy';
 @import '../components/checkboxInput/checkboxInput';
 @import '../components/circlesIntroduction/circlesIntroduction';


### PR DESCRIPTION
## Why are you doing this?

To improve the UX and UI of the direct debit form. **This is not the final design of the form**. There should be a design/UX iteration before the final release. 
[**Trello Card**](https://trello.com/c/nOdfGQgS/254-direct-debit-as-a-payment-mechanism)

## Changes

* Modify a11y label-for linting rule. Before it required both nesting and id link, now it only requires one of those.
* Come up with more meaningful codes for errors
* Added CSS✨ to improve the PopUp Form and the Direct debit form.

## Screenshots
![directdebitpolished](https://user-images.githubusercontent.com/825398/35435525-ef5078ba-0282-11e8-9d86-5132cbd669f6.gif)


### Form style
#### Before
<img width="1137" alt="picture 521" src="https://user-images.githubusercontent.com/825398/35431649-31f5a220-0275-11e8-8cac-97dd8669031d.png">

#### After
<img width="1257" alt="picture 522" src="https://user-images.githubusercontent.com/825398/35431741-969b51fc-0275-11e8-89b4-4b40b339cd34.png">

### Error message
#### Before
<img width="666" alt="picture 523" src="https://user-images.githubusercontent.com/825398/35431805-e7da6436-0275-11e8-804a-a34ba76984bd.png">

#### After
<img width="509" alt="picture 524" src="https://user-images.githubusercontent.com/825398/35431812-f15934e2-0275-11e8-9be4-b0c77218d79b.png">
