### PR TITLE
Adding link to the switch file from the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Frontend for the new supporter platform: [https//support.theguardian.com/](https
 12. [Supported browsers](https://github.com/guardian/support-frontend/wiki/12.-Supported-Browsers)
 13. [Quickstart: Create a component](https://github.com/guardian/support-frontend/wiki/13.-Quickstart:-Create-a-component)
 14. [Tooling](https://github.com/guardian/support-frontend/wiki/14.-Tooling)
+15. [Switch file](https://github.com/guardian/support-frontend/wiki/15.-Switch-file)
 
 
 ## Getting started


### PR DESCRIPTION
## Why are you doing this?

To access the switch file wiki from the Readme.

[**Trello Card**](https://trello.com)

## Changes

* Readme

## Screenshots
N/A

