### PR TITLE
Move subscribe routes into separate controller

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -58,21 +58,6 @@ class Application(
     Redirect(redirectUrl, request.queryString, status = FOUND)
   }
 
-  def subscribeGeoRedirect: Action[AnyContent] = GeoTargetedCachedAction() { implicit request =>
-    val redirectUrl = request.fastlyCountry match {
-      case Some(UK) => "/uk/subscribe"
-      case _ => "https://subscribe.theguardian.com"
-    }
-
-    Redirect(redirectUrl, request.queryString, status = FOUND)
-  }
-
-  def subscribeRedirect(countryCode: String): Action[AnyContent] = CachedAction() { implicit request =>
-    // Country code is required here because it's a parameter in the route.
-    // But we don't actually use it.
-    Redirect("https://subscribe.theguardian.com", request.queryString, status = FOUND)
-  }
-
   def redirect(location: String): Action[AnyContent] = CachedAction() { implicit request =>
     Redirect(location, request.queryString, status = FOUND)
   }
@@ -106,10 +91,6 @@ class Application(
       css = "contributionsLandingPageStyles.css",
       paymentApiPayPalEndpoint = paymentAPIService.payPalCreatePaymentEndpoint
     ))
-  }
-
-  def subscriptionsLanding(title: String, id: String, js: String): Action[AnyContent] = CachedAction() { implicit request =>
-    Ok(views.html.main(title, id, js, description = Some(stringsConfig.subscriptionsLandingDescription)))
   }
 
   def reactTemplate(title: String, id: String, js: String): Action[AnyContent] = CachedAction() { implicit request =>

--- a/app/controllers/Subscriptions.scala
+++ b/app/controllers/Subscriptions.scala
@@ -20,7 +20,7 @@ class Subscriptions(
 
   implicit val ar = assets
 
-  def subscribeGeoRedirect: Action[AnyContent] = GeoTargetedCachedAction() { implicit request =>
+  def geoRedirect: Action[AnyContent] = GeoTargetedCachedAction() { implicit request =>
     val redirectUrl = request.fastlyCountry match {
       case Some(UK) => "/uk/subscribe"
       case _ => "https://subscribe.theguardian.com"
@@ -29,13 +29,13 @@ class Subscriptions(
     Redirect(redirectUrl, request.queryString, status = FOUND)
   }
 
-  def subscribeRedirect(countryCode: String): Action[AnyContent] = CachedAction() { implicit request =>
+  def legacyRedirect(countryCode: String): Action[AnyContent] = CachedAction() { implicit request =>
     // Country code is required here because it's a parameter in the route.
     // But we don't actually use it.
     Redirect("https://subscribe.theguardian.com", request.queryString, status = FOUND)
   }
 
-  def subscriptionsLanding(title: String, id: String, js: String): Action[AnyContent] = CachedAction() { implicit request =>
+  def landing(title: String, id: String, js: String): Action[AnyContent] = CachedAction() { implicit request =>
     Ok(views.html.main(title, id, js, description = Some(stringsConfig.subscriptionsLandingDescription)))
   }
 }

--- a/app/controllers/Subscriptions.scala
+++ b/app/controllers/Subscriptions.scala
@@ -1,0 +1,41 @@
+package controllers
+
+import actions.CustomActionBuilders
+import assets.AssetsResolver
+import com.gu.i18n.CountryGroup._
+import config.StringsConfig
+import play.api.mvc._
+import utils.RequestCountry._
+
+import scala.concurrent.ExecutionContext
+
+class Subscriptions(
+    actionRefiners: CustomActionBuilders,
+    val assets: AssetsResolver,
+    components: ControllerComponents,
+    stringsConfig: StringsConfig
+)(implicit val ec: ExecutionContext) extends AbstractController(components) {
+
+  import actionRefiners._
+
+  implicit val ar = assets
+
+  def subscribeGeoRedirect: Action[AnyContent] = GeoTargetedCachedAction() { implicit request =>
+    val redirectUrl = request.fastlyCountry match {
+      case Some(UK) => "/uk/subscribe"
+      case _ => "https://subscribe.theguardian.com"
+    }
+
+    Redirect(redirectUrl, request.queryString, status = FOUND)
+  }
+
+  def subscribeRedirect(countryCode: String): Action[AnyContent] = CachedAction() { implicit request =>
+    // Country code is required here because it's a parameter in the route.
+    // But we don't actually use it.
+    Redirect("https://subscribe.theguardian.com", request.queryString, status = FOUND)
+  }
+
+  def subscriptionsLanding(title: String, id: String, js: String): Action[AnyContent] = CachedAction() { implicit request =>
+    Ok(views.html.main(title, id, js, description = Some(stringsConfig.subscriptionsLandingDescription)))
+  }
+}

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -45,6 +45,7 @@ trait AppComponents extends PlayComponents
     regularContributionsController,
     identityController,
     oneOffContributions,
+    subscriptionsController,
     loginController,
     testUsersController,
     payPalNvpController,

--- a/app/wiring/Controllers.scala
+++ b/app/wiring/Controllers.scala
@@ -17,6 +17,13 @@ trait Controllers {
     stringsConfig
   )
 
+  lazy val subscriptionsController = new Subscriptions(
+    actionRefiners,
+    assetsResolver,
+    controllerComponents,
+    stringsConfig
+  )
+
   lazy val regularContributionsController = new RegularContributions(
     regularContributionsClient,
     assetsResolver,

--- a/conf/routes
+++ b/conf/routes
@@ -58,12 +58,12 @@ GET  /contribute/one-off/thankyou                   controllers.OneOffContributi
 GET  /contribute/one-off/autofill                   controllers.OneOffContributions.autofill
 
 # ----- Subscriptions ----- #
-GET  /subscribe                                    controllers.Subscriptions.subscribeGeoRedirect()
-GET  /uk/subscribe                                 controllers.Subscriptions.subscriptionsLanding(title="Support the Guardian | Get a Subscription", id="subscriptions-landing-page", js="subscriptionsLandingPage.js")
+GET  /subscribe                                    controllers.Subscriptions.geoRedirect()
+GET  /uk/subscribe                                 controllers.Subscriptions.landing(title="Support the Guardian | Get a Subscription", id="subscriptions-landing-page", js="subscriptionsLandingPage.js")
 
 # This is just a fallback in case someone accidentally uses an unsupported country-specific
 # subscribe route. We just redirect to the subscriptions site and let its geolocation handle it.
-GET  /:countryCode/subscribe                       controllers.Subscriptions.subscribeRedirect(countryCode: String)
+GET  /:countryCode/subscribe                       controllers.Subscriptions.legacyRedirect(countryCode: String)
 
 
 # ----- Authentication ----- #

--- a/conf/routes
+++ b/conf/routes
@@ -58,13 +58,12 @@ GET  /contribute/one-off/thankyou                   controllers.OneOffContributi
 GET  /contribute/one-off/autofill                   controllers.OneOffContributions.autofill
 
 # ----- Subscriptions ----- #
-
-GET  /subscribe                                    controllers.Application.subscribeGeoRedirect()
-GET  /uk/subscribe                                 controllers.Application.subscriptionsLanding(title="Support the Guardian | Get a Subscription", id="subscriptions-landing-page", js="subscriptionsLandingPage.js")
+GET  /subscribe                                    controllers.Subscriptions.subscribeGeoRedirect()
+GET  /uk/subscribe                                 controllers.Subscriptions.subscriptionsLanding(title="Support the Guardian | Get a Subscription", id="subscriptions-landing-page", js="subscriptionsLandingPage.js")
 
 # This is just a fallback in case someone accidentally uses an unsupported country-specific
 # subscribe route. We just redirect to the subscriptions site and let its geolocation handle it.
-GET  /:countryCode/subscribe                       controllers.Application.subscribeRedirect(countryCode: String)
+GET  /:countryCode/subscribe                       controllers.Subscriptions.subscribeRedirect(countryCode: String)
 
 
 # ----- Authentication ----- #


### PR DESCRIPTION
## Why are you doing this?

The generic Application file is started to grow, and we will soon be adding more routes for the digipack so now seems like a good time to split the subs routes into a separate file.
