### PR TITLE
Added CSRF Token To One-Off Template

### DIFF
--- a/app/views/oneOffContributions.scala.html
+++ b/app/views/oneOffContributions.scala.html
@@ -40,6 +40,7 @@
         };
         window.guardian.contributionsStripeEndpoint = "@contributionsStripeEndpoint";
         window.guardian.contributionsPayPalEndpoint = "@contributionsPayPalEndpoint";
+        window.guardian.csrf = { token: "@CSRF.getToken.value" };
     </script>
 }
 


### PR DESCRIPTION
## Why are you doing this?

The marketing preferences request made on the one-off thank you page has been consistently failing. It turns out that this is because the CSRF token was missing. I *think* this probably happened in #631, when the thank you page became part of the one-off contributions checkout. At this point the thank you page template, which had the CSRF token, was replaced by the one-off checkout template, which hadn't needed this token up to that point.

This wasn't being picked up by our logging until #635 was merged, as errors weren't being correctly reported until this point. However, from the point when Sentry started working again there is a clear spike in errors showing this problem.

## Changes

- Added token into template.
