### PR TITLE
New payment flow: one-off strip payment

### DIFF
--- a/app/wiring/Controllers.scala
+++ b/app/wiring/Controllers.scala
@@ -13,6 +13,7 @@ trait Controllers {
     assetsResolver,
     identityService,
     controllerComponents,
+    appConfig.oneOffStripeConfigProvider,
     paymentAPIService,
     stringsConfig,
     appConfig.switches

--- a/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
@@ -97,6 +97,7 @@ function ContributionAmount(props: PropTypes) {
               min={config[props.countryGroupId][props.contributionType].min}
               max={config[props.countryGroupId][props.contributionType].max}
               autoComplete="off"
+              required
             />
             <span className="form__icon">
               <SvgDollar />

--- a/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
@@ -111,7 +111,7 @@ function ContributionAmount(props: PropTypes) {
 
 ContributionAmount.defaultProps = {
   amount: null,
-  otherAmount: null,
+  showOther: false,
 };
 
 const NewContributionAmount = connect(mapStateToProps, mapDispatchToProps)(ContributionAmount);

--- a/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
@@ -30,9 +30,9 @@ type PropTypes = {
 /* eslint-enable react/no-unused-prop-types */
 
 const mapStateToProps = state => ({
-  contributionType: state.page.contributionType,
-  amount: state.page.amount,
-  showOther: state.page.showOtherAmount,
+  contributionType: state.page.form.contributionType,
+  amount: state.page.form.amount,
+  showOther: state.page.form.showOtherAmount,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch<Action>) => ({

--- a/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -1,0 +1,118 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+import { connect } from 'react-redux';
+import type { Dispatch } from 'redux';
+
+import { countryGroupSpecificDetails } from 'helpers/internationalisation/contributions';
+import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { classNameWithModifiers } from 'helpers/utilities';
+import { type ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
+import { type OptimizeExperiments } from 'helpers/tracking/optimize';
+import { type IsoCurrency } from 'helpers/internationalisation/currency';
+import { type Participations } from 'helpers/abTests/abtest';
+import { setupStripeCheckout, openDialogBox } from 'helpers/paymentIntegrations/stripeCheckout';
+
+import SvgEnvelope from 'components/svgs/envelope';
+import SvgUser from 'components/svgs/user';
+
+import { NewContributionType } from './ContributionType';
+import { NewContributionAmount } from './ContributionAmount';
+import { NewContributionPayment } from './ContributionPayment';
+import { NewContributionState } from './ContributionState';
+import { NewContributionSubmit } from './ContributionSubmit';
+import { NewContributionTextInput } from './ContributionTextInput';
+
+import postCheckout from '../../oneoff-contributions/helpers/ajax';
+import { type State } from '../contributionsLandingReducer';
+import { type Action } from '../contributionsLandingActions';
+
+// ----- Types ----- //
+type PropTypes = {|
+  countryGroupId: CountryGroupId,
+  currency: IsoCurrency,
+  selectedCountryGroupDetails: CountryMetaData,
+  abParticipations: Participations,
+  dispatch: Dispatch<Action>,
+  referrerAcquisitionData: ReferrerAcquisitionData,
+  optimizeExperiments: OptimizeExperiments
+|};
+
+const mapStateToProps = (state: State) => ({
+  referrerAcquisitionData: state.common.referrerAcquisitionData,
+  abParticipations: state.common.abParticipations,
+  optimizeExperiments: state.common.optimizeExperiments,
+});
+
+const mapDispatchToProps = (dispatch: Dispatch<Action>) => ({
+  dispatch,
+});
+
+// ----- Event handlers ----- //
+
+const onSubmit = (props: PropTypes) => (e) => {
+  e.preventDefault();
+
+  const { elements } = e.target;
+  const amount = elements.contributionAmount === 'other' ? elements.contributionOther : elements.contributionAmount;
+  const email = elements.contributionEmail;
+
+  if (window.StripeCheckout === undefined) {
+    const firstName = elements.contributionFirstName;
+    const lastName = elements.contributionLastName;
+    const callback = postCheckout(
+      props.abParticipations,
+      props.dispatch,
+      amount,
+      props.currency,
+      props.referrerAcquisitionData,
+      () => ({ page: { user: { fullName: `${firstName} ${lastName}`, email } } }),
+      props.optimizeExperiments,
+    );
+
+    setupStripeCheckout(callback, () => {}, props.currency, false);
+  }
+
+  openDialogBox(amount, email);
+};
+
+
+// ----- Render ----- //
+
+function ContributionForm(props: PropTypes) {
+  const { countryGroupId, selectedCountryGroupDetails, currency } = props;
+  return (
+    <div className="gu-content__content">
+      <h1>{countryGroupSpecificDetails[countryGroupId].headerCopy}</h1>
+      <p className="blurb">{countryGroupSpecificDetails[countryGroupId].contributeCopy}</p>
+      <form className={classNameWithModifiers('form', ['contribution'])} onSubmit={onSubmit(props)}>
+        <NewContributionType />
+        <NewContributionAmount
+          countryGroupId={countryGroupId}
+          countryGroupDetails={selectedCountryGroupDetails}
+          currency={currency}
+        />
+        <NewContributionTextInput id="contributionFirstName" name="contribution-fname" label="First Name" icon={<SvgUser />} required />
+        <NewContributionTextInput id="contributionLastName" name="contribution-lname" label="Last Name" icon={<SvgUser />} required />
+        <NewContributionTextInput
+          id="contributionEmail"
+          name="contribution-email"
+          label="Email address"
+          type="email"
+          placeholder="example@domain.com"
+          icon={<SvgEnvelope />}
+          required
+        />
+        <NewContributionState countryGroupId={countryGroupId} />
+        <NewContributionPayment />
+        <NewContributionSubmit countryGroupId={countryGroupId} currency={currency} />
+      </form>
+    </div>
+  );
+}
+
+const NewContributionForm = connect(mapStateToProps, mapDispatchToProps)(ContributionForm);
+
+export { NewContributionForm };

--- a/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
@@ -25,9 +25,9 @@ type PropTypes = {
 
 const mapStateToProps = (state: State) =>
   ({
-    contributionType: state.page.contributionType,
-    paymentMethod: state.page.paymentMethod,
-    amount: state.page.amount,
+    contributionType: state.page.form.contributionType,
+    paymentMethod: state.page.form.paymentMethod,
+    amount: state.page.form.amount,
   });
 
 // ----- Render ----- //

--- a/assets/pages/new-contributions-landing/components/ContributionType.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionType.jsx
@@ -19,7 +19,7 @@ type PropTypes = {
 };
 
 const mapStateToProps = (state: State) => ({
-  contributionType: state.page.contributionType,
+  contributionType: state.page.form.contributionType,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch<Action>) => ({

--- a/assets/pages/new-contributions-landing/contributionsLanding.jsx
+++ b/assets/pages/new-contributions-landing/contributionsLanding.jsx
@@ -7,7 +7,6 @@ import { Provider } from 'react-redux';
 
 import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
-import { classNameWithModifiers } from 'helpers/utilities';
 import { detect, countryGroups, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { countryGroupSpecificDetails } from 'helpers/internationalisation/contributions';
 import { type IsoCurrency, detect as detectCurrency } from 'helpers/internationalisation/currency';
@@ -17,16 +16,8 @@ import Footer from 'components/footer/footer';
 import SvgContributionsBgMobile from 'components/svgs/contributionsBgMobile';
 import SvgContributionsBgDesktop from 'components/svgs/contributionsBgDesktop';
 
-import SvgEnvelope from 'components/svgs/envelope';
-import SvgUser from 'components/svgs/user';
-
 import { NewHeader } from 'components/headers/new-header/Header';
-import { NewContributionType } from './components/ContributionType';
-import { NewContributionAmount } from './components/ContributionAmount';
-import { NewContributionPayment } from './components/ContributionPayment';
-import { NewContributionState } from './components/ContributionState';
-import { NewContributionSubmit } from './components/ContributionSubmit';
-import { NewContributionTextInput } from './components/ContributionTextInput';
+import { NewContributionForm } from './components/ContributionForm';
 
 import { initReducer } from './contributionsLandingReducer';
 
@@ -52,32 +43,11 @@ const content = (
       header={<NewHeader selectedCountryGroup={selectedCountryGroup} />}
       footer={<Footer disclaimer countryGroupId={countryGroupId} />}
     >
-      <div className="gu-content__content">
-        <h1>{countryGroupSpecificDetails[countryGroupId].headerCopy}</h1>
-        <p className="blurb">{countryGroupSpecificDetails[countryGroupId].contributeCopy}</p>
-        <form action="#" method="post" className={classNameWithModifiers('form', ['contribution'])}>
-          <NewContributionType />
-          <NewContributionAmount
-            countryGroupId={countryGroupId}
-            countryGroupDetails={selectedCountryGroupDetails}
-            currency={currency}
-          />
-          <NewContributionTextInput id="contributionFirstName" name="contribution-fname" label="First Name" icon={<SvgUser />} required />
-          <NewContributionTextInput id="contributionLastName" name="contribution-lname" label="Last Name" icon={<SvgUser />} required />
-          <NewContributionTextInput
-            id="contributionEmail"
-            name="contribution-email"
-            label="Email address"
-            type="email"
-            placeholder="example@domain.com"
-            icon={<SvgEnvelope />}
-            required
-          />
-          <NewContributionState countryGroupId={countryGroupId} />
-          <NewContributionPayment />
-          <NewContributionSubmit countryGroupId={countryGroupId} currency={currency} />
-        </form>
-      </div>
+      <NewContributionForm
+        countryGroupId={countryGroupId}
+        currency={currency}
+        selectedCountryGroupDetails={selectedCountryGroupDetails}
+      />
       <div className="gu-content__bg">
         <SvgContributionsBgMobile />
         <SvgContributionsBgDesktop />

--- a/assets/pages/new-contributions-landing/contributionsLanding.jsx
+++ b/assets/pages/new-contributions-landing/contributionsLanding.jsx
@@ -10,6 +10,7 @@ import { renderPage } from 'helpers/render';
 import { detect, countryGroups, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { countryGroupSpecificDetails } from 'helpers/internationalisation/contributions';
 import { type IsoCurrency, detect as detectCurrency } from 'helpers/internationalisation/currency';
+import * as user from 'helpers/user/user';
 
 import GridImage from 'components/gridImage/gridImage';
 
@@ -29,6 +30,8 @@ const countryGroupId: CountryGroupId = detect();
 const currency: IsoCurrency = detectCurrency(countryGroupId);
 
 const store = pageInit(initReducer(countryGroupId));
+
+user.init(store.dispatch);
 
 const reactElementId = `new-contributions-landing-page-${countryGroups[countryGroupId].supportInternationalisationId}`;
 

--- a/assets/pages/new-contributions-landing/contributionsLandingReducer.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingReducer.js
@@ -2,20 +2,30 @@
 
 // ----- Imports ----- //
 
+import { combineReducers } from 'redux';
 import { type PaymentMethod } from 'helpers/checkouts';
 import { amounts, type Amount, type Contrib } from 'helpers/contributions';
 import { type CommonState } from 'helpers/page/page';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { createUserReducer, type UserState } from 'helpers/user/userReducer';
+import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
+import csrf from 'helpers/csrf/csrfReducer';
 
 import { type Action } from './contributionsLandingActions';
 
 // ----- Types ----- //
 
-type PageState = {
+type FormState = {
   contributionType: Contrib,
   paymentMethod: PaymentMethod,
   amount: Amount | null,
   showOtherAmount: boolean,
+};
+
+type PageState = {
+  form: FormState,
+  user: UserState,
+  csrf: CsrfState,
 };
 
 export type State = {
@@ -27,38 +37,46 @@ export type State = {
 
 // ----- Functions ----- //
 
+function createFormReducer(countryGroupId: CountryGroupId) {
+    const initialState: FormState = {
+      contributionType: 'ONE_OFF',
+      paymentMethod: 'PayPal',
+      amount: amounts('notintest').ONE_OFF[countryGroupId][0],
+      showOtherAmount: false,
+    };
+  
+    return function formReducer(state: FormState = initialState, action: Action): FormState {
+      switch (action.type) {
+        case 'UPDATE_CONTRIBUTION_TYPE':
+          return {
+            ...state,
+            contributionType: action.contributionType,
+            amount: amounts('notintest')[action.contributionType][countryGroupId][0],
+            showOtherAmount: false,
+          };
+  
+        case 'UPDATE_PAYMENT_METHOD':
+          return { ...state, paymentMethod: action.paymentMethod };
+  
+        case 'SELECT_AMOUNT':
+          return { ...state, amount: action.amount, showOtherAmount: false };
+  
+        case 'SELECT_OTHER_AMOUNT':
+          return { ...state, amount: null, showOtherAmount: true };
+  
+        default:
+          return state;
+      }
+    };
+}
+
 function initReducer(countryGroupId: CountryGroupId) {
 
-  const initialState: PageState = {
-    contributionType: 'ONE_OFF',
-    paymentMethod: 'PayPal',
-    amount: amounts('notintest').ONE_OFF[countryGroupId][0],
-    showOtherAmount: false,
-  };
-
-  return function reducer(state: PageState = initialState, action: Action): PageState {
-    switch (action.type) {
-      case 'UPDATE_CONTRIBUTION_TYPE':
-        return {
-          ...state,
-          contributionType: action.contributionType,
-          amount: amounts('notintest')[action.contributionType][countryGroupId][0],
-          showOtherAmount: false,
-        };
-
-      case 'UPDATE_PAYMENT_METHOD':
-        return { ...state, paymentMethod: action.paymentMethod };
-
-      case 'SELECT_AMOUNT':
-        return { ...state, amount: action.amount, showOtherAmount: false };
-
-      case 'SELECT_OTHER_AMOUNT':
-        return { ...state, amount: null, showOtherAmount: true };
-
-      default:
-        return state;
-    }
-  };
+  return combineReducers({
+    form: createFormReducer(countryGroupId),
+    user: createUserReducer(countryGroupId),
+    csrf,
+  });
 }
 
 


### PR DESCRIPTION
## Why are you doing this?

Adds the logic to wire money for single contributions via Stripe. There was some logic I could reuse from the existing code, with a few modifications. Rather than addressing these changes locally and risk a regression, I just copy-pasted the code elsewhere—I don't think it belongs there anyway. The aim is that it becomes the only logic necessary to handle payments via Stripe (single, monthly and annual included); then later a lot of code can be deleted. Ok, so what's going on here:

- I am focusing on one-off contribution via Stripe first and will generalise in a follow-up PR
- The server-side logic is updated to reflect that: at the moment, it requires the same logic as the one-off contribution code (_with_ the user data if available)
- I have updated the Redux state type so that it includes user and csrf data, although I don't have a clue yet how the latter needs to be used
- I moved the form into a bona fide component (`ContributionForm`) so that it can receive properties like any other
- I copied the content of [ajax.js](https://github.com/guardian/support-frontend/blob/master/assets/pages/oneoff-contributions/helpers/ajax.js) into [stripeCheckout.js](https://github.com/guardian/support-frontend/blob/master/assets/pages/oneoff-contributions/helpers/ajax.js) with a few modifications that make it a little bit more decoupled—they are documented in situ.

I expect some more refactoring when I tackle recurring contributions with Stripe. In particular, all the pre-/post- logic should be moved into its own set of helpers, it should be independent of any payment method.

TODO
- [ ] use csrf properly
- [ ] add routing logic for switching between the form and the thank you page
- [ ] write `onSuccess` logic
- [ ] write `onError` logic

[**Trello Card**](https://trello.com/c/U5Uu58QI/715-npf-stripe-one-off)
