### PR TITLE
Bump jackson-databind and jackson-annotations to 2.9.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -84,7 +84,8 @@ libraryDependencies ++= Seq(
   "com.squareup.okhttp3" % "okhttp" % "3.9.0",
   "com.gocardless" % "gocardless-pro" % "2.8.0",
   // This is required to force aws libraries to use the latest version of jackson
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.8.11.1",
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.7",
+  "com.fasterxml.jackson.core" % "jackson-annotations" % "2.9.7",
   filters,
   ws
 )


### PR DESCRIPTION
## Why are you doing this?
https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-31507

We are pulling in old versions of jackson-databind primarily via aws-sdks. It's suggested here that overriding jackson-databind shouldn't be a breaking change. Indeed, when running the project locally after the version bump, that seems to be the case.

We are also pulling in an old version of jackson-databind to support sign in.

I bumped the version, signed in with a test user, then signed up for a recurring contribution and saw it in zuora and that worked fine running locally. 

Any other suggested checks?
<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com) // none. Inspired by Snyk.

## Changes

* Bumped jackson-databind and jackson-annotations to 2.9.7

## Screenshots
n/a; just needs to preserve existing behaviour.