### PR TITLE
Scale up to 6 instances

### DIFF
--- a/cloud-formation/cfn.yaml
+++ b/cloud-formation/cfn.yaml
@@ -35,8 +35,8 @@ Mappings:
       CertificateARN: arn:aws:acm:eu-west-1:865473395570:certificate/44e9f40c-c884-40e6-a171-6769e9a8b173
       AwsKeyARN: arn:aws:kms:eu-west-1:865473395570:key/89f17663-c79e-4104-b718-ee0986402ad9
     PROD:
-      MaxInstances: 6
-      MinInstances: 3
+      MaxInstances: 12
+      MinInstances: 6
       InstanceType: t2.small
       CertificateARN: arn:aws:acm:eu-west-1:865473395570:certificate/9d8ff96c-63d5-425b-88d1-f529770e5b6d
       AwsKeyARN: arn:aws:kms:eu-west-1:865473395570:key/d7aed06c-e961-4078-8604-0aeedae08613


### PR DESCRIPTION
To handle any increase in traffic during the US midterms

Since we made the `contribute` routes uncacheable (they now vary by user login cookie), we're being extra cautious