### PR TITLE
Temporarily turn off recurring guest checkout test

### DIFF
--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -80,7 +80,7 @@ export const tests: Tests = {
         size: 1,
       },
     },
-    isActive: true,
+    isActive: false,
     independent: true,
     seed: 4,
   },


### PR DESCRIPTION
We want to restart the test in the near future with some improvements, so for now we are going to turn it off
