### PR TITLE
Put Price In Digital Page And Tidy Up

### DIFF
--- a/assets/components/priceCta/priceCta.jsx
+++ b/assets/components/priceCta/priceCta.jsx
@@ -6,6 +6,8 @@ import React from 'react';
 
 import CtaLink from 'components/ctaLink/ctaLink';
 
+import { classNameWithModifiers } from 'helpers/utilities';
+
 
 // ----- Types ----- //
 
@@ -13,23 +15,38 @@ type PropTypes = {
   ctaText: string,
   url: string,
   price: string,
+  secondaryCopy: string | null,
 };
 
 
 // ----- Component ----- //
 
-export default function PriceCta(props: PropTypes) {
+function PriceCta(props: PropTypes) {
+
+  const withSecondary = props.secondaryCopy !== null;
 
   return (
-    <div className="component-price-cta">
+    <div className={classNameWithModifiers('component-price-cta', withSecondary ? ['with-secondary'] : [])}>
       <CtaLink
         text={props.ctaText}
         url={props.url}
         accessibilityHint={`${props.ctaText} for only ${props.price} per month`}
         ctaId="price-cta"
       />
+      {withSecondary ? <p className="component-price-cta__secondary">{props.secondaryCopy}</p> : null}
     </div>
   );
 
 }
 
+
+// ----- Default Props ----- //
+
+PriceCta.defaultProps = {
+  secondaryCopy: null,
+};
+
+
+// ----- Exports ----- //
+
+export default PriceCta;

--- a/assets/components/priceCta/priceCta.scss
+++ b/assets/components/priceCta/priceCta.scss
@@ -1,12 +1,10 @@
 .component-price-cta {
   padding-top: $gu-v-spacing;
   padding-bottom: $gu-v-spacing;
-  background-color: #000;
   position: relative;
-  border-top: white 1px solid;
 
   .component-cta-link {
-    width: 185px;
+    width: 200px;
     background-color: gu-colour(news-garnett-highlight);
     color: gu-colour(garnett-neutral-1);
     margin-left: $gu-h-spacing / 2;
@@ -16,7 +14,7 @@
     }
 
     @include mq($from: mobileMedium) {
-      width: 190px;
+      width: 200px;
     }
 
     @include mq($from: desktop) {

--- a/assets/components/priceCta/priceCta.scss
+++ b/assets/components/priceCta/priceCta.scss
@@ -1,5 +1,4 @@
 .component-price-cta {
-  padding-left: $gu-h-spacing / 2;
   padding-top: $gu-v-spacing;
   padding-bottom: $gu-v-spacing;
   background-color: #000;
@@ -10,6 +9,7 @@
     width: 185px;
     background-color: gu-colour(news-garnett-highlight);
     color: gu-colour(garnett-neutral-1);
+    margin-left: $gu-h-spacing / 2;
 
     &:hover {
       background-color: darken(gu-colour(news-garnett-highlight), 5%);
@@ -27,4 +27,23 @@
   .svg-arrow-right-straight {
     fill: gu-colour(garnett-neutral-1);
   }
+}
+
+.component-price-cta--with-secondary {
+  padding-bottom: 0;
+
+  .component-cta-link {
+    margin-bottom: $gu-v-spacing;
+  }
+}
+
+.component-price-cta__secondary {
+  background-color: gu-colour(garnett-neutral-3);
+  font-size: 14px;
+  font-style: italic;
+  line-height: 24px;
+  padding-bottom: $gu-v-spacing / 2;
+  padding-left: $gu-h-spacing / 2;
+  width: 100%;
+  box-sizing: border-box;
 }

--- a/assets/pages/digital-subscription-landing/components/ctaSwitch.jsx
+++ b/assets/pages/digital-subscription-landing/components/ctaSwitch.jsx
@@ -3,12 +3,30 @@
 // ----- Imports ----- //
 
 import React from 'react';
+
 import PriceCtaContainer from './priceCtaContainer';
 import FindOutMoreCta from './findOutMoreCta';
 import { showPromotion } from '../helpers/promotions';
 
-export default function CtaSwitch(props: {referringCta: string}) {
-  return showPromotion() ?
-    <FindOutMoreCta referringCta={props.referringCta} /> :
-    <PriceCtaContainer referringCta={props.referringCta} />;
+
+// ----- Component ----- //
+
+function CtaSwitch(props: { referringCta: string }) {
+
+  if (showPromotion()) {
+    return <FindOutMoreCta referringCta={props.referringCta} />;
+  }
+
+  return (
+    <PriceCtaContainer
+      referringCta={props.referringCta}
+      secondaryCopy="You can cancel your subscription at any time"
+    />
+  );
+
 }
+
+
+// ----- Exports ----- //
+
+export default CtaSwitch;

--- a/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
+++ b/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
@@ -144,13 +144,13 @@ export default function DigitalSubscriptionLandingHeader(props: PropTypes) {
           <GridPicture {...gridPicture(props.countryGroupId)} />
         </div>
         <div className="digital-subscription-landing-header__wrapper">
-          <div className="digital-subscription-landing-header__product">
+          <h1 className="digital-subscription-landing-header__product">
             Digital Pack
-          </div>
+          </h1>
           <div className="digital-subscription-landing-header__title">
-            <h1 className="digital-subscription-landing-header__title-copy">
+            <p className="digital-subscription-landing-header__title-copy">
               {getPageTitle(props.countryGroupId)}
-            </h1>
+            </p>
           </div>
         </div>
         <CtaSwitch referringCta="support_digipack_page_header" />

--- a/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
+++ b/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
@@ -148,7 +148,9 @@ export default function DigitalSubscriptionLandingHeader(props: PropTypes) {
             Digital Pack
           </div>
           <div className="digital-subscription-landing-header__title">
-            <h1 className="digital-subscription-landing-header__title-copy">{getPageTitle()}</h1>
+            <h1 className="digital-subscription-landing-header__title-copy">
+              {getPageTitle(props.countryGroupId)}
+            </h1>
           </div>
         </div>
         <CtaSwitch referringCta="support_digipack_page_header" />

--- a/assets/pages/digital-subscription-landing/components/priceCtaContainer.jsx
+++ b/assets/pages/digital-subscription-landing/components/priceCtaContainer.jsx
@@ -20,7 +20,7 @@ function mapStateToProps(state: { common: CommonState }, ownProps: { referringCt
   const price = getProductPrice('DigitalPack', countryGroupId);
 
   return {
-    ctaText: 'Start a 14 day free trial',
+    ctaText: 'Start your free trial now',
     url: getDigitalCheckout(
       referrerAcquisitionData,
       countryGroupId,

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -60,7 +60,7 @@
       }
     }
 
-    .component-price-cta__cancel {
+    .component-price-cta__secondary {
       background-color: #fff;
     }
   }
@@ -245,6 +245,12 @@
 
   .component-grid-picture__image {
     display: block;
+  }
+
+  .digital-subscription-landing-header {
+    .component-price-cta__secondary {
+      border-left: 1px solid gu-colour(garnett-neutral-4);
+    }
   }
 
   .digital-subscription-landing-header__wrapper {

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -248,6 +248,10 @@
   }
 
   .digital-subscription-landing-header {
+    .component-price-cta {
+      background-color: gu-colour(garnett-neutral-1);
+      border-top: 1px solid #fff;
+    }
     .component-price-cta__secondary {
       border-left: 1px solid gu-colour(garnett-neutral-4);
     }
@@ -278,12 +282,13 @@
     font-weight: bold;
     font-size: 24px;
     padding: 4px 12px;
+    color: gu-colour(garnett-neutral-1);
   }
 
   .digital-subscription-landing-header__title {
     position: relative;
     width: 100%;
-    background-color: #000000;
+    background-color: gu-colour(garnett-neutral-1);
   }
 
   .digital-subscription-landing-header__title-copy {
@@ -296,28 +301,25 @@
     font-size: 22px;
     line-height: 29px;
     height: 70px;
-
-    @include mq($until: mobileMedium) {
-      width: 310px;
-    }
+    width: 250px;
 
     @include mq($from: mobileMedium, $until: tablet) {
       padding-top: 8px;
       font-size: 28px;
       line-height: 34px;
-      width: 380px;
+      width: 320px;
       height: 80px;
     }
 
     @include mq($from: tablet, $until: leftCol) {
-      width: 560px;
+      width: 480px;
       font-size: 42px;
       line-height: 48px;
       height: 106px;
     }
 
     @include mq($from: leftCol) {
-      width: 580px;
+      width: 520px;
       font-size: 44px;
       line-height: 50px;
       margin-left: 12px;
@@ -328,10 +330,6 @@
   .component-left-margin-section--header-block {
     .component-grid-picture {
       position: relative;
-    }
-
-    .component-price-cta__cancel {
-      background-color: #f6f6f6;
     }
 
     .svg-title-circles-left-mobile {

--- a/assets/pages/digital-subscription-landing/helpers/promotions.js
+++ b/assets/pages/digital-subscription-landing/helpers/promotions.js
@@ -1,6 +1,13 @@
 // @flow
 
+// ----- Imports ----- //
+
 import { getQueryParameter } from 'helpers/url';
+import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { displayPrice } from 'helpers/subscriptions';
+
+
+// ----- Functions ----- //
 
 function showPromotion(): boolean {
   return getQueryParameter('utm_source') === 'eml' &&
@@ -8,11 +15,14 @@ function showPromotion(): boolean {
     getQueryParameter('utm_campaign') === 'SC_AD_Print_Upsell_270918_ID2';
 }
 
-function getPageTitle(): string {
+function getPageTitle(cgId: CountryGroupId): string {
   if (showPromotion()) {
     return 'Upgrade your subscription to Paper+Digital now';
   }
-  return 'Get the full digital experience of The Guardian';
+  return `14-day free trial and then ${displayPrice('DigitalPack', cgId)}`;
 }
+
+
+// ----- Exports ----- //
 
 export { getPageTitle, showPromotion };


### PR DESCRIPTION
## Why are you doing this?

Puts the digital pack price in large copy section at the top of the digital product page. Also applies some minor design tweaks for consistency.

[**Trello Card**](https://trello.com/c/HT1d8JwT/1936-add-pricing-and-cancellation-info-back-into-digital-pack-product-page)

cc @JustinPinner 

## Changes

- `PriceCta` allows optional secondary copy, which includes cancellation info on digital product page.
- Tweaked copy on CTA and adjusted size to match.
- Aligned some colours with the palette.
- Updated heading copy to include trial and price information.
- Flipped the "Digital Pack" copy to an `<h1>`.

## Screenshots

![digital-landing](https://user-images.githubusercontent.com/5131341/46091424-be883a00-c1aa-11e8-8544-b758bbc9572d.jpg)
