### PR TITLE
Apply click events for app store buttons

### DIFF
--- a/assets/components/digitalSubscriptions/digitalSubscriptions.jsx
+++ b/assets/components/digitalSubscriptions/digitalSubscriptions.jsx
@@ -131,6 +131,7 @@ function PremiumTier(props: {
 
 PremiumTier.defaultProps = {
   subheading: null,
+  ctaOnClick: () => {},
 };
 
 function DailyEdition(props: {
@@ -168,6 +169,10 @@ function DailyEdition(props: {
   );
 
 }
+
+DailyEdition.defaultProps = {
+  ctaOnClick: () => {},
+};
 
 function DigitalBundle(props: {
   countryGroupId: CountryGroupId,

--- a/assets/components/digitalSubscriptions/digitalSubscriptions.jsx
+++ b/assets/components/digitalSubscriptions/digitalSubscriptions.jsx
@@ -13,6 +13,7 @@ import {
 import { getCampaign } from 'helpers/tracking/acquisitions';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import { addQueryParamsToURL } from 'helpers/url';
+import { appStoreCtaClick } from 'helpers/tracking/googleTagManager';
 
 import PageSection from 'components/pageSection/pageSection';
 import SubscriptionBundle from 'components/subscriptionBundle/subscriptionBundle';
@@ -62,10 +63,12 @@ export default function DigitalSubscriptions(props: PropTypes) {
           iOSUrl={addQueryParamsToURL(iOSAppUrl, { referrer: appReferrer })}
           androidUrl={addQueryParamsToURL(androidAppUrl, { referrer: appReferrer })}
           headingSize={props.headingSize}
+          ctaOnClick={appStoreCtaClick}
         />
         <DailyEdition
           url={addQueryParamsToURL(dailyEditionUrl, { referrer: appReferrer })}
           headingSize={props.headingSize}
+          ctaOnClick={appStoreCtaClick}
         />
         <DigitalBundle
           countryGroupId={countryGroupId}
@@ -86,6 +89,7 @@ function PremiumTier(props: {
     androidUrl: string,
     headingSize: HeadingSize,
     subheading: ?string,
+    ctaOnClick?: ?Function,
 }) {
 
   return (
@@ -110,12 +114,14 @@ function PremiumTier(props: {
           url: props.iOSUrl,
           accessibilityHint: 'Proceed to buy the premium app in the app store',
           modifierClasses: ['premium-tier', 'border', 'ios'],
+          onClick: props.ctaOnClick,
         },
         {
           text: 'Buy on Google Play',
           url: props.androidUrl,
           accessibilityHint: 'Proceed to buy the premium app in the play store',
           modifierClasses: ['premium-tier', 'border', 'android'],
+          onClick: props.ctaOnClick,
         },
       ]}
     />
@@ -130,6 +136,7 @@ PremiumTier.defaultProps = {
 function DailyEdition(props: {
   url: string,
   headingSize: HeadingSize,
+  ctaOnClick?: ?Function,
 }) {
 
   return (
@@ -154,6 +161,7 @@ function DailyEdition(props: {
           url: props.url,
           accessibilityHint: 'Proceed to buy the daily edition app for iPad in the app store',
           modifierClasses: ['daily-edition', 'border'],
+          onClick: props.ctaOnClick,
         },
       ]}
     />

--- a/assets/components/internationalSubscriptions/internationalSubscriptions.jsx
+++ b/assets/components/internationalSubscriptions/internationalSubscriptions.jsx
@@ -10,6 +10,7 @@ import {
   androidAppUrl,
 } from 'helpers/externalLinks';
 import { getCampaign } from 'helpers/tracking/acquisitions';
+import { appStoreCtaClick } from 'helpers/tracking/googleTagManager';
 import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import { addQueryParamsToURL } from 'helpers/url';
 
@@ -63,6 +64,7 @@ export default function InternationalSubscriptions(props: PropTypes) {
           androidUrl={addQueryParamsToURL(androidAppUrl, { referrer: appReferrer })}
           headingSize={props.headingSize}
           subheading="7-day free trial"
+          ctaOnClick={appStoreCtaClick}
         />
         <DigitalBundle
           countryGroupId={props.countryGroupId}

--- a/assets/components/subscriptionBundle/subscriptionBundle.jsx
+++ b/assets/components/subscriptionBundle/subscriptionBundle.jsx
@@ -23,6 +23,7 @@ type BundleCta = {
   url: string,
   accessibilityHint: string,
   modifierClasses: Array<?string>,
+  onClick?: ?Function,
 };
 
 type PropTypes = {

--- a/assets/components/subscriptionsByCountryGroup/subscriptionsByCountryGroup.jsx
+++ b/assets/components/subscriptionsByCountryGroup/subscriptionsByCountryGroup.jsx
@@ -8,8 +8,8 @@ import { connect } from 'react-redux';
 import PaperSubscriptionsContainer from 'components/paperSubscriptions/paperSubscriptionsContainer';
 import DigitalSubscriptionsContainer from 'components/digitalSubscriptions/digitalSubscriptionsContainer';
 import InternationalSubscriptions from 'components/internationalSubscriptions/internationalSubscriptionsContainer';
-import { type HeadingSize } from 'components/heading/heading';
 
+import { type HeadingSize } from 'components/heading/heading';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { type CommonState } from 'helpers/page/page';
 

--- a/assets/helpers/tracking/googleTagManager.js
+++ b/assets/helpers/tracking/googleTagManager.js
@@ -202,7 +202,7 @@ function gaEvent(gaEventData: GaEventData) {
 }
 
 function appStoreCtaClick() {
-  sendData('AppStoreCtaClick', {TestName: ''});
+  sendData('AppStoreCtaClick', { TestName: '' });
 }
 
 // ----- Exports ---//

--- a/assets/helpers/tracking/googleTagManager.js
+++ b/assets/helpers/tracking/googleTagManager.js
@@ -11,7 +11,7 @@ import type { Participations } from 'helpers/abTests/abtest';
 
 
 // ----- Types ----- //
-type EventType = 'DataLayerReady' | 'SuccessfulConversion' | 'GAEvent';
+type EventType = 'DataLayerReady' | 'SuccessfulConversion' | 'GAEvent' | 'AppStoreCtaClick';
 
 type PaymentRequestAPIStatus =
   'PaymentRequestAPINotAvailable' |
@@ -201,11 +201,16 @@ function gaEvent(gaEventData: GaEventData) {
   });
 }
 
+function appStoreCtaClick() {
+  sendData('AppStoreCtaClick', {TestName: ''});
+}
+
 // ----- Exports ---//
 
 export {
   init,
   gaEvent,
   successfulConversion,
+  appStoreCtaClick,
   gaPropertyId,
 };


### PR DESCRIPTION
## Why are you doing this?
We want to monitor the performance of the app store CTAs during the September marketing campaign

[**Trello Card**](https://trello.com/c/32QGic1Z/1876-add-app-nexus-for-september-campaign)

## Changes

* Adds a new GTM event `AppStoreCtaClick` (note: it's the same event and tracking id for all the digipack app CTAs)
* Wires up the CTAs to fire the event on click

## Screenshots
N/A

## Tested
- [x] Locally (with GTM in preview mode, and following the network activity)
- [ ] On code
