### PR TITLE
Select the correct initial payment method depending on state of payment method switches

### DIFF
--- a/assets/helpers/__tests__/checkoutsTest.js
+++ b/assets/helpers/__tests__/checkoutsTest.js
@@ -1,0 +1,57 @@
+// @flow
+
+// ----- Imports ----- //
+
+import { getValidPaymentMethods } from '../checkouts';
+
+// ----- Tests ----- //
+
+describe('checkouts', () => {
+
+  describe('getValidPaymentMethods', () => {
+
+    const allSwitchesOn = {
+      oneOffPaymentMethods: {
+        stripe: 'On',
+        payPal: 'On',
+      },
+      recurringPaymentMethods: {
+        stripe: 'On',
+        payPal: 'On',
+        directDebit: 'On',
+      },
+    };
+
+    const allSwitchesOff = {
+      oneOffPaymentMethods: {
+        stripe: 'Off',
+        payPal: 'Off',
+      },
+      recurringPaymentMethods: {
+        stripe: 'Off',
+        payPal: 'Off',
+        directDebit: 'Off',
+      },
+    };
+
+    it('should return correct values for Monthly Recurring UK when switches are all on', () => {
+      const contributionType = 'MONTHLY';
+      const countryId = 'GB';
+      expect(getValidPaymentMethods(contributionType, allSwitchesOn, countryId)).toEqual(['DirectDebit', 'Stripe', 'PayPal']);
+    });
+
+    it('should return en empty array for Monthly Recurring UK when switches are all off', () => {
+      const contributionType = 'MONTHLY';
+      const countryId = 'GB';
+      expect(getValidPaymentMethods(contributionType, allSwitchesOff, countryId)).toEqual([]);
+    });
+
+    it('should return just Stripe for One Off US when only Stripe is on', () => {
+      const contributionType = 'ONE_OFF';
+      const justStripeOn = { ...allSwitchesOff, oneOffPaymentMethods: { ...allSwitchesOff.oneOffPaymentMethods, stripe: 'On' } };
+      const countryId = 'US';
+      expect(getValidPaymentMethods(contributionType, justStripeOn, countryId)).toEqual(['Stripe']);
+    });
+
+  });
+});

--- a/assets/helpers/checkouts.js
+++ b/assets/helpers/checkouts.js
@@ -53,7 +53,8 @@ function getAmount(contributionType: Contrib, countryGroup: CountryGroupId): num
 
 }
 
