### PR TITLE
Configure the Sentry appender and the filters in the code again

### DIFF
--- a/app/monitoring/SentryLogging.scala
+++ b/app/monitoring/SentryLogging.scala
@@ -38,8 +38,6 @@ object SentryLogging {
           case Failure(e) => SafeLogger.error(scrub"Something went wrong when setting up Sentry logging ${e.getStackTrace}")
         }
     }
-    val compliment = "bee's knees"
-    SafeLogger.error(scrub"Why, you are just the bee's knees! again, $compliment!")
   }
 }
 

--- a/app/monitoring/SentryLogging.scala
+++ b/app/monitoring/SentryLogging.scala
@@ -1,12 +1,17 @@
 package monitoring
 
+import ch.qos.logback.classic.filter.ThresholdFilter
 import monitoring.SafeLogger._
-
 import config.Configuration
 import io.sentry.Sentry
+import io.sentry.logback.SentryAppender
 
 import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
+import SentryFilters._
+import ch.qos.logback.classic.Logger
+import org.slf4j.Logger.ROOT_LOGGER_NAME
+import org.slf4j.LoggerFactory
 
 object SentryLogging {
   def init(config: Configuration) {
@@ -16,13 +21,34 @@ object SentryLogging {
         SafeLogger.info(s"Initialising Sentry logging")
         Try {
           val sentryClient = Sentry.init(sentryDSN)
+          val sentryAppender = new SentryAppender {
+            addFilter(errorLevelFilter)
+            addFilter(piiFilter)
+          }
+
+          sentryAppender.start()
+
           val buildInfo: Map[String, String] = app.BuildInfo.toMap.mapValues(_.toString)
           val tags = Map("stage" -> config.stage.toString) ++ buildInfo
           sentryClient.setTags(tags.asJava)
+
+          LoggerFactory.getLogger(ROOT_LOGGER_NAME).asInstanceOf[Logger].addAppender(sentryAppender)
         } match {
           case Success(_) => SafeLogger.debug("Sentry logging configured.")
           case Failure(e) => SafeLogger.error(scrub"Something went wrong when setting up Sentry logging ${e.getStackTrace}")
         }
     }
+    val compliment = "bee's knees"
+    SafeLogger.error(scrub"Why, you are just the bee's knees! again, $compliment!")
   }
+}
+
+object SentryFilters {
+
+  val errorLevelFilter = new ThresholdFilter { setLevel("ERROR") }
+  val piiFilter = new PiiFilter
+
+  errorLevelFilter.start()
+  piiFilter.start()
+
 }

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -23,18 +23,8 @@
     </encoder>
 </appender>
 
-<appender name="Sentry" class="io.sentry.logback.SentryAppender">
-    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
-        <level>ERROR</level>
-    </filter>
-    <filter class="monitoring.PiiFilter">
-        <level>ERROR</level>
-    </filter>
-</appender>
-
 <root level="INFO">
     <appender-ref ref="LOGFILE"/>
-    <appender-ref ref="Sentry"/>
 </root>
 
 </configuration>


### PR DESCRIPTION
## Why are you doing this?
As part of https://github.com/guardian/support-frontend/pull/699/files, we upgraded to sentry-logback 1.7.5 and opted to configure the Sentry appender and so also the filters in the logback.xml as seen in the migration guide. However, if we have a custom filter (as we do now with the PiiFilter), then in DEV mode only, the logback.xml references this class before it's loaded and gives an ugly error message to the console (see screenshot below). We are returning to the previous approach to creating and configuring the sentry appenders and filters to resolve this issue.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/LiojyKYR/1555-delete-all-projects-which-contain-pii-from-sentry-and-replace-with-a-clean-project)

## Changes

* Create SentryAppender and SentryFilters in the SentryLogging object and add the filters to the appender there, rather than in logback.xml

## Screenshots
![image](https://user-images.githubusercontent.com/3072877/40973287-a0c16ade-68bb-11e8-8367-95b968e5cd3d.png)
