### PR TITLE
Remove Component Events From CtaLink

### DIFF
--- a/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
+++ b/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
@@ -116,7 +116,6 @@ function OneOffCta(props: {
 
   return (
     <CtaLink
-      ctaId="contribute-one-off"
       text={`Contribute ${props.currency.glyph}${props.amount} with card`}
       accessibilityHint={`proceed to make your ${spokenType} contribution`}
       url={clickUrl}
@@ -147,7 +146,6 @@ function RegularCta(props: {
 
   return (
     <CtaLink
-      ctaId="contribute-regular"
       text={`Contribute ${props.currency.glyph}${props.amount} a month`}
       accessibilityHint={`proceed to make your ${spokenType} contribution`}
       url={clickUrl}

--- a/assets/components/ctaLink/ctaLink.jsx
+++ b/assets/components/ctaLink/ctaLink.jsx
@@ -18,9 +18,7 @@ import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 type PropTypes = {
   text: string,
   accessibilityHint: string,
-  ctaId: string,
   url?: ?string,
-  trackComponentEvent?: Function,
   onClick?: ?Function,
   tabIndex?: number,
   id?: ?string,
@@ -44,16 +42,7 @@ export default function CtaLink(props: PropTypes) {
         addQueryParamToURL(urlString, 'acquisitionData', JSON.stringify(props.acquisitionData))
          : props.url
       }
-      onClick={
-        (clickEvent) => {
-          if (props.trackComponentEvent) {
-            props.trackComponentEvent('CLICK', props.ctaId);
-          }
-          if (props.onClick) {
-            props.onClick(clickEvent);
-          }
-        }
-      }
+      onClick={props.onClick}
       onKeyPress={props.onClick ? clickSubstituteKeyPressHandler(props.onClick) : null}
       tabIndex={props.tabIndex}
       aria-describedby={accessibilityHintId}
@@ -71,7 +60,6 @@ export default function CtaLink(props: PropTypes) {
 
 CtaLink.defaultProps = {
   url: null,
-  trackComponentEvent: () => {},
   onClick: null,
   tabIndex: 0,
   id: null,

--- a/assets/components/dotcomCta/dotcomCta.jsx
+++ b/assets/components/dotcomCta/dotcomCta.jsx
@@ -18,7 +18,6 @@ export default function DotcomCta() {
         <CtaLink
           text="Return to The Guardian"
           accessibilityHint="click here to return to The Guardian front page"
-          ctaId="return-to-the-guardian"
           url="https://www.theguardian.com"
         />
       </PageSection>

--- a/assets/components/otherProduct/otherProduct.jsx
+++ b/assets/components/otherProduct/otherProduct.jsx
@@ -20,7 +20,6 @@ type PropTypes = {
   copy: string,
   ctaText: string,
   ctaUrl: string,
-  ctaId: string,
   ctaAccessibilityHint: string,
 };
 
@@ -44,7 +43,6 @@ export default function OtherProduct(props: PropTypes) {
       <CtaLink
         text={props.ctaText}
         url={props.ctaUrl}
-        ctaId={props.ctaId}
         accessibilityHint={props.ctaAccessibilityHint}
       />
     </div>

--- a/assets/components/patronsEvents/patronsEvents.jsx
+++ b/assets/components/patronsEvents/patronsEvents.jsx
@@ -31,7 +31,6 @@ export default function PatronsEvents(props: PropTypes) {
         copy="The Patron tier is for those who want a deeper relationship with the Guardian and its journalists"
         ctaText="Find out more"
         ctaUrl={getMemLink('patrons', props.campaignCode)}
-        ctaId="patrons"
         ctaAccessibilityHint="Find out more about becoming a Patron"
       />
       <OtherProduct
@@ -42,7 +41,6 @@ export default function PatronsEvents(props: PropTypes) {
         copy="Meet Guardian journalists and readers at our events, debates, interviews and festivals"
         ctaText="Find out more"
         ctaUrl={getMemLink('events', props.campaignCode)}
-        ctaId="live-events"
         ctaAccessibilityHint="Find out more about Guardian live events"
       />
     </PageSection>

--- a/assets/components/readyToSupport/readyToSupport.jsx
+++ b/assets/components/readyToSupport/readyToSupport.jsx
@@ -29,7 +29,6 @@ export default function ReadyToSupport(props: PropTypes) {
         <CtaLink
           text="See supporter options"
           url={props.ctaUrl}
-          ctaId="see-supporter-options"
           accessibilityHint="See the options for becoming a supporter"
           svg={<SvgChevronUp />}
           modifierClasses={['see-supporter-options']}

--- a/assets/components/subscriptionBundle/subscriptionBundle.jsx
+++ b/assets/components/subscriptionBundle/subscriptionBundle.jsx
@@ -24,7 +24,6 @@ type PropTypes = {
   benefits: ListItem[],
   ctaText: string,
   ctaUrl: string,
-  ctaId: string,
   ctaAccessibilityHint: string,
   gridImage: GridImg,
   ctaModifiers?: Array<?string>,
@@ -47,7 +46,6 @@ export default function SubscriptionBundle(props: PropTypes) {
         <CtaLink
           text={props.ctaText}
           url={props.ctaUrl}
-          ctaId={props.ctaId}
           accessibilityHint={props.ctaAccessibilityHint}
           modifierClasses={props.ctaModifiers}
         />

--- a/assets/components/threeSubscriptions/threeSubscriptions.jsx
+++ b/assets/components/threeSubscriptions/threeSubscriptions.jsx
@@ -66,7 +66,6 @@ function DigitalBundle(props: { url: string }) {
       benefits={getDigitalBenefits()}
       ctaText="Start your 14 day trial"
       ctaUrl={props.url}
-      ctaId="digital-sub"
       ctaAccessibilityHint="The Guardian\'s digital subscription is available for eleven pounds and ninety nine pence per month. Find out how to sign up for a free trial."
       gridImage={{
         gridId: 'digitalCircle',
@@ -89,7 +88,6 @@ function PaperBundle(props: { url: string }) {
       benefits={getPaperBenefits()}
       ctaText="Get a paper subscription"
       ctaUrl={props.url}
-      ctaId="paper-sub"
       ctaAccessibilityHint="Proceed to paper subscription options, starting at ten pounds seventy nine pence per month."
       gridImage={{
         gridId: 'paperCircle',
@@ -112,7 +110,6 @@ function PaperDigitalBundle(props: { url: string }) {
       benefits={getPaperDigitalBenefits()}
       ctaText="Get a paper+digital subscription"
       ctaUrl={props.url}
-      ctaId="paper-digi-sub"
       ctaAccessibilityHint="Proceed to choose which days you would like to regularly receive the newspaper in conjunction with a digital subscription"
       gridImage={{
         gridId: 'paperDigitalCircle',

--- a/assets/containerisableComponents/marketingConsent/marketingConsent.jsx
+++ b/assets/containerisableComponents/marketingConsent/marketingConsent.jsx
@@ -83,7 +83,6 @@ function ChooseMarketingPreference(props: {
         onClick={
           () => props.onClick(props.marketingPreferencesOptIn, props.email, props.csrf)
         }
-        ctaId="next"
         text="Next"
         accessibilityHint="Go to the guardian dot com front page"
         modifierClasses={['next']}

--- a/assets/pages/error/components/errorPage.jsx
+++ b/assets/pages/error/components/errorPage.jsx
@@ -41,14 +41,12 @@ export default function ErrorPage(props: PropTypes) {
         <CtaLink
           text="Support The Guardian"
           accessibilityHint="click here to support The Guardian"
-          ctaId="support-the-guardian"
           url="/"
           modifierClasses={['support-the-guardian']}
         />
         <CtaLink
           text="Go to The Guardian home page"
           accessibilityHint="click here to return to The Guardian home page"
-          ctaId="guardian-home-page"
           url="https://www.theguardian.com"
           modifierClasses={['guardian-home-page', 'border']}
         />

--- a/assets/pages/paypal-error/payPalError.jsx
+++ b/assets/pages/paypal-error/payPalError.jsx
@@ -33,7 +33,6 @@ const content = (
         Sorry, there was a problem completing your PayPal payment. Please try again:
       </p>
       <CtaLink
-        ctaId="become-supporter-paypal"
         text="Become a Supporter"
         url="/"
         accessibilityHint="Restart your journey to become a guardian supporter"

--- a/assets/pages/regular-contributions-existing/regularContributionsExisting.jsx
+++ b/assets/pages/regular-contributions-existing/regularContributionsExisting.jsx
@@ -44,7 +44,6 @@ const content = (
           and it makes a world of difference.
       </p>
       <CtaLink
-        ctaId="manage-contribution"
         text="Amend your recurring contribution"
         url={buildMMAUrl()}
         accessibilityHint="Further support the guardian by increasing your regular contribution"


### PR DESCRIPTION
## Why are you doing this?

This isn't used anywhere in the codebase, I'm removing it from `CtaLink` for now to simplify the code.

cc @JustinPinner 

## Changes

- Removed component event tracking from `CtaLink`.
- Stopped passing through `ctaId` across the codebase.
