### PR TITLE
Remove clickEvents from subs landing page

### DIFF
--- a/assets/components/digitalSubscriptions/digitalSubscriptions.jsx
+++ b/assets/components/digitalSubscriptions/digitalSubscriptions.jsx
@@ -23,17 +23,9 @@ import { displayPrice } from 'helpers/subscriptions';
 
 // ----- Types ----- //
 
-type ClickEvent = () => void;
-
 type PropTypes = {
   referrerAcquisitionData: ReferrerAcquisitionData,
   headingSize: HeadingSize,
-  clickEvents?: {
-    iOSApp: ?ClickEvent,
-    androidApp: ?ClickEvent,
-    dailyEdition: ?ClickEvent,
-    digiPack: ?ClickEvent,
-  },
 };
 
 
@@ -45,7 +37,7 @@ const gridImageProperties = {
   imgType: 'png',
 };
 
-const appReferrer = 'utm_source=support.theguardian.com&utm_medium=subscribe_landing_page&utm_campaign=split_subscriptions_test';
+const appReferrer = 'utm_source=support.theguardian.com&utm_medium=subscribe_landing_page';
 
 
 // ----- Component ----- //
@@ -70,40 +62,21 @@ export default function DigitalSubscriptions(props: PropTypes) {
           iOSUrl={addQueryParamsToURL(iOSAppUrl, { referrer: appReferrer })}
           androidUrl={addQueryParamsToURL(androidAppUrl, { referrer: appReferrer })}
           headingSize={props.headingSize}
-          iOSOnClick={props.clickEvents && props.clickEvents.iOSApp ? props.clickEvents.iOSApp : () => undefined}
-          androidOnClick={
-            props.clickEvents && props.clickEvents.androidApp ?
-              props.clickEvents.androidApp :
-              () => undefined
-          }
         />
         <DailyEdition
           url={addQueryParamsToURL(dailyEditionUrl, { referrer: appReferrer })}
           headingSize={props.headingSize}
-          onClick={
-            props.clickEvents && props.clickEvents.dailyEdition ?
-              props.clickEvents.dailyEdition :
-              () => undefined
-          }
         />
         <DigitalBundle
           countryGroupId={countryGroupId}
           url={subsLinks.DigitalPack}
           headingSize={props.headingSize}
-          onClick={
-            props.clickEvents && props.clickEvents.digiPack ?
-              props.clickEvents.digiPack :
-              () => undefined}
         />
       </PageSection>
     </div>
   );
 
 }
-
-DigitalSubscriptions.defaultProps = {
-  clickEvents: undefined,
-};
 
 // ----- Auxiliary Components ----- //
 
