### PR TITLE
Bump Google Guava

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -75,7 +75,7 @@ libraryDependencies ++= Seq(
   "joda-time" % "joda-time" % "2.9.9",
   "com.gu.identity" %% "identity-play-auth" % "2.4",
   "com.gu" %% "identity-test-users" % "0.6",
-  "com.google.guava" % "guava" % "23.0",
+  "com.google.guava" % "guava" % "25.0-jre",
   "com.netaporter" %% "scala-uri" % "0.4.16",
   "com.gu" %% "play-googleauth" % "0.7.1",
   "io.github.bonigarcia" % "webdrivermanager" % "2.1.0" % "test",


### PR DESCRIPTION
## Why are you doing this?

Guava is a direct and transitive dependency for support-frontend. I've tested the flows and test user pages (it's a dependency of some oauth libraries) and everything seems ok.

That said, I could also bump some of our other dependencies to reduce the risk of incompatibility errors if necessary.

[**Trello Card**](https://trello.com/c/q5JmiVzz/1572-ensure-that-snyk-has-zero-issues-on-all-sc-projects-support-frontend-scala)

cc @JustinPinner 

## Changes

- Bump Guava to v25.0.
