### PR TITLE
Acquisition data tidy up

### DIFF
--- a/assets/helpers/page/__tests__/__snapshots__/pageTest.js.snap
+++ b/assets/helpers/page/__tests__/__snapshots__/pageTest.js.snap
@@ -20,7 +20,6 @@ Object {
   "otherQueryParams": Array [],
   "referrerAcquisitionData": Object {
     "abTest": null,
-    "abTests": Array [],
     "campaignCode": null,
     "componentId": null,
     "componentType": null,

--- a/assets/helpers/page/__tests__/pageTest.js
+++ b/assets/helpers/page/__tests__/pageTest.js
@@ -24,7 +24,6 @@ describe('reducer tests', () => {
         componentType: null,
         source: null,
         abTest: null,
-        abTests: [],
         queryParameters: [],
       },
       internationalisation: {

--- a/assets/helpers/page/page.js
+++ b/assets/helpers/page/page.js
@@ -24,7 +24,7 @@ import { detect as detectCurrency, type IsoCurrency } from 'helpers/internationa
 import { getAllQueryParamsWithExclusions } from 'helpers/url';
 import {
   getCampaign,
-  getAcquisition,
+  getReferrerAcquisitionData,
   type Campaign,
   type ReferrerAcquisitionData,
 } from 'helpers/tracking/acquisitions';
@@ -80,7 +80,7 @@ function buildInitialState(
   currencyId: IsoCurrency,
   switches: Switches,
 ): CommonState {
-  const acquisition = getAcquisition(abParticipations);
+  const acquisition = getReferrerAcquisitionData();
   const excludedParameters = ['REFPVID', 'INTCMP', 'acquisitionData'];
   const otherQueryParams = getAllQueryParamsWithExclusions(excludedParameters);
   const internationalisation = {

--- a/assets/helpers/tracking/__tests__/acquisitionsTest.js
+++ b/assets/helpers/tracking/__tests__/acquisitionsTest.js
@@ -28,7 +28,6 @@ describe('acquisitions', () => {
           name: 'referrerAbTest',
           variant: 'value1',
         },
-        abTests: [],
         queryParameters: [{ name: 'param1', value: 'value1' }, { name: 'param2', value: 'value2' }],
       };
 

--- a/assets/helpers/tracking/acquisitions.js
+++ b/assets/helpers/tracking/acquisitions.js
@@ -42,7 +42,7 @@ export type ReferrerAcquisitionData = {|
   source: ?string,
   abTest: ?AcquisitionABTest,
   // these aren't in the referrer acquisition data model on frontend, but they're convenient to include
-  // as we want to include other query parameters in the acquisition event e.g. for off-platform tracking
+  // as we want to include query parameters in the acquisition event to e.g. facilitate off-platform tracking
   queryParameters: ?AcquisitionQueryParameters,
 |};
 
@@ -119,7 +119,7 @@ function getCampaign(acquisition: ReferrerAcquisitionData): ?Campaign {
 }
 
 // Stores the acquisition data in sessionStorage.
-function storeAcquisition(referrerAcquisitionData: ReferrerAcquisitionData): boolean {
+function storeReferrerAcquisitionData(referrerAcquisitionData: ReferrerAcquisitionData): boolean {
 
   try {
 
@@ -135,7 +135,7 @@ function storeAcquisition(referrerAcquisitionData: ReferrerAcquisitionData): boo
 }
 
 // Reads the acquisition data from sessionStorage.
-function readAcquisition(): ?ReferrerAcquisitionData {
+function readReferrerAcquisitionData(): ?ReferrerAcquisitionData {
 
   const stored = storage.getSession(ACQUISITIONS_STORAGE_KEY);
   return stored ? deserialiseJsonObject(stored) : null;
@@ -166,11 +166,13 @@ const participationsToAcquisitionABTest = (participations: Participations): Acqu
 };
 
 // Builds the acquisition object from data and other sources.
-function buildAcquisition(acquisitionData: Object = {}): ReferrerAcquisitionData {
+function buildReferrerAcquisitionData(acquisitionData: Object = {}): ReferrerAcquisitionData {
 
+  // This was how referrer pageview id used to be passed.
   const referrerPageviewId = acquisitionData.referrerPageviewId ||
     getQueryParameter('REFPVID');
 
+  // This was how referrer pageview id used to be passed.
   const campaignCode = acquisitionData.campaignCode ||
     getQueryParameter('INTCMP');
 
@@ -236,8 +238,8 @@ function getReferrerAcquisitionData(): ReferrerAcquisitionData {
   const paramData = deserialiseJsonObject(getQueryParameter(ACQUISITIONS_PARAM) || '');
 
   // Read from param, or read from sessionStorage, or build minimal version.
-  const referrerAcquisitionData = buildAcquisition(paramData || readAcquisition() || undefined);
-  storeAcquisition(referrerAcquisitionData);
+  const referrerAcquisitionData = buildReferrerAcquisitionData(paramData || readReferrerAcquisitionData() || undefined);
+  storeReferrerAcquisitionData(referrerAcquisitionData);
 
   return referrerAcquisitionData;
 }


### PR DESCRIPTION
## Why are you doing this?

This is in preparation for the pull request which will track Optimizie experiments in the data lake. When looking through this part of the code base with @Ap0c, we saw that support-frontend AB tests were getting added to the AB tests field of the referrer acquisition data ([reference](https://github.com/guardian/support-frontend/blob/master/assets/helpers/tracking/acquisitions.js#L185)). However, they are also passed down the component hierarchy and used to build the POST data requests for the various payment endpoints ([one-off Stripe](https://github.com/guardian/support-frontend/blob/master/assets/helpers/tracking/acquisitions.js#L216); [one-off Paypal](https://github.com/guardian/support-frontend/blob/master/assets/helpers/paymentIntegrations/payPalPaymentAPICheckout.js#L49); [recurring](https://github.com/guardian/support-frontend/blob/master/assets/pages/regular-contributions/helpers/ajax.js#L146)). Only one of these is necessary and the latter is preferred as it doesn't mutate the referrer acquisition data.