### PR TITLE
Canada Uses Province/Territory

### DIFF
--- a/assets/pages/regular-contributions/components/formFields.jsx
+++ b/assets/pages/regular-contributions/components/formFields.jsx
@@ -80,6 +80,7 @@ function stateDropdown(countryGroup: CountryGroupId, stateUpdate: (UsState | CaS
     return null;
   }
   const states = countryGroup === 'Canada' ? caStates : usStates;
+  const stateLabel = countryGroup === 'Canada' ? 'province/territory' : 'state';
 
   const options: SelectOption[] = Object.keys(states).map((stateCode: UsState | CaState) =>
     ({ value: stateCode, text: states[stateCode] }));
@@ -91,7 +92,7 @@ function stateDropdown(countryGroup: CountryGroupId, stateUpdate: (UsState | CaS
     id="qa-state-dropdown"
     onChange={stateUpdate}
     options={options}
-    label="Select your state"
+    label={`Select your ${stateLabel}`}
   />);
 }
 


### PR DESCRIPTION
## Why are you doing this?

They're provinces/territories in Canada.

cc @JustinPinner 

## Changes

- Use the word 'state' for the US, 'province/territory' for Canada.

## Screenshots

**Canada**

![canada-dropdown](https://user-images.githubusercontent.com/5131341/42821382-58e5ab0e-89d0-11e8-864a-8c988e63dac8.png)

**US**

![us-dropdown](https://user-images.githubusercontent.com/5131341/42821374-514dceda-89d0-11e8-8939-ff6d9b6da0f2.png)
