### PR TITLE
Re-instate 500 error logging

### DIFF
--- a/app/lib/CustomHttpErrorHandler.scala
+++ b/app/lib/CustomHttpErrorHandler.scala
@@ -33,11 +33,13 @@ class CustomHttpErrorHandler(
         .withHeaders(CacheControl.defaultCacheHeaders(30.seconds, 30.seconds): _*)
     )
 
-  override protected def onProdServerError(request: RequestHeader, exception: UsefulException): Future[Result] =
+  override protected def onProdServerError(request: RequestHeader, exception: UsefulException): Future[Result] = {
+    logServerError(request, exception)
     Future.successful(
       InternalServerError(main("Error 500", "error-500-page", "error500Page.js", "errorPageStyles.css")(assets, request))
         .withHeaders(CacheControl.noCache)
     )
+  }
 
   override protected def onBadRequest(request: RequestHeader, message: String): Future[Result] =
     super.onBadRequest(request, message).map(_.withHeaders(CacheControl.noCache))


### PR DESCRIPTION
## Why are you doing this?

We accidentally dropped the error logging when we introduced Circles-branded 500 pages. Re-instating this makes it easier to debug production issues.

## Changes

* Log server errors when we throw a 500

