### PR TITLE
Adding padding to the country switcher

### DIFF
--- a/assets/components/headers/countrySwitcherHeader/countrySwitcherHeader.scss
+++ b/assets/components/headers/countrySwitcherHeader/countrySwitcherHeader.scss
@@ -13,6 +13,14 @@
   height: 100%;
 }
 
+.component-country-group-switcher {
+  padding-left: $gu-h-spacing / 2;
+
+  @include mq($from: tablet) {
+    padding-left: $gu-h-spacing;
+  }
+}
+
 .component-country-switcher-header__content {
   padding: ($gu-v-spacing / 2) 0 $gu-v-spacing;
   height: 68px;


### PR DESCRIPTION
## Why are you doing this?

To add padding to the country switcher box element.


## Changes

* Up to tablet 10px.
* From tablet 20px.

## Screenshots
### Mobile
<img width="396" alt="picture 552" src="https://user-images.githubusercontent.com/825398/36531665-90303fa2-17b6-11e8-8e32-d3e897e454a4.png">

### Desktop
<img width="1183" alt="picture 553" src="https://user-images.githubusercontent.com/825398/36531667-9052af6a-17b6-11e8-9f87-4096bf346bf6.png">
