### PR TITLE
Update PayPal REST Cancel URL

### DIFF
--- a/assets/components/payPalContributionButton/payPalContributionButton.jsx
+++ b/assets/components/payPalContributionButton/payPalContributionButton.jsx
@@ -33,6 +33,7 @@ type PropTypes = {
   additionalClass: string,
   onClick: ?(void => void),
   switchStatus: Status,
+  cancelURL: string,
 };
 /* eslint-enable react/no-unused-prop-types */
 
@@ -55,6 +56,7 @@ function payWithPayPal(props: PropTypes) {
         props.countryGroupId,
         props.errorHandler,
         props.abParticipations,
+        props.cancelURL,
       );
     }
   };

--- a/assets/helpers/paymentIntegrations/payPalPaymentAPICheckout.js
+++ b/assets/helpers/paymentIntegrations/payPalPaymentAPICheckout.js
@@ -4,7 +4,7 @@
 
 import { derivePaymentApiAcquisitionData } from 'helpers/tracking/acquisitions';
 import * as cookie from 'helpers/cookie';
-import { addQueryParamsToURL, getAbsoluteURL } from 'helpers/url';
+import { addQueryParamsToURL, getAbsoluteURL, getOrigin, getCurrentURL } from 'helpers/url';
 import { routes } from 'helpers/routes';
 import { countryGroups } from 'helpers/internationalisation/countryGroup';
 
@@ -53,7 +53,7 @@ export function paypalPaymentAPIRedirect(
     amount,
     currency,
     returnURL: getAbsoluteURL(routes.payPalRestReturnURL),
-    cancelURL: getAbsoluteURL(routes.payPalRestCancelURL),
+    cancelURL: getCurrentURL() || getOrigin(),
   };
 
   const fetchOptions: Object = {

--- a/assets/helpers/paymentIntegrations/payPalPaymentAPICheckout.js
+++ b/assets/helpers/paymentIntegrations/payPalPaymentAPICheckout.js
@@ -4,7 +4,7 @@
 
 import { derivePaymentApiAcquisitionData } from 'helpers/tracking/acquisitions';
 import * as cookie from 'helpers/cookie';
-import { addQueryParamsToURL, getAbsoluteURL, getOrigin, getCurrentURL } from 'helpers/url';
+import { addQueryParamsToURL, getAbsoluteURL } from 'helpers/url';
 import { routes } from 'helpers/routes';
 import { countryGroups } from 'helpers/internationalisation/countryGroup';
 
@@ -43,6 +43,7 @@ export function paypalPaymentAPIRedirect(
   countryGroupId: CountryGroupId,
   errorHandler: (string) => void,
   nativeAbParticipations: Participations,
+  cancelURL: string,
 ): void {
 
   const acquisitionData = derivePaymentApiAcquisitionData(referrerAcquisitionData, nativeAbParticipations);
@@ -53,7 +54,7 @@ export function paypalPaymentAPIRedirect(
     amount,
     currency,
     returnURL: getAbsoluteURL(routes.payPalRestReturnURL),
-    cancelURL: getCurrentURL() || getOrigin(),
+    cancelURL,
   };
 
   const fetchOptions: Object = {

--- a/assets/helpers/routes.js
+++ b/assets/helpers/routes.js
@@ -19,7 +19,6 @@ const routes: {
   payPalCreateAgreement: '/paypal/create-agreement',
   directDebitCheckAccount: '/direct-debit/check-account',
   payPalRestReturnURL: '/paypal/rest/return',
-  payPalRestCancelURL: '/paypal/rest/cancel',
 };
 
 

--- a/assets/helpers/url.js
+++ b/assets/helpers/url.js
@@ -91,13 +91,24 @@ function getAbsoluteURL(path: string = ''): string {
   return `${getOrigin()}${path}`;
 }
 
+function getCurrentURL(): ?string {
+  try {
+    return getOrigin() + window.location.pathname;
+  } catch (e) {
+    return null;
+  }
+}
+
+
 // ----- Exports ----- //
 
 export {
   getQueryParameter,
   getAllQueryParams,
   getAllQueryParamsWithExclusions,
+  getOrigin,
   getBaseDomain,
   addQueryParamsToURL,
   getAbsoluteURL,
+  getCurrentURL,
 };

--- a/assets/helpers/url.js
+++ b/assets/helpers/url.js
@@ -91,14 +91,6 @@ function getAbsoluteURL(path: string = ''): string {
   return `${getOrigin()}${path}`;
 }
 
-function getCurrentURL(): ?string {
-  try {
-    return getOrigin() + window.location.pathname;
-  } catch (e) {
-    return null;
-  }
-}
-
 
 // ----- Exports ----- //
 
@@ -110,5 +102,4 @@ export {
   getBaseDomain,
   addQueryParamsToURL,
   getAbsoluteURL,
-  getCurrentURL,
 };

--- a/assets/pages/contributions-landing/pagesVersions/horizontalLayoutLandingPage.jsx
+++ b/assets/pages/contributions-landing/pagesVersions/horizontalLayoutLandingPage.jsx
@@ -5,8 +5,9 @@
 import * as React from 'react';
 import { Provider } from 'react-redux';
 import type { Store } from 'redux';
-import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
+import { type CountryGroupId, countryGroups } from 'helpers/internationalisation/countryGroup';
+import { getOrigin } from 'helpers/url';
 import Page from 'components/page/page';
 import CirclesIntroduction from 'components/introduction/circlesIntroduction';
 import Footer from 'components/footer/footer';
@@ -75,6 +76,10 @@ const CountrySwitcherHeader = CountrySwitcherHeaderContainer(
   ['GBPCountries', 'UnitedStates', 'EURCountries', 'NZDCountries', 'Canada', 'International', 'AUDCountries'],
 );
 
+function payPalCancelUrl(cgId: CountryGroupId): string {
+  return `${getOrigin()}/${countryGroups[cgId].supportInternationalisationId}/contribute`;
+}
+
 
 // ----- Render ----- //
 
@@ -96,7 +101,9 @@ const HorizontalLayoutLandingPage: (PropTypes) => React.Node = (props: PropTypes
         <ContributionSelectionContainer />
         <ContributionAwarePaymentLogosContainer />
         <ContributionPaymentCtasContainer
-          PayPalButton={PayPalContributionButtonContainer}
+          PayPalButton={() =>
+            <PayPalContributionButtonContainer cancelURL={payPalCancelUrl(props.countryGroupId)} />
+          }
         />
       </Contribute>
     </Page>

--- a/assets/pages/support-landing/supportLanding.jsx
+++ b/assets/pages/support-landing/supportLanding.jsx
@@ -20,6 +20,7 @@ import PatronsEventsContainer from 'components/patronsEvents/patronsEventsContai
 
 import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
+import { getOrigin } from 'helpers/url';
 
 import pageReducer from './supportLandingReducer';
 
@@ -70,7 +71,9 @@ const content = (
           <ContributionSelectionContainer />
           <ContributionAwarePaymentLogosContainer />
           <ContributionPaymentCtasContainer
-            PayPalButton={PayPalContributionButtonContainer}
+            PayPalButton={() =>
+              <PayPalContributionButtonContainer cancelURL={`${getOrigin()}/uk`} />
+          }
           />
         </Contribute>
         <ThreeSubscriptionsContainer


### PR DESCRIPTION
## Why are you doing this?

In the PayPal REST integration, the cancel URL is used whenever a user cancels their payment in the PayPal UI. This should send users back to where they were on our site, rather than to an error page.

## Changes

- Added a new method to get current URL.
- Updated the one-off cancel URL to be the current URL or, if that fails, the origin.
