### PR TITLE
Implement monitoring for one-off PayPal payments using TiP

### DIFF
--- a/app/controllers/PayPalOneOff.scala
+++ b/app/controllers/PayPalOneOff.scala
@@ -12,9 +12,10 @@ import cats.data.EitherT
 import cats.implicits._
 import monitoring.SafeLogger
 import admin.{Settings, SettingsProvider, SettingsSurrogateKeySyntax}
-
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
+import services.{IdentityService, PaymentAPIService, TestUserService}
+import com.gu.tip.Tip
 
 class PayPalOneOff(
     actionBuilders: CustomActionBuilders,
@@ -23,7 +24,8 @@ class PayPalOneOff(
     components: ControllerComponents,
     paymentAPIService: PaymentAPIService,
     identityService: IdentityService,
-    settingsProvider: SettingsProvider
+    settingsProvider: SettingsProvider,
+    tipMonitoring: Tip
 )(implicit val ec: ExecutionContext) extends AbstractController(components) with Circe with SettingsSurrogateKeySyntax {
 
   import actionBuilders._
@@ -60,14 +62,15 @@ class PayPalOneOff(
 
   def resultFromPaypalSuccess(success: PayPalSuccess, country: Option[String])(implicit request: RequestHeader): Result = {
     SafeLogger.info(s"One-off contribution for Paypal payment is successful")
-
     val redirect = Redirect {
       country match {
         case Some(c) => s"/$c/thankyou.new"
         case None => "/contribute/one-off/thankyou"
       }
     }
-
+    val countryCookie = request.cookies.get("GU_country")
+    val countryFromCookie = countryCookie.map(_.value).getOrElse("Unknown")
+    tipMonitoring.verify(s"${country.getOrElse(countryFromCookie)} One-off PayPal contribution")
     success.email.fold({
       SafeLogger.info("Redirecting to thank you page without email in flash session")
       redirect

--- a/app/monitoring/Tip.scala
+++ b/app/monitoring/Tip.scala
@@ -1,7 +1,7 @@
 package monitoring
 
 import app.BuildInfo
-import com.gu.support.config.Stages.DEV
+import com.gu.support.config.Stages.PROD
 import com.gu.tip.{Tip, TipConfig, TipFactory}
 import config.Configuration
 
@@ -15,7 +15,7 @@ object TipFromConfig {
       boardSha = BuildInfo.gitCommitId
     )
 
-    if (config.stage == DEV) //todo - verify this works correctly
+    if (config.stage == PROD)
       TipFactory.create(tipConfig)
     else
       TipFactory.createDummy(tipConfig)

--- a/app/monitoring/Tip.scala
+++ b/app/monitoring/Tip.scala
@@ -1,0 +1,24 @@
+package monitoring
+
+import app.BuildInfo
+import com.gu.support.config.Stages.DEV
+import com.gu.tip.{Tip, TipConfig, TipFactory}
+import config.Configuration
+
+object TipFromConfig {
+
+  def apply(config: Configuration): Tip = {
+
+    val tipConfig = TipConfig(
+      repo = "guardian/support-frontend",
+      cloudEnabled = true,
+      boardSha = BuildInfo.gitCommitId
+    )
+
+    if (config.stage == DEV) //todo - verify this works correctly
+      TipFactory.create(tipConfig)
+    else
+      TipFactory.createDummy(tipConfig)
+  }
+
+}

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -20,7 +20,8 @@ trait AppComponents extends PlayComponents
   with ActionBuilders
   with Assets
   with GoogleAuth
-  with HttpFiltersComponents {
+  with HttpFiltersComponents
+  with Monitoring {
   self: BuiltInComponentsFromContext =>
 
   override lazy val httpErrorHandler = new CustomHttpErrorHandler(

--- a/app/wiring/Controllers.scala
+++ b/app/wiring/Controllers.scala
@@ -4,7 +4,7 @@ import controllers._
 import play.api.BuiltInComponentsFromContext
 
 trait Controllers {
-  self: AssetsComponents with Services with BuiltInComponentsFromContext with ApplicationConfiguration with ActionBuilders with Assets with GoogleAuth =>
+  self: AssetsComponents with Services with BuiltInComponentsFromContext with ApplicationConfiguration with ActionBuilders with Assets with GoogleAuth with Monitoring =>
 
   lazy val assetController = new controllers.Assets(httpErrorHandler, assetsMetadata)
 
@@ -60,7 +60,8 @@ trait Controllers {
     controllerComponents,
     paymentAPIService,
     identityService,
-    settingsProvider
+    settingsProvider,
+    tipMonitoring
   )
 
   lazy val oneOffContributions = new OneOffContributions(

--- a/app/wiring/Controllers.scala
+++ b/app/wiring/Controllers.scala
@@ -4,7 +4,10 @@ import controllers._
 import play.api.BuiltInComponentsFromContext
 
 trait Controllers {
+
+  // scalastyle:off
   self: AssetsComponents with Services with BuiltInComponentsFromContext with ApplicationConfiguration with ActionBuilders with Assets with GoogleAuth with Monitoring =>
+  // scalastyle:on
 
   lazy val assetController = new controllers.Assets(httpErrorHandler, assetsMetadata)
 

--- a/app/wiring/Monitoring.scala
+++ b/app/wiring/Monitoring.scala
@@ -1,0 +1,13 @@
+package wiring
+
+import com.gu.tip.Tip
+import monitoring.TipFromConfig
+import play.api.BuiltInComponentsFromContext
+
+trait Monitoring {
+
+  self: BuiltInComponentsFromContext with ApplicationConfiguration =>
+
+  lazy val tipMonitoring: Tip = TipFromConfig(appConfig)
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -83,6 +83,7 @@ libraryDependencies ++= Seq(
   "org.seleniumhq.selenium" % "selenium-java" % "3.8.1" % "test",
   "com.squareup.okhttp3" % "okhttp" % "3.9.0",
   "com.gocardless" % "gocardless-pro" % "2.8.0",
+  "com.gu" %% "tip" % "0.5.1",
   // This is required to force aws libraries to use the latest version of jackson
   "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.7",
   "com.fasterxml.jackson.core" % "jackson-annotations" % "2.9.7",

--- a/conf/tip.yaml
+++ b/conf/tip.yaml
@@ -1,0 +1,8 @@
+- name: US One-off PayPal contribution
+  description: Successful one-off contribution in USD (using PayPal)
+
+- name: GB One-off PayPal contribution
+  description: Successful one-off contribution in GBP (using PayPal)
+
+- name: AU One-off PayPal contribution
+  description: Successful one-off contribution in AUD (using PayPal)


### PR DESCRIPTION
## Why are you doing this?

This PR adds production monitoring for one-off contributions, using the [TiP library](https://github.com/guardian/tip#testing-in-production-tip---). As a first pass (to see if this is useful), I've only implemented this for one-off PayPal contributions. 

After each deploy, a dashboard is automatically generated. This dashboard is updated (based on real user behaviour) to show which critical journeys have been completed:

![image](https://user-images.githubusercontent.com/19384074/47844727-0e19e100-ddbb-11e8-91d7-2988dd725140.png)

Obviously this dashboard looks a bit sparse when we're only tracking 3 events, but hopefully it provides a reasonable demonstration of how this would work for us.

Thanks to @michaelwmcnamara, who spiked adding this library here: https://github.com/guardian/support-frontend/pull/1004. This PR is largely based on his work.

## Changes

* Add TiP library, basic configuration and wiring
* Track successful one-off PayPal journeys