### PR TITLE
checks array is defined before pushing

### DIFF
--- a/assets/helpers/tracking/googleTagManager.js
+++ b/assets/helpers/tracking/googleTagManager.js
@@ -191,12 +191,14 @@ function successfulConversion(participations: Participations) {
 }
 
 function gaEvent(gaEventData: GaEventData) {
-  window.googleTagManagerDataLayer.push({
-    event: 'GAEvent',
-    eventCategory: gaEventData.category,
-    eventAction: gaEventData.action,
-    eventLabel: gaEventData.label,
-  });
+  if (window.googleTagManagerDataLayer) {
+    window.googleTagManagerDataLayer.push({
+      event: 'GAEvent',
+      eventCategory: gaEventData.category,
+      eventAction: gaEventData.action,
+      eventLabel: gaEventData.label,
+    });
+  }
 }
 
 function appStoreCtaClick() {


### PR DESCRIPTION
## Why are you doing this?
To prevent a type error. 

If `doNotTrack` is set on `navigator` or `window`, e.g. in Firefox private session, then [googleTagManager init](https://github.com/guardian/support-frontend/blob/master/assets/helpers/page/page.js#L72) is not called. This means that `window.googleTagManagerDataLayer` is undefined. 

When a user clicks on ctas it triggers `gaEvent`, e.g. clicking on 'Find Out More' for the Digital pack. This pushes details to `window.googleTagManagerDataLayer` which results in a type error if `window.googleTagManagerDataLayer` is undefined. 

We've had 2.2k sentry errors since October due to `Cannot read property 'push' of undefined`.  This should prevent some of them. 

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Changes

* Checks `window.googleTagManagerDataLayer` exists before trying to push to it. 

