### PR TITLE
Remove PayPal Button Query Param

### DIFF
--- a/app/controllers/OneOffContributions.scala
+++ b/app/controllers/OneOffContributions.scala
@@ -39,12 +39,11 @@ class OneOffContributions(
     )
   }
 
-  private def formHtml(idUser: Option[IdUser], paypal: Option[Boolean])(implicit request: RequestHeader) =
+  private def formHtml(idUser: Option[IdUser])(implicit request: RequestHeader) =
     oneOffContributions(
       title = "Support the Guardian | One-off Contribution",
       id = "oneoff-contributions-page",
       js = "oneoffContributionsPage.js",
-      payPalButton = paypal.getOrElse(true),
       defaultStripeConfig = stripeConfigProvider.get(false),
       uatStripeConfig = stripeConfigProvider.get(true),
       contributionsStripeEndpoint = contributionsStripeEndpoint,
@@ -52,14 +51,14 @@ class OneOffContributions(
       idUser = idUser
     )
 
-  def displayForm(paypal: Option[Boolean]): Action[AnyContent] = MaybeAuthenticatedAction.async { implicit request =>
+  def displayForm(): Action[AnyContent] = MaybeAuthenticatedAction.async { implicit request =>
     request.user.fold {
-      Future.successful(Ok(formHtml(None, paypal)))
+      Future.successful(Ok(formHtml(None)))
     } { minimalUser =>
       {
         identityService.getUser(minimalUser).fold(
-          _ => Ok(formHtml(None, paypal)),
-          user => Ok(formHtml(Some(user), paypal))
+          _ => Ok(formHtml(None)),
+          user => Ok(formHtml(Some(user)))
         )
       }
     }

--- a/app/controllers/RegularContributions.scala
+++ b/app/controllers/RegularContributions.scala
@@ -35,7 +35,7 @@ class RegularContributions(
 
   implicit val ar = assets
 
-  def displayForm(paypal: Option[Boolean]): Action[AnyContent] = AuthenticatedAction.async { implicit request =>
+  def displayForm(): Action[AnyContent] = AuthenticatedAction.async { implicit request =>
     identityService.getUser(request.user).semiflatMap { fullUser =>
       isMonthlyContributor(request.user.credentials) map {
         case Some(true) =>
@@ -50,7 +50,6 @@ class RegularContributions(
               js = "regularContributionsPage.js",
               user = fullUser,
               uatMode = uatMode,
-              payPalButton = paypal.getOrElse(true),
               defaultStripeConfig = stripeConfigProvider.get(false),
               uatStripeConfig = stripeConfigProvider.get(true),
               payPalConfig = payPalConfigProvider.get(uatMode)

--- a/app/views/monthlyContributions.scala.html
+++ b/app/views/monthlyContributions.scala.html
@@ -10,7 +10,6 @@
   js: String,
   user: IdUser,
   uatMode: Boolean,
-  payPalButton: Boolean,
   defaultStripeConfig: StripeConfig,
   uatStripeConfig: StripeConfig,
   payPalConfig: PayPalConfig
@@ -31,7 +30,6 @@
                 lastName: "@lastName",
             }
         };
-        window.guardian.payPalType = @payPalButton? 'ExpressCheckout' : 'NotSet';
         window.guardian.stripeKeyDefaultCurrencies = {
           default: "@defaultStripeConfig.forCurrency(None).publicKey",
           uat: "@uatStripeConfig.forCurrency(None).publicKey"

--- a/app/views/oneOffContributions.scala.html
+++ b/app/views/oneOffContributions.scala.html
@@ -7,7 +7,6 @@
         title: String,
         id: String,
         js: String,
-        payPalButton: Boolean,
         defaultStripeConfig: StripeConfig,
         uatStripeConfig: StripeConfig,
         contributionsStripeEndpoint: String,
@@ -41,7 +40,6 @@
         };
         window.guardian.contributionsStripeEndpoint = "@contributionsStripeEndpoint";
         window.guardian.contributionsPayPalEndpoint = "@contributionsPayPalEndpoint";
-        window.guardian.payPalType = @payPalButton ? 'ContributionsCheckout' : 'NotSet';
     </script>
 }
 

--- a/assets/pages/oneoff-contributions/__tests__/__snapshots__/oneoffContributionsReducersTest.js.snap
+++ b/assets/pages/oneoff-contributions/__tests__/__snapshots__/oneoffContributionsReducersTest.js.snap
@@ -1,7 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`One-off Reducer should handle CHECKOUT_ERROR 1`] = `"NotSet"`;
-
 exports[`One-off Reducer should handle SET_PAYPAL_BUTTON 1`] = `null`;
 
 exports[`One-off Reducer should return the initial state 1`] = `
@@ -16,7 +14,6 @@ Object {
   "oneoffContrib": Object {
     "amount": 20,
     "error": null,
-    "payPalType": "NotSet",
   },
   "user": Object {
     "displayName": "",

--- a/assets/pages/oneoff-contributions/__tests__/oneoffContributionsActionsTest.js
+++ b/assets/pages/oneoff-contributions/__tests__/oneoffContributionsActionsTest.js
@@ -1,8 +1,5 @@
 // @flow
-import {
-  checkoutError,
-  setPayPalButton,
-} from '../oneoffContributionsActions';
+import { checkoutError } from '../oneoffContributionsActions';
 
 
 describe('One-off actions', () => {
@@ -16,12 +13,4 @@ describe('One-off actions', () => {
     expect(checkoutError(message)).toEqual(expectedAction);
   });
 
-  it('should create an action to set the value of the PayPal button.', () => {
-    const value = 32.50;
-    const expectedAction = {
-      type: 'SET_PAYPAL_BUTTON',
-      value,
-    };
-    expect(setPayPalButton(value)).toEqual(expectedAction);
-  });
 });

--- a/assets/pages/oneoff-contributions/__tests__/oneoffContributionsReducersTest.js
+++ b/assets/pages/oneoff-contributions/__tests__/oneoffContributionsReducersTest.js
@@ -19,7 +19,6 @@ describe('One-off Reducer', () => {
     const newState = reducer(20, 'GBP')(undefined, action);
 
     expect(newState.oneoffContrib.error).toEqual(message);
-    expect(newState.oneoffContrib.payPalType).toMatchSnapshot();
   });
 
   it('should handle SET_PAYPAL_BUTTON', () => {
@@ -32,7 +31,6 @@ describe('One-off Reducer', () => {
 
     const newState = reducer(20, 'GBP')(undefined, action);
 
-    expect(newState.oneoffContrib.payPalType).toEqual(value);
     expect(newState.oneoffContrib.error).toMatchSnapshot();
   });
 

--- a/assets/pages/oneoff-contributions/components/oneoffContributionsPayment.jsx
+++ b/assets/pages/oneoff-contributions/components/oneoffContributionsPayment.jsx
@@ -23,8 +23,6 @@ import postCheckout from '../helpers/ajax';
 
 // ----- Types ----- //
 
-export type PayPalButtonType = 'ContributionsCheckout' | 'NotSet';
-
 type PropTypes = {
   dispatch: Function,
   email: string,

--- a/assets/pages/oneoff-contributions/oneOffContributionsReducers.js
+++ b/assets/pages/oneoff-contributions/oneOffContributionsReducers.js
@@ -12,7 +12,6 @@ import csrf from 'helpers/csrf/csrfReducer';
 
 import type { CommonState } from 'helpers/page/page';
 
-import type { PayPalButtonType } from './components/oneoffContributionsPayment';
 import type { Action } from './oneoffContributionsActions';
 
 
@@ -21,7 +20,6 @@ import type { Action } from './oneoffContributionsActions';
 export type State = {
   amount: number,
   error: ?string,
-  payPalType: PayPalButtonType,
 };
 
 export type CombinedState = {
@@ -43,7 +41,6 @@ function createOneOffContribReducer(amount: number) {
   const initialState: State = {
     amount,
     error: null,
-    payPalType: 'NotSet',
   };
 
   return function oneOffContribReducer(state: State = initialState, action: Action): State {
@@ -52,9 +49,6 @@ function createOneOffContribReducer(amount: number) {
 
       case 'CHECKOUT_ERROR':
         return Object.assign({}, state, { error: action.message });
-
-      case 'SET_PAYPAL_BUTTON':
-        return Object.assign({}, state, { payPalType: action.value });
 
       default:
         return state;

--- a/assets/pages/oneoff-contributions/oneoffContributions.jsx
+++ b/assets/pages/oneoff-contributions/oneoffContributions.jsx
@@ -18,7 +18,6 @@ import { getAmount } from 'helpers/checkouts';
 
 import ContributionsThankYouPageContainer from './components/contributionsThankYouPageContainer';
 import reducer from './oneOffContributionsReducers';
-import { setPayPalButton } from './oneoffContributionsActions';
 import OneOffContributionsPage from './components/oneOffContributionsPage';
 
 
@@ -37,7 +36,6 @@ const store = pageInit(
 );
 
 user.init(store.dispatch);
-store.dispatch(setPayPalButton(window.guardian.payPalType));
 
 const router = (
   <BrowserRouter>

--- a/assets/pages/oneoff-contributions/oneoffContributionsActions.js
+++ b/assets/pages/oneoff-contributions/oneoffContributionsActions.js
@@ -1,15 +1,8 @@
 // @flow
 
-// ----- Imports ----- //
-
-import type { PayPalButtonType } from './components/oneoffContributionsPayment';
-
-
 // ----- Types ----- //
 
-export type Action =
-  | { type: 'CHECKOUT_ERROR', message: ?string }
-  | { type: 'SET_PAYPAL_BUTTON', value: PayPalButtonType };
+export type Action = { type: 'CHECKOUT_ERROR', message: ?string };
 
 
 // ----- Actions ----- //
@@ -18,13 +11,7 @@ function checkoutError(message: ?string): Action {
   return { type: 'CHECKOUT_ERROR', message };
 }
 
-function setPayPalButton(value: PayPalButtonType): Action {
-  return { type: 'SET_PAYPAL_BUTTON', value };
-}
 
 // ----- Exports ----- //
 
-export {
-  checkoutError,
-  setPayPalButton,
-};
+export { checkoutError };

--- a/assets/pages/regular-contributions/__tests__/__snapshots__/regularContributionsReducersTest.js.snap
+++ b/assets/pages/regular-contributions/__tests__/__snapshots__/regularContributionsReducersTest.js.snap
@@ -1,8 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`One-off Reducer should handle CHECKOUT_ERROR 1`] = `"NotSet"`;
-
-exports[`One-off Reducer should handle CHECKOUT_ERROR 2`] = `"Failed"`;
+exports[`One-off Reducer should handle CHECKOUT_ERROR 1`] = `"Failed"`;
 
 exports[`One-off Reducer should handle SET_PAYPAL_BUTTON 1`] = `null`;
 
@@ -33,7 +31,6 @@ Object {
     "amount": 20,
     "error": null,
     "payPalHasLoaded": false,
-    "payPalType": "NotSet",
     "paymentMethod": "GBP",
     "paymentStatus": "NotStarted",
     "pollCount": 0,

--- a/assets/pages/regular-contributions/__tests__/regularContributionsActionsTest.js
+++ b/assets/pages/regular-contributions/__tests__/regularContributionsActionsTest.js
@@ -1,7 +1,6 @@
 // @flow
 import {
   checkoutError,
-  setPayPalButton,
   setPayPalHasLoaded,
   creatingContributor,
 } from '../regularContributionsActions';
@@ -16,15 +15,6 @@ describe('Regular contributions actions', () => {
       message,
     };
     expect(checkoutError(message)).toEqual(expectedAction);
-  });
-
-  it('should create an action to set the value of the PayPal button.', () => {
-    const value = 'NotSet';
-    const expectedAction = {
-      type: 'SET_PAYPAL_BUTTON',
-      value,
-    };
-    expect(setPayPalButton(value)).toEqual(expectedAction);
   });
 
   it('should create an action to set a value when PayPal has loaded', () => {

--- a/assets/pages/regular-contributions/__tests__/regularContributionsReducersTest.js
+++ b/assets/pages/regular-contributions/__tests__/regularContributionsReducersTest.js
@@ -19,7 +19,6 @@ describe('One-off Reducer', () => {
     const newState = reducer(20, 'GBP')(undefined, action);
 
     expect(newState.regularContrib.error).toEqual(message);
-    expect(newState.regularContrib.payPalType).toMatchSnapshot();
     expect(newState.regularContrib.paymentStatus).toMatchSnapshot();
   });
 
@@ -33,7 +32,6 @@ describe('One-off Reducer', () => {
 
     const newState = reducer(20, 'GBP')(undefined, action);
 
-    expect(newState.regularContrib.payPalType).toEqual(value);
     expect(newState.regularContrib.error).toMatchSnapshot();
   });
 

--- a/assets/pages/regular-contributions/components/regularContributionsPayment.jsx
+++ b/assets/pages/regular-contributions/components/regularContributionsPayment.jsx
@@ -26,8 +26,6 @@ import { emptyInputField } from '../../../helpers/utilities';
 
 export type PaymentStatus = 'NotStarted' | 'Pending' | 'PollingTimedOut' | 'Failed' | 'Success';
 
-export type PayPalButtonType = 'ExpressCheckout' | 'NotSet';
-
 type PropTypes = {
   dispatch: Function,
   email: string,

--- a/assets/pages/regular-contributions/regularContributions.jsx
+++ b/assets/pages/regular-contributions/regularContributions.jsx
@@ -21,7 +21,6 @@ import { detect as detectCountryGroup } from 'helpers/internationalisation/count
 import ContributionsThankYouPageContainer from './components/contributionsThankYouPageContainer';
 import RegularContributionsPage from './components/regularContributionsPage';
 import reducer from './regularContributionsReducers';
-import { setPayPalButton } from './regularContributionsActions';
 
 
 // ----- Page Startup ----- //
@@ -40,7 +39,6 @@ const store = pageInit(
 );
 
 user.init(store.dispatch);
-store.dispatch(setPayPalButton(window.guardian.payPalType));
 
 
 // ----- Render ----- //

--- a/assets/pages/regular-contributions/regularContributionsActions.js
+++ b/assets/pages/regular-contributions/regularContributionsActions.js
@@ -3,7 +3,6 @@
 // ----- Imports ----- //
 
 import type { PaymentMethod } from 'helpers/checkouts';
-import type { PayPalButtonType } from './components/regularContributionsPayment';
 
 
 // ----- Types ----- //
@@ -12,7 +11,6 @@ export type Action =
   | { type: 'CHECKOUT_PENDING', paymentMethod: PaymentMethod }
   | { type: 'CHECKOUT_SUCCESS', paymentMethod: PaymentMethod }
   | { type: 'CHECKOUT_ERROR', message: string }
-  | { type: 'SET_PAYPAL_BUTTON', value: PayPalButtonType }
   | { type: 'SET_PAYPAL_HAS_LOADED' }
   | { type: 'CREATING_CONTRIBUTOR' };
 
@@ -33,10 +31,6 @@ function checkoutError(specificError: ?string): Action {
   return { type: 'CHECKOUT_ERROR', message };
 }
 
-function setPayPalButton(value: PayPalButtonType): Action {
-  return { type: 'SET_PAYPAL_BUTTON', value };
-}
-
 function setPayPalHasLoaded(): Action {
   return { type: 'SET_PAYPAL_HAS_LOADED' };
 }
@@ -51,7 +45,6 @@ export {
   checkoutPending,
   checkoutSuccess,
   checkoutError,
-  setPayPalButton,
   setPayPalHasLoaded,
   creatingContributor,
 };

--- a/assets/pages/regular-contributions/regularContributionsReducers.js
+++ b/assets/pages/regular-contributions/regularContributionsReducers.js
@@ -14,7 +14,7 @@ import csrf from 'helpers/csrf/csrfReducer';
 import type { CommonState } from 'helpers/page/page';
 import type { PaymentMethod } from 'helpers/checkouts';
 import type { Action } from './regularContributionsActions';
-import type { PaymentStatus, PayPalButtonType } from './components/regularContributionsPayment';
+import type { PaymentStatus } from './components/regularContributionsPayment';
 
 // ----- Types ----- //
 
@@ -23,7 +23,6 @@ export type State = {
   error: ?string,
   paymentStatus: PaymentStatus,
   paymentMethod: ?PaymentMethod,
-  payPalType: PayPalButtonType,
   payPalHasLoaded: boolean,
   statusUri: ?string,
   pollCount: number,
@@ -51,7 +50,6 @@ function createRegularContribReducer(amount: number, paymentMethod: ?PaymentMeth
     error: null,
     paymentStatus: 'NotStarted',
     paymentMethod,
-    payPalType: 'NotSet',
     payPalHasLoaded: false,
     statusUri: null,
     pollCount: 0,
@@ -71,9 +69,6 @@ function createRegularContribReducer(amount: number, paymentMethod: ?PaymentMeth
 
       case 'CREATING_CONTRIBUTOR':
         return Object.assign({}, state, { paymentStatus: 'Pending' });
-
-      case 'SET_PAYPAL_BUTTON':
-        return Object.assign({}, state, { payPalType: action.value });
 
       case 'SET_PAYPAL_HAS_LOADED':
         return Object.assign({}, state, { payPalHasLoaded: true });

--- a/conf/routes
+++ b/conf/routes
@@ -41,20 +41,20 @@ GET  /int/contribute                                controllers.Application.cont
 GET  /nz/contribute                                 controllers.Application.contributionsLanding(id="contributions-landing-page-nz")
 GET  /ca/contribute                                 controllers.Application.contributionsLanding(id="contributions-landing-page-ca")
 
-GET  /contribute/recurring                          controllers.RegularContributions.displayForm(paypal: Option[Boolean])
-GET  /contribute/recurring/thankyou                 controllers.RegularContributions.displayForm(paypal: Option[Boolean])
+GET  /contribute/recurring                          controllers.RegularContributions.displayForm()
+GET  /contribute/recurring/thankyou                 controllers.RegularContributions.displayForm()
 GET  /contribute/recurring/existing                 controllers.Application.reactTemplate(title="Support the Guardian | Existing Contributor", id="regular-contributions-existing-page", js="regularContributionsExistingPage.js")
 POST /contribute/recurring/create                   controllers.RegularContributions.create
 GET  /contribute/recurring/status                   controllers.RegularContributions.status(jobId: String)
-GET  /contribute/recurring/pending                  controllers.RegularContributions.displayForm(paypal: Option[Boolean])
+GET  /contribute/recurring/pending                  controllers.RegularContributions.displayForm()
 
 # this endpoint should be removed once identity remove
 # the need for a client token
 POST  /contribute/send-marketing                     controllers.IdentityController.submitMarketing
 
 
-GET  /contribute/one-off                            controllers.OneOffContributions.displayForm(paypal: Option[Boolean])
-GET  /contribute/one-off/thankyou                   controllers.OneOffContributions.displayForm(paypal: Option[Boolean])
+GET  /contribute/one-off                            controllers.OneOffContributions.displayForm()
+GET  /contribute/one-off/thankyou                   controllers.OneOffContributions.displayForm()
 GET  /contribute/one-off/autofill                   controllers.OneOffContributions.autofill
 
 # ----- Subscriptions ----- #

--- a/test/controllers/RegularContributionsTest.scala
+++ b/test/controllers/RegularContributionsTest.scala
@@ -158,7 +158,7 @@ class RegularContributionsTest extends WordSpec with MustMatchers with TestCSRFC
           stripeConfigProvider,
           payPalConfigProvider,
           stubControllerComponents()
-        ).displayForm(paypal = None)(FakeRequest())
+        ).displayForm()(FakeRequest())
       }
     }
   }


### PR DESCRIPTION
## Why are you doing this?

This query param was originally used to hide the PayPal Express Checkout button for the apps, as this integration was buggy in webviews. However, the apps no longer direct traffic to our site in webviews, and the query param doesn't seem to work now in any case.

**Note:** This problem only occurred for the regular contributions checkout (where we use the Express Checkout integration). The query param was introduced for one-off in #163, to make the button visible only to developers while it was still under construction. We kept the logic around for a while because of a potential test, but it seems that test never happened and the logic has since been broken.

cc @JustinPinner 

## Changes

- Removed the query param logic from Play.
- Removed the state from the one-off and regular checkouts, and deleted the corresponding actions and reducers.
