### PR TITLE
Refactor internationalisation tests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,6 +23,7 @@
     "React": true,
     "ga": true,
     "Raven": true,
+    "jsdom": true,
   },
   "rules": {
     "curly": [2, "all"],

--- a/assets/helpers/internationalisation/__tests__/countryGroupTest.js
+++ b/assets/helpers/internationalisation/__tests__/countryGroupTest.js
@@ -12,27 +12,27 @@ describe('detect countryGroup', () => {
   it('should return the correct country group from the path', () => {
 
     jsdom.reconfigure({
-      url: "https://support.theguardian.com/uk",
+      url: 'https://support.theguardian.com/uk',
     });
     expect(detect()).toEqual('GBPCountries');
 
     jsdom.reconfigure({
-      url: "https://support.theguardian.com/us",
+      url: 'https://support.theguardian.com/us',
     });
     expect(detect()).toEqual('UnitedStates');
 
     jsdom.reconfigure({
-      url: "https://support.theguardian.com/au",
+      url: 'https://support.theguardian.com/au',
     });
     expect(detect()).toEqual('AUDCountries');
 
     jsdom.reconfigure({
-      url: "https://support.theguardian.com/eu",
+      url: 'https://support.theguardian.com/eu',
     });
     expect(detect()).toEqual('EURCountries');
 
     jsdom.reconfigure({
-      url: "https://support.theguardian.com/int",
+      url: 'https://support.theguardian.com/int',
     });
     expect(detect()).toEqual('International');
   });
@@ -40,27 +40,27 @@ describe('detect countryGroup', () => {
   it('should return the correct country group from the query parameter', () => {
 
     jsdom.reconfigure({
-      url: "https://support.theguardian.com/examplePath?countryGroup=GBPCountries",
+      url: 'https://support.theguardian.com/examplePath?countryGroup=GBPCountries',
     });
     expect(detect()).toEqual('GBPCountries');
 
     jsdom.reconfigure({
-      url: "https://support.theguardian.com/examplePath?countryGroup=UnitedStates",
+      url: 'https://support.theguardian.com/examplePath?countryGroup=UnitedStates',
     });
     expect(detect()).toEqual('UnitedStates');
 
     jsdom.reconfigure({
-      url: "https://support.theguardian.com/examplePath?countryGroup=AUDCountries",
+      url: 'https://support.theguardian.com/examplePath?countryGroup=AUDCountries',
     });
     expect(detect()).toEqual('AUDCountries');
 
     jsdom.reconfigure({
-      url: "https://support.theguardian.com/examplePath?countryGroup=EURCountries",
+      url: 'https://support.theguardian.com/examplePath?countryGroup=EURCountries',
     });
     expect(detect()).toEqual('EURCountries');
 
     jsdom.reconfigure({
-      url: "https://support.theguardian.com/examplePath?countryGroup=International",
+      url: 'https://support.theguardian.com/examplePath?countryGroup=International',
     });
     expect(detect()).toEqual('International');
   });
@@ -68,7 +68,7 @@ describe('detect countryGroup', () => {
   it('should return the correct country group from GU_country cookie', () => {
 
     jsdom.reconfigure({
-      url: "https://support.theguardian.com/examplePath",
+      url: 'https://support.theguardian.com/examplePath',
     });
 
     document.cookie = 'GU_country=UK';
@@ -88,7 +88,7 @@ describe('detect countryGroup', () => {
 
 
     jsdom.reconfigure({
-      url: "https://support.theguardian.com/examplePath?countryGroup=42",
+      url: 'https://support.theguardian.com/examplePath?countryGroup=42',
     });
     document.cookie = 'GU_country=BR';
     expect(detect()).toEqual('International');
@@ -97,7 +97,7 @@ describe('detect countryGroup', () => {
   it('should return the correct country group from GU_country cookie', () => {
 
     jsdom.reconfigure({
-      url: "https://support.theguardian.com/examplePath",
+      url: 'https://support.theguardian.com/examplePath',
     });
 
     document.cookie = 'GU_country=UK';
@@ -120,7 +120,7 @@ describe('detect countryGroup', () => {
 
 
     jsdom.reconfigure({
-      url: "https://support.theguardian.com/examplePath?countryGroup=42",
+      url: 'https://support.theguardian.com/examplePath?countryGroup=42',
     });
     document.cookie = 'GU_country=BR';
     expect(detect()).toEqual('International');
@@ -128,11 +128,10 @@ describe('detect countryGroup', () => {
 
   it('should return the correct country group from GU_geo_country cookie', () => {
 
-
     jsdom.reconfigure({
-      url: "https://support.theguardian.com/examplePath",
+      url: 'https://support.theguardian.com/examplePath',
     });
-    document.cookie='GU_country=42';
+    document.cookie = 'GU_country=42';
 
     document.cookie = 'GU_geo_country=UK';
     expect(detect()).toEqual('GBPCountries');
@@ -153,7 +152,7 @@ describe('detect countryGroup', () => {
     expect(detect()).toEqual('International');
 
     jsdom.reconfigure({
-      url: "https://support.theguardian.com/examplePath?countryGroup=42",
+      url: 'https://support.theguardian.com/examplePath?countryGroup=42',
     });
     document.cookie = 'GU_geo_country=BR';
     expect(detect()).toEqual('International');
@@ -162,9 +161,9 @@ describe('detect countryGroup', () => {
   it('should return the GBPCountries by default', () => {
 
     jsdom.reconfigure({
-      url: "https://support.theguardian.com/examplePath",
+      url: 'https://support.theguardian.com/examplePath',
     });
-    document.cookie='GU_country=42';
+    document.cookie = 'GU_country=42';
     document.cookie = 'GU_geo_country=42';
 
     expect(detect()).toEqual('GBPCountries');

--- a/assets/helpers/internationalisation/__tests__/countryGroupTest.js
+++ b/assets/helpers/internationalisation/__tests__/countryGroupTest.js
@@ -2,31 +2,174 @@
 
 // ----- Imports ----- //
 
-import { fromCountry } from '../countryGroup';
+import { detect } from '../countryGroup';
 
 
 // ----- Tests ----- //
 
-describe('countryGroup', () => {
+describe('detect countryGroup', () => {
 
-  describe('fromCountry', () => {
+  it('should return the correct country group from the path', () => {
 
-    it('retrieves countries that exist', () => {
+    jsdom.reconfigure({
+      url: "https://support.theguardian.com/uk",
+    });
+    expect(detect()).toEqual('GBPCountries');
 
-      expect(fromCountry('GB')).toEqual('GBPCountries');
-      expect(fromCountry('US')).toEqual('UnitedStates');
-      expect(fromCountry('AU')).toEqual('AUDCountries');
-      expect(fromCountry('FR')).toEqual('EURCountries');
-      expect(fromCountry('CI')).toEqual('International');
+    jsdom.reconfigure({
+      url: "https://support.theguardian.com/us",
+    });
+    expect(detect()).toEqual('UnitedStates');
 
+    jsdom.reconfigure({
+      url: "https://support.theguardian.com/au",
+    });
+    expect(detect()).toEqual('AUDCountries');
+
+    jsdom.reconfigure({
+      url: "https://support.theguardian.com/eu",
+    });
+    expect(detect()).toEqual('EURCountries');
+
+    jsdom.reconfigure({
+      url: "https://support.theguardian.com/int",
+    });
+    expect(detect()).toEqual('International');
+  });
+
+  it('should return the correct country group from the query parameter', () => {
+
+    jsdom.reconfigure({
+      url: "https://support.theguardian.com/examplePath?countryGroup=GBPCountries",
+    });
+    expect(detect()).toEqual('GBPCountries');
+
+    jsdom.reconfigure({
+      url: "https://support.theguardian.com/examplePath?countryGroup=UnitedStates",
+    });
+    expect(detect()).toEqual('UnitedStates');
+
+    jsdom.reconfigure({
+      url: "https://support.theguardian.com/examplePath?countryGroup=AUDCountries",
+    });
+    expect(detect()).toEqual('AUDCountries');
+
+    jsdom.reconfigure({
+      url: "https://support.theguardian.com/examplePath?countryGroup=EURCountries",
+    });
+    expect(detect()).toEqual('EURCountries');
+
+    jsdom.reconfigure({
+      url: "https://support.theguardian.com/examplePath?countryGroup=International",
+    });
+    expect(detect()).toEqual('International');
+  });
+
+  it('should return the correct country group from GU_country cookie', () => {
+
+    jsdom.reconfigure({
+      url: "https://support.theguardian.com/examplePath",
     });
 
-    it('returns \'null\' for a country that does not exist', () => {
+    document.cookie = 'GU_country=UK';
+    expect(detect()).toEqual('GBPCountries');
 
-      expect(fromCountry('42')).toBeNull();
+    document.cookie = 'GU_country=US';
+    expect(detect()).toEqual('UnitedStates');
 
+    document.cookie = 'GU_country=AU';
+    expect(detect()).toEqual('AUDCountries');
+
+    document.cookie = 'GU_country=FR';
+    expect(detect()).toEqual('EURCountries');
+
+    document.cookie = 'GU_country=CI';
+    expect(detect()).toEqual('International');
+
+
+    jsdom.reconfigure({
+      url: "https://support.theguardian.com/examplePath?countryGroup=42",
     });
+    document.cookie = 'GU_country=BR';
+    expect(detect()).toEqual('International');
+  });
+
+  it('should return the correct country group from GU_country cookie', () => {
+
+    jsdom.reconfigure({
+      url: "https://support.theguardian.com/examplePath",
+    });
+
+    document.cookie = 'GU_country=UK';
+    expect(detect()).toEqual('GBPCountries');
+
+    document.cookie = 'GU_country=GB';
+    expect(detect()).toEqual('GBPCountries');
+
+    document.cookie = 'GU_country=US';
+    expect(detect()).toEqual('UnitedStates');
+
+    document.cookie = 'GU_country=AU';
+    expect(detect()).toEqual('AUDCountries');
+
+    document.cookie = 'GU_country=FR';
+    expect(detect()).toEqual('EURCountries');
+
+    document.cookie = 'GU_country=CI';
+    expect(detect()).toEqual('International');
+
+
+    jsdom.reconfigure({
+      url: "https://support.theguardian.com/examplePath?countryGroup=42",
+    });
+    document.cookie = 'GU_country=BR';
+    expect(detect()).toEqual('International');
+  });
+
+  it('should return the correct country group from GU_geo_country cookie', () => {
+
+
+    jsdom.reconfigure({
+      url: "https://support.theguardian.com/examplePath",
+    });
+    document.cookie='GU_country=42';
+
+    document.cookie = 'GU_geo_country=UK';
+    expect(detect()).toEqual('GBPCountries');
+
+    document.cookie = 'GU_geo_country=GB';
+    expect(detect()).toEqual('GBPCountries');
+
+    document.cookie = 'GU_geo_country=US';
+    expect(detect()).toEqual('UnitedStates');
+
+    document.cookie = 'GU_geo_country=AU';
+    expect(detect()).toEqual('AUDCountries');
+
+    document.cookie = 'GU_geo_country=FR';
+    expect(detect()).toEqual('EURCountries');
+
+    document.cookie = 'GU_geo_country=CI';
+    expect(detect()).toEqual('International');
+
+    jsdom.reconfigure({
+      url: "https://support.theguardian.com/examplePath?countryGroup=42",
+    });
+    document.cookie = 'GU_geo_country=BR';
+    expect(detect()).toEqual('International');
+  });
+
+  it('should return the GBPCountries by default', () => {
+
+    jsdom.reconfigure({
+      url: "https://support.theguardian.com/examplePath",
+    });
+    document.cookie='GU_country=42';
+    document.cookie = 'GU_geo_country=42';
+
+    expect(detect()).toEqual('GBPCountries');
 
   });
 
 });
+

--- a/assets/helpers/internationalisation/__tests__/countryGroupTest.js
+++ b/assets/helpers/internationalisation/__tests__/countryGroupTest.js
@@ -74,35 +74,6 @@ describe('detect countryGroup', () => {
     document.cookie = 'GU_country=UK';
     expect(detect()).toEqual('GBPCountries');
 
-    document.cookie = 'GU_country=US';
-    expect(detect()).toEqual('UnitedStates');
-
-    document.cookie = 'GU_country=AU';
-    expect(detect()).toEqual('AUDCountries');
-
-    document.cookie = 'GU_country=FR';
-    expect(detect()).toEqual('EURCountries');
-
-    document.cookie = 'GU_country=CI';
-    expect(detect()).toEqual('International');
-
-
-    jsdom.reconfigure({
-      url: 'https://support.theguardian.com/examplePath?countryGroup=42',
-    });
-    document.cookie = 'GU_country=BR';
-    expect(detect()).toEqual('International');
-  });
-
-  it('should return the correct country group from GU_country cookie', () => {
-
-    jsdom.reconfigure({
-      url: 'https://support.theguardian.com/examplePath',
-    });
-
-    document.cookie = 'GU_country=UK';
-    expect(detect()).toEqual('GBPCountries');
-
     document.cookie = 'GU_country=GB';
     expect(detect()).toEqual('GBPCountries');
 

--- a/assets/helpers/internationalisation/__tests__/countryTest.js
+++ b/assets/helpers/internationalisation/__tests__/countryTest.js
@@ -1,0 +1,301 @@
+// @flow
+
+// ----- Imports ----- //
+
+import { detect } from '../country';
+
+
+// ----- Tests ----- //
+
+describe('detect country', () => {
+
+  it('should return, under eu case (path case), the correct country from the query parameter', () => {
+
+    jsdom.reconfigure({
+      url: 'https://support.theguardian.com/eu?country=FR',
+    });
+    expect(detect()).toEqual('FR');
+
+    jsdom.reconfigure({
+      url: 'https://support.theguardian.com/eu?country=be',
+    });
+    expect(detect()).toEqual('BE');
+
+    jsdom.reconfigure({
+      url: 'https://support.theguardian.com/eu?country=IE',
+    });
+    expect(detect()).toEqual('IE');
+
+    jsdom.reconfigure({
+      url: 'https://support.theguardian.com/eu?country=DE',
+    });
+    expect(detect()).toEqual('DE');
+
+    jsdom.reconfigure({
+      url: 'https://support.theguardian.com/eu?country=AR',
+    });
+    expect(detect()).toEqual('DE');
+  });
+
+  it('should return, under eu case (path case), the correct country from GU_country cookie', () => {
+
+    jsdom.reconfigure({
+      url: 'https://support.theguardian.com/eu',
+    });
+    document.cookie = 'GU_country=FR';
+    expect(detect()).toEqual('FR');
+
+    document.cookie = 'GU_country=be';
+    expect(detect()).toEqual('BE');
+
+    document.cookie = 'GU_country=IE';
+    expect(detect()).toEqual('IE');
+
+    document.cookie = 'GU_country=DE';
+    expect(detect()).toEqual('DE');
+
+    document.cookie = 'GU_country=AR';
+    expect(detect()).toEqual('DE');
+  });
+
+  it('should return, under eu case (path case), the correct country from GU_geo_country cookie', () => {
+
+    jsdom.reconfigure({
+      url: 'https://support.theguardian.com/eu',
+    });
+    document.cookie = 'GU_country=42';
+    document.cookie = 'GU_geo_country=FR';
+    expect(detect()).toEqual('FR');
+
+    document.cookie = 'GU_country=42';
+    document.cookie = 'GU_geo_country=BE';
+    expect(detect()).toEqual('BE');
+
+    document.cookie = 'GU_country=42';
+    document.cookie = 'GU_geo_country=IE';
+    expect(detect()).toEqual('IE');
+
+    document.cookie = 'GU_country=42';
+    document.cookie = 'GU_geo_country=DE';
+    expect(detect()).toEqual('DE');
+
+    document.cookie = 'GU_country=42';
+    document.cookie = 'GU_geo_country=AR';
+    expect(detect()).toEqual('DE');
+  });
+
+  it('should return, under eu case (country group), the correct country from the query parameter', () => {
+
+    jsdom.reconfigure({
+      url: 'https://support.theguardian.com/example?country=FR',
+    });
+    expect(detect('EURCountries')).toEqual('FR');
+
+    jsdom.reconfigure({
+      url: 'https://support.theguardian.com/example?country=be',
+    });
+    expect(detect('EURCountries')).toEqual('BE');
+
+    jsdom.reconfigure({
+      url: 'https://support.theguardian.com/example?country=IE',
+    });
+    expect(detect('EURCountries')).toEqual('IE');
+
+    jsdom.reconfigure({
+      url: 'https://support.theguardian.com/example?country=DE',
+    });
+    expect(detect('EURCountries')).toEqual('DE');
+
+    jsdom.reconfigure({
+      url: 'https://support.theguardian.com/example?country=AR',
+    });
+    expect(detect('EURCountries')).toEqual('DE');
+  });
+
+  it('should return, under eu case (country group), the correct country from GU_country cookie', () => {
+
+    jsdom.reconfigure({
+      url: 'https://support.theguardian.com/example',
+    });
+    document.cookie = 'GU_country=FR';
+    expect(detect('EURCountries')).toEqual('FR');
+
+    document.cookie = 'GU_country=be';
+    expect(detect('EURCountries')).toEqual('BE');
+
+    document.cookie = 'GU_country=IE';
+    expect(detect('EURCountries')).toEqual('IE');
+
+    document.cookie = 'GU_country=DE';
+    expect(detect('EURCountries')).toEqual('DE');
+
+    document.cookie = 'GU_country=AR';
+    expect(detect('EURCountries')).toEqual('DE');
+  });
+
+  it('should return, under eu case (country group), the correct country from GU_geo_country cookie', () => {
+
+    jsdom.reconfigure({
+      url: 'https://support.theguardian.com/example',
+    });
+    document.cookie = 'GU_country=42';
+    document.cookie = 'GU_geo_country=FR';
+    expect(detect('EURCountries')).toEqual('FR');
+
+    document.cookie = 'GU_country=42';
+    document.cookie = 'GU_geo_country=BE';
+    expect(detect('EURCountries')).toEqual('BE');
+
+    document.cookie = 'GU_country=42';
+    document.cookie = 'GU_geo_country=IE';
+    expect(detect('EURCountries')).toEqual('IE');
+
+    document.cookie = 'GU_country=42';
+    document.cookie = 'GU_geo_country=DE';
+    expect(detect('EURCountries')).toEqual('DE');
+
+    document.cookie = 'GU_country=42';
+    document.cookie = 'GU_geo_country=AR';
+    expect(detect('EURCountries')).toEqual('DE');
+  });
+
+  it('should return the correct country from the country group (non EU case)', () => {
+    expect(detect('GBPCountries')).toEqual('GB');
+    expect(detect('UnitedStates')).toEqual('US');
+    expect(detect('AUDCountries')).toEqual('AU');
+  });
+
+  it('should return the correct country from path (non EU case)', () => {
+
+    jsdom.reconfigure({
+      url: 'https://support.theguardian.com/uk',
+    });
+    expect(detect()).toEqual('GB');
+
+    jsdom.reconfigure({
+      url: 'https://support.theguardian.com/us',
+    });
+    expect(detect()).toEqual('US');
+
+    jsdom.reconfigure({
+      url: 'https://support.theguardian.com/au',
+    });
+    expect(detect()).toEqual('AU');
+  });
+
+  it('should return the correct country from query parameter (non EU case)', () => {
+
+    jsdom.reconfigure({
+      url: 'https://support.theguardian.com/example?country=uk',
+    });
+    expect(detect()).toEqual('GB');
+
+    jsdom.reconfigure({
+      url: 'https://support.theguardian.com/example?country=Gb',
+    });
+    expect(detect()).toEqual('GB');
+
+    jsdom.reconfigure({
+      url: 'https://support.theguardian.com/example?country=BR',
+    });
+    expect(detect()).toEqual('BR');
+
+    jsdom.reconfigure({
+      url: 'https://support.theguardian.com/example?country=IE',
+    });
+    expect(detect()).toEqual('IE');
+
+    jsdom.reconfigure({
+      url: 'https://support.theguardian.com/example?country=uS',
+    });
+    expect(detect()).toEqual('US');
+  });
+
+  it('should return the correct country from GU_country cookie (non EU case)', () => {
+
+    jsdom.reconfigure({
+      url: 'https://support.theguardian.com/examplePath',
+    });
+
+    document.cookie = 'GU_country=UK';
+    expect(detect()).toEqual('GB');
+
+    document.cookie = 'GU_country=GB';
+    expect(detect()).toEqual('GB');
+
+    document.cookie = 'GU_country=US';
+    expect(detect()).toEqual('US');
+
+    document.cookie = 'GU_country=AU';
+    expect(detect()).toEqual('AU');
+
+    document.cookie = 'GU_country=FR';
+    expect(detect()).toEqual('FR');
+
+    document.cookie = 'GU_country=CI';
+    expect(detect()).toEqual('CI');
+
+    jsdom.reconfigure({
+      url: 'https://support.theguardian.com/examplePath?country=42',
+    });
+    document.cookie = 'GU_country=BR';
+    expect(detect()).toEqual('BR');
+  });
+
+  it('should return the correct country from GU_geo_country cookie (non EU case)', () => {
+
+    jsdom.reconfigure({
+      url: 'https://support.theguardian.com/examplePath',
+    });
+
+    document.cookie = 'GU_country=42';
+    document.cookie = 'GU_geo_country=UK';
+    expect(detect()).toEqual('GB');
+
+    document.cookie = 'GU_country=42';
+    document.cookie = 'GU_geo_country=GB';
+    document.cookie = 'GU_country=GB';
+    expect(detect()).toEqual('GB');
+
+    document.cookie = 'GU_country=42';
+    document.cookie = 'GU_geo_country=US';
+    expect(detect()).toEqual('US');
+
+    document.cookie = 'GU_country=42';
+    document.cookie = 'GU_geo_country=AU';
+    expect(detect()).toEqual('AU');
+
+    document.cookie = 'GU_country=42';
+    document.cookie = 'GU_geo_country=FR';
+    expect(detect()).toEqual('FR');
+
+    document.cookie = 'GU_country=42';
+    document.cookie = 'GU_geo_country=CI';
+    expect(detect()).toEqual('CI');
+
+    jsdom.reconfigure({
+      url: 'https://support.theguardian.com/examplePath?country=42',
+    });
+    document.cookie = 'GU_country=42';
+    document.cookie = 'GU_geo_country=BR';
+    expect(detect()).toEqual('BR');
+  });
+
+  it('should return GB as default country', () => {
+
+    jsdom.reconfigure({
+      url: 'https://support.theguardian.com/examplePath',
+    });
+    document.cookie = 'GU_country=42';
+    document.cookie = 'GU_geo_country=42';
+    expect(detect()).toEqual('GB');
+
+    jsdom.reconfigure({
+      url: 'https://support.theguardian.com/examplePath?country=42',
+    });
+    document.cookie = 'GU_country=42';
+    document.cookie = 'GU_geo_country=42';
+    expect(detect()).toEqual('GB');
+  });
+});
+

--- a/assets/helpers/internationalisation/countryGroup.js
+++ b/assets/helpers/internationalisation/countryGroup.js
@@ -97,6 +97,9 @@ function fromString(countryGroup: string): ?CountryGroupId {
 }
 
 function fromCountry(isoCountry: string): ?CountryGroupId {
+  if (isoCountry === 'UK') {
+    return 'GBPCountries';
+  }
 
   const countryGroup = Object.keys(countryGroups).find(countryGroupId =>
     countryGroups[countryGroupId].countries.includes(isoCountry));
@@ -135,6 +138,5 @@ function detect(): CountryGroupId {
 
 export {
   countryGroups,
-  fromCountry,
   detect,
 };

--- a/jestEnvironment.js
+++ b/jestEnvironment.js
@@ -1,0 +1,14 @@
+const JSDOMEnvironment = require('jest-environment-jsdom');
+
+module.exports = class JSDomGlobalEnvironment extends JSDOMEnvironment {
+  constructor(config) {
+    super(config);
+    this.global.jsdom = this.dom;
+  }
+
+  teardown() {
+    this.global.jsdom = null;
+    return super.teardown();
+  }
+};
+

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "moduleNameMapper": {
       "ophan(.*)": "<rootDir>/node_modules/ophan-tracker-js/build/ophan.support"
     },
-    "verbose": true
+    "verbose": true,
+    "testEnvironment": "./jestEnvironment"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Why are you doing this?

To be able to test the entire logic of CountryGroup and Country helpers.

[**Trello Card**](https://trello.com)

## Changes

* Introduced a jest environment to expose `jsdom` to the global environment and allow us to change window properties.
* Added a complete set of tests for the `countryGroup` helper.
* Added a complete set of tests for the `country` helper.
* Stop exporting an internal method.

## Screenshots

### Before:
<img width="796" alt="picture 618" src="https://user-images.githubusercontent.com/825398/37100625-5cab7484-221b-11e8-9f0f-e1608e7a8ac0.png">

### After:
<img width="800" alt="picture 617" src="https://user-images.githubusercontent.com/825398/37100641-65ff0ca8-221b-11e8-98fd-82363e08f1cb.png">
