### PR TITLE
import styles within component

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -8,6 +8,11 @@ assets
 [libs]
 
 [options]
+module.file_ext=.js
+module.file_ext=.jsx
+module.file_ext=.json
+module.file_ext=.css
+module.file_ext=.scss
 module.name_mapper='^containerisableComponents/' -> '<PROJECT_ROOT>/assets/containerisableComponents/'
 module.name_mapper='^components/' -> '<PROJECT_ROOT>/assets/components/'
 module.name_mapper='^helpers/' -> '<PROJECT_ROOT>/assets/helpers/'

--- a/app/lib/CustomHttpErrorHandler.scala
+++ b/app/lib/CustomHttpErrorHandler.scala
@@ -31,7 +31,7 @@ class CustomHttpErrorHandler(
 
   override protected def onNotFound(request: RequestHeader, message: String): Future[Result] =
     Future.successful(
-      NotFound(main("Error 404", "error-404-page", "error404Page.js", "errorPageStyles.css")(assets, request, settingsProvider.settings()))
+      NotFound(main("Error 404", "error-404-page", "error404Page.js", "error404Page.css")(assets, request, settingsProvider.settings()))
         .withHeaders(CacheControl.defaultCacheHeaders(30.seconds, 30.seconds): _*)
         .withSettingsSurrogateKey
     )
@@ -39,7 +39,7 @@ class CustomHttpErrorHandler(
   override protected def onProdServerError(request: RequestHeader, exception: UsefulException): Future[Result] = {
     logServerError(request, exception)
     Future.successful(
-      InternalServerError(main("Error 500", "error-500-page", "error500Page.js", "errorPageStyles.css")(assets, request, settingsProvider.settings()))
+      InternalServerError(main("Error 500", "error-500-page", "error500Page.js", "error500Page.css")(assets, request, settingsProvider.settings()))
         .withHeaders(CacheControl.noCache)
         .withSettingsSurrogateKey
     )

--- a/assets/pages/error/components/errorPage.jsx
+++ b/assets/pages/error/components/errorPage.jsx
@@ -12,6 +12,7 @@ import PageSection from 'components/pageSection/pageSection';
 import CtaLink from 'components/ctaLink/ctaLink';
 import { contributionsEmail } from 'helpers/legal';
 
+import '../error.scss';
 
 // ----- Types ----- //
 

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -51,7 +51,6 @@ module.exports = (cssFilename, outputFilename, minimizeCss) => ({
     optimizeScript: 'helpers/optimize/optimizeScript.js',
     error404Page: 'pages/error/error404.jsx',
     error500Page: 'pages/error/error500.jsx',
-    errorPageStyles: 'pages/error/error.scss',
     unsupportedBrowserStyles: 'stylesheets/fallback-pages/unsupportedBrowser.scss',
     contributionsRedirectStyles: 'stylesheets/fallback-pages/contributionsRedirect.scss',
   },


### PR DESCRIPTION
## Why are you doing this?
The motivation behind this is to make our components truly standalone, just import the Preact component and the styles come with it.

This means you don't have to remember to add the relevant `@import ~foo/bar` in your page's stylesheet.

In essence, [this step](https://github.com/guardian/support-frontend/wiki/Quickstart:-Adding-a-new-route#assetspagesguardian-forthnightlyguardianforthnightlyscss) now becomes obsolete.

Making this change on 404 and 500 pages to start as its fairly low risk.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com)

## Screenshots
n/a