### PR TITLE
a user selecting to cancel their payment should not be logged as an error

### DIFF
--- a/app/controllers/PayPalOneOff.scala
+++ b/app/controllers/PayPalOneOff.scala
@@ -84,7 +84,7 @@ class PayPalOneOff(
   }
 
   def cancelURL(): Action[AnyContent] = PrivateAction { implicit request =>
-    SafeLogger.(info"The user selected cancel payment and decided not to contribute.")
+    SafeLogger.info("The user selected cancel payment and decided not to contribute.")
     Ok(views.html.main(
       "Support the Guardian | PayPal Error",
       "paypal-error-page",

--- a/app/controllers/PayPalOneOff.scala
+++ b/app/controllers/PayPalOneOff.scala
@@ -84,7 +84,7 @@ class PayPalOneOff(
   }
 
   def cancelURL(): Action[AnyContent] = PrivateAction { implicit request =>
-    SafeLogger.error(scrub"The user selected cancel payment and decided not to contribute.")
+    SafeLogger.(info"The user selected cancel payment and decided not to contribute.")
     Ok(views.html.main(
       "Support the Guardian | PayPal Error",
       "paypal-error-page",


### PR DESCRIPTION
Currently we log any payment cancellations from paypal as an error.
This seems incorrect.
This change will log payment cancellations as info - avoiding sentry alerts for something that is not actually an error.
