### PR TITLE
Added Id To Why Support Section On Subs Landing Page

### DIFF
--- a/assets/components/whySupport/whySupport.jsx
+++ b/assets/components/whySupport/whySupport.jsx
@@ -23,10 +23,12 @@ type PropTypes = {
 
 export default function WhySupport(props: PropTypes) {
 
+  const { headingSize, ...otherProps } = props;
+
   return (
-    <div className="component-why-support">
+    <div className="component-why-support" {...otherProps}>
       <PageSection heading="Why support?" modifierClass="why-support">
-        <Heading size={props.headingSize} className="component-why-support__heading">
+        <Heading size={headingSize} className="component-why-support__heading">
           <SvgScribble />
         </Heading>
         <p className="component-why-support__copy">
@@ -35,7 +37,7 @@ export default function WhySupport(props: PropTypes) {
           than ever now read and support the Guardian&#39;s independent,
           quality and investigative journalism.
         </p>
-        <Heading size={props.headingSize} className="component-why-support__heading">
+        <Heading size={headingSize} className="component-why-support__heading">
           <SvgAdvertisingGraphMobile />
           <SvgAdvertisingGraphDesktop />
         </Heading>
@@ -44,7 +46,7 @@ export default function WhySupport(props: PropTypes) {
           incredibly challenging commercial environment, and the advertising
           that we used to rely on to fund our work continues to fall.
         </p>
-        <Heading size={props.headingSize} className="component-why-support__heading component-why-support__heading--paywall">
+        <Heading size={headingSize} className="component-why-support__heading component-why-support__heading--paywall">
           <SvgPaywallMobile />
           <SvgPaywallDesktop />
           <SvgPaywallWide />

--- a/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
+++ b/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
@@ -80,7 +80,7 @@ const content = (
         highlightsHeadingSize={2}
       />
       {getSubscriptionsForCountry()}
-      <WhySupport headingSize={3} />
+      <WhySupport headingSize={3} id="why-support" />
       <ReadyToSupport
         ctaUrl={`#${supporterSectionId}`}
         headingSize={2}


### PR DESCRIPTION
## Why are you doing this?

Adding an id to the why support section so that it becomes accessible via a fragment url `#why-support`.

[**Trello Card**](https://trello.com/c/vIDUGyxt/1910-add-why-support-anchor)

cc @JustinPinner 

## Changes

- Allowed pass-through props on "Why Support" section.
- Passed through id from subs landing page.
