### PR TITLE
Handling rejected case of PaymentRequest's promise 

### DIFF
--- a/assets/helpers/tracking/googleTagManager.js
+++ b/assets/helpers/tracking/googleTagManager.js
@@ -21,7 +21,8 @@ type PaymentRequestAPIStatus =
   'AvailableInUse' |
   'PaymentRequestAPIError' |
   'PromiseNotSupported' |
-  'PromiseRejected';
+  'PromiseRejected' |
+  'PaymentApiPromiseRejected';
 
 // ----- Functions ----- //
 
@@ -83,6 +84,10 @@ function getPaymentAPIStatus(): Promise<PaymentRequestAPIStatus> {
           } else {
             resolve('AvailableNotInUse');
           }
+        })
+        .catch((e) => {
+          logException(e);
+          resolve('PaymentApiPromiseRejected');
         });
     } catch (e) {
       resolve('PaymentRequestAPIError');

--- a/assets/helpers/tracking/googleTagManager.js
+++ b/assets/helpers/tracking/googleTagManager.js
@@ -7,13 +7,21 @@ import { detect as detectCurrency } from 'helpers/internationalisation/currency'
 import { getQueryParameter } from 'helpers/url';
 import { detect as detectCountryGroup } from 'helpers/internationalisation/countryGroup';
 import { getOphanIds } from 'helpers/tracking/acquisitions';
+import { logException } from 'helpers/logger';
 import type { Participations } from 'helpers/abTests/abtest';
 
 
 // ----- Types ----- //
 type EventType = 'DataLayerReady' | 'SuccessfulConversion';
 
-type PaymentRequestAPIStatus = 'PaymentRequestAPINotAvailable' | 'CanMakePaymentNotAvailable' | 'AvailableNotInUse' | 'AvailableInUse' | 'PaymentRequestAPIError';
+type PaymentRequestAPIStatus =
+  'PaymentRequestAPINotAvailable' |
+  'CanMakePaymentNotAvailable' |
+  'AvailableNotInUse' |
+  'AvailableInUse' |
+  'PaymentRequestAPIError' |
+  'PromiseNotSupported' |
+  'PromiseRejected';
 
 // ----- Functions ----- //
 
@@ -90,28 +98,41 @@ function getContributionValue() {
   return storage.getSession('contributionValue') || 0;
 }
 
+function sendData(event: EventType, participations: Participations, paymentRequestApiStatus: PaymentRequestAPIStatus) {
+  window.googleTagManagerDataLayer.push({
+    event,
+    // orderId anonymously identifies this user in this session.
+    // We need this to prevent page refreshes on conversion pages being
+    // treated as new conversions
+    orderId: getDataValue('orderId', uuidv4),
+    currency: getDataValue('currency', getCurrency),
+    value: getContributionValue(),
+    paymentMethod: storage.getSession('paymentMethod') || undefined,
+    campaignCodeBusinessUnit: getQueryParameter('CMP_BUNIT') || undefined,
+    campaignCodeTeam: getQueryParameter('CMP_TU') || undefined,
+    experience: getVariantsAsString(participations),
+    ophanBrowserID: getOphanIds().browserId,
+    paymentRequestApiStatus,
+  });
+}
+
+
 function pushToDataLayer(event: EventType, participations: Participations) {
   window.googleTagManagerDataLayer = window.googleTagManagerDataLayer || [];
 
-
-  getPaymentAPIStatus()
-    .then((paymentRequestApiStatus) => {
-      window.googleTagManagerDataLayer.push({
-        event,
-        // orderId anonymously identifies this user in this session.
-        // We need this to prevent page refreshes on conversion pages being
-        // treated as new conversions
-        orderId: getDataValue('orderId', uuidv4),
-        currency: getDataValue('currency', getCurrency),
-        value: getContributionValue(),
-        paymentMethod: storage.getSession('paymentMethod') || undefined,
-        campaignCodeBusinessUnit: getQueryParameter('CMP_BUNIT') || undefined,
-        campaignCodeTeam: getQueryParameter('CMP_TU') || undefined,
-        experience: getVariantsAsString(participations),
-        ophanBrowserID: getOphanIds().browserId,
-        paymentRequestApiStatus,
+  try {
+    getPaymentAPIStatus()
+      .then((paymentRequestApiStatus) => {
+        sendData(event, participations, paymentRequestApiStatus);
+      })
+      .catch((e) => {
+        logException(e);
+        sendData(event, participations, 'PromiseRejected');
       });
-    });
+  } catch (e) {
+    sendData(event, participations, 'PromiseNotSupported');
+  }
+
 }
 
 function init(participations: Participations) {


### PR DESCRIPTION
## Why are you doing this?
Since we released this PR: https://github.com/guardian/support-frontend/pull/727 the number of errors in Sentry went up. I have two theories about this, the first is we are not handling the rejected case of the promise, the second in old browsers Promise is not available and therefore, returns an error.

As a solution, I added a "PromisedRejected" case and "PromiseNotSupported" case to the tracking.

## Screenshots
N/A
