### PR TITLE
Update patrons image, link and copy

### DIFF
--- a/assets/components/otherProduct/otherProduct.jsx
+++ b/assets/components/otherProduct/otherProduct.jsx
@@ -8,6 +8,8 @@ import CtaLink from 'components/ctaLink/ctaLink';
 import GridImage from 'components/gridImage/gridImage';
 
 import { classNameWithModifiers } from 'helpers/utilities';
+import type { ImageType } from 'helpers/theGrid';
+
 
 
 // ----- Props ----- //
@@ -21,6 +23,7 @@ type PropTypes = {
   ctaText: string,
   ctaUrl: string,
   ctaAccessibilityHint: string,
+  imgType?: ImageType,
 };
 
 
@@ -36,6 +39,7 @@ export default function OtherProduct(props: PropTypes) {
           srcSizes={[1000, 500, 140]}
           sizes="(max-width: 480px) 90vw, (max-width: 660px) 400px, 270px"
           altText={props.imgAlt}
+          imgType={props.imgType}
         />
       </div>
       <h2 className="component-other-product__heading">{props.heading}</h2>
@@ -55,4 +59,5 @@ export default function OtherProduct(props: PropTypes) {
 
 OtherProduct.defaultProps = {
   modifierClass: '',
+  imgType: 'jpg',
 };

--- a/assets/components/otherProduct/otherProduct.jsx
+++ b/assets/components/otherProduct/otherProduct.jsx
@@ -10,8 +10,6 @@ import GridImage from 'components/gridImage/gridImage';
 import { classNameWithModifiers } from 'helpers/utilities';
 import type { ImageType } from 'helpers/theGrid';
 
-
-
 // ----- Props ----- //
 
 type PropTypes = {

--- a/assets/components/patronsEvents/patronsEvents.jsx
+++ b/assets/components/patronsEvents/patronsEvents.jsx
@@ -8,8 +8,6 @@ import PageSection from 'components/pageSection/pageSection';
 import OtherProduct from 'components/otherProduct/otherProduct';
 
 import { getMemLink, getPatronsLink } from 'helpers/externalLinks';
-import type { ImageType } from 'helpers/theGrid';
-
 
 // ----- Types ----- //
 
@@ -33,7 +31,7 @@ export default function PatronsEvents(props: PropTypes) {
         ctaText="Find out more"
         ctaUrl={getPatronsLink(props.campaignCode)}
         ctaAccessibilityHint="Find out more about becoming a Patron"
-        imgType='png'
+        imgType="png"
       />
       <OtherProduct
         modifierClass="live-events"

--- a/assets/components/patronsEvents/patronsEvents.jsx
+++ b/assets/components/patronsEvents/patronsEvents.jsx
@@ -27,7 +27,7 @@ export default function PatronsEvents(props: PropTypes) {
         gridImg="windrushGreyscale"
         imgAlt="passengers aboard windrush ship"
         heading="Patrons"
-        copy="Support from our patrons is crucial to ensure that generations to come will be able to enjoy The Guardian."
+        copy="Support from our Patrons is crucial to ensure that generations to come will be able to enjoy The Guardian."
         ctaText="Find out more"
         ctaUrl={getPatronsLink(props.campaignCode)}
         ctaAccessibilityHint="Find out more about becoming a Patron"

--- a/assets/components/patronsEvents/patronsEvents.jsx
+++ b/assets/components/patronsEvents/patronsEvents.jsx
@@ -7,7 +7,8 @@ import React from 'react';
 import PageSection from 'components/pageSection/pageSection';
 import OtherProduct from 'components/otherProduct/otherProduct';
 
-import { getMemLink } from 'helpers/externalLinks';
+import { getMemLink, getPatronsLink } from 'helpers/externalLinks';
+import type { ImageType } from 'helpers/theGrid';
 
 
 // ----- Types ----- //
@@ -25,13 +26,14 @@ export default function PatronsEvents(props: PropTypes) {
     <PageSection heading="Other ways you can support us" modifierClass="patrons-events">
       <OtherProduct
         modifierClass="patrons"
-        gridImg="newsroom"
-        imgAlt="newsroom"
+        gridImg="windrushGreyscale"
+        imgAlt="passengers aboard windrush ship"
         heading="Patrons"
-        copy="The Patron tier is for those who want a deeper relationship with the Guardian and its journalists"
+        copy="Patrons support is crucial to ensuring that generations to come will be able to enjoy The Guardian."
         ctaText="Find out more"
-        ctaUrl={getMemLink('patrons', props.campaignCode)}
+        ctaUrl={getPatronsLink(props.campaignCode)}
         ctaAccessibilityHint="Find out more about becoming a Patron"
+        imgType='png'
       />
       <OtherProduct
         modifierClass="live-events"

--- a/assets/components/patronsEvents/patronsEvents.jsx
+++ b/assets/components/patronsEvents/patronsEvents.jsx
@@ -27,7 +27,7 @@ export default function PatronsEvents(props: PropTypes) {
         gridImg="windrushGreyscale"
         imgAlt="passengers aboard windrush ship"
         heading="Patrons"
-        copy="Patrons support is crucial to ensuring that generations to come will be able to enjoy The Guardian."
+        copy="Support from our patrons is crucial to ensure that generations to come will be able to enjoy The Guardian."
         ctaText="Find out more"
         ctaUrl={getPatronsLink(props.campaignCode)}
         ctaAccessibilityHint="Find out more about becoming a Patron"

--- a/assets/components/patronsEvents/patronsEvents.scss
+++ b/assets/components/patronsEvents/patronsEvents.scss
@@ -43,10 +43,6 @@
       padding-right: $gu-h-spacing;
       padding-left: $gu-h-spacing;
     }
-
-    .component-grid-image {
-      margin-left: -90px;
-    }
   }
 
   .component-other-product--live-events {

--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -34,6 +34,7 @@ export type SubsUrls = {
 // ----- Setup ----- //
 
 const subsUrl = 'https://subscribe.theguardian.com';
+const patronsUrl = 'https://patrons.theguardian.com';
 const defaultIntCmp = 'gdnwb_copts_bundles_landing_default';
 const iOSAppUrl = 'https://itunes.apple.com/app/the-guardian/id409128287?mt=8';
 const androidAppUrl = 'https://play.google.com/store/apps/details?id=com.guardian';
@@ -42,7 +43,6 @@ const dailyEditionUrl = 'https://itunes.apple.com/app/guardian-observer-daily-ed
 const memUrls: {
   [MemProduct]: string,
 } = {
-  patrons: 'https://membership.theguardian.com/patrons',
   events: 'https://membership.theguardian.com/events',
 };
 
@@ -113,6 +113,14 @@ function getMemLink(product: MemProduct, intCmp: ?string): string {
 
   return `${memUrls[product]}?${params.toString()}`;
 
+}
+
+function getPatronsLink(intCmp: ?string): string {
+
+  const params = new URLSearchParams();
+  params.append('INTCMP', intCmp || defaultIntCmp);
+
+  return `${patronsUrl}?${params.toString()}`;
 }
 
 function buildParamString(
@@ -213,6 +221,7 @@ function getDigitalCheckout(
 export {
   getSubsLinks,
   getMemLink,
+  getPatronsLink,
   getDigitalCheckout,
   iOSAppUrl,
   androidAppUrl,

--- a/assets/helpers/theGrid.js
+++ b/assets/helpers/theGrid.js
@@ -33,6 +33,7 @@ export const imageCatalogue: {
   premiumTierAU: '4b6fd9805c7d0a88b4b71a683c4b46279a410b9d/0_0_1610_1120',
   dailyEdition: '168cab5197d7b4c5d9e05eb3ff2801b2929f2995/0_0_644_448',
   windrush: '4addd475d3af57d908fa87124e556ab96fddb2e7/0_0_370_370',
+  windrushGreyscale: '8637bed472263161e35de986b463ed0c3675987d/0_0_830_830',
   zuck: 'e6142101bc909caee866be05ced677c54e9d3b4e/0_0_374_374',
   digitalSubscriptionHeaderDesktop: '01f9a081d0f78cb057ca585725f2742bed5a98fb/0_0_4045_1945',
   digitalSubscriptionHeaderDesktopAU: 'f46b1e2c498ac4f1ebec1b2620b6e80583e4348f/0_0_4045_1945',


### PR DESCRIPTION
**Do not merge until updated patrons link is available**

## Why are you doing this?
Keeping the [UK landing page](https://support.theguardian.com/uk) up to date 😎 

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/JPU3c6Zj/1868-update-patrons-link-copy-and-image-on-showcase-page-to-reflect-new-patrons-scheme)

## Changes
On the UK landing page, patrons section
* Update the CTA link
* Update the copy
* Update image

## Screenshots

| **mobile**  | **tablet**           | **web**   |
| ------------- |:-------------:| -----------|
| <img src="https://user-images.githubusercontent.com/3072877/46356112-f800ef80-c659-11e8-8f10-1067ea1a73c1.png" alt="updates for, mobile" height="200"/>  | <img src="https://user-images.githubusercontent.com/3072877/46356030-d6076d00-c659-11e8-87c7-393b7baa55c1.png" alt="updates for, tablet" height="200"/>  | <img src="https://user-images.githubusercontent.com/3072877/46355963-bb34f880-c659-11e8-8007-54bb173a0f02.png" alt="updates for, web" height="200"/>  |