### PR TITLE
Add authenticated case to OPF recurring guest checkout test

### DIFF
--- a/test/selenium/RecurringContributionsSpec.scala
+++ b/test/selenium/RecurringContributionsSpec.scala
@@ -63,10 +63,34 @@ class RecurringContributionsSpec extends FeatureSpec with GivenWhenThen with Bef
 
       val landingPage = ContributionsLanding("us")
       val testUser = new TestUser(driverConfig)
+      val registerPageOne = RegisterPageOne(testUser, 15)
       val payPalCheckout = new PayPalCheckout
       val expectedPayment = "15.00"
       val recurringContributionForm = RecurringContributionForm(testUser)
       val recurringContributionThankYou = new RecurringContributionThankYou
+
+      goTo(registerPageOne)
+
+      assert(registerPageOne.pageHasLoaded)
+
+      Given("that the user fills in their personal details correctly")
+      registerPageOne.fillInPersonalDetails()
+
+      When("they submit the form to create their Identity account")
+      registerPageOne.submit()
+      Then("they should be redirected to register as an Identity user")
+
+      val registerPageTwo = RegisterPageTwo(testUser, 15)
+      assert(registerPageTwo.pageHasLoaded)
+
+      Given("that the user fills in their personal details correctly")
+      registerPageTwo.fillInPersonalDetails()
+
+      When("they submit the form to create their Identity account")
+
+      registerPageTwo.submit()
+
+      goTo(landingPage)
 
       Given("that a test user goes to the contributions landing page")
       goTo(landingPage)
@@ -77,9 +101,6 @@ class RecurringContributionsSpec extends FeatureSpec with GivenWhenThen with Bef
 
       Then("they should be redirected to the Monthly Contributions page")
       assert(recurringContributionForm.detailsPageHasLoaded)
-
-      Given("The user fills in their details correctly")
-      recurringContributionForm.fillInPersonalDetailsNoEmail()
 
       Given("They select next")
       recurringContributionForm.clickNext

--- a/test/selenium/pages/RegisterPageOne.scala
+++ b/test/selenium/pages/RegisterPageOne.scala
@@ -8,7 +8,7 @@ import selenium.util.{Browser, Config, TestUser}
 
 case class RegisterPageOne(testUser: TestUser, amount: Int)(implicit val webDriver: WebDriver) extends Page with Browser {
   private val returnUrlParam = URLEncoder.encode(s"${Config.supportFrontendUrl}/contribute/recurring?contributionValue%3D${amount}", "UTF-8")
-  val url = s"${Config.identityFrontendUrl}/signin/start?returnUrl=${returnUrlParam}&skipConfirmation=true&clientId=recurringContributions"
+  val url = s"${Config.identityFrontendUrl}/signin?returnUrl=${returnUrlParam}&skipConfirmation=true&clientId=recurringContributions"
 
   def fillInPersonalDetails() { RegisterFields.fillIn() }
 


### PR DESCRIPTION
## Why are you doing this?
Amends one of the selenium recurring tests to go through the flow as an authenticated user, to give us more coverage. 