### PR TITLE
Geo Redirect Digital Product Page

### DIFF
--- a/app/controllers/Subscriptions.scala
+++ b/app/controllers/Subscriptions.scala
@@ -57,4 +57,15 @@ class Subscriptions(
     }
   }
 
+  def digitalGeoRedirect: Action[AnyContent] = GeoTargetedCachedAction() { implicit request =>
+    val redirectUrl = request.fastlyCountry match {
+      case Some(UK) => "/uk/subscribe/digital"
+      case Some(US) => "/us/subscribe/digital"
+      case Some(RestOfTheWorld) => "/int/subscribe/digital"
+      case _ => "https://subscribe.theguardian.com/digital"
+    }
+
+    Redirect(redirectUrl, request.queryString, status = FOUND)
+  }
+
 }

--- a/conf/routes
+++ b/conf/routes
@@ -66,6 +66,7 @@ GET  /uk/subscribe                                 controllers.Subscriptions.lan
 # subscribe route. We just redirect to the subscriptions site and let its geolocation handle it.
 GET  /:countryCode/subscribe                       controllers.Subscriptions.legacyRedirect(countryCode: String)
 
+GET  /subscribe/digital                            controllers.Subscriptions.digitalGeoRedirect()
 GET  /uk/subscribe/digital                         controllers.Subscriptions.digital(countryCode="uk")
 GET  /us/subscribe/digital                         controllers.Subscriptions.digital(countryCode="us")
 GET  /int/subscribe/digital                        controllers.Subscriptions.digital(countryCode="int")


### PR DESCRIPTION
## Why are you doing this?

So that we can use geolocation to pass users on to the correct version of the page.

[**Trello Card**](https://trello.com/c/t8yzHmmG/1604-geo-redirect-subscribe-digital)

cc @JustinPinner 

## Changes

- Added `Subscriptions` controller method to handle the redirect.
- Added new route at `/subscribe/digital` for redirection.
