### PR TITLE
Remove noisy akka user agent warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,7 +66,7 @@ libraryDependencies ++= Seq(
   "com.gu" %% "support-models" % "0.26",
   "com.gu" %% "support-config" % "0.16",
   "com.gu" %% "fezziwig" % "0.8",
-  "com.typesafe.akka" %% "akka-agent" % "2.5.6",
+  "com.typesafe.akka" %% "akka-agent" % "2.5.14",
   "com.gu" %% "support-internationalisation" % "0.9",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.14")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.16")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.7")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.13")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.13")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.14")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
 


### PR DESCRIPTION
This change bumps Play to a later version and Akka to its latest version.

This change is to remove the huge amount of "invalid user-agent" warning messages in the support-frontend logs. These were so numerous as to render the logs almost unreadable.
See https://github.com/guardian/grid/pull/2129 for similar change for same reason.

A fix to this issue became available in Play 2.6.13: https://discuss.lightbend.com/t/play-2-6-13-released/629