### PR TITLE
Check session storage too for consistent banner experience

### DIFF
--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -1,4 +1,5 @@
 // @flow
+import { getSession } from 'helpers/storage';
 import type { Tests } from './abtest';
 
 // ----- Tests ----- //
@@ -33,6 +34,12 @@ export const tests: Tests = {
     canRun: () => [
       'ACQUISITIONS_EPIC',
       'ACQUISITIONS_ENGAGEMENT_BANNER',
-    ].some(componentType => window.location.href.includes(componentType)),
+    ].some((componentType: string) => {
+      // Try from session storage first. This is so that we get the correct header
+      // on subsequent pageviews which don't have the componentType in the URL, e.g.
+      // thank you page after PayPal one-off, or after changing country dropdown.
+      const searchString = getSession('acquisitionData') || window.location.href;
+      return searchString.includes(componentType);
+    }),
   },
 };

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -1103,19 +1103,19 @@ form {
     }
   }
 
-  .gu-content--no-blurb {
+  .gu-content--contribution-form.gu-content--no-blurb {
     .blurb {
       display: none;
     }
   }
 
-  .gu-content--no-header {
+  .gu-content--contribution-form.gu-content--no-header {
     .header {
       display: none;
     }
   }
 
-  .gu-content--no-blurb.gu-content--no-header {
+  .gu-content--contribution-form.gu-content--no-blurb.gu-content--no-header {
     .form__radio-group-list {
       padding-top: 0;
     }


### PR DESCRIPTION
This is so that we get the correct header on subsequent pageviews which don't have the componentType in the URL, e.g. thank you page after PayPal one-off, or after changing country dropdown.


also fixes this:

| old | new |
| --- | ---- |
| ![picture 364](https://user-images.githubusercontent.com/5122968/48634645-f008cf00-e9bd-11e8-8d21-9b69e56855fb.png) | ![picture 363](https://user-images.githubusercontent.com/5122968/48634657-f72fdd00-e9bd-11e8-93c3-1668fd5a7960.png) |

| old | new |
| --- | ---- |
| ![picture 362](https://user-images.githubusercontent.com/5122968/48634673-0151db80-e9be-11e8-9e0d-7f757846cff4.png) | ![picture 361](https://user-images.githubusercontent.com/5122968/48634686-0747bc80-e9be-11e8-978b-0187437e4e01.png) |




