### PR TITLE
Increase max line length to 120

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -42,7 +42,19 @@
         "some": [ "nesting", "id" ]
       },
       "allowChildren": false
-    }]
+    }],
+    "max-len": [
+      "error",
+      120,
+      2,
+      {
+        "ignoreUrls": true,
+        "ignoreComments": false,
+        "ignoreRegExpLiterals": true,
+        "ignoreStrings": true,
+        "ignoreTemplateLiterals": true
+      }
+    ],
   },
   "settings": {
     "import/resolver": {

--- a/assets/components/directDebit/directDebitForm/directDebitGuarantee.jsx
+++ b/assets/components/directDebit/directDebitForm/directDebitGuarantee.jsx
@@ -15,7 +15,6 @@ function className(baseClass: string, open: boolean) {
 }
 
 function DirectDebitGuarantee(props: PropTypes) {
-  // eslint-disable-next-line max-len
   const onClick = props.isDDGuaranteeOpen ? props.closeDDGuaranteeClicked : props.openDDGuaranteeClicked;
   return (
     <div className="component-direct-debit-guarantee">

--- a/assets/pages/regular-contributions/regularContributions.jsx
+++ b/assets/pages/regular-contributions/regularContributions.jsx
@@ -54,7 +54,6 @@ user.init(store.dispatch);
 store.dispatch(setPayPalButton(window.guardian.payPalType));
 
 const router = (
-  /* eslint-disable max-len */
   <BrowserRouter>
     <Provider store={store}>
       <div>


### PR DESCRIPTION
## Why are you doing this?

Because 100 characters really isn't very much and 
```javascript
const onClick = props.isDDGuaranteeOpen ? props.closeDDGuaranteeClicked : props.openDDGuaranteeClicked;
```
is easier to read than 

```javascript
let onClick = props.openDDGuaranteeClicked;
if(props.isDDGuaranteeOpen){
  onClick = props.closeDDGuaranteeClicked;
}
```

