### PR TITLE
Use a more restrictive SSM policy

### DIFF
--- a/cloud-formation/cfn.yaml
+++ b/cloud-formation/cfn.yaml
@@ -84,7 +84,8 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       Path: "/"
-      ManagedPolicyArns: [ "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM" ]
+      ManagedPolicyArns:
+      - !Sub arn:aws:iam::${AWS::AccountId}:policy/guardian-ec2-role-for-ssm
       AssumeRolePolicyDocument:
         Statement:
           - Effect: Allow

--- a/cloud-formation/cfn.yaml
+++ b/cloud-formation/cfn.yaml
@@ -20,7 +20,7 @@ Parameters:
     Type: String
     Default: frontend
   AMI:
-    Description: AMI ID
+    Description: AMI ID (may be replaced by RiffRaff for latest baked AMI)
     Type: String
     Default: ami-0eb88168
 Conditions:


### PR DESCRIPTION
## Why are you doing this?
The default SSM policy is too open, we should be able to reuse a more restrictive version.

Done as part of [**This Trello card**](https://trello.com/c/kizmbanA/1494-use-ssm-instead-of-github-for-ssh-access)
## Changes
* Modify `cfn.yaml` to use `guardian-ec2-role-for-ssm`
* Updated the description of the AMI section to say why the ID may not match any existing AMI

## Screenshots
N/A: Proof will be the ability to `ssm ssh` to a code instance after this is cloud-formed 

## Tested on CODE
Well, that's a bit harsh
![screen shot 2018-05-16 at 14 10 16](https://user-images.githubusercontent.com/690395/40118870-041eeb1e-5913-11e8-9eec-4746d1cb7214.png)
