### PR TITLE
Don't show email field if user is signed in

### DIFF
--- a/assets/pages/oneoff-contributions/components/formFields.jsx
+++ b/assets/pages/oneoff-contributions/components/formFields.jsx
@@ -34,6 +34,7 @@ type PropTypes = {
   setEmail: (string) => void,
   setFullNameShouldValidate: () => void,
   setEmailShouldValidate: () => void,
+  isSignedIn: boolean,
 };
 
 // ----- Map State/Props ----- //
@@ -45,6 +46,7 @@ function mapStateToProps(state: State) {
   return {
     fullName,
     email,
+    isSignedIn: state.page.user.isSignedIn,
   };
 
 }
@@ -74,17 +76,21 @@ function NameForm(props: PropTypes) {
 
   return (
     <form className="oneoff-contrib__name-form">
-      <TextInput
-        id="email"
-        value={props.email.value}
-        labelText="Email"
-        placeholder="Email"
-        onChange={props.setEmail}
-        onBlur={onFormFieldBlur(props.setEmailShouldValidate, stripeButtonClassName)}
-        modifierClasses={['email']}
-        showError={shouldShowError(props.email)}
-        errorMessage="Please enter a valid email address."
-      />
+      {
+        !props.isSignedIn ? (
+          <TextInput
+            id="email"
+            value={props.email.value}
+            labelText="Email"
+            placeholder="Email"
+            onChange={props.setEmail}
+            onBlur={onFormFieldBlur(props.setEmailShouldValidate, stripeButtonClassName)}
+            modifierClasses={['email']}
+            showError={shouldShowError(props.email)}
+            errorMessage="Please enter a valid email address."
+          />
+        ) : null
+      }
       <TextInput
         id="name"
         placeholder="Full name"

--- a/assets/pages/regular-contributions/components/formFields.jsx
+++ b/assets/pages/regular-contributions/components/formFields.jsx
@@ -52,6 +52,7 @@ type PropTypes = {
   setEmailShouldValidate: () => void,
   countryGroup: CountryGroupId,
   country: IsoCountry,
+  isSignedIn: boolean,
 };
 
 // ----- Map State/Props ----- //
@@ -66,6 +67,7 @@ function mapStateToProps(state: State) {
     email,
     countryGroup: state.common.internationalisation.countryGroupId,
     country: state.common.internationalisation.countryId,
+    isSignedIn: state.page.user.isSignedIn,
   };
 
 }
@@ -158,17 +160,21 @@ function NameForm(props: PropTypes) {
 
   return (
     <form className="regular-contrib__name-form">
-      <TextInput
-        id="email"
-        value={props.email.value}
-        labelText="Email"
-        placeholder="Email"
-        onChange={props.setEmail}
-        onBlur={onFormFieldBlur(props.setEmailShouldValidate, continueButtonClassName)}
-        modifierClasses={['email']}
-        showError={shouldShowError(props.email)}
-        errorMessage="Please enter a valid email address."
-      />
+      {
+        !props.isSignedIn ? (
+          <TextInput
+            id="email"
+            value={props.email.value}
+            labelText="Email"
+            placeholder="Email"
+            onChange={props.setEmail}
+            onBlur={onFormFieldBlur(props.setEmailShouldValidate, continueButtonClassName)}
+            modifierClasses={['email']}
+            showError={shouldShowError(props.email)}
+            errorMessage="Please enter a valid email address."
+          />
+        ) : null
+      }
       <TextInput
         id="first-name"
         labelText="First name"


### PR DESCRIPTION
## Why are you doing this?
When we removed the email form field container in [this refactor ](https://github.com/guardian/support-frontend/pull/907), the logic to not show the email field if the user is singed in wasn't ported over. 

This PR reinstates that logic. 