### PR TITLE
Ensure that the email is available in the state on the new thank you page 

### DIFF
--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -69,6 +69,9 @@ const updateFirstName = (firstName: string): Action => ({ type: 'UPDATE_FIRST_NA
 const updateLastName = (lastName: string): Action => ({ type: 'UPDATE_LAST_NAME', lastName });
 
 const updateEmail = (email: string): Action => {
+  // PayPal one-off redirects away from the site before hitting the thank you page
+  // so we need to store the email in the storage so that it is available on the
+  // thank you page in all scenarios.
   storage.setSession('gu.email', email);
   return ({ type: 'UPDATE_EMAIL', email });
 };

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -68,7 +68,10 @@ const updateFirstName = (firstName: string): Action => ({ type: 'UPDATE_FIRST_NA
 
 const updateLastName = (lastName: string): Action => ({ type: 'UPDATE_LAST_NAME', lastName });
 
-const updateEmail = (email: string): Action => ({ type: 'UPDATE_EMAIL', email });
+const updateEmail = (email: string): Action => {
+  storage.setSession('gu.email', email);
+  return ({ type: 'UPDATE_EMAIL', email });
+};
 
 const updatePassword = (password: string): Action => ({ type: 'UPDATE_PASSWORD', password });
 

--- a/assets/pages/new-contributions-landing/contributionsLandingReducer.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingReducer.js
@@ -16,6 +16,7 @@ import type { DirectDebitState } from 'components/directDebit/directDebitReducer
 import { directDebitReducer as directDebit } from 'components/directDebit/directDebitReducer';
 import { type Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import { type VisitToken as VisitTokenState } from 'helpers/visitToken/reducer';
+import * as storage from 'helpers/storage';
 
 import { type Action } from './contributionsLandingActions';
 
@@ -110,7 +111,7 @@ function createFormReducer(countryGroupId: CountryGroupId) {
     formData: {
       firstName: null,
       lastName: null,
-      email: null,
+      email: storage.getSession('email') || null,
       otherAmounts: {
         ONE_OFF: { amount: null },
         MONTHLY: { amount: null },


### PR DESCRIPTION
## Why are you doing this?

We want to guarantee that the email will be available on the thank you page, so that we can use it to set marketing permissions. 

This PR:

. sets a session cookie as the user is typing in their email
. Initialises `state.page.form.formData.email` with the value from the session, if available

This means that even if the user refreshes the thank you page, or if they had to get there via the one off paypal site, the email will be available in the state. 
