### PR TITLE
Stop showing error message after successful paypal payment creation

### DIFF
--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -184,12 +184,12 @@ const onCreateOneOffPayPalPaymentResponse =
 
         if (result.type === 'success') {
           window.location.href = result.data.approvalUrl;
+        } else {
+          // For PayPal create payment errors, the Payment API passes through the
+          // error from PayPal's API which we don't want to expose to the user.
+          dispatch(paymentFailure('unknown'));
+          dispatch(paymentWaiting(false));
         }
-
-        // For PayPal create payment errors, the Payment API passes through the
-        // error from PayPal's API which we don't want to expose to the user.
-        dispatch(paymentFailure('unknown'));
-        dispatch(paymentWaiting(false));
       });
     };
 


### PR DESCRIPTION
## Why are you doing this?
When the one-off paypal contribution form is submitted, it briefly and incorrectly displays an error message before navigating to paypal.
<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/jkv5OUHs/97-npf-an-error-message-is-always-briefly-displayed-when-submitting-the-on-off-payment-form)
