### PR TITLE
Secure Component - Styles in Stylesheet

### DIFF
--- a/assets/components/bundle/bundle.jsx
+++ b/assets/components/bundle/bundle.jsx
@@ -35,7 +35,7 @@ export default function Bundle(props: PropTypes) {
     <div className={className}>
       <div style={{ float: 'right' }}>
         {props.showPaymentLogos ? <InlinePaymentLogos /> : null}
-        {props.showSecureLogo ? <Secure style={{ textAlign: 'right', paddingTop: '5px' }} /> : null}
+        {props.showSecureLogo ? <Secure /> : null}
       </div>
       <DoubleHeading
         heading={props.heading}

--- a/assets/components/secure/secure.jsx
+++ b/assets/components/secure/secure.jsx
@@ -6,27 +6,16 @@ import React from 'react';
 
 import { SvgLock } from 'components/svg/svg';
 
-// ----- Types ----- //
-
-type PropTypes = {
-  style?: Object
-}
 
 // ----- Component ----- //
 
-export default function Secure(props: PropTypes) {
+export default function Secure() {
 
   return (
-    <div className="component-secure" style={props.style}>
+    <div className="component-secure">
       <SvgLock />
       <span className="component-secure__text">Secure</span>
     </div>
   );
 
 }
-
-// ----- Default Props ----- //
-
-Secure.defaultProps = {
-  style: {},
-};

--- a/assets/components/secure/secure.jsx
+++ b/assets/components/secure/secure.jsx
@@ -6,16 +6,32 @@ import React from 'react';
 
 import { SvgLock } from 'components/svg/svg';
 
+import { generateClassName } from 'helpers/utilities';
+
+
+// ----- Props ----- //
+
+type PropTypes = {
+  modifierClass?: string,
+};
+
 
 // ----- Component ----- //
 
-export default function Secure() {
+export default function Secure(props: PropTypes) {
 
   return (
-    <div className="component-secure">
+    <div className={generateClassName('component-secure', props.modifierClass)}>
       <SvgLock />
       <span className="component-secure__text">Secure</span>
     </div>
   );
 
 }
+
+
+// ----- Default Props ----- //
+
+Secure.defaultProps = {
+  modifierClass: '',
+};

--- a/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/assets/pages/contributions-landing/contributionsLanding.scss
@@ -338,6 +338,11 @@ strong {
 		}
 	}
 
+	.component-secure {
+		text-align: right;
+		padding-top: 5px;
+	}
+
 	.component-double-heading {
   	margin-bottom: (2 * $gu-v-spacing);
   	color: gu-colour(neutral-1);


### PR DESCRIPTION
## Why are you doing this?

Our preference is for styles to exist in the stylesheet rather than inline on the JSX component. This was added [here](https://github.com/guardian/support-frontend/pull/424#discussion_r158332011) initially with regards to making sure style rules only apply to a specific instance of the component. However, in the case of the contributions landing page (where this `style` prop is used) the styles will only be scoped to that page, due to the convention we have for wrapping page styles in id tags.

That said, this will not always be the case, for example in pages where a component is used twice. The reason I've come across this is that I've hit an instance of exactly that in one of the circles designs. In these cases I think it would be good to apply a convention of passing through an optional `modifierClass` prop to components, as this is something we already do in multiple places, seems to work quite well, and fits in with BEM.

cc @JustinPinner 

## Changes

- Stopped passing through `styles` prop to Secure.
- Started passing through `modifierClass` prop to Secure.
- Applied styles for the US secure lock test directly in the contributions landing stylesheet.

## Screenshots

 | Before | After
 |-|-
 | ![lock-before](https://user-images.githubusercontent.com/5131341/35570205-6f9a9a46-05c6-11e8-89a4-4b50601df81b.png) | ![lock-after](https://user-images.githubusercontent.com/5131341/35570230-82f0d81c-05c6-11e8-81e0-eae774188b70.png)
