### PR TITLE
Tighten up validation on name fields

### DIFF
--- a/assets/helpers/__tests__/utilitiesTest.js
+++ b/assets/helpers/__tests__/utilitiesTest.js
@@ -11,6 +11,7 @@ import {
   parseBoolean,
   deserialiseJsonObject,
   validateEmailAddress,
+  validInputField,
 } from '../utilities';
 
 
@@ -190,6 +191,30 @@ describe('utilities', () => {
     it('should return true for test@gu.co.uk', () => {
       expect(validateEmailAddress('test@gu.co.uk')).toEqual(true);
     });
+  });
+
+  describe('validInputField', () => {
+
+    it('should return false for null', () => {
+      expect(validInputField(null)).toEqual(false);
+    });
+
+    it('should return false for undefined', () => {
+      expect(validInputField(undefined)).toEqual(false);
+    });
+
+    it('should return false for an empty string', () => {
+      expect(validInputField('')).toEqual(false);
+    });
+
+    it('should return false for a string which only contains a space', () => {
+      expect(validInputField(' ')).toEqual(false);
+    });
+
+    it('should return true for a string which contains characters other than a space', () => {
+      expect(validInputField('Test')).toEqual(true);
+    });
+
   });
 
 });

--- a/assets/helpers/__tests__/utilitiesTest.js
+++ b/assets/helpers/__tests__/utilitiesTest.js
@@ -11,7 +11,7 @@ import {
   parseBoolean,
   deserialiseJsonObject,
   validateEmailAddress,
-  validInputField,
+  emptyInputField,
 } from '../utilities';
 
 
@@ -193,26 +193,26 @@ describe('utilities', () => {
     });
   });
 
