### PR TITLE
Fix a typo in a prop name that I managed to sneak past the type checker

### DIFF
--- a/assets/components/gridPicture/gridPicture.jsx
+++ b/assets/components/gridPicture/gridPicture.jsx
@@ -28,7 +28,7 @@ type Source = {
 
 /* eslint-enable react/no-unused-prop-types */
 
-type PropTypes = {
+export type PropTypes = {
   sources: Source[],
   fallback: string,
   fallbackSize: number,

--- a/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
+++ b/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
@@ -40,7 +40,7 @@ const gridPicture = {
   fallback: 'digitalSubscriptionHeaderDesktop',
   fallbackSize: 500,
   altText: 'digital subscription',
-  fallbackImageType: 'png',
+  fallbackImgType: 'png',
 };
 
 export default function DigitalSubscriptionLandingHeader() {

--- a/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
+++ b/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
@@ -4,7 +4,7 @@
 import React from 'react';
 
 import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
-import GridPicture from 'components/gridPicture/gridPicture';
+import GridPicture, { type PropTypes as GridPictureProps } from 'components/gridPicture/gridPicture';
 import { CirclesLeft, CirclesRight } from 'components/svgs/digitalSubscriptionLandingHeaderCircles';
 import PriceCtaContainer from './priceCtaContainer';
 
@@ -35,7 +35,7 @@ const pictureSources = [
   },
 ];
 
-const gridPicture = {
+const gridPicture: GridPictureProps = {
   sources: pictureSources,
   fallback: 'digitalSubscriptionHeaderDesktop',
   fallbackSize: 500,


### PR DESCRIPTION
## Why are you doing this?
We're seeing 404s when requesting the fallback image for the digi subs landing page header. That's because I somehow got a bad property name past the type checker. This fixes it.

Introduced in https://github.com/guardian/support-frontend/pull/719

[**Trello Card**](https://trello.com/c/ZJeu2J1a/1741-fix-incorrect-property-name-for-fallback-image-in-digital-subscription-landing-page)

