### PR TITLE
add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+


### PR DESCRIPTION
## Why are you doing this?
IntelliJ's default is to indent js files with 4 spaces. It looks like we've standadised on 2 in the repo, so add .editorconfig to tell the IDE what to use.

More info here - https://editorconfig.org/
