### PR TITLE
Adding "travis_retry" wrapper to selenium test step. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ cache:
 before_cache:
   - find $HOME/.sbt -name "*.lock" -type f -delete -print
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" -type f -delete -print
-script: travis_retry sbt ++$TRAVIS_SCALA_VERSION selenium:test
+script: travis_retry 1 sbt ++$TRAVIS_SCALA_VERSION selenium:test

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ cache:
 before_cache:
   - find $HOME/.sbt -name "*.lock" -type f -delete -print
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" -type f -delete -print
-script: sbt ++$TRAVIS_SCALA_VERSION selenium:test
+script: travis_retry sbt ++$TRAVIS_SCALA_VERSION selenium:test


### PR DESCRIPTION
Very occasionally selenium tests are failing randomly and then working again on retry.
This can be the result of things like timeouts or selenium issues which don't reflect on the code being tested.

This change will force a failing test to be retried 3 times before the developer is alerted. 
The aim of this is to minimise false alarms and guarantee that if the developer is to be alerted - there is something worthy of attention.

documentation on this command can be found here: https://docs.travis-ci.com/user/common-build-problems/