### PR TITLE
Add 'from' into the price descriptions for Paper and Paper+Digital

### DIFF
--- a/assets/components/threeSubscriptions/threeSubscriptions.jsx
+++ b/assets/components/threeSubscriptions/threeSubscriptions.jsx
@@ -84,7 +84,7 @@ function PaperBundle(props: { url: string }) {
     <SubscriptionBundle
       modifierClass="paper"
       heading="Paper"
-      subheading={`£${getPrice('paper', '10.36')}/month`}
+      subheading={`from £${getPrice('paper', '10.36')}/month`}
       benefits={getPaperBenefits()}
       ctaText="Get a paper subscription"
       ctaUrl={props.url}
@@ -106,7 +106,7 @@ function PaperDigitalBundle(props: { url: string }) {
     <SubscriptionBundle
       modifierClass="paper-digital"
       heading="Paper+digital"
-      subheading={`£${getPrice('paperAndDigital', '21.62')}/month`}
+      subheading={`from £${getPrice('paperAndDigital', '21.62')}/month`}
       benefits={getPaperDigitalBenefits()}
       ctaText="Get a paper+digital subscription"
       ctaUrl={props.url}


### PR DESCRIPTION
## Why are you doing this?

The word 'from' was accidentally dropped from the price descriptions in the May 2018 flash sale. This puts it back.