### PR TITLE
Removed NZ from country switcher.

### DIFF
--- a/assets/pages/contributions-landing/containers/countrySwitcherHeaderContainer.js
+++ b/assets/pages/contributions-landing/containers/countrySwitcherHeaderContainer.js
@@ -13,7 +13,7 @@ import type { State } from '../contributionsLandingReducer';
 // ----- Setup ----- //
 
 const availableCountriesGroups: CountryGroupId[] =
-  ['GBPCountries', 'UnitedStates', 'EURCountries', 'International', 'NZDCountries'];
+  ['GBPCountries', 'UnitedStates', 'EURCountries', 'International'];
 
 
 // ----- Functions ----- //
@@ -34,9 +34,6 @@ function handleCountryGroupChange(value: string): void {
       break;
     case 'International':
       window.location.pathname = '/int/contribute';
-      break;
-    case 'NZDCountries':
-      window.location.pathname = '/nz/contribute';
       break;
     default:
   }


### PR DESCRIPTION
## Why are you doing this?

We don't want to drive traffic to NZ page yet. Therefore we remove it from the country switcher.
[**Trello Card**](https://trello.com)

## Changes

* Removed from landing country-switcher

## Screenshots

### Before
<img width="1233" alt="picture 671" src="https://user-images.githubusercontent.com/825398/38026713-16e03578-3285-11e8-8b15-540b6b96eee1.png">


### After
<img width="1232" alt="picture 670" src="https://user-images.githubusercontent.com/825398/38026693-064e6b76-3285-11e8-8d8b-aee55cf4f25b.png">
