### PR TITLE
Specify a height on the header image container to prevent page jump

### DIFF
--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -240,6 +240,18 @@
     display: block;
   }
 
+  .digital-subscription-landing-header__picture {
+    @include mq($until: tablet) {
+      height: 351px
+    }
+    @include mq($from: tablet) {
+      height: 332px;
+    }
+    @include mq($from: leftCol) {
+      height: 389px;
+    }
+  }
+
   .digital-subscription-landing-header__title {
     position: relative;
     width: 100%;


### PR DESCRIPTION
## Why are you doing this?
On a slow connection the digital subscription landing page jumps severely when images are loaded into the header. If we specify a height of the container element upfront, we can prevent that jump from happening.

[Trello card](https://trello.com/c/Sg1o3Kfo/1738-prevent-digital-subs-landing-page-jump-when-loading-header-images)