### PR TITLE
Split Subscriptions Is Plural

### DIFF
--- a/assets/pages/subscriptions-landing/components/splitSubscriptionsTest.jsx
+++ b/assets/pages/subscriptions-landing/components/splitSubscriptionsTest.jsx
@@ -38,9 +38,9 @@ function sendEventsOnClick(
         products: product === 'digital' ? ['DIGITAL_SUBSCRIPTION'] : ['PRINT_SUBSCRIPTION'],
       },
       action: 'CLICK',
-      id: `split_subscription_test_${id}`,
+      id: `split_subscriptions_test_${id}`,
       abTest: {
-        name: 'split_subscription_test',
+        name: 'split_subscriptions_test',
         variant: variant ? 'variant' : 'control',
       },
     });


### PR DESCRIPTION
## Why are you doing this?

Adding an 's', `subscription` -> `subscriptions`.

## Changes

- Changed ophan events to `split_subscriptions_test` from `split_subscription_test`.
