### PR TITLE
Turn off annual test

### DIFF
--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -14,7 +14,7 @@ export const tests: Tests = {
         size: 1,
       },
     },
-    isActive: true,
+    isActive: false,
     independent: true,
     seed: 3,
   },


### PR DESCRIPTION
## Why are you doing this?
I had started to remove all the code, but then realised how much there was and thought it seemed unnecessary when we are very likely to resume amounts testing as soon as the NPF test is complete. 

