### PR TITLE
Add click events since conversions aren't working on new flow

### DIFF
--- a/assets/helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis.js
+++ b/assets/helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis.js
@@ -152,9 +152,7 @@ function checkRegularStatus(
         return logPromise(pollUntilPromise(
           MAX_POLLS,
           POLLING_INTERVAL,
-          () => {
-            return fetchJson(json.trackingUri, getRequestOptions('same-origin', csrf));
-          },
+          () => fetchJson(json.trackingUri, getRequestOptions('same-origin', csrf)),
           json2 => json2.status === 'pending',
         ).then(handleCompletion, handleExhaustedPolls));
 

--- a/assets/helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis.js
+++ b/assets/helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis.js
@@ -13,10 +13,9 @@ import { type CaState, type IsoCountry, type UsState } from 'helpers/internation
 import { logPromise, pollUntilPromise } from 'helpers/promise';
 import { logException } from 'helpers/logger';
 import { fetchJson, getRequestOptions, requestOptions } from 'helpers/fetch';
-import trackConversion from 'helpers/tracking/conversions';
+import { trackComponentClick } from 'helpers/tracking/ophanComponentEventTracking';
 
 import { type ThankYouPageStage } from '../../../pages/new-contributions-landing/contributionsLandingReducer';
-import { trackComponentClick } from 'helpers/tracking/ophanComponentEventTracking';
 
 // ----- Types ----- //
 

--- a/assets/helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis.js
+++ b/assets/helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis.js
@@ -16,6 +16,7 @@ import { fetchJson, getRequestOptions, requestOptions } from 'helpers/fetch';
 import trackConversion from 'helpers/tracking/conversions';
 
 import { type ThankYouPageStage } from '../../../pages/new-contributions-landing/contributionsLandingReducer';
+import { trackComponentClick } from 'helpers/tracking/ophanComponentEventTracking';
 
 // ----- Types ----- //
 
@@ -121,6 +122,11 @@ function checkRegularStatus(
     switch (json.status) {
       case 'success':
       case 'pending':
+        try {
+          trackComponentClick('recurring-conversion-new-payment-flow');
+        } catch (err) {
+          // just being cautious
+        }
         return PaymentSuccess;
 
       default:
@@ -148,7 +154,6 @@ function checkRegularStatus(
           MAX_POLLS,
           POLLING_INTERVAL,
           () => {
-            trackConversion(participations, routes.recurringContribPending);
             return fetchJson(json.trackingUri, getRequestOptions('same-origin', csrf));
           },
           json2 => json2.status === 'pending',

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -240,7 +240,7 @@ const regularPaymentRequestFromAuthorisation = (
 // This will execute at the end of every checkout, with the exception
 // of PayPal one-off where this happens on the backend after the user is redirected to our site.
 const onPaymentResult = (paymentResult: Promise<PaymentResult>) =>
-  (dispatch: Dispatch<Action>, getState: () => State): void => {
+  (dispatch: Dispatch<Action>): void => {
     paymentResult.then((result) => {
       switch (result.paymentStatus) {
         case 'success':

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -38,9 +38,9 @@ import {
   getSupportAbTests,
 } from 'helpers/tracking/acquisitions';
 import { logException } from 'helpers/logger';
-import trackConversion from 'helpers/tracking/conversions';
 import { type UserTypeFromIdentityResponse } from 'helpers/identityApis';
 import { checkoutFormShouldSubmit, getForm } from 'helpers/checkoutForm/checkoutForm';
+import { trackComponentClick } from 'helpers/tracking/ophanComponentEventTracking';
 import * as cookie from 'helpers/cookie';
 import {
   type State,
@@ -242,11 +242,13 @@ const regularPaymentRequestFromAuthorisation = (
 const onPaymentResult = (paymentResult: Promise<PaymentResult>) =>
   (dispatch: Dispatch<Action>, getState: () => State): void => {
     paymentResult.then((result) => {
-      const state = getState();
-
       switch (result.paymentStatus) {
         case 'success':
-          trackConversion(state.common.abParticipations, '/contribute/thankyou.new');
+          try {
+            trackComponentClick('one-off-conversion-new-payment-flow');
+          } catch (err) {
+            // just being cautious
+          }
           dispatch(paymentSuccess());
           break;
 

--- a/assets/pages/oneoff-contributions/helpers/ajax.js
+++ b/assets/pages/oneoff-contributions/helpers/ajax.js
@@ -16,6 +16,7 @@ import { routes } from 'helpers/routes';
 import { logException } from 'helpers/logger';
 import type { CheckoutFailureReason } from 'helpers/checkoutErrors';
 import type { StripeAuthorisation } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
+import { trackComponentClick } from 'helpers/tracking/ophanComponentEventTracking';
 import { checkoutError, checkoutSuccess } from '../oneoffContributionsActions';
 
 
@@ -134,6 +135,11 @@ function postCheckout(
 
   const onSuccess: OnSuccess = () => {
     trackConversion(abParticipations, routes.oneOffContribThankyou);
+    try {
+      trackComponentClick('one-off-conversion-old-payment-flow');
+    } catch (err) {
+      // just being cautious
+    }
     dispatch(checkoutSuccess());
   };
 

--- a/assets/pages/regular-contributions/helpers/ajax.js
+++ b/assets/pages/regular-contributions/helpers/ajax.js
@@ -20,8 +20,8 @@ import { billingPeriodFromContrib } from 'helpers/contributions';
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import type { PaymentMethod } from 'helpers/contributions';
 import type { OptimizeExperiments } from 'helpers/tracking/optimize';
-import { checkoutPending, checkoutSuccess, checkoutError, creatingContributor, setGuestAccountCreationToken } from '../regularContributionsActions';
 import { trackComponentClick } from 'helpers/tracking/ophanComponentEventTracking';
+import { checkoutPending, checkoutSuccess, checkoutError, creatingContributor, setGuestAccountCreationToken } from '../regularContributionsActions';
 
 // ----- Setup ----- //
 

--- a/assets/pages/regular-contributions/helpers/ajax.js
+++ b/assets/pages/regular-contributions/helpers/ajax.js
@@ -21,6 +21,7 @@ import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import type { PaymentMethod } from 'helpers/contributions';
 import type { OptimizeExperiments } from 'helpers/tracking/optimize';
 import { checkoutPending, checkoutSuccess, checkoutError, creatingContributor, setGuestAccountCreationToken } from '../regularContributionsActions';
+import { trackComponentClick } from 'helpers/tracking/ophanComponentEventTracking';
 
 // ----- Setup ----- //
 
@@ -192,6 +193,11 @@ function statusPoll(
 
   if (pollCount >= MAX_POLLS) {
     trackConversion(participations, routes.recurringContribPending);
+    try {
+      trackComponentClick('recurring-conversion-old-payment-flow');
+    } catch (err) {
+      // just being cautious
+    }
     dispatch(checkoutPending(paymentMethod));
     return undefined;
   }
@@ -252,6 +258,11 @@ function handleStatus(
           break;
         case 'success':
           trackConversion(participations, routes.recurringContribThankyou);
+          try {
+            trackComponentClick('recurring-conversion-old-payment-flow');
+          } catch (err) {
+            // just being cautious
+          }
           dispatch(checkoutSuccess(paymentMethod));
           break;
         default: // pending


### PR DESCRIPTION
For new flow, we just send clicks (since conversions aren't working)

For old flow, I've added in clicks in addition to conversions (since conversions are working)