### PR TITLE
Optimize switch

### DIFF
--- a/app/switchboard/Switches.scala
+++ b/app/switchboard/Switches.scala
@@ -2,13 +2,14 @@ package switchboard
 
 import com.typesafe.config.Config
 
-case class Switches(onOffPaymentMethods: PaymentMethodsSwitch, recurringPaymentMethods: PaymentMethodsSwitch)
+case class Switches(onOffPaymentMethods: PaymentMethodsSwitch, recurringPaymentMethods: PaymentMethodsSwitch, optimize: SwitchState)
 
 object Switches {
   def fromConfig(config: Config): Switches =
     Switches(
       PaymentMethodsSwitch.fromConfig(config.getConfig("oneOff")),
-      PaymentMethodsSwitch.fromConfig(config.getConfig("recurring"))
+      PaymentMethodsSwitch.fromConfig(config.getConfig("recurring")),
+      SwitchState.fromString(config.getString("optimize"))
     )
 }
 

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -28,26 +28,7 @@
 	<title>@title</title>
 	<meta property="og:title" content="@title"/>
 
-	<!--- Optimize scripts, see: https://support.google.com/optimize/answer/7359264 -->
-	<!-- Page-hiding snippet -->
-	<style>.async-hide { opacity: 0 !important} </style>
-	<script>(function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;
-	h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
-	(a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;
-	})(window,document.documentElement,'async-hide','dataLayer',4000,
-	{'GTM-NZGXNBL':true});</script>
-
-	<!-- Modified Analytics tracking code with Optimize plugin -->
-	<script>
-	  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-	  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-	  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-	  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-	  ga('create', 'UA-51507017-5', 'auto', {cookieDomain: 'auto', anonymizeIp: true});
-	  ga('require', 'GTM-NZGXNBL');
-	</script>
-	<!-- End Optimize -->
+	@optimizeScript()
 
 	<link rel="stylesheet" href="@assets(mainStyleBundle)">
 	<link rel="shortcut icon" type="image/png" href="@assets("images/favicons/32x32.ico")">

--- a/app/views/optimizeScript.scala.html
+++ b/app/views/optimizeScript.scala.html
@@ -1,0 +1,12 @@
+@import assets.AssetsResolver
+@import switchboard.Switches
+@import switchboard.SwitchState
+@()(implicit assets: AssetsResolver, switches: Switches)
+@if(switches.optimize == SwitchState.On) {
+    <!--- Optimize scripts, see: https://support.google.com/optimize/answer/7359264 -->
+    <!-- Page-hiding snippet -->
+    <style>.async-hide {
+        opacity: 0 !important
+    } </style>
+    <script async type="text/javascript" src="@assets("optimize.js")"></script>
+}

--- a/app/views/switchesScript.scala.html
+++ b/app/views/switchesScript.scala.html
@@ -14,5 +14,6 @@
         payPal: '@switches.recurringPaymentMethods.payPal',
         directDebit: '@switches.recurringPaymentMethods.directDebit',
       },
+      optimize: '@switches.optimize',
     };
 </script>

--- a/app/wiring/ApplicationConfiguration.scala
+++ b/app/wiring/ApplicationConfiguration.scala
@@ -1,6 +1,7 @@
 package wiring
 
 import config.{Configuration, StringsConfig}
+import switchboard.Switches
 
 trait ApplicationConfiguration {
   val appConfig = new Configuration()

--- a/app/wiring/ApplicationConfiguration.scala
+++ b/app/wiring/ApplicationConfiguration.scala
@@ -1,7 +1,6 @@
 package wiring
 
 import config.{Configuration, StringsConfig}
-import switchboard.Switches
 
 trait ApplicationConfiguration {
   val appConfig = new Configuration()

--- a/assets/helpers/tracking/optimize.js
+++ b/assets/helpers/tracking/optimize.js
@@ -1,0 +1,15 @@
+/* eslint-disable */
+(function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;
+  h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
+  (a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;
+})(window,document.documentElement,'async-hide','dataLayer',4000,
+  {'GTM-NZGXNBL':true});
+
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+ga('create', 'UA-51507017-5', 'auto', {cookieDomain: 'auto', anonymizeIp: true});
+ga('require', 'GTM-NZGXNBL');
+/* eslint-enable */

--- a/conf/CODE.public.conf
+++ b/conf/CODE.public.conf
@@ -34,4 +34,6 @@ switches {
     payPal=On
     directDebit=On
   }
+  //Google Optimize tags
+  optimize=On
 }

--- a/conf/DEV.public.conf
+++ b/conf/DEV.public.conf
@@ -33,5 +33,7 @@ switches {
     payPal=On
     directDebit=On
   }
+  //Google Optimize tags
+  optimize=Off
 }
 

--- a/conf/PROD.public.conf
+++ b/conf/PROD.public.conf
@@ -34,5 +34,7 @@ switches {
     payPal=On
     directDebit=On
   }
+  //Google Optimize tags
+  optimize=On
 }
 

--- a/test/controllers/RegularContributionsTest.scala
+++ b/test/controllers/RegularContributionsTest.scala
@@ -160,7 +160,7 @@ class RegularContributionsTest extends WordSpec with MustMatchers with TestCSRFC
           stripeConfigProvider,
           payPalConfigProvider,
           stubControllerComponents(),
-          Switches(PaymentMethodsSwitch(On, On, None), PaymentMethodsSwitch(On, On, Some(On)))
+          Switches(PaymentMethodsSwitch(On, On, None), PaymentMethodsSwitch(On, On, Some(On)), On)
         ).displayForm(false)(FakeRequest())
       }
     }

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -39,6 +39,7 @@ module.exports = (cssFilename, outputFilename, minimizeCss) => ({
     payPalErrorPage: 'pages/paypal-error/payPalError.jsx',
     payPalErrorPageStyles: 'pages/paypal-error/payPalError.scss',
     googleTagManagerScript: 'helpers/tracking/googleTagManagerScript.js',
+    optimize: 'helpers/tracking/optimize.js',
     error404Page: 'pages/error/error404.jsx',
     error500Page: 'pages/error/error500.jsx',
     errorPageStyles: 'pages/error/error.scss',


### PR DESCRIPTION
## Why are you doing this?
Depends on: https://github.com/guardian/support-frontend/pull/757

To enable us to switch off Google Optimize if we decide to, either for performance reasons or if it causes any unexpected issues. It also switches Optimize off by default in DEV to avoid confusion during development.


[**Trello Card**](https://trello.com/c/BZjieC3Q/1753-make-optimize-configurable-by-the-switchboard)

## Changes

* Add an `optimize` switch to the Switches object and stage configs.
* Move the Google Optimize tag into a separate Twirl fragment and js file and only include these in the page when `optimize=On`.
