### PR TITLE
Switch on Guardian Weekly page

### DIFF
--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -197,7 +197,7 @@ function buildSubsUrls(
   const paper = `${subsUrl}/p/${promoCodes.Paper}?${buildParamString('Paper', intCmp, referrerAcquisitionData)}`;
   const paperDig = `${subsUrl}/p/${promoCodes.PaperAndDigital}?${buildParamString('PaperAndDigital', intCmp, referrerAcquisitionData)}`;
   const digital = `/${countryId}/subscribe/digital?${buildParamString('DigitalPack', intCmp, null)}`;
-  const weekly = `${subsUrl}/weekly?${buildParamString('GuardianWeekly', intCmp, referrerAcquisitionData)}`;
+  const weekly = `/${countryId}/subscribe/weekly?${buildParamString('GuardianWeekly', intCmp, referrerAcquisitionData)}`;
 
   return {
     DigitalPack: digital,

--- a/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingReducer.js
+++ b/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingReducer.js
@@ -50,7 +50,7 @@ export type State = {
 const promoInUrl = getQueryParameter('promo');
 
 const initialState: PageState = {
-  period: promoInUrl === 'sixweek' || promoInUrl === 'quarter' || promoInUrl === 'year' ? promoInUrl : null,
+  period: promoInUrl === 'sixweek' || promoInUrl === 'quarter' || promoInUrl === 'year' ? promoInUrl : 'sixweek',
 };
 
 function reducer(state: PageState = initialState, action: Action): PageState {


### PR DESCRIPTION
## Why are you doing this?
To start sending traffic to the new Guardian Weekly page from the subs landing page.
This will also make 6 for 6 the default payment option