### PR TITLE
Only set one-off contribution cookie for one-off contributions

### DIFF
--- a/assets/pages/new-contributions-landing/contributionsLanding.jsx
+++ b/assets/pages/new-contributions-landing/contributionsLanding.jsx
@@ -12,6 +12,8 @@ import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
 import { detect, countryGroups, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import * as user from 'helpers/user/user';
+import * as storage from 'helpers/storage';
+import type { Contrib } from 'helpers/contributions';
 import { set as setCookie } from 'helpers/cookie';
 import Page from 'components/page/page';
 import Footer from 'components/footer/footer';
@@ -52,6 +54,15 @@ const extraClasses = smallMobileHeader
 const ONE_OFF_CONTRIBUTION_COOKIE = 'gu.contributions.contrib-timestamp';
 const currentTimeInEpochMilliseconds: number = Date.now();
 
+const setOneOffContributionCookie = (contributionType: Contrib) => {
+  if (contributionType === 'ONE_OFF') {
+    setCookie(
+      ONE_OFF_CONTRIBUTION_COOKIE,
+      currentTimeInEpochMilliseconds.toString(),
+    );
+  }
+};
+
 const router = (
   <BrowserRouter>
     <Provider store={store}>
@@ -76,10 +87,7 @@ const router = (
           exact
           path="/:countryId(uk|us|au|eu|int|nz|ca)/thankyou"
           render={() => {
-            setCookie(
-              ONE_OFF_CONTRIBUTION_COOKIE,
-              currentTimeInEpochMilliseconds.toString(),
-            );
+            setOneOffContributionCookie(storage.getSession('contributionType'));
             return (
               <Page
                 classModifiers={['contribution-thankyou', ...extraClasses]}

--- a/assets/pages/new-contributions-landing/contributionsLanding.jsx
+++ b/assets/pages/new-contributions-landing/contributionsLanding.jsx
@@ -14,7 +14,6 @@ import { detect, countryGroups, type CountryGroupId } from 'helpers/internationa
 import * as user from 'helpers/user/user';
 import { isFromEpicOrBanner } from 'helpers/referrerComponent';
 import * as storage from 'helpers/storage';
-import type { Contrib } from 'helpers/contributions';
 import { set as setCookie } from 'helpers/cookie';
 import Page from 'components/page/page';
 import Footer from 'components/footer/footer';

--- a/assets/pages/new-contributions-landing/contributionsLanding.jsx
+++ b/assets/pages/new-contributions-landing/contributionsLanding.jsx
@@ -85,6 +85,7 @@ const router = (
           exact
           path="/:countryId(uk|us|au|eu|int|nz|ca)/thankyou"
           render={() => {
+            // we set the recurring cookie server side
             if (storage.getSession('contributionType') === 'ONE_OFF') {
               setOneOffContributionCookie();
             }

--- a/assets/pages/new-contributions-landing/contributionsLanding.jsx
+++ b/assets/pages/new-contributions-landing/contributionsLanding.jsx
@@ -54,13 +54,11 @@ const extraClasses = smallMobileHeader
 const ONE_OFF_CONTRIBUTION_COOKIE = 'gu.contributions.contrib-timestamp';
 const currentTimeInEpochMilliseconds: number = Date.now();
 
-const setOneOffContributionCookie = (contributionType: Contrib) => {
-  if (contributionType === 'ONE_OFF') {
-    setCookie(
-      ONE_OFF_CONTRIBUTION_COOKIE,
-      currentTimeInEpochMilliseconds.toString(),
-    );
-  }
+const setOneOffContributionCookie = () => {
+  setCookie(
+    ONE_OFF_CONTRIBUTION_COOKIE,
+    currentTimeInEpochMilliseconds.toString(),
+  );
 };
 
 const router = (
@@ -87,7 +85,9 @@ const router = (
           exact
           path="/:countryId(uk|us|au|eu|int|nz|ca)/thankyou"
           render={() => {
-            setOneOffContributionCookie(storage.getSession('contributionType'));
+            if (storage.getSession('contributionType') === 'ONE_OFF') {
+              setOneOffContributionCookie();
+            }
             return (
               <Page
                 classModifiers={['contribution-thankyou', ...extraClasses]}

--- a/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -7,6 +7,7 @@ import { loadPayPalRecurring } from 'helpers/paymentIntegrations/newPaymentFlow/
 import { setupStripeCheckout, loadStripe } from 'helpers/paymentIntegrations/newPaymentFlow/stripeCheckout';
 import { type ThirdPartyPaymentLibrary, getValidPaymentMethods, getPaymentMethodFromSession } from 'helpers/checkouts';
 import { amounts, type Amount } from 'helpers/contributions';
+import * as storage from 'helpers/storage';
 import {
   type Action,
   paymentWaiting,
@@ -84,6 +85,9 @@ const init = (store: Store<State, Action, Function>) => {
   selectDefaultPaymentMethod(state, dispatch);
   initialisePaymentMethods(state, dispatch);
   initialiseSelectedAnnualAmount(state, dispatch);
+  storage.setSession('contributionType', state.page.form.contributionType);
+  storage.setSession('paymentMethod', state.page.form.paymentMethod);
+
 
   const {
     firstName,


### PR DESCRIPTION
## Why are you doing this?

Previously, we were setting the one-off contribution cookie (that `gu.com` uses to prevent displaying the epic or banner) for recurring contributors hitting the thank you page. There is an equivalent recurring contributions cookie, which is set server side, so we don't need to set anything here for recurring contributors. 

The impact of this bug is that everyone who has given a recurring contribution in the past few weeks will have both cookies. There's nothing we can really do about this, other than fix it going forwards

