### PR TITLE
Remove client-side GA conversion tracking

### DIFF
--- a/assets/helpers/tracking/conversions.js
+++ b/assets/helpers/tracking/conversions.js
@@ -10,10 +10,6 @@ export default function trackConversion(
   participations: Participations,
   currentRoute: string,
 ) {
-  if (!doNotTrack()) {
-    // Fire GTM conversion events
-    successfulConversion(participations);
-  }
   // Send an Ophan pageview. Because this function is used to track page views
   // from client side routed thank you pages, the referrer will always be the current location
   pageView(getAbsoluteURL(currentRoute), document.location.href);

--- a/assets/helpers/tracking/conversions.js
+++ b/assets/helpers/tracking/conversions.js
@@ -1,9 +1,7 @@
 // @flow
 
-import { doNotTrack } from 'helpers/page/page';
 import { getAbsoluteURL } from '../url';
 import { pageView } from './ophanComponentEventTracking';
-import { successfulConversion } from './googleTagManager';
 import type { Participations } from '../abTests/abtest';
 
 export default function trackConversion(

--- a/assets/helpers/tracking/googleTagManager.js
+++ b/assets/helpers/tracking/googleTagManager.js
@@ -143,21 +143,6 @@ function sendData(
       internalCampaignCode: getQueryParameter('INTCMP') || undefined,
       experience: getVariantsAsString(participations),
       paymentRequestApiStatus,
-      ecommerce: {
-        currencyCode: currency,
-        purchase: {
-          actionField: {
-            id: orderId,
-            revenue: value, // Total transaction value (incl. tax and shipping)
-          },
-          products: [{
-            name: `${getContributionType()}_contribution`,
-            category: 'contribution',
-            price: value,
-            quantity: 1,
-          }],
-        },
-      },
     });
   } catch (e) {
     console.log(`Error in GTM tracking ${e}`);
@@ -186,10 +171,6 @@ function init(participations: Participations) {
   pushToDataLayer('DataLayerReady', participations);
 }
 
-function successfulConversion(participations: Participations) {
-  sendData('SuccessfulConversion', participations);
-}
-
 function gaEvent(gaEventData: GaEventData) {
   if (window.googleTagManagerDataLayer) {
     window.googleTagManagerDataLayer.push({
@@ -210,7 +191,6 @@ function appStoreCtaClick() {
 export {
   init,
   gaEvent,
-  successfulConversion,
   appStoreCtaClick,
   gaPropertyId,
 };

--- a/assets/helpers/tracking/googleTagManager.js
+++ b/assets/helpers/tracking/googleTagManager.js
@@ -41,14 +41,6 @@ function getOrderId() {
   return value;
 }
 
-function getContributionType() {
-  const param = getQueryParameter('contribType');
-  if (param) {
-    storage.setSession('contribType', param);
-  }
-  return (storage.getSession('contribType') || 'one_off').toLowerCase(); // PayPal route doesn't set the contribType
-}
-
 function getCurrency(): string {
   const currency = detectCurrency(detectCountryGroup());
   if (currency) {


### PR DESCRIPTION
## Why are you doing this?
GA conversion tracking is now done server-side by support-workers and payment-api.


