### PR TITLE
Circles Rebuild - Part XVII - Cross-Browser Fixes

### DIFF
--- a/assets/components/contributionPaymentCtas/contributionPaymentCtas.scss
+++ b/assets/components/contributionPaymentCtas/contributionPaymentCtas.scss
@@ -22,6 +22,11 @@
     height: 35%;
     top: 18px;
     right: 15px;
+
+    // Fix for IE.
+    @include mq($from: phablet) {
+      left: 465px;
+    }
   }
 
   .component-paypal-contribution-button {

--- a/assets/components/dotcomCta/dotcomCta.scss
+++ b/assets/components/dotcomCta/dotcomCta.scss
@@ -27,6 +27,11 @@
     height: 35%;
     top: 17px;
     right: 13px;
+
+    // Fix for IE.
+    @include mq($from: mobileMedium) {
+      left: 321px;
+    }
   }
 
 }

--- a/assets/components/svg/svg.jsx
+++ b/assets/components/svg/svg.jsx
@@ -680,7 +680,7 @@ function SvgCirclesHeroDesktop() {
       className="svg-circles-hero-desktop"
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 1400 406"
-      preserveAspectRatio="xMinYMid"
+      preserveAspectRatio="xMinYMid slice"
     >
       <g fill="none" fillRule="evenodd">
         <path d="M18.512 320.347c6.889-12.381 18.47-22.136 33.143-26.343A55.1 55.1 0 0 1 81 293.685c-12.986 13.825-18.576 33.973-12.954 53.579s21.039 33.73 39.378 38.572a55.1 55.1 0 0 1-25.056 15.28c-14.673 4.208-29.663 2.073-42.067-4.776-12.515-6.912-22.398-18.622-26.657-33.477-4.26-14.855-2.084-30.022 4.867-42.516" fill="#00B2FF" opacity=".6" />
@@ -731,7 +731,7 @@ function SvgCirclesHeroMobileLandscape() {
       className="svg-circles-hero-mobile-landscape"
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 768 382"
-      preserveAspectRatio="xMinYMid"
+      preserveAspectRatio="xMinYMid slice"
     >
       <g fill="none" fillRule="evenodd" transform="translate(-2)">
         <path d="M728.406 348.214c-7.84-10.002-19.467-17.017-33.055-18.686a49.417 49.417 0 0 0-26.04 3.835c13.443 10.424 21.222 27.487 18.992 45.644-2.23 18.156-13.905 32.83-29.47 39.693a49.417 49.417 0 0 0 24.339 10.02c13.587 1.67 26.567-2.325 36.593-10.133 10.117-7.878 17.228-19.638 18.917-33.394 1.69-13.757-2.366-26.887-10.276-36.98" fill="#FF1921" opacity=".6" />
@@ -804,7 +804,7 @@ function SvgThankYouHeroDesktop() {
       className="svg-thank-you-hero-desktop"
       xmlns="http://www.w3.org/2000/svg"
       viewBox="0 0 1400 308"
-      preserveAspectRatio="xMinYMid"
+      preserveAspectRatio="xMinYMid slice"
     >
       <g fill="none" fillRule="evenodd">
         <g transform="scale(1 -1) rotate(-55 -173.131 -218.706)">


### PR DESCRIPTION
## Why are you doing this?

There are a couple of bugs @michaelwmcnamara and I discovered doing cross-browser testing. This fixes them.

### Background Overlap

This is to do with the way an SVG's viewbox interacts with the viewport it's being displayed in. The circles background is meant to overflow the heading container, with any cropped parts hidden. This was working in Firefox but not in other browsers (Chrome, Safari).

![overlap-bug](https://user-images.githubusercontent.com/5131341/36684942-c381365c-1b19-11e8-971d-4f104cff33eb.png)

The solution is to apply `slice` to the `preserveAspectRatio` `meetOrSlice` [parameter](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/preserveAspectRatio), which controls this viewbox/viewport interaction. I'm not sure whether this is due to my misunderstanding of the spec, a bug in Firefox, or a bug in the other browsers. Anyway, it's now fixed:

![overlap-fixed](https://user-images.githubusercontent.com/5131341/36685122-4ef0c4aa-1b1a-11e8-9c2d-f7c4876eee69.png)

[**Trello Card**](https://trello.com/c/FT06kKxL/1319-minimum-browser-testing-needed-for-circles-launch)

cc @JustinPinner 

**Note:** There is one other minor bug with the alignment of the Secure logo on IE, but I don't have a quick fix for it, so I'm going to leave it for the test. It's not as noticeable as the other two issues.

### CTA Arrows

This is a problem that's happened before in IE10+, `position: absolute; right: x` seems to cause issues:

![contribute-cta-broken](https://user-images.githubusercontent.com/5131341/36685308-e485e8f6-1b1a-11e8-8b75-13c9f46c7b8a.png)

![return-cta-broken](https://user-images.githubusercontent.com/5131341/36685311-e61c38e6-1b1a-11e8-936a-015a27698e27.png)

I can't quite remember why this is happening, as IE is meant to [support this](https://developer.mozilla.org/en-US/docs/Web/CSS/right). Anyway, the fix is to use `left: y` instead:

![contribute-cta-fixed](https://user-images.githubusercontent.com/5131341/36685480-5d205116-1b1b-11e8-9aed-34dc5c0070f8.png)

![return-cta-fixed](https://user-images.githubusercontent.com/5131341/36685605-bd3adee0-1b1b-11e8-8b62-b5a8f5569744.png)

## Changes

- Added `slice` to some of the SVGs that weren't being cropped correctly.
- Added `left: y` to some of the CTA SVGs.
