### PR TITLE
Use common privacy policy for subscription + contribution footers 

### DIFF
--- a/assets/components/footer/footer.jsx
+++ b/assets/components/footer/footer.jsx
@@ -6,14 +6,13 @@ import React from 'react';
 import type { Node } from 'react';
 
 import ContribLegal from 'components/legal/contribLegal/contribLegal';
-import { privacyLink, copyrightNotice } from 'helpers/legal';
+import { copyrightNotice } from 'helpers/legal';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import TermsPrivacy from '../legal/termsPrivacy/termsPrivacy';
 
 // ----- Props ----- //
 
 type PropTypes = {|
-  privacyPolicy: boolean,
   disclaimer: boolean,
   countryGroupId: CountryGroupId,
   children: Node,
@@ -21,21 +20,6 @@ type PropTypes = {|
 
 
 // ----- Functions ----- //
-
-function PrivacyPolicy(props: { privacyPolicy: boolean }) {
-
-  if (props.privacyPolicy) {
-    return (
-      <div className="component-footer__privacy-policy-text">
-        To find out what personal data we collect and how we use it, please visit our
-        <a className="component-footer__privacy-policy" href={privacyLink}> Privacy Policy</a>.
-      </div>
-    );
-  }
-
-  return null;
-
-}
 
 function Disclaimer(props: { disclaimer: boolean, countryGroupId: CountryGroupId }) {
   if (props.disclaimer) {
@@ -55,7 +39,6 @@ function Footer(props: PropTypes) {
   return (
     <footer className="component-footer" role="contentinfo">
       <div className="component-footer__content">
-        <PrivacyPolicy privacyPolicy={props.privacyPolicy} />
         {props.children}
         <small className="component-footer__copyright">{copyrightNotice}</small>
         <Disclaimer disclaimer={props.disclaimer} countryGroupId={props.countryGroupId} />
@@ -69,7 +52,6 @@ function Footer(props: PropTypes) {
 // ----- Default Props ----- //
 
 Footer.defaultProps = {
-  privacyPolicy: false,
   disclaimer: false,
   countryGroupId: 'GBPCountries',
   children: [],

--- a/assets/components/footer/footer.scss
+++ b/assets/components/footer/footer.scss
@@ -6,7 +6,6 @@
   padding: $gu-v-spacing 0;
 
   .component-contrib-legal, .component-terms-privacy {
-    //margin-top: $gu-v-spacing;
     font-weight: 400;
     display: block;
     padding: 3px 0;

--- a/assets/components/footer/footer.scss
+++ b/assets/components/footer/footer.scss
@@ -5,12 +5,16 @@
   line-height: 16px;
   padding: $gu-v-spacing 0;
 
-  .component-contrib-legal {
-    margin-top: $gu-v-spacing;
+  .component-contrib-legal, .component-terms-privacy {
+    //margin-top: $gu-v-spacing;
     font-weight: 400;
     display: block;
     padding: 3px 0;
     color: gu-colour(neutral-4);
+
+    a {
+      color: gu-colour(garnett-neutral-5);
+    }
   }
 }
 

--- a/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
+++ b/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
@@ -27,7 +27,7 @@ const content = (
   <Provider store={store}>
     <Page
       header={<SimpleHeader />}
-      footer={<FooterContainer disclaimer privacyPolicy />}
+      footer={<FooterContainer disclaimer />}
     >
       <FeaturedProductAb
         headingSize={3}

--- a/assets/pages/support-landing/supportLanding.jsx
+++ b/assets/pages/support-landing/supportLanding.jsx
@@ -56,7 +56,7 @@ const content = (
   <Provider store={store}>
     <Page
       header={<CountrySwitcherHeader />}
-      footer={<Footer disclaimer privacyPolicy />}
+      footer={<Footer disclaimer />}
     >
       <CirclesIntroduction
         headings={['Help us deliver the', 'independent journalism', 'the world needs']}


### PR DESCRIPTION
## Why are you doing this?
The /subscription page footer now has a couple of issues:
1. It now has 2 privacy messages because of [this change](https://github.com/guardian/support-frontend/pull/1231)
2. The new privacy message needs a styling fix

## Screenshots
Before:
![picture 14](https://user-images.githubusercontent.com/1513454/48937238-5f724780-ef05-11e8-862d-d8b88ca77390.png)

After:
![picture 16](https://user-images.githubusercontent.com/1513454/48937243-61d4a180-ef05-11e8-8e08-598b9d2e2381.png)


