### PR TITLE
Delete unreliable post-deployment test

### DIFF
--- a/test/selenium/OneOffContributionsSpec.scala
+++ b/test/selenium/OneOffContributionsSpec.scala
@@ -20,7 +20,7 @@ class OneOffContributionsSpec extends FeatureSpec with GivenWhenThen with Before
 
   feature("Sign up for a one-off contribution") {
 
-    scenario("One-off contribution sign-up with Stripe - GBP") {
+    scenario("One-off contribution sign-up with Stripe - AUD") {
 
       val stripePayment = 22.55
       val currency = "AUD"
@@ -60,48 +60,6 @@ class OneOffContributionsSpec extends FeatureSpec with GivenWhenThen with Before
       assert(oneOffContributionThankYou.pageHasLoaded)
     }
 
-    scenario("One-off contribution sign-up with PayPal - USD") {
-
-      val testUser = new TestUser(driverConfig)
-      val landingPage = ContributionsLanding("us")
-      val payPalCheckout = new PayPalCheckout
-      val oneOffContributionThankYou = new OneOffContributionThankYou
-      val expectedPayment = "50.00"
-
-      Given("that a test user goes to the contributions landing page")
-      goTo(landingPage)
-      assert(landingPage.pageHasLoaded)
-
-      When("he/she selects to make a one-time contribution")
-      landingPage.clickOneOff
-
-      And("he/she selects to contribute via PayPal")
-      landingPage.clickContributePayPalButton
-
-      Then("they should be redirected to PayPal Checkout")
-      assert(payPalCheckout.initialPageHasLoaded)
-      payPalCheckout.handleGuestRegistrationPage()
-      assert(payPalCheckout.loginContainerHasLoaded)
-
-      Given("that the user fills in their PayPal credentials correctly")
-      payPalCheckout.enterLoginDetails()
-
-      When("the user clicks 'Log In'")
-      payPalCheckout.logIn
-
-      Then("the payment summary appears")
-      assert(payPalCheckout.payPalSummaryHasLoaded)
-
-      Given("that the summary displays the correct details")
-      assert(payPalCheckout.payPalSummaryHasCorrectDetails(expectedPayment))
-
-      When("that the user agrees to payment")
-      payPalCheckout.acceptPayPalPaymentPage
-
-      Then("the thankyou page should display")
-      assert(oneOffContributionThankYou.pageHasLoaded)
-
-    }
   }
 
 }

--- a/test/selenium/util/PayPalCheckout.scala
+++ b/test/selenium/util/PayPalCheckout.scala
@@ -46,10 +46,6 @@ class PayPalCheckout(implicit val webDriver: WebDriver) extends Browser {
     elementIsClickable(emailInput)
   }
 
-  def switchToPayPalPage(): Unit = {
-    switchFrame(container)
-  }
-
   def acceptPayPalPaymentPage(): Unit = {
     pageDoesNotHaveElement(id("preloaderSpinner"))
     pageDoesNotHaveElement(id("spinner"))


### PR DESCRIPTION
## Why are you doing this?

This test is very unreliable and it wastes a lot of time. 

It fails so regularly that it undermines confidence in the post-deployment tests in general.

We already have fairly sensitive alerting for this functionality (https://github.com/guardian/payment-api/blob/master/src/main/resources/cloud-formation.yaml#L430-L447), so I don't think we introduce too much risk by deleting this test.

We may need to delete the recurring PayPal test too (for the same reasons), but apparently this test is the most flakey, so let's try getting rid of it first.

[**Trello Card**](https://trello.com/c/JXk7kxGp/2021-delete-paypal-one-off-acceptance-test)

## Changes

* Delete unreliable test
* Delete unused PayPal method
* Fix name of remaining one-off scenario
