### PR TITLE
Tests can deal with new version of Paypal payment sign-in windows

### DIFF
--- a/test/selenium/OneOffContributionsSpec.scala
+++ b/test/selenium/OneOffContributionsSpec.scala
@@ -39,7 +39,6 @@ class OneOffContributionsSpec extends FeatureSpec with GivenWhenThen with Before
       landingPage.clickContributePayPalButton
 
       Then("they should be redirected to PayPal Checkout")
-      payPalCheckout.switchToPayPalPage()
       assert(payPalCheckout.hasLoaded)
 
       Given("that the user fills in their PayPal credentials correctly")

--- a/test/selenium/RecurringContributionsSpec.scala
+++ b/test/selenium/RecurringContributionsSpec.scala
@@ -101,6 +101,7 @@ class RecurringContributionsSpec extends FeatureSpec with GivenWhenThen with Bef
       recurringContributionForm.selectPayPalPayment
 
       Then("the PayPal Express Checkout mini-browser should display")
+      payPalCheckout.switchToPayPalPopUp()
       assert(payPalCheckout.hasLoaded)
 
       Given("that the user fills in their PayPal credentials correctly")

--- a/test/selenium/RecurringContributionsSpec.scala
+++ b/test/selenium/RecurringContributionsSpec.scala
@@ -30,10 +30,7 @@ class RecurringContributionsSpec extends FeatureSpec with GivenWhenThen with Bef
       val testUser = new TestUser(driverConfig)
       goTo(landingPage)
       assert(landingPage.pageHasLoaded)
-
-      Then("test code remove this later")
-      assert(landingPage.pageHasLoaded)
-
+      
       When("they select to contribute the default amount")
       landingPage.clickContribute
 
@@ -101,7 +98,7 @@ class RecurringContributionsSpec extends FeatureSpec with GivenWhenThen with Bef
       recurringContributionForm.selectPayPalPayment
 
       Then("the PayPal Express Checkout mini-browser should display")
-      payPalCheckout.switchToPayPalPopUp()
+      payPalCheckout.switchToPayPalPopUp
       assert(payPalCheckout.hasLoaded)
 
       Given("that the user fills in their PayPal credentials correctly")

--- a/test/selenium/RecurringContributionsSpec.scala
+++ b/test/selenium/RecurringContributionsSpec.scala
@@ -31,6 +31,9 @@ class RecurringContributionsSpec extends FeatureSpec with GivenWhenThen with Bef
       goTo(landingPage)
       assert(landingPage.pageHasLoaded)
 
+      Then("test code remove this later")
+      assert(landingPage.pageHasLoaded)
+
       When("they select to contribute the default amount")
       landingPage.clickContribute
 
@@ -98,7 +101,6 @@ class RecurringContributionsSpec extends FeatureSpec with GivenWhenThen with Bef
       recurringContributionForm.selectPayPalPayment
 
       Then("the PayPal Express Checkout mini-browser should display")
-      payPalCheckout.switchToPayPalPopUp
       assert(payPalCheckout.hasLoaded)
 
       Given("that the user fills in their PayPal credentials correctly")

--- a/test/selenium/RecurringContributionsSpec.scala
+++ b/test/selenium/RecurringContributionsSpec.scala
@@ -30,7 +30,7 @@ class RecurringContributionsSpec extends FeatureSpec with GivenWhenThen with Bef
       val testUser = new TestUser(driverConfig)
       goTo(landingPage)
       assert(landingPage.pageHasLoaded)
-      
+
       When("they select to contribute the default amount")
       landingPage.clickContribute
 

