### PR TITLE
Populate the email field when requiring sign in

### DIFF
--- a/assets/pages/new-contributions-landing/components/ContributionFormFields.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionFormFields.jsx
@@ -116,6 +116,7 @@ function FormFields(props: PropTypes) {
         userTypeFromIdentityResponse={props.userTypeFromIdentityResponse}
         contributionType={props.contributionType}
         checkoutFormHasBeenSubmitted={props.checkoutFormHasBeenSubmitted}
+        email={props.email}
       />
       <NewContributionTextInput
         id="contributionFirstName"

--- a/assets/pages/new-contributions-landing/components/MustSignIn.jsx
+++ b/assets/pages/new-contributions-landing/components/MustSignIn.jsx
@@ -28,7 +28,7 @@ function buildUrl(email: string): string {
   const encodedReturn = encodeURIComponent(window.location);
   const encodedEmail = encodeURIComponent(email);
 
-  return `https://profile.${getBaseDomain()}/signin?returnUrl=${encodedReturn}&email=${encodedEmail}`;
+  return `https://profile.${getBaseDomain()}/signin/current?returnUrl=${encodedReturn}&email=${encodedEmail}`;
 
 }
 

--- a/assets/pages/new-contributions-landing/components/MustSignIn.jsx
+++ b/assets/pages/new-contributions-landing/components/MustSignIn.jsx
@@ -17,17 +17,17 @@ type PropTypes = {|
   userTypeFromIdentityResponse: UserTypeFromIdentityResponse,
   contributionType: Contrib,
   checkoutFormHasBeenSubmitted: boolean,
+  email: string,
 |};
 
 
 // ----- Functions ----- //
 
 // Build signout URL from given return URL or current location.
-function buildUrl(): string {
-
+function buildUrl(email: string): string {
   const encodedReturn = encodeURIComponent(window.location);
 
-  return `https://profile.${getBaseDomain()}/signin?returnUrl=${encodedReturn}`;
+  return `https://profile.${getBaseDomain()}/signin?returnUrl=${encodedReturn}&email=${email}`;
 
 }
 
@@ -59,7 +59,7 @@ export const MustSignIn = (props: PropTypes) => {
 
     case 'current':
       return (
-        <a className={classNameWithModifiers('form__error', ['sign-in'])} href={buildUrl()}>
+        <a className={classNameWithModifiers('form__error', ['sign-in'])} href={buildUrl(props.email)}>
             You already have a Guardian account. Please <span className="underline">sign in</span> or use another email address.
         </a>
       );

--- a/assets/pages/new-contributions-landing/components/MustSignIn.jsx
+++ b/assets/pages/new-contributions-landing/components/MustSignIn.jsx
@@ -26,8 +26,9 @@ type PropTypes = {|
 // Build signout URL from given return URL or current location.
 function buildUrl(email: string): string {
   const encodedReturn = encodeURIComponent(window.location);
+  const encodedEmail = encodeURIComponent(email);
 
-  return `https://profile.${getBaseDomain()}/signin?returnUrl=${encodedReturn}&email=${email}`;
+  return `https://profile.${getBaseDomain()}/signin?returnUrl=${encodedReturn}&email=${encodedEmail}`;
 
 }
 

--- a/assets/pages/regular-contributions/components/formFields.jsx
+++ b/assets/pages/regular-contributions/components/formFields.jsx
@@ -188,6 +188,7 @@ function NameForm(props: PropTypes) {
               isSignedIn={props.isSignedIn}
               userTypeFromIdentityResponse={props.userTypeFromIdentityResponse}
               checkoutFormHasBeenSubmitted={props.checkoutFormHasBeenSubmitted}
+              email={props.email.value}
             />
           </div>
         ) : null


### PR DESCRIPTION
## Why are you doing this?
Populates the identity frontend form with the email, so that the user doesn't have to type it in again

see https://github.com/guardian/identity-frontend/pull/486/files

## Screenshots
Goes direct to:
![picture 7](https://user-images.githubusercontent.com/1513454/47804977-1710a100-dd2e-11e8-9302-cec06cdec3d6.png)


