### PR TITLE
Add exclusions to query parameters

### DIFF
--- a/assets/helpers/tracking/acquisitions.js
+++ b/assets/helpers/tracking/acquisitions.js
@@ -162,7 +162,8 @@ function buildAcquisition(
   const campaignCode = acquisitionData.campaignCode ||
     getQueryParameter('INTCMP');
 
-  const parameterExclusions = ['REFPVID', 'INTCMP', 'acquisitionData'];
+  const parameterExclusions =
+    ['REFPVID', 'INTCMP', 'acquisitionData', 'contributionValue', 'contribType', 'currency'];
 
   const queryParameters =
     acquisitionData.queryParameters ||


### PR DESCRIPTION
## Why are you doing this?
`contributionValue`, `contribType` and `currency` were sneaking into the query parameters field in the acquisition tracking. We don't want this, so this PR adds them to the list of exclusions

@guardian/contributions 