### PR TITLE
Remove hyphen in long-term

### DIFF
--- a/assets/pages/contributions-landing-us/contributionsLandingUS.jsx
+++ b/assets/pages/contributions-landing-us/contributionsLandingUS.jsx
@@ -41,7 +41,7 @@ const content = (
         highlights={['Support', 'The Guardian']}
       />
       <Contribute
-        copy="Make a monthly commitment to support The Guardian long-term or a one-time contribution
+        copy="Make a monthly commitment to support The Guardian long term or a one-time contribution
             as and when you feel like it – choose the option that suits you best."
       >
         <ContributionSelectionContainer />


### PR DESCRIPTION
## Why are you doing this?

The world's smallest PR. the previous copy change had the phrase 'long-term' in it. This should be 'long term'.