### PR TITLE
Adding EURCountries to the country switcher

### DIFF
--- a/assets/pages/bundles-landing/components/countrySwitcherHeaderContainer.jsx
+++ b/assets/pages/bundles-landing/components/countrySwitcherHeaderContainer.jsx
@@ -11,7 +11,7 @@ import type { State } from '../bundlesLandingReducers';
 
 
 const availableCountriesGroups: CountryGroupId[] =
-  ['GBPCountries', 'UnitedStates'];
+  ['GBPCountries', 'UnitedStates', 'EURCountries'];
 
 // ----- Functions ----- //
 

--- a/assets/pages/contributions-landing/components/countrySwitcherHeaderContainer.jsx
+++ b/assets/pages/contributions-landing/components/countrySwitcherHeaderContainer.jsx
@@ -12,7 +12,7 @@ import type { State } from '../contributionsLandingReducers';
 
 
 const availableCountriesGroups: CountryGroupId[] =
-  ['GBPCountries', 'UnitedStates'];
+  ['GBPCountries', 'UnitedStates', 'EURCountries'];
 
 // ----- Functions ----- //
 


### PR DESCRIPTION

## Why are you doing this?

To add EUR  to the contributions EU country switcher.

[**Trello Card**](https://trello.com/c/M1AkspCf/6-technical-work-launch-of-the-aus-and-eu-supporter-pages)

## Changes

* Eu contributions page


## Screenshots

