### PR TITLE
Make digital pack the featured product during flash sale outside of the UK

### DIFF
--- a/assets/pages/subscriptions-landing/components/featuredProducts.jsx
+++ b/assets/pages/subscriptions-landing/components/featuredProducts.jsx
@@ -156,6 +156,9 @@ const getProduct = (subsLinks: SubsUrls, countryGroupId: CountryGroupId): ?Produ
       if (countryGroupId === 'GBPCountries' && flashSaleIsActive('Paper')) {
         return products.Paper;
       }
+      if (countryGroupId === 'UnitedStates' && flashSaleIsActive('DigitalPack')) {
+        return products.DigitalPack;
+      }
       return products.GuardianWeekly;
   }
 };

--- a/assets/pages/subscriptions-landing/components/featuredProducts.jsx
+++ b/assets/pages/subscriptions-landing/components/featuredProducts.jsx
@@ -156,7 +156,7 @@ const getProduct = (subsLinks: SubsUrls, countryGroupId: CountryGroupId): ?Produ
       if (countryGroupId === 'GBPCountries' && flashSaleIsActive('Paper')) {
         return products.Paper;
       }
-      if (countryGroupId === 'UnitedStates' && flashSaleIsActive('DigitalPack')) {
+      if (countryGroupId !== 'GBPCountries' && flashSaleIsActive('DigitalPack')) {
         return products.DigitalPack;
       }
       return products.GuardianWeekly;


### PR DESCRIPTION
## Why are you doing this?
Our PM expected Digital Pack to be promoted to US users during the flash sale. That wasn't happening.

[**Trello Card**](https://trello.com/c/ewib2bNI/2087-show-digital-pack-as-promoted-product-to-us-users-during-november-flash-sale)

## Screenshots
![usfeaturedproduct](https://user-images.githubusercontent.com/690395/48717648-c21bc880-ec11-11e8-8a87-fb55c1bfa030.gif)

