### PR TITLE
Fresh Sentry projects

### DIFF
--- a/app/monitoring/Logging.scala
+++ b/app/monitoring/Logging.scala
@@ -1,12 +1,12 @@
 package monitoring
 
-import ch.qos.logback.classic.filter.ThresholdFilter
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.core.filter.Filter
 import ch.qos.logback.core.spi.FilterReply
 import com.typesafe.scalalogging.LazyLogging
 import org.slf4j.{Marker, MarkerFactory}
 
+// This filter is referenced in logback.xml
 class PiiFilter extends Filter[ILoggingEvent] {
   override def decide(event: ILoggingEvent): FilterReply = if (event.getMarker.contains(SafeLogger.sanitizedLogMessage)) FilterReply.ACCEPT
   else FilterReply.DENY
@@ -14,6 +14,7 @@ class PiiFilter extends Filter[ILoggingEvent] {
 
 object SafeLogger extends LazyLogging {
 
+  // Used to mark scrubbed messages suitable to be sent to Sentry.
   val sanitizedLogMessage: Marker = MarkerFactory.getMarker("SENTRY")
 
   case class LogMessage(raw: String, sanitized: String) {
@@ -50,12 +51,3 @@ object SafeLogger extends LazyLogging {
 
 }
 
-object SentryFilters {
-
-  val errorLevelFilter = new ThresholdFilter { setLevel("ERROR") }
-  val piiFilter = new PiiFilter
-
-  errorLevelFilter.start()
-  piiFilter.start()
-
-}

--- a/app/monitoring/SentryLogging.scala
+++ b/app/monitoring/SentryLogging.scala
@@ -16,16 +16,13 @@ object SentryLogging {
         SafeLogger.info(s"Initialising Sentry logging with $sentryDSN")
         Try {
           val sentryClient = Sentry.init(sentryDSN)
-          SafeLogger.info("Initialised! Adding tags.")
           val buildInfo: Map[String, String] = app.BuildInfo.toMap.mapValues(_.toString)
           val tags = Map("stage" -> config.stage.toString) ++ buildInfo
-          SafeLogger.info(s"tagmap $tags")
           sentryClient.setTags(tags.asJava)
         } match {
           case Success(_) => SafeLogger.debug("Sentry logging configured.")
           case Failure(e) => SafeLogger.error(scrub"Something went wrong when setting up Sentry logging ${e.getStackTrace}")
         }
     }
-    SafeLogger.error(scrub"*TEST* more spam from Leigh-Anne. Why, you look radiant today! ^-^ ")
   }
 }

--- a/app/monitoring/SentryLogging.scala
+++ b/app/monitoring/SentryLogging.scala
@@ -13,19 +13,16 @@ object SentryLogging {
     config.sentryDsn match {
       case None => SafeLogger.warn("No Sentry logging configured (OK for dev)")
       case Some(sentryDSN) =>
-        SafeLogger.info(s"Initialising Sentry logging with $sentryDSN")
+        SafeLogger.info(s"Initialising Sentry logging")
         Try {
           val sentryClient = Sentry.init(sentryDSN)
-          SafeLogger.info("Initialised! Adding tags.")
           val buildInfo: Map[String, String] = app.BuildInfo.toMap.mapValues(_.toString)
           val tags = Map("stage" -> config.stage.toString) ++ buildInfo
-          SafeLogger.info(s"tagmap $tags")
           sentryClient.setTags(tags.asJava)
         } match {
           case Success(_) => SafeLogger.debug("Sentry logging configured.")
           case Failure(e) => SafeLogger.error(scrub"Something went wrong when setting up Sentry logging ${e.getStackTrace}")
         }
     }
-    SafeLogger.error(scrub"*TEST* Why hello there, you clever thing you. ")
   }
 }

--- a/app/monitoring/SentryLogging.scala
+++ b/app/monitoring/SentryLogging.scala
@@ -16,15 +16,16 @@ object SentryLogging {
         SafeLogger.info(s"Initialising Sentry logging with $sentryDSN")
         Try {
           val sentryClient = Sentry.init(sentryDSN)
+          SafeLogger.info("Initialised! Adding tags.")
           val buildInfo: Map[String, String] = app.BuildInfo.toMap.mapValues(_.toString)
           val tags = Map("stage" -> config.stage.toString) ++ buildInfo
+          SafeLogger.info(s"tagmap $tags")
           sentryClient.setTags(tags.asJava)
         } match {
           case Success(_) => SafeLogger.debug("Sentry logging configured.")
           case Failure(e) => SafeLogger.error(scrub"Something went wrong when setting up Sentry logging ${e.getStackTrace}")
         }
     }
+    SafeLogger.error(scrub"*TEST* Why hello there, you clever thing you. ")
   }
-
-  SafeLogger.error(scrub"*TEST* Why hello there, you clever thing you. ")
 }

--- a/app/monitoring/SentryLogging.scala
+++ b/app/monitoring/SentryLogging.scala
@@ -25,4 +25,6 @@ object SentryLogging {
         }
     }
   }
+
+  SafeLogger.error(scrub"*TEST* Why hello there, you clever thing you. ")
 }

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -54,6 +54,6 @@ trait AppComponents extends PlayComponents
     assetController
   )
 
-  appConfig.sentryDsn foreach { dsn => new SentryLogging(dsn, appConfig.stage) }
+  SentryLogging.init(appConfig)
   new StateMachineMonitor(regularContributionsClient, actorSystem).start()
 }

