### PR TITLE
Use EitherT and PaymentAPIResponseError for handling errors

### DIFF
--- a/app/controllers/PayPalOneOff.scala
+++ b/app/controllers/PayPalOneOff.scala
@@ -7,8 +7,11 @@ import com.gu.identity.play.AuthenticatedIdUser
 import play.api.libs.circe.Circe
 import play.api.libs.json.{JsObject, JsString, JsValue, Json}
 import play.api.mvc._
+
 import services._
 import admin.Settings
+import cats.data.EitherT
+import cats.implicits._
 import monitoring.SafeLogger
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -62,29 +65,31 @@ class PayPalOneOff(
     }
   }
 
-  def processPaymentApiResponse(
-    paymentApiResponse: Option[Either[PayPalError, PayPalSuccess]]
-  )(implicit request: RequestHeader): Result = {
-    paymentApiResponse.fold(
-      Redirect(routes.PayPalOneOff.paypalError())
-    )(resp => {
-      resp.fold(
-        processPayPalError,
-        successfulResponse => {
-          SafeLogger.info(s"One-off contribution for Paypal payment is successful")
-          resultFromEmailOption(successfulResponse.email)
-        }
-      )
-    })
+  def resultFromPaymentAPIError(error: PaymentAPIResponseError[PayPalError])(implicit request: RequestHeader): Result = {
+    error match {
+      case PaymentAPIResponseError.APIError(err: PayPalError) => processPayPalError(err)
+      case _ => Redirect(routes.PayPalOneOff.paypalError())
+    }
   }
 
-  def emailForUser(user: AuthenticatedIdUser)(implicit request: RequestHeader): Future[Option[String]] =
-    identityService.getUser(user).value.map(_.toOption.map(_.primaryEmailAddress))
+  def resultFromPaypalSuccess(success: PayPalSuccess)(implicit request: RequestHeader): Result = {
+    SafeLogger.info(s"One-off contribution for Paypal payment is successful")
+    val redirect = Redirect(routes.OneOffContributions.displayForm())
+    success.email.fold({
+      SafeLogger.info("Redirecting to thank you page without email in flash session")
+      redirect
+    })({ email =>
+      SafeLogger.info("Redirecting to thank you page with email in flash session")
+      redirect.flashing("email" -> email)
+    })
+  }
 
   def returnURL(paymentId: String, PayerID: String): Action[AnyContent] = maybeAuthenticatedAction().async { implicit request =>
     val acquisitionData = (for {
       cookie <- request.cookies.get("acquisition_data")
-      cookieAcquisitionData <- Try { Json.parse(java.net.URLDecoder.decode(cookie.value, "UTF-8")) }.toOption
+      cookieAcquisitionData <- Try {
+        Json.parse(java.net.URLDecoder.decode(cookie.value, "UTF-8"))
+      }.toOption
     } yield cookieAcquisitionData).getOrElse(fallbackAcquisitionData)
 
     val paymentJSON = Json.obj(
@@ -96,11 +101,23 @@ class PayPalOneOff(
     val testUsername = request.cookies.get("_test_username")
     val isTestUser = testUsers.isTestUser(testUsername.map(_.value))
 
-    for {
-      maybeEmail <- request.user.map(emailForUser).getOrElse(Future.successful(None))
-      result <- paymentAPIService.executePaypalPayment(paymentJSON, acquisitionData, queryStrings, maybeEmail, isTestUser)
-    } yield processPaymentApiResponse(result)
+    def emailForUser(user: Option[AuthenticatedIdUser])(
+      implicit
+      request: RequestHeader
+    ): EitherT[Future, PaymentAPIResponseError[PayPalError], Option[String]] = {
 
+      val noEmail = EitherT.pure[Future, PaymentAPIResponseError[PayPalError]](Option.empty[String])
+
+      user.fold(noEmail) { authUser =>
+        identityService.getUser(authUser)
+          .map(idUser => Option(idUser.primaryEmailAddress))
+          .leftFlatMap(_ => noEmail)
+      }
+    }
+
+    emailForUser(request.user)
+      .flatMap(paymentAPIService.executePaypalPayment(paymentJSON, acquisitionData, queryStrings, _, isTestUser))
+      .fold(resultFromPaymentAPIError, resultFromPaypalSuccess)
   }
 
   def cancelURL(): Action[AnyContent] = PrivateAction { implicit request =>

--- a/app/services/PaymentAPIService.scala
+++ b/app/services/PaymentAPIService.scala
@@ -1,17 +1,30 @@
 package services
 
+import cats.data.EitherT
 import monitoring.SafeLogger._
 import play.api.libs.json._
 import play.api.libs.ws.{WSClient, WSResponse}
+
 import services.ExecutePaymentBody._
 import codecs.CirceDecoders._
 import io.circe.Decoder
+import io.circe.parser.decode
 import monitoring.SafeLogger
+import cats.implicits._
 
 import scala.concurrent.{ExecutionContext, Future}
 
 case class PayPalSuccess(email: Option[String])
+
 case class PayPalError(responseCode: Option[Int], errorName: Option[String], message: String)
+
+sealed trait PaymentAPIResponseError[+A]
+
+object PaymentAPIResponseError {
+  case class DecodingError(error: io.circe.Error) extends PaymentAPIResponseError[Nothing]
+  case class ExecuteError(error: Throwable) extends PaymentAPIResponseError[Nothing]
+  case class APIError[A](error: A) extends PaymentAPIResponseError[A]
+}
 
 case class ExecutePaymentBody(
     signedInUserEmail: Option[String],
@@ -27,7 +40,7 @@ object PaymentAPIService {
   case class Email(value: String)
 }
 
-class PaymentAPIService(wsClient: WSClient, paymentAPIUrl: String) {
+class PaymentAPIService(wsClient: WSClient, paymentAPIUrl: String)(implicit ec: ExecutionContext) {
 
   private val paypalCreatePaymentPath = "/contribute/one-off/paypal/create-payment"
   private val paypalExecutePaymentPath = "/contribute/one-off/paypal/execute-payment"
@@ -43,7 +56,12 @@ class PaymentAPIService(wsClient: WSClient, paymentAPIUrl: String) {
     }
   }
 
-  private def postPaypalData(data: ExecutePaymentBody, queryStrings: Map[String, Seq[String]], isTestUser: Boolean) = {
+  private def postPaypalData[A](
+    data: ExecutePaymentBody,
+    queryStrings: Map[String, Seq[String]],
+    isTestUser: Boolean
+  ): EitherT[Future, PaymentAPIResponseError[A], WSResponse] = {
+
     val allQueryParams = if (isTestUser) queryStrings + ("mode" -> Seq("test")) else queryStrings
 
     wsClient.url(payPalExecutePaymentEndpoint)
@@ -52,19 +70,16 @@ class PaymentAPIService(wsClient: WSClient, paymentAPIUrl: String) {
       .withBody(Json.toJson(data))
       .withMethod("POST")
       .execute()
+      .attemptT
+      .leftMap(PaymentAPIResponseError.ExecuteError)
   }
 
-  def decodePaymentAPIResponse[A: Decoder, B: Decoder](response: WSResponse): Option[Either[A, B]] = {
-    implicit def paymentAPIPaypalResponseDecoder: Decoder[Either[A, B]] =
-      Decoder.decodeEither[A, B]("error", "data")
-    io.circe.parser.decode[Either[A, B]](response.body)
-      .fold(
-        failure => {
-          SafeLogger.error(scrub"Unable to decode payment API response: ${response.body}. Message is ${failure.getMessage}")
-          None
-        },
-        resp => Some(resp)
-      )
+  def decodePaymentAPIResponse[A: Decoder, B: Decoder](response: WSResponse): Either[PaymentAPIResponseError[A], B] = {
+    implicit def paymentAPIResponseDecoder: Decoder[Either[A, B]] = Decoder.decodeEither[A, B]("error", "data")
+    decode[Either[A, B]](response.body).fold(
+      err => Left(PaymentAPIResponseError.DecodingError(err)),
+      response => response.leftMap(err => PaymentAPIResponseError.APIError(err))
+    )
   }
 
   def logErrorResponse(error: PayPalError): Unit = {
@@ -81,8 +96,9 @@ class PaymentAPIService(wsClient: WSClient, paymentAPIUrl: String) {
     queryStrings: Map[String, Seq[String]],
     email: Option[String],
     isTestUser: Boolean
-  )(implicit ec: ExecutionContext): Future[Option[Either[PayPalError, PayPalSuccess]]] = {
+  )(implicit ec: ExecutionContext): EitherT[Future, PaymentAPIResponseError[PayPalError], PayPalSuccess] = {
     val data = ExecutePaymentBody(email, acquisitionData, paymentJSON)
-    postPaypalData(data, queryStrings, isTestUser).map(decodePaymentAPIResponse[PayPalError, PayPalSuccess])
+    postPaypalData(data, queryStrings, isTestUser) //.map(decodePaymentAPIResponse[PayPalError, PayPalSuccess])
+      .subflatMap(decodePaymentAPIResponse[PayPalError, PayPalSuccess])
   }
 }

--- a/app/services/PaymentAPIService.scala
+++ b/app/services/PaymentAPIService.scala
@@ -98,7 +98,6 @@ class PaymentAPIService(wsClient: WSClient, paymentAPIUrl: String)(implicit ec: 
     isTestUser: Boolean
   )(implicit ec: ExecutionContext): EitherT[Future, PaymentAPIResponseError[PayPalError], PayPalSuccess] = {
     val data = ExecutePaymentBody(email, acquisitionData, paymentJSON)
-    postPaypalData(data, queryStrings, isTestUser) //.map(decodePaymentAPIResponse[PayPalError, PayPalSuccess])
-      .subflatMap(decodePaymentAPIResponse[PayPalError, PayPalSuccess])
+    postPaypalData(data, queryStrings, isTestUser).subflatMap(decodePaymentAPIResponse[PayPalError, PayPalSuccess])
   }
 }


### PR DESCRIPTION
## Why are you doing this?

Update so that we don't have to encode different errors in a nested data type i.e. `Option[Either[A, B]]`
