### PR TITLE
Add Multiple Query Params To A URL

### DIFF
--- a/assets/helpers/__tests__/urlTest.js
+++ b/assets/helpers/__tests__/urlTest.js
@@ -1,0 +1,75 @@
+// @flow
+
+// ----- Imports ----- //
+
+import { addQueryParamsToURL } from '../url';
+
+
+// ----- Tests ----- //
+
+describe('url', () => {
+
+  describe('addQueryParamsToURL', () => {
+
+    it('should add a query param to an absolute URL', () => {
+
+      const startingUrl = 'https://gu.com/index?hello=world';
+      const params = { spam: 'eggs' };
+      const expectedUrl = `${startingUrl}&spam=eggs`;
+
+      expect(addQueryParamsToURL(startingUrl, params)).toEqual(expectedUrl);
+
+    });
+
+    it('should add multiple query params to an absolute URL', () => {
+
+      const startingUrl = 'https://gu.com/index?hello=world';
+      const params = { spam: 'eggs', answer: '42' };
+      const expectedUrl = `${startingUrl}&spam=eggs&answer=42`;
+
+      expect(addQueryParamsToURL(startingUrl, params)).toEqual(expectedUrl);
+
+    });
+
+    it('should add a query param to a relative URL', () => {
+
+      const startingUrl = 'https://gu.com?hello=world';
+      const params = { spam: 'eggs' };
+      const expectedUrl = `${startingUrl}&spam=eggs`;
+
+      expect(addQueryParamsToURL(startingUrl, params)).toEqual(expectedUrl);
+
+    });
+
+    it('should add multiple query params to a relative URL', () => {
+
+      const startingUrl = '/index?hello=world';
+      const params = { spam: 'eggs', answer: '42' };
+      const expectedUrl = `${startingUrl}&spam=eggs&answer=42`;
+
+      expect(addQueryParamsToURL(startingUrl, params)).toEqual(expectedUrl);
+
+    });
+
+    it('should return the existing URL if no params are passed', () => {
+
+      const startingUrl = '/index?hello=world';
+      const params = {};
+
+      expect(addQueryParamsToURL(startingUrl, params)).toEqual(startingUrl);
+
+    });
+
+    it('should add params if none exist', () => {
+
+      const startingUrl = 'https://gu.com/index';
+      const params = { spam: 'eggs', answer: '42' };
+      const expectedUrl = `${startingUrl}?spam=eggs&answer=42`;
+
+      expect(addQueryParamsToURL(startingUrl, params)).toEqual(expectedUrl);
+
+    });
+
+  });
+
+});

--- a/assets/helpers/url.js
+++ b/assets/helpers/url.js
@@ -59,6 +59,22 @@ const addQueryParamToURL = (urlOrPath: string, paramsKey: string, paramsValue: ?
   return `${strInit}?${paramsObj.toString()}`;
 };
 
+// Takes a mapping of query params and adds to an absolute or relative URL.
+function addQueryParamsToURL(
+  urlString: string,
+  params: { [string]: string },
+): string {
+
+  const [baseUrl, ...oldParams] = urlString.split('?');
+  const searchParams = new URLSearchParams(oldParams.join('&'));
+
+  Object.keys(params).forEach(key =>
+    searchParams.set(key, params[key]));
+
+  return `${baseUrl}?${searchParams.toString()}`;
+
+}
+
 // Retrieves the domain for the given env, e.g. guardian.com/gulocal.com.
 function getBaseDomain(): Domain {
 
@@ -84,4 +100,5 @@ export {
   getQueryParams,
   addQueryParamToURL,
   getBaseDomain,
+  addQueryParamsToURL,
 };


### PR DESCRIPTION
## Why are you doing this?

There's a few places where we have to add multiple query params to URL, and it's a bit laborious. This adds a helper to handle that. There are also some tests to check that it works.

**Note:** Why aren't we using the `URL()` constructor? You have to supply it with an absolute URL unfortunately, which we don't always want.

cc @JustinPinner 

## Changes

- Created a helper for adding multiple query params to a URL.
- Added some corresponding tests.
