### PR TITLE
More Descriptive Modifier Class and Update ESLint Default Props Rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -55,6 +55,7 @@
         "ignoreTemplateLiterals": true
       }
     ],
+    "react/default-props-match-prop-types": [2, { "allowRequiredDefaults": true }],
   },
   "settings": {
     "import/resolver": {

--- a/assets/components/contribute/contribute.jsx
+++ b/assets/components/contribute/contribute.jsx
@@ -51,9 +51,7 @@ export default function Contribute(props: PropTypes) {
 
 // ----- Default Props ----- //
 
-/* eslint-disable react/default-props-match-prop-types */
 Contribute.defaultProps = {
   heading: '',
   modifierClasses: [],
 };
-/* eslint-enable react/default-props-match-prop-types */

--- a/assets/components/contribute/contribute.jsx
+++ b/assets/components/contribute/contribute.jsx
@@ -10,20 +10,22 @@ import { classNameWithModifiers } from 'helpers/utilities';
 
 import type { Node } from 'react';
 
+
 // ----- Types ----- //
+
 type PropTypes = {
   copy: string | Node,
   children: Node,
   heading?: string,
-  modifiers?: Array<?string>,
+  modifierClasses: Array<?string>,
 };
+
 
 // ----- Component ----- //
 
 export default function Contribute(props: PropTypes) {
-  const modifiers = props.modifiers || [];
-  const secureHeadingModifiers = modifiers.slice(0);
-  const secureBodyModifiers = modifiers.slice(0);
+  const secureHeadingModifiers = props.modifierClasses.slice(0);
+  const secureBodyModifiers = props.modifierClasses.slice(0);
 
   secureHeadingModifiers.push('contribute-header');
   secureBodyModifiers.push('contribute-body');
@@ -33,10 +35,12 @@ export default function Contribute(props: PropTypes) {
       <PageSection
         modifierClass="contribute"
         heading={props.heading}
-        headingChildren={<Secure modifiers={secureHeadingModifiers} />}
+        headingChildren={<Secure modifierClasses={secureHeadingModifiers} />}
       >
-        <Secure modifiers={secureBodyModifiers} />
-        <p className={classNameWithModifiers('component-contribute__description', modifiers)}>{props.copy}</p>
+        <Secure modifierClasses={secureBodyModifiers} />
+        <p className={classNameWithModifiers('component-contribute__description', props.modifierClasses)}>
+          {props.copy}
+        </p>
         {props.children}
       </PageSection>
     </div>
@@ -44,7 +48,12 @@ export default function Contribute(props: PropTypes) {
 
 }
 
+
+// ----- Default Props ----- //
+
+/* eslint-disable react/default-props-match-prop-types */
 Contribute.defaultProps = {
   heading: '',
-  modifiers: [],
+  modifierClasses: [],
 };
+/* eslint-enable react/default-props-match-prop-types */

--- a/assets/components/ctaLink/ctaLink.jsx
+++ b/assets/components/ctaLink/ctaLink.jsx
@@ -69,7 +69,6 @@ export default function CtaLink(props: PropTypes) {
 
 // ----- Default Props ----- //
 
-/* eslint-disable react/default-props-match-prop-types */
 CtaLink.defaultProps = {
   url: null,
   trackComponentEvent: () => {},
@@ -80,4 +79,3 @@ CtaLink.defaultProps = {
   acquisitionData: null,
   modifierClasses: [],
 };
-/* eslint-enable react/default-props-match-prop-types */

--- a/assets/components/gridImage/gridImage.jsx
+++ b/assets/components/gridImage/gridImage.jsx
@@ -57,9 +57,7 @@ export default function GridImage(props: PropTypes) {
 
 // ----- Default Props ----- //
 
-/* eslint-disable react/default-props-match-prop-types */
 GridImage.defaultProps = {
   imgType: 'jpg',
   altText: '',
 };
-/* eslint-enable react/default-props-match-prop-types */

--- a/assets/components/gridPicture/gridPicture.jsx
+++ b/assets/components/gridPicture/gridPicture.jsx
@@ -58,8 +58,6 @@ export default function GridPicture(props: PropTypes) {
 
 // ----- Default Props ----- //
 
-/* eslint-disable react/default-props-match-prop-types */
 GridPicture.defaultProps = {
   altText: '',
 };
-/* eslint-enable react/default-props-match-prop-types */

--- a/assets/components/highlights/highlights.jsx
+++ b/assets/components/highlights/highlights.jsx
@@ -37,8 +37,6 @@ export default function Highlights(props: PropTypes) {
 
 // ----- Default Props ----- //
 
-/* eslint-disable react/default-props-match-prop-types */
 Highlights.defaultProps = {
   modifierClasses: [],
 };
-/* eslint-enable react/default-props-match-prop-types */

--- a/assets/components/highlights/highlights.jsx
+++ b/assets/components/highlights/highlights.jsx
@@ -5,11 +5,12 @@
 import React from 'react';
 import { classNameWithModifiers } from 'helpers/utilities';
 
+
 // ----- Types ----- //
 
 type PropTypes = {
   highlights: ?string[],
-  modifiers: Array<?string>,
+  modifierClasses: Array<?string>,
 };
 
 
@@ -22,13 +23,22 @@ export default function Highlights(props: PropTypes) {
   }
 
   return (
-    <h1 className={classNameWithModifiers('component-highlights', props.modifiers)}>
+    <h1 className={classNameWithModifiers('component-highlights', props.modifierClasses)}>
       {props.highlights.map(highlight => (
         <span className="component-highlights__line">
-          <span className={classNameWithModifiers('component-highlights__highlight', props.modifiers)}>{highlight}</span>
+          <span className={classNameWithModifiers('component-highlights__highlight', props.modifierClasses)}>{highlight}</span>
         </span>
       ))}
     </h1>
   );
 
 }
+
+
+// ----- Default Props ----- //
+
+/* eslint-disable react/default-props-match-prop-types */
+Highlights.defaultProps = {
+  modifierClasses: [],
+};
+/* eslint-enable react/default-props-match-prop-types */

--- a/assets/components/introduction/circlesIntroduction.jsx
+++ b/assets/components/introduction/circlesIntroduction.jsx
@@ -16,37 +16,40 @@ import { classNameWithModifiers } from 'helpers/utilities';
 type PropTypes = {
   headings: string[],
   highlights?: ?string[],
-  modifiers?: Array<?string>,
+  modifierClasses: Array<?string>,
 };
 
 
 // ----- Component ----- //
 
 function CirclesIntroduction(props: PropTypes) {
-  const modifiers = props.modifiers || [];
+
   return (
     <section className="component-circles-introduction">
       <SvgCirclesHeroDesktop />
       <SvgCirclesHeroMobileLandscape />
       <SvgCirclesHeroMobile />
-      <div className={`${classNameWithModifiers('component-circles-introduction__content', modifiers)} gu-content-margin`}>
-        <h1 className={classNameWithModifiers('component-circles-introduction__heading', modifiers)}>
+      <div className={`${classNameWithModifiers('component-circles-introduction__content', props.modifierClasses)} gu-content-margin`}>
+        <h1 className={classNameWithModifiers('component-circles-introduction__heading', props.modifierClasses)}>
           {props.headings.map(heading =>
             <span className="component-circles-introduction__heading-line">{heading}</span>)}
         </h1>
-        <Highlights highlights={props.highlights} modifiers={modifiers} />
+        <Highlights highlights={props.highlights} modifierClasses={props.modifierClasses} />
       </div>
     </section>
   );
+
 }
 
 
 // ----- Default Props ----- //
 
+/* eslint-disable react/default-props-match-prop-types */
 CirclesIntroduction.defaultProps = {
   highlights: null,
-  modifiers: [],
+  modifierClasses: [],
 };
+/* eslint-enable react/default-props-match-prop-types */
 
 
 // ----- Exports ----- //

--- a/assets/components/introduction/circlesIntroduction.jsx
+++ b/assets/components/introduction/circlesIntroduction.jsx
@@ -44,12 +44,10 @@ function CirclesIntroduction(props: PropTypes) {
 
 // ----- Default Props ----- //
 
-/* eslint-disable react/default-props-match-prop-types */
 CirclesIntroduction.defaultProps = {
   highlights: null,
   modifierClasses: [],
 };
-/* eslint-enable react/default-props-match-prop-types */
 
 
 // ----- Exports ----- //

--- a/assets/components/introduction/squaresIntroduction.jsx
+++ b/assets/components/introduction/squaresIntroduction.jsx
@@ -27,7 +27,7 @@ function SquaresIntroduction(props: PropTypes) {
       <SvgSquaresHeroTablet />
       <SvgSquaresHeroMobile />
       <div className="component-squares-introduction__content gu-content-margin">
-        <Highlights highlights={props.highlights} modifiers={[]} />
+        <Highlights highlights={props.highlights} />
         <h1 className="component-squares-introduction__heading">
           {props.headings.map(heading =>
             <span className="component-squares-introduction__heading-line">{heading}</span>)}

--- a/assets/components/paymentButtons/directDebitPopUpButton/directDebitPopUpButton.jsx
+++ b/assets/components/paymentButtons/directDebitPopUpButton/directDebitPopUpButton.jsx
@@ -89,11 +89,9 @@ function Button(props: { openPopUp: () => void }) {
 
 // ----- Default Props ----- //
 
-/* eslint-disable react/default-props-match-prop-types */
 DirectDebitPopUpButton.defaultProps = {
   switchedOff: false,
 };
-/* eslint-enable react/default-props-match-prop-types */
 
 
 // ----- Exports ----- //

--- a/assets/components/paymentButtons/payPalExpressButton/payPalExpressButton.jsx
+++ b/assets/components/paymentButtons/payPalExpressButton/payPalExpressButton.jsx
@@ -69,11 +69,9 @@ function Button(props: PropTypes) {
 
 // ----- Default Props ----- //
 
-/* eslint-disable react/default-props-match-prop-types */
 PayPalExpressButton.defaultProps = {
   switchedOff: false,
 };
-/* eslint-enable react/default-props-match-prop-types */
 
 
 // ----- Export ----- //

--- a/assets/components/paymentButtons/stripePopUpButton/stripePopUpButton.jsx
+++ b/assets/components/paymentButtons/stripePopUpButton/stripePopUpButton.jsx
@@ -84,13 +84,11 @@ function Button(props: PropTypes) {
 
 // ----- Default Props ----- //
 
-/* eslint-disable react/default-props-match-prop-types */
 StripePopUpButton.defaultProps = {
   canOpen: () => true,
   closeHandler: () => {},
   switchedOff: false,
 };
-/* eslint-enable react/default-props-match-prop-types */
 
 
 // ----- Exports ----- //

--- a/assets/components/secure/secure.jsx
+++ b/assets/components/secure/secure.jsx
@@ -33,8 +33,6 @@ export default function Secure(props: PropTypes) {
 
 // ----- Default Props ----- //
 
-/* eslint-disable react/default-props-match-prop-types */
 Secure.defaultProps = {
   modifierClasses: [],
 };
-/* eslint-enable react/default-props-match-prop-types */

--- a/assets/components/secure/secure.jsx
+++ b/assets/components/secure/secure.jsx
@@ -12,7 +12,7 @@ import { classNameWithModifiers } from 'helpers/utilities';
 // ----- Props ----- //
 
 type PropTypes = {
-  modifiers: Array<?string>,
+  modifierClasses: Array<?string>,
 };
 
 
@@ -22,7 +22,7 @@ export default function Secure(props: PropTypes) {
 
 
   return (
-    <div className={classNameWithModifiers('component-secure', props.modifiers)}>
+    <div className={classNameWithModifiers('component-secure', props.modifierClasses)}>
       <SvgLock />
       <span className="component-secure__text">Secure</span>
     </div>
@@ -32,8 +32,9 @@ export default function Secure(props: PropTypes) {
 
 
 // ----- Default Props ----- //
+
 /* eslint-disable react/default-props-match-prop-types */
 Secure.defaultProps = {
-  modifiers: [],
+  modifierClasses: [],
 };
 /* eslint-enable react/default-props-match-prop-types */

--- a/assets/components/switchable/errorComponents/paymentError.jsx
+++ b/assets/components/switchable/errorComponents/paymentError.jsx
@@ -31,11 +31,9 @@ function PaymentError(props: PropTypes) {
 
 // ----- Default Props ----- //
 
-/* eslint-disable react/default-props-match-prop-types */
 PaymentError.defaultProps = {
   modifierClass: '',
 };
-/* eslint-enable react/default-props-match-prop-types */
 
 
 // ----- Export ----- //

--- a/assets/components/switchable/switchable.jsx
+++ b/assets/components/switchable/switchable.jsx
@@ -31,11 +31,9 @@ function Switchable(props: PropTypes) {
 
 // ----- Default Props ----- //
 
-/* eslint-disable react/default-props-match-prop-types */
 Switchable.defaultProps = {
   fallback: null,
 };
-/* eslint-enable react/default-props-match-prop-types */
 
 
 // ----- Exports ----- //

--- a/assets/containerisableComponents/payPalContributionButton/payPalContributionButton.jsx
+++ b/assets/containerisableComponents/payPalContributionButton/payPalContributionButton.jsx
@@ -94,7 +94,6 @@ function Button(props: PropTypes) {
 
 // ----- Default Props ----- //
 
-/* eslint-disable react/default-props-match-prop-types */
 PayPalContributionButton.defaultProps = {
   canClick: true,
   buttonText: 'Pay with PayPal',
@@ -102,7 +101,6 @@ PayPalContributionButton.defaultProps = {
   onClick: null,
   switchedOff: false,
 };
-/* eslint-enable react/default-props-match-prop-types */
 
 
 // ----- Exports ----- //

--- a/assets/pages/contributions-landing/contributionsLanding.jsx
+++ b/assets/pages/contributions-landing/contributionsLanding.jsx
@@ -89,6 +89,8 @@ const CountrySwitcherHeader = CountrySwitcherHeaderContainer(
 
 const dropIntroTextTestVariant = store && store.getState().common.abParticipations.dropIntroText;
 const copyText = dropIntroTextTestVariant === 'variant' ? '' : countryGroupSpecificDetails[countryGroupId].contributeCopy;
+
+
 // ----- Render ----- //
 
 const content = (
@@ -98,11 +100,11 @@ const content = (
       <CirclesIntroduction
         headings={countryGroupSpecificDetails[countryGroupId].headerCopy}
         highlights={['Your contribution']}
-        modifiers={['compact']}
+        modifierClasses={['compact']}
       />
       <Contribute
         copy={copyText}
-        modifiers={['compact']}
+        modifierClasses={['compact']}
       >
         <ContributionSelectionContainer />
         <ContributionAwarePaymentLogosContainer />

--- a/assets/pages/support-landing/supportLanding.jsx
+++ b/assets/pages/support-landing/supportLanding.jsx
@@ -55,12 +55,12 @@ const content = (
       <CirclesIntroduction
         headings={['Help us deliver the', 'independent journalism', 'the world needs']}
         highlights={['Support The Guardian']}
-        modifiers={['compact']}
+        modifierClasses={['compact']}
       />
       <section id={supporterSectionId}>
         <Contribute
           copy="Your contribution funds and supports The Guardian's journalism."
-          modifiers={['compact']}
+          modifierClasses={['compact']}
         >
           <ContributionSelectionContainer />
           <ContributionAwarePaymentLogosContainer />


### PR DESCRIPTION
## Why are you doing this?

Everywhere that we used `modifiers`, we now use `modifierClasses`. Also, the `react/default-props-match-prop-types` ESLint rule was conflicting with flow. This tweaks it, rather than manually disabling it all over the place. Follow-up from #697.

## Changes

- Replace prop name `modifiers` with `modifierClasses`.
- Updated `react/default-props-match-prop-types` to ignore default props for required `PropTypes`. Flow wants props with defaults to be required.
