### PR TITLE
Make the shrink_no-blurb_no-header variant from the smallMobileHeader test the control (EPIC and BANNER) only

### DIFF
--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -1,5 +1,5 @@
 // @flow
-import { getSession } from 'helpers/storage';
+import { isFromEpicOrBanner } from 'helpers/referrerComponent';
 import type { Tests } from './abtest';
 
 // ----- Tests ----- //
@@ -31,15 +31,6 @@ export const tests: Tests = {
     isActive: true,
     independent: true,
     seed: 4,
-    canRun: () => ![
-      'ACQUISITIONS_EPIC',
-      'ACQUISITIONS_ENGAGEMENT_BANNER',
-    ].some((componentType: string) => {
-      // Try from session storage first. This is so that we get the correct header
-      // on subsequent pageviews which don't have the componentType in the URL, e.g.
-      // thank you page after PayPal one-off, or after changing country dropdown.
-      const searchString = getSession('acquisitionData') || window.location.href;
-      return searchString.includes(componentType);
-    }),
+    canRun: () => !isFromEpicOrBanner,
   },
 };

--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -20,7 +20,7 @@ export const tests: Tests = {
     seed: 3,
   },
 
-  smallMobileHeader: {
+  smallMobileHeaderNotEpicOrBanner: {
     variants: ['control', 'shrink', 'shrink_no-blurb', 'shrink_no-blurb_no-header'],
     audiences: {
       ALL: {
@@ -31,7 +31,7 @@ export const tests: Tests = {
     isActive: true,
     independent: true,
     seed: 4,
-    canRun: () => [
+    canRun: () => ![
       'ACQUISITIONS_EPIC',
       'ACQUISITIONS_ENGAGEMENT_BANNER',
     ].some((componentType: string) => {

--- a/assets/helpers/referrerComponent.js
+++ b/assets/helpers/referrerComponent.js
@@ -1,0 +1,17 @@
+// @flow
+import { getSession } from 'helpers/storage';
+
+const isFromEpicOrBanner = [
+  'ACQUISITIONS_EPIC',
+  'ACQUISITIONS_ENGAGEMENT_BANNER',
+].some((componentType: string) => {
+  // Try from session storage first. This is so that we get the correct header
+  // on subsequent pageviews which don't have the componentType in the URL, e.g.
+  // thank you page after PayPal one-off, or after changing country dropdown.
+  const searchString = getSession('acquisitionData') || window.location.href;
+  return searchString.includes(componentType);
+});
+
+export {
+  isFromEpicOrBanner,
+};

--- a/assets/pages/new-contributions-landing/contributionsLanding.jsx
+++ b/assets/pages/new-contributions-landing/contributionsLanding.jsx
@@ -16,6 +16,7 @@ import { set as setCookie } from 'helpers/cookie';
 import Page from 'components/page/page';
 import Footer from 'components/footer/footer';
 import { NewHeader } from 'components/headers/new-header/Header';
+import { getSession } from 'helpers/storage';
 
 import { init as formInit } from './contributionsLandingInit';
 import { initReducer } from './contributionsLandingReducer';
@@ -42,10 +43,25 @@ const reactElementId = `new-contributions-landing-page-${countryGroups[countryGr
 
 const selectedCountryGroup = countryGroups[countryGroupId];
 
-const { smallMobileHeader } = store.getState().common.abParticipations;
-const extraClasses = smallMobileHeader
-  ? smallMobileHeader.split('_').filter(x => x !== 'control' && x !== 'notintest')
-  : [];
+const { smallMobileHeaderNotEpicOrBanner } = store.getState().common.abParticipations;
+
+const isFromEpicOrBanner = [
+  'ACQUISITIONS_EPIC',
+  'ACQUISITIONS_ENGAGEMENT_BANNER',
+].some((componentType: string) => {
+  // Try from session storage first. This is so that we get the correct header
+  // on subsequent pageviews which don't have the componentType in the URL, e.g.
+  // thank you page after PayPal one-off, or after changing country dropdown.
+  const searchString = getSession('acquisitionData') || window.location.href;
+  return searchString.includes(componentType);
+});
+
+let extraClasses = [];
+if (smallMobileHeaderNotEpicOrBanner) {
+  extraClasses = smallMobileHeaderNotEpicOrBanner.split('_').filter(x => x !== 'control' && x !== 'notintest');
+} else if (isFromEpicOrBanner) {
+  extraClasses = ['shrink', 'no-blurb', 'no-header'];
+}
 
 // ----- Render ----- //
 

--- a/assets/pages/new-contributions-landing/contributionsLanding.jsx
+++ b/assets/pages/new-contributions-landing/contributionsLanding.jsx
@@ -12,11 +12,11 @@ import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
 import { detect, countryGroups, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import * as user from 'helpers/user/user';
+import { isFromEpicOrBanner } from 'helpers/referrerComponent';
 import { set as setCookie } from 'helpers/cookie';
 import Page from 'components/page/page';
 import Footer from 'components/footer/footer';
 import { NewHeader } from 'components/headers/new-header/Header';
-import { getSession } from 'helpers/storage';
 
 import { init as formInit } from './contributionsLandingInit';
 import { initReducer } from './contributionsLandingReducer';
@@ -44,17 +44,6 @@ const reactElementId = `new-contributions-landing-page-${countryGroups[countryGr
 const selectedCountryGroup = countryGroups[countryGroupId];
 
 const { smallMobileHeaderNotEpicOrBanner } = store.getState().common.abParticipations;
-
-const isFromEpicOrBanner = [
-  'ACQUISITIONS_EPIC',
-  'ACQUISITIONS_ENGAGEMENT_BANNER',
-].some((componentType: string) => {
-  // Try from session storage first. This is so that we get the correct header
-  // on subsequent pageviews which don't have the componentType in the URL, e.g.
-  // thank you page after PayPal one-off, or after changing country dropdown.
-  const searchString = getSession('acquisitionData') || window.location.href;
-  return searchString.includes(componentType);
-});
 
 let extraClasses = [];
 if (smallMobileHeaderNotEpicOrBanner) {


### PR DESCRIPTION
## Why are you doing this?

Following [this test ](https://github.com/guardian/support-frontend/pull/1193), we are going to default to the winning variant, `shrink_no-blurb_no-header`, on mobile for those coming from the epic and banner. 

This PR also sets up a new test, which is the same as the test before, but for everyone that didn't come from the epic or banner. 

| `shrink_no-blurb_no-header` | `shrink_no-blurb` | `shrink` | `control` |
| ------------ | ----------------| -----| -----|
| ![support thegulocal com_uk_contribute iphone 5_se 4](https://user-images.githubusercontent.com/5122968/48582980-edef3380-e91d-11e8-93ef-33d809c86872.png) | ![support thegulocal com_uk_contribute iphone 5_se 3](https://user-images.githubusercontent.com/5122968/48582984-f182ba80-e91d-11e8-83f8-e9227b9b1c35.png) | ![support thegulocal com_uk_contribute iphone 5_se 2](https://user-images.githubusercontent.com/5122968/48582987-f3e51480-e91d-11e8-8629-696ac0aca5ee.png) | ![support thegulocal com_uk_contribute iphone 5_se 1](https://user-images.githubusercontent.com/5122968/48583015-08291180-e91e-11e8-93e7-4dc8b8fc2060.png) |