### PR TITLE
No Multiline On The Header

### DIFF
--- a/assets/components/headers/simpleHeader/simpleHeader.scss
+++ b/assets/components/headers/simpleHeader/simpleHeader.scss
@@ -5,13 +5,7 @@
     height: 100%;
   }
 
-  // The quadruple lines under the header.
-  &:after {
-    @include multiline(4, gu-colour(garnett-neutral-4));
-    background-color: #fff;
-    display: block;
-    content: '';
-  }
+  border-bottom: 1px solid gu-colour(nav-rule);
 }
 
 .component-simple-header__link {

--- a/assets/stylesheets/gu-sass/colours.scss
+++ b/assets/stylesheets/gu-sass/colours.scss
@@ -84,7 +84,8 @@ $gu-colours: (
 	light-black: #999,
 
 	// Garnett
-	nav-background-colour: #e7edef,
+  nav-background-colour: #e7edef,
+  nav-rule: #abc2c9,
 
   garnett-neutral-1: #121212,
   garnett-neutral-2: #999999,


### PR DESCRIPTION
## Why are you doing this?

Dotcom doesn't put a multiline directly under the header, so we don't either. We use a single ruled line instead.

cc @JustinPinner 

## Changes

- Added the nav rule colour from dotcom.
- Swapped in a single rule for the multiline on the header.

## Screenshots

**Before:**

![rule-before](https://user-images.githubusercontent.com/5131341/35733509-9d5e320c-0815-11e8-8177-71c9c173615d.png)

**After:**

![rule-support](https://user-images.githubusercontent.com/5131341/35733207-691bd8b0-0814-11e8-9737-442f3ed3a070.png)

![rule-contribute](https://user-images.githubusercontent.com/5131341/35733212-6d9370b0-0814-11e8-9941-50bfbb72c85f.png)
