### PR TITLE
Upgrade autoprefixer to version 8 and update supported browser list

### DIFF
--- a/docs/supported-browsers.md
+++ b/docs/supported-browsers.md
@@ -10,7 +10,7 @@
 * Chrome 38 and above
 * Safari 8 and above
 * IE 11
-* Microsoft Edge all versions
+* Microsoft Edge 12 and above
 * Firefox 44 and above
 * Samsung 4 and above
 * Opera 25 and above

--- a/docs/supported-browsers.md
+++ b/docs/supported-browsers.md
@@ -18,7 +18,7 @@
 Note about Android WebView and iOS WebView:
 > iOS WebView should be mostly equivalent to **Safari**, and Android WebView (for recent versions of Android) should be mostly equivalent to **Chrome**. Based on this premise we have concluded that by supporting their parent browsers we implicitly include support for these WebView as well. However, if we discover that there are problems with this approach then we will revise it. 
 
-### Browsers we will fix if someone raise an issue that something is wrong
+### Browsers we will fix if someone raise an issue
 
 * Opera Mini
 * amazon Silk

--- a/docs/supported-browsers.md
+++ b/docs/supported-browsers.md
@@ -5,6 +5,8 @@
 
 ## The list of supported browsers is:
 
+### Browsers we don't want to break 
+
 * Chrome 38 and above
 * Safari 8 and above
 * IE 11
@@ -14,8 +16,12 @@
 * Opera 25 and above
 
 Note about Android WebView and iOS WebView:
-
 > iOS WebView should be mostly equivalent to **Safari**, and Android WebView (for recent versions of Android) should be mostly equivalent to **Chrome**. Based on this premise we have concluded that by supporting their parent browsers we implicitly include support for these WebView as well. However, if we discover that there are problems with this approach then we will revise it. 
+
+### Browsers we will fix if someone raise an issue that something is wrong
+
+* Opera Mini
+* amazon Silk
 
 ### Coverage: 98.08% of our traffic
 

--- a/package.json
+++ b/package.json
@@ -19,12 +19,14 @@
     "Chrome >= 38",
     "ChromeAndroid >= 44",
     "Safari >= 8",
+    "ios_saf >= 8",
     "IE >= 11",
     "Edge >= 12",
     "Firefox >= 44",
     "FirefoxAndroid > 44",
     "Samsung >= 4",
-    "Opera >= 25"
+    "Opera >= 25",
+    "OperaMini all"
   ],
   "jest": {
     "transform": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,17 @@
     "test": "echo 'Running JS tests' && jest",
     "jest-update-snapshot": "echo 'Updating JS tests' && jest -u"
   },
