### PR TITLE
add contribution survey to thank you pages

### DIFF
--- a/assets/components/contributionsThankYou/contributionsThankYouPage.jsx
+++ b/assets/components/contributionsThankYou/contributionsThankYouPage.jsx
@@ -14,6 +14,7 @@ import SpreadTheWord from 'components/spreadTheWord/spreadTheWord';
 import EmailConfirmation from './emailConfirmation';
 import DirectDebitDetails, { type PropTypes as DirectDebit } from './directDebitDetails';
 import type { CountryGroupId } from '../../helpers/internationalisation/countryGroup';
+import ContributionsSurveySection from '../survey/contributionsSurveySection';
 
 // ---- Types ----- //
 
@@ -52,11 +53,15 @@ export default function ContributionsThankYouPage(props: PropTypes) {
 
 function BodyCopy(props: PropTypes) {
   if (props.contributionType === 'ONE_OFF') {
-    return null;
+    return <ContributionsSurveySection />;
   } else if (props.directDebit) {
     return (
-      <DirectDebitDetails {...props.directDebit} />
+      <div className="component-direct-debit-details__container">
+        <DirectDebitDetails {...props.directDebit} />
+        <ContributionsSurveySection />
+      </div>
     );
+  } else {
+    return <EmailConfirmation/>;
   }
-  return <EmailConfirmation />;
 }

--- a/assets/components/contributionsThankYou/emailConfirmation.jsx
+++ b/assets/components/contributionsThankYou/emailConfirmation.jsx
@@ -5,6 +5,7 @@
 import React from 'react';
 
 import PageSection from 'components/pageSection/pageSection';
+import ContributionsSurvey from '../survey/contributionsSurvey';
 
 // ----- Component ----- //
 
@@ -16,6 +17,7 @@ export default function EmailConfirmation() {
         <p className="component-email-confirmation__copy">
           Look out for an email confirming your recurring payment.
         </p>
+        <ContributionsSurvey />
       </PageSection>
     </div>
   );

--- a/assets/components/survey/contributionsSurvey.jsx
+++ b/assets/components/survey/contributionsSurvey.jsx
@@ -1,0 +1,27 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+import CtaLink from '../ctaLink/ctaLink';
+
+// ----- Component ----- //
+
+export default function ContributionsSurvey() {
+
+    return (
+        <div className="component-contributions-survey">
+            <p>
+                Please tell us about your contribution to The Guardian by filling out this short form.
+            </p>
+            <CtaLink
+                text="Share your thoughts"
+                url="https://www.surveymonkey.co.uk/r/CM6NPH2"
+                accessibilityHint="Please tell us about your contribution to The Guardian by filling out this short form."
+                modifierClasses={['survey']}
+            />
+        </div>
+    );
+
+}

--- a/assets/components/survey/contributionsSurveySection.jsx
+++ b/assets/components/survey/contributionsSurveySection.jsx
@@ -1,0 +1,23 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+import PageSection from 'components/pageSection/pageSection';
+import ContributionsSurvey from './contributionsSurvey';
+
+
+// ----- Component ----- //
+
+export default function ContributionsSurveySection() {
+
+    return (
+        <div className="component-contributions-survey-section">
+            <PageSection modifierClass="component-contributions-survey-section">
+                <ContributionsSurvey />
+            </PageSection>
+        </div>
+    );
+
+}

--- a/assets/components/survey/survey.scss
+++ b/assets/components/survey/survey.scss
@@ -1,0 +1,34 @@
+.component-contributions-survey {
+  .component-cta-link {
+    margin-bottom: $gu-v-spacing * 3;
+    margin-top: $gu-v-spacing * 2;
+
+    @include mq($from: mobileMedium) {
+      width: 300px;
+    }
+  }
+
+  .component-cta-link--survey {
+    background-color: gu-colour(news-garnett-highlight);
+    color: gu-colour(garnett-neutral-1);
+
+    &:hover {
+      background-color: darken(gu-colour(news-garnett-highlight), 5%);
+    }
+
+    .svg-arrow-right-straight { fill: gu-colour(garnett-neutral-1) }
+
+  }
+
+  @include mq($from: desktop) {
+    padding-left: $gu-h-spacing;
+  }
+}
+
+.component-contributions-survey-section {
+  border-bottom: 1px solid gu-colour(garnett-neutral-4);
+
+  .component-contributions-survey {
+    padding-top: $gu-v-spacing / 2;
+  }
+}

--- a/assets/components/survey/surveySection.scss
+++ b/assets/components/survey/surveySection.scss
@@ -1,0 +1,7 @@
+.component-contributions-survey-section {
+  border-bottom: 1px solid gu-colour(garnett-neutral-4);
+
+  .component-contributions-survey {
+    padding-top: $gu-v-spacing / 2;
+  }
+}

--- a/assets/pages/oneoff-contributions/oneoffContributions.scss
+++ b/assets/pages/oneoff-contributions/oneoffContributions.scss
@@ -38,7 +38,8 @@
 @import '~components/yourDetails/yourDetails';
 @import '~components/legal/legalSection/legalSection';
 @import '~components/contributionsCheckout/contributionsCheckout';
-
+@import '~components/survey/survey';
+@import '~components/survey/surveySection';
 
 // ----- Page-Specific Styles ----- //
 

--- a/assets/pages/regular-contributions/regularContributions.scss
+++ b/assets/pages/regular-contributions/regularContributions.scss
@@ -41,6 +41,7 @@
 @import '~components/yourDetails/yourDetails';
 @import '~components/legal/legalSection/legalSection';
 @import '~components/contributionsCheckout/contributionsCheckout';
+@import '~components/survey/survey';
 
 // ----- Page-Specific Styles ----- //
 


### PR DESCRIPTION
## Why are you doing this?

Add new survey for people after the ycontributed.  This is needed to get plenty of testimonials to understand the motivations of contributors.

This is based pretty much character for character on https://github.com/guardian/support-frontend/pull/829  it is bascially just a repeat of the original with a new link.

[**Trello Card**](https://trello.com/c/XTSgKu0q/23-testimonials-survey-ask-2018)

## Screenshots

recurring pending
![image](https://user-images.githubusercontent.com/7304387/46530218-e8b7b700-c890-11e8-819d-b9afe78565e5.png)

direct debit
![image](https://user-images.githubusercontent.com/7304387/46530662-68925100-c892-11e8-9ce2-51994e5836d1.png)

one off
![image](https://user-images.githubusercontent.com/7304387/46530703-88297980-c892-11e8-8ad7-386c346ff6f6.png)

@ionamckendrick @jranks123 @joelochlann 