### PR TITLE
Show paypal payment with "PAYMENT_ALREADY_DONE" as successful

### DIFF
--- a/app/codecs/CirceDecoders.scala
+++ b/app/codecs/CirceDecoders.scala
@@ -16,7 +16,7 @@ import ophan.thrift.event.{AbTest, AcquisitionSource}
 import com.gu.fezziwig.CirceScroogeMacros.{decodeThriftEnum, decodeThriftStruct, encodeThriftEnum, encodeThriftStruct}
 import ophan.thrift.componentEvent.ComponentType
 import switchboard.{PaymentMethodsSwitch, SwitchState, Switches}
-import services.{ErrorWrapper, PaymentApiError, PayPalApiError, StripeApiError}
+import services.{PaymentApiError, PaymentProviderError, PayPalError, StripeError}
 
 object CirceDecoders {
 
@@ -86,12 +86,10 @@ object CirceDecoders {
   implicit val switchStateDecode: Decoder[SwitchState] = deriveDecoder
   implicit val paymentMethodsSwitchCodec: Codec[PaymentMethodsSwitch] = deriveCodec
   implicit val switchesCodec: Codec[Switches] = deriveCodec
-  implicit val stripeApiErrorDecoder: Decoder[StripeApiError] = deriveDecoder
-  implicit val paypalApiErrorDecoder: Decoder[PayPalApiError] = deriveDecoder
-  implicit val decodeErrorWrapper: Decoder[ErrorWrapper] = Decoder.forProduct2("error", "type")(ErrorWrapper.apply)
 
-  implicit def decodePaymentApiError: Decoder[PaymentApiError] =
-    Decoder[PayPalApiError].widen.or(Decoder[StripeApiError].widen)
-
+  private implicit val stripeApiErrorDecoder: Decoder[StripeError] = deriveDecoder
+  private implicit val paypalApiErrorDecoder: Decoder[PayPalError] = deriveDecoder
+  private implicit val paymentProviderErrorDecoder: Decoder[PaymentProviderError] = stripeApiErrorDecoder.widen.or(paypalApiErrorDecoder.widen)
+  implicit val paymentApiError: Decoder[PaymentApiError] = deriveDecoder
 }
 

--- a/app/codecs/CirceDecoders.scala
+++ b/app/codecs/CirceDecoders.scala
@@ -17,7 +17,7 @@ import ophan.thrift.event.{AbTest, AcquisitionSource}
 import com.gu.fezziwig.CirceScroogeMacros.{decodeThriftEnum, decodeThriftStruct, encodeThriftEnum, encodeThriftStruct}
 import ophan.thrift.componentEvent.ComponentType
 import switchboard.{PaymentMethodsSwitch, SwitchState, Switches}
-import services.{PaypalApiError, StripeApiError}
+import services.{ErrorWrapper, PaypalApiError, StripeApiError}
 
 object CirceDecoders {
 
@@ -89,5 +89,6 @@ object CirceDecoders {
   implicit val switchesCodec: Codec[Switches] = deriveCodec
   implicit val stripeApiErrorCodec: Codec[StripeApiError] = deriveCodec
   implicit val paypalApiErrorCodec: Codec[PaypalApiError] = deriveCodec
+  implicit val errorWrapperCodec: Codec[ErrorWrapper] = deriveCodec
 }
 

--- a/app/codecs/CirceDecoders.scala
+++ b/app/codecs/CirceDecoders.scala
@@ -16,7 +16,7 @@ import ophan.thrift.event.{AbTest, AcquisitionSource}
 import com.gu.fezziwig.CirceScroogeMacros.{decodeThriftEnum, decodeThriftStruct, encodeThriftEnum, encodeThriftStruct}
 import ophan.thrift.componentEvent.ComponentType
 import switchboard.{PaymentMethodsSwitch, SwitchState, Switches}
-import services.{ErrorWrapper, PaymentApiError, PaypalApiError, StripeApiError}
+import services.{ErrorWrapper, PaymentApiError, PayPalApiError, StripeApiError}
 
 object CirceDecoders {
 
@@ -87,11 +87,11 @@ object CirceDecoders {
   implicit val paymentMethodsSwitchCodec: Codec[PaymentMethodsSwitch] = deriveCodec
   implicit val switchesCodec: Codec[Switches] = deriveCodec
   implicit val stripeApiErrorDecoder: Decoder[StripeApiError] = deriveDecoder
-  implicit val paypalApiErrorDecoder: Decoder[PaypalApiError] = deriveDecoder
+  implicit val paypalApiErrorDecoder: Decoder[PayPalApiError] = deriveDecoder
   implicit val decodeErrorWrapper: Decoder[ErrorWrapper] = Decoder.forProduct2("error", "type")(ErrorWrapper.apply)
 
   implicit def decodePaymentApiError: Decoder[PaymentApiError] =
-    Decoder[PaypalApiError].widen.or(Decoder[StripeApiError].widen)
+    Decoder[PayPalApiError].widen.or(Decoder[StripeApiError].widen)
 
 }
 

--- a/app/codecs/CirceDecoders.scala
+++ b/app/codecs/CirceDecoders.scala
@@ -17,7 +17,7 @@ import ophan.thrift.event.{AbTest, AcquisitionSource}
 import com.gu.fezziwig.CirceScroogeMacros.{decodeThriftEnum, decodeThriftStruct, encodeThriftEnum, encodeThriftStruct}
 import ophan.thrift.componentEvent.ComponentType
 import switchboard.{PaymentMethodsSwitch, SwitchState, Switches}
-import services.{ErrorWrapper, PaypalApiError, StripeApiError}
+import services.{ErrorWrapper, PaymentApiError, PaypalApiError, StripeApiError}
 
 object CirceDecoders {
 
@@ -89,6 +89,13 @@ object CirceDecoders {
   implicit val switchesCodec: Codec[Switches] = deriveCodec
   implicit val stripeApiErrorCodec: Codec[StripeApiError] = deriveCodec
   implicit val paypalApiErrorCodec: Codec[PaypalApiError] = deriveCodec
-  implicit val errorWrapperCodec: Codec[ErrorWrapper] = deriveCodec
+  implicit val decodeErrorWrapper: Decoder[ErrorWrapper] = Decoder.forProduct2("error", "type")(ErrorWrapper.apply)
+
+  implicit def decodePaymentApiError: Decoder[PaymentApiError] =
+    List[Decoder[PaymentApiError]](
+      Decoder[PaypalApiError].widen,
+      Decoder[StripeApiError].widen
+    ).reduceLeft(_ or _)
+
 }
 

--- a/app/codecs/CirceDecoders.scala
+++ b/app/codecs/CirceDecoders.scala
@@ -9,7 +9,6 @@ import com.gu.support.workers.model.monthlyContributions.state.{CompletedState, 
 import io.circe.generic.decoding.DerivedDecoder
 import io.circe.generic.encoding.DerivedObjectEncoder
 import io.circe.generic.semiauto._
-import cats.syntax.either._
 import cats.syntax.functor._
 import shapeless.Lazy
 import com.gu.support.workers.model.monthlyContributions.Status
@@ -87,15 +86,12 @@ object CirceDecoders {
   implicit val switchStateDecode: Decoder[SwitchState] = deriveDecoder
   implicit val paymentMethodsSwitchCodec: Codec[PaymentMethodsSwitch] = deriveCodec
   implicit val switchesCodec: Codec[Switches] = deriveCodec
-  implicit val stripeApiErrorCodec: Codec[StripeApiError] = deriveCodec
-  implicit val paypalApiErrorCodec: Codec[PaypalApiError] = deriveCodec
+  implicit val stripeApiErrorDecoder: Decoder[StripeApiError] = deriveDecoder
+  implicit val paypalApiErrorDecoder: Decoder[PaypalApiError] = deriveDecoder
   implicit val decodeErrorWrapper: Decoder[ErrorWrapper] = Decoder.forProduct2("error", "type")(ErrorWrapper.apply)
 
   implicit def decodePaymentApiError: Decoder[PaymentApiError] =
-    List[Decoder[PaymentApiError]](
-      Decoder[PaypalApiError].widen,
-      Decoder[StripeApiError].widen
-    ).reduceLeft(_ or _)
+    Decoder[PaypalApiError].widen.or(Decoder[StripeApiError].widen)
 
 }
 

--- a/app/codecs/CirceDecoders.scala
+++ b/app/codecs/CirceDecoders.scala
@@ -16,7 +16,7 @@ import ophan.thrift.event.{AbTest, AcquisitionSource}
 import com.gu.fezziwig.CirceScroogeMacros.{decodeThriftEnum, decodeThriftStruct, encodeThriftEnum, encodeThriftStruct}
 import ophan.thrift.componentEvent.ComponentType
 import switchboard.{PaymentMethodsSwitch, SwitchState, Switches}
-import services.{PaymentApiError, PaymentProviderError, PayPalError, StripeError}
+import services.{PaymentApiError, PayPalError}
 
 object CirceDecoders {
 
@@ -87,9 +87,7 @@ object CirceDecoders {
   implicit val paymentMethodsSwitchCodec: Codec[PaymentMethodsSwitch] = deriveCodec
   implicit val switchesCodec: Codec[Switches] = deriveCodec
 
-  private implicit val stripeApiErrorDecoder: Decoder[StripeError] = deriveDecoder
   private implicit val paypalApiErrorDecoder: Decoder[PayPalError] = deriveDecoder
-  private implicit val paymentProviderErrorDecoder: Decoder[PaymentProviderError] = stripeApiErrorDecoder.widen.or(paypalApiErrorDecoder.widen)
   implicit val paymentApiError: Decoder[PaymentApiError] = deriveDecoder
 }
 

--- a/app/codecs/CirceDecoders.scala
+++ b/app/codecs/CirceDecoders.scala
@@ -17,6 +17,7 @@ import ophan.thrift.event.{AbTest, AcquisitionSource}
 import com.gu.fezziwig.CirceScroogeMacros.{decodeThriftEnum, decodeThriftStruct, encodeThriftEnum, encodeThriftStruct}
 import ophan.thrift.componentEvent.ComponentType
 import switchboard.{PaymentMethodsSwitch, SwitchState, Switches}
+import services.{PaypalApiError, StripeApiError}
 
 object CirceDecoders {
 
@@ -86,5 +87,7 @@ object CirceDecoders {
   implicit val switchStateDecode: Decoder[SwitchState] = deriveDecoder
   implicit val paymentMethodsSwitchCodec: Codec[PaymentMethodsSwitch] = deriveCodec
   implicit val switchesCodec: Codec[Switches] = deriveCodec
+  implicit val stripeApiErrorCodec: Codec[StripeApiError] = deriveCodec
+  implicit val paypalApiErrorCodec: Codec[PaypalApiError] = deriveCodec
 }
 

--- a/app/services/PaymentAPIService.scala
+++ b/app/services/PaymentAPIService.scala
@@ -3,6 +3,7 @@ package services
 import java.io.IOException
 
 import io.circe.parser.decode
+import codecs.CirceDecoders.paymentApiError
 import monitoring.SafeLogger
 import play.api.libs.json._
 import play.api.libs.ws.{WSClient, WSResponse}
@@ -68,7 +69,6 @@ class PaymentAPIService(wsClient: WSClient, paymentAPIUrl: String) {
   }
 
   def isDuplicatePaymentResponse(response: WSResponse): Boolean = {
-    import codecs.CirceDecoders.paymentApiError
     decode[PaymentApiError](response.body).fold(
       failure => {
         val failureMessage = SafeLogger.LogMessage(

--- a/app/services/PaymentAPIService.scala
+++ b/app/services/PaymentAPIService.scala
@@ -13,7 +13,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 sealed trait PaymentApiError extends Exception
 
-case class StripeApiError(exceptionType: Option[String], responseCode: Option[Int], requestId: Option[String], message: String) extends PaymentApiError {
+case class StripeApiError(exceptionType: Option[String], responseCode: Option[Int], errorName: Option[String], message: String) extends PaymentApiError {
   override val getMessage: String = message
 }
 

--- a/app/services/PaymentAPIService.scala
+++ b/app/services/PaymentAPIService.scala
@@ -11,13 +11,9 @@ import services.ExecutePaymentBody._
 
 import scala.concurrent.{ExecutionContext, Future}
 
-sealed trait PaymentProviderError
+case class PayPalError(responseCode: Option[Int], errorName: Option[String], message: String)
 
-case class StripeError(exceptionType: String, responseCode: Option[Int], errorName: Option[String], message: String) extends PaymentProviderError
-
-case class PayPalError(responseCode: Option[Int], errorName: Option[String], message: String) extends PaymentProviderError
-
-case class PaymentApiError(error: PaymentProviderError)
+case class PaymentApiError(error: PayPalError)
 
 case class ExecutePaymentBody(
     signedInUserEmail: Option[String],
@@ -78,12 +74,7 @@ class PaymentAPIService(wsClient: WSClient, paymentAPIUrl: String) {
         SafeLogger.error(failureMessage)
         false
       },
-      paymentApiError => {
-        paymentApiError.error match {
-          case err: PayPalError => err.errorName.contains("PAYMENT_ALREADY_DONE")
-          case _ => false
-        }
-      }
+      paymentApiError => paymentApiError.error.errorName.contains("PAYMENT_ALREADY_DONE")
     )
   }
 

--- a/app/services/PaymentAPIService.scala
+++ b/app/services/PaymentAPIService.scala
@@ -12,7 +12,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 sealed trait PaymentProviderError
 
-case class StripeError(exceptionType: Option[String], responseCode: Option[Int], errorName: Option[String], message: String) extends PaymentProviderError
+case class StripeError(exceptionType: String, responseCode: Option[Int], errorName: Option[String], message: String) extends PaymentProviderError
 
 case class PayPalError(responseCode: Option[Int], errorName: Option[String], message: String) extends PaymentProviderError
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,8 +6,6 @@ packageSummary := "Support Play APP"
 
 scalaVersion := "2.12.4"
 
-addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
-
 import scala.sys.process._
 
 def env(key: String, default: String): String = Option(System.getenv(key)).getOrElse(default)

--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,8 @@ packageSummary := "Support Play APP"
 
 scalaVersion := "2.12.4"
 
+addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
+
 import scala.sys.process._
 
 def env(key: String, default: String): String = Option(System.getenv(key)).getOrElse(default)


### PR DESCRIPTION
Currently there are a significant number of payment attempts that seem to be duplicated. 
We suspect this is caused by the contributors browser sending the execute payment command twice - perhaps because the response from the first attempt did not reach the browser.
When this happens, Paypal processes the payment on receipt of the first the execute command and then responds to the second execute command with a "PAYMENT_ALREADY_DONE" error.
This means that from the contributors perspective it looks like the payment has failed and this risks them making a second payment if they re-attempt it.

As we have updated Payment API to send the error details of any payment error back to support frontend, this change will inspect the contents of any error and if the error is a PAYMENT_ALREADY_DONE error, it will send the user to the thank you page so that they do not get the impression their payment didn't go through.

This will guard the user from mistakenly double-paying.
