### PR TITLE
Add span flex container within button

### DIFF
--- a/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
@@ -120,16 +120,18 @@ function ContributionSubmit(props: PropTypes) {
           type="submit"
           className={hiddenIf(showPayPalRecurringButton, 'form__submit-button')}
         >
-          Contribute&nbsp;
-          {amount ? formatAmount(
-            currencies[props.currency],
-            spokenCurrencies[props.currency],
-            amount,
-            false,
-          ) : null}&nbsp;
-          {frequency ? `${frequency} ` : null}
-          {getPaymentDescription(props.contributionType, props.paymentMethod)}&nbsp;
-          <SvgArrowRight />
+          <span className={'form__submit-button__inner'}>
+            Contribute&nbsp;
+            {amount ? formatAmount(
+              currencies[props.currency],
+              spokenCurrencies[props.currency],
+              amount,
+              false,
+            ) : null}&nbsp;
+            {frequency ? `${frequency} ` : null}
+            {getPaymentDescription(props.contributionType, props.paymentMethod)}&nbsp;
+            <SvgArrowRight />
+          </span>
         </button>
       </div>
     );

--- a/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
@@ -120,7 +120,7 @@ function ContributionSubmit(props: PropTypes) {
           type="submit"
           className={hiddenIf(showPayPalRecurringButton, 'form__submit-button')}
         >
-          <span className='form__submit-button__inner'>
+          <span className="form__submit-button__inner">
             Contribute&nbsp;
             {amount ? formatAmount(
               currencies[props.currency],

--- a/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
@@ -120,7 +120,7 @@ function ContributionSubmit(props: PropTypes) {
           type="submit"
           className={hiddenIf(showPayPalRecurringButton, 'form__submit-button')}
         >
-          <span className={'form__submit-button__inner'}>
+          <span className='form__submit-button__inner'>
             Contribute&nbsp;
             {amount ? formatAmount(
               currencies[props.currency],

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -770,21 +770,16 @@ form {
 }
 
 .form__submit {
-  display: flex;
-  justify-content: flex-end;
   margin-top: 24px;
   padding-bottom: 30px;
 }
 
 .form__submit-button {
-  align-items: center;
+  width: 100%;
   background: gu-colour(news-garnett-highlight);
   border: none;
   border-radius: 20px;
-  display: inline-flex;
   padding: 9px 20px;
-  flex: 1;
-  justify-content: space-between;
 
   &:enabled {
     cursor: pointer;
@@ -794,6 +789,13 @@ form {
       filter: brightness(90%);
     }
   }
+}
+
+.form__submit-button__inner {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .form__submit-button--hidden {


### PR DESCRIPTION
The basic problem here is that `<button>` elements cannot be flex containers. https://stackoverflow.com/questions/35464067/flexbox-not-working-on-button-or-fieldset-elements

This fixes it for the homepage submit button, which is the most important. But there are buttons on the thank you page which use duplicated CSS and different components. I suggest that in a separate PR, we try and rationalise the button components for the new flow - one component, one set of CSS rules. And in the process, fix the thank you page buttons too.

Based on GA, this fix will affect at least 5% of our site visitors

### Firefox 48

| Before  | After |
| ------------- | ------------- |
| <img width="430" alt="picture 325" src="https://user-images.githubusercontent.com/5122968/48087992-bf27dd80-e1f8-11e8-9060-e1171d3837c1.png"> | <img width="435" alt="picture 327" src="https://user-images.githubusercontent.com/5122968/48088014-ca7b0900-e1f8-11e8-8c80-37b34f024068.png"> |

### Safari 10
| Before  | After |
| ------------- | ------------- |
| <img width="395" alt="picture 331" src="https://user-images.githubusercontent.com/5122968/48088085-f39b9980-e1f8-11e8-8444-68b0dca61bab.png"> | <img width="401" alt="picture 330" src="https://user-images.githubusercontent.com/5122968/48088100-fd250180-e1f8-11e8-951d-7b718df8fcc0.png"> |