### PR TITLE
Fix double click on checkout for firefox

### DIFF
--- a/assets/helpers/checkoutForm/checkoutForm.js
+++ b/assets/helpers/checkoutForm/checkoutForm.js
@@ -54,15 +54,21 @@ export function getTitle(contributionType: ContributionType): string {
   }
 }
 
-function isButtonFocused(event: FocusEvent, buttonClassName: string): boolean {
-  const { relatedTarget } = event;
+function isButtonFocused(event: any, buttonClassName: string): boolean {
+  const { relatedTarget, explicitOriginalTarget } = event;
+  // Working in Chrome
   if (relatedTarget instanceof HTMLElement) {
     return relatedTarget.classList.contains(buttonClassName);
+  }
+  // Work around for firefox
+  if (explicitOriginalTarget instanceof HTMLElement) {
+    return explicitOriginalTarget.classList.contains(buttonClassName);
   }
   return false;
 }
 
-export const onFormFieldBlur = (setShouldValidate: () => void, buttonClassName: string) => (event: FocusEvent) => {
+
+export const onFormFieldBlur = (setShouldValidate: () => void, buttonClassName: string) => (event: any) => {
   // Don't update the Redux state if the focus event is on the payment button, as this
   // will cause a re-render and the click event on the button will be lost
   if (!isButtonFocused(event, buttonClassName)) {


### PR DESCRIPTION
The double click fix we issued earlier this week only works on Chrome, meaning that the issue stil exists for Firefox and IE users. 

This is a workaround for firefox. Notice that we have had to lose the type safety on event, as `FocusEvent` doesn't contain `explicitOriginalTarget`

https://github.com/facebook/react/issues/2011