### PR TITLE
Adding payment api endpoint

### DIFF
--- a/app/controllers/PayPalNvp.scala
+++ b/app/controllers/PayPalNvp.scala
@@ -12,8 +12,8 @@ import play.api.libs.circe.Circe
 import play.api.mvc._
 import services.paypal.PayPalBillingDetails.codec
 import services.paypal.{PayPalBillingDetails, PayPalServiceProvider, Token}
-import services.{ContributionsFrontendService, PayPalService, TestUserService}
-import services.ContributionsFrontendService.Email
+import services.{PaymentAPIService, PayPalService, TestUserService}
+import services.PaymentAPIService.Email
 import scala.concurrent.ExecutionContext
 
 class PayPalNvp(

--- a/app/controllers/PayPalRest.scala
+++ b/app/controllers/PayPalRest.scala
@@ -12,8 +12,8 @@ import play.api.libs.circe.Circe
 import play.api.mvc._
 import services.paypal.PayPalBillingDetails.codec
 import services.paypal.{PayPalBillingDetails, PayPalServiceProvider, Token}
-import services.{ContributionsFrontendService, PayPalService, TestUserService}
-import services.ContributionsFrontendService.Email
+import services.{PaymentAPIService, PayPalService, TestUserService}
+import services.PaymentAPIService.Email
 import scala.concurrent.ExecutionContext
 
 class PayPalRest(
@@ -22,7 +22,7 @@ class PayPalRest(
   payPalServiceProvider: PayPalServiceProvider,
   testUsers: TestUserService,
   components: ControllerComponents,
-  contributionsFrontendService: ContributionsFrontendService
+  PaymentAPIService: PaymentAPIService
 )(implicit val ec: ExecutionContext) extends AbstractController(components) with Circe {
 
   import actionBuilders._
@@ -38,7 +38,7 @@ class PayPalRest(
   }
 
   def execute(): Action[AnyContent] = PrivateAction.async { implicit request =>
-    contributionsFrontendService.execute(request).fold(
+    PaymentAPIService.execute(request).fold(
       e => {
         SafeLogger.error(scrub"Error making paypal payment", e)
         Ok(views.html.react("Support the Guardian | PayPal Error", "paypal-error-page", "payPalErrorPage.js"))

--- a/app/controllers/PayPalRest.scala
+++ b/app/controllers/PayPalRest.scala
@@ -1,0 +1,49 @@
+
+package controllers
+
+import actions.CustomActionBuilders
+import assets.AssetsResolver
+import com.gu.identity.play.AuthenticatedIdUser
+import io.circe.syntax._
+import cats.implicits._
+import monitoring.SafeLogger._
+import monitoring.SafeLogger
+import play.api.libs.circe.Circe
+import play.api.mvc._
+import services.paypal.PayPalBillingDetails.codec
+import services.paypal.{PayPalBillingDetails, PayPalServiceProvider, Token}
+import services.{ContributionsFrontendService, PayPalService, TestUserService}
+import services.ContributionsFrontendService.Email
+import scala.concurrent.ExecutionContext
+
+class PayPalRest(
+  actionBuilders: CustomActionBuilders,
+  assets: AssetsResolver,
+  payPalServiceProvider: PayPalServiceProvider,
+  testUsers: TestUserService,
+  components: ControllerComponents,
+  contributionsFrontendService: ContributionsFrontendService
+)(implicit val ec: ExecutionContext) extends AbstractController(components) with Circe {
+
+  import actionBuilders._
+
+  implicit val assetsResolver = assets
+
+  def resultFromEmailOption(email: Option[Email]): Result = {
+    val redirect = Redirect("/contribute/one-off/thankyou")
+    email.fold(redirect)(e => {
+      SafeLogger.info("Redirecting to thank you page with email in flash session")
+      redirect.flashing("email" -> e.value)
+    })
+  }
+
+  def execute(): Action[AnyContent] = PrivateAction.async { implicit request =>
+    contributionsFrontendService.execute(request).fold(
+      e => {
+        SafeLogger.error(scrub"Error making paypal payment", e)
+        Ok(views.html.react("Support the Guardian | PayPal Error", "paypal-error-page", "payPalErrorPage.js"))
+      },
+      resultFromEmailOption
+    )
+  }
+}

--- a/app/services/PaymentAPIService.scala
+++ b/app/services/PaymentAPIService.scala
@@ -8,7 +8,7 @@ import play.api.mvc._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-object ContributionsFrontendService {
+object PaymentAPIService {
   case class Email(value: String)
   object Email {
     def fromResponse(resp: WSResponse): Either[Throwable, Option[Email]] = {
@@ -21,8 +21,8 @@ object ContributionsFrontendService {
   }
 }
 
-class ContributionsFrontendService(wsClient: WSClient, contributionsFrontendUrl: String) {
-  import ContributionsFrontendService._
+class PaymentAPIService(wsClient: WSClient, paymentAPIUrl: String) {
+  import PaymentAPIService._
 
   def convertQueryString(queryString: Map[String, Seq[String]]): List[(String, String)] = {
     queryString.foldLeft(List.empty[(String, String)]) {
@@ -38,7 +38,7 @@ class ContributionsFrontendService(wsClient: WSClient, contributionsFrontendUrl:
       DefaultWSCookie(c.name, c.value, c.domain, Some(c.path), c.maxAge.map(_.toLong), c.secure, c.httpOnly)
     }
     val endpoint = "/paypal/uk/execute"
-    wsClient.url(s"$contributionsFrontendUrl/$endpoint")
+    wsClient.url(s"$paymentAPIUrl/$endpoint")
       .withQueryStringParameters(convertQueryString(request.queryString): _*)
       .withHttpHeaders("Accept" -> "application/json")
       .withCookies(wcCookies: _*)

--- a/app/wiring/Controllers.scala
+++ b/app/wiring/Controllers.scala
@@ -29,7 +29,15 @@ trait Controllers {
     controllerComponents
   )
 
-  lazy val payPalController = new PayPal(
+  lazy val payPalNvpController = new PayPalNvp(
+    actionRefiners,
+    assetsResolver,
+    payPalServiceProvider,
+    testUsers,
+    controllerComponents
+  )
+
+  lazy val payPalRestController = new PayPalRest(
     actionRefiners,
     assetsResolver,
     payPalServiceProvider,

--- a/app/wiring/Services.scala
+++ b/app/wiring/Services.scala
@@ -34,5 +34,5 @@ trait Services {
 
   lazy val authenticationService = AuthenticationService(appConfig.identity.keys).authenticatedIdUserProvider
 
-  lazy val contributionsFrontendService = new ContributionsFrontendService(wsClient, appConfig.contributionsFrontendUrl)
+  lazy val contributionsFrontendService = new PaymentAPIService(wsClient, appConfig.contributionsFrontendUrl)
 }

--- a/conf/routes
+++ b/conf/routes
@@ -64,11 +64,14 @@ GET  /test-users                                    controllers.TestUsersManagem
 
 # ----- PayPal (NVP Endpoints) ----- #
 
-POST /paypal/setup-payment                          controllers.PayPal.setupPayment
-POST /paypal/create-agreement                       controllers.PayPal.createAgreement
-GET  /paypal/return                                 controllers.PayPal.returnUrl
-GET  /paypal/cancel                                 controllers.PayPal.cancelUrl
-GET  /paypal/execute                                controllers.PayPal.execute
+POST /paypal/setup-payment                          controllers.PayPalNvp.setupPayment
+POST /paypal/create-agreement                       controllers.PayPalNvp.createAgreement
+GET  /paypal/return                                 controllers.PayPalNvp.returnUrl
+GET  /paypal/cancel                                 controllers.PayPalNvp.cancelUrl
+
+# ----- PayPal (REST Endpoints) ----- #
+
+GET  /paypal/execute                                controllers.PayPalRest.execute
 
 # ----- Direct Debit ----- #
 


### PR DESCRIPTION
## [Do Not Review] Why are you doing this?

Start using the payment API for paypal.

[**Trello Card**](https://trello.com)

## Changes

* Split up the PayPal controller into two controllers, one for Nvp and one for Rest.
* Replaced contributions Contributions Service with Payment API service.
* 

## Screenshots

