### PR TITLE
one-off --> single

### DIFF
--- a/app/controllers/OneOffContributions.scala
+++ b/app/controllers/OneOffContributions.scala
@@ -43,7 +43,7 @@ class OneOffContributions(
 
   private def formHtml(idUser: Option[IdUser])(implicit request: RequestHeader) =
     oneOffContributions(
-      title = "Support the Guardian | One-off Contribution",
+      title = "Support the Guardian | Single Contribution",
       id = "oneoff-contributions-page",
       js = "oneoffContributionsPage.js",
       css = "oneoffContributionsPageStyles.css",

--- a/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
+++ b/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
@@ -12,7 +12,6 @@ import TermsPrivacy from 'components/legal/termsPrivacy/termsPrivacy';
 
 import {
   getSpokenType,
-  getOneOffSpokenName,
   getFrequency,
 } from 'helpers/contributions';
 import { classNameWithModifiers } from 'helpers/utilities';
@@ -22,7 +21,6 @@ import { addQueryParamsToURL } from 'helpers/url';
 import { currencies, type IsoCurrency } from 'helpers/internationalisation/currency';
 import { type Contrib as ContributionType } from 'helpers/contributions';
 import { type Status } from 'helpers/switch';
-import { type IsoCountry } from 'helpers/internationalisation/country';
 import { type ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
@@ -33,7 +31,6 @@ type PropTypes = {
   contributionType: ContributionType,
   amount: number,
   referrerAcquisitionData: ReferrerAcquisitionData,
-  country: IsoCountry,
   countryGroupId: CountryGroupId,
   currencyId: IsoCurrency,
   isDisabled: boolean,
@@ -102,14 +99,12 @@ export default function ContributionPaymentCtas(props: PropTypes) {
 // Build the one-off payment button.
 function OneOffCta(props: {
   contributionType: ContributionType,
-  countryGroupId: CountryGroupId,
   amount: number,
   currencyId: IsoCurrency,
   isDisabled: boolean,
   resetError: void => void,
 }): Node {
 
-  const spokenType = getOneOffSpokenName(props.countryGroupId);
   const clickUrl = addQueryParamsToURL(routes.oneOffContribCheckout, {
     contributionValue: props.amount.toString(),
     contribType: props.contributionType,
@@ -119,7 +114,7 @@ function OneOffCta(props: {
   return (
     <CtaLink
       text={`Contribute ${currencies[props.currencyId].glyph}${props.amount} with card`}
-      accessibilityHint={`proceed to make your ${spokenType} contribution`}
+      accessibilityHint="proceed to make your single contribution"
       url={clickUrl}
       onClick={onCtaClick(props.isDisabled, props.resetError)}
       id="qa-contribute-button"
@@ -132,7 +127,6 @@ function OneOffCta(props: {
 // Build the regular payment button.
 function RegularCta(props: {
   contributionType: ContributionType,
-  countryGroupId: CountryGroupId,
   amount: number,
   currencyId: IsoCurrency,
   isDisabled: boolean,
@@ -141,7 +135,7 @@ function RegularCta(props: {
 }): Node {
   const recurringRoute = props.isGuestCheckout ? routes.recurringContribCheckoutGuest : routes.recurringContribCheckout;
   const frequency = getFrequency(props.contributionType);
-  const spokenType = getSpokenType(props.contributionType, props.countryGroupId);
+  const spokenType = getSpokenType(props.contributionType);
   const clickUrl = addQueryParamsToURL(recurringRoute, {
     contributionValue: props.amount.toString(),
     contribType: props.contributionType,

--- a/assets/components/contributionSelection/contributionSelection.jsx
+++ b/assets/components/contributionSelection/contributionSelection.jsx
@@ -41,8 +41,6 @@ type PropTypes = {|
   setCustomAmount: (string, CountryGroupId) => void,
   onKeyPress: Object => void,
   error: ContributionError,
-  oneOffSingleOneTimeTestVariant: 'control' | 'single' | 'once' | 'oneTime' | 'notintest',
-  usOneOffSingleOneTimeTestVariant: 'control' | 'single' | 'once' | 'oneOff' | 'notintest',
   annualTestVariant: AnnualContributionsTestVariant,
 |};
 
@@ -63,8 +61,6 @@ function ContributionSelection(props: PropTypes) {
           name="contribution-type-toggle"
           radios={getContributionTypeRadios(
             props.countryGroupId,
-            props.oneOffSingleOneTimeTestVariant,
-            props.usOneOffSingleOneTimeTestVariant,
             props.annualTestVariant,
           )}
           checked={props.contributionType}

--- a/assets/components/contributionsCheckout/contributionsCheckout.jsx
+++ b/assets/components/contributionsCheckout/contributionsCheckout.jsx
@@ -16,7 +16,6 @@ import LegalSectionContainer from 'components/legal/legalSection/legalSectionCon
 
 import { type Contrib as ContributionType } from 'helpers/contributions';
 import { type IsoCurrency } from 'helpers/internationalisation/currency';
-import { type IsoCountry } from 'helpers/internationalisation/country';
 
 
 // ----- Types ----- //
@@ -24,7 +23,6 @@ import { type IsoCountry } from 'helpers/internationalisation/country';
 type PropTypes = {
   amount: number,
   currencyId: IsoCurrency,
-  country: IsoCountry,
   contributionType: ContributionType,
   name: string,
   isSignedIn: boolean,
@@ -35,10 +33,7 @@ type PropTypes = {
 
 // ----- Functions ----- //
 
-function getTitle(
-  contributionType: ContributionType,
-  country: IsoCountry,
-): string {
+function getTitle(contributionType: ContributionType): string {
 
   switch (contributionType) {
     case 'ANNUAL':
@@ -47,7 +42,7 @@ function getTitle(
       return 'Make a monthly';
     case 'ONE_OFF':
     default:
-      return `Make a ${country === 'US' ? 'one-time' : 'one-off'}`;
+      return 'Make a single';
   }
 
 }
@@ -64,12 +59,11 @@ export default function ContributionsCheckout(props: PropTypes) {
         footer={<Footer />}
       >
         <CirclesIntroduction
-          headings={[getTitle(props.contributionType, props.country), 'contribution']}
+          headings={[getTitle(props.contributionType), 'contribution']}
           modifierClasses={['compact']}
         />
         <YourContribution
           contributionType={props.contributionType}
-          country={props.country}
           amount={props.amount}
           currencyId={props.currencyId}
         />

--- a/assets/components/yourContribution/yourContribution.jsx
+++ b/assets/components/yourContribution/yourContribution.jsx
@@ -9,7 +9,6 @@ import PaymentAmount from 'components/paymentAmount/paymentAmount';
 import Secure from 'components/secure/secure';
 
 import { type IsoCurrency } from 'helpers/internationalisation/currency';
-import { type IsoCountry } from 'helpers/internationalisation/country';
 import { type Contrib as ContributionType } from 'helpers/contributions';
 
 
@@ -17,7 +16,6 @@ import { type Contrib as ContributionType } from 'helpers/contributions';
 
 type PropTypes = {
   contributionType: ContributionType,
-  country: IsoCountry,
   amount: number,
   currencyId: IsoCurrency,
 };
@@ -25,10 +23,7 @@ type PropTypes = {
 
 // ----- Setup ----- //
 
-function getHeading(
-  contributionType: ContributionType,
-  country: IsoCountry,
-): string {
+function getHeading(contributionType: ContributionType): string {
 
   switch (contributionType) {
     case 'ANNUAL':
@@ -37,7 +32,7 @@ function getHeading(
       return 'Your monthly contribution';
     case 'ONE_OFF':
     default:
-      return `Your ${country === 'US' ? 'one-time' : 'one-off'} contribution`;
+      return 'Your single contribution';
   }
 
 }
@@ -49,7 +44,7 @@ export default function YourContribution(props: PropTypes) {
 
   return (
     <div className="component-your-contribution">
-      <PageSection heading={getHeading(props.contributionType, props.country)}>
+      <PageSection heading={getHeading(props.contributionType)}>
         <PaymentAmount
           amount={props.amount}
           currencyId={props.currencyId}

--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -38,30 +38,6 @@ export const tests: Tests = {
     independent: true,
     seed: 0,
   },
-  usOneOffOneTimeSingle: {
-    variants: ['control', 'single', 'once', 'oneOff'],
-    audiences: {
-      UnitedStates: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: true,
-    independent: true,
-    seed: 2,
-  },
-  annualContributionsRoundTwo: {
-    variants: ['control', 'annual', 'annualHigherAmounts'],
-    audiences: {
-      ALL: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: true,
-    independent: true,
-    seed: 3,
-  },
   recurringGuestCheckout: {
     variants: ['control', 'guest'],
     audiences: {

--- a/assets/helpers/contributions.js
+++ b/assets/helpers/contributions.js
@@ -368,41 +368,6 @@ function errorMessage(
 
 }
 
-function getOneOffName(
-  countryGroupId: CountryGroupId,
-  oneOffSingleOneTimeTestVariant: 'control' | 'single' | 'once' | 'oneTime' | 'notintest',
-  usOneOffSingleOneTimeTestVariant: 'control' | 'single' | 'once' | 'oneOff' | 'notintest',
-) {
-  let response = null;
-
-  const variant = oneOffSingleOneTimeTestVariant === 'notintest' ? usOneOffSingleOneTimeTestVariant : oneOffSingleOneTimeTestVariant;
-
-  switch (variant) {
-    case 'single':
-      response = 'Single';
-      break;
-    case 'once':
-      response = 'Just once';
-      break;
-    case 'oneTime':
-      response = 'One-time';
-      break;
-    case 'oneOff':
-      response = 'One-off';
-      break;
-    case 'control':
-    default:
-      response = countryGroupId === 'UnitedStates' ? 'One-time' : 'One-off';
-      break;
-  }
-
-  return response;
-}
-
-function getOneOffSpokenName(countryGroupId: CountryGroupId) {
-  return countryGroupId === 'UnitedStates' ? 'one time' : 'one off';
-}
-
 function getContributionTypeClassName(contributionType: Contrib): string {
 
   if (contributionType === 'ONE_OFF') {
@@ -415,13 +380,10 @@ function getContributionTypeClassName(contributionType: Contrib): string {
 
 }
 
-function getSpokenType(
-  contributionType: Contrib,
-  countryGroupId: CountryGroupId,
-): string {
+function getSpokenType(contributionType: Contrib): string {
 
   if (contributionType === 'ONE_OFF') {
-    return getOneOffSpokenName(countryGroupId);
+    return 'single';
   } else if (contributionType === 'ANNUAL') {
     return 'annual';
   }
@@ -456,7 +418,7 @@ function getCustomAmountA11yHint(
 
   return `Enter an amount of ${config[countryGroupId][contributionType].minInWords}
     ${spokenCurrency} or more for your 
-    ${getSpokenType(contributionType, countryGroupId)} contribution.`;
+    ${getSpokenType(contributionType)} contribution.`;
 
 }
 
@@ -469,7 +431,7 @@ function getAmountA11yHint(
   const spokenCurrency = spokenCurrencies[currencyId].plural;
 
   if (contributionType === 'ONE_OFF') {
-    return `make a one-off contribution of ${spokenAmount} ${spokenCurrency}`;
+    return `make a single contribution of ${spokenAmount} ${spokenCurrency}`;
   } else if (contributionType === 'MONTHLY') {
     return `contribute ${spokenAmount} ${spokenCurrency} a month`;
   }
@@ -480,15 +442,13 @@ function getAmountA11yHint(
 
 function getContributionTypeRadios(
   countryGroupId: CountryGroupId,
-  oneOffSingleOneTimeTestVariant: 'control' | 'single' | 'once' | 'oneTime' | 'notintest',
-  usOneOffSingleOneTimeTestVariant: 'control' | 'single' | 'once' | 'oneOff' | 'notintest',
   annualTestVariant: AnnualContributionsTestVariant,
 ) {
 
   const oneOff = {
     value: 'ONE_OFF',
-    text: getOneOffName(countryGroupId, oneOffSingleOneTimeTestVariant, usOneOffSingleOneTimeTestVariant),
-    accessibilityHint: `Make a ${getOneOffSpokenName(countryGroupId)} contribution`,
+    text: 'Single',
+    accessibilityHint: 'Make a single contribution',
     id: 'qa-one-off-toggle',
   };
   const monthly = {
@@ -535,8 +495,6 @@ export {
   getMinContribution,
   billingPeriodFromContrib,
   errorMessage,
-  getOneOffName,
-  getOneOffSpokenName,
   getContributionTypeClassName,
   getSpokenType,
   getFrequency,

--- a/assets/pages/contributions-landing/pagesVersions/horizontalLayoutLandingPage.jsx
+++ b/assets/pages/contributions-landing/pagesVersions/horizontalLayoutLandingPage.jsx
@@ -33,7 +33,7 @@ type PropTypes = {
 // ----- Internationalisation ----- //
 
 const defaultHeaderCopy = ['Help us deliver the', 'independent journalism', 'the world needs'];
-const defaultContributeCopy = 'Make a monthly commitment to support The Guardian long term or a one-off contribution as and when you feel like it – choose the option that suits you best.';
+const defaultContributeCopy = 'Make a monthly commitment to support The Guardian long term or a single contribution as and when you feel like it – choose the option that suits you best.';
 
 const countryGroupSpecificDetails: {
   [CountryGroupId]: {headerCopy: string[], contributeCopy: string}
@@ -81,7 +81,7 @@ function payPalCancelUrl(cgId: CountryGroupId): string {
 // ----- Render ----- //
 
 const HorizontalLayoutLandingPage: (PropTypes) => React.Node = (props: PropTypes) => {
-  const annualContributeCopy = 'Make a recurring commitment to support The Guardian long term or a one-off contribution as and when you feel like it – choose the option that suits you best.';
+  const annualContributeCopy = 'Make a recurring commitment to support The Guardian long term or a single contribution as and when you feel like it – choose the option that suits you best.';
   const annualTestVariant = props.store && props.store.getState().common.abParticipations.annualContributionsRoundTwo;
   const copyText = annualTestVariant === 'annual' || annualTestVariant === 'annualHigherAmounts'
     ? annualContributeCopy

--- a/assets/pages/oneoff-contributions/components/contributionsCheckoutContainer/contributionsCheckoutContainer.js
+++ b/assets/pages/oneoff-contributions/components/contributionsCheckoutContainer/contributionsCheckoutContainer.js
@@ -15,7 +15,6 @@ function mapStateToProps(state: State) {
   return {
     amount: state.page.oneoffContrib.amount,
     currencyId: state.common.internationalisation.currencyId,
-    country: state.common.internationalisation.countryId,
     name: state.page.user.displayName,
     isSignedIn: state.page.user.isSignedIn,
   };


### PR DESCRIPTION
## Why are you doing this?
To make copy consistent prior to running another copy test. 
<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/LbebbpdQ/723-change-one-off-one-time-to-single-globally-on-landing-pages)

## Changes

* Removes two ab tests: US copy test and ROW copy test.
```
oneOffSingleOneTimeTestVariant: 'control' | 'single' | 'once' | 'oneTime' | 'notintest',
usOneOffSingleOneTimeTestVariant: 'control' | 'single' | 'once' | 'oneOff' | 'notintest',
```
* Sets copy language to  'single'. NB that code still refers to 'one-off'. 

## Screenshots
@ionamckendrick 

 
![screen shot 2018-09-05 at 10 53 23](https://user-images.githubusercontent.com/8484757/45087766-ec73e480-b0fe-11e8-8ac8-8005c3a0350b.jpg)
![screen shot 2018-09-04 at 17 35 20](https://user-images.githubusercontent.com/8484757/45087768-ec73e480-b0fe-11e8-8127-a1409bf35adc.jpg)




