### PR TITLE
Paypal button enables/disables correctly according to validity of form and the User Type

### DIFF
--- a/assets/helpers/checkoutForm/checkoutForm.js
+++ b/assets/helpers/checkoutForm/checkoutForm.js
@@ -51,7 +51,6 @@ export const formInputs = (formClassName: string): Array<HTMLInputElement> => {
 export const getForm: string => Object | null =
   (formName: string) => document.querySelector(`.${formName}`);
 
-// Takes either a form element, or the HTML class of the form
 export const formElementIsValid = (formElement: Object | null) => {
   if (formElement && formElement instanceof HTMLFormElement) {
     return formElement.checkValidity();

--- a/assets/helpers/checkoutForm/checkoutForm.js
+++ b/assets/helpers/checkoutForm/checkoutForm.js
@@ -48,31 +48,27 @@ export const formInputs = (formClassName: string): Array<HTMLInputElement> => {
   return [];
 };
 
+export const getForm: string => Object | null =
+  (formName: string) => document.querySelector(`.${formName}`);
+
 // Takes either a form element, or the HTML class of the form
-export const formIsValid = (form: Object | string) => {
-
-  let formElement;
-
-  if (typeof form === 'string') {
-    formElement = document.querySelector(`.${form}`);
-  } else {
-    formElement = form;
-  }
-
+export const formElementIsValid = (formElement: Object | null) => {
   if (formElement && formElement instanceof HTMLFormElement) {
     return formElement.checkValidity();
   }
-
   return false;
 };
+
+export const formIsValid = (formName: string) => formElementIsValid(getForm(formName));
 
 export function checkoutFormShouldSubmit(
   contributionType: Contrib,
   isSignedIn: boolean,
   userTypeFromIdentityResponse: UserTypeFromIdentityResponse,
-  form: Object | string,
+  form: Object | null,
 ) {
-  return formIsValid(form) && canContributeWithoutSigningIn(contributionType, isSignedIn, userTypeFromIdentityResponse);
+  return formElementIsValid(form)
+    && canContributeWithoutSigningIn(contributionType, isSignedIn, userTypeFromIdentityResponse);
 }
 
 export function getTitle(contributionType: ContributionType): string {

--- a/assets/helpers/checkoutForm/checkoutForm.js
+++ b/assets/helpers/checkoutForm/checkoutForm.js
@@ -75,7 +75,7 @@ export function checkoutFormShouldSubmit(
   userTypeFromIdentityResponse: UserTypeFromIdentityResponse,
   form: Object | string,
 ) {
-  return formIsValid(form) && canContributeWithoutSigningIn(contributionType, isSignedIn, userTypeFromIdentityResponse)
+  return formIsValid(form) && canContributeWithoutSigningIn(contributionType, isSignedIn, userTypeFromIdentityResponse);
 }
 
 export function getTitle(contributionType: ContributionType): string {

--- a/assets/helpers/checkoutForm/checkoutForm.js
+++ b/assets/helpers/checkoutForm/checkoutForm.js
@@ -2,6 +2,9 @@
 
 // ----- Imports ----- //
 import { type Contrib as ContributionType } from 'helpers/contributions';
+import type { Contrib } from 'helpers/contributions';
+import type { UserTypeFromIdentityResponse } from 'helpers/identityApis';
+import { canContributeWithoutSigningIn } from 'helpers/identityApis';
 
 // Copied from
 // https://github.com/playframework/playframework/blob/38abd1ca6d17237950c82b1483057c5c39929cb4/framework/src/play/
@@ -45,13 +48,35 @@ export const formInputs = (formClassName: string): Array<HTMLInputElement> => {
   return [];
 };
 
-export const formIsValid = (formClassName: string) => {
-  const form = document.querySelector(`.${formClassName}`);
-  if (form && form instanceof HTMLFormElement) {
-    return form.checkValidity();
+// Takes either a form element, or the HTML class of the form
+export const formIsValid = (form: Object | string) => {
+
+  // JONNY: i think it's fine to pass it as an object, as you are checking
+  // that it is an instance of HTMLFormElement below
+
+  let formElement;
+
+  if (typeof form === 'string') {
+    formElement = document.querySelector(`.${form}`);
+  } else {
+    formElement = form;
   }
+
+  if (formElement && formElement instanceof HTMLFormElement) {
+    return formElement.checkValidity();
+  }
+
   return false;
 };
+
+export function checkoutFormShouldSubmit(
+  contributionType: Contrib,
+  isSignedIn: boolean,
+  userTypeFromIdentityResponse: UserTypeFromIdentityResponse,
+  form: Object | string,
+) {
+  return formIsValid(form) && canContributeWithoutSigningIn(contributionType, isSignedIn, userTypeFromIdentityResponse)
+}
 
 export function getTitle(contributionType: ContributionType): string {
 

--- a/assets/helpers/checkoutForm/checkoutForm.js
+++ b/assets/helpers/checkoutForm/checkoutForm.js
@@ -51,9 +51,6 @@ export const formInputs = (formClassName: string): Array<HTMLInputElement> => {
 // Takes either a form element, or the HTML class of the form
 export const formIsValid = (form: Object | string) => {
 
-  // JONNY: i think it's fine to pass it as an object, as you are checking
-  // that it is an instance of HTMLFormElement below
-
   let formElement;
 
   if (typeof form === 'string') {

--- a/assets/helpers/identityApis.js
+++ b/assets/helpers/identityApis.js
@@ -70,12 +70,5 @@ function canContributeWithoutSigningIn(
     || userTypeFromIdentityResponse === 'new';
 }
 
-function formShouldSubmit(
-  contributionType: Contrib,
-  isSignedIn: boolean,
-  userTypeFromIdentityResponse: UserTypeFromIdentityResponse,
-  form: Object | string) {
-  return formIsValid(form) && canContributeWithoutSigningIn(contributionType, isSignedIn, userTypeFromIdentityResponse)
-}
 
 export { getUserTypeFromIdentity, canContributeWithoutSigningIn };

--- a/assets/helpers/identityApis.js
+++ b/assets/helpers/identityApis.js
@@ -7,6 +7,8 @@ import { routes } from 'helpers/routes';
 import { fetchJson } from 'helpers/fetch';
 import { checkEmail } from 'helpers/formValidation';
 import type { Csrf } from 'helpers/csrf/csrfReducer';
+import type { Contrib } from 'helpers/contributions';
+import { formIsValid } from 'helpers/checkoutForm/checkoutForm';
 
 // ----- Types     ----- //
 type UserType = 'new' | 'guest' | 'current';
@@ -57,4 +59,23 @@ function getUserTypeFromIdentity(
     });
 }
 
-export { getUserTypeFromIdentity };
+function canContributeWithoutSigningIn(
+  contributionType: Contrib,
+  isSignedIn: boolean,
+  userTypeFromIdentityResponse: UserTypeFromIdentityResponse,
+) {
+  return contributionType === 'ONE_OFF'
+    || isSignedIn
+    || userTypeFromIdentityResponse === 'guest'
+    || userTypeFromIdentityResponse === 'new';
+}
+
+function formShouldSubmit(
+  contributionType: Contrib,
+  isSignedIn: boolean,
+  userTypeFromIdentityResponse: UserTypeFromIdentityResponse,
+  form: Object | string) {
+  return formIsValid(form) && canContributeWithoutSigningIn(contributionType, isSignedIn, userTypeFromIdentityResponse)
+}
+
+export { getUserTypeFromIdentity, canContributeWithoutSigningIn };

--- a/assets/helpers/identityApis.js
+++ b/assets/helpers/identityApis.js
@@ -8,7 +8,6 @@ import { fetchJson } from 'helpers/fetch';
 import { checkEmail } from 'helpers/formValidation';
 import type { Csrf } from 'helpers/csrf/csrfReducer';
 import type { Contrib } from 'helpers/contributions';
-import { formIsValid } from 'helpers/checkoutForm/checkoutForm';
 
 // ----- Types     ----- //
 type UserType = 'new' | 'guest' | 'current';

--- a/assets/helpers/paymentIntegrations/newPaymentFlow/payPalRecurringCheckout.js
+++ b/assets/helpers/paymentIntegrations/newPaymentFlow/payPalRecurringCheckout.js
@@ -98,15 +98,6 @@ function getPayPalOptions(
       validateCalled = true;
       toggleButton(actions);
 
-      const form = document.querySelector(`.${formClassName}`);
-      if (form instanceof HTMLElement) {
-        // Thanks to event bubbling, we can just listen on the form element.
-        // This means that we'll get change events even from form elements which
-        // aren't in the DOM at the time this handler is bound.
-        form.addEventListener('change', () => toggleButton(actions));
-      } else {
-        logException(`No form found with class ${formClassName}`);
-      }
     },
 
     onClick() {

--- a/assets/helpers/paymentIntegrations/newPaymentFlow/payPalRecurringCheckout.js
+++ b/assets/helpers/paymentIntegrations/newPaymentFlow/payPalRecurringCheckout.js
@@ -92,6 +92,9 @@ function getPayPalOptions(
         return;
       }
 
+      window.enablePayPalButton = actions.enable;
+      window.disablePayPalButton = actions.disable;
+
       validateCalled = true;
       toggleButton(actions);
 

--- a/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
@@ -15,7 +15,7 @@ import SvgDollar from 'components/svgs/dollar';
 import SvgEuro from 'components/svgs/euro';
 import SvgPound from 'components/svgs/pound';
 
-import { selectAmount, updateFormValue, updateOtherAmount } from '../contributionsLandingActions';
+import { selectAmount, setStateValueAndTogglePayPal, updateOtherAmount } from '../contributionsLandingActions';
 import { NewContributionTextInput } from './ContributionTextInput';
 
 // ----- Types ----- //
@@ -48,7 +48,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = (dispatch: Function) => ({
   selectAmount: (amount, contributionType) => () => { dispatch(selectAmount(amount, contributionType)); },
-  updateOtherAmount: (amount) => { dispatch(updateFormValue<string>(updateOtherAmount, amount)); },
+  updateOtherAmount: (amount) => { dispatch(setStateValueAndTogglePayPal<string>(updateOtherAmount, amount)); },
 });
 
 // ----- Render ----- //

--- a/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
@@ -4,7 +4,6 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
-import type { Dispatch } from 'redux';
 
 import { config, amounts, type Amount, type Contrib } from 'helpers/contributions';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
@@ -16,7 +15,7 @@ import SvgDollar from 'components/svgs/dollar';
 import SvgEuro from 'components/svgs/euro';
 import SvgPound from 'components/svgs/pound';
 
-import { type Action, selectAmount, updateFormValue, updateOtherAmount } from '../contributionsLandingActions';
+import { selectAmount, updateFormValue, updateOtherAmount } from '../contributionsLandingActions';
 import { NewContributionTextInput } from './ContributionTextInput';
 
 // ----- Types ----- //

--- a/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
@@ -16,7 +16,7 @@ import SvgDollar from 'components/svgs/dollar';
 import SvgEuro from 'components/svgs/euro';
 import SvgPound from 'components/svgs/pound';
 
-import { type Action, selectAmount, updateOtherAmount } from '../contributionsLandingActions';
+import { type Action, selectAmount, updateFormValue, updateOtherAmount } from '../contributionsLandingActions';
 import { NewContributionTextInput } from './ContributionTextInput';
 
 // ----- Types ----- //
@@ -47,9 +47,9 @@ const mapStateToProps = state => ({
   annualTestVariant: state.common.abParticipations.annualContributionsRoundThree,
 });
 
-const mapDispatchToProps = (dispatch: Dispatch<Action>) => ({
+const mapDispatchToProps = (dispatch: Function) => ({
   selectAmount: (amount, contributionType) => () => { dispatch(selectAmount(amount, contributionType)); },
-  updateOtherAmount: (amount) => { dispatch(updateOtherAmount(amount)); },
+  updateOtherAmount: (amount) => { dispatch(updateFormValue<string>(updateOtherAmount, amount)); },
 });
 
 // ----- Render ----- //

--- a/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
@@ -15,7 +15,7 @@ import SvgDollar from 'components/svgs/dollar';
 import SvgEuro from 'components/svgs/euro';
 import SvgPound from 'components/svgs/pound';
 
-import { selectAmount, setStateValueAndTogglePayPal, updateOtherAmount } from '../contributionsLandingActions';
+import { selectAmount, setValueAndTogglePayPal, updateOtherAmount } from '../contributionsLandingActions';
 import { NewContributionTextInput } from './ContributionTextInput';
 
 // ----- Types ----- //
@@ -48,7 +48,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = (dispatch: Function) => ({
   selectAmount: (amount, contributionType) => () => { dispatch(selectAmount(amount, contributionType)); },
-  updateOtherAmount: (amount) => { dispatch(setStateValueAndTogglePayPal<string>(updateOtherAmount, amount)); },
+  updateOtherAmount: (amount) => { dispatch(setValueAndTogglePayPal<string>(updateOtherAmount, amount)); },
 });
 
 // ----- Render ----- //

--- a/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -32,6 +32,7 @@ import {
   isLargerOrEqual,
   maxTwoDecimals,
 } from 'helpers/formValidation';
+import { checkoutFormShouldSubmit } from 'helpers/checkoutForm/checkoutForm';
 import type { UserTypeFromIdentityResponse } from 'helpers/identityApis';
 
 import { ContributionFormFields } from './ContributionFormFields';
@@ -161,19 +162,22 @@ const formHandlers: PaymentMatrix<PropTypes => void> = {
 };
 
 
+// A || B
+
+// !(A || B) = !A && !A
+
 function onSubmit(props: PropTypes): Event => void {
-
-  const signInNotRequired = props.contributionType === 'ONE_OFF'
-    || props.isSignedIn
-    || props.userTypeFromIdentityResponse === 'guest'
-    || props.userTypeFromIdentityResponse === 'new';
-
   return (event) => {
     // Causes errors to be displayed against payment fields
     props.setCheckoutFormHasBeenSubmitted();
     event.preventDefault();
 
-    if (signInNotRequired && (event.target: any).checkValidity()) {
+    if (checkoutFormShouldSubmit(
+      props.contributionType,
+      props.isSignedIn,
+      props.userTypeFromIdentityResponse,
+      event.target,
+    )) {
       formHandlers[props.contributionType][props.paymentMethod](props);
     }
   };

--- a/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -161,11 +161,6 @@ const formHandlers: PaymentMatrix<PropTypes => void> = {
   },
 };
 
-
-// A || B
-
-// !(A || B) = !A && !A
-
 function onSubmit(props: PropTypes): Event => void {
   return (event) => {
     // Causes errors to be displayed against payment fields

--- a/assets/pages/new-contributions-landing/components/ContributionFormFields.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionFormFields.jsx
@@ -30,6 +30,7 @@ import {
   updateEmail,
   updateState,
   checkIfEmailHasPassword,
+  updateFormValue,
 } from '../contributionsLandingActions';
 
 
@@ -69,12 +70,11 @@ const mapStateToProps = (state: State) => ({
   contributionType: state.page.form.contributionType,
 });
 
-
 const mapDispatchToProps = (dispatch: Function) => ({
-  updateFirstName: (event) => { dispatch(updateFirstName(event.target.value)); },
-  updateLastName: (event) => { dispatch(updateLastName(event.target.value)); },
-  updateEmail: (event) => { dispatch(updateEmail(event.target.value)); },
-  updateState: (event) => { dispatch(updateState(event.target.value === '' ? null : event.target.value)); },
+  updateFirstName: (event) => { dispatch(updateFormValue<string>(updateFirstName, event.target.value)); },
+  updateLastName: (event) => { dispatch(updateFormValue<string>(updateLastName, event.target.value)); },
+  updateEmail: (event) => { dispatch(updateFormValue<string>(updateEmail, event.target.value)); },
+  updateState: (event) => { dispatch(updateFormValue<UsState | CaState | null>(updateState, event.target.value === '' ? null : event.target.value)); },
   checkIfEmailHasPassword: (event) => { dispatch(checkIfEmailHasPassword(event.target.value)); },
 });
 

--- a/assets/pages/new-contributions-landing/components/ContributionFormFields.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionFormFields.jsx
@@ -30,7 +30,7 @@ import {
   updateEmail,
   updateState,
   checkIfEmailHasPassword,
-  setStateValueAndTogglePayPal,
+  setValueAndTogglePayPal,
 } from '../contributionsLandingActions';
 
 
@@ -71,10 +71,10 @@ const mapStateToProps = (state: State) => ({
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
-  updateFirstName: (event) => { dispatch(setStateValueAndTogglePayPal<string>(updateFirstName, event.target.value)); },
-  updateLastName: (event) => { dispatch(setStateValueAndTogglePayPal<string>(updateLastName, event.target.value)); },
-  updateEmail: (event) => { dispatch(setStateValueAndTogglePayPal<string>(updateEmail, event.target.value)); },
-  updateState: (event) => { dispatch(setStateValueAndTogglePayPal<UsState | CaState | null>(updateState, event.target.value === '' ? null : event.target.value)); },
+  updateFirstName: (event) => { dispatch(setValueAndTogglePayPal<string>(updateFirstName, event.target.value)); },
+  updateLastName: (event) => { dispatch(setValueAndTogglePayPal<string>(updateLastName, event.target.value)); },
+  updateEmail: (event) => { dispatch(setValueAndTogglePayPal<string>(updateEmail, event.target.value)); },
+  updateState: (event) => { dispatch(setValueAndTogglePayPal<UsState | CaState | null>(updateState, event.target.value === '' ? null : event.target.value)); },
   checkIfEmailHasPassword: (event) => { dispatch(checkIfEmailHasPassword(event.target.value)); },
 });
 

--- a/assets/pages/new-contributions-landing/components/ContributionFormFields.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionFormFields.jsx
@@ -30,7 +30,7 @@ import {
   updateEmail,
   updateState,
   checkIfEmailHasPassword,
-  updateFormValue,
+  setStateValueAndTogglePayPal,
 } from '../contributionsLandingActions';
 
 
@@ -71,10 +71,10 @@ const mapStateToProps = (state: State) => ({
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
-  updateFirstName: (event) => { dispatch(updateFormValue<string>(updateFirstName, event.target.value)); },
-  updateLastName: (event) => { dispatch(updateFormValue<string>(updateLastName, event.target.value)); },
-  updateEmail: (event) => { dispatch(updateFormValue<string>(updateEmail, event.target.value)); },
-  updateState: (event) => { dispatch(updateFormValue<UsState | CaState | null>(updateState, event.target.value === '' ? null : event.target.value)); },
+  updateFirstName: (event) => { dispatch(setStateValueAndTogglePayPal<string>(updateFirstName, event.target.value)); },
+  updateLastName: (event) => { dispatch(setStateValueAndTogglePayPal<string>(updateLastName, event.target.value)); },
+  updateEmail: (event) => { dispatch(setStateValueAndTogglePayPal<string>(updateEmail, event.target.value)); },
+  updateState: (event) => { dispatch(setStateValueAndTogglePayPal<UsState | CaState | null>(updateState, event.target.value === '' ? null : event.target.value)); },
   checkIfEmailHasPassword: (event) => { dispatch(checkIfEmailHasPassword(event.target.value)); },
 });
 

--- a/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
@@ -12,7 +12,7 @@ import { type IsoCurrency, currencies, spokenCurrencies } from 'helpers/internat
 import SvgArrowRight from 'components/svgs/arrowRightStraight';
 import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
 import { hiddenIf } from 'helpers/utilities';
-import { checkoutFormShouldSubmit } from 'helpers/checkoutForm/checkoutForm';
+import { checkoutFormShouldSubmit, getForm } from 'helpers/checkoutForm/checkoutForm';
 import type { UserTypeFromIdentityResponse } from 'helpers/identityApis';
 import { type State } from '../contributionsLandingReducer';
 import { formatAmount } from './ContributionAmount';
@@ -106,7 +106,7 @@ function ContributionSubmit(props: PropTypes) {
                 props.contributionType,
                 props.isSignedIn,
                 props.userTypeFromIdentityResponse,
-                formClassName,
+                getForm(formClassName),
               )
             }
             whenUnableToOpen={() => props.setCheckoutFormHasBeenSubmitted()}

--- a/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
@@ -12,7 +12,7 @@ import { type IsoCurrency, currencies, spokenCurrencies } from 'helpers/internat
 import SvgArrowRight from 'components/svgs/arrowRightStraight';
 import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
 import { hiddenIf } from 'helpers/utilities';
-import { formIsValid } from 'helpers/checkoutForm/checkoutForm';
+import { checkoutFormShouldSubmit, formIsValid } from 'helpers/checkoutForm/checkoutForm';
 import { type State } from '../contributionsLandingReducer';
 import { formatAmount } from './ContributionAmount';
 import { PayPalRecurringButton } from './PayPalRecurringButton';
@@ -96,7 +96,7 @@ function ContributionSubmit(props: PropTypes) {
             csrf={props.csrf}
             currencyId={props.currencyId}
             hasLoaded={props.payPalHasLoaded}
-            canOpen={() => formIsValid(formClassName)}
+            canOpen={() => checkoutFormShouldSubmit(formClassName)}
             whenUnableToOpen={() => props.setCheckoutFormHasBeenSubmitted()}
             formClassName={formClassName}
             isTestUser={props.isTestUser}

--- a/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
@@ -12,7 +12,8 @@ import { type IsoCurrency, currencies, spokenCurrencies } from 'helpers/internat
 import SvgArrowRight from 'components/svgs/arrowRightStraight';
 import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
 import { hiddenIf } from 'helpers/utilities';
-import { checkoutFormShouldSubmit, formIsValid } from 'helpers/checkoutForm/checkoutForm';
+import { checkoutFormShouldSubmit } from 'helpers/checkoutForm/checkoutForm';
+import type { UserTypeFromIdentityResponse } from 'helpers/identityApis';
 import { type State } from '../contributionsLandingReducer';
 import { formatAmount } from './ContributionAmount';
 import { PayPalRecurringButton } from './PayPalRecurringButton';
@@ -38,6 +39,8 @@ type PropTypes = {|
   payPalHasLoaded: boolean,
   isTestUser: boolean,
   onPaymentAuthorisation: PaymentAuthorisation => void,
+  isSignedIn: boolean,
+  userTypeFromIdentityResponse: UserTypeFromIdentityResponse,
 |};
 
 const mapStateToProps = (state: State) =>
@@ -52,6 +55,8 @@ const mapStateToProps = (state: State) =>
     csrf: state.page.csrf,
     payPalHasLoaded: state.page.form.payPalHasLoaded,
     isTestUser: state.page.user.isTestUser,
+    isSignedIn: state.page.user.isSignedIn,
+    userTypeFromIdentityResponse: state.page.form.userTypeFromIdentityResponse,
   });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -96,7 +101,14 @@ function ContributionSubmit(props: PropTypes) {
             csrf={props.csrf}
             currencyId={props.currencyId}
             hasLoaded={props.payPalHasLoaded}
-            canOpen={() => checkoutFormShouldSubmit(formClassName)}
+            canOpen={() =>
+              checkoutFormShouldSubmit(
+                props.contributionType,
+                props.isSignedIn,
+                props.userTypeFromIdentityResponse,
+                formClassName,
+              )
+            }
             whenUnableToOpen={() => props.setCheckoutFormHasBeenSubmitted()}
             formClassName={formClassName}
             isTestUser={props.isTestUser}

--- a/assets/pages/new-contributions-landing/components/MustSignIn.jsx
+++ b/assets/pages/new-contributions-landing/components/MustSignIn.jsx
@@ -41,31 +41,32 @@ export const MustSignIn = (props: PropTypes) => {
     return null;
   }
 
-  if (props.userTypeFromIdentityResponse === 'requestPending') {
-    return (
-      <a className="component-signout" href={buildUrl(props.returnUrl)}>
-        PENDING
-      </a>
-    );
+  switch (props.userTypeFromIdentityResponse) {
+    case 'requestPending':
+      return (
+        <a className="component-signout" href={buildUrl(props.returnUrl)}>
+          PENDING
+        </a>
+      );
+
+    case 'requestFailed':
+      return (
+        <a className="component-signout" href={buildUrl(props.returnUrl)}>
+          FAILED IDENTITY REQUEST
+        </a>
+      );
+
+    case 'current':
+      return (
+        <a className="component-signout" href={buildUrl(props.returnUrl)}>
+          YOU MUST SIGN IN
+        </a>
+      );
+
+    default:
+      return null;
   }
 
-  if (props.userTypeFromIdentityResponse === 'requestFailed') {
-    return (
-      <a className="component-signout" href={buildUrl(props.returnUrl)}>
-        FAILED IDENTITY REQUEST
-      </a>
-    );
-  }
-
-  if (props.userTypeFromIdentityResponse === 'current') {
-    return (
-      <a className="component-signout" href={buildUrl(props.returnUrl)}>
-        YOU MUST SIGN IN
-      </a>
-    );
-  }
-
-  return null;
 };
 
 

--- a/assets/pages/new-contributions-landing/components/MustSignIn.jsx
+++ b/assets/pages/new-contributions-landing/components/MustSignIn.jsx
@@ -6,7 +6,7 @@
 import type { Contrib } from 'helpers/contributions';
 import React from 'react';
 import { getBaseDomain } from 'helpers/url';
-import { type UserTypeFromIdentityResponse } from 'helpers/identityApis';
+import { canContributeWithoutSigningIn, type UserTypeFromIdentityResponse } from 'helpers/identityApis';
 
 // ---- Types ----- //
 
@@ -34,7 +34,10 @@ function buildUrl(returnUrl: ?string): string {
 
 export const MustSignIn = (props: PropTypes) => {
 
-  if (props.contributionType === 'ONE_OFF' || !props.checkoutFormHasBeenSubmitted || props.isSignedIn) {
+  if (
+    canContributeWithoutSigningIn(props.contributionType, props.isSignedIn, props.userTypeFromIdentityResponse)
+    || !props.checkoutFormHasBeenSubmitted
+  ) {
     return null;
   }
 

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -153,30 +153,10 @@ const setUserTypeFromIdentityResponse = (userTypeFromIdentityResponse: UserTypeF
   userTypeFromIdentityResponse,
 });
 
-const togglePayPalButtonAndSetUserTypeFromIdentityResponse = (
-  userTypeFromIdentityResponse: UserTypeFromIdentityResponse
-) =>
+const togglePayPalButton = (userTypeFromIdentityResponse?: UserTypeFromIdentityResponse) =>
   (dispatch: Function, getState: () => State): void => {
     const state = getState();
-    const shouldEnable = checkoutFormShouldSubmit(
-      state.page.form.contributionType,
-      state.page.user.isSignedIn,
-      userTypeFromIdentityResponse,
-      // TODO: use the actual form state rather than re-fetching from DOM
-      'form--contribution',
-    );
-    if (shouldEnable && window.enablePayPalButton) {
-      window.enablePayPalButton();
-    } else if (window.disablePayPalButton) {
-      window.disablePayPalButton();
-    }
-
-    dispatch(setUserTypeFromIdentityResponse(userTypeFromIdentityResponse));
-  };
-
-const togglePayPalButton = (userType: UserTypeFromIdentityResponse) =>
-  (dispatch: Function, getState: () => State): void => {
-    const state = getState();
+    const userType = userTypeFromIdentityResponse || state.page.form.userTypeFromIdentityResponse;
     const shouldEnable = checkoutFormShouldSubmit(
       state.page.form.contributionType,
       state.page.user.isSignedIn,
@@ -185,12 +165,27 @@ const togglePayPalButton = (userType: UserTypeFromIdentityResponse) =>
       'form--contribution',
     );
     if (shouldEnable && window.enablePayPalButton) {
+      console.log("enabling paypal");
       window.enablePayPalButton();
     } else if (window.disablePayPalButton) {
+      console.log("disable paypal");
       window.disablePayPalButton();
     }
   };
 
+const togglePayPalButtonAndSetUserTypeFromIdentityResponse =
+  (userTypeFromIdentityResponse: UserTypeFromIdentityResponse) =>
+    (dispatch: Function): void => {
+      dispatch(togglePayPalButton(userTypeFromIdentityResponse));
+      dispatch(setUserTypeFromIdentityResponse(userTypeFromIdentityResponse));
+    };
+
+function updateFormValue<T>(updateFormValueState: T => Action, value: T) {
+  return (dispatch: Function): void => {
+    dispatch(updateFormValueState(value));
+    dispatch(togglePayPalButton());
+  };
+}
 
 const checkIfEmailHasPassword = (email: string) =>
   (dispatch: Function, getState: () => State): void => {
@@ -455,4 +450,6 @@ export {
   setHasSeenDirectDebitThankYouCopy,
   checkIfEmailHasPassword,
   togglePayPalButtonAndSetUserTypeFromIdentityResponse,
+  togglePayPalButton,
+  updateFormValue,
 };

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -165,10 +165,8 @@ const togglePayPalButton = (userTypeFromIdentityResponse?: UserTypeFromIdentityR
       'form--contribution',
     );
     if (shouldEnable && window.enablePayPalButton) {
-      console.log("enabling paypal");
       window.enablePayPalButton();
     } else if (window.disablePayPalButton) {
-      console.log("disable paypal");
       window.disablePayPalButton();
     }
   };

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -40,7 +40,7 @@ import {
 import { logException } from 'helpers/logger';
 import trackConversion from 'helpers/tracking/conversions';
 import { type UserTypeFromIdentityResponse } from 'helpers/identityApis';
-import { checkoutFormShouldSubmit } from 'helpers/checkoutForm/checkoutForm';
+import { checkoutFormShouldSubmit, getForm } from 'helpers/checkoutForm/checkoutForm';
 import * as cookie from 'helpers/cookie';
 import {
   type State,
@@ -161,7 +161,7 @@ const togglePayPalButton = () =>
       state.page.user.isSignedIn,
       state.page.form.userTypeFromIdentityResponse,
       // TODO: use the actual form state rather than re-fetching from DOM
-      'form--contribution',
+      getForm('form--contribution'),
     );
     if (shouldEnable && window.enablePayPalButton) {
       window.enablePayPalButton();

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -47,7 +47,6 @@ import {
   type UserFormData,
   type ThankYouPageStage,
 } from './contributionsLandingReducer';
-import type { User } from 'helpers/user/userReducer';
 
 export type Action =
   | { type: 'UPDATE_CONTRIBUTION_TYPE', contributionType: Contrib, paymentMethodToSelect: PaymentMethod }
@@ -171,7 +170,7 @@ const togglePayPalButton = () =>
     }
   };
 
-function setStateValueAndTogglePayPal<T>(setStateValue: T => Action, value: T) {
+function setValueAndTogglePayPal<T>(setStateValue: T => Action, value: T) {
   return (dispatch: Function): void => {
     dispatch(setStateValue(value));
     dispatch(togglePayPalButton());
@@ -189,7 +188,7 @@ const checkIfEmailHasPassword = (email: string) =>
       isSignedIn,
       csrf,
       (userType: UserTypeFromIdentityResponse) =>
-        dispatch(setStateValueAndTogglePayPal<UserTypeFromIdentityResponse>(setUserTypeFromIdentityResponse, userType)),
+        dispatch(setValueAndTogglePayPal<UserTypeFromIdentityResponse>(setUserTypeFromIdentityResponse, userType)),
     );
   };
 
@@ -441,5 +440,5 @@ export {
   setHasSeenDirectDebitThankYouCopy,
   checkIfEmailHasPassword,
   togglePayPalButton,
-  setStateValueAndTogglePayPal,
+  setValueAndTogglePayPal,
 };

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -47,6 +47,7 @@ import {
   type UserFormData,
   type ThankYouPageStage,
 } from './contributionsLandingReducer';
+import type { User } from 'helpers/user/userReducer';
 
 export type Action =
   | { type: 'UPDATE_CONTRIBUTION_TYPE', contributionType: Contrib, paymentMethodToSelect: PaymentMethod }
@@ -153,14 +154,13 @@ const setUserTypeFromIdentityResponse = (userTypeFromIdentityResponse: UserTypeF
   userTypeFromIdentityResponse,
 });
 
-const togglePayPalButton = (userTypeFromIdentityResponse?: UserTypeFromIdentityResponse) =>
+const togglePayPalButton = () =>
   (dispatch: Function, getState: () => State): void => {
     const state = getState();
-    const userType = userTypeFromIdentityResponse || state.page.form.userTypeFromIdentityResponse;
     const shouldEnable = checkoutFormShouldSubmit(
       state.page.form.contributionType,
       state.page.user.isSignedIn,
-      userType,
+      state.page.form.userTypeFromIdentityResponse,
       // TODO: use the actual form state rather than re-fetching from DOM
       'form--contribution',
     );
@@ -171,16 +171,9 @@ const togglePayPalButton = (userTypeFromIdentityResponse?: UserTypeFromIdentityR
     }
   };
 
-const togglePayPalButtonAndSetUserTypeFromIdentityResponse =
-  (userTypeFromIdentityResponse: UserTypeFromIdentityResponse) =>
-    (dispatch: Function): void => {
-      dispatch(togglePayPalButton(userTypeFromIdentityResponse));
-      dispatch(setUserTypeFromIdentityResponse(userTypeFromIdentityResponse));
-    };
-
-function updateFormValue<T>(updateFormValueState: T => Action, value: T) {
+function setStateValueAndTogglePayPal<T>(setStateValue: T => Action, value: T) {
   return (dispatch: Function): void => {
-    dispatch(updateFormValueState(value));
+    dispatch(setStateValue(value));
     dispatch(togglePayPalButton());
   };
 }
@@ -196,7 +189,7 @@ const checkIfEmailHasPassword = (email: string) =>
       isSignedIn,
       csrf,
       (userType: UserTypeFromIdentityResponse) =>
-        dispatch(togglePayPalButtonAndSetUserTypeFromIdentityResponse(userType)),
+        dispatch(setStateValueAndTogglePayPal<UserTypeFromIdentityResponse>(setUserTypeFromIdentityResponse, userType)),
     );
   };
 
@@ -447,7 +440,6 @@ export {
   setupRecurringPayPalPayment,
   setHasSeenDirectDebitThankYouCopy,
   checkIfEmailHasPassword,
-  togglePayPalButtonAndSetUserTypeFromIdentityResponse,
   togglePayPalButton,
-  updateFormValue,
+  setStateValueAndTogglePayPal,
 };


### PR DESCRIPTION
## Why are you doing this?
This PR enables/disables the PayPal button according to the validity of form and the type of account belonging to the email address entered by the user. 

There is only one edge case bug _i think_. This is where the user goes from typing a valid email that doesn't have a password, then clicks directly onto the payment button. In this instance, the user has to double click. But this is unexpected behaviour due to the order of the buttons, and is something we are begrudgingly willing to accept.