### PR TITLE
Fix paypal one-off GA events

### DIFF
--- a/app/controllers/PayPalOneOff.scala
+++ b/app/controllers/PayPalOneOff.scala
@@ -89,7 +89,12 @@ class PayPalOneOff(
     val acquisitionData = (for {
       cookie <- request.cookies.get("acquisition_data")
       cookieAcquisitionData <- Try {
-        Json.parse(java.net.URLDecoder.decode(cookie.value, "UTF-8"))
+        val parsed = Json.parse(java.net.URLDecoder.decode(cookie.value, "UTF-8"))
+
+        request.cookies.get("_ga") match {
+          case Some(gaId) => parsed.as[JsObject] + ("gaId" -> Json.toJson(gaId.value))
+          case None => parsed
+        }
       }.toOption
     } yield cookieAcquisitionData).getOrElse(fallbackAcquisitionData)
 


### PR DESCRIPTION
## Why are you doing this?
Currently when sending data to payment-api, the gaId value is always `1` - get the `_ga` cookie value instead.

