### PR TITLE
Circles Brand PayPal Error

### DIFF
--- a/assets/pages/paypal-error/payPalError.jsx
+++ b/assets/pages/paypal-error/payPalError.jsx
@@ -7,12 +7,12 @@ import React from 'react';
 import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
 import Footer from 'components/footer/footer';
 import CtaLink from 'components/ctaLink/ctaLink';
-import InfoSection from 'components/infoSection/infoSection';
-import SocialShare from 'components/socialShare/socialShare';
+import PageSection from 'components/pageSection/pageSection';
+import QuestionsContact from 'components/questionsContact/questionsContact';
+import SpreadTheWord from 'components/spreadTheWord/spreadTheWord';
 
 import { statelessInit as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
-import { contributionsEmail } from 'helpers/legal';
 
 
 // ----- Page Startup ----- //
@@ -23,41 +23,24 @@ pageInit();
 // ----- Render ----- //
 
 const content = (
-  <div className="gu-content">
+  <div className="paypal-error gu-content">
     <SimpleHeader />
-    <section className="paypal-error gu-content-filler">
-      <div className="paypal-error__content gu-content-filler__inner">
-        <div className="paypal-error__wrapper">
-          <h1 className="paypal-error__heading">PayPal Error!</h1>
-          <h2 className="paypal-error__subheading">
-            <p>Sorry, there was a problem completing your PayPal payment. Please try again:</p>
-          </h2>
-          <CtaLink
-            ctaId="become-supporter-paypal"
-            text="Become a Supporter"
-            url="https://support.theguardian.com/uk"
-            accessibilityHint="Restart your journey to become a guardian supporter"
-          />
-        </div>
-        <InfoSection heading="Questions?" className="paypal-error__questions">
-          <p>
-            If you have any questions about contributing to the Guardian,
-            please <a href={contributionsEmail}>contact us</a>
-          </p>
-        </InfoSection>
-        <InfoSection
-          heading="Spread the word"
-          className="paypal-error__spread-the-word"
-        >
-          <p>
-            We report for everyone. Let your friends and followers know that
-            you support independent journalism.
-          </p>
-          <SocialShare name="facebook" />
-          <SocialShare name="twitter" />
-        </InfoSection>
-      </div>
-    </section>
+    <PageSection
+      modifierClass="paypal-error"
+    >
+      <h1 className="paypal-error__heading">PayPal Error!</h1>
+      <p className="paypal-error__copy">
+        Sorry, there was a problem completing your PayPal payment. Please try again:
+      </p>
+      <CtaLink
+        ctaId="become-supporter-paypal"
+        text="Become a Supporter"
+        url="/"
+        accessibilityHint="Restart your journey to become a guardian supporter"
+      />
+    </PageSection>
+    <QuestionsContact />
+    <SpreadTheWord />
     <Footer />
   </div>
 );

--- a/assets/pages/paypal-error/payPalError.scss
+++ b/assets/pages/paypal-error/payPalError.scss
@@ -8,7 +8,9 @@
 @import '~components/ctaLink/ctaLink';
 @import '~components/footer/footer';
 @import '~components/headers/simpleHeader/simpleHeader';
-@import '~components/infoSection/infoSection';
+@import '~components/pageSection/pageSection';
+@import '~components/questionsContact/questionsContact';
+@import '~components/spreadTheWord/spreadTheWord';
 @import '~components/socialShare/socialShare';
 
 
@@ -16,32 +18,11 @@
 
 #paypal-error-page {
 
-  a {
-    color: gu-colour(neutral-1);
-  }
-
   // ----- Headings
-
-  .paypal-error {
-    background-color: darken(gu-colour(multimedia-main-2), 5%);
-  }
-
-  .paypal-error__content {
-    background-color: gu-colour(multimedia-main-2);
-    padding: $gu-v-spacing $gu-h-spacing;
-  }
-
-  .paypal-error__wrapper {
-
-    @include mq($from: desktop) {
-      margin-left: 20%;
-      margin-right: 20%;
-    }
-  }
 
   .paypal-error__heading {
     font-family: $gu-egyptian-web;
-    color: gu-colour(neutral-1);
+    color: gu-colour(garnett-neutral-1);
     font-size: 28px;
     line-height: 32px;
     font-weight: bold;
@@ -52,49 +33,56 @@
     }
   }
 
-  .paypal-error__subheading {
+  .paypal-error__copy {
     font-family: $gu-egyptian-web;
-    font-size: 28px;
-    line-height: 32px;
+    font-size: 24px;
+    line-height: 28px;
     font-weight: lighter;
-    color: gu-colour(neutral-1);
+    color: gu-colour(garnett-neutral-1);
+    margin: $gu-v-spacing 0;
 
     @include mq($from: desktop) {
-      font-size: 36px;
-      line-height: 40px;
+      font-size: 28px;
+      line-height: 32px;
+      width: 600px;
+    }
+  }
+
+  .component-page-section__body {
+    padding-top: $gu-v-spacing;
+
+    @include mq($from: desktop) {
+      padding-left: $gu-h-spacing;
     }
   }
 
   .component-cta-link {
-    color: #fff;
-    background: gu-colour(neutral-1);
+    color: gu-colour(garnett-neutral-1);
+    background-color: gu-colour(news-garnett-highlight);
     box-sizing: border-box;
     display: inline-block;
     width: 230px;
-    line-height: 40px;
-    border: 1px solid gu-colour(neutral-1);
+    line-height: 44px;
     font-weight: normal;
     margin-bottom: $gu-v-spacing * 4;
     padding-top: 0;
     padding-bottom: 0;
+    transition: background-color .3s;
 
-    svg {
-      fill: #fff;
-      top: 10px;
+    .svg-arrow-right-straight {
+      fill: gu-colour(garnett-neutral-1);;
+      top: 14px;
+      height: 35%;
       // Fix for IE10.
-      left: 190px;
+      left: 197px;
     }
 
     &:hover {
-      background: darken(gu-colour(neutral-1), 10%);
+      background-color: darken(gu-colour(news-garnett-highlight), 5%);
     }
   }
 
-  .component-social-share {
-    margin-right: $gu-h-spacing / 2;
-
-    svg {
-      margin-top: $gu-v-spacing;
-    }
+  .component-spread-the-word {
+    @include gu-content-filler;
   }
 }


### PR DESCRIPTION
## Why are you doing this?

These are really out of date, this applies newer branding. It also reduces the usage of some legacy components and styles, that will now hopefully move closer to deletion.

[**Trello Card**](https://trello.com/c/Rud2TjYy/1605-paypal-error-pages-refresh)

cc @JustinPinner 

## Changes

- Used more off-the-shelf components for the PayPal error pages.
- Brought the styling more inline with current brand.
- Set the URL on the CTA to `/`, as `/uk` was too country-specific.

## Screenshots

**Before**

![paypal-desktop-before](https://user-images.githubusercontent.com/5131341/40731668-75ed3f18-6429-11e8-9c88-9ec1ed2f3607.png)
![paypal-mobile-before](https://user-images.githubusercontent.com/5131341/40731669-76035a46-6429-11e8-8d51-fc590653161d.png)

**After**

![paypal-desktop-after](https://user-images.githubusercontent.com/5131341/40731676-7be6c916-6429-11e8-8e8d-2e044d391ec2.png)
![paypal-mobile-after](https://user-images.githubusercontent.com/5131341/40731678-7c096a2a-6429-11e8-9c64-333a01ed4bde.png)
