### PR TITLE
Dropdown for GBP countries

### DIFF
--- a/assets/helpers/internationalisation/country.js
+++ b/assets/helpers/internationalisation/country.js
@@ -394,21 +394,21 @@ function setCountry(country: IsoCountry) {
   cookie.set('GU_country', country, 7);
 }
 
-type TargetCountries = 'International' | 'EURCountries' | 'NZDCountries' | 'GBPCountries';
+type TargetCountryGroups = 'International' | 'EURCountries' | 'NZDCountries' | 'GBPCountries';
 
 function handleCountryForCountryGroup(
-  targetCountryGroup: TargetCountries,
+  targetCountryGroup: TargetCountryGroups,
   countryGroupId: ?CountryGroupId = null,
 ): ?IsoCountry {
 
-  const paths: {[TargetCountries]: string[]} = {
+  const paths: {[TargetCountryGroups]: string[]} = {
     International: ['/int', '/int/'],
     EURCountries: ['/eu', '/eu/'],
     NZDCountries: ['/nz', '/nz/'],
     GBPCountries: ['/uk', '/uk/'],
   };
 
-  const defaultCountry: {[TargetCountries]: IsoCountry} = {
+  const defaultCountry: {[TargetCountryGroups]: IsoCountry} = {
     International: 'IN',
     EURCountries: 'DE',
     NZDCountries: 'NZ',
@@ -436,7 +436,7 @@ function handleCountryForCountryGroup(
 
 function detect(countryGroupId: ?CountryGroupId = null): IsoCountry {
 
-  const targetCountryGroups: TargetCountries[] = ['International', 'EURCountries', 'NZDCountries', 'GBPCountries'];
+  const targetCountryGroups: TargetCountryGroups[] = ['International', 'EURCountries', 'NZDCountries', 'GBPCountries'];
   let country = null;
 
   targetCountryGroups.forEach((targetCountryGroupId) => {

--- a/assets/helpers/internationalisation/country.js
+++ b/assets/helpers/internationalisation/country.js
@@ -348,6 +348,8 @@ function fromString(s: string): ?IsoCountry {
 
 function fromCountryGroup(countryGroupId: ?CountryGroupId = null): ?IsoCountry {
   switch (countryGroupId) {
+    case 'AUDCountries':
+      return 'AU';
     case 'UnitedStates':
       return 'US';
     default: return null;
@@ -357,6 +359,8 @@ function fromCountryGroup(countryGroupId: ?CountryGroupId = null): ?IsoCountry {
 function fromPath(path: string = window.location.pathname): ?IsoCountry {
   if (path === '/us' || path.startsWith('/us/')) {
     return 'US';
+  } else if (path === '/au' || path.startsWith('/au/')) {
+    return 'AU';
   }
 
   return null;
@@ -391,7 +395,7 @@ function setCountry(country: IsoCountry) {
 }
 
 function handleCountryForCountryGroup(
-  targetCountryGroup: 'International' | 'EURCountries' | 'NZDCountries' | 'GBPCountries' | 'AUDCountries',
+  targetCountryGroup: 'International' | 'EURCountries' | 'NZDCountries' | 'GBPCountries',
   countryGroupId: ?CountryGroupId = null,
 ): ?IsoCountry {
 
@@ -400,7 +404,6 @@ function handleCountryForCountryGroup(
     EURCountries: ['/eu', '/eu/'],
     NZDCountries: ['/nz', '/nz/'],
     GBPCountries: ['/uk', '/uk/'],
-    AUDCountries: ['/au', '/au/'],
   };
 
   const defaultCountry = {
@@ -408,7 +411,6 @@ function handleCountryForCountryGroup(
     EURCountries: 'DE',
     NZDCountries: 'NZ',
     GBPCountries: 'GB',
-    AUDCountries: 'AU',
   };
 
   const path = window.location.pathname;
@@ -432,7 +434,7 @@ function handleCountryForCountryGroup(
 
 function detect(countryGroupId: ?CountryGroupId = null): IsoCountry {
 
-  const targetCountryGroups = ['International', 'EURCountries', 'NZDCountries', 'GBPCountries', 'AUDCountries'];
+  const targetCountryGroups = ['International', 'EURCountries', 'NZDCountries', 'GBPCountries'];
   let country = null;
 
   targetCountryGroups.forEach((targetCountryGroupId) => {

--- a/assets/helpers/internationalisation/country.js
+++ b/assets/helpers/internationalisation/country.js
@@ -394,19 +394,21 @@ function setCountry(country: IsoCountry) {
   cookie.set('GU_country', country, 7);
 }
 
+type TargetCountries = 'International' | 'EURCountries' | 'NZDCountries' | 'GBPCountries';
+
 function handleCountryForCountryGroup(
-  targetCountryGroup: 'International' | 'EURCountries' | 'NZDCountries' | 'GBPCountries',
+  targetCountryGroup: TargetCountries,
   countryGroupId: ?CountryGroupId = null,
 ): ?IsoCountry {
 
-  const paths = {
+  const paths: {[TargetCountries]: string[]} = {
     International: ['/int', '/int/'],
     EURCountries: ['/eu', '/eu/'],
     NZDCountries: ['/nz', '/nz/'],
     GBPCountries: ['/uk', '/uk/'],
   };
 
-  const defaultCountry = {
+  const defaultCountry: {[TargetCountries]: IsoCountry} = {
     International: 'IN',
     EURCountries: 'DE',
     NZDCountries: 'NZ',
@@ -434,7 +436,7 @@ function handleCountryForCountryGroup(
 
 function detect(countryGroupId: ?CountryGroupId = null): IsoCountry {
 
-  const targetCountryGroups = ['International', 'EURCountries', 'NZDCountries', 'GBPCountries'];
+  const targetCountryGroups: TargetCountries[] = ['International', 'EURCountries', 'NZDCountries', 'GBPCountries'];
   let country = null;
 
   targetCountryGroups.forEach((targetCountryGroupId) => {

--- a/assets/helpers/internationalisation/country.js
+++ b/assets/helpers/internationalisation/country.js
@@ -421,8 +421,7 @@ function handleCountryForCountryGroup(
     return null;
   }
 
-  const candidateCountry: ?IsoCountry =
-    fromQueryParameter() || fromCookie() || fromGeolocation() || fromPath();
+  const candidateCountry: ?IsoCountry = fromQueryParameter() || fromCookie() || fromGeolocation();
 
   if (candidateCountry && countryGroups[targetCountryGroup].countries.includes(candidateCountry)) {
     return candidateCountry;

--- a/assets/helpers/internationalisation/country.js
+++ b/assets/helpers/internationalisation/country.js
@@ -348,8 +348,6 @@ function fromString(s: string): ?IsoCountry {
 
 function fromCountryGroup(countryGroupId: ?CountryGroupId = null): ?IsoCountry {
   switch (countryGroupId) {
-    case 'AUDCountries':
-      return 'AU';
     case 'UnitedStates':
       return 'US';
     default: return null;
@@ -359,9 +357,8 @@ function fromCountryGroup(countryGroupId: ?CountryGroupId = null): ?IsoCountry {
 function fromPath(path: string = window.location.pathname): ?IsoCountry {
   if (path === '/us' || path.startsWith('/us/')) {
     return 'US';
-  } else if (path === '/au' || path.startsWith('/au/')) {
-    return 'AU';
   }
+
   return null;
 }
 
@@ -394,7 +391,7 @@ function setCountry(country: IsoCountry) {
 }
 
 function handleCountryForCountryGroup(
-  targetCountryGroup: 'International' | 'EURCountries' | 'NZDCountries' | 'GBPCountries',
+  targetCountryGroup: 'International' | 'EURCountries' | 'NZDCountries' | 'GBPCountries' | 'AUDCountries',
   countryGroupId: ?CountryGroupId = null,
 ): ?IsoCountry {
 
@@ -403,6 +400,7 @@ function handleCountryForCountryGroup(
     EURCountries: ['/eu', '/eu/'],
     NZDCountries: ['/nz', '/nz/'],
     GBPCountries: ['/uk', '/uk/'],
+    AUDCountries: ['/au', '/au/'],
   };
 
   const defaultCountry = {
@@ -410,6 +408,7 @@ function handleCountryForCountryGroup(
     EURCountries: 'DE',
     NZDCountries: 'NZ',
     GBPCountries: 'GB',
+    AUDCountries: 'AU',
   };
 
   const path = window.location.pathname;
@@ -434,7 +433,7 @@ function handleCountryForCountryGroup(
 
 function detect(countryGroupId: ?CountryGroupId = null): IsoCountry {
 
-  const targetCountryGroups = ['International', 'EURCountries', 'NZDCountries', 'GBPCountries'];
+  const targetCountryGroups = ['International', 'EURCountries', 'NZDCountries', 'GBPCountries', 'AUDCountries'];
   let country = null;
 
   targetCountryGroups.forEach((targetCountryGroupId) => {

--- a/assets/pages/regular-contributions/components/formFields.jsx
+++ b/assets/pages/regular-contributions/components/formFields.jsx
@@ -94,7 +94,9 @@ function countriesDropdown(
   country: IsoCountry,
 ) {
 
-  if (countryGroup !== 'EURCountries' && countryGroup !== 'International' && countryGroup !== 'NZDCountries') {
+  const askForCountryCountryGroups = ['EURCountries', 'International', 'NZDCountries', 'GBPCountries', 'AUDCountries'];
+
+  if (!askForCountryCountryGroups.includes(countryGroup)) {
     return null;
   }
 

--- a/assets/pages/regular-contributions/components/formFields.jsx
+++ b/assets/pages/regular-contributions/components/formFields.jsx
@@ -94,7 +94,7 @@ function countriesDropdown(
   country: IsoCountry,
 ) {
 
-  const askForCountryCountryGroups = ['EURCountries', 'International', 'NZDCountries', 'GBPCountries', 'AUDCountries'];
+  const askForCountryCountryGroups = ['EURCountries', 'International', 'NZDCountries', 'GBPCountries'];
 
   if (!askForCountryCountryGroups.includes(countryGroup)) {
     return null;


### PR DESCRIPTION
## Why are you doing this?

In guardian/support-internationalization the United Kingdom (a.k.a. `GBPCountries`) and Australia (a.k.a. `AUDCountries`) are two country groups containing more countries. Additionally, Zuora requires us to set up the country from which the user is making the transaction from. Since we are basing the logic for redirects in country groups, we need to bubble up this decision to the end user as we do in Europe and ROW cases.

Bear in mind the current logic will default the country via geoLocalization and if it can't be done it will set up the top contribution country for each country group. Therefore, the user should not interact with this component.

[**Trello Card**](https://trello.com)

## Changes

* Small refactor in the country.js helper.
* Adding country dropdown to `GBPCountries` and `AUDCountries` checkout pages.

## Screenshots
### GBPCountries

<img width="935" alt="picture 673" src="https://user-images.githubusercontent.com/825398/38247198-3c076798-373c-11e8-9627-c284c12cbff5.png">


