### PR TITLE
Fix the wrapping of the title on the Digital Pack US page

### DIFF
--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -262,7 +262,7 @@
       position: relative;
       border-top: 1px solid #fff;
       background: gu-colour(garnett-neutral-1);
-      color: #fff;    
+      color: #fff;
       .component-countdown__chip {
         padding-left: 10px;
         padding-right: 10px;
@@ -336,7 +336,7 @@
     }
 
     @include mq($from: leftCol) {
-      width: 580px;
+      width: 600px;
       font-size: 44px;
       line-height: 50px;
       margin-left: 12px;


### PR DESCRIPTION
## Why are you doing this?

I noticed we have a wrapping problem on the US digipack page, this fixes it:
## Before
![screen shot 2018-10-25 at 15 05 36](https://user-images.githubusercontent.com/181371/47506576-46c03480-d868-11e8-95e1-ffe87c2269b0.png)
## After
![screen shot 2018-10-25 at 15 13 46](https://user-images.githubusercontent.com/181371/47506747-a1599080-d868-11e8-952b-a242f9da88a4.png)

