### PR TITLE
Replace h1 elements for h2 or h3 where applicable

### DIFF
--- a/assets/components/doubleHeading/doubleHeading.jsx
+++ b/assets/components/doubleHeading/doubleHeading.jsx
@@ -4,6 +4,7 @@
 
 import React from 'react';
 import { classNameWithModifiers } from 'helpers/utilities';
+import Heading  from 'components/heading/heading';
 
 
 // ---- Types ----- //
@@ -22,12 +23,10 @@ export default function DoubleHeading(props: PropTypes) {
   const className = classNameWithModifiers('component-double-heading', [props.modifierClass]);
 
   return (
-    <div className={className}>
-      <h3>
-        <span className="component-double-heading__heading">{ props.heading }</span>
-        <span className="component-double-heading__subheading">{ props.subheading }</span>
-      </h3>
-    </div>
+    <Heading size={3} className={className}>
+      <span className="component-double-heading__heading">{ props.heading }</span>
+      <span className="component-double-heading__subheading">{ props.subheading }</span>
+    </Heading>
   );
 
 }

--- a/assets/components/doubleHeading/doubleHeading.jsx
+++ b/assets/components/doubleHeading/doubleHeading.jsx
@@ -23,9 +23,9 @@ export default function DoubleHeading(props: PropTypes) {
 
   return (
     <div className={className}>
-      <h3 className="component-double-heading__heading">
-        <div>{ props.heading }</div>
-        <div className="component-double-heading__subheading">{ props.subheading }</div>
+      <h3>
+        <span className="component-double-heading__heading">{ props.heading }</span>
+        <span className="component-double-heading__subheading">{ props.subheading }</span>
       </h3>
     </div>
   );

--- a/assets/components/doubleHeading/doubleHeading.jsx
+++ b/assets/components/doubleHeading/doubleHeading.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { classNameWithModifiers } from 'helpers/utilities';
-import Heading from 'components/heading/heading';
+import Heading, { type HeadingSize } from 'components/heading/heading';
 
 
 // ---- Types ----- //
@@ -12,6 +12,7 @@ import Heading from 'components/heading/heading';
 type PropTypes = {
   heading: string,
   subheading?: string,
+  headingSize: HeadingSize,
   modifierClass?: string,
 };
 
@@ -23,7 +24,7 @@ export default function DoubleHeading(props: PropTypes) {
   const className = classNameWithModifiers('component-double-heading', [props.modifierClass]);
 
   return (
-    <Heading size={3} className={className}>
+    <Heading size={props.headingSize} className={className}>
       <span className="component-double-heading__heading">{ props.heading }</span>
       <span className="component-double-heading__subheading">{ props.subheading }</span>
     </Heading>

--- a/assets/components/doubleHeading/doubleHeading.jsx
+++ b/assets/components/doubleHeading/doubleHeading.jsx
@@ -23,12 +23,10 @@ export default function DoubleHeading(props: PropTypes) {
 
   return (
     <div className={className}>
-      <h1 className="component-double-heading__heading">
-        { props.heading }
-      </h1>
-      <h2 className="component-double-heading__subheading">
-        { props.subheading }
-      </h2>
+      <h3 className="component-double-heading__heading">
+        <div>{ props.heading }</div>
+        <div className="component-double-heading__subheading">{ props.subheading }</div>
+      </h3>
     </div>
   );
 

--- a/assets/components/doubleHeading/doubleHeading.jsx
+++ b/assets/components/doubleHeading/doubleHeading.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { classNameWithModifiers } from 'helpers/utilities';
-import Heading  from 'components/heading/heading';
+import Heading from 'components/heading/heading';
 
 
 // ---- Types ----- //

--- a/assets/components/doubleHeading/doubleHeading.scss
+++ b/assets/components/doubleHeading/doubleHeading.scss
@@ -5,5 +5,6 @@
 }
 
 .component-double-heading__subheading {
+	display: block;
 	margin: 0;
 }

--- a/assets/components/featureList/featureList.jsx
+++ b/assets/components/featureList/featureList.jsx
@@ -6,8 +6,6 @@ import React, { type Node } from 'react';
 
 import { classNameWithModifiers } from 'helpers/utilities';
 
-import Heading, { type HeadingRange } from 'components/heading/heading';
-
 
 // ----- Types ----- //
 
@@ -24,7 +22,6 @@ export type ListItem =
 type PropTypes = {
   modifierClass?: string,
   listItems: ListItem[],
-  headingSize: HeadingRange,
 };
 
 
@@ -34,7 +31,7 @@ function FeatureList(props: PropTypes) {
 
   const items = props.listItems.map((item: ListItem) => (
     <li className="component-feature-list__item">
-      <ItemHeading heading={item.heading ? item.heading : null} size={props.headingSize} />
+      <ItemHeading heading={item.heading ? item.heading : null} />
       <ItemText text={item.text ? item.text : null} />
     </li>
   ));
@@ -50,16 +47,13 @@ function FeatureList(props: PropTypes) {
 
 // ----- Auxiliary Components ----- //
 
-function ItemHeading(props: { heading: ?Node, size: HeadingRange }) {
+function ItemHeading(props: { heading: ?Node }) {
 
   if (props.heading) {
     return (
-      <Heading
-        className="component-feature-list__heading"
-        size={props.size}
-      >
-        {props.heading}
-      </Heading>
+      <span className="component-feature-list__heading">
+        <strong>{props.heading}</strong>
+      </span>
     );
   }
 

--- a/assets/components/heading/heading.jsx
+++ b/assets/components/heading/heading.jsx
@@ -7,10 +7,10 @@ import React, { type Node } from 'react';
 
 // ----- Types ----- //
 
-export type HeadingRange = 1 | 2 | 3 | 4 | 5 | 6;
+export type HeadingSize = 1 | 2 | 3 | 4 | 5 | 6;
 
 type PropTypes = {
-  size: HeadingRange,
+  size: HeadingSize,
   className: string,
   children: Node,
 };

--- a/assets/components/highlights/highlights.jsx
+++ b/assets/components/highlights/highlights.jsx
@@ -3,7 +3,7 @@
 // ----- Imports ----- //
 
 import React from 'react';
-import Heading  from 'components/heading/heading';
+import Heading from 'components/heading/heading';
 import { classNameWithModifiers } from 'helpers/utilities';
 
 

--- a/assets/components/highlights/highlights.jsx
+++ b/assets/components/highlights/highlights.jsx
@@ -3,6 +3,7 @@
 // ----- Imports ----- //
 
 import React from 'react';
+import Heading  from 'components/heading/heading';
 import { classNameWithModifiers } from 'helpers/utilities';
 
 
@@ -23,13 +24,13 @@ export default function Highlights(props: PropTypes) {
   }
 
   return (
-    <h2 className={classNameWithModifiers('component-highlights', props.modifierClasses)}>
+    <Heading size={2} className={classNameWithModifiers('component-highlights', props.modifierClasses)}>
       {props.highlights.map(highlight => (
         <span className="component-highlights__line">
           <span className={classNameWithModifiers('component-highlights__highlight', props.modifierClasses)}>{highlight}</span>
         </span>
       ))}
-    </h2>
+    </Heading>
   );
 
 }

--- a/assets/components/highlights/highlights.jsx
+++ b/assets/components/highlights/highlights.jsx
@@ -3,7 +3,7 @@
 // ----- Imports ----- //
 
 import React from 'react';
-import Heading from 'components/heading/heading';
+import Heading, { type HeadingSize } from 'components/heading/heading';
 import { classNameWithModifiers } from 'helpers/utilities';
 
 
@@ -11,6 +11,7 @@ import { classNameWithModifiers } from 'helpers/utilities';
 
 type PropTypes = {
   highlights: ?string[],
+  headingSize: HeadingSize,
   modifierClasses: Array<?string>,
 };
 
@@ -24,7 +25,7 @@ export default function Highlights(props: PropTypes) {
   }
 
   return (
-    <Heading size={2} className={classNameWithModifiers('component-highlights', props.modifierClasses)}>
+    <Heading size={props.headingSize} className={classNameWithModifiers('component-highlights', props.modifierClasses)}>
       {props.highlights.map(highlight => (
         <span className="component-highlights__line">
           <span className={classNameWithModifiers('component-highlights__highlight', props.modifierClasses)}>{highlight}</span>

--- a/assets/components/highlights/highlights.jsx
+++ b/assets/components/highlights/highlights.jsx
@@ -23,13 +23,13 @@ export default function Highlights(props: PropTypes) {
   }
 
   return (
-    <h1 className={classNameWithModifiers('component-highlights', props.modifierClasses)}>
+    <h2 className={classNameWithModifiers('component-highlights', props.modifierClasses)}>
       {props.highlights.map(highlight => (
         <span className="component-highlights__line">
           <span className={classNameWithModifiers('component-highlights__highlight', props.modifierClasses)}>{highlight}</span>
         </span>
       ))}
-    </h1>
+    </h2>
   );
 
 }

--- a/assets/components/introduction/circlesIntroduction.jsx
+++ b/assets/components/introduction/circlesIntroduction.jsx
@@ -10,6 +10,7 @@ import SvgCirclesHeroMobile from 'components/svgs/circlesHeroMobile';
 import Highlights from 'components/highlights/highlights';
 import { classNameWithModifiers } from 'helpers/utilities';
 
+import { type HeadingSize } from 'components/heading/heading';
 
 // ----- Types ----- //
 
@@ -17,6 +18,7 @@ type PropTypes = {
   headings: string[],
   highlights?: ?string[],
   modifierClasses: Array<?string>,
+  highlightsHeadingSize: HeadingSize,
 };
 
 
@@ -34,7 +36,11 @@ function CirclesIntroduction(props: PropTypes) {
           {props.headings.map(heading =>
             <span className="component-circles-introduction__heading-line">{heading}</span>)}
         </h1>
-        <Highlights highlights={props.highlights} modifierClasses={props.modifierClasses} />
+        <Highlights
+          highlights={props.highlights}
+          modifierClasses={props.modifierClasses}
+          headingSize={props.highlightsHeadingSize}
+        />
       </div>
     </section>
   );
@@ -47,6 +53,7 @@ function CirclesIntroduction(props: PropTypes) {
 CirclesIntroduction.defaultProps = {
   highlights: null,
   modifierClasses: [],
+  highlightsHeadingSize: 2,
 };
 
 

--- a/assets/components/introduction/squaresIntroduction.jsx
+++ b/assets/components/introduction/squaresIntroduction.jsx
@@ -9,12 +9,15 @@ import SvgSquaresHeroTablet from 'components/svgs/squaresHeroTablet';
 import SvgSquaresHeroMobile from 'components/svgs/squaresHeroMobile';
 import Highlights from 'components/highlights/highlights';
 
+import { type HeadingSize } from 'components/heading/heading';
+
 
 // ----- Types ----- //
 
 type PropTypes = {
   highlights?: ?string[],
   headings: string[],
+  highlightsHeadingSize: HeadingSize,
 };
 
 
@@ -27,7 +30,10 @@ function SquaresIntroduction(props: PropTypes) {
       <SvgSquaresHeroTablet />
       <SvgSquaresHeroMobile />
       <div className="component-squares-introduction__content">
-        <Highlights highlights={props.highlights} />
+        <Highlights
+          highlights={props.highlights}
+          headingSize={props.highlightsHeadingSize}
+        />
         <h1 className="component-squares-introduction__heading">
           {props.headings.map(heading =>
             <span className="component-squares-introduction__heading-line">{heading}</span>)}
@@ -42,6 +48,7 @@ function SquaresIntroduction(props: PropTypes) {
 
 SquaresIntroduction.defaultProps = {
   highlights: null,
+  highlightsHeadingSize: 2,
 };
 
 

--- a/assets/components/readyToSupport/readyToSupport.jsx
+++ b/assets/components/readyToSupport/readyToSupport.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 import CtaLink from 'components/ctaLink/ctaLink';
 import SvgChevronUp from 'components/svgs/chevronUp';
-
+import Heading  from 'components/heading/heading';
 
 // ----- Props ----- //
 
@@ -22,10 +22,10 @@ export default function ReadyToSupport(props: PropTypes) {
   return (
     <section className="component-ready-to-support">
       <div className="component-ready-to-support__content">
-        <h3 className="component-ready-to-support__heading">
+        <Heading size={3} className="component-ready-to-support__heading">
           <span className="component-ready-to-support__heading-line">Ready to support</span>
           <span className="component-ready-to-support__heading-line">The&nbsp;Guardian?</span>
-        </h3>
+        </Heading>
         <CtaLink
           text="See supporter options"
           url={props.ctaUrl}

--- a/assets/components/readyToSupport/readyToSupport.jsx
+++ b/assets/components/readyToSupport/readyToSupport.jsx
@@ -22,10 +22,10 @@ export default function ReadyToSupport(props: PropTypes) {
   return (
     <section className="component-ready-to-support">
       <div className="component-ready-to-support__content">
-        <h1 className="component-ready-to-support__heading">
+        <h3 className="component-ready-to-support__heading">
           <span className="component-ready-to-support__heading-line">Ready to support</span>
           <span className="component-ready-to-support__heading-line">The&nbsp;Guardian?</span>
-        </h1>
+        </h3>
         <CtaLink
           text="See supporter options"
           url={props.ctaUrl}

--- a/assets/components/readyToSupport/readyToSupport.jsx
+++ b/assets/components/readyToSupport/readyToSupport.jsx
@@ -6,12 +6,13 @@ import React from 'react';
 
 import CtaLink from 'components/ctaLink/ctaLink';
 import SvgChevronUp from 'components/svgs/chevronUp';
-import Heading from 'components/heading/heading';
+import Heading, { type HeadingSize } from 'components/heading/heading';
 
 // ----- Props ----- //
 
 type PropTypes = {
   ctaUrl: string,
+  headingSize: HeadingSize,
 };
 
 
@@ -22,7 +23,7 @@ export default function ReadyToSupport(props: PropTypes) {
   return (
     <section className="component-ready-to-support">
       <div className="component-ready-to-support__content">
-        <Heading size={3} className="component-ready-to-support__heading">
+        <Heading size={props.headingSize} className="component-ready-to-support__heading">
           <span className="component-ready-to-support__heading-line">Ready to support</span>
           <span className="component-ready-to-support__heading-line">The&nbsp;Guardian?</span>
         </Heading>

--- a/assets/components/readyToSupport/readyToSupport.jsx
+++ b/assets/components/readyToSupport/readyToSupport.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 import CtaLink from 'components/ctaLink/ctaLink';
 import SvgChevronUp from 'components/svgs/chevronUp';
-import Heading  from 'components/heading/heading';
+import Heading from 'components/heading/heading';
 
 // ----- Props ----- //
 

--- a/assets/components/subscriptionBundle/subscriptionBundle.jsx
+++ b/assets/components/subscriptionBundle/subscriptionBundle.jsx
@@ -11,6 +11,7 @@ import GridImage from 'components/gridImage/gridImage';
 
 import { classNameWithModifiers } from 'helpers/utilities';
 
+import type { HeadingSize } from 'components/heading/heading';
 import type { ListItem } from 'components/featureList/featureList';
 import type { GridImg } from 'components/gridImage/gridImage';
 
@@ -26,6 +27,7 @@ type PropTypes = {
   ctaUrl: string,
   ctaAccessibilityHint: string,
   gridImage: GridImg,
+  headingSize: HeadingSize,
   ctaModifiers?: Array<?string>,
 };
 
@@ -41,6 +43,7 @@ export default function SubscriptionBundle(props: PropTypes) {
         <DoubleHeading
           heading={props.heading}
           subheading={props.subheading}
+          headingSize={props.headingSize}
         />
         <FeatureList listItems={props.benefits} modifierClass={props.modifierClass} />
         <CtaLink

--- a/assets/components/subscriptionBundle/subscriptionBundle.jsx
+++ b/assets/components/subscriptionBundle/subscriptionBundle.jsx
@@ -42,7 +42,7 @@ export default function SubscriptionBundle(props: PropTypes) {
           heading={props.heading}
           subheading={props.subheading}
         />
-        <FeatureList listItems={props.benefits} modifierClass={props.modifierClass} headingSize={3} />
+        <FeatureList listItems={props.benefits} modifierClass={props.modifierClass} />
         <CtaLink
           text={props.ctaText}
           url={props.ctaUrl}

--- a/assets/components/threeSubscriptions/threeSubscriptions.jsx
+++ b/assets/components/threeSubscriptions/threeSubscriptions.jsx
@@ -12,12 +12,16 @@ import PageSection from 'components/pageSection/pageSection';
 import SubscriptionBundle from 'components/subscriptionBundle/subscriptionBundle';
 
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
+import type { HeadingSize } from 'components/heading/heading';
 
 
 // ----- Types ----- //
 
 type PropTypes = {
   referrerAcquisitionData: ReferrerAcquisitionData,
+  digitalHeadingSize: HeadingSize,
+  paperHeadingSize: HeadingSize,
+  paperDigitalHeadingSize: HeadingSize,
 };
 
 
@@ -44,9 +48,9 @@ export default function ThreeSubscriptions(props: PropTypes) {
   return (
     <div className="component-three-subscriptions">
       <PageSection heading="Subscribe" modifierClass="three-subscriptions">
-        <DigitalBundle url={subsLinks.digital} />
-        <PaperBundle url={subsLinks.paper} />
-        <PaperDigitalBundle url={subsLinks.paperDig} />
+        <DigitalBundle url={subsLinks.digital} headingSize={props.digitalHeadingSize} />
+        <PaperBundle url={subsLinks.paper} headingSize={props.paperHeadingSize} />
+        <PaperDigitalBundle url={subsLinks.paperDig} headingSize={props.paperDigitalHeadingSize} />
       </PageSection>
     </div>
   );
@@ -56,7 +60,7 @@ export default function ThreeSubscriptions(props: PropTypes) {
 
 // ----- Auxiliary Components ----- //
 
-function DigitalBundle(props: { url: string }) {
+function DigitalBundle(props: { url: string, headingSize: HeadingSize }) {
 
   return (
     <SubscriptionBundle
@@ -73,12 +77,13 @@ function DigitalBundle(props: { url: string }) {
         ...gridImageProperties,
       }}
       ctaModifiers={['digital', 'border']}
+      headingSize={props.headingSize}
     />
   );
 
 }
 
-function PaperBundle(props: { url: string }) {
+function PaperBundle(props: { url: string, headingSize: HeadingSize }) {
 
   return (
     <SubscriptionBundle
@@ -95,12 +100,13 @@ function PaperBundle(props: { url: string }) {
         ...gridImageProperties,
       }}
       ctaModifiers={['paper', 'border']}
+      headingSize={props.headingSize}
     />
   );
 
 }
 
-function PaperDigitalBundle(props: { url: string }) {
+function PaperDigitalBundle(props: { url: string, headingSize: HeadingSize }) {
 
   return (
     <SubscriptionBundle
@@ -117,6 +123,7 @@ function PaperDigitalBundle(props: { url: string }) {
         ...gridImageProperties,
       }}
       ctaModifiers={['paper-digital', 'border']}
+      headingSize={props.headingSize}
     />
   );
 

--- a/assets/components/whySupport/whySupport.jsx
+++ b/assets/components/whySupport/whySupport.jsx
@@ -20,29 +20,29 @@ export default function WhySupport() {
   return (
     <div className="component-why-support">
       <PageSection heading="Why support?" modifierClass="why-support">
-        <h1 className="component-why-support__heading">
+        <h3 className="component-why-support__heading">
           <SvgScribble />
-        </h1>
+        </h3>
         <p className="component-why-support__copy">
           Your support is vital in helping the Guardian do the most important
           journalism of all: that which takes time and effort. More people
           than ever now read and support the Guardian&#39;s independent,
           quality and investigative journalism.
         </p>
-        <h1 className="component-why-support__heading">
+        <h3 className="component-why-support__heading">
           <SvgAdvertisingGraphMobile />
           <SvgAdvertisingGraphDesktop />
-        </h1>
+        </h3>
         <p className="component-why-support__copy">
           Like many media organisations, the Guardian is operating in an
           incredibly challenging commercial environment, and the advertising
           that we used to rely on to fund our work continues to fall.
         </p>
-        <h1 className="component-why-support__heading component-why-support__heading--paywall">
+        <h3 className="component-why-support__heading component-why-support__heading--paywall">
           <SvgPaywallMobile />
           <SvgPaywallDesktop />
           <SvgPaywallWide />
-        </h1>
+        </h3>
         <p className="component-why-support__copy">
           We want to keep our journalism as open as we can.
         </p>

--- a/assets/components/whySupport/whySupport.jsx
+++ b/assets/components/whySupport/whySupport.jsx
@@ -11,16 +11,22 @@ import SvgAdvertisingGraphDesktop from 'components/svgs/advertisingGraphDesktop'
 import SvgPaywallMobile from 'components/svgs/payWallMobile';
 import SvgPaywallDesktop from 'components/svgs/payWallDesktop';
 import SvgPaywallWide from 'components/svgs/payWallWide';
-import Heading from 'components/heading/heading';
+import Heading, { type HeadingSize } from 'components/heading/heading';
+
+// ----- Props ----- //
+
+type PropTypes = {
+  headingSize: HeadingSize,
+};
 
 // ----- Component ----- //
 
-export default function WhySupport() {
+export default function WhySupport(props: PropTypes) {
 
   return (
     <div className="component-why-support">
       <PageSection heading="Why support?" modifierClass="why-support">
-        <Heading size={3} className="component-why-support__heading">
+        <Heading size={props.headingSize} className="component-why-support__heading">
           <SvgScribble />
         </Heading>
         <p className="component-why-support__copy">
@@ -29,7 +35,7 @@ export default function WhySupport() {
           than ever now read and support the Guardian&#39;s independent,
           quality and investigative journalism.
         </p>
-        <Heading size={3} className="component-why-support__heading">
+        <Heading size={props.headingSize} className="component-why-support__heading">
           <SvgAdvertisingGraphMobile />
           <SvgAdvertisingGraphDesktop />
         </Heading>
@@ -38,7 +44,7 @@ export default function WhySupport() {
           incredibly challenging commercial environment, and the advertising
           that we used to rely on to fund our work continues to fall.
         </p>
-        <Heading size={3} className="component-why-support__heading component-why-support__heading--paywall">
+        <Heading size={props.headingSize} className="component-why-support__heading component-why-support__heading--paywall">
           <SvgPaywallMobile />
           <SvgPaywallDesktop />
           <SvgPaywallWide />

--- a/assets/components/whySupport/whySupport.jsx
+++ b/assets/components/whySupport/whySupport.jsx
@@ -11,7 +11,7 @@ import SvgAdvertisingGraphDesktop from 'components/svgs/advertisingGraphDesktop'
 import SvgPaywallMobile from 'components/svgs/payWallMobile';
 import SvgPaywallDesktop from 'components/svgs/payWallDesktop';
 import SvgPaywallWide from 'components/svgs/payWallWide';
-
+import Heading  from 'components/heading/heading';
 
 // ----- Component ----- //
 
@@ -20,29 +20,29 @@ export default function WhySupport() {
   return (
     <div className="component-why-support">
       <PageSection heading="Why support?" modifierClass="why-support">
-        <h3 className="component-why-support__heading">
+        <Heading size={3} className="component-why-support__heading">
           <SvgScribble />
-        </h3>
+        </Heading>
         <p className="component-why-support__copy">
           Your support is vital in helping the Guardian do the most important
           journalism of all: that which takes time and effort. More people
           than ever now read and support the Guardian&#39;s independent,
           quality and investigative journalism.
         </p>
-        <h3 className="component-why-support__heading">
+        <Heading size={3} className="component-why-support__heading">
           <SvgAdvertisingGraphMobile />
           <SvgAdvertisingGraphDesktop />
-        </h3>
+        </Heading>
         <p className="component-why-support__copy">
           Like many media organisations, the Guardian is operating in an
           incredibly challenging commercial environment, and the advertising
           that we used to rely on to fund our work continues to fall.
         </p>
-        <h3 className="component-why-support__heading component-why-support__heading--paywall">
+        <Heading size={3} className="component-why-support__heading component-why-support__heading--paywall">
           <SvgPaywallMobile />
           <SvgPaywallDesktop />
           <SvgPaywallWide />
-        </h3>
+        </Heading>
         <p className="component-why-support__copy">
           We want to keep our journalism as open as we can.
         </p>

--- a/assets/components/whySupport/whySupport.jsx
+++ b/assets/components/whySupport/whySupport.jsx
@@ -11,7 +11,7 @@ import SvgAdvertisingGraphDesktop from 'components/svgs/advertisingGraphDesktop'
 import SvgPaywallMobile from 'components/svgs/payWallMobile';
 import SvgPaywallDesktop from 'components/svgs/payWallDesktop';
 import SvgPaywallWide from 'components/svgs/payWallWide';
-import Heading  from 'components/heading/heading';
+import Heading from 'components/heading/heading';
 
 // ----- Component ----- //
 

--- a/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
+++ b/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
@@ -43,12 +43,20 @@ const content = (
         headings={['Help us deliver the', 'independent journalism', 'the world needs']}
         highlights={['Support The Guardian']}
         modifierClasses={['compact']}
+        highlightsHeadingSize={2}
       />
       <section id={supporterSectionId}>
-        <ThreeSubscriptionsContainer />
+        <ThreeSubscriptionsContainer
+          digitalHeadingSize={3}
+          paperHeadingSize={3}
+          paperDigitalHeadingSize={3}
+        />
       </section>
-      <WhySupport />
-      <ReadyToSupport ctaUrl={`#${supporterSectionId}`} />
+      <WhySupport headingSize={3} />
+      <ReadyToSupport
+        ctaUrl={`#${supporterSectionId}`}
+        headingSize={3}
+      />
       <PatronsEventsContainer />
     </Page>
   </Provider>

--- a/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
+++ b/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
@@ -55,7 +55,7 @@ const content = (
       <WhySupport headingSize={3} />
       <ReadyToSupport
         ctaUrl={`#${supporterSectionId}`}
-        headingSize={3}
+        headingSize={2}
       />
       <PatronsEventsContainer />
     </Page>

--- a/assets/pages/support-landing/supportLanding.jsx
+++ b/assets/pages/support-landing/supportLanding.jsx
@@ -60,6 +60,7 @@ const content = (
         headings={['Help us deliver the', 'independent journalism', 'the world needs']}
         highlights={['Support The Guardian']}
         modifierClasses={['compact']}
+        highlightsHeadingSize={2}
       />
       <section id={supporterSectionId}>
         <Contribute
@@ -72,10 +73,17 @@ const content = (
             PayPalButton={PayPalContributionButtonContainer}
           />
         </Contribute>
-        <ThreeSubscriptionsContainer />
+        <ThreeSubscriptionsContainer
+          digitalHeadingSize={3}
+          paperHeadingSize={3}
+          paperDigitalHeadingSize={3}
+        />
       </section>
-      <WhySupport />
-      <ReadyToSupport ctaUrl={`#${supporterSectionId}`} />
+      <WhySupport headingSize={3} />
+      <ReadyToSupport
+        ctaUrl={`#${supporterSectionId}`}
+        headingSize={3}
+      />
       <PatronsEventsContainer />
     </Page>
   </Provider>

--- a/assets/pages/support-landing/supportLanding.jsx
+++ b/assets/pages/support-landing/supportLanding.jsx
@@ -82,7 +82,7 @@ const content = (
       <WhySupport headingSize={3} />
       <ReadyToSupport
         ctaUrl={`#${supporterSectionId}`}
-        headingSize={3}
+        headingSize={2}
       />
       <PatronsEventsContainer />
     </Page>


### PR DESCRIPTION
## Why are you doing this?
Because there should only be one `<h1>` on a page. The showcase page contained nine!

[**Trello Card**](https://trello.com/c/2lLVUOPz/1786-only-one-h1-per-page)

## Changes
* Leave the main page title alone, it's an `<h1>` with multiple spans inside
* Change all other `<h1>` elements to `<h2>` or `<h3>` depending where they sit within the page hierarchy

## Screenshots
**Before**
![screencapture-support-thegulocal-uk-before-2018-07-24-12_58_32](https://user-images.githubusercontent.com/690395/43136667-5f80191a-8f41-11e8-9924-003097e51356.png)

**After**
![screencapture-support-thegulocal-uk-after-2018-07-24-12_21_00](https://user-images.githubusercontent.com/690395/43136473-c619cb40-8f40-11e8-902a-8a8f1a59c485.png)

Note: You shouldn't have seen any differences between those screen captures!