### PR TITLE
Featured product test AB setup

### DIFF
--- a/assets/components/featuredProductHero/featuredProductHero.jsx
+++ b/assets/components/featuredProductHero/featuredProductHero.jsx
@@ -5,6 +5,7 @@
 import React, { type Node } from 'react';
 
 import { classNameWithModifiers } from 'helpers/utilities';
+import { type SubscriptionProduct } from 'helpers/subscriptions';
 
 import Heading from 'components/heading/heading';
 import FlashSaleCountdown from 'components/flashSaleCountdown/flashSaleCountdown';
@@ -20,6 +21,7 @@ type PropTypes = {
   bodyText: string,
   cta?: Node,
   image?: Node,
+  product?: ?SubscriptionProduct,
 };
 
 export default function FeaturedProductHero(props: PropTypes) {
@@ -32,12 +34,20 @@ export default function FeaturedProductHero(props: PropTypes) {
     bodyText,
     cta,
     image,
+    product,
   } = props;
 
   const timerClassName = classNameWithModifiers('component-featured-product-hero__countdownbox', hasTimer ? [] : ['hidden']);
-
+  const rootClassName = classNameWithModifiers(
+    'component-featured-product-hero',
+    [
+      product === 'DigitalPack' ? 'digital-pack' : null,
+      product === 'Paper' ? 'paper' : null,
+      product === 'GuardianWeekly' ? 'guardian-weekly' : null,
+    ],
+  );
   return (
-    <section className="component-featured-product-hero">
+    <section className={rootClassName}>
       <div className="component-featured-product-hero__content">
         <div className="component-featured-product-hero__description">
           <Heading
@@ -78,4 +88,5 @@ FeaturedProductHero.defaultProps = {
   cta: null,
   image: null,
   hasTimer: false,
+  product: null,
 };

--- a/assets/components/featuredProductHero/featuredProductHero.scss
+++ b/assets/components/featuredProductHero/featuredProductHero.scss
@@ -132,6 +132,14 @@
     padding-right: 0;
     padding-left: 21px;
   }
+
+  @include mq($from: leftCol) {
+    min-height: 350px;
+  }
+
+  @include mq($from: wide) {
+    min-height: 400px;
+  }
 }
 
 .component-featured-product-hero__image {

--- a/assets/components/featuredProductHero/featuredProductHero.scss
+++ b/assets/components/featuredProductHero/featuredProductHero.scss
@@ -1,3 +1,8 @@
+@mixin with-colour($color) {
+  & .component-featured-product-hero__heading,
+  & .component-flash-sale-countdown, {
+    color: gu-colour($color);
+  }}
 
 .component-featured-product-hero {
   position: relative;
@@ -42,7 +47,6 @@
 
   .component-featured-product-hero__countdownbox .component-flash-sale-countdown {
     margin: 0 -5px;
-    color: #bb3b80;
     width: 130%;
     display: inline-block;
     .component-countdown {
@@ -150,7 +154,6 @@
 
 .component-featured-product-hero__heading {
   @extend .component-featured-product-hero__title;
-  color: gu-colour(lifestyle-garnett-main-1);
   margin-top: 8px;
   @include mq($from: phablet) {
     max-width: 350px;
@@ -178,4 +181,14 @@
 
 .component-cta-link--flash-sale {
   z-index: 1;
+}
+
+.component-featured-product-hero--digital-pack {
+  @include with-colour(lifestyle-garnett-main-1);
+}
+.component-featured-product-hero--paper {
+  @include with-colour(sport-garnett-media-main-1);
+}
+.component-featured-product-hero--guardian-weekly {
+  @include with-colour(opinion-garnett-main-1);
 }

--- a/assets/pages/subscriptions-landing/components/featuredProductAb.jsx
+++ b/assets/pages/subscriptions-landing/components/featuredProductAb.jsx
@@ -17,7 +17,7 @@ import { type OptimizeExperiments } from 'helpers/tracking/optimize';
 import { type CommonState } from 'helpers/page/page';
 import FeaturedProductHero from 'components/featuredProductHero/featuredProductHero';
 
-import { getProduct, type Product } from './featuredProducts';
+import { getProduct, getProducts, type Product } from './featuredProducts';
 
 // ----- Types ----- //
 
@@ -71,7 +71,7 @@ function FeaturedProductAb(props: PropTypes) {
     optimizeExperiments,
   );
 
-  const product = getProduct(subsLinks, countryGroupId);
+  const product = getProduct(subsLinks, countryGroupId) || getProducts(subsLinks, countryGroupId).GuardianWeekly;
 
   return product ? (
     <FeaturedProductHero

--- a/assets/pages/subscriptions-landing/components/featuredProductAb.jsx
+++ b/assets/pages/subscriptions-landing/components/featuredProductAb.jsx
@@ -71,7 +71,7 @@ function FeaturedProductAb(props: PropTypes) {
     optimizeExperiments,
   );
 
-  const product = getProduct(subsLinks);
+  const product = getProduct(subsLinks, countryGroupId);
 
   return product ? (
     <FeaturedProductHero

--- a/assets/pages/subscriptions-landing/components/featuredProductAb.jsx
+++ b/assets/pages/subscriptions-landing/components/featuredProductAb.jsx
@@ -2,22 +2,22 @@
 
 // ----- Imports ----- //
 
-import React, { type Node } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 
 import CtaLink from 'components/ctaLink/ctaLink';
-import GridPicture from 'components/gridPicture/gridPicture';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
 import { getSubsLinks } from 'helpers/externalLinks';
 import { getCampaign, type ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
-import { type ComponentAbTest, type SubscriptionProduct } from 'helpers/subscriptions';
+import { type ComponentAbTest } from 'helpers/subscriptions';
 import type { HeadingSize } from 'components/heading/heading';
 import { type Participations } from 'helpers/abTests/abtest';
 import { type OptimizeExperiments } from 'helpers/tracking/optimize';
 import { type CommonState } from 'helpers/page/page';
 import FeaturedProductHero from 'components/featuredProductHero/featuredProductHero';
-import { getQueryParameter } from 'helpers/url';
+
+import { getProduct, type Product } from './featuredProducts';
 
 // ----- Types ----- //
 
@@ -30,37 +30,6 @@ type PropTypes = {|
   optimizeExperiments: OptimizeExperiments,
 |};
 
-type Product = {|
-  name: SubscriptionProduct,
-  headingText: string,
-  bodyText: string,
-  link: string,
-  image: Node,
-|}
-
-const dpImage = (
-  <GridPicture
-    sources={[
-      {
-        gridId: 'digitalPackFlashSaleMobile',
-        srcSizes: [140, 500, 717],
-        imgType: 'png',
-        sizes: '90vw',
-        media: '(max-width: 739px)',
-      },
-      {
-        gridId: 'digitalPackFlashSaleDesktop',
-        srcSizes: [140, 500, 1000, 1388],
-        imgType: 'png',
-        sizes: '(min-width: 1300px) 750px, (min-width: 1140px) 700px, (min-width: 980px) 600px, (min-width: 740px) 60vw',
-        media: '(min-width: 740px)',
-      },
-    ]}
-    fallback="digitalPackFlashSaleDesktop"
-    fallbackSize={500}
-    altText="ad-free, live and discover, and the daily edition"
-    fallbackImgType="png"
-  />);
 
 function mapStateToProps(state: { common: CommonState }) {
 
@@ -102,46 +71,9 @@ function FeaturedProductAb(props: PropTypes) {
     optimizeExperiments,
   );
 
-  const products: {DigitalPack: Product, Paper: Product, GuardianWeekly: Product} = {
-    DigitalPack: {
-      name: 'DigitalPack',
-      headingText: 'Digital Pack',
-      bodyText: 'Read the Guardian ad-free on all devices, plus get all the benefits of the Premium App and Daily Edition iPad app of the UK newspaper',
-      link: subsLinks.DigitalPack,
-      image: dpImage,
-    },
-    Paper: {
-      name: 'Paper',
-      headingText: 'Print Subscription',
-      bodyText: 'Save on The Guardian and The Observer retail price all year round.',
-      link: subsLinks.Paper,
-      image: dpImage,
-    },
-    GuardianWeekly: {
-      name: 'GuardianWeekly',
-      headingText: 'Guardian Weekly',
-      bodyText: 'Our new, weekly magazine with free delivery worldwide',
-      link: subsLinks.GuardianWeekly,
-      image: dpImage,
-    },
-  };
+  const product = getProduct(subsLinks);
 
-  function getProduct(): ?Product {
-    switch (getQueryParameter('ab_product')) {
-      case 'DigitalPack':
-        return products.DigitalPack;
-      case 'Paper':
-        return products.Paper;
-      case 'GuardianWeekly':
-        return products.GuardianWeekly;
-      default:
-        return null;
-    }
-  }
-
-  const product = getProduct();
-
-  return product && (
+  return product ? (
     <FeaturedProductHero
       headingText={product.headingText}
       bodyText={product.bodyText}
@@ -149,9 +81,8 @@ function FeaturedProductAb(props: PropTypes) {
       cta={getCta(product)}
       headingSize={headingSize}
       product={product.name}
-    />
+    />) : null;
 
-  );
 }
 
 

--- a/assets/pages/subscriptions-landing/components/featuredProductAb.jsx
+++ b/assets/pages/subscriptions-landing/components/featuredProductAb.jsx
@@ -1,0 +1,168 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React, { type Node } from 'react';
+import { connect } from 'react-redux';
+
+import CtaLink from 'components/ctaLink/ctaLink';
+import GridPicture from 'components/gridPicture/gridPicture';
+import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
+import { getSubsLinks } from 'helpers/externalLinks';
+import { getCampaign, type ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
+import { type ComponentAbTest, type SubscriptionProduct } from 'helpers/subscriptions';
+import type { HeadingSize } from 'components/heading/heading';
+import { type Participations } from 'helpers/abTests/abtest';
+import { type OptimizeExperiments } from 'helpers/tracking/optimize';
+import { type CommonState } from 'helpers/page/page';
+import FeaturedProductHero from 'components/featuredProductHero/featuredProductHero';
+import { getQueryParameter } from 'helpers/url';
+
+// ----- Types ----- //
+
+type PropTypes = {|
+  headingSize: HeadingSize,
+  countryGroupId: CountryGroupId,
+  abTest: ComponentAbTest | null,
+  referrerAcquisitionData: ReferrerAcquisitionData,
+  abParticipations: Participations,
+  optimizeExperiments: OptimizeExperiments,
+|};
+
+type Product = {|
+  name: SubscriptionProduct,
+  headingText: string,
+  bodyText: string,
+  link: string,
+  image: Node,
+|}
+
+const dpImage = (
+  <GridPicture
+    sources={[
+      {
+        gridId: 'digitalPackFlashSaleMobile',
+        srcSizes: [140, 500, 717],
+        imgType: 'png',
+        sizes: '90vw',
+        media: '(max-width: 739px)',
+      },
+      {
+        gridId: 'digitalPackFlashSaleDesktop',
+        srcSizes: [140, 500, 1000, 1388],
+        imgType: 'png',
+        sizes: '(min-width: 1300px) 750px, (min-width: 1140px) 700px, (min-width: 980px) 600px, (min-width: 740px) 60vw',
+        media: '(min-width: 740px)',
+      },
+    ]}
+    fallback="digitalPackFlashSaleDesktop"
+    fallbackSize={500}
+    altText="ad-free, live and discover, and the daily edition"
+    fallbackImgType="png"
+  />);
+
+function mapStateToProps(state: { common: CommonState }) {
+
+  return {
+    countryGroupId: state.common.internationalisation.countryGroupId,
+    referrerAcquisitionData: state.common.referrerAcquisitionData,
+    abParticipations: state.common.abParticipations,
+    optimizeExperiments: state.common.optimizeExperiments,
+  };
+
+}
+
+function FeaturedProductAb(props: PropTypes) {
+
+  const {
+    countryGroupId,
+    headingSize,
+    referrerAcquisitionData,
+    abParticipations,
+    abTest,
+    optimizeExperiments,
+  } = props;
+
+  const getCta = ({ link, name }: Product) => (
+    <CtaLink
+      text="Subscribe now"
+      url={link}
+      accessibilityHint="Subscribe now"
+      onClick={sendTrackingEventsOnClick(`featured_${name}_cta`, name, abTest)}
+    />
+  );
+
+  const subsLinks = getSubsLinks(
+    countryGroupId,
+    referrerAcquisitionData.campaignCode,
+    getCampaign(referrerAcquisitionData),
+    referrerAcquisitionData,
+    abParticipations,
+    optimizeExperiments,
+  );
+
+  const products: {DigitalPack: Product, Paper: Product, GuardianWeekly: Product} = {
+    DigitalPack: {
+      name: 'DigitalPack',
+      headingText: 'Digital Pack',
+      bodyText: 'Read the Guardian ad-free on all devices, plus get all the benefits of the Premium App and Daily Edition iPad app of the UK newspaper',
+      link: subsLinks.DigitalPack,
+      image: dpImage,
+    },
+    Paper: {
+      name: 'Paper',
+      headingText: 'Print Subscription',
+      bodyText: 'Save on The Guardian and The Observer retail price all year round.',
+      link: subsLinks.Paper,
+      image: dpImage,
+    },
+    GuardianWeekly: {
+      name: 'GuardianWeekly',
+      headingText: 'Guardian Weekly',
+      bodyText: 'Our new, weekly magazine with free delivery worldwide',
+      link: subsLinks.GuardianWeekly,
+      image: dpImage,
+    },
+  };
+
+  function getProduct(): ?Product {
+    switch (getQueryParameter('ab_product')) {
+      case 'DigitalPack':
+        return products.DigitalPack;
+      case 'Paper':
+        return products.Paper;
+      case 'GuardianWeekly':
+        return products.GuardianWeekly;
+      default:
+        return null;
+    }
+  }
+
+  const product = getProduct();
+
+  return product && (
+    <FeaturedProductHero
+      headingText={product.headingText}
+      bodyText={product.bodyText}
+      image={product.image}
+      cta={getCta(product)}
+      headingSize={headingSize}
+      product={product.name}
+    />
+
+  );
+}
+
+
+// ----- Default Props ----- //
+
+FeaturedProductAb.defaultProps = {
+  abTest: null,
+};
+
+
+// ----- Export ----- //
+
+export default connect(mapStateToProps)(FeaturedProductAb);
+

--- a/assets/pages/subscriptions-landing/components/featuredProducts.jsx
+++ b/assets/pages/subscriptions-landing/components/featuredProducts.jsx
@@ -6,6 +6,7 @@ import React, { type Node } from 'react';
 import { type SubsUrls } from 'helpers/externalLinks';
 import { getQueryParameter } from 'helpers/url';
 import { type SubscriptionProduct } from 'helpers/subscriptions';
+import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 import GridPicture from 'components/gridPicture/gridPicture';
 
@@ -46,11 +47,16 @@ const dpImage = (
   />);
 
 
-const getProducts = (subsLinks: SubsUrls): {DigitalPack: Product, Paper: Product, GuardianWeekly: Product} => ({
+const getProducts = (
+  subsLinks: SubsUrls,
+  countryGroupId: CountryGroupId,
+): {DigitalPack: Product, Paper: Product, GuardianWeekly: Product} => ({
   DigitalPack: {
     name: 'DigitalPack',
     headingText: 'Digital Pack',
-    bodyText: 'Read the Guardian ad-free on all devices, plus get all the benefits of the Premium App and Daily Edition iPad app of the UK newspaper',
+    bodyText: (countryGroupId === 'GBPCountries') ?
+      'Read the Guardian ad-free on all devices, plus get all the benefits of the Premium App and Daily Edition iPad app of the newspaper' :
+      'Read the Guardian ad-free on all devices, plus get all the benefits of the Premium App and Daily Edition iPad app of the UK newspaper',
     link: subsLinks.DigitalPack,
     image: dpImage,
   },
@@ -70,14 +76,14 @@ const getProducts = (subsLinks: SubsUrls): {DigitalPack: Product, Paper: Product
   },
 });
 
-const getProduct = (subsLinks: SubsUrls): ?Product => {
+const getProduct = (subsLinks: SubsUrls, countryGroupId: CountryGroupId): ?Product => {
   switch (getQueryParameter('ab_product')) {
     case 'DigitalPack':
-      return getProducts(subsLinks).DigitalPack;
+      return getProducts(subsLinks, countryGroupId).DigitalPack;
     case 'Paper':
-      return getProducts(subsLinks).Paper;
+      return getProducts(subsLinks, countryGroupId).Paper;
     case 'GuardianWeekly':
-      return getProducts(subsLinks).GuardianWeekly;
+      return getProducts(subsLinks, countryGroupId).GuardianWeekly;
     default:
       return null;
   }

--- a/assets/pages/subscriptions-landing/components/featuredProducts.jsx
+++ b/assets/pages/subscriptions-landing/components/featuredProducts.jsx
@@ -89,5 +89,5 @@ const getProduct = (subsLinks: SubsUrls, countryGroupId: CountryGroupId): ?Produ
   }
 };
 
-export { getProduct };
+export { getProduct, getProducts };
 export type { Product };

--- a/assets/pages/subscriptions-landing/components/featuredProducts.jsx
+++ b/assets/pages/subscriptions-landing/components/featuredProducts.jsx
@@ -1,0 +1,87 @@
+// @flow
+
+// ----- Imports ----- //
+import React, { type Node } from 'react';
+
+import { type SubsUrls } from 'helpers/externalLinks';
+import { getQueryParameter } from 'helpers/url';
+import { type SubscriptionProduct } from 'helpers/subscriptions';
+
+import GridPicture from 'components/gridPicture/gridPicture';
+
+
+// ----- Types ----- //
+type Product = {|
+  name: SubscriptionProduct,
+  headingText: string,
+  bodyText: string,
+  link: string,
+  image: Node,
+|}
+
+
+// ----- Exports ----- //
+const dpImage = (
+  <GridPicture
+    sources={[
+      {
+        gridId: 'digitalPackFlashSaleMobile',
+        srcSizes: [140, 500, 717],
+        imgType: 'png',
+        sizes: '90vw',
+        media: '(max-width: 739px)',
+      },
+      {
+        gridId: 'digitalPackFlashSaleDesktop',
+        srcSizes: [140, 500, 1000, 1388],
+        imgType: 'png',
+        sizes: '(min-width: 1300px) 750px, (min-width: 1140px) 700px, (min-width: 980px) 600px, (min-width: 740px) 60vw',
+        media: '(min-width: 740px)',
+      },
+    ]}
+    fallback="digitalPackFlashSaleDesktop"
+    fallbackSize={500}
+    altText="ad-free, live and discover, and the daily edition"
+    fallbackImgType="png"
+  />);
+
+
+const getProducts = (subsLinks: SubsUrls): {DigitalPack: Product, Paper: Product, GuardianWeekly: Product} => ({
+  DigitalPack: {
+    name: 'DigitalPack',
+    headingText: 'Digital Pack',
+    bodyText: 'Read the Guardian ad-free on all devices, plus get all the benefits of the Premium App and Daily Edition iPad app of the UK newspaper',
+    link: subsLinks.DigitalPack,
+    image: dpImage,
+  },
+  Paper: {
+    name: 'Paper',
+    headingText: 'Print Subscription',
+    bodyText: 'Save on The Guardian and The Observer retail price all year round.',
+    link: subsLinks.Paper,
+    image: dpImage,
+  },
+  GuardianWeekly: {
+    name: 'GuardianWeekly',
+    headingText: 'Guardian Weekly',
+    bodyText: 'Our new, weekly magazine with free delivery worldwide',
+    link: subsLinks.GuardianWeekly,
+    image: dpImage,
+  },
+});
+
+const getProduct = (subsLinks: SubsUrls): ?Product => {
+  switch (getQueryParameter('ab_product')) {
+    case 'DigitalPack':
+      return getProducts(subsLinks).DigitalPack;
+    case 'Paper':
+      return getProducts(subsLinks).Paper;
+    case 'GuardianWeekly':
+      return getProducts(subsLinks).GuardianWeekly;
+    default:
+      return null;
+  }
+};
+
+export { getProduct };
+export type { Product };

--- a/assets/pages/subscriptions-landing/components/flashSaleDigitalPack.jsx
+++ b/assets/pages/subscriptions-landing/components/flashSaleDigitalPack.jsx
@@ -108,6 +108,7 @@ function FlashSaleDigitalPack(props: PropTypes) {
       cta={cta}
       headingSize={headingSize}
       hasTimer={getCountdownAbTestParticipation()}
+      product="DigitalPack"
     />
 
   );


### PR DESCRIPTION
## Why are you doing this?

Continues #1101 . This sets up a component to render the three possible variants for the featured product AB test in `FeaturedProductHero` and makes it change text colours based on the product.

We are missing images & final copy but adding those should be a super minor PR compared to this which is the major code-related work

There are no user-facing changes as the component is not rendered from anywhere (Plan is for it to replace the flash sale hero currently in place) but to throw in a quick visual this is how the current state (missing final copy & images & a designer to go over the colours) looks like for GW if it were to be rendered:

![screenshot 2018-10-30 at 1 03 08 pm](https://user-images.githubusercontent.com/11539094/47719859-51057880-dc44-11e8-8cc8-23cc8d7623a5.png)


<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com)