### PR TITLE
New Payment Flow: payment method and state

### DIFF
--- a/assets/pages/new-contributions-landing/components/ContributionPayment.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionPayment.jsx
@@ -4,6 +4,7 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
+import { type Dispatch } from 'redux';
 
 import { type PaymentMethod } from 'helpers/checkouts';
 import { classNameWithModifiers } from 'helpers/utilities';
@@ -12,6 +13,7 @@ import SvgNewCreditCard from 'components/svgs/newCreditCard';
 import SvgPayPal from 'components/svgs/paypal';
 
 import { type State } from '../contributionsLandingReducer';
+import { type Action, updatePaymentMethod } from '../contributionsLandingActions';
 
 // ----- Types ----- //
 
@@ -19,9 +21,13 @@ type PropTypes = {
   paymentMethod: PaymentMethod,
 };
 
-const mapStateToProps: State => PropTypes = () => ({
+const mapStateToProps = (state: State) => ({
   paymentMethod: state.page.paymentMethod,
 });
+
+const mapDispatchToProps = {
+  updatePaymentMethod
+};
 
 // ----- Render ----- //
 
@@ -37,7 +43,8 @@ function ContributionPayment(props: PropTypes) {
             className="form__radio-group-input"
             name="contributionPayment"
             type="radio"
-            value="card"
+            value="Stripe"
+            onChange={() => props.updatePaymentMethod('Stripe')}
             checked={props.paymentMethod !== 'PayPal'}
           />
           <label htmlFor="contributionPayment-card" className="form__radio-group-label">
@@ -52,7 +59,8 @@ function ContributionPayment(props: PropTypes) {
             className="form__radio-group-input"
             name="contributionPayment"
             type="radio"
-            value="paypal"
+            value="PayPal"
+            onChange={() => props.updatePaymentMethod('PayPal')}
             checked={props.paymentMethod === 'PayPal'}
           />
           <label htmlFor="contributionPayment-paypal" className="form__radio-group-label">
@@ -66,6 +74,6 @@ function ContributionPayment(props: PropTypes) {
   );
 }
 
-const NewContributionPayment = connect(mapStateToProps)(ContributionPayment);
+const NewContributionPayment = connect(mapStateToProps, mapDispatchToProps)(ContributionPayment);
 
 export { NewContributionPayment };

--- a/assets/pages/new-contributions-landing/components/ContributionPayment.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionPayment.jsx
@@ -20,7 +20,7 @@ type PropTypes = {
 };
 
 const mapStateToProps: State => PropTypes = () => ({
-  paymentMethod: 'PayPal',
+  paymentMethod: state.page.paymentMethod,
 });
 
 // ----- Render ----- //

--- a/assets/pages/new-contributions-landing/components/ContributionPayment.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionPayment.jsx
@@ -4,7 +4,6 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
-import { type Dispatch } from 'redux';
 
 import { type PaymentMethod } from 'helpers/checkouts';
 import { classNameWithModifiers } from 'helpers/utilities';
@@ -13,12 +12,13 @@ import SvgNewCreditCard from 'components/svgs/newCreditCard';
 import SvgPayPal from 'components/svgs/paypal';
 
 import { type State } from '../contributionsLandingReducer';
-import { type Action, updatePaymentMethod } from '../contributionsLandingActions';
+import { updatePaymentMethod } from '../contributionsLandingActions';
 
 // ----- Types ----- //
 
 type PropTypes = {
   paymentMethod: PaymentMethod,
+  updatePaymentMethod: PaymentMethod => void,
 };
 
 const mapStateToProps = (state: State) => ({
@@ -26,7 +26,7 @@ const mapStateToProps = (state: State) => ({
 });
 
 const mapDispatchToProps = {
-  updatePaymentMethod
+  updatePaymentMethod,
 };
 
 // ----- Render ----- //

--- a/assets/pages/new-contributions-landing/components/ContributionPayment.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionPayment.jsx
@@ -33,21 +33,6 @@ function ContributionPayment(props: PropTypes) {
       <ul className="form__radio-group-list">
         <li className="form__radio-group-item">
           <input
-            id="contributionPayment-paypal"
-            className="form__radio-group-input"
-            name="contributionPayment"
-            type="radio"
-            value="paypal"
-            checked={props.paymentMethod === 'PayPal'}
-          />
-          <label htmlFor="contributionPayment-paypal" className="form__radio-group-label">
-            <span className="radio-ui" />
-            <span className="radio-ui__label">PayPal</span>
-            <SvgPayPal />
-          </label>
-        </li>
-        <li className="form__radio-group-item">
-          <input
             id="contributionPayment-card"
             className="form__radio-group-input"
             name="contributionPayment"
@@ -59,6 +44,21 @@ function ContributionPayment(props: PropTypes) {
             <span className="radio-ui" />
             <span className="radio-ui__label">Credit/Debit Card</span>
             <SvgNewCreditCard />
+          </label>
+        </li>
+        <li className="form__radio-group-item">
+          <input
+            id="contributionPayment-paypal"
+            className="form__radio-group-input"
+            name="contributionPayment"
+            type="radio"
+            value="paypal"
+            checked={props.paymentMethod === 'PayPal'}
+          />
+          <label htmlFor="contributionPayment-paypal" className="form__radio-group-label">
+            <span className="radio-ui" />
+            <span className="radio-ui__label">PayPal</span>
+            <SvgPayPal />
           </label>
         </li>
       </ul>

--- a/assets/pages/new-contributions-landing/components/ContributionPayment.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionPayment.jsx
@@ -12,13 +12,13 @@ import SvgNewCreditCard from 'components/svgs/newCreditCard';
 import SvgPayPal from 'components/svgs/paypal';
 
 import { type State } from '../contributionsLandingReducer';
-import { updatePaymentMethod } from '../contributionsLandingActions';
+import { type Action, updatePaymentMethod } from '../contributionsLandingActions';
 
 // ----- Types ----- //
 
 type PropTypes = {
   paymentMethod: PaymentMethod,
-  updatePaymentMethod: PaymentMethod => void,
+  updatePaymentMethod: PaymentMethod => Action,
 };
 
 const mapStateToProps = (state: State) => ({

--- a/assets/pages/new-contributions-landing/components/ContributionState.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionState.jsx
@@ -9,7 +9,6 @@ import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { classNameWithModifiers } from 'helpers/utilities';
 
 import SvgGlobe from 'components/svgs/globe';
-import { type State } from '../contributionsLandingReducer';
 
 // ----- Types ----- //
 type PropTypes = {
@@ -19,10 +18,10 @@ type PropTypes = {
 // ----- Render ----- //
 
 const renderState = ([stateValue, stateName]: [string, string]) => (
-  <option value="{stateValue}">{stateName}</option>
+  <option value={stateValue}>{stateName}</option>
 );
 
-const renderStatesField = (states) => (
+const renderStatesField = states => (
   <div className={classNameWithModifiers('form__field', ['contribution-state'])}>
     <label className="form__label" htmlFor="contributionState">State</label>
     <span className="form__input-with-icon">

--- a/assets/pages/new-contributions-landing/components/ContributionState.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionState.jsx
@@ -3,7 +3,6 @@
 // ----- Imports ----- //
 
 import React from 'react';
-import { connect } from 'react-redux';
 
 import { usStates, caStates } from 'helpers/internationalisation/country';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
@@ -15,27 +14,21 @@ import { type State } from '../contributionsLandingReducer';
 // ----- Types ----- //
 type PropTypes = {
   countryGroupId: CountryGroupId,
-  selectedState: string,
 };
-
-const mapStateToProps: State => PropTypes = () => ({
-  countryGroupId: 'UnitedStates',
-  selectedState: 'WY',
-});
 
 // ----- Render ----- //
 
-const renderState = (selectedState: string) => ([stateValue, stateName]: [string, string]) => (
-  <option value="{stateValue}" selected={stateValue === selectedState}>{stateName}</option>
+const renderState = ([stateValue, stateName]: [string, string]) => (
+  <option value="{stateValue}">{stateName}</option>
 );
 
-const renderStatesField = (selectedState, states) => (
+const renderStatesField = (states) => (
   <div className={classNameWithModifiers('form__field', ['contribution-state'])}>
     <label className="form__label" htmlFor="contributionState">State</label>
     <span className="form__input-with-icon">
       <select id="contributionState" className="form__input" placeholder="State" required>
         <option />
-        {(Object.entries(states): any).map(renderState(selectedState))}
+        {(Object.entries(states): any).map(renderState)}
       </select>
       <span className="form__icon">
         <SvgGlobe />
@@ -44,17 +37,15 @@ const renderStatesField = (selectedState, states) => (
   </div>
 );
 
-function ContributionState(props: PropTypes) {
+function NewContributionState(props: PropTypes) {
   switch (props.countryGroupId) {
     case 'UnitedStates':
-      return renderStatesField(props.selectedState, usStates);
+      return renderStatesField(usStates);
     case 'Canada':
-      return renderStatesField(props.selectedState, caStates);
+      return renderStatesField(caStates);
     default:
       return null;
   }
 }
-
-const NewContributionState = connect(mapStateToProps)(ContributionState);
 
 export { NewContributionState };

--- a/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
@@ -34,6 +34,8 @@ const mapStateToProps = (state: State) =>
 
 
 function ContributionSubmit(props: PropTypes) {
+  const freq = getFrequency(props.contributionType);
+
   return (
     <div className="form__submit">
       <button className="form__submit-button" type="submit">
@@ -43,8 +45,8 @@ function ContributionSubmit(props: PropTypes) {
           spokenCurrencies[props.currency],
           props.amount,
           false,
-        ) : null}
-        {getFrequency(props.contributionType)}&nbsp;
+        ) : null}&nbsp;
+        {freq ? `${freq} ` : null}
         {getPaymentDescription(props.contributionType, props.paymentMethod)}&nbsp;
         <SvgArrowRight />
       </button>

--- a/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
@@ -34,7 +34,7 @@ const mapStateToProps = (state: State) =>
 
 
 function ContributionSubmit(props: PropTypes) {
-  const freq = getFrequency(props.contributionType);
+  const frequency = getFrequency(props.contributionType);
 
   return (
     <div className="form__submit">
@@ -46,7 +46,7 @@ function ContributionSubmit(props: PropTypes) {
           props.amount,
           false,
         ) : null}&nbsp;
-        {freq ? `${freq} ` : null}
+        {frequency ? `${frequency} ` : null}
         {getPaymentDescription(props.contributionType, props.paymentMethod)}&nbsp;
         <SvgArrowRight />
       </button>

--- a/assets/pages/new-contributions-landing/components/ContributionType.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionType.jsx
@@ -15,7 +15,7 @@ import { type Action, updateContributionType } from '../contributionsLandingActi
 
 type PropTypes = {
   contributionType: Contrib,
-  onSelectContributionType: Event => void,
+  onSelectContributionType: Event => Action,
 };
 
 const mapStateToProps = (state: State) => ({

--- a/assets/pages/new-contributions-landing/contributionsLandingReducer.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingReducer.js
@@ -31,7 +31,7 @@ function initReducer(countryGroupId: CountryGroupId) {
 
   const initialState: PageState = {
     contributionType: 'ONE_OFF',
-    paymentMethod: 'PayPal',
+    paymentMethod: 'Stripe',
     amount: amounts('notintest').ONE_OFF[countryGroupId][0],
     showOtherAmount: false,
   };


### PR DESCRIPTION
## Why are you doing this?

I had delayed dealing with this until now, thinking it would require substantial changes, but I was wrong 😆 

- @ionamckendrick asked me to reverse the order of payment methods in anticipation of the paypal button change and set the default method to Stripe
- there is no need to store the selected state outside of the form itself

[**Trello Card**](https://trello.com/c/5oregpb2/833-npf-state-and-payment-method-selection)
