### PR TITLE
Paper subs route

### DIFF
--- a/app/controllers/Subscriptions.scala
+++ b/app/controllers/Subscriptions.scala
@@ -123,7 +123,8 @@ class Subscriptions(
     Ok(views.html.main(title, id, js, css, description)).withSettingsSurrogateKey
   }
 
-  def paperMethodRedirect(): Action[AnyContent] = Action { implicit request => Redirect(buildCanonicalPaperSubscriptionLink(), request.queryString, status = FOUND)
+  def paperMethodRedirect(): Action[AnyContent] = Action { implicit request =>
+    Redirect(buildCanonicalPaperSubscriptionLink(), request.queryString, status = FOUND)
   }
 
   def paper(method: String): Action[AnyContent] = CachedAction() { implicit request =>

--- a/app/controllers/Subscriptions.scala
+++ b/app/controllers/Subscriptions.scala
@@ -123,6 +123,20 @@ class Subscriptions(
     Ok(views.html.main(title, id, js, css, description)).withSettingsSurrogateKey
   }
 
+  def paperMethodRedirect(): Action[AnyContent] = Action { implicit request => Redirect(buildCanonicalPaperSubscriptionLink(), request.queryString, status = FOUND)
+  }
+
+  def paper(method: String): Action[AnyContent] = CachedAction() { implicit request =>
+    implicit val settings: Settings = settingsProvider.settings()
+    val title = "The Guardian Subscriptions | The Guardian"
+    val id = "paper-subscription-landing-page-" + method
+    val js = "paperSubscriptionLandingPage.js"
+    val css = "paperSubscriptionLandingPage.css"
+    val canonicalLink = Some(buildCanonicalPaperSubscriptionLink())
+
+    Ok(views.html.main(title, id, js, css, None, canonicalLink)).withSettingsSurrogateKey
+  }
+
   def premiumTierGeoRedirect: Action[AnyContent] = geoRedirect("subscribe/premium-tier")
 
   def displayForm(countryCode: String, displayCheckout: String): Action[AnyContent] =
@@ -138,6 +152,9 @@ class Subscriptions(
         Redirect(routes.Subscriptions.geoRedirect)
       }
     }
+
+  def buildCanonicalPaperSubscriptionLink(method: String = "collection"): String =
+    s"${supportUrl}/subscribe/paper/${method}"
 
   def buildCanonicalDigitalSubscriptionLink(countryCode: String): String =
     s"${supportUrl}/${countryCode}/subscribe/digital"

--- a/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
+++ b/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
@@ -1,0 +1,48 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+import Page from 'components/page/page';
+import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
+import Footer from 'components/footer/footer';
+
+import { statelessInit as pageInit } from 'helpers/page/page';
+import { renderPage } from 'helpers/render';
+
+import './paperSubscriptionLandingPage.scss';
+
+
+// ----- Collection or delivery ----- //
+
+type Method = 'collection' | 'delivery';
+
+const method: Method = window.location.pathname.includes('collection') ? 'collection' : 'delivery';
+
+const reactElementId: {
+  [Method]: string,
+} = {
+  collection: 'paper-subscription-landing-page-collection',
+  delivery: 'paper-subscription-landing-page-delivery',
+};
+
+
+// ----- Page Startup ----- //
+
+pageInit();
+
+
+// ----- Render ----- //
+
+const content = (
+  <Page
+    header={<SimpleHeader />}
+    footer={<Footer />}
+  >
+    <h1>Guardian Paper subs</h1>
+    <h2>{method}</h2>
+  </Page>
+);
+
+renderPage(content, reactElementId[method]);

--- a/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.scss
+++ b/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.scss
@@ -1,0 +1,9 @@
+// -----  gu-sass ----- //
+
+@import '~stylesheets/gu-sass/gu-sass';
+
+
+// ----- Shared Components ----- //
+
+@import '~components/footer/footer';
+@import '~components/headers/simpleHeader/simpleHeader';

--- a/conf/routes
+++ b/conf/routes
@@ -80,6 +80,9 @@ GET  /$country<(uk|us|au|int)>/subscribe/premium-tier   controllers.Subscription
 GET  /subscribe/weekly                            controllers.Subscriptions.weeklyGeoRedirect()
 GET  /$country<(uk|us|au|int|nz|ca|eu)>/subscribe/weekly   controllers.Subscriptions.weekly(country: String)
 
+GET  /subscribe/paper          controllers.Subscriptions.paperMethodRedirect()
+GET  /subscribe/paper/$method<collection|delivery>          controllers.Subscriptions.paper(method: String)
+
 # ----- Authentication ----- #
 
 GET  /login                                         controllers.Login.login

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -15,6 +15,8 @@ Disallow: /eu/subscribe/weekly
 Disallow: /ca/subscribe/weekly
 Disallow: /int/subscribe/weekly
 Disallow: /subscribe/weekly
+Disallow: /subscribe/paper/delivery
+Disallow: /subscribe/paper/collection
 
 Disallow: /uk/subscribe/digital/checkout
 Disallow: /us/subscribe/digital/checkout

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -7,6 +7,7 @@ Disallow: /au/subscribe/premium-tier
 Disallow: /int/subscribe/premium-tier
 Disallow: /contribute/recurring-guest
 
+Disallow: /subscribe/paper
 Disallow: /subscribe/paper/delivery
 Disallow: /subscribe/paper/collection
 

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -35,6 +35,7 @@ module.exports = (cssFilename, outputFilename, minimizeCss) => ({
     digitalSubscriptionLandingPageStyles: 'pages/digital-subscription-landing/digitalSubscriptionLanding.scss',
     digitalSubscriptionCheckoutPage: 'pages/digital-subscription-checkout/digitalSubscriptionCheckout.jsx',
     digitalSubscriptionCheckoutPageStyles: 'pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss',
+    paperSubscriptionLandingPage: 'pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx',
     weeklySubscriptionLandingPage: 'pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx',
     weeklySubscriptionLandingPageStyles: 'pages/weekly-subscription-landing/weeklySubscriptionLanding.scss',
     premiumTierLandingPage: 'pages/premium-tier-landing/premiumTierLanding.jsx',


### PR DESCRIPTION
## Why are you doing this?

Create an empty page for paper subs to begin work on it

- `/subscribe/paper` (redirects to collection)
- `/subscribe/paper/delivery`
- `/subscribe/paper/collection`

[**Trello Card**](https://trello.com/c/Rjq5SmCR/2057-print-product-page-v0)

## Screenshots
<img src="https://i.imgur.com/5VHnERY.png" />
