### PR TITLE
Drop cookie when user hits one off contribution thank you page

### DIFF
--- a/assets/pages/oneoff-contributions/oneoffContributions.jsx
+++ b/assets/pages/oneoff-contributions/oneoffContributions.jsx
@@ -13,6 +13,7 @@ import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
 import { routes } from 'helpers/routes';
 import { getAmount } from 'helpers/checkouts';
+import { set as setCookie } from 'helpers/cookie';
 
 import ContributionsThankYouPage from 'components/contributionsThankYou/contributionsThankYouPage';
 
@@ -26,6 +27,10 @@ import FormFields from './components/formFields';
 const countryGroup = detectCountryGroup();
 
 const store = pageInit(reducer(getAmount('ONE_OFF', countryGroup)), true);
+
+const ONE_OFF_CONTRIBUTION_COOKIE = 'gu.contributions.contrib-timestamp';
+
+const currentTime = new Date().toString();
 
 user.init(store.dispatch);
 
@@ -46,8 +51,13 @@ const router = (
         <Route
           exact
           path={routes.oneOffContribThankyou}
-          render={() =>
-            <ContributionsThankYouPage contributionType="ONE_OFF" directDebit={null} />
+          render={() => {
+            setCookie(
+              ONE_OFF_CONTRIBUTION_COOKIE,
+              currentTime,
+            );
+            return (<ContributionsThankYouPage contributionType="ONE_OFF" directDebit={null} />);
+          }
           }
         />
       </div>


### PR DESCRIPTION
## Why are you doing this?
When we deprecated `contributions-frontend`, one thing we didn't port over was the dropping of a cookie when a user makes a one-off contribution, which stops users on the site seeing contributions ads for a limited time. 

This PR re-implements this behaviour. 

An example of the cookie dropped is: 

`gu.contributions.contrib-timestamp`: `Wed Aug 08 2018 15:41:08 GMT+0100 (British Summer Time)`