### PR TITLE
Don't use the Constraint Validation API to determine whether to submit the form or not

### DIFF
--- a/assets/helpers/__tests__/formValidation.js
+++ b/assets/helpers/__tests__/formValidation.js
@@ -2,7 +2,7 @@
 
 // ----- Imports ----- //
 
-import { maxTwoDecimals } from '../formValidation';
+import { checkAmountOrOtherAmount, maxTwoDecimals } from '../formValidation';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { checkStateIfApplicable } from 'helpers/formValidation';
 import type { ContributionType, OtherAmounts, SelectedAmounts } from 'helpers/contributions';
@@ -82,6 +82,62 @@ describe('formValidation', () => {
       expect(checkStateIfApplicable(state, 'EURCountries')).toEqual(true);
       expect(checkStateIfApplicable(state, 'International')).toEqual(true);
       expect(checkStateIfApplicable(state, 'NZDCountries')).toEqual(true);
+    });
+  });
+
+  describe('checkAmountOrOtherAmount', () => {
+
+    const defaultSelectedAmounts =  {
+      ONE_OFF: {
+        value: '50',
+        spoken: 'fifty',
+        isDefault: true,
+      },
+      MONTHLY: {
+        value: '15',
+        spoken: 'fifteen',
+        isDefault: true,
+      },
+      ANNUAL: {
+        value: '100',
+        spoken: 'one hundred',
+        isDefault: true,
+      },
+    };
+
+    const selectedAmountsWithOtherSelected = {
+      ONE_OFF: 'other',
+      MONTHLY: 'other',
+      ANNUAL: 'other',
+    };
+
+    const defaultOtherAmounts = {
+      ONE_OFF: {
+        amount: null,
+      },
+      MONTHLY: {
+        amount: '2',
+      },
+      ANNUAL: {
+        amount: '0',
+      },
+    };
+
+
+    it('should return true if selected amount is not other and amount is valid', () => {
+      expect(checkAmountOrOtherAmount(defaultSelectedAmounts, defaultOtherAmounts, 'MONTHLY', 'UnitedStates')).toEqual(true);
+    });
+
+    it('should return true if other is selected and amount is valid', () => {
+      expect(checkAmountOrOtherAmount(selectedAmountsWithOtherSelected, defaultOtherAmounts, 'MONTHLY', 'UnitedStates')).toEqual(true);
+    });
+
+    it('should return false if other is selected and amount is empty', () => {
+      expect(checkAmountOrOtherAmount(selectedAmountsWithOtherSelected, defaultOtherAmounts, 'ONE_OFF', 'UnitedStates')).toEqual(false);
+    });
+
+    it('should return false if other is selected and amount is invalid', () => {
+      expect(checkAmountOrOtherAmount(selectedAmountsWithOtherSelected, defaultOtherAmounts, 'ANNUAL', 'UnitedStates')).toEqual(false);
     });
   });
 });

--- a/assets/helpers/__tests__/formValidation.js
+++ b/assets/helpers/__tests__/formValidation.js
@@ -2,10 +2,8 @@
 
 // ----- Imports ----- //
 
-import { checkAmountOrOtherAmount, maxTwoDecimals } from '../formValidation';
-import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { checkStateIfApplicable } from 'helpers/formValidation';
-import type { ContributionType, OtherAmounts, SelectedAmounts } from 'helpers/contributions';
+import { checkAmountOrOtherAmount, maxTwoDecimals } from '../formValidation';
 
 // ----- Tests ----- //
 
