### PR TITLE
Left Margin Section For Digital Sub Landing

### DIFF
--- a/assets/components/leftMarginSection/leftMarginSection.jsx
+++ b/assets/components/leftMarginSection/leftMarginSection.jsx
@@ -1,0 +1,29 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+import type { Node } from 'react';
+
+
+// ----- Props ----- //
+
+type PropTypes = {
+  children: Node,
+};
+
+
+// ----- Component ----- //
+
+export default function LeftMarginSection(props: PropTypes) {
+
+  return (
+    <section className="component-left-margin-section">
+      <div className="component-left-margin-section__content">
+        {props.children}
+      </div>
+    </section>
+  );
+
+}

--- a/assets/components/leftMarginSection/leftMarginSection.jsx
+++ b/assets/components/leftMarginSection/leftMarginSection.jsx
@@ -2,14 +2,15 @@
 
 // ----- Imports ----- //
 
-import React from 'react';
+import React, { type Node } from 'react';
 
-import type { Node } from 'react';
+import { classNameWithModifiers } from 'helpers/utilities';
 
 
 // ----- Props ----- //
 
 type PropTypes = {
+  modifierClasses: Array<?string>,
   children: Node,
 };
 
@@ -19,7 +20,7 @@ type PropTypes = {
 export default function LeftMarginSection(props: PropTypes) {
 
   return (
-    <section className="component-left-margin-section">
+    <section className={classNameWithModifiers('component-left-margin-section', props.modifierClasses)}>
       <div className="component-left-margin-section__content">
         {props.children}
       </div>
@@ -27,3 +28,10 @@ export default function LeftMarginSection(props: PropTypes) {
   );
 
 }
+
+
+// ----- Default Props ----- //
+
+LeftMarginSection.defaultProps = {
+  modifierClasses: [],
+};

--- a/assets/components/leftMarginSection/leftMarginSection.scss
+++ b/assets/components/leftMarginSection/leftMarginSection.scss
@@ -1,0 +1,25 @@
+.component-left-margin-section {
+  display: flex;
+
+  @include mq($from: tablet) {
+    &:before {
+      content: "";
+      flex-basis: 0;
+      flex-grow: 1;
+      // Fix for IE11, it doesn't treat inline elements as flex items.
+      display: block;
+    }
+  }
+}
+
+.component-left-margin-section__content {
+  flex-grow: 1;
+
+  @include mq($from: tablet) {
+    flex-basis: 730px;
+  }
+
+  @include mq($from: desktop) {
+    flex-basis: 970px;
+  }
+}

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -10,6 +10,7 @@ import { detect, type CountryGroupId } from 'helpers/internationalisation/countr
 
 import countrySwitcherHeaderContainer from 'components/headers/countrySwitcherHeader/countrySwitcherHeaderContainer';
 import Footer from 'components/footer/footer';
+import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
 
 import { init as pageInit } from 'helpers/page/page';
 
@@ -43,10 +44,16 @@ const CountrySwitcherHeader = countrySwitcherHeaderContainer(
 const content = (
   <Provider store={store}>
     <div>
-      <CountrySwitcherHeader /> { /* https://trello.com/c/IrhfApmz/1456-digital-pack-product-page-aus */ }
-      { /* <DigipackHeaderBlock /> (https://trello.com/c/LDgBVJWi/1601-digital-pack-header-block) */ }
-      { /* <DigipackProductBlock /> (https://trello.com/c/8UBqJMTP/1532-digital-pack-product-block) */ }
-      { /* <DigipackJournalismBlock /> (https://trello.com/c/owe2K3bS/1533-independent-journalism-block) */ }
+      <CountrySwitcherHeader />
+      <LeftMarginSection>
+        <h1>Support The Guardian with a digital subscription</h1>
+      </LeftMarginSection>
+      <LeftMarginSection>
+        <h2>Enjoy our quality, independent journalism, plus some extra features, on mobile and tablet apps</h2>
+      </LeftMarginSection>
+      <LeftMarginSection>
+        <h2>Your subscription helps support independent investigative journalism</h2>
+      </LeftMarginSection>
       <Footer />
     </div>
   </Provider>

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -5,9 +5,10 @@
 
 // ----- Shared Components ----- //
 
+@import '~components/countryGroupSwitcher/countryGroupSwitcher';
 @import '~components/footer/footer';
 @import '~components/headers/countrySwitcherHeader/countrySwitcherHeader';
-@import '~components/countryGroupSwitcher/countryGroupSwitcher';
+@import '~components/leftMarginSection/leftMarginSection';
 
 
 // ----- Page-Specific Styles ----- //


### PR DESCRIPTION
## Why are you doing this?

We need a new type of page section for the digital subscription landing page. The new component added here will wrap each of the sections on the new page, and grow/shrink the size of the content and margins accordingly.

[**Trello Card**](https://trello.com/c/xIIEXAmC/1606-digital-product-page-containers)

cc @JustinPinner 

## Changes

- Added a `LeftMarginSection` component.
- Created placeholders for the sections on the digital sub landing page.
