### PR TITLE
Handle the new paypal sandbox guest checkout page

### DIFF
--- a/test/selenium/OneOffContributionsSpec.scala
+++ b/test/selenium/OneOffContributionsSpec.scala
@@ -1,6 +1,5 @@
 package selenium
 
-import com.twitter.conversions.thread
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FeatureSpec, GivenWhenThen}
 import selenium.pages.{ContributionsLanding, OneOffContributionThankYou}
 import selenium.util._
@@ -38,20 +37,15 @@ class OneOffContributionsSpec extends FeatureSpec with GivenWhenThen with Before
       landingPage.clickOneOff
 
       And("he/she selects to contribute via PayPal")
-      payPalCheckout.addPaypalCookie()(landingPage)
       landingPage.clickContributePayPalButton
 
       Then("they should be redirected to PayPal Checkout")
       assert(payPalCheckout.initialPageHasLoaded)
-      val url = webDriver.getCurrentUrl
-      if (url.contains(payPalCheckout.guestRegistrationUrlFragment)) {
-        val token = url.substring(url.indexOf("&token="), url.indexOf(payPalCheckout.guestRegistrationUrlFragment))
-        webDriver.navigate().to(payPalCheckout.loginUrlFragment + token)
-        assert(payPalCheckout.loginContainerHasLoaded)
-      }
+      payPalCheckout.handleGuestRegistrationPage()
+      assert(payPalCheckout.loginContainerHasLoaded)
 
       Given("that the user fills in their PayPal credentials correctly")
-      payPalCheckout.fillIn()
+      payPalCheckout.enterLoginDetails()
 
       When("the user clicks 'Log In'")
       payPalCheckout.logIn

--- a/test/selenium/OneOffContributionsSpec.scala
+++ b/test/selenium/OneOffContributionsSpec.scala
@@ -25,7 +25,6 @@ class OneOffContributionsSpec extends FeatureSpec with GivenWhenThen with Before
       val testUser = new TestUser(driverConfig)
       val landingPage = ContributionsLanding("us")
       val payPalCheckout = new PayPalCheckout
-
       val oneOffContributionThankYou = new OneOffContributionThankYou
       val expectedPayment = "50.00"
 

--- a/test/selenium/RecurringContributionsSpec.scala
+++ b/test/selenium/RecurringContributionsSpec.scala
@@ -95,11 +95,19 @@ class RecurringContributionsSpec extends FeatureSpec with GivenWhenThen with Bef
       And("they select to pay with PayPal")
 
       When("they press the PayPal payment button")
+      payPalCheckout.addPaypalCookie()(landingPage)
       recurringContributionForm.selectPayPalPayment
 
       Then("the PayPal Express Checkout mini-browser should display")
       payPalCheckout.switchToPayPalPopUp
-      assert(payPalCheckout.hasLoaded)
+      assert(payPalCheckout.initialPageHasLoaded)
+      val url = webDriver.getCurrentUrl
+      if (url.contains(payPalCheckout.guestRegistrationUrlFragment)) {
+        val token = url.substring(url.indexOf("&token="), url.indexOf(payPalCheckout.guestRegistrationUrlFragment))
+        webDriver.navigate().to(payPalCheckout.loginUrlFragment + token)
+        payPalCheckout.switchToPayPalPopUp
+        assert(payPalCheckout.loginContainerHasLoaded)
+      }
 
       Given("that the user fills in their PayPal credentials correctly")
       payPalCheckout.fillIn()

--- a/test/selenium/RecurringContributionsSpec.scala
+++ b/test/selenium/RecurringContributionsSpec.scala
@@ -98,9 +98,9 @@ class RecurringContributionsSpec extends FeatureSpec with GivenWhenThen with Bef
       recurringContributionForm.selectPayPalPayment
 
       Then("the PayPal Express Checkout mini-browser should display")
+      payPalCheckout.switchToPayPalPopUp
       assert(payPalCheckout.initialPageHasLoaded)
       payPalCheckout.handleGuestRegistrationPage()
-      payPalCheckout.switchToPayPalPopUp
       assert(payPalCheckout.loginContainerHasLoaded)
 
       Given("that the user fills in their PayPal credentials correctly")

--- a/test/selenium/RecurringContributionsSpec.scala
+++ b/test/selenium/RecurringContributionsSpec.scala
@@ -95,22 +95,16 @@ class RecurringContributionsSpec extends FeatureSpec with GivenWhenThen with Bef
       And("they select to pay with PayPal")
 
       When("they press the PayPal payment button")
-      payPalCheckout.addPaypalCookie()(landingPage)
       recurringContributionForm.selectPayPalPayment
 
       Then("the PayPal Express Checkout mini-browser should display")
-      payPalCheckout.switchToPayPalPopUp
       assert(payPalCheckout.initialPageHasLoaded)
-      val url = webDriver.getCurrentUrl
-      if (url.contains(payPalCheckout.guestRegistrationUrlFragment)) {
-        val token = url.substring(url.indexOf("&token="), url.indexOf(payPalCheckout.guestRegistrationUrlFragment))
-        webDriver.navigate().to(payPalCheckout.loginUrlFragment + token)
-        payPalCheckout.switchToPayPalPopUp
-        assert(payPalCheckout.loginContainerHasLoaded)
-      }
+      payPalCheckout.handleGuestRegistrationPage()
+      payPalCheckout.switchToPayPalPopUp
+      assert(payPalCheckout.loginContainerHasLoaded)
 
       Given("that the user fills in their PayPal credentials correctly")
