### PR TITLE
Test the new sign-in flow for recurring contributors

### DIFF
--- a/app/actions/CustomActionBuilders.scala
+++ b/app/actions/CustomActionBuilders.scala
@@ -41,7 +41,12 @@ class CustomActionBuilders(
   private def idWebAppRegisterUrl(path: String): String =
     idWebAppUrl / "register" ? ("returnUrl" -> s"$supportUrl$path") & idSkipConfirmation & idSkipValidationReturn & idMember
 
+  private def newSignInFlowIdWebAppRegisterUrl(path: String): String =
+    idWebAppUrl / "signin/start" ? ("returnUrl" -> s"$supportUrl$path") & idSkipConfirmation & idSkipValidationReturn & idMember
+
   private val chooseRegister = (request: RequestHeader) => SeeOther(idWebAppRegisterUrl(request.uri))
+
+  private val newSignInFlowChooseRegister = (request: RequestHeader) => SeeOther(newSignInFlowIdWebAppRegisterUrl(request.uri))
 
   private def maybeAuthenticated(onUnauthenticated: RequestHeader => Result = chooseRegister): ActionBuilder[OptionalAuthRequest, AnyContent] =
     new AuthenticatedBuilder(authenticatedIdUserProvider.andThen(Some.apply), cc.parsers.defaultBodyParser, onUnauthenticated)
@@ -59,6 +64,10 @@ class CustomActionBuilders(
   val PrivateAction = new PrivateActionBuilder(addToken, checkToken, csrfConfig, cc.parsers.defaultBodyParser, cc.executionContext)
 
   val AuthenticatedAction = PrivateAction andThen authenticated()
+
+  val NewSignInFlowAuthenticatedAction = PrivateAction andThen authenticated(newSignInFlowChooseRegister)
+
+  val AuthenticatedActionSignInTest = PrivateAction andThen authenticated()
 
   val AuthenticatedTestUserAction = PrivateAction andThen authenticatedTestUser()
 

--- a/app/actions/CustomActionBuilders.scala
+++ b/app/actions/CustomActionBuilders.scala
@@ -65,14 +65,11 @@ class CustomActionBuilders(
 
   val AuthenticatedAction = PrivateAction andThen authenticated()
 
-  val NewSignInFlowAuthenticatedAction = (useNewSignIn: Option[Boolean]) =>
-    useNewSignIn.fold {
+  val SignInFlowAuthenticatedAction = (useNewSignIn: Boolean) =>
+    if (useNewSignIn) {
+      PrivateAction andThen authenticated(newSignInFlowChooseRegister)
+    } else {
       AuthenticatedAction
-    } { useNew =>
-      if (useNew)
-        PrivateAction andThen authenticated(newSignInFlowChooseRegister)
-      else
-        AuthenticatedAction
     }
 
   val AuthenticatedTestUserAction = PrivateAction andThen authenticatedTestUser()

--- a/app/actions/CustomActionBuilders.scala
+++ b/app/actions/CustomActionBuilders.scala
@@ -65,9 +65,15 @@ class CustomActionBuilders(
 
   val AuthenticatedAction = PrivateAction andThen authenticated()
 
-  val NewSignInFlowAuthenticatedAction = PrivateAction andThen authenticated(newSignInFlowChooseRegister)
-
-  val AuthenticatedActionSignInTest = PrivateAction andThen authenticated()
+  val NewSignInFlowAuthenticatedAction = (useNewSignIn: Option[Boolean]) =>
+    useNewSignIn.fold {
+      AuthenticatedAction
+    } { useNew =>
+      if (useNew)
+        PrivateAction andThen authenticated(newSignInFlowChooseRegister)
+      else
+        AuthenticatedAction
+    }
 
   val AuthenticatedTestUserAction = PrivateAction andThen authenticatedTestUser()
 

--- a/app/controllers/RegularContributions.scala
+++ b/app/controllers/RegularContributions.scala
@@ -35,36 +35,41 @@ class RegularContributions(
 
   implicit val ar = assets
 
-  def displayForm(): Action[AnyContent] = AuthenticatedAction.async { implicit request =>
-    identityService.getUser(request.user).semiflatMap { fullUser =>
-      isMonthlyContributor(request.user.credentials) map {
-        case Some(true) =>
-          SafeLogger.info(s"Determined that ${request.user.id} is already a monthly contributor; re-directing to /contribute/recurring/existing")
-          Redirect("/contribute/recurring/existing")
-        case Some(false) | None =>
-          val uatMode = testUsers.isTestUser(fullUser.publicFields.displayName)
-          Ok(
-            monthlyContributions(
-              title = "Support the Guardian | Monthly Contributions",
-              id = "regular-contributions-page",
-              js = "regularContributionsPage.js",
-              css = "regularContributionsPageStyles.css",
-              user = fullUser,
-              uatMode = uatMode,
-              defaultStripeConfig = stripeConfigProvider.get(false),
-              uatStripeConfig = stripeConfigProvider.get(true),
-              payPalConfig = payPalConfigProvider.get(uatMode)
-            )
+  def displayForm(useNewSignIn: Option[Boolean] = None): Action[AnyContent] =
+    useNewSignIn.fold(AuthenticatedAction.async { implicit request => displayFormFunciton() })(useNew =>
+      if (useNew)
+        NewSignInFlowAuthenticatedAction.async { implicit request => displayFormFunciton() }
+      else
+        AuthenticatedAction.async { implicit request => displayFormFunciton() })
+
+  def displayFormFunciton()(implicit request: CustomActionBuilders.AuthRequest[AnyContent]): Future[Result] = identityService.getUser(request.user).semiflatMap { fullUser =>
+    isMonthlyContributor(request.user.credentials) map {
+      case Some(true) =>
+        SafeLogger.info(s"Determined that ${request.user.id} is already a monthly contributor; re-directing to /contribute/recurring/existing")
+        Redirect("/contribute/recurring/existing")
+      case Some(false) | None =>
+        val uatMode = testUsers.isTestUser(fullUser.publicFields.displayName)
+        Ok(
+          monthlyContributions(
+            title = "Support the Guardian | Monthly Contributions",
+            id = "regular-contributions-page",
+            js = "regularContributionsPage.js",
+            css = "regularContributionsPageStyles.css",
+            user = fullUser,
+            uatMode = uatMode,
+            defaultStripeConfig = stripeConfigProvider.get(false),
+            uatStripeConfig = stripeConfigProvider.get(true),
+            payPalConfig = payPalConfigProvider.get(uatMode)
           )
-      }
-    } fold (
-      { error =>
-        SafeLogger.error(scrub"Failed to display recurring contributions form for ${request.user.id} due to error from identityService: $error")
-        InternalServerError
-      },
-      identity
-    )
-  }
+        )
+    }
+  } fold (
+    { error =>
+      SafeLogger.error(scrub"Failed to display recurring contributions form for ${request.user.id} due to error from identityService: $error")
+      InternalServerError
+    },
+    identity
+  )
 
   def status(jobId: String): Action[AnyContent] = AuthenticatedAction.async { implicit request =>
     client.status(jobId, request.uuid).fold(

--- a/app/controllers/RegularContributions.scala
+++ b/app/controllers/RegularContributions.scala
@@ -35,36 +35,37 @@ class RegularContributions(
 
   implicit val ar = assets
 
-  def displayForm(useNewSignIn: Option[Boolean] = None): Action[AnyContent] = NewSignInFlowAuthenticatedAction(useNewSignIn).async { implicit request =>
-    identityService.getUser(request.user).semiflatMap { fullUser =>
-      isMonthlyContributor(request.user.credentials) map {
-        case Some(true) =>
-          SafeLogger.info(s"Determined that ${request.user.id} is already a monthly contributor; re-directing to /contribute/recurring/existing")
-          Redirect("/contribute/recurring/existing")
-        case Some(false) | None =>
-          val uatMode = testUsers.isTestUser(fullUser.publicFields.displayName)
-          Ok(
-            monthlyContributions(
-              title = "Support the Guardian | Monthly Contributions",
-              id = "regular-contributions-page",
-              js = "regularContributionsPage.js",
-              css = "regularContributionsPageStyles.css",
-              user = fullUser,
-              uatMode = uatMode,
-              defaultStripeConfig = stripeConfigProvider.get(false),
-              uatStripeConfig = stripeConfigProvider.get(true),
-              payPalConfig = payPalConfigProvider.get(uatMode)
+  def displayForm(useNewSignIn: Boolean): Action[AnyContent] =
+    SignInFlowAuthenticatedAction(useNewSignIn).async { implicit request =>
+      identityService.getUser(request.user).semiflatMap { fullUser =>
+        isMonthlyContributor(request.user.credentials) map {
+          case Some(true) =>
+            SafeLogger.info(s"Determined that ${request.user.id} is already a monthly contributor; re-directing to /contribute/recurring/existing")
+            Redirect("/contribute/recurring/existing")
+          case Some(false) | None =>
+            val uatMode = testUsers.isTestUser(fullUser.publicFields.displayName)
+            Ok(
+              monthlyContributions(
+                title = "Support the Guardian | Monthly Contributions",
+                id = "regular-contributions-page",
+                js = "regularContributionsPage.js",
+                css = "regularContributionsPageStyles.css",
+                user = fullUser,
+                uatMode = uatMode,
+                defaultStripeConfig = stripeConfigProvider.get(false),
+                uatStripeConfig = stripeConfigProvider.get(true),
+                payPalConfig = payPalConfigProvider.get(uatMode)
+              )
             )
-          )
-      }
-    } fold (
-      { error =>
-        SafeLogger.error(scrub"Failed to display recurring contributions form for ${request.user.id} due to error from identityService: $error")
-        InternalServerError
-      },
-      identity
-    )
-  }
+        }
+      } fold (
+        { error =>
+          SafeLogger.error(scrub"Failed to display recurring contributions form for ${request.user.id} due to error from identityService: $error")
+          InternalServerError
+        },
+        identity
+      )
+    }
 
   def status(jobId: String): Action[AnyContent] = AuthenticatedAction.async { implicit request =>
     client.status(jobId, request.uuid).fold(

--- a/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
+++ b/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
@@ -24,7 +24,6 @@ import type { Status } from 'helpers/switch';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import {Test} from "../../helpers/abTests/abtest";
 
 
 // ----- Types ----- //
@@ -45,7 +44,7 @@ type PropTypes = {
   }>,
   error: ?string,
   resetError: void => void,
-  newSignInFlowVariant:  'control' | 'variant' 
+  newSignInFlowVariant: 'control' | 'variant',
 };
 
 
@@ -137,20 +136,19 @@ function RegularCta(props: {
   currency: Currency,
   isDisabled: boolean,
   resetError: void => void,
-  newSignInFlowVariant: Test,
+  newSignInFlowVariant: 'control' | 'variant',
 
 }): Node {
 
-  const useNewSignIn = newSignInFlowVariant === 'variant' ? 'true' : 'false';
+  const useNewSignIn = props.newSignInFlowVariant === 'variant' ? 'true' : 'false';
 
-  console.log(newSignInFlowVariant);
 
   const spokenType = getSpokenType(props.contributionType, props.countryGroupId);
   const clickUrl = addQueryParamsToURL(routes.recurringContribCheckout, {
     contributionValue: props.amount.toString(),
     contribType: props.contributionType,
     currency: props.currency.iso,
-    useNewSignIn: useNewSignIn
+    useNewSignIn,
   });
 
   return (

--- a/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
+++ b/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
@@ -24,6 +24,7 @@ import type { Status } from 'helpers/switch';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import {Test} from "../../helpers/abTests/abtest";
 
 
 // ----- Types ----- //
@@ -44,6 +45,7 @@ type PropTypes = {
   }>,
   error: ?string,
   resetError: void => void,
+  newSignInFlowVariant:  'control' | 'variant' 
 };
 
 
@@ -135,13 +137,20 @@ function RegularCta(props: {
   currency: Currency,
   isDisabled: boolean,
   resetError: void => void,
+  newSignInFlowVariant: Test,
+
 }): Node {
+
+  const useNewSignIn = newSignInFlowVariant === 'variant' ? 'true' : 'false';
+
+  console.log(newSignInFlowVariant);
 
   const spokenType = getSpokenType(props.contributionType, props.countryGroupId);
   const clickUrl = addQueryParamsToURL(routes.recurringContribCheckout, {
     contributionValue: props.amount.toString(),
     contribType: props.contributionType,
     currency: props.currency.iso,
+    useNewSignIn: useNewSignIn
   });
 
   return (

--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -68,7 +68,7 @@ export const tests: Tests = {
         size: 1,
       },
     },
-    isActive: true,
+    isActive: false,
     independent: true,
     seed: 1,
   },

--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -60,4 +60,16 @@ export const tests: Tests = {
     independent: true,
     seed: 2,
   },
+  newSignInFlow: {
+    variants: ['control', 'variant'],
+    audiences: {
+      ALL: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: true,
+    independent: true,
+    seed: 1,
+  },
 };

--- a/assets/pages/contributions-landing/containers/contributionPaymentCtasContainer.js
+++ b/assets/pages/contributions-landing/containers/contributionPaymentCtasContainer.js
@@ -23,6 +23,7 @@ function mapStateToProps(state: State) {
     currency: state.common.currency,
     isDisabled: !!state.page.selection.error,
     error: state.page.payPal.error,
+    newSignInFlowVariant: state.common.abParticipations.newSignInFlow,
   };
 
 }

--- a/assets/pages/support-landing/components/contributionPaymentCtasContainer.js
+++ b/assets/pages/support-landing/components/contributionPaymentCtasContainer.js
@@ -23,6 +23,7 @@ function mapStateToProps(state: State) {
     currency: state.common.currency,
     isDisabled: !!state.page.selection.error,
     error: state.page.payPal.error,
+    newSignInFlowVariant: state.common.abParticipations.newSignInFlow,
   };
 
 }

--- a/conf/routes
+++ b/conf/routes
@@ -41,12 +41,12 @@ GET  /int/contribute                                controllers.Application.cont
 GET  /nz/contribute                                 controllers.Application.contributionsLanding(id="contributions-landing-page-nz")
 GET  /ca/contribute                                 controllers.Application.contributionsLanding(id="contributions-landing-page-ca")
 
-GET  /contribute/recurring                          controllers.RegularContributions.displayForm()
-GET  /contribute/recurring/thankyou                 controllers.RegularContributions.displayForm()
+GET  /contribute/recurring                          controllers.RegularContributions.displayForm(useNewSignIn: Option[Boolean])
+GET  /contribute/recurring/thankyou                 controllers.RegularContributions.displayForm(useNewSignIn: Option[Boolean])
 GET  /contribute/recurring/existing                 controllers.Application.reactTemplate(title="Support the Guardian | Existing Contributor", id="regular-contributions-existing-page", js="regularContributionsExistingPage.js", css="regularContributionsExistingPageStyles.css")
 POST /contribute/recurring/create                   controllers.RegularContributions.create
 GET  /contribute/recurring/status                   controllers.RegularContributions.status(jobId: String)
-GET  /contribute/recurring/pending                  controllers.RegularContributions.displayForm()
+GET  /contribute/recurring/pending                  controllers.RegularContributions.displayForm(useNewSignIn: Option[Boolean])
 
 # this endpoint should be removed once identity remove
 # the need for a client token

--- a/conf/routes
+++ b/conf/routes
@@ -41,12 +41,12 @@ GET  /int/contribute                                controllers.Application.cont
 GET  /nz/contribute                                 controllers.Application.contributionsLanding(id="contributions-landing-page-nz")
 GET  /ca/contribute                                 controllers.Application.contributionsLanding(id="contributions-landing-page-ca")
 
-GET  /contribute/recurring                          controllers.RegularContributions.displayForm(useNewSignIn: Option[Boolean])
-GET  /contribute/recurring/thankyou                 controllers.RegularContributions.displayForm(useNewSignIn: Option[Boolean])
+GET  /contribute/recurring                          controllers.RegularContributions.displayForm(useNewSignIn: Boolean ?= false)
+GET  /contribute/recurring/thankyou                 controllers.RegularContributions.displayForm(useNewSignIn: Boolean ?= false)
 GET  /contribute/recurring/existing                 controllers.Application.reactTemplate(title="Support the Guardian | Existing Contributor", id="regular-contributions-existing-page", js="regularContributionsExistingPage.js", css="regularContributionsExistingPageStyles.css")
 POST /contribute/recurring/create                   controllers.RegularContributions.create
 GET  /contribute/recurring/status                   controllers.RegularContributions.status(jobId: String)
-GET  /contribute/recurring/pending                  controllers.RegularContributions.displayForm(useNewSignIn: Option[Boolean])
+GET  /contribute/recurring/pending                  controllers.RegularContributions.displayForm(useNewSignIn: Boolean ?= false)
 
 # this endpoint should be removed once identity remove
 # the need for a client token

--- a/test/controllers/RegularContributionsTest.scala
+++ b/test/controllers/RegularContributionsTest.scala
@@ -158,7 +158,7 @@ class RegularContributionsTest extends WordSpec with MustMatchers with TestCSRFC
           stripeConfigProvider,
           payPalConfigProvider,
           stubControllerComponents()
-        ).displayForm()(FakeRequest())
+        ).displayForm(false)(FakeRequest())
       }
     }
   }


### PR DESCRIPTION
## Why are you doing this?
An A/B test that tests Identity's new (and as yet unfinished) flow. 

Half of the non-signed in users who choose to try and make a recurring contribution will go to the old flow (https://profile.theguardian.com/register) and half to the new (https://profile.theguardian.com/signin/start)

The test is currently set to inactive, we will flip it to active when identity is ready.

@guardian/contributions 