### PR TITLE
Fix fromCountry

### DIFF
--- a/assets/helpers/internationalisation/__tests__/countryGroupTest.js
+++ b/assets/helpers/internationalisation/__tests__/countryGroupTest.js
@@ -1,0 +1,32 @@
+// @flow
+
+// ----- Imports ----- //
+
+import { fromCountry } from '../countryGroup';
+
+
+// ----- Tests ----- //
+
+describe('countryGroup', () => {
+
+  describe('fromCountry', () => {
+
+    it('retrieves countries that exist', () => {
+
+      expect(fromCountry('GB')).toEqual('GBPCountries');
+      expect(fromCountry('US')).toEqual('UnitedStates');
+      expect(fromCountry('AU')).toEqual('AUDCountries');
+      expect(fromCountry('FR')).toEqual('EURCountries');
+      expect(fromCountry('CI')).toEqual('International');
+
+    });
+
+    it('returns \'null\' for a country that does not exist', () => {
+
+      expect(fromCountry('42')).toBeNull();
+
+    });
+
+  });
+
+});

--- a/assets/helpers/internationalisation/countryGroup.js
+++ b/assets/helpers/internationalisation/countryGroup.js
@@ -98,12 +98,11 @@ function fromString(countryGroup: string): ?CountryGroupId {
 
 function fromCountry(isoCountry: string): ?CountryGroupId {
 
-  Object.keys(countryGroups).forEach((countryGroupId) => {
-    if (countryGroups[countryGroupId].countries.includes(isoCountry)) {
-      return countryGroupId;
-    }
-    return null;
-  });
+  const countryGroup = Object.keys(countryGroups).find(countryGroupId =>
+    countryGroups[countryGroupId].countries.includes(isoCountry));
+
+  return countryGroup || null;
+
 }
 
 function fromQueryParameter(): ?CountryGroupId {
@@ -136,5 +135,6 @@ function detect(): CountryGroupId {
 
 export {
   countryGroups,
+  fromCountry,
   detect,
 };


### PR DESCRIPTION
## Why are you doing this?

The `fromCountry` function in the `countryGroup` module isn't working as expected. This is causing the checkout pages to break when the query param is missing, as the next fallback to the cookie fails, and the default of 'GBPCountries' is set instead. This hides the 'state' field for the US, which in turn causes Zuora to complain.

Noticed this running Circles, as the Circles landing pages don't pass through the Country Group as a query param.

[**Trello Card**](https://trello.com/c/gIzgGn4H/1338-fix-fromcountry)

cc @JustinPinner 

## Changes

- Switched to using `Array.find`, because you can't return from `forEach`.
- Added tests.