+  "browserslist": [
+    "Chrome >= 38",
+    "ChromeAndroid >= 44",
+    "Safari >= 8",
+    "IE >= 11",
+    "Edge >= 12",
+    "Firefox >= 44",
+    "FirefoxAndroid > 44",
+    "Samsung >= 4",
+    "Opera >= 25"
+  ],
   "jest": {
     "transform": {
       ".*": "./node_modules/babel-jest"
@@ -51,7 +62,7 @@
     "uuid": "^3.2.1"
   },
   "devDependencies": {
-    "autoprefixer": "^7.2.5",
+    "autoprefixer": "^8.0.0",
     "babel-eslint": "^8.2.2",
     "babel-jest": "^22.4.1",
     "babel-loader": "^7.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -428,15 +428,15 @@ autoprefixer@^6.3.1:
     postcss "^5.2.16"
     postcss-value-parser "^3.2.3"
 
-autoprefixer@^7.2.5:
-  version "7.2.5"
-  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-7.2.5.tgz#04ccbd0c6a61131b6d13f53d371926092952d192"
+autoprefixer@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-8.0.0.tgz#c19e480f061013127c373df0b01cf46919943f74"
   dependencies:
-    browserslist "^2.11.1"
-    caniuse-lite "^1.0.30000791"
+    browserslist "^3.0.0"
+    caniuse-lite "^1.0.30000808"
     normalize-range "^0.1.2"
     num2fraction "^1.2.2"
-    postcss "^6.0.16"
+    postcss "^6.0.17"
     postcss-value-parser "^3.2.3"
 
 aws-sign2@~0.6.0:
@@ -1269,12 +1269,12 @@ browserslist@^2.1.2:
     caniuse-lite "^1.0.30000760"
     electron-to-chromium "^1.3.27"
 
-browserslist@^2.11.1:
-  version "2.11.3"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-2.11.3.tgz#fe36167aed1bbcde4827ebfe71347a2cc70b99b2"
+browserslist@^3.0.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-3.1.1.tgz#d380fc048bc3a33e60fb87dc135110ebaaa6320a"
   dependencies:
-    caniuse-lite "^1.0.30000792"
-    electron-to-chromium "^1.3.30"
+    caniuse-lite "^1.0.30000809"
+    electron-to-chromium "^1.3.33"
 
 bser@^2.0.0:
   version "2.0.0"
@@ -1382,9 +1382,9 @@ caniuse-lite@^1.0.30000760:
   version "1.0.30000760"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000760.tgz#ec720395742f1c7ec8947fd6dd2604e77a8f98ff"
 
-caniuse-lite@^1.0.30000791, caniuse-lite@^1.0.30000792:
-  version "1.0.30000792"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000792.tgz#d0cea981f8118f3961471afbb43c9a1e5bbf0332"
+caniuse-lite@^1.0.30000808, caniuse-lite@^1.0.30000809:
+  version "1.0.30000810"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000810.tgz#47585fffce0e9f3593a6feea4673b945424351d9"
 
 caseless@~0.11.0:
   version "0.11.0"
@@ -2114,19 +2114,13 @@ ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
-electron-releases@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/electron-releases/-/electron-releases-2.1.0.tgz#c5614bf811f176ce3c836e368a0625782341fd4e"
-
 electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.27:
   version "1.3.27"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.27.tgz#78ecb8a399066187bb374eede35d9c70565a803d"
 
-electron-to-chromium@^1.3.30:
-  version "1.3.30"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.30.tgz#9666f532a64586651fc56a72513692e820d06a80"
-  dependencies:
-    electron-releases "^2.1.0"
+electron-to-chromium@^1.3.33:
+  version "1.3.34"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.34.tgz#d93498f40391bb0c16a603d8241b9951404157ed"
 
 elliptic@^6.0.0:
   version "6.4.0"
@@ -5562,15 +5556,7 @@ postcss@^6.0.0, postcss@^6.0.1:
     source-map "^0.6.1"
     supports-color "^4.4.0"
 
-postcss@^6.0.16:
-  version "6.0.16"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.16.tgz#112e2fe2a6d2109be0957687243170ea5589e146"
-  dependencies:
-    chalk "^2.3.0"
-    source-map "^0.6.1"
-    supports-color "^5.1.0"
-
-postcss@^6.0.19:
+postcss@^6.0.17, postcss@^6.0.19:
   version "6.0.19"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-6.0.19.tgz#76a78386f670b9d9494a655bf23ac012effd1555"
   dependencies:


### PR DESCRIPTION
## Why are you doing this?

Upgrading `autoprefixer` to version 8. Since version 8 autoprefixier uses browserslist, a tool already used by preset-env. The [suggested way of specifying](https://github.com/ai/browserslist#queries) which browser a project supports for browserslits is stating that in `package.json`.  Our current coverage is [here](https://goo.gl/KnaeBn)

[**Trello Card**](https://trello.com/c/HDwP2FhE/1350-setup-correctly-autoprefixier)

## Changes

* Upgrade autoprefixier
* Introduced browserslist's browsers
* Added a second category of supported browsers

## Screenshots

### Chrome v38


| Page                     | Screen capture |
|--------------------------|----------------|
| Bundles Landing          |   ![picture 582](https://user-images.githubusercontent.com/825398/37032753-808461c6-213b-11e8-90ca-7c85c7f70c46.png)  |
| US Contributions Landing |        ![picture 583](https://user-images.githubusercontent.com/825398/37032796-9e825976-213b-11e8-91aa-2bedbc62a8e0.png)          |
| Circles Landing          |        ![picture 585](https://user-images.githubusercontent.com/825398/37033594-7a1a366e-213e-11e8-9824-4396b8d16da7.png)        |
| Checkout Page            |          ![picture 584](https://user-images.githubusercontent.com/825398/37032847-c59ea1ea-213b-11e8-9c54-7ade44372c34.png)       |



### IE 11
| Page                     | Screen capture |
|--------------------------|----------------|
| Bundles Landing          |  ![picture 590](https://user-images.githubusercontent.com/825398/37034307-ca330aa2-2140-11e8-9cc8-c041d0fa8519.png)|
| US Contributions Landing |   ![picture 591](https://user-images.githubusercontent.com/825398/37034394-fca97ca0-2140-11e8-8f85-bed67ceb92bf.png)|
| Circles Landing          |        ![picture 589](https://user-images.githubusercontent.com/825398/37034251-93883996-2140-11e8-8288-34be36df2472.png)       |
| Checkout Page            |  ![picture 592](https://user-images.githubusercontent.com/825398/37034422-1b680422-2141-11e8-8191-4caa0f66fa64.png)|
### Safari 8
| Page                     | Screen capture |
|--------------------------|----------------|
| Bundles Landing          |       ![picture 593](https://user-images.githubusercontent.com/825398/37034496-602f7270-2141-11e8-8d3a-d8ca735fb612.png)         |
| US Contributions Landing |  ![picture 594](https://user-images.githubusercontent.com/825398/37034523-74e64090-2141-11e8-834f-6b6cc829be8d.png)|
| Circles Landing          |    ![picture 596](https://user-images.githubusercontent.com/825398/37034630-d97f0744-2141-11e8-9e32-007344a964e9.png)|
| Checkout Page            |     ![picture 595](https://user-images.githubusercontent.com/825398/37034561-94fda972-2141-11e8-941a-f641e5feccf1.png)           |


### Edge
| Page                     | Screen capture |
|--------------------------|----------------|
| Bundles Landing          |    ![picture 599](https://user-images.githubusercontent.com/825398/37034766-45735eaa-2142-11e8-9ffe-42b3148afb99.png)       |
| US Contributions Landing |          ![picture 600](https://user-images.githubusercontent.com/825398/37034794-59d7ca34-2142-11e8-8a30-13a890798638.png)|
| Circles Landing          |    ![picture 597](https://user-images.githubusercontent.com/825398/37034692-0dfb1a1c-2142-11e8-8b68-33cc37654808.png)            |
| Checkout Page            |       ![picture 598](https://user-images.githubusercontent.com/825398/37034709-1f3074bc-2142-11e8-9cc6-fc73ea263de3.png)|

### Firefox 44
| Page                     | Screen capture |
|--------------------------|----------------|
| Bundles Landing          | ![picture 604](https://user-images.githubusercontent.com/825398/37035151-7a6be108-2143-11e8-8ef2-1ff0b6c04084.png) |
| US Contributions Landing | ![picture 601](https://user-images.githubusercontent.com/825398/37035011-0a3c6736-2143-11e8-8c81-d46ab9a00282.png)|
| Circles Landing          |  ![picture 605](https://user-images.githubusercontent.com/825398/37035192-997e175a-2143-11e8-9fa3-a328da2374e1.png)              |
| Checkout Page            |    ![picture 602](https://user-images.githubusercontent.com/825398/37035052-26423b68-2143-11e8-898f-d578cda045ff.png)|

### Samsung 4
| Page                     | Screen capture |
|--------------------------|----------------|
| Bundles Landing          |  ![picture 609](https://user-images.githubusercontent.com/825398/37035443-7c4cb348-2144-11e8-94d4-b87446764b1a.png)|
| US Contributions Landing | #![picture 610](https://user-images.githubusercontent.com/825398/37035473-966a0154-2144-11e8-819d-2b6225d9336e.png)   |
| Circles Landing          |      ![picture 606](https://user-images.githubusercontent.com/825398/37035273-f1dbd5e0-2143-11e8-97ba-e3d792d228ea.png)|
| Checkout Page            |    ![picture 607](https://user-images.githubusercontent.com/825398/37035316-12073c42-2144-11e8-8e22-43c0da9363ee.png)    |

### Opera 25
| Page                     | Screen capture |
|--------------------------|----------------|
| Bundles Landing          |        ![picture 613](https://user-images.githubusercontent.com/825398/37036724-6a4e1304-2148-11e8-8d0f-964ee6fd7ece.png)        |
| US Contributions Landing |  ![picture 612](https://user-images.githubusercontent.com/825398/37036738-73fd4190-2148-11e8-8e22-d98e584c1d78.png)|
| Circles Landing   |         ![picture 615](https://user-images.githubusercontent.com/825398/37036841-c3f2e4fc-2148-11e8-8593-bafa9add9ed2.png)       |
| Checkout Page            |    ![picture 614](https://user-images.githubusercontent.com/825398/37036772-889530ea-2148-11e8-8792-4ed165a3460e.png)|
