### PR TITLE
reinstates annual test round two

### DIFF
--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -6,37 +6,17 @@ import type { Tests } from './abtest';
 export type AnnualContributionsTestVariant = 'control' | 'annual' | 'annualHigherAmounts' | 'notintest';
 
 export const tests: Tests = {
-  oneOffOneTimeSingle: {
-    variants: ['control', 'single', 'once', 'oneTime'],
+  annualContributionsRoundTwo: {
+    variants: ['control', 'annual', 'annualHigherAmounts'],
     audiences: {
-      GBPCountries: {
-        offset: 0,
-        size: 1,
-      },
-      AUDCountries: {
-        offset: 0,
-        size: 1,
-      },
-      Canada: {
-        offset: 0,
-        size: 1,
-      },
-      NZDCountries: {
-        offset: 0,
-        size: 1,
-      },
-      International: {
-        offset: 0,
-        size: 1,
-      },
-      EURCountries: {
+      ALL: {
         offset: 0,
         size: 1,
       },
     },
     isActive: true,
     independent: true,
-    seed: 0,
+    seed: 3,
   },
   recurringGuestCheckout: {
     variants: ['control', 'guest'],


### PR DESCRIPTION
## Why are you doing this?
This [PR](#917) removed the annual contribution test round two in error. This reinstates it and removes the redundant `oneOffTimeSingle` test. 

