### PR TITLE
uses valid payments methods for rendering

### DIFF
--- a/assets/helpers/checkouts.js
+++ b/assets/helpers/checkouts.js
@@ -111,7 +111,6 @@ function getPaymentLabel(paymentMethod: PaymentMethod): string {
 
 export {
   getAmount,
-  getPaymentMethods,
   getValidPaymentMethods,
   getPaymentMethodFromSession,
   getPaymentDescription,

--- a/assets/pages/new-contributions-landing/components/ContributionPayment.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionPayment.jsx
@@ -5,7 +5,8 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { type PaymentMethod, type PaymentHandler, getPaymentLabel, getPaymentMethods } from 'helpers/checkouts';
+import { type PaymentMethod, type PaymentHandler, getPaymentLabel, getValidPaymentMethods } from 'helpers/checkouts';
+import { type Switches } from 'helpers/settings';
 import { type Contrib } from 'helpers/contributions';
 import { classNameWithModifiers } from 'helpers/utilities';
 import { type IsoCountry } from 'helpers/internationalisation/country';
@@ -31,6 +32,7 @@ type PropTypes = {
   updatePaymentMethod: PaymentMethod => Action,
   isPaymentReady: (boolean, ?{ [PaymentMethod]: PaymentHandler }) => Action,
   isTestUser: boolean,
+  switches: Switches,
 };
 /* eslint-enable react/no-unused-prop-types */
 
@@ -41,6 +43,7 @@ const mapStateToProps = (state: State) => ({
   paymentMethod: state.page.form.paymentMethod,
   paymentHandler: state.page.form.paymentHandler,
   isTestUser: state.page.user.isTestUser || false,
+  switches: state.common.settings.switches,
 });
 
 const mapDispatchToProps = {
@@ -85,7 +88,9 @@ function setupPaymentMethod(props: PropTypes): void {
 // ----- Render ----- //
 
 function ContributionPayment(props: PropTypes) {
-  const paymentMethods: PaymentMethod[] = getPaymentMethods(props.contributionType, props.countryId);
+
+  const paymentMethods: PaymentMethod[] =
+    getValidPaymentMethods(props.contributionType, props.switches, props.countryId);
 
   setupPaymentMethod(props);
 


### PR DESCRIPTION
## Why are you doing this?
So users do not see invalid payment methods. 

As we are hiding radio buttons for invalid payment methods, rather than displaying a fallback element, we do not need to use the switchable wrapper.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

TODO: When all payment methods are switched off we need to surface a messgae to the user. Currently, when a payment methods is switched off the radio button still shows, so this PR is an improvement despite this todo. 

[**Trello Card**](https://trello.com/c/A3xl1tTo/891-npf-buttons-should-be-switch-controlled)

## Changes

* Uses `getValidPaymentMethods` function to map over and render payment method buttons. This function filters out switched off buttons, ensuring these are not shown to the user. 
* No longer exports `getPaymentMethods` as this is no longer used outside checkout.js

## Screenshots

