### PR TITLE
Split CSS On Checkouts

### DIFF
--- a/app/controllers/OneOffContributions.scala
+++ b/app/controllers/OneOffContributions.scala
@@ -43,6 +43,7 @@ class OneOffContributions(
       title = "Support the Guardian | One-off Contribution",
       id = "oneoff-contributions-page",
       js = "oneoffContributionsPage.js",
+      css = "oneoffContributionsPageStyles.css",
       defaultStripeConfig = stripeConfigProvider.get(false),
       uatStripeConfig = stripeConfigProvider.get(true),
       paymentApiStripeEndpoint = paymentAPIService.stripeExecutePaymentEndpoint,

--- a/app/controllers/RegularContributions.scala
+++ b/app/controllers/RegularContributions.scala
@@ -48,6 +48,7 @@ class RegularContributions(
               title = "Support the Guardian | Monthly Contributions",
               id = "regular-contributions-page",
               js = "regularContributionsPage.js",
+              css = "regularContributionsPageStyles.css",
               user = fullUser,
               uatMode = uatMode,
               defaultStripeConfig = stripeConfigProvider.get(false),

--- a/app/views/monthlyContributions.scala.html
+++ b/app/views/monthlyContributions.scala.html
@@ -8,6 +8,7 @@
   title: String,
   id: String,
   js: String,
+  css: String,
   user: IdUser,
   uatMode: Boolean,
   defaultStripeConfig: StripeConfig,
@@ -43,4 +44,4 @@
     </script>
 }
 
-@main(title = title, scripts = scripts, mainJsBundle = js, mainId = id)
+@main(title = title, scripts = scripts, mainJsBundle = js, mainId = id, mainStyleBundle = css)

--- a/app/views/oneOffContributions.scala.html
+++ b/app/views/oneOffContributions.scala.html
@@ -7,6 +7,7 @@
         title: String,
         id: String,
         js: String,
+        css: String,
         defaultStripeConfig: StripeConfig,
         uatStripeConfig: StripeConfig,
         paymentApiStripeEndpoint: String,
@@ -44,4 +45,4 @@
     </script>
 }
 
-@main(title = title, scripts = scripts, mainJsBundle = js, mainId = id)
+@main(title = title, scripts = scripts, mainJsBundle = js, mainId = id, mainStyleBundle = css)

--- a/assets/pages/oneoff-contributions/oneoffContributions.scss
+++ b/assets/pages/oneoff-contributions/oneoffContributions.scss
@@ -1,3 +1,42 @@
+// -----  gu-sass ----- //
+
+@import '~stylesheets/gu-sass/gu-sass';
+
+
+// ----- Shared Components ----- //
+
+@import '~components/checkboxInput/checkboxInput';
+@import '~components/ctaLink/ctaLink';
+@import '~components/displayName/displayName';
+@import '~components/dotcomCta/dotcomCta';
+@import '~components/errorMessage/errorMessage';
+@import '~components/footer/footer';
+@import '~components/headers/simpleHeader/simpleHeader';
+@import '~components/infoSection/infoSection';
+@import '~components/introduction/introduction';
+@import '~components/introduction/circlesIntroduction';
+@import '~components/legal/contribLegal/contribLegal';
+@import '~components/legal/termsPrivacy/termsPrivacy';
+@import '~components/pageSection/pageSection';
+@import '~components/paymentAmount/paymentAmount';
+@import '~components/paymentButtons/stripePopUpButton/stripePopUpButton';
+@import '~components/progressMessage/progressMessage';
+@import '~components/questionsContact/questionsContact';
+@import '~components/secure/secure';
+@import '~components/signout/signout';
+@import '~components/socialShare/socialShare';
+@import '~components/spinners/animatedDots';
+@import '~components/spreadTheWord/spreadTheWord';
+@import '~components/svgs/svg';
+@import '~components/testUserBanner/testUserBanner';
+@import '~components/textInput/textInput';
+@import '~containerisableComponents/contributionsThankYou/contributionsThankYouPage';
+@import '~containerisableComponents/marketingConsent/marketingConsent';
+@import '~containerisableComponents/payPalContributionButton/payPalContributionButton';
+
+
+// ----- Page-Specific Styles ----- //
+
 #oneoff-contributions-page {
 
 	// ----- General ----- //

