### PR TITLE
Use ideal country code in Apple app store links where possible

### DIFF
--- a/assets/components/subscriptionBundles/dailyEdition.jsx
+++ b/assets/components/subscriptionBundles/dailyEdition.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import SubscriptionBundle from 'components/subscriptionBundle/subscriptionBundle';
 import { gridImageProperties } from 'components/threeSubscriptions/helpers/gridImageProperties';
 import { addQueryParamsToURL } from 'helpers/url';
-import { dailyEditionUrl } from 'helpers/externalLinks';
+import { getDailyEditionUrl } from 'helpers/externalLinks';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { ComponentAbTest } from 'helpers/subscriptions';
 import { displayPrice } from 'helpers/subscriptions';
@@ -19,6 +19,7 @@ export default function DailyEdition(props: {
   countryGroupId: CountryGroupId,
   appReferrer: string,
   abTest: ComponentAbTest | null,
+  countryGroupId: CountryGroupId,
 }) {
   return (
     <SubscriptionBundle
@@ -38,7 +39,7 @@ export default function DailyEdition(props: {
       ctas={[
         {
           text: 'Buy in the App Store',
-          url: addQueryParamsToURL(dailyEditionUrl, { referrer: props.appReferrer }),
+          url: addQueryParamsToURL(getDailyEditionUrl(props.countryGroupId), { referrer: props.appReferrer }),
           accessibilityHint: 'Proceed to buy the daily edition app for iPad in the app store',
           modifierClasses: ['border'],
           onClick: trackAppStoreLink('daily_edition_ios_cta', 'DailyEdition', props.abTest),

--- a/assets/components/subscriptionBundles/premiumTier.jsx
+++ b/assets/components/subscriptionBundles/premiumTier.jsx
@@ -8,10 +8,11 @@ import { type HeadingSize } from 'components/heading/heading';
 import SubscriptionBundle from 'components/subscriptionBundle/subscriptionBundle';
 import { gridImageProperties } from 'components/threeSubscriptions/helpers/gridImageProperties';
 
-import { androidAppUrl, iOSAppUrl } from 'helpers/externalLinks';
+import { androidAppUrl, getIosAppUrl } from 'helpers/externalLinks';
 import { addQueryParamsToURL } from 'helpers/url';
 import trackAppStoreLink from 'components/subscriptionBundles/appCtaTracking';
 import type { ComponentAbTest } from 'helpers/subscriptions';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 
 // ----- Component ----- //
@@ -21,6 +22,7 @@ function PremiumTier(props: {
   subheading: string,
   referrer: string,
   abTest: ComponentAbTest | null,
+  countryGroupId: CountryGroupId
 }) {
 
   return (
@@ -41,7 +43,7 @@ function PremiumTier(props: {
       ctas={[
         {
           text: 'Buy in the App Store',
-          url: addQueryParamsToURL(iOSAppUrl, { referrer: props.referrer }),
+          url: addQueryParamsToURL(getIosAppUrl(props.countryGroupId), { referrer: props.referrer }),
           accessibilityHint: 'Proceed to buy the premium app in the app store',
           modifierClasses: ['border', 'ios'],
           onClick: trackAppStoreLink('premium_tier_ios_cta', 'PremiumTier', props.abTest),

--- a/assets/components/subscriptionsByCountryGroup/components/digitalSection.jsx
+++ b/assets/components/subscriptionsByCountryGroup/components/digitalSection.jsx
@@ -36,6 +36,7 @@ function DigitalSection(props: PropTypes) {
         referrer={props.appReferrer}
         subheading={displayPrice('PremiumTier', props.countryGroupId)}
         abTest={props.abTest}
+        countryGroupId={props.countryGroupId}
       />
       <DailyEdition
         headingSize={props.headingSize}

--- a/assets/components/subscriptionsByCountryGroup/components/internationalSection.jsx
+++ b/assets/components/subscriptionsByCountryGroup/components/internationalSection.jsx
@@ -28,6 +28,7 @@ function InternationalSection(props: {
         headingSize={props.headingSize}
         referrer={props.appReferrer}
         subheading="7-day free trial"
+        countryGroupId={props.countryGroupId}
       />
       <DigitalPack
         countryGroupId={props.countryGroupId}

--- a/assets/helpers/__tests__/externalLinksTest.js
+++ b/assets/helpers/__tests__/externalLinksTest.js
@@ -16,7 +16,7 @@ describe('externalLinks', () => {
   const ca: CountryGroupId = 'Canada';
   const nz: CountryGroupId = 'NZDCountries';
 
-  const appStoreRoot = 'https://itunes.apple.com/';
+  const appStoreRoot = 'https://itunes.apple.com';
   const iosPremiumAppProduct = 'app/the-guardian/id409128287';
   const iosDailyEditionProduct = 'app/guardian-observer-daily-edition/id452707806';
   const iosPremiumTail = '?mt=8';
@@ -24,68 +24,68 @@ describe('externalLinks', () => {
   // NOTE: all comparisons ignore added parameters
 
   describe('iOSPremiumAppLink', () => {
-    const ukExpectedLink = appStoreRoot + 'gb/' + iosPremiumAppProduct + iosPremiumTail;
+    const ukExpectedLink = `${appStoreRoot}/gb/${iosPremiumAppProduct}${iosPremiumTail}`;
     it('should return /gb/ app store link for UK', () => {
       expect(getIosAppUrl(uk).startsWith(ukExpectedLink));
     });
 
-    const auExpectedLink = appStoreRoot + 'au/' + iosPremiumAppProduct + iosPremiumTail;
+    const auExpectedLink = `${appStoreRoot}/au/${iosPremiumAppProduct}${iosPremiumTail}`;
     it('should return /au/ app store link for AU', () => {
       expect(getIosAppUrl(au).startsWith(auExpectedLink));
     });
 
-    const usExpectedLink = appStoreRoot + 'us/' + iosPremiumAppProduct + iosPremiumTail;
+    const usExpectedLink = `${appStoreRoot}/us/${iosPremiumAppProduct}${iosPremiumTail}`;
     it('should return /us/ app store link for US', () => {
       expect(getIosAppUrl(us).startsWith(usExpectedLink));
     });
 
-    const nzExpectedLink = appStoreRoot + 'nz/' + iosPremiumAppProduct + iosPremiumTail;
+    const nzExpectedLink = `${appStoreRoot}/nz/${iosPremiumAppProduct}${iosPremiumTail}`;
     it('should return /nz/ app store link for NZ', () => {
       expect(getIosAppUrl(nz).startsWith(nzExpectedLink));
     });
 
-    const caExpectedLink = appStoreRoot + 'ca/' + iosPremiumAppProduct + iosPremiumTail;
+    const caExpectedLink = `${appStoreRoot}/ca/${iosPremiumAppProduct}${iosPremiumTail}`;
     it('should return /ca/ app store link for CA', () => {
       expect(getIosAppUrl(ca).startsWith(caExpectedLink));
     });
 
-    const usDefaultLink = appStoreRoot + 'us/' + iosPremiumAppProduct + iosPremiumTail;
+    const usDefaultLink = `${appStoreRoot}/us/${iosPremiumAppProduct}${iosPremiumTail}`;
     it('should return default /us/ app store link for EU and International countries', () => {
-      ['EURCountries', 'International'].forEach( c => expect(getIosAppUrl(nz).startsWith(usDefaultLink)));
+      ['EURCountries', 'International'].forEach(c => expect(getIosAppUrl(c).startsWith(usDefaultLink)));
     });
   });
 
   describe('iOSDailyEditionLink', () => {
     it('should return /gb/ app store link for UK', () => {
-      const ukExpectedLink = appStoreRoot + 'gb/' + iosDailyEditionProduct + iosPremiumTail;
+      const ukExpectedLink = `${appStoreRoot}/gb/${iosDailyEditionProduct}${iosPremiumTail}`;
       expect(getDailyEditionUrl(uk).startsWith(ukExpectedLink));
     });
 
     // The rest of these are mostly pointless as Daily Edition is UK only - but proves it isn't broken anyway
 
-    const auExpectedLink = appStoreRoot + 'au/' + iosDailyEditionProduct + iosPremiumTail;
+    const auExpectedLink = `${appStoreRoot}/au/${iosDailyEditionProduct}${iosPremiumTail}`;
     it('should return /au/ app store link for AU', () => {
       expect(getDailyEditionUrl(au).startsWith(auExpectedLink));
     });
 
-    const usExpectedLink = appStoreRoot + 'us/' + iosDailyEditionProduct + iosPremiumTail;
+    const usExpectedLink = `${appStoreRoot}/us/${iosDailyEditionProduct}${iosPremiumTail}`;
     it('should return /us/ app store link for US', () => {
       expect(getDailyEditionUrl(us).startsWith(usExpectedLink));
     });
 
-    const nzExpectedLink = appStoreRoot + 'nz/' + iosDailyEditionProduct + iosPremiumTail;
+    const nzExpectedLink = `${appStoreRoot}/nz/${iosDailyEditionProduct}${iosPremiumTail}`;
     it('should return /nz/ app store link for NZ', () => {
       expect(getDailyEditionUrl(nz).startsWith(nzExpectedLink));
     });
 
-    const caExpectedLink = appStoreRoot + 'ca/' + iosDailyEditionProduct + iosPremiumTail;
+    const caExpectedLink = `${appStoreRoot}/ca/${iosDailyEditionProduct}${iosPremiumTail}`;
     it('should return /ca/ app store link for CA', () => {
       expect(getDailyEditionUrl(ca).startsWith(caExpectedLink));
     });
 
-    const usDefaultLink = appStoreRoot + 'us/' + iosDailyEditionProduct + iosPremiumTail;
+    const usDefaultLink = `${appStoreRoot}/us/${iosDailyEditionProduct}${iosPremiumTail}`;
     it('should return default /us/ app store link for EU and International countries', () => {
-      ['EURCountries', 'International'].forEach( c => expect(getDailyEditionUrl(nz).startsWith(usDefaultLink)));
+      ['EURCountries', 'International'].forEach(c => expect(getDailyEditionUrl(c).startsWith(usDefaultLink)));
     });
   });
 

--- a/assets/helpers/__tests__/externalLinksTest.js
+++ b/assets/helpers/__tests__/externalLinksTest.js
@@ -1,0 +1,99 @@
+// @flow
+
+// ----- Imports ----- //
+
+import { type CountryGroupId } from '../internationalisation/countryGroup';
+import { androidAppUrl, getIosAppUrl, getDailyEditionUrl } from '../externalLinks';
+
+// ----- Tests ----- //
+
+jest.mock('ophan', () => ({ viewId: '123456' }));
+
+describe('externalLinks', () => {
+  const uk: CountryGroupId = 'GBPCountries';
+  const us: CountryGroupId = 'UnitedStates';
+  const au: CountryGroupId = 'AUDCountries';
+  const ca: CountryGroupId = 'Canada';
+  const nz: CountryGroupId = 'NZDCountries';
+
+  const appStoreRoot = 'https://itunes.apple.com/';
+  const iosPremiumAppProduct = 'app/the-guardian/id409128287';
+  const iosDailyEditionProduct = 'app/guardian-observer-daily-edition/id452707806';
+  const iosPremiumTail = '?mt=8';
+
+  // NOTE: all comparisons ignore added parameters
+
+  describe('iOSPremiumAppLink', () => {
+    const ukExpectedLink = appStoreRoot + 'gb/' + iosPremiumAppProduct + iosPremiumTail;
+    it('should return /gb/ app store link for UK', () => {
+      expect(getIosAppUrl(uk).startsWith(ukExpectedLink));
+    });
+
+    const auExpectedLink = appStoreRoot + 'au/' + iosPremiumAppProduct + iosPremiumTail;
+    it('should return /au/ app store link for AU', () => {
+      expect(getIosAppUrl(au).startsWith(auExpectedLink));
+    });
+
+    const usExpectedLink = appStoreRoot + 'us/' + iosPremiumAppProduct + iosPremiumTail;
+    it('should return /us/ app store link for US', () => {
+      expect(getIosAppUrl(us).startsWith(usExpectedLink));
+    });
+
+    const nzExpectedLink = appStoreRoot + 'nz/' + iosPremiumAppProduct + iosPremiumTail;
+    it('should return /nz/ app store link for NZ', () => {
+      expect(getIosAppUrl(nz).startsWith(nzExpectedLink));
+    });
+
+    const caExpectedLink = appStoreRoot + 'ca/' + iosPremiumAppProduct + iosPremiumTail;
+    it('should return /ca/ app store link for CA', () => {
+      expect(getIosAppUrl(ca).startsWith(caExpectedLink));
+    });
+
+    const usDefaultLink = appStoreRoot + 'us/' + iosPremiumAppProduct + iosPremiumTail;
+    it('should return default /us/ app store link for EU and International countries', () => {
+      ['EURCountries', 'International'].forEach( c => expect(getIosAppUrl(nz).startsWith(usDefaultLink)));
+    });
+  });
+
+  describe('iOSDailyEditionLink', () => {
+    it('should return /gb/ app store link for UK', () => {
+      const ukExpectedLink = appStoreRoot + 'gb/' + iosDailyEditionProduct + iosPremiumTail;
+      expect(getDailyEditionUrl(uk).startsWith(ukExpectedLink));
+    });
+
+    // The rest of these are mostly pointless as Daily Edition is UK only - but proves it isn't broken anyway
+
+    const auExpectedLink = appStoreRoot + 'au/' + iosDailyEditionProduct + iosPremiumTail;
+    it('should return /au/ app store link for AU', () => {
+      expect(getDailyEditionUrl(au).startsWith(auExpectedLink));
+    });
+
+    const usExpectedLink = appStoreRoot + 'us/' + iosDailyEditionProduct + iosPremiumTail;
+    it('should return /us/ app store link for US', () => {
+      expect(getDailyEditionUrl(us).startsWith(usExpectedLink));
+    });
+
+    const nzExpectedLink = appStoreRoot + 'nz/' + iosDailyEditionProduct + iosPremiumTail;
+    it('should return /nz/ app store link for NZ', () => {
+      expect(getDailyEditionUrl(nz).startsWith(nzExpectedLink));
+    });
+
+    const caExpectedLink = appStoreRoot + 'ca/' + iosDailyEditionProduct + iosPremiumTail;
+    it('should return /ca/ app store link for CA', () => {
+      expect(getDailyEditionUrl(ca).startsWith(caExpectedLink));
+    });
+
+    const usDefaultLink = appStoreRoot + 'us/' + iosDailyEditionProduct + iosPremiumTail;
+    it('should return default /us/ app store link for EU and International countries', () => {
+      ['EURCountries', 'International'].forEach( c => expect(getDailyEditionUrl(nz).startsWith(usDefaultLink)));
+    });
+  });
+
+  describe('AndroidAppLink', () => {
+    const androidPremiumAppLink = 'https://play.google.com/store/apps/details?id=com.guardian';
+    it('should return correct Google play store link for Daily Edition', () => {
+      expect(androidAppUrl.startsWith(androidPremiumAppLink));
+    });
+  });
+
+});

--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -36,9 +36,7 @@ export type SubsUrls = {
 const subsUrl = 'https://subscribe.theguardian.com';
 const patronsUrl = 'https://patrons.theguardian.com';
 const defaultIntCmp = 'gdnwb_copts_bundles_landing_default';
-const iOSAppUrl = 'https://itunes.apple.com/app/the-guardian/id409128287?mt=8';
 const androidAppUrl = 'https://play.google.com/store/apps/details?id=com.guardian';
-const dailyEditionUrl = 'https://itunes.apple.com/app/guardian-observer-daily-edition/id452707806?mt=8';
 
 const memUrls: {
   [MemProduct]: string,
@@ -216,6 +214,37 @@ function getDigitalCheckout(
 }
 
 
+function convertCountryGroupIdToAppStoreCountryCode(cgId: CountryGroupId) {
+  const groupFromId = countryGroups[cgId];
+  if (groupFromId) {
+    switch (groupFromId.supportInternationalisationId.toLowerCase()) {
+      case 'uk':
+        return 'gb';
+      case 'int':
+        return 'us';
+      case 'eu':
+        return 'us';
+      default:
+        return groupFromId.supportInternationalisationId.toLowerCase();
+    }
+  } else {
+    return 'us';
+  }
+}
+
+function getAppleStoreUrl(product: string, countryGroupId: CountryGroupId) {
+  const appStoreCountryCode = convertCountryGroupIdToAppStoreCountryCode(countryGroupId);
+  return `https://itunes.apple.com/${appStoreCountryCode}/app/${product}?mt=8`;
+}
+
+function getIosAppUrl(countryGroupId: CountryGroupId) {
+  return getAppleStoreUrl('the-guardian/id409128287', countryGroupId);
+}
+
+function getDailyEditionUrl(countryGroupId: CountryGroupId) {
+  return getAppleStoreUrl('guardian-observer-daily-edition/id452707806', countryGroupId);
+}
+
 // ----- Exports ----- //
 
 export {
@@ -223,7 +252,7 @@ export {
   getMemLink,
   getPatronsLink,
   getDigitalCheckout,
-  iOSAppUrl,
+  getIosAppUrl,
   androidAppUrl,
-  dailyEditionUrl,
+  getDailyEditionUrl,
 };

--- a/assets/pages/digital-subscription-checkout/components/appsSection.jsx
+++ b/assets/pages/digital-subscription-checkout/components/appsSection.jsx
@@ -5,10 +5,12 @@
 import React from 'react';
 
 import {
-  iOSAppUrl,
+  getIosAppUrl,
   androidAppUrl,
-  dailyEditionUrl,
+  getDailyEditionUrl,
 } from 'helpers/externalLinks';
+
+import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
 import CtaLink from 'components/ctaLink/ctaLink';
@@ -16,7 +18,9 @@ import CtaLink from 'components/ctaLink/ctaLink';
 
 // ----- Component ----- //
 
-function AppsSection() {
+function AppsSection(props: {
+  countryGroupId: CountryGroupId,
+}) {
 
   return (
     <div className="apps-section">
@@ -34,7 +38,7 @@ function AppsSection() {
           <CtaLink
             text="Download from the App Store"
             accessibilityHint="Click to download the app on the Apple App Store"
-            url={iOSAppUrl}
+            url={getIosAppUrl(props.countryGroupId)}
           />
           <CtaLink
             text="Download from Google Play"
@@ -56,7 +60,7 @@ function AppsSection() {
           <CtaLink
             text="Download the Daily Tablet edition"
             accessibilityHint="Click to download the Daily Tablet Edition app on the Apple App Store"
-            url={dailyEditionUrl}
+            url={getDailyEditionUrl(props.countryGroupId)}
           />
         </div>
       </LeftMarginSection>

--- a/assets/pages/digital-subscription-checkout/components/checkoutStage.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutStage.jsx
@@ -8,6 +8,8 @@ import { connect } from 'react-redux';
 import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
 import SubscriptionsThankYou from 'components/subscriptionsThankYou/subscriptionsThankYou';
 
+import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+
 import { type Stage } from '../digitalSubscriptionCheckoutReducer';
 import AppsSection from './appsSection';
 
@@ -16,6 +18,7 @@ import AppsSection from './appsSection';
 
 type PropTypes = {
   stage: Stage;
+  countryGroupId: CountryGroupId;
 };
 
 
@@ -25,6 +28,7 @@ function mapStateToProps(state): PropTypes {
 
   return {
     stage: state.page.stage,
+    countryGroupId: state.page.countryGroupId,
   };
 
 }
@@ -39,7 +43,9 @@ function CheckoutStage(props: PropTypes) {
     case 'thankyou':
       return (
         <SubscriptionsThankYou>
-          <AppsSection />
+          <AppsSection
+            countryGroupId={props.countryGroupId}
+          />
         </SubscriptionsThankYou>
       );
 


### PR DESCRIPTION
## Why are you doing this?
Apple's app store defaults to US, and therefore US dollars, unless given a hint at the user's location. We can pass that through (after translating it into one of Apple's known values).

[**Trello Card**](https://trello.com/c/fX63xBuy/2005-add-region-country-into-ios-app-store-link)

## Screenshots
![screen shot 2018-10-09 at 16 21 11](https://user-images.githubusercontent.com/690395/46681596-7a059100-cbe3-11e8-8d32-b1223a26fe54.png)

![screen shot 2018-10-09 at 16 21 33](https://user-images.githubusercontent.com/690395/46681610-812c9f00-cbe3-11e8-8abe-37cb5b34403c.png)

![screen shot 2018-10-09 at 16 21 56](https://user-images.githubusercontent.com/690395/46681622-8ab60700-cbe3-11e8-8270-c7370d304cf9.png)

![screen shot 2018-10-09 at 16 22 22](https://user-images.githubusercontent.com/690395/46681636-90abe800-cbe3-11e8-850d-8b54db8aa047.png)

![screen shot 2018-10-09 at 16 23 24](https://user-images.githubusercontent.com/690395/46681648-99042300-cbe3-11e8-9347-147f415d8893.png)

