### PR TITLE
Upsell recurring contributions test

### DIFF
--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -42,5 +42,18 @@ export const tests: Tests = {
     independent: true,
     seed: 7,
   },
+
+  upsellRecurringContributions: {
+    variants: ['control', 'benefitsOfBoth', 'bolderControl'],
+    audiences: {
+      US: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: true,
+    independent: true,
+    seed: 0,
+  },
 };
 

--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -53,7 +53,6 @@ export const tests: Tests = {
     },
     isActive: true,
     independent: true,
-    seed: 0,
+    seed: 99,
   },
 };
-

--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -44,7 +44,7 @@ export const tests: Tests = {
   },
 
   upsellRecurringContributions: {
-    variants: ['control', 'benefitsOfBoth', 'bolderControl'],
+    variants: ['control', 'benefitsOfBoth', 'shorterControl'],
     audiences: {
       US: {
         offset: 0,

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -84,8 +84,8 @@ const subHeadingOneOffText = {
   EUR: '',
 };
 
-const contentText = {
-  GBP: 'Support the Guardian’s editorial operations by making a monthly or one-off contribution today',
+const defaultContentText = {
+  GBP: 'Support The Guardian’s editorial operations by making a monthly or one-off contribution today',
   USD: (
     <span>
       Contributing to The Guardian makes a big impact. If you’re able, please consider
@@ -109,8 +109,29 @@ const contentText = {
   ),
 };
 
+const upsellRecurringContributionsTestContentText = {
+  control: defaultContentText.US,
+  benefitsOfBoth: (
+    <span>
+      Make a monthly commitment to support The Guardian long-term or a one-time contribution
+      as and when you feel like it – choose the option that suits you best
+    </span>
+  ),
+  bolderControl: (
+    <span>
+      If you’re able, please consider monthly support –
+      it will help to fund The Guardian’s journalism for the long term.
+    </span>
+  ),
+};
+
+function getContentText(props: PropTypes) {
+  return upsellRecurringContributionsTestContentText[props.abTests.upsellRecurringContributions] ||
+    defaultContentText[props.isoCountry];
+}
+
 function ContentText(props: PropTypes) {
-  return <p className="component-bundle__content-intro"> {contentText[props.currency.iso]} </p>;
+  return <p className="component-bundle__content-intro"> {getContentText(props)} </p>;
 }
 
 const contribCtaText = {

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -110,7 +110,7 @@ const defaultContentText = {
 };
 
 const upsellRecurringContributionsTestContentText = {
-  control: defaultContentText.US,
+  control: defaultContentText.USD,
   benefitsOfBoth: (
     <span>
       Make a monthly commitment to support The Guardian long-term or a one-time contribution
@@ -127,16 +127,11 @@ const upsellRecurringContributionsTestContentText = {
 
 function getContentText(props: PropTypes) {
   return upsellRecurringContributionsTestContentText[props.abTests.upsellRecurringContributions] ||
-    defaultContentText[props.isoCountry];
-}
-
-function getContentTextClassName(props: PropTypes) {
-  const modifier = (props.abTests.upsellRecurringContributions === 'bolderControl' ? '--bolder-control' : '');
-  return `component-bundle__content-intro${modifier}`;
+    defaultContentText[props.currency.iso];
 }
 
 function ContentText(props: PropTypes) {
-  return <p className={getContentTextClassName(props)}> {getContentText(props)} </p>;
+  return <p className="component-bundle__content-intro"> {getContentText(props)} </p>;
 }
 
 const contribCtaText = {

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -130,8 +130,13 @@ function getContentText(props: PropTypes) {
     defaultContentText[props.isoCountry];
 }
 
+function getContentTextClassName(props: PropTypes) {
+  const modifier = (props.abTests.upsellRecurringContributions === 'bolderControl' ? '--bolder-control' : '');
+  return `component-bundle__content-intro${modifier}`;
+}
+
 function ContentText(props: PropTypes) {
-  return <p className="component-bundle__content-intro"> {getContentText(props)} </p>;
+  return <p className={getContentTextClassName(props)}> {getContentText(props)} </p>;
 }
 
 const contribCtaText = {

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -114,7 +114,7 @@ const upsellRecurringContributionsTestContentText = {
   benefitsOfBoth: (
     <span>
       Make a monthly commitment to support The Guardian long-term or a one-time contribution
-      as and when you feel like it &ndash choose the option that suits you best
+      as and when you feel like it &ndash choose the option that suits you best.
     </span>
   ),
   bolderControl: (

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -114,13 +114,13 @@ const upsellRecurringContributionsTestContentText = {
   benefitsOfBoth: (
     <span>
       Make a monthly commitment to support The Guardian long-term or a one-time contribution
-      as and when you feel like it &ndash choose the option that suits you best.
+      as and when you feel like it &ndash; choose the option that suits you best.
     </span>
   ),
   bolderControl: (
     <span>
-      If you’re able, please consider monthly support &ndash
-      it will help to fund The Guardian’s journalism for the long term.
+      If you’re able, please consider <strong>monthly</strong> support &ndash;
+      it will help to fund The Guardian’s journalism for the long-term.
     </span>
   ),
 };

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -117,7 +117,7 @@ const upsellRecurringContributionsTestContentText = {
       as and when you feel like it &ndash; choose the option that suits you best.
     </span>
   ),
-  bolderControl: (
+  shorterControl: (
     <span>
       If you’re able, please consider <strong>monthly</strong> support &ndash;
       it will help to fund The Guardian’s journalism for the long-term.

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -114,12 +114,12 @@ const upsellRecurringContributionsTestContentText = {
   benefitsOfBoth: (
     <span>
       Make a monthly commitment to support The Guardian long-term or a one-time contribution
-      as and when you feel like it – choose the option that suits you best
+      as and when you feel like it &ndash choose the option that suits you best
     </span>
   ),
   bolderControl: (
     <span>
-      If you’re able, please consider monthly support –
+      If you’re able, please consider monthly support &ndash
       it will help to fund The Guardian’s journalism for the long term.
     </span>
   ),

--- a/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/assets/pages/contributions-landing/contributionsLanding.scss
@@ -378,6 +378,13 @@ strong {
     color: gu-colour(neutral-1);
   }
 
+  // TODO: implement
+  .component-bundle__content-intro--bolder-control {
+    line-height: 20px;
+    margin-bottom: $gu-v-spacing * 2;
+    color: gu-colour(neutral-1);
+  }
+
   .component-radio-toggle input:not(:checked)+label, .component-number-input {
     background-color: gu-colour(comment-support-3);
   }

--- a/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/assets/pages/contributions-landing/contributionsLanding.scss
@@ -378,13 +378,6 @@ strong {
     color: gu-colour(neutral-1);
   }
 
-  // TODO: implement
-  .component-bundle__content-intro--bolder-control {
-    line-height: 20px;
-    margin-bottom: $gu-v-spacing * 2;
-    color: gu-colour(neutral-1);
-  }
-
   .component-radio-toggle input:not(:checked)+label, .component-number-input {
     background-color: gu-colour(comment-support-3);
   }


### PR DESCRIPTION
## Why are you doing this?

To try and increase the proportion of readers who sign-up to recurring contributions (vs one-off contributions).

__[Trello card](https://trello.com/c/gcc8Ipi4/68-us-landing-page-test)__

## Changes

- change `the Guardian` to `The Guardian` in the default content text of GBP one-off contributions (house-keeping)
- implement the Upsell Recurring Contributions test

## Screenshots

__control__
<img width="1263" alt="control" src="https://user-images.githubusercontent.com/4085817/36026275-4082c22c-0d8e-11e8-8fa5-bcc7e2389a2e.png">

__benefits of both__
<img width="1259" alt="benefits-of-both" src="https://user-images.githubusercontent.com/4085817/36026287-49316fae-0d8e-11e8-80ee-0202368361dc.png">

__shorter control__
<img width="1260" alt="shorter-control" src="https://user-images.githubusercontent.com/4085817/36026292-4fe1f74c-0d8e-11e8-92f8-125f5beb9669.png">




