### PR TITLE
Changes for the US subscribe landing page

### DIFF
--- a/assets/components/digitalSubscriptions/digitalSubscriptions.jsx
+++ b/assets/components/digitalSubscriptions/digitalSubscriptions.jsx
@@ -142,7 +142,7 @@ function PremiumTier(props: {
 }
 
 PremiumTier.defaultProps = {
-  subheading: undefined,
+  subheading: null,
 };
 
 function DailyEdition(props: {
@@ -231,7 +231,7 @@ function DigitalBundle(props: {
 }
 
 DigitalBundle.defaultProps = {
-  subheading: undefined,
+  subheading: null,
 };
 
 export {

--- a/assets/components/digitalSubscriptions/digitalSubscriptions.jsx
+++ b/assets/components/digitalSubscriptions/digitalSubscriptions.jsx
@@ -112,7 +112,7 @@ function PremiumTier(props: {
       headingSize={props.headingSize}
       benefits={[
         {
-          text: 'The ad free, premium app, designed especially for your smartphone and tablet',
+          text: 'The ad-free, premium app, designed especially for your smartphone and tablet',
         },
       ]}
       gridImage={{

--- a/assets/components/digitalSubscriptions/digitalSubscriptions.jsx
+++ b/assets/components/digitalSubscriptions/digitalSubscriptions.jsx
@@ -99,6 +99,7 @@ function PremiumTier(props: {
     iOSUrl: string,
     androidUrl: string,
     headingSize: HeadingSize,
+    subheading: ?string,
     iOSOnClick: ClickEvent,
     androidOnClick: ClickEvent,
 }) {
@@ -107,7 +108,7 @@ function PremiumTier(props: {
     <SubscriptionBundle
       modifierClass="premium-tier"
       heading="Premium App"
-      subheading={displayPrice('PremiumTier', props.countryGroupId)}
+      subheading={props.subheading || displayPrice('PremiumTier', props.countryGroupId)}
       headingSize={props.headingSize}
       benefits={[
         {
@@ -139,6 +140,10 @@ function PremiumTier(props: {
   );
 
 }
+
+PremiumTier.defaultProps = {
+  subheading: undefined,
+};
 
 function DailyEdition(props: {
   url: string,
@@ -180,6 +185,7 @@ function DigitalBundle(props: {
   countryGroupId: CountryGroupId,
   url: string,
   headingSize: HeadingSize,
+  subheading: ?string,
   onClick: ClickEvent | null,
 }) {
 
@@ -198,7 +204,7 @@ function DigitalBundle(props: {
     <SubscriptionBundle
       modifierClass="digital"
       heading="Digital Pack"
-      subheading={displayPrice('DigitalPack', props.countryGroupId)}
+      subheading={props.subheading || displayPrice('DigitalPack', props.countryGroupId)}
       headingSize={props.headingSize}
       benefits={[
         {
@@ -223,6 +229,10 @@ function DigitalBundle(props: {
   );
 
 }
+
+DigitalBundle.defaultProps = {
+  subheading: undefined,
+};
 
 export {
   DigitalBundle,

--- a/assets/components/internationalSubscriptions/internationalSubscriptions.jsx
+++ b/assets/components/internationalSubscriptions/internationalSubscriptions.jsx
@@ -19,6 +19,7 @@ import { WeeklyBundle } from 'components/paperSubscriptions/paperSubscriptions';
 import { type HeadingSize } from 'components/heading/heading';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { countryGroups } from 'helpers/internationalisation/countryGroup';
+import { classNameWithModifiers } from 'helpers/utilities';
 
 // ----- Types ----- //
 
@@ -57,7 +58,11 @@ export default function InternationalSubscriptions(props: PropTypes) {
 
   return (
     <section id={props.sectionId}>
-      <div className={`component-international-subscriptions component-international-subscriptions-${countryGroups[props.countryGroupId].supportInternationalisationId}`}>
+      <div className={classNameWithModifiers(
+        'component-international-subscriptions',
+        [countryGroups[props.countryGroupId].supportInternationalisationId],
+      )}
+      >
         <PageSection
           heading="Subscribe"
           modifierClass="international-subscriptions"

--- a/assets/components/internationalSubscriptions/internationalSubscriptions.jsx
+++ b/assets/components/internationalSubscriptions/internationalSubscriptions.jsx
@@ -18,6 +18,7 @@ import { PremiumTier, DigitalBundle } from 'components/digitalSubscriptions/digi
 import { WeeklyBundle } from 'components/paperSubscriptions/paperSubscriptions';
 import { type HeadingSize } from 'components/heading/heading';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { countryGroups } from 'helpers/internationalisation/countryGroup';
 
 // ----- Types ----- //
 
@@ -56,7 +57,7 @@ export default function InternationalSubscriptions(props: PropTypes) {
 
   return (
     <section id={props.sectionId}>
-      <div className="component-international-subscriptions">
+      <div className={`component-international-subscriptions component-international-subscriptions-${countryGroups[props.countryGroupId].supportInternationalisationId}`}>
         <PageSection
           heading="Subscribe"
           modifierClass="international-subscriptions"
@@ -66,6 +67,7 @@ export default function InternationalSubscriptions(props: PropTypes) {
             iOSUrl={addQueryParamsToURL(iOSAppUrl, { referrer: appReferrer })}
             androidUrl={addQueryParamsToURL(androidAppUrl, { referrer: appReferrer })}
             headingSize={props.headingSize}
+            subheading="7-day free trial"
             iOSOnClick={props.clickEvents.iOSApp}
             androidOnClick={props.clickEvents.androidApp}
           />
@@ -73,12 +75,14 @@ export default function InternationalSubscriptions(props: PropTypes) {
             countryGroupId={props.countryGroupId}
             url={subsLinks.DigitalPack}
             headingSize={props.headingSize}
+            subheading="14-day free trial"
             onClick={props.clickEvents.digiPack}
           />
           <WeeklyBundle
             countryGroupId={props.countryGroupId}
             url={subsLinks.GuardianWeekly}
             headingSize={props.headingSize}
+            subheading="&nbsp;"
             onClick={props.clickEvents.weekly}
           />
         </PageSection>

--- a/assets/components/internationalSubscriptions/internationalSubscriptions.scss
+++ b/assets/components/internationalSubscriptions/internationalSubscriptions.scss
@@ -205,3 +205,8 @@
     }
   }
 }
+
+// As a test we are tweaking the layout of the US product bundles
+.component-international-subscriptions-us .component-double-heading__subheading {
+  font-size: 24px;
+}

--- a/assets/components/internationalSubscriptions/internationalSubscriptions.scss
+++ b/assets/components/internationalSubscriptions/internationalSubscriptions.scss
@@ -207,6 +207,6 @@
 }
 
 // As a test we are tweaking the layout of the US product bundles
-.component-international-subscriptions-us .component-double-heading__subheading {
+.component-international-subscriptions--us .component-double-heading__subheading {
   font-size: 24px;
 }

--- a/assets/components/paperSubscriptions/paperSubscriptions.jsx
+++ b/assets/components/paperSubscriptions/paperSubscriptions.jsx
@@ -189,7 +189,7 @@ function WeeklyBundle(props: {
 }
 
 WeeklyBundle.defaultProps = {
-  subheading: undefined,
+  subheading: null,
 };
 
 export {

--- a/assets/components/paperSubscriptions/paperSubscriptions.jsx
+++ b/assets/components/paperSubscriptions/paperSubscriptions.jsx
@@ -155,6 +155,7 @@ function WeeklyBundle(props: {
   countryGroupId: CountryGroupId,
   url: string,
   headingSize: HeadingSize,
+  subheading: ?string,
   onClick: ClickEvent,
 }) {
 
@@ -162,7 +163,7 @@ function WeeklyBundle(props: {
     <SubscriptionBundle
       modifierClass="weekly"
       heading="Guardian Weekly"
-      subheading={displayPrice('GuardianWeekly', props.countryGroupId)}
+      subheading={props.subheading || displayPrice('GuardianWeekly', props.countryGroupId)}
       headingSize={props.headingSize}
       benefits={[
         {
@@ -185,8 +186,11 @@ function WeeklyBundle(props: {
       ]}
     />
   );
-
 }
+
+WeeklyBundle.defaultProps = {
+  subheading: undefined,
+};
 
 export {
   PaperBundle,

--- a/assets/components/paperSubscriptions/paperSubscriptions.jsx
+++ b/assets/components/paperSubscriptions/paperSubscriptions.jsx
@@ -162,7 +162,7 @@ function WeeklyBundle(props: {
   return (
     <SubscriptionBundle
       modifierClass="weekly"
-      heading="Guardian Weekly"
+      heading="Guardian&nbsp;Weekly"
       subheading={props.subheading || displayPrice('GuardianWeekly', props.countryGroupId)}
       headingSize={props.headingSize}
       benefits={[

--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -31,9 +31,9 @@ export type SubsUrls = {
 
 const subsUrl = 'https://subscribe.theguardian.com';
 const defaultIntCmp = 'gdnwb_copts_bundles_landing_default';
-const iOSAppUrl = 'https://itunes.apple.com/gb/app/the-guardian/id409128287?mt=8';
+const iOSAppUrl = 'https://itunes.apple.com/app/the-guardian/id409128287?mt=8';
 const androidAppUrl = 'https://play.google.com/store/apps/details?id=com.guardian';
-const dailyEditionUrl = 'https://itunes.apple.com/gb/app/guardian-observer-daily-edition/id452707806?mt=8';
+const dailyEditionUrl = 'https://itunes.apple.com/app/guardian-observer-daily-edition/id452707806?mt=8';
 
 const memUrls: {
   [MemProduct]: string,

--- a/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
+++ b/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
@@ -14,7 +14,6 @@ import ReadyToSupport from 'components/readyToSupport/readyToSupport';
 import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
 
 // React components connected to redux store
-import PatronsEventsContainer from 'components/patronsEvents/patronsEventsContainer';
 
 import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
@@ -76,7 +75,6 @@ const content = (
         ctaUrl={`#${supporterSectionId}`}
         headingSize={2}
       />
-      <PatronsEventsContainer />
     </Page>
   </Provider>
 );


### PR DESCRIPTION
## Why are you doing this?
The new US landing page has been doing very badly compared to the control so we've decided to make some changes and retest.

[**Trello Card**](https://trello.com/c/ZrJn8ZH8/1859-updates-to-us-subscription-landing-page)

## Changes

* Remove prices
* Add free trial text
* Remove Patrons link
* Correct the itunes url

## Screenshots
*Original:*
![screen shot 2018-08-17 at 16 32 03](https://user-images.githubusercontent.com/181371/44274884-42a9e200-a23b-11e8-9282-6b53fe39a387.png)
*New:*
![screen shot 2018-08-17 at 16 36 27](https://user-images.githubusercontent.com/181371/44275125-d7acdb00-a23b-11e8-9318-44bc76cace1a.png)


