### PR TITLE
Form Elements Should Have Labels

### DIFF
--- a/assets/components/contributionsCheckout/contributionsCheckout.scss
+++ b/assets/components/contributionsCheckout/contributionsCheckout.scss
@@ -9,13 +9,6 @@
     margin-top: $gu-v-spacing * 3;
   }
 
-  .component-your-details__text {
-    font-size: 14px;
-    font-family: $gu-text-sans-web;
-    font-weight: 300;
-    margin-bottom: $gu-v-spacing;
-  }
-
   .component-page-section--payment-methods {
     border-top: 1px solid gu-colour(garnett-neutral-4);
     margin-top: $gu-v-spacing * 3;

--- a/assets/components/countryGroupSwitcher/countryGroupSwitcher.jsx
+++ b/assets/components/countryGroupSwitcher/countryGroupSwitcher.jsx
@@ -44,7 +44,6 @@ function CountryGroupSwitcher(props: PropTypes) {
       <SvgGlobe />
       <SelectInput
         id="qa-country-group-dropdown"
-        className="component-country-group-switcher__selector"
         onChange={compose(props.onCountryGroupSelect, stringToCountryGroupId)}
         options={options}
         label="Select your region"

--- a/assets/components/countryGroupSwitcher/countryGroupSwitcher.scss
+++ b/assets/components/countryGroupSwitcher/countryGroupSwitcher.scss
@@ -20,7 +20,7 @@
     background-color: transparent;
     background: none;
     padding: 0;
-    height: unset;
+    height: auto;
 
     @include mq($from: mobileLandscape) {
       font-size: 14px;

--- a/assets/components/countryGroupSwitcher/countryGroupSwitcher.scss
+++ b/assets/components/countryGroupSwitcher/countryGroupSwitcher.scss
@@ -30,4 +30,8 @@
       text-decoration: underline;
     }
   }
+
+  .component-select-input__label {
+    @include accessibility-hint;
+  }
 }

--- a/assets/components/countryGroupSwitcher/countryGroupSwitcher.scss
+++ b/assets/components/countryGroupSwitcher/countryGroupSwitcher.scss
@@ -9,33 +9,25 @@
     padding: 7px;
     margin-right: 5px;
   }
-}
 
