### PR TITLE
Fix issue where we were sending "undefined" as the email address to the identity Consent API

### DIFF
--- a/app/controllers/IdentityController.scala
+++ b/app/controllers/IdentityController.scala
@@ -27,7 +27,7 @@ class IdentityController(
         Ok
       } else {
         SafeLogger.error(scrub"Failed to send consents preferences email")
-        InternalServerError
+        BadRequest
       }
     }
   }

--- a/app/views/thankYou.scala.html
+++ b/app/views/thankYou.scala.html
@@ -13,7 +13,9 @@
     <script type="text/javascript">
         window.guardian = window.guardian || {};
         window.guardian.csrf = { token: "@CSRF.getToken.value" };
-        window.guardian.email = "@email.getOrElse("undefined")";
+        @email.map { e => {
+            window.guardian.email = "@e";
+        }}
         window.guardian.showConfirmationEmailCopy = @showConfirmationEmailCopy;
     </script>
 }


### PR DESCRIPTION
## Why are you doing this?

As of the 20th March, we had frequently been sending the string "undefined" as the users email address to the Identity Consent API.

The bug was caused in [this PR](https://github.com/guardian/support-frontend/pull/575/files), which changed the way we instantiated `window.guardain.email ` in the window. This change set this to be the string "undefined" if there was no email in the flash session, which only persists on the fiest request.

This meant that if the page reloaded, `window.guardian.email` would be set to undefined, meaning that the `user.email` field in the state would be set to "undefined". The tickbox was set up to show if the `user.email` in the state was a string - as "undefined" is indeed a string, it was still showing the box.

By mapping on the email when creating the window object instead, we not only fix the bug where we show the marketing consent box when we shouldn't, we also don't overwrite the `user.email` field in the state, so even if one does reload the page, their email is persisted. 