### PR TITLE
Prevent logged in users from changing their email address

### DIFF
--- a/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -60,6 +60,7 @@ type PropTypes = {|
   selectedAmounts: { [Contrib]: Amount | 'other' },
   otherAmount: string | null,
   paymentMethod: PaymentMethod,
+  isSignedIn: boolean,
   paymentHandler: { [PaymentMethod]: PaymentHandler | null },
   updateFirstName: Event => void,
   updateLastName: Event => void,
@@ -93,6 +94,7 @@ const mapStateToProps = (state: State) => ({
   selectedAmounts: state.page.form.selectedAmounts,
   otherAmount: state.page.form.formData.otherAmounts[state.page.form.contributionType].amount,
   paymentMethod: state.page.form.paymentMethod,
+  isSignedIn: state.page.user.isSignedIn,
   paymentHandler: state.page.form.paymentHandler,
   contributionType: state.page.form.contributionType,
   checkoutFormHasBeenSubmitted: state.page.form.formData.checkoutFormHasBeenSubmitted,
@@ -171,6 +173,7 @@ function ContributionForm(props: PropTypes) {
     lastName,
     email,
     state,
+    isSignedIn,
     checkoutFormHasBeenSubmitted,
   } = props;
 
@@ -239,6 +242,7 @@ function ContributionForm(props: PropTypes) {
             checkoutFormHasBeenSubmitted={checkoutFormHasBeenSubmitted}
             errorMessage="Please provide a valid email address"
             required
+            disabled={isSignedIn}
           />
           <NewContributionState onChange={props.updateState} value={state} />
           <NewContributionPayment onPaymentAuthorisation={onPaymentAuthorisation} />

--- a/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -23,6 +23,7 @@ import SvgUser from 'components/svgs/user';
 import ProgressMessage from 'components/progressMessage/progressMessage';
 import DirectDebitPopUpForm from 'components/directDebit/directDebitPopUpForm/directDebitPopUpForm';
 import { openDirectDebitPopUp } from 'components/directDebit/directDebitActions';
+import Signout from 'components/signout/signout';
 
 import { NewContributionType } from './ContributionType';
 import { NewContributionAmount } from './ContributionAmount';
@@ -244,6 +245,7 @@ function ContributionForm(props: PropTypes) {
             required
             disabled={isSignedIn}
           />
+          <Signout isSignedIn={isSignedIn} />
           <NewContributionState onChange={props.updateState} value={state} />
           <NewContributionPayment onPaymentAuthorisation={onPaymentAuthorisation} />
           <NewContributionSubmit />

--- a/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -202,6 +202,23 @@ function ContributionForm(props: PropTypes) {
             checkOtherAmount={checkOtherAmount}
           />
           <NewContributionTextInput
+            id="contributionEmail"
+            name="contribution-email"
+            label="Email address"
+            value={email}
+            type="email"
+            autoComplete="email"
+            placeholder="example@domain.com"
+            icon={<SvgEnvelope />}
+            onInput={props.updateEmail}
+            isValid={checkEmail(email)}
+            checkoutFormHasBeenSubmitted={checkoutFormHasBeenSubmitted}
+            errorMessage="Please provide a valid email address"
+            required
+            disabled={isSignedIn}
+          />
+          <Signout isSignedIn={isSignedIn} />
+          <NewContributionTextInput
             id="contributionFirstName"
             name="contribution-fname"
             label="First name"
@@ -229,23 +246,6 @@ function ContributionForm(props: PropTypes) {
             errorMessage="Please provide your last name"
             required
           />
-          <NewContributionTextInput
-            id="contributionEmail"
-            name="contribution-email"
-            label="Email address"
-            value={email}
-            type="email"
-            autoComplete="email"
-            placeholder="example@domain.com"
-            icon={<SvgEnvelope />}
-            onInput={props.updateEmail}
-            isValid={checkEmail(email)}
-            checkoutFormHasBeenSubmitted={checkoutFormHasBeenSubmitted}
-            errorMessage="Please provide a valid email address"
-            required
-            disabled={isSignedIn}
-          />
-          <Signout isSignedIn={isSignedIn} />
           <NewContributionState onChange={props.updateState} value={state} />
           <NewContributionPayment onPaymentAuthorisation={onPaymentAuthorisation} />
           <NewContributionSubmit />

--- a/assets/pages/new-contributions-landing/components/ContributionTextInput.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionTextInput.jsx
@@ -26,6 +26,7 @@ type PropTypes = {
   autoFocus: boolean,
   min: number | void,
   max: number | void,
+  disabled: boolean,
 };
 
 // ----- Render ----- //
@@ -52,6 +53,7 @@ function NewContributionTextInput(props: PropTypes) {
           value={props.value}
           min={props.min}
           max={props.max}
+          disabled={props.disabled}
         />
         <span className="form__icon">
           {props.icon}
@@ -77,6 +79,7 @@ NewContributionTextInput.defaultProps = {
   autoFocus: false,
   max: undefined,
   min: undefined,
+  disabled: false,
 };
 
 export { NewContributionTextInput };

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -705,13 +705,12 @@ form {
   transition: box-shadow .2s ease-in-out;
 }
 
-.form__input:not(:disabled):hover {
+.form__input:enabled:hover {
   box-shadow: 0 0 0 3px #ededed;
 }
 
 .form__input:disabled {
-  background: #ddccdd;
-  color: #757575;
+  background: gu-colour(garnett-neutral-4);
 }
 
 .form__input:focus {

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -711,6 +711,7 @@ form {
 
 .form__input:disabled {
   background: gu-colour(garnett-neutral-4);
+  color: gu-colour(media-garnett-main-1);
 }
 
 .form__input:focus {

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -705,8 +705,13 @@ form {
   transition: box-shadow .2s ease-in-out;
 }
 
-.form__input:hover {
+.form__input:not(:disabled):hover {
   box-shadow: 0 0 0 3px #ededed;
+}
+
+.form__input:disabled {
+  background: #ddccdd;
+  color: #757575;
 }
 
 .form__input:focus {

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -921,3 +921,10 @@ form {
   margin: ($gu-v-spacing * 2) -10px 0;
 }
 
+/* = SIGN OUT link */
+
+.component-signout {
+  color: inherit;
+  display: block;
+  text-align: right;
+}

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -242,7 +242,7 @@ header[role="banner"] {
     left: 50%;
     position: absolute;
     transform: translate(-50%,0);
-    width: 375px;
+    width: 100%;
   }
 
   .countryGroups {


### PR DESCRIPTION
## Why are you doing this?

From the Trello card: _"On the old flow, we didn't allow signed in users to change their email address. We need to implement the same thing on the new flow, else we will end up in a world of trouble."_

[**Trello Card**](https://trello.com/c/V5fLc8jq/894-npf-dont-allow-signed-in-users-to-change-their-email-address)

![screen shot 2018-09-26 at 16 10 24](https://user-images.githubusercontent.com/629976/46089571-bcbc7780-c1a6-11e8-9f14-1c4697fd0038.png)

