### PR TITLE
Use DOM validation on all checkout forms and remove greyed-out button validation

### DIFF
--- a/assets/components/paymentButtons/directDebitPopUpButton/directDebitPopUpButton.jsx
+++ b/assets/components/paymentButtons/directDebitPopUpButton/directDebitPopUpButton.jsx
@@ -16,7 +16,6 @@ import DirectDebitPopUpForm from 'components/directDebit/directDebitPopUpForm/di
 import SvgArrowRightStraight from 'components/svgs/arrowRightStraight';
 import type { Status } from 'helpers/settings';
 import type { RegularCheckoutCallback } from 'helpers/checkouts';
-import { classNameWithModifiers } from 'helpers/utilities';
 
 
 // ---- Types ----- //
@@ -27,7 +26,8 @@ type PropTypes = {
   isPopUpOpen: boolean,
   openDirectDebitPopUp: () => void,
   switchStatus: Status,
-  disable: boolean,
+  whenUnableToOpen: () => void,
+  canOpen: () => boolean,
 };
 /* eslint-enable react/no-unused-prop-types */
 
@@ -65,35 +65,49 @@ const DirectDebitPopUpButton = (props: PropTypes) => (
 // ----- Auxiliary Components ----- //
 
 function ButtonAndForm(props: PropTypes) {
+
+
   if (props.isPopUpOpen) {
     return (
       <div>
-        <Button openPopUp={props.openDirectDebitPopUp} disable={props.disable} />
+        <Button
+          openPopUp={props.openDirectDebitPopUp}
+          canOpen={props.canOpen}
+          whenUnableToOpen={props.whenUnableToOpen}
+        />
         <DirectDebitPopUpForm callback={props.callback} />
       </div>
     );
   }
 
-  return <Button openPopUp={props.openDirectDebitPopUp} disable={props.disable} />;
+  return (<Button
+    openPopUp={props.openDirectDebitPopUp}
+    canOpen={props.canOpen}
+    whenUnableToOpen={props.whenUnableToOpen}
+  />);
 
 }
 
 function Button(props: {
   openPopUp: () => void,
-  disable: boolean
+  canOpen: () => boolean,
+  whenUnableToOpen: () => void,
   }) {
 
-  const baseClass = 'component-direct-debit-pop-up-button';
-  const className: string = props.disable
-    ? classNameWithModifiers(baseClass, ['disable'])
-    : baseClass;
+  const onClick = () => {
+    if (props.canOpen()) {
+      props.openPopUp();
+    } else {
+      props.whenUnableToOpen();
+    }
+  };
 
   return (
     <button
       id="qa-pay-with-direct-debit"
-      className={className}
-      onClick={props.openPopUp}
-      disabled={props.disable}
+      className="component-direct-debit-pop-up-button"
+      onClick={onClick}
+      disabled={!props.canOpen()}
     >
       Pay with Direct Debit
       <SvgArrowRightStraight />
@@ -106,6 +120,8 @@ function Button(props: {
 
 DirectDebitPopUpButton.defaultProps = {
   switchStatus: 'On',
+  canOpen: () => true,
+  whenUnableToOpen: () => undefined,
 };
 
 

--- a/assets/components/paymentButtons/directDebitPopUpButton/directDebitPopUpButton.scss
+++ b/assets/components/paymentButtons/directDebitPopUpButton/directDebitPopUpButton.scss
@@ -29,17 +29,3 @@
   }
 }
 
-.component-direct-debit-pop-up-button--disable {
-  background-color: gu-colour(garnett-neutral-4);
-  color: gu-colour(garnett-neutral-2);
-  cursor: auto;
-
-  .svg-arrow-right-straight {
-    fill: gu-colour(garnett-neutral-2);
-  }
-
-  &:hover {
-    background-color: gu-colour(garnett-neutral-4);
-  }
-
-}

--- a/assets/components/paymentButtons/payPalExpressButton/payPalExpressButton.jsx
+++ b/assets/components/paymentButtons/payPalExpressButton/payPalExpressButton.jsx
@@ -9,7 +9,6 @@ import Switchable from 'components/switchable/switchable';
 import PaymentError from 'components/switchable/errorComponents/paymentError';
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import type { Status } from 'helpers/settings';
-import SvgArrowRightStraight from 'components/svgs/arrowRightStraight';
 import { loadPayPalExpress, setup } from 'helpers/paymentIntegrations/payPalExpressCheckout';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 
@@ -24,7 +23,6 @@ type PropTypes = {|
   hasLoaded: boolean,
   setHasLoaded: () => void,
   switchStatus: Status,
-  disable: boolean,
   canOpen: () => boolean,
   whenUnableToOpen: () => void,
 |};
@@ -62,22 +60,12 @@ function Button(props: PropTypes) {
     props.whenUnableToOpen,
   );
 
-  const disabledButton = (
-    <button
-      className="component-paypal-button-checkout__disabled-pop-up-button"
-      disabled
-    >
-      Pay with PayPal
-      <SvgArrowRightStraight />
-    </button>
-  );
 
-
-  const ActiveButton = window.paypal.Button.driver('react', { React, ReactDOM });
+  const PayPalButton = window.paypal.Button.driver('react', { React, ReactDOM });
 
   return (
     <div id="component-paypal-button-checkout" className="component-paypal-button-checkout">
-      { props.disable ? disabledButton : <ActiveButton {...payPalOptions} /> }
+      <PayPalButton {...payPalOptions} />
     </div>
   );
 }

--- a/assets/components/paymentButtons/payPalExpressButton/payPalExpressButton.jsx
+++ b/assets/components/paymentButtons/payPalExpressButton/payPalExpressButton.jsx
@@ -25,6 +25,8 @@ type PropTypes = {|
   setHasLoaded: () => void,
   switchStatus: Status,
   disable: boolean,
+  canOpen: () => boolean,
+  whenUnableToOpen: () => void,
 |};
 
 
@@ -56,6 +58,8 @@ function Button(props: PropTypes) {
     props.currencyId,
     props.csrf,
     props.callback,
+    props.canOpen,
+    props.whenUnableToOpen,
   );
 
   const disabledButton = (

--- a/assets/components/paymentButtons/payPalExpressButton/payPalExpressButton.scss
+++ b/assets/components/paymentButtons/payPalExpressButton/payPalExpressButton.scss
@@ -5,30 +5,3 @@
     width: 304px;
   }
 }
-
-.component-paypal-button-checkout__disabled-pop-up-button {
-  background-color: gu-colour(garnett-neutral-4);
-  border: none;
-  border-radius: 600px;
-  color: gu-colour(garnett-neutral-2);
-  display: block;
-  font-family: $gu-sans-web;
-  font-size: 14px;
-  height: $cta-height;
-  padding-left: $gu-h-spacing;
-  position: relative;
-  text-align: left;
-  width: 100%;
-  margin-top: $gu-v-spacing;
-
-  @include mq($from: mobileMedium) {
-    width: 304px;
-  }
-
-  .svg-arrow-right-straight {
-    height: 16px;
-    position: absolute;
-    left: calc(100% - 34px);
-    fill: gu-colour(garnett-neutral-2);
-  }
-}

--- a/assets/components/paymentButtons/stripePopUpButton/stripePopUpButton.jsx
+++ b/assets/components/paymentButtons/stripePopUpButton/stripePopUpButton.jsx
@@ -12,7 +12,6 @@ import {
   setupStripeCheckout,
   openDialogBox,
 } from 'helpers/paymentIntegrations/stripeCheckout';
-import { classNameWithModifiers } from 'helpers/utilities';
 
 // ---- Types ----- //
 
@@ -28,7 +27,6 @@ type PropTypes = {|
   whenUnableToOpen: () => void,
   canOpen: () => boolean,
   switchStatus: Status,
-  disable: boolean,
   svg: Node,
 |};
 /* eslint-enable react/no-unused-prop-types */
@@ -72,17 +70,12 @@ function Button(props: PropTypes) {
     }
   };
 
-  const baseClass = 'component-stripe-pop-up-button';
-  const className: string = props.disable
-    ? classNameWithModifiers(baseClass, ['disable'])
-    : baseClass;
-
   return (
     <button
       id="qa-pay-with-card"
-      className={className}
+      className="component-stripe-pop-up-button"
       onClick={onClick}
-      disabled={props.disable}
+      disabled={!props.canOpen()}
     >
       Pay with debit/credit card {props.svg}
     </button>

--- a/assets/components/paymentButtons/stripePopUpButton/stripePopUpButton.scss
+++ b/assets/components/paymentButtons/stripePopUpButton/stripePopUpButton.scss
@@ -35,17 +35,3 @@
   }
 }
 
