### PR TITLE
Set `ophanBrowserId` directly from the cookie

### DIFF
--- a/assets/helpers/tracking/googleTagManager.js
+++ b/assets/helpers/tracking/googleTagManager.js
@@ -6,7 +6,6 @@ import { getVariantsAsString } from 'helpers/abTests/abtest';
 import { detect as detectCurrency } from 'helpers/internationalisation/currency';
 import { getQueryParameter } from 'helpers/url';
 import { detect as detectCountryGroup } from 'helpers/internationalisation/countryGroup';
-import { getOphanIds } from 'helpers/tracking/acquisitions';
 import type { Participations } from 'helpers/abTests/abtest';
 
 
@@ -143,7 +142,6 @@ function sendData(
       campaignCodeTeam: getQueryParameter('CMP_TU') || undefined,
       internalCampaignCode: getQueryParameter('INTCMP') || undefined,
       experience: getVariantsAsString(participations),
-      ophanBrowserID: getOphanIds().browserId,
       paymentRequestApiStatus,
       ecommerce: {
         currencyCode: currency,


### PR DESCRIPTION
## Why are you doing this?
I am updating our tracking to use Ophan's browser ID as the [GA User Id](https://support.google.com/analytics/answer/3123663) which will make it easier to join up our view of the user across support-frontend, subscribe-frontend and server side conversion tracking.

In doing this I'm following the [advice for Google Tag Manager](https://support.google.com/tagmanager/answer/4565987?hl=en) to set this from a cookie. This means that we can also set the custom dimension that we previously set from the datalayer directly from the cookie as well and so this line is no longer needed.

[**Trello Card**](https://trello.com/c/AfmLDoqa)
