### PR TITLE
Keep utm params

### DIFF
--- a/assets/components/digitalSubscriptions/digitalSubscriptions.jsx
+++ b/assets/components/digitalSubscriptions/digitalSubscriptions.jsx
@@ -56,7 +56,6 @@ export default function DigitalSubscriptions(props: PropTypes) {
     countryGroupId,
     props.referrerAcquisitionData.campaignCode,
     getCampaign(props.referrerAcquisitionData),
-    [],
     props.referrerAcquisitionData,
   );
 

--- a/assets/components/internationalSubscriptions/internationalSubscriptions.jsx
+++ b/assets/components/internationalSubscriptions/internationalSubscriptions.jsx
@@ -52,7 +52,6 @@ export default function InternationalSubscriptions(props: PropTypes) {
     props.countryGroupId,
     props.referrerAcquisitionData.campaignCode,
     getCampaign(props.referrerAcquisitionData),
-    [],
     props.referrerAcquisitionData,
   );
 

--- a/assets/components/paperSubscriptions/paperSubscriptions.jsx
+++ b/assets/components/paperSubscriptions/paperSubscriptions.jsx
@@ -47,7 +47,6 @@ export default function PaperSubscriptions(props: PropTypes) {
     'GBPCountries',
     props.referrerAcquisitionData.campaignCode,
     getCampaign(props.referrerAcquisitionData),
-    [],
     props.referrerAcquisitionData,
   );
 

--- a/assets/components/threeSubscriptions/threeSubscriptions.jsx
+++ b/assets/components/threeSubscriptions/threeSubscriptions.jsx
@@ -52,7 +52,6 @@ function ThreeSubscriptions(props: PropTypes) {
     countryGroupId,
     props.referrerAcquisitionData.campaignCode,
     getCampaign(props.referrerAcquisitionData),
-    [],
     props.referrerAcquisitionData,
   );
 

--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -111,32 +111,19 @@ function getMemLink(product: MemProduct, intCmp: ?string): string {
 
 }
 
