### PR TITLE
Make marketing consent a shared component (using new design)

### DIFF
--- a/app/controllers/Subscriptions.scala
+++ b/app/controllers/Subscriptions.scala
@@ -8,6 +8,7 @@ import config.StringsConfig
 import play.api.mvc._
 import admin.{Settings, SettingsProvider, SettingsSurrogateKeySyntax, SwitchState}
 import utils.RequestCountry._
+import views.html.helper.CSRF
 
 import scala.concurrent.ExecutionContext
 
@@ -125,7 +126,7 @@ class Subscriptions(
 
   def premiumTierGeoRedirect: Action[AnyContent] = geoRedirect("subscribe/premium-tier")
 
-  def displayForm(countryCode: String, displayCheckout: String): Action[AnyContent] =
+  def displayForm(countryCode: String, displayCheckout: String, isCsrf: Boolean = false): Action[AnyContent] =
     authenticatedAction(recurringIdentityClientId) { implicit request =>
       if (displayCheckout == "true") {
         implicit val settings: Settings = settingsProvider.settings()
@@ -133,7 +134,8 @@ class Subscriptions(
         val id = "digital-subscription-checkout-page-" + countryCode
         val js = "digitalSubscriptionCheckoutPage.js"
         val css = "digitalSubscriptionCheckoutPageStyles.css"
-        Ok(views.html.main(title, id, js, css)).withSettingsSurrogateKey
+        val csrf = CSRF.getToken.value
+        Ok(views.html.main(title, id, js, css, csrf = Some(csrf))).withSettingsSurrogateKey
       } else {
         Redirect(routes.Subscriptions.geoRedirect)
       }

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -10,7 +10,8 @@
 	canonicalLink: Option[String] = None,
 	hrefLangLinks: Map[String, String] = Map(),
 	styles: Html = Html(""),
-	scripts: Html = Html("")
+	scripts: Html = Html(""),
+  csrf: Option[String] = None
 )(implicit assets: AssetsResolver, request: RequestHeader, settings: Settings)
 
 <!DOCTYPE html>
@@ -19,6 +20,13 @@
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<meta name="google-site-verification" content="nFrhJ3suC2OpKRasEkZyH1KZKpSZc-ofno_uunJgfvg" />
+
+  @csrf.map { token =>
+    <script type="text/javascript">
+      window.guardian = window.guardian || {};
+      window.guardian.csrf = {token: "@token"}
+    </script>
+  }
 
 	@description.map { definedDescription =>
 		<meta name="description" content="@definedDescription" />

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -24,7 +24,9 @@
   @csrf.map { token =>
     <script type="text/javascript">
       window.guardian = window.guardian || {};
-      window.guardian.csrf = {token: "@token"}
+      if(!window.guardian.csrf) {
+        window.guardian.csrf = {token: "@token"}
+      }
     </script>
   }
 

--- a/assets/components/marketingConsentNew/marketingConsent.jsx
+++ b/assets/components/marketingConsentNew/marketingConsent.jsx
@@ -3,18 +3,13 @@
 // ----- Imports ----- //
 
 import React from 'react';
-import { connect } from 'react-redux';
 import { classNameWithModifiers } from 'helpers/utilities';
-
 import SvgSubscribe from 'components/svgs/subscribe';
 import SvgSubscribed from 'components/svgs/subscribed';
 import SvgNewsletters from 'components/svgs/newsletters';
 import SvgInformation from 'components/svgs/information';
-import { trackComponentClick } from 'helpers/tracking/ophanComponentEventTracking';
-import type { Dispatch } from 'redux';
-import type { Action } from '../../../helpers/user/userActions';
-import type { Csrf as CsrfState } from '../../../helpers/csrf/csrfReducer';
-import { sendMarketingPreferencesToIdentity } from '../../../components/marketingConsent/helpers';
+import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
+
 
 // ----- Types ----- //
 
@@ -25,26 +20,6 @@ type PropTypes = {|
   onClick: (?string, CsrfState) => void,
 |};
 
-const mapStateToProps = state => ({
-  confirmOptIn: state.page.marketingConsent.confirmOptIn,
-  email: state.page.form.formData.email,
-  csrf: state.page.csrf,
-});
-
-function mapDispatchToProps(dispatch: Dispatch<Action>) {
-  return {
-    onClick: (email: string, csrf: CsrfState) => {
-      trackComponentClick('marketing-permissions');
-      sendMarketingPreferencesToIdentity(
-        true,
-        email,
-        dispatch,
-        csrf,
-        'MARKETING_CONSENT',
-      );
-    },
-  };
-}
 
 // ----- Render ----- //
 
@@ -89,4 +64,7 @@ function MarketingConsent(props: PropTypes) {
   );
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(MarketingConsent);
+
+// ----- Exports ----- //
+
+export default MarketingConsent;

--- a/assets/pages/digital-subscription-checkout/__tests__/digitalSubscriptionCheckoutReducerTest.js
+++ b/assets/pages/digital-subscription-checkout/__tests__/digitalSubscriptionCheckoutReducerTest.js
@@ -2,7 +2,7 @@
 
 // ----- Imports ----- //
 
-import { reducer, setStage, type Stage } from '../digitalSubscriptionCheckoutReducer';
+import { initReducer, setStage, type Stage } from '../digitalSubscriptionCheckoutReducer';
 
 
 // ----- Tests ----- //
@@ -14,9 +14,9 @@ describe('Digital Subscription Checkout Reducer', () => {
     const stage: Stage = 'thankyou';
     const action = setStage(stage);
 
-    const newState = reducer(undefined, action);
+    const newState = initReducer()(undefined, action);
 
-    expect(newState.stage).toEqual(stage);
+    expect(newState.form.stage).toEqual(stage);
 
   });
 
@@ -25,9 +25,9 @@ describe('Digital Subscription Checkout Reducer', () => {
     const stage: Stage = 'checkout';
     const action = setStage(stage);
 
-    const newState = reducer(undefined, action);
+    const newState = initReducer()(undefined, action);
 
-    expect(newState.stage).toEqual(stage);
+    expect(newState.form.stage).toEqual(stage);
 
   });
 

--- a/assets/pages/digital-subscription-checkout/components/MarketingConsentContainer.jsx
+++ b/assets/pages/digital-subscription-checkout/components/MarketingConsentContainer.jsx
@@ -2,7 +2,6 @@
 
 // ----- Imports ----- //
 
-import React from 'react';
 import { connect } from 'react-redux';
 import MarketingConsent from 'components/marketingConsentNew/marketingConsent';
 import { trackComponentClick } from 'helpers/tracking/ophanComponentEventTracking';

--- a/assets/pages/digital-subscription-checkout/components/MarketingConsentContainer.jsx
+++ b/assets/pages/digital-subscription-checkout/components/MarketingConsentContainer.jsx
@@ -14,7 +14,7 @@ import { sendMarketingPreferencesToIdentity } from 'components/marketingConsent/
 
 const mapStateToProps = state => ({
   confirmOptIn: state.page.marketingConsent.confirmOptIn,
-  email: state.page.form.email,
+  email: state.page.user.email,
   csrf: state.page.csrf,
 });
 

--- a/assets/pages/digital-subscription-checkout/components/MarketingConsentContainer.jsx
+++ b/assets/pages/digital-subscription-checkout/components/MarketingConsentContainer.jsx
@@ -1,0 +1,37 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+import { connect } from 'react-redux';
+import MarketingConsent from 'components/marketingConsentNew/marketingConsent';
+import { trackComponentClick } from 'helpers/tracking/ophanComponentEventTracking';
+import type { Dispatch } from 'redux';
+import type { Action } from 'helpers/user/userActions';
+import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
+import { sendMarketingPreferencesToIdentity } from 'components/marketingConsent/helpers';
+
+
+const mapStateToProps = state => ({
+  confirmOptIn: state.page.marketingConsent.confirmOptIn,
+  email: state.page.form.email,
+  csrf: state.page.csrf,
+});
+
+function mapDispatchToProps(dispatch: Dispatch<Action>) {
+  return {
+    onClick: (email: string, csrf: CsrfState) => {
+      trackComponentClick('marketing-permissions');
+      sendMarketingPreferencesToIdentity(
+        true, // it's TRUE because the button says Sign Me Up!
+        email,
+        dispatch,
+        csrf,
+        'MARKETING_CONSENT',
+      );
+    },
+  };
+}
+
+
+export default connect(mapStateToProps, mapDispatchToProps)(MarketingConsent);

--- a/assets/pages/digital-subscription-checkout/components/checkoutStage.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutStage.jsx
@@ -83,7 +83,7 @@ const heroesByCountry: ImagesByCountry = {
 function mapStateToProps(state: State): PropTypes {
 
   return {
-    stage: state.page.stage,
+    stage: state.page.form.stage,
     countryGroupId: state.common.internationalisation.countryGroupId,
   };
 

--- a/assets/pages/digital-subscription-checkout/components/thankYouContent.jsx
+++ b/assets/pages/digital-subscription-checkout/components/thankYouContent.jsx
@@ -16,9 +16,7 @@ import { classNameWithModifiers } from 'helpers/utilities';
 
 import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
 import CtaLink from 'components/ctaLink/ctaLink';
-import SvgNewsletters from 'components/svgs/newsletters';
-import SvgInformation from 'components/svgs/information';
-
+import MarketingConsent from './MarketingConsentContainer';
 
 // ----- Types ----- //
 
@@ -39,7 +37,7 @@ function ThankYouContent(props: PropTypes) {
         </p>
       </LeftMarginSection>
       <AppsSection countryGroupId={props.countryGroupId} />
-      <EmailsSection />
+      <MarketingConsent />
     </div>
   );
 
@@ -83,31 +81,6 @@ function AppsSection(props: { countryGroupId: CountryGroupId }) {
         accessibilityHint="Click to download the Daily Tablet Edition app on the Apple App Store"
         url={getDailyEditionUrl(props.countryGroupId)}
       />
-    </LeftMarginSection>
-  );
-
-}
-
-function EmailsSection() {
-
-  return (
-    <LeftMarginSection modifierClasses={['thank-you-emails']}>
-      <div className="thank-you-content__email-copy">
-        <h2 className="thank-you-content__heading">
-          Stay in the know
-        </h2>
-        <p className="thank-you-content__copy">
-          Opt in below to receive news and offers from The Guardian, The Observer
-          and Guardian Weekly on the ways to read and support our journalism.
-        </p>
-        <p className="thank-you-content__copy thank-you-content__copy--small">
-          <small>
-            <SvgInformation />
-            You can unsubscribe at any time by going to the <a className="thank-you-content__link" href={emailPreferencesUrl}>preference centre</a>
-          </small>
-        </p>
-      </div>
-      <SvgNewsletters />
     </LeftMarginSection>
   );
 

--- a/assets/pages/digital-subscription-checkout/components/thankYouContent.jsx
+++ b/assets/pages/digital-subscription-checkout/components/thankYouContent.jsx
@@ -8,7 +8,6 @@ import {
   getIosAppUrl,
   androidAppUrl,
   getDailyEditionUrl,
-  emailPreferencesUrl,
 } from 'helpers/externalLinks';
 
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.jsx
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.jsx
@@ -8,6 +8,7 @@ import { Provider } from 'react-redux';
 import { renderPage } from 'helpers/render';
 import { detect, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { init as pageInit } from 'helpers/page/page';
+import * as user from 'helpers/user/user';
 
 import Page from 'components/page/page';
 import SimpleHeader from 'components/headers/simpleHeader/simpleHeader';
@@ -24,6 +25,7 @@ import CheckoutStage from './components/checkoutStage';
 
 const store = pageInit(initReducer());
 
+user.init(store.dispatch);
 
 // ----- Internationalisation ----- //
 

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.jsx
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.jsx
@@ -16,13 +16,13 @@ import CustomerService from 'components/customerService/customerService';
 import SubscriptionTermsPrivacy from 'components/legal/subscriptionTermsPrivacy/subscriptionTermsPrivacy';
 import SubscriptionFaq from 'components/subscriptionFaq/subscriptionFaq';
 
-import { reducer } from './digitalSubscriptionCheckoutReducer';
+import { initReducer } from './digitalSubscriptionCheckoutReducer';
 import CheckoutStage from './components/checkoutStage';
 
 
 // ----- Redux Store ----- //
 
-const store = pageInit(reducer);
+const store = pageInit(initReducer());
 
 
 // ----- Internationalisation ----- //

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss
@@ -95,33 +95,11 @@
       margin-right: 5px;
     }
 
-    .svg-newsletters {
-      display: block;
-
-      @include mq($from: tablet) {
-        width: 50%;
-        margin-left: calc(50% + 10px);
-      }
-
-      @include mq($from: wide) {
-        width: 40%;
-        display: inline-block;
-        margin-left: 0;
-        vertical-align: top;
-        padding-top: $gu-v-spacing * 2;
-      }
-    }
   }
 
-  .component-left-margin-section--thank-you-apps, .component-left-margin-section--thank-you-emails {
+  .component-left-margin-section--thank-you-apps {
     .component-left-margin-section__content {
       border-top: 1px solid gu-colour(garnett-neutral-4);
-    }
-  }
-
-  .component-left-margin-section--thank-you-emails {
-    .component-left-margin-section__content {
-      padding-bottom: 0;
     }
   }
 
@@ -166,13 +144,6 @@
 
     @include mq($from: phablet) {
       width: 560px;
-    }
-  }
-
-  .thank-you-content__email-copy {
-    @include mq($from: wide) {
-      display: inline-block;
-      vertical-align: top;
     }
   }
 

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -11,7 +11,7 @@ import csrf from 'helpers/csrf/csrfReducer';
 
 import { createUserReducer, type User as UserState } from 'helpers/user/userReducer';
 import { marketingConsentReducerFor } from 'components/marketingConsent/marketingConsentReducer';
-import {combineReducers} from "redux";
+import { combineReducers } from 'redux';
 
 
 // ----- Types ----- //

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -85,7 +85,7 @@ function formFieldsSelector(state: State): FormFields {
 // ----- Reducer ----- //
 
 const initialState = {
-  stage: 'thankyou',
+  stage: 'checkout',
   firstName: '',
   lastName: '',
   country: null,

--- a/assets/pages/new-contributions-landing/components/ContributionThankYou.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionThankYou.jsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { type Contrib, getSpokenType } from 'helpers/contributions';
 import CtaLink from 'components/ctaLink/ctaLink';
-import MarketingConsent from '../components/MarketingConsent';
+import MarketingConsent from './MarketingConsentContainer';
 import ContributionsSurvey from '../components/ContributionsSurvey';
 import { type Action, setHasSeenDirectDebitThankYouCopy } from '../contributionsLandingActions';
 

--- a/assets/pages/new-contributions-landing/components/ContributionThankYouPasswordSet.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionThankYouPasswordSet.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import CtaLink from 'components/ctaLink/ctaLink';
-import MarketingConsent from '../components/MarketingConsent';
+import MarketingConsent from './MarketingConsentContainer';
 import ContributionsSurvey from '../components/ContributionsSurvey';
 
 // ----- Render ----- //

--- a/assets/pages/new-contributions-landing/components/MarketingConsentContainer.jsx
+++ b/assets/pages/new-contributions-landing/components/MarketingConsentContainer.jsx
@@ -2,7 +2,6 @@
 
 // ----- Imports ----- //
 
-import React from 'react';
 import { connect } from 'react-redux';
 import MarketingConsent from 'components/marketingConsentNew/marketingConsent';
 import { trackComponentClick } from 'helpers/tracking/ophanComponentEventTracking';

--- a/assets/pages/new-contributions-landing/components/MarketingConsentContainer.jsx
+++ b/assets/pages/new-contributions-landing/components/MarketingConsentContainer.jsx
@@ -1,0 +1,37 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+import { connect } from 'react-redux';
+import MarketingConsent from 'components/marketingConsentNew/marketingConsent';
+import { trackComponentClick } from 'helpers/tracking/ophanComponentEventTracking';
+import type { Dispatch } from 'redux';
+import type { Action } from 'helpers/user/userActions';
+import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
+import { sendMarketingPreferencesToIdentity } from 'components/marketingConsent/helpers';
+
+
+const mapStateToProps = state => ({
+  confirmOptIn: state.page.marketingConsent.confirmOptIn,
+  email: state.page.form.formData.email,
+  csrf: state.page.csrf,
+});
+
+function mapDispatchToProps(dispatch: Dispatch<Action>) {
+  return {
+    onClick: (email: string, csrf: CsrfState) => {
+      trackComponentClick('marketing-permissions');
+      sendMarketingPreferencesToIdentity(
+        true, // it's TRUE because the button says Sign Me Up!
+        email,
+        dispatch,
+        csrf,
+        'MARKETING_CONSENT',
+      );
+    },
+  };
+}
+
+
+export default connect(mapStateToProps, mapDispatchToProps)(MarketingConsent);


### PR DESCRIPTION
## Why are you doing this?
This PR replaces this one: https://github.com/guardian/support-frontend/pull/1174

First, some background. When the work to separate out this component started the new payment flow for contributions was a test. Between then and now, it has gone live but all the original code was left behind in that transition, so we now have a mess that needs to be cleaned up. Sadly that's going to be compounded by this batch of changes.

This PR creates a shared marketing preferences component for these specific areas *only*:
* Contributions 'new payment flow' thank you page UI
* New digital pack checkout thank you page

It does *not* change:
* Contributions 'old payment flow' thank you page UI   
* Marketing preferences component used by the 'old payment flow'

[**Trello Card**](https://trello.com/c/vEfya0Nx/1809-marketing-permissions-for-new-checkout-thank-you-page)

## Changes
Yes, there really are 12 files changed in order to run just two sentences and one button on three different pages!

## Screenshots
As seen on CODE:
![newpaymentflowconsent](https://user-images.githubusercontent.com/690395/48707051-1e70ef00-ebf6-11e8-9274-0d00fdaf4f00.gif)

