### PR TITLE
move /subscribe/paper to /uk/subscribe/paper

### DIFF
--- a/app/controllers/Subscriptions.scala
+++ b/app/controllers/Subscriptions.scala
@@ -128,6 +128,10 @@ class Subscriptions(
     Redirect(buildCanonicalPaperSubscriptionLink(), request.queryString, status = FOUND)
   }
 
+  def paperMethodRedirectTo(method: String): Action[AnyContent] = Action { implicit request =>
+    Redirect(buildCanonicalPaperSubscriptionLink(Some(method)), request.queryString, status = FOUND)
+  }
+
   def paper(method: String): Action[AnyContent] = CachedAction() { implicit request =>
     implicit val settings: Settings = settingsProvider.settings()
     val title = "The Guardian Subscriptions | The Guardian"
@@ -156,8 +160,8 @@ class Subscriptions(
       }
     }
 
-  def buildCanonicalPaperSubscriptionLink(method: String = "collection"): String =
-    s"${supportUrl}/subscribe/paper/${method}"
+  def buildCanonicalPaperSubscriptionLink(method: Option[String] = None): String =
+    s"${supportUrl}/uk/subscribe/paper/${method.getOrElse("collection")}"
 
   def buildCanonicalDigitalSubscriptionLink(countryCode: String): String =
     s"${supportUrl}/${countryCode}/subscribe/digital"

--- a/conf/routes
+++ b/conf/routes
@@ -81,7 +81,9 @@ GET  /subscribe/weekly                            controllers.Subscriptions.week
 GET  /$country<(uk|us|au|int|nz|ca|eu)>/subscribe/weekly   controllers.Subscriptions.weekly(country: String)
 
 GET  /subscribe/paper          controllers.Subscriptions.paperMethodRedirect()
-GET  /subscribe/paper/$method<collection|delivery>          controllers.Subscriptions.paper(method: String)
+GET  /uk/subscribe/paper          controllers.Subscriptions.paperMethodRedirect()
+GET  /subscribe/paper/$method<collection|delivery>          controllers.Subscriptions.paperMethodRedirectTo(method)
+GET  /uk/subscribe/paper/$method<collection|delivery>          controllers.Subscriptions.paper(method: String)
 
 # ----- Authentication ----- #
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -10,6 +10,9 @@ Disallow: /contribute/recurring-guest
 Disallow: /subscribe/paper
 Disallow: /subscribe/paper/delivery
 Disallow: /subscribe/paper/collection
+Disallow: /uk/subscribe/paper
+Disallow: /uk/subscribe/paper/delivery
+Disallow: /uk/subscribe/paper/collection
 
 Disallow: /uk/subscribe/digital/checkout
 Disallow: /us/subscribe/digital/checkout


### PR DESCRIPTION
## Why are you doing this?

it's more consistent with all other routes, this page is unlaunched so there are no user-facing consequences to doing this