### PR TITLE
Make Payment CTAs Consistent

### DIFF
--- a/assets/helpers/__tests__/contributionsTest.js
+++ b/assets/helpers/__tests__/contributionsTest.js
@@ -2,7 +2,7 @@
 
 // ----- Imports ----- //
 
-import { contribCamelCase } from '../contributions';
+import { getContribKey } from '../contributions';
 
 
 // ----- Tests ----- //
@@ -11,9 +11,9 @@ describe('theGrid', () => {
 
   it('should correctly return camelCase versions of contributions', () => {
 
-    expect(contribCamelCase('ANNUAL')).toEqual('annual');
-    expect(contribCamelCase('MONTHLY')).toEqual('monthly');
-    expect(contribCamelCase('ONE_OFF')).toEqual('oneOff');
+    expect(getContribKey('ANNUAL')).toEqual('annual');
+    expect(getContribKey('MONTHLY')).toEqual('monthly');
+    expect(getContribKey('ONE_OFF')).toEqual('oneOff');
 
   });
 

--- a/assets/helpers/contributions.js
+++ b/assets/helpers/contributions.js
@@ -132,7 +132,7 @@ function errorMessage(
 
 }
 
-function contribCamelCase(contrib: Contrib): string {
+function getContribKey(contrib: Contrib): string {
 
   switch (contrib) {
     case 'ANNUAL': return 'annual';
@@ -186,7 +186,7 @@ export {
   parseContrib,
   billingPeriodFromContrib,
   errorMessage,
-  contribCamelCase,
+  getContribKey,
   getOneOffName,
   getOneOffSpokenName,
   getContributionTypeClassName,

--- a/assets/pages/bundles-landing/components/stackedBundle.jsx
+++ b/assets/pages/bundles-landing/components/stackedBundle.jsx
@@ -12,7 +12,7 @@ import ContribAmounts from 'components/contribAmounts/contribAmounts';
 import PayPalContributionButton from 'containerisableComponents/payPalContributionButton/payPalContributionButton';
 import TermsPrivacy from 'components/legal/termsPrivacy/termsPrivacy';
 import { routes } from 'helpers/routes';
-import { contribCamelCase } from 'helpers/contributions';
+import { getContribKey } from 'helpers/contributions';
 
 import type { ListItem } from 'components/featureList/featureList';
 import type { Contrib, Amounts, ContribError } from 'helpers/contributions';
@@ -240,7 +240,7 @@ const getContribAttrs = (
   intCmp: ?string,
 ): ContribAttrs => {
 
-  const contType = contribCamelCase(contribType);
+  const contType = getContribKey(contribType);
   const params = new URLSearchParams();
 
   params.append('contributionValue', contribAmount[contType].value);

--- a/assets/pages/bundles-landing/support-landing-ab-test/components/contributeNewDesign.jsx
+++ b/assets/pages/bundles-landing/support-landing-ab-test/components/contributeNewDesign.jsx
@@ -12,7 +12,7 @@ import CtaLink from 'components/ctaLink/ctaLink';
 import PayPalContributionButton
   from 'containerisableComponents/payPalContributionButton/payPalContributionButton';
 import TermsPrivacy from 'components/legal/termsPrivacy/termsPrivacy';
-import { contribCamelCase } from 'helpers/contributions';
+import { getContribKey } from 'helpers/contributions';
 
 import type {
   Amount,
@@ -69,14 +69,14 @@ type PropTypes = {
 
 function mapStateToProps(state) {
 
-  const contributionTypeCamelCase = contribCamelCase(state.page.type);
+  const contributionTypeKey = getContribKey(state.page.type);
 
   return {
     contributionType: state.page.type,
     country: state.common.country,
     countryGroupId: state.common.countryGroup,
     currency: state.common.currency,
-    selectedAmount: state.page.amount[contributionTypeCamelCase],
+    selectedAmount: state.page.amount[contributionTypeKey],
     contributionError: state.page.error,
     referrerAcquisitionData: state.common.referrerAcquisitionData,
     abTests: state.common.abParticipations,

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -13,9 +13,11 @@ import ContribAmounts from 'components/contribAmounts/contribAmounts';
 import PayPalContributionButton from 'containerisableComponents/payPalContributionButton/payPalContributionButton';
 import TermsPrivacy from 'components/legal/termsPrivacy/termsPrivacy';
 
+import { contribCamelCase } from 'helpers/contributions';
+
 import type { Contrib, Amounts, ContribError } from 'helpers/contributions';
 import type { IsoCountry } from 'helpers/internationalisation/country';
-import type { IsoCurrency, Currency } from 'helpers/internationalisation/currency';
+import type { Currency } from 'helpers/internationalisation/currency';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import type { Participations } from 'helpers/abTests/abtest';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
@@ -176,15 +178,20 @@ function ContentText(props: PropTypes) {
   return <p className="component-bundle__content-intro"> {getContentText(props)} </p>;
 }
 
-const contribCtaText = {
-  ANNUAL: 'Contribute with card or PayPal',
-  MONTHLY: 'Contribute with card or PayPal',
-  ONE_OFF: 'Contribute with debit/credit card',
-};
+function getCtaText(contribType: Contrib, currency: Currency, amounts: Amounts) {
+
+  const paymentMethods = contribType === 'ONE_OFF' ? 'card' : 'card or PayPal';
+  const contType = contribCamelCase(contribType);
+
+  return `Contribute ${currency.glyph}${amounts[contType].value} with ${paymentMethods}`;
+
+}
 
 function contribAttrs(
   countryGroupId: CountryGroupId,
   contribType: Contrib,
+  currency: Currency,
+  amounts: Amounts,
 ): ContribAttrs {
   const subHeadingText = contribType === 'ONE_OFF'
     ? subHeadingOneOffText[countryGroupId]
@@ -193,7 +200,7 @@ function contribAttrs(
   return {
     heading: 'contribute',
     subheading: subHeadingText,
-    ctaText: contribCtaText[contribType],
+    ctaText: getCtaText(contribType, currency, amounts),
     modifierClass: 'contributions',
     ctaLink: '',
     showPaymentLogos: false,
@@ -211,7 +218,7 @@ function showPayPal(props: PropTypes) {
       countryGroupId={props.countryGroupId}
       errorHandler={props.payPalErrorHandler}
       canClick={!props.contribError}
-      buttonText="Contribute with PayPal"
+      buttonText={`Contribute ${props.currency.glyph}${props.contribAmount.oneOff.value} with PayPal`}
     />);
   }
   return null;
@@ -240,7 +247,7 @@ const getContribAttrs = (
   referrerAcquisitionData: ReferrerAcquisitionData,
   isoCountry: IsoCountry,
   countryGroupId: CountryGroupId,
-  currency: IsoCurrency,
+  currency: Currency,
 ): ContribAttrs => {
 
   const contType = getContribKey(contribType);
@@ -250,7 +257,7 @@ const getContribAttrs = (
 
   params.append('contributionValue', contribAmount[contType].value);
   params.append('contribType', contribType);
-  params.append('currency', currency);
+  params.append('currency', currency.iso);
   params.append('countryGroup', countryGroupId);
 
   if (intCmp) {
@@ -263,7 +270,11 @@ const getContribAttrs = (
 
   const ctaLink = `${ctaLinks[contType]}?${params.toString()}`;
 
-  return Object.assign({}, contribAttrs(countryGroupId, contribType), { ctaLink });
+  return Object.assign(
+    {},
+    contribAttrs(countryGroupId, contribType, currency, contribAmount),
+    { ctaLink },
+  );
 
 };
 
@@ -288,7 +299,7 @@ function ContributionsBundle(props: PropTypes) {
     props.referrerAcquisitionData,
     props.isoCountry,
     props.countryGroupId,
-    props.currency.iso,
+    props.currency,
   );
 
   attrs.showPaymentLogos = true;

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -13,7 +13,7 @@ import ContribAmounts from 'components/contribAmounts/contribAmounts';
 import PayPalContributionButton from 'containerisableComponents/payPalContributionButton/payPalContributionButton';
 import TermsPrivacy from 'components/legal/termsPrivacy/termsPrivacy';
 
-import { contribCamelCase } from 'helpers/contributions';
+import { getContribKey } from 'helpers/contributions';
 
 import type { Contrib, Amounts, ContribError } from 'helpers/contributions';
 import type { IsoCountry } from 'helpers/internationalisation/country';
@@ -181,7 +181,7 @@ function ContentText(props: PropTypes) {
 function getCtaText(contribType: Contrib, currency: Currency, amounts: Amounts) {
 
   const paymentMethods = contribType === 'ONE_OFF' ? 'card' : 'card or PayPal';
-  const contType = contribCamelCase(contribType);
+  const contType = getContribKey(contribType);
 
   return `Contribute ${currency.glyph}${amounts[contType].value} with ${paymentMethods}`;
 
@@ -242,7 +242,7 @@ const getContribAttrs = (
   currency: Currency,
 ): ContribAttrs => {
 
-  const contType = contribCamelCase(contribType);
+  const contType = getContribKey(contribType);
   const params = new URLSearchParams();
   const intCmp = referrerAcquisitionData.campaignCode;
   const refpvid = referrerAcquisitionData.referrerPageviewId;

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -233,14 +233,6 @@ const ctaLinks = {
 
 // ----- Functions ----- //
 
-function getContribKey(contribType) {
-  switch (contribType) {
-    case 'ANNUAL': return 'annual';
-    case 'MONTHLY': return 'monthly';
-    default: return 'oneOff';
-  }
-}
-
 const getContribAttrs = (
   contribType: Contrib,
   contribAmount: Amounts,
@@ -250,7 +242,7 @@ const getContribAttrs = (
   currency: Currency,
 ): ContribAttrs => {
 
-  const contType = getContribKey(contribType);
+  const contType = contribCamelCase(contribType);
   const params = new URLSearchParams();
   const intCmp = referrerAcquisitionData.campaignCode;
   const refpvid = referrerAcquisitionData.referrerPageviewId;


### PR DESCRIPTION
## Why are you doing this?

To make the contributions landing CTAs consistent with those on the bundles landing page.

[**Trello Card**](https://trello.com/c/exBI9PIc/1316-ensure-consistency-across-cta-copy-for-all-support-pages)

cc @JustinPinner @ionamckendrick @CPKING 

## Changes

- Changed 'Contribute with debit/credit card' to 'Contribute with card'.
- Added the amount to the CTA.
- Renamed `contribCamelCase` to `getContribKey`.

## Screenshots

x | Monthly | One-Off
-|-|-
Before | ![cta-monthly-before](https://user-images.githubusercontent.com/5131341/36427816-1515b5ac-1646-11e8-879f-cb3a6fc23bbf.png) | ![cta-oneoff-before](https://user-images.githubusercontent.com/5131341/36427866-3305d6c8-1646-11e8-9999-a359ee4e9223.png)
After | ![cta-monthly-after](https://user-images.githubusercontent.com/5131341/36427884-404d7048-1646-11e8-9a9e-1eeda988d739.png) | ![cta-oneoff-after](https://user-images.githubusercontent.com/5131341/36427890-44dc6efc-1646-11e8-8926-bba1cce80ac2.png)
