### PR TITLE
Circles Rebuild - Part XIV - Another Contribution Amount Validation Bug-fix

### DIFF
--- a/assets/containerisableComponents/contributionSelection/__tests__/contributionSelectionReducerTest.js
+++ b/assets/containerisableComponents/contributionSelection/__tests__/contributionSelectionReducerTest.js
@@ -42,7 +42,7 @@ describe('Contributions Selection reducer', () => {
 
   });
 
-  it('should re-parse custom amounts when SET_CONTRIBUTION_TYPE is fired', () => {
+  it('should re-parse custom amounts when SET_CONTRIBUTION_TYPE is fired for MONTHLY', () => {
 
     const contributionType = 'MONTHLY';
     const initialState = {
@@ -58,6 +58,25 @@ describe('Contributions Selection reducer', () => {
     const changeContributionType = actions.setContributionType(contributionType);
     const newState = reducer(initialState, changeContributionType);
     expect(newState.error).toEqual('tooLittle');
+
+  });
+
+  it('should re-parse custom amounts when SET_CONTRIBUTION_TYPE is fired for ONE_OFF', () => {
+
+    const contributionType = 'ONE_OFF';
+    const initialState = {
+      contributionType: 'MONTHLY',
+      oneOffAmount: '50',
+      monthlyAmount: '5',
+      annualAmount: '75',
+      customAmount: '1',
+      isCustomAmount: true,
+      error: 'tooLittle',
+    };
+
+    const changeContributionType = actions.setContributionType(contributionType);
+    const newState = reducer(initialState, changeContributionType);
+    expect(newState.error).toBeNull();
 
   });
 

--- a/assets/containerisableComponents/contributionSelection/contributionSelectionReducer.js
+++ b/assets/containerisableComponents/contributionSelection/contributionSelectionReducer.js
@@ -2,7 +2,7 @@
 
 // ----- Imports ----- //
 
-import { betterParse as parseContribution } from 'helpers/contributions';
+import { circlesParse as parseContribution } from 'helpers/contributions';
 
 import type {
   Contrib as ContributionType,

--- a/assets/containerisableComponents/contributionSelection/contributionSelectionReducer.js
+++ b/assets/containerisableComponents/contributionSelection/contributionSelectionReducer.js
@@ -2,11 +2,12 @@
 
 // ----- Imports ----- //
 
-import { parse as parseContribution } from 'helpers/contributions';
+import { betterParse as parseContribution } from 'helpers/contributions';
 
 import type {
   Contrib as ContributionType,
   ContribError as ContributionError,
+  ParsedAmount,
 } from 'helpers/contributions';
 
 import type { Action } from './contributionSelectionActions';
@@ -23,14 +24,6 @@ export type State = {
   customAmount: ?number,
   error: ?ContributionError,
 };
-
-type ParsedCustomAmount = {|
-  error: ContributionError,
-  customAmount: null,
-|} | {|
-  error: null,
-  customAmount: number,
-|};
 
 
 // ----- Setup ----- //
@@ -66,31 +59,15 @@ function updatePredefinedAmount(state: State, newAmount: string): State {
 
 }
 
-// Checks if the custom amount is acceptable, returns a specific error if not.
-function parseCustomAmount(
-  contributionType: ContributionType,
-  customAmount: string,
-): ParsedCustomAmount {
-
-  const { error, amount } = parseContribution(customAmount, contributionType);
-
-  if (error) {
-    return { error, customAmount: null };
-  }
-
-  return { error: null, customAmount: amount };
-
-}
-
 // Re-parses the custom amount when the contribution type is changed.
 function checkCustomAmount(
   isCustomAmount: boolean,
   customAmount: ?number,
   contributionType: ContributionType,
-): ?ParsedCustomAmount {
+): ?ParsedAmount {
 
   if (isCustomAmount && customAmount) {
-    return parseCustomAmount(contributionType, customAmount.toString());
+    return parseContribution(customAmount.toString(), contributionType);
   }
 
   return null;
@@ -148,7 +125,7 @@ function contributionSelectionReducerFor(scope: string, stateOverrides?: Object 
         return {
           ...state,
           isCustomAmount: true,
-          ...parseCustomAmount(state.contributionType, action.amount),
+          ...parseContribution(action.amount, state.contributionType),
         };
 
       default:

--- a/assets/helpers/contributions.js
+++ b/assets/helpers/contributions.js
@@ -99,7 +99,7 @@ function parse(input: ?string, contrib: Contrib): ParsedContrib {
 
 }
 
-function betterParse(input: string, contributionType: Contrib): ParsedAmount {
+function circlesParse(input: string, contributionType: Contrib): ParsedAmount {
 
   const customAmount = Number(input);
 
@@ -205,7 +205,7 @@ export {
   config,
   parse,
   parseContrib,
-  betterParse,
+  circlesParse,
   billingPeriodFromContrib,
   errorMessage,
   contribCamelCase,

--- a/assets/helpers/contributions.js
+++ b/assets/helpers/contributions.js
@@ -35,6 +35,11 @@ export type ParsedContrib = {
   error: ?ContribError,
 };
 
+export type ParsedAmount = {
+  error: ?ContribError,
+  customAmount: ?number,
+};
+
 type Config = {
   [Contrib]: {
     min: number,
@@ -91,6 +96,22 @@ function parse(input: ?string, contrib: Contrib): ParsedContrib {
   const amount = error ? config[contrib].default : roundDp(numericAmount);
 
   return { error, amount };
+
+}
+
+function betterParse(input: string, contributionType: Contrib): ParsedAmount {
+
+  const customAmount = Number(input);
+
+  if (input === '' || Number.isNaN(customAmount)) {
+    return { error: 'invalidEntry', customAmount: null };
+  } else if (customAmount < config[contributionType].min) {
+    return { error: 'tooLittle', customAmount };
+  } else if (customAmount > config[contributionType].max) {
+    return { error: 'tooMuch', customAmount };
+  }
+
+  return { error: null, customAmount };
 
 }
 
@@ -184,6 +205,7 @@ export {
   config,
   parse,
   parseContrib,
+  betterParse,
   billingPeriodFromContrib,
   errorMessage,
   contribCamelCase,


### PR DESCRIPTION
## Why are you doing this?

@CPKING has found another one.

### Problem

When the user had entered an invalid custom amount, and then switched to a contribution type where it was a valid amount, the error still showed until they clicked the custom amount field, at which point it was re-parsed.

### Solution

Rework the parsing mechanism to always store custom amounts if they are valid numbers, even if they aren't within the bounds of the given contribution type. This has the side-benefit of showing the entered amount in the payment button, even if it doesn't fit in the bounds, instead of resetting it to a default.

[**Trello Card**](https://trello.com/c/asGbLr0v/1314-bug-validation-on-us-page)

cc @JustinPinner 

## Changes

- Simplified the parsing of custom amounts by adding a new parsing function. The old one now just exists for the old contributions component, and will go away when the non-circles pages do.
- Added a test to catch the bug.
