### PR TITLE
Adding default switch file

### DIFF
--- a/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
+++ b/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
@@ -20,6 +20,7 @@ import { addQueryParamsToURL } from 'helpers/url';
 
 import type { Currency } from 'helpers/internationalisation/currency';
 import type { Contrib as ContributionType } from 'helpers/contributions';
+import type { Status } from 'helpers/switch';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
@@ -39,7 +40,7 @@ type PropTypes = {
     buttonText?: string,
     onClick?: ?(void => void),
     additionalClass?: string,
-    switchedOff?: boolean,
+    switchStatus?: Status,
   }>,
   error: ?string,
   resetError: void => void,

--- a/assets/components/paymentButtons/directDebitPopUpButton/directDebitPopUpButton.jsx
+++ b/assets/components/paymentButtons/directDebitPopUpButton/directDebitPopUpButton.jsx
@@ -13,6 +13,7 @@ import {
   type Action,
 } from 'components/directDebit/directDebitActions';
 import DirectDebitPopUpForm from 'components/directDebit/directDebitPopUpForm/directDebitPopUpForm';
+import type { Status } from 'helpers/switch';
 
 
 // ---- Types ----- //
@@ -22,7 +23,7 @@ type PropTypes = {
   callback: Function,
   isPopUpOpen: boolean,
   openDirectDebitPopUp: () => void,
-  switchedOff: boolean,
+  switchStatus: Status,
 };
 /* eslint-enable react/no-unused-prop-types */
 
