### PR TITLE
Exclude log messages intended for Sentry from log file on disk

### DIFF
--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -3,6 +3,14 @@
 <contextName>frontend</contextName>
 
 <appender name="LOGFILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+
+    <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+        <evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
+            <marker>SENTRY</marker>
+        </evaluator>
+        <onMatch>DENY</onMatch>
+    </filter>
+
     <file>logs/application.log</file>
 
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">


### PR DESCRIPTION
## Why are you doing this?

This is a small improvement on https://github.com/guardian/support-frontend/pull/494

After that PR the application.log file started to contain both the original and sanitized versions of error messages (unnecessary duplication). This PR filters out the sanitized error messages.

## Changes

* Add filter to file appender in logback.xml.

