### PR TITLE
Fix email regex

### DIFF
--- a/assets/helpers/checkoutForm/__tests__/checkoutFormTest.js
+++ b/assets/helpers/checkoutForm/__tests__/checkoutFormTest.js
@@ -28,7 +28,7 @@ describe('checkoutForm', () => {
     });
 
     it('should return false if there is no dot in the domain', () => {
-      expect(patternIsValid('test@gu', emailRegexPattern)).toEqual(false);
+      expect(patternIsValid('test@guuuuuuuuuu', emailRegexPattern)).toEqual(false);
     });
 
     it('should return true for test@gu.co.uk', () => {

--- a/assets/helpers/checkoutForm/checkoutForm.js
+++ b/assets/helpers/checkoutForm/checkoutForm.js
@@ -8,7 +8,7 @@ import { type Contrib as ContributionType } from 'helpers/contributions';
 // src/main/scala/play/api/data/validation/Validation.scala#L80
 // but with minor modification (last * becomes +) to enforce at least one dot in domain.  This is
 // for compatibility with Stripe
-export const emailRegexPattern = '^[a-zA-Z0-9.!#$%&\'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$';
+export const emailRegexPattern = '^[a-zA-Z0-9\\.!#$%&\'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$';
 
 export function patternIsValid(value: string, pattern: string): boolean {
   const regex = new RegExp(pattern);

--- a/assets/helpers/checkoutForm/checkoutForm.js
+++ b/assets/helpers/checkoutForm/checkoutForm.js
@@ -4,8 +4,8 @@
 import { type Contrib as ContributionType } from 'helpers/contributions';
 
 // Copied from
-// https://github.com/playframework/playframework/blob/38abd1ca6d17237950c82b1483057c5c39929cb4/framework/src/play/
-// src/main/scala/play/api/data/validation/Validation.scala#L80
+// https://github.com/playframework/playframework/blob/master/framework/src/play/
+// src/main/scala/play/api/data/validation/Validation.scala#L81
 // but with minor modification (last * becomes +) to enforce at least one dot in domain.  This is
 // for compatibility with Stripe
 export const emailRegexPattern = '^[a-zA-Z0-9\\.!#$%&\'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$';

--- a/assets/helpers/formValidation.js
+++ b/assets/helpers/formValidation.js
@@ -5,7 +5,7 @@
 // src/main/scala/play/api/data/validation/Validation.scala#L80
 // but with minor modification (last * becomes +) to enforce at least one dot in domain.  This is
 // for compatibility with Stripe
-export const emailRegexPattern = '^[a-zA-Z0-9.!#$%&\'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$';
+export const emailRegexPattern = '^[a-zA-Z0-9\\.!#$%&\'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$';
 
 export const isNotEmpty: string => boolean = input => !!input && input.trim() !== '';
 export const isValidEmail: string => boolean = input => new RegExp(emailRegexPattern).test(input);

--- a/assets/helpers/formValidation.js
+++ b/assets/helpers/formValidation.js
@@ -1,8 +1,8 @@
 // @flow
 
 // Copied from
-// https://github.com/playframework/playframework/blob/38abd1ca6d17237950c82b1483057c5c39929cb4/framework/src/play/
-// src/main/scala/play/api/data/validation/Validation.scala#L80
+// https://github.com/playframework/playframework/blob/master/framework/src/play/
+// src/main/scala/play/api/data/validation/Validation.scala#L81
 // but with minor modification (last * becomes +) to enforce at least one dot in domain.  This is
 // for compatibility with Stripe
 export const emailRegexPattern = '^[a-zA-Z0-9\\.!#$%&\'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$';


### PR DESCRIPTION
## Why are you doing this?
Our email regex wasn't actually working. For example, the email `test@guuuuuuuuuu` was coming back as valid. We did have a test for `test@gu` but for the regex to fail there had to be 3 or more letters after the `@`.

I searched the play docs for the email regex that we supposedly were copying from (the link was broken) and found it and re-copied and pasted it in, and wrote a test that was failing before but now works 