### PR TITLE
update Grid crop sizes

### DIFF
--- a/assets/components/otherProduct/otherProduct.jsx
+++ b/assets/components/otherProduct/otherProduct.jsx
@@ -34,7 +34,7 @@ export default function OtherProduct(props: PropTypes) {
       <div className="component-other-product__image">
         <GridImage
           gridId={props.gridImg}
-          srcSizes={[1000, 500, 140]}
+          srcSizes={[500, 140]}
           sizes="(max-width: 480px) 90vw, (max-width: 660px) 400px, 270px"
           altText={props.imgAlt}
           imgType={props.imgType}


### PR DESCRIPTION
Only use 500 and 140 width crops as some images (specifically the patron image) do not have 1000 width crops and so the request 404s and the image renders as the alt text.