### PR TITLE
Link Digital Product Page To Subs Checkout

### DIFF
--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -154,6 +154,7 @@ function getSubsLinks(
 function getDigitalCheckout(referrerAcquisitionData: ReferrerAcquisitionData): string {
 
   return addQueryParamsToURL(`${subsUrl}/checkout`, {
+    promoCode: defaultPromos.digital,
     acquisitionData: JSON.stringify(referrerAcquisitionData),
   });
 

--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -4,7 +4,11 @@
 
 import type { Campaign } from 'helpers/tracking/acquisitions';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
+
+import { addQueryParamsToURL } from 'helpers/url';
+
 import { getPromoCode } from './flashSale';
+
 
 // ----- Types ----- //
 
@@ -146,10 +150,20 @@ function getSubsLinks(
 
 }
 
+// Builds a link to the digital pack checkout.
+function getDigitalCheckout(referrerAcquisitionData: ReferrerAcquisitionData): string {
+
+  return addQueryParamsToURL(`${subsUrl}/checkout`, {
+    acquisitionData: JSON.stringify(referrerAcquisitionData),
+  });
+
+}
+
 
 // ----- Exports ----- //
 
 export {
   getSubsLinks,
   getMemLink,
+  getDigitalCheckout,
 };

--- a/assets/pages/digital-subscription-landing/components/priceCtaContainer.jsx
+++ b/assets/pages/digital-subscription-landing/components/priceCtaContainer.jsx
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 import PriceCta from 'components/priceCta/priceCta';
 
 import { digitalSubPrices } from 'helpers/subscriptions';
+import { getDigitalCheckout } from 'helpers/externalLinks';
 import type { CommonState } from 'helpers/page/page';
 
 
@@ -18,7 +19,7 @@ function mapStateToProps(state: { common: CommonState }) {
 
   return {
     ctaText: 'Start a 14 day free trial',
-    url: '/',
+    url: getDigitalCheckout(state.common.referrerAcquisitionData),
     price: `${state.common.currency.glyph}${price}`,
   };
 


### PR DESCRIPTION
## Why are you doing this?

We want the CTAs on the digital product page to link to the checkout on subs for now.

[**Trello Card**](https://trello.com/c/re8kTdtQ/1730-where-does-the-digipack-page-link-to)

## Changes

- Added new function to build the digital pack URL.
- Mapped the digital checkout URL to the digital product CTA.
- Updated `externalLinks` and `flashSale` to handle promo codes as just the code, and transform them into a URL later as needed.
