### PR TITLE
fix click on country selector svg

### DIFF
--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -67,6 +67,11 @@ header[role="banner"] {
   height: 40px;
   outline: none;
   transition: box-shadow .2s ease-in-out, color .2s ease-in-out;
+
+  // this is to fix IE bug where events on svgs don't bubble up
+  & svg {
+    pointer-events: none;
+  }
 }
 
 .countryGroups:not([open]) > :not(summary) {


### PR DESCRIPTION
## Why are you doing this?
So an IE user can click on the downward arrow and open the country selector (expected behaviour).

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

Currently the details will open if you click around the svg but not on it... 

![wontopen](https://user-images.githubusercontent.com/8484757/47425599-b825b780-d782-11e8-9e15-1de194096914.gif)

## Changes

* Use css trick from [here](https://stackoverflow.com/questions/24078524/svg-click-events-not-firing-bubbling-when-using-use-element).  Which says:

> The element is never the target of mouse events; however, mouse events may target its descendant elements if those descendants have pointer-events set to some other value. In these circumstances, mouse events will trigger event listeners on this parent element as appropriate on their way to/from the descendant during the event capture/bubble phases.
