### PR TITLE
Remove UDP 123 for NTP

### DIFF
--- a/cloud-formation/cfn.yaml
+++ b/cloud-formation/cfn.yaml
@@ -234,10 +234,6 @@ Resources:
           FromPort: 443
           ToPort: 443
           CidrIp: 0.0.0.0/0
-        - IpProtocol: udp
-          FromPort: 123
-          ToPort: 123
-          CidrIp: 0.0.0.0/0
 
   NoHealthyInstancesAlarm:
     Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
## Why are you doing this?

We should only open ports that are necessary.  Since we've moved from NTP to AWS time sync service this port can be clsoed.

> The Amazon Time Sync Service is available through NTP at the 169.254.169.123 IP address for any instance running in a VPC. Your instance does not require access to the internet, and you do not have to configure your security group rules or your network ACL rules to allow access. Use the following procedures to configure the Amazon Time Sync Service on your instance using the chrony client.

From https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/set-time.html