@@ -87,7 +85,7 @@ describe('formValidation', () => {
 
   describe('checkAmountOrOtherAmount', () => {
 
-    const defaultSelectedAmounts =  {
+    const defaultSelectedAmounts = {
       ONE_OFF: {
         value: '50',
         spoken: 'fifty',

--- a/assets/helpers/__tests__/formValidation.js
+++ b/assets/helpers/__tests__/formValidation.js
@@ -3,6 +3,9 @@
 // ----- Imports ----- //
 
 import { maxTwoDecimals } from '../formValidation';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { checkStateIfApplicable } from 'helpers/formValidation';
+import type { ContributionType, OtherAmounts, SelectedAmounts } from 'helpers/contributions';
 
 // ----- Tests ----- //
 
@@ -43,5 +46,42 @@ describe('formValidation', () => {
       expect(maxTwoDecimals('-12')).toEqual(false);
     });
 
+  });
+
+  describe('checkStateIfApplicable', () => {
+
+    it('should return false if state is null', () => {
+      const state = null;
+      const countryGroupId = 'UnitedStates';
+      expect(checkStateIfApplicable(state, countryGroupId)).toEqual(false);
+    });
+
+    it('should return true if countryGroupId is UnitedStates and state is a string', () => {
+      const state = 'CA';
+      const countryGroupId = 'UnitedStates';
+      expect(checkStateIfApplicable(state, countryGroupId)).toEqual(true);
+    });
+
+    it('should return true if countryGroupId is Canada and state is a string', () => {
+      const state = 'AL';
+      const countryGroupId = 'Canada';
+      expect(checkStateIfApplicable(state, countryGroupId)).toEqual(true);
+    });
+
+    it('should return true if countryGroupId is not Canada or United States regardless of the state', () => {
+      let state = 'AL';
+      expect(checkStateIfApplicable(state, 'GBPCountries')).toEqual(true);
+      expect(checkStateIfApplicable(state, 'AUDCountries')).toEqual(true);
+      expect(checkStateIfApplicable(state, 'EURCountries')).toEqual(true);
+      expect(checkStateIfApplicable(state, 'International')).toEqual(true);
+      expect(checkStateIfApplicable(state, 'NZDCountries')).toEqual(true);
+
+      state = null;
+      expect(checkStateIfApplicable(state, 'GBPCountries')).toEqual(true);
+      expect(checkStateIfApplicable(state, 'AUDCountries')).toEqual(true);
+      expect(checkStateIfApplicable(state, 'EURCountries')).toEqual(true);
+      expect(checkStateIfApplicable(state, 'International')).toEqual(true);
+      expect(checkStateIfApplicable(state, 'NZDCountries')).toEqual(true);
+    });
   });
 });

--- a/assets/helpers/checkoutForm/checkoutForm.js
+++ b/assets/helpers/checkoutForm/checkoutForm.js
@@ -4,6 +4,16 @@
 import { type ContributionType, contributionTypeIsRecurring } from 'helpers/contributions';
 import { type UserTypeFromIdentityResponse } from 'helpers/identityApis';
 import { canContributeWithoutSigningIn } from 'helpers/identityApis';
+import type { OtherAmounts, SelectedAmounts } from 'helpers/contributions';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import type { CaState, UsState } from 'helpers/internationalisation/country';
+import {
+  checkAmountOrOtherAmount,
+  checkEmail,
+  checkFirstName,
+  checkLastName,
+  checkStateIfApplicable,
+} from 'helpers/formValidation';
 
 // Copied from
 // https://github.com/playframework/playframework/blob/master/framework/src/play/
@@ -86,18 +96,48 @@ export const formElementIsValid = (formElement: Object | null) => {
 
 export const formIsValid = (formClassName: string) => formElementIsValid(getForm(formClassName));
 
+export type FormIsValidParameters = {
+  selectedAmounts: SelectedAmounts,
+  otherAmounts: OtherAmounts,
+  countryGroupId: CountryGroupId,
+  contributionType: ContributionType,
+  state: UsState | CaState | null,
+  firstName: string | null,
+  lastName: string | null,
+  email: string | null,
+}
+
+const getFormIsValid = (formIsValidParameters: FormIsValidParameters) => {
+  const {
+    selectedAmounts,
+    otherAmounts,
+    countryGroupId,
+    contributionType,
+    state,
+    firstName,
+    lastName,
+    email,
+  } = formIsValidParameters;
+
+  return checkFirstName(firstName)
+    && checkLastName(lastName)
+    && checkEmail(email)
+    && checkStateIfApplicable(state, countryGroupId)
+    && checkAmountOrOtherAmount(selectedAmounts, otherAmounts, contributionType, countryGroupId);
+};
+
 export function checkoutFormShouldSubmit(
   contributionType: ContributionType,
   isSignedIn: boolean,
   isRecurringContributor: boolean,
   userTypeFromIdentityResponse: UserTypeFromIdentityResponse,
-  form: Object | null,
+  formIsValidParameters: FormIsValidParameters,
 ) {
 
   const shouldBlockExistingRecurringContributor =
       isRecurringContributor && contributionTypeIsRecurring(contributionType);
 
-  return formElementIsValid(form)
+  return getFormIsValid(formIsValidParameters)
     && canContributeWithoutSigningIn(contributionType, isSignedIn, userTypeFromIdentityResponse)
     && !(shouldBlockExistingRecurringContributor);
 }

--- a/assets/helpers/contributions.js
+++ b/assets/helpers/contributions.js
@@ -80,6 +80,12 @@ type Config = {
   }
 }
 
+export type OtherAmounts = {
+  [ContributionType]: { amount: string | null }
+};
+
+export type SelectedAmounts = { [ContributionType]: Amount | 'other' };
+
 
 // ----- Setup ----- //
 

--- a/assets/helpers/formValidation.js
+++ b/assets/helpers/formValidation.js
@@ -5,15 +5,50 @@
 // src/main/scala/play/api/data/validation/Validation.scala#L81
 // but with minor modification (last * becomes +) to enforce at least one dot in domain.  This is
 // for compatibility with Stripe
+import { config } from 'helpers/contributions';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import type { ContributionType, OtherAmounts, SelectedAmounts } from 'helpers/contributions';
+
 export const emailRegexPattern = '^[a-zA-Z0-9\\.!#$%&\'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$';
 
-export const isNotEmpty: string => boolean = input => !!input && input.trim() !== '';
-export const isValidEmail: string => boolean = input => new RegExp(emailRegexPattern).test(input);
+export const isNotEmpty: (string | null) => boolean = input => !!input && input.trim() !== '';
+export const isValidEmail: (string | null) => boolean = input => !!input && new RegExp(emailRegexPattern).test(input);
 export const isLargerOrEqual: (number, string) => boolean = (min, input) => min <= parseFloat(input);
 export const isSmallerOrEqual: (number, string) => boolean = (max, input) => parseFloat(input) <= max;
 export const maxTwoDecimals: string => boolean = input => new RegExp('^\\d+\\.?\\d{0,2}$').test(input);
 
-export const checkFirstName: string => boolean = isNotEmpty;
-export const checkLastName: string => boolean = isNotEmpty;
+export const checkFirstName: (string | null) => boolean = isNotEmpty;
+export const checkLastName: (string | null) => boolean = isNotEmpty;
 export const checkState: (string | null) => boolean = s => typeof s === 'string' && isNotEmpty(s);
-export const checkEmail: string => boolean = input => isNotEmpty(input) && isValidEmail(input);
+export const checkEmail: (string | null) => boolean = input => isNotEmpty(input) && isValidEmail(input);
+
+
+export const checkAmount: (string, CountryGroupId, ContributionType) =>
+  boolean = (input: string, countryGroupId: CountryGroupId, contributionType: ContributionType) =>
+    isNotEmpty(input)
+    && isLargerOrEqual(config[countryGroupId][contributionType].min, input)
+    && isSmallerOrEqual(config[countryGroupId][contributionType].max, input)
+    && maxTwoDecimals(input);
+
+
+export const checkAmountOrOtherAmount: (SelectedAmounts, OtherAmounts, ContributionType, CountryGroupId) => boolean = (
+  selectedAmounts: SelectedAmounts,
+  otherAmounts: OtherAmounts,
+  contributionType: ContributionType,
+  countryGroupId: CountryGroupId,
+) => {
+  const amount = selectedAmounts[contributionType] === 'other'
+    ? otherAmounts[contributionType].amount || ''
+    : selectedAmounts[contributionType].value || '';
+  return checkAmount(amount, countryGroupId, contributionType);
+};
+
+export const checkStateIfApplicable: ((string | null), CountryGroupId) => boolean = (
+  state: (string | null),
+  countryGroupId: CountryGroupId,
+) => {
+  if (countryGroupId === 'UnitedStates' || countryGroupId === 'Canada') {
+    return checkState(state);
+  }
+  return true;
+};

--- a/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
@@ -29,7 +29,7 @@ type PropTypes = {|
   selectedAmounts: { [ContributionType]: Amount | 'other' },
   selectAmount: (Amount | 'other', CountryGroupId, ContributionType) => (() => void),
   otherAmount: string | null,
-  checkOtherAmount: string => boolean,
+  checkOtherAmount: (string, CountryGroupId, ContributionType) => boolean,
   updateOtherAmount: (string, CountryGroupId, ContributionType) => void,
   checkoutFormHasBeenSubmitted: boolean,
   annualTestVariant: AnnualContributionsTestVariant,
@@ -127,7 +127,7 @@ function ContributionAmount(props: PropTypes) {
           value={props.otherAmount}
           icon={iconForCountryGroup(props.countryGroupId)}
           onInput={e => props.updateOtherAmount((e.target: any).value, props.countryGroupId, props.contributionType)}
-          isValid={props.checkOtherAmount(props.otherAmount || '')}
+          isValid={props.checkOtherAmount(props.otherAmount || '', props.countryGroupId, props.contributionType)}
           formHasBeenSubmitted={props.checkoutFormHasBeenSubmitted}
           errorMessage={`Please provide an amount between ${minAmount} and ${maxAmount}`}
           autoComplete="off"

--- a/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -9,7 +9,6 @@ import { connect } from 'react-redux';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { classNameWithModifiers } from 'helpers/utilities';
 import {
-  config,
   type ContributionType,
   type PaymentMatrix,
   type PaymentMethod,
@@ -25,12 +24,7 @@ import { payPalCancelUrl, payPalReturnUrl } from 'helpers/routes';
 import ProgressMessage from 'components/progressMessage/progressMessage';
 import { openDirectDebitPopUp } from 'components/directDebit/directDebitActions';
 
-import {
-  isNotEmpty,
-  isSmallerOrEqual,
-  isLargerOrEqual,
-  maxTwoDecimals,
-} from 'helpers/formValidation';
+import { checkAmount } from 'helpers/formValidation';
 import { onFormSubmit } from 'helpers/checkoutForm/onFormSubmit';
 import { type UserTypeFromIdentityResponse } from 'helpers/identityApis';
 
@@ -200,17 +194,11 @@ function onSubmit(props: PropTypes): Event => void {
 // ----- Render ----- //
 
 function ContributionForm(props: PropTypes) {
-  const checkOtherAmount: string => boolean = input =>
-    isNotEmpty(input)
-    && isLargerOrEqual(config[props.countryGroupId][props.contributionType].min, input)
-    && isSmallerOrEqual(config[props.countryGroupId][props.contributionType].max, input)
-    && maxTwoDecimals(input);
-
   return (
     <form onSubmit={onSubmit(props)} className={classNameWithModifiers('form', ['contribution'])} noValidate>
       <ContributionTypeTabs />
       <NewContributionAmount
-        checkOtherAmount={checkOtherAmount}
+        checkOtherAmount={checkAmount}
       />
       <ContributionFormFields />
       <NewPaymentMethodSelector onPaymentAuthorisation={props.onPaymentAuthorisation} />

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -163,13 +163,25 @@ const setUserTypeFromIdentityResponse = (userTypeFromIdentityResponse: UserTypeF
 const togglePayPalButton = () =>
   (dispatch: Function, getState: () => State): void => {
     const state = getState();
+
+    const formIsValidParameters = {
+      selectedAmounts: state.page.form.selectedAmounts,
+      otherAmounts: state.page.form.formData.otherAmounts,
+      countryGroupId: state.common.internationalisation.countryGroupId,
+      contributionType: state.page.form.contributionType,
+      state: state.page.form.formData.state,
+      firstName: state.page.form.formData.firstName,
+      lastName: state.page.form.formData.lastName,
+      email: state.page.form.formData.email,
+    };
+
     const shouldEnable = checkoutFormShouldSubmit(
       state.page.form.contributionType,
       state.page.user.isSignedIn,
       state.page.user.isRecurringContributor,
       state.page.form.userTypeFromIdentityResponse,
       // TODO: use the actual form state rather than re-fetching from DOM
-      getForm('form--contribution'),
+      formIsValidParameters,
     );
     if (shouldEnable && window.enablePayPalButton) {
       window.enablePayPalButton();

--- a/assets/pages/new-contributions-landing/contributionsLandingReducer.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingReducer.js
@@ -13,6 +13,7 @@ import { type UsState, type CaState } from 'helpers/internationalisation/country
 import { createUserReducer, type User as UserState } from 'helpers/user/userReducer';
 import { type DirectDebitState } from 'components/directDebit/directDebitReducer';
 import { directDebitReducer as directDebit } from 'components/directDebit/directDebitReducer';
+import type { OtherAmounts, SelectedAmounts } from 'helpers/contributions';
 import { type Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import { type SessionId as SessionIdState } from 'helpers/sessionId/reducer';
 import { getContributionTypeFromSessionOrElse } from 'helpers/checkouts';
@@ -41,9 +42,7 @@ export type ThankYouPageStageMap<T> = {
 export type ThankYouPageStage = $Keys<ThankYouPageStageMap<null>>
 
 type FormData = UserFormData & {
-  otherAmounts: {
-    [ContributionType]: { amount: string | null }
-  },
+  otherAmounts: OtherAmounts,
   state: UsState | CaState | null,
   checkoutFormHasBeenSubmitted: boolean,
 };
@@ -58,7 +57,7 @@ type FormState = {
   contributionType: ContributionType,
   paymentMethod: PaymentMethod,
   thirdPartyPaymentLibraries: ThirdPartyPaymentLibraries,
-  selectedAmounts: { [ContributionType]: Amount | 'other' },
+  selectedAmounts: SelectedAmounts,
   isWaiting: boolean,
   formData: FormData,
   setPasswordData: SetPasswordData,


### PR DESCRIPTION
## Why are you doing this?
Using the Constraint Validation API to determine whether the form is valid was causing us some issues. There was a race condition error whereby if you change the amount to other, the change to the DOM doesn't happen in time for the correct valid state to be determined. This was currently only an issue for the PayPal button, as the rest of the payment methods evaluated the form on submit, rather than on form change, but that is changing in [this PR](https://github.com/guardian/support-frontend/pull/1209).  

It was also always the plan to move to state-based form validation anyway because that's what we use to decide whether to show an error or not, and having 2 different validation systems was always going to (and has already) cause problems. 

So we need to switch to state-based form validation. 

Note: you can see why we are moving our form validation logic into one place, as I've had to make the changes twice on this PR, once for PayPal recurring and once for everything else. 