### PR TITLE
Don't send Identity ids in the Stripe payment details

### DIFF
--- a/assets/pages/regular-contributions/__tests__/ajaxTest.js
+++ b/assets/pages/regular-contributions/__tests__/ajaxTest.js
@@ -9,7 +9,6 @@ describe('Regular Contributions Payment fields', () => {
     const accountNumber = '55779911';
     const accountHolderName = 'Bart Simpson';
     const paymentFieldName = 'directDebitData';
-    const userId = '123456';
 
     const expectedPaymentFields = {
       accountHolderName,
@@ -22,7 +21,6 @@ describe('Regular Contributions Payment fields', () => {
       sortCode,
       accountHolderName,
       paymentFieldName,
-      userId,
     );
 
     expect(paymentFields.accountHolderName).toEqual(expectedPaymentFields.accountHolderName);
@@ -34,7 +32,6 @@ describe('Regular Contributions Payment fields', () => {
   it('should create the correct payment field to handle PayPal', () => {
 
     const paymentFieldName = 'baid';
-    const userId = '123456';
     const token = 'PayPalToken';
 
     const expectedPaymentFields = {
@@ -46,7 +43,6 @@ describe('Regular Contributions Payment fields', () => {
       undefined,
       undefined,
       paymentFieldName,
-      userId,
     );
 
     expect(paymentFields.baid).toEqual(expectedPaymentFields.baid);
@@ -57,12 +53,10 @@ describe('Regular Contributions Payment fields', () => {
   it('should create the correct payment field to handle Stripe', () => {
 
     const paymentFieldName = 'stripeToken';
-    const userId = '123456';
     const token = 'StripeToken';
 
     const expectedPaymentFields = {
       stripeToken: token,
-      userId,
     };
     const paymentFields = getPaymentFields(
       token,
@@ -70,18 +64,15 @@ describe('Regular Contributions Payment fields', () => {
       undefined,
       undefined,
       paymentFieldName,
-      userId,
     );
 
     expect(paymentFields.stripeToken).toEqual(expectedPaymentFields.stripeToken);
-    expect(paymentFields.userId).toEqual(expectedPaymentFields.userId);
-    expect(Object.keys(paymentFields).length).toEqual(2);
+    expect(Object.keys(paymentFields).length).toEqual(1);
   });
 
   it('should return null if a unknown payment field name is passed', () => {
 
     const paymentFieldName = 'helloWorld';
-    const userId = '123456';
     const token = 'PayPalToken';
 
     const paymentFields = getPaymentFields(
@@ -90,7 +81,6 @@ describe('Regular Contributions Payment fields', () => {
       undefined,
       undefined,
       paymentFieldName,
-      userId,
     );
 
     expect(paymentFields).toEqual(null);

--- a/assets/pages/regular-contributions/helpers/ajax.js
+++ b/assets/pages/regular-contributions/helpers/ajax.js
@@ -39,7 +39,6 @@ type PayPalDetails = {|
 |};
 
 type StripeDetails = {|
-  userId: string,
   stripeToken: string,
 |};
 
@@ -75,7 +74,6 @@ const getPaymentFields =
     sortCode?: string,
     accountHolderName?: string,
     paymentFieldName: string,
-    userId: string,
   ): ?(PayPalDetails | StripeDetails | DirectDebitDetails
     ) => {
     let response = null;
@@ -90,7 +88,6 @@ const getPaymentFields =
       case 'stripeToken':
         if (token) {
           response = {
-            userId,
             [paymentFieldName]: token,
           };
         }
@@ -144,7 +141,6 @@ function requestData(
     sortCode,
     accountHolderName,
     paymentFieldName,
-    user.id,
   );
 
   if (!paymentFields) {

--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-sts" % awsVersion,
   "org.typelevel" %% "cats-core" % "1.0.1",
   "com.dripower" %% "play-circe" % "2609.1",
-  "com.gu" %% "support-models" % "0.25",
+  "com.gu" %% "support-models" % "0.26",
   "com.gu" %% "support-config" % "0.16",
   "com.gu" %% "fezziwig" % "0.8",
   "com.typesafe.akka" %% "akka-agent" % "2.5.6",


### PR DESCRIPTION
## Why are you doing this?
Currently when a user signs up with a credit card we send their Identity ID to Stripe when creating the Stripe customer record. For GDPR reasons we need to stop doing this.

I have tested this on code.

[**Trello Card**](https://trello.com/c/rNWSgTCY/1363-investigate-data-sent-to-stripe)
