### PR TITLE
update error message

### DIFF
--- a/assets/components/paymentFailureMessage/paymentFailureMessage.jsx
+++ b/assets/components/paymentFailureMessage/paymentFailureMessage.jsx
@@ -4,6 +4,7 @@
 
 import React, { type Node } from 'react';
 import { appropriateErrorMessage, type CheckoutFailureReason } from 'helpers/checkoutErrors';
+import { classNameWithModifiers } from 'helpers/utilities';
 import SvgExclamationAlternate from '../svgs/exclamationAlternate';
 
 
@@ -13,6 +14,7 @@ type PropTypes = {|
   checkoutFailureReason: ?CheckoutFailureReason,
   errorHeading: string,
   svg: Node,
+  classModifiers: Array<?string>
 |};
 
 
@@ -23,7 +25,7 @@ export default function PaymentFailureMessage(props: PropTypes) {
   if (props.checkoutFailureReason) {
 
     return (
-      <div className="component-payment-failure-message">
+      <div className={classNameWithModifiers('component-payment-failure-message', props.classModifiers)}>
         {props.svg}<span className="component-payment-failure-message__error-heading">{props.errorHeading}</span>
         <span className="component-payment-failure-message__small-print">{appropriateErrorMessage(props.checkoutFailureReason)}</span>
       </div>
@@ -41,4 +43,5 @@ export default function PaymentFailureMessage(props: PropTypes) {
 PaymentFailureMessage.defaultProps = {
   errorHeading: 'Payment Attempt Failed',
   svg: <SvgExclamationAlternate />,
+  classModifiers: [],
 };

--- a/assets/components/paymentFailureMessage/paymentFailureMessage.scss
+++ b/assets/components/paymentFailureMessage/paymentFailureMessage.scss
@@ -10,8 +10,15 @@
 
 }
 
-.gu-content__content .component-payment-failure-message {
-  width: auto;
+.gu-content__content {
+  .component-payment-failure-message {
+    width: auto;
+    background-color: transparent;
+  }
+
+  .component-payment-failure-message--no-valid-payments {
+      padding: 0;
+  }
 }
 
 .svg-exclamation-alternate {

--- a/assets/helpers/checkoutErrors.js
+++ b/assets/helpers/checkoutErrors.js
@@ -26,6 +26,8 @@ function appropriateErrorMessage(checkoutFailureReason: ?CheckoutFailureReason):
       return 'The transaction was unsuccessful and you have not been charged. Please use a different card or choose another payment method.';
     case 'payment_provider_unavailable':
       return 'The transaction was unsuccessful. This does not mean there’s anything wrong with your card, and you have not been charged. Please try using an alternative payment method.';
+    case 'all_payment_methods_unavailable':
+      return 'Sorry, our payment methods are unavailable at this time. We are working hard to fix the problem and hope to be back up and running soon. Please come back later to complete your contribution or consider another type of contribution from the tabs above. Thank you.';
     default:
       return 'The transaction was temporarily declined. Please try entering your payment details again. Alternatively, try another payment method.';
   }

--- a/assets/helpers/checkoutErrors.js
+++ b/assets/helpers/checkoutErrors.js
@@ -10,6 +10,7 @@ export type CheckoutFailureReason =
   'payment_method_unacceptable' |
   'payment_provider_unavailable' |
   'payment_recently_taken' |
+  'all_payment_methods_unavailable' |
   'unknown';
 
 // ----- Functions ----- //

--- a/assets/pages/new-contributions-landing/components/ContributionPayment.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionPayment.jsx
@@ -21,6 +21,7 @@ import { type PaymentAuthorisation } from 'helpers/paymentIntegrations/newPaymen
 import SvgNewCreditCard from 'components/svgs/newCreditCard';
 import SvgPayPal from 'components/svgs/paypal';
 import { logException } from 'helpers/logger';
+import PaymentFailureMessage from 'components/paymentFailureMessage/paymentFailureMessage';
 
 import { type State } from '../contributionsLandingReducer';
 import { type Action, updatePaymentMethod, isPaymentReady } from '../contributionsLandingActions';
@@ -122,30 +123,35 @@ function ContributionPayment(props: PropTypes) {
     paymentMethodInitialisers[props.contributionType][paymentMethod](props);
   });
 
+  const noPaymentMethodsErrorMessage = <PaymentFailureMessage classModifiers={['no-valid-payments']} errorHeading="Payment methods are unavailable" checkoutFailureReason="all_payment_methods_unavailable" />;
+
   return (
     <fieldset className={classNameWithModifiers('form__radio-group', ['buttons', 'contribution-pay'])}>
       <legend className="form__legend">Payment method</legend>
 
-      <ul className="form__radio-group-list">
-        {paymentMethods.map(paymentMethod => (
-          <li className="form__radio-group-item">
-            <input
-              id={`contributionPayment-${paymentMethod}`}
-              className="form__radio-group-input"
-              name="contributionPayment"
-              type="radio"
-              value={paymentMethod}
-              onChange={() => props.updatePaymentMethod(paymentMethod)}
-              checked={props.paymentMethod === paymentMethod}
-            />
-            <label htmlFor={`contributionPayment-${paymentMethod}`} className="form__radio-group-label">
-              <span className="radio-ui" />
-              <span className="radio-ui__label">{getPaymentLabel(paymentMethod)}</span>
-              {paymentMethod === 'PayPal' ? (<SvgPayPal />) : (<SvgNewCreditCard />)}
-            </label>
-          </li>
-        ))}
-      </ul>
+      { paymentMethods.length ?
+        <ul className="form__radio-group-list">
+          {paymentMethods.map(paymentMethod => (
+            <li className="form__radio-group-item">
+              <input
+                id={`contributionPayment-${paymentMethod}`}
+                className="form__radio-group-input"
+                name="contributionPayment"
+                type="radio"
+                value={paymentMethod}
+                onChange={() => props.updatePaymentMethod(paymentMethod)}
+                checked={props.paymentMethod === paymentMethod}
+              />
+              <label htmlFor={`contributionPayment-${paymentMethod}`} className="form__radio-group-label">
+                <span className="radio-ui" />
+                <span className="radio-ui__label">{ getPaymentLabel(paymentMethod) }</span>
+                { paymentMethod === 'PayPal' ? (<SvgPayPal />) : (<SvgNewCreditCardi />) }
+              </label>
+            </li>
+          ))}
+        </ul>
+        : noPaymentMethodsErrorMessage
+      }
     </fieldset>
   );
 }

--- a/assets/pages/new-contributions-landing/components/ContributionPayment.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionPayment.jsx
@@ -145,7 +145,7 @@ function ContributionPayment(props: PropTypes) {
               <label htmlFor={`contributionPayment-${paymentMethod}`} className="form__radio-group-label">
                 <span className="radio-ui" />
                 <span className="radio-ui__label">{ getPaymentLabel(paymentMethod) }</span>
-                { paymentMethod === 'PayPal' ? (<SvgPayPal />) : (<SvgNewCreditCardi />) }
+                { paymentMethod === 'PayPal' ? (<SvgPayPal />) : (<SvgNewCreditCard />) }
               </label>
             </li>
           ))}


### PR DESCRIPTION
## Why are you doing this?
To explain to users why there cannot see any payment methods. 
To update CSS in line with designs. 

@ionamckendrick 


<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/r0Pmf3lD/8-npf-all-payment-methods-unavailable-error-state-design)

## Changes

* Removes background on error messages on NPF
* Adds error message for when all payment methods are switched off. 

## Screenshots
![screen shot 2018-10-12 at 18 13 43](https://user-images.githubusercontent.com/8484757/46944801-ef051a80-d06a-11e8-96c2-01d7df33116e.jpg)

