### PR TITLE
Wrap switches in settings

### DIFF
--- a/app/admin/Group.scala
+++ b/app/admin/Group.scala
@@ -1,4 +1,4 @@
-package switchboard
+package admin
 
 sealed abstract class Group(val name: String)
 object Group {

--- a/app/admin/Segment.scala
+++ b/app/admin/Segment.scala
@@ -1,4 +1,4 @@
-package switchboard
+package admin
 
 import com.typesafe.config.Config
 

--- a/app/admin/Settings.scala
+++ b/app/admin/Settings.scala
@@ -1,4 +1,4 @@
-package switchboard
+package admin
 
 import com.typesafe.config.Config
 import collection.JavaConverters._
@@ -12,14 +12,20 @@ case class Switches(
     internationalSubscribePages: SwitchState
 )
 
-object Switches {
-  def fromConfig(config: Config): Switches =
-    Switches(
-      PaymentMethodsSwitch.fromConfig(config.getConfig("oneOff")),
-      PaymentMethodsSwitch.fromConfig(config.getConfig("recurring")),
-      experimentsFromConfig(config, "abtests"),
-      SwitchState.fromConfig(config, "optimize"),
-      SwitchState.fromConfig(config, "internationalSubscribePages")
+case class Settings(
+    switches: Switches
+)
+
+object Settings {
+  def fromConfig(config: Config): Settings =
+    Settings(
+      Switches(
+        PaymentMethodsSwitch.fromConfig(config.getConfig("oneOff")),
+        PaymentMethodsSwitch.fromConfig(config.getConfig("recurring")),
+        experimentsFromConfig(config, "abtests"),
+        SwitchState.fromConfig(config, "optimize"),
+        SwitchState.fromConfig(config, "internationalSubscribePages")
+      )
     )
 
   def experimentsFromConfig(config: Config, rootKey: String): Map[String, ExperimentSwitch] =

--- a/app/codecs/CirceDecoders.scala
+++ b/app/codecs/CirceDecoders.scala
@@ -17,8 +17,8 @@ import com.gu.fezziwig.CirceScroogeMacros.{decodeThriftEnum, decodeThriftStruct,
 import com.gu.support.workers.model.CheckoutFailureReasons.CheckoutFailureReason
 import ophan.thrift.componentEvent.ComponentType
 import services.stepfunctions.StatusResponse
-import switchboard.{PaymentMethodsSwitch, ExperimentSwitch, Group, Segment, SwitchState, Switches}
-import services.{PaymentApiError, PayPalError}
+import admin._
+import services.{PayPalError, PaymentApiError}
 
 object CirceDecoders {
 
@@ -105,6 +105,7 @@ object CirceDecoders {
   implicit val segmentDecoder: Decoder[Segment] = deriveDecoder
   implicit val experimentSwitchCodec: Codec[ExperimentSwitch] = deriveCodec
   implicit val switchesCodec: Codec[Switches] = deriveCodec
+  implicit val settingsCodec: Codec[Settings] = deriveCodec
 
   implicit val statusEncoder: Encoder[StatusResponse] = deriveEncoder
   implicit val decodeFailureReason: Decoder[CheckoutFailureReason] = Decoder.decodeString.emap {

--- a/app/config/Configuration.scala
+++ b/app/config/Configuration.scala
@@ -6,7 +6,7 @@ import config.ConfigImplicits._
 import services.GoCardlessConfigProvider
 import services.aws.AwsConfig
 import services.stepfunctions.StateMachineArn
-import switchboard.Switches
+import admin.Settings
 
 class Configuration {
   val config = ConfigFactory.load()
@@ -39,6 +39,6 @@ class Configuration {
 
   lazy val stepFunctionArn = StateMachineArn.fromString(config.getString("supportWorkers.arn")).get
 
-  implicit val switches = Switches.fromConfig(config.getConfig("switches"))
+  implicit val settings = Settings.fromConfig(config.getConfig("switches"))
 
 }

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -6,7 +6,7 @@ import com.gu.i18n.CountryGroup._
 import config.StringsConfig
 import play.api.mvc._
 import services.{IdentityService, PaymentAPIService}
-import switchboard.Switches
+import admin.Settings
 import utils.BrowserCheck
 import utils.RequestCountry._
 import scala.concurrent.ExecutionContext
@@ -19,13 +19,13 @@ class Application(
     components: ControllerComponents,
     paymentAPIService: PaymentAPIService,
     stringsConfig: StringsConfig,
-    switches: Switches
+    settings: Settings
 )(implicit val ec: ExecutionContext) extends AbstractController(components) {
 
   import actionRefiners._
 
   implicit val ar = assets
-  implicit val sw = switches
+  implicit val sw = settings
 
   def contributionsRedirect(): Action[AnyContent] = CachedAction() {
     Ok(views.html.contributionsRedirect())

--- a/app/controllers/OneOffContributions.scala
+++ b/app/controllers/OneOffContributions.scala
@@ -15,24 +15,24 @@ import com.gu.identity.play.{AuthenticatedIdUser, IdUser}
 import models.Autofill
 import io.circe.syntax._
 import play.twirl.api.Html
-import switchboard.Switches
+import admin.Settings
 
 class OneOffContributions(
-    val assets: AssetsResolver,
-    actionRefiners: CustomActionBuilders,
-    identityService: IdentityService,
-    testUsers: TestUserService,
-    stripeConfigProvider: StripeConfigProvider,
-    paymentAPIService: PaymentAPIService,
-    authAction: AuthAction[AnyContent],
-    components: ControllerComponents,
-    switches: Switches
+  val assets: AssetsResolver,
+  actionRefiners: CustomActionBuilders,
+  identityService: IdentityService,
+  testUsers: TestUserService,
+  stripeConfigProvider: StripeConfigProvider,
+  paymentAPIService: PaymentAPIService,
+  authAction: AuthAction[AnyContent],
+  components: ControllerComponents,
+  settings: Settings
 )(implicit val exec: ExecutionContext) extends AbstractController(components) with Circe {
 
   import actionRefiners._
 
   implicit val ar = assets
-  implicit val sw = switches
+  implicit val st = settings
 
   def autofill: Action[AnyContent] = authenticatedAction().async { implicit request =>
     identityService.getUser(request.user).fold(

--- a/app/controllers/PayPalOneOff.scala
+++ b/app/controllers/PayPalOneOff.scala
@@ -12,7 +12,7 @@ import play.api.libs.json.{JsObject, JsString, JsValue, Json}
 import play.api.mvc._
 import services.PaymentAPIService.Email
 import services.{IdentityService, PaymentAPIService, TestUserService}
-import switchboard.Switches
+import admin.Settings
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
@@ -24,13 +24,13 @@ class PayPalOneOff(
     components: ControllerComponents,
     paymentAPIService: PaymentAPIService,
     identityService: IdentityService,
-    switches: Switches
+    settings: Settings
 )(implicit val ec: ExecutionContext) extends AbstractController(components) with Circe {
 
   import actionBuilders._
 
   implicit val assetsResolver = assets
-  implicit val sw = switches
+  implicit val sw = settings
 
   def resultFromEmailOption(email: Option[Email]): Result = {
     val redirect = Redirect("/contribute/one-off/thankyou")

--- a/app/controllers/PayPalRegular.scala
+++ b/app/controllers/PayPalRegular.scala
@@ -11,7 +11,7 @@ import play.api.mvc._
 import services.paypal.PayPalBillingDetails.codec
 import services.paypal.{PayPalBillingDetails, PayPalNvpServiceProvider, Token}
 import services.{PayPalNvpService, TestUserService}
-import switchboard.Switches
+import admin.Settings
 
 import scala.concurrent.ExecutionContext
 
@@ -21,13 +21,13 @@ class PayPalRegular(
     payPalNvpServiceProvider: PayPalNvpServiceProvider,
     testUsers: TestUserService,
     components: ControllerComponents,
-    switches: Switches
+    settings: Settings
 )(implicit val ec: ExecutionContext) extends AbstractController(components) with Circe {
 
   import actionBuilders._
 
   implicit val assetsResolver = assets
-  implicit val sw = switches
+  implicit val st = settings
 
   // Sets up a payment by contacting PayPal, returns the token as JSON.
   def setupPayment: Action[PayPalBillingDetails] = maybeAuthenticatedAction().async(circe.json[PayPalBillingDetails]) { implicit request =>

--- a/app/controllers/RegularContributions.scala
+++ b/app/controllers/RegularContributions.scala
@@ -18,7 +18,7 @@ import play.api.mvc._
 import services.MembersDataService.UserNotFound
 import services.stepfunctions.{CreateRegularContributorRequest, RegularContributionsClient}
 import services.{IdentityService, MembersDataService, TestUserService}
-import switchboard.Switches
+import admin.Settings
 import views.html.recurringContributions
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -33,14 +33,14 @@ class RegularContributions(
     stripeConfigProvider: StripeConfigProvider,
     payPalConfigProvider: PayPalConfigProvider,
     components: ControllerComponents,
-    switches: Switches,
+    settings: Settings,
     guardianDomain: String
 )(implicit val exec: ExecutionContext) extends AbstractController(components) with Circe {
 
   import actionRefiners._
 
   implicit val ar = assets
-  implicit val sw = switches
+  implicit val st = settings
 
   def monthlyContributionsPage(maybeUser: Option[IdUser], uatMode: Boolean)(implicit request: WrappedRequest[AnyContent]): Result =
     Ok(recurringContributions(

--- a/app/controllers/Subscriptions.scala
+++ b/app/controllers/Subscriptions.scala
@@ -6,7 +6,7 @@ import com.gu.i18n.CountryGroup._
 import com.typesafe.scalalogging.LazyLogging
 import config.StringsConfig
 import play.api.mvc._
-import switchboard.{SwitchState, Switches}
+import admin.{SwitchState, Settings}
 import utils.RequestCountry._
 
 import scala.concurrent.ExecutionContext
@@ -16,13 +16,13 @@ class Subscriptions(
     val assets: AssetsResolver,
     components: ControllerComponents,
     stringsConfig: StringsConfig,
-    switches: Switches
+    settings: Settings
 )(implicit val ec: ExecutionContext) extends AbstractController(components) with LazyLogging {
 
   import actionRefiners._
 
   implicit val ar = assets
-  implicit val sw = switches
+  implicit val st = settings
 
   def geoRedirect: Action[AnyContent] = GeoTargetedCachedAction() { implicit request =>
     val redirectUrl = request.fastlyCountry match {
@@ -42,7 +42,7 @@ class Subscriptions(
   }
 
   def landing(countryCode: String): Action[AnyContent] = CachedAction() { implicit request =>
-    if (switches.internationalSubscribePages == SwitchState.Off && countryCode.toLowerCase != "uk") {
+    if (settings.switches.internationalSubscribePages == SwitchState.Off && countryCode.toLowerCase != "uk") {
       Redirect(controllers.routes.Subscriptions.geoRedirect())
     } else {
       val title = "Support the Guardian | Get a Subscription"

--- a/app/lib/CustomHttpErrorHandler.scala
+++ b/app/lib/CustomHttpErrorHandler.scala
@@ -12,7 +12,7 @@ import play.api.mvc.Results.{InternalServerError, NotFound}
 import assets.AssetsResolver
 import views.html.main
 import play.core.SourceMapper
-import switchboard.Switches
+import admin.Settings
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
@@ -23,7 +23,7 @@ class CustomHttpErrorHandler(
     sourceMapper: Option[SourceMapper],
     router: => Option[Router],
     val assets: AssetsResolver,
-    switches: Switches
+    settings: Settings
 )(implicit val ec: ExecutionContext) extends DefaultHttpErrorHandler(env, config, sourceMapper, router) with LazyLogging {
 
   override def onClientError(request: RequestHeader, statusCode: Int, message: String = ""): Future[Result] =
@@ -31,14 +31,14 @@ class CustomHttpErrorHandler(
 
   override protected def onNotFound(request: RequestHeader, message: String): Future[Result] =
     Future.successful(
-      NotFound(main("Error 404", "error-404-page", "error404Page.js", "errorPageStyles.css")(assets, request, switches))
+      NotFound(main("Error 404", "error-404-page", "error404Page.js", "errorPageStyles.css")(assets, request, settings))
         .withHeaders(CacheControl.defaultCacheHeaders(30.seconds, 30.seconds): _*)
     )
 
   override protected def onProdServerError(request: RequestHeader, exception: UsefulException): Future[Result] = {
     logServerError(request, exception)
     Future.successful(
-      InternalServerError(main("Error 500", "error-500-page", "error500Page.js", "errorPageStyles.css")(assets, request, switches))
+      InternalServerError(main("Error 500", "error-500-page", "error500Page.js", "errorPageStyles.css")(assets, request, settings))
         .withHeaders(CacheControl.noCache)
     )
   }

--- a/app/views/ViewHelpers.scala
+++ b/app/views/ViewHelpers.scala
@@ -1,15 +1,15 @@
 package views
 
 import play.api.mvc.RequestHeader
-import switchboard.Switches
+import admin.Settings
 import codecs.CirceDecoders._
 import io.circe.Printer
 import io.circe.syntax._
 
 object ViewHelpers {
   def doNotTrack(implicit request: RequestHeader): Boolean = request.headers.get("DNT").contains("1")
-  def printSwitches(switches: Switches): String =
-    switches
+  def printSettings(settings: Settings): String =
+    settings
       .asJson
       .pretty(Printer.spaces2.copy(dropNullValues = true))
 }

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -1,6 +1,6 @@
 @import assets.AssetsResolver
 @import views.ViewHelpers._
-@import switchboard.Switches
+@import admin.Settings
 @(
 	title: String,
 	mainId: String,
@@ -9,7 +9,7 @@
 	description: Option[String] = None,
 	styles: Html = Html(""),
 	scripts: Html = Html("")
-)(implicit assets: AssetsResolver, request: RequestHeader, switches: Switches)
+)(implicit assets: AssetsResolver, request: RequestHeader, settings: Settings)
 
 <!DOCTYPE html>
 <html lang="en">
@@ -23,7 +23,7 @@
 		<meta property="og:description" content="@description" />
 	}
 
-	@switchesScript(switches)
+	@(settings)
 
 	<title>@title</title>
 	<meta property="og:title" content="@title"/>

--- a/app/views/oneOffContributions.scala.html
+++ b/app/views/oneOffContributions.scala.html
@@ -3,7 +3,7 @@
 @import com.gu.support.config.StripeConfig
 @import helper.CSRF
 @import com.gu.i18n.Currency.AUD
-@import switchboard.Switches
+@import admin.Settings
 @(
         title: String,
         id: String,
@@ -14,7 +14,7 @@
         paymentApiStripeEndpoint: String,
         paymentApiPayPalEndpoint: String,
         idUser: Option[IdUser]
-)(implicit assets: AssetsResolver, request: RequestHeader, switches: Switches)
+)(implicit assets: AssetsResolver, request: RequestHeader, settings: Settings)
 
 @scripts = {
     <script type="text/javascript">

--- a/app/views/optimizeScript.scala.html
+++ b/app/views/optimizeScript.scala.html
@@ -1,8 +1,8 @@
 @import assets.AssetsResolver
-@import switchboard.Switches
-@import switchboard.SwitchState
-@()(implicit assets: AssetsResolver, switches: Switches)
-@if(switches.optimize == SwitchState.On) {
+@import admin.Settings
+@import admin.SwitchState
+@()(implicit assets: AssetsResolver, settings: Settings)
+@if(settings.switches.optimize == SwitchState.On) {
     <!--- Optimize scripts, see: https://support.google.com/optimize/answer/7359264 -->
     <!-- Page-hiding snippet -->
     <style>.async-hide {

--- a/app/views/recurringContributions.scala.html
+++ b/app/views/recurringContributions.scala.html
@@ -4,7 +4,7 @@
 @import helper.CSRF
 
 @import com.gu.i18n.Currency.AUD
-@import switchboard.Switches
+@import admin.Settings
 @(
   title: String,
   id: String,
@@ -15,7 +15,7 @@
   defaultStripeConfig: StripeConfig,
   uatStripeConfig: StripeConfig,
   payPalConfig: PayPalConfig
-)(implicit assets: AssetsResolver, requestHeader: RequestHeader, switches: Switches)
+)(implicit assets: AssetsResolver, requestHeader: RequestHeader, settings: Settings)
 
 @scripts = {
     <script type="text/javascript">

--- a/app/views/settingsScript.scala.html
+++ b/app/views/settingsScript.scala.html
@@ -1,0 +1,9 @@
+@import admin.Settings
+@import views.ViewHelpers.printSettings
+
+@(settings: Settings)
+
+<script type="text/javascript">
+    window.guardian = window.guardian || {};
+    guardian.settings = @Html(printSettings(settings));
+</script>

--- a/app/views/switchesScript.scala.html
+++ b/app/views/switchesScript.scala.html
@@ -1,9 +1,0 @@
-@import switchboard.Switches
-@import views.ViewHelpers.printSwitches
-
-@(switches: Switches)
-
-<script type="text/javascript">
-    window.guardian = window.guardian || {};
-    guardian.switches = @Html(printSwitches(switches));
-</script>

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -29,7 +29,7 @@ trait AppComponents extends PlayComponents
     sourceMapper,
     Some(router),
     assetsResolver,
-    appConfig.switches
+    appConfig.settings
   )
 
   override lazy val httpFilters: Seq[EssentialFilter] = Seq(

--- a/app/wiring/Controllers.scala
+++ b/app/wiring/Controllers.scala
@@ -15,7 +15,7 @@ trait Controllers {
     controllerComponents,
     paymentAPIService,
     stringsConfig,
-    appConfig.switches
+    appConfig.settings
   )
 
   lazy val subscriptionsController = new Subscriptions(
@@ -23,7 +23,7 @@ trait Controllers {
     assetsResolver,
     controllerComponents,
     stringsConfig,
-    appConfig.switches
+    appConfig.settings
   )
 
   lazy val regularContributionsController = new RegularContributions(
@@ -36,7 +36,7 @@ trait Controllers {
     appConfig.regularStripeConfigProvider,
     appConfig.regularPayPalConfigProvider,
     controllerComponents,
-    appConfig.switches,
+    appConfig.settings,
     appConfig.guardianDomain
   )
 
@@ -46,7 +46,7 @@ trait Controllers {
     payPalNvpServiceProvider,
     testUsers,
     controllerComponents,
-    appConfig.switches
+    appConfig.settings
   )
 
   lazy val payPalOneOffController = new PayPalOneOff(
@@ -56,7 +56,7 @@ trait Controllers {
     controllerComponents,
     paymentAPIService,
     identityService,
-    appConfig.switches
+    appConfig.settings
   )
 
   lazy val oneOffContributions = new OneOffContributions(
@@ -68,7 +68,7 @@ trait Controllers {
     paymentAPIService,
     authAction,
     controllerComponents,
-    appConfig.switches
+    appConfig.settings
   )
 
   lazy val testUsersController = new TestUsersManagement(

--- a/assets/helpers/page/__tests__/pageTest.js
+++ b/assets/helpers/page/__tests__/pageTest.js
@@ -33,7 +33,9 @@ describe('reducer tests', () => {
       },
       abParticipations: {},
       otherQueryParams: [],
-      switches: {},
+      settings: {
+        switches: {},
+      },
       optimizeExperiments: {},
     };
 

--- a/assets/helpers/page/page.js
+++ b/assets/helpers/page/page.js
@@ -16,7 +16,7 @@ import type { Store } from 'redux';
 
 import * as abTest from 'helpers/abTests/abtest';
 import type { Participations } from 'helpers/abTests/abtest';
-import type { Switches } from 'helpers/switch';
+import type { Settings } from 'helpers/settings';
 import * as logger from 'helpers/logger';
 import * as googleTagManager from 'helpers/tracking/googleTagManager';
 import { detect as detectCountry, type IsoCountry } from 'helpers/internationalisation/country';
@@ -50,7 +50,7 @@ export type CommonState = {
   referrerAcquisitionData: ReferrerAcquisitionData,
   otherQueryParams: Array<[string, string]>,
   abParticipations: Participations,
-  switches: Switches,
+  settings: Settings,
   internationalisation: Internationalisation,
   optimizeExperiments: OptimizeExperiments,
 };
@@ -80,7 +80,7 @@ function buildInitialState(
   countryGroupId: CountryGroupId,
   countryId: IsoCountry,
   currencyId: IsoCurrency,
-  switches: Switches,
+  settings: Settings,
 ): CommonState {
   const acquisition = getReferrerAcquisitionData();
   const optimizeExperiments = getOptimizeExperiments();
@@ -98,7 +98,7 @@ function buildInitialState(
     otherQueryParams,
     internationalisation,
     abParticipations,
-    switches,
+    settings,
     optimizeExperiments,
   };
 
@@ -162,7 +162,7 @@ function init<S, A>(
   const countryId: IsoCountry = detectCountry();
   const currencyId: IsoCurrency = detectCurrency(countryGroupId);
   const participations: Participations = abTest.init(countryId, countryGroupId);
-  const { switches } = window.guardian;
+  const { settings: { switches } } = window.guardian;
   analyticsInitialisation(participations);
 
   const initialState: CommonState = buildInitialState(

--- a/assets/helpers/settings.js
+++ b/assets/helpers/settings.js
@@ -9,3 +9,7 @@ type SwitchObject = {
 export type Switches = {
   [string]: SwitchObject,
 };
+
+export type Settings = {
+  switches: Switches
+};

--- a/assets/pages/contributions-landing/containers/payPalContributionButtonContainer.js
+++ b/assets/pages/contributions-landing/containers/payPalContributionButtonContainer.js
@@ -20,7 +20,7 @@ function mapStateToProps(state: State) {
     abParticipations: state.common.abParticipations,
     isoCountry: state.common.internationalisation.countryId,
     canClick: !state.page.selection.error,
-    switchStatus: state.common.switches.oneOffPaymentMethods.payPal,
+    switchStatus: state.common.settings.switches.oneOffPaymentMethods.payPal,
     optimizeExperiments: state.common.optimizeExperiments,
   };
 

--- a/assets/pages/support-landing/components/payPalContributionButtonContainer.js
+++ b/assets/pages/support-landing/components/payPalContributionButtonContainer.js
@@ -21,7 +21,7 @@ function mapStateToProps(state: State) {
     abParticipations: state.common.abParticipations,
     isoCountry: state.common.internationalisation.countryId,
     canClick: !state.page.selection.error,
-    switchStatus: state.common.switches.oneOffPaymentMethods.payPal,
+    switchStatus: state.common.settings.switches.oneOffPaymentMethods.payPal,
     optimizeExperiments: state.common.optimizeExperiments,
   };
 

--- a/conf/CODE.public.conf
+++ b/conf/CODE.public.conf
@@ -52,6 +52,11 @@ switches {
       state=On
     }
   ]
-  
+
   internationalSubscribePages=On
+}
+
+adminSettings.s3 {
+  bucket="support-frontend-admin-console"
+  key= "settings.json"
 }

--- a/conf/DEV.public.conf
+++ b/conf/DEV.public.conf
@@ -22,6 +22,7 @@ play.filters.headers.contentSecurityPolicy = "default-src 'self' polyfill.guim.c
 // To override a value for local development change it in your private conf file
 // /etc/gu/support-frontend.private.conf and that value will be used instead.
 switches {
+
   //Payment methods for one-off contributions
   oneOff {
     stripe=On
@@ -44,7 +45,8 @@ switches {
       state=On
     }
   ]
-  
+
   internationalSubscribePages=On
 }
 
+adminSettings.local.path="~/.gu/support-frontend-admin-console/settings.json"

--- a/conf/PROD.public.conf
+++ b/conf/PROD.public.conf
@@ -55,3 +55,7 @@ switches {
   internationalSubscribePages=On
 }
 
+adminSettings.s3 {
+  bucket="support-frontend-admin-console"
+  key= "settings.json"
+}

--- a/test/controllers/ApplicationTest.scala
+++ b/test/controllers/ApplicationTest.scala
@@ -12,7 +12,7 @@ import config.StringsConfig
 import fixtures.TestCSRFComponents
 import org.scalatest.mockito.MockitoSugar.mock
 import services.{HttpIdentityService, PaymentAPIService, TestUserService}
-import switchboard.Switches
+import admin.Settings
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
@@ -36,14 +36,14 @@ class ApplicationTest extends WordSpec with MustMatchers with TestCSRFComponents
   "/healthcheck" should {
     "return healthy" in {
       val result = new Application(
-        actionRefiner, mock[AssetsResolver], mock[HttpIdentityService], stubControllerComponents(), mock[PaymentAPIService], mock[StringsConfig], mock[Switches]
+        actionRefiner, mock[AssetsResolver], mock[HttpIdentityService], stubControllerComponents(), mock[PaymentAPIService], mock[StringsConfig], mock[Settings]
       )(mock[ExecutionContext]).healthcheck.apply(FakeRequest())
       contentAsString(result) mustBe "healthy"
     }
 
     "not be cached" in {
       val result = new Application(
-        actionRefiner, mock[AssetsResolver], mock[HttpIdentityService], stubControllerComponents(), mock[PaymentAPIService], mock[StringsConfig], mock[Switches]
+        actionRefiner, mock[AssetsResolver], mock[HttpIdentityService], stubControllerComponents(), mock[PaymentAPIService], mock[StringsConfig], mock[Settings]
       )(mock[ExecutionContext]).healthcheck.apply(FakeRequest())
       header("Cache-Control", result) mustBe Some("no-cache, private")
     }

--- a/test/controllers/OneOffContributionsTest.scala
+++ b/test/controllers/OneOffContributionsTest.scala
@@ -22,7 +22,7 @@ import services.{HttpIdentityService, PaymentAPIService, TestUserService}
 import com.gu.support.config.StripeConfigProvider
 import fixtures.TestCSRFComponents
 import play.api.libs.json.JsString
-import switchboard.Switches
+import admin.Settings
 
 class OneOffContributionsTest extends WordSpec with MustMatchers with TestCSRFComponents {
 
@@ -92,7 +92,7 @@ class OneOffContributionsTest extends WordSpec with MustMatchers with TestCSRFCo
           mock[PaymentAPIService],
           mock[AuthAction[AnyContent]],
           stubControllerComponents(),
-          mock[Switches]
+          mock[Settings]
         ).autofill(FakeRequest())
       }
     }

--- a/test/controllers/RegularContributionsTest.scala
+++ b/test/controllers/RegularContributionsTest.scala
@@ -23,8 +23,8 @@ import services.{HttpIdentityService, MembersDataService, TestUserService}
 import services.MembersDataService._
 import com.gu.support.config._
 import fixtures.TestCSRFComponents
-import switchboard.SwitchState.On
-import switchboard.{PaymentMethodsSwitch, Switches}
+import admin.SwitchState.On
+import admin.{PaymentMethodsSwitch, Settings}
 
 class RegularContributionsTest extends WordSpec with MustMatchers with TestCSRFComponents {
 
@@ -111,7 +111,7 @@ class RegularContributionsTest extends WordSpec with MustMatchers with TestCSRFC
         stripeConfigProvider,
         payPalConfigProvider,
         stubControllerComponents(),
-        Switches(PaymentMethodsSwitch(On, On, None), PaymentMethodsSwitch(On, On, Some(On)), Map.empty, On, On),
+        Settings(PaymentMethodsSwitch(On, On, None), PaymentMethodsSwitch(On, On, Some(On)), Map.empty, On, On),
         guardianDomain = ".thegulocal.com"
       )
     }


### PR DESCRIPTION
Some renaming/refactoring in preparation for fetching settings (including but not limited to switches) from S3, which is a first step towards a Reader Revenue Admin Console (RRAC for short) where we can control these settings without redeploying.

- `switchboard` => `admin`
- `switches` => `settings.switches` (in JS terms), since switches will be a subset of settings (other settings include payment amounts)

Also added currently unused config which will be used in a subsequent PR to figure out where to fetch the settings from:

in PROD and CODE:

```
adminSettings.s3 {
  bucket="support-frontend-admin-console"
  key= "settings.json"
}
```

in DEV:

```
adminSettings.local.path="~/.gu/support-frontend-admin-console/settings.json"
```