### PR TITLE
internationalisation of contact email and terms

### DIFF
--- a/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
+++ b/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
@@ -81,7 +81,7 @@ export default function ContributionPaymentCtas(props: PropTypes) {
         />
         <OneOffCta {...props} />
         <ErrorMessage message={props.error} />
-        <TermsPrivacy country={props.country} />
+        <TermsPrivacy countryGroupId={props.countryGroupId} />
       </div>
     );
 

--- a/assets/components/directDebit/directDebitForm/directDebitForm.jsx
+++ b/assets/components/directDebit/directDebitForm/directDebitForm.jsx
@@ -149,7 +149,7 @@ const DirectDebitForm = (props: PropTypes) => (
       svg={<SvgExclamationAlternate />}
     />
 
-    <LegalNotice />
+    <LegalNotice countryGroupId={props.countryGroupId} />
 
     <DirectDebitGuarantee
       isDDGuaranteeOpen={props.isDDGuaranteeOpen}
@@ -339,6 +339,3 @@ function LegalNotice(props: { countryGroupId: CountryGroupId }) {
 
 export default connect(mapStateToProps, mapDispatchToProps)(DirectDebitForm);
 
-LegalNotice.defaultProps = {
-  countryGroupId: 'GBPCountries',
-};

--- a/assets/components/directDebit/directDebitForm/directDebitForm.jsx
+++ b/assets/components/directDebit/directDebitForm/directDebitForm.jsx
@@ -27,7 +27,7 @@ import SvgDirectDebitSymbolAndText from 'components/svgs/directDebitSymbolAndTex
 import SvgArrowRightStraight from 'components/svgs/arrowRightStraight';
 import SvgExclamationAlternate from 'components/svgs/exclamationAlternate';
 import { contributionsEmail } from 'helpers/legal';
-
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 // ---- Types ----- //
 
@@ -50,6 +50,7 @@ type PropTypes = {
   payDirectDebitClicked: () => void,
   editDirectDebitClicked: () => void,
   confirmDirectDebitClicked: (callback: RegularCheckoutCallback) => void,
+  countryGroupId: CountryGroupId,
 };
 /* eslint-enable react/no-unused-prop-types */
 
@@ -64,6 +65,7 @@ function mapStateToProps(state) {
     accountHolderConfirmation: state.page.directDebit.accountHolderConfirmation,
     formError: state.page.directDebit.formError,
     phase: state.page.directDebit.phase,
+    countryGroupId: state.common.internationalisation.countryGroupId,
   };
 }
 
@@ -313,7 +315,7 @@ function PaymentButton(props: {
   }
 }
 
-function LegalNotice() {
+function LegalNotice(props: { countryGroupId: CountryGroupId }) {
   return (
     <div className="component-direct-debit-form__legal-notice">
       <p><strong>Advance notice</strong> The details of your Direct Debit instruction including
@@ -326,7 +328,7 @@ function LegalNotice() {
         LE65 1JT United Kingdom<br />
         Tel: 0330 333 6767 (within UK). Lines are open 8am-8pm on weekdays,
         8am-6pm at weekends (GMT/BST)<br />
-        <a href={contributionsEmail}>contribution.support@theguardian.com</a>
+        <a href={contributionsEmail[props.countryGroupId]}>{contributionsEmail[props.countryGroupId].replace('mailto:', '')}</a>
       </p>
       <SvgDirectDebitSymbolAndText />
     </div>
@@ -336,3 +338,7 @@ function LegalNotice() {
 // ----- Exports ----- //
 
 export default connect(mapStateToProps, mapDispatchToProps)(DirectDebitForm);
+
+LegalNotice.defaultProps = {
+  countryGroupId: 'GBPCountries',
+};

--- a/assets/components/footer/footer.jsx
+++ b/assets/components/footer/footer.jsx
@@ -7,12 +7,14 @@ import type { Node } from 'react';
 
 import ContribLegal from 'components/legal/contribLegal/contribLegal';
 import { privacyLink, copyrightNotice } from 'helpers/legal';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 // ----- Props ----- //
 
 type PropTypes = {
   privacyPolicy: boolean,
   disclaimer: boolean,
+  countryGroupId: CountryGroupId,
   children: Node,
 };
 
@@ -34,8 +36,8 @@ function PrivacyPolicy(props: { privacyPolicy: boolean }) {
 
 }
 
-function Disclaimer(props: { disclaimer: boolean }) {
-  return props.disclaimer ? <ContribLegal /> : null;
+function Disclaimer(props: { disclaimer: boolean, countryGroupId: CountryGroupId }) {
+  return props.disclaimer ? <ContribLegal countryGroupId={props.countryGroupId} /> : null;
 }
 
 // ----- Component ----- //
@@ -48,7 +50,7 @@ function Footer(props: PropTypes) {
         <PrivacyPolicy privacyPolicy={props.privacyPolicy} />
         {props.children}
         <small className="component-footer__copyright">{copyrightNotice}</small>
-        <Disclaimer disclaimer={props.disclaimer} />
+        <Disclaimer disclaimer={props.disclaimer} countryGroupId={props.countryGroupId} />
       </div>
     </footer>
   );
@@ -61,6 +63,7 @@ function Footer(props: PropTypes) {
 Footer.defaultProps = {
   privacyPolicy: false,
   disclaimer: false,
+  countryGroupId: 'GBPCountries',
   children: [],
 };
 

--- a/assets/components/legal/contribLegal/contribLegal.jsx
+++ b/assets/components/legal/contribLegal/contribLegal.jsx
@@ -6,10 +6,19 @@ import React from 'react';
 
 import { contributionsEmail } from 'helpers/legal';
 
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+
+
+// ---- Types ----- //
+
+type PropTypes = {
+    countryGroupId: CountryGroupId,
+};
+
 
 // ----- Component ----- //
 
-export default function ContribLegal() {
+export default function ContribLegal(props: PropTypes) {
 
   return (
     <p className="component-contrib-legal">
@@ -20,7 +29,7 @@ export default function ContribLegal() {
       journalism does not constitute a charitable donation, as such your
       contribution is not eligible for Gift Aid in the UK nor a tax-deduction
       elsewhere. If you have any questions about contributing to the Guardian,
-      please <a href={contributionsEmail}>contact us here</a>.
+      please <a href={contributionsEmail[props.countryGroupId]}>contact us here</a>.
     </p>
   );
 

--- a/assets/components/legal/legalSection/legalSection.jsx
+++ b/assets/components/legal/legalSection/legalSection.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 
 import PageSection from 'components/pageSection/pageSection';
-import type { IsoCountry } from 'helpers/internationalisation/country';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 import TermsPrivacy from '../termsPrivacy/termsPrivacy';
 import ContribLegal from '../contribLegal/contribLegal';
@@ -14,7 +14,7 @@ import ContribLegal from '../contribLegal/contribLegal';
 // ----- Types ----- //
 
 type PropTypes = {
-  country: IsoCountry,
+  countryGroupId: CountryGroupId,
 };
 
 
@@ -25,8 +25,8 @@ export default function LegalSection(props: PropTypes) {
   return (
     <div className="component-legal-section">
       <PageSection>
-        <TermsPrivacy country={props.country} />
-        <ContribLegal />
+        <TermsPrivacy countryGroupId={props.countryGroupId} />
+        <ContribLegal countryGroupId={props.countryGroupId} />
       </PageSection>
     </div>
   );

--- a/assets/components/legal/legalSection/legalSectionContainer.js
+++ b/assets/components/legal/legalSection/legalSectionContainer.js
@@ -14,7 +14,7 @@ import LegalSection from './legalSection';
 function mapStateToProps(state: { common: CommonState }) {
 
   return {
-    country: state.common.internationalisation.countryId,
+    countryGroupId: state.common.internationalisation.countryGroupId,
   };
 
 }

--- a/assets/components/legal/termsPrivacy/termsPrivacy.jsx
+++ b/assets/components/legal/termsPrivacy/termsPrivacy.jsx
@@ -5,22 +5,19 @@
 import React from 'react';
 
 import { privacyLink, termsLinks } from 'helpers/legal';
-
-import type { IsoCountry } from 'helpers/internationalisation/country';
-
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 // ---- Types ----- //
 
 type PropTypes = {
-  country: IsoCountry,
+  countryGroupId: CountryGroupId,
 };
 
 
 // ----- Component ----- //
 
 function TermsPrivacy(props: PropTypes) {
-
-  const terms = <a href={termsLinks[props.country]}>Terms and Conditions</a>;
+  const terms = <a href={termsLinks[props.countryGroupId]}>Terms and Conditions</a>;
   const privacy = <a href={privacyLink}>Privacy Policy</a>;
 
   return (

--- a/assets/components/questionsContact/questionsContact.jsx
+++ b/assets/components/questionsContact/questionsContact.jsx
@@ -6,11 +6,19 @@ import React from 'react';
 
 import PageSection from 'components/pageSection/pageSection';
 import { contributionsEmail } from 'helpers/legal';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+
+
+// ---- Types ----- //
+
+type PropTypes = {
+    countryGroupId: CountryGroupId,
+};
 
 
 // ----- Component ----- //
 
-export default function QuestionsContact() {
+function QuestionsContact(props: PropTypes) {
 
   return (
     <div className="component-questions-contact">
@@ -23,7 +31,7 @@ export default function QuestionsContact() {
           please&nbsp;
           <a
             className="component-questions-contact__link"
-            href={contributionsEmail}
+            href={contributionsEmail[props.countryGroupId]}
           >
             contact us
           </a>
@@ -33,3 +41,13 @@ export default function QuestionsContact() {
   );
 
 }
+// ----- Default Props ----- //
+
+QuestionsContact.defaultProps = {
+  countryGroupId: 'GBPCountries',
+};
+
+
+// ----- Exports ----- //
+
+export default QuestionsContact;

--- a/assets/helpers/internationalisation/countryGroup.js
+++ b/assets/helpers/internationalisation/countryGroup.js
@@ -164,7 +164,6 @@ function stringToCountryGroupId(countryGroupId: string): CountryGroupId {
   return fromString(countryGroupId) || 'GBPCountries';
 }
 
-
 // ----- Exports ----- //
 
 export {

--- a/assets/helpers/legal.js
+++ b/assets/helpers/legal.js
@@ -2,16 +2,20 @@
 
 // ----- Imports ----- //
 
-import type { IsoCountry } from 'helpers/internationalisation/country';
-
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 // ----- Terms & Conditions ----- //
 
 const termsLinks: {
-  [IsoCountry]: string,
+  [CountryGroupId]: string,
 } = {
-  GB: 'https://www.theguardian.com/info/2016/apr/04/contribution-terms-and-conditions',
-  US: 'https://www.theguardian.com/info/2016/apr/07/us-contribution-terms-and-conditions',
+  GBPCountries: 'https://www.theguardian.com/info/2016/apr/04/contribution-terms-and-conditions',
+  UnitedStates: 'https://www.theguardian.com/info/2016/apr/07/us-contribution-terms-and-conditions',
+  AUDCountries: 'https://www.theguardian.com/info/2016/apr/04/contribution-terms-and-conditions',
+  EURCountries: 'https://www.theguardian.com/info/2016/apr/04/contribution-terms-and-conditions',
+  International: 'https://www.theguardian.com/info/2016/apr/04/contribution-terms-and-conditions',
+  NZDCountries: 'https://www.theguardian.com/info/2016/apr/04/contribution-terms-and-conditions',
+  Canada: 'https://www.theguardian.com/info/2016/apr/04/contribution-terms-and-conditions',
 };
 
 const privacyLink = 'https://www.theguardian.com/help/privacy-policy';
@@ -19,7 +23,17 @@ const privacyLink = 'https://www.theguardian.com/help/privacy-policy';
 const copyrightNotice = `\u00A9 ${(new Date()).getFullYear()} Guardian News and Media Limited or its
   affiliated companies. All rights reserved.`;
 
-const contributionsEmail = 'mailto:contribution.support@theguardian.com';
+const contributionsEmail: {
+    [CountryGroupId]: string,
+} = {
+  GBPCountries: 'mailto:contribution.support@theguardian.com',
+  UnitedStates: 'mailto:contribution.support@theguardian.com',
+  AUDCountries: 'mailto:apac.help@theguardian.com',
+  EURCountries: 'mailto:contribution.support@theguardian.com',
+  International: 'mailto:contribution.support@theguardian.com',
+  NZDCountries: 'mailto:contribution.support@theguardian.com',
+  Canada: 'mailto:contribution.support@theguardian.com',
+};
 
 
 // ----- Exports ----- //

--- a/assets/helpers/legal.js
+++ b/assets/helpers/legal.js
@@ -6,19 +6,22 @@ import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 // ----- Terms & Conditions ----- //
 
+const defaultTermsLink: string = 'https://www.theguardian.com/info/2016/apr/04/contribution-terms-and-conditions';
+
 const termsLinks: {
   [CountryGroupId]: string,
 } = {
-  GBPCountries: 'https://www.theguardian.com/info/2016/apr/04/contribution-terms-and-conditions',
+  GBPCountries: defaultTermsLink,
   UnitedStates: 'https://www.theguardian.com/info/2016/apr/07/us-contribution-terms-and-conditions',
-  AUDCountries: 'https://www.theguardian.com/info/2016/apr/04/contribution-terms-and-conditions',
-  EURCountries: 'https://www.theguardian.com/info/2016/apr/04/contribution-terms-and-conditions',
-  International: 'https://www.theguardian.com/info/2016/apr/04/contribution-terms-and-conditions',
-  NZDCountries: 'https://www.theguardian.com/info/2016/apr/04/contribution-terms-and-conditions',
-  Canada: 'https://www.theguardian.com/info/2016/apr/04/contribution-terms-and-conditions',
+  AUDCountries: defaultTermsLink,
+  EURCountries: defaultTermsLink,
+  International: defaultTermsLink,
+  NZDCountries: defaultTermsLink,
+  Canada: defaultTermsLink,
 };
 
 const privacyLink = 'https://www.theguardian.com/help/privacy-policy';
+const defaultContributionEmail = 'mailto:contribution.support@theguardian.com';
 
 const copyrightNotice = `\u00A9 ${(new Date()).getFullYear()} Guardian News and Media Limited or its
   affiliated companies. All rights reserved.`;
@@ -26,13 +29,13 @@ const copyrightNotice = `\u00A9 ${(new Date()).getFullYear()} Guardian News and 
 const contributionsEmail: {
     [CountryGroupId]: string,
 } = {
-  GBPCountries: 'mailto:contribution.support@theguardian.com',
-  UnitedStates: 'mailto:contribution.support@theguardian.com',
   AUDCountries: 'mailto:apac.help@theguardian.com',
-  EURCountries: 'mailto:contribution.support@theguardian.com',
-  International: 'mailto:contribution.support@theguardian.com',
-  NZDCountries: 'mailto:contribution.support@theguardian.com',
-  Canada: 'mailto:contribution.support@theguardian.com',
+  GBPCountries: defaultContributionEmail,
+  UnitedStates: defaultContributionEmail,
+  EURCountries: defaultContributionEmail,
+  International: defaultContributionEmail,
+  NZDCountries: defaultContributionEmail,
+  Canada: defaultContributionEmail,
 };
 
 

--- a/assets/pages/contributions-landing/pagesVersions/horizontalLayoutLandingPage.jsx
+++ b/assets/pages/contributions-landing/pagesVersions/horizontalLayoutLandingPage.jsx
@@ -82,7 +82,7 @@ const HorizontalLayoutLandingPage: (PropTypes) => React.Node = (props: PropTypes
   <Provider store={props.store}>
     <Page
       header={<CountrySwitcherHeader />}
-      footer={<Footer disclaimer />}
+      footer={<Footer disclaimer countryGroupId={props.countryGroupId} />}
     >
       <CirclesIntroduction
         headings={countryGroupSpecificDetails[props.countryGroupId].headerCopy}

--- a/assets/pages/error/components/errorPage.jsx
+++ b/assets/pages/error/components/errorPage.jsx
@@ -11,7 +11,6 @@ import SquaresIntroduction from 'components/introduction/squaresIntroduction';
 import PageSection from 'components/pageSection/pageSection';
 import CtaLink from 'components/ctaLink/ctaLink';
 import { contributionsEmail } from 'helpers/legal';
-import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 
 // ----- Types ----- //
@@ -63,12 +62,12 @@ export default function ErrorPage(props: PropTypes) {
 
 // ----- Auxiliary Components ----- //
 
-function ReportLink(props: { show: boolean, countryGroupId: CountryGroupId}) {
+function ReportLink(props: { show: boolean }) {
 
   if (props.show) {
     return (
       <span className="error-copy__text">
-        please <a className="error-copy__link" href={contributionsEmail[props.countryGroupId]}>report it</a>.
+        please <a className="error-copy__link" href={contributionsEmail.GBPCountries}>report it</a>.
       </span>
     );
   }
@@ -82,8 +81,4 @@ function ReportLink(props: { show: boolean, countryGroupId: CountryGroupId}) {
 
 ErrorPage.defaultProps = {
   reportLink: false,
-};
-
-ReportLink.defaultProps = {
-  countryGroupId: 'GBPCountries',
 };

--- a/assets/pages/error/components/errorPage.jsx
+++ b/assets/pages/error/components/errorPage.jsx
@@ -11,6 +11,7 @@ import SquaresIntroduction from 'components/introduction/squaresIntroduction';
 import PageSection from 'components/pageSection/pageSection';
 import CtaLink from 'components/ctaLink/ctaLink';
 import { contributionsEmail } from 'helpers/legal';
+import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 
 // ----- Types ----- //
@@ -62,12 +63,12 @@ export default function ErrorPage(props: PropTypes) {
 
 // ----- Auxiliary Components ----- //
 
-function ReportLink(props: { show: boolean }) {
+function ReportLink(props: { show: boolean, countryGroupId: CountryGroupId}) {
 
   if (props.show) {
     return (
       <span className="error-copy__text">
-        please <a className="error-copy__link" href={contributionsEmail}>report it</a>.
+        please <a className="error-copy__link" href={contributionsEmail[props.countryGroupId]}>report it</a>.
       </span>
     );
   }
@@ -81,4 +82,8 @@ function ReportLink(props: { show: boolean }) {
 
 ErrorPage.defaultProps = {
   reportLink: false,
+};
+
+ReportLink.defaultProps = {
+  countryGroupId: 'GBPCountries',
 };


### PR DESCRIPTION
## Why are you doing this?
So `/au` pages have an Australia specific contact email. This PR changes the email in the footer on the contribution landing page only. 

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/GUZ8HYhH/606-australian-footer-link-update)


## Changes

The contact email appears in the `contribLegal`,`QuestionsContact`, `LegalNotice`, and `ReportLink` components. 

Its value is now set to vary by optional prop CountryGroupId, with a default of `GBPCountries`. 

The default (GBPCountries) is used in all function calls (no props are passed) except on the support landing page where the internationalisation group is passed as an argument. So far, only `AUDCountries` has a distinct email. 

The terms link, in `TermsPrivacy` component, is now set by `countryGroupId` (previously this was determined by country and so broken for any internationalisation group except 'gb' and 'us' ). This also defaults to `GBPCountries`. So far only the US has distinct terms. 

## Screenshots

