### PR TITLE
guard against attempts to click on buttons that are visible but not clickable yet

### DIFF
--- a/test/selenium/util/Browser.scala
+++ b/test/selenium/util/Browser.scala
@@ -20,6 +20,9 @@ trait Browser extends WebBrowser {
   def pageHasElement(q: Query): Boolean =
     waitUntil(ExpectedConditions.visibilityOfElementLocated(q.by))
 
+  def elementIsClickable(q: Query): Boolean =
+    waitUntil(ExpectedConditions.elementToBeClickable(q.by))
+
   def pageDoesNotHaveElement(q: Query): Boolean =
     waitUntil(ExpectedConditions.not(ExpectedConditions.presenceOfAllElementsLocatedBy(q.by)))
 

--- a/test/selenium/util/PayPalCheckout.scala
+++ b/test/selenium/util/PayPalCheckout.scala
@@ -19,7 +19,11 @@ class PayPalCheckout(implicit val webDriver: WebDriver) extends Browser {
 
   def logIn(): Unit = clickOn(loginButton)
 
-  def acceptPayment(): Unit = clickOn(agreeAndPay)
+  def acceptPayment(): Unit = {
+    pageHasElement(agreeAndPay)
+    elementIsClickable(agreeAndPay)
+    clickOn(agreeAndPay)
+  }
 
   def payPalHasPaymentSummary(): Boolean = pageHasElement(agreeAndPay)
 


### PR DESCRIPTION
This change is to solve some failure issues on our end-to-end tests when they hit the paypal sandbox.