### PR TITLE
[NPF] Read and propagate guest account registration token to thank you page for NPF

### DIFF
--- a/assets/helpers/paymentIntegrations/readerRevenueApis.js
+++ b/assets/helpers/paymentIntegrations/readerRevenueApis.js
@@ -1,5 +1,5 @@
 // @flow
-import type { Dispatch } from "redux";
+import type { Dispatch } from 'redux';
 import { routes } from 'helpers/routes';
 import { addQueryParamsToURL } from 'helpers/url';
 import {
@@ -8,7 +8,6 @@ import {
   type OphanIds,
   type AcquisitionABTest,
 } from 'helpers/tracking/acquisitions';
-import { type Action, setGuestAccountCreationToken } from 'pages/new-contributions-landing/contributionsLandingActions'
 import { type CheckoutFailureReason } from 'helpers/checkoutErrors';
 import { type Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import { type BillingPeriod } from 'helpers/contributions';
@@ -18,6 +17,7 @@ import { type UsState, type CaState, type IsoCountry } from 'helpers/internation
 import { pollUntilPromise, logPromise } from 'helpers/promise';
 import { fetchJson } from 'helpers/fetch';
 import trackConversion from 'helpers/tracking/conversions';
+import { type Action, setGuestAccountCreationToken } from '../../pages/new-contributions-landing/contributionsLandingActions';
 
 import * as cookie from 'helpers/cookie';
 
@@ -74,7 +74,6 @@ export type PaymentResult
   | {| paymentStatus: 'failure', error: CheckoutFailureReason |};
 
 // ----- Setup ----- //
-
 const PaymentSuccess: PaymentResult = { paymentStatus: 'success' };
 const POLLING_INTERVAL = 3000;
 const MAX_POLLS = 10;
@@ -124,7 +123,11 @@ function checkOneOffStatus(json: Object): Promise<PaymentResult> {
  * - failed, then we bubble up an error value
  * - otherwise, we bubble up a success value
  */
-function checkRegularStatus(participations: Participations, csrf: CsrfState, dispatch: Dispatch<Action>): Object => Promise<PaymentResult> {
+function checkRegularStatus(
+  participations: Participations,
+  csrf: CsrfState,
+  dispatch: Dispatch<Action>,
+): Object => Promise<PaymentResult> {
   const handleCompletion = (json) => {
     switch (json.status) {
       case 'success':
@@ -192,7 +195,7 @@ function postRegularStripeRequest(
   data: PaymentFields,
   participations: Participations,
   csrf: CsrfState,
-  dispatch: Dispatch<Action>
+  dispatch: Dispatch<Action>,
 ): Promise<PaymentResult> {
   return logPromise(fetchJson(
     routes.recurringContribCreate,

--- a/assets/helpers/paymentIntegrations/readerRevenueApis.js
+++ b/assets/helpers/paymentIntegrations/readerRevenueApis.js
@@ -1,5 +1,4 @@
 // @flow
-import type { Dispatch } from 'redux';
 import { routes } from 'helpers/routes';
 import { addQueryParamsToURL } from 'helpers/url';
 import {
@@ -17,7 +16,6 @@ import { type UsState, type CaState, type IsoCountry } from 'helpers/internation
 import { pollUntilPromise, logPromise } from 'helpers/promise';
 import { fetchJson } from 'helpers/fetch';
 import trackConversion from 'helpers/tracking/conversions';
-import { type Action, setGuestAccountCreationToken } from '../../pages/new-contributions-landing/contributionsLandingActions';
 
 import * as cookie from 'helpers/cookie';
 
@@ -126,7 +124,7 @@ function checkOneOffStatus(json: Object): Promise<PaymentResult> {
 function checkRegularStatus(
   participations: Participations,
   csrf: CsrfState,
-  dispatch: Dispatch<Action>,
+  setGuestAccountCreationToken: (string) => void,
 ): Object => Promise<PaymentResult> {
   const handleCompletion = (json) => {
     switch (json.status) {
@@ -150,7 +148,7 @@ function checkRegularStatus(
 
   return (json) => {
     if (json.guestAccountCreationToken) {
-      dispatch(setGuestAccountCreationToken(json.guestAccountCreationToken));
+      setGuestAccountCreationToken(json.guestAccountCreationToken);
     }
     switch (json.status) {
       case 'pending':
@@ -195,12 +193,12 @@ function postRegularStripeRequest(
   data: PaymentFields,
   participations: Participations,
   csrf: CsrfState,
-  dispatch: Dispatch<Action>,
+  setGuestAccountCreationToken: (string) => void,
 ): Promise<PaymentResult> {
   return logPromise(fetchJson(
     routes.recurringContribCreate,
     postRequestOptions(data, 'same-origin', csrf),
-  ).then(checkRegularStatus(participations, csrf, dispatch)));
+  ).then(checkRegularStatus(participations, csrf, setGuestAccountCreationToken)));
 }
 
 export {

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -104,7 +104,7 @@ const sendData = (data: PaymentFields) =>
               data,
               state.common.abParticipations,
               state.page.csrf,
-              dispatch,
+              token => dispatch(setGuestAccountCreationToken(token)),
             )));
             return;
         }

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -5,7 +5,13 @@
 import { type PaymentMethod, type PaymentHandler } from 'helpers/checkouts';
 import { type Amount, type Contrib } from 'helpers/contributions';
 import { type UsState, type CaState } from 'helpers/internationalisation/country';
-import { type Token, type PaymentFields, type PaymentResult, PaymentSuccess, postOneOffStripeRequest, postRegularStripeRequest } from 'helpers/paymentIntegrations/readerRevenueApis';
+import { type Token,
+  type PaymentFields,
+  type PaymentResult,
+  PaymentSuccess,
+  postOneOffStripeRequest,
+  postRegularStripeRequest
+} from 'helpers/paymentIntegrations/readerRevenueApis';
 import { derivePaymentApiAcquisitionData, getSupportAbTests, getOphanIds } from 'helpers/tracking/acquisitions';
 import trackConversion from 'helpers/tracking/conversions';
 import { type State } from './contributionsLandingReducer';
@@ -26,6 +32,7 @@ export type Action =
   | { type: 'PAYMENT_FAILURE', error: string }
   | { type: 'PAYMENT_WAITING', isWaiting: boolean }
   | { type: 'SET_CHECKOUT_FORM_HAS_BEEN_SUBMITTED' }
+  | { type: 'SET_GUEST_ACCOUNT_CREATION_TOKEN', guestAccountCreationToken: string }
   | { type: 'PAYMENT_SUCCESS' };
 
 const updateContributionType = (contributionType: Contrib): Action =>
@@ -56,6 +63,9 @@ const paymentSuccess = (): Action => ({ type: 'PAYMENT_SUCCESS' });
 const paymentWaiting = (isWaiting: boolean): Action => ({ type: 'PAYMENT_WAITING', isWaiting });
 
 const paymentFailure = (error: string): Action => ({ type: 'PAYMENT_FAILURE', error });
+
+const setGuestAccountCreationToken = (guestAccountCreationToken: string): Action =>
+  ({ type: 'SET_GUEST_ACCOUNT_CREATION_TOKEN', guestAccountCreationToken });
 
 const isPaymentReady = (paymentReady: boolean, paymentHandler: ?{ [PaymentMethod]: PaymentHandler }): Action =>
   ({ type: 'UPDATE_PAYMENT_READY', paymentReady, paymentHandler: paymentHandler || null });
@@ -89,7 +99,7 @@ const sendData = (data: PaymentFields) =>
             return;
 
           default:
-            dispatch(onPaymentResult(postRegularStripeRequest(data, state.common.abParticipations, state.page.csrf)));
+            dispatch(onPaymentResult(postRegularStripeRequest(data, state.common.abParticipations, state.page.csrf, dispatch)));
             return;
         }
 
@@ -180,4 +190,5 @@ export {
   paymentSuccess,
   onThirdPartyPaymentDone,
   setCheckoutFormHasBeenSubmitted,
+  setGuestAccountCreationToken,
 };

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -5,12 +5,13 @@
 import { type PaymentMethod, type PaymentHandler } from 'helpers/checkouts';
 import { type Amount, type Contrib } from 'helpers/contributions';
 import { type UsState, type CaState } from 'helpers/internationalisation/country';
-import { type Token,
+import {
+  type Token,
   type PaymentFields,
   type PaymentResult,
   PaymentSuccess,
   postOneOffStripeRequest,
-  postRegularStripeRequest
+  postRegularStripeRequest,
 } from 'helpers/paymentIntegrations/readerRevenueApis';
 import { derivePaymentApiAcquisitionData, getSupportAbTests, getOphanIds } from 'helpers/tracking/acquisitions';
 import trackConversion from 'helpers/tracking/conversions';
@@ -99,7 +100,12 @@ const sendData = (data: PaymentFields) =>
             return;
 
           default:
-            dispatch(onPaymentResult(postRegularStripeRequest(data, state.common.abParticipations, state.page.csrf, dispatch)));
+            dispatch(onPaymentResult(postRegularStripeRequest(
+              data,
+              state.common.abParticipations,
+              state.page.csrf,
+              dispatch,
+            )));
             return;
         }
 

--- a/assets/pages/new-contributions-landing/contributionsLandingReducer.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingReducer.js
@@ -40,6 +40,7 @@ type FormState = {
   isWaiting: boolean,
   formData: FormData,
   done: boolean,
+  guestAccountCreationToken: ?string,
 };
 
 type PageState = {
@@ -96,6 +97,7 @@ function createFormReducer(countryGroupId: CountryGroupId) {
     selectedAmounts: initialAmount,
     isWaiting: false,
     done: false,
+    guestAccountCreationToken: null,
   };
 
   return function formReducer(state: FormState = initialState, action: Action): FormState {
@@ -163,6 +165,9 @@ function createFormReducer(countryGroupId: CountryGroupId) {
 
       case 'SET_CHECKOUT_FORM_HAS_BEEN_SUBMITTED':
         return { ...state, formData: { ...state.formData, checkoutFormHasBeenSubmitted: true } };
+
+      case 'SET_GUEST_ACCOUNT_CREATION_TOKEN':
+        return { ...state, guestAccountCreationToken: action.guestAccountCreationToken };
 
       default:
         return state;


### PR DESCRIPTION
## Why are you doing this?
In order to create a password on the thank you page, we need to read the guestAccountRegistrationToken from the response from the call to `/contribute/recurring/create` and store it in the state. 

[This PR](https://github.com/guardian/support-frontend/pull/962) did the same thing for the old payment flow, this implements the same logic for the NPF. 


@regiskuckaertz @joelochlann @tsop14 @Mullefa 