### PR TITLE
Drop a cookie to track Awin affiliate referrals

### DIFF
--- a/assets/helpers/page/page.js
+++ b/assets/helpers/page/page.js
@@ -33,6 +33,7 @@ import {
   type CountryGroupId,
 } from 'helpers/internationalisation/countryGroup';
 import { type OptimizeExperiments, getOptimizeExperiments } from 'helpers/tracking/optimize';
+import storeReferrer from 'helpers/tracking/awin';
 
 import { type Action } from './pageActions';
 
@@ -69,6 +70,7 @@ function doNotTrack(): boolean {
 function analyticsInitialisation(participations: Participations): void {
   if (!(doNotTrack())) {
     googleTagManager.init(participations);
+    storeReferrer();
   }
   // Logging.
   logger.init();

--- a/assets/helpers/tracking/awin.js
+++ b/assets/helpers/tracking/awin.js
@@ -1,0 +1,17 @@
+// @flow
+
+import { set as setCookie } from 'helpers/cookie';
+
+export default function storeReferrer() {
+  const cookieExpiryDays = 30;
+  const parsedUrl = new URL(window.location.href);
+  const utmSource = parsedUrl.searchParams.get('utm_source');
+  const utmMedium = parsedUrl.searchParams.get('utm_medium');
+  const gclid = parsedUrl.searchParams.get('gclid'); // Google AdWords
+  if (utmSource && utmMedium) {
+    setCookie('gu_referrer_channel', `${utmSource}&${utmMedium}`, cookieExpiryDays);
+  } else if (gclid) {
+    setCookie('gu_referrer_channel', 'google&adwords', cookieExpiryDays);
+  }
+
+}


### PR DESCRIPTION
## Why are you doing this?

Now that we are redirecting subscribe traffic to the support site, the affiliate tracking is getting lost which will lead to errors in attribution. This PR makes sure that we store the referrer in a cookie readable on subs when users first arrive on our site.

[**Trello Card**](https://trello.com/c/vEW5B56Q/1905-add-awin-to-support-frontend)