### PR TITLE
Refactor generateClassName

### DIFF
--- a/assets/components/bundle/bundle.jsx
+++ b/assets/components/bundle/bundle.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 import DoubleHeading from 'components/doubleHeading/doubleHeading';
 import InlinePaymentLogos from 'components/inlinePaymentLogos/inlinePaymentLogos';
-import { classNameWithOptModifier } from 'helpers/utilities';
+import { classNameWithModifiers } from 'helpers/utilities';
 
 import type { Node } from 'react';
 
@@ -27,7 +27,7 @@ type PropTypes = {
 
 export default function Bundle(props: PropTypes) {
 
-  const className = classNameWithOptModifier('component-bundle', props.modifierClass);
+  const className = classNameWithModifiers('component-bundle', [props.modifierClass]);
 
   return (
     <div className={className}>

--- a/assets/components/bundle/bundle.jsx
+++ b/assets/components/bundle/bundle.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 import DoubleHeading from 'components/doubleHeading/doubleHeading';
 import InlinePaymentLogos from 'components/inlinePaymentLogos/inlinePaymentLogos';
-import { generateClassName } from 'helpers/utilities';
+import { classNameWithOptModifier } from 'helpers/utilities';
 
 import type { Node } from 'react';
 
@@ -27,7 +27,7 @@ type PropTypes = {
 
 export default function Bundle(props: PropTypes) {
 
-  const className = generateClassName('component-bundle', props.modifierClass);
+  const className = classNameWithOptModifier('component-bundle', props.modifierClass);
 
   return (
     <div className={className}>

--- a/assets/components/contribAmounts/contribAmounts.jsx
+++ b/assets/components/contribAmounts/contribAmounts.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import RadioToggle from 'components/radioToggle/radioToggle';
 import NumberInput from 'components/numberInput/numberInput';
 import {
-  generateClassName,
+  classNameWithOptModifier,
   clickSubstituteKeyPressHandler,
 } from 'helpers/utilities';
 import { errorMessage as contributionErrorMessage } from 'helpers/contributions';
@@ -468,9 +468,9 @@ function getClassName(contribType: Contrib): string {
   switch (contribType) {
     case 'ANNUAL':
     case 'MONTHLY':
-      return generateClassName('component-contrib-amounts__amounts', 'recurring');
+      return classNameWithOptModifier('component-contrib-amounts__amounts', 'recurring');
     default:
-      return generateClassName('component-contrib-amounts__amounts', 'one-off');
+      return classNameWithOptModifier('component-contrib-amounts__amounts', 'one-off');
   }
 }
 

--- a/assets/components/contribAmounts/contribAmounts.jsx
+++ b/assets/components/contribAmounts/contribAmounts.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import RadioToggle from 'components/radioToggle/radioToggle';
 import NumberInput from 'components/numberInput/numberInput';
 import {
-  classNameWithOptModifier,
+  classNameWithModifiers,
   clickSubstituteKeyPressHandler,
 } from 'helpers/utilities';
 import { errorMessage as contributionErrorMessage } from 'helpers/contributions';
@@ -468,9 +468,9 @@ function getClassName(contribType: Contrib): string {
   switch (contribType) {
     case 'ANNUAL':
     case 'MONTHLY':
-      return classNameWithOptModifier('component-contrib-amounts__amounts', 'recurring');
+      return classNameWithModifiers('component-contrib-amounts__amounts', ['recurring']);
     default:
-      return classNameWithOptModifier('component-contrib-amounts__amounts', 'one-off');
+      return classNameWithModifiers('component-contrib-amounts__amounts', ['one-off']);
   }
 }
 

--- a/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
+++ b/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
@@ -14,7 +14,7 @@ import {
   getSpokenType,
   getOneOffSpokenName,
 } from 'helpers/contributions';
-import { generateClassName } from 'helpers/utilities';
+import { classNameWithOptModifier } from 'helpers/utilities';
 import { routes } from 'helpers/routes';
 import { addQueryParamsToURL } from 'helpers/url';
 
@@ -68,7 +68,7 @@ export default function ContributionPaymentCtas(props: PropTypes) {
   if (props.contributionType === 'ONE_OFF') {
 
     return (
-      <div className={generateClassName(baseClassName, props.isDisabled ? 'disabled' : null)}>
+      <div className={classNameWithOptModifier(baseClassName, props.isDisabled ? 'disabled' : null)}>
         <OneOffCta {...props} />
         <props.PayPalButton
           buttonText={`Contribute ${props.currency.glyph}${props.amount} with PayPal`}
@@ -82,7 +82,7 @@ export default function ContributionPaymentCtas(props: PropTypes) {
   }
 
   return (
-    <div className={generateClassName(baseClassName, props.isDisabled ? 'disabled' : null)}>
+    <div className={classNameWithOptModifier(baseClassName, props.isDisabled ? 'disabled' : null)}>
       <RegularCta {...props} />
     </div>
   );

--- a/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
+++ b/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
@@ -14,7 +14,7 @@ import {
   getSpokenType,
   getOneOffSpokenName,
 } from 'helpers/contributions';
-import { classNameWithOptModifier } from 'helpers/utilities';
+import { classNameWithModifiers } from 'helpers/utilities';
 import { routes } from 'helpers/routes';
 import { addQueryParamsToURL } from 'helpers/url';
 
@@ -68,7 +68,7 @@ export default function ContributionPaymentCtas(props: PropTypes) {
   if (props.contributionType === 'ONE_OFF') {
 
     return (
-      <div className={classNameWithOptModifier(baseClassName, props.isDisabled ? 'disabled' : null)}>
+      <div className={classNameWithModifiers(baseClassName, props.isDisabled ? ['disabled'] : [])}>
         <OneOffCta {...props} />
         <props.PayPalButton
           buttonText={`Contribute ${props.currency.glyph}${props.amount} with PayPal`}
@@ -82,7 +82,7 @@ export default function ContributionPaymentCtas(props: PropTypes) {
   }
 
   return (
-    <div className={classNameWithOptModifier(baseClassName, props.isDisabled ? 'disabled' : null)}>
+    <div className={classNameWithModifiers(baseClassName, props.isDisabled ? ['disabled'] : [])}>
       <RegularCta {...props} />
     </div>
   );

--- a/assets/components/ctaCircle/ctaCircle.jsx
+++ b/assets/components/ctaCircle/ctaCircle.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { SvgArrowRightStraight } from 'components/svg/svg';
-import { classNameWithOptModifier } from 'helpers/utilities';
+import { classNameWithModifiers } from 'helpers/utilities';
 import { clickSubstituteKeyPressHandler } from 'helpers/utilities';
 
 // ----- Types ----- //
@@ -22,7 +22,7 @@ type PropTypes = {
 
 const CtaCircle = (props: PropTypes) => {
 
-  const className = classNameWithOptModifier('component-cta-circle', props.modifierClass);
+  const className = classNameWithModifiers('component-cta-circle', [props.modifierClass]);
 
   return (
     <a

--- a/assets/components/ctaCircle/ctaCircle.jsx
+++ b/assets/components/ctaCircle/ctaCircle.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { SvgArrowRightStraight } from 'components/svg/svg';
-import { generateClassName } from 'helpers/utilities';
+import { classNameWithOptModifier } from 'helpers/utilities';
 import { clickSubstituteKeyPressHandler } from 'helpers/utilities';
 
 // ----- Types ----- //
@@ -22,7 +22,7 @@ type PropTypes = {
 
 const CtaCircle = (props: PropTypes) => {
 
-  const className = generateClassName('component-cta-circle', props.modifierClass);
+  const className = classNameWithOptModifier('component-cta-circle', props.modifierClass);
 
   return (
     <a

--- a/assets/components/ctaLink/ctaLink.jsx
+++ b/assets/components/ctaLink/ctaLink.jsx
@@ -7,7 +7,7 @@ import { SvgArrowRightStraight } from 'components/svg/svg';
 import { clickSubstituteKeyPressHandler } from 'helpers/utilities';
 import uuidv4 from 'uuid';
 import { addQueryParamToURL } from 'helpers/url';
-import { classNameWithOptModifier } from 'helpers/utilities';
+import { classNameWithModifiers } from 'helpers/utilities';
 
 import type { Node } from 'react';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
@@ -38,7 +38,7 @@ export default function CtaLink(props: PropTypes) {
   return (
     <a
       id={props.id}
-      className={classNameWithOptModifier('component-cta-link', props.ctaId)}
+      className={classNameWithModifiers('component-cta-link', [props.ctaId])}
       href={props.acquisitionData ?
         addQueryParamToURL(urlString, 'acquisitionData', JSON.stringify(props.acquisitionData))
          : props.url

--- a/assets/components/ctaLink/ctaLink.jsx
+++ b/assets/components/ctaLink/ctaLink.jsx
@@ -7,7 +7,7 @@ import { SvgArrowRightStraight } from 'components/svg/svg';
 import { clickSubstituteKeyPressHandler } from 'helpers/utilities';
 import uuidv4 from 'uuid';
 import { addQueryParamToURL } from 'helpers/url';
-import { generateClassName } from 'helpers/utilities';
+import { classNameWithOptModifier } from 'helpers/utilities';
 
 import type { Node } from 'react';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
@@ -38,7 +38,7 @@ export default function CtaLink(props: PropTypes) {
   return (
     <a
       id={props.id}
-      className={generateClassName('component-cta-link', props.ctaId)}
+      className={classNameWithOptModifier('component-cta-link', props.ctaId)}
       href={props.acquisitionData ?
         addQueryParamToURL(urlString, 'acquisitionData', JSON.stringify(props.acquisitionData))
          : props.url

--- a/assets/components/doubleHeading/doubleHeading.jsx
+++ b/assets/components/doubleHeading/doubleHeading.jsx
@@ -3,7 +3,7 @@
 // ----- Imports ----- //
 
 import React from 'react';
-import { generateClassName } from 'helpers/utilities';
+import { classNameWithOptModifier } from 'helpers/utilities';
 
 
 // ---- Types ----- //
@@ -19,7 +19,7 @@ type PropTypes = {
 
 export default function DoubleHeading(props: PropTypes) {
 
-  const className = generateClassName('component-double-heading', props.modifierClass);
+  const className = classNameWithOptModifier('component-double-heading', props.modifierClass);
 
   return (
     <div className={className}>

--- a/assets/components/doubleHeading/doubleHeading.jsx
+++ b/assets/components/doubleHeading/doubleHeading.jsx
@@ -3,7 +3,7 @@
 // ----- Imports ----- //
 
 import React from 'react';
-import { classNameWithOptModifier } from 'helpers/utilities';
+import { classNameWithModifiers } from 'helpers/utilities';
 
 
 // ---- Types ----- //
@@ -19,7 +19,7 @@ type PropTypes = {
 
 export default function DoubleHeading(props: PropTypes) {
 
-  const className = classNameWithOptModifier('component-double-heading', props.modifierClass);
+  const className = classNameWithModifiers('component-double-heading', [props.modifierClass]);
 
   return (
     <div className={className}>

--- a/assets/components/featureList/featureList.jsx
+++ b/assets/components/featureList/featureList.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 
-import { classNameWithOptModifier } from 'helpers/utilities';
+import { classNameWithModifiers } from 'helpers/utilities';
 
 
 // ----- Types ----- //
@@ -37,7 +37,7 @@ function FeatureList(props: PropTypes) {
   ));
 
   return (
-    <ul className={classNameWithOptModifier('component-feature-list', props.modifierClass)}>
+    <ul className={classNameWithModifiers('component-feature-list', [props.modifierClass])}>
       { items }
     </ul>
   );

--- a/assets/components/featureList/featureList.jsx
+++ b/assets/components/featureList/featureList.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 
-import { generateClassName } from 'helpers/utilities';
+import { classNameWithOptModifier } from 'helpers/utilities';
 
 
 // ----- Types ----- //
@@ -37,7 +37,7 @@ function FeatureList(props: PropTypes) {
   ));
 
   return (
-    <ul className={generateClassName('component-feature-list', props.modifierClass)}>
+    <ul className={classNameWithOptModifier('component-feature-list', props.modifierClass)}>
       { items }
     </ul>
   );

--- a/assets/components/numberInput/numberInput.jsx
+++ b/assets/components/numberInput/numberInput.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 
-import { classNameWithOptModifier } from 'helpers/utilities';
+import { classNameWithModifiers } from 'helpers/utilities';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 
@@ -42,7 +42,7 @@ export default function NumberInput(props: PropTypes) {
   const selectedClass = props.selected ? 'selected' : null;
 
   return (
-    <div className={classNameWithOptModifier('component-number-input', selectedClass)}>
+    <div className={classNameWithModifiers('component-number-input', [selectedClass])}>
       {getLabel(props.labelText)}
       <input
         className="component-number-input__input"

--- a/assets/components/numberInput/numberInput.jsx
+++ b/assets/components/numberInput/numberInput.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 
-import { generateClassName } from 'helpers/utilities';
+import { classNameWithOptModifier } from 'helpers/utilities';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 
@@ -42,7 +42,7 @@ export default function NumberInput(props: PropTypes) {
   const selectedClass = props.selected ? 'selected' : null;
 
   return (
-    <div className={generateClassName('component-number-input', selectedClass)}>
+    <div className={classNameWithOptModifier('component-number-input', selectedClass)}>
       {getLabel(props.labelText)}
       <input
         className="component-number-input__input"

--- a/assets/components/otherProduct/otherProduct.jsx
+++ b/assets/components/otherProduct/otherProduct.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import CtaLink from 'components/ctaLink/ctaLink';
 import GridImage from 'components/gridImage/gridImage';
 
-import { generateClassName } from 'helpers/utilities';
+import { classNameWithOptModifier } from 'helpers/utilities';
 
 
 // ----- Props ----- //
@@ -30,7 +30,7 @@ type PropTypes = {
 export default function OtherProduct(props: PropTypes) {
 
   return (
-    <div className={generateClassName('component-other-product', props.modifierClass)}>
+    <div className={classNameWithOptModifier('component-other-product', props.modifierClass)}>
       <div className="component-other-product__image">
         <GridImage
           gridId={props.gridImg}

--- a/assets/components/otherProduct/otherProduct.jsx
+++ b/assets/components/otherProduct/otherProduct.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import CtaLink from 'components/ctaLink/ctaLink';
 import GridImage from 'components/gridImage/gridImage';
 
-import { classNameWithOptModifier } from 'helpers/utilities';
+import { classNameWithModifiers } from 'helpers/utilities';
 
 
 // ----- Props ----- //
@@ -30,7 +30,7 @@ type PropTypes = {
 export default function OtherProduct(props: PropTypes) {
 
   return (
-    <div className={classNameWithOptModifier('component-other-product', props.modifierClass)}>
+    <div className={classNameWithModifiers('component-other-product', [props.modifierClass])}>
       <div className="component-other-product__image">
         <GridImage
           gridId={props.gridImg}

--- a/assets/components/pageSection/pageSection.jsx
+++ b/assets/components/pageSection/pageSection.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 
-import { generateClassName } from 'helpers/utilities';
+import { classNameWithOptModifier } from 'helpers/utilities';
 
 import type { Node } from 'react';
 
@@ -24,7 +24,7 @@ type PropTypes = {
 function PageSection(props: PropTypes) {
 
   return (
-    <section className={generateClassName('component-page-section', props.modifierClass)}>
+    <section className={classNameWithOptModifier('component-page-section', props.modifierClass)}>
       <div className="component-page-section__content gu-content-margin">
         <div className="component-page-section__header">
           <Heading heading={props.heading} />

--- a/assets/components/pageSection/pageSection.jsx
+++ b/assets/components/pageSection/pageSection.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 
-import { classNameWithOptModifier } from 'helpers/utilities';
+import { classNameWithModifiers } from 'helpers/utilities';
 
 import type { Node } from 'react';
 
@@ -24,7 +24,7 @@ type PropTypes = {
 function PageSection(props: PropTypes) {
 
   return (
-    <section className={classNameWithOptModifier('component-page-section', props.modifierClass)}>
+    <section className={classNameWithModifiers('component-page-section', [props.modifierClass])}>
       <div className="component-page-section__content gu-content-margin">
         <div className="component-page-section__header">
           <Heading heading={props.heading} />

--- a/assets/components/radioToggle/radioToggle.jsx
+++ b/assets/components/radioToggle/radioToggle.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import uuidv4 from 'uuid';
 
-import { classNameWithOptModifier } from 'helpers/utilities';
+import { classNameWithModifiers } from 'helpers/utilities';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 
@@ -50,7 +50,7 @@ function getRadioButtons(props: PropTypes) {
     return (
       <span
         id={radio.id}
-        className={classNameWithOptModifier('component-radio-toggle__button', props.modifierClass)}
+        className={classNameWithModifiers('component-radio-toggle__button', [props.modifierClass])}
         key={radioId}
       >
         <A11yHint id={a11yHintId} hint={radio.accessibilityHint} />
@@ -67,7 +67,7 @@ function getRadioButtons(props: PropTypes) {
         />
         <label
           htmlFor={radioId}
-          className={classNameWithOptModifier('component-radio-toggle__label', labelModifier)}
+          className={classNameWithModifiers('component-radio-toggle__label', [labelModifier])}
         >
           {radio.text}
         </label>

--- a/assets/components/radioToggle/radioToggle.jsx
+++ b/assets/components/radioToggle/radioToggle.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import uuidv4 from 'uuid';
 
-import { generateClassName } from 'helpers/utilities';
+import { classNameWithOptModifier } from 'helpers/utilities';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 
@@ -50,7 +50,7 @@ function getRadioButtons(props: PropTypes) {
     return (
       <span
         id={radio.id}
-        className={generateClassName('component-radio-toggle__button', props.modifierClass)}
+        className={classNameWithOptModifier('component-radio-toggle__button', props.modifierClass)}
         key={radioId}
       >
         <A11yHint id={a11yHintId} hint={radio.accessibilityHint} />
@@ -67,7 +67,7 @@ function getRadioButtons(props: PropTypes) {
         />
         <label
           htmlFor={radioId}
-          className={generateClassName('component-radio-toggle__label', labelModifier)}
+          className={classNameWithOptModifier('component-radio-toggle__label', labelModifier)}
         >
           {radio.text}
         </label>

--- a/assets/components/secure/secure.jsx
+++ b/assets/components/secure/secure.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 import { SvgLock } from 'components/svg/svg';
 
-import { generateClassName } from 'helpers/utilities';
+import { classNameWithOptModifier } from 'helpers/utilities';
 
 
 // ----- Props ----- //
@@ -21,7 +21,7 @@ type PropTypes = {
 export default function Secure(props: PropTypes) {
 
   return (
-    <div className={generateClassName('component-secure', props.modifierClass)}>
+    <div className={classNameWithOptModifier('component-secure', props.modifierClass)}>
       <SvgLock />
       <span className="component-secure__text">Secure</span>
     </div>

--- a/assets/components/secure/secure.jsx
+++ b/assets/components/secure/secure.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 import { SvgLock } from 'components/svg/svg';
 
-import { classNameWithOptModifier } from 'helpers/utilities';
+import { classNameWithModifiers } from 'helpers/utilities';
 
 
 // ----- Props ----- //
@@ -21,7 +21,7 @@ type PropTypes = {
 export default function Secure(props: PropTypes) {
 
   return (
-    <div className={classNameWithOptModifier('component-secure', props.modifierClass)}>
+    <div className={classNameWithModifiers('component-secure', [props.modifierClass])}>
       <SvgLock />
       <span className="component-secure__text">Secure</span>
     </div>

--- a/assets/components/subscriptionBundle/subscriptionBundle.jsx
+++ b/assets/components/subscriptionBundle/subscriptionBundle.jsx
@@ -9,7 +9,7 @@ import FeatureList from 'components/featureList/featureList';
 import CtaLink from 'components/ctaLink/ctaLink';
 import GridImage from 'components/gridImage/gridImage';
 
-import { generateClassName } from 'helpers/utilities';
+import { classNameWithOptModifier } from 'helpers/utilities';
 
 import type { ListItem } from 'components/featureList/featureList';
 import type { GridImg } from 'components/gridImage/gridImage';
@@ -35,7 +35,7 @@ type PropTypes = {
 export default function SubscriptionBundle(props: PropTypes) {
 
   return (
-    <div className={generateClassName('component-subscription-bundle', props.modifierClass)}>
+    <div className={classNameWithOptModifier('component-subscription-bundle', props.modifierClass)}>
       <GridImage {...props.gridImage} />
       <div className="component-subscription-bundle__content">
         <DoubleHeading

--- a/assets/components/subscriptionBundle/subscriptionBundle.jsx
+++ b/assets/components/subscriptionBundle/subscriptionBundle.jsx
@@ -9,7 +9,7 @@ import FeatureList from 'components/featureList/featureList';
 import CtaLink from 'components/ctaLink/ctaLink';
 import GridImage from 'components/gridImage/gridImage';
 
-import { classNameWithOptModifier } from 'helpers/utilities';
+import { classNameWithModifiers } from 'helpers/utilities';
 
 import type { ListItem } from 'components/featureList/featureList';
 import type { GridImg } from 'components/gridImage/gridImage';
@@ -35,7 +35,7 @@ type PropTypes = {
 export default function SubscriptionBundle(props: PropTypes) {
 
   return (
-    <div className={classNameWithOptModifier('component-subscription-bundle', props.modifierClass)}>
+    <div className={classNameWithModifiers('component-subscription-bundle', [props.modifierClass])}>
       <GridImage {...props.gridImage} />
       <div className="component-subscription-bundle__content">
         <DoubleHeading

--- a/assets/containerisableComponents/contributionSelection/contributionSelection.jsx
+++ b/assets/containerisableComponents/contributionSelection/contributionSelection.jsx
@@ -12,7 +12,7 @@ import {
   errorMessage as contributionsErrorMessage,
   getContributionTypeClassName,
 } from 'helpers/contributions';
-import { classNameWithOptModifier } from 'helpers/utilities';
+import { classNameWithModifiers } from 'helpers/utilities';
 
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { Currency } from 'helpers/internationalisation/currency';
@@ -53,7 +53,7 @@ function ContributionSelection(props: PropTypes) {
   const modifierClass = getContributionTypeClassName(props.contributionType);
 
   return (
-    <div className={classNameWithOptModifier('component-contribution-selection', modifierClass)}>
+    <div className={classNameWithModifiers('component-contribution-selection', [modifierClass])}>
       <div className="component-contribution-selection__type">
         <RadioToggle
           name="contribution-type-toggle"

--- a/assets/containerisableComponents/contributionSelection/contributionSelection.jsx
+++ b/assets/containerisableComponents/contributionSelection/contributionSelection.jsx
@@ -12,7 +12,7 @@ import {
   errorMessage as contributionsErrorMessage,
   getContributionTypeClassName,
 } from 'helpers/contributions';
-import { generateClassName } from 'helpers/utilities';
+import { classNameWithOptModifier } from 'helpers/utilities';
 
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { Currency } from 'helpers/internationalisation/currency';
@@ -53,7 +53,7 @@ function ContributionSelection(props: PropTypes) {
   const modifierClass = getContributionTypeClassName(props.contributionType);
 
   return (
-    <div className={generateClassName('component-contribution-selection', modifierClass)}>
+    <div className={classNameWithOptModifier('component-contribution-selection', modifierClass)}>
       <div className="component-contribution-selection__type">
         <RadioToggle
           name="contribution-type-toggle"

--- a/assets/containerisableComponents/payPalContributionButton/payPalContributionButton.jsx
+++ b/assets/containerisableComponents/payPalContributionButton/payPalContributionButton.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { SvgPaypalPLogo, SvgArrowRightStraight } from 'components/svg/svg';
 import { paypalContributionsRedirect } from 'helpers/payPalContributionsCheckout/payPalContributionsCheckout';
-import { generateClassName } from 'helpers/utilities';
+import { classNameWithOptModifier } from 'helpers/utilities';
 import * as storage from 'helpers/storage';
 
 import type { IsoCountry } from 'helpers/internationalisation/country';
@@ -62,7 +62,7 @@ const PayPalContributionButton = (props: PropTypes) =>
   (
     <button
       id="qa-contribute-paypal-button"
-      className={generateClassName('component-paypal-contribution-button', props.additionalClass)}
+      className={classNameWithOptModifier('component-paypal-contribution-button', props.additionalClass)}
       onClick={payWithPayPal(props)}
     >
 

--- a/assets/containerisableComponents/payPalContributionButton/payPalContributionButton.jsx
+++ b/assets/containerisableComponents/payPalContributionButton/payPalContributionButton.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { SvgPaypalPLogo, SvgArrowRightStraight } from 'components/svg/svg';
 import { paypalContributionsRedirect } from 'helpers/payPalContributionsCheckout/payPalContributionsCheckout';
-import { classNameWithOptModifier } from 'helpers/utilities';
+import { classNameWithModifiers } from 'helpers/utilities';
 import * as storage from 'helpers/storage';
 
 import type { IsoCountry } from 'helpers/internationalisation/country';
@@ -62,7 +62,7 @@ const PayPalContributionButton = (props: PropTypes) =>
   (
     <button
       id="qa-contribute-paypal-button"
-      className={classNameWithOptModifier('component-paypal-contribution-button', props.additionalClass)}
+      className={classNameWithModifiers('component-paypal-contribution-button', [props.additionalClass])}
       onClick={payWithPayPal(props)}
     >
 

--- a/assets/helpers/__tests__/utilitiesTest.js
+++ b/assets/helpers/__tests__/utilitiesTest.js
@@ -7,7 +7,6 @@ import {
   descending,
   roundDp,
   classNameWithModifiers,
-  classNameWithOptModifier,
   clickSubstituteKeyPressHandler,
   parseBoolean,
   deserialiseJsonObject,
@@ -98,8 +97,8 @@ describe('utilities', () => {
 
   describe('classNameWithModifiers', () => {
 
-    it('should create the same classname if no modifier is passed', () => {
-      expect(classNameWithModifiers('made-up-class')).toBe('made-up-class');
+    it('should create the same classname if no modifiers are passed', () => {
+      expect(classNameWithModifiers('made-up-class', [])).toBe('made-up-class');
     });
 
     it('should return a classname with a modifier attached', () => {
@@ -112,21 +111,9 @@ describe('utilities', () => {
         .toBe('made-up-class made-up-class--fake-modifier made-up-class--pseudo-modifier');
     });
 
-  });
-
-  describe('classNameWithModifier', () => {
-
-    it('should create the same classname if no modifier is passed', () => {
-      expect(classNameWithOptModifier('made-up-class')).toBe('made-up-class');
-    });
-
-    it('should create the same classname if a null modifier is passed', () => {
-      expect(classNameWithOptModifier('made-up-class', null)).toBe('made-up-class');
-    });
-
-    it('should return a classname with a modifier attached', () => {
-      expect(classNameWithOptModifier('made-up-class', 'fake-modifier'))
-        .toBe('made-up-class made-up-class--fake-modifier');
+    it('should not add modifiers for null, undefined or empty strings', () => {
+      expect(classNameWithModifiers('made-up-class', [null, undefined, 'pseudo-modifier', '']))
+        .toBe('made-up-class made-up-class--pseudo-modifier');
     });
 
   });

--- a/assets/helpers/__tests__/utilitiesTest.js
+++ b/assets/helpers/__tests__/utilitiesTest.js
@@ -7,7 +7,7 @@ import {
   descending,
   roundDp,
   classNameWithModifiers,
-  classNameWithModifier,
+  classNameWithOptModifier,
   clickSubstituteKeyPressHandler,
   parseBoolean,
   deserialiseJsonObject,
@@ -117,15 +117,15 @@ describe('utilities', () => {
   describe('classNameWithModifier', () => {
 
     it('should create the same classname if no modifier is passed', () => {
-      expect(classNameWithModifier('made-up-class')).toBe('made-up-class');
+      expect(classNameWithOptModifier('made-up-class')).toBe('made-up-class');
     });
 
     it('should create the same classname if a null modifier is passed', () => {
-      expect(classNameWithModifier('made-up-class', null)).toBe('made-up-class');
+      expect(classNameWithOptModifier('made-up-class', null)).toBe('made-up-class');
     });
 
     it('should return a classname with a modifier attached', () => {
-      expect(classNameWithModifier('made-up-class', 'fake-modifier'))
+      expect(classNameWithOptModifier('made-up-class', 'fake-modifier'))
         .toBe('made-up-class made-up-class--fake-modifier');
     });
 

--- a/assets/helpers/__tests__/utilitiesTest.js
+++ b/assets/helpers/__tests__/utilitiesTest.js
@@ -6,7 +6,8 @@ import {
   ascending,
   descending,
   roundDp,
-  generateClassName,
+  classNameWithModifiers,
+  classNameWithModifier,
   clickSubstituteKeyPressHandler,
   parseBoolean,
   deserialiseJsonObject,
@@ -95,14 +96,36 @@ describe('utilities', () => {
 
   });
 
-  describe('generateClassName', () => {
+  describe('classNameWithModifiers', () => {
 
     it('should create the same classname if no modifier is passed', () => {
-      expect(generateClassName('made-up-class')).toBe('made-up-class');
+      expect(classNameWithModifiers('made-up-class')).toBe('made-up-class');
     });
 
     it('should return a classname with a modifier attached', () => {
-      expect(generateClassName('made-up-class', 'fake-modifier'))
+      expect(classNameWithModifiers('made-up-class', ['fake-modifier']))
+        .toBe('made-up-class made-up-class--fake-modifier');
+    });
+
+    it('should return a classname with multiple modifiers attached', () => {
+      expect(classNameWithModifiers('made-up-class', ['fake-modifier', 'pseudo-modifier']))
+        .toBe('made-up-class made-up-class--fake-modifier made-up-class--pseudo-modifier');
+    });
+
+  });
+
+  describe('classNameWithModifier', () => {
+
+    it('should create the same classname if no modifier is passed', () => {
+      expect(classNameWithModifier('made-up-class')).toBe('made-up-class');
+    });
+
+    it('should create the same classname if a null modifier is passed', () => {
+      expect(classNameWithModifier('made-up-class', null)).toBe('made-up-class');
+    });
+
+    it('should return a classname with a modifier attached', () => {
+      expect(classNameWithModifier('made-up-class', 'fake-modifier'))
         .toBe('made-up-class made-up-class--fake-modifier');
     });
 

--- a/assets/helpers/utilities.js
+++ b/assets/helpers/utilities.js
@@ -18,14 +18,12 @@ function roundDp(num: number, dps: number = 2) {
   return Math.round(num * (10 ** dps)) / (10 ** dps);
 }
 
-// Generates the "class modifier-class" string for HTML elements
-function classNameWithModifiers(className: string, modifiers?: string[] = []): string {
-  return modifiers.reduce((acc, modifier) => `${acc} ${className}--${modifier}`, className);
-}
-
-// Generates a className with an optional modifier (common pattern convenience function).
-function classNameWithOptModifier(className: string, modifier: ?string): string {
-  return classNameWithModifiers(className, modifier ? [modifier] : undefined);
+// Generates the "class class-modifier" string for HTML elements.
+// Does not add null, undefined and empty string.
+function classNameWithModifiers(className: string, modifiers: Array<?string>): string {
+  return modifiers
+    .filter(Boolean)
+    .reduce((acc, modifier) => `${acc} ${className}--${modifier}`, className);
 }
 
 // Generates a key handler that only trigger a function if the
@@ -96,7 +94,6 @@ export {
   ascending,
   descending,
   roundDp,
-  classNameWithOptModifier,
   classNameWithModifiers,
   clickSubstituteKeyPressHandler,
   parseBoolean,

--- a/assets/helpers/utilities.js
+++ b/assets/helpers/utilities.js
@@ -24,7 +24,7 @@ function classNameWithModifiers(className: string, modifiers?: string[] = []): s
 }
 
 // Generates a className with an optional modifier (common pattern convenience function).
-function classNameWithModifier(className: string, modifier: ?string): string {
+function classNameWithOptModifier(className: string, modifier: ?string): string {
   return classNameWithModifiers(className, modifier ? [modifier] : undefined);
 }
 
@@ -96,7 +96,7 @@ export {
   ascending,
   descending,
   roundDp,
-  classNameWithModifier,
+  classNameWithOptModifier,
   classNameWithModifiers,
   clickSubstituteKeyPressHandler,
   parseBoolean,

--- a/assets/helpers/utilities.js
+++ b/assets/helpers/utilities.js
@@ -20,7 +20,7 @@ function roundDp(num: number, dps: number = 2) {
 
 // Generates the "class modifier-class" string for HTML elements
 function classNameWithModifiers(className: string, modifiers?: string[] = []): string {
-  return modifiers.reduce((acc, m) => `${acc} ${className}--${m}`, className);
+  return modifiers.reduce((acc, modifier) => `${acc} ${className}--${modifier}`, className);
 }
 
 // Generates a className with an optional modifier (common pattern convenience function).

--- a/assets/helpers/utilities.js
+++ b/assets/helpers/utilities.js
@@ -19,14 +19,13 @@ function roundDp(num: number, dps: number = 2) {
 }
 
 // Generates the "class modifier-class" string for HTML elements
-function generateClassName(className: string, modifierClass: ?string): string {
-  let response = className;
+function classNameWithModifiers(className: string, modifiers?: string[] = []): string {
+  return modifiers.reduce((acc, m) => `${acc} ${className}--${m}`, className);
+}
 
-  if (modifierClass) {
-    response = `${className} ${className}--${modifierClass}`;
-  }
-
-  return response;
+// Generates a className with an optional modifier (common pattern convenience function).
+function classNameWithModifier(className: string, modifier: ?string): string {
+  return classNameWithModifiers(className, modifier ? [modifier] : undefined);
 }
 
 // Generates a key handler that only trigger a function if the
@@ -97,7 +96,8 @@ export {
   ascending,
   descending,
   roundDp,
-  generateClassName,
+  classNameWithModifier,
+  classNameWithModifiers,
   clickSubstituteKeyPressHandler,
   parseBoolean,
   deserialiseJsonObject,


### PR DESCRIPTION
# Why are you doing this?

In a discussion [here](https://github.com/guardian/support-frontend/pull/381#discussion_r152587640) we decided that it would be useful to have `generateClassName` take an array of modifiers. There are situations with [BEM](http://getbem.com/) where you may want multiple modifiers on an element. I've also used this opportunity to make the function name a bit more explicit.

The result is a new function, `classNameWithModifiers`, which takes an array of modifiers and applies them to a base `className`. Filters out `null`, `undefined` and `''` (empty string).

[**Trello Card**](https://trello.com/c/vo3iRyuE/1108-generateclassname-should-receive-an-array-of-modifiers)

cc @JustinPinner 

**Note:** The `Boolean` function is used here to keep [Flow happy](https://stackoverflow.com/questions/44131502/filtering-an-array-of-maybe-nullable-types-in-flow-to-remove-null-values).

# Changes

- Added a new function to handle className generation.
- Updated all the call sites.
