### PR TITLE
Payment Flow: update text input component

### DIFF
--- a/assets/components/textInput/textInput.jsx
+++ b/assets/components/textInput/textInput.jsx
@@ -9,14 +9,31 @@ import { classNameWithModifiers } from 'helpers/utilities';
 
 // ----- Types ----- //
 
+type AutoComplete = 'on' | 'off';
+
+type AutoCapitalize = 'off'
+                    | 'none'
+                    | 'on'
+                    | 'sentences'
+                    | 'words';
+
+type InputType = 'text'
+               | 'email'
+               | 'password'
+               | 'url'
+               | 'tel';
+
 type PropTypes = {
   id: string,
+  type: InputType,
   labelText: string,
   onChange: (name: string) => void,
   value: string,
   placeholder: string,
   required: boolean,
-  modifierClasses: Array<?string>,
+  autocomplete: AutoComplete,
+  autocapitalize?: AutoCapitalize,
+  modifierClasses?: Array<?string>,
   onBlur: () => void,
 };
 
@@ -39,6 +56,8 @@ export default function TextInput(props: PropTypes) {
         value={props.value}
         placeholder={props.placeholder}
         required={props.required}
+        autocomplete={props.autocomplete}
+        autocapitalize={props.autocapitalize}
       />
     </div>
   );
@@ -49,6 +68,7 @@ export default function TextInput(props: PropTypes) {
 // ----- Proptypes ----- //
 
 TextInput.defaultProps = {
+  type: 'text',
   placeholder: '',
   required: false,
   modifierClasses: [],


### PR DESCRIPTION
## Why are you doing this?

Adds a few necessary attributes to the `input` element:

- `autocomplete`: this is on by default but may be turned off for things like amounts, card numbers, etc.
- `autocapitalize`: neat UX trick in iOS to speed up typing your name (no need to hit the ⇪ key all the time)
- `pattern`: this is necessary to add more specific constraints to the shape of the input

Also relax the assumption on the `type` attribute so that we can use this component for other input types.

