### PR TITLE
add paypal payment success message to logs

### DIFF
--- a/app/controllers/PayPalOneOff.scala
+++ b/app/controllers/PayPalOneOff.scala
@@ -55,8 +55,10 @@ class PayPalOneOff(
     )
 
     def processPaymentApiResponse(success: Boolean): Result = {
-      if (success)
+      if (success) {
+        SafeLogger.info(s"One-off contribution for Paypal payment is successful")
         Redirect("/contribute/one-off/thankyou")
+      }
       else {
         SafeLogger.error(scrub"Error making paypal payment")
         Ok(views.html.main(


### PR DESCRIPTION
Small tweak to the logs to include a message when paypal one-off payments are successful.