### PR TITLE
Add more detailed logs for paypal payment failures

### DIFF
--- a/app/controllers/PayPalOneOff.scala
+++ b/app/controllers/PayPalOneOff.scala
@@ -56,10 +56,10 @@ class PayPalOneOff(
 
     def processPaymentApiResponse(success: Boolean): Result = {
       if (success) {
-        SafeLogger.info(s"One-off contribution for Paypal payment is successful")
+        SafeLogger.info(s"One-off contribution for Paypal payment is successful. Sending user to thank-you page")
         Redirect("/contribute/one-off/thankyou")
       } else {
-        SafeLogger.error(scrub"Error making paypal payment")
+        SafeLogger.error(scrub"Error making paypal payment. Sending user to error page.")
         Ok(views.html.main(
           "Support the Guardian | PayPal Error",
           "paypal-error-page",

--- a/app/services/PaymentAPIService.scala
+++ b/app/services/PaymentAPIService.scala
@@ -75,26 +75,30 @@ class PaymentAPIService(wsClient: WSClient, paymentAPIUrl: String) {
         None
       },
       resp => {
-       Some(resp)
+        Some(resp)
       }
     )
   }
 
   def logErrorResponse(paymentApiError: Option[PaymentApiError]): Unit = {
     paymentApiError.foreach(err => {
-      val errorMessage = SafeLogger.LogMessage(
-        s"Paypal payment failed due to ${err.error.errorName} error. Full message: ${err.error.message}",
-        "Paypal payment failed due to error. See logs for full details"
-      )
-      SafeLogger.error(errorMessage)
+      if (err.error.errorName.contains("INSTRUMENT_DECLINED")) {
+        SafeLogger.info("Paypal payment failed with 'INSTRUMENT_DECLINED' response.")
+      } else {
+        val errorMessage = SafeLogger.LogMessage(
+          s"Paypal payment failed due to ${err.error.errorName} error. Full message: ${err.error.message}",
+          "Paypal payment failed due to error. See logs for full details"
+        )
+        SafeLogger.error(errorMessage)
+      }
     })
   }
 
   def isDuplicatePaymentResponse(errorOpt: Option[PaymentApiError]): Boolean = {
-      errorOpt match {
-        case None => false
-        case Some(err) => err.error.errorName.contains("PAYMENT_ALREADY_DONE")
-      }
+    errorOpt match {
+      case None => false
+      case Some(err) => err.error.errorName.contains("PAYMENT_ALREADY_DONE")
+    }
   }
 
   def isSuccessful(response: WSResponse): Boolean = {


### PR DESCRIPTION
Currently the only information we log for payment failures in support frontend is the fact that they have failed.
This change takes advantage of the increased information we have available to us to give more detail on the nature of the payment failures.

