### PR TITLE
fix logging for stripe payments

### DIFF
--- a/assets/pages/oneoff-contributions/helpers/ajax.js
+++ b/assets/pages/oneoff-contributions/helpers/ajax.js
@@ -93,21 +93,21 @@ function postToEndpoint(request: Object, dispatch: Function, abParticipations: P
     }
     return response.json();
   }).then((data) => {
-      if (!(data.type === 'success')) {
-          if (data.type === 'error') {
-              const {error: {exceptionType = 'Unknown', responseCode = 0, errorName = 'Unknown'}} = data;
-              if (exceptionType === 'CardException') {
-                  dispatch(checkoutError('Your card has been declined.'));
-              } else {
-                  logException(`Stripe payment attempt failed with following error: code: ${responseCode} type: ${exceptionType} error-name: ${errorName}.`);
-                  dispatch(checkoutError('There was an error processing your payment. Please\u00a0try\u00a0again\u00a0later.'));
-              }
-          } else {
-              logException(`Stripe payment attempt failed with unexpected error while attempting to process payment response ${data.text()}`);
-              dispatch(checkoutError('There was an error processing your payment. Please\u00a0try\u00a0again\u00a0later.'));
-          }
+    if (!(data.type === 'success')) {
+      if (data.type === 'error') {
+        const { error: { exceptionType = 'Unknown', responseCode = 0, errorName = 'Unknown' } } = data;
+        if (exceptionType === 'CardException') {
+          dispatch(checkoutError('Your card has been declined.'));
+        } else {
+          logException(`Stripe payment attempt failed with following error: code: ${responseCode} type: ${exceptionType} error-name: ${errorName}.`);
+          dispatch(checkoutError('There was an error processing your payment. Please\u00a0try\u00a0again\u00a0later.'));
+        }
+      } else {
+        logException(`Stripe payment attempt failed with unexpected error while attempting to process payment response ${data.text()}`);
+        dispatch(checkoutError('There was an error processing your payment. Please\u00a0try\u00a0again\u00a0later.'));
       }
-  })
+    }
+  });
 }
 
 export default function postCheckout(

--- a/assets/pages/oneoff-contributions/helpers/ajax.js
+++ b/assets/pages/oneoff-contributions/helpers/ajax.js
@@ -92,18 +92,18 @@ function postToEndpoint(request: Object, dispatch: Function, abParticipations: P
       dispatch(checkoutSuccess());
     }
     return response.json();
-  }).then((responseJson) => {
-    if (responseJson.error.exceptionType === 'CardException') {
-      dispatch(checkoutError('Your card has been declined.'));
-    } else {
-      const errorHttpCode = responseJson.error.errorCode || 'unknown';
-      const exceptionType = responseJson.error.exceptionType || 'unknown';
-      const errorName = responseJson.error.errorName || 'unknown';
-      logException(`Stripe payment attempt failed with following error: code: ${errorHttpCode} type: ${exceptionType} error-name: ${errorName}.`);
-      dispatch(checkoutError('There was an error processing your payment. Please\u00a0try\u00a0again\u00a0later.'));
+  }).then((data) => {
+    if (data.type === 'error') {
+      const { error: { exceptionType, responseCode, errorName = 'Unknown' } } = data;
+      if (exceptionType === 'CardException') {
+        dispatch(checkoutError('Your card has been declined.'));
+      } else {
+        logException(`Stripe payment attempt failed with following error: code: ${responseCode} type: ${exceptionType} error-name: ${errorName}.`);
+        dispatch(checkoutError('There was an error processing your payment. Please\u00a0try\u00a0again\u00a0later.'));
+      }
     }
-  }).catch(() => {
-    logException('Stripe payment attempt failed with unexpected error while attempting to process payment response');
+  }).catch((err) => {
+    logException(`Stripe payment attempt failed with unexpected error while attempting to process payment response ${err}`);
     dispatch(checkoutError('There was an error processing your payment. Please\u00a0try\u00a0again\u00a0later.'));
   });
 }

--- a/assets/pages/oneoff-contributions/helpers/ajax.js
+++ b/assets/pages/oneoff-contributions/helpers/ajax.js
@@ -93,19 +93,21 @@ function postToEndpoint(request: Object, dispatch: Function, abParticipations: P
     }
     return response.json();
   }).then((data) => {
-    if (data.type === 'error') {
-      const { error: { exceptionType, responseCode, errorName = 'Unknown' } } = data;
-      if (exceptionType === 'CardException') {
-        dispatch(checkoutError('Your card has been declined.'));
-      } else {
-        logException(`Stripe payment attempt failed with following error: code: ${responseCode} type: ${exceptionType} error-name: ${errorName}.`);
-        dispatch(checkoutError('There was an error processing your payment. Please\u00a0try\u00a0again\u00a0later.'));
+      if (!(data.type === 'success')) {
+          if (data.type === 'error') {
+              const {error: {exceptionType = 'Unknown', responseCode = 0, errorName = 'Unknown'}} = data;
+              if (exceptionType === 'CardException') {
+                  dispatch(checkoutError('Your card has been declined.'));
+              } else {
+                  logException(`Stripe payment attempt failed with following error: code: ${responseCode} type: ${exceptionType} error-name: ${errorName}.`);
+                  dispatch(checkoutError('There was an error processing your payment. Please\u00a0try\u00a0again\u00a0later.'));
+              }
+          } else {
+              logException(`Stripe payment attempt failed with unexpected error while attempting to process payment response ${data.text()}`);
+              dispatch(checkoutError('There was an error processing your payment. Please\u00a0try\u00a0again\u00a0later.'));
+          }
       }
-    }
-  }).catch((err) => {
-    logException(`Stripe payment attempt failed with unexpected error while attempting to process payment response ${err}`);
-    dispatch(checkoutError('There was an error processing your payment. Please\u00a0try\u00a0again\u00a0later.'));
-  });
+  })
 }
 
 export default function postCheckout(


### PR DESCRIPTION
Currently we are getting a spurious error after payment success in the dev-tools console and in Sentry
 (Note: the user is taken to the thank-you page regardless and this error is not visible to the user unless they have their debugging tools open).
This change will stop us sending that error and also fix up the error handling so it is firing and logging correctly