### PR TITLE
Log errors on app startup

### DIFF
--- a/app/wiring/AppLoader.scala
+++ b/app/wiring/AppLoader.scala
@@ -1,9 +1,10 @@
 package wiring
 
+import com.typesafe.scalalogging.StrictLogging
 import play.api.ApplicationLoader.Context
 import play.api._
 
-class AppLoader extends ApplicationLoader {
+class AppLoader extends ApplicationLoader with StrictLogging {
 
   override def load(context: Context): Application = {
 
@@ -11,6 +12,13 @@ class AppLoader extends ApplicationLoader {
       _.configure(context.environment)
     }
 
-    (new BuiltInComponentsFromContext(context) with AppComponents).application
+    try {
+      (new BuiltInComponentsFromContext(context) with AppComponents).application
+    } catch {
+      case err: Throwable => {
+        logger.error("Could not start application", err)
+        throw err
+      }
+    }
   }
 }


### PR DESCRIPTION
If errors occur on app startup that prevent Play from starting, we don't see them in CloudWatch. That makes them very hard to debug.

This should let see these errors in CloudWatch so we can more easily debug failed deploys

We did something similar in the Payment API: https://github.com/guardian/payment-api/blob/master/src/main/scala/MyApplicationLoader.scala#L25-L33