### PR TITLE
Click Events And Optimize Participations

### DIFF
--- a/assets/components/featuredDigitalPack/featuredDigitalPack.jsx
+++ b/assets/components/featuredDigitalPack/featuredDigitalPack.jsx
@@ -55,7 +55,7 @@ function FeaturedDigitalPack(props: PropTypes) {
           text="Buy now"
           url={props.url}
           accessibilityHint="Buy now"
-          onClick={sendTrackingEventsOnClick('featured_digipack_cta', 'digital', props.abTest)}
+          onClick={sendTrackingEventsOnClick('featured_digipack_cta', 'DigitalPack', props.abTest)}
         />
       </div>
       <div className="component-featured-digital-pack__image">

--- a/assets/components/featuredDigitalPack/featuredDigitalPack.jsx
+++ b/assets/components/featuredDigitalPack/featuredDigitalPack.jsx
@@ -9,7 +9,11 @@ import CtaLink from 'components/ctaLink/ctaLink';
 import GridPicture from 'components/gridPicture/gridPicture';
 import SvgCircle from 'components/svgs/circle';
 
-import { displayPrice } from 'helpers/subscriptions';
+import {
+  displayPrice,
+  sendTrackingEventsOnClick,
+  type ComponentAbTest,
+} from 'helpers/subscriptions';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 
@@ -19,6 +23,7 @@ type PropTypes = {
   headingSize: HeadingSize,
   countryGroupId: CountryGroupId,
   url: string,
+  abTest: ComponentAbTest | void,
 };
 
 
@@ -50,6 +55,7 @@ function FeaturedDigitalPack(props: PropTypes) {
           text="Buy now"
           url={props.url}
           accessibilityHint="Buy now"
+          onClick={sendTrackingEventsOnClick('featured_digipack_cta', 'digital', props.abTest)}
         />
       </div>
       <div className="component-featured-digital-pack__image">
@@ -81,6 +87,13 @@ function FeaturedDigitalPack(props: PropTypes) {
   );
 
 }
+
+
+// ----- Default Props ----- //
+
+FeaturedDigitalPack.defaultProps = {
+  abTest: undefined,
+};
 
 
 // ----- Exports ----- //

--- a/assets/components/featuredDigitalPack/featuredDigitalPack.jsx
+++ b/assets/components/featuredDigitalPack/featuredDigitalPack.jsx
@@ -23,7 +23,7 @@ type PropTypes = {
   headingSize: HeadingSize,
   countryGroupId: CountryGroupId,
   url: string,
-  abTest: ComponentAbTest | void,
+  abTest: ComponentAbTest | null,
 };
 
 
@@ -92,7 +92,7 @@ function FeaturedDigitalPack(props: PropTypes) {
 // ----- Default Props ----- //
 
 FeaturedDigitalPack.defaultProps = {
-  abTest: undefined,
+  abTest: null,
 };
 
 

--- a/assets/components/featuredDigitalPack/featuredDigitalPack.jsx
+++ b/assets/components/featuredDigitalPack/featuredDigitalPack.jsx
@@ -64,14 +64,14 @@ function FeaturedDigitalPack(props: PropTypes) {
           sources={[
             {
               gridId: 'digitalPackBenefitsMobile',
-              srcSizes: [140, 500, 1000, 1730],
+              srcSizes: [140, 500, 1000, 1729],
               imgType: 'png',
               sizes: '90vw',
               media: '(max-width: 659px)',
             },
             {
               gridId: 'digitalPackBenefitsDesktop',
-              srcSizes: [140, 500, 796],
+              srcSizes: [140, 500, 1000, 2000],
               imgType: 'png',
               sizes: '(min-width: 1300px) 750px, (min-width: 1140px) 700px, (min-width: 980px) 600px, (min-width: 740px) 60vw, 90vw',
               media: '(min-width: 660px)',

--- a/assets/components/subscriptionsByCountryGroup/components/digitalPack.jsx
+++ b/assets/components/subscriptionsByCountryGroup/components/digitalPack.jsx
@@ -9,6 +9,7 @@ import SubscriptionBundle from 'components/subscriptionBundle/subscriptionBundle
 import { gridImageProperties } from 'components/threeSubscriptions/helpers/gridImageProperties';
 
 import { type ImageId } from 'helpers/theGrid';
+import { sendTrackingEventsOnClick, type ComponentAbTest } from 'helpers/subscriptions';
 
 
 // ----- Component ----- //
@@ -19,6 +20,7 @@ function DigitalPack(props: {
   subheading: string,
   copy: string,
   gridId: ImageId,
+  abTest: ComponentAbTest | void,
 }) {
 
   return (
@@ -42,12 +44,20 @@ function DigitalPack(props: {
           url: props.url,
           accessibilityHint: 'Find out how to sign up for a free trial of The Guardian\'s digital subscription.',
           modifierClasses: ['border'],
+          onClick: sendTrackingEventsOnClick('digipack_cta', 'digital', props.abTest),
         },
       ]}
     />
   );
 
 }
+
+
+// ----- Default Props ----- //
+
+DigitalPack.defaultProps = {
+  abTest: undefined,
+};
 
 
 // ----- Exports ----- //

--- a/assets/components/subscriptionsByCountryGroup/components/digitalPack.jsx
+++ b/assets/components/subscriptionsByCountryGroup/components/digitalPack.jsx
@@ -44,7 +44,7 @@ function DigitalPack(props: {
           url: props.url,
           accessibilityHint: 'Find out how to sign up for a free trial of The Guardian\'s digital subscription.',
           modifierClasses: ['border'],
-          onClick: sendTrackingEventsOnClick('digipack_cta', 'digital', props.abTest),
+          onClick: sendTrackingEventsOnClick('digipack_cta', 'DigitalPack', props.abTest),
         },
       ]}
     />

--- a/assets/components/subscriptionsByCountryGroup/components/digitalPack.jsx
+++ b/assets/components/subscriptionsByCountryGroup/components/digitalPack.jsx
@@ -20,7 +20,7 @@ function DigitalPack(props: {
   subheading: string,
   copy: string,
   gridId: ImageId,
-  abTest: ComponentAbTest | void,
+  abTest: ComponentAbTest | null,
 }) {
 
   return (
@@ -56,7 +56,7 @@ function DigitalPack(props: {
 // ----- Default Props ----- //
 
 DigitalPack.defaultProps = {
-  abTest: undefined,
+  abTest: null,
 };
 
 

--- a/assets/components/subscriptionsByCountryGroup/components/digitalSection.jsx
+++ b/assets/components/subscriptionsByCountryGroup/components/digitalSection.jsx
@@ -45,7 +45,7 @@ function DigitalSection(props: PropTypes) {
       <SubscriptionBundle
         modifierClass="daily-edition"
         heading="Daily Edition"
-        subheading={`from ${displayPrice('DailyEdition', props.countryGroupId)}`}
+        subheading={displayPrice('DailyEdition', props.countryGroupId)}
         headingSize={props.headingSize}
         benefits={{
           list: false,

--- a/assets/components/subscriptionsByCountryGroup/components/digitalSection.jsx
+++ b/assets/components/subscriptionsByCountryGroup/components/digitalSection.jsx
@@ -28,7 +28,7 @@ type PropTypes = {|
   subsLinks: SubsUrls,
   countryGroupId: CountryGroupId,
   appReferrer: string,
-  abTest: ComponentAbTest | void,
+  abTest: ComponentAbTest | null,
 |};
 
 
@@ -82,7 +82,7 @@ function DigitalSection(props: PropTypes) {
 // ----- Default Props ----- //
 
 DigitalSection.defaultProps = {
-  abTest: undefined,
+  abTest: null,
 };
 
 

--- a/assets/components/subscriptionsByCountryGroup/components/digitalSection.jsx
+++ b/assets/components/subscriptionsByCountryGroup/components/digitalSection.jsx
@@ -15,19 +15,26 @@ import { appStoreCtaClick } from 'helpers/tracking/googleTagManager';
 import { displayPrice, displayDigitalPackBenefitCopy } from 'helpers/subscriptions';
 import { type SubsUrls } from 'helpers/externalLinks';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { type ComponentAbTest } from 'helpers/subscriptions';
 
 import PremiumTier from './premiumTier';
 import DigitalPack from './digitalPack';
 
 
-// ----- Component ----- //
+// ----- Types ----- //
 
-function DigitalSection(props: {
+type PropTypes = {|
   headingSize: HeadingSize,
   subsLinks: SubsUrls,
   countryGroupId: CountryGroupId,
   appReferrer: string,
-}) {
+  abTest: ComponentAbTest | void,
+|};
+
+
+// ----- Component ----- //
+
+function DigitalSection(props: PropTypes) {
   return (
     <ThreeSubscriptions heading="Digital Subscriptions">
       <PremiumTier
@@ -65,10 +72,18 @@ function DigitalSection(props: {
         subheading={displayPrice('DigitalPack', props.countryGroupId)}
         gridId="digitalCircleAlt"
         copy={displayDigitalPackBenefitCopy(props.countryGroupId)}
+        abTest={props.abTest}
       />
     </ThreeSubscriptions>
   );
 }
+
+
+// ----- Default Props ----- //
+
+DigitalSection.defaultProps = {
+  abTest: undefined,
+};
 
 
 // ----- Exports ----- //

--- a/assets/components/subscriptionsByCountryGroup/components/featuredProductTest.jsx
+++ b/assets/components/subscriptionsByCountryGroup/components/featuredProductTest.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 
 import { getQueryParameter } from 'helpers/url';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { type ComponentAbTest } from 'helpers/subscriptions';
 
 import FeaturedDigitalPack from 'components/featuredDigitalPack/featuredDigitalPack';
 
@@ -16,8 +17,8 @@ import PaperSection from './paperSection';
 // ----- Types ----- //
 
 type PropTypes = {
-  paperSection: React$Element<typeof PaperSection>,
-  digitalSection: React$Element<typeof DigitalSection>,
+  paperSection: (ComponentAbTest | void) => React$Element<typeof PaperSection>,
+  digitalSection: (ComponentAbTest | void) => React$Element<typeof DigitalSection>,
   countryGroupId: CountryGroupId,
   digitalPackUrl: string,
 };
@@ -40,8 +41,8 @@ function FeaturedProductTest(props: PropTypes) {
             countryGroupId={props.countryGroupId}
             url={props.digitalPackUrl}
           />
-          {props.digitalSection}
-          {props.paperSection}
+          {props.digitalSection({ name: 'featuredProduct', variant: 'featured' })}
+          {props.paperSection({ name: 'featuredProduct', variant: 'featured' })}
         </div>
       );
 
@@ -53,16 +54,23 @@ function FeaturedProductTest(props: PropTypes) {
             countryGroupId={props.countryGroupId}
             url={props.digitalPackUrl}
           />
-          {props.paperSection}
+          {props.paperSection({ name: 'featuredProduct', variant: 'featuredShort' })}
         </div>
       );
 
     case 'control':
+      return (
+        <div className={className}>
+          {props.digitalSection({ name: 'featuredProduct', variant: 'control' })}
+          {props.paperSection({ name: 'featuredProduct', variant: 'control' })}
+        </div>
+      );
+
     default:
       return (
         <div className={className}>
-          {props.digitalSection}
-          {props.paperSection}
+          {props.digitalSection()}
+          {props.paperSection()}
         </div>
       );
 

--- a/assets/components/subscriptionsByCountryGroup/components/featuredProductTest.jsx
+++ b/assets/components/subscriptionsByCountryGroup/components/featuredProductTest.jsx
@@ -78,6 +78,11 @@ function FeaturedProductTest(props: PropTypes) {
     default:
       return (
         <div className={className}>
+          <FeaturedDigitalPack
+            headingSize={3}
+            countryGroupId={props.countryGroupId}
+            url={props.digitalPackUrl}
+          />
           {props.digitalSection(null)}
           {props.paperSection(null)}
         </div>

--- a/assets/components/subscriptionsByCountryGroup/components/featuredProductTest.jsx
+++ b/assets/components/subscriptionsByCountryGroup/components/featuredProductTest.jsx
@@ -17,8 +17,8 @@ import PaperSection from './paperSection';
 // ----- Types ----- //
 
 type PropTypes = {
-  paperSection: (ComponentAbTest | void) => React$Element<typeof PaperSection>,
-  digitalSection: (ComponentAbTest | void) => React$Element<typeof DigitalSection>,
+  paperSection: (ComponentAbTest | null) => React$Element<typeof PaperSection>,
+  digitalSection: (ComponentAbTest | null) => React$Element<typeof DigitalSection>,
   countryGroupId: CountryGroupId,
   digitalPackUrl: string,
 };
@@ -69,8 +69,8 @@ function FeaturedProductTest(props: PropTypes) {
     default:
       return (
         <div className={className}>
-          {props.digitalSection()}
-          {props.paperSection()}
+          {props.digitalSection(null)}
+          {props.paperSection(null)}
         </div>
       );
 

--- a/assets/components/subscriptionsByCountryGroup/components/featuredProductTest.jsx
+++ b/assets/components/subscriptionsByCountryGroup/components/featuredProductTest.jsx
@@ -24,6 +24,13 @@ type PropTypes = {
 };
 
 
+// ----- Functions ----- //
+
+function getTestProperties(variant: string): ComponentAbTest {
+  return { name: 'featuredProduct', variant };
+}
+
+
 // ----- Component ----- //
 
 function FeaturedProductTest(props: PropTypes) {
@@ -40,9 +47,10 @@ function FeaturedProductTest(props: PropTypes) {
             headingSize={3}
             countryGroupId={props.countryGroupId}
             url={props.digitalPackUrl}
+            abTest={getTestProperties('featured')}
           />
-          {props.digitalSection({ name: 'featuredProduct', variant: 'featured' })}
-          {props.paperSection({ name: 'featuredProduct', variant: 'featured' })}
+          {props.digitalSection(getTestProperties('featured'))}
+          {props.paperSection(getTestProperties('featured'))}
         </div>
       );
 
@@ -53,16 +61,17 @@ function FeaturedProductTest(props: PropTypes) {
             headingSize={3}
             countryGroupId={props.countryGroupId}
             url={props.digitalPackUrl}
+            abTest={getTestProperties('featuredShort')}
           />
-          {props.paperSection({ name: 'featuredProduct', variant: 'featuredShort' })}
+          {props.paperSection(getTestProperties('featuredShort'))}
         </div>
       );
 
     case 'control':
       return (
         <div className={className}>
-          {props.digitalSection({ name: 'featuredProduct', variant: 'control' })}
-          {props.paperSection({ name: 'featuredProduct', variant: 'control' })}
+          {props.digitalSection(getTestProperties('control'))}
+          {props.paperSection(getTestProperties('control'))}
         </div>
       );
 

--- a/assets/components/subscriptionsByCountryGroup/components/paperSection.jsx
+++ b/assets/components/subscriptionsByCountryGroup/components/paperSection.jsx
@@ -23,7 +23,7 @@ type PropTypes = {|
   headingSize: HeadingSize,
   subsLinks: SubsUrls,
   countryGroupId: CountryGroupId,
-  abTest: ComponentAbTest | void,
+  abTest: ComponentAbTest | null,
 |};
 
 
@@ -95,7 +95,7 @@ function PaperSection(props: PropTypes) {
 // ----- Default Props ----- //
 
 PaperSection.defaultProps = {
-  abTest: undefined,
+  abTest: null,
 };
 
 

--- a/assets/components/subscriptionsByCountryGroup/components/paperSection.jsx
+++ b/assets/components/subscriptionsByCountryGroup/components/paperSection.jsx
@@ -12,17 +12,24 @@ import { type HeadingSize } from 'components/heading/heading';
 import { displayPrice } from 'helpers/subscriptions';
 import { type SubsUrls } from 'helpers/externalLinks';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { sendTrackingEventsOnClick, type ComponentAbTest } from 'helpers/subscriptions';
 
 import Weekly from './weekly';
 
 
-// ----- Component ----- //
+// ----- Types ----- //
 
-function PaperSection(props: {
+type PropTypes = {|
   headingSize: HeadingSize,
   subsLinks: SubsUrls,
   countryGroupId: CountryGroupId,
-}) {
+  abTest: ComponentAbTest | void,
+|};
+
+
+// ----- Component ----- //
+
+function PaperSection(props: PropTypes) {
 
   return (
     <ThreeSubscriptions heading="Print Subscriptions">
@@ -46,6 +53,7 @@ function PaperSection(props: {
             url: props.subsLinks.Paper,
             accessibilityHint: 'Proceed to paper subscription options',
             modifierClasses: ['border'],
+            onClick: sendTrackingEventsOnClick('paper_cta', 'print', props.abTest),
           },
         ]}
       />
@@ -69,6 +77,7 @@ function PaperSection(props: {
             url: props.subsLinks.PaperAndDigital,
             accessibilityHint: 'Proceed to choose which days you would like to regularly receive the newspaper in conjunction with a digital subscription',
             modifierClasses: ['border'],
+            onClick: sendTrackingEventsOnClick('paper_digital_cta', 'print', props.abTest),
           },
         ]}
       />
@@ -76,11 +85,18 @@ function PaperSection(props: {
         headingSize={props.headingSize}
         url={props.subsLinks.GuardianWeekly}
         subheading={displayPrice('GuardianWeekly', props.countryGroupId)}
+        abTest={props.abTest}
       />
     </ThreeSubscriptions>
   );
 
 }
+
+// ----- Default Props ----- //
+
+PaperSection.defaultProps = {
+  abTest: undefined,
+};
 
 
 // ----- Exports ----- //

--- a/assets/components/subscriptionsByCountryGroup/components/paperSection.jsx
+++ b/assets/components/subscriptionsByCountryGroup/components/paperSection.jsx
@@ -53,7 +53,7 @@ function PaperSection(props: PropTypes) {
             url: props.subsLinks.Paper,
             accessibilityHint: 'Proceed to paper subscription options',
             modifierClasses: ['border'],
-            onClick: sendTrackingEventsOnClick('paper_cta', 'print', props.abTest),
+            onClick: sendTrackingEventsOnClick('paper_cta', 'Paper', props.abTest),
           },
         ]}
       />
@@ -77,7 +77,7 @@ function PaperSection(props: PropTypes) {
             url: props.subsLinks.PaperAndDigital,
             accessibilityHint: 'Proceed to choose which days you would like to regularly receive the newspaper in conjunction with a digital subscription',
             modifierClasses: ['border'],
-            onClick: sendTrackingEventsOnClick('paper_digital_cta', 'print', props.abTest),
+            onClick: sendTrackingEventsOnClick('paper_digital_cta', 'PaperAndDigital', props.abTest),
           },
         ]}
       />

--- a/assets/components/subscriptionsByCountryGroup/components/weekly.jsx
+++ b/assets/components/subscriptionsByCountryGroup/components/weekly.jsx
@@ -8,10 +8,22 @@ import { type HeadingSize } from 'components/heading/heading';
 import SubscriptionBundle from 'components/subscriptionBundle/subscriptionBundle';
 import { gridImageProperties } from 'components/threeSubscriptions/helpers/gridImageProperties';
 
+import { sendTrackingEventsOnClick, type ComponentAbTest } from 'helpers/subscriptions';
+
+
+// ----- Types ----- //
+
+type PropTypes = {
+  headingSize: HeadingSize,
+  url: string,
+  subheading: string,
+  abTest: ComponentAbTest | void,
+};
+
 
 // ----- Component ----- //
 
-function Weekly(props: { headingSize: HeadingSize, url: string, subheading: string }) {
+function Weekly(props: PropTypes) {
 
   return (
     <SubscriptionBundle
@@ -34,12 +46,20 @@ function Weekly(props: { headingSize: HeadingSize, url: string, subheading: stri
           url: props.url,
           accessibilityHint: 'Proceed to buy a subscription to The Guardian Weekly',
           modifierClasses: ['border'],
+          onClick: sendTrackingEventsOnClick('weekly_cta', 'print', props.abTest),
         },
       ]}
     />
   );
 
 }
+
+
+// ----- Default Props ----- //
+
+Weekly.defaultProps = {
+  abTest: undefined,
+};
 
 
 // ----- Exports ----- //

--- a/assets/components/subscriptionsByCountryGroup/components/weekly.jsx
+++ b/assets/components/subscriptionsByCountryGroup/components/weekly.jsx
@@ -46,7 +46,7 @@ function Weekly(props: PropTypes) {
           url: props.url,
           accessibilityHint: 'Proceed to buy a subscription to The Guardian Weekly',
           modifierClasses: ['border'],
-          onClick: sendTrackingEventsOnClick('weekly_cta', 'print', props.abTest),
+          onClick: sendTrackingEventsOnClick('weekly_cta', 'GuardianWeekly', props.abTest),
         },
       ]}
     />

--- a/assets/components/subscriptionsByCountryGroup/components/weekly.jsx
+++ b/assets/components/subscriptionsByCountryGroup/components/weekly.jsx
@@ -17,7 +17,7 @@ type PropTypes = {
   headingSize: HeadingSize,
   url: string,
   subheading: string,
-  abTest: ComponentAbTest | void,
+  abTest: ComponentAbTest | null,
 };
 
 
@@ -58,7 +58,7 @@ function Weekly(props: PropTypes) {
 // ----- Default Props ----- //
 
 Weekly.defaultProps = {
-  abTest: undefined,
+  abTest: null,
 };
 
 

--- a/assets/components/subscriptionsByCountryGroup/subscriptionsByCountryGroup.jsx
+++ b/assets/components/subscriptionsByCountryGroup/subscriptionsByCountryGroup.jsx
@@ -83,7 +83,7 @@ function SubscriptionsByCountryGroup(props: PropTypes) {
         <FeaturedProductTest
           countryGroupId="GBPCountries"
           digitalPackUrl={subsLinks.DigitalPack}
-          digitalSection={(abTest: ComponentAbTest | void) => (
+          digitalSection={(abTest: ComponentAbTest | null) => (
             <DigitalSection
               headingSize={headingSize}
               subsLinks={subsLinks}
@@ -92,7 +92,7 @@ function SubscriptionsByCountryGroup(props: PropTypes) {
               abTest={abTest}
             />
           )}
-          paperSection={(abTest: ComponentAbTest | void) => (
+          paperSection={(abTest: ComponentAbTest | null) => (
             <PaperSection
               headingSize={headingSize}
               subsLinks={subsLinks}

--- a/assets/components/subscriptionsByCountryGroup/subscriptionsByCountryGroup.jsx
+++ b/assets/components/subscriptionsByCountryGroup/subscriptionsByCountryGroup.jsx
@@ -14,6 +14,7 @@ import { getSubsLinks } from 'helpers/externalLinks';
 import { classNameWithModifiers } from 'helpers/utilities';
 import { countryGroups } from 'helpers/internationalisation/countryGroup';
 import { getAppReferrer } from 'helpers/tracking/appStores';
+import { type ComponentAbTest } from 'helpers/subscriptions';
 
 import FeaturedProductTest from './components/featuredProductTest';
 import DigitalSection from './components/digitalSection';
@@ -68,21 +69,23 @@ function SubscriptionsByCountryGroup(props: PropTypes) {
         <FeaturedProductTest
           countryGroupId="GBPCountries"
           digitalPackUrl={subsLinks.DigitalPack}
-          digitalSection={
+          digitalSection={(abTest: ComponentAbTest | void) => (
             <DigitalSection
               headingSize={headingSize}
               subsLinks={subsLinks}
               countryGroupId={countryGroupId}
               appReferrer={appReferrer}
+              abTest={abTest}
             />
-          }
-          paperSection={
+          )}
+          paperSection={(abTest: ComponentAbTest | void) => (
             <PaperSection
               headingSize={headingSize}
               subsLinks={subsLinks}
               countryGroupId={countryGroupId}
+              abTest={abTest}
             />
-          }
+          )}
         />
       </div>
     );

--- a/assets/components/subscriptionsByCountryGroup/subscriptionsByCountryGroup.jsx
+++ b/assets/components/subscriptionsByCountryGroup/subscriptionsByCountryGroup.jsx
@@ -15,6 +15,8 @@ import { classNameWithModifiers } from 'helpers/utilities';
 import { countryGroups } from 'helpers/internationalisation/countryGroup';
 import { getAppReferrer } from 'helpers/tracking/appStores';
 import { type ComponentAbTest } from 'helpers/subscriptions';
+import { type Participations } from 'helpers/abTests/abtest';
+import { type OptimizeExperiments } from 'helpers/tracking/optimize';
 
 import FeaturedProductTest from './components/featuredProductTest';
 import DigitalSection from './components/digitalSection';
@@ -28,6 +30,8 @@ type PropTypes = {
   countryGroupId: CountryGroupId,
   headingSize: HeadingSize,
   referrerAcquisitionData: ReferrerAcquisitionData,
+  abParticipations: Participations,
+  optimizeExperiments: OptimizeExperiments,
   appMedium: string,
 };
 
@@ -36,6 +40,8 @@ function mapStateToProps(state: { common: CommonState }) {
   return {
     countryGroupId: state.common.internationalisation.countryGroupId,
     referrerAcquisitionData: state.common.referrerAcquisitionData,
+    abParticipations: state.common.abParticipations,
+    optimizeExperiments: state.common.optimizeExperiments,
   };
 
 }
@@ -46,7 +52,13 @@ function mapStateToProps(state: { common: CommonState }) {
 function SubscriptionsByCountryGroup(props: PropTypes) {
 
   const {
-    countryGroupId, headingSize, referrerAcquisitionData, appMedium, ...otherProps
+    countryGroupId,
+    headingSize,
+    referrerAcquisitionData,
+    appMedium,
+    abParticipations,
+    optimizeExperiments,
+    ...otherProps
   } = props;
 
   const subsLinks = getSubsLinks(
@@ -54,6 +66,8 @@ function SubscriptionsByCountryGroup(props: PropTypes) {
     referrerAcquisitionData.campaignCode,
     getCampaign(referrerAcquisitionData),
     referrerAcquisitionData,
+    abParticipations,
+    optimizeExperiments,
   );
 
   const className = classNameWithModifiers(

--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -2,12 +2,17 @@
 
 // ----- Imports ----- //
 
-import type { Campaign } from 'helpers/tracking/acquisitions';
-import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
+import {
+  type Campaign,
+  type ReferrerAcquisitionData,
+  deriveSubsAcquisitionData,
+} from 'helpers/tracking/acquisitions';
 import {
   countryGroups,
   type CountryGroupId,
 } from 'helpers/internationalisation/countryGroup';
+import type { Participations } from 'helpers/abTests/abtest';
+import { type OptimizeExperiments } from 'helpers/tracking/optimize';
 
 import { getPromoCode, getIntcmp } from './flashSale';
 import type { SubscriptionProduct } from './subscriptions';
@@ -154,17 +159,25 @@ function getSubsLinks(
   intCmp: ?string,
   campaign: ?Campaign,
   referrerAcquisitionData: ReferrerAcquisitionData,
+  nativeAbParticipations: Participations,
+  optimizeExperiments: OptimizeExperiments,
 ): SubsUrls {
+  const acquisitionData = deriveSubsAcquisitionData(
+    referrerAcquisitionData,
+    nativeAbParticipations,
+    optimizeExperiments,
+  );
+
   if ((campaign && customPromos[campaign])) {
     return buildSubsUrls(
       countryGroupId,
       customPromos[campaign],
       intCmp,
-      referrerAcquisitionData,
+      acquisitionData,
     );
   }
 
-  return buildSubsUrls(countryGroupId, defaultPromos, intCmp, referrerAcquisitionData);
+  return buildSubsUrls(countryGroupId, defaultPromos, intCmp, acquisitionData);
 
 }
 
@@ -173,10 +186,17 @@ function getDigitalCheckout(
   referrerAcquisitionData: ReferrerAcquisitionData,
   cgId: CountryGroupId,
   referringCta: ?string,
+  nativeAbParticipations: Participations,
+  optimizeExperiments: OptimizeExperiments,
 ): string {
+  const acquisitionData = deriveSubsAcquisitionData(
+    referrerAcquisitionData,
+    nativeAbParticipations,
+    optimizeExperiments,
+  );
 
   const params = new URLSearchParams(window.location.search);
-  params.set('acquisitionData', JSON.stringify(referrerAcquisitionData));
+  params.set('acquisitionData', JSON.stringify(acquisitionData));
   params.set('promoCode', defaultPromos.DigitalPack);
   params.set('countryGroup', countryGroups[cgId].supportInternationalisationId);
   params.set('startTrialButton', referringCta || '');

--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -118,13 +118,16 @@ function getMemLink(product: MemProduct, intCmp: ?string): string {
 function buildParamString(
   product: SubscriptionProduct,
   intCmp: ?string,
-  referrerAcquisitionData: ReferrerAcquisitionData,
+  referrerAcquisitionData: ReferrerAcquisitionData | null,
 ): string {
   const params = new URLSearchParams(window.location.search);
 
   const maybeCustomIntcmp = getIntcmp(product, intCmp, defaultIntCmp);
   params.set('INTCMP', maybeCustomIntcmp);
-  params.set('acquisitionData', JSON.stringify(referrerAcquisitionData));
+
+  if (referrerAcquisitionData) {
+    params.set('acquisitionData', JSON.stringify(referrerAcquisitionData));
+  }
 
   return params.toString();
 }
@@ -141,7 +144,7 @@ function buildSubsUrls(
 
   const paper = `${subsUrl}/p/${promoCodes.Paper}?${buildParamString('Paper', intCmp, referrerAcquisitionData)}`;
   const paperDig = `${subsUrl}/p/${promoCodes.PaperAndDigital}?${buildParamString('PaperAndDigital', intCmp, referrerAcquisitionData)}`;
-  const digital = `/${countryId}/subscribe/digital?${buildParamString('DigitalPack', intCmp, referrerAcquisitionData)}`;
+  const digital = `/${countryId}/subscribe/digital?${buildParamString('DigitalPack', intCmp, null)}`;
   const weekly = `${subsUrl}/weekly?${buildParamString('GuardianWeekly', intCmp, referrerAcquisitionData)}`;
 
   return {

--- a/assets/helpers/page/__tests__/__snapshots__/pageTest.js.snap
+++ b/assets/helpers/page/__tests__/__snapshots__/pageTest.js.snap
@@ -20,7 +20,7 @@ Object {
   "optimizeExperiments": Object {},
   "otherQueryParams": Array [],
   "referrerAcquisitionData": Object {
-    "abTest": null,
+    "abTests": Array [],
     "campaignCode": null,
     "componentId": null,
     "componentType": null,

--- a/assets/helpers/page/__tests__/pageTest.js
+++ b/assets/helpers/page/__tests__/pageTest.js
@@ -23,7 +23,7 @@ describe('reducer tests', () => {
         componentId: null,
         componentType: null,
         source: null,
-        abTest: null,
+        abTests: [],
         queryParameters: [],
       },
       internationalisation: {

--- a/assets/helpers/subscriptions.js
+++ b/assets/helpers/subscriptions.js
@@ -97,7 +97,7 @@ function displayDigitalPackBenefitCopy(countryGroupId: CountryGroupId): string {
 function sendTrackingEventsOnClick(
   id: string,
   product: 'digital' | 'print',
-  abTest: ComponentAbTest | void,
+  abTest: ComponentAbTest | null,
 ): () => void {
 
   const componentEvent = {
@@ -108,7 +108,7 @@ function sendTrackingEventsOnClick(
     },
     action: 'CLICK',
     id,
-    abTest,
+    ...(abTest ? { abTest } : {}),
   };
 
   const gaAction = abTest ? abTest.name : product;

--- a/assets/helpers/subscriptions.js
+++ b/assets/helpers/subscriptions.js
@@ -60,7 +60,7 @@ const subscriptionPrices: {
     GBPCountries: 21.62,
   },
   DailyEdition: {
-    GBPCountries: 6.99,
+    GBPCountries: 11.99,
   },
 };
 

--- a/assets/helpers/subscriptions.js
+++ b/assets/helpers/subscriptions.js
@@ -20,6 +20,8 @@ export type SubscriptionProduct =
   'Paper' |
   'PaperAndDigital';
 
+type OphanSubscriptionsProduct = 'DIGITAL_SUBSCRIPTION' | 'PRINT_SUBSCRIPTION';
+
 export type ComponentAbTest = {
   name: string,
   variant: string,
@@ -94,9 +96,25 @@ function displayDigitalPackBenefitCopy(countryGroupId: CountryGroupId): string {
     : 'The premium app and the daily edition iPad app of the UK newspaper in one pack, plus ad-free reading on all your devices';
 }
 
+function ophanProductFromSubscriptionProduct(product: SubscriptionProduct): OphanSubscriptionsProduct {
+
+  switch (product) {
+    case 'DigitalPack':
+    case 'PremiumTier':
+    case 'DailyEdition':
+      return 'DIGITAL_SUBSCRIPTION';
+    case 'GuardianWeekly':
+    case 'Paper':
+    case 'PaperAndDigital':
+    default:
+      return 'PRINT_SUBSCRIPTION';
+  }
+
+}
+
 function sendTrackingEventsOnClick(
   id: string,
-  product: 'digital' | 'print',
+  product: SubscriptionProduct,
   abTest: ComponentAbTest | null,
 ): () => void {
 
@@ -104,14 +122,12 @@ function sendTrackingEventsOnClick(
     component: {
       componentType: 'ACQUISITIONS_BUTTON',
       id,
-      products: product === 'digital' ? ['DIGITAL_SUBSCRIPTION'] : ['PRINT_SUBSCRIPTION'],
+      products: [ophanProductFromSubscriptionProduct(product)],
     },
     action: 'CLICK',
     id,
     ...(abTest ? { abTest } : {}),
   };
-
-  const gaAction = abTest ? abTest.name : product;
 
   return () => {
 
@@ -119,7 +135,7 @@ function sendTrackingEventsOnClick(
 
     gaEvent({
       category: 'click',
-      action: gaAction,
+      action: product,
       label: id,
     });
 

--- a/assets/helpers/theGrid.js
+++ b/assets/helpers/theGrid.js
@@ -41,8 +41,8 @@ export const imageCatalogue: {
   digitalSubscriptionHeaderMobile: 'ed4028ccd5abd85b330114e3ef48660358f63969/0_0_1200_1755',
   digitalSubscriptionHeaderMobileAU: 'dbe3974508706a41e710f198b1da02f44e6141a1/945_0_1088_1755',
   digitalSubscriptionPromotionPopUpHeader: 'd0322e698dc8b30337feefd3294c8b82882c353b/0_0_2770_1410',
-  digitalPackBenefitsMobile: '4dbe893d4d76164a5ddef7e0230372dc6acb2f53/0_0_1730_1510',
-  digitalPackBenefitsDesktop: '35e2adb47899023829cd8d5af1a24697ffe59f77/0_0_796_420',
+  digitalPackBenefitsMobile: 'bd335622063afd12463bf286a2058008b5f05efc/0_0_1729_1505',
+  digitalPackBenefitsDesktop: 'cb3028a5f9aaf0a1b46ba1594e90b9d3a0b2ad3e/0_0_3750_2000',
 };
 
 // Utility type: https://flow.org/en/docs/types/utilities/#toc-keys

--- a/assets/helpers/tracking/__tests__/__snapshots__/acquisitionsTest.js.snap
+++ b/assets/helpers/tracking/__tests__/__snapshots__/acquisitionsTest.js.snap
@@ -16,15 +16,15 @@ Object {
       "variant": "variant3",
     },
     Object {
-      "name": "optimizeExperiment1",
+      "name": "optimize$$optimizeExperiment1",
       "variant": "variant1",
     },
     Object {
-      "name": "optimizeExperiment2",
+      "name": "optimize$$optimizeExperiment2",
       "variant": "variant2",
     },
     Object {
-      "name": "optimizeExperiment3",
+      "name": "optimize$$optimizeExperiment3",
       "variant": "variant3",
     },
     Object {

--- a/assets/helpers/tracking/__tests__/acquisitionsTest.js
+++ b/assets/helpers/tracking/__tests__/acquisitionsTest.js
@@ -28,10 +28,10 @@ describe('acquisitions', () => {
         componentId: 'exampleComponentId',
         componentType: 'exampleComponentType',
         source: 'exampleSource',
-        abTest: {
+        abTests: [{
           name: 'referrerAbTest',
           variant: 'value1',
-        },
+        }],
         queryParameters: [{ name: 'param1', value: 'value1' }, { name: 'param2', value: 'value2' }],
       };
 
@@ -109,7 +109,7 @@ describe('acquisitions', () => {
       expect(optimizeExperimentsToAcquisitionABTest({})).toEqual([]);
     });
 
-    it('should return an array of AcquisitionAbTests appended with an Optimize tag', () => {
+    it('should return an array of AcquisitionAbTests prepended with an Optimize tag', () => {
 
       const optimizeExperiments: OptimizeExperiments = {
         testOne: 'variantOne',
@@ -120,7 +120,7 @@ describe('acquisitions', () => {
       const acquisitionABTests = optimizeExperimentsToAcquisitionABTest(optimizeExperiments);
 
       expect(acquisitionABTests.length).toBe(3);
-      expect(acquisitionABTests[0]).toEqual({ name: 'testOne', variant: 'variantOne' });
+      expect(acquisitionABTests[0]).toEqual({ name: 'optimize$$testOne', variant: 'variantOne' });
 
     });
 

--- a/assets/helpers/tracking/acquisitions.js
+++ b/assets/helpers/tracking/acquisitions.js
@@ -167,11 +167,11 @@ const participationsToAcquisitionABTest = (participations: Participations): Acqu
   return response;
 };
 
-// Appends all the experiment names (the keys) with '$Optimize' to avoid name
-// collision with native tests, and returns as array of AB tests.
+// Prepends all the experiment names (the keys) with 'optimize$$' to be able to
+// differentiate from native tests, and returns as array of AB tests.
 function optimizeExperimentsToAcquisitionABTest(opt: OptimizeExperiments): AcquisitionABTest[] {
   return Object.keys(opt).map(k => ({
-    name: k,
+    name: `optimize$$${k}`,
     variant: opt[k],
   }));
 }

--- a/assets/helpers/tracking/acquisitions.js
+++ b/assets/helpers/tracking/acquisitions.js
@@ -249,6 +249,24 @@ function derivePaymentApiAcquisitionData(
   };
 }
 
+function deriveSubsAcquisitionData(
+  referrerAcquisitionData: ReferrerAcquisitionData,
+  nativeAbParticipations: Participations,
+  optimizeExperiments: OptimizeExperiments,
+): ReferrerAcquisitionData {
+
+  const abTests = [
+    ...getSupportAbTests(nativeAbParticipations, optimizeExperiments),
+    ...(referrerAcquisitionData.abTests || []),
+  ];
+
+  return {
+    ...referrerAcquisitionData,
+    abTests,
+  };
+
+}
+
 // Returns the acquisition metadata, either from query param or sessionStorage.
 // Also stores in sessionStorage if not present or new from param.
 function getReferrerAcquisitionData(): ReferrerAcquisitionData {
@@ -272,5 +290,6 @@ export {
   participationsToAcquisitionABTest,
   optimizeExperimentsToAcquisitionABTest,
   derivePaymentApiAcquisitionData,
+  deriveSubsAcquisitionData,
   getSupportAbTests,
 };

--- a/assets/helpers/tracking/acquisitions.js
+++ b/assets/helpers/tracking/acquisitions.js
@@ -41,7 +41,7 @@ export type ReferrerAcquisitionData = {|
   componentId: ?string,
   componentType: ?string,
   source: ?string,
-  abTest: ?AcquisitionABTest,
+  abTests: ?AcquisitionABTest[],
   // these aren't in the referrer acquisition data model on frontend, but they're convenient to include
   // as we want to include query parameters in the acquisition event to e.g. facilitate off-platform tracking
   queryParameters: ?AcquisitionQueryParameters,
@@ -137,7 +137,7 @@ function storeReferrerAcquisitionData(referrerAcquisitionData: ReferrerAcquisiti
 }
 
 // Reads the acquisition data from sessionStorage.
-function readReferrerAcquisitionData(): ?ReferrerAcquisitionData {
+function readReferrerAcquisitionData(): ?Object {
 
   const stored = storage.getSession(ACQUISITIONS_STORAGE_KEY);
   return stored ? deserialiseJsonObject(stored) : null;
@@ -201,7 +201,7 @@ function buildReferrerAcquisitionData(acquisitionData: Object = {}): ReferrerAcq
     componentId: acquisitionData.componentId,
     componentType: acquisitionData.componentType,
     source: acquisitionData.source,
-    abTest: acquisitionData.abTest,
+    abTests: acquisitionData.abTest ? [acquisitionData.abTest] : acquisitionData.abTests,
     queryParameters: queryParameters.length > 0 ? queryParameters : undefined,
   };
 }
@@ -226,11 +226,10 @@ function derivePaymentApiAcquisitionData(
 ): PaymentAPIAcquisitionData {
   const ophanIds: OphanIds = getOphanIds();
 
-  const abTests = getSupportAbTests(nativeAbParticipations, optimizeExperiments);
-
-  if (referrerAcquisitionData.abTest) {
-    abTests.push(referrerAcquisitionData.abTest);
-  }
+  const abTests = [
+    ...getSupportAbTests(nativeAbParticipations, optimizeExperiments),
+    ...(referrerAcquisitionData.abTests || []),
+  ];
 
   const campaignCodes = referrerAcquisitionData.campaignCode ?
     [referrerAcquisitionData.campaignCode] : [];

--- a/assets/pages/digital-subscription-landing/components/priceCtaContainer.jsx
+++ b/assets/pages/digital-subscription-landing/components/priceCtaContainer.jsx
@@ -16,7 +16,7 @@ import { getProductPrice } from 'helpers/subscriptions';
 
 function mapStateToProps(state: { common: CommonState }, ownProps: { referringCta: ?string }) {
   const { countryGroupId } = state.common.internationalisation;
-  const { referrerAcquisitionData } = state.common;
+  const { referrerAcquisitionData, abParticipations, optimizeExperiments } = state.common;
   const price = getProductPrice('DigitalPack', countryGroupId);
 
   return {
@@ -25,6 +25,8 @@ function mapStateToProps(state: { common: CommonState }, ownProps: { referringCt
       referrerAcquisitionData,
       countryGroupId,
       ownProps.referringCta,
+      abParticipations,
+      optimizeExperiments,
     ),
     price: `${currencies[state.common.internationalisation.currencyId].glyph}${price}`,
   };

--- a/assets/pages/premium-tier-landing/components/priceCtaContainer.jsx
+++ b/assets/pages/premium-tier-landing/components/priceCtaContainer.jsx
@@ -16,7 +16,7 @@ import { getProductPrice } from 'helpers/subscriptions';
 
 function mapStateToProps(state: { common: CommonState }, ownProps: { referringCta: ?string }) {
   const { countryGroupId } = state.common.internationalisation;
-  const { referrerAcquisitionData } = state.common;
+  const { referrerAcquisitionData, abParticipations, optimizeExperiments } = state.common;
   const price = getProductPrice('PremiumTier', countryGroupId);
 
   return {
@@ -25,6 +25,8 @@ function mapStateToProps(state: { common: CommonState }, ownProps: { referringCt
       referrerAcquisitionData,
       countryGroupId,
       ownProps.referringCta,
+      abParticipations,
+      optimizeExperiments,
     ),
     price: `${currencies[state.common.internationalisation.currencyId].glyph}${price}`,
   };

--- a/assets/pages/support-landing/components/subscriptionsSection.jsx
+++ b/assets/pages/support-landing/components/subscriptionsSection.jsx
@@ -11,6 +11,8 @@ import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { type ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import { getDigitalBenefits, getPaperBenefits, getPaperDigitalBenefits } from 'helpers/flashSale';
 import { displayPrice } from 'helpers/subscriptions';
+import { type Participations } from 'helpers/abTests/abtest';
+import { type OptimizeExperiments } from 'helpers/tracking/optimize';
 
 import ThreeSubscriptions from 'components/threeSubscriptions/threeSubscriptions';
 import SubscriptionBundle from 'components/subscriptionBundle/subscriptionBundle';
@@ -24,6 +26,8 @@ import type { State } from '../supportLandingReducer';
 type PropTypes = {
   referrerAcquisitionData: ReferrerAcquisitionData,
   countryGroupId: CountryGroupId,
+  abParticipations: Participations,
+  optimizeExperiments: OptimizeExperiments,
 };
 
 
@@ -34,6 +38,8 @@ function mapStateToProps(state: State) {
   return {
     referrerAcquisitionData: state.common.referrerAcquisitionData,
     countryGroupId: state.common.internationalisation.countryGroupId,
+    abParticipations: state.common.abParticipations,
+    optimizeExperiments: state.common.optimizeExperiments,
   };
 
 }
@@ -48,6 +54,8 @@ function SubscriptionsSection(props: PropTypes) {
     props.referrerAcquisitionData.campaignCode,
     getCampaign(props.referrerAcquisitionData),
     props.referrerAcquisitionData,
+    props.abParticipations,
+    props.optimizeExperiments,
   );
 
   return (


### PR DESCRIPTION
## Why are you doing this?

To support the changes in #980, we need to make sure AB test information is correctly being recorded.

Also brings the `ReferrerAcquisitionData` type into line with how it's defined in other places. It now has an `abTests: ?AcquisitionABTest[]` field instead of an `abTest: ?AcquisitionABTest` field. Dotcom still only has a single `abTest` field AFAIK (@jranks123 @Mullefa ?), so support-frontend will now translate that into an array. It should also handle any `sessionStorage` copies of `ReferrerAcquisitionData` through the same mechanism.

[**Trello Card**](https://trello.com/c/1Z71dBIk/1925-reinstate-click-events-and-add-optimize-participations-for-subs)

## Changes

- Changed `ReferrerAcquisitionData` to have an `abTests` field.
- Reinstated Ophan and GA click events for products on the subs landing pages. These events optionally take an AB test.
- Built on the work in #895 to pass Optimize experiments as AB participations to Ophan. That PR sent them through to the Payment API, this one also starts passing them through in the links to subs, using `deriveSubsAcquisitionData`.
- Prepended all Optimize tests with the string `optimize$$`.
- Updated the tests and snapshots.
- Added the featured product section to the default UK subs landing page.
- Updated the ad-free image.
- Updated the daily edition price copy.

## Screenshots

![featured-section](https://user-images.githubusercontent.com/5131341/46220849-53be3680-c343-11e8-8917-6f4f3fcbd52c.png)
