### PR TITLE
Switch on product test

### DIFF
--- a/app/controllers/Subscriptions.scala
+++ b/app/controllers/Subscriptions.scala
@@ -49,15 +49,11 @@ class Subscriptions(
   }
 
   def digital(countryCode: String): Action[AnyContent] = CachedAction() { implicit request =>
-    if (request.getQueryString("digiSub").contains("true")) {
-      val title = "Support the Guardian | Digital Subscription"
-      val id = "digital-subscription-landing-page-" + countryCode
-      val js = "digitalSubscriptionLandingPage.js"
-      val css = "digitalSubscriptionLandingPageStyles.css"
-      Ok(views.html.main(title, id, js, css))
-    } else {
-      Redirect(s"/$countryCode/subscribe")
-    }
+    val title = "Support the Guardian | Digital Subscription"
+    val id = "digital-subscription-landing-page-" + countryCode
+    val js = "digitalSubscriptionLandingPage.js"
+    val css = "digitalSubscriptionLandingPageStyles.css"
+    Ok(views.html.main(title, id, js, css))
   }
 
   def digitalGeoRedirect: Action[AnyContent] = GeoTargetedCachedAction() { implicit request =>

--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -123,7 +123,7 @@ function buildSubsUrls(
 
   const paper = `${subsUrl}/p/${promoCodes.paper}?${params.toString()}`;
   const paperDig = `${subsUrl}/p/${promoCodes.paperDig}?${params.toString()}`;
-  const digital = `${subsUrl}/p/${promoCodes.digital}?${params.toString()}`;
+  const digital = `/uk/subscribe/digital?${params.toString()}`; // This page is only used in the UK currently
 
   return {
     digital,

--- a/assets/helpers/tracking/optimize.js
+++ b/assets/helpers/tracking/optimize.js
@@ -1,15 +1,24 @@
 /* eslint-disable */
-(function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;
-  h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
-  (a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;
-})(window,document.documentElement,'async-hide','dataLayer',4000,
-  {'GTM-NZGXNBL':true});
 
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+var db = indexedDB.open("test");
+// Check if Firefox Private Browsing is enabled
+// because the page hiding snippet doesn't work
+// properly in FF PB mode, see here:
+// https://www.en.advertisercommunity.com/t5/Google-Optimize-Implement/Optimize-Page-Hiding-Snippet-Unhide-delay-issue-in-Firefox/td-p/1106919
+db.onsuccess = function() {
+  // Not in FF PB mode
+  (function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;
+    h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
+    (a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;
+  })(window,document.documentElement,'async-hide','dataLayer',4000,
+    {'GTM-NZGXNBL':true});
 
-ga('create', 'UA-51507017-5', 'auto', {cookieDomain: 'auto', anonymizeIp: true});
-ga('require', 'GTM-NZGXNBL');
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-51507017-5', 'auto', {cookieDomain: 'auto', anonymizeIp: true});
+  ga('require', 'GTM-NZGXNBL');
+};
 /* eslint-enable */

--- a/assets/helpers/tracking/optimize.js
+++ b/assets/helpers/tracking/optimize.js
@@ -1,24 +1,27 @@
 /* eslint-disable */
+try {
+  var db = indexedDB.open("test");
+  // Check if Firefox Private Browsing is enabled
+  // because the page hiding snippet doesn't work
+  // properly in FF PB mode, see here:
+  // https://www.en.advertisercommunity.com/t5/Google-Optimize-Implement/Optimize-Page-Hiding-Snippet-Unhide-delay-issue-in-Firefox/td-p/1106919
+  db.onsuccess = function() {
+    // Not in FF PB mode
+    (function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;
+      h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
+      (a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;
+    })(window,document.documentElement,'async-hide','dataLayer',4000,
+      {'GTM-NZGXNBL':true});
 
-var db = indexedDB.open("test");
-// Check if Firefox Private Browsing is enabled
-// because the page hiding snippet doesn't work
-// properly in FF PB mode, see here:
-// https://www.en.advertisercommunity.com/t5/Google-Optimize-Implement/Optimize-Page-Hiding-Snippet-Unhide-delay-issue-in-Firefox/td-p/1106919
-db.onsuccess = function() {
-  // Not in FF PB mode
-  (function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;
-    h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
-    (a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;
-  })(window,document.documentElement,'async-hide','dataLayer',4000,
-    {'GTM-NZGXNBL':true});
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
-
-  ga('create', 'UA-51507017-5', 'auto', {cookieDomain: 'auto', anonymizeIp: true});
-  ga('require', 'GTM-NZGXNBL');
-};
+    ga('create', 'UA-51507017-5', 'auto', {cookieDomain: 'auto', anonymizeIp: true});
+    ga('require', 'GTM-NZGXNBL');
+  };
+} catch (e) {
+  console.log(`Error initialising Optimize script: ${e.message}`);
+}
 /* eslint-enable */


### PR DESCRIPTION
## Why are you doing this?
To A/B test the new Digital Pack product page against the old (subscribe.theguardian.com) one.

[**Trello Card**](https://trello.com/c/4JrlMG26/1502-a-b-test)

## Changes

* Remove the need to add `digiSub=true` to the product page url
* Change the digi pack destination url from the `/subscribe` & `/uk` page to the new page - the A/B split is handled by Google Optimize

