### PR TITLE
Circles As Default

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -98,10 +98,6 @@ class Application(
       }
     }
 
-  def regularContributionsPending(title: String, id: String, js: String, INTCMP: String): Action[AnyContent] = CachedAction() { implicit request =>
-    Ok(views.html.react(title, id, js))
-  }
-
   def contributionsLanding(title: String, id: String, js: String): Action[AnyContent] = CachedAction() { implicit request =>
     Ok(views.html.contributionsLanding(title, description = Some(stringsConfig.contributionLandingDescription), id, js, contributionsPayPalEndpoint))
   }

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -99,28 +99,6 @@ class Application(
       }
     }
 
-  def contributionsLandingUK(title: String, id: String, js: String, INTCMP: String): Action[AnyContent] = CachedAction() { implicit request =>
-    val (updatedId, updatedJs) = applyCircles(INTCMP, id, js, "contributions-landing-page-uk", "contributionsLandingPageUK.js")
-    Ok(views.html.contributionsLanding(
-      title,
-      description = Some(stringsConfig.contributionLandingDescription),
-      updatedId,
-      updatedJs,
-      contributionsPayPalEndpoint
-    ))
-  }
-
-  def contributionsLandingUS(title: String, id: String, js: String, INTCMP: String): Action[AnyContent] = CachedAction() { implicit request =>
-    val (updatedId, updatedJs) = applyCircles(INTCMP, id, js, "contributions-landing-page-us", "contributionsLandingPageUS.js")
-    Ok(views.html.contributionsLanding(
-      title,
-      description = Some(stringsConfig.contributionLandingDescription),
-      updatedId,
-      updatedJs,
-      contributionsPayPalEndpoint
-    ))
-  }
-
   def regularContributionsPending(title: String, id: String, js: String, INTCMP: String): Action[AnyContent] = CachedAction() { implicit request =>
     val (updatedId, updatedJs) = applyCircles(INTCMP, id, js, "regular-contributions-thank-you-page", "regularContributionsThankYouPage.js")
     Ok(views.html.react(title, updatedId, updatedJs))

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -86,7 +86,6 @@ class Application(
     AuthenticatedAction.async { implicit request =>
       import cats.implicits._
 
-      val (updatedId, updatedJs) = applyCircles(INTCMP, id, js, "regular-contributions-thank-you-page", "regularContributionsThankYouPage.js")
       val identityUser = identityService.getUser(request.user)
 
       identityUser.value.foreach({
@@ -95,13 +94,12 @@ class Application(
       })
 
       identityUser.toOption.value.map { maybeUser =>
-        Ok(views.html.monthlyContributionsThankyou(title, updatedId, updatedJs, maybeUser))
+        Ok(views.html.monthlyContributionsThankyou(title, id, js, maybeUser))
       }
     }
 
   def regularContributionsPending(title: String, id: String, js: String, INTCMP: String): Action[AnyContent] = CachedAction() { implicit request =>
-    val (updatedId, updatedJs) = applyCircles(INTCMP, id, js, "regular-contributions-thank-you-page", "regularContributionsThankYouPage.js")
-    Ok(views.html.react(title, updatedId, updatedJs))
+    Ok(views.html.react(title, id, js))
   }
 
   def contributionsLanding(title: String, id: String, js: String): Action[AnyContent] = CachedAction() { implicit request =>

--- a/app/controllers/SiteMap.scala
+++ b/app/controllers/SiteMap.scala
@@ -27,7 +27,7 @@ class SiteMap(
         routes.Application.bundleLanding().absoluteURL(secure = true)
       }</loc>
       <xhtml:link rel="alternate" hreflang="en-us" href={
-        routes.Application.contributionsLandingUS().absoluteURL(secure = true)
+        contributionsLandingPageUS
       }/>
       <xhtml:link rel="alternate" hreflang="en" href={
         routes.Application.bundleLanding().absoluteURL(secure = true)
@@ -39,16 +39,23 @@ class SiteMap(
   private def contributeLandingPages()(implicit req: RequestHeader) = {
     <url>
       <loc>{
-        routes.Application.contributionsLandingUS().absoluteURL(secure = true)
+        contributionsLandingPageUS
       }</loc>
       <xhtml:link rel="alternate" hreflang="en-us" href={
-        routes.Application.contributionsLandingUS().absoluteURL(secure = true)
+        contributionsLandingPageUS
       }/>
       <xhtml:link rel="alternate" hreflang="en" href={
         routes.Application.bundleLanding().absoluteURL(secure = true)
       }/>
       <priority>1.0</priority>
     </url>
+  }
+
+  private def contributionsLandingPageUS()(implicit req: RequestHeader) = {
+    routes.Application.contributionsLanding(
+      id = "contributions-landing-page-us",
+      js = "contributionsLandingPageUS.js"
+    ).absoluteURL(secure = true)
   }
 
 }

--- a/conf/routes
+++ b/conf/routes
@@ -29,8 +29,8 @@ GET  /monthly-contributions                         controllers.Application.cont
 
 # ----- Contributions ----- #
 
-GET  /uk/contribute                                 controllers.Application.contributionsLandingUK(title="Support the Guardian | Make a Contribution", id="contributions-landing-page-uk-old", js="contributionsLandingPageUKOld.js", INTCMP: String ?= "")
-GET  /us/contribute                                 controllers.Application.contributionsLandingUS(title="Support the Guardian | Make a Contribution", id="contributions-landing-page-us-old", js="contributionsLandingPageUSOld.js", INTCMP: String ?= "")
+GET  /uk/contribute                                 controllers.Application.contributionsLanding(title="Support the Guardian | Make a Contribution", id="contributions-landing-page-uk", js="contributionsLandingPageUK.js")
+GET  /us/contribute                                 controllers.Application.contributionsLanding(title="Support the Guardian | Make a Contribution", id="contributions-landing-page-us", js="contributionsLandingPageUS.js")
 GET  /au/contribute                                 controllers.Application.contributionsLanding(title="Support the Guardian | Make a Contribution", id="contributions-landing-page-au", js="contributionsLandingPageAU.js")
 GET  /eu/contribute                                 controllers.Application.contributionsLanding(title="Support the Guardian | Make a Contribution", id="contributions-landing-page-eu", js="contributionsLandingPageEU.js")
 

--- a/conf/routes
+++ b/conf/routes
@@ -35,11 +35,11 @@ GET  /au/contribute                                 controllers.Application.cont
 GET  /eu/contribute                                 controllers.Application.contributionsLanding(title="Support the Guardian | Make a Contribution", id="contributions-landing-page-eu", js="contributionsLandingPageEU.js")
 
 GET  /contribute/recurring                          controllers.RegularContributions.displayForm(paypal: Option[Boolean], directDebit: Option[Boolean])
-GET  /contribute/recurring/thankyou                 controllers.Application.regularContributionsThankYou(title="Support the Guardian | Thank You", id="regular-contributions-thankyou-page-old", js="regularContributionsThankyouPageOld.js", INTCMP: String ?= "")
+GET  /contribute/recurring/thankyou                 controllers.Application.regularContributionsThankYou(title="Support the Guardian | Thank You", id="regular-contributions-thank-you-page", js="regularContributionsThankYouPage.js", INTCMP: String ?= "")
 GET  /contribute/recurring/existing                 controllers.Application.reactTemplate(title="Support the Guardian | Existing Contributor", id="regular-contributions-existing-page", js="regularContributionsExistingPage.js")
 POST /contribute/recurring/create                   controllers.RegularContributions.create
 GET  /contribute/recurring/status                   controllers.RegularContributions.status(jobId: String)
-GET  /contribute/recurring/pending                  controllers.Application.regularContributionsThankYou(title="Support the Guardian | Thank You", id="regular-contributions-pending-page", js="regularContributionsPendingPage.js", INTCMP: String ?= "")
+GET  /contribute/recurring/pending                  controllers.Application.regularContributionsThankYou(title="Support the Guardian | Thank You", id="regular-contributions-thank-you-page", js="regularContributionsThankYouPage.js", INTCMP: String ?= "")
 
 # this endpoint should be removed once identity remove
 # the need for a client token


### PR DESCRIPTION
## Why are you doing this?

To serve the contributions landing pages (US/UK) and the regular contributions thank you page with Circles as default.

[**Trello Card**](https://trello.com/c/Hb7b3hXR/1353-tbc-from-test-results-put-circles-live)

cc @JustinPinner 

## Changes

- Removed the circles check from the regular thank you page.
- Deleted the custom controller methods for the US and UK contributions landing pages, they're now back to using the `contributionsLanding` method.
- Deleted an unused method for the regular contributions pending page (the route has used the thank you page for a while).
- Updated the site map to handle the US contributions landing (and added a helper method to reduce code duplication).
- Updated the routes file to match the controller method changes.
