### PR TITLE
checking for multiple spinner id-tags checking buttons are clickable …

### DIFF
--- a/test/selenium/pages/ContributionsLanding.scala
+++ b/test/selenium/pages/ContributionsLanding.scala
@@ -16,7 +16,10 @@ case class ContributionsLanding(region: String)(implicit val webDriver: WebDrive
 
   private val otherAmountField = id("qa-payment-amount-input")
 
-  def pageHasLoaded: Boolean = pageHasElement(contributeButton)
+  def pageHasLoaded: Boolean = {
+    pageHasElement(contributeButton)
+    elementIsClickable(contributeButton)
+  }
 
   def clickContribute: Unit = clickOn(contributeButton)
 

--- a/test/selenium/pages/OneOffContributionForm.scala
+++ b/test/selenium/pages/OneOffContributionForm.scala
@@ -22,7 +22,10 @@ case class OneOffContributionForm(testUser: TestUser, amount: Int, currency: Str
     }
   }
 
-  def pageHasLoaded: Boolean = pageHasElement(payWithCard)
+  def pageHasLoaded: Boolean = {
+    pageHasElement(payWithCard)
+    elementIsClickable(payWithCard)
+  }
 
   def getAmountDisplayed(): Double = webDriver.findElement(paymentAmountDisplay.by).getText.tail.trim.toDouble
 

--- a/test/selenium/util/PayPalCheckout.scala
+++ b/test/selenium/util/PayPalCheckout.scala
@@ -25,6 +25,8 @@ class PayPalCheckout(implicit val webDriver: WebDriver) extends Browser {
   }
 
   def payPalSummaryHasLoaded(): Boolean = {
+    pageDoesNotHaveElement(id("preloaderSpinner"))
+    pageDoesNotHaveElement(id("spinner"))
     pageHasElement(agreeAndPay)
     elementIsClickable(agreeAndPay)
   }
@@ -32,11 +34,16 @@ class PayPalCheckout(implicit val webDriver: WebDriver) extends Browser {
   def payPalSummaryHasCorrectDetails(expectedCurrencyAndAmount: String): Boolean = elementHasText(paymentAmount, expectedCurrencyAndAmount)
 
   def initialPageHasLoaded: Boolean = {
+    pageDoesNotHaveElement(id("preloaderSpinner"))
+    pageDoesNotHaveElement(id("spinner"))
     pageHasUrlOrElement(guestRegistrationUrlFragment, emailInput)
   }
 
   def loginContainerHasLoaded: Boolean = {
+    pageDoesNotHaveElement(id("preloaderSpinner"))
+    pageDoesNotHaveElement(id("spinner"))
     pageHasElement(emailInput)
+    elementIsClickable(emailInput)
   }
 
   def switchToPayPalPage(): Unit = {
@@ -44,6 +51,7 @@ class PayPalCheckout(implicit val webDriver: WebDriver) extends Browser {
   }
 
   def acceptPayPalPaymentPage(): Unit = {
+    pageDoesNotHaveElement(id("preloaderSpinner"))
     pageDoesNotHaveElement(id("spinner"))
     acceptPayment()
   }
@@ -53,6 +61,7 @@ class PayPalCheckout(implicit val webDriver: WebDriver) extends Browser {
   }
 
   def acceptPayPalPaymentPopUp(): Unit = {
+    pageDoesNotHaveElement(id("preloaderSpinner"))
     pageDoesNotHaveElement(id("spinner"))
     acceptPayment()
     switchToParentWindow()


### PR DESCRIPTION
Paypal sandbox has changed the id of its spinner from "spinner" to "preloaderSpinner".
I have kept a check for both id's due to the paypal sandbox's general inconsistency. They've been known to display have multiple versions of the sandbox page, consequently you cant be sure what you will get.
I've also added some more checks for elements used as indicators in pageHasLoaded checks to make sure they are clickable and not just displayed behind an overlay.