### PR TITLE
Change "with card or Paypal" to "a month"

### DIFF
--- a/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
+++ b/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
@@ -146,7 +146,7 @@ function RegularCta(props: {
   return (
     <CtaLink
       ctaId="contribute-regular"
-      text={`Contribute ${props.currency.glyph}${props.amount} with card or PayPal`}
+      text={`Contribute ${props.currency.glyph}${props.amount} a month`}
       accessibilityHint={`proceed to make your ${spokenType} contribution`}
       url={clickUrl}
       onClick={onCtaClick(props.isDisabled, props.resetError)}


### PR DESCRIPTION
## What?

Change the recurring CTA on the landing page from "Contribute <amount> with card or Paypal" to "<amount> a month" 

## Why are you doing this?

This has been requested by UX as it isn't even accurate any more: we also have direct debit in the UK, and the logos already convey that we provide card and paypal

## Screenshots
| Before | After |
|---------|--------|
|![paypl](https://user-images.githubusercontent.com/2844554/40727268-70d552e0-641f-11e8-980e-5a8c960cfca2.png)|![5 a month](https://user-images.githubusercontent.com/2844554/40727252-6754eaa0-641f-11e8-8905-7ee87d41e8f8.png)|