### PR TITLE
Enable marketing subscription on the new thank you page

### DIFF
--- a/assets/components/svgs/subscribed.jsx
+++ b/assets/components/svgs/subscribed.jsx
@@ -6,11 +6,20 @@ import React from 'react';
 export default function SvgSubscribed() {
 
   return (
-    <svg className="svg-subscribed" width="22" height="18" viewBox="0 0 22 18" fill="none"
-         xmlns="http://www.w3.org/2000/svg">
-      <path fill-rule="evenodd" clip-rule="evenodd"
-            d="M1.11252 8.87163L0 10.0127L5.56258 18H6.09102L22 1.11252L20.8875 0L6.09102 13.7496L1.11252 8.87163Z"
-            fill="#2D8530"></path>
+    <svg
+      className="svg-subscribed"
+      width="22"
+      height="18"
+      viewBox="0 0 22 18"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M1.11252 8.87163L0 10.0127L5.56258 18H6.09102L22 1.11252L20.8875 0L6.09102 13.7496L1.11252 8.87163Z"
+        fill="#2D8530"
+      />
     </svg>
   );
 }

--- a/assets/components/svgs/subscribed.jsx
+++ b/assets/components/svgs/subscribed.jsx
@@ -18,7 +18,7 @@ export default function SvgSubscribed() {
         fillRule="evenodd"
         clipRule="evenodd"
         d="M1.11252 8.87163L0 10.0127L5.56258 18H6.09102L22 1.11252L20.8875 0L6.09102 13.7496L1.11252 8.87163Z"
-        fill="#2D8530"
+        fill="#236925"
       />
     </svg>
   );

--- a/assets/components/svgs/subscribed.jsx
+++ b/assets/components/svgs/subscribed.jsx
@@ -1,0 +1,16 @@
+// @flow
+
+import React from 'react';
+
+// Subscribe button icon
+export default function SvgSubscribed() {
+
+  return (
+    <svg className="svg-subscribed" width="22" height="18" viewBox="0 0 22 18" fill="none"
+         xmlns="http://www.w3.org/2000/svg">
+      <path fill-rule="evenodd" clip-rule="evenodd"
+            d="M1.11252 8.87163L0 10.0127L5.56258 18H6.09102L22 1.11252L20.8875 0L6.09102 13.7496L1.11252 8.87163Z"
+            fill="#2D8530"></path>
+    </svg>
+  );
+}

--- a/assets/pages/new-contributions-landing/components/ContributionThankYou.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionThankYou.jsx
@@ -9,8 +9,7 @@ import { type Contrib, getSpokenType } from 'helpers/contributions';
 import { classNameWithModifiers } from 'helpers/utilities';
 
 import SvgArrowRight from 'components/svgs/arrowRightStraight';
-import SvgSubscribe from 'components/svgs/subscribe';
-import SvgNewsletters from 'components/svgs/newsletters';
+import MarketingConsent from '../components/marketingConsent';
 
 // ----- Types ----- //
 
@@ -39,19 +38,7 @@ function ContributionThankYou(props: PropTypes) {
         </section>
       ) : null}
 
-      <section className={classNameWithModifiers('confirmation', ['newsletter'])}>
-        <h3 className="confirmation__title">Subscriptions, membership and contributions</h3>
-        <p>
-          Get related news and offers – whether you are a subscriber, member,
-          contributor or would like to become one.
-        </p>
-        <a className={classNameWithModifiers('button', ['newsletter'])} href="/subscribe">
-          <SvgSubscribe />
-          Sign me up
-        </a>
-        <p className="confirmation__meta"><small>You can stop these at any time.</small></p>
-        <SvgNewsletters />
-      </section>
+      <MarketingConsent />
 
       <div className={classNameWithModifiers('confirmation', ['backtothegu'])}>
         <a className={classNameWithModifiers('button', ['wob'])} href="https://www.theguardian.com">

--- a/assets/pages/new-contributions-landing/components/marketingConsent.jsx
+++ b/assets/pages/new-contributions-landing/components/marketingConsent.jsx
@@ -3,16 +3,16 @@
 // ----- Imports ----- //
 
 import React from 'react';
+import { connect } from 'react-redux';
 import { classNameWithModifiers } from 'helpers/utilities';
 
 import SvgSubscribe from 'components/svgs/subscribe';
 import SvgSubscribed from 'components/svgs/subscribed';
 import SvgNewsletters from 'components/svgs/newsletters';
-import type {Dispatch} from "redux";
-import type {Action} from "../../../helpers/user/userActions";
-import type {Csrf as CsrfState} from "../../../helpers/csrf/csrfReducer";
-import {sendMarketingPreferencesToIdentity} from "../../../components/marketingConsent/helpers";
-import connect from "react-redux/es/connect/connect";
+import type { Dispatch } from 'redux';
+import type { Action } from '../../../helpers/user/userActions';
+import type { Csrf as CsrfState } from '../../../helpers/csrf/csrfReducer';
+import { sendMarketingPreferencesToIdentity } from '../../../components/marketingConsent/helpers';
 
 // ----- Types ----- //
 
