### PR TITLE
Initialise form data from user state

### DIFF
--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -16,9 +16,7 @@ import {
 } from 'helpers/paymentIntegrations/readerRevenueApis';
 import { derivePaymentApiAcquisitionData, getSupportAbTests, getOphanIds } from 'helpers/tracking/acquisitions';
 import trackConversion from 'helpers/tracking/conversions';
-import { type State } from './contributionsLandingReducer';
-
-export type FieldName = 'otherAmount' | 'email' | 'lastName' | 'firstName';
+import { type State, type UserFormData } from './contributionsLandingReducer';
 
 export type Action =
   | { type: 'UPDATE_CONTRIBUTION_TYPE', contributionType: Contrib }
@@ -27,6 +25,7 @@ export type Action =
   | { type: 'UPDATE_LAST_NAME', lastName: string }
   | { type: 'UPDATE_EMAIL', email: string }
   | { type: 'UPDATE_STATE', state: UsState | CaState | null }
+  | { type: 'UPDATE_USER_FORM_DATA', userFormData: UserFormData }
   | { type: 'UPDATE_PAYMENT_READY', paymentReady: boolean, paymentHandler: ?{ [PaymentMethod]: PaymentHandler } }
   | { type: 'SELECT_AMOUNT', amount: Amount | 'other', contributionType: Contrib }
   | { type: 'UPDATE_OTHER_AMOUNT', otherAmount: string }
@@ -48,6 +47,8 @@ const updateFirstName = (firstName: string): Action => ({ type: 'UPDATE_FIRST_NA
 const updateLastName = (lastName: string): Action => ({ type: 'UPDATE_LAST_NAME', lastName });
 
 const updateEmail = (email: string): Action => ({ type: 'UPDATE_EMAIL', email });
+
+const updateUserFormData = (userFormData: UserFormData): Action => ({ type: 'UPDATE_USER_FORM_DATA', userFormData });
 
 const updateState = (state: UsState | CaState | null): Action => ({ type: 'UPDATE_STATE', state });
 
@@ -217,6 +218,7 @@ export {
   updateLastName,
   updateEmail,
   updateState,
+  updateUserFormData,
   isPaymentReady,
   selectAmount,
   updateOtherAmount,

--- a/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -3,16 +3,17 @@
 // ----- Imports ----- //
 import { type Store, type Dispatch } from 'redux';
 import { getValidPaymentMethods } from 'helpers/checkouts';
-import { updatePaymentMethod } from './contributionsLandingActions';
+import {
+  updatePaymentMethod,
+  updateUserFormData,
+} from './contributionsLandingActions';
 import { type State } from './contributionsLandingReducer';
 import { type Action } from './contributionsLandingActions';
 
 // ----- Functions ----- //
 
-const init = (store: Store<State, Action, Dispatch<Action>>) => {
-  const { dispatch } = store;
-  const state = store.getState();
 
+function initialisePaymentMethod(state, dispatch) {
   const { contributionType } = state.page.form;
   const { countryId } = state.common.internationalisation;
   const { switches } = state.common.settings;
@@ -24,6 +25,18 @@ const init = (store: Store<State, Action, Dispatch<Action>>) => {
   } else {
     dispatch(updatePaymentMethod('None'));
   }
+}
+
+
+const init = (store: Store<State, Action, Dispatch<Action>>) => {
+  const { dispatch } = store;
+  const state = store.getState();
+  initialisePaymentMethod(state, dispatch);
+
+  const { firstName, lastName, email } = state.page.user;
+  dispatch(updateUserFormData({ firstName, lastName, email }));
+
+
 };
 
 

--- a/assets/pages/new-contributions-landing/contributionsLandingReducer.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingReducer.js
@@ -18,10 +18,13 @@ import { type Action } from './contributionsLandingActions';
 
 // ----- Types ----- //
 
-type FormData = {
+export type UserFormData = {
   firstName: string | null,
   lastName: string | null,
   email: string | null,
+}
+
+type FormData = UserFormData & {
   otherAmounts: {
     [Contrib]: { amount: string | null }
   },
@@ -134,6 +137,9 @@ function createFormReducer(countryGroupId: CountryGroupId) {
 
       case 'UPDATE_STATE':
         return { ...state, formData: { ...state.formData, state: action.state } };
+
+      case 'UPDATE_USER_FORM_DATA':
+        return { ...state, formData: { ...state.formData, ...action.userFormData } };
 
       case 'SELECT_AMOUNT':
         return {


### PR DESCRIPTION
## Why are you doing this?
If the user is signed in, we want to initialise the email, first name and last name of the form data with the values from the user state. This PR fixes a bug whereby the fields were being filled from the user state but the form state wasn't being set with these values, meaning that payments weren't working for signed in users. 