### PR TITLE
Refactor identity service models

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -9,7 +9,6 @@ import com.gu.support.config.StripeConfigProvider
 import com.gu.identity.play.IdUser
 import config.StringsConfig
 import play.api.mvc._
-
 import services.{IdentityService, PaymentAPIService}
 import admin.{Settings, SettingsProvider, SettingsSurrogateKeySyntax}
 import utils.BrowserCheck

--- a/app/controllers/IdentityController.scala
+++ b/app/controllers/IdentityController.scala
@@ -6,8 +6,9 @@ import io.circe.generic.semiauto.deriveDecoder
 import monitoring.SafeLogger
 import monitoring.SafeLogger._
 import play.api.mvc._
-import services.IdentityService
 import play.api.libs.circe.Circe
+import services.IdentityService
+
 import scala.concurrent.ExecutionContext
 
 class IdentityController(

--- a/app/controllers/OneOffContributions.scala
+++ b/app/controllers/OneOffContributions.scala
@@ -6,16 +6,14 @@ import play.api.mvc._
 import play.api.libs.circe.Circe
 
 import scala.concurrent.{ExecutionContext, Future}
-
 import services.{IdentityService, PaymentAPIService, TestUserService}
 import views.html.oneOffContributions
 import com.gu.support.config.StripeConfigProvider
 import cats.implicits._
 import com.gu.googleauth.AuthAction
-import com.gu.identity.play.{AuthenticatedIdUser, IdUser}
+import com.gu.identity.play.IdUser
 import models.Autofill
 import io.circe.syntax._
-import play.twirl.api.Html
 import admin.{Settings, SettingsProvider, SettingsSurrogateKeySyntax}
 
 class OneOffContributions(

--- a/app/controllers/PayPalOneOff.scala
+++ b/app/controllers/PayPalOneOff.scala
@@ -7,7 +7,6 @@ import com.gu.identity.play.AuthenticatedIdUser
 import play.api.libs.circe.Circe
 import play.api.libs.json.{JsObject, JsString, JsValue, Json}
 import play.api.mvc._
-
 import services._
 import cats.data.EitherT
 import cats.implicits._

--- a/app/controllers/RegularContributions.scala
+++ b/app/controllers/RegularContributions.scala
@@ -15,11 +15,10 @@ import monitoring.SafeLogger
 import monitoring.SafeLogger._
 import play.api.libs.circe.Circe
 import play.api.mvc._
-
 import services.MembersDataService.UserNotFound
 import services.stepfunctions.{CreateRegularContributorRequest, RegularContributionsClient, StatusResponse}
 import services.{IdentityService, MembersDataService, TestUserService}
-import admin.{Settings, SettingsSurrogateKeySyntax, SettingsProvider}
+import admin.{Settings, SettingsProvider, SettingsSurrogateKeySyntax}
 import views.html.recurringContributions
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/app/models/identity/UserIdWithGuestAccountToken.scala
+++ b/app/models/identity/UserIdWithGuestAccountToken.scala
@@ -1,0 +1,14 @@
+package models.identity
+
+import models.identity.responses.GuestRegistrationResponse
+
+// A userId with an optional guest account registration toke (created when a guest account is registered)
+case class UserIdWithGuestAccountToken(userId: String, guestAccountRegistrationToken: Option[String])
+
+object UserIdWithGuestAccountToken {
+  def fromGuestRegistrationResponse(guestRegistrationResponse: GuestRegistrationResponse): UserIdWithGuestAccountToken =
+    UserIdWithGuestAccountToken(
+      guestRegistrationResponse.guestRegistrationRequest.userId,
+      guestRegistrationResponse.guestRegistrationRequest.token
+    )
+}

--- a/app/models/identity/requests/CreateGuestAccountRequestBody.scala
+++ b/app/models/identity/requests/CreateGuestAccountRequestBody.scala
@@ -1,0 +1,31 @@
+package models.identity.requests
+
+import akka.util.ByteString
+import com.gu.identity.play.PublicFields
+import play.api.libs.json.{Json, Writes}
+import play.api.libs.ws.{BodyWritable, InMemoryBody}
+
+// Models a valid request to /guest
+//
+// Example request:
+// =================
+// {
+//   "email": "a@b.com",
+//   "publicFields": {
+//     "displayName": "a"
+//   }
+// }
+case class CreateGuestAccountRequestBody(primaryEmailAddress: String, publicFields: PublicFields)
+object CreateGuestAccountRequestBody {
+
+  def guestDisplayName(email: String): String = email.split("@").headOption.getOrElse("Guest User")
+
+  def fromEmail(email: String): CreateGuestAccountRequestBody = CreateGuestAccountRequestBody(email, PublicFields(Some(guestDisplayName(email))))
+
+  implicit val writesCreateGuestAccountRequestBody: Writes[CreateGuestAccountRequestBody] = Json.writes[CreateGuestAccountRequestBody]
+  implicit val bodyWriteable: BodyWritable[CreateGuestAccountRequestBody] = BodyWritable[CreateGuestAccountRequestBody](
+    transform = body => InMemoryBody(ByteString.fromString(Json.toJson(body).toString)),
+    contentType = "application/json"
+  )
+
+}

--- a/app/models/identity/responses/GuestRegistrationResponse.scala
+++ b/app/models/identity/responses/GuestRegistrationResponse.scala
@@ -1,0 +1,28 @@
+package models.identity.responses
+
+import play.api.libs.json.{Json, Reads}
+
+// Models the response of successfully creating a guest account.
+//
+// Example response:
+// =================
+// {
+//   "status": "ok",
+//   "guestRegistrationRequest": {
+//     "token": "83e41c1d-458d-49c0-b469-ddc263507034",
+//     "userId": "100000190",
+//     "timeIssued": "2018-02-28T14:46:01Z"
+//   }
+// }
+case class GuestRegistrationResponse(
+    guestRegistrationRequest: GuestRegistrationResponse.GuestRegistrationRequest
+)
+
+object GuestRegistrationResponse {
+  implicit val readsGuestRegistrationResponse: Reads[GuestRegistrationResponse] = Json.reads[GuestRegistrationResponse]
+  case class GuestRegistrationRequest(token: Option[String], userId: String)
+
+  object GuestRegistrationRequest {
+    implicit val readsGuestRegistrationRequest: Reads[GuestRegistrationRequest] = Json.reads[GuestRegistrationRequest]
+  }
+}

--- a/app/models/identity/responses/UserResponse.scala
+++ b/app/models/identity/responses/UserResponse.scala
@@ -1,0 +1,28 @@
+package models.identity.responses
+
+import play.api.libs.json.{Json, Reads}
+
+// Models the response of successfully looking up user details via email address.
+//
+// Example response:
+// =================
+// {
+//   "status": "ok",
+//   "user": {
+//     "id": "100000190",
+//     "dates": {
+//       "accountCreatedDate": "2018-02-28T14:46:01Z"
+//     }
+//   }
+// }
+case class UserResponse(user: UserResponse.User)
+
+object UserResponse {
+
+  implicit val readsUserResponse: Reads[UserResponse] = Json.reads[UserResponse]
+  case class User(id: String)
+
+  object User {
+    implicit val readsUser: Reads[User] = Json.reads[User]
+  }
+}

--- a/app/services/StubIdentityService.scala
+++ b/app/services/StubIdentityService.scala
@@ -3,6 +3,7 @@ package services
 import cats.data.EitherT
 import cats.implicits._
 import com.gu.identity.play.{IdMinimalUser, IdUser, PrivateFields, PublicFields}
+import models.identity.UserIdWithGuestAccountToken
 import monitoring.SafeLogger
 import play.api.mvc.RequestHeader
 

--- a/app/wiring/Services.scala
+++ b/app/wiring/Services.scala
@@ -3,8 +3,7 @@ package wiring
 import admin.SettingsProvider
 import play.api.BuiltInComponentsFromContext
 import play.api.libs.ws.ahc.AhcWSComponents
-
-import services._
+import services.{IdentityService, _}
 import services.aws.AwsS3Client.s3
 import services.paypal.PayPalNvpServiceProvider
 import services.stepfunctions.{Encryption, RegularContributionsClient, StateWrapper}

--- a/test/controllers/ApplicationTest.scala
+++ b/test/controllers/ApplicationTest.scala
@@ -11,7 +11,6 @@ import com.gu.identity.play.AuthenticatedIdUser
 import config.StringsConfig
 import fixtures.TestCSRFComponents
 import org.scalatest.mockito.MockitoSugar.mock
-
 import services.{HttpIdentityService, PaymentAPIService, TestUserService}
 import com.gu.support.config.StripeConfigProvider
 import admin.SettingsProvider

--- a/test/controllers/OneOffContributionsTest.scala
+++ b/test/controllers/OneOffContributionsTest.scala
@@ -18,7 +18,6 @@ import assets.AssetsResolver
 import com.gu.googleauth.AuthAction
 import com.gu.identity.play.{PrivateFields, PublicFields}
 import com.gu.identity.play.{AccessCredentials, AuthenticatedIdUser, IdMinimalUser, IdUser}
-
 import services.{HttpIdentityService, PaymentAPIService, TestUserService}
 import com.gu.support.config.StripeConfigProvider
 import fixtures.TestCSRFComponents

--- a/test/controllers/RegularContributionsTest.scala
+++ b/test/controllers/RegularContributionsTest.scala
@@ -18,7 +18,6 @@ import play.api.Environment
 import assets.AssetsResolver
 import com.gu.identity.play.PublicFields
 import com.gu.identity.play.{AccessCredentials, AuthenticatedIdUser, IdMinimalUser, IdUser}
-
 import services.stepfunctions.RegularContributionsClient
 import services.{HttpIdentityService, MembersDataService, TestUserService}
 import services.MembersDataService._


### PR DESCRIPTION
## Why are you doing this?
As part of the work to set the password for guest accounts in support frontend, I needed to create some case classes to model the responses from the API. `HttpIdentityService.scala` was the previous dumping ground for these models, and rather than add to it I decided to refactor it a bit to put the models in their own files. So as not to clutter up that PR with too many changes, I'm making this change in a separate PR. 

Note: this is just moving things around, not implementing anything new, so any concerns about the functionality etc will be noted and potentially raised in another PR, but not addressed in this one.


| New file structure |
|---------|
|![image](https://user-images.githubusercontent.com/2844554/45955959-46364300-c009-11e8-9383-05fa0be13ea1.png)|

