### PR TITLE
errorpage redirect

### DIFF
--- a/assets/helpers/internationalisation/countryGroup.js
+++ b/assets/helpers/internationalisation/countryGroup.js
@@ -166,7 +166,7 @@ function stringToCountryGroupId(countryGroupId: string): CountryGroupId {
 
 function internationalisationId() {
   const countryCodeId = fromPath();
-  return countryGroups[countryCodeId] ? countryGroups[countryCodeId].supportInternationalisationId : 'uk'
+  return countryGroups[countryCodeId] ? countryGroups[countryCodeId].supportInternationalisationId : 'uk';
 }
 
 // ----- Exports ----- //

--- a/assets/helpers/internationalisation/countryGroup.js
+++ b/assets/helpers/internationalisation/countryGroup.js
@@ -164,6 +164,10 @@ function stringToCountryGroupId(countryGroupId: string): CountryGroupId {
   return fromString(countryGroupId) || 'GBPCountries';
 }
 
+function internationalisationId() {
+  const countryCodeId = fromPath();
+  return countryGroups[countryCodeId] ? countryGroups[countryCodeId].supportInternationalisationId : 'uk'
+}
 
 // ----- Exports ----- //
 
@@ -171,4 +175,5 @@ export {
   countryGroups,
   detect,
   stringToCountryGroupId,
+  internationalisationId,
 };

--- a/assets/helpers/internationalisation/countryGroup.js
+++ b/assets/helpers/internationalisation/countryGroup.js
@@ -164,9 +164,12 @@ function stringToCountryGroupId(countryGroupId: string): CountryGroupId {
   return fromString(countryGroupId) || 'GBPCountries';
 }
 
-function internationalisationId() {
-  const countryCodeId = fromPath();
-  return countryGroups[countryCodeId] ? countryGroups[countryCodeId].supportInternationalisationId : 'uk';
+function internationalisationId(): string {
+  const countryGroupId = fromPath();
+  if (countryGroupId) {
+    return countryGroups[countryGroupId].supportInternationalisationId;
+  }
+  return 'uk';
 }
 
 // ----- Exports ----- //

--- a/assets/pages/error/components/errorPage.jsx
+++ b/assets/pages/error/components/errorPage.jsx
@@ -45,7 +45,7 @@ export default function ErrorPage(props: PropTypes) {
         <CtaLink
           text="Support The Guardian"
           accessibilityHint="click here to support The Guardian"
-          url={"/" + internationalisationId()}
+          url={`/${internationalisationId()}`}
           modifierClasses={['support-the-guardian']}
         />
         <CtaLink

--- a/assets/pages/error/components/errorPage.jsx
+++ b/assets/pages/error/components/errorPage.jsx
@@ -11,6 +11,7 @@ import SquaresIntroduction from 'components/introduction/squaresIntroduction';
 import PageSection from 'components/pageSection/pageSection';
 import CtaLink from 'components/ctaLink/ctaLink';
 import { contributionsEmail } from 'helpers/legal';
+import { internationalisationId } from 'helpers/internationalisation/countryGroup';
 
 
 // ----- Types ----- //
@@ -44,7 +45,7 @@ export default function ErrorPage(props: PropTypes) {
         <CtaLink
           text="Support The Guardian"
           accessibilityHint="click here to support The Guardian"
-          url="/"
+          url={"/" + internationalisationId()}
           modifierClasses={['support-the-guardian']}
         />
         <CtaLink


### PR DESCRIPTION
## Why are you doing this?
Currently the 'Support the Guardian' cta on the error page redirects to `/`, which then redirects based on geolocation. 

This PR checks if the broken link includes a valid internationalisation code and redirects there, otherwise defaults to UK. 

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com)
None, just a change while getting to know the project better. 
