### PR TITLE
Annual contribution amounts test 3

### DIFF
--- a/assets/components/contributionSelection/contributionSelection.jsx
+++ b/assets/components/contributionSelection/contributionSelection.jsx
@@ -50,7 +50,7 @@ type PropTypes = {|
 function ContributionSelection(props: PropTypes) {
 
   const modifierClassArray = [getContributionTypeClassName(props.contributionType)];
-  if (props.annualTestVariant === 'annual' || props.annualTestVariant === 'annualHigherAmounts') {
+  if (props.annualTestVariant === 'annualAmountsA' || props.annualTestVariant === 'annualAmountsB') {
     modifierClassArray.push('annual-test');
   }
 

--- a/assets/components/contributionSelection/contributionSelection.jsx
+++ b/assets/components/contributionSelection/contributionSelection.jsx
@@ -50,7 +50,7 @@ type PropTypes = {|
 function ContributionSelection(props: PropTypes) {
 
   const modifierClassArray = [getContributionTypeClassName(props.contributionType)];
-  if (props.annualTestVariant === 'annualAmountsA' || props.annualTestVariant === 'annualAmountsB') {
+  if (props.annualTestVariant === 'control' || props.annualTestVariant === 'annualAmountsA') {
     modifierClassArray.push('annual-test');
   }
 

--- a/assets/components/contributionSelection/contributionSelection.jsx
+++ b/assets/components/contributionSelection/contributionSelection.jsx
@@ -11,7 +11,7 @@ import ErrorMessage from 'components/errorMessage/errorMessage';
 import {
   errorMessage as contributionsErrorMessage,
   getContributionTypeClassName,
-  getContributionTypeRadios,
+  contributionTypeRadios,
   getContributionAmountRadios,
   getCustomAmountA11yHint,
 } from 'helpers/contributions';
@@ -50,19 +50,14 @@ type PropTypes = {|
 function ContributionSelection(props: PropTypes) {
 
   const modifierClassArray = [getContributionTypeClassName(props.contributionType)];
-  if (props.annualTestVariant === 'control' || props.annualTestVariant === 'annualAmountsA') {
-    modifierClassArray.push('annual-test');
-  }
+  modifierClassArray.push('annual-test');
 
   return (
     <div className={classNameWithModifiers('component-contribution-selection', modifierClassArray)}>
       <div className="component-contribution-selection__type">
         <RadioToggle
           name="contribution-type-toggle"
-          radios={getContributionTypeRadios(
-            props.countryGroupId,
-            props.annualTestVariant,
-          )}
+          radios={contributionTypeRadios}
           checked={props.contributionType}
           toggleAction={props.setContributionType}
           countryGroupId={props.countryGroupId}

--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -9,7 +9,7 @@ export type AnnualContributionsTestVariant = 'control' | 'annualAmountsA';
 // to browsers landing on pages/contributions-landing/contributionsLanding.jsx
 export const oldContributionsFlowTests: Tests = {
   annualContributionsRoundThree: {
-    variants: ['annualAmountsA', 'annualAmountsB'],
+    variants: ['control', 'annualAmountsA'],
     audiences: {
       ALL: {
         offset: 0,

--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -3,7 +3,7 @@ import type { Tests } from './abtest';
 
 // ----- Tests ----- //
 
-export type AnnualContributionsTestVariant = 'annualAmountsA' | 'annualAmountsB' | 'notintest';
+export type AnnualContributionsTestVariant = 'control' | 'annualAmountsA' | 'notintest';
 
 // Participations in these tests are only assigned
 // to browsers landing on pages/contributions-landing/contributionsLanding.jsx
@@ -39,7 +39,7 @@ export const oldContributionsFlowTests: Tests = {
 // to browsers landing on pages/new-contributions-landing/contributionsLanding.jsx
 export const newContributionsFlowTests: Tests = {
   annualContributionsRoundThree: {
-    variants: ['annualAmountsA', 'annualAmountsB'],
+    variants: ['control', 'annualAmountsA'],
     audiences: {
       ALL: {
         offset: 0,

--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -3,7 +3,7 @@ import type { Tests } from './abtest';
 
 // ----- Tests ----- //
 
-export type AnnualContributionsTestVariant = 'control' | 'annualAmountsA' | 'notintest';
+export type AnnualContributionsTestVariant = 'control' | 'annualAmountsA';
 
 // Participations in these tests are only assigned
 // to browsers landing on pages/contributions-landing/contributionsLanding.jsx

--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -3,7 +3,7 @@ import type { Tests } from './abtest';
 
 // ----- Tests ----- //
 
-export type AnnualContributionsTestVariant = 'control' | 'annualAmountsA';
+export type AnnualContributionsTestVariant = 'control' | 'annualAmountsA' | 'notintest';
 
 // Participations in these tests are only assigned
 // to browsers landing on pages/contributions-landing/contributionsLanding.jsx

--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -3,13 +3,13 @@ import type { Tests } from './abtest';
 
 // ----- Tests ----- //
 
-export type AnnualContributionsTestVariant = 'control' | 'annual' | 'annualHigherAmounts' | 'notintest';
+export type AnnualContributionsTestVariant = 'annualAmountsA' | 'annualAmountsB' | 'notintest';
 
 // Participations in these tests are only assigned
 // to browsers landing on pages/contributions-landing/contributionsLanding.jsx
 export const oldContributionsFlowTests: Tests = {
-  annualContributionsRoundTwo: {
-    variants: ['control', 'annual', 'annualHigherAmounts'],
+  annualContributionsRoundThree: {
+    variants: ['annualAmountsA', 'annualAmountsB'],
     audiences: {
       ALL: {
         offset: 0,
@@ -38,6 +38,18 @@ export const oldContributionsFlowTests: Tests = {
 // Participations in these tests are only assigned
 // to browsers landing on pages/new-contributions-landing/contributionsLanding.jsx
 export const newContributionsFlowTests: Tests = {
+  annualContributionsRoundThree: {
+    variants: ['annualAmountsA', 'annualAmountsB'],
+    audiences: {
+      ALL: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: true,
+    independent: true,
+    seed: 3,
+  },
   newPaymentFlow: {
     // 100% of people will be put in this variant
     variants: ['newPaymentFlow'],

--- a/assets/helpers/abTests/helpers/annualContributions.js
+++ b/assets/helpers/abTests/helpers/annualContributions.js
@@ -2,10 +2,130 @@
 
 import { type Store } from 'redux';
 import { contributionSelectionActionsFor } from 'components/contributionSelection/contributionSelectionActions';
+import type { AnnualContributionsTestVariant } from '../abtestDefinitions';
 
-export function setInitialAmountsForAnnualHigherAmountsVariant(store: Store<*, *, *>) {
-  const annualTestVariant = store.getState().common.abParticipations.annualContributionsRoundTwo;
-  if (annualTestVariant === 'annualHigherAmounts') {
-    store.dispatch(contributionSelectionActionsFor('CONTRIBUTE_SECTION').setAmountForContributionType('ANNUAL', 100));
+/* eslint-disable quote-props */
+const numbersInWords = {
+  '25': 'twenty five',
+  '35': 'thirty five',
+  '50': 'fifty',
+  '75': 'seventy five',
+  '100': 'one hundred',
+  '125': 'one hundred and twenty five',
+  '250': 'two hundred and fifty',
+  '300': 'three hundred',
+  '500': 'five hundred',
+  '750': 'seven hundred and fifty',
+};
+/* eslint-enable  quote-props */
+
+const VariantA = {
+  defaults: {
+    GBPCountries: '100',
+    UnitedStates: '100',
+    AUDCountries: '100',
+    EURCountries: '100',
+    International: '100',
+    NZDCountries: '50',
+    Canada: '100',
+  },
+
+  standard: [
+    { value: '50', spoken: numbersInWords['50'], isDefault: false },
+    { value: '100', spoken: numbersInWords['100'], isDefault: true },
+    { value: '250', spoken: numbersInWords['250'], isDefault: false },
+    { value: '500', spoken: numbersInWords['500'], isDefault: false },
+  ],
+
+  newZealand: [
+    { value: '50', spoken: numbersInWords['50'], isDefault: true },
+    { value: '100', spoken: numbersInWords['100'], isDefault: false },
+    { value: '250', spoken: numbersInWords['250'], isDefault: false },
+    { value: '500', spoken: numbersInWords['500'], isDefault: false },
+  ],
+
+  australia: [
+    { value: '100', spoken: numbersInWords['100'], isDefault: true },
+    { value: '250', spoken: numbersInWords['250'], isDefault: false },
+    { value: '500', spoken: numbersInWords['500'], isDefault: false },
+    { value: '750', spoken: numbersInWords['750'], isDefault: false },
+  ],
+};
+
+const VariantB = {
+  defaults: {
+    GBPCountries: '100',
+    UnitedStates: '75',
+    AUDCountries: '300',
+    EURCountries: '100',
+    International: '50',
+    NZDCountries: '100',
+    Canada: '100',
+  },
+
+  standard: [
+    { value: '75', spoken: numbersInWords['75'], isDefault: false },
+    { value: '100', spoken: numbersInWords['100'], isDefault: true },
+    { value: '250', spoken: numbersInWords['250'], isDefault: false },
+    { value: '500', spoken: numbersInWords['500'], isDefault: false },
+  ],
+
+  us: [
+    { value: '35', spoken: numbersInWords['35'], isDefault: false },
+    { value: '75', spoken: numbersInWords['75'], isDefault: true },
+    { value: '125', spoken: numbersInWords['125'], isDefault: false },
+    { value: '250', spoken: numbersInWords['250'], isDefault: false },
+  ],
+
+  australia: [
+    { value: '125', spoken: numbersInWords['125'], isDefault: false },
+    { value: '300', spoken: numbersInWords['300'], isDefault: true },
+    { value: '500', spoken: numbersInWords['500'], isDefault: false },
+    { value: '750', spoken: numbersInWords['750'], isDefault: false },
+  ],
+
+  international: [
+    { value: '25', spoken: numbersInWords['25'], isDefault: false },
+    { value: '50', spoken: numbersInWords['50'], isDefault: true },
+    { value: '100', spoken: numbersInWords['100'], isDefault: false },
+    { value: '250', spoken: numbersInWords['250'], isDefault: false },
+  ],
+
+  newZealand: [
+    { value: '100', spoken: numbersInWords['100'], isDefault: true },
+    { value: '250', spoken: numbersInWords['250'], isDefault: false },
+    { value: '500', spoken: numbersInWords['500'], isDefault: false },
+    { value: '750', spoken: numbersInWords['750'], isDefault: false },
+  ],
+};
+
+export const getAnnualAmounts = (annualTestVariant: AnnualContributionsTestVariant) => {
+  if (annualTestVariant === 'annualAmountsB') {
+    return {
+      GBPCountries: VariantB.standard,
+      UnitedStates: VariantB.us,
+      AUDCountries: VariantB.australia,
+      EURCountries: VariantB.standard,
+      International: VariantB.international,
+      NZDCountries: VariantB.newZealand,
+      Canada: VariantB.standard,
+    };
   }
+  return {
+    GBPCountries: VariantA.standard,
+    UnitedStates: VariantA.standard,
+    AUDCountries: VariantA.australia,
+    EURCountries: VariantA.standard,
+    International: VariantA.standard,
+    NZDCountries: VariantA.newZealand,
+    Canada: VariantA.standard,
+  };
+};
+
+//For the old payment flow only
+export function setInitialAmountsForAnnualVariants(store: Store<*, *, *>) {
+  const annualTestVariant = store.getState().common.abParticipations.annualContributionsRoundThree;
+  const countryGroupId = store.getState().common.internationalisation.countryGroupId;
+  const amount = annualTestVariant === 'annualAmountsA' ? VariantA.defaults[countryGroupId] : VariantB.defaults[countryGroupId];
+  store.dispatch(contributionSelectionActionsFor('CONTRIBUTE_SECTION').setAmountForContributionType('ANNUAL', amount));
 }

--- a/assets/helpers/abTests/helpers/annualContributions.js
+++ b/assets/helpers/abTests/helpers/annualContributions.js
@@ -126,6 +126,6 @@ export const getAnnualAmounts = (annualTestVariant: AnnualContributionsTestVaria
 export function setInitialAmountsForAnnualVariants(store: Store<*, *, *>) {
   const annualTestVariant = store.getState().common.abParticipations.annualContributionsRoundThree;
   const { countryGroupId } = store.getState().common.internationalisation;
-  const amount = annualTestVariant === 'control' ? Control.defaults[countryGroupId] : VariantA.defaults[countryGroupId];
+  const amount = annualTestVariant === 'annualAmountsA' ? VariantA.defaults[countryGroupId] : Control.defaults[countryGroupId];
   store.dispatch(contributionSelectionActionsFor('CONTRIBUTE_SECTION').setAmountForContributionType('ANNUAL', amount));
 }

--- a/assets/helpers/abTests/helpers/annualContributions.js
+++ b/assets/helpers/abTests/helpers/annualContributions.js
@@ -100,7 +100,6 @@ const VariantA = {
 };
 
 export const getAnnualAmounts = (annualTestVariant: AnnualContributionsTestVariant) => {
-  console.log(annualTestVariant)
   if (annualTestVariant === 'annualAmountsA') {
     return {
       GBPCountries: VariantA.standard,

--- a/assets/helpers/abTests/helpers/annualContributions.js
+++ b/assets/helpers/abTests/helpers/annualContributions.js
@@ -19,7 +19,7 @@ const numbersInWords = {
 };
 /* eslint-enable  quote-props */
 
-const VariantA = {
+const Control = {
   defaults: {
     GBPCountries: '100',
     UnitedStates: '100',
@@ -52,7 +52,7 @@ const VariantA = {
   ],
 };
 
-const VariantB = {
+const VariantA = {
   defaults: {
     GBPCountries: '100',
     UnitedStates: '75',
@@ -100,32 +100,33 @@ const VariantB = {
 };
 
 export const getAnnualAmounts = (annualTestVariant: AnnualContributionsTestVariant) => {
-  if (annualTestVariant === 'annualAmountsB') {
+  if (annualTestVariant === 'annualAmountsA') {
     return {
-      GBPCountries: VariantB.standard,
-      UnitedStates: VariantB.us,
-      AUDCountries: VariantB.australia,
-      EURCountries: VariantB.standard,
-      International: VariantB.international,
-      NZDCountries: VariantB.newZealand,
-      Canada: VariantB.standard,
+      GBPCountries: VariantA.standard,
+      UnitedStates: VariantA.us,
+      AUDCountries: VariantA.australia,
+      EURCountries: VariantA.standard,
+      International: VariantA.international,
+      NZDCountries: VariantA.newZealand,
+      Canada: VariantA.standard,
     };
   }
   return {
-    GBPCountries: VariantA.standard,
-    UnitedStates: VariantA.standard,
-    AUDCountries: VariantA.australia,
-    EURCountries: VariantA.standard,
-    International: VariantA.standard,
-    NZDCountries: VariantA.newZealand,
-    Canada: VariantA.standard,
+    GBPCountries: Control.standard,
+    UnitedStates: Control.standard,
+    AUDCountries: Control.australia,
+    EURCountries: Control.standard,
+    International: Control.standard,
+    NZDCountries: Control.newZealand,
+    Canada: Control.standard,
   };
 };
 
 // For the old payment flow only
 export function setInitialAmountsForAnnualVariants(store: Store<*, *, *>) {
   const annualTestVariant = store.getState().common.abParticipations.annualContributionsRoundThree;
-  const { countryGroupId } = store.getState().common.internationalisation.countryGroupId;
-  const amount = annualTestVariant === 'annualAmountsA' ? VariantA.defaults[countryGroupId] : VariantB.defaults[countryGroupId];
+  const { countryGroupId } = store.getState().common.internationalisation;
+  console.log(annualTestVariant, countryGroupId)
+  const amount = annualTestVariant === 'control' ? Control.defaults[countryGroupId] : VariantA.defaults[countryGroupId];
   store.dispatch(contributionSelectionActionsFor('CONTRIBUTE_SECTION').setAmountForContributionType('ANNUAL', amount));
 }

--- a/assets/helpers/abTests/helpers/annualContributions.js
+++ b/assets/helpers/abTests/helpers/annualContributions.js
@@ -122,10 +122,10 @@ export const getAnnualAmounts = (annualTestVariant: AnnualContributionsTestVaria
   };
 };
 
-//For the old payment flow only
+// For the old payment flow only
 export function setInitialAmountsForAnnualVariants(store: Store<*, *, *>) {
   const annualTestVariant = store.getState().common.abParticipations.annualContributionsRoundThree;
-  const countryGroupId = store.getState().common.internationalisation.countryGroupId;
+  const { countryGroupId } = store.getState().common.internationalisation.countryGroupId;
   const amount = annualTestVariant === 'annualAmountsA' ? VariantA.defaults[countryGroupId] : VariantB.defaults[countryGroupId];
   store.dispatch(contributionSelectionActionsFor('CONTRIBUTE_SECTION').setAmountForContributionType('ANNUAL', amount));
 }

--- a/assets/helpers/abTests/helpers/annualContributions.js
+++ b/assets/helpers/abTests/helpers/annualContributions.js
@@ -126,7 +126,6 @@ export const getAnnualAmounts = (annualTestVariant: AnnualContributionsTestVaria
 export function setInitialAmountsForAnnualVariants(store: Store<*, *, *>) {
   const annualTestVariant = store.getState().common.abParticipations.annualContributionsRoundThree;
   const { countryGroupId } = store.getState().common.internationalisation;
-  console.log(annualTestVariant, countryGroupId)
   const amount = annualTestVariant === 'control' ? Control.defaults[countryGroupId] : VariantA.defaults[countryGroupId];
   store.dispatch(contributionSelectionActionsFor('CONTRIBUTE_SECTION').setAmountForContributionType('ANNUAL', amount));
 }

--- a/assets/helpers/abTests/helpers/annualContributions.js
+++ b/assets/helpers/abTests/helpers/annualContributions.js
@@ -100,6 +100,7 @@ const VariantA = {
 };
 
 export const getAnnualAmounts = (annualTestVariant: AnnualContributionsTestVariant) => {
+  console.log(annualTestVariant)
   if (annualTestVariant === 'annualAmountsA') {
     return {
       GBPCountries: VariantA.standard,

--- a/assets/helpers/contributions.js
+++ b/assets/helpers/contributions.js
@@ -10,6 +10,7 @@ import { currencies, spokenCurrencies } from 'helpers/internationalisation/curre
 import type { Radio } from 'components/radioToggle/radioToggle';
 import type { AnnualContributionsTestVariant } from 'helpers/abTests/abtestDefinitions';
 import { logException } from 'helpers/logger';
+import { getAnnualAmounts } from 'helpers/abTests/helpers/annualContributions';
 
 // ----- Types ----- //
 
@@ -218,51 +219,6 @@ const defaultMonthlyAmount = [
   { value: '15', spoken: numbersInWords['15'], isDefault: true },
   { value: '30', spoken: numbersInWords['30'], isDefault: false },
 ];
-
-const annualAmountLow = [
-  { value: '25', spoken: numbersInWords['25'], isDefault: false },
-  { value: '50', spoken: numbersInWords['50'], isDefault: true },
-  { value: '100', spoken: numbersInWords['100'], isDefault: false },
-  { value: '250', spoken: numbersInWords['250'], isDefault: false },
-];
-
-const annualAmountMedium = [
-  { value: '50', spoken: numbersInWords['50'], isDefault: false },
-  { value: '100', spoken: numbersInWords['100'], isDefault: true },
-  { value: '250', spoken: numbersInWords['250'], isDefault: false },
-  { value: '500', spoken: numbersInWords['500'], isDefault: false },
-];
-
-
-const annualAmountHigh = [
-  { value: '100', spoken: numbersInWords['100'], isDefault: false },
-  { value: '250', spoken: numbersInWords['250'], isDefault: true },
-  { value: '500', spoken: numbersInWords['500'], isDefault: false },
-  { value: '750', spoken: numbersInWords['750'], isDefault: false },
-];
-
-const getAnnualAmounts = (annualTestVariant: AnnualContributionsTestVariant) => {
-  if (annualTestVariant === 'annualHigherAmounts') {
-    return {
-      GBPCountries: annualAmountMedium,
-      UnitedStates: annualAmountMedium,
-      AUDCountries: annualAmountHigh,
-      EURCountries: annualAmountMedium,
-      International: annualAmountMedium,
-      NZDCountries: annualAmountHigh,
-      Canada: annualAmountMedium,
-    };
-  }
-  return {
-    GBPCountries: annualAmountLow,
-    UnitedStates: annualAmountLow,
-    AUDCountries: annualAmountMedium,
-    EURCountries: annualAmountLow,
-    International: annualAmountLow,
-    NZDCountries: annualAmountMedium,
-    Canada: annualAmountLow,
-  };
-};
 
 const amounts = (annualTestVariant: AnnualContributionsTestVariant) => ({
   ONE_OFF: {
@@ -498,7 +454,7 @@ function getContributionTypeRadios(
     accessibilityHint: 'Make a regular annual contribution',
   };
 
-  return annualTestVariant === 'annual' || annualTestVariant === 'annualHigherAmounts'
+  return annualTestVariant === 'annualAmountsA' || annualTestVariant === 'annualAmountsB'
     ? [oneOff, monthly, annual]
     : [monthly, oneOff];
 

--- a/assets/helpers/contributions.js
+++ b/assets/helpers/contributions.js
@@ -454,7 +454,7 @@ function getContributionTypeRadios(
     accessibilityHint: 'Make a regular annual contribution',
   };
 
-  return annualTestVariant === 'annualAmountsA' || annualTestVariant === 'annualAmountsB'
+  return annualTestVariant === 'control' || annualTestVariant === 'annualAmountsA'
     ? [oneOff, monthly, annual]
     : [monthly, oneOff];
 

--- a/assets/helpers/contributions.js
+++ b/assets/helpers/contributions.js
@@ -432,33 +432,25 @@ function getAmountA11yHint(
 
 }
 
-function getContributionTypeRadios(
-  countryGroupId: CountryGroupId,
-  annualTestVariant: AnnualContributionsTestVariant,
-) {
-
-  const oneOff = {
+const contributionTypeRadios = [
+  {
     value: 'ONE_OFF',
     text: 'Single',
     accessibilityHint: 'Make a single contribution',
     id: 'qa-one-off-toggle',
-  };
-  const monthly = {
+  },
+  {
     value: 'MONTHLY',
     text: 'Monthly',
     accessibilityHint: 'Make a regular monthly contribution',
-  };
-  const annual = {
+  },
+  {
     value: 'ANNUAL',
     text: 'Annually',
     accessibilityHint: 'Make a regular annual contribution',
-  };
+  },
+];
 
-  return annualTestVariant === 'control' || annualTestVariant === 'annualAmountsA'
-    ? [oneOff, monthly, annual]
-    : [monthly, oneOff];
-
-}
 
 function getContributionAmountRadios(
   contributionType: Contrib,
@@ -491,7 +483,7 @@ export {
   getSpokenType,
   getFrequency,
   getCustomAmountA11yHint,
-  getContributionTypeRadios,
+  contributionTypeRadios,
   getContributionAmountRadios,
   parseRegularContributionType,
 };

--- a/assets/pages/contributions-landing/containers/contributionSelectionContainer.js
+++ b/assets/pages/contributions-landing/containers/contributionSelectionContainer.js
@@ -25,7 +25,7 @@ function mapStateToProps(state: State) {
     error: state.page.selection.error,
     oneOffSingleOneTimeTestVariant: state.common.abParticipations.oneOffOneTimeSingle,
     usOneOffSingleOneTimeTestVariant: state.common.abParticipations.usOneOffOneTimeSingle,
-    annualTestVariant: state.common.abParticipations.annualContributionsRoundTwo,
+    annualTestVariant: state.common.abParticipations.annualContributionsRoundThree,
   };
 
 }

--- a/assets/pages/contributions-landing/contributionsLanding.jsx
+++ b/assets/pages/contributions-landing/contributionsLanding.jsx
@@ -9,7 +9,7 @@ import { renderPage } from 'helpers/render';
 import { detect, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { oldContributionsFlowTests } from 'helpers/abTests/abtestDefinitions';
 
-import { setInitialAmountsForAnnualHigherAmountsVariant } from 'helpers/abTests/helpers/annualContributions';
+import { setInitialAmountsForAnnualVariants } from 'helpers/abTests/helpers/annualContributions';
 import HorizontalLandingLayout from './pagesVersions/horizontalLayoutLandingPage';
 
 import { createPageReducerFor } from './contributionsLandingReducer';
@@ -43,5 +43,5 @@ const reactElementId: {
 
 const content = <HorizontalLandingLayout store={store} countryGroupId={countryGroupId} />;
 
-setInitialAmountsForAnnualHigherAmountsVariant(store);
+setInitialAmountsForAnnualVariants(store);
 renderPage(content, reactElementId[countryGroupId]);

--- a/assets/pages/contributions-landing/pagesVersions/horizontalLayoutLandingPage.jsx
+++ b/assets/pages/contributions-landing/pagesVersions/horizontalLayoutLandingPage.jsx
@@ -79,7 +79,7 @@ const CountrySwitcherHeader = CountrySwitcherHeaderContainer(
 const HorizontalLayoutLandingPage: (PropTypes) => React.Node = (props: PropTypes) => {
   const annualContributeCopy = 'Make a recurring commitment to support The Guardian long term or a single contribution as and when you feel like it – choose the option that suits you best.';
   const annualTestVariant = props.store && props.store.getState().common.abParticipations.annualContributionsRoundThree;
-  const copyText = annualTestVariant === 'annualAmountsA' || annualTestVariant === 'annualAmountsB'
+  const copyText = annualTestVariant === 'control' || annualTestVariant === 'annualAmountsA'
     ? annualContributeCopy
     : countryGroupSpecificDetails[props.countryGroupId].contributeCopy;
 

--- a/assets/pages/contributions-landing/pagesVersions/horizontalLayoutLandingPage.jsx
+++ b/assets/pages/contributions-landing/pagesVersions/horizontalLayoutLandingPage.jsx
@@ -78,8 +78,8 @@ const CountrySwitcherHeader = CountrySwitcherHeaderContainer(
 
 const HorizontalLayoutLandingPage: (PropTypes) => React.Node = (props: PropTypes) => {
   const annualContributeCopy = 'Make a recurring commitment to support The Guardian long term or a single contribution as and when you feel like it – choose the option that suits you best.';
-  const annualTestVariant = props.store && props.store.getState().common.abParticipations.annualContributionsRoundTwo;
-  const copyText = annualTestVariant === 'annual' || annualTestVariant === 'annualHigherAmounts'
+  const annualTestVariant = props.store && props.store.getState().common.abParticipations.annualContributionsRoundThree;
+  const copyText = annualTestVariant === 'annualAmountsA' || annualTestVariant === 'annualAmountsB'
     ? annualContributeCopy
     : countryGroupSpecificDetails[props.countryGroupId].contributeCopy;
 

--- a/assets/pages/contributions-landing/pagesVersions/horizontalLayoutLandingPage.jsx
+++ b/assets/pages/contributions-landing/pagesVersions/horizontalLayoutLandingPage.jsx
@@ -33,7 +33,7 @@ type PropTypes = {|
 // ----- Internationalisation ----- //
 
 const defaultHeaderCopy = ['Help us deliver the', 'independent journalism', 'the world needs'];
-const defaultContributeCopy = 'Make a monthly commitment to support The Guardian long term or a single contribution as and when you feel like it – choose the option that suits you best.';
+const defaultContributeCopy = 'Make a recurring commitment to support The Guardian long term or a single contribution as and when you feel like it – choose the option that suits you best.';
 
 const countryGroupSpecificDetails: {
   [CountryGroupId]: {headerCopy: string[], contributeCopy: string}
@@ -77,11 +77,7 @@ const CountrySwitcherHeader = CountrySwitcherHeaderContainer(
 // ----- Render ----- //
 
 const HorizontalLayoutLandingPage: (PropTypes) => React.Node = (props: PropTypes) => {
-  const annualContributeCopy = 'Make a recurring commitment to support The Guardian long term or a single contribution as and when you feel like it – choose the option that suits you best.';
-  const annualTestVariant = props.store && props.store.getState().common.abParticipations.annualContributionsRoundThree;
-  const copyText = annualTestVariant === 'control' || annualTestVariant === 'annualAmountsA'
-    ? annualContributeCopy
-    : countryGroupSpecificDetails[props.countryGroupId].contributeCopy;
+  const copyText = countryGroupSpecificDetails[props.countryGroupId].contributeCopy;
 
   return (
     <Provider store={props.store}>

--- a/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
@@ -10,6 +10,7 @@ import { config, amounts, type Amount, type Contrib } from 'helpers/contribution
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { type IsoCurrency, type Currency, type SpokenCurrency, currencies, spokenCurrencies } from 'helpers/internationalisation/currency';
 import { classNameWithModifiers } from 'helpers/utilities';
+import type { AnnualContributionsTestVariant } from 'helpers/abTests/abtestDefinitions';
 
 import SvgDollar from 'components/svgs/dollar';
 import SvgEuro from 'components/svgs/euro';
@@ -31,7 +32,9 @@ type PropTypes = {|
   checkOtherAmount: string => boolean,
   updateOtherAmount: string => void,
   checkoutFormHasBeenSubmitted: boolean,
+  annualTestVariant: AnnualContributionsTestVariant,
 |};
+
 /* eslint-enable react/no-unused-prop-types */
 
 const mapStateToProps = state => ({
@@ -41,6 +44,7 @@ const mapStateToProps = state => ({
   selectedAmounts: state.page.form.selectedAmounts,
   otherAmount: state.page.form.formData.otherAmounts[state.page.form.contributionType].amount,
   checkoutFormHasBeenSubmitted: state.page.form.formData.checkoutFormHasBeenSubmitted,
+  annualTestVariant: state.common.abParticipations.annualContributionsRoundThree,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch<Action>) => ({
@@ -84,7 +88,7 @@ const iconForCountryGroup = (countryGroupId: CountryGroupId): React$Element<*> =
 
 
 function ContributionAmount(props: PropTypes) {
-  const validAmounts: Amount[] = amounts('notintest')[props.contributionType][props.countryGroupId];
+  const validAmounts: Amount[] = amounts(props.annualTestVariant)[props.contributionType][props.countryGroupId];
   const showOther: boolean = props.selectedAmounts[props.contributionType] === 'other';
   const { min, max } = config[props.countryGroupId][props.contributionType]; // eslint-disable-line react/prop-types
   const minAmount: string = formatAmount(currencies[props.currency], spokenCurrencies[props.currency], { value: min.toString(), spoken: '', isDefault: false }, false);

--- a/assets/pages/new-contributions-landing/contributionsLandingReducer.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingReducer.js
@@ -86,9 +86,9 @@ export type State = {
 
 function createFormReducer(countryGroupId: CountryGroupId) {
   const amountsForCountry: { [Contrib]: Amount[] } = {
-    ONE_OFF: amounts('notintest').ONE_OFF[countryGroupId],
-    MONTHLY: amounts('notintest').MONTHLY[countryGroupId],
-    ANNUAL: amounts('notintest').ANNUAL[countryGroupId],
+    ONE_OFF: amounts('control').ONE_OFF[countryGroupId],
+    MONTHLY: amounts('control').MONTHLY[countryGroupId],
+    ANNUAL: amounts('control').ANNUAL[countryGroupId],
   };
 
   const initialAmount: { [Contrib]: Amount | 'other' } = {

--- a/assets/pages/new-contributions-landing/contributionsLandingReducer.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingReducer.js
@@ -86,9 +86,9 @@ export type State = {
 
 function createFormReducer(countryGroupId: CountryGroupId) {
   const amountsForCountry: { [Contrib]: Amount[] } = {
-    ONE_OFF: amounts('control').ONE_OFF[countryGroupId],
-    MONTHLY: amounts('control').MONTHLY[countryGroupId],
-    ANNUAL: amounts('control').ANNUAL[countryGroupId],
+    ONE_OFF: amounts('notintest').ONE_OFF[countryGroupId],
+    MONTHLY: amounts('notintest').MONTHLY[countryGroupId],
+    ANNUAL: amounts('notintest').ANNUAL[countryGroupId],
   };
 
   const initialAmount: { [Contrib]: Amount | 'other' } = {

--- a/assets/pages/support-landing/components/contributionSelectionContainer.js
+++ b/assets/pages/support-landing/components/contributionSelectionContainer.js
@@ -25,7 +25,7 @@ function mapStateToProps(state: State) {
     error: state.page.selection.error,
     oneOffSingleOneTimeTestVariant: state.common.abParticipations.oneOffOneTimeSingle,
     usOneOffSingleOneTimeTestVariant: state.common.abParticipations.usOneOffOneTimeSingle,
-    annualTestVariant: state.common.abParticipations.annualContributionsRoundTwo,
+    annualTestVariant: state.common.abParticipations.annualContributionsRoundThree,
   };
 
 }

--- a/assets/pages/support-landing/supportLanding.jsx
+++ b/assets/pages/support-landing/supportLanding.jsx
@@ -12,7 +12,7 @@ import CirclesIntroduction from 'components/introduction/circlesIntroduction';
 import WhySupport from 'components/whySupport/whySupport';
 import ReadyToSupport from 'components/readyToSupport/readyToSupport';
 import Contribute from 'components/contribute/contribute';
-import { setInitialAmountsForAnnualHigherAmountsVariant } from 'helpers/abTests/helpers/annualContributions';
+import { setInitialAmountsForAnnualVariants } from 'helpers/abTests/helpers/annualContributions';
 
 // React components connected to redux store
 import CountrySwitcherHeaderContainer from 'components/headers/countrySwitcherHeader/countrySwitcherHeaderContainer';
@@ -90,5 +90,5 @@ const content = (
   </Provider>
 );
 
-setInitialAmountsForAnnualHigherAmountsVariant(store);
+setInitialAmountsForAnnualVariants(store);
 renderPage(content, 'support-landing-page');


### PR DESCRIPTION
## Why are you doing this?
A third test for annual contribution amounts.
All users will see the annual contribution option. There are 2 variants.

Some of the code in `annualContributions.js` is quite hacky to support the old payments flow, which we will hopefully remove soon.

In future we will build a tool to make these tests much easier to configure.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/gQMjG2Om/92-amounts-test-annual-contribs-round-3-ad-hoc)

## Screenshots
#### Old flow, control
![picture 14](https://user-images.githubusercontent.com/1513454/47374037-f2d91280-d6e4-11e8-9bce-dbb3ac362f6d.png)

#### Old flow, variantA
<img width="437" alt="picture 18" src="https://user-images.githubusercontent.com/1513454/47431353-8b2dd080-d793-11e8-9e07-6ae7f2d80405.png">


#### New flow, control
![picture 13](https://user-images.githubusercontent.com/1513454/47374042-f66c9980-d6e4-11e8-801f-34509fe905d0.png)

#### New flow, variantA
<img width="400" alt="picture 17" src="https://user-images.githubusercontent.com/1513454/47431305-75b8a680-d793-11e8-8af2-7a793948c639.png">
