### PR TITLE
thank you button fix

### DIFF
--- a/assets/pages/new-contributions-landing/components/ButtonWithRightArrow.jsx
+++ b/assets/pages/new-contributions-landing/components/ButtonWithRightArrow.jsx
@@ -20,7 +20,7 @@ function ButtonWithRightArrow(props: PropTypes) {
 
   return (
     <div className={props.componentClassName}>
-      <button
+      <a
         className={props.buttonClassName}
         type={props.type}
         href={props.url}
@@ -30,7 +30,7 @@ function ButtonWithRightArrow(props: PropTypes) {
         {props.buttonCopy}
         <p id={props.accessibilityHintId} className="accessibility-hint">{props.buttonCopy}</p>
         <SvgArrowRight />
-      </button>
+      </a>
     </div>
   );
 }

--- a/assets/pages/new-contributions-landing/components/ButtonWithRightArrow.jsx
+++ b/assets/pages/new-contributions-landing/components/ButtonWithRightArrow.jsx
@@ -11,7 +11,6 @@ type PropTypes = {
   type: string,
   accessibilityHintId: string,
   buttonCopy: string,
-  url: ?string,
   onClick: () => void,
 };
 // ----- Render ----- //
@@ -20,17 +19,16 @@ function ButtonWithRightArrow(props: PropTypes) {
 
   return (
     <div className={props.componentClassName}>
-      <a
+      <button
         className={props.buttonClassName}
         type={props.type}
-        href={props.url}
         aria-describedby={props.accessibilityHintId}
         onClick={props.onClick}
       >
         {props.buttonCopy}
         <p id={props.accessibilityHintId} className="accessibility-hint">{props.buttonCopy}</p>
         <SvgArrowRight />
-      </a>
+      </button>
     </div>
   );
 }
@@ -39,7 +37,6 @@ function ButtonWithRightArrow(props: PropTypes) {
 
 ButtonWithRightArrow.defaultProps = {
   onClick: () => undefined,
-  url: null,
 };
 
 export { ButtonWithRightArrow };

--- a/assets/pages/new-contributions-landing/components/ContributionThankYou.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionThankYou.jsx
@@ -7,8 +7,8 @@ import type { PaymentMethod } from 'helpers/contributions';
 import React from 'react';
 import { connect } from 'react-redux';
 import { type Contrib, getSpokenType } from 'helpers/contributions';
-import MarketingConsent from '../components/MarketingConsent';
 import CtaLink from 'components/ctaLink/ctaLink';
+import MarketingConsent from '../components/MarketingConsent';
 import { type Action, setHasSeenDirectDebitThankYouCopy } from '../contributionsLandingActions';
 
 // ----- Types ----- //

--- a/assets/pages/new-contributions-landing/components/ContributionThankYou.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionThankYou.jsx
@@ -7,9 +7,8 @@ import type { PaymentMethod } from 'helpers/contributions';
 import React from 'react';
 import { connect } from 'react-redux';
 import { type Contrib, getSpokenType } from 'helpers/contributions';
-import { classNameWithModifiers } from 'helpers/utilities';
 import MarketingConsent from '../components/MarketingConsent';
-import { ButtonWithRightArrow } from '../components/ButtonWithRightArrow';
+import CtaLink from 'components/ctaLink/ctaLink';
 import { type Action, setHasSeenDirectDebitThankYouCopy } from '../contributionsLandingActions';
 
 // ----- Types ----- //
@@ -62,14 +61,14 @@ function ContributionThankYou(props: PropTypes) {
         </section>
       ) : null}
       <MarketingConsent />
-      <ButtonWithRightArrow
-        componentClassName={classNameWithModifiers('confirmation', ['backtothegu'])}
-        buttonClassName={classNameWithModifiers('button', ['wob'])}
-        accessibilityHintId="accessibility-hint-return-to-guardian"
-        type="button"
-        url="https://www.theguardian.com"
-        buttonCopy="Return to The Guardian&nbsp;"
-      />
+      <div className="confirmation confirmation--backtothegu">
+        <CtaLink
+          modifierClasses={['backtothegu']}
+          accessibilityHint="accessibility-hint-return-to-guardian"
+          url="https://www.theguardian.com"
+          text="Return to The Guardian&nbsp;"
+        />
+      </div>
     </div>
   );
 }

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -917,6 +917,10 @@ form {
   margin-bottom: $gu-v-spacing + 20px;
   padding-bottom: $gu-v-spacing;
   padding-top: $gu-v-spacing;
+
+  & > a {
+    font-size: 16px;
+  }
 }
 
 .confirmation__meta {

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -910,22 +910,19 @@ form {
 }
 
 .confirmation--backtothegu {
-  border-bottom: 0;
-}
-
-.confirmation--backtothegu {
   margin-bottom: $gu-v-spacing + 20px;
   padding-bottom: $gu-v-spacing;
   padding-top: $gu-v-spacing;
-
-  & > a {
-    font-size: 16px;
-  }
+  border-bottom: 0;
 }
 
 .confirmation__meta {
   font-family: $gu-text-sans-web;
   font-size: 12px;
+}
+
+.component-cta-link--backtothegu {
+  font-size: 16px;
 }
 
 .button {


### PR DESCRIPTION
## Why are you doing this?
* Fix link to the Gu on thank you page. 
<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->
## Changes

* Uses `CtaLink` for link on thank you page
* Removes optional url from `ButtonWithRightArrow`. This elem is used twice on the password setting thank you page. One submits the form if a password is being added, the other uses the onclick function passed through to redirect to the next thank you page. As neither use `url`, this property can be removed. 

![screen shot 2018-10-23 at 19 28 36](https://user-images.githubusercontent.com/8484757/47382376-10fd3d80-d6fa-11e8-8878-1652e17f6fd9.jpg)
