### PR TITLE
Make the countdown test a redirect test

### DIFF
--- a/assets/components/featuredDigitalPack/flashSaleDigitalPack.jsx
+++ b/assets/components/featuredDigitalPack/flashSaleDigitalPack.jsx
@@ -10,7 +10,7 @@ import GridPicture from 'components/gridPicture/gridPicture';
 import FlashSaleCountdown from 'components/flashSaleCountdown/flashSaleCountdown';
 import { currencies, detect } from 'helpers/internationalisation/currency';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import { getDiscountedPrice } from 'helpers/flashSale';
+import { getDiscountedPrice, getCountdownAbTestParticipation } from 'helpers/flashSale';
 import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
 import type { ComponentAbTest } from 'helpers/subscriptions';
 import type { HeadingSize } from 'components/heading/heading';
@@ -27,6 +27,7 @@ type PropTypes = {
 
 function FlashSaleDigitalPack(props: PropTypes) {
   const currency = currencies[detect(props.countryGroupId)].glyph;
+  const timerClassName = getCountdownAbTestParticipation() ? "component-flash-sale-featured-digital-pack__countdownbox" : "component-flash-sale-featured-digital-pack__countdownbox component-flash-sale-featured-digital-pack__countdownbox--hidden";
   return (
     <section className="component-flash-sale-featured-digital-pack">
       <div className="component-flash-sale-featured-digital-pack__content">
@@ -43,7 +44,7 @@ function FlashSaleDigitalPack(props: PropTypes) {
           >
             Save 50% for three months
           </Heading>
-          <div className="component-flash-sale-featured-digital-pack__countdownbox component-flash-sale-featured-digital-pack__countdownbox--hidden">
+          <div className={timerClassName}>
             <FlashSaleCountdown />
             <p className="component-flash-sale-featured-digital-pack__copy">
               Read the Guardian ad-free on all devices, including the Premium App and Daily Edition iPad app.

--- a/assets/components/featuredDigitalPack/flashSaleDigitalPack.jsx
+++ b/assets/components/featuredDigitalPack/flashSaleDigitalPack.jsx
@@ -27,7 +27,7 @@ type PropTypes = {
 
 function FlashSaleDigitalPack(props: PropTypes) {
   const currency = currencies[detect(props.countryGroupId)].glyph;
-  const timerClassName = getCountdownAbTestParticipation() ? "component-flash-sale-featured-digital-pack__countdownbox" : "component-flash-sale-featured-digital-pack__countdownbox component-flash-sale-featured-digital-pack__countdownbox--hidden";
+  const timerClassName = getCountdownAbTestParticipation() ? 'component-flash-sale-featured-digital-pack__countdownbox' : 'component-flash-sale-featured-digital-pack__countdownbox component-flash-sale-featured-digital-pack__countdownbox--hidden';
   return (
     <section className="component-flash-sale-featured-digital-pack">
       <div className="component-flash-sale-featured-digital-pack__content">

--- a/assets/helpers/flashSale.js
+++ b/assets/helpers/flashSale.js
@@ -67,6 +67,10 @@ const saleDetails: SaleDetails = {
   },
 };
 
+function getCountdownAbTestParticipation(): boolean {
+  return getQueryParameter('ab_timer') === 'variant';
+}
+
 function getDiscountedPrice(product: SubscriptionProduct, countryGroupId: CountryGroupId): string {
   if (flashSaleIsActive(product) && saleDetails[product].prices && saleDetails[product].prices[countryGroupId]) {
     return `${saleDetails[product].prices[countryGroupId]}/month`;
@@ -93,5 +97,6 @@ export {
   flashSaleIsActive,
   getPromoCode,
   getIntcmp,
+  getCountdownAbTestParticipation,
   getEndTime,
 };

--- a/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
+++ b/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
@@ -17,7 +17,7 @@ import { CirclesLeft, CirclesRight } from 'components/svgs/digitalSubscriptionLa
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { displayPrice } from 'helpers/subscriptions';
 import { currencies, detect } from 'helpers/internationalisation/currency';
-import { flashSaleIsActive, getDiscountedPrice } from 'helpers/flashSale';
+import { flashSaleIsActive, getDiscountedPrice, getCountdownAbTestParticipation } from 'helpers/flashSale';
 import CtaSwitch from './ctaSwitch';
 import { showUpgradeMessage } from '../helpers/upgradePromotion';
 
@@ -178,8 +178,8 @@ export default function DigitalSubscriptionLandingHeader(props: PropTypes) {
             </p>
           </div>
         </div>
-        {flashSaleIsActive('DigitalPack') &&
-          <div className="digital-subscription-landing-header__countdown digital-subscription-landing-header__countdown--hidden">
+        {flashSaleIsActive('DigitalPack') && getCountdownAbTestParticipation() &&
+          <div className="digital-subscription-landing-header__countdown">
             <FlashSaleCountdown />
           </div>
         }

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -271,10 +271,6 @@
     }
   }
 
-  .digital-subscription-landing-header__countdown--hidden {
-    display: none;
-  }
-
   .digital-subscription-landing-header__wrapper {
     position: relative;
   }


### PR DESCRIPTION
## Why are you doing this?

So we can ab test the countdown timer on pages.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/CqQGZXfR/2029-setup-a-b-test-for-countdown-timer-vs-no-countdown-timer)

## Changes
* add a `?ab_timer=variant` parameter to both pages

## Screenshots
![screenshot 2018-10-26 at 10 47 38 am](https://user-images.githubusercontent.com/11539094/47559109-95270f00-d90c-11e8-9601-d28d7d643a74.png)
![screenshot 2018-10-26 at 10 47 46 am](https://user-images.githubusercontent.com/11539094/47559111-96f0d280-d90c-11e8-8737-b2faaac52da5.png)

