### PR TITLE
 Specify target browsers in .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,25 @@
 {
-  "presets": ["react", ["env", {"modules": false}]],
+  "presets": [
+    "react",
+    [ "env", {
+      "modules": false,
+      "targets": {
+        "browsers": [
+          "Chrome >= 38",
+          "ChromeAndroid >= 44",
+          "Safari >= 8",
+          "ios_saf >= 8",
+          "IE >= 11",
+          "Edge >= 12",
+          "Firefox >= 44",
+          "FirefoxAndroid > 44",
+          "Samsung >= 4",
+          "Opera >= 25",
+          "OperaMini all"
+        ]
+      }
+    }]
+  ],
   "plugins": [
     "babel-plugin-transform-exponentiation-operator",
     "transform-class-properties",


### PR DESCRIPTION
## Why are you doing this?

To only transform for the browsers we care about.

[**Trello Card**](https://trello.com/c/X4tr2Agj/1139-setup-correctly-babel-preset-env)

## Changes

* `.babelrc`

