### PR TITLE
Circles Rebuild - Part XV - AB Test

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -24,9 +24,9 @@ class Application(
 
   implicit val ar = assets
 
-  private def applyCircles(queryParam: String, id: String, js: String, modifiedId: String, modifiedJs: String): (String, String) = {
-    queryParam match {
-      case "circles-garnett" => (modifiedId, modifiedJs)
+  private def applyCircles(intCmp: String, id: String, js: String, modifiedId: String, modifiedJs: String): (String, String) = {
+    intCmp match {
+      case "gdnwb_copts_memco_sandc_circles_variant" => (modifiedId, modifiedJs)
       case _ => (id, js)
     }
   }
@@ -59,8 +59,8 @@ class Application(
     Ok(views.html.unsupportedBrowserPage())
   }
 
-  def bundleLanding(title: String, id: String, js: String, newDesigns: String): Action[AnyContent] = CachedAction() { implicit request =>
-    if (newDesigns == "circles") {
+  def bundleLanding(title: String, id: String, js: String, INTCMP: String): Action[AnyContent] = CachedAction() { implicit request =>
+    if (INTCMP == "circles") {
       Ok(views.html.bundleLanding(
         title,
         "support-landing-page-old",
@@ -69,7 +69,7 @@ class Application(
         description = Some(stringsConfig.bundleLandingDescription)
       ))
     } else {
-      val (updatedId, updatedJs) = applyCircles(newDesigns, id, js, "support-landing-page", "supportLandingPage.js")
+      val (updatedId, updatedJs) = applyCircles(INTCMP, id, js, "support-landing-page", "supportLandingPage.js")
       Ok(views.html.bundleLanding(
         title,
         updatedId,
@@ -80,13 +80,13 @@ class Application(
     }
   }
 
-  def regularContributionsThankYou(title: String, id: String, js: String, newDesigns: String): Action[AnyContent] = CachedAction() { implicit request =>
-    val (updatedId, updatedJs) = applyCircles(newDesigns, id, js, "regular-contributions-thank-you-page", "regularContributionsThankYouPage.js")
+  def regularContributionsThankYou(title: String, id: String, js: String, INTCMP: String): Action[AnyContent] = CachedAction() { implicit request =>
+    val (updatedId, updatedJs) = applyCircles(INTCMP, id, js, "regular-contributions-thank-you-page", "regularContributionsThankYouPage.js")
     Ok(views.html.react(title, updatedId, updatedJs))
   }
 
-  def contributionsLandingUK(title: String, id: String, js: String, newDesigns: String): Action[AnyContent] = CachedAction() { implicit request =>
-    val (updatedId, updatedJs) = applyCircles(newDesigns, id, js, "contributions-landing-page-uk", "contributionsLandingPageUK.js")
+  def contributionsLandingUK(title: String, id: String, js: String, INTCMP: String): Action[AnyContent] = CachedAction() { implicit request =>
+    val (updatedId, updatedJs) = applyCircles(INTCMP, id, js, "contributions-landing-page-uk", "contributionsLandingPageUK.js")
     Ok(views.html.contributionsLanding(
       title,
       description = Some(stringsConfig.contributionLandingDescription),
@@ -96,8 +96,8 @@ class Application(
     ))
   }
 
-  def contributionsLandingUS(title: String, id: String, js: String, newDesigns: String): Action[AnyContent] = CachedAction() { implicit request =>
-    val (updatedId, updatedJs) = applyCircles(newDesigns, id, js, "contributions-landing-page-us", "contributionsLandingPageUS.js")
+  def contributionsLandingUS(title: String, id: String, js: String, INTCMP: String): Action[AnyContent] = CachedAction() { implicit request =>
+    val (updatedId, updatedJs) = applyCircles(INTCMP, id, js, "contributions-landing-page-us", "contributionsLandingPageUS.js")
     Ok(views.html.contributionsLanding(
       title,
       description = Some(stringsConfig.contributionLandingDescription),
@@ -107,8 +107,8 @@ class Application(
     ))
   }
 
-  def regularContributionsPending(title: String, id: String, js: String, newDesigns: String): Action[AnyContent] = CachedAction() { implicit request =>
-    val (updatedId, updatedJs) = applyCircles(newDesigns, id, js, "regular-contributions-thank-you-page", "regularContributionsThankYouPage.js")
+  def regularContributionsPending(title: String, id: String, js: String, INTCMP: String): Action[AnyContent] = CachedAction() { implicit request =>
+    val (updatedId, updatedJs) = applyCircles(INTCMP, id, js, "regular-contributions-thank-you-page", "regularContributionsThankYouPage.js")
     Ok(views.html.react(title, updatedId, updatedJs))
   }
 

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -59,8 +59,8 @@ class Application(
     Ok(views.html.unsupportedBrowserPage())
   }
 
-  def bundleLanding(title: String, id: String, js: String, INTCMP: String): Action[AnyContent] = CachedAction() { implicit request =>
-    if (INTCMP == "circles") {
+  def bundleLanding(title: String, id: String, js: String, newDesigns: String): Action[AnyContent] = CachedAction() { implicit request =>
+    if (newDesigns == "circles") {
       Ok(views.html.bundleLanding(
         title,
         "support-landing-page-old",
@@ -69,7 +69,7 @@ class Application(
         description = Some(stringsConfig.bundleLandingDescription)
       ))
     } else {
-      val (updatedId, updatedJs) = applyCircles(INTCMP, id, js, "support-landing-page", "supportLandingPage.js")
+      val (updatedId, updatedJs) = applyCircles(newDesigns, id, js, "support-landing-page", "supportLandingPage.js")
       Ok(views.html.bundleLanding(
         title,
         updatedId,

--- a/conf/routes
+++ b/conf/routes
@@ -8,7 +8,7 @@ GET /unsupported-browser                            controllers.Application.unsu
 
 # ----- Bundles Landing Page ----- #
 
-GET /uk                                             controllers.Application.bundleLanding(title="Support the Guardian", id="bundles-landing-page", js="bundlesLandingPage.js", newDesigns: String ?= "")
+GET /uk                                             controllers.Application.bundleLanding(title="Support the Guardian", id="bundles-landing-page", js="bundlesLandingPage.js", INTCMP: String ?= "")
 GET /us                                             controllers.Application.redirect(location="/us/contribute")
 GET /au                                             controllers.Application.redirect(location="/au/contribute")
 GET /eu                                             controllers.Application.redirect(location="/eu/contribute")
@@ -29,17 +29,17 @@ GET  /monthly-contributions                         controllers.Application.cont
 
 # ----- Contributions ----- #
 
-GET  /uk/contribute                                 controllers.Application.contributionsLandingUK(title="Support the Guardian | Make a Contribution", id="contributions-landing-page-uk-old", js="contributionsLandingPageUKOld.js", newDesigns: String ?= "")
-GET  /us/contribute                                 controllers.Application.contributionsLandingUS(title="Support the Guardian | Make a Contribution", id="contributions-landing-page-us-old", js="contributionsLandingPageUSOld.js", newDesigns: String ?= "")
+GET  /uk/contribute                                 controllers.Application.contributionsLandingUK(title="Support the Guardian | Make a Contribution", id="contributions-landing-page-uk-old", js="contributionsLandingPageUKOld.js", INTCMP: String ?= "")
+GET  /us/contribute                                 controllers.Application.contributionsLandingUS(title="Support the Guardian | Make a Contribution", id="contributions-landing-page-us-old", js="contributionsLandingPageUSOld.js", INTCMP: String ?= "")
 GET  /au/contribute                                 controllers.Application.contributionsLanding(title="Support the Guardian | Make a Contribution", id="contributions-landing-page-au", js="contributionsLandingPageAU.js")
 GET  /eu/contribute                                 controllers.Application.contributionsLanding(title="Support the Guardian | Make a Contribution", id="contributions-landing-page-eu", js="contributionsLandingPageEU.js")
 
 GET  /contribute/recurring                          controllers.RegularContributions.displayForm(paypal: Option[Boolean])
-GET  /contribute/recurring/thankyou                 controllers.Application.regularContributionsThankYou(title="Support the Guardian | Thank You", id="regular-contributions-thankyou-page-old", js="regularContributionsThankyouPageOld.js", newDesigns: String ?= "")
+GET  /contribute/recurring/thankyou                 controllers.Application.regularContributionsThankYou(title="Support the Guardian | Thank You", id="regular-contributions-thankyou-page-old", js="regularContributionsThankyouPageOld.js", INTCMP: String ?= "")
 GET  /contribute/recurring/existing                 controllers.Application.reactTemplate(title="Support the Guardian | Existing Contributor", id="regular-contributions-existing-page", js="regularContributionsExistingPage.js")
 POST /contribute/recurring/create                   controllers.RegularContributions.create
 GET  /contribute/recurring/status                   controllers.RegularContributions.status(jobId: String)
-GET  /contribute/recurring/pending                  controllers.Application.regularContributionsThankYou(title="Support the Guardian | Thank You", id="regular-contributions-pending-page", js="regularContributionsPendingPage.js", newDesigns: String ?= "")
+GET  /contribute/recurring/pending                  controllers.Application.regularContributionsThankYou(title="Support the Guardian | Thank You", id="regular-contributions-pending-page", js="regularContributionsPendingPage.js", INTCMP: String ?= "")
 GET  /contribute/marketing-confirm                  controllers.Application.reactTemplate(title="Support the Guardian | Thank You", id="contributions-confirm-marketing", js="contributionsMarketingConfirmPage.js")
 
 # this endpoint should be removed once identity remove

--- a/conf/routes
+++ b/conf/routes
@@ -8,7 +8,7 @@ GET /unsupported-browser                            controllers.Application.unsu
 
 # ----- Bundles Landing Page ----- #
 
-GET /uk                                             controllers.Application.bundleLanding(title="Support the Guardian", id="bundles-landing-page", js="bundlesLandingPage.js", INTCMP: String ?= "")
+GET /uk                                             controllers.Application.bundleLanding(title="Support the Guardian", id="bundles-landing-page", js="bundlesLandingPage.js", newDesigns: String ?= "")
 GET /us                                             controllers.Application.redirect(location="/us/contribute")
 GET /au                                             controllers.Application.redirect(location="/au/contribute")
 GET /eu                                             controllers.Application.redirect(location="/eu/contribute")


### PR DESCRIPTION
## Why are you doing this?

We want to AB test circles. The AB test itself will actually be set up (and the user will be bucketed) on dotcom. Therefore we need a way of showing the user Circles or not-Circles based upon whether they are in a test variant on dotcom.

To actually display the user the circles pages is a bit more complicated than just tweaking a couple of components client-side, because the pages themselves are entirely separate from the control versions (different js file). Up to now they've been viewable using a query param: `newDesigns`. However, since we're now using `INTCMP` to define the test, I've updated the server-side code to serve circles pages depending on whether they have a campaign code that says they should see Circles. This has the added benefit that it *just works* for the thank you pages, because we already pass the `INTCMP` through to them.

Our AB test framework takes a back seat and doesn't assign anyone a variant itself. We're going to use the test information from dotcom to do the data analysis.

**Note:** These campaign codes are not final, they will be updated when we get confirmation.

[**Trello Card**](https://trello.com/c/xPUBDTix/1311-support-test)

cc @JustinPinner 

## Changes

- Set up the Application class to give the user a circles page based on `INTCMP` rather than `newDesigns`.
- Updated the routes file to pick up `INTCMP` for Circles and pass it to `Application`.
- Used old `newDesigns` param for bundles landing, just in case someone ends up on that page by accident and sees the broken circles implementation.
