### PR TITLE
Review Checkout Defaults

### DIFF
--- a/assets/containerisableComponents/contributionSelection/__tests__/contributionSelectionReducerTest.js
+++ b/assets/containerisableComponents/contributionSelection/__tests__/contributionSelectionReducerTest.js
@@ -62,7 +62,7 @@ describe('Contributions Selection reducer', () => {
 
     const changeContributionType = actions.setContributionType(contributionType, 'GBPCountries');
     const newState = reducer(initialState, changeContributionType);
-    expect(newState.error).toEqual('tooLittle');
+    expect(newState.error).toEqual('TooLittle');
 
   });
 
@@ -76,7 +76,7 @@ describe('Contributions Selection reducer', () => {
       annualAmount: '75',
       customAmount: '1',
       isCustomAmount: true,
-      error: 'tooLittle',
+      error: 'TooLittle',
     };
 
     const changeContributionType = actions.setContributionType(contributionType, 'GBPCountries');
@@ -191,7 +191,7 @@ describe('Contributions Selection reducer', () => {
     const newState = reducer(initialState, actions.setCustomAmount(amount, 'GBPCountries'));
 
     expect(newState.customAmount).toBeNull();
-    expect(newState.error).toEqual('invalidEntry');
+    expect(newState.error).toEqual('ParseError');
 
   });
 

--- a/assets/containerisableComponents/contributionSelection/contributionSelection.jsx
+++ b/assets/containerisableComponents/contributionSelection/contributionSelection.jsx
@@ -22,7 +22,7 @@ import type { Currency } from 'helpers/internationalisation/currency';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type {
   Contrib as ContributionType,
-  ContribError as ContributionError,
+  ContributionError,
 } from 'helpers/contributions';
 
 

--- a/assets/containerisableComponents/contributionSelection/contributionSelectionReducer.js
+++ b/assets/containerisableComponents/contributionSelection/contributionSelectionReducer.js
@@ -3,7 +3,8 @@
 // ----- Imports ----- //
 
 import {
-  circlesParse as parseContribution,
+  parseAndValidateContribution,
+  validateContribution,
   config,
 } from 'helpers/contributions';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
@@ -11,7 +12,7 @@ import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type {
   Contrib as ContributionType,
   ContribError as ContributionError,
-  ParsedAmount,
+  ParsedContribution,
 } from 'helpers/contributions';
 
 import type { Action } from './contributionSelectionActions';
@@ -71,10 +72,10 @@ function checkCustomAmount(
   customAmount: ?number,
   contributionType: ContributionType,
   countryGroupId: CountryGroupId,
-): ?ParsedAmount {
+): ?ParsedContribution {
 
   if (isCustomAmount && customAmount) {
-    return parseContribution(customAmount.toString(), contributionType, countryGroupId);
+    return validateContribution(customAmount, contributionType, countryGroupId);
   }
 
   return null;
@@ -137,7 +138,7 @@ function contributionSelectionReducerFor(scope: string, countryGroupId: CountryG
         return {
           ...state,
           isCustomAmount: true,
-          ...parseContribution(action.amount, state.contributionType, action.countryGroupId),
+          ...parseAndValidateContribution(action.amount, state.contributionType, action.countryGroupId),
         };
 
       default:

--- a/assets/containerisableComponents/contributionSelection/contributionSelectionReducer.js
+++ b/assets/containerisableComponents/contributionSelection/contributionSelectionReducer.js
@@ -3,7 +3,7 @@
 // ----- Imports ----- //
 
 import {
-  parseAndValidateContribution,
+  parseContribution,
   validateContribution,
   config,
 } from 'helpers/contributions';
@@ -11,7 +11,8 @@ import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 import type {
   Contrib as ContributionType,
-  ContribError as ContributionError,
+  ContributionError,
+  ValidationError,
 } from 'helpers/contributions';
 
 import type { Action } from './contributionSelectionActions';
@@ -71,14 +72,12 @@ function checkCustomAmount(
   customAmount: ?number,
   contributionType: ContributionType,
   countryGroupId: CountryGroupId,
-): ?{ customAmount: ?number, error: ?ContributionError } {
+): ?{ error: ?ValidationError } {
 
   if (isCustomAmount && customAmount) {
-    const validated = validateContribution(customAmount, contributionType, countryGroupId);
 
-    if (validated.valid) {
-      return { customAmount: validated.amount, error: null };
-    }
+    const error = validateContribution(customAmount, contributionType, countryGroupId);
+    return { error };
 
   }
 
@@ -92,13 +91,16 @@ function parseCustomAmount(
   countryGroupId: CountryGroupId,
 ): { customAmount: ?number, error: ?ContributionError } {
 
-  const parsed = parseAndValidateContribution(amount, contributionType, countryGroupId);
+  const parsed = parseContribution(amount);
 
-  if (parsed.valid) {
-    return { customAmount: parsed.amount, error: null };
+  if (!parsed.valid) {
+    return { customAmount: null, error: parsed.error };
   }
 
-  return { customAmount: null, error: parsed.error };
+  return {
+    customAmount: parsed.amount,
+    error: validateContribution(parsed.amount, contributionType, countryGroupId),
+  };
 
 }
 

--- a/assets/helpers/__tests__/contributionsTests.js
+++ b/assets/helpers/__tests__/contributionsTests.js
@@ -1,0 +1,65 @@
+// @flow
+
+// ----- Imports ----- //
+
+import {
+  config,
+  validateContribution,
+  parseContribution,
+  getMinContribution,
+} from '../contributions';
+
+
+// ----- Tests ----- //
+
+describe('contributions', () => {
+
+  describe('validateContribution', () => {
+
+    it('should return "TooLittle" for contributions below the minimum', () => {
+      [
+        [1, 'MONTHLY', 'GBPCountries'],
+        [5, 'ANNUAL', 'AUDCountries'],
+        [0.5, 'ONE_OFF', 'EURCountries'],
+      ].forEach(a => expect(validateContribution(...a)).toBe('TooLittle'));
+    });
+
+    it('should return "TooMuch" for contributions above the maximum', () => {
+      [
+        [200, 'MONTHLY', 'UnitedStates'],
+        [2030, 'ANNUAL', 'International'],
+        [2030, 'ONE_OFF', 'Canada'],
+      ].forEach(a => expect(validateContribution(...a)).toBe('TooMuch'));
+    });
+
+    it('should return null for contributions that are OK', () => {
+      [
+        [100, 'MONTHLY', 'NZDCountries'],
+        [100, 'ANNUAL', 'UnitedStates'],
+        [100, 'ONE_OFF', 'GBPCountries'],
+      ].forEach(a => expect(validateContribution(...a)).toBeNull());
+    });
+
+  });
+
+  describe('parseContribution', () => {
+
+    it('should parse and format contribution strings that are valid', () => {
+      expect(parseContribution('22.5')).toEqual({ valid: true, amount: 22.50 });
+      expect(parseContribution('0.4')).toEqual({ valid: true, amount: 0.40 });
+      expect(parseContribution('9.555')).toEqual({ valid: true, amount: 9.56 });
+    });
+
+    it('should return an error for invalid contribution strings', () => {
+      expect(parseContribution('a word')).toEqual({ error: 'ParseError' });
+    });
+
+  });
+
+  describe('getMinContribution', () => {
+    it('should retrieve the minimum contribution', () => {
+      expect(getMinContribution('ONE_OFF', 'GBPCountries')).toBe(1);
+    });
+  });
+
+});

--- a/assets/helpers/__tests__/contributionsTests.js
+++ b/assets/helpers/__tests__/contributionsTests.js
@@ -3,7 +3,6 @@
 // ----- Imports ----- //
 
 import {
-  config,
   validateContribution,
   parseContribution,
   getMinContribution,

--- a/assets/helpers/checkouts.js
+++ b/assets/helpers/checkouts.js
@@ -3,10 +3,11 @@
 // ----- Imports ----- //
 
 import { getQueryParameter } from 'helpers/url';
-import { detect as detectCountryGroup } from 'helpers/internationalisation/countryGroup';
 import { getMinContribution, parseContribution, validateContribution } from 'helpers/contributions';
 import * as storage from 'helpers/storage';
-import { parseContrib } from 'helpers/contributions';
+
+import type { Contrib } from 'helpers/contributions';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 
 // ----- Types ----- //
@@ -16,10 +17,7 @@ export type PaymentMethod = 'DirectDebit' | 'PayPal' | 'Stripe';
 
 // ----- Functions ----- //
 
-function getAmount(): number {
-
-  const contributionType = parseContrib(getQueryParameter('contribType'), 'MONTHLY');
-  const countryGroup = detectCountryGroup();
+function getAmount(contributionType: Contrib, countryGroup: CountryGroupId): number {
 
   const contributionValue = getQueryParameter('contributionValue');
 

--- a/assets/helpers/checkouts.js
+++ b/assets/helpers/checkouts.js
@@ -1,0 +1,56 @@
+// @flow
+
+// ----- Imports ----- //
+
+import { getQueryParameter } from 'helpers/url';
+import { detect as detectCountryGroup } from 'helpers/internationalisation/countryGroup';
+import { getMinContribution, parseContribution, validateContribution } from 'helpers/contributions';
+import * as storage from 'helpers/storage';
+import { parseContrib } from 'helpers/contributions';
+
+
+// ----- Types ----- //
+
+export type PaymentMethod = 'DirectDebit' | 'PayPal' | 'Stripe';
+
+
+// ----- Functions ----- //
+
+function getAmount(): number {
+
+  const contributionType = parseContrib(getQueryParameter('contribType'), 'MONTHLY');
+  const countryGroup = detectCountryGroup();
+
+  const contributionValue = getQueryParameter('contributionValue');
+
+  if (contributionValue !== null && contributionValue !== undefined) {
+    const parsed = parseContribution(contributionValue);
+
+    if (parsed.valid) {
+      const error = validateContribution(parsed.amount, contributionType, countryGroup);
+
+      if (!error) {
+        return parsed.amount;
+      }
+    }
+  }
+
+  return getMinContribution(contributionType, countryGroup);
+
+}
+
+function getPaymentMethod(): ?PaymentMethod {
+  const pm: ?string = storage.getSession('paymentMethod');
+  if (pm === 'DirectDebit' || pm === 'Stripe' || pm === 'PayPal') {
+    return (pm: PaymentMethod);
+  }
+  return null;
+}
+
+
+// ----- Exports ----- //
+
+export {
+  getAmount,
+  getPaymentMethod,
+};

--- a/assets/helpers/contributions.js
+++ b/assets/helpers/contributions.js
@@ -23,6 +23,10 @@ export type ContribError =
   | 'tooMuch'
   | 'invalidEntry';
 
+type ParseError = 'ParseError';
+export type ValidationError = 'TooMuch' | 'TooLittle';
+export type ContributionError = ParseError | ValidationError;
+
 export type ParsedContrib = {
   amount: number,
   error: ?ContribError,
@@ -32,7 +36,7 @@ export type ParsedContribution = {|
   valid: true,
   amount: number,
 |} | {|
-  error: ContribError,
+  error: ParseError,
 |};
 
 type Config = {
@@ -274,15 +278,15 @@ function validateContribution(
   input: number,
   contributionType: Contrib,
   countryGroupId: CountryGroupId,
-): ParsedContribution {
+): ?ValidationError {
 
   if (input < config[countryGroupId][contributionType].min) {
-    return { error: 'tooLittle' };
+    return 'TooLittle';
   } else if (input > config[countryGroupId][contributionType].max) {
-    return { error: 'tooMuch' };
+    return 'TooMuch';
   }
 
-  return { valid: true, amount: roundDp(input) };
+  return null;
 
 }
 
@@ -291,26 +295,10 @@ function parseContribution(input: string): ParsedContribution {
   const amount = Number(input);
 
   if (input === '' || Number.isNaN(amount)) {
-    return { error: 'invalidEntry' };
+    return { error: 'ParseError' };
   }
 
-  return { valid: true, amount };
-
-}
-
-function parseAndValidateContribution(
-  input: string,
-  contributionType: Contrib,
-  countryGroupId: CountryGroupId,
-): ParsedContribution {
-
-  const parsed = parseContribution(input);
-
-  if (parsed.valid) {
-    return validateContribution(parsed.amount, contributionType, countryGroupId);
-  }
-
-  return parsed;
+  return { valid: true, amount: roundDp(amount) };
 
 }
 
@@ -464,7 +452,7 @@ export {
   parse,
   parseContrib,
   validateContribution,
-  parseAndValidateContribution,
+  parseContribution,
   billingPeriodFromContrib,
   errorMessage,
   getOneOffName,

--- a/assets/helpers/contributions.js
+++ b/assets/helpers/contributions.js
@@ -279,9 +279,9 @@ function circlesParse(
   if (input === '' || Number.isNaN(customAmount)) {
     return { error: 'invalidEntry', customAmount: null };
   } else if (customAmount < config[countryGroupId][contributionType].min) {
-    return { error: 'tooLittle', customAmount };
+    return { error: 'tooLittle', customAmount: null };
   } else if (customAmount > config[countryGroupId][contributionType].max) {
-    return { error: 'tooMuch', customAmount };
+    return { error: 'tooMuch', customAmount: null };
   }
 
   return { error: null, customAmount };

--- a/assets/helpers/contributions.js
+++ b/assets/helpers/contributions.js
@@ -28,7 +28,7 @@ export type ParsedContrib = {
   error: ?ContribError,
 };
 
-export type ParsedAmount = {
+export type ParsedContribution = {
   error: ?ContribError,
   customAmount: ?number,
 };
@@ -268,23 +268,47 @@ function parse(input: ?string, contrib: Contrib, countryGroupId: CountryGroupId)
 
 }
 
-function circlesParse(
-  input: string,
+function validateContribution(
+  input: number,
   contributionType: Contrib,
   countryGroupId: CountryGroupId,
-): ParsedAmount {
+): ParsedContribution {
 
-  const customAmount = Number(input);
-
-  if (input === '' || Number.isNaN(customAmount)) {
-    return { error: 'invalidEntry', customAmount: null };
-  } else if (customAmount < config[countryGroupId][contributionType].min) {
+  if (input < config[countryGroupId][contributionType].min) {
     return { error: 'tooLittle', customAmount: null };
-  } else if (customAmount > config[countryGroupId][contributionType].max) {
+  } else if (input > config[countryGroupId][contributionType].max) {
     return { error: 'tooMuch', customAmount: null };
   }
 
-  return { error: null, customAmount: roundDp(customAmount) };
+  return { error: null, customAmount: roundDp(input) };
+
+}
+
+function parseContribution(input: string): ParsedContribution {
+
+  const amount = Number(input);
+
+  if (input === '' || Number.isNaN(amount)) {
+    return { error: 'invalidEntry', customAmount: null };
+  }
+
+  return { error: null, customAmount: amount };
+
+}
+
+function parseAndValidateContribution(
+  input: string,
+  contributionType: Contrib,
+  countryGroupId: CountryGroupId,
+): ParsedContribution {
+
+  const parsed = parseContribution(input);
+
+  if (parsed.customAmount) {
+    return validateContribution(parsed.customAmount, contributionType, countryGroupId);
+  }
+
+  return parsed;
 
 }
 
@@ -437,7 +461,8 @@ export {
   config,
   parse,
   parseContrib,
-  circlesParse,
+  validateContribution,
+  parseAndValidateContribution,
   billingPeriodFromContrib,
   errorMessage,
   getOneOffName,

--- a/assets/helpers/contributions.js
+++ b/assets/helpers/contributions.js
@@ -18,11 +18,6 @@ export type Contrib = 'ANNUAL' | 'MONTHLY' | 'ONE_OFF';
 
 export type BillingPeriod = 'Monthly' | 'Annual';
 
-export type ContribError =
-  | 'tooLittle'
-  | 'tooMuch'
-  | 'invalidEntry';
-
 type ParseError = 'ParseError';
 export type ValidationError = 'TooMuch' | 'TooLittle';
 export type ContributionError = ParseError | ValidationError;
@@ -299,7 +294,7 @@ function billingPeriodFromContrib(contrib: Contrib): BillingPeriod {
 }
 
 function errorMessage(
-  error: ContribError,
+  error: ContributionError,
   contributionType: Contrib,
   countryGroupId: CountryGroupId,
 ): ?string {
@@ -309,11 +304,11 @@ function errorMessage(
   const currency = currencies[countryGroups[countryGroupId].currency];
 
   switch (error) {
-    case 'tooLittle':
+    case 'TooLittle':
       return `Please enter at least ${currency.glyph}${minContrib}`;
-    case 'tooMuch':
+    case 'TooMuch':
       return `${currency.glyph}${maxContrib} is the maximum we can accept`;
-    case 'invalidEntry':
+    case 'ParseError':
       return 'Please enter a numeric amount';
     default:
       return null;

--- a/assets/helpers/contributions.js
+++ b/assets/helpers/contributions.js
@@ -27,11 +27,6 @@ type ParseError = 'ParseError';
 export type ValidationError = 'TooMuch' | 'TooLittle';
 export type ContributionError = ParseError | ValidationError;
 
-export type ParsedContrib = {
-  amount: number,
-  error: ?ContribError,
-};
-
 export type ParsedContribution = {|
   valid: true,
   amount: number,
@@ -255,25 +250,6 @@ const amounts = {
 
 // ----- Functions ----- //
 
-function parse(input: ?string, contrib: Contrib, countryGroupId: CountryGroupId): ParsedContrib {
-
-  let error = null;
-  const numericAmount = Number(input);
-
-  if (input === undefined || input === null || input === '' || Number.isNaN(numericAmount)) {
-    error = 'invalidEntry';
-  } else if (numericAmount < config[countryGroupId][contrib].min) {
-    error = 'tooLittle';
-  } else if (numericAmount > config[countryGroupId][contrib].max) {
-    error = 'tooMuch';
-  }
-
-  const amount = error ? config[countryGroupId][contrib].default : roundDp(numericAmount);
-
-  return { error, amount };
-
-}
-
 function validateContribution(
   input: number,
   contributionType: Contrib,
@@ -453,7 +429,6 @@ function getContributionAmountRadios(
 
 export {
   config,
-  parse,
   parseContrib,
   validateContribution,
   parseContribution,

--- a/assets/helpers/contributions.js
+++ b/assets/helpers/contributions.js
@@ -302,6 +302,10 @@ function parseContribution(input: string): ParsedContribution {
 
 }
 
+function getMinContribution(contributionType: Contrib, countryGroupId: CountryGroupId): number {
+  return config[countryGroupId][contributionType].min;
+}
+
 function parseContrib(s: ?string, contrib: Contrib): Contrib {
   switch ((s || contrib).toUpperCase()) {
     case 'ANNUAL': return 'ANNUAL';
@@ -453,6 +457,7 @@ export {
   parseContrib,
   validateContribution,
   parseContribution,
+  getMinContribution,
   billingPeriodFromContrib,
   errorMessage,
   getOneOffName,

--- a/assets/helpers/contributions.js
+++ b/assets/helpers/contributions.js
@@ -284,7 +284,7 @@ function circlesParse(
     return { error: 'tooMuch', customAmount: null };
   }
 
-  return { error: null, customAmount };
+  return { error: null, customAmount: roundDp(customAmount) };
 
 }
 

--- a/assets/helpers/contributions.js
+++ b/assets/helpers/contributions.js
@@ -28,10 +28,12 @@ export type ParsedContrib = {
   error: ?ContribError,
 };
 
-export type ParsedContribution = {
-  error: ?ContribError,
-  customAmount: ?number,
-};
+export type ParsedContribution = {|
+  valid: true,
+  amount: number,
+|} | {|
+  error: ContribError,
+|};
 
 type Config = {
   [Contrib]: {
@@ -275,12 +277,12 @@ function validateContribution(
 ): ParsedContribution {
 
   if (input < config[countryGroupId][contributionType].min) {
-    return { error: 'tooLittle', customAmount: null };
+    return { error: 'tooLittle' };
   } else if (input > config[countryGroupId][contributionType].max) {
-    return { error: 'tooMuch', customAmount: null };
+    return { error: 'tooMuch' };
   }
 
-  return { error: null, customAmount: roundDp(input) };
+  return { valid: true, amount: roundDp(input) };
 
 }
 
@@ -289,10 +291,10 @@ function parseContribution(input: string): ParsedContribution {
   const amount = Number(input);
 
   if (input === '' || Number.isNaN(amount)) {
-    return { error: 'invalidEntry', customAmount: null };
+    return { error: 'invalidEntry' };
   }
 
-  return { error: null, customAmount: amount };
+  return { valid: true, amount };
 
 }
 
@@ -304,8 +306,8 @@ function parseAndValidateContribution(
 
   const parsed = parseContribution(input);
 
-  if (parsed.customAmount) {
-    return validateContribution(parsed.customAmount, contributionType, countryGroupId);
+  if (parsed.valid) {
+    return validateContribution(parsed.amount, contributionType, countryGroupId);
   }
 
   return parsed;

--- a/assets/pages/oneoff-contributions/oneoffContributions.jsx
+++ b/assets/pages/oneoff-contributions/oneoffContributions.jsx
@@ -13,15 +13,13 @@ import { BrowserRouter } from 'react-router-dom';
 
 import { detect as detectCountryGroup } from 'helpers/internationalisation/countryGroup';
 import * as user from 'helpers/user/user';
-import { getQueryParameter } from 'helpers/url';
-import { parse as parseContrib } from 'helpers/contributions';
 import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
 import { routes } from 'helpers/routes';
+import { getAmount } from 'helpers/checkouts';
+
 import ContributionsThankYouPageContainer from './components/contributionsThankYouPageContainer';
-
 import reducer from './oneOffContributionsReducers';
-
 import { setPayPalButton } from './oneoffContributionsActions';
 import OneOffContributionsPage from './components/oneOffContributionsPage';
 
@@ -29,14 +27,13 @@ import OneOffContributionsPage from './components/oneOffContributionsPage';
 // ----- Page Startup ----- //
 
 const countryGroup = detectCountryGroup();
-const contributionAmount = parseContrib(getQueryParameter('contributionValue'), 'ONE_OFF', countryGroup).amount;
 
 /* eslint-disable no-underscore-dangle */
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 /* eslint-enable */
 
 const store = pageInit(
-  reducer(contributionAmount),
+  reducer(getAmount('ONE_OFF', countryGroup)),
   undefined,
   composeEnhancers(applyMiddleware(thunkMiddleware)),
 );

--- a/assets/pages/regular-contributions/helpers/ajax.js
+++ b/assets/pages/regular-contributions/helpers/ajax.js
@@ -15,6 +15,8 @@ import type { Participations } from 'helpers/abTests/abtest';
 import { successfulConversion } from 'helpers/tracking/googleTagManager';
 
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
+import type { PaymentMethod } from 'helpers/checkouts';
+
 import { checkoutPending, checkoutSuccess, checkoutError, creatingContributor } from '../regularContributionsActions';
 import { billingPeriodFromContrib } from '../../../helpers/contributions';
 
@@ -33,8 +35,6 @@ type ContributionRequest = {
 };
 
 type PaymentFieldName = 'baid' | 'stripeToken' | 'directDebitData';
-
-export type PaymentMethod = 'DirectDebit' | 'PayPal' | 'Stripe';
 
 type PayPalDetails = {|
   'baid': string

--- a/assets/pages/regular-contributions/regularContributions.jsx
+++ b/assets/pages/regular-contributions/regularContributions.jsx
@@ -14,6 +14,9 @@ import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
 import { routes } from 'helpers/routes';
 import { getAmount, getPaymentMethod } from 'helpers/checkouts';
+import { parseContrib } from 'helpers/contributions';
+import { getQueryParameter } from 'helpers/url';
+import { detect as detectCountryGroup } from 'helpers/internationalisation/countryGroup';
 
 import ContributionsThankYouPageContainer from './components/contributionsThankYouPageContainer';
 import RegularContributionsPage from './components/regularContributionsPage';
@@ -28,7 +31,10 @@ const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 /* eslint-enable */
 
 const store = pageInit(
-  reducer(getAmount(), getPaymentMethod()),
+  reducer(
+    getAmount(parseContrib(getQueryParameter('contribType'), 'MONTHLY'), detectCountryGroup()),
+    getPaymentMethod(),
+  ),
   undefined,
   composeEnhancers(applyMiddleware(thunkMiddleware)),
 );

--- a/assets/pages/regular-contributions/regularContributions.jsx
+++ b/assets/pages/regular-contributions/regularContributions.jsx
@@ -6,52 +6,38 @@ import React from 'react';
 import { applyMiddleware, compose } from 'redux';
 import { Provider } from 'react-redux';
 import thunkMiddleware from 'redux-thunk';
-
 import { Route } from 'react-router';
 import { BrowserRouter } from 'react-router-dom';
 
-import { detect as detectCountryGroup } from 'helpers/internationalisation/countryGroup';
 import * as user from 'helpers/user/user';
-import * as storage from 'helpers/storage';
 import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
 import { routes } from 'helpers/routes';
-import { getQueryParameter } from 'helpers/url';
-import { parse as parseAmount } from 'helpers/contributions';
+import { getAmount, getPaymentMethod } from 'helpers/checkouts';
+
 import ContributionsThankYouPageContainer from './components/contributionsThankYouPageContainer';
 import RegularContributionsPage from './components/regularContributionsPage';
 import reducer from './regularContributionsReducers';
 import { setPayPalButton } from './regularContributionsActions';
-import { parseContrib } from '../../helpers/contributions';
-import type { PaymentMethod } from './helpers/ajax';
 
 
 // ----- Page Startup ----- //
-const contributionType = parseContrib(getQueryParameter('contribType'), 'MONTHLY');
-const countryGroup = detectCountryGroup();
-const { amount } = parseAmount(getQueryParameter('contributionValue'), contributionType, countryGroup);
-
-function getPaymentMethod(): ?PaymentMethod {
-  const pm: ?string = storage.getSession('paymentMethod');
-  if (pm === 'DirectDebit' || pm === 'Stripe' || pm === 'PayPal') {
-    return (pm: PaymentMethod);
-  }
-  return null;
-}
-
 
 /* eslint-disable no-underscore-dangle */
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 /* eslint-enable */
 
 const store = pageInit(
-  reducer(amount, getPaymentMethod()),
+  reducer(getAmount(), getPaymentMethod()),
   undefined,
   composeEnhancers(applyMiddleware(thunkMiddleware)),
 );
 
 user.init(store.dispatch);
 store.dispatch(setPayPalButton(window.guardian.payPalType));
+
+
+// ----- Render ----- //
 
 const router = (
   <BrowserRouter>

--- a/assets/pages/regular-contributions/regularContributionsActions.js
+++ b/assets/pages/regular-contributions/regularContributionsActions.js
@@ -2,8 +2,8 @@
 
 // ----- Imports ----- //
 
+import type { PaymentMethod } from 'helpers/checkouts';
 import type { PayPalButtonType } from './components/regularContributionsPayment';
-import type { PaymentMethod } from './helpers/ajax';
 
 
 // ----- Types ----- //

--- a/assets/pages/regular-contributions/regularContributionsReducers.js
+++ b/assets/pages/regular-contributions/regularContributionsReducers.js
@@ -12,9 +12,9 @@ import { directDebitReducer as directDebit } from 'components/directDebit/direct
 import { marketingConsentReducerFor } from 'containerisableComponents/marketingConsent/marketingConsentReducer';
 import csrf from 'helpers/csrf/csrfReducer';
 import type { CommonState } from 'helpers/page/page';
+import type { PaymentMethod } from 'helpers/checkouts';
 import type { Action } from './regularContributionsActions';
 import type { PaymentStatus, PayPalButtonType } from './components/regularContributionsPayment';
-import type { PaymentMethod } from './helpers/ajax';
 
 // ----- Types ----- //
 


### PR DESCRIPTION
# Why are you doing this?

This PR covers two issues:

1. We have two very similar functions for parsing contributions:
  - `parse`, which is used on the checkouts.
  - `circlesParse`, which is used on the landing pages.
2. If a user arrives on the checkout without a contribution value set, they will be defaulted to an amount that may be higher than their original choice.

The proposed solutions are as follows:

1. Share parsing functionality between the checkouts and the landing pages. The result is actually still two functions, but they now do different things, rather than the same thing in different ways:
- `parseContribution`, which reads a contribution from a string and converts it to a monetary value.
- `validateContribution`, which checks that a contribution is within the accepted limits.
2. Get the checkouts to default to the minimum accepted contribution value.

cc @JustinPinner 

[**Trello Card**](https://trello.com/c/cXZi3pkn/1336-review-checkout-defaults)

# Changes

- Deleted the old `parse` and `circlesParse` functions.
- Added `parseContribution`, `validateContribution` and `getMinContribution`.
- Created a new, shared `checkouts` helper to manage functionality common to both checkouts.
- Updated and added further tests.
