### PR TITLE
Read email from flash session 

### DIFF
--- a/app/views/oneOffContributions.scala.html
+++ b/app/views/oneOffContributions.scala.html
@@ -14,11 +14,14 @@
         paymentApiStripeEndpoint: String,
         paymentApiPayPalEndpoint: String,
         idUser: Option[IdUser]
-)(implicit assets: AssetsResolver, request: RequestHeader, settings: Settings)
+)(implicit assets: AssetsResolver, request: RequestHeader, settings: Settings, flash: Flash)
 
 @scripts = {
     <script type="text/javascript">
         window.guardian = window.guardian || {};
+        @flash.get("email").map { email =>
+            window.guardian.email = "@email";
+        }
         @idUser.map { user =>
             window.guardian.user = {
                 id: "@user.id",


### PR DESCRIPTION
## Why are you doing this?
In order to display marketing permissions on the thank you page for paypal one off contributions, we need to read the email from the flash session.
