### PR TITLE
Add a placeholder checkout page for digital pack

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -84,11 +84,11 @@ class Application(
     ))
   }
 
-  def contributionsLanding(id: String): Action[AnyContent] = CachedAction() { implicit request =>
+  def contributionsLanding(countryCode: String): Action[AnyContent] = CachedAction() { implicit request =>
     Ok(views.html.main(
       title = "Support the Guardian | Make a Contribution",
       description = Some(stringsConfig.contributionsLandingDescription),
-      mainId = id,
+      mainId = s"contributions-landing-page-$countryCode",
       mainJsBundle = "contributionsLandingPage.js",
       mainStyleBundle = "contributionsLandingPageStyles.css",
       scripts = views.html.addToWindow("paymentApiPayPalEndpoint", paymentAPIService.payPalCreatePaymentEndpoint)

--- a/app/controllers/SiteMap.scala
+++ b/app/controllers/SiteMap.scala
@@ -53,7 +53,7 @@ class SiteMap(
 
   private def contributionsLandingPageUS()(implicit req: RequestHeader) = {
     routes.Application.contributionsLanding(
-      id = "contributions-landing-page-us"
+      country = "us"
     ).absoluteURL(secure = true)
   }
 

--- a/app/controllers/Subscriptions.scala
+++ b/app/controllers/Subscriptions.scala
@@ -68,12 +68,14 @@ class Subscriptions(
     Redirect(redirectUrl, request.queryString, status = FOUND)
   }
 
-  def digitalCheckout(countryCode: String): Action[AnyContent] = CachedAction() { implicit request =>
-    val title = "Support the Guardian | Digital Subscription"
-    val id = "digital-subscription-checkout-page-" + countryCode
-    val js = "digitalSubscriptionCheckoutPage.js"
-    val css = "digitalSubscriptionCheckoutPageStyles.css"
-    Ok(views.html.main(title, id, js, css))
-  }
+  def displayForm(countryCode: String): Action[AnyContent] =
+    authenticatedAction(recurringIdentityClientId) {
+      implicit request =>
+        val title = "Support the Guardian | Digital Subscription"
+        val id = "digital-subscription-checkout-page-" + countryCode
+        val js = "digitalSubscriptionCheckoutPage.js"
+        val css = "digitalSubscriptionCheckoutPageStyles.css"
+        Ok(views.html.main(title, id, js, css))
+    }
 
 }

--- a/app/controllers/Subscriptions.scala
+++ b/app/controllers/Subscriptions.scala
@@ -68,4 +68,12 @@ class Subscriptions(
     Redirect(redirectUrl, request.queryString, status = FOUND)
   }
 
+  def digitalCheckout(countryCode: String): Action[AnyContent] = CachedAction() { implicit request =>
+    val title = "Support the Guardian | Digital Subscription"
+    val id = "digital-subscription-checkout-page-" + countryCode
+    val js = "digitalSubscriptionCheckoutPage.js"
+    val css = "digitalSubscriptionCheckoutPageStyles.css"
+    Ok(views.html.main(title, id, js, css))
+  }
+
 }

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.jsx
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.jsx
@@ -1,0 +1,61 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+import { Provider } from 'react-redux';
+
+import { renderPage } from 'helpers/render';
+import { detect, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { init as pageInit } from 'helpers/page/page';
+
+import Page from 'components/page/page';
+import countrySwitcherHeaderContainer from 'components/headers/countrySwitcherHeader/countrySwitcherHeaderContainer';
+import CustomerService from 'components/customerService/customerService';
+import Footer from 'components/footer/footer';
+import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
+
+
+// ----- Redux Store ----- //
+
+const store = pageInit();
+
+// ----- Internationalisation ----- //
+
+const countryGroupId: CountryGroupId = detect();
+
+const reactElementId: {
+  [CountryGroupId]: string,
+} = {
+  GBPCountries: 'digital-subscription-checkout-page-uk',
+  UnitedStates: 'digital-subscription-checkout-page-us',
+  AUDCountries: 'digital-subscription-checkout-page-au',
+  International: 'digital-subscription-checkout-page-int',
+};
+
+const CountrySwitcherHeader = countrySwitcherHeaderContainer(
+  '/subscribe/digital',
+  [
+    'GBPCountries',
+    'UnitedStates',
+    'AUDCountries',
+    'International',
+  ],
+);
+
+// ----- Render ----- //
+
+const content = (
+  <Provider store={store}>
+    <Page
+      header={<CountrySwitcherHeader />}
+      footer={<Footer><CustomerService selectedCountryGroup={countryGroupId} /></Footer>}
+    >
+      <LeftMarginSection modifierClasses={['grey']}>
+        <p>Placeholder</p>
+      </LeftMarginSection>
+    </Page>
+  </Provider>
+);
+
+renderPage(content, reactElementId[countryGroupId]);

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss
@@ -1,0 +1,33 @@
+// -----  gu-sass ----- //
+
+@import '~stylesheets/gu-sass/gu-sass';
+
+
+// ----- Shared Components ----- //
+
+@import '~components/countryGroupSwitcher/countryGroupSwitcher';
+@import '~components/selectInput/selectInput';
+@import '~components/ctaLink/ctaLink';
+@import '~components/footer/footer';
+@import '~components/headers/countrySwitcherHeader/countrySwitcherHeader';
+@import '~components/leftMarginSection/leftMarginSection';
+@import '~components/customerService/customerService';
+
+
+// ----- Page-Specific Styles ----- //
+
+#digital-subscription-checkout-page-int,
+#digital-subscription-checkout-page-uk,
+#digital-subscription-checkout-page-us,
+#digital-subscription-checkout-page-au {
+  .component-left-margin-section__content {
+    overflow-x: hidden;
+    @include mq($from: leftCol) {
+      overflow-x: visible;
+    }
+  }
+}
+
+.component-left-margin-section--grey {
+  background: gu-colour(neutral-6);
+}

--- a/conf/routes
+++ b/conf/routes
@@ -75,6 +75,10 @@ GET  /uk/subscribe/digital                         controllers.Subscriptions.dig
 GET  /us/subscribe/digital                         controllers.Subscriptions.digital(countryCode="us")
 GET  /au/subscribe/digital                         controllers.Subscriptions.digital(countryCode="au")
 GET  /int/subscribe/digital                        controllers.Subscriptions.digital(countryCode="int")
+GET  /uk/subscribe/digital/checkout                controllers.Subscriptions.digitalCheckout(countryCode="uk")
+GET  /us/subscribe/digital/checkout                controllers.Subscriptions.digitalCheckout(countryCode="us")
+GET  /au/subscribe/digital/checkout                controllers.Subscriptions.digitalCheckout(countryCode="au")
+GET  /int/subscribe/digital/checkout               controllers.Subscriptions.digitalCheckout(countryCode="int")
 
 # ----- Authentication ----- #
 

--- a/conf/routes
+++ b/conf/routes
@@ -37,13 +37,7 @@ GET  /monthly-contributions                         controllers.Application.cont
 # ----- Contributions ----- #
 
 GET  /contribute                                    controllers.Application.contributeGeoRedirect()
-GET  /uk/contribute                                 controllers.Application.contributionsLanding(id="contributions-landing-page-uk")
-GET  /us/contribute                                 controllers.Application.contributionsLanding(id="contributions-landing-page-us")
-GET  /au/contribute                                 controllers.Application.contributionsLanding(id="contributions-landing-page-au")
-GET  /eu/contribute                                 controllers.Application.contributionsLanding(id="contributions-landing-page-eu")
-GET  /int/contribute                                controllers.Application.contributionsLanding(id="contributions-landing-page-int")
-GET  /nz/contribute                                 controllers.Application.contributionsLanding(id="contributions-landing-page-nz")
-GET  /ca/contribute                                 controllers.Application.contributionsLanding(id="contributions-landing-page-ca")
+GET  /$country<(uk|us|au|eu|int|nz|ca)>/contribute  controllers.Application.contributionsLanding(country: String)
 
 GET  /contribute/recurring                          controllers.RegularContributions.displayForm()
 GET  /contribute/recurring/thankyou                 controllers.RegularContributions.displayForm()
@@ -68,17 +62,11 @@ GET  /uk/subscribe                                 controllers.Subscriptions.lan
 
 # This is just a fallback in case someone accidentally uses an unsupported country-specific
 # subscribe route. We just redirect to the subscriptions site and let its geolocation handle it.
-GET  /:countryCode/subscribe                       controllers.Subscriptions.legacyRedirect(countryCode: String)
+GET  /:country/subscribe                           controllers.Subscriptions.legacyRedirect(country: String)
 
 GET  /subscribe/digital                            controllers.Subscriptions.digitalGeoRedirect()
-GET  /uk/subscribe/digital                         controllers.Subscriptions.digital(countryCode="uk")
-GET  /us/subscribe/digital                         controllers.Subscriptions.digital(countryCode="us")
-GET  /au/subscribe/digital                         controllers.Subscriptions.digital(countryCode="au")
-GET  /int/subscribe/digital                        controllers.Subscriptions.digital(countryCode="int")
-GET  /uk/subscribe/digital/checkout                controllers.Subscriptions.digitalCheckout(countryCode="uk")
-GET  /us/subscribe/digital/checkout                controllers.Subscriptions.digitalCheckout(countryCode="us")
-GET  /au/subscribe/digital/checkout                controllers.Subscriptions.digitalCheckout(countryCode="au")
-GET  /int/subscribe/digital/checkout               controllers.Subscriptions.digitalCheckout(countryCode="int")
+GET  /$country<(uk|us|au|int)>/subscribe/digital   controllers.Subscriptions.digital(country: String)
+GET  /$country<(uk|us|au|int)>/subscribe/digital/checkout  controllers.Subscriptions.displayForm(country: String)
 
 # ----- Authentication ----- #
 

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -30,6 +30,8 @@ module.exports = (cssFilename, outputFilename, minimizeCss) => ({
     contributionsLandingPageStyles: 'pages/contributions-landing/contributionsLanding.scss',
     digitalSubscriptionLandingPage: 'pages/digital-subscription-landing/digitalSubscriptionLanding.jsx',
     digitalSubscriptionLandingPageStyles: 'pages/digital-subscription-landing/digitalSubscriptionLanding.scss',
+    digitalSubscriptionCheckoutPage: 'pages/digital-subscription-checkout/digitalSubscriptionCheckout.jsx',
+    digitalSubscriptionCheckoutPageStyles: 'pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss',
     regularContributionsPage: 'pages/regular-contributions/regularContributions.jsx',
     regularContributionsPageStyles: 'pages/regular-contributions/regularContributions.scss',
     oneoffContributionsPage: 'pages/oneoff-contributions/oneoffContributions.jsx',


### PR DESCRIPTION
## Why are you doing this?

Create a placeholder page for Digital Pack checkout and put it behind an Identity check so that only signed in users can access it.

[**Trello Card**](https://trello.com/c/68lxjHGr/1504-sign-in-sign-up-identity)