-.component-country-group-switcher__selector {
-  margin-top: 8px;
-  font-size: 12px;
-
-  @include mq($from: mobileLandscape) {
-    font-size: 14px;
-  }
-
-  font-family: $gu-egyptian-web;
-  font-weight: 500;
-  line-height: 20px;
-
-  cursor: pointer;
-  color: gu-colour(neutral-1);
-  border: none;
-  appearance: none;
-  background-color: transparent;
-
-  // Fix for IE.
-  &::-ms-expand {
-    border: none;
+  .component-select-input__select {
+    margin-top: 8px;
+    font-size: 12px;
+    font-family: $gu-egyptian-web;
+    font-weight: 500;
+    line-height: 20px;
+    cursor: pointer;
     background-color: transparent;
-  }
+    background: none;
+    padding: 0;
+    height: unset;
 
-  &:hover {
-    text-decoration: underline;
+    @include mq($from: mobileLandscape) {
+      font-size: 14px;
+    }    
+
+    &:hover {
+      text-decoration: underline;
+    }
   }
 }

--- a/assets/components/countryGroupSwitcher/countryGroupSwitcher.scss
+++ b/assets/components/countryGroupSwitcher/countryGroupSwitcher.scss
@@ -29,6 +29,10 @@
     &:hover {
       text-decoration: underline;
     }
+
+    &::-ms-expand {
+      background-color: transparent;
+    }
   }
 
   .component-select-input__label {

--- a/assets/components/selectInput/selectInput.jsx
+++ b/assets/components/selectInput/selectInput.jsx
@@ -7,17 +7,11 @@ import React from 'react';
 
 // ----- Types ----- //
 
-// Disabling the linter here because it's just buggy...
-// It can't handle props being passed to another function.
-/* eslint-disable react/no-unused-prop-types */
-
 export type SelectOption = {
   text: string,
   value: string,
   selected?: boolean,
 };
-
-/* eslint-enable react/no-unused-prop-types */
 
 type PropTypes = {
   options: SelectOption[],

--- a/assets/components/selectInput/selectInput.jsx
+++ b/assets/components/selectInput/selectInput.jsx
@@ -9,7 +9,7 @@ import React from 'react';
 
 // Disabling the linter here because it's just buggy...
 // It can't handle props being passed to another function.
-/* eslint-disable react/no-unused-prop-types, react/require-default-props */
+/* eslint-disable react/no-unused-prop-types */
 
 export type SelectOption = {
   text: string,
@@ -17,15 +17,14 @@ export type SelectOption = {
   selected?: boolean,
 };
 
-/* eslint-enable react/no-unused-prop-types, react/require-default-props */
+/* eslint-enable react/no-unused-prop-types */
 
 type PropTypes = {
   options: SelectOption[],
   onChange: (string) => void,
-  required?: boolean,
+  required: boolean,
   id: string,
   label: string,
-  className?: string,
 };
 
 
@@ -37,14 +36,14 @@ export default function SelectInput(props: PropTypes) {
     <option value={option.value} selected={option.selected}>{option.text}</option>);
 
   return (
-    <div>
+    <div className="component-select-input">
       <label htmlFor={props.id} className="accessibility-hint">
         {props.label}
       </label>
       <select
         id={props.id}
         name={props.id}
-        className={props.className}
+        className="component-select-input__select"
         required={props.required}
         onChange={event => props.onChange(event.target.value)}
       >
@@ -60,5 +59,4 @@ export default function SelectInput(props: PropTypes) {
 
 SelectInput.defaultProps = {
   required: false,
-  className: 'component-select-input',
 };

--- a/assets/components/selectInput/selectInput.jsx
+++ b/assets/components/selectInput/selectInput.jsx
@@ -37,7 +37,7 @@ export default function SelectInput(props: PropTypes) {
 
   return (
     <div className="component-select-input">
-      <label htmlFor={props.id} className="accessibility-hint">
+      <label htmlFor={props.id} className="component-select-input__label">
         {props.label}
       </label>
       <select

--- a/assets/components/selectInput/selectInput.scss
+++ b/assets/components/selectInput/selectInput.scss
@@ -1,3 +1,8 @@
+.component-select-input__label {
+  font-size: 14px;
+  font-family: $gu-text-sans-web;
+}
+
 .component-select-input__select {
 	font-family: $gu-sans-web;
 	font-size: 14px;
@@ -7,6 +12,7 @@
 	height: $gu-v-spacing * 4;
 	padding: 0 $gu-h-spacing;
 	appearance: none;
+  display: block;
 	background-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 7 14.13"><style>.st0{fill:#333333;}</style><path class="st0" d="M.55 3.84L0 3.29 3.28 0h.45L7 3.29l-.55.55-2.31-1.77v3.71H2.86V2.07L.55 3.84zM7 10.85l-3.28 3.28h-.44L0 10.85l.55-.58 2.31 1.77V8.35h1.28v3.69l2.31-1.77.55.58z"/></svg>');
   background-repeat: no-repeat;
   background-position: right 20px top 15px;

--- a/assets/components/selectInput/selectInput.scss
+++ b/assets/components/selectInput/selectInput.scss
@@ -1,23 +1,23 @@
-.component-select-input {
+.component-select-input__select {
 	font-family: $gu-sans-web;
 	font-size: 14px;
 	color: gu-colour(neutral-1);
-	margin: 0 -2px 20px;
 	border: none;
 	border-radius: 600px;
 	height: $gu-v-spacing * 4;
 	padding: 0 $gu-h-spacing;
 	appearance: none;
 	background-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 7 14.13"><style>.st0{fill:#333333;}</style><path class="st0" d="M.55 3.84L0 3.29 3.28 0h.45L7 3.29l-.55.55-2.31-1.77v3.71H2.86V2.07L.55 3.84zM7 10.85l-3.28 3.28h-.44L0 10.85l.55-.58 2.31 1.77V8.35h1.28v3.69l2.31-1.77.55.58z"/></svg>');
-    background-repeat: no-repeat;
-    background-position: right 20px top 15px;
-    background-size: 9px;
-    // Fix for Safari 8.
-    background-color: #fff;
+  background-repeat: no-repeat;
+  background-position: right 20px top 15px;
+  background-size: 9px;
+
+  // Fix for Safari 8.
+  background-color: #fff;
 
 	// Fix for IE.
-    &::-ms-expand {
-	    border: none;
-	    background-color: #fff;
+  &::-ms-expand {
+    border: none;
+    background-color: #fff;
 	}
 }

--- a/assets/components/selectInput/selectInput.scss
+++ b/assets/components/selectInput/selectInput.scss
@@ -1,6 +1,7 @@
 .component-select-input__label {
   font-size: 14px;
   font-family: $gu-text-sans-web;
+  color: gu-colour(garnett-neutral-1);
 }
 
 .component-select-input__select {

--- a/assets/components/textInput/textInput.jsx
+++ b/assets/components/textInput/textInput.jsx
@@ -11,19 +11,19 @@ import { classNameWithModifiers } from 'helpers/utilities';
 
 // Disabling the linter here because it's just buggy...
 // It can't handle props being passed to another function.
-/* eslint-disable react/no-unused-prop-types, react/require-default-props */
+/* eslint-disable react/no-unused-prop-types */
 
 type PropTypes = {
-  placeholder?: string,
-  labelText?: string,
-  id?: string,
-  onChange?: (name: string) => void,
-  value?: string,
-  required?: boolean,
+  id: string,
+  labelText: string,
+  onChange: (name: string) => void,
+  value: string,
+  placeholder: string,
+  required: boolean,
   modifierClasses: Array<?string>,
 };
 
-/* eslint-enable react/no-unused-prop-types, react/require-default-props */
+/* eslint-enable react/no-unused-prop-types */
 
 
 // ----- Functions ----- //
@@ -69,7 +69,6 @@ export default function TextInput(props: PropTypes) {
   if (!props.labelText) {
     return input;
   }
-  /* eslint-disable jsx-a11y/label-has-for */
   return (
     <div className={classNameWithModifiers('component-text-input', props.modifierClasses)}>
       <label htmlFor={props.id} className="component-text-input__label">
@@ -78,7 +77,6 @@ export default function TextInput(props: PropTypes) {
       {input}
     </div>
   );
-  /* eslint-enable jsx-a11y/label-has-for */
 
 }
 
@@ -86,11 +84,9 @@ export default function TextInput(props: PropTypes) {
 // ----- Proptypes ----- //
 
 TextInput.defaultProps = {
-  placeholder: null,
+  placeholder: '',
   labelText: '',
   id: null,
-  onChange: null,
-  value: '',
   required: false,
   modifierClasses: [],
 };

--- a/assets/components/textInput/textInput.jsx
+++ b/assets/components/textInput/textInput.jsx
@@ -54,7 +54,6 @@ export default function TextInput(props: PropTypes) {
 
 TextInput.defaultProps = {
   placeholder: '',
-  labelText: '',
   required: false,
   modifierClasses: [],
 };

--- a/assets/components/textInput/textInput.jsx
+++ b/assets/components/textInput/textInput.jsx
@@ -26,55 +26,24 @@ type PropTypes = {
 /* eslint-enable react/no-unused-prop-types */
 
 
-// ----- Functions ----- //
-
-function inputClass(hasLabel: boolean, modifierClasses: Array<?string>): string {
-
-  if (hasLabel) {
-    return 'component-text-input__input';
-  }
-
-  return classNameWithModifiers('component-text-input', modifierClasses);
-
-}
-
-function buildInput(props: PropTypes): React$Element<any> {
-
-  const attrs = {
-    className: inputClass(!!props.labelText, props.modifierClasses),
-    id: props.id,
-    type: 'text',
-    placeholder: props.placeholder,
-    value: props.value || '',
-    required: props.required,
-  };
-
-  // Keeps flow happy (https://github.com/facebook/flow/issues/2819).
-  if (typeof props.onChange === 'function') {
-    const change = props.onChange;
-    return <input {...attrs} onChange={event => change(event.target.value || '')} />;
-  }
-
-  return <input {...attrs} />;
-
-}
-
-
 // ----- Component ----- //
 
 export default function TextInput(props: PropTypes) {
 
-  const input = buildInput(props);
-
-  if (!props.labelText) {
-    return input;
-  }
   return (
     <div className={classNameWithModifiers('component-text-input', props.modifierClasses)}>
       <label htmlFor={props.id} className="component-text-input__label">
         {props.labelText}
       </label>
-      {input}
+      <input
+        className="component-text-input__input"
+        type="text"
+        id={props.id}
+        onChange={event => props.onChange(event.target.value || '')}
+        value={props.value}
+        placeholder={props.placeholder}
+        required={props.required}
+      />
     </div>
   );
 
@@ -86,7 +55,6 @@ export default function TextInput(props: PropTypes) {
 TextInput.defaultProps = {
   placeholder: '',
   labelText: '',
-  id: null,
   required: false,
   modifierClasses: [],
 };

--- a/assets/components/textInput/textInput.jsx
+++ b/assets/components/textInput/textInput.jsx
@@ -9,10 +9,6 @@ import { classNameWithModifiers } from 'helpers/utilities';
 
 // ----- Types ----- //
 
-// Disabling the linter here because it's just buggy...
-// It can't handle props being passed to another function.
-/* eslint-disable react/no-unused-prop-types */
-
 type PropTypes = {
   id: string,
   labelText: string,
@@ -22,8 +18,6 @@ type PropTypes = {
   required: boolean,
   modifierClasses: Array<?string>,
 };
-
-/* eslint-enable react/no-unused-prop-types */
 
 
 // ----- Component ----- //

--- a/assets/components/textInput/textInput.scss
+++ b/assets/components/textInput/textInput.scss
@@ -1,22 +1,17 @@
 .component-text-input {
-	font-family: $gu-sans-web;
-	font-size: 14px;
+	font-family: $gu-text-sans-web;
 	color: gu-colour(neutral-1);
-	margin: 0 -2px 20px;
-
-	input {
-		border: none;
-		border-radius: 600px;
-		height: $gu-v-spacing * 4;
-		padding: 0 $gu-h-spacing;
-	}
 }
 
-// Sometimes in this component the input is at the top level.
-input.component-text-input {
+.component-text-input__input {
 	display: block;
 	border: none;
+	font-size: 14px;
 	border-radius: 600px;
 	height: $gu-v-spacing * 4;
 	padding: 0 $gu-h-spacing;
+}
+
+.component-text-input__label {
+	font-size: 14px;
 }

--- a/assets/components/textInput/textInput.scss
+++ b/assets/components/textInput/textInput.scss
@@ -14,4 +14,5 @@
 
 .component-text-input__label {
 	font-size: 14px;
+  color: gu-colour(garnett-neutral-1);
 }

--- a/assets/components/yourDetails/yourDetails.jsx
+++ b/assets/components/yourDetails/yourDetails.jsx
@@ -26,8 +26,10 @@ export default function YourDetails(props: PropTypes) {
     <div className="component-your-details">
       <PageSection heading="Your details" headingChildren={<Signout />}>
         <DisplayName name={props.name} isSignedIn={props.isSignedIn} />
-        <p className="component-your-details__text">All fields are required.</p>
         {props.children}
+        <p className="component-your-details__info">
+          <small>All fields are required.</small>
+        </p>
       </PageSection>
     </div>
   );

--- a/assets/components/yourDetails/yourDetails.scss
+++ b/assets/components/yourDetails/yourDetails.scss
@@ -23,3 +23,11 @@
     }
   }
 }
+
+.component-your-details__info {
+  font-size: 14px;
+  font-family: $gu-text-sans-web;
+  font-weight: 300;
+  margin-top: $gu-v-spacing;
+  font-style: italic;
+}

--- a/assets/pages/oneoff-contributions/components/emailFormField.jsx
+++ b/assets/pages/oneoff-contributions/components/emailFormField.jsx
@@ -30,6 +30,7 @@ const EmailFormField = (props: PropTypes) => {
   return (<TextInput
     id="email"
     value={props.email}
+    labelText="Email"
     placeholder="Email"
     onChange={props.emailUpdate}
     modifierClasses={['email']}

--- a/assets/pages/oneoff-contributions/components/nameFormField.jsx
+++ b/assets/pages/oneoff-contributions/components/nameFormField.jsx
@@ -24,6 +24,7 @@ const NameFormField = (props: PropTypes) =>
   (<TextInput
     id="name"
     placeholder="Full name"
+    labelText="Full name"
     value={props.name}
     onChange={props.nameUpdate}
     modifierClasses={['name']}

--- a/assets/pages/oneoff-contributions/oneoffContributions.scss
+++ b/assets/pages/oneoff-contributions/oneoffContributions.scss
@@ -46,7 +46,7 @@
 
   // ----- Your details
 
-  .component-text-input {
+  .component-text-input__input {
     border: 2px solid gu-colour(news-garnett-highlight);
     font-family: $gu-text-sans-web;
     height: 44px;

--- a/assets/pages/regular-contributions/components/formFields.jsx
+++ b/assets/pages/regular-contributions/components/formFields.jsx
@@ -132,6 +132,7 @@ function NameForm(props: PropTypes) {
     <form className="regular-contrib__name-form">
       <TextInput
         id="first-name"
+        labelText="First name"
         placeholder="First name"
         value={props.firstName}
         onChange={props.firstNameUpdate}
@@ -140,6 +141,7 @@ function NameForm(props: PropTypes) {
       />
       <TextInput
         id="last-name"
+        labelText="Last name"
         placeholder="Last name"
         value={props.lastName}
         onChange={props.lastNameUpdate}

--- a/assets/pages/regular-contributions/regularContributions.scss
+++ b/assets/pages/regular-contributions/regularContributions.scss
@@ -49,7 +49,7 @@
 
   // ----- Your details
 
-  .component-text-input {
+  .component-text-input__input {
     border: 2px solid gu-colour(news-garnett-highlight);
     font-family: $gu-text-sans-web;
     height: 44px;

--- a/assets/pages/regular-contributions/regularContributions.scss
+++ b/assets/pages/regular-contributions/regularContributions.scss
@@ -66,10 +66,12 @@
     }
   }
 
+  .component-select-input {
+    margin-top: $gu-v-spacing;
+  }
+
   .component-select-input__select {
     width: 100%;
-    margin-top: $gu-v-spacing;
-    margin-bottom: 0;
     border: 2px solid gu-colour(news-garnett-highlight);
 
     @include mq($from: desktop) {

--- a/assets/pages/regular-contributions/regularContributions.scss
+++ b/assets/pages/regular-contributions/regularContributions.scss
@@ -66,7 +66,7 @@
     }
   }
 
-  .component-select-input {
+  .component-select-input__select {
     width: 100%;
     margin-top: $gu-v-spacing;
     margin-bottom: 0;

--- a/assets/pages/support-landing/supportLanding.scss
+++ b/assets/pages/support-landing/supportLanding.scss
@@ -7,6 +7,7 @@
 
 @import '../../components/headers/countrySwitcherHeader/countrySwitcherHeader';
 @import '../../components/countryGroupSwitcher/countryGroupSwitcher';
+@import '../../components/selectInput/selectInput';
 @import '../../components/introduction/introduction';
 @import '../../components/introduction/circlesIntroduction';
 @import '../../components/contribute/contribute';

--- a/assets/stylesheets/gu-sass/accessibility.scss
+++ b/assets/stylesheets/gu-sass/accessibility.scss
@@ -1,10 +1,14 @@
 // ----- Assistive technologies guidance (non-visible) ----- //
 
+@mixin accessibility-hint {
+  position: absolute;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
 .accessibility-hint {
-  position:absolute;
-  left:-10000px;
-  top:auto;
-  width:1px;
-  height:1px;
-  overflow:hidden;
+  @include accessibility-hint;
 }


### PR DESCRIPTION
## Why are you doing this?

It provides a better user experience and is important for accessibility (particularly screen readers). This affects the form fields on the contributions checkouts (regular and one-off), and the country group switcher.

**Note:** There aren't that many lines altered in this PR, but it's quite dense in terms of the number of changes (see below).

[**Trello Card**](https://trello.com/c/7XvdNj67/1475-ensure-form-elements-have-an-associated-label)

cc @JustinPinner 

## Changes

- Moved 'All fields are required' to the bottom of the form on the contributions checkout, and tweaked where the CSS lives.
- Tweaked the country group switcher to apply styles to the existing `SelectInput` classes, rather than passing through its own class name.
- Updated the way `SelectInput` and `TextInput` handle default props to follow the flow standard (see #702).
- Stopped disabling the `react/no-unused-prop-types` rule for `SelectInput` and `TextInput` because it doesn't appear to be causing problems any more.
- Stopped passing through a class name to `SelectInput`.
- Stopped hiding the label by default for `SelectInput`.
- Applied default styling to the `SelectInput` label and fixed(?) indentation weirdness in the SCSS file.
- Removed the logic that handles missing labels from `TextInput`, they're now mandatory and are therefore also passed at all the call-sites.
- Made `onChange` a mandatory prop for `TextInput` (we always pass it).
- Updated the `TextInput` CSS to use classes only, and added default label styles.
- Made `accessibility-hint` available as a mixin.

## Screenshots

### One-Off Checkout - Signed Out - Before

![oneoff-signedout-before](https://user-images.githubusercontent.com/5131341/42765162-4b927fe8-890f-11e8-9603-489dd3acdf8c.png)

### One-Off Checkout - Signed Out - After

![oneoff-signedout-after](https://user-images.githubusercontent.com/5131341/42765650-6adc6f0c-8910-11e8-8728-5dec3457e7db.png)

### Regular Checkout - Before

![monthly-before](https://user-images.githubusercontent.com/5131341/42765418-e226dc7e-890f-11e8-8645-665ea08c0068.png)

### Regular Checkout - After

![monthly-after](https://user-images.githubusercontent.com/5131341/42765307-a696ee1a-890f-11e8-9640-5ca10de2b16f.png)

### One-Off Checkout - Signed In - Before

![oneoff-signedin-before](https://user-images.githubusercontent.com/5131341/42765542-30df2cfe-8910-11e8-8b90-4b731bd7c96c.png)

### One-Off Checkout - Signed In - After

![oneoff-signedin-after](https://user-images.githubusercontent.com/5131341/42765554-3660dfec-8910-11e8-8fc5-59ae7b96c33c.png)
