### PR TITLE
Routes for international subscribe pages

### DIFF
--- a/app/controllers/Subscriptions.scala
+++ b/app/controllers/Subscriptions.scala
@@ -27,7 +27,9 @@ class Subscriptions(
   def geoRedirect: Action[AnyContent] = GeoTargetedCachedAction() { implicit request =>
     val redirectUrl = request.fastlyCountry match {
       case Some(UK) => "/uk/subscribe"
-      case _ => "https://subscribe.theguardian.com"
+      case Some(US) => "/us/subscribe"
+      case Some(Australia) => "/au/subscribe"
+      case _ => "/int/subscribe"
     }
 
     Redirect(redirectUrl, request.queryString, status = FOUND)

--- a/assets/components/internationalSubscriptions/internationalSubscriptions.jsx
+++ b/assets/components/internationalSubscriptions/internationalSubscriptions.jsx
@@ -24,6 +24,7 @@ import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 type ClickEvent = () => void;
 
 type PropTypes = {
+  sectionId: string,
   countryGroupId: CountryGroupId,
   referrerAcquisitionData: ReferrerAcquisitionData,
   headingSize: HeadingSize,
@@ -54,33 +55,35 @@ export default function InternationalSubscriptions(props: PropTypes) {
   );
 
   return (
-    <div className="component-international-subscriptions">
-      <PageSection
-        heading="Subscribe"
-        modifierClass="international-subscriptions"
-      >
-        <PremiumTier
-          countryGroupId={props.countryGroupId}
-          iOSUrl={addQueryParamsToURL(iOSAppUrl, { referrer: appReferrer })}
-          androidUrl={addQueryParamsToURL(androidAppUrl, { referrer: appReferrer })}
-          headingSize={props.headingSize}
-          iOSOnClick={props.clickEvents.iOSApp}
-          androidOnClick={props.clickEvents.androidApp}
-        />
-        <DigitalBundle
-          countryGroupId={props.countryGroupId}
-          url={subsLinks.DigitalPack}
-          headingSize={props.headingSize}
-          onClick={props.clickEvents.digiPack}
-        />
-        <WeeklyBundle
-          countryGroupId={props.countryGroupId}
-          url={subsLinks.GuardianWeekly}
-          headingSize={props.headingSize}
-          onClick={props.clickEvents.digiPack}
-        />
-      </PageSection>
-    </div>
+    <section id={props.sectionId}>
+      <div className="component-international-subscriptions">
+        <PageSection
+          heading="Subscribe"
+          modifierClass="international-subscriptions"
+        >
+          <PremiumTier
+            countryGroupId={props.countryGroupId}
+            iOSUrl={addQueryParamsToURL(iOSAppUrl, { referrer: appReferrer })}
+            androidUrl={addQueryParamsToURL(androidAppUrl, { referrer: appReferrer })}
+            headingSize={props.headingSize}
+            iOSOnClick={props.clickEvents.iOSApp}
+            androidOnClick={props.clickEvents.androidApp}
+          />
+          <DigitalBundle
+            countryGroupId={props.countryGroupId}
+            url={subsLinks.DigitalPack}
+            headingSize={props.headingSize}
+            onClick={props.clickEvents.digiPack}
+          />
+          <WeeklyBundle
+            countryGroupId={props.countryGroupId}
+            url={subsLinks.GuardianWeekly}
+            headingSize={props.headingSize}
+            onClick={props.clickEvents.digiPack}
+          />
+        </PageSection>
+      </div>
+    </section>
   );
 
 }

--- a/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
+++ b/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
@@ -46,6 +46,7 @@ function getSubscriptionsForCountry() {
   const testName = 'international_subs_landing_pages';
   return (
     <InternationalSubscriptions
+      sectionId={supporterSectionId}
       countryGroupId={countryGroupId}
       headingSize={3}
       clickEvents={{


### PR DESCRIPTION
## Why are you doing this?

* Missed the `/subscribe` route in https://github.com/guardian/support-frontend/pull/835
* Fix the 'See supporter options' button on international pages
