### PR TITLE
Update contact number for digital pack page for Australia

### DIFF
--- a/assets/components/customerService/customerService.jsx
+++ b/assets/components/customerService/customerService.jsx
@@ -64,7 +64,7 @@ function CustomerService(props: PropTypes) {
         <div className="component-customer-service__text">
           For help with Guardian and Observer subscription services please
           email <DigitalPackEmail email="apac.help@theguardian.com" /> or
-          call 1800 773 766 (within Australia) or +61 2076 8599 (outside Australia).
+          call 1800 773 766 (within Australia) or +61 2 8076 8599 (outside Australia).
           Lines are open 9am-5pm Monday-Friday (AEDT)
           <FAQBlock />
         </div>


### PR DESCRIPTION
## Why are you doing this?
Add the correct contact number for the Australian digital pack product page so that customers can reach us if they need to! 

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/Tg4kTE1c/1858-update-phone-number-on-au-digital-pack-page)

## Changes

* Add the correct contact number for the Australian digital pack product page

## Screenshots
Current footer with incorrect number
![image](https://user-images.githubusercontent.com/3072877/44338125-e4684380-a474-11e8-9ae0-6337930e04ba.png)

With the number corrected (after this change is merged)
![image](https://user-images.githubusercontent.com/3072877/44338088-c4d11b00-a474-11e8-832d-c8b96af233c7.png)
