### PR TITLE
Make existing contribution page more circles

### DIFF
--- a/assets/pages/regular-contributions-existing/regularContributionsExisting.jsx
+++ b/assets/pages/regular-contributions-existing/regularContributionsExisting.jsx
@@ -42,14 +42,14 @@ const content = (
                     Guardian - thank you. If you&#39;re feeling generous, there is
                     another way you can&nbsp;help.
                 </p>
+                <CtaLink
+                    ctaId="contribute-one-off-again"
+                    text="Make a one-off contribution"
+                    url={routes.oneOffContribCheckout}
+                    accessibilityHint="Further support the guardian over and above your current regular contribution"
+                />
             </PageSection>
         </div>
-        <CtaLink
-          ctaId="contribute-one-off-again"
-          text="Make a one-off contribution"
-          url={routes.oneOffContribCheckout}
-          accessibilityHint="Further support the guardian over and above your current regular contribution"
-        />
         <QuestionsContact />
       </div>
     </section>

--- a/assets/pages/regular-contributions-existing/regularContributionsExisting.jsx
+++ b/assets/pages/regular-contributions-existing/regularContributionsExisting.jsx
@@ -7,12 +7,14 @@ import React from 'react';
 import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
 import Footer from 'components/footer/footer';
 import CtaLink from 'components/ctaLink/ctaLink';
-import InfoSection from 'components/infoSection/infoSection';
+import QuestionsContact from 'components/questionsContact/questionsContact';
 
 import { routes } from 'helpers/routes';
 import { statelessInit as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
 import { contributionsEmail } from 'helpers/legal';
+import CirclesIntroduction from "../../components/introduction/circlesIntroduction";
+import PageSection from "../../components/pageSection/pageSection";
 
 
 // ----- Page Startup ----- //
@@ -22,31 +24,33 @@ pageInit();
 
 // ----- Render ----- //
 
+
 const content = (
   <div className="gu-content">
     <SimpleHeader />
+    <CirclesIntroduction
+      headings={['Whoops!']}
+    />
+    <div className="multiline-divider" />
+
     <section className="existing gu-content-filler">
       <div className="existing__content gu-content-filler__inner">
-        <div className="existing__wrapper">
-          <h1 className="existing__heading">Whoops!</h1>
-          <h2 className="existing__subheading">
-            Looks like you are already making a regular contribution to the
-            Guardian - thank you. If you&#39;re feeling generous, there is
-            another way you can&nbsp;help.
-          </h2>
-          <CtaLink
-            ctaId="contribute-one-off-again"
-            text="Make a one-off contribution"
-            url={routes.oneOffContribCheckout}
-            accessibilityHint="Further support the guardian over and above your current regular contribution"
-          />
+        <div className="component-existing-contribution">
+            <PageSection modifierClass="existing-contribution">
+                <p className="component-existing-contribition__copy">
+                    Looks like you are already making a regular contribution to the
+                    Guardian - thank you. If you&#39;re feeling generous, there is
+                    another way you can&nbsp;help.
+                </p>
+            </PageSection>
         </div>
-        <InfoSection heading="Questions?" className="existing__questions">
-          <p>
-            If you have any questions about contributing to the Guardian,
-            please <a href={contributionsEmail}>contact us</a>
-          </p>
-        </InfoSection>
+        <CtaLink
+          ctaId="contribute-one-off-again"
+          text="Make a one-off contribution"
+          url={routes.oneOffContribCheckout}
+          accessibilityHint="Further support the guardian over and above your current regular contribution"
+        />
+        <QuestionsContact />
       </div>
     </section>
     <Footer />

--- a/assets/pages/regular-contributions-existing/regularContributionsExisting.jsx
+++ b/assets/pages/regular-contributions-existing/regularContributionsExisting.jsx
@@ -12,9 +12,8 @@ import QuestionsContact from 'components/questionsContact/questionsContact';
 import { routes } from 'helpers/routes';
 import { statelessInit as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
-import { contributionsEmail } from 'helpers/legal';
-import CirclesIntroduction from "../../components/introduction/circlesIntroduction";
-import PageSection from "../../components/pageSection/pageSection";
+import CirclesIntroduction from '../../components/introduction/circlesIntroduction';
+import PageSection from '../../components/pageSection/pageSection';
 
 
 // ----- Page Startup ----- //
@@ -31,28 +30,23 @@ const content = (
     <CirclesIntroduction
       headings={['Whoops!']}
     />
-    <div className="multiline-divider" />
+    <div className="existing__content gu-content-filler__inner">
 
-    <section className="existing gu-content-filler">
-      <div className="existing__content gu-content-filler__inner">
-        <div className="component-existing-contribution">
-            <PageSection modifierClass="existing-contribution">
-                <p className="component-existing-contribition__copy">
-                    Looks like you are already making a regular contribution to the
-                    Guardian - thank you. If you&#39;re feeling generous, there is
-                    another way you can&nbsp;help.
-                </p>
-                <CtaLink
-                    ctaId="contribute-one-off-again"
-                    text="Make a one-off contribution"
-                    url={routes.oneOffContribCheckout}
-                    accessibilityHint="Further support the guardian over and above your current regular contribution"
-                />
-            </PageSection>
-        </div>
-        <QuestionsContact />
-      </div>
-    </section>
+      <PageSection modifierClass="existing-contribution">
+        <p className="existing-contribition-copy">
+            Looks like you are already making a regular contribution to the
+            Guardian - thank you. If you&#39;re feeling generous, there is
+            another way you can&nbsp;help.
+        </p>
+        <CtaLink
+          ctaId="contribute-one-off-again"
+          text="Make a one-off contribution"
+          url={routes.oneOffContribCheckout}
+          accessibilityHint="Further support the guardian over and above your current regular contribution"
+        />
+      </PageSection>
+    </div>
+    <QuestionsContact />
     <Footer />
   </div>
 );

--- a/assets/pages/regular-contributions-existing/regularContributionsExisting.jsx
+++ b/assets/pages/regular-contributions-existing/regularContributionsExisting.jsx
@@ -30,22 +30,19 @@ const content = (
     <CirclesIntroduction
       headings={['Whoops!']}
     />
-    <div className="existing__content gu-content-filler__inner">
-
-      <PageSection modifierClass="existing-contribution">
-        <p className="existing-contribition-copy">
-            Looks like you are already making a regular contribution to the
-            Guardian - thank you. If you&#39;re feeling generous, there is
-            another way you can&nbsp;help.
-        </p>
-        <CtaLink
-          ctaId="contribute-one-off-again"
-          text="Make a one-off contribution"
-          url={routes.oneOffContribCheckout}
-          accessibilityHint="Further support the guardian over and above your current regular contribution"
-        />
-      </PageSection>
-    </div>
+    <PageSection modifierClass="existing-contribution">
+      <p className="existing-contribition-copy">
+          Looks like you are already making a regular contribution to the
+          Guardian - thank you. If you&#39;re feeling generous, there is
+          another way you can&nbsp;help.
+      </p>
+      <CtaLink
+        ctaId="contribute-one-off-again"
+        text="Make a one-off contribution"
+        url={routes.oneOffContribCheckout}
+        accessibilityHint="Further support the guardian over and above your current regular contribution"
+      />
+    </PageSection>
     <QuestionsContact />
     <Footer />
   </div>

--- a/assets/pages/regular-contributions-existing/regularContributionsExisting.scss
+++ b/assets/pages/regular-contributions-existing/regularContributionsExisting.scss
@@ -24,32 +24,34 @@
 	}
 
 	.existing-contribution-copy {
-		padding-top: $gu-v-spacing / 2;
-		padding-bottom: $gu-v-spacing * 2;
+      padding-top: $gu-v-spacing / 2;
+      padding-bottom: $gu-v-spacing * 2;
 
-		@include mq($from: desktop) {
-			padding-left: $gu-h-spacing;
-		}
+      @include mq($from: desktop) {
+        padding-left: $gu-h-spacing;
+      }
 	}
 
 	.component-cta-link {
-		background-color: gu-colour(garnett-neutral-1);
-		border: 1px solid gu-colour(garnett-neutral-1);
-		color: #fff;
-		height: 54px;
-		line-height: 54px;
-		padding: 0 30px 0 25px;
-		transition: background-color .3s;
-		margin-bottom: $gu-v-spacing * 3;
-		margin-top: $gu-v-spacing * 2;
+      background-color: gu-colour(garnett-neutral-1);
+      border: 1px solid gu-colour(garnett-neutral-1);
+      color: #fff;
+      height: 54px;
+      line-height: 54px;
+      padding: 0 30px 0 25px;
+      transition: background-color .3s;
+      margin-bottom: $gu-v-spacing * 3;
+      margin-top: $gu-v-spacing * 2;
 
-		@include mq($from: mobileMedium) {
-			width: 300px;
-		}
+      @include mq($from: mobileMedium) {
+        width: 300px;
+      }
 
-		&:hover {
-			background-color: darken(gu-colour(garnett-neutral-1), 10%);
-		}
+      &:hover {
+        background-color: darken(gu-colour(garnett-neutral-1), 10%);
+      }
 	}
-
+  .component-questions-contact {
+    @include gu-content-filler;
+  }
 }

--- a/assets/pages/regular-contributions-existing/regularContributionsExisting.scss
+++ b/assets/pages/regular-contributions-existing/regularContributionsExisting.scss
@@ -3,34 +3,32 @@
 		@include multiline(4, gu-colour(garnett-neutral-4));
 	}
 
-	a {
-		color: gu-colour(neutral-1);
-	}
-
-	// ----- Headings
-
-	.existing {
-		//background-color: darken(gu-colour(garnett-neutral-3), 5%);
-		background-color: gu-colour(garnett-neutral-5);
-	}
-    //
-	.existing__content {
-		background-color: gu-colour(garnett-neutral-5);
-		padding: $gu-v-spacing $gu-h-spacing;
-	}
-
-	.existing__wrapper {
-
-		@include mq($from: desktop) {
-			margin-left: 20%;
-			margin-right: 20%;
-		}
-	}
-
 	.component-existing-contribution {
-      @include mq($from: desktop) {
-        //margin-left: 20%;
-        margin-right: 20%;
+
+      .component-page-section__heading {
+        font-family: $gu-egyptian-web;
+        font-size: 24px;
+        line-height: 1.17;
+        font-weight: bold;
+      }
+
+      .component-page-section__header {
+        position: relative;
+
+        @include dropline;
+      }
+
+      .component-page-section__body {
+        padding-top: $gu-v-spacing / 2;
+        padding-bottom: $gu-v-spacing * 2;
+
+        @include mq($from: desktop) {
+          padding-left: $gu-h-spacing;
+        }
+
+        @include mq($from: phablet) {
+          width: 500px;
+        }
       }
 
 	}
@@ -44,7 +42,6 @@
 		}
 	}
 
-	//todo I just copied this from marketingConsent.scss
 	.component-cta-link {
 		background-color: gu-colour(garnett-neutral-1);
 		border: 1px solid gu-colour(garnett-neutral-1);
@@ -63,10 +60,6 @@
 		&:hover {
 			background-color: darken(gu-colour(garnett-neutral-1), 10%);
 		}
-	}
-
-	.help-further {
-		margin-top: $gu-v-spacing * 4;
 	}
 
 }

