### PR TITLE
Fix recurring cookie logic

### DIFF
--- a/assets/helpers/user/user.js
+++ b/assets/helpers/user/user.js
@@ -51,7 +51,7 @@ const init = (dispatch: Function) => {
     dispatch(setPostDeploymentTestUser(true));
   }
 
-  if (getCookie('gu_recurring_contributor')) {
+  if (getCookie('gu_recurring_contributor') === 'true') {
     dispatch(setIsRecurringContributor());
   }
 


### PR DESCRIPTION
## Why are you doing this?
This ensures that only those with the cookie set to `true` will be blocked