### PR TITLE
Digital Checkout - State/Province

### DIFF
--- a/assets/components/forms/customFields/sortedOptions.jsx
+++ b/assets/components/forms/customFields/sortedOptions.jsx
@@ -1,0 +1,21 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+
+// ----- Functions ----- //
+
+function sortedOptions(os: { [string]: string }): React$Node {
+
+  return Object.keys(os)
+    .sort((a, b) => os[a].localeCompare(os[b]))
+    .map(k => <option value={k}>{os[k]}</option>);
+
+}
+
+
+// ----- Exports ----- //
+
+export { sortedOptions };

--- a/assets/components/forms/formHOCs/canShow.jsx
+++ b/assets/components/forms/formHOCs/canShow.jsx
@@ -1,0 +1,27 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+
+// ----- Types ----- //
+
+type AugmentedProps<Props> = Props & {
+  isShown: boolean,
+};
+
+type In<Props> = React$ComponentType<Props>;
+type Out<Props> = React$ComponentType<AugmentedProps<Props>>;
+
+
+// ----- Component ----- //
+
+function canShow<Props>(Component: In<Props>): Out<Props> {
+  return ({ isShown, ...props }: AugmentedProps<Props>) => (isShown ? <Component {...props} /> : null);
+}
+
+
+// ----- Exports ----- //
+
+export { canShow };

--- a/assets/helpers/internationalisation/country.js
+++ b/assets/helpers/internationalisation/country.js
@@ -4,6 +4,8 @@
 
 import { getQueryParameter } from 'helpers/url';
 import * as cookie from 'helpers/cookie';
+import { type Option } from 'helpers/types/option';
+
 import { countryGroups } from './countryGroup';
 import type { CountryGroupId } from './countryGroup';
 
