### PR TITLE
Show ✨flash sale✨ header on all regions of the DP page

### DIFF
--- a/assets/components/featuredDigitalPack/flashSaleDigitalPack.jsx
+++ b/assets/components/featuredDigitalPack/flashSaleDigitalPack.jsx
@@ -8,6 +8,7 @@ import Heading from 'components/heading/heading';
 import CtaLink from 'components/ctaLink/ctaLink';
 import GridPicture from 'components/gridPicture/gridPicture';
 import { currencies, detect } from 'helpers/internationalisation/currency';
+import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { getDiscountedPrice } from 'helpers/flashSale';
 import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
 import type { ComponentAbTest } from 'helpers/subscriptions';
@@ -18,11 +19,12 @@ import type { HeadingSize } from 'components/heading/heading';
 type PropTypes = {
   headingSize: HeadingSize,
   url: string,
+  countryGroupId: CountryGroupId,
   abTest: ComponentAbTest | null,
 };
 
 
-export default function FlashSaleDigitalPack(props: PropTypes) {
+function FlashSaleDigitalPack(props: PropTypes) {
   const currency = currencies[detect(props.countryGroupId)].glyph;
   return (
     <section className="component-flash-sale-featured-digital-pack">
@@ -81,3 +83,14 @@ export default function FlashSaleDigitalPack(props: PropTypes) {
   );
 }
 
+
+// ----- Default Props ----- //
+
+FlashSaleDigitalPack.defaultProps = {
+  abTest: null,
+};
+
+
+// ----- Export ----- //
+
+export default FlashSaleDigitalPack;

--- a/assets/components/featuredDigitalPack/flashSaleDigitalPack.jsx
+++ b/assets/components/featuredDigitalPack/flashSaleDigitalPack.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import Heading from 'components/heading/heading';
 import CtaLink from 'components/ctaLink/ctaLink';
 import GridPicture from 'components/gridPicture/gridPicture';
+import { currencies, detect } from 'helpers/internationalisation/currency';
 import { getDiscountedPrice } from 'helpers/flashSale';
 import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
 import type { ComponentAbTest } from 'helpers/subscriptions';
@@ -22,6 +23,7 @@ type PropTypes = {
 
 
 export default function FlashSaleDigitalPack(props: PropTypes) {
+  const currency = currencies[detect(props.countryGroupId)].glyph;
   return (
     <section className="component-flash-sale-featured-digital-pack">
       <div className="component-flash-sale-featured-digital-pack__content">
@@ -40,7 +42,7 @@ export default function FlashSaleDigitalPack(props: PropTypes) {
           </Heading>
           <p className="component-flash-sale-featured-digital-pack__copy">
             Read the Guardian ad-free on all devices, including the Premium App and Daily Edition iPad app.
-            £{getDiscountedPrice('DigitalPack', props.countryGroupId)} for your first three months.
+            {currency}{getDiscountedPrice('DigitalPack', props.countryGroupId)} for your first three months.
           </p>
           <CtaLink
             text="Subscribe now"

--- a/assets/components/featuredDigitalPack/flashSaleDigitalPack.jsx
+++ b/assets/components/featuredDigitalPack/flashSaleDigitalPack.jsx
@@ -42,7 +42,7 @@ export default function FlashSaleDigitalPack(props: PropTypes) {
           </Heading>
           <p className="component-flash-sale-featured-digital-pack__copy">
             Read the Guardian ad-free on all devices, including the Premium App and Daily Edition iPad app.
-            {currency}{getDiscountedPrice('DigitalPack', props.countryGroupId)} for your first three months.
+            {' '}{currency}{getDiscountedPrice('DigitalPack', props.countryGroupId)} for your first three months.
           </p>
           <CtaLink
             text="Subscribe now"

--- a/assets/components/featuredDigitalPack/flashSaleDigitalPack.jsx
+++ b/assets/components/featuredDigitalPack/flashSaleDigitalPack.jsx
@@ -40,7 +40,7 @@ export default function FlashSaleDigitalPack(props: PropTypes) {
           </Heading>
           <p className="component-flash-sale-featured-digital-pack__copy">
             Read the Guardian ad-free on all devices, including the Premium App and Daily Edition iPad app.
-            £{getDiscountedPrice('DigitalPack', 'GBPCountries')} for your first three months.
+            £{getDiscountedPrice('DigitalPack', props.countryGroupId)} for your first three months.
           </p>
           <CtaLink
             text="Subscribe now"

--- a/assets/components/subscriptionsByCountryGroup/subscriptionsByCountryGroup.jsx
+++ b/assets/components/subscriptionsByCountryGroup/subscriptionsByCountryGroup.jsx
@@ -15,7 +15,9 @@ import { classNameWithModifiers } from 'helpers/utilities';
 import { getAppReferrer } from 'helpers/tracking/appStores';
 import { type Participations } from 'helpers/abTests/abtest';
 import { type OptimizeExperiments } from 'helpers/tracking/optimize';
+import { flashSaleIsActive } from 'helpers/flashSale';
 import FeaturedDigitalPack from 'components/featuredDigitalPack/featuredDigitalPack';
+import FlashSaleDigitalPack from 'components/featuredDigitalPack/flashSaleDigitalPack';
 import DigitalSection from './components/digitalSection';
 import PaperSection from './components/paperSection';
 import InternationalSection from './components/internationalSection';
@@ -99,11 +101,13 @@ function SubscriptionsByCountryGroup(props: PropTypes) {
 
   return (
     <div className={className} {...otherProps}>
-      <FeaturedDigitalPack
-        headingSize={3}
-        countryGroupId={props.countryGroupId}
-        url={subsLinks.DigitalPack}
-      />
+      {flashSaleIsActive('DigitalPack') &&
+        <FlashSaleDigitalPack
+          headingSize={3}
+          countryGroupId={props.countryGroupId}
+          url={subsLinks.DigitalPack}
+        />
+      }
       <InternationalSection
         headingSize={headingSize}
         subsLinks={subsLinks}

--- a/assets/components/subscriptionsByCountryGroup/subscriptionsByCountryGroup.jsx
+++ b/assets/components/subscriptionsByCountryGroup/subscriptionsByCountryGroup.jsx
@@ -99,6 +99,11 @@ function SubscriptionsByCountryGroup(props: PropTypes) {
 
   return (
     <div className={className} {...otherProps}>
+      <FeaturedDigitalPack
+        headingSize={3}
+        countryGroupId={props.countryGroupId}
+        url={subsLinks.DigitalPack}
+      />
       <InternationalSection
         headingSize={headingSize}
         subsLinks={subsLinks}

--- a/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
+++ b/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
@@ -38,7 +38,7 @@ const content = (
       header={<SimpleHeader />}
       footer={<FooterContainer disclaimer privacyPolicy />}
     >
-      {header}
+      { header }
       <SubscriptionsByCountryGroup headingSize={3} appMedium="subscribe_landing_page" />
       <WhySupportVideoContainer headingSize={3} id="why-support" />
       <ReadyToSupport

--- a/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
+++ b/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
@@ -38,7 +38,7 @@ const content = (
       header={<SimpleHeader />}
       footer={<FooterContainer disclaimer privacyPolicy />}
     >
-      { header }
+      {header}
       <SubscriptionsByCountryGroup headingSize={3} appMedium="subscribe_landing_page" />
       <WhySupportVideoContainer headingSize={3} id="why-support" />
       <ReadyToSupport


### PR DESCRIPTION
## Why are you doing this?
SHows the header in all regions, makes the currency match

[**Trello Card**](https://trello.com/c/RslWVV0m/2030-add-featured-product-section-with-flash-sale-info-to-international-subs-landing-pages)

## Screenshots
<img width="1311" alt="screenshot 2018-10-24 at 3 45 32 pm" src="https://user-images.githubusercontent.com/11539094/47439815-f0d68880-d7a4-11e8-90d2-c50632dab2f7.png">
<img width="1311" alt="screenshot 2018-10-24 at 3 45 41 pm" src="https://user-images.githubusercontent.com/11539094/47439817-f207b580-d7a4-11e8-9475-bc312a0b5c06.png">
<img width="1311" alt="screenshot 2018-10-24 at 3 45 45 pm" src="https://user-images.githubusercontent.com/11539094/47439820-f338e280-d7a4-11e8-897e-44ee79662c80.png">

