### PR TITLE
Driving traffic to Australian support frontend

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -32,11 +32,12 @@ class Application(
     val redirectUrl = request.fastlyCountry match {
       case Some(UK) => "/uk"
       case Some(US) => "/us/contribute"
+      case Some(Australia) => "/au/contribute"
       case Some(Europe) => "/eu/contribute"
       case Some(Canada) => "/ca/contribute"
       case Some(NewZealand) => "/nz/contribute"
       case Some(RestOfTheWorld) => "/int/contribute"
-      case _ => "https://membership.theguardian.com/supporter"
+      case _ => "/uk/contribute"
     }
 
     Redirect(redirectUrl, request.queryString, status = FOUND)
@@ -46,11 +47,12 @@ class Application(
     val redirectUrl = request.fastlyCountry match {
       case Some(UK) => "/uk/contribute"
       case Some(US) => "/us/contribute"
+      case Some(Australia) => "/au/contribute"
       case Some(Europe) => "/eu/contribute"
       case Some(Canada) => "/ca/contribute"
       case Some(NewZealand) => "/nz/contribute"
       case Some(RestOfTheWorld) => "/int/contribute"
-      case _ => "https://contribute.theguardian.com"
+      case _ => "/uk/contribute"
     }
 
     Redirect(redirectUrl, request.queryString, status = FOUND)

--- a/assets/components/headers/countrySwitcherHeader/countrySwitcherHeaderContainer.js
+++ b/assets/components/headers/countrySwitcherHeader/countrySwitcherHeaderContainer.js
@@ -11,7 +11,7 @@ import type { CommonState } from 'helpers/page/page';
 
 
 const availableCountriesGroups: CountryGroupId[] =
-  ['GBPCountries', 'UnitedStates', 'EURCountries', 'NZDCountries', 'Canada', 'International'];
+  ['GBPCountries', 'UnitedStates', 'EURCountries', 'NZDCountries', 'Canada', 'International', 'AUDCountries'];
 
 // ----- Functions ----- //
 
@@ -34,6 +34,9 @@ function handleCountryGroupChange(value: string): void {
       break;
     case 'International':
       window.location.pathname = '/int/contribute';
+      break;
+    case 'AUDCountries':
+      window.location.pathname = '/au/contribute';
       break;
     default:
   }

--- a/assets/pages/contributions-landing-au/components/countrySwitcherHeaderContainer.jsx
+++ b/assets/pages/contributions-landing-au/components/countrySwitcherHeaderContainer.jsx
@@ -12,31 +12,35 @@ import type { State } from '../contributionsLandingReducers';
 
 
 const availableCountriesGroups: CountryGroupId[] =
-  ['GBPCountries', 'UnitedStates', 'EURCountries', 'AUDCountries'];
+  ['GBPCountries', 'UnitedStates', 'EURCountries', 'NZDCountries', 'Canada', 'International', 'AUDCountries'];
 
 // ----- Functions ----- //
 
-function handleCountryGroupChange(dispatch) {
-  return (value: string) => {
-
-    if (value === 'GBPCountries') {
-      window.location.pathname = '/uk';
-    }
-
-    switch (value) {
-      case 'UnitedStates':
-        dispatch(setCountryGroup('UnitedStates'));
-        break;
-      case 'AUDCountries':
-        dispatch(setCountryGroup('AUDCountries'));
-        break;
-      case 'EURCountries':
-        dispatch(setCountryGroup('EURCountries'));
-        break;
-      default:
-    }
-
-  };
+function handleCountryGroupChange(value: string): void {
+  switch (value) {
+    case 'UnitedStates':
+      window.location.pathname = '/us/contribute';
+      break;
+    case 'GBPCountries':
+      window.location.pathname = '/uk/contribute';
+      break;
+    case 'EURCountries':
+      window.location.pathname = '/eu/contribute';
+      break;
+    case 'NZDCountries':
+      window.location.pathname = '/nz/contribute';
+      break;
+    case 'Canada':
+      window.location.pathname = '/ca/contribute';
+      break;
+    case 'International':
+      window.location.pathname = '/int/contribute';
+      break;
+    case 'AUDCountries':
+      window.location.pathname = '/au/contribute';
+      break;
+    default:
+  }
 }
 
 // ----- State Maps ----- //
@@ -46,17 +50,10 @@ function mapStateToProps(state: State) {
   return {
     countryGroupIds: availableCountriesGroups,
     selectedCountryGroup: state.common.countryGroup,
+    onCountryGroupSelect: handleCountryGroupChange,
   };
 }
-
-
-function mapDispatchToProps(dispatch) {
-  return {
-    onCountryGroupSelect: handleCountryGroupChange(dispatch),
-  };
-}
-
 
 // ----- Exports ----- //
 
-export default connect(mapStateToProps, mapDispatchToProps)(CountrySwitcherHeader);
+export default connect(mapStateToProps)(CountrySwitcherHeader);

--- a/assets/pages/contributions-landing-au/components/countrySwitcherHeaderContainer.jsx
+++ b/assets/pages/contributions-landing-au/components/countrySwitcherHeaderContainer.jsx
@@ -7,7 +7,6 @@ import { connect } from 'react-redux';
 import CountrySwitcherHeader from 'components/headers/countrySwitcherHeader/countrySwitcherHeader';
 
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import { setCountryGroup } from 'helpers/page/pageActions';
 import type { State } from '../contributionsLandingReducers';
 
 


### PR DESCRIPTION
## Why are you doing this?

To drive traffic to the Australian version of Support Frontend.
[**Trello Card**](https://trello.com)

## Changes

* Added redirects for the Australian case
* Added Australian to the country switcher

## Screenshots
### All pages except AUD
<img width="460" alt="picture 712" src="https://user-images.githubusercontent.com/825398/38740503-a67bc4de-3f2f-11e8-8a15-edbd022cb79f.png">

### AUD Page
<img width="253" alt="picture 713" src="https://user-images.githubusercontent.com/825398/38740504-a69770d0-3f2f-11e8-9552-1d08378bea99.png">
