### PR TITLE
Client side do not track check to avoid problems with cached pages

### DIFF
--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -56,9 +56,7 @@
 		}
 	</script>
 
-	@if(!doNotTrack) {
-		<script async type="text/javascript" src="@assets("googleTagManagerScript.js")"></script>
-	}
+	<script async type="text/javascript" src="@assets("googleTagManagerScript.js")"></script>
 
 	<link rel="preload"  as="script" href="@assets(mainJsBundle)">
 

--- a/assets/helpers/tracking/googleTagManagerScript.js
+++ b/assets/helpers/tracking/googleTagManagerScript.js
@@ -1,10 +1,23 @@
 // Google Tag Manager
 /* eslint-disable */
-(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-  // $FlowFixMe
-  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','googleTagManagerDataLayer','GTM-W6GJ68L');
+import { doNotTrack } from 'helpers/page/page';
+if(!doNotTrack()) {
+  (function (w, d, s, l, i) {
+    w[l] = w[l] || [];
+    w[l].push({
+      'gtm.start':
+        new Date().getTime(),
+      event: 'gtm.js'
+    });
+    var f = d.getElementsByTagName(s)[0],
+      j = d.createElement(s),
+      dl = l != 'dataLayer' ? '&l=' + l : '';
+    j.async = true;
+    j.src =
+      // $FlowFixMe
+      'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+    f.parentNode.insertBefore(j, f);
+  })(window, document, 'script', 'googleTagManagerDataLayer', 'GTM-W6GJ68L');
+}
 /* eslint-enable */
 // End Google Tag Manager


### PR DESCRIPTION
## Why are you doing this?

Currently we have a server side 'do not track' check, this probably will not behave correctly for pages that are cached so this PR moves the check to the client side.

[**Trello Card**](https://trello.com/c/XOMsQJKV/1903-fix-tracking-move-gtm-do-not-track-check-client-side)

