### PR TITLE
removes instanceOf check in details polyfill

### DIFF
--- a/assets/helpers/details.js
+++ b/assets/helpers/details.js
@@ -2,7 +2,7 @@
 
 const isDetailsSupported: boolean = ('open' in document.createElement('details'));
 
-function toggleDetailsState(details: HTMLDetailsElement) {
+function toggleDetailsState(details: Element) {
   if (details.hasAttribute('open')) {
     details.removeAttribute('open');
   } else {
@@ -16,7 +16,8 @@ function handleEvent(event: UIEvent) {
   while (targetNode.nodeName.toLowerCase() !== 'summary' && targetNode !== document && targetNode.parentElement) {
     targetNode = targetNode.parentElement;
   }
-  if (targetNode.nodeName.toLowerCase() === 'summary' && targetNode.parentElement instanceof HTMLDetailsElement) {
+
+  if (targetNode.nodeName.toLowerCase() === 'summary' && targetNode.parentElement && targetNode.parentElement.nodeName.toLowerCase() === 'details') {
     toggleDetailsState(targetNode.parentElement);
   }
 }


### PR DESCRIPTION
## Why are you doing this?
To fix the country selector in browsers that do not support `<details>`, such as IE 11, Edge 17, and older versions of FF. (note, supported browsers are listed in the [wiki](https://github.com/guardian/support-frontend/wiki/Supported-Browsers)). 

Currently, the polyfill checks `instanceOf HTMLDetailsElement` which results in a typeError and prevents `toggleDetailsState` being successfully called. 

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Changes
* Check parent is a details tag by using name.

I've tested this on Edge and Firefox using BrowserStack Local but I cannot get local version running on IE inside BrowserStack. 


