### PR TITLE
Payment Flow: Remove participation test

### DIFF
--- a/app/views/newMain.scala.html
+++ b/app/views/newMain.scala.html
@@ -25,11 +25,7 @@
 </head>
 <body>
 
-	@if(switches.experiments.get("newPaymentFlow").exists(_.isParticipating)) {
-
 		@newPaymentFlow()
 	
-	}
-  
 </body>
 </html>


### PR DESCRIPTION
## Why are you doing this?

So that it's easier for people outside the department to see the results of this ongoing redesign.

I'm not cleaning up the config as it will come in handy when we're ready to launch the 50% test.