### PR TITLE
scripts to make setup easier

### DIFF
--- a/devrun.sh
+++ b/devrun.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+yarn devrun &
+sbt devrun

--- a/fetch-config.sh
+++ b/fetch-config.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+aws s3 cp s3://membership-private/DEV/support-frontend.private.conf \
+  /etc/gu/support-frontend.private.conf \
+  --profile membership

--- a/fetch-config.sh
+++ b/fetch-config.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/env bash
 
-aws s3 cp s3://membership-private/DEV/support-frontend.private.conf \
-  /etc/gu/support-frontend.private.conf \
-  --profile membership
+CONFIG_DIR=/etc/gu
+
+if [[ -w ${CONFIG_DIR} ]]; then
+  aws s3 cp s3://membership-private/DEV/support-frontend.private.conf \
+    ${CONFIG_DIR}/support-frontend.private.conf \
+    --profile membership
+else
+  echo "ERROR! Cannot write to ${CONFIG_DIR}. Check it exists and you have write permissions to it.";
+  echo "  'sudo chown -R $(whoami):admin ${CONFIG_DIR}' will make you the owner of ${CONFIG_DIR}";
+fi

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -e
+
+readonly SYSTEM=$(uname -s)
+EXTRA_STEPS=()
+
+linux() {
+  [[ ${SYSTEM} == 'Linux' ]]
+}
+
+mac() {
+  [[ ${SYSTEM} == 'Darwin' ]]
+}
+
+installed() {
+  hash "$1" 2>/dev/null
+}
+
+nvm_installed() {
+  if [ -d '/usr/local/opt/nvm' ] || [ -d "$HOME/.nvm" ]; then
+    true
+  else
+    false
+  fi
+}
+
+nvm_available() {
+  type -t nvm > /dev/null
+}
+
+source_nvm() {
+  if ! nvm_available; then
+    [ -e "/usr/local/opt/nvm/nvm.sh" ] && source /usr/local/opt/nvm/nvm.sh
+  fi
+  if ! nvm_available; then
+    [ -e "$HOME/.nvm/nvm.sh" ] && source $HOME/.nvm/nvm.sh
+  fi
+}
+
+check_encryption() {
+  if linux; then
+    EXTRA_STEPS+=("Sorry, can't check if your hard disk is encrypted - please ensure that it is! (applies to both portable and Desktop machines)")
+  elif mac; then
+    if [[ "$(fdesetup status)" != "FileVault is On." ]]; then
+      EXTRA_STEPS+=("your hard disk is not encrypted! Encryption must be enabled on all guardian machines. Follow these instructions: https://support.apple.com/en-gb/HT204837")
+    fi
+  fi
+}
+
+create_aws_config() {
+  local path="$HOME/.aws"
+  local filename="config"
+
+  if [[ ! -f "$path/$filename" ]]; then
+    if [[ ! -d "$path" ]]; then
+      mkdir "$path"
+    fi
+
+    echo "[profile membership]
+region = eu-west-1" > "$path/$filename"
+  fi
+}
+
+install_homebrew() {
+  if mac && ! installed brew; then
+    ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+  fi
+}
+
+install_jdk() {
+  if ! installed javac; then
+    if linux; then
+      sudo apt-get install -y openjdk-8-jdk
+    elif mac; then
+      EXTRA_STEPS+=("Download the JDK from http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html")
+    fi
+  fi
+}
+
+install_node() {
+  if ! nvm_installed; then
+    if linux; then
+      if ! installed curl; then
+        sudo apt-get install -y curl
+      fi
+    fi
+
+    curl -o- https://raw.githubusercontent.com/creationix/nvm/v0.33.8/install.sh | bash
+    nvm install
+    EXTRA_STEPS+=("Add https://git.io/vKTnK to your .bash_profile")
+  else
+    if ! nvm_available; then
+      source_nvm
+    fi
+    nvm install
+  fi
+}
+
+install_nginx() {
+  if ! installed nginx; then
+    brew install nginx
+  fi
+}
+
+install_awscli() {
+  if ! installed aws; then
+    brew install awscli
+  fi
+}
+
+install_sbt() {
+  if ! installed sbt; then
+    brew install sbt@1
+  fi
+}
+
+install_yarn() {
+  npm install -g yarn
+}
+
+install_js_deps() {
+  yarn install
+}
+
+report() {
+  if [[ ${#EXTRA_STEPS[@]} -gt 0 ]]; then
+    for i in "${!EXTRA_STEPS[@]}"; do
+      echo "  $((i+1)). ${EXTRA_STEPS[$i]}"
+    done
+  fi
+}
+
+main () {
+  check_encryption
+  create_aws_config
+  install_homebrew
+  install_nginx
+  install_awscli
+  install_jdk
+  install_sbt
+  install_node
+  install_js_deps
+  report
+}
+
+main

--- a/setup.sh
+++ b/setup.sh
@@ -148,6 +148,7 @@ report() {
 main () {
   check_encryption
   create_aws_config
+  install_node
   install_homebrew
   install_nginx
   install_awscli
@@ -155,7 +156,6 @@ main () {
   copy_nginx_config
   install_jdk
   install_sbt
-  install_node
   install_yarn
   install_js_deps
   report

--- a/setup.sh
+++ b/setup.sh
@@ -115,7 +115,13 @@ install_sbt() {
 }
 
 install_yarn() {
-  npm install -g yarn
+  if ! installed yarn; then
+    if linux; then
+      sudo apt-get install yarn
+    elif mac; then
+      brew install yarn
+    fi
+  fi
 }
 
 install_js_deps() {
@@ -139,6 +145,7 @@ main () {
   install_jdk
   install_sbt
   install_node
+  install_yarn
   install_js_deps
   report
 }

--- a/setup.sh
+++ b/setup.sh
@@ -129,9 +129,12 @@ install_js_deps() {
 }
 
 fetch_dev_cert() {
-  aws s3 cp s3://gu-reader-revenue-private/subscriptions/frontend/DEV/subscriptions-frontend.private.conf \
-    /etc/gu  \
-    --profile membership
+  aws s3 cp s3://identity-local-ssl/wildcard-thegulocal-com-exp2019-01-09.crt /usr/local/etc/nginx/ --profile membership
+  aws s3 cp s3://identity-local-ssl/wildcard-thegulocal-com-exp2019-01-09.key /usr/local/etc/nginx/ --profile membership
+}
+
+copy_nginx_config() {
+  ln -s ../nginx/support.conf /usr/local/etc/nginx/sites-enabled/support.conf
 }
 
 report() {
@@ -149,6 +152,7 @@ main () {
   install_nginx
   install_awscli
   fetch_dev_cert
+  copy_nginx_config
   install_jdk
   install_sbt
   install_node

--- a/setup.sh
+++ b/setup.sh
@@ -128,6 +128,12 @@ install_js_deps() {
   yarn install
 }
 
+fetch_dev_cert() {
+  aws s3 cp s3://gu-reader-revenue-private/subscriptions/frontend/DEV/subscriptions-frontend.private.conf \
+    /etc/gu  \
+    --profile membership
+}
+
 report() {
   if [[ ${#EXTRA_STEPS[@]} -gt 0 ]]; then
     for i in "${!EXTRA_STEPS[@]}"; do
@@ -142,6 +148,7 @@ main () {
   install_homebrew
   install_nginx
   install_awscli
+  fetch_dev_cert
   install_jdk
   install_sbt
   install_node

--- a/setup.sh
+++ b/setup.sh
@@ -4,6 +4,8 @@ set -e
 readonly SYSTEM=$(uname -s)
 EXTRA_STEPS=()
 
+NGINX_ROOT=/usr/local/etc/nginx/
+
 linux() {
   [[ ${SYSTEM} == 'Linux' ]]
 }
@@ -72,7 +74,7 @@ install_jdk() {
     if linux; then
       sudo apt-get install -y openjdk-8-jdk
     elif mac; then
-      EXTRA_STEPS+=("Download the JDK from http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html")
+      EXTRA_STEPS+=("Download the JDK from https://adoptopenjdk.net")
     fi
   fi
 }
@@ -99,6 +101,7 @@ install_node() {
 install_nginx() {
   if ! installed nginx; then
     brew install nginx
+    EXTRA_STEPS+=("nginx has been installed. Ensure you have 'include sites-enabled/*' in your nginx configuration ${NGINX_ROOT}/nginx.conf and add '127.0.0.1 support.thegulocal.com' to /etc/hosts")
   fi
 }
 
@@ -129,12 +132,12 @@ install_js_deps() {
 }
 
 fetch_dev_cert() {
-  aws s3 cp s3://identity-local-ssl/wildcard-thegulocal-com-exp2019-01-09.crt /usr/local/etc/nginx/ --profile membership
-  aws s3 cp s3://identity-local-ssl/wildcard-thegulocal-com-exp2019-01-09.key /usr/local/etc/nginx/ --profile membership
+  aws s3 cp s3://identity-local-ssl/wildcard-thegulocal-com-exp2019-01-09.crt ${NGINX_ROOT} --profile membership
+  aws s3 cp s3://identity-local-ssl/wildcard-thegulocal-com-exp2019-01-09.key ${NGINX_ROOT} --profile membership
 }
 
-copy_nginx_config() {
-  ln -s ../nginx/support.conf /usr/local/etc/nginx/sites-enabled/support.conf
+link_nginx_config() {
+  ln -sf ../nginx/support.conf ${NGINX_ROOT}sites-enabled/support.conf
 }
 
 report() {
@@ -153,7 +156,7 @@ main () {
   install_nginx
   install_awscli
   fetch_dev_cert
-  copy_nginx_config
+  link_nginx_config
   install_jdk
   install_sbt
   install_yarn


### PR DESCRIPTION
## Why are you doing this?
This is to make the project slightly easier to setup and run, ideally to empower the our ux+d and product colleagues to make changes. Essentially, scripting [these instructions](https://github.com/guardian/support-frontend/wiki/Install).

Ideally the process is:
- clone repo
- run `setup.sh`
- run `fetch-config.sh`
- run `devrun.sh`

Then, going forward, `devrun.sh` is all that's needed to run the project. 🤞

Inspired by https://github.com/guardian/frontend/blob/master/setup.sh.

![img](https://media.giphy.com/media/UyWXNumwNvXmE/giphy.gif)

TODO:
- [x] add a note to ensure `include sites-enabled/*` is in the main nginx config
- [x] ensure using the correct version of node by running `nvm use` first
- [x] `sudo chown -R $(whoami):admin /etc/gu` to change ownership of `/etc/gu` to current user
- [x] add a note to update `/etc/hosts` with an entry for `127.0.0.1 support.thegulocal.com`