### PR TITLE
Disable paypal button

### DIFF
--- a/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
+++ b/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
@@ -70,10 +70,6 @@ export default function ContributionPaymentCtas(props: PropTypes) {
     return (
       <div className={generateClassName(baseClassName, props.isDisabled ? 'disabled' : null)}>
         <OneOffCta {...props} />
-        <props.PayPalButton
-          buttonText={`Contribute ${props.currency.glyph}${props.amount} with PayPal`}
-          onClick={props.resetError}
-        />
         <ErrorMessage message={props.error} />
         <TermsPrivacy country={props.country} />
       </div>

--- a/assets/pages/bundles-landing/components/stackedBundle.jsx
+++ b/assets/pages/bundles-landing/components/stackedBundle.jsx
@@ -9,7 +9,6 @@ import FeatureList from 'components/featureList/featureList';
 import CtaLink from 'components/ctaLink/ctaLink';
 import Bundle from 'components/bundle/bundle';
 import ContribAmounts from 'components/contribAmounts/contribAmounts';
-import PayPalContributionButton from 'containerisableComponents/payPalContributionButton/payPalContributionButton';
 import TermsPrivacy from 'components/legal/termsPrivacy/termsPrivacy';
 import { routes } from 'helpers/routes';
 import { getContribKey } from 'helpers/contributions';

--- a/assets/pages/bundles-landing/components/stackedBundle.jsx
+++ b/assets/pages/bundles-landing/components/stackedBundle.jsx
@@ -318,20 +318,6 @@ function ContributionBundle(props: PropTypes) {
         onClick={onClick}
       />
 
-      {props.contribType === 'ONE_OFF' && !!contribAttrs.paypalCta &&
-      <PayPalContributionButton
-        buttonText={contribAttrs.paypalCta.text}
-        amount={Number(props.contribAmount.oneOff.value)}
-        referrerAcquisitionData={props.referrerAcquisitionData}
-        isoCountry={props.isoCountry}
-        countryGroupId={props.countryGroupId}
-        // eslint-disable-next-line no-alert
-        errorHandler={e => alert(e)}
-        abParticipations={props.abTests}
-        additionalClass={props.contribError ? 'contrib-error' : ''}
-        canClick={!props.contribError}
-      />
-      }
 
       <TermsPrivacy country={props.isoCountry} />
 

--- a/assets/pages/contributions-landing-au/components/contributionsBundle.jsx
+++ b/assets/pages/contributions-landing-au/components/contributionsBundle.jsx
@@ -10,7 +10,6 @@ import Bundle from 'components/bundle/bundle';
 import ErrorMessage from 'components/errorMessage/errorMessage';
 import { routes } from 'helpers/routes';
 import ContribAmounts from 'components/contribAmounts/contribAmounts';
-import PayPalContributionButton from 'containerisableComponents/payPalContributionButton/payPalContributionButton';
 import TermsPrivacy from 'components/legal/termsPrivacy/termsPrivacy';
 
 import { getContribKey } from 'helpers/contributions';
@@ -182,16 +181,7 @@ function contribAttrs(
 
 function showPayPal(props: PropTypes) {
   if (props.contribType === 'ONE_OFF') {
-    return (<PayPalContributionButton
-      amount={Number(props.contribAmount.oneOff.value)}
-      abParticipations={props.abTests}
-      referrerAcquisitionData={props.referrerAcquisitionData}
-      isoCountry={props.isoCountry}
-      countryGroupId={props.countryGroupId}
-      errorHandler={props.payPalErrorHandler}
-      canClick={!props.contribError}
-      buttonText={`Contribute ${props.currency.glyph}${props.contribAmount.oneOff.value} with PayPal`}
-    />);
+    return null;
   }
   return null;
 }

--- a/assets/pages/oneoff-contributions/components/oneoffContributionsPayment.jsx
+++ b/assets/pages/oneoff-contributions/components/oneoffContributionsPayment.jsx
@@ -6,7 +6,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import StripePopUpButton from 'components/paymentButtons/stripePopUpButton/stripePopUpButton';
-import PayPalContributionButton from 'containerisableComponents/payPalContributionButton/payPalContributionButton';
 import ErrorMessage from 'components/errorMessage/errorMessage';
 
 import { validateEmailAddress } from 'helpers/utilities';
@@ -133,14 +132,6 @@ function OneoffContributionsPayment(props: PropTypes, context) {
         isTestUser={props.isTestUser}
         isPostDeploymentTestUser={props.isPostDeploymentTestUser}
         amount={props.amount}
-      />
-      <PayPalContributionButton
-        amount={props.amount}
-        referrerAcquisitionData={props.referrerAcquisitionData}
-        isoCountry={props.isoCountry}
-        countryGroupId={props.countryGroupId}
-        errorHandler={props.checkoutError}
-        abParticipations={props.abParticipations}
       />
     </section>
   );

--- a/assets/pages/oneoff-contributions/components/oneoffContributionsPayment.jsx
+++ b/assets/pages/oneoff-contributions/components/oneoffContributionsPayment.jsx
@@ -31,8 +31,8 @@ type PropTypes = {
   isFormEmpty: boolean,
   amount: number,
   referrerAcquisitionData: ReferrerAcquisitionData,
-  isoCountry: IsoCountry,
-  countryGroupId: CountryGroupId,
+  isoCountry: IsoCountry, // eslint-disable-line react/no-unused-prop-types
+  countryGroupId: CountryGroupId, // eslint-disable-line react/no-unused-prop-types
   checkoutError: (?string) => void,
   abParticipations: Participations,
   currency: Currency,


### PR DESCRIPTION
## Why are you doing this?

We currently can't process paypal one-off contributions, so we remove the button. 
[**Trello Card**](https://trello.com)

## Changes

* Change 1
* Change 2

## Screenshots

