### PR TITLE
Stop logging PaymentRequestApi errors to Sentry

### DIFF
--- a/assets/helpers/tracking/googleTagManager.js
+++ b/assets/helpers/tracking/googleTagManager.js
@@ -112,11 +112,11 @@ function getPaymentAPIStatus(): Promise<PaymentRequestAPIStatus> {
           }
         })
         .catch((e) => {
-          logInfo(`PaymentAPI Promise rejected: ${e.message}`);
+          logInfo(`GTM error: canMakePayment check failed while checking PaymentAPI status. Promise rejected: ${e.message}`);
           resolve('PaymentApiPromiseRejected');
         });
     } catch (e) {
-      logInfo(`PaymentAPI Request error: ${e.message}`);
+      logInfo(`GTM error: Get PaymentAPI Status failed wiht an error: ${e.message}`);
       resolve('PaymentRequestAPIError');
     }
   });
@@ -177,7 +177,7 @@ function pushToDataLayer(event: EventType, participations: Participations) {
         sendData(event, participations, paymentRequestApiStatus);
       })
       .catch((e) => {
-        logInfo(`Promise rejected: ${e.message}`);
+        logInfo(`GTM Error: Get PaymentAPIStatus failed due Promise Rejected: ${e.message}`);
         sendData(event, participations, 'PromiseRejected');
       });
   } catch (e) {

--- a/assets/helpers/tracking/googleTagManager.js
+++ b/assets/helpers/tracking/googleTagManager.js
@@ -7,7 +7,6 @@ import { detect as detectCurrency } from 'helpers/internationalisation/currency'
 import { getQueryParameter } from 'helpers/url';
 import { detect as detectCountryGroup } from 'helpers/internationalisation/countryGroup';
 import { getOphanIds } from 'helpers/tracking/acquisitions';
-import { logInfo } from 'helpers/logger';
 import type { Participations } from 'helpers/abTests/abtest';
 
 
@@ -112,11 +111,9 @@ function getPaymentAPIStatus(): Promise<PaymentRequestAPIStatus> {
           }
         })
         .catch((e) => {
-          logInfo(`GTM error: canMakePayment check failed while checking PaymentAPI status. Promise rejected: ${e.message}`);
           resolve('PaymentApiPromiseRejected');
         });
     } catch (e) {
-      logInfo(`GTM error: Get PaymentAPI Status failed wiht an error: ${e.message}`);
       resolve('PaymentRequestAPIError');
     }
   });
@@ -177,7 +174,6 @@ function pushToDataLayer(event: EventType, participations: Participations) {
         sendData(event, participations, paymentRequestApiStatus);
       })
       .catch((e) => {
-        logInfo(`GTM Error: Get PaymentAPIStatus failed due Promise Rejected: ${e.message}`);
         sendData(event, participations, 'PromiseRejected');
       });
   } catch (e) {

--- a/assets/helpers/tracking/googleTagManager.js
+++ b/assets/helpers/tracking/googleTagManager.js
@@ -110,7 +110,7 @@ function getPaymentAPIStatus(): Promise<PaymentRequestAPIStatus> {
             resolve('AvailableNotInUse');
           }
         })
-        .catch((e) => {
+        .catch(() => {
           resolve('PaymentApiPromiseRejected');
         });
     } catch (e) {
@@ -173,7 +173,7 @@ function pushToDataLayer(event: EventType, participations: Participations) {
       .then((paymentRequestApiStatus) => {
         sendData(event, participations, paymentRequestApiStatus);
       })
-      .catch((e) => {
+      .catch(() => {
         sendData(event, participations, 'PromiseRejected');
       });
   } catch (e) {


### PR DESCRIPTION
Remove paymentRequestApi error logging.
Currently when google tag manager cannot access paymentRequestApi in a browser, it is sending a message to Sentry.
This message is being treated as an error and the wording of it makes it look like a problem with the payment api to the uninitiated.
This change will remove this logging as we won't take any action in response to it anyway.