### PR TITLE
Switch PayPal off while it is broken

### DIFF
--- a/conf/PROD.public.conf
+++ b/conf/PROD.public.conf
@@ -28,8 +28,8 @@ switches {
     // |----------------------------------|
     // |-----------24/7 Support-----------|
     // |----------------------------------|
-    payPal=On     // Comment this line
-    //payPal=Off  // Uncomment this line
+    //payPal=On     // Comment this line
+    payPal=Off  // Uncomment this line
     // |----------------------------------|
     // |-----------24/7 Support-----------|
     // |----------------------------------|
@@ -37,7 +37,7 @@ switches {
   //Payment methods for recurring contributions
   recurring {
     stripe=On
-    payPal=On
+    payPal=Off
     directDebit=On
   }
   //Google Optimize tags


### PR DESCRIPTION
## Why are you doing this?

PayPal has a certificate problem on its CDN so we are switching our integration off until it is resolved
