### PR TITLE
Updated the alarms to point reader-revenue-dev sns

### DIFF
--- a/cloud-formation/cfn.yaml
+++ b/cloud-formation/cfn.yaml
@@ -242,7 +242,7 @@ Resources:
     Condition: CreateProdResources
     Properties:
       AlarmActions:
-      - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:simple-dev
+      - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
       AlarmName: !Sub No healthy instances for support-frontend in ${Stage}
       MetricName: HealthyHostCount
       Namespace: AWS/ApplicationELB
@@ -265,7 +265,7 @@ Resources:
     Condition: CreateProdResources
     Properties:
       AlarmActions:
-      - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:simple-dev
+      - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
       AlarmName: !Sub High 5XX rate for support-frontend in ${Stage}
       MetricName: HTTPCode_Target_5XX_Count
       Namespace: AWS/ApplicationELB


### PR DESCRIPTION

## Why are you doing this?
To notify all the reader revenue devs when something goes wrong.


## Changes

* `cfn.yaml`


## Screenshots
N/A
