### PR TITLE
Add back padding on mobile hero for DP sale

### DIFF
--- a/assets/components/featuredDigitalPack/flashSaleDigitalPack.scss
+++ b/assets/components/featuredDigitalPack/flashSaleDigitalPack.scss
@@ -32,10 +32,6 @@
     border-left: 1px solid gu-colour(garnett-neutral-4);
     padding-left: 5px;
     padding-bottom: 70px;
-
-    @include mq($from: tablet) {
-      padding-bottom: 20px;
-    }
   }
 
   .component-flash-sale-featured-digital-pack__countdownbox .component-flash-sale-countdown {

--- a/assets/components/featuredDigitalPack/flashSaleDigitalPack.scss
+++ b/assets/components/featuredDigitalPack/flashSaleDigitalPack.scss
@@ -31,7 +31,11 @@
   .component-flash-sale-featured-digital-pack__countdownbox {
     border-left: 1px solid gu-colour(garnett-neutral-4);
     padding-left: 5px;
-    padding-bottom: 70px;
+    padding-bottom: 120px;
+
+    @include mq($from: tablet) {
+      padding-bottom: 70px;
+    }
   }
 
   .component-flash-sale-featured-digital-pack__countdownbox .component-flash-sale-countdown {

--- a/assets/components/featuredDigitalPack/flashSaleDigitalPack.scss
+++ b/assets/components/featuredDigitalPack/flashSaleDigitalPack.scss
@@ -31,6 +31,7 @@
   .component-flash-sale-featured-digital-pack__countdownbox {
     border-left: 1px solid gu-colour(garnett-neutral-4);
     padding-left: 5px;
+    padding-bottom: 70px;
 
     @include mq($from: tablet) {
       padding-bottom: 20px;


### PR DESCRIPTION
## Why are you doing this?
it looks wrong right now in prod

This is the fixed one:
<img width="512" alt="screenshot 2018-10-25 at 3 56 17 pm" src="https://user-images.githubusercontent.com/11539094/47509796-bdf8c700-d86e-11e8-90a1-e0c4f014b763.png">
