### PR TITLE
Fix The Sitemap

### DIFF
--- a/app/controllers/SiteMap.scala
+++ b/app/controllers/SiteMap.scala
@@ -27,10 +27,7 @@ class SiteMap(
         routes.Application.bundleLanding().absoluteURL(secure = true)
       }</loc>
       <xhtml:link rel="alternate" hreflang="en-us" href={
-        routes.Application.contributionsLanding(
-          id = "contributions-landing-page-us",
-          js = "contributionsLandingPageUS.js"
-        ).absoluteURL(secure = true)
+        routes.Application.contributionsLandingUS().absoluteURL(secure = true)
       }/>
       <xhtml:link rel="alternate" hreflang="en" href={
         routes.Application.bundleLanding().absoluteURL(secure = true)
@@ -42,13 +39,10 @@ class SiteMap(
   private def contributeLandingPages()(implicit req: RequestHeader) = {
     <url>
       <loc>{
-        routes.Application.contributionsLanding(id = "contributions-landing-page-us", js = "contributionsLandingPageUS.js").absoluteURL(secure = true)
+        routes.Application.contributionsLandingUS().absoluteURL(secure = true)
       }</loc>
       <xhtml:link rel="alternate" hreflang="en-us" href={
-        routes.Application.contributionsLanding(
-          id = "contributions-landing-page-us",
-          js = "contributionsLandingPageUS.js"
-        ).absoluteURL(secure = true)
+        routes.Application.contributionsLandingUS().absoluteURL(secure = true)
       }/>
       <xhtml:link rel="alternate" hreflang="en" href={
         routes.Application.bundleLanding().absoluteURL(secure = true)

--- a/test/controllers/SiteMapTest.scala
+++ b/test/controllers/SiteMapTest.scala
@@ -1,0 +1,42 @@
+package controllers
+
+import org.scalatest.WordSpec
+import org.scalatest.MustMatchers
+import fixtures.TestCSRFComponents
+import actions.CustomActionBuilders
+import play.api.test.FakeRequest
+import play.api.test.Helpers.{stubControllerComponents, status}
+import akka.util.Timeout
+import org.scalatest.mockito.MockitoSugar.mock
+import com.gu.identity.play.AuthenticatedIdUser
+import services.TestUserService
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class SiteMapTest extends WordSpec with MustMatchers with TestCSRFComponents {
+
+  implicit val timeout = Timeout(2.seconds)
+
+  val actionRefiner = new CustomActionBuilders(
+    authenticatedIdUserProvider = _ => Some(mock[AuthenticatedIdUser]),
+    idWebAppUrl = "",
+    supportUrl = "",
+    testUsers = mock[TestUserService],
+    cc = stubControllerComponents(),
+    addToken = csrfAddToken,
+    checkToken = csrfCheck,
+    csrfConfig = csrfConfig
+  )
+
+  "GET /sitemap.xml" should {
+    "not return an error" in {
+      val result = new SiteMap(
+        actionRefiner, stubControllerComponents()
+      )(mock[ExecutionContext]).sitemap.apply(FakeRequest())
+      status(result) mustBe 200
+    }
+  }
+
+}


### PR DESCRIPTION
# Why are you doing this?

We recently started getting 500s from the sitemap endpoint.

## How did that happen?

The `SiteMap` controller uses reverse-routing to lookup the US landing page, and the routes changed for this page in #510. Previously there was a generic `Application.contributionsLanding` method, which was called with the id and JavaScript bundle for each regionalised landing page. However, the changes made in the above PR switched to using a more specific `Application.contributionsLandingUS` method, which no longer requires these parameters passed through. This resulted in a match error in the auto-generated `ReverseRoutes` file, as `SiteMap` was still using the old controller method for the US.

## How is this fixed?

Switch the `SiteMap` controller across to using the new US route. I've also added a test to catch any errors thrown from the `sitemap` endpoint in the future.

**Note:** I've based the test code on existing code for the other controllers, if there's a better way of doing it please let me know!

cc @JustinPinner 

[**Trello Card**](https://trello.com/c/gVNtFyV3/1369-stop-the-sitemap-throwing-500s)

# Changes

- Update `SiteMap` to use the new US endpoint.
- Add test to check that the sitemap endpoint isn't throwing errors.
