### PR TITLE
Don't ask signed in one-off contributors for their email

### DIFF
--- a/app/controllers/OneOffContributions.scala
+++ b/app/controllers/OneOffContributions.scala
@@ -40,7 +40,7 @@ class OneOffContributions(
     )
   }
 
-  def getOneOffContributions(idUser: Option[IdUser], paypal: Option[Boolean])(implicit request: RequestHeader): Html = {
+  def formHtml(idUser: Option[IdUser], paypal: Option[Boolean])(implicit request: RequestHeader): Html = {
     oneOffContributions(
       title = "Support the Guardian | One-off Contribution",
       id = "oneoff-contributions-page",
@@ -55,14 +55,16 @@ class OneOffContributions(
   }
 
   def displayForm(paypal: Option[Boolean]): Action[AnyContent] = MaybeAuthenticatedAction.async { implicit request =>
-    request.user.fold(
-      Future.successful(Ok(getOneOffContributions(None, paypal)))
-    )(u => {
-        identityService.getUser(u).fold(
-          _ => Ok(Autofill.empty.asJson),
-          user => Ok(getOneOffContributions(Some(user), paypal))
+    request.user.fold {
+      Future.successful(Ok(formHtml(None, paypal)))
+    } { minimalUser =>
+      {
+        identityService.getUser(minimalUser).fold(
+          _ => Ok(formHtml(None, paypal)),
+          user => Ok(formHtml(Some(user), paypal))
         )
-      })
+      }
+    }
   }
 
   def thankYouPage(): Action[AnyContent] = PrivateAction { implicit request =>

--- a/app/controllers/OneOffContributions.scala
+++ b/app/controllers/OneOffContributions.scala
@@ -40,7 +40,7 @@ class OneOffContributions(
     )
   }
 
-  def formHtml(idUser: Option[IdUser], paypal: Option[Boolean])(implicit request: RequestHeader): Html = {
+  private def formHtml(idUser: Option[IdUser], paypal: Option[Boolean])(implicit request: RequestHeader) =
     oneOffContributions(
       title = "Support the Guardian | One-off Contribution",
       id = "oneoff-contributions-page",
@@ -52,7 +52,6 @@ class OneOffContributions(
       contributionsPayPalEndpoint = contributionsPayPalEndpoint,
       idUser = idUser
     )
-  }
 
   def displayForm(paypal: Option[Boolean]): Action[AnyContent] = MaybeAuthenticatedAction.async { implicit request =>
     request.user.fold {

--- a/app/views/monthlyContributions.scala.html
+++ b/app/views/monthlyContributions.scala.html
@@ -23,6 +23,7 @@
         window.guardian.uatMode = @uatMode;
         window.guardian.user = {
             id: "@user.id",
+            isSignedIn: true,
             email: "@user.primaryEmailAddress",
             @user.publicFields.displayName.map { displayName =>
             displayName: "@displayName",

--- a/app/views/monthlyContributions.scala.html
+++ b/app/views/monthlyContributions.scala.html
@@ -23,7 +23,6 @@
         window.guardian.uatMode = @uatMode;
         window.guardian.user = {
             id: "@user.id",
-            isSignedIn: true,
             email: "@user.primaryEmailAddress",
             @user.publicFields.displayName.map { displayName =>
             displayName: "@displayName",

--- a/app/views/oneOffContributions.scala.html
+++ b/app/views/oneOffContributions.scala.html
@@ -11,12 +11,27 @@
         defaultStripeConfig: StripeConfig,
         uatStripeConfig: StripeConfig,
         contributionsStripeEndpoint: String,
-        contributionsPayPalEndpoint: String
+        contributionsPayPalEndpoint: String,
+        idUser: Option[IdUser]
 )(implicit assets: AssetsResolver, request: RequestHeader)
 
 @scripts = {
     <script type="text/javascript">
         window.guardian = window.guardian || {};
+        @idUser.map { user =>
+            window.guardian.user = {
+                id: "@user.id",
+                isSignedIn: true,
+                email: "@user.primaryEmailAddress",
+                @user.publicFields.displayName.map { displayName =>
+                displayName: "@displayName",
+                }
+                @for(fields <- user.privateFields; firstName <- fields.firstName; lastName <- fields.secondName) {
+                        firstName: "@firstName",
+                        lastName: "@lastName",
+                }
+            };
+    };
         window.guardian.stripeKeyDefaultCurrencies = {
           default: "@defaultStripeConfig.forCurrency(None).publicKey",
           uat: "@uatStripeConfig.forCurrency(None).publicKey"

--- a/app/views/oneOffContributions.scala.html
+++ b/app/views/oneOffContributions.scala.html
@@ -21,7 +21,6 @@
         @idUser.map { user =>
             window.guardian.user = {
                 id: "@user.id",
-                isSignedIn: true,
                 email: "@user.primaryEmailAddress",
                 @user.publicFields.displayName.map { displayName =>
                 displayName: "@displayName",

--- a/assets/components/displayName/displayName.jsx
+++ b/assets/components/displayName/displayName.jsx
@@ -16,16 +16,17 @@ type PropTypes = {
 
 // ----- Component ----- //
 
-function DisplayName(props: PropTypes) {
-  if (props.isSignedIn) {
-    return (
-      <div className="component-display-name">
-        <SvgUser />
-        <span className="component-display-name__name">{props.name}</span>
-      </div>
-    );
+const DisplayName = (props: PropTypes) => {
+  if (!props.isSignedIn) {
+    return null;
   }
-}
+  return (
+    <div className="component-display-name">
+      <SvgUser />
+      <span className="component-display-name__name">{props.name}</span>
+    </div>
+  );
+};
 
 
 // ----- Map State/Props ----- //

--- a/assets/components/displayName/displayName.jsx
+++ b/assets/components/displayName/displayName.jsx
@@ -4,28 +4,27 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
-
 import { SvgUser } from 'components/svg/svg';
-
 
 // ---- Types ----- //
 
 type PropTypes = {
   name: string,
+  isSignedIn: boolean,
 };
 
 
 // ----- Component ----- //
 
 function DisplayName(props: PropTypes) {
-
-  return (
-    <div className="component-display-name">
-      <SvgUser />
-      <span className="component-display-name__name">{props.name}</span>
-    </div>
-  );
-
+  if (props.isSignedIn) {
+    return (
+      <div className="component-display-name">
+        <SvgUser />
+        <span className="component-display-name__name">{props.name}</span>
+      </div>
+    );
+  }
 }
 
 
@@ -35,6 +34,7 @@ function mapStateToProps(state) {
 
   return {
     name: state.page.user.displayName,
+    isSignedIn: state.page.user.isSignedIn,
   };
 
 }

--- a/assets/components/signout/signout.jsx
+++ b/assets/components/signout/signout.jsx
@@ -25,34 +25,39 @@ function buildUrl(returnUrl: ?string): string {
 
 }
 
-function Signout(props: PropTypes) {
-  if (props.isSignedIn) {
-    return (
-      <a className="component-signout" href={buildUrl(props.returnUrl)}>
-        Not you? Sign out
-      </a>
-    );
+// ----- Component ----- //
+
+const Signout = (props: PropTypes) => {
+  if (!props.isSignedIn) {
+    return null;
   }
-}
+  return (
+    <a className="component-signout" href={buildUrl(props.returnUrl)}>
+      Not you? Sign out
+    </a>
+  );
+};
+
 
 // ----- Map State/Props ----- //
 
 function mapStateToProps(state) {
 
   return {
-    email: state.page.user.email,
     isSignedIn: state.page.user.isSignedIn,
   };
 
 }
-// ----- Component ----- //
-
-export default connect(mapStateToProps)(Signout);
 
 
 // ----- Default Props ----- //
 
 Signout.defaultProps = {
   returnUrl: '',
-  email: null,
 };
+
+
+// ----- Exports ----- //
+
+export default connect(mapStateToProps)(Signout);
+

--- a/assets/components/signout/signout.jsx
+++ b/assets/components/signout/signout.jsx
@@ -3,14 +3,14 @@
 // ----- Imports ----- //
 
 import React from 'react';
-
+import { connect } from 'react-redux';
 import { getBaseDomain } from 'helpers/url';
-
 
 // ---- Types ----- //
 
 type PropTypes = {
   returnUrl?: string,
+  isSignedIn: boolean
 };
 
 
@@ -25,22 +25,34 @@ function buildUrl(returnUrl: ?string): string {
 
 }
 
+function Signout(props: PropTypes) {
+  if (props.isSignedIn) {
+    return (
+      <a className="component-signout" href={buildUrl(props.returnUrl)}>
+        Not you? Sign out
+      </a>
+    );
+  }
+}
 
-// ----- Component ----- //
+// ----- Map State/Props ----- //
 
-export default function Signout(props: PropTypes) {
+function mapStateToProps(state) {
 
-  return (
-    <a className="component-signout" href={buildUrl(props.returnUrl)}>
-      Not you? Sign out
-    </a>
-  );
+  return {
+    email: state.page.user.email,
+    isSignedIn: state.page.user.isSignedIn,
+  };
 
 }
+// ----- Component ----- //
+
+export default connect(mapStateToProps)(Signout);
 
 
 // ----- Default Props ----- //
 
 Signout.defaultProps = {
   returnUrl: '',
+  email: null,
 };

--- a/assets/helpers/user/__tests__/__snapshots__/userReducerTest.js.snap
+++ b/assets/helpers/user/__tests__/__snapshots__/userReducerTest.js.snap
@@ -8,6 +8,7 @@ Object {
   "gnmMarketing": false,
   "id": "",
   "isPostDeploymentTestUser": false,
+  "isSignedIn": false,
   "isTestUser": null,
   "lastName": "",
 }

--- a/assets/helpers/user/__tests__/userActionsTest.js
+++ b/assets/helpers/user/__tests__/userActionsTest.js
@@ -9,6 +9,7 @@ import {
   setTestUser,
   setPostDeploymentTestUser,
   setGnmMarketing,
+  setIsSignedIn,
 } from '../userActions';
 
 
@@ -93,5 +94,14 @@ describe('actions', () => {
       preference,
     };
     expect(setGnmMarketing(preference)).toEqual(expectedAction);
+  });
+
+  it('should create SET_IS_SIGNED_IN action', () => {
+    const isSignedIn: boolean = true;
+    const expectedAction = {
+      type: 'SET_IS_SIGNED_IN',
+      isSignedIn,
+    };
+    expect(setIsSignedIn(isSignedIn)).toEqual(expectedAction);
   });
 });

--- a/assets/helpers/user/user.js
+++ b/assets/helpers/user/user.js
@@ -56,12 +56,13 @@ const init = (dispatch: Function) => {
     dispatch(setFirstName(window.guardian.user.firstName));
     dispatch(setLastName(window.guardian.user.lastName));
     dispatch(setFullName(`${window.guardian.user.firstName} ${window.guardian.user.lastName}`));
-    dispatch(setIsSignedIn(window.guardian.user.isSignedIn));
+    dispatch(setIsSignedIn(true));
   } else if (userAppearsLoggedIn) {
     fetch(routes.oneOffContribAutofill, { credentials: 'include' }).then((response) => {
       if (response.ok) {
         response.json().then((data) => {
           if (data.id) {
+            dispatch(setIsSignedIn(true));
             dispatch(setId(data.id));
           }
           if (data.name) {

--- a/assets/helpers/user/user.js
+++ b/assets/helpers/user/user.js
@@ -15,6 +15,7 @@ import {
   setTestUser,
   setPostDeploymentTestUser,
   setFullName,
+  setIsSignedIn,
 } from './userActions';
 
 
@@ -55,6 +56,7 @@ const init = (dispatch: Function) => {
     dispatch(setFirstName(window.guardian.user.firstName));
     dispatch(setLastName(window.guardian.user.lastName));
     dispatch(setFullName(`${window.guardian.user.firstName} ${window.guardian.user.lastName}`));
+    dispatch(setIsSignedIn(window.guardian.user.isSignedIn));
   } else if (userAppearsLoggedIn) {
     fetch(routes.oneOffContribAutofill, { credentials: 'include' }).then((response) => {
       if (response.ok) {
@@ -67,6 +69,9 @@ const init = (dispatch: Function) => {
           }
           if (data.email) {
             dispatch(setEmail(data.email));
+          }
+          if (data.displayName) {
+            dispatch(setDisplayName(data.displayName));
           }
         });
       }

--- a/assets/helpers/user/userActions.js
+++ b/assets/helpers/user/userActions.js
@@ -14,7 +14,8 @@ export type Action =
   | { type: 'SET_STATEFIELD', stateField: string }
   | { type: 'SET_TEST_USER', testUser: boolean }
   | { type: 'SET_POST_DEPLOYMENT_TEST_USER', postDeploymentTestUser: boolean }
-  | { type: 'SET_GNM_MARKETING', preference: boolean };
+  | { type: 'SET_GNM_MARKETING', preference: boolean }
+  | { type: 'SET_IS_SIGNED_IN', isSignedIn: boolean };
 
 
 // ----- Actions Creators ----- //
@@ -37,6 +38,10 @@ export function setLastName(name: string): Action {
 
 export function setFullName(name: string): Action {
   return { type: 'SET_FULL_NAME', name };
+}
+
+export function setIsSignedIn(isSignedIn: boolean): Action {
+  return { type: 'SET_IS_SIGNED_IN', isSignedIn };
 }
 
 export function setEmail(email: string): Action {

--- a/assets/helpers/user/userReducer.js
+++ b/assets/helpers/user/userReducer.js
@@ -18,6 +18,7 @@ export type User = {
   fullName?: string,
   stateField?: string,
   gnmMarketing: boolean,
+  isSignedIn: boolean,
 };
 
 
@@ -32,6 +33,7 @@ const initialState: User = {
   isTestUser: null,
   isPostDeploymentTestUser: false,
   gnmMarketing: false,
+  isSignedIn: false,
 };
 
 
@@ -72,6 +74,9 @@ function userReducer(
 
     case 'SET_GNM_MARKETING':
       return Object.assign({}, state, { gnmMarketing: action.preference });
+
+    case 'SET_IS_SIGNED_IN':
+      return Object.assign({}, state, { isSignedIn: action.isSignedIn });
 
     default:
       return state;

--- a/assets/pages/oneoff-contributions/__tests__/__snapshots__/oneoffContributionsReducersTest.js.snap
+++ b/assets/pages/oneoff-contributions/__tests__/__snapshots__/oneoffContributionsReducersTest.js.snap
@@ -27,6 +27,7 @@ Object {
     "gnmMarketing": false,
     "id": "",
     "isPostDeploymentTestUser": false,
+    "isSignedIn": false,
     "isTestUser": null,
     "lastName": "",
   },

--- a/assets/pages/oneoff-contributions/components/emailFormField.jsx
+++ b/assets/pages/oneoff-contributions/components/emailFormField.jsx
@@ -1,0 +1,62 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+import { connect } from 'react-redux';
+import TextInput from 'components/textInput/textInput';
+
+import { setEmail } from 'helpers/user/userActions';
+
+
+// ----- Types ----- //
+
+type PropTypes = {
+  emailUpdate: (email: string) => void,
+  email: string,
+  isSignedIn: boolean,
+};
+
+
+// ----- Component ----- //
+
+function EmailFormField(props: PropTypes) {
+
+  if (!props.isSignedIn) {
+    return (<TextInput
+      id="email"
+      value={props.email}
+      placeholder="Email"
+      onChange={props.emailUpdate}
+      required
+    />);
+  }
+}
+
+
+// ----- Map State/Props ----- //
+
+function mapStateToProps(state) {
+  const { user } = state.page;
+  return {
+    email: user.email,
+    isoCountry: state.common.country,
+    isSignedIn: state.page.user.isSignedIn,
+  };
+
+}
+
+function mapDispatchToProps(dispatch) {
+
+  return {
+    emailUpdate: (email: string) => {
+      dispatch(setEmail(email));
+    },
+  };
+
+}
+
+
+// ----- Exports ----- //
+
+export default connect(mapStateToProps, mapDispatchToProps)(EmailFormField);

--- a/assets/pages/oneoff-contributions/components/emailFormField.jsx
+++ b/assets/pages/oneoff-contributions/components/emailFormField.jsx
@@ -20,18 +20,21 @@ type PropTypes = {
 
 // ----- Component ----- //
 
-function EmailFormField(props: PropTypes) {
+const EmailFormField = (props: PropTypes) => {
 
-  if (!props.isSignedIn) {
-    return (<TextInput
-      id="email"
-      value={props.email}
-      placeholder="Email"
-      onChange={props.emailUpdate}
-      required
-    />);
+  if (props.isSignedIn) {
+    return null;
   }
-}
+
+  return (<TextInput
+    id="email"
+    value={props.email}
+    placeholder="Email"
+    onChange={props.emailUpdate}
+    required
+  />);
+
+};
 
 
 // ----- Map State/Props ----- //

--- a/assets/pages/oneoff-contributions/components/formFields.jsx
+++ b/assets/pages/oneoff-contributions/components/formFields.jsx
@@ -3,77 +3,18 @@
 // ----- Imports ----- //
 
 import React from 'react';
-import { connect } from 'react-redux';
-import TextInput from 'components/textInput/textInput';
-
-import {
-  setFullName,
-  setEmail,
-} from 'helpers/user/userActions';
-
-
-// ----- Types ----- //
-
-type PropTypes = {
-  nameUpdate: (name: string) => void,
-  emailUpdate: (email: string) => void,
-  name: string,
-  email: string,
-};
+import NameFormField from './nameFormField';
+import EmailFormField from './emailFormField';
 
 
 // ----- Component ----- //
 
-function FormFields(props: PropTypes) {
-
-  return (
-    <form className="oneoff-contrib__name-form">
-      <TextInput
-        id="name"
-        placeholder="Full name"
-        value={props.name}
-        onChange={props.nameUpdate}
-        required
-      />
-      <TextInput
-        id="email"
-        placeholder="Email"
-        value={props.email}
-        onChange={props.emailUpdate}
-        required
-      />
-    </form>
-  );
-
-}
-
-
-// ----- Map State/Props ----- //
-
-function mapStateToProps(state) {
-  const { user } = state.page;
-  return {
-    name: user.fullName,
-    email: user.email,
-    isoCountry: state.common.country,
-  };
-
-}
-
-function mapDispatchToProps(dispatch) {
-
-  return {
-    nameUpdate: (name: string) => {
-      dispatch(setFullName(name));
-    },
-    emailUpdate: (email: string) => {
-      dispatch(setEmail(email));
-    },
-  };
-
-}
-
+const FormFields = () => (
+  <form className="oneoff-contrib__name-form">
+    <NameFormField />
+    <EmailFormField />
+  </form>);
 
 // ----- Exports ----- //
 
-export default connect(mapStateToProps, mapDispatchToProps)(FormFields);
+export default FormFields;

--- a/assets/pages/oneoff-contributions/components/nameFormField.jsx
+++ b/assets/pages/oneoff-contributions/components/nameFormField.jsx
@@ -1,0 +1,60 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+import { connect } from 'react-redux';
+import TextInput from 'components/textInput/textInput';
+
+import { setFullName } from 'helpers/user/userActions';
+
+
+// ----- Types ----- //
+
+type PropTypes = {
+  nameUpdate: (name: string) => void,
+  name: string,
+};
+
+
+// ----- Component ----- //
+
+function NameFormField(props: PropTypes) {
+
+  return (
+    <TextInput
+      id="name"
+      placeholder="Full name"
+      value={props.name}
+      onChange={props.nameUpdate}
+      required
+    />);
+}
+
+
+// ----- Map State/Props ----- //
+
+function mapStateToProps(state) {
+  const { user } = state.page;
+  return {
+    name: user.fullName,
+    isoCountry: state.common.country,
+    isSignedIn: state.page.user.isSignedIn,
+  };
+
+}
+
+function mapDispatchToProps(dispatch) {
+
+  return {
+    nameUpdate: (name: string) => {
+      dispatch(setFullName(name));
+    },
+  };
+
+}
+
+
+// ----- Exports ----- //
+
+export default connect(mapStateToProps, mapDispatchToProps)(NameFormField);

--- a/assets/pages/oneoff-contributions/components/nameFormField.jsx
+++ b/assets/pages/oneoff-contributions/components/nameFormField.jsx
@@ -19,17 +19,14 @@ type PropTypes = {
 
 // ----- Component ----- //
 
-function NameFormField(props: PropTypes) {
-
-  return (
-    <TextInput
-      id="name"
-      placeholder="Full name"
-      value={props.name}
-      onChange={props.nameUpdate}
-      required
-    />);
-}
+const NameFormField = (props: PropTypes) =>
+  (<TextInput
+    id="name"
+    placeholder="Full name"
+    value={props.name}
+    onChange={props.nameUpdate}
+    required
+  />);
 
 
 // ----- Map State/Props ----- //

--- a/assets/pages/oneoff-contributions/oneoffContributions.jsx
+++ b/assets/pages/oneoff-contributions/oneoffContributions.jsx
@@ -15,6 +15,8 @@ import TermsPrivacy from 'components/legal/termsPrivacy/termsPrivacy';
 import TestUserBanner from 'components/testUserBanner/testUserBanner';
 import PaymentAmount from 'components/paymentAmount/paymentAmount';
 import ContribLegal from 'components/legal/contribLegal/contribLegal';
+import DisplayName from 'components/displayName/displayName';
+import Signout from 'components/signout/signout';
 
 import { detect as detectCountryGroup } from 'helpers/internationalisation/countryGroup';
 import { detect as detectCountry } from 'helpers/internationalisation/country';
@@ -76,7 +78,8 @@ const content = (
             currency={state.page.oneoffContrib.currency}
           />
         </InfoSection>
-        <InfoSection heading="Your details" className="oneoff-contrib__your-details">
+        <InfoSection heading="Your details" headingContent={<Signout />} className="oneoff-contrib__your-details">
+          <DisplayName />
           <FormFields />
         </InfoSection>
         <InfoSection heading="Payment methods" className="oneoff-contrib__payment-methods">

--- a/assets/pages/regular-contributions/__tests__/__snapshots__/regularContributionsReducersTest.js.snap
+++ b/assets/pages/regular-contributions/__tests__/__snapshots__/regularContributionsReducersTest.js.snap
@@ -41,6 +41,7 @@ Object {
     "gnmMarketing": false,
     "id": "",
     "isPostDeploymentTestUser": false,
+    "isSignedIn": false,
     "isTestUser": null,
     "lastName": "",
   },


### PR DESCRIPTION
## Why are you doing this?
We already have an email address for signed in users, and now that we are using identity accounts to link users to their contribution, we don't want users to supply a different email address if they are signed in. 

As part of this PR, I have added a `isSignedIn` property to the user state object. The reason for it is that the user state object gets populated via different sources, either from identity or from form fields. Therefore it makes using the existence of the user state object as a proxy for being signed in useless, which is problematic here where we want to hide the email field if a user is signed in. 

[NOTE: I have not yet made the tests pass]
@guardian/contributions 


Signed in users:
![screenshot at mar 27 11-56-50](https://user-images.githubusercontent.com/2844554/37963475-48e2dfaa-31b6-11e8-9da7-4aa1932c867e.png)

Non signed in users:
![screenshot at mar 27 11-57-13](https://user-images.githubusercontent.com/2844554/37963476-48f6f4e0-31b6-11e8-9aeb-5e2c488db500.png)

