### PR TITLE
Swap the order of the payment ctas on the support landing page

### DIFF
--- a/assets/pages/support-landing/components/contributionPaymentCtasContainer.js
+++ b/assets/pages/support-landing/components/contributionPaymentCtasContainer.js
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import ContributionPaymentCtas from 'components/contributionPaymentCtas/contributionPaymentCtas';
 import { getAmount } from 'containerisableComponents/contributionSelection/contributionSelectionReducer';
 import { payPalContributionButtonActionsFor } from 'containerisableComponents/payPalContributionButton/payPalContributionButtonActions';
-
+import { inPaymentLogosTest } from 'helpers/abTests/abtest';
 import type { State } from '../supportLandingReducer';
 
 
@@ -23,6 +23,7 @@ function mapStateToProps(state: State) {
     currency: state.common.currency,
     isDisabled: !!state.page.selection.error,
     error: state.page.payPal.error,
+    isInPaymentLogosVariant: inPaymentLogosTest(state.common.abParticipations),
   };
 
 }

--- a/assets/pages/support-landing/components/payPalContributionButtonContainer.js
+++ b/assets/pages/support-landing/components/payPalContributionButtonContainer.js
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 import PayPalContributionButton from 'containerisableComponents/payPalContributionButton/payPalContributionButton';
 import { payPalContributionButtonActionsFor } from 'containerisableComponents/payPalContributionButton/payPalContributionButtonActions';
 import { getAmount } from 'containerisableComponents/contributionSelection/contributionSelectionReducer';
+import { inPaymentLogosTest } from 'helpers/abTests/abtest';
 
 import type { State } from '../supportLandingReducer';
 
@@ -14,13 +15,14 @@ import type { State } from '../supportLandingReducer';
 // ----- State Maps ----- //
 
 function mapStateToProps(state: State) {
-
+  const inLogosTest = inPaymentLogosTest(state.common.abParticipations);
   return {
     amount: getAmount(state.page.selection),
     countryGroupId: state.common.countryGroup,
     referrerAcquisitionData: state.common.referrerAcquisitionData,
     abParticipations: state.common.abParticipations,
     isoCountry: state.common.country,
+    inPaymentLogosTest: inLogosTest,
     canClick: !state.page.selection.error,
   };
 


### PR DESCRIPTION
## Why are you doing this?
Fixes a bug caused by the payment logos AB test whereby the payment logos on the support landing test are against the wrong ctas

## Screenshots
### Before
![screen shot 2018-05-11 at 15 17 53](https://user-images.githubusercontent.com/181371/39928931-94c34d74-552e-11e8-99bb-8237b6783333.png)
### After
![screen shot 2018-05-11 at 15 18 06](https://user-images.githubusercontent.com/181371/39928930-94a72964-552e-11e8-9887-47d34e05fb14.png)

