### PR TITLE
Show users an error when the checkout process fails (due a payment failure)

### DIFF
--- a/app/services/stepfunctions/RegularContributionsClient.scala
+++ b/app/services/stepfunctions/RegularContributionsClient.scala
@@ -6,17 +6,15 @@ import scala.concurrent.Future
 import akka.actor.ActorSystem
 import cats.data.EitherT
 import cats.implicits._
-import com.gu.support.config.Stage
 import RegularContributionsClient._
 import com.gu.support.workers.model._
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.{Decoder, Encoder}
 import codecs.CirceDecoders._
-import com.amazonaws.services.stepfunctions.model.HistoryEvent
 import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
 import com.gu.i18n.Country
 import com.gu.support.workers.model.monthlyContributions.Contribution
-import com.gu.support.workers.model.monthlyContributions.state.{CompletedState, CreatePaymentMethodState}
+import com.gu.support.workers.model.monthlyContributions.state.CreatePaymentMethodState
 import play.api.mvc.Call
 import com.gu.support.workers.model.monthlyContributions.Status
 import monitoring.SafeLogger


### PR DESCRIPTION
## Why are you doing this?

This PR allows us to start providing faster feedback when a payment failure occurs during the checkout process.

Companion PR here: https://github.com/guardian/support-workers/pull/133

[**Trello Card**](https://trello.com/c/KTqKRJ44/1826-fix-polling-functionality-to-improve-checkout-experience)

## Changes

* Re-factor polling logic and recognise new CheckoutFailure state (https://github.com/guardian/support-workers/pull/133/files#diff-dfd6eb6e38897b10b523498706e43f59)
* Do NOT tell the client that the checkout was a failure if the overall Step Function execution fails (https://github.com/guardian/support-frontend/compare/jw-understand-failures?expand=1#diff-ecaf18660141161c28efec09643d39a4L126), since it's possible that the execution could fail after we've taken the user's money. In cases where we aren't 100% sure what happened, we should just show the pending page and follow up via userhelp.

