### PR TITLE
Lower password max-length to 20

### DIFF
--- a/assets/pages/new-contributions-landing/components/SetPassword/SetPasswordForm.jsx
+++ b/assets/pages/new-contributions-landing/components/SetPassword/SetPasswordForm.jsx
@@ -126,7 +126,7 @@ function SetPasswordForm(props: PropTypes) {
           value={props.password}
           onInput={props.updatePassword}
           pattern={'^.{6,20}$'}
-          isValid={props.password.length >= 6 && props.password.length <= 72}
+          isValid={props.password.length >= 6 && props.password.length <= 20}
           formHasBeenSubmitted={props.passwordHasBeenSubmitted}
           errorMessage="Please enter a password between 6 and 20 characters long"
           required

--- a/assets/pages/new-contributions-landing/components/SetPassword/SetPasswordForm.jsx
+++ b/assets/pages/new-contributions-landing/components/SetPassword/SetPasswordForm.jsx
@@ -125,10 +125,10 @@ function SetPasswordForm(props: PropTypes) {
           autoComplete="off"
           value={props.password}
           onInput={props.updatePassword}
-          pattern={'^.{6,72}$'}
+          pattern={'^.{6,20}$'}
           isValid={props.password.length >= 6 && props.password.length <= 72}
           formHasBeenSubmitted={props.passwordHasBeenSubmitted}
-          errorMessage="Please enter a password between 6 and 72 characters long"
+          errorMessage="Please enter a password between 6 and 20 characters long"
           required
         />
         <ButtonWithRightArrow


### PR DESCRIPTION
## Why are you doing this?
Making the password rules consistent with [identity-api](https://github.com/guardian/identity/blob/master/identity-api/src/main/scala/com/gu/identity/api/postgres/PostgresPasswordHashRepository.scala#L20)

Invalid password entry has been the cause of _some_ of the 500 errors on support-frontend lately - it's not surprising that some users try it repeatedly given that the message is incorrect here.

## Screenshots
<img width="345" alt="picture 6" src="https://user-images.githubusercontent.com/1513454/48716389-28531c00-ec0f-11e8-938d-28694707ca61.png">

For the record, these are logged by support-frontend as:
```
Failed to set password using guest account registration token...
{ "status": "error", "errors": [ { "message": "Invalid password", "description": "The password provided is invalid" } ] }
```