### PR TITLE
Handle 'FailState' result from step functions

### DIFF
--- a/app/services/stepfunctions/RegularContributionsClient.scala
+++ b/app/services/stepfunctions/RegularContributionsClient.scala
@@ -169,7 +169,7 @@ object StepFunctionExecutionStatus {
     val searchForFinishedCheckout: Option[StatusResponse] = detailedHistory.collectFirst {
       case detailsAttempt if detailsAttempt.map(_.getName) == Success("CheckoutSuccess") =>
         StatusResponse(Status.Success, trackingUri, None)
-      case detailsAttempt if detailsAttempt.map(_.getName) == Success("CheckoutFailure") =>
+      case detailsAttempt if detailsAttempt.map(_.getName) == Success("SucceedOrFailChoice") =>
         StatusResponse(Status.Failure, trackingUri, getFailureDetails(stateWrapper, detailsAttempt.get))
     }
 

--- a/test/services/stepfunctions/RegularContributionsClientTest.scala
+++ b/test/services/stepfunctions/RegularContributionsClientTest.scala
@@ -40,7 +40,7 @@ class RegularContributionsClientTest extends FlatSpec with Matchers with Mockito
 
   "checkoutStatus" should "detect a failed execution correctly" in {
     val failedCheckoutState = new StateExitedEventDetails
-    failedCheckoutState.setName("CheckoutFailure")
+    failedCheckoutState.setName("SucceedOrFailChoice")
     failedCheckoutState.setOutput("test")
     when(mockStateWrapper.unWrap[CheckoutFailureState]("test")).thenReturn(Success(CheckoutFailureState(mock[User], CheckoutFailureReasons.Unknown)))
     val actual = checkoutStatus(List(Success(fillerState), Success(fillerState), Success(failedCheckoutState)), mockStateWrapper, "tracking123")


### PR DESCRIPTION
## Why are you doing this?
If the step functions reach the `FailState`:
![picture 9](https://user-images.githubusercontent.com/1513454/48783797-33727e80-ecd9-11e8-8361-fce916a89062.png)
then the user is not told that something failed - they are instead redirected to the thank you page.
This change ensures that the standard error is displayed.

This was discovered because a user managed to submit a US contribution with no state selected.

## Screenshots

![picture 8](https://user-images.githubusercontent.com/1513454/48783869-556c0100-ecd9-11e8-9663-e36a40681861.png)

