### PR TITLE
Pass skipValidationReturn to Identity

### DIFF
--- a/app/actions/CustomActionBuilders.scala
+++ b/app/actions/CustomActionBuilders.scala
@@ -31,12 +31,15 @@ class CustomActionBuilders(
 
   import CustomActionBuilders._
 
+  // Tells identity to send users back to the checkout immediately after sign-up.
   private val idSkipConfirmation: (String, String) = "skipConfirmation" -> "true"
+  // Prevents the identity validation email sending users back to our checkout.
+  private val idSkipValidationReturn: (String, String) = "skipValidationReturn" -> "true"
 
   private val idMember = "clientId" -> "members"
 
   private def idWebAppRegisterUrl(path: String): String =
-    idWebAppUrl / "register" ? ("returnUrl" -> s"$supportUrl$path") & idSkipConfirmation & idMember
+    idWebAppUrl / "register" ? ("returnUrl" -> s"$supportUrl$path") & idSkipConfirmation & idSkipValidationReturn & idMember
 
   private val chooseRegister = (request: RequestHeader) => SeeOther(idWebAppRegisterUrl(request.uri))
 


### PR DESCRIPTION
# Why are you doing this?

## Problem

The recurring contributions flow looks like this:

```
landing page -> identity sign-in/up -> checkout page -> thank you page
```

The landing page sends users directly to the checkout page. If they are signed in, they see the checkout page immediately. If not, they get redirected to identity, where they sign-up/sign-in, and then are re-directed via the `returnUrl` back to the checkout. Having made a contribution they are sent to the thank you page, where they're told to expect a confirmation email.

Checking their inbox, if they've signed up, they will see two emails, one for identity validation, and one for confirmation. When they click on the validation link in the identity email, they are presented with a consent page, which then uses *the same returnUrl to pass them back to the checkout page*. However, by this point they're already making a contribution, so instead they see an error page. This may lead them to believe their payment has failed. Furthermore, if there are delays in payment processing, for example due to Zuora/Salesforce problems, they may not yet be flagged as a recurring contributor, and may actually be able to access the checkout page they are sent to, which could cause further problems.

cc @JustinPinner 

## Solution

Identity [have added](https://github.com/guardian/identity-frontend/pull/378) a `skipValidationReturn` query param, which can be used to remove this return URL from the validation email.

[**Trello Card**](https://trello.com/c/phBZEATE/1373-identity-confirmation-flow-return-url)

# Changes

- Pass `skipValidationReturn` to identity.