@@ -348,9 +350,31 @@ const countries = {
 export type UsState = $Keys<typeof usStates>;
 export type CaState = $Keys<typeof caStates>;
 export type IsoCountry = $Keys<typeof countries>;
+export type StateProvince = UsState | CaState;
 
 
 // ----- Functions ----- /
+
+function usStateFromString(s: string): Option<UsState> {
+  return usStates[s] ? s : null;
+}
+
+function caStateFromString(s: string): Option<CaState> {
+  return caStates[s] ? s : null;
+}
+
+function stateProvinceFromString(country: Option<IsoCountry>, s: string): Option<StateProvince> {
+
+  switch (country) {
+    case 'US':
+      return usStateFromString(s);
+    case 'CA':
+      return caStateFromString(s);
+    default:
+      return null;
+  }
+
+}
 
 function fromString(s: string): ?IsoCountry {
   const candidateIso = s.toUpperCase();
@@ -491,4 +515,5 @@ export {
   caStates,
   countries,
   fromString,
+  stateProvinceFromString,
 };

--- a/assets/pages/digital-subscription-checkout/__tests__/digitalSubscriptionCheckoutReducerTest.js
+++ b/assets/pages/digital-subscription-checkout/__tests__/digitalSubscriptionCheckoutReducerTest.js
@@ -16,7 +16,7 @@ describe('Digital Subscription Checkout Reducer', () => {
 
     const newState = initReducer()(undefined, action);
 
-    expect(newState.form.stage).toEqual(stage);
+    expect(newState.checkout.stage).toEqual(stage);
 
   });
 
@@ -27,7 +27,7 @@ describe('Digital Subscription Checkout Reducer', () => {
 
     const newState = initReducer()(undefined, action);
 
-    expect(newState.form.stage).toEqual(stage);
+    expect(newState.checkout.stage).toEqual(stage);
 
   });
 

--- a/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -12,6 +12,7 @@ import { type Option } from 'helpers/types/option';
 
 import { Input } from 'components/forms/standardFields/input';
 import { Select } from 'components/forms/standardFields/select';
+import { sortedOptions } from 'components/forms/customFields/sortedOptions';
 import { withLabel } from 'components/forms/formHOCs/withLabel';
 import { withError } from 'components/forms/formHOCs/withError';
 import { asControlled } from 'components/forms/formHOCs/asControlled';
@@ -52,19 +53,13 @@ const Input1 = compose(asControlled, withError, withLabel)(Input);
 const Select1 = compose(asControlled, withError, withLabel)(Select);
 const Select2 = canShow(Select1);
 
-function options<A: {}>(os: A): React$Node {
-  return Object.keys(os)
-    .sort((a, b) => os[a].localeCompare(os[b]))
-    .map(k => <option value={k}>{os[k]}</option>);
-}
-
 function statesForCountry(country: Option<IsoCountry>): React$Node {
 
   switch (country) {
     case 'US':
-      return options(usStates);
+      return sortedOptions(usStates);
     case 'CA':
-      return options(caStates);
+      return sortedOptions(caStates);
     default:
       return null;
   }
@@ -102,7 +97,7 @@ function CheckoutForm(props: PropTypes) {
         error={firstError('country', props.errors)}
       >
         <option value="">--</option>
-        {options(countries)}
+        {sortedOptions(countries)}
       </Select1>
       <Select2
         id="stateProvince"

--- a/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -39,7 +39,7 @@ type PropTypes = {|
 function mapStateToProps(state: State) {
   return {
     ...getFormFields(state),
-    errors: state.page.form.errors,
+    errors: state.page.checkout.errors,
   };
 }
 

--- a/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -6,14 +6,16 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 
-import { countries } from 'helpers/internationalisation/country';
+import { countries, usStates, caStates, type IsoCountry } from 'helpers/internationalisation/country';
 import { type FormError, firstError } from 'helpers/subscriptionsForms/validation';
+import { type Option } from 'helpers/types/option';
 
 import { Input } from 'components/forms/standardFields/input';
 import { Select } from 'components/forms/standardFields/select';
 import { withLabel } from 'components/forms/formHOCs/withLabel';
 import { withError } from 'components/forms/formHOCs/withError';
 import { asControlled } from 'components/forms/formHOCs/asControlled';
+import { canShow } from 'components/forms/formHOCs/canShow';
 
 import {
   type State,
@@ -48,6 +50,26 @@ function mapStateToProps(state: State) {
 
 const Input1 = compose(asControlled, withError, withLabel)(Input);
 const Select1 = compose(asControlled, withError, withLabel)(Select);
+const Select2 = canShow(Select1);
+
+function options<A: {}>(os: A): React$Node {
+  return Object.keys(os)
+    .sort((a, b) => os[a].localeCompare(os[b]))
+    .map(k => <option value={k}>{os[k]}</option>);
+}
+
+function statesForCountry(country: Option<IsoCountry>): React$Node {
+
+  switch (country) {
+    case 'US':
+      return options(usStates);
+    case 'CA':
+      return options(caStates);
+    default:
+      return null;
+  }
+
+}
 
 
 // ----- Component ----- //
@@ -80,11 +102,19 @@ function CheckoutForm(props: PropTypes) {
         error={firstError('country', props.errors)}
       >
         <option value="">--</option>
-        {Object.keys(countries)
-          .sort((a, b) => countries[a].localeCompare(countries[b]))
-          .map(iso => <option value={iso}>{countries[iso]}</option>)
-        }
+        {options(countries)}
       </Select1>
+      <Select2
+        id="stateProvince"
+        label={props.country === 'CA' ? 'Province/Territory' : 'State'}
+        value={props.stateProvince}
+        setValue={props.setStateProvince}
+        error={firstError('stateProvince', props.errors)}
+        isShown={props.country === 'US' || props.country === 'CA'}
+      >
+        <option value="">--</option>
+        {statesForCountry(props.country)}
+      </Select2>
       <Input1
         id="telephone"
         label="Telephone (optional)"

--- a/assets/pages/digital-subscription-checkout/components/checkoutStage.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutStage.jsx
@@ -83,7 +83,7 @@ const heroesByCountry: ImagesByCountry = {
 function mapStateToProps(state: State): PropTypes {
 
   return {
-    stage: state.page.form.stage,
+    stage: state.page.checkout.stage,
     countryGroupId: state.common.internationalisation.countryGroupId,
   };
 

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -38,20 +38,13 @@ export type FormFields = {|
 export type FormField = $Keys<FormFields>;
 
 type CheckoutState = {|
-  stage: string,
-  firstName: string,
-  lastName: string,
-  country: ?string,
-  telephone: string,
+  stage: Stage,
+  ...FormFields,
   errors: FormError<FormField>[],
-|}
+|};
 
 type PageState = {|
-  form: {
-    stage: Stage,
-    ...FormFields,
-    errors: FormError<FormField>[],
-  },
+  checkout: CheckoutState,
   user: UserState,
   csrf: CsrfState,
   marketingConsent: MarketingConsentState,
@@ -75,10 +68,10 @@ export type Action =
 
 function getFormFields(state: State): FormFields {
   return {
-    firstName: state.page.form.firstName,
-    lastName: state.page.form.lastName,
-    country: state.page.form.country,
-    telephone: state.page.form.telephone,
+    firstName: state.page.checkout.firstName,
+    lastName: state.page.checkout.lastName,
+    country: state.page.checkout.country,
+    telephone: state.page.checkout.telephone,
   };
 }
 
@@ -162,7 +155,7 @@ function reducer(state: CheckoutState = initialState, action: Action): CheckoutS
 
 function initReducer(countryGroupId: CountryGroupId = detect()) {
   return combineReducers({
-    form: reducer,
+    checkout: reducer,
     user: createUserReducer(countryGroupId),
     csrf,
     marketingConsent: marketingConsentReducerFor('MARKETING_CONSENT'),


### PR DESCRIPTION
## Why are you doing this?

Adding a state/province dropdown for the US and Canada.

[**Trello Card**](https://trello.com/c/i6owjmJJ/1507-personal-details-in-checkout)

## Changes

- Refactored the structure of the checkout state.
- Added a `sortedOptions` helper to produce a list of sorted `<option>`s.
- Added a `HOC` to hide or show a component.
- Added helpers to `country` to manage State and Province.
- Added a state/province dropdown to the checkout.
- Added validation for the new state/province field.

## Screenshots

Country With No State/Province | United States With Validation Error | Canada With State/Province Selected
-|-|-
![form-nodropdown](https://user-images.githubusercontent.com/5131341/48843307-983be080-ed8e-11e8-82e2-5b1abb47f4ed.png) | ![form-us](https://user-images.githubusercontent.com/5131341/48843319-9ffb8500-ed8e-11e8-8811-9b348225a4b0.png) | ![form-canada](https://user-images.githubusercontent.com/5131341/48843331-a853c000-ed8e-11e8-854d-2b0a52bf88a7.png)
