### PR TITLE
Fix Post-Deploy Tests For Circles

### DIFF
--- a/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
+++ b/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
@@ -116,6 +116,7 @@ function OneOffCta(props: {
       accessibilityHint={`proceed to make your ${spokenType} contribution`}
       url={clickUrl}
       onClick={onCtaClick(props.isDisabled, props.resetError)}
+      id="qa-contribute-button"
     />
   );
 
@@ -145,6 +146,7 @@ function RegularCta(props: {
       accessibilityHint={`proceed to make your ${spokenType} contribution`}
       url={clickUrl}
       onClick={onCtaClick(props.isDisabled, props.resetError)}
+      id="qa-contribute-button"
     />
   );
 

--- a/assets/components/thankYouIntroduction/thankYouIntroduction.jsx
+++ b/assets/components/thankYouIntroduction/thankYouIntroduction.jsx
@@ -27,7 +27,7 @@ function ThankYouIntroduction(props: PropTypes) {
       <SvgThankYouHeroDesktop />
       <SvgThankYouHeroMobile />
       <div className="component-thank-you-introduction__content gu-content-margin">
-        <div className="component-thank-you-introduction__display-copy">
+        <div id="qa-thank-you-message" className="component-thank-you-introduction__display-copy">
           <Highlights highlights={props.highlights} />
           <h1 className="component-thank-you-introduction__heading">
             {props.headings.map(heading =>

--- a/assets/helpers/contributions.js
+++ b/assets/helpers/contributions.js
@@ -387,6 +387,7 @@ function getContributionTypeRadios(countryGroupId: CountryGroupId) {
       value: 'ONE_OFF',
       text: getOneOffName(countryGroupId),
       accessibilityHint: `Make a ${getOneOffSpokenName(countryGroupId)} contribution`,
+      id: 'qa-one-off-toggle',
     },
   ];
 


### PR DESCRIPTION
## Why are you doing this?

The Circles pages are complete rebuilds, so don't contain the QA ids on key elements. This reintroduces those ids.

cc @JustinPinner 

## Changes

- Added a QA id to the contribute CTA.
- Added a QA id to the thank you page.
- Added a QA id to the one-off toggle.
