### PR TITLE
Add compliant DD copy to thank you page

### DIFF
--- a/assets/pages/new-contributions-landing/components/ContributionThankYou.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionThankYou.jsx
@@ -56,7 +56,7 @@ function ContributionThankYou(props: PropTypes) {
       {props.contributionType !== 'ONE_OFF' ? (
         <section className="confirmation">
           <p className="confirmation__message">
-            {`Look out for an email confirming your ${getSpokenType(props.contributionType)} recurring payment. ${directDebitMessageSuffix}`}
+            {`Look out for an email within three business days confirming your ${getSpokenType(props.contributionType)} recurring payment. ${directDebitMessageSuffix}`}
           </p>
         </section>
       ) : null}

--- a/assets/pages/new-contributions-landing/contributionsLandingReducer.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingReducer.js
@@ -64,7 +64,7 @@ type FormState = {
   paymentError: CheckoutFailureReason | null,
   guestAccountCreationToken: ?string,
   thankYouPageStage: ThankYouPageStage,
-  hasSeenDirectDebitThankYouPageCopy: boolean,
+  hasSeenDirectDebitThankYouCopy: boolean,
   payPalHasLoaded: boolean,
 };
 
@@ -140,7 +140,7 @@ function createFormReducer(countryGroupId: CountryGroupId) {
     guestAccountCreationToken: null,
     thankYouPageStage: 'thankYou',
     payPalHasLoaded: false,
-    hasSeenDirectDebitThankYouPageCopy: false,
+    hasSeenDirectDebitThankYouCopy: false,
   };
 
   return function formReducer(state: FormState = initialState, action: Action): FormState {
@@ -237,7 +237,7 @@ function createFormReducer(countryGroupId: CountryGroupId) {
         return { ...state, formData: { ...state.formData, checkoutFormHasBeenSubmitted: true } };
 
       case 'SET_HAS_SEEN_DIRECT_DEBIT_THANK_YOU_COPY':
-        return { ...state, hasSeenDirectDebitThankYouPageCopy: true };
+        return { ...state, hasSeenDirectDebitThankYouCopy: true };
 
       case 'SET_GUEST_ACCOUNT_CREATION_TOKEN':
         return { ...state, guestAccountCreationToken: action.guestAccountCreationToken };


### PR DESCRIPTION
## Why are you doing this?
What it says on the tin, plus I renamed `hasSeenDirectDebitThankYouPageCopy` to `hasSeenDirectDebitThankYouPageCopy` to keep it consistent with what we call the prop in the thank you page component
