### PR TITLE
Tidy up One-Off Contributions Reducer

### DIFF
--- a/assets/pages/oneoff-contributions/components/contributionsCheckoutContainer.js
+++ b/assets/pages/oneoff-contributions/components/contributionsCheckoutContainer.js
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 
 import ContributionsCheckout from 'components/contributionsCheckout/contributionsCheckout';
 
-import { type PageState as State } from '../oneOffContributionsReducer';
+import { type State } from '../oneOffContributionsReducer';
 
 
 // ----- State Maps ----- //

--- a/assets/pages/oneoff-contributions/components/formFields.jsx
+++ b/assets/pages/oneoff-contributions/components/formFields.jsx
@@ -22,7 +22,7 @@ import {
   setEmailShouldValidate,
 } from '../helpers/checkoutForm/checkoutFormActions';
 import { getFormFields } from '../helpers/checkoutForm/checkoutFormFieldsSelector';
-import { type PageState as State } from '../oneOffContributionsReducer';
+import { type State } from '../oneOffContributionsReducer';
 
 
 // ----- Types ----- //

--- a/assets/pages/oneoff-contributions/components/marketingConsentContainer.jsx
+++ b/assets/pages/oneoff-contributions/components/marketingConsentContainer.jsx
@@ -12,7 +12,8 @@ import MarketingConsent from 'components/marketingConsent/marketingConsent';
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import { type State } from '../oneOffContributionsReducer';
 
-// ----- Component ----- //
+
+// ----- State/Action Maps ----- //
 
 function mapDispatchToProps(dispatch: Dispatch<Action>) {
   return {
@@ -40,5 +41,8 @@ function mapStateToProps(state: State) {
     csrf: state.page.csrf,
   };
 }
+
+
+// ----- Exports ----- //
 
 export default connect(mapStateToProps, mapDispatchToProps)(MarketingConsent);

--- a/assets/pages/oneoff-contributions/components/marketingConsentContainer.jsx
+++ b/assets/pages/oneoff-contributions/components/marketingConsentContainer.jsx
@@ -10,7 +10,7 @@ import { sendMarketingPreferencesToIdentity } from 'components/marketingConsent/
 import MarketingConsent from 'components/marketingConsent/marketingConsent';
 
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
-import type { PageState as OneOffPageState } from '../oneOffContributionsReducer';
+import { type State } from '../oneOffContributionsReducer';
 
 // ----- Component ----- //
 
@@ -31,7 +31,7 @@ function mapDispatchToProps(dispatch: Dispatch<Action>) {
   };
 }
 
