### PR TITLE
Minimize css a bit more

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "mini-css-extract-plugin": "^0.4.0",
     "node-sass": "^4.9.0",
     "npm-run-all": "^4.1.3",
+    "optimize-css-assets-webpack-plugin": "^5.0.1",
     "postcss": "^7.0.2",
     "postcss-loader": "^3.0.0",
     "postcss-pxtorem": "^4.0.1",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -6,6 +6,7 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const autoprefixer = require('autoprefixer');
 const pxtorem = require('postcss-pxtorem');
 const cssnano = require('cssnano');
+const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 
 module.exports = (cssFilename, outputFilename, minimizeCss) => ({
   plugins: [
@@ -16,6 +17,13 @@ module.exports = (cssFilename, outputFilename, minimizeCss) => ({
     new MiniCssExtractPlugin({
       filename: path.join('stylesheets', cssFilename),
     }),
+    ...(minimizeCss ? [new OptimizeCssAssetsPlugin({
+      cssProcessor: cssnano,
+      cssProcessorPluginOptions: {
+        preset: 'default',
+      },
+      canPrint: true,
+    })] : []),
   ],
 
   context: path.resolve(__dirname, 'assets'),
@@ -103,7 +111,6 @@ module.exports = (cssFilename, outputFilename, minimizeCss) => ({
               plugins: [
                 pxtorem({ propList: ['*'] }),
                 autoprefixer(),
-                ...(minimizeCss ? [cssnano] : []),
               ],
             },
           },


### PR DESCRIPTION
## Why are you doing this?

`cssnano` was running before sass meaning a lot of the optimisations (especially around removing suplicates) weren't happening. This uses `optimize-css-assets-webpack-plugin` to put minification at the last step.

## Before/After for GW page
![screenshot 2018-11-22 at 11 12 23 am](https://user-images.githubusercontent.com/11539094/48899453-88340780-ee47-11e8-87ec-bf54c34ae6d7.png)
![screenshot 2018-11-22 at 11 13 01 am](https://user-images.githubusercontent.com/11539094/48899479-997d1400-ee47-11e8-82ee-1000fcc1f02b.png)
