### PR TITLE
Make heading font size consistent across pages

### DIFF
--- a/assets/containerisableComponents/contributionsThankYou/contributionsThankYouPage.jsx
+++ b/assets/containerisableComponents/contributionsThankYou/contributionsThankYouPage.jsx
@@ -32,6 +32,7 @@ export default function ContributionsThankYouPage(props: PropTypes) {
       <SimpleHeader />
       <CirclesIntroduction
         headings={['Thank you', 'for a valuable', 'contribution']}
+        modifierClasses={['compact']}
       />
       <div className="multiline-divider" />
       <BodyCopy {...props} />

--- a/assets/pages/oneoff-contributions/components/oneOffContributionsPage.jsx
+++ b/assets/pages/oneoff-contributions/components/oneOffContributionsPage.jsx
@@ -48,7 +48,7 @@ function OneOffContributionsPage(props: PropTypes) {
     <div className="gu-content">
       <TestUserBanner />
       <SimpleHeader />
-      <CirclesIntroduction headings={[`Make a ${contribDescription}`, 'contribution']} />
+      <CirclesIntroduction headings={[`Make a ${contribDescription}`, 'contribution']} modifierClasses={['compact']} />
       <hr className="oneoff-contrib__multiline" />
       <div className="oneoff-contrib gu-content-margin">
         <InfoSection heading={`Your ${contribDescription} contribution`} className="oneoff-contrib__your-contrib">

--- a/assets/pages/regular-contributions-existing/regularContributionsExisting.jsx
+++ b/assets/pages/regular-contributions-existing/regularContributionsExisting.jsx
@@ -34,6 +34,7 @@ const content = (
     <SimpleHeader />
     <CirclesIntroduction
       headings={['Whoops!']}
+      modifierClasses={['compact']}
     />
     <PageSection modifierClass="existing-contribution">
       <p className="existing-contribition-copy">

--- a/assets/pages/regular-contributions/components/regularContributionsPage.jsx
+++ b/assets/pages/regular-contributions/components/regularContributionsPage.jsx
@@ -67,7 +67,7 @@ function RegularContributionsPage(props: PropTypes) {
     <div className="gu-content">
       <TestUserBanner />
       <SimpleHeader />
-      <CirclesIntroduction headings={title[props.contributionType.toLowerCase()]} />
+      <CirclesIntroduction headings={title[props.contributionType.toLowerCase()]} modifierClasses={['compact']} />
       <hr className="regular-contrib__multiline" />
       <div className="regular-contrib gu-content-margin">
         <InfoSection heading={`Your ${props.contributionType.toLowerCase()} contribution`} className="regular-contrib__your-contrib">

--- a/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
+++ b/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
@@ -39,6 +39,7 @@ const content = (
       <CirclesIntroduction
         headings={['Help us deliver', 'the independent', 'journalism the', 'world needs']}
         highlights={['Support', 'The Guardian']}
+        modifierClasses={['compact']}
       />
       <section id={supporterSectionId}>
         <ThreeSubscriptionsContainer />


### PR DESCRIPTION
## Why are you doing this?
The font size on the subsequant pages from the landing page in the contributions flow was larger than that of the landing page. This PR fixes this issue


## Screenshots
Landing Page (no change, just including to compare to other pages below):

Before | After
|-------|------|
|![page 1](https://user-images.githubusercontent.com/2844554/41539152-f326bfd8-7304-11e8-890a-4515fcc416d9.png)| ![page 1](https://user-images.githubusercontent.com/2844554/41539291-4ffe8574-7305-11e8-93ef-e0296e66c316.png) 

One-off payment page

Before | After
|-------|------|
|![page2old](https://user-images.githubusercontent.com/2844554/41539162-f8f919d8-7304-11e8-9bdf-413880aa9189.png)| ![page2new](https://user-images.githubusercontent.com/2844554/41539296-54d94d04-7305-11e8-8488-30f99201ca0f.png) |

Thank you page
 
Before | After
|-------|------|
|![thankyouold](https://user-images.githubusercontent.com/2844554/41539167-fdc6b63c-7304-11e8-9c13-d470cc075131.png)| ![thankyounew](https://user-images.githubusercontent.com/2844554/41539303-59b5fbd8-7305-11e8-9334-e2254e9d4ac6.png) |


Recurring payment page
 
Before | After
|-------|------|
|![recurringold](https://user-images.githubusercontent.com/2844554/41546179-e2ddcc06-7314-11e8-965d-d62cf632fcc6.png)| ![recurringneq](https://user-images.githubusercontent.com/2844554/41546143-c6431100-7314-11e8-84ce-8b0bfa82d4ef.png) |