-function mapStateToProps(state: OneOffPageState) {
+function mapStateToProps(state: State) {
   return {
     email: state.page.user.email,
     marketingPreferencesOptIn: state.page.user.gnmMarketing,

--- a/assets/pages/oneoff-contributions/components/oneoffContributionsPayment.jsx
+++ b/assets/pages/oneoff-contributions/components/oneoffContributionsPayment.jsx
@@ -20,7 +20,7 @@ import { type Action as CheckoutAction } from '../helpers/checkoutForm/checkoutF
 import { setFullNameShouldValidate, setEmailShouldValidate } from '../helpers/checkoutForm/checkoutFormActions';
 import postCheckout from '../helpers/ajax';
 import { getFormFields } from '../helpers/checkoutForm/checkoutFormFieldsSelector';
-import { type PageState as State } from '../oneOffContributionsReducer';
+import { type State } from '../oneOffContributionsReducer';
 
 // ----- Types ----- //
 

--- a/assets/pages/oneoff-contributions/helpers/checkoutForm/checkoutFormFieldsSelector.js
+++ b/assets/pages/oneoff-contributions/helpers/checkoutForm/checkoutFormFieldsSelector.js
@@ -1,6 +1,12 @@
 // @flow
+
+// ----- Imports ----- //
+
 import { formFieldIsValid } from 'helpers/checkoutForm/checkoutForm';
-import { type PageState as State } from '../../oneOffContributionsReducer';
+import { type State } from '../../oneOffContributionsReducer';
+
+
+// ----- Selectors ----- //
 
 function getFormFields(state: State) {
 
@@ -27,5 +33,8 @@ function getFormFields(state: State) {
 
   return { fullName, email };
 }
+
+
+// ----- Exports ----- //
 
 export { getFormFields };

--- a/assets/pages/oneoff-contributions/oneOffContributionsReducer.js
+++ b/assets/pages/oneoff-contributions/oneOffContributionsReducer.js
@@ -18,37 +18,40 @@ import { checkoutFormReducer as checkoutForm, type OneOffContributionsCheckoutFo
 
 // ----- Types ----- //
 
-export type State = {
+export type OneOffContributionsState = {
   amount: number,
   error: ?string,
   paymentComplete: boolean,
 };
 
-export type CombinedState = {
-  oneoffContrib: State,
+export type PageState = {
+  oneoffContrib: OneOffContributionsState,
   user: UserState,
   csrf: CsrfState,
   checkoutForm: OneOffContributionsCheckoutFormState,
   marketingConsent: MarketingConsentState,
 };
 
-export type PageState = {
+export type State = {
   common: CommonState,
-  page: CombinedState,
-}
+  page: PageState,
+};
 
 
 // ----- Reducers ----- //
 
-function createOneOffContribReducer(amount: number) {
+function createOneOffContributionsReducer(amount: number) {
 
-  const initialState: State = {
+  const initialState: OneOffContributionsState = {
     amount,
     error: null,
     paymentComplete: false,
   };
 
-  return function oneOffContribReducer(state: State = initialState, action: Action): State {
+  return function oneOffContribReducer(
+    state: OneOffContributionsState = initialState,
+    action: Action,
+  ): OneOffContributionsState {
 
     switch (action.type) {
 
@@ -68,9 +71,9 @@ function createOneOffContribReducer(amount: number) {
 
 // ----- Exports ----- //
 
-export default function createRootOneOffContribReducer(amount: number, countryGroup: CountryGroupId) {
+export default function createRootOneOffContributionsReducer(amount: number, countryGroup: CountryGroupId) {
   return combineReducers({
-    oneoffContrib: createOneOffContribReducer(amount),
+    oneoffContrib: createOneOffContributionsReducer(amount),
     marketingConsent: marketingConsentReducerFor('CONTRIBUTIONS_THANK_YOU'),
     user: createUserReducer(countryGroup),
     csrf,

--- a/assets/pages/oneoff-contributions/oneOffContributionsReducer.js
+++ b/assets/pages/oneoff-contributions/oneOffContributionsReducer.js
@@ -18,13 +18,13 @@ import { checkoutFormReducer as checkoutForm, type OneOffContributionsCheckoutFo
 
 // ----- Types ----- //
 
-export type OneOffContributionsState = {
+type OneOffContributionsState = {
   amount: number,
   error: ?string,
   paymentComplete: boolean,
 };
 
-export type PageState = {
+type PageState = {
   oneoffContrib: OneOffContributionsState,
   user: UserState,
   csrf: CsrfState,

--- a/assets/pages/oneoff-contributions/oneOffContributionsReducer.js
+++ b/assets/pages/oneoff-contributions/oneOffContributionsReducer.js
@@ -56,10 +56,10 @@ function createOneOffContributionsReducer(amount: number) {
     switch (action.type) {
 
       case 'CHECKOUT_ERROR':
-        return Object.assign({}, state, { error: action.message });
+        return { ...state, error: action.message };
 
       case 'CHECKOUT_SUCCESS':
-        return Object.assign({}, state, { paymentComplete: true });
+        return { ...state, paymentComplete: true };
 
       default:
         return state;


### PR DESCRIPTION
## Why are you doing this?

There were some confusingly named types and some old practices being used in this file. The companion to #906.

## Changes

- Renamed types for consistency with the rest of the codebase.
- Switched to object spread syntax.
