### PR TITLE
Logging payment API request errors using info level

### DIFF
--- a/assets/helpers/logger.js
+++ b/assets/helpers/logger.js
@@ -27,3 +27,12 @@ export const logException = (ex: string, context?: Object): void => {
   }
 };
 
+export const logInfo = (message: string): void => {
+  Raven.captureMessage(
+    message,
+    {
+      level: 'info',
+    },
+  );
+};
+

--- a/assets/helpers/logger.js
+++ b/assets/helpers/logger.js
@@ -3,7 +3,7 @@ import Raven from 'raven-js';
 
 // ----- Functions ----- //
 
-export const init = () => {
+const init = () => {
   const dsn: string = 'https://65f7514888b6407881f34a6cf1320d06@sentry.io/1213654';
   const { gitCommitId } = window.guardian;
 
@@ -14,7 +14,7 @@ export const init = () => {
 };
 
 
-export const logException = (ex: string, context?: Object): void => {
+const logException = (ex: string, context?: Object): void => {
   Raven.captureException(
     new Error(ex),
     {
@@ -27,7 +27,7 @@ export const logException = (ex: string, context?: Object): void => {
   }
 };
 
-export const logInfo = (message: string): void => {
+const logInfo = (message: string): void => {
   Raven.captureMessage(
     message,
     {
@@ -36,3 +36,10 @@ export const logInfo = (message: string): void => {
   );
 };
 
+// ----- Exports ----- //
+
+export {
+  init,
+  logException,
+  logInfo,
+};

--- a/assets/helpers/tracking/googleTagManager.js
+++ b/assets/helpers/tracking/googleTagManager.js
@@ -7,7 +7,7 @@ import { detect as detectCurrency } from 'helpers/internationalisation/currency'
 import { getQueryParameter } from 'helpers/url';
 import { detect as detectCountryGroup } from 'helpers/internationalisation/countryGroup';
 import { getOphanIds } from 'helpers/tracking/acquisitions';
-import { logException } from 'helpers/logger';
+import { logInfo } from 'helpers/logger';
 import type { Participations } from 'helpers/abTests/abtest';
 
 
@@ -86,10 +86,11 @@ function getPaymentAPIStatus(): Promise<PaymentRequestAPIStatus> {
           }
         })
         .catch((e) => {
-          logException(e.message);
+          logInfo(`PaymentAPI Promise rejected: ${e.message}`);
           resolve('PaymentApiPromiseRejected');
         });
     } catch (e) {
+      logInfo(`PaymentAPI Request error: ${e.message}`);
       resolve('PaymentRequestAPIError');
     }
   });
@@ -131,7 +132,7 @@ function pushToDataLayer(event: EventType, participations: Participations) {
         sendData(event, participations, paymentRequestApiStatus);
       })
       .catch((e) => {
-        logException(e.message);
+        logInfo(`Promise rejected: ${e.message}`);
         sendData(event, participations, 'PromiseRejected');
       });
   } catch (e) {


### PR DESCRIPTION
## Why are you doing this?
To reduce the noise in Sentry.

At the moment we are logging several "Payment Request API" errors as Errors but we shouldn't. We are trying out the payment API in production, and we would like to know the reason for its failure, but we are not going to fix it. Therefore, to reduce the noise in Sentry, I am passing those logs from exception to info. In the place where the previous exceptions took place, we handle them correctly, so the behaviour for the end user should be the same.
[**Trello Card**](https://trello.com)

## Changes

* Created `logInfo`
* Replace `logException` with `logInfo` in Payment Api flow

## Screenshots
N/A