### PR TITLE
Reinstate Country Switcher Header On Support Landing

### DIFF
--- a/assets/pages/support-landing/components/countrySwitcherHeaderContainer.js
+++ b/assets/pages/support-landing/components/countrySwitcherHeaderContainer.js
@@ -1,0 +1,57 @@
+// @flow
+
+// ----- Imports ----- //
+
+import { connect } from 'react-redux';
+
+import CountrySwitcherHeader from 'components/headers/countrySwitcherHeader/countrySwitcherHeader';
+
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import type { State } from '../supportLandingReducer';
+
+
+const availableCountriesGroups: CountryGroupId[] =
+  ['GBPCountries', 'UnitedStates', 'EURCountries', 'AUDCountries', 'NZDCountries', 'Canada', 'International'];
+
+// ----- Functions ----- //
+
+function handleCountryGroupChange(value: string): void {
+  switch (value) {
+    case 'UnitedStates':
+      window.location.pathname = '/us/contribute';
+      break;
+    case 'AUDCountries':
+      window.location.pathname = '/au';
+      break;
+    case 'EURCountries':
+      window.location.pathname = '/eu/contribute';
+      break;
+    case 'NZDCountries':
+      window.location.pathname = '/nz/contribute';
+      break;
+    case 'Canada':
+      window.location.pathname = '/ca/contribute';
+      break;
+    case 'International':
+      window.location.pathname = '/int/contribute';
+      break;
+    default:
+  }
+}
+
+
+// ----- State Maps ----- //
+
+function mapStateToProps(state: State) {
+
+  return {
+    countryGroupIds: availableCountriesGroups,
+    selectedCountryGroup: state.common.countryGroup,
+    onCountryGroupSelect: handleCountryGroupChange,
+  };
+}
+
+
+// ----- Exports ----- //
+
+export default connect(mapStateToProps)(CountrySwitcherHeader);

--- a/assets/pages/support-landing/supportLanding.jsx
+++ b/assets/pages/support-landing/supportLanding.jsx
@@ -5,7 +5,6 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 
-import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
 import Footer from 'components/footer/footer';
 import CirclesIntroduction from 'components/circlesIntroduction/circlesIntroduction';
 import Contribute from 'components/contribute/contribute';
@@ -16,6 +15,7 @@ import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
 
 import pageReducer from './supportLandingReducer';
+import CountrySwitcherHeaderContainer from './components/countrySwitcherHeaderContainer';
 import ContributionSelectionContainer from './components/contributionSelectionContainer';
 import ContributionPaymentCtasContainer from './components/contributionPaymentCtasContainer';
 import PayPalContributionButtonContainer from './components/payPalContributionButtonContainer';
@@ -44,7 +44,7 @@ const store = pageInit(
 const content = (
   <Provider store={store}>
     <div>
-      <SimpleHeader />
+      <CountrySwitcherHeaderContainer />
       <CirclesIntroduction
         headings={['Help us deliver', 'the independent', 'journalism the', 'world needs']}
         highlights={['Support', 'The Guardian']}


### PR DESCRIPTION
## Why are you doing this?

The switch to the support landing page in #605 didn't bring the country switcher header with it. This reinstates it.

## Changes

- Use the country switcher header in place of the simple header.

## Screenshots

**Before**

![switcher-before](https://user-images.githubusercontent.com/5131341/38376411-67491c02-38f0-11e8-8f37-a0bfe0a760b9.png)

**After**

![switcher-after](https://user-images.githubusercontent.com/5131341/38376429-6c176252-38f0-11e8-912c-1405ab184490.png)
