### PR TITLE
Strip trailing slashes from paths

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -102,4 +102,9 @@ class Application(
   def healthcheck: Action[AnyContent] = PrivateAction {
     Ok("healthy")
   }
+
+  // Remove trailing slashes so that /uk/ redirects to /uk
+  def removeTrailingSlash(path: String): Action[AnyContent] = CachedAction() {
+    MovedPermanently("/" + path)
+  }
 }

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -105,6 +105,7 @@ class Application(
 
   // Remove trailing slashes so that /uk/ redirects to /uk
   def removeTrailingSlash(path: String): Action[AnyContent] = CachedAction() {
-    MovedPermanently("/" + path)
+    request =>
+      Redirect("/" + path, request.queryString, MOVED_PERMANENTLY)
   }
 }

--- a/conf/routes
+++ b/conf/routes
@@ -6,6 +6,10 @@ GET /healthcheck                                    controllers.Application.heal
 
 GET /unsupported-browser                            controllers.Application.unsupportedBrowser
 
+# ----- Remove trailing slashes so that /uk/ redirects to /uk ---- #
+
+GET  /*path/  controllers.Application.removeTrailingSlash(path: String)
+
 # ----- Bundles Landing Page ----- #
 
 GET /uk                                             controllers.Application.supportLanding()


### PR DESCRIPTION
## Why are you doing this?

Currently if a user types in a url of `/uk/` we serve a 404. This PR changes that behaviour so that we redirect them to `/uk` instead.
