### PR TITLE
Update minimum paper price now we no longer have Saturday

### DIFF
--- a/assets/helpers/subscriptions.js
+++ b/assets/helpers/subscriptions.js
@@ -57,7 +57,7 @@ const subscriptionPricesForDefaultBillingPeriod: {
     International: 81.30,
   },
   Paper: {
-    GBPCountries: 10.36,
+    GBPCountries: 10.79,
   },
   PaperAndDigital: {
     GBPCountries: 21.62,


### PR DESCRIPTION
## Why are you doing this?
Now that we no longer sell Saturday pack, the 'from £10.36' message on the subscribe page is wrong, this corrects it.

[**Trello Card**](https://trello.com/c/ZCMzVkhm/2072-update-print-price-on-subscriptions-landing-page-and-showcase-page)


