### PR TITLE
Add /contribute/set-password-guest endpoint 

### DIFF
--- a/app/codecs/CirceDecoders.scala
+++ b/app/codecs/CirceDecoders.scala
@@ -18,7 +18,10 @@ import com.gu.support.workers.model.CheckoutFailureReasons.CheckoutFailureReason
 import ophan.thrift.componentEvent.ComponentType
 import services.stepfunctions.StatusResponse
 import admin._
+import models.identity.{CookieResponse, CookiesResponse}
+import models.identity.responses.IdentityApiResponseError
 import services.{PayPalError, PayPalSuccess}
+import org.joda.time.DateTime
 
 object CirceDecoders {
 
@@ -117,5 +120,9 @@ object CirceDecoders {
   implicit val payPalErrorBodyDecoder: Decoder[PayPalError] = deriveDecoder
   implicit val payPalSuccessDecoder: Decoder[PayPalSuccess] = deriveDecoder
 
-}
+  implicit val identityApiResponseErrorEncoders: Encoder[IdentityApiResponseError] = deriveEncoder
+  implicit val dateTimeEncoder: Encoder[DateTime] = Encoder.encodeString.contramap(_.toString)
+  implicit val cookieResponseEncoder: Encoder[CookieResponse] = deriveEncoder
+  implicit val cookiesResponseEncoder: Encoder[CookiesResponse] = deriveEncoder
 
+}

--- a/app/codecs/CirceDecoders.scala
+++ b/app/codecs/CirceDecoders.scala
@@ -19,7 +19,6 @@ import ophan.thrift.componentEvent.ComponentType
 import services.stepfunctions.StatusResponse
 import admin._
 import models.identity.{CookieResponse, CookiesResponse}
-import models.identity.responses.IdentityApiResponseError
 import services.{PayPalError, PayPalSuccess}
 import org.joda.time.DateTime
 
