### PR TITLE
Turn off paypal credit

### DIFF
--- a/assets/helpers/paymentIntegrations/newPaymentFlow/payPalRecurringCheckout.js
+++ b/assets/helpers/paymentIntegrations/newPaymentFlow/payPalRecurringCheckout.js
@@ -78,7 +78,13 @@ function getPayPalOptions(
   return {
     env: getPayPalEnvironment(isTestUser),
 
-    style: { color: 'blue', size: 'responsive', label: 'pay' },
+    style: {
+      color: 'blue',
+      size: 'responsive',
+      label: 'pay',
+      layout: 'horizontal',
+      fundingicons: false,
+    },
 
     // Defines whether user sees 'Agree and Continue' or 'Agree and Pay now' in overlay.
     commit: true,
@@ -98,6 +104,10 @@ function getPayPalOptions(
       validateCalled = true;
       toggleButton(actions);
 
+    },
+
+    funding: {
+      disallowed: [window.paypal.FUNDING.CREDIT],
     },
 
     onClick() {

--- a/assets/helpers/paymentIntegrations/payPalExpressCheckout.js
+++ b/assets/helpers/paymentIntegrations/payPalExpressCheckout.js
@@ -116,7 +116,13 @@ function setup(
 
   const payPalOptions: Object = {
     env: window.guardian.payPalEnvironment,
-    style: { color: 'blue', size: 'responsive', label: 'pay' },
+    style: {
+      color: 'blue',
+      size: 'responsive',
+      label: 'pay',
+      layout: 'horizontal',
+      fundingicons: false,
+    },
 
     // Defines whether user sees 'Agree and Continue' or 'Agree and Pay now' in overlay.
     commit: true,
@@ -131,6 +137,10 @@ function setup(
       if (!canOpen()) {
         whenUnableToOpen();
       }
+    },
+
+    funding: {
+      disallowed: [window.paypal.FUNDING.CREDIT],
     },
 
     // This function is called when user clicks the PayPal button.


### PR DESCRIPTION
## Why are you doing this?
Out of the blue and unannounced, the PayPal express checkout button decided to change into 2 buttons, one for normal PayPal and one for PayPal credit. 

So it now looks like this:

| erguh |
|------|
|![image](https://user-images.githubusercontent.com/2844554/47787410-c0dc3780-dd06-11e8-8ca8-cb7227800f0c.png)|

Kindly, their docs have been [updated](https://developer.paypal.com/docs/checkout/how-to/customize-button/#multiple-button-layout) and there is now some config you can set around the multiple button layout. 

For now, we just want what we had before, so we are disabling the CREDIT option. It now looks like this again:

| aaaaah |
|-------|
|![image](https://user-images.githubusercontent.com/2844554/47787467-ef5a1280-dd06-11e8-9213-4b450a4dbbe5.png)|
