### PR TITLE
Update newspaper -> magazine for Weekly

### DIFF
--- a/assets/components/subscriptionBundles/weekly.jsx
+++ b/assets/components/subscriptionBundles/weekly.jsx
@@ -33,7 +33,7 @@ function Weekly(props: PropTypes) {
       headingSize={props.headingSize}
       benefits={{
         list: false,
-        copy: 'A weekly, global newspaper from The Guardian, with free delivery worldwide',
+        copy: 'A weekly, global magazine from The Guardian, with free delivery worldwide',
       }}
       gridImage={{
         gridId: 'weeklyCircle',


### PR DESCRIPTION
## Why are you doing this?
Because it's a glorious magazine now, not a newspaper.

[**Trello Card**](https://trello.com/c/S7PAob3t/2010-update-product-copy-for-gw-on-all-subscriptions-landing-pages)

## Changes

* See that word 'newspaper' on the Guardian Weekly copy? That's 'magazine' now, thank you very much. End of.

## Screenshots
**Before:**
![screen shot 2018-10-10 at 16 21 25](https://user-images.githubusercontent.com/690395/46752224-97566000-ccb4-11e8-836f-d81944ac8a34.png)

**After:**
![screen shot 2018-10-10 at 17 44 16](https://user-images.githubusercontent.com/690395/46752247-9de4d780-ccb4-11e8-9dc4-f5b5e440eb4c.png)

