### PR TITLE
User Reducer Sets Default State

### DIFF
--- a/assets/helpers/user/__tests__/__snapshots__/userReducerTest.js.snap
+++ b/assets/helpers/user/__tests__/__snapshots__/userReducerTest.js.snap
@@ -11,5 +11,6 @@ Object {
   "isSignedIn": false,
   "isTestUser": null,
   "lastName": "",
+  "stateField": "",
 }
 `;

--- a/assets/helpers/user/__tests__/userReducerTest.js
+++ b/assets/helpers/user/__tests__/userReducerTest.js
@@ -1,11 +1,14 @@
-import { userReducer as reducer } from '../userReducer';
+// ----- Imports ----- //
+
+import { createUserReducer } from '../userReducer';
+
 
 // ----- Tests ----- //
 
 describe('user reducer tests', () => {
 
   it('should return the initial state', () => {
-    expect(reducer(undefined, {})).toMatchSnapshot();
+    expect(createUserReducer('GBPCountries')(undefined, {})).toMatchSnapshot();
   });
 
   it('should handle SET_DISPLAY_NAME', () => {
@@ -15,7 +18,7 @@ describe('user reducer tests', () => {
       name,
     };
 
-    const newState = reducer(undefined, action);
+    const newState = createUserReducer('GBPCountries')(undefined, action);
 
     expect(newState.displayName).toEqual(name);
   });
@@ -27,7 +30,7 @@ describe('user reducer tests', () => {
       name,
     };
 
-    const newState = reducer(undefined, action);
+    const newState = createUserReducer('GBPCountries')(undefined, action);
     expect(newState.firstName).toEqual(name);
   });
 
@@ -38,7 +41,7 @@ describe('user reducer tests', () => {
       name,
     };
 
-    const newState = reducer(undefined, action);
+    const newState = createUserReducer('GBPCountries')(undefined, action);
 
     expect(newState.lastName).toEqual(name);
   });
@@ -51,7 +54,7 @@ describe('user reducer tests', () => {
       name,
     };
 
-    const newState = reducer(undefined, action);
+    const newState = createUserReducer('GBPCountries')(undefined, action);
 
     expect(newState.fullName).toEqual(name);
   });
@@ -64,7 +67,7 @@ describe('user reducer tests', () => {
       testUser,
     };
 
-    const newState = reducer(undefined, action);
+    const newState = createUserReducer('GBPCountries')(undefined, action);
 
     expect(newState.isTestUser).toEqual(testUser);
   });
@@ -77,7 +80,7 @@ describe('user reducer tests', () => {
       postDeploymentTestUser,
     };
 
-    const newState = reducer(undefined, action);
+    const newState = createUserReducer('GBPCountries')(undefined, action);
 
     expect(newState.isPostDeploymentTestUser).toEqual(postDeploymentTestUser);
   });
@@ -90,7 +93,7 @@ describe('user reducer tests', () => {
       email,
     };
 
-    const newState = reducer(undefined, action);
+    const newState = createUserReducer('GBPCountries')(undefined, action);
 
     expect(newState.email).toEqual(email);
   });
@@ -103,7 +106,7 @@ describe('user reducer tests', () => {
       stateField,
     };
 
-    const newState = reducer(undefined, action);
+    const newState = createUserReducer('UnitedStates')(undefined, action);
     expect(newState.stateField).toEqual(stateField);
   });
 
@@ -115,7 +118,7 @@ describe('user reducer tests', () => {
       preference,
     };
 
-    const newState = reducer(undefined, action);
+    const newState = createUserReducer('GBPCountries')(undefined, action);
     expect(newState.gnmMarketing).toEqual(preference);
   });
 });

--- a/assets/helpers/user/__tests__/userReducerTest.js
+++ b/assets/helpers/user/__tests__/userReducerTest.js
@@ -11,6 +11,14 @@ describe('user reducer tests', () => {
     expect(createUserReducer('GBPCountries')(undefined, {})).toMatchSnapshot();
   });
 
+  it('should have a default state for the US', () => {
+    expect(createUserReducer('UnitedStates')(undefined, {}).stateField).toBe('AK');
+  });
+
+  it('should have a default province for Canada', () => {
+    expect(createUserReducer('Canada')(undefined, {}).stateField).toBe('AB');
+  });
+
   it('should handle SET_DISPLAY_NAME', () => {
     const name = 'John Doe';
     const action = {

--- a/assets/helpers/user/userReducer.js
+++ b/assets/helpers/user/userReducer.js
@@ -1,6 +1,10 @@
 // @flow
 
 // ----- Imports ----- //
+
+import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { usStates, caStates } from 'helpers/internationalisation/country';
+
 import type { Action } from './userActions';
 
 
@@ -36,52 +40,74 @@ const initialState: User = {
 };
 
 
+// ----- Functions ----- //
+
+function defaultStateOrProvince(countryGroup: CountryGroupId): string {
+  if (countryGroup === 'UnitedStates') {
+    return Object.keys(usStates)[0];
+  } else if (countryGroup === 'Canada') {
+    return Object.keys(caStates)[0];
+  }
+
+  return '';
+}
+
+
 // ----- Reducer ----- //
 
-function userReducer(
-  state: User = initialState,
-  action: Action,
-): User {
+function createUserReducer(countryGroup: CountryGroupId) {
 
-  switch (action.type) {
-    case 'SET_USER_ID':
-      return Object.assign({}, state, { id: action.id });
+  const initialStateWithStateOrProvince = {
+    ...initialState,
+    stateField: defaultStateOrProvince(countryGroup),
+  };
 
-    case 'SET_DISPLAY_NAME':
-      return Object.assign({}, state, { displayName: action.name });
+  return function userReducer(
+    state: User = initialStateWithStateOrProvince,
+    action: Action,
+  ): User {
 
-    case 'SET_FIRST_NAME':
-      return Object.assign({}, state, { firstName: action.name });
+    switch (action.type) {
+      case 'SET_USER_ID':
+        return Object.assign({}, state, { id: action.id });
 
-    case 'SET_LAST_NAME':
-      return Object.assign({}, state, { lastName: action.name });
+      case 'SET_DISPLAY_NAME':
+        return Object.assign({}, state, { displayName: action.name });
 
-    case 'SET_FULL_NAME':
-      return Object.assign({}, state, { fullName: action.name });
+      case 'SET_FIRST_NAME':
+        return Object.assign({}, state, { firstName: action.name });
 
-    case 'SET_TEST_USER':
-      return Object.assign({}, state, { isTestUser: action.testUser });
+      case 'SET_LAST_NAME':
+        return Object.assign({}, state, { lastName: action.name });
 
-    case 'SET_POST_DEPLOYMENT_TEST_USER':
-      return Object.assign({}, state, { isPostDeploymentTestUser: action.postDeploymentTestUser });
+      case 'SET_FULL_NAME':
+        return Object.assign({}, state, { fullName: action.name });
 
-    case 'SET_EMAIL':
-      return Object.assign({}, state, { email: action.email });
+      case 'SET_TEST_USER':
+        return Object.assign({}, state, { isTestUser: action.testUser });
 
-    case 'SET_STATEFIELD':
-      return Object.assign({}, state, { stateField: action.stateField });
+      case 'SET_POST_DEPLOYMENT_TEST_USER':
+        return Object.assign({}, state, { isPostDeploymentTestUser: action.postDeploymentTestUser });
 
-    case 'SET_GNM_MARKETING':
-      return Object.assign({}, state, { gnmMarketing: action.preference });
+      case 'SET_EMAIL':
+        return Object.assign({}, state, { email: action.email });
 
-    case 'SET_IS_SIGNED_IN':
-      return Object.assign({}, state, { isSignedIn: action.isSignedIn });
+      case 'SET_STATEFIELD':
+        return Object.assign({}, state, { stateField: action.stateField });
 
-    default:
-      return state;
+      case 'SET_GNM_MARKETING':
+        return Object.assign({}, state, { gnmMarketing: action.preference });
 
-  }
+      case 'SET_IS_SIGNED_IN':
+        return Object.assign({}, state, { isSignedIn: action.isSignedIn });
+
+      default:
+        return state;
+
+    }
+
+  };
 
 }
 
-export { userReducer };
+export { createUserReducer };

--- a/assets/pages/oneoff-contributions/__tests__/__snapshots__/oneoffContributionsReducersTest.js.snap
+++ b/assets/pages/oneoff-contributions/__tests__/__snapshots__/oneoffContributionsReducersTest.js.snap
@@ -27,6 +27,7 @@ Object {
     "isSignedIn": false,
     "isTestUser": null,
     "lastName": "",
+    "stateField": "",
   },
 }
 `;

