### PR TITLE
Fix error message height on mobile

### DIFF
--- a/assets/components/directDebit/directDebitForm/directDebitForm.scss
+++ b/assets/components/directDebit/directDebitForm/directDebitForm.scss
@@ -12,7 +12,7 @@
     background-color: transparent;
     color: gu-colour(error);
     padding: 0;
-    height: 0;
+    height: 60px;
   }
 
   .svg-exclamation-alternate {

--- a/assets/components/errorMessage/errorMessage.scss
+++ b/assets/components/errorMessage/errorMessage.scss
@@ -2,7 +2,7 @@
   position: relative;
   border: none;
   border-radius: 600px;
-  height: 60px;
+  height: 32px;
   padding: 0 $gu-h-spacing;
   color: #fff;
   background-color: gu-colour(error);


### PR DESCRIPTION
## Why are you doing this?

There was a weird bug where the error message height was waaay to big on mobile:

| Before |
|------|
|![image](https://user-images.githubusercontent.com/2844554/47807591-68239380-dd34-11e8-890d-fbc4033969fc.png)|

this fixes it:
|After|
|-----|
|![image](https://user-images.githubusercontent.com/2844554/47807658-8ee1ca00-dd34-11e8-9b7c-14c0faa22d8a.png)|



