### PR TITLE
Show The Current Year In Copyright

### DIFF
--- a/assets/helpers/legal.js
+++ b/assets/helpers/legal.js
@@ -16,7 +16,7 @@ const termsLinks: {
 
 const privacyLink = 'https://www.theguardian.com/help/privacy-policy';
 
-const copyrightNotice = `\u00A9 2017 Guardian News and Media Limited or its
+const copyrightNotice = `\u00A9 ${(new Date()).getFullYear()} Guardian News and Media Limited or its
   affiliated companies. All rights reserved.`;
 
 


### PR DESCRIPTION
## Why are you doing this?

To show the correct year in the copyright notice. I thought this would be easier than doing a PR every time this changes (because we'll forget, as evidenced by the fact that it's February 2018 now). Technically this could show the wrong year if a user's clock is messed up. Thoughts?

cc @JustinPinner @CPKING

## Changes

- Auto-update the copyright notice by year.

## Screenshots

![copyright-year](https://user-images.githubusercontent.com/5131341/36317470-1422b24e-1335-11e8-96b9-9394187ab39d.png)