### PR TITLE
Stop Putting Everything In Main

### DIFF
--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -71,7 +71,7 @@
     </div>
   </noscript>
 
-	<main id="@mainId" class="gu-content-wrapper"></main>
+	<div id="@mainId" class="gu-content-wrapper"></div>
 
 	<script src="https://polyfill.guim.co.uk/v2/polyfill.min.js?features=default,Array.prototype.find,fetch,Array.prototype.includes"></script>
 	<script defer id="stripe-js" src="https://js.stripe.com/v3/"></script>

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -71,7 +71,7 @@
     </div>
   </noscript>
 
-	<div id="@mainId" class="gu-content-wrapper"></div>
+	<div id="@mainId"></div>
 
 	<script src="https://polyfill.guim.co.uk/v2/polyfill.min.js?features=default,Array.prototype.find,fetch,Array.prototype.includes"></script>
 	<script defer id="stripe-js" src="https://js.stripe.com/v3/"></script>

--- a/app/views/unsupportedBrowserPage.scala.html
+++ b/app/views/unsupportedBrowserPage.scala.html
@@ -10,37 +10,37 @@
         <meta name="google-site-verification" content="IU-vqTBscxkgU3J_f5i10_i624mvE3IjvYpeVPB2A98" />
         <link rel="stylesheet" href="@assets("unsupportedBrowserStyles.css")">
     </head>
-    <body class="gu-content-wrapper">
+    <body>
         <div id="unsupported-browser" class="gu-content">
             <header class="unsupported-browser__header">
-                <div class="unsupported-browser__header-content gu-header-margin">
+                <div class="unsupported-browser__header-content">
                     <a class="unsupported-browser__header-link" href="https://www.theguardian.com">
                         <div class="accessibility-hint">The guardian logo</div>
                         <svg class="svg-guardian-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 324.999 104.42" preserveAspectRatio="xMinYMid"><path fill="#121212" d="M72.381 55.621l5.539-2.883V9.17h-4.188L63.493 22.755h-1.151l.646-15.138h44.387l.645 15.138h-1.222L96.772 9.17h-4.295v43.474l5.576 2.943v1.469H72.381zM113.322 53.693V5.418l-4.303-1.721v-.899L124.587 0h1.642v22.842l.43-.365c3.442-3.012 8.389-4.948 13.337-4.948 6.813 0 9.824 3.845 9.824 11.017v25.147l3.639 1.982.002 1.463h-20.348v-1.455l3.657-1.989v-25.23c0-3.944-1.722-5.521-4.948-5.521-2.151 0-4.006.674-5.378 1.776v29.043l3.585 1.98v1.396h-20.361V55.75l3.654-2.057zM165.513 38.869c.422 7.979 3.996 14.154 12.469 14.154 4.094 0 7.002-1.898 9.742-3.343v1.571c-2.117 2.894-7.484 6.963-14.968 6.963-13.131 0-19.838-7.3-19.838-19.938 0-12.354 7.343-20.048 19.203-20.048 11.155 0 16.944 5.576 16.944 20.261v.379h-23.552zm-.213-1.838l11.551-.706c0-9.885-1.693-16.445-5.082-16.445-3.601-.001-6.469 7.62-6.469 17.151M0 76.391c0-21.012 13.907-28.493 29.401-28.493 6.575 0 12.773 1.058 16.249 2.494l.303 14.663h-1.478l-9.096-14.188c-1.558-.669-3.035-.931-5.756-.931-8.239 0-12.447 9.515-12.315 25.118.157 18.669 3.401 27.142 10.959 27.142 1.965 0 3.477-.303 4.535-.756V81.454l-4.988-2.858V76.92h24.111v1.785l-4.915 2.749v19.728c-4.08 1.588-10.958 3.099-18.214 3.099C11.186 104.28 0 96.118 0 76.391M50.87 66.585v-1.212l16.219-2.859 1.777.148v31.951c0 3.852 1.852 5.035 4.962 5.035 1.999 0 3.81-.761 5.258-2.482V68.51l-4.444-1.925v-1.259l16.219-2.859 1.63.147v36.624l4.369 1.835v1.165l-15.997 1.967-1.629-.148v-4.812h-.445c-2.962 2.739-7.109 5.109-12.145 5.109-7.776 0-11.331-4.592-11.331-11.553V68.51l-4.443-1.925zM154.449 62.446l1.333.147-.004 11.828h.37c1.732-8.672 5.554-11.907 10.22-11.907.741 0 1.555.073 1.999.298v12.1c-.741-.222-2.073-.296-3.332-.296-3.703 0-6.425.669-8.813 1.761l.004 23.378 3.687 2.046.001 1.518h-21.027v-1.503l3.787-2.056V67.862l-4.444-1.325v-1.083l16.219-3.008zM196.163 63.443V50.967l-4.443-1.556v-.999l16.367-3.009 1.555.223v53.596l4.518 1.64v1.381l-16.145 2.178-1.258-.148v-4.435h-.371c-2.369 2.368-5.629 4.517-10.737 4.517-8.813 0-15.257-6.739-15.257-20.513 0-14.518 7.479-21.657 18.811-21.657 3.257-.001 5.701.592 6.96 1.258m-.023 34.315V65.72c-1.036-.666-1.786-1.489-4.473-1.396-4.377.155-7.08 6.764-7.08 18.539 0 10.589 1.943 16.509 7.776 16.314 1.629-.054 2.963-.637 3.777-1.419M232.846 62.409l1.407.149v37.197l3.697 2.046.002 1.517h-21.027v-1.504l3.775-2.055V68.436l-4.518-1.777v-1.241l16.664-3.009zm1.482-10.043c0 3.926-3.333 6.888-7.185 6.888-3.998 0-7.109-2.962-7.109-6.888 0-3.925 3.111-6.962 7.109-6.962 3.852 0 7.185 3.037 7.185 6.962M283.532 99.759V68.092l-4.443-1.555v-1.536l16.145-3.008 1.629.147v4.74h.444c3.481-3.11 8.666-5.11 13.774-5.11 7.037 0 10.146 3.332 10.146 10.738v27.188l3.771 2.103v1.517h-21.026v-1.503l3.776-2.055V73.25c0-4.074-1.776-5.702-5.109-5.702-2.148 0-3.919.544-5.555 1.767v30.433l3.703 2.053v1.517h-21.035v-1.503l3.78-2.056zM259.661 79.857v-5.311c0-8.003-1.745-10.622-6.693-10.622-.58 0-1.09.073-1.673.146l-8.803 11.931h-1.235V65.017c3.782-1.164 8.51-2.547 14.767-2.547 10.768 0 17.024 2.983 17.024 12.004v25.899l3.855 1.019v1.018c-1.528.946-4.584 1.819-7.93 1.819-5.311 0-7.857-1.746-9.021-4.656h-.363c-2.256 3.055-5.457 4.802-10.476 4.802-6.402 0-10.767-4.001-10.767-10.913 0-6.692 4.146-10.331 12.586-11.931l8.729-1.674zm0 17.896V81.75l-2.691.217c-4.221.364-5.748 3.057-5.748 9.021 0 6.475 2.111 8.147 5.094 8.147 1.673 0 2.619-.509 3.345-1.382M119.175 79.857v-5.311c0-8.003-1.745-10.622-6.693-10.622-.581 0-1.09.073-1.673.146l-8.803 11.931h-1.236V65.017c3.783-1.164 8.511-2.547 14.767-2.547 10.768 0 17.024 2.983 17.024 12.004v25.899l3.856 1.019v1.018c-1.528.946-4.584 1.819-7.93 1.819-5.31 0-7.857-1.746-9.021-4.656h-.364c-2.255 3.055-5.456 4.802-10.475 4.802-6.402 0-10.767-4.001-10.767-10.913 0-6.692 4.146-10.331 12.586-11.931l8.729-1.674zm0 17.896V81.75l-2.691.217c-4.221.364-5.748 3.057-5.748 9.021 0 6.475 2.111 8.147 5.093 8.147 1.672 0 2.619-.509 3.346-1.382"></path></svg>
                     </a>
                 </div>
             </header>
