### PR TITLE
Show more helpful errors on failed checkout (recurring contributions)

### DIFF
--- a/assets/components/paymentFailureMessage/paymentFailureMessage.jsx
+++ b/assets/components/paymentFailureMessage/paymentFailureMessage.jsx
@@ -3,29 +3,29 @@
 // ----- Imports ----- //
 
 import React, { type Node } from 'react';
+import { appropriateErrorMessage, type CheckoutFailureReason } from 'helpers/checkoutErrors';
 import SvgExclamationAlternate from '../svgs/exclamationAlternate';
 
 
 // ---- Types ----- //
 
-type PropTypes = {
-  showError: boolean,
-  message: ?string,
+type PropTypes = {|
+  checkoutFailureReason: ?CheckoutFailureReason,
   errorHeading: string,
   svg: Node,
-};
+|};
 
 
 // ----- Component ----- //
 
 export default function PaymentFailureMessage(props: PropTypes) {
 
-  if (props.showError && props.message) {
+  if (props.checkoutFailureReason) {
 
     return (
       <div className="component-payment-failure-message">
-        {props.svg}<span className="component-payment-failure-message__error-message">{props.errorHeading}</span>
-        <span className="component-payment-failure-message__small-print">{props.message}</span>
+        {props.svg}<span className="component-payment-failure-message__error-heading">{props.errorHeading}</span>
+        <span className="component-payment-failure-message__small-print">{appropriateErrorMessage(props.checkoutFailureReason)}</span>
       </div>
     );
 
@@ -39,7 +39,6 @@ export default function PaymentFailureMessage(props: PropTypes) {
 // ----- Default Props ----- //
 
 PaymentFailureMessage.defaultProps = {
-  showError: true,
   errorHeading: 'Payment Attempt Failed',
   svg: <SvgExclamationAlternate />,
 };

--- a/assets/components/paymentFailureMessage/paymentFailureMessage.scss
+++ b/assets/components/paymentFailureMessage/paymentFailureMessage.scss
@@ -24,7 +24,7 @@
   fill: gu-colour(garnett-neutral-5);
 }
 
-.component-payment-failure-message__error-message {
+.component-payment-failure-message__error-heading {
   vertical-align: bottom;
   display: inline-block;
   font-family: $gu-sans-web;

--- a/assets/helpers/checkoutErrors.js
+++ b/assets/helpers/checkoutErrors.js
@@ -1,0 +1,36 @@
+// @flow
+
+// ----- Types ----- //
+
+// See https://github.com/guardian/support-models/blob/master/src/main/scala/com/gu/support/workers/model/CheckoutFailureReasons.scala
+export type CheckoutFailureReason =
+  'insufficient_funds' |
+  'payment_details_incorrect' |
+  'payment_method_temporarily_declined' |
+  'payment_method_unacceptable' |
+  'payment_provider_unavailable' |
+  'payment_recently_taken' |
+  'unknown';
+
+// ----- Functions ----- //
+
+function appropriateErrorMessage(checkoutFailureReason: ?CheckoutFailureReason): ?string {
+  switch (checkoutFailureReason) {
+    case 'insufficient_funds':
+      return 'The transaction was declined due to insufficient funds in your account. Please use a different card or contact your bank.';
+    case 'payment_details_incorrect':
+      return 'An error occurred while trying to process your payment. Please double check your card details and try again. Alternatively, try another card or payment method.';
+    case 'payment_method_temporarily_declined':
+      return 'The transaction was temporarily declined. Please try entering your payment details again. Alternatively, try another payment method.';
+    case 'payment_method_unacceptable':
+      return 'The transaction was unsuccessful and you have not been charged. Please use a different card or choose another payment method.';
+    case 'payment_provider_unavailable':
+      return 'The transaction was unsuccessful. This does not mean there’s anything wrong with your card, and you have not been charged. Please try using an alternative payment method.';
+    default:
+      return 'The transaction was temporarily declined. Please try entering your payment details again. Alternatively, try another payment method.';
+  }
+}
+
+// ----- Exports ----- //
+
+export { appropriateErrorMessage };

--- a/assets/pages/oneoff-contributions/__tests__/__snapshots__/oneoffContributionsReducersTest.js.snap
+++ b/assets/pages/oneoff-contributions/__tests__/__snapshots__/oneoffContributionsReducersTest.js.snap
@@ -21,7 +21,7 @@ Object {
   },
   "oneoffContrib": Object {
     "amount": 20,
-    "error": null,
+    "checkoutFailureReason": null,
     "paymentComplete": false,
   },
   "user": Object {

--- a/assets/pages/oneoff-contributions/__tests__/oneoffContributionsActionsTest.js
+++ b/assets/pages/oneoff-contributions/__tests__/oneoffContributionsActionsTest.js
@@ -1,16 +1,17 @@
 // @flow
+import type { CheckoutFailureReason } from 'helpers/checkoutErrors';
 import { checkoutError } from '../oneoffContributionsActions';
 
 
 describe('One-off actions', () => {
 
   it('should create an action to flag a checkout error', () => {
-    const message:string = 'This is an error.';
+    const insufficientFunds: CheckoutFailureReason = 'insufficient_funds';
     const expectedAction = {
       type: 'CHECKOUT_ERROR',
-      message,
+      checkoutFailureReason: insufficientFunds,
     };
-    expect(checkoutError(message)).toEqual(expectedAction);
+    expect(checkoutError(insufficientFunds)).toEqual(expectedAction);
   });
 
 });

--- a/assets/pages/oneoff-contributions/__tests__/oneoffContributionsReducersTest.js
+++ b/assets/pages/oneoff-contributions/__tests__/oneoffContributionsReducersTest.js
@@ -2,6 +2,7 @@
 
 // ----- Imports ----- //
 
+import type { CheckoutFailureReason } from 'helpers/checkoutErrors';
 import createReducer from '../oneOffContributionsReducer';
 
 
@@ -17,15 +18,15 @@ describe('One-off Reducer', () => {
 
   it('should handle CHECKOUT_ERROR', () => {
 
-    const message = 'Test error';
+    const insufficientFunds: CheckoutFailureReason = 'insufficient_funds';
     const action = {
       type: 'CHECKOUT_ERROR',
-      message,
+      checkoutFailureReason: insufficientFunds,
     };
 
     const newState = reducer(undefined, action);
 
-    expect(newState.oneoffContrib.error).toEqual(message);
+    expect(newState.oneoffContrib.checkoutFailureReason).toEqual(insufficientFunds);
   });
 
   it('should handle SET_PAYPAL_BUTTON', () => {
@@ -38,7 +39,7 @@ describe('One-off Reducer', () => {
 
     const newState = reducer(undefined, action);
 
-    expect(newState.oneoffContrib.error).toMatchSnapshot();
+    expect(newState.oneoffContrib.checkoutFailureReason).toMatchSnapshot();
   });
 
 });

--- a/assets/pages/oneoff-contributions/components/oneoffContributionsPayment.jsx
+++ b/assets/pages/oneoff-contributions/components/oneoffContributionsPayment.jsx
@@ -15,6 +15,7 @@ import type { Status } from 'helpers/settings';
 import SvgCreditCard from 'components/svgs/creditCard';
 import type { OptimizeExperiments } from 'helpers/tracking/optimize';
 import PaymentFailureMessage from 'components/paymentFailureMessage/paymentFailureMessage';
+import type { CheckoutFailureReason } from 'helpers/checkoutErrors';
 import { formIsValid } from 'helpers/checkoutForm/checkoutForm';
 import { type Action as CheckoutAction } from '../helpers/checkoutForm/checkoutFormActions';
 import { setFullNameShouldValidate, setEmailShouldValidate } from '../helpers/checkoutForm/checkoutFormActions';
@@ -28,7 +29,7 @@ type PropTypes = {|
   dispatch: Function,
   email: string,
   setShouldValidateFunctions: Array<() => void>,
-  error: ?string,
+  checkoutFailureReason: ?CheckoutFailureReason,
   amount: number,
   referrerAcquisitionData: ReferrerAcquisitionData,
   abParticipations: Participations,
@@ -49,7 +50,7 @@ function mapStateToProps(state: State) {
     isTestUser: state.page.user.isTestUser || false,
     isPostDeploymentTestUser: state.page.user.isPostDeploymentTestUser,
     email: state.page.user.email,
-    error: state.page.oneoffContrib.error,
+    checkoutFailureReason: state.page.oneoffContrib.checkoutFailureReason,
     areAnyRequiredFieldsEmpty: !state.page.user.email || !state.page.user.fullName,
     amount: state.page.oneoffContrib.amount,
     referrerAcquisitionData: state.common.referrerAcquisitionData,
@@ -84,7 +85,7 @@ function OneoffContributionsPayment(props: PropTypes, context) {
   return (
     <section className="oneoff-contribution-payment">
       { props.paymentComplete ? <Redirect to={{ pathname: routes.oneOffContribThankyou }} /> : null }
-      <PaymentFailureMessage message={props.error} />
+      <PaymentFailureMessage checkoutFailureReason={props.checkoutFailureReason} />
       <StripePopUpButton
         email={props.email}
         callback={postCheckout(

--- a/assets/pages/oneoff-contributions/oneOffContributionsReducer.js
+++ b/assets/pages/oneoff-contributions/oneOffContributionsReducer.js
@@ -5,7 +5,7 @@
 import { combineReducers } from 'redux';
 import type { User as UserState } from 'helpers/user/userReducer';
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
-
+import type { CheckoutFailureReason } from 'helpers/checkoutErrors';
 import { createUserReducer } from 'helpers/user/userReducer';
 import { marketingConsentReducerFor } from 'components/marketingConsent/marketingConsentReducer';
 import csrf from 'helpers/csrf/csrfReducer';
@@ -20,7 +20,7 @@ import { checkoutFormReducer as checkoutForm, type OneOffContributionsCheckoutFo
 
 type OneOffContributionsState = {
   amount: number,
-  error: ?string,
+  checkoutFailureReason: ?CheckoutFailureReason,
   paymentComplete: boolean,
 };
 
@@ -44,7 +44,7 @@ function createOneOffContributionsReducer(amount: number) {
 
   const initialState: OneOffContributionsState = {
     amount,
-    error: null,
+    checkoutFailureReason: null,
     paymentComplete: false,
   };
 
@@ -56,7 +56,7 @@ function createOneOffContributionsReducer(amount: number) {
     switch (action.type) {
 
       case 'CHECKOUT_ERROR':
-        return { ...state, error: action.message };
+        return { ...state, checkoutFailureReason: action.checkoutFailureReason };
 
       case 'CHECKOUT_SUCCESS':
         return { ...state, paymentComplete: true };

--- a/assets/pages/oneoff-contributions/oneoffContributionsActions.js
+++ b/assets/pages/oneoff-contributions/oneoffContributionsActions.js
@@ -1,18 +1,20 @@
 // @flow
 
+// ----- Imports ----- //
+
+import type { CheckoutFailureReason } from 'helpers/checkoutErrors';
+
 // ----- Types ----- //
 
 export type Action =
-    | { type: 'CHECKOUT_ERROR', message: ?string }
+    | { type: 'CHECKOUT_ERROR', checkoutFailureReason: CheckoutFailureReason }
     | { type: 'CHECKOUT_SUCCESS' };
 
 
 // ----- Action Creators ----- //
 
-function checkoutError(specificError: ?string): Action {
-  const defaultError = 'The transaction was temporarily declined. Please try entering your payment details again. Alternatively, try another payment method.';
-  const message = specificError || defaultError;
-  return { type: 'CHECKOUT_ERROR', message };
+function checkoutError(checkoutFailureReason: CheckoutFailureReason = 'unknown'): Action {
+  return { type: 'CHECKOUT_ERROR', checkoutFailureReason };
 }
 
 function checkoutSuccess(): Action {

--- a/assets/pages/regular-contributions/__tests__/__snapshots__/regularContributionsReducersTest.js.snap
+++ b/assets/pages/regular-contributions/__tests__/__snapshots__/regularContributionsReducersTest.js.snap
@@ -41,8 +41,8 @@ Object {
   },
   "regularContrib": Object {
     "amount": 20,
+    "checkoutFailureReason": null,
     "contributionType": "MONTHLY",
-    "error": null,
     "payPalHasLoaded": false,
     "paymentMethod": "DirectDebit",
     "paymentStatus": "NotStarted",

--- a/assets/pages/regular-contributions/__tests__/regularContributionsActionsTest.js
+++ b/assets/pages/regular-contributions/__tests__/regularContributionsActionsTest.js
@@ -1,4 +1,5 @@
 // @flow
+import type { CheckoutFailureReason } from 'helpers/checkoutErrors';
 import {
   checkoutError,
   setPayPalHasLoaded,
@@ -9,12 +10,12 @@ import {
 describe('Regular contributions actions', () => {
 
   it('should create an action to flag a checkout error', () => {
-    const message:string = 'This is an error.';
+    const insufficientFunds: CheckoutFailureReason = 'insufficient_funds';
     const expectedAction = {
       type: 'CHECKOUT_ERROR',
-      message,
+      checkoutFailureReason: insufficientFunds,
     };
-    expect(checkoutError(message)).toEqual(expectedAction);
+    expect(checkoutError(insufficientFunds)).toEqual(expectedAction);
   });
 
   it('should create an action to set a value when PayPal has loaded', () => {

--- a/assets/pages/regular-contributions/__tests__/regularContributionsReducersTest.js
+++ b/assets/pages/regular-contributions/__tests__/regularContributionsReducersTest.js
@@ -2,6 +2,7 @@
 
 // ----- Imports ----- //
 
+import type { CheckoutFailureReason } from 'helpers/checkoutErrors';
 import createReducer from '../regularContributionsReducer';
 
 
@@ -17,15 +18,15 @@ describe('Regular contributions Reducer', () => {
 
   it('should handle CHECKOUT_ERROR', () => {
 
-    const message = 'Test error';
+    const insufficientFunds: CheckoutFailureReason = 'insufficient_funds';
     const action = {
       type: 'CHECKOUT_ERROR',
-      message,
+      checkoutFailureReason: insufficientFunds,
     };
 
     const newState = reducer(undefined, action);
 
-    expect(newState.regularContrib.error).toEqual(message);
+    expect(newState.regularContrib.checkoutFailureReason).toEqual(insufficientFunds);
     expect(newState.regularContrib.paymentStatus).toMatchSnapshot();
   });
 
@@ -39,7 +40,7 @@ describe('Regular contributions Reducer', () => {
 
     const newState = reducer(undefined, action);
 
-    expect(newState.regularContrib.error).toMatchSnapshot();
+    expect(newState.regularContrib.checkoutFailureReason).toMatchSnapshot();
   });
 
   it('should handle CREATING_CONTRIBUTOR', () => {

--- a/assets/pages/regular-contributions/components/regularContributionsPayment.jsx
+++ b/assets/pages/regular-contributions/components/regularContributionsPayment.jsx
@@ -21,6 +21,7 @@ import type { Contrib } from 'helpers/contributions';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { Participations } from 'helpers/abTests/abtest';
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
+import type { CheckoutFailureReason } from 'helpers/checkoutErrors';
 import PaymentFailureMessage from 'components/paymentFailureMessage/paymentFailureMessage';
 import { setPayPalHasLoaded } from '../regularContributionsActions';
 import { postCheckout } from '../helpers/ajax';
@@ -32,7 +33,7 @@ export type PaymentStatus = 'NotStarted' | 'Pending' | 'PollingTimedOut' | 'Fail
 type PropTypes = {|
   dispatch: Dispatch<*>,
   email: string,
-  error: ?string,
+  checkoutFailureReason: ?CheckoutFailureReason,
   isTestUser: boolean,
   isPostDeploymentTestUser: boolean,
   contributionType: Contrib,
@@ -59,13 +60,13 @@ type PropTypes = {|
 // Shows a message about the status of the form or the payment.
 function getStatusMessage(
   paymentStatus: PaymentStatus,
-  error: ?string,
+  checkoutFailureReason: ?CheckoutFailureReason,
 ): Node {
 
   if (paymentStatus === 'Pending') {
     return <ProgressMessage message={['Processing transaction', 'Please wait']} />;
   }
-  return <PaymentFailureMessage message={error} />;
+  return <PaymentFailureMessage checkoutFailureReason={checkoutFailureReason} />;
 
 }
 
@@ -153,7 +154,7 @@ function RegularContributionsPayment(props: PropTypes, context) {
     <section className="regular-contribution-payment">
       { props.paymentStatus === 'Success' ? <Redirect to={{ pathname: routes.recurringContribThankyou }} /> : null }
       { props.paymentStatus === 'PollingTimedOut' ? <Redirect to={{ pathname: routes.recurringContribPending }} /> : null }
-      {getStatusMessage(props.paymentStatus, props.error)}
+      {getStatusMessage(props.paymentStatus, props.checkoutFailureReason)}
       {directDebitButton}
       {stripeButton}
       {payPalButton}
@@ -169,7 +170,7 @@ function mapStateToProps(state) {
     isTestUser: state.page.user.isTestUser || false,
     isPostDeploymentTestUser: state.page.user.isPostDeploymentTestUser,
     email: state.page.user.email,
-    error: state.page.regularContrib.error,
+    checkoutFailureReason: state.page.regularContrib.checkoutFailureReason,
     paymentStatus: state.page.regularContrib.paymentStatus,
     amount: state.page.regularContrib.amount,
     currencyId: state.common.internationalisation.currencyId,

--- a/assets/pages/regular-contributions/helpers/ajax.js
+++ b/assets/pages/regular-contributions/helpers/ajax.js
@@ -14,6 +14,7 @@ import type { User as UserState } from 'helpers/user/userReducer';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import type { Participations } from 'helpers/abTests/abtest';
 import type { RegularCheckoutCallback } from 'helpers/checkouts';
+import type { CheckoutFailureReason } from 'helpers/checkoutErrors';
 import trackConversion from 'helpers/tracking/conversions';
 import { billingPeriodFromContrib } from 'helpers/contributions';
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
@@ -63,6 +64,15 @@ type RegularContribFields = {|
   supportAbTests: AcquisitionABTest[],
   email: ?string
 |};
+
+// https://github.com/guardian/support-models/blob/master/src/main/scala/com/gu/support/workers/model/Status.scala
+type Status = 'success' | 'failure' | 'pending';
+
+type StatusResponse = {|
+  status: Status,
+  trackingUri: string,
+  failureReason: CheckoutFailureReason
+|}
 
 // ----- Functions ----- //
 
@@ -249,12 +259,12 @@ function handleStatus(
 ) {
 
   if (response.ok) {
-    response.json().then((status) => {
-      trackingURI = status.trackingUri;
+    response.json().then((statusResponse: StatusResponse) => {
+      trackingURI = statusResponse.trackingUri;
 
-      switch (status.status) {
+      switch (statusResponse.status) {
         case 'failure':
-          dispatch(checkoutError());
+          dispatch(checkoutError(statusResponse.failureReason));
           break;
         case 'success':
           trackConversion(participations, routes.recurringContribThankyou);
@@ -267,7 +277,7 @@ function handleStatus(
   } else if (trackingURI) {
     delayedStatusPoll(dispatch, csrf, referrerAcquisitionData, paymentMethod, participations);
   } else {
-    dispatch(checkoutError());
+    dispatch(checkoutError('unknown'));
   }
 }
 

--- a/assets/pages/regular-contributions/regularContributionsActions.js
+++ b/assets/pages/regular-contributions/regularContributionsActions.js
@@ -3,6 +3,7 @@
 // ----- Imports ----- //
 
 import type { PaymentMethod } from 'helpers/checkouts';
+import type { CheckoutFailureReason } from 'helpers/checkoutErrors';
 
 
 // ----- Types ----- //
@@ -10,7 +11,7 @@ import type { PaymentMethod } from 'helpers/checkouts';
 export type Action =
   | { type: 'CHECKOUT_PENDING', paymentMethod: PaymentMethod }
   | { type: 'CHECKOUT_SUCCESS', paymentMethod: PaymentMethod }
-  | { type: 'CHECKOUT_ERROR', message: string }
+  | { type: 'CHECKOUT_ERROR', checkoutFailureReason: CheckoutFailureReason }
   | { type: 'SET_PAYPAL_HAS_LOADED' }
   | { type: 'CREATING_CONTRIBUTOR' };
 
@@ -24,10 +25,8 @@ function checkoutSuccess(paymentMethod: PaymentMethod): Action {
   return { type: 'CHECKOUT_SUCCESS', paymentMethod };
 }
 
-function checkoutError(specificError: ?string): Action {
-  const defaultError = 'The transaction was temporarily declined. Please try entering your payment details again. Alternatively, try another payment method.';
-  const message = specificError || defaultError;
-  return { type: 'CHECKOUT_ERROR', message };
+function checkoutError(checkoutFailureReason: CheckoutFailureReason): Action {
+  return { type: 'CHECKOUT_ERROR', checkoutFailureReason };
 }
 
 function setPayPalHasLoaded(): Action {

--- a/assets/pages/regular-contributions/regularContributionsReducer.js
+++ b/assets/pages/regular-contributions/regularContributionsReducer.js
@@ -13,6 +13,7 @@ import { marketingConsentReducerFor } from 'components/marketingConsent/marketin
 import csrf from 'helpers/csrf/csrfReducer';
 import type { CommonState } from 'helpers/page/page';
 import type { PaymentMethod } from 'helpers/checkouts';
+import type { CheckoutFailureReason } from 'helpers/checkoutErrors';
 import { type RegularContributionType } from 'helpers/contributions';
 import type { State as MarketingConsentState } from 'components/marketingConsent/marketingConsentReducer';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
@@ -26,7 +27,7 @@ import type { PaymentStatus } from './components/regularContributionsPayment';
 type RegularContributionsState = {
   amount: number,
   contributionType: RegularContributionType,
-  error: ?string,
+  checkoutFailureReason: ?CheckoutFailureReason,
   paymentStatus: PaymentStatus,
   paymentMethod: ?PaymentMethod,
   payPalHasLoaded: boolean,
@@ -60,7 +61,7 @@ function createRegularContributionsReducer(
   const initialState: RegularContributionsState = {
     amount,
     contributionType,
-    error: null,
+    checkoutFailureReason: null,
     paymentStatus: 'NotStarted',
     paymentMethod,
     payPalHasLoaded: false,
@@ -82,7 +83,7 @@ function createRegularContributionsReducer(
         return { ...state, paymentStatus: 'Success', paymentMethod: action.paymentMethod };
 
       case 'CHECKOUT_ERROR':
-        return { ...state, paymentStatus: 'Failed', error: action.message };
+        return { ...state, paymentStatus: 'Failed', checkoutFailureReason: action.checkoutFailureReason };
 
       case 'CREATING_CONTRIBUTOR':
         return { ...state, paymentStatus: 'Pending' };


### PR DESCRIPTION
## Why are you doing this?

So that users who experience problems whilst attempting to sign up for a recurring contribution are given helpful advice, which is specific to their payment error (see also: #856 and #939).

There will be a follow up PR for one-off contributions, as this requires a corresponding change to the payment-api. For one-off, I've temporarily hardcoded a failure reason, regardless of the contents of the error.

[**Trello Card**](https://trello.com/c/aMt99CR2/1885-return-specific-errors-based-on-payment-failure-reason-client-side-work)

## Changes

* Simplify logic for displaying payment failure error
* Rename a poorly named CSS class (which I missed in #939)
* Add mapping between checkout failure reasons and user-friendly error messages
* Store the checkout failure reason in the state, (hopefully) following the spirit of this suggestion: https://github.com/guardian/support-frontend/pull/939#discussion_r216630681
* Introduce types for status polling response body
* Fix tests / snapshots


