### PR TITLE
Display error message if signup fails

### DIFF
--- a/assets/pages/new-contributions-landing/components/SetPassword/SetPasswordForm.jsx
+++ b/assets/pages/new-contributions-landing/components/SetPassword/SetPasswordForm.jsx
@@ -11,12 +11,16 @@ import { setPasswordGuest } from 'helpers/paymentIntegrations/newPaymentFlow/rea
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import SvgPasswordKey from 'components/svgs/passwordKey';
 import SvgEnvelope from 'components/svgs/envelope';
+import SvgExclamationAlternate from 'components/svgs/exclamationAlternate';
 import { checkEmail, emailRegexPattern } from 'helpers/formValidation';
 
 import { NewContributionTextInput } from '../ContributionTextInput';
 import { type ThankYouPageStage } from '../../contributionsLandingReducer';
-import { setThankYouPageStage, setPasswordHasBeenSubmitted, updatePassword, type Action } from '../../contributionsLandingActions';
+import { setThankYouPageStage, setPasswordHasBeenSubmitted, setPasswordError, updatePassword, type Action } from '../../contributionsLandingActions';
 import { ButtonWithRightArrow } from '../ButtonWithRightArrow';
+
+const passwordErrorHeading = 'Account set up failure';
+const passwordErrorMessage = 'Sorry, we are unable to register you at this time. We are working hard to fix the problem and hope to be back up and running soon. Please come back later to complete your registration. Thank you.';
 
 // ----- Types ----- //
 
@@ -30,6 +34,8 @@ type PropTypes = {
   passwordHasBeenSubmitted: boolean,
   updatePassword: (Event) => void,
   csrf: CsrfState,
+  passwordError: boolean,
+  setPasswordError: (boolean) => void,
 };
 /* eslint-enable react/no-unused-prop-types */
 
@@ -42,6 +48,7 @@ const mapStateToProps = state => ({
   passwordHasBeenSubmitted: state.page.form.setPasswordData.passwordHasBeenSubmitted,
   guestAccountCreationToken: state.page.form.guestAccountCreationToken,
   csrf: state.page.csrf,
+  passwordError: state.page.form.setPasswordData.passwordError,
 });
 
 function mapDispatchToProps(dispatch: Dispatch<Action>) {
@@ -56,6 +63,9 @@ function mapDispatchToProps(dispatch: Dispatch<Action>) {
       if (event.target instanceof HTMLInputElement) {
         dispatch(updatePassword(event.target.value));
       }
+    },
+    setPasswordError: (passwordError: boolean) => {
+      dispatch(setPasswordError(passwordError));
     },
   };
 }
@@ -77,6 +87,8 @@ function onSubmit(props: PropTypes): Event => void {
       .then((response) => {
         if (response === true) {
           props.setThankYouPageStage('thankYouPasswordSet');
+        } else {
+          props.setPasswordError(true);
         }
       });
   };
@@ -134,6 +146,12 @@ function SetPasswordForm(props: PropTypes) {
           onClick={() => { props.setThankYouPageStage('thankYouPasswordDeclinedToSet'); }}
         />
       </form>
+      {props.passwordError === true ?
+        <div className="component-password-failure-message component-payment-failure-message">
+          <SvgExclamationAlternate /><span className="component-payment-failure-message__error-heading">{passwordErrorHeading}</span>
+          <span className="component-payment-failure-message__small-print">{passwordErrorMessage}</span>
+        </div> : null
+      }
     </div>
   );
 

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -983,3 +983,7 @@ form {
   vertical-align: top;
   padding-left: 5px;
 }
+
+.component-password-failure-message {
+  padding: 0 $gu-h-spacing $gu-v-spacing;
+}

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -56,6 +56,7 @@ export type Action =
   | { type: 'PAYMENT_WAITING', isWaiting: boolean }
   | { type: 'SET_CHECKOUT_FORM_HAS_BEEN_SUBMITTED' }
   | { type: 'SET_PASSWORD_HAS_BEEN_SUBMITTED' }
+  | { type: 'SET_PASSWORD_ERROR', passwordError: boolean }
   | { type: 'SET_GUEST_ACCOUNT_CREATION_TOKEN', guestAccountCreationToken: string }
   | { type: 'SET_THANK_YOU_PAGE_STAGE', thankYouPageStage: ThankYouPageStage }
   | { type: 'SET_PAYPAL_HAS_LOADED' }
@@ -95,6 +96,8 @@ const selectAmount = (amount: Amount | 'other', contributionType: Contrib): Acti
 const setCheckoutFormHasBeenSubmitted = (): Action => ({ type: 'SET_CHECKOUT_FORM_HAS_BEEN_SUBMITTED' });
 
 const setPasswordHasBeenSubmitted = (): Action => ({ type: 'SET_PASSWORD_HAS_BEEN_SUBMITTED' });
+
+const setPasswordError = (passwordError: boolean): Action => ({ type: 'SET_PASSWORD_ERROR', passwordError });
 
 const updateOtherAmount = (otherAmount: string): Action => ({ type: 'UPDATE_OTHER_AMOUNT', otherAmount });
 
@@ -356,6 +359,7 @@ export {
   setGuestAccountCreationToken,
   setThankYouPageStage,
   setPasswordHasBeenSubmitted,
+  setPasswordError,
   updatePassword,
   createOneOffPayPalPayment,
   setPayPalHasLoaded,

--- a/assets/pages/new-contributions-landing/contributionsLandingReducer.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingReducer.js
@@ -49,6 +49,7 @@ type FormData = UserFormData & {
 type SetPasswordData = {
   password: string,
   passwordHasBeenSubmitted: boolean,
+  passwordError: boolean,
 }
 
 type FormState = {
@@ -129,6 +130,7 @@ function createFormReducer(countryGroupId: CountryGroupId) {
     setPasswordData: {
       password: '',
       passwordHasBeenSubmitted: false,
+      passwordError: false,
     },
     showOtherAmount: false,
     selectedAmounts: initialAmount,
@@ -188,6 +190,9 @@ function createFormReducer(countryGroupId: CountryGroupId) {
 
       case 'SET_PASSWORD_HAS_BEEN_SUBMITTED':
         return { ...state, setPasswordData: { ...state.setPasswordData, passwordHasBeenSubmitted: true } };
+
+      case 'SET_PASSWORD_ERROR':
+        return { ...state, setPasswordData: { ...state.setPasswordData, passwordError: action.passwordError } };
 
       case 'UPDATE_STATE':
         return { ...state, formData: { ...state.formData, state: action.state } };


### PR DESCRIPTION
## Why are you doing this?
If there is a server-side error after a user enters a password, it needs to display an error message in the same page.
<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/Rl2eyHuG/103-npf-show-error-message-if-set-password-fails)

## Screenshots
<img width="404" alt="picture 8" src="https://user-images.githubusercontent.com/1513454/47226714-16d0e700-d3b9-11e8-984f-01dd0013d587.png">