--- a/assets/pages/regular-contributions-existing/regularContributionsExisting.scss
+++ b/assets/pages/regular-contributions-existing/regularContributionsExisting.scss
@@ -1,4 +1,7 @@
 #regular-contributions-existing-page {
+	.multiline-divider {
+		@include multiline(4, gu-colour(garnett-neutral-4));
+	}
 
 	a {
 		color: gu-colour(neutral-1);
@@ -7,11 +10,12 @@
 	// ----- Headings
 
 	.existing {
-		background-color: darken(gu-colour(multimedia-main-2), 5%);
+		//background-color: darken(gu-colour(garnett-neutral-3), 5%);
+		background-color: gu-colour(garnett-neutral-5);
 	}
-
+    //
 	.existing__content {
-		background-color: gu-colour(multimedia-main-2);
+		background-color: gu-colour(garnett-neutral-5);
 		padding: $gu-v-spacing $gu-h-spacing;
 	}
 
@@ -23,55 +27,41 @@
 		}
 	}
 
-	.existing__heading {
-		font-family: $gu-egyptian-web;
-		color: gu-colour(neutral-1);
-		font-size: 28px;
-		line-height: 32px;
-		font-weight: bold;
+	.component-existing-contribution {
+      @include mq($from: desktop) {
+        //margin-left: 20%;
+        margin-right: 20%;
+      }
+
+	}
+
+	.component-existing-contribution__copy {
+		padding-top: $gu-v-spacing / 2;
+		padding-bottom: $gu-v-spacing * 2;
 
 		@include mq($from: desktop) {
-			font-size: 36px;
-			line-height: 40px;
+			padding-left: $gu-h-spacing;
 		}
 	}
 
-	.existing__subheading {
-		font-family: $gu-egyptian-web;
-		font-size: 28px;
-		line-height: 32px;
-		font-weight: lighter;
-		color: gu-colour(neutral-1);
-
-		@include mq($from: desktop) {
-			font-size: 36px;
-			line-height: 40px;
-		}
-	}
-
+	//todo I just copied this from marketingConsent.scss
 	.component-cta-link {
-		color: gu-colour(neutral-1);
-		background: transparent;
-		display: inline-block;
-		width: 200px;
-		border: 1px solid gu-colour(neutral-1);
-		font-weight: normal;
-		margin-bottom: $gu-v-spacing * 4;
-		margin-top: 2 * $gu-v-spacing;
+		background-color: gu-colour(garnett-neutral-1);
+		border: 1px solid gu-colour(garnett-neutral-1);
+		color: #fff;
+		height: 54px;
+		line-height: 54px;
+		padding: 0 30px 0 25px;
+		transition: background-color .3s;
+		margin-bottom: $gu-v-spacing * 3;
+		margin-top: $gu-v-spacing * 2;
 
-		svg {
-			fill: gu-colour(neutral-1);
-			// Fix for IE10.
-			left: 210px;
+		@include mq($from: mobileMedium) {
+			width: 300px;
 		}
 
 		&:hover {
-			border-color: #000;
-			color: #000;
-
-			svg {
-				fill: #000;
-			}
+			background-color: darken(gu-colour(garnett-neutral-1), 10%);
 		}
 	}
 

--- a/assets/pages/regular-contributions-existing/regularContributionsExisting.scss
+++ b/assets/pages/regular-contributions-existing/regularContributionsExisting.scss
@@ -1,56 +1,67 @@
 #regular-contributions-existing-page {
-	.component-page-section--existing-contribution {
-      @include multiline-top-border;
 
-      .component-page-section__header {
-        position: relative;
+  .component-page-section--existing-contribution {
+    @include multiline-top-border;
 
-        @include dropline;
-      }
+    .component-page-section__header {
+      position: relative;
+      @include dropline;
+    }
 
-      .component-page-section__body {
-        padding-top: $gu-v-spacing / 2;
-        padding-bottom: $gu-v-spacing * 2;
-
-        @include mq($from: desktop) {
-          padding-left: $gu-h-spacing;
-        }
-
-        @include mq($from: phablet) {
-          width: 500px;
-        }
-      }
-
-	}
-
-	.existing-contribution-copy {
+    .component-page-section__body {
       padding-top: $gu-v-spacing / 2;
       padding-bottom: $gu-v-spacing * 2;
 
       @include mq($from: desktop) {
         padding-left: $gu-h-spacing;
       }
-	}
 
-	.component-cta-link {
-      background-color: gu-colour(garnett-neutral-1);
-      border: 1px solid gu-colour(garnett-neutral-1);
-      color: #fff;
-      height: 54px;
-      line-height: 54px;
-      padding: 0 30px 0 25px;
-      transition: background-color .3s;
-      margin-bottom: $gu-v-spacing * 3;
-      margin-top: $gu-v-spacing * 2;
-
-      @include mq($from: mobileMedium) {
-        width: 300px;
+      @include mq($from: phablet) {
+        width: 500px;
       }
+    }
+  }
 
-      &:hover {
-        background-color: darken(gu-colour(garnett-neutral-1), 10%);
-      }
-	}
+  .existing-contribution-copy {
+    padding-top: $gu-v-spacing / 2;
+    padding-bottom: $gu-v-spacing * 2;
+
+    @include mq($from: desktop) {
+      padding-left: $gu-h-spacing;
+    }
+  }
+
+  .component-cta-link {
+    background-color: gu-colour(garnett-neutral-1);
+    border: 1px solid gu-colour(garnett-neutral-1);
+    color: #fff;
+    height: 54px;
+    line-height: 54px;
+    padding: 0 30px 0 25px;
+    transition: background-color .3s;
+    margin-bottom: $gu-v-spacing * 3;
+    margin-top: $gu-v-spacing * 2;
+
+    @include mq($from: mobileMedium) {
+      width: 300px;
+    }
+
+    &:hover {
+      background-color: darken(gu-colour(garnett-neutral-1), 10%);
+    }
+  }
+
+  .svg-arrow-right-straight {
+    height: 35%;
+    top: 17px;
+    right: 13px;
+
+    // Fix for IE.
+    @include mq($from: mobileMedium) {
+      left: 321px;
+    }
+  }
+
   .component-questions-contact {
     @include gu-content-filler;
   }

--- a/assets/pages/regular-contributions-existing/regularContributionsExisting.scss
+++ b/assets/pages/regular-contributions-existing/regularContributionsExisting.scss
@@ -1,16 +1,6 @@
 #regular-contributions-existing-page {
-	.multiline-divider {
-		@include multiline(4, gu-colour(garnett-neutral-4));
-	}
-
-	.component-existing-contribution {
-
-      .component-page-section__heading {
-        font-family: $gu-egyptian-web;
-        font-size: 24px;
-        line-height: 1.17;
-        font-weight: bold;
-      }
+	.component-page-section--existing-contribution {
+      @include multiline-top-border;
 
       .component-page-section__header {
         position: relative;
@@ -33,7 +23,7 @@
 
 	}
 
-	.component-existing-contribution__copy {
+	.existing-contribution-copy {
 		padding-top: $gu-v-spacing / 2;
 		padding-bottom: $gu-v-spacing * 2;
 


### PR DESCRIPTION
## Why are you doing this?
When someone is already a recurring contributor, if they try to contribute again, they get directed to an error page inviting them to make a one-off contribution.

This should page should look like the rest of the site.

As a part of this card, we are also going to invite them to go to manage my account and change the recurring contribution instead, but I'm going to do this in two PRs because I'm looking to do the smallest change possible first. 

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/TWCHaftV/1469-existing-contributor)

## Changes

* Update the existing contribution page based on the thank-you page. 

## Screenshots
existing page
![image](https://user-images.githubusercontent.com/3072877/39639122-434764a8-4fc0-11e8-90c8-5e72dc150c1e.png)
page based on thank-you page
![image](https://user-images.githubusercontent.com/3072877/39639338-de414f14-4fc0-11e8-90e5-e4ce35debaee.png)

