### PR TITLE
Exact types for PaymentMatrix and no more baseHandlers

### DIFF
--- a/assets/helpers/contributions.js
+++ b/assets/helpers/contributions.js
@@ -13,12 +13,12 @@ import { logException } from 'helpers/logger';
 
 // ----- Types ----- //
 
-export type PaymentMethodMap<T> = {
+export type PaymentMethodMap<T> = {|
   Stripe: T,
   PayPal: T,
   DirectDebit: T,
   None: T,
-}
+|};
 
 // This lets us create a union type from the object keys,
 // avoiding the need to specify them separately and keep them in sync!
@@ -27,14 +27,15 @@ export type PaymentMethodMap<T> = {
 // so it's irrelevant - so we supply null
 export type PaymentMethod = $Keys<PaymentMethodMap<null>>;
 
-export type RegularContributionTypeMap<T> = {
+export type RegularContributionTypeMap<T> = {|
   MONTHLY: T,
   ANNUAL: T,
-}
+|};
 
-export type ContributionTypeMap<T> = RegularContributionTypeMap<T> & {
+export type ContributionTypeMap<T> = {|
+  ...RegularContributionTypeMap<T>,
   ONE_OFF: T,
-};
+|};
 
 export type RegularContributionType = $Keys<RegularContributionTypeMap<null>>;
 export type Contrib = $Keys<ContributionTypeMap<null>>;
@@ -43,24 +44,6 @@ export type PaymentMatrix<T> = ContributionTypeMap<PaymentMethodMap<T>>;
 
 export const logInvalidCombination = (contributionType: Contrib, paymentMethod: PaymentMethod) => {
   logException(`Invalid combination of contribution type ${contributionType} and payment method ${paymentMethod}`);
-};
-
-const recurringBaseHandler = (contributionType: RegularContributionType) => ({
-  Stripe: () => {},
-  PayPal: () => {},
-  DirectDebit: () => {},
-  None: () => { logInvalidCombination(contributionType, 'None'); },
-});
-
-export const baseHandlers: PaymentMatrix<() => void> = {
-  ONE_OFF: {
-    Stripe: () => {},
-    PayPal: () => {},
-    DirectDebit: () => { logInvalidCombination('ONE_OFF', 'DirectDebit'); },
-    None: () => { logInvalidCombination('ONE_OFF', 'None'); },
-  },
-  MONTHLY: recurringBaseHandler('MONTHLY'),
-  ANNUAL: recurringBaseHandler('ANNUAL'),
 };
 
 export type BillingPeriod = 'Monthly' | 'Annual';

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -4,7 +4,7 @@
 
 import type { CheckoutFailureReason } from 'helpers/checkoutErrors';
 import { type PaymentHandler } from 'helpers/checkouts';
-import { type Amount, baseHandlers, type Contrib, type PaymentMethod, type PaymentMatrix } from 'helpers/contributions';
+import { type Amount, logInvalidCombination, type Contrib, type PaymentMethod, type PaymentMatrix } from 'helpers/contributions';
 import { type CaState, type UsState } from 'helpers/internationalisation/country';
 import type { RegularPaymentRequest } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
 import {
@@ -28,6 +28,7 @@ import {
 import trackConversion from 'helpers/tracking/conversions';
 import * as cookie from 'helpers/cookie';
 import { type State, type UserFormData, type ThankYouPageStage } from './contributionsLandingReducer';
+import { logException } from 'helpers/logger';
 
 export type Action =
   | { type: 'UPDATE_CONTRIBUTION_TYPE', contributionType: Contrib, paymentMethodToSelect: PaymentMethod }
@@ -240,18 +241,25 @@ const recurringPaymentAuthorisationHandlers = {
 
 const paymentAuthorisationHandlers: PaymentMatrix<(Dispatch<Action>, State, PaymentAuthorisation) => void> = {
   ONE_OFF: {
-    ...baseHandlers.ONE_OFF,
     PayPal: () => {
-      // No handler required.
       // Executing a one-off PayPal payment happens on the backend in the /paypal/rest/return
       // endpoint, after PayPal redirects the browser back to our site.
+      logException('Paypal one-off has no authorisation handler');
     },
     Stripe: (dispatch: Dispatch<Action>, state: State, paymentAuthorisation: PaymentAuthorisation): void => {
       dispatch(executeStripeOneOffPayment(stripeChargeDataFromAuthorisation(paymentAuthorisation, state)));
     },
+    DirectDebit: () => { logInvalidCombination('ONE_OFF', 'DirectDebit'); },
+    None: () => { logInvalidCombination('ONE_OFF', 'None'); },
   },
-  ANNUAL: { ...baseHandlers.ANNUAL, ...recurringPaymentAuthorisationHandlers },
-  MONTHLY: { ...baseHandlers.MONTHLY, ...recurringPaymentAuthorisationHandlers },
+  ANNUAL: {
+    ...recurringPaymentAuthorisationHandlers,
+    None: () => { logInvalidCombination('ANNUAL', 'None'); },
+  },
+  MONTHLY: {
+    ...recurringPaymentAuthorisationHandlers,
+    None: () => { logInvalidCombination('MONTHLY', 'None'); },
+  },
 };
 
 const onThirdPartyPaymentAuthorised = (paymentAuthorisation: PaymentAuthorisation) =>

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -25,10 +25,10 @@ import {
   getOphanIds,
   getSupportAbTests,
 } from 'helpers/tracking/acquisitions';
+import { logException } from 'helpers/logger';
 import trackConversion from 'helpers/tracking/conversions';
 import * as cookie from 'helpers/cookie';
 import { type State, type UserFormData, type ThankYouPageStage } from './contributionsLandingReducer';
-import { logException } from 'helpers/logger';
 
 export type Action =
   | { type: 'UPDATE_CONTRIBUTION_TYPE', contributionType: Contrib, paymentMethodToSelect: PaymentMethod }


### PR DESCRIPTION
Unfortunately two missing `...`s broke the recurring payment methods: https://github.com/guardian/support-frontend/blob/master/assets/pages/new-contributions-landing/components/ContributionForm.jsx#L187-L188. The empty functions in the base handlers were not being overridden so we got a silent failure! Bad.

Using exact types for `PaymentMethodMap`, `ContributionTypeMap` and `RegularContributionTypeMap` would've been enough to catch this. But it's made me decide that it's clearer to just be explicit about what we're declaring in each one and not mix in`baseHandlers`. It's a bit more repetitive but it means you can see at a glance what it's doing in each case rather than figuring out what's overriding what etc.

**Note:** we need to use spread syntax rather than an intersection type when using exact types, since the intersection of distinct exact object types is an empty set (it's like [intersecting `number` and `string`](https://flow.org/en/docs/types/intersections/#toc-impossible-intersection-types))