### PR TITLE
Adding test for recurring request

### DIFF
--- a/assets/pages/regular-contributions/__tests__/ajaxTest.js
+++ b/assets/pages/regular-contributions/__tests__/ajaxTest.js
@@ -58,7 +58,7 @@ describe('Regular Contributions Payment fields', () => {
 
     const paymentFieldName = 'stripeToken';
     const userId = '123456';
-    const token = 'PayPalToken';
+    const token = 'StripeToken';
 
     const expectedPaymentFields = {
       stripeToken: token,

--- a/assets/pages/regular-contributions/__tests__/ajaxTest.js
+++ b/assets/pages/regular-contributions/__tests__/ajaxTest.js
@@ -82,10 +82,6 @@ describe('Regular Contributions Payment fields', () => {
     const userId = '123456';
     const token = 'PayPalToken';
 
-    const expectedPaymentFields = {
-      stripeToken: token,
-      userId,
-    };
     const paymentFields = getPaymentFields(
       token,
       undefined,

--- a/assets/pages/regular-contributions/__tests__/ajaxTest.js
+++ b/assets/pages/regular-contributions/__tests__/ajaxTest.js
@@ -30,4 +30,71 @@ describe('Regular Contributions Payment fields', () => {
     expect(paymentFields.accountNumber).toEqual(expectedPaymentFields.accountNumber);
 
   });
+
+  it('should create the correct payment field to handle PayPal', () => {
+
+    const paymentFieldName = 'baid';
+    const userId = '123456';
+    const token = 'PayPalToken';
+
+    const expectedPaymentFields = {
+      baid: token,
+    };
+    const paymentFields = getPaymentFields(
+      token,
+      undefined,
+      undefined,
+      undefined,
+      paymentFieldName,
+      userId,
+    );
+
+    expect(paymentFields.baid).toEqual(expectedPaymentFields.baid);
+    expect(paymentFields.userId).toEqual(undefined);
+  });
+
+  it('should create the correct payment field to handle Stripe', () => {
+
+    const paymentFieldName = 'stripeToken';
+    const userId = '123456';
+    const token = 'PayPalToken';
+
+    const expectedPaymentFields = {
+      stripeToken: token,
+      userId,
+    };
+    const paymentFields = getPaymentFields(
+      token,
+      undefined,
+      undefined,
+      undefined,
+      paymentFieldName,
+      userId,
+    );
+
+    expect(paymentFields.stripeToken).toEqual(expectedPaymentFields.stripeToken);
+    expect(paymentFields.userId).toEqual(expectedPaymentFields.userId);
+  });
+
+  it('should return null if a unknown payment field name is passed', () => {
+
+    const paymentFieldName = 'helloWorld';
+    const userId = '123456';
+    const token = 'PayPalToken';
+
+    const expectedPaymentFields = {
+      stripeToken: token,
+      userId,
+    };
+    const paymentFields = getPaymentFields(
+      token,
+      undefined,
+      undefined,
+      undefined,
+      paymentFieldName,
+      userId,
+    );
+
+    expect(paymentFields).toEqual(null);
+  });
 });

--- a/assets/pages/regular-contributions/__tests__/ajaxTest.js
+++ b/assets/pages/regular-contributions/__tests__/ajaxTest.js
@@ -1,0 +1,33 @@
+import { getPaymentFields } from '../helpers/ajax';
+
+jest.mock('ophan', () => {});
+
+describe('Regular Contributions Payment fields', () => {
+
+  it('should create the correct payment field to handle direct debit', () => {
+    const sortCode = '200000';
+    const accountNumber = '55779911';
+    const accountHolderName = 'Bart Simpson';
+    const paymentFieldName = 'directDebitData';
+    const userId = '123456';
+
+    const expectedPaymentFields = {
+      accountHolderName,
+      sortCode,
+      accountNumber,
+    };
+    const paymentFields = getPaymentFields(
+      undefined,
+      accountNumber,
+      sortCode,
+      accountHolderName,
+      paymentFieldName,
+      userId,
+    );
+
+    expect(paymentFields.accountHolderName).toEqual(expectedPaymentFields.accountHolderName);
+    expect(paymentFields.sortCode).toEqual(expectedPaymentFields.sortCode);
+    expect(paymentFields.accountNumber).toEqual(expectedPaymentFields.accountNumber);
+
+  });
+});

--- a/assets/pages/regular-contributions/__tests__/ajaxTest.js
+++ b/assets/pages/regular-contributions/__tests__/ajaxTest.js
@@ -28,7 +28,7 @@ describe('Regular Contributions Payment fields', () => {
     expect(paymentFields.accountHolderName).toEqual(expectedPaymentFields.accountHolderName);
     expect(paymentFields.sortCode).toEqual(expectedPaymentFields.sortCode);
     expect(paymentFields.accountNumber).toEqual(expectedPaymentFields.accountNumber);
-
+    expect(Object.keys(paymentFields).length).toEqual(3);
   });
 
   it('should create the correct payment field to handle PayPal', () => {
@@ -51,6 +51,7 @@ describe('Regular Contributions Payment fields', () => {
 
     expect(paymentFields.baid).toEqual(expectedPaymentFields.baid);
     expect(paymentFields.userId).toEqual(undefined);
+    expect(Object.keys(paymentFields).length).toEqual(1);
   });
 
   it('should create the correct payment field to handle Stripe', () => {
@@ -74,6 +75,7 @@ describe('Regular Contributions Payment fields', () => {
 
     expect(paymentFields.stripeToken).toEqual(expectedPaymentFields.stripeToken);
     expect(paymentFields.userId).toEqual(expectedPaymentFields.userId);
+    expect(Object.keys(paymentFields).length).toEqual(2);
   });
 
   it('should return null if a unknown payment field name is passed', () => {

--- a/assets/pages/regular-contributions/components/regularContributionsPayment.jsx
+++ b/assets/pages/regular-contributions/components/regularContributionsPayment.jsx
@@ -17,7 +17,7 @@ import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { Participations } from 'helpers/abTests/abtest';
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import { setPayPalHasLoaded } from '../regularContributionsActions';
-import postCheckout from '../helpers/ajax';
+import { postCheckout } from '../helpers/ajax';
 
 // ----- Types ----- //
 

--- a/assets/pages/regular-contributions/helpers/ajax.js
+++ b/assets/pages/regular-contributions/helpers/ajax.js
@@ -254,7 +254,7 @@ function handleStatus(
 }
 
 
-export default function postCheckout(
+function postCheckout(
   abParticipations: Participations,
   amount: number,
   csrf: CsrfState,
@@ -297,3 +297,8 @@ export default function postCheckout(
     });
   };
 }
+
+export {
+  postCheckout,
+  getPaymentFields,
+};


### PR DESCRIPTION
## Why are you doing this?

The `paymentFields` logic is quite fragile and payment errors would appear if we do not handle correctly the three cases. In this PR I am adding some unit tests to be sure that we always generate what the backend expects, depending on the payment method chosen. 

## Changes
* Added a test file
* Exported the `getPaymentField` function so we are able to import it into the test file.

## Screenshots
N/A
