### PR TITLE
Fix preload links

### DIFF
--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -39,12 +39,12 @@
 	<link rel="apple-touch-icon" sizes="72x72" href="@assets("images/favicons/72x72.png")">
 	<link rel="apple-touch-icon-precomposed" href="@assets("images/favicons/57x57.png")">
 
-	<link rel="preload" href="@assets("fonts/GHGuardianHeadline-Bold.woff2")" as="font">
-	<link rel="preload" href="@assets("fonts/GHGuardianHeadline-BoldItalic.woff2")" as="font">
-	<link rel="preload" href="@assets("fonts/GHGuardianHeadline-Light.woff2")" as="font">
-	<link rel="preload" href="@assets("fonts/GHGuardianHeadline-LightItalic.woff2")" as="font">
-	<link rel="preload" href="@assets("fonts/GHGuardianHeadline-Regular.woff2")" as="font">
-	<link rel="preload" href="@assets("fonts/GHGuardianHeadline-Semibold.woff2")" as="font">
+	<link rel="preload" href="@assets("fonts/GHGuardianHeadline-Bold.woff2")" as="font" type="font/woff2" crossorigin>
+	<link rel="preload" href="@assets("fonts/GHGuardianHeadline-BoldItalic.woff2")" as="font" type="font/woff2" crossorigin>
+	<link rel="preload" href="@assets("fonts/GHGuardianHeadline-Light.woff2")" as="font" type="font/woff2" crossorigin>
+	<link rel="preload" href="@assets("fonts/GHGuardianHeadline-LightItalic.woff2")" as="font" type="font/woff2" crossorigin>
+	<link rel="preload" href="@assets("fonts/GHGuardianHeadline-Regular.woff2")" as="font" type="font/woff2" crossorigin>
+	<link rel="preload" href="@assets("fonts/GHGuardianHeadline-Semibold.woff2")" as="font" type="font/woff2" crossorigin>
 
 	<script type="application/ld+json">
 		{


### PR DESCRIPTION
I noticed our font preload links are giving some errors:

<img width="1195" alt="picture 270" src="https://user-images.githubusercontent.com/5122968/44261841-ca2e2b80-a210-11e8-863b-c8823bb3ab63.png">

And that the browser seems to be fetching the fonts twice:

<img width="1188" alt="picture 269" src="https://user-images.githubusercontent.com/5122968/44261842-ca2e2b80-a210-11e8-99dd-69310b5ae6d1.png">

The issue is that fonts are loaded using anonymous mode CORS, even when they're on the same domain: https://drafts.csswg.org/css-fonts/#font-fetching-requirements

Adding a `crossorigin` attribute fixes the issue. I also added `type="font/woff2"` for good measure though I'm not sure if it makes any difference.

Now fonts are just loaded once:
<img width="1169" alt="picture 271" src="https://user-images.githubusercontent.com/5122968/44262560-5b9e9d00-a213-11e8-8bf7-d93cbf12d09c.png">
