### PR TITLE
Use epoch milliseconds for contributions timestamps

### DIFF
--- a/app/cookies/RecurringContributionCookie.scala
+++ b/app/cookies/RecurringContributionCookie.scala
@@ -7,7 +7,7 @@ import play.api.mvc.Cookie
 
 object RecurringContributionCookie {
 
-  val currentTime = Instant.ofEpochSecond(System.currentTimeMillis / 1000).toString
+  val currentTime = Instant.ofEpochSecond(System.currentTimeMillis / 1000).toEpochMilli.toString
 
   def create(domain: String, billingPeriod: BillingPeriod): Cookie = Cookie(
     name = s"gu.contributions.recurring.contrib-timestamp.$billingPeriod",

--- a/assets/pages/oneoff-contributions/oneoffContributions.jsx
+++ b/assets/pages/oneoff-contributions/oneoffContributions.jsx
@@ -30,7 +30,7 @@ const store = pageInit(reducer(getAmount('ONE_OFF', countryGroup)), true);
 
 const ONE_OFF_CONTRIBUTION_COOKIE = 'gu.contributions.contrib-timestamp';
 
-const currentTime = new Date().toString();
+const currentTimeInEpochMilliseconds: number = Date.now();
 
 user.init(store.dispatch);
 
@@ -54,7 +54,7 @@ const router = (
           render={() => {
             setCookie(
               ONE_OFF_CONTRIBUTION_COOKIE,
-              currentTime,
+              currentTimeInEpochMilliseconds.toString(),
             );
             return (<ContributionsThankYouPage contributionType="ONE_OFF" directDebit={null} />);
           }


### PR DESCRIPTION
Whitespace and colons are not allowed in cookie values (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#Directives). These are causing cookie parsing in Identity to break, preventing Google sign-in for anyone who has a contributions timestamp cookie.

This has also highlighted the fact that we were actually using two different time formats in the recurring and one-off timestamp cookies (ISO 8601 and the JS-specific format like "Tue Aug 19 1975 23:15:30 GMT+0200 (CEST)", respectively)

So I've set them both to Unix epoch milliseconds