### PR TITLE
Updated one-time one-off copy for US

### DIFF
--- a/assets/pages/contributions-landing/contributionsLanding.jsx
+++ b/assets/pages/contributions-landing/contributionsLanding.jsx
@@ -41,8 +41,11 @@ const oneOffOnlyVariant = (store && store.getState().common.abParticipations.Con
 const defaultHeaderCopy = ['Help us deliver', 'the independent', 'journalism the', 'world needs'];
 const defaultContributeCopy = oneOffOnlyVariant && oneOffOnlyVariant === 'oneOffOnly'
   ? 'Your contribution funds and supports The Guardian\'s journalism.'
-  : 'Make a monthly commitment to support The Guardian long term or a one-time contribution as and when you feel like it – choose the option that suits you best.';
+  : 'Make a monthly commitment to support The Guardian long term or a one-off contribution as and when you feel like it – choose the option that suits you best.';
 
+const usContributeCopy = oneOffOnlyVariant && oneOffOnlyVariant === 'oneOffOnly'
+  ? 'Your contribution funds and supports The Guardian\'s journalism.'
+  : 'Make a monthly commitment to support The Guardian long term or a one-time contribution as and when you feel like it – choose the option that suits you best.';
 
 const countryGroupSpecificDetails: {
   [CountryGroupId]: {headerCopy: string[], contributeCopy: string, reactElementId: string}
@@ -59,7 +62,7 @@ const countryGroupSpecificDetails: {
   },
   UnitedStates: {
     headerCopy: defaultHeaderCopy,
-    contributeCopy: defaultContributeCopy,
+    contributeCopy: usContributeCopy,
     reactElementId: 'contributions-landing-page-us',
   },
   AUDCountries: {


### PR DESCRIPTION
## Why are you doing this?
 
* One-time only for US 🇺🇸
* One-off for the rest

[**Trello Card**](https://trello.com/c/JeqvHqj5/469-update-one-off-in-us)

## Changes

* Updated copy of the contributions landing pages

## Screenshots

### UK
<img width="1178" alt="picture 792" src="https://user-images.githubusercontent.com/825398/40714360-572a0504-63fa-11e8-8fba-fcc0f22550fe.png">

### US
<img width="1142" alt="picture 793" src="https://user-images.githubusercontent.com/825398/40714361-573f4e0a-63fa-11e8-92ff-34d674a7155f.png">