-            <section class="unsupported-browser__introduction-text">
-                <div class="gu-content-margin">
+            <div class="gu-content__main">
+                <section class="unsupported-browser__introduction-text">
                     <p>The browser you are using has known problems which may prevent some of this site's features from working as they should.</p>
                     <p>Your financial support is vital to the Guardian's future, so if possible please update your browser and try again, or try an alternative such as Google's <a href="https://www.google.co.uk/chrome/browser">Chrome</a>.</p>
                     <p>If you continue to have difficulty making a payment, our <a href="https://www.theguardian.com/info/tech-feedback">customer support team</a> are on hand to help.</p>
                     <p>Thank you!</p>
-                </div>
-            </section>
-            <section class="unsupported-browser__why-support">
-                <div class="unsupported-browser__why-support-content gu-content-margin">
-                    <h1 class="unsupported-browser__why-support-heading">Why do we need your support?</h1>
-                    <h2 class="unsupported-browser__why-support-subheading">No one edits our editor</h2>
-                    <p class="unsupported-browser__why-support-copy">Your support is vital in helping the Guardian do the most important journalism of all: that which takes time and effort. More people than ever now read and support the Guardian's independent, quality and investigative journalism.</p>
-                    <h2 class="unsupported-browser__why-support-subheading">Advertising revenues are falling</h2>
-                    <p class="unsupported-browser__why-support-copy">Like many media organisations, the Guardian is operating in an incredibly challenging commercial environment, and the advertising that we used to rely on to fund our work continues to fall.</p>
-                    <h2 class="unsupported-browser__why-support-subheading">We haven't put up a paywall</h2>
-                    <p class="unsupported-browser__why-support-copy">We want to keep our journalism as open as we can.</p>
-                </div>
-            </section>
+                </section>
+                <section class="unsupported-browser__why-support">
+                    <div class="unsupported-browser__why-support-content">
+                        <h1 class="unsupported-browser__why-support-heading">Why do we need your support?</h1>
+                        <h2 class="unsupported-browser__why-support-subheading">No one edits our editor</h2>
+                        <p class="unsupported-browser__why-support-copy">Your support is vital in helping the Guardian do the most important journalism of all: that which takes time and effort. More people than ever now read and support the Guardian's independent, quality and investigative journalism.</p>
+                        <h2 class="unsupported-browser__why-support-subheading">Advertising revenues are falling</h2>
+                        <p class="unsupported-browser__why-support-copy">Like many media organisations, the Guardian is operating in an incredibly challenging commercial environment, and the advertising that we used to rely on to fund our work continues to fall.</p>
+                        <h2 class="unsupported-browser__why-support-subheading">We haven't put up a paywall</h2>
+                        <p class="unsupported-browser__why-support-copy">We want to keep our journalism as open as we can.</p>
+                    </div>
+                </section>
+            </div>
             <footer class="unsupported-browser__footer">
-                <div class="unsupported-browser__footer-content gu-content-margin">
+                <div class="unsupported-browser__footer-content">
                     <a class="unsupported-browser__footer-privacy-policy" href="https://www.theguardian.com/help/privacy-policy">Privacy Policy</a>
                     <small class="unsupported-browser__footer-copyright">© 2018 Guardian News and Media Limited or its affiliated companies. All rights reserved.</small>
                     <p class="unsupported-browser__footer-legal">The ultimate owner of the Guardian is The Scott Trust Limited, whose role it is to secure the editorial and financial independence of the Guardian in perpetuity. Reader contributions support the Guardian’s journalism. Please note that your support of the Guardian’s journalism does not constitute a charitable donation, as such your contribution is not eligible for Gift Aid in the UK nor a tax-deduction elsewhere. If you have any questions about contributing to the Guardian, please <a class="unsupported-browser__footer-legal-link" href="mailto:contribution.support@@theguardian.com">contact us here</a>.</p>

--- a/assets/components/footer/footer.jsx
+++ b/assets/components/footer/footer.jsx
@@ -44,7 +44,7 @@ function Footer(props: PropTypes) {
 
   return (
     <footer className="component-footer">
-      <div className="component-footer__content gu-content-margin">
+      <div className="component-footer__content">
         <PrivacyPolicy privacyPolicy={props.privacyPolicy} />
         {props.children}
         <small className="component-footer__copyright">{copyrightNotice}</small>

--- a/assets/components/footer/footer.scss
+++ b/assets/components/footer/footer.scss
@@ -15,7 +15,7 @@
 }
 
 .component-footer__content {
-  @include gu-content-margin;
+  @extend .gu-content-margin;
 }
 
 .component-footer__privacy-policy {

--- a/assets/components/footer/footer.scss
+++ b/assets/components/footer/footer.scss
@@ -14,6 +14,10 @@
   }
 }
 
