### PR TITLE
Applying variant header copy to all regions

### DIFF
--- a/assets/pages/contributions-landing/contributionsLanding.jsx
+++ b/assets/pages/contributions-landing/contributionsLanding.jsx
@@ -88,7 +88,13 @@ const variantHeader = ['Help us deliver the', 'independent journalism', 'the wor
 
 if (desktopAboveTheFold === 'variant') {
   countryGroupSpecificDetails.GBPCountries.headerCopy = variantHeader;
+  countryGroupSpecificDetails.EURCountries.headerCopy = variantHeader;
   countryGroupSpecificDetails.UnitedStates.headerCopy = variantHeader;
+  countryGroupSpecificDetails.AUDCountries.headerCopy = variantHeader;
+  countryGroupSpecificDetails.International.headerCopy = variantHeader;
+  countryGroupSpecificDetails.NZDCountries.headerCopy = variantHeader;
+  countryGroupSpecificDetails.Canada.headerCopy = variantHeader;
+
 }
 
 const content = (


### PR DESCRIPTION
## Why are you doing this?

To set up the same header in all regions for the variant of the test.

## Screenshots
N/A