-      payPalCheckout.fillIn()
+      payPalCheckout.enterLoginDetails()
 
       When("the user clicks 'Log In'")
       payPalCheckout.logIn

--- a/test/selenium/util/Browser.scala
+++ b/test/selenium/util/Browser.scala
@@ -1,11 +1,9 @@
 package selenium.util
 
 import org.openqa.selenium.WebDriver
-import org.openqa.selenium.support.ui
 import org.openqa.selenium.support.ui.ExpectedConditions.numberOfWindowsToBe
 import org.openqa.selenium.support.ui.{ExpectedCondition, ExpectedConditions, WebDriverWait}
 import org.scalatest.selenium.WebBrowser
-
 import scala.collection.JavaConverters.asScalaSetConverter
 import scala.util.Try
 

--- a/test/selenium/util/Browser.scala
+++ b/test/selenium/util/Browser.scala
@@ -1,9 +1,11 @@
 package selenium.util
 
 import org.openqa.selenium.WebDriver
+import org.openqa.selenium.support.ui
 import org.openqa.selenium.support.ui.ExpectedConditions.numberOfWindowsToBe
 import org.openqa.selenium.support.ui.{ExpectedCondition, ExpectedConditions, WebDriverWait}
 import org.scalatest.selenium.WebBrowser
+
 import scala.collection.JavaConverters.asScalaSetConverter
 import scala.util.Try
 
@@ -25,6 +27,14 @@ trait Browser extends WebBrowser {
 
   def pageHasUrl(urlFraction: String): Boolean =
     waitUntil(ExpectedConditions.urlContains(urlFraction))
+
+  def pageHasUrlOrElement(urlFraction: String, q: Query): Boolean =
+    waitUntil(
+      ExpectedConditions.or(
+        ExpectedConditions.urlContains(urlFraction),
+        ExpectedConditions.visibilityOfElementLocated(q.by)
+      )
+    )
 
   def clickOn(q: Query) {
     if (pageHasElement(q))

--- a/test/selenium/util/PayPalCheckout.scala
+++ b/test/selenium/util/PayPalCheckout.scala
@@ -1,9 +1,6 @@
 package selenium.util
 
-import java.time.ZoneOffset
-import java.util.Date
 import org.openqa.selenium.WebDriver
-import selenium.pages.ContributionsLanding
 
 // Handles interaction with the PayPal Express Checkout overlay.
 class PayPalCheckout(implicit val webDriver: WebDriver) extends Browser {

--- a/test/selenium/util/PayPalCheckout.scala
+++ b/test/selenium/util/PayPalCheckout.scala
@@ -18,32 +18,6 @@ class PayPalCheckout(implicit val webDriver: WebDriver) extends Browser {
   val guestRegistrationUrlFragment = "#/checkout/guest"
   val loginUrlFragment = "https://www.sandbox.paypal.com/webapps/hermes?country.x=US&hermesLoginRedirect=xoon&locale.x=en_US"
 
-  def addPaypalCookie()(implicit landing: ContributionsLanding): Unit = {
-    val cookieName: String = "tsrce"
-    val cookieValue: String = "authchallengenodeweb"
-    val path: String = "/"
-    val domain: String = ".paypal.com"
-    val isSecure: Boolean = true
-
-    /*Note: The very convoluted creation of the expiry Date is due to the fact that
-    most of the creation methods for Date.java are deprecated. */
-    val expiry = java.time.LocalDateTime.now().plusMonths(1)
-    val expiryAsInstant = expiry.toInstant(ZoneOffset.MIN)
-    val expiryAsDate = Date.from(expiryAsInstant)
-
-    landing.addCookie(cookieName, cookieValue, path, expiryAsDate, domain, isSecure)
-  }
-
-  def fillIn(): Unit = {
-    setValueSlowly(emailInput, Config.paypalBuyerEmail)
-    if (pageHasElement(nextButton)) {
-      clickNext()
-    }
-    if (pageHasElement(loginButton)) {
-      setValueSlowly(passwordInput, Config.paypalBuyerPassword)
-    }
-  }
-
   def clickNext(): Unit = clickOn(nextButton)
 
   def logIn(): Unit = clickOn(loginButton)
@@ -79,5 +53,23 @@ class PayPalCheckout(implicit val webDriver: WebDriver) extends Browser {
     pageDoesNotHaveElement(id("spinner"))
     acceptPayment()
     switchToParentWindow()
+  }
+
+  def handleGuestRegistrationPage(): Unit = {
+    val url = webDriver.getCurrentUrl
+    if (url.contains(guestRegistrationUrlFragment)) {
+      val token = url.substring(url.indexOf("&token="), url.indexOf(guestRegistrationUrlFragment))
+      webDriver.navigate().to(loginUrlFragment + token)
+    }
+  }
+
+  def enterLoginDetails(): Unit = {
+    setValueSlowly(emailInput, Config.paypalBuyerEmail)
+    if (pageHasElement(nextButton)) {
+      clickNext()
+    }
+    if (pageHasElement(loginButton)) {
+      setValueSlowly(passwordInput, Config.paypalBuyerPassword)
+    }
   }
 }


### PR DESCRIPTION
Post production tests are failing on Paypal payments.
This is because paypal have introduced a new guest checkout page.
Unfortunately, unlike Stripe, the functionality does not exist to mock the paypal process so we must continue running through the payment flow.

This change checks whether a guest checkout page has opened, and if it has it navigates to the express checkout page so that payment flow can begin.

This work was done in response to a retrospective action tracked in trello card:
https://trello.com/c/DQUOaoW7/1491-stub-paypal-in-end-to-end-tests
