### PR TITLE
Fix layout issues on small screen devices

### DIFF
--- a/assets/components/directDebit/directDebitForm/directDebitForm.scss
+++ b/assets/components/directDebit/directDebitForm/directDebitForm.scss
@@ -44,7 +44,7 @@
   border-radius: 25px;
   height: 41px;
   width: 47px;
-  @include mq($from: mobileMedium){
+  @include mq($from: mobileMedium) {
     width: 57px;
   }
   padding: 0 15px;
@@ -54,7 +54,7 @@
 .component-direct-debit-form__sort-code-separator {
   margin: 6px;
   font-size: 18px;
-  @include mq($from: mobileMedium){
+  @include mq($from: mobileMedium) {
     margin: 10px;
   }
 }
@@ -69,7 +69,7 @@
   border-radius: 25px;
   height: 40px;
   width: 266px;
-  @include mq($from: mobileMedium){
+  @include mq($from: mobileMedium) {
     width: 313px;
   }
   @include mq($from: mobileLandscape) {
@@ -144,7 +144,7 @@
   text-align: left;
   height: 54px;
   width: 300px;
-  @include mq($from: mobileMedium){
+  @include mq($from: mobileMedium) {
     width: 343px;
   }
   @include mq($from: mobileLandscape) {
@@ -185,13 +185,13 @@
 }
 
 .component-direct-debit-form__open-link {
-  background:none;
+  background: none;
   outline: none;
-  color:inherit;
-  border:none;
-  padding:0;
+  color: inherit;
+  border: none;
+  padding: 0;
   font: inherit;
-  text-decoration:underline;
+  text-decoration: underline;
   cursor: pointer;
 }
 

--- a/assets/components/directDebit/directDebitForm/directDebitForm.scss
+++ b/assets/components/directDebit/directDebitForm/directDebitForm.scss
@@ -43,14 +43,20 @@
   border: 1px solid gu-colour(garnett-neutral-1);
   border-radius: 25px;
   height: 41px;
-  width: 57px;
+  width: 47px;
+  @include mq($from: mobileMedium){
+    width: 57px;
+  }
   padding: 0 15px;
   margin-bottom: 25px;
 }
 
 .component-direct-debit-form__sort-code-separator {
-  margin: 0 10px;
+  margin: 6px;
   font-size: 18px;
+  @include mq($from: mobileMedium){
+    margin: 10px;
+  }
 }
 
 .component-direct-debit-form__text-field {
@@ -62,7 +68,10 @@
   border: 1px solid gu-colour(garnett-neutral-1);
   border-radius: 25px;
   height: 40px;
-  width: 313px;
+  width: 300px;
+  @include mq($from: mobileMedium){
+    width: 313px;
+  }
   @include mq($from: mobileLandscape) {
     width: 405px;
   }
@@ -134,7 +143,10 @@
   position: relative;
   text-align: left;
   height: 54px;
-  width: 343px;
+  width: 300px;
+  @include mq($from: mobileMedium){
+    width: 343px;
+  }
   @include mq($from: mobileLandscape) {
     width: 435px;
   }

--- a/assets/components/directDebit/directDebitForm/directDebitForm.scss
+++ b/assets/components/directDebit/directDebitForm/directDebitForm.scss
@@ -68,7 +68,7 @@
   border: 1px solid gu-colour(garnett-neutral-1);
   border-radius: 25px;
   height: 40px;
-  width: 300px;
+  width: 266px;
   @include mq($from: mobileMedium){
     width: 313px;
   }

--- a/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.jsx
+++ b/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.jsx
@@ -57,7 +57,6 @@ const DirectDebitPopUpForm = (props: PropTypes) => {
           </button>
           <DirectDebitForm callback={props.callback} />
         </div>
-        <div className="component-direct-debit-pop-up-form__background" />
       </div>
     );
   }

--- a/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.scss
+++ b/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.scss
@@ -24,14 +24,17 @@
 .component-direct-debit-pop-up-form__content {
   position: relative;
   display: inline-block;
-  top: 50%;
-  width: 345px;
+  width: 305px;
   padding: 10px;
+  @include mq($from: mobileMedium){
+    width: 345px;
+  }
   @include mq($from: mobileLandscape) {
     width: 475px;
+    top: 50%;
+    transform: translateY(-50%);
   }
   min-height: 566px;
-  transform: translateY(-50%);
   background-color: gu-colour(garnett-neutral-3);
   text-align: left;
   border-top: 1px solid gu-colour(garnett-neutral-1);
@@ -43,7 +46,10 @@
   font-weight: bolder;
   font-size: 24px;
   line-height: 30px;
-  max-width: 280px;
+  max-width: 260px;
+  @include mq($from: mobileMedium){
+    max-width: 280px;
+  }
   @include mq($from: mobileLandscape) {
     max-width: 400px;
   }
@@ -70,5 +76,5 @@
   bottom: 0;
   left: 0;
   right: 0;
-  background:transparent;
+  background:rgba(0,0,0,0.6);
 }

--- a/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.scss
+++ b/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.scss
@@ -14,6 +14,7 @@
   width: 100%;
   height: 100%;
   text-align: center;
+  background:rgba(0,0,0,0.6);
 }
 
 .focus-target:focus {
@@ -31,6 +32,8 @@
   }
   @include mq($from: mobileLandscape) {
     width: 475px;
+  }
+  @media(min-height: 732px) {
     top: 50%;
     transform: translateY(-50%);
   }
@@ -67,14 +70,4 @@
     padding-top: 3px;
     height: 19px;
   }
-}
-
-.component-direct-debit-pop-up-form__background {
-  z-index: -1;
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  background:rgba(0,0,0,0.6);
 }

--- a/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.scss
+++ b/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.scss
@@ -14,11 +14,11 @@
   width: 100%;
   height: 100%;
   text-align: center;
-  background:rgba(0,0,0,0.6);
+  background: rgba(0, 0, 0, 0.6);
 }
 
 .focus-target:focus {
-  outline:0;
+  outline: 0;
   box-shadow: 0 0 1px 2px gu-colour(garnett-neutral-2);
 }
 
