### PR TITLE
Turn off inline Stripe payment test

### DIFF
--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -44,7 +44,7 @@ export const tests: Tests = {
         size: 1,
       },
     },
-    isActive: true,
+    isActive: false,
     independent: true,
     seed: 1,
   },


### PR DESCRIPTION
We've got an issue where some customers paying via Stripe are being charged multiple times. These issues started about the time the inline Stripe test (#728) went out, and the inline variant is disproportionately represented in cases where multiple payments happened. This makes us suspect the test is to blame.