### PR TITLE
Log the reason config could not be fetched

### DIFF
--- a/app/admin/SettingsProvider.scala
+++ b/app/admin/SettingsProvider.scala
@@ -51,7 +51,7 @@ object SettingsProvider {
 
   def fromConfigurationUnsafe(config: Config)(implicit s3: AmazonS3): SettingsProvider =
     fromConfiguration(config).valueOr { error =>
-      throw new RuntimeException("unable to load settings provider from config", error)
+      throw new RuntimeException(s"unable to load settings provider from config. ${error.getMessage}")
     }
 }
 


### PR DESCRIPTION
For whatever reason, passing the underlying error as a second arg to `RuntimeException` means we don't get the message from it displayed (and, I assume, logged).

There may be a nicer way to do this - if so, let me know

# Before
![picture 307](https://user-images.githubusercontent.com/5122968/45776516-03601e00-bc4b-11e8-9c0c-bdccce1c39e3.png)

# After
###  (stack trace cut off, but present!)
![picture 304](https://user-images.githubusercontent.com/5122968/45776518-03601e00-bc4b-11e8-800b-3a6122aa2462.png)