### PR TITLE
Reduce Highlight Size

### DIFF
--- a/assets/components/introduction/investIntroduction.scss
+++ b/assets/components/introduction/investIntroduction.scss
@@ -15,11 +15,11 @@
       left: -64px;
     }
     @include mq($from: tablet) {
-      top: -156px;
+      top: -140px;
       left: -82px;
     }
     @include mq($from: desktop) {
-      top: -145px;
+      top: -129px;
       left: -102px;
     }
     @include mq($from: leftCol) {
@@ -47,6 +47,11 @@
   font-size: 34px;
   line-height: 36px;
   position: relative;
+
+  .component-highlights__highlight {
+    padding: 0 8px 4px;
+  }
+
   @include mq($from: tablet) {
     font-size: 50px;
     line-height: 58px;


### PR DESCRIPTION
## Why are you doing this?

Reducing the height of the top highlight on the subs landing page.

## Changes

- Reduced the padding and the corresponding `top` gaps.

## Screenshots

### Before

![header-before](https://user-images.githubusercontent.com/5131341/46822296-08644900-cd83-11e8-9cc5-7371478a3ca7.jpg)

### After

![header-after](https://user-images.githubusercontent.com/5131341/46822295-08644900-cd83-11e8-894a-612591b955ac.jpg)
