### PR TITLE
open jdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 scala:
 - 2.11.8
 jdk:
-- oraclejdk8
+- openjdk8
 sudo: false
 cache:
   directories:


### PR DESCRIPTION
## Why are you doing this?
Re. engineering chat: 

> You should use OpenJDK and *not* Oracle JDK.

> On continuous integration. For travis you need to specify openjdk8 instead of oraclejdk8. Example PR: https://github.com/guardian/play-googleauth/pull/66/files


