### PR TITLE
Fix recurring selenium test for old payment flow

### DIFF
--- a/test/selenium/RecurringContributionsSpec.scala
+++ b/test/selenium/RecurringContributionsSpec.scala
@@ -20,42 +20,32 @@ class RecurringContributionsSpec extends FeatureSpec with GivenWhenThen with Bef
 
   feature("Sign up for a Monthly Contribution") {
 
-    ignore("Monthly contribution sign-up with Stripe - GBP") {
+    scenario("Monthly contribution sign-up with Stripe - GBP") {
 
       val landingPage = ContributionsLanding("uk")
-      val recurringContributionForm = new RecurringContributionForm
+      val testUser = new TestUser(driverConfig)
+
+      val recurringContributionForm = RecurringContributionForm(testUser)
       val recurringContributionThankYou = new RecurringContributionThankYou
 
       Given("that a test user goes to the contributions landing page")
-      val testUser = new TestUser(driverConfig)
       goTo(landingPage)
       assert(landingPage.pageHasLoaded)
 
       When("they select to contribute the default amount")
       landingPage.clickContribute
 
-      Then("they should be redirected to register as an Identity user")
-      val registerPageOne = RegisterPageOne(testUser, 10)
-      assert(registerPageOne.pageHasLoaded)
-
-      Given("that the user fills in their personal details correctly")
-      registerPageOne.fillInPersonalDetails()
-
-      When("they submit the form to create their Identity account")
-      registerPageOne.submit()
-
-      Then("they should be redirected to register as an Identity user")
-      val registerPageTwo = RegisterPageTwo(testUser, 10)
-      assert(registerPageTwo.pageHasLoaded)
-
-      Given("that the user fills in their personal details correctly")
-      registerPageTwo.fillInPersonalDetails()
-
-      When("they submit the form to create their Identity account")
-      registerPageTwo.submit()
-
       Then("they should be redirected to the Monthly Contributions page")
-      assert(recurringContributionForm.pageHasLoaded)
+      assert(recurringContributionForm.detailsPageHasLoaded)
+
+      Given("The user fills in their details correctly")
+      recurringContributionForm.fillInPersonalDetails()
+
+      Given("They select next")
+      recurringContributionForm.clickNext
+
+      Then("they should be redirected to the payment page")
+      assert(recurringContributionForm.paymentPageHasLoaded)
 
       Given("that the user selects to pay with Stripe")
 
@@ -69,50 +59,35 @@ class RecurringContributionsSpec extends FeatureSpec with GivenWhenThen with Bef
 
     }
 
-    ignore("Monthly contribution sign-up with PayPal - USD") {
-
-      val expectedPayment = "15.00"
+    scenario("Monthly contribution sign-up with Paypal - USD") {
 
       val landingPage = ContributionsLanding("us")
-      val recurringContributionForm = new RecurringContributionForm
+      val testUser = new TestUser(driverConfig)
       val payPalCheckout = new PayPalCheckout
+      val expectedPayment = "15.00"
+      val recurringContributionForm = RecurringContributionForm(testUser)
       val recurringContributionThankYou = new RecurringContributionThankYou
 
       Given("that a test user goes to the contributions landing page")
-      val testUser = new TestUser(driverConfig)
       goTo(landingPage)
       assert(landingPage.pageHasLoaded)
 
       When("they select to contribute the default amount")
       landingPage.clickContribute
 
-      Then("they should be redirected to register as an Identity user")
-      val registerPageOne = RegisterPageOne(testUser, 10)
-      assert(registerPageOne.pageHasLoaded)
-
-      Given("that the user fills in their personal details correctly")
-      registerPageOne.fillInPersonalDetails()
-
-      When("they submit the form to create their Identity account")
-      registerPageOne.submit()
-
-      Then("they should be redirected to register as an Identity user")
-      val registerPageTwo = RegisterPageTwo(testUser, 10)
-      assert(registerPageTwo.pageHasLoaded)
-
-      Given("that the user fills in their personal details correctly")
-      registerPageTwo.fillInPersonalDetails()
-
-      When("they submit the form to create their Identity account")
-      registerPageTwo.submit()
-
       Then("they should be redirected to the Monthly Contributions page")
-      assert(recurringContributionForm.pageHasLoaded)
+      assert(recurringContributionForm.detailsPageHasLoaded)
 
-      Given("that the user sets their state correctly")
-      recurringContributionForm.selectState
+      Given("The user fills in their details correctly")
+      recurringContributionForm.fillInPersonalDetailsNoEmail()
 
-      And("they select to pay with PayPal")
+      Given("They select next")
+      recurringContributionForm.clickNext
+
+      Then("they should be redirected to the payment page")
+      assert(recurringContributionForm.paymentPageHasLoaded)
+
+      Given("they select to pay with PayPal")
 
       When("they press the PayPal payment button")
       recurringContributionForm.selectPayPalPayment

--- a/test/selenium/RecurringContributionsSpec.scala
+++ b/test/selenium/RecurringContributionsSpec.scala
@@ -41,7 +41,7 @@ class RecurringContributionsSpec extends FeatureSpec with GivenWhenThen with Bef
       Given("The user fills in their details correctly")
       recurringContributionForm.fillInPersonalDetails()
 
-      Given("They select next")
+      When("They select next")
       recurringContributionForm.clickNext
 
       Then("they should be redirected to the payment page")

--- a/test/selenium/pages/RecurringContributionForm.scala
+++ b/test/selenium/pages/RecurringContributionForm.scala
@@ -2,21 +2,49 @@ package selenium.pages
 
 import org.openqa.selenium.WebDriver
 import org.scalatest.selenium.Page
-import selenium.util.{Browser, Config, PayPalCheckout}
+import selenium.util.{Browser, Config, PayPalCheckout, TestUser}
 
-class RecurringContributionForm(implicit val webDriver: WebDriver) extends Page with Browser {
+case class RecurringContributionForm(testUser: TestUser)(implicit val webDriver: WebDriver) extends Page with Browser {
 
-  val url = s"${Config.supportFrontendUrl}/contribute/recurring"
+  val url = s"${Config.supportFrontendUrl}/contribute/recurring-guest"
 
   private val stripeButton = id("qa-pay-with-card")
 
   private val payPalButton = id("component-paypal-button-checkout")
 
+  private object RegisterFields {
+    private val firstName = id("first-name")
+    private val lastName = id("last-name")
+    private val email = id("email")
+
+    def fillIn() {
+
+      setValue(email, s"${testUser.username}@gu.com", clear = true)
+      setValue(firstName, testUser.username, clear = true)
+      setValue(lastName, testUser.username, clear = true)
+    }
+
+    def fillInWithoutEmail() {
+      setValue(firstName, testUser.username, clear = true)
+      setValue(lastName, testUser.username, clear = true)
+    }
+  }
+
+  private val nextButton = id("qa-contribute-button")
+
   private val stateSelector = id("qa-state-dropdown")
 
-  def pageHasLoaded: Boolean = pageHasElement(stripeButton) && pageHasElement(payPalButton)
+  def paymentPageHasLoaded: Boolean = pageHasElement(stripeButton) && pageHasElement(payPalButton)
+
+  def detailsPageHasLoaded: Boolean = pageHasElement(nextButton)
+
+  def clickNext: Unit = clickOn(nextButton)
 
   def selectState: Unit = setSingleSelectionValue(stateSelector, "NY")
+
+  def fillInPersonalDetails() { RegisterFields.fillIn() }
+
+  def fillInPersonalDetailsNoEmail() { RegisterFields.fillInWithoutEmail() }
 
   // ----- Stripe ----- //
 


### PR DESCRIPTION
## Why are you doing this?

We need to write tests for the old flow, but for now, I've fixed the ones we broke before.

Annoyingly, the second time around, the email field autofills and won't clear. I looked into it and it's something to do with `autocomplete` being on which Selenium has trouble with ( [see here](https://www.google.co.uk/search?q=selenium+webelement+clear+not+working&rlz=1C5CHFA_enGB806GB806&oq=selenium+webelement+clear+not+working&aqs=chrome..69i57.9175j0j7&sourceid=chrome&ie=UTF-8) ) But for now, the second time around we just don't fill in the email and it still works with the test email generated the first time round!
