### PR TITLE
Fix oneOffPaymentMethods spelling

### DIFF
--- a/app/switchboard/Switches.scala
+++ b/app/switchboard/Switches.scala
@@ -2,7 +2,7 @@ package switchboard
 
 import com.typesafe.config.Config
 
-case class Switches(onOffPaymentMethods: PaymentMethodsSwitch, recurringPaymentMethods: PaymentMethodsSwitch, optimize: SwitchState)
+case class Switches(oneOffPaymentMethods: PaymentMethodsSwitch, recurringPaymentMethods: PaymentMethodsSwitch, optimize: SwitchState)
 
 object Switches {
   def fromConfig(config: Config): Switches =


### PR DESCRIPTION
Fixes a mistake in #778, not visible in the actual PR because the mistake was in the Scala code that's used to generate the JS