### PR TITLE
Change unsupported user agent to info level and add logging for unsupported user agent page

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -10,6 +10,7 @@ import switchboard.Switches
 import utils.BrowserCheck
 import utils.RequestCountry._
 import scala.concurrent.ExecutionContext
+import monitoring.SafeLogger
 
 class Application(
     actionRefiners: CustomActionBuilders,
@@ -70,6 +71,7 @@ class Application(
 
   def unsupportedBrowser: Action[AnyContent] = NoCacheAction() { implicit request =>
     BrowserCheck.logUserAgent(request)
+    SafeLogger.info("Redirecting to unsupported-browser page")
     Ok(views.html.unsupportedBrowserPage())
   }
 

--- a/app/utils/BrowserCheck.scala
+++ b/app/utils/BrowserCheck.scala
@@ -5,7 +5,7 @@ import play.api.mvc.RequestHeader
 
 object BrowserCheck {
   def logUserAgent(implicit request: RequestHeader): Unit = {
-    SafeLogger.warn(s"Unsupported user agent: ${
+    SafeLogger.info(s"Unsupported user agent: ${
       request.headers.get("User-Agent").getOrElse("No User-Agent available in request.headers")
     }")
   }


### PR DESCRIPTION
unsupported user agent log messages are confusing. They imply that an unsupported browser has somehow made it past our filters. However it is in fact only logged when we send a user to the "unsupported browser" page - which is correct behaviour.
Consequently this should be informational rather than a warning, as all is well.