### PR TITLE
Use an encrypted AMI

### DIFF
--- a/conf/riff-raff.yaml
+++ b/conf/riff-raff.yaml
@@ -9,6 +9,7 @@ deployments:
       amiTags:
         Recipe: xenial-membership
         AmigoStage: PROD
+      amiEncrypted: true
   frontend:
     type: autoscaling
     dependencies: [cfn]


### PR DESCRIPTION
## Why are you doing this?

This helps us to fulfil our GDPR obligations, as it means that any personal data in our log files, or secrets in our conf files are stored on an encrypted volume.

I've tested a deployment and a couple of sign-up journeys in CODE.

## Changes

* Tell riff-raff to use an [encrypted copy of the xenial-membership AMI](https://amigo.gutools.co.uk/recipes/xenial-membership) (from our AWS account).


