### PR TITLE
Fix Digital Product Side Scroll

### DIFF
--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -338,13 +338,14 @@
     .svg-title-circles-right-mobile {
       position: absolute;
       top: 335px;
-      left: calc(50% + 120px);
-      @include mq($until: mobileMedium) {
-        width: 60px;
-      }
+      left: calc(50% + 100px);
+      width: 60px;
+
       @include mq($from: mobileMedium) {
         width: 80px;
+        left: calc(50% + 105px);
       }
+
       @include mq($from: tablet) {
         display: none;
       }


### PR DESCRIPTION
## Why are you doing this?

We've picked up some side-scrolling on mobile on the digital product page. Can't quite figure out why `overflow-x: hidden` isn't dealing with this, so I've moved the image to the left a bit.

cc @JustinPinner 

## Changes

- Tweaked the `left` property to stop side-scroll.

## Screenshots

![side-scroll](https://user-images.githubusercontent.com/5131341/43078466-738c78dc-8e82-11e8-8492-5e3fb6d8ab40.png)