-
+// Returns an array of Payment Methods, in the order of preference,
+// i.e the first element in the array will be the default option
 function getPaymentMethods(contributionType: Contrib, countryId: IsoCountry): PaymentMethod[] {
   return contributionType !== 'ONE_OFF' && countryId === 'GB'
     ? ['DirectDebit', 'Stripe', 'PayPal']
@@ -74,7 +75,7 @@ function getValidPaymentMethods(
     .filter(paymentMethod => switchIsOn(switches, toPaymentMethodSwitchNaming(paymentMethod)));
 }
 
-function getPaymentMethod(): ?PaymentMethod {
+function getPaymentMethodFromSession(): ?PaymentMethod {
   const pm: ?string = storage.getSession('paymentMethod');
   if (pm === 'DirectDebit' || pm === 'Stripe' || pm === 'PayPal') {
     return (pm: PaymentMethod);
@@ -112,7 +113,7 @@ export {
   getAmount,
   getPaymentMethods,
   getValidPaymentMethods,
-  getPaymentMethod,
+  getPaymentMethodFromSession,
   getPaymentDescription,
   getPaymentLabel,
 };

--- a/assets/helpers/settings.js
+++ b/assets/helpers/settings.js
@@ -2,7 +2,7 @@
 
 export type Status = 'On' | 'Off';
 
-type SwitchObject = {
+export type SwitchObject = {
   [string]: Status,
 };
 

--- a/assets/pages/new-contributions-landing/components/ContributionPayment.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionPayment.jsx
@@ -25,7 +25,7 @@ type PropTypes = {
   countryId: IsoCountry,
   contributionType: Contrib,
   currency: IsoCurrency,
-  paymentMethod: PaymentMethod | null,
+  paymentMethod: PaymentMethod,
   onPaymentAuthorisation: PaymentAuthorisation => void,
   paymentHandler: { [PaymentMethod]: PaymentHandler | null },
   updatePaymentMethod: PaymentMethod => Action,
@@ -60,7 +60,7 @@ function setupPaymentMethod(props: PropTypes): void {
     isTestUser,
   } = props;
 
-  if (paymentMethod && !paymentHandler[paymentMethod]) {
+  if (!paymentHandler[paymentMethod]) {
     props.isPaymentReady(false);
 
     switch (paymentMethod) {

--- a/assets/pages/new-contributions-landing/components/ContributionPayment.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionPayment.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { type PaymentMethod, type PaymentHandler, getPaymentLabel, paymentMethodsForCountryAndContributionType } from 'helpers/checkouts';
+import { type PaymentMethod, type PaymentHandler, getPaymentLabel, getPaymentMethods } from 'helpers/checkouts';
 import { type Contrib } from 'helpers/contributions';
 import { classNameWithModifiers } from 'helpers/utilities';
 import { type IsoCountry } from 'helpers/internationalisation/country';
@@ -76,6 +76,8 @@ function setupPaymentMethod(props: PropTypes): void {
         setupStripeCheckout(onPaymentAuthorisation, contributionType, currency, isTestUser)
           .then((handler: PaymentHandler) => props.isPaymentReady(true, { Stripe: handler }));
         break;
+
+      default: break;
     }
   }
 }
@@ -83,7 +85,7 @@ function setupPaymentMethod(props: PropTypes): void {
 // ----- Render ----- //
 
 function ContributionPayment(props: PropTypes) {
-  const paymentMethods: PaymentMethod[] = paymentMethodsForCountryAndContributionType(props.contributionType, props.countryId);
+  const paymentMethods: PaymentMethod[] = getPaymentMethods(props.contributionType, props.countryId);
 
   setupPaymentMethod(props);
 

--- a/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
@@ -39,6 +39,12 @@ const mapStateToProps = (state: State) =>
 
 
 function ContributionSubmit(props: PropTypes) {
+
+  // if all payment methods are switched off, do not display the button
+  if(!props.paymentMethod) {
+    return;
+  }
+
   const frequency = getFrequency(props.contributionType);
   const otherAmount = props.otherAmount ? { value: props.otherAmount, spoken: '', isDefault: false } : null;
   const amount = props.selectedAmounts[props.contributionType] === 'other' ? otherAmount : props.selectedAmounts[props.contributionType];

--- a/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
@@ -41,35 +41,33 @@ const mapStateToProps = (state: State) =>
 function ContributionSubmit(props: PropTypes) {
 
   // if all payment methods are switched off, do not display the button
-  if(!props.paymentMethod) {
-    return;
+  if (props.paymentMethod !== 'None') {
+    const frequency = getFrequency(props.contributionType);
+    const otherAmount = props.otherAmount ? { value: props.otherAmount, spoken: '', isDefault: false } : null;
+    const amount = props.selectedAmounts[props.contributionType] === 'other' ? otherAmount : props.selectedAmounts[props.contributionType];
+    const showPayPalButton = props.paymentMethod === 'PayPal';
+
+    return (
+      <div className="form__submit">
+        {showPayPalButton ? (
+          <button disabled={props.isWaiting}>Pay with PayPal, bro</button>
+        ) : (
+          <button disabled={props.isWaiting} className="form__submit-button" type="submit">
+            Contribute&nbsp;
+            {amount ? formatAmount(
+              currencies[props.currency],
+              spokenCurrencies[props.currency],
+              amount,
+              false,
+            ) : null}&nbsp;
+            {frequency ? `${frequency} ` : null}
+            {getPaymentDescription(props.contributionType, props.paymentMethod)}&nbsp;
+            <SvgArrowRight />
+          </button>
+        )}
+      </div>
+    );
   }
-
-  const frequency = getFrequency(props.contributionType);
-  const otherAmount = props.otherAmount ? { value: props.otherAmount, spoken: '', isDefault: false } : null;
-  const amount = props.selectedAmounts[props.contributionType] === 'other' ? otherAmount : props.selectedAmounts[props.contributionType];
-  const showPayPalButton = props.paymentMethod === 'PayPal';
-
-  return (
-    <div className="form__submit">
-      {showPayPalButton ? (
-        <button disabled={props.isWaiting}>Pay with PayPal, bro</button>
-      ) : (
-        <button disabled={props.isWaiting} className="form__submit-button" type="submit">
-          Contribute&nbsp;
-          {amount ? formatAmount(
-            currencies[props.currency],
-            spokenCurrencies[props.currency],
-            amount,
-            false,
-          ) : null}&nbsp;
-          {frequency ? `${frequency} ` : null}
-          {getPaymentDescription(props.contributionType, props.paymentMethod)}&nbsp;
-          <SvgArrowRight />
-        </button>
-      )}
-    </div>
-  );
 }
 
 const NewContributionSubmit = connect(mapStateToProps)(ContributionSubmit);

--- a/assets/pages/new-contributions-landing/contributionsLanding.jsx
+++ b/assets/pages/new-contributions-landing/contributionsLanding.jsx
@@ -12,18 +12,17 @@ import { renderPage } from 'helpers/render';
 import { detect, countryGroups, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { countryGroupSpecificDetails } from 'helpers/internationalisation/contributions';
 import * as user from 'helpers/user/user';
-import { init as formInit } from './contributionsLandingInit';
 import { set as setCookie } from 'helpers/cookie';
-
 import Page from 'components/page/page';
 import Footer from 'components/footer/footer';
-
 import { NewHeader } from 'components/headers/new-header/Header';
+
+import { init as formInit } from './contributionsLandingInit';
+import { initReducer } from './contributionsLandingReducer';
 import { NewContributionForm } from './components/ContributionForm';
 import { NewContributionThanks } from './components/ContributionThanks';
 import { NewContributionBackground } from './components/ContributionBackground';
 
-import { initReducer } from './contributionsLandingReducer';
 
 // ----- Redux Store ----- //
 

--- a/assets/pages/new-contributions-landing/contributionsLanding.jsx
+++ b/assets/pages/new-contributions-landing/contributionsLanding.jsx
@@ -12,6 +12,7 @@ import { renderPage } from 'helpers/render';
 import { detect, countryGroups, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { countryGroupSpecificDetails } from 'helpers/internationalisation/contributions';
 import * as user from 'helpers/user/user';
+import { init as formInit } from './contributionsLandingInit';
 import { set as setCookie } from 'helpers/cookie';
 
 import Page from 'components/page/page';
@@ -31,6 +32,7 @@ const countryGroupId: CountryGroupId = detect();
 const store = pageInit(initReducer(countryGroupId), true);
 
 user.init(store.dispatch);
+formInit(store);
 
 const reactElementId = `new-contributions-landing-page-${countryGroups[countryGroupId].supportInternationalisationId}`;
 

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -110,7 +110,7 @@ const setupRegularPayment = (data: PaymentFields) =>
         return;
 
       default:
-        dispatch(paymentFailure(`Invalid payment method ${state.page.form.paymentMethod}`));
+        dispatch(paymentFailure(`No payment method selected`));
     }
   };
 
@@ -129,7 +129,7 @@ const executeOneOffPayment = (data: PaymentFields) =>
         return;
 
       default:
-        dispatch(paymentFailure(`Invalid payment method ${state.page.form.paymentMethod}`));
+        dispatch(paymentFailure(`No payment method selected`));
     }
   };
 

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -109,8 +109,9 @@ const setupRegularPayment = (data: PaymentFields) =>
         dispatch(onPaymentResult(Promise.resolve(PaymentSuccess)));
         return;
 
+      case 'None':
       default:
-        dispatch(paymentFailure(`No payment method selected`));
+        dispatch(paymentFailure('No payment method selected'));
     }
   };
 
@@ -128,8 +129,9 @@ const executeOneOffPayment = (data: PaymentFields) =>
         dispatch(onPaymentResult(Promise.resolve(PaymentSuccess)));
         return;
 
+      case 'None':
       default:
-        dispatch(paymentFailure(`No payment method selected`));
+        dispatch(paymentFailure('No payment method selected'));
     }
   };
 

--- a/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -1,0 +1,39 @@
+// @flow
+
+// ----- Imports ----- //
+import {
+  updatePaymentMethod
+} from './contributionsLandingActions';
+import { type Store, type Dispatch } from "redux";
+import { type State } from './contributionsLandingReducer';
+import { type Action } from './contributionsLandingActions';
+import { type PaymentMethod, getValidPaymentMethods } from 'helpers/checkouts';
+
+// ----- Functions ----- //
+
+
+
+const init = (store:  Store<State, Action, Dispatch<Action>>) => {
+  const dispatch = store.dispatch;
+  const state = store.getState();
+
+  const contributionType = state.page.form.contributionType;
+  const countryId = state.common.internationalisation.countryId;
+  const switches = state.common.settings.switches;
+
+  const validPaymentMethods = getValidPaymentMethods(contributionType, switches, countryId);
+
+  if (validPaymentMethods && validPaymentMethods[0]) {
+    dispatch(updatePaymentMethod(validPaymentMethods[0]));
+  }
+
+};
+
+
+// ----- Exports ----- //
+
+    export { init };
+
+
+
+

--- a/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -1,39 +1,32 @@
 // @flow
 
 // ----- Imports ----- //
-import {
-  updatePaymentMethod
-} from './contributionsLandingActions';
-import { type Store, type Dispatch } from "redux";
+import { type Store, type Dispatch } from 'redux';
+import { getValidPaymentMethods } from 'helpers/checkouts';
+import { updatePaymentMethod } from './contributionsLandingActions';
 import { type State } from './contributionsLandingReducer';
 import { type Action } from './contributionsLandingActions';
-import { type PaymentMethod, getValidPaymentMethods } from 'helpers/checkouts';
 
 // ----- Functions ----- //
 
-
-
-const init = (store:  Store<State, Action, Dispatch<Action>>) => {
-  const dispatch = store.dispatch;
+const init = (store: Store<State, Action, Dispatch<Action>>) => {
+  const { dispatch } = store;
   const state = store.getState();
 
-  const contributionType = state.page.form.contributionType;
-  const countryId = state.common.internationalisation.countryId;
-  const switches = state.common.settings.switches;
+  const { contributionType } = state.page.form;
+  const { countryId } = state.common.internationalisation;
+  const { switches } = state.common.settings;
 
   const validPaymentMethods = getValidPaymentMethods(contributionType, switches, countryId);
 
-  if (validPaymentMethods && validPaymentMethods[0]) {
+  if (validPaymentMethods[0]) {
     dispatch(updatePaymentMethod(validPaymentMethods[0]));
+  } else {
+    dispatch(updatePaymentMethod('None'));
   }
-
 };
 
 
 // ----- Exports ----- //
 
-    export { init };
-
-
-
-
+export { init };

--- a/assets/pages/new-contributions-landing/contributionsLandingReducer.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingReducer.js
@@ -79,6 +79,7 @@ function createFormReducer(countryGroupId: CountryGroupId) {
       Stripe: null,
       DirectDebit: null,
       PayPal: null,
+      None: null,
     },
     paymentReady: false,
     formData: {

--- a/assets/pages/new-contributions-landing/contributionsLandingReducer.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingReducer.js
@@ -31,7 +31,7 @@ type FormData = {
 
 type FormState = {
   contributionType: Contrib,
-  paymentMethod: PaymentMethod | null,
+  paymentMethod: PaymentMethod,
   paymentReady: boolean,
   paymentHandler: {
     [PaymentMethod]: PaymentHandler | null
@@ -74,7 +74,7 @@ function createFormReducer(countryGroupId: CountryGroupId) {
 
   const initialState: FormState = {
     contributionType: 'MONTHLY',
-    paymentMethod: null,
+    paymentMethod: 'None',
     paymentHandler: {
       Stripe: null,
       DirectDebit: null,

--- a/assets/pages/new-contributions-landing/contributionsLandingReducer.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingReducer.js
@@ -31,7 +31,7 @@ type FormData = {
 
 type FormState = {
   contributionType: Contrib,
-  paymentMethod: PaymentMethod,
+  paymentMethod: PaymentMethod | null,
   paymentReady: boolean,
   paymentHandler: {
     [PaymentMethod]: PaymentHandler | null
@@ -74,7 +74,7 @@ function createFormReducer(countryGroupId: CountryGroupId) {
 
   const initialState: FormState = {
     contributionType: 'MONTHLY',
-    paymentMethod: 'Stripe',
+    paymentMethod: null,
     paymentHandler: {
       Stripe: null,
       DirectDebit: null,

--- a/assets/pages/regular-contributions/helpers/ajax.js
+++ b/assets/pages/regular-contributions/helpers/ajax.js
@@ -36,7 +36,7 @@ type ContributionRequest = {
   billingPeriod: BillingPeriod,
 };
 
-type PaymentFieldName = 'baid' | 'stripeToken' | 'directDebitData';
+type PaymentFieldName = 'baid' | 'stripeToken' | 'directDebitData' | 'none';
 
 type PayPalDetails = {|
   'baid': string
@@ -86,6 +86,7 @@ const paymentMethodToPaymentFieldMap = {
   DirectDebit: 'directDebitData',
   PayPal: 'baid',
   Stripe: 'stripeToken',
+  None: 'none',
 };
 
 const getPaymentFields =

--- a/assets/pages/regular-contributions/regularContributions.jsx
+++ b/assets/pages/regular-contributions/regularContributions.jsx
@@ -12,7 +12,7 @@ import * as user from 'helpers/user/user';
 import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
 import { routes } from 'helpers/routes';
-import { getAmount, getPaymentMethod } from 'helpers/checkouts';
+import { getAmount, getPaymentMethodFromSession } from 'helpers/checkouts';
 import { parseRegularContributionType } from 'helpers/contributions';
 import { getQueryParameter } from 'helpers/url';
 import { detect as detectCountryGroup } from 'helpers/internationalisation/countryGroup';
@@ -31,7 +31,7 @@ const countryGroup = detectCountryGroup();
 
 const store = pageInit(reducer(
   getAmount(contributionType, countryGroup),
-  getPaymentMethod(),
+  getPaymentMethodFromSession(),
   contributionType,
   countryGroup,
 ), true);

--- a/assets/pages/regular-contributions/regularContributions.jsx
+++ b/assets/pages/regular-contributions/regularContributions.jsx
@@ -12,7 +12,7 @@ import * as user from 'helpers/user/user';
 import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
 import { routes } from 'helpers/routes';
-import { getAmount, getPaymentMethodFromSession } from 'helpers/checkouts';
+import { getAmount, getPaymentMethod } from 'helpers/checkouts';
 import { parseRegularContributionType } from 'helpers/contributions';
 import { getQueryParameter } from 'helpers/url';
 import { detect as detectCountryGroup } from 'helpers/internationalisation/countryGroup';
@@ -31,7 +31,7 @@ const countryGroup = detectCountryGroup();
 
 const store = pageInit(reducer(
   getAmount(contributionType, countryGroup),
-  getPaymentMethodFromSession(),
+  getPaymentMethod(),
   contributionType,
   countryGroup,
 ), true);


### PR DESCRIPTION
## Why are you doing this?
If a payment method is switched off, we need to make sure we do 3 things:

1) Hide that payment option somehow (not part of this PR)
2) Ensure that the next preferred payment option's radio button is selected 
3) Ensure that the payment button is set up to the correct payment method

Previously, we were initialising the `paymentMethod` state to `Stripe`. For starters, we have different preferred payment methods depending on the Region and Payment Type (DD is prefferred for UK recurring, for example), so this was never going to be correct for all cases anyway. 

Therefore, this PR introduces an init function which is called after the `store` is created in `contributionsLanding.jsx`. In this function, we look at the state of the switches, and set the appropriate payment method (this will select the correct radio button and load the correct payment button). 

There is also a case where all payment methods are switched off. To deal with this, I have added a `None` to the type declaration of `PaymentMethod`. If indeed all payment methods are turned off, we don't display the button. @tsop14 will be dealing with what the page looks like in this instance in a future PR. I could have made `paymentMethod` in the state optional and initialised it with `null`, but it seemed more explicit to consciously deal with the situation where there are no valid payment methods to offer the user. 

When setting the initial state values in the `contributionsLandingReducer`, we set the payment type to `None`, and then once the reducer has been created and added to the store, we call our new init function and dispatch the appropriate action depending on the state of the payment method switches. 

@regiskuckaertz @tsop14 @joelochlann @Ap0c  