@@ -50,7 +51,7 @@ function mapDispatchToProps(dispatch: Dispatch<Action>) {
 
 const DirectDebitPopUpButton = (props: PropTypes) => (
   <Switchable
-    off={props.switchedOff}
+    status={props.switchStatus}
     component={() => <ButtonAndForm {...props} />}
     fallback={() => <PaymentError paymentMethod="direct debit" />}
   />
@@ -91,7 +92,7 @@ function Button(props: { openPopUp: () => void }) {
 
 /* eslint-disable react/default-props-match-prop-types */
 DirectDebitPopUpButton.defaultProps = {
-  switchedOff: false,
+  switchStatus: 'ON',
 };
 /* eslint-enable react/default-props-match-prop-types */
 

--- a/assets/components/paymentButtons/payPalExpressButton/payPalExpressButton.jsx
+++ b/assets/components/paymentButtons/payPalExpressButton/payPalExpressButton.jsx
@@ -8,6 +8,7 @@ import React from 'react';
 import Switchable from 'components/switchable/switchable';
 import PaymentError from 'components/switchable/errorComponents/paymentError';
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
+import type { Status } from 'helpers/switch';
 import { loadPayPalExpress, setup } from 'helpers/payPalExpressCheckout/payPalExpressCheckout';
 import type { Currency } from 'helpers/internationalisation/currency';
 
@@ -21,7 +22,7 @@ type PropTypes = {
   callback: Function,
   setHasLoaded: Function,
   hasLoaded: boolean,
-  switchedOff: boolean,
+  switchStatus: Status,
 };
 
 
@@ -31,7 +32,7 @@ function PayPalExpressButton(props: PropTypes) {
 
   return (
     <Switchable
-      off={props.switchedOff}
+      status={props.switchStatus}
       component={() => <Button {...props} />}
       fallback={() => <PaymentError paymentMethod="PayPal" modifierClass="paypal-express" />}
     />
@@ -71,7 +72,7 @@ function Button(props: PropTypes) {
 
 /* eslint-disable react/default-props-match-prop-types */
 PayPalExpressButton.defaultProps = {
-  switchedOff: false,
+  switchStatus: 'ON',
 };
 /* eslint-enable react/default-props-match-prop-types */
 

--- a/assets/components/paymentButtons/stripePopUpButton/stripePopUpButton.jsx
+++ b/assets/components/paymentButtons/stripePopUpButton/stripePopUpButton.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import SvgCreditCard from 'components/svgs/creditCard';
 import Switchable from 'components/switchable/switchable';
 import PaymentError from 'components/switchable/errorComponents/paymentError';
+import type { Status } from 'helpers/switch';
 import type { Currency } from 'helpers/internationalisation/currency';
 import * as storage from 'helpers/storage';
 import {
@@ -27,7 +28,7 @@ type PropTypes = {
   isTestUser: boolean,
   isPostDeploymentTestUser: boolean,
   canOpen: Function,
-  switchedOff: boolean,
+  switchStatus: Status,
 };
 /* eslint-enable react/no-unused-prop-types */
 
@@ -43,7 +44,7 @@ function isStripeSetup(): boolean {
 
 const StripePopUpButton = (props: PropTypes) => (
   <Switchable
-    off={props.switchedOff}
+    status={props.switchStatus}
     component={() => <Button {...props} />}
     fallback={() => <PaymentError paymentMethod="credit/debit card" />}
   />
@@ -88,7 +89,7 @@ function Button(props: PropTypes) {
 StripePopUpButton.defaultProps = {
   canOpen: () => true,
   closeHandler: () => {},
-  switchedOff: false,
+  switchStatus: 'ON',
 };
 /* eslint-enable react/default-props-match-prop-types */
 

--- a/assets/components/switchable/switchable.jsx
+++ b/assets/components/switchable/switchable.jsx
@@ -3,13 +3,13 @@
 // ----- Imports ----- //
 
 import React from 'react';
-
+import type { Status } from 'helpers/switch';
 
 // ----- Types ----- //
 
 /* eslint-disable react/no-unused-prop-types */
 type PropTypes = {
-  off: boolean,
+  status: Status,
   component: React$ComponentType<*>,
   fallback: React$ComponentType<*>,
 };
@@ -20,7 +20,7 @@ type PropTypes = {
 
 function Switchable(props: PropTypes) {
 
-  if (props.off) {
+  if (props.status === 'OFF') {
     return <props.fallback />;
   }
 

--- a/assets/containerisableComponents/payPalContributionButton/payPalContributionButton.jsx
+++ b/assets/containerisableComponents/payPalContributionButton/payPalContributionButton.jsx
@@ -13,6 +13,7 @@ import * as storage from 'helpers/storage';
 
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
+import type { Status } from 'helpers/switch';
 import type { Participations } from 'helpers/abTests/abtest';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
@@ -31,7 +32,7 @@ type PropTypes = {
   buttonText: string,
   additionalClass: string,
   onClick: ?(void => void),
-  switchedOff: boolean,
+  switchStatus: Status,
 };
 /* eslint-enable react/no-unused-prop-types */
 
@@ -66,7 +67,7 @@ function PayPalContributionButton(props: PropTypes) {
 
   return (
     <Switchable
-      off={props.switchedOff}
+      status={props.switchStatus}
       component={() => <Button {...props} />}
       fallback={() => <PaymentError paymentMethod="PayPal" modifierClass="paypal" />}
     />
@@ -100,7 +101,7 @@ PayPalContributionButton.defaultProps = {
   buttonText: 'Pay with PayPal',
   additionalClass: '',
   onClick: null,
-  switchedOff: false,
+  switchStatus: 'ON',
 };
 /* eslint-enable react/default-props-match-prop-types */
 

--- a/assets/helpers/page/page.js
+++ b/assets/helpers/page/page.js
@@ -15,8 +15,10 @@ import thunkMiddleware from 'redux-thunk';
 
 import * as abTest from 'helpers/abTests/abtest';
 import type { Participations } from 'helpers/abTests/abtest';
+import type { Switches } from 'helpers/switch';
 import * as logger from 'helpers/logger';
 import * as googleTagManager from 'helpers/tracking/googleTagManager';
+import * as switchHelper from 'helpers/switch';
 import { detect as detectCountry, type IsoCountry } from 'helpers/internationalisation/country';
 import { detect as detectCurrency, type Currency } from 'helpers/internationalisation/currency';
 import { getAllQueryParamsWithExclusions } from 'helpers/url';
@@ -44,6 +46,7 @@ export type CommonState = {
   countryGroup: CountryGroupId,
   country: IsoCountry,
   abParticipations: Participations,
+  switches: Switches,
 };
 
 export type PreloadedState = {
@@ -79,6 +82,7 @@ function buildInitialState(
   countryGroup: CountryGroupId,
   country: IsoCountry,
   currency: Currency,
+  switches: Switches,
 ): CommonState {
   const acquisition = getAcquisition(abParticipations);
   const excludedParameters = ['REFPVID', 'INTCMP', 'acquisitionData'];
@@ -92,6 +96,7 @@ function buildInitialState(
     country,
     abParticipations,
     currency,
+    switches,
   }, preloadedState);
 
 }
@@ -155,6 +160,7 @@ function init<S, A>(
   const country: IsoCountry = detectCountry();
   const currency: Currency = detectCurrency(countryGroup);
   const participations: Participations = abTest.init(country);
+  const switches: Switches = switchHelper.init();
   analyticsInitialisation(participations);
 
   const initialState: CommonState = buildInitialState(
@@ -163,6 +169,7 @@ function init<S, A>(
     countryGroup,
     country,
     currency,
+    switches,
   );
   const commonReducer = createCommonReducer(initialState);
 

--- a/assets/helpers/switch.js
+++ b/assets/helpers/switch.js
@@ -1,0 +1,30 @@
+// @flow
+
+export type Status = 'ON' | 'OFF';
+
+type SwitchObject = {
+  [string]: Status,
+};
+
+export type Switches = {
+  [string]: SwitchObject,
+};
+
+
+// ----- Default state ----- //
+
+const defaultSwitches: Switches = {
+  oneOffPaymentMethods: {
+    stripe: 'ON',
+    payPal: 'ON',
+  },
+  recurringPaymentMethods: {
+    stripe: 'ON',
+    payPal: 'ON',
+    directDebit: 'ON',
+  },
+};
+
+const init: () => Switches = () => defaultSwitches;
+
+export { init };

--- a/assets/pages/contributions-landing/containers/payPalContributionButtonContainer.js
+++ b/assets/pages/contributions-landing/containers/payPalContributionButtonContainer.js
@@ -20,6 +20,7 @@ function mapStateToProps(state: State) {
     abParticipations: state.common.abParticipations,
     isoCountry: state.common.country,
     canClick: !state.page.selection.error,
+    switchStatus: state.common.switches.oneOffPaymentMethods.payPal,
   };
 
 }

--- a/assets/pages/oneoff-contributions/components/oneoffContributionsPayment.jsx
+++ b/assets/pages/oneoff-contributions/components/oneoffContributionsPayment.jsx
@@ -17,6 +17,7 @@ import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import type { Participations } from 'helpers/abTests/abtest';
 import type { Currency } from 'helpers/internationalisation/currency';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import type { Status } from 'helpers/switch';
 
 import { checkoutError, type Action } from '../oneoffContributionsActions';
 import postCheckout from '../helpers/ajax';
@@ -38,6 +39,8 @@ type PropTypes = {
   currency: Currency,
   isTestUser: boolean,
   isPostDeploymentTestUser: boolean,
+  stripeSwitchStatus: Status,
+  payPalSwitchStatus: Status,
 };
 
 // ----- Map State/Props ----- //
@@ -55,6 +58,8 @@ function mapStateToProps(state) {
     countryGroupId: state.common.countryGroup,
     abParticipations: state.common.abParticipations,
     currency: state.common.currency,
+    stripeSwitchStatus: state.common.switches.oneOffPaymentMethods.stripe,
+    payPalSwitchStatus: state.common.switches.oneOffPaymentMethods.payPal,
   };
 }
 
@@ -119,6 +124,7 @@ function OneoffContributionsPayment(props: PropTypes, context) {
         countryGroupId={props.countryGroupId}
         errorHandler={props.checkoutError}
         abParticipations={props.abParticipations}
+        switchStatus={props.payPalSwitchStatus}
       />
       <StripePopUpButton
         email={props.email}
@@ -139,6 +145,7 @@ function OneoffContributionsPayment(props: PropTypes, context) {
         isTestUser={props.isTestUser}
         isPostDeploymentTestUser={props.isPostDeploymentTestUser}
         amount={props.amount}
+        switchStatus={props.stripeSwitchStatus}
       />
     </section>
   );

--- a/assets/pages/regular-contributions/components/regularContributionsPayment.jsx
+++ b/assets/pages/regular-contributions/components/regularContributionsPayment.jsx
@@ -10,6 +10,8 @@ import PayPalExpressButton from 'components/paymentButtons/payPalExpressButton/p
 import DirectDebitPopUpButton from 'components/paymentButtons/directDebitPopUpButton/directDebitPopUpButton';
 import ErrorMessage from 'components/errorMessage/errorMessage';
 import ProgressMessage from 'components/progressMessage/progressMessage';
+import { emptyInputField } from 'helpers/utilities';
+import type { Status } from 'helpers/switch';
 import { routes } from 'helpers/routes';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import type { Currency } from 'helpers/internationalisation/currency';
@@ -20,7 +22,7 @@ import type { Participations } from 'helpers/abTests/abtest';
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import { setPayPalHasLoaded } from '../regularContributionsActions';
 import { postCheckout } from '../helpers/ajax';
-import { emptyInputField } from '../../../helpers/utilities';
+
 
 // ----- Types ----- //
 
@@ -42,6 +44,9 @@ type PropTypes = {
   abParticipations: Participations,
   referrerAcquisitionData: ReferrerAcquisitionData,
   payPalHasLoaded: boolean,
+  directDebitSwitchStatus: Status,
+  stripeSwitchStatus: Status,
+  payPalSwitchStatus: Status,
 };
 
 
@@ -90,6 +95,7 @@ function RegularContributionsPayment(props: PropTypes, context) {
           props.referrerAcquisitionData,
           context.store.getState,
       )}
+        switchStatus={props.directDebitSwitchStatus}
       />);
   }
 
@@ -110,6 +116,7 @@ function RegularContributionsPayment(props: PropTypes, context) {
     isTestUser={props.isTestUser}
     isPostDeploymentTestUser={props.isPostDeploymentTestUser}
     amount={props.amount}
+    switchStatus={props.stripeSwitchStatus}
   />);
 
   let payPalButton = (<PayPalExpressButton
@@ -129,6 +136,7 @@ function RegularContributionsPayment(props: PropTypes, context) {
     )}
     hasLoaded={props.payPalHasLoaded}
     setHasLoaded={() => props.dispatch(setPayPalHasLoaded())}
+    switchStatus={props.payPalSwitchStatus}
   />);
 
   if (props.hide) {
@@ -167,6 +175,9 @@ function mapStateToProps(state) {
     abParticipations: state.common.abParticipations,
     referrerAcquisitionData: state.common.referrerAcquisitionData,
     payPalHasLoaded: state.page.regularContrib.payPalHasLoaded,
+    directDebitSwitchStatus: state.common.switches.recurringPaymentMethods.directDebit,
+    stripeSwitchStatus: state.common.switches.recurringPaymentMethods.stripe,
+    payPalSwitchStatus: state.common.switches.recurringPaymentMethods.payPal,
   };
 }
 

--- a/assets/pages/support-landing/components/payPalContributionButtonContainer.js
+++ b/assets/pages/support-landing/components/payPalContributionButtonContainer.js
@@ -21,6 +21,7 @@ function mapStateToProps(state: State) {
     abParticipations: state.common.abParticipations,
     isoCountry: state.common.country,
     canClick: !state.page.selection.error,
+    switchStatus: state.common.switches.oneOffPaymentMethods.payPal,
   };
 
 }


### PR DESCRIPTION
## Why are you doing this?

To be able to change one line in the source-code, re-deploy and disable a payment flow.

### tldr;

After the brilliant work done by @Ap0c with the switchable component, I am adding a helper with the default switches and pushing them into the common state. Then I am reading these switches from the common state whenever is necessary. 

## Next steps, for the future:
This work almost concludes the client side work required for the switchboard, next steps are deciding a place where to save the switches and reading them in the `switch.js` from that place, this logic should be located in the init function (which currently return the default switches). 


[**Trello Card**](https://trello.com)

## Changes

* Define default switches
* Push the switches to the common state
* Read the switches status form the common state and passing it to the different buttons whenever is necessary.

## Screenshots

If we would like to disable any of the payment flow, we go to the `helpers/switch.js` file and set it to `OFF` (eg. `directDebit`).
```
const defaultSwitches: Switches = {
  oneOffPaymentMethods: {
    stripe: 'ON',
    payPal: 'ON',
  },
  recurringPaymentMethods: {
    stripe: 'ON',
    payPal: 'ON',
    directDebit: 'OFF',
  },
};
```

Then we can see that the button is disabled on the checkout page:

![switchboardexample](https://user-images.githubusercontent.com/825398/40986550-6494a65c-68de-11e8-8702-f249e342d4ba.png)


