### PR TITLE
Rename sign in test

### DIFF
--- a/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
+++ b/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
@@ -44,7 +44,7 @@ type PropTypes = {
   }>,
   error: ?string,
   resetError: void => void,
-  newSignInFlowVariant: 'control' | 'variant',
+  newSignInFlowRebootVariant: 'control' | 'variant',
 };
 
 
@@ -136,11 +136,11 @@ function RegularCta(props: {
   currencyId: IsoCurrency,
   isDisabled: boolean,
   resetError: void => void,
-  newSignInFlowVariant: 'control' | 'variant',
+  newSignInFlowRebootVariant: 'control' | 'variant',
 
 }): Node {
 
-  const useNewSignIn = props.newSignInFlowVariant === 'variant' ? 'true' : 'false';
+  const useNewSignIn = props.newSignInFlowRebootVariant === 'variant' ? 'true' : 'false';
 
 
   const spokenType = getSpokenType(props.contributionType, props.countryGroupId);

--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -60,7 +60,7 @@ export const tests: Tests = {
     independent: true,
     seed: 2,
   },
-  newSignInFlow: {
+  newSignInFlowReboot: {
     variants: ['control', 'variant'],
     audiences: {
       ALL: {

--- a/assets/pages/contributions-landing/containers/contributionPaymentCtasContainer.js
+++ b/assets/pages/contributions-landing/containers/contributionPaymentCtasContainer.js
@@ -23,7 +23,7 @@ function mapStateToProps(state: State) {
     currencyId: state.common.internationalisation.currencyId,
     isDisabled: !!state.page.selection.error,
     error: state.page.payPal.error,
-    newSignInFlowVariant: state.common.abParticipations.newSignInFlow,
+    newSignInFlowRebootVariant: state.common.abParticipations.newSignInFlowReboot,
   };
 
 }

--- a/assets/pages/support-landing/components/contributionPaymentCtasContainer.js
+++ b/assets/pages/support-landing/components/contributionPaymentCtasContainer.js
@@ -23,7 +23,7 @@ function mapStateToProps(state: State) {
     currencyId: state.common.internationalisation.currencyId,
     isDisabled: !!state.page.selection.error,
     error: state.page.payPal.error,
-    newSignInFlowVariant: state.common.abParticipations.newSignInFlow,
+    newSignInFlowRebootVariant: state.common.abParticipations.newSignInFlowReboot,
   };
 
 }


### PR DESCRIPTION
## Why are you doing this?
Due to a bug in identity for one of the variants, the data we have thus far collected is invalid and we need to restart the test. The simplest way to do this is to rename the test, which is what this PR does