### PR TITLE
Digital Subscription Skeleton

### DIFF
--- a/app/controllers/Subscriptions.scala
+++ b/app/controllers/Subscriptions.scala
@@ -47,17 +47,15 @@ class Subscriptions(
 
   def digital(countryCode: String): Action[AnyContent] = CachedAction() { implicit request =>
     val urlWhenDisabled = s"/$countryCode/subscribe"
-    request.getQueryString("digiSub").map { queryValue =>
-      if (queryValue == "true") {
-        val title = "Support the Guardian | Digital Subscription"
-        val id = "digital-subscription-landing-page-" + countryCode
-        val js = "digitalSubscriptionLandingPage.js"
-        val css = "digitalSubscriptionLandingPageStyles.css"
-        Ok(views.html.main(title, id, js, css))
-      } else {
-        Redirect(urlWhenDisabled)
-      }
-    }.getOrElse(Redirect(urlWhenDisabled))
+    if (request.getQueryString("digiSub").contains("true")) {
+      val title = "Support the Guardian | Digital Subscription"
+      val id = "digital-subscription-landing-page-" + countryCode
+      val js = "digitalSubscriptionLandingPage.js"
+      val css = "digitalSubscriptionLandingPageStyles.css"
+      Ok(views.html.main(title, id, js, css))
+    } else {
+      Redirect(urlWhenDisabled)
+    }
   }
 
 }

--- a/app/controllers/Subscriptions.scala
+++ b/app/controllers/Subscriptions.scala
@@ -52,7 +52,8 @@ class Subscriptions(
         val title = "Support the Guardian | Digital Subscription"
         val id = "digital-subscription-landing-page-" + countryCode
         val js = "digitalSubscriptionLandingPage.js"
-        Ok(views.html.main(title, id, js))
+        val css = "digitalSubscriptionLandingPageStyles.css"
+        Ok(views.html.main(title, id, js, css))
       } else {
         Redirect(urlWhenDisabled)
       }

