### PR TITLE
fix the element ids in the acceptance tests

### DIFF
--- a/test/selenium/pages/OneOffContributionThankYou.scala
+++ b/test/selenium/pages/OneOffContributionThankYou.scala
@@ -8,7 +8,7 @@ class OneOffContributionThankYou(implicit val webDriver: WebDriver) extends Page
 
   val url = s"${Config.supportFrontendUrl}/contribute/one-off/thankyou"
 
-  private val thankYouHeader = id("qa-thank-you-message")
+  private val thankYouHeader = id("contributions-thank-you-page")
 
   def pageHasLoaded: Boolean = pageHasElement(thankYouHeader) && pageHasUrl("/contribute/one-off/thankyou")
 

--- a/test/selenium/pages/RecurringContributionThankYou.scala
+++ b/test/selenium/pages/RecurringContributionThankYou.scala
@@ -8,7 +8,7 @@ class RecurringContributionThankYou(implicit val webDriver: WebDriver) extends P
 
   val url = s"${Config.supportFrontendUrl}/contribute/recurring/thankyou"
 
-  private val thankYouHeader = id("qa-thank-you-message")
+  private val thankYouHeader = id("regular-contributions-thank-you-page")
 
   def pageHasLoaded: Boolean = pageHasElement(thankYouHeader) && (pageHasUrl("/contribute/recurring/thankyou") || pageHasUrl("/contribute/recurring/pending"))
 


### PR DESCRIPTION
## Why are you doing this?

The DD thank you page PR broke the acceptance tests by removing an element which they looked for to check that the thank you page had loaded, this PR fixes them

