### PR TITLE
Show survey on NPF thank you pages

### DIFF
--- a/assets/components/headers/countrySwitcherHeader/countrySwitcherHeaderContainerWithTracking.js
+++ b/assets/components/headers/countrySwitcherHeader/countrySwitcherHeaderContainerWithTracking.js
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import CountrySwitcherHeader from 'components/headers/countrySwitcherHeader/countrySwitcherHeader';
 
 import { countryGroups, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import type { CommonState } from 'helpers/page/page';
+import type { CommonState } from 'helpers/page/commonReducer';
 import { sendTrackingEventsOnClick, type SubscriptionProduct } from 'helpers/subscriptions';
 import type { PropTypes } from './countrySwitcherHeader';
 

--- a/assets/pages/new-contributions-landing/components/ContributionThankYou.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionThankYou.jsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
 import { type Contrib, getSpokenType } from 'helpers/contributions';
 import CtaLink from 'components/ctaLink/ctaLink';
 import MarketingConsent from '../components/MarketingConsent';
+import ContributionsSurvey from '../components/ContributionsSurvey';
 import { type Action, setHasSeenDirectDebitThankYouCopy } from '../contributionsLandingActions';
 
 // ----- Types ----- //
@@ -52,7 +53,6 @@ function ContributionThankYou(props: PropTypes) {
   return (
     <div className="thank-you__container">
       <h1 className="header">{`Thank you for a valuable contribution. ${directDebitHeaderSuffix}`}</h1>
-
       {props.contributionType !== 'ONE_OFF' ? (
         <section className="confirmation">
           <p className="confirmation__message">
@@ -60,6 +60,7 @@ function ContributionThankYou(props: PropTypes) {
           </p>
         </section>
       ) : null}
+      <ContributionsSurvey />
       <MarketingConsent />
       <div className="confirmation confirmation--backtothegu">
         <CtaLink

--- a/assets/pages/new-contributions-landing/components/ContributionThankYouPasswordSet.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionThankYouPasswordSet.jsx
@@ -5,6 +5,7 @@
 import React from 'react';
 import CtaLink from 'components/ctaLink/ctaLink';
 import MarketingConsent from '../components/MarketingConsent';
+import ContributionsSurvey from '../components/ContributionsSurvey';
 
 // ----- Render ----- //
 
@@ -18,6 +19,7 @@ function ContributionThankYouPasswordSet() {
           preferences.
         </p>
       </section>
+      <ContributionsSurvey />
       <MarketingConsent />
       <div className="confirmation confirmation--backtothegu">
         <CtaLink

--- a/assets/pages/new-contributions-landing/components/ContributionsSurvey.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionsSurvey.jsx
@@ -1,0 +1,27 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+import CtaLink from 'components/ctaLink/ctaLink';
+
+// ----- Component ----- //
+
+export default function ContributionsSurvey() {
+
+  return (
+    <div className="component-contributions-survey">
+      <h3>
+        Please tell us about your contribution to The Guardian by filling out this short form.
+      </h3>
+      <CtaLink
+        text="Share your thoughts"
+        url="https://www.surveymonkey.co.uk/r/QVKCKXQ"
+        accessibilityHint="Please tell us about your contribution to The Guardian by filling out this short form."
+        modifierClasses={['survey']}
+      />
+    </div>
+  );
+
+}

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -1035,3 +1035,28 @@ form {
 .component-password-failure-message {
   padding: 0 $gu-h-spacing $gu-v-spacing;
 }
+
+.component-contributions-survey {
+  border-bottom: 1px solid gu-colour(garnett-neutral-4);
+  margin: 0 -10px;
+  padding: 0 10px;
+
+  h3 {
+    font-family: $gu-text-egyptian-web;
+    letter-spacing: -0.5px;
+    font-weight: 900;
+    font-size: 17px;
+    margin: ($gu-v-spacing / 3) 0;
+  }
+
+  .component-cta-link {
+    display: inline-block;
+    margin-bottom: $gu-v-spacing * 3;
+    margin-top: $gu-v-spacing;
+  }
+
+  .component-cta-link__text {
+    padding-right: 25px;
+    font-size: 16px;
+  }
+}


### PR DESCRIPTION
## Why are you doing this?
We need to show the survey on the new payment flow thank you pages



<img width="367" alt="picture 19" src="https://user-images.githubusercontent.com/1513454/48428908-e5eb9400-e763-11e8-868e-27d8a1ad1159.png">
<img width="368" alt="picture 20" src="https://user-images.githubusercontent.com/1513454/48428909-e5eb9400-e763-11e8-9903-44f5955e8066.png">
<img width="367" alt="picture 21" src="https://user-images.githubusercontent.com/1513454/48428910-e5eb9400-e763-11e8-8205-ead44a4e79e4.png">

Users will not be shown the button if we ask them to sign up (but on the next page they will see it)
<img width="390" alt="picture 22" src="https://user-images.githubusercontent.com/1513454/48428911-e6842a80-e763-11e8-8a26-5422c6bdd704.png">
