### PR TITLE
Flip One-Off Payment Buttons

### DIFF
--- a/assets/components/contributionPaymentCtas/contributionPaymentCtas.scss
+++ b/assets/components/contributionPaymentCtas/contributionPaymentCtas.scss
@@ -36,8 +36,9 @@
 
   .svg-arrow-right-straight {
     fill: gu-colour(garnett-neutral-1);
-    height: 35%;
-    top: 15px;
+    width: 20px;
+    top: 50%;
+    transform: translateY(-50%);
     right: 15px;
 
     @include mq($from: mobileMedium) {
@@ -51,12 +52,6 @@
 
     @include mq($from: mobileMedium) {
       width: $cta-width;
-    }
-
-    .svg-arrow-right-straight {
-      height: 35%;
-      top: 21px;
-      right: 7px;
     }
   }
 
@@ -82,12 +77,6 @@
   .component-terms-privacy {
     font-family: $gu-text-sans-web;
     margin-top: $gu-v-spacing * 3;
-  }
-
-  .component-cta-link {
-    @include mq($until: mobileMedium) {
-      margin-top: $gu-v-spacing * 2;
-    }
   }
 }
 

--- a/assets/containerisableComponents/payPalContributionButton/payPalContributionButton.scss
+++ b/assets/containerisableComponents/payPalContributionButton/payPalContributionButton.scss
@@ -2,7 +2,7 @@
   background-color: gu-colour(news-garnett-highlight);
   border-radius: 600px;
   border: none;
-  color: gu-colour(neutral-1);
+  color: gu-colour(garnett-neutral-1);
   cursor: pointer;
   display: block;
   font-family: $gu-sans-web;
@@ -12,15 +12,14 @@
   position: relative;
   text-align: left;
   width: 100%;
-  margin-top: $gu-v-spacing;
 
   @include mq($from: mobileMedium) {
     width: 304px;
   }
 
   .svg-arrow-right-straight {
-    width: 24px;
-    fill: gu-colour(neutral-1);
+    width: 20px;
+    fill: gu-colour(garnett-neutral-1);
     position: absolute;
     right: 15px;
     top: 50%;
@@ -28,9 +27,6 @@
   }
 
   &:hover {
-    color: #000;
-    .svg-arrow-right-straight {
-      fill: #000;
-    }
+    background-color: darken(gu-colour(news-garnett-highlight), 5%);
   }
 }

--- a/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/assets/pages/contributions-landing/contributionsLanding.scss
@@ -42,6 +42,10 @@
     @include gu-content-filler;
   }
 
+  .component-paypal-contribution-button {
+    margin-top: $gu-v-spacing;
+  }
+
 }
 
 #contributions-landing-page-us {

--- a/assets/pages/oneoff-contributions/components/oneoffContributionsPayment.jsx
+++ b/assets/pages/oneoff-contributions/components/oneoffContributionsPayment.jsx
@@ -112,7 +112,14 @@ function OneoffContributionsPayment(props: PropTypes, context) {
   return (
     <section className="oneoff-contribution-payment">
       <ErrorMessage message={props.error} />
-
+      <PayPalContributionButton
+        amount={props.amount}
+        referrerAcquisitionData={props.referrerAcquisitionData}
+        isoCountry={props.isoCountry}
+        countryGroupId={props.countryGroupId}
+        errorHandler={props.checkoutError}
+        abParticipations={props.abParticipations}
+      />
       <StripePopUpButton
         email={props.email}
         callback={postCheckout(
@@ -132,14 +139,6 @@ function OneoffContributionsPayment(props: PropTypes, context) {
         isTestUser={props.isTestUser}
         isPostDeploymentTestUser={props.isPostDeploymentTestUser}
         amount={props.amount}
-      />
-      <PayPalContributionButton
-        amount={props.amount}
-        referrerAcquisitionData={props.referrerAcquisitionData}
-        isoCountry={props.isoCountry}
-        countryGroupId={props.countryGroupId}
-        errorHandler={props.checkoutError}
-        abParticipations={props.abParticipations}
       />
     </section>
   );

--- a/assets/pages/oneoff-contributions/oneoffContributions.scss
+++ b/assets/pages/oneoff-contributions/oneoffContributions.scss
@@ -147,9 +147,11 @@
 		.component-stripe-pop-up-button {
 			box-sizing: border-box;
 			height: $cta-height;
-			background-color: gu-colour(news-garnett-highlight);
+			background-color: #fff;
       color: gu-colour(garnett-neutral-1);
+      border: 1px solid gu-colour(garnett-neutral-1);
       width: 100%;
+      margin-top: $gu-v-spacing;
 
       svg {
       	fill: gu-colour(garnett-neutral-1);
@@ -160,14 +162,14 @@
 			}
 
 			&:hover {
-				background-color: darken(gu-colour(news-garnett-highlight), 5%);
+				color: #000;
+				border-color: #000;
 			}
 		}
 	}
 
 	.component-paypal-contribution-button {
 		height: $cta-height;
-		margin-top: $gu-v-spacing;
 		width: 100%;
 
 		@include mq($from: phablet) {

--- a/assets/pages/support-landing/supportLanding.scss
+++ b/assets/pages/support-landing/supportLanding.scss
@@ -2,6 +2,7 @@
 
 @import '../../stylesheets/gu-sass/gu-sass';
 
+
 // ----- Shared Components ----- //
 
 @import '../../components/headers/countrySwitcherHeader/countrySwitcherHeader';
@@ -31,3 +32,12 @@
 @import '../../components/patronsEvents/patronsEvents';
 @import '../../components/readyToSupport/readyToSupport';
 @import '../../components/footer/footer';
+
+
+// ----- Page-Specific Styles ----- //
+
+#support-landing-page {
+  .component-paypal-contribution-button {
+    margin-top: $gu-v-spacing;
+  }
+}


### PR DESCRIPTION
## Why are you doing this?

The payment buttons on the one-off checkout are being flipped. This PR also makes the styles more consistent across the different places these buttons are used.

## Changes

- Flipped buttons on one-off checkout.
- Made credit/debit button white on checkout.
- Made hover, colour, sizing and padding consistent across the buttons on the landing pages and one-off checkout.

## Screenshots

**One-Off Checkout Before**

![checkout-before](https://user-images.githubusercontent.com/5131341/40438335-c39b4eaa-5eaf-11e8-8231-3237f9c1b1a4.png)

**One-Off Checkout After**

![checkout-after](https://user-images.githubusercontent.com/5131341/40438356-ccb675be-5eaf-11e8-9929-82f391ae989e.png)

**Contribute Before**

![contribute-before](https://user-images.githubusercontent.com/5131341/40438416-f1b94bfc-5eaf-11e8-8454-5f937006da65.png)

**Contribute After**

![contribute-after](https://user-images.githubusercontent.com/5131341/40438414-f1a3ddb2-5eaf-11e8-8ec3-5305a25eda0b.png)