--- a/test/selenium/util/PayPalCheckout.scala
+++ b/test/selenium/util/PayPalCheckout.scala
@@ -9,6 +9,7 @@ class PayPalCheckout(implicit val webDriver: WebDriver) extends Browser {
   val container = name("injectedUl")
   val loginButton = name("btnLogin")
   val nextButton = name("btnNext")
+  val emailField = id("login_emaildiv")
   val emailInput = name("login_email")
   val passwordInput = name("login_password")
   val agreeAndPay = id("confirmButtonTop")
@@ -16,10 +17,10 @@ class PayPalCheckout(implicit val webDriver: WebDriver) extends Browser {
 
   def fillIn(): Unit = {
     setValueSlowly(emailInput, Config.paypalBuyerEmail)
-    if(pageHasElement(nextButton)) {
+    if (pageHasElement(nextButton)) {
       clickNext()
     }
-    if(pageHasElement(loginButton)) {
+    if (pageHasElement(loginButton)) {
       setValueSlowly(passwordInput, Config.paypalBuyerPassword)
     }
   }
@@ -34,7 +35,9 @@ class PayPalCheckout(implicit val webDriver: WebDriver) extends Browser {
 
   def payPalSummaryHasCorrectDetails(expectedCurrencyAndAmount: String): Boolean = elementHasText(paymentAmount, expectedCurrencyAndAmount)
 
-  def hasLoaded: Boolean = pageHasElement(loginButton) || pageHasElement(nextButton)
+  def hasLoaded: Boolean = {
+    pageHasElement(emailField)
+  }
 
   def switchToPayPalPage(): Unit = {
     switchFrame(container)

--- a/test/selenium/util/PayPalCheckout.scala
+++ b/test/selenium/util/PayPalCheckout.scala
@@ -49,7 +49,6 @@ class PayPalCheckout(implicit val webDriver: WebDriver) extends Browser {
 
   def switchToPayPalPopUp(): Unit = {
     switchWindow
-    switchFrame(container)
   }
 
   def acceptPayPalPaymentPopUp(): Unit = {

--- a/test/selenium/util/PayPalCheckout.scala
+++ b/test/selenium/util/PayPalCheckout.scala
@@ -9,7 +9,6 @@ class PayPalCheckout(implicit val webDriver: WebDriver) extends Browser {
   val container = name("injectedUl")
   val loginButton = name("btnLogin")
   val nextButton = name("btnNext")
-  val emailField = id("login_emaildiv")
   val emailInput = name("login_email")
   val passwordInput = name("login_password")
   val agreeAndPay = id("confirmButtonTop")
@@ -36,7 +35,7 @@ class PayPalCheckout(implicit val webDriver: WebDriver) extends Browser {
   def payPalSummaryHasCorrectDetails(expectedCurrencyAndAmount: String): Boolean = elementHasText(paymentAmount, expectedCurrencyAndAmount)
 
   def hasLoaded: Boolean = {
-    pageHasElement(emailField)
+    pageHasElement(emailInput)
   }
 
   def switchToPayPalPage(): Unit = {

--- a/test/selenium/util/PayPalCheckout.scala
+++ b/test/selenium/util/PayPalCheckout.scala
@@ -1,12 +1,14 @@
 package selenium.util
 
 import org.openqa.selenium.WebDriver
+import play.api.test.FutureAwaits
 
 // Handles interaction with the PayPal Express Checkout overlay.
 class PayPalCheckout(implicit val webDriver: WebDriver) extends Browser {
 
   val container = name("injectedUl")
   val loginButton = name("btnLogin")
+  val nextButton = name("btnNext")
   val emailInput = name("login_email")
   val passwordInput = name("login_password")
   val agreeAndPay = id("confirmButtonTop")
@@ -14,8 +16,15 @@ class PayPalCheckout(implicit val webDriver: WebDriver) extends Browser {
 
   def fillIn(): Unit = {
     setValueSlowly(emailInput, Config.paypalBuyerEmail)
-    setValueSlowly(passwordInput, Config.paypalBuyerPassword)
+    if(pageHasElement(nextButton)) {
+      clickNext()
+    }
+    if(pageHasElement(loginButton)) {
+      setValueSlowly(passwordInput, Config.paypalBuyerPassword)
+    }
   }
+
+  def clickNext(): Unit = clickOn(nextButton)
 
   def logIn(): Unit = clickOn(loginButton)
 
@@ -25,7 +34,7 @@ class PayPalCheckout(implicit val webDriver: WebDriver) extends Browser {
 
   def payPalSummaryHasCorrectDetails(expectedCurrencyAndAmount: String): Boolean = elementHasText(paymentAmount, expectedCurrencyAndAmount)
 
-  def hasLoaded: Boolean = pageHasElement(loginButton)
+  def hasLoaded: Boolean = pageHasElement(loginButton) || pageHasElement(nextButton)
 
   def switchToPayPalPage(): Unit = {
     switchFrame(container)


### PR DESCRIPTION
This change allows tests to work even if paypal splits the signup flow into 2 subsequent windows.

## Why are you doing this?
Currently end-to-end tests are failing on paypal payments due to a change in paypal sign in flow.
Instead of both username and password appearing on the same page, with the new flow, the user must enter username on first page then click "next" button to get to second form.

To make things really awkward, it seems to be inconsistent as to which type of payment sign-in window you are going to get, so the test needs to be able to handle both.

## What has changed?
Changed the "fill in" function for paypal so that it fills in the email then checks to see if a next button is present. If it is, it clicks this and then waits for a login button to be present before entering password and logging in. If no next button is present, it carries on as before.

Also removed the switch window step from the tests as paypal is opening in same window in webdriver. 
(note: I have not deleted the switch window functions from the utils files yet as I want to be sure things are stable first - these will be removed in a later PR once I'm happy the fix is stable)