### PR TITLE
Digital pack landing page copy changes

### DIFF
--- a/assets/components/featureList/featureList.jsx
+++ b/assets/components/featureList/featureList.jsx
@@ -25,16 +25,16 @@ type PropTypes = {
 function FeatureList(props: PropTypes) {
 
   const items = props.listItems.map((item: ListItem) => (
-    <li className="component-feature-list__item">
+    <div className="component-feature-list__item">
       <ItemHeading heading={item.heading ? item.heading : null} />
       <ItemText text={item.text ? item.text : null} />
-    </li>
+    </div>
   ));
 
   return (
-    <ul className={classNameWithModifiers('component-feature-list', [props.modifierClass])}>
+    <div className={classNameWithModifiers('component-feature-list', [props.modifierClass])}>
       { items }
-    </ul>
+    </div>
   );
 
 }

--- a/assets/components/featureList/featureList.scss
+++ b/assets/components/featureList/featureList.scss
@@ -2,9 +2,6 @@
 	margin: 0;
 	padding: 0;
 	padding-left: 10px;
-
-	display: grid;
-	grid-template-columns: 100px 100px;
 }
 
 .component-feature-list__heading {

--- a/assets/components/featureList/featureList.scss
+++ b/assets/components/featureList/featureList.scss
@@ -2,6 +2,9 @@
 	margin: 0;
 	padding: 0;
 	padding-left: 10px;
+
+	display: grid;
+	grid-template-columns: 100px 100px;
 }
 
 .component-feature-list__heading {
@@ -17,4 +20,6 @@
 .component-feature-list__item {
 	margin-bottom: $gu-v-spacing;
 	margin-left: $gu-h-spacing;
+
+	//list-style-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 10 10"><circle cx="5" cy="5" r="5" fill="#ff4e36"/></svg>');
 }

--- a/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
+++ b/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
@@ -143,7 +143,6 @@ export default function DigitalSubscriptionLandingHeader(props: PropTypes) {
         </div>
         <div className="digital-subscription-landing-header__title">
           <div className="digital-subscription-landing-header__title-copy">
-            {/*<h1>Support The Guardian with a digital subscription abc</h1>*/}
             <h1>Get the full digital experience of The Guardian</h1>
           </div>
         </div>

--- a/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
+++ b/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
@@ -143,7 +143,8 @@ export default function DigitalSubscriptionLandingHeader(props: PropTypes) {
         </div>
         <div className="digital-subscription-landing-header__title">
           <div className="digital-subscription-landing-header__title-copy">
-            <h1>Support The Guardian with a digital subscription</h1>
+            {/*<h1>Support The Guardian with a digital subscription abc</h1>*/}
+            <h1>Get the full digital experience of The Guardian</h1>
           </div>
         </div>
         <PriceCtaContainer dark referringCta="support_digipack_page_header" />

--- a/assets/pages/digital-subscription-landing/components/productBlock.jsx
+++ b/assets/pages/digital-subscription-landing/components/productBlock.jsx
@@ -41,7 +41,7 @@ const defaultFeatures: ListItem[] = [
   },
   {
     heading: 'Enhanced offline reading',
-    text: 'Download the day\'s news before you travel',
+    text: 'Quality journalism on your schedule - download the day\'s news before you travel',
   },
 ];
 

--- a/assets/pages/digital-subscription-landing/components/productBlock.jsx
+++ b/assets/pages/digital-subscription-landing/components/productBlock.jsx
@@ -28,20 +28,20 @@ const imageSlot = '(max-width: 480px) 100vw, (max-width: 660px) 460px, 345px';
 
 const defaultFeatures: ListItem[] = [
   {
-    heading: ['Discover ', <mark className="product-block__highlight">New</mark>],
-    text: 'A selection of long reads, interviews and features to be read at leisure',
+    heading: 'Ad-free reading',
+    text: 'Independent reporting with no distractions',
   },
   {
     heading: ['Live ', <mark className="product-block__highlight">New</mark>],
-    text: 'A fast way to catch up on every news story as it breaks',
+    text: 'Catch up on every news story as it breaks',
   },
   {
-    heading: 'Complete the daily crossword',
-    text: 'Get our daily crossword wherever you are',
+    heading: ['Discover ', <mark className="product-block__highlight">New</mark>],
+    text: 'Explore a beautifully curated feed of features, reviews and opinion',
   },
   {
-    heading: 'Ad-free reading',
-    text: 'Read the news with no distractions',
+    heading: 'Enhanced offline reading',
+    text: 'Quality journalism on your schedule - download the day\'s news before you travel',
   },
 ];
 
@@ -54,7 +54,7 @@ const appFeatures: {
   AUDCountries: [
     {
       heading: 'Ad-free reading',
-      text: 'Read the news with no distractions',
+      text: 'Independent reporting with no distractions',
     },
     {
       heading: 'Complete the daily crossword',
@@ -106,7 +106,7 @@ function ProductBlock(props: PropTypes) {
           imageProps={appImages[props.countryGroupId]}
           companionSvg={null}
           heading="App premium tier"
-          description="Exciting new app features available for mobile and tablet users with a digital subscription"
+          description="Your enhanced experience of The Guardian for mobile and tablet, with exclusive features and ad-free reading"
           features={appFeatures[props.countryGroupId]}
         />
         <div className="product-block__ampersand">&</div>
@@ -121,23 +121,23 @@ function ProductBlock(props: PropTypes) {
           }}
           companionSvg={<SvgPennyFarthingCircles />}
           heading="iPad daily Edition"
-          description="Enjoy the daily UK newspaper and all of our supplements, specially designed to be read on the iPad"
+          description="Every issue of The Guardian and Observer, designed for your iPad and available offline"
           features={[
             {
-              heading: 'Read on the go',
-              text: 'Your complete daily newspaper, designed for iPad and available offline',
+              heading: 'On-the-go reading',
+              text: 'Your complete daily newspaper, beautifully designed for your iPad',
             },
             {
-              heading: 'Never wait for the news',
-              text: 'Downloads automatically at 4am every day, so it\'s there when you wake up',
+              heading: 'Every supplement',
+              text: 'Including Weekend, Review, Feast and Observer Food Monthly',
             },
             {
-              heading: 'Get every supplement',
-              text: 'Including Weekend, Feast and Observer Food Monthly',
+              heading: 'Journalism at your own pace',
+              text: 'Access a month of issues in your 30-day archive',
             },
             {
-              heading: 'Enjoy our journalism at your own pace',
-              text: 'Access to your own 30-day archive',
+              heading: 'The news when you need it',
+              text: 'Downloads automatically every day, ready for you to read offline',
             },
           ]}
         />

--- a/assets/pages/digital-subscription-landing/components/productBlock.jsx
+++ b/assets/pages/digital-subscription-landing/components/productBlock.jsx
@@ -41,7 +41,7 @@ const defaultFeatures: ListItem[] = [
   },
   {
     heading: 'Enhanced offline reading',
-    text: 'Quality journalism on your schedule - download the day\'s news before you travel',
+    text: 'Download the day\'s news before you travel',
   },
 ];
 
@@ -120,7 +120,7 @@ function ProductBlock(props: PropTypes) {
             imgType: 'png',
           }}
           companionSvg={<SvgPennyFarthingCircles />}
-          heading="iPad daily Edition"
+          heading="iPad daily edition"
           description="Every issue of The Guardian and Observer, designed for your iPad and available offline"
           features={[
             {

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -275,7 +275,7 @@
       width: 320px;
     }
 
-    @include mq($from: mobileMedium, $until: tablet) {
+    @include mq($from: mobileMedium, $until: leftCol) {
       width: 330px;
     }
 
@@ -286,11 +286,17 @@
     }
 
     @include mq($from: leftCol) {
-      width: 490px;
-      margin-left: 12px;
-      font-size: 36px;
-      line-height: 42px;
+      width: 500px;
+      font-size: 32px;
+      line-height: 36px;
     }
+
+    //@include mq($from: leftCol) {
+    //  width: 490px;
+    //  margin-left: 12px;
+    //  font-size: 36px;
+    //  line-height: 42px;
+    //}
   }
 
   .component-left-margin-section--header-block {

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -275,7 +275,7 @@
       width: 320px;
     }
 
-    @include mq($from: mobileMedium, $until: leftCol) {
+    @include mq($from: mobileMedium, $until: tablet) {
       width: 330px;
     }
 

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -153,21 +153,14 @@
     line-height: 1.25;
     font-family: $gu-headline;
     list-style-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 10 10"><circle cx="5" cy="5" r="5" fill="#ff4e36"/></svg>');
-   // margin-left: 26px;
-
-    display: grid;
-    grid-template-columns: 1fr;
-
-    //@include mq($from: leftCol) {
-    //  columns: 2;
-    //  column-gap: 54px;
-    //  column-fill: auto;
-    //  height: 175px;
-    //}
+    margin-left: 26px;
+    display: flex;
+    flex-flow: column wrap;
 
     @include mq($from: leftCol) {
-      grid-template-columns: 1fr 1fr;
+      height: 200px;
     }
+
   }
 
   .component-feature-list__heading {
@@ -178,8 +171,11 @@
 
   .component-feature-list__item {
     margin-bottom: $gu-v-spacing / 2;
-    margin-left: 25px;
-    display:list-item;
+    display: list-item;
+
+    @include mq($from: leftCol) {
+      width: 200px;
+    }
   }
 
   .product-block__highlight {

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -153,13 +153,20 @@
     line-height: 1.25;
     font-family: $gu-headline;
     list-style-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 10 10"><circle cx="5" cy="5" r="5" fill="#ff4e36"/></svg>');
-    margin-left: 26px;
+   // margin-left: 26px;
+
+    display: grid;
+    grid-template-columns: 1fr;
+
+    //@include mq($from: leftCol) {
+    //  columns: 2;
+    //  column-gap: 54px;
+    //  column-fill: auto;
+    //  height: 175px;
+    //}
 
     @include mq($from: leftCol) {
-      columns: 2;
-      column-gap: 54px;
-      column-fill: auto;
-      height: 175px;
+      grid-template-columns: 1fr 1fr;
     }
   }
 
@@ -171,6 +178,8 @@
 
   .component-feature-list__item {
     margin-bottom: $gu-v-spacing / 2;
+    margin-left: 25px;
+    display:list-item;
   }
 
   .product-block__highlight {

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -286,17 +286,11 @@
     }
 
     @include mq($from: leftCol) {
-      width: 500px;
-      font-size: 32px;
-      line-height: 36px;
+      width: 550px;
+      margin-left: 12px;
+      font-size: 36px;
+      line-height: 42px;
     }
-
-    //@include mq($from: leftCol) {
-    //  width: 490px;
-    //  margin-left: 12px;
-    //  font-size: 36px;
-    //  line-height: 42px;
-    //}
   }
 
   .component-left-margin-section--header-block {


### PR DESCRIPTION
## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->
We need to update the copy on the digital pack landing page to align with the copy for the September campaign so that prospective customers will have a consistent experience. See the doc on the trello card for the copy changes. 

[**Trello Card**](https://trello.com/c/YAnEWs8B/1827-update-digital-pack-product-pages-with-campaign-copy)

## Changes

* Copy changes 
* Update the width of the header text at breakpoint leftCol because otherwise the pricing covers the text. 
* Put the features list in a flexbox (to create fewer wrapping issues when needing to change copy. This time, it was:
<img src="https://user-images.githubusercontent.com/3072877/45751650-e3a90580-bc0a-11e8-90b6-17a84e590c26.png" alt="updated copy, mobile" height="250"/>

## Screenshots

|        | **With updated copy**           | **Current state of page**   |
| ------------- |:-------------:| -----|
| **mobile**     | <img src="https://user-images.githubusercontent.com/3072877/45750945-a6dc0f00-bc08-11e8-8ffe-234ae357b4f3.png" alt="updated copy, mobile" height="200"/> | <img src="https://user-images.githubusercontent.com/3072877/45750848-39c87980-bc08-11e8-8645-dae2c94331fa.png" alt="current state of copy, mobile" height="200"/> |
| **tablet**    | <img src="https://user-images.githubusercontent.com/3072877/45750967-c115ed00-bc08-11e8-88c2-9f4eee094e49.png" alt="updated copy, tablet" height="200"/> | <img src="https://user-images.githubusercontent.com/3072877/45751548-9167e480-bc0a-11e8-8e38-611451224a73.png" alt="current state of copy, tablet" height="200"/> |
| **big web browser window**    | <img src="https://user-images.githubusercontent.com/3072877/45751012-ec004100-bc08-11e8-9bb8-dcb339fdf780.png" alt="updated copy, big web browser window" width="200"/> | <img src="https://user-images.githubusercontent.com/3072877/45750907-6c727200-bc08-11e8-95a2-f7dbe944f687.png" alt="current state of copy, big web browser window" width="200"/> |

