### PR TITLE
Different Digital Pack product copy for non-UK markets

### DIFF
--- a/assets/pages/digital-subscription-landing/components/productBlock.jsx
+++ b/assets/pages/digital-subscription-landing/components/productBlock.jsx
@@ -88,11 +88,25 @@ const appImages: {
   },
 };
 
+function getDailyEditionCopy(countryGroupId: CountryGroupId) {
+  if (countryGroupId === 'GBPCountries') {
+    return {
+      description: 'Every issue of The Guardian and Observer, designed for your iPad and available offline',
+      onTheGoText: 'Your complete daily newspaper, beautifully designed for your iPad',
+    };
+  }
+  return {
+    description: 'Every issue of The Guardian and Observer UK newspapers, designed for your iPad and available offline',
+    onTheGoText: 'Your complete daily UK newspaper, beautifully designed for your iPad',
+  };
+
+}
+
 
 // ----- Component ----- //
 
 function ProductBlock(props: PropTypes) {
-
+  const dailyEditionCopy = getDailyEditionCopy(props.countryGroupId);
   return (
     <div className="product-block">
       <LeftMarginSection>
@@ -120,11 +134,11 @@ function ProductBlock(props: PropTypes) {
           }}
           companionSvg={<SvgPennyFarthingCircles />}
           heading="iPad daily edition"
-          description="Every issue of The Guardian and Observer, designed for your iPad and available offline"
+          description={dailyEditionCopy.description}
           features={[
             {
               heading: 'On-the-go reading',
-              text: 'Your complete daily newspaper, beautifully designed for your iPad',
+              text: dailyEditionCopy.onTheGoText,
             },
             {
               heading: 'Every supplement',


### PR DESCRIPTION
## Why are you doing this?
To make it clear that the Daily Edition is the UK newspaper so that customers in regions other than the UK understand that they won't be getting localised content.

[**Trello Card**](https://trello.com/c/wafP19z3/2036-tiny-copy-update-for-international-digital-pack-product-pages)

