### PR TITLE
Subs Landing Ready To Support Link Points To Top

### DIFF
--- a/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
+++ b/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
@@ -18,11 +18,6 @@ import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
 
 
-// ----- Setup ----- //
-
-const supporterSectionId = 'supporter-options';
-
-
 // ----- Redux Store ----- //
 
 const store = pageInit();
@@ -42,7 +37,7 @@ const content = (
       <SubscriptionsByCountryGroup headingSize={3} appMedium="subscribe_landing_page" />
       <WhySupportVideoContainer headingSize={3} id="why-support" />
       <ReadyToSupport
-        ctaUrl={`#${supporterSectionId}`}
+        ctaUrl="#top"
         headingSize={2}
       />
     </Page>


### PR DESCRIPTION
## Why are you doing this?

The "Ready to Support" link on the subs landing page is broken. This updates it to point to the top of the page.

cc @JustinPinner 

## Changes

- Updated link to point to `#top`.
