### PR TITLE
Styled flash sale countdown component

### DIFF
--- a/assets/components/countdown/countdown.jsx
+++ b/assets/components/countdown/countdown.jsx
@@ -75,7 +75,7 @@ export default class Countdown extends Component<PropTypes, StateTypes> {
 
     return (
       <time>
-        {units.map(addLeadingZeros).join(':')}
+        {units.map(unit => addLeadingZeros(unit, 2)).join(':')}
       </time>
     );
   }

--- a/assets/components/countdown/countdown.jsx
+++ b/assets/components/countdown/countdown.jsx
@@ -71,11 +71,16 @@ export default class Countdown extends Component<PropTypes, StateTypes> {
       days, hours, minutes, seconds,
     } = this.state.time;
 
-    const units = days > 0 ? [days, hours, minutes] : [hours, minutes, seconds];
+    const units = days > 0 ? [days, hours, minutes, seconds] : [hours, minutes, seconds];
 
     return (
-      <time>
-        {units.map(unit => addLeadingZeros(unit, 2)).join(':')}
+      <time className="component-countdown">
+        {units.map((unit, index) => (
+          <span>
+            <span className="component-countdown__time">{addLeadingZeros(unit, 2)}</span>
+            {index < units.length - 1 && ':'}
+          </span>
+        ))}
       </time>
     );
   }

--- a/assets/components/flashSaleCountdown/flashSaleCountdown.jsx
+++ b/assets/components/flashSaleCountdown/flashSaleCountdown.jsx
@@ -1,0 +1,21 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+import Countdown from 'components/countdown/countdown';
+import { getEndTime } from 'helpers/flashSale';
+
+// ----- Render ----- //
+
+export default () => (
+  <div className="component-flash-sale-countdown">
+    <span className="component-flash-sale-countdown__chip component-flash-sale-countdown__chip--time">
+      <Countdown to={getEndTime()} />
+    </span>
+    <span className="component-flash-sale-countdown__chip component-flash-sale-countdown__chip--help">
+      Until flash sale ends
+    </span>
+  </div>
+);

--- a/assets/components/flashSaleCountdown/flashSaleCountdown.scss
+++ b/assets/components/flashSaleCountdown/flashSaleCountdown.scss
@@ -9,7 +9,7 @@
   background: gu-colour(sport-garnett-feature);
   color: #fff;
   font-weight: 800;
-  width: 92px;
+  width: 98px;
   text-align: center;
   padding-left: 0;
   padding-right: 0;

--- a/assets/components/flashSaleCountdown/flashSaleCountdown.scss
+++ b/assets/components/flashSaleCountdown/flashSaleCountdown.scss
@@ -10,10 +10,11 @@
   color: #fff;
   font-weight: 800;
   /*This fixed width is set to prevent the counter from shifting sizes slightly when the time changes, as the font doesn't have monospaced numbers.*/
-  text-align: center;
-  padding-left: 0;
-  padding-right: 0;
-  width: 98px;
+  .component-countdown__time {
+    min-width: 24px;
+    display: inline-block;
+    text-align: center;
+  }
 }
 
 .component-flash-sale-countdown__chip--help {

--- a/assets/components/flashSaleCountdown/flashSaleCountdown.scss
+++ b/assets/components/flashSaleCountdown/flashSaleCountdown.scss
@@ -1,0 +1,20 @@
+.component-flash-sale-countdown__chip {
+  font-family: $gu-text-sans-web;
+  font-size: 18px;
+  padding: 6px 10px 4px;
+  display: inline-block;
+}
+
+.component-flash-sale-countdown__chip--time {
+  background: gu-colour(sport-garnett-feature);
+  color: #fff;
+  font-weight: 800;
+  width: 92px;
+  text-align: center;
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.component-flash-sale-countdown__chip--help {
+  color: gu-colour(sport-garnett-feature);
+}

--- a/assets/components/flashSaleCountdown/flashSaleCountdown.scss
+++ b/assets/components/flashSaleCountdown/flashSaleCountdown.scss
@@ -9,10 +9,11 @@
   background: gu-colour(sport-garnett-feature);
   color: #fff;
   font-weight: 800;
-  width: 98px;
+  /*This fixed width is set to prevent the counter from shifting sizes slightly when the time changes, as the font doesn't have monospaced numbers.*/
   text-align: center;
   padding-left: 0;
   padding-right: 0;
+  width: 98px;
 }
 
 .component-flash-sale-countdown__chip--help {


### PR DESCRIPTION
## Why are you doing this?
Adds a styled component for the flash sale countdown. It's not implemented anywhere on the site yet, this is just the styles in isolation.

There's also a small fix in `Countdown.jsx` to render `00` instead of `0`

[**Trello Card**](https://trello.com/c/OPrDKDBQ/2027-countdown-timer-for-flash-sales)

## Screenshots
![screenshot 2018-10-23 at 4 13 27 pm](https://user-images.githubusercontent.com/11539094/47370891-983cb800-d6de-11e8-8d8b-91b4d45e38a9.png)
