### PR TITLE
Fix a broken CTA on the digipack page

### DIFF
--- a/assets/pages/digital-subscription-landing/components/independentJournalismSection.scss
+++ b/assets/pages/digital-subscription-landing/components/independentJournalismSection.scss
@@ -65,8 +65,6 @@
   position: absolute;
   left: -281px;
   top: -34px;
-  margin-bottom: -123px;
-  z-index: 5;
   @include mq($until: leftCol) {
     display: none;
   }


### PR DESCRIPTION
## Why are you doing this?
### Before:
![support-uk-subscribe-half-button-working](https://user-images.githubusercontent.com/181371/45440447-2f602a00-b6b4-11e8-917e-34533ef6a7b2.gif)
### After:
![fixed-cta](https://user-images.githubusercontent.com/181371/45440458-35560b00-b6b4-11e8-954e-26d4cba9346f.gif)

[**Trello Card**](https://trello.com/c/Gtgr11Kd/1920-cta-is-half-broken)