+.component-footer__content {
+  @include gu-content-margin;
+}
+
 .component-footer__privacy-policy {
   text-decoration: none;
   color: gu-colour(neutral-4);

--- a/assets/components/footer/footer.scss
+++ b/assets/components/footer/footer.scss
@@ -5,24 +5,28 @@
   line-height: 16px;
   padding: $gu-v-spacing 0;
 
-  .component-footer__privacy-policy {
-    text-decoration: none;
-    color: gu-colour(neutral-4);
-    padding: 5px 0;
-  }
-
-  .component-footer__privacy-policy:hover {
-    text-decoration: underline;
-  }
-
-  .component-footer__copyright, .component-contrib-legal, .component-footer__privacy-policy-text {
+  .component-contrib-legal {
+    margin-top: $gu-v-spacing;
     font-weight: 400;
     display: block;
     padding: 3px 0;
     color: gu-colour(neutral-4);
   }
+}
 
-  .component-contrib-legal {
-    margin-top: $gu-v-spacing;
+.component-footer__privacy-policy {
+  text-decoration: none;
+  color: gu-colour(neutral-4);
+  padding: 5px 0;
+
+  &:hover {
+    text-decoration: underline;
   }
+}
+
+.component-footer__privacy-policy-text, .component-footer__copyright {
+  font-weight: 400;
+  display: block;
+  padding: 3px 0;
+  color: gu-colour(neutral-4);
 }

--- a/assets/components/headers/countrySwitcherHeader/countrySwitcherHeader.jsx
+++ b/assets/components/headers/countrySwitcherHeader/countrySwitcherHeader.jsx
@@ -19,7 +19,7 @@ export type PropTypes = {
 
 const CountrySwitcherHeader = (props: PropTypes) => (
   <header className="component-country-switcher-header">
-    <div className="component-country-switcher-header__content gu-content-margin">
+    <div className="component-country-switcher-header__content">
       <CountryGroupSwitcher
         countryGroupIds={props.countryGroupIds}
         selectedCountryGroup={props.selectedCountryGroup}

--- a/assets/components/headers/countrySwitcherHeader/countrySwitcherHeader.jsx
+++ b/assets/components/headers/countrySwitcherHeader/countrySwitcherHeader.jsx
@@ -19,7 +19,7 @@ export type PropTypes = {
 
 const CountrySwitcherHeader = (props: PropTypes) => (
   <header className="component-country-switcher-header">
-    <div className="component-country-switcher-header__content gu-header-margin">
+    <div className="component-country-switcher-header__content gu-content-margin">
       <CountryGroupSwitcher
         countryGroupIds={props.countryGroupIds}
         selectedCountryGroup={props.selectedCountryGroup}

--- a/assets/components/headers/countrySwitcherHeader/countrySwitcherHeader.scss
+++ b/assets/components/headers/countrySwitcherHeader/countrySwitcherHeader.scss
@@ -27,6 +27,7 @@
 }
 
 .component-country-switcher-header__content {
+  @include gu-content-margin;
   padding: ($gu-v-spacing / 2) 0 ($gu-v-spacing/2);
   height: 54px;
 

--- a/assets/components/headers/countrySwitcherHeader/countrySwitcherHeader.scss
+++ b/assets/components/headers/countrySwitcherHeader/countrySwitcherHeader.scss
@@ -27,7 +27,7 @@
 }
 
 .component-country-switcher-header__content {
-  @include gu-content-margin;
+  @extend .gu-content-margin;
   padding: ($gu-v-spacing / 2) 0 ($gu-v-spacing/2);
   height: 54px;
 

--- a/assets/components/headers/simpleHeader/simpleHeader.jsx
+++ b/assets/components/headers/simpleHeader/simpleHeader.jsx
@@ -13,7 +13,7 @@ export default function SimpleHeader() {
 
   return (
     <header className="component-simple-header">
-      <div className="component-simple-header__content gu-header-margin">
+      <div className="component-simple-header__content gu-content-margin">
         <a className="component-simple-header__link" href="https://www.theguardian.com">
           <div className="accessibility-hint">The guardian logo</div>
           <SvgGuardianLogo />

--- a/assets/components/headers/simpleHeader/simpleHeader.jsx
+++ b/assets/components/headers/simpleHeader/simpleHeader.jsx
@@ -13,7 +13,7 @@ export default function SimpleHeader() {
 
   return (
     <header className="component-simple-header">
-      <div className="component-simple-header__content gu-content-margin">
+      <div className="component-simple-header__content">
         <a className="component-simple-header__link" href="https://www.theguardian.com">
           <div className="accessibility-hint">The guardian logo</div>
           <SvgGuardianLogo />

--- a/assets/components/headers/simpleHeader/simpleHeader.scss
+++ b/assets/components/headers/simpleHeader/simpleHeader.scss
@@ -14,7 +14,7 @@
 }
 
 .component-simple-header__content {
-  @include gu-content-margin;
+  @extend .gu-content-margin;
   padding: ($gu-v-spacing / 2) 0 $gu-v-spacing;
   height: 68px;
 

--- a/assets/components/headers/simpleHeader/simpleHeader.scss
+++ b/assets/components/headers/simpleHeader/simpleHeader.scss
@@ -14,6 +14,7 @@
 }
 
 .component-simple-header__content {
+  @include gu-content-margin;
   padding: ($gu-v-spacing / 2) 0 $gu-v-spacing;
   height: 68px;
 

--- a/assets/components/infoSection/infoSection.scss
+++ b/assets/components/infoSection/infoSection.scss
@@ -4,7 +4,7 @@
 	border-top: 1px dotted rgba(0,0,0,0.2);
 	padding-bottom: $gu-v-spacing * 3;
 	padding-top: $gu-v-spacing / 2;
-	@include gu-content-margin;
+	@extend .gu-content-margin;
 
 	@include mq($from: desktop) {
 		padding-bottom: $gu-v-spacing * 4;

--- a/assets/components/infoSection/infoSection.scss
+++ b/assets/components/infoSection/infoSection.scss
@@ -4,6 +4,7 @@
 	border-top: 1px dotted rgba(0,0,0,0.2);
 	padding-bottom: $gu-v-spacing * 3;
 	padding-top: $gu-v-spacing / 2;
+	@include gu-content-margin;
 
 	@include mq($from: desktop) {
 		padding-bottom: $gu-v-spacing * 4;

--- a/assets/components/infoSection/infoSection.scss
+++ b/assets/components/infoSection/infoSection.scss
@@ -4,7 +4,6 @@
 	border-top: 1px dotted rgba(0,0,0,0.2);
 	padding-bottom: $gu-v-spacing * 3;
 	padding-top: $gu-v-spacing / 2;
-	@extend .gu-content-margin;
 
 	@include mq($from: desktop) {
 		padding-bottom: $gu-v-spacing * 4;

--- a/assets/components/introduction/circlesIntroduction.jsx
+++ b/assets/components/introduction/circlesIntroduction.jsx
@@ -29,7 +29,7 @@ function CirclesIntroduction(props: PropTypes) {
       <SvgCirclesHeroDesktop />
       <SvgCirclesHeroMobileLandscape />
       <SvgCirclesHeroMobile />
-      <div className={`${classNameWithModifiers('component-circles-introduction__content', props.modifierClasses)} gu-content-margin`}>
+      <div className={classNameWithModifiers('component-circles-introduction__content', props.modifierClasses)}>
         <h1 className={classNameWithModifiers('component-circles-introduction__heading', props.modifierClasses)}>
           {props.headings.map(heading =>
             <span className="component-circles-introduction__heading-line">{heading}</span>)}

--- a/assets/components/introduction/circlesIntroduction.scss
+++ b/assets/components/introduction/circlesIntroduction.scss
@@ -29,7 +29,7 @@
 }
 
 .component-circles-introduction__content {
-  @include gu-content-margin;
+  @extend .gu-content-margin;
   padding-bottom: 100px;
 
   @include mq($from: mobileMedium) {

--- a/assets/components/introduction/circlesIntroduction.scss
+++ b/assets/components/introduction/circlesIntroduction.scss
@@ -29,6 +29,7 @@
 }
 
 .component-circles-introduction__content {
+  @include gu-content-margin;
   padding-bottom: 100px;
 
   @include mq($from: mobileMedium) {

--- a/assets/components/introduction/squaresIntroduction.jsx
+++ b/assets/components/introduction/squaresIntroduction.jsx
@@ -26,7 +26,7 @@ function SquaresIntroduction(props: PropTypes) {
       <SvgSquaresHeroDesktop />
       <SvgSquaresHeroTablet />
       <SvgSquaresHeroMobile />
-      <div className="component-squares-introduction__content gu-content-margin">
+      <div className="component-squares-introduction__content">
         <Highlights highlights={props.highlights} />
         <h1 className="component-squares-introduction__heading">
           {props.headings.map(heading =>

--- a/assets/components/introduction/squaresIntroduction.scss
+++ b/assets/components/introduction/squaresIntroduction.scss
@@ -19,6 +19,7 @@
 }
 
 .component-squares-introduction__content {
+  @include gu-content-margin;
   padding-top: $gu-v-spacing;
   padding-bottom: 220px;
 

--- a/assets/components/introduction/squaresIntroduction.scss
+++ b/assets/components/introduction/squaresIntroduction.scss
@@ -19,7 +19,7 @@
 }
 
 .component-squares-introduction__content {
-  @include gu-content-margin;
+  @extend .gu-content-margin;
   padding-top: $gu-v-spacing;
   padding-bottom: 220px;
 

--- a/assets/components/page/page.jsx
+++ b/assets/components/page/page.jsx
@@ -1,0 +1,39 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React, { type Node } from 'react';
+
+
+// ----- Types ----- //
+
+type PropTypes = {
+  id: ?string,
+  header: Node,
+  footer: Node,
+  children: Node,
+};
+
+
+// ----- Component ----- //
+
+export default function Page(props: PropTypes) {
+
+  return (
+    <div id={props.id} className="gu-content">
+      {props.header}
+      <main role="main" className="gu-content__main">
+        {props.children}
+      </main>
+      {props.footer}
+    </div>
+  );
+
+}
+
+
+// ----- Default Props ----- //
+
+Page.defaultProps = {
+  id: null,
+};

--- a/assets/components/pageSection/pageSection.jsx
+++ b/assets/components/pageSection/pageSection.jsx
@@ -25,7 +25,7 @@ function PageSection(props: PropTypes) {
 
   return (
     <section className={classNameWithModifiers('component-page-section', [props.modifierClass])}>
-      <div className="component-page-section__content gu-content-margin">
+      <div className="component-page-section__content">
         <div className="component-page-section__header">
           <Heading heading={props.heading} />
           {props.headingChildren}

--- a/assets/components/pageSection/pageSection.scss
+++ b/assets/components/pageSection/pageSection.scss
@@ -6,6 +6,10 @@
   }
 }
 
+.component-page-section__content {
+  @include gu-content-margin;
+}
+
 .component-page-section__body {
   box-sizing: border-box;
 

--- a/assets/components/pageSection/pageSection.scss
+++ b/assets/components/pageSection/pageSection.scss
@@ -7,7 +7,7 @@
 }
 
 .component-page-section__content {
-  @include gu-content-margin;
+  @extend .gu-content-margin;
 }
 
 .component-page-section__body {

--- a/assets/components/readyToSupport/readyToSupport.jsx
+++ b/assets/components/readyToSupport/readyToSupport.jsx
@@ -21,7 +21,7 @@ export default function ReadyToSupport(props: PropTypes) {
 
   return (
     <section className="component-ready-to-support">
-      <div className="component-ready-to-support__content gu-content-margin">
+      <div className="component-ready-to-support__content">
         <h1 className="component-ready-to-support__heading">
           <span className="component-ready-to-support__heading-line">Ready to support</span>
           <span className="component-ready-to-support__heading-line">The&nbsp;Guardian?</span>

--- a/assets/components/readyToSupport/readyToSupport.scss
+++ b/assets/components/readyToSupport/readyToSupport.scss
@@ -3,6 +3,7 @@
 }
 
 .component-ready-to-support__content {
+  @include gu-content-margin;
   padding-bottom: $gu-v-spacing * 4;
   position: relative;
 

--- a/assets/components/readyToSupport/readyToSupport.scss
+++ b/assets/components/readyToSupport/readyToSupport.scss
@@ -3,7 +3,7 @@
 }
 
 .component-ready-to-support__content {
-  @include gu-content-margin;
+  @extend .gu-content-margin;
   padding-bottom: $gu-v-spacing * 4;
   position: relative;
 

--- a/assets/containerisableComponents/contributionsThankYou/contributionsThankYouPage.jsx
+++ b/assets/containerisableComponents/contributionsThankYou/contributionsThankYouPage.jsx
@@ -4,6 +4,7 @@
 
 import React from 'react';
 
+import Page from 'components/page/page';
 import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
 import Footer from 'components/footer/footer';
 import CirclesIntroduction from 'components/introduction/circlesIntroduction';
@@ -28,8 +29,11 @@ type PropTypes = {
 
 export default function ContributionsThankYouPage(props: PropTypes) {
   return (
-    <div id="contributions-thank-you-page" className="gu-content">
-      <SimpleHeader />
+    <Page
+      id="contributions-thank-you-page"
+      header={<SimpleHeader />}
+      footer={<Footer />}
+    >
       <CirclesIntroduction
         headings={['Thank you', 'for a valuable', 'contribution']}
         modifierClasses={['compact']}
@@ -39,8 +43,7 @@ export default function ContributionsThankYouPage(props: PropTypes) {
       <MarketingConsentContainer />
       <QuestionsContact />
       <SpreadTheWord />
-      <Footer />
-    </div>
+    </Page>
   );
 }
 

--- a/assets/containerisableComponents/contributionsThankYou/contributionsThankYouPage.scss
+++ b/assets/containerisableComponents/contributionsThankYou/contributionsThankYouPage.scss
@@ -34,10 +34,6 @@
     padding-top: 4px;
   }
 
-  .component-spread-the-word {
-    @include gu-content-filler;
-  }
-
   .component-direct-debit-confirmation__item-name {
     @include mq($from: desktop) {
       padding-left: $gu-h-spacing;

--- a/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/assets/pages/contributions-landing/contributionsLanding.scss
@@ -38,10 +38,6 @@
 #contributions-landing-page-us,
 #contributions-landing-page-au {
 
-  .component-contribute {
-    @include gu-content-filler;
-  }
-
   .component-paypal-contribution-button {
     margin-top: $gu-v-spacing;
   }

--- a/assets/pages/contributions-landing/pagesVersions/horizontalLayoutLandingPage.jsx
+++ b/assets/pages/contributions-landing/pagesVersions/horizontalLayoutLandingPage.jsx
@@ -3,12 +3,11 @@
 // ----- Imports ----- //
 
 import * as React from 'react';
-
 import { Provider } from 'react-redux';
 import type { Store } from 'redux';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
-
+import Page from 'components/page/page';
 import CirclesIntroduction from 'components/introduction/circlesIntroduction';
 import Footer from 'components/footer/footer';
 import Contribute from 'components/contribute/contribute';
@@ -81,8 +80,10 @@ const CountrySwitcherHeader = CountrySwitcherHeaderContainer(
 
 const HorizontalLayoutLandingPage: (PropTypes) => React.Node = (props: PropTypes) => (
   <Provider store={props.store}>
-    <div className="gu-content">
-      <CountrySwitcherHeader />
+    <Page
+      header={<CountrySwitcherHeader />}
+      footer={<Footer disclaimer />}
+    >
       <CirclesIntroduction
         headings={countryGroupSpecificDetails[props.countryGroupId].headerCopy}
         highlights={['Your contribution']}
@@ -98,8 +99,7 @@ const HorizontalLayoutLandingPage: (PropTypes) => React.Node = (props: PropTypes
           PayPalButton={PayPalContributionButtonContainer}
         />
       </Contribute>
-      <Footer disclaimer />
-    </div>
+    </Page>
   </Provider>
 );
 

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -9,6 +9,7 @@ import { renderPage } from 'helpers/render';
 import { detect, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { init as pageInit } from 'helpers/page/page';
 
+import Page from 'components/page/page';
 import countrySwitcherHeaderContainer from 'components/headers/countrySwitcherHeader/countrySwitcherHeaderContainer';
 import CustomerService from 'components/customerService/customerService';
 import Footer from 'components/footer/footer';
@@ -44,15 +45,16 @@ const CountrySwitcherHeader = countrySwitcherHeaderContainer(
 
 const content = (
   <Provider store={store}>
-    <div>
-      <CountrySwitcherHeader />
+    <Page
+      header={<CountrySwitcherHeader />}
+      footer={<Footer><CustomerService selectedCountryGroup={countryGroupId} /></Footer>}
+    >
       <DigitalSubscriptionLandingHeader />
       <ProductBlock />
       <LeftMarginSection modifierClasses={['grey']}>
         <IndependentJournalismSection />
       </LeftMarginSection>
-      <Footer><CustomerService selectedCountryGroup={countryGroupId} /></Footer>
-    </div>
+    </Page>
   </Provider>
 );
 

--- a/assets/pages/error/components/errorPage.jsx
+++ b/assets/pages/error/components/errorPage.jsx
@@ -4,6 +4,7 @@
 
 import React from 'react';
 
+import Page from 'components/page/page';
 import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
 import Footer from 'components/footer/footer';
 import SquaresIntroduction from 'components/introduction/squaresIntroduction';
@@ -27,8 +28,10 @@ type PropTypes = {
 export default function ErrorPage(props: PropTypes) {
 
   return (
-    <div className="component-error-content gu-content">
-      <SimpleHeader />
+    <Page
+      header={<SimpleHeader />}
+      footer={<Footer />}
+    >
       <SquaresIntroduction
         headings={props.headings}
         highlights={[`Error ${props.errorCode}`]}
@@ -51,8 +54,7 @@ export default function ErrorPage(props: PropTypes) {
           modifierClasses={['guardian-home-page', 'border']}
         />
       </PageSection>
-      <Footer />
-    </div>
+    </Page>
   );
 
 }

--- a/assets/pages/error/error.scss
+++ b/assets/pages/error/error.scss
@@ -20,8 +20,6 @@
   .component-page-section--ctas {
     @include multiline-top-border;
 
-    @include gu-content-filler;
-
     .component-page-section__header {
       @include dropline;
     }

--- a/assets/pages/oneoff-contributions/components/oneOffContributionsPage.jsx
+++ b/assets/pages/oneoff-contributions/components/oneOffContributionsPage.jsx
@@ -5,6 +5,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
+import Page from 'components/page/page';
 import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
 import Footer from 'components/footer/footer';
 import InfoSection from 'components/infoSection/infoSection';
@@ -52,9 +53,10 @@ function OneOffContributionsPage(props: PropTypes) {
   const Payment = props.inlineCardPaymentVariant === 'inline' ? OneoffInlineContributionsPayment : OneoffContributionsPayment;
 
   return (
-    <div className="gu-content">
-      <TestUserBanner />
-      <SimpleHeader />
+    <Page
+      header={[<TestUserBanner />, <SimpleHeader />]}
+      footer={<Footer />}
+    >
       <CirclesIntroduction headings={[`Make a ${contribDescription}`, 'contribution']} modifierClasses={['compact']} />
       <hr className="oneoff-contrib__multiline" />
       <div className="oneoff-contrib">
@@ -79,8 +81,7 @@ function OneOffContributionsPage(props: PropTypes) {
           <ContribLegal />
         </InfoSection>
       </div>
-      <Footer />
-    </div>
+    </Page>
   );
 }
 

--- a/assets/pages/oneoff-contributions/components/oneOffContributionsPage.jsx
+++ b/assets/pages/oneoff-contributions/components/oneOffContributionsPage.jsx
@@ -57,7 +57,7 @@ function OneOffContributionsPage(props: PropTypes) {
       <SimpleHeader />
       <CirclesIntroduction headings={[`Make a ${contribDescription}`, 'contribution']} modifierClasses={['compact']} />
       <hr className="oneoff-contrib__multiline" />
-      <div className="oneoff-contrib gu-content-margin">
+      <div className="oneoff-contrib">
         <InfoSection heading={`Your ${contribDescription} contribution`} className="oneoff-contrib__your-contrib">
           <PaymentAmount
             amount={props.amount}

--- a/assets/pages/oneoff-contributions/components/oneOffContributionsPage.jsx
+++ b/assets/pages/oneoff-contributions/components/oneOffContributionsPage.jsx
@@ -73,8 +73,8 @@ function OneOffContributionsPage(props: PropTypes) {
           <Payment />
         </InfoSection>
       </div>
-      <div className="terms-privacy gu-content-filler">
-        <InfoSection className="terms-privacy__content gu-content-filler__inner">
+      <div className="terms-privacy">
+        <InfoSection className="terms-privacy__content">
           <TermsPrivacy country={props.country} />
           <ContribLegal />
         </InfoSection>

--- a/assets/pages/oneoff-contributions/oneoffContributions.scss
+++ b/assets/pages/oneoff-contributions/oneoffContributions.scss
@@ -224,6 +224,8 @@
 	// ----- Legal ----- //
 
 	.terms-privacy {
+		@include gu-content-filler;
+
 		.component-info-section__content {
 			@include mq($from: desktop) {
 				width: 550px;
@@ -232,6 +234,8 @@
 	}
 
 	.terms-privacy__content {
+		@extend .gu-content-margin;
+    flex: 1 0 auto;
 		background-color: #fff;
 		color: gu-colour(media-garnett-main-1);
 	}

--- a/assets/pages/oneoff-contributions/oneoffContributions.scss
+++ b/assets/pages/oneoff-contributions/oneoffContributions.scss
@@ -121,6 +121,10 @@
 
 	// ----- Your contrib
 
+	.oneoff-contrib {
+		@extend .gu-content-margin;
+	}
+
 	.oneoff-contrib__your-contrib {
 		border: none;
 

--- a/assets/pages/oneoff-contributions/oneoffContributions.scss
+++ b/assets/pages/oneoff-contributions/oneoffContributions.scss
@@ -232,7 +232,7 @@
 	}
 
 	.terms-privacy__content {
-		@include gu-content-margin;
+		@extend .gu-content-margin;
     flex: 1 0 auto;
 		background-color: #fff;
 		color: gu-colour(media-garnett-main-1);

--- a/assets/pages/oneoff-contributions/oneoffContributions.scss
+++ b/assets/pages/oneoff-contributions/oneoffContributions.scss
@@ -224,8 +224,6 @@
 	// ----- Legal ----- //
 
 	.terms-privacy {
-		@include gu-content-filler;
-
 		.component-info-section__content {
 			@include mq($from: desktop) {
 				width: 550px;

--- a/assets/pages/oneoff-contributions/oneoffContributions.scss
+++ b/assets/pages/oneoff-contributions/oneoffContributions.scss
@@ -237,7 +237,6 @@
 
 	.terms-privacy__content {
 		@extend .gu-content-margin;
-    flex: 1 0 auto;
 		background-color: #fff;
 		color: gu-colour(media-garnett-main-1);
 	}

--- a/assets/pages/oneoff-contributions/oneoffContributions.scss
+++ b/assets/pages/oneoff-contributions/oneoffContributions.scss
@@ -234,7 +234,7 @@
 	}
 
 	.terms-privacy__content {
-		@extend .gu-content-margin;
+		@include gu-content-margin;
     flex: 1 0 auto;
 		background-color: #fff;
 		color: gu-colour(media-garnett-main-1);

--- a/assets/pages/paypal-error/payPalError.jsx
+++ b/assets/pages/paypal-error/payPalError.jsx
@@ -4,6 +4,7 @@
 
 import React from 'react';
 
+import Page from 'components/page/page';
 import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
 import Footer from 'components/footer/footer';
 import CtaLink from 'components/ctaLink/ctaLink';
@@ -23,25 +24,28 @@ pageInit();
 // ----- Render ----- //
 
 const content = (
-  <div className="paypal-error gu-content">
-    <SimpleHeader />
-    <PageSection
-      modifierClass="paypal-error"
-    >
-      <h1 className="paypal-error__heading">PayPal Error!</h1>
-      <p className="paypal-error__copy">
-        Sorry, there was a problem completing your PayPal payment. Please try again:
-      </p>
-      <CtaLink
-        text="Become a Supporter"
-        url="/"
-        accessibilityHint="Restart your journey to become a guardian supporter"
-      />
-    </PageSection>
-    <QuestionsContact />
-    <SpreadTheWord />
-    <Footer />
-  </div>
+  <Page
+    header={<SimpleHeader />}
+    footer={<Footer />}
+  >
+    <div className="paypal-error">
+      <PageSection
+        modifierClass="paypal-error"
+      >
+        <h1 className="paypal-error__heading">PayPal Error!</h1>
+        <p className="paypal-error__copy">
+          Sorry, there was a problem completing your PayPal payment. Please try again:
+        </p>
+        <CtaLink
+          text="Become a Supporter"
+          url="/"
+          accessibilityHint="Restart your journey to become a guardian supporter"
+        />
+      </PageSection>
+      <QuestionsContact />
+      <SpreadTheWord />
+    </div>
+  </Page>
 );
 
 renderPage(content, 'paypal-error-page');

--- a/assets/pages/paypal-error/payPalError.scss
+++ b/assets/pages/paypal-error/payPalError.scss
@@ -70,8 +70,4 @@
       background-color: darken(gu-colour(news-garnett-highlight), 5%);
     }
   }
-
-  .component-spread-the-word {
-    @include gu-content-filler;
-  }
 }

--- a/assets/pages/regular-contributions-existing/regularContributionsExisting.jsx
+++ b/assets/pages/regular-contributions-existing/regularContributionsExisting.jsx
@@ -4,6 +4,7 @@
 
 import React from 'react';
 
+import Page from 'components/page/page';
 import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
 import Footer from 'components/footer/footer';
 import CtaLink from 'components/ctaLink/ctaLink';
@@ -30,8 +31,10 @@ pageInit();
 // ----- Render ----- //
 
 const content = (
-  <div className="gu-content">
-    <SimpleHeader />
+  <Page
+    header={<SimpleHeader />}
+    footer={<Footer />}
+  >
     <CirclesIntroduction
       headings={['Whoops!']}
       modifierClasses={['compact']}
@@ -52,8 +55,7 @@ const content = (
       />
     </PageSection>
     <QuestionsContact />
-    <Footer />
-  </div>
+  </Page>
 );
 
 renderPage(content, 'regular-contributions-existing-page');

--- a/assets/pages/regular-contributions-existing/regularContributionsExisting.scss
+++ b/assets/pages/regular-contributions-existing/regularContributionsExisting.scss
@@ -49,10 +49,6 @@
     }
   }
 
-  .component-questions-contact {
-    @include gu-content-filler;
-  }
-
   .component-cta-link--manage-contribution {
     margin-bottom: $gu-v-spacing * 3;
     margin-top: $gu-v-spacing * 2;

--- a/assets/pages/regular-contributions/components/regularContributionsPage.jsx
+++ b/assets/pages/regular-contributions/components/regularContributionsPage.jsx
@@ -85,8 +85,8 @@ function RegularContributionsPage(props: PropTypes) {
           {contributionsPayment}
         </InfoSection>
       </div>
-      <div className="terms-privacy gu-content-filler">
-        <InfoSection className="terms-privacy__content gu-content-filler__inner">
+      <div className="terms-privacy">
+        <InfoSection className="terms-privacy__content">
           <TermsPrivacy country={props.country} />
           <ContribLegal />
         </InfoSection>

--- a/assets/pages/regular-contributions/components/regularContributionsPage.jsx
+++ b/assets/pages/regular-contributions/components/regularContributionsPage.jsx
@@ -27,7 +27,6 @@ import RegularContributionsPayment from './regularContributionsPayment';
 import RegularInlineContributionsPayment from './regularInlineContributionsPayment';
 
 
-
 // ----- Types ----- //
 
 type PropTypes = {

--- a/assets/pages/regular-contributions/components/regularContributionsPage.jsx
+++ b/assets/pages/regular-contributions/components/regularContributionsPage.jsx
@@ -5,6 +5,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
+import Page from 'components/page/page';
 import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
 import Footer from 'components/footer/footer';
 import InfoSection from 'components/infoSection/infoSection';
@@ -26,6 +27,7 @@ import RegularContributionsPayment from './regularContributionsPayment';
 import RegularInlineContributionsPayment from './regularInlineContributionsPayment';
 
 
+
 // ----- Types ----- //
 
 type PropTypes = {
@@ -35,6 +37,7 @@ type PropTypes = {
   country: IsoCountry,
   inlineCardPaymentVariant: 'notintest' | 'control' | 'inline',
 };
+
 
 // ----- Map State/Props ----- //
 
@@ -49,12 +52,14 @@ function mapStateToProps(state) {
   };
 }
 
+
 // ----- Page Startup ----- //
 
 const title = {
   annual: ['Make an annual', 'contribution'],
   monthly: ['Make a monthly', 'contribution'],
 };
+
 
 // ----- Render ----- //
 
@@ -64,9 +69,10 @@ function RegularContributionsPage(props: PropTypes) {
   const contributionsPayment = props.inlineCardPaymentVariant === 'inline' ? <RegularInlineContributionsPayment contributionType={props.contributionType} /> : <RegularContributionsPayment contributionType={props.contributionType} />;
 
   return (
-    <div className="gu-content">
-      <TestUserBanner />
-      <SimpleHeader />
+    <Page
+      header={[<TestUserBanner />, <SimpleHeader />]}
+      footer={<Footer />}
+    >
       <CirclesIntroduction headings={title[props.contributionType.toLowerCase()]} modifierClasses={['compact']} />
       <hr className="regular-contrib__multiline" />
       <div className="regular-contrib">
@@ -91,10 +97,10 @@ function RegularContributionsPage(props: PropTypes) {
           <ContribLegal />
         </InfoSection>
       </div>
-      <Footer />
-    </div>
+    </Page>
   );
 }
+
 
 // ----- Exports ----- //
 

--- a/assets/pages/regular-contributions/components/regularContributionsPage.jsx
+++ b/assets/pages/regular-contributions/components/regularContributionsPage.jsx
@@ -69,7 +69,7 @@ function RegularContributionsPage(props: PropTypes) {
       <SimpleHeader />
       <CirclesIntroduction headings={title[props.contributionType.toLowerCase()]} modifierClasses={['compact']} />
       <hr className="regular-contrib__multiline" />
-      <div className="regular-contrib gu-content-margin">
+      <div className="regular-contrib">
         <InfoSection heading={`Your ${props.contributionType.toLowerCase()} contribution`} className="regular-contrib__your-contrib">
           <PaymentAmount
             amount={props.amount}

--- a/assets/pages/regular-contributions/regularContributions.scss
+++ b/assets/pages/regular-contributions/regularContributions.scss
@@ -255,8 +255,6 @@
 	// ----- Legal ----- //
 
 	.terms-privacy {
-		@include gu-content-filler;
-
 		.component-info-section__content {
 			@include mq($from: desktop) {
 				width: 550px;

--- a/assets/pages/regular-contributions/regularContributions.scss
+++ b/assets/pages/regular-contributions/regularContributions.scss
@@ -263,7 +263,7 @@
 	}
 
 	.terms-privacy__content {
-		@include gu-content-margin;
+		@extend .gu-content-margin;
     flex: 1 0 auto;
 		background-color: #fff;
 		color: gu-colour(media-garnett-main-1);

--- a/assets/pages/regular-contributions/regularContributions.scss
+++ b/assets/pages/regular-contributions/regularContributions.scss
@@ -265,7 +265,7 @@
 	}
 
 	.terms-privacy__content {
-		@extend .gu-content-margin;
+		@include gu-content-margin;
     flex: 1 0 auto;
 		background-color: #fff;
 		color: gu-colour(media-garnett-main-1);

--- a/assets/pages/regular-contributions/regularContributions.scss
+++ b/assets/pages/regular-contributions/regularContributions.scss
@@ -114,6 +114,10 @@
 
 	// ----- Your contrib
 
+	.regular-contrib {
+		@extend .gu-content-margin;
+	}
+
 	.regular-contrib__your-contrib {
 		border: none;
 

--- a/assets/pages/regular-contributions/regularContributions.scss
+++ b/assets/pages/regular-contributions/regularContributions.scss
@@ -264,7 +264,6 @@
 
 	.terms-privacy__content {
 		@extend .gu-content-margin;
-    flex: 1 0 auto;
 		background-color: #fff;
 		color: gu-colour(media-garnett-main-1);
 	}

--- a/assets/pages/regular-contributions/regularContributions.scss
+++ b/assets/pages/regular-contributions/regularContributions.scss
@@ -255,6 +255,8 @@
 	// ----- Legal ----- //
 
 	.terms-privacy {
+		@include gu-content-filler;
+
 		.component-info-section__content {
 			@include mq($from: desktop) {
 				width: 550px;
@@ -263,6 +265,8 @@
 	}
 
 	.terms-privacy__content {
+		@extend .gu-content-margin;
+    flex: 1 0 auto;
 		background-color: #fff;
 		color: gu-colour(media-garnett-main-1);
 	}

--- a/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
+++ b/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 
 // React components
+import Page from 'components/page/page';
 import Footer from 'components/footer/footer';
 import CirclesIntroduction from 'components/introduction/circlesIntroduction';
 import WhySupport from 'components/whySupport/whySupport';
@@ -34,8 +35,10 @@ const store = pageInit();
 
 const content = (
   <Provider store={store}>
-    <div>
-      <SimpleHeader />
+    <Page
+      header={<SimpleHeader />}
+      footer={<Footer disclaimer privacyPolicy />}
+    >
       <CirclesIntroduction
         headings={['Help us deliver', 'the independent', 'journalism the', 'world needs']}
         highlights={['Support', 'The Guardian']}
@@ -47,8 +50,7 @@ const content = (
       <WhySupport />
       <ReadyToSupport ctaUrl={`#${supporterSectionId}`} />
       <PatronsEventsContainer />
-      <Footer disclaimer privacyPolicy />
-    </div>
+    </Page>
   </Provider>
 );
 

--- a/assets/pages/support-landing/supportLanding.jsx
+++ b/assets/pages/support-landing/supportLanding.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 
 // React components
+import Page from 'components/page/page';
 import Footer from 'components/footer/footer';
 import CirclesIntroduction from 'components/introduction/circlesIntroduction';
 import WhySupport from 'components/whySupport/whySupport';
@@ -27,6 +28,7 @@ import ContributionSelectionContainer from './components/contributionSelectionCo
 import ContributionPaymentCtasContainer from './components/contributionPaymentCtasContainer';
 import PayPalContributionButtonContainer from './components/payPalContributionButtonContainer';
 import ContributionAwarePaymentLogosContainer from './components/contributionAwarePaymentLogosContainer';
+
 
 // ----- Setup ----- //
 
@@ -50,8 +52,10 @@ const CountrySwitcherHeader = CountrySwitcherHeaderContainer(
 
 const content = (
   <Provider store={store}>
-    <div>
-      <CountrySwitcherHeader />
+    <Page
+      header={<CountrySwitcherHeader />}
+      footer={<Footer disclaimer privacyPolicy />}
+    >
       <CirclesIntroduction
         headings={['Help us deliver the', 'independent journalism', 'the world needs']}
         highlights={['Support The Guardian']}
@@ -73,8 +77,7 @@ const content = (
       <WhySupport />
       <ReadyToSupport ctaUrl={`#${supporterSectionId}`} />
       <PatronsEventsContainer />
-      <Footer disclaimer privacyPolicy />
-    </div>
+    </Page>
   </Provider>
 );
 

--- a/assets/stylesheets/fallback-pages/unsupportedBrowser.scss
+++ b/assets/stylesheets/fallback-pages/unsupportedBrowser.scss
@@ -21,7 +21,7 @@
 }
 
 .unsupported-browser__header-content {
-  @include gu-content-margin;
+  @extend .gu-content-margin;
   padding: ($gu-v-spacing / 2) 0 $gu-v-spacing;
   height: 68px;
 
@@ -46,7 +46,7 @@
 }
 
 .unsupported-browser__introduction-text {
-  @include gu-content-margin;
+  @extend .gu-content-margin;
   background-color: #e9e939;
   padding-top: 5px;
   padding-bottom: 5px;
@@ -59,7 +59,7 @@
 }
 
 .unsupported-browser__why-support-content {
-  @include gu-content-margin;
+  @extend .gu-content-margin;
 }
 
 .unsupported-browser__why-support-heading {
@@ -91,7 +91,7 @@
 }
 
 .unsupported-browser__footer-content {
-  @include gu-content-margin;
+  @extend .gu-content-margin;
 }
 
 .unsupported-browser__footer-privacy-policy {

--- a/assets/stylesheets/fallback-pages/unsupportedBrowser.scss
+++ b/assets/stylesheets/fallback-pages/unsupportedBrowser.scss
@@ -21,6 +21,7 @@
 }
 
 .unsupported-browser__header-content {
+  @include gu-content-margin;
   padding: ($gu-v-spacing / 2) 0 $gu-v-spacing;
   height: 68px;
 
@@ -45,6 +46,7 @@
 }
 
 .unsupported-browser__introduction-text {
+  @include gu-content-margin;
   background-color: #e9e939;
   padding-top: 5px;
   padding-bottom: 5px;
@@ -54,6 +56,10 @@
 
 .unsupported-browser__why-support {
   padding-bottom: $gu-v-spacing * 2;
+}
+
+.unsupported-browser__why-support-content {
+  @include gu-content-margin;
 }
 
 .unsupported-browser__why-support-heading {
@@ -82,6 +88,10 @@
   font-size: 12px;
   line-height: 16px;
   padding: $gu-v-spacing 0;
+}
+
+.unsupported-browser__footer-content {
+  @include gu-content-margin;
 }
 
 .unsupported-browser__footer-privacy-policy {

--- a/assets/stylesheets/fallback-pages/unsupportedBrowser.scss
+++ b/assets/stylesheets/fallback-pages/unsupportedBrowser.scss
@@ -53,7 +53,6 @@
 }
 
 .unsupported-browser__why-support {
-  @include gu-content-filler;
   padding-bottom: $gu-v-spacing * 2;
 }
 

--- a/assets/stylesheets/gu-sass/layout.scss
+++ b/assets/stylesheets/gu-sass/layout.scss
@@ -59,7 +59,7 @@ $cta-height: 44px;
   }
 }
 
-@mixin gu-content-filler {
+.gu-content__main {
   @supports (display: flex) {
     flex: 1 0 auto;
   }

--- a/assets/stylesheets/gu-sass/layout.scss
+++ b/assets/stylesheets/gu-sass/layout.scss
@@ -17,7 +17,7 @@ $cta-height: 44px;
 // =============================================================================
 
 // Standard sizes and margins for the content and headers.
-.gu-content-margin {
+@mixin gu-content-margin {
   box-sizing: border-box;
   padding: 0 ($gu-h-spacing / 2);
 

--- a/assets/stylesheets/gu-sass/layout.scss
+++ b/assets/stylesheets/gu-sass/layout.scss
@@ -17,7 +17,7 @@ $cta-height: 44px;
 // =============================================================================
 
 // Standard sizes and margins for the content and headers.
-@mixin gu-content-margin {
+.gu-content-margin {
   box-sizing: border-box;
   padding: 0 ($gu-h-spacing / 2);
 

--- a/assets/stylesheets/gu-sass/layout.scss
+++ b/assets/stylesheets/gu-sass/layout.scss
@@ -17,21 +17,25 @@ $cta-height: 44px;
 // =============================================================================
 
 // Standard sizes and margins for the content and headers.
-.gu-content-margin, .gu-header-margin {
+.gu-content-margin {
   box-sizing: border-box;
+  padding: 0 ($gu-h-spacing / 2);
 
   @include mq($from: mobileLandscape) {
     width: gu-breakpoint(mobileLandscape);
     margin: 0 auto;
+    padding: 0 $gu-h-spacing;
   }
 
   @include mq($from: phablet) {
     width: gu-breakpoint(phablet);
     margin: 0 auto;
+    padding: 0 auto;
   }
 
   @include mq($from: tablet) {
     width: gu-breakpoint(tablet);
+    padding: 0 $gu-h-spacing;
   }
 
   @include mq($from: desktop) {
@@ -47,53 +51,16 @@ $cta-height: 44px;
   }
 }
 
-// The paddings at different breakpoints for the content.
-.gu-content-margin {
-  padding: 0 ($gu-h-spacing / 2);
-
-  @include mq($from: mobileLandscape) {
-    padding: 0 $gu-h-spacing;
-  }
-
-  @include mq($from: phablet) {
-    padding: 0 auto;
-  }
-
-  @include mq($from: tablet) {
-    padding: 0 $gu-h-spacing;
-  }
-}
-
-.gu-content-wrapper {
-
-  .gu-content {
-    @supports (display: flex) {
-      display: flex;
-      flex-direction: column;
-      min-height: 100vh;
-
-      header, footer {
-        flex: 0 0 auto;
-      }
-
-      .gu-content-filler {
-        flex: 1 0 auto;
-        flex-direction: column;
-        display: flex;
-      }
-
-      .gu-content-filler__inner {
-        @extend .gu-content-margin;
-        flex: 1 0 auto;
-      }
-    }
+.gu-content {
+  @supports (display: flex) {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
   }
 }
 
 @mixin gu-content-filler {
   @supports (display: flex) {
     flex: 1 0 auto;
-    flex-direction: column;
-    display: flex;
   }
 }


### PR DESCRIPTION
## Why are you doing this?

We currently have a `<main>` element into which we inject all of our React-rendered content. That results in a DOM that looks something like this:

```html
<main>
  <header></header>
  <section></section>
  <footer></footer>
</main>
```

This is not how the `<main>` element is meant to be used, as `<header>` and `<footer>` should not appear inside it. This is bad both for navigation using assistive technologies (e.g. screen readers), and for the semantics of the page in general. This PR updates the layout of the page, so that the DOM now looks something like this:

```html
<header></header>
<main>
  <section></section>
</main>
<footer></footer>
```

It also simplifies much of the layout CSS we were using to create margins and push the footer down on shorter pages. This is all largely done by introducing a new `<Page>` component, which contains the `<main>` element and applies the flexbox styles used to ensure the page is the correct height (no more `gu-content-filler`!).

[**Trello Card**](https://trello.com/c/hXGzwY4c/1490-stop-putting-everything-in-main)

cc @JustinPinner 

## Changes

- Updated the React injection element to be a `<div>` instead of `<main>`.
- Removed `gu-content-wrapper` (it wasn't doing anything any more).
- Tweaked the unsupported browser page to pick up the new style changes.
- Flattened the footer CSS.
- Stopped using `.gu-content-margin` as an additional class and accessed it via `@extend` instead; this adheres more closely to the principles of BEM.
- Added a new `Page` component to handle layout via `.gu-content` and `.gu-content__main`, and put `<header>`s, `<footer>`s and `<main>` in the correct places.
- Applied the new `Page` component to all pages.
- Simplified the layout CSS.

## Screenshots

Everything should look the same!
