### PR TITLE
Pass Country Group To Subs Checkout

### DIFF
--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -4,7 +4,7 @@
 
 import type { Campaign } from 'helpers/tracking/acquisitions';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
-
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { addQueryParamsToURL } from 'helpers/url';
 
 import { getPromoCode } from './flashSale';
@@ -150,11 +150,31 @@ function getSubsLinks(
 
 }
 
+// Takes our CountryGroupId and turns it into the query param string that
+// subscriptions-frontend wants.
+function getSubsCountryGroup(cgId: CountryGroupId): string {
+
+  switch (cgId) {
+    case 'UnitedStates':
+      return 'us';
+    case 'International':
+      return 'int';
+    case 'GBPCountries':
+    default:
+      return 'gb';
+  }
+
+}
+
 // Builds a link to the digital pack checkout.
-function getDigitalCheckout(referrerAcquisitionData: ReferrerAcquisitionData): string {
+function getDigitalCheckout(
+  referrerAcquisitionData: ReferrerAcquisitionData,
+  cgId: CountryGroupId,
+): string {
 
   return addQueryParamsToURL(`${subsUrl}/checkout`, {
     promoCode: defaultPromos.digital,
+    countryGroup: getSubsCountryGroup(cgId),
     acquisitionData: JSON.stringify(referrerAcquisitionData),
   });
 

--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -4,7 +4,10 @@
 
 import type { Campaign } from 'helpers/tracking/acquisitions';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
-import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import {
+  countryGroups,
+  type CountryGroupId,
+} from 'helpers/internationalisation/countryGroup';
 import { addQueryParamsToURL } from 'helpers/url';
 
 import { getPromoCode } from './flashSale';
@@ -150,22 +153,6 @@ function getSubsLinks(
 
 }
 
-// Takes our CountryGroupId and turns it into the query param string that
-// subscriptions-frontend wants.
-function getSubsCountryGroup(cgId: CountryGroupId): string {
-
-  switch (cgId) {
-    case 'UnitedStates':
-      return 'us';
-    case 'International':
-      return 'int';
-    case 'GBPCountries':
-    default:
-      return 'gb';
-  }
-
-}
-
 // Builds a link to the digital pack checkout.
 function getDigitalCheckout(
   referrerAcquisitionData: ReferrerAcquisitionData,
@@ -174,7 +161,7 @@ function getDigitalCheckout(
 
   return addQueryParamsToURL(`${subsUrl}/checkout`, {
     promoCode: defaultPromos.digital,
-    countryGroup: getSubsCountryGroup(cgId),
+    countryGroup: countryGroups[cgId].supportInternationalisationId,
     acquisitionData: JSON.stringify(referrerAcquisitionData),
   });
 

--- a/assets/pages/digital-subscription-landing/components/priceCtaContainer.jsx
+++ b/assets/pages/digital-subscription-landing/components/priceCtaContainer.jsx
@@ -19,7 +19,10 @@ function mapStateToProps(state: { common: CommonState }) {
 
   return {
     ctaText: 'Start a 14 day free trial',
-    url: getDigitalCheckout(state.common.referrerAcquisitionData),
+    url: getDigitalCheckout(
+      state.common.referrerAcquisitionData,
+      state.common.countryGroup,
+    ),
     price: `${state.common.currency.glyph}${price}`,
   };
 


### PR DESCRIPTION
## Why are you doing this?

The digital pack checkout on subs takes a `countryGroup` query param to determine what version of the form to show. This passes through that query param from the product page.

[**Trello Card**](https://trello.com/c/YlDLscXN/1740-digital-pack-checkout-country-group)

cc @JustinPinner 

## Changes

- Passed the `countryGroup` query param to subs on the product page.
