### PR TITLE
Remove the `internationalSubscribePages` switch

### DIFF
--- a/app/admin/Settings.scala
+++ b/app/admin/Settings.scala
@@ -15,8 +15,7 @@ case class Switches(
     oneOffPaymentMethods: PaymentMethodsSwitch,
     recurringPaymentMethods: PaymentMethodsSwitch,
     experiments: Map[String, ExperimentSwitch],
-    optimize: SwitchState,
-    internationalSubscribePages: SwitchState
+    optimize: SwitchState
 )
 
 case class Settings(switches: Switches)

--- a/app/controllers/Subscriptions.scala
+++ b/app/controllers/Subscriptions.scala
@@ -58,21 +58,18 @@ class Subscriptions(
   }
 
   def landing(countryCode: String): Action[AnyContent] = CachedAction() { implicit request =>
-    if (settingsProvider.settings().switches.internationalSubscribePages == SwitchState.Off && countryCode.toLowerCase != "uk") {
-      Redirect(controllers.routes.Subscriptions.geoRedirect())
-    } else {
-      implicit val settings: Settings = settingsProvider.settings()
-      val title = "Support the Guardian | Get a Subscription"
-      val id = "subscriptions-landing-page"
-      val js = "subscriptionsLandingPage.js"
-      Ok(views.html.main(
-        title,
-        id,
-        js,
-        "subscriptionsLandingPageStyles.css",
-        description = stringsConfig.subscriptionsLandingDescription
-      )).withSettingsSurrogateKey
-    }
+    implicit val settings: Settings = settingsProvider.settings()
+    val title = "Support the Guardian | Get a Subscription"
+    val id = "subscriptions-landing-page"
+    val js = "subscriptionsLandingPage.js"
+    Ok(views.html.main(
+      title,
+      id,
+      js,
+      "subscriptionsLandingPageStyles.css",
+      description = stringsConfig.subscriptionsLandingDescription
+    )).withSettingsSurrogateKey
+
   }
 
   def digital(countryCode: String): Action[AnyContent] = CachedAction() { implicit request =>

--- a/test/codecs/CirceDecodersTest.scala
+++ b/test/codecs/CirceDecodersTest.scala
@@ -204,8 +204,7 @@ class CirceDecodersTest extends WordSpec with MustMatchers {
           |        "state": "On"
           |      }
           |    },
-          |    "optimize": "Off",
-          |    "internationalSubscribePages": "On"
+          |    "optimize": "Off"
           |  }
           |}""".stripMargin
 
@@ -228,8 +227,7 @@ class CirceDecodersTest extends WordSpec with MustMatchers {
               state = On
             )
           ),
-          optimize = Off,
-          internationalSubscribePages = On
+          optimize = Off
         )
       )
 

--- a/test/controllers/RegularContributionsTest.scala
+++ b/test/controllers/RegularContributionsTest.scala
@@ -104,7 +104,7 @@ class RegularContributionsTest extends WordSpec with MustMatchers with TestCSRFC
 
       val settingsProvider = mock[SettingsProvider]
       when(settingsProvider.settings()).thenReturn(
-        Settings(Switches(PaymentMethodsSwitch(On, On, None), PaymentMethodsSwitch(On, On, Some(On)), Map.empty, On, On))
+        Settings(Switches(PaymentMethodsSwitch(On, On, None), PaymentMethodsSwitch(On, On, Some(On)), Map.empty, On))
       )
 
       new RegularContributions(


### PR DESCRIPTION
## Why are you doing this?

When we first implemented the international subscribe pages they were behind a switch in case we wanted to turn them off again. This is no longer needed so I've removed it.

This has been tested on CODE with both the old settings file and the new updated one and works fine so the deployment order should be: Merge this PR, wait till it deploys then remove the switch from `settings.json`

[**Trello Card**](https://trello.com/c/1YNXWVNb/2056-remove-old-international-non-uk-subs-landing-page-redirection)