### PR TITLE
Revert "Merge pull request #1053 from guardian/conversion-tracking-fo…

### DIFF
--- a/assets/helpers/abTests/abtest.js
+++ b/assets/helpers/abTests/abtest.js
@@ -10,21 +10,13 @@ import * as ophan from 'ophan';
 import * as cookie from 'helpers/cookie';
 import * as storage from 'helpers/storage';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import {
-  oldContributionsFlowTests,
-  newContributionsFlowTests,
-  tests,
-} from 'helpers/abTests/abtestDefinitions';
+
+import { tests } from './abtestDefinitions';
 
 
 // ----- Types ----- //
-const allTests = {
-  ...tests,
-  ...oldContributionsFlowTests,
-  ...newContributionsFlowTests,
-};
 
-type TestId = $Keys<typeof allTests>;
+type TestId = $Keys<typeof tests>;
 
 type OphanABEvent = {
   variantName: string,
@@ -237,7 +229,7 @@ const trackABOphan = (participations: Participations, complete: boolean): void =
   });
 };
 
-const init = (country: IsoCountry, countryGroupId: CountryGroupId, abTests: Tests): Participations => {
+const init = (country: IsoCountry, countryGroupId: CountryGroupId, abTests: Tests = tests): Participations => {
 
   const mvt: number = getMvtId();
   const participations: Participations = getParticipations(abTests, mvt, country, countryGroupId);

--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -5,67 +5,17 @@ import type { Tests } from './abtest';
 
 export type AnnualContributionsTestVariant = 'control' | 'annualAmountsA' | 'notintest';
 
-// Participations in these tests are only assigned
-// to browsers landing on pages/contributions-landing/contributionsLanding.jsx
-export const oldContributionsFlowTests: Tests = {
-  annualContributionsRoundThree: {
-    variants: ['control', 'annualAmountsA'],
-    audiences: {
-      ALL: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: true,
-    independent: true,
-    seed: 3,
-  },
-  newPaymentFlow: {
-    // 100% of people will be put in this variant
-    variants: ['control'],
-    audiences: {
-      ALL: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: false,
-    independent: true,
-    seed: 4,
-  },
-};
-
-// Participations in these tests are only assigned
-// to browsers landing on pages/new-contributions-landing/contributionsLanding.jsx
-export const newContributionsFlowTests: Tests = {
-  annualContributionsRoundThree: {
-    variants: ['control', 'annualAmountsA'],
-    audiences: {
-      ALL: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: true,
-    independent: true,
-    seed: 3,
-  },
-  newPaymentFlow: {
-    // 100% of people will be put in this variant
-    variants: ['newPaymentFlow'],
-    audiences: {
-      ALL: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: false,
-    independent: true,
-    seed: 5,
-  },
-};
-
 export const tests: Tests = {
-  // Participations in these tests will be assigned on all pages
-  // EXCEPT the existing & new contributions landing pages
+  annualContributionsRoundThree: {
+    variants: ['control', 'annualAmountsA'],
+    audiences: {
+      ALL: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: true,
+    independent: true,
+    seed: 3,
+  },
 };

--- a/assets/helpers/page/page.js
+++ b/assets/helpers/page/page.js
@@ -14,8 +14,7 @@ import thunkMiddleware from 'redux-thunk';
 import type { Store } from 'redux';
 
 import * as abTest from 'helpers/abTests/abtest';
-import { tests } from 'helpers/abTests/abtestDefinitions';
-import type { Participations, Tests } from 'helpers/abTests/abtest';
+import type { Participations } from 'helpers/abTests/abtest';
 import type { Settings } from 'helpers/settings';
 import * as logger from 'helpers/logger';
 import * as googleTagManager from 'helpers/tracking/googleTagManager';
@@ -134,7 +133,7 @@ function createCommonReducer(initialState: CommonState): (state?: CommonState, a
 function statelessInit() {
   const country: IsoCountry = detectCountry();
   const countryGroupId: CountryGroupId = detectCountryGroup();
-  const participations: Participations = abTest.init(country, countryGroupId, tests);
+  const participations: Participations = abTest.init(country, countryGroupId);
   analyticsInitialisation(participations);
 }
 
@@ -158,13 +157,12 @@ function storeEnhancer(thunk: boolean) {
 function init<S, A>(
   pageReducer: Reducer<S, A> | null = null,
   thunk?: boolean = false,
-  abTests: Tests = tests,
 ): Store<*, *, *> {
 
   const countryGroupId: CountryGroupId = detectCountryGroup();
   const countryId: IsoCountry = detectCountry();
   const currencyId: IsoCurrency = detectCurrency(countryGroupId);
-  const participations: Participations = abTest.init(countryId, countryGroupId, abTests);
+  const participations: Participations = abTest.init(countryId, countryGroupId);
   const { settings } = window.guardian;
   analyticsInitialisation(participations);
 

--- a/assets/pages/contributions-landing/contributionsLanding.jsx
+++ b/assets/pages/contributions-landing/contributionsLanding.jsx
@@ -6,8 +6,9 @@ import React from 'react';
 
 import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
-import { detect, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import { oldContributionsFlowTests } from 'helpers/abTests/abtestDefinitions';
+import { detect } from 'helpers/internationalisation/countryGroup';
+
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 import { setInitialAmountsForAnnualVariants } from 'helpers/abTests/helpers/annualContributions';
 import HorizontalLandingLayout from './pagesVersions/horizontalLayoutLandingPage';
@@ -19,11 +20,7 @@ import { createPageReducerFor } from './contributionsLandingReducer';
 
 const countryGroupId: CountryGroupId = detect();
 
-const store = pageInit(
-  createPageReducerFor(countryGroupId),
-  false,
-  oldContributionsFlowTests,
-);
+const store = pageInit(createPageReducerFor(countryGroupId));
 
 
 const reactElementId: {

--- a/assets/pages/new-contributions-landing/contributionsLanding.jsx
+++ b/assets/pages/new-contributions-landing/contributionsLanding.jsx
@@ -8,7 +8,6 @@ import { Route } from 'react-router';
 import { BrowserRouter } from 'react-router-dom';
 
 import { isDetailsSupported, polyfillDetails } from 'helpers/details';
-import { newContributionsFlowTests } from 'helpers/abTests/abtestDefinitions';
 import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
 import { detect, countryGroups, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
@@ -32,11 +31,7 @@ if (!isDetailsSupported) {
 
 const countryGroupId: CountryGroupId = detect();
 
-const store = pageInit(
-  initReducer(countryGroupId),
-  true,
-  newContributionsFlowTests,
-);
+const store = pageInit(initReducer(countryGroupId), true);
 
 user.init(store.dispatch);
 formInit(store);


### PR DESCRIPTION
Unfortunately #1053 broke our A/B test tracking. It violated the assumption made by other A/B test code that all pages have the same A/B test object ([this code](https://github.com/guardian/support-frontend/blob/master/assets/helpers/abTests/abtest.js#L201-L220) only loops through test definitions available on the page, so it will wipe out any participations which were available on other pages but not on the current page)

Me and @tsop14 are working on another PR to assign participation for the new payment flow in a different way which shouldn't affect existing tests.