### PR TITLE
Removing upsellRecurringContributions test

### DIFF
--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -29,17 +29,4 @@ export const tests: Tests = {
     independent: true,
     seed: 7,
   },
-
-  upsellRecurringContributions: {
-    variants: ['control', 'benefitsOfBoth', 'shorterControl'],
-    audiences: {
-      US: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: true,
-    independent: true,
-    seed: 99,
-  },
 };

--- a/assets/pages/contributions-landing/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing/components/contributionsBundle.jsx
@@ -130,9 +130,8 @@ const defaultContentText = {
   GBPCountries: 'Support The Guardian’s editorial operations by making a monthly or one-off contribution today',
   UnitedStates: (
     <span>
-      Contributing to The Guardian makes a big impact. If you’re able, please consider
-      <strong> monthly</strong> support &ndash; it will help to fund our journalism for
-      the long term.
+      Make a monthly commitment to support The Guardian long-term or a one-time contribution
+      as and when you feel like it &ndash; choose the option that suits you best.
     </span>
   ),
   AUDCountries: (
@@ -152,29 +151,8 @@ const defaultContentText = {
   International: '',
 };
 
-const upsellRecurringContributionsTestContentText = {
-  control: defaultContentText.UnitedStates,
-  benefitsOfBoth: (
-    <span>
-      Make a monthly commitment to support The Guardian long-term or a one-time contribution
-      as and when you feel like it &ndash; choose the option that suits you best.
-    </span>
-  ),
-  shorterControl: (
-    <span>
-      If you’re able, please consider <strong>monthly</strong> support &ndash;
-      it will help to fund The Guardian’s journalism for the long-term.
-    </span>
-  ),
-};
-
-function getContentText(props: PropTypes) {
-  return upsellRecurringContributionsTestContentText[props.abTests.upsellRecurringContributions] ||
-    defaultContentText[props.countryGroupId];
-}
-
 function ContentText(props: PropTypes) {
-  return <p className="component-bundle__content-intro"> {getContentText(props)} </p>;
+  return <p className="component-bundle__content-intro"> {defaultContentText[props.countryGroupId]} </p>;
 }
 
 function getCtaText(contribType: Contrib, currency: Currency, amounts: Amounts) {


### PR DESCRIPTION
## Why are you doing this?

The test is done, the results were not conclusive but we decide to keep the `benefitsOfBoth` variant
[**Trello Card**](https://trello.com/c/L9zmjWqK/138-remove-finished-tests-on-support-frontend)

## Changes

* Removed an old test
## Screenshots

![testsssss](https://user-images.githubusercontent.com/825398/36849902-29d6a1ea-1d5d-11e8-91b4-4e121c3999af.png)