@@ -27,13 +27,13 @@
   display: inline-block;
   width: 305px;
   padding: 10px;
-  @include mq($from: mobileMedium){
+  @include mq($from: mobileMedium) {
     width: 345px;
   }
   @include mq($from: mobileLandscape) {
     width: 475px;
   }
-  @media(min-height: 732px) {
+  @include mq($from: 732px, $media) {
     top: 50%;
     transform: translateY(-50%);
   }
@@ -50,7 +50,7 @@
   font-size: 24px;
   line-height: 30px;
   max-width: 260px;
-  @include mq($from: mobileMedium){
+  @include mq($from: mobileMedium) {
     max-width: 280px;
   }
   @include mq($from: mobileLandscape) {

--- a/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.scss
+++ b/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.scss
@@ -33,7 +33,7 @@
   @include mq($from: mobileLandscape) {
     width: 475px;
   }
-  @include mq($from: 732px, $media) {
+  @media(min-height: 732px) {
     top: 50%;
     transform: translateY(-50%);
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3110,7 +3110,7 @@ file-entry-cache@^2.0.0:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
 
-file-loader@^1.1.11:
+file-loader@^1.1.10:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-1.1.11.tgz#6fe886449b0f2a936e43cabaac0cdbfb369506f8"
   dependencies:
@@ -3203,9 +3203,9 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-bin@^0.68.0:
-  version "0.68.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.68.0.tgz#86c2d14857d306eb2e85e274f2eebf543564f623"
+flow-bin@^0.66.0:
+  version "0.66.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.66.0.tgz#a96dde7015dc3343fd552a7b4963c02be705ca26"
 
 flow-parser@^0.*:
   version "0.68.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3110,7 +3110,7 @@ file-entry-cache@^2.0.0:
     flat-cache "^1.2.1"
     object-assign "^4.0.1"
 
-file-loader@^1.1.10:
+file-loader@^1.1.11:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-1.1.11.tgz#6fe886449b0f2a936e43cabaac0cdbfb369506f8"
   dependencies:
@@ -3203,9 +3203,9 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-bin@^0.66.0:
-  version "0.66.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.66.0.tgz#a96dde7015dc3343fd552a7b4963c02be705ca26"
+flow-bin@^0.68.0:
+  version "0.68.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.68.0.tgz#86c2d14857d306eb2e85e274f2eebf543564f623"
 
 flow-parser@^0.*:
   version "0.68.0"


### PR DESCRIPTION
## Why are you doing this?

The current Direct Debit payment details popup doesn't scale correctly on small devices, this PR fixes it.
[**Trello Card**](https://trello.com/c/TM07aW3k/1409-fix-scrolling-on-direct-debit-details-form-for-small-screens)

## Changes

* Make the popup scrollable when the content is higher than the screen
* Adjust the width to match the smaller layout

## Screenshots

### Old layout 
![screen shot 2018-03-27 at 11 03 03](https://user-images.githubusercontent.com/181371/37960809-7dac5f5c-31ae-11e8-8c05-347adffef201.png)
### New layout 
![screen shot 2018-03-27 at 11 01 51](https://user-images.githubusercontent.com/181371/37960810-7dc752a8-31ae-11e8-8e83-27928f565030.png)


