### PR TITLE
Em decimal check

### DIFF
--- a/assets/helpers/__tests__/formValidation.js
+++ b/assets/helpers/__tests__/formValidation.js
@@ -1,0 +1,34 @@
+// @flow
+
+// ----- Imports ----- //
+
+import { maxTwoDecimals } from '../formValidation';
+
+// ----- Tests ----- //
+
+
+describe('formValidation', () => {
+
+  describe('maxTwoDecimals', () => {
+
+    it('should return true for an int', () => {
+      expect(maxTwoDecimals('3')).toEqual(true);
+    });
+
+    it('should return true for one dp', () => {
+      expect(maxTwoDecimals('3.2')).toEqual(true);
+    });
+
+    it('should return true for two dp', () => {
+      expect(maxTwoDecimals('3.22')).toEqual(true);
+    });
+
+    it('should return false for three dp', () => {
+      expect(maxTwoDecimals('3.222')).toEqual(false);
+    });
+
+    it('should return false for invalid number', () => {
+      expect(maxTwoDecimals('3e22')).toEqual(false);
+    });
+  });
+});

--- a/assets/helpers/__tests__/formValidation.js
+++ b/assets/helpers/__tests__/formValidation.js
@@ -19,6 +19,10 @@ describe('formValidation', () => {
       expect(maxTwoDecimals('3.2')).toEqual(true);
     });
 
+    it('should return true for decimal point and no decimal places', () => {
+      expect(maxTwoDecimals('3.')).toEqual(true);
+    });
+
     it('should return true for two dp', () => {
       expect(maxTwoDecimals('3.22')).toEqual(true);
     });
@@ -30,5 +34,14 @@ describe('formValidation', () => {
     it('should return false for invalid number', () => {
       expect(maxTwoDecimals('3e22')).toEqual(false);
     });
+
+    it('should return false for empty string', () => {
+      expect(maxTwoDecimals('')).toEqual(false);
+    });
+
+    it('should return false for empty string', () => {
+      expect(maxTwoDecimals('-12')).toEqual(false);
+    });
+
   });
 });

--- a/assets/helpers/formValidation.js
+++ b/assets/helpers/formValidation.js
@@ -11,7 +11,7 @@ export const isNotEmpty: string => boolean = input => !!input && input.trim() !=
 export const isValidEmail: string => boolean = input => new RegExp(emailRegexPattern).test(input);
 export const isLargerOrEqual: (number, string) => boolean = (min, input) => min <= parseFloat(input);
 export const isSmallerOrEqual: (number, string) => boolean = (max, input) => parseFloat(input) <= max;
-export const maxTwoDecimals: string => boolean = input => new RegExp('^\\d+.?\\d{0,2}$').test(input);
+export const maxTwoDecimals: string => boolean = input => new RegExp('^\\d+\\.?\\d{0,2}$').test(input);
 
 export const checkFirstName: string => boolean = isNotEmpty;
 export const checkLastName: string => boolean = isNotEmpty;

--- a/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -130,17 +130,6 @@ const getAmount = (props: PropTypes) =>
     ? props.otherAmount
     : props.selectedAmounts[props.contributionType].value);
 
-const isNotEmpty: string => boolean = input => input.trim() !== '';
-const isValidEmail: string => boolean = input => new RegExp(emailRegexPattern).test(input);
-const isLargerOrEqual: (number, string) => boolean = (min, input) => min <= parseFloat(input);
-const isSmallerOrEqual: (number, string) => boolean = (max, input) => parseFloat(input) <= max;
-const maxTwoDecimals: string => boolean = input => new RegExp('^\\d+\\.?\\d{0,2}$').test(input);
-
-const checkFirstName: string => boolean = isNotEmpty;
-const checkLastName: string => boolean = isNotEmpty;
-const checkState: (string | null) => boolean = s => typeof s === 'string' && isNotEmpty(s);
-const checkEmail: string => boolean = input => isNotEmpty(input) && isValidEmail(input);
-
 // ----- Event handlers ----- //
 
 function onSubmit(props: PropTypes): Event => void {

--- a/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -34,7 +34,7 @@ import {
   isLargerOrEqual,
   maxTwoDecimals,
   emailRegexPattern,
-} from '../formValidation';
+} from 'helpers/formValidation';
 
 import { NewContributionType } from './ContributionType';
 import { NewContributionAmount } from './ContributionAmount';

