### PR TITLE
Refine grid+type on new product pages css

### DIFF
--- a/assets/components/headingBlock/headingBlock.scss
+++ b/assets/components/headingBlock/headingBlock.scss
@@ -27,7 +27,7 @@
   @extend %component-heading-block__card;
   @include gu-font-header-responsive();
   font-weight: bold;
-  padding: ($gu-v-spacing /2) ($gu-h-spacing / 2) ($gu-v-spacing * 1.5);
+  padding: ($gu-v-spacing /4) ($gu-h-spacing / 2) ($gu-v-spacing * 1.5);
 }
 
 .component-heading-block__banner {

--- a/assets/components/headingBlock/headingBlock.scss
+++ b/assets/components/headingBlock/headingBlock.scss
@@ -31,8 +31,7 @@
 }
 
 .component-heading-block__banner {
+  @include gu-font-body-responsive;
   border-top: 1px solid gu-colour(garnett-neutral-5);
   padding: ($gu-v-spacing / 1.5) ($gu-h-spacing / 2) $gu-v-spacing;
-  font-size: 17px;
-  line-height: 1;
 }

--- a/assets/components/headingBlock/headingBlock.scss
+++ b/assets/components/headingBlock/headingBlock.scss
@@ -28,8 +28,7 @@
 
 .component-heading-block__heading {
   @extend %component-heading-block__card;
-  @include gu-fontset-header();
-  font-weight: bold;
+  @include gu-fontset-heading-large;
   padding: ($gu-v-spacing /4) ($gu-h-spacing / 2) ($gu-v-spacing * 1.5);
 }
 

--- a/assets/components/headingBlock/headingBlock.scss
+++ b/assets/components/headingBlock/headingBlock.scss
@@ -1,19 +1,15 @@
 
 
 .component-heading-block__overheading {
+  @include gu-font-header-tag-responsive();
   background-color: gu-colour(news-garnett-highlight);
   color: gu-colour(garnett-neutral-1);
   padding: ($gu-v-spacing/2) ($gu-h-spacing / 2);
-  font-family: $gu-headline;
   font-weight: bold;
-  font-size: 20px;
   @supports(transform:translateY(-100%)){
     transform:translateY(-100%);
     position: absolute;
     display: inline-block;
-  }
-  @include mq($from: tablet) {
-    font-size: 24px;
   }
 }
 
@@ -29,22 +25,12 @@
 
 .component-heading-block__heading {
   @extend %component-heading-block__card;
-  font-size: 26px;
+  @include gu-font-header-responsive();
   font-weight: bold;
-  line-height: 1.12;
   padding: ($gu-v-spacing /2) ($gu-h-spacing / 2) ($gu-v-spacing * 1.5);
-
-  @include mq($from: tablet) {
-    font-size: 30px;
-  }
-
-  @include mq($from: desktop) {
-    font-size: 36px;
-  }
 }
 
 .component-heading-block__banner {
-  @extend %component-heading-block__card;
   border-top: 1px solid gu-colour(garnett-neutral-5);
   padding: ($gu-v-spacing / 1.5) ($gu-h-spacing / 2) $gu-v-spacing;
   font-size: 17px;

--- a/assets/components/headingBlock/headingBlock.scss
+++ b/assets/components/headingBlock/headingBlock.scss
@@ -18,12 +18,7 @@
 }
 
 .component-heading-block__maxwidth {
-  @include mq($from: tablet) {
-    width: 75%;
-  }
-  @include mq($from: desktop) {
-    width: 50%;
-  }
+  max-width: gu-span(8);
 }
 
 %component-heading-block__card {

--- a/assets/components/headingBlock/headingBlock.scss
+++ b/assets/components/headingBlock/headingBlock.scss
@@ -1,18 +1,18 @@
 .component-heading-block__overheading {
-  @include gu-family-headline;
-	font-size: 16px;
+  @include gu-typeface(headline, 16);
   line-height: 1;
   font-weight: bold;
   background-color: gu-colour(news-garnett-highlight);
   color: gu-colour(garnett-neutral-1);
   padding: ($gu-v-spacing/2) ($gu-h-spacing / 2);
-  @include mq($from: desktop) {
-    font-size: 22px;
-  }
   @supports(transform:translateY(-100%)){
     transform:translateY(-100%);
     position: absolute;
     display: inline-block;
+  }
+  @include mq($from: desktop) {
+    @include gu-typeface(headline, 22, true);
+    line-height: 1;
   }
 }
 

--- a/assets/components/headingBlock/headingBlock.scss
+++ b/assets/components/headingBlock/headingBlock.scss
@@ -11,7 +11,7 @@
     display: inline-block;
   }
   @include mq($from: desktop) {
-    @include gu-typeface(headline, 22, true);
+    @include gu-typeface(headline, 22, $size-only: true);
     line-height: 1;
   }
 }