--- a/assets/pages/regular-contributions/regularContributions.scss
+++ b/assets/pages/regular-contributions/regularContributions.scss
@@ -1,3 +1,43 @@
+// -----  gu-sass ----- //
+
+@import '~stylesheets/gu-sass/gu-sass';
+
+
+// ----- Shared Components ----- //
+
+@import '~components/checkboxInput/checkboxInput';
+@import '~components/ctaLink/ctaLink';
+@import '~components/displayName/displayName';
+@import '~components/dotcomCta/dotcomCta';
+@import '~components/errorMessage/errorMessage';
+@import '~components/footer/footer';
+@import '~components/headers/simpleHeader/simpleHeader';
+@import '~components/infoSection/infoSection';
+@import '~components/introduction/introduction';
+@import '~components/introduction/circlesIntroduction';
+@import '~components/legal/contribLegal/contribLegal';
+@import '~components/legal/termsPrivacy/termsPrivacy';
+@import '~components/pageSection/pageSection';
+@import '~components/paymentAmount/paymentAmount';
+@import '~components/paymentButtons/payPalExpressButton/payPalExpressButton';
+@import '~components/paymentButtons/stripePopUpButton/stripePopUpButton';
+@import '~components/progressMessage/progressMessage';
+@import '~components/questionsContact/questionsContact';
+@import '~components/secure/secure';
+@import '~components/selectInput/selectInput';
+@import '~components/signout/signout';
+@import '~components/socialShare/socialShare';
+@import '~components/spinners/animatedDots';
+@import '~components/spreadTheWord/spreadTheWord';
+@import '~components/svgs/svg';
+@import '~components/testUserBanner/testUserBanner';
+@import '~components/textInput/textInput';
+@import '~containerisableComponents/contributionsThankYou/contributionsThankYouPage';
+@import '~containerisableComponents/marketingConsent/marketingConsent';
+
+
+// ----- Page-Specific Styles ----- //
+
 #regular-contributions-page {
 
 	// ----- General ----- //

--- a/assets/pages/regular-contributions/regularContributions.scss
+++ b/assets/pages/regular-contributions/regularContributions.scss
@@ -7,6 +7,8 @@
 
 @import '~components/checkboxInput/checkboxInput';
 @import '~components/ctaLink/ctaLink';
+@import '~components/directDebit/directDebitPopUpForm/directDebitPopUpForm';
+@import '~components/directDebit/directDebitForm/directDebitForm';
 @import '~components/displayName/displayName';
 @import '~components/dotcomCta/dotcomCta';
 @import '~components/errorMessage/errorMessage';
@@ -19,6 +21,7 @@
 @import '~components/legal/termsPrivacy/termsPrivacy';
 @import '~components/pageSection/pageSection';
 @import '~components/paymentAmount/paymentAmount';
+@import '~components/paymentButtons/directDebitPopUpButton/directDebitPopUpButton';
 @import '~components/paymentButtons/payPalExpressButton/payPalExpressButton';
 @import '~components/paymentButtons/stripePopUpButton/stripePopUpButton';
 @import '~components/progressMessage/progressMessage';

--- a/assets/stylesheets/main.scss
+++ b/assets/stylesheets/main.scss
@@ -56,8 +56,5 @@
 // ----- Pages ----- //
 
 @import '../pages/subscriptions-landing/subscriptionsLanding';
-@import '../pages/regular-contributions/regularContributions';
-@import '../containerisableComponents/contributionsThankYou/contributionsThankYouPage';
-@import '../pages/oneoff-contributions/oneoffContributions';
 @import '../pages/regular-contributions-existing/regularContributionsExisting';
 @import '../pages/paypal-error/payPalError';

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -29,6 +29,7 @@ module.exports = (cssFilename, outputFilename, minimizeCss) => ({
     contributionsLandingPage: 'pages/contributions-landing/contributionsLanding.jsx',
     contributionsLandingPageStyles: 'pages/contributions-landing/contributionsLanding.scss',
     regularContributionsPage: 'pages/regular-contributions/regularContributions.jsx',
+    regularContributionsPageStyles: 'pages/regular-contributions/regularContributions.scss',
     oneoffContributionsPage: 'pages/oneoff-contributions/oneoffContributions.jsx',
     regularContributionsExistingPage: 'pages/regular-contributions-existing/regularContributionsExisting.jsx',
     payPalErrorPage: 'pages/paypal-error/payPalError.jsx',

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -31,6 +31,7 @@ module.exports = (cssFilename, outputFilename, minimizeCss) => ({
     regularContributionsPage: 'pages/regular-contributions/regularContributions.jsx',
     regularContributionsPageStyles: 'pages/regular-contributions/regularContributions.scss',
     oneoffContributionsPage: 'pages/oneoff-contributions/oneoffContributions.jsx',
+    oneoffContributionsPageStyles: 'pages/oneoff-contributions/oneoffContributions.scss',
     regularContributionsExistingPage: 'pages/regular-contributions-existing/regularContributionsExisting.jsx',
     payPalErrorPage: 'pages/paypal-error/payPalError.jsx',
     googleTagManagerScript: 'helpers/tracking/googleTagManagerScript.js',


### PR DESCRIPTION
## Why are you doing this?

To reduce the amount of CSS we serve to the checkouts.

| Stylesheet | Size Before | Size After
|-|-|-
regular | 73.4 KiB | 33 KiB
one-off | 73.4 KiB  | 32 KiB
styles | 73.4 KiB  | 61 KiB

[**Trello Card**](https://trello.com/c/u96YNgNV/1466-apply-css-optimisation-changes)

**Note:** I got fed up using `../../` everywhere so I've started taking advantage of `sass-loader`'s ability to use the [webpack resolver](https://github.com/webpack-contrib/sass-loader#imports). We resolve our assets in webpack from the `assets/` directory, so we can use `~` on imports to specify them relative to that path.

cc @JustinPinner 

## Changes

- Create page-specific stylesheets for the one-off and regular checkouts.
- Remove the checkouts and thank you pages from the main styles bundle.
