### PR TITLE
Revert "Derive the Js switches from the Scala ones automagically"

### DIFF
--- a/app/codecs/CirceDecoders.scala
+++ b/app/codecs/CirceDecoders.scala
@@ -16,7 +16,6 @@ import com.gu.support.workers.model.monthlyContributions.Status
 import ophan.thrift.event.{AbTest, AcquisitionSource}
 import com.gu.fezziwig.CirceScroogeMacros.{decodeThriftEnum, decodeThriftStruct, encodeThriftEnum, encodeThriftStruct}
 import ophan.thrift.componentEvent.ComponentType
-import switchboard.{PaymentMethodsSwitch, SwitchState, Switches}
 
 object CirceDecoders {
 
@@ -82,9 +81,5 @@ object CirceDecoders {
   implicit val createPaymentMethodStateCodec: Codec[CreatePaymentMethodState] = deriveCodec
   implicit val failureHandlerStateCodec: Codec[FailureHandlerState] = deriveCodec
   implicit val completedStateCodec: Codec[CompletedState] = deriveCodec
-  implicit val switchStateEncode: Encoder[SwitchState] = Encoder.encodeString.contramap[SwitchState](s => s"'${s.toString}'")
-  implicit val switchStateDecode: Decoder[SwitchState] = deriveDecoder
-  implicit val paymentMethodsSwitchCodec: Codec[PaymentMethodsSwitch] = deriveCodec
-  implicit val switchesCodec: Codec[Switches] = deriveCodec
 }
 

--- a/app/views/ViewHelpers.scala
+++ b/app/views/ViewHelpers.scala
@@ -1,16 +1,7 @@
 package views
 
 import play.api.mvc.RequestHeader
-import switchboard.Switches
-import codecs.CirceDecoders._
-import io.circe.Printer
-import io.circe.syntax._
 
 object ViewHelpers {
   def doNotTrack(implicit request: RequestHeader): Boolean = request.headers.get("DNT").contains("1")
-  def printSwitches(switches: Switches): String =
-    switches
-      .asJson
-      .pretty(Printer.spaces2.copy(dropNullValues = true))
-      .replaceAll("\"", "")
 }

--- a/app/views/switchesScript.scala.html
+++ b/app/views/switchesScript.scala.html
@@ -1,9 +1,19 @@
 @import switchboard.Switches
-@import views.ViewHelpers.printSwitches
 
 @(switches: Switches)
 
 <script type="text/javascript">
     window.guardian = window.guardian || {};
-    guardian.switches = @Html(printSwitches(switches));
+    guardian.switches = {
+      oneOffPaymentMethods: {
+        stripe: '@switches.onOffPaymentMethods.stripe',
+        payPal: '@switches.onOffPaymentMethods.payPal',
+      },
+      recurringPaymentMethods: {
+        stripe: '@switches.recurringPaymentMethods.stripe',
+        payPal: '@switches.recurringPaymentMethods.payPal',
+        directDebit: '@switches.recurringPaymentMethods.directDebit',
+      },
+      optimize: '@switches.optimize',
+    };
 </script>


### PR DESCRIPTION
Reverts guardian/support-frontend#778

This gives us `Cannot read property 'payPal' of undefined` JS errors in prod