### PR TITLE
Improve validation on email form (recurring + one off)

### DIFF
--- a/assets/components/contributionsCheckout/contributionsCheckout.scss
+++ b/assets/components/contributionsCheckout/contributionsCheckout.scss
@@ -36,4 +36,14 @@
     margin-top: $gu-v-spacing * 3;
     margin-bottom: $gu-v-spacing * 2;
   }
+
+  .component-error-message {
+    height: 32px;
+    position: relative;
+
+    @include mq($from: desktop) {
+      width: 260px;
+    }
+  }
+
 }

--- a/assets/components/emailFormField/emailFormField.jsx
+++ b/assets/components/emailFormField/emailFormField.jsx
@@ -4,6 +4,8 @@
 
 import React from 'react';
 import TextInput from 'components/textInput/textInput';
+import ErrorMessage from 'components/errorMessage/errorMessage';
+import { validateEmailAddress } from '../../helpers/utilities';
 
 // ----- Types ----- //
 
@@ -11,26 +13,49 @@ type PropTypes = {
   emailUpdate: (email: string) => void,
   email: string,
   isSignedIn: boolean,
+  setEmailHasBeenBlurred: () => void,
+  emailHasBeenBlurred: boolean,
 };
-
 
 // ----- Component ----- //
 
 const EmailFormField = (props: PropTypes) => {
 
+  const showEmailError = props.emailHasBeenBlurred && !validateEmailAddress(props.email);
+
   if (props.isSignedIn) {
     return null;
   }
 
-  return (<TextInput
-    id="email"
-    value={props.email}
-    labelText="Email"
-    placeholder="Email"
-    onChange={props.emailUpdate}
-    modifierClasses={['email']}
-    required
-  />);
+  const modifierClass = ['email'];
+
+  if (showEmailError) {
+    modifierClass.push('error');
+  }
+
+  const errorMessage = () => {
+    if (!showEmailError) {
+      return '';
+    }
+    return (<ErrorMessage message="Please enter a valid email address." />);
+  };
+
+
+  return (
+    <div>
+      <TextInput
+        id="email"
+        value={props.email}
+        labelText="Email"
+        placeholder="Email"
+        onChange={props.emailUpdate}
+        onBlur={props.setEmailHasBeenBlurred}
+        modifierClasses={modifierClass}
+        required
+      />
+      {errorMessage()}
+    </div>
+  );
 
 };
 

--- a/assets/components/emailFormField/emailFormField.jsx
+++ b/assets/components/emailFormField/emailFormField.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import TextInput from 'components/textInput/textInput';
 import ErrorMessage from 'components/errorMessage/errorMessage';
-import { validateEmailAddress } from '../../helpers/utilities';
+import { validateEmailAddress } from 'helpers/utilities';
 
 // ----- Types ----- //
 
@@ -18,6 +18,14 @@ type PropTypes = {
 };
 
 // ----- Component ----- //
