### PR TITLE
Send session id on old flow

### DIFF
--- a/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
+++ b/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
@@ -133,7 +133,7 @@ function RegularCta(props: {
 }): Node {
   const frequency = getFrequency(props.contributionType);
   const spokenType = getSpokenType(props.contributionType);
-  const clickUrl = addQueryParamsToURL(routes.recurringContribCheckout, {
+  const clickUrl = addQueryParamsToURL(routes.recurringContribCheckoutGuest, {
     contributionValue: props.amount.toString(),
     contribType: props.contributionType,
     currency: props.currencyId,

--- a/assets/pages/regular-contributions/helpers/ajax.js
+++ b/assets/pages/regular-contributions/helpers/ajax.js
@@ -21,6 +21,7 @@ import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import type { PaymentMethod } from 'helpers/contributions';
 import type { OptimizeExperiments } from 'helpers/tracking/optimize';
 import { checkoutPending, checkoutSuccess, checkoutError, creatingContributor, setGuestAccountCreationToken } from '../regularContributionsActions';
+import uuidv4 from "uuid";
 
 // ----- Setup ----- //
 
@@ -62,7 +63,8 @@ type RegularContribFields = {|
   ophanIds: OphanIds,
   referrerAcquisitionData: ReferrerAcquisitionData,
   supportAbTests: AcquisitionABTest[],
-  email: ?string
+  email: ?string,
+  sessionId: string,
 |};
 
 // https://github.com/guardian/support-models/blob/master/src/main/scala/com/gu/support/workers/model/Status.scala
@@ -165,6 +167,7 @@ function requestData(
     referrerAcquisitionData,
     supportAbTests,
     email: user.email,
+    sessionId: uuidv4(),
   };
 
   if (user.stateField) {

--- a/assets/pages/regular-contributions/helpers/ajax.js
+++ b/assets/pages/regular-contributions/helpers/ajax.js
@@ -20,8 +20,8 @@ import { billingPeriodFromContrib } from 'helpers/contributions';
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import type { PaymentMethod } from 'helpers/contributions';
 import type { OptimizeExperiments } from 'helpers/tracking/optimize';
+import uuidv4 from 'uuid';
 import { checkoutPending, checkoutSuccess, checkoutError, creatingContributor, setGuestAccountCreationToken } from '../regularContributionsActions';
-import uuidv4 from "uuid";
 
 // ----- Setup ----- //
 


### PR DESCRIPTION
and turn guest checkout back on

This sessionId is required by the backend when trying to create a guest account for a new email address. We supply it in the new flow but forgot to send it for the old flow