### PR TITLE
Digital Subscription Product Page - Product Block

### DIFF
--- a/assets/components/featureList/featureList.jsx
+++ b/assets/components/featureList/featureList.jsx
@@ -6,6 +6,8 @@ import React from 'react';
 
 import { classNameWithModifiers } from 'helpers/utilities';
 
+import Heading, { type HeadingRange } from 'components/heading/heading';
+
 
 // ----- Types ----- //
 
@@ -22,6 +24,7 @@ export type ListItem =
 type PropTypes = {
   modifierClass?: string,
   listItems: ListItem[],
+  headingSize: HeadingRange,
 };
 
 
@@ -31,7 +34,7 @@ function FeatureList(props: PropTypes) {
 
   const items = props.listItems.map((item: ListItem) => (
     <li className="component-feature-list__item">
-      <ItemHeading heading={item.heading ? item.heading : null} />
+      <ItemHeading heading={item.heading ? item.heading : null} size={props.headingSize} />
       <ItemText text={item.text ? item.text : null} />
     </li>
   ));
@@ -47,10 +50,17 @@ function FeatureList(props: PropTypes) {
 
 // ----- Auxiliary Components ----- //
 
-function ItemHeading(props: { heading: ?string }) {
+function ItemHeading(props: { heading: ?string, size: HeadingRange }) {
 
   if (props.heading) {
-    return <h3 className="component-feature-list__heading">{props.heading}</h3>;
+    return (
+      <Heading
+        className="component-feature-list__heading"
+        size={props.size}
+      >
+        {props.heading}
+      </Heading>
+    );
   }
 
   return null;

--- a/assets/components/featureList/featureList.jsx
+++ b/assets/components/featureList/featureList.jsx
@@ -2,7 +2,7 @@
 
 // ----- Imports ----- //
 
-import React from 'react';
+import React, { type Node } from 'react';
 
 import { classNameWithModifiers } from 'helpers/utilities';
 
@@ -15,8 +15,8 @@ import Heading, { type HeadingRange } from 'components/heading/heading';
 /* eslint-disable react/no-unused-prop-types */
 
 export type ListItem =
-  | {| heading: string, text: string |}
-  | {| heading: string |}
+  | {| heading: Node, text: string |}
+  | {| heading: Node |}
   | {| text: string |};
 
 /* eslint-enable react/no-unused-prop-types */
@@ -50,7 +50,7 @@ function FeatureList(props: PropTypes) {
 
 // ----- Auxiliary Components ----- //
 
-function ItemHeading(props: { heading: ?string, size: HeadingRange }) {
+function ItemHeading(props: { heading: ?Node, size: HeadingRange }) {
 
   if (props.heading) {
     return (

--- a/assets/components/heading/heading.jsx
+++ b/assets/components/heading/heading.jsx
@@ -1,0 +1,39 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React, { type Node } from 'react';
+
+
+// ----- Types ----- //
+
+export type HeadingRange = 1 | 2 | 3 | 4 | 5 | 6;
+
+type PropTypes = {
+  size: HeadingRange,
+  className: string,
+  children: Node,
+};
+
+
+// ----- Component ----- //
+
+export default function Heading(props: PropTypes) {
+
+  switch (props.size) {
+    case 1:
+      return <h1 className={props.className}>{props.children}</h1>;
+    case 2:
+      return <h2 className={props.className}>{props.children}</h2>;
+    case 3:
+      return <h3 className={props.className}>{props.children}</h3>;
+    case 4:
+      return <h4 className={props.className}>{props.children}</h4>;
+    case 5:
+      return <h5 className={props.className}>{props.children}</h5>;
+    case 6:
+    default:
+      return <h6 className={props.className}>{props.children}</h6>;
+  }
+
+}

--- a/assets/components/subscriptionBundle/subscriptionBundle.jsx
+++ b/assets/components/subscriptionBundle/subscriptionBundle.jsx
@@ -43,7 +43,7 @@ export default function SubscriptionBundle(props: PropTypes) {
           heading={props.heading}
           subheading={props.subheading}
         />
-        <FeatureList listItems={props.benefits} modifierClass={props.modifierClass} />
+        <FeatureList listItems={props.benefits} modifierClass={props.modifierClass} headingSize={3} />
         <CtaLink
           text={props.ctaText}
           url={props.ctaUrl}

--- a/assets/components/svgs/pennyFarthingCircles.jsx
+++ b/assets/components/svgs/pennyFarthingCircles.jsx
@@ -1,0 +1,23 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+
+// ----- SVG ----- //
+
+export default function SvgPennyFarthingCircles() {
+
+  return (
+    <svg
+      className="svg-penny-farthing-circles"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 138 100"
+      preserveAspectRatio="xMinYMid"
+    >
+      <circle cx="50" cy="50" r="50" fill="#f6f6f6" />
+      <circle cx="116" cy="78" r="22" fill="#ffe500" />
+    </svg>
+  );
+}

--- a/assets/helpers/theGrid.js
+++ b/assets/helpers/theGrid.js
@@ -23,6 +23,8 @@ export const imageCatalogue: {
   digitalCircle: '639c3abc4c09281aedb515d684ac4053ef38a1df/0_0_825_825',
   paperCircle: 'c462d60f2962b745b1e206d5ede998dfb166a8ed/0_0_825_825',
   paperDigitalCircle: 'd94c0f9bade09487b9afca5ee8149efb33f34ccf/0_0_825_825',
+  premiumTier: 'fb0c788ddee28f8e0e66d814595cf81d6aa21ec6/0_0_644_448',
+  dailyEdition: '168cab5197d7b4c5d9e05eb3ff2801b2929f2995/0_0_644_448',
 };
 
 // Utility type: https://flow.org/en/docs/types/utilities/#toc-keys

--- a/assets/pages/digital-subscription-landing/components/productBlock.jsx
+++ b/assets/pages/digital-subscription-landing/components/productBlock.jsx
@@ -1,0 +1,109 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
+import FeatureList from 'components/featureList/featureList';
+import GridImage from 'components/gridImage/gridImage';
+
+import PriceCtaContainer from './priceCtaContainer';
+
+
+// ----- Component ----- //
+
+export default function ProductBlock() {
+
+  return (
+    <div className="product-block">
+      <LeftMarginSection>
+        <h2 className="product-block__heading">
+          Enjoy our quality, independent journalism, plus some extra features,
+          on mobile and tablet apps
+        </h2>
+        <div className="product-block__product product-block__product--premium-app">
+          <div className="product-block__image">
+            <GridImage
+              gridId="premiumTier"
+              altText="the premium tier on the guardian app"
+              srcSizes={[644, 500, 140]}
+              sizes="(max-width: 740px) 100vw, 50vw"
+              imgType="png"
+            />
+          </div>
+          <div className="product-block__copy">
+            <h3 className="product-block__product-heading">App premium tier</h3>
+            <p className="product-block__product-description">
+              Exciting new app features available for mobile and tablet users with
+              a digital subscription
+            </p>
+            <FeatureList
+              headingSize={4}
+              listItems={[
+                {
+                  heading: 'Discover',
+                  text: 'A selection of long reads, interviews and features to be read at leisure',
+                },
+                {
+                  heading: 'Live',
+                  text: 'A fast way to catch up on every news story as it breaks',
+                },
+                {
+                  heading: 'Complete the daily crossword',
+                  text: 'Get our daily crossword wherever you are',
+                },
+                {
+                  heading: 'Ad-free reading',
+                  text: 'Read the news with no distractions',
+                },
+              ]}
+            />
+          </div>
+        </div>
+        <div className="product-block__ampersand">&</div>
+        <div className="product-block__product product-block__product--daily-edition">
+          <div className="product-block__image">
+            <GridImage
+              gridId="dailyEdition"
+              altText="the guardian daily edition app"
+              srcSizes={[644, 500, 140]}
+              sizes="(max-width: 740px) 100vw, 50vw"
+              imgType="png"
+            />
+          </div>
+          <div className="product-block__copy">
+            <h3 className="product-block__product-heading">iPad daily edition</h3>
+            <p className="product-block__product-description">
+              Exciting new app features available for mobile and tablet users with
+              a digital subscription
+            </p>
+            <FeatureList
+              headingSize={4}
+              listItems={[
+                {
+                  heading: 'Read on the go',
+                  text: 'Your complete daily newspaper, designed for iPad and available offline',
+                },
+                {
+                  heading: 'Never wait for the news',
+                  text: 'Downloads automatically at 4am every day, so it\'s there when you wake up',
+                },
+                {
+                  heading: 'Get every supplement',
+                  text: 'Including Weekend, Feast and Observer Food Monthly',
+                },
+                {
+                  heading: 'Enjoy our journalism at your own pace',
+                  text: 'Access to your own 30-day archive',
+                },
+              ]}
+            />
+          </div>
+        </div>
+        <PriceCtaContainer />
+      </LeftMarginSection>
+    </div>
+  );
+
+}

--- a/assets/pages/digital-subscription-landing/components/productBlock.jsx
+++ b/assets/pages/digital-subscription-landing/components/productBlock.jsx
@@ -2,11 +2,13 @@
 
 // ----- Imports ----- //
 
-import React from 'react';
+import React, { type Node } from 'react';
+
+import { classNameWithModifiers } from 'helpers/utilities';
 
 import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
-import FeatureList from 'components/featureList/featureList';
-import GridImage from 'components/gridImage/gridImage';
+import FeatureList, { type ListItem } from 'components/featureList/featureList';
+import GridImage, { type GridImg } from 'components/gridImage/gridImage';
 import SvgPennyFarthingCircles from 'components/svgs/pennyFarthingCircles';
 
 import PriceCtaContainer from './priceCtaContainer';
@@ -32,85 +34,103 @@ export default function ProductBlock() {
           Enjoy our quality, independent journalism, plus some extra features,
           on mobile and tablet apps
         </h2>
-        <div className="product-block__product product-block__product--premium-app">
-          <div className="product-block__image">
-            <GridImage
-              gridId="premiumTier"
-              altText="the premium tier on the guardian app"
-              {...imageProperties}
-            />
-          </div>
-          <div className="product-block__copy">
-            <h3 className="product-block__product-heading">App premium tier</h3>
-            <p className="product-block__product-description">
-              Exciting new app features available for mobile and tablet users with
-              a digital subscription
-            </p>
-            <FeatureList
-              headingSize={4}
-              listItems={[
-                {
-                  heading: ['Discover ', <mark className="product-block__highlight">New</mark>],
-                  text: 'A selection of long reads, interviews and features to be read at leisure',
-                },
-                {
-                  heading: ['Live ', <mark className="product-block__highlight">New</mark>],
-                  text: 'A fast way to catch up on every news story as it breaks',
-                },
-                {
-                  heading: 'Complete the daily crossword',
-                  text: 'Get our daily crossword wherever you are',
-                },
-                {
-                  heading: 'Ad-free reading',
-                  text: 'Read the news with no distractions',
-                },
-              ]}
-            />
-          </div>
-        </div>
+        <Product
+          modifierClass="premium-app"
+          imageProps={{
+            gridId: 'premiumTier',
+            altText: 'the premium tier on the guardian app',
+            ...imageProperties,
+          }}
+          companionSvg={null}
+          heading="App premium tier"
+          description="Exciting new app features available for mobile and tablet users with a digital subscription"
+          features={[
+            {
+              heading: ['Discover ', <mark className="product-block__highlight">New</mark>],
+              text: 'A selection of long reads, interviews and features to be read at leisure',
+            },
+            {
+              heading: ['Live ', <mark className="product-block__highlight">New</mark>],
+              text: 'A fast way to catch up on every news story as it breaks',
+            },
+            {
+              heading: 'Complete the daily crossword',
+              text: 'Get our daily crossword wherever you are',
+            },
+            {
+              heading: 'Ad-free reading',
+              text: 'Read the news with no distractions',
+            },
+          ]}
+        />
         <div className="product-block__ampersand">&</div>
-        <div className="product-block__product product-block__product--daily-edition">
-          <div className="product-block__image">
-            <GridImage
-              gridId="dailyEdition"
-              altText="the guardian daily edition app"
-              {...imageProperties}
-            />
-            <SvgPennyFarthingCircles />
-          </div>
-          <div className="product-block__copy">
-            <h3 className="product-block__product-heading">iPad daily edition</h3>
-            <p className="product-block__product-description">
-              Exciting new app features available for mobile and tablet users with
-              a digital subscription
-            </p>
-            <FeatureList
-              headingSize={4}
-              listItems={[
-                {
-                  heading: 'Read on the go',
-                  text: 'Your complete daily newspaper, designed for iPad and available offline',
-                },
-                {
-                  heading: 'Never wait for the news',
-                  text: 'Downloads automatically at 4am every day, so it\'s there when you wake up',
-                },
-                {
-                  heading: 'Get every supplement',
-                  text: 'Including Weekend, Feast and Observer Food Monthly',
-                },
-                {
-                  heading: 'Enjoy our journalism at your own pace',
-                  text: 'Access to your own 30-day archive',
-                },
-              ]}
-            />
-          </div>
-        </div>
+        <Product
+          modifierClass="daily-edition"
+          imageProps={{
+            gridId: 'dailyEdition',
+            altText: 'the guardian daily edition app',
+            ...imageProperties,
+          }}
+          companionSvg={<SvgPennyFarthingCircles />}
+          heading="iPad daily Edition"
+          description="Enjoy the daily UK newspaper and all of our supplements, specially designed to be read on the iPad"
+          features={[
+            {
+              heading: 'Read on the go',
+              text: 'Your complete daily newspaper, designed for iPad and available offline',
+            },
+            {
+              heading: 'Never wait for the news',
+              text: 'Downloads automatically at 4am every day, so it\'s there when you wake up',
+            },
+            {
+              heading: 'Get every supplement',
+              text: 'Including Weekend, Feast and Observer Food Monthly',
+            },
+            {
+              heading: 'Enjoy our journalism at your own pace',
+              text: 'Access to your own 30-day archive',
+            },
+          ]}
+        />
         <PriceCtaContainer />
       </LeftMarginSection>
     </div>
   );
 
 }
+
+
+// ----- Auxiliary Components ----- //
+
+function Product(props: {
+  modifierClass: string,
+  imageProps: GridImg,
+  companionSvg?: Node,
+  heading: string,
+  description: string,
+  features: ListItem[],
+}) {
+
+  return (
+    <div className={classNameWithModifiers('product-block__product', [props.modifierClass])}>
+      <div className="product-block__image">
+        <GridImage {...props.imageProps} />
+        {props.companionSvg}
+      </div>
+      <div className="product-block__copy">
+        <h3 className="product-block__product-heading">{props.heading}</h3>
+        <p className="product-block__product-description">{props.description}</p>
+        <FeatureList
+          headingSize={4}
+          listItems={props.features}
+        />
+      </div>
+    </div>
+  );
+
+}
+
+Product.defaultProps = {
+  companionSvg: null,
+};

--- a/assets/pages/digital-subscription-landing/components/productBlock.jsx
+++ b/assets/pages/digital-subscription-landing/components/productBlock.jsx
@@ -42,11 +42,11 @@ export default function ProductBlock() {
               headingSize={4}
               listItems={[
                 {
-                  heading: 'Discover',
+                  heading: ['Discover ', <mark className="product-block__highlight">New</mark>],
                   text: 'A selection of long reads, interviews and features to be read at leisure',
                 },
                 {
-                  heading: 'Live',
+                  heading: ['Live ', <mark className="product-block__highlight">New</mark>],
                   text: 'A fast way to catch up on every news story as it breaks',
                 },
                 {

--- a/assets/pages/digital-subscription-landing/components/productBlock.jsx
+++ b/assets/pages/digital-subscription-landing/components/productBlock.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
 import FeatureList from 'components/featureList/featureList';
 import GridImage from 'components/gridImage/gridImage';
+import SvgPennyFarthingCircles from 'components/svgs/pennyFarthingCircles';
 
 import PriceCtaContainer from './priceCtaContainer';
 
@@ -71,6 +72,7 @@ export default function ProductBlock() {
               sizes="(max-width: 740px) 100vw, 50vw"
               imgType="png"
             />
+            <SvgPennyFarthingCircles />
           </div>
           <div className="product-block__copy">
             <h3 className="product-block__product-heading">iPad daily edition</h3>

--- a/assets/pages/digital-subscription-landing/components/productBlock.jsx
+++ b/assets/pages/digital-subscription-landing/components/productBlock.jsx
@@ -12,6 +12,15 @@ import SvgPennyFarthingCircles from 'components/svgs/pennyFarthingCircles';
 import PriceCtaContainer from './priceCtaContainer';
 
 
+// ----- Setup ----- //
+
+const imageProperties = {
+  srcSizes: [644, 500, 140],
+  sizes: '(max-width: 480px) 100vw, (max-width: 660px) 460px, 345px',
+  imgType: 'png',
+};
+
+
 // ----- Component ----- //
 
 export default function ProductBlock() {
@@ -28,9 +37,7 @@ export default function ProductBlock() {
             <GridImage
               gridId="premiumTier"
               altText="the premium tier on the guardian app"
-              srcSizes={[644, 500, 140]}
-              sizes="(max-width: 740px) 100vw, 50vw"
-              imgType="png"
+              {...imageProperties}
             />
           </div>
           <div className="product-block__copy">
@@ -68,9 +75,7 @@ export default function ProductBlock() {
             <GridImage
               gridId="dailyEdition"
               altText="the guardian daily edition app"
-              srcSizes={[644, 500, 140]}
-              sizes="(max-width: 740px) 100vw, 50vw"
-              imgType="png"
+              {...imageProperties}
             />
             <SvgPennyFarthingCircles />
           </div>

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -13,6 +13,7 @@ import countrySwitcherHeaderContainer from 'components/headers/countrySwitcherHe
 import Footer from 'components/footer/footer';
 import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
 import PriceCtaContainer from './components/priceCtaContainer';
+import ProductBlock from './components/productBlock';
 
 
 // ----- Redux Store ----- //
@@ -49,10 +50,7 @@ const content = (
         <h1>Support The Guardian with a digital subscription</h1>
         <PriceCtaContainer dark />
       </LeftMarginSection>
-      <LeftMarginSection>
-        <h2>Enjoy our quality, independent journalism, plus some extra features, on mobile and tablet apps</h2>
-        <PriceCtaContainer />
-      </LeftMarginSection>
+      <ProductBlock />
       <LeftMarginSection>
         <h2>Your subscription helps support independent investigative journalism</h2>
         <PriceCtaContainer />

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -26,20 +26,45 @@
   // ----- Product Block
 
   .product-block {
+    .component-left-margin-section__content {
+      position: relative;
+    }
+
     .component-grid-image {
-      width: calc(100vw - 20px);
+      width: 100%;
       display: block;
+
+      @include mq($from: mobileLandscape, $until: phablet) {
+        width: 460px;
+        margin: 0 auto;
+      }
     }
 
     .component-price-cta {
-      margin-top: $gu-v-spacing;
+      margin-top: $gu-v-spacing * 2;
+    }
+  }
+
+  .product-block__product {
+    @include mq($from: phablet) {
+      display: inline-block;
+      width: 50%;
+      vertical-align: top;
+    }
+
+    @include mq($from: leftCol) {
+      width: 520px;
     }
   }
 
   .product-block__image {
-    border-bottom: 1px solid gu-colour(garnett-neutral-2);
+    border-bottom: 1px solid gu-colour(garnett-neutral-4);
     padding: 0 ($gu-h-spacing / 2);
     margin-bottom: $gu-v-spacing / 2;
+
+    @include mq($from: tablet) {
+      width: 345px;
+    }
   }
 
   .product-block__heading {
@@ -48,6 +73,19 @@
     font-size: 22px;
     line-height: 26px;
     padding: 0 ($gu-h-spacing / 2) $gu-v-spacing;
+
+    @include mq($from: phablet) {
+      font-size: 28px;
+      line-height: 1.14;
+      width: 700px;
+    }
+
+    @include mq($from: leftCol) {
+      font-size: 36px;
+      line-height: 1.11;
+      width: 600px;
+      padding-bottom: $gu-v-spacing * 3;
+    }
   }
 
   .product-block__copy {
@@ -75,7 +113,7 @@
     line-height: 1.25;
     font-family: $gu-egyptian-web;
 
-    @include mq($from: tablet) {
+    @include mq($from: leftCol) {
       columns: 2;
     }
   }
@@ -136,5 +174,27 @@
     background-color: gu-colour(news-garnett-highlight);
     margin: 0 auto -35px;
     position: relative;
+
+    @include mq($from: phablet) {
+      position: absolute;
+      left: calc(50% - 40px);
+      top: 90px;
+    }
+
+    @include mq($from: tablet) {
+      left: calc(140px + 25%);
+    }
+
+    @include mq($from: desktop) {
+      width: 100px;
+      height: 100px;
+      font-size: 60px;
+      line-height: 100px;
+    }
+
+    @include mq($from: leftCol) {
+      left: 395px;
+      top: 160px;
+    }
   }
 }

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -28,6 +28,10 @@
   .product-block {
     .component-left-margin-section__content {
       position: relative;
+
+      @include mq($from: tablet) {
+        border-left: 1px solid gu-colour(garnett-neutral-4);
+      }
     }
 
     .component-grid-image {

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -112,42 +112,27 @@
     font-size: 16px;
     line-height: 1.25;
     font-family: $gu-egyptian-web;
+    list-style-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 10 10"><circle cx="5" cy="5" r="5" fill="#ff4e36"/></svg>');
+    margin-left: 26px;
 
     @include mq($from: leftCol) {
       columns: 2;
+      column-gap: 54px;
     }
   }
 
   .component-feature-list__heading {
     font-weight: bold;
     display: inline;
-    vertical-align: middle;
-    margin-left: 5px;
+    vertical-align: top;
   }
 
   .component-feature-list__item {
-    margin-top: $gu-v-spacing / 2;
-
-    &:before {
-      content: " ";
-      display: inline-block;
-      vertical-align: middle;
-      border-radius: 600px;
-      width: 18px;
-      height: 18px;
-    }
-  }
-
-  .component-feature-list__text {
-    margin-left: 23px;
+    margin-bottom: $gu-v-spacing / 2;
   }
 
   .product-block__product--premium-app {
     .product-block__product-heading {
-      background-color: gu-colour(news-garnett-media-main-1);
-    }
-
-    .component-feature-list__item:before {
       background-color: gu-colour(news-garnett-media-main-1);
     }
   }
@@ -157,8 +142,8 @@
       background-color: gu-colour(sport-garnett-media-main-1);
     }
 
-    .component-feature-list__item:before {
-      background-color: gu-colour(sport-garnett-media-main-1);
+    .component-feature-list {
+      list-style-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 10 10"><circle cx="5" cy="5" r="5" fill="#00b2ff"/></svg>');
     }
   }
 

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -29,7 +29,7 @@
     .component-left-margin-section__content {
       position: relative;
 
-      @include mq($from: tablet) {
+      @include mq($from: desktop) {
         border-left: 1px solid gu-colour(garnett-neutral-4);
       }
     }

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -71,6 +71,26 @@
     border-bottom: 1px solid gu-colour(garnett-neutral-4);
     padding: 0 ($gu-h-spacing / 2);
     margin-bottom: $gu-v-spacing / 2;
+
+    @include mq($from: desktop) {
+      position: relative;
+    }
+
+    .svg-penny-farthing-circles {
+      display: none;
+
+      @include mq($from: desktop) {
+        display: block;
+        position: absolute;
+        width: 250px;
+        bottom: 0;
+        left: 255px;
+      }
+
+      @include mq($from: leftCol) {
+        left: 220px;        
+      }
+    }
   }
 
   .product-block__heading {

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -53,6 +53,10 @@
         margin-top: $gu-v-spacing * 2;
       }
     }
+
+    .component-price-cta__cancel {
+      background-color: #fff;
+    }
   }
 
   .product-block__product {

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -45,7 +45,9 @@
     }
 
     .component-price-cta {
-      margin-top: $gu-v-spacing * 2;
+      @include mq($until: desktop) {
+        margin-top: $gu-v-spacing * 2;
+      }
     }
   }
 

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -135,6 +135,12 @@
     margin-bottom: $gu-v-spacing / 2;
   }
 
+  .product-block__highlight {
+    font-weight: normal;
+    background-color: gu-colour(news-garnett-highlight);
+    padding: 0 2px;
+  }
+
   .product-block__product--premium-app {
     .product-block__product-heading {
       background-color: gu-colour(news-garnett-media-main-1);

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -22,4 +22,119 @@
   .component-left-margin-section__content {
     overflow-x: hidden;
   }
+
+  // ----- Product Block
+
+  .product-block {
+    .component-grid-image {
+      width: calc(100vw - 20px);
+      display: block;
+    }
+
+    .component-price-cta {
+      margin-top: $gu-v-spacing;
+    }
+  }
+
+  .product-block__image {
+    border-bottom: 1px solid gu-colour(garnett-neutral-2);
+    padding: 0 ($gu-h-spacing / 2);
+    margin-bottom: $gu-v-spacing / 2;
+  }
+
+  .product-block__heading {
+    font-family: $gu-egyptian-web;
+    font-weight: 200;
+    font-size: 22px;
+    line-height: 26px;
+    padding: 0 ($gu-h-spacing / 2) $gu-v-spacing;
+  }
+
+  .product-block__copy {
+    padding: 0 ($gu-h-spacing / 2) $gu-v-spacing;
+  }
+
+  .product-block__product-heading {
+    color: #fff;
+    font-weight: bold;
+    font-family: $gu-egyptian-web;
+    line-height: 1;
+    display: inline;
+    padding: 0 5px 3px;
+  }
+
+  .product-block__product-description {
+    margin: $gu-v-spacing / 2 0 $gu-v-spacing;
+    font-size: 16px;
+    line-height: 1.25;
+    font-family: $gu-egyptian-web;
+  }
+
+  .component-feature-list {
+    font-size: 16px;
+    line-height: 1.25;
+    font-family: $gu-egyptian-web;
+
+    @include mq($from: tablet) {
+      columns: 2;
+    }
+  }
+
+  .component-feature-list__heading {
+    font-weight: bold;
+    display: inline;
+    vertical-align: middle;
+    margin-left: 5px;
+  }
+
+  .component-feature-list__item {
+    margin-top: $gu-v-spacing / 2;
+
+    &:before {
+      content: " ";
+      display: inline-block;
+      vertical-align: middle;
+      border-radius: 600px;
+      width: 18px;
+      height: 18px;
+    }
+  }
+
+  .component-feature-list__text {
+    margin-left: 23px;
+  }
+
+  .product-block__product--premium-app {
+    .product-block__product-heading {
+      background-color: gu-colour(news-garnett-media-main-1);
+    }
+
+    .component-feature-list__item:before {
+      background-color: gu-colour(news-garnett-media-main-1);
+    }
+  }
+
+  .product-block__product--daily-edition {
+    .product-block__product-heading {
+      background-color: gu-colour(sport-garnett-media-main-1);
+    }
+
+    .component-feature-list__item:before {
+      background-color: gu-colour(sport-garnett-media-main-1);
+    }
+  }
+
+  .product-block__ampersand {
+    border-radius: 600px;
+    width: 80px;
+    height: 80px;
+    text-align: center;
+    font-size: 50px;
+    line-height: 80px;
+    font-family: $gu-egyptian-web;
+    font-weight: bold;
+    background-color: gu-colour(news-garnett-highlight);
+    margin: 0 auto -35px;
+    position: relative;
+  }
 }

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -110,7 +110,7 @@
       width: 700px;
     }
 
-    @include mq($from: leftCol) {
+    @include mq($from: desktop) {
       font-size: 36px;
       line-height: 1.11;
       width: 600px;
@@ -222,12 +222,8 @@
       height: 100px;
       font-size: 60px;
       line-height: 100px;
-      top: 88px;
-      left: 325px;
-    }
-
-    @include mq($from: leftCol) {
       top: 167px;
+      left: 325px;
     }
   }
 }

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -38,6 +38,10 @@
         width: 460px;
         margin: 0 auto;
       }
+
+      @include mq($from: tablet) {
+        width: 345px;
+      }
     }
 
     .component-price-cta {
@@ -52,6 +56,10 @@
       vertical-align: top;
     }
 
+    @include mq($from: desktop) {
+      width: 485px;
+    }
+
     @include mq($from: leftCol) {
       width: 520px;
     }
@@ -61,10 +69,6 @@
     border-bottom: 1px solid gu-colour(garnett-neutral-4);
     padding: 0 ($gu-h-spacing / 2);
     margin-bottom: $gu-v-spacing / 2;
-
-    @include mq($from: tablet) {
-      width: 345px;
-    }
   }
 
   .product-block__heading {
@@ -138,6 +142,17 @@
   }
 
   .product-block__product--daily-edition {
+    .component-grid-image {
+      @include mq($from: desktop) {
+        position: relative;
+        left: -100px;
+      }
+
+      @include mq($from: leftCol) {
+        left: -135px;
+      }
+    }
+
     .product-block__product-heading {
       background-color: gu-colour(sport-garnett-media-main-1);
     }
@@ -175,11 +190,12 @@
       height: 100px;
       font-size: 60px;
       line-height: 100px;
+      top: 88px;
+      left: 325px;
     }
 
     @include mq($from: leftCol) {
-      left: 395px;
-      top: 160px;
+      top: 167px;
     }
   }
 }


### PR DESCRIPTION
## Why are you doing this?

This adds the "product block" (i.e. the second section) to the digital sub landing page.

[**Trello Card**](https://trello.com/c/8UBqJMTP/1532-product-block)

cc @JustinPinner 

## Changes

- Tweaked the `FeatureList` component to take a React `Node` as a heading, rather than just a `string`.
- Added a new `Heading` component to abstract creation of `h1-6` elements. This is used so that the `FeatureList` headings make semantic sense in the context of the page where they are used; good for a11y.
- Added two new images from the Grid, and a new circles-themed SVG.
- Created a new "product block" component for the digital sub landing page.

## Screenshots

Breakpoint | Screenshot
-|-
LeftCol/Wide | ![product-leftcol](https://user-images.githubusercontent.com/5131341/41180387-03723f76-6b66-11e8-9f49-e219dba45039.jpg)
Desktop | ![product-desktop](https://user-images.githubusercontent.com/5131341/41180392-0999b1d6-6b66-11e8-9284-f4bd7d164a1c.jpg)
Tablet | ![product-tablet](https://user-images.githubusercontent.com/5131341/41180398-109a5242-6b66-11e8-84d2-42cfdabf5365.jpg)
Phablet | ![product-phablet](https://user-images.githubusercontent.com/5131341/41180406-15e8a168-6b66-11e8-8e29-8bdbf0348db5.jpg)
Mobile Landscape | ![product-mobileland](https://user-images.githubusercontent.com/5131341/41180415-1e0f125a-6b66-11e8-83ef-090dee784e33.jpg)
Mobile | ![product-mobile](https://user-images.githubusercontent.com/5131341/41180424-238c439c-6b66-11e8-9048-b07582ca6436.jpg)
