### PR TITLE
Move tests to browserstack

### DIFF
--- a/test/selenium/util/Config.scala
+++ b/test/selenium/util/Config.scala
@@ -38,7 +38,6 @@ object Config {
     logger.info(s"Stage: ${conf.getString("stage")}")
     logger.info(s"Support Frontend: ${supportFrontendUrl}")
     logger.info(s"Identity Frontend: ${identityFrontendUrl}")
-    logger.info(s"Screencast = https://saucelabs.com/tests/${sessionId.toString}")
   }
 
 }

--- a/test/selenium/util/DriverConfig.scala
+++ b/test/selenium/util/DriverConfig.scala
@@ -26,7 +26,7 @@ class DriverConfig {
   // Used by Travis to run tests in SauceLabs
   private def instantiateRemoteBrowser(): WebDriver = {
     val chromeOptions = new ChromeOptions
-    chromeOptions.setCapability("platform", "Windows 8.1")
+    chromeOptions.setCapability("platform", "WINDOWS")
     chromeOptions.setCapability("name", "support-frontend")
     new RemoteWebDriver(new URL(Config.webDriverRemoteUrl), chromeOptions)
   }

--- a/test/selenium/util/DriverConfig.scala
+++ b/test/selenium/util/DriverConfig.scala
@@ -23,7 +23,7 @@ class DriverConfig {
     new ChromeDriver()
   }
 
-  // Used by Travis to run tests in SauceLabs
+  // Used by Travis to run tests in BrowserStack
   private def instantiateRemoteBrowser(): WebDriver = {
     val chromeOptions = new ChromeOptions
     chromeOptions.setCapability("platform", "WINDOWS")


### PR DESCRIPTION
These are small changes to facilitate the moving of our post deploy automated tests to Browserstack.