### PR TITLE
Enforce exact types for PropTypes as convention

### DIFF
--- a/assets/components/adFreeSection/adFreeSection.jsx
+++ b/assets/components/adFreeSection/adFreeSection.jsx
@@ -9,9 +9,9 @@ import Heading, { type HeadingSize } from 'components/heading/heading';
 
 // ---- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   headingSize: HeadingSize,
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/checkboxInput/checkboxInput.jsx
+++ b/assets/components/checkboxInput/checkboxInput.jsx
@@ -7,13 +7,13 @@ import * as React from 'react';
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   id: ?string,
   onChange: (preference: boolean) => void,
   checked: boolean,
   labelTitle?: string,
   labelCopy?: string,
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/contribute/contribute.jsx
+++ b/assets/components/contribute/contribute.jsx
@@ -13,12 +13,12 @@ import type { Node } from 'react';
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   copy: string | Node,
   children: Node,
   heading?: string,
   modifierClasses: Array<?string>,
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
+++ b/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
@@ -27,22 +27,22 @@ import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   contributionType: ContributionType,
   amount: number,
   referrerAcquisitionData: ReferrerAcquisitionData,
   countryGroupId: CountryGroupId,
   currencyId: IsoCurrency,
   isDisabled: boolean,
-  PayPalButton: React$ComponentType<{
+  PayPalButton: React$ComponentType<{|
     buttonText?: string,
     onClick?: ?(void => void),
     additionalClass?: string,
     switchStatus?: Status,
-  }>,
+  |}>,
   error: ?string,
   resetError: void => void,
-};
+|};
 
 
 // ----- Heading ----- //

--- a/assets/components/contributionsCheckout/contributionsCheckout.jsx
+++ b/assets/components/contributionsCheckout/contributionsCheckout.jsx
@@ -21,7 +21,7 @@ import { getTitle } from 'helpers/checkoutForm/checkoutForm';
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   amount: number,
   currencyId: IsoCurrency,
   contributionType: ContributionType,
@@ -29,7 +29,7 @@ type PropTypes = {
   isSignedIn: boolean,
   form: Node,
   payment: Node,
-};
+|};
 
 // ----- Component ----- //
 

--- a/assets/components/contributionsThankYou/contributionsThankYouPage.jsx
+++ b/assets/components/contributionsThankYou/contributionsThankYouPage.jsx
@@ -17,12 +17,12 @@ import type { CountryGroupId } from '../../helpers/internationalisation/countryG
 
 // ---- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   contributionType: Contrib,
   directDebit: ?DirectDebit,
   countryGroupId: CountryGroupId,
   marketingConsent: Node,
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/contributionsThankYou/directDebitPaymentMethodDetails.jsx
+++ b/assets/components/contributionsThankYou/directDebitPaymentMethodDetails.jsx
@@ -7,11 +7,11 @@ import React from 'react';
 import PageSection from 'components/pageSection/pageSection';
 import SvgDirectDebitSymbolAndText from 'components/svgs/directDebitSymbolAndText';
 
