### PR TITLE
Check email is valid before calling identity API, and don't submit form unless email doesn't have a password

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -161,10 +161,4 @@ class Application(
       Redirect("/" + path, request.queryString, MOVED_PERMANENTLY)
   }
 
-  def dummy(email: String): Action[AnyContent] = NoCacheAction() { implicit request =>
-    if (email == "has@password.com")
-      Ok(Map("userType" -> "current").asJson)
-    else
-      Ok(Map("userType" -> "new").asJson)
-  }
 }

--- a/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -39,8 +39,7 @@ import { NewContributionAmount } from './ContributionAmount';
 import { NewPaymentMethodSelector } from './PaymentMethodSelector';
 import { NewContributionSubmit } from './ContributionSubmit';
 
-
-import { type State } from '../contributionsLandingReducer';
+import { type State, type IdentityResponse } from '../contributionsLandingReducer';
 
 import {
   paymentWaiting,
@@ -71,6 +70,7 @@ type PropTypes = {|
   onPaymentAuthorisation: PaymentAuthorisation => void,
   isSignInRequired: boolean,
   isIdentityRequestPending: boolean,
+  lastIdentityResponse: IdentityResponse,
 |};
 
 // We only want to use the user state value if the form state value has not been changed since it was initialised,
@@ -93,6 +93,8 @@ const mapStateToProps = (state: State) => ({
   selectedAmounts: state.page.form.selectedAmounts,
   isSignInRequired: state.page.form.isSignInRequired,
   isIdentityRequestPending: state.page.form.isIdentityRequestPending,
+  lastIdentityResponse: state.page.form.lastIdentityResponse,
+
 });
 
 
@@ -162,13 +164,16 @@ const formHandlers: PaymentMatrix<PropTypes => void> = {
 
 
 function onSubmit(props: PropTypes): Event => void {
+
+  const userMayNeedToSignIn = props.isSignInRequired || props.isIdentityRequestPending || props.lastIdentityResponse !== 'success';
+
   return (event) => {
     // Causes errors to be displayed against payment fields
     props.setCheckoutFormHasBeenSubmitted();
     event.preventDefault();
     if (
       !(event.target: any).checkValidity() ||
-      (props.contributionType !== 'ONE_OFF' && (props.isSignInRequired || props.isIdentityRequestPending))
+      (props.contributionType !== 'ONE_OFF' && userMayNeedToSignIn)
     ) {
       return;
     }

--- a/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -69,6 +69,8 @@ type PropTypes = {|
   setCheckoutFormHasBeenSubmitted: () => void,
   createOneOffPayPalPayment: (data: CreatePaypalPaymentData) => void,
   onPaymentAuthorisation: PaymentAuthorisation => void,
+  isSignInRequired: boolean,
+  isIdentityRequestPending: boolean,
 |};
 
 // We only want to use the user state value if the form state value has not been changed since it was initialised,
@@ -89,6 +91,8 @@ const mapStateToProps = (state: State) => ({
   currency: state.common.internationalisation.currencyId,
   paymentError: state.page.form.paymentError,
   selectedAmounts: state.page.form.selectedAmounts,
+  isSignInRequired: state.page.form.isSignInRequired,
+  isIdentityRequestPending: state.page.form.isIdentityRequestPending,
 });
 
 
@@ -162,7 +166,7 @@ function onSubmit(props: PropTypes): Event => void {
     // Causes errors to be displayed against payment fields
     props.setCheckoutFormHasBeenSubmitted();
     event.preventDefault();
-    if (!(event.target: any).checkValidity()) {
+    if (!(event.target: any).checkValidity() || props.isSignInRequired || props.isIdentityRequestPending) {
       return;
     }
     formHandlers[props.contributionType][props.paymentMethod](props);

--- a/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -166,7 +166,10 @@ function onSubmit(props: PropTypes): Event => void {
     // Causes errors to be displayed against payment fields
     props.setCheckoutFormHasBeenSubmitted();
     event.preventDefault();
-    if (!(event.target: any).checkValidity() || props.isSignInRequired || props.isIdentityRequestPending) {
+    if (
+      !(event.target: any).checkValidity() ||
+      (props.contributionType !== 'ONE_OFF' && (props.isSignInRequired || props.isIdentityRequestPending))
+    ) {
       return;
     }
     formHandlers[props.contributionType][props.paymentMethod](props);

--- a/assets/pages/new-contributions-landing/components/ContributionFormFields.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionFormFields.jsx
@@ -4,6 +4,7 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
+import { type Contrib } from 'helpers/contributions';
 import { type UsState, type CaState } from 'helpers/internationalisation/country';
 import SvgEnvelope from 'components/svgs/envelope';
 import SvgUser from 'components/svgs/user';
@@ -48,6 +49,7 @@ type PropTypes = {|
   updateEmail: Event => void,
   updateState: Event => void,
   checkIfEmailHasPassword: Event => void,
+  contributionType: Contrib,
 |};
 
 // We only want to use the user state value if the form state value has not been changed since it was initialised,
@@ -67,6 +69,7 @@ const mapStateToProps = (state: State) => ({
   isSignInRequired: state.page.form.isSignInRequired,
   isIdentityRequestPending: state.page.form.isIdentityRequestPending,
   lastIdentityResponse: state.page.form.lastIdentityResponse,
+  contributionType: state.page.form.contributionType,
 });
 
 
@@ -115,6 +118,7 @@ function FormFields(props: PropTypes) {
         isSignInRequired={props.isSignInRequired}
         isIdentityRequestPending={props.isIdentityRequestPending}
         lastIdentityResponse={props.lastIdentityResponse}
+        contributionType={props.contributionType}
       />
       <NewContributionTextInput
         id="contributionFirstName"

--- a/assets/pages/new-contributions-landing/components/ContributionFormFields.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionFormFields.jsx
@@ -119,6 +119,7 @@ function FormFields(props: PropTypes) {
         isIdentityRequestPending={props.isIdentityRequestPending}
         lastIdentityResponse={props.lastIdentityResponse}
         contributionType={props.contributionType}
+        checkoutFormHasBeenSubmitted={props.checkoutFormHasBeenSubmitted}
       />
       <NewContributionTextInput
         id="contributionFirstName"

--- a/assets/pages/new-contributions-landing/components/MustSignIn.jsx
+++ b/assets/pages/new-contributions-landing/components/MustSignIn.jsx
@@ -15,7 +15,8 @@ type PropTypes = {|
   isSignInRequired: boolean,
   isIdentityRequestPending: boolean,
   lastIdentityResponse: IdentityResponse,
-  contributionType: Contrib
+  contributionType: Contrib,
+  checkoutFormHasBeenSubmitted: boolean,
 |};
 
 
@@ -34,7 +35,7 @@ function buildUrl(returnUrl: ?string): string {
 
 export const MustSignIn = (props: PropTypes) => {
 
-  if (props.contributionType === 'ONE_OFF') {
+  if (props.contributionType === 'ONE_OFF' || !props.checkoutFormHasBeenSubmitted) {
     return null;
   }
 

--- a/assets/pages/new-contributions-landing/components/MustSignIn.jsx
+++ b/assets/pages/new-contributions-landing/components/MustSignIn.jsx
@@ -3,6 +3,7 @@
 
 // ----- Imports ----- //
 
+import type { Contrib } from 'helpers/contributions';
 import React from 'react';
 import { getBaseDomain } from 'helpers/url';
 import type { IdentityResponse } from '../contributionsLandingReducer';
@@ -14,6 +15,7 @@ type PropTypes = {|
   isSignInRequired: boolean,
   isIdentityRequestPending: boolean,
   lastIdentityResponse: IdentityResponse,
+  contributionType: Contrib
 |};
 
 
@@ -31,6 +33,11 @@ function buildUrl(returnUrl: ?string): string {
 // ----- Component ----- //
 
 export const MustSignIn = (props: PropTypes) => {
+
+  if (props.contributionType === 'ONE_OFF') {
+    return null;
+  }
+
   if (props.isIdentityRequestPending) {
     return (
       <a className="component-signout" href={buildUrl(props.returnUrl)}>

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -2,6 +2,7 @@
 
 // ----- Imports ----- //
 
+import { checkEmail } from 'helpers/formValidation';
 import type { CheckoutFailureReason } from 'helpers/checkoutErrors';
 import { type ThirdPartyPaymentLibrary } from 'helpers/checkouts';
 import { type Amount, logInvalidCombination, type Contrib, type PaymentMethod, type PaymentMatrix } from 'helpers/contributions';
@@ -160,10 +161,13 @@ const setLastIdentityResponse = (lastIdentityResponse: IdentityResponse): Action
 
 const checkIfEmailHasPassword = (email: string) =>
   (dispatch: Dispatch<Action>, getState: () => State): void => {
+    if (!checkEmail(email)) {
+      return;
+    }
     const state = getState();
     dispatch(setIdentityRequestPending(true));
     fetchJson(
-      `/dummy/${encodeURIComponent(email)}`,
+      `${routes.getUserType}?maybeEmail=${encodeURIComponent(email)}`,
       getRequestOptions('same-origin', state.page.csrf),
     ).then(({ userType }) => {
       dispatch(setIdentityRequestPending(false));

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -5,7 +5,13 @@
 import { checkEmail } from 'helpers/formValidation';
 import type { CheckoutFailureReason } from 'helpers/checkoutErrors';
 import { type ThirdPartyPaymentLibrary } from 'helpers/checkouts';
-import { type Amount, logInvalidCombination, type Contrib, type PaymentMethod, type PaymentMatrix } from 'helpers/contributions';
+import {
+  type Amount,
+  logInvalidCombination,
+  type Contrib,
+  type PaymentMethod,
+  type PaymentMatrix
+} from 'helpers/contributions';
 import type { Csrf } from 'helpers/csrf/csrfReducer';
 import { type CaState, type UsState } from 'helpers/internationalisation/country';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
@@ -51,7 +57,7 @@ export type Action =
   | { type: 'UPDATE_PASSWORD', password: string }
   | { type: 'UPDATE_STATE', state: UsState | CaState | null }
   | { type: 'UPDATE_USER_FORM_DATA', userFormData: UserFormData }
-  | { type: 'UPDATE_PAYMENT_READY', thirdPartyPaymentLibraryByContrib: { [Contrib]: {[PaymentMethod]: ThirdPartyPaymentLibrary}} }
+  | { type: 'UPDATE_PAYMENT_READY', thirdPartyPaymentLibraryByContrib: { [Contrib]: { [PaymentMethod]: ThirdPartyPaymentLibrary } } }
   | { type: 'SELECT_AMOUNT', amount: Amount | 'other', contributionType: Contrib }
   | { type: 'UPDATE_OTHER_AMOUNT', otherAmount: string }
   | { type: 'PAYMENT_RESULT', paymentResult: Promise<PaymentResult> }
@@ -161,10 +167,10 @@ const setLastIdentityResponse = (lastIdentityResponse: IdentityResponse): Action
 
 const checkIfEmailHasPassword = (email: string) =>
   (dispatch: Dispatch<Action>, getState: () => State): void => {
+    const state = getState();
     if (!checkEmail(email)) {
       return;
     }
-    const state = getState();
     dispatch(setIdentityRequestPending(true));
     fetchJson(
       `${routes.getUserType}?maybeEmail=${encodeURIComponent(email)}`,
@@ -328,7 +334,7 @@ const setupRecurringPayPalPayment = (
 
     fetch(routes.payPalSetupPayment, payPalRequestData(requestBody, csrfToken || ''))
       .then(response => (response.ok ? response.json() : null))
-      .then((token: {token: string} | null) => {
+      .then((token: { token: string } | null) => {
         if (token) {
           resolve(token.token);
         } else {
@@ -377,16 +383,24 @@ const paymentAuthorisationHandlers: PaymentMatrix<(Dispatch<Action>, State, Paym
     Stripe: (dispatch: Dispatch<Action>, state: State, paymentAuthorisation: PaymentAuthorisation): void => {
       dispatch(executeStripeOneOffPayment(stripeChargeDataFromAuthorisation(paymentAuthorisation, state)));
     },
-    DirectDebit: () => { logInvalidCombination('ONE_OFF', 'DirectDebit'); },
-    None: () => { logInvalidCombination('ONE_OFF', 'None'); },
+    DirectDebit: () => {
+      logInvalidCombination('ONE_OFF', 'DirectDebit');
+    },
+    None: () => {
+      logInvalidCombination('ONE_OFF', 'None');
+    },
   },
   ANNUAL: {
     ...recurringPaymentAuthorisationHandlers,
-    None: () => { logInvalidCombination('ANNUAL', 'None'); },
+    None: () => {
+      logInvalidCombination('ANNUAL', 'None');
+    },
   },
   MONTHLY: {
     ...recurringPaymentAuthorisationHandlers,
-    None: () => { logInvalidCombination('MONTHLY', 'None'); },
+    None: () => {
+      logInvalidCombination('MONTHLY', 'None');
+    },
   },
 };
 

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -10,7 +10,7 @@ import {
   logInvalidCombination,
   type Contrib,
   type PaymentMethod,
-  type PaymentMatrix
+  type PaymentMatrix,
 } from 'helpers/contributions';
 import type { Csrf } from 'helpers/csrf/csrfReducer';
 import { type CaState, type UsState } from 'helpers/internationalisation/country';
@@ -166,7 +166,7 @@ const setLastIdentityResponse = (lastIdentityResponse: IdentityResponse): Action
 });
 
 const checkIfEmailHasPassword = (email: string) =>
-  (dispatch: Dispatch<Action>, getState: () => State): void => {
+  (dispatch: Function, getState: () => State): void => {
     const state = getState();
     if (!checkEmail(email)) {
       return;

--- a/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -86,7 +86,7 @@ const init = (store: Store<State, Action, Function>) => {
   initialiseSelectedAnnualAmount(state, dispatch);
 
   const { firstName, lastName, email } = state.page.user;
-  dispatch(checkIfEmailHasPassword(email))
+  dispatch(checkIfEmailHasPassword(email));
   dispatch(updateUserFormData({ firstName, lastName, email }));
 
 };

--- a/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -16,6 +16,7 @@ import {
   updateUserFormData,
   setPayPalHasLoaded,
   selectAmount,
+  checkIfEmailHasPassword
 } from './contributionsLandingActions';
 import { type State } from './contributionsLandingReducer';
 
@@ -85,6 +86,7 @@ const init = (store: Store<State, Action, Dispatch<Action>>) => {
   initialiseSelectedAnnualAmount(state, dispatch);
 
   const { firstName, lastName, email } = state.page.user;
+  dispatch(checkIfEmailHasPassword(email))
   dispatch(updateUserFormData({ firstName, lastName, email }));
 
 };

--- a/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -16,7 +16,7 @@ import {
   updateUserFormData,
   setPayPalHasLoaded,
   selectAmount,
-  checkIfEmailHasPassword
+  checkIfEmailHasPassword,
 } from './contributionsLandingActions';
 import { type State } from './contributionsLandingReducer';
 
@@ -77,7 +77,7 @@ function initialiseSelectedAnnualAmount(state: State, dispatch: Function) {
   }
 }
 
-const init = (store: Store<State, Action, Dispatch<Action>>) => {
+const init = (store: Store<State, Action, Function>) => {
   const { dispatch } = store;
 
   const state = store.getState();

--- a/conf/routes
+++ b/conf/routes
@@ -1,7 +1,5 @@
 # ----- System ----- #
 
-GET  /dummy/*email                                  controllers.Application.dummy(email)
-
 GET /healthcheck                                    controllers.Application.healthcheck
 
 # ----- Unsupported Browsers ----- #


### PR DESCRIPTION
- remove dummy endpoint
- use new identity endpoint 
- Check email is valid before calling identity API
- Don't submit form unless email doesn't have a password (all recurring payment types bar paypal) 
- Don't block one-off contributions 
- Call identity API on init 
- Don't show error message until form has been submitted