### PR TITLE
Avoid disabling button on server error

### DIFF
--- a/assets/components/stripeInlineForm/stripeInlineForm.jsx
+++ b/assets/components/stripeInlineForm/stripeInlineForm.jsx
@@ -51,6 +51,15 @@ const setupStripeInlineForm = (stripeIsLoaded: () => void) => {
   }
 };
 
+function enableSubmitButton() {
+  const element = document.getElementsByClassName(submitClassName)[0];
+  try {
+    element.removeAttribute('disabled');
+    element.classList.remove(submitClassNameDisabled);
+  } catch (e) {
+    logException(`Enable submit button failed: ${e.message}`);
+  }
+}
 
 // ----- Component ----- //
 
@@ -111,16 +120,6 @@ function disableSubmitButton() {
     element.classList.add(submitClassNameDisabled);
   } catch (e) {
     logException(`Disable submit button failed: ${e.message}`);
-  }
-}
-
-function enableSubmitButton() {
-  const element = document.getElementsByClassName(submitClassName)[0];
-  try {
-    element.removeAttribute('disabled');
-    element.classList.remove(submitClassNameDisabled);
-  } catch (e) {
-    logException(`Enable submit button failed: ${e.message}`);
   }
 }
 

--- a/assets/components/stripeInlineForm/stripeInlineForm.jsx
+++ b/assets/components/stripeInlineForm/stripeInlineForm.jsx
@@ -40,6 +40,9 @@ type PropTypes = {|
 
 // ---- Auxiliary functions ----- //
 
+const submitClassName = 'component-stripe-inline-form__submit-payment';
+const submitClassNameDisabled = `${submitClassName}--disabled`;
+
 const setupStripeInlineForm = (stripeIsLoaded: () => void) => {
   const htmlElement = document.getElementById('stripe-js');
 
@@ -50,6 +53,17 @@ const setupStripeInlineForm = (stripeIsLoaded: () => void) => {
     );
   }
 };
+
+function disableSubmitButton() {
+  const element = document.getElementsByClassName(submitClassName)[0];
+
+  try {
+    element.setAttribute('disabled', '');
+    element.classList.add(submitClassNameDisabled);
+  } catch (e) {
+    logException(`Disable submit button failed: ${e.message}`);
+  }
+}
 
 function enableSubmitButton() {
   const element = document.getElementsByClassName(submitClassName)[0];
@@ -108,20 +122,6 @@ const stripeElementsStyle = {
       lineHeight: '40px',
     },
 };
-
-const submitClassName = 'component-stripe-inline-form__submit-payment';
-const submitClassNameDisabled = `${submitClassName}--disabled`;
-
-function disableSubmitButton() {
-  const element = document.getElementsByClassName(submitClassName)[0];
-
-  try {
-    element.setAttribute('disabled', '');
-    element.classList.add(submitClassNameDisabled);
-  } catch (e) {
-    logException(`Disable submit button failed: ${e.message}`);
-  }
-}
 
 function checkoutForm(props: {
   stripe: Object,

--- a/assets/components/stripeInlineForm/stripeInlineForm.jsx
+++ b/assets/components/stripeInlineForm/stripeInlineForm.jsx
@@ -61,6 +61,7 @@ function StripeInlineFormComp(props: PropTypes) {
     return null;
   }
 
+  enableSubmitButton();
   return (
     <StripeProvider apiKey={getStripeKey(props.currencyId, props.isTestUser)}>
       <Elements>


### PR DESCRIPTION
## Why are you doing this?

@jranks123 discovered as it current stands, if there is a server error, the submit button disable itself and it will not enable again.



## Changes

* Enable the button at the beginning.
* Move functions to the top of the file to keep linter happy.

## Screenshots

