### PR TITLE
Add a distinct route for unsupported browsers

### DIFF
--- a/app/actions/CachedActionBuilder.scala
+++ b/app/actions/CachedActionBuilder.scala
@@ -2,7 +2,7 @@ package actions
 
 import org.joda.time.DateTime
 import play.api.mvc._
-import HttpHeaders.merge
+import HttpHeaders.mergeHeader
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
 
@@ -17,7 +17,7 @@ class CachedActionBuilder(
   private val maximumBrowserAge = 1.minute
 
   override def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]): Future[Result] =
-    block(request).map(_.withHeaders(merge("Vary", cacheHeaders() ++ headers): _*))
+    block(request).map(_.withHeaders(mergeHeader("Vary", cacheHeaders() ++ headers): _*))
 
   private def cacheHeaders(now: DateTime = DateTime.now): List[(String, String)] = {
     val browserAge = maximumBrowserAge min maxAge

--- a/app/actions/CustomActionBuilders.scala
+++ b/app/actions/CustomActionBuilders.scala
@@ -57,6 +57,8 @@ class CustomActionBuilders(
 
   val CachedAction = new CachedAction(cc.parsers.defaultBodyParser, cc.executionContext)
 
+  val NoCacheAction = new NoCacheAction(cc.parsers.defaultBodyParser, cc.executionContext)
+
   val GeoTargetedCachedAction = new CachedAction(
     cc.parsers.defaultBodyParser,
     cc.executionContext,

--- a/app/actions/HttpHeaders.scala
+++ b/app/actions/HttpHeaders.scala
@@ -17,4 +17,17 @@ object HttpHeaders {
   implicit class DateTime2ToHttpDateFormat(date: DateTime) {
     def toHttpDateTimeString: String = date.toString(HTTPDateFormat)
   }
+
+  def merge(header: String, headers: List[(String, String)]): List[(String, String)] =
+    mergeHeader(header, headers)
+
+  private def mergeHeader(header: String, headers: List[(String, String)]): List[(String, String)] = {
+    val (selected, others) = headers.partition(_._1.toLowerCase == header.toLowerCase)
+    if (selected.isEmpty) {
+      others
+    } else {
+      val selectedValues = selected.map(_._2)
+      (header -> selectedValues.mkString(", ")) :: others
+    }
+  }
 }

--- a/app/actions/HttpHeaders.scala
+++ b/app/actions/HttpHeaders.scala
@@ -18,10 +18,7 @@ object HttpHeaders {
     def toHttpDateTimeString: String = date.toString(HTTPDateFormat)
   }
 
-  def merge(header: String, headers: List[(String, String)]): List[(String, String)] =
-    mergeHeader(header, headers)
-
-  private def mergeHeader(header: String, headers: List[(String, String)]): List[(String, String)] = {
+  def mergeHeader(header: String, headers: List[(String, String)]): List[(String, String)] = {
     val (selected, others) = headers.partition(_._1.toLowerCase == header.toLowerCase)
     if (selected.isEmpty) {
       others

--- a/app/actions/NoCacheAction.scala
+++ b/app/actions/NoCacheAction.scala
@@ -1,0 +1,13 @@
+package actions
+
+import play.api.mvc.{ActionBuilder, AnyContent, BodyParser, Request}
+
+import scala.concurrent.ExecutionContext
+
+class NoCacheAction(
+    parser: BodyParser[AnyContent],
+    executionContext: ExecutionContext,
+    headers: List[(String, String)] = List.empty
+)(implicit val ec: ExecutionContext) {
+  def apply(): ActionBuilder[Request, AnyContent] = new NoCacheActionBuilder(parser, executionContext, headers)
+}

--- a/app/actions/NoCacheActionBuilder.scala
+++ b/app/actions/NoCacheActionBuilder.scala
@@ -1,0 +1,17 @@
+package actions
+
+import play.api.mvc._
+import scala.concurrent.{ExecutionContext, Future}
+import HttpHeaders.merge
+
+class NoCacheActionBuilder(
+    val parser: BodyParser[AnyContent],
+    val executionContext: ExecutionContext,
+    val headers: List[(String, String)]
+) extends ActionBuilder[Request, AnyContent] {
+  implicit private val ec = executionContext
+
+  override def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]): Future[Result] =
+    block(request).map(_.withHeaders(merge("Vary", List(CacheControl.noCache) ++ headers): _*))
+
+}

--- a/app/actions/NoCacheActionBuilder.scala
+++ b/app/actions/NoCacheActionBuilder.scala
@@ -2,7 +2,7 @@ package actions
 
 import play.api.mvc._
 import scala.concurrent.{ExecutionContext, Future}
-import HttpHeaders.merge
+import HttpHeaders.mergeHeader
 
 class NoCacheActionBuilder(
     val parser: BodyParser[AnyContent],
@@ -12,6 +12,6 @@ class NoCacheActionBuilder(
   implicit private val ec = executionContext
 
   override def invokeBlock[A](request: Request[A], block: (Request[A]) => Future[Result]): Future[Result] =
-    block(request).map(_.withHeaders(merge("Vary", List(CacheControl.noCache) ++ headers): _*))
+    block(request).map(_.withHeaders(mergeHeader("Vary", List(CacheControl.noCache) ++ headers): _*))
 
 }

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -7,6 +7,7 @@ import play.api.mvc._
 import services.IdentityService
 import utils.RequestCountry._
 import config.StringsConfig
+import utils.BrowserCheck
 
 import scala.concurrent.ExecutionContext
 
@@ -43,6 +44,11 @@ class Application(
 
   def redirectPath(location: String, path: String): Action[AnyContent] = CachedAction() { implicit request =>
     Redirect(location + path, request.queryString)
+  }
+
+  def unsupportedBrowser: Action[AnyContent] = CachedAction() { implicit request =>
+    BrowserCheck.logUserAgent
+    Ok(views.html.unsupportedBrowserPage())
   }
 
   def bundleLanding(title: String, id: String, js: String, newDesigns: String): Action[AnyContent] = CachedAction() { implicit request =>

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -46,8 +46,8 @@ class Application(
     Redirect(location + path, request.queryString)
   }
 
-  def unsupportedBrowser: Action[AnyContent] = CachedAction() { implicit request =>
-    BrowserCheck.logUserAgent
+  def unsupportedBrowser: Action[AnyContent] = NoCacheAction() { implicit request =>
+    BrowserCheck.logUserAgent(request)
     Ok(views.html.unsupportedBrowserPage())
   }
 

--- a/app/utils/BrowserCheck.scala
+++ b/app/utils/BrowserCheck.scala
@@ -1,0 +1,12 @@
+package utils
+
+import com.typesafe.scalalogging.LazyLogging
+import play.api.mvc.RequestHeader
+
+object BrowserCheck extends LazyLogging {
+  def logUserAgent(implicit request: RequestHeader): Unit = {
+    logger.warn(s"Unsupported user agent: ${
+      request.headers.get("User-Agent").getOrElse("No User-Agent available in request.headers")
+    }")
+  }
+}

--- a/conf/routes
+++ b/conf/routes
@@ -2,6 +2,9 @@
 
 GET /healthcheck                                    controllers.Application.healthcheck
 
+# ----- Unsupported Browsers ----- #
+
+GET /unsupported-browser                            controllers.Application.unsupportedBrowser
 
 # ----- Bundles Landing Page ----- #
 


### PR DESCRIPTION
## Why are you doing this?
We're moving the unsupported browser intercept code to Fastly. From there it'll redirect trapped browsers to a specific page, and for that we need a route into the application.

We'll continue to log the user agents that are sent here to make sure the regex in Fastly is working as it should.

Once we've proved this is reliable, we can also record additional data such as the destination page etc.

[**Trello Card**](https://trello.com/c/ZGxOC5xb/1259-add-samsung-browser-trap-to-fastly)

## Screenshots
![screen shot 2018-01-31 at 15 39 54](https://user-images.githubusercontent.com/690395/35631908-1785bb9c-069d-11e8-9c22-782d4ee4456d.png)

Here's a bonus snippet from the logs too;
```2018-01-31 16:20:18,981 [application-akka.actor.default-dispatcher-501] WARN utils.BrowserCheck$ - Unsupported user agent: SamsungBrowser/2.0 but its really Justin pretending```
