### PR TITLE
Add GA/Ophan tracking to Guardian Weekly page

### DIFF
--- a/assets/components/headers/countrySwitcherHeader/countrySwitcherHeaderContainerWithTracking.js
+++ b/assets/components/headers/countrySwitcherHeader/countrySwitcherHeaderContainerWithTracking.js
@@ -1,0 +1,34 @@
+// @flow
+
+// ----- Imports ----- //
+
+import { connect } from 'react-redux';
+
+import CountrySwitcherHeader from 'components/headers/countrySwitcherHeader/countrySwitcherHeader';
+
+import { countryGroups, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import type { CommonState } from 'helpers/page/page';
+import { sendTrackingEventsOnClick, type SubscriptionProduct } from 'helpers/subscriptions';
+import type { PropTypes } from './countrySwitcherHeader';
+
+// ------ Component ----- //
+
+export default function (subPath: string, listOfCountries: CountryGroupId[], product: SubscriptionProduct) {
+
+  function handleChange(cgId: CountryGroupId): void {
+    sendTrackingEventsOnClick(`toggle_country_${cgId}`, product, null)();
+    window.location.pathname = `/${countryGroups[cgId].supportInternationalisationId}${subPath}`;
+  }
+
+  function mapStateToProps(state: { common: CommonState }): PropTypes {
+
+    return {
+      countryGroupIds: listOfCountries,
+      selectedCountryGroupId: state.common.internationalisation.countryGroupId,
+      onCountryGroupSelect: handleChange,
+    };
+  }
+
+  return connect(mapStateToProps)(CountrySwitcherHeader);
+
+}

--- a/assets/pages/weekly-subscription-landing/components/weeklyCta.jsx
+++ b/assets/pages/weekly-subscription-landing/components/weeklyCta.jsx
@@ -15,20 +15,31 @@ type PropTypes = {|
   href: ?string,
   disabled: boolean,
   onClick: ?(void => void),
+  trackingOnClick: ?(void => void),
 |};
 
 
 // ----- Render ----- //
 
 const WeeklyCtaButton = ({
-  children, icon, type, onClick, href, disabled,
+  children, icon, type, onClick, href, disabled, trackingOnClick,
 }: PropTypes) => (href ? (
-  <a href={href} data-disabled={disabled} className="weekly-cta">
+  <a
+    href={href}
+    data-disabled={disabled}
+    className="weekly-cta"
+    onClick={trackingOnClick}
+  >
     <span className="weekly-cta__content">{children}</span>
     {icon}
   </a>
 ) : (
-  <button disabled={disabled} onClick={onClick} type={type} className="weekly-cta">
+  <button
+    disabled={disabled}
+    onClick={(ev) => { if (onClick) { onClick(ev); } if (trackingOnClick) { trackingOnClick(); } }}
+    type={type}
+    className="weekly-cta"
+  >
     <span className="weekly-cta__content">{children}</span>
     {icon}
   </button>
@@ -38,6 +49,7 @@ WeeklyCtaButton.defaultProps = {
   icon: <SvgArrowRightStraight />,
   type: 'button',
   onClick: null,
+  trackingOnClick: null,
   href: null,
   disabled: false,
 };

--- a/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -12,6 +12,7 @@ import Footer from 'components/footer/footer';
 import { detect, countryGroups, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
+import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
 import GridImage from 'components/gridImage/gridImage';
 import SvgWeeklyHeroCircles from 'components/svgs/weeklyHeroCircles';
 import SvgChevron from 'components/svgs/chevron';
@@ -74,7 +75,7 @@ const content = (
         overheading="The Guardian Weekly subscriptions"
         heading="Seven days of international news curated to give you a clearer global perspective."
         modifierClasses={['weekly']}
-        cta={<WeeklyCta icon={<SvgChevron />} href="#subscribe">See Subscription options</WeeklyCta>}
+        cta={<WeeklyCta trackingOnClick={sendTrackingEventsOnClick('options_cta_click', 'GuardianWeekly', null)} icon={<SvgChevron />} href="#subscribe">See Subscription options</WeeklyCta>}
       >
         <GridImage
           gridId="weeklyLandingHero"

--- a/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 
 import Page from 'components/page/page';
-import countrySwitcherHeaderContainer from 'components/headers/countrySwitcherHeader/countrySwitcherHeaderContainer';
+import countrySwitcherHeaderContainerWithTracking from 'components/headers/countrySwitcherHeader/countrySwitcherHeaderContainerWithTracking';
 import Footer from 'components/footer/footer';
 
 import { detect, countryGroups, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
@@ -47,7 +47,7 @@ const reactElementId: {
   International: 'weekly-landing-page-int',
 };
 
-const CountrySwitcherHeader = countrySwitcherHeaderContainer(
+const CountrySwitcherHeader = countrySwitcherHeaderContainerWithTracking(
   '/subscribe/weekly',
   [
     'GBPCountries',
@@ -58,6 +58,7 @@ const CountrySwitcherHeader = countrySwitcherHeaderContainer(
     'NZDCountries',
     'International',
   ],
+  'GuardianWeekly',
 );
 
 // ----- Render ----- //

--- a/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingActions.js
+++ b/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingActions.js
@@ -4,6 +4,7 @@
 
 import { type WeeklyBillingPeriod } from 'helpers/subscriptions';
 import { getWeeklyCheckout } from 'helpers/externalLinks';
+import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
 import { type State } from './weeklySubscriptionLandingReducer';
 
 
@@ -14,8 +15,11 @@ export type Action = { type: 'SET_PERIOD', period: WeeklyBillingPeriod };
 
 // ----- Action Creators ----- //
 
-function setPeriod(period: WeeklyBillingPeriod): Action {
-  return { type: 'SET_PERIOD', period };
+function setPeriod(period: WeeklyBillingPeriod): (dispatch: Function) => Action {
+  return (dispatch) => {
+    sendTrackingEventsOnClick(`toggle_period_${period}`, 'GuardianWeekly', null)();
+    return dispatch({ type: 'SET_PERIOD', period });
+  };
 }
 
 function redirectToWeeklyPage() {

--- a/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingActions.js
+++ b/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingActions.js
@@ -36,6 +36,7 @@ function redirectToWeeklyPage() {
     ) : null;
 
     if (location) {
+      sendTrackingEventsOnClick('main_cta_click', 'GuardianWeekly', null)();
       window.location.href = location;
     }
   };


### PR DESCRIPTION
## Why are you doing this?
So we can assess the performance of the new page

[**Trello Card**](https://trello.com/c/agMdXNa7/1995-analytics-for-new-gw-product-page)

## Changes

* Added a `countrySwitcherHeaderContainerWithTracking` that adds tracking to the country switcher
* Added a `trackingOnClick` function to `weeklyCta` that allows to specify a custom tracking function that runs alongside a normal click handler and doesn't alter the current behaviour of using an anchor for links and a button for buttons

## Screenshots
![screenshot 2018-11-12 at 4 13 55 pm](https://user-images.githubusercontent.com/11539094/48360159-82476500-e696-11e8-988a-0b24f0717b02.png)

