### PR TITLE
Tidy Up CtaLink

### DIFF
--- a/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
+++ b/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
@@ -121,7 +121,7 @@ function OneOffCta(props: {
       url={clickUrl}
       onClick={onCtaClick(props.isDisabled, props.resetError)}
       id="qa-contribute-button"
-      modifierClasses={['contribute-one-off']}
+      modifierClasses={['contribute-one-off', 'border']}
     />
   );
 

--- a/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
+++ b/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
@@ -121,6 +121,7 @@ function OneOffCta(props: {
       url={clickUrl}
       onClick={onCtaClick(props.isDisabled, props.resetError)}
       id="qa-contribute-button"
+      modifierClasses={['contribute-one-off']}
     />
   );
 
@@ -151,6 +152,7 @@ function RegularCta(props: {
       url={clickUrl}
       onClick={onCtaClick(props.isDisabled, props.resetError)}
       id="qa-contribute-button"
+      modifierClasses={['contribute-regular']}
     />
   );
 

--- a/assets/components/contributionPaymentCtas/contributionPaymentCtas.scss
+++ b/assets/components/contributionPaymentCtas/contributionPaymentCtas.scss
@@ -28,14 +28,8 @@
   .component-cta-link--contribute-one-off {
     background-color: transparent;
     margin-top: $gu-v-spacing;
-    border: 1px solid gu-colour(garnett-neutral-1);
-    height: $cta-height - 2;
-    line-height: $cta-height - 2;
+    border-color: gu-colour(garnett-neutral-1);
     width: 258px;
-
-    svg {
-      top: 13px;
-    }
 
     &:hover {
       background-color: transparent;

--- a/assets/components/contributionPaymentCtas/contributionPaymentCtas.scss
+++ b/assets/components/contributionPaymentCtas/contributionPaymentCtas.scss
@@ -6,14 +6,14 @@
 
   .component-cta-link {
     color: gu-colour(garnett-neutral-1);
-    height: $cta-height;
-    line-height: $cta-height;
-    box-sizing: border-box;
-    padding: 0 $gu-h-spacing;
 
     @include mq($from: mobileMedium) {
-      width: $cta-width;
+      width: 260px;
     }
+  }
+
+  .svg-arrow-right-straight {
+    fill: gu-colour(garnett-neutral-1);
   }
 
   .component-cta-link--contribute-regular {
@@ -27,31 +27,24 @@
 
   .component-cta-link--contribute-one-off {
     background-color: transparent;
-    border: 1px solid;
+    margin-top: $gu-v-spacing;
+    border: 1px solid gu-colour(garnett-neutral-1);
+    height: $cta-height - 2;
+    line-height: $cta-height - 2;
+    width: 258px;
+
+    svg {
+      top: 13px;
+    }
 
     &:hover {
       background-color: transparent;
     }
   }
 
-  .svg-arrow-right-straight {
-    fill: gu-colour(garnett-neutral-1);
-    width: 20px;
-    top: 50%;
-    transform: translateY(-50%);
-    right: 15px;
-
-    @include mq($from: mobileMedium) {
-      left: 268px;
-    }
-  }
-
   .component-paypal-contribution-button {
-    height: $cta-height;
-    width: 100%;
-
     @include mq($from: mobileMedium) {
-      width: $cta-width;
+      width: 300px;
     }
   }
 

--- a/assets/components/ctaLink/ctaLink.jsx
+++ b/assets/components/ctaLink/ctaLink.jsx
@@ -26,6 +26,7 @@ type PropTypes = {
   id?: ?string,
   svg?: Node,
   acquisitionData?: ?ReferrerAcquisitionData,
+  modifierClasses: Array<?string>,
 };
 
 // ----- Component ----- //
@@ -38,7 +39,7 @@ export default function CtaLink(props: PropTypes) {
   return (
     <a
       id={props.id}
-      className={classNameWithModifiers('component-cta-link', [props.ctaId])}
+      className={classNameWithModifiers('component-cta-link', props.modifierClasses)}
       href={props.acquisitionData ?
         addQueryParamToURL(urlString, 'acquisitionData', JSON.stringify(props.acquisitionData))
          : props.url
@@ -68,6 +69,7 @@ export default function CtaLink(props: PropTypes) {
 
 // ----- Default Props ----- //
 
+/* eslint-disable react/default-props-match-prop-types */
 CtaLink.defaultProps = {
   url: null,
   trackComponentEvent: () => {},
@@ -76,4 +78,6 @@ CtaLink.defaultProps = {
   id: null,
   svg: <SvgArrowRightStraight />,
   acquisitionData: null,
+  modifierClasses: [],
 };
+/* eslint-enable react/default-props-match-prop-types */

--- a/assets/components/ctaLink/ctaLink.scss
+++ b/assets/components/ctaLink/ctaLink.scss
@@ -1,5 +1,6 @@
 .component-cta-link {
-  background-color: gu-colour(neutral-1);
+  background-color: gu-colour(garnett-neutral-1);
+  transition: background-color .3s;
   border: none;
   border-radius: 600px;
   color: #fff;
@@ -8,23 +9,20 @@
   font-family: $gu-text-sans-web;
   font-size: 14px;
   height: $cta-height;
-  line-height: 180%;
-  margin-top: 12px;
-  padding: 6px 20px;
+  line-height: $cta-height;
+  padding: 0 $gu-h-spacing;
   position: relative;
-  text-align: left;
   text-decoration: none;
-  vertical-align: bottom;
 
   &:hover {
-    background-color: #000;
+    background-color: darken(gu-colour(garnett-neutral-1), 5%);
   }
 
   svg {
-    height: 50%;
+    height: 16px;
     position: absolute;
-    right: 8px;
-    top: 9px;
+    left: calc(100% - 34px);
+    top: 14px;
     fill: #fff;
   }
 }

--- a/assets/components/ctaLink/ctaLink.scss
+++ b/assets/components/ctaLink/ctaLink.scss
@@ -26,3 +26,14 @@
     fill: #fff;
   }
 }
+
+.component-cta-link--border {
+  border: 1px solid;
+  height: $cta-height - 2;
+  line-height: $cta-height - 2;
+
+  svg {
+    top: 13px;
+    left: calc(100% - 33px);
+  }
+}

--- a/assets/components/dotcomCta/dotcomCta.scss
+++ b/assets/components/dotcomCta/dotcomCta.scss
@@ -1,36 +1,11 @@
 .component-dotcom-cta {
-
   .component-cta-link {
-    background-color: gu-colour(garnett-neutral-1);
-    border: 1px solid gu-colour(garnett-neutral-1);
-    color: #fff;
-    height: $cta-height;
-    line-height: $cta-height;
-    padding: 0 30px 0 25px;
-    transition: background-color .3s;
-    margin: 0;
-
     @include mq($from: mobileMedium) {
       width: 300px;
-    }
-
-    &:hover {
-      background-color: darken(gu-colour(garnett-neutral-1), 10%);
     }
   }
 
   .component-page-section__body {
     padding-bottom: $gu-v-spacing * 3;
-  }
-
-  .svg-arrow-right-straight {
-    height: 35%;
-    top: 17px;
-    right: 13px;
-
-    // Fix for IE.
-    @include mq($from: mobileMedium) {
-      left: 321px;
-    }
   }
 }

--- a/assets/components/patronsEvents/patronsEvents.scss
+++ b/assets/components/patronsEvents/patronsEvents.scss
@@ -89,9 +89,8 @@
     background: transparent;
     color: gu-colour(garnett-neutral-1);
     border: 1px solid gu-colour(garnett-neutral-1);
-    height: $cta-height;
-    line-height: $cta-height;
-    padding: 0 30px 0 25px;
+    height: $cta-height - 2;
+    line-height: $cta-height - 2;
     transition: background-color .3s;
 
     &:hover {
@@ -106,13 +105,6 @@
 
   .svg-arrow-right-straight {
     fill: gu-colour(garnett-neutral-1);
-    height: 35%;
-    top: 14px;
-    right: 13px;
-
-    // Fix for IE.
-    @include mq($from: tablet) {
-      left: 89%;
-    }
+    top: 13px;
   }
 }

--- a/assets/components/readyToSupport/readyToSupport.jsx
+++ b/assets/components/readyToSupport/readyToSupport.jsx
@@ -32,6 +32,7 @@ export default function ReadyToSupport(props: PropTypes) {
           ctaId="see-supporter-options"
           accessibilityHint="See the options for becoming a supporter"
           svg={<SvgChevronUp />}
+          modifierClasses={['see-supporter-options']}
         />
       </div>
     </section>

--- a/assets/components/readyToSupport/readyToSupport.scss
+++ b/assets/components/readyToSupport/readyToSupport.scss
@@ -59,12 +59,7 @@
 }
 
 .component-cta-link--see-supporter-options {
-  height: $cta-height;
-  padding: 0 30px;
-  font-size: 14px;
-  line-height: $cta-height;
   background-color: gu-colour(lifestyle-garnett-main-1);
-  transition: background-color .3s;
 
   @include mq($from: tablet) {
     width: 500px;
@@ -77,11 +72,6 @@
   .svg-chevron-up {
     height: 70%;
     top: 8px;
-    right: 15px;
-
-    // Fix for IE.
-    @include mq($from: tablet) {
-      left: 91%;
-    }
+    left: calc(100% - 44px);
   }
 }

--- a/assets/components/subscriptionBundle/subscriptionBundle.jsx
+++ b/assets/components/subscriptionBundle/subscriptionBundle.jsx
@@ -48,6 +48,7 @@ export default function SubscriptionBundle(props: PropTypes) {
           url={props.ctaUrl}
           ctaId={props.ctaId}
           accessibilityHint={props.ctaAccessibilityHint}
+          modifierClasses={[props.modifierClass]}
         />
       </div>
     </div>

--- a/assets/components/subscriptionBundle/subscriptionBundle.jsx
+++ b/assets/components/subscriptionBundle/subscriptionBundle.jsx
@@ -27,6 +27,7 @@ type PropTypes = {
   ctaId: string,
   ctaAccessibilityHint: string,
   gridImage: GridImg,
+  ctaModifiers?: Array<?string>,
 };
 
 
@@ -48,7 +49,7 @@ export default function SubscriptionBundle(props: PropTypes) {
           url={props.ctaUrl}
           ctaId={props.ctaId}
           accessibilityHint={props.ctaAccessibilityHint}
-          modifierClasses={[props.modifierClass]}
+          modifierClasses={props.ctaModifiers}
         />
       </div>
     </div>
@@ -61,4 +62,5 @@ export default function SubscriptionBundle(props: PropTypes) {
 
 SubscriptionBundle.defaultProps = {
   modifierClass: '',
+  ctaModifiers: [],
 };

--- a/assets/components/threeSubscriptions/threeSubscriptions.jsx
+++ b/assets/components/threeSubscriptions/threeSubscriptions.jsx
@@ -73,6 +73,7 @@ function DigitalBundle(props: { url: string }) {
         altText: 'digital subscription',
         ...gridImageProperties,
       }}
+      ctaModifiers={['digital', 'border']}
     />
   );
 
@@ -95,6 +96,7 @@ function PaperBundle(props: { url: string }) {
         altText: 'paper subscription',
         ...gridImageProperties,
       }}
+      ctaModifiers={['paper', 'border']}
     />
   );
 
@@ -117,6 +119,7 @@ function PaperDigitalBundle(props: { url: string }) {
         altText: 'paper + digital subscription',
         ...gridImageProperties,
       }}
+      ctaModifiers={['paper-digital', 'border']}
     />
   );
 

--- a/assets/components/threeSubscriptions/threeSubscriptions.scss
+++ b/assets/components/threeSubscriptions/threeSubscriptions.scss
@@ -126,14 +126,10 @@
   .component-cta-link {
     padding-left: 28px;
     background-color: transparent;
-    border: 1px solid;
-    height: $cta-height - 2;
-    line-height: $cta-height - 2;
   }
 
   .svg-arrow-right-straight {
     fill: gu-colour(garnett-neutral-1);
-    top: 13px;
   }
 
   .component-cta-link--digital {

--- a/assets/components/threeSubscriptions/threeSubscriptions.scss
+++ b/assets/components/threeSubscriptions/threeSubscriptions.scss
@@ -124,17 +124,21 @@
   }
 
   .component-cta-link {
-    height: $cta-height;
-    padding: 0 30px 0 25px;
-    font-size: 14px;
-    line-height: $cta-height;
+    padding-left: 28px;
     background-color: transparent;
-    transition: background-color .3s;
+    border: 1px solid;
+    height: $cta-height - 2;
+    line-height: $cta-height - 2;
+  }
+
+  .svg-arrow-right-straight {
+    fill: gu-colour(garnett-neutral-1);
+    top: 13px;
   }
 
   .component-cta-link--digital-sub {
     color: gu-colour(lifestyle-garnett-main-1);
-    border: 1px solid gu-colour(lifestyle-garnett-main-1);
+    border-color: gu-colour(lifestyle-garnett-main-1);
 
     .svg-arrow-right-straight {
       fill: gu-colour(lifestyle-garnett-main-1);
@@ -152,7 +156,7 @@
 
   .component-cta-link--paper-sub {
     color: gu-colour(sport-garnett-media-main-1);
-    border: 1px solid gu-colour(sport-garnett-media-main-1);
+    border-color: gu-colour(sport-garnett-media-main-1);
 
     .svg-arrow-right-straight {
       fill: gu-colour(sport-garnett-media-main-1);
@@ -170,7 +174,7 @@
 
   .component-cta-link--paper-digi-sub {
     color: gu-colour(opinion-garnett-main-1);
-    border: 1px solid gu-colour(opinion-garnett-main-1);
+    border-color: gu-colour(opinion-garnett-main-1);
 
     .svg-arrow-right-straight {
       fill: gu-colour(opinion-garnett-main-1);
@@ -183,26 +187,6 @@
       .svg-arrow-right-straight {
         fill: #fff;
       }
-    }
-  }
-
-  .svg-arrow-right-straight {
-    fill: gu-colour(garnett-neutral-1);
-    height: 35%;
-    top: 14px;
-    right: 16px;
-
-    // Fixes for IE.
-    @include mq($from: tablet) {
-      left: 93%;
-    }
-
-    @include mq($from: leftCol) {
-      left: 88%;
-    }
-
-    @include mq($from: wide) {
-      left: 90%;
     }
   }
 }

--- a/assets/components/threeSubscriptions/threeSubscriptions.scss
+++ b/assets/components/threeSubscriptions/threeSubscriptions.scss
@@ -136,7 +136,7 @@
     top: 13px;
   }
 
-  .component-cta-link--digital-sub {
+  .component-cta-link--digital {
     color: gu-colour(lifestyle-garnett-main-1);
     border-color: gu-colour(lifestyle-garnett-main-1);
 
@@ -154,7 +154,7 @@
     }
   }
 
-  .component-cta-link--paper-sub {
+  .component-cta-link--paper {
     color: gu-colour(sport-garnett-media-main-1);
     border-color: gu-colour(sport-garnett-media-main-1);
 
@@ -172,7 +172,7 @@
     }
   }
 
-  .component-cta-link--paper-digi-sub {
+  .component-cta-link--paper-digital {
     color: gu-colour(opinion-garnett-main-1);
     border-color: gu-colour(opinion-garnett-main-1);
 

--- a/assets/containerisableComponents/marketingConsent/marketingConsent.jsx
+++ b/assets/containerisableComponents/marketingConsent/marketingConsent.jsx
@@ -86,6 +86,7 @@ function ChooseMarketingPreference(props: {
         ctaId="next"
         text="Next"
         accessibilityHint="Go to the guardian dot com front page"
+        modifierClasses={['next']}
       />
     </PageSection>
   );

--- a/assets/containerisableComponents/marketingConsent/marketingConsent.scss
+++ b/assets/containerisableComponents/marketingConsent/marketingConsent.scss
@@ -37,37 +37,12 @@
     font-family: $gu-text-sans-web;
   }
 
-
   .component-cta-link--next {
-    background-color: gu-colour(garnett-neutral-1);
-    border: 1px solid gu-colour(garnett-neutral-1);
-    color: #fff;
-    height: $cta-height;
-    line-height: $cta-height;
-    padding: 0 30px 0 25px;
-    transition: background-color .3s;
     margin-bottom: $gu-v-spacing * 3;
     margin-top: $gu-v-spacing * 2;
 
     @include mq($from: mobileMedium) {
       width: 300px;
-    }
-
-    &:hover {
-      background-color: darken(gu-colour(garnett-neutral-1), 10%);
-    }
-  }
-
-
-
-  .svg-arrow-right-straight {
-    height: 35%;
-    top: 12px;
-    right: 13px;
-
-    // Fix for IE.
-    @include mq($from: mobileMedium) {
-      left: 321px;
     }
   }
 }

--- a/assets/containerisableComponents/payPalContributionButton/payPalContributionButton.scss
+++ b/assets/containerisableComponents/payPalContributionButton/payPalContributionButton.scss
@@ -5,25 +5,21 @@
   color: gu-colour(garnett-neutral-1);
   cursor: pointer;
   display: block;
-  font-family: $gu-sans-web;
+  font-family: $gu-text-sans-web;
   font-size: 14px;
-  height: $gu-v-spacing * 4;
-  padding-left: $gu-h-spacing;
+  height: $cta-height;
+  line-height: $cta-height;
+  padding: 0 $gu-h-spacing;
   position: relative;
   text-align: left;
   width: 100%;
 
-  @include mq($from: mobileMedium) {
-    width: 304px;
-  }
-
   .svg-arrow-right-straight {
-    width: 20px;
     fill: gu-colour(garnett-neutral-1);
+    height: 16px;
     position: absolute;
-    right: 15px;
-    top: 50%;
-    transform: translateY(-50%);
+    left: calc(100% - 34px);
+    top: 14px;
   }
 
   &:hover {

--- a/assets/pages/error/components/errorPage.jsx
+++ b/assets/pages/error/components/errorPage.jsx
@@ -43,12 +43,14 @@ export default function ErrorPage(props: PropTypes) {
           accessibilityHint="click here to support The Guardian"
           ctaId="support-the-guardian"
           url="/"
+          modifierClasses={['support-the-guardian']}
         />
         <CtaLink
           text="Go to The Guardian home page"
           accessibilityHint="click here to return to The Guardian home page"
           ctaId="guardian-home-page"
           url="https://www.theguardian.com"
+          modifierClasses={['guardian-home-page']}
         />
       </PageSection>
       <Footer />

--- a/assets/pages/error/components/errorPage.jsx
+++ b/assets/pages/error/components/errorPage.jsx
@@ -50,7 +50,7 @@ export default function ErrorPage(props: PropTypes) {
           accessibilityHint="click here to return to The Guardian home page"
           ctaId="guardian-home-page"
           url="https://www.theguardian.com"
-          modifierClasses={['guardian-home-page']}
+          modifierClasses={['guardian-home-page', 'border']}
         />
       </PageSection>
       <Footer />

--- a/assets/pages/error/error.scss
+++ b/assets/pages/error/error.scss
@@ -36,26 +36,13 @@
     }
 
     .component-cta-link {
-      box-sizing: border-box;
-      height: 46px;
-      line-height: 46px;
-      padding: 0 $gu-h-spacing;
-
       @include mq($from: phablet) {
-        width: 292px;
+        width: 252px;
       }
     }
 
     .svg-arrow-right-straight {
       fill: gu-colour(garnett-neutral-1);
-      height: 35%;
-      top: 14px;
-      right: 15px;
-
-      // Fix for IE.
-      @include mq($from: phablet) {
-        left: 258px;
-      }
     }
   }
 
@@ -82,12 +69,19 @@
 
   .component-cta-link--guardian-home-page {
     background-color: #fff;
+    margin-top: $gu-v-spacing;
     color: gu-colour(garnett-neutral-1);
     border: 1px solid gu-colour(garnett-neutral-1);
+    height: 42px;
+    line-height: 42px;
 
     &:hover {
       color: darken(gu-colour(garnett-neutral-1), 5%);
       border-color: darken(gu-colour(garnett-neutral-1), 5%);
+    }
+
+    .svg-arrow-right-straight {
+      top: 13px;
     }
   }
 }

--- a/assets/pages/error/error.scss
+++ b/assets/pages/error/error.scss
@@ -35,12 +35,6 @@
       }
     }
 
-    .component-cta-link {
-      @include mq($from: phablet) {
-        width: 252px;
-      }
-    }
-
     .svg-arrow-right-straight {
       fill: gu-colour(garnett-neutral-1);
     }
@@ -65,23 +59,25 @@
     &:hover {
       background-color: darken(gu-colour(news-garnett-highlight), 5%);
     }
+
+    @include mq($from: phablet) {
+      width: 252px;
+    }
   }
 
   .component-cta-link--guardian-home-page {
     background-color: #fff;
     margin-top: $gu-v-spacing;
     color: gu-colour(garnett-neutral-1);
-    border: 1px solid gu-colour(garnett-neutral-1);
-    height: 42px;
-    line-height: 42px;
+    border-color: gu-colour(garnett-neutral-1);
 
     &:hover {
       color: darken(gu-colour(garnett-neutral-1), 5%);
       border-color: darken(gu-colour(garnett-neutral-1), 5%);
     }
 
-    .svg-arrow-right-straight {
-      top: 13px;
+    @include mq($from: phablet) {
+      width: 250px;
     }
   }
 }

--- a/assets/pages/paypal-error/payPalError.scss
+++ b/assets/pages/paypal-error/payPalError.scss
@@ -59,22 +59,11 @@
   .component-cta-link {
     color: gu-colour(garnett-neutral-1);
     background-color: gu-colour(news-garnett-highlight);
-    box-sizing: border-box;
-    display: inline-block;
     width: 230px;
-    line-height: 44px;
-    font-weight: normal;
     margin-bottom: $gu-v-spacing * 4;
-    padding-top: 0;
-    padding-bottom: 0;
-    transition: background-color .3s;
 
     .svg-arrow-right-straight {
-      fill: gu-colour(garnett-neutral-1);;
-      top: 14px;
-      height: 35%;
-      // Fix for IE10.
-      left: 197px;
+      fill: gu-colour(garnett-neutral-1);
     }
 
     &:hover {

--- a/assets/pages/regular-contributions-existing/regularContributionsExisting.jsx
+++ b/assets/pages/regular-contributions-existing/regularContributionsExisting.jsx
@@ -48,6 +48,7 @@ const content = (
         text="Amend your recurring contribution"
         url={buildMMAUrl()}
         accessibilityHint="Further support the guardian by increasing your regular contribution"
+        modifierClasses={['manage-contribution']}
       />
     </PageSection>
     <QuestionsContact />

--- a/assets/pages/regular-contributions-existing/regularContributionsExisting.scss
+++ b/assets/pages/regular-contributions-existing/regularContributionsExisting.scss
@@ -54,33 +54,11 @@
   }
 
   .component-cta-link--manage-contribution {
-    background-color: gu-colour(garnett-neutral-1);
-    border: 1px solid gu-colour(garnett-neutral-1);
-    color: #fff;
-    height: 54px;
-    line-height: 54px;
-    padding: 0 30px 0 25px;
-    transition: background-color .3s;
     margin-bottom: $gu-v-spacing * 3;
     margin-top: $gu-v-spacing * 2;
 
     @include mq($from: mobileMedium) {
       width: 300px;
-    }
-
-    &:hover {
-      background-color: darken(gu-colour(garnett-neutral-1), 5%);
-    }
-
-    .svg-arrow-right-straight {
-      height: 35%;
-      top: 17px;
-      right: 13px;
-
-      // Fix for IE.
-      @include mq($from: mobileMedium) {
-        left: 321px;
-      }
     }
   }
 }

--- a/assets/stylesheets/gu-sass/layout.scss
+++ b/assets/stylesheets/gu-sass/layout.scss
@@ -11,7 +11,6 @@ $gu-v-spacing: 12px;
 
 // Size of cta buttons
 $cta-height: 44px;
-$cta-width: 301px;
 
 
 // Margin


### PR DESCRIPTION
## Why are you doing this?

The CtaLink component had very similar styles applied to it in multiple different places. This de-dupes these styles.

cc @JustinPinner 

## Changes

- Decoupled `CtaLink` modifier classes from the id used for component tracking.
- Standardised and simplified the `CtaLink` styles.
- Deleted duplicate styles.
- Allowed border styles with `component-cta-link--border`.
- Brought the `PayPalContributionButton` in line with the `CtaLink` styles.
- Removed `$cta-width`, since the width isn't as standardised as the height now.
