### PR TITLE
Refactor Page Helper

### DIFF
--- a/assets/helpers/page/page.js
+++ b/assets/helpers/page/page.js
@@ -107,19 +107,29 @@ function createCommonReducer(initialState: CommonState): (state?: CommonState, a
     state?: CommonState = initialState,
     action: Action,
   ): CommonState {
-    const { internationalisation } = state;
+
     switch (action.type) {
+
       case 'SET_COUNTRY':
-        internationalisation.countryId = action.country;
-        return Object.assign({}, state, { internationalisation });
+        return {
+          ...state,
+          internationalisation: { ...state.internationalisation, countryId: action.country },
+        };
+
       case 'SET_COUNTRY_GROUP':
-        internationalisation.countryGroupId = action.countryGroup;
-        internationalisation.currencyId = detectCurrency(action.countryGroup);
-        internationalisation.countryId = detectCountry(action.countryGroup);
-        return Object.assign({}, state, { internationalisation });
+        return {
+          ...state,
+          internationalisation: {
+            countryGroupId: action.countryGroup,
+            currencyId: detectCurrency(action.countryGroup),
+            countryId: detectCountry(action.countryGroup),
+          },
+        };
+
       default:
         return state;
     }
+
   };
 
 }

--- a/assets/helpers/page/page.js
+++ b/assets/helpers/page/page.js
@@ -53,12 +53,6 @@ export type CommonState = {
   internationalisation: Internationalisation,
 };
 
-export type PreloadedState = {
-  campaign?: $PropertyType<CommonState, 'campaign'>,
-  referrerAcquisitionData?: $PropertyType<CommonState, 'referrerAcquisitionData'>,
-  abParticipations?: $PropertyType<CommonState, 'abParticipations'>,
-};
-
 
 // ----- Functions ----- //
 
@@ -81,7 +75,6 @@ function analyticsInitialisation(participations: Participations): void {
 // Creates the initial state for the common reducer.
 function buildInitialState(
   abParticipations: Participations,
-  preloadedState: ?PreloadedState = {},
   countryGroupId: CountryGroupId,
   countryId: IsoCountry,
   currencyId: IsoCurrency,
@@ -96,14 +89,14 @@ function buildInitialState(
     currencyId,
   };
 
-  return Object.assign({}, {
+  return {
     campaign: acquisition ? getCampaign(acquisition) : null,
     referrerAcquisitionData: acquisition,
     otherQueryParams,
     internationalisation,
     abParticipations,
     switches,
-  }, preloadedState);
+  };
 
 }
 
@@ -160,7 +153,6 @@ function storeEnhancer<S, A>(thunk: boolean): StoreEnhancer<S, A> | typeof undef
 function init<S, A>(
   pageReducer: Reducer<S, A> | null = null,
   thunk?: boolean = false,
-  preloadedState: ?PreloadedState = null,
 ): Store<*, *, *> {
 
   const countryGroupId: CountryGroupId = detectCountryGroup();
@@ -172,7 +164,6 @@ function init<S, A>(
 
   const initialState: CommonState = buildInitialState(
     participations,
-    preloadedState,
     countryGroupId,
     countryId,
     currencyId,

--- a/assets/helpers/page/page.js
+++ b/assets/helpers/page/page.js
@@ -103,7 +103,7 @@ function buildInitialState(
 // Sets up the common reducer with its initial state.
 function createCommonReducer(initialState: CommonState): (state?: CommonState, action: Action) => CommonState {
 
-  function commonReducer(
+  return function commonReducer(
     state?: CommonState = initialState,
     action: Action,
   ): CommonState {
@@ -120,9 +120,8 @@ function createCommonReducer(initialState: CommonState): (state?: CommonState, a
       default:
         return state;
     }
-  }
+  };
 
-  return commonReducer;
 }
 
 // For pages that don't need Redux.

--- a/assets/helpers/page/page.js
+++ b/assets/helpers/page/page.js
@@ -116,16 +116,6 @@ function createCommonReducer(initialState: CommonState): (state?: CommonState, a
           internationalisation: { ...state.internationalisation, countryId: action.country },
         };
 
-      case 'SET_COUNTRY_GROUP':
-        return {
-          ...state,
-          internationalisation: {
-            countryGroupId: action.countryGroup,
-            currencyId: detectCurrency(action.countryGroup),
-            countryId: detectCountry(action.countryGroup),
-          },
-        };
-
       default:
         return state;
     }

--- a/assets/helpers/page/pageActions.js
+++ b/assets/helpers/page/pageActions.js
@@ -3,14 +3,13 @@
 // ----- Imports ----- //
 
 import type { IsoCountry } from 'helpers/internationalisation/country';
-import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 
 // ----- Types ----- //
 
 export type Action =
-  | { type: 'SET_COUNTRY', country: IsoCountry }
-  | { type: 'SET_COUNTRY_GROUP', countryGroup: CountryGroupId };
+  | { type: 'SET_COUNTRY', country: IsoCountry };
+
 
 // ----- Action Creators ----- //
 
@@ -18,13 +17,7 @@ function setCountry(country: IsoCountry): Action {
   return { type: 'SET_COUNTRY', country };
 }
 
-function setCountryGroup(countryGroup: CountryGroupId): Action {
-  return { type: 'SET_COUNTRY_GROUP', countryGroup };
-}
 
 // ----- Exports ----- //
 
-export {
-  setCountry,
-  setCountryGroup,
-};
+export { setCountry };


### PR DESCRIPTION
## Why are you doing this?

Prep for some other work I'm doing. This tidies up the page helper.

cc @JustinPinner 

## Changes

- Removed `PreloadedState` because it's unused.
- Removed `SET_COUNTRY_GROUP` because it's unused (it can be re-introduced if we need it).
- Switched to object spread in `commonReducer`.
