### PR TITLE
Send the INTCMP code to GA

### DIFF
--- a/assets/helpers/tracking/googleTagManager.js
+++ b/assets/helpers/tracking/googleTagManager.js
@@ -117,6 +117,7 @@ function sendData(event: EventType, participations: Participations, paymentReque
     paymentMethod: storage.getSession('paymentMethod') || undefined,
     campaignCodeBusinessUnit: getQueryParameter('CMP_BUNIT') || undefined,
     campaignCodeTeam: getQueryParameter('CMP_TU') || undefined,
+    internalCampaignCode: getQueryParameter('INTCMP') || undefined,
     experience: getVariantsAsString(participations),
     ophanBrowserID: getOphanIds().browserId,
     paymentRequestApiStatus,


### PR DESCRIPTION
## Why are you doing this?

To track internal campaign codes in GA which will make it possible to segment traffic from the banner and epic.

[**Trello Card**](https://trello.com/c/42TRdjiX/1758-track-intcmp-code-in-ga)

