### PR TITLE
Rejig the circle-less header on mobile

### DIFF
--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -239,6 +239,11 @@ header[role="banner"] {
     width: 100%;
   }
 
+  .thank-you__container .header {
+    background-color: gu-colour(news-garnett-highlight);
+  }
+
+
   .glogo {
     top: 10px;
     right: 10px;

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -235,10 +235,8 @@ header[role="banner"] {
 @include mq($from: mobile, $until: tablet) {
   .header {
     border: 0;
-    position: absolute;
-    top: 0;
     left: 10px;
-    width: 290px;
+    width: 100%;
   }
 
   .glogo {
@@ -252,8 +250,7 @@ header[role="banner"] {
   }
 
   .gu-content__bg {
-    height: 280px;
-    position: relative;
+    display: none;
   }
 
   .gu-content__bg .svg-contributions-bg-desktop {


### PR DESCRIPTION
## Why are you doing this?
This PR hides the header background `div` on mobile, meaning that the body is brought up to the text.

This also makes the header block yellow on mobile, for landing and thank you pages. 

@ionamckendrick what do you think?

|Landing page Before| Landing page after |
|------|------------|
|![image](https://user-images.githubusercontent.com/2844554/47516354-29e22c00-d87d-11e8-982b-ceb6122f7c66.png)|![image](https://user-images.githubusercontent.com/2844554/47665189-79d03400-db98-11e8-96e1-9baf50e406ae.png)|



|Thank you page before| Thank you page after |
|------|----------|
|![image](https://user-images.githubusercontent.com/2844554/47516647-e5a35b80-d87d-11e8-893d-9dde27e9c455.png))|![image](https://user-images.githubusercontent.com/2844554/47517157-38c9de00-d87f-11e8-9638-b2e787eef55c.png)|

