### PR TITLE
Fix selenium test - remove old url

### DIFF
--- a/test/selenium/pages/ContributionsLanding.scala
+++ b/test/selenium/pages/ContributionsLanding.scala
@@ -8,7 +8,7 @@ case class ContributionsLanding(region: String)(implicit val webDriver: WebDrive
 
   // While the new contributions landing page test is running,
   // we just want Selenium to test the old page.
-  val url = s"${Config.supportFrontendUrl}/$region/contribute.old"
+  val url = s"${Config.supportFrontendUrl}/$region/contribute"
 
   private val contributeButton = id("qa-contribute-button")
 


### PR DESCRIPTION
## Why are you doing this?
This got missed in the PR to move to NPF. Causes selenium tests to fail
