### PR TITLE
Temporarily ignore recurring selenium tests

### DIFF
--- a/test/selenium/RecurringContributionsSpec.scala
+++ b/test/selenium/RecurringContributionsSpec.scala
@@ -20,7 +20,7 @@ class RecurringContributionsSpec extends FeatureSpec with GivenWhenThen with Bef
 
   feature("Sign up for a Monthly Contribution") {
 
-    scenario("Monthly contribution sign-up with Stripe - GBP") {
+    ignore("Monthly contribution sign-up with Stripe - GBP") {
 
       val landingPage = ContributionsLanding("uk")
       val recurringContributionForm = new RecurringContributionForm
@@ -69,7 +69,7 @@ class RecurringContributionsSpec extends FeatureSpec with GivenWhenThen with Bef
 
     }
 
-    scenario("Monthly contribution sign-up with PayPal - USD") {
+    ignore("Monthly contribution sign-up with PayPal - USD") {
 
       val expectedPayment = "15.00"
 


### PR DESCRIPTION
## Why are you doing this?
The selenium tests aren't set up to deal with the guest checkout flow, which has just gone out. Until we fix the tests, we want to ignore them. You can still manually follow the same process that the selenium tests would follow, by hitting [support.theguardian.com/test-users](https://support.theguardian.com/test-users) and using the email address it gives you when completing the flow. 