### PR TITLE
International subscribe pages

### DIFF
--- a/app/controllers/Subscriptions.scala
+++ b/app/controllers/Subscriptions.scala
@@ -38,7 +38,10 @@ class Subscriptions(
     Redirect("https://subscribe.theguardian.com", request.queryString, status = FOUND)
   }
 
-  def landing(title: String, id: String, js: String): Action[AnyContent] = CachedAction() { implicit request =>
+  def landing(countryCode: String): Action[AnyContent] = CachedAction() { implicit request =>
+    val title = "Support the Guardian | Get a Subscription"
+    val id = "subscriptions-landing-page"
+    val js = "subscriptionsLandingPage.js"
     Ok(views.html.main(
       title,
       id,

--- a/app/switchboard/Switches.scala
+++ b/app/switchboard/Switches.scala
@@ -5,7 +5,8 @@ import com.typesafe.config.Config
 case class Switches(
     oneOffPaymentMethods: PaymentMethodsSwitch,
     recurringPaymentMethods: PaymentMethodsSwitch,
-    optimize: SwitchState
+    optimize: SwitchState,
+    internationalSubscribePages: SwitchState
 )
 
 object Switches {
@@ -13,7 +14,8 @@ object Switches {
     Switches(
       PaymentMethodsSwitch.fromConfig(config.getConfig("oneOff")),
       PaymentMethodsSwitch.fromConfig(config.getConfig("recurring")),
-      SwitchState.fromConfig(config, "optimize")
+      SwitchState.fromConfig(config, "optimize"),
+      SwitchState.fromConfig(config, "internationalSubscribePages")
     )
 
 }

--- a/assets/components/digitalSubscriptions/digitalSubscriptions.jsx
+++ b/assets/components/digitalSubscriptions/digitalSubscriptions.jsx
@@ -18,7 +18,7 @@ import PageSection from 'components/pageSection/pageSection';
 import SubscriptionBundle from 'components/subscriptionBundle/subscriptionBundle';
 import { type HeadingSize } from 'components/heading/heading';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import { displayPrice } from '../../helpers/subscriptions';
+import { displayPrice } from 'helpers/subscriptions';
 
 
 // ----- Types ----- //
@@ -51,9 +51,9 @@ const appReferrer = 'utm_source=support.theguardian.com&utm_medium=subscribe_lan
 // ----- Component ----- //
 
 export default function DigitalSubscriptions(props: PropTypes) {
-
+  const countryGroupId = 'GBPCountries'; // This component is only used in the UK
   const subsLinks = getSubsLinks(
-    'GBPCountries',
+    countryGroupId,
     props.referrerAcquisitionData.campaignCode,
     getCampaign(props.referrerAcquisitionData),
     [],
@@ -67,7 +67,7 @@ export default function DigitalSubscriptions(props: PropTypes) {
         modifierClass="digital-subscriptions"
       >
         <PremiumTier
-          countryGroupId="GBPCountries"
+          countryGroupId={countryGroupId}
           iOSUrl={addQueryParamsToURL(iOSAppUrl, { referrer: appReferrer })}
           androidUrl={addQueryParamsToURL(androidAppUrl, { referrer: appReferrer })}
           headingSize={props.headingSize}
@@ -80,7 +80,7 @@ export default function DigitalSubscriptions(props: PropTypes) {
           onClick={props.clickEvents.dailyEdition}
         />
         <DigitalBundle
-          countryGroupId="GBPCountries"
+          countryGroupId={countryGroupId}
           url={subsLinks.DigitalPack}
           headingSize={props.headingSize}
           onClick={props.clickEvents.digiPack}
@@ -150,7 +150,7 @@ function DailyEdition(props: {
     <SubscriptionBundle
       modifierClass="daily-edition"
       heading="Daily Edition"
-      subheading="from £6.99/month"
+      subheading={`from ${displayPrice('DailyEdition', 'GBPCountries')}`}
       headingSize={props.headingSize}
       benefits={[
         {

--- a/assets/components/digitalSubscriptions/digitalSubscriptions.jsx
+++ b/assets/components/digitalSubscriptions/digitalSubscriptions.jsx
@@ -11,7 +11,6 @@ import {
   dailyEditionUrl,
 } from 'helpers/externalLinks';
 import { getCampaign } from 'helpers/tracking/acquisitions';
-import { getDiscountedPrice } from 'helpers/flashSale';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import { addQueryParamsToURL } from 'helpers/url';
 
@@ -82,7 +81,7 @@ export default function DigitalSubscriptions(props: PropTypes) {
         />
         <DigitalBundle
           countryGroupId="GBPCountries"
-          url={subsLinks.digital}
+          url={subsLinks.DigitalPack}
           headingSize={props.headingSize}
           onClick={props.clickEvents.digiPack}
         />
@@ -181,7 +180,7 @@ function DigitalBundle(props: {
   countryGroupId: CountryGroupId,
   url: string,
   headingSize: HeadingSize,
-  onClick: ClickEvent,
+  onClick: ClickEvent | null,
 }) {
 
   return (

--- a/assets/components/digitalSubscriptions/digitalSubscriptions.jsx
+++ b/assets/components/digitalSubscriptions/digitalSubscriptions.jsx
@@ -183,6 +183,10 @@ function DigitalBundle(props: {
   onClick: ClickEvent | null,
 }) {
 
+  const benefits = props.countryGroupId === 'GBPCountries' ?
+    'The premium app and the daily edition in one pack' :
+    'The Premium App and the Daily Edition iPad app of the UK newspaper in one pack';
+
   return (
     <SubscriptionBundle
       modifierClass="digital"
@@ -191,7 +195,7 @@ function DigitalBundle(props: {
       headingSize={props.headingSize}
       benefits={[
         {
-          text: 'The premium app and the daily edition in one pack',
+          text: benefits,
         },
       ]}
       gridImage={{

--- a/assets/components/digitalSubscriptions/digitalSubscriptions.jsx
+++ b/assets/components/digitalSubscriptions/digitalSubscriptions.jsx
@@ -11,13 +11,15 @@ import {
   dailyEditionUrl,
 } from 'helpers/externalLinks';
 import { getCampaign } from 'helpers/tracking/acquisitions';
-import { getPrice } from 'helpers/flashSale';
+import { getDiscountedPrice } from 'helpers/flashSale';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import { addQueryParamsToURL } from 'helpers/url';
 
 import PageSection from 'components/pageSection/pageSection';
 import SubscriptionBundle from 'components/subscriptionBundle/subscriptionBundle';
 import { type HeadingSize } from 'components/heading/heading';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { displayPrice } from '../../helpers/subscriptions';
 
 
 // ----- Types ----- //
@@ -52,6 +54,7 @@ const appReferrer = 'utm_source=support.theguardian.com&utm_medium=subscribe_lan
 export default function DigitalSubscriptions(props: PropTypes) {
 
   const subsLinks = getSubsLinks(
+    'GBPCountries',
     props.referrerAcquisitionData.campaignCode,
     getCampaign(props.referrerAcquisitionData),
     [],
@@ -65,6 +68,7 @@ export default function DigitalSubscriptions(props: PropTypes) {
         modifierClass="digital-subscriptions"
       >
         <PremiumTier
+          countryGroupId="GBPCountries"
           iOSUrl={addQueryParamsToURL(iOSAppUrl, { referrer: appReferrer })}
           androidUrl={addQueryParamsToURL(androidAppUrl, { referrer: appReferrer })}
           headingSize={props.headingSize}
@@ -77,6 +81,7 @@ export default function DigitalSubscriptions(props: PropTypes) {
           onClick={props.clickEvents.dailyEdition}
         />
         <DigitalBundle
+          countryGroupId="GBPCountries"
           url={subsLinks.digital}
           headingSize={props.headingSize}
           onClick={props.clickEvents.digiPack}
@@ -91,6 +96,7 @@ export default function DigitalSubscriptions(props: PropTypes) {
 // ----- Auxiliary Components ----- //
 
 function PremiumTier(props: {
+    countryGroupId: CountryGroupId,
     iOSUrl: string,
     androidUrl: string,
     headingSize: HeadingSize,
@@ -102,7 +108,7 @@ function PremiumTier(props: {
     <SubscriptionBundle
       modifierClass="premium-tier"
       heading="Premium App"
-      subheading="£5.99/month"
+      subheading={displayPrice('PremiumTier', props.countryGroupId)}
       headingSize={props.headingSize}
       benefits={[
         {
@@ -172,6 +178,7 @@ function DailyEdition(props: {
 }
 
 function DigitalBundle(props: {
+  countryGroupId: CountryGroupId,
   url: string,
   headingSize: HeadingSize,
   onClick: ClickEvent,
@@ -181,7 +188,7 @@ function DigitalBundle(props: {
     <SubscriptionBundle
       modifierClass="digital"
       heading="Digital Pack"
-      subheading={`£${getPrice('digital', '11.99')}/month`}
+      subheading={displayPrice('DigitalPack', props.countryGroupId)}
       headingSize={props.headingSize}
       benefits={[
         {

--- a/assets/components/digitalSubscriptions/digitalSubscriptions.jsx
+++ b/assets/components/digitalSubscriptions/digitalSubscriptions.jsx
@@ -206,3 +206,9 @@ function DigitalBundle(props: {
   );
 
 }
+
+export {
+  DigitalBundle,
+  PremiumTier,
+  DailyEdition,
+};

--- a/assets/components/digitalSubscriptions/digitalSubscriptions.jsx
+++ b/assets/components/digitalSubscriptions/digitalSubscriptions.jsx
@@ -183,9 +183,16 @@ function DigitalBundle(props: {
   onClick: ClickEvent | null,
 }) {
 
-  const benefits = props.countryGroupId === 'GBPCountries' ?
-    'The premium app and the daily edition in one pack' :
-    'The Premium App and the Daily Edition iPad app of the UK newspaper in one pack';
+  const i13n = props.countryGroupId === 'GBPCountries' ?
+    {
+      gridId: 'digitalCircleAlt',
+      benefits: 'The premium app and the daily edition in one pack',
+    } :
+    {
+      gridId: 'digitalCircleInternational',
+      benefits: 'The Premium App and the Daily Edition iPad app of the UK newspaper in one pack',
+    };
+
 
   return (
     <SubscriptionBundle
@@ -195,11 +202,11 @@ function DigitalBundle(props: {
       headingSize={props.headingSize}
       benefits={[
         {
-          text: benefits,
+          text: i13n.benefits,
         },
       ]}
       gridImage={{
-        gridId: 'digitalCircleAlt',
+        gridId: i13n.gridId,
         altText: 'digital subscription',
         ...gridImageProperties,
       }}

--- a/assets/components/internationalSubscriptions/internationalSubscriptions.jsx
+++ b/assets/components/internationalSubscriptions/internationalSubscriptions.jsx
@@ -18,8 +18,6 @@ import { PremiumTier, DigitalBundle } from 'components/digitalSubscriptions/digi
 import { WeeklyBundle } from 'components/paperSubscriptions/paperSubscriptions';
 import { type HeadingSize } from 'components/heading/heading';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import { digitalSubPrices } from '../../helpers/subscriptions';
-
 
 // ----- Types ----- //
 
@@ -71,13 +69,13 @@ export default function InternationalSubscriptions(props: PropTypes) {
         />
         <DigitalBundle
           countryGroupId={props.countryGroupId}
-          url={subsLinks.digital}
+          url={subsLinks.DigitalPack}
           headingSize={props.headingSize}
           onClick={props.clickEvents.digiPack}
         />
         <WeeklyBundle
           countryGroupId={props.countryGroupId}
-          url={subsLinks.weekly}
+          url={subsLinks.GuardianWeekly}
           headingSize={props.headingSize}
           onClick={props.clickEvents.digiPack}
         />

--- a/assets/components/internationalSubscriptions/internationalSubscriptions.jsx
+++ b/assets/components/internationalSubscriptions/internationalSubscriptions.jsx
@@ -1,0 +1,84 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+import {
+  getSubsLinks,
+  iOSAppUrl,
+  androidAppUrl,
+} from 'helpers/externalLinks';
+import { getCampaign } from 'helpers/tracking/acquisitions';
+import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
+import { addQueryParamsToURL } from 'helpers/url';
+
+import PageSection from 'components/pageSection/pageSection';
+import { PremiumTier, DigitalBundle } from 'components/digitalSubscriptions/digitalSubscriptions';
+import { WeeklyBundle } from 'components/paperSubscriptions/paperSubscriptions';
+import { type HeadingSize } from 'components/heading/heading';
+import type { CountryGroupId } from '../../helpers/internationalisation/countryGroup';
+
+
+// ----- Types ----- //
+
+type ClickEvent = () => void;
+
+type PropTypes = {
+  countryGroupId: CountryGroupId,
+  referrerAcquisitionData: ReferrerAcquisitionData,
+  headingSize: HeadingSize,
+  clickEvents: {
+    iOSApp: ClickEvent,
+    androidApp: ClickEvent,
+    digiPack: ClickEvent,
+    weekly: ClickEvent,
+  },
+};
+
+
+// ----- Setup ----- //
+
+const appReferrer = 'utm_source=support.theguardian.com&utm_medium=subscribe_landing_page&utm_campaign=international_subs_landing_pages';
+
+
+// ----- Component ----- //
+
+export default function InternationalSubscriptions(props: PropTypes) {
+
+  const subsLinks = getSubsLinks(
+    props.countryGroupId,
+    props.referrerAcquisitionData.campaignCode,
+    getCampaign(props.referrerAcquisitionData),
+    [],
+    props.referrerAcquisitionData,
+  );
+
+  return (
+    <div className="component-international-subscriptions">
+      <PageSection
+        heading="Subscribe"
+        modifierClass="international-subscriptions"
+      >
+        <PremiumTier
+          iOSUrl={addQueryParamsToURL(iOSAppUrl, { referrer: appReferrer })}
+          androidUrl={addQueryParamsToURL(androidAppUrl, { referrer: appReferrer })}
+          headingSize={props.headingSize}
+          iOSOnClick={props.clickEvents.iOSApp}
+          androidOnClick={props.clickEvents.androidApp}
+        />
+        <DigitalBundle
+          url={subsLinks.digital}
+          headingSize={props.headingSize}
+          onClick={props.clickEvents.digiPack}
+        />
+        <WeeklyBundle
+          url={subsLinks.weekly}
+          headingSize={props.headingSize}
+          onClick={props.clickEvents.digiPack}
+        />
+      </PageSection>
+    </div>
+  );
+
+}

--- a/assets/components/internationalSubscriptions/internationalSubscriptions.jsx
+++ b/assets/components/internationalSubscriptions/internationalSubscriptions.jsx
@@ -17,7 +17,8 @@ import PageSection from 'components/pageSection/pageSection';
 import { PremiumTier, DigitalBundle } from 'components/digitalSubscriptions/digitalSubscriptions';
 import { WeeklyBundle } from 'components/paperSubscriptions/paperSubscriptions';
 import { type HeadingSize } from 'components/heading/heading';
-import type { CountryGroupId } from '../../helpers/internationalisation/countryGroup';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { digitalSubPrices } from '../../helpers/subscriptions';
 
 
 // ----- Types ----- //
@@ -61,6 +62,7 @@ export default function InternationalSubscriptions(props: PropTypes) {
         modifierClass="international-subscriptions"
       >
         <PremiumTier
+          countryGroupId={props.countryGroupId}
           iOSUrl={addQueryParamsToURL(iOSAppUrl, { referrer: appReferrer })}
           androidUrl={addQueryParamsToURL(androidAppUrl, { referrer: appReferrer })}
           headingSize={props.headingSize}
@@ -68,11 +70,13 @@ export default function InternationalSubscriptions(props: PropTypes) {
           androidOnClick={props.clickEvents.androidApp}
         />
         <DigitalBundle
+          countryGroupId={props.countryGroupId}
           url={subsLinks.digital}
           headingSize={props.headingSize}
           onClick={props.clickEvents.digiPack}
         />
         <WeeklyBundle
+          countryGroupId={props.countryGroupId}
           url={subsLinks.weekly}
           headingSize={props.headingSize}
           onClick={props.clickEvents.digiPack}

--- a/assets/components/internationalSubscriptions/internationalSubscriptions.scss
+++ b/assets/components/internationalSubscriptions/internationalSubscriptions.scss
@@ -1,0 +1,207 @@
+.component-international-subscriptions {
+  border-top: 1px solid gu-colour(garnett-neutral-4);
+  padding-bottom: $gu-v-spacing * 3;
+
+  .component-page-section__header {
+    @include dropline;
+  }
+
+  .component-page-section__heading {
+    font-family: $gu-egyptian-web;
+    font-size: 24px;
+    line-height: 1.17;
+    font-weight: bold;
+  }
+
+  .component-page-section__body {
+    @include mq($from: desktop) {
+      padding-left: $gu-h-spacing;
+    }
+
+    @include mq($from: leftCol) {
+      padding-left: $gu-h-spacing / 2;
+      display: inline-flex;
+    }
+  }
+
+  .component-subscription-bundle {
+    padding: $gu-v-spacing 0;
+
+    @include mq($from: leftCol) {
+      flex: 1 33%;
+      padding: ($gu-v-spacing * 2) ($gu-h-spacing / 2) 0;
+      display: flex;
+      flex-direction: column;
+    }
+  }
+
+  .component-subscription-bundle__content {
+    @include mq($from: phablet, $until: leftCol) {
+      display: inline-block;
+      width: 70%;
+      vertical-align: top;
+    }
+
+    @include mq($from: leftCol) {
+      flex: 1 0 auto;
+      display: flex;
+      flex-direction: column;
+    }
+  }
+
+  .component-grid-image {
+    width: 165px;
+    height: 165px;
+    margin: $gu-v-spacing auto;
+    display: block;
+
+    @include mq($from: phablet, $until: leftCol) {
+      width: 28%;
+      height: 28%;
+      padding-right: 2%;
+      margin: 0;
+      display: inline-block;
+      vertical-align: top;
+    }
+  }
+
+  .component-subscription-bundle--premium-tier, .component-subscription-bundle--daily-edition {
+    @include mq($from: leftCol) {
+      @include dropline;
+    }
+  }
+
+  .component-feature-list {
+    font-size: 16px;
+    line-height: 1.25;
+
+    @include mq($until: phablet) {
+      padding-left: 0;
+    }
+
+    @include mq($from: leftCol) {
+      padding-left: 0;
+      flex: 1 0 auto;
+    }
+  }
+
+  .component-feature-list__item {
+    @include mq($until: phablet) {
+      margin-left: 0;
+    }
+
+    @include mq($from: leftCol) {
+      margin-left: 0;
+    }
+  }
+
+  .component-double-heading {
+    margin-bottom: $gu-v-spacing * 2;
+
+    @include mq($from: phablet, $until: leftCol) {
+      padding-left: 30px;
+    }
+  }
+
+  .component-double-heading__heading {
+    font-size: 36px;
+    line-height: 1.1;
+
+    @include mq($from: phablet, $until: leftCol) {
+      font-size: 30px;
+    }
+  }
+
+  .component-double-heading__subheading {
+    font-size: 30px;
+    line-height: 1;
+    font-weight: 400;
+    font-family: $gu-egyptian-web;
+
+    @include mq($from: phablet, $until: leftCol) {
+      font-size: 24px;
+      line-height: 1.17;
+    }
+  }
+
+  .component-cta-link {
+    padding-left: 28px;
+    background-color: transparent;
+  }
+
+  .svg-arrow-right-straight {
+    fill: gu-colour(garnett-neutral-1);
+  }
+
+  .component-cta-link--premium-tier {
+    color: gu-colour(sport-garnett-media-main-1);
+    border-color: gu-colour(sport-garnett-media-main-1);
+
+    .svg-arrow-right-straight {
+      fill: gu-colour(sport-garnett-media-main-1);
+    }
+
+    &:hover {
+      color: #fff;
+      background-color: gu-colour(sport-garnett-media-main-1);
+
+      .svg-arrow-right-straight {
+        fill: #fff;
+      }
+    }
+  }
+
+  .component-cta-link--daily-edition {
+    color: gu-colour(lifestyle-garnett-main-1);
+    border-color: gu-colour(lifestyle-garnett-main-1);
+
+    .svg-arrow-right-straight {
+      fill: gu-colour(lifestyle-garnett-main-1);
+    }
+
+    &:hover {
+      color: #fff;
+      background-color: gu-colour(lifestyle-garnett-main-1);
+
+      .svg-arrow-right-straight {
+        fill: #fff;
+      }
+    }
+  }
+
+  .component-cta-link--digital {
+    color: gu-colour(news-garnett-media-main-1);
+    border-color: gu-colour(news-garnett-media-main-1);
+
+    .svg-arrow-right-straight {
+      fill: gu-colour(news-garnett-media-main-1);
+    }
+
+    &:hover {
+      color: #fff;
+      background-color: gu-colour(news-garnett-media-main-1);
+
+      .svg-arrow-right-straight {
+        fill: #fff;
+      }
+    }
+  }
+
+  .component-cta-link--weekly {
+    color: gu-colour(news-garnett-media-main-1);
+    border-color: gu-colour(news-garnett-media-main-1);
+
+    .svg-arrow-right-straight {
+      fill: gu-colour(news-garnett-media-main-1);
+    }
+
+    &:hover {
+      color: #fff;
+      background-color: gu-colour(news-garnett-media-main-1);
+
+      .svg-arrow-right-straight {
+        fill: #fff;
+      }
+    }
+  }
+}

--- a/assets/components/internationalSubscriptions/internationalSubscriptions.scss
+++ b/assets/components/internationalSubscriptions/internationalSubscriptions.scss
@@ -170,16 +170,16 @@
   }
 
   .component-cta-link--digital {
-    color: gu-colour(news-garnett-media-main-1);
-    border-color: gu-colour(news-garnett-media-main-1);
+    color: gu-colour(lifestyle-garnett-main-1);
+    border-color: gu-colour(lifestyle-garnett-main-1);
 
     .svg-arrow-right-straight {
-      fill: gu-colour(news-garnett-media-main-1);
+      fill: gu-colour(lifestyle-garnett-main-1);
     }
 
     &:hover {
       color: #fff;
-      background-color: gu-colour(news-garnett-media-main-1);
+      background-color: gu-colour(lifestyle-garnett-main-1);
 
       .svg-arrow-right-straight {
         fill: #fff;

--- a/assets/components/internationalSubscriptions/internationalSubscriptionsContainer.js
+++ b/assets/components/internationalSubscriptions/internationalSubscriptionsContainer.js
@@ -1,0 +1,25 @@
+// @flow
+
+// ----- Imports ----- //
+
+import { connect } from 'react-redux';
+
+import type { CommonState } from 'helpers/page/page';
+
+import InternationalSubscriptions from './internationalSubscriptions';
+
+
+// ----- State Maps ----- //
+
+function mapStateToProps(state: { common: CommonState }) {
+
+  return {
+    referrerAcquisitionData: state.common.referrerAcquisitionData,
+  };
+
+}
+
+
+// ----- Exports ----- //
+
+export default connect(mapStateToProps)(InternationalSubscriptions);

--- a/assets/components/paperSubscriptions/paperSubscriptions.jsx
+++ b/assets/components/paperSubscriptions/paperSubscriptions.jsx
@@ -183,3 +183,9 @@ function WeeklyBundle(props: {
   );
 
 }
+
+export {
+  PaperBundle,
+  WeeklyBundle,
+  PaperDigitalBundle,
+};

--- a/assets/components/paperSubscriptions/paperSubscriptions.jsx
+++ b/assets/components/paperSubscriptions/paperSubscriptions.jsx
@@ -6,14 +6,13 @@ import React from 'react';
 
 import { getSubsLinks } from 'helpers/externalLinks';
 import { getCampaign } from 'helpers/tracking/acquisitions';
-import { getDiscountedPrice } from 'helpers/flashSale';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 
 import PageSection from 'components/pageSection/pageSection';
 import SubscriptionBundle from 'components/subscriptionBundle/subscriptionBundle';
 import { type HeadingSize } from 'components/heading/heading';
-import type { CountryGroupId } from '../../helpers/internationalisation/countryGroup';
-import { displayPrice } from '../../helpers/subscriptions';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { displayPrice } from 'helpers/subscriptions';
 
 
 // ----- Types ----- //
@@ -90,7 +89,7 @@ function PaperBundle(props: {
     <SubscriptionBundle
       modifierClass="paper"
       heading="Paper"
-      subheading={`from £${getDiscountedPrice('Paper', '10.36')}/month`}
+      subheading={`from ${displayPrice('Paper', 'GBPCountries')}`}
       headingSize={props.headingSize}
       benefits={[
         {
@@ -126,7 +125,7 @@ function PaperDigitalBundle(props: {
     <SubscriptionBundle
       modifierClass="paper-digital"
       heading="Paper+Digital"
-      subheading={`from £${getDiscountedPrice('PaperAndDigital', '21.62')}/month`}
+      subheading={`from ${displayPrice('PaperAndDigital', 'GBPCountries')}`}
       headingSize={props.headingSize}
       benefits={[
         {

--- a/assets/components/paperSubscriptions/paperSubscriptions.jsx
+++ b/assets/components/paperSubscriptions/paperSubscriptions.jsx
@@ -6,12 +6,14 @@ import React from 'react';
 
 import { getSubsLinks } from 'helpers/externalLinks';
 import { getCampaign } from 'helpers/tracking/acquisitions';
-import { getPrice } from 'helpers/flashSale';
+import { getDiscountedPrice } from 'helpers/flashSale';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 
 import PageSection from 'components/pageSection/pageSection';
 import SubscriptionBundle from 'components/subscriptionBundle/subscriptionBundle';
 import { type HeadingSize } from 'components/heading/heading';
+import type { CountryGroupId } from '../../helpers/internationalisation/countryGroup';
+import { displayPrice } from '../../helpers/subscriptions';
 
 
 // ----- Types ----- //
@@ -43,6 +45,7 @@ const gridImageProperties = {
 export default function PaperSubscriptions(props: PropTypes) {
 
   const subsLinks = getSubsLinks(
+    'GBPCountries',
     props.referrerAcquisitionData.campaignCode,
     getCampaign(props.referrerAcquisitionData),
     [],
@@ -63,6 +66,7 @@ export default function PaperSubscriptions(props: PropTypes) {
           onClick={props.clickEvents.paperDigital}
         />
         <WeeklyBundle
+          countryGroupId="GBPCountries"
           url={subsLinks.weekly}
           headingSize={props.headingSize}
           onClick={props.clickEvents.weekly}
@@ -86,7 +90,7 @@ function PaperBundle(props: {
     <SubscriptionBundle
       modifierClass="paper"
       heading="Paper"
-      subheading={`from £${getPrice('paper', '10.36')}/month`}
+      subheading={`from £${getDiscountedPrice('Paper', '10.36')}/month`}
       headingSize={props.headingSize}
       benefits={[
         {
@@ -122,7 +126,7 @@ function PaperDigitalBundle(props: {
     <SubscriptionBundle
       modifierClass="paper-digital"
       heading="Paper+Digital"
-      subheading={`from £${getPrice('paperAndDigital', '21.62')}/month`}
+      subheading={`from £${getDiscountedPrice('PaperAndDigital', '21.62')}/month`}
       headingSize={props.headingSize}
       benefits={[
         {
@@ -149,6 +153,7 @@ function PaperDigitalBundle(props: {
 }
 
 function WeeklyBundle(props: {
+  countryGroupId: CountryGroupId,
   url: string,
   headingSize: HeadingSize,
   onClick: ClickEvent,
@@ -158,7 +163,7 @@ function WeeklyBundle(props: {
     <SubscriptionBundle
       modifierClass="weekly"
       heading="Guardian Weekly"
-      subheading="£30/quarter"
+      subheading={displayPrice('GuardianWeekly', props.countryGroupId)}
       headingSize={props.headingSize}
       benefits={[
         {

--- a/assets/components/paperSubscriptions/paperSubscriptions.jsx
+++ b/assets/components/paperSubscriptions/paperSubscriptions.jsx
@@ -56,18 +56,18 @@ export default function PaperSubscriptions(props: PropTypes) {
     <div className="component-paper-subscriptions">
       <PageSection heading="Print Subscriptions" modifierClass="paper-subscriptions">
         <PaperBundle
-          url={subsLinks.paper}
+          url={subsLinks.Paper}
           headingSize={props.headingSize}
           onClick={props.clickEvents.paper}
         />
         <PaperDigitalBundle
-          url={subsLinks.paperDig}
+          url={subsLinks.PaperAndDigital}
           headingSize={props.headingSize}
           onClick={props.clickEvents.paperDigital}
         />
         <WeeklyBundle
           countryGroupId="GBPCountries"
-          url={subsLinks.weekly}
+          url={subsLinks.GuardianWeekly}
           headingSize={props.headingSize}
           onClick={props.clickEvents.weekly}
         />
@@ -83,7 +83,7 @@ export default function PaperSubscriptions(props: PropTypes) {
 function PaperBundle(props: {
   url: string,
   headingSize: HeadingSize,
-  onClick: ClickEvent,
+  onClick: ClickEvent | null,
 }) {
 
   return (
@@ -119,7 +119,7 @@ function PaperBundle(props: {
 function PaperDigitalBundle(props: {
   url: string,
   headingSize: HeadingSize,
-  onClick: ClickEvent,
+  onClick: ClickEvent | null,
 }) {
 
   return (

--- a/assets/components/threeSubscriptions/threeSubscriptions.jsx
+++ b/assets/components/threeSubscriptions/threeSubscriptions.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 import { getSubsLinks } from 'helpers/externalLinks';
 import { getCampaign } from 'helpers/tracking/acquisitions';
-import { getPaperBenefits, getDigitalBenefits, getPaperDigitalBenefits, getPrice } from 'helpers/flashSale';
+import { getPaperBenefits, getDigitalBenefits, getPaperDigitalBenefits, getDiscountedPrice } from 'helpers/flashSale';
 
 import PageSection from 'components/pageSection/pageSection';
 import SubscriptionBundle from 'components/subscriptionBundle/subscriptionBundle';
@@ -46,6 +46,7 @@ const gridImageProperties = {
 function ThreeSubscriptions(props: PropTypes) {
 
   const subsLinks = getSubsLinks(
+    'GBPCountries',
     props.referrerAcquisitionData.campaignCode,
     getCampaign(props.referrerAcquisitionData),
     [],
@@ -87,9 +88,9 @@ function DigitalBundle(props: {
 
   return (
     <SubscriptionBundle
+      countryGroupId="GBPCountries"
       modifierClass="digital"
       heading="Digital"
-      subheading={`£${getPrice('digital', '11.99')}/month`}
       benefits={getDigitalBenefits()}
       gridImage={{
         gridId: 'digitalCircle',
@@ -121,7 +122,7 @@ function PaperBundle(props: {
     <SubscriptionBundle
       modifierClass="paper"
       heading="Paper"
-      subheading={`from £${getPrice('paper', '10.36')}/month`}
+      subheading={`from £${getDiscountedPrice('Paper', '10.36')}/month`}
       benefits={getPaperBenefits()}
       gridImage={{
         gridId: 'paperCircle',
@@ -153,7 +154,7 @@ function PaperDigitalBundle(props: {
     <SubscriptionBundle
       modifierClass="paper-digital"
       heading="Paper+digital"
-      subheading={`from £${getPrice('paperAndDigital', '21.62')}/month`}
+      subheading={`from £${getDiscountedPrice('PaperAndDigital', '21.62')}/month`}
       benefits={getPaperDigitalBenefits()}
       gridImage={{
         gridId: 'paperDigitalCircle',

--- a/assets/components/threeSubscriptions/threeSubscriptions.jsx
+++ b/assets/components/threeSubscriptions/threeSubscriptions.jsx
@@ -6,12 +6,14 @@ import React from 'react';
 
 import { getSubsLinks } from 'helpers/externalLinks';
 import { getCampaign } from 'helpers/tracking/acquisitions';
+import { getPaperBenefits, getDigitalBenefits, getPaperDigitalBenefits } from 'helpers/flashSale';
 
 import PageSection from 'components/pageSection/pageSection';
-import { DigitalBundle } from 'components/digitalSubscriptions/digitalSubscriptions';
-import { PaperBundle, PaperDigitalBundle } from 'components/paperSubscriptions/paperSubscriptions';
+import SubscriptionBundle from 'components/subscriptionBundle/subscriptionBundle';
+
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import type { HeadingSize } from 'components/heading/heading';
+import { displayPrice } from '../../helpers/subscriptions';
 
 
 // ----- Types ----- //
@@ -31,11 +33,20 @@ type PropTypes = {
 };
 
 
+// ----- Setup ----- //
+
+const gridImageProperties = {
+  srcSizes: [825, 500, 140],
+  sizes: '(max-width: 660px) 165px, (max-width: 740px) 174px, (max-width: 980px) 196px, (max-width: 1140px) 205px, 165px',
+  imgType: 'png',
+};
+
+const countryGroupId = 'GBPCountries'; // This component is only used in the UK
+
+
 // ----- Component ----- //
 
 function ThreeSubscriptions(props: PropTypes) {
-
-  const countryGroupId = 'GBPCountries'; // This component is only used in the UK
 
   const subsLinks = getSubsLinks(
     countryGroupId,
@@ -49,25 +60,121 @@ function ThreeSubscriptions(props: PropTypes) {
     <div className="component-three-subscriptions">
       <PageSection heading="Subscribe" modifierClass="three-subscriptions">
         <DigitalBundle
-          countryGroupId={countryGroupId}
           url={subsLinks.DigitalPack}
           headingSize={props.digitalHeadingSize}
           onClick={props.clickEvents ? props.clickEvents.digital : null}
         />
         <PaperBundle
-          countryGroupId={countryGroupId}
           url={subsLinks.Paper}
           headingSize={props.paperHeadingSize}
           onClick={props.clickEvents ? props.clickEvents.paper : null}
         />
         <PaperDigitalBundle
-          countryGroupId={countryGroupId}
           url={subsLinks.PaperAndDigital}
           headingSize={props.paperDigitalHeadingSize}
           onClick={props.clickEvents ? props.clickEvents.paperDigital : null}
         />
       </PageSection>
     </div>
+  );
+
+}
+
+
+// ----- Auxiliary Components ----- //
+
+function DigitalBundle(props: {
+  url: string,
+  headingSize: HeadingSize,
+  onClick: ClickEvent | null,
+}) {
+
+  return (
+    <SubscriptionBundle
+      modifierClass="digital"
+      heading="Digital"
+      subheading={displayPrice('DigitalPack', countryGroupId)}
+      benefits={getDigitalBenefits()}
+      gridImage={{
+        gridId: 'digitalCircle',
+        altText: 'digital subscription',
+        ...gridImageProperties,
+      }}
+      headingSize={props.headingSize}
+      ctas={[
+        {
+          text: 'Start your 14 day trial',
+          url: props.url,
+          accessibilityHint: 'Find out how to sign up for a free trial of The Guardian\'s digital subscription.',
+          modifierClasses: ['digital', 'border'],
+          onClick: props.onClick,
+        },
+      ]}
+    />
+  );
+
+}
+
+function PaperBundle(props: {
+  url: string,
+  headingSize: HeadingSize,
+  onClick: ClickEvent | null,
+}) {
+
+  return (
+    <SubscriptionBundle
+      modifierClass="paper"
+      heading="Paper"
+      subheading={`from ${displayPrice('Paper', countryGroupId)}`}
+      benefits={getPaperBenefits()}
+      gridImage={{
+        gridId: 'paperCircle',
+        altText: 'paper subscription',
+        ...gridImageProperties,
+      }}
+      headingSize={props.headingSize}
+      ctas={[
+        {
+          text: 'Get a paper subscription',
+          url: props.url,
+          accessibilityHint: 'Proceed to paper subscription options',
+          modifierClasses: ['paper', 'border'],
+          onClick: props.onClick,
+        },
+      ]}
+    />
+  );
+
+}
+
+function PaperDigitalBundle(props: {
+  url: string,
+  headingSize: HeadingSize,
+  onClick: ClickEvent | null,
+}) {
+
+  return (
+    <SubscriptionBundle
+      modifierClass="paper-digital"
+      heading="Paper+digital"
+      subheading={`from ${displayPrice('PaperAndDigital', countryGroupId)}`}
+      benefits={getPaperDigitalBenefits()}
+      gridImage={{
+        gridId: 'paperDigitalCircle',
+        altText: 'paper + digital subscription',
+        ...gridImageProperties,
+      }}
+      headingSize={props.headingSize}
+      ctas={[
+        {
+          text: 'Get a paper+digital subscription',
+          url: props.url,
+          accessibilityHint: 'Proceed to choose which days you would like to regularly receive the newspaper in conjunction with a digital subscription',
+          modifierClasses: ['paper-digital', 'border'],
+          onClick: props.onClick,
+        },
+      ]}
+    />
   );
 
 }

--- a/assets/components/threeSubscriptions/threeSubscriptions.jsx
+++ b/assets/components/threeSubscriptions/threeSubscriptions.jsx
@@ -6,11 +6,10 @@ import React from 'react';
 
 import { getSubsLinks } from 'helpers/externalLinks';
 import { getCampaign } from 'helpers/tracking/acquisitions';
-import { getPaperBenefits, getDigitalBenefits, getPaperDigitalBenefits, getDiscountedPrice } from 'helpers/flashSale';
 
 import PageSection from 'components/pageSection/pageSection';
-import SubscriptionBundle from 'components/subscriptionBundle/subscriptionBundle';
-
+import { DigitalBundle } from 'components/digitalSubscriptions/digitalSubscriptions';
+import { PaperBundle, PaperDigitalBundle } from 'components/paperSubscriptions/paperSubscriptions';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import type { HeadingSize } from 'components/heading/heading';
 
@@ -32,21 +31,14 @@ type PropTypes = {
 };
 
 
-// ----- Setup ----- //
-
-const gridImageProperties = {
-  srcSizes: [825, 500, 140],
-  sizes: '(max-width: 660px) 165px, (max-width: 740px) 174px, (max-width: 980px) 196px, (max-width: 1140px) 205px, 165px',
-  imgType: 'png',
-};
-
-
 // ----- Component ----- //
 
 function ThreeSubscriptions(props: PropTypes) {
 
+  const countryGroupId = 'GBPCountries'; // This component is only used in the UK
+
   const subsLinks = getSubsLinks(
-    'GBPCountries',
+    countryGroupId,
     props.referrerAcquisitionData.campaignCode,
     getCampaign(props.referrerAcquisitionData),
     [],
@@ -57,121 +49,25 @@ function ThreeSubscriptions(props: PropTypes) {
     <div className="component-three-subscriptions">
       <PageSection heading="Subscribe" modifierClass="three-subscriptions">
         <DigitalBundle
-          url={subsLinks.digital}
+          countryGroupId={countryGroupId}
+          url={subsLinks.DigitalPack}
           headingSize={props.digitalHeadingSize}
           onClick={props.clickEvents ? props.clickEvents.digital : null}
         />
         <PaperBundle
-          url={subsLinks.paper}
+          countryGroupId={countryGroupId}
+          url={subsLinks.Paper}
           headingSize={props.paperHeadingSize}
           onClick={props.clickEvents ? props.clickEvents.paper : null}
         />
         <PaperDigitalBundle
-          url={subsLinks.paperDig}
+          countryGroupId={countryGroupId}
+          url={subsLinks.PaperAndDigital}
           headingSize={props.paperDigitalHeadingSize}
           onClick={props.clickEvents ? props.clickEvents.paperDigital : null}
         />
       </PageSection>
     </div>
-  );
-
-}
-
-
-// ----- Auxiliary Components ----- //
-
-function DigitalBundle(props: {
-  url: string,
-  headingSize: HeadingSize,
-  onClick: ClickEvent | null,
-}) {
-
-  return (
-    <SubscriptionBundle
-      countryGroupId="GBPCountries"
-      modifierClass="digital"
-      heading="Digital"
-      benefits={getDigitalBenefits()}
-      gridImage={{
-        gridId: 'digitalCircle',
-        altText: 'digital subscription',
-        ...gridImageProperties,
-      }}
-      headingSize={props.headingSize}
-      ctas={[
-        {
-          text: 'Start your 14 day trial',
-          url: props.url,
-          accessibilityHint: 'Find out how to sign up for a free trial of The Guardian\'s digital subscription.',
-          modifierClasses: ['digital', 'border'],
-          onClick: props.onClick,
-        },
-      ]}
-    />
-  );
-
-}
-
-function PaperBundle(props: {
-  url: string,
-  headingSize: HeadingSize,
-  onClick: ClickEvent | null,
-}) {
-
-  return (
-    <SubscriptionBundle
-      modifierClass="paper"
-      heading="Paper"
-      subheading={`from £${getDiscountedPrice('Paper', '10.36')}/month`}
-      benefits={getPaperBenefits()}
-      gridImage={{
-        gridId: 'paperCircle',
-        altText: 'paper subscription',
-        ...gridImageProperties,
-      }}
-      headingSize={props.headingSize}
-      ctas={[
-        {
-          text: 'Get a paper subscription',
-          url: props.url,
-          accessibilityHint: 'Proceed to paper subscription options',
-          modifierClasses: ['paper', 'border'],
-          onClick: props.onClick,
-        },
-      ]}
-    />
-  );
-
-}
-
-function PaperDigitalBundle(props: {
-  url: string,
-  headingSize: HeadingSize,
-  onClick: ClickEvent | null,
-}) {
-
-  return (
-    <SubscriptionBundle
-      modifierClass="paper-digital"
-      heading="Paper+digital"
-      subheading={`from £${getDiscountedPrice('PaperAndDigital', '21.62')}/month`}
-      benefits={getPaperDigitalBenefits()}
-      gridImage={{
-        gridId: 'paperDigitalCircle',
-        altText: 'paper + digital subscription',
-        ...gridImageProperties,
-      }}
-      headingSize={props.headingSize}
-      ctas={[
-        {
-          text: 'Get a paper+digital subscription',
-          url: props.url,
-          accessibilityHint: 'Proceed to choose which days you would like to regularly receive the newspaper in conjunction with a digital subscription',
-          modifierClasses: ['paper-digital', 'border'],
-          onClick: props.onClick,
-        },
-      ]}
-    />
   );
 
 }

--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -11,19 +11,19 @@ import {
 import { addQueryParamsToURL } from 'helpers/url';
 
 import { getPromoCode } from './flashSale';
+import type { SubscriptionProduct } from './subscriptions';
 
 
 // ----- Types ----- //
 
-export type SubsProduct = 'paper' | 'digital' | 'paperDig' | 'weekly';
 export type MemProduct = 'patrons' | 'events';
 
 type PromoCodes = {
-  [SubsProduct]: string,
+  [SubscriptionProduct]: string,
 };
 
 export type SubsUrls = {
-  [SubsProduct]: string,
+  [SubscriptionProduct]: string,
 };
 
 
@@ -43,58 +43,58 @@ const memUrls: {
 };
 
 const defaultPromos: PromoCodes = {
-  digital: getPromoCode('digital', 'DXX83X'),
-  paper: getPromoCode('paper', 'GXX83P'),
-  paperDig: getPromoCode('paperAndDigital', 'GXX83X'),
+  DigitalPack: getPromoCode('DigitalPack', 'DXX83X'),
+  Paper: getPromoCode('Paper', 'GXX83P'),
+  PaperAndDigital: getPromoCode('PaperAndDigital', 'GXX83X'),
 };
 
 const customPromos : {
   [Campaign]: PromoCodes,
 } = {
   seven_fifty_middle: {
-    digital: 'D750MIDDLE',
-    paper: 'N750MIDDLE',
-    paperDig: 'ND750MIDDLE',
+    DigitalPack: 'D750MIDDLE',
+    Paper: 'N750MIDDLE',
+    PaperAndDigital: 'ND750MIDDLE',
   },
   seven_fifty_end: {
-    digital: 'D750END',
-    paper: 'N750END',
-    paperDig: 'ND750END',
+    DigitalPack: 'D750END',
+    Paper: 'N750END',
+    PaperAndDigital: 'ND750END',
   },
   seven_fifty_email: {
-    digital: 'D750EMAIL',
-    paper: 'N750EMAIL',
-    paperDig: 'ND750EMAIL',
+    DigitalPack: 'D750EMAIL',
+    Paper: 'N750EMAIL',
+    PaperAndDigital: 'ND750EMAIL',
   },
   epic_paradise_paradise_highlight: {
-    digital: 'DPARAHIGH',
-    paper: 'NPARAHIGH',
-    paperDig: 'NDPARAHIGH',
+    DigitalPack: 'DPARAHIGH',
+    Paper: 'NPARAHIGH',
+    PaperAndDigital: 'NDPARAHIGH',
   },
   epic_paradise_control: {
-    digital: 'DPARACON',
-    paper: 'NPARACON',
-    paperDig: 'NDPARACON',
+    DigitalPack: 'DPARACON',
+    Paper: 'NPARACON',
+    PaperAndDigital: 'NDPARACON',
   },
   epic_paradise_different_highlight: {
-    digital: 'DPARADIFF',
-    paper: 'NPARADIFF',
-    paperDig: 'NDPARADIFF',
+    DigitalPack: 'DPARADIFF',
+    Paper: 'NPARADIFF',
+    PaperAndDigital: 'NDPARADIFF',
   },
   epic_paradise_standfirst: {
-    digital: 'DPARASTAND',
-    paper: 'NPARASTAND',
-    paperDig: 'NDPARASTAND',
+    DigitalPack: 'DPARASTAND',
+    Paper: 'NPARASTAND',
+    PaperAndDigital: 'NDPARASTAND',
   },
   banner_just_one_control: {
-    digital: 'DBANJUSTCON',
-    paper: 'NBANJUSTCON',
-    paperDig: 'NDBANJUSTCON',
+    DigitalPack: 'DBANJUSTCON',
+    Paper: 'NBANJUSTCON',
+    PaperAndDigital: 'NDBANJUSTCON',
   },
   banner_just_one_just_one: {
-    digital: 'DBANJUSTONE',
-    paper: 'NBANJUSTONE',
-    paperDig: 'NDBANJUSTONE',
+    DigitalPack: 'DBANJUSTONE',
+    Paper: 'NBANJUSTONE',
+    PaperAndDigital: 'NDBANJUSTONE',
   },
 };
 
@@ -126,16 +126,16 @@ function buildSubsUrls(
   otherQueryParams.forEach(p => params.append(p[0], p[1]));
   params.append('acquisitionData', JSON.stringify(referrerAcquisitionData));
 
-  const paper = `${subsUrl}/p/${promoCodes.paper}?${params.toString()}`;
-  const paperDig = `${subsUrl}/p/${promoCodes.paperDig}?${params.toString()}`;
+  const paper = `${subsUrl}/p/${promoCodes.Paper}?${params.toString()}`;
+  const paperDig = `${subsUrl}/p/${promoCodes.PaperAndDigital}?${params.toString()}`;
   const digital = `/${countryId}/subscribe/digital?${params.toString()}`;
   const weekly = `${subsUrl}/weekly?${params.toString()}`;
 
   return {
-    digital,
-    paper,
-    paperDig,
-    weekly,
+    DigitalPack: digital,
+    Paper: paper,
+    PaperAndDigital: paperDig,
+    GuardianWeekly: weekly,
   };
 
 }
@@ -170,7 +170,7 @@ function getDigitalCheckout(
 ): string {
 
   return addQueryParamsToURL(`${subsUrl}/checkout`, {
-    promoCode: defaultPromos.digital,
+    promoCode: defaultPromos.DigitalPack,
     countryGroup: countryGroups[cgId].supportInternationalisationId,
     acquisitionData: JSON.stringify(referrerAcquisitionData),
     startTrialButton: referringCta,

--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -113,12 +113,14 @@ function getMemLink(product: MemProduct, intCmp: ?string): string {
 
 // Creates URLs for the subs site from promo codes and intCmp.
 function buildSubsUrls(
+  countryGroupId: CountryGroupId,
   promoCodes: PromoCodes,
   intCmp: ?string,
   otherQueryParams: Array<[string, string]>,
   referrerAcquisitionData: ReferrerAcquisitionData,
 ): SubsUrls {
 
+  const countryId = countryGroups[countryGroupId].supportInternationalisationId;
   const params = new URLSearchParams();
   params.append('INTCMP', intCmp || defaultIntCmp);
   otherQueryParams.forEach(p => params.append(p[0], p[1]));
@@ -126,8 +128,8 @@ function buildSubsUrls(
 
   const paper = `${subsUrl}/p/${promoCodes.paper}?${params.toString()}`;
   const paperDig = `${subsUrl}/p/${promoCodes.paperDig}?${params.toString()}`;
-  const digital = `/uk/subscribe/digital?${params.toString()}`; // This page is only used in the UK currently
-  const weekly = `${subsUrl}/weekly/GB?${params.toString()}`;
+  const digital = `/${countryId}/subscribe/digital?${params.toString()}`;
+  const weekly = `${subsUrl}/weekly?${params.toString()}`;
 
   return {
     digital,
@@ -140,6 +142,7 @@ function buildSubsUrls(
 
 // Creates links to subscriptions, tailored to the user's campaign.
 function getSubsLinks(
+  countryGroupId: CountryGroupId = 'GBPCountries',
   intCmp: ?string,
   campaign: ?Campaign,
   otherQueryParams: Array<[string, string]>,
@@ -147,6 +150,7 @@ function getSubsLinks(
 ): SubsUrls {
   if ((campaign && customPromos[campaign])) {
     return buildSubsUrls(
+      countryGroupId,
       customPromos[campaign],
       intCmp,
       otherQueryParams,
@@ -154,7 +158,7 @@ function getSubsLinks(
     );
   }
 
-  return buildSubsUrls(defaultPromos, intCmp, otherQueryParams, referrerAcquisitionData);
+  return buildSubsUrls(countryGroupId, defaultPromos, intCmp, otherQueryParams, referrerAcquisitionData);
 
 }
 

--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -142,7 +142,7 @@ function buildSubsUrls(
 
 // Creates links to subscriptions, tailored to the user's campaign.
 function getSubsLinks(
-  countryGroupId: CountryGroupId = 'GBPCountries',
+  countryGroupId: CountryGroupId,
   intCmp: ?string,
   campaign: ?Campaign,
   otherQueryParams: Array<[string, string]>,

--- a/assets/helpers/flashSale.js
+++ b/assets/helpers/flashSale.js
@@ -14,6 +14,9 @@ function inOfferPeriod(product: SubscriptionProduct): boolean {
     DigitalPack: true,
     Paper: false,
     PaperAndDigital: false,
+    DailyEdition: false,
+    GuardianWeekly: false,
+    PremiumTier: false,
   };
 
   const now = Date.now();
@@ -34,6 +37,18 @@ const promoCodes = {
   PaperAndDigital: {
     promoCode: 'GST80G',
     price: '10.81',
+  },
+  DailyEdition: {
+    promoCode: '',
+    price: '6.99',
+  },
+  GuardianWeekly: {
+    promoCode: '',
+    price: '30',
+  },
+  PremiumTier: {
+    promoCode: '',
+    price: '5.99',
   },
 };
 

--- a/assets/helpers/flashSale.js
+++ b/assets/helpers/flashSale.js
@@ -1,19 +1,19 @@
 // @flow
 
 import { getQueryParameter } from 'helpers/url';
+import type { SubscriptionProduct } from './subscriptions';
 
-type ProductType = 'digital' | 'paper' | 'paperAndDigital';
 
-function inOfferPeriod(product: ProductType): boolean {
+function inOfferPeriod(product: SubscriptionProduct): boolean {
   // Days are 1 based, months are 0 based
   const startTime = new Date(2018, 5, 18, 0, 0).getTime(); // 18th June 2018
   const endTime = new Date(2018, 6, 1, 0, 0).getTime(); // 1st July 2018
 
   // The current sale is digital only, paper & paper + digital is unaffected
   const included = {
-    digital: true,
-    paper: false,
-    paperAndDigital: false,
+    DigitalPack: true,
+    Paper: false,
+    PaperAndDigital: false,
   };
 
   const now = Date.now();
@@ -23,28 +23,28 @@ function inOfferPeriod(product: ProductType): boolean {
 
 // Promo codes
 const promoCodes = {
-  digital: {
+  DigitalPack: {
     promoCode: 'DPS80S',
     price: '11.99',
   },
-  paper: {
+  Paper: {
     promoCode: 'GST80F',
     price: '5.18',
   },
-  paperAndDigital: {
+  PaperAndDigital: {
     promoCode: 'GST80G',
     price: '10.81',
   },
 };
 
-function getPromoCode(product: ProductType, defaultCode: string) {
+function getPromoCode(product: SubscriptionProduct, defaultCode: string) {
   if (inOfferPeriod(product)) {
     return promoCodes[product].promoCode;
   }
   return defaultCode;
 }
 
-function getPrice(product: ProductType, defaultPrice: string) {
+function getDiscountedPrice(product: SubscriptionProduct, defaultPrice: string) {
   if (inOfferPeriod(product)) {
     return promoCodes[product].price;
   }
@@ -72,21 +72,21 @@ function getDigitalBenefits() {
     },
   ];
 
-  if (inOfferPeriod('digital')) {
+  if (inOfferPeriod('DigitalPack')) {
     return [offerItem, ...items];
   }
   return items;
 }
 
 function getPaperBenefits() {
-  if (inOfferPeriod('paper')) {
+  if (inOfferPeriod('Paper')) {
     return [offerItem, chooseYourPackage, saveMoneyOnRetailPrice];
   }
   return [chooseYourPackage, saveMoneyOnRetailPrice];
 }
 
 function getPaperDigitalBenefits() {
-  if (inOfferPeriod('paperAndDigital')) {
+  if (inOfferPeriod('PaperAndDigital')) {
     return [offerItem, chooseYourPackage, saveMoneyOnRetailPrice, getAllBenefits];
   }
   return [chooseYourPackage, saveMoneyOnRetailPrice, getAllBenefits];
@@ -97,5 +97,5 @@ export {
   getPaperBenefits,
   getPaperDigitalBenefits,
   getPromoCode,
-  getPrice,
+  getDiscountedPrice,
 };

--- a/assets/helpers/flashSale.js
+++ b/assets/helpers/flashSale.js
@@ -9,7 +9,7 @@ function inOfferPeriod(product: SubscriptionProduct): boolean {
   const startTime = new Date(2018, 5, 18, 0, 0).getTime(); // 18th June 2018
   const endTime = new Date(2018, 6, 1, 0, 0).getTime(); // 1st July 2018
 
-  // The current sale is digital only, paper & paper + digital is unaffected
+  // The current sale is digital only, everything else is unaffected
   const included = {
     DigitalPack: true,
     Paper: false,

--- a/assets/helpers/flashSale.js
+++ b/assets/helpers/flashSale.js
@@ -28,27 +28,27 @@ function inOfferPeriod(product: SubscriptionProduct): boolean {
 const promoCodes = {
   DigitalPack: {
     promoCode: 'DPS80S',
-    price: '11.99',
+    price: 11.99,
   },
   Paper: {
     promoCode: 'GST80F',
-    price: '5.18',
+    price: 5.18,
   },
   PaperAndDigital: {
     promoCode: 'GST80G',
-    price: '10.81',
+    price: 10.81,
   },
   DailyEdition: {
     promoCode: '',
-    price: '6.99',
+    price: 6.99,
   },
   GuardianWeekly: {
     promoCode: '',
-    price: '30',
+    price: 30,
   },
   PremiumTier: {
     promoCode: '',
-    price: '5.99',
+    price: 5.99,
   },
 };
 
@@ -59,7 +59,7 @@ function getPromoCode(product: SubscriptionProduct, defaultCode: string) {
   return defaultCode;
 }
 
-function getDiscountedPrice(product: SubscriptionProduct, defaultPrice: string) {
+function getDiscountedPrice(product: SubscriptionProduct, defaultPrice: number) {
   if (inOfferPeriod(product)) {
     return promoCodes[product].price;
   }

--- a/assets/helpers/subscriptions.js
+++ b/assets/helpers/subscriptions.js
@@ -3,6 +3,8 @@
 // ----- Imports ----- //
 
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { trackComponentEvents } from './tracking/ophanComponentEventTracking';
+import { gaEvent } from './tracking/googleTagManager';
 
 
 // ----- Config ----- //
@@ -17,6 +19,39 @@ const digitalSubPrices: {
 };
 
 
+function sendTrackingEventsOnClick(
+  id: string,
+  product: 'digital' | 'print',
+  abTest: string,
+  variant: boolean,
+): () => void {
+
+  return () => {
+
+    trackComponentEvents({
+      component: {
+        componentType: 'ACQUISITIONS_BUTTON',
+        id,
+        products: product === 'digital' ? ['DIGITAL_SUBSCRIPTION'] : ['PRINT_SUBSCRIPTION'],
+      },
+      action: 'CLICK',
+      id: `${abTest}${id}`,
+      abTest: {
+        name: `${abTest}`,
+        variant: variant ? 'variant' : 'control',
+      },
+    });
+
+    gaEvent({
+      category: 'click',
+      action: `${abTest}`,
+      label: id,
+    });
+
+  };
+
+}
+
 // ----- Exports ----- //
 
-export { digitalSubPrices };
+export { digitalSubPrices, sendTrackingEventsOnClick };

--- a/assets/helpers/subscriptions.js
+++ b/assets/helpers/subscriptions.js
@@ -5,18 +5,58 @@
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { trackComponentEvents } from './tracking/ophanComponentEventTracking';
 import { gaEvent } from './tracking/googleTagManager';
+import { currencies, detect } from './internationalisation/currency';
+import { getDiscountedPrice } from './flashSale';
 
+// ----- Types ------ //
+
+export type SubscriptionProduct = 'DigitalPack' |
+  'PremiumTier' |
+  'DailyEdition' |
+  'GuardianWeekly' |
+  'Paper' |
+  'PaperAndDigital'
 
 // ----- Config ----- //
 
 const digitalSubPrices: {
-  [CountryGroupId]: number,
+  [SubscriptionProduct]: {
+    [CountryGroupId]: number,
+  }
 } = {
-  GBPCountries: 11.99,
-  UnitedStates: 19.99,
-  AUDCountries: 21.50,
-  International: 19.99,
+  PremiumTier: {
+    GBPCountries: 5.99,
+    UnitedStates: 6.99,
+    AUDCountries: 7.99,
+    International: 5.99,
+  },
+  DigitalPack: {
+    GBPCountries: 11.99,
+    UnitedStates: 19.99,
+    AUDCountries: 21.50,
+    International: 19.99,
+  },
+  GuardianWeekly: {
+    GBPCountries: 30,
+    UnitedStates: 60,
+    AUDCountries: 78,
+    International: 65,
+  },
 };
+
+const defaultBillingPeriods = {
+  PremiumTier: 'month',
+  DigitalPack: 'month',
+  GuardianWeekly: 'quarter',
+};
+
+function displayPrice(product: SubscriptionProduct, countryGroupId: CountryGroupId) {
+  const currency = currencies[detect(countryGroupId)].glyph;
+  const price = (digitalSubPrices[product][countryGroupId]);
+  const formatted = Number.isInteger(price) ? price : price.toFixed(2);
+  const discountedPrice = getDiscountedPrice(product, formatted);
+  return `${currency}${discountedPrice}/${defaultBillingPeriods[product]}`;
+}
 
 
 function sendTrackingEventsOnClick(
@@ -54,4 +94,4 @@ function sendTrackingEventsOnClick(
 
 // ----- Exports ----- //
 
-export { digitalSubPrices, sendTrackingEventsOnClick };
+export { digitalSubPrices, sendTrackingEventsOnClick, displayPrice };

--- a/assets/helpers/subscriptions.js
+++ b/assets/helpers/subscriptions.js
@@ -44,7 +44,9 @@ const digitalSubPrices: {
   },
 };
 
-const defaultBillingPeriods = {
+const defaultBillingPeriods: {
+  [SubscriptionProduct]: string,
+} = {
   PremiumTier: 'month',
   DigitalPack: 'month',
   GuardianWeekly: 'quarter',
@@ -54,7 +56,7 @@ function displayPrice(product: SubscriptionProduct, countryGroupId: CountryGroup
   const currency = currencies[detect(countryGroupId)].glyph;
   const price = (digitalSubPrices[product][countryGroupId]);
   const formatted = Number.isInteger(price) ? price : price.toFixed(2);
-  const discountedPrice = getDiscountedPrice(product, formatted);
+  const discountedPrice = getDiscountedPrice(product, formatted.toString());
   return `${currency}${discountedPrice}/${defaultBillingPeriods[product]}`;
 }
 

--- a/assets/helpers/subscriptions.js
+++ b/assets/helpers/subscriptions.js
@@ -67,8 +67,8 @@ const defaultBillingPeriods: {
 
 function getProductPrice(product: SubscriptionProduct, countryGroupId: CountryGroupId) {
   const price = subscriptionPrices[product][countryGroupId];
-  const formatted = Number.isInteger(price) ? price : price.toFixed(2);
-  return getDiscountedPrice(product, formatted.toString());
+  const discounted = getDiscountedPrice(product, price);
+  return Number.isInteger(discounted) ? discounted : discounted.toFixed(2);
 }
 
 function displayPrice(product: SubscriptionProduct, countryGroupId: CountryGroupId) {
@@ -76,7 +76,6 @@ function displayPrice(product: SubscriptionProduct, countryGroupId: CountryGroup
   const price = getProductPrice(product, countryGroupId);
   return `${currency}${price}/${defaultBillingPeriods[product]}`;
 }
-
 
 function sendTrackingEventsOnClick(
   id: string,

--- a/assets/helpers/subscriptions.js
+++ b/assets/helpers/subscriptions.js
@@ -10,7 +10,8 @@ import { getDiscountedPrice } from './flashSale';
 
 // ----- Types ------ //
 
-export type SubscriptionProduct = 'DigitalPack' |
+export type SubscriptionProduct =
+  'DigitalPack' |
   'PremiumTier' |
   'DailyEdition' |
   'GuardianWeekly' |
@@ -19,7 +20,7 @@ export type SubscriptionProduct = 'DigitalPack' |
 
 // ----- Config ----- //
 
-const digitalSubPrices: {
+const subscriptionPrices: {
   [SubscriptionProduct]: {
     [CountryGroupId]: number,
   }
@@ -42,6 +43,15 @@ const digitalSubPrices: {
     AUDCountries: 78,
     International: 65,
   },
+  Paper: {
+    GBPCountries: 10.36,
+  },
+  PaperAndDigital: {
+    GBPCountries: 21.62,
+  },
+  DailyEdition: {
+    GBPCountries: 6.99,
+  },
 };
 
 const defaultBillingPeriods: {
@@ -50,14 +60,21 @@ const defaultBillingPeriods: {
   PremiumTier: 'month',
   DigitalPack: 'month',
   GuardianWeekly: 'quarter',
+  Paper: 'month',
+  PaperAndDigital: 'month',
+  DailyEdition: 'month',
 };
+
+function getProductPrice(product: SubscriptionProduct, countryGroupId: CountryGroupId) {
+  const price = subscriptionPrices[product][countryGroupId];
+  const formatted = Number.isInteger(price) ? price : price.toFixed(2);
+  return getDiscountedPrice(product, formatted.toString());
+}
 
 function displayPrice(product: SubscriptionProduct, countryGroupId: CountryGroupId) {
   const currency = currencies[detect(countryGroupId)].glyph;
-  const price = (digitalSubPrices[product][countryGroupId]);
-  const formatted = Number.isInteger(price) ? price : price.toFixed(2);
-  const discountedPrice = getDiscountedPrice(product, formatted.toString());
-  return `${currency}${discountedPrice}/${defaultBillingPeriods[product]}`;
+  const price = getProductPrice(product, countryGroupId);
+  return `${currency}${price}/${defaultBillingPeriods[product]}`;
 }
 
 
@@ -96,4 +113,4 @@ function sendTrackingEventsOnClick(
 
 // ----- Exports ----- //
 
-export { digitalSubPrices, sendTrackingEventsOnClick, displayPrice };
+export { sendTrackingEventsOnClick, displayPrice, getProductPrice };

--- a/assets/helpers/theGrid.js
+++ b/assets/helpers/theGrid.js
@@ -24,6 +24,7 @@ export const imageCatalogue: {
   dailyEditionCircle: '64ba1a800e4c2975054b33ba07c4fe3c64d4b5f4/0_0_825_825',
   digitalCircle: '639c3abc4c09281aedb515d684ac4053ef38a1df/0_0_825_825',
   digitalCircleAlt: '0b5ded2325275e25f5b38198766c57363bddfa21/0_0_825_825',
+  digitalCircleInternational: '7d404c1920f065c1b7e71b903cc3899f388acb22/0_0_825_825',
   paperCircle: 'c462d60f2962b745b1e206d5ede998dfb166a8ed/0_0_825_825',
   paperDigitalCircle: 'd94c0f9bade09487b9afca5ee8149efb33f34ccf/0_0_825_825',
   paperDigitalCircleAlt: '69d90e5d6fca261a227e47b311f80807b123c87b/0_0_825_825',

--- a/assets/pages/digital-subscription-landing/components/priceCtaContainer.jsx
+++ b/assets/pages/digital-subscription-landing/components/priceCtaContainer.jsx
@@ -17,7 +17,7 @@ import { currencies } from 'helpers/internationalisation/currency';
 function mapStateToProps(state: { common: CommonState }, ownProps: { referringCta: ?string }) {
   const { countryGroupId } = state.common.internationalisation;
   const { referrerAcquisitionData } = state.common;
-  const price = digitalSubPrices[countryGroupId].toFixed(2);
+  const price = digitalSubPrices.DigitalPack[countryGroupId].toFixed(2);
 
   return {
     ctaText: 'Start a 14 day free trial',

--- a/assets/pages/digital-subscription-landing/components/priceCtaContainer.jsx
+++ b/assets/pages/digital-subscription-landing/components/priceCtaContainer.jsx
@@ -6,10 +6,10 @@ import { connect } from 'react-redux';
 
 import PriceCta from 'components/priceCta/priceCta';
 
-import { digitalSubPrices } from 'helpers/subscriptions';
 import { getDigitalCheckout } from 'helpers/externalLinks';
 import type { CommonState } from 'helpers/page/page';
 import { currencies } from 'helpers/internationalisation/currency';
+import { getProductPrice } from 'helpers/subscriptions';
 
 
 // ----- State Maps ----- //
@@ -17,7 +17,7 @@ import { currencies } from 'helpers/internationalisation/currency';
 function mapStateToProps(state: { common: CommonState }, ownProps: { referringCta: ?string }) {
   const { countryGroupId } = state.common.internationalisation;
   const { referrerAcquisitionData } = state.common;
-  const price = digitalSubPrices.DigitalPack[countryGroupId].toFixed(2);
+  const price = getProductPrice('DigitalPack', countryGroupId);
 
   return {
     ctaText: 'Start a 14 day free trial',

--- a/assets/pages/subscriptions-landing/components/splitSubscriptionsTest.jsx
+++ b/assets/pages/subscriptions-landing/components/splitSubscriptionsTest.jsx
@@ -9,10 +9,7 @@ import { getQueryParameter } from 'helpers/url';
 import ThreeSubscriptionsContainer from 'components/threeSubscriptions/threeSubscriptionsContainer';
 import DigitalSubscriptionsContainer from 'components/digitalSubscriptions/digitalSubscriptionsContainer';
 import PaperSubscriptionsContainer from 'components/paperSubscriptions/paperSubscriptionsContainer';
-
-import { trackComponentEvents } from 'helpers/tracking/ophanComponentEventTracking';
-import { gaEvent } from 'helpers/tracking/googleTagManager';
-
+import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
 
 // ----- Types ----- //
 
@@ -20,40 +17,7 @@ type PropTypes = {
   sectionId: string,
 };
 
-
-// ----- Functions ----- //
-
-function sendEventsOnClick(
-  id: string,
-  product: 'digital' | 'print',
-  variant: boolean,
-): () => void {
-
-  return () => {
-
-    trackComponentEvents({
-      component: {
-        componentType: 'ACQUISITIONS_BUTTON',
-        id,
-        products: product === 'digital' ? ['DIGITAL_SUBSCRIPTION'] : ['PRINT_SUBSCRIPTION'],
-      },
-      action: 'CLICK',
-      id: `split_subscriptions_test_${id}`,
-      abTest: {
-        name: 'split_subscriptions_test',
-        variant: variant ? 'variant' : 'control',
-      },
-    });
-
-    gaEvent({
-      category: 'click',
-      action: 'split_subscriptions_test',
-      label: id,
-    });
-
-  };
-
-}
+const testName = 'split_subscriptions_test';
 
 function getSections() {
 
@@ -62,18 +26,18 @@ function getSections() {
       <DigitalSubscriptionsContainer
         headingSize={3}
         clickEvents={{
-          iOSApp: sendEventsOnClick('premium_tier_ios_cta', 'digital', true),
-          androidApp: sendEventsOnClick('premium_tier_android_cta', 'digital', true),
-          dailyEdition: sendEventsOnClick('daily_edition_cta', 'digital', true),
-          digiPack: sendEventsOnClick('digipack_cta', 'digital', true),
+          iOSApp: sendTrackingEventsOnClick('premium_tier_ios_cta', 'digital', testName, true),
+          androidApp: sendTrackingEventsOnClick('premium_tier_android_cta', 'digital', testName, true),
+          dailyEdition: sendTrackingEventsOnClick('daily_edition_cta', 'digital', testName, true),
+          digiPack: sendTrackingEventsOnClick('digipack_cta', 'digital', testName, true),
         }}
       />,
       <PaperSubscriptionsContainer
         headingSize={3}
         clickEvents={{
-          paper: sendEventsOnClick('paper_cta', 'print', true),
-          paperDigital: sendEventsOnClick('paper_digital_cta', 'print', true),
-          weekly: sendEventsOnClick('weekly_cta', 'print', true),
+          paper: sendTrackingEventsOnClick('paper_cta', 'print', testName, true),
+          paperDigital: sendTrackingEventsOnClick('paper_digital_cta', 'print', testName, true),
+          weekly: sendTrackingEventsOnClick('weekly_cta', 'print', testName, true),
         }}
       />,
     ];
@@ -85,9 +49,9 @@ function getSections() {
       paperHeadingSize={3}
       paperDigitalHeadingSize={3}
       clickEvents={{
-        digital: sendEventsOnClick('digital_cta', 'digital', false),
-        paper: sendEventsOnClick('paper_cta', 'print', false),
-        paperDigital: sendEventsOnClick('paper_digital_cta', 'print', false),
+        digital: sendTrackingEventsOnClick('digital_cta', 'digital', testName, false),
+        paper: sendTrackingEventsOnClick('paper_cta', 'print', testName, false),
+        paperDigital: sendTrackingEventsOnClick('paper_digital_cta', 'print', testName, false),
       }}
     />
   );

--- a/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
+++ b/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
@@ -21,9 +21,9 @@ import { renderPage } from 'helpers/render';
 
 import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
 import InternationalSubscriptions from 'components/internationalSubscriptions/internationalSubscriptionsContainer';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { detect } from 'helpers/internationalisation/countryGroup';
 import SplitSubscriptionsTest from './components/splitSubscriptionsTest';
-import type { CountryGroupId } from '../../helpers/internationalisation/countryGroup';
-import { detect } from '../../helpers/internationalisation/countryGroup';
 
 
 // ----- Setup ----- //

--- a/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
+++ b/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
@@ -19,12 +19,17 @@ import PatronsEventsContainer from 'components/patronsEvents/patronsEventsContai
 import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
 
+import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
+import InternationalSubscriptions from 'components/internationalSubscriptions/internationalSubscriptionsContainer';
 import SplitSubscriptionsTest from './components/splitSubscriptionsTest';
+import type { CountryGroupId } from '../../helpers/internationalisation/countryGroup';
+import { detect } from '../../helpers/internationalisation/countryGroup';
 
 
 // ----- Setup ----- //
 
 const supporterSectionId = 'supporter-options';
+const countryGroupId: CountryGroupId = detect();
 
 
 // ----- Redux Store ----- //
@@ -33,6 +38,23 @@ const store = pageInit();
 
 
 // ----- Render ----- //
+
+function getSubscriptionsForCountry() {
+  if (countryGroupId === 'GBPCountries') {
+    return <SplitSubscriptionsTest sectionId={supporterSectionId} />;
+  }
+  const testName = 'international_subs_landing_pages';
+  return (
+    <InternationalSubscriptions
+      countryGroupId={countryGroupId}
+      headingSize={3}
+      clickEvents={{
+        iOSApp: sendTrackingEventsOnClick('premium_tier_ios_cta', 'digital', testName, true),
+        androidApp: sendTrackingEventsOnClick('premium_tier_android_cta', 'digital', testName, true),
+        digiPack: sendTrackingEventsOnClick('digipack_cta', 'digital', testName, true),
+      }}
+    />);
+}
 
 const content = (
   <Provider store={store}>
@@ -46,7 +68,7 @@ const content = (
         modifierClasses={['compact']}
         highlightsHeadingSize={2}
       />
-      <SplitSubscriptionsTest sectionId={supporterSectionId} />
+      {getSubscriptionsForCountry()}
       <WhySupport headingSize={3} />
       <ReadyToSupport
         ctaUrl={`#${supporterSectionId}`}

--- a/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
+++ b/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
@@ -52,6 +52,7 @@ function getSubscriptionsForCountry() {
         iOSApp: sendTrackingEventsOnClick('premium_tier_ios_cta', 'digital', testName, true),
         androidApp: sendTrackingEventsOnClick('premium_tier_android_cta', 'digital', testName, true),
         digiPack: sendTrackingEventsOnClick('digipack_cta', 'digital', testName, true),
+        weekly: sendTrackingEventsOnClick('weekly_cta', 'print', testName, true),
       }}
     />);
 }

--- a/assets/pages/subscriptions-landing/subscriptionsLanding.scss
+++ b/assets/pages/subscriptions-landing/subscriptionsLanding.scss
@@ -21,6 +21,7 @@
 @import '~components/threeSubscriptions/threeSubscriptions';
 @import '~components/digitalSubscriptions/digitalSubscriptions';
 @import '~components/paperSubscriptions/paperSubscriptions';
+@import '~components/internationalSubscriptions/internationalSubscriptions';
 @import '~components/whySupport/whySupport';
 
 

--- a/conf/CODE.public.conf
+++ b/conf/CODE.public.conf
@@ -43,4 +43,5 @@ switches {
   }
   //Google Optimize tags
   optimize=On
+  internationalSubscribePages=On
 }

--- a/conf/DEV.public.conf
+++ b/conf/DEV.public.conf
@@ -35,5 +35,6 @@ switches {
   }
   //Google Optimize tags
   optimize=Off
+  internationalSubscribePages=On
 }
 

--- a/conf/PROD.public.conf
+++ b/conf/PROD.public.conf
@@ -42,5 +42,6 @@ switches {
   }
   //Google Optimize tags
   optimize=On
+  internationalSubscribePages=Off
 }
 

--- a/conf/routes
+++ b/conf/routes
@@ -60,7 +60,7 @@ GET  /contribute/one-off/autofill                   controllers.OneOffContributi
 # ----- Subscriptions ----- #
 
 GET  /subscribe                                    controllers.Subscriptions.geoRedirect()
-GET  /uk/subscribe                                 controllers.Subscriptions.landing(title="Support the Guardian | Get a Subscription", id="subscriptions-landing-page", js="subscriptionsLandingPage.js")
+GET  /$country<(uk|us|au|int)>/subscribe           controllers.Subscriptions.landing(country: String)
 
 # This is just a fallback in case someone accidentally uses an unsupported country-specific
 # subscribe route. We just redirect to the subscriptions site and let its geolocation handle it.

--- a/test/controllers/RegularContributionsTest.scala
+++ b/test/controllers/RegularContributionsTest.scala
@@ -111,7 +111,7 @@ class RegularContributionsTest extends WordSpec with MustMatchers with TestCSRFC
         stripeConfigProvider,
         payPalConfigProvider,
         stubControllerComponents(),
-        Switches(PaymentMethodsSwitch(On, On, None), PaymentMethodsSwitch(On, On, Some(On)), On),
+        Switches(PaymentMethodsSwitch(On, On, None), PaymentMethodsSwitch(On, On, Some(On)), On, On),
         guardianDomain = ".thegulocal.com"
       )
     }


### PR DESCRIPTION
## Why are you doing this?

To add subscribe landing pages for the US, Australia and the rest of the world.

[**Trello Card**](https://trello.com)

## Changes

* Created new routes for the international versions of the subscribe landing page - these are behind a switch
* Added a `countryGroupId` parameter to the subscription components which are valid outside the UK (not Paper or Paper+Digital)
* Added a new type `SubscriptionProduct` to the subscriptions.js helper file - we had a number of different types scattered around various files, all of which represented a subscription product. To tidy this up I've created a new type and migrated all of the old code over to use it. 
* Added all prices into subscriptions.js and integrated these with the discounting code in flashSale.js so that it is simpler to get hold of the correct price for a product and we don't accidentally end up showing a mix of discounted and non-discounted prices.

### TODO: 
In another PR I'd like to refactor the css for the subs components because we currently have `threeSubscriptions.css`, `digitalSubscriptions.css`, `paperSubscriptions.css` & `internationalSubscriptions.css` which are all more or less identical.

## Screenshots
<img width="1364" alt="screen shot 2018-08-09 at 15 07 27" src="https://user-images.githubusercontent.com/181371/43904207-029fc590-9be6-11e8-81b2-958bbceec7c8.png">
