### PR TITLE
Add clearer logging to Regular Contributions controller

### DIFF
--- a/app/controllers/RegularContributions.scala
+++ b/app/controllers/RegularContributions.scala
@@ -54,7 +54,13 @@ class RegularContributions(
             )
           )
       }
-    } getOrElse InternalServerError
+    } fold (
+      { error =>
+        SafeLogger.error(scrub"Failed to display recurring contributions form for ${request.user.id} due to Identity error: $error")
+        InternalServerError
+      },
+      identity
+    )
   }
 
   def status(jobId: String): Action[AnyContent] = AuthenticatedAction.async { implicit request =>

--- a/app/controllers/RegularContributions.scala
+++ b/app/controllers/RegularContributions.scala
@@ -36,8 +36,10 @@ class RegularContributions(
 
   def displayForm(paypal: Option[Boolean]): Action[AnyContent] = AuthenticatedAction.async { implicit request =>
     identityService.getUser(request.user).semiflatMap { fullUser =>
-      isMonthlyContributor(request.user.credentials).recover({ case _ => None }) map {
-        case Some(true) => Redirect("/contribute/recurring/existing")
+      isMonthlyContributor(request.user.credentials) map {
+        case Some(true) =>
+          SafeLogger.info(s"Determined that ${request.user.id} is already a monthly contributor; re-directing to /contribute/recurring/existing")
+          Redirect("/contribute/recurring/existing")
         case Some(false) | None =>
           val uatMode = testUsers.isTestUser(fullUser.publicFields.displayName)
           Ok(
@@ -56,7 +58,7 @@ class RegularContributions(
       }
     } fold (
       { error =>
-        SafeLogger.error(scrub"Failed to display recurring contributions form for ${request.user.id} due to Identity error: $error")
+        SafeLogger.error(scrub"Failed to display recurring contributions form for ${request.user.id} due to error from identityService: $error")
         InternalServerError
       },
       identity
@@ -66,7 +68,7 @@ class RegularContributions(
   def status(jobId: String): Action[AnyContent] = AuthenticatedAction.async { implicit request =>
     client.status(jobId, request.uuid).fold(
       { error =>
-        SafeLogger.error(scrub"Failed to get status of step function execution due to $error")
+        SafeLogger.error(scrub"Failed to get status of step function execution for user ${request.user.id} due to $error")
         InternalServerError
       },
       response => Ok(response.asJson)
@@ -111,11 +113,15 @@ class RegularContributions(
         {
           case UserNotFound => Some(false)
           case error =>
-            SafeLogger.error(scrub"Failed to fetch user attributes from members data service: $error")
+            SafeLogger.warn(s"Failed to fetch user attributes due to an error from members-data-api: $error")
             None
         },
         { response => Some(response.contentAccess.recurringContributor) }
-      )
+      ).recover {
+          case throwable @ _ =>
+            SafeLogger.warn(s"Failed to fetch user attributes from members-data-api due to a failed Future: ${throwable.getCause}")
+            None
+        }
     case _ => Future.successful(None)
   }
 }


### PR DESCRIPTION
## Why are you doing this?

A user reported an issue and I was unable to debug it because our logging is currently too sparse. 

## Changes

* Log when we fail to display the regular contributions form due to errors from Identity
* Clarify existing logging
* Downgrade errors from members-data-api to warn level
* Handle failed futures when calling members-data-api within _isMonthlyContributor_ instead of _displayForm_.

