### PR TITLE
Don't set disabled state of buttons 

### DIFF
--- a/assets/components/paymentButtons/directDebitPopUpButton/directDebitPopUpButton.jsx
+++ b/assets/components/paymentButtons/directDebitPopUpButton/directDebitPopUpButton.jsx
@@ -107,7 +107,6 @@ function Button(props: {
       id="qa-pay-with-direct-debit"
       className="component-direct-debit-pop-up-button"
       onClick={onClick}
-      disabled={!props.canOpen()}
     >
       Pay with Direct Debit
       <SvgArrowRightStraight />

--- a/assets/components/paymentButtons/stripePopUpButton/stripePopUpButton.jsx
+++ b/assets/components/paymentButtons/stripePopUpButton/stripePopUpButton.jsx
@@ -75,7 +75,6 @@ function Button(props: PropTypes) {
       id="qa-pay-with-card"
       className="component-stripe-pop-up-button"
       onClick={onClick}
-      disabled={!props.canOpen()}
     >
       Pay with debit/credit card {props.svg}
     </button>


### PR DESCRIPTION
## Why are you doing this?
We have no need to set the disabled state on the buttons, as we are dealing with the clicks in the `onClick` handler. 

This was actually causing a bug whereby the stripe one-off button was loading is a disabled state, as on the first pageload there are no DOM elements to check the validity for, so `props.canOpen()`, which in this case looks in the DOM for the form and checks its validity, evaluates to false. 