### PR TITLE
Post contributions clean up

### DIFF
--- a/app/config/Configuration.scala
+++ b/app/config/Configuration.scala
@@ -27,13 +27,11 @@ class Configuration {
 
   lazy val paymentApiUrl = config.getString("paymentApi.url");
 
-  lazy val contributionsFrontendUrl = config.getString("contribution.url")
-
   lazy val membersDataServiceApiUrl = config.getString("membersDataService.api.url")
 
   lazy val goCardlessConfigProvider = new GoCardlessConfigProvider(config, stage)
 
-  lazy val payPalConfigProvider = new PayPalConfigProvider(config, stage)
+  lazy val payPalNvpConfigProvider = new PayPalConfigProvider(config, stage)
 
   lazy val regularStripeConfigProvider = new StripeConfigProvider(config, stage)
 

--- a/app/config/Configuration.scala
+++ b/app/config/Configuration.scala
@@ -31,7 +31,7 @@ class Configuration {
 
   lazy val goCardlessConfigProvider = new GoCardlessConfigProvider(config, stage)
 
-  lazy val payPalNvpConfigProvider = new PayPalConfigProvider(config, stage)
+  lazy val regularPayPalConfigProvider = new PayPalConfigProvider(config, stage)
 
   lazy val regularStripeConfigProvider = new StripeConfigProvider(config, stage)
 

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -48,8 +48,8 @@ trait AppComponents extends PlayComponents
     subscriptionsController,
     loginController,
     testUsersController,
-    payPalNvpController,
-    payPalRestController,
+    payPalRegularController,
+    payPalOneOffController,
     directDebitController,
     assetController
   )

--- a/app/wiring/Controllers.scala
+++ b/app/wiring/Controllers.scala
@@ -32,11 +32,11 @@ trait Controllers {
     identityService,
     testUsers,
     appConfig.regularStripeConfigProvider,
-    appConfig.payPalConfigProvider,
+    appConfig.payPalNvpConfigProvider,
     controllerComponents
   )
 
-  lazy val payPalNvpController = new PayPalRegular(
+  lazy val payPalRegularController = new PayPalRegular(
     actionRefiners,
     assetsResolver,
     payPalNvpServiceProvider,
@@ -44,7 +44,7 @@ trait Controllers {
     controllerComponents
   )
 
-  lazy val payPalRestController = new PayPalOneOff(
+  lazy val payPalOneOffController = new PayPalOneOff(
     actionRefiners,
     assetsResolver,
     testUsers,

--- a/app/wiring/Controllers.scala
+++ b/app/wiring/Controllers.scala
@@ -32,7 +32,7 @@ trait Controllers {
     identityService,
     testUsers,
     appConfig.regularStripeConfigProvider,
-    appConfig.payPalNvpConfigProvider,
+    appConfig.regularPayPalConfigProvider,
     controllerComponents
   )
 

--- a/app/wiring/Services.scala
+++ b/app/wiring/Services.scala
@@ -14,7 +14,7 @@ trait Services {
 
   lazy val membersDataService = MembersDataService(appConfig.membersDataServiceApiUrl)
 
-  lazy val payPalNvpServiceProvider = new PayPalNvpServiceProvider(appConfig.payPalNvpConfigProvider, wsClient)
+  lazy val payPalNvpServiceProvider = new PayPalNvpServiceProvider(appConfig.regularPayPalConfigProvider, wsClient)
 
   lazy val identityService = IdentityService(appConfig.identity)
 

--- a/app/wiring/Services.scala
+++ b/app/wiring/Services.scala
@@ -14,7 +14,7 @@ trait Services {
 
   lazy val membersDataService = MembersDataService(appConfig.membersDataServiceApiUrl)
 
-  lazy val payPalNvpServiceProvider = new PayPalNvpServiceProvider(appConfig.payPalConfigProvider, wsClient)
+  lazy val payPalNvpServiceProvider = new PayPalNvpServiceProvider(appConfig.payPalNvpConfigProvider, wsClient)
 
   lazy val identityService = IdentityService(appConfig.identity)
 

--- a/conf/CODE.public.conf
+++ b/conf/CODE.public.conf
@@ -13,7 +13,6 @@ identity.production.keys=false
 identity.useStub=false
 guardianDomain=".code.dev-theguardian.com"
 support.url="https://support.code.dev-theguardian.com"
-contribution.url="https://contribute.code.dev-theguardian.com"
 googleAuth.redirectUrl = "https://support.code.dev-theguardian.com/oauth2callback"
 paymentApi.url="https://payment.code.dev-guardianapis.com"
 membersDataService.api.url="https://members-data-api.code.dev-theguardian.com"

--- a/conf/DEV.public.conf
+++ b/conf/DEV.public.conf
@@ -13,7 +13,6 @@ identity.production.keys=false
 identity.useStub=false
 guardianDomain=".thegulocal.com"
 support.url="https://support.thegulocal.com"
-contribution.url="https://contribute.thegulocal.com"
 googleAuth.redirectUrl = "https://support.thegulocal.com/oauth2callback"
 paymentApi.url="https://payment.code.dev-guardianapis.com"
 membersDataService.api.url="https://members-data-api.thegulocal.com"

--- a/conf/PROD.public.conf
+++ b/conf/PROD.public.conf
@@ -12,7 +12,6 @@ identity.api.url="https://idapi.theguardian.com"
 identity.production.keys=true
 guardianDomain=".theguardian.com"
 support.url="https://support.theguardian.com"
-contribution.url="https://contribute.theguardian.com"
 googleAuth.redirectUrl = "https://support.theguardian.com/oauth2callback"
 paymentApi.url="https://payment.guardianapis.com"
 membersDataService.api.url="https://members-data-api.theguardian.com"

--- a/test/selenium/conf/selenium-test.conf
+++ b/test/selenium/conf/selenium-test.conf
@@ -7,7 +7,6 @@ identity {
   test.users.secret = ${?IDENTITY_TEST_USERS_SECRET}
 }
 support.url = ${?SUPPORT_URL}
-contribution.url = ${?CONTRIBUTION_URL}
 web.driver.remote.url = ${?WEBDRIVER_REMOTE_URL}
 guardianDomain = ${?GUARDIAN_DOMAIN}
 

--- a/test/selenium/util/Config.scala
+++ b/test/selenium/util/Config.scala
@@ -17,8 +17,6 @@ object Config {
 
   val identityFrontendUrl = conf.getString("identity.webapp.url")
 
-  val contributionFrontend = conf.getString("contribution.url")
-
   val waitTimeout = 45
 
   val paypalSandbox = conf.getString("paypal.sandbox.url")

--- a/test/selenium/util/Dependencies.scala
+++ b/test/selenium/util/Dependencies.scala
@@ -23,10 +23,6 @@ object Dependencies {
     val url = s"${Config.identityFrontendUrl}/signin"
   }
 
-  object ContributionFrontend extends Availability {
-    val url = s"${Config.contributionFrontend}"
-  }
-
   def dependencyCheck: Unit = {
     assume(
       SupportFrontend.isAvailable,
@@ -35,10 +31,6 @@ object Dependencies {
     assume(
       IdentityFrontend.isAvailable,
       s"- ${Dependencies.IdentityFrontend.url} is unavailable! Please run identity-frontend locally before running these tests."
-    )
-    assume(
-      ContributionFrontend.isAvailable,
-      s"${Dependencies.ContributionFrontend.url} is unavailable! Please run contribution-frontend locally before running these tests."
     )
   }
 

--- a/test/selenium/util/DriverConfig.scala
+++ b/test/selenium/util/DriverConfig.scala
@@ -35,9 +35,6 @@ class DriverConfig {
     webDriver.get(Config.paypalSandbox)
     webDriver.manage.deleteAllCookies()
 
-    webDriver.get(Config.contributionFrontend)
-    webDriver.manage.deleteAllCookies()
-
     webDriver.get(Config.identityFrontendUrl)
     webDriver.manage.deleteAllCookies()
 


### PR DESCRIPTION
## Why are you doing this?

> `contributions-frontend`is gone. Long live `support-frontend`.

To remove contribution-frontend's references from the project.

[**Trello Card**](https://trello.com/c/3MQOcUp0/398-clean-up-support-frontend-after-paypal-and-stripe-prs)

## Changes

* Removed contributions reference from config files and controllers
* Renamed payPalService to show the fact that is the NVP integration.

## Screenshots
N/A
