### PR TITLE
WIP - handle payment already done error as success

### DIFF
--- a/app/codecs/CirceDecoders.scala
+++ b/app/codecs/CirceDecoders.scala
@@ -2,7 +2,7 @@ package codecs
 
 import com.gu.i18n.{Country, CountryGroup, Currency}
 import com.gu.support.workers.model._
-import io.circe.{Decoder, Encoder, Json}
+import io.circe.{Decoder, Encoder, Json, ObjectEncoder}
 import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
 import com.gu.support.workers.model.monthlyContributions.Contribution
 import com.gu.support.workers.model.monthlyContributions.state.{CompletedState, CreatePaymentMethodState, FailureHandlerState}
@@ -16,7 +16,10 @@ import com.gu.support.workers.model.monthlyContributions.Status
 import ophan.thrift.event.{AbTest, AcquisitionSource}
 import com.gu.fezziwig.CirceScroogeMacros.{decodeThriftEnum, decodeThriftStruct, encodeThriftEnum, encodeThriftStruct}
 import ophan.thrift.componentEvent.ComponentType
-import services.PaypalApiError
+import play.shaded.ahc.io.netty.handler.codec.serialization.ObjectDecoder
+import services.{MyError, PaypalApiError, StripeApiError}
+
+import scala.reflect.{ClassTag, classTag}
 
 object CirceDecoders {
 
@@ -42,7 +45,6 @@ object CirceDecoders {
   implicit val payPalPaymentFieldsCodec: Codec[PayPalPaymentFields] = deriveCodec
   implicit val stripePaymentFieldsCodec: Codec[StripePaymentFields] = deriveCodec
   implicit val directDebitPaymentFieldsCodec: Codec[DirectDebitPaymentFields] = deriveCodec
-  implicit val paypalApiErrorCodec: Codec[PaypalApiError] = deriveCodec
 
   implicit val encodePaymentFields: Encoder[PaymentFields] = new Encoder[PaymentFields] {
     override final def apply(a: PaymentFields): Json = a match {
@@ -83,5 +85,17 @@ object CirceDecoders {
   implicit val createPaymentMethodStateCodec: Codec[CreatePaymentMethodState] = deriveCodec
   implicit val failureHandlerStateCodec: Codec[FailureHandlerState] = deriveCodec
   implicit val completedStateCodec: Codec[CompletedState] = deriveCodec
+
+  //Payment Errors are received form Payment-API
+  implicit val stripeApiErrorCodec: Codec[StripeApiError] = deriveCodec
+  implicit val paypalApiErrorCodec: Codec[PaypalApiError] = deriveCodec
+
+  // case class MyError(error: Exception, responseType: String)
+
+  //implicit val errorCodec: Codec[MyError] = deriveCodec
+
+  //case class Error[A](error: A)
+
+  //implicit val errorCodec: Codec[Error[A]] = deriveCodec[Error[A]]
 }
 

--- a/app/codecs/CirceDecoders.scala
+++ b/app/codecs/CirceDecoders.scala
@@ -16,6 +16,7 @@ import com.gu.support.workers.model.monthlyContributions.Status
 import ophan.thrift.event.{AbTest, AcquisitionSource}
 import com.gu.fezziwig.CirceScroogeMacros.{decodeThriftEnum, decodeThriftStruct, encodeThriftEnum, encodeThriftStruct}
 import ophan.thrift.componentEvent.ComponentType
+import services.PaypalApiError
 
 object CirceDecoders {
 
@@ -41,6 +42,7 @@ object CirceDecoders {
   implicit val payPalPaymentFieldsCodec: Codec[PayPalPaymentFields] = deriveCodec
   implicit val stripePaymentFieldsCodec: Codec[StripePaymentFields] = deriveCodec
   implicit val directDebitPaymentFieldsCodec: Codec[DirectDebitPaymentFields] = deriveCodec
+  implicit val paypalApiErrorCodec: Codec[PaypalApiError] = deriveCodec
 
   implicit val encodePaymentFields: Encoder[PaymentFields] = new Encoder[PaymentFields] {
     override final def apply(a: PaymentFields): Json = a match {

--- a/app/services/PaymentAPIService.scala
+++ b/app/services/PaymentAPIService.scala
@@ -6,6 +6,7 @@ import com.typesafe.scalalogging.LazyLogging
 import io.circe.generic.JsonCodec
 import io.circe.parser.parse
 import codecs.CirceDecoders._
+import io.circe.{Json, ParsingFailure}
 import play.api.libs.json._
 import play.api.libs.ws.{WSClient, WSResponse}
 import services.ExecutePaymentBody._
@@ -19,12 +20,33 @@ case class ExecutePaymentBody(
     paymentData: JsObject
 )
 
+@JsonCodec case class MyError(error: String, responseType: String)
+
+object MyError {
+
+  def apply(error: PaypalApiError, responseType: String): MyError = {
+    MyError(error, responseType)
+  }
+
+  def apply(error: StripeApiError, responseType: String): MyError = {
+    MyError(error, responseType)
+  }
+}
+
+@JsonCodec case class StripeApiError(exceptionType: Option[String], responseCode: Option[Int], requestId: Option[String], message: String) extends Exception {
+  override val getMessage: String = message
+}
+
 @JsonCodec case class PaypalApiError(responseCode: Option[Int], errorName: Option[String], message: String) extends Exception {
   override val getMessage: String = message
 }
 
+//@JsonCodec case class Success[A](data: A)
+
+@JsonCodec case class Error[A](error: A)
+
 object ExecutePaymentBody {
-  implicit val jf: OFormat[ExecutePaymentBody] = Json.format[ExecutePaymentBody]
+  // implicit val jf: OFormat[ExecutePaymentBody] = Json.format[ExecutePaymentBody]
 }
 
 object PaymentAPIService {
@@ -61,25 +83,35 @@ class PaymentAPIService(wsClient: WSClient, paymentAPIUrl: String) extends LazyL
     wsClient.url(payPalExecutePaymentEndpoint)
       .withQueryStringParameters(convertQueryString(allQueryParams): _*)
       .withHttpHeaders("Accept" -> "application/json")
-      .withBody(Json.toJson(data))
+      //.withBody(Json.toJson(data))
       .withMethod("POST")
       .execute()
   }
 
   def isPaymentSuccessful(response: WSResponse): Boolean = {
+    logger.info(s"response returned: ${response.toString}\n" +
+      s"\n status: ${response.status}\n" +
+      s"body toString: ${response.body}\n" +
+      s"body: ${parse(response.json.toString()).toOption.get.asString}")
     response match {
-      case r: WSResponse => r.status == 200
       case r: WSResponse if r.status == 400 => {
-        val paypalAPIError: Option[PaypalApiError] = paypalApiErrorCodec.decodeJson(parse(r.json.toString()).toOption.get).right.toOption
-        paypalAPIError match {
+        val body = r.body
+        logger.info(s"body as string is: ${r.body}")
+        val bodyJson = parse(body)
+        logger.error(s"parsing bodyJson failure? ${bodyJson.isLeft}  message: ${bodyJson.left.get.message}")
+        val errorJsonOpt = bodyJson.right.toOption.flatMap(_.\\("error").headOption)
+        val errorJson = errorJsonOpt.getOrElse(Json.Null)
+        val apiError = paypalApiErrorCodec.decodeJson(errorJson).toOption
+        logger.error(s"apiError is equal to: ${apiError.getOrElse("not defined")}")
+        apiError match {
           case Some(err) => {
-            logger.error(s"PaypalAPIError returned of type: ${err.errorName}")
+            logger.error(s"Payment error is PaypalApiError of type ${err.errorName}")
             err.errorName.contains("PAYMENT_ALREADY_DONE")
           }
-          case None => false
-
+          case _ => false
         }
       }
+      case r: WSResponse => r.status == 200
       case _ => false
     }
   }

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,8 @@ packageSummary := "Support Play APP"
 
 scalaVersion := "2.12.4"
 
+addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
+
 import scala.sys.process._
 
 def env(key: String, default: String): String = Option(System.getenv(key)).getOrElse(default)


### PR DESCRIPTION
WIP - don't approve yet - suggestions always welcome though. 
Currently we are getting a sporadic PAYMENT_ALREADY_DONE errors when a user makes a paypal payment. This results in the user seeing a payment failed message, even though we have actually taken the payment from them.
This change will handle this particular error as though it was a success - passing the user on to the thank-you page.
