### PR TITLE
Custom intcmp values that are valid during a flash sale

### DIFF
--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -22,11 +22,6 @@ type PromoCodes = {
   [SubscriptionProduct]: string,
 };
 
-type Intcmps = {
-  [SubscriptionProduct]: string,
-};
-
-
 export type SubsUrls = {
   [SubscriptionProduct]: string,
 };
@@ -51,12 +46,6 @@ const defaultPromos: PromoCodes = {
   DigitalPack: getPromoCode('DigitalPack', 'DXX83X'),
   Paper: getPromoCode('Paper', 'GXX83P'),
   PaperAndDigital: getPromoCode('PaperAndDigital', 'GXX83X'),
-};
-
-const defaultIntcmps: Intcmps = {
-  DigitalPack: getIntcmp('DigitalPack', defaultIntCmp),
-  Paper: getIntcmp('Paper', defaultIntCmp),
-  PaperAndDigital: getIntcmp('PaperAndDigital', defaultIntCmp),
 };
 
 const customPromos : {
@@ -124,12 +113,14 @@ function getMemLink(product: MemProduct, intCmp: ?string): string {
 
 function buildParamString(
   product: SubscriptionProduct,
-  intCmp: Intcmps,
+  intCmp: ?string,
   otherQueryParams: Array<[string, string]>,
   referrerAcquisitionData: ReferrerAcquisitionData,
 ): string {
   const params = new URLSearchParams();
-  params.append('INTCMP', intCmp[product] || defaultIntCmp);
+
+  const maybeCustomIntcmp = getIntcmp(product, intCmp, defaultIntCmp);
+  params.append('INTCMP', maybeCustomIntcmp);
   otherQueryParams.forEach(p => params.append(p[0], p[1]));
   params.append('acquisitionData', JSON.stringify(referrerAcquisitionData));
 
@@ -140,7 +131,7 @@ function buildParamString(
 function buildSubsUrls(
   countryGroupId: CountryGroupId,
   promoCodes: PromoCodes,
-  intCmp: Intcmps,
+  intCmp: ?string,
   otherQueryParams: Array<[string, string]>,
   referrerAcquisitionData: ReferrerAcquisitionData,
 ): SubsUrls {
@@ -173,13 +164,13 @@ function getSubsLinks(
     return buildSubsUrls(
       countryGroupId,
       customPromos[campaign],
-      defaultIntcmps,
+      intCmp,
       otherQueryParams,
       referrerAcquisitionData,
     );
   }
 
-  return buildSubsUrls(countryGroupId, defaultPromos, defaultIntcmps, otherQueryParams, referrerAcquisitionData);
+  return buildSubsUrls(countryGroupId, defaultPromos, intCmp, otherQueryParams, referrerAcquisitionData);
 
 }
 

--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -146,9 +146,6 @@ function buildSubsUrls(
 ): SubsUrls {
 
   const countryId = countryGroups[countryGroupId].supportInternationalisationId;
-  const params = new URLSearchParams();
-  otherQueryParams.forEach(p => params.append(p[0], p[1]));
-  params.append('acquisitionData', JSON.stringify(referrerAcquisitionData));
 
   const paper = `${subsUrl}/p/${promoCodes.Paper}?${buildParamString('Paper', intCmp, otherQueryParams, referrerAcquisitionData)}`;
   const paperDig = `${subsUrl}/p/${promoCodes.PaperAndDigital}?${buildParamString('PaperAndDigital', intCmp, otherQueryParams, referrerAcquisitionData)}`;

--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -53,7 +53,7 @@ const defaultPromos: PromoCodes = {
   PaperAndDigital: getPromoCode('PaperAndDigital', 'GXX83X'),
 };
 
-const defaultIntcmp: Intcmps = {
+const defaultIntcmps: Intcmps = {
   DigitalPack: getIntcmp('DigitalPack', defaultIntCmp),
   Paper: getIntcmp('Paper', defaultIntCmp),
   PaperAndDigital: getIntcmp('PaperAndDigital', defaultIntCmp),
@@ -176,13 +176,13 @@ function getSubsLinks(
     return buildSubsUrls(
       countryGroupId,
       customPromos[campaign],
-      defaultIntcmp,
+      defaultIntcmps,
       otherQueryParams,
       referrerAcquisitionData,
     );
   }
 
-  return buildSubsUrls(countryGroupId, defaultPromos, defaultIntcmp, otherQueryParams, referrerAcquisitionData);
+  return buildSubsUrls(countryGroupId, defaultPromos, defaultIntcmps, otherQueryParams, referrerAcquisitionData);
 
 }
 

--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -122,6 +122,20 @@ function getMemLink(product: MemProduct, intCmp: ?string): string {
 
 }
 
+function buildParamString(
+  product: SubscriptionProduct,
+  intCmp: Intcmps,
+  otherQueryParams: Array<[string, string]>,
+  referrerAcquisitionData: ReferrerAcquisitionData,
+): string {
+  const params = new URLSearchParams();
+  params.append('INTCMP', intCmp[product] || defaultIntCmp);
+  otherQueryParams.forEach(p => params.append(p[0], p[1]));
+  params.append('acquisitionData', JSON.stringify(referrerAcquisitionData));
+
+  return params.toString();
+}
+
 // Creates URLs for the subs site from promo codes and intCmp.
 function buildSubsUrls(
   countryGroupId: CountryGroupId,
@@ -138,7 +152,7 @@ function buildSubsUrls(
 
   const paper = `${subsUrl}/p/${promoCodes.Paper}?${buildParamString('Paper', intCmp, otherQueryParams, referrerAcquisitionData)}`;
   const paperDig = `${subsUrl}/p/${promoCodes.PaperAndDigital}?${buildParamString('PaperAndDigital', intCmp, otherQueryParams, referrerAcquisitionData)}`;
-  const digital = `/${countryId}/subscribe/digital?${buildParamString('Digital', intCmp, otherQueryParams, referrerAcquisitionData)}`;
+  const digital = `/${countryId}/subscribe/digital?${buildParamString('DigitalPack', intCmp, otherQueryParams, referrerAcquisitionData)}`;
   const weekly = `${subsUrl}/weekly?${buildParamString('GuardianWeekly', intCmp, otherQueryParams, referrerAcquisitionData)}`;
 
   return {
@@ -148,20 +162,6 @@ function buildSubsUrls(
     GuardianWeekly: weekly,
   };
 
-}
-
-function buildParamString(
-  product: SubscriptionProduct,
-  intCmp: Intcmps,
-  otherQueryParams: Array<[string, string]>,
-  referrerAcquisitionData: ReferrerAcquisitionData,
-  ): string {
-  const params = new URLSearchParams();
-  params.append('INTCMP', intCmp[product] || defaultIntCmp);
-  otherQueryParams.forEach(p => params.append(p[0], p[1]));
-  params.append('acquisitionData', JSON.stringify(referrerAcquisitionData));
-
-  return params.toString();
 }
 
 // Creates links to subscriptions, tailored to the user's campaign.

--- a/assets/helpers/flashSale.js
+++ b/assets/helpers/flashSale.js
@@ -65,11 +65,11 @@ function getPromoCode(product: SubscriptionProduct, defaultCode: string): string
   return defaultCode;
 }
 
-function getIntcmp(product: SubscriptionProduct, defaultIntcmp: string): string {
+function getIntcmp(product: SubscriptionProduct, intcmp: ?string, defaultIntcmp: string): string {
   if (inOfferPeriod(product)) {
-    return promoCodes[product].intcmp || defaultIntcmp;
+    return promoCodes[product].intcmp || intcmp || defaultIntcmp;
   }
-  return defaultIntcmp;
+  return intcmp || defaultIntcmp;
 }
 
 function getDiscountedPrice(product: SubscriptionProduct, defaultPrice: number): number {

--- a/assets/helpers/flashSale.js
+++ b/assets/helpers/flashSale.js
@@ -67,7 +67,7 @@ function getPromoCode(product: SubscriptionProduct, defaultCode: string): string
 
 function getIntcmp(product: SubscriptionProduct, defaultIntcmp: string): string {
   if (inOfferPeriod(product)) {
-    return promoCodes[product].intcmp;// || defaultIntcmp;
+    return promoCodes[product].intcmp || defaultIntcmp;
   }
   return defaultIntcmp;
 }

--- a/assets/helpers/flashSale.js
+++ b/assets/helpers/flashSale.js
@@ -29,26 +29,32 @@ const promoCodes = {
   DigitalPack: {
     promoCode: '',
     price: 11.99,
+    intcmp: '',
   },
   Paper: {
     promoCode: 'GFS80G',
     price: 5.18,
+    intcmp: 'gdnwb_macqn_other_subs_SubscribeLandingPagePrintOnlySupporterLandingPagePrintOnly_',
   },
   PaperAndDigital: {
     promoCode: 'GFS80I',
     price: 10.81,
+    intcmp: 'gdnwb_macqn_other_subs_SubscribeLandingPagePrint+digitalSupporterLandingPagePrint+digital_',
   },
   DailyEdition: {
     promoCode: '',
     price: 6.99,
+    intcmp: '',
   },
   GuardianWeekly: {
     promoCode: '',
     price: 30,
+    intcmp: '',
   },
   PremiumTier: {
     promoCode: '',
     price: 5.99,
+    intcmp: '',
   },
 };
 
@@ -57,6 +63,13 @@ function getPromoCode(product: SubscriptionProduct, defaultCode: string): string
     return promoCodes[product].promoCode;
   }
   return defaultCode;
+}
+
+function getIntcmp(product: SubscriptionProduct, defaultIntcmp: string): string {
+  if (inOfferPeriod(product)) {
+    return promoCodes[product].intcmp;// || defaultIntcmp;
+  }
+  return defaultIntcmp;
 }
 
 function getDiscountedPrice(product: SubscriptionProduct, defaultPrice: number): number {
@@ -112,5 +125,6 @@ export {
   getPaperBenefits,
   getPaperDigitalBenefits,
   getPromoCode,
+  getIntcmp,
   getDiscountedPrice,
 };


### PR DESCRIPTION
## Why are you doing this?
During a flash sale, it is useful to be able to set a custom value for the internal campaign code to more easily track the promotion in GA.

This adds that capability.

This does mean that there is a map of intcmp values that are valid during the flash sale that needs to be manually updated whenever we set up another flash sale if we are going to use a specific intcmp value for tracking.

The particular intcmp values specified in this PR relate to this flash sale: https://github.com/guardian/support-frontend/pull/850

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/3wVpGbeA/1751-voucher-home-delivery-flash-sale-updates)

## Changes

* Particular products during a flash sale can now have a specific intcmp value. If there is one specified, it is used if the flash sale is live, otherwise the default value is used.  

## Screenshots

