### PR TITLE
use NFP test variant from server 

### DIFF
--- a/assets/helpers/abTests/abtest.js
+++ b/assets/helpers/abTests/abtest.js
@@ -11,7 +11,7 @@ import * as cookie from 'helpers/cookie';
 import * as storage from 'helpers/storage';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
-import { tests } from './abtestDefinitions';
+import { tests, type NewPaymentFlowTestVariant } from './abtestDefinitions';
 
 
 // ----- Types ----- //
@@ -254,7 +254,8 @@ const getVariantsAsString = (participation: Participations): string => {
 const getNewPaymentFlowTestParticipation = (): ?Participations => {
   const npfVariant = cookie.get('gu.serverside.ab.test');
   if (npfVariant) {
-    return { 'newPaymentFlow' : npfVariant }
+    const variant: NewPaymentFlowTestVariant = npfVariant === "Variant" ? 'newPaymentFlow' : 'control';
+    return { 'newPaymentFlow' : variant }
   }
 };
 

--- a/assets/helpers/abTests/abtest.js
+++ b/assets/helpers/abTests/abtest.js
@@ -230,11 +230,12 @@ const trackABOphan = (participations: Participations, complete: boolean): void =
 };
 
 const init = (country: IsoCountry, countryGroupId: CountryGroupId, abTests: Tests = tests): Participations => {
-
+ 
+  const newPaymentFlowParticipation: ?Participations = getNewPaymentFlowTestParticipation(); 
   const mvt: number = getMvtId();
   const participations: Participations = getParticipations(abTests, mvt, country, countryGroupId);
   const urlParticipations: ?Participations = getParticipationsFromUrl();
-  setLocalStorageParticipations(Object.assign({}, participations, urlParticipations));
+  setLocalStorageParticipations(Object.assign({}, participations, urlParticipations, newPaymentFlowParticipation));
   trackABOphan(participations, false);
 
   return participations;
@@ -249,6 +250,14 @@ const getVariantsAsString = (participation: Participations): string => {
 
   return variants.join('; ');
 };
+
+const getNewPaymentFlowTestParticipation = (): ?Participations => {
+  const npfVariant = cookie.get('gu.serverside.ab.test');
+  if (npfVariant) {
+    return { 'newPaymentFlow' : npfVariant }
+  }
+};
+
 
 const getCurrentParticipations = (): Participations => getLocalStorageParticipation();
 

--- a/assets/helpers/abTests/abtest.js
+++ b/assets/helpers/abTests/abtest.js
@@ -229,16 +229,28 @@ const trackABOphan = (participations: Participations, complete: boolean): void =
   });
 };
 
+const getNewPaymentFlowTestParticipation = (): ?Participations => {
+  const npfVariant = cookie.get('gu.serverside.ab.test');
+  if (npfVariant) {
+    const variant: NewPaymentFlowTestVariant = npfVariant === 'Variant' ? 'newPaymentFlow' : 'control';
+    return { newPaymentFlow: variant };
+  }
+
+  return {};
+};
+
 const init = (country: IsoCountry, countryGroupId: CountryGroupId, abTests: Tests = tests): Participations => {
- 
-  const newPaymentFlowParticipation: ?Participations = getNewPaymentFlowTestParticipation(); 
+  // this is to assign the correct variant while npf server side test runs
+  const newPaymentFlowParticipation: ?Participations = getNewPaymentFlowTestParticipation();
+
   const mvt: number = getMvtId();
   const participations: Participations = getParticipations(abTests, mvt, country, countryGroupId);
+  const participationsWithServerSideNPFVariant = { ...participations, ...newPaymentFlowParticipation };
   const urlParticipations: ?Participations = getParticipationsFromUrl();
-  setLocalStorageParticipations(Object.assign({}, participations, urlParticipations, newPaymentFlowParticipation));
-  trackABOphan(participations, false);
+  setLocalStorageParticipations(Object.assign({}, participationsWithServerSideNPFVariant, urlParticipations));
+  trackABOphan(participationsWithServerSideNPFVariant, false);
 
-  return participations;
+  return participationsWithServerSideNPFVariant;
 };
 
 const getVariantsAsString = (participation: Participations): string => {
@@ -250,15 +262,6 @@ const getVariantsAsString = (participation: Participations): string => {
 
   return variants.join('; ');
 };
-
-const getNewPaymentFlowTestParticipation = (): ?Participations => {
-  const npfVariant = cookie.get('gu.serverside.ab.test');
-  if (npfVariant) {
-    const variant: NewPaymentFlowTestVariant = npfVariant === "Variant" ? 'newPaymentFlow' : 'control';
-    return { 'newPaymentFlow' : variant }
-  }
-};
-
 
 const getCurrentParticipations = (): Participations => getLocalStorageParticipation();
 

--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -4,6 +4,7 @@ import type { Tests } from './abtest';
 // ----- Tests ----- //
 
 export type AnnualContributionsTestVariant = 'control' | 'annualAmountsA' | 'notintest';
+export type NewPaymentFlowTestVariant = 'control' | 'newPaymentFlow';
 
 export const tests: Tests = {
   annualContributionsRoundThree: {
@@ -17,5 +18,17 @@ export const tests: Tests = {
     isActive: true,
     independent: true,
     seed: 3,
+  },
+  newPaymentFlow: {
+    variants: [ 'control', 'newPaymentFlow'],
+    audiences: {
+      ALL: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: false,
+    independent: true,
+    seed: 5,
   },
 };

--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -20,7 +20,7 @@ export const tests: Tests = {
     seed: 3,
   },
   newPaymentFlow: {
-    variants: [ 'control', 'newPaymentFlow'],
+    variants: ['control', 'newPaymentFlow'],
     audiences: {
       ALL: {
         offset: 0,


### PR DESCRIPTION
## Why are you doing this?
So users are assigned to the correct variant for npf test. 

For previous ab tests, we determine a user's test variant client side. Because the new payment flow is running as a server side test, users have already been allocated to a variant and we need to ensure this value is respected. 

The variant value is:
* Set in local storage
* Used for ophan tracking

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Changes

* We plan to set a  [`gu.serverside.ab.test`](https://github.com/guardian/support-frontend/blob/2125cedfec1176e39ee744d5837fe74bffb15cb7/app/cookies/ServersideAbTestCookie.scala) to ensure users remain in the same variant once allocated.
* We can use this cookie value to set the correct `newPaymentFlow`. Note `getParticipations` will still assign a variant, as this loops over all tests currently defined. However, this value is then overwritten by the value collected from `newPaymentFlowParticipation`. 
* The correct participation values are set in local storage and used for ophan tracking. 

Once the server side test is finished the `newPaymentFlowParticipation` logic should be removed.

This PR assumes the name of the cookie. If this changes, the value will need to be updated. 

## Screenshots

