### PR TITLE
Server side switches

### DIFF
--- a/app/config/Configuration.scala
+++ b/app/config/Configuration.scala
@@ -1,16 +1,14 @@
 package config
 
-import com.gocardless.GoCardlessClient
 import com.gu.support.config.{PayPalConfigProvider, Stage, StripeConfigProvider}
 import com.typesafe.config.ConfigFactory
-import com.typesafe.scalalogging.LazyLogging
 import config.ConfigImplicits._
 import services.GoCardlessConfigProvider
 import services.aws.AwsConfig
 import services.stepfunctions.StateMachineArn
 import switchboard.Switches
 
-class Configuration extends LazyLogging {
+class Configuration {
   val config = ConfigFactory.load()
 
   lazy val stage = Stage.fromString(config.getString("stage")).get
@@ -39,7 +37,7 @@ class Configuration extends LazyLogging {
 
   lazy val oneOffStripeConfigProvider = new StripeConfigProvider(config, stage, "oneOffStripe")
 
-  lazy val stepFuctionArn = StateMachineArn.fromString(config.getString("supportWorkers.arn")).get
+  lazy val stepFunctionArn = StateMachineArn.fromString(config.getString("supportWorkers.arn")).get
 
   implicit val switches = new Switches(config.getConfig("switches"))
 

--- a/app/config/Configuration.scala
+++ b/app/config/Configuration.scala
@@ -3,12 +3,14 @@ package config
 import com.gocardless.GoCardlessClient
 import com.gu.support.config.{PayPalConfigProvider, Stage, StripeConfigProvider}
 import com.typesafe.config.ConfigFactory
+import com.typesafe.scalalogging.LazyLogging
 import config.ConfigImplicits._
 import services.GoCardlessConfigProvider
 import services.aws.AwsConfig
 import services.stepfunctions.StateMachineArn
+import switchboard.Switches
 
-class Configuration {
+class Configuration extends LazyLogging {
   val config = ConfigFactory.load()
 
   lazy val stage = Stage.fromString(config.getString("stage")).get
@@ -38,4 +40,7 @@ class Configuration {
   lazy val oneOffStripeConfigProvider = new StripeConfigProvider(config, stage, "oneOffStripe")
 
   lazy val stepFuctionArn = StateMachineArn.fromString(config.getString("supportWorkers.arn")).get
+
+  implicit val switches = new Switches(config.getConfig("switches"))
+
 }

--- a/app/config/Configuration.scala
+++ b/app/config/Configuration.scala
@@ -39,6 +39,6 @@ class Configuration {
 
   lazy val stepFunctionArn = StateMachineArn.fromString(config.getString("supportWorkers.arn")).get
 
-  implicit val switches = new Switches(config.getConfig("switches"))
+  implicit val switches = Switches.fromConfig(config.getConfig("switches"))
 
 }

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -6,9 +6,9 @@ import com.gu.i18n.CountryGroup._
 import config.StringsConfig
 import play.api.mvc._
 import services.{IdentityService, PaymentAPIService}
+import switchboard.Switches
 import utils.BrowserCheck
 import utils.RequestCountry._
-
 import scala.concurrent.ExecutionContext
 
 class Application(
@@ -17,12 +17,14 @@ class Application(
     identityService: IdentityService,
     components: ControllerComponents,
     paymentAPIService: PaymentAPIService,
-    stringsConfig: StringsConfig
+    stringsConfig: StringsConfig,
+    switches: Switches
 )(implicit val ec: ExecutionContext) extends AbstractController(components) {
 
   import actionRefiners._
 
   implicit val ar = assets
+  implicit val sw = switches
 
   def contributionsRedirect(): Action[AnyContent] = CachedAction() {
     Ok(views.html.contributionsRedirect())

--- a/app/controllers/OneOffContributions.scala
+++ b/app/controllers/OneOffContributions.scala
@@ -15,6 +15,7 @@ import com.gu.identity.play.{AuthenticatedIdUser, IdUser}
 import models.Autofill
 import io.circe.syntax._
 import play.twirl.api.Html
+import switchboard.Switches
 
 class OneOffContributions(
     val assets: AssetsResolver,
@@ -24,12 +25,14 @@ class OneOffContributions(
     stripeConfigProvider: StripeConfigProvider,
     paymentAPIService: PaymentAPIService,
     authAction: AuthAction[AnyContent],
-    components: ControllerComponents
+    components: ControllerComponents,
+    switches: Switches
 )(implicit val exec: ExecutionContext) extends AbstractController(components) with Circe {
 
   import actionRefiners._
 
   implicit val ar = assets
+  implicit val sw = switches
 
   def autofill: Action[AnyContent] = authenticatedAction().async { implicit request =>
     identityService.getUser(request.user).fold(

--- a/app/controllers/PayPalOneOff.scala
+++ b/app/controllers/PayPalOneOff.scala
@@ -10,9 +10,10 @@ import monitoring.SafeLogger._
 import play.api.libs.circe.Circe
 import play.api.libs.json.{JsObject, JsString, JsValue, Json}
 import play.api.mvc._
-
 import services.PaymentAPIService.Email
 import services.{IdentityService, PaymentAPIService, TestUserService}
+import switchboard.Switches
+
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 
@@ -22,12 +23,14 @@ class PayPalOneOff(
     testUsers: TestUserService,
     components: ControllerComponents,
     paymentAPIService: PaymentAPIService,
-    identityService: IdentityService
+    identityService: IdentityService,
+    switches: Switches
 )(implicit val ec: ExecutionContext) extends AbstractController(components) with Circe {
 
   import actionBuilders._
 
   implicit val assetsResolver = assets
+  implicit val sw = switches
 
   def resultFromEmailOption(email: Option[Email]): Result = {
     val redirect = Redirect("/contribute/one-off/thankyou")

--- a/app/controllers/PayPalRegular.scala
+++ b/app/controllers/PayPalRegular.scala
@@ -12,6 +12,7 @@ import play.api.mvc._
 import services.paypal.PayPalBillingDetails.codec
 import services.paypal.{PayPalBillingDetails, PayPalNvpServiceProvider, Token}
 import services.{PayPalNvpService, TestUserService}
+import switchboard.Switches
 
 import scala.concurrent.ExecutionContext
 
@@ -20,12 +21,14 @@ class PayPalRegular(
     assets: AssetsResolver,
     payPalNvpServiceProvider: PayPalNvpServiceProvider,
     testUsers: TestUserService,
-    components: ControllerComponents
+    components: ControllerComponents,
+    switches: Switches
 )(implicit val ec: ExecutionContext) extends AbstractController(components) with Circe {
 
   import actionBuilders._
 
   implicit val assetsResolver = assets
+  implicit val sw = switches
 
   // Sets up a payment by contacting PayPal, returns the token as JSON.
   def setupPayment: Action[PayPalBillingDetails] = authenticatedAction().async(circe.json[PayPalBillingDetails]) { implicit request =>

--- a/app/controllers/RegularContributions.scala
+++ b/app/controllers/RegularContributions.scala
@@ -15,6 +15,7 @@ import play.api.mvc._
 import services.MembersDataService.UserNotFound
 import services.stepfunctions.{CreateRegularContributorRequest, RegularContributionsClient}
 import services.{IdentityService, MembersDataService, TestUserService}
+import switchboard.Switches
 import views.html.monthlyContributions
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -28,12 +29,14 @@ class RegularContributions(
     testUsers: TestUserService,
     stripeConfigProvider: StripeConfigProvider,
     payPalConfigProvider: PayPalConfigProvider,
-    components: ControllerComponents
+    components: ControllerComponents,
+    switches: Switches
 )(implicit val exec: ExecutionContext) extends AbstractController(components) with Circe {
 
   import actionRefiners._
 
   implicit val ar = assets
+  implicit val sw = switches
 
   def displayForm(useNewSignIn: Boolean): Action[AnyContent] =
     authenticatedAction(membersIdentityClientId, useNewSignIn).async { implicit request =>

--- a/app/controllers/Subscriptions.scala
+++ b/app/controllers/Subscriptions.scala
@@ -5,6 +5,7 @@ import assets.AssetsResolver
 import com.gu.i18n.CountryGroup._
 import config.StringsConfig
 import play.api.mvc._
+import switchboard.Switches
 import utils.RequestCountry._
 
 import scala.concurrent.ExecutionContext
@@ -13,12 +14,14 @@ class Subscriptions(
     actionRefiners: CustomActionBuilders,
     val assets: AssetsResolver,
     components: ControllerComponents,
-    stringsConfig: StringsConfig
+    stringsConfig: StringsConfig,
+    switches: Switches
 )(implicit val ec: ExecutionContext) extends AbstractController(components) {
 
   import actionRefiners._
 
   implicit val ar = assets
+  implicit val sw = switches
 
   def geoRedirect: Action[AnyContent] = GeoTargetedCachedAction() { implicit request =>
     val redirectUrl = request.fastlyCountry match {

--- a/app/switchboard/Switches.scala
+++ b/app/switchboard/Switches.scala
@@ -1,0 +1,32 @@
+package switchboard
+
+import com.typesafe.config.Config
+import com.typesafe.scalalogging.LazyLogging
+import switchboard.SwitchState.Off
+
+class Switches(config: Config) {
+  lazy val onOffPaymentMethods: PaymentMethodsSwitch = new PaymentMethodsSwitch(config.getConfig("oneOff"))
+  lazy val recurringPaymentMethods: PaymentMethodsSwitch = new PaymentMethodsSwitch(config.getConfig("recurring"))
+}
+
+class PaymentMethodsSwitch(config: Config) {
+  lazy val stripe: SwitchState = SwitchState.fromString(config.getString("stripe"))
+  lazy val payPal: SwitchState = SwitchState.fromString(config.getString("payPal"))
+  lazy val directDebit: SwitchState =
+    if (config.hasPath("directDebit"))
+      SwitchState.fromString(config.getString("directDebit"))
+    else
+      Off
+}
+
+sealed trait SwitchState
+
+object SwitchState {
+  def fromString(s: String): SwitchState = if (s.toLowerCase == "on") On else Off
+
+  case object On extends SwitchState
+
+  case object Off extends SwitchState
+
+}
+

--- a/app/switchboard/Switches.scala
+++ b/app/switchboard/Switches.scala
@@ -1,22 +1,29 @@
 package switchboard
 
 import com.typesafe.config.Config
-import com.typesafe.scalalogging.LazyLogging
-import switchboard.SwitchState.Off
 
-class Switches(config: Config) {
-  lazy val onOffPaymentMethods: PaymentMethodsSwitch = new PaymentMethodsSwitch(config.getConfig("oneOff"))
-  lazy val recurringPaymentMethods: PaymentMethodsSwitch = new PaymentMethodsSwitch(config.getConfig("recurring"))
+case class Switches(onOffPaymentMethods: PaymentMethodsSwitch, recurringPaymentMethods: PaymentMethodsSwitch)
+
+object Switches {
+  def fromConfig(config: Config): Switches =
+    Switches(
+      PaymentMethodsSwitch.fromConfig(config.getConfig("oneOff")),
+      PaymentMethodsSwitch.fromConfig(config.getConfig("recurring"))
+    )
 }
 
-class PaymentMethodsSwitch(config: Config) {
-  lazy val stripe: SwitchState = SwitchState.fromString(config.getString("stripe"))
-  lazy val payPal: SwitchState = SwitchState.fromString(config.getString("payPal"))
-  lazy val directDebit: SwitchState =
-    if (config.hasPath("directDebit"))
-      SwitchState.fromString(config.getString("directDebit"))
-    else
-      Off
+case class PaymentMethodsSwitch(stripe: SwitchState, payPal: SwitchState, directDebit: Option[SwitchState])
+
+object PaymentMethodsSwitch {
+  def fromConfig(config: Config): PaymentMethodsSwitch =
+    PaymentMethodsSwitch(
+      SwitchState.fromString(config.getString("stripe")),
+      SwitchState.fromString(config.getString("payPal")),
+      if (config.hasPath("directDebit"))
+        Some(SwitchState.fromString(config.getString("directDebit")))
+      else
+        None
+    )
 }
 
 sealed trait SwitchState

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -1,5 +1,6 @@
 @import assets.AssetsResolver
 @import views.ViewHelpers._
+@import switchboard.Switches
 @(
 	title: String,
 	mainId: String,
@@ -8,7 +9,7 @@
 	description: Option[String] = None,
 	styles: Html = Html(""),
 	scripts: Html = Html("")
-)(implicit assets: AssetsResolver, request: RequestHeader)
+)(implicit assets: AssetsResolver, request: RequestHeader, switches: Switches)
 
 <!DOCTYPE html>
 <html lang="en">
@@ -21,6 +22,8 @@
 		<meta name="description" content="@description" />
 		<meta property="og:description" content="@description" />
 	}
+
+	@switchesScript(switches)
 
 	<title>@title</title>
 	<meta property="og:title" content="@title"/>

--- a/app/views/monthlyContributions.scala.html
+++ b/app/views/monthlyContributions.scala.html
@@ -4,6 +4,7 @@
 @import helper.CSRF
 
 @import com.gu.i18n.Currency.AUD
+@import switchboard.Switches
 @(
   title: String,
   id: String,
@@ -14,7 +15,7 @@
   defaultStripeConfig: StripeConfig,
   uatStripeConfig: StripeConfig,
   payPalConfig: PayPalConfig
-)(implicit assets: AssetsResolver, requestHeader: RequestHeader)
+)(implicit assets: AssetsResolver, requestHeader: RequestHeader, switches: Switches)
 
 @scripts = {
     <script type="text/javascript">

--- a/app/views/oneOffContributions.scala.html
+++ b/app/views/oneOffContributions.scala.html
@@ -3,6 +3,7 @@
 @import com.gu.support.config.StripeConfig
 @import helper.CSRF
 @import com.gu.i18n.Currency.AUD
+@import switchboard.Switches
 @(
         title: String,
         id: String,
@@ -13,7 +14,7 @@
         paymentApiStripeEndpoint: String,
         paymentApiPayPalEndpoint: String,
         idUser: Option[IdUser]
-)(implicit assets: AssetsResolver, request: RequestHeader)
+)(implicit assets: AssetsResolver, request: RequestHeader, switches: Switches)
 
 @scripts = {
     <script type="text/javascript">

--- a/app/views/switchesScript.scala.html
+++ b/app/views/switchesScript.scala.html
@@ -1,0 +1,18 @@
+@import switchboard.Switches
+
+@(switches: Switches)
+
+<script type="text/javascript">
+    window.guardian = window.guardian || {};
+    guardian.switches = {
+      oneOffPaymentMethods: {
+        stripe: '@switches.onOffPaymentMethods.stripe',
+        payPal: '@switches.onOffPaymentMethods.payPal',
+      },
+      recurringPaymentMethods: {
+        stripe: '@switches.recurringPaymentMethods.stripe',
+        payPal: '@switches.recurringPaymentMethods.payPal',
+        directDebit: '@switches.recurringPaymentMethods.directDebit',
+      },
+    };
+</script>

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -28,7 +28,8 @@ trait AppComponents extends PlayComponents
     configuration,
     sourceMapper,
     Some(router),
-    assetsResolver
+    assetsResolver,
+    appConfig.switches
   )
 
   override lazy val httpFilters: Seq[EssentialFilter] = Seq(

--- a/app/wiring/ApplicationConfiguration.scala
+++ b/app/wiring/ApplicationConfiguration.scala
@@ -1,6 +1,7 @@
 package wiring
 
 import config.{Configuration, StringsConfig}
+import switchboard.Switches
 
 trait ApplicationConfiguration {
   val appConfig = new Configuration()

--- a/app/wiring/ApplicationConfiguration.scala
+++ b/app/wiring/ApplicationConfiguration.scala
@@ -1,7 +1,6 @@
 package wiring
 
 import config.{Configuration, StringsConfig}
-import switchboard.Switches
 
 trait ApplicationConfiguration {
   val appConfig = new Configuration()

--- a/app/wiring/Controllers.scala
+++ b/app/wiring/Controllers.scala
@@ -14,14 +14,16 @@ trait Controllers {
     identityService,
     controllerComponents,
     paymentAPIService,
-    stringsConfig
+    stringsConfig,
+    appConfig.switches
   )
 
   lazy val subscriptionsController = new Subscriptions(
     actionRefiners,
     assetsResolver,
     controllerComponents,
-    stringsConfig
+    stringsConfig,
+    appConfig.switches
   )
 
   lazy val regularContributionsController = new RegularContributions(
@@ -33,7 +35,8 @@ trait Controllers {
     testUsers,
     appConfig.regularStripeConfigProvider,
     appConfig.regularPayPalConfigProvider,
-    controllerComponents
+    controllerComponents,
+    appConfig.switches
   )
 
   lazy val payPalRegularController = new PayPalRegular(
@@ -41,7 +44,8 @@ trait Controllers {
     assetsResolver,
     payPalNvpServiceProvider,
     testUsers,
-    controllerComponents
+    controllerComponents,
+    appConfig.switches
   )
 
   lazy val payPalOneOffController = new PayPalOneOff(
@@ -50,7 +54,8 @@ trait Controllers {
     testUsers,
     controllerComponents,
     paymentAPIService,
-    identityService
+    identityService,
+    appConfig.switches
   )
 
   lazy val oneOffContributions = new OneOffContributions(
@@ -61,7 +66,8 @@ trait Controllers {
     appConfig.oneOffStripeConfigProvider,
     paymentAPIService,
     authAction,
-    controllerComponents
+    controllerComponents,
+    appConfig.switches
   )
 
   lazy val testUsersController = new TestUsersManagement(

--- a/app/wiring/Services.scala
+++ b/app/wiring/Services.scala
@@ -23,7 +23,7 @@ trait Services {
   lazy val regularContributionsClient = {
     val stateWrapper = new StateWrapper(Encryption.getProvider(appConfig.aws), appConfig.aws.useEncryption)
     RegularContributionsClient(
-      appConfig.stepFuctionArn,
+      appConfig.stepFunctionArn,
       stateWrapper,
       appConfig.supportUrl,
       controllers.routes.RegularContributions.status

--- a/assets/components/paymentButtons/directDebitPopUpButton/directDebitPopUpButton.jsx
+++ b/assets/components/paymentButtons/directDebitPopUpButton/directDebitPopUpButton.jsx
@@ -94,7 +94,7 @@ function Button(props: { openPopUp: () => void }) {
 // ----- Default Props ----- //
 
 DirectDebitPopUpButton.defaultProps = {
-  switchStatus: 'ON',
+  switchStatus: 'On',
 };
 
 

--- a/assets/components/paymentButtons/payPalExpressButton/payPalExpressButton.jsx
+++ b/assets/components/paymentButtons/payPalExpressButton/payPalExpressButton.jsx
@@ -71,7 +71,7 @@ function Button(props: PropTypes) {
 // ----- Default Props ----- //
 
 PayPalExpressButton.defaultProps = {
-  switchStatus: 'ON',
+  switchStatus: 'On',
 };
 
 

--- a/assets/components/paymentButtons/stripePopUpButton/stripePopUpButton.jsx
+++ b/assets/components/paymentButtons/stripePopUpButton/stripePopUpButton.jsx
@@ -88,7 +88,7 @@ function Button(props: PropTypes) {
 StripePopUpButton.defaultProps = {
   canOpen: () => true,
   closeHandler: () => {},
-  switchStatus: 'ON',
+  switchStatus: 'On',
 };
 
 

--- a/assets/components/stripeInlineForm/stripeInlineForm.jsx
+++ b/assets/components/stripeInlineForm/stripeInlineForm.jsx
@@ -153,7 +153,7 @@ const InjectedCheckoutForm = injectStripe(checkoutForm);
 
 StripeInlineForm.defaultProps = {
   canProceed: () => true,
-  switchStatus: 'ON',
+  switchStatus: 'On',
 };
 
 export default StripeInlineForm;

--- a/assets/components/switchable/switchable.jsx
+++ b/assets/components/switchable/switchable.jsx
@@ -20,7 +20,7 @@ type PropTypes = {
 
 function Switchable(props: PropTypes) {
 
-  if (props.status === 'OFF') {
+  if (props.status === 'Off') {
     return <props.fallback />;
   }
 

--- a/assets/containerisableComponents/payPalContributionButton/payPalContributionButton.jsx
+++ b/assets/containerisableComponents/payPalContributionButton/payPalContributionButton.jsx
@@ -100,7 +100,7 @@ PayPalContributionButton.defaultProps = {
   buttonText: 'Pay with PayPal',
   additionalClass: '',
   onClick: null,
-  switchStatus: 'ON',
+  switchStatus: 'On',
 };
 
 

--- a/assets/helpers/page/page.js
+++ b/assets/helpers/page/page.js
@@ -167,7 +167,7 @@ function init<S, A>(
   const countryId: IsoCountry = detectCountry();
   const currencyId: IsoCurrency = detectCurrency(countryGroupId);
   const participations: Participations = abTest.init(countryId, countryGroupId);
-  const { switches } : Switches = guardian;
+  const { switches } = window.guardian;
   analyticsInitialisation(participations);
 
   const initialState: CommonState = buildInitialState(

--- a/assets/helpers/page/page.js
+++ b/assets/helpers/page/page.js
@@ -19,7 +19,6 @@ import type { Participations } from 'helpers/abTests/abtest';
 import type { Switches } from 'helpers/switch';
 import * as logger from 'helpers/logger';
 import * as googleTagManager from 'helpers/tracking/googleTagManager';
-import * as switchHelper from 'helpers/switch';
 import { detect as detectCountry, type IsoCountry } from 'helpers/internationalisation/country';
 import { detect as detectCurrency, type IsoCurrency } from 'helpers/internationalisation/currency';
 import { getAllQueryParamsWithExclusions } from 'helpers/url';
@@ -168,7 +167,7 @@ function init<S, A>(
   const countryId: IsoCountry = detectCountry();
   const currencyId: IsoCurrency = detectCurrency(countryGroupId);
   const participations: Participations = abTest.init(countryId, countryGroupId);
-  const switches: Switches = switchHelper.init();
+  const { switches } : Switches = guardian;
   analyticsInitialisation(participations);
 
   const initialState: CommonState = buildInitialState(

--- a/assets/helpers/switch.js
+++ b/assets/helpers/switch.js
@@ -9,27 +9,3 @@ type SwitchObject = {
 export type Switches = {
   [string]: SwitchObject,
 };
-
-
-// ----- Default state ----- //
-
-const defaultSwitches: Switches = {
-  oneOffPaymentMethods: {
-    stripe: 'ON',
-
-    // === 24-7 ===
-    // Comment the following line and uncomment one after to disable PayPal one-off Flow
-    payPal: 'ON', // 24-7 comment this line
-    // payPal: 'OFF', //24-7 Uncomment this line
-    // === end 24-7 ===
-  },
-  recurringPaymentMethods: {
-    stripe: 'ON',
-    payPal: 'ON',
-    directDebit: 'ON',
-  },
-};
-
-const init: () => Switches = () => defaultSwitches;
-
-export { init };

--- a/assets/helpers/switch.js
+++ b/assets/helpers/switch.js
@@ -1,6 +1,6 @@
 // @flow
 
-export type Status = 'ON' | 'OFF';
+export type Status = 'On' | 'Off';
 
 type SwitchObject = {
   [string]: Status,

--- a/conf/CODE.public.conf
+++ b/conf/CODE.public.conf
@@ -17,3 +17,14 @@ googleAuth.redirectUrl = "https://support.code.dev-theguardian.com/oauth2callbac
 paymentApi.url="https://payment.code.dev-guardianapis.com"
 membersDataService.api.url="https://members-data-api.code.dev-theguardian.com"
 play.filters.headers.contentSecurityPolicy = "default-src 'self' polyfill.guim.co.uk www.paypalobjects.com www.paypal.com www.sandbox.paypal.com js.stripe.com pasteup.guim.co.uk ophan.theguardian.com j.ophan.co.uk media.guim.co.uk www.google-analytics.com www.googletagmanager.com tagmanager.google.com www.googleadservices.com googleads.g.doubleclick.net www.google.com www.google.co.uk optimize.google.com static.ads-twitter.com bat.bing.com bid.g.doubleclick.net t.co analytics.twitter.com stats.g.doubleclick.net www.youtube.com connect.facebook.net www.facebook.com consumer.krxd.net cdn.krxd.net beacon.krxd.net secure.adnxs.com checkout.stripe.com fonts.googleapis.com ssl.gstatic.com www.gstatic.com fonts.gstatic.com sentry.io data: wss: 'unsafe-inline' q.stripe.com payment.code.dev-guardianapis.com"
+switches {
+  oneOff {
+    stripe=On
+    payPal=On
+  }
+  recurring {
+    stripe=On
+    payPal=On
+    directDebit=On
+  }
+}

--- a/conf/CODE.public.conf
+++ b/conf/CODE.public.conf
@@ -17,11 +17,18 @@ googleAuth.redirectUrl = "https://support.code.dev-theguardian.com/oauth2callbac
 paymentApi.url="https://payment.code.dev-guardianapis.com"
 membersDataService.api.url="https://members-data-api.code.dev-theguardian.com"
 play.filters.headers.contentSecurityPolicy = "default-src 'self' polyfill.guim.co.uk www.paypalobjects.com www.paypal.com www.sandbox.paypal.com js.stripe.com pasteup.guim.co.uk ophan.theguardian.com j.ophan.co.uk media.guim.co.uk www.google-analytics.com www.googletagmanager.com tagmanager.google.com www.googleadservices.com googleads.g.doubleclick.net www.google.com www.google.co.uk optimize.google.com static.ads-twitter.com bat.bing.com bid.g.doubleclick.net t.co analytics.twitter.com stats.g.doubleclick.net www.youtube.com connect.facebook.net www.facebook.com consumer.krxd.net cdn.krxd.net beacon.krxd.net secure.adnxs.com checkout.stripe.com fonts.googleapis.com ssl.gstatic.com www.gstatic.com fonts.gstatic.com sentry.io data: wss: 'unsafe-inline' q.stripe.com payment.code.dev-guardianapis.com"
+
+// ------------------------ Feature switches ----------------------------
+// To disable a feature change the value from On to Off and redeploy the app.
+// To override a value for local development change it in your private conf file
+// /etc/gu/support-frontend.private.conf and that value will be used instead.
 switches {
+  //Payment methods for one-off contributions
   oneOff {
     stripe=On
     payPal=On
   }
+  //Payment methods for recurring contributions
   recurring {
     stripe=On
     payPal=On

--- a/conf/DEV.public.conf
+++ b/conf/DEV.public.conf
@@ -19,7 +19,6 @@ membersDataService.api.url="https://members-data-api.thegulocal.com"
 play.filters.headers.contentSecurityPolicy = "default-src 'self' polyfill.guim.co.uk www.paypalobjects.com www.paypal.com www.sandbox.paypal.com js.stripe.com pasteup.guim.co.uk ophan.theguardian.com j.ophan.co.uk media.guim.co.uk www.google-analytics.com www.googletagmanager.com tagmanager.google.com www.googleadservices.com googleads.g.doubleclick.net www.google.com www.google.co.uk optimize.google.com static.ads-twitter.com bat.bing.com bid.g.doubleclick.net t.co analytics.twitter.com stats.g.doubleclick.net www.youtube.com connect.facebook.net www.facebook.com consumer.krxd.net cdn.krxd.net beacon.krxd.net secure.adnxs.com checkout.stripe.com fonts.googleapis.com ssl.gstatic.com www.gstatic.com fonts.gstatic.com sentry.io data: wss: 'unsafe-inline' 'unsafe-eval'  q.stripe.com payment.code.dev-guardianapis.com"
 
 // ------------------------ Feature switches ----------------------------
-// To disable a feature change the value from On to Off and redeploy the app.
 // To override a value for local development change it in your private conf file
 // /etc/gu/support-frontend.private.conf and that value will be used instead.
 switches {

--- a/conf/DEV.public.conf
+++ b/conf/DEV.public.conf
@@ -17,14 +17,22 @@ googleAuth.redirectUrl = "https://support.thegulocal.com/oauth2callback"
 paymentApi.url="https://payment.code.dev-guardianapis.com"
 membersDataService.api.url="https://members-data-api.thegulocal.com"
 play.filters.headers.contentSecurityPolicy = "default-src 'self' polyfill.guim.co.uk www.paypalobjects.com www.paypal.com www.sandbox.paypal.com js.stripe.com pasteup.guim.co.uk ophan.theguardian.com j.ophan.co.uk media.guim.co.uk www.google-analytics.com www.googletagmanager.com tagmanager.google.com www.googleadservices.com googleads.g.doubleclick.net www.google.com www.google.co.uk optimize.google.com static.ads-twitter.com bat.bing.com bid.g.doubleclick.net t.co analytics.twitter.com stats.g.doubleclick.net www.youtube.com connect.facebook.net www.facebook.com consumer.krxd.net cdn.krxd.net beacon.krxd.net secure.adnxs.com checkout.stripe.com fonts.googleapis.com ssl.gstatic.com www.gstatic.com fonts.gstatic.com sentry.io data: wss: 'unsafe-inline' 'unsafe-eval'  q.stripe.com payment.code.dev-guardianapis.com"
+
+// ------------------------ Feature switches ----------------------------
+// To disable a feature change the value from On to Off and redeploy the app.
+// To override a value for local development change it in your private conf file
+// /etc/gu/support-frontend.private.conf and that value will be used instead.
 switches {
+  //Payment methods for one-off contributions
   oneOff {
     stripe=On
     payPal=On
   }
+  //Payment methods for recurring contributions
   recurring {
     stripe=On
     payPal=On
     directDebit=On
   }
 }
+

--- a/conf/DEV.public.conf
+++ b/conf/DEV.public.conf
@@ -17,3 +17,14 @@ googleAuth.redirectUrl = "https://support.thegulocal.com/oauth2callback"
 paymentApi.url="https://payment.code.dev-guardianapis.com"
 membersDataService.api.url="https://members-data-api.thegulocal.com"
 play.filters.headers.contentSecurityPolicy = "default-src 'self' polyfill.guim.co.uk www.paypalobjects.com www.paypal.com www.sandbox.paypal.com js.stripe.com pasteup.guim.co.uk ophan.theguardian.com j.ophan.co.uk media.guim.co.uk www.google-analytics.com www.googletagmanager.com tagmanager.google.com www.googleadservices.com googleads.g.doubleclick.net www.google.com www.google.co.uk optimize.google.com static.ads-twitter.com bat.bing.com bid.g.doubleclick.net t.co analytics.twitter.com stats.g.doubleclick.net www.youtube.com connect.facebook.net www.facebook.com consumer.krxd.net cdn.krxd.net beacon.krxd.net secure.adnxs.com checkout.stripe.com fonts.googleapis.com ssl.gstatic.com www.gstatic.com fonts.gstatic.com sentry.io data: wss: 'unsafe-inline' 'unsafe-eval'  q.stripe.com payment.code.dev-guardianapis.com"
+switches {
+  oneOff {
+    stripe=On
+    payPal=On
+  }
+  recurring {
+    stripe=On
+    payPal=On
+    directDebit=On
+  }
+}

--- a/conf/PROD.public.conf
+++ b/conf/PROD.public.conf
@@ -16,14 +16,22 @@ googleAuth.redirectUrl = "https://support.theguardian.com/oauth2callback"
 paymentApi.url="https://payment.guardianapis.com"
 membersDataService.api.url="https://members-data-api.theguardian.com"
 play.filters.headers.contentSecurityPolicy = "default-src 'self' polyfill.guim.co.uk www.paypalobjects.com www.paypal.com www.sandbox.paypal.com js.stripe.com pasteup.guim.co.uk ophan.theguardian.com j.ophan.co.uk media.guim.co.uk www.google-analytics.com www.googletagmanager.com tagmanager.google.com www.googleadservices.com googleads.g.doubleclick.net www.google.com www.google.co.uk optimize.google.com static.ads-twitter.com bat.bing.com bid.g.doubleclick.net t.co analytics.twitter.com stats.g.doubleclick.net www.youtube.com connect.facebook.net www.facebook.com consumer.krxd.net cdn.krxd.net beacon.krxd.net secure.adnxs.com checkout.stripe.com fonts.googleapis.com ssl.gstatic.com www.gstatic.com fonts.gstatic.com sentry.io data: wss: 'unsafe-inline' q.stripe.com payment.guardianapis.com"
+
+// ------------------------ Feature switches ----------------------------
+// To disable a feature change the value from On to Off and redeploy the app.
+// To override a value for local development change it in your private conf file
+// /etc/gu/support-frontend.private.conf and that value will be used instead.
 switches {
+  //Payment methods for one-off contributions
   oneOff {
     stripe=On
     payPal=On
   }
+  //Payment methods for recurring contributions
   recurring {
     stripe=On
     payPal=On
     directDebit=On
   }
 }
+

--- a/conf/PROD.public.conf
+++ b/conf/PROD.public.conf
@@ -16,3 +16,14 @@ googleAuth.redirectUrl = "https://support.theguardian.com/oauth2callback"
 paymentApi.url="https://payment.guardianapis.com"
 membersDataService.api.url="https://members-data-api.theguardian.com"
 play.filters.headers.contentSecurityPolicy = "default-src 'self' polyfill.guim.co.uk www.paypalobjects.com www.paypal.com www.sandbox.paypal.com js.stripe.com pasteup.guim.co.uk ophan.theguardian.com j.ophan.co.uk media.guim.co.uk www.google-analytics.com www.googletagmanager.com tagmanager.google.com www.googleadservices.com googleads.g.doubleclick.net www.google.com www.google.co.uk optimize.google.com static.ads-twitter.com bat.bing.com bid.g.doubleclick.net t.co analytics.twitter.com stats.g.doubleclick.net www.youtube.com connect.facebook.net www.facebook.com consumer.krxd.net cdn.krxd.net beacon.krxd.net secure.adnxs.com checkout.stripe.com fonts.googleapis.com ssl.gstatic.com www.gstatic.com fonts.gstatic.com sentry.io data: wss: 'unsafe-inline' q.stripe.com payment.guardianapis.com"
+switches {
+  oneOff {
+    stripe=On
+    payPal=On
+  }
+  recurring {
+    stripe=On
+    payPal=On
+    directDebit=On
+  }
+}

--- a/conf/PROD.public.conf
+++ b/conf/PROD.public.conf
@@ -17,10 +17,11 @@ paymentApi.url="https://payment.guardianapis.com"
 membersDataService.api.url="https://members-data-api.theguardian.com"
 play.filters.headers.contentSecurityPolicy = "default-src 'self' polyfill.guim.co.uk www.paypalobjects.com www.paypal.com www.sandbox.paypal.com js.stripe.com pasteup.guim.co.uk ophan.theguardian.com j.ophan.co.uk media.guim.co.uk www.google-analytics.com www.googletagmanager.com tagmanager.google.com www.googleadservices.com googleads.g.doubleclick.net www.google.com www.google.co.uk optimize.google.com static.ads-twitter.com bat.bing.com bid.g.doubleclick.net t.co analytics.twitter.com stats.g.doubleclick.net www.youtube.com connect.facebook.net www.facebook.com consumer.krxd.net cdn.krxd.net beacon.krxd.net secure.adnxs.com checkout.stripe.com fonts.googleapis.com ssl.gstatic.com www.gstatic.com fonts.gstatic.com sentry.io data: wss: 'unsafe-inline' q.stripe.com payment.guardianapis.com"
 
-// ------------------------ Feature switches ----------------------------
-// To disable a feature change the value from On to Off and redeploy the app.
-// To override a value for local development change it in your private conf file
-// /etc/gu/support-frontend.private.conf and that value will be used instead.
+// ---------------------------Feature switches---------------------------
+// -----------------------------24/7 Support-----------------------------
+// To disable a feature change the value from On to Off and redeploy
+// the app using Riff Raff
+// -----------------------------24/7 Support-----------------------------
 switches {
   //Payment methods for one-off contributions
   oneOff {

--- a/test/controllers/ApplicationTest.scala
+++ b/test/controllers/ApplicationTest.scala
@@ -11,7 +11,8 @@ import com.gu.identity.play.AuthenticatedIdUser
 import config.StringsConfig
 import fixtures.TestCSRFComponents
 import org.scalatest.mockito.MockitoSugar.mock
-import services.{HttpIdentityService, TestUserService, PaymentAPIService}
+import services.{HttpIdentityService, PaymentAPIService, TestUserService}
+import switchboard.Switches
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
@@ -35,14 +36,14 @@ class ApplicationTest extends WordSpec with MustMatchers with TestCSRFComponents
   "/healthcheck" should {
     "return healthy" in {
       val result = new Application(
-        actionRefiner, mock[AssetsResolver], mock[HttpIdentityService], stubControllerComponents(), mock[PaymentAPIService], mock[StringsConfig]
+        actionRefiner, mock[AssetsResolver], mock[HttpIdentityService], stubControllerComponents(), mock[PaymentAPIService], mock[StringsConfig], mock[Switches]
       )(mock[ExecutionContext]).healthcheck.apply(FakeRequest())
       contentAsString(result) mustBe "healthy"
     }
 
     "not be cached" in {
       val result = new Application(
-        actionRefiner, mock[AssetsResolver], mock[HttpIdentityService], stubControllerComponents(), mock[PaymentAPIService], mock[StringsConfig]
+        actionRefiner, mock[AssetsResolver], mock[HttpIdentityService], stubControllerComponents(), mock[PaymentAPIService], mock[StringsConfig], mock[Switches]
       )(mock[ExecutionContext]).healthcheck.apply(FakeRequest())
       header("Cache-Control", result) mustBe Some("no-cache, private")
     }

--- a/test/controllers/OneOffContributionsTest.scala
+++ b/test/controllers/OneOffContributionsTest.scala
@@ -22,6 +22,7 @@ import services.{HttpIdentityService, PaymentAPIService, TestUserService}
 import com.gu.support.config.StripeConfigProvider
 import fixtures.TestCSRFComponents
 import play.api.libs.json.JsString
+import switchboard.Switches
 
 class OneOffContributionsTest extends WordSpec with MustMatchers with TestCSRFComponents {
 
@@ -90,7 +91,8 @@ class OneOffContributionsTest extends WordSpec with MustMatchers with TestCSRFCo
           mock[StripeConfigProvider],
           mock[PaymentAPIService],
           mock[AuthAction[AnyContent]],
-          stubControllerComponents()
+          stubControllerComponents(),
+          mock[Switches]
         ).autofill(FakeRequest())
       }
     }

--- a/test/controllers/RegularContributionsTest.scala
+++ b/test/controllers/RegularContributionsTest.scala
@@ -23,6 +23,8 @@ import services.{HttpIdentityService, MembersDataService, TestUserService}
 import services.MembersDataService._
 import com.gu.support.config._
 import fixtures.TestCSRFComponents
+import switchboard.SwitchState.On
+import switchboard.{PaymentMethodsSwitch, Switches}
 
 class RegularContributionsTest extends WordSpec with MustMatchers with TestCSRFComponents {
 
@@ -157,7 +159,8 @@ class RegularContributionsTest extends WordSpec with MustMatchers with TestCSRFC
           testUsers,
           stripeConfigProvider,
           payPalConfigProvider,
-          stubControllerComponents()
+          stubControllerComponents(),
+          Switches(PaymentMethodsSwitch(On, On, None), PaymentMethodsSwitch(On, On, Some(On)))
         ).displayForm(false)(FakeRequest())
       }
     }


### PR DESCRIPTION
## Why are you doing this?
The switch board we currently have is client side only, this means that we are unable to switch out any part of the app at the server level and also that it is hard to switch out client side code which loads very early in the page such as Google Optimize tags.

This PR adds in a server side layer to the switch board which is driven from the config files to enable us to easily configure it on a per environment basis or on a person by person basis for developers.

The config that is loaded on the server is written into the page as Javascript variables so client and server are in sync and the client side logic for swapping out components is basically untouched.

The new config is in the stage specific public conf files and looks like this:
```
switches {
  oneOff {
    stripe=On
    payPal=On
  }
  recurring {
    stripe=On
    payPal=On
    directDebit=On
  }
}
```

If you want to override a value for local development you can do so in your private conf file `/etc/gu/support-frontend.private.conf` and that value will be used instead.

[**Trello Card**](https://trello.com/c/BXe05nSk/1755-make-switchboard-work-for-server-side-config)


