### PR TITLE
Direct debit phase 4/6 - Create a GoCardless service provider 

### DIFF
--- a/app/config/Configuration.scala
+++ b/app/config/Configuration.scala
@@ -4,6 +4,7 @@ import com.gocardless.GoCardlessClient
 import com.gu.support.config.{PayPalConfigProvider, Stage, StripeConfigProvider}
 import com.typesafe.config.ConfigFactory
 import config.ConfigImplicits._
+import services.GoCardlessConfigProvider
 import services.aws.AwsConfig
 
 class Configuration {
@@ -21,13 +22,6 @@ class Configuration {
 
   lazy val guardianDomain = config.getString("guardianDomain")
 
-  lazy val goCardlessToken = config.getString("gocardless.token")
-
-  lazy val goCardlessEnvironment = config.getString("gocardless.environment") match {
-    case "LIVE" => GoCardlessClient.Environment.LIVE
-    case "SANDBOX" => GoCardlessClient.Environment.SANDBOX
-  }
-
   lazy val supportUrl = config.getString("support.url")
 
   lazy val contributionsStripeEndpoint = config.getString("contributions.stripe.url")
@@ -37,6 +31,8 @@ class Configuration {
   lazy val contributionsFrontendUrl = config.getString("contribution.url")
 
   lazy val membersDataServiceApiUrl = config.getString("membersDataService.api.url")
+
+  lazy val goCardlessConfigProvider = new GoCardlessConfigProvider(config, stage)
 
   lazy val payPalConfigProvider = new PayPalConfigProvider(config, stage)
 

--- a/app/controllers/DirectDebit.scala
+++ b/app/controllers/DirectDebit.scala
@@ -22,9 +22,8 @@ class DirectDebit(
   import actionBuilders._
 
   def checkAccount: Action[CheckBankAccountDetails] =
-    PrivateAction.async(circe.json[CheckBankAccountDetails]) { implicit request =>
-      val isTestUser = testUsers.isTestUser(request.cookies.get("_test_username").map(_.value))
-      val goCardlessService = goCardlessServiceProvider.forUser(isTestUser)
+    AuthenticatedAction.async(circe.json[CheckBankAccountDetails]) { implicit request =>
+      val goCardlessService = goCardlessServiceProvider.forUser(testUsers.isTestUser(request.user))
       goCardlessService.checkBankDetails(request.body).map { isAccountValid =>
         Ok(Map("accountValid" -> isAccountValid).asJson)
       }

--- a/app/services/GoCardlessConfigProvider.scala
+++ b/app/services/GoCardlessConfigProvider.scala
@@ -1,26 +1,19 @@
 package services
 
+import com.gocardless.GoCardlessClient.Environment
 import com.gu.support.config.{Stage, TouchpointConfig, TouchpointConfigProvider}
 import com.typesafe.config.Config
 
 case class GoCardlessConfig(
-  payPalEnvironment: String,
-  NVPVersion: String,
-  url: String,
-  user: String,
-  password: String,
-  signature: String
+    apiToken: String,
+    environment: Environment
 ) extends TouchpointConfig
 
 class GoCardlessConfigProvider(config: Config, defaultStage: Stage) extends TouchpointConfigProvider[GoCardlessConfig](config, defaultStage) {
   def fromConfig(config: Config): GoCardlessConfig = {
     GoCardlessConfig(
-      config.getString("paypal.paypal-environment"),
-      config.getString("paypal.nvp-version"),
-      config.getString("paypal.url"),
-      config.getString("paypal.user"),
-      config.getString("paypal.password"),
-      config.getString("paypal.signature")
+      config.getString("gocardless.token"),
+      Environment.valueOf(config.getString("gocardless.environment"))
     )
   }
 }

--- a/app/services/GoCardlessConfigProvider.scala
+++ b/app/services/GoCardlessConfigProvider.scala
@@ -1,0 +1,26 @@
+package services
+
+import com.gu.support.config.{Stage, TouchpointConfig, TouchpointConfigProvider}
+import com.typesafe.config.Config
+
+case class GoCardlessConfig(
+  payPalEnvironment: String,
+  NVPVersion: String,
+  url: String,
+  user: String,
+  password: String,
+  signature: String
+) extends TouchpointConfig
+
+class GoCardlessConfigProvider(config: Config, defaultStage: Stage) extends TouchpointConfigProvider[GoCardlessConfig](config, defaultStage) {
+  def fromConfig(config: Config): GoCardlessConfig = {
+    GoCardlessConfig(
+      config.getString("paypal.paypal-environment"),
+      config.getString("paypal.nvp-version"),
+      config.getString("paypal.url"),
+      config.getString("paypal.user"),
+      config.getString("paypal.password"),
+      config.getString("paypal.signature")
+    )
+  }
+}

--- a/app/services/GoCardlessService.scala
+++ b/app/services/GoCardlessService.scala
@@ -6,11 +6,12 @@ import com.gocardless.errors.GoCardlessApiException
 import com.gocardless.resources.BankDetailsLookup.AvailableDebitScheme
 import com.typesafe.scalalogging.LazyLogging
 import models.CheckBankAccountDetails
+import services.touchpoint.TouchpointService
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class GoCardlessService(token: String, environment: Environment) extends LazyLogging {
+class GoCardlessService(token: String, environment: Environment) extends TouchpointService with LazyLogging {
 
   lazy val client = GoCardlessClient.create(token, environment)
 

--- a/app/services/GoCardlessServiceProvider.scala
+++ b/app/services/GoCardlessServiceProvider.scala
@@ -1,0 +1,11 @@
+package services
+
+import services.touchpoint.TouchpointServiceProvider
+
+import scala.concurrent.ExecutionContext
+
+class GoCardlessServiceProvider(configProvider: GoCardlessConfigProvider)(implicit executionContext: ExecutionContext)
+  extends TouchpointServiceProvider[GoCardlessService, CoCardLessConfig](configProvider) {
+  override protected def createService(config: GoCardlessConfig) =
+    new GoCardlessService(config.apiToken, config.environment)
+}

--- a/app/services/GoCardlessServiceProvider.scala
+++ b/app/services/GoCardlessServiceProvider.scala
@@ -5,7 +5,7 @@ import services.touchpoint.TouchpointServiceProvider
 import scala.concurrent.ExecutionContext
 
 class GoCardlessServiceProvider(configProvider: GoCardlessConfigProvider)(implicit executionContext: ExecutionContext)
-  extends TouchpointServiceProvider[GoCardlessService, CoCardLessConfig](configProvider) {
+  extends TouchpointServiceProvider[GoCardlessService, GoCardlessConfig](configProvider) {
   override protected def createService(config: GoCardlessConfig) =
     new GoCardlessService(config.apiToken, config.environment)
 }

--- a/app/wiring/Controllers.scala
+++ b/app/wiring/Controllers.scala
@@ -72,6 +72,7 @@ trait Controllers {
   lazy val directDebitController = new DirectDebit(
     actionRefiners,
     controllerComponents,
-    goCardlessService
+    goCardlessServiceProvider,
+    testUsers
   )
 }

--- a/app/wiring/Services.scala
+++ b/app/wiring/Services.scala
@@ -18,7 +18,7 @@ trait Services {
 
   lazy val identityService = IdentityService(appConfig.identity)
 
-  lazy val goCardlessService = new GoCardlessService(appConfig.goCardlessToken, appConfig.goCardlessEnvironment)
+  lazy val goCardlessServiceProvider = new GoCardlessServiceProvider(appConfig.goCardlessConfigProvider)
 
   lazy val regularContributionsClient = {
     val stateWrapper = new StateWrapper(Encryption.getProvider(appConfig.aws), appConfig.aws.useEncryption)


### PR DESCRIPTION
## Why are you doing this?

To be able to hit go cardless sandbox environment when you use a test user in PROD.
We need to update config files before merging.

1.- Added DirectDebit components to support-frontend (#448)
2.- Connect support-frontend with gocardless (#456)
3.- Integrate direct debit with step-functions/Zuora (#460, https://github.com/guardian/support-models/pull/29, https://github.com/guardian/support-models/pull/28 and https://github.com/guardian/support-workers/pull/91)
4.- Implement a GoCardLess provider (#473)
5.- Apply styles to support frontend.
6.- Build an A/B Test