--- a/assets/pages/oneoff-contributions/__tests__/oneoffContributionsReducersTest.js
+++ b/assets/pages/oneoff-contributions/__tests__/oneoffContributionsReducersTest.js
@@ -9,7 +9,7 @@ import createReducer from '../oneOffContributionsReducer';
 
 describe('One-off Reducer', () => {
 
-  const reducer = createReducer(20);
+  const reducer = createReducer(20, 'GBPCountries');
 
   it('should return the initial state', () => {
     expect(reducer(undefined, {})).toMatchSnapshot();

--- a/assets/pages/oneoff-contributions/oneOffContributionsReducer.js
+++ b/assets/pages/oneoff-contributions/oneOffContributionsReducer.js
@@ -6,10 +6,10 @@ import { combineReducers } from 'redux';
 import type { User as UserState } from 'helpers/user/userReducer';
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 
-import { userReducer as user } from 'helpers/user/userReducer';
+import { createUserReducer } from 'helpers/user/userReducer';
 import { marketingConsentReducerFor } from 'components/marketingConsent/marketingConsentReducer';
 import csrf from 'helpers/csrf/csrfReducer';
-
+import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { CommonState } from 'helpers/page/page';
 import type { State as MarketingConsentState } from 'components/marketingConsent/marketingConsentReducer';
 import type { Action } from './oneoffContributionsActions';
@@ -71,11 +71,11 @@ function createOneOffContribReducer(amount: number) {
 
 // ----- Exports ----- //
 
-export default function createRootOneOffContribReducer(amount: number) {
+export default function createRootOneOffContribReducer(amount: number, countryGroup: CountryGroupId) {
   return combineReducers({
     oneoffContrib: createOneOffContribReducer(amount),
     marketingConsent: marketingConsentReducerFor('CONTRIBUTIONS_THANK_YOU'),
-    user,
+    user: createUserReducer(countryGroup),
     csrf,
   });
 }

--- a/assets/pages/oneoff-contributions/oneoffContributions.jsx
+++ b/assets/pages/oneoff-contributions/oneoffContributions.jsx
@@ -29,7 +29,7 @@ import OneoffContributionsPayment from './components/oneoffContributionsPayment'
 
 const countryGroup = detectCountryGroup();
 
-const store = pageInit(reducer(getAmount('ONE_OFF', countryGroup)), true);
+const store = pageInit(reducer(getAmount('ONE_OFF', countryGroup), countryGroup), true);
 
 const ONE_OFF_CONTRIBUTION_COOKIE = 'gu.contributions.contrib-timestamp';
 

--- a/assets/pages/regular-contributions/__tests__/__snapshots__/regularContributionsReducersTest.js.snap
+++ b/assets/pages/regular-contributions/__tests__/__snapshots__/regularContributionsReducersTest.js.snap
@@ -48,6 +48,7 @@ Object {
     "isSignedIn": false,
     "isTestUser": null,
     "lastName": "",
+    "stateField": "",
   },
 }
 `;

--- a/assets/pages/regular-contributions/__tests__/regularContributionsReducersTest.js
+++ b/assets/pages/regular-contributions/__tests__/regularContributionsReducersTest.js
@@ -9,7 +9,7 @@ import createReducer from '../regularContributionsReducer';
 
 describe('Regular contributions Reducer', () => {
 
-  const reducer = createReducer(20, 'DirectDebit', 'MONTHLY');
+  const reducer = createReducer(20, 'DirectDebit', 'MONTHLY', 'GBPCountries');
 
   it('should return the initial state', () => {
     expect(reducer(undefined, {})).toMatchSnapshot();

--- a/assets/pages/regular-contributions/components/formFields.jsx
+++ b/assets/pages/regular-contributions/components/formFields.jsx
@@ -83,9 +83,6 @@ function stateDropdown(countryGroup: CountryGroupId, stateUpdate: (UsState | CaS
   const options: SelectOption[] = Object.keys(states).map((stateCode: UsState | CaState) =>
     ({ value: stateCode, text: states[stateCode] }));
 
-  // Sets the initial state to the first in the dropdown.
-  stateUpdate(options[0].value);
-
   return (<SelectInput
     id="qa-state-dropdown"
     onChange={stateUpdate}

--- a/assets/pages/regular-contributions/regularContributions.jsx
+++ b/assets/pages/regular-contributions/regularContributions.jsx
@@ -26,11 +26,13 @@ import RegularContributionsPayment from './components/regularContributionsPaymen
 // ----- Page Startup ----- //
 
 const contributionType = parseRegularContributionType(getQueryParameter('contribType') || 'MONTHLY');
+const countryGroup = detectCountryGroup();
 
 const store = pageInit(reducer(
-  getAmount(contributionType, detectCountryGroup()),
+  getAmount(contributionType, countryGroup),
   getPaymentMethod(),
   contributionType,
+  countryGroup,
 ), true);
 
 user.init(store.dispatch);

--- a/assets/pages/regular-contributions/regularContributionsReducer.js
+++ b/assets/pages/regular-contributions/regularContributionsReducer.js
@@ -7,7 +7,7 @@ import { combineReducers } from 'redux';
 import type { User as UserState } from 'helpers/user/userReducer';
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import type { DirectDebitState } from 'components/directDebit/directDebitReducer';
-import { userReducer as user } from 'helpers/user/userReducer';
+import { createUserReducer } from 'helpers/user/userReducer';
 import { directDebitReducer as directDebit } from 'components/directDebit/directDebitReducer';
 import { marketingConsentReducerFor } from 'components/marketingConsent/marketingConsentReducer';
 import csrf from 'helpers/csrf/csrfReducer';
@@ -15,6 +15,7 @@ import type { CommonState } from 'helpers/page/page';
 import type { PaymentMethod } from 'helpers/checkouts';
 import { type RegularContributionType } from 'helpers/contributions';
 import type { State as MarketingConsentState } from 'components/marketingConsent/marketingConsentReducer';
+import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 import type { Action } from './regularContributionsActions';
 import type { PaymentStatus } from './components/regularContributionsPayment';
@@ -103,11 +104,12 @@ export default function createRootRegularContributionsReducer(
   amount: number,
   paymentMethod: ?PaymentMethod,
   contributionType: RegularContributionType,
+  countryGroup: CountryGroupId,
 ) {
   return combineReducers({
     regularContrib: createRegularContribReducer(amount, paymentMethod, contributionType),
     marketingConsent: marketingConsentReducerFor('CONTRIBUTIONS_THANK_YOU'),
-    user,
+    user: createUserReducer(countryGroup),
     csrf,
     directDebit,
   });


### PR DESCRIPTION
## Why are you doing this?

The user reducer starts off with its default state/province field blank, but when it's used on the checkouts we always set a default state anyway. This PR consolidates this initial state creation in the user reducer itself, which is where the other initial state values are set.

## Changes

- Created a higher-order reducer for user. It now takes a country group and generates an initial state/province from that.
- Updated the one-off and recurring contribution checkouts to handle this change.
- Brought the tests into line and added a couple to cover this new functionality.
