### PR TITLE
Payment Flow: Positioning images in bubbles

### DIFF
--- a/assets/components/gridImage/gridImage.jsx
+++ b/assets/components/gridImage/gridImage.jsx
@@ -10,6 +10,7 @@ import React from 'react';
 
 import { gridUrl, gridSrcset } from 'helpers/theGrid';
 import { ascending } from 'helpers/utilities';
+import { classNameWithModifiers } from 'helpers/utilities';
 
 import type { ImageType, ImageId } from 'helpers/theGrid';
 
@@ -27,6 +28,7 @@ export type GridImg = {
   sizes: string,
   altText: string,
   imgType?: ImageType,
+  classModifiers?: string[],
 }
 
 type PropTypes = GridImg;
@@ -48,7 +50,7 @@ export default function GridImage(props: PropTypes) {
 
   return (
     <img
-      className="component-grid-image"
+      className={classNameWithModifiers('component-grid-image', props.classModifiers)}
       sizes={props.sizes}
       srcSet={srcSet}
       src={fallbackSrc}
@@ -64,4 +66,5 @@ export default function GridImage(props: PropTypes) {
 GridImage.defaultProps = {
   imgType: 'jpg',
   altText: '',
+  classModifiers: [],
 };

--- a/assets/components/gridImage/gridImage.jsx
+++ b/assets/components/gridImage/gridImage.jsx
@@ -28,7 +28,7 @@ export type GridImg = {
   sizes: string,
   altText: string,
   imgType?: ImageType,
-  classModifiers?: string[],
+  classModifiers?: Array<?string>,
 }
 
 type PropTypes = GridImg;
@@ -50,7 +50,7 @@ export default function GridImage(props: PropTypes) {
 
   return (
     <img
-      className={classNameWithModifiers('component-grid-image', props.classModifiers)}
+      className={classNameWithModifiers('component-grid-image', props.classModifiers || [])}
       sizes={props.sizes}
       srcSet={srcSet}
       src={fallbackSrc}

--- a/assets/components/svgs/contributionsBgDesktop.jsx
+++ b/assets/components/svgs/contributionsBgDesktop.jsx
@@ -7,21 +7,11 @@ export default function SvgContributionsBgDesktop() {
 
   return (
     <svg className="svg-contributions-bg-desktop" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1300 580">
-      <defs>
-        <circle id="circle-a" cx="112.5" cy="112.5" r="112.5" />
-        <circle id="circle-b" cx="140" cy="140" r="140" />
-        <circle id="circle-c" cx="225" cy="225" r="225" />
-      </defs>
-      <g transform="translate(-140)" fill="none" fillRule="evenodd">
-        <use fill="#121212" href="#circle-a" transform="translate(1114)" />
-        <use fill="#121212" href="#circle-b" transform="translate(107 300)" />
-        <circle fill="#E7D4B9" transform="matrix(-1 0 0 1 638 0)" cx="319" cy="243" r="70" />
-        <circle fill="#FEC8D3" transform="matrix(-1 0 0 1 2714 0)" cx="1357" cy="329" r="140" />
-        <circle fill="#00B2FF" transform="matrix(-1 0 0 1 253 0)" cx="126.5" cy="202.5" r="126.5" />
-        <circle fill="#FF4E36" transform="matrix(-1 0 0 1 1649 0)" cx="824.5" cy="123.5" r="58.5" />
-        <circle fill="#FFF" transform="matrix(-1 0 0 1 2486 0)" cx="1243" cy="509" r="70" />
-        <use fill="#121212" href="#circle-c" transform="translate(766 129)" />
-      </g>
+      <circle fill="#E7D4B9" cx="180" cy="243" r="70" />
+      <circle fill="#FEC8D3" cx="1160" cy="329" r="140" />
+      <circle fill="#00B2FF" cx="-12" cy="198" r="126" />
+      <circle fill="#FF4E36" cx="629" cy="125" r="58" />
+      <circle fill="#FFFFFF" cx="1050" cy="509" r="70" />
     </svg>
   );
 }

--- a/assets/components/svgs/contributionsBgMobile.jsx
+++ b/assets/components/svgs/contributionsBgMobile.jsx
@@ -7,19 +7,9 @@ export default function SvgContributionsBgMobile() {
 
   return (
     <svg className="svg-contributions-bg-mobile" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 375 223">
-      <defs>
-        <circle id="circle-a" cx="89.25" cy="89.25" r="89.25" />
-        <circle id="circle-b" cx="35" cy="35" r="35" />
-        <circle id="circle-c" cx="61.5" cy="61.5" r="61.5" />
-      </defs>
-      <g transform="matrix(-1 0 0 1 404 0)" fill="none" fillRule="evenodd">
-        <use fill="#121212" href="#circle-a" transform="translate(0 44)" />
-        <use fill="#121212" href="#circle-b" transform="matrix(-1 0 0 1 237 153)" />
-        <circle fill="#FFF" cx="38.125" cy="28.125" r="28.125" />
-        <circle fill="#FF4E36" transform="matrix(-1 0 0 1 479 0)" cx="239.5" cy="151.5" r="17.5" />
-        <use fill="#121212" href="#circle-c" transform="matrix(-1 0 0 1 378.872 100.385)" />
-        <circle fill="#00B2FF" cx="401.258" cy="194.118" r="28.125" />
-      </g>
+      <circle fill="#FFFFFF" cx="365" cy="28" r="28" />
+      <circle fill="#FF4E36" cx="165" cy="151" r="17" />
+      <circle fill="#00B2FF" cx="3" cy="194" r="28" />
     </svg>
   );
 }

--- a/assets/pages/new-contributions-landing/contributionsLanding.jsx
+++ b/assets/pages/new-contributions-landing/contributionsLanding.jsx
@@ -76,9 +76,9 @@ const content = (
         </form>
       </div>
       <div className="gu-content__bg">
-        <GridImage gridId="newsroom" srcSizes={[1000, 500, 140]} classModifiers={['circle-a']} />
-        <GridImage gridId="newsroom" srcSizes={[1000, 500, 140]} classModifiers={['circle-b']} />
-        <GridImage gridId="newsroom" srcSizes={[1000, 500, 140]} classModifiers={['circle-c']} />
+        <GridImage gridId="newsroom" sizes="" srcSizes={[1000, 500, 140]} classModifiers={['circle-a']} />
+        <GridImage gridId="newsroom" sizes="" srcSizes={[1000, 500, 140]} classModifiers={['circle-b']} />
+        <GridImage gridId="newsroom" sizes="" srcSizes={[1000, 500, 140]} classModifiers={['circle-c']} />
         <SvgContributionsBgMobile />
         <SvgContributionsBgDesktop />
       </div>

--- a/assets/pages/new-contributions-landing/contributionsLanding.jsx
+++ b/assets/pages/new-contributions-landing/contributionsLanding.jsx
@@ -13,6 +13,8 @@ import { classNameWithModifiers } from 'helpers/utilities';
 import { detect, countryGroups, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { countryGroupSpecificDetails } from 'helpers/internationalisation/contributions';
 
+import GridImage from 'components/gridImage/gridImage';
+
 import Page from 'components/page/page';
 import Footer from 'components/footer/footer';
 import SvgContributionsBgMobile from 'components/svgs/contributionsBgMobile';
@@ -74,6 +76,9 @@ const content = (
         </form>
       </div>
       <div className="gu-content__bg">
+        <GridImage gridId="newsroom" srcSizes={[1000, 500, 140]} classModifiers={['circle-a']} />
+        <GridImage gridId="newsroom" srcSizes={[1000, 500, 140]} classModifiers={['circle-b']} />
+        <GridImage gridId="newsroom" srcSizes={[1000, 500, 140]} classModifiers={['circle-c']} />
         <SvgContributionsBgMobile />
         <SvgContributionsBgDesktop />
       </div>

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -355,6 +355,20 @@ header[role="banner"] {
     display: grid;
   }
 
+  @include mq($from: mobile, $until: tablet) {
+    header[role="banner"] {
+      justify-content: flex-end;
+    }
+    
+    .gu-content__bg {
+      grid-row: 1;
+    }
+
+    .gu-content__content {
+      grid-row: 2;
+    }
+  }
+
   @include mq($from: tablet) {
     .gu-content,
     header[role="banner"] {

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -876,27 +876,21 @@ form {
 }
 
 @include mq($from: mobile, $until: tablet) {
-  .component-grid-image--circle-a,
-  .component-grid-image--circle-b,
-  .component-grid-image--circle-c {
-    display: none;
-  }
-
-  .component-grid-image--circle-d {
+  .component-grid-image--circle-a {
     bottom: 0px;
     height: 123px;
     left: 8px;
     width: 123px;
   }
 
-  .component-grid-image--circle-e {
+  .component-grid-image--circle-b {
     bottom: 0px;
     height: 70px;
     left: 150px;
     width: 70px;
   }
 
-  .component-grid-image--circle-f {
+  .component-grid-image--circle-c {
     bottom: 0px;
     height: 178px;
     right: -46px;
@@ -905,12 +899,6 @@ form {
 }  
 
 @include mq($from: tablet) {
-  .component-grid-image--circle-d,
-  .component-grid-image--circle-e,
-  .component-grid-image--circle-f {
-    display: none;
-  }
-
   .component-grid-image--circle-a {
     bottom: 0;
     height: 450px;

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -324,151 +324,152 @@ header[role="banner"] {
   }
 }
 
-// @supports(display: grid) {
-//   .gu-content {
-//     display: grid;
-//     grid-template-rows: [header-t] 75px [header-b] 1fr [footer-t] auto [footer-b];
-//     grid-template-columns: 1fr;
-//   }
+@supports(display: grid) {
+  .gu-content {
+    display: grid;
+    grid-template-rows: [header-t] 75px [header-b] 1fr [footer-t] auto [footer-b];
+    grid-template-columns: 1fr;
+  }
   
-//   header[role="banner"] {
-//     height: auto;
-//     grid-row: header-t / header-b;
-//   }
+  header[role="banner"] {
+    height: auto;
+    grid-row: header-t / header-b;
+  }
   
-//   footer[role="contentinfo"] {
-//     grid-row: footer-t / footer-b;
-//   }
+  footer[role="contentinfo"] {
+    grid-row: footer-t / footer-b;
+  }
   
-//   .gu-content__main {
-//     grid-row: header-b / footer-t;  
-//   }
+  .gu-content__main {
+    grid-row: header-b / footer-t;  
+  }
 
-//   header[role="banner"],
-//   footer[role="contentinfo"],
-//   .gu-content__main {
-//     display: grid;
-//   }
+  header[role="banner"],
+  footer[role="contentinfo"],
+  .gu-content__main {
+    display: grid;
+  }
 
-//   .gu-content__bg {
-//     position: static;
-//   }
+  .gu-content__bg {
+    position: static;
+  }
 
-//   @include mq($from: tablet) {
-//     .gu-content,
-//     header[role="banner"] {
-//       padding: 0;
-//       width: auto;
-//     }
+  @include mq($from: tablet) {
+    .gu-content,
+    header[role="banner"] {
+      padding: 0;
+      width: auto;
+    }
 
-//     footer[role="contentinfo"] {
-//       padding: 0 0 ($gu-v-spacing * 2);
-//       width: auto;
-//     }
+    footer[role="contentinfo"] {
+      padding: 0 0 ($gu-v-spacing * 2);
+      width: auto;
+    }
     
-//     .gu-content__main,
-//     footer[role="contentinfo"] {
-//       grid-column-gap: $gu-h-spacing;
-//       grid-template-columns: 1fr repeat(8, 70px) 1fr;  
-//     }
+    .gu-content__main,
+    footer[role="contentinfo"] {
+      grid-column-gap: $gu-h-spacing;
+      grid-template-columns: 1fr repeat(8, 70px) 1fr;  
+    }
     
-//     header[role="banner"],
-//     footer[role="contentinfo"] {
-//       display: grid;
-//       grid-column: span 10;
-//     }
+    header[role="banner"],
+    footer[role="contentinfo"] {
+      display: grid;
+      grid-column: span 10;
+    }
 
-//     .glogo {
-//       grid-column: 9;
-//     }
+    .glogo {
+      grid-column: 9;
+    }
 
-//     .countryGroups {
-//       grid-column: 2 / 8;
-//       grid-row: 1;
-//     }
+    .countryGroups {
+      grid-column: 2 / 8;
+      grid-row: 1;
+    }
 
-//     .gu-content__content {
-//       margin: 0 -11px;
-//       grid-row: 1;
-//       grid-column: 2 / 6;
-//     }
+    .gu-content__content {
+      margin: 0 -11px;
+      grid-row: 1;
+      grid-column: 2 / 6;
+    }
 
-//     .component-footer__content {
-//       grid-column: 2 / 9;
-//     }
+    .component-footer__content {
+      grid-column: 2 / 9;
+    }
 
-//     .gu-content__bg {
-//       align-items: flex-end;
-//       display: flex;
-//       grid-column: 1 / 11;
-//       grid-row: 1;
-//       justify-content: center;
-//     }
-//   }
+    .gu-content__bg {
+      align-items: flex-end;
+      display: flex;
+      grid-column: 1 / 11;
+      grid-row: 1;
+      justify-content: center;
+    }
+  }
 
-//   @include mq($from: leftCol) {
-//     .gu-content__main,
-//     header[role="banner"],
-//     footer[role="contentinfo"] {
-//       grid-column-gap: $gu-h-spacing;
-//       grid-template-columns: 1fr repeat(14, 60px) 1fr;  
-//       width: auto;
-//     }
+  @include mq($from: leftCol) {
+    .gu-content__main,
+    header[role="banner"],
+    footer[role="contentinfo"] {
+      grid-column-gap: $gu-h-spacing;
+      grid-template-columns: 1fr repeat(14, 60px) 1fr;  
+      width: auto;
+    }
+
+    header[role="banner"],
+    footer[role="contentinfo"] {
+      grid-column: span 16;
+    }
     
-//     header[role="banner"],
-//     footer[role="contentinfo"] {
-//       grid-column: span 16;
-//     }
+    .glogo {
+      grid-column: 14;
+      justify-self: flex-end;
+    }
 
-//     .glogo {
-//       grid-column: 14;
-//       justify-self: flex-end;
-//     }
+    .gu-content__content {
+      width: auto;
+      grid-column: 4 / 8;
+    }
 
-//     .gu-content__content {
-//       width: auto;
-//       grid-column: 4 / 8;
-//     }
+    .component-footer__content {
+      grid-column: 2 / 11;
+    }
 
-//     .component-footer__content {
-//       grid-column: 2 / 11;
-//     }
+    .gu-content__bg {
+      grid-column: 1 / 17;
+    }
+  }  
 
-//     .gu-content__bg {
-//       grid-column: 1 / 17;
-//     }
-//   }  
+  @include mq($from: wide) {
+    .gu-content__main,
+    header[role="banner"],
+    footer[role="contentinfo"] {
+      grid-column-gap: $gu-h-spacing;
+      grid-template-columns: 1fr repeat(16, 60px) 1fr;  
+    }  
 
-//   @include mq($from: wide) {
-//     .gu-content__main,
-//     header[role="banner"],
-//     footer[role="contentinfo"] {
-//       grid-column-gap: $gu-h-spacing;
-//       grid-template-columns: 1fr repeat(16, 60px) 1fr;  
-//     }  
+    .glogo {
+      grid-column: 16;
+    }
 
-//     .glogo {
-//       grid-column: 16;
-//     }
+    header[role="banner"],
+    footer[role="contentinfo"] {
+        grid-column: span 18;
+    }
 
-//     header[role="banner"],
-//     footer[role="contentinfo"] {
-//         grid-column: span 18;
-//     }
+    .gu-content__content {
+      grid-column: 5 / 9;
+    }
 
-//     .gu-content__content {
-//       grid-column: 5 / 9;
-//     }
+    .component-footer__content {
+      grid-column: 2 / 12;
+    }
 
-//     .component-footer__content {
-//       grid-column: 2 / 12;
-//     }
+    .gu-content__bg {
+      grid-column: 1 / 19;
+    }
+  }
+}
 
-//     .gu-content__bg {
-//       grid-column: 1 / 19;
-//     }
-//   }
-// }
 /*= CONTENT */
 .content {
   background: gu-colour(garnett-neutral-5);

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -269,6 +269,7 @@ header[role="banner"] {
 
   .gu-content__bg {
     bottom: 0;
+    height: 580px;
     left: 0;
     position: absolute;
     width: 100%;
@@ -276,9 +277,12 @@ header[role="banner"] {
   }
   
   .gu-content__bg svg {
-    height: auto;
-    max-width: 1300px;
-    width: 100%;
+    bottom: 0;
+    height: 580px;
+    left: 50%;
+    position: absolute;
+    transform: translate(-50%,0);
+    width: 1300px;
   }
 
   .gu-content__main .svg-contributions-bg-mobile {

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -216,7 +216,7 @@ header[role="banner"] {
     flex-direction: column;
   }
 
-  .gu-content__main .svg-contributions-bg-desktop {
+  .gu-content__bg .svg-contributions-bg-desktop {
     display: none;
   }
 

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -887,27 +887,28 @@ form {
   border-radius: 100%;
   object-fit: cover;
   position: absolute;
+  left: 50%;
 }
 
 @include mq($from: mobile, $until: tablet) {
   .component-grid-image--circle-a {
     bottom: 0px;
     height: 123px;
-    left: 8px;
+    transform: translate(-162px, 0);
     width: 123px;
   }
 
   .component-grid-image--circle-b {
     bottom: 0px;
     height: 70px;
-    left: 150px;
+    transform: translate(-20px, 0);
     width: 70px;
   }
 
   .component-grid-image--circle-c {
     bottom: 0px;
     height: 178px;
-    right: -46px;
+    transform: translate(39px, 0);
     width: 178px;
   }
 }  
@@ -916,21 +917,21 @@ form {
   .component-grid-image--circle-a {
     bottom: 0;
     height: 450px;
-    right: 261px;
+    transform: translate(-78px,0);
     width: 450px;
   }
-
+  
   .component-grid-image--circle-b {
     bottom: 359px;
     height: 250px;
-    right: 124px;
+    transform: translate(258px,0);
     width: 250px;
   }
-
+  
   .component-grid-image--circle-c {
     bottom: 0px;
     height: 280px;
-    left: -59px;
+    transform: translate(-692px,0);
     width: 290px;
   }
 }

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -13,7 +13,6 @@ body {
 
 .gu-content__bg svg {
   display: block;
-  margin: 0 auto;
 }
 
 /*= HEADER */
@@ -209,15 +208,21 @@ header[role="banner"] {
   }
 
   .gu-content__bg {
-    align-items: stretch;
-    display: flex;
-    justify-content: flex-end;
-    min-height: 280px;
-    flex-direction: column;
+    height: 280px;
+    position: relative;
   }
 
   .gu-content__bg .svg-contributions-bg-desktop {
     display: none;
+  }
+  
+  .gu-content__bg .svg-contributions-bg-mobile {
+    bottom: 0;
+    height: 223px;
+    left: 50%;
+    position: absolute;
+    transform: translate(-50%,0);
+    width: 375px;
   }
 
   .countryGroups {
@@ -348,10 +353,6 @@ header[role="banner"] {
   footer[role="contentinfo"],
   .gu-content__main {
     display: grid;
-  }
-
-  .gu-content__bg {
-    position: static;
   }
 
   @include mq($from: tablet) {
@@ -868,14 +869,48 @@ form {
 }
 
 /*= Positioning background circles */
+.gu-content__bg .component-grid-image {
+  border-radius: 100%;
+  object-fit: cover;
+  position: absolute;
+}
+
+@include mq($from: mobile, $until: tablet) {
+  .component-grid-image--circle-a,
+  .component-grid-image--circle-b,
+  .component-grid-image--circle-c {
+    display: none;
+  }
+
+  .component-grid-image--circle-d {
+    bottom: 0px;
+    height: 123px;
+    left: 8px;
+    width: 123px;
+  }
+
+  .component-grid-image--circle-e {
+    bottom: 0px;
+    height: 70px;
+    left: 150px;
+    width: 70px;
+  }
+
+  .component-grid-image--circle-f {
+    bottom: 0px;
+    height: 178px;
+    right: -46px;
+    width: 178px;
+  }
+}  
 
 @include mq($from: tablet) {
-  .gu-content__bg .component-grid-image {
-    border-radius: 100%;
-    object-fit: cover;
-    position: absolute;
+  .component-grid-image--circle-d,
+  .component-grid-image--circle-e,
+  .component-grid-image--circle-f {
+    display: none;
   }
-  
+
   .component-grid-image--circle-a {
     bottom: 0;
     height: 450px;

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -414,12 +414,12 @@ header[role="banner"] {
       grid-template-columns: 1fr repeat(14, 60px) 1fr;  
       width: auto;
     }
-
+    
     header[role="banner"],
     footer[role="contentinfo"] {
       grid-column: span 16;
     }
-    
+
     .glogo {
       grid-column: 14;
       justify-self: flex-end;
@@ -865,4 +865,35 @@ form {
 .svg-newsletters {
   display: block;
   margin: ($gu-v-spacing * 2) -10px 0;
+}
+
+/*= Positioning background circles */
+
+@include mq($from: tablet) {
+  .gu-content__bg .component-grid-image {
+    border-radius: 100%;
+    object-fit: cover;
+    position: absolute;
+  }
+  
+  .component-grid-image--circle-a {
+    bottom: 0;
+    height: 450px;
+    right: 261px;
+    width: 450px;
+  }
+
+  .component-grid-image--circle-b {
+    bottom: 359px;
+    height: 250px;
+    right: 124px;
+    width: 250px;
+  }
+
+  .component-grid-image--circle-c {
+    bottom: 0px;
+    height: 280px;
+    left: -59px;
+    width: 290px;
+  }
 }

--- a/assets/pages/new-thank-you/thankYou.jsx
+++ b/assets/pages/new-thank-you/thankYou.jsx
@@ -10,6 +10,8 @@ import { renderPage } from 'helpers/render';
 import { classNameWithModifiers } from 'helpers/utilities';
 import { detect, countryGroups, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
+import GridImage from 'components/gridImage/gridImage';
+
 import Page from 'components/page/page';
 import Footer from 'components/footer/footer';
 import SvgArrowRight from 'components/svgs/arrowRightStraight';
@@ -71,6 +73,9 @@ const content = (
         </div>
       </div>
       <div className="gu-content__bg">
+        <GridImage gridId="newsroom" srcSizes={[1000, 500, 140]} classModifiers={['circle-a']} />
+        <GridImage gridId="newsroom" srcSizes={[1000, 500, 140]} classModifiers={['circle-b']} />
+        <GridImage gridId="newsroom" srcSizes={[1000, 500, 140]} classModifiers={['circle-c']} />
         <SvgContributionsBgMobile />
         <SvgContributionsBgDesktop />
       </div>

--- a/assets/pages/new-thank-you/thankYou.jsx
+++ b/assets/pages/new-thank-you/thankYou.jsx
@@ -73,9 +73,9 @@ const content = (
         </div>
       </div>
       <div className="gu-content__bg">
-        <GridImage gridId="newsroom" srcSizes={[1000, 500, 140]} classModifiers={['circle-a']} />
-        <GridImage gridId="newsroom" srcSizes={[1000, 500, 140]} classModifiers={['circle-b']} />
-        <GridImage gridId="newsroom" srcSizes={[1000, 500, 140]} classModifiers={['circle-c']} />
+        <GridImage gridId="newsroom" sizes="" srcSizes={[1000, 500, 140]} classModifiers={['circle-a']} />
+        <GridImage gridId="newsroom" sizes="" srcSizes={[1000, 500, 140]} classModifiers={['circle-b']} />
+        <GridImage gridId="newsroom" sizes="" srcSizes={[1000, 500, 140]} classModifiers={['circle-c']} />
         <SvgContributionsBgMobile />
         <SvgContributionsBgDesktop />
       </div>


### PR DESCRIPTION
## Why are you doing this?

The new design has a background with images inset into circles. We wanted these images to respect the user's device constraints, something SVG does not provide with the `image` element. There are two solutions for this:

- in CSS, using `image-set` (the syntax is similar to the `srcset` attribute)
- in HTML, using `<img srcset="...">` elements

I went for the latter because there is existing infrastructure; but ideally this should be moved into the CSS. Anyway, images are in the DOM and are set centred in the canvas, then offset either left or right using a translation.

At the moment I am using the same image all the time, but the ones provided by @Amohkhan should be inserted into the grid and used here, with appropriate sizes (the ones I used are random).

[**Trello Card**](https://trello.com/c/LZUMRF8W/815-npf-positioning-images-in-bubbles-i-cant-believe-i-wrote-that)

## Screenshots

<img width="360" alt="screen shot 2018-09-04 at 11 29 42" src="https://user-images.githubusercontent.com/629976/45026579-9e93a980-b036-11e8-9c1e-a1a29fa061b3.png">
<img width="1280" alt="screen shot 2018-09-04 at 10 57 58" src="https://user-images.githubusercontent.com/629976/45026585-a3585d80-b036-11e8-8613-9195544cd981.png">