-function buildParamString(
-  product: SubscriptionProduct,
-  intCmp: ?string,
-  otherQueryParams: Array<[string, string]>,
-  referrerAcquisitionData: ReferrerAcquisitionData,
-): string {
-  const params = new URLSearchParams();
-
-  const maybeCustomIntcmp = getIntcmp(product, intCmp, defaultIntCmp);
-  params.append('INTCMP', maybeCustomIntcmp);
-  otherQueryParams.forEach(p => params.append(p[0], p[1]));
-  params.append('acquisitionData', JSON.stringify(referrerAcquisitionData));
-
-  return params.toString();
-}
 
 // Creates URLs for the subs site from promo codes and intCmp.
 function buildSubsUrls(
   countryGroupId: CountryGroupId,
   promoCodes: PromoCodes,
   intCmp: ?string,
-  otherQueryParams: Array<[string, string]>,
   referrerAcquisitionData: ReferrerAcquisitionData,
 ): SubsUrls {
 
   const countryId = countryGroups[countryGroupId].supportInternationalisationId;
+  const params = new URLSearchParams(window.location.search);
+  params.set('INTCMP', getIntcmp(product, intCmp, defaultIntCmp));
+  params.set('acquisitionData', JSON.stringify(referrerAcquisitionData));
 
   const paper = `${subsUrl}/p/${promoCodes.Paper}?${buildParamString('Paper', intCmp, otherQueryParams, referrerAcquisitionData)}`;
   const paperDig = `${subsUrl}/p/${promoCodes.PaperAndDigital}?${buildParamString('PaperAndDigital', intCmp, otherQueryParams, referrerAcquisitionData)}`;
@@ -157,7 +144,6 @@ function getSubsLinks(
   countryGroupId: CountryGroupId,
   intCmp: ?string,
   campaign: ?Campaign,
-  otherQueryParams: Array<[string, string]>,
   referrerAcquisitionData: ReferrerAcquisitionData,
 ): SubsUrls {
   if ((campaign && customPromos[campaign])) {
@@ -165,12 +151,11 @@ function getSubsLinks(
       countryGroupId,
       customPromos[campaign],
       intCmp,
-      otherQueryParams,
       referrerAcquisitionData,
     );
   }
 
-  return buildSubsUrls(countryGroupId, defaultPromos, intCmp, otherQueryParams, referrerAcquisitionData);
+  return buildSubsUrls(countryGroupId, defaultPromos, intCmp, referrerAcquisitionData);
 
 }
 
@@ -181,13 +166,13 @@ function getDigitalCheckout(
   referringCta: ?string,
 ): string {
 
-  return addQueryParamsToURL(`${subsUrl}/checkout`, {
-    promoCode: defaultPromos.DigitalPack,
-    countryGroup: countryGroups[cgId].supportInternationalisationId,
-    acquisitionData: JSON.stringify(referrerAcquisitionData),
-    startTrialButton: referringCta,
-  });
+  const params = new URLSearchParams(window.location.search);
+  params.set('acquisitionData', JSON.stringify(referrerAcquisitionData));
+  params.set('promoCode', defaultPromos.DigitalPack);
+  params.set('countryGroup', countryGroups[cgId].supportInternationalisationId);
+  params.set('startTrialButton', referringCta);
 
+  return `${subsUrl}/checkout?${params.toString()}`;
 }
 
 

--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -8,7 +8,6 @@ import {
   countryGroups,
   type CountryGroupId,
 } from 'helpers/internationalisation/countryGroup';
-import { addQueryParamsToURL } from 'helpers/url';
 
 import { getPromoCode, getIntcmp } from './flashSale';
 import type { SubscriptionProduct } from './subscriptions';
@@ -111,6 +110,19 @@ function getMemLink(product: MemProduct, intCmp: ?string): string {
 
 }
 
+function buildParamString(
+  product: SubscriptionProduct,
+  intCmp: ?string,
+  referrerAcquisitionData: ReferrerAcquisitionData,
+): string {
+  const params = new URLSearchParams(window.location.search);
+
+  const maybeCustomIntcmp = getIntcmp(product, intCmp, defaultIntCmp);
+  params.set('INTCMP', maybeCustomIntcmp);
+  params.set('acquisitionData', JSON.stringify(referrerAcquisitionData));
+
+  return params.toString();
+}
 
 // Creates URLs for the subs site from promo codes and intCmp.
 function buildSubsUrls(
@@ -121,14 +133,11 @@ function buildSubsUrls(
 ): SubsUrls {
 
   const countryId = countryGroups[countryGroupId].supportInternationalisationId;
-  const params = new URLSearchParams(window.location.search);
-  params.set('INTCMP', getIntcmp(product, intCmp, defaultIntCmp));
-  params.set('acquisitionData', JSON.stringify(referrerAcquisitionData));
 
-  const paper = `${subsUrl}/p/${promoCodes.Paper}?${buildParamString('Paper', intCmp, otherQueryParams, referrerAcquisitionData)}`;
-  const paperDig = `${subsUrl}/p/${promoCodes.PaperAndDigital}?${buildParamString('PaperAndDigital', intCmp, otherQueryParams, referrerAcquisitionData)}`;
-  const digital = `/${countryId}/subscribe/digital?${buildParamString('DigitalPack', intCmp, otherQueryParams, referrerAcquisitionData)}`;
-  const weekly = `${subsUrl}/weekly?${buildParamString('GuardianWeekly', intCmp, otherQueryParams, referrerAcquisitionData)}`;
+  const paper = `${subsUrl}/p/${promoCodes.Paper}?${buildParamString('Paper', intCmp, referrerAcquisitionData)}`;
+  const paperDig = `${subsUrl}/p/${promoCodes.PaperAndDigital}?${buildParamString('PaperAndDigital', intCmp, referrerAcquisitionData)}`;
+  const digital = `/${countryId}/subscribe/digital?${buildParamString('DigitalPack', intCmp, referrerAcquisitionData)}`;
+  const weekly = `${subsUrl}/weekly?${buildParamString('GuardianWeekly', intCmp, referrerAcquisitionData)}`;
 
   return {
     DigitalPack: digital,
@@ -170,7 +179,7 @@ function getDigitalCheckout(
   params.set('acquisitionData', JSON.stringify(referrerAcquisitionData));
   params.set('promoCode', defaultPromos.DigitalPack);
   params.set('countryGroup', countryGroups[cgId].supportInternationalisationId);
-  params.set('startTrialButton', referringCta);
+  params.set('startTrialButton', referringCta || '');
 
   return `${subsUrl}/checkout?${params.toString()}`;
 }


### PR DESCRIPTION
## Why are you doing this?
Previously we have been losing any query params passed to the support site when we send the user on to subscribe. This is particularly problematic for 'utm' parameters which are used by marketing to attribute conversions to particular acquisition channels.

[**Trello Card**](https://trello.com/c/Qmg8Ml52/1865-utm-tracking-codes-are-not-passed-to-the-subscribe-site)

## Changes

* Remove an unused `otherQueryParams` function parameter.
* Use URLSearchParams to pass on any query params we receive to the subs site.

