### PR TITLE
Set default annual value in new payment flow

### DIFF
--- a/assets/helpers/abTests/abtest.js
+++ b/assets/helpers/abTests/abtest.js
@@ -10,6 +10,7 @@ import * as ophan from 'ophan';
 import * as cookie from 'helpers/cookie';
 import * as storage from 'helpers/storage';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import type { AnnualContributionsTestVariant } from 'helpers/abTests/abtestDefinitions';
 import {
   oldContributionsFlowTests,
   newContributionsFlowTests,
@@ -52,6 +53,7 @@ type BreakpointRange = {|
 
 export type Participations = {
   [TestId]: string,
+  annualContributionsRoundThree: AnnualContributionsTestVariant
 }
 
 type OphanABPayload = {

--- a/assets/helpers/abTests/abtest.js
+++ b/assets/helpers/abTests/abtest.js
@@ -10,7 +10,6 @@ import * as ophan from 'ophan';
 import * as cookie from 'helpers/cookie';
 import * as storage from 'helpers/storage';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import type { AnnualContributionsTestVariant } from 'helpers/abTests/abtestDefinitions';
 import {
   oldContributionsFlowTests,
   newContributionsFlowTests,
@@ -53,7 +52,6 @@ type BreakpointRange = {|
 
 export type Participations = {
   [TestId]: string,
-  annualContributionsRoundThree: AnnualContributionsTestVariant
 }
 
 type OphanABPayload = {

--- a/assets/helpers/abTests/helpers/annualContributions.js
+++ b/assets/helpers/abTests/helpers/annualContributions.js
@@ -2,7 +2,6 @@
 
 import { type Store } from 'redux';
 import { contributionSelectionActionsFor } from 'components/contributionSelection/contributionSelectionActions';
-import type { AnnualContributionsTestVariant } from '../abtestDefinitions';
 
 /* eslint-disable quote-props */
 const numbersInWords = {
@@ -99,7 +98,7 @@ const VariantA = {
   ],
 };
 
-export const getAnnualAmounts = (annualTestVariant: AnnualContributionsTestVariant) => {
+export const getAnnualAmounts = (annualTestVariant: string) => {
   if (annualTestVariant === 'annualAmountsA') {
     return {
       GBPCountries: VariantA.standard,

--- a/assets/helpers/contributions.js
+++ b/assets/helpers/contributions.js
@@ -220,7 +220,7 @@ const defaultMonthlyAmount = [
   { value: '30', spoken: numbersInWords['30'], isDefault: false },
 ];
 
-const amounts = (annualTestVariant: AnnualContributionsTestVariant) => ({
+const amounts = (annualTestVariant: string) => ({
   ONE_OFF: {
     GBPCountries: defaultOneOffAmount,
     UnitedStates: defaultOneOffAmount,

--- a/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -6,6 +6,8 @@ import { type PaymentAuthorisation } from 'helpers/paymentIntegrations/newPaymen
 import { loadPayPalRecurring } from 'helpers/paymentIntegrations/newPaymentFlow/payPalRecurringCheckout';
 import { setupStripeCheckout, loadStripe } from 'helpers/paymentIntegrations/newPaymentFlow/stripeCheckout';
 import { type ThirdPartyPaymentLibrary, getPaymentMethodToSelect, getValidPaymentMethods } from 'helpers/checkouts';
+import { amounts, type Amount, type Contrib } from 'helpers/contributions';
+import type { AnnualContributionsTestVariant } from 'helpers/abTests/abtestDefinitions';
 import {
   type Action,
   paymentWaiting,
@@ -14,6 +16,7 @@ import {
   updatePaymentMethod,
   updateUserFormData,
   setPayPalHasLoaded,
+  selectAmount,
 } from './contributionsLandingActions';
 import { type State } from './contributionsLandingReducer';
 
@@ -57,12 +60,22 @@ function initialisePaymentMethods(state: State, dispatch: Function) {
   loadPayPalRecurring().then(() => dispatch(setPayPalHasLoaded()));
 }
 
+function initialiseSelectedAnnualAmount(state: State, dispatch: Function) {
+  const { countryGroupId } = state.common.internationalisation;
+  const annualTestVariant: AnnualContributionsTestVariant = state.common.abParticipations.annualContributionsRoundThree;
+
+  const annualAmounts: Amount[] = amounts(annualTestVariant).ANNUAL[countryGroupId];
+
+  dispatch(selectAmount(annualAmounts.find(amount => amount.isDefault) || annualAmounts[0], 'ANNUAL'));
+}
+
 const init = (store: Store<State, Action, Dispatch<Action>>) => {
   const { dispatch } = store;
 
   const state = store.getState();
   selectDefaultPaymentMethod(state, dispatch);
   initialisePaymentMethods(state, dispatch);
+  initialiseSelectedAnnualAmount(state, dispatch);
 
   const { firstName, lastName, email } = state.page.user;
   dispatch(updateUserFormData({ firstName, lastName, email }));

--- a/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -6,8 +6,7 @@ import { type PaymentAuthorisation } from 'helpers/paymentIntegrations/newPaymen
 import { loadPayPalRecurring } from 'helpers/paymentIntegrations/newPaymentFlow/payPalRecurringCheckout';
 import { setupStripeCheckout, loadStripe } from 'helpers/paymentIntegrations/newPaymentFlow/stripeCheckout';
 import { type ThirdPartyPaymentLibrary, getPaymentMethodToSelect, getValidPaymentMethods } from 'helpers/checkouts';
-import { amounts, type Amount, type Contrib } from 'helpers/contributions';
-import type { AnnualContributionsTestVariant } from 'helpers/abTests/abtestDefinitions';
+import { amounts, type Amount } from 'helpers/contributions';
 import {
   type Action,
   paymentWaiting,
@@ -62,7 +61,7 @@ function initialisePaymentMethods(state: State, dispatch: Function) {
 
 function initialiseSelectedAnnualAmount(state: State, dispatch: Function) {
   const { countryGroupId } = state.common.internationalisation;
-  const annualTestVariant: AnnualContributionsTestVariant = state.common.abParticipations.annualContributionsRoundThree;
+  const annualTestVariant = state.common.abParticipations.annualContributionsRoundThree;
 
   const annualAmounts: Amount[] = amounts(annualTestVariant).ANNUAL[countryGroupId];
 

--- a/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -63,9 +63,11 @@ function initialiseSelectedAnnualAmount(state: State, dispatch: Function) {
   const { countryGroupId } = state.common.internationalisation;
   const annualTestVariant = state.common.abParticipations.annualContributionsRoundThree;
 
-  const annualAmounts: Amount[] = amounts(annualTestVariant).ANNUAL[countryGroupId];
+  if (annualTestVariant) {
+    const annualAmounts: Amount[] = amounts(annualTestVariant).ANNUAL[countryGroupId];
 
-  dispatch(selectAmount(annualAmounts.find(amount => amount.isDefault) || annualAmounts[0], 'ANNUAL'));
+    dispatch(selectAmount(annualAmounts.find(amount => amount.isDefault) || annualAmounts[0], 'ANNUAL'));
+  }
 }
 
 const init = (store: Store<State, Action, Dispatch<Action>>) => {


### PR DESCRIPTION
## Why are you doing this?
Currently the default annual amount is initialised with the control values.
This change updates the selected annual amount once the variant name is known

## Screenshots
control:
![picture 1](https://user-images.githubusercontent.com/1513454/47568983-615ae200-d92a-11e8-94b9-a8f7d3127baf.png)
variant:
![picture 2](https://user-images.githubusercontent.com/1513454/47568984-615ae200-d92a-11e8-970a-b5255025df85.png)

