### PR TITLE
Redux on GW page

### DIFF
--- a/assets/pages/weekly-subscription-landing/components/weeklyContentBlock.scss
+++ b/assets/pages/weekly-subscription-landing/components/weeklyContentBlock.scss
@@ -25,8 +25,10 @@
 }
 
 .weekly-content-block {
-  .weekly-feature-list {
-    margin: 0 ($gu-h-spacing / 2 * -1);
+  .weekly-feature-list,
+  .weekly-form {
+    margin-left: ($gu-h-spacing / 2 * -1);
+    margin-right: ($gu-h-spacing / 2 * -1);
   }
   .weekly-text-block {
     margin-bottom: ($gu-v-spacing*2)

--- a/assets/pages/weekly-subscription-landing/components/weeklyContentBlock.scss
+++ b/assets/pages/weekly-subscription-landing/components/weeklyContentBlock.scss
@@ -1,5 +1,7 @@
 .weekly-content-block .component-left-margin-section__content {
-  border-left: 1px solid gu-colour(garnett-neutral-4);
+  @include mq($from: tablet) {
+    border-left: 1px solid gu-colour(garnett-neutral-4);
+  }
 }
 
 .weekly-content-block--grey .component-left-margin-section__content {

--- a/assets/pages/weekly-subscription-landing/components/weeklyCta.jsx
+++ b/assets/pages/weekly-subscription-landing/components/weeklyCta.jsx
@@ -13,6 +13,7 @@ type PropTypes = {|
   icon?: Node,
   type: 'submit' | 'button',
   href: ?string,
+  disabled: boolean,
   onClick: ?(void => void),
 |};
 
@@ -20,14 +21,14 @@ type PropTypes = {|
 // ----- Render ----- //
 
 const WeeklyCtaButton = ({
-  children, icon, type, onClick, href,
+  children, icon, type, onClick, href, disabled,
 }: PropTypes) => (href ? (
-  <a href={href} className="weekly-cta">
+  <a href={href} data-disabled={disabled} className="weekly-cta">
     <span className="weekly-cta__content">{children}</span>
     {icon}
   </a>
 ) : (
-  <button onClick={onClick} type={type} className="weekly-cta">
+  <button disabled={disabled} onClick={onClick} type={type} className="weekly-cta">
     <span className="weekly-cta__content">{children}</span>
     {icon}
   </button>
@@ -38,6 +39,7 @@ WeeklyCtaButton.defaultProps = {
   type: 'button',
   onClick: null,
   href: null,
+  disabled: false,
 };
 
 export default WeeklyCtaButton;

--- a/assets/pages/weekly-subscription-landing/components/weeklyCta.scss
+++ b/assets/pages/weekly-subscription-landing/components/weeklyCta.scss
@@ -10,7 +10,10 @@
   border: none;
   border-radius: 600px;
   cursor: pointer;
-   &:hover {
+  transition: background-color .2s;
+  will-change: background-color;
+
+  &:hover {
     background-color: gu-colour(highlight-dark);
   }
 }

--- a/assets/pages/weekly-subscription-landing/components/weeklyCta.scss
+++ b/assets/pages/weekly-subscription-landing/components/weeklyCta.scss
@@ -25,3 +25,7 @@
   height: $gu-v-spacing * 2;
   margin: $gu-v-spacing * -1 $gu-h-spacing * -.5 $gu-v-spacing * -1 $gu-h-spacing * .5;
 }
+
+.weekly-cta svg.svg-chevron {
+  height: $gu-v-spacing * 1.1;
+}

--- a/assets/pages/weekly-subscription-landing/components/weeklyFeatureList.scss
+++ b/assets/pages/weekly-subscription-landing/components/weeklyFeatureList.scss
@@ -1,5 +1,7 @@
 .weekly-feature-list {
-  display: flex;
+  @include mq($from: tablet) {
+    display: flex;
+  }
 }
 
 .weekly-feature-list__title {
@@ -12,8 +14,15 @@
 .weekly-feature-list__item {
   flex: 0 0 25%;
   box-sizing: border-box;
-  padding: 0 ($gu-h-spacing / 2) ($gu-v-spacing*2);
-  &:not(:last-child) {
-    border-right: 1px solid gu-colour(garnett-neutral-4);
+  padding: ($gu-v-spacing / 6) ($gu-h-spacing/2) ($gu-v-spacing * 2) 0;
+  margin-left: $gu-h-spacing / 2;
+  border-top: 1px solid gu-colour(garnett-neutral-4);
+  @include mq($from: tablet) {
+    padding: 0 ($gu-h-spacing / 2) ($gu-v-spacing*2);
+    margin: 0;
+    border-top: 0;
+    &:not(:last-child) {
+      border-right: 1px solid gu-colour(garnett-neutral-4);
+    }
   }
 }

--- a/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
+++ b/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
@@ -2,51 +2,54 @@
 
 // ----- Imports ----- //
 
-import React, { type Node } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
-
-import uuidv4 from 'uuid';
-import { classNameWithModifiers } from 'helpers/utilities';
 
 import WeeklyCta from './weeklyCta';
-import { type Subscription } from './../weeklySubscriptionLandingReducer';
+import { subscriptions, type Subscription } from './../weeklySubscriptionLandingReducer';
 import { type State } from './../weeklySubscriptionLandingReducer';
-import { setSubscription, type Action } from './../weeklySubscriptionLandingActions';
+import WeeklyFormLabel from './weeklyFormLabel';
 
 // ---- Types ----- //
 
-type LabelPropTypes = {|
-  type: Subscription,
-  title: string,
-  offer?: ?string,
-  children: Node,
+type PropTypes = {|
   checked?: ?Subscription,
-  setSubscriptionAction: (Subscription) => Action,
 |};
-
 
 // ----- Render ----- //
 
-const PreFormLabel = ({
-  type, title, offer, children, checked, setSubscriptionAction,
-}: LabelPropTypes) => {
-  const id = uuidv4();
-  return (
-    <label onChange={() => { setSubscriptionAction(type); }} className={classNameWithModifiers('weekly-form-label', [type === checked ? 'checked' : null])} htmlFor={id}>
-      <input checked={type === checked} className="weekly-form-label__input" id={id} type="radio" name="sub-type" value={type} />
-      <div className="weekly-form-label__title">{title}</div>
-      {offer && <div className="weekly-form-label__offer">{offer}</div>}
-      <div className="weekly-form-label__copy">{children}</div>
-    </label>
-  );
+const onSubmit = (ev: Event, subscription: ?Subscription) => {
+  ev.preventDefault();
+  if (subscription) {
+    console.log(`now leaving to the ${subscription} checkout 🚀`);
+  }
 };
 
-PreFormLabel.defaultProps = {
-  offer: null,
+const WeeklyForm = ({ checked }: PropTypes) => (
+  <form className="weekly-form-wrap" onSubmit={(ev) => { onSubmit(ev, checked); }}>
+    <div className="weekly-form">
+      {Object.keys(subscriptions).map((type: Subscription) => {
+         const {
+          offer, copy, title,
+        } = subscriptions[type];
+        return (
+          <div className="weekly-form__item">
+            <WeeklyFormLabel title={title} offer={offer} type={type} key={type}>
+              {copy}
+            </WeeklyFormLabel>
+          </div>
+
+    );
+})}
+    </div>
+
+    <WeeklyCta disabled={checked === null} type="submit">Subscribe now – {checked}</WeeklyCta>
+  </form>
+);
+
+WeeklyForm.defaultProps = {
   checked: null,
 };
-
 
 // ----- State/Props Maps ----- //
 
@@ -54,35 +57,6 @@ const mapStateToProps = (state: State) => ({
   checked: state.page.subscription,
 });
 
-const mapDispatchToProps = (dispatch: Dispatch<Action>) => ({
-  setSubscriptionAction: bindActionCreators(setSubscription, dispatch),
-});
+// ----- Exports ----- //
 
-
-const FormLabel = connect(mapStateToProps, mapDispatchToProps)(PreFormLabel);
-
-const WeeklyForm = () => (
-  <form className="weekly-form-wrap">
-    <div className="weekly-form">
-      <div className="weekly-form__item">
-        <FormLabel title="6 for £6" offer="Introductory offer" type="weekly">
-        6 issues for 6 pounds and then £37 every 3 months
-        </FormLabel>
-      </div>
-      <div className="weekly-form__item">
-        <FormLabel title="Quarterly" type="quarterly">
-        6 issues for 6 pounds and then £37 every 3 months
-        </FormLabel>
-      </div>
-      <div className="weekly-form__item">
-        <FormLabel title="Annually" offer="10% off" type="annually">
-        6 issues for 6 pounds and then £37 every 3 months
-        </FormLabel>
-      </div>
-    </div>
-
-    <WeeklyCta type="submit">Subscribe now</WeeklyCta>
-  </form>
-);
-
-export default WeeklyForm;
+export default connect(mapStateToProps)(WeeklyForm);

--- a/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
+++ b/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
@@ -3,32 +3,38 @@
 // ----- Imports ----- //
 
 import React, { type Node } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 
 import uuidv4 from 'uuid';
 import { classNameWithModifiers } from 'helpers/utilities';
 
 import WeeklyCta from './weeklyCta';
+import { type Subscription } from './../weeklySubscriptionLandingReducer';
+import { type State } from './../weeklySubscriptionLandingReducer';
+import { setSubscription, type Action } from './../weeklySubscriptionLandingActions';
 
 // ---- Types ----- //
 
 type LabelPropTypes = {|
-  type: string,
+  type: Subscription,
   title: string,
   offer?: ?string,
   children: Node,
-  checked: boolean,
+  checked?: ?Subscription,
+  setSubscriptionAction: (Subscription) => Action,
 |};
 
 
 // ----- Render ----- //
 
-const FormLabel = ({
-  type, title, offer, children, checked,
+const PreFormLabel = ({
+  type, title, offer, children, checked, setSubscriptionAction,
 }: LabelPropTypes) => {
   const id = uuidv4();
   return (
-    <label className={classNameWithModifiers('weekly-form-label', [checked ? 'checked' : null])} htmlFor={id}>
-      <input className="weekly-form-label__input" id={id} type="radio" name="sub-type" value={type} />
+    <label onChange={() => { setSubscriptionAction(type); }} className={classNameWithModifiers('weekly-form-label', [type === checked ? 'checked' : null])} htmlFor={id}>
+      <input checked={type === checked} className="weekly-form-label__input" id={id} type="radio" name="sub-type" value={type} />
       <div className="weekly-form-label__title">{title}</div>
       {offer && <div className="weekly-form-label__offer">{offer}</div>}
       <div className="weekly-form-label__copy">{children}</div>
@@ -36,10 +42,24 @@ const FormLabel = ({
   );
 };
 
-FormLabel.defaultProps = {
+PreFormLabel.defaultProps = {
   offer: null,
-  checked: false,
+  checked: null,
 };
+
+
+// ----- State/Props Maps ----- //
+
+const mapStateToProps = (state: State) => ({
+  checked: state.page.subscription,
+});
+
+const mapDispatchToProps = (dispatch: Dispatch<Action>) => ({
+  setSubscriptionAction: bindActionCreators(setSubscription, dispatch),
+});
+
+
+const FormLabel = connect(mapStateToProps, mapDispatchToProps)(PreFormLabel);
 
 const WeeklyForm = () => (
   <form className="weekly-form-wrap">

--- a/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
+++ b/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
@@ -2,24 +2,65 @@
 
 // ----- Imports ----- //
 
-import React from 'react';
+import React, { type Node } from 'react';
 
 import uuidv4 from 'uuid';
+import { classNameWithModifiers } from 'helpers/utilities';
 
 import WeeklyCta from './weeklyCta';
 
+// ---- Types ----- //
+
+type LabelPropTypes = {|
+  type: string,
+  title: string,
+  offer?: ?string,
+  children: Node,
+  checked: boolean,
+|};
+
+
 // ----- Render ----- //
 
-const FormLabel = ({ type }: {type: string}) => {
+const FormLabel = ({
+  type, title, offer, children, checked,
+}: LabelPropTypes) => {
   const id = uuidv4();
-  return (<label htmlFor={id}><input id={id} type="radio" name="sub-type" value={type} />{type}</label>);
+  return (
+    <label className={classNameWithModifiers('weekly-form-label', [checked ? 'checked' : null])} htmlFor={id}>
+      <input className="weekly-form-label__input" id={id} type="radio" name="sub-type" value={type} />
+      <div className="weekly-form-label__title">{title}</div>
+      {offer && <div className="weekly-form-label__offer">{offer}</div>}
+      <div className="weekly-form-label__copy">{children}</div>
+    </label>
+  );
+};
+
+FormLabel.defaultProps = {
+  offer: null,
+  checked: false,
 };
 
 const WeeklyForm = () => (
-  <form>
-    <FormLabel type="weekly" />
-    <FormLabel type="quarterly" />
-    <FormLabel type="monthly" />
+  <form className="weekly-form-wrap">
+    <div className="weekly-form">
+      <div className="weekly-form__item">
+        <FormLabel title="6 for £6" offer="Introductory offer" type="weekly">
+        6 issues for 6 pounds and then £37 every 3 months
+        </FormLabel>
+      </div>
+      <div className="weekly-form__item">
+        <FormLabel title="Quarterly" type="quarterly">
+        6 issues for 6 pounds and then £37 every 3 months
+        </FormLabel>
+      </div>
+      <div className="weekly-form__item">
+        <FormLabel title="Annually" offer="10% off" type="annually">
+        6 issues for 6 pounds and then £37 every 3 months
+        </FormLabel>
+      </div>
+    </div>
+
     <WeeklyCta type="submit">Subscribe now</WeeklyCta>
   </form>
 );

--- a/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
+++ b/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
@@ -5,6 +5,8 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
+import SvgInfo from 'components/svgs/information';
+
 import WeeklyCta from './weeklyCta';
 import { subscriptions, type Subscription } from './../weeklySubscriptionLandingReducer';
 import { type State } from './../weeklySubscriptionLandingReducer';
@@ -29,7 +31,7 @@ const WeeklyForm = ({ checked }: PropTypes) => (
   <form className="weekly-form-wrap" onSubmit={(ev) => { onSubmit(ev, checked); }}>
     <div className="weekly-form">
       {Object.keys(subscriptions).map((type: Subscription) => {
-         const {
+        const {
           offer, copy, title,
         } = subscriptions[type];
         return (
@@ -38,12 +40,16 @@ const WeeklyForm = ({ checked }: PropTypes) => (
               {copy}
             </WeeklyFormLabel>
           </div>
-
-    );
-})}
+          );
+        })}
     </div>
 
     <WeeklyCta disabled={checked === null} type="submit">Subscribe now{checked && ` – ${subscriptions[checked].title}`}</WeeklyCta>
+
+    <div className="weekly-form__info">
+      <SvgInfo />
+      You can cancel your subscription at any time
+    </div>
   </form>
 );
 

--- a/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
+++ b/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
@@ -43,7 +43,7 @@ const WeeklyForm = ({ checked }: PropTypes) => (
 })}
     </div>
 
-    <WeeklyCta disabled={checked === null} type="submit">Subscribe now – {checked}</WeeklyCta>
+    <WeeklyCta disabled={checked === null} type="submit">Subscribe now{checked && ` – ${subscriptions[checked].title}`}</WeeklyCta>
   </form>
 );
 

--- a/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
+++ b/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
@@ -8,8 +8,7 @@ import { connect } from 'react-redux';
 import SvgInfo from 'components/svgs/information';
 
 import WeeklyCta from './weeklyCta';
-import { subscriptions, type Subscription } from './../weeklySubscriptionLandingReducer';
-import { type State } from './../weeklySubscriptionLandingReducer';
+import { subscriptions, type Subscription, type State } from '../weeklySubscriptionLandingReducer';
 import WeeklyFormLabel from './weeklyFormLabel';
 
 // ---- Types ----- //

--- a/assets/pages/weekly-subscription-landing/components/weeklyForm.scss
+++ b/assets/pages/weekly-subscription-landing/components/weeklyForm.scss
@@ -3,17 +3,21 @@
 }
 
 .weekly-form {
-  display: flex;
-  display: grid;
-  grid-template-columns: 1fr 1fr 1fr 1fr;
-  grid-auto-rows: 1fr;
   margin-bottom: $gu-v-spacing * 2;
+  @include mq($from: tablet) {
+    display: flex;
+  }
 }
 
 .weekly-form > .weekly-form__item {
   flex: 0 0 25%;
   padding: 0 $gu-h-spacing/2;
   box-sizing: border-box;
+  margin-bottom: $gu-v-spacing;
+  @include mq($from: tablet) {
+    height: 100%;
+    margin-bottom: 0;
+  }
 }
 
 .weekly-form-label {

--- a/assets/pages/weekly-subscription-landing/components/weeklyForm.scss
+++ b/assets/pages/weekly-subscription-landing/components/weeklyForm.scss
@@ -2,6 +2,7 @@
   margin-bottom: $gu-v-spacing * 2;
   @include mq($from: tablet) {
     display: flex;
+    align-items: stretch;
   }
 }
 
@@ -11,7 +12,6 @@
   box-sizing: border-box;
   margin-bottom: $gu-v-spacing;
   @include mq($from: tablet) {
-    height: 100%;
     margin-bottom: 0;
   }
 }

--- a/assets/pages/weekly-subscription-landing/components/weeklyForm.scss
+++ b/assets/pages/weekly-subscription-landing/components/weeklyForm.scss
@@ -1,0 +1,53 @@
+.weekly-form-wrap {
+  margin-bottom: $gu-v-spacing * 2;
+}
+
+.weekly-form {
+  display: flex;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 1fr;
+  grid-auto-rows: 1fr;
+  margin-bottom: $gu-v-spacing * 2;
+}
+
+.weekly-form > .weekly-form__item {
+  flex: 0 0 25%;
+  padding: 0 $gu-h-spacing/2;
+  box-sizing: border-box;
+}
+
+.weekly-form-label {
+  font-family: $gu-text-sans-web;
+  border: 1px solid gu-colour(garnett-neutral-4);
+  display: block;
+  overflow: hidden;
+  position: relative;
+  height: 100%;
+}
+
+.weekly-form-label__input {
+  position: absolute;
+  left: -4em;
+  visibility: hidden;
+}
+
+.weekly-form-label--checked {
+  background: gu-colour(garnett-neutral-5);
+}
+
+.weekly-form-label__title,
+.weekly-form-label__copy,
+.weekly-form-label__offer {
+  padding: $gu-v-spacing/2 $gu-h-spacing/2;
+  display: block;
+}
+
+.weekly-form-label__title {
+  font-weight: 600;
+  border-bottom: 1px solid gu-colour(garnett-neutral-4);
+}
+
+.weekly-form-label__offer {
+  color: gu-colour(green-dark);
+  font-weight: 600;
+}

--- a/assets/pages/weekly-subscription-landing/components/weeklyForm.scss
+++ b/assets/pages/weekly-subscription-landing/components/weeklyForm.scss
@@ -16,43 +16,6 @@
   }
 }
 
-.weekly-form-label {
-  font-family: $gu-text-sans-web;
-  border: 1px solid gu-colour(garnett-neutral-4);
-  display: block;
-  overflow: hidden;
-  position: relative;
-  height: 100%;
-  cursor: pointer;
-}
-
-.weekly-form-label__input {
-  position: absolute;
-  left: -4em;
-  visibility: hidden;
-}
-
-.weekly-form-label--checked {
-  background: gu-colour(garnett-neutral-5);
-}
-
-.weekly-form-label__title,
-.weekly-form-label__copy,
-.weekly-form-label__offer {
-  padding: $gu-v-spacing/2 $gu-h-spacing/2;
-  display: block;
-}
-
-.weekly-form-label__title {
-  font-weight: 600;
-  border-bottom: 1px solid gu-colour(garnett-neutral-4);
-}
-
-.weekly-form-label__offer {
-  color: gu-colour(green-dark);
-  font-weight: 600;
-}
-
 .weekly-form__info {
   padding-top: $gu-v-spacing * 2;
   padding-bottom: $gu-v-spacing * 2.5;

--- a/assets/pages/weekly-subscription-landing/components/weeklyForm.scss
+++ b/assets/pages/weekly-subscription-landing/components/weeklyForm.scss
@@ -1,7 +1,3 @@
-.weekly-form-wrap {
-  margin-bottom: $gu-v-spacing * 2;
-}
-
 .weekly-form {
   margin-bottom: $gu-v-spacing * 2;
   @include mq($from: tablet) {
@@ -55,4 +51,20 @@
 .weekly-form-label__offer {
   color: gu-colour(green-dark);
   font-weight: 600;
+}
+
+.weekly-form__info {
+  padding-top: $gu-v-spacing * 2;
+  padding-bottom: $gu-v-spacing * 2.5;
+  color: gu-colour(garnett-neutral-6);
+  font-family: $gu-text-sans-web;
+  font-size: 16px;
+  svg {
+    display: inline-block;
+    vertical-align: text-bottom;
+    margin-right: $gu-h-spacing / 4;
+    circle {
+      fill: gu-colour(garnett-neutral-6);
+    }
+  }
 }

--- a/assets/pages/weekly-subscription-landing/components/weeklyForm.scss
+++ b/assets/pages/weekly-subscription-landing/components/weeklyForm.scss
@@ -23,6 +23,7 @@
   overflow: hidden;
   position: relative;
   height: 100%;
+  cursor: pointer;
 }
 
 .weekly-form-label__input {

--- a/assets/pages/weekly-subscription-landing/components/weeklyFormLabel.jsx
+++ b/assets/pages/weekly-subscription-landing/components/weeklyFormLabel.jsx
@@ -7,7 +7,6 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
 import uuidv4 from 'uuid';
-import { classNameWithModifiers } from 'helpers/utilities';
 
 import { type Subscription } from '../weeklySubscriptionLandingReducer';
 import { type State } from '../weeklySubscriptionLandingReducer';
@@ -32,11 +31,13 @@ const WeeklyFormLabel = ({
 }: PropTypes) => {
   const id = uuidv4();
   return (
-    <label onChange={() => { setSubscriptionAction(type); }} className={classNameWithModifiers('weekly-form-label', [type === checked ? 'checked' : null])} htmlFor={id}>
-      <input checked={type === checked} className="weekly-form-label__input" id={id} type="radio" name="sub-type" value={type} />
-      <div className="weekly-form-label__title">{title}</div>
-      {offer && <div className="weekly-form-label__offer">{offer}</div>}
-      <div className="weekly-form-label__copy">{children}</div>
+    <label onChange={() => { setSubscriptionAction(type); }} htmlFor={id} className="weekly-form-label-wrap">
+      <input checked={type === checked} className="weekly-form-label-wrap__input" id={id} type="radio" name="sub-type" value={type} />
+      <div className="weekly-form-label">
+        <div className="weekly-form-label__title">{title}</div>
+        {offer && <div className="weekly-form-label__offer">{offer}</div>}
+        <div className="weekly-form-label__copy">{children}</div>
+      </div>
     </label>
   );
 };

--- a/assets/pages/weekly-subscription-landing/components/weeklyFormLabel.jsx
+++ b/assets/pages/weekly-subscription-landing/components/weeklyFormLabel.jsx
@@ -1,0 +1,61 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React, { type Node } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+import uuidv4 from 'uuid';
+import { classNameWithModifiers } from 'helpers/utilities';
+
+import { type Subscription } from '../weeklySubscriptionLandingReducer';
+import { type State } from '../weeklySubscriptionLandingReducer';
+import { setSubscription, type Action } from '../weeklySubscriptionLandingActions';
+
+// ---- Types ----- //
+
+type PropTypes = {|
+  type: Subscription,
+  title: string,
+  offer?: ?string,
+  children: Node,
+  checked?: ?Subscription,
+  setSubscriptionAction: (Subscription) => Action,
+|};
+
+
+// ----- Render ----- //
+
+const WeeklyFormLabel = ({
+  type, title, offer, children, checked, setSubscriptionAction,
+}: PropTypes) => {
+  const id = uuidv4();
+  return (
+    <label onChange={() => { setSubscriptionAction(type); }} className={classNameWithModifiers('weekly-form-label', [type === checked ? 'checked' : null])} htmlFor={id}>
+      <input checked={type === checked} className="weekly-form-label__input" id={id} type="radio" name="sub-type" value={type} />
+      <div className="weekly-form-label__title">{title}</div>
+      {offer && <div className="weekly-form-label__offer">{offer}</div>}
+      <div className="weekly-form-label__copy">{children}</div>
+    </label>
+  );
+};
+
+WeeklyFormLabel.defaultProps = {
+  offer: null,
+  checked: null,
+};
+
+
+// ----- State/Props Maps ----- //
+
+const mapStateToProps = (state: State) => ({
+  checked: state.page.subscription,
+});
+
+const mapDispatchToProps = (dispatch: Dispatch<Action>) => ({
+  setSubscriptionAction: bindActionCreators(setSubscription, dispatch),
+});
+
+
+export default connect(mapStateToProps, mapDispatchToProps)(WeeklyFormLabel);

--- a/assets/pages/weekly-subscription-landing/components/weeklyFormLabel.jsx
+++ b/assets/pages/weekly-subscription-landing/components/weeklyFormLabel.jsx
@@ -8,8 +8,7 @@ import { bindActionCreators } from 'redux';
 
 import uuidv4 from 'uuid';
 
-import { type Subscription } from '../weeklySubscriptionLandingReducer';
-import { type State } from '../weeklySubscriptionLandingReducer';
+import { type Subscription, type State } from '../weeklySubscriptionLandingReducer';
 import { setSubscription, type Action } from '../weeklySubscriptionLandingActions';
 
 // ---- Types ----- //

--- a/assets/pages/weekly-subscription-landing/components/weeklyFormLabel.scss
+++ b/assets/pages/weekly-subscription-landing/components/weeklyFormLabel.scss
@@ -1,20 +1,26 @@
+.weekly-form-label-wrap {
+  position: relative;
+  height: 100%;
+}
+
+.weekly-form-label-wrap__input {
+  position: absolute;
+  opacity: 0;
+}
+
 .weekly-form-label {
   font-family: $gu-text-sans-web;
   border: 1px solid gu-colour(garnett-neutral-4);
   display: block;
-  overflow: hidden;
-  position: relative;
   height: 100%;
   cursor: pointer;
 }
 
-.weekly-form-label__input {
-  position: absolute;
-  left: -4em;
-  visibility: hidden;
+.weekly-form-label-wrap__input:focus + .weekly-form-label {
+  box-shadow: 0 0 0 2px gu-colour(news-garnett-highlight);
 }
 
-.weekly-form-label--checked {
+.weekly-form-label-wrap__input:checked + .weekly-form-label {
   background: gu-colour(garnett-neutral-5);
 }
 

--- a/assets/pages/weekly-subscription-landing/components/weeklyFormLabel.scss
+++ b/assets/pages/weekly-subscription-landing/components/weeklyFormLabel.scss
@@ -14,6 +14,12 @@
   display: block;
   height: 100%;
   cursor: pointer;
+  transition: .2s;
+  will-change: background-color box-shadow;
+}
+
+.weekly-form-label-wrap__input:hover + .weekly-form-label {
+  box-shadow: 0 0 0 2px rgba(gu-colour(garnett-neutral-4),.5);
 }
 
 .weekly-form-label-wrap__input:focus + .weekly-form-label {

--- a/assets/pages/weekly-subscription-landing/components/weeklyFormLabel.scss
+++ b/assets/pages/weekly-subscription-landing/components/weeklyFormLabel.scss
@@ -1,0 +1,36 @@
+.weekly-form-label {
+  font-family: $gu-text-sans-web;
+  border: 1px solid gu-colour(garnett-neutral-4);
+  display: block;
+  overflow: hidden;
+  position: relative;
+  height: 100%;
+  cursor: pointer;
+}
+
+.weekly-form-label__input {
+  position: absolute;
+  left: -4em;
+  visibility: hidden;
+}
+
+.weekly-form-label--checked {
+  background: gu-colour(garnett-neutral-5);
+}
+
+.weekly-form-label__title,
+.weekly-form-label__copy,
+.weekly-form-label__offer {
+  padding: $gu-v-spacing/2 $gu-h-spacing/2;
+  display: block;
+}
+
+.weekly-form-label__title {
+  font-weight: 600;
+  border-bottom: 1px solid gu-colour(garnett-neutral-4);
+}
+
+.weekly-form-label__offer {
+  color: gu-colour(green-dark);
+  font-weight: 600;
+}

--- a/assets/pages/weekly-subscription-landing/components/weeklyHero.jsx
+++ b/assets/pages/weekly-subscription-landing/components/weeklyHero.jsx
@@ -6,6 +6,8 @@ import React from 'react';
 import HeadingBlock from 'components/headingBlock/headingBlock';
 import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
 
+import SvgChevron from 'components/svgs/chevron';
+
 import WeeklyCta from './weeklyCta';
 
 
@@ -26,7 +28,7 @@ const WeeklyHero = ({ subsLink }: PropTypes) => (
     <div className="weekly-hero-hanger">
       <LeftMarginSection>
         <div className="weekly-hero-hanger__content">
-          <WeeklyCta href={subsLink}>See Subscription options</WeeklyCta>
+          <WeeklyCta icon={<SvgChevron />} href={subsLink}>See Subscription options</WeeklyCta>
         </div>
       </LeftMarginSection>
     </div>

--- a/assets/pages/weekly-subscription-landing/components/weeklyHero.scss
+++ b/assets/pages/weekly-subscription-landing/components/weeklyHero.scss
@@ -3,7 +3,9 @@
   overflow: hidden;
   padding-top: 300px;
   .component-left-margin-section__content {
-    border-left: 1px solid gu-colour(garnett-neutral-4);
+    @include mq($from: tablet) {
+      border-left: 1px solid gu-colour(garnett-neutral-4);
+    }
   }
 }
 

--- a/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -3,13 +3,14 @@
 // ----- Imports ----- //
 
 import React from 'react';
+import { Provider } from 'react-redux';
 
 import Page from 'components/page/page';
 import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
 import Footer from 'components/footer/footer';
 
 import { detect, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import { statelessInit as pageInit } from 'helpers/page/page';
+import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
 
 import WeeklyContentBlock from './components/weeklyContentBlock';
@@ -18,6 +19,11 @@ import WeeklyFeatureList from './components/weeklyFeatureList';
 import WeeklyHero from './components/weeklyHero';
 import WeeklyForm from './components/weeklyForm';
 
+import reducer from './weeklySubscriptionLandingReducer';
+
+// ----- Redux Store ----- //
+
+const store = pageInit(reducer);
 
 // ----- Internationalisation ----- //
 
@@ -43,65 +49,67 @@ pageInit();
 // ----- Render ----- //
 
 const content = (
-  <Page
-    header={<SimpleHeader />}
-    footer={<Footer />}
-  >
-    <WeeklyHero subsLink="#subscribe" />
-    <WeeklyContentBlock>
-      <WeeklyTextBlock title="Open up your world view, Weekly">
-        <p>Inside the magazine you’ll find quality, independent journalism including opinion,
+  <Provider store={store}>
+    <Page
+      header={<SimpleHeader />}
+      footer={<Footer />}
+    >
+      <WeeklyHero subsLink="#subscribe" />
+      <WeeklyContentBlock>
+        <WeeklyTextBlock title="Open up your world view, Weekly">
+          <p>Inside the magazine you’ll find quality, independent journalism including opinion,
           insight, culture and access to new puzzles each week. Subscribe today and get an
           expert view on some of the most challenging issues of today, as well as free delivery,
           wherever you are in the world
-        </p>
-      </WeeklyTextBlock>
-    </WeeklyContentBlock>
-    <WeeklyContentBlock type="feature">
-      <WeeklyTextBlock title="As a subscriber you’ll enjoy" />
-      <WeeklyFeatureList features={[
+          </p>
+        </WeeklyTextBlock>
+      </WeeklyContentBlock>
+      <WeeklyContentBlock type="feature">
+        <WeeklyTextBlock title="As a subscriber you’ll enjoy" />
+        <WeeklyFeatureList features={[
         { title: 'Up to 30% off the retail cover price' },
         { title: 'Up to 30% off the retail cover price' },
         { title: 'Up to 30% off the retail cover price' },
         { title: 'Up to 30% off the retail cover price' },
       ]}
-      />
-    </WeeklyContentBlock>
-    <WeeklyContentBlock type="grey" id="subscribe">
-      <WeeklyTextBlock title="Get your Guardian Weekly, subscribe now">
-        <p>How would you like to pay for your Guardian Weekly?</p>
-      </WeeklyTextBlock>
-      <WeeklyForm />
-    </WeeklyContentBlock>
-    <WeeklyContentBlock type="white">
-      <WeeklyTextBlock title="Buying as a gift?">
-        <p>If you’d like to buy a Guardian Weekly subscription as a gift,
+        />
+      </WeeklyContentBlock>
+      <WeeklyContentBlock type="grey" id="subscribe">
+        <WeeklyTextBlock title="Get your Guardian Weekly, subscribe now">
+          <p>How would you like to pay for your Guardian Weekly?</p>
+        </WeeklyTextBlock>
+        <WeeklyForm />
+      </WeeklyContentBlock>
+      <WeeklyContentBlock type="white">
+        <WeeklyTextBlock title="Buying as a gift?">
+          <p>If you’d like to buy a Guardian Weekly subscription as a gift,
           just get in touch with your local customer service team.
-        </p>
-      </WeeklyTextBlock>
-      <WeeklyFeatureList features={[
+          </p>
+        </WeeklyTextBlock>
+        <WeeklyFeatureList features={[
         { title: 'UK, Europe and Rest of World', copy: '+44 (0) 330 333 6767' },
         { title: 'Australia and New Zealand', copy: '+44 (0) 330 333 6767' },
         { title: 'UK, Europe and Rest of World', copy: '+44 (0) 330 333 6767' },
       ]}
-      />
+        />
 
-    </WeeklyContentBlock>
-    <WeeklyContentBlock type="dark">
-      <WeeklyTextBlock title="Promotion terms and conditions">
-        <p>Offer subject to availability. Guardian News and Media Limited
+      </WeeklyContentBlock>
+      <WeeklyContentBlock type="dark">
+        <WeeklyTextBlock title="Promotion terms and conditions">
+          <p>Offer subject to availability. Guardian News and Media Limited
           (&quot;GNM&quot;) reserves the right to withdraw this promotion
           at any time. View full promotion terms and conditions here.
-        </p>
-      </WeeklyTextBlock>
-      <WeeklyTextBlock title="Guardian Weekly terms and conditions">
-        <p>Offer subject to availability. Guardian News and Media Limited
+          </p>
+        </WeeklyTextBlock>
+        <WeeklyTextBlock title="Guardian Weekly terms and conditions">
+          <p>Offer subject to availability. Guardian News and Media Limited
           (&quot;GNM&quot;) reserves the right to withdraw this promotion
           at any time. View full promotion terms and conditions here.
-        </p>
-      </WeeklyTextBlock>
-    </WeeklyContentBlock>
-  </Page>
+          </p>
+        </WeeklyTextBlock>
+      </WeeklyContentBlock>
+    </Page>
+  </Provider>
 );
 
 renderPage(content, reactElementId[countryGroupId]);

--- a/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.scss
+++ b/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.scss
@@ -15,3 +15,4 @@
 @import 'components/weeklyFeatureList';
 @import 'components/weeklyHero';
 @import 'components/weeklyCta';
+@import 'components/weeklyForm';

--- a/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.scss
+++ b/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.scss
@@ -16,3 +16,4 @@
 @import 'components/weeklyHero';
 @import 'components/weeklyCta';
 @import 'components/weeklyForm';
+@import 'components/weeklyFormLabel';

--- a/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingActions.js
+++ b/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingActions.js
@@ -1,0 +1,22 @@
+// @flow
+
+// ----- Imports ----- //
+
+import { type Subscription } from './weeklySubscriptionLandingReducer';
+
+
+// ----- Types ----- //
+
+export type Action = { type: 'SET_SUBSCRIPTION', subscription: Subscription };
+
+
+// ----- Action Creators ----- //
+
+function setStage(subscription: Subscription): Action {
+  return { type: 'SET_SUBSCRIPTION', subscription };
+}
+
+
+// ----- Exports ----- //
+
+export { setStage };

--- a/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingActions.js
+++ b/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingActions.js
@@ -12,11 +12,11 @@ export type Action = { type: 'SET_SUBSCRIPTION', subscription: Subscription };
 
 // ----- Action Creators ----- //
 
-function setStage(subscription: Subscription): Action {
+function setSubscription(subscription: Subscription): Action {
   return { type: 'SET_SUBSCRIPTION', subscription };
 }
 
 
 // ----- Exports ----- //
 
-export { setStage };
+export { setSubscription };

--- a/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingReducer.js
+++ b/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingReducer.js
@@ -1,0 +1,47 @@
+// @flow
+
+// ----- Imports ----- //
+
+import type { CommonState } from 'helpers/page/page';
+
+import { type Action } from './weeklySubscriptionLandingActions';
+
+
+// ----- Types ----- //
+
+export type Subscription = 'weekly' | 'monthly' | 'quarterly';
+
+type PageState = {
+  subscription: Subscription;
+};
+
+export type State = {
+  common: CommonState,
+  page: PageState,
+};
+
+
+// ----- Reducer ----- //
+
+const initialState = {
+  subscription: 'weekly',
+};
+
+function reducer(state: PageState = initialState, action: Action): PageState {
+
+  switch (action.type) {
+
+    case 'SET_SUBSCRIPTION':
+      return { ...state, subscription: action.subscription };
+
+    default:
+      return state;
+
+  }
+
+}
+
+
+// ----- Export ----- //
+
+export default reducer;

--- a/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingReducer.js
+++ b/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingReducer.js
@@ -7,9 +7,37 @@ import type { CommonState } from 'helpers/page/page';
 import { type Action } from './weeklySubscriptionLandingActions';
 
 
-// ----- Types ----- //
+// ----- Subs ------ //
+export type SubscriptionWithDetails = {
+  title: string,
+  offer?: ?string,
+  copy: string,
+}
 
-export type Subscription = 'weekly' | 'monthly' | 'quarterly';
+type Subscriptions = {
+  weekly: SubscriptionWithDetails,
+  quarterly: SubscriptionWithDetails,
+  annually: SubscriptionWithDetails
+}
+
+export const subscriptions: Subscriptions = {
+  weekly: {
+    title: 'Weekly',
+    offer: 'Introductory offer',
+    copy: '6 issues for 6 pounds and then £37 every 3 months',
+  },
+  quarterly: {
+    title: 'Quarterly',
+    copy: '6 issues for 6 pounds and then £37 every 3 months',
+  },
+  annually: {
+    title: 'Annually',
+    offer: '10% off',
+    copy: '6 issues for 6 pounds and then £37 every 3 months',
+  },
+};
+
+export type Subscription = $Keys<typeof subscriptions>;
 
 type PageState = {
   subscription: Subscription;

--- a/assets/stylesheets/gu-sass/colours.scss
+++ b/assets/stylesheets/gu-sass/colours.scss
@@ -140,7 +140,7 @@ $gu-colours: (
   immersive-garnett-main-1: rgba(0, 0, 0, .65),
   analysis-garnett-underline: #ffbac8,
 
-  green-dark: #236925,
+  green-dark: #29a05f,
 );
 
 // Given the name of the colour this returns the hex value.

--- a/assets/stylesheets/gu-sass/colours.scss
+++ b/assets/stylesheets/gu-sass/colours.scss
@@ -140,7 +140,7 @@ $gu-colours: (
   immersive-garnett-main-1: rgba(0, 0, 0, .65),
   analysis-garnett-underline: #ffbac8,
 
-  green-dark: #29a05f,
+  green-dark: #236925,
 );
 
 // Given the name of the colour this returns the hex value.


### PR DESCRIPTION
## Why are you doing this?

To get the GW page closer to a shippable state

[**Trello Card**](https://trello.com/c/Q4l0D1pR/2062-gw-page-redux-store)

## Changes

- Redux store for the chosen pack
- Many CSS/A11y niceties
- Responsive components

## Screenshots
<img width="916" alt="screenshot 2018-11-06 at 10 28 25 am" src="https://user-images.githubusercontent.com/11539094/48058646-d6da7400-e1ae-11e8-8161-2f9040dc5505.png">