@@ -55,16 +55,17 @@ function MarketingConsent(props: PropTypes) {
       </p>
 
       {props.confirmOptIn === null ?
-        <button className={classNameWithModifiers('button', ['newsletter'])}
+        <button
+          className={classNameWithModifiers('button', ['newsletter'])}
           onClick={
             () => props.onClick(props.email, props.csrf)
           }
         >
-          <SvgSubscribe/>
+          <SvgSubscribe />
           Sign me up
         </button> :
-        <button disabled='disabled' className={classNameWithModifiers('button', ['newsletter', 'newsletter__subscribed'])}>
-          <SvgSubscribed/>
+        <button disabled="disabled" className={classNameWithModifiers('button', ['newsletter', 'newsletter__subscribed'])}>
+          <SvgSubscribed />
           Signed up
         </button>
       }

--- a/assets/pages/new-contributions-landing/components/marketingConsent.jsx
+++ b/assets/pages/new-contributions-landing/components/marketingConsent.jsx
@@ -1,0 +1,78 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+import { classNameWithModifiers } from 'helpers/utilities';
+
+import SvgSubscribe from 'components/svgs/subscribe';
+import SvgSubscribed from 'components/svgs/subscribed';
+import SvgNewsletters from 'components/svgs/newsletters';
+import type {Dispatch} from "redux";
+import type {Action} from "../../../helpers/user/userActions";
+import type {Csrf as CsrfState} from "../../../helpers/csrf/csrfReducer";
+import {sendMarketingPreferencesToIdentity} from "../../../components/marketingConsent/helpers";
+import connect from "react-redux/es/connect/connect";
+
+// ----- Types ----- //
+
+type PropTypes = {
+  confirmOptIn: ?boolean,
+  email: string,
+  csrf: CsrfState,
+  onClick: (?string, CsrfState) => void,
+};
+
+const mapStateToProps = state => ({
+  confirmOptIn: state.page.marketingConsent.confirmOptIn,
+  email: state.page.form.formData.email,
+  csrf: state.page.csrf,
+});
+
+function mapDispatchToProps(dispatch: Dispatch<Action>) {
+  return {
+    onClick: (email: string, csrf: CsrfState) => {
+      sendMarketingPreferencesToIdentity(
+        true,
+        email,
+        dispatch,
+        csrf,
+        'MARKETING_CONSENT',
+      );
+    },
+  };
+}
+
+// ----- Render ----- //
+
+function MarketingConsent(props: PropTypes) {
+  return (
+    <section className={classNameWithModifiers('confirmation', ['newsletter'])}>
+      <h3 className="confirmation__title">Subscriptions, membership and contributions</h3>
+      <p>
+        Get related news and offers – whether you are a subscriber, member,
+        contributor or would like to become one.
+      </p>
+
+      {props.confirmOptIn === null ?
+        <button className={classNameWithModifiers('button', ['newsletter'])}
+          onClick={
+            () => props.onClick(props.email, props.csrf)
+          }
+        >
+          <SvgSubscribe/>
+          Sign me up
+        </button> :
+        <button disabled='disabled' className={classNameWithModifiers('button', ['newsletter', 'newsletter__subscribed'])}>
+          <SvgSubscribed/>
+          Signed up
+        </button>
+      }
+
+      <p className="confirmation__meta"><small>You can stop these at any time.</small></p>
+      <SvgNewsletters />
+    </section>
+  );
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(MarketingConsent);

--- a/assets/pages/new-contributions-landing/components/marketingConsent.jsx
+++ b/assets/pages/new-contributions-landing/components/marketingConsent.jsx
@@ -70,7 +70,14 @@ function MarketingConsent(props: PropTypes) {
         </button>
       }
 
-      <p className="confirmation__meta"><small>You can stop these at any time.</small></p>
+      <p className="confirmation__meta">
+        <small>
+          { props.confirmOptIn === true ?
+            'We\'ll be in touch. Check your inbox for a confirmation link.' :
+            'You can stop these at any time.'
+          }
+        </small>
+      </p>
       <SvgNewsletters />
     </section>
   );

--- a/assets/pages/new-contributions-landing/components/marketingConsent.jsx
+++ b/assets/pages/new-contributions-landing/components/marketingConsent.jsx
@@ -54,7 +54,11 @@ function MarketingConsent(props: PropTypes) {
         contributor or would like to become one.
       </p>
 
-      {props.confirmOptIn === null ?
+      {props.confirmOptIn === true ?
+        <button disabled="disabled" className={classNameWithModifiers('button', ['newsletter', 'newsletter__subscribed'])}>
+          <SvgSubscribed />
+          Signed up
+        </button> :
         <button
           className={classNameWithModifiers('button', ['newsletter'])}
           onClick={
@@ -63,10 +67,6 @@ function MarketingConsent(props: PropTypes) {
         >
           <SvgSubscribe />
           Sign me up
-        </button> :
-        <button disabled="disabled" className={classNameWithModifiers('button', ['newsletter', 'newsletter__subscribed'])}>
-          <SvgSubscribed />
-          Signed up
         </button>
       }
 

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -903,7 +903,7 @@ form {
 }
 
 .button--newsletter {
-  color: #ffffff;
+  color: gu-colour(garnett-neutral-5);
   background-color: #22834D;
 
   &:enabled {

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -908,6 +908,10 @@ form {
 
   &:enabled {
     cursor: pointer;
+
+    &:hover {
+      background-color: #206B44;
+    }
   }
 }
 

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -904,19 +904,19 @@ form {
 
 .button--newsletter {
   color: gu-colour(garnett-neutral-5);
-  background-color: #22834D;
+  background-color: gu-colour(green-dark);
 
   &:enabled {
     cursor: pointer;
 
     &:hover {
-      background-color: #206B44;
+      filter: brightness(90%);
     }
   }
 }
 
 .button--newsletter__subscribed {
-  color: #22834D;
+  color: gu-colour(green-dark);
   background-color: transparent;
 }
 

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -903,10 +903,20 @@ form {
 }
 
 .button--newsletter {
-  color: #29a05f;
+  color: #ffffff;
+  background-color: #22834D;
+
+  &:enabled {
+    cursor: pointer;
+  }
 }
 
-.button--newsletter .svg-subscribe {
+.button--newsletter__subscribed {
+  color: #22834D;
+  background-color: transparent;
+}
+
+.button--newsletter .svg-subscribe, .button--newsletter .svg-subscribed {
   margin-right: 10px;
 }
 

--- a/assets/pages/new-contributions-landing/contributionsLandingReducer.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingReducer.js
@@ -98,7 +98,7 @@ function createFormReducer(countryGroupId: CountryGroupId) {
   // ----- Initial state ----- //
 
   const initialState: FormState = {
-    contributionType: 'ONE_OFF',
+    contributionType: 'MONTHLY',
     paymentMethod: 'None',
     thirdPartyPaymentLibraries: {
       ONE_OFF: {

--- a/assets/pages/new-contributions-landing/contributionsLandingReducer.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingReducer.js
@@ -18,8 +18,8 @@ import { type SessionId as SessionIdState } from 'helpers/sessionId/reducer';
 import * as storage from 'helpers/storage';
 
 import { type Action } from './contributionsLandingActions';
-import type {State as MarketingConsentState} from "../../components/marketingConsent/marketingConsentReducer";
-import {marketingConsentReducerFor} from "../../components/marketingConsent/marketingConsentReducer";
+import type { State as MarketingConsentState } from '../../components/marketingConsent/marketingConsentReducer';
+import { marketingConsentReducerFor } from '../../components/marketingConsent/marketingConsentReducer';
 
 // ----- Types ----- //
 

--- a/assets/pages/new-contributions-landing/contributionsLandingReducer.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingReducer.js
@@ -18,6 +18,8 @@ import { type SessionId as SessionIdState } from 'helpers/sessionId/reducer';
 import * as storage from 'helpers/storage';
 
 import { type Action } from './contributionsLandingActions';
+import type {State as MarketingConsentState} from "../../components/marketingConsent/marketingConsentReducer";
+import {marketingConsentReducerFor} from "../../components/marketingConsent/marketingConsentReducer";
 
 // ----- Types ----- //
 
@@ -70,6 +72,7 @@ type PageState = {
   csrf: CsrfState,
   directDebit: DirectDebitState,
   sessionId: SessionIdState,
+  marketingConsent: MarketingConsentState,
 };
 
 export type State = {
@@ -95,7 +98,7 @@ function createFormReducer(countryGroupId: CountryGroupId) {
   // ----- Initial state ----- //
 
   const initialState: FormState = {
-    contributionType: 'MONTHLY',
+    contributionType: 'ONE_OFF',
     paymentMethod: 'None',
     thirdPartyPaymentLibraries: {
       ONE_OFF: {
@@ -252,6 +255,7 @@ function initReducer(countryGroupId: CountryGroupId) {
     directDebit,
     csrf,
     sessionId,
+    marketingConsent: marketingConsentReducerFor('MARKETING_CONSENT'),
   });
 }
 

--- a/assets/stylesheets/gu-sass/colours.scss
+++ b/assets/stylesheets/gu-sass/colours.scss
@@ -137,6 +137,8 @@ $gu-colours: (
 
   immersive-garnett-main-1: rgba(0, 0, 0, .65),
   analysis-garnett-underline: #ffbac8,
+
+  green-dark: #236925,
 );
 
 // Given the name of the colour this returns the hex value.


### PR DESCRIPTION
## Why are you doing this?
Enables the 'Sign me up' button on the new thank you page.
Uses the same `confirmOptIn` state as the existing implementation, but in a new scope.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/vKWRd715/11-npf-thank-you-page-wire-up-marketing-permissions)

## Screenshots
![picture 4](https://user-images.githubusercontent.com/1513454/47207977-92fd0780-d384-11e8-8a3b-e82e66c5478f.png)
![picture 6](https://user-images.githubusercontent.com/1513454/47212683-d65d7300-d390-11e8-9331-0332b6392a21.png)



