### PR TITLE
Add query parameter to the acquisition tracking

### DIFF
--- a/assets/components/trackedComponent/trackedComponent.jsx
+++ b/assets/components/trackedComponent/trackedComponent.jsx
@@ -41,6 +41,7 @@ class TrackedComponent extends React.Component<Props> {
       source: 'GUARDIAN_WEB',
       abTest: undefined,
       abTests: undefined,
+      queryParameters: undefined,
     };
 
     const childrenWithProps = React.Children.map(

--- a/assets/helpers/page/page.js
+++ b/assets/helpers/page/page.js
@@ -20,7 +20,7 @@ import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { Currency } from 'helpers/internationalisation/currency';
 import type { Participations } from 'helpers/abTests/abtest';
 
-import { getQueryParams } from 'helpers/url';
+import { getAllQueryParamsWithExclusions } from 'helpers/url';
 import type { Action } from './pageActions';
 
 
@@ -71,8 +71,8 @@ function buildInitialState(
   currency: Currency,
 ): CommonState {
   const acquisition = getAcquisition(abParticipations);
-  // note: getQueryParams takes a list of parameters to exclude
-  const otherQueryParams = getQueryParams(['REFPVID', 'INTCMP', 'acquisitionData']);
+  const excludedParameters = ['REFPVID', 'INTCMP', 'acquisitionData'];
+  const otherQueryParams = getAllQueryParamsWithExclusions(excludedParameters);
 
   return Object.assign({}, {
     campaign: acquisition ? getCampaign(acquisition) : null,

--- a/assets/helpers/url.js
+++ b/assets/helpers/url.js
@@ -34,7 +34,7 @@ const getQueryParameter = (paramName: string, defaultValue?: string): ?string =>
 
 };
 
-const getQueryParams = (excluded: string[]): Array<[string, string]> => Array
+const getAllQueryParamsWithExclusions = (excluded: string[]): Array<[string, string]> => Array
   .from(new URL(window.location).searchParams.entries())
   .filter(p => excluded.indexOf(p[0]) === -1);
 
@@ -97,7 +97,7 @@ function getBaseDomain(): Domain {
 
 export {
   getQueryParameter,
-  getQueryParams,
+  getAllQueryParamsWithExclusions,
   addQueryParamToURL,
   getBaseDomain,
   addQueryParamsToURL,

--- a/assets/pages/oneoff-contributions/helpers/ajax.js
+++ b/assets/pages/oneoff-contributions/helpers/ajax.js
@@ -82,6 +82,7 @@ function requestData(
       nativeAbTests: participationsToAcquisitionABTest(abParticipations),
       refererAbTest: referrerAcquisitionData.abTest,
       isSupport: true,
+      queryParameters: referrerAcquisitionData.queryParameters,
     };
 
     return {

--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-sts" % awsVersion,
   "org.typelevel" %% "cats" % "0.9.0",
   "com.dripower" %% "play-circe" % "2608.5",
-  "com.gu" %% "support-models" % "0.23",
+  "com.gu" %% "support-models" % "0.25",
   "com.gu" %% "support-config" % "0.16",
   "com.gu" %% "fezziwig" % "0.7",
   "com.typesafe.akka" %% "akka-agent" % "2.5.6",


### PR DESCRIPTION
## Why are you doing this?
We want to track any query parameters associated with an acquisition so that we can track off platform properly. This PR adds the query parameters to acquisition model, and once it is merged, 
we will be sending query parameters from the client to the various backend routes. 


@guardian/contributions 