### PR TITLE
Simpler Redux State Type

### DIFF
--- a/assets/helpers/page/page.js
+++ b/assets/helpers/page/page.js
@@ -28,6 +28,15 @@ if (process.env.NODE_ENV === 'DEV') {
   import('preact/devtools');
 }
 
+
+// ----- Types ----- //
+
+export type ReduxState<PageState> = {|
+  common: CommonState,
+  page: PageState,
+|};
+
+
 // ----- Functions ----- //
 
 function doNotTrack(): boolean {

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -4,7 +4,7 @@
 
 import { compose, type Dispatch } from 'redux';
 
-import type { CommonState } from 'helpers/page/commonReducer';
+import { type ReduxState } from 'helpers/page/page';
 import { type Option } from 'helpers/types/option';
 import {
   type IsoCountry,
@@ -50,17 +50,12 @@ type CheckoutState = {|
   errors: FormError<FormField>[],
 |};
 
-type PageState = {|
+export type State = ReduxState<{|
   checkout: CheckoutState,
   user: UserState,
   csrf: CsrfState,
   marketingConsent: MarketingConsentState,
-|};
-
-export type State = {
-  common: CommonState,
-  page: PageState,
-};
+|}>;
 
 export type Action =
   | { type: 'SET_STAGE', stage: Stage }


### PR DESCRIPTION
## Why are you doing this?

To simplify building the Redux state type, to reduce boilerplate and hopefully make it easier to understand the types in each reducer file. If this works well for the digital checkout it can be rolled out to the other reducer files.

cc @JustinPinner 

## Changes

- Added new parameterised `ReduxState` type.
- Used the new type on the digital checkout.
