### PR TITLE
Split Error Page CSS

### DIFF
--- a/app/lib/CustomHttpErrorHandler.scala
+++ b/app/lib/CustomHttpErrorHandler.scala
@@ -29,13 +29,13 @@ class CustomHttpErrorHandler(
 
   override protected def onNotFound(request: RequestHeader, message: String): Future[Result] =
     Future.successful(
-      NotFound(main("Error 404", "error-404-page", "error404Page.js")(assets, request))
+      NotFound(main("Error 404", "error-404-page", "error404Page.js", "errorPageStyles.css")(assets, request))
         .withHeaders(CacheControl.defaultCacheHeaders(30.seconds, 30.seconds): _*)
     )
 
   override protected def onProdServerError(request: RequestHeader, exception: UsefulException): Future[Result] =
     Future.successful(
-      InternalServerError(main("Error 500", "error-500-page", "error500Page.js")(assets, request))
+      InternalServerError(main("Error 500", "error-500-page", "error500Page.js", "errorPageStyles.css")(assets, request))
         .withHeaders(CacheControl.noCache)
     )
 

--- a/assets/pages/error/components/errorPage.jsx
+++ b/assets/pages/error/components/errorPage.jsx
@@ -24,7 +24,7 @@ type PropTypes = {
 
 // ----- Component ----- //
 
-export default function ErrorContent(props: PropTypes) {
+export default function ErrorPage(props: PropTypes) {
 
   return (
     <div className="component-error-content gu-content">
@@ -77,6 +77,6 @@ function ReportLink(props: { show: boolean }) {
 
 // ----- Default Props ----- //
 
-ErrorContent.defaultProps = {
+ErrorPage.defaultProps = {
   reportLink: false,
 };

--- a/assets/pages/error/error.scss
+++ b/assets/pages/error/error.scss
@@ -1,3 +1,21 @@
+// -----  gu-sass ----- //
+
+@import '../../stylesheets/gu-sass/gu-sass';
+
+
+// ----- Shared Components ----- //
+
+@import '../../components/headers/simpleHeader/simpleHeader';
+@import '../../components/footer/footer';
+@import '../../components/introduction/introduction';
+@import '../../components/introduction/squaresIntroduction';
+@import '../../components/highlights/highlights';
+@import '../../components/pageSection/pageSection';
+@import '../../components/ctaLink/ctaLink';
+
+
+// ----- Page ----- //
+
 #error-404-page, #error-500-page {
   .component-page-section--ctas {
     @include multiline-top-border;

--- a/assets/pages/error/error404.jsx
+++ b/assets/pages/error/error404.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { statelessInit as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
 
-import ErrorContent from './components/errorContent';
+import ErrorPage from './components/errorPage';
 
 
 // ----- Page Startup ----- //
@@ -18,7 +18,7 @@ pageInit();
 // ----- Render ----- //
 
 const content = (
-  <ErrorContent
+  <ErrorPage
     errorCode="404"
     headings={['the page you', 'have requested', 'does not exist']}
     copy="You may have followed an outdated link, or have mistyped a URL. If you believe this to be an error, "

--- a/assets/pages/error/error500.jsx
+++ b/assets/pages/error/error500.jsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { statelessInit as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
 
-import ErrorContent from './components/errorContent';
+import ErrorPage from './components/errorPage';
 
 
 // ----- Page Startup ----- //
@@ -18,7 +18,7 @@ pageInit();
 // ----- Render ----- //
 
 const content = (
-  <ErrorContent
+  <ErrorPage
     errorCode="500"
     headings={['sorry - we seem', 'to be having a', 'problem completing', 'your request']}
     copy="Please try again. If the problem persists, "

--- a/assets/stylesheets/main.scss
+++ b/assets/stylesheets/main.scss
@@ -9,7 +9,6 @@
 @import '../components/checkboxInput/checkboxInput';
 @import '../components/introduction/introduction';
 @import '../components/introduction/circlesIntroduction';
-@import '../components/introduction/squaresIntroduction';
 @import '../components/contribute/contribute';
 @import '../components/contributionPaymentCtas/contributionPaymentCtas';
 @import '../containerisableComponents/contributionSelection/contributionSelection';
@@ -61,4 +60,3 @@
 @import '../pages/oneoff-contributions/oneoffContributions';
 @import '../pages/regular-contributions-existing/regularContributionsExisting';
 @import '../pages/paypal-error/payPalError';
-@import '../pages/error/error';

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -35,6 +35,7 @@ module.exports = (cssFilename, outputFilename, minimizeCss) => ({
     googleTagManagerScript: 'helpers/tracking/googleTagManagerScript.js',
     error404Page: 'pages/error/error404.jsx',
     error500Page: 'pages/error/error500.jsx',
+    errorPageStyles: 'pages/error/error.scss',
   },
 
   output: {


### PR DESCRIPTION
## Why are you doing this?

To improve performance. Far less unused CSS downloaded and parsed.

_ | Before | After
-|-|-
Error Styles | 76.5 KiB | 14.8 KiB
Main Styles | 76.5 KiB | 71.7 KiB

[**Trello Card**](https://trello.com/c/uJ8T9Nmp/1493-split-error-page-css)

cc @JustinPinner 

## Changes

- Made `error.scss` the main stylesheet for the error pages.
- Deleted some content from `main.scss`.
- Renamed `errorContent` to `errorPage`.
