### PR TITLE
Circles On The Checkout

### DIFF
--- a/assets/components/paymentAmount/paymentAmount.scss
+++ b/assets/components/paymentAmount/paymentAmount.scss
@@ -1,11 +1,12 @@
 .component-payment-amount {
   border-radius: 1000px;
-  font-size: 24px;
-  color: #fff;
+  font-size: 18px;
+  color: gu-colour(garnett-neutral-1);
+  font-weight: bold;
   width: 60px;
   height: 60px;
   text-align: center;
-  background-color: gu-colour(neutral-1);
+  background-color: gu-colour(news-garnett-highlight);
   line-height: 60px;
 }
 

--- a/assets/pages/oneoff-contributions/oneoffContributions.jsx
+++ b/assets/pages/oneoff-contributions/oneoffContributions.jsx
@@ -69,7 +69,7 @@ const content = (
       <TestUserBanner />
       <SimpleHeader />
       <CirclesIntroduction headings={[`Make a ${contribDescription}`, 'contribution']} />
-       <hr className="oneoff-contrib__multiline" />
+      <hr className="oneoff-contrib__multiline" />
       <div className="oneoff-contrib gu-content-margin">
         <InfoSection heading={`Your ${contribDescription} contribution`} className="oneoff-contrib__your-contrib">
           <PaymentAmount

--- a/assets/pages/oneoff-contributions/oneoffContributions.jsx
+++ b/assets/pages/oneoff-contributions/oneoffContributions.jsx
@@ -17,6 +17,7 @@ import PaymentAmount from 'components/paymentAmount/paymentAmount';
 import ContribLegal from 'components/legal/contribLegal/contribLegal';
 import DisplayName from 'components/displayName/displayName';
 import Signout from 'components/signout/signout';
+import CirclesIntroduction from 'components/circlesIntroduction/circlesIntroduction';
 
 import { detect as detectCountryGroup } from 'helpers/internationalisation/countryGroup';
 import { detect as detectCountry } from 'helpers/internationalisation/country';
@@ -67,16 +68,15 @@ const content = (
     <div className="gu-content">
       <TestUserBanner />
       <SimpleHeader />
+      <CirclesIntroduction headings={[`Make a ${contribDescription}`, 'contribution']} />
+       <hr className="oneoff-contrib__multiline" />
       <div className="oneoff-contrib gu-content-margin">
-        <InfoSection className="oneoff-contrib__header">
-          <h1 className="oneoff-contrib__heading">{`Make a ${contribDescription} contribution`}</h1>
-          <Secure />
-        </InfoSection>
         <InfoSection heading={`Your ${contribDescription} contribution`} className="oneoff-contrib__your-contrib">
           <PaymentAmount
             amount={state.page.oneoffContrib.amount}
             currency={state.page.oneoffContrib.currency}
           />
+          <Secure />
         </InfoSection>
         <InfoSection heading="Your details" headingContent={<Signout />} className="oneoff-contrib__your-details">
           <DisplayName />

--- a/assets/pages/oneoff-contributions/oneoffContributions.scss
+++ b/assets/pages/oneoff-contributions/oneoffContributions.scss
@@ -2,20 +2,10 @@
 
 	// ----- General ----- //
 
-	background-color: darken(gu-colour(multimedia-main-2), 5%);
-	color: gu-colour(neutral-1);
-
-	// Fix for IE.
-	& > div {
-		background-color: darken(gu-colour(multimedia-main-2), 5%);
-	}
-
-	.oneoff-contrib {
-		background-color: gu-colour(multimedia-main-2);
-	}
+	color: gu-colour(garnett-neutral-1);
 
 	a {
-		color: gu-colour(neutral-1);
+		color: gu-colour(garnett-neutral-1);
 	}
 
 
@@ -23,6 +13,28 @@
 
 	h2 {
 		margin-top: -2px;
+	}
+
+	.component-info-section {
+		padding-top: 0;
+	}
+
+	.component-info-section__heading {
+		font-family: $gu-egyptian-web;
+		font-size: 24px;
+		line-height: 1.17;
+		padding-top: $gu-v-spacing / 2;
+
+		@include dropline;
+	}
+
+	.component-info-section__content {
+		padding-top: $gu-v-spacing;
+
+		@include mq($from: desktop) {
+			box-sizing: border-box;
+			padding-left: $gu-h-spacing;
+		}
 	}
 
 	// ----- Header
@@ -65,6 +77,12 @@
 			margin-bottom: 0px;
 		}
 
+		#postcode {
+			@include mq($from: desktop) {
+				width: 174px;
+			}
+		}
+
 		input[type='text'] {
 			width: 100%;
 			box-sizing: border-box;
@@ -79,24 +97,45 @@
 		}
 	}
 
