### PR TITLE
Standardise and clarify payment callbacks

### DIFF
--- a/assets/components/directDebit/directDebitActions.js
+++ b/assets/components/directDebit/directDebitActions.js
@@ -1,9 +1,9 @@
 // @flow
 
 import * as storage from 'helpers/storage';
+import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
 
 import { checkAccount } from './helpers/ajax';
-
 
 // ----- Types ----- //
 
@@ -111,7 +111,7 @@ function payDirectDebitClicked(): Function {
   };
 }
 
-function confirmDirectDebitClicked(callback: Function): Function {
+function confirmDirectDebitClicked(onPaymentAuthorisation: PaymentAuthorisation => void): Function {
 
   return (dispatch: Function, getState: Function) => {
 
@@ -123,7 +123,12 @@ function confirmDirectDebitClicked(callback: Function): Function {
 
     const sortCode = sortCodeArray.join('');
 
-    callback(undefined, accountNumber, sortCode, accountHolderName);
+    onPaymentAuthorisation({
+      paymentMethod: 'DirectDebit',
+      accountHolderName,
+      sortCode,
+      accountNumber,
+    });
 
     dispatch(closeDirectDebitPopUp());
 

--- a/assets/components/directDebit/directDebitForm/directDebitForm.jsx
+++ b/assets/components/directDebit/directDebitForm/directDebitForm.jsx
@@ -32,7 +32,7 @@ import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRev
 // ---- Types ----- //
 
 type PropTypes = {
-  callback: PaymentAuthorisation => void,
+  onPaymentAuthorisation: PaymentAuthorisation => void,
   isDDGuaranteeOpen: boolean,
   sortCodeArray: Array<string>,
   accountNumber: string,
@@ -48,7 +48,7 @@ type PropTypes = {
   phase: Phase,
   payDirectDebitClicked: () => void,
   editDirectDebitClicked: () => void,
-  confirmDirectDebitClicked: (callback: PaymentAuthorisation => void) => void,
+  confirmDirectDebitClicked: (onPaymentAuthorisation: PaymentAuthorisation => void) => void,
   countryGroupId: CountryGroupId,
 };
 
@@ -78,8 +78,8 @@ function mapDispatchToProps(dispatch: Dispatch<Action>) {
     editDirectDebitClicked: () => {
       dispatch(setDirectDebitFormPhase('entry'));
     },
-    confirmDirectDebitClicked: (callback) => {
-      dispatch(confirmDirectDebitClicked(callback));
+    confirmDirectDebitClicked: (onPaymentAuthorisation: PaymentAuthorisation => void) => {
+      dispatch(confirmDirectDebitClicked(onPaymentAuthorisation));
       return false;
     },
     openDDGuaranteeClicked: () => {
@@ -140,7 +140,7 @@ const DirectDebitForm = (props: PropTypes) => (
       phase={props.phase}
       onPayClick={() => props.payDirectDebitClicked()}
       onEditClick={() => props.editDirectDebitClicked()}
-      onConfirmClick={() => props.confirmDirectDebitClicked(props.callback)}
+      onConfirmClick={() => props.confirmDirectDebitClicked(props.onPaymentAuthorisation)}
     />
 
     <ErrorMessage

--- a/assets/components/directDebit/directDebitForm/directDebitForm.jsx
+++ b/assets/components/directDebit/directDebitForm/directDebitForm.jsx
@@ -27,12 +27,12 @@ import SvgArrowRightStraight from 'components/svgs/arrowRightStraight';
 import SvgExclamationAlternate from 'components/svgs/exclamationAlternate';
 import { contributionsEmail } from 'helpers/legal';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import type { Token } from 'helpers/paymentIntegrations/readerRevenueApis';
+import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
 
 // ---- Types ----- //
 
 type PropTypes = {
-  callback: Token => void,
+  callback: PaymentAuthorisation => void,
   isDDGuaranteeOpen: boolean,
   sortCodeArray: Array<string>,
   accountNumber: string,
@@ -48,7 +48,7 @@ type PropTypes = {
   phase: Phase,
   payDirectDebitClicked: () => void,
   editDirectDebitClicked: () => void,
-  confirmDirectDebitClicked: (callback: Token => void) => void,
+  confirmDirectDebitClicked: (callback: PaymentAuthorisation => void) => void,
   countryGroupId: CountryGroupId,
 };
 

--- a/assets/components/directDebit/directDebitForm/directDebitForm.jsx
+++ b/assets/components/directDebit/directDebitForm/directDebitForm.jsx
@@ -21,18 +21,18 @@ import {
   setDirectDebitFormPhase,
 } from 'components/directDebit/directDebitActions';
 import type { SortCodeIndex, Phase, Action } from 'components/directDebit/directDebitActions';
-import type { RegularCheckoutCallback } from 'helpers/checkouts';
 import SvgDirectDebitSymbol from 'components/svgs/directDebitSymbol';
 import SvgDirectDebitSymbolAndText from 'components/svgs/directDebitSymbolAndText';
 import SvgArrowRightStraight from 'components/svgs/arrowRightStraight';
 import SvgExclamationAlternate from 'components/svgs/exclamationAlternate';
 import { contributionsEmail } from 'helpers/legal';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import type { Token } from 'helpers/paymentIntegrations/readerRevenueApis';
 
 // ---- Types ----- //
 
 type PropTypes = {
-  callback: RegularCheckoutCallback,
+  callback: Token => void,
   isDDGuaranteeOpen: boolean,
   sortCodeArray: Array<string>,
   accountNumber: string,
@@ -48,7 +48,7 @@ type PropTypes = {
   phase: Phase,
   payDirectDebitClicked: () => void,
   editDirectDebitClicked: () => void,
-  confirmDirectDebitClicked: (callback: RegularCheckoutCallback) => void,
+  confirmDirectDebitClicked: (callback: Token => void) => void,
   countryGroupId: CountryGroupId,
 };
 

--- a/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.jsx
+++ b/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.jsx
@@ -20,7 +20,7 @@ import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRev
 // ---- Types ----- //
 
 type PropTypes = {
-  callback: PaymentAuthorisation => void,
+  onPaymentAuthorisation: PaymentAuthorisation => void,
   isPopUpOpen: boolean,
   closeDirectDebitPopUp: () => void,
   phase: Phase,
@@ -70,7 +70,7 @@ const DirectDebitPopUpForm = (props: PropTypes) => {
               <SvgCross />
             </span>
           </button>
-          <DirectDebitForm callback={props.callback} />
+          <DirectDebitForm onPaymentAuthorisation={props.onPaymentAuthorisation} />
         </div>
       </div>
     );

--- a/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.jsx
+++ b/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.jsx
@@ -15,13 +15,12 @@ import DirectDebitForm from 'components/directDebit/directDebitForm/directDebitF
 import SvgCross from 'components/svgs/cross';
 
 import type { Phase } from 'components/directDebit/directDebitActions';
-import type { RegularCheckoutCallback } from 'helpers/checkouts';
-
+import type { Token } from 'helpers/paymentIntegrations/readerRevenueApis';
 
 // ---- Types ----- //
 
 type PropTypes = {
-  callback: RegularCheckoutCallback,
+  callback: Token => void,
   isPopUpOpen: boolean,
   closeDirectDebitPopUp: () => void,
   phase: Phase,

--- a/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.jsx
+++ b/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.jsx
@@ -15,12 +15,12 @@ import DirectDebitForm from 'components/directDebit/directDebitForm/directDebitF
 import SvgCross from 'components/svgs/cross';
 
 import type { Phase } from 'components/directDebit/directDebitActions';
-import type { Token } from 'helpers/paymentIntegrations/readerRevenueApis';
+import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
 
 // ---- Types ----- //
 
 type PropTypes = {
-  callback: Token => void,
+  callback: PaymentAuthorisation => void,
   isPopUpOpen: boolean,
   closeDirectDebitPopUp: () => void,
   phase: Phase,

--- a/assets/components/paymentButtons/directDebitPopUpButton/directDebitPopUpButton.jsx
+++ b/assets/components/paymentButtons/directDebitPopUpButton/directDebitPopUpButton.jsx
@@ -22,7 +22,7 @@ import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRev
 
 /* eslint-disable react/no-unused-prop-types */
 type PropTypes = {
-  callback: PaymentAuthorisation => void,
+  onPaymentAuthorisation: PaymentAuthorisation => void,
   isPopUpOpen: boolean,
   openDirectDebitPopUp: () => void,
   switchStatus: Status,
@@ -75,7 +75,7 @@ function ButtonAndForm(props: PropTypes) {
           canOpen={props.canOpen}
           whenUnableToOpen={props.whenUnableToOpen}
         />
-        <DirectDebitPopUpForm callback={props.callback} />
+        <DirectDebitPopUpForm onPaymentAuthorisation={props.onPaymentAuthorisation} />
       </div>
     );
   }

--- a/assets/components/paymentButtons/directDebitPopUpButton/directDebitPopUpButton.jsx
+++ b/assets/components/paymentButtons/directDebitPopUpButton/directDebitPopUpButton.jsx
@@ -15,14 +15,14 @@ import {
 import DirectDebitPopUpForm from 'components/directDebit/directDebitPopUpForm/directDebitPopUpForm';
 import SvgArrowRightStraight from 'components/svgs/arrowRightStraight';
 import type { Status } from 'helpers/settings';
-import type { Token } from 'helpers/paymentIntegrations/readerRevenueApis';
+import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
 
 
 // ---- Types ----- //
 
 /* eslint-disable react/no-unused-prop-types */
 type PropTypes = {
-  callback: Token => void,
+  callback: PaymentAuthorisation => void,
   isPopUpOpen: boolean,
   openDirectDebitPopUp: () => void,
   switchStatus: Status,

--- a/assets/components/paymentButtons/directDebitPopUpButton/directDebitPopUpButton.jsx
+++ b/assets/components/paymentButtons/directDebitPopUpButton/directDebitPopUpButton.jsx
@@ -15,14 +15,14 @@ import {
 import DirectDebitPopUpForm from 'components/directDebit/directDebitPopUpForm/directDebitPopUpForm';
 import SvgArrowRightStraight from 'components/svgs/arrowRightStraight';
 import type { Status } from 'helpers/settings';
-import type { RegularCheckoutCallback } from 'helpers/checkouts';
+import type { Token } from 'helpers/paymentIntegrations/readerRevenueApis';
 
 
 // ---- Types ----- //
 
 /* eslint-disable react/no-unused-prop-types */
 type PropTypes = {
-  callback: RegularCheckoutCallback,
+  callback: Token => void,
   isPopUpOpen: boolean,
   openDirectDebitPopUp: () => void,
   switchStatus: Status,

--- a/assets/components/paymentButtons/payPalExpressButton/payPalExpressButton.jsx
+++ b/assets/components/paymentButtons/payPalExpressButton/payPalExpressButton.jsx
@@ -11,13 +11,13 @@ import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import type { Status } from 'helpers/settings';
 import { loadPayPalExpress, setup } from 'helpers/paymentIntegrations/payPalExpressCheckout';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
-import type { Token } from 'helpers/paymentIntegrations/readerRevenueApis';
+import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
 
 // ---- Types ----- //
 
 type PropTypes = {|
   amount: number,
-  callback: Token => void,
+  callback: PaymentAuthorisation => void,
   csrf: CsrfState,
   currencyId: IsoCurrency,
   hasLoaded: boolean,

--- a/assets/components/paymentButtons/payPalExpressButton/payPalExpressButton.jsx
+++ b/assets/components/paymentButtons/payPalExpressButton/payPalExpressButton.jsx
@@ -17,7 +17,7 @@ import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRev
 
 type PropTypes = {|
   amount: number,
-  callback: PaymentAuthorisation => void,
+  onPaymentAuthorisation: PaymentAuthorisation => void,
   csrf: CsrfState,
   currencyId: IsoCurrency,
   hasLoaded: boolean,
@@ -55,7 +55,7 @@ function Button(props: PropTypes) {
     props.amount,
     props.currencyId,
     props.csrf,
-    props.callback,
+    props.onPaymentAuthorisation,
     props.canOpen,
     props.whenUnableToOpen,
   );

--- a/assets/components/paymentButtons/payPalExpressButton/payPalExpressButton.jsx
+++ b/assets/components/paymentButtons/payPalExpressButton/payPalExpressButton.jsx
@@ -11,13 +11,13 @@ import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import type { Status } from 'helpers/settings';
 import { loadPayPalExpress, setup } from 'helpers/paymentIntegrations/payPalExpressCheckout';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
-
+import type { Token } from 'helpers/paymentIntegrations/readerRevenueApis';
 
 // ---- Types ----- //
 
 type PropTypes = {|
   amount: number,
-  callback: (token: string) => Promise<*>,
+  callback: Token => void,
   csrf: CsrfState,
   currencyId: IsoCurrency,
   hasLoaded: boolean,

--- a/assets/components/paymentButtons/payPalExpressButton/payPalExpressButton.jsx
+++ b/assets/components/paymentButtons/payPalExpressButton/payPalExpressButton.jsx
@@ -12,6 +12,7 @@ import type { Status } from 'helpers/settings';
 import { loadPayPalExpress, setup } from 'helpers/paymentIntegrations/payPalExpressCheckout';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
+import type { PayPalAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
 
 // ---- Types ----- //
 
@@ -51,11 +52,20 @@ function Button(props: PropTypes) {
     return null;
   }
 
+  const tokenToAuthorisation = (token: string): PayPalAuthorisation => ({
+    paymentMethod: 'PayPal',
+    token,
+  });
+
+  const onPaymentAuthorisation = (token: string): void => {
+    props.onPaymentAuthorisation(tokenToAuthorisation(token));
+  };
+
   const payPalOptions = setup(
     props.amount,
     props.currencyId,
     props.csrf,
-    props.onPaymentAuthorisation,
+    onPaymentAuthorisation,
     props.canOpen,
     props.whenUnableToOpen,
   );

--- a/assets/components/paymentButtons/stripePopUpButton/stripePopUpButton.jsx
+++ b/assets/components/paymentButtons/stripePopUpButton/stripePopUpButton.jsx
@@ -12,7 +12,7 @@ import {
   setupStripeCheckout,
   openDialogBox,
 } from 'helpers/paymentIntegrations/stripeCheckout';
-import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
+import type { StripeAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
 
 
 // ---- Types ----- //
@@ -20,7 +20,7 @@ import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRev
 /* eslint-disable react/no-unused-prop-types */
 type PropTypes = {|
   amount: number,
-  callback: PaymentAuthorisation => void,
+  callback: StripeAuthorisation => void,
   closeHandler: () => void,
   currencyId: IsoCurrency,
   email: string,
@@ -55,13 +55,13 @@ const StripePopUpButton = (props: PropTypes) => (
 
 function Button(props: PropTypes) {
 
-  const stripeTokenToToken = (stripeTokenAsString: string): PaymentAuthorisation => ({
+  const tokenToAuthorisation = (token: string): StripeAuthorisation => ({
     paymentMethod: 'Stripe',
-    token: stripeTokenAsString,
+    token,
   });
 
-  const newCallback = (stripeTokenAsString: string): void => {
-    props.callback(stripeTokenToToken(stripeTokenAsString));
+  const newCallback = (token: string): void => {
+    props.callback(tokenToAuthorisation(token));
   };
 
   if (!isStripeSetup()) {

--- a/assets/components/paymentButtons/stripePopUpButton/stripePopUpButton.jsx
+++ b/assets/components/paymentButtons/stripePopUpButton/stripePopUpButton.jsx
@@ -12,13 +12,15 @@ import {
   setupStripeCheckout,
   openDialogBox,
 } from 'helpers/paymentIntegrations/stripeCheckout';
+import type { Token } from 'helpers/paymentIntegrations/readerRevenueApis';
+
 
 // ---- Types ----- //
 
 /* eslint-disable react/no-unused-prop-types */
 type PropTypes = {|
   amount: number,
-  callback: (token: string) => Promise<*>,
+  callback: Token => void,
   closeHandler: () => void,
   currencyId: IsoCurrency,
   email: string,
@@ -61,7 +63,10 @@ function Button(props: PropTypes) {
     // Don't open Stripe Checkout for automated tests, call the backend immediately
     if (props.isPostDeploymentTestUser) {
       const testTokenId = 'tok_visa';
-      props.callback(testTokenId);
+      props.callback({
+        paymentMethod: 'Stripe',
+        token: testTokenId,
+      });
     } else if (props.canOpen()) {
       storage.setSession('paymentMethod', 'Stripe');
       openDialogBox(props.amount, props.email);

--- a/assets/components/paymentButtons/stripePopUpButton/stripePopUpButton.jsx
+++ b/assets/components/paymentButtons/stripePopUpButton/stripePopUpButton.jsx
@@ -20,7 +20,7 @@ import type { StripeAuthorisation } from 'helpers/paymentIntegrations/readerReve
 /* eslint-disable react/no-unused-prop-types */
 type PropTypes = {|
   amount: number,
-  callback: StripeAuthorisation => void,
+  onPaymentAuthorisation: StripeAuthorisation => void,
   closeHandler: () => void,
   currencyId: IsoCurrency,
   email: string,
@@ -60,18 +60,18 @@ function Button(props: PropTypes) {
     token,
   });
 
-  const newCallback = (token: string): void => {
-    props.callback(tokenToAuthorisation(token));
+  const onPaymentAuthorisation = (token: string): void => {
+    props.onPaymentAuthorisation(tokenToAuthorisation(token));
   };
 
   if (!isStripeSetup()) {
-    setupStripeCheckout(newCallback, props.closeHandler, props.currencyId, props.isTestUser);
+    setupStripeCheckout(onPaymentAuthorisation, props.closeHandler, props.currencyId, props.isTestUser);
   }
 
   const onClick = () => {
     // Don't open Stripe Checkout for automated tests, call the backend immediately
     if (props.isPostDeploymentTestUser) {
-      newCallback('tok_visa');
+      onPaymentAuthorisation('tok_visa');
     } else if (props.canOpen()) {
       storage.setSession('paymentMethod', 'Stripe');
       openDialogBox(props.amount, props.email);

--- a/assets/components/paymentButtons/stripePopUpButton/stripePopUpButton.jsx
+++ b/assets/components/paymentButtons/stripePopUpButton/stripePopUpButton.jsx
@@ -12,7 +12,7 @@ import {
   setupStripeCheckout,
   openDialogBox,
 } from 'helpers/paymentIntegrations/stripeCheckout';
-import type { Token } from 'helpers/paymentIntegrations/readerRevenueApis';
+import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
 
 
 // ---- Types ----- //
@@ -20,7 +20,7 @@ import type { Token } from 'helpers/paymentIntegrations/readerRevenueApis';
 /* eslint-disable react/no-unused-prop-types */
 type PropTypes = {|
   amount: number,
-  callback: Token => void,
+  callback: PaymentAuthorisation => void,
   closeHandler: () => void,
   currencyId: IsoCurrency,
   email: string,
@@ -55,7 +55,7 @@ const StripePopUpButton = (props: PropTypes) => (
 
 function Button(props: PropTypes) {
 
-  const stripeTokenToToken = (stripeTokenAsString: string): Token => ({
+  const stripeTokenToToken = (stripeTokenAsString: string): PaymentAuthorisation => ({
     paymentMethod: 'Stripe',
     token: stripeTokenAsString,
   });

--- a/assets/components/paymentButtons/stripePopUpButton/stripePopUpButton.jsx
+++ b/assets/components/paymentButtons/stripePopUpButton/stripePopUpButton.jsx
@@ -55,18 +55,23 @@ const StripePopUpButton = (props: PropTypes) => (
 
 function Button(props: PropTypes) {
 
+  const stripeTokenToToken = (stripeTokenAsString: string): Token => ({
+    paymentMethod: 'Stripe',
+    token: stripeTokenAsString,
+  });
+
+  const newCallback = (stripeTokenAsString: string): void => {
+    props.callback(stripeTokenToToken(stripeTokenAsString));
+  };
+
   if (!isStripeSetup()) {
-    setupStripeCheckout(props.callback, props.closeHandler, props.currencyId, props.isTestUser);
+    setupStripeCheckout(newCallback, props.closeHandler, props.currencyId, props.isTestUser);
   }
 
   const onClick = () => {
     // Don't open Stripe Checkout for automated tests, call the backend immediately
     if (props.isPostDeploymentTestUser) {
-      const testTokenId = 'tok_visa';
-      props.callback({
-        paymentMethod: 'Stripe',
-        token: testTokenId,
-      });
+      newCallback('tok_visa');
     } else if (props.canOpen()) {
       storage.setSession('paymentMethod', 'Stripe');
       openDialogBox(props.amount, props.email);

--- a/assets/helpers/checkouts.js
+++ b/assets/helpers/checkouts.js
@@ -18,13 +18,6 @@ type StripeHandler = { open: Function, close: Function };
 
 export type PaymentHandler = StripeHandler;
 
-export type RegularCheckoutCallback = (
-  token?: string,
-  accountNumber?: string,
-  sortCode?: string,
-  accountHolderName?: string
-) => Promise<*>
-
 // ----- Functions ----- //
 
 function getAmount(contributionType: Contrib, countryGroup: CountryGroupId): number {

--- a/assets/helpers/paymentIntegrations/newStripeCheckout.js
+++ b/assets/helpers/paymentIntegrations/newStripeCheckout.js
@@ -56,14 +56,14 @@ function getStripeKey(contributionType: Contrib, currency: IsoCurrency, isTestUs
 }
 
 function setupStripeCheckout(
-  callback: PaymentAuthorisation => void,
+  onPaymentAuthorisation: PaymentAuthorisation => void,
   contributionType: Contrib,
   currency: IsoCurrency,
   isTestUser: boolean,
 ): Promise<Object> {
   return loadStripe().then(() => {
     const handleToken = (token) => {
-      callback({ paymentMethod: 'Stripe', token: token.id });
+      onPaymentAuthorisation({ paymentMethod: 'Stripe', token: token.id });
     };
 
     const stripeKey = getStripeKey(contributionType, currency, isTestUser);

--- a/assets/helpers/paymentIntegrations/newStripeCheckout.js
+++ b/assets/helpers/paymentIntegrations/newStripeCheckout.js
@@ -20,7 +20,7 @@
 
 import { type IsoCurrency } from 'helpers/internationalisation/currency';
 import { type Contrib } from 'helpers/contributions';
-import { type Token } from './readerRevenueApis';
+import { type PaymentAuthorisation } from './readerRevenueApis';
 
 // ----- Functions ----- //
 
@@ -56,7 +56,7 @@ function getStripeKey(contributionType: Contrib, currency: IsoCurrency, isTestUs
 }
 
 function setupStripeCheckout(
-  callback: Token => void,
+  callback: PaymentAuthorisation => void,
   contributionType: Contrib,
   currency: IsoCurrency,
   isTestUser: boolean,

--- a/assets/helpers/paymentIntegrations/payPalExpressCheckout.js
+++ b/assets/helpers/paymentIntegrations/payPalExpressCheckout.js
@@ -8,7 +8,7 @@ import * as storage from 'helpers/storage';
 import { formInputs } from 'helpers/checkoutForm/checkoutForm';
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
-import type { Token } from 'helpers/paymentIntegrations/readerRevenueApis';
+import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
 import { formClassName } from '../../pages/regular-contributions/components/formFields';
 
 
@@ -90,7 +90,7 @@ function setup(
   amount: number,
   currencyId: IsoCurrency,
   csrf: CsrfState,
-  callback: Token => void,
+  callback: PaymentAuthorisation => void,
   canOpen: () => boolean,
   whenUnableToOpen: () => void,
 ): Promise<Object> {

--- a/assets/helpers/paymentIntegrations/payPalExpressCheckout.js
+++ b/assets/helpers/paymentIntegrations/payPalExpressCheckout.js
@@ -8,8 +8,8 @@ import * as storage from 'helpers/storage';
 import { formInputs } from 'helpers/checkoutForm/checkoutForm';
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
-import { formClassName } from '../../pages/regular-contributions/components/formFields';
 import type { Token } from 'helpers/paymentIntegrations/readerRevenueApis';
+import { formClassName } from '../../pages/regular-contributions/components/formFields';
 
 
 // ----- Functions ----- //

--- a/assets/helpers/paymentIntegrations/payPalExpressCheckout.js
+++ b/assets/helpers/paymentIntegrations/payPalExpressCheckout.js
@@ -90,7 +90,7 @@ function setup(
   amount: number,
   currencyId: IsoCurrency,
   csrf: CsrfState,
-  onPaymentAuthorisation: PaymentAuthorisation => void,
+  onPaymentAuthorisation: string => void,
   canOpen: () => boolean,
   whenUnableToOpen: () => void,
 ): Promise<Object> {

--- a/assets/helpers/paymentIntegrations/payPalExpressCheckout.js
+++ b/assets/helpers/paymentIntegrations/payPalExpressCheckout.js
@@ -9,6 +9,8 @@ import { formInputs } from 'helpers/checkoutForm/checkoutForm';
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import { formClassName } from '../../pages/regular-contributions/components/formFields';
+import type { Token } from 'helpers/paymentIntegrations/readerRevenueApis';
+
 
 // ----- Functions ----- //
 
@@ -88,7 +90,7 @@ function setup(
   amount: number,
   currencyId: IsoCurrency,
   csrf: CsrfState,
-  callback: (token: string) => Promise<*>,
+  callback: Token => void,
   canOpen: () => boolean,
   whenUnableToOpen: () => void,
 ): Promise<Object> {

--- a/assets/helpers/paymentIntegrations/payPalExpressCheckout.js
+++ b/assets/helpers/paymentIntegrations/payPalExpressCheckout.js
@@ -90,13 +90,13 @@ function setup(
   amount: number,
   currencyId: IsoCurrency,
   csrf: CsrfState,
-  callback: PaymentAuthorisation => void,
+  onPaymentAuthorisation: PaymentAuthorisation => void,
   canOpen: () => boolean,
   whenUnableToOpen: () => void,
 ): Promise<Object> {
 
   const handleBaId = (baid: Object) => {
-    callback(baid.token);
+    onPaymentAuthorisation(baid.token);
   };
 
   const onAuthorize = (data) => {

--- a/assets/helpers/paymentIntegrations/payPalExpressCheckout.js
+++ b/assets/helpers/paymentIntegrations/payPalExpressCheckout.js
@@ -8,7 +8,6 @@ import * as storage from 'helpers/storage';
 import { formInputs } from 'helpers/checkoutForm/checkoutForm';
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
-import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
 import { formClassName } from '../../pages/regular-contributions/components/formFields';
 
 

--- a/assets/helpers/paymentIntegrations/readerRevenueApis.js
+++ b/assets/helpers/paymentIntegrations/readerRevenueApis.js
@@ -63,10 +63,16 @@ export type PaymentFields
 
 type Credentials = 'omit' | 'same-origin' | 'include';
 
-export type Token
-  = {| paymentMethod: 'Stripe', token: string |}
-  | {| paymentMethod: 'PayPal', token: string |}
-  | {| paymentMethod: 'DirectDebit', accountHolderName: string, sortCode: string, accountNumber: string |};
+export type StripeAuthorisation = {| paymentMethod: 'Stripe', token: string |};
+export type PayPalAuthorisation = {| paymentMethod: 'PayPal', token: string |};
+export type DirectDebitAuthorisation = {|
+  paymentMethod: 'DirectDebit',
+  accountHolderName: string,
+  sortCode: string,
+  accountNumber: string
+|};
+
+export type PaymentAuthorisation = StripeAuthorisation | PayPalAuthorisation | DirectDebitAuthorisation;
 
 export type PaymentResult
   = {| paymentStatus: 'success' |}

--- a/assets/helpers/paymentIntegrations/stripeCheckout.js
+++ b/assets/helpers/paymentIntegrations/stripeCheckout.js
@@ -1,5 +1,7 @@
 // @flow
 
+import type { Token } from 'helpers/paymentIntegrations/readerRevenueApis';
+
 
 // ----- Setup ----- //
 
@@ -47,7 +49,7 @@ const getStripeKey = (currency: string, isTestUser: boolean) => {
 };
 
 export const setupStripeCheckout = (
-  callback: (token: string) => Promise<*>,
+  callback: Token => void,
   closeHandler: ?() => void,
   currency: string,
   isTestUser: boolean,

--- a/assets/helpers/paymentIntegrations/stripeCheckout.js
+++ b/assets/helpers/paymentIntegrations/stripeCheckout.js
@@ -1,7 +1,5 @@
 // @flow
 
-import type { Token } from 'helpers/paymentIntegrations/readerRevenueApis';
-
 
 // ----- Setup ----- //
 
@@ -49,7 +47,7 @@ const getStripeKey = (currency: string, isTestUser: boolean) => {
 };
 
 export const setupStripeCheckout = (
-  callback: Token => void,
+  callback: string => void,
   closeHandler: ?() => void,
   currency: string,
   isTestUser: boolean,

--- a/assets/helpers/paymentIntegrations/stripeCheckout.js
+++ b/assets/helpers/paymentIntegrations/stripeCheckout.js
@@ -47,14 +47,14 @@ const getStripeKey = (currency: string, isTestUser: boolean) => {
 };
 
 export const setupStripeCheckout = (
-  callback: string => void,
+  onPaymentAuthorisation: string => void,
   closeHandler: ?() => void,
   currency: string,
   isTestUser: boolean,
 ): Promise<void> => loadStripe().then(() => {
 
   const handleToken = (token) => {
-    callback(token.id);
+    onPaymentAuthorisation(token.id);
   };
   const defaultCloseHandler: () => void = () => {};
 

--- a/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -15,7 +15,7 @@ import { config, type Contrib, type Amount } from 'helpers/contributions';
 import { type CheckoutFailureReason } from 'helpers/checkoutErrors';
 import { emailRegexPattern } from 'helpers/checkoutForm/checkoutForm';
 import { openDialogBox } from 'helpers/paymentIntegrations/newStripeCheckout';
-import { type Token } from 'helpers/paymentIntegrations/readerRevenueApis';
+import { type PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
 
 import PaymentFailureMessage from 'components/paymentFailureMessage/paymentFailureMessage';
 import SvgEnvelope from 'components/svgs/envelope';
@@ -66,7 +66,7 @@ type PropTypes = {|
   updateEmail: Event => void,
   updateState: Event => void,
   onWaiting: boolean => void,
-  onThirdPartyPaymentDone: Token => void,
+  onThirdPartyPaymentDone: PaymentAuthorisation => void,
   checkoutFormHasBeenSubmitted: boolean,
   setCheckoutFormHasBeenSubmitted: () => void,
   openDirectDebitPopUp: () => void,
@@ -172,7 +172,7 @@ function ContributionForm(props: PropTypes) {
     checkoutFormHasBeenSubmitted,
   } = props;
 
-  const paymentCallback = (token: Token) => {
+  const paymentCallback = (token: PaymentAuthorisation) => {
     props.onWaiting(true);
     props.onThirdPartyPaymentDone(token);
   };

--- a/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -172,7 +172,7 @@ function ContributionForm(props: PropTypes) {
     checkoutFormHasBeenSubmitted,
   } = props;
 
-  const paymentCallback = (paymentAuthorisation: PaymentAuthorisation) => {
+  const onPaymentAuthorisation = (paymentAuthorisation: PaymentAuthorisation) => {
     props.onWaiting(true);
     props.onThirdPartyPaymentAuthorised(paymentAuthorisation);
   };
@@ -239,13 +239,13 @@ function ContributionForm(props: PropTypes) {
             required
           />
           <NewContributionState onChange={props.updateState} value={state} />
-          <NewContributionPayment paymentCallback={paymentCallback} />
+          <NewContributionPayment onPaymentAuthorisation={onPaymentAuthorisation} />
           <NewContributionSubmit />
           {props.isWaiting ? <ProgressMessage message={['Processing transaction', 'Please wait']} /> : null}
         </form>
         <DirectDebitPopUpForm
           // TODO: put payment through
-          callback={() => undefined}
+          onPaymentAuthorisation={() => undefined}
           isPopUpOpen={props.isDirectDebitPopUpOpen}
         />
       </div>

--- a/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -245,7 +245,7 @@ function ContributionForm(props: PropTypes) {
         </form>
         <DirectDebitPopUpForm
           // TODO: put payment through
-          callback={() => Promise.resolve()}
+          callback={() => undefined}
           isPopUpOpen={props.isDirectDebitPopUpOpen}
         />
       </div>

--- a/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -39,7 +39,7 @@ import {
   updateLastName,
   updateEmail,
   updateState,
-  onThirdPartyPaymentDone,
+  onThirdPartyPaymentAuthorised,
   setCheckoutFormHasBeenSubmitted,
 } from '../contributionsLandingActions';
 
@@ -66,7 +66,7 @@ type PropTypes = {|
   updateEmail: Event => void,
   updateState: Event => void,
   onWaiting: boolean => void,
-  onThirdPartyPaymentDone: PaymentAuthorisation => void,
+  onThirdPartyPaymentAuthorised: PaymentAuthorisation => void,
   checkoutFormHasBeenSubmitted: boolean,
   setCheckoutFormHasBeenSubmitted: () => void,
   openDirectDebitPopUp: () => void,
@@ -104,7 +104,7 @@ const mapDispatchToProps = (dispatch: Function) => ({
   updateEmail: (event) => { dispatch(updateEmail(event.target.value)); },
   updateState: (event) => { dispatch(updateState(event.target.value === '' ? null : event.target.value)); },
   onWaiting: (isWaiting) => { dispatch(paymentWaiting(isWaiting)); },
-  onThirdPartyPaymentDone: (token) => { dispatch(onThirdPartyPaymentDone(token)); },
+  onThirdPartyPaymentAuthorised: (token) => { dispatch(onThirdPartyPaymentAuthorised(token)); },
   setCheckoutFormHasBeenSubmitted: () => { dispatch(setCheckoutFormHasBeenSubmitted()); },
   openDirectDebitPopUp: () => { dispatch(openDirectDebitPopUp()); },
 });
@@ -172,9 +172,9 @@ function ContributionForm(props: PropTypes) {
     checkoutFormHasBeenSubmitted,
   } = props;
 
-  const paymentCallback = (token: PaymentAuthorisation) => {
+  const paymentCallback = (paymentAuthorisation: PaymentAuthorisation) => {
     props.onWaiting(true);
-    props.onThirdPartyPaymentDone(token);
+    props.onThirdPartyPaymentAuthorised(paymentAuthorisation);
   };
 
   const checkOtherAmount: string => boolean = input =>

--- a/assets/pages/new-contributions-landing/components/ContributionPayment.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionPayment.jsx
@@ -27,7 +27,7 @@ type PropTypes = {
   contributionType: Contrib,
   currency: IsoCurrency,
   paymentMethod: PaymentMethod,
-  paymentCallback: PaymentAuthorisation => void,
+  onPaymentAuthorisation: PaymentAuthorisation => void,
   paymentHandler: { [PaymentMethod]: PaymentHandler | null },
   updatePaymentMethod: PaymentMethod => Action,
   isPaymentReady: (boolean, ?{ [PaymentMethod]: PaymentHandler }) => Action,
@@ -54,7 +54,7 @@ const mapDispatchToProps = {
 function setupPaymentMethod(props: PropTypes): void {
   const {
     paymentMethod,
-    paymentCallback,
+    onPaymentAuthorisation,
     paymentHandler,
     contributionType,
     currency,
@@ -75,7 +75,7 @@ function setupPaymentMethod(props: PropTypes): void {
 
       case 'Stripe':
       default:
-        setupStripeCheckout(paymentCallback, contributionType, currency, isTestUser)
+        setupStripeCheckout(onPaymentAuthorisation, contributionType, currency, isTestUser)
           .then((handler: PaymentHandler) => props.isPaymentReady(true, { Stripe: handler }));
     }
   }

--- a/assets/pages/new-contributions-landing/components/ContributionPayment.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionPayment.jsx
@@ -11,7 +11,7 @@ import { classNameWithModifiers } from 'helpers/utilities';
 import { type IsoCountry } from 'helpers/internationalisation/country';
 import { type IsoCurrency } from 'helpers/internationalisation/currency';
 import { setupStripeCheckout } from 'helpers/paymentIntegrations/newStripeCheckout';
-import { type Token } from 'helpers/paymentIntegrations/readerRevenueApis';
+import { type PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
 
 import SvgNewCreditCard from 'components/svgs/newCreditCard';
 import SvgPayPal from 'components/svgs/paypal';
@@ -27,7 +27,7 @@ type PropTypes = {
   contributionType: Contrib,
   currency: IsoCurrency,
   paymentMethod: PaymentMethod,
-  paymentCallback: Token => void,
+  paymentCallback: PaymentAuthorisation => void,
   paymentHandler: { [PaymentMethod]: PaymentHandler | null },
   updatePaymentMethod: PaymentMethod => Action,
   isPaymentReady: (boolean, ?{ [PaymentMethod]: PaymentHandler }) => Action,

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -150,17 +150,17 @@ const makeRegularPaymentData: (PaymentAuthorisation, State) => PaymentFields = (
   },
 });
 
-const onThirdPartyPaymentDone = (token: PaymentAuthorisation) =>
+const onThirdPartyPaymentAuthorised = (paymentAuthorisation: PaymentAuthorisation) =>
   (dispatch: Dispatch<Action>, getState: () => State): void => {
     const state = getState();
 
     switch (state.page.form.contributionType) {
       case 'ONE_OFF':
-        dispatch(sendData(makeOneOffPaymentData(token, state)));
+        dispatch(sendData(makeOneOffPaymentData(paymentAuthorisation, state)));
         return;
 
       default:
-        dispatch(sendData(makeRegularPaymentData(token, state)));
+        dispatch(sendData(makeRegularPaymentData(paymentAuthorisation, state)));
 
     }
   };
@@ -178,6 +178,6 @@ export {
   paymentFailure,
   paymentWaiting,
   paymentSuccess,
-  onThirdPartyPaymentDone,
+  onThirdPartyPaymentAuthorised,
   setCheckoutFormHasBeenSubmitted,
 };

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -5,7 +5,7 @@
 import { type PaymentMethod, type PaymentHandler } from 'helpers/checkouts';
 import { type Amount, type Contrib } from 'helpers/contributions';
 import { type UsState, type CaState } from 'helpers/internationalisation/country';
-import { type Token, type PaymentFields, type PaymentResult, PaymentSuccess, postOneOffStripeRequest, postRegularStripeRequest } from 'helpers/paymentIntegrations/readerRevenueApis';
+import { type PaymentAuthorisation, type PaymentFields, type PaymentResult, PaymentSuccess, postOneOffStripeRequest, postRegularStripeRequest } from 'helpers/paymentIntegrations/readerRevenueApis';
 import { derivePaymentApiAcquisitionData, getSupportAbTests, getOphanIds } from 'helpers/tracking/acquisitions';
 import trackConversion from 'helpers/tracking/conversions';
 import { type State } from './contributionsLandingReducer';
@@ -111,7 +111,7 @@ const getAmount = (state: State) =>
     ? state.page.form.formData.otherAmounts[state.page.form.contributionType].amount
     : state.page.form.selectedAmounts[state.page.form.contributionType].value);
 
-const makeOneOffPaymentData: (Token, State) => PaymentFields = (token, state) => ({
+const makeOneOffPaymentData: (PaymentAuthorisation, State) => PaymentFields = (token, state) => ({
   contributionType: 'oneoff',
   fields: {
     paymentData: {
@@ -128,7 +128,7 @@ const makeOneOffPaymentData: (Token, State) => PaymentFields = (token, state) =>
   },
 });
 
-const makeRegularPaymentData: (Token, State) => PaymentFields = (token, state) => ({
+const makeRegularPaymentData: (PaymentAuthorisation, State) => PaymentFields = (token, state) => ({
   contributionType: 'regular',
   fields: {
     firstName: state.page.form.formData.firstName || '',
@@ -150,7 +150,7 @@ const makeRegularPaymentData: (Token, State) => PaymentFields = (token, state) =
   },
 });
 
-const onThirdPartyPaymentDone = (token: Token) =>
+const onThirdPartyPaymentDone = (token: PaymentAuthorisation) =>
   (dispatch: Dispatch<Action>, getState: () => State): void => {
     const state = getState();
 

--- a/assets/pages/oneoff-contributions/components/oneoffContributionsPayment.jsx
+++ b/assets/pages/oneoff-contributions/components/oneoffContributionsPayment.jsx
@@ -88,7 +88,7 @@ function OneoffContributionsPayment(props: PropTypes, context) {
       <PaymentFailureMessage checkoutFailureReason={props.checkoutFailureReason} />
       <StripePopUpButton
         email={props.email}
-        callback={postCheckout(
+        onPaymentAuthorisation={postCheckout(
           props.abParticipations,
           props.dispatch,
           props.amount,

--- a/assets/pages/oneoff-contributions/helpers/ajax.js
+++ b/assets/pages/oneoff-contributions/helpers/ajax.js
@@ -57,7 +57,7 @@ type OnFailure = CheckoutFailureReason => void;
 
 function requestData(
   abParticipations: Participations,
-  token: StripeAuthorisation,
+  stripeAuthorisation: StripeAuthorisation,
   currency: IsoCurrency,
   amount: number,
   referrerAcquisitionData: ReferrerAcquisitionData,
@@ -73,7 +73,7 @@ function requestData(
       paymentData: {
         currency,
         amount,
-        token: token.token,
+        token: stripeAuthorisation.token,
         email: user.email,
       },
       acquisitionData: derivePaymentApiAcquisitionData(referrerAcquisitionData, abParticipations, optimizeExperiments),
@@ -141,10 +141,10 @@ function postCheckout(
     dispatch(checkoutError(checkoutFailureReason));
   };
 
-  return (paymentToken: StripeAuthorisation) => {
+  return (stripeAuthorisation: StripeAuthorisation) => {
     const request = requestData(
       abParticipations,
-      paymentToken,
+      stripeAuthorisation,
       currencyId,
       amount,
       referrerAcquisitionData,

--- a/assets/pages/oneoff-contributions/helpers/ajax.js
+++ b/assets/pages/oneoff-contributions/helpers/ajax.js
@@ -15,7 +15,7 @@ import trackConversion from 'helpers/tracking/conversions';
 import { routes } from 'helpers/routes';
 import { logException } from 'helpers/logger';
 import type { CheckoutFailureReason } from 'helpers/checkoutErrors';
-import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
+import type { StripeAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
 import { checkoutError, checkoutSuccess } from '../oneoffContributionsActions';
 
 
@@ -57,7 +57,7 @@ type OnFailure = CheckoutFailureReason => void;
 
 function requestData(
   abParticipations: Participations,
-  token: PaymentAuthorisation,
+  token: StripeAuthorisation,
   currency: IsoCurrency,
   amount: number,
   referrerAcquisitionData: ReferrerAcquisitionData,
@@ -67,7 +67,7 @@ function requestData(
   const { user } = getState().page;
 
   if (user.fullName !== null && user.fullName !== undefined &&
-    user.email !== null && user.email !== undefined && token.paymentMethod === 'Stripe') {
+    user.email !== null && user.email !== undefined) {
 
     const oneOffContribFields: PaymentApiStripeExecutePaymentBody = {
       paymentData: {
@@ -130,7 +130,7 @@ function postCheckout(
   referrerAcquisitionData: ReferrerAcquisitionData,
   getState: Function,
   optimizeExperiments: OptimizeExperiments,
-): PaymentAuthorisation => void {
+): StripeAuthorisation => void {
 
   const onSuccess: OnSuccess = () => {
     trackConversion(abParticipations, routes.oneOffContribThankyou);
@@ -141,7 +141,7 @@ function postCheckout(
     dispatch(checkoutError(checkoutFailureReason));
   };
 
-  return (paymentToken: PaymentAuthorisation) => {
+  return (paymentToken: StripeAuthorisation) => {
     const request = requestData(
       abParticipations,
       paymentToken,

--- a/assets/pages/oneoff-contributions/helpers/ajax.js
+++ b/assets/pages/oneoff-contributions/helpers/ajax.js
@@ -15,7 +15,7 @@ import trackConversion from 'helpers/tracking/conversions';
 import { routes } from 'helpers/routes';
 import { logException } from 'helpers/logger';
 import type { CheckoutFailureReason } from 'helpers/checkoutErrors';
-import type { Token } from 'helpers/paymentIntegrations/readerRevenueApis';
+import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
 import { checkoutError, checkoutSuccess } from '../oneoffContributionsActions';
 
 
@@ -57,7 +57,7 @@ type OnFailure = CheckoutFailureReason => void;
 
 function requestData(
   abParticipations: Participations,
-  token: Token,
+  token: PaymentAuthorisation,
   currency: IsoCurrency,
   amount: number,
   referrerAcquisitionData: ReferrerAcquisitionData,
@@ -130,7 +130,7 @@ function postCheckout(
   referrerAcquisitionData: ReferrerAcquisitionData,
   getState: Function,
   optimizeExperiments: OptimizeExperiments,
-): Token => void {
+): PaymentAuthorisation => void {
 
   const onSuccess: OnSuccess = () => {
     trackConversion(abParticipations, routes.oneOffContribThankyou);
@@ -141,7 +141,7 @@ function postCheckout(
     dispatch(checkoutError(checkoutFailureReason));
   };
 
-  return (paymentToken: Token) => {
+  return (paymentToken: PaymentAuthorisation) => {
     const request = requestData(
       abParticipations,
       paymentToken,

--- a/assets/pages/oneoff-contributions/helpers/ajax.js
+++ b/assets/pages/oneoff-contributions/helpers/ajax.js
@@ -15,8 +15,8 @@ import trackConversion from 'helpers/tracking/conversions';
 import { routes } from 'helpers/routes';
 import { logException } from 'helpers/logger';
 import type { CheckoutFailureReason } from 'helpers/checkoutErrors';
-import { checkoutError, checkoutSuccess } from '../oneoffContributionsActions';
 import type { Token } from 'helpers/paymentIntegrations/readerRevenueApis';
+import { checkoutError, checkoutSuccess } from '../oneoffContributionsActions';
 
 
 // ----- Setup ----- //

--- a/assets/pages/regular-contributions/__tests__/ajaxTest.js
+++ b/assets/pages/regular-contributions/__tests__/ajaxTest.js
@@ -8,20 +8,16 @@ describe('Regular Contributions Payment fields', () => {
     const sortCode = '200000';
     const accountNumber = '55779911';
     const accountHolderName = 'Bart Simpson';
-    const paymentFieldName = 'directDebitData';
 
     const expectedPaymentFields = {
       accountHolderName,
       sortCode,
       accountNumber,
     };
-    const paymentFields = getPaymentFields(
-      undefined,
-      accountNumber,
-      sortCode,
-      accountHolderName,
-      paymentFieldName,
-    );
+    const paymentFields = getPaymentFields({
+      paymentMethod: 'DirectDebit',
+      ...expectedPaymentFields,
+    });
 
     expect(paymentFields.accountHolderName).toEqual(expectedPaymentFields.accountHolderName);
     expect(paymentFields.sortCode).toEqual(expectedPaymentFields.sortCode);
@@ -30,58 +26,31 @@ describe('Regular Contributions Payment fields', () => {
   });
 
   it('should create the correct payment field to handle PayPal', () => {
+    const paymentFields = getPaymentFields({
+      paymentMethod: 'PayPal',
+      token: 'PayPalToken',
+    });
 
-    const paymentFieldName = 'baid';
-    const token = 'PayPalToken';
-
-    const expectedPaymentFields = {
-      baid: token,
-    };
-    const paymentFields = getPaymentFields(
-      token,
-      undefined,
-      undefined,
-      undefined,
-      paymentFieldName,
-    );
-
-    expect(paymentFields.baid).toEqual(expectedPaymentFields.baid);
+    expect(paymentFields.baid).toEqual('PayPalToken');
     expect(paymentFields.userId).toEqual(undefined);
     expect(Object.keys(paymentFields).length).toEqual(1);
   });
 
   it('should create the correct payment field to handle Stripe', () => {
+    const paymentFields = getPaymentFields({
+      paymentMethod: 'Stripe',
+      token: 'StripeToken',
+    });
 
-    const paymentFieldName = 'stripeToken';
-    const token = 'StripeToken';
-
-    const expectedPaymentFields = {
-      stripeToken: token,
-    };
-    const paymentFields = getPaymentFields(
-      token,
-      undefined,
-      undefined,
-      undefined,
-      paymentFieldName,
-    );
-
-    expect(paymentFields.stripeToken).toEqual(expectedPaymentFields.stripeToken);
+    expect(paymentFields.stripeToken).toEqual('StripeToken');
     expect(Object.keys(paymentFields).length).toEqual(1);
   });
 
   it('should return null if a unknown payment field name is passed', () => {
-
-    const paymentFieldName = 'helloWorld';
-    const token = 'PayPalToken';
-
-    const paymentFields = getPaymentFields(
-      token,
-      undefined,
-      undefined,
-      undefined,
-      paymentFieldName,
-    );
+    const paymentFields = getPaymentFields({
+      paymentMethod: 'Not allowed',
+      token: 'PayPalToken',
+    });
 
     expect(paymentFields).toEqual(null);
   });

--- a/assets/pages/regular-contributions/components/regularContributionsPayment.jsx
+++ b/assets/pages/regular-contributions/components/regularContributionsPayment.jsx
@@ -85,7 +85,7 @@ function RegularContributionsPayment(props: PropTypes, context) {
   if (props.country === 'GB') {
     directDebitButton = (
       <DirectDebitPopUpButton
-        callback={postCheckout(
+        onPaymentAuthorisation={postCheckout(
           props.abParticipations,
           props.amount,
           props.csrf,
@@ -105,7 +105,7 @@ function RegularContributionsPayment(props: PropTypes, context) {
 
   const stripeButton = (<StripePopUpButton
     email={props.email}
-    callback={postCheckout(
+    onPaymentAuthorisation={postCheckout(
       props.abParticipations,
       props.amount,
       props.csrf,
@@ -131,7 +131,7 @@ function RegularContributionsPayment(props: PropTypes, context) {
     amount={props.amount}
     currencyId={props.currencyId}
     csrf={props.csrf}
-    callback={postCheckout(
+    onPaymentAuthorisation={postCheckout(
       props.abParticipations,
       props.amount,
       props.csrf,

--- a/assets/pages/regular-contributions/helpers/ajax.js
+++ b/assets/pages/regular-contributions/helpers/ajax.js
@@ -13,7 +13,7 @@ import { getSupportAbTests } from 'helpers/tracking/acquisitions';
 import type { User as UserState } from 'helpers/user/userReducer';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import type { Participations } from 'helpers/abTests/abtest';
-import type { Token } from 'helpers/paymentIntegrations/readerRevenueApis';
+import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
 import type { CheckoutFailureReason } from 'helpers/checkoutErrors';
 import trackConversion from 'helpers/tracking/conversions';
 import { billingPeriodFromContrib } from 'helpers/contributions';
@@ -89,7 +89,7 @@ const paymentMethodToPaymentFieldMap = {
 };
 
 const getPaymentFields =
-  (token: Token): ?(PayPalDetails | StripeDetails | DirectDebitDetails) => {
+  (token: PaymentAuthorisation): ?(PayPalDetails | StripeDetails | DirectDebitDetails) => {
     let response = null;
     switch (token.paymentMethod) {
       case 'PayPal':
@@ -125,7 +125,7 @@ function requestData(
   paymentFieldName: PaymentFieldName,
   referrerAcquisitionData: ReferrerAcquisitionData,
   getState: Function,
-  token: Token,
+  token: PaymentAuthorisation,
   optimizeExperiments: OptimizeExperiments,
 ) {
 
@@ -275,8 +275,8 @@ function postCheckout(
   referrerAcquisitionData: ReferrerAcquisitionData,
   getState: Function,
   optimizeExperiments: OptimizeExperiments,
-): Token => void {
-  return (token: Token) => {
+): PaymentAuthorisation => void {
+  return (token: PaymentAuthorisation) => {
     pollCount = 0;
     dispatch(creatingContributor());
 

--- a/assets/pages/regular-contributions/helpers/ajax.js
+++ b/assets/pages/regular-contributions/helpers/ajax.js
@@ -13,7 +13,7 @@ import { getSupportAbTests } from 'helpers/tracking/acquisitions';
 import type { User as UserState } from 'helpers/user/userReducer';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import type { Participations } from 'helpers/abTests/abtest';
-import type { RegularCheckoutCallback } from 'helpers/checkouts';
+import type { Token } from 'helpers/paymentIntegrations/readerRevenueApis';
 import type { CheckoutFailureReason } from 'helpers/checkoutErrors';
 import trackConversion from 'helpers/tracking/conversions';
 import { billingPeriodFromContrib } from 'helpers/contributions';
@@ -89,38 +89,25 @@ const paymentMethodToPaymentFieldMap = {
 };
 
 const getPaymentFields =
-  (
-    token?: string,
-    accountNumber?: string,
-    sortCode?: string,
-    accountHolderName?: string,
-    paymentFieldName: string,
-  ): ?(PayPalDetails | StripeDetails | DirectDebitDetails
-    ) => {
+  (token: Token): ?(PayPalDetails | StripeDetails | DirectDebitDetails) => {
     let response = null;
-    switch (paymentFieldName) {
-      case 'baid':
-        if (token) {
-          response = {
-            [paymentFieldName]: token,
-          };
-        }
+    switch (token.paymentMethod) {
+      case 'PayPal':
+        response = {
+          baid: token.token,
+        };
         break;
-      case 'stripeToken':
-        if (token) {
-          response = {
-            [paymentFieldName]: token,
-          };
-        }
+      case 'Stripe':
+        response = {
+          stripeToken: token.token,
+        };
         break;
-      case 'directDebitData':
-        if (accountHolderName && sortCode && accountNumber) {
-          response = {
-            accountHolderName,
-            sortCode,
-            accountNumber,
-          };
-        }
+      case 'DirectDebit':
+        response = {
+          accountHolderName: token.accountHolderName,
+          sortCode: token.sortCode,
+          accountNumber: token.accountNumber,
+        };
         break;
       default:
         response = null;
@@ -138,10 +125,7 @@ function requestData(
   paymentFieldName: PaymentFieldName,
   referrerAcquisitionData: ReferrerAcquisitionData,
   getState: Function,
-  token?: string,
-  accountNumber?: string,
-  sortCode?: string,
-  accountHolderName?: string,
+  token: Token,
   optimizeExperiments: OptimizeExperiments,
 ) {
 
@@ -157,13 +141,7 @@ function requestData(
 
   const ophanIds: OphanIds = getOphanIds();
   const supportAbTests = getSupportAbTests(abParticipations, optimizeExperiments);
-  const paymentFields = getPaymentFields(
-    token,
-    accountNumber,
-    sortCode,
-    accountHolderName,
-    paymentFieldName,
-  );
+  const paymentFields = getPaymentFields(token);
 
   if (!paymentFields) {
     return Promise.resolve({
@@ -297,14 +275,8 @@ function postCheckout(
   referrerAcquisitionData: ReferrerAcquisitionData,
   getState: Function,
   optimizeExperiments: OptimizeExperiments,
-): RegularCheckoutCallback {
-  return (
-    token?: string,
-    accountNumber?: string,
-    sortCode?: string,
-    accountHolderName?: string,
-  ) => {
-
+): Token => void {
+  return (token: Token) => {
     pollCount = 0;
     dispatch(creatingContributor());
 
@@ -318,13 +290,10 @@ function postCheckout(
       referrerAcquisitionData,
       getState,
       token,
-      accountNumber,
-      sortCode,
-      accountHolderName,
       optimizeExperiments,
     );
 
-    return fetch(routes.recurringContribCreate, request).then((response) => {
+    fetch(routes.recurringContribCreate, request).then((response) => {
       handleStatus(
         response,
         dispatch,

--- a/assets/pages/regular-contributions/helpers/ajax.js
+++ b/assets/pages/regular-contributions/helpers/ajax.js
@@ -125,7 +125,7 @@ function requestData(
   paymentFieldName: PaymentFieldName,
   referrerAcquisitionData: ReferrerAcquisitionData,
   getState: Function,
-  token: PaymentAuthorisation,
+  paymentAuthorisation: PaymentAuthorisation,
   optimizeExperiments: OptimizeExperiments,
 ) {
 
@@ -141,7 +141,7 @@ function requestData(
 
   const ophanIds: OphanIds = getOphanIds();
   const supportAbTests = getSupportAbTests(abParticipations, optimizeExperiments);
-  const paymentFields = getPaymentFields(token);
+  const paymentFields = getPaymentFields(paymentAuthorisation);
 
   if (!paymentFields) {
     return Promise.resolve({
@@ -276,7 +276,7 @@ function postCheckout(
   getState: Function,
   optimizeExperiments: OptimizeExperiments,
 ): PaymentAuthorisation => void {
-  return (token: PaymentAuthorisation) => {
+  return (paymentAuthorisation: PaymentAuthorisation) => {
     pollCount = 0;
     dispatch(creatingContributor());
 
@@ -289,7 +289,7 @@ function postCheckout(
       paymentMethodToPaymentFieldMap[paymentMethod],
       referrerAcquisitionData,
       getState,
-      token,
+      paymentAuthorisation,
       optimizeExperiments,
     );
 


### PR DESCRIPTION
This replaces `RegularCheckoutCallback`:

```javascript
export type RegularCheckoutCallback = (	
  token?: string,	
  accountNumber?: string,	
  sortCode?: string,	
  accountHolderName?: string	
) => Promise<*>
```

with `PaymentAuthorisation => void`. `PaymentAuthorisation` is a union type which looks like this:

```javascript
export type StripeAuthorisation = {| paymentMethod: 'Stripe', token: string |};
export type PayPalAuthorisation = {| paymentMethod: 'PayPal', token: string |};
export type DirectDebitAuthorisation = {|
  paymentMethod: 'DirectDebit',
  accountHolderName: string,
  sortCode: string,
  accountNumber: string
|};

export type PaymentAuthorisation = StripeAuthorisation | PayPalAuthorisation | DirectDebitAuthorisation;
```

This is because the new payment flow uses the `PaymentAuthorisation => void` type for its payment callback, and I want to be able to pass that same callback to existing components (e.g. `DirectDebitPopUpForm`). I could have taken the @regiskuckaertz approach and copied/pasted `DirectDebitPopUpForm` with modifications. But unlike with his payment flow work, the modifications were so minimal and there was so much useful self-contained functionality within the direct debit popup that it seemed better to modify the existing code.

I also think the union type is much clearer than a type consisting exclusively of optional properties. Moreover, the return type of `Promise<*>` was actually misleading since the returned `Promise` is never actually used - any subsequent actions are a result of calling `dispatch` functions inside callbacks.

## Other renaming/refactoring stuff
- `Token` => `PaymentAuthorisation`
- `callback` or `paymentCallback` => `onPaymentAuthorisation`
- `onThirdPartyPaymentDone` => `onThirdPartyPaymentAuthorised`

Stuff done in response to receiving a "token" is actually stuff done response to having a payment *authorised* by a third party. The payment is not actually complete at that point - in fact, the thing we do with a `PaymentAuthorisation` is either use it straight away to get some money, or send it off to Zuora to get some money repeatedly in the future.