### PR TITLE
Extract out GW page components into reusable `productPage` components

### DIFF
--- a/assets/components/productPage/productPageContentBlock/productPageContentBlock.jsx
+++ b/assets/components/productPage/productPageContentBlock/productPageContentBlock.jsx
@@ -12,25 +12,29 @@ import { classNameWithModifiers } from 'helpers/utilities';
 type PropTypes = {|
   type: 'white' | 'grey' | 'feature' | 'dark',
   id?: ?string,
-  children: Node
+  children: Node,
+  modifierClasses: Array<?string>,
 |};
 
 
 // ----- Render ----- //
 
-const WeeklyContentBlock = ({ type, children, id }: PropTypes) => (
-  <div id={id} className={classNameWithModifiers('weekly-content-block', [type])}>
+const ProductPageContentBlock = ({
+  type, children, id, modifierClasses,
+}: PropTypes) => (
+  <div id={id} className={classNameWithModifiers('component-product-page-content-block', [type, ...modifierClasses])}>
     <LeftMarginSection>
-      <div className="weekly-content-block__content">
+      <div className="component-product-page-content-block__content">
         {children}
       </div>
     </LeftMarginSection>
   </div>
 );
 
-WeeklyContentBlock.defaultProps = {
+ProductPageContentBlock.defaultProps = {
   type: 'white',
   id: null,
+  modifierClasses: [],
 };
 
-export default WeeklyContentBlock;
+export default ProductPageContentBlock;

--- a/assets/components/productPage/productPageContentBlock/productPageContentBlock.scss
+++ b/assets/components/productPage/productPageContentBlock/productPageContentBlock.scss
@@ -1,10 +1,10 @@
-.weekly-content-block .component-left-margin-section__content {
+.component-product-page-content-block .component-left-margin-section__content {
   @include mq($from: tablet) {
     border-left: 1px solid gu-colour(garnett-neutral-4);
   }
 }
 
-.weekly-content-block--grey {
+.component-product-page-content-block--grey {
   background-color: gu-colour(garnett-neutral-3);
   .component-left-margin-section__content {
     border-left: 0;
@@ -12,7 +12,7 @@
   }
 }
 
-.weekly-content-block--feature {
+.component-product-page-content-block--feature {
   background-color: gu-colour(header-dark);
   color: gu-colour(garnett-neutral-5);
   .component-left-margin-section__content {
@@ -23,7 +23,7 @@
   }
 }
 
-.weekly-content-block--dark {
+.component-product-page-content-block--dark {
   background-color: gu-colour(garnett-neutral-7);
   color: gu-colour(garnett-neutral-5);
   .component-left-margin-section__content {
@@ -31,18 +31,18 @@
   }
 }
 
-.weekly-content-block__content {
+.component-product-page-content-block__content {
   max-width: 1180px;
   padding: ($gu-v-spacing/2) ($gu-h-spacing / 2) 0;
 }
 
-.weekly-content-block {
-  .weekly-feature-list,
-  .weekly-form {
-    margin-left: ($gu-h-spacing / 2 * -1);
-    margin-right: ($gu-h-spacing / 2 * -1);
-  }
-  .weekly-text-block {
+.component-product-page-content-block__outset {
+  margin-left: ($gu-h-spacing / 2 * -1);
+  margin-right: ($gu-h-spacing / 2 * -1);
+}
+
+.component-product-page-content-block {
+  .component-product-page-text-block {
     margin-bottom: ($gu-v-spacing*2)
   }
 }

--- a/assets/components/productPage/productPageContentBlock/productPageContentBlockOutset.jsx
+++ b/assets/components/productPage/productPageContentBlock/productPageContentBlockOutset.jsx
@@ -1,0 +1,25 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React, { type Node } from 'react';
+
+
+// ---- Types ----- //
+
+type PropTypes = {|
+  children: Node,
+|};
+
+
+// ----- Render ----- //
+
+const ProductPageContentBlockOutset = ({
+  children,
+}: PropTypes) => (
+  <div className="component-product-page-content-block__outset">
+    {children}
+  </div>
+);
+
+export default ProductPageContentBlockOutset;

--- a/assets/components/productPage/productPageHero/productPageHero.jsx
+++ b/assets/components/productPage/productPageHero/productPageHero.jsx
@@ -5,8 +5,6 @@
 import React, { type Node } from 'react';
 import HeadingBlock from 'components/headingBlock/headingBlock';
 import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
-import GridImage from 'components/gridImage/gridImage';
-import SvgWeeklyHeroCircles from 'components/svgs/weeklyHeroCircles';
 import { classNameWithModifiers } from 'helpers/utilities';
 
 

--- a/assets/components/productPage/productPageHero/productPageHero.jsx
+++ b/assets/components/productPage/productPageHero/productPageHero.jsx
@@ -7,6 +7,7 @@ import HeadingBlock from 'components/headingBlock/headingBlock';
 import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
 import GridImage from 'components/gridImage/gridImage';
 import SvgWeeklyHeroCircles from 'components/svgs/weeklyHeroCircles';
+import { classNameWithModifiers } from 'helpers/utilities';
 
 
 // ---- Types ----- //
@@ -16,36 +17,32 @@ type PropTypes = {|
   heading: string,
   headline: string | null,
   cta: Node | null,
+  children: Node | null,
+  modifierClasses: Array<?string>,
 |};
 
 
 // ----- Render ----- //
 
-const WeeklyHero = ({
-  headline, overheading, heading, cta,
+const ProductPageHero = ({
+  headline, overheading, heading, cta, modifierClasses, children,
 }: PropTypes) => (
   <header>
-    <div className="weekly-hero">
+    <div className={classNameWithModifiers('component-product-page-hero', modifierClasses)}>
       <LeftMarginSection>
         {headline &&
-        <p className="weekly-hero__headline">
+        <p className="component-product-page-hero__headline">
           {headline}
         </p>
         }
-        <GridImage
-          gridId="weeklyLandingHero"
-          srcSizes={[1000, 500]}
-          sizes="(max-width: 740px) 90vw, 600px"
-          imgType="png"
-        />
-        <SvgWeeklyHeroCircles />
+        {children}
         <HeadingBlock overheading={overheading} heading={heading} />
       </LeftMarginSection>
     </div>
     {cta &&
-    <div className="weekly-hero-hanger">
+    <div className="component-product-page-hero-hanger">
       <LeftMarginSection>
-        <div className="weekly-hero-hanger__content">
+        <div className="component-product-page-hero-hanger__content">
           {cta}
         </div>
       </LeftMarginSection>
@@ -54,4 +51,9 @@ const WeeklyHero = ({
   </header>
 );
 
-export default WeeklyHero;
+ProductPageHero.defaultProps = {
+  modifierClasses: [],
+};
+
+
+export default ProductPageHero;

--- a/assets/components/productPage/productPageHero/productPageHero.scss
+++ b/assets/components/productPage/productPageHero/productPageHero.scss
@@ -40,7 +40,7 @@
 .component-product-page-hero__headline {
   color: gu-colour(garnett-neutral-5);
   font-family: $gu-titlepiece;
-  font-weight: bold;
+  font-weight: 400;
   line-height: 1;
   display: block;
   max-width: 440px;

--- a/assets/components/productPage/productPageHero/productPageHero.scss
+++ b/assets/components/productPage/productPageHero/productPageHero.scss
@@ -1,10 +1,9 @@
 .component-product-page-hero {
-  background: gu-colour(header-dark);
-  border-top: 1px solid gu-colour(header-border);
+  background: gu-colour(garnett-neutral-3);
   overflow: hidden;
   .component-left-margin-section__content {
     @include mq($from: tablet) {
-      border-left: 1px solid gu-colour(header-border);
+      border-left: 1px solid gu-colour(garnett-neutral-4);
       position: relative;
       .component-heading-block {
         margin-left: -1px;
@@ -38,7 +37,7 @@
 }
 
 .component-product-page-hero__headline {
-  color: gu-colour(garnett-neutral-5);
+  color: gu-colour(garnett-neutral-1);
   font-family: $gu-titlepiece;
   font-weight: 400;
   line-height: 1;

--- a/assets/components/productPage/productPageHero/productPageHero.scss
+++ b/assets/components/productPage/productPageHero/productPageHero.scss
@@ -1,4 +1,4 @@
-.weekly-hero {
+.component-product-page-hero {
   background: gu-colour(header-dark);
   border-top: 1px solid gu-colour(header-border);
   overflow: hidden;
@@ -11,44 +11,18 @@
       }    
     }
   }
-  .svg-weekly-hero-circles {
-    position: absolute;
-    width: 300px;
-    left: -300px;
-    bottom: 0;
-  }
   .component-heading-block {
     z-index: 10;
     position: relative;
   }
-  .component-grid-image {
-    display: block;
-    width: 90%;
-    max-width: 500px;
-    margin: ($gu-v-spacing * 3) auto -25%;
-    z-index: 9;
-    @include mq($from: tablet) {
-      width: auto;
-      max-width: 100%;
-      height: 100%;
-      position: absolute;
-      top: 10%;
-      right: -20%;
-      margin: 0;
-    }
-    @include mq($from: desktop) {
-      left: 500px;
-      right: auto;
-    }
-  }
 }
 
-.weekly-hero-hanger {
+.component-product-page-hero-hanger {
   background: gu-colour(garnett-neutral-5);
   .component-left-margin-section__content {
     @include mq($from: tablet) {
       border-left: 1px solid gu-colour(garnett-neutral-4);
-      .weekly-hero-hanger__content {
+      .component-product-page-hero-hanger__content {
         margin-left: -1px;
       }
     }
@@ -56,14 +30,14 @@
   }
 }
 
-.weekly-hero-hanger__content {
+.component-product-page-hero-hanger__content {
   border-top: 1px solid #ffffff;
   padding: $gu-v-spacing  ($gu-h-spacing / 2);
   background: gu-colour(garnett-neutral-1);
   color: #ffffff;
 }
 
-.weekly-hero__headline {
+.component-product-page-hero__headline {
   color: gu-colour(garnett-neutral-5);
   font-family: $gu-titlepiece;
   font-weight: bold;

--- a/assets/components/productPage/productPageTextBlock/productPageTextBlock.jsx
+++ b/assets/components/productPage/productPageTextBlock/productPageTextBlock.jsx
@@ -15,16 +15,16 @@ type PropTypes = {|
 
 // ----- Render ----- //
 
-const WeeklyTextBlock = ({ title, children, headingSize }: PropTypes) => (
-  <div className="weekly-text-block">
-    <Heading className="weekly-text-block__heading" size={headingSize}>{title}</Heading>
+const ProductPageTextBlock = ({ title, children, headingSize }: PropTypes) => (
+  <div className="component-product-page-text-block">
+    <Heading className="component-product-page-text-block__heading" size={headingSize}>{title}</Heading>
     {children}
   </div>
 );
 
-WeeklyTextBlock.defaultProps = {
+ProductPageTextBlock.defaultProps = {
   headingSize: 2,
   children: null,
 };
 
-export default WeeklyTextBlock;
+export default ProductPageTextBlock;

--- a/assets/components/productPage/productPageTextBlock/productPageTextBlock.scss
+++ b/assets/components/productPage/productPageTextBlock/productPageTextBlock.scss
@@ -1,4 +1,4 @@
-.weekly-text-block__heading {
+.component-product-page-text-block__heading {
   font-size: 24px;
   font-weight: bold;
   line-height: 1.16;
@@ -6,10 +6,10 @@
   margin-bottom: ($gu-v-spacing/2);
 }
 
-.weekly-text-block {
+.component-product-page-text-block {
   max-width: 480px;
 }
 
-.weekly-text-block a {
+.component-product-page-text-block a {
   color: inherit;
 }

--- a/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
+++ b/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
@@ -9,6 +9,7 @@ import { bindActionCreators } from 'redux';
 import SvgInfo from 'components/svgs/information';
 import { type WeeklyBillingPeriod } from 'helpers/subscriptions';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import ProductPageContentBlockOutset from 'components/productPage/productPageContentBlock/productPageContentBlockOutset';
 
 import WeeklyCta from './weeklyCta';
 import { billingPeriods, type State } from '../weeklySubscriptionLandingReducer';
@@ -37,8 +38,9 @@ const WeeklyForm = ({
       redirectToWeeklyPageAction();
     }}
   >
-    <div className="weekly-form">
-      {Object.keys(billingPeriods).map((type: WeeklyBillingPeriod) => {
+    <ProductPageContentBlockOutset>
+      <div className="weekly-form">
+        {Object.keys(billingPeriods).map((type: WeeklyBillingPeriod) => {
         const {
           copy, title,
         } = billingPeriods[type];
@@ -57,7 +59,8 @@ const WeeklyForm = ({
           </div>
           );
         })}
-    </div>
+      </div>
+    </ProductPageContentBlockOutset>
 
     <WeeklyCta disabled={selectedPeriod === null} type="submit">
       Subscribe now{selectedPeriod && ` – ${billingPeriods[selectedPeriod].title}`}

--- a/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -16,9 +16,10 @@ import GridImage from 'components/gridImage/gridImage';
 import SvgWeeklyHeroCircles from 'components/svgs/weeklyHeroCircles';
 import SvgChevron from 'components/svgs/chevron';
 import ProductPagehero from 'components/productPage/productPageHero/productPageHero';
+import ProductPageContentBlock from 'components/productPage/productPageContentBlock/productPageContentBlock';
+import ProductPageContentBlockOutset from 'components/productPage/productPageContentBlock/productPageContentBlockOutset';
+import ProductPageTextBlock from 'components/productPage/productPageTextBlock/productPageTextBlock';
 
-import WeeklyContentBlock from './components/weeklyContentBlock';
-import WeeklyTextBlock from './components/weeklyTextBlock';
 import WeeklyFeatureList from './components/weeklyFeatureList';
 import WeeklyForm from './components/weeklyForm';
 import WeeklyCta from './components/weeklyCta';
@@ -82,54 +83,58 @@ const content = (
         />
         <SvgWeeklyHeroCircles />
       </ProductPagehero>
-      <WeeklyContentBlock>
-        <WeeklyTextBlock title="Open up your world view, Weekly">
+      <ProductPageContentBlock>
+        <ProductPageTextBlock title="Open up your world view, Weekly">
           <p>Inside the magazine you’ll find quality, independent journalism
             including opinion, insight, culture and access to new puzzles each week.
             Subscribe today and get an expert view on some of the most challenging
             issues of today, as well as free delivery, wherever you are in the world.
           </p>
-        </WeeklyTextBlock>
-      </WeeklyContentBlock>
-      <WeeklyContentBlock type="grey">
-        <WeeklyTextBlock title="As a subscriber you’ll enjoy" />
-        <WeeklyFeatureList features={[
+        </ProductPageTextBlock>
+      </ProductPageContentBlock>
+      <ProductPageContentBlock type="grey">
+        <ProductPageTextBlock title="As a subscriber you’ll enjoy" />
+        <ProductPageContentBlockOutset>
+          <WeeklyFeatureList features={[
         { title: 'Up to 30% off the retail cover price' },
         { title: 'Free international shipping' },
         { title: 'A weekly email newsletter from the editor' },
         { title: 'Access to all editions at any time, on any device, through PressReader.' },
       ]}
-        />
-      </WeeklyContentBlock>
-      <WeeklyContentBlock type="feature" id="subscribe">
-        <WeeklyTextBlock title="Get your Guardian Weekly, subscribe now">
+          />
+        </ProductPageContentBlockOutset>
+      </ProductPageContentBlock>
+      <ProductPageContentBlock type="feature" id="subscribe">
+        <ProductPageTextBlock title="Get your Guardian Weekly, subscribe now">
           <p>How would you like to pay for your Guardian Weekly?</p>
-        </WeeklyTextBlock>
+        </ProductPageTextBlock>
         <WeeklyForm />
-      </WeeklyContentBlock>
-      <WeeklyContentBlock type="grey">
-        <WeeklyTextBlock title="Buying as a gift?">
+      </ProductPageContentBlock>
+      <ProductPageContentBlock type="grey">
+        <ProductPageTextBlock title="Buying as a gift?">
           <p>If you’d like to buy a Guardian Weekly subscription as a gift,
           just get in touch with your local customer service team.
           </p>
-        </WeeklyTextBlock>
-        <WeeklyFeatureList features={[
-        { title: 'UK, Europe and Rest of World', copy: '+44 (0) 330 333 6767' },
-        { title: 'Australia and New Zealand', copy: '+61 2 8076 8599' },
-        { title: 'USA and Canada', copy: '+1 917-900-4663' },
-      ]}
-        />
-      </WeeklyContentBlock>
-      <WeeklyContentBlock type="white">
-        <WeeklyTextBlock title="Promotion terms and conditions">
+        </ProductPageTextBlock>
+        <ProductPageContentBlockOutset>
+          <WeeklyFeatureList features={[
+            { title: 'UK, Europe and Rest of World', copy: '+44 (0) 330 333 6767' },
+            { title: 'Australia and New Zealand', copy: '+61 2 8076 8599' },
+            { title: 'USA and Canada', copy: '+1 917-900-4663' },
+          ]}
+          />
+        </ProductPageContentBlockOutset>
+      </ProductPageContentBlock>
+      <ProductPageContentBlock type="white">
+        <ProductPageTextBlock title="Promotion terms and conditions">
           <p>Subscriptions available to people aged 18 and over with a valid email address. For full details of Guardian Weekly print subscription services and their terms and conditions - see <a href="https://www.theguardian.com/guardian-weekly-subscription-terms-conditions">here</a>
           </p>
-        </WeeklyTextBlock>
-        <WeeklyTextBlock title="Guardian Weekly terms and conditions">
+        </ProductPageTextBlock>
+        <ProductPageTextBlock title="Guardian Weekly terms and conditions">
           <p>Offer subject to availability. Guardian News and Media Limited (&quot;GNM&quot;) reserves the right to withdraw this promotion at any time. For full promotion terms and conditions see <a href={`https://subscribe.theguardian.com/p/WWM99X/terms?country=${subsCountry}`}>here</a>.
           </p>
-        </WeeklyTextBlock>
-      </WeeklyContentBlock>
+        </ProductPageTextBlock>
+      </ProductPageContentBlock>
     </Page>
   </Provider>
 );

--- a/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -12,12 +12,14 @@ import Footer from 'components/footer/footer';
 import { detect, countryGroups, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
+import GridImage from 'components/gridImage/gridImage';
+import SvgWeeklyHeroCircles from 'components/svgs/weeklyHeroCircles';
 import SvgChevron from 'components/svgs/chevron';
+import ProductPagehero from 'components/productPage/productPageHero/productPageHero';
 
 import WeeklyContentBlock from './components/weeklyContentBlock';
 import WeeklyTextBlock from './components/weeklyTextBlock';
 import WeeklyFeatureList from './components/weeklyFeatureList';
-import WeeklyHero from './components/weeklyHero';
 import WeeklyForm from './components/weeklyForm';
 import WeeklyCta from './components/weeklyCta';
 import reducer from './weeklySubscriptionLandingReducer';
@@ -65,12 +67,21 @@ const content = (
       header={<CountrySwitcherHeader />}
       footer={<Footer />}
     >
-      <WeeklyHero
+      <ProductPagehero
         headline="The essential new Weekly magazine from The&nbsp;Guardian"
         overheading="The Guardian Weekly subscriptions"
         heading="Seven days of international news curated to give you a clearer global perspective."
+        modifierClasses={['weekly']}
         cta={<WeeklyCta icon={<SvgChevron />} href="#subscribe">See Subscription options</WeeklyCta>}
-      />
+      >
+        <GridImage
+          gridId="weeklyLandingHero"
+          srcSizes={[1000, 500]}
+          sizes="(max-width: 740px) 90vw, 600px"
+          imgType="png"
+        />
+        <SvgWeeklyHeroCircles />
+      </ProductPagehero>
       <WeeklyContentBlock>
         <WeeklyTextBlock title="Open up your world view, Weekly">
           <p>Inside the magazine you’ll find quality, independent journalism

--- a/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.scss
+++ b/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.scss
@@ -11,11 +11,40 @@
 @import '~components/selectInput/selectInput';
 @import '~components/headingBlock/headingBlock';
 @import '~components/leftMarginSection/leftMarginSection';
+@import '~components/productPage/productPageHero/productPageHero';
 
 @import 'components/weeklyContentBlock';
 @import 'components/weeklyTextBlock';
 @import 'components/weeklyFeatureList';
-@import 'components/weeklyHero';
 @import 'components/weeklyCta';
 @import 'components/weeklyForm';
 @import 'components/weeklyFormLabel';
+
+.component-product-page-hero--weekly {
+  .svg-weekly-hero-circles {
+    position: absolute;
+    width: 300px;
+    left: -300px;
+    bottom: 0;
+  }
+  .component-grid-image {
+    display: block;
+    width: 90%;
+    max-width: 500px;
+    margin: ($gu-v-spacing * 3) auto -25%;
+    z-index: 9;
+    @include mq($from: tablet) {
+      width: auto;
+      max-width: 100%;
+      height: 100%;
+      position: absolute;
+      top: 10%;
+      right: -20%;
+      margin: 0;
+    }
+    @include mq($from: desktop) {
+      left: 500px;
+      right: auto;
+    }
+  }
+}

--- a/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.scss
+++ b/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.scss
@@ -12,9 +12,9 @@
 @import '~components/headingBlock/headingBlock';
 @import '~components/leftMarginSection/leftMarginSection';
 @import '~components/productPage/productPageHero/productPageHero';
+@import '~components/productPage/productPageContentBlock/productPageContentBlock';
+@import '~components/productPage/productPageTextBlock/productPageTextBlock';
 
-@import 'components/weeklyContentBlock';
-@import 'components/weeklyTextBlock';
 @import 'components/weeklyFeatureList';
 @import 'components/weeklyCta';
 @import 'components/weeklyForm';


### PR DESCRIPTION
## Why are you doing this?

This page layout will be reused across all new pages (Including paper subs - due for this week) so it makes sense to extract it into reusable chunks sooner than later.

Right now they live in `components/productPage/*` and there is some further optimisation we can make (there's already a `productHero` for checkouts but integrating that felt like a separate task.

There'se even more to split out but this is a solid starting point to kick this split off

[**Trello Card**](https://trello.com/c/lbXVrZWt/1955-new-guardian-weekly-product-page)

## Screenshots

![screenshot 2018-11-12 at 11 17 15 am](https://user-images.githubusercontent.com/11539094/48344291-865e8d00-e66c-11e8-85d1-785f874459ae.png)
