### PR TITLE
Adding AUDCountries dropdown in checkout page

### DIFF
--- a/assets/helpers/internationalisation/country.js
+++ b/assets/helpers/internationalisation/country.js
@@ -368,10 +368,10 @@ function fromString(s: string): ?IsoCountry {
 
 function fromCountryGroup(countryGroupId: ?CountryGroupId = null): ?IsoCountry {
   switch (countryGroupId) {
-    case 'AUDCountries':
-      return 'AU';
     case 'UnitedStates':
       return 'US';
+    case 'Canada':
+      return 'CA';
     default: return null;
   }
 }
@@ -379,8 +379,6 @@ function fromCountryGroup(countryGroupId: ?CountryGroupId = null): ?IsoCountry {
 function fromPath(path: string = window.location.pathname): ?IsoCountry {
   if (path === '/us' || path.startsWith('/us/')) {
     return 'US';
-  } else if (path === '/au' || path.startsWith('/au/')) {
-    return 'AU';
   } else if (path === '/ca' || path.startsWith('/ca/')) {
     return 'CA';
   }
@@ -416,7 +414,7 @@ function setCountry(country: IsoCountry) {
   cookie.set('GU_country', country, 7);
 }
 
-type TargetCountryGroups = 'International' | 'EURCountries' | 'NZDCountries' | 'GBPCountries';
+type TargetCountryGroups = 'International' | 'EURCountries' | 'NZDCountries' | 'GBPCountries' | 'AUDCountries';
 
 function handleCountryForCountryGroup(
   targetCountryGroup: TargetCountryGroups,
@@ -428,6 +426,7 @@ function handleCountryForCountryGroup(
     EURCountries: ['/eu', '/eu/'],
     NZDCountries: ['/nz', '/nz/'],
     GBPCountries: ['/uk', '/uk/'],
+    AUDCountries: ['/au', '/au/'],
   };
 
   const defaultCountry: {[TargetCountryGroups]: IsoCountry} = {
@@ -435,6 +434,7 @@ function handleCountryForCountryGroup(
     EURCountries: 'DE',
     NZDCountries: 'NZ',
     GBPCountries: 'GB',
+    AUDCountries: 'AU',
   };
 
   const path = window.location.pathname;
@@ -458,7 +458,7 @@ function handleCountryForCountryGroup(
 
 function detect(countryGroupId: ?CountryGroupId = null): IsoCountry {
 
-  const targetCountryGroups: TargetCountryGroups[] = ['International', 'EURCountries', 'NZDCountries', 'GBPCountries'];
+  const targetCountryGroups: TargetCountryGroups[] = ['International', 'EURCountries', 'NZDCountries', 'GBPCountries', 'AUDCountries'];
   let country = null;
 
   targetCountryGroups.forEach((targetCountryGroupId) => {

--- a/assets/pages/regular-contributions/components/formFields.jsx
+++ b/assets/pages/regular-contributions/components/formFields.jsx
@@ -94,7 +94,7 @@ function countriesDropdown(
   country: IsoCountry,
 ) {
 
-  const askForCountryCountryGroups = ['EURCountries', 'International', 'NZDCountries', 'GBPCountries'];
+  const askForCountryCountryGroups = ['EURCountries', 'International', 'NZDCountries', 'GBPCountries', 'AUDCountries'];
 
   if (!askForCountryCountryGroups.includes(countryGroup)) {
     return null;


### PR DESCRIPTION
## Why are you doing this?

We need to ask the reader in which country he/she is, in order to send this data to Zuora.

[**Trello Card**](https://trello.com/c/ybJt4X7R/265-add-a-country-dropdown-for-audcountries)

## Changes

* Treating `AUDCountries` as a country group with several countries inside.
* Adding Country dropdown for AUD checkout

## Screenshots

### Checkout Page
<img width="660" alt="picture 688" src="https://user-images.githubusercontent.com/825398/38610637-58498ee8-3d79-11e8-8082-e8d867d7bc8d.png">

### Dropdown open

<img width="448" alt="picture 689" src="https://user-images.githubusercontent.com/825398/38610622-5143424c-3d79-11e8-8cf2-e8276c90fb5e.png">
