### PR TITLE
Digital Subscription Checkout Validation

### DIFF
--- a/assets/components/forms/formHOCs/withError.jsx
+++ b/assets/components/forms/formHOCs/withError.jsx
@@ -7,23 +7,56 @@ import React from 'react';
 
 // ----- Types ----- //
 
-type AugmentedProps<Props> = Props & {
-  message: string | null,
+type Option<A> = A | null;
+
+export type FormError<FormField> = {
+  field: FormField,
+  message: string,
+};
+
+type AugmentedProps<Props, FormField> = Props & {
+  errors: FormError<FormField>[],
+  fieldName: FormField,
 };
 
 type In<Props> = React$ComponentType<Props>;
-type Out<Props> = React$ComponentType<AugmentedProps<Props>>;
+type Out<Props, A> = React$ComponentType<AugmentedProps<Props, A>>;
+
+
+// ----- Functions ----- //
+
+function headOption<A>(arr: Array<A>): Option<A> {
+  return arr[0] || null;
+}
+
+function firstError<FormField>(field: FormField): FormError<FormField>[] => Option<string> {
+
+  return (errors) => {
+    const msgs = errors.filter(err => err.field === field).map(err => err.message);
+    return headOption(msgs);
+  };
+
+}
 
 
 // ----- Component ----- //
 
-function withError<Props: { id: string }>(Component: In<Props>): Out<Props> {
-  return ({ message, ...props }: AugmentedProps<Props>) => (
-    <div>
-      <Component {...props} />
-      {message ? <label className="component-error" htmlFor={props.id}>{message}</label> : null}
-    </div>
-  );
+function withError<Props: { id: string }>(Component: In<Props>): Out<Props, *> {
+
+  function WrapperComponent<FormField>({ errors, fieldName, ...props }: AugmentedProps<Props, FormField>) {
+
+    const error = firstError(fieldName)(errors);
+
+    return (
+      <div>
+        <Component {...props} />
+        {error ? <label className="component-error" htmlFor={props.id}>{error}</label> : null}
+      </div>
+    );
+
+  }
+
+  return WrapperComponent;
 }
 
 

--- a/assets/components/forms/formHOCs/withError.jsx
+++ b/assets/components/forms/formHOCs/withError.jsx
@@ -4,59 +4,30 @@
 
 import React from 'react';
 
+import { type Option } from 'helpers/types/option';
+
 
 // ----- Types ----- //
 
-type Option<A> = A | null;
-
-export type FormError<FormField> = {
-  field: FormField,
-  message: string,
-};
-
-type AugmentedProps<Props, FormField> = Props & {
-  errors: FormError<FormField>[],
-  fieldName: FormField,
+type AugmentedProps<Props> = Props & {
+  error: Option<string>,
 };
 
 type In<Props> = React$ComponentType<Props>;
-type Out<Props, A> = React$ComponentType<AugmentedProps<Props, A>>;
-
-
-// ----- Functions ----- //
-
-function headOption<A>(arr: Array<A>): Option<A> {
-  return arr[0] || null;
-}
-
-function firstError<FormField>(field: FormField): FormError<FormField>[] => Option<string> {
-
-  return (errors) => {
-    const msgs = errors.filter(err => err.field === field).map(err => err.message);
-    return headOption(msgs);
-  };
-
-}
+type Out<Props> = React$ComponentType<AugmentedProps<Props>>;
 
 
 // ----- Component ----- //
 
-function withError<Props: { id: string }>(Component: In<Props>): Out<Props, *> {
+function withError<Props: { id: string }>(Component: In<Props>): Out<Props> {
 
-  function WrapperComponent<FormField>({ errors, fieldName, ...props }: AugmentedProps<Props, FormField>) {
+  return ({ error, ...props }: AugmentedProps<Props>) => (
+    <div>
+      <Component {...props} />
+      {error ? <label className="component-error" htmlFor={props.id}>{error}</label> : null}
+    </div>
+  );
 
-    const error = firstError(fieldName)(errors);
-
-    return (
-      <div>
-        <Component {...props} />
-        {error ? <label className="component-error" htmlFor={props.id}>{error}</label> : null}
-      </div>
-    );
-
-  }
-
-  return WrapperComponent;
 }
 
 

--- a/assets/helpers/subscriptionsForms/__tests__/validationTest.js
+++ b/assets/helpers/subscriptionsForms/__tests__/validationTest.js
@@ -1,0 +1,100 @@
+// @flow
+
+// ----- Imports ----- //
+
+import {
+  nonEmptyString,
+  notNull,
+  firstError,
+  formError,
+  validate,
+} from '../validation';
+
+
+// ----- Tests ----- //
+
+describe('validation', () => {
+
+  describe('nonEmptyString', () => {
+
+    it('should return false for an empty string', () => {
+      expect(nonEmptyString('')).toBe(false);
+    });
+
+    it('should return false for a space-padded empty string', () => {
+      expect(nonEmptyString('  ')).toBe(false);
+    });
+
+    it('should return true for a valid string', () => {
+      expect(nonEmptyString('foo')).toBe(true);
+      expect(nonEmptyString(' foo ')).toBe(true);
+    });
+
+  });
+
+  describe('notNull', () => {
+
+    it('should return false if the value is null', () => {
+      expect(notNull(null)).toBe(false);
+    });
+
+    it('should return true if the value is not null', () => {
+      expect(notNull(1)).toBe(true);
+      expect(notNull('')).toBe(true);
+      expect(notNull('foo')).toBe(true);
+      expect(notNull(true)).toBe(true);
+      expect(notNull(false)).toBe(true);
+      expect(notNull(undefined)).toBe(true);
+      expect(notNull({})).toBe(true);
+      expect(notNull([])).toBe(true);
+    });
+
+  });
+
+  describe('firstError', () => {
+
+    const someErrors = [
+      { field: 'foo', message: 'bar' },
+      { field: 'hello', message: 'world' },
+      { field: 'foo', message: 'baz' },
+    ];
+
+    it('should return the first error from a list of errors', () => {
+      expect(firstError('foo', someErrors)).toBe('bar');
+    });
+
+    it('should return null if there are no matching errors', () => {
+      expect(firstError('bar', someErrors)).toBeNull();
+    });
+
+    it('should return null if there are no errors at all', () => {
+      expect(firstError('foo', [])).toBeNull();
+    });
+
+  });
+
+  describe('formError', () => {
+
+    it('should return a FormError', () => {
+      expect(formError('foo', 'bar')).toEqual({ field: 'foo', message: 'bar' });
+    });
+
+  });
+
+  describe('validate', () => {
+
+    it('should return a list of validation errors', () => {
+
+      const rules = [
+        { rule: false, error: 'foo' },
+        { rule: true, error: 'bar' },
+        { rule: false, error: 'baz' },
+      ];
+
+      expect(validate(rules)).toEqual(['foo', 'baz']);
+
+    });
+
+  });
+
+});

--- a/assets/helpers/subscriptionsForms/validation.js
+++ b/assets/helpers/subscriptionsForms/validation.js
@@ -1,0 +1,53 @@
+// @flow
+
+// ----- Imports ----- //
+
+import { type Option, headOption } from 'helpers/types/option';
+
+
+// ----- Types ----- //
+
+type Rule<Err> = { rule: boolean, error: Err };
+
+export type FormError<FormField> = {
+  field: FormField,
+  message: string,
+};
+
+
+// ----- Rules ----- //
+
+const nonEmptyString: string => boolean = s => s.trim() !== '';
+
+function notNull<A>(value: A): boolean {
+  return value !== null;
+}
+
+
+// ----- Functions ----- //
+
+function firstError<FormField>(field: FormField, errors: FormError<FormField>[]): Option<string> {
+
+  const msgs = errors.filter(err => err.field === field).map(err => err.message);
+  return headOption(msgs);
+
+}
+
+function formError<Field>(field: Field, message: string): FormError<Field> {
+  return { field, message };
+}
+
+function validate<Err>(rules: Rule<Err>[]): Err[] {
+  return rules.reduce((errors, { rule, error }) => (rule ? errors : [...errors, error]), []);
+}
+
+
+// ----- Exports ----- //
+
+export {
+  nonEmptyString,
+  notNull,
+  firstError,
+  formError,
+  validate,
+};

--- a/assets/helpers/types/__tests__/optionTest.js
+++ b/assets/helpers/types/__tests__/optionTest.js
@@ -1,0 +1,36 @@
+// @flow
+
+// ----- Imports ----- //
+
+import { headOption } from '../option';
+
+
+// ----- Tests ----- //
+
+describe('option', () => {
+
+  describe('headOption', () => {
+
+    it('retrieves the first item from an array', () => {
+      expect(headOption([1, 2, 3])).toBe(1);
+    });
+
+    it('returns null when the array is empty', () => {
+      expect(headOption([])).toBeNull();
+    });
+
+    it('returns null when the array contains null', () => {
+      expect(headOption([null, 2, 3])).toBeNull();
+    });
+
+    it('returns empty string when the array contains empty string', () => {
+      expect(headOption(['', 2, 3])).toBe('');
+    });
+
+    it('returns false when the array contains false', () => {
+      expect(headOption([false, true, false])).toBe(false);
+    });
+
+  });
+
+});

--- a/assets/helpers/types/__tests__/optionTest.js
+++ b/assets/helpers/types/__tests__/optionTest.js
@@ -13,22 +13,13 @@ describe('option', () => {
 
     it('retrieves the first item from an array', () => {
       expect(headOption([1, 2, 3])).toBe(1);
+      expect(headOption([null, 2, 3])).toBeNull();
+      expect(headOption(['', 2, 3])).toBe('');
+      expect(headOption([false, true, false])).toBe(false);
     });
 
     it('returns null when the array is empty', () => {
       expect(headOption([])).toBeNull();
-    });
-
-    it('returns null when the array contains null', () => {
-      expect(headOption([null, 2, 3])).toBeNull();
-    });
-
-    it('returns empty string when the array contains empty string', () => {
-      expect(headOption(['', 2, 3])).toBe('');
-    });
-
-    it('returns false when the array contains false', () => {
-      expect(headOption([false, true, false])).toBe(false);
     });
 
   });

--- a/assets/helpers/types/option.js
+++ b/assets/helpers/types/option.js
@@ -8,7 +8,7 @@ export type Option<A> = A | null;
 // ----- Helpers ----- //
 
 function headOption<A>(arr: Array<A>): Option<A> {
-  return arr[0] || null;
+  return arr[0] !== undefined ? arr[0] : null;
 }
 
 

--- a/assets/helpers/types/option.js
+++ b/assets/helpers/types/option.js
@@ -1,0 +1,17 @@
+// @flow
+
+// ----- Type ----- //
+
+export type Option<A> = A | null;
+
+
+// ----- Helpers ----- //
+
+function headOption<A>(arr: Array<A>): Option<A> {
+  return arr[0] || null;
+}
+
+
+// ----- Exports ----- //
+
+export { headOption };

--- a/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -11,11 +11,13 @@ import { countries } from 'helpers/internationalisation/country';
 import { Input } from 'components/forms/standardFields/input';
 import { Select } from 'components/forms/standardFields/select';
 import { withLabel } from 'components/forms/formHOCs/withLabel';
+import { withError, type FormError } from 'components/forms/formHOCs/withError';
 import { asControlled } from 'components/forms/formHOCs/asControlled';
 
 import {
   type State,
   type FormFields,
+  type FormField,
   type FormActionCreators,
   formFieldsSelector,
   formActionCreators,
@@ -26,6 +28,7 @@ import {
 
 type PropTypes = {|
   ...FormFields,
+  errors: FormError<FormField>[],
   ...FormActionCreators,
 |};
 
@@ -33,14 +36,17 @@ type PropTypes = {|
 // ----- Map State/Props ----- //
 
 function mapStateToProps(state: State) {
-  return formFieldsSelector(state);
+  return {
+    ...formFieldsSelector(state),
+    errors: state.page.form.errors,
+  };
 }
 
 
 // ----- Form Fields ----- //
 
-const Input1 = compose(asControlled, withLabel)(Input);
-const Select1 = compose(asControlled, withLabel)(Select);
+const Input1 = compose(asControlled, withError, withLabel)(Input);
+const Select1 = compose(asControlled, withError, withLabel)(Select);
 
 
 // ----- Component ----- //
@@ -55,6 +61,8 @@ function CheckoutForm(props: PropTypes) {
         type="text"
         value={props.firstName}
         setValue={props.setFirstName}
+        errors={props.errors}
+        fieldName="firstName"
       />
       <Input1
         id="last-name"
@@ -62,8 +70,17 @@ function CheckoutForm(props: PropTypes) {
         type="text"
         value={props.lastName}
         setValue={props.setLastName}
+        errors={props.errors}
+        fieldName="lastName"
       />
-      <Select1 id="country" label="Country" value={props.country} setValue={props.setCountry}>
+      <Select1
+        id="country"
+        label="Country"
+        value={props.country}
+        setValue={props.setCountry}
+        errors={props.errors}
+        fieldName="country"
+      >
         <option value="">--</option>
         {Object.keys(countries)
           .sort((a, b) => countries[a].localeCompare(countries[b]))
@@ -76,6 +93,8 @@ function CheckoutForm(props: PropTypes) {
         type="tel"
         value={props.telephone}
         setValue={props.setTelephone}
+        errors={props.errors}
+        fieldName="telephone"
       />
     </div>
   );

--- a/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -7,11 +7,12 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 
 import { countries } from 'helpers/internationalisation/country';
+import { type FormError, firstError } from 'helpers/subscriptionsForms/validation';
 
 import { Input } from 'components/forms/standardFields/input';
 import { Select } from 'components/forms/standardFields/select';
 import { withLabel } from 'components/forms/formHOCs/withLabel';
-import { withError, type FormError } from 'components/forms/formHOCs/withError';
+import { withError } from 'components/forms/formHOCs/withError';
 import { asControlled } from 'components/forms/formHOCs/asControlled';
 
 import {
@@ -19,7 +20,7 @@ import {
   type FormFields,
   type FormField,
   type FormActionCreators,
-  formFieldsSelector,
+  getFormFields,
   formActionCreators,
 } from '../digitalSubscriptionCheckoutReducer';
 
@@ -37,7 +38,7 @@ type PropTypes = {|
 
 function mapStateToProps(state: State) {
   return {
-    ...formFieldsSelector(state),
+    ...getFormFields(state),
     errors: state.page.form.errors,
   };
 }
@@ -61,8 +62,7 @@ function CheckoutForm(props: PropTypes) {
         type="text"
         value={props.firstName}
         setValue={props.setFirstName}
-        errors={props.errors}
-        fieldName="firstName"
+        error={firstError('firstName', props.errors)}
       />
       <Input1
         id="last-name"
@@ -70,16 +70,14 @@ function CheckoutForm(props: PropTypes) {
         type="text"
         value={props.lastName}
         setValue={props.setLastName}
-        errors={props.errors}
-        fieldName="lastName"
+        error={firstError('lastName', props.errors)}
       />
       <Select1
         id="country"
         label="Country"
         value={props.country}
         setValue={props.setCountry}
-        errors={props.errors}
-        fieldName="country"
+        error={firstError('country', props.errors)}
       >
         <option value="">--</option>
         {Object.keys(countries)
@@ -93,9 +91,9 @@ function CheckoutForm(props: PropTypes) {
         type="tel"
         value={props.telephone}
         setValue={props.setTelephone}
-        errors={props.errors}
-        fieldName="telephone"
+        error={firstError('telephone', props.errors)}
       />
+      <button onClick={() => props.submitForm()}>Submit</button>
     </div>
   );
 

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.jsx
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.jsx
@@ -23,7 +23,7 @@ import CheckoutStage from './components/checkoutStage';
 
 // ----- Redux Store ----- //
 
-const store = pageInit(initReducer());
+const store = pageInit(initReducer(), true);
 
 user.init(store.dispatch);
 

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss
@@ -20,6 +20,7 @@
 @import '~components/forms/standardFields/input';
 @import '~components/forms/standardFields/select';
 @import '~components/forms/formHOCs/withLabel';
+@import '~components/forms/formHOCs/withError';
 
 
 // ----- Page-Specific Styles ----- //

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -13,6 +13,8 @@ import { createUserReducer, type User as UserState } from 'helpers/user/userRedu
 import { marketingConsentReducerFor } from 'components/marketingConsent/marketingConsentReducer';
 import { combineReducers } from 'redux';
 
+import { type FormError } from 'components/forms/formHOCs/withError';
+
 
 // ----- Types ----- //
 
@@ -25,18 +27,22 @@ export type FormFields = {|
   telephone: string,
 |};
 
+export type FormField = $Keys<FormFields>;
+
 type CheckoutState = {|
   stage: string,
   firstName: string,
   lastName: string,
   country: ?string,
   telephone: string,
+  errors: FormError<FormField>[],
 |}
 
 type PageState = {|
   form: {
     stage: Stage,
     ...FormFields,
+    errors: FormError<FormField>[],
   },
   user: UserState,
   csrf: CsrfState,
@@ -90,6 +96,7 @@ const initialState = {
   lastName: '',
   country: null,
   telephone: '',
+  errors: [],
 };
 
 function reducer(state: CheckoutState = initialState, action: Action): CheckoutState {

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -2,6 +2,8 @@
 
 // ----- Imports ----- //
 
+import { compose, type Dispatch } from 'redux';
+
 import type { CommonState } from 'helpers/page/commonReducer';
 import { type IsoCountry, fromString } from 'helpers/internationalisation/country';
 import { detect, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
@@ -13,7 +15,13 @@ import { createUserReducer, type User as UserState } from 'helpers/user/userRedu
 import { marketingConsentReducerFor } from 'components/marketingConsent/marketingConsentReducer';
 import { combineReducers } from 'redux';
 
-import { type FormError } from 'components/forms/formHOCs/withError';
+import {
+  validate,
+  nonEmptyString,
+  notNull,
+  formError,
+  type FormError,
+} from 'helpers/subscriptionsForms/validation';
 
 
 // ----- Types ----- //
@@ -59,26 +67,13 @@ export type Action =
   | { type: 'SET_FIRST_NAME', firstName: string }
   | { type: 'SET_LAST_NAME', lastName: string }
   | { type: 'SET_TELEPHONE', telephone: string }
-  | { type: 'SET_COUNTRY', country: string };
-
-
-// ----- Action Creators ----- //
-
-const setStage = (stage: Stage): Action => ({ type: 'SET_STAGE', stage });
-
-const formActionCreators = {
-  setFirstName: (firstName: string): Action => ({ type: 'SET_FIRST_NAME', firstName }),
-  setLastName: (lastName: string): Action => ({ type: 'SET_LAST_NAME', lastName }),
-  setTelephone: (telephone: string): Action => ({ type: 'SET_TELEPHONE', telephone }),
-  setCountry: (country: string): Action => ({ type: 'SET_COUNTRY', country }),
-};
-
-export type FormActionCreators = typeof formActionCreators;
+  | { type: 'SET_COUNTRY', country: string }
+  | { type: 'SET_ERRORS', errors: FormError<FormField>[] };
 
 
 // ----- Selectors ----- //
 
-function formFieldsSelector(state: State): FormFields {
+function getFormFields(state: State): FormFields {
   return {
     firstName: state.page.form.firstName,
     lastName: state.page.form.lastName,
@@ -86,6 +81,43 @@ function formFieldsSelector(state: State): FormFields {
     telephone: state.page.form.telephone,
   };
 }
+
+
+// ----- Functions ----- //
+
+function getErrors(fields: FormFields): FormError<FormField>[] {
+  return validate([
+    {
+      rule: nonEmptyString(fields.firstName),
+      error: formError('firstName', 'Please enter a value.'),
+    },
+    {
+      rule: nonEmptyString(fields.lastName),
+      error: formError('lastName', 'Please enter a value.'),
+    },
+    {
+      rule: notNull(fields.country),
+      error: formError('country', 'Please select a country.'),
+    },
+  ]);
+}
+
+
+// ----- Action Creators ----- //
+
+const setStage = (stage: Stage): Action => ({ type: 'SET_STAGE', stage });
+const setFormErrors = (errors: Array<FormError<FormField>>): Action => ({ type: 'SET_ERRORS', errors });
+
+const formActionCreators = {
+  setFirstName: (firstName: string): Action => ({ type: 'SET_FIRST_NAME', firstName }),
+  setLastName: (lastName: string): Action => ({ type: 'SET_LAST_NAME', lastName }),
+  setTelephone: (telephone: string): Action => ({ type: 'SET_TELEPHONE', telephone }),
+  setCountry: (country: string): Action => ({ type: 'SET_COUNTRY', country }),
+  submitForm: () => (dispatch: Dispatch<Action>, getState: () => State) =>
+    compose(dispatch, setFormErrors, getErrors, getFormFields)(getState()),
+};
+
+export type FormActionCreators = typeof formActionCreators;
 
 
 // ----- Reducer ----- //
@@ -118,6 +150,9 @@ function reducer(state: CheckoutState = initialState, action: Action): CheckoutS
     case 'SET_COUNTRY':
       return { ...state, country: fromString(action.country) };
 
+    case 'SET_ERRORS':
+      return { ...state, errors: action.errors };
+
     default:
       return state;
 
@@ -140,6 +175,6 @@ function initReducer(countryGroupId: CountryGroupId = detect()) {
 export {
   initReducer,
   setStage,
-  formFieldsSelector,
+  getFormFields,
   formActionCreators,
 };


### PR DESCRIPTION
## Why are you doing this?

To apply validation rules to the digital subscription checkout, and to make the validation code generic enough to use on other checkouts.

This introduces a new `validate` function, which takes a list of rules and corresponding error messages. It then returns a series of error messages based on these rules. Also included is a `FormError` type that combines a form field with an error message, which can be used in conjunction with this validation framework (or not, any error message format should work). The resultant error messages are then used in combination with the `withError` HOC to display error messages on the page (see the screenshot below).

[**Trello Card**](https://trello.com/c/yH3GBpu7/1782-mandatory-fields-incomplete-error-messaging)

cc @JustinPinner 

## Changes

- Tweaked `withError` to use `error` as a prop instead of `message`.
- Added a new `validation` helper.
- Added a new `Option` type and corresponding `headOption` helper for arrays.
- Updated the `CheckoutForm` components to use the `withError` HOC.
- Updated the checkout reducer and actions to run validation rules and update the state with any errors.

## Screenshots

![form-errors](https://user-images.githubusercontent.com/5131341/48563747-e7949380-e8ec-11e8-9608-d5586567c8b4.png)
