### PR TITLE
When changing contribution type, select the correct payment type 

### DIFF
--- a/assets/helpers/__tests__/checkoutsTest.js
+++ b/assets/helpers/__tests__/checkoutsTest.js
@@ -2,13 +2,14 @@
 
 // ----- Imports ----- //
 
-import { getValidPaymentMethods } from '../checkouts';
+import { getValidPaymentMethods, getPaymentMethodToSelect } from '../checkouts';
 
 // ----- Tests ----- //
 
+
 describe('checkouts', () => {
 
-  describe('getValidPaymentMethods', () => {
+  describe('getValidPaymentMethods and getPaymentMethodToSelect', () => {
 
     const allSwitchesOn = {
       oneOffPaymentMethods: {
@@ -38,12 +39,16 @@ describe('checkouts', () => {
       const contributionType = 'MONTHLY';
       const countryId = 'GB';
       expect(getValidPaymentMethods(contributionType, allSwitchesOn, countryId)).toEqual(['DirectDebit', 'Stripe', 'PayPal']);
+      expect(getPaymentMethodToSelect(contributionType, allSwitchesOn, countryId)).toEqual('DirectDebit');
+
     });
 
-    it('should return en empty array for Monthly Recurring UK when switches are all off', () => {
+    it('should return en empty array/\'None\' for Monthly Recurring UK when switches are all off', () => {
       const contributionType = 'MONTHLY';
       const countryId = 'GB';
       expect(getValidPaymentMethods(contributionType, allSwitchesOff, countryId)).toEqual([]);
+      expect(getPaymentMethodToSelect(contributionType, allSwitchesOff, countryId)).toEqual('None');
+
     });
 
     it('should return just Stripe for One Off US when only Stripe is on', () => {
@@ -51,6 +56,8 @@ describe('checkouts', () => {
       const justStripeOn = { ...allSwitchesOff, oneOffPaymentMethods: { ...allSwitchesOff.oneOffPaymentMethods, stripe: 'On' } };
       const countryId = 'US';
       expect(getValidPaymentMethods(contributionType, justStripeOn, countryId)).toEqual(['Stripe']);
+      expect(getPaymentMethodToSelect(contributionType, justStripeOn, countryId)).toEqual('Stripe');
+
     });
 
   });

--- a/assets/helpers/checkouts.js
+++ b/assets/helpers/checkouts.js
@@ -75,6 +75,15 @@ function getValidPaymentMethods(
     .filter(paymentMethod => switchIsOn(switches, toPaymentMethodSwitchNaming(paymentMethod)));
 }
 
+function getPaymentMethodToSelect(
+  contributionType: Contrib,
+  allSwitches: Switches,
+  countryId: IsoCountry,
+) {
+  const validPaymentMethods = getValidPaymentMethods(contributionType, allSwitches, countryId);
+  return validPaymentMethods[0] || 'None';
+}
+
 function getPaymentMethodFromSession(): ?PaymentMethod {
   const pm: ?string = storage.getSession('paymentMethod');
   if (pm === 'DirectDebit' || pm === 'Stripe' || pm === 'PayPal') {
@@ -112,6 +121,7 @@ function getPaymentLabel(paymentMethod: PaymentMethod): string {
 export {
   getAmount,
   getValidPaymentMethods,
+  getPaymentMethodToSelect,
   getPaymentMethodFromSession,
   getPaymentDescription,
   getPaymentLabel,

--- a/assets/pages/new-contributions-landing/components/ContributionType.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionType.jsx
@@ -7,8 +7,10 @@ import { connect } from 'react-redux';
 import { type Dispatch } from 'redux';
 import { type Contrib } from 'helpers/contributions';
 import { classNameWithModifiers } from 'helpers/utilities';
-import { getValidPaymentMethods } from 'helpers/checkouts';
+import { getPaymentMethodToSelect } from 'helpers/checkouts';
 
+import type { IsoCountry } from 'helpers/internationalisation/country';
+import type { Switches } from 'helpers/settings';
 import { type State } from '../contributionsLandingReducer';
 import { type Action, updateContributionType } from '../contributionsLandingActions';
 
@@ -16,39 +18,30 @@ import { type Action, updateContributionType } from '../contributionsLandingActi
 
 type PropTypes = {
   contributionType: Contrib,
-  onSelectContributionType: Event => Action,
+  countryId: IsoCountry,
+  switches: Switches,
+  onSelectContributionType: (Contrib, Switches, IsoCountry) => void,
 };
 
 const mapStateToProps = (state: State) => ({
-  state,
   contributionType: state.page.form.contributionType,
   countryId: state.common.internationalisation.countryId,
   switches: state.common.settings.switches,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch<Action>) => ({
-  dispatch,
+  onSelectContributionType: (contributionType: Contrib, switches: Switches, countryId: IsoCountry) => {
+    const paymentMethodToSelect = getPaymentMethodToSelect(contributionType, switches, countryId);
+    dispatch(updateContributionType(contributionType, paymentMethodToSelect));
+  },
 });
-
-function mergeProps(stateProps, dispatchProps, ownProps) {
-
-  const onSelectContributionType = (e) => {
-    if (e.target.value !== 'ONE_OFF' && e.target.value !== 'MONTHLY' && e.target.value !== 'ANNUAL') { return; }
-    const paymentMethodToSelect =
-      getValidPaymentMethods(e.target.value, stateProps.switches, stateProps.countryId)[0] || 'None';
-    dispatchProps.dispatch(updateContributionType(e.target.value, paymentMethodToSelect));
-  };
-
-  return {
-    ...ownProps,
-    ...stateProps,
-    onSelectContributionType,
-  };
-}
 
 // ----- Render ----- //
 
 function ContributionType(props: PropTypes) {
+  const oneOff = 'ONE_OFF';
+  const monthly = 'MONTHLY';
+  const annual = 'ANNUAL';
   return (
     <fieldset className={classNameWithModifiers('form__radio-group', ['tabs', 'contribution-type'])}>
       <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>Recurrence</legend>
@@ -59,9 +52,9 @@ function ContributionType(props: PropTypes) {
             className="form__radio-group-input"
             type="radio"
             name="contributionType"
-            value="ONE_OFF"
-            onChange={props.onSelectContributionType}
-            checked={props.contributionType === 'ONE_OFF'}
+            value={oneOff}
+            onChange={() => props.onSelectContributionType(oneOff, props.switches, props.countryId)}
+            checked={props.contributionType === oneOff}
           />
           <label htmlFor="contributionType-oneoff" className="form__radio-group-label">Single</label>
         </li>
@@ -71,9 +64,9 @@ function ContributionType(props: PropTypes) {
             className="form__radio-group-input"
             type="radio"
             name="contributionType"
-            value="MONTHLY"
-            onChange={props.onSelectContributionType}
-            checked={props.contributionType === 'MONTHLY'}
+            value={monthly}
+            onChange={() => props.onSelectContributionType(monthly, props.switches, props.countryId)}
+            checked={props.contributionType === monthly}
           />
           <label htmlFor="contributionType-monthly" className="form__radio-group-label">Monthly</label>
         </li>
@@ -83,9 +76,9 @@ function ContributionType(props: PropTypes) {
             className="form__radio-group-input"
             type="radio"
             name="contributionType"
-            value="ANNUAL"
-            onChange={props.onSelectContributionType}
-            checked={props.contributionType === 'ANNUAL'}
+            value={annual}
+            onChange={() => props.onSelectContributionType(annual, props.switches, props.countryId)}
+            checked={props.contributionType === annual}
           />
           <label htmlFor="contributionType-annual" className="form__radio-group-label">Annual</label>
         </li>
@@ -94,6 +87,6 @@ function ContributionType(props: PropTypes) {
   );
 }
 
-const NewContributionType = connect(mapStateToProps, mapDispatchToProps, mergeProps)(ContributionType);
+const NewContributionType = connect(mapStateToProps, mapDispatchToProps)(ContributionType);
 
 export { NewContributionType };

--- a/assets/pages/new-contributions-landing/components/ContributionType.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionType.jsx
@@ -10,6 +10,8 @@ import { classNameWithModifiers } from 'helpers/utilities';
 
 import { type State } from '../contributionsLandingReducer';
 import { type Action, updateContributionType } from '../contributionsLandingActions';
+import {getValidPaymentMethods} from "../../../helpers/checkouts";
+import {setPaymentMethod} from "../contributionsLandingInit";
 
 // ----- Types ----- //
 
@@ -19,16 +21,29 @@ type PropTypes = {
 };
 
 const mapStateToProps = (state: State) => ({
+  state,
   contributionType: state.page.form.contributionType,
+  countryId: state.common.internationalisation.countryId,
+  switches: state.common.settings.switches,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch<Action>) => ({
-  onSelectContributionType: (e) => {
-    if (e.target.value !== 'ONE_OFF' && e.target.value !== 'MONTHLY' && e.target.value !== 'ANNUAL') { return; }
-
-    dispatch(updateContributionType(e.target.value));
-  },
+  dispatch,
 });
+
+function mergeProps(stateProps, dispatchProps, ownProps) {
+
+  const onSelectContributionType = (e) => {
+    if (e.target.value !== 'ONE_OFF' && e.target.value !== 'MONTHLY' && e.target.value !== 'ANNUAL') { return; }
+    setPaymentMethod(dispatchProps.dispatch, e.target.value, stateProps.switches, stateProps.countryId);
+    dispatchProps.dispatch(updateContributionType(e.target.value));
+  };
+
+  return {
+    ...ownProps,
+    onSelectContributionType,
+  };
+}
 
 // ----- Render ----- //
 
@@ -78,6 +93,6 @@ function ContributionType(props: PropTypes) {
   );
 }
 
-const NewContributionType = connect(mapStateToProps, mapDispatchToProps)(ContributionType);
+const NewContributionType = connect(mapStateToProps, mapDispatchToProps, mergeProps)(ContributionType);
 
 export { NewContributionType };

--- a/assets/pages/new-contributions-landing/components/ContributionType.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionType.jsx
@@ -7,11 +7,10 @@ import { connect } from 'react-redux';
 import { type Dispatch } from 'redux';
 import { type Contrib } from 'helpers/contributions';
 import { classNameWithModifiers } from 'helpers/utilities';
+import { getValidPaymentMethods } from 'helpers/checkouts';
 
 import { type State } from '../contributionsLandingReducer';
 import { type Action, updateContributionType } from '../contributionsLandingActions';
-import {getValidPaymentMethods} from "../../../helpers/checkouts";
-import {setPaymentMethod} from "../contributionsLandingInit";
 
 // ----- Types ----- //
 
@@ -35,12 +34,14 @@ function mergeProps(stateProps, dispatchProps, ownProps) {
 
   const onSelectContributionType = (e) => {
     if (e.target.value !== 'ONE_OFF' && e.target.value !== 'MONTHLY' && e.target.value !== 'ANNUAL') { return; }
-    setPaymentMethod(dispatchProps.dispatch, e.target.value, stateProps.switches, stateProps.countryId);
-    dispatchProps.dispatch(updateContributionType(e.target.value));
+    const paymentMethodToSelect =
+      getValidPaymentMethods(e.target.value, stateProps.switches, stateProps.countryId)[0] || 'None';
+    dispatchProps.dispatch(updateContributionType(e.target.value, paymentMethodToSelect));
   };
 
   return {
     ...ownProps,
+    ...stateProps,
     onSelectContributionType,
   };
 }

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -19,7 +19,7 @@ import trackConversion from 'helpers/tracking/conversions';
 import { type State, type UserFormData } from './contributionsLandingReducer';
 
 export type Action =
-  | { type: 'UPDATE_CONTRIBUTION_TYPE', contributionType: Contrib }
+  | { type: 'UPDATE_CONTRIBUTION_TYPE', contributionType: Contrib, paymentMethodToSelect: PaymentMethod }
   | { type: 'UPDATE_PAYMENT_METHOD', paymentMethod: PaymentMethod }
   | { type: 'UPDATE_FIRST_NAME', firstName: string }
   | { type: 'UPDATE_LAST_NAME', lastName: string }
@@ -36,8 +36,8 @@ export type Action =
   | { type: 'SET_GUEST_ACCOUNT_CREATION_TOKEN', guestAccountCreationToken: string }
   | { type: 'PAYMENT_SUCCESS' };
 
-const updateContributionType = (contributionType: Contrib): Action =>
-  ({ type: 'UPDATE_CONTRIBUTION_TYPE', contributionType });
+const updateContributionType = (contributionType: Contrib, paymentMethodToSelect: PaymentMethod): Action =>
+  ({ type: 'UPDATE_CONTRIBUTION_TYPE', contributionType, paymentMethodToSelect });
 
 const updatePaymentMethod = (paymentMethod: PaymentMethod): Action =>
   ({ type: 'UPDATE_PAYMENT_METHOD', paymentMethod });

--- a/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -2,7 +2,7 @@
 
 // ----- Imports ----- //
 import { type Store, type Dispatch } from 'redux';
-import { getValidPaymentMethods } from 'helpers/checkouts';
+import { getPaymentMethodToSelect } from 'helpers/checkouts';
 import {
   updatePaymentMethod,
   updateUserFormData,
@@ -18,13 +18,9 @@ function initialisePaymentMethod(state: State, dispatch: Dispatch<Action>) {
   const { countryId } = state.common.internationalisation;
   const { switches } = state.common.settings;
 
-  const validPaymentMethods = getValidPaymentMethods(contributionType, switches, countryId);
+  const paymentMethodToSelect = getPaymentMethodToSelect(contributionType, switches, countryId);
 
-  if (validPaymentMethods[0]) {
-    dispatch(updatePaymentMethod(validPaymentMethods[0]));
-  } else {
-    dispatch(updatePaymentMethod('None'));
-  }
+  dispatch(updatePaymentMethod(paymentMethodToSelect));
 }
 
 

--- a/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -3,23 +3,21 @@
 // ----- Imports ----- //
 import { type Store, type Dispatch } from 'redux';
 import { getValidPaymentMethods } from 'helpers/checkouts';
-import { type Switches } from 'helpers/settings';
-import { type IsoCountry } from 'helpers/internationalisation/country';
 import {
-updatePaymentMethod,
-updateUserFormData,
+  updatePaymentMethod,
+  updateUserFormData,
 } from './contributionsLandingActions';
 import { type State } from './contributionsLandingReducer';
 import { type Action } from './contributionsLandingActions';
 
 // ----- Functions ----- //
 
-function setPaymentMethod(
-  dispatch: Dispatch<Action>,
-  contributionType: string,
-  switches: Switches,
-  countryId: IsoCountry
-) {
+
+function initialisePaymentMethod(state: State, dispatch: Dispatch<Action>) {
+  const { contributionType } = state.page.form;
+  const { countryId } = state.common.internationalisation;
+  const { switches } = state.common.settings;
+
   const validPaymentMethods = getValidPaymentMethods(contributionType, switches, countryId);
 
   if (validPaymentMethods[0]) {
@@ -32,12 +30,9 @@ function setPaymentMethod(
 
 const init = (store: Store<State, Action, Dispatch<Action>>) => {
   const { dispatch } = store;
-  const state = store.getState();
 
-  const { contributionType } = state.page.form;
-  const { countryId } = state.common.internationalisation;
-  const { switches } = state.common.settings;
-  setPaymentMethod(dispatch, contributionType, switches, countryId);
+  const state = store.getState();
+  initialisePaymentMethod(state, dispatch);
 
   const { firstName, lastName, email } = state.page.user;
   dispatch(updateUserFormData({ firstName, lastName, email }));
@@ -48,4 +43,4 @@ const init = (store: Store<State, Action, Dispatch<Action>>) => {
 
 // ----- Exports ----- //
 
-export { init, setPaymentMethod };
+export { init };

--- a/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -3,21 +3,23 @@
 // ----- Imports ----- //
 import { type Store, type Dispatch } from 'redux';
 import { getValidPaymentMethods } from 'helpers/checkouts';
+import { type Switches } from 'helpers/settings';
+import { type IsoCountry } from 'helpers/internationalisation/country';
 import {
-  updatePaymentMethod,
-  updateUserFormData,
+updatePaymentMethod,
+updateUserFormData,
 } from './contributionsLandingActions';
 import { type State } from './contributionsLandingReducer';
 import { type Action } from './contributionsLandingActions';
 
 // ----- Functions ----- //
 
-
-function initialisePaymentMethod(state, dispatch) {
-  const { contributionType } = state.page.form;
-  const { countryId } = state.common.internationalisation;
-  const { switches } = state.common.settings;
-
+function setPaymentMethod(
+  dispatch: Dispatch<Action>,
+  contributionType: string,
+  switches: Switches,
+  countryId: IsoCountry
+) {
   const validPaymentMethods = getValidPaymentMethods(contributionType, switches, countryId);
 
   if (validPaymentMethods[0]) {
@@ -31,7 +33,11 @@ function initialisePaymentMethod(state, dispatch) {
 const init = (store: Store<State, Action, Dispatch<Action>>) => {
   const { dispatch } = store;
   const state = store.getState();
-  initialisePaymentMethod(state, dispatch);
+
+  const { contributionType } = state.page.form;
+  const { countryId } = state.common.internationalisation;
+  const { switches } = state.common.settings;
+  setPaymentMethod(dispatch, contributionType, switches, countryId);
 
   const { firstName, lastName, email } = state.page.user;
   dispatch(updateUserFormData({ firstName, lastName, email }));
@@ -42,4 +48,4 @@ const init = (store: Store<State, Action, Dispatch<Action>>) => {
 
 // ----- Exports ----- //
 
-export { init };
+export { init, setPaymentMethod };

--- a/assets/pages/new-contributions-landing/contributionsLandingReducer.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingReducer.js
@@ -111,6 +111,7 @@ function createFormReducer(countryGroupId: CountryGroupId) {
           ...state,
           contributionType: action.contributionType,
           showOtherAmount: false,
+          paymentMethod: action.paymentMethodToSelect,
           formData: { ...state.formData },
         };
 


### PR DESCRIPTION
## Why are you doing this?
Previously, if you changed the contribution type, for example from `Monthly` to `Single`, the payment type didn't change. 

Allow me to illustrate with an example. If you were on the UK page and `Direct Debit` was selected on the `Monthly` tab and then you changed to `Single`, the payment button would still be the `Direct Debit` button and none of the radio buttons would be selected (as Direct Debit isn't a valid payment option for Single contributions), when in fact the button should be the `Stripe` payment button and the credit card radio button should be selected.

This PR fixes this issue. 

@joelochlann @regiskuckaertz 