### PR TITLE
Update privacy policy copy in the footer.

### DIFF
--- a/assets/components/legal/termsPrivacy/termsPrivacy.jsx
+++ b/assets/components/legal/termsPrivacy/termsPrivacy.jsx
@@ -20,12 +20,12 @@ type PropTypes = {
 
 function TermsPrivacy(props: PropTypes) {
 
-  const terms = <a href={termsLinks[props.country]}>Terms and Conditions</a>;
+  const terms = <a href={termsLinks[props.country]}>Terms of Service</a>;
   const privacy = <a href={privacyLink}>Privacy Policy</a>;
 
   return (
     <div className="component-terms-privacy">
-      By proceeding, you are agreeing to our {terms} and {privacy}.
+      By proceeding, you agree to our {terms}. To find out what personal data we collect and how we use it, please visit our {privacy}.
     </div>
   );
 

--- a/assets/components/legal/termsPrivacy/termsPrivacy.jsx
+++ b/assets/components/legal/termsPrivacy/termsPrivacy.jsx
@@ -25,7 +25,8 @@ function TermsPrivacy(props: PropTypes) {
 
   return (
     <div className="component-terms-privacy">
-      By proceeding, you agree to our {terms}. To find out what personal data we collect and how we use it, please visit our {privacy}.
+      By proceeding, you agree to our {terms}. To find out what personal data we collect and how we use it, please
+        visit our {privacy}.
     </div>
   );
 

--- a/assets/components/legal/termsPrivacy/termsPrivacy.jsx
+++ b/assets/components/legal/termsPrivacy/termsPrivacy.jsx
@@ -20,13 +20,13 @@ type PropTypes = {
 
 function TermsPrivacy(props: PropTypes) {
 
-  const terms = <a href={termsLinks[props.country]}>Terms of Service</a>;
+  const terms = <a href={termsLinks[props.country]}>Terms and Conditions</a>;
   const privacy = <a href={privacyLink}>Privacy Policy</a>;
 
   return (
     <div className="component-terms-privacy">
-      By proceeding, you agree to our {terms}. To find out what personal data we collect and how we use it, please
-        visit our {privacy}.
+      By proceeding, you are agreeing to our {terms}. To find out what personal data we collect and how we use it,
+        please visit our {privacy}.
     </div>
   );
 

--- a/assets/helpers/legal.js
+++ b/assets/helpers/legal.js
@@ -11,7 +11,7 @@ const termsLinks: {
   [IsoCountry]: string,
 } = {
   GB: 'https://www.theguardian.com/help/terms-of-service',
-  US: 'https://www.theguardian.com/info/2016/apr/07/us-contribution-terms-and-conditions'
+  US: 'https://www.theguardian.com/info/2016/apr/07/us-contribution-terms-and-conditions',
 };
 
 const privacyLink = 'https://www.theguardian.com/help/privacy-policy';

--- a/assets/helpers/legal.js
+++ b/assets/helpers/legal.js
@@ -10,7 +10,7 @@ import type { IsoCountry } from 'helpers/internationalisation/country';
 const termsLinks: {
   [IsoCountry]: string,
 } = {
-  GB: 'https://www.theguardian.com/help/terms-of-service',
+  GB: 'https://www.theguardian.com/info/2016/apr/04/contribution-terms-and-conditions',
   US: 'https://www.theguardian.com/info/2016/apr/07/us-contribution-terms-and-conditions',
 };
 

--- a/assets/helpers/legal.js
+++ b/assets/helpers/legal.js
@@ -10,8 +10,8 @@ import type { IsoCountry } from 'helpers/internationalisation/country';
 const termsLinks: {
   [IsoCountry]: string,
 } = {
-  GB: 'https://www.theguardian.com/info/2016/apr/04/contribution-terms-and-conditions',
-  US: 'https://www.theguardian.com/info/2016/apr/07/us-contribution-terms-and-conditions',
+  GB: 'https://www.theguardian.com/help/terms-of-service',
+  US: 'https://www.theguardian.com/info/2016/apr/07/us-contribution-terms-and-conditions'
 };
 
 const privacyLink = 'https://www.theguardian.com/help/privacy-policy';


### PR DESCRIPTION
## Why are you doing this?
New standards for GDPR require copy changes around the privacy policy.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/BZ5HMG0g/1448-update-copy-for-tscs-and-privacy-policy)

## Changes
* Copy change for privacy policy in the footer. 

## Screenshots
Current privacy policy copy 
![image](https://user-images.githubusercontent.com/3072877/39468890-36e20fe6-4d2d-11e8-8645-e2db5746e673.png)

Footer with ⭐️ new ⭐️  privacy policy copy
![image](https://user-images.githubusercontent.com/3072877/39468850-0e5186b0-4d2d-11e8-8311-03d3bc09559d.png)
