### PR TITLE
Initial state for AU EU

### DIFF
--- a/assets/pages/contributions-landing/__tests__/contributionsLandingReducersTest.js
+++ b/assets/pages/contributions-landing/__tests__/contributionsLandingReducersTest.js
@@ -4,7 +4,8 @@
 
 import type { Contrib, Amount } from 'helpers/contributions';
 
-import reducer from '../contributionsLandingReducers';
+import { createContributionLandingReducer } from '../contributionsLandingReducers';
+
 
 
 // ----- Tests ----- //
@@ -15,11 +16,14 @@ describe('reducer tests', () => {
 
   it('should return the initial state', () => {
 
+    const reducer = createContributionLandingReducer('10');
+
     expect(reducer(undefined, {})).toMatchSnapshot();
   });
 
   it('should handle CHANGE_CONTRIB_TYPE to ONE_OFF', () => {
 
+    const reducer = createContributionLandingReducer('10');
     const contribType: Contrib = 'ONE_OFF';
     const action = {
       type: 'CHANGE_CONTRIB_TYPE',
@@ -35,6 +39,7 @@ describe('reducer tests', () => {
 
   it('should handle CHANGE_CONTRIB_TYPE to MONTHLY', () => {
 
+    const reducer = createContributionLandingReducer('10');
     const contribType: Contrib = 'MONTHLY';
     const action = {
       type: 'CHANGE_CONTRIB_TYPE',
@@ -50,6 +55,7 @@ describe('reducer tests', () => {
 
   it('should handle CHANGE_CONTRIB_TYPE to ANNUAL', () => {
 
+    const reducer = createContributionLandingReducer('10');
     const contribType: Contrib = 'ANNUAL';
     const action = {
       type: 'CHANGE_CONTRIB_TYPE',
@@ -65,6 +71,7 @@ describe('reducer tests', () => {
 
   it('should handle CHANGE_CONTRIB_AMOUNT', () => {
 
+    const reducer = createContributionLandingReducer('10');
     const amount: Amount = {
       value: '50',
       userDefined: true,
@@ -84,6 +91,7 @@ describe('reducer tests', () => {
 
   it('should handle CHANGE_CONTRIB_AMOUNT_MONTHLY', () => {
 
+    const reducer = createContributionLandingReducer('10');
     const amount: Amount = {
       value: '45',
       userDefined: true,
@@ -103,6 +111,7 @@ describe('reducer tests', () => {
 
   it('should handle CHANGE_CONTRIB_AMOUNT_ANNUAL', () => {
 
+    const reducer = createContributionLandingReducer('10');
     const amount: Amount = {
       value: '50',
       userDefined: false,
@@ -122,6 +131,7 @@ describe('reducer tests', () => {
 
   it('should handle CHANGE_CONTRIB_AMOUNT_ONEOFF', () => {
 
+    const reducer = createContributionLandingReducer('10');
     const amount: Amount = {
       value: '45',
       userDefined: true,

--- a/assets/pages/contributions-landing/__tests__/contributionsLandingReducersTest.js
+++ b/assets/pages/contributions-landing/__tests__/contributionsLandingReducersTest.js
@@ -7,7 +7,6 @@ import type { Contrib, Amount } from 'helpers/contributions';
 import { createContributionLandingReducer } from '../contributionsLandingReducers';
 
 
-
 // ----- Tests ----- //
 
 jest.mock('ophan', () => {});

--- a/assets/pages/contributions-landing/contributionsLandingAU.jsx
+++ b/assets/pages/contributions-landing/contributionsLandingAU.jsx
@@ -13,7 +13,7 @@ import ContribLegal from 'components/legal/contribLegal/contribLegal';
 import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
 
-import reducer from './contributionsLandingReducers';
+import { createContributionLandingReducer } from './contributionsLandingReducers';
 import { saveContext } from './helpers/context';
 import ContributionsBundleContent from './components/contributionsBundleContent';
 
@@ -23,7 +23,7 @@ import ContributionsBundleContent from './components/contributionsBundleContent'
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 /* eslint-enable */
 
-const store = pageInit(reducer, undefined, composeEnhancers(applyMiddleware(thunkMiddleware)));
+const store = pageInit(createContributionLandingReducer('15'), undefined, composeEnhancers(applyMiddleware(thunkMiddleware)));
 
 saveContext(store.dispatch);
 

--- a/assets/pages/contributions-landing/contributionsLandingEU.jsx
+++ b/assets/pages/contributions-landing/contributionsLandingEU.jsx
@@ -13,7 +13,7 @@ import ContribLegal from 'components/legal/contribLegal/contribLegal';
 import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
 
-import reducer from './contributionsLandingReducers';
+import { createContributionLandingReducer } from './contributionsLandingReducers';
 import { saveContext } from './helpers/context';
 import ContributionsBundleContent from './components/contributionsBundleContent';
 
@@ -23,7 +23,7 @@ import ContributionsBundleContent from './components/contributionsBundleContent'
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 /* eslint-enable */
 
-const store = pageInit(reducer, undefined, composeEnhancers(applyMiddleware(thunkMiddleware)));
+const store = pageInit(createContributionLandingReducer('15'), undefined, composeEnhancers(applyMiddleware(thunkMiddleware)));
 
 saveContext(store.dispatch);
 

--- a/assets/pages/contributions-landing/contributionsLandingReducers.js
+++ b/assets/pages/contributions-landing/contributionsLandingReducers.js
@@ -125,7 +125,7 @@ function createContributionLandingReducer(amountMonthly: string) {
 
     }
 
-  }
+  };
 }
 
 // ----- Exports ----- //

--- a/assets/pages/contributions-landing/contributionsLandingReducers.js
+++ b/assets/pages/contributions-landing/contributionsLandingReducers.js
@@ -19,116 +19,117 @@ export type ContribState = {
 };
 
 
-// ----- Setup ----- //
-// TODO: This file is basically a copy and past of bundles-landing/bundleLandingReducers.js
-// we should refactor them to remove duplication
-const initialContrib: ContribState = {
-  type: 'MONTHLY',
-  error: null,
-  amount: {
-    annual: {
-      value: '75',
-      userDefined: false,
-    },
-    monthly: {
-      value: '10',
-      userDefined: false,
-    },
-    oneOff: {
-      value: '50',
-      userDefined: false,
-    },
-  },
-  payPalError: null,
-  context: false,
-};
-
-
 // ----- Reducers ----- //
 
-function contribution(
-  state: ContribState = initialContrib,
-  action: Action,
-): ContribState {
+function createContributionLandingReducer(amountMonthly: string) {
 
-  switch (action.type) {
+  const initialContrib: ContribState = {
+    type: 'MONTHLY',
+    error: null,
+    amount: {
+      annual: {
+        value: '75',
+        userDefined: false,
+      },
+      monthly: {
+        value: amountMonthly,
+        userDefined: false,
+      },
+      oneOff: {
+        value: '50',
+        userDefined: false,
+      },
+    },
+    payPalError: null,
+    context: false,
+  };
 
-    case 'CHANGE_CONTRIB_TYPE': {
+  return function contributionLandingReducer(
+    state: ContribState = initialContrib,
+    action: Action,
+  ): ContribState {
 
-      let amount;
+    switch (action.type) {
 
-      if (action.contribType === 'ONE_OFF') {
-        amount = state.amount.oneOff.value;
-      } else if (action.contribType === 'ANNUAL') {
-        amount = state.amount.annual.value;
-      } else {
-        amount = state.amount.monthly.value;
+      case 'CHANGE_CONTRIB_TYPE': {
+
+        let amount;
+
+        if (action.contribType === 'ONE_OFF') {
+          amount = state.amount.oneOff.value;
+        } else if (action.contribType === 'ANNUAL') {
+          amount = state.amount.annual.value;
+        } else {
+          amount = state.amount.monthly.value;
+        }
+
+        return Object.assign({}, state, {
+          type: action.contribType,
+          error: parseContribution(amount, action.contribType).error,
+        });
+
       }
 
-      return Object.assign({}, state, {
-        type: action.contribType,
-        error: parseContribution(amount, action.contribType).error,
-      });
+      case 'CHANGE_CONTRIB_AMOUNT':
+
+        return Object.assign({}, state, {
+          amount: { annual: action.amount, monthly: action.amount, oneOff: action.amount },
+          error: parseContribution(action.amount.value, state.type).error,
+        });
+
+      case 'CHANGE_CONTRIB_AMOUNT_ANNUAL':
+
+        return Object.assign({}, state, {
+          amount: {
+            annual: action.amount,
+            monthly: state.amount.monthly,
+            oneOff: state.amount.oneOff,
+          },
+          error: parseContribution(action.amount.value, state.type).error,
+        });
+
+      case 'CHANGE_CONTRIB_AMOUNT_MONTHLY':
+
+        return Object.assign({}, state, {
+          amount: {
+            annual: state.amount.annual,
+            monthly: action.amount,
+            oneOff: state.amount.oneOff,
+          },
+          error: parseContribution(action.amount.value, state.type).error,
+        });
+
+      case 'CHANGE_CONTRIB_AMOUNT_ONEOFF':
+
+        return Object.assign({}, state, {
+          amount: {
+            annual: state.amount.annual,
+            monthly: state.amount.monthly,
+            oneOff: action.amount,
+          },
+          error: parseContribution(action.amount.value, state.type).error,
+        });
+
+      case 'PAYPAL_ERROR':
+
+        return Object.assign({}, state, {
+          payPalError: action.message,
+        });
+
+      case 'SET_CONTEXT':
+
+        return Object.assign({}, state, { context: action.context });
+
+      default:
+        return state;
 
     }
 
-    case 'CHANGE_CONTRIB_AMOUNT':
-
-      return Object.assign({}, state, {
-        amount: { annual: action.amount, monthly: action.amount, oneOff: action.amount },
-        error: parseContribution(action.amount.value, state.type).error,
-      });
-
-    case 'CHANGE_CONTRIB_AMOUNT_ANNUAL':
-
-      return Object.assign({}, state, {
-        amount: {
-          annual: action.amount,
-          monthly: state.amount.monthly,
-          oneOff: state.amount.oneOff,
-        },
-        error: parseContribution(action.amount.value, state.type).error,
-      });
-
-    case 'CHANGE_CONTRIB_AMOUNT_MONTHLY':
-
-      return Object.assign({}, state, {
-        amount: {
-          annual: state.amount.annual,
-          monthly: action.amount,
-          oneOff: state.amount.oneOff,
-        },
-        error: parseContribution(action.amount.value, state.type).error,
-      });
-
-    case 'CHANGE_CONTRIB_AMOUNT_ONEOFF':
-
-      return Object.assign({}, state, {
-        amount: {
-          annual: state.amount.annual,
-          monthly: state.amount.monthly,
-          oneOff: action.amount,
-        },
-        error: parseContribution(action.amount.value, state.type).error,
-      });
-
-    case 'PAYPAL_ERROR':
-
-      return Object.assign({}, state, {
-        payPalError: action.message,
-      });
-
-    case 'SET_CONTEXT':
-
-      return Object.assign({}, state, { context: action.context });
-
-    default:
-      return state;
-
   }
-
 }
 
 // ----- Exports ----- //
 
-export default contribution;
+export {
+  createContributionLandingReducer,
+};

--- a/assets/pages/contributions-landing/contributionsLandingUK.jsx
+++ b/assets/pages/contributions-landing/contributionsLandingUK.jsx
@@ -14,7 +14,7 @@ import ContribLegal from 'components/legal/contribLegal/contribLegal';
 import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
 
-import reducer from './contributionsLandingReducers';
+import { createContributionLandingReducer } from './contributionsLandingReducers';
 import { saveContext } from './helpers/context';
 import ContributionsBundleContent from './components/contributionsBundleContent';
 
@@ -25,7 +25,7 @@ import ContributionsBundleContent from './components/contributionsBundleContent'
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 /* eslint-enable */
 
-const store = pageInit(reducer, undefined, composeEnhancers(applyMiddleware(thunkMiddleware)));
+const store = pageInit(createContributionLandingReducer('10'), undefined, composeEnhancers(applyMiddleware(thunkMiddleware)));
 
 saveContext(store.dispatch);
 

--- a/assets/pages/contributions-landing/contributionsLandingUS.jsx
+++ b/assets/pages/contributions-landing/contributionsLandingUS.jsx
@@ -17,8 +17,6 @@ import { createContributionLandingReducer } from './contributionsLandingReducers
 import { saveContext } from './helpers/context';
 import ContributionsBundleContent from './components/contributionsBundleContent';
 
-import { changeContribAmountMonthly } from './contributionsLandingActions';
-
 
 // ----- Page Startup ----- //
 

--- a/assets/pages/contributions-landing/contributionsLandingUS.jsx
+++ b/assets/pages/contributions-landing/contributionsLandingUS.jsx
@@ -13,7 +13,7 @@ import ContribLegal from 'components/legal/contribLegal/contribLegal';
 import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
 
-import reducer from './contributionsLandingReducers';
+import { createContributionLandingReducer } from './contributionsLandingReducers';
 import { saveContext } from './helpers/context';
 import ContributionsBundleContent from './components/contributionsBundleContent';
 
@@ -26,17 +26,9 @@ import { changeContribAmountMonthly } from './contributionsLandingActions';
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 /* eslint-enable */
 
-const store = pageInit(reducer, undefined, composeEnhancers(applyMiddleware(thunkMiddleware)));
+const store = pageInit(createContributionLandingReducer('15'), undefined, composeEnhancers(applyMiddleware(thunkMiddleware)));
 
 saveContext(store.dispatch);
-
-(function initialiseAmountsTest() {
-  try {
-    return store.dispatch(changeContribAmountMonthly({
-      value: '15', userDefined: false,
-    }));
-  } catch (e) { return null; }
-}());
 
 
 // ----- Render ----- //


### PR DESCRIPTION
## Why are you doing this?

The initial state of each contribution landing page is different. Therefore in this PR, I am creating a reducer factory which receives the bit of state that differs in each landing page.

This PR fixes the initial state bug in AU and EU.

## Changes

* Create a reducer factor for contributions landing page.

## Screenshots

|      | Before | After |
|------|--------|-------|
| 🇪🇺 |   ![eu-before](https://user-images.githubusercontent.com/825398/35987442-96e9983e-0cf3-11e8-98e3-0bf73f919156.png)     |  ![eu-after](https://user-images.githubusercontent.com/825398/35987488-b3954550-0cf3-11e8-9626-b6ea14b32df4.png)     |
| 🇦🇺 |       ![au-before](https://user-images.githubusercontent.com/825398/35987620-17a6f714-0cf4-11e8-9b38-08915a3f6943.png) |    ![au-after](https://user-images.githubusercontent.com/825398/35987629-1ccede8c-0cf4-11e8-8a58-39f5dff32bb3.png)  |
| 🇬🇧 |   ![uk-before](https://user-images.githubusercontent.com/825398/35987716-6b1a56f2-0cf4-11e8-825f-bf4bfc568b3a.png)     |     ![uk-after](https://user-images.githubusercontent.com/825398/35987738-780fe638-0cf4-11e8-8e45-993de7c92a42.png)  |
| 🇺🇸 |  ![us-before](https://user-images.githubusercontent.com/825398/35987704-6236064e-0cf4-11e8-828a-5f049eece84e.png)      |     ![us-after](https://user-images.githubusercontent.com/825398/35987697-59f54116-0cf4-11e8-8d4f-c496614799f9.png)  |



