### PR TITLE
Simplify polling

### DIFF
--- a/app/services/stepfunctions/RegularContributionsClient.scala
+++ b/app/services/stepfunctions/RegularContributionsClient.scala
@@ -128,13 +128,13 @@ class RegularContributionsClient(
           respondToClient(StatusResponse(Status.Pending, trackingUri, None))
         }
 
-        def paymentSuccess(executionHistory: List[HistoryEvent]): Boolean = {
+        def checkoutSuccess(executionHistory: List[HistoryEvent]): Boolean = {
           executionHistory
             .map { event => Try(event.getStateExitedEventDetails.getName) }
-            .contains(Success("PaymentSuccess"))
+            .contains(Success("CheckoutSuccess"))
         }
 
-        if (paymentSuccess(events)) {
+        if (checkoutSuccess(events)) {
           respondToClient(StatusResponse(Status.Success, trackingUri, None))
         } else {
           pendingOrFailure

--- a/app/services/stepfunctions/RegularContributionsClient.scala
+++ b/app/services/stepfunctions/RegularContributionsClient.scala
@@ -1,6 +1,7 @@
 package services.stepfunctions
 
 import java.util.UUID
+
 import scala.concurrent.Future
 import akka.actor.ActorSystem
 import cats.data.EitherT
@@ -11,6 +12,7 @@ import com.gu.support.workers.model._
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.{Decoder, Encoder}
 import codecs.CirceDecoders._
+import com.amazonaws.services.stepfunctions.model.HistoryEvent
 import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
 import com.gu.i18n.Country
 import com.gu.support.workers.model.monthlyContributions.Contribution
@@ -20,6 +22,8 @@ import com.gu.support.workers.model.monthlyContributions.Status
 import monitoring.SafeLogger
 import monitoring.SafeLogger._
 import ophan.thrift.event.AbTest
+
+import scala.util.{Success, Try}
 
 object CreateRegularContributorRequest {
   implicit val decoder: Decoder[CreateRegularContributorRequest] = deriveDecoder
@@ -124,12 +128,17 @@ class RegularContributionsClient(
           respondToClient(StatusResponse(Status.Pending, trackingUri, None))
         }
 
-        events
-          .collect { case event if event.getType == "LambdaFunctionSucceeded" => event.getLambdaFunctionSucceededEventDetails }
-          .flatMap { event => stateWrapper.unWrap[CompletedState](event.getOutput).toOption }
-          .headOption
-          .map { event => respondToClient(StatusResponse(event.status, trackingUri, event.message)) }
-          .getOrElse(pendingOrFailure)
+        def paymentSuccess(executionHistory: List[HistoryEvent]): Boolean = {
+          executionHistory
+            .map { event => Try(event.getStateExitedEventDetails.getName) }
+            .contains(Success("PaymentSuccess"))
+        }
+
+        if (paymentSuccess(events)) {
+          respondToClient(StatusResponse(Status.Success, trackingUri, None))
+        } else {
+          pendingOrFailure
+        }
       }
     )
   }


### PR DESCRIPTION
## Why are you doing this?

The polling logic is currently broken (it always shows the pending thank you page, rather than the thank you page).

This logic relies on parsing the ContributionCompleted state in order to recognise the successful completion of the checkout process. However, since support-workers and support-frontend are using a different version of the schema at the moment (see https://github.com/guardian/support-workers/pull/124/files, https://github.com/guardian/support-frontend/blob/master/build.sbt#L66, https://github.com/guardian/support-models/pull/12) we never acknowledge that an execution has completed successfully.

I've simplified the approach taken in support-workers: https://github.com/guardian/support-workers/pull/131. This PR allows us to understand the new state machine logic.

## Changes

* Look for the CheckoutSuccess state instead of worrying about parsing JSON.