+	.component-text-input {
+		border: 2px solid gu-colour(news-garnett-highlight);
+		font-family: $gu-text-sans-web;
+		height: 44px;
+		font-weight: bold;
+		margin-bottom: $gu-v-spacing;
+	}
+
 	// ----- Payment methods
 
 	.oneoff-contrib__payment-methods {
 		.component-stripe-pop-up-button {
 			box-sizing: border-box;
+			height: 54px;
+			background-color: gu-colour(news-garnett-highlight);
+      color: gu-colour(garnett-neutral-1);
+
+      svg {
+      	fill: gu-colour(garnett-neutral-1);
+      }
 
 			@include mq($from: desktop) {
 				width: 304px;
 			}
 
+			&:hover {
+				background-color: darken(gu-colour(news-garnett-highlight), 5%);
+			}
 		}
+	}
+
+	.component-paypal-contribution-button {
+		height: 54px;
+		margin-top: $gu-v-spacing;
 	}
 
 	// ----- Legal ----- //
 
 	.terms-privacy {
-		background-color: darken(#fff, 5%);
-
 		.component-info-section__content {
 			@include mq($from: desktop) {
 				width: 550px;
@@ -106,12 +145,13 @@
 
 	.terms-privacy__content {
 		background-color: #fff;
-		padding-top: $gu-v-spacing;
+		color: gu-colour(media-garnett-main-1);
 	}
 
 	.component-contrib-legal {
 		padding-top: $gu-v-spacing;
 		padding-bottom: $gu-v-spacing * 2;
+		font-size: 14px;
 	}
 
 }

--- a/assets/pages/oneoff-contributions/oneoffContributions.scss
+++ b/assets/pages/oneoff-contributions/oneoffContributions.scss
@@ -17,6 +17,8 @@
 
 	.component-info-section {
 		padding-top: 0;
+		padding-bottom: $gu-v-spacing * 3;
+		border-top: 1px solid gu-colour(garnett-neutral-4);
 	}
 
 	.component-info-section__heading {
@@ -69,6 +71,46 @@
 
 	}
 
+	.oneoff-contrib__multiline {
+		width: 100%;
+		border: none;
+		margin: 0;
+
+		&:after {
+			@include multiline(4, gu-colour(garnett-neutral-4));
+			background-color: #fff;
+			content: '';
+			display: block;
+		}
+	}
+
+	// ----- Your contrib
+
+	.oneoff-contrib__your-contrib {
+		border: none;
+
+		.component-info-section__content {
+			position: relative;
+		}
+
+		.component-secure {
+			position: absolute;
+			right: 0;
+			top: $gu-v-spacing;
+			color: gu-colour(garnett-neutral-2);
+
+			&__text {
+				margin-top: 2px;
+			}
+
+			// Fix for IE.
+			svg {
+				width: 13px;
+				fill: gu-colour(garnett-neutral-2);
+			}
+		}
+	}
+
 	// ----- Your details
 
 	.oneoff-contrib__your-details {
@@ -113,12 +155,13 @@
 			height: 54px;
 			background-color: gu-colour(news-garnett-highlight);
       color: gu-colour(garnett-neutral-1);
+      width: 100%;
 
       svg {
       	fill: gu-colour(garnett-neutral-1);
       }
 
-			@include mq($from: desktop) {
+			@include mq($from: phablet) {
 				width: 304px;
 			}
 
@@ -131,6 +174,11 @@
 	.component-paypal-contribution-button {
 		height: 54px;
 		margin-top: $gu-v-spacing;
+		width: 100%;
+
+		@include mq($from: phablet) {
+			width: 304px;
+		}
 	}
 
 	// ----- Legal ----- //

--- a/assets/pages/regular-contributions/regularContributions.jsx
+++ b/assets/pages/regular-contributions/regularContributions.jsx
@@ -17,6 +17,7 @@ import TestUserBanner from 'components/testUserBanner/testUserBanner';
 import PaymentAmount from 'components/paymentAmount/paymentAmount';
 import ContribLegal from 'components/legal/contribLegal/contribLegal';
 import Signout from 'components/signout/signout';
+import CirclesIntroduction from 'components/circlesIntroduction/circlesIntroduction';
 
 import { detect as detectCurrency } from 'helpers/internationalisation/currency';
 import { detect as detectCountry } from 'helpers/internationalisation/country';
@@ -46,8 +47,8 @@ const contributionType = parseContrib(getQueryParameter('contribType'), 'MONTHLY
 const contributionAmount = parseAmount(getQueryParameter('contributionValue'), contributionType, countryGroup).amount;
 
 const title = {
-  annual: 'Make an annual contribution',
-  monthly: 'Make a monthly contribution',
+  annual: ['Make an annual', 'contribution'],
+  monthly: ['Make a monthly', 'contribution'],
 };
 
 /* eslint-disable no-underscore-dangle */
@@ -73,16 +74,15 @@ const content = (
     <div className="gu-content">
       <TestUserBanner />
       <SimpleHeader />
+      <CirclesIntroduction headings={title[contributionType.toLowerCase()]} />
+      <hr className="regular-contrib__multiline" />
       <div className="regular-contrib gu-content-margin">
-        <InfoSection className="regular-contrib__header">
-          <h1 className="regular-contrib__heading">{title[contributionType.toLowerCase()]}</h1>
-          <Secure />
-        </InfoSection>
         <InfoSection heading={`Your ${contributionType.toLowerCase()} contribution`} className="regular-contrib__your-contrib">
           <PaymentAmount
             amount={state.page.regularContrib.amount}
             currency={state.page.regularContrib.currency}
           />
+          <Secure />
         </InfoSection>
         <InfoSection heading="Your details" headingContent={<Signout />} className="regular-contrib__your-details">
           <DisplayName />

--- a/assets/pages/regular-contributions/regularContributions.scss
+++ b/assets/pages/regular-contributions/regularContributions.scss
@@ -2,17 +2,7 @@
 
 	// ----- General ----- //
 
-	background-color: darken(gu-colour(multimedia-main-2), 5%);
-	color: gu-colour(neutral-1);
-
-	// Fix for IE.
-	& > div {
-		background-color: darken(gu-colour(multimedia-main-2), 5%);
-	}
-
-	.regular-contrib {
-		background-color: gu-colour(multimedia-main-2);
-	}
+	color: gu-colour(garnett-neutral-1);
 
 
 	// ----- Sections ----- //
@@ -20,6 +10,29 @@
 	h2 {
 		margin-top: -2px;
 	}
+
+	.component-info-section {
+		padding-top: 0;
+	}
+
+	.component-info-section__heading {
+		font-family: $gu-egyptian-web;
+		font-size: 24px;
+		line-height: 1.17;
+		padding-top: $gu-v-spacing / 2;
+
+		@include dropline;
+	}
+
+	.component-info-section__content {
+		padding-top: $gu-v-spacing;
+
+		@include mq($from: desktop) {
+			box-sizing: border-box;
+			padding-left: $gu-h-spacing;
+		}
+	}
+
 
 	// ----- Header
 
@@ -110,6 +123,14 @@
 
 	}
 
+	.component-text-input {
+		border: 2px solid gu-colour(news-garnett-highlight);
+		font-family: $gu-text-sans-web;
+		height: 44px;
+		font-weight: bold;
+		margin-bottom: $gu-v-spacing;
+	}
+
 	// ----- Payment methods
 
   .regular-contrib__payment-methods {
@@ -120,6 +141,12 @@
 
     .component-stripe-pop-up-button {
       box-sizing: border-box;
+      background-color: gu-colour(news-garnett-highlight);
+      color: gu-colour(garnett-neutral-1);
+
+      svg {
+      	fill: gu-colour(garnett-neutral-1);
+      }
 
       @include mq($from: desktop) {
         width: 304px;
@@ -128,11 +155,13 @@
     }
   }
 
+  .component-paypal-button-checkout {
+  	margin-top: $gu-v-spacing;
+  }
+
 	// ----- Legal ----- //
 
 	.terms-privacy {
-		background-color: darken(#fff, 5%);
-
 		.component-info-section__content {
 			@include mq($from: desktop) {
 				width: 550px;
@@ -142,12 +171,13 @@
 
 	.terms-privacy__content {
 		background-color: #fff;
-		padding-top: $gu-v-spacing;
+		color: gu-colour(media-garnett-main-1);
 	}
 
 	.component-contrib-legal {
 		padding-top: $gu-v-spacing;
 		padding-bottom: $gu-v-spacing * 2;
+		font-size: 14px;
 	}
 
 }

--- a/assets/pages/regular-contributions/regularContributions.scss
+++ b/assets/pages/regular-contributions/regularContributions.scss
@@ -141,8 +141,9 @@
 
 		.component-select-input {
 			width: 100%;
-			margin-top: 20px;
+			margin-top: $gu-v-spacing;
 			margin-bottom: 0;
+			border: 2px solid gu-colour(news-garnett-highlight);
 
 			@include mq($from: desktop) {
 				width: 304px;

--- a/assets/pages/regular-contributions/regularContributions.scss
+++ b/assets/pages/regular-contributions/regularContributions.scss
@@ -13,6 +13,8 @@
 
 	.component-info-section {
 		padding-top: 0;
+		padding-bottom: $gu-v-spacing * 3;
+		border-top: 1px solid gu-colour(garnett-neutral-4);
 	}
 
 	.component-info-section__heading {
@@ -52,21 +54,47 @@
 				line-height: 44px;
 			}
 		}
+	}
+
+	.regular-contrib__multiline {
+		width: 100%;
+		border: none;
+		margin: 0;
+
+		&:after {
+			@include multiline(4, gu-colour(garnett-neutral-4));
+			background-color: #fff;
+			content: '';
+			display: block;
+		}
+	}
+
+	// ----- Your contrib
+
+	.regular-contrib__your-contrib {
+		border: none;
+
+		.component-info-section__content {
+			position: relative;
+		}
 
 		.component-secure {
+			position: absolute;
+			right: 0;
+			top: $gu-v-spacing;
+			color: gu-colour(garnett-neutral-2);
+
 			&__text {
-				margin-top: $gu-v-spacing / 2;
+				margin-top: 2px;
 			}
 
 			// Fix for IE.
 			svg {
 				width: 13px;
+				fill: gu-colour(garnett-neutral-2);
 			}
 		}
-
 	}
-
-	// ----- Your contrib
 
 	.regular-contrib__amount {
 		border-radius: 1000px;
@@ -143,20 +171,29 @@
       box-sizing: border-box;
       background-color: gu-colour(news-garnett-highlight);
       color: gu-colour(garnett-neutral-1);
+      width: 100%;
 
       svg {
       	fill: gu-colour(garnett-neutral-1);
       }
 
-      @include mq($from: desktop) {
+      @include mq($from: phablet) {
         width: 304px;
       }
 
+			&:hover {
+				background-color: darken(gu-colour(news-garnett-highlight), 5%);
+			}
     }
   }
 
   .component-paypal-button-checkout {
   	margin-top: $gu-v-spacing;
+  	width: 100%;
+
+		@include mq($from: phablet) {
+			width: 304px;
+		}
   }
 
 	// ----- Legal ----- //


### PR DESCRIPTION
## Why are you doing this?

To go live with Circles we've agreed to make some minor changes to the checkout pages, to keep the user journeys consistent. This PR updates the one-off and regular contribution checkouts with some Circles branding.

This is a first pass to get Circles live. We'd like to give these pages a more thorough treatment in the near future, to improve the design, sort out the CSS problems, and use some of the newer components that exist on the other Circles pages.

[**Trello Card**](https://trello.com/c/2vlrnKh1/1220-recurring-contribution-page) and [**this one**](https://trello.com/c/QcBiRp0w/1221-one-off-contribution-page).

cc @JustinPinner @CPKING

## Changes

- Brought the regular contributions checkout page styling in-line with the other Circles pages.
- Brought the one-off contributions checkout page styling in-line with the other Circles pages.
- Added Circles hero headings to both checkout pages.

## Screenshots

**Regular**

![monthly-desktop](https://user-images.githubusercontent.com/5131341/37361846-c4577036-26eb-11e8-99d2-b0855980b1c1.png)

![monthly-mobile](https://user-images.githubusercontent.com/5131341/37361981-057f4eee-26ec-11e8-89bc-7378aeb9f594.png)

**One-off**

![oneoff-desktop](https://user-images.githubusercontent.com/5131341/37361992-0cb14208-26ec-11e8-86cb-2365dc435b54.png)

![oneoff-mobile](https://user-images.githubusercontent.com/5131341/37361997-0f8a3034-26ec-11e8-8b70-49e46c579d7f.png)
