### PR TITLE
Fix - Checkout Amount Querystring Bug

### DIFF
--- a/assets/helpers/url.js
+++ b/assets/helpers/url.js
@@ -25,7 +25,7 @@ const DOMAINS: {
 
 const getQueryParameter = (paramName: string, defaultValue?: string): ?string => {
 
-  const params = new URLSearchParams(window.location.search);
+  const params = new URL(window.location).searchParams;
 
   return params.get(paramName) ||
     params.get(paramName.toLowerCase()) ||

--- a/assets/helpers/url.js
+++ b/assets/helpers/url.js
@@ -35,7 +35,7 @@ const getQueryParameter = (paramName: string, defaultValue?: string): ?string =>
 };
 
 const getQueryParams = (excluded: string[]): Array<[string, string]> => Array
-  .from(new URLSearchParams(window.location.search).entries())
+  .from(new URL(window.location).searchParams.entries())
   .filter(p => excluded.indexOf(p[0]) === -1);
 
 const addQueryParamToURL = (urlOrPath: string, paramsKey: string, paramsValue: ?string): string => {


### PR DESCRIPTION
## Why are you doing this?

### Problem

On some older browsers we've had a problem passing through the contribution amount to our checkout pages. For some reason, these browsers weren't picking up the amount from the query param in the URL, and were showing the default amount as a result. This was one of the issues dealt with in #465 for the Samsung Browser. It has subsequently shown up in older versions of Firefox.

### What's going on?

This was an interesting one to track down. This screenshot explains the problem:

![querystring-madness](https://user-images.githubusercontent.com/5131341/36557330-defc1b94-17ff-11e8-8b10-461e0046b253.png)

The `URLSearchParams` constructor doesn't handle querystrings that include the leading question mark `?`. This is a problem because that's what `window.location.search` returns, which is what we happen to be using in our `getQueryParameter` helper.

It seems like the spec wasn't specific as to what should happen here, and was subsequently updated to mandate that the leading `?` be handled. However, both [Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1268361) and Chromium (which is what the Samsung Browser is based on) had already implemented the standard. They have both been updated to fix this, but older versions still suffer from the problem.

### Solution

I've switched our usages of `URLSearchParams(window.location.search)` to use `URL(window.location).searchParams` instead. By getting our URLSearchParams object via the URL interface, instead of from the URLSearchParams constructor, we sidestep the problem, as seen here:

![querystring-solution](https://user-images.githubusercontent.com/5131341/36557929-7d783a72-1801-11e8-9932-4751f1e7bf8b.png)

Presumably when picking apart a full URL, the `?` was usually expected, so it was handled from the start.

[**Trello Card**](https://trello.com/c/xskTe9Ak/1322-ff-48-not-passing-through-contribution-amount-to-checkout)

## Changes

- Updated two usages of the `URLSearchParams` constructor being used in concert with `window.location.search` to use the `URL.searchParams` interface instead.