--- a/assets/components/headingBlock/headingBlock.scss
+++ b/assets/components/headingBlock/headingBlock.scss
@@ -1,7 +1,7 @@
 
 
 .component-heading-block__overheading {
-  @include gu-font-header-tag-responsive();
+  @include gu-font-header-tag();
   background-color: gu-colour(news-garnett-highlight);
   color: gu-colour(garnett-neutral-1);
   padding: ($gu-v-spacing/2) ($gu-h-spacing / 2);
@@ -25,13 +25,13 @@
 
 .component-heading-block__heading {
   @extend %component-heading-block__card;
-  @include gu-font-header-responsive();
+  @include gu-font-header();
   font-weight: bold;
   padding: ($gu-v-spacing /4) ($gu-h-spacing / 2) ($gu-v-spacing * 1.5);
 }
 
 .component-heading-block__banner {
-  @include gu-font-body-responsive;
+  @include gu-font-body;
   border-top: 1px solid gu-colour(garnett-neutral-5);
   padding: ($gu-v-spacing / 1.5) ($gu-h-spacing / 2) $gu-v-spacing;
 }

--- a/assets/components/headingBlock/headingBlock.scss
+++ b/assets/components/headingBlock/headingBlock.scss
@@ -1,11 +1,16 @@
 
 
 .component-heading-block__overheading {
-  @include gu-font-header-tag();
+  @include gu-font-headline;
+	font-size: 16px;
+  line-height: 1;
+  font-weight: bold;
   background-color: gu-colour(news-garnett-highlight);
   color: gu-colour(garnett-neutral-1);
   padding: ($gu-v-spacing/2) ($gu-h-spacing / 2);
-  font-weight: bold;
+  @include mq($from: desktop) {
+    font-size: 22px;
+  }
   @supports(transform:translateY(-100%)){
     transform:translateY(-100%);
     position: absolute;

--- a/assets/components/headingBlock/headingBlock.scss
+++ b/assets/components/headingBlock/headingBlock.scss
@@ -1,7 +1,5 @@
-
-
 .component-heading-block__overheading {
-  @include gu-font-headline;
+  @include gu-family-headline;
 	font-size: 16px;
   line-height: 1;
   font-weight: bold;
@@ -30,13 +28,13 @@
 
 .component-heading-block__heading {
   @extend %component-heading-block__card;
-  @include gu-font-header();
+  @include gu-fontset-header();
   font-weight: bold;
   padding: ($gu-v-spacing /4) ($gu-h-spacing / 2) ($gu-v-spacing * 1.5);
 }
 
 .component-heading-block__banner {
-  @include gu-font-body;
+  @include gu-fontset-body;
   border-top: 1px solid gu-colour(garnett-neutral-5);
   padding: ($gu-v-spacing / 1.5) ($gu-h-spacing / 2) $gu-v-spacing;
 }

--- a/assets/components/leftMarginSection/leftMarginSection.scss
+++ b/assets/components/leftMarginSection/leftMarginSection.scss
@@ -21,12 +21,9 @@
 
 .component-left-margin-section__content {
   flex-grow: 1;
+  flex-basis: gu-span(11);
 
-  @include mq($from: tablet) {
-    flex-basis: 730px;
-  }
-
-  @include mq($from: desktop) {
-    flex-basis: 960px;
+  @include mq($from: leftCol) {
+    flex-basis: gu-span(13);
   }
 }

--- a/assets/components/leftMarginSection/leftMarginSection.scss
+++ b/assets/components/leftMarginSection/leftMarginSection.scss
@@ -26,8 +26,4 @@
   @include mq($from: desktop) {
     flex-basis: gu-span(12);
   }
-
-  @include mq($from: leftCol) {
-    flex-basis: gu-span(13);
-  }
 }

--- a/assets/components/leftMarginSection/leftMarginSection.scss
+++ b/assets/components/leftMarginSection/leftMarginSection.scss
@@ -21,9 +21,9 @@
 
 .component-left-margin-section__content {
   flex-grow: 1;
-  flex-basis: gu-span(11);
+  flex-basis: gu-span(11) + $gu-h-spacing;
 
-  @include mq($from: desktop) {
-    flex-basis: gu-span(12);
+  @include mq($from: leftCol) {
+    flex-basis: gu-span(12) + $gu-h-spacing;
   }
 }

--- a/assets/components/leftMarginSection/leftMarginSection.scss
+++ b/assets/components/leftMarginSection/leftMarginSection.scss
@@ -23,6 +23,10 @@
   flex-grow: 1;
   flex-basis: gu-span(11);
 
+  @include mq($from: desktop) {
+    flex-basis: gu-span(12);
+  }
+
   @include mq($from: leftCol) {
     flex-basis: gu-span(13);
   }

--- a/assets/components/productPage/productPageButton/productPageButton.scss
+++ b/assets/components/productPage/productPageButton/productPageButton.scss
@@ -1,10 +1,8 @@
 .component-product-page-button {
-  font-size: 16px;
-  line-height: 1.2;
+  @include gu-font-sans-responsive;
   display: inline-flex;
   align-items: center;
   text-decoration: none;
-  font-family: $gu-text-sans-web;
   font-weight: bold;
   padding: ($gu-v-spacing) $gu-h-spacing;
   background-color: gu-colour(news-garnett-highlight);

--- a/assets/components/productPage/productPageButton/productPageButton.scss
+++ b/assets/components/productPage/productPageButton/productPageButton.scss
@@ -1,5 +1,5 @@
 .component-product-page-button {
-  @include gu-font-sans-responsive;
+  @include gu-font-sans;
   display: inline-flex;
   align-items: center;
   text-decoration: none;

--- a/assets/components/productPage/productPageButton/productPageButton.scss
+++ b/assets/components/productPage/productPageButton/productPageButton.scss
@@ -1,5 +1,5 @@
 .component-product-page-button {
-  @include gu-fontset-sans;
+  @include gu-fontset-body-sans;
   display: inline-flex;
   align-items: center;
   text-decoration: none;

--- a/assets/components/productPage/productPageButton/productPageButton.scss
+++ b/assets/components/productPage/productPageButton/productPageButton.scss
@@ -1,5 +1,5 @@
 .component-product-page-button {
-  @include gu-font-sans;
+  @include gu-fontset-sans;
   display: inline-flex;
   align-items: center;
   text-decoration: none;

--- a/assets/components/productPage/productPageContentBlock/productPageContentBlock.scss
+++ b/assets/components/productPage/productPageContentBlock/productPageContentBlock.scss
@@ -45,7 +45,7 @@
 }
 
 .component-product-page-content-block__content {
-  max-width: 944px;
+  max-width: gu-span(12);
   padding: ($gu-v-spacing/2) ($gu-h-spacing / 2) 0;
 }
 

--- a/assets/components/productPage/productPageFeatures/productPageFeatures.scss
+++ b/assets/components/productPage/productPageFeatures/productPageFeatures.scss
@@ -1,5 +1,8 @@
 .component-product-page-features {
-  @include mq($from: tablet) {
+  @include mq($until: leftCol) {
+    max-width: gu-span(6);
+  }
+  @include mq($from: leftCol) {
     display: flex;
   }
 }
@@ -17,10 +20,10 @@
 .component-product-page-features__item {
   flex: 0 0 25%;
   box-sizing: border-box;
-  padding: ($gu-v-spacing / 6) ($gu-h-spacing/2) ($gu-v-spacing * 2) 0;
-  margin-left: $gu-h-spacing / 2;
+  padding: ($gu-v-spacing / 6) 0 ($gu-v-spacing * 2) ($gu-h-spacing/2);
+  padding-left: $gu-h-spacing / 2;
   border-top: 1px solid gu-colour(garnett-neutral-4);
-  @include mq($from: tablet) {
+  @include mq($from: leftCol) {
     padding: 0 ($gu-h-spacing * 2) ($gu-v-spacing*2) ($gu-h-spacing / 2);
     margin: 0 0 0 -1px;
     border-top: 0;

--- a/assets/components/productPage/productPageFeatures/productPageFeatures.scss
+++ b/assets/components/productPage/productPageFeatures/productPageFeatures.scss
@@ -8,8 +8,7 @@
 }
 
 .component-product-page-features__title {
-  @include gu-fontset-standfirst;
-  font-weight: 200;
+  @include gu-fontset-body-large;
 }
 
 .component-product-page-features__copy {

--- a/assets/components/productPage/productPageFeatures/productPageFeatures.scss
+++ b/assets/components/productPage/productPageFeatures/productPageFeatures.scss
@@ -5,12 +5,12 @@
 }
 
 .component-product-page-features__title {
-  @include gu-font-standfirst;
+  @include gu-fontset-standfirst;
   font-weight: 200;
 }
 
 .component-product-page-features__copy {
-  @include gu-font-body;
+  @include gu-fontset-body;
   margin-top: $gu-v-spacing / 4;
 }
 

--- a/assets/components/productPage/productPageFeatures/productPageFeatures.scss
+++ b/assets/components/productPage/productPageFeatures/productPageFeatures.scss
@@ -5,7 +5,7 @@
 }
 
 .component-product-page-features__title {
-  @include gu-font-headline-responsive;
+  @include gu-font-standfirst-responsive;
   font-weight: 200;
 }
 

--- a/assets/components/productPage/productPageFeatures/productPageFeatures.scss
+++ b/assets/components/productPage/productPageFeatures/productPageFeatures.scss
@@ -5,12 +5,12 @@
 }
 
 .component-product-page-features__title {
-  @include gu-font-standfirst-responsive;
+  @include gu-font-standfirst;
   font-weight: 200;
 }
 
 .component-product-page-features__copy {
-  @include gu-font-body-responsive;
+  @include gu-font-body;
   margin-top: $gu-v-spacing / 4;
 }
 

--- a/assets/components/productPage/productPageFeatures/productPageFeatures.scss
+++ b/assets/components/productPage/productPageFeatures/productPageFeatures.scss
@@ -11,6 +11,7 @@
 
 .component-product-page-features__copy {
   @include gu-font-body-responsive;
+  margin-top: $gu-v-spacing / 4;
 }
 
 .component-product-page-features__item {

--- a/assets/components/productPage/productPageFeatures/productPageFeatures.scss
+++ b/assets/components/productPage/productPageFeatures/productPageFeatures.scss
@@ -9,6 +9,10 @@
   font-weight: 200;
 }
 
+.component-product-page-features__copy {
+  @include gu-font-body-responsive;
+}
+
 .component-product-page-features__item {
   flex: 0 0 25%;
   box-sizing: border-box;

--- a/assets/components/productPage/productPagePeriodForm/productPagePeriodForm.scss
+++ b/assets/components/productPage/productPagePeriodForm/productPagePeriodForm.scss
@@ -17,7 +17,7 @@
 }
 
 .component-product-page-period-form__info {
-  @include gu-font-sans;
+  @include gu-fontset-sans;
   padding-top: $gu-v-spacing * 2;
   padding-bottom: $gu-v-spacing * 2.5;
   color: gu-colour(garnett-neutral-5);

--- a/assets/components/productPage/productPagePeriodForm/productPagePeriodForm.scss
+++ b/assets/components/productPage/productPagePeriodForm/productPagePeriodForm.scss
@@ -17,11 +17,10 @@
 }
 
 .component-product-page-period-form__info {
+  @include gu-font-sans-responsive;
   padding-top: $gu-v-spacing * 2;
   padding-bottom: $gu-v-spacing * 2.5;
   color: gu-colour(garnett-neutral-5);
-  font-family: $gu-text-sans-web;
-  font-size: 16px;
   svg {
     display: inline-block;
     vertical-align: text-bottom;

--- a/assets/components/productPage/productPagePeriodForm/productPagePeriodForm.scss
+++ b/assets/components/productPage/productPagePeriodForm/productPagePeriodForm.scss
@@ -20,7 +20,7 @@
 }
 
 .component-product-page-period-form__info {
-  @include gu-fontset-sans;
+  @include gu-fontset-body-sans;
   padding-top: $gu-v-spacing * 2;
   padding-bottom: $gu-v-spacing * 2.5;
   color: gu-colour(garnett-neutral-5);

--- a/assets/components/productPage/productPagePeriodForm/productPagePeriodForm.scss
+++ b/assets/components/productPage/productPagePeriodForm/productPagePeriodForm.scss
@@ -1,6 +1,9 @@
 .component-product-page-period-form__items {
   margin-bottom: $gu-v-spacing * 2;
-  @include mq($from: tablet) {
+  @include mq($until: leftCol) {
+    max-width: gu-span(6);
+  }
+  @include mq($from: leftCol) {
     display: flex;
     align-items: stretch;
   }
@@ -11,7 +14,7 @@
   padding: 0 $gu-h-spacing/2;
   box-sizing: border-box;
   margin-bottom: $gu-v-spacing;
-  @include mq($from: tablet) {
+  @include mq($from: leftCol) {
     margin-bottom: 0;
   }
 }

--- a/assets/components/productPage/productPagePeriodForm/productPagePeriodForm.scss
+++ b/assets/components/productPage/productPagePeriodForm/productPagePeriodForm.scss
@@ -17,7 +17,7 @@
 }
 
 .component-product-page-period-form__info {
-  @include gu-font-sans-responsive;
+  @include gu-font-sans;
   padding-top: $gu-v-spacing * 2;
   padding-bottom: $gu-v-spacing * 2.5;
   color: gu-colour(garnett-neutral-5);

--- a/assets/components/productPage/productPagePeriodForm/productPagePeriodFormLabel.scss
+++ b/assets/components/productPage/productPagePeriodForm/productPagePeriodFormLabel.scss
@@ -9,7 +9,7 @@
 }
 
 .component-product-page-period-form-label__box {
-  @include gu-font-sans;
+  @include gu-fontset-sans;
   background: gu-colour(garnett-neutral-5);
   border: 1px solid gu-colour(garnett-neutral-2);
   color: gu-colour(garnett-neutral-1);
@@ -27,7 +27,7 @@
 }
 
 .component-product-page-period-form-label__title {
-  @include gu-font-sans-title(true);
+  @include gu-fontset-sans-title(true);
   font-weight: 600;
   position: relative;
   border-bottom: 1px solid gu-colour(garnett-neutral-2);

--- a/assets/components/productPage/productPagePeriodForm/productPagePeriodFormLabel.scss
+++ b/assets/components/productPage/productPagePeriodForm/productPagePeriodFormLabel.scss
@@ -9,7 +9,7 @@
 }
 
 .component-product-page-period-form-label__box {
-  font-family: $gu-text-sans-web;
+  @include gu-font-sans-responsive;
   background: gu-colour(garnett-neutral-5);
   border: 1px solid gu-colour(garnett-neutral-2);
   color: gu-colour(garnett-neutral-1);
@@ -27,8 +27,8 @@
 }
 
 .component-product-page-period-form-label__title {
+  @include gu-font-sans-title-responsive(true);
   font-weight: 600;
-  font-size: 20px;
   position: relative;
   border-bottom: 1px solid gu-colour(garnett-neutral-2);
 }

--- a/assets/components/productPage/productPagePeriodForm/productPagePeriodFormLabel.scss
+++ b/assets/components/productPage/productPagePeriodForm/productPagePeriodFormLabel.scss
@@ -9,7 +9,7 @@
 }
 
 .component-product-page-period-form-label__box {
-  @include gu-fontset-sans;
+  @include gu-fontset-body-sans;
   background: gu-colour(garnett-neutral-5);
   border: 1px solid gu-colour(garnett-neutral-2);
   color: gu-colour(garnett-neutral-1);
@@ -27,8 +27,7 @@
 }
 
 .component-product-page-period-form-label__title {
-  @include gu-fontset-sans-title(true);
-  font-weight: 600;
+  @include gu-fontset-heading-sans;
   position: relative;
   border-bottom: 1px solid gu-colour(garnett-neutral-2);
 }

--- a/assets/components/productPage/productPagePeriodForm/productPagePeriodFormLabel.scss
+++ b/assets/components/productPage/productPagePeriodForm/productPagePeriodFormLabel.scss
@@ -9,7 +9,7 @@
 }
 
 .component-product-page-period-form-label__box {
-  @include gu-font-sans-responsive;
+  @include gu-font-sans;
   background: gu-colour(garnett-neutral-5);
   border: 1px solid gu-colour(garnett-neutral-2);
   color: gu-colour(garnett-neutral-1);
@@ -27,7 +27,7 @@
 }
 
 .component-product-page-period-form-label__title {
-  @include gu-font-sans-title-responsive(true);
+  @include gu-font-sans-title(true);
   font-weight: 600;
   position: relative;
   border-bottom: 1px solid gu-colour(garnett-neutral-2);

--- a/assets/components/productPage/productPageTextBlock/productPageTextBlock.scss
+++ b/assets/components/productPage/productPageTextBlock/productPageTextBlock.scss
@@ -6,12 +6,7 @@
 
 .component-product-page-text-block {
   overflow-wrap: break-word;
-  @include mq($from: tablet) {
-    width: 75%;
-  }
-  @include mq($from: desktop) {
-    width: 57.5%;
-  }
+  max-width: gu-span(8);
 }
 
 .component-product-page-text-block a {

--- a/assets/components/productPage/productPageTextBlock/productPageTextBlock.scss
+++ b/assets/components/productPage/productPageTextBlock/productPageTextBlock.scss
@@ -7,7 +7,10 @@
 .component-product-page-text-block {
   @include gu-fontset-body;
   overflow-wrap: break-word;
-  max-width: gu-span(8);
+  max-width: gu-span(7);
+  @include mq($from: tablet) {
+    max-width: gu-span(8);
+  }
 }
 
 .component-product-page-text-block a {

--- a/assets/components/productPage/productPageTextBlock/productPageTextBlock.scss
+++ b/assets/components/productPage/productPageTextBlock/productPageTextBlock.scss
@@ -1,11 +1,11 @@
 .component-product-page-text-block__heading {
-  @include gu-font-headline-responsive;
+  @include gu-font-headline;
   font-weight: bold;
   margin-bottom: ($gu-v-spacing/2);
 }
 
 .component-product-page-text-block {
-  @include gu-font-body-responsive;
+  @include gu-font-body;
   overflow-wrap: break-word;
   max-width: gu-span(8);
 }
@@ -15,6 +15,6 @@
 }
 
 .component-product-page-text-block__large {
-  @include gu-font-standfirst-responsive;
+  @include gu-font-standfirst;
   font-weight: 200;
 }

--- a/assets/components/productPage/productPageTextBlock/productPageTextBlock.scss
+++ b/assets/components/productPage/productPageTextBlock/productPageTextBlock.scss
@@ -5,6 +5,7 @@
 }
 
 .component-product-page-text-block {
+  @include gu-font-body-responsive;
   overflow-wrap: break-word;
   max-width: gu-span(8);
 }

--- a/assets/components/productPage/productPageTextBlock/productPageTextBlock.scss
+++ b/assets/components/productPage/productPageTextBlock/productPageTextBlock.scss
@@ -15,6 +15,6 @@
 }
 
 .component-product-page-text-block__large {
-  @include gu-font-headline-responsive;
+  @include gu-font-standfirst-responsive;
   font-weight: 200;
 }

--- a/assets/components/productPage/productPageTextBlock/productPageTextBlock.scss
+++ b/assets/components/productPage/productPageTextBlock/productPageTextBlock.scss
@@ -1,5 +1,5 @@
 .component-product-page-text-block__heading {
-  @include gu-family-headline;
+  @include gu-fontset-headline;
   font-weight: bold;
   margin-bottom: ($gu-v-spacing/2);
 }

--- a/assets/components/productPage/productPageTextBlock/productPageTextBlock.scss
+++ b/assets/components/productPage/productPageTextBlock/productPageTextBlock.scss
@@ -1,11 +1,11 @@
 .component-product-page-text-block__heading {
-  @include gu-font-headline;
+  @include gu-family-headline;
   font-weight: bold;
   margin-bottom: ($gu-v-spacing/2);
 }
 
 .component-product-page-text-block {
-  @include gu-font-body;
+  @include gu-fontset-body;
   overflow-wrap: break-word;
   max-width: gu-span(8);
 }
@@ -15,6 +15,6 @@
 }
 
 .component-product-page-text-block__large {
-  @include gu-font-standfirst;
+  @include gu-fontset-standfirst;
   font-weight: 200;
 }

--- a/assets/components/productPage/productPageTextBlock/productPageTextBlock.scss
+++ b/assets/components/productPage/productPageTextBlock/productPageTextBlock.scss
@@ -1,6 +1,5 @@
 .component-product-page-text-block__heading {
-  @include gu-fontset-headline;
-  font-weight: bold;
+  @include gu-fontset-heading;
   margin-bottom: ($gu-v-spacing/2);
 }
 
@@ -18,6 +17,5 @@
 }
 
 .component-product-page-text-block__large {
-  @include gu-fontset-standfirst;
-  font-weight: 200;
+  @include gu-fontset-body-large;
 }

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -75,6 +75,13 @@
       width: 50%;
       vertical-align: top;
     }
+    @include mq($from: desktop) {
+      max-width: 485px;
+    }
+
+    @include mq($from: leftCol) {
+      max-width: 520px;
+    }
   }
 
   .product-block__image {

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -75,14 +75,6 @@
       width: 50%;
       vertical-align: top;
     }
-
-    @include mq($from: desktop) {
-      width: 485px;
-    }
-
-    @include mq($from: leftCol) {
-      width: 520px;
-    }
   }
 
   .product-block__image {

--- a/assets/stylesheets/gu-sass/layout.scss
+++ b/assets/stylesheets/gu-sass/layout.scss
@@ -7,10 +7,18 @@
 // =============================================================================
 $gu-h-spacing: 20px;
 $gu-v-spacing: 12px;
+$gu-col-width: 60px;
 
 
 // Size of cta buttons
 $cta-height: 44px;
+
+// Columns
+// =============================================================================
+@function gu-span($n-columns) {
+  @return $n-columns * $gu-col-width + $gu-h-spacing * ($n-columns - 1);
+}
+
 
 
 // Margin

--- a/assets/stylesheets/gu-sass/typography.scss
+++ b/assets/stylesheets/gu-sass/typography.scss
@@ -77,7 +77,7 @@ $gu-fonts: (
 
 
 // ----- Headlines ----- //
-@mixin gu-font-header-responsive($size-only: false) {
+@mixin gu-font-header($size-only: false) {
 	@if $size-only == false {
 		@include gu-font-headline;
 	}
@@ -87,7 +87,7 @@ $gu-fonts: (
     font-size: 42px;
   }
 }
-@mixin gu-font-header-tag-responsive($size-only: false) {
+@mixin gu-font-header-tag($size-only: false) {
 	@if $size-only == false {
 		@include gu-font-headline;
 	}
@@ -97,7 +97,7 @@ $gu-fonts: (
     font-size: 22px;
   }
 }
-@mixin gu-font-headline-responsive($size-only: false) {
+@mixin gu-font-headline($size-only: false) {
 	@if $size-only == false {
 		@include gu-font-headline;
 	}
@@ -106,7 +106,7 @@ $gu-fonts: (
     font-size: 24px;
   }
 }
-@mixin gu-font-standfirst-responsive($size-only: false) {
+@mixin gu-font-standfirst($size-only: false) {
 	@if $size-only == false {
 		@include gu-font-headline;
 	}
@@ -118,7 +118,7 @@ $gu-fonts: (
 
 
 // ----- Body ----- //
-@mixin gu-font-body-responsive($size-only: false) {
+@mixin gu-font-body($size-only: false) {
 	@if $size-only == false {
 		@include gu-font-egyptian;
 	}
@@ -127,14 +127,14 @@ $gu-fonts: (
 
 
 // ----- Sans ----- //
-@mixin gu-font-sans-responsive($size-only: false) {
+@mixin gu-font-sans($size-only: false) {
 	@if $size-only == false {
 		@include gu-font-sans;
 	}
   font-size: 16px;
 }
 
-@mixin gu-font-sans-title-responsive($size-only: false) {
+@mixin gu-font-sans-title($size-only: false) {
 	@if $size-only == false {
 		@include gu-font-sans;
 	}

--- a/assets/stylesheets/gu-sass/typography.scss
+++ b/assets/stylesheets/gu-sass/typography.scss
@@ -71,49 +71,57 @@ $gu-fonts: (
 
 
 
-// ----- Headlines ----- //
-
-@mixin gu-fontset-header($size-only: false) {
+// ----- Headings ----- //
+@mixin gu-fontset-heading-sans($size-only: false) {
+	@include gu-typeface(sans, 18, $size-only);
+	@if $size-only == false {
+		font-weight: 700;
+	}
+}
+@mixin gu-fontset-heading-large($size-only: false) {
 	@include gu-typeface(headline, 32, $size-only);
   @include mq($from: tablet) {
 		@include gu-typeface(headline, 42, true);
   }
   @include mq($from: leftCol) {
 		@include gu-typeface(headline, 50, true);
-  }
+	}
+	@if $size-only == false {
+		font-weight: 700;
+	}
 }
-@mixin gu-fontset-headline($size-only: false) {
+@mixin gu-fontset-heading($size-only: false) {
 	@include gu-typeface(headline, 22, $size-only);
   @include mq($from: tablet) {
 		@include gu-typeface(headline, 24, true);
-  }
+	}
+	@if $size-only == false {
+		font-weight: 700;
+	}
 }
-@mixin gu-fontset-standfirst($size-only: false) {
+
+// ----- Body ----- //
+@mixin gu-fontset-body-sans($size-only: false) {
+	@include gu-typeface(sans, 16, $size-only);
+	@if $size-only == false {
+		font-weight: 400;
+	}
+}
+@mixin gu-fontset-body($size-only: false) {
+	@include gu-typeface(egyptian, 17, $size-only);
+	@if $size-only == false {
+		font-weight: 400;
+	}
+}
+@mixin gu-fontset-body-large($size-only: false) {
 	@include gu-typeface(headline, 20, $size-only);
   @include mq($from: tablet) {
 		@include gu-typeface(headline, 22, true);
-  }
+	}
+	@if $size-only == false {
+		font-weight: 400;
+	}
 }
-
-
-
-// ----- Body ----- //
-
-@mixin gu-fontset-body($size-only: false) {
-	@include gu-typeface(egyptian, 17, $size-only);
-}
-
-
-
-// ----- Sans ----- //
-
-@mixin gu-fontset-sans($size-only: false) {
-	@include gu-typeface(sans, 16, $size-only);
-}
-
-@mixin gu-fontset-sans-title($size-only: false) {
-	@include gu-typeface(sans, 18, $size-only);}
-
 
 
 // ----- Defaults ----- //

--- a/assets/stylesheets/gu-sass/typography.scss
+++ b/assets/stylesheets/gu-sass/typography.scss
@@ -81,10 +81,10 @@ $gu-fonts: (
 @mixin gu-fontset-heading-large($size-only: false) {
 	@include gu-typeface(headline, 32, $size-only);
   @include mq($from: tablet) {
-		@include gu-typeface(headline, 42, true);
+		@include gu-typeface(headline, 42, $size-only: true);
   }
   @include mq($from: leftCol) {
-		@include gu-typeface(headline, 50, true);
+		@include gu-typeface(headline, 50, $size-only: true);
 	}
 	@if $size-only == false {
 		font-weight: 700;
@@ -93,7 +93,7 @@ $gu-fonts: (
 @mixin gu-fontset-heading($size-only: false) {
 	@include gu-typeface(headline, 22, $size-only);
   @include mq($from: tablet) {
-		@include gu-typeface(headline, 24, true);
+		@include gu-typeface(headline, 24, $size-only: true);
 	}
 	@if $size-only == false {
 		font-weight: 700;
@@ -116,7 +116,7 @@ $gu-fonts: (
 @mixin gu-fontset-body-large($size-only: false) {
 	@include gu-typeface(headline, 20, $size-only);
   @include mq($from: tablet) {
-		@include gu-typeface(headline, 22, true);
+		@include gu-typeface(headline, 22, $size-only: true);
 	}
 	@if $size-only == false {
 		font-weight: 400;

--- a/assets/stylesheets/gu-sass/typography.scss
+++ b/assets/stylesheets/gu-sass/typography.scss
@@ -17,7 +17,7 @@ $gu-text-sans-web: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial,
 // ----- Font Properties ----- //
 
 $gu-fonts: (
-	egyptian: (
+	textEgyptian: (
 		family: $gu-text-egyptian-web,
 		sizes: (
 			17: 24px,
@@ -35,7 +35,7 @@ $gu-fonts: (
 			50: 54px,
 		)
 	),
-	sans: (
+	textSans: (
 		family: $gu-text-sans-web,
 		sizes: (
 			16: 22px,
@@ -51,9 +51,9 @@ $gu-fonts: (
 //
 // Usage:
 //
-// gu-typeface(egyptian, 17);
-// gu-typeface(sans, 16)
-// gu-typeface(sans, 18, true)
+// gu-typeface(textEgyptian, 17);
+// gu-typeface(textSans, 16)
+// gu-typeface(textSans, 18, $size-only: true)
 //
 @mixin gu-typeface($name, $size, $size-only: false) {
 	$font-data: map-get($gu-fonts, $name);
@@ -73,7 +73,7 @@ $gu-fonts: (
 
 // ----- Headings ----- //
 @mixin gu-fontset-heading-sans($size-only: false) {
-	@include gu-typeface(sans, 18, $size-only);
+	@include gu-typeface(textSans, 18, $size-only);
 	@if $size-only == false {
 		font-weight: 700;
 	}
@@ -102,13 +102,13 @@ $gu-fonts: (
 
 // ----- Body ----- //
 @mixin gu-fontset-body-sans($size-only: false) {
-	@include gu-typeface(sans, 16, $size-only);
+	@include gu-typeface(textSans, 16, $size-only);
 	@if $size-only == false {
 		font-weight: 400;
 	}
 }
 @mixin gu-fontset-body($size-only: false) {
-	@include gu-typeface(egyptian, 17, $size-only);
+	@include gu-typeface(textEgyptian, 17, $size-only);
 	@if $size-only == false {
 		font-weight: 400;
 	}

--- a/assets/stylesheets/gu-sass/typography.scss
+++ b/assets/stylesheets/gu-sass/typography.scss
@@ -57,17 +57,89 @@ $gu-fonts: (
 	} @else {
 		line-height: map-get(map-get($font-data, sizes), $size);
 	}
-
 }
 
-@mixin gu-font-headline-responsive {
-  line-height: 1.2;
-  font-size: 20px;
-  font-family: $gu-headline;
+// ----- Base fonts ----- //
+@mixin gu-font-headline {
+	font-family: $gu-headline;
+	line-height: 1.1;
+}
+
+@mixin gu-font-egyptian {
+	font-family: $gu-text-egyptian-web;
+	line-height: 1.4;
+}
+
+@mixin gu-font-sans {
+	font-family: $gu-text-sans-web;
+	line-height: 1.375;
+}
+
+
+// ----- Headlines ----- //
+@mixin gu-font-header-responsive($size-only: false) {
+	@if $size-only == false {
+		@include gu-font-headline;
+	}
+	font-size: 32px;
+  @include mq($from: desktop) {
+    font-size: 42px;
+  }
+}
+@mixin gu-font-header-tag-responsive($size-only: false) {
+	@if $size-only == false {
+		@include gu-font-headline;
+	}
+	font-size: 16px;
+  @include mq($from: desktop) {
+    font-size: 22px;
+  }
+}
+@mixin gu-font-headline-responsive($size-only: false) {
+	@if $size-only == false {
+		@include gu-font-headline;
+	}
+	font-size: 22px;
+	font-weight: 800;
   @include mq($from: tablet) {
     font-size: 24px;
   }
 }
+@mixin gu-font-standfirst-responsive($size-only: false) {
+	@if $size-only == false {
+		@include gu-font-headline;
+	}
+  font-size: 20px;
+  @include mq($from: tablet) {
+    font-size: 22px;
+  }
+}
+
+
+// ----- Body ----- //
+@mixin gu-font-body-responsive($size-only: false) {
+	@if $size-only == false {
+		@include gu-font-egyptian;
+	}
+  font-size: 17px;
+}
+
+
+// ----- Sans ----- //
+@mixin gu-font-sans-responsive($size-only: false) {
+	@if $size-only == false {
+		@include gu-font-sans;
+	}
+  font-size: 16px;
+}
+
+@mixin gu-font-sans-title-responsive($size-only: false) {
+	@if $size-only == false {
+		@include gu-font-sans;
+	}
+  font-size: 18px;
+}
+
 
 
 // ----- Defaults ----- //

--- a/assets/stylesheets/gu-sass/typography.scss
+++ b/assets/stylesheets/gu-sass/typography.scss
@@ -17,13 +17,28 @@ $gu-text-sans-web: 'Guardian Text Sans Web', 'Helvetica Neue', Helvetica, Arial,
 // ----- Font Properties ----- //
 
 $gu-fonts: (
-	copy: (
+	egyptian: (
 		family: $gu-text-egyptian-web,
-		font-weight: normal,
 		sizes: (
-			14: 20px,
-			16: 20px,
-			18: 28px
+			17: 24px
+		)
+	),
+	headline: (
+		family: $gu-headline,
+		sizes: (
+			16: 18px,
+			20: 24px,
+			22: 26px,
+			24: 28px,
+			32: 35px,
+			42: 45px,
+		)
+	),
+	sans: (
+		family: $gu-text-sans-web,
+		sizes: (
+			16: 22px,
+			18: 24px,
 		)
 	)
 );
@@ -31,105 +46,69 @@ $gu-fonts: (
 
 // ----- Mixins ----- //
 
-// Used to populate font information.
+// Used to get font/lh pairs.
 //
 // Usage:
 //
-// gu-font(copy, 16);
-// gu-font(copy, 14, $weight: bold)
-// gu-font(copy, 18, $line-height: 22)
+// gu-typeface(copy, 16);
+// gu-typeface(copy, 14)
+// gu-typeface(copy, 18, true)
 //
-@mixin gu-font($name, $size, $weight: null, $line-height: null) {
-
+@mixin gu-typeface($name, $size, $size-only: false) {
 	$font-data: map-get($gu-fonts, $name);
-
 	font-size: $size + 0px;
-	font-family: map-get($font-data, family);
-
-	@if ($weight) {
-		font-weight: $weight;
-	} @else {
-		font-weight: map-get($font-data, font-weight);
-	}
-
-	@if ($line-height) {
-		line-height: $line-height + 0px;
-	} @else {
-		line-height: map-get(map-get($font-data, sizes), $size);
+	line-height: map-get(map-get($font-data, sizes), $size);
+	@if $size-only == false {
+		font-family: map-get($font-data, family);
 	}
 }
 
-// ----- Base fonts ----- //
-@mixin gu-family-headline {
-	font-family: $gu-headline;
-	line-height: 1.15;
-}
 
-@mixin gu-family-egyptian {
-	font-family: $gu-text-egyptian-web;
-	line-height: 1.4;
-}
+// ----- Font sets ----- //
 
-@mixin gu-family-sans {
-	font-family: $gu-text-sans-web;
-	line-height: 1.375;
-}
+// Use these to get uniform responsive type across pages
+
 
 
 // ----- Headlines ----- //
+
 @mixin gu-fontset-header($size-only: false) {
-	@if $size-only == false {
-		@include gu-family-headline;
-	}
-	font-size: 32px;
-	line-height: 1.08;
-  @include mq($from: desktop) {
-    font-size: 42px;
+	@include gu-typeface(headline, 32, $size-only);
+  @include mq($from: tablet) {
+		@include gu-typeface(headline, 42, true);
   }
 }
 @mixin gu-fontset-headline($size-only: false) {
-	@if $size-only == false {
-		@include gu-family-headline;
-	}
-	font-size: 22px;
+	@include gu-typeface(headline, 22, $size-only);
   @include mq($from: tablet) {
-    font-size: 24px;
+		@include gu-typeface(headline, 24, true);
   }
 }
 @mixin gu-fontset-standfirst($size-only: false) {
-	@if $size-only == false {
-		@include gu-family-headline;
-	}
-	font-size: 20px;
+	@include gu-typeface(headline, 20, $size-only);
   @include mq($from: tablet) {
-    font-size: 22px;
+		@include gu-typeface(headline, 22, true);
   }
 }
 
 
+
 // ----- Body ----- //
+
 @mixin gu-fontset-body($size-only: false) {
-	@if $size-only == false {
-		@include gu-family-egyptian;
-	}
-  font-size: 17px;
+	@include gu-typeface(egyptian, 17, $size-only);
 }
+
 
 
 // ----- Sans ----- //
+
 @mixin gu-fontset-sans($size-only: false) {
-	@if $size-only == false {
-		@include gu-family-sans;
-	}
-  font-size: 16px;
+	@include gu-typeface(sans, 16, $size-only);
 }
 
 @mixin gu-fontset-sans-title($size-only: false) {
-	@if $size-only == false {
-		@include gu-family-sans;
-	}
-  font-size: 18px;
-}
+	@include gu-typeface(sans, 18, $size-only);}
 
 
 

--- a/assets/stylesheets/gu-sass/typography.scss
+++ b/assets/stylesheets/gu-sass/typography.scss
@@ -32,6 +32,7 @@ $gu-fonts: (
 			24: 28px,
 			32: 35px,
 			42: 45px,
+			50: 54px,
 		)
 	),
 	sans: (
@@ -76,6 +77,9 @@ $gu-fonts: (
 	@include gu-typeface(headline, 32, $size-only);
   @include mq($from: tablet) {
 		@include gu-typeface(headline, 42, true);
+  }
+  @include mq($from: leftCol) {
+		@include gu-typeface(headline, 50, true);
   }
 }
 @mixin gu-fontset-headline($size-only: false) {

--- a/assets/stylesheets/gu-sass/typography.scss
+++ b/assets/stylesheets/gu-sass/typography.scss
@@ -87,16 +87,6 @@ $gu-fonts: (
     font-size: 42px;
   }
 }
-@mixin gu-font-header-tag($size-only: false) {
-	@if $size-only == false {
-		@include gu-font-headline;
-	}
-	font-size: 16px;
-	line-height: 1;
-  @include mq($from: desktop) {
-    font-size: 22px;
-  }
-}
 @mixin gu-font-headline($size-only: false) {
 	@if $size-only == false {
 		@include gu-font-headline;

--- a/assets/stylesheets/gu-sass/typography.scss
+++ b/assets/stylesheets/gu-sass/typography.scss
@@ -60,26 +60,26 @@ $gu-fonts: (
 }
 
 // ----- Base fonts ----- //
-@mixin gu-font-headline {
+@mixin gu-family-headline {
 	font-family: $gu-headline;
 	line-height: 1.15;
 }
 
-@mixin gu-font-egyptian {
+@mixin gu-family-egyptian {
 	font-family: $gu-text-egyptian-web;
 	line-height: 1.4;
 }
 
-@mixin gu-font-sans {
+@mixin gu-family-sans {
 	font-family: $gu-text-sans-web;
 	line-height: 1.375;
 }
 
 
 // ----- Headlines ----- //
-@mixin gu-font-header($size-only: false) {
+@mixin gu-fontset-header($size-only: false) {
 	@if $size-only == false {
-		@include gu-font-headline;
+		@include gu-family-headline;
 	}
 	font-size: 32px;
 	line-height: 1.08;
@@ -87,18 +87,18 @@ $gu-fonts: (
     font-size: 42px;
   }
 }
-@mixin gu-font-headline($size-only: false) {
+@mixin gu-fontset-headline($size-only: false) {
 	@if $size-only == false {
-		@include gu-font-headline;
+		@include gu-family-headline;
 	}
 	font-size: 22px;
   @include mq($from: tablet) {
     font-size: 24px;
   }
 }
-@mixin gu-font-standfirst($size-only: false) {
+@mixin gu-fontset-standfirst($size-only: false) {
 	@if $size-only == false {
-		@include gu-font-headline;
+		@include gu-family-headline;
 	}
 	font-size: 20px;
   @include mq($from: tablet) {
@@ -108,25 +108,25 @@ $gu-fonts: (
 
 
 // ----- Body ----- //
-@mixin gu-font-body($size-only: false) {
+@mixin gu-fontset-body($size-only: false) {
 	@if $size-only == false {
-		@include gu-font-egyptian;
+		@include gu-family-egyptian;
 	}
   font-size: 17px;
 }
 
 
 // ----- Sans ----- //
-@mixin gu-font-sans($size-only: false) {
+@mixin gu-fontset-sans($size-only: false) {
 	@if $size-only == false {
-		@include gu-font-sans;
+		@include gu-family-sans;
 	}
   font-size: 16px;
 }
 
-@mixin gu-font-sans-title($size-only: false) {
+@mixin gu-fontset-sans-title($size-only: false) {
 	@if $size-only == false {
-		@include gu-font-sans;
+		@include gu-family-sans;
 	}
   font-size: 18px;
 }

--- a/assets/stylesheets/gu-sass/typography.scss
+++ b/assets/stylesheets/gu-sass/typography.scss
@@ -62,7 +62,7 @@ $gu-fonts: (
 // ----- Base fonts ----- //
 @mixin gu-font-headline {
 	font-family: $gu-headline;
-	line-height: 1.1;
+	line-height: 1.15;
 }
 
 @mixin gu-font-egyptian {
@@ -82,6 +82,7 @@ $gu-fonts: (
 		@include gu-font-headline;
 	}
 	font-size: 32px;
+	line-height: 1.08;
   @include mq($from: desktop) {
     font-size: 42px;
   }
@@ -91,6 +92,7 @@ $gu-fonts: (
 		@include gu-font-headline;
 	}
 	font-size: 16px;
+	line-height: 1;
   @include mq($from: desktop) {
     font-size: 22px;
   }
@@ -100,7 +102,6 @@ $gu-fonts: (
 		@include gu-font-headline;
 	}
 	font-size: 22px;
-	font-weight: 800;
   @include mq($from: tablet) {
     font-size: 24px;
   }
@@ -109,7 +110,7 @@ $gu-fonts: (
 	@if $size-only == false {
 		@include gu-font-headline;
 	}
-  font-size: 20px;
+	font-size: 20px;
   @include mq($from: tablet) {
     font-size: 22px;
   }

--- a/assets/stylesheets/gu-sass/typography.scss
+++ b/assets/stylesheets/gu-sass/typography.scss
@@ -20,7 +20,7 @@ $gu-fonts: (
 	egyptian: (
 		family: $gu-text-egyptian-web,
 		sizes: (
-			17: 24px
+			17: 24px,
 		)
 	),
 	headline: (
@@ -50,9 +50,9 @@ $gu-fonts: (
 //
 // Usage:
 //
-// gu-typeface(copy, 16);
-// gu-typeface(copy, 14)
-// gu-typeface(copy, 18, true)
+// gu-typeface(egyptian, 17);
+// gu-typeface(sans, 16)
+// gu-typeface(sans, 18, true)
 //
 @mixin gu-typeface($name, $size, $size-only: false) {
 	$font-data: map-get($gu-fonts, $name);


### PR DESCRIPTION
## Why are you doing this?
This PR has two goals - First of all, implement @Joshua-David's grid template more closely. Second of all, codify a set of responsive type sizes, and a column size mixin that will serve as the source of truth for all product pages moving forward. This will help us be more consistent with font-sizes and widths across the board 

## Changes

* Add `gu-span()` mixin (copying frontend's `gs-span()`
* Tweak the left margin section sizing a bit to better conform to the column grid
* Add semantic `gu-fontset-*` mixins to define common text styles (family + sizing) such as body, title, standfirst, etc.
* Remove `gu-font()` mixin (nothing was using it) in lieu of a simpler `gu-typeface` one with the new pairs and less parameters (it's just family, size, and line height now)
* Implement the new font sizes, resulting in visible design changes

## Screenshots
Spot the differences!

<table><tr><td>

![screenshot 2018-11-19 at 11 43 55 am](https://user-images.githubusercontent.com/11539094/48705487-2da16e00-ebf1-11e8-8082-ece3991d46bc.png)

</td><td>

![screenshot 2018-11-19 at 11 44 06 am](https://user-images.githubusercontent.com/11539094/48705494-309c5e80-ebf1-11e8-881b-fad5e01bdb23.png)

</td></table>
