### PR TITLE
Fix CSS Minification In Dev

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -102,7 +102,7 @@ module.exports = (cssFilename, outputFilename, minimizeCss) => ({
               plugins: [
                 pxtorem({ propList: ['*'] }),
                 autoprefixer(),
-                minimizeCss ? cssnano : false,
+                ...(minimizeCss ? cssnano : []),
               ],
             },
           },

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -102,7 +102,7 @@ module.exports = (cssFilename, outputFilename, minimizeCss) => ({
               plugins: [
                 pxtorem({ propList: ['*'] }),
                 autoprefixer(),
-                ...(minimizeCss ? cssnano : []),
+                ...(minimizeCss ? [cssnano] : []),
               ],
             },
           },


### PR DESCRIPTION
## Why are you doing this?

Webpack doesn't accept `false` as a plugin, this switches to spreading with an empty array instead.

## Changes

- Switched to array spread syntax with empty array instead of false.
