### PR TITLE
Fix JSON rendering

### DIFF
--- a/app/codecs/CirceDecoders.scala
+++ b/app/codecs/CirceDecoders.scala
@@ -82,7 +82,7 @@ object CirceDecoders {
   implicit val createPaymentMethodStateCodec: Codec[CreatePaymentMethodState] = deriveCodec
   implicit val failureHandlerStateCodec: Codec[FailureHandlerState] = deriveCodec
   implicit val completedStateCodec: Codec[CompletedState] = deriveCodec
-  implicit val switchStateEncode: Encoder[SwitchState] = Encoder.encodeString.contramap[SwitchState](s => s"${s.toString}")
+  implicit val switchStateEncode: Encoder[SwitchState] = Encoder.encodeString.contramap[SwitchState](_.toString)
   implicit val switchStateDecode: Decoder[SwitchState] = deriveDecoder
   implicit val paymentMethodsSwitchCodec: Codec[PaymentMethodsSwitch] = deriveCodec
   implicit val switchesCodec: Codec[Switches] = deriveCodec

--- a/app/codecs/CirceDecoders.scala
+++ b/app/codecs/CirceDecoders.scala
@@ -82,7 +82,7 @@ object CirceDecoders {
   implicit val createPaymentMethodStateCodec: Codec[CreatePaymentMethodState] = deriveCodec
   implicit val failureHandlerStateCodec: Codec[FailureHandlerState] = deriveCodec
   implicit val completedStateCodec: Codec[CompletedState] = deriveCodec
-  implicit val switchStateEncode: Encoder[SwitchState] = Encoder.encodeString.contramap[SwitchState](s => s"'${s.toString}'")
+  implicit val switchStateEncode: Encoder[SwitchState] = Encoder.encodeString.contramap[SwitchState](s => s"${s.toString}")
   implicit val switchStateDecode: Decoder[SwitchState] = deriveDecoder
   implicit val paymentMethodsSwitchCodec: Codec[PaymentMethodsSwitch] = deriveCodec
   implicit val switchesCodec: Codec[Switches] = deriveCodec

--- a/app/views/ViewHelpers.scala
+++ b/app/views/ViewHelpers.scala
@@ -12,5 +12,4 @@ object ViewHelpers {
     switches
       .asJson
       .pretty(Printer.spaces2.copy(dropNullValues = true))
-      .replaceAll("\"", "")
 }


### PR DESCRIPTION
## Why are you doing this?

To enforce encoding rules across different formats is a dangerous game, as I learned recently 😒  

For instance, the hocon syntax (a superset of json) in the configuration files is very lenient when it comes to strings: they may contain spaces and key may contain dashes. So 
```
  my-key: look at me I contain spaces and I don't even care
```
is valid, but not in JSON. Circe pretty-printers normally take care of that:
```
  "my-key": "look at me I contain spaces and I don't even care"
```
but all the double-quotes are stripped off in the Twirl template. This PR removes that.

Now:
![screen shot 2018-08-09 at 17 11 45](https://user-images.githubusercontent.com/629976/43911429-55d0b718-9bf7-11e8-95c6-51862ecddfd8.png)
