### PR TITLE
Remove Australia from the country picker for the digital subscription product page

### DIFF
--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -29,13 +29,12 @@ const reactElementId: {
 } = {
   GBPCountries: 'digital-subscription-landing-page-uk',
   UnitedStates: 'digital-subscription-landing-page-us',
-  AUDCountries: 'digital-subscription-landing-page-au',
   International: 'digital-subscription-landing-page-int',
 };
 
 const CountrySwitcherHeader = countrySwitcherHeaderContainer(
   '/subscribe/digital',
-  ['GBPCountries', 'UnitedStates', 'AUDCountries', 'International'],
+  ['GBPCountries', 'UnitedStates', 'International'],
 );
 
 

--- a/conf/routes
+++ b/conf/routes
@@ -68,7 +68,6 @@ GET  /:countryCode/subscribe                       controllers.Subscriptions.leg
 
 GET  /uk/subscribe/digital                         controllers.Subscriptions.digital(countryCode="uk")
 GET  /us/subscribe/digital                         controllers.Subscriptions.digital(countryCode="us")
-GET  /au/subscribe/digital                         controllers.Subscriptions.digital(countryCode="au")
 GET  /int/subscribe/digital                        controllers.Subscriptions.digital(countryCode="int")
 
 # ----- Authentication ----- #


### PR DESCRIPTION

## Why are you doing this?

The PR to add a skeleton page for digital subscription (https://github.com/guardian/support-frontend/pull/691) already added a country picker that updated the price on the page. However, while we resolve questions about the Australia product page, we shall remove it from the country picker. It will be readded in the future. 

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/IrhfApmz/1456-product-pages-for-other-regions)

## Changes

* Removes Australia from the country picker of the digital subscription product page

## Screenshots