--- a/assets/helpers/logger.js
+++ b/assets/helpers/logger.js
@@ -4,7 +4,7 @@ import Raven from 'raven-js';
 // ----- Functions ----- //
 
 export const init = () => {
-  const dsn: string = 'https://dc13eb8698614a8081ce6a139d9f4aab@sentry.io/171710';
+  const dsn: string = 'https://65f7514888b6407881f34a6cf1320d06@sentry.io/1213654';
   const { gitCommitId } = window.guardian;
 
   Raven.config(dsn, {

--- a/assets/pages/regular-contributions-existing/regularContributionsExisting.jsx
+++ b/assets/pages/regular-contributions-existing/regularContributionsExisting.jsx
@@ -12,20 +12,25 @@ import QuestionsContact from 'components/questionsContact/questionsContact';
 import { statelessInit as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
 import { getBaseDomain } from 'helpers/url';
+import { logException } from 'helpers/logger';
 
 import CirclesIntroduction from '../../components/introduction/circlesIntroduction';
 import PageSection from '../../components/pageSection/pageSection';
+import Raven from "raven-js/typescript/raven";
+
 
 // ----- Functions ----- //
 
 function buildMMAUrl(): string {
+  Raven.captureMessage('*TEST*: Leigh-Anne still making Sentry changes. By the way, reader, it is a delight to work with you.');
+
+  logException('*TEST*: Leigh-Anne still making Sentry changes. By the way, reader, it is a delight to work with you.');
   return `https://profile.${getBaseDomain()}/contribution/recurring/edit`;
 }
 
 // ----- Page Startup ----- //
 
 pageInit();
-
 
 // ----- Render ----- //
 

--- a/assets/pages/regular-contributions-existing/regularContributionsExisting.jsx
+++ b/assets/pages/regular-contributions-existing/regularContributionsExisting.jsx
@@ -16,7 +16,6 @@ import { getBaseDomain } from 'helpers/url';
 import CirclesIntroduction from '../../components/introduction/circlesIntroduction';
 import PageSection from '../../components/pageSection/pageSection';
 
-
 // ----- Functions ----- //
 
 function buildMMAUrl(): string {
@@ -26,6 +25,7 @@ function buildMMAUrl(): string {
 // ----- Page Startup ----- //
 
 pageInit();
+
 
 // ----- Render ----- //
 

--- a/assets/pages/regular-contributions-existing/regularContributionsExisting.jsx
+++ b/assets/pages/regular-contributions-existing/regularContributionsExisting.jsx
@@ -12,19 +12,14 @@ import QuestionsContact from 'components/questionsContact/questionsContact';
 import { statelessInit as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
 import { getBaseDomain } from 'helpers/url';
-import { logException } from 'helpers/logger';
 
 import CirclesIntroduction from '../../components/introduction/circlesIntroduction';
 import PageSection from '../../components/pageSection/pageSection';
-import Raven from "raven-js/typescript/raven";
 
 
 // ----- Functions ----- //
 
 function buildMMAUrl(): string {
-  Raven.captureMessage('*TEST*: Leigh-Anne still making Sentry changes. By the way, reader, it is a delight to work with you.');
-
-  logException('*TEST*: Leigh-Anne still making Sentry changes. By the way, reader, it is a delight to work with you.');
   return `https://profile.${getBaseDomain()}/contribution/recurring/edit`;
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,7 @@ val awsVersion = "1.11.221"
 libraryDependencies ++= Seq(
   "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
   "org.mockito" % "mockito-core" % "2.11.0" % Test,
-  "com.getsentry.raven" % "raven-logback" % "8.0.3",
+  "io.sentry" % "sentry-logback" % "1.7.5",
   "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2",
   "com.amazonaws" % "aws-java-sdk-kms" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-stepfunctions" % awsVersion,

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -23,8 +23,18 @@
     </encoder>
 </appender>
 
+<appender name="Sentry" class="io.sentry.logback.SentryAppender">
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+        <level>ERROR</level>
+    </filter>
+    <filter class="monitoring.PiiFilter">
+        <level>ERROR</level>
+    </filter>
+</appender>
+
 <root level="INFO">
     <appender-ref ref="LOGFILE"/>
+    <appender-ref ref="Sentry"/>
 </root>
 
 </configuration>


### PR DESCRIPTION
### Why do we need this? 
We scrubbed PII here:  https://github.com/guardian/support-frontend/pull/494
As we stop sending PII, to sentry, we are also deleting old sentry projects and starting anew. 

Both support and support-client-side shall point to new projects in conjunction with this PR. 

### The changes <!-- technical description/bullets (if it's long, would two PRs would have been better?) -->
* Pointing to the DSN of the new project for support-client-side
* Update the DSN configured in the config for the new sentry project for support
* Move to using sentry-logback (raven-logback is deprecated)
* Wrap Sentry.init in a try 

TODO:
Pre-merge
- [x] Test in CODE that error logs go to the new project
- [x] Add the DSN for the new sentry project to the PROD config 
- [ ] Remove the DSN from the CODE config

Post-merge
- [ ] Delete the existing sentry project
- [ ] Rename the new sentry projects back to support and support-client-side as before


### trello card/screenshot/json/related PRs etc
[**Trello Card**](https://trello.com/c/LiojyKYR/1555-delete-all-projects-which-contain-pii-from-sentry-and-replace-with-a-clean-project)
[Scrub PII from logs sent to sentry]( https://github.com/guardian/support-frontend/pull/494)