### PR TITLE
Fix Circe decoders for Segment and SwitchState

### DIFF
--- a/app/admin/Segment.scala
+++ b/app/admin/Segment.scala
@@ -10,7 +10,9 @@ object Segment {
   case object Perc0 extends Segment("Perc0")
   case object Perc50 extends Segment("Perc50")
 
-  def fromConfig(config: Config, key: String): Segment = config.getString(key) match {
+  def fromConfig(config: Config, key: String): Segment = fromString(config.getString(key))
+
+  def fromString(key: String): Segment = key match {
     case "Perc0" => Perc0
     case "Perc50" => Perc50
     case _ => Perc50

--- a/app/codecs/CirceDecoders.scala
+++ b/app/codecs/CirceDecoders.scala
@@ -98,11 +98,11 @@ object CirceDecoders {
 
   implicit val userCodec: Codec[User] = deriveCodec
   implicit val createPaymentMethodStateCodec: Codec[CreatePaymentMethodState] = deriveCodec
-  implicit val switchStateEncode: Encoder[SwitchState] = Encoder.encodeString.contramap[SwitchState](_.toString)
-  implicit val switchStateDecode: Decoder[SwitchState] = deriveDecoder
+  implicit val switchStateEncoder: Encoder[SwitchState] = Encoder.encodeString.contramap[SwitchState](_.toString)
+  implicit val switchStateDecoder: Decoder[SwitchState] = Decoder.decodeString.map(SwitchState.fromString)
   implicit val paymentMethodsSwitchCodec: Codec[PaymentMethodsSwitch] = deriveCodec
   implicit val segmentEncoder: Encoder[Segment] = Encoder.encodeString.contramap[Segment](_.toString)
-  implicit val segmentDecoder: Decoder[Segment] = deriveDecoder
+  implicit val segmentDecoder: Decoder[Segment] = Decoder.decodeString.map(Segment.fromString)
   implicit val experimentSwitchCodec: Codec[ExperimentSwitch] = deriveCodec
   implicit val switchesCodec: Codec[Switches] = deriveCodec
   implicit val settingsCodec: Codec[Settings] = deriveCodec

--- a/test/codecs/CirceDecodersTest.scala
+++ b/test/codecs/CirceDecodersTest.scala
@@ -15,6 +15,7 @@ import ophan.thrift.componentEvent.ComponentType.{AcquisitionsEpic, EnumUnknownC
 import ophan.thrift.event.AbTest
 import ophan.thrift.event.AcquisitionSource.GuardianWeb
 import org.scalatest.{MustMatchers, WordSpec}
+import org.scalatest.EitherValues._
 class CirceDecodersTest extends WordSpec with MustMatchers {
 
   "referrerAcquisitionDataCodec" should {
@@ -149,8 +150,8 @@ class CirceDecodersTest extends WordSpec with MustMatchers {
 
   "SwitchStateDecoder" should {
     "decode json" in {
-      decode[SwitchState]("\"On\"") mustBe Right(On)
-      decode[SwitchState]("\"Off\"") mustBe Right(Off)
+      decode[SwitchState]("\"On\"").right.value mustBe On
+      decode[SwitchState]("\"Off\"").right.value mustBe Off
     }
 
   }
@@ -166,9 +167,9 @@ class CirceDecodersTest extends WordSpec with MustMatchers {
 
   "SegmentDecoder" should {
     "decode json" in {
-      decode[Segment]("\"Perc0\"") mustBe Right(Segment.Perc0)
-      decode[Segment]("\"Perc50\"") mustBe Right(Segment.Perc50)
-      decode[Segment]("\"Anything else\"") mustBe Right(Segment.Perc50)
+      decode[Segment]("\"Perc0\"").right.value mustBe Segment.Perc0
+      decode[Segment]("\"Perc50\"").right.value mustBe Segment.Perc50
+      decode[Segment]("\"Anything else\"").right.value mustBe Segment.Perc50
     }
   }
 
@@ -234,7 +235,7 @@ class CirceDecodersTest extends WordSpec with MustMatchers {
         )
       )
 
-      decode[Settings](json) mustBe Right(settings)
+      decode[Settings](json).right.value mustBe settings
     }
   }
 }

--- a/test/codecs/CirceDecodersTest.scala
+++ b/test/codecs/CirceDecodersTest.scala
@@ -8,7 +8,9 @@ import com.gu.support.workers.model.DirectDebitPaymentFields
 import io.circe.parser.parse
 import io.circe.parser._
 import io.circe.syntax._
+import io.circe.{Json, JsonObject}
 import models.CheckBankAccountDetails
+import SwitchState._
 import ophan.thrift.componentEvent.ComponentType.{AcquisitionsEpic, EnumUnknownComponentType}
 import ophan.thrift.event.AbTest
 import ophan.thrift.event.AcquisitionSource.GuardianWeb
@@ -147,20 +149,20 @@ class CirceDecodersTest extends WordSpec with MustMatchers {
 
   "SwitchStateDecoder" should {
     "decode json" in {
-      decode[SwitchState]("\"On\"") mustBe Right(SwitchState.On)
-      decode[SwitchState]("\"Off\"") mustBe Right(SwitchState.Off)
+      decode[SwitchState]("\"On\"") mustBe Right(On)
+      decode[SwitchState]("\"Off\"") mustBe Right(Off)
+    }
+
+  }
+  "SwitchStateEncoder" should {
+    "encode json" in {
+      val on: SwitchState = On
+      on.asJson mustBe Json.fromString("On")
+
+      val off: SwitchState = Off
+      off.asJson mustBe Json.fromString("Off")
     }
   }
-
-  //  "SwitchStateEncoder" should {
-  //    "encode json" in {
-  //      val on: SwitchState = SwitchState.On
-  //      on.asJson mustBe "On"
-  //
-  //      val off: SwitchState = SwitchState.Off
-  //      off.asJson mustBe "Off"
-  //    }
-  //  }
 
   "SegmentDecoder" should {
     "decode json" in {
@@ -170,20 +172,18 @@ class CirceDecodersTest extends WordSpec with MustMatchers {
     }
   }
 
-  //    "SegmentEncoder" should {
-  //      "decode json" in {
-  //        val perc0: Segment = Segment.Perc0
-  //        perc0.asJson mustBe "Perc0"
-  //
-  //        val perc50: Segment = Segment.Perc50
-  //        perc50.asJson mustBe "Perc50"
-  //      }
-  //    }
+  "SegmentEncoder" should {
+    "encode json" in {
+      val perc0: Segment = Segment.Perc0
+      perc0.asJson mustBe Json.fromString("Perc0")
+
+      val perc50: Segment = Segment.Perc50
+      perc50.asJson mustBe Json.fromString("Perc50")
+    }
+  }
 
   "SettingsDecoder" should {
     "decode json" in {
-      import SwitchState._
-
       val json =
         """{
           |  "switches": {

--- a/test/codecs/CirceDecodersTest.scala
+++ b/test/codecs/CirceDecodersTest.scala
@@ -147,8 +147,8 @@ class CirceDecodersTest extends WordSpec with MustMatchers {
 
   "SwitchStateDecoder" should {
     "decode json" in {
-      decode[SwitchState](""""On"""") mustBe Right(SwitchState.On)
-      decode[SwitchState](""""Off"""") mustBe Right(SwitchState.Off)
+      decode[SwitchState]("\"On\"") mustBe Right(SwitchState.On)
+      decode[SwitchState]("\"Off\"") mustBe Right(SwitchState.Off)
     }
   }
 


### PR DESCRIPTION
The Circe decoders for `Segment` and `SwitchState` (both sealed traits modelling an enum type) were never implemented correctly. We've gotten away with this because we only encode JSON from those types and don't decode it. But in the upcoming work to fetch settings from an external JSON file (on disk or in S3), we need to decode too.

So this implements the decoding correctly and adds some tests.