### PR TITLE
update au and nz min montly values to 5

### DIFF
--- a/assets/helpers/contributions.js
+++ b/assets/helpers/contributions.js
@@ -96,8 +96,8 @@ const config: { [CountryGroupId]: Config } = {
   AUDCountries: {
     ANNUAL: defaultConfig.ANNUAL,
     MONTHLY: {
-      min: 10,
-      minInWords: numbersInWords['10'],
+      min: 5,
+      minInWords: numbersInWords['5'],
       max: 166,
       maxInWords: numbersInWords['166'],
       default: 20,
@@ -146,8 +146,8 @@ const config: { [CountryGroupId]: Config } = {
   NZDCountries: {
     ANNUAL: defaultConfig.ANNUAL,
     MONTHLY: {
-      min: 10,
-      minInWords: numbersInWords['10'],
+      min: 5,
+      minInWords: numbersInWords['5'],
       max: 166,
       maxInWords: numbersInWords['166'],
       default: 20,


### PR DESCRIPTION
## Why are you doing this?
Epic round 6 – promoting recurring contributions requires the ability to donate $5 in NZ and AU in monthly. 

@ionamckendrick 

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/45nLkEc6/674-change-minimum-recurring-amount-in-aus-nz-to-5)

## Screenshots

NOW
![screen shot 2018-08-03 at 11 04 08](https://user-images.githubusercontent.com/8484757/43637463-0a77acac-970d-11e8-93d7-cfab59f0b09b.jpg)


BEFORE
![screen shot 2018-08-03 at 11 04 23](https://user-images.githubusercontent.com/8484757/43637466-0b9d6bd0-970d-11e8-9db7-b7e0e16a4911.jpg)

