### PR TITLE
Digital Subscription CTA

### DIFF
--- a/assets/components/priceCta/priceCta.jsx
+++ b/assets/components/priceCta/priceCta.jsx
@@ -30,6 +30,7 @@ export default function PriceCta(props: PropTypes) {
         text={props.ctaText}
         url={props.url}
         accessibilityHint={`${props.ctaText} for only ${props.price} per month`}
+        ctaId="price-cta"
       />
       <p className="component-price-cta__price">
         <span className="component-price-cta__price-copy">for only</span>

--- a/assets/components/priceCta/priceCta.jsx
+++ b/assets/components/priceCta/priceCta.jsx
@@ -16,6 +16,7 @@ type PropTypes = {
   url: string,
   price: string,
   dark: boolean,
+  secondaryCopy: string,
 };
 
 
@@ -35,7 +36,7 @@ export default function PriceCta(props: PropTypes) {
         <span className="component-price-cta__price-amount">{props.price}</span>
         <span className="component-price-cta__price-copy">per month</span>
       </p>
-      <p className="component-price-cta__cancel">You can cancel your subscription at any time</p>
+      <p className="component-price-cta__cancel">{props.secondaryCopy}</p>
     </div>
   );
 
@@ -46,4 +47,5 @@ export default function PriceCta(props: PropTypes) {
 
 PriceCta.defaultProps = {
   dark: false,
+  secondaryCopy: 'You can cancel your subscription at any time',
 };

--- a/assets/components/priceCta/priceCta.jsx
+++ b/assets/components/priceCta/priceCta.jsx
@@ -4,6 +4,8 @@
 
 import React from 'react';
 
+import { classNameWithModifiers } from 'helpers/utilities';
+
 import CtaLink from 'components/ctaLink/ctaLink';
 
 
@@ -13,6 +15,7 @@ type PropTypes = {
   ctaText: string,
   url: string,
   price: string,
+  dark: boolean,
 };
 
 
@@ -21,7 +24,7 @@ type PropTypes = {
 export default function PriceCta(props: PropTypes) {
 
   return (
-    <div className="component-price-cta">
+    <div className={classNameWithModifiers('component-price-cta', props.dark ? ['dark'] : [])}>
       <CtaLink
         text={props.ctaText}
         url={props.url}
@@ -37,3 +40,10 @@ export default function PriceCta(props: PropTypes) {
   );
 
 }
+
+
+// ----- Default Props ----- //
+
+PriceCta.defaultProps = {
+  dark: false,
+};

--- a/assets/components/priceCta/priceCta.jsx
+++ b/assets/components/priceCta/priceCta.jsx
@@ -1,0 +1,39 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+import CtaLink from 'components/ctaLink/ctaLink';
+
+
+// ----- Types ----- //
+
+type PropTypes = {
+  ctaText: string,
+  url: string,
+  price: string,
+};
+
+
+// ----- Component ----- //
+
+export default function PriceCta(props: PropTypes) {
+
+  return (
+    <div className="component-price-cta">
+      <CtaLink
+        text={props.ctaText}
+        url={props.url}
+        accessibilityHint={`${props.ctaText} for only ${props.price} per month`}
+      />
+      <p className="component-price-cta__price">
+        <span className="component-price-cta__price-copy">for only</span>
+        <span className="component-price-cta__price-amount">{props.price}</span>
+        <span className="component-price-cta__price-copy">per month</span>
+      </p>
+      <p className="component-price-cta__cancel">You can cancel your subscription at any time</p>
+    </div>
+  );
+
+}

--- a/assets/components/priceCta/priceCta.scss
+++ b/assets/components/priceCta/priceCta.scss
@@ -85,3 +85,15 @@
   width: 100%;
   box-sizing: border-box;
 }
+
+.component-price-cta--dark {
+  background-color: gu-colour(media-garnett-main-1);
+
+  .component-price-cta__price {
+    background-color: gu-colour(news-garnett-highlight);
+  }
+
+  .component-price-cta__price-copy, .component-price-cta__price-amount {
+    color: gu-colour(garnett-neutral-1);
+  }
+}

--- a/assets/components/priceCta/priceCta.scss
+++ b/assets/components/priceCta/priceCta.scss
@@ -1,0 +1,87 @@
+.component-price-cta {
+  padding-left: $gu-h-spacing / 2;
+  padding-top: $gu-v-spacing / 2;
+  background-color: gu-colour(news-garnett-highlight);
+  position: relative;
+  height: 86px;
+
+  .component-cta-link {
+    width: 165px;
+    background-color: #fff;
+    color: gu-colour(garnett-neutral-1);
+
+    &:hover {
+      background-color: darken(#fff, 5%);
+    }
+
+    @include mq($from: mobileMedium) {
+      width: 190px;
+    }
+
+    @include mq($from: desktop) {
+      width: 220px;
+    }
+  }
+
+  .svg-arrow-right-straight {
+    fill: gu-colour(garnett-neutral-1);
+  }
+}
+
+.component-price-cta__price {
+  background-color: gu-colour(garnett-neutral-1);
+  width: 105px;
+  height: 105px;
+  border-radius: 600px;
+  position: absolute;
+  left: 225px;
+  top: -28px;
+  padding-top: 20px;
+  box-sizing: border-box;
+
+  @include mq($from: mobileMedium) {
+    left: 260px;
+  }
+
+  @include mq($from: mobileLandscape) {
+    left: 360px;
+  }
+
+  @include mq($from: desktop) {
+    left: 380px;
+  }
+}
+
+.component-price-cta__price-copy {
+  display: block;
+  text-align: center;
+  color: gu-colour(news-garnett-highlight);
+  font-size: 14px;
+  line-height: 14px;
+  font-family: $gu-text-sans-web;
+}
+
+.component-price-cta__price-amount {
+  display: block;
+  text-align: center;
+  color: gu-colour(news-garnett-highlight);
+  font-size: 26px;
+  line-height: 26px;
+  font-family: $gu-egyptian-web;
+  font-weight: bold;
+  margin-bottom: 4px;
+}
+
+.component-price-cta__cancel {
+  background-color: gu-colour(garnett-neutral-3);
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  font-size: 14px;
+  font-style: italic;
+  line-height: 24px;
+  padding-bottom: $gu-v-spacing / 2;
+  padding-left: $gu-h-spacing / 2;
+  width: 100%;
+  box-sizing: border-box;
+}

--- a/assets/helpers/subscriptions.js
+++ b/assets/helpers/subscriptions.js
@@ -1,0 +1,22 @@
+// @flow
+
+// ----- Imports ----- //
+
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+
+
+// ----- Config ----- //
+
+const digitalSubPrices: {
+  [CountryGroupId]: number,
+} = {
+  GBPCountries: 11.99,
+  UnitedStates: 19.99,
+  AUDCountries: 21.50,
+  International: 19.99,
+};
+
+
+// ----- Exports ----- //
+
+export { digitalSubPrices };

--- a/assets/pages/digital-subscription-landing/components/priceCtaContainer.jsx
+++ b/assets/pages/digital-subscription-landing/components/priceCtaContainer.jsx
@@ -1,0 +1,30 @@
+// @flow
+
+// ----- Imports ----- //
+
+import { connect } from 'react-redux';
+
+import PriceCta from 'components/priceCta/priceCta';
+
+import { digitalSubPrices } from 'helpers/subscriptions';
+import type { CommonState } from 'helpers/page/page';
+
+
+// ----- State Maps ----- //
+
+function mapStateToProps(state: { common: CommonState }) {
+
+  const price = digitalSubPrices[state.common.countryGroup].toFixed(2);
+
+  return {
+    ctaText: 'Start a 14 day free trial',
+    url: '/',
+    price: `${state.common.currency.glyph}${price}`,
+  };
+
+}
+
+
+// ----- Exports ----- //
+
+export default connect(mapStateToProps)(PriceCta);

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -7,13 +7,12 @@ import { Provider } from 'react-redux';
 
 import { renderPage } from 'helpers/render';
 import { detect, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { init as pageInit } from 'helpers/page/page';
 
 import countrySwitcherHeaderContainer from 'components/headers/countrySwitcherHeader/countrySwitcherHeaderContainer';
 import Footer from 'components/footer/footer';
 import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
-import PriceCta from 'components/priceCta/priceCta';
-
-import { init as pageInit } from 'helpers/page/page';
+import PriceCtaContainer from './components/priceCtaContainer';
 
 
 // ----- Redux Store ----- //
@@ -48,28 +47,15 @@ const content = (
       <CountrySwitcherHeader />
       <LeftMarginSection>
         <h1>Support The Guardian with a digital subscription</h1>
-        <PriceCta
-          ctaText="Start a 14 day free trial"
-          price="£11.99"
-          url="/"
-          dark
-        />
+        <PriceCtaContainer dark />
       </LeftMarginSection>
       <LeftMarginSection>
         <h2>Enjoy our quality, independent journalism, plus some extra features, on mobile and tablet apps</h2>
-        <PriceCta
-          ctaText="Start a 14 day free trial"
-          price="£11.99"
-          url="/"
-        />
+        <PriceCtaContainer />
       </LeftMarginSection>
       <LeftMarginSection>
         <h2>Your subscription helps support independent investigative journalism</h2>
-        <PriceCta
-          ctaText="Start a 14 day free trial"
-          price="£11.99"
-          url="/"
-        />
+        <PriceCtaContainer />
       </LeftMarginSection>
       <Footer />
     </div>

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -52,13 +52,24 @@ const content = (
           ctaText="Start a 14 day free trial"
           price="£11.99"
           url="/"
+          dark
         />
       </LeftMarginSection>
       <LeftMarginSection>
         <h2>Enjoy our quality, independent journalism, plus some extra features, on mobile and tablet apps</h2>
+        <PriceCta
+          ctaText="Start a 14 day free trial"
+          price="£11.99"
+          url="/"
+        />
       </LeftMarginSection>
       <LeftMarginSection>
         <h2>Your subscription helps support independent investigative journalism</h2>
+        <PriceCta
+          ctaText="Start a 14 day free trial"
+          price="£11.99"
+          url="/"
+        />
       </LeftMarginSection>
       <Footer />
     </div>

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -11,6 +11,7 @@ import { detect, type CountryGroupId } from 'helpers/internationalisation/countr
 import countrySwitcherHeaderContainer from 'components/headers/countrySwitcherHeader/countrySwitcherHeaderContainer';
 import Footer from 'components/footer/footer';
 import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
+import PriceCta from 'components/priceCta/priceCta';
 
 import { init as pageInit } from 'helpers/page/page';
 
@@ -47,6 +48,11 @@ const content = (
       <CountrySwitcherHeader />
       <LeftMarginSection>
         <h1>Support The Guardian with a digital subscription</h1>
+        <PriceCta
+          ctaText="Start a 14 day free trial"
+          price="£11.99"
+          url="/"
+        />
       </LeftMarginSection>
       <LeftMarginSection>
         <h2>Enjoy our quality, independent journalism, plus some extra features, on mobile and tablet apps</h2>

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -6,9 +6,11 @@
 // ----- Shared Components ----- //
 
 @import '~components/countryGroupSwitcher/countryGroupSwitcher';
+@import '~components/ctaLink/ctaLink';
 @import '~components/footer/footer';
 @import '~components/headers/countrySwitcherHeader/countrySwitcherHeader';
 @import '~components/leftMarginSection/leftMarginSection';
+@import '~components/priceCta/priceCta';
 
 
 // ----- Page-Specific Styles ----- //
@@ -17,5 +19,7 @@
 #digital-subscription-landing-page-uk,
 #digital-subscription-landing-page-us,
 #digital-subscription-landing-page-au {
-  // your code here
+  .component-left-margin-section__content {
+    overflow-x: hidden;
+  }
 }


### PR DESCRIPTION
## Why are you doing this?

The CTA on the digital subscription landing page is consistent across all sections, a good case for a component. This creates that reusable component and drops it into the page.

[**Trello Card**](https://trello.com/c/xIIEXAmC/1606-digital-product-page-containers)

cc @JustinPinner 

## Changes

- Added a `PriceCta` component.
- Added a container for the `PriceCta` on the digital landing page.
- Added a new `subscriptions` helper, the equal of the existing `contributions` helper.

## Screenshots

**CTA Desktop - AU**

![cta-desktop](https://user-images.githubusercontent.com/5131341/41051769-eb6c698c-69ae-11e8-93cd-380a14fb1733.png)

**CTA Tablet - US**

![cta-tablet](https://user-images.githubusercontent.com/5131341/41051771-ec06a146-69ae-11e8-95d0-549f5d7517dc.png)

**CTA Mobile - UK**

![cta-mobile](https://user-images.githubusercontent.com/5131341/41051770-ebec54da-69ae-11e8-8b60-32109e037754.png)
