### PR TITLE
Merge appstore link tracking

### DIFF
--- a/assets/components/subscriptionBundles/appCtaTracking.js
+++ b/assets/components/subscriptionBundles/appCtaTracking.js
@@ -1,0 +1,20 @@
+// @flow
+
+import { type ComponentAbTest, type SubscriptionProduct } from 'helpers/subscriptions';
+import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
+import { appStoreCtaClick } from 'helpers/tracking/googleTagManager';
+
+export default function trackAppStoreLink(
+  id: string,
+  product: SubscriptionProduct,
+  abTest: ComponentAbTest | null,
+): () => void {
+  return () => {
+    try {
+      sendTrackingEventsOnClick(id, product, abTest)();
+      appStoreCtaClick();
+    } catch (e) {
+      console.log('Error sending tracking event');
+    }
+  };
+}

--- a/assets/components/subscriptionBundles/dailyEdition.jsx
+++ b/assets/components/subscriptionBundles/dailyEdition.jsx
@@ -5,19 +5,20 @@
 import React from 'react';
 import SubscriptionBundle from 'components/subscriptionBundle/subscriptionBundle';
 import { gridImageProperties } from 'components/threeSubscriptions/helpers/gridImageProperties';
-
-import { appStoreCtaClick } from 'helpers/tracking/googleTagManager';
 import { addQueryParamsToURL } from 'helpers/url';
 import { dailyEditionUrl } from 'helpers/externalLinks';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import type { ComponentAbTest } from 'helpers/subscriptions';
 import { displayPrice } from 'helpers/subscriptions';
 import type { HeadingSize } from 'components/heading/heading';
+import trackAppStoreLink from 'components/subscriptionBundles/appCtaTracking';
 
 
 export default function DailyEdition(props: {
   headingSize: HeadingSize,
   countryGroupId: CountryGroupId,
   appReferrer: string,
+  abTest: ComponentAbTest | null,
 }) {
   return (
     <SubscriptionBundle
@@ -40,9 +41,13 @@ export default function DailyEdition(props: {
           url: addQueryParamsToURL(dailyEditionUrl, { referrer: props.appReferrer }),
           accessibilityHint: 'Proceed to buy the daily edition app for iPad in the app store',
           modifierClasses: ['border'],
-          onClick: appStoreCtaClick,
+          onClick: trackAppStoreLink('daily_edition_ios_cta', 'DailyEdition', props.abTest),
         },
       ]}
     />
   );
 }
+
+DailyEdition.defaultProps = {
+  abTest: null,
+};

--- a/assets/components/subscriptionBundles/premiumTier.jsx
+++ b/assets/components/subscriptionBundles/premiumTier.jsx
@@ -8,9 +8,10 @@ import { type HeadingSize } from 'components/heading/heading';
 import SubscriptionBundle from 'components/subscriptionBundle/subscriptionBundle';
 import { gridImageProperties } from 'components/threeSubscriptions/helpers/gridImageProperties';
 
-import { iOSAppUrl, androidAppUrl } from 'helpers/externalLinks';
+import { androidAppUrl, iOSAppUrl } from 'helpers/externalLinks';
 import { addQueryParamsToURL } from 'helpers/url';
-import { appStoreCtaClick } from 'helpers/tracking/googleTagManager';
+import trackAppStoreLink from 'components/subscriptionBundles/appCtaTracking';
+import type { ComponentAbTest } from 'helpers/subscriptions';
 
 
 // ----- Component ----- //
@@ -19,6 +20,7 @@ function PremiumTier(props: {
   headingSize: HeadingSize,
   subheading: string,
   referrer: string,
+  abTest: ComponentAbTest | null,
 }) {
 
   return (
@@ -42,20 +44,24 @@ function PremiumTier(props: {
           url: addQueryParamsToURL(iOSAppUrl, { referrer: props.referrer }),
           accessibilityHint: 'Proceed to buy the premium app in the app store',
           modifierClasses: ['border', 'ios'],
-          onClick: appStoreCtaClick,
+          onClick: trackAppStoreLink('premium_tier_ios_cta', 'PremiumTier', props.abTest),
         },
         {
           text: 'Buy on Google Play',
           url: addQueryParamsToURL(androidAppUrl, { referrer: props.referrer }),
           accessibilityHint: 'Proceed to buy the premium app in the play store',
           modifierClasses: ['border', 'android'],
-          onClick: appStoreCtaClick,
+          onClick: trackAppStoreLink('premium_tier_android_cta', 'PremiumTier', props.abTest),
         },
       ]}
     />
   );
 
 }
+
+PremiumTier.defaultProps = {
+  abTest: null,
+};
 
 
 // ----- Exports ----- //

--- a/assets/components/subscriptionsByCountryGroup/components/digitalSection.jsx
+++ b/assets/components/subscriptionsByCountryGroup/components/digitalSection.jsx
@@ -35,11 +35,13 @@ function DigitalSection(props: PropTypes) {
         headingSize={props.headingSize}
         referrer={props.appReferrer}
         subheading={displayPrice('PremiumTier', props.countryGroupId)}
+        abTest={props.abTest}
       />
       <DailyEdition
         headingSize={props.headingSize}
         countryGroupId={props.countryGroupId}
         appReferrer={props.appReferrer}
+        abTest={props.abTest}
       />
       <DigitalPack
         countryGroupId={props.countryGroupId}


### PR DESCRIPTION
## Why are you doing this?
We need two different tracking events to occur when app store links are clicked:
1. Standard Google Analytics CTA click tracking which allows us to analyse the proportion of clicks to each CTA.
2. AppNexus pixel tracking to allow us to track the success of programmatic campaigns across Subscriptions and Support.

Previously we only had the second of these on our app store CTAs, this PR adds the first as well.

[**Trello Card**](https://trello.com/c/aXN0q1Da/2000-reinstate-click-tracking-for-app-clicks-on-subscriptions-landing-pages)

## Changes
Wrap the two tracking calls in a wrapper method and call this from the Premium tier and Daily Edition CTAs
