### PR TITLE
Refactor Subs Landing - Part I

### DIFF
--- a/assets/components/footer/footerContainer.js
+++ b/assets/components/footer/footerContainer.js
@@ -1,0 +1,25 @@
+// @flow
+
+// ----- Imports ----- //
+
+import { connect } from 'react-redux';
+
+import type { CommonState } from 'helpers/page/page';
+
+import Footer from './footer';
+
+
+// ----- State Maps ----- //
+
+function mapStateToProps(state: { common: CommonState }) {
+
+  return {
+    countryGroupId: state.common.internationalisation.countryGroupId,
+  };
+
+}
+
+
+// ----- Exports ----- //
+
+export default connect(mapStateToProps)(Footer);

--- a/assets/components/internationalSubscriptions/internationalSubscriptions.jsx
+++ b/assets/components/internationalSubscriptions/internationalSubscriptions.jsx
@@ -24,7 +24,6 @@ import { classNameWithModifiers } from 'helpers/utilities';
 // ----- Types ----- //
 
 type PropTypes = {
-  sectionId: string,
   countryGroupId: CountryGroupId,
   referrerAcquisitionData: ReferrerAcquisitionData,
   headingSize: HeadingSize,
@@ -48,38 +47,37 @@ export default function InternationalSubscriptions(props: PropTypes) {
   );
 
   return (
-    <section id={props.sectionId}>
-      <div className={classNameWithModifiers(
+    <div
+      className={classNameWithModifiers(
         'component-international-subscriptions',
         [countryGroups[props.countryGroupId].supportInternationalisationId],
       )}
+    >
+      <PageSection
+        heading="Subscribe"
+        modifierClass="international-subscriptions"
       >
-        <PageSection
-          heading="Subscribe"
-          modifierClass="international-subscriptions"
-        >
-          <PremiumTier
-            countryGroupId={props.countryGroupId}
-            iOSUrl={addQueryParamsToURL(iOSAppUrl, { referrer: appReferrer })}
-            androidUrl={addQueryParamsToURL(androidAppUrl, { referrer: appReferrer })}
-            headingSize={props.headingSize}
-            subheading="7-day free trial"
-          />
-          <DigitalBundle
-            countryGroupId={props.countryGroupId}
-            url={subsLinks.DigitalPack}
-            headingSize={props.headingSize}
-            subheading="14-day free trial"
-          />
-          <WeeklyBundle
-            countryGroupId={props.countryGroupId}
-            url={subsLinks.GuardianWeekly}
-            headingSize={props.headingSize}
-            subheading="&nbsp;"
-          />
-        </PageSection>
-      </div>
-    </section>
+        <PremiumTier
+          countryGroupId={props.countryGroupId}
+          iOSUrl={addQueryParamsToURL(iOSAppUrl, { referrer: appReferrer })}
+          androidUrl={addQueryParamsToURL(androidAppUrl, { referrer: appReferrer })}
+          headingSize={props.headingSize}
+          subheading="7-day free trial"
+        />
+        <DigitalBundle
+          countryGroupId={props.countryGroupId}
+          url={subsLinks.DigitalPack}
+          headingSize={props.headingSize}
+          subheading="14-day free trial"
+        />
+        <WeeklyBundle
+          countryGroupId={props.countryGroupId}
+          url={subsLinks.GuardianWeekly}
+          headingSize={props.headingSize}
+          subheading="&nbsp;"
+        />
+      </PageSection>
+    </div>
   );
 
 }

--- a/assets/components/subscriptionsByCountryGroup/subscriptionsByCountryGroup.jsx
+++ b/assets/components/subscriptionsByCountryGroup/subscriptionsByCountryGroup.jsx
@@ -18,7 +18,6 @@ import { type CommonState } from 'helpers/page/page';
 
 type PropTypes = {
   countryGroupId: CountryGroupId,
-  supporterSectionId: string,
   headingSize: HeadingSize,
 };
 
@@ -36,25 +35,29 @@ function mapStateToProps(state: { common: CommonState }) {
 
 function SubscriptionsByCountryGroup(props: PropTypes) {
 
-  if (props.countryGroupId === 'GBPCountries') {
+  const { countryGroupId, headingSize, ...otherProps } = props;
+
+  if (countryGroupId === 'GBPCountries') {
     return (
-      <section id={props.supporterSectionId}>
+      <div {...otherProps}>
         <DigitalSubscriptionsContainer
-          headingSize={props.headingSize}
+          headingSize={headingSize}
         />
         <PaperSubscriptionsContainer
-          headingSize={props.headingSize}
+          headingSize={headingSize}
         />
-      </section>
+      </div>
     );
   }
 
   return (
-    <InternationalSubscriptions
-      sectionId={props.supporterSectionId}
-      countryGroupId={props.countryGroupId}
-      headingSize={props.headingSize}
-    />
+    <div {...otherProps}>
+      <InternationalSubscriptions
+        countryGroupId={countryGroupId}
+        headingSize={headingSize}
+        {...otherProps}
+      />
+    </div>
   );
 
 }

--- a/assets/components/subscriptionsByCountryGroup/subscriptionsByCountryGroup.jsx
+++ b/assets/components/subscriptionsByCountryGroup/subscriptionsByCountryGroup.jsx
@@ -1,0 +1,65 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+import { connect } from 'react-redux';
+
+import PaperSubscriptionsContainer from 'components/paperSubscriptions/paperSubscriptionsContainer';
+import DigitalSubscriptionsContainer from 'components/digitalSubscriptions/digitalSubscriptionsContainer';
+import InternationalSubscriptions from 'components/internationalSubscriptions/internationalSubscriptionsContainer';
+import { type HeadingSize } from 'components/heading/heading';
+
+import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { type CommonState } from 'helpers/page/page';
+
+
+// ----- Types and State Mapping ----- //
+
+type PropTypes = {
+  countryGroupId: CountryGroupId,
+  supporterSectionId: string,
+  headingSize: HeadingSize,
+};
+
+
+function mapStateToProps(state: { common: CommonState }) {
+
+  return {
+    countryGroupId: state.common.internationalisation.countryGroupId,
+  };
+
+}
+
+
+// ----- Component ----- //
+
+function SubscriptionsByCountryGroup(props: PropTypes) {
+
+  if (props.countryGroupId === 'GBPCountries') {
+    return (
+      <section id={props.supporterSectionId}>
+        <DigitalSubscriptionsContainer
+          headingSize={props.headingSize}
+        />
+        <PaperSubscriptionsContainer
+          headingSize={props.headingSize}
+        />
+      </section>
+    );
+  }
+
+  return (
+    <InternationalSubscriptions
+      sectionId={props.supporterSectionId}
+      countryGroupId={props.countryGroupId}
+      headingSize={props.headingSize}
+    />
+  );
+
+}
+
+
+// ----- Exports ----- //
+
+export default connect(mapStateToProps)(SubscriptionsByCountryGroup);

--- a/assets/components/threeSubscriptions/threeSubscriptions.jsx
+++ b/assets/components/threeSubscriptions/threeSubscriptions.jsx
@@ -18,18 +18,11 @@ import { displayPrice } from '../../helpers/subscriptions';
 
 // ----- Types ----- //
 
-type ClickEvent = () => void;
-
 type PropTypes = {
   referrerAcquisitionData: ReferrerAcquisitionData,
   digitalHeadingSize: HeadingSize,
   paperHeadingSize: HeadingSize,
   paperDigitalHeadingSize: HeadingSize,
-  clickEvents: ?{
-    digital: ClickEvent,
-    paper: ClickEvent,
-    paperDigital: ClickEvent,
-  },
 };
 
 
@@ -61,17 +54,14 @@ function ThreeSubscriptions(props: PropTypes) {
         <DigitalBundle
           url={subsLinks.DigitalPack}
           headingSize={props.digitalHeadingSize}
-          onClick={props.clickEvents ? props.clickEvents.digital : null}
         />
         <PaperBundle
           url={subsLinks.Paper}
           headingSize={props.paperHeadingSize}
-          onClick={props.clickEvents ? props.clickEvents.paper : null}
         />
         <PaperDigitalBundle
           url={subsLinks.PaperAndDigital}
           headingSize={props.paperDigitalHeadingSize}
-          onClick={props.clickEvents ? props.clickEvents.paperDigital : null}
         />
       </PageSection>
     </div>
@@ -85,7 +75,6 @@ function ThreeSubscriptions(props: PropTypes) {
 function DigitalBundle(props: {
   url: string,
   headingSize: HeadingSize,
-  onClick: ClickEvent | null,
 }) {
 
   return (
@@ -106,7 +95,6 @@ function DigitalBundle(props: {
           url: props.url,
           accessibilityHint: 'Find out how to sign up for a free trial of The Guardian\'s digital subscription.',
           modifierClasses: ['digital', 'border'],
-          onClick: props.onClick,
         },
       ]}
     />
@@ -117,7 +105,6 @@ function DigitalBundle(props: {
 function PaperBundle(props: {
   url: string,
   headingSize: HeadingSize,
-  onClick: ClickEvent | null,
 }) {
 
   return (
@@ -138,7 +125,6 @@ function PaperBundle(props: {
           url: props.url,
           accessibilityHint: 'Proceed to paper subscription options',
           modifierClasses: ['paper', 'border'],
-          onClick: props.onClick,
         },
       ]}
     />
@@ -149,7 +135,6 @@ function PaperBundle(props: {
 function PaperDigitalBundle(props: {
   url: string,
   headingSize: HeadingSize,
-  onClick: ClickEvent | null,
 }) {
 
   return (
@@ -170,20 +155,12 @@ function PaperDigitalBundle(props: {
           url: props.url,
           accessibilityHint: 'Proceed to choose which days you would like to regularly receive the newspaper in conjunction with a digital subscription',
           modifierClasses: ['paper-digital', 'border'],
-          onClick: props.onClick,
         },
       ]}
     />
   );
 
 }
-
-
-// ----- Default Props ----- //
-
-ThreeSubscriptions.defaultProps = {
-  clickEvents: null,
-};
 
 
 // ----- Exports ----- //

--- a/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
+++ b/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
@@ -42,7 +42,7 @@ const content = (
         modifierClasses={['compact']}
         highlightsHeadingSize={2}
       />
-      <SubscriptionsByCountryGroup supporterSectionId={supporterSectionId} headingSize={3} />
+      <SubscriptionsByCountryGroup id={supporterSectionId} headingSize={3} />
       <WhySupport headingSize={3} id="why-support" />
       <ReadyToSupport
         ctaUrl={`#${supporterSectionId}`}

--- a/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
+++ b/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
@@ -5,30 +5,22 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 
-// React components
 import Page from 'components/page/page';
-import Footer from 'components/footer/footer';
+import FooterContainer from 'components/footer/footerContainer';
 import CirclesIntroduction from 'components/introduction/circlesIntroduction';
 import WhySupport from 'components/whySupport/whySupport';
 import ReadyToSupport from 'components/readyToSupport/readyToSupport';
 import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
-import PaperSubscriptionsContainer from 'components/paperSubscriptions/paperSubscriptionsContainer';
-
-// React components connected to redux store
 
 import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
 
-import InternationalSubscriptions from 'components/internationalSubscriptions/internationalSubscriptionsContainer';
-import DigitalSubscriptionsContainer from 'components/digitalSubscriptions/digitalSubscriptionsContainer';
-import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import { detect } from 'helpers/internationalisation/countryGroup';
+import SubscriptionsByCountryGroup from 'components/subscriptionsByCountryGroup/subscriptionsByCountryGroup';
 
 
 // ----- Setup ----- //
 
 const supporterSectionId = 'supporter-options';
-const countryGroupId: CountryGroupId = detect();
 
 
 // ----- Redux Store ----- //
@@ -38,33 +30,11 @@ const store = pageInit();
 
 // ----- Render ----- //
 
-function getSubscriptionsForCountry() {
-  if (countryGroupId === 'GBPCountries') {
-    return (
-      <section id={supporterSectionId}>
-        <DigitalSubscriptionsContainer
-          headingSize={3}
-        />
-        <PaperSubscriptionsContainer
-          headingSize={3}
-        />
-      </section>
-    );
-  }
-
-  return (
-    <InternationalSubscriptions
-      sectionId={supporterSectionId}
-      countryGroupId={countryGroupId}
-      headingSize={3}
-    />);
-}
-
 const content = (
   <Provider store={store}>
     <Page
       header={<SimpleHeader />}
-      footer={<Footer disclaimer privacyPolicy countryGroupId={countryGroupId} />}
+      footer={<FooterContainer disclaimer privacyPolicy />}
     >
       <CirclesIntroduction
         headings={['Help us deliver the', 'independent journalism', 'the world needs']}
@@ -72,7 +42,7 @@ const content = (
         modifierClasses={['compact']}
         highlightsHeadingSize={2}
       />
-      {getSubscriptionsForCountry()}
+      <SubscriptionsByCountryGroup supporterSectionId={supporterSectionId} headingSize={3} />
       <WhySupport headingSize={3} id="why-support" />
       <ReadyToSupport
         ctaUrl={`#${supporterSectionId}`}

--- a/assets/pages/subscriptions-landing/subscriptionsLanding.scss
+++ b/assets/pages/subscriptions-landing/subscriptionsLanding.scss
@@ -29,7 +29,7 @@
 
 #subscriptions-landing-page {
 
-  .component-digital-subscriptions, .component-three-subscriptions {
+  .component-digital-subscriptions, .component-international-subscriptions {
     @include multiline-top-border;
 
     border-top: none;


### PR DESCRIPTION
## Why are you doing this?

Tidying up the subscriptions landing pages now that the tests have finished.

[**Trello Card**](https://trello.com/c/oPAHir20/1911-tidy-up-subs-landing-pages)

cc @JustinPinner 

## Changes

- Added a shared container for the footer (allowed because it's only mapping from the `common` state), so that `CountryGroupId` doesn't have to passed every time.
- Dropped wrapping `<section>` from international subscriptions component, and stopped passing through id.
- Created a new connected component to switch between subscriptions sections based on country.
- Dropped unused click events from `ThreeSubscriptions`.
- Applied the multiline to the international subs page.
