### PR TITLE
Bump Flow to 0.83.0

### DIFF
--- a/assets/components/directDebit/directDebitForm/directDebitForm.jsx
+++ b/assets/components/directDebit/directDebitForm/directDebitForm.jsx
@@ -312,6 +312,8 @@ function PaymentButton(props: {
       </span>
     );
   }
+
+  return null;
 }
 
 function LegalNotice(props: { countryGroupId: CountryGroupId }) {

--- a/assets/helpers/page/page.js
+++ b/assets/helpers/page/page.js
@@ -9,7 +9,6 @@ import {
   applyMiddleware,
   compose,
   type Reducer,
-  type StoreEnhancer,
 } from 'redux';
 import thunkMiddleware from 'redux-thunk';
 import type { Store } from 'redux';

--- a/assets/helpers/page/page.js
+++ b/assets/helpers/page/page.js
@@ -140,7 +140,7 @@ function statelessInit() {
 
 // Enables redux devtools extension and optional redux-thunk.
 /* eslint-disable no-underscore-dangle */
-function storeEnhancer<S, A>(thunk: boolean): StoreEnhancer<S, A> | typeof undefined {
+function storeEnhancer(thunk: boolean) {
 
   if (thunk) {
     const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;

--- a/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
@@ -128,6 +128,8 @@ function ContributionSubmit(props: PropTypes) {
       </div>
     );
   }
+
+  return null;
 }
 
 const NewContributionSubmit = connect(mapStateToProps, mapDispatchToProps)(ContributionSubmit);

--- a/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
@@ -17,8 +17,6 @@ import { type State } from '../contributionsLandingReducer';
 import { formatAmount } from './ContributionAmount';
 import { PayPalRecurringButton } from './PayPalRecurringButton';
 import {
-  onThirdPartyPaymentAuthorised,
-  paymentWaiting,
   setCheckoutFormHasBeenSubmitted,
   setupRecurringPayPalPayment,
 } from '../contributionsLandingActions';
@@ -35,8 +33,6 @@ type PropTypes = {
   otherAmount: string | null,
   currencyId: IsoCurrency,
   csrf: CsrfState,
-  setPaymentIsWaiting: boolean => void,
-  onThirdPartyPaymentAuthorised: PaymentAuthorisation => void,
   setCheckoutFormHasBeenSubmitted: () => void,
   setupRecurringPayPalPayment: (resolve: string => void, reject: Error => void, IsoCurrency, CsrfState) => void,
   payPalHasLoaded: boolean,
@@ -59,8 +55,6 @@ const mapStateToProps = (state: State) =>
   });
 
 const mapDispatchToProps = (dispatch: Function) => ({
-  setPaymentIsWaiting: (isWaiting) => { dispatch(paymentWaiting(isWaiting)); },
-  onThirdPartyPaymentAuthorised: (token) => { dispatch(onThirdPartyPaymentAuthorised(token)); },
   setCheckoutFormHasBeenSubmitted: () => { dispatch(setCheckoutFormHasBeenSubmitted()); },
   setupRecurringPayPalPayment: (
     resolve: Function,

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-react": "^7.9.1",
     "file-loader": "^2.0.0",
-    "flow-bin": "^0.74.0",
+    "flow-bin": "^0.83.0",
     "flow-typed": "^2.4.0",
     "jest": "^23.5.0",
     "mini-css-extract-plugin": "^0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3972,10 +3972,10 @@ flatten@^1.0.2:
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
   integrity sha1-2uRqnXj74lKSJYzB54CkHZXAN4I=
 
-flow-bin@^0.74.0:
-  version "0.74.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.74.0.tgz#8017bb00efb37cbe8d81fbb7f464038bde06adc9"
-  integrity sha512-tIN9J5qg71S4UbofCu80tve8a+p7Hj7ytwUtu79cLg9KJVVTNnVVJXKgCghVzaZT1Rvl9SMHVPlDs9uYhPHEGQ==
+flow-bin@^0.83.0:
+  version "0.83.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.83.0.tgz#fd26f5f95758d7701264b3f9a1e1a3d4cbcab1a9"
+  integrity sha512-1K83EL/U9Gh0BaXPKkZe6TRizSmNSKx9Wuws1c8gh7DJEwiburtCxYT+4o7in1+GnNEm3CZWnbnVV8n9HMpiDA==
 
 flow-typed@^2.4.0:
   version "2.5.1"


### PR DESCRIPTION
## Why are you doing this?

Keeping flow up-to-date and fixing errors.

cc @JustinPinner 

## Changes

- Bumped flow to 0.83.0.
- Explicitly returned `null` from components in places where `undefined` was being implicitly returned.
- Stopped trying to annotate `storeEnhancer` function, allowing flow to do it implicitly now.
- Removed some props in `ContributionSubmit` that weren't being used (@joelochlann @jranks123 ESLint thinks they aren't and I think it's right, can you confirm?).
