### PR TITLE
Different Method For getAllQueryParamsWithExclusions For Old FF

### DIFF
--- a/assets/helpers/__tests__/urlTest.js
+++ b/assets/helpers/__tests__/urlTest.js
@@ -2,7 +2,12 @@
 
 // ----- Imports ----- //
 
-import { addQueryParamsToURL, getAbsoluteURL } from '../url';
+import {
+  addQueryParamsToURL,
+  getAbsoluteURL,
+  getAllQueryParams,
+  getAllQueryParamsWithExclusions,
+} from '../url';
 
 
 // ----- Tests ----- //
@@ -96,6 +101,49 @@ describe('url', () => {
       const expectedUrl = `${startingUrl}?spam=eggs&answer=42`;
 
       expect(addQueryParamsToURL(startingUrl, params)).toEqual(expectedUrl);
+
+    });
+
+  });
+
+  describe('getAllQueryParams', () => {
+
+    const baseUrl = 'https://support.thegulocal.com/uk';
+
+    it('should return an array of query params', () => {
+
+      jsdom.reconfigure({ url: `${baseUrl}?foo=bar&spam=eggs` });
+      expect(getAllQueryParams()).toEqual([['foo', 'bar'], ['spam', 'eggs']]);
+
+    });
+
+    it('should return an empty array if there are no params', () => {
+
+      jsdom.reconfigure({ url: `${baseUrl}` });
+      expect(getAllQueryParams()).toEqual([]);
+
+      jsdom.reconfigure({ url: `${baseUrl}?` });
+      expect(getAllQueryParams()).toEqual([]);
+
+    });
+
+    it('should ignore malformed params', () => {
+
+      jsdom.reconfigure({ url: `${baseUrl}?foo&spam=eggs` });
+      expect(getAllQueryParams()).toEqual([['spam', 'eggs']]);
+
+    });
+
+  });
+
+  describe('getAllQueryParamsWithExclusions', () => {
+
+    const baseUrl = 'https://support.thegulocal.com/uk';
+
+    it('should exclude query params', () => {
+
+      jsdom.reconfigure({ url: `${baseUrl}?foo=bar&spam=eggs` });
+      expect(getAllQueryParamsWithExclusions('foo')).toEqual([['spam', 'eggs']]);
 
     });
 

--- a/assets/helpers/url.js
+++ b/assets/helpers/url.js
@@ -34,9 +34,14 @@ const getQueryParameter = (paramName: string, defaultValue?: string): ?string =>
 
 };
 
-const getAllQueryParamsWithExclusions = (excluded: string[]): Array<[string, string]> => Array
-  .from(new URL(window.location).searchParams.entries())
-  .filter(p => excluded.indexOf(p[0]) === -1);
+// Drop leading '?'
+// Turn into array of 'param=value'
+// Turn each param into array of '[param, value]'
+const getAllQueryParams = (): Array<[string, string]> =>
+  window.location.search.slice(1).split('&').map(a => a.split('='));
+
+const getAllQueryParamsWithExclusions = (excluded: string[]): Array<[string, string]> =>
+  getAllQueryParams().filter(p => excluded.indexOf(p[0]) === -1);
 
 const addQueryParamToURL = (urlOrPath: string, paramsKey: string, paramsValue: ?string): string => {
 

--- a/assets/helpers/url.js
+++ b/assets/helpers/url.js
@@ -37,8 +37,13 @@ const getQueryParameter = (paramName: string, defaultValue?: string): ?string =>
 // Drop leading '?'
 // Turn into array of 'param=value'
 // Turn each param into array of '[param, value]'
+// Filter out items that are not key-value pairs
 const getAllQueryParams = (): Array<[string, string]> =>
-  window.location.search.slice(1).split('&').map(a => a.split('='));
+  window.location.search
+    .slice(1)
+    .split('&')
+    .map(a => a.split('='))
+    .filter(a => a.length === 2 && a.every(e => e !== ''));
 
 const getAllQueryParamsWithExclusions = (excluded: string[]): Array<[string, string]> =>
   getAllQueryParams().filter(p => excluded.indexOf(p[0]) === -1);
@@ -111,6 +116,7 @@ function getAbsoluteURL(path: string = ''): string {
 
 export {
   getQueryParameter,
+  getAllQueryParams,
   getAllQueryParamsWithExclusions,
   addQueryParamToURL,
   getBaseDomain,


### PR DESCRIPTION
## Why are you doing this?

Sentry is reporting quite a lot of users hitting errors with `URLSearchParams.entries()` on older versions of Firefox. Technically we only support FF 44 and up (which is when this [was introduced](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/entries#Browser_compatibility), and polyfill.io doesn't seem to provide a polyfill). However, it's a straightforward fix and it's one of our most common errors so I've just done it. Will probably add some tests before merging since we don't have any at the moment.

cc @JustinPinner 

## Changes

- Added new function to get all query params as an array of type `Array<[string, string]>`.
- Used new function for `getAllQueryParamsWithExclusions`.
- Added corresponding tests.
