### PR TITLE
Re-enabling stripe elements

### DIFF
--- a/assets/components/stripeInlineForm/stripeInlineForm.jsx
+++ b/assets/components/stripeInlineForm/stripeInlineForm.jsx
@@ -115,6 +115,12 @@ function checkoutForm(props: {
       props.callback(testTokenId);
     } else if (props.canProceed && props.canProceed()) {
       storage.setSession('paymentMethod', 'Stripe');
+
+      /*
+       * We are passing the email in the name field here because in the StripeCheckout integration Stripe push the
+       * user's email in their internal name field.
+       */
+
       props
         .stripe
         .createToken({ name: props.email })

--- a/assets/components/stripeInlineForm/stripeInlineForm.jsx
+++ b/assets/components/stripeInlineForm/stripeInlineForm.jsx
@@ -22,6 +22,7 @@ type PropTypes = {|
   stripeIsLoaded: void => void,
   isStripeLoaded: boolean,
   currency: Currency,
+  email: string,
   isTestUser: boolean,
   callback: (token: string) => Promise<*>,
   switchStatus: Status,
@@ -68,6 +69,7 @@ function StripeInlineFormComp(props: PropTypes) {
           errorMessage={props.errorMessage}
           setError={props.setError}
           resetError={props.resetError}
+          email={props.email}
         />
       </Elements>
     </StripeProvider>
@@ -101,6 +103,7 @@ function checkoutForm(props: {
   errorMessage: ?string,
   setError: (string) => void,
   resetError: () => void,
+  email: string,
 }) {
 
   const handleSubmit = (event) => {
@@ -114,7 +117,7 @@ function checkoutForm(props: {
       storage.setSession('paymentMethod', 'Stripe');
       props
         .stripe
-        .createToken()
+        .createToken({ name: props.email })
         .then(({ token, error }) => {
           if (error !== undefined) {
             props.setError(error.message);

--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -44,7 +44,7 @@ export const tests: Tests = {
         size: 1,
       },
     },
-    isActive: false,
+    isActive: true,
     independent: true,
     seed: 0,
   },

--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -36,7 +36,7 @@ export const tests: Tests = {
     independent: true,
     seed: 0,
   },
-  inlineCardPayment: {
+  inlineStripeCardPayment: {
     variants: ['control', 'inline'],
     audiences: {
       ALL: {

--- a/assets/pages/oneoff-contributions/components/oneoffInlineContributionsPayment.jsx
+++ b/assets/pages/oneoff-contributions/components/oneoffInlineContributionsPayment.jsx
@@ -134,6 +134,7 @@ function OneoffContributionsPayment(props: PropTypes, context) {
     <section className="oneoff-contribution-payment">
       <ErrorMessage message={props.error} />
       <StripeInlineForm
+        email={props.email}
         callback={postCheckout(
           props.abParticipations,
           props.dispatch,

--- a/assets/pages/regular-contributions/components/regularInlineContributionsPayment.jsx
+++ b/assets/pages/regular-contributions/components/regularInlineContributionsPayment.jsx
@@ -54,6 +54,7 @@ type PropTypes = {
   stripeInlineErrorMessage: ?string,
   stripeInlineSetError: (string) => void,
   stripeInlineResetError: () => void,
+  email: string,
 };
 
 
@@ -107,6 +108,7 @@ function RegularContributionsPayment(props: PropTypes, context) {
   }
 
   let stripeInlineForm = (<StripeInlineForm
+    email={props.email}
     callback={postCheckout(
       props.abParticipations,
       props.amount,
@@ -174,6 +176,7 @@ function RegularContributionsPayment(props: PropTypes, context) {
 
 function mapStateToProps(state) {
   return {
+    email: state.page.user.email,
     isTestUser: state.page.user.isTestUser || false,
     isPostDeploymentTestUser: state.page.user.isPostDeploymentTestUser,
     hide: emptyInputField(state.page.user.firstName) || emptyInputField(state.page.user.lastName),


### PR DESCRIPTION
## Why are you doing this?

Before we were not able to see the use who made payment in stripe dashboard, now we can.

[**Trello Card**](https://trello.com)

## Changes

* Passing the email as the name in `stripe.createToken` function.

## Screenshots
N/A
