### PR TITLE
Delete Old Query Param Function

### DIFF
--- a/assets/components/ctaLink/ctaLink.jsx
+++ b/assets/components/ctaLink/ctaLink.jsx
@@ -6,11 +6,9 @@ import React from 'react';
 import SvgArrowRightStraight from 'components/svgs/arrowRightStraight';
 import { clickSubstituteKeyPressHandler } from 'helpers/utilities';
 import uuidv4 from 'uuid';
-import { addQueryParamToURL } from 'helpers/url';
 import { classNameWithModifiers } from 'helpers/utilities';
 
 import type { Node } from 'react';
-import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 
 
 // ----- Types ----- //
@@ -23,7 +21,6 @@ type PropTypes = {
   tabIndex?: number,
   id?: ?string,
   svg?: Node,
-  acquisitionData?: ?ReferrerAcquisitionData,
   modifierClasses: Array<?string>,
 };
 
@@ -32,16 +29,12 @@ type PropTypes = {
 export default function CtaLink(props: PropTypes) {
 
   const accessibilityHintId = props.id ? `accessibility-hint-${props.id}` : uuidv4();
-  const urlString = props.url || '';
 
   return (
     <a
       id={props.id}
       className={classNameWithModifiers('component-cta-link', props.modifierClasses)}
-      href={props.acquisitionData ?
-        addQueryParamToURL(urlString, 'acquisitionData', JSON.stringify(props.acquisitionData))
-         : props.url
-      }
+      href={props.url}
       onClick={props.onClick}
       onKeyPress={props.onClick ? clickSubstituteKeyPressHandler(props.onClick) : null}
       tabIndex={props.tabIndex}
@@ -64,6 +57,5 @@ CtaLink.defaultProps = {
   tabIndex: 0,
   id: null,
   svg: <SvgArrowRightStraight />,
-  acquisitionData: null,
   modifierClasses: [],
 };

--- a/assets/helpers/url.js
+++ b/assets/helpers/url.js
@@ -48,27 +48,6 @@ const getAllQueryParams = (): Array<[string, string]> =>
 const getAllQueryParamsWithExclusions = (excluded: string[]): Array<[string, string]> =>
   getAllQueryParams().filter(p => excluded.indexOf(p[0]) === -1);
 
-const addQueryParamToURL = (urlOrPath: string, paramsKey: string, paramsValue: ?string): string => {
-
-  // We are interested in the query params i.e. the part after the '?'
-  const strParts = urlOrPath.split('?');
-
-  // Save the first part of the urlOrPath and drop it from the strParts array.
-  const strInit = strParts.shift();
-
-  // I concatenate the rest of the array's values since all of them are query params.
-  const params = strParts.reduce((a, b) => `${a}?${b}`, '');
-
-  // Add the new param to the list of params.
-  const paramsObj = new URLSearchParams(params);
-
-  if (paramsValue !== undefined && paramsValue !== null) {
-    paramsObj.set(paramsKey, paramsValue);
-  }
-
-  return `${strInit}?${paramsObj.toString()}`;
-};
-
 // Takes a mapping of query params and adds to an absolute or relative URL.
 function addQueryParamsToURL(
   urlString: string,
@@ -118,7 +97,6 @@ export {
   getQueryParameter,
   getAllQueryParams,
   getAllQueryParamsWithExclusions,
-  addQueryParamToURL,
   getBaseDomain,
   addQueryParamsToURL,
   getAbsoluteURL,


### PR DESCRIPTION
## Why are you doing this?

We have deprecated `addQueryParamToURL` in favour of `addQueryParamsToURL`; this removes it. It also turned out that `acquisitionData` wasn't being passed to `CtaLink` anywhere so I've removed it from the file.

[**Trello Card**](https://trello.com/c/NenDn1H8/1300-replace-addqueryparamtourl)

cc @JustinPinner 

## Changes

- Removed the `acquisitionData` prop from `CtaLink`.
- Deleted `addQueryParamToURL`.
