### PR TITLE
Fix IE Integer Bug

### DIFF
--- a/assets/helpers/flashSale.js
+++ b/assets/helpers/flashSale.js
@@ -52,14 +52,14 @@ const promoCodes = {
   },
 };
 
-function getPromoCode(product: SubscriptionProduct, defaultCode: string) {
+function getPromoCode(product: SubscriptionProduct, defaultCode: string): string {
   if (inOfferPeriod(product)) {
     return promoCodes[product].promoCode;
   }
   return defaultCode;
 }
 
-function getDiscountedPrice(product: SubscriptionProduct, defaultPrice: number) {
+function getDiscountedPrice(product: SubscriptionProduct, defaultPrice: number): number {
   if (inOfferPeriod(product)) {
     return promoCodes[product].price;
   }

--- a/assets/helpers/subscriptions.js
+++ b/assets/helpers/subscriptions.js
@@ -3,6 +3,8 @@
 // ----- Imports ----- //
 
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { isInteger } from 'helpers/utilities';
+
 import { trackComponentEvents } from './tracking/ophanComponentEventTracking';
 import { gaEvent } from './tracking/googleTagManager';
 import { currencies, detect } from './internationalisation/currency';
@@ -16,7 +18,7 @@ export type SubscriptionProduct =
   'DailyEdition' |
   'GuardianWeekly' |
   'Paper' |
-  'PaperAndDigital'
+  'PaperAndDigital';
 
 // ----- Config ----- //
 
@@ -65,13 +67,13 @@ const defaultBillingPeriods: {
   DailyEdition: 'month',
 };
 
-function getProductPrice(product: SubscriptionProduct, countryGroupId: CountryGroupId) {
+function getProductPrice(product: SubscriptionProduct, countryGroupId: CountryGroupId): string {
   const price = subscriptionPrices[product][countryGroupId];
   const discounted = getDiscountedPrice(product, price);
-  return Number.isInteger(discounted) ? discounted : discounted.toFixed(2);
+  return isInteger(discounted) ? discounted.toString() : discounted.toFixed(2);
 }
 
-function displayPrice(product: SubscriptionProduct, countryGroupId: CountryGroupId) {
+function displayPrice(product: SubscriptionProduct, countryGroupId: CountryGroupId): string {
   const currency = currencies[detect(countryGroupId)].glyph;
   const price = getProductPrice(product, countryGroupId);
   return `${currency}${price}/${defaultBillingPeriods[product]}`;

--- a/assets/helpers/utilities.js
+++ b/assets/helpers/utilities.js
@@ -18,6 +18,11 @@ function roundDp(num: number, dps: number = 2) {
   return Math.round(num * (10 ** dps)) / (10 ** dps);
 }
 
+// Cross-browser compatible integer check.
+function isInteger(n: number): boolean {
+  return n % 1 === 0;
+}
+
 // Generates the "class class-modifier" string for HTML elements.
 // Does not add null, undefined and empty string.
 function classNameWithModifiers(className: string, modifiers: Array<?string>): string {
@@ -94,6 +99,7 @@ export {
   ascending,
   descending,
   roundDp,
+  isInteger,
   classNameWithModifiers,
   clickSubstituteKeyPressHandler,
   parseBoolean,


### PR DESCRIPTION
## Why are you doing this?

A usage of `Number.isInteger` was introduced in #835. This isn't supported in IE, so this PR adds a cross-browser compatible version.

[**Trello Card**](https://trello.com/c/yWCYO1ER/1849-fix-internet-explorer-isinteger-bug)

cc @JustinPinner 

## Changes

- Added an `isInteger` utility function.
- Applied some type annotations.
