### PR TITLE
more accurate method names

### DIFF
--- a/app/controllers/PayPalOneOff.scala
+++ b/app/controllers/PayPalOneOff.scala
@@ -77,7 +77,7 @@ class PayPalOneOff(
 
     for {
       maybeEmail <- request.user.map(emailForUser).getOrElse(Future.successful(None))
-      result <- paymentAPIService.execute(paymentJSON, acquisitionData, queryStrings, maybeEmail, isTestUser)
+      result <- paymentAPIService.executePaypalPayment(paymentJSON, acquisitionData, queryStrings, maybeEmail, isTestUser)
     } yield processPaymentApiResponse(result)
 
   }

--- a/app/services/PaymentAPIService.scala
+++ b/app/services/PaymentAPIService.scala
@@ -46,7 +46,7 @@ class PaymentAPIService(wsClient: WSClient, paymentAPIUrl: String) {
     }
   }
 
-  private def postData(data: ExecutePaymentBody, queryStrings: Map[String, Seq[String]], isTestUser: Boolean) = {
+  private def postPaypalData(data: ExecutePaymentBody, queryStrings: Map[String, Seq[String]], isTestUser: Boolean) = {
     val allQueryParams = if (isTestUser) queryStrings + ("mode" -> Seq("test")) else queryStrings
 
     wsClient.url(payPalExecutePaymentEndpoint)
@@ -57,7 +57,7 @@ class PaymentAPIService(wsClient: WSClient, paymentAPIUrl: String) {
       .execute()
   }
 
-  def execute(
+  def executePaypalPayment(
     paymentJSON: JsObject,
     acquisitionData: JsValue,
     queryStrings: Map[String, Seq[String]],
@@ -65,6 +65,6 @@ class PaymentAPIService(wsClient: WSClient, paymentAPIUrl: String) {
     isTestUser: Boolean
   )(implicit ec: ExecutionContext): Future[Boolean] = {
     val data = ExecutePaymentBody(email, acquisitionData, paymentJSON)
-    postData(data, queryStrings, isTestUser).map(_.status == 200)
+    postPaypalData(data, queryStrings, isTestUser).map(_.status == 200)
   }
 }


### PR DESCRIPTION
## Why are you doing this?

Update method names in `PaymentAPIService` to more accurately reflect what they're doing. As it stands, they are a potential source of confusion e.g. in #786 we have modelled Stripe and Paypal API errors whereas actually only the Paypal API error is necessary.

