### PR TITLE
After already picking pay by card don't suggest paying by paypal

### DIFF
--- a/assets/components/paymentButtons/stripePopUpButton/stripePopUpButton.scss
+++ b/assets/components/paymentButtons/stripePopUpButton/stripePopUpButton.scss
@@ -8,7 +8,6 @@
   font-family: $gu-sans-web;
   font-size: 14px;
   height: $cta-height;
-  margin-top: $gu-v-spacing;
   padding-left: $gu-h-spacing;
   position: relative;
   text-align: left;
@@ -24,10 +23,6 @@
   }
   .svg-credit-card {
     fill: gu-colour(garnett-neutral-1);
-  }
-
-  @include mq($from: mobileMedium) {
-    width: 304px;
   }
 
   &:hover {

--- a/assets/components/paymentButtons/stripePopUpButton/stripePopUpButton.scss
+++ b/assets/components/paymentButtons/stripePopUpButton/stripePopUpButton.scss
@@ -1,21 +1,19 @@
 .component-stripe-pop-up-button {
-  background-color: gu-colour(neutral-1);
+  box-sizing: border-box;
+  background-color: gu-colour(news-garnett-highlight);
   border: none;
   border-radius: 600px;
-  color: #fff;
+  color: gu-colour(garnett-neutral-1);
   cursor: pointer;
   display: block;
   font-family: $gu-sans-web;
   font-size: 14px;
   height: $cta-height;
+  margin-top: $gu-v-spacing;
   padding-left: $gu-h-spacing;
   position: relative;
   text-align: left;
   width: 100%;
-
-  @include mq($from: mobileMedium) {
-    width: 304px;
-  }
 
   svg {
     width: 24px;
@@ -25,8 +23,15 @@
     top: 50%;
     transform: translateY(-50%);
   }
+  .svg-credit-card {
+    fill: gu-colour(garnett-neutral-1);
+  }
+
+  @include mq($from: phablet) {
+    width: 304px;
+  }
 
   &:hover {
-    background-color: #000;
+    background-color: darken(gu-colour(news-garnett-highlight), 5%);
   }
 }

--- a/assets/components/paymentButtons/stripePopUpButton/stripePopUpButton.scss
+++ b/assets/components/paymentButtons/stripePopUpButton/stripePopUpButton.scss
@@ -1,5 +1,4 @@
 .component-stripe-pop-up-button {
-  box-sizing: border-box;
   background-color: gu-colour(news-garnett-highlight);
   border: none;
   border-radius: 600px;
@@ -27,7 +26,7 @@
     fill: gu-colour(garnett-neutral-1);
   }
 
-  @include mq($from: phablet) {
+  @include mq($from: mobileMedium) {
     width: 304px;
   }
 

--- a/assets/pages/oneoff-contributions/components/oneoffContributionsPayment.jsx
+++ b/assets/pages/oneoff-contributions/components/oneoffContributionsPayment.jsx
@@ -7,16 +7,13 @@ import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import StripePopUpButton from 'components/paymentButtons/stripePopUpButton/stripePopUpButton';
-import PayPalContributionButton from 'containerisableComponents/payPalContributionButton/payPalContributionButton';
 import ErrorMessage from 'components/errorMessage/errorMessage';
 
 import { validateEmailAddress } from 'helpers/utilities';
 
-import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import type { Participations } from 'helpers/abTests/abtest';
 import type { Currency } from 'helpers/internationalisation/currency';
-import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { Status } from 'helpers/switch';
 
 import { checkoutError, type Action } from '../oneoffContributionsActions';
@@ -32,15 +29,12 @@ type PropTypes = {
   isFormEmpty: boolean,
   amount: number,
   referrerAcquisitionData: ReferrerAcquisitionData,
-  isoCountry: IsoCountry,
-  countryGroupId: CountryGroupId,
   checkoutError: (?string) => void,
   abParticipations: Participations,
   currency: Currency,
   isTestUser: boolean,
   isPostDeploymentTestUser: boolean,
   stripeSwitchStatus: Status,
-  payPalSwitchStatus: Status,
 };
 
 // ----- Map State/Props ----- //
@@ -54,12 +48,9 @@ function mapStateToProps(state) {
     isFormEmpty: state.page.user.email === '' || state.page.user.fullName === '',
     amount: state.page.oneoffContrib.amount,
     referrerAcquisitionData: state.common.referrerAcquisitionData,
-    isoCountry: state.common.country,
-    countryGroupId: state.common.countryGroup,
     abParticipations: state.common.abParticipations,
     currency: state.common.currency,
     stripeSwitchStatus: state.common.switches.oneOffPaymentMethods.stripe,
-    payPalSwitchStatus: state.common.switches.oneOffPaymentMethods.payPal,
   };
 }
 
@@ -117,15 +108,6 @@ function OneoffContributionsPayment(props: PropTypes, context) {
   return (
     <section className="oneoff-contribution-payment">
       <ErrorMessage message={props.error} />
-      <PayPalContributionButton
-        amount={props.amount}
-        referrerAcquisitionData={props.referrerAcquisitionData}
-        isoCountry={props.isoCountry}
-        countryGroupId={props.countryGroupId}
-        errorHandler={props.checkoutError}
-        abParticipations={props.abParticipations}
-        switchStatus={props.payPalSwitchStatus}
-      />
       <StripePopUpButton
         email={props.email}
         callback={postCheckout(

--- a/assets/pages/oneoff-contributions/components/oneoffInlineContributionsPayment.jsx
+++ b/assets/pages/oneoff-contributions/components/oneoffInlineContributionsPayment.jsx
@@ -7,16 +7,13 @@ import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import StripeInlineForm from 'components/stripeInlineForm/stripeInlineForm';
-import PayPalContributionButton from 'containerisableComponents/payPalContributionButton/payPalContributionButton';
 import ErrorMessage from 'components/errorMessage/errorMessage';
 
 import { validateEmailAddress } from 'helpers/utilities';
 
-import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import type { Participations } from 'helpers/abTests/abtest';
 import type { Currency } from 'helpers/internationalisation/currency';
-import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { Status } from 'helpers/switch';
 import { type Action as StripeInlineFormAction, stripeInlineFormActionsFor } from 'components/stripeInlineForm/stripeInlineFormActions';
 
@@ -33,15 +30,12 @@ type PropTypes = {
   isFormEmpty: boolean,
   amount: number,
   referrerAcquisitionData: ReferrerAcquisitionData,
-  isoCountry: IsoCountry,
-  countryGroupId: CountryGroupId,
   checkoutError: (?string) => void,
   abParticipations: Participations,
   currency: Currency,
   isTestUser: boolean,
   isPostDeploymentTestUser: boolean,
   stripeSwitchStatus: Status,
-  payPalSwitchStatus: Status,
   isStripeLoaded: boolean,
   stripeIsLoaded: () => void,
   stripeInlineErrorMessage: ?string,
@@ -60,12 +54,9 @@ function mapStateToProps(state) {
     isFormEmpty: state.page.user.email === '' || state.page.user.fullName === '',
     amount: state.page.oneoffContrib.amount,
     referrerAcquisitionData: state.common.referrerAcquisitionData,
-    isoCountry: state.common.country,
-    countryGroupId: state.common.countryGroup,
     abParticipations: state.common.abParticipations,
     currency: state.common.currency,
     stripeSwitchStatus: state.common.switches.oneOffPaymentMethods.stripe,
-    payPalSwitchStatus: state.common.switches.oneOffPaymentMethods.payPal,
     isStripeLoaded: state.page.stripeInlineForm.isStripeLoaded,
     stripeInlineErrorMessage: state.page.stripeInlineForm.errorMessage,
   };
@@ -157,17 +148,6 @@ function OneoffContributionsPayment(props: PropTypes, context) {
         errorMessage={props.stripeInlineErrorMessage}
         setError={props.stripeInlineSetError}
         resetError={props.stripeInlineResetError}
-      />
-
-      <p className="oneoff-contribution-payment__or-label">or</p>
-      <PayPalContributionButton
-        amount={props.amount}
-        referrerAcquisitionData={props.referrerAcquisitionData}
-        isoCountry={props.isoCountry}
-        countryGroupId={props.countryGroupId}
-        errorHandler={props.checkoutError}
-        abParticipations={props.abParticipations}
-        switchStatus={props.payPalSwitchStatus}
       />
     </section>
   );

--- a/assets/pages/oneoff-contributions/oneoffContributions.scss
+++ b/assets/pages/oneoff-contributions/oneoffContributions.scss
@@ -103,6 +103,15 @@
     }
   }
 
+  .component-stripe-pop-up-button {
+    margin-top: $gu-v-spacing;
+
+    @include mq($from: phablet) {
+      width: 304px;
+    }
+  }
+
+
   .component-paypal-contribution-button {
     height: $cta-height;
     width: 100%;

--- a/assets/pages/oneoff-contributions/oneoffContributions.scss
+++ b/assets/pages/oneoff-contributions/oneoffContributions.scss
@@ -103,28 +103,6 @@
     }
   }
 
-  .component-stripe-pop-up-button {
-    box-sizing: border-box;
-    background-color: #fff;
-    color: gu-colour(garnett-neutral-1);
-    border: 1px solid gu-colour(garnett-neutral-1);
-    width: 100%;
-    margin-top: $gu-v-spacing;
-
-    .svg-credit-card {
-      fill: gu-colour(garnett-neutral-1);
-    }
-
-    @include mq($from: phablet) {
-      width: 304px;
-    }
-
-    &:hover {
-      color: darken(gu-colour(garnett-neutral-1), 5%);
-      border-color: darken(gu-colour(garnett-neutral-1), 5%);
-    }
-  }
-
   .component-paypal-contribution-button {
     height: $cta-height;
     width: 100%;

--- a/assets/pages/regular-contributions/regularContributions.scss
+++ b/assets/pages/regular-contributions/regularContributions.scss
@@ -126,6 +126,12 @@
     }
   }
 
+  .component-stripe-pop-up-button {
+    @include mq($from: phablet) {
+      width: 304px;
+    }
+  }
+
   .component-paypal-button-checkout {
     margin-top: $gu-v-spacing;
     width: 100%;

--- a/assets/pages/regular-contributions/regularContributions.scss
+++ b/assets/pages/regular-contributions/regularContributions.scss
@@ -126,25 +126,6 @@
     }
   }
 
-  .component-stripe-pop-up-button {
-    box-sizing: border-box;
-    background-color: gu-colour(news-garnett-highlight);
-    color: gu-colour(garnett-neutral-1);
-    width: 100%;
-
-    .svg-credit-card {
-      fill: gu-colour(garnett-neutral-1);
-    }
-
-    @include mq($from: phablet) {
-      width: 304px;
-    }
-
-    &:hover {
-      background-color: darken(gu-colour(news-garnett-highlight), 5%);
-    }
-  }
-
   .component-paypal-button-checkout {
     margin-top: $gu-v-spacing;
     width: 100%;


### PR DESCRIPTION
## Why are you doing this?
One-off contributors who have already selected to pay by card were being asked again to pick a payment method: card or paypal. We should remove paypal as an option if they have already selected to pay by card. 

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/n9x8uawR/1747-remove-paypal-button-from-pay-with-card-page-for-one-off-contributions)

## Changes

* Removed the button to pay by paypal on the page shown when a user has indicated they will make a one-off contribution by card
* Removed the button to pay by paypal for the [inline stripe test](https://github.com/guardian/support-frontend/pull/728), too


## Screenshots
|        | **With paypal button removed**           | **Current behaviour**   |
| ------------- |:-------------:| -----|
| **Pop-up stripe checkout**     | ![image](https://user-images.githubusercontent.com/3072877/41909410-db746a94-793e-11e8-9505-2807ae29abf3.png) | ![image](https://user-images.githubusercontent.com/3072877/41774925-991b51c6-7619-11e8-8e11-ff225e5b75f8.png) |
| **Inline stripe checkout**  |![image](https://user-images.githubusercontent.com/3072877/41774861-5da61bbc-7619-11e8-9845-ae13fd0caa02.png)     | ![image](https://user-images.githubusercontent.com/3072877/41774907-8953695e-7619-11e8-8afb-f199322f2551.png) |


