### PR TITLE
Fix Alignment Issue

### DIFF
--- a/assets/components/threeSubscriptions/threeSubscriptions.scss
+++ b/assets/components/threeSubscriptions/threeSubscriptions.scss
@@ -52,6 +52,7 @@
   .component-subscription-bundle__description {
     line-height: 20px;
     margin-bottom: $gu-v-spacing;
+    flex-grow: 1;
 
     @include mq($from: phablet, $until: leftCol) {
       margin-left: 1.5 * $gu-h-spacing;


### PR DESCRIPTION
## Why are you doing this?

Fixes a small alignment bug on the showcase page.

cc @JustinPinner 

## Changes

- Use `flex-grow` to push CTA down.

## Screenshots

### Before

![align-before](https://user-images.githubusercontent.com/5131341/46752868-2ca62400-ccb6-11e8-8cdc-cc1f5999089a.png)

### After

![align-after](https://user-images.githubusercontent.com/5131341/46752866-2c0d8d80-ccb6-11e8-9a0a-75e1a0d55090.png)
