### PR TITLE
Drop cookie for recurring contributions

### DIFF
--- a/app/cookies/RecurringContributionCookie.scala
+++ b/app/cookies/RecurringContributionCookie.scala
@@ -1,0 +1,19 @@
+package cookies
+
+import java.time.Instant
+
+import com.gu.support.workers.model.BillingPeriod
+import play.api.mvc.Cookie
+
+object RecurringContributionCookie {
+
+  val currentTime = Instant.ofEpochSecond(System.currentTimeMillis / 1000).toString
+
+  def create(domain: String, billingPeriod: BillingPeriod): Cookie = Cookie(
+    name = s"gu.contributions.recurring.contrib-timestamp.$billingPeriod",
+    value = currentTime,
+    secure = true,
+    httpOnly = false,
+    domain = Some(domain)
+  )
+}

--- a/app/wiring/Controllers.scala
+++ b/app/wiring/Controllers.scala
@@ -36,7 +36,8 @@ trait Controllers {
     appConfig.regularStripeConfigProvider,
     appConfig.regularPayPalConfigProvider,
     controllerComponents,
-    appConfig.switches
+    appConfig.switches,
+    appConfig.guardianDomain
   )
 
   lazy val payPalRegularController = new PayPalRegular(

--- a/test/controllers/RegularContributionsTest.scala
+++ b/test/controllers/RegularContributionsTest.scala
@@ -111,7 +111,8 @@ class RegularContributionsTest extends WordSpec with MustMatchers with TestCSRFC
         stripeConfigProvider,
         payPalConfigProvider,
         stubControllerComponents(),
-        Switches(PaymentMethodsSwitch(On, On, None), PaymentMethodsSwitch(On, On, Some(On)), On)
+        Switches(PaymentMethodsSwitch(On, On, None), PaymentMethodsSwitch(On, On, Some(On)), On),
+        guardianDomain = ".thegulocal.com"
       )
     }
 


### PR DESCRIPTION
## Why are you doing this?
As not all recurring contributors will sign in with guest checkout, we need to drop a cookie so that frontend can recognise recurring contributors and push them to sign in

Here is an example of the cookie (one for monthly, one for annual)

`gu.contributions.recurring.contrib-timestamp.Monthly` : `2018-08-03T11:05:38Z`
`gu.contributions.recurring.contrib-timestamp.Annual` : `2018-08-03T11:05:38Z`