### PR TITLE
Fix the tracking for weekly on international subs pages

### DIFF
--- a/assets/components/internationalSubscriptions/internationalSubscriptions.jsx
+++ b/assets/components/internationalSubscriptions/internationalSubscriptions.jsx
@@ -79,7 +79,7 @@ export default function InternationalSubscriptions(props: PropTypes) {
             countryGroupId={props.countryGroupId}
             url={subsLinks.GuardianWeekly}
             headingSize={props.headingSize}
-            onClick={props.clickEvents.digiPack}
+            onClick={props.clickEvents.weekly}
           />
         </PageSection>
       </div>


### PR DESCRIPTION
## Why are you doing this?

To fix the tracking of the weekly CTA on the international subs pages