### PR TITLE
Do not set cookie if test switched off

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -106,7 +106,8 @@ class Application(
     implicit val gd: GuardianDomain = guardianDomain
 
     val experiments = settings.switches.experiments
-    if (experiments.get("newPaymentFlow").exists(_.isInVariant(participation))) {
+    val npf = experiments.get("newPaymentFlow")
+    if (npf.exists(_.isInVariant(participation))) {
       SafeLogger.info("SERVENEW: Serving new contribution landing page")
       request.user.traverse[Attempt, IdUser](identityService.getUser(_)).fold(
         err => {
@@ -115,9 +116,11 @@ class Application(
         },
         user => Ok(newContributions(countryCode, user))
       ).map(result => result.withSettingsSurrogateKey.withServersideAbTestCookie)
-    } else {
+    } else if (npf.exists(_.isInControl(participation))) {
       SafeLogger.info("SERVEOLD: Serving old contributions landing page")
       Future(Ok(oldContributions(countryCode)).withSettingsSurrogateKey.withServersideAbTestCookie)
+    } else {
+      Future(Ok(oldContributions(countryCode)).withSettingsSurrogateKey)
     }
   }
 

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -106,7 +106,7 @@ class Application(
     implicit val gd: GuardianDomain = guardianDomain
 
     val experiments = settings.switches.experiments
-    val npf = experiments.get("newPaymentFlow")
+    val npf = experiments.get("newFlow")
     if (npf.exists(_.isInVariant(participation))) {
       SafeLogger.info("SERVENEW: Serving new contribution landing page")
       request.user.traverse[Attempt, IdUser](identityService.getUser(_)).fold(

--- a/assets/helpers/__tests__/checkoutsTest.js
+++ b/assets/helpers/__tests__/checkoutsTest.js
@@ -21,6 +21,7 @@ describe('checkouts', () => {
         payPal: 'On',
         directDebit: 'On',
       },
+      experiments: {},
     };
 
     const allSwitchesOff = {
@@ -33,6 +34,7 @@ describe('checkouts', () => {
         payPal: 'Off',
         directDebit: 'Off',
       },
+      experiments: {},
     };
 
     it('should return correct values for Monthly Recurring UK when switches are all on', () => {

--- a/assets/helpers/abTests/__tests__/abtestTest.js
+++ b/assets/helpers/abTests/__tests__/abtestTest.js
@@ -2,6 +2,7 @@
 
 // ----- Imports ----- //
 
+import type { Settings } from 'helpers/settings';
 import { getVariantsAsString, init as abInit } from '../abtest';
 import type { Participations } from '../abtest';
 
@@ -11,6 +12,9 @@ jest.mock('ophan', () => ({
 
 // ----- Tests ----- //
 
+const emptySettings: Settings = {
+  switches: { experiments: {} },
+};
 
 describe('basic behaviour of init', () => {
 
@@ -38,7 +42,7 @@ describe('basic behaviour of init', () => {
     };
 
     const country = 'GB';
-    const participations: Participations = abInit(country, 'GBPCountries', tests);
+    const participations: Participations = abInit(country, 'GBPCountries', emptySettings, tests);
     const expectedParticipations: Participations = { mockTest: 'control' };
 
     expect(participations).toEqual(expectedParticipations);
@@ -64,7 +68,7 @@ describe('basic behaviour of init', () => {
     };
 
     const country = 'GB';
-    const participations: Participations = abInit(country, 'GBPCountries', tests);
+    const participations: Participations = abInit(country, 'GBPCountries', emptySettings, tests);
     const expectedParticipations: Participations = { mockTest: 'variant' };
 
     expect(participations).toEqual(expectedParticipations);
@@ -91,7 +95,7 @@ describe('basic behaviour of init', () => {
 
     const country = 'GB';
     const countryGroupId = 'GBPCountries';
-    const participations: Participations = abInit(country, countryGroupId, tests);
+    const participations: Participations = abInit(country, countryGroupId, emptySettings, tests);
     const expectedParticipations: Participations = { mockTest: 'variant' };
 
     expect(participations).toEqual(expectedParticipations);
@@ -118,7 +122,7 @@ describe('basic behaviour of init', () => {
 
     const country = 'US';
     const countryGroupId = 'UnitedStates';
-    const participations: Participations = abInit(country, countryGroupId, tests);
+    const participations: Participations = abInit(country, countryGroupId, emptySettings, tests);
     const expectedParticipations: Participations = { mockTest: 'notintest' };
 
     expect(participations).toEqual(expectedParticipations);
@@ -148,7 +152,7 @@ describe('basic behaviour of init', () => {
 
     const country = 'US';
     const countryGroupId = 'UnitedStates';
-    const participations: Participations = abInit(country, countryGroupId, tests);
+    const participations: Participations = abInit(country, countryGroupId, emptySettings, tests);
     const expectedParticipations: Participations = { mockTest: 'notintest' };
     const expectedMediaQuery = '(min-width:740px) and (max-width:980px)';
 
@@ -180,7 +184,7 @@ describe('basic behaviour of init', () => {
 
     const country = 'US';
     const countryGroupId = 'UnitedStates';
-    const participations: Participations = abInit(country, countryGroupId, tests);
+    const participations: Participations = abInit(country, countryGroupId, emptySettings, tests);
     const expectedParticipations: Participations = { mockTest: 'notintest' };
     const expectedMediaQuery = '(min-width:740px)';
 
@@ -213,7 +217,7 @@ describe('basic behaviour of init', () => {
 
     const country = 'US';
     const countryGroupId = 'UnitedStates';
-    const participations: Participations = abInit(country, countryGroupId, tests);
+    const participations: Participations = abInit(country, countryGroupId, emptySettings, tests);
     const expectedParticipations: Participations = { mockTest: 'notintest' };
     const expectedMediaQuery = '(min-width:740px)';
 
@@ -245,7 +249,7 @@ describe('basic behaviour of init', () => {
 
     const country = 'US';
     const countryGroupId = 'UnitedStates';
-    const participations: Participations = abInit(country, countryGroupId, tests);
+    const participations: Participations = abInit(country, countryGroupId, emptySettings, tests);
     const expectedParticipations: Participations = { mockTest: 'notintest' };
     const expectedMediaQuery = '(max-width:740px)';
 
@@ -274,7 +278,7 @@ describe('basic behaviour of init', () => {
 
     const country = 'GI';
     const countryGroupId = 'GBPCountries';
-    const participations: Participations = abInit(country, countryGroupId, tests);
+    const participations: Participations = abInit(country, countryGroupId, emptySettings, tests);
     const expectedParticipations: Participations = { mockTest: 'control' };
 
     expect(participations).toEqual(expectedParticipations);
@@ -305,7 +309,7 @@ describe('basic behaviour of init', () => {
 
     const country = 'US';
     const countryGroupId = 'UnitedStates';
-    const participations: Participations = abInit(country, countryGroupId, tests);
+    const participations: Participations = abInit(country, countryGroupId, emptySettings, tests);
     const expectedParticipations: Participations = { mockTest: 'notintest' };
     const expectedMediaQuery = '(min-width:740px)';
 
@@ -342,7 +346,7 @@ describe('basic behaviour of init', () => {
 
     const country = 'GB';
     const countryGroupId = 'GBPCountries';
-    const participations: Participations = abInit(country, countryGroupId, tests);
+    const participations: Participations = abInit(country, countryGroupId, emptySettings, tests);
     const expectedParticipations: Participations = { mockTest: 'notintest' };
 
     expect(participations).toEqual(expectedParticipations);
@@ -414,7 +418,7 @@ describe('Correct allocation in a multi test environment', () => {
     document.cookie = 'GU_mvt_id=810000';
     const country = 'GB';
     const countryGroupId = 'GBPCountries';
-    const participations: Participations = abInit(country, countryGroupId, tests);
+    const participations: Participations = abInit(country, countryGroupId, emptySettings, tests);
     const expectedParticipations: Participations = { mockTest: 'control', mockTest2: 'notintest', mockTest3: 'notintest' };
     expect(participations).toEqual(expectedParticipations);
   });
@@ -424,7 +428,7 @@ describe('Correct allocation in a multi test environment', () => {
     document.cookie = 'GU_mvt_id=810000';
     const country = 'US';
     const countryGroupId = 'GBPCountries';
-    const participations: Participations = abInit(country, countryGroupId, tests);
+    const participations: Participations = abInit(country, countryGroupId, emptySettings, tests);
     const expectedParticipations: Participations = { mockTest: 'notintest', mockTest2: 'notintest', mockTest3: 'notintest' };
     expect(participations).toEqual(expectedParticipations);
   });
@@ -434,12 +438,12 @@ describe('Correct allocation in a multi test environment', () => {
     document.cookie = 'GU_mvt_id=510000';
     const country = 'GB';
     const countryGroupId = 'GBPCountries';
-    let participations: Participations = abInit(country, countryGroupId, tests);
+    let participations: Participations = abInit(country, countryGroupId, emptySettings, tests);
     let expectedParticipations: Participations = { mockTest: 'control', mockTest2: 'notintest', mockTest3: 'notintest' };
     expect(participations).toEqual(expectedParticipations);
 
     document.cookie = 'GU_mvt_id=510001';
-    participations = abInit(country, countryGroupId, tests);
+    participations = abInit(country, countryGroupId, emptySettings, tests);
     expectedParticipations = { mockTest: 'variant', mockTest2: 'notintest', mockTest3: 'notintest' };
     expect(participations).toEqual(expectedParticipations);
   });
@@ -449,12 +453,12 @@ describe('Correct allocation in a multi test environment', () => {
     document.cookie = 'GU_mvt_id=510000';
     const country = 'US';
     const countryGroupId = 'UnitedStates';
-    let participations: Participations = abInit(country, countryGroupId, tests);
+    let participations: Participations = abInit(country, countryGroupId, emptySettings, tests);
     let expectedParticipations: Participations = { mockTest: 'notintest', mockTest2: 'control', mockTest3: 'notintest' };
     expect(participations).toEqual(expectedParticipations);
 
     document.cookie = 'GU_mvt_id=510001';
-    participations = abInit(country, countryGroupId, tests);
+    participations = abInit(country, countryGroupId, emptySettings, tests);
     expectedParticipations = { mockTest: 'notintest', mockTest2: 'variant', mockTest3: 'notintest' };
     expect(participations).toEqual(expectedParticipations);
     expect(getVariantsAsString(participations)).toEqual('mockTest=notintest; mockTest2=variant; mockTest3=notintest');
@@ -466,12 +470,12 @@ describe('Correct allocation in a multi test environment', () => {
     const country = 'GB';
     const countryGroupId = 'GBPCountries';
 
-    let participations: Participations = abInit(country, countryGroupId, tests);
+    let participations: Participations = abInit(country, countryGroupId, emptySettings, tests);
     let expectedParticipations: Participations = { mockTest: 'control', mockTest2: 'notintest', mockTest3: 'notintest' };
     expect(participations).toEqual(expectedParticipations);
 
     document.cookie = 'GU_mvt_id=150001';
-    participations = abInit(country, countryGroupId, tests);
+    participations = abInit(country, countryGroupId, emptySettings, tests);
     expectedParticipations = { mockTest: 'variant', mockTest2: 'notintest', mockTest3: 'notintest' };
     expect(participations).toEqual(expectedParticipations);
   });
@@ -482,12 +486,12 @@ describe('Correct allocation in a multi test environment', () => {
     const country = 'US';
     const countryGroupId = 'UnitedStates';
 
-    let participations: Participations = abInit(country, countryGroupId, tests);
+    let participations: Participations = abInit(country, countryGroupId, emptySettings, tests);
     let expectedParticipations: Participations = { mockTest: 'control', mockTest2: 'notintest', mockTest3: 'notintest' };
     expect(participations).toEqual(expectedParticipations);
 
     document.cookie = 'GU_mvt_id=150001';
-    participations = abInit(country, 'GBPCountries', tests);
+    participations = abInit(country, 'GBPCountries', emptySettings, tests);
     expectedParticipations = { mockTest: 'variant', mockTest2: 'notintest', mockTest3: 'notintest' };
     expect(participations).toEqual(expectedParticipations);
   });

--- a/assets/helpers/abTests/abtest.js
+++ b/assets/helpers/abTests/abtest.js
@@ -13,6 +13,7 @@ import type { Settings } from 'helpers/settings';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 import { tests, type NewFlowTestVariant } from './abtestDefinitions';
+import { isTestSwitchedOn } from 'helpers/settings';
 
 
 // ----- Types ----- //
@@ -232,8 +233,7 @@ const trackABOphan = (participations: Participations, complete: boolean): void =
 
 const getNewPaymentFlowTestParticipation = (settings: Settings): ?Participations => {
   const npfVariant = cookie.get('gu.serverside.ab.test');
-  const { newPaymentFlow: serverSideTest } = settings.switches.experiments;
-  if (serverSideTest.state === 'On' && npfVariant) {
+  if (isTestSwitchedOn(settings, 'newFlow') && npfVariant) {
     const variant: NewFlowTestVariant = npfVariant === 'Variant' ? 'newFlow' : 'control';
     return { newFlow: variant };
   }

--- a/assets/helpers/abTests/abtest.js
+++ b/assets/helpers/abTests/abtest.js
@@ -230,7 +230,7 @@ const trackABOphan = (participations: Participations, complete: boolean): void =
   });
 };
 
-const getNewPaymentFlowTestParticipation = (settings: Settings): ?Participations => {
+const getNewFlowTestParticipation = (settings: Settings): ?Participations => {
   const npfVariant = cookie.get('gu.serverside.ab.test');
   if (isTestSwitchedOn(settings, 'newFlow') && npfVariant) {
     const variant: NewFlowTestVariant = npfVariant === 'Variant' ? 'newFlow' : 'control';
@@ -247,11 +247,11 @@ const init = (
   abTests: Tests = tests,
 ): Participations => {
   // this is to assign the correct variant while npf server side test runs
-  const newPaymentFlowParticipation: ?Participations = getNewPaymentFlowTestParticipation(settings);
+  const newFlowTestParticipation: ?Participations = getNewFlowTestParticipation(settings);
 
   const mvt: number = getMvtId();
   const participations: Participations = getParticipations(abTests, mvt, country, countryGroupId);
-  const participationsWithServerSideNPFVariant = { ...participations, ...newPaymentFlowParticipation };
+  const participationsWithServerSideNPFVariant = { ...participations, ...newFlowTestParticipation };
   const urlParticipations: ?Participations = getParticipationsFromUrl();
   setLocalStorageParticipations(Object.assign({}, participationsWithServerSideNPFVariant, urlParticipations));
   trackABOphan(participationsWithServerSideNPFVariant, false);

--- a/assets/helpers/abTests/abtest.js
+++ b/assets/helpers/abTests/abtest.js
@@ -12,7 +12,7 @@ import * as storage from 'helpers/storage';
 import { type Settings, isTestSwitchedOn } from 'helpers/settings';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
-import { tests, type NewFlowTestVariant } from './abtestDefinitions';
+import { tests } from './abtestDefinitions';
 
 
 // ----- Types ----- //
@@ -233,7 +233,7 @@ const trackABOphan = (participations: Participations, complete: boolean): void =
 const getNewFlowTestParticipation = (settings: Settings): ?Participations => {
   const npfVariant = cookie.get('gu.serverside.ab.test');
   if (isTestSwitchedOn(settings, 'newFlow') && npfVariant) {
-    const variant: NewFlowTestVariant = npfVariant === 'Variant' ? 'newFlow' : 'control';
+    const variant = npfVariant === 'Variant' ? 'newFlow' : 'control';
     return { newFlow: variant };
   }
 

--- a/assets/helpers/abTests/abtest.js
+++ b/assets/helpers/abTests/abtest.js
@@ -9,8 +9,8 @@ import seedrandom from 'seedrandom';
 import * as ophan from 'ophan';
 import * as cookie from 'helpers/cookie';
 import * as storage from 'helpers/storage';
-import type { Settings, isTestSwitchedOn } from 'helpers/settings';
-import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { type Settings, isTestSwitchedOn } from 'helpers/settings';
+import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 import { tests, type NewFlowTestVariant } from './abtestDefinitions';
 

--- a/assets/helpers/abTests/abtest.js
+++ b/assets/helpers/abTests/abtest.js
@@ -233,7 +233,7 @@ const trackABOphan = (participations: Participations, complete: boolean): void =
 const getNewPaymentFlowTestParticipation = (settings: Settings): ?Participations => {
   const npfVariant = cookie.get('gu.serverside.ab.test');
   const { newPaymentFlow: serverSideTest } = settings.switches.experiments;
-  if (serverSideTest === 'On' && npfVariant) {
+  if (serverSideTest.state === 'On' && npfVariant) {
     const variant: NewFlowTestVariant = npfVariant === 'Variant' ? 'newFlow' : 'control';
     return { newFlow: variant };
   }

--- a/assets/helpers/abTests/abtest.js
+++ b/assets/helpers/abTests/abtest.js
@@ -9,11 +9,10 @@ import seedrandom from 'seedrandom';
 import * as ophan from 'ophan';
 import * as cookie from 'helpers/cookie';
 import * as storage from 'helpers/storage';
-import type { Settings } from 'helpers/settings';
+import type { Settings, isTestSwitchedOn } from 'helpers/settings';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 import { tests, type NewFlowTestVariant } from './abtestDefinitions';
-import { isTestSwitchedOn } from 'helpers/settings';
 
 
 // ----- Types ----- //

--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -4,7 +4,7 @@ import type { Tests } from './abtest';
 // ----- Tests ----- //
 
 export type AnnualContributionsTestVariant = 'control' | 'annualAmountsA' | 'notintest';
-export type NewPaymentFlowTestVariant = 'control' | 'newPaymentFlow';
+export type NewFlowTestVariant = 'control' | 'newFlow';
 
 export const tests: Tests = {
   annualContributionsRoundThree: {
@@ -18,17 +18,5 @@ export const tests: Tests = {
     isActive: true,
     independent: true,
     seed: 3,
-  },
-  newPaymentFlow: {
-    variants: ['control', 'newPaymentFlow'],
-    audiences: {
-      ALL: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: false,
-    independent: true,
-    seed: 5,
   },
 };

--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -4,7 +4,6 @@ import type { Tests } from './abtest';
 // ----- Tests ----- //
 
 export type AnnualContributionsTestVariant = 'control' | 'annualAmountsA' | 'notintest';
-export type NewFlowTestVariant = 'control' | 'newFlow';
 
 export const tests: Tests = {
   annualContributionsRoundThree: {

--- a/assets/helpers/page/__tests__/__snapshots__/pageTest.js.snap
+++ b/assets/helpers/page/__tests__/__snapshots__/pageTest.js.snap
@@ -29,7 +29,9 @@ Object {
     "source": null,
   },
   "settings": Object {
-    "switches": Object {},
+    "switches": Object {
+      "experiments": Object {},
+    },
   },
 }
 `;

--- a/assets/helpers/page/__tests__/pageTest.js
+++ b/assets/helpers/page/__tests__/pageTest.js
@@ -34,7 +34,9 @@ describe('reducer tests', () => {
       abParticipations: {},
       otherQueryParams: [],
       settings: {
-        switches: {},
+        switches: {
+          experiments: {},
+        },
       },
       optimizeExperiments: {},
     };

--- a/assets/helpers/page/page.js
+++ b/assets/helpers/page/page.js
@@ -136,7 +136,7 @@ function createCommonReducer(initialState: CommonState): (state?: CommonState, a
 function statelessInit() {
   const country: IsoCountry = detectCountry();
   const countryGroupId: CountryGroupId = detectCountryGroup();
-  const participations: Participations = abTest.init(country, countryGroupId);
+  const participations: Participations = abTest.init(country, countryGroupId, window.guardian.settings);
   analyticsInitialisation(participations);
 }
 
@@ -162,11 +162,11 @@ function init<S, A>(
   thunk?: boolean = false,
 ): Store<*, *, *> {
 
+  const { settings } = window.guardian;
   const countryGroupId: CountryGroupId = detectCountryGroup();
   const countryId: IsoCountry = detectCountry();
   const currencyId: IsoCurrency = detectCurrency(countryGroupId);
-  const participations: Participations = abTest.init(countryId, countryGroupId);
-  const { settings } = window.guardian;
+  const participations: Participations = abTest.init(countryId, countryGroupId, settings);
   analyticsInitialisation(participations);
 
   const initialState: CommonState = buildInitialState(

--- a/assets/helpers/settings.js
+++ b/assets/helpers/settings.js
@@ -8,8 +8,15 @@ export type SwitchObject = {
 
 export type Switches = {
   [string]: SwitchObject,
+  experiments: {
+    [string]: {
+      name: string,
+      description: string,
+      state: Status,
+    }
+  }
 };
 
 export type Settings = {
-  switches: Switches
+  switches: Switches,
 };

--- a/assets/helpers/settings.js
+++ b/assets/helpers/settings.js
@@ -21,8 +21,8 @@ export type Settings = {
   switches: Switches,
 };
 
-export function isTestSwitchedOn(settings: Settings, testName: string) {
+export function isTestSwitchedOn(settings: Settings, testName: string): boolean {
   const { experiments } = settings.switches;
   const test = experiments[testName];
-  return test && test.state && test.state === 'On';
+  return !!(test && test.state && test.state === 'On');
 }

--- a/assets/helpers/settings.js
+++ b/assets/helpers/settings.js
@@ -20,3 +20,9 @@ export type Switches = {
 export type Settings = {
   switches: Switches,
 };
+
+export function isTestSwitchedOn(settings: Settings, testName: string) {
+  const { experiments } = settings.switches;
+  const test = experiments[testName];
+  return test && test.state && test.state === 'On';
+}

--- a/conf/DEV.public.conf
+++ b/conf/DEV.public.conf
@@ -25,4 +25,4 @@ settingsSource.s3 {
 }
 
 # Uncomment the line below if you want to override admin settings locally
-settingsSource.local.path="~/.gu/support-frontend-admin-console/settings.json"
+# settingsSource.local.path="~/.gu/support-frontend-admin-console/settings.json"

--- a/conf/DEV.public.conf
+++ b/conf/DEV.public.conf
@@ -25,4 +25,4 @@ settingsSource.s3 {
 }
 
 # Uncomment the line below if you want to override admin settings locally
-# settingsSource.local.path="~/.gu/support-frontend-admin-console/settings.json"
+settingsSource.local.path="~/.gu/support-frontend-admin-console/settings.json"

--- a/test/codecs/CirceDecodersTest.scala
+++ b/test/codecs/CirceDecodersTest.scala
@@ -198,10 +198,9 @@ class CirceDecodersTest extends WordSpec with MustMatchers {
           |      "directDebit": "On"
           |    },
           |    "experiments": {
-          |      "newPaymentFlow": {
-          |        "name": "newPaymentFlow",
+          |      "newFlow": {
+          |        "name": "newFlow",
           |        "description": "Redesign of the payment flow UI",
-          |        "segment": "Perc0",
           |        "state": "On"
           |      }
           |    },
@@ -223,8 +222,8 @@ class CirceDecodersTest extends WordSpec with MustMatchers {
             directDebit = Some(On)
           ),
           experiments = Map(
-            "newPaymentFlow" -> ExperimentSwitch(
-              name = "newPaymentFlow",
+            "newFlow" -> ExperimentSwitch(
+              name = "newFlow",
               description = "Redesign of the payment flow UI",
               state = On
             )


### PR DESCRIPTION
Fixes a bug whereby even if the serverside test was switched off in `settings.json`, the server would still set a cookie and the client would still set an A/B test participations (although thankfully it only ever served the existing page!).

So I've
- renamed the test from  `newPaymentFlow` -> `newFlow` so we don't get derailed by the dud data we've been pumping in for a few days
- removed the `newFlow` test from `abtestDefinitions.js` because this was misleading (none of the settings in there, not even `isActive`, actually had any effect on test since this was all determined serverside)
- made sure the client takes account of the serverside switch when figuring out A/B test participation
- made sure the server only drops a cookie if the test switch is on