### PR TITLE
Revert removal of client-side GA conversions

### DIFF
--- a/assets/helpers/tracking/conversions.js
+++ b/assets/helpers/tracking/conversions.js
@@ -1,13 +1,19 @@
 // @flow
 
+import { doNotTrack } from 'helpers/page/page';
 import { getAbsoluteURL } from '../url';
 import { pageView } from './ophanComponentEventTracking';
+import { successfulConversion } from './googleTagManager';
 import type { Participations } from '../abTests/abtest';
 
 export default function trackConversion(
   participations: Participations,
   currentRoute: string,
 ) {
+  if (!doNotTrack()) {
+    // Fire GTM conversion events
+    successfulConversion(participations);
+  }
   // Send an Ophan pageview. Because this function is used to track page views
   // from client side routed thank you pages, the referrer will always be the current location
   pageView(getAbsoluteURL(currentRoute), document.location.href);


### PR DESCRIPTION
## Why are you doing this?
undo https://github.com/guardian/support-frontend/pull/1155
apparently this data is still needed

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com)

## Changes

* Change 1
* Change 2

## Screenshots

