### PR TITLE
Fix greyed out form labels

### DIFF
--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -800,17 +800,12 @@ form {
   display: none;
 }
 
-.form__radio-group--contribution-amount,
-.form__field--contribution-other-amount,
-.form__field--contribution-fname,
-.form__field--contribution-lname {
-  margin-top: 12px;
+.form__radio-group--contribution-amount {
+  margin: 12px 0;
 }
 
-.form__field--contribution-email,
-.form__field--contribution-state {
-  margin-top: 24px;
-  color: gu-colour(garnett-neutral-2);
+.form__field {
+  margin-top: 12px;
 }
 
 .form__radio-group--contribution-pay {


### PR DESCRIPTION
and some extra padding before "State" in US/Canada

| Before  | After |
| ------------- | ------------- |
| <img width="380" alt="picture 324" src="https://user-images.githubusercontent.com/5122968/48083583-7585c580-e1ed-11e8-8c64-750e1a5f3972.png"> | <img width="380" alt="picture 323" src="https://user-images.githubusercontent.com/5122968/48083609-85050e80-e1ed-11e8-89f7-d2b47b03b1e5.png"> |