### PR TITLE
Actually update privacy policy copy in the footer.

### DIFF
--- a/assets/components/footer/footer.jsx
+++ b/assets/components/footer/footer.jsx
@@ -22,9 +22,10 @@ function PrivacyPolicy(props: { privacyPolicy: boolean }) {
 
   if (props.privacyPolicy) {
     return (
-      <a className="component-footer__privacy-policy" href={privacyLink}>
-        Privacy Policy
-      </a>
+        <div className="component-footer__privacy-policy-text">
+          To find out what personal data we collect and how we use it, please visit our
+          <a className="component-footer__privacy-policy" href={privacyLink}> Privacy Policy</a>.
+        </div>
     );
   }
 

--- a/assets/components/footer/footer.jsx
+++ b/assets/components/footer/footer.jsx
@@ -22,10 +22,10 @@ function PrivacyPolicy(props: { privacyPolicy: boolean }) {
 
   if (props.privacyPolicy) {
     return (
-        <div className="component-footer__privacy-policy-text">
-          To find out what personal data we collect and how we use it, please visit our
-          <a className="component-footer__privacy-policy" href={privacyLink}> Privacy Policy</a>.
-        </div>
+      <div className="component-footer__privacy-policy-text">
+        To find out what personal data we collect and how we use it, please visit our
+        <a className="component-footer__privacy-policy" href={privacyLink}> Privacy Policy</a>.
+      </div>
     );
   }
 

--- a/assets/components/footer/footer.scss
+++ b/assets/components/footer/footer.scss
@@ -7,7 +7,6 @@
 
   .component-footer__privacy-policy {
     text-decoration: none;
-    display: block;
     color: gu-colour(neutral-4);
     padding: 5px 0;
   }
@@ -16,7 +15,7 @@
     text-decoration: underline;
   }
 
-  .component-footer__copyright, .component-contrib-legal {
+  .component-footer__copyright, .component-contrib-legal, .component-footer__privacy-policy-text {
     font-weight: 400;
     display: block;
     padding: 3px 0;


### PR DESCRIPTION
## Why are you doing this?
New standards for GDPR require copy changes around the privacy policy.

https://github.com/guardian/support-frontend/pull/639 just updated the privacy policy copy for the confirmation page for a contribution but this needs to be updated in the footer as well. 

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/BZ5HMG0g/1448-update-copy-for-tscs-and-privacy-policy)

## Changes

* Add required privacy policy copy to the footer. 

## Screenshots
Old footer 
![image](https://user-images.githubusercontent.com/3072877/39471032-e84bc60e-4d38-11e8-9940-bf53b2020d6e.png)

Footer with updated copy
![image](https://user-images.githubusercontent.com/3072877/39471088-2e42c5d6-4d39-11e8-92c0-03d504294ef9.png)