-type PropTypes = {
+type PropTypes = {|
   accountHolderName: string,
   accountNumber: string,
   sortCodeArray: string[],
-}
+|}
 
 function mask(s: string): string {
   return `******${s.substring(6)}`;

--- a/assets/components/countryGroupSwitcher/countryGroupSwitcher.jsx
+++ b/assets/components/countryGroupSwitcher/countryGroupSwitcher.jsx
@@ -20,11 +20,11 @@ import type { SelectOption } from 'components/selectInput/selectInput';
 
 // ----- Props ----- //
 
-type PropTypes = {
+type PropTypes = {|
   countryGroupIds: CountryGroupId[],
   selectedCountryGroup: CountryGroupId,
   onCountryGroupSelect: CountryGroupId => void,
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/ctaLink/ctaLink.jsx
+++ b/assets/components/ctaLink/ctaLink.jsx
@@ -13,7 +13,7 @@ import type { Node } from 'react';
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   text: string,
   accessibilityHint: string,
   url?: ?string,
@@ -22,7 +22,7 @@ type PropTypes = {
   id?: ?string,
   svg?: Node,
   modifierClasses: Array<?string>,
-};
+|};
 
 // ----- Component ----- //
 

--- a/assets/components/customerService/customerService.jsx
+++ b/assets/components/customerService/customerService.jsx
@@ -8,13 +8,13 @@ import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 // ----- Props ----- //
 
-type PropTypes = {
+type PropTypes = {|
   selectedCountryGroup: CountryGroupId,
-};
+|};
 
 // ----- Functions ----- //
 
-function DigitalPackEmail(props: {email: string}) {
+function DigitalPackEmail(props: { email: string }) {
   return (
     <a className="component-customer-service__digital-pack-email" href={`mailto:${props.email}`}>
       {props.email}
@@ -40,45 +40,49 @@ function FAQBlock() {
 
 function CustomerService(props: PropTypes) {
   switch (props.selectedCountryGroup) {
-    case 'UnitedStates': return (
-      <div className="component-customer-service">
-        <div className="component-customer-service__text">
-          For help with Guardian and Observer subscription services please email <DigitalPackEmail /> or
-          call 1-844-632-2010 (toll free); 917-900-4663 (direct line).
-          Lines are open 9:15am-6pm, Monday to Friday (EST/EDT).
-          <FAQBlock />
+    case 'UnitedStates':
+      return (
+        <div className="component-customer-service">
+          <div className="component-customer-service__text">
+            For help with Guardian and Observer subscription services please email <DigitalPackEmail /> or
+            call 1-844-632-2010 (toll free); 917-900-4663 (direct line).
+            Lines are open 9:15am-6pm, Monday to Friday (EST/EDT).
+            <FAQBlock />
+          </div>
         </div>
-      </div>
-    );
-    case 'GBPCountries': return (
-      <div className="component-customer-service">
-        <div className="component-customer-service__text">
-          For help with Guardian and Observer subscription services please email <DigitalPackEmail /> or
-          call 0330 333 6767 (within UK). Lines are open 8am-8pm on weekdays, 8am-6pm at weekends (GMT/BST).
-          <FAQBlock />
+      );
+    case 'GBPCountries':
+      return (
+        <div className="component-customer-service">
+          <div className="component-customer-service__text">
+            For help with Guardian and Observer subscription services please email <DigitalPackEmail /> or
+            call 0330 333 6767 (within UK). Lines are open 8am-8pm on weekdays, 8am-6pm at weekends (GMT/BST).
+            <FAQBlock />
+          </div>
         </div>
-      </div>
-    );
-    case 'AUDCountries': return (
-      <div className="component-customer-service">
-        <div className="component-customer-service__text">
-          For help with Guardian and Observer subscription services please
-          email <DigitalPackEmail email="apac.help@theguardian.com" /> or
-          call 1800 773 766 (within Australia) or +61 2 8076 8599 (outside Australia).
-          Lines are open 9am-5pm Monday-Friday (AEDT)
-          <FAQBlock />
+      );
+    case 'AUDCountries':
+      return (
+        <div className="component-customer-service">
+          <div className="component-customer-service__text">
+            For help with Guardian and Observer subscription services please
+            email <DigitalPackEmail email="apac.help@theguardian.com" /> or
+            call 1800 773 766 (within Australia) or +61 2 8076 8599 (outside Australia).
+            Lines are open 9am-5pm Monday-Friday (AEDT)
+            <FAQBlock />
+          </div>
         </div>
-      </div>
-    );
-    default: return (
-      <div className="component-customer-service">
-        <div className="component-customer-service__text">
-          For help with Guardian and Observer subscription services please email <DigitalPackEmail /> or
-          call +44 (0) 330 333 6767. Lines are open 8am-8pm on weekdays, 8am-6pm at weekends (GMT/BST).
-          <FAQBlock />
+      );
+    default:
+      return (
+        <div className="component-customer-service">
+          <div className="component-customer-service__text">
+            For help with Guardian and Observer subscription services please email <DigitalPackEmail /> or
+            call +44 (0) 330 333 6767. Lines are open 8am-8pm on weekdays, 8am-6pm at weekends (GMT/BST).
+            <FAQBlock />
+          </div>
         </div>
-      </div>
-    );
+      );
   }
 }
 

--- a/assets/components/directDebit/directDebitForm/directDebitForm.jsx
+++ b/assets/components/directDebit/directDebitForm/directDebitForm.jsx
@@ -31,7 +31,7 @@ import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/newPaymen
 
 // ---- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   onPaymentAuthorisation: PaymentAuthorisation => void,
   isDDGuaranteeOpen: boolean,
   sortCodeArray: Array<string>,
@@ -50,7 +50,7 @@ type PropTypes = {
   editDirectDebitClicked: () => void,
   confirmDirectDebitClicked: (onPaymentAuthorisation: PaymentAuthorisation => void) => void,
   countryGroupId: CountryGroupId,
-};
+|};
 
 
 // ----- Map State/Props ----- //

--- a/assets/components/directDebit/directDebitForm/directDebitGuarantee.jsx
+++ b/assets/components/directDebit/directDebitForm/directDebitGuarantee.jsx
@@ -4,11 +4,11 @@
 import React from 'react';
 import { classNameWithModifiers } from 'helpers/utilities';
 
-type PropTypes = {
+type PropTypes = {|
   isDDGuaranteeOpen: boolean,
   openDDGuaranteeClicked: () => void,
   closeDDGuaranteeClicked: () => void
-};
+|};
 
 function className(baseClass: string, open: boolean) {
   return classNameWithModifiers(baseClass, open ? ['open'] : ['closed']);

--- a/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.jsx
+++ b/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.jsx
@@ -19,12 +19,12 @@ import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/newPaymen
 
 // ---- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   onPaymentAuthorisation: PaymentAuthorisation => void,
   isPopUpOpen: boolean,
   closeDirectDebitPopUp: () => void,
   phase: Phase,
-};
+|};
 
 
 // ----- Map State/Props ----- //

--- a/assets/components/displayName/displayName.jsx
+++ b/assets/components/displayName/displayName.jsx
@@ -8,10 +8,10 @@ import SvgUser from 'components/svgs/user';
 
 // ---- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   name: string,
   isSignedIn: boolean,
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/doubleHeading/doubleHeading.jsx
+++ b/assets/components/doubleHeading/doubleHeading.jsx
@@ -10,12 +10,12 @@ import Heading, { type HeadingSize } from 'components/heading/heading';
 
 // ---- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   heading: string,
   subheading?: Node,
   headingSize: HeadingSize,
   modifierClass?: string,
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/errorMessage/errorMessage.jsx
+++ b/assets/components/errorMessage/errorMessage.jsx
@@ -9,11 +9,11 @@ import SvgExclamation from 'components/svgs/exclamation';
 
 // ---- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   showError?: boolean,
   message: ?string,
   svg?: Node,
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/featureList/featureList.jsx
+++ b/assets/components/featureList/featureList.jsx
@@ -14,10 +14,10 @@ export type ListItem =
   | {| heading: Node |}
   | {| text: string |};
 
-type PropTypes = {
+type PropTypes = {|
   modifierClass?: string,
   listItems: ListItem[],
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/featuredDigitalPack/featuredDigitalPack.jsx
+++ b/assets/components/featuredDigitalPack/featuredDigitalPack.jsx
@@ -20,12 +20,12 @@ import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   headingSize: HeadingSize,
   countryGroupId: CountryGroupId,
   url: string,
   abTest: ComponentAbTest | null,
-};
+|};
 
 type Copy = {
   heading: string,

--- a/assets/components/footer/footer.jsx
+++ b/assets/components/footer/footer.jsx
@@ -11,12 +11,12 @@ import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 // ----- Props ----- //
 
-type PropTypes = {
+type PropTypes = {|
   privacyPolicy: boolean,
   disclaimer: boolean,
   countryGroupId: CountryGroupId,
   children: Node,
-};
+|};
 
 
 // ----- Functions ----- //

--- a/assets/components/headers/countrySwitcherHeader/countrySwitcherHeader.jsx
+++ b/assets/components/headers/countrySwitcherHeader/countrySwitcherHeader.jsx
@@ -8,11 +8,11 @@ import SvgGuardianLogo from 'components/svgs/guardianLogo';
 import CountryGroupSwitcher from 'components/countryGroupSwitcher/countryGroupSwitcher';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
-export type PropTypes = {
+export type PropTypes = {|
   countryGroupIds: CountryGroupId[],
   selectedCountryGroupId: CountryGroupId,
   onCountryGroupSelect: CountryGroupId => void,
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/headers/new-header/Header.jsx
+++ b/assets/components/headers/new-header/Header.jsx
@@ -14,9 +14,9 @@ import SvgRoundel from 'components/svgs/roundel';
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   selectedCountryGroup: ?CountryGroup,
-};
+|};
 
 // ----- Render ----- //
 

--- a/assets/components/heading/heading.jsx
+++ b/assets/components/heading/heading.jsx
@@ -9,11 +9,11 @@ import React, { type Node } from 'react';
 
 export type HeadingSize = 1 | 2 | 3 | 4 | 5 | 6;
 
-type PropTypes = {
+type PropTypes = {|
   size: HeadingSize,
   className: string,
   children: Node,
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/headingBlock/headingBlock.jsx
+++ b/assets/components/headingBlock/headingBlock.jsx
@@ -7,10 +7,10 @@ import React, { type Node } from 'react';
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   heading: string,
   children: Node,
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/highlights/highlights.jsx
+++ b/assets/components/highlights/highlights.jsx
@@ -9,11 +9,11 @@ import { classNameWithModifiers } from 'helpers/utilities';
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   highlights: ?string[],
   headingSize: HeadingSize,
   modifierClasses: Array<?string>,
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/introduction/circlesIntroduction.jsx
+++ b/assets/components/introduction/circlesIntroduction.jsx
@@ -14,12 +14,12 @@ import { type HeadingSize } from 'components/heading/heading';
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   headings: string[],
   highlights?: ?string[],
   modifierClasses: Array<?string>,
   highlightsHeadingSize: HeadingSize,
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/introduction/squaresIntroduction.jsx
+++ b/assets/components/introduction/squaresIntroduction.jsx
@@ -14,11 +14,11 @@ import { type HeadingSize } from 'components/heading/heading';
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   highlights?: ?string[],
   headings: string[],
   highlightsHeadingSize: HeadingSize,
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/leftMarginSection/leftMarginSection.jsx
+++ b/assets/components/leftMarginSection/leftMarginSection.jsx
@@ -9,10 +9,10 @@ import { classNameWithModifiers } from 'helpers/utilities';
 
 // ----- Props ----- //
 
-type PropTypes = {
+type PropTypes = {|
   modifierClasses: Array<?string>,
   children: Node,
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/legal/contribLegal/contribLegal.jsx
+++ b/assets/components/legal/contribLegal/contribLegal.jsx
@@ -11,9 +11,9 @@ import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 // ---- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
     countryGroupId: CountryGroupId,
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/legal/legalSection/legalSection.jsx
+++ b/assets/components/legal/legalSection/legalSection.jsx
@@ -13,9 +13,9 @@ import ContribLegal from '../contribLegal/contribLegal';
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   countryGroupId: CountryGroupId,
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/legal/termsPrivacy/termsPrivacy.jsx
+++ b/assets/components/legal/termsPrivacy/termsPrivacy.jsx
@@ -9,9 +9,9 @@ import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 // ---- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   countryGroupId: CountryGroupId,
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/marketingConsent/marketingConsent.jsx
+++ b/assets/components/marketingConsent/marketingConsent.jsx
@@ -14,7 +14,7 @@ import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   consentApiError: boolean,
   confirmOptIn: ?boolean,
   onClick: (boolean, ?string, CsrfState) => void,
@@ -22,7 +22,7 @@ type PropTypes = {
   marketingPreferenceUpdate: (preference: boolean) => void,
   email?: ?string,
   csrf: CsrfState,
-};
+|};
 
 // ----- Component ----- //
 

--- a/assets/components/numberInput/numberInput.jsx
+++ b/assets/components/numberInput/numberInput.jsx
@@ -10,7 +10,7 @@ import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   onFocus: (string, CountryGroupId) => void,
   onInput: (string, CountryGroupId) => void,
   countryGroupId: CountryGroupId,
@@ -19,7 +19,7 @@ type PropTypes = {
   onKeyPress: ?(event: Object) => void,
   ariaDescribedBy: ?string,
   labelText?: ?string,
-};
+|};
 
 
 // ----- Functions ----- //

--- a/assets/components/otherProduct/otherProduct.jsx
+++ b/assets/components/otherProduct/otherProduct.jsx
@@ -12,7 +12,7 @@ import type { ImageType } from 'helpers/theGrid';
 
 // ----- Props ----- //
 
-type PropTypes = {
+type PropTypes = {|
   modifierClass?: string,
   gridImg: string,
   imgAlt: string,
@@ -22,7 +22,7 @@ type PropTypes = {
   ctaUrl: string,
   ctaAccessibilityHint: string,
   imgType?: ImageType,
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/page/page.jsx
+++ b/assets/components/page/page.jsx
@@ -8,13 +8,13 @@ import { classNameWithModifiers } from 'helpers/utilities';
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   id: ?string,
   header: Node,
   footer: Node,
   children: Node,
   classModifiers: Array<?string>
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/pageSection/pageSection.jsx
+++ b/assets/components/pageSection/pageSection.jsx
@@ -11,12 +11,12 @@ import type { Node } from 'react';
 
 // ----- Props ----- //
 
-type PropTypes = {
+type PropTypes = {|
   modifierClass?: string,
   heading?: string,
   headingChildren?: Node,
   children?: Node,
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/patronsEvents/patronsEvents.jsx
+++ b/assets/components/patronsEvents/patronsEvents.jsx
@@ -11,9 +11,9 @@ import { getMemLink, getPatronsLink } from 'helpers/externalLinks';
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   campaignCode?: ?string,
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/payPalContributionButton/payPalContributionButton.jsx
+++ b/assets/components/payPalContributionButton/payPalContributionButton.jsx
@@ -22,7 +22,7 @@ import type { OptimizeExperiments } from 'helpers/tracking/optimize';
 // ---- Types ----- //
 
 /* eslint-disable react/no-unused-prop-types */
-type PropTypes = {
+type PropTypes = {|
   amount: number,
   referrerAcquisitionData: ReferrerAcquisitionData,
   abParticipations: Participations,
@@ -36,7 +36,7 @@ type PropTypes = {
   switchStatus: Status,
   cancelURL: string,
   optimizeExperiments: OptimizeExperiments,
-};
+|};
 /* eslint-enable react/no-unused-prop-types */
 
 

--- a/assets/components/paymentAmount/paymentAmount.jsx
+++ b/assets/components/paymentAmount/paymentAmount.jsx
@@ -14,10 +14,10 @@ const wideClass = 'component-payment-amount--wide-value';
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   amount: number,
   currencyId: IsoCurrency,
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/paymentButtons/directDebitPopUpButton/directDebitPopUpButton.jsx
+++ b/assets/components/paymentButtons/directDebitPopUpButton/directDebitPopUpButton.jsx
@@ -21,14 +21,14 @@ import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/newPaymen
 // ---- Types ----- //
 
 /* eslint-disable react/no-unused-prop-types */
-type PropTypes = {
+type PropTypes = {|
   onPaymentAuthorisation: PaymentAuthorisation => void,
   isPopUpOpen: boolean,
   openDirectDebitPopUp: () => void,
   switchStatus: Status,
   whenUnableToOpen: () => void,
   canOpen: () => boolean,
-};
+|};
 /* eslint-enable react/no-unused-prop-types */
 
 

--- a/assets/components/priceCta/priceCta.jsx
+++ b/assets/components/priceCta/priceCta.jsx
@@ -31,7 +31,7 @@ function PriceCta(props: PropTypes) {
         text={props.ctaText}
         url={props.url}
         accessibilityHint={`${props.ctaText} for only ${props.price} per month`}
-        ctaId="price-cta"
+        id="price-cta"
       />
       {withSecondary ? <p className="component-price-cta__secondary">{props.secondaryCopy}</p> : null}
     </div>

--- a/assets/components/progressMessage/progressMessage.jsx
+++ b/assets/components/progressMessage/progressMessage.jsx
@@ -7,9 +7,9 @@ import AnimatedDots from 'components/spinners/animatedDots';
 
 // ---- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   message: string[],
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/questionsContact/questionsContact.jsx
+++ b/assets/components/questionsContact/questionsContact.jsx
@@ -11,9 +11,9 @@ import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 // ---- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
     countryGroupId: CountryGroupId,
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/radioToggle/radioToggle.jsx
+++ b/assets/components/radioToggle/radioToggle.jsx
@@ -21,7 +21,7 @@ export type Radio = {
 // Disabling the linter here because it's just buggy...
 /* eslint-disable react/no-unused-prop-types */
 
-type PropTypes = {
+type PropTypes = {|
   name: string,
   radios: Radio[],
   checked: ?string,
@@ -29,7 +29,7 @@ type PropTypes = {
   modifierClass?: ?string,
   accessibilityHint?: ?string,
   countryGroupId: CountryGroupId,
-};
+|};
 
 /* eslint-enable react/no-unused-prop-types */
 

--- a/assets/components/readyToSupport/readyToSupport.jsx
+++ b/assets/components/readyToSupport/readyToSupport.jsx
@@ -10,10 +10,10 @@ import Heading, { type HeadingSize } from 'components/heading/heading';
 
 // ----- Props ----- //
 
-type PropTypes = {
+type PropTypes = {|
   ctaUrl: string,
   headingSize: HeadingSize,
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/secure/secure.jsx
+++ b/assets/components/secure/secure.jsx
@@ -11,9 +11,9 @@ import { classNameWithModifiers } from 'helpers/utilities';
 
 // ----- Props ----- //
 
-type PropTypes = {
+type PropTypes = {|
   modifierClasses: Array<?string>,
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/selectInput/selectInput.jsx
+++ b/assets/components/selectInput/selectInput.jsx
@@ -13,13 +13,13 @@ export type SelectOption = {
   selected?: boolean,
 };
 
-type PropTypes = {
+type PropTypes = {|
   options: SelectOption[],
   onChange: (string) => void,
   required: boolean,
   id: string,
   label: string,
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/signout/signout.jsx
+++ b/assets/components/signout/signout.jsx
@@ -10,7 +10,7 @@ import { getBaseDomain } from 'helpers/url';
 
 type PropTypes = {
   returnUrl?: string,
-  isSignedIn: boolean
+  isSignedIn: boolean,
 };
 
 

--- a/assets/components/socialShare/socialShare.jsx
+++ b/assets/components/socialShare/socialShare.jsx
@@ -14,9 +14,7 @@ import SvgTwitter from 'components/svgs/twitter';
 
 type Platform = 'facebook' | 'twitter';
 
-type PropTypes = {
-  name: Platform,
-};
+type PropTypes = {| name: Platform |};
 
 type SocialMedia = {
   link: string,

--- a/assets/components/subscriptionBundle/subscriptionBundle.jsx
+++ b/assets/components/subscriptionBundle/subscriptionBundle.jsx
@@ -35,7 +35,7 @@ type Benefits = {
   copy: Node,
 };
 
-type PropTypes = {
+type PropTypes = {|
   modifierClass?: string,
   heading: string,
   subheading: Node,
@@ -43,7 +43,7 @@ type PropTypes = {
   gridImage: GridImg,
   headingSize: HeadingSize,
   ctas: BundleCta[],
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/subscriptionBundles/weekly.jsx
+++ b/assets/components/subscriptionBundles/weekly.jsx
@@ -13,12 +13,12 @@ import SubscriptionBundle from 'components/subscriptionBundle/subscriptionBundle
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   headingSize: HeadingSize,
   url: string,
   subheading: string,
   abTest: ComponentAbTest | null,
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/subscriptionsThankYou/subscriptionsThankYou.jsx
+++ b/assets/components/subscriptionsThankYou/subscriptionsThankYou.jsx
@@ -14,9 +14,9 @@ import SvgSubsThankYouHeroDesktop from 'components/svgs/subsThankYouHeroDesktop'
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   children: Node,
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/switchable/errorComponents/paymentError.jsx
+++ b/assets/components/switchable/errorComponents/paymentError.jsx
@@ -9,10 +9,10 @@ import { classNameWithModifiers } from 'helpers/utilities';
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   paymentMethod: string,
   modifierClass: string,
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/switchable/switchable.jsx
+++ b/assets/components/switchable/switchable.jsx
@@ -8,11 +8,11 @@ import type { Status } from 'helpers/settings';
 // ----- Types ----- //
 
 /* eslint-disable react/no-unused-prop-types */
-type PropTypes = {
+type PropTypes = {|
   status: Status,
   component: React$ComponentType<*>,
   fallback: React$ComponentType<*>,
-};
+|};
 /* eslint-enable react/no-unused-prop-types */
 
 

--- a/assets/components/testUserBanner/testUserBanner.jsx
+++ b/assets/components/testUserBanner/testUserBanner.jsx
@@ -8,9 +8,9 @@ import { connect } from 'react-redux';
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   isTestUser: boolean,
-};
+|};
 
 // ----- Component ----- //
 

--- a/assets/components/textInput/textInput.jsx
+++ b/assets/components/textInput/textInput.jsx
@@ -24,7 +24,7 @@ type InputType = 'text'
                | 'url'
                | 'tel';
 
-type PropTypes = {
+type PropTypes = {|
   id: string,
   type: InputType,
   labelText: string,
@@ -39,7 +39,7 @@ type PropTypes = {
   required: boolean,
   pattern?: string,
   type: ?string,
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/threeSubscriptions/threeSubscriptions.jsx
+++ b/assets/components/threeSubscriptions/threeSubscriptions.jsx
@@ -9,10 +9,10 @@ import PageSection from 'components/pageSection/pageSection';
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   children: [React$Node, React$Node, React$Node],
   heading: string,
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/components/whySupport/whySupport.jsx
+++ b/assets/components/whySupport/whySupport.jsx
@@ -15,9 +15,9 @@ import Heading, { type HeadingSize } from 'components/heading/heading';
 
 // ----- Props ----- //
 
-type PropTypes = {
+type PropTypes = {|
   headingSize: HeadingSize,
-};
+|};
 
 // ----- Component ----- //
 

--- a/assets/components/yourContribution/yourContribution.jsx
+++ b/assets/components/yourContribution/yourContribution.jsx
@@ -14,11 +14,11 @@ import { type Contrib as ContributionType } from 'helpers/contributions';
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   contributionType: ContributionType,
   amount: number,
   currencyId: IsoCurrency,
-};
+|};
 
 
 // ----- Setup ----- //

--- a/assets/components/yourDetails/yourDetails.jsx
+++ b/assets/components/yourDetails/yourDetails.jsx
@@ -10,11 +10,11 @@ import DisplayName from 'components/displayName/displayName';
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   name: string,
   isSignedIn: boolean,
   children: Node,
-};
+|};
 
 // ----- Component ----- //
 

--- a/assets/pages/contributions-landing/pagesVersions/horizontalLayoutLandingPage.jsx
+++ b/assets/pages/contributions-landing/pagesVersions/horizontalLayoutLandingPage.jsx
@@ -25,10 +25,10 @@ import ContributionAwarePaymentLogosContainer
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   store: Store<*, *, *>,
   countryGroupId: CountryGroupId,
-};
+|};
 
 // ----- Internationalisation ----- //
 

--- a/assets/pages/digital-subscription-checkout/components/checkoutStage.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutStage.jsx
@@ -16,10 +16,10 @@ import AppsSection from './appsSection';
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   stage: Stage;
   countryGroupId: CountryGroupId;
-};
+|};
 
 
 // ----- State/Props Maps ----- //

--- a/assets/pages/digital-subscription-landing/components/ctaSwitch.jsx
+++ b/assets/pages/digital-subscription-landing/components/ctaSwitch.jsx
@@ -16,7 +16,7 @@ import { showUpgradeMessage } from '../helpers/upgradePromotion';
 function CtaSwitch(props: { referringCta: string }) {
 
   if (showUpgradeMessage()) {
-    return <FindOutMoreCta referringCta={props.referringCta} />;
+    return <FindOutMoreCta />;
   }
 
   return (

--- a/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
+++ b/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
@@ -22,9 +22,9 @@ import { showUpgradeMessage } from '../helpers/upgradePromotion';
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   countryGroupId: CountryGroupId,
-};
+|};
 
 type GridImages = {
   breakpoints: {

--- a/assets/pages/digital-subscription-landing/components/findOutMoreCta.jsx
+++ b/assets/pages/digital-subscription-landing/components/findOutMoreCta.jsx
@@ -9,9 +9,9 @@ import SvgArrowRightStraight from 'components/svgs/arrowRightStraight';
 import { type Action, openPopUp } from './promotionPopUpActions';
 
 
-type PropTypes = {
+type PropTypes = {|
   openPopUpDialog: () => void,
-}
+|}
 
 function mapDispatchToProps(dispatch: Dispatch<Action>) {
   return {

--- a/assets/pages/digital-subscription-landing/components/productBlock.jsx
+++ b/assets/pages/digital-subscription-landing/components/productBlock.jsx
@@ -17,9 +17,9 @@ import CtaSwitch from './ctaSwitch';
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   countryGroupId: CountryGroupId,
-};
+|};
 
 
 // ----- Setup ----- //
@@ -169,7 +169,6 @@ function Product(props: {
         <h3 className="product-block__product-heading">{props.heading}</h3>
         <p className="product-block__product-description">{props.description}</p>
         <FeatureList
-          headingSize={4}
           listItems={props.features}
         />
       </div>

--- a/assets/pages/digital-subscription-landing/components/promotionPopUp.jsx
+++ b/assets/pages/digital-subscription-landing/components/promotionPopUp.jsx
@@ -13,12 +13,12 @@ import { type Action, closePopUp } from './promotionPopUpActions';
 import { expandOption, type PromotionOptions } from './promotionPopUpActions';
 import { type State } from './promotionPopUpReducer';
 
-type PropTypes = {
+type PropTypes = {|
   isPopUpOpen: boolean,
   expandedOption: PromotionOptions,
   closePopUpDialog: () => void,
   expandOption: (option: PromotionOptions) => void,
-}
+|}
 
 // ----- Map State/Props ----- //
 

--- a/assets/pages/error/components/errorPage.jsx
+++ b/assets/pages/error/components/errorPage.jsx
@@ -15,12 +15,12 @@ import { contributionsEmail } from 'helpers/legal';
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   errorCode: string,
   headings: string[],
   copy: string,
   reportLink?: boolean,
-};
+|};
 
 
 // ----- Component ----- //

--- a/assets/pages/new-contributions-landing/components/ButtonWithRightArrow.jsx
+++ b/assets/pages/new-contributions-landing/components/ButtonWithRightArrow.jsx
@@ -5,7 +5,7 @@
 import React from 'react';
 import SvgArrowRight from 'components/svgs/arrowRightStraight';
 
-type PropTypes = {
+type PropTypes = {|
   componentClassName: string,
   buttonClassName: string,
   type: string,
@@ -13,7 +13,7 @@ type PropTypes = {
   buttonCopy: string,
   url: ?string,
   onClick: () => void,
-};
+|};
 // ----- Render ----- //
 
 function ButtonWithRightArrow(props: PropTypes) {

--- a/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
@@ -21,7 +21,7 @@ import { NewContributionTextInput } from './ContributionTextInput';
 // ----- Types ----- //
 
 /* eslint-disable react/no-unused-prop-types */
-type PropTypes = {
+type PropTypes = {|
   countryGroupId: CountryGroupId,
   currency: IsoCurrency,
   contributionType: Contrib,
@@ -31,7 +31,7 @@ type PropTypes = {
   checkOtherAmount: string => boolean,
   updateOtherAmount: string => void,
   checkoutFormHasBeenSubmitted: boolean,
-};
+|};
 /* eslint-enable react/no-unused-prop-types */
 
 const mapStateToProps = state => ({
@@ -131,11 +131,6 @@ function ContributionAmount(props: PropTypes) {
     </fieldset>
   );
 }
-
-ContributionAmount.defaultProps = {
-  amount: null,
-  showOther: false,
-};
 
 const NewContributionAmount = connect(mapStateToProps, mapDispatchToProps)(ContributionAmount);
 

--- a/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -3,7 +3,6 @@
 // ----- Imports ----- //
 
 import { type Amount, type ThirdPartyPaymentLibraries } from 'helpers/contributions';
-import type { CountryMetaData } from 'helpers/internationalisation/contributions';
 import React from 'react';
 import { connect } from 'react-redux';
 
@@ -64,7 +63,6 @@ type PropTypes = {|
   currency: IsoCurrency,
   paymentError: CheckoutFailureReason | null,
   selectedAmounts: { [Contrib]: Amount | 'other' },
-  selectedCountryGroupDetails: CountryMetaData,
   onThirdPartyPaymentAuthorised: PaymentAuthorisation => void,
   setPaymentIsWaiting: boolean => void,
   openDirectDebitPopUp: () => void,
@@ -91,7 +89,6 @@ const mapStateToProps = (state: State) => ({
   currency: state.common.internationalisation.currencyId,
   paymentError: state.page.form.paymentError,
   selectedAmounts: state.page.form.selectedAmounts,
-
 });
 
 
@@ -186,7 +183,6 @@ function ContributionForm(props: PropTypes) {
     <form onSubmit={onSubmit(props)} className={classNameWithModifiers('form', ['contribution'])} noValidate>
       <NewContributionType />
       <NewContributionAmount
-        countryGroupDetails={props.selectedCountryGroupDetails}
         checkOtherAmount={checkOtherAmount}
       />
       <ContributionFormFields />

--- a/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
@@ -39,7 +39,6 @@ type PropTypes = {|
   paymentError: CheckoutFailureReason | null,
   currencyId: IsoCurrency,
   countryGroupId: CountryGroupId,
-  isDirectDebitPopUpOpen: boolean,
   thankYouRoute: string,
   setPaymentIsWaiting: boolean => void,
   onThirdPartyPaymentAuthorised: PaymentAuthorisation => void,
@@ -62,7 +61,6 @@ const mapStateToProps = (state: State) => ({
   paymentError: state.page.form.paymentError,
   currencyId: state.common.internationalisation.currencyId,
   countryGroupId: state.common.internationalisation.countryGroupId,
-  isDirectDebitPopUpOpen: state.page.directDebit.isPopUpOpen,
   isTestUser: state.page.user.isTestUser,
   paymentMethod: state.page.form.paymentMethod,
   contributionType: state.page.form.contributionType,
@@ -86,8 +84,6 @@ function ContributionFormContainer(props: PropTypes) {
     props.onThirdPartyPaymentAuthorised(paymentAuthorisation);
   };
 
-  const selectedCountryGroupDetails = countryGroupSpecificDetails[props.countryGroupId];
-
   return props.paymentComplete ?
     <Redirect to={props.thankYouRoute} />
     : (
@@ -96,11 +92,9 @@ function ContributionFormContainer(props: PropTypes) {
         <p className="blurb">{countryGroupSpecificDetails[props.countryGroupId].contributeCopy}</p>
         <NewContributionForm
           onPaymentAuthorisation={onPaymentAuthorisation}
-          selectedCountryGroupDetails={selectedCountryGroupDetails}
         />
         <DirectDebitPopUpForm
           onPaymentAuthorisation={onPaymentAuthorisation}
-          isPopUpOpen={props.isDirectDebitPopUpOpen}
         />
       </div>
     );

--- a/assets/pages/new-contributions-landing/components/ContributionFormFields.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionFormFields.jsx
@@ -99,7 +99,7 @@ function FormFields(props: PropTypes) {
         required
         disabled={isSignedIn}
       />
-      <Signout isSignedIn={isSignedIn} />
+      <Signout isSignedIn />
       <NewContributionTextInput
         id="contributionFirstName"
         name="contribution-fname"

--- a/assets/pages/new-contributions-landing/components/ContributionState.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionState.jsx
@@ -14,14 +14,14 @@ import SvgGlobe from 'components/svgs/globe';
 import { type State } from '../contributionsLandingReducer';
 
 // ----- Types ----- //
-type PropTypes = {
+type PropTypes = {|
   countryGroupId: CountryGroupId,
   selectedState: CaState | UsState | null,
   onChange: (Event => void) | false,
   errorMessage: string | null,
   isValid: boolean,
   formHasBeenSubmitted: boolean,
-};
+|};
 
 const mapStateToProps = (state: State) => ({
   countryGroupId: state.common.internationalisation.countryGroupId,

--- a/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
@@ -26,7 +26,7 @@ import {
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   contributionType: Contrib,
   paymentMethod: PaymentMethod,
   currency: IsoCurrency,
@@ -42,7 +42,7 @@ type PropTypes = {
   payPalHasLoaded: boolean,
   isTestUser: boolean,
   onPaymentAuthorisation: PaymentAuthorisation => void,
-};
+|};
 
 const mapStateToProps = (state: State) =>
   ({

--- a/assets/pages/new-contributions-landing/components/ContributionTextInput.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionTextInput.jsx
@@ -8,7 +8,7 @@ import { classNameWithModifiers } from 'helpers/utilities';
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   id: string,
   name: string,
   label: string,
@@ -29,7 +29,7 @@ type PropTypes = {
   step: number | void,
   pattern: string | void,
   disabled: boolean,
-};
+|};
 
 // ----- Render ----- //
 

--- a/assets/pages/new-contributions-landing/components/ContributionThankYou.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionThankYou.jsx
@@ -15,12 +15,12 @@ import { type Action, setHasSeenDirectDebitThankYouCopy } from '../contributions
 // ----- Types ----- //
 
 /* eslint-disable react/no-unused-prop-types */
-type PropTypes = {
+type PropTypes = {|
   contributionType: Contrib,
   paymentMethod: PaymentMethod,
   hasSeenDirectDebitThankYouCopy: boolean,
   setHasSeenDirectDebitThankYouCopy: () => void,
-};
+  |};
 /* eslint-enable react/no-unused-prop-types */
 
 const mapStateToProps = state => ({

--- a/assets/pages/new-contributions-landing/components/ContributionThankYouContainer.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionThankYouContainer.jsx
@@ -2,7 +2,6 @@
 
 // ----- Imports ----- //
 
-import type { PaymentMethod } from 'helpers/contributions';
 import React from 'react';
 import { connect } from 'react-redux';
 import { type ThankYouPageStageMap, type ThankYouPageStage } from '../contributionsLandingReducer';
@@ -13,15 +12,13 @@ import ContributionThankYouPasswordSet from './ContributionThankYouPasswordSet';
 // ----- Types ----- //
 
 /* eslint-disable react/no-unused-prop-types */
-type PropTypes = {
+type PropTypes = {|
   thankYouPageStage: ThankYouPageStage,
-  paymentMethod: PaymentMethod,
-};
+|};
 /* eslint-enable react/no-unused-prop-types */
 
 const mapStateToProps = state => ({
   thankYouPageStage: state.page.form.thankYouPageStage,
-  paymentMethod: state.page.form.paymentMethod,
 });
 
 // ----- Render ----- //
@@ -29,7 +26,7 @@ const mapStateToProps = state => ({
 function ContributionThankYouContainer(props: PropTypes) {
 
   const thankYouPageStage: ThankYouPageStageMap<React$Element<*>> = {
-    thankYou: (<ContributionThankYou showDirectDebitCopy={props.paymentMethod === 'DirectDebit'} />),
+    thankYou: (<ContributionThankYou />),
     thankYouSetPassword: (<ContributionThankYouSetPassword />),
     thankYouPasswordDeclinedToSet: (<ContributionThankYou />),
     thankYouPasswordSet: (<ContributionThankYouPasswordSet />),

--- a/assets/pages/new-contributions-landing/components/ContributionThankYouSetPassword.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionThankYouSetPassword.jsx
@@ -12,12 +12,12 @@ import SetPasswordForm from './SetPassword/SetPasswordForm';
 // ----- Types ----- //
 
 /* eslint-disable react/no-unused-prop-types */
-type PropTypes = {
+type PropTypes = {|
   paymentMethod: PaymentMethod,
   passwordFailed: boolean,
   hasSeenDirectDebitThankYouCopy: boolean,
   setHasSeenDirectDebitThankYouCopy: () => void,
-};
+|};
 /* eslint-enable react/no-unused-prop-types */
 
 

--- a/assets/pages/new-contributions-landing/components/ContributionType.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionType.jsx
@@ -16,12 +16,12 @@ import { type Action, updateContributionType } from '../contributionsLandingActi
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   contributionType: Contrib,
   countryId: IsoCountry,
   switches: Switches,
   onSelectContributionType: (Contrib, Switches, IsoCountry) => void,
-};
+|};
 
 const mapStateToProps = (state: State) => ({
   contributionType: state.page.form.contributionType,

--- a/assets/pages/new-contributions-landing/components/MarketingConsent.jsx
+++ b/assets/pages/new-contributions-landing/components/MarketingConsent.jsx
@@ -17,12 +17,12 @@ import { sendMarketingPreferencesToIdentity } from '../../../components/marketin
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   confirmOptIn: ?boolean,
   email: string,
   csrf: CsrfState,
   onClick: (?string, CsrfState) => void,
-};
+|};
 
 const mapStateToProps = state => ({
   confirmOptIn: state.page.marketingConsent.confirmOptIn,

--- a/assets/pages/new-contributions-landing/components/PaymentMethodSelector.jsx
+++ b/assets/pages/new-contributions-landing/components/PaymentMethodSelector.jsx
@@ -26,7 +26,7 @@ import { type Action, updatePaymentMethod, setThirdPartyPaymentLibrary } from '.
 // ----- Types ----- //
 
 /* eslint-disable react/no-unused-prop-types */
-type PropTypes = {
+type PropTypes = {|
   countryId: IsoCountry,
   contributionType: Contrib,
   currency: IsoCurrency,
@@ -37,7 +37,7 @@ type PropTypes = {
   setThirdPartyPaymentLibrary: (?{ [Contrib]: { [PaymentMethod]: ThirdPartyPaymentLibrary }}) => Action,
   isTestUser: boolean,
   switches: Switches,
-};
+|};
 /* eslint-enable react/no-unused-prop-types */
 
 const mapStateToProps = (state: State) => ({

--- a/assets/pages/new-contributions-landing/components/SetPassword/SetPasswordForm.jsx
+++ b/assets/pages/new-contributions-landing/components/SetPassword/SetPasswordForm.jsx
@@ -21,7 +21,7 @@ import { ButtonWithRightArrow } from '../ButtonWithRightArrow';
 // ----- Types ----- //
 
 /* eslint-disable react/no-unused-prop-types */
-type PropTypes = {
+type PropTypes = {|
   email: string,
   password: string,
   guestAccountCreationToken: string,
@@ -30,7 +30,7 @@ type PropTypes = {
   passwordHasBeenSubmitted: boolean,
   updatePassword: (Event) => void,
   csrf: CsrfState,
-};
+|};
 /* eslint-enable react/no-unused-prop-types */
 
 

--- a/assets/pages/oneoff-contributions/components/formFields.jsx
+++ b/assets/pages/oneoff-contributions/components/formFields.jsx
@@ -23,13 +23,13 @@ import { type State } from '../oneOffContributionsReducer';
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   fullName: UserFormFieldAttribute,
   email: UserFormFieldAttribute,
   setFullName: (string) => void,
   setEmail: (string) => void,
   isSignedIn: boolean,
-};
+|};
 
 // ----- Map State/Props ----- //
 

--- a/assets/pages/premium-tier-landing/components/premiumTierLandingHeader.jsx
+++ b/assets/pages/premium-tier-landing/components/premiumTierLandingHeader.jsx
@@ -20,9 +20,9 @@ import PriceCtaContainer from './priceCtaContainer';
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   countryGroupId: CountryGroupId
-};
+|};
 
 type GridImages = {
   breakpoints: {

--- a/assets/pages/premium-tier-landing/components/productBlock.jsx
+++ b/assets/pages/premium-tier-landing/components/productBlock.jsx
@@ -17,9 +17,9 @@ import PriceCtaContainer from './priceCtaContainer';
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   countryGroupId: CountryGroupId,
-};
+|};
 
 
 // ----- Setup ----- //
@@ -170,7 +170,6 @@ function Product(props: {
         <h3 className="product-block__product-heading">{props.heading}</h3>
         <p className="product-block__product-description">{props.description}</p>
         <FeatureList
-          headingSize={4}
           listItems={props.features}
         />
       </div>

--- a/assets/pages/regular-contributions/components/contributionsGuestCheckout.jsx
+++ b/assets/pages/regular-contributions/components/contributionsGuestCheckout.jsx
@@ -21,7 +21,7 @@ import { type Stage } from '../helpers/checkoutForm/checkoutFormReducer';
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   amount: number,
   currencyId: IsoCurrency,
   contributionType: ContributionType,
@@ -32,7 +32,7 @@ type PropTypes = {
   onNextButtonClick: () => void,
   onBackClick: () => void,
   stage: Stage,
-};
+|};
 
 // ----- Component ----- //
 

--- a/assets/pages/regular-contributions/components/formFields.jsx
+++ b/assets/pages/regular-contributions/components/formFields.jsx
@@ -37,7 +37,7 @@ import { getFormFields } from '../helpers/checkoutForm/checkoutFormFieldsSelecto
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   stateUpdate: (value: UsState | CaState) => void,
   countryUpdate: (value: string) => void,
   firstName: UserFormFieldAttribute,
@@ -50,7 +50,7 @@ type PropTypes = {
   country: IsoCountry,
   isSignedIn: boolean,
   stateField: UsState | CaState,
-};
+|};
 
 // ----- Map State/Props ----- //
 

--- a/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
+++ b/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
@@ -36,7 +36,7 @@ const content = (
       footer={<FooterContainer disclaimer privacyPolicy />}
     >
       <InvestIntroduction />
-      <SubscriptionsByCountryGroup id={supporterSectionId} headingSize={3} appMedium="subscribe_landing_page" />
+      <SubscriptionsByCountryGroup headingSize={3} appMedium="subscribe_landing_page" />
       <WhySupportVideoContainer headingSize={3} id="why-support" />
       <ReadyToSupport
         ctaUrl={`#${supporterSectionId}`}

--- a/assets/pages/support-landing/components/subscriptionsSection.jsx
+++ b/assets/pages/support-landing/components/subscriptionsSection.jsx
@@ -19,12 +19,12 @@ import type { State } from '../supportLandingReducer';
 
 // ----- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   referrerAcquisitionData: ReferrerAcquisitionData,
   countryGroupId: CountryGroupId,
   abParticipations: Participations,
   optimizeExperiments: OptimizeExperiments,
-};
+|};
 
 
 // ----- State Maps ----- //


### PR DESCRIPTION
## Why are you doing this?
Unless there is a good reason (for example, you are using object spread syntax to read your props so that you don't have to name them in the component), we should use [exact types](https://flow.org/en/docs/types/objects/#toc-exact-object-types) for our PropTypes. This prevents people deleting props from components but neglecting to stop sending those props to the component.

There are multiple instances where this had infact already happened, see 

- `assets/pages/digital-subscription-landing/components/ctaSwitch.jsx`
- `assets/pages/digital-subscription-landing/components/productBlock.jsx` 
- `assets/pages/new-contributions-landing/components/ContributionThankYouContainer.jsx` 

It also guards against making a typeo when sending an optional prop to a component, and not being notified by flow, which is what I think has happened here (@Ap0c can you confirm this? I've made a fix assuming that this was what had happened):

- `assets/components/priceCta/priceCta.jsx`


So this PR enforces exact types _nearly_ everywhere for PropTypes, and fixes any validity errors that this change shone a light on