### PR TITLE
Treat sort code as numeric in browser form

### DIFF
--- a/assets/components/directDebit/directDebitForm/sortCodeInput.jsx
+++ b/assets/components/directDebit/directDebitForm/sortCodeInput.jsx
@@ -58,7 +58,9 @@ function SortCodeField(props: {
       id="sort-code-field"
       value={props.value}
       onChange={props.onChange}
-      type="text"
+      type="tel"
+      pattern="[0-9][0-9]"
+      minLength={2}
       maxLength={2}
       className="component-direct-debit-form__sort-code-field focus-target"
     />


### PR DESCRIPTION
So that you get the keyboard with just numbers on your phone! Will quadruple our mobile conversion rate, obvs...

| Before  | After |
| ------------- | ------------- |
| ![img_9c9c52d74002-1](https://user-images.githubusercontent.com/5122968/47534704-4d729a00-d8b0-11e8-8508-24699cb6ccfa.jpeg)  | ![img_0035](https://user-images.githubusercontent.com/5122968/47518192-2a30f600-d882-11e8-86b6-cec8f2e31cbd.PNG)  |



