### PR TITLE
Adding breakpoints to the AB Test framework

### DIFF
--- a/assets/helpers/abTests/__tests__/abtestTest.js
+++ b/assets/helpers/abTests/__tests__/abtestTest.js
@@ -118,6 +118,189 @@ describe('basic behaviour of init', () => {
     expect(participations).toEqual(expectedParticipations);
   });
 
+  it('The ab test framework should check for both (min and max) breakpoints if they are provided', () => {
+
+    window.matchMedia = window.matchMedia || jest.fn(() => {
+      return {
+        matches: false,
+      };
+    });
+    document.cookie = 'GU_mvt_id=12346';
+
+    const tests = {
+      mockTest: {
+        variants: ['control', 'variant'],
+        audiences: {
+          US: {
+            offset: 0,
+            size: 1,
+            breakpoint: {
+              minWidth: 'tablet',
+              maxWidth: 'desktop',
+            },
+          },
+        },
+        isActive: true,
+        independent: false,
+        seed: 0,
+      },
+    };
+
+    const country = 'US';
+    const participations: Participations = abInit(country, tests);
+    const expectedParticipations: Participations = { mockTest: 'notintest' };
+    const expectedMediaQuery = '(min-width:740px) and (max-width:980px)';
+
+    expect(window.matchMedia).toHaveBeenCalledWith(expectedMediaQuery);
+    expect(participations).toEqual(expectedParticipations);
+  });
+
+  it('The ab test framework should check for min breakpoints if only min is provided', () => {
+
+    window.matchMedia = window.matchMedia || jest.fn(() => {
+      return {
+        matches: false,
+      };
+    });
+    document.cookie = 'GU_mvt_id=12346';
+
+    const tests = {
+      mockTest: {
+        variants: ['control', 'variant'],
+        audiences: {
+          US: {
+            offset: 0,
+            size: 1,
+            breakpoint: {
+              minWidth: 'tablet',
+            },
+          },
+        },
+        isActive: true,
+        independent: false,
+        seed: 0,
+      },
+    };
+
+    const country = 'US';
+    const participations: Participations = abInit(country, tests);
+    const expectedParticipations: Participations = { mockTest: 'notintest' };
+    const expectedMediaQuery = '(min-width:740px)';
+
+    expect(window.matchMedia).toHaveBeenCalledWith(expectedMediaQuery);
+    expect(participations).toEqual(expectedParticipations);
+  });
+
+  it('The ab test framework should check for min breakpoints if only min is provided and max is undefined', () => {
+
+    window.matchMedia = window.matchMedia || jest.fn(() => {
+      return {
+        matches: false,
+      };
+    });
+    document.cookie = 'GU_mvt_id=12346';
+
+    const tests = {
+      mockTest: {
+        variants: ['control', 'variant'],
+        audiences: {
+          US: {
+            offset: 0,
+            size: 1,
+            breakpoint: {
+              minWidth: 'tablet',
+              maxWidth: undefined,
+            },
+          },
+        },
+        isActive: true,
+        independent: false,
+        seed: 0,
+      },
+    };
+
+    const country = 'US';
+    const participations: Participations = abInit(country, tests);
+    const expectedParticipations: Participations = { mockTest: 'notintest' };
+    const expectedMediaQuery = '(min-width:740px)';
+
+    expect(window.matchMedia).toHaveBeenCalledWith(expectedMediaQuery);
+    expect(participations).toEqual(expectedParticipations);
+  });
+
+  it('The ab test framework should check for max breakpoints if only max is provided', () => {
+
+    window.matchMedia = window.matchMedia || jest.fn(() => {
+      return {
+        matches: false,
+      };
+    });
+    document.cookie = 'GU_mvt_id=12346';
+
+    const tests = {
+      mockTest: {
+        variants: ['control', 'variant'],
+        audiences: {
+          US: {
+            offset: 0,
+            size: 1,
+            breakpoint: {
+              maxWidth: 'tablet',
+            },
+          },
+        },
+        isActive: true,
+        independent: false,
+        seed: 0,
+      },
+    };
+
+    const country = 'US';
+    const participations: Participations = abInit(country, tests);
+    const expectedParticipations: Participations = { mockTest: 'notintest' };
+    const expectedMediaQuery = '(max-width:740px)';
+
+    expect(window.matchMedia).toHaveBeenCalledWith(expectedMediaQuery);
+    expect(participations).toEqual(expectedParticipations);
+  });
+
+  it('The ab test framework should check for min breakpoints if only max is provided and min is undefined', () => {
+
+    window.matchMedia = window.matchMedia || jest.fn(() => {
+      return {
+        matches: false,
+      };
+    });
+    document.cookie = 'GU_mvt_id=12346';
+
+    const tests = {
+      mockTest: {
+        variants: ['control', 'variant'],
+        audiences: {
+          US: {
+            offset: 0,
+            size: 1,
+            breakpoint: {
+              minWidth: undefined,
+              maxWidth: 'tablet',
+            },
+          },
+        },
+        isActive: true,
+        independent: false,
+        seed: 0,
+      },
+    };
+
+    const country = 'US';
+    const participations: Participations = abInit(country, tests);
+    const expectedParticipations: Participations = { mockTest: 'notintest' };
+    const expectedMediaQuery = '(min-width:740px)';
+
+    expect(window.matchMedia).toHaveBeenCalledWith(expectedMediaQuery);
+    expect(participations).toEqual(expectedParticipations);
+  });
+
   it('A post-deployment test user should not be allocated into a test', () => {
 
     const postDeploymentTestCookie = '_post_deploy_user=true; path=/;';

--- a/assets/helpers/abTests/__tests__/abtestTest.js
+++ b/assets/helpers/abTests/__tests__/abtestTest.js
@@ -15,7 +15,7 @@ jest.mock('ophan', () => ({
 describe('basic behaviour of init', () => {
 
   beforeEach(() => {
-    window.matchMedia = window.matchMedia || jest.fn(() => ({matches: false}));
+    window.matchMedia = window.matchMedia || jest.fn(() => ({ matches: false }));
   });
 
   it('The user should be allocated in the control bucket', () => {

--- a/assets/helpers/abTests/__tests__/abtestTest.js
+++ b/assets/helpers/abTests/__tests__/abtestTest.js
@@ -120,11 +120,7 @@ describe('basic behaviour of init', () => {
 
   it('The ab test framework should check for both (min and max) breakpoints if they are provided', () => {
 
-    window.matchMedia = window.matchMedia || jest.fn(() => {
-      return {
-        matches: false,
-      };
-    });
+    window.matchMedia = window.matchMedia || jest.fn(() => ({ matches: false }));
     document.cookie = 'GU_mvt_id=12346';
 
     const tests = {
@@ -157,11 +153,7 @@ describe('basic behaviour of init', () => {
 
   it('The ab test framework should check for min breakpoints if only min is provided', () => {
 
-    window.matchMedia = window.matchMedia || jest.fn(() => {
-      return {
-        matches: false,
-      };
-    });
+    window.matchMedia = window.matchMedia || jest.fn(() => ({ matches: false }));
     document.cookie = 'GU_mvt_id=12346';
 
     const tests = {
@@ -193,11 +185,7 @@ describe('basic behaviour of init', () => {
 
   it('The ab test framework should check for min breakpoints if only min is provided and max is undefined', () => {
 
-    window.matchMedia = window.matchMedia || jest.fn(() => {
-      return {
-        matches: false,
-      };
-    });
+    window.matchMedia = window.matchMedia || jest.fn(() => ({ matches: false }));
     document.cookie = 'GU_mvt_id=12346';
 
     const tests = {
@@ -230,11 +218,7 @@ describe('basic behaviour of init', () => {
 
   it('The ab test framework should check for max breakpoints if only max is provided', () => {
 
-    window.matchMedia = window.matchMedia || jest.fn(() => {
-      return {
-        matches: false,
-      };
-    });
+    window.matchMedia = window.matchMedia || jest.fn(() => ({ matches: false }));
     document.cookie = 'GU_mvt_id=12346';
 
     const tests = {
@@ -266,11 +250,7 @@ describe('basic behaviour of init', () => {
 
   it('The ab test framework should check for min breakpoints if only max is provided and min is undefined', () => {
 
-    window.matchMedia = window.matchMedia || jest.fn(() => {
-      return {
-        matches: false,
-      };
-    });
+    window.matchMedia = window.matchMedia || jest.fn(() => ({ matches: false }));
     document.cookie = 'GU_mvt_id=12346';
 
     const tests = {

--- a/assets/helpers/abTests/__tests__/abtestTest.js
+++ b/assets/helpers/abTests/__tests__/abtestTest.js
@@ -14,6 +14,10 @@ jest.mock('ophan', () => ({
 
 describe('basic behaviour of init', () => {
 
+  beforeEach(() => {
+    window.matchMedia = window.matchMedia || jest.fn(() => ({matches: false}));
+  });
+
   it('The user should be allocated in the control bucket', () => {
 
     document.cookie = 'GU_mvt_id=12346';
@@ -119,8 +123,6 @@ describe('basic behaviour of init', () => {
   });
 
   it('The ab test framework should check for both (min and max) breakpoints if they are provided', () => {
-
-    window.matchMedia = window.matchMedia || jest.fn(() => ({ matches: false }));
     document.cookie = 'GU_mvt_id=12346';
 
     const tests = {
@@ -153,7 +155,6 @@ describe('basic behaviour of init', () => {
 
   it('The ab test framework should check for min breakpoints if only min is provided', () => {
 
-    window.matchMedia = window.matchMedia || jest.fn(() => ({ matches: false }));
     document.cookie = 'GU_mvt_id=12346';
 
     const tests = {
@@ -185,7 +186,6 @@ describe('basic behaviour of init', () => {
 
   it('The ab test framework should check for min breakpoints if only min is provided and max is undefined', () => {
 
-    window.matchMedia = window.matchMedia || jest.fn(() => ({ matches: false }));
     document.cookie = 'GU_mvt_id=12346';
 
     const tests = {
@@ -218,7 +218,6 @@ describe('basic behaviour of init', () => {
 
   it('The ab test framework should check for max breakpoints if only max is provided', () => {
 
-    window.matchMedia = window.matchMedia || jest.fn(() => ({ matches: false }));
     document.cookie = 'GU_mvt_id=12346';
 
     const tests = {
@@ -250,7 +249,6 @@ describe('basic behaviour of init', () => {
 
   it('The ab test framework should check for min breakpoints if only max is provided and min is undefined', () => {
 
-    window.matchMedia = window.matchMedia || jest.fn(() => ({ matches: false }));
     document.cookie = 'GU_mvt_id=12346';
 
     const tests = {

--- a/assets/helpers/abTests/abtest.js
+++ b/assets/helpers/abTests/abtest.js
@@ -83,7 +83,7 @@ function getMvtId(): number {
 
   let mvtId = cookie.get(MVT_COOKIE);
 
-  if (!mvtId) {
+  if (mvtId === null || mvtId === undefined) {
 
     mvtId = String(Math.floor(Math.random() * (MVT_MAX)));
     cookie.set(MVT_COOKIE, mvtId);
@@ -159,7 +159,7 @@ function userInTest(audiences: Audiences, mvtId: number, country: IsoCountry) {
   const testMin: number = MVT_MAX * audience.offset;
   const testMax: number = testMin + (MVT_MAX * audience.size);
 
-  return (mvtId > testMin) && (mvtId < testMax) && userInBreakpoint(audience);
+  return (mvtId >= testMin) && (mvtId < testMax) && userInBreakpoint(audience);
 }
 
 function randomNumber(mvtId: number, independent: boolean, seed: number): number {

--- a/assets/helpers/abTests/abtest.js
+++ b/assets/helpers/abTests/abtest.js
@@ -81,16 +81,14 @@ const MVT_MAX: number = 1000000;
 // Attempts to retrieve the MVT id from a cookie, or sets it.
 function getMvtId(): number {
 
-  let mvtId = cookie.get(MVT_COOKIE);
+  let mvtId = Number(cookie.get(MVT_COOKIE));
 
-  if (mvtId === null || mvtId === undefined) {
-
-    mvtId = String(Math.floor(Math.random() * (MVT_MAX)));
-    cookie.set(MVT_COOKIE, mvtId);
-
+  if (Number.isNaN(mvtId) || mvtId >= MVT_MAX || mvtId < 0) {
+    mvtId = Math.floor(Math.random() * (MVT_MAX));
+    cookie.set(MVT_COOKIE, String(mvtId));
   }
 
-  return Number(mvtId);
+  return mvtId;
 }
 
 function getLocalStorageParticipation(): Participations {

--- a/assets/helpers/abTests/abtest.js
+++ b/assets/helpers/abTests/abtest.js
@@ -36,8 +36,8 @@ const breakpoints = {
 type Breakpoint = $Keys<typeof breakpoints>;
 
 type BreakpointRange = {
-  minWidth: ?Breakpoint,
-  maxWidth: ?Breakpoint,
+  minWidth?: Breakpoint,
+  maxWidth?: Breakpoint,
 }
 
 export type Participations = {

--- a/assets/helpers/abTests/abtest.js
+++ b/assets/helpers/abTests/abtest.js
@@ -127,15 +127,14 @@ function userInBreakpoint(audience: Audience): boolean {
     return true;
   }
 
-  const { minWidth } = audience.breakpoint;
-  const minWidthMediaQuery = minWidth ? `(min-width:${breakpoints[minWidth]}px)` : null;
-
-  const { maxWidth } = audience.breakpoint;
-  const maxWidthMediaQuery = maxWidth ? `(max-width:${breakpoints[maxWidth]}px)` : null;
+  const { minWidth, maxWidth } = audience.breakpoint;
 
   if (!(minWidth || maxWidth)) {
     return true;
   }
+
+  const minWidthMediaQuery = minWidth ? `(min-width:${breakpoints[minWidth]}px)` : null;
+  const maxWidthMediaQuery = maxWidth ? `(max-width:${breakpoints[maxWidth]}px)` : null;
 
   const mediaQuery = minWidthMediaQuery && maxWidthMediaQuery ?
     `${minWidthMediaQuery} and ${maxWidthMediaQuery}` :

--- a/assets/helpers/abTests/abtest.js
+++ b/assets/helpers/abTests/abtest.js
@@ -35,10 +35,10 @@ const breakpoints = {
 
 type Breakpoint = $Keys<typeof breakpoints>;
 
-type BreakpointRange = {
+type BreakpointRange = {|
   minWidth?: Breakpoint,
   maxWidth?: Breakpoint,
-}
+|}
 
 export type Participations = {
   [TestId]: string,


### PR DESCRIPTION
## Why are you doing this?

To be able to specify breakpoints to the audience segment of the AB test framework. If no breakpoint is defined by default the user will be in the test.

[**Trello Card**](https://trello.com/c/ot7uM3CU/444-add-breakpoints-in-ab-test-framework)

## Changes

* Created `Audience` type
* Created `Breakpoint` type.
* Added the check `userInBreakpoint` to the `userInTest` function
* Defined `breakpoints` object in `abTest` helper
* Refactor validation to reconsider the case of `mvtId` equal to 0.

## Screenshots
N/A

