### PR TITLE
Digital Product Page AU Tweaks

### DIFF
--- a/assets/components/gridPicture/gridPicture.jsx
+++ b/assets/components/gridPicture/gridPicture.jsx
@@ -15,9 +15,6 @@ import type { ImageId, ImageType } from 'helpers/theGrid';
 
 // ----- Types ----- //
 
-// Disabling the linter here because it's just buggy...
-/* eslint-disable react/no-unused-prop-types */
-
 export type Source = {
   gridId: ImageId,
   sizes: string,
@@ -25,8 +22,6 @@ export type Source = {
   srcSizes: number[],
   imgType: ImageType,
 };
-
-/* eslint-enable react/no-unused-prop-types */
 
 export type PropTypes = {
   sources: Source[],

--- a/assets/components/gridPicture/gridPicture.jsx
+++ b/assets/components/gridPicture/gridPicture.jsx
@@ -15,21 +15,26 @@ import type { ImageId, ImageType } from 'helpers/theGrid';
 
 // ----- Types ----- //
 
-export type Source = {
+export type GridImage = {
   gridId: ImageId,
-  sizes: string,
-  media: string,
   srcSizes: number[],
   imgType: ImageType,
 };
 
-export type PropTypes = {
+export type GridSlot = {
+  sizes: string,
+  media: string,
+};
+
+export type Source = GridImage & GridSlot;
+
+export type PropTypes = {|
   sources: Source[],
   fallback: string,
   fallbackSize: number,
   altText: string,
   fallbackImgType: ImageType,
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/gridPicture/gridPicture.jsx
+++ b/assets/components/gridPicture/gridPicture.jsx
@@ -18,7 +18,7 @@ import type { ImageId, ImageType } from 'helpers/theGrid';
 // Disabling the linter here because it's just buggy...
 /* eslint-disable react/no-unused-prop-types */
 
-type Source = {
+export type Source = {
   gridId: ImageId,
   sizes: string,
   media: string,

--- a/assets/helpers/theGrid.js
+++ b/assets/helpers/theGrid.js
@@ -24,6 +24,7 @@ export const imageCatalogue: {
   paperCircle: 'c462d60f2962b745b1e206d5ede998dfb166a8ed/0_0_825_825',
   paperDigitalCircle: 'd94c0f9bade09487b9afca5ee8149efb33f34ccf/0_0_825_825',
   premiumTier: 'fb0c788ddee28f8e0e66d814595cf81d6aa21ec6/0_0_644_448',
+  premiumTierAU: '4b6fd9805c7d0a88b4b71a683c4b46279a410b9d/0_0_1610_1120',
   dailyEdition: '168cab5197d7b4c5d9e05eb3ff2801b2929f2995/0_0_644_448',
   amberRudd: '33d55e682e496b355baed45c0d92ca7dedbc6eff/0_0_370_370',
   zuck: 'e6142101bc909caee866be05ced677c54e9d3b4e/0_0_374_374',

--- a/assets/helpers/theGrid.js
+++ b/assets/helpers/theGrid.js
@@ -28,8 +28,11 @@ export const imageCatalogue: {
   amberRudd: '33d55e682e496b355baed45c0d92ca7dedbc6eff/0_0_370_370',
   zuck: 'e6142101bc909caee866be05ced677c54e9d3b4e/0_0_374_374',
   digitalSubscriptionHeaderDesktop: '01f9a081d0f78cb057ca585725f2742bed5a98fb/0_0_4045_1945',
+  digitalSubscriptionHeaderDesktopAU: 'f46b1e2c498ac4f1ebec1b2620b6e80583e4348f/0_0_4045_1945',
   digitalSubscriptionHeaderTablet: '4d588918cae445d7ded1e68960286fd91217434b/0_0_2035_1660',
+  digitalSubscriptionHeaderTabletAU: 'dbe3974508706a41e710f198b1da02f44e6141a1/0_0_2035_1660',
   digitalSubscriptionHeaderMobile: 'ed4028ccd5abd85b330114e3ef48660358f63969/0_0_1200_1755',
+  digitalSubscriptionHeaderMobileAU: 'dbe3974508706a41e710f198b1da02f44e6141a1/945_0_1088_1755',
 };
 
 // Utility type: https://flow.org/en/docs/types/utilities/#toc-keys

--- a/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
+++ b/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
@@ -1,56 +1,154 @@
 // @flow
 
 // ----- Imports ----- //
+
 import React from 'react';
 
 import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
-import GridPicture, { type PropTypes as GridPictureProps } from 'components/gridPicture/gridPicture';
+import GridPicture, {
+  type PropTypes as GridPictureProps,
+  type Source as GSource,
+} from 'components/gridPicture/gridPicture';
+import { type ImageId as GridId } from 'helpers/theGrid';
 import { CirclesLeft, CirclesRight } from 'components/svgs/digitalSubscriptionLandingHeaderCircles';
+import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+
 import PriceCtaContainer from './priceCtaContainer';
+
+
+// ----- Types ----- //
+
+type PropTypes = {
+  cgId: CountryGroupId
+};
+
+type GridSource = {
+  gridId: GridId,
+  srcSizes: number[],
+  imgType: 'png' | 'jpg',
+};
+
+type GridSources = {
+  sources: {
+    mobile: GridSource,
+    tablet: GridSource,
+    desktop: GridSource,
+  },
+  fallback: GridId,
+};
+
+type GridSlot = {
+  sizes: string,
+  media: string,
+};
+
+type GridSlots = {
+  mobile: GridSlot,
+  tablet: GridSlot,
+  desktop: GridSlot,
+};
 
 
 // ----- Setup ----- //
 
-const pictureSources = [
-  {
-    gridId: 'digitalSubscriptionHeaderMobile',
-    sizes: '240px',
-    media: '(max-width: 739px)',
-    srcSizes: [342, 684, 1200],
-    imgType: 'png',
+const defaultSources: GridSources = {
+  sources: {
+    mobile: {
+      gridId: 'digitalSubscriptionHeaderMobile',
+      srcSizes: [342, 684, 1200],
+      imgType: 'png',
+    },
+    tablet: {
+      gridId: 'digitalSubscriptionHeaderTablet',
+      srcSizes: [500, 1000, 2000],
+      imgType: 'png',
+    },
+    desktop: {
+      gridId: 'digitalSubscriptionHeaderDesktop',
+      srcSizes: [500, 1000, 2000, 4045],
+      imgType: 'png',
+    },
   },
-  {
-    gridId: 'digitalSubscriptionHeaderTablet',
-    sizes: '407px',
-    media: '(min-width: 740px) and (max-width: 1139px)',
-    srcSizes: [500, 1000, 2000],
-    imgType: 'png',
-  },
-  {
-    gridId: 'digitalSubscriptionHeaderDesktop',
-    sizes: '809px',
-    media: '(min-width: 1140px)',
-    srcSizes: [500, 1000, 2000, 4045],
-    imgType: 'png',
-  },
-];
-
-const gridPicture: GridPictureProps = {
-  sources: pictureSources,
   fallback: 'digitalSubscriptionHeaderDesktop',
-  fallbackSize: 500,
-  altText: 'digital subscription',
-  fallbackImgType: 'png',
 };
 
-export default function DigitalSubscriptionLandingHeader() {
+const gridSourcesByCountry: {
+  [CountryGroupId]: GridSources,
+} = {
+  GBPCountries: defaultSources,
+  UnitedStates: defaultSources,
+  International: defaultSources,
+  AUDCountries: {
+    sources: {
+      mobile: {
+        gridId: 'digitalSubscriptionHeaderMobileAU',
+        srcSizes: [310, 620, 1088],
+        imgType: 'png',
+      },
+      tablet: {
+        gridId: 'digitalSubscriptionHeaderTabletAU',
+        srcSizes: [500, 1000, 2000],
+        imgType: 'png',
+      },
+      desktop: {
+        gridId: 'digitalSubscriptionHeaderDesktopAU',
+        srcSizes: [500, 1000, 2000, 4045],
+        imgType: 'png',
+      },
+    },
+    fallback: 'digitalSubscriptionHeaderDesktopAU',
+  },
+};
+
+const gridSlots: GridSlots = {
+  mobile: {
+    sizes: '240px',
+    media: '(max-width: 739px)',
+  },
+  tablet: {
+    sizes: '407px',
+    media: '(min-width: 740px) and (max-width: 1139px)',
+  },
+  desktop: {
+    sizes: '809px',
+    media: '(min-width: 1140px)',
+  },
+};
+
+
+// ----- Functions ----- //
+
+function gridPicture(cgId: CountryGroupId): GridPictureProps {
+
+  const gridSources: GridSources = gridSourcesByCountry[cgId];
+
+  const sources: GSource[] = [
+    { ...gridSlots.mobile, ...gridSources.sources.mobile },
+    { ...gridSlots.tablet, ...gridSources.sources.tablet },
+    { ...gridSlots.desktop, ...gridSources.sources.desktop },
+  ];
+
+  return {
+    sources,
+    fallback: gridSources.fallback,
+    fallbackSize: 500,
+    altText: 'digital subscription',
+    fallbackImgType: 'png',
+  };
+
+}
+
+
+// ----- Component ----- //
+
+export default function DigitalSubscriptionLandingHeader(props: PropTypes) {
   return (
     <div className="digital-subscription-landing-header">
       <LeftMarginSection modifierClasses={['header-block', 'grey']}>
         <CirclesLeft />
         <CirclesRight />
         <div className="digital-subscription-landing-header__picture">
-          <GridPicture {...gridPicture} />
+          <GridPicture {...gridPicture(props.cgId)} />
         </div>
         <div className="digital-subscription-landing-header__title">
           <div className="digital-subscription-landing-header__title-copy">

--- a/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
+++ b/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
@@ -7,7 +7,9 @@ import React from 'react';
 import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
 import GridPicture, {
   type PropTypes as GridPictureProps,
-  type Source as GSource,
+  type GridImage,
+  type GridSlot,
+  type Source as GridSource,
 } from 'components/gridPicture/gridPicture';
 import { type ImageId as GridId } from 'helpers/theGrid';
 import { CirclesLeft, CirclesRight } from 'components/svgs/digitalSubscriptionLandingHeaderCircles';
@@ -22,24 +24,13 @@ type PropTypes = {
   cgId: CountryGroupId
 };
 
-type GridSource = {
-  gridId: GridId,
-  srcSizes: number[],
-  imgType: 'png' | 'jpg',
-};
-
-type GridSources = {
-  sources: {
-    mobile: GridSource,
-    tablet: GridSource,
-    desktop: GridSource,
+type GridImages = {
+  breakpoints: {
+    mobile: GridImage,
+    tablet: GridImage,
+    desktop: GridImage,
   },
   fallback: GridId,
-};
-
-type GridSlot = {
-  sizes: string,
-  media: string,
 };
 
 type GridSlots = {
@@ -51,8 +42,8 @@ type GridSlots = {
 
 // ----- Setup ----- //
 
-const defaultSources: GridSources = {
-  sources: {
+const defaultImages: GridImages = {
+  breakpoints: {
     mobile: {
       gridId: 'digitalSubscriptionHeaderMobile',
       srcSizes: [342, 684, 1200],
@@ -72,14 +63,14 @@ const defaultSources: GridSources = {
   fallback: 'digitalSubscriptionHeaderDesktop',
 };
 
-const gridSourcesByCountry: {
-  [CountryGroupId]: GridSources,
+const gridImagesByCountry: {
+  [CountryGroupId]: GridImages,
 } = {
-  GBPCountries: defaultSources,
-  UnitedStates: defaultSources,
-  International: defaultSources,
+  GBPCountries: defaultImages,
+  UnitedStates: defaultImages,
+  International: defaultImages,
   AUDCountries: {
-    sources: {
+    breakpoints: {
       mobile: {
         gridId: 'digitalSubscriptionHeaderMobileAU',
         srcSizes: [310, 620, 1088],
@@ -120,17 +111,17 @@ const gridSlots: GridSlots = {
 
 function gridPicture(cgId: CountryGroupId): GridPictureProps {
 
-  const gridSources: GridSources = gridSourcesByCountry[cgId];
+  const gridImages: GridImages = gridImagesByCountry[cgId];
 
-  const sources: GSource[] = [
-    { ...gridSlots.mobile, ...gridSources.sources.mobile },
-    { ...gridSlots.tablet, ...gridSources.sources.tablet },
-    { ...gridSlots.desktop, ...gridSources.sources.desktop },
+  const sources: GridSource[] = [
+    { ...gridSlots.mobile, ...gridImages.breakpoints.mobile },
+    { ...gridSlots.tablet, ...gridImages.breakpoints.tablet },
+    { ...gridSlots.desktop, ...gridImages.breakpoints.desktop },
   ];
 
   return {
     sources,
-    fallback: gridSources.fallback,
+    fallback: gridImages.fallback,
     fallbackSize: 500,
     altText: 'digital subscription',
     fallbackImgType: 'png',

--- a/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
+++ b/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
@@ -21,7 +21,7 @@ import PriceCtaContainer from './priceCtaContainer';
 // ----- Types ----- //
 
 type PropTypes = {
-  cgId: CountryGroupId
+  countryGroupId: CountryGroupId
 };
 
 type GridImages = {
@@ -139,7 +139,7 @@ export default function DigitalSubscriptionLandingHeader(props: PropTypes) {
         <CirclesLeft />
         <CirclesRight />
         <div className="digital-subscription-landing-header__picture">
-          <GridPicture {...gridPicture(props.cgId)} />
+          <GridPicture {...gridPicture(props.countryGroupId)} />
         </div>
         <div className="digital-subscription-landing-header__title">
           <div className="digital-subscription-landing-header__title-copy">

--- a/assets/pages/digital-subscription-landing/components/productBlock.jsx
+++ b/assets/pages/digital-subscription-landing/components/productBlock.jsx
@@ -10,8 +10,16 @@ import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
 import FeatureList, { type ListItem } from 'components/featureList/featureList';
 import GridImage, { type GridImg } from 'components/gridImage/gridImage';
 import SvgPennyFarthingCircles from 'components/svgs/pennyFarthingCircles';
+import { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 import PriceCtaContainer from './priceCtaContainer';
+
+
+// ----- Types ----- //
+
+type PropTypes = {
+  countryGroupId: CountryGroupId,
+};
 
 
 // ----- Setup ----- //
@@ -22,10 +30,52 @@ const imageProperties = {
   imgType: 'png',
 };
 
+const defaultFeatures: ListItem[] = [
+  {
+    heading: ['Discover ', <mark className="product-block__highlight">New</mark>],
+    text: 'A selection of long reads, interviews and features to be read at leisure',
+  },
+  {
+    heading: ['Live ', <mark className="product-block__highlight">New</mark>],
+    text: 'A fast way to catch up on every news story as it breaks',
+  },
+  {
+    heading: 'Complete the daily crossword',
+    text: 'Get our daily crossword wherever you are',
+  },
+  {
+    heading: 'Ad-free reading',
+    text: 'Read the news with no distractions',
+  },
+];
+
+const appFeatures: {
+  [CountryGroupId]: ListItem[],
+} = {
+  GBPCountries: defaultFeatures,
+  UnitedStates: defaultFeatures,
+  International: defaultFeatures,
+  AUDCountries: [
+    {
+      heading: 'Ad-free reading',
+      text: 'Read the news with no distractions',
+    },
+    {
+      heading: 'Complete the daily crossword',
+      text: 'Get our daily crossword wherever you are',
+    },
+    {
+      heading: ['Live news and sport ', <mark className="product-block__highlight">New</mark>],
+      text: 'Catch up on every breaking story from Australia and the world, in real time',
+    },
+
+  ],
+};
+
 
 // ----- Component ----- //
 
-export default function ProductBlock() {
+function ProductBlock(props: PropTypes) {
 
   return (
     <div className="product-block">
@@ -44,24 +94,7 @@ export default function ProductBlock() {
           companionSvg={null}
           heading="App premium tier"
           description="Exciting new app features available for mobile and tablet users with a digital subscription"
-          features={[
-            {
-              heading: ['Discover ', <mark className="product-block__highlight">New</mark>],
-              text: 'A selection of long reads, interviews and features to be read at leisure',
-            },
-            {
-              heading: ['Live ', <mark className="product-block__highlight">New</mark>],
-              text: 'A fast way to catch up on every news story as it breaks',
-            },
-            {
-              heading: 'Complete the daily crossword',
-              text: 'Get our daily crossword wherever you are',
-            },
-            {
-              heading: 'Ad-free reading',
-              text: 'Read the news with no distractions',
-            },
-          ]}
+          features={appFeatures[props.countryGroupId]}
         />
         <div className="product-block__ampersand">&</div>
         <Product
@@ -131,6 +164,14 @@ function Product(props: {
 
 }
 
+
+// ----- Default Props ----- //
+
 Product.defaultProps = {
   companionSvg: null,
 };
+
+
+// ----- Exports ----- //
+
+export default ProductBlock;

--- a/assets/pages/digital-subscription-landing/components/productBlock.jsx
+++ b/assets/pages/digital-subscription-landing/components/productBlock.jsx
@@ -24,11 +24,7 @@ type PropTypes = {
 
 // ----- Setup ----- //
 
-const imageProperties = {
-  srcSizes: [644, 500, 140],
-  sizes: '(max-width: 480px) 100vw, (max-width: 660px) 460px, 345px',
-  imgType: 'png',
-};
+const imageSlot = '(max-width: 480px) 100vw, (max-width: 660px) 460px, 345px';
 
 const defaultFeatures: ListItem[] = [
   {
@@ -72,6 +68,27 @@ const appFeatures: {
   ],
 };
 
+const defaultAppImage = {
+  gridId: 'premiumTier',
+  altText: 'the premium tier on the guardian app',
+  srcSizes: [644, 500, 140],
+  sizes: imageSlot,
+  imgType: 'png',
+};
+
+const appImages: {
+  [CountryGroupId]: GridImg,
+} = {
+  GBPCountries: defaultAppImage,
+  UnitedStates: defaultAppImage,
+  International: defaultAppImage,
+  AUDCountries: {
+    ...defaultAppImage,
+    gridId: 'premiumTierAU',
+    srcSizes: [1000, 500, 140],
+  },
+};
+
 
 // ----- Component ----- //
 
@@ -86,11 +103,7 @@ function ProductBlock(props: PropTypes) {
         </h2>
         <Product
           modifierClass="premium-app"
-          imageProps={{
-            gridId: 'premiumTier',
-            altText: 'the premium tier on the guardian app',
-            ...imageProperties,
-          }}
+          imageProps={appImages[props.countryGroupId]}
           companionSvg={null}
           heading="App premium tier"
           description="Exciting new app features available for mobile and tablet users with a digital subscription"
@@ -102,7 +115,9 @@ function ProductBlock(props: PropTypes) {
           imageProps={{
             gridId: 'dailyEdition',
             altText: 'the guardian daily edition app',
-            ...imageProperties,
+            srcSizes: [644, 500, 140],
+            sizes: imageSlot,
+            imgType: 'png',
           }}
           companionSvg={<SvgPennyFarthingCircles />}
           heading="iPad daily Edition"

--- a/assets/pages/digital-subscription-landing/components/productBlock.jsx
+++ b/assets/pages/digital-subscription-landing/components/productBlock.jsx
@@ -10,7 +10,7 @@ import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
 import FeatureList, { type ListItem } from 'components/featureList/featureList';
 import GridImage, { type GridImg } from 'components/gridImage/gridImage';
 import SvgPennyFarthingCircles from 'components/svgs/pennyFarthingCircles';
-import { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 import PriceCtaContainer from './priceCtaContainer';
 

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -54,7 +54,7 @@ const content = (
       header={<CountrySwitcherHeader />}
       footer={<Footer><CustomerService selectedCountryGroup={countryGroupId} /></Footer>}
     >
-      <DigitalSubscriptionLandingHeader />
+      <DigitalSubscriptionLandingHeader cgId={countryGroupId} />
       <ProductBlock countryGroupId={countryGroupId} />
       <LeftMarginSection modifierClasses={['grey']}>
         <IndependentJournalismSection />

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -55,7 +55,7 @@ const content = (
       footer={<Footer><CustomerService selectedCountryGroup={countryGroupId} /></Footer>}
     >
       <DigitalSubscriptionLandingHeader />
-      <ProductBlock />
+      <ProductBlock countryGroupId={countryGroupId} />
       <LeftMarginSection modifierClasses={['grey']}>
         <IndependentJournalismSection />
       </LeftMarginSection>

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -54,7 +54,7 @@ const content = (
       header={<CountrySwitcherHeader />}
       footer={<Footer><CustomerService selectedCountryGroup={countryGroupId} /></Footer>}
     >
-      <DigitalSubscriptionLandingHeader cgId={countryGroupId} />
+      <DigitalSubscriptionLandingHeader countryGroupId={countryGroupId} />
       <ProductBlock countryGroupId={countryGroupId} />
       <LeftMarginSection modifierClasses={['grey']}>
         <IndependentJournalismSection />

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -158,6 +158,8 @@
     @include mq($from: leftCol) {
       columns: 2;
       column-gap: 54px;
+      column-fill: auto;
+      height: 175px;
     }
   }
 


### PR DESCRIPTION
## Why are you doing this?

Image and copy changes for the AU version of the digital product page.

[**Trello Card**](https://trello.com/c/8SpzwrWd/1727-product-block-aus) and [also](https://trello.com/c/8xwxpoJb/1728-header-block-aus).

cc @JustinPinner 

## Changes

- Refactored the `GridPicture` types to split up the image and the slot on the page that it goes into.
- Added AU images from the Grid.
- Updated the digital product header to allow internationalised versions of the image, and added AU version.
- Updated the product block to allow internationalised versions of the app image and copy, and added AU version.
- Tweaked the product block column wrapping to accomodate new copy.

## Screenshots

### Desktop

![au-desktop](https://user-images.githubusercontent.com/5131341/43091083-1e35ec0a-8ea1-11e8-9803-1cf58323f6b8.jpg)

### Tablet

![au-tablet](https://user-images.githubusercontent.com/5131341/43091088-258c1236-8ea1-11e8-9bfa-f74ec4817288.jpg)

### Mobile

![au-mobile](https://user-images.githubusercontent.com/5131341/43091101-2c1f71ec-8ea1-11e8-9e11-7b0dac6d8829.jpg)
