### PR TITLE
Disconnect DisplayName

### DIFF
--- a/assets/components/contributionsCheckout/contributionsCheckout.jsx
+++ b/assets/components/contributionsCheckout/contributionsCheckout.jsx
@@ -27,6 +27,8 @@ type PropTypes = {
   country: IsoCountry,
   contributionType: ContributionType,
   inlineCardPaymentVariant: 'notintest' | 'control' | 'inline',
+  name: string,
+  isSignedIn: boolean,
   form: Node,
   payment: Node,
 };
@@ -76,7 +78,7 @@ export default function ContributionsCheckout(props: PropTypes) {
           amount={props.amount}
           currencyId={props.currencyId}
         />
-        <YourDetails>
+        <YourDetails name={props.name} isSignedIn={props.isSignedIn}>
           {props.form}
         </YourDetails>
         <PageSection heading={paymentSectionHeading} modifierClass="payment-methods">

--- a/assets/components/displayName/displayName.jsx
+++ b/assets/components/displayName/displayName.jsx
@@ -3,8 +3,8 @@
 // ----- Imports ----- //
 
 import React from 'react';
-import { connect } from 'react-redux';
 import SvgUser from 'components/svgs/user';
+
 
 // ---- Types ----- //
 
@@ -29,18 +29,6 @@ const DisplayName = (props: PropTypes) => {
 };
 
 
-// ----- Map State/Props ----- //
-
-function mapStateToProps(state) {
-
-  return {
-    name: state.page.user.displayName,
-    isSignedIn: state.page.user.isSignedIn,
-  };
-
-}
-
-
 // ----- Exports ----- //
 
-export default connect(mapStateToProps)(DisplayName);
+export default DisplayName;

--- a/assets/components/yourDetails/yourDetails.jsx
+++ b/assets/components/yourDetails/yourDetails.jsx
@@ -12,6 +12,8 @@ import DisplayName from 'components/displayName/displayName';
 // ----- Types ----- //
 
 type PropTypes = {
+  name: string,
+  isSignedIn: boolean,
   children: Node,
 };
 
@@ -23,7 +25,7 @@ export default function YourDetails(props: PropTypes) {
   return (
     <div className="component-your-details">
       <PageSection heading="Your details" headingChildren={<Signout />}>
-        <DisplayName />
+        <DisplayName name={props.name} isSignedIn={props.isSignedIn} />
         <p className="component-your-details__text">All fields are required.</p>
         {props.children}
       </PageSection>

--- a/assets/pages/oneoff-contributions/components/contributionsCheckoutContainer.jsx
+++ b/assets/pages/oneoff-contributions/components/contributionsCheckoutContainer.jsx
@@ -26,6 +26,8 @@ function mapStateToProps(state: State) {
     payment: inlineCardPaymentVariant === 'inline' ?
       <OneoffInlineContributionsPayment /> :
       <OneoffContributionsPayment />,
+    name: state.page.user.displayName,
+    isSignedIn: state.page.user.isSignedIn,
   };
 
 }

--- a/assets/pages/regular-contributions/components/contributionsCheckoutContainer.jsx
+++ b/assets/pages/regular-contributions/components/contributionsCheckoutContainer.jsx
@@ -26,6 +26,8 @@ function mapStateToProps(state: State) {
     payment: inlineCardPaymentVariant === 'inline' ?
       <RegularInlineContributionsPayment /> :
       <RegularContributionsPayment />,
+    name: state.page.user.displayName,
+    isSignedIn: state.page.user.isSignedIn,
   };
 
 }


### PR DESCRIPTION
## Why are you doing this?

`DisplayName` is a shared component and therefore shouldn't be connected to Redux.

[**Trello Card**](https://trello.com/c/fQQkzyUR/1453-disconnect-displayname)

cc @JustinPinner 

## Changes

- Removed the Redux `connect`ion from `DisplayName`.
- Passed the `name` and `isSignedIn` props down from the checkout.
