### PR TITLE
[NPF] show errors on submit of form rather than on blur of fields

### DIFF
--- a/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
@@ -15,7 +15,7 @@ import SvgDollar from 'components/svgs/dollar';
 import SvgEuro from 'components/svgs/euro';
 import SvgPound from 'components/svgs/pound';
 
-import { type Action, selectAmount, updateOtherAmount, updateBlurred } from '../contributionsLandingActions';
+import { type Action, selectAmount, updateOtherAmount } from '../contributionsLandingActions';
 import { NewContributionTextInput } from './ContributionTextInput';
 
 // ----- Types ----- //
@@ -28,10 +28,9 @@ type PropTypes = {
   selectedAmounts: { [Contrib]: Amount | 'other' },
   selectAmount: (Amount | 'other', Contrib) => (() => void),
   otherAmount: string | null,
-  otherAmountBlurred: boolean,
   checkOtherAmount: string => boolean,
   updateOtherAmount: string => void,
-  updateBlurred: () => void,
+  checkoutFormHasBeenSubmitted: boolean,
 };
 /* eslint-enable react/no-unused-prop-types */
 
@@ -41,13 +40,12 @@ const mapStateToProps = state => ({
   contributionType: state.page.form.contributionType,
   selectedAmounts: state.page.form.selectedAmounts,
   otherAmount: state.page.form.formData.otherAmounts[state.page.form.contributionType].amount,
-  otherAmountBlurred: state.page.form.formData.otherAmounts[state.page.form.contributionType].blurred,
+  checkoutFormHasBeenSubmitted: state.page.form.formData.checkoutFormHasBeenSubmitted,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch<Action>) => ({
   selectAmount: (amount, contributionType) => () => { dispatch(selectAmount(amount, contributionType)); },
   updateOtherAmount: (amount) => { dispatch(updateOtherAmount(amount)); },
-  updateBlurred: () => { dispatch(updateBlurred('otherAmount')); },
 });
 
 // ----- Render ----- //
@@ -119,9 +117,8 @@ function ContributionAmount(props: PropTypes) {
           value={props.otherAmount}
           icon={iconForCountryGroup(props.countryGroupId)}
           onInput={e => props.updateOtherAmount((e.target: any).value)}
-          onBlur={() => props.updateBlurred()}
           isValid={props.checkOtherAmount(props.otherAmount || '')}
-          wasBlurred={props.otherAmountBlurred}
+          checkoutFormHasBeenSubmitted={props.checkoutFormHasBeenSubmitted}
           errorMessage={`Please provide an amount between ${minAmount} and ${maxAmount}`}
           autoComplete="off"
           min={min}

--- a/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -31,7 +31,16 @@ import { NewContributionSubmit } from './ContributionSubmit';
 import { NewContributionTextInput } from './ContributionTextInput';
 
 import { type State } from '../contributionsLandingReducer';
-import { type Action, paymentWaiting, updateFirstName, updateLastName, updateEmail, updateState, onThirdPartyPaymentDone, updateBlurred } from '../contributionsLandingActions';
+import {
+  type Action,
+  paymentWaiting,
+  updateFirstName,
+  updateLastName,
+  updateEmail,
+  updateState,
+  onThirdPartyPaymentDone,
+  setCheckoutFormHasBeenSubmitted,
+} from '../contributionsLandingActions';
 
 // ----- Types ----- //
 /* eslint-disable react/no-unused-prop-types */
@@ -44,24 +53,21 @@ type PropTypes = {|
   contributionType: Contrib,
   thankYouRoute: string,
   firstName: string,
-  firstNameBlurred: boolean,
   lastName: string,
-  lastNameBlurred: boolean,
   email: string,
-  emailBlurred: boolean,
   state: UsState | CaState | null,
   selectedAmounts: { [Contrib]: Amount | 'other' },
   otherAmount: string | null,
-  otherAmountBlurred: boolean,
   paymentMethod: PaymentMethod,
   paymentHandler: { [PaymentMethod]: PaymentHandler | null },
   updateFirstName: Event => void,
   updateLastName: Event => void,
   updateEmail: Event => void,
   updateState: Event => void,
-  updateBlurred: string => void,
   onWaiting: boolean => void,
   onThirdPartyPaymentDone: Token => void,
+  checkoutFormHasBeenSubmitted: boolean,
+  setCheckoutFormHasBeenSubmitted: () => void,
 |};
 /* eslint-enable react/no-unused-prop-types */
 
@@ -70,18 +76,15 @@ const mapStateToProps = (state: State) => ({
   isWaiting: state.page.form.isWaiting,
   countryGroupId: state.common.internationalisation.countryGroupId,
   firstName: state.page.form.formData.firstName || state.page.user.firstName,
-  firstNameBlurred: state.page.form.formData.firstNameBlurred,
   lastName: state.page.form.formData.lastName || state.page.user.lastName,
-  lastNameBlurred: state.page.form.formData.lastNameBlurred,
   email: state.page.form.formData.email || state.page.user.email,
-  emailBlurred: state.page.form.formData.emailBlurred,
   state: state.page.form.formData.state || state.page.user.stateField,
   selectedAmounts: state.page.form.selectedAmounts,
   otherAmount: state.page.form.formData.otherAmounts[state.page.form.contributionType].amount,
-  otherAmountBlurred: state.page.form.formData.otherAmounts[state.page.form.contributionType].blurred,
   paymentMethod: state.page.form.paymentMethod,
   paymentHandler: state.page.form.paymentHandler,
   contributionType: state.page.form.contributionType,
+  checkoutFormHasBeenSubmitted: state.page.form.formData.checkoutFormHasBeenSubmitted,
 });
 
 function maybeDispatch(dispatch: Dispatch<Action>, action: string => Action, string: string) {
@@ -96,9 +99,9 @@ const mapDispatchToProps = (dispatch: Function) => ({
   updateLastName: (event) => { maybeDispatch(dispatch, updateLastName, event.target.value); },
   updateEmail: (event) => { maybeDispatch(dispatch, updateEmail, event.target.value); },
   updateState: (event) => { dispatch(updateState(event.target.value === '' ? null : event.target.value)); },
-  updateBlurred: (field) => { dispatch(updateBlurred(field)); },
   onWaiting: (isWaiting) => { dispatch(paymentWaiting(isWaiting)); },
   onThirdPartyPaymentDone: (token) => { dispatch(onThirdPartyPaymentDone(token)); },
+  setCheckoutFormHasBeenSubmitted: () => { dispatch(setCheckoutFormHasBeenSubmitted()); },
 });
 
 // ----- Functions ----- //
@@ -121,12 +124,11 @@ const checkEmail: string => boolean = input => isNotEmpty(input) && isValidEmail
 
 function onSubmit(props: PropTypes): Event => void {
   return (event) => {
+    props.setCheckoutFormHasBeenSubmitted();
     event.preventDefault();
-
     if (!(event.target: any).checkValidity()) {
       return;
     }
-
     const amount = getAmount(props);
     const { email } = props;
 
@@ -159,12 +161,10 @@ function ContributionForm(props: PropTypes) {
     selectedCountryGroupDetails,
     thankYouRoute,
     firstName,
-    firstNameBlurred,
     lastName,
-    lastNameBlurred,
     email,
-    emailBlurred,
     state,
+    checkoutFormHasBeenSubmitted,
   } = props;
 
   const paymentCallback = (token: Token) => {
@@ -199,9 +199,8 @@ function ContributionForm(props: PropTypes) {
             autoComplete="given-name"
             autoCapitalize="words"
             onInput={props.updateFirstName}
-            onBlur={() => props.updateBlurred('firstName')}
             isValid={checkFirstName(firstName)}
-            wasBlurred={firstNameBlurred}
+            checkoutFormHasBeenSubmitted={checkoutFormHasBeenSubmitted}
             errorMessage="Please provide your first name"
             required
           />
@@ -214,9 +213,8 @@ function ContributionForm(props: PropTypes) {
             autoComplete="family-name"
             autoCapitalize="words"
             onInput={props.updateLastName}
-            onBlur={() => props.updateBlurred('lastName')}
             isValid={checkLastName(lastName)}
-            wasBlurred={lastNameBlurred}
+            checkoutFormHasBeenSubmitted={checkoutFormHasBeenSubmitted}
             errorMessage="Please provide your last name"
             required
           />
@@ -230,9 +228,8 @@ function ContributionForm(props: PropTypes) {
             placeholder="example@domain.com"
             icon={<SvgEnvelope />}
             onInput={props.updateEmail}
-            onBlur={() => props.updateBlurred('email')}
             isValid={checkEmail(email)}
-            wasBlurred={emailBlurred}
+            checkoutFormHasBeenSubmitted={checkoutFormHasBeenSubmitted}
             errorMessage="Please provide a valid email address"
             required
           />

--- a/assets/pages/new-contributions-landing/components/ContributionTextInput.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionTextInput.jsx
@@ -18,9 +18,8 @@ type PropTypes = {
   value: string | null,
   errorMessage: string | null,
   isValid: boolean,
-  wasBlurred: boolean,
+  checkoutFormHasBeenSubmitted: boolean,
   onInput: (Event => void) | void,
-  onBlur: (Event => void) | void,
   required?: boolean,
   autoCapitalize: 'off' | 'none' | 'on' | 'sentences' | 'words',
   autoComplete: 'off' | 'on' | 'name' | 'given-name' | 'family-name' | 'email',
@@ -32,7 +31,7 @@ type PropTypes = {
 // ----- Render ----- //
 
 function NewContributionTextInput(props: PropTypes) {
-  const showError = props.value !== '' && !props.isValid && props.wasBlurred;
+  const showError = !props.isValid && props.checkoutFormHasBeenSubmitted;
 
   return (
     <div className={classNameWithModifiers('form__field', [props.name])}>
@@ -50,7 +49,6 @@ function NewContributionTextInput(props: PropTypes) {
           required={props.required}
           placeholder={props.placeholder}
           onInput={props.onInput}
-          onBlur={props.onBlur}
           value={props.value}
           min={props.min}
           max={props.max}
@@ -73,7 +71,6 @@ NewContributionTextInput.defaultProps = {
   placeholder: false,
   required: false,
   onInput: undefined,
-  onBlur: undefined,
   value: null,
   autoCapitalize: 'none',
   autoComplete: 'on',

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -20,12 +20,12 @@ export type Action =
   | { type: 'UPDATE_EMAIL', email: string }
   | { type: 'UPDATE_STATE', state: UsState | CaState | null }
   | { type: 'UPDATE_PAYMENT_READY', paymentReady: boolean, paymentHandler: ?{ [PaymentMethod]: PaymentHandler } }
-  | { type: 'UPDATE_BLURRED', field: FieldName }
   | { type: 'SELECT_AMOUNT', amount: Amount | 'other', contributionType: Contrib }
   | { type: 'UPDATE_OTHER_AMOUNT', otherAmount: string }
   | { type: 'PAYMENT_RESULT', paymentResult: Promise<PaymentResult> }
   | { type: 'PAYMENT_FAILURE', error: string }
   | { type: 'PAYMENT_WAITING', isWaiting: boolean }
+  | { type: 'SET_CHECKOUT_FORM_HAS_BEEN_SUBMITTED' }
   | { type: 'PAYMENT_SUCCESS' };
 
 const updateContributionType = (contributionType: Contrib): Action =>
@@ -42,12 +42,12 @@ const updateEmail = (email: string): Action => ({ type: 'UPDATE_EMAIL', email })
 
 const updateState = (state: UsState | CaState | null): Action => ({ type: 'UPDATE_STATE', state });
 
-const updateBlurred = (field: FieldName): Action => ({ type: 'UPDATE_BLURRED', field });
-
 const selectAmount = (amount: Amount | 'other', contributionType: Contrib): Action =>
   ({
     type: 'SELECT_AMOUNT', amount, contributionType,
   });
+
+const setCheckoutFormHasBeenSubmitted = (): Action => ({ type: 'SET_CHECKOUT_FORM_HAS_BEEN_SUBMITTED' });
 
 const updateOtherAmount = (otherAmount: string): Action => ({ type: 'UPDATE_OTHER_AMOUNT', otherAmount });
 
@@ -172,7 +172,6 @@ export {
   updateLastName,
   updateEmail,
   updateState,
-  updateBlurred,
   isPaymentReady,
   selectAmount,
   updateOtherAmount,
@@ -180,4 +179,5 @@ export {
   paymentWaiting,
   paymentSuccess,
   onThirdPartyPaymentDone,
+  setCheckoutFormHasBeenSubmitted,
 };

--- a/assets/pages/new-contributions-landing/contributionsLandingReducer.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingReducer.js
@@ -18,15 +18,13 @@ import { type Action } from './contributionsLandingActions';
 
 type FormData = {
   firstName: string | null,
-  firstNameBlurred: boolean,
   lastName: string | null,
-  lastNameBlurred: boolean,
   email: string | null,
-  emailBlurred: boolean,
   otherAmounts: {
-    [Contrib]: { amount: string | null, blurred: boolean }
+    [Contrib]: { amount: string | null }
   },
   state: UsState | CaState | null,
+  checkoutFormHasBeenSubmitted: boolean,
 };
 
 type FormState = {
@@ -81,17 +79,15 @@ function createFormReducer(countryGroupId: CountryGroupId) {
     paymentReady: false,
     formData: {
       firstName: null,
-      firstNameBlurred: false,
       lastName: null,
-      lastNameBlurred: false,
       email: null,
-      emailBlurred: false,
       otherAmounts: {
-        ONE_OFF: { amount: null, blurred: false },
-        MONTHLY: { amount: null, blurred: false },
-        ANNUAL: { amount: null, blurred: false },
+        ONE_OFF: { amount: null },
+        MONTHLY: { amount: null },
+        ANNUAL: { amount: null },
       },
       state: null,
+      checkoutFormHasBeenSubmitted: false,
     },
     showOtherAmount: false,
     selectedAmounts: initialAmount,
@@ -133,31 +129,6 @@ function createFormReducer(countryGroupId: CountryGroupId) {
       case 'UPDATE_STATE':
         return { ...state, formData: { ...state.formData, state: action.state } };
 
-      case 'UPDATE_BLURRED':
-        switch (action.field) {
-          case 'otherAmount':
-            return {
-              ...state,
-              formData: {
-                ...state.formData,
-                otherAmounts: {
-                  ...state.formData.otherAmounts,
-                  [state.contributionType]: {
-                    amount: state.formData.otherAmounts[state.contributionType].amount,
-                    blurred: true,
-                  },
-                },
-              },
-            };
-          case 'email':
-            return { ...state, formData: { ...state.formData, emailBlurred: true } };
-          case 'lastName':
-            return { ...state, formData: { ...state.formData, lastNameBlurred: true } };
-          case 'firstName':
-          default:
-            return { ...state, formData: { ...state.formData, firstNameBlurred: true } };
-        }
-
       case 'SELECT_AMOUNT':
         return {
           ...state,
@@ -173,7 +144,6 @@ function createFormReducer(countryGroupId: CountryGroupId) {
               ...state.formData.otherAmounts,
               [state.contributionType]: {
                 amount: action.otherAmount,
-                blurred: state.formData.otherAmounts[state.contributionType].blurred,
               },
             },
           },
@@ -187,6 +157,9 @@ function createFormReducer(countryGroupId: CountryGroupId) {
 
       case 'PAYMENT_SUCCESS':
         return { ...state, done: true };
+
+      case 'SET_CHECKOUT_FORM_HAS_BEEN_SUBMITTED':
+        return { ...state, formData: { ...state.formData, checkoutFormHasBeenSubmitted: true } };
 
       default:
         return state;


### PR DESCRIPTION
## Why are you doing this?
Currently, we hold off on showing an error message on a form field until it has been blurred. This PR replaces this rule with a new rule that says that we can't show an error message until the form has been submitted once. This basically means that there is no live validation until the form has been submitted for the first time. 

The extra complexity (and boilerplate to maintain) that we get from having to store the blurred state of each field in the state is quite sizable, and arguably not an improvement on what this is PR is proposing. It is a simple form, let's simplify things. 