### PR TITLE
Update Android app store link

### DIFF
--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -36,7 +36,9 @@ export type SubsUrls = {
 const subsUrl = 'https://subscribe.theguardian.com';
 const patronsUrl = 'https://patrons.theguardian.com';
 const defaultIntCmp = 'gdnwb_copts_bundles_landing_default';
-const androidAppUrl = 'https://play.google.com/store/apps/details?id=com.guardian';
+const iOSAppUrl = 'https://itunes.apple.com/app/the-guardian/id409128287?mt=8';
+const androidAppUrl = 'https://theguardian.app.link/dPnRUMLd1P';
+const dailyEditionUrl = 'https://itunes.apple.com/app/guardian-observer-daily-edition/id452707806?mt=8';
 
 const memUrls: {
   [MemProduct]: string,


### PR DESCRIPTION
## Why are you doing this?

We have now integrated the [Branch.io](https://docs.branch.io/) deferred deep linking SDK into our Android app (iOS have a card in the backlog) this allows us to add links to the support site which will go directly to a purchase subscription page in the app if it is already installed or the app store if it is not.  User who go via the app store will be taken to the purchase screen on first launch once they do install the app.

[**Trello Card**](https://trello.com/c/gJvqGanY/1872-change-android-premium-tier-link-on-subscribe-page-to-a-deep-link)
