### PR TITLE
Fix TiP for paypal

### DIFF
--- a/app/controllers/PayPalOneOff.scala
+++ b/app/controllers/PayPalOneOff.scala
@@ -71,7 +71,7 @@ class PayPalOneOff(
     }
     val countryCookie = request.cookies.get("GU_country")
     val countryFromCookie = countryCookie.map(_.value).getOrElse("Unknown")
-    if (!isTestUser) tipMonitoring.verify(s"${country.getOrElse(countryFromCookie)} One-off PayPal contribution")
+    if (!isTestUser) tipMonitoring.verify(s"${country.getOrElse(countryFromCookie).toUpperCase} One-off PayPal contribution")
     success.email.fold({
       SafeLogger.info("Redirecting to thank you page without email in flash session")
       redirect

--- a/conf/tip.yaml
+++ b/conf/tip.yaml
@@ -6,3 +6,15 @@
 
 - name: AU One-off PayPal contribution
   description: Successful one-off contribution in AUD (using PayPal)
+
+- name: EU One-off PayPal contribution
+  description: Successful one-off contribution in EUR (using PayPal)
+
+- name: INT One-off PayPal contribution
+  description: Successful one-off contribution in USD (using PayPal)
+
+- name: NZ One-off PayPal contribution
+  description: Successful one-off contribution in NZD (using PayPal)
+
+- name: CA One-off PayPal contribution
+  description: Successful one-off contribution in CAD (using PayPal)


### PR DESCRIPTION
## Why are you doing this?
This is currently causing lots of `ERROR` logs in cloudwatch

e.g.
```
ERROR com.gu.tip.PathsActor - Unrecognized path name. Available paths: US One-off PayPal contribution,GB One-off PayPal contribution,AU One-off PayPal contribution
ERROR com.gu.tip.TipFactory$$anon$1 - Unrecognized path name: int One-off PayPal contribution
```

