### PR TITLE
Fix old contributions tests

### DIFF
--- a/test/selenium/contributions/old/OneOffContributionsSpec.scala
+++ b/test/selenium/contributions/old/OneOffContributionsSpec.scala
@@ -20,12 +20,12 @@ class OneOffContributionsSpec extends FeatureSpec with GivenWhenThen with Before
 
   feature("Sign up for a one-off contribution") {
 
-    scenario("One-off contribution sign-up with Stripe - AUD") {
+    scenario("One-off contribution sign-up with Stripe - GBP") {
 
       val stripePayment = 22.55
-      val currency = "AUD"
+      val currency = "GBP"
       val testUser = new TestUser(driverConfig)
-      val landingPage = ContributionsLanding("au")
+      val landingPage = ContributionsLanding("uk")
       val oneOffContributionForm = OneOffContributionForm(testUser, stripePayment.toInt, currency)
       val oneOffContributionThankYou = new OneOffContributionThankYou
 

--- a/test/selenium/contributions/old/OneOffContributionsSpec.scala
+++ b/test/selenium/contributions/old/OneOffContributionsSpec.scala
@@ -1,7 +1,7 @@
-package selenium
+package selenium.contributions.old
 
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FeatureSpec, GivenWhenThen}
-import selenium.pages.{ContributionsLanding, OneOffContributionForm, OneOffContributionThankYou}
+import selenium.contributions.old.pages.{ContributionsLanding, OneOffContributionForm, OneOffContributionThankYou}
 import selenium.util._
 
 class OneOffContributionsSpec extends FeatureSpec with GivenWhenThen with BeforeAndAfter with BeforeAndAfterAll with Browser {

--- a/test/selenium/contributions/old/RecurringContributionsSpec.scala
+++ b/test/selenium/contributions/old/RecurringContributionsSpec.scala
@@ -59,13 +59,13 @@ class RecurringContributionsSpec extends FeatureSpec with GivenWhenThen with Bef
 
     }
 
-    scenario("Monthly contribution sign-up with Paypal - USD") {
+    scenario("Monthly contribution sign-up with Paypal - GBP") {
 
-      val landingPage = ContributionsLanding("us")
+      val landingPage = ContributionsLanding("uk")
       val testUser = new TestUser(driverConfig)
-      val registerPageOne = RegisterPageOne(testUser, 15)
+      val registerPageOne = RegisterPageOne(testUser, 5)
       val payPalCheckout = new PayPalCheckout
-      val expectedPayment = "15.00"
+      val expectedPayment = "5.00"
       val recurringContributionForm = RecurringContributionForm(testUser)
       val recurringContributionThankYou = new RecurringContributionThankYou
 
@@ -80,7 +80,7 @@ class RecurringContributionsSpec extends FeatureSpec with GivenWhenThen with Bef
       registerPageOne.submit()
       Then("they should be redirected to register as an Identity user")
 
-      val registerPageTwo = RegisterPageTwo(testUser, 15)
+      val registerPageTwo = RegisterPageTwo(testUser, 5)
       assert(registerPageTwo.pageHasLoaded)
 
       Given("that the user fills in their personal details correctly")

--- a/test/selenium/contributions/old/RecurringContributionsSpec.scala
+++ b/test/selenium/contributions/old/RecurringContributionsSpec.scala
@@ -1,8 +1,8 @@
-package selenium
+package selenium.contributions.old
 
-import org.scalatest._
-import _root_.selenium.pages._
+import selenium.contributions.old.pages._
 import _root_.selenium.util._
+import org.scalatest._
 
 class RecurringContributionsSpec extends FeatureSpec with GivenWhenThen with BeforeAndAfter with BeforeAndAfterAll with Browser {
 

--- a/test/selenium/contributions/old/pages/ContributionsLanding.scala
+++ b/test/selenium/contributions/old/pages/ContributionsLanding.scala
@@ -8,7 +8,7 @@ case class ContributionsLanding(region: String)(implicit val webDriver: WebDrive
 
   // While the new contributions landing page test is running,
   // we just want Selenium to test the old page.
-  val url = s"${Config.supportFrontendUrl}/$region/contribute"
+  val url = s"${Config.supportFrontendUrl}/$region"
 
   private val contributeButton = id("qa-contribute-button")
 

--- a/test/selenium/contributions/old/pages/ContributionsLanding.scala
+++ b/test/selenium/contributions/old/pages/ContributionsLanding.scala
@@ -1,4 +1,4 @@
-package selenium.pages
+package selenium.contributions.old.pages
 
 import org.openqa.selenium.WebDriver
 import org.scalatest.selenium.Page

--- a/test/selenium/contributions/old/pages/OneOffContributionForm.scala
+++ b/test/selenium/contributions/old/pages/OneOffContributionForm.scala
@@ -1,4 +1,4 @@
-package selenium.pages
+package selenium.contributions.old.pages
 
 import selenium.util.{Browser, Config, TestUser}
 import org.openqa.selenium.WebDriver

--- a/test/selenium/contributions/old/pages/OneOffContributionThankYou.scala
+++ b/test/selenium/contributions/old/pages/OneOffContributionThankYou.scala
@@ -1,4 +1,4 @@
-package selenium.pages
+package selenium.contributions.old.pages
 
 import org.openqa.selenium.WebDriver
 import org.scalatest.selenium.Page

--- a/test/selenium/contributions/old/pages/RecurringContributionForm.scala
+++ b/test/selenium/contributions/old/pages/RecurringContributionForm.scala
@@ -1,4 +1,4 @@
-package selenium.pages
+package selenium.contributions.old.pages
 
 import org.openqa.selenium.WebDriver
 import org.scalatest.selenium.Page

--- a/test/selenium/contributions/old/pages/RecurringContributionThankYou.scala
+++ b/test/selenium/contributions/old/pages/RecurringContributionThankYou.scala
@@ -1,4 +1,4 @@
-package selenium.pages
+package selenium.contributions.old.pages
 
 import org.openqa.selenium.WebDriver
 import org.scalatest.selenium.Page

--- a/test/selenium/contributions/old/pages/RegisterPageOne.scala
+++ b/test/selenium/contributions/old/pages/RegisterPageOne.scala
@@ -1,4 +1,4 @@
-package selenium.pages
+package selenium.contributions.old.pages
 
 import java.net.URLEncoder
 

--- a/test/selenium/contributions/old/pages/RegisterPageTwo.scala
+++ b/test/selenium/contributions/old/pages/RegisterPageTwo.scala
@@ -1,4 +1,4 @@
-package selenium.pages
+package selenium.contributions.old.pages
 
 import org.scalatest.selenium.Page
 import java.net.URLEncoder


### PR DESCRIPTION
## Why are you doing this?
The selenium tests are currently failing because we've removed the routes to the old payment flow.
Now the only way to use the old payment flow is to visit /uk.

- Commit 1 - moves these old selenium tests into `/contributions/old`
- Commit 2 - fixes them (can now only use old flow for UK).

New selenium tests for the new payment flow will follow asap

