### PR TITLE
Add some contextualised click tracking primarily for the showcase page

### DIFF
--- a/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
+++ b/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
@@ -58,7 +58,7 @@ function onCtaClick(isDisabled: boolean, resetError: void => void, context?: str
       clickEvent.preventDefault();
     }
 
-    sendClickedEvent(`${(context ? context + '-' : '')}ContributeCTA`);
+    sendClickedEvent(`${(context ? context.concat('-') : '')}ContributeCTA`);
 
     resetError();
 
@@ -96,6 +96,10 @@ export default function ContributionPaymentCtas(props: PropTypes) {
 
 }
 
+ContributionPaymentCtas.defaultProps = {
+  context: 'component-contribution-payment-ctas',
+};
+
 
 // ----- Auxiliary Components ----- //
 
@@ -106,7 +110,7 @@ function OneOffCta(props: {
   currencyId: IsoCurrency,
   isDisabled: boolean,
   resetError: void => void,
-  context?: string,
+  context: string,
 }): Node {
 
   const clickUrl = addQueryParamsToURL(routes.oneOffContribCheckout, {
@@ -115,7 +119,7 @@ function OneOffCta(props: {
     currency: props.currencyId,
   });
 
-  const ctaContext = (props.context ? props.context + '-' : '') +  'one-off';
+  const ctaContext = props.context.concat('-one_off_cta');
 
   return (
     <CtaLink
@@ -137,7 +141,7 @@ function RegularCta(props: {
   currencyId: IsoCurrency,
   isDisabled: boolean,
   resetError: void => void,
-  context?: string,
+  context: string,
 }): Node {
   const frequency = getFrequency(props.contributionType);
   const spokenType = getSpokenType(props.contributionType);
@@ -147,7 +151,7 @@ function RegularCta(props: {
     currency: props.currencyId,
   });
 
-  const ctaContext = (props.context ? props.context + '-' : '') +  'regular';
+  const ctaContext = props.context.concat('-regular_cta');
 
   return (
     <CtaLink

--- a/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
+++ b/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
@@ -50,16 +50,16 @@ type PropTypes = {|
 // ----- Heading ----- //
 
 // Prevents a click event if it's not allowed.
-function onCtaClick(isDisabled: boolean, resetError: void => void, context?: string): Function {
+function onCtaClick(isDisabled: boolean, resetError: void => void, context: string): Function {
+
+  if (!isDisabled) {
+    sendClickedEvent(context);
+  }
 
   return (clickEvent) => {
 
     if (isDisabled) {
       clickEvent.preventDefault();
-    }
-
-    if (!isDisabled) {
-      sendClickedEvent(`${(context ? context : 'contribute_cta')}`);
     }
 
     resetError();

--- a/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
+++ b/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
@@ -52,14 +52,12 @@ type PropTypes = {|
 // Prevents a click event if it's not allowed.
 function onCtaClick(isDisabled: boolean, resetError: void => void, context: string): Function {
 
-  if (!isDisabled) {
-    sendClickedEvent(context);
-  }
-
   return (clickEvent) => {
 
     if (isDisabled) {
       clickEvent.preventDefault();
+    } else {
+      sendClickedEvent(context);
     }
 
     resetError();

--- a/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
+++ b/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
@@ -57,7 +57,7 @@ function onCtaClick(isDisabled: boolean, resetError: void => void, context: stri
     if (isDisabled) {
       clickEvent.preventDefault();
     } else {
-      sendClickedEvent(context);
+      sendClickedEvent(context)();
     }
 
     resetError();

--- a/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
+++ b/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
@@ -43,7 +43,7 @@ type PropTypes = {|
   |}>,
   error: ?string,
   resetError: void => void,
-  context?: string,
+  context: string,
 |};
 
 
@@ -58,7 +58,9 @@ function onCtaClick(isDisabled: boolean, resetError: void => void, context?: str
       clickEvent.preventDefault();
     }
 
-    sendClickedEvent(`${(context ? context.concat('-') : '')}ContributeCTA`);
+    if (!isDisabled) {
+      sendClickedEvent(`${(context ? context : 'contribute_cta')}`);
+    }
 
     resetError();
 

--- a/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
+++ b/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
@@ -17,6 +17,7 @@ import {
 import { classNameWithModifiers } from 'helpers/utilities';
 import { routes } from 'helpers/routes';
 import { addQueryParamsToURL } from 'helpers/url';
+import { sendClickedEvent } from 'helpers/tracking/clickTracking';
 
 import { currencies, type IsoCurrency } from 'helpers/internationalisation/currency';
 import { type ContributionType } from 'helpers/contributions';
@@ -42,19 +43,22 @@ type PropTypes = {|
   |}>,
   error: ?string,
   resetError: void => void,
+  context?: string,
 |};
 
 
 // ----- Heading ----- //
 
 // Prevents a click event if it's not allowed.
-function onCtaClick(isDisabled: boolean, resetError: void => void): Function {
+function onCtaClick(isDisabled: boolean, resetError: void => void, context?: string): Function {
 
   return (clickEvent) => {
 
     if (isDisabled) {
       clickEvent.preventDefault();
     }
+
+    sendClickedEvent(`${(context ? context + '-' : '')}ContributeCTA`);
 
     resetError();
 
@@ -102,6 +106,7 @@ function OneOffCta(props: {
   currencyId: IsoCurrency,
   isDisabled: boolean,
   resetError: void => void,
+  context?: string,
 }): Node {
 
   const clickUrl = addQueryParamsToURL(routes.oneOffContribCheckout, {
@@ -110,12 +115,14 @@ function OneOffCta(props: {
     currency: props.currencyId,
   });
 
+  const ctaContext = (props.context ? props.context + '-' : '') +  'one-off';
+
   return (
     <CtaLink
       text={`Contribute ${currencies[props.currencyId].glyph}${props.amount} with card`}
       accessibilityHint="proceed to make your single contribution"
       url={clickUrl}
-      onClick={onCtaClick(props.isDisabled, props.resetError)}
+      onClick={onCtaClick(props.isDisabled, props.resetError, ctaContext)}
       id="qa-contribute-button"
       modifierClasses={['contribute-one-off', 'border']}
     />
@@ -130,6 +137,7 @@ function RegularCta(props: {
   currencyId: IsoCurrency,
   isDisabled: boolean,
   resetError: void => void,
+  context?: string,
 }): Node {
   const frequency = getFrequency(props.contributionType);
   const spokenType = getSpokenType(props.contributionType);
@@ -139,12 +147,14 @@ function RegularCta(props: {
     currency: props.currencyId,
   });
 
+  const ctaContext = (props.context ? props.context + '-' : '') +  'regular';
+
   return (
     <CtaLink
       text={`Contribute ${currencies[props.currencyId].glyph}${props.amount} ${frequency}`}
       accessibilityHint={`proceed to make your ${spokenType} contribution`}
       url={clickUrl}
-      onClick={onCtaClick(props.isDisabled, props.resetError)}
+      onClick={onCtaClick(props.isDisabled, props.resetError, ctaContext)}
       id="qa-contribute-button"
       modifierClasses={['contribute-regular']}
     />

--- a/assets/components/otherProduct/otherProduct.jsx
+++ b/assets/components/otherProduct/otherProduct.jsx
@@ -23,7 +23,7 @@ type PropTypes = {|
   ctaUrl: string,
   ctaAccessibilityHint: string,
   imgType?: ImageType,
-  context?: string,
+  context: string,
 |};
 
 
@@ -47,7 +47,7 @@ export default function OtherProduct(props: PropTypes) {
         text={props.ctaText}
         url={props.ctaUrl}
         accessibilityHint={props.ctaAccessibilityHint}
-        onClick={sendClickedEvent(props.context || '')}
+        onClick={sendClickedEvent(props.context.concat('-cta_link'))}
       />
     </div>
   );
@@ -60,4 +60,5 @@ export default function OtherProduct(props: PropTypes) {
 OtherProduct.defaultProps = {
   modifierClass: '',
   imgType: 'jpg',
+  context: 'component-other-product',
 };

--- a/assets/components/otherProduct/otherProduct.jsx
+++ b/assets/components/otherProduct/otherProduct.jsx
@@ -9,6 +9,7 @@ import GridImage from 'components/gridImage/gridImage';
 
 import { classNameWithModifiers } from 'helpers/utilities';
 import type { ImageType } from 'helpers/theGrid';
+import { sendClickedEvent } from 'helpers/tracking/clickTracking';
 
 // ----- Props ----- //
 
@@ -22,13 +23,13 @@ type PropTypes = {|
   ctaUrl: string,
   ctaAccessibilityHint: string,
   imgType?: ImageType,
+  context?: string,
 |};
 
 
 // ----- Component ----- //
 
 export default function OtherProduct(props: PropTypes) {
-
   return (
     <div className={classNameWithModifiers('component-other-product', [props.modifierClass])}>
       <div className="component-other-product__image">
@@ -46,6 +47,7 @@ export default function OtherProduct(props: PropTypes) {
         text={props.ctaText}
         url={props.ctaUrl}
         accessibilityHint={props.ctaAccessibilityHint}
+        onClick={sendClickedEvent(props.context || '')}
       />
     </div>
   );

--- a/assets/components/patronsEvents/patronsEvents.jsx
+++ b/assets/components/patronsEvents/patronsEvents.jsx
@@ -13,6 +13,7 @@ import { getMemLink, getPatronsLink } from 'helpers/externalLinks';
 
 type PropTypes = {|
   campaignCode?: ?string,
+  context?: string,
 |};
 
 
@@ -32,6 +33,7 @@ export default function PatronsEvents(props: PropTypes) {
         ctaUrl={getPatronsLink(props.campaignCode)}
         ctaAccessibilityHint="Find out more about becoming a Patron"
         imgType="png"
+        context={(props.context ? props.context + '-' : '') +  'patrons'}
       />
       <OtherProduct
         modifierClass="live-events"
@@ -42,6 +44,7 @@ export default function PatronsEvents(props: PropTypes) {
         ctaText="Find out more"
         ctaUrl={getMemLink('events', props.campaignCode)}
         ctaAccessibilityHint="Find out more about Guardian live events"
+        context={(props.context ? props.context + '-' : '') + 'events'}
       />
     </PageSection>
   );

--- a/assets/components/patronsEvents/patronsEvents.jsx
+++ b/assets/components/patronsEvents/patronsEvents.jsx
@@ -13,7 +13,7 @@ import { getMemLink, getPatronsLink } from 'helpers/externalLinks';
 
 type PropTypes = {|
   campaignCode?: ?string,
-  context?: string,
+  context: string,
 |};
 
 
@@ -33,7 +33,7 @@ export default function PatronsEvents(props: PropTypes) {
         ctaUrl={getPatronsLink(props.campaignCode)}
         ctaAccessibilityHint="Find out more about becoming a Patron"
         imgType="png"
-        context={(props.context ? props.context + '-' : '') +  'patrons'}
+        context={props.context.concat('-patrons_cta')}
       />
       <OtherProduct
         modifierClass="live-events"
@@ -44,7 +44,7 @@ export default function PatronsEvents(props: PropTypes) {
         ctaText="Find out more"
         ctaUrl={getMemLink('events', props.campaignCode)}
         ctaAccessibilityHint="Find out more about Guardian live events"
-        context={(props.context ? props.context + '-' : '') + 'events'}
+        context={props.context.concat('-live_events_cta')}
       />
     </PageSection>
   );
@@ -56,4 +56,5 @@ export default function PatronsEvents(props: PropTypes) {
 
 PatronsEvents.defaultProps = {
   campaignCode: null,
+  context: 'patrons-events',
 };

--- a/assets/components/readyToSupport/readyToSupport.jsx
+++ b/assets/components/readyToSupport/readyToSupport.jsx
@@ -14,7 +14,7 @@ import { sendClickedEvent } from 'helpers/tracking/clickTracking';
 type PropTypes = {|
   ctaUrl: string,
   headingSize: HeadingSize,
-  context?: string,
+  context: string,
 |};
 
 
@@ -35,10 +35,15 @@ export default function ReadyToSupport(props: PropTypes) {
           accessibilityHint="See the options for becoming a supporter"
           svg={<SvgChevronUp />}
           modifierClasses={['see-supporter-options']}
-          onClick={sendClickedEvent((props.context ? props.context + '-' : '') + 'supporter-options')}
+          onClick={sendClickedEvent(props.context.concat('-supporter_options_cta'))}
         />
       </div>
     </section>
   );
 
 }
+
+
+ReadyToSupport.defaultProps = {
+  context: 'component-ready-to-support',
+};

--- a/assets/components/readyToSupport/readyToSupport.jsx
+++ b/assets/components/readyToSupport/readyToSupport.jsx
@@ -7,12 +7,14 @@ import React from 'react';
 import CtaLink from 'components/ctaLink/ctaLink';
 import SvgChevronUp from 'components/svgs/chevronUp';
 import Heading, { type HeadingSize } from 'components/heading/heading';
+import { sendClickedEvent } from 'helpers/tracking/clickTracking';
 
 // ----- Props ----- //
 
 type PropTypes = {|
   ctaUrl: string,
   headingSize: HeadingSize,
+  context?: string,
 |};
 
 
@@ -33,6 +35,7 @@ export default function ReadyToSupport(props: PropTypes) {
           accessibilityHint="See the options for becoming a supporter"
           svg={<SvgChevronUp />}
           modifierClasses={['see-supporter-options']}
+          onClick={sendClickedEvent((props.context ? props.context + '-' : '') + 'supporter-options')}
         />
       </div>
     </section>

--- a/assets/components/subscriptionBundles/digitalPack.jsx
+++ b/assets/components/subscriptionBundles/digitalPack.jsx
@@ -58,7 +58,7 @@ function DigitalPack(props: {
   url: string,
   gridId: ImageId,
   abTest: ComponentAbTest | null,
-  context?: string,
+  context: string,
 }) {
   const copy = getCopy(props.countryGroupId);
   return (
@@ -95,6 +95,7 @@ function DigitalPack(props: {
 
 DigitalPack.defaultProps = {
   abTest: null,
+  context: 'digital-subscription',
 };
 
 

--- a/assets/components/subscriptionBundles/digitalPack.jsx
+++ b/assets/components/subscriptionBundles/digitalPack.jsx
@@ -58,6 +58,7 @@ function DigitalPack(props: {
   url: string,
   gridId: ImageId,
   abTest: ComponentAbTest | null,
+  context?: string,
 }) {
   const copy = getCopy(props.countryGroupId);
   return (
@@ -81,7 +82,7 @@ function DigitalPack(props: {
           url: props.url,
           accessibilityHint: 'Find out how to sign up for a free trial of The Guardian\'s digital subscription.',
           modifierClasses: ['border'],
-          onClick: sendTrackingEventsOnClick('digipack_cta', 'DigitalPack', props.abTest),
+          onClick: sendTrackingEventsOnClick('digipack_cta', 'DigitalPack', props.abTest, props.context),
         },
       ]}
     />

--- a/assets/components/subscriptionBundles/paper.jsx
+++ b/assets/components/subscriptionBundles/paper.jsx
@@ -12,6 +12,7 @@ import { flashSaleIsActive } from 'helpers/flashSale';
 type PropTypes = {|
   url: string,
   abTest: ComponentAbTest | null,
+  context?: string,
 |};
 
 
@@ -53,7 +54,7 @@ export default function Paper(props: PropTypes) {
           url: props.url,
           accessibilityHint: 'Proceed to paper subscription options',
           modifierClasses: ['border'],
-          onClick: sendTrackingEventsOnClick('paper_cta', 'Paper', props.abTest),
+          onClick: sendTrackingEventsOnClick('paper_cta', 'Paper', props.abTest, props.context),
         },
       ]}
     />

--- a/assets/components/subscriptionBundles/paper.jsx
+++ b/assets/components/subscriptionBundles/paper.jsx
@@ -12,7 +12,7 @@ import { flashSaleIsActive } from 'helpers/flashSale';
 type PropTypes = {|
   url: string,
   abTest: ComponentAbTest | null,
-  context?: string,
+  context: string,
 |};
 
 
@@ -60,3 +60,7 @@ export default function Paper(props: PropTypes) {
     />
   );
 }
+
+Paper.defaultProps = {
+  context: 'paper-subscription',
+};

--- a/assets/components/subscriptionBundles/paperDigital.jsx
+++ b/assets/components/subscriptionBundles/paperDigital.jsx
@@ -13,7 +13,7 @@ type PropTypes = {|
   url: string,
   abTest: ComponentAbTest | null,
   gridId: 'paperDigitalCirclePink' | 'paperDigitalCircleOrange',
-  context?: string,
+  context: string,
 |};
 
 
@@ -63,3 +63,7 @@ export default function PaperDigital(props: PropTypes) {
     />
   );
 }
+
+PaperDigital.defaultProps = {
+  context: 'paper-and-digital-subscription',
+};

--- a/assets/components/subscriptionBundles/paperDigital.jsx
+++ b/assets/components/subscriptionBundles/paperDigital.jsx
@@ -12,7 +12,8 @@ import { flashSaleIsActive } from 'helpers/flashSale';
 type PropTypes = {|
   url: string,
   abTest: ComponentAbTest | null,
-  gridId: 'paperDigitalCirclePink' | 'paperDigitalCircleOrange'
+  gridId: 'paperDigitalCirclePink' | 'paperDigitalCircleOrange',
+  context?: string,
 |};
 
 
@@ -55,7 +56,7 @@ export default function PaperDigital(props: PropTypes) {
           url: props.url,
           accessibilityHint: 'Proceed to choose which days you would like to regularly receive the newspaper in conjunction with a digital subscription',
           modifierClasses: ['border'],
-          onClick: sendTrackingEventsOnClick('paper_digital_cta', 'PaperAndDigital', props.abTest),
+          onClick: sendTrackingEventsOnClick('paper_digital_cta', 'PaperAndDigital', props.abTest, props.context),
         },
       ]}
 

--- a/assets/helpers/subscriptions.js
+++ b/assets/helpers/subscriptions.js
@@ -195,6 +195,7 @@ function sendTrackingEventsOnClick(
   id: string,
   product: SubscriptionProduct,
   abTest: ComponentAbTest | null,
+  context?: string,
 ): () => void {
 
   const componentEvent = {
@@ -215,7 +216,7 @@ function sendTrackingEventsOnClick(
     gaEvent({
       category: 'click',
       action: product,
-      label: id,
+      label: (context ? context + '-' : '') + id,
     });
 
   };

--- a/assets/helpers/subscriptions.js
+++ b/assets/helpers/subscriptions.js
@@ -216,7 +216,7 @@ function sendTrackingEventsOnClick(
     gaEvent({
       category: 'click',
       action: product,
-      label: (context ? context + '-' : '') + id,
+      label: (context ? context.concat('-') : '').concat(id),
     });
 
   };

--- a/assets/helpers/tracking/clickTracking.js
+++ b/assets/helpers/tracking/clickTracking.js
@@ -2,7 +2,6 @@
 
 // ----- Imports ----- //
 
-import { type ComponentAbTest } from 'helpers/subscriptions';
 import { gaEvent } from './googleTagManager';
 
 
@@ -17,7 +16,7 @@ function sendClickedEvent(
     gaEvent({
       category: 'click',
       action: triggerActivity || 'CLICK',
-      label: label,
+      label,
     });
   };
 

--- a/assets/helpers/tracking/clickTracking.js
+++ b/assets/helpers/tracking/clickTracking.js
@@ -1,0 +1,30 @@
+// @flow
+
+// ----- Imports ----- //
+
+import { type ComponentAbTest } from 'helpers/subscriptions';
+import { gaEvent } from './googleTagManager';
+
+
+// ----- Functions ----- //
+
+function sendClickedEvent(
+  label: string,
+  triggerActivity?: string,
+): () => void {
+
+  return () => {
+    gaEvent({
+      category: 'click',
+      action: triggerActivity || 'CLICK',
+      label: label,
+    });
+  };
+
+}
+
+// ----- Exports ----- //
+
+export {
+  sendClickedEvent,
+};

--- a/assets/pages/support-landing/components/subscriptionsSection.jsx
+++ b/assets/pages/support-landing/components/subscriptionsSection.jsx
@@ -24,6 +24,7 @@ type PropTypes = {|
   countryGroupId: CountryGroupId,
   abParticipations: Participations,
   optimizeExperiments: OptimizeExperiments,
+  context?: string,
 |};
 
 
@@ -61,15 +62,18 @@ function SubscriptionsSection(props: PropTypes) {
         countryGroupId={props.countryGroupId}
         gridId="digitalCirclePink"
         abTest={props.abParticipations}
+        context={props.context}
       />
       <Paper
         url={subsLinks.Paper}
         abTest={props.abParticipations}
+        context={props.context}
       />
       <PaperDigital
         url={subsLinks.PaperAndDigital}
         abTest={props.abParticipations}
         gridId="paperDigitalCircleOrange"
+        context={props.context}
       />
     </ThreeSubscriptions>
   );

--- a/assets/pages/support-landing/components/subscriptionsSection.jsx
+++ b/assets/pages/support-landing/components/subscriptionsSection.jsx
@@ -24,7 +24,7 @@ type PropTypes = {|
   countryGroupId: CountryGroupId,
   abParticipations: Participations,
   optimizeExperiments: OptimizeExperiments,
-  context?: string,
+  context: string,
 |};
 
 
@@ -80,6 +80,10 @@ function SubscriptionsSection(props: PropTypes) {
 
 }
 
+
+SubscriptionsSection.defaultProps = {
+  context: 'subscriptions-section',
+};
 
 // ----- Exports ----- //
 

--- a/assets/pages/support-landing/supportLanding.jsx
+++ b/assets/pages/support-landing/supportLanding.jsx
@@ -52,6 +52,8 @@ const CountrySwitcherHeader = CountrySwitcherHeaderContainer(
 
 // ----- Render ----- //
 
+const context = 'support-landing-page';
+
 const content = (
   <Provider store={store}>
     <Page
@@ -73,19 +75,25 @@ const content = (
           <ContributionSelectionContainer />
           <ContributionAwarePaymentLogosContainer />
           <ContributionPaymentCtasContainer
+            context={context}
             PayPalButton={() =>
               <PayPalContributionButtonContainer cancelURL={`${getOrigin()}/uk`} />
           }
           />
         </Contribute>
-        <SubscriptionsSection />
+        <SubscriptionsSection
+          context={context}
+        />
       </section>
       <WhySupport headingSize={3} />
       <ReadyToSupport
         ctaUrl={`#${supporterSectionId}`}
         headingSize={2}
+        context={context}
       />
-      <PatronsEventsContainer />
+      <PatronsEventsContainer
+        context={context}
+      />
     </Page>
   </Provider>
 );


### PR DESCRIPTION
## Why are you doing this?
We want to know how people are engaging with the showcase page, and to do that we'll need to know a bit more of the context behind the clicks.

This change prefixes the GA tracked label with some information about which page the button was on when it was clicked, and adds a couple of new event calls for elements that previously had none.

We can measure engagement with these controls via the labels applied in the GA events as follows;
* Supporter Options
  * `support-landing-page-supporter_options_cta`
* Subscribe
  * Digi-pack
    * `support-landing-page-digipack_cta`
  * Paper
    * `support-landing-page-paper_cta`
  * Paper+Digital
    * `support-landing-page-paper_digital_cta`
* Contribute
  * One-off
    * `support-landing-page-one_off_cta`
  * Recurring
    * `support-landing-page-regular_cta`
* Patrons
  * `support-landing-page-patrons_cta-cta_link`
* Live Events / Masterclasses
  * `support-landing-page-live_events_cta-cta_link`
 
[**Trello Card**](https://trello.com/c/8cHAoqso/2031-analytics-updates-for-showcase-page)

## Screenshots

There's absolutely nothing to see that's any different as a result of this.