@@ -113,8 +86,6 @@ function PremiumTier(props: {
     androidUrl: string,
     headingSize: HeadingSize,
     subheading: ?string,
-    iOSOnClick?: ClickEvent,
-    androidOnClick?: ClickEvent,
 }) {
 
   return (
@@ -139,18 +110,12 @@ function PremiumTier(props: {
           url: props.iOSUrl,
           accessibilityHint: 'Proceed to buy the premium app in the app store',
           modifierClasses: ['premium-tier', 'border', 'ios'],
-          onClick: props.iOSOnClick ?
-            props.iOSOnClick :
-            () => {},
         },
         {
           text: 'Buy on Google Play',
           url: props.androidUrl,
           accessibilityHint: 'Proceed to buy the premium app in the play store',
           modifierClasses: ['premium-tier', 'border', 'android'],
-          onClick: props.androidOnClick ?
-            props.androidOnClick :
-            () => {},
         },
       ]}
     />
@@ -160,14 +125,11 @@ function PremiumTier(props: {
 
 PremiumTier.defaultProps = {
   subheading: null,
-  iOSOnClick: () => {},
-  androidOnClick: () => {},
 };
 
 function DailyEdition(props: {
   url: string,
   headingSize: HeadingSize,
-  onClick: ClickEvent,
 }) {
 
   return (
@@ -192,7 +154,6 @@ function DailyEdition(props: {
           url: props.url,
           accessibilityHint: 'Proceed to buy the daily edition app for iPad in the app store',
           modifierClasses: ['daily-edition', 'border'],
-          onClick: props.onClick,
         },
       ]}
     />
@@ -205,7 +166,6 @@ function DigitalBundle(props: {
   url: string,
   headingSize: HeadingSize,
   subheading: ?string,
-  onClick: ClickEvent | null,
 }) {
 
   const i13n = props.countryGroupId === 'GBPCountries' ?
@@ -241,7 +201,6 @@ function DigitalBundle(props: {
           url: props.url,
           accessibilityHint: 'Find out how to sign up for a free trial of The Guardian\'s digital subscription.',
           modifierClasses: ['digital', 'border'],
-          onClick: props.onClick,
         },
       ]}
     />

--- a/assets/components/digitalSubscriptions/digitalSubscriptions.jsx
+++ b/assets/components/digitalSubscriptions/digitalSubscriptions.jsx
@@ -113,8 +113,8 @@ function PremiumTier(props: {
     androidUrl: string,
     headingSize: HeadingSize,
     subheading: ?string,
-    iOSOnClick: ClickEvent,
-    androidOnClick: ClickEvent,
+    iOSOnClick?: ClickEvent,
+    androidOnClick?: ClickEvent,
 }) {
 
   return (
@@ -139,14 +139,18 @@ function PremiumTier(props: {
           url: props.iOSUrl,
           accessibilityHint: 'Proceed to buy the premium app in the app store',
           modifierClasses: ['premium-tier', 'border', 'ios'],
-          onClick: props.iOSOnClick,
+          onClick: props.iOSOnClick ?
+            props.iOSOnClick :
+            () => {},
         },
         {
           text: 'Buy on Google Play',
           url: props.androidUrl,
           accessibilityHint: 'Proceed to buy the premium app in the play store',
           modifierClasses: ['premium-tier', 'border', 'android'],
-          onClick: props.androidOnClick,
+          onClick: props.androidOnClick ?
+            props.androidOnClick :
+            () => {},
         },
       ]}
     />
@@ -156,6 +160,8 @@ function PremiumTier(props: {
 
 PremiumTier.defaultProps = {
   subheading: null,
+  iOSOnClick: () => {},
+  androidOnClick: () => {},
 };
 
 function DailyEdition(props: {

--- a/assets/components/internationalSubscriptions/internationalSubscriptions.jsx
+++ b/assets/components/internationalSubscriptions/internationalSubscriptions.jsx
@@ -23,19 +23,11 @@ import { classNameWithModifiers } from 'helpers/utilities';
 
 // ----- Types ----- //
 
-type ClickEvent = () => void;
-
 type PropTypes = {
   sectionId: string,
   countryGroupId: CountryGroupId,
   referrerAcquisitionData: ReferrerAcquisitionData,
   headingSize: HeadingSize,
-  clickEvents?: {
-    iOSApp: ?ClickEvent,
-    androidApp: ?ClickEvent,
-    digiPack: ?ClickEvent,
-    weekly: ?ClickEvent,
-  },
 };
 
 
@@ -72,34 +64,18 @@ export default function InternationalSubscriptions(props: PropTypes) {
             androidUrl={addQueryParamsToURL(androidAppUrl, { referrer: appReferrer })}
             headingSize={props.headingSize}
             subheading="7-day free trial"
-            iOSOnClick={props.clickEvents && props.clickEvents.iOSApp ?
-              props.clickEvents.iOSApp :
-              () => {}
-            }
-            androidOnClick={props.clickEvents && props.clickEvents.androidApp ?
-              props.clickEvents.androidApp :
-              () => {}
-            }
           />
           <DigitalBundle
             countryGroupId={props.countryGroupId}
             url={subsLinks.DigitalPack}
             headingSize={props.headingSize}
             subheading="14-day free trial"
-            onClick={props.clickEvents && props.clickEvents.digiPack ?
-              props.clickEvents.digiPack :
-              () => {}
-            }
           />
           <WeeklyBundle
             countryGroupId={props.countryGroupId}
             url={subsLinks.GuardianWeekly}
             headingSize={props.headingSize}
             subheading="&nbsp;"
-            onClick={props.clickEvents && props.clickEvents.weekly ?
-              props.clickEvents.weekly :
-              () => {}
-            }
           />
         </PageSection>
       </div>
@@ -107,8 +83,4 @@ export default function InternationalSubscriptions(props: PropTypes) {
   );
 
 }
-
-InternationalSubscriptions.defaultProps = {
-  clickEvents: undefined,
-};
 

--- a/assets/components/internationalSubscriptions/internationalSubscriptions.jsx
+++ b/assets/components/internationalSubscriptions/internationalSubscriptions.jsx
@@ -30,11 +30,11 @@ type PropTypes = {
   countryGroupId: CountryGroupId,
   referrerAcquisitionData: ReferrerAcquisitionData,
   headingSize: HeadingSize,
-  clickEvents: {
-    iOSApp: ClickEvent,
-    androidApp: ClickEvent,
-    digiPack: ClickEvent,
-    weekly: ClickEvent,
+  clickEvents?: {
+    iOSApp: ?ClickEvent,
+    androidApp: ?ClickEvent,
+    digiPack: ?ClickEvent,
+    weekly: ?ClickEvent,
   },
 };
 
@@ -72,22 +72,34 @@ export default function InternationalSubscriptions(props: PropTypes) {
             androidUrl={addQueryParamsToURL(androidAppUrl, { referrer: appReferrer })}
             headingSize={props.headingSize}
             subheading="7-day free trial"
-            iOSOnClick={props.clickEvents.iOSApp}
-            androidOnClick={props.clickEvents.androidApp}
+            iOSOnClick={props.clickEvents && props.clickEvents.iOSApp ?
+              props.clickEvents.iOSApp :
+              () => {}
+            }
+            androidOnClick={props.clickEvents && props.clickEvents.androidApp ?
+              props.clickEvents.androidApp :
+              () => {}
+            }
           />
           <DigitalBundle
             countryGroupId={props.countryGroupId}
             url={subsLinks.DigitalPack}
             headingSize={props.headingSize}
             subheading="14-day free trial"
-            onClick={props.clickEvents.digiPack}
+            onClick={props.clickEvents && props.clickEvents.digiPack ?
+              props.clickEvents.digiPack :
+              () => {}
+            }
           />
           <WeeklyBundle
             countryGroupId={props.countryGroupId}
             url={subsLinks.GuardianWeekly}
             headingSize={props.headingSize}
             subheading="&nbsp;"
-            onClick={props.clickEvents.weekly}
+            onClick={props.clickEvents && props.clickEvents.weekly ?
+              props.clickEvents.weekly :
+              () => {}
+            }
           />
         </PageSection>
       </div>
@@ -95,3 +107,8 @@ export default function InternationalSubscriptions(props: PropTypes) {
   );
 
 }
+
+InternationalSubscriptions.defaultProps = {
+  clickEvents: undefined,
+};
+

--- a/assets/components/paperSubscriptions/paperSubscriptions.jsx
+++ b/assets/components/paperSubscriptions/paperSubscriptions.jsx
@@ -17,16 +17,9 @@ import { displayPrice } from 'helpers/subscriptions';
 
 // ----- Types ----- //
 
-type ClickEvent = () => void;
-
 type PropTypes = {
   referrerAcquisitionData: ReferrerAcquisitionData,
   headingSize: HeadingSize,
-  clickEvents?: {
-    paper: ?ClickEvent,
-    paperDigital: ?ClickEvent,
-    weekly: ?ClickEvent,
-  },
 };
 
 
@@ -56,24 +49,15 @@ export default function PaperSubscriptions(props: PropTypes) {
         <PaperBundle
           url={subsLinks.Paper}
           headingSize={props.headingSize}
-          onClick={props.clickEvents && props.clickEvents.paper ?
-            props.clickEvents.paper :
-            () => undefined}
         />
         <PaperDigitalBundle
           url={subsLinks.PaperAndDigital}
           headingSize={props.headingSize}
-          onClick={props.clickEvents && props.clickEvents.paperDigital ?
-            props.clickEvents.paperDigital :
-            () => undefined}
         />
         <WeeklyBundle
           countryGroupId="GBPCountries"
           url={subsLinks.GuardianWeekly}
           headingSize={props.headingSize}
-          onClick={props.clickEvents && props.clickEvents.weekly ?
-            props.clickEvents.weekly :
-            () => undefined}
         />
       </PageSection>
     </div>
@@ -81,16 +65,11 @@ export default function PaperSubscriptions(props: PropTypes) {
 
 }
 
-PaperSubscriptions.defaultProps = {
-  clickEvents: undefined,
-};
-
 // ----- Auxiliary Components ----- //
 
 function PaperBundle(props: {
   url: string,
   headingSize: HeadingSize,
-  onClick: ClickEvent | null,
 }) {
 
   return (
@@ -115,7 +94,6 @@ function PaperBundle(props: {
           url: props.url,
           accessibilityHint: 'Proceed to paper subscription options',
           modifierClasses: ['paper', 'border'],
-          onClick: props.onClick,
         },
       ]}
     />
@@ -126,7 +104,6 @@ function PaperBundle(props: {
 function PaperDigitalBundle(props: {
   url: string,
   headingSize: HeadingSize,
-  onClick: ClickEvent | null,
 }) {
 
   return (
@@ -151,7 +128,6 @@ function PaperDigitalBundle(props: {
           url: props.url,
           accessibilityHint: 'Proceed to choose which days you would like to regularly receive the newspaper in conjunction with a digital subscription',
           modifierClasses: ['paper-digital', 'border'],
-          onClick: props.onClick,
         },
       ]}
     />
@@ -164,7 +140,6 @@ function WeeklyBundle(props: {
   url: string,
   headingSize: HeadingSize,
   subheading: ?string,
-  onClick: ClickEvent,
 }) {
 
   return (
@@ -189,7 +164,6 @@ function WeeklyBundle(props: {
           url: props.url,
           accessibilityHint: 'Proceed to buy a subscription to The Guardian Weekly',
           modifierClasses: ['weekly', 'border'],
-          onClick: props.onClick,
         },
       ]}
     />

--- a/assets/components/subscriptionBundle/subscriptionBundle.jsx
+++ b/assets/components/subscriptionBundle/subscriptionBundle.jsx
@@ -23,7 +23,6 @@ type BundleCta = {
   url: string,
   accessibilityHint: string,
   modifierClasses: Array<?string>,
-  onClick: ?Function,
 };
 
 type PropTypes = {

--- a/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
+++ b/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
@@ -19,7 +19,6 @@ import PaperSubscriptionsContainer from 'components/paperSubscriptions/paperSubs
 import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
 
-import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
 import InternationalSubscriptions from 'components/internationalSubscriptions/internationalSubscriptionsContainer';
 import DigitalSubscriptionsContainer from 'components/digitalSubscriptions/digitalSubscriptionsContainer';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
@@ -52,18 +51,12 @@ function getSubscriptionsForCountry() {
       </section>
     );
   }
-  const testName = 'international_subs_landing_pages';
+
   return (
     <InternationalSubscriptions
       sectionId={supporterSectionId}
       countryGroupId={countryGroupId}
       headingSize={3}
-      clickEvents={{
-        iOSApp: sendTrackingEventsOnClick('premium_tier_ios_cta', 'digital', testName, true),
-        androidApp: sendTrackingEventsOnClick('premium_tier_android_cta', 'digital', testName, true),
-        digiPack: sendTrackingEventsOnClick('digipack_cta', 'digital', testName, true),
-        weekly: sendTrackingEventsOnClick('weekly_cta', 'print', testName, true),
-      }}
     />);
 }
 


### PR DESCRIPTION
## Why are you doing this?
We've shut down the tests, so all traffic now passes through the new landing pages. This PR eliminates the need for `clickEvents` used to record test participation.

[**Trello Card**](https://trello.com/c/yaceoeDS/1887-switching-subs-landing-pages-live)

## Screenshots
N/A
