### PR TITLE
Turn on 2 step sign in test, and send new client id to identity

### DIFF
--- a/app/actions/CustomActionBuilders.scala
+++ b/app/actions/CustomActionBuilders.scala
@@ -40,15 +40,20 @@ class CustomActionBuilders(
   // Prevents the identity validation email sending users back to our checkout.
   private val idSkipValidationReturn: (String, String) = "skipValidationReturn" -> "true"
 
-  private def idWebAppRegisterUrl(path: String, clientId: String, idWebAppRegisterPath: String): String =
-    idWebAppUrl / idWebAppRegisterPath ? ("returnUrl" -> s"$supportUrl$path") & idSkipConfirmation & idSkipValidationReturn & "clientId" -> clientId
+  private def idWebAppRegisterUrl(path: String, clientId: String, idWebAppRegisterPath: String, campaignCode: Option[String]): String =
+    idWebAppUrl / idWebAppRegisterPath ?
+      ("returnUrl" -> s"$supportUrl$path") &
+      idSkipConfirmation &
+      idSkipValidationReturn &
+      "clientId" -> clientId &
+      "INTCMP" -> campaignCode
 
   def chooseRegister(identityClientId: String): RequestHeader => Result = request => {
-    SeeOther(idWebAppRegisterUrl(request.uri, identityClientId, "register"))
+    SeeOther(idWebAppRegisterUrl(request.uri, identityClientId, "register", Some("recurring-contributions-control")))
   }
 
   def chooseSignInStart(identityClientId: String): RequestHeader => Result = request => {
-    SeeOther(idWebAppRegisterUrl(request.uri, identityClientId, "signin/start"))
+    SeeOther(idWebAppRegisterUrl(request.uri, identityClientId, "signin/start", Some("recurring-contributions-variant")))
   }
 
   private def maybeAuthenticated(onUnauthenticated: RequestHeader => Result): ActionBuilder[OptionalAuthRequest, AnyContent] =

--- a/app/controllers/RegularContributions.scala
+++ b/app/controllers/RegularContributions.scala
@@ -39,7 +39,7 @@ class RegularContributions(
   implicit val sw = switches
 
   def displayForm(useNewSignIn: Boolean): Action[AnyContent] =
-    authenticatedAction(membersIdentityClientId, useNewSignIn).async { implicit request =>
+    authenticatedAction(recurringIdentityClientId, useNewSignIn).async { implicit request =>
       identityService.getUser(request.user).semiflatMap { fullUser =>
         isMonthlyContributor(request.user.credentials) map {
           case Some(true) =>

--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -68,7 +68,7 @@ export const tests: Tests = {
         size: 1,
       },
     },
-    isActive: false,
+    isActive: true,
     independent: true,
     seed: 1,
   },


### PR DESCRIPTION
## Why are you doing this?

This PR does 2 things:

1) Send new client ID to identity. To see the effects of the new `recurringContributions` clientID, check out [this PR](https://github.com/guardian/identity-frontend/pull/427) on `identity-frontend`.

2) Turn on the 2 step sign in test. To see the effects of this test, see [this PR](https://github.com/guardian/support-frontend/pull/739) in `support-frontend`.

@guardian/contributions 



If you merge this, you should check:

a) that hitting identity with the `recurringContributions` clientId results in exactly the behaviour described in the PR

b) that the control in the test boots you to `/register` and that the variant boots you to `/signin/start`. You should sit down with Katya and test it on CODE to validate that it is working correctly for all paths