### PR TITLE
NCF: Make input focus ring persist on hover

### DIFF
--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -733,7 +733,7 @@ form {
   color: gu-colour(media-garnett-main-1);
 }
 
-.form__input:focus {
+.form__input:enabled:focus {
   box-shadow: 0 0 0 3px gu-colour(sport-garnett-media-main-1);
   outline: none;
 }


### PR DESCRIPTION
## Why are you doing this?

The input fields in the NCF weren't getting their blue focus state until the mouse was outside of them, which I suspect is a bug and in my criteria looked a bit confusing and took away a lot of the satisfaction of clicking down on the input field.

Luckily the [components cheatsheet](https://interactive.guim.co.uk/embed/article-embeds/HiZef/embed.html) keeps the bright focus ring on hover too, so I can just change the ncf behaviour to match the cheatsheet and be happy about it! 😸 

## Screenshots
![2018-11-01 2_43_39 pm](https://user-images.githubusercontent.com/11539094/47858804-bf813c80-dde4-11e8-8135-323ef4519634.gif)

