### PR TITLE
Clear local storage before running each Selenium test

### DIFF
--- a/test/selenium/util/DriverConfig.scala
+++ b/test/selenium/util/DriverConfig.scala
@@ -5,7 +5,7 @@ import java.util.Date
 import io.github.bonigarcia.wdm.ChromeDriverManager
 import org.openqa.selenium.chrome.{ChromeDriver, ChromeOptions}
 import org.openqa.selenium.remote.RemoteWebDriver
-import org.openqa.selenium.{Cookie, WebDriver}
+import org.openqa.selenium.{Cookie, JavascriptExecutor, WebDriver}
 
 class DriverConfig {
 
@@ -40,6 +40,8 @@ class DriverConfig {
 
     webDriver.get(Config.supportFrontendUrl + "/uk")
     webDriver.manage.deleteAllCookies()
+
+    webDriver.asInstanceOf[JavascriptExecutor].executeScript("window.localStorage.clear();")
   }
 
   def quit(): Unit = webDriver.quit()


### PR DESCRIPTION
## Why are you doing this?

To ensure that the post-deployment tests never end up in an A/B test variant.

## Changes

* Clear local storage before each test.



