### PR TITLE
Populate email field if sign-in required from old payment flow

### DIFF
--- a/assets/pages/regular-contributions/components/mustSignIn.jsx
+++ b/assets/pages/regular-contributions/components/mustSignIn.jsx
@@ -17,17 +17,19 @@ type PropTypes = {|
   userTypeFromIdentityResponse: UserTypeFromIdentityResponse,
   contributionType: Contrib,
   checkoutFormHasBeenSubmitted: boolean,
+  email: string,
 |};
 
 
 // ----- Functions ----- //
 
 // Build signout URL from given return URL or current location.
-function buildUrl(): string {
+function buildUrl(email: string): string {
 
   const encodedReturn = encodeURIComponent(window.location);
+  const encodedEmail = encodeURIComponent(email);
 
-  return `https://profile.${getBaseDomain()}/signin?returnUrl=${encodedReturn}`;
+  return `https://profile.${getBaseDomain()}/signin/current?returnUrl=${encodedReturn}&email=${encodedEmail}`;
 
 }
 
@@ -59,7 +61,7 @@ export const MustSignIn = (props: PropTypes) => {
 
     case 'current':
       return (
-        <a href={buildUrl()}>
+        <a href={buildUrl(props.email)}>
           <div className={classNameWithModifiers('component-error-message', ['sign-in'])}>
             <div>
               You already have a Guardian account.


### PR DESCRIPTION
## Why are you doing this?
If a user needs to sign in from the old payment flow, populate the email field to save them from having to type it in again

## Screenshots
Goes direct to:
![picture 9](https://user-images.githubusercontent.com/1513454/47849912-42959900-ddcb-11e8-9718-ab85c9333bb1.png)