@@ -120,7 +119,6 @@ object CirceDecoders {
   implicit val payPalErrorBodyDecoder: Decoder[PayPalError] = deriveDecoder
   implicit val payPalSuccessDecoder: Decoder[PayPalSuccess] = deriveDecoder
 
-  implicit val identityApiResponseErrorEncoders: Encoder[IdentityApiResponseError] = deriveEncoder
   implicit val dateTimeEncoder: Encoder[DateTime] = Encoder.encodeString.contramap(_.toString)
   implicit val cookieResponseEncoder: Encoder[CookieResponse] = deriveEncoder
   implicit val cookiesResponseEncoder: Encoder[CookiesResponse] = deriveEncoder

--- a/app/controllers/IdentityController.scala
+++ b/app/controllers/IdentityController.scala
@@ -4,13 +4,13 @@ import actions.CustomActionBuilders
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
 import io.circe.syntax._
-import models.identity.responses.IdentityApiResponseError
 import monitoring.SafeLogger
 import monitoring.SafeLogger._
 import play.api.mvc._
 import play.api.libs.circe.Circe
 import services.IdentityService
 import codecs.CirceDecoders._
+import cats.implicits._
 
 import scala.concurrent.ExecutionContext
 
@@ -22,7 +22,6 @@ class IdentityController(
   extends AbstractController(components) with Circe {
 
   import actionRefiners._
-  import cats.implicits._
 
   def submitMarketing(): Action[SendMarketingRequest] = PrivateAction.async(circe.json[SendMarketingRequest]) { implicit request =>
     val result = identityService.sendConsentPreferencesEmail(request.body.email)
@@ -45,7 +44,7 @@ class IdentityController(
           SafeLogger.error(scrub"Failed to set password")
           InternalServerError(err.asJson)
         },
-        cookies =>  {
+        cookies => {
           SafeLogger.info("Successfully set passwrod")
           Ok(cookies.asJson)
         }

--- a/app/controllers/IdentityController.scala
+++ b/app/controllers/IdentityController.scala
@@ -3,11 +3,14 @@ package controllers
 import actions.CustomActionBuilders
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
+import io.circe.syntax._
+import models.identity.responses.IdentityApiResponseError
 import monitoring.SafeLogger
 import monitoring.SafeLogger._
 import play.api.mvc._
 import play.api.libs.circe.Circe
 import services.IdentityService
+import codecs.CirceDecoders._
 
 import scala.concurrent.ExecutionContext
 
@@ -19,6 +22,7 @@ class IdentityController(
   extends AbstractController(components) with Circe {
 
   import actionRefiners._
+  import cats.implicits._
 
   def submitMarketing(): Action[SendMarketingRequest] = PrivateAction.async(circe.json[SendMarketingRequest]) { implicit request =>
     val result = identityService.sendConsentPreferencesEmail(request.body.email)
@@ -28,9 +32,24 @@ class IdentityController(
         Ok
       } else {
         SafeLogger.error(scrub"Failed to send consents preferences email")
-        BadRequest
+        InternalServerError
       }
     }
+  }
+
+  def setPasswordGuest(): Action[SetPasswordRequest] = PrivateAction.async(circe.json[SetPasswordRequest]) { implicit request =>
+    identityService
+      .setPasswordGuest(request.body.password, request.body.guestAccountRegistrationToken)
+      .fold(
+        err => {
+          SafeLogger.error(scrub"Failed to set password")
+          InternalServerError(err.asJson)
+        },
+        cookies =>  {
+          SafeLogger.info("Successfully set passwrod")
+          Ok(cookies.asJson)
+        }
+      )
   }
 }
 
@@ -39,3 +58,7 @@ object SendMarketingRequest {
 }
 case class SendMarketingRequest(email: String)
 
+object SetPasswordRequest {
+  implicit val decoder: Decoder[SetPasswordRequest] = deriveDecoder
+}
+case class SetPasswordRequest(password: String, guestAccountRegistrationToken: String)

--- a/app/models/identity/CookieResponse.scala
+++ b/app/models/identity/CookieResponse.scala
@@ -1,0 +1,7 @@
+package models.identity
+
+import org.joda.time.DateTime
+
+case class CookieResponse(key: String, value: String, sessionCookie: Option[Boolean] = None)
+
+case class CookiesResponse(expiresAt: DateTime, values: List[CookieResponse])

--- a/app/models/identity/CookieResponse.scala
+++ b/app/models/identity/CookieResponse.scala
@@ -1,7 +1,19 @@
 package models.identity
 
+import com.gu.identity.model.LiftJsonConfig
 import org.joda.time.DateTime
+import org.joda.time.format.DateTimeFormat
+import play.api.libs.json.{Json, Reads}
 
 case class CookieResponse(key: String, value: String, sessionCookie: Option[Boolean] = None)
 
 case class CookiesResponse(expiresAt: DateTime, values: List[CookieResponse])
+
+object CookiesResponse {
+  val dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+  implicit val jodaDateReads = Reads[DateTime](js =>
+    js.validate[String].map[DateTime](dtString =>
+      DateTime.parse(dtString, DateTimeFormat.forPattern(dateFormat))))
+  implicit val readsCookieResponse: Reads[CookieResponse] = Json.reads[CookieResponse]
+  implicit val readsCookiesResponse: Reads[CookiesResponse] = Json.reads[CookiesResponse]
+}

--- a/app/services/HttpIdentityService.scala
+++ b/app/services/HttpIdentityService.scala
@@ -7,7 +7,7 @@ import cats.implicits._
 import com.google.common.net.InetAddresses
 import com.gu.identity.play.{IdMinimalUser, IdUser}
 import config.Identity
-import models.identity.UserIdWithGuestAccountToken
+import models.identity.{CookiesResponse, UserIdWithGuestAccountToken}
 import models.identity.requests.CreateGuestAccountRequestBody
 import models.identity.responses.{GuestRegistrationResponse, UserResponse}
 import monitoring.SafeLogger
@@ -15,7 +15,6 @@ import monitoring.SafeLogger._
 import play.api.libs.json.Json
 import play.api.libs.ws.{WSClient, WSRequest, WSResponse}
 import play.api.mvc.RequestHeader
-
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
@@ -78,6 +77,23 @@ class HttpIdentityService(apiUrl: String, apiClientToken: String)(implicit wsCli
     }
   }
 
+  def setPasswordGuest(
+    password: String,
+    guestAccountRegistrationToken: String
+  )(implicit ec: ExecutionContext): EitherT[Future, String, CookiesResponse] = {
+    val payload = Json.obj("password" -> password)
+    val headers =
+      List("Authorization" -> s"Bearer $apiClientToken", "X-Guest-Registration-Token" -> guestAccountRegistrationToken, "Content-Type" -> "application/json")
+    val urlParameters = List("validate-email" -> "0")
+    request(s"guest/password")
+      .withHttpHeaders(headers: _*)
+      .withQueryStringParameters(urlParameters: _*)
+      .put(payload)
+      .attemptT
+      .leftMap(_.toString)
+      .subflatMap(resp => (resp.json \ "cookies").validate[CookiesResponse].asEither.leftMap(_.mkString(",")))
+  }
+
   private def getHeaders(request: RequestHeader): List[(String, String)] = List(
     "X-GU-ID-Client-Access-Token" -> Some(s"Bearer $apiClientToken"),
     "X-GU-ID-FOWARDED-SC-GU-U" -> request.cookies.get("SC_GU_U").map(_.value),
@@ -109,7 +125,9 @@ class HttpIdentityService(apiUrl: String, apiClientToken: String)(implicit wsCli
     }
   }
 
-  def createUserIdFromEmailUser(email: String)(implicit req: RequestHeader, ec: ExecutionContext): EitherT[Future, String, UserIdWithGuestAccountToken] = {
+  def createUserIdFromEmailUser(
+    email: String
+  )(implicit req: RequestHeader, ec: ExecutionContext): EitherT[Future, String, UserIdWithGuestAccountToken] = {
     val body = CreateGuestAccountRequestBody.fromEmail(email)
     execute(
       wsClient.url(s"$apiUrl/guest")
@@ -124,7 +142,9 @@ class HttpIdentityService(apiUrl: String, apiClientToken: String)(implicit wsCli
       }
   }
 
-  def getOrCreateUserIdFromEmail(email: String)(implicit req: RequestHeader, ec: ExecutionContext): EitherT[Future, String, UserIdWithGuestAccountToken] = {
+  def getOrCreateUserIdFromEmail(
+    email: String
+  )(implicit req: RequestHeader, ec: ExecutionContext): EitherT[Future, String, UserIdWithGuestAccountToken] = {
     getUserIdFromEmail(email).leftFlatMap(_ => createUserIdFromEmailUser(email))
   }
 
@@ -157,5 +177,9 @@ class HttpIdentityService(apiUrl: String, apiClientToken: String)(implicit wsCli
 trait IdentityService {
   def getUser(user: IdMinimalUser)(implicit req: RequestHeader, ec: ExecutionContext): EitherT[Future, String, IdUser]
   def sendConsentPreferencesEmail(email: String)(implicit ec: ExecutionContext): Future[Boolean]
+  def setPasswordGuest(
+    password: String,
+    guestAccountRegistrationToken: String
+  )(implicit ec: ExecutionContext): EitherT[Future, String, CookiesResponse]
   def getOrCreateUserIdFromEmail(email: String)(implicit req: RequestHeader, ec: ExecutionContext): EitherT[Future, String, UserIdWithGuestAccountToken]
 }

--- a/app/services/HttpIdentityService.scala
+++ b/app/services/HttpIdentityService.scala
@@ -83,7 +83,7 @@ class HttpIdentityService(apiUrl: String, apiClientToken: String)(implicit wsCli
   )(implicit ec: ExecutionContext): EitherT[Future, String, CookiesResponse] = {
     val payload = Json.obj("password" -> password)
     val headers =
-      List("Authorization" -> s"Bearer $apiClientToken", "X-Guest-Registration-Token" -> guestAccountRegistrationToken, "Content-Type" -> "application/json")
+      List("X-Guest-Registration-Token" -> guestAccountRegistrationToken, "Content-Type" -> "application/json")
     val urlParameters = List("validate-email" -> "0")
     request(s"guest/password")
       .withHttpHeaders(headers: _*)

--- a/app/services/StubIdentityService.scala
+++ b/app/services/StubIdentityService.scala
@@ -3,9 +3,11 @@ package services
 import cats.data.EitherT
 import cats.implicits._
 import com.gu.identity.play.{IdMinimalUser, IdUser, PrivateFields, PublicFields}
-import models.identity.UserIdWithGuestAccountToken
+import models.identity.{CookiesResponse, UserIdWithGuestAccountToken}
+import models.identity.responses.IdentityApiResponseError
 import monitoring.SafeLogger
 import play.api.mvc.RequestHeader
+import org.joda.time.DateTime
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -21,6 +23,14 @@ class StubIdentityService extends IdentityService {
   def sendConsentPreferencesEmail(email: String)(implicit ec: ExecutionContext): Future[Boolean] = {
     SafeLogger.info("Stubbed identity service active. Returning true (Successful response from Identity Consent API) ")
     Future.successful(true)
+  }
+
+  def setPasswordGuest(
+    password: String,
+    guestAccountRegistrationToken: String
+  )(implicit ec: ExecutionContext): EitherT[Future, IdentityApiResponseError, CookiesResponse] = {
+    SafeLogger.info("Stubbed identity service active. Returning true (Successful response from Identity Consent API) ")
+    EitherT.rightT[Future, IdentityApiResponseError](CookiesResponse(DateTime.now(), List.empty))
   }
 
   def getOrCreateUserIdFromEmail(email: String)(implicit req: RequestHeader, ec: ExecutionContext): EitherT[Future, String, UserIdWithGuestAccountToken] = {

--- a/app/services/StubIdentityService.scala
+++ b/app/services/StubIdentityService.scala
@@ -4,7 +4,6 @@ import cats.data.EitherT
 import cats.implicits._
 import com.gu.identity.play.{IdMinimalUser, IdUser, PrivateFields, PublicFields}
 import models.identity.{CookiesResponse, UserIdWithGuestAccountToken}
-import models.identity.responses.IdentityApiResponseError
 import monitoring.SafeLogger
 import play.api.mvc.RequestHeader
 import org.joda.time.DateTime
@@ -28,9 +27,9 @@ class StubIdentityService extends IdentityService {
   def setPasswordGuest(
     password: String,
     guestAccountRegistrationToken: String
-  )(implicit ec: ExecutionContext): EitherT[Future, IdentityApiResponseError, CookiesResponse] = {
+  )(implicit ec: ExecutionContext): EitherT[Future, String, CookiesResponse] = {
     SafeLogger.info("Stubbed identity service active. Returning true (Successful response from Identity Consent API) ")
-    EitherT.rightT[Future, IdentityApiResponseError](CookiesResponse(DateTime.now(), List.empty))
+    EitherT.rightT[Future, String](CookiesResponse(DateTime.now(), List.empty))
   }
 
   def getOrCreateUserIdFromEmail(email: String)(implicit req: RequestHeader, ec: ExecutionContext): EitherT[Future, String, UserIdWithGuestAccountToken] = {

--- a/conf/routes
+++ b/conf/routes
@@ -52,6 +52,7 @@ GET  /contribute/recurring/pending                  controllers.RegularContribut
 # this endpoint should be removed once identity remove
 # the need for a client token
 POST  /contribute/send-marketing                     controllers.IdentityController.submitMarketing
+PUT  /contribute/set-password-guest                 controllers.IdentityController.setPasswordGuest
 
 
 GET  /contribute/one-off                            controllers.OneOffContributions.displayForm()


### PR DESCRIPTION
## Why are you doing this?
Currently I'm working on adding the ability for users to set a password post-recurring payment in the guest checkout flow. I'm approaching the Regis way, getting this work out bit by bit rather than in one huge PR, so this PR just deals with the backend. 
