### PR TITLE
Derive the Js switches from the Scala ones automagically

### DIFF
--- a/app/codecs/CirceDecoders.scala
+++ b/app/codecs/CirceDecoders.scala
@@ -16,6 +16,7 @@ import com.gu.support.workers.model.monthlyContributions.Status
 import ophan.thrift.event.{AbTest, AcquisitionSource}
 import com.gu.fezziwig.CirceScroogeMacros.{decodeThriftEnum, decodeThriftStruct, encodeThriftEnum, encodeThriftStruct}
 import ophan.thrift.componentEvent.ComponentType
+import switchboard.{PaymentMethodsSwitch, SwitchState, Switches}
 
 object CirceDecoders {
 
@@ -81,5 +82,9 @@ object CirceDecoders {
   implicit val createPaymentMethodStateCodec: Codec[CreatePaymentMethodState] = deriveCodec
   implicit val failureHandlerStateCodec: Codec[FailureHandlerState] = deriveCodec
   implicit val completedStateCodec: Codec[CompletedState] = deriveCodec
+  implicit val switchStateEncode: Encoder[SwitchState] = Encoder.encodeString.contramap[SwitchState](s => s"'${s.toString}'")
+  implicit val switchStateDecode: Decoder[SwitchState] = deriveDecoder
+  implicit val paymentMethodsSwitchCodec: Codec[PaymentMethodsSwitch] = deriveCodec
+  implicit val switchesCodec: Codec[Switches] = deriveCodec
 }
 

--- a/app/views/ViewHelpers.scala
+++ b/app/views/ViewHelpers.scala
@@ -1,7 +1,16 @@
 package views
 
 import play.api.mvc.RequestHeader
+import switchboard.Switches
+import codecs.CirceDecoders._
+import io.circe.Printer
+import io.circe.syntax._
 
 object ViewHelpers {
   def doNotTrack(implicit request: RequestHeader): Boolean = request.headers.get("DNT").contains("1")
+  def printSwitches(switches: Switches): String =
+    switches
+      .asJson
+      .pretty(Printer.spaces2.copy(dropNullValues = true))
+      .replaceAll("\"", "")
 }

--- a/app/views/switchesScript.scala.html
+++ b/app/views/switchesScript.scala.html
@@ -1,19 +1,9 @@
 @import switchboard.Switches
+@import views.ViewHelpers.printSwitches
 
 @(switches: Switches)
 
 <script type="text/javascript">
     window.guardian = window.guardian || {};
-    guardian.switches = {
-      oneOffPaymentMethods: {
-        stripe: '@switches.onOffPaymentMethods.stripe',
-        payPal: '@switches.onOffPaymentMethods.payPal',
-      },
-      recurringPaymentMethods: {
-        stripe: '@switches.recurringPaymentMethods.stripe',
-        payPal: '@switches.recurringPaymentMethods.payPal',
-        directDebit: '@switches.recurringPaymentMethods.directDebit',
-      },
-      optimize: '@switches.optimize',
-    };
+    guardian.switches = @Html(printSwitches(switches));
 </script>


### PR DESCRIPTION
## Why are you doing this?

DRY - it's much better to just update the switch code in one place rather than having to remember to update the Js version as well.
