### PR TITLE
Add paypal diagram to README

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -15,6 +15,7 @@ Support Frontend, how they interact and how you can start adding code to this re
 8. [A/B Test framework](#8-ab-test-framework)
 9. [Test environments](#9-test-environments)
 10. [CSS guidelines](#10-css-guidelines)
+11. [Payment Diagrams](#11-payment-diagrams)
 
 ## 1. Getting started
 
@@ -513,3 +514,7 @@ As an example consider the following CSS for a shared component called `DoubleHe
 ```
 
 Note that we avoid nesting, we use a BEM approach and we prefix the classes with `component`. 
+
+## 11 Payment Diagrams 
+The following diagram shows the series of requests that take place for a One-Off PayPal payment
+![This diagram shows the series of requests that take place for a One-Off PayPal payment ](http://i68.tinypic.com/2m5bjeo.png)

--- a/docs/development.md
+++ b/docs/development.md
@@ -517,4 +517,4 @@ Note that we avoid nesting, we use a BEM approach and we prefix the classes with
 
 ## 11 Payment Diagrams 
 The following diagram shows the series of requests that take place for a One-Off PayPal payment
-![This diagram shows the series of requests that take place for a One-Off PayPal payment ](http://i68.tinypic.com/2m5bjeo.png)
+![This diagram shows the series of requests that take place for a One-Off PayPal payment ](https://user-images.githubusercontent.com/2844554/35405125-1a6a53ee-01fd-11e8-892b-8716f685d6d3.png)


### PR DESCRIPTION
Seeing as we are soon to move the one-off endpoints to the new API, it's probably not worth making the companion diagram for Stripe, but I think this is still worth uploading for now. 

The image is hosted on tinypic, if this is an issue let me know