### PR TITLE
Settings from file or s3

### DIFF
--- a/app/admin/Settings.scala
+++ b/app/admin/Settings.scala
@@ -67,7 +67,7 @@ object AdminSettingsSource {
   private def fromS3(config: Config): Either[Throwable, AdminSettingsSource] = Either.catchNonFatal {
     S3(
       config.getString("adminSettingsSource.s3.bucket"),
-      config.getString("adminSettingsSource.s3.key"),
+      config.getString("adminSettingsSource.s3.key")
     )
   }
 

--- a/app/admin/Settings.scala
+++ b/app/admin/Settings.scala
@@ -10,6 +10,7 @@ import io.circe.parser._
 import cats.implicits._
 import com.amazonaws.services.s3.AmazonS3
 import io.circe.syntax._
+import monitoring.SafeLogger
 
 case class Switches(
     oneOffPaymentMethods: PaymentMethodsSwitch,
@@ -30,7 +31,10 @@ object Settings {
       source <- AdminSettingsSource.fromConfig(config)
       rawJson <- getRawJson(source).leftMap(err => new Error(s"Could not fetch settings from $source. $err"))
       settings <- decodeJson(rawJson).leftMap(err => new Error(s"Could not decode settings JSON from $source. $err"))
-    } yield settings
+    } yield {
+      SafeLogger.info(s"Loaded settings from $source")
+      settings
+    }
 
   private def decodeJson(rawJson: String): Either[Throwable, Settings] = decode[Settings](rawJson)
 

--- a/app/admin/Settings.scala
+++ b/app/admin/Settings.scala
@@ -24,7 +24,7 @@ case class Settings(
 )
 
 object Settings {
-  def fromDiskOrS3(config: Config, s3: AmazonS3): Either[Throwable, Settings] = {
+  def fromDiskOrS3(config: Config)(implicit s3: AmazonS3): Either[Throwable, Settings] = {
     val adminSettingsSource: Either[Throwable, AdminSettingsSource] = if (config.hasPath("local.path")) {
       AdminSettingsSource.fromDisk(config.getString("local.path"))
     } else if (config.hasPath("s3")) {

--- a/app/admin/Settings.scala
+++ b/app/admin/Settings.scala
@@ -43,10 +43,9 @@ object Settings {
     }
 
     adminSettingsSource.flatMap(settingsSource =>
-      decode[Settings](settingsSource.path)
+      decode[Settings](settingsSource.rawJson)
         .leftMap(err => new Error(s"Error decoding settings JSON at ${settingsSource.path}. Circe error: ${err.getMessage}")))
   }
-
 
   def experimentsFromConfig(config: Config, rootKey: String): Map[String, ExperimentSwitch] =
     config.getConfigList(rootKey).asScala.map(ExperimentSwitch.fromConfig).map { x => x.name -> x }.toMap

--- a/app/admin/Settings.scala
+++ b/app/admin/Settings.scala
@@ -28,8 +28,8 @@ object Settings {
   def fromDiskOrS3(config: Config)(implicit s3: AmazonS3): Either[Throwable, Settings] =
     for {
       source <- AdminSettingsSource.fromConfig(config)
-      rawJson <- getRawJson(source).leftMap(err => new Error(s"Could not fetch JSON from $source. $err"))
-      settings <- decodeJson(rawJson).leftMap(err => new Error(s"Could not decode JSON from $source. $err"))
+      rawJson <- getRawJson(source).leftMap(err => new Error(s"Could not fetch settings from $source. $err"))
+      settings <- decodeJson(rawJson).leftMap(err => new Error(s"Could not decode settings JSON from $source. $err"))
     } yield settings
 
   private def decodeJson(rawJson: String): Either[Throwable, Settings] = decode[Settings](rawJson)
@@ -53,8 +53,12 @@ object Settings {
 
 sealed trait AdminSettingsSource
 
-case class S3(bucket: String, key: String) extends AdminSettingsSource
-case class LocalFile(path: String) extends AdminSettingsSource
+case class S3(bucket: String, key: String) extends AdminSettingsSource {
+  override def toString: String = s"s3://$bucket/$key"
+}
+case class LocalFile(path: String) extends AdminSettingsSource {
+  override def toString: String = s"local file at $path"
+}
 
 object AdminSettingsSource {
 

--- a/app/admin/Settings.scala
+++ b/app/admin/Settings.scala
@@ -1,5 +1,6 @@
 package admin
 
+import scala.io.Source
 import com.typesafe.config.Config
 import collection.JavaConverters._
 import play.api.mvc.RequestHeader
@@ -27,6 +28,18 @@ object Settings {
         SwitchState.fromConfig(config, "internationalSubscribePages")
       )
     )
+
+  def fromDiskOrS3(adminSettingsSource: Config): String = {
+    if (adminSettingsSource.hasPath("local.path")) {
+      val homeDir = System.getProperty("user.home")
+      val localPath = adminSettingsSource.getString("local.path").replaceFirst("~", homeDir)
+      val bufferedSource = Source.fromFile(localPath)
+      val rawJson = bufferedSource.getLines.mkString
+      bufferedSource.close()
+
+      rawJson
+    } else ""
+  }
 
   def experimentsFromConfig(config: Config, rootKey: String): Map[String, ExperimentSwitch] =
     config.getConfigList(rootKey).asScala.map(ExperimentSwitch.fromConfig).map { x => x.name -> x }.toMap

--- a/app/config/Configuration.scala
+++ b/app/config/Configuration.scala
@@ -4,12 +4,13 @@ import com.gu.support.config.{PayPalConfigProvider, Stage, StripeConfigProvider}
 import com.typesafe.config.ConfigFactory
 import config.ConfigImplicits._
 import services.GoCardlessConfigProvider
-import services.aws.{AwsConfig, AwsS3Client}
+import services.aws.AwsConfig
+import com.amazonaws.services.s3.AmazonS3
 import services.stepfunctions.StateMachineArn
 import admin.Settings
 import cats.syntax.either._
 
-class Configuration {
+class Configuration(implicit s3: AmazonS3) {
   val config = ConfigFactory.load()
 
   lazy val stage = Stage.fromString(config.getString("stage")).get
@@ -26,7 +27,7 @@ class Configuration {
 
   lazy val supportUrl = config.getString("support.url")
 
-  lazy val paymentApiUrl = config.getString("paymentApi.url");
+  lazy val paymentApiUrl = config.getString("paymentApi.url")
 
   lazy val membersDataServiceApiUrl = config.getString("membersDataService.api.url")
 
@@ -40,7 +41,6 @@ class Configuration {
 
   lazy val stepFunctionArn = StateMachineArn.fromString(config.getString("supportWorkers.arn")).get
 
-  private val s3 = AwsS3Client.getClient
-  implicit val settings = Settings.fromDiskOrS3(config.getConfig("adminSettingsSource"), s3).valueOr(throw _)
+  implicit val settings = Settings.fromDiskOrS3(config.getConfig("adminSettingsSource")).valueOr(throw _)
 
 }

--- a/app/config/Configuration.scala
+++ b/app/config/Configuration.scala
@@ -4,7 +4,7 @@ import com.gu.support.config.{PayPalConfigProvider, Stage, StripeConfigProvider}
 import com.typesafe.config.ConfigFactory
 import config.ConfigImplicits._
 import services.GoCardlessConfigProvider
-import services.aws.AwsConfig
+import services.aws.{AwsConfig, AwsS3Client}
 import services.stepfunctions.StateMachineArn
 import admin.Settings
 import cats.syntax.either._
@@ -40,6 +40,7 @@ class Configuration {
 
   lazy val stepFunctionArn = StateMachineArn.fromString(config.getString("supportWorkers.arn")).get
 
-  implicit val settings = Settings.fromDiskOrS3(config.getConfig("adminSettingsSource")).valueOr(throw _)
+  private val s3 = AwsS3Client.getClient
+  implicit val settings = Settings.fromDiskOrS3(config.getConfig("adminSettingsSource"), s3).valueOr(throw _)
 
 }

--- a/app/config/Configuration.scala
+++ b/app/config/Configuration.scala
@@ -41,4 +41,5 @@ class Configuration {
 
   implicit val settings = Settings.fromConfig(config.getConfig("switches"))
 
+  implicit val settingsFromDisk = Settings.fromDiskOrS3(config.getConfig("adminSettingsSource"))
 }

--- a/app/config/Configuration.scala
+++ b/app/config/Configuration.scala
@@ -41,6 +41,6 @@ class Configuration(implicit s3: AmazonS3) {
 
   lazy val stepFunctionArn = StateMachineArn.fromString(config.getString("supportWorkers.arn")).get
 
-  implicit val settings = Settings.fromDiskOrS3(config.getConfig("adminSettingsSource")).valueOr(throw _)
+  implicit val settings = Settings.fromDiskOrS3(config).valueOr(throw _)
 
 }

--- a/app/config/Configuration.scala
+++ b/app/config/Configuration.scala
@@ -7,6 +7,7 @@ import services.GoCardlessConfigProvider
 import services.aws.AwsConfig
 import services.stepfunctions.StateMachineArn
 import admin.Settings
+import cats.syntax.either._
 
 class Configuration {
   val config = ConfigFactory.load()
@@ -39,7 +40,6 @@ class Configuration {
 
   lazy val stepFunctionArn = StateMachineArn.fromString(config.getString("supportWorkers.arn")).get
 
-  implicit val settings = Settings.fromConfig(config.getConfig("switches"))
+  implicit val settings = Settings.fromDiskOrS3(config.getConfig("adminSettingsSource")).valueOr(throw _)
 
-  implicit val settingsFromDisk = Settings.fromDiskOrS3(config.getConfig("adminSettingsSource"))
 }

--- a/app/services/aws/AwsS3Client.scala
+++ b/app/services/aws/AwsS3Client.scala
@@ -1,12 +1,11 @@
 package services.aws
 
 import com.amazonaws.regions.Regions
-import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import services.aws
 
 object AwsS3Client {
-  def getClient: AmazonS3 =
+  implicit val s3: AmazonS3 =
     AmazonS3ClientBuilder
       .standard()
       .withRegion(Regions.EU_WEST_1)

--- a/app/services/aws/AwsS3Client.scala
+++ b/app/services/aws/AwsS3Client.scala
@@ -1,0 +1,15 @@
+package services.aws
+
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import services.aws
+
+object AwsS3Client {
+  def getClient: AmazonS3 =
+    AmazonS3ClientBuilder
+      .standard()
+      .withRegion(Regions.EU_WEST_1)
+      .withCredentials(aws.CredentialsProvider)
+      .build()
+}

--- a/app/wiring/ApplicationConfiguration.scala
+++ b/app/wiring/ApplicationConfiguration.scala
@@ -1,6 +1,7 @@
 package wiring
 
 import config.{Configuration, StringsConfig}
+import services.aws.AwsS3Client.s3
 
 trait ApplicationConfiguration {
   val appConfig = new Configuration()

--- a/build.sbt
+++ b/build.sbt
@@ -61,6 +61,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-kms" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-stepfunctions" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-sts" % awsVersion,
+  "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,
   "org.typelevel" %% "cats-core" % "1.0.1",
   "com.dripower" %% "play-circe" % "2609.1",
   "com.gu" %% "support-models" % "0.32",

--- a/cloud-formation/cfn.yaml
+++ b/cloud-formation/cfn.yaml
@@ -102,6 +102,13 @@ Resources:
               - Effect: Allow
                 Action: s3:GetObject
                 Resource: !Sub arn:aws:s3:::membership-private/${Stage}/support-frontend.private.conf
+        - PolicyName: SettingsBucket
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action: s3:GetObject
+                Resource: !Sub arn:aws:s3:::support-frontend-admin-console/${Stage}/*
         - PolicyName: UpdateSSHKeys
           PolicyDocument:
             Version: 2012-10-17

--- a/conf/CODE.public.conf
+++ b/conf/CODE.public.conf
@@ -56,7 +56,7 @@ switches {
   internationalSubscribePages=On
 }
 
-adminSettings.s3 {
+adminSettingsSource.s3 {
   bucket="support-frontend-admin-console"
   key= "settings.json"
 }

--- a/conf/CODE.public.conf
+++ b/conf/CODE.public.conf
@@ -18,45 +18,8 @@ paymentApi.url="https://payment.code.dev-guardianapis.com"
 membersDataService.api.url="https://members-data-api.code.dev-theguardian.com"
 play.filters.headers.contentSecurityPolicy = "default-src 'self' polyfill.guim.co.uk www.paypalobjects.com www.paypal.com www.sandbox.paypal.com js.stripe.com pasteup.guim.co.uk ophan.theguardian.com j.ophan.co.uk media.guim.co.uk www.google-analytics.com www.googletagmanager.com tagmanager.google.com www.googleadservices.com googleads.g.doubleclick.net www.google.com www.google.co.uk optimize.google.com static.ads-twitter.com bat.bing.com bid.g.doubleclick.net t.co analytics.twitter.com stats.g.doubleclick.net www.youtube.com connect.facebook.net www.facebook.com consumer.krxd.net cdn.krxd.net beacon.krxd.net secure.adnxs.com checkout.stripe.com fonts.googleapis.com ssl.gstatic.com www.gstatic.com fonts.gstatic.com sentry.io data: wss: 'unsafe-inline' q.stripe.com payment.code.dev-guardianapis.com"
 
-// ------------------------ Feature switches ----------------------------
-// To disable a feature change the value from On to Off and redeploy the app.
-// To override a value for local development change it in your private conf file
-// /etc/gu/support-frontend.private.conf and that value will be used instead.
-switches {
-  //Payment methods for one-off contributions
-  oneOff {
-    stripe=On
-    // |----------------------------------|
-    // |-----------24/7 Support-----------|
-    // |----------------------------------|
-    payPal=On     // Comment this line
-    //payPal=Off  // Uncomment this line
-    // |----------------------------------|
-    // |-----------24/7 Support-----------|
-    // |----------------------------------|
-  }
-  //Payment methods for recurring contributions
-  recurring {
-    stripe=On
-    payPal=On
-    directDebit=On
-  }
-  //Google Optimize tags
-  optimize=On
-
-  abtests = [
-    {
-      name=newPaymentFlow
-      description=Redesign of the payment flow UI
-      segment=Perc0
-      state=On
-    }
-  ]
-
-  internationalSubscribePages=On
-}
-
+# Settings configurable via the admin console
 adminSettingsSource.s3 {
   bucket="support-frontend-admin-console"
-  key= "settings.json"
+  key= "CODE/settings.json"
 }

--- a/conf/DEV.public.conf
+++ b/conf/DEV.public.conf
@@ -18,4 +18,11 @@ paymentApi.url="https://payment.code.dev-guardianapis.com"
 membersDataService.api.url="https://members-data-api.thegulocal.com"
 play.filters.headers.contentSecurityPolicy = "default-src 'self' polyfill.guim.co.uk www.paypalobjects.com www.paypal.com www.sandbox.paypal.com js.stripe.com pasteup.guim.co.uk ophan.theguardian.com j.ophan.co.uk media.guim.co.uk www.google-analytics.com www.googletagmanager.com tagmanager.google.com www.googleadservices.com googleads.g.doubleclick.net www.google.com www.google.co.uk optimize.google.com static.ads-twitter.com bat.bing.com bid.g.doubleclick.net t.co analytics.twitter.com stats.g.doubleclick.net www.youtube.com connect.facebook.net www.facebook.com consumer.krxd.net cdn.krxd.net beacon.krxd.net secure.adnxs.com checkout.stripe.com fonts.googleapis.com ssl.gstatic.com www.gstatic.com fonts.gstatic.com sentry.io data: wss: 'unsafe-inline' 'unsafe-eval'  q.stripe.com payment.code.dev-guardianapis.com"
 
-adminSettingsSource.local.path="~/.gu/support-frontend-admin-console/settings.json"
+# Settings configurable via the admin console
+adminSettingsSource.s3 {
+  bucket="support-frontend-admin-console"
+  key= "DEV/settings.json"
+}
+
+# Uncomment the line below if you want to override admin settings locally
+# adminSettingsSource.local.path="~/.gu/support-frontend-admin-console/settings.json"

--- a/conf/DEV.public.conf
+++ b/conf/DEV.public.conf
@@ -18,35 +18,4 @@ paymentApi.url="https://payment.code.dev-guardianapis.com"
 membersDataService.api.url="https://members-data-api.thegulocal.com"
 play.filters.headers.contentSecurityPolicy = "default-src 'self' polyfill.guim.co.uk www.paypalobjects.com www.paypal.com www.sandbox.paypal.com js.stripe.com pasteup.guim.co.uk ophan.theguardian.com j.ophan.co.uk media.guim.co.uk www.google-analytics.com www.googletagmanager.com tagmanager.google.com www.googleadservices.com googleads.g.doubleclick.net www.google.com www.google.co.uk optimize.google.com static.ads-twitter.com bat.bing.com bid.g.doubleclick.net t.co analytics.twitter.com stats.g.doubleclick.net www.youtube.com connect.facebook.net www.facebook.com consumer.krxd.net cdn.krxd.net beacon.krxd.net secure.adnxs.com checkout.stripe.com fonts.googleapis.com ssl.gstatic.com www.gstatic.com fonts.gstatic.com sentry.io data: wss: 'unsafe-inline' 'unsafe-eval'  q.stripe.com payment.code.dev-guardianapis.com"
 
-// ------------------------ Feature switches ----------------------------
-// To override a value for local development change it in your private conf file
-// /etc/gu/support-frontend.private.conf and that value will be used instead.
-switches {
-
-  //Payment methods for one-off contributions
-  oneOff {
-    stripe=On
-    payPal=On
-  }
-  //Payment methods for recurring contributions
-  recurring {
-    stripe=On
-    payPal=On
-    directDebit=On
-  }
-  //Google Optimize tags
-  optimize=Off
-
-  abtests = [
-    {
-      name=newPaymentFlow
-      description=Redesign of the payment flow UI
-      segment=Perc0
-      state=On
-    }
-  ]
-
-  internationalSubscribePages=On
-}
-
 adminSettingsSource.local.path="~/.gu/support-frontend-admin-console/settings.json"

--- a/conf/DEV.public.conf
+++ b/conf/DEV.public.conf
@@ -49,4 +49,4 @@ switches {
   internationalSubscribePages=On
 }
 
-adminSettings.local.path="~/.gu/support-frontend-admin-console/settings.json"
+adminSettingsSource.local.path="~/.gu/support-frontend-admin-console/settings.json"

--- a/conf/PROD.public.conf
+++ b/conf/PROD.public.conf
@@ -17,45 +17,8 @@ paymentApi.url="https://payment.guardianapis.com"
 membersDataService.api.url="https://members-data-api.theguardian.com"
 play.filters.headers.contentSecurityPolicy = "default-src 'self' polyfill.guim.co.uk www.paypalobjects.com www.paypal.com www.sandbox.paypal.com js.stripe.com pasteup.guim.co.uk ophan.theguardian.com j.ophan.co.uk media.guim.co.uk www.google-analytics.com www.googletagmanager.com tagmanager.google.com www.googleadservices.com googleads.g.doubleclick.net www.google.com www.google.co.uk optimize.google.com static.ads-twitter.com bat.bing.com bid.g.doubleclick.net t.co analytics.twitter.com stats.g.doubleclick.net www.youtube.com connect.facebook.net www.facebook.com consumer.krxd.net cdn.krxd.net beacon.krxd.net secure.adnxs.com checkout.stripe.com fonts.googleapis.com ssl.gstatic.com www.gstatic.com fonts.gstatic.com sentry.io data: wss: 'unsafe-inline' q.stripe.com payment.guardianapis.com"
 
-// ---------------------------Feature switches---------------------------
-// To disable a feature change the value from On to Off and redeploy
-// the app using Riff Raff
-
-switches {
-  //Payment methods for one-off contributions
-  oneOff {
-    stripe=On
-    // |----------------------------------|
-    // |-----------24/7 Support-----------|
-    // |----------------------------------|
-    payPal=On     // Comment this line
-    //payPal=Off  // Uncomment this line
-    // |----------------------------------|
-    // |-----------24/7 Support-----------|
-    // |----------------------------------|
-  }
-  //Payment methods for recurring contributions
-  recurring {
-    stripe=On
-    payPal=On
-    directDebit=On
-  }
-  //Google Optimize tags
-  optimize=On
-
-  abtests = [
-    {
-      name=newPaymentFlow
-      description=Redesign of the payment flow UI
-      segment=Perc0
-      state=On
-    }
-  ]
-
-  internationalSubscribePages=On
-}
-
+# Settings configurable via the admin console
 adminSettingsSource.s3 {
   bucket="support-frontend-admin-console"
-  key= "settings.json"
+  key= "PROD/settings.json"
 }

--- a/conf/PROD.public.conf
+++ b/conf/PROD.public.conf
@@ -55,7 +55,7 @@ switches {
   internationalSubscribePages=On
 }
 
-adminSettings.s3 {
+adminSettingsSource.s3 {
   bucket="support-frontend-admin-console"
   key= "settings.json"
 }


### PR DESCRIPTION
Following on from #922 and #937

`switches` should no longer be set inside the Play config. Instead, the Play config must specify at least one of these (example values given):

```
adminSettingsSource.s3 {
  bucket="support-frontend-admin-console"
  key= "DEV/settings.json"
}
```

```
adminSettingsSource.local.path="~/.gu/support-frontend-admin-console/settings.json"
```

It will look for the `adminSettingsSource.local.path` config first. If not present, it will expect both `adminSettingsSource.s3.bucket` and `adminSettingsSource.s3.key`. If these aren't present, the app will not start up. Similarly the app will not start up if it's unable to fetch and decode the settings from the specified location.