### PR TITLE
initialise third party payment libraries

### DIFF
--- a/assets/helpers/checkouts.js
+++ b/assets/helpers/checkouts.js
@@ -17,7 +17,7 @@ export type PaymentMethodSwitch = 'directDebit' | 'payPal' | 'stripe';
 
 type StripeHandler = { open: Function, close: Function };
 
-export type PaymentHandler = StripeHandler;
+export type ThirdPartyPaymentLibrary = StripeHandler;
 
 // ----- Functions ----- //
 

--- a/assets/helpers/contributions.js
+++ b/assets/helpers/contributions.js
@@ -46,6 +46,12 @@ export const logInvalidCombination = (contributionType: Contrib, paymentMethod: 
   logException(`Invalid combination of contribution type ${contributionType} and payment method ${paymentMethod}`);
 };
 
+export type ThirdPartyPaymentLibraries = {
+  ONE_OFF: { Stripe: Object },
+  MONTHLY: { Stripe: Object, PayPal: Object },
+  ANNUAL: { Stripe: Object, PayPal: Object },
+};
+
 export type BillingPeriod = 'Monthly' | 'Annual';
 
 export type Amount = { value: string, spoken: string, isDefault: boolean };

--- a/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -86,7 +86,7 @@ type PropTypes = {|
   otherAmount: string | null,
   paymentMethod: PaymentMethod,
   isSignedIn: boolean,
-  paymentHandlers: PaymentMatrix<PaymentHandler | null>,
+  thirdPartyPaymentLibraries: PaymentMatrix<PaymentHandler | null>,
   updateFirstName: Event => void,
   updateLastName: Event => void,
   updateEmail: Event => void,
@@ -120,7 +120,7 @@ const mapStateToProps = (state: State) => ({
   otherAmount: state.page.form.formData.otherAmounts[state.page.form.contributionType].amount,
   paymentMethod: state.page.form.paymentMethod,
   isSignedIn: state.page.user.isSignedIn,
-  paymentHandlers: state.page.form.paymentHandlers,
+  thirdPartyPaymentLibraries: state.page.form.thirdPartyPaymentLibraries,
   contributionType: state.page.form.contributionType,
   checkoutFormHasBeenSubmitted: state.page.form.formData.checkoutFormHasBeenSubmitted,
   isDirectDebitPopUpOpen: state.page.directDebit.isPopUpOpen,
@@ -154,8 +154,8 @@ const getAmount = (props: PropTypes) =>
 // ----- Event handlers ----- //
 
 function openStripePopup(props: PropTypes) {
-  if (props.paymentHandlers[props.contributionType] && props.paymentHandlers[props.contributionType].Stripe) {
-    openDialogBox(props.paymentHandlers[props.contributionType].Stripe, getAmount(props), props.email);
+  if (props.thirdPartyPaymentLibraries[props.contributionType] && props.thirdPartyPaymentLibraries[props.contributionType].Stripe) {
+    openDialogBox(props.thirdPartyPaymentLibraries[props.contributionType].Stripe, getAmount(props), props.email);
   }
 }
 

--- a/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
 
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { classNameWithModifiers } from 'helpers/utilities';
-import { type PaymentHandler } from 'helpers/checkouts';
+import { type ThirdPartyPaymentLibrary } from 'helpers/checkouts';
 import {
   config,
   type Contrib,
@@ -60,7 +60,7 @@ type PropTypes = {|
   email: string,
   otherAmount: string | null,
   paymentMethod: PaymentMethod,
-  thirdPartyPaymentLibraries: PaymentMatrix<PaymentHandler | null>,
+  thirdPartyPaymentLibraries: PaymentMatrix<ThirdPartyPaymentLibrary | null>,
   contributionType: Contrib,
   currency: IsoCurrency,
   paymentError: CheckoutFailureReason | null,

--- a/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -86,7 +86,7 @@ type PropTypes = {|
   otherAmount: string | null,
   paymentMethod: PaymentMethod,
   isSignedIn: boolean,
-  paymentHandlers: { [PaymentMethod]: PaymentHandler | null },
+  paymentHandlers: PaymentMatrix<PaymentHandler | null>,
   updateFirstName: Event => void,
   updateLastName: Event => void,
   updateEmail: Event => void,
@@ -154,8 +154,8 @@ const getAmount = (props: PropTypes) =>
 // ----- Event handlers ----- //
 
 function openStripePopup(props: PropTypes) {
-  if (props.paymentHandlers.Stripe) {
-    openDialogBox(props.paymentHandlers.Stripe, getAmount(props), props.email);
+  if (props.paymentHandlers[props.contributionType] && props.paymentHandlers[props.contributionType].Stripe) {
+    openDialogBox(props.paymentHandlers[props.contributionType].Stripe, getAmount(props), props.email);
   }
 }
 

--- a/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -154,8 +154,9 @@ const getAmount = (props: PropTypes) =>
 // ----- Event handlers ----- //
 
 function openStripePopup(props: PropTypes) {
-  if (props.thirdPartyPaymentLibraries[props.contributionType] && props.thirdPartyPaymentLibraries[props.contributionType].Stripe) {
-    openDialogBox(props.thirdPartyPaymentLibraries[props.contributionType].Stripe, getAmount(props), props.email);
+  const paymentLibraries = props.thirdPartyPaymentLibraries[props.contributionType];
+  if (paymentLibraries && paymentLibraries.Stripe) {
+    openDialogBox(paymentLibraries.Stripe, getAmount(props), props.email);
   }
 }
 

--- a/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -2,14 +2,13 @@
 
 // ----- Imports ----- //
 
-import type { Amount } from 'helpers/contributions';
+import { type Amount, type ThirdPartyPaymentLibraries } from 'helpers/contributions';
 import type { CountryMetaData } from 'helpers/internationalisation/contributions';
 import React from 'react';
 import { connect } from 'react-redux';
 
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { classNameWithModifiers } from 'helpers/utilities';
-import { type ThirdPartyPaymentLibrary } from 'helpers/checkouts';
 import {
   config,
   type Contrib,
@@ -60,7 +59,7 @@ type PropTypes = {|
   email: string,
   otherAmount: string | null,
   paymentMethod: PaymentMethod,
-  thirdPartyPaymentLibraries: PaymentMatrix<ThirdPartyPaymentLibrary | null>,
+  thirdPartyPaymentLibraries: ThirdPartyPaymentLibraries,
   contributionType: Contrib,
   currency: IsoCurrency,
   paymentError: CheckoutFailureReason | null,

--- a/assets/pages/new-contributions-landing/components/ContributionPayment.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionPayment.jsx
@@ -35,9 +35,9 @@ type PropTypes = {
   currency: IsoCurrency,
   paymentMethod: PaymentMethod,
   onPaymentAuthorisation: PaymentAuthorisation => void,
-  paymentHandlers: { [PaymentMethod]: PaymentHandler | null },
+  paymentHandlers: PaymentMatrix<PaymentHandler | null>,
   updatePaymentMethod: PaymentMethod => Action,
-  isPaymentReady: (boolean, ?{ [PaymentMethod]: PaymentHandler }) => Action,
+  isPaymentReady: (boolean, ?{ [Contrib]: { [PaymentMethod]: PaymentHandler }}) => Action,
   isTestUser: boolean,
   switches: Switches,
 };
@@ -118,7 +118,7 @@ function ContributionPayment(props: PropTypes) {
   // This means a particular payment method will only be initialised
   // once its tab becomes active. If the tab is the default one selected,
   // its payment methods will be initialised on page load.
-  const uninitialisedPaymentMethods = paymentMethods.filter(paymentMethod => !props.paymentHandlers[paymentMethod]);
+  const uninitialisedPaymentMethods = paymentMethods.filter(paymentMethod => !props.paymentHandlers[props.contributionType][paymentMethod]);
   uninitialisedPaymentMethods.forEach((paymentMethod) => {
     paymentMethodInitialisers[props.contributionType][paymentMethod](props);
   });

--- a/assets/pages/new-contributions-landing/components/ContributionPayment.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionPayment.jsx
@@ -11,16 +11,13 @@ import {
   type Contrib,
   type PaymentMethod,
   type PaymentMatrix,
-  logInvalidCombination,
 } from 'helpers/contributions';
 import { classNameWithModifiers } from 'helpers/utilities';
 import { type IsoCountry } from 'helpers/internationalisation/country';
 import { type IsoCurrency } from 'helpers/internationalisation/currency';
-import { setupStripeCheckout } from 'helpers/paymentIntegrations/newPaymentFlow/stripeCheckout';
 import { type PaymentAuthorisation } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
 import SvgNewCreditCard from 'components/svgs/newCreditCard';
 import SvgPayPal from 'components/svgs/paypal';
-import { logException } from 'helpers/logger';
 import PaymentFailureMessage from 'components/paymentFailureMessage/paymentFailureMessage';
 
 import { type State } from '../contributionsLandingReducer';
@@ -35,7 +32,7 @@ type PropTypes = {
   currency: IsoCurrency,
   paymentMethod: PaymentMethod,
   onPaymentAuthorisation: PaymentAuthorisation => void,
-  paymentHandlers: PaymentMatrix<PaymentHandler | null>,
+  thirdPartyPaymentLibraries: PaymentMatrix<PaymentHandler | null>,
   updatePaymentMethod: PaymentMethod => Action,
   isPaymentReady: (boolean, ?{ [Contrib]: { [PaymentMethod]: PaymentHandler }}) => Action,
   isTestUser: boolean,
@@ -48,7 +45,7 @@ const mapStateToProps = (state: State) => ({
   currency: state.common.internationalisation.currencyId,
   contributionType: state.page.form.contributionType,
   paymentMethod: state.page.form.paymentMethod,
-  paymentHandlers: state.page.form.paymentHandlers,
+  thirdPartyPaymentLibraries: state.page.form.thirdPartyPaymentLibraries,
   isTestUser: state.page.user.isTestUser || false,
   switches: state.common.settings.switches,
 });
@@ -58,70 +55,12 @@ const mapDispatchToProps = {
   isPaymentReady,
 };
 
-// ----- Logic ----- //
-
-function initialiseStripeCheckout(props: PropTypes) {
-  const {
-    onPaymentAuthorisation,
-    contributionType,
-    currency,
-    isTestUser,
-  } = props;
-
-  // TODO IMPORTANT: we need to initialise Stripe separately for one-off and recurring
-  // I think this requires us to make
-  // paymentHandlers: { [PaymentMethod]: PaymentHandler | null }
-  // into
-  // paymentHandlers: { [Contrib]: {[PaymentMethod]: PaymentHandler | null }}
-  setupStripeCheckout(onPaymentAuthorisation, contributionType, currency, isTestUser)
-    .then((handler: PaymentHandler) => props.isPaymentReady(true, { Stripe: handler }));
-}
-
-// Bizarrely, adding a type to this object means the type-checking on the
-// paymentMethodInitialisers is no longer accurate.
-// (Flow thinks it's OK when it's missing required properties).
-const recurringPaymentMethodInitialisers = {
-  PayPal: () => { /* TODO PayPal recurring */ },
-  Stripe: initialiseStripeCheckout,
-  DirectDebit: () => { /* no initialisation required */ },
-};
-
-const paymentMethodInitialisers: PaymentMatrix<PropTypes => void> = {
-  ONE_OFF: {
-    Stripe: initialiseStripeCheckout,
-    PayPal: () => {
-      // PayPal one-off payments involve a call to PayPal's API (via the Payment API)
-      // and a clientside redirect. No third-party JS needed.
-      logException('Paypal one-off does not require initialisation');
-    },
-    DirectDebit: () => { logInvalidCombination('ONE_OFF', 'DirectDebit'); },
-    None: () => { logInvalidCombination('ONE_OFF', 'None'); },
-  },
-  ANNUAL: {
-    ...recurringPaymentMethodInitialisers,
-    None: () => { logInvalidCombination('ANNUAL', 'None'); },
-  },
-  MONTHLY: {
-    ...recurringPaymentMethodInitialisers,
-    None: () => { logInvalidCombination('MONTHLY', 'None'); },
-  },
-};
-
-
 // ----- Render ----- //
 
 function ContributionPayment(props: PropTypes) {
 
   const paymentMethods: PaymentMethod[] =
     getValidPaymentMethods(props.contributionType, props.switches, props.countryId);
-
-  // This means a particular payment method will only be initialised
-  // once its tab becomes active. If the tab is the default one selected,
-  // its payment methods will be initialised on page load.
-  const uninitialisedPaymentMethods = paymentMethods.filter(paymentMethod => !props.paymentHandlers[props.contributionType][paymentMethod]);
-  uninitialisedPaymentMethods.forEach((paymentMethod) => {
-    paymentMethodInitialisers[props.contributionType][paymentMethod](props);
-  });
 
   const noPaymentMethodsErrorMessage = <PaymentFailureMessage classModifiers={['no-valid-payments']} errorHeading="Payment methods are unavailable" checkoutFailureReason="all_payment_methods_unavailable" />;
 

--- a/assets/pages/new-contributions-landing/components/PaymentMethodSelector.jsx
+++ b/assets/pages/new-contributions-landing/components/PaymentMethodSelector.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { type PaymentHandler, getPaymentLabel, getValidPaymentMethods } from 'helpers/checkouts';
+import { type ThirdPartyPaymentLibrary, getPaymentLabel, getValidPaymentMethods } from 'helpers/checkouts';
 import { type Switches } from 'helpers/settings';
 import {
   type Contrib,
@@ -21,7 +21,7 @@ import SvgPayPal from 'components/svgs/paypal';
 import PaymentFailureMessage from 'components/paymentFailureMessage/paymentFailureMessage';
 
 import { type State } from '../contributionsLandingReducer';
-import { type Action, updatePaymentMethod, setPaymentIsReady } from '../contributionsLandingActions';
+import { type Action, updatePaymentMethod, setThirdPartyPaymentLibrary } from '../contributionsLandingActions';
 
 // ----- Types ----- //
 
@@ -32,9 +32,9 @@ type PropTypes = {
   currency: IsoCurrency,
   paymentMethod: PaymentMethod,
   onPaymentAuthorisation: PaymentAuthorisation => void,
-  thirdPartyPaymentLibraries: PaymentMatrix<PaymentHandler | null>,
+  thirdPartyPaymentLibraries: PaymentMatrix<ThirdPartyPaymentLibrary | null>,
   updatePaymentMethod: PaymentMethod => Action,
-  setPaymentIsReady: (boolean, ?{ [Contrib]: { [PaymentMethod]: PaymentHandler }}) => Action,
+  setThirdPartyPaymentLibrary: (?{ [Contrib]: { [PaymentMethod]: ThirdPartyPaymentLibrary }}) => Action,
   isTestUser: boolean,
   switches: Switches,
 };
@@ -52,7 +52,7 @@ const mapStateToProps = (state: State) => ({
 
 const mapDispatchToProps = {
   updatePaymentMethod,
-  setPaymentIsReady,
+  setThirdPartyPaymentLibrary,
 };
 
 // ----- Render ----- //

--- a/assets/pages/new-contributions-landing/components/PaymentMethodSelector.jsx
+++ b/assets/pages/new-contributions-landing/components/PaymentMethodSelector.jsx
@@ -10,7 +10,7 @@ import { type Switches } from 'helpers/settings';
 import {
   type Contrib,
   type PaymentMethod,
-  type PaymentMatrix,
+  type ThirdPartyPaymentLibraries,
 } from 'helpers/contributions';
 import { classNameWithModifiers } from 'helpers/utilities';
 import { type IsoCountry } from 'helpers/internationalisation/country';
@@ -32,7 +32,7 @@ type PropTypes = {
   currency: IsoCurrency,
   paymentMethod: PaymentMethod,
   onPaymentAuthorisation: PaymentAuthorisation => void,
-  thirdPartyPaymentLibraries: PaymentMatrix<ThirdPartyPaymentLibrary | null>,
+  thirdPartyPaymentLibraries: ThirdPartyPaymentLibraries,
   updatePaymentMethod: PaymentMethod => Action,
   setThirdPartyPaymentLibrary: (?{ [Contrib]: { [PaymentMethod]: ThirdPartyPaymentLibrary }}) => Action,
   isTestUser: boolean,

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -39,7 +39,7 @@ export type Action =
   | { type: 'UPDATE_PASSWORD', password: string }
   | { type: 'UPDATE_STATE', state: UsState | CaState | null }
   | { type: 'UPDATE_USER_FORM_DATA', userFormData: UserFormData }
-  | { type: 'UPDATE_PAYMENT_READY', paymentReady: boolean, paymentHandlers: ?{ [Contrib] : { [PaymentMethod]: PaymentHandler } } }
+  | { type: 'UPDATE_PAYMENT_READY', paymentReady: boolean, thirdPartyPaymentLibraries: ?{ [Contrib] : { [PaymentMethod]: PaymentHandler } } }
   | { type: 'SELECT_AMOUNT', amount: Amount | 'other', contributionType: Contrib }
   | { type: 'UPDATE_OTHER_AMOUNT', otherAmount: string }
   | { type: 'PAYMENT_RESULT', paymentResult: Promise<PaymentResult> }
@@ -94,8 +94,7 @@ const setThankYouPageStage = (thankYouPageStage: ThankYouPageStage): Action =>
   ({ type: 'SET_THANK_YOU_PAGE_STAGE', thankYouPageStage });
 
 const isPaymentReady = (paymentReady: boolean, paymentHandlers: ?{ [Contrib] : { [PaymentMethod]: PaymentHandler }}): Action =>
-  ({ type: 'UPDATE_PAYMENT_READY', paymentReady, paymentHandlers: paymentHandlers || null });
-
+  ({ type: 'UPDATE_PAYMENT_READY', paymentReady, thirdPartyPaymentLibraries: paymentHandlers || null });
 
 const getAmount = (state: State) =>
   parseFloat(state.page.form.selectedAmounts[state.page.form.contributionType] === 'other'

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -39,7 +39,7 @@ export type Action =
   | { type: 'UPDATE_PASSWORD', password: string }
   | { type: 'UPDATE_STATE', state: UsState | CaState | null }
   | { type: 'UPDATE_USER_FORM_DATA', userFormData: UserFormData }
-  | { type: 'UPDATE_PAYMENT_READY', paymentReady: boolean, thirdPartyPaymentLibraries: ?{ [Contrib] : { [PaymentMethod]: PaymentHandler } } }
+  | { type: 'UPDATE_PAYMENT_READY', paymentReady: boolean, thirdPartyPaymentLibraries: ?{ [Contrib]: { [PaymentMethod]: PaymentHandler } } }
   | { type: 'SELECT_AMOUNT', amount: Amount | 'other', contributionType: Contrib }
   | { type: 'UPDATE_OTHER_AMOUNT', otherAmount: string }
   | { type: 'PAYMENT_RESULT', paymentResult: Promise<PaymentResult> }
@@ -93,7 +93,10 @@ const setGuestAccountCreationToken = (guestAccountCreationToken: string): Action
 const setThankYouPageStage = (thankYouPageStage: ThankYouPageStage): Action =>
   ({ type: 'SET_THANK_YOU_PAGE_STAGE', thankYouPageStage });
 
-const isPaymentReady = (paymentReady: boolean, paymentHandlers: ?{ [Contrib] : { [PaymentMethod]: PaymentHandler }}): Action =>
+const isPaymentReady = (
+  paymentReady: boolean,
+  paymentHandlers: ?{ [Contrib]: { [PaymentMethod]: PaymentHandler }},
+): Action =>
   ({ type: 'UPDATE_PAYMENT_READY', paymentReady, thirdPartyPaymentLibraries: paymentHandlers || null });
 
 const getAmount = (state: State) =>
@@ -264,7 +267,7 @@ const paymentAuthorisationHandlers: PaymentMatrix<(Dispatch<Action>, State, Paym
 
 const onThirdPartyPaymentAuthorised = (paymentAuthorisation: PaymentAuthorisation) =>
   (dispatch: Function, getState: () => State): void => {
-  const state = getState();
+    const state = getState();
 
     paymentAuthorisationHandlers[state.page.form.contributionType][state.page.form.paymentMethod](
       dispatch,

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -3,7 +3,7 @@
 // ----- Imports ----- //
 
 import type { CheckoutFailureReason } from 'helpers/checkoutErrors';
-import { type PaymentHandler } from 'helpers/checkouts';
+import { type ThirdPartyPaymentLibrary } from 'helpers/checkouts';
 import { type Amount, logInvalidCombination, type Contrib, type PaymentMethod, type PaymentMatrix } from 'helpers/contributions';
 import type { Csrf } from 'helpers/csrf/csrfReducer';
 import { type CaState, type UsState } from 'helpers/internationalisation/country';
@@ -44,7 +44,7 @@ export type Action =
   | { type: 'UPDATE_PASSWORD', password: string }
   | { type: 'UPDATE_STATE', state: UsState | CaState | null }
   | { type: 'UPDATE_USER_FORM_DATA', userFormData: UserFormData }
-  | { type: 'UPDATE_PAYMENT_READY', paymentReady: boolean, thirdPartyPaymentLibraries: ?{ [Contrib]: { [PaymentMethod]: PaymentHandler } } }
+  | { type: 'UPDATE_PAYMENT_READY', thirdPartyPaymentLibrary: ?{ [Contrib]: { [PaymentMethod]: ThirdPartyPaymentLibrary } } }
   | { type: 'SELECT_AMOUNT', amount: Amount | 'other', contributionType: Contrib }
   | { type: 'UPDATE_OTHER_AMOUNT', otherAmount: string }
   | { type: 'PAYMENT_RESULT', paymentResult: Promise<PaymentResult> }
@@ -100,11 +100,10 @@ const setGuestAccountCreationToken = (guestAccountCreationToken: string): Action
 const setThankYouPageStage = (thankYouPageStage: ThankYouPageStage): Action =>
   ({ type: 'SET_THANK_YOU_PAGE_STAGE', thankYouPageStage });
 
-const setPaymentIsReady = (
-  paymentReady: boolean,
-  paymentHandlers: ?{ [Contrib]: { [PaymentMethod]: PaymentHandler }},
+const setThirdPartyPaymentLibrary = (
+  thirdPartyPaymentLibrary: ?{ [Contrib]: { [PaymentMethod]: ThirdPartyPaymentLibrary }},
 ): Action =>
-  ({ type: 'UPDATE_PAYMENT_READY', paymentReady, thirdPartyPaymentLibraries: paymentHandlers || null });
+  ({ type: 'UPDATE_PAYMENT_READY', thirdPartyPaymentLibrary: thirdPartyPaymentLibrary || null });
 
 const setPayPalHasLoaded = (): Action => ({ type: 'SET_PAYPAL_HAS_LOADED' });
 
@@ -329,7 +328,7 @@ export {
   updateEmail,
   updateState,
   updateUserFormData,
-  setPaymentIsReady,
+  setThirdPartyPaymentLibrary,
   selectAmount,
   updateOtherAmount,
   paymentFailure,

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -39,7 +39,7 @@ export type Action =
   | { type: 'UPDATE_PASSWORD', password: string }
   | { type: 'UPDATE_STATE', state: UsState | CaState | null }
   | { type: 'UPDATE_USER_FORM_DATA', userFormData: UserFormData }
-  | { type: 'UPDATE_PAYMENT_READY', paymentReady: boolean, paymentHandlers: ?{ [PaymentMethod]: PaymentHandler } }
+  | { type: 'UPDATE_PAYMENT_READY', paymentReady: boolean, paymentHandlers: ?{ [Contrib] : { [PaymentMethod]: PaymentHandler } } }
   | { type: 'SELECT_AMOUNT', amount: Amount | 'other', contributionType: Contrib }
   | { type: 'UPDATE_OTHER_AMOUNT', otherAmount: string }
   | { type: 'PAYMENT_RESULT', paymentResult: Promise<PaymentResult> }
@@ -93,7 +93,7 @@ const setGuestAccountCreationToken = (guestAccountCreationToken: string): Action
 const setThankYouPageStage = (thankYouPageStage: ThankYouPageStage): Action =>
   ({ type: 'SET_THANK_YOU_PAGE_STAGE', thankYouPageStage });
 
-const isPaymentReady = (paymentReady: boolean, paymentHandlers: ?{ [PaymentMethod]: PaymentHandler }): Action =>
+const isPaymentReady = (paymentReady: boolean, paymentHandlers: ?{ [Contrib] : { [PaymentMethod]: PaymentHandler }}): Action =>
   ({ type: 'UPDATE_PAYMENT_READY', paymentReady, paymentHandlers: paymentHandlers || null });
 
 

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -264,7 +264,7 @@ const paymentAuthorisationHandlers: PaymentMatrix<(Dispatch<Action>, State, Paym
 
 const onThirdPartyPaymentAuthorised = (paymentAuthorisation: PaymentAuthorisation) =>
   (dispatch: Dispatch<Action>, getState: () => State): void => {
-    const state = getState();
+  const state = getState();
 
     paymentAuthorisationHandlers[state.page.form.contributionType][state.page.form.paymentMethod](
       dispatch,

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -44,7 +44,7 @@ export type Action =
   | { type: 'UPDATE_PASSWORD', password: string }
   | { type: 'UPDATE_STATE', state: UsState | CaState | null }
   | { type: 'UPDATE_USER_FORM_DATA', userFormData: UserFormData }
-  | { type: 'UPDATE_PAYMENT_READY', thirdPartyPaymentLibrary: ?{ [Contrib]: { [PaymentMethod]: ThirdPartyPaymentLibrary } } }
+  | { type: 'UPDATE_PAYMENT_READY', thirdPartyPaymentLibraryByContrib: { [Contrib]: {[PaymentMethod]: ThirdPartyPaymentLibrary}} }
   | { type: 'SELECT_AMOUNT', amount: Amount | 'other', contributionType: Contrib }
   | { type: 'UPDATE_OTHER_AMOUNT', otherAmount: string }
   | { type: 'PAYMENT_RESULT', paymentResult: Promise<PaymentResult> }
@@ -100,10 +100,15 @@ const setGuestAccountCreationToken = (guestAccountCreationToken: string): Action
 const setThankYouPageStage = (thankYouPageStage: ThankYouPageStage): Action =>
   ({ type: 'SET_THANK_YOU_PAGE_STAGE', thankYouPageStage });
 
-const setThirdPartyPaymentLibrary = (
-  thirdPartyPaymentLibrary: ?{ [Contrib]: { [PaymentMethod]: ThirdPartyPaymentLibrary }},
-): Action =>
-  ({ type: 'UPDATE_PAYMENT_READY', thirdPartyPaymentLibrary: thirdPartyPaymentLibrary || null });
+const setThirdPartyPaymentLibrary =
+  (thirdPartyPaymentLibraryByContrib: {
+    [Contrib]: {
+      [PaymentMethod]: ThirdPartyPaymentLibrary
+    }
+  }): Action => ({
+    type: 'UPDATE_PAYMENT_READY',
+    thirdPartyPaymentLibraryByContrib: thirdPartyPaymentLibraryByContrib || null,
+  });
 
 const setPayPalHasLoaded = (): Action => ({ type: 'SET_PAYPAL_HAS_LOADED' });
 

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -263,7 +263,7 @@ const paymentAuthorisationHandlers: PaymentMatrix<(Dispatch<Action>, State, Paym
 };
 
 const onThirdPartyPaymentAuthorised = (paymentAuthorisation: PaymentAuthorisation) =>
-  (dispatch: Dispatch<Action>, getState: () => State): void => {
+  (dispatch: Function, getState: () => State): void => {
   const state = getState();
 
     paymentAuthorisationHandlers[state.page.form.contributionType][state.page.form.paymentMethod](

--- a/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -33,7 +33,7 @@ function initialisePaymentMethods(state: State, dispatch: Dispatch<Action>) {
 
   const onPaymentAuthorisation = (paymentAuthorisation: PaymentAuthorisation) => {
       dispatch(paymentWaiting(true));
-      onThirdPartyPaymentAuthorised(paymentAuthorisation)(dispatch, () => state)
+      dispatch(onThirdPartyPaymentAuthorised(paymentAuthorisation))
   };
 
   ['ONE_OFF', 'ANNUAL', 'MONTHLY'].forEach(contribType => {

--- a/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -5,12 +5,12 @@ import { type Store, type Dispatch } from 'redux';
 import { type PaymentAuthorisation } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
 import { loadPayPalRecurring } from 'helpers/paymentIntegrations/newPaymentFlow/payPalRecurringCheckout';
 import { setupStripeCheckout } from 'helpers/paymentIntegrations/newPaymentFlow/stripeCheckout';
-import { type PaymentHandler, getPaymentMethodToSelect, getValidPaymentMethods } from 'helpers/checkouts';
+import { type ThirdPartyPaymentLibrary, getPaymentMethodToSelect, getValidPaymentMethods } from 'helpers/checkouts';
 import {
   type Action,
   paymentWaiting,
   onThirdPartyPaymentAuthorised,
-  setPaymentIsReady,
+  setThirdPartyPaymentLibrary,
   updatePaymentMethod,
   updateUserFormData,
   setPayPalHasLoaded,
@@ -32,13 +32,12 @@ function selectDefaultPaymentMethod(state: State, dispatch: Dispatch<Action>) {
 function initialiseStripeCheckout(onPaymentAuthorisation, contributionType, currencyId, isTestUser, dispatch) {
 
   setupStripeCheckout(onPaymentAuthorisation, contributionType, currencyId, isTestUser)
-    .then((handler: PaymentHandler) => dispatch(setPaymentIsReady(true, { [contributionType]: { Stripe: handler } })));
+    .then((handler: ThirdPartyPaymentLibrary) => dispatch(setThirdPartyPaymentLibrary(true, { [contributionType]: { Stripe: handler } })));
 }
 
 function initialisePaymentMethods(state: State, dispatch: Function) {
-  const { countryId } = state.common.internationalisation;
+  const { countryId, currencyId } = state.common.internationalisation;
   const { switches } = state.common.settings;
-  const { currencyId } = state.common.internationalisation;
   const { isTestUser } = state.page.user;
 
   const onPaymentAuthorisation = (paymentAuthorisation: PaymentAuthorisation) => {

--- a/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -2,18 +2,32 @@
 
 // ----- Imports ----- //
 import { type Store, type Dispatch } from 'redux';
-import { getPaymentMethodToSelect } from 'helpers/checkouts';
 import {
   updatePaymentMethod,
   updateUserFormData,
 } from './contributionsLandingActions';
 import { type State } from './contributionsLandingReducer';
-import { type Action } from './contributionsLandingActions';
+import { type Action, paymentWaiting, onThirdPartyPaymentAuthorised, isPaymentReady } from './contributionsLandingActions';
+import { type PaymentAuthorisation } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
+import { setupStripeCheckout } from 'helpers/paymentIntegrations/newPaymentFlow/stripeCheckout';
+import { type PaymentHandler, getPaymentMethodToSelect, getValidPaymentMethods } from 'helpers/checkouts';
+import { type PaymentMatrix, type Contrib, logInvalidCombination } from 'helpers/contributions';
+import { logException,} from 'helpers/logger';
+import type {IsoCountry} from "../../helpers/internationalisation/country";
+
+
+
+type args = {
+  onPaymentAuthorisation: PaymentAuthorisation => void,
+  contributionType: Contrib,
+  currencyId: IsoCountry,
+  isTestUser: boolean,
+}
 
 // ----- Functions ----- //
 
 
-function initialisePaymentMethod(state: State, dispatch: Dispatch<Action>) {
+function selectDefaultPaymentMethod(state: State, dispatch: Dispatch<Action>) {
   const { contributionType } = state.page.form;
   const { countryId } = state.common.internationalisation;
   const { switches } = state.common.settings;
@@ -23,12 +37,40 @@ function initialisePaymentMethod(state: State, dispatch: Dispatch<Action>) {
   dispatch(updatePaymentMethod(paymentMethodToSelect));
 }
 
+function initialisePaymentMethods(state: State, dispatch: Dispatch<Action>) {
+  const {countryId} = state.common.internationalisation;
+  const {switches} = state.common.settings;
+  const {currencyId } = state.common.internationalisation;
+  const {isTestUser} = state.page.user;
+
+  const onPaymentAuthorisation = (paymentAuthorisation: PaymentAuthorisation) => {
+      dispatch(paymentWaiting(true));
+      onThirdPartyPaymentAuthorised(paymentAuthorisation)(dispatch, () => state)
+  };
+
+  ['ONE_OFF', 'ANNUAL', 'MONTHLY'].forEach(contribType => {
+    getValidPaymentMethods(contribType, switches, countryId).forEach((paymentMethod) => {
+      if (paymentMethod == 'Stripe') {
+        initialiseStripeCheckout(onPaymentAuthorisation, contribType, currencyId, !!isTestUser, dispatch)
+      }
+    });
+  })
+}
+
+// ----- Logic ----- //
+
+function initialiseStripeCheckout(onPaymentAuthorisation, contributionType, currencyId, isTestUser, dispatch) {
+
+  setupStripeCheckout(onPaymentAuthorisation, contributionType, currencyId, isTestUser)
+    .then((handler: PaymentHandler) => dispatch(isPaymentReady(true, { [contributionType] : { Stripe: handler } })));
+}
 
 const init = (store: Store<State, Action, Dispatch<Action>>) => {
   const { dispatch } = store;
 
   const state = store.getState();
-  initialisePaymentMethod(state, dispatch);
+  selectDefaultPaymentMethod(state, dispatch);
+  initialisePaymentMethods(state, dispatch);
 
   const { firstName, lastName, email } = state.page.user;
   dispatch(updateUserFormData({ firstName, lastName, email }));

--- a/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -25,7 +25,7 @@ function selectDefaultPaymentMethod(state: State, dispatch: Dispatch<Action>) {
   dispatch(updatePaymentMethod(paymentMethodToSelect));
 }
 
-function initialisePaymentMethods(state: State, dispatch: Dispatch<Action>) {
+function initialisePaymentMethods(state: State, dispatch: Function) {
   const {countryId} = state.common.internationalisation;
   const {switches} = state.common.settings;
   const {currencyId } = state.common.internationalisation;

--- a/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -11,18 +11,6 @@ import { type Action, paymentWaiting, onThirdPartyPaymentAuthorised, isPaymentRe
 import { type PaymentAuthorisation } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
 import { setupStripeCheckout } from 'helpers/paymentIntegrations/newPaymentFlow/stripeCheckout';
 import { type PaymentHandler, getPaymentMethodToSelect, getValidPaymentMethods } from 'helpers/checkouts';
-import { type PaymentMatrix, type Contrib, logInvalidCombination } from 'helpers/contributions';
-import { logException,} from 'helpers/logger';
-import type {IsoCountry} from "../../helpers/internationalisation/country";
-
-
-
-type args = {
-  onPaymentAuthorisation: PaymentAuthorisation => void,
-  contributionType: Contrib,
-  currencyId: IsoCountry,
-  isTestUser: boolean,
-}
 
 // ----- Functions ----- //
 

--- a/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -2,18 +2,18 @@
 
 // ----- Imports ----- //
 import { type Store, type Dispatch } from 'redux';
+import { type PaymentAuthorisation } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
+import { setupStripeCheckout } from 'helpers/paymentIntegrations/newPaymentFlow/stripeCheckout';
+import { type PaymentHandler, getPaymentMethodToSelect, getValidPaymentMethods } from 'helpers/checkouts';
 import {
   updatePaymentMethod,
   updateUserFormData,
 } from './contributionsLandingActions';
 import { type State } from './contributionsLandingReducer';
 import { type Action, paymentWaiting, onThirdPartyPaymentAuthorised, isPaymentReady } from './contributionsLandingActions';
-import { type PaymentAuthorisation } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
-import { setupStripeCheckout } from 'helpers/paymentIntegrations/newPaymentFlow/stripeCheckout';
-import { type PaymentHandler, getPaymentMethodToSelect, getValidPaymentMethods } from 'helpers/checkouts';
+
 
 // ----- Functions ----- //
-
 
 function selectDefaultPaymentMethod(state: State, dispatch: Dispatch<Action>) {
   const { contributionType } = state.page.form;
@@ -25,32 +25,30 @@ function selectDefaultPaymentMethod(state: State, dispatch: Dispatch<Action>) {
   dispatch(updatePaymentMethod(paymentMethodToSelect));
 }
 
-function initialisePaymentMethods(state: State, dispatch: Function) {
-  const {countryId} = state.common.internationalisation;
-  const {switches} = state.common.settings;
-  const {currencyId } = state.common.internationalisation;
-  const {isTestUser} = state.page.user;
-
-  const onPaymentAuthorisation = (paymentAuthorisation: PaymentAuthorisation) => {
-      dispatch(paymentWaiting(true));
-      dispatch(onThirdPartyPaymentAuthorised(paymentAuthorisation))
-  };
-
-  ['ONE_OFF', 'ANNUAL', 'MONTHLY'].forEach(contribType => {
-    getValidPaymentMethods(contribType, switches, countryId).forEach((paymentMethod) => {
-      if (paymentMethod == 'Stripe') {
-        initialiseStripeCheckout(onPaymentAuthorisation, contribType, currencyId, !!isTestUser, dispatch)
-      }
-    });
-  })
-}
-
-// ----- Logic ----- //
-
 function initialiseStripeCheckout(onPaymentAuthorisation, contributionType, currencyId, isTestUser, dispatch) {
 
   setupStripeCheckout(onPaymentAuthorisation, contributionType, currencyId, isTestUser)
-    .then((handler: PaymentHandler) => dispatch(isPaymentReady(true, { [contributionType] : { Stripe: handler } })));
+    .then((handler: PaymentHandler) => dispatch(isPaymentReady(true, { [contributionType]: { Stripe: handler } })));
+}
+
+function initialisePaymentMethods(state: State, dispatch: Function) {
+  const { countryId } = state.common.internationalisation;
+  const { switches } = state.common.settings;
+  const { currencyId } = state.common.internationalisation;
+  const { isTestUser } = state.page.user;
+
+  const onPaymentAuthorisation = (paymentAuthorisation: PaymentAuthorisation) => {
+    dispatch(paymentWaiting(true));
+    dispatch(onThirdPartyPaymentAuthorised(paymentAuthorisation));
+  };
+
+  ['ONE_OFF', 'ANNUAL', 'MONTHLY'].forEach((contribType) => {
+    getValidPaymentMethods(contribType, switches, countryId).forEach((paymentMethod) => {
+      if (paymentMethod === 'Stripe') {
+        initialiseStripeCheckout(onPaymentAuthorisation, contribType, currencyId, !!isTestUser, dispatch);
+      }
+    });
+  });
 }
 
 const init = (store: Store<State, Action, Dispatch<Action>>) => {

--- a/assets/pages/new-contributions-landing/contributionsLandingReducer.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingReducer.js
@@ -163,7 +163,11 @@ function createFormReducer(countryGroupId: CountryGroupId) {
           ? {
             ...state,
             paymentReady: action.paymentReady,
-            thirdPartyPaymentLibraries: { ...state.thirdPartyPaymentLibraries, ...action.thirdPartyPaymentLibraries },
+            thirdPartyPaymentLibraries: {
+              ONE_OFF: {...state.thirdPartyPaymentLibraries.ONE_OFF, ...action.thirdPartyPaymentLibraries.ONE_OFF},
+              MONTHLY: {...state.thirdPartyPaymentLibraries.MONTHLY, ...action.thirdPartyPaymentLibraries.MONTHLY},
+              ANNUAL: {...state.thirdPartyPaymentLibraries.ANNUAL, ...action.thirdPartyPaymentLibraries.ANNUAL},
+            }
           }
           : { ...state, paymentReady: action.paymentReady };
 

--- a/assets/pages/new-contributions-landing/contributionsLandingReducer.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingReducer.js
@@ -4,7 +4,7 @@
 
 import type { CheckoutFailureReason } from 'helpers/checkoutErrors';
 import { combineReducers } from 'redux';
-import { amounts, type Amount, type Contrib, type PaymentMethod, type PaymentMatrix } from 'helpers/contributions';
+import { amounts, type Amount, type Contrib, type PaymentMethod, type ThirdPartyPaymentLibraries } from 'helpers/contributions';
 import csrf from 'helpers/csrf/csrfReducer';
 import visitToken from 'helpers/visitToken/reducer';
 import { type CommonState } from 'helpers/page/page';
@@ -51,8 +51,7 @@ type SetPasswordData = {
 type FormState = {
   contributionType: Contrib,
   paymentMethod: PaymentMethod,
-  paymentReady: boolean,
-  thirdPartyPaymentLibraries: PaymentMatrix<Object>,
+  thirdPartyPaymentLibraries: ThirdPartyPaymentLibraries,
   selectedAmounts: { [Contrib]: Amount | 'other' },
   isWaiting: boolean,
   formData: FormData,
@@ -100,24 +99,16 @@ function createFormReducer(countryGroupId: CountryGroupId) {
     thirdPartyPaymentLibraries: {
       ONE_OFF: {
         Stripe: {},
-        DirectDebit: {},
-        PayPal: {},
-        None: {},
       },
       MONTHLY: {
         Stripe: {},
-        DirectDebit: {},
         PayPal: {},
-        None: {},
       },
       ANNUAL: {
         Stripe: {},
-        DirectDebit: {},
         PayPal: {},
-        None: {},
       },
     },
-    paymentReady: false,
     formData: {
       firstName: null,
       lastName: null,
@@ -159,17 +150,23 @@ function createFormReducer(countryGroupId: CountryGroupId) {
         return { ...state, paymentMethod: action.paymentMethod };
 
       case 'UPDATE_PAYMENT_READY':
-        return action.thirdPartyPaymentLibraries
-          ? {
-            ...state,
-            paymentReady: action.paymentReady,
-            thirdPartyPaymentLibraries: {
-              ONE_OFF: {...state.thirdPartyPaymentLibraries.ONE_OFF, ...action.thirdPartyPaymentLibraries.ONE_OFF},
-              MONTHLY: {...state.thirdPartyPaymentLibraries.MONTHLY, ...action.thirdPartyPaymentLibraries.MONTHLY},
-              ANNUAL: {...state.thirdPartyPaymentLibraries.ANNUAL, ...action.thirdPartyPaymentLibraries.ANNUAL},
-            }
-          }
-          : { ...state, paymentReady: action.paymentReady };
+        return {
+          ...state,
+          thirdPartyPaymentLibraries: {
+            ONE_OFF: {
+              ...state.thirdPartyPaymentLibraries.ONE_OFF,
+              ...action.thirdPartyPaymentLibraryByContrib.ONE_OFF,
+            },
+            MONTHLY: {
+              ...state.thirdPartyPaymentLibraries.MONTHLY,
+              ...action.thirdPartyPaymentLibraryByContrib.MONTHLY,
+            },
+            ANNUAL: {
+              ...state.thirdPartyPaymentLibraries.ANNUAL,
+              ...action.thirdPartyPaymentLibraryByContrib.ANNUAL,
+            },
+          },
+        };
 
       case 'UPDATE_FIRST_NAME':
         return { ...state, formData: { ...state.formData, firstName: action.firstName } };

--- a/assets/pages/new-contributions-landing/contributionsLandingReducer.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingReducer.js
@@ -5,7 +5,7 @@
 import type { CheckoutFailureReason } from 'helpers/checkoutErrors';
 import { combineReducers } from 'redux';
 import { type PaymentHandler } from 'helpers/checkouts';
-import { amounts, type Amount, type Contrib, type PaymentMethod } from 'helpers/contributions';
+import { amounts, type Amount, type Contrib, type PaymentMethod, type PaymentMatrix } from 'helpers/contributions';
 import csrf from 'helpers/csrf/csrfReducer';
 import visitToken from 'helpers/visitToken/reducer';
 import { type CommonState } from 'helpers/page/page';
@@ -53,9 +53,7 @@ type FormState = {
   contributionType: Contrib,
   paymentMethod: PaymentMethod,
   paymentReady: boolean,
-  paymentHandlers: {
-    [PaymentMethod]: PaymentHandler | null
-  },
+  paymentHandlers: PaymentMatrix<PaymentMethod | null>,
   selectedAmounts: { [Contrib]: Amount | 'other' },
   isWaiting: boolean,
   formData: FormData,
@@ -100,10 +98,24 @@ function createFormReducer(countryGroupId: CountryGroupId) {
     contributionType: 'MONTHLY',
     paymentMethod: 'None',
     paymentHandlers: {
-      Stripe: null,
-      DirectDebit: null,
-      PayPal: null,
-      None: null,
+      ONE_OFF: {
+        Stripe: null,
+        DirectDebit: null,
+        PayPal: null,
+        None: null,
+      },
+      MONTHLY: {
+        Stripe: null,
+        DirectDebit: null,
+        PayPal: null,
+        None: null,
+      },
+      ANNUAL: {
+        Stripe: null,
+        DirectDebit: null,
+        PayPal: null,
+        None: null,
+      },
     },
     paymentReady: false,
     formData: {

--- a/assets/pages/new-contributions-landing/contributionsLandingReducer.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingReducer.js
@@ -4,7 +4,6 @@
 
 import type { CheckoutFailureReason } from 'helpers/checkoutErrors';
 import { combineReducers } from 'redux';
-import { type PaymentHandler } from 'helpers/checkouts';
 import { amounts, type Amount, type Contrib, type PaymentMethod, type PaymentMatrix } from 'helpers/contributions';
 import csrf from 'helpers/csrf/csrfReducer';
 import visitToken from 'helpers/visitToken/reducer';
@@ -53,7 +52,7 @@ type FormState = {
   contributionType: Contrib,
   paymentMethod: PaymentMethod,
   paymentReady: boolean,
-  paymentHandlers: PaymentMatrix<PaymentMethod | null>,
+  thirdPartyPaymentLibraries: PaymentMatrix<Object>,
   selectedAmounts: { [Contrib]: Amount | 'other' },
   isWaiting: boolean,
   formData: FormData,
@@ -97,24 +96,24 @@ function createFormReducer(countryGroupId: CountryGroupId) {
   const initialState: FormState = {
     contributionType: 'MONTHLY',
     paymentMethod: 'None',
-    paymentHandlers: {
+    thirdPartyPaymentLibraries: {
       ONE_OFF: {
-        Stripe: null,
-        DirectDebit: null,
-        PayPal: null,
-        None: null,
+        Stripe: {},
+        DirectDebit: {},
+        PayPal: {},
+        None: {},
       },
       MONTHLY: {
-        Stripe: null,
-        DirectDebit: null,
-        PayPal: null,
-        None: null,
+        Stripe: {},
+        DirectDebit: {},
+        PayPal: {},
+        None: {},
       },
       ANNUAL: {
-        Stripe: null,
-        DirectDebit: null,
-        PayPal: null,
-        None: null,
+        Stripe: {},
+        DirectDebit: {},
+        PayPal: {},
+        None: {},
       },
     },
     paymentReady: false,
@@ -158,11 +157,11 @@ function createFormReducer(countryGroupId: CountryGroupId) {
         return { ...state, paymentMethod: action.paymentMethod };
 
       case 'UPDATE_PAYMENT_READY':
-        return action.paymentHandlers
+        return action.thirdPartyPaymentLibraries
           ? {
             ...state,
             paymentReady: action.paymentReady,
-            paymentHandlers: { ...state.paymentHandlers, ...action.paymentHandlers },
+            thirdPartyPaymentLibraries: { ...state.thirdPartyPaymentLibraries, ...action.thirdPartyPaymentLibraries },
           }
           : { ...state, paymentReady: action.paymentReady };
 


### PR DESCRIPTION
## Why are you doing this?
So the NPF works for Stripe one-off. 
<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/41e5ijeC/76-npf-stripe-does-not-switch-between-recurring-one-off-keys-when-changing-tabs-this-means-stripe-one-off-is-broken)

## Changes

* Renames `paymentHandlers` to `thirdPartyPaymentLibraries` because that is what they are! 
* Adds extra dimension to thirdPartyPaymentLibraries as Stripe one-off is different from recurring. Uses PaymentMatrix to ensure all combinations are covered! 
* Moves initialization of these libraries out of the render function and in to `contributionsLandingInit`.
* Initialises all libraries on page load (rather than when the tab / payment option is selected)
* No longer initialises with the matrix as the majority of combinations did not require action, instead uses a humble if statement to initialise stripe checkout. 

