### PR TITLE
Fixes for ecommerce tracking

### DIFF
--- a/assets/helpers/tracking/googleTagManager.js
+++ b/assets/helpers/tracking/googleTagManager.js
@@ -46,7 +46,7 @@ function getContributionType() {
   if (param) {
     storage.setSession('contribType', param);
   }
-  return (storage.getSession('contribType') || '').toLowerCase();
+  return (storage.getSession('contribType') || 'one_off').toLowerCase(); // PayPal route doesn't set the contribType
 }
 
 function getCurrency(): string {
@@ -146,11 +146,11 @@ function sendData(
     ophanBrowserID: getOphanIds().browserId,
     paymentRequestApiStatus,
     ecommerce: {
+      currencyCode: currency,
       purchase: {
         actionField: {
           id: orderId,
           revenue: value, // Total transaction value (incl. tax and shipping)
-          currency,
         },
         products: [{
           name: `${getContributionType()}_contribution`,


### PR DESCRIPTION
## Why are you doing this?
There are a couple of issues with the [original implementation of ecommerce tracking](https://github.com/guardian/support-frontend/pull/813)
* Currency code is not being set correctly
* The product type is missing for one off contributions which have checked out via PayPal.

<img width="488" alt="screen shot 2018-08-06 at 08 52 02" src="https://user-images.githubusercontent.com/181371/43703939-297966a4-9956-11e8-83a9-53ac8c18fa66.png">

This PR sets the currency at the root of the ecommerce tag object which looks like the correct approach according to [this doc](https://developers.google.com/tag-manager/enhanced-ecommerce) although it's far from explicit.
It also sets the product type to `one_off_contribution` when it is missing.  