### PR TITLE
Circles Rebuild - Part XIII - Custom Contribution Amount Validation Bug-fix

### DIFF
--- a/assets/containerisableComponents/contributionSelection/__tests__/contributionSelectionReducerTest.js
+++ b/assets/containerisableComponents/contributionSelection/__tests__/contributionSelectionReducerTest.js
@@ -42,6 +42,25 @@ describe('Contributions Selection reducer', () => {
 
   });
 
+  it('should re-parse custom amounts when SET_CONTRIBUTION_TYPE is fired', () => {
+
+    const contributionType = 'MONTHLY';
+    const initialState = {
+      contributionType: 'ONE_OFF',
+      oneOffAmount: '50',
+      monthlyAmount: '5',
+      annualAmount: '75',
+      customAmount: '1',
+      isCustomAmount: true,
+      error: null,
+    };
+
+    const changeContributionType = actions.setContributionType(contributionType);
+    const newState = reducer(initialState, changeContributionType);
+    expect(newState.error).toEqual('tooLittle');
+
+  });
+
   it('should handle SET_AMOUNT for one-off', () => {
 
     const amount = '42';


### PR DESCRIPTION
## Why are you doing this?

@CPKING discovered a subtle bug lurking in the custom amount selection (circles only).

### Background

When the user enters a custom amount, we validate it according to certain conditions: is it a valid number, and does it fall within the boundaries accepted for the given contribution type (e.g. maximum one-off amount, minimum monthly amount)? The conditions are different depending on whether one-off or monthly (or annual) is selected, as there are different maximum and minimum amounts.

### The Problem

If the user enters a custom amount for one contribution type, then the validation runs for that contributions type. However, if they then switch contribution types with the custom amount still selected, the validation doesn't re-run on the entered value, allowing them to continue with an invalid amount for the new type of contribution.

### The Solution

Apply the validation of the custom amount whenever the user switches contribution type. I've added a new function to do this.

[**Trello Card**](https://trello.com/c/jUyIXhAv/1309-bug-circles-validation-quirkiness)

cc @JustinPinner 

## Changes

- Added a more specific type for parsed custom contribution amounts.
- Stopped passing the full state to `parseCustomAmount`.
- Added a new `checkCustomAmount` function to validate the existing custom amount.
- Now running a check on the custom amount whenever the contribution type is changed.
