### PR TITLE
Make acquisition data for one-off Paypal payment non-optional

### DIFF
--- a/app/services/PaymentAPIService.scala
+++ b/app/services/PaymentAPIService.scala
@@ -10,7 +10,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 case class ExecutePaymentBody(
     signedInUserEmail: Option[String],
-    acquisitionData: Option[JsValue],
+    acquisitionData: JsValue,
     paymentData: JsObject
 )
 
@@ -59,7 +59,7 @@ class PaymentAPIService(wsClient: WSClient, paymentAPIUrl: String) {
 
   def execute(
     paymentJSON: JsObject,
-    acquisitionData: Option[JsValue],
+    acquisitionData: JsValue,
     queryStrings: Map[String, Seq[String]],
     email: Option[String],
     isTestUser: Boolean


### PR DESCRIPTION
## Why are you doing this?

There have been 13 instances where the user has been unable to make a payment using Paypal - log message:

```
[ERROR] from controllers.PaypalController in application-akka.actor.default-dispatcher-2464 - unable to decode JSON. io.circe.DecodingFailure$$anon$2: Attempt to decode value on failed cursor: DownField(acquisitionData)
```

This is due to the acquisition data field being modelled as optional in support frontend, but required by the Payment API. In the instance the acquisition data can't be derived from the `acquisition_data` cookie, the fallback acquisition data - `{"platform": "SUPPORT"}` - is provided.

## Changes

* make acquisition data for a one-off contribution with Paypal request required
* provide fallback acquisition data in the instance it can't be derived from the `acquisition_data` cookie

## Note

I don't know under what circumstances the acquisition data can't be derived from the `acquisition_data` cookie. I've tried making a one-off contribution with Paypal with no `acquisition_data` cookie set, but it ended up being set before the call to execute the payment was made, resulting in acquisition data being included in the request.
