### PR TITLE
Em payment error

### DIFF
--- a/assets/components/paymentFailureMessage/paymentFailureMessage.scss
+++ b/assets/components/paymentFailureMessage/paymentFailureMessage.scss
@@ -10,6 +10,10 @@
 
 }
 
+.gu-content__content .component-payment-failure-message {
+  width: auto;
+}
+
 .svg-exclamation-alternate {
   display: inline-block;
   margin-right: 8px;

--- a/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -73,7 +73,7 @@ import {
 /* eslint-disable react/no-unused-prop-types */
 type PropTypes = {|
   paymentComplete: boolean,
-  error: CheckoutFailureReason | null,
+  paymentError: CheckoutFailureReason | null,
   isWaiting: boolean,
   countryGroupId: CountryGroupId,
   selectedCountryGroupDetails: CountryMetaData,
@@ -126,6 +126,7 @@ const mapStateToProps = (state: State) => ({
   checkoutFormHasBeenSubmitted: state.page.form.formData.checkoutFormHasBeenSubmitted,
   isDirectDebitPopUpOpen: state.page.directDebit.isPopUpOpen,
   currency: state.common.internationalisation.currencyId,
+  paymentError: state.page.form.paymentError,
 });
 
 
@@ -231,7 +232,6 @@ function ContributionForm(props: PropTypes) {
       <div className="gu-content__content">
         <h1 className="header">{countryGroupSpecificDetails[countryGroupId].headerCopy}</h1>
         <p className="blurb">{countryGroupSpecificDetails[countryGroupId].contributeCopy}</p>
-        <PaymentFailureMessage checkoutFailureReason={props.error} />
         <form onSubmit={onSubmit(props)} className={classNameWithModifiers('form', ['contribution'])} noValidate>
           <NewContributionType />
           <NewContributionAmount
@@ -292,7 +292,10 @@ function ContributionForm(props: PropTypes) {
             errorMessage="Please provide a state"
           />
           <NewContributionPayment onPaymentAuthorisation={onPaymentAuthorisation} />
-          <NewContributionSubmit />
+          <PaymentFailureMessage checkoutFailureReason={props.paymentError} />
+          <NewContributionSubmit
+            whenUnableToOpen={props.setCheckoutFormHasBeenSubmitted}
+          />
           {props.isWaiting ? <ProgressMessage message={['Processing transaction', 'Please wait']} /> : null}
         </form>
         <DirectDebitPopUpForm
@@ -302,10 +305,6 @@ function ContributionForm(props: PropTypes) {
       </div>
     );
 }
-
-ContributionForm.defaultProps = {
-  error: null,
-};
 
 const NewContributionForm = connect(mapStateToProps, mapDispatchToProps)(ContributionForm);
 

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -7,6 +7,7 @@
 @import '~components/directDebit/directDebitForm/directDebitForm';
 @import '~components/errorMessage/errorMessage';
 @import '~components/ctaLink/ctaLink';
+@import '~components/paymentFailureMessage/paymentFailureMessage';
 @import 'components/SetPassword/setPassword';
 
 body {

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -42,7 +42,7 @@ export type Action =
   | { type: 'SELECT_AMOUNT', amount: Amount | 'other', contributionType: Contrib }
   | { type: 'UPDATE_OTHER_AMOUNT', otherAmount: string }
   | { type: 'PAYMENT_RESULT', paymentResult: Promise<PaymentResult> }
-  | { type: 'PAYMENT_FAILURE', paymentError: string }
+  | { type: 'PAYMENT_FAILURE', paymentError: CheckoutFailureReason }
   | { type: 'PAYMENT_WAITING', isWaiting: boolean }
   | { type: 'SET_CHECKOUT_FORM_HAS_BEEN_SUBMITTED' }
   | { type: 'SET_PASSWORD_HAS_BEEN_SUBMITTED' }
@@ -187,7 +187,7 @@ const onCreateOneOffPayPalPaymentResponse =
         // For PayPal create payment errors, the Payment API passes through the
         // error from PayPal's API which we don't want to expose to the user.
         dispatch(paymentFailure('unknown'));
-        dispatch(setPaymentIsWaiting(false));
+        dispatch(paymentWaiting(false));
       });
     };
 

--- a/assets/pages/new-contributions-landing/contributionsLandingReducer.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingReducer.js
@@ -2,6 +2,7 @@
 
 // ----- Imports ----- //
 
+import type { CheckoutFailureReason } from 'helpers/checkoutErrors';
 import { combineReducers } from 'redux';
 import { type PaymentHandler } from 'helpers/checkouts';
 import { amounts, type Amount, type Contrib, type PaymentMethod } from 'helpers/contributions';
@@ -58,6 +59,7 @@ type FormState = {
   formData: FormData,
   setPasswordData: SetPasswordData,
   paymentComplete: boolean,
+  paymentError: CheckoutFailureReason | null,
   guestAccountCreationToken: ?string,
   thankYouPageStage: ThankYouPageStage,
 };
@@ -121,6 +123,7 @@ function createFormReducer(countryGroupId: CountryGroupId) {
     selectedAmounts: initialAmount,
     isWaiting: false,
     paymentComplete: false,
+    paymentError: null,
     guestAccountCreationToken: null,
     thankYouPageStage: 'thankYou',
   };
@@ -190,7 +193,7 @@ function createFormReducer(countryGroupId: CountryGroupId) {
         };
 
       case 'PAYMENT_FAILURE':
-        return { ...state, paymentComplete: false, error: action.error };
+        return { ...state, paymentComplete: false, paymentError: action.paymentError };
 
       case 'PAYMENT_WAITING':
         return { ...state, paymentComplete: false, isWaiting: action.isWaiting };


### PR DESCRIPTION
## Why are you doing this?
Deal with error responses from Payment API by exiting "Processing Transaction" state and displaying payment error message. 

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/WCt3abmA/15-npf-error-responses-from-payment-api-are-not-handled-page-hangs-in-processing-transaction-state)

## Changes

* Adds and initialises paymentError in reducer
* Updates actions to also set `isWaiting` to false when a payment error is returned. 
* Moves `paymentErrorMessage` component to above the payment button.
* Updates CSS to remove width when component appears in NPF. 


## Screenshots
![screen shot 2018-10-09 at 18 51 33](https://user-images.githubusercontent.com/8484757/46688953-9959e980-cbf6-11e8-8010-04b5b80e6ba4.jpg)


