### PR TITLE
NPF: Add extra form validation and amounts selection tracking + couple of tracking fixes

### DIFF
--- a/assets/components/radioToggle/radioToggle.jsx
+++ b/assets/components/radioToggle/radioToggle.jsx
@@ -7,6 +7,7 @@ import uuidv4 from 'uuid';
 
 import { classNameWithModifiers } from 'helpers/utilities';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { trackComponentClick } from 'helpers/tracking/ophanComponentEventTracking';
 
 
 // ----- Types ----- //
@@ -60,7 +61,10 @@ function getRadioButtons(props: PropTypes) {
           name={props.name}
           value={radio.value}
           id={radioId}
-          onChange={() => props.toggleAction(radio.value, props.countryGroupId)}
+          onChange={() => {
+            trackComponentClick(`opf-${props.name}-${props.countryGroupId}-${radio.value}`);
+            props.toggleAction(radio.value, props.countryGroupId);
+          }}
           checked={radioChecked}
           tabIndex="0"
           aria-describedby={a11yHintId}

--- a/assets/helpers/checkoutForm/checkoutForm.js
+++ b/assets/helpers/checkoutForm/checkoutForm.js
@@ -63,7 +63,8 @@ export const invalidReason = (form: Object | null): string => {
   let invalidReasonString = '';
   if (form instanceof HTMLFormElement) {
     [...form.elements].forEach((element) => {
-      if (element instanceof HTMLInputElement && !element.checkValidity()) {
+      if ((element instanceof HTMLInputElement || element instanceof HTMLSelectElement)
+        && !element.checkValidity()) {
         invalidReasonString += `-${element.id}${getInvalidReason(element.validity)}`;
       }
     });

--- a/assets/helpers/checkoutForm/checkoutForm.js
+++ b/assets/helpers/checkoutForm/checkoutForm.js
@@ -60,16 +60,22 @@ const getInvalidReason = (validityState: ValidityState) => {
 };
 
 export const invalidReason = (form: Object | null): string => {
-  let invalidReasonString = '';
-  if (form instanceof HTMLFormElement) {
-    [...form.elements].forEach((element) => {
-      if ((element instanceof HTMLInputElement || element instanceof HTMLSelectElement)
-        && !element.checkValidity()) {
-        invalidReasonString += `-${element.id}${getInvalidReason(element.validity)}`;
-      }
-    });
+  try {
+    let invalidReasonString = '';
+    if (form instanceof HTMLFormElement) {
+      [...form.elements].forEach((element) => {
+        if ((element instanceof HTMLInputElement || element instanceof HTMLSelectElement)
+          && !element.checkValidity()) {
+          invalidReasonString += `-${element.id}${getInvalidReason(element.validity)}`;
+        }
+      });
+    } else {
+      invalidReasonString = 'form-not-instance-of-html-element';
+    }
+    return invalidReasonString;
+  } catch (e) {
+    return e;
   }
-  return invalidReasonString;
 };
 
 

--- a/assets/helpers/checkoutForm/checkoutForm.js
+++ b/assets/helpers/checkoutForm/checkoutForm.js
@@ -50,6 +50,28 @@ export const formInputs = (formClassName: string): Array<HTMLInputElement> => {
 export const getForm: string => Object | null =
   (formName: string) => document.querySelector(`.${formName}`);
 
+const getInvalidReason = (validityState: ValidityState) => {
+  if (validityState.valueMissing) {
+    return '-value-missing';
+  } else if (validityState.patternMismatch) {
+    return '-pattern-mismatch';
+  }
+  return '';
+};
+
+export const invalidReason = (form: Object | null): string => {
+  let invalidReasonString = '';
+  if (form instanceof HTMLFormElement) {
+    [...form.elements].forEach((element) => {
+      if (element instanceof HTMLInputElement && !element.checkValidity()) {
+        invalidReasonString += `-${element.id}${getInvalidReason(element.validity)}`;
+      }
+    });
+  }
+  return invalidReasonString;
+};
+
+
 export const formElementIsValid = (formElement: Object | null) => {
   if (formElement && formElement instanceof HTMLFormElement) {
     return formElement.checkValidity();

--- a/assets/helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis.js
+++ b/assets/helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis.js
@@ -121,6 +121,7 @@ function checkRegularStatus(
     switch (json.status) {
       case 'success':
       case 'pending':
+        trackConversion(participations, routes.recurringContribPending);
         return PaymentSuccess;
 
       default:
@@ -147,10 +148,7 @@ function checkRegularStatus(
         return logPromise(pollUntilPromise(
           MAX_POLLS,
           POLLING_INTERVAL,
-          () => {
-            trackConversion(participations, routes.recurringContribPending);
-            return fetchJson(json.trackingUri, getRequestOptions('same-origin', csrf));
-          },
+          () => fetchJson(json.trackingUri, getRequestOptions('same-origin', csrf)),
           json2 => json2.status === 'pending',
         ).then(handleCompletion, handleExhaustedPolls));
 

--- a/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
@@ -30,7 +30,7 @@ type PropTypes = {|
   selectAmount: (Amount | 'other', CountryGroupId, Contrib) => (() => void),
   otherAmount: string | null,
   checkOtherAmount: string => boolean,
-  updateOtherAmount: (string, Contrib) => void,
+  updateOtherAmount: (string, CountryGroupId, Contrib) => void,
   checkoutFormHasBeenSubmitted: boolean,
   annualTestVariant: AnnualContributionsTestVariant,
 |};
@@ -49,11 +49,11 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = (dispatch: Function) => ({
   selectAmount: (amount, countryGroupId, contributionType) => () => {
-    trackComponentClick(`npf-change-amount-${contributionType}-${countryGroupId}-${amount.value || amount}`);
+    trackComponentClick(`npf-contribution-amount-toggle-${countryGroupId}-${contributionType}-${amount.value || amount}`);
     dispatch(selectAmount(amount, contributionType));
   },
-  updateOtherAmount: (amount, contributionType) => {
-    trackComponentClick(`npf-change-other-amount-${contributionType}-${amount}`);
+  updateOtherAmount: (amount, countryGroupId, contributionType) => {
+    trackComponentClick(`npf-contribution-amount-toggle-${countryGroupId}-${contributionType}-${amount}`);
     dispatch(setValueAndTogglePayPal<string>(updateOtherAmount, amount));
   },
 });
@@ -126,7 +126,7 @@ function ContributionAmount(props: PropTypes) {
           label="Other amount"
           value={props.otherAmount}
           icon={iconForCountryGroup(props.countryGroupId)}
-          onInput={e => props.updateOtherAmount((e.target: any).value, props.contributionType)}
+          onInput={e => props.updateOtherAmount((e.target: any).value, props.countryGroupId, props.contributionType)}
           isValid={props.checkOtherAmount(props.otherAmount || '')}
           formHasBeenSubmitted={props.checkoutFormHasBeenSubmitted}
           errorMessage={`Please provide an amount between ${minAmount} and ${maxAmount}`}

--- a/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
@@ -10,6 +10,7 @@ import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { type IsoCurrency, type Currency, type SpokenCurrency, currencies, spokenCurrencies } from 'helpers/internationalisation/currency';
 import { classNameWithModifiers } from 'helpers/utilities';
 import type { AnnualContributionsTestVariant } from 'helpers/abTests/abtestDefinitions';
+import { trackComponentClick } from 'helpers/tracking/ophanComponentEventTracking';
 
 import SvgDollar from 'components/svgs/dollar';
 import SvgEuro from 'components/svgs/euro';
@@ -29,7 +30,7 @@ type PropTypes = {|
   selectAmount: (Amount | 'other', Contrib) => (() => void),
   otherAmount: string | null,
   checkOtherAmount: string => boolean,
-  updateOtherAmount: string => void,
+  updateOtherAmount: (string, Contrib) => void,
   checkoutFormHasBeenSubmitted: boolean,
   annualTestVariant: AnnualContributionsTestVariant,
 |};
@@ -47,8 +48,14 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
-  selectAmount: (amount, contributionType) => () => { dispatch(selectAmount(amount, contributionType)); },
-  updateOtherAmount: (amount) => { dispatch(setValueAndTogglePayPal<string>(updateOtherAmount, amount)); },
+  selectAmount: (amount, contributionType) => () => {
+    trackComponentClick(`change-amount-new-flow-${contributionType}-${amount}`);
+    dispatch(selectAmount(amount, contributionType));
+  },
+  updateOtherAmount: (amount, contributionType) => {
+    trackComponentClick(`change-other-amount-new-flow-${contributionType}-${amount}`);
+    dispatch(setValueAndTogglePayPal<string>(updateOtherAmount, amount));
+  },
 });
 
 // ----- Render ----- //
@@ -119,7 +126,7 @@ function ContributionAmount(props: PropTypes) {
           label="Other amount"
           value={props.otherAmount}
           icon={iconForCountryGroup(props.countryGroupId)}
-          onInput={e => props.updateOtherAmount((e.target: any).value)}
+          onInput={e => props.updateOtherAmount((e.target: any).value, props.contributionType)}
           isValid={props.checkOtherAmount(props.otherAmount || '')}
           formHasBeenSubmitted={props.checkoutFormHasBeenSubmitted}
           errorMessage={`Please provide an amount between ${minAmount} and ${maxAmount}`}

--- a/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
@@ -27,7 +27,7 @@ type PropTypes = {|
   currency: IsoCurrency,
   contributionType: Contrib,
   selectedAmounts: { [Contrib]: Amount | 'other' },
-  selectAmount: (Amount | 'other', Contrib) => (() => void),
+  selectAmount: (Amount | 'other', CountryGroupId, Contrib) => (() => void),
   otherAmount: string | null,
   checkOtherAmount: string => boolean,
   updateOtherAmount: (string, Contrib) => void,
@@ -48,8 +48,8 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
-  selectAmount: (amount, contributionType) => () => {
-    trackComponentClick(`change-amount-new-flow-${contributionType}-${amount}`);
+  selectAmount: (amount, countryGroupId, contributionType) => () => {
+    trackComponentClick(`change-amount-new-flow-${contributionType}-${countryGroupId}-${amount.value || amount}`);
     dispatch(selectAmount(amount, contributionType));
   },
   updateOtherAmount: (amount, contributionType) => {
@@ -75,7 +75,7 @@ const renderAmount = (currency: Currency, spokenCurrency: SpokenCurrency, props:
       value={amount.value}
       /* eslint-disable react/prop-types */
       checked={props.selectedAmounts[props.contributionType] !== 'other' && amount.value === props.selectedAmounts[props.contributionType].value}
-      onChange={props.selectAmount(amount, props.contributionType)}
+      onChange={props.selectAmount(amount, props.countryGroupId, props.contributionType)}
       /* eslint-enable react/prop-types */
     />
     <label htmlFor={`contributionAmount-${amount.value}`} className="form__radio-group-label" aria-label={formatAmount(currency, spokenCurrency, amount, true)}>
@@ -113,7 +113,7 @@ function ContributionAmount(props: PropTypes) {
             name="contributionAmount"
             value="other"
             checked={showOther}
-            onChange={props.selectAmount('other', props.contributionType)}
+            onChange={props.selectAmount('other', props.countryGroupId, props.contributionType)}
           />
           <label htmlFor="contributionAmount-other" className="form__radio-group-label">Other</label>
         </li>

--- a/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
@@ -49,11 +49,11 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = (dispatch: Function) => ({
   selectAmount: (amount, countryGroupId, contributionType) => () => {
-    trackComponentClick(`change-amount-new-flow-${contributionType}-${countryGroupId}-${amount.value || amount}`);
+    trackComponentClick(`npf-change-amount-${contributionType}-${countryGroupId}-${amount.value || amount}`);
     dispatch(selectAmount(amount, contributionType));
   },
   updateOtherAmount: (amount, contributionType) => {
-    trackComponentClick(`change-other-amount-new-flow-${contributionType}-${amount}`);
+    trackComponentClick(`npf-change-other-amount-${contributionType}-${amount}`);
     dispatch(setValueAndTogglePayPal<string>(updateOtherAmount, amount));
   },
 });

--- a/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -32,7 +32,7 @@ import {
   isLargerOrEqual,
   maxTwoDecimals,
 } from 'helpers/formValidation';
-import { formElementIsValid } from 'helpers/checkoutForm/checkoutForm';
+import { formElementIsValid, invalidReason } from 'helpers/checkoutForm/checkoutForm';
 import { type UserTypeFromIdentityResponse, canContributeWithoutSigningIn } from 'helpers/identityApis';
 import { trackCheckoutSubmitAttempt } from 'helpers/tracking/ophanComponentEventTracking';
 
@@ -186,7 +186,6 @@ function onSubmit(props: PropTypes): Event => void {
 
     if (formIsValid) {
       props.setFormIsValid(true);
-
       if (canContribute) {
         formHandlers[props.contributionType][props.paymentMethod](props);
         trackCheckoutSubmitAttempt(componentId, `allowed-for-user-type-${userType}`);
@@ -195,7 +194,7 @@ function onSubmit(props: PropTypes): Event => void {
       }
     } else {
       props.setFormIsValid(false);
-      trackCheckoutSubmitAttempt(componentId, 'blocked-because-form-not-valid');
+      trackCheckoutSubmitAttempt(componentId, `blocked-because-form-not-valid${invalidReason(event.target)}`);
     }
   };
 }

--- a/assets/pages/new-contributions-landing/components/ContributionType.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionType.jsx
@@ -12,6 +12,7 @@ import { getPaymentMethodToSelect } from 'helpers/checkouts';
 import { trackComponentClick } from 'helpers/tracking/ophanComponentEventTracking';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { Switches } from 'helpers/settings';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { type State } from '../contributionsLandingReducer';
 import { type Action, updateContributionType } from '../contributionsLandingActions';
 
@@ -20,20 +21,27 @@ import { type Action, updateContributionType } from '../contributionsLandingActi
 type PropTypes = {|
   contributionType: Contrib,
   countryId: IsoCountry,
+  countryGroupId: CountryGroupId,
   switches: Switches,
-  onSelectContributionType: (Contrib, Switches, IsoCountry) => void,
+  onSelectContributionType: (Contrib, Switches, IsoCountry, CountryGroupId) => void,
 |};
 
 const mapStateToProps = (state: State) => ({
+  countryGroupId: state.common.internationalisation.countryGroupId,
   contributionType: state.page.form.contributionType,
   countryId: state.common.internationalisation.countryId,
   switches: state.common.settings.switches,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch<Action>) => ({
-  onSelectContributionType: (contributionType: Contrib, switches: Switches, countryId: IsoCountry) => {
+  onSelectContributionType: (
+    contributionType: Contrib,
+    switches: Switches,
+    countryId: IsoCountry,
+    countryGroupId: CountryGroupId,
+  ) => {
     const paymentMethodToSelect = getPaymentMethodToSelect(contributionType, switches, countryId);
-    trackComponentClick(`npf-change-contribution-type-${contributionType}`);
+    trackComponentClick(`npf-contribution-type-toggle-${countryGroupId}-${contributionType}`);
     dispatch(updateContributionType(contributionType, paymentMethodToSelect));
   },
 });
@@ -55,7 +63,7 @@ function ContributionType(props: PropTypes) {
             type="radio"
             name="contributionType"
             value={oneOff}
-            onChange={() => props.onSelectContributionType(oneOff, props.switches, props.countryId)}
+            onChange={() => props.onSelectContributionType(oneOff, props.switches, props.countryId, props.countryGroupId)}
             checked={props.contributionType === oneOff}
           />
           <label htmlFor="contributionType-oneoff" className="form__radio-group-label">Single</label>
@@ -67,7 +75,7 @@ function ContributionType(props: PropTypes) {
             type="radio"
             name="contributionType"
             value={monthly}
-            onChange={() => props.onSelectContributionType(monthly, props.switches, props.countryId)}
+            onChange={() => props.onSelectContributionType(monthly, props.switches, props.countryId, props.countryGroupId)}
             checked={props.contributionType === monthly}
           />
           <label htmlFor="contributionType-monthly" className="form__radio-group-label">Monthly</label>
@@ -79,7 +87,7 @@ function ContributionType(props: PropTypes) {
             type="radio"
             name="contributionType"
             value={annual}
-            onChange={() => props.onSelectContributionType(annual, props.switches, props.countryId)}
+            onChange={() => props.onSelectContributionType(annual, props.switches, props.countryId, props.countryGroupId)}
             checked={props.contributionType === annual}
           />
           <label htmlFor="contributionType-annual" className="form__radio-group-label">Annual</label>

--- a/assets/pages/new-contributions-landing/components/ContributionType.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionType.jsx
@@ -9,6 +9,7 @@ import { type Contrib } from 'helpers/contributions';
 import { classNameWithModifiers } from 'helpers/utilities';
 import { getPaymentMethodToSelect } from 'helpers/checkouts';
 
+import { trackComponentClick } from 'helpers/tracking/ophanComponentEventTracking';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { Switches } from 'helpers/settings';
 import { type State } from '../contributionsLandingReducer';
@@ -32,6 +33,7 @@ const mapStateToProps = (state: State) => ({
 const mapDispatchToProps = (dispatch: Dispatch<Action>) => ({
   onSelectContributionType: (contributionType: Contrib, switches: Switches, countryId: IsoCountry) => {
     const paymentMethodToSelect = getPaymentMethodToSelect(contributionType, switches, countryId);
+    trackComponentClick(`change-contribution-type-new-flow-${contributionType}`);
     dispatch(updateContributionType(contributionType, paymentMethodToSelect));
   },
 });

--- a/assets/pages/new-contributions-landing/components/ContributionType.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionType.jsx
@@ -33,7 +33,7 @@ const mapStateToProps = (state: State) => ({
 const mapDispatchToProps = (dispatch: Dispatch<Action>) => ({
   onSelectContributionType: (contributionType: Contrib, switches: Switches, countryId: IsoCountry) => {
     const paymentMethodToSelect = getPaymentMethodToSelect(contributionType, switches, countryId);
-    trackComponentClick(`change-contribution-type-new-flow-${contributionType}`);
+    trackComponentClick(`npf-change-contribution-type-${contributionType}`);
     dispatch(updateContributionType(contributionType, paymentMethodToSelect));
   },
 });

--- a/assets/pages/new-contributions-landing/components/ContributionType.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionType.jsx
@@ -63,7 +63,9 @@ function ContributionType(props: PropTypes) {
             type="radio"
             name="contributionType"
             value={oneOff}
-            onChange={() => props.onSelectContributionType(oneOff, props.switches, props.countryId, props.countryGroupId)}
+            onChange={() =>
+              props.onSelectContributionType(oneOff, props.switches, props.countryId, props.countryGroupId)
+            }
             checked={props.contributionType === oneOff}
           />
           <label htmlFor="contributionType-oneoff" className="form__radio-group-label">Single</label>
@@ -75,7 +77,9 @@ function ContributionType(props: PropTypes) {
             type="radio"
             name="contributionType"
             value={monthly}
-            onChange={() => props.onSelectContributionType(monthly, props.switches, props.countryId, props.countryGroupId)}
+            onChange={() =>
+              props.onSelectContributionType(monthly, props.switches, props.countryId, props.countryGroupId)
+            }
             checked={props.contributionType === monthly}
           />
           <label htmlFor="contributionType-monthly" className="form__radio-group-label">Monthly</label>
@@ -87,7 +91,9 @@ function ContributionType(props: PropTypes) {
             type="radio"
             name="contributionType"
             value={annual}
-            onChange={() => props.onSelectContributionType(annual, props.switches, props.countryId, props.countryGroupId)}
+            onChange={() =>
+              props.onSelectContributionType(annual, props.switches, props.countryId, props.countryGroupId)
+            }
             checked={props.contributionType === annual}
           />
           <label htmlFor="contributionType-annual" className="form__radio-group-label">Annual</label>


### PR DESCRIPTION
## Why are you doing this?
We have been seeing an unexpectedly high rate of form errors on the new payment flow. This PR does a few things around this:

- Adds the form validation error tracking to the old flow so we can see if this is a new issue we've created
- Adds the reasons for the form validation error to the event

and example of what the form validation error event looks like: 

`blocked-because-form-not-valid-contributionEmail-pattern-mismatch-contributionFirstName-value-missing-contributionLastName-value-missing-contributionState-value-missing`

Yes it's rather unwieldy, but it gets the job done.

It also adds click tracking on the amounts and contribution type selections on the new and oldflow

Examples of the events:
NPF change amount: `npf-contribution-amount-toggle-GBPCountries-MONTHLY-10`
NPF change contribution type: `npf-contribution-type-toggle-GBPCountries-MONTHLY`

OPF change amount: `opf-contribution-amount-toggle-GBPCountries-100`
OPF change contribution type: `opf-contribution-type-toggle-GBPCountries-ONE_OFF`

You'll notice that the OPF change amount doesn't have the contribution type. This is because both the amounts toggle and the contribution type toggle come from the same generic `RadioToggle` class which doesn't have knowledge of the context it is in with regards to other instances of Radio Toggle. We could get around this, but as this flow will likely be turned off very soon I think this will suffice for now

Finally, it puts the NPF recurring conversion tracking in the right place

@guardian/contributions 
