### PR TITLE
Conversion tracking fix

### DIFF
--- a/assets/helpers/tracking/conversions.js
+++ b/assets/helpers/tracking/conversions.js
@@ -13,6 +13,6 @@ export default function trackConversion(
   successfulConversion(participations);
   // Send an Ophan pageview. Because this function is used to track page views
   // from client side routed thank you pages, the referrer will always be the current location
-  pageView(getAbsoluteURL(currentRoute), document.location);
+  pageView(getAbsoluteURL(currentRoute), document.location.href);
 }
 

--- a/assets/helpers/tracking/conversions.js
+++ b/assets/helpers/tracking/conversions.js
@@ -1,0 +1,18 @@
+// @flow
+
+import { getAbsoluteURL } from '../url';
+import { pageView } from './ophanComponentEventTracking';
+import { successfulConversion } from './googleTagManager';
+import type { Participations } from '../abTests/abtest';
+
+export default function trackConversion(
+  participations: Participations,
+  currentRoute: string,
+) {
+  // Fire GTM conversion events
+  successfulConversion(participations);
+  // Send an Ophan pageview. Because this function is used to track page views
+  // from client side routed thank you pages, the referrer will always be the current location
+  pageView(getAbsoluteURL(currentRoute), document.location);
+}
+

--- a/assets/helpers/tracking/ophanComponentEventTracking.js
+++ b/assets/helpers/tracking/ophanComponentEventTracking.js
@@ -2,7 +2,6 @@
 // ----- Imports ----- //
 
 import * as ophan from 'ophan';
-import { getAbsoluteURL } from '../url';
 
 // ----- Types ----- //
 

--- a/assets/helpers/tracking/ophanComponentEventTracking.js
+++ b/assets/helpers/tracking/ophanComponentEventTracking.js
@@ -74,11 +74,11 @@ const trackComponentEvents = (componentEvent: OphanComponentEvent) => {
   });
 };
 
-function pageView(currentRoute: string, referringRoute: string) {
+function pageView(url: string, referrer: string) {
   try {
     ophan.sendInitialEvent(
-      getAbsoluteURL(currentRoute),
-      getAbsoluteURL(referringRoute),
+      url,
+      referrer,
     );
   } catch (e) {
     console.log(`Error in Ophan tracking: ${e}`);

--- a/assets/pages/oneoff-contributions/helpers/ajax.js
+++ b/assets/pages/oneoff-contributions/helpers/ajax.js
@@ -5,13 +5,12 @@
 import { addQueryParamsToURL } from 'helpers/url';
 import { derivePaymentApiAcquisitionData } from 'helpers/tracking/acquisitions';
 
-import { successfulConversion } from 'helpers/tracking/googleTagManager';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import type { Participations } from 'helpers/abTests/abtest';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import type { PaymentAPIAcquisitionData } from 'helpers/tracking/acquisitions';
 import * as cookie from 'helpers/cookie';
-import { pageView } from 'helpers/tracking/ophanComponentEventTracking';
+import trackConversion from 'helpers/tracking/conversions';
 import { routes } from 'helpers/routes';
 import { logException } from 'helpers/logger';
 
@@ -87,8 +86,7 @@ function requestData(
 function postToEndpoint(request: Object, dispatch: Function, abParticipations: Participations): Promise<*> {
   return fetch(stripeOneOffContributionEndpoint(cookie.get('_test_username')), request).then((response) => {
     if (response.ok) {
-      successfulConversion(abParticipations);
-      pageView(routes.oneOffContribThankyou, routes.oneOffContribCheckout);
+      trackConversion(abParticipations, routes.oneOffContribThankyou);
       dispatch(checkoutSuccess());
     }
     return response.json();

--- a/assets/pages/regular-contributions/helpers/ajax.js
+++ b/assets/pages/regular-contributions/helpers/ajax.js
@@ -14,13 +14,11 @@ import type { User as UserState } from 'helpers/user/userReducer';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import type { Participations } from 'helpers/abTests/abtest';
 import type { RegularCheckoutCallback } from 'helpers/checkouts';
-import { successfulConversion } from 'helpers/tracking/googleTagManager';
+import trackConversion from 'helpers/tracking/conversions';
 import { billingPeriodFromContrib } from 'helpers/contributions';
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import type { PaymentMethod } from 'helpers/checkouts';
-import { pageView } from 'helpers/tracking/ophanComponentEventTracking';
 import { checkoutPending, checkoutSuccess, checkoutError, creatingContributor } from '../regularContributionsActions';
-
 
 // ----- Setup ----- //
 
@@ -201,8 +199,7 @@ function statusPoll(
 ): ?Promise<void> {
 
   if (pollCount >= MAX_POLLS) {
-    successfulConversion(participations);
-    pageView(routes.recurringContribThankyou, routes.recurringContribCheckout);
+    trackConversion(participations, routes.recurringContribPending);
     dispatch(checkoutPending(paymentMethod));
     return undefined;
   }
@@ -258,7 +255,7 @@ function handleStatus(
           dispatch(checkoutError(status.message));
           break;
         case 'success':
-          successfulConversion(participations);
+          trackConversion(participations, routes.recurringContribThankyou);
           dispatch(checkoutSuccess(paymentMethod));
           break;
         default: // pending


### PR DESCRIPTION
## Why are you doing this?

Previously we weren't tracking an Ophan pageview on the recurring `thankyou` page, only on the `pending` page. This PR moves the tracking for both into a single function to reduce the chance of this happening anywhere else