-.component-stripe-pop-up-button--disable {
-  background-color: gu-colour(garnett-neutral-4);
-  color: gu-colour(garnett-neutral-2);
-  cursor: auto;
-
-  .svg-credit-card {
-    fill: gu-colour(garnett-neutral-2);
-  }
-
-  &:hover {
-    background-color: gu-colour(garnett-neutral-4);
-  }
-}
-

--- a/assets/components/textInput/textInput.jsx
+++ b/assets/components/textInput/textInput.jsx
@@ -34,9 +34,11 @@ type PropTypes = {
   autocomplete?: AutoComplete,
   autocapitalize?: AutoCapitalize,
   modifierClasses: Array<?string>,
-  onBlur: (FocusEvent) => void,
   showError: boolean,
   errorMessage: string,
+  required: boolean,
+  pattern?: string,
+  type: ?string,
 };
 
 
@@ -57,14 +59,14 @@ export default function TextInput(props: PropTypes) {
       <input
         className="component-text-input__input"
         type={props.type}
+        pattern={props.pattern}
         id={props.id}
         onChange={event => props.onChange(event.target.value || '')}
-        onBlur={props.onBlur}
         value={props.value}
         placeholder={props.placeholder}
         autoComplete={props.autocomplete}
         autoCapitalize={props.autocapitalize}
-        required={true}
+        required={props.required}
       />
       <ErrorMessage
         showError={props.showError}
@@ -84,5 +86,5 @@ TextInput.defaultProps = {
   autocomplete: 'on',
   autocapitalize: 'off',
   modifierClasses: [],
-  onBlur: () => undefined,
+  pattern: '.*',
 };

--- a/assets/components/textInput/textInput.jsx
+++ b/assets/components/textInput/textInput.jsx
@@ -64,6 +64,7 @@ export default function TextInput(props: PropTypes) {
         placeholder={props.placeholder}
         autoComplete={props.autocomplete}
         autoCapitalize={props.autocapitalize}
+        required={true}
       />
       <ErrorMessage
         showError={props.showError}

--- a/assets/helpers/checkoutForm/checkoutForm.js
+++ b/assets/helpers/checkoutForm/checkoutForm.js
@@ -29,8 +29,13 @@ export function shouldShowError(field: UserFormFieldAttribute): boolean {
   return field.shouldValidate && !formFieldIsValid(field.id);
 }
 
-export const formInputs = (formClassName: string): Array<HTMLInputElement> =>
-  [...document.querySelector('.' + formClassName).getElementsByTagName('input')];
+export const formInputs = (formClassName: string): Array<HTMLInputElement> => {
+  const form = document.querySelector(`.${formClassName}`);
+  if (form) {
+    return [...form.getElementsByTagName('input')];
+  }
+  return [];
+};
 
 export const formIsValid = (formId: string) =>
   [...formInputs(formId)].every(element => element.validity.valid);

--- a/assets/helpers/checkoutForm/checkoutForm.js
+++ b/assets/helpers/checkoutForm/checkoutForm.js
@@ -20,25 +20,27 @@ export function emptyInputField(input: ?string): boolean {
 }
 
 export type UserFormFieldAttribute = {
+  id: string,
   value: string,
   shouldValidate: boolean,
-  isValid: boolean,
 }
 
 export function shouldShowError(field: UserFormFieldAttribute): boolean {
-  return field.shouldValidate && !field.isValid;
+  return field.shouldValidate && !formFieldIsValid(field.id);
 }
 
-export type formFieldIsValidParameters = {
-  value: string,
-  required: boolean,
-  pattern: RegExp
-}
+export const formInputs = (formClassName: string): Array<HTMLInputElement> =>
+  [...document.querySelector('.' + formClassName).getElementsByTagName('input')];
 
-export function formFieldIsValid(params: formFieldIsValidParameters): boolean {
-  const emptyFieldError = params.required && emptyInputField(params.value);
-  const patternMatchError = !patternIsValid(params.value, params.pattern);
-  return !emptyFieldError && !patternMatchError;
+export const formIsValid = (formId: string) =>
+  [...formInputs(formId)].every(element => element.validity.valid);
+
+export function formFieldIsValid(id: string) {
+  const element = document.getElementById(id);
+  if (element && element instanceof HTMLInputElement) {
+    return element.validity.valid;
+  }
+  return false;
 }
 
 export function getTitle(contributionType: ContributionType): string {

--- a/assets/helpers/checkoutForm/checkoutForm.js
+++ b/assets/helpers/checkoutForm/checkoutForm.js
@@ -8,9 +8,9 @@ import { type Contrib as ContributionType } from 'helpers/contributions';
 // src/main/scala/play/api/data/validation/Validation.scala#L80
 // but with minor modification (last * becomes +) to enforce at least one dot in domain.  This is
 // for compatibility with Stripe
-export const emailRegexPattern = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$/;
+export const emailRegexPattern = '^[a-zA-Z0-9.!#$%&\'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$';
 
-export function patternIsValid(value: string, pattern: RegExp): boolean {
+export function patternIsValid(value: string, pattern: string): boolean {
   const regex = new RegExp(pattern);
   return regex.test(value);
 }
@@ -25,6 +25,14 @@ export type UserFormFieldAttribute = {
   shouldValidate: boolean,
 }
 
+export function formFieldIsValid(id: string) {
+  const element = document.getElementById(id);
+  if (element && element instanceof HTMLInputElement) {
+    return element.validity.valid;
+  }
+  return false;
+}
+
 export function shouldShowError(field: UserFormFieldAttribute): boolean {
   return field.shouldValidate && !formFieldIsValid(field.id);
 }
@@ -37,16 +45,13 @@ export const formInputs = (formClassName: string): Array<HTMLInputElement> => {
   return [];
 };
 
-export const formIsValid = (formId: string) =>
-  [...formInputs(formId)].every(element => element.validity.valid);
-
-export function formFieldIsValid(id: string) {
-  const element = document.getElementById(id);
-  if (element && element instanceof HTMLInputElement) {
-    return element.validity.valid;
+export const formIsValid = (formClassName: string) => {
+  const form = document.querySelector(`.${formClassName}`);
+  if (form && form instanceof HTMLFormElement) {
+    return form.checkValidity();
   }
   return false;
-}
+};
 
 export function getTitle(contributionType: ContributionType): string {
 
@@ -61,18 +66,3 @@ export function getTitle(contributionType: ContributionType): string {
   }
 }
 
-function isButtonFocused(event: FocusEvent, buttonClassName: string): boolean {
-  const { relatedTarget } = event;
-  if (relatedTarget instanceof HTMLElement) {
-    return relatedTarget.classList.contains(buttonClassName);
-  }
-  return false;
-}
-
-export const onFormFieldBlur = (setShouldValidate: () => void, buttonClassName: string) => (event: FocusEvent) => {
-  // Don't update the Redux state if the focus event is on the payment button, as this
-  // will cause a re-render and the click event on the button will be lost
-  if (!isButtonFocused(event, buttonClassName)) {
-    setShouldValidate();
-  }
-};

--- a/assets/helpers/paymentIntegrations/payPalExpressCheckout.js
+++ b/assets/helpers/paymentIntegrations/payPalExpressCheckout.js
@@ -5,10 +5,10 @@
 import { logException } from 'helpers/logger';
 import { routes } from 'helpers/routes';
 import * as storage from 'helpers/storage';
-import { formIsValid, formInputs } from 'helpers/checkoutForm/checkoutForm'
+import { formInputs } from 'helpers/checkoutForm/checkoutForm';
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
-import { formClassName } from 'pages/regular-contributions/components/formFields';
+import { formClassName } from '../../pages/regular-contributions/components/formFields';
 
 // ----- Functions ----- //
 
@@ -90,8 +90,8 @@ function setup(
   csrf: CsrfState,
   callback: (token: string) => Promise<*>,
   canOpen: () => boolean,
-  whenUnableToOpen: () => boolean)
-: Promise<Object> {
+  whenUnableToOpen: () => void,
+): Promise<Object> {
 
   const handleBaId = (baid: Object) => {
     callback(baid.token);
@@ -105,14 +105,12 @@ function setup(
       });
   };
 
-  function addFormChangeListeners(handler) {
-    formInputs(formClassName).forEach(input => {
-      input.addEventListener('change', handler);
-    });
+  function addFormChangeListeners(handler: () => void) {
+    formInputs(formClassName).forEach(input => input.addEventListener('change', handler));
   }
 
-  function toggleButton(actions){
-    return canOpen() ? actions.enable() : actions.disable ();
+  function toggleButton(actions): void {
+    return canOpen() ? actions.enable() : actions.disable();
   }
 
   const payPalOptions: Object = {
@@ -122,15 +120,13 @@ function setup(
     // Defines whether user sees 'Agree and Continue' or 'Agree and Pay now' in overlay.
     commit: true,
 
-    validate: function(actions) {
-      toggleButton(actions, canOpen);
+    validate(actions) {
+      toggleButton(actions);
 
-      addFormChangeListeners(function () {
-        toggleButton(actions, canOpen);
-      });
+      addFormChangeListeners(() => toggleButton(actions));
     },
 
-    onClick: function(e) {
+    onClick() {
       if (!canOpen()) {
         whenUnableToOpen();
       }

--- a/assets/helpers/paymentIntegrations/payPalExpressCheckout.js
+++ b/assets/helpers/paymentIntegrations/payPalExpressCheckout.js
@@ -106,7 +106,7 @@ function setup(
   };
 
   function addFormChangeListeners(handler) {
-    formInputs(formId).forEach(input => {
+    formInputs(formClassName).forEach(input => {
       input.addEventListener('change', handler);
     });
   }

--- a/assets/pages/oneoff-contributions/__tests__/__snapshots__/oneoffContributionsReducersTest.js.snap
+++ b/assets/pages/oneoff-contributions/__tests__/__snapshots__/oneoffContributionsReducersTest.js.snap
@@ -6,13 +6,9 @@ exports[`One-off Reducer should return the initial state 1`] = `
 Object {
   "checkoutForm": Object {
     "email": Object {
-      "pattern": /\\^\\[a-zA-Z0-9\\.!#\\$%&'\\*\\+\\\\/=\\?\\^_\`\\{\\|\\}~-\\]\\+@\\[a-zA-Z0-9\\]\\(\\?:\\[a-zA-Z0-9-\\]\\{0,61\\}\\[a-zA-Z0-9\\]\\)\\?\\(\\?:\\\\\\.\\[a-zA-Z0-9\\]\\(\\?:\\[a-zA-Z0-9-\\]\\{0,61\\}\\[a-zA-Z0-9\\]\\)\\?\\)\\+\\$/,
-      "required": true,
       "shouldValidate": false,
     },
     "fullName": Object {
-      "pattern": /\\.\\*/,
-      "required": true,
       "shouldValidate": false,
     },
   },

--- a/assets/pages/oneoff-contributions/components/formFields.jsx
+++ b/assets/pages/oneoff-contributions/components/formFields.jsx
@@ -14,6 +14,7 @@ import {
 import {
   type UserFormFieldAttribute,
   shouldShowError,
+  emailRegexPattern,
 } from 'helpers/checkoutForm/checkoutForm';
 import { type Action as CheckoutAction } from '../helpers/checkoutForm/checkoutFormActions';
 import { getFormFields } from '../helpers/checkoutForm/checkoutFormFieldsSelector';
@@ -56,11 +57,13 @@ function mapDispatchToProps(dispatch: Dispatch<UserAction | CheckoutAction>) {
   };
 }
 
+export const formClassName = 'oneoff-contrib__checkout-form';
+
 // ----- Component ----- //
 
 function NameForm(props: PropTypes) {
   return (
-    <form className="oneoff-contrib__name-form">
+    <form className={formClassName}>
       {
         !props.isSignedIn ? (
           <TextInput
@@ -72,6 +75,9 @@ function NameForm(props: PropTypes) {
             modifierClasses={['email']}
             showError={shouldShowError(props.email)}
             errorMessage="Please enter a valid email address."
+            type="email"
+            pattern={emailRegexPattern}
+            required
           />
         ) : null
       }
@@ -84,6 +90,7 @@ function NameForm(props: PropTypes) {
         modifierClasses={['name']}
         showError={shouldShowError(props.fullName)}
         errorMessage="Please enter your name."
+        required
       />
       <p className="component-your-details__info">
         <small>All fields are required.</small>

--- a/assets/pages/oneoff-contributions/components/oneoffContributionsPayment.jsx
+++ b/assets/pages/oneoff-contributions/components/oneoffContributionsPayment.jsx
@@ -100,7 +100,7 @@ function OneoffContributionsPayment(props: PropTypes, context) {
           context.store.getState,
           props.optimizeExperiments,
         )}
-        canOpen={() => props.formFields.every(f => f.isValid)}
+        canOpen={() => true}
         whenUnableToOpen={() => props.setShouldValidateFunctions.forEach(f => f())}
         currencyId={props.currencyId}
         isTestUser={props.isTestUser}

--- a/assets/pages/oneoff-contributions/components/oneoffContributionsPayment.jsx
+++ b/assets/pages/oneoff-contributions/components/oneoffContributionsPayment.jsx
@@ -15,12 +15,12 @@ import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import type { Status } from 'helpers/settings';
 import SvgCreditCard from 'components/svgs/creditCard';
 import type { OptimizeExperiments } from 'helpers/tracking/optimize';
-import { type UserFormFieldAttribute } from 'helpers/checkoutForm/checkoutForm';
+import { formIsValid } from 'helpers/checkoutForm/checkoutForm';
 import { type Action as CheckoutAction } from '../helpers/checkoutForm/checkoutFormActions';
 import { setFullNameShouldValidate, setEmailShouldValidate } from '../helpers/checkoutForm/checkoutFormActions';
 import postCheckout from '../helpers/ajax';
-import { getFormFields } from '../helpers/checkoutForm/checkoutFormFieldsSelector';
 import { type State } from '../oneOffContributionsReducer';
+import { formClassName } from './formFields';
 
 // ----- Types ----- //
 
@@ -38,7 +38,6 @@ type PropTypes = {|
   stripeSwitchStatus: Status,
   paymentComplete: boolean,
   optimizeExperiments: OptimizeExperiments,
-  formFields: Array<UserFormFieldAttribute>
 |};
 
 
@@ -46,13 +45,10 @@ type PropTypes = {|
 
 
 function mapStateToProps(state: State) {
-  const { fullName, email } = getFormFields(state);
-
   return {
     isTestUser: state.page.user.isTestUser || false,
     isPostDeploymentTestUser: state.page.user.isPostDeploymentTestUser,
-    email: email.value,
-    formFields: [email, fullName],
+    email: state.page.user.email,
     error: state.page.oneoffContrib.error,
     areAnyRequiredFieldsEmpty: !state.page.user.email || !state.page.user.fullName,
     amount: state.page.oneoffContrib.amount,
@@ -69,8 +65,8 @@ function mapDispatchToProps(dispatch: Dispatch<CheckoutAction>) {
   return {
     dispatch,
     setShouldValidateFunctions: [
-      () => dispatch(setFullNameShouldValidate()),
-      () => dispatch(setEmailShouldValidate()),
+      () => dispatch(setFullNameShouldValidate(true)),
+      () => dispatch(setEmailShouldValidate(true)),
     ],
   };
 }
@@ -100,14 +96,13 @@ function OneoffContributionsPayment(props: PropTypes, context) {
           context.store.getState,
           props.optimizeExperiments,
         )}
-        canOpen={() => true}
+        canOpen={() => formIsValid(formClassName)}
         whenUnableToOpen={() => props.setShouldValidateFunctions.forEach(f => f())}
         currencyId={props.currencyId}
         isTestUser={props.isTestUser}
         isPostDeploymentTestUser={props.isPostDeploymentTestUser}
         amount={props.amount}
         switchStatus={props.stripeSwitchStatus}
-        disable={false}
         svg={<SvgCreditCard />}
       />
     </section>

--- a/assets/pages/oneoff-contributions/helpers/checkoutForm/__tests__/__snapshots__/checkoutFormReducerTest.js.snap
+++ b/assets/pages/oneoff-contributions/helpers/checkoutForm/__tests__/__snapshots__/checkoutFormReducerTest.js.snap
@@ -1,15 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`user reducer tests should return the initial state 1`] = `
+exports[`checkout form reducer tests should return the initial state 1`] = `
 Object {
   "email": Object {
-    "pattern": /\\^\\[a-zA-Z0-9\\.!#\\$%&'\\*\\+\\\\/=\\?\\^_\`\\{\\|\\}~-\\]\\+@\\[a-zA-Z0-9\\]\\(\\?:\\[a-zA-Z0-9-\\]\\{0,61\\}\\[a-zA-Z0-9\\]\\)\\?\\(\\?:\\\\\\.\\[a-zA-Z0-9\\]\\(\\?:\\[a-zA-Z0-9-\\]\\{0,61\\}\\[a-zA-Z0-9\\]\\)\\?\\)\\+\\$/,
-    "required": true,
     "shouldValidate": false,
   },
   "fullName": Object {
-    "pattern": /\\.\\*/,
-    "required": true,
     "shouldValidate": false,
   },
 }

--- a/assets/pages/oneoff-contributions/helpers/checkoutForm/__tests__/checkoutFormActionsTest.js
+++ b/assets/pages/oneoff-contributions/helpers/checkoutForm/__tests__/checkoutFormActionsTest.js
@@ -4,14 +4,14 @@ import { setEmailShouldValidate, setFullNameShouldValidate } from '../checkoutFo
 
 describe('Checkout form', () => {
 
-  it('should create an action to set the shouldValidate on the checkout form email field', () => {
-    const expectedAction = { type: 'SET_EMAIL_SHOULD_VALIDATE' };
-    expect(setEmailShouldValidate()).toEqual(expectedAction);
+  it('should create an action to set the shouldValidate to true on the checkout form email field', () => {
+    const expectedAction = { type: 'SET_EMAIL_SHOULD_VALIDATE', shouldValidate: true };
+    expect(setEmailShouldValidate(true)).toEqual(expectedAction);
   });
 
-  it('should create an action to set the shouldValidate on the checkout form full name field', () => {
-    const expectedAction = { type: 'SET_FULL_NAME_SHOULD_VALIDATE' };
-    expect(setFullNameShouldValidate()).toEqual(expectedAction);
+  it('should create an action to set the shouldValidate to true on the checkout form full name field', () => {
+    const expectedAction = { type: 'SET_FULL_NAME_SHOULD_VALIDATE', shouldValidate: true };
+    expect(setFullNameShouldValidate(true)).toEqual(expectedAction);
   });
 
 });

--- a/assets/pages/oneoff-contributions/helpers/checkoutForm/__tests__/checkoutFormReducerTest.js
+++ b/assets/pages/oneoff-contributions/helpers/checkoutForm/__tests__/checkoutFormReducerTest.js
@@ -2,14 +2,14 @@ import { checkoutFormReducer as reducer } from '../checkoutFormReducer';
 
 // ----- Tests ----- //
 
-describe('user reducer tests', () => {
+describe('checkout form reducer tests', () => {
 
   it('should return the initial state', () => {
     expect(reducer(undefined, {})).toMatchSnapshot();
   });
 
   it('should handle SET_EMAIL_SHOULD_VALIDATE', () => {
-    const action = { type: 'SET_EMAIL_SHOULD_VALIDATE' };
+    const action = { type: 'SET_EMAIL_SHOULD_VALIDATE', shouldValidate: true };
 
     const newState = reducer(undefined, action);
 
@@ -17,7 +17,7 @@ describe('user reducer tests', () => {
   });
 
   it('should handle SET_FULL_NAME_SHOULD_VALIDATE', () => {
-    const action = { type: 'SET_FULL_NAME_SHOULD_VALIDATE' };
+    const action = { type: 'SET_FULL_NAME_SHOULD_VALIDATE', shouldValidate: true };
 
     const newState = reducer(undefined, action);
 

--- a/assets/pages/oneoff-contributions/helpers/checkoutForm/checkoutFormActions.js
+++ b/assets/pages/oneoff-contributions/helpers/checkoutForm/checkoutFormActions.js
@@ -3,17 +3,17 @@
 // ----- Types ----- //
 
 export type Action =
-  | { type: 'SET_FULL_NAME_SHOULD_VALIDATE' }
-  | { type: 'SET_EMAIL_SHOULD_VALIDATE' }
+  | { type: 'SET_FULL_NAME_SHOULD_VALIDATE', shouldValidate: boolean }
+  | { type: 'SET_EMAIL_SHOULD_VALIDATE', shouldValidate: boolean }
 
 
 // ----- Actions Creators ----- //
 
 
-export function setEmailShouldValidate(): Action {
-  return { type: 'SET_EMAIL_SHOULD_VALIDATE' };
+export function setEmailShouldValidate(shouldValidate: boolean): Action {
+  return { type: 'SET_EMAIL_SHOULD_VALIDATE', shouldValidate };
 }
 
-export function setFullNameShouldValidate(): Action {
-  return { type: 'SET_FULL_NAME_SHOULD_VALIDATE' };
+export function setFullNameShouldValidate(shouldValidate: boolean): Action {
+  return { type: 'SET_FULL_NAME_SHOULD_VALIDATE', shouldValidate };
 }

--- a/assets/pages/oneoff-contributions/helpers/checkoutForm/checkoutFormFieldsSelector.js
+++ b/assets/pages/oneoff-contributions/helpers/checkoutForm/checkoutFormFieldsSelector.js
@@ -2,7 +2,6 @@
 
 // ----- Imports ----- //
 
-import { formFieldIsValid } from 'helpers/checkoutForm/checkoutForm';
 import { type State } from '../../oneOffContributionsReducer';
 
 

--- a/assets/pages/oneoff-contributions/helpers/checkoutForm/checkoutFormFieldsSelector.js
+++ b/assets/pages/oneoff-contributions/helpers/checkoutForm/checkoutFormFieldsSelector.js
@@ -10,25 +10,16 @@ import { type State } from '../../oneOffContributionsReducer';
 
 function getFormFields(state: State) {
 
-  const fullNameFromState = {
+  const fullName = {
+    id: 'name',
     value: state.page.user.fullName,
     ...state.page.checkoutForm.fullName,
   };
 
-  const emailFromState = {
+  const email = {
+    id: 'email',
     value: state.page.user.email,
     ...state.page.checkoutForm.email,
-  };
-
-  const fullName = {
-    value: fullNameFromState.value,
-    shouldValidate: state.page.checkoutForm.fullName.shouldValidate,
-    isValid: formFieldIsValid(fullNameFromState),
-  };
-  const email = {
-    value: emailFromState.value,
-    shouldValidate: state.page.checkoutForm.email.shouldValidate,
-    isValid: formFieldIsValid(emailFromState),
   };
 
   return { fullName, email };

--- a/assets/pages/oneoff-contributions/helpers/checkoutForm/checkoutFormReducer.js
+++ b/assets/pages/oneoff-contributions/helpers/checkoutForm/checkoutFormReducer.js
@@ -7,7 +7,6 @@ import { type Action } from './checkoutFormActions';
 
 
 export type CheckoutFormAttribute = {
-  id: string,
   shouldValidate: boolean,
 }
 

--- a/assets/pages/oneoff-contributions/helpers/checkoutForm/checkoutFormReducer.js
+++ b/assets/pages/oneoff-contributions/helpers/checkoutForm/checkoutFormReducer.js
@@ -1,16 +1,14 @@
 // @flow
 
 // ----- Imports ----- //
-import { emailRegexPattern } from 'helpers/checkoutForm/checkoutForm';
 import { type Action } from './checkoutFormActions';
 
 // ----- Types ----- //
 
 
 export type CheckoutFormAttribute = {
+  id: string,
   shouldValidate: boolean,
-  required: boolean,
-  pattern: RegExp,
 }
 
 export type OneOffContributionsCheckoutFormState = {
@@ -23,13 +21,9 @@ export type OneOffContributionsCheckoutFormState = {
 const initialState: OneOffContributionsCheckoutFormState = {
   email: {
     shouldValidate: false,
-    required: true,
-    pattern: emailRegexPattern,
   },
   fullName: {
     shouldValidate: false,
-    required: true,
-    pattern: /.*/,
   },
 };
 

--- a/assets/pages/regular-contributions/__tests__/__snapshots__/regularContributionsReducersTest.js.snap
+++ b/assets/pages/regular-contributions/__tests__/__snapshots__/regularContributionsReducersTest.js.snap
@@ -8,18 +8,12 @@ exports[`Regular contributions Reducer should return the initial state 1`] = `
 Object {
   "checkoutForm": Object {
     "email": Object {
-      "pattern": /\\^\\[a-zA-Z0-9\\.!#\\$%&'\\*\\+\\\\/=\\?\\^_\`\\{\\|\\}~-\\]\\+@\\[a-zA-Z0-9\\]\\(\\?:\\[a-zA-Z0-9-\\]\\{0,61\\}\\[a-zA-Z0-9\\]\\)\\?\\(\\?:\\\\\\.\\[a-zA-Z0-9\\]\\(\\?:\\[a-zA-Z0-9-\\]\\{0,61\\}\\[a-zA-Z0-9\\]\\)\\?\\)\\+\\$/,
-      "required": true,
       "shouldValidate": false,
     },
     "firstName": Object {
-      "pattern": /\\.\\*/,
-      "required": true,
       "shouldValidate": false,
     },
     "lastName": Object {
-      "pattern": /\\.\\*/,
-      "required": true,
       "shouldValidate": false,
     },
     "stage": "checkout",

--- a/assets/pages/regular-contributions/components/contributionsGuestCheckoutContainer.jsx
+++ b/assets/pages/regular-contributions/components/contributionsGuestCheckoutContainer.jsx
@@ -4,10 +4,9 @@
 
 import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
-import { type UserFormFieldAttribute } from 'helpers/checkoutForm/checkoutForm';
+import { formIsValid } from 'helpers/checkoutForm/checkoutForm';
 import ContributionsGuestCheckout from './contributionsGuestCheckout';
 import { type State } from '../regularContributionsReducer';
-import { getFormFields } from '../helpers/checkoutForm/checkoutFormFieldsSelector';
 import { setStage } from '../helpers/checkoutForm/checkoutFormActions';
 import { type Action as CheckoutAction } from '../helpers/checkoutForm/checkoutFormActions';
 import { formClassName, setShouldValidateFunctions } from './formFields';
@@ -18,17 +17,15 @@ import { formClassName, setShouldValidateFunctions } from './formFields';
 const submitYourDetailsForm = (dispatch: Dispatch<CheckoutAction>) => {
   if (formIsValid(formClassName)) {
     dispatch(setStage('payment'));
+    setShouldValidateFunctions.forEach(f => dispatch(f(false)));
   } else {
-    setShouldValidateFunctions.forEach(f => dispatch(f()));
+    setShouldValidateFunctions.forEach(f => dispatch(f(true)));
   }
 };
 
 // ----- State Maps ----- //
 
 function mapStateToProps(state: State) {
-
-  const { firstName, lastName, email } = getFormFields(state);
-
 
   return {
     amount: state.page.regularContrib.amount,
@@ -37,9 +34,6 @@ function mapStateToProps(state: State) {
     displayName: state.page.user.displayName,
     isSignedIn: state.page.user.isSignedIn,
     stage: state.page.checkoutForm.stage,
-    firstName,
-    lastName,
-    email,
   };
 }
 

--- a/assets/pages/regular-contributions/components/contributionsGuestCheckoutContainer.jsx
+++ b/assets/pages/regular-contributions/components/contributionsGuestCheckoutContainer.jsx
@@ -8,26 +8,15 @@ import { type UserFormFieldAttribute } from 'helpers/checkoutForm/checkoutForm';
 import ContributionsGuestCheckout from './contributionsGuestCheckout';
 import { type State } from '../regularContributionsReducer';
 import { getFormFields } from '../helpers/checkoutForm/checkoutFormFieldsSelector';
-import {
-  setEmailShouldValidate,
-  setFirstNameShouldValidate,
-  setLastNameShouldValidate,
-  setStage,
-} from '../helpers/checkoutForm/checkoutFormActions';
+import { setStage } from '../helpers/checkoutForm/checkoutFormActions';
 import { type Action as CheckoutAction } from '../helpers/checkoutForm/checkoutFormActions';
+import { formClassName, setShouldValidateFunctions } from './formFields';
 
 
 // ----- Functions ----- //
 
-const setShouldValidateFunctions = [
-  setFirstNameShouldValidate,
-  setLastNameShouldValidate,
-  setEmailShouldValidate,
-];
-
-const submitYourDetailsForm = (dispatch: Dispatch<CheckoutAction>, formFields: Array<UserFormFieldAttribute>) => {
-  const formIsValid = formFields.every(el => el.isValid);
-  if (formIsValid) {
+const submitYourDetailsForm = (dispatch: Dispatch<CheckoutAction>) => {
+  if (formIsValid(formClassName)) {
     dispatch(setStage('payment'));
   } else {
     setShouldValidateFunctions.forEach(f => dispatch(f()));
@@ -55,28 +44,14 @@ function mapStateToProps(state: State) {
 }
 
 const mapDispatchToProps = (dispatch: Dispatch<CheckoutAction>) => ({
-  dispatch,
   onBackClick: () => {
     dispatch(setStage('checkout'));
   },
+  onNextButtonClick:
+    () => submitYourDetailsForm(dispatch),
 });
-
-
-function mergeProps(stateProps, dispatchProps, ownProps) {
-
-  return {
-    ...ownProps,
-    ...stateProps,
-    ...dispatchProps,
-    onNextButtonClick:
-      () => submitYourDetailsForm(
-        dispatchProps.dispatch,
-        [stateProps.firstName, stateProps.lastName, stateProps.email],
-      ),
-  };
-}
 
 
 // ----- Exports ----- //
 
-export default connect(mapStateToProps, mapDispatchToProps, mergeProps)(ContributionsGuestCheckout);
+export default connect(mapStateToProps, mapDispatchToProps)(ContributionsGuestCheckout);

--- a/assets/pages/regular-contributions/components/formFields.jsx
+++ b/assets/pages/regular-contributions/components/formFields.jsx
@@ -24,12 +24,12 @@ import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import {
   type UserFormFieldAttribute,
   shouldShowError,
-  onFormFieldBlur,
+  emailRegexPattern,
 } from 'helpers/checkoutForm/checkoutForm';
 import {
   type Action as CheckoutAction, setEmailShouldValidate,
   setFirstNameShouldValidate,
-  setLastNameShouldValidate
+  setLastNameShouldValidate,
 } from '../helpers/checkoutForm/checkoutFormActions';
 import { type State } from '../regularContributionsReducer';
 import { getFormFields } from '../helpers/checkoutForm/checkoutFormFieldsSelector';
@@ -151,8 +151,6 @@ export const setShouldValidateFunctions = [
 // ----- Component ----- //
 
 function NameForm(props: PropTypes) {
-  const continueButtonClassName = 'component-cta-link--continue';
-
   return (
     <form className={formClassName}>
       {
@@ -166,6 +164,9 @@ function NameForm(props: PropTypes) {
             modifierClasses={['email']}
             showError={shouldShowError(props.email)}
             errorMessage="Please enter a valid email address."
+            type="email"
+            pattern={emailRegexPattern}
+            required
           />
         ) : null
       }
@@ -178,6 +179,7 @@ function NameForm(props: PropTypes) {
         modifierClasses={['first-name']}
         showError={shouldShowError(props.firstName)}
         errorMessage="Please enter a first name."
+        required
       />
       <TextInput
         id="last-name"
@@ -188,6 +190,7 @@ function NameForm(props: PropTypes) {
         modifierClasses={['last-name']}
         showError={shouldShowError(props.lastName)}
         errorMessage="Please enter a last name."
+        required
       />
       {stateDropdown(props.countryGroup, props.stateUpdate)}
       {countriesDropdown(props.countryGroup, props.countryUpdate, props.country)}

--- a/assets/pages/regular-contributions/components/formFields.jsx
+++ b/assets/pages/regular-contributions/components/formFields.jsx
@@ -27,10 +27,9 @@ import {
   onFormFieldBlur,
 } from 'helpers/checkoutForm/checkoutForm';
 import {
-  type Action as CheckoutAction,
+  type Action as CheckoutAction, setEmailShouldValidate,
   setFirstNameShouldValidate,
-  setLastNameShouldValidate,
-  setEmailShouldValidate,
+  setLastNameShouldValidate
 } from '../helpers/checkoutForm/checkoutFormActions';
 import { type State } from '../regularContributionsReducer';
 import { getFormFields } from '../helpers/checkoutForm/checkoutFormFieldsSelector';
@@ -47,9 +46,6 @@ type PropTypes = {
   setFirstName: (string) => void,
   setLastName: (string) => void,
   setEmail: (string) => void,
-  setFirstNameShouldValidate: () => void,
-  setLastNameShouldValidate: () => void,
-  setEmailShouldValidate: () => void,
   countryGroup: CountryGroupId,
   country: IsoCountry,
   isSignedIn: boolean,
@@ -81,20 +77,11 @@ function mapDispatchToProps(dispatch: Dispatch<UserAction | PageAction | Checkou
     countryUpdate: (value: IsoCountry) => {
       dispatch(setCountry(value));
     },
-    setFirstNameShouldValidate: () => {
-      dispatch(setFirstNameShouldValidate());
-    },
     setFirstName: (firstName: string) => {
       dispatch(setFirstName(firstName));
     },
-    setLastNameShouldValidate: () => {
-      dispatch(setLastNameShouldValidate());
-    },
     setLastName: (lastName: string) => {
       dispatch(setLastName(lastName));
-    },
-    setEmailShouldValidate: () => {
-      dispatch(setEmailShouldValidate());
     },
     setEmail: (email: string) => {
       dispatch(setEmail(email));
@@ -152,6 +139,14 @@ function countriesDropdown(
   />);
 }
 
+export const formClassName = 'regular-contrib__checkout-form';
+
+export const setShouldValidateFunctions = [
+  setFirstNameShouldValidate,
+  setLastNameShouldValidate,
+  setEmailShouldValidate,
+];
+
 
 // ----- Component ----- //
 
@@ -168,7 +163,6 @@ function NameForm(props: PropTypes) {
             labelText="Email"
             placeholder="Email"
             onChange={props.setEmail}
-            onBlur={onFormFieldBlur(props.setEmailShouldValidate, continueButtonClassName)}
             modifierClasses={['email']}
             showError={shouldShowError(props.email)}
             errorMessage="Please enter a valid email address."
@@ -181,7 +175,6 @@ function NameForm(props: PropTypes) {
         placeholder="First name"
         value={props.firstName.value}
         onChange={props.setFirstName}
-        onBlur={onFormFieldBlur(props.setFirstNameShouldValidate, continueButtonClassName)}
         modifierClasses={['first-name']}
         showError={shouldShowError(props.firstName)}
         errorMessage="Please enter a first name."
@@ -192,7 +185,6 @@ function NameForm(props: PropTypes) {
         placeholder="Last name"
         value={props.lastName.value}
         onChange={props.setLastName}
-        onBlur={onFormFieldBlur(props.setLastNameShouldValidate, continueButtonClassName)}
         modifierClasses={['last-name']}
         showError={shouldShowError(props.lastName)}
         errorMessage="Please enter a last name."

--- a/assets/pages/regular-contributions/components/formFields.jsx
+++ b/assets/pages/regular-contributions/components/formFields.jsx
@@ -154,7 +154,7 @@ function NameForm(props: PropTypes) {
   const continueButtonClassName = 'component-cta-link--continue';
 
   return (
-    <form className="regular-contrib__name-form">
+    <form className={formClassName}>
       {
         !props.isSignedIn ? (
           <TextInput

--- a/assets/pages/regular-contributions/components/regularContributionsPayment.jsx
+++ b/assets/pages/regular-contributions/components/regularContributionsPayment.jsx
@@ -25,6 +25,7 @@ import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import { formFieldIsValid } from 'helpers/checkoutForm/checkoutForm';
 import { setPayPalHasLoaded } from '../regularContributionsActions';
 import { postCheckout } from '../helpers/ajax';
+import { formClassName, setShouldValidateFunctions } from './formFields';
 
 // ----- Types ----- //
 
@@ -33,7 +34,6 @@ export type PaymentStatus = 'NotStarted' | 'Pending' | 'PollingTimedOut' | 'Fail
 type PropTypes = {|
   dispatch: Dispatch<*>,
   email: string,
-  disable: boolean,
   error: ?string,
   isTestUser: boolean,
   isPostDeploymentTestUser: boolean,
@@ -51,6 +51,8 @@ type PropTypes = {|
   stripeSwitchStatus: Status,
   payPalSwitchStatus: Status,
   optimizeExperiments: OptimizeExperiments,
+  canOpen?: () => boolean,
+  whenUnableToOpen?: (dispatch: CheckoutAction)
 |};
 
 
@@ -97,7 +99,8 @@ function RegularContributionsPayment(props: PropTypes, context) {
           props.optimizeExperiments,
         )}
         switchStatus={props.directDebitSwitchStatus}
-        disable={props.disable}
+        canOpen={() => formIsValid(formClassName)}
+        whenUnableToOpen={() => setShouldValidateFunctions}
       />);
   }
 
@@ -120,8 +123,9 @@ function RegularContributionsPayment(props: PropTypes, context) {
     isPostDeploymentTestUser={props.isPostDeploymentTestUser}
     amount={props.amount}
     switchStatus={props.stripeSwitchStatus}
-    disable={props.disable}
     svg={<SvgArrowRightStraight />}
+    canOpen={() => formIsValid(formClassName)}
+    whenUnableToOpen={() => setShouldValidateFunctions}
   />);
 
   const payPalButton = (<PayPalExpressButton
@@ -143,7 +147,8 @@ function RegularContributionsPayment(props: PropTypes, context) {
     hasLoaded={props.payPalHasLoaded}
     setHasLoaded={props.payPalSetHasLoaded}
     switchStatus={props.payPalSwitchStatus}
-    disable={props.disable}
+    canOpen={() => formIsValid(formClassName)}
+    whenUnableToOpen={() => setShouldValidateFunctions}
   />);
 
   return (
@@ -181,10 +186,6 @@ function mapStateToProps(state) {
     isTestUser: state.page.user.isTestUser || false,
     isPostDeploymentTestUser: state.page.user.isPostDeploymentTestUser,
     email: state.page.user.email,
-    disable:
-      !formFieldIsValid(firstName)
-      || !formFieldIsValid(lastName)
-      || !formFieldIsValid(email),
     error: state.page.regularContrib.error,
     paymentStatus: state.page.regularContrib.paymentStatus,
     amount: state.page.regularContrib.amount,

--- a/assets/pages/regular-contributions/components/regularContributionsPayment.jsx
+++ b/assets/pages/regular-contributions/components/regularContributionsPayment.jsx
@@ -22,10 +22,8 @@ import type { Contrib } from 'helpers/contributions';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { Participations } from 'helpers/abTests/abtest';
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
-import { formFieldIsValid } from 'helpers/checkoutForm/checkoutForm';
 import { setPayPalHasLoaded } from '../regularContributionsActions';
 import { postCheckout } from '../helpers/ajax';
-import { formClassName, setShouldValidateFunctions } from './formFields';
 
 // ----- Types ----- //
 
@@ -52,7 +50,7 @@ type PropTypes = {|
   payPalSwitchStatus: Status,
   optimizeExperiments: OptimizeExperiments,
   canOpen: () => boolean,
-  whenUnableToOpen: (dispatch: CheckoutAction) => void,
+  whenUnableToOpen: () => void,
 |};
 
 
@@ -100,7 +98,7 @@ function RegularContributionsPayment(props: PropTypes, context) {
         )}
         switchStatus={props.directDebitSwitchStatus}
         canOpen={props.canOpen}
-        whenUnableToOpen={() => setShouldValidateFunctions}
+        whenUnableToOpen={props.whenUnableToOpen}
       />);
   }
 
@@ -167,21 +165,6 @@ function RegularContributionsPayment(props: PropTypes, context) {
 
 function mapStateToProps(state) {
 
-  const firstName = {
-    value: state.page.user.firstName,
-    ...state.page.checkoutForm.firstName,
-  };
-
-  const lastName = {
-    value: state.page.user.lastName,
-    ...state.page.checkoutForm.lastName,
-  };
-
-  const email = {
-    value: state.page.user.email,
-    ...state.page.checkoutForm.email,
-  };
-
   return {
     isTestUser: state.page.user.isTestUser || false,
     isPostDeploymentTestUser: state.page.user.isPostDeploymentTestUser,
@@ -217,7 +200,6 @@ RegularContributionsPayment.defaultProps = {
   canOpen: () => true,
   whenUnableToOpen: () => undefined,
 };
-
 
 
 // ----- Exports ----- //

--- a/assets/pages/regular-contributions/components/regularContributionsPayment.jsx
+++ b/assets/pages/regular-contributions/components/regularContributionsPayment.jsx
@@ -51,8 +51,8 @@ type PropTypes = {|
   stripeSwitchStatus: Status,
   payPalSwitchStatus: Status,
   optimizeExperiments: OptimizeExperiments,
-  canOpen?: () => boolean,
-  whenUnableToOpen?: (dispatch: CheckoutAction)
+  canOpen: () => boolean,
+  whenUnableToOpen: (dispatch: CheckoutAction) => void,
 |};
 
 
@@ -99,7 +99,7 @@ function RegularContributionsPayment(props: PropTypes, context) {
           props.optimizeExperiments,
         )}
         switchStatus={props.directDebitSwitchStatus}
-        canOpen={() => formIsValid(formClassName)}
+        canOpen={props.canOpen}
         whenUnableToOpen={() => setShouldValidateFunctions}
       />);
   }
@@ -124,8 +124,8 @@ function RegularContributionsPayment(props: PropTypes, context) {
     amount={props.amount}
     switchStatus={props.stripeSwitchStatus}
     svg={<SvgArrowRightStraight />}
-    canOpen={() => formIsValid(formClassName)}
-    whenUnableToOpen={() => setShouldValidateFunctions}
+    canOpen={props.canOpen}
+    whenUnableToOpen={props.whenUnableToOpen}
   />);
 
   const payPalButton = (<PayPalExpressButton
@@ -147,8 +147,8 @@ function RegularContributionsPayment(props: PropTypes, context) {
     hasLoaded={props.payPalHasLoaded}
     setHasLoaded={props.payPalSetHasLoaded}
     switchStatus={props.payPalSwitchStatus}
-    canOpen={() => formIsValid(formClassName)}
-    whenUnableToOpen={() => setShouldValidateFunctions}
+    canOpen={props.canOpen}
+    whenUnableToOpen={props.whenUnableToOpen}
   />);
 
   return (
@@ -212,6 +212,13 @@ function mapDispatchToProps(dispatch: Dispatch<*>) {
     },
   };
 }
+
+RegularContributionsPayment.defaultProps = {
+  canOpen: () => true,
+  whenUnableToOpen: () => undefined,
+};
+
+
 
 // ----- Exports ----- //
 

--- a/assets/pages/regular-contributions/helpers/checkoutForm/__tests__/__snapshots__/checkoutFormReducerTest.js.snap
+++ b/assets/pages/regular-contributions/helpers/checkoutForm/__tests__/__snapshots__/checkoutFormReducerTest.js.snap
@@ -3,18 +3,12 @@
 exports[`user reducer tests should return the initial state 1`] = `
 Object {
   "email": Object {
-    "pattern": /\\^\\[a-zA-Z0-9\\.!#\\$%&'\\*\\+\\\\/=\\?\\^_\`\\{\\|\\}~-\\]\\+@\\[a-zA-Z0-9\\]\\(\\?:\\[a-zA-Z0-9-\\]\\{0,61\\}\\[a-zA-Z0-9\\]\\)\\?\\(\\?:\\\\\\.\\[a-zA-Z0-9\\]\\(\\?:\\[a-zA-Z0-9-\\]\\{0,61\\}\\[a-zA-Z0-9\\]\\)\\?\\)\\+\\$/,
-    "required": true,
     "shouldValidate": false,
   },
   "firstName": Object {
-    "pattern": /\\.\\*/,
-    "required": true,
     "shouldValidate": false,
   },
   "lastName": Object {
-    "pattern": /\\.\\*/,
-    "required": true,
     "shouldValidate": false,
   },
   "stage": "checkout",

--- a/assets/pages/regular-contributions/helpers/checkoutForm/__tests__/checkoutFormActionsTest.js
+++ b/assets/pages/regular-contributions/helpers/checkoutForm/__tests__/checkoutFormActionsTest.js
@@ -10,18 +10,18 @@ import {
 describe('Checkout form', () => {
 
   it('should create an action to set the shouldValidate on the checkout form email field', () => {
-    const expectedAction = { type: 'SET_EMAIL_SHOULD_VALIDATE' };
-    expect(setEmailShouldValidate()).toEqual(expectedAction);
+    const expectedAction = { type: 'SET_EMAIL_SHOULD_VALIDATE', shouldValidate: true };
+    expect(setEmailShouldValidate(true)).toEqual(expectedAction);
   });
 
   it('should create an action to set the shouldValidate on the checkout form first name field', () => {
-    const expectedAction = { type: 'SET_FIRST_NAME_SHOULD_VALIDATE' };
-    expect(setFirstNameShouldValidate()).toEqual(expectedAction);
+    const expectedAction = { type: 'SET_FIRST_NAME_SHOULD_VALIDATE', shouldValidate: true };
+    expect(setFirstNameShouldValidate(true)).toEqual(expectedAction);
   });
 
   it('should create an action to set the shouldValidate on the checkout form last name field', () => {
-    const expectedAction = { type: 'SET_LAST_NAME_SHOULD_VALIDATE' };
-    expect(setLastNameShouldValidate()).toEqual(expectedAction);
+    const expectedAction = { type: 'SET_LAST_NAME_SHOULD_VALIDATE', shouldValidate: true };
+    expect(setLastNameShouldValidate(true)).toEqual(expectedAction);
   });
 
   it('should create an action to set the stage ', () => {

--- a/assets/pages/regular-contributions/helpers/checkoutForm/__tests__/checkoutFormReducerTest.js
+++ b/assets/pages/regular-contributions/helpers/checkoutForm/__tests__/checkoutFormReducerTest.js
@@ -9,7 +9,7 @@ describe('user reducer tests', () => {
   });
 
   it('should handle SET_EMAIL_SHOULD_VALIDATE', () => {
-    const action = { type: 'SET_EMAIL_SHOULD_VALIDATE' };
+    const action = { type: 'SET_EMAIL_SHOULD_VALIDATE', shouldValidate: true };
 
     const newState = reducer(undefined, action);
 
@@ -17,7 +17,7 @@ describe('user reducer tests', () => {
   });
 
   it('should handle SET_FIRST_NAME_SHOULD_VALIDATE', () => {
-    const action = { type: 'SET_FIRST_NAME_SHOULD_VALIDATE' };
+    const action = { type: 'SET_FIRST_NAME_SHOULD_VALIDATE', shouldValidate: true };
 
     const newState = reducer(undefined, action);
 
@@ -25,7 +25,7 @@ describe('user reducer tests', () => {
   });
 
   it('should handle SET_LAST_NAME_SHOULD_VALIDATE', () => {
-    const action = { type: 'SET_LAST_NAME_SHOULD_VALIDATE' };
+    const action = { type: 'SET_LAST_NAME_SHOULD_VALIDATE', shouldValidate: true };
 
     const newState = reducer(undefined, action);
 

--- a/assets/pages/regular-contributions/helpers/checkoutForm/checkoutFormActions.js
+++ b/assets/pages/regular-contributions/helpers/checkoutForm/checkoutFormActions.js
@@ -6,25 +6,25 @@ import { type Stage } from './checkoutFormReducer';
 // ----- Types ----- //
 
 export type Action =
-  | { type: 'SET_EMAIL_SHOULD_VALIDATE' }
-  | { type: 'SET_FIRST_NAME_SHOULD_VALIDATE' }
-  | { type: 'SET_LAST_NAME_SHOULD_VALIDATE' }
+  | { type: 'SET_EMAIL_SHOULD_VALIDATE', shouldValidate: boolean }
+  | { type: 'SET_FIRST_NAME_SHOULD_VALIDATE', shouldValidate: boolean }
+  | { type: 'SET_LAST_NAME_SHOULD_VALIDATE', shouldValidate: boolean }
   | { type: 'SET_STAGE', stage: Stage }
 
 
 // ----- Actions Creators ----- //
 
 
-export function setEmailShouldValidate(): Action {
-  return { type: 'SET_EMAIL_SHOULD_VALIDATE' };
+export function setEmailShouldValidate(shouldValidate: boolean): Action {
+  return { type: 'SET_EMAIL_SHOULD_VALIDATE', shouldValidate };
 }
 
-export function setFirstNameShouldValidate(): Action {
-  return { type: 'SET_FIRST_NAME_SHOULD_VALIDATE' };
+export function setFirstNameShouldValidate(shouldValidate: boolean): Action {
+  return { type: 'SET_FIRST_NAME_SHOULD_VALIDATE', shouldValidate };
 }
 
-export function setLastNameShouldValidate(): Action {
-  return { type: 'SET_LAST_NAME_SHOULD_VALIDATE' };
+export function setLastNameShouldValidate(shouldValidate: boolean): Action {
+  return { type: 'SET_LAST_NAME_SHOULD_VALIDATE', shouldValidate };
 }
 export function setStage(stage: Stage): Action {
   return { type: 'SET_STAGE', stage };

--- a/assets/pages/regular-contributions/helpers/checkoutForm/checkoutFormFieldsSelector.js
+++ b/assets/pages/regular-contributions/helpers/checkoutForm/checkoutFormFieldsSelector.js
@@ -10,37 +10,23 @@ import { type State } from '../../regularContributionsReducer';
 
 function getFormFields(state: State) {
 
-  const firstNameFromState = {
+
+  const firstName = {
+    id: 'first-name',
     value: state.page.user.firstName,
     ...state.page.checkoutForm.firstName,
   };
 
-  const lastNameFromState = {
+  const lastName = {
+    id: 'lastName',
     value: state.page.user.lastName,
     ...state.page.checkoutForm.lastName,
   };
 
-  const emailFromState = {
+  const email = {
+    id: 'email',
     value: state.page.user.email,
     ...state.page.checkoutForm.email,
-  };
-
-  const firstName = {
-    value: firstNameFromState.value,
-    shouldValidate: firstNameFromState.shouldValidate,
-    isValid: formFieldIsValid(firstNameFromState),
-  };
-
-  const lastName = {
-    value: lastNameFromState.value,
-    shouldValidate: lastNameFromState.shouldValidate,
-    isValid: formFieldIsValid(lastNameFromState),
-  };
-
-  const email = {
-    value: emailFromState.value,
-    shouldValidate: emailFromState.shouldValidate,
-    isValid: formFieldIsValid(emailFromState),
   };
 
   return { firstName, lastName, email };

--- a/assets/pages/regular-contributions/helpers/checkoutForm/checkoutFormFieldsSelector.js
+++ b/assets/pages/regular-contributions/helpers/checkoutForm/checkoutFormFieldsSelector.js
@@ -2,7 +2,6 @@
 
 // ----- Imports ----- //
 
-import { formFieldIsValid } from 'helpers/checkoutForm/checkoutForm';
 import { type State } from '../../regularContributionsReducer';
 
 

--- a/assets/pages/regular-contributions/helpers/checkoutForm/checkoutFormFieldsSelector.js
+++ b/assets/pages/regular-contributions/helpers/checkoutForm/checkoutFormFieldsSelector.js
@@ -18,7 +18,7 @@ function getFormFields(state: State) {
   };
 
   const lastName = {
-    id: 'lastName',
+    id: 'last-name',
     value: state.page.user.lastName,
     ...state.page.checkoutForm.lastName,
   };

--- a/assets/pages/regular-contributions/helpers/checkoutForm/checkoutFormReducer.js
+++ b/assets/pages/regular-contributions/helpers/checkoutForm/checkoutFormReducer.js
@@ -1,7 +1,6 @@
 // @flow
 
 // ----- Imports ----- //
-import { emailRegexPattern } from 'helpers/checkoutForm/checkoutForm';
 import { type Action } from './checkoutFormActions';
 
 // ----- Types ----- //
@@ -45,13 +44,13 @@ function checkoutFormReducer(
 
   switch (action.type) {
     case 'SET_FIRST_NAME_SHOULD_VALIDATE':
-      return { ...state, firstName: { ...state.firstName, shouldValidate: true } };
+      return { ...state, firstName: { ...state.firstName, shouldValidate: action.shouldValidate } };
 
     case 'SET_LAST_NAME_SHOULD_VALIDATE':
-      return { ...state, lastName: { ...state.lastName, shouldValidate: true } };
+      return { ...state, lastName: { ...state.lastName, shouldValidate: action.shouldValidate } };
 
     case 'SET_EMAIL_SHOULD_VALIDATE':
-      return { ...state, email: { ...state.email, shouldValidate: true } };
+      return { ...state, email: { ...state.email, shouldValidate: action.shouldValidate } };
 
     case 'SET_STAGE':
       return { ...state, stage: action.stage };

--- a/assets/pages/regular-contributions/helpers/checkoutForm/checkoutFormReducer.js
+++ b/assets/pages/regular-contributions/helpers/checkoutForm/checkoutFormReducer.js
@@ -8,9 +8,7 @@ import { type Action } from './checkoutFormActions';
 
 
 export type CheckoutFormAttribute = {
-  shouldValidate: boolean,
-  required: boolean,
-  pattern: RegExp,
+  shouldValidate: boolean;
 }
 
 export type Stage = 'checkout' | 'payment'
@@ -27,18 +25,12 @@ export type RegularContributionsCheckoutFormState = {
 const initialState: RegularContributionsCheckoutFormState = {
   email: {
     shouldValidate: false,
-    required: true,
-    pattern: emailRegexPattern,
   },
   firstName: {
     shouldValidate: false,
-    required: true,
-    pattern: /.*/,
   },
   lastName: {
     shouldValidate: false,
-    required: true,
-    pattern: /.*/,
   },
   stage: 'checkout',
 };

--- a/assets/pages/regular-contributions/regularContributions.jsx
+++ b/assets/pages/regular-contributions/regularContributions.jsx
@@ -3,7 +3,6 @@
 // ----- Imports ----- //
 
 import React from 'react';
-import type { Dispatch } from 'redux';
 import { Provider } from 'react-redux';
 import { Route } from 'react-router';
 import Loadable from 'react-loadable';
@@ -22,8 +21,7 @@ import ContributionsCheckoutContainer from './components/contributionsCheckoutCo
 import ContributionsGuestCheckoutContainer from './components/contributionsGuestCheckoutContainer';
 import MarketingConsentContainer from './components/marketingConsentContainer';
 import reducer from './regularContributionsReducer';
-import { type Action as CheckoutAction } from './helpers/checkoutForm/checkoutFormActions';
-import FormFields, {formClassName, setShouldValidateFunctions} from './components/formFields';
+import FormFields, { formClassName, setShouldValidateFunctions } from './components/formFields';
 import RegularContributionsPayment from './components/regularContributionsPayment';
 
 // ----- Page Startup ----- //
@@ -65,7 +63,7 @@ const router = (
                 <RegularContributionsPayment
                   whenUnableToOpen={
                     () =>
-                      setShouldValidateFunctions.forEach(f => store.dispatch(f()))
+                      setShouldValidateFunctions.forEach(f => store.dispatch(f(true)))
                   }
                   canOpen={
                     () => formIsValid(formClassName)

--- a/assets/pages/regular-contributions/regularContributions.jsx
+++ b/assets/pages/regular-contributions/regularContributions.jsx
@@ -64,8 +64,8 @@ const router = (
               payment={
                 <RegularContributionsPayment
                   whenUnableToOpen={
-                    (dispatch: Dispatch<CheckoutAction>) =>
-                      setShouldValidateFunctions.forEach(f => dispatch(f()))
+                    () =>
+                      setShouldValidateFunctions.forEach(f => store.dispatch(f()))
                   }
                   canOpen={
                     () => formIsValid(formClassName)

--- a/assets/pages/regular-contributions/regularContributions.jsx
+++ b/assets/pages/regular-contributions/regularContributions.jsx
@@ -3,6 +3,7 @@
 // ----- Imports ----- //
 
 import React from 'react';
+import type { Dispatch } from 'redux';
 import { Provider } from 'react-redux';
 import { Route } from 'react-router';
 import Loadable from 'react-loadable';
@@ -16,11 +17,13 @@ import { getAmount, getPaymentMethod } from 'helpers/checkouts';
 import { parseRegularContributionType } from 'helpers/contributions';
 import { getQueryParameter } from 'helpers/url';
 import { detect as detectCountryGroup } from 'helpers/internationalisation/countryGroup';
+import { formIsValid } from 'helpers/checkoutForm/checkoutForm';
 import ContributionsCheckoutContainer from './components/contributionsCheckoutContainer';
 import ContributionsGuestCheckoutContainer from './components/contributionsGuestCheckoutContainer';
 import MarketingConsentContainer from './components/marketingConsentContainer';
 import reducer from './regularContributionsReducer';
-import FormFields from './components/formFields';
+import { type Action as CheckoutAction } from './helpers/checkoutForm/checkoutFormActions';
+import FormFields, {formClassName, setShouldValidateFunctions} from './components/formFields';
 import RegularContributionsPayment from './components/regularContributionsPayment';
 
 // ----- Page Startup ----- //
@@ -58,7 +61,17 @@ const router = (
             <ContributionsCheckoutContainer
               contributionType={contributionType}
               form={<FormFields />}
-              payment={<RegularContributionsPayment />}
+              payment={
+                <RegularContributionsPayment
+                  whenUnableToOpen={
+                    (dispatch: Dispatch<CheckoutAction>) =>
+                      setShouldValidateFunctions.forEach(f => dispatch(f()))
+                  }
+                  canOpen={
+                    () => formIsValid(formClassName)
+                  }
+                />
+              }
             />
           )}
         />
@@ -69,7 +82,9 @@ const router = (
             <ContributionsGuestCheckoutContainer
               contributionType={contributionType}
               form={<FormFields />}
-              payment={<RegularContributionsPayment />}
+              payment={
+                <RegularContributionsPayment />
+              }
             />
           )}
         />

--- a/assets/pages/regular-contributions/regularContributions.scss
+++ b/assets/pages/regular-contributions/regularContributions.scss
@@ -103,16 +103,6 @@
     }
   }
 
-
-  .component-paypal-button-checkout__disabled-pop-up-button {
-    margin-bottom: $gu-v-spacing;
-    width: 100%;
-
-    @include mq($from: phablet) {
-      width: 304px;
-    }
-  }
-
   .component-stripe-pop-up-button {
     @include mq($from: phablet) {
       width: 304px;


### PR DESCRIPTION
## Why are you doing this?

We had previously thought that we couldn't intercept the onClick events of the PayPal Express button, so we couldn't fire client-side validation on the click of the button. This lead to some rather horrible greyed out button validation on the recurring checkout, and lead to us implementing an overly complicated validation system.

That turned out to be incorrect, you can in fact intercept the onClick events of the PayPal Express button. 

Due to Regis' upcoming test, it almost seems pointless implementing this now, but for one reason. The  old validation fired the `setShouldValidate` functions for the form fields on the `blur` of the field, which was causing a weird bug where you had to click on the payment button twice. As we now can intercept the click of the paypal button, we can fire the `setShouldValidate` functions when the PayPal button is pressed, meaning we don't need the onBlur anymore, which fixes the bug without the hacky half-fix we had in place before. 

I've also switched to using the browser DOM validation to determine if the form is valid. We can do this now as we know that we will only check the validity of the forms on a button click, at which point the fields are guaranteed to be in the DOM, and it is ultimately simpler than having custom validation functions for the values in the state. 

At this point, we could ditch the custom error messages and all this setShouldValidate business, and just have the browser do the validation on the submission of the form, but in the interest of expediency I don't want to spend any more time on form validation for a form that won't exist in 2 weeks, and this fixes the bug ready for the test. 

As you can see from the GIFs below, the buttons are now always visibly, but if the form is not valid they are not clickable. 

| Before | After |
|-----|-----|
|![old](https://user-images.githubusercontent.com/2844554/45355444-55a09f80-b5b8-11e8-9942-17c6fcf53757.gif)|![new](https://user-images.githubusercontent.com/2844554/45355736-1161cf00-b5b9-11e8-9cd1-56a571e57e93.gif)|

@Mullefa @joelochlann @Ap0c @rupertbates @lmath @JustinPinner 