### PR TITLE
Fix styling bug on error messages

### DIFF
--- a/assets/components/contributionsCheckout/contributionsCheckout.scss
+++ b/assets/components/contributionsCheckout/contributionsCheckout.scss
@@ -38,7 +38,7 @@
   }
 
   .component-error-message {
-    height: 32px;
+    height: 40px;
     position: relative;
 
     @include mq($from: desktop) {


### PR DESCRIPTION
## Why are you doing this?
Previosuly, if an error message went over 2 lines, the text struggled to fit in the box. This PR makes the box taller so that it can accomodate 2 lines. 

| Checkout Error Before | Checkout Error After |
|-----|------|
|![old](https://user-images.githubusercontent.com/2844554/44351329-8d289a00-a499-11e8-89ee-a1829e2b16d5.png)|![new](https://user-images.githubusercontent.com/2844554/44351327-8d289a00-a499-11e8-8a72-a8c257a2bea4.png)|

| Form Error Before | Form Error After |
|-----|------|
|![emailold](https://user-images.githubusercontent.com/2844554/44351476-dd9ff780-a499-11e8-9b2a-ab4e07de4b2d.png)|![newemail](https://user-images.githubusercontent.com/2844554/44351477-dd9ff780-a499-11e8-9448-835140c37732.png)|




