### PR TITLE
Add the AU digipack page

### DIFF
--- a/app/controllers/Subscriptions.scala
+++ b/app/controllers/Subscriptions.scala
@@ -60,6 +60,7 @@ class Subscriptions(
     val redirectUrl = request.fastlyCountry match {
       case Some(UK) => "/uk/subscribe/digital"
       case Some(US) => "/us/subscribe/digital"
+      case Some(Australia) => "/au/subscribe/digital"
       case Some(RestOfTheWorld) => "/int/subscribe/digital"
       case _ => "https://subscribe.theguardian.com/digital"
     }

--- a/app/switchboard/Switches.scala
+++ b/app/switchboard/Switches.scala
@@ -2,15 +2,20 @@ package switchboard
 
 import com.typesafe.config.Config
 
-case class Switches(oneOffPaymentMethods: PaymentMethodsSwitch, recurringPaymentMethods: PaymentMethodsSwitch, optimize: SwitchState)
+case class Switches(
+    oneOffPaymentMethods: PaymentMethodsSwitch,
+    recurringPaymentMethods: PaymentMethodsSwitch,
+    optimize: SwitchState
+)
 
 object Switches {
   def fromConfig(config: Config): Switches =
     Switches(
       PaymentMethodsSwitch.fromConfig(config.getConfig("oneOff")),
       PaymentMethodsSwitch.fromConfig(config.getConfig("recurring")),
-      SwitchState.fromString(config.getString("optimize"))
+      SwitchState.fromConfig(config, "optimize")
     )
+
 }
 
 case class PaymentMethodsSwitch(stripe: SwitchState, payPal: SwitchState, directDebit: Option[SwitchState])
@@ -18,10 +23,10 @@ case class PaymentMethodsSwitch(stripe: SwitchState, payPal: SwitchState, direct
 object PaymentMethodsSwitch {
   def fromConfig(config: Config): PaymentMethodsSwitch =
     PaymentMethodsSwitch(
-      SwitchState.fromString(config.getString("stripe")),
-      SwitchState.fromString(config.getString("payPal")),
+      SwitchState.fromConfig(config, "stripe"),
+      SwitchState.fromConfig(config, "payPal"),
       if (config.hasPath("directDebit"))
-        Some(SwitchState.fromString(config.getString("directDebit")))
+        Some(SwitchState.fromConfig(config, "directDebit"))
       else
         None
     )
@@ -30,6 +35,8 @@ object PaymentMethodsSwitch {
 sealed trait SwitchState
 
 object SwitchState {
+  def fromConfig(config: Config, path: String): SwitchState = fromString(config.getString(path))
+
   def fromString(s: String): SwitchState = if (s.toLowerCase == "on") On else Off
 
   case object On extends SwitchState

--- a/assets/components/customerService/customerService.jsx
+++ b/assets/components/customerService/customerService.jsx
@@ -14,10 +14,11 @@ type PropTypes = {
 
 // ----- Functions ----- //
 
-function DigitalPackEmail() {
+function DigitalPackEmail(props: {email: string}) {
+  const email = props.email || 'digitalpack@theguardian.com';
   return (
-    <a className="component-customer-service__digital-pack-email" href="mailto:digitalpack@theguardian.com">
-      digitalpack@theguardian.com
+    <a className="component-customer-service__digital-pack-email" href={`mailto:${email}`}>
+      {email}
     </a>
   );
 }
@@ -51,6 +52,17 @@ function CustomerService(props: PropTypes) {
         <div className="component-customer-service__text">
           For help with Guardian and Observer subscription services please email <DigitalPackEmail /> or
           call 0330 333 6767 (within UK). Lines are open 8am-8pm on weekdays, 8am-6pm at weekends (GMT/BST).
+          <FAQBlock />
+        </div>
+      </div>
+    );
+    case 'AUDCountries': return (
+      <div className="component-customer-service">
+        <div className="component-customer-service__text">
+          For help with Guardian and Observer subscription services please
+          email <DigitalPackEmail email="apac.help@theguardian.com" /> or
+          call 1800 773 766 (within Australia) or +61 2076 8599 (outside Australia).
+          Lines are open 9am-5pm Monday-Friday (AEDT)
           <FAQBlock />
         </div>
       </div>

--- a/assets/components/customerService/customerService.jsx
+++ b/assets/components/customerService/customerService.jsx
@@ -15,13 +15,16 @@ type PropTypes = {
 // ----- Functions ----- //
 
 function DigitalPackEmail(props: {email: string}) {
-  const email = props.email || 'digitalpack@theguardian.com';
   return (
-    <a className="component-customer-service__digital-pack-email" href={`mailto:${email}`}>
-      {email}
+    <a className="component-customer-service__digital-pack-email" href={`mailto:${props.email}`}>
+      {props.email}
     </a>
   );
 }
+
+DigitalPackEmail.defaultProps = {
+  email: 'digitalpack@theguardian.com',
+};
 
 
 function FAQBlock() {

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -23,7 +23,6 @@ import ProductBlock from './components/productBlock';
 
 const store = pageInit();
 
-
 // ----- Internationalisation ----- //
 
 const countryGroupId: CountryGroupId = detect();
@@ -33,12 +32,18 @@ const reactElementId: {
 } = {
   GBPCountries: 'digital-subscription-landing-page-uk',
   UnitedStates: 'digital-subscription-landing-page-us',
+  AUDCountries: 'digital-subscription-landing-page-au',
   International: 'digital-subscription-landing-page-int',
 };
 
 const CountrySwitcherHeader = countrySwitcherHeaderContainer(
   '/subscribe/digital',
-  ['GBPCountries', 'UnitedStates', 'International'],
+  [
+    'GBPCountries',
+    'UnitedStates',
+    'AUDCountries',
+    'International',
+  ],
 );
 
 // ----- Render ----- //

--- a/conf/routes
+++ b/conf/routes
@@ -69,6 +69,7 @@ GET  /:countryCode/subscribe                       controllers.Subscriptions.leg
 GET  /subscribe/digital                            controllers.Subscriptions.digitalGeoRedirect()
 GET  /uk/subscribe/digital                         controllers.Subscriptions.digital(countryCode="uk")
 GET  /us/subscribe/digital                         controllers.Subscriptions.digital(countryCode="us")
+GET  /au/subscribe/digital                         controllers.Subscriptions.digital(countryCode="au")
 GET  /int/subscribe/digital                        controllers.Subscriptions.digital(countryCode="int")
 
 # ----- Authentication ----- #


### PR DESCRIPTION
## Why are you doing this?

To create the Australian version of the Digital Pack page and then to set the correct price and customer service details on it.

**Trello Cards:** [Here](https://trello.com/c/sO5QICtf/1729-update-price-for-aus) and [here](https://trello.com/c/cjygywqe/1739-customer-service-details-for-aus)

## Screenshots
### New Price
![screen shot 2018-07-10 at 16 53 08](https://user-images.githubusercontent.com/181371/42521907-cd5db6d0-8461-11e8-8294-c39853009a14.png)

### New customer service details
![screen shot 2018-07-10 at 16 54 02](https://user-images.githubusercontent.com/181371/42521990-f8f871ea-8461-11e8-980b-4364fe6d392b.png)