--- a/app/controllers/Subscriptions.scala
+++ b/app/controllers/Subscriptions.scala
@@ -46,7 +46,6 @@ class Subscriptions(
   }
 
   def digital(countryCode: String): Action[AnyContent] = CachedAction() { implicit request =>
-    val urlWhenDisabled = s"/$countryCode/subscribe"
     if (request.getQueryString("digiSub").contains("true")) {
       val title = "Support the Guardian | Digital Subscription"
       val id = "digital-subscription-landing-page-" + countryCode
@@ -54,7 +53,7 @@ class Subscriptions(
       val css = "digitalSubscriptionLandingPageStyles.css"
       Ok(views.html.main(title, id, js, css))
     } else {
-      Redirect(urlWhenDisabled)
+      Redirect(s"/$countryCode/subscribe")
     }
   }
 

--- a/app/controllers/Subscriptions.scala
+++ b/app/controllers/Subscriptions.scala
@@ -46,16 +46,17 @@ class Subscriptions(
   }
 
   def digital(countryCode: String): Action[AnyContent] = CachedAction() { implicit request =>
-    request.headers.get("enableDigipack").map { header =>
-      if (header == "true") {
+    val urlWhenDisabled = s"/$countryCode/subscribe"
+    request.headers.get("enableDigipack").map { headerValue =>
+      if (headerValue == "true") {
         val title = "Support the Guardian | Digital Subscription"
         val id = "digital-subscription-landing-page-" + countryCode
         val js = "digitalSubscriptionLandingPage.js"
         Ok(views.html.main(title, id, js))
       } else {
-        Redirect("/subscribe")
+        Redirect(urlWhenDisabled)
       }
-    }.getOrElse(Redirect("/subscribe"))
+    }.getOrElse(Redirect(urlWhenDisabled))
   }
 
 }

--- a/app/controllers/Subscriptions.scala
+++ b/app/controllers/Subscriptions.scala
@@ -47,8 +47,8 @@ class Subscriptions(
 
   def digital(countryCode: String): Action[AnyContent] = CachedAction() { implicit request =>
     val urlWhenDisabled = s"/$countryCode/subscribe"
-    request.headers.get("enableDigipack").map { headerValue =>
-      if (headerValue == "true") {
+    request.getQueryString("digiSub").map { queryValue =>
+      if (queryValue == "true") {
         val title = "Support the Guardian | Digital Subscription"
         val id = "digital-subscription-landing-page-" + countryCode
         val js = "digitalSubscriptionLandingPage.js"

--- a/app/controllers/Subscriptions.scala
+++ b/app/controllers/Subscriptions.scala
@@ -44,4 +44,18 @@ class Subscriptions(
       description = Some(stringsConfig.subscriptionsLandingDescription)
     ))
   }
+
+  def digital(countryCode: String): Action[AnyContent] = CachedAction() { implicit request =>
+    request.headers.get("enableDigipack").map { header =>
+      if (header == "true") {
+        val title = "Support the Guardian | Digital Subscription"
+        val id = "digital-subscription-landing-page-" + countryCode
+        val js = "digitalSubscriptionLandingPage.js"
+        Ok(views.html.main(title, id, js))
+      } else {
+        Redirect("/subscribe")
+      }
+    }.getOrElse(Redirect("/subscribe"))
+  }
+
 }

--- a/assets/components/countryGroupSwitcher/countryGroupSwitcher.jsx
+++ b/assets/components/countryGroupSwitcher/countryGroupSwitcher.jsx
@@ -4,22 +4,33 @@
 
 import React from 'react';
 
-import { countryGroups } from 'helpers/internationalisation/countryGroup';
 import SelectInput from 'components/selectInput/selectInput';
 import SvgGlobe from 'components/svgs/globe';
+
+import {
+  countryGroups,
+  fromString,
+  type CountryGroupId,
+} from 'helpers/internationalisation/countryGroup';
 import { currencies } from 'helpers/internationalisation/currency';
 
-import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { SelectOption } from 'components/selectInput/selectInput';
 
-// ----- Props ----- //
 
+// ----- Props ----- //
 
 type PropTypes = {
   countryGroupIds: CountryGroupId[],
   selectedCountryGroup: CountryGroupId,
-  onCountryGroupSelect: (string) => void,
+  onCountryGroupSelect: CountryGroupId => void,
 };
+
+
+// ----- Functions ----- //
+
+function stringToCountryGroup(cg: string): CountryGroupId {
+  return fromString(cg) || 'GBPCountries';
+}
 
 
 // ----- Component ----- //
@@ -40,7 +51,7 @@ function CountryGroupSwitcher(props: PropTypes) {
       <SelectInput
         id="qa-country-group-dropdown"
         className="component-country-group-switcher__selector"
-        onChange={props.onCountryGroupSelect}
+        onChange={cg => props.onCountryGroupSelect(stringToCountryGroup(cg))}
         options={options}
         label="Select your region"
       />

--- a/assets/components/countryGroupSwitcher/countryGroupSwitcher.jsx
+++ b/assets/components/countryGroupSwitcher/countryGroupSwitcher.jsx
@@ -3,13 +3,14 @@
 // ----- Imports ----- //
 
 import React from 'react';
+import { compose } from 'redux';
 
 import SelectInput from 'components/selectInput/selectInput';
 import SvgGlobe from 'components/svgs/globe';
 
 import {
   countryGroups,
-  fromString,
+  stringToCountryGroup,
   type CountryGroupId,
 } from 'helpers/internationalisation/countryGroup';
 import { currencies } from 'helpers/internationalisation/currency';
@@ -24,13 +25,6 @@ type PropTypes = {
   selectedCountryGroup: CountryGroupId,
   onCountryGroupSelect: CountryGroupId => void,
 };
-
-
-// ----- Functions ----- //
-
-function stringToCountryGroup(cg: string): CountryGroupId {
-  return fromString(cg) || 'GBPCountries';
-}
 
 
 // ----- Component ----- //
@@ -51,7 +45,7 @@ function CountryGroupSwitcher(props: PropTypes) {
       <SelectInput
         id="qa-country-group-dropdown"
         className="component-country-group-switcher__selector"
-        onChange={cg => props.onCountryGroupSelect(stringToCountryGroup(cg))}
+        onChange={compose(props.onCountryGroupSelect, stringToCountryGroup)}
         options={options}
         label="Select your region"
       />

--- a/assets/components/countryGroupSwitcher/countryGroupSwitcher.jsx
+++ b/assets/components/countryGroupSwitcher/countryGroupSwitcher.jsx
@@ -10,7 +10,7 @@ import SvgGlobe from 'components/svgs/globe';
 
 import {
   countryGroups,
-  stringToCountryGroup,
+  stringToCountryGroupId,
   type CountryGroupId,
 } from 'helpers/internationalisation/countryGroup';
 import { currencies } from 'helpers/internationalisation/currency';
@@ -45,7 +45,7 @@ function CountryGroupSwitcher(props: PropTypes) {
       <SelectInput
         id="qa-country-group-dropdown"
         className="component-country-group-switcher__selector"
-        onChange={compose(props.onCountryGroupSelect, stringToCountryGroup)}
+        onChange={compose(props.onCountryGroupSelect, stringToCountryGroupId)}
         options={options}
         label="Select your region"
       />

--- a/assets/components/headers/countrySwitcherHeader/countrySwitcherHeader.jsx
+++ b/assets/components/headers/countrySwitcherHeader/countrySwitcherHeader.jsx
@@ -8,10 +8,10 @@ import SvgGuardianLogo from 'components/svgs/guardianLogo';
 import CountryGroupSwitcher from 'components/countryGroupSwitcher/countryGroupSwitcher';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
-type PropTypes = {
+export type PropTypes = {
   countryGroupIds: CountryGroupId[],
   selectedCountryGroup: CountryGroupId,
-  onCountryGroupSelect: (string) => void,
+  onCountryGroupSelect: CountryGroupId => void,
 };
 
 

--- a/assets/components/headers/countrySwitcherHeader/countrySwitcherHeaderContainer.js
+++ b/assets/components/headers/countrySwitcherHeader/countrySwitcherHeaderContainer.js
@@ -15,8 +15,8 @@ import type { PropTypes } from './countrySwitcherHeader';
 
 export default function (subPath: string, listOfCountries: CountryGroupId[]) {
 
-  function handleChange(cg: CountryGroupId): void {
-    window.location.pathname = `/${countryGroups[cg].supportInternationalisationId}${subPath}`;
+  function handleChange(cgId: CountryGroupId): void {
+    window.location.pathname = `/${countryGroups[cgId].supportInternationalisationId}${subPath}`;
   }
 
   function mapStateToProps(state: { common: CommonState }): PropTypes {

--- a/assets/components/headers/countrySwitcherHeader/countrySwitcherHeaderContainer.js
+++ b/assets/components/headers/countrySwitcherHeader/countrySwitcherHeaderContainer.js
@@ -6,55 +6,28 @@ import { connect } from 'react-redux';
 
 import CountrySwitcherHeader from 'components/headers/countrySwitcherHeader/countrySwitcherHeader';
 
-import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { countryGroups, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { CommonState } from 'helpers/page/page';
+import type { PropTypes } from './countrySwitcherHeader';
 
 
-const availableCountriesGroups: CountryGroupId[] =
-  ['GBPCountries', 'UnitedStates', 'EURCountries', 'NZDCountries', 'Canada', 'International', 'AUDCountries'];
+// ------ Component ----- //
 
-// ----- Functions ----- //
+export default function (subPath: string, listOfCountries: CountryGroupId[]) {
 
-function handleCountryGroupChange(value: string): void {
-  switch (value) {
-    case 'UnitedStates':
-      window.location.pathname = '/us/contribute';
-      break;
-    case 'GBPCountries':
-      window.location.pathname = '/uk/contribute';
-      break;
-    case 'EURCountries':
-      window.location.pathname = '/eu/contribute';
-      break;
-    case 'NZDCountries':
-      window.location.pathname = '/nz/contribute';
-      break;
-    case 'Canada':
-      window.location.pathname = '/ca/contribute';
-      break;
-    case 'International':
-      window.location.pathname = '/int/contribute';
-      break;
-    case 'AUDCountries':
-      window.location.pathname = '/au/contribute';
-      break;
-    default:
+  function handleChange(cg: CountryGroupId): void {
+    window.location.pathname = `/${countryGroups[cg].supportInternationalisationId}${subPath}`;
   }
+
+  function mapStateToProps(state: { common: CommonState }): PropTypes {
+
+    return {
+      countryGroupIds: listOfCountries,
+      selectedCountryGroup: state.common.countryGroup,
+      onCountryGroupSelect: handleChange,
+    };
+  }
+
+  return connect(mapStateToProps)(CountrySwitcherHeader);
+
 }
-
-
-// ----- State Maps ----- //
-
-function mapStateToProps(state: { common: CommonState }) {
-
-  return {
-    countryGroupIds: availableCountriesGroups,
-    selectedCountryGroup: state.common.countryGroup,
-    onCountryGroupSelect: handleCountryGroupChange,
-  };
-}
-
-
-// ----- Exports ----- //
-
-export default connect(mapStateToProps)(CountrySwitcherHeader);

--- a/assets/helpers/internationalisation/countryGroup.js
+++ b/assets/helpers/internationalisation/countryGroup.js
@@ -157,4 +157,5 @@ function detect(): CountryGroupId {
 export {
   countryGroups,
   detect,
+  fromString,
 };

--- a/assets/helpers/internationalisation/countryGroup.js
+++ b/assets/helpers/internationalisation/countryGroup.js
@@ -160,8 +160,8 @@ function detect(): CountryGroupId {
   return fromPath() || fromQueryParameter() || fromCookie() || fromGeolocation() || 'GBPCountries';
 }
 
-function stringToCountryGroup(cg: string): CountryGroupId {
-  return fromString(cg) || 'GBPCountries';
+function stringToCountryGroup(cgId: string): CountryGroupId {
+  return fromString(cgId) || 'GBPCountries';
 }
 
 

--- a/assets/helpers/internationalisation/countryGroup.js
+++ b/assets/helpers/internationalisation/countryGroup.js
@@ -160,8 +160,8 @@ function detect(): CountryGroupId {
   return fromPath() || fromQueryParameter() || fromCookie() || fromGeolocation() || 'GBPCountries';
 }
 
-function stringToCountryGroup(cgId: string): CountryGroupId {
-  return fromString(cgId) || 'GBPCountries';
+function stringToCountryGroupId(countryGroupId: string): CountryGroupId {
+  return fromString(countryGroupId) || 'GBPCountries';
 }
 
 
@@ -170,5 +170,5 @@ function stringToCountryGroup(cgId: string): CountryGroupId {
 export {
   countryGroups,
   detect,
-  stringToCountryGroup,
+  stringToCountryGroupId,
 };

--- a/assets/helpers/internationalisation/countryGroup.js
+++ b/assets/helpers/internationalisation/countryGroup.js
@@ -8,6 +8,9 @@ import { getQueryParameter } from 'helpers/url';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 
+
+// ----- Types ----- //
+
 export type CountryGroupId = 'GBPCountries' | 'UnitedStates' | 'AUDCountries' | 'EURCountries' | 'International' | 'NZDCountries' | 'Canada';
 
 /*
@@ -82,6 +85,9 @@ const countryGroups: CountryGroups = {
   },
 };
 
+
+// ----- Functions ----- //
+
 function fromPath(path: string = window.location.pathname): ?CountryGroupId {
   if (path === '/uk' || path.startsWith('/uk/')) {
     return 'GBPCountries';
@@ -154,8 +160,15 @@ function detect(): CountryGroupId {
   return fromPath() || fromQueryParameter() || fromCookie() || fromGeolocation() || 'GBPCountries';
 }
 
+function stringToCountryGroup(cg: string): CountryGroupId {
+  return fromString(cg) || 'GBPCountries';
+}
+
+
+// ----- Exports ----- //
+
 export {
   countryGroups,
   detect,
-  fromString,
+  stringToCountryGroup,
 };

--- a/assets/pages/contributions-landing/contributionsLanding.jsx
+++ b/assets/pages/contributions-landing/contributionsLanding.jsx
@@ -36,6 +36,7 @@ const store = pageInit(createPageReducerFor(countryGroupId));
 
 const oneOffOnlyVariant = (store && store.getState().common.abParticipations.ContributeLandingOneOffOnlyTest) || 'notintest';
 
+
 // ----- Internationalisation ----- //
 
 const defaultHeaderCopy = ['Help us deliver', 'the independent', 'journalism the', 'world needs'];
@@ -87,6 +88,11 @@ const countryGroupSpecificDetails: {
   },
 };
 
+const CountrySwitcherHeader = CountrySwitcherHeaderContainer(
+  '/contribute',
+  ['GBPCountries', 'UnitedStates', 'EURCountries', 'NZDCountries', 'Canada', 'International', 'AUDCountries'],
+);
+
 
 // ----- Render ----- //
 
@@ -107,7 +113,7 @@ if (desktopAboveTheFold === 'variant') {
 const content = (
   <Provider store={store}>
     <div className="gu-content">
-      <CountrySwitcherHeaderContainer />
+      <CountrySwitcherHeader />
       <CirclesIntroduction
         headings={countryGroupSpecificDetails[countryGroupId].headerCopy}
         highlights={['Support', 'The Guardian']}

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -43,7 +43,10 @@ const CountrySwitcherHeader = countrySwitcherHeaderContainer(
 const content = (
   <Provider store={store}>
     <div>
-      <CountrySwitcherHeader />
+      <CountrySwitcherHeader /> { /* https://trello.com/c/IrhfApmz/1456-digital-pack-product-page-aus */ }
+      { /* <DigipackHeaderBlock /> (https://trello.com/c/LDgBVJWi/1601-digital-pack-header-block) */ }
+      { /* <DigipackProductBlock /> (https://trello.com/c/8UBqJMTP/1532-digital-pack-product-block) */ }
+      { /* <DigipackJournalismBlock /> (https://trello.com/c/owe2K3bS/1533-independent-journalism-block) */ }
       <Footer />
     </div>
   </Provider>

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -3,20 +3,50 @@
 // ----- Imports ----- //
 
 import React from 'react';
+import { Provider } from 'react-redux';
 
 import { renderPage } from 'helpers/render';
+import { detect, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
-import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
+import countrySwitcherHeaderContainer from 'components/headers/countrySwitcherHeader/countrySwitcherHeaderContainer';
 import Footer from 'components/footer/footer';
+
+import { init as pageInit } from 'helpers/page/page';
+
+
+// ----- Redux Store ----- //
+
+const store = pageInit();
+
+
+// ----- Internationalisation ----- //
+
+const countryGroupId: CountryGroupId = detect();
+
+const reactElementId: {
+  [CountryGroupId]: string,
+} = {
+  GBPCountries: 'digital-subscription-landing-page-uk',
+  UnitedStates: 'digital-subscription-landing-page-us',
+  AUDCountries: 'digital-subscription-landing-page-au',
+  International: 'digital-subscription-landing-page-int',
+};
+
+const CountrySwitcherHeader = countrySwitcherHeaderContainer(
+  '/subscribe/digital',
+  ['GBPCountries', 'UnitedStates', 'AUDCountries', 'International'],
+);
 
 
 // ----- Render ----- //
 
 const content = (
-  <div>
-    <SimpleHeader />
-    <Footer />
-  </div>
+  <Provider store={store}>
+    <div>
+      <CountrySwitcherHeader />
+      <Footer />
+    </div>
+  </Provider>
 );
 
-renderPage(content, 'digital-subscription-landing-page');
+renderPage(content, reactElementId[countryGroupId]);

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -1,0 +1,22 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+import { renderPage } from 'helpers/render';
+
+import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
+import Footer from 'components/footer/footer';
+
+
+// ----- Render ----- //
+
+const content = (
+  <div>
+    <SimpleHeader />
+    <Footer />
+  </div>
+);
+
+renderPage(content, 'digital-subscription-landing-page');

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -1,0 +1,20 @@
+// -----  gu-sass ----- //
+
+@import '~stylesheets/gu-sass/gu-sass';
+
+
+// ----- Shared Components ----- //
+
+@import '~components/footer/footer';
+@import '~components/headers/countrySwitcherHeader/countrySwitcherHeader';
+@import '~components/countryGroupSwitcher/countryGroupSwitcher';
+
+
+// ----- Page-Specific Styles ----- //
+
+#digital-subscription-landing-page-int,
+#digital-subscription-landing-page-uk,
+#digital-subscription-landing-page-us,
+#digital-subscription-landing-page-au {
+  // your code here
+}

--- a/assets/pages/support-landing/supportLanding.jsx
+++ b/assets/pages/support-landing/supportLanding.jsx
@@ -38,12 +38,20 @@ const supporterSectionId = 'supporter-options';
 const store = pageInit(pageReducer);
 
 
+// ----- Internationalisation ----- //
+
+const CountrySwitcherHeader = CountrySwitcherHeaderContainer(
+  '/contribute',
+  ['GBPCountries', 'UnitedStates', 'EURCountries', 'NZDCountries', 'Canada', 'International', 'AUDCountries'],
+);
+
+
 // ----- Render ----- //
 
 const content = (
   <Provider store={store}>
     <div>
-      <CountrySwitcherHeaderContainer />
+      <CountrySwitcherHeader />
       <CirclesIntroduction
         headings={['Help us deliver', 'the independent', 'journalism the', 'world needs']}
         highlights={['Support', 'The Guardian']}

--- a/conf/routes
+++ b/conf/routes
@@ -66,10 +66,10 @@ GET  /uk/subscribe                                 controllers.Subscriptions.lan
 # subscribe route. We just redirect to the subscriptions site and let its geolocation handle it.
 GET  /:countryCode/subscribe                       controllers.Subscriptions.legacyRedirect(countryCode: String)
 
-GET  /uk/subscribe/digital                         controllers.Application.reactTemplate(title="Support the Guardian | Digital Subscription", id="digital-subscription-landing-page-uk", js="digitalSubscriptionLandingPage.js")
-GET  /us/subscribe/digital                         controllers.Application.reactTemplate(title="Support the Guardian | Digital Subscription", id="digital-subscription-landing-page-us", js="digitalSubscriptionLandingPage.js")
-GET  /au/subscribe/digital                         controllers.Application.reactTemplate(title="Support the Guardian | Digital Subscription", id="digital-subscription-landing-page-au", js="digitalSubscriptionLandingPage.js")
-GET  /int/subscribe/digital                        controllers.Application.reactTemplate(title="Support the Guardian | Digital Subscription", id="digital-subscription-landing-page-int", js="digitalSubscriptionLandingPage.js")
+GET  /uk/subscribe/digital                         controllers.Subscriptions.digital(countryCode="uk")
+GET  /us/subscribe/digital                         controllers.Subscriptions.digital(countryCode="us")
+GET  /au/subscribe/digital                         controllers.Subscriptions.digital(countryCode="au")
+GET  /int/subscribe/digital                        controllers.Subscriptions.digital(countryCode="int")
 
 # ----- Authentication ----- #
 

--- a/conf/routes
+++ b/conf/routes
@@ -66,7 +66,10 @@ GET  /uk/subscribe                                 controllers.Subscriptions.lan
 # subscribe route. We just redirect to the subscriptions site and let its geolocation handle it.
 GET  /:countryCode/subscribe                       controllers.Subscriptions.legacyRedirect(countryCode: String)
 
-GET  /uk/subscribe/digital                         controllers.Application.reactTemplate(title="Support the Guardian | Digital Subscription", id="digital-subscription-landing-page", js="digitalSubscriptionLandingPage.js")
+GET  /uk/subscribe/digital                         controllers.Application.reactTemplate(title="Support the Guardian | Digital Subscription", id="digital-subscription-landing-page-uk", js="digitalSubscriptionLandingPage.js")
+GET  /us/subscribe/digital                         controllers.Application.reactTemplate(title="Support the Guardian | Digital Subscription", id="digital-subscription-landing-page-us", js="digitalSubscriptionLandingPage.js")
+GET  /au/subscribe/digital                         controllers.Application.reactTemplate(title="Support the Guardian | Digital Subscription", id="digital-subscription-landing-page-au", js="digitalSubscriptionLandingPage.js")
+GET  /int/subscribe/digital                        controllers.Application.reactTemplate(title="Support the Guardian | Digital Subscription", id="digital-subscription-landing-page-int", js="digitalSubscriptionLandingPage.js")
 
 # ----- Authentication ----- #
 

--- a/conf/routes
+++ b/conf/routes
@@ -58,6 +58,7 @@ GET  /contribute/one-off/thankyou                   controllers.OneOffContributi
 GET  /contribute/one-off/autofill                   controllers.OneOffContributions.autofill
 
 # ----- Subscriptions ----- #
+
 GET  /subscribe                                    controllers.Subscriptions.geoRedirect()
 GET  /uk/subscribe                                 controllers.Subscriptions.landing(title="Support the Guardian | Get a Subscription", id="subscriptions-landing-page", js="subscriptionsLandingPage.js")
 
@@ -65,6 +66,7 @@ GET  /uk/subscribe                                 controllers.Subscriptions.lan
 # subscribe route. We just redirect to the subscriptions site and let its geolocation handle it.
 GET  /:countryCode/subscribe                       controllers.Subscriptions.legacyRedirect(countryCode: String)
 
+GET  /uk/subscribe/digital                         controllers.Application.reactTemplate(title="Support the Guardian | Digital Subscription", id="digital-subscription-landing-page", js="digitalSubscriptionLandingPage.js")
 
 # ----- Authentication ----- #
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,11 @@
 User-agent: *
 
+Disallow: /subscribe/digital
+Disallow: /uk/subscribe/digital
+Disallow: /us/subscribe/digital
+Disallow: /au/subscribe/digital
+Disallow: /int/subscribe/digital
+
 Allow: /
 
 Sitemap: https://support.theguardian.com/sitemap.xml

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -29,6 +29,7 @@ module.exports = (cssFilename, outputFilename, minimizeCss) => ({
     contributionsLandingPage: 'pages/contributions-landing/contributionsLanding.jsx',
     contributionsLandingPageStyles: 'pages/contributions-landing/contributionsLanding.scss',
     digitalSubscriptionLandingPage: 'pages/digital-subscription-landing/digitalSubscriptionLanding.jsx',
+    digitalSubscriptionLandingPageStyles: 'pages/digital-subscription-landing/digitalSubscriptionLanding.scss',
     regularContributionsPage: 'pages/regular-contributions/regularContributions.jsx',
     regularContributionsPageStyles: 'pages/regular-contributions/regularContributions.scss',
     oneoffContributionsPage: 'pages/oneoff-contributions/oneoffContributions.jsx',

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -28,6 +28,7 @@ module.exports = (cssFilename, outputFilename, minimizeCss) => ({
     subscriptionsLandingPageStyles: 'pages/subscriptions-landing/subscriptionsLanding.scss',
     contributionsLandingPage: 'pages/contributions-landing/contributionsLanding.jsx',
     contributionsLandingPageStyles: 'pages/contributions-landing/contributionsLanding.scss',
+    digitalSubscriptionLandingPage: 'pages/digital-subscription-landing/digitalSubscriptionLanding.jsx',
     regularContributionsPage: 'pages/regular-contributions/regularContributions.jsx',
     regularContributionsPageStyles: 'pages/regular-contributions/regularContributions.scss',
     oneoffContributionsPage: 'pages/oneoff-contributions/oneoffContributions.jsx',


### PR DESCRIPTION
## Why are you doing this?

This creates the skeleton of a page for the digital subscription. This will be filled in with a few independent sections.

[**Trello Card**](https://trello.com/c/P4kYc7Av/1451-product-page-uk)

## Changes

- Added new controller method for the page, which puts in behind a query param while in dev.
- Updated the `CountryGroupSwitcher` and `CountrySwitcherHeader` to be more generic, so we can use them for any internationalised URL. Now takes a `subPath` and a list of countries, and returns a connected component.
- Created a new method `stringToCountryGroup`.
- Added a new JSX entry point for the digital subscription page.
- Added routes for the new, internationalised digital sub page.
- Put the new routes in `robots.txt` for now.
