### PR TITLE
Set paymentMethod and contributionType in session storage & use to determine correct Thank You message

### DIFF
--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -64,11 +64,22 @@ export type Action =
   | { type: 'PAYMENT_SUCCESS' };
 
 
-const updateContributionType = (contributionType: Contrib, paymentMethodToSelect: PaymentMethod): Action =>
-  ({ type: 'UPDATE_CONTRIBUTION_TYPE', contributionType, paymentMethodToSelect });
+const updateContributionType = (contributionType: Contrib, paymentMethodToSelect: PaymentMethod): Action => {
+  // PayPal one-off redirects away from the site before hitting the thank you page
+  // so we need to store the contrib type & payment method in the storage so that it is available on the
+  // thank you page in all scenarios.
+  storage.setSession('contributionType', contributionType);
+  storage.setSession('paymentMethod', paymentMethodToSelect);
+  return ({ type: 'UPDATE_CONTRIBUTION_TYPE', contributionType, paymentMethodToSelect });
+};
 
-const updatePaymentMethod = (paymentMethod: PaymentMethod): Action =>
-  ({ type: 'UPDATE_PAYMENT_METHOD', paymentMethod });
+const updatePaymentMethod = (paymentMethod: PaymentMethod): Action => {
+  // PayPal one-off redirects away from the site before hitting the thank you page
+  // so we need to store the payment method in the storage so that it is available on the
+  // thank you page in all scenarios.
+  storage.setSession('paymentMethod', paymentMethod);
+  return ({type: 'UPDATE_PAYMENT_METHOD', paymentMethod});
+};
 
 const updateFirstName = (firstName: string): Action => ({ type: 'UPDATE_FIRST_NAME', firstName });
 

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -78,7 +78,7 @@ const updatePaymentMethod = (paymentMethod: PaymentMethod): Action => {
   // so we need to store the payment method in the storage so that it is available on the
   // thank you page in all scenarios.
   storage.setSession('paymentMethod', paymentMethod);
-  return ({type: 'UPDATE_PAYMENT_METHOD', paymentMethod});
+  return ({ type: 'UPDATE_PAYMENT_METHOD', paymentMethod });
 };
 
 const updateFirstName = (firstName: string): Action => ({ type: 'UPDATE_FIRST_NAME', firstName });

--- a/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -5,7 +5,7 @@ import { type Store, type Dispatch } from 'redux';
 import { type PaymentAuthorisation } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
 import { loadPayPalRecurring } from 'helpers/paymentIntegrations/newPaymentFlow/payPalRecurringCheckout';
 import { setupStripeCheckout, loadStripe } from 'helpers/paymentIntegrations/newPaymentFlow/stripeCheckout';
-import { type ThirdPartyPaymentLibrary, getPaymentMethodToSelect, getValidPaymentMethods } from 'helpers/checkouts';
+import { type ThirdPartyPaymentLibrary, getValidPaymentMethods, getPaymentMethodFromSession, } from 'helpers/checkouts';
 import { amounts, type Amount } from 'helpers/contributions';
 import {
   type Action,
@@ -26,7 +26,13 @@ function selectDefaultPaymentMethod(state: State, dispatch: Dispatch<Action>) {
   const { countryId } = state.common.internationalisation;
   const { switches } = state.common.settings;
 
-  const paymentMethodToSelect = getPaymentMethodToSelect(contributionType, switches, countryId);
+  const paymentMethodFromSession = getPaymentMethodFromSession();
+  const validPaymentMethods = getValidPaymentMethods(contributionType, switches, countryId);
+
+  const paymentMethodToSelect =
+    paymentMethodFromSession && validPaymentMethods.includes(getPaymentMethodFromSession())
+      ? paymentMethodFromSession
+      : validPaymentMethods[0] || 'None';
 
   dispatch(updatePaymentMethod(paymentMethodToSelect));
 }

--- a/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -5,7 +5,7 @@ import { type Store, type Dispatch } from 'redux';
 import { type PaymentAuthorisation } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
 import { loadPayPalRecurring } from 'helpers/paymentIntegrations/newPaymentFlow/payPalRecurringCheckout';
 import { setupStripeCheckout, loadStripe } from 'helpers/paymentIntegrations/newPaymentFlow/stripeCheckout';
-import { type ThirdPartyPaymentLibrary, getValidPaymentMethods, getPaymentMethodFromSession, } from 'helpers/checkouts';
+import { type ThirdPartyPaymentLibrary, getValidPaymentMethods, getPaymentMethodFromSession } from 'helpers/checkouts';
 import { amounts, type Amount } from 'helpers/contributions';
 import {
   type Action,

--- a/assets/pages/new-contributions-landing/contributionsLandingReducer.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingReducer.js
@@ -4,7 +4,7 @@
 
 import type { CheckoutFailureReason } from 'helpers/checkoutErrors';
 import { combineReducers } from 'redux';
-import { amounts, type Amount, type Contrib, type PaymentMethod, type ThirdPartyPaymentLibraries } from 'helpers/contributions';
+import { amounts, parseContrib, type Amount, type Contrib, type PaymentMethod, type ThirdPartyPaymentLibraries } from 'helpers/contributions';
 import csrf from 'helpers/csrf/csrfReducer';
 import sessionId from 'helpers/sessionId/reducer';
 import { type CommonState } from 'helpers/page/page';
@@ -100,7 +100,7 @@ function createFormReducer(countryGroupId: CountryGroupId) {
   // ----- Initial state ----- //
 
   const initialState: FormState = {
-    contributionType: 'MONTHLY',
+    contributionType: parseContrib(storage.getSession('contributionType'), 'MONTHLY'),
     paymentMethod: 'None',
     thirdPartyPaymentLibraries: {
       ONE_OFF: {


### PR DESCRIPTION
## Why are you doing this?

So the user sees the correct thank you message when using PayPal (and if they refresh the thank you page). 


<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/K3kS9w2E/125-npf-bug-after-paypal-one-off-conversion-the-thank-you-page-says-thank-you-for-your-direct-debit)

## Changes

PayPal flow redirects away from the site. When it routes to the thank you page the contribution type and payment method are incorrect as they default to Direct Debit and monthly. This is also true if you refresh the page.

* sets `paymentMethod` and `contributionType` in session storage on update action. 
* sets initial `contributionType` value (in reducer) from session if available. 
* sets initial `paymentMethod` value (in landing init) from session if available and a valid payment method. 

## Screenshots

Example of PayPal one-off contribution:

before 😞

![screen shot 2018-10-29 at 15 34 06](https://user-images.githubusercontent.com/8484757/47661039-2ce85f80-db90-11e8-81bc-21bbfb71c29b.jpg)


now 🚀

![screen shot 2018-10-29 at 15 38 22](https://user-images.githubusercontent.com/8484757/47661314-b5670000-db90-11e8-8798-11ec28b9a5f4.jpg)



