### PR TITLE
Circles Rebuild - Part XVI - Copy and Design and UX Review

### DIFF
--- a/assets/components/contribute/contribute.jsx
+++ b/assets/components/contribute/contribute.jsx
@@ -14,6 +14,7 @@ import type { Node } from 'react';
 // ----- Types ----- //
 
 type PropTypes = {
+  copy: string | Node,
   children: Node,
 };
 
@@ -37,10 +38,7 @@ export default function Contribute(props: PropTypes) {
         headingChildren={paymentImages}
       >
         <Secure modifierClass="contribute-body" />
-        <p className="component-contribute__description">
-          Support the&nbsp;Guardian&#39;s editorial operations by making a
-          monthly, or one-off contribution today
-        </p>
+        <p className="component-contribute__description">{props.copy}</p>
         {props.children}
       </PageSection>
     </div>

--- a/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
+++ b/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
@@ -66,7 +66,7 @@ export default function ContributionPaymentCtas(props: PropTypes) {
   if (props.contributionType === 'ONE_OFF') {
 
     return (
-      <div className={generateClassName(baseClassName, 'one-off')}>
+      <div className={generateClassName(baseClassName, props.isDisabled ? 'disabled' : null)}>
         <OneOffCta {...props} />
         <props.PayPalButton
           buttonText={`Contribute ${props.currency.glyph}${props.amount} with PayPal`}
@@ -80,7 +80,7 @@ export default function ContributionPaymentCtas(props: PropTypes) {
   }
 
   return (
-    <div className={generateClassName(baseClassName, 'regular')}>
+    <div className={generateClassName(baseClassName, props.isDisabled ? 'disabled' : null)}>
       <RegularCta {...props} />
     </div>
   );

--- a/assets/components/contributionPaymentCtas/contributionPaymentCtas.scss
+++ b/assets/components/contributionPaymentCtas/contributionPaymentCtas.scss
@@ -69,3 +69,9 @@
     }
   }
 }
+
+.component-contribution-payment-ctas--disabled {
+  .component-cta-link, .component-paypal-contribution-button {
+    opacity: 0.5;
+  }
+}

--- a/assets/components/contributionPaymentCtas/contributionPaymentCtas.scss
+++ b/assets/components/contributionPaymentCtas/contributionPaymentCtas.scss
@@ -63,4 +63,9 @@
     margin-top: $gu-v-spacing;
   }
 
+  .component-cta-link {
+    @include mq($until: phablet) {
+      margin-top: $gu-v-spacing * 2;
+    }
+  }
 }

--- a/assets/components/numberInput/numberInput.scss
+++ b/assets/components/numberInput/numberInput.scss
@@ -25,6 +25,7 @@
   text-align: center;
   width: 100%;
   padding: 2px 0;
+  box-shadow: none;
 
   &:focus {
     outline: none;

--- a/assets/containerisableComponents/contributionSelection/contributionSelection.scss
+++ b/assets/containerisableComponents/contributionSelection/contributionSelection.scss
@@ -16,12 +16,17 @@
     background-color: transparent;
     box-sizing: border-box;
     color: gu-colour(news-garnett-main-1);
-    border: 1px solid gu-colour(news-garnett-media-main-1);
+    border: none;
     height: 40px;
+    padding-left: 23px;
 
     .svg-exclamation {
-      fill: gu-colour(news-garnett-main-1);
+      display: none;
     }
+  }
+
+  .component-error-message__message {
+    position: static;
   }
 }
 
@@ -33,31 +38,11 @@
       width: 317px;
     }
   }
-
-  .component-error-message {
-    width: 100%;
-
-    @include mq($from: mobileMedium) {
-      width: 321px;
-    }
-  }
-
-  .component-error-message__message {
-    padding-left: 7px;
-  }
 }
 
 .component-contribution-selection--one-off {
   .component-number-input {
     width: 261px;
-  }
-
-  .component-error-message {
-    width: 265px;
-  }
-
-  .component-error-message__message {
-    padding-left: 14px;
   }
 }
 
@@ -123,13 +108,25 @@
 
   .component-number-input__input {
     font-size: 14px;
+    font-weight: bold;
+    color: rgba(gu-colour(garnett-neutral-1), 0.5);
+
+    &::-moz-placeholder {
+      opacity: 1;
+    }
   }
 
   .component-number-input--selected {
-    background-color: gu-colour(news-garnett-highlight);
-
     .component-number-input__label {
       color: gu-colour(garnett-neutral-1);
+    }
+
+    .component-number-input__input {
+      color: gu-colour(garnett-neutral-1);
+
+      &::placeholder {
+        color: transparent;
+      }
     }
   }
 }

--- a/assets/containerisableComponents/contributionSelection/contributionSelection.scss
+++ b/assets/containerisableComponents/contributionSelection/contributionSelection.scss
@@ -17,8 +17,9 @@
     box-sizing: border-box;
     color: gu-colour(news-garnett-main-1);
     border: none;
-    height: 40px;
     padding-left: 23px;
