### PR TITLE
Fix form validation error on One Off Contributions checkout page

### DIFF
--- a/assets/pages/oneoff-contributions/components/oneoffContributionsPayment.jsx
+++ b/assets/pages/oneoff-contributions/components/oneoffContributionsPayment.jsx
@@ -28,7 +28,7 @@ type PropTypes = {|
   dispatch: Function,
   email: string,
   error: ?string,
-  isFormEmpty: boolean,
+  areAnyRequiredFieldsEmpty: boolean,
   amount: number,
   referrerAcquisitionData: ReferrerAcquisitionData,
   checkoutError: (?string) => void,
@@ -49,7 +49,7 @@ function mapStateToProps(state) {
     isPostDeploymentTestUser: state.page.user.isPostDeploymentTestUser,
     email: state.page.user.email,
     error: state.page.oneoffContrib.error,
-    isFormEmpty: state.page.user.email === '' || state.page.user.fullName === '',
+    areAnyRequiredFieldsEmpty: !state.page.user.email || !state.page.user.fullName,
     amount: state.page.oneoffContrib.amount,
     referrerAcquisitionData: state.common.referrerAcquisitionData,
     abParticipations: state.common.abParticipations,
@@ -72,14 +72,14 @@ function mapDispatchToProps(dispatch: Dispatch<Action>) {
 
 // If the form is valid, calls the given callback, otherwise sets an error.
 function formValidation(
-  isFormEmpty: boolean,
+  areAnyRequiredFieldsEmpty: boolean,
   validEmail: boolean,
   error: ?string => void,
 ): Function {
 
   return (): boolean => {
 
-    if (!isFormEmpty && validEmail) {
+    if (!areAnyRequiredFieldsEmpty && validEmail) {
       if (error) {
         error(null);
       }
@@ -87,7 +87,7 @@ function formValidation(
     }
 
     if (error) {
-      if (isFormEmpty) {
+      if (areAnyRequiredFieldsEmpty) {
         error('Please fill in all the fields above.');
       } else {
         error('Please fill in a valid email address.');
@@ -125,7 +125,7 @@ function OneoffContributionsPayment(props: PropTypes, context) {
           context.store.getState,
         )}
         canOpen={formValidation(
-          props.isFormEmpty,
+          props.areAnyRequiredFieldsEmpty,
           validateEmailAddress(props.email),
           props.checkoutError,
         )}

--- a/assets/pages/oneoff-contributions/components/oneoffInlineContributionsPayment.jsx
+++ b/assets/pages/oneoff-contributions/components/oneoffInlineContributionsPayment.jsx
@@ -87,23 +87,23 @@ function mapDispatchToProps(dispatch: Dispatch<OneOffCheckoutAction | StripeInli
 function formValidation(
   areAnyRequiredFieldsEmpty: boolean,
   validEmail: boolean,
-  error: ?string => void,
+  setError: ?string => void,
 ): () => boolean {
 
   return (): boolean => {
 
     if (!areAnyRequiredFieldsEmpty && validEmail) {
-      if (error) {
-        error(null);
+      if (setError) {
+        setError(null);
       }
       return true;
     }
 
-    if (error) {
+    if (setError) {
       if (areAnyRequiredFieldsEmpty) {
-        error('Please fill in all the fields above.');
+        setError('Please fill in all the fields above.');
       } else {
-        error('Please fill in a valid email address.');
+        setError('Please fill in a valid email address.');
       }
     }
     return false;

--- a/assets/pages/oneoff-contributions/components/oneoffInlineContributionsPayment.jsx
+++ b/assets/pages/oneoff-contributions/components/oneoffInlineContributionsPayment.jsx
@@ -28,7 +28,7 @@ type PropTypes = {|
   dispatch: Dispatch<*>,
   email: string,
   error: ?string,
-  isFormEmpty: boolean,
+  areAnyRequiredFieldsEmpty: boolean,
   amount: number,
   referrerAcquisitionData: ReferrerAcquisitionData,
   checkoutError: (?string) => void,
@@ -52,7 +52,7 @@ function mapStateToProps(state) {
     isPostDeploymentTestUser: state.page.user.isPostDeploymentTestUser,
     email: state.page.user.email,
     error: state.page.oneoffContrib.error,
-    isFormEmpty: state.page.user.email === '' || state.page.user.fullName === '',
+    areAnyRequiredFieldsEmpty: !state.page.user.email || !state.page.user.fullName,
     amount: state.page.oneoffContrib.amount,
     referrerAcquisitionData: state.common.referrerAcquisitionData,
     abParticipations: state.common.abParticipations,
@@ -85,14 +85,14 @@ function mapDispatchToProps(dispatch: Dispatch<OneOffCheckoutAction | StripeInli
 
 // If the form is valid, calls the given callback, otherwise sets an error.
 function formValidation(
-  isFormEmpty: boolean,
+  areAnyRequiredFieldsEmpty: boolean,
   validEmail: boolean,
   error: ?string => void,
 ): () => boolean {
 
   return (): boolean => {
 
-    if (!isFormEmpty && validEmail) {
+    if (!areAnyRequiredFieldsEmpty && validEmail) {
       if (error) {
         error(null);
       }
@@ -100,7 +100,7 @@ function formValidation(
     }
 
     if (error) {
-      if (isFormEmpty) {
+      if (areAnyRequiredFieldsEmpty) {
         error('Please fill in all the fields above.');
       } else {
         error('Please fill in a valid email address.');
@@ -136,7 +136,7 @@ function OneoffContributionsPayment(props: PropTypes, context) {
           context.store.getState,
         )}
         canProceed={formValidation(
-          props.isFormEmpty,
+          props.areAnyRequiredFieldsEmpty,
           validateEmailAddress(props.email),
           props.checkoutError,
         )}


### PR DESCRIPTION
## Why are you doing this?
There was a bug whereby the `isFormEmpty` prop for the `oneOffContributionsPayment` component (and the inline version of the page) was being incorrectly set, if the user isn't signed in. This is because the check to see if the name field is empty was `state.page.user.fullName === ''`. But if the user isn't signed in, `state.page.user.fullName` doesn't get set until the user types something into the name field, so `state.page.user.fullName` returns `undefined`. 

This fix changes the check to `!state.page.user.fullName`, and names the varaible `isFormEmpty` to `areAnyRequiredFieldsEmpty`, which better describes the field. 