### PR TITLE
[NPF] Fix authentication bug in set-password endpoint

### DIFF
--- a/app/models/identity/CookieResponse.scala
+++ b/app/models/identity/CookieResponse.scala
@@ -10,10 +10,9 @@ case class CookieResponse(key: String, value: String, sessionCookie: Option[Bool
 case class CookiesResponse(expiresAt: DateTime, values: List[CookieResponse])
 
 object CookiesResponse {
-  val dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
   implicit val jodaDateReads = Reads[DateTime](js =>
     js.validate[String].map[DateTime](dtString =>
-      DateTime.parse(dtString, DateTimeFormat.forPattern(dateFormat))))
+      DateTime.parse(dtString)))
   implicit val readsCookieResponse: Reads[CookieResponse] = Json.reads[CookieResponse]
   implicit val readsCookiesResponse: Reads[CookiesResponse] = Json.reads[CookiesResponse]
 }

--- a/app/services/HttpIdentityService.scala
+++ b/app/services/HttpIdentityService.scala
@@ -86,7 +86,7 @@ class HttpIdentityService(apiUrl: String, apiClientToken: String)(implicit wsCli
       List("X-Guest-Registration-Token" -> guestAccountRegistrationToken, "Content-Type" -> "application/json")
     val urlParameters = List("validate-email" -> "0")
     request(s"guest/password")
-      .withHttpHeaders(headers: _*)
+      .addHttpHeaders(headers: _*)
       .withQueryStringParameters(urlParameters: _*)
       .put(payload)
       .attemptT


### PR DESCRIPTION
## Why are you doing this?
Turns out that `withHttpHeaders` replaces the headers in the request, meaning that the Authentication header was being overridden . We want `addHttpHeaders`

also a small formatting bug fix