+    margin-bottom: 0;
+    height: unset;
 
     .svg-exclamation {
       display: none;
@@ -49,7 +50,7 @@
 .component-contribution-selection__type {
   font-size: 14px;
   line-height: 14px;
-  margin: ($gu-v-spacing * 3) 0 ($gu-v-spacing * 2);
+  margin: ($gu-v-spacing * 2) 0 ($gu-v-spacing * 1);
 
   .component-radio-toggle {
     display: inline-block;
@@ -84,14 +85,13 @@
 
 .component-contribution-selection__custom-amount {
   margin-top: $gu-v-spacing * 2;
-  margin-bottom: $gu-v-spacing * 3;
+  margin-bottom: $gu-v-spacing;
 
   @include mq($from: phablet) {
     display: inline-block;
     vertical-align: top;
     margin-left: $gu-v-spacing;
     margin-top: $gu-v-spacing;
-    margin-bottom: $gu-v-spacing * 2;
   }
 
   .component-number-input {

--- a/assets/containerisableComponents/contributionSelection/contributionSelection.scss
+++ b/assets/containerisableComponents/contributionSelection/contributionSelection.scss
@@ -15,7 +15,7 @@
   .component-error-message {
     background-color: transparent;
     box-sizing: border-box;
-    color: gu-colour(news-garnett-main-1);
+    color: gu-colour(garnett-neutral-1);
     border: none;
     padding-left: 23px;
     margin-bottom: 0;

--- a/assets/pages/contributions-landing-uk/contributionsLandingUK.jsx
+++ b/assets/pages/contributions-landing-uk/contributionsLandingUK.jsx
@@ -40,7 +40,9 @@ const content = (
         headings={['Help us deliver', 'the independent', 'journalism the', 'world needs']}
         highlights={['Support', 'The Guardian']}
       />
-      <Contribute>
+      <Contribute
+        copy="Your contribution funds and supports The Guardian's journalism."
+      >
         <ContributionSelectionContainer />
         <ContributionPaymentCtasContainer
           PayPalButton={PayPalContributionButtonContainer}

--- a/assets/pages/contributions-landing-us/contributionsLandingUS.jsx
+++ b/assets/pages/contributions-landing-us/contributionsLandingUS.jsx
@@ -40,7 +40,15 @@ const content = (
         headings={['Help us deliver', 'the independent', 'journalism the', 'world needs']}
         highlights={['Support', 'The Guardian']}
       />
-      <Contribute>
+      <Contribute
+        copy={
+          <span>
+            Contributing to The&nbsp;Guardian makes a big impact. If you&#39;re able,
+            please consider <strong>monthly</strong> support - it will help to
+            fund our journalism for the long term.
+          </span>
+        }
+      >
         <ContributionSelectionContainer />
         <ContributionPaymentCtasContainer
           PayPalButton={PayPalContributionButtonContainer}

--- a/assets/pages/support-landing/supportLanding.jsx
+++ b/assets/pages/support-landing/supportLanding.jsx
@@ -44,7 +44,9 @@ const content = (
         headings={['Help us deliver', 'the independent', 'journalism the', 'world needs']}
         highlights={['Support', 'The Guardian']}
       />
-      <Contribute>
+      <Contribute
+        copy="Your contribution funds and supports The Guardian's journalism."
+      >
         <ContributionSelectionContainer />
         <ContributionPaymentCtasContainer
           PayPalButton={PayPalContributionButtonContainer}


### PR DESCRIPTION
## Why are you doing this?

To polish off all (hopefully!) the outstanding copy, design and UX issues.

[**Trello Card**](https://trello.com/c/GZlf4GYX/1308-copy-design-and-legal-review), and [**the other one**](https://trello.com/c/QfVTS2iW/1318-implement-uxd-tweaks-to-other-amount-on-circles-lp).

cc @JustinPinner @jonathan-nobbs

## Changes

- Allowed custom copy on the contribute component, and updated the copy.
- Set up a disabled state for the payment CTAs when there's an error.
- Got rid of the unwanted red error glow on the number input (for all instances, not just Circles).
- Tidied up padding and margins on contribute component.
- Updated error styling on custom amount input.

## Screenshots

**Desktop US Landing**

![desktop-us](https://user-images.githubusercontent.com/5131341/36494791-0e274c34-172b-11e8-80df-0ba2c7d059cb.png)

**Desktop UK Landing**

![desktop-uk](https://user-images.githubusercontent.com/5131341/36494803-15311df2-172b-11e8-9fae-e41b2a8b389f.png)

More to follow.

**Desktop One-off**

![desktop-oneoff](https://user-images.githubusercontent.com/5131341/36494866-4bb1e7b2-172b-11e8-9f4b-9a73bfaeb08e.png)

**Error States**

![error-monthly](https://user-images.githubusercontent.com/5131341/36494938-832d37fa-172b-11e8-99fe-4a6d59a972c4.png)

![error-oneoff](https://user-images.githubusercontent.com/5131341/36494943-8653a8ce-172b-11e8-85b5-7574ae4f0476.png)

**Mobile**

![mobile](https://user-images.githubusercontent.com/5131341/36494969-9c85a192-172b-11e8-9dd4-8e91d94e7a2a.png)
