### PR TITLE
Adding AUDCountries to the country group switcher

### DIFF
--- a/assets/pages/bundles-landing/components/countrySwitcherHeaderContainer.jsx
+++ b/assets/pages/bundles-landing/components/countrySwitcherHeaderContainer.jsx
@@ -11,7 +11,7 @@ import type { State } from '../bundlesLandingReducers';
 
 
 const availableCountriesGroups: CountryGroupId[] =
-  ['GBPCountries', 'UnitedStates', 'EURCountries'];
+  ['GBPCountries', 'UnitedStates', 'EURCountries', 'AUDCountries'];
 
 // ----- Functions ----- //
 

--- a/assets/pages/contributions-landing/components/countrySwitcherHeaderContainer.jsx
+++ b/assets/pages/contributions-landing/components/countrySwitcherHeaderContainer.jsx
@@ -12,7 +12,7 @@ import type { State } from '../contributionsLandingReducers';
 
 
 const availableCountriesGroups: CountryGroupId[] =
-  ['GBPCountries', 'UnitedStates', 'EURCountries'];
+  ['GBPCountries', 'UnitedStates', 'EURCountries', 'AUDCountries'];
 
 // ----- Functions ----- //
 


### PR DESCRIPTION
## Why are you doing this?

To be able to switch countries from the `AUDcountries` landing page and to the `AUDcountries` landing page.
[**Trello Card**](https://trello.com)

## Changes

* Country switcher

## Screenshots

### AUD landing page
<img width="1219" alt="picture 637" src="https://user-images.githubusercontent.com/825398/37290889-552863a0-2605-11e8-9e40-91e303e84c31.png">

<img width="272" alt="picture 638" src="https://user-images.githubusercontent.com/825398/37290954-7fb836b8-2605-11e8-80a2-dac8f3c340dd.png">


