### PR TITLE
add stripe one-off contribution test

### DIFF
--- a/assets/components/numberInput/numberInput.jsx
+++ b/assets/components/numberInput/numberInput.jsx
@@ -45,6 +45,7 @@ export default function NumberInput(props: PropTypes) {
     <div className={classNameWithModifiers('component-number-input', [selectedClass])}>
       {getLabel(props.labelText)}
       <input
+        id="qa-payment-amount-input"
         className="component-number-input__input"
         type="number"
         placeholder={props.placeholder}

--- a/test/selenium/OneOffContributionsSpec.scala
+++ b/test/selenium/OneOffContributionsSpec.scala
@@ -22,12 +22,11 @@ class OneOffContributionsSpec extends FeatureSpec with GivenWhenThen with Before
 
     scenario("One-off contribution sign-up with Stripe - GBP") {
 
-      val expectedPayment = 50.00
-      val expectedPaymentAsString = "50.00"
+      val stripePayment = 22.00
       val currency = "AUD"
       val testUser = new TestUser(driverConfig)
       val landingPage = ContributionsLanding("au")
-      val oneOffContributionForm = OneOffContributionForm(testUser, expectedPayment.toInt, currency)
+      val oneOffContributionForm = OneOffContributionForm(testUser, stripePayment.toInt, currency)
       val oneOffContributionThankYou = new OneOffContributionThankYou
 
       Given("that a test user goes to the contributions landing page")
@@ -37,11 +36,17 @@ class OneOffContributionsSpec extends FeatureSpec with GivenWhenThen with Before
       When("he/she selects to make a one-time contribution")
       landingPage.clickOneOff
 
+      And("he/she manually enters an amount in the other-amount field")
+      landingPage.enterAmount(stripePayment)
+
       And("he/she selects to contribute via Stripe")
       landingPage.clickContribute
 
       Then("he/she is redirected to the personal details page")
       assert(oneOffContributionForm.pageHasLoaded)
+
+      And("The payment amount on the personal details page is correct")
+      assert(oneOffContributionForm.compareAmountDisplayed(stripePayment.toInt))
 
       Given("The user fills in their name and email correctly")
       oneOffContributionForm.fillInPersonalDetails()

--- a/test/selenium/OneOffContributionsSpec.scala
+++ b/test/selenium/OneOffContributionsSpec.scala
@@ -1,7 +1,7 @@
 package selenium
 
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FeatureSpec, GivenWhenThen}
-import selenium.pages.{ContributionsLanding, OneOffContributionThankYou}
+import selenium.pages.{ContributionsLanding, OneOffContributionForm, OneOffContributionThankYou}
 import selenium.util._
 
 class OneOffContributionsSpec extends FeatureSpec with GivenWhenThen with BeforeAndAfter with BeforeAndAfterAll with Browser {
@@ -19,6 +19,41 @@ class OneOffContributionsSpec extends FeatureSpec with GivenWhenThen with Before
   override def afterAll(): Unit = { driverConfig.quit() }
 
   feature("Sign up for a one-off contribution") {
+
+    scenario("One-off contribution sign-up with Stripe - GBP") {
+
+      val expectedPayment = 50.00
+      val expectedPaymentAsString = "50.00"
+      val currency = "AUD"
+      val testUser = new TestUser(driverConfig)
+      val landingPage = ContributionsLanding("au")
+      val oneOffContributionForm = OneOffContributionForm(testUser, expectedPayment.toInt, currency)
+      val oneOffContributionThankYou = new OneOffContributionThankYou
+
+      Given("that a test user goes to the contributions landing page")
+      goTo(landingPage)
+      assert(landingPage.pageHasLoaded)
+
+      When("he/she selects to make a one-time contribution")
+      landingPage.clickOneOff
+
+      And("he/she selects to contribute via Stripe")
+      landingPage.clickContribute
+
+      Then("he/she is redirected to the personal details page")
+      assert(oneOffContributionForm.pageHasLoaded)
+
+      Given("The user fills in their name and email correctly")
+      oneOffContributionForm.fillInPersonalDetails()
+
+      And("The user selects to pay by Card")
+      oneOffContributionForm.clickContributeByCard
+
+      And("the mock calls the backend using a test Stripe token")
+
+      Then("the thankyou page should display")
+      assert(oneOffContributionThankYou.pageHasLoaded)
+    }
 
     scenario("One-off contribution sign-up with PayPal - USD") {
 

--- a/test/selenium/OneOffContributionsSpec.scala
+++ b/test/selenium/OneOffContributionsSpec.scala
@@ -22,7 +22,7 @@ class OneOffContributionsSpec extends FeatureSpec with GivenWhenThen with Before
 
     scenario("One-off contribution sign-up with Stripe - GBP") {
 
-      val stripePayment = 22.00
+      val stripePayment = 22.55
       val currency = "AUD"
       val testUser = new TestUser(driverConfig)
       val landingPage = ContributionsLanding("au")
@@ -46,7 +46,7 @@ class OneOffContributionsSpec extends FeatureSpec with GivenWhenThen with Before
       assert(oneOffContributionForm.pageHasLoaded)
 
       And("The payment amount on the personal details page is correct")
-      assert(oneOffContributionForm.compareAmountDisplayed(stripePayment.toInt))
+      assert(oneOffContributionForm.compareAmountDisplayed(stripePayment))
 
       Given("The user fills in their name and email correctly")
       oneOffContributionForm.fillInPersonalDetails()

--- a/test/selenium/pages/ContributionsLanding.scala
+++ b/test/selenium/pages/ContributionsLanding.scala
@@ -14,7 +14,7 @@ case class ContributionsLanding(region: String)(implicit val webDriver: WebDrive
 
   private val oneOffButton = id("qa-one-off-toggle")
 
-  private val otherAmountField = className("component-number-input__input")
+  private val otherAmountField = id("qa-payment-amount-input")
 
   def pageHasLoaded: Boolean = pageHasElement(contributeButton)
 

--- a/test/selenium/pages/ContributionsLanding.scala
+++ b/test/selenium/pages/ContributionsLanding.scala
@@ -14,6 +14,8 @@ case class ContributionsLanding(region: String)(implicit val webDriver: WebDrive
 
   private val oneOffButton = id("qa-one-off-toggle")
 
+  private val otherAmountField = className("component-number-input__input")
+
   def pageHasLoaded: Boolean = pageHasElement(contributeButton)
 
   def clickContribute: Unit = clickOn(contributeButton)
@@ -21,5 +23,7 @@ case class ContributionsLanding(region: String)(implicit val webDriver: WebDrive
   def clickOneOff: Unit = clickOn(oneOffButton)
 
   def clickContributePayPalButton: Unit = clickOn(contributePayPalButton)
+
+  def enterAmount(amount: Double): Unit = setValueSlowly(otherAmountField, amount.toString)
 
 }

--- a/test/selenium/pages/OneOffContributionForm.scala
+++ b/test/selenium/pages/OneOffContributionForm.scala
@@ -11,6 +11,7 @@ case class OneOffContributionForm(testUser: TestUser, amount: Int, currency: Str
   private val paymentAmountDisplay = className("component-payment-amount")
   private val payWithCard = id("qa-pay-with-card")
   private val contributePayPalButton = id("qa-contribute-paypal-button")
+  val url2 = s"https://q.stripe.com/?event=checkout.outer.open&rf="
 
   private object RegisterFields {
     val fullName = id("name")
@@ -24,9 +25,9 @@ case class OneOffContributionForm(testUser: TestUser, amount: Int, currency: Str
 
   def pageHasLoaded: Boolean = pageHasElement(payWithCard)
 
-  def getAmountDisplayed(): Int = webDriver.findElement(paymentAmountDisplay.by).getText.tail.trim.toInt
+  def getAmountDisplayed(): Double = webDriver.findElement(paymentAmountDisplay.by).getText.tail.trim.toDouble
 
-  def compareAmountDisplayed(expectedAmount: Int): Boolean = expectedAmount == getAmountDisplayed()
+  def compareAmountDisplayed(expectedAmount: Double): Boolean = expectedAmount == getAmountDisplayed()
 
   def fillInPersonalDetails() { RegisterFields.fillIn() }
 

--- a/test/selenium/pages/OneOffContributionForm.scala
+++ b/test/selenium/pages/OneOffContributionForm.scala
@@ -11,7 +11,6 @@ case class OneOffContributionForm(testUser: TestUser, amount: Int, currency: Str
   private val paymentAmountDisplay = className("component-payment-amount")
   private val payWithCard = id("qa-pay-with-card")
   private val contributePayPalButton = id("qa-contribute-paypal-button")
-  val url2 = s"https://q.stripe.com/?event=checkout.outer.open&rf="
 
   private object RegisterFields {
     val fullName = id("name")

--- a/test/selenium/pages/OneOffContributionForm.scala
+++ b/test/selenium/pages/OneOffContributionForm.scala
@@ -8,8 +8,8 @@ case class OneOffContributionForm(testUser: TestUser, amount: Int, currency: Str
 
   val url = s"${Config.supportFrontendUrl}/contribute/one-off?contributionValue=${amount}&contribType=ONE_OFF&currency=${currency}"
 
+  private val paymentAmountDisplay = className("component-payment-amount")
   private val payWithCard = id("qa-pay-with-card")
-
   private val contributePayPalButton = id("qa-contribute-paypal-button")
 
   private object RegisterFields {
@@ -24,10 +24,14 @@ case class OneOffContributionForm(testUser: TestUser, amount: Int, currency: Str
 
   def pageHasLoaded: Boolean = pageHasElement(payWithCard)
 
+  def getAmountDisplayed(): Int = webDriver.findElement(paymentAmountDisplay.by).getText.tail.trim.toInt
+
+  def compareAmountDisplayed(expectedAmount: Int): Boolean = expectedAmount == getAmountDisplayed()
+
   def fillInPersonalDetails() { RegisterFields.fillIn() }
 
-  def clickContributeByCard: Unit = clickOn(payWithCard)
+  def clickContributeByCard(): Unit = clickOn(payWithCard)
 
-  def clickContributePayPalButton: Unit = clickOn(contributePayPalButton)
+  def clickContributePayPalButton(): Unit = clickOn(contributePayPalButton)
 
 }

--- a/test/selenium/pages/OneOffContributionForm.scala
+++ b/test/selenium/pages/OneOffContributionForm.scala
@@ -1,0 +1,33 @@
+package selenium.pages
+
+import selenium.util.{Browser, Config, TestUser}
+import org.openqa.selenium.WebDriver
+import org.scalatest.selenium.Page
+
+case class OneOffContributionForm(testUser: TestUser, amount: Int, currency: String)(implicit val webDriver: WebDriver) extends Page with Browser {
+
+  val url = s"${Config.supportFrontendUrl}/contribute/one-off?contributionValue=${amount}&contribType=ONE_OFF&currency=${currency}"
+
+  private val payWithCard = id("qa-pay-with-card")
+
+  private val contributePayPalButton = id("qa-contribute-paypal-button")
+
+  private object RegisterFields {
+    val fullName = id("name")
+    val email = id("email")
+
+    def fillIn() {
+      setValue(fullName, testUser.username, clear = true)
+      setValue(email, s"${testUser.username}@gu.com", clear = true)
+    }
+  }
+
+  def pageHasLoaded: Boolean = pageHasElement(payWithCard)
+
+  def fillInPersonalDetails() { RegisterFields.fillIn() }
+
+  def clickContributeByCard: Unit = clickOn(payWithCard)
+
+  def clickContributePayPalButton: Unit = clickOn(contributePayPalButton)
+
+}


### PR DESCRIPTION
Currently we have a stripe end to end test for monthly contributions, but none for one off payments.

Once this is merged we will have a stripe and paypal test each for one-off and regular contributions.

This change adds the test steps and also adds the flow for catering to the one-off enter details form.


Work tracked by trello card: https://trello.com/c/RzYa6bG9/1579-add-post-deployment-test-for-one-off-stripe-payments

