### PR TITLE
Revert to sending "members" identity clientID

### DIFF
--- a/app/controllers/DirectDebit.scala
+++ b/app/controllers/DirectDebit.scala
@@ -20,7 +20,7 @@ class DirectDebit(
   import actionBuilders._
 
   def checkAccount: Action[CheckBankAccountDetails] =
-    authenticatedAction(recurringIdentityClientId).async(circe.json[CheckBankAccountDetails]) { implicit request =>
+    authenticatedAction().async(circe.json[CheckBankAccountDetails]) { implicit request =>
       val goCardlessService = goCardlessServiceProvider.forUser(testUsers.isTestUser(request.user))
       goCardlessService.checkBankDetails(request.body).map { isAccountValid =>
         Ok(Map("accountValid" -> isAccountValid).asJson)

--- a/app/controllers/PayPalRegular.scala
+++ b/app/controllers/PayPalRegular.scala
@@ -28,7 +28,7 @@ class PayPalRegular(
   implicit val assetsResolver = assets
 
   // Sets up a payment by contacting PayPal, returns the token as JSON.
-  def setupPayment: Action[PayPalBillingDetails] = authenticatedAction(recurringIdentityClientId).async(circe.json[PayPalBillingDetails]) { implicit request =>
+  def setupPayment: Action[PayPalBillingDetails] = authenticatedAction().async(circe.json[PayPalBillingDetails]) { implicit request =>
     val paypalBillingDetails = request.body
 
     withPaypalServiceForUser(request.user) { service =>
@@ -41,7 +41,7 @@ class PayPalRegular(
     }
   }
 
-  def createAgreement: Action[Token] = authenticatedAction(recurringIdentityClientId).async(circe.json[Token]) { implicit request =>
+  def createAgreement: Action[Token] = authenticatedAction().async(circe.json[Token]) { implicit request =>
     withPaypalServiceForUser(request.user) { service =>
       service.createBillingAgreement(request.body)
     }.map(token => Ok(Token(token).asJson))

--- a/app/controllers/RegularContributions.scala
+++ b/app/controllers/RegularContributions.scala
@@ -36,7 +36,7 @@ class RegularContributions(
   implicit val ar = assets
 
   def displayForm(useNewSignIn: Boolean): Action[AnyContent] =
-    authenticatedAction(recurringIdentityClientId, useNewSignIn).async { implicit request =>
+    authenticatedAction(membersIdentityClientId, useNewSignIn).async { implicit request =>
       identityService.getUser(request.user).semiflatMap { fullUser =>
         isMonthlyContributor(request.user.credentials) map {
           case Some(true) =>
@@ -67,7 +67,7 @@ class RegularContributions(
       )
     }
 
-  def status(jobId: String): Action[AnyContent] = authenticatedAction(recurringIdentityClientId).async { implicit request =>
+  def status(jobId: String): Action[AnyContent] = authenticatedAction().async { implicit request =>
     client.status(jobId, request.uuid).fold(
       { error =>
         SafeLogger.error(scrub"Failed to get status of step function execution for user ${request.user.id} due to $error")
@@ -77,7 +77,7 @@ class RegularContributions(
     )
   }
 
-  def create: Action[CreateRegularContributorRequest] = authenticatedAction(recurringIdentityClientId).async(circe.json[CreateRegularContributorRequest]) {
+  def create: Action[CreateRegularContributorRequest] = authenticatedAction().async(circe.json[CreateRegularContributorRequest]) {
     implicit request =>
       SafeLogger.info(s"[${request.uuid}] User ${request.user.id} is attempting to create a new ${request.body.contribution.billingPeriod} contribution")
 

--- a/test/actions/ActionRefinerTest.scala
+++ b/test/actions/ActionRefinerTest.scala
@@ -34,7 +34,7 @@ class ActionRefinerTest extends WordSpec with MustMatchers with TestCSRFComponen
       val actionRefiner = new CustomActionBuilders(
         _ => Some(mock[AuthenticatedIdUser]), "", "", mock[TestUserService], stubControllerComponents(), csrfAddToken, csrfCheck, csrfConfig
       )
-      val result = actionRefiner.authenticatedAction(actionRefiner.recurringIdentityClientId)(Ok("authentication-test")).apply(fakeRequest)
+      val result = actionRefiner.authenticatedAction()(Ok("authentication-test")).apply(fakeRequest)
       status(result) mustEqual Status.OK
       contentAsString(result) mustEqual "authentication-test"
     }
@@ -51,7 +51,7 @@ class ActionRefinerTest extends WordSpec with MustMatchers with TestCSRFComponen
         checkToken = csrfCheck,
         csrfConfig = csrfConfig
       )
-      val result = actionRefiner.authenticatedAction(actionRefiner.recurringIdentityClientId)(Ok("authentication-test")).apply(fakeRequest)
+      val result = actionRefiner.authenticatedAction()(Ok("authentication-test")).apply(fakeRequest)
 
       status(result) mustEqual Status.SEE_OTHER
       redirectLocation(result) mustBe defined
@@ -59,7 +59,7 @@ class ActionRefinerTest extends WordSpec with MustMatchers with TestCSRFComponen
         location must startWith(idApiUrl)
         location must include(s"returnUrl=$supportUrl$path")
         location must include("skipConfirmation=true")
-        location must include("clientId=recurringContributions")
+        location must include("clientId=members")
       }
     }
 
@@ -74,7 +74,7 @@ class ActionRefinerTest extends WordSpec with MustMatchers with TestCSRFComponen
         checkToken = csrfCheck,
         csrfConfig = csrfConfig
       )
-      val result = actionRefiner.authenticatedAction(actionRefiner.recurringIdentityClientId)(Ok("authentication-test")).apply(fakeRequest)
+      val result = actionRefiner.authenticatedAction()(Ok("authentication-test")).apply(fakeRequest)
       header("Cache-Control", result) mustBe Some("no-cache, private")
     }
 
@@ -89,7 +89,7 @@ class ActionRefinerTest extends WordSpec with MustMatchers with TestCSRFComponen
         checkToken = csrfCheck,
         csrfConfig = csrfConfig
       )
-      val result = actionRefiner.authenticatedAction(actionRefiner.recurringIdentityClientId)(Ok("authentication-test")).apply(fakeRequest)
+      val result = actionRefiner.authenticatedAction()(Ok("authentication-test")).apply(fakeRequest)
       header("Cache-Control", result) mustBe Some("no-cache, private")
     }
 
@@ -116,7 +116,7 @@ class ActionRefinerTest extends WordSpec with MustMatchers with TestCSRFComponen
         checkToken = csrfCheck,
         csrfConfig = csrfConfig
       )
-      val result = actionRefiner.authenticatedTestUserAction(actionRefiner.recurringIdentityClientId)(Ok("authentication-test")).apply(fakeRequest)
+      val result = actionRefiner.authenticatedTestUserAction()(Ok("authentication-test")).apply(fakeRequest)
       status(result) mustEqual Status.OK
       contentAsString(result) mustEqual "authentication-test"
     }
@@ -133,7 +133,7 @@ class ActionRefinerTest extends WordSpec with MustMatchers with TestCSRFComponen
         checkToken = csrfCheck,
         csrfConfig = csrfConfig
       )
-      val result = actionRefiner.authenticatedTestUserAction(actionRefiner.recurringIdentityClientId)(Ok("authentication-test")).apply(fakeRequest)
+      val result = actionRefiner.authenticatedTestUserAction()(Ok("authentication-test")).apply(fakeRequest)
 
       status(result) mustEqual Status.SEE_OTHER
       redirectLocation(result) mustBe defined
@@ -141,13 +141,13 @@ class ActionRefinerTest extends WordSpec with MustMatchers with TestCSRFComponen
         location must startWith(idApiUrl)
         location must include(s"returnUrl=$supportUrl$path")
         location must include("skipConfirmation=true")
-        location must include("clientId=recurringContributions")
+        location must include("clientId=members")
       }
     }
 
     "return a private cache header if user is an authenticated test user" in {
       val actionRefiner = new CustomActionBuilders(_ => Some(testUser), "", "", testUsers, stubControllerComponents(), csrfAddToken, csrfCheck, csrfConfig)
-      val result = actionRefiner.authenticatedTestUserAction(actionRefiner.recurringIdentityClientId)(Ok("authentication-test")).apply(fakeRequest)
+      val result = actionRefiner.authenticatedTestUserAction()(Ok("authentication-test")).apply(fakeRequest)
       header("Cache-Control", result) mustBe Some("no-cache, private")
     }
 


### PR DESCRIPTION
## Why are you doing this?
Identity Frontend is not ready to receive the new client ID, as it was previously inserting some custom "Support the Guardian" text for the `members` clientId, which it is not set up to do for the new `recurringContributions` client Id.

This PR ensures that the `members` clientId is always sent to identity frontend, as it was previously