### PR TITLE
Fix Sentry error reporting to remove spurious error and handle actual errors correctly

### DIFF
--- a/assets/pages/oneoff-contributions/helpers/ajax.js
+++ b/assets/pages/oneoff-contributions/helpers/ajax.js
@@ -97,10 +97,10 @@ const handleFailure = (onFailure: OnFailure) => (errorJson: Object): void => {
   if (error.exceptionType === 'CardException') {
     onFailure('Your card has been declined.');
   } else {
-    const errorHttpCode = error.errorCode || 'unknown';
+    const errorHttpCode = error.errorHttpCode || 'unknown';
     const exceptionType = error.exceptionType || 'unknown';
     const errorName = error.errorName || 'unknown';
-    logException(`Stripe payment attempt failed with following error: code: ${errorHttpCode} type: ${exceptionType} error-name: ${errorName}.`);
+    logException(`Stripe payment attempt failed with following error: code: ${errorHttpCode}, type: ${exceptionType}, error-name: ${errorName}.`);
     onFailure('There was an error processing your payment. Please\u00a0try\u00a0again\u00a0later.');
   }
 


### PR DESCRIPTION
Currently we are getting a spurious error after payment success in the dev-tools console and in Sentry
(Note: the user is taken to the thank-you page regardless and this error is not visible to the user unless they have their debugging tools open).
This change will stop us sending that error and also fix up the error handling so it is firing and logging correctly

This is an improved version of https://github.com/guardian/support-frontend/pull/920 that uses @Ap0c's branch instead.