+
+
+const EmailError = (props: {showEmailError: boolean}) => {
+  if (!props.showEmailError) {
+    return null;
+  }
+  return <ErrorMessage message="Please enter a valid email address." />;
+};
 
 const EmailFormField = (props: PropTypes) => {
 
@@ -33,16 +41,8 @@ const EmailFormField = (props: PropTypes) => {
     modifierClass.push('error');
   }
 
-  const errorMessage = () => {
-    if (!showEmailError) {
-      return '';
-    }
-    return (<ErrorMessage message="Please enter a valid email address." />);
-  };
-
-
   return (
-    <div>
+    <div className="component-email-form-field">
       <TextInput
         id="email"
         value={props.email}
@@ -53,7 +53,7 @@ const EmailFormField = (props: PropTypes) => {
         modifierClasses={modifierClass}
         required
       />
-      {errorMessage()}
+      <EmailError showEmailError={showEmailError} />
     </div>
   );
 

--- a/assets/components/textInput/textInput.jsx
+++ b/assets/components/textInput/textInput.jsx
@@ -17,6 +17,7 @@ type PropTypes = {
   placeholder: string,
   required: boolean,
   modifierClasses: Array<?string>,
+  onBlur?: () => void,
 };
 
 
@@ -30,10 +31,11 @@ export default function TextInput(props: PropTypes) {
         {props.labelText}
       </label>
       <input
-        className="component-text-input__input"
+        className={classNameWithModifiers('component-text-input__input', props.modifierClasses)}
         type="text"
         id={props.id}
         onChange={event => props.onChange(event.target.value || '')}
+        onBlur={props.onBlur}
         value={props.value}
         placeholder={props.placeholder}
         required={props.required}
@@ -50,4 +52,5 @@ TextInput.defaultProps = {
   placeholder: '',
   required: false,
   modifierClasses: [],
+  onBlur: () => undefined,
 };

--- a/assets/components/textInput/textInput.jsx
+++ b/assets/components/textInput/textInput.jsx
@@ -17,7 +17,7 @@ type PropTypes = {
   placeholder: string,
   required: boolean,
   modifierClasses: Array<?string>,
-  onBlur?: () => void,
+  onBlur: () => void,
 };
 
 

--- a/assets/helpers/user/userReducer.js
+++ b/assets/helpers/user/userReducer.js
@@ -1,7 +1,6 @@
 // @flow
 
 // ----- Imports ----- //
-
 import type { Action } from './userActions';
 
 

--- a/assets/pages/oneoff-contributions/__tests__/__snapshots__/oneoffContributionsReducersTest.js.snap
+++ b/assets/pages/oneoff-contributions/__tests__/__snapshots__/oneoffContributionsReducersTest.js.snap
@@ -13,6 +13,7 @@ Object {
   },
   "oneoffContrib": Object {
     "amount": 20,
+    "emailHasBeenBlurred": false,
     "error": null,
   },
   "stripeInlineForm": Object {

--- a/assets/pages/oneoff-contributions/__tests__/oneoffContributionsReducersTest.js
+++ b/assets/pages/oneoff-contributions/__tests__/oneoffContributionsReducersTest.js
@@ -41,4 +41,13 @@ describe('One-off Reducer', () => {
     expect(newState.oneoffContrib.error).toMatchSnapshot();
   });
 
+  it('should handle SET_EMAIL_HAS_BEEN_BLURRED', () => {
+
+    const action = { type: 'SET_EMAIL_HAS_BEEN_BLURRED' };
+
+    const newState = reducer(undefined, action);
+
+    expect(newState.oneoffContrib.emailHasBeenBlurred).toEqual(true);
+  });
+
 });

--- a/assets/pages/oneoff-contributions/components/emailFormFieldContainer.jsx
+++ b/assets/pages/oneoff-contributions/components/emailFormFieldContainer.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 
 import { setEmail } from 'helpers/user/userActions';
 import EmailFormField from 'components/emailFormField/emailFormField';
+import { setEmailHasBeenBlurred } from '../oneoffContributionsActions';
 
 // ----- State/Action Maps ----- //
 
@@ -12,11 +13,15 @@ function mapStateToProps(state) {
   return {
     email: state.page.user.email,
     isSignedIn: state.page.user.isSignedIn,
+    emailHasBeenBlurred: state.page.oneoffContrib.emailHasBeenBlurred,
   };
 
 }
 
-const mapDispatchToProps = { emailUpdate: setEmail };
+const mapDispatchToProps = {
+  emailUpdate: setEmail,
+  setEmailHasBeenBlurred,
+};
 
 
 // ----- Exports ----- //

--- a/assets/pages/oneoff-contributions/oneOffContributionsReducer.js
+++ b/assets/pages/oneoff-contributions/oneOffContributionsReducer.js
@@ -21,6 +21,7 @@ import type { Action } from './oneoffContributionsActions';
 export type State = {
   amount: number,
   error: ?string,
+  emailHasBeenBlurred: boolean,
 };
 
 export type CombinedState = {
@@ -42,6 +43,7 @@ function createOneOffContribReducer(amount: number) {
   const initialState: State = {
     amount,
     error: null,
+    emailHasBeenBlurred: false,
   };
 
   return function oneOffContribReducer(state: State = initialState, action: Action): State {
@@ -50,6 +52,9 @@ function createOneOffContribReducer(amount: number) {
 
       case 'CHECKOUT_ERROR':
         return Object.assign({}, state, { error: action.message });
+
+      case 'SET_EMAIL_HAS_BEEN_BLURRED':
+        return Object.assign({}, state, { emailHasBeenBlurred: true });
 
       default:
         return state;

--- a/assets/pages/oneoff-contributions/oneoffContributions.scss
+++ b/assets/pages/oneoff-contributions/oneoffContributions.scss
@@ -90,6 +90,11 @@
   .component-payment-error--paypal {
     margin-top: $gu-v-spacing;
   }
+
+  .component-text-input__input--error {
+    border: 2px solid gu-colour(error);
+    margin-bottom: $gu-v-spacing / 2;
+  }
 }
 
 .oneoff-contribution-payment__or-label {

--- a/assets/pages/oneoff-contributions/oneoffContributionsActions.js
+++ b/assets/pages/oneoff-contributions/oneoffContributionsActions.js
@@ -2,8 +2,9 @@
 
 // ----- Types ----- //
 
-export type Action = { type: 'CHECKOUT_ERROR', message: ?string };
-
+export type Action =
+    | { type: 'CHECKOUT_ERROR', message: ?string }
+    | { type: 'SET_EMAIL_HAS_BEEN_BLURRED' };
 
 // ----- Actions ----- //
 
@@ -11,7 +12,10 @@ function checkoutError(message: ?string): Action {
   return { type: 'CHECKOUT_ERROR', message };
 }
 
+function setEmailHasBeenBlurred(): Action {
+  return { type: 'SET_EMAIL_HAS_BEEN_BLURRED' };
+}
 
 // ----- Exports ----- //
 
-export { checkoutError };
+export { checkoutError, setEmailHasBeenBlurred };

--- a/assets/pages/regular-contributions/__tests__/__snapshots__/regularContributionsReducersTest.js.snap
+++ b/assets/pages/regular-contributions/__tests__/__snapshots__/regularContributionsReducersTest.js.snap
@@ -30,6 +30,7 @@ Object {
   "regularContrib": Object {
     "amount": 20,
     "contributionType": "MONTHLY",
+    "emailHasBeenBlurred": false,
     "error": null,
     "payPalHasLoaded": false,
     "paymentMethod": "DirectDebit",

--- a/assets/pages/regular-contributions/__tests__/regularContributionsReducersTest.js
+++ b/assets/pages/regular-contributions/__tests__/regularContributionsReducersTest.js
@@ -42,7 +42,7 @@ describe('Regular contributions Reducer', () => {
     expect(newState.regularContrib.error).toMatchSnapshot();
   });
 
-  it('should handle SET_PAYPAL_BUTTON', () => {
+  it('should handle CREATING_CONTRIBUTOR', () => {
 
     const action = {
       type: 'CREATING_CONTRIBUTOR',
@@ -50,5 +50,15 @@ describe('Regular contributions Reducer', () => {
 
     const newState = reducer(undefined, action);
     expect(newState.regularContrib.paymentStatus).toEqual('Pending');
+  });
+
+  it('should handle SET_EMAIL_HAS_BEEN_BLURRED', () => {
+
+    const action = {
+      type: 'SET_EMAIL_HAS_BEEN_BLURRED',
+    };
+
+    const newState = reducer(undefined, action);
+    expect(newState.regularContrib.emailHasBeenBlurred).toEqual(true);
   });
 });

--- a/assets/pages/regular-contributions/components/emailFormFieldContainer.jsx
+++ b/assets/pages/regular-contributions/components/emailFormFieldContainer.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 
 import { setEmail } from 'helpers/user/userActions';
 import EmailFormField from 'components/emailFormField/emailFormField';
+import { setEmailHasBeenBlurred } from '../regularContributionsActions';
 
 // ----- State/Action Maps ----- //
 
@@ -12,11 +13,16 @@ function mapStateToProps(state) {
   return {
     email: state.page.user.email,
     isSignedIn: state.page.user.isSignedIn,
+    emailHasBeenBlurred: state.page.regularContrib.emailHasBeenBlurred,
+    emailIsValid: state.page.user.emailIsValid,
   };
 
 }
 
-const mapDispatchToProps = { emailUpdate: setEmail };
+const mapDispatchToProps = {
+  emailUpdate: setEmail,
+  setEmailHasBeenBlurred,
+};
 
 
 // ----- Exports ----- //

--- a/assets/pages/regular-contributions/regularContributions.scss
+++ b/assets/pages/regular-contributions/regularContributions.scss
@@ -83,6 +83,10 @@
     margin-bottom: $gu-v-spacing;
   }
 
+  .component-text-input__input--error {
+    border: 2px solid gu-colour(error);
+  }
+
   .component-text-input--last-name {
     margin-top: $gu-v-spacing;
   }

--- a/assets/pages/regular-contributions/regularContributionsActions.js
+++ b/assets/pages/regular-contributions/regularContributionsActions.js
@@ -12,6 +12,7 @@ export type Action =
   | { type: 'CHECKOUT_SUCCESS', paymentMethod: PaymentMethod }
   | { type: 'CHECKOUT_ERROR', message: string }
   | { type: 'SET_PAYPAL_HAS_LOADED' }
+  | { type: 'SET_EMAIL_HAS_BEEN_BLURRED' }
   | { type: 'CREATING_CONTRIBUTOR' };
 
 
@@ -35,6 +36,10 @@ function setPayPalHasLoaded(): Action {
   return { type: 'SET_PAYPAL_HAS_LOADED' };
 }
 
+function setEmailHasBeenBlurred(): Action {
+  return { type: 'SET_EMAIL_HAS_BEEN_BLURRED' };
+}
+
 function creatingContributor(): Action {
   return { type: 'CREATING_CONTRIBUTOR' };
 }
@@ -47,4 +52,5 @@ export {
   checkoutError,
   setPayPalHasLoaded,
   creatingContributor,
+  setEmailHasBeenBlurred,
 };

--- a/assets/pages/regular-contributions/regularContributionsReducer.js
+++ b/assets/pages/regular-contributions/regularContributionsReducer.js
@@ -31,6 +31,7 @@ export type State = {
   payPalHasLoaded: boolean,
   statusUri: ?string,
   pollCount: number,
+  emailHasBeenBlurred: boolean,
 };
 
 export type CombinedState = {
@@ -63,6 +64,7 @@ function createRegularContribReducer(
     payPalHasLoaded: false,
     statusUri: null,
     pollCount: 0,
+    emailHasBeenBlurred: false,
   };
 
   return function regularContrib(state: State = initialState, action: Action): State {
@@ -82,6 +84,9 @@ function createRegularContribReducer(
 
       case 'SET_PAYPAL_HAS_LOADED':
         return Object.assign({}, state, { payPalHasLoaded: true });
+
+      case 'SET_EMAIL_HAS_BEEN_BLURRED':
+        return Object.assign({}, state, { emailHasBeenBlurred: true });
 
       default:
         return state;


### PR DESCRIPTION
## Why are you doing this?
Previously, if the email address entered by the user was invalid, the payment buttons would be disabled, but the only indication as to why was the "All fields required" text. This PR adds some instant validation to the email field which fires in the `onChange` event on the input, but only once `onBlur` has been fired once, to make sure that we don't show an error message on the users first attempt to write in their email (as whilst they are typing their email for the first time, it will be in an invalid state until they get to the first character after the first period after the `@` sign)

| Before | After |
| ----- | ------- |
|![oldemail](https://user-images.githubusercontent.com/2844554/43536365-55984e44-95b4-11e8-9dd4-277992c68350.gif)|![newemail](https://user-images.githubusercontent.com/2844554/43536484-9f697d5e-95b4-11e8-8128-b362b4bdb903.gif)|


This change applies to both the one off and recurring checkout pages