-  describe('validInputField', () => {
+  describe('emptyInputField', () => {
 
-    it('should return false for null', () => {
-      expect(validInputField(null)).toEqual(false);
+    it('should return true for null', () => {
+      expect(emptyInputField(null)).toEqual(true);
     });
 
-    it('should return false for undefined', () => {
-      expect(validInputField(undefined)).toEqual(false);
+    it('should return true for undefined', () => {
+      expect(emptyInputField(undefined)).toEqual(true);
     });
 
-    it('should return false for an empty string', () => {
-      expect(validInputField('')).toEqual(false);
+    it('should return true for an empty string', () => {
+      expect(emptyInputField('')).toEqual(true);
     });
 
-    it('should return false for a string which only contains a space', () => {
-      expect(validInputField(' ')).toEqual(false);
+    it('should return true for a string which only contains a space', () => {
+      expect(emptyInputField(' ')).toEqual(true);
     });
 
-    it('should return true for a string which contains characters other than a space', () => {
-      expect(validInputField('Test')).toEqual(true);
+    it('should return false for a string which contains characters other than a space', () => {
+      expect(emptyInputField('Test')).toEqual(false);
     });
 
   });

--- a/assets/helpers/utilities.js
+++ b/assets/helpers/utilities.js
@@ -87,6 +87,10 @@ function validateEmailAddress(email: string): boolean {
   return emailValidationRegex.test(email);
 }
 
+function validInputField(value: ?string): boolean {
+  return value !== undefined && value !== null && value !== '' && value.trim().length !== 0;
+}
+
 // ----- Exports ----- //
 
 export {
@@ -98,4 +102,5 @@ export {
   parseBoolean,
   deserialiseJsonObject,
   validateEmailAddress,
+  validInputField,
 };

--- a/assets/helpers/utilities.js
+++ b/assets/helpers/utilities.js
@@ -87,8 +87,8 @@ function validateEmailAddress(email: string): boolean {
   return emailValidationRegex.test(email);
 }
 
-function validInputField(value: ?string): boolean {
-  return value !== undefined && value !== null && value !== '' && value.trim().length !== 0;
+function validInputField(input: ?string): boolean {
+  return input !== undefined && input !== null && input !== '' && input.trim().length !== 0;
 }
 
 // ----- Exports ----- //

--- a/assets/helpers/utilities.js
+++ b/assets/helpers/utilities.js
@@ -87,8 +87,8 @@ function validateEmailAddress(email: string): boolean {
   return emailValidationRegex.test(email);
 }
 
-function validInputField(input: ?string): boolean {
-  return input !== undefined && input !== null && input !== '' && input.trim().length !== 0;
+function emptyInputField(input: ?string): boolean {
+  return input === undefined || input === null || input === '' || input.trim().length === 0;
 }
 
 // ----- Exports ----- //
@@ -102,5 +102,5 @@ export {
   parseBoolean,
   deserialiseJsonObject,
   validateEmailAddress,
-  validInputField,
+  emptyInputField,
 };

--- a/assets/pages/regular-contributions/components/regularContributionsPayment.jsx
+++ b/assets/pages/regular-contributions/components/regularContributionsPayment.jsx
@@ -18,6 +18,7 @@ import type { Participations } from 'helpers/abTests/abtest';
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import { setPayPalHasLoaded } from '../regularContributionsActions';
 import { postCheckout } from '../helpers/ajax';
+import { validInputField } from '../../../helpers/utilities';
 
 // ----- Types ----- //
 
@@ -157,7 +158,7 @@ function mapStateToProps(state) {
     isTestUser: state.page.user.isTestUser || false,
     isPostDeploymentTestUser: state.page.user.isPostDeploymentTestUser,
     email: state.page.user.email,
-    hide: state.page.user.firstName === '' || state.page.user.lastName === '',
+    hide: !validInputField(state.page.user.firstName) || !validInputField(state.page.user.lastName),
     error: state.page.regularContrib.error,
     paymentStatus: state.page.regularContrib.paymentStatus,
     amount: state.page.regularContrib.amount,

--- a/assets/pages/regular-contributions/components/regularContributionsPayment.jsx
+++ b/assets/pages/regular-contributions/components/regularContributionsPayment.jsx
@@ -18,7 +18,7 @@ import type { Participations } from 'helpers/abTests/abtest';
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import { setPayPalHasLoaded } from '../regularContributionsActions';
 import { postCheckout } from '../helpers/ajax';
-import { validInputField } from '../../../helpers/utilities';
+import { emptyInputField } from '../../../helpers/utilities';
 
 // ----- Types ----- //
 
@@ -158,7 +158,7 @@ function mapStateToProps(state) {
     isTestUser: state.page.user.isTestUser || false,
     isPostDeploymentTestUser: state.page.user.isPostDeploymentTestUser,
     email: state.page.user.email,
-    hide: !validInputField(state.page.user.firstName) || !validInputField(state.page.user.lastName),
+    hide: emptyInputField(state.page.user.firstName) || emptyInputField(state.page.user.lastName),
     error: state.page.regularContrib.error,
     paymentStatus: state.page.regularContrib.paymentStatus,
     amount: state.page.regularContrib.amount,


### PR DESCRIPTION
## Why are you doing this?

There are a couple of scenarios where users can currently attempt to make a recurring contribution, even though the attempt will never succeed:

1. User populates first and/or last name fields with a space.
2. User has no first or last name in identity, and therefore tries to proceed when these fields are undefined.

Currently, in the first case the user will always see the pending thank you page, but the Step Function execution will eventually time out.

In the second case, the user gets a generic and unhelpful error ("There was an error processing your payment. Please try again later"). This doesn't help them to fix the problem, and is likely to slightly lower our conversion rate.

[**Trello Card**](https://trello.com/c/nFKiCfTn/1226-users-can-attempt-to-sign-up-without-a-last-name-but-they-cannot-succeed-due-to-salesforce-validation)

## Changes

* Add checks to catch null, undefined and strings which only contains spaces

## Screenshots
Users with invalid names in identity now arrive on a page which looks like this:

![image](https://user-images.githubusercontent.com/19384074/35740767-c9d00b36-082d-11e8-87bb-161e27982d25.png)

