### PR TITLE
Remove circles svg from mobile on thank you page

### DIFF
--- a/assets/pages/new-contributions-landing/components/ContributionBackground.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionBackground.jsx
@@ -4,7 +4,6 @@
 
 import React from 'react';
 
-import SvgContributionsBgMobile from 'components/svgs/contributionsBgMobile';
 import SvgContributionsBgDesktop from 'components/svgs/contributionsBgDesktop';
 
 // ----- Render ----- //
@@ -12,7 +11,6 @@ import SvgContributionsBgDesktop from 'components/svgs/contributionsBgDesktop';
 function NewContributionBackground() {
   return (
     <div className="gu-content__bg">
-      <SvgContributionsBgMobile />
       <SvgContributionsBgDesktop />
     </div>
   );


### PR DESCRIPTION
## Why are you doing this?
There was a visual bug whereby the circles were getting in the way of the copy in the header on mobile. To keep things simple (and for expediency), we are going to remove the circles from the header for now.

Before:
![image](https://user-images.githubusercontent.com/2844554/47509289-b8e74800-d86d-11e8-88f4-7536e0921c9b.png)

After:
![image](https://user-images.githubusercontent.com/2844554/47509309-c43a7380-d86d-11e8-9e09-6d7cc20ae5c4.png)


This affects all the pages of the thank you flow (set password and thank you)