--- a/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -130,6 +130,16 @@ const getAmount = (props: PropTypes) =>
     ? props.otherAmount
     : props.selectedAmounts[props.contributionType].value);
 
+const isNotEmpty: string => boolean = input => input.trim() !== '';
+const isValidEmail: string => boolean = input => new RegExp(emailRegexPattern).test(input);
+const isLargerOrEqual: (number, string) => boolean = (min, input) => min <= parseFloat(input);
+const isSmallerOrEqual: (number, string) => boolean = (max, input) => parseFloat(input) <= max;
+const maxTwoDecimals: string => boolean = input => new RegExp('^\\d+\\.?\\d{0,2}$').test(input);
+
+const checkFirstName: string => boolean = isNotEmpty;
+const checkLastName: string => boolean = isNotEmpty;
+const checkState: (string | null) => boolean = s => typeof s === 'string' && isNotEmpty(s);
+const checkEmail: string => boolean = input => isNotEmpty(input) && isValidEmail(input);
 
 // ----- Event handlers ----- //
 

--- a/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -32,6 +32,7 @@ import {
   isNotEmpty,
   isSmallerOrEqual,
   isLargerOrEqual,
+  maxTwoDecimals,
   emailRegexPattern,
 } from '../formValidation';
 
@@ -181,7 +182,8 @@ function ContributionForm(props: PropTypes) {
   const checkOtherAmount: string => boolean = input =>
     isNotEmpty(input)
     && isLargerOrEqual(config[props.countryGroupId][props.contributionType].min, input)
-    && isSmallerOrEqual(config[props.countryGroupId][props.contributionType].max, input);
+    && isSmallerOrEqual(config[props.countryGroupId][props.contributionType].max, input)
+    && maxTwoDecimals(input);
 
   const onPaymentAuthorisation = (paymentAuthorisation: PaymentAuthorisation) => {
     props.onWaiting(true);

--- a/assets/pages/new-contributions-landing/components/SetPassword/SetPassword.jsx
+++ b/assets/pages/new-contributions-landing/components/SetPassword/SetPassword.jsx
@@ -12,11 +12,11 @@ import { setPasswordGuest } from 'helpers/paymentIntegrations/readerRevenueApis'
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import SvgPasswordKey from 'components/svgs/passwordKey';
 import SvgEnvelope from 'components/svgs/envelope';
+import { checkEmail, emailRegexPattern } from 'helpers/formValidation';
 
 import { NewContributionTextInput } from '../ContributionTextInput';
 import { type ThankYouPageStage } from '../../contributionsLandingReducer';
 import { setThankYouPageStage, setPasswordHasBeenSubmitted, updatePassword, type Action } from '../../contributionsLandingActions';
-import { checkEmail, emailRegexPattern } from '../../formValidation';
 import { ButtonWithRightArrow } from '../ButtonWithRightArrow';
 
 // ----- Types ----- //

--- a/assets/pages/new-contributions-landing/formValidation.js
+++ b/assets/pages/new-contributions-landing/formValidation.js
@@ -11,6 +11,7 @@ export const isNotEmpty: string => boolean = input => !!input && input.trim() !=
 export const isValidEmail: string => boolean = input => new RegExp(emailRegexPattern).test(input);
 export const isLargerOrEqual: (number, string) => boolean = (min, input) => min <= parseFloat(input);
 export const isSmallerOrEqual: (number, string) => boolean = (max, input) => parseFloat(input) <= max;
+export const maxTwoDecimals: string => boolean = input => new RegExp('^\\d+.?\\d{0,2}$').test(input);
 
 export const checkFirstName: string => boolean = isNotEmpty;
 export const checkLastName: string => boolean = isNotEmpty;


### PR DESCRIPTION
## Why are you doing this?
To surface an error when the payment amount is invalid. Currently amounts with more than two decimals prevent a user from proceeding to the next step in the payment flow but doesn't warn them that the Other amount field is the badun. 
<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/iJoiL98o/13-nfp-validation-on-other-amount-field)

## Changes

* Adds custom verification on Other payment amount to check that no more than two decimals are used. 

## Screenshots
![screen shot 2018-10-03 at 14 13 25](https://user-images.githubusercontent.com/8484757/46412764-4e803380-c717-11e8-977c-48f0ff1b2f1d.jpg)


