### PR TITLE
Digital Checkout Payment Frequency, Method and Styling

### DIFF
--- a/assets/components/checkoutCopy/checkoutCopy.jsx
+++ b/assets/components/checkoutCopy/checkoutCopy.jsx
@@ -1,0 +1,30 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+
+// ----- Types ----- //
+
+type PropTypes = {|
+  strong: string,
+  copy: string,
+|};
+
+
+// ----- Component ----- //
+
+function CheckoutCopy(props: PropTypes) {
+  return (
+    <p className="component-checkout-copy">
+      <strong className="component-checkout-copy__strong">{props.strong}</strong>
+      {props.copy}
+    </p>
+  );
+}
+
+
+// ----- Exports ----- //
+
+export default CheckoutCopy;

--- a/assets/components/checkoutCopy/checkoutCopy.scss
+++ b/assets/components/checkoutCopy/checkoutCopy.scss
@@ -1,0 +1,14 @@
+.component-checkout-copy {
+  @include gu-fontset-body;
+
+  margin-top: $gu-v-spacing * 2;
+  width: calc(100vw - 20px);
+
+  @include mq($from: mobileMedium) {
+    width: 340px;
+  }
+}
+
+.component-checkout-copy__strong {
+  font-weight: bold;
+}

--- a/assets/components/checkoutHeading/checkoutHeading.jsx
+++ b/assets/components/checkoutHeading/checkoutHeading.jsx
@@ -1,0 +1,36 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
+
+
+// ----- Types ----- //
+
+type PropTypes = {|
+  heading: string,
+  copy: string,
+|};
+
+
+// ----- Component ----- //
+
+function CheckoutHeading(props: PropTypes) {
+
+  return (
+    <div className="component-checkout-heading">
+      <LeftMarginSection>
+        <h1 className="component-checkout-heading__heading">{props.heading}</h1>
+        <p className="component-checkout-heading__copy">{props.copy}</p>
+      </LeftMarginSection>
+    </div>
+  );
+
+}
+
+
+// ----- Export ----- //
+
+export default CheckoutHeading;

--- a/assets/components/checkoutHeading/checkoutHeading.scss
+++ b/assets/components/checkoutHeading/checkoutHeading.scss
@@ -19,4 +19,6 @@
 
 .component-checkout-heading__copy {
   @include gu-fontset-body-sans;
+
+  color: gu-colour(news-garnett-highlight);
 }

--- a/assets/components/checkoutHeading/checkoutHeading.scss
+++ b/assets/components/checkoutHeading/checkoutHeading.scss
@@ -11,9 +11,10 @@
 .component-checkout-heading__heading {
   @include gu-fontset-heading-large;
   margin-bottom: $gu-v-spacing * 3;
+  width: 300px;
 
   @include mq($from: tablet) {
-    width: 580px;
+    width: 500px;
   }
 }
 

--- a/assets/components/checkoutHeading/checkoutHeading.scss
+++ b/assets/components/checkoutHeading/checkoutHeading.scss
@@ -11,10 +11,10 @@
 .component-checkout-heading__heading {
   @include gu-fontset-heading-large;
   margin-bottom: $gu-v-spacing * 3;
-  width: 300px;
+  width: gu-span(4);
 
   @include mq($from: tablet) {
-    width: 500px;
+    width: gu-span(6);
   }
 }
 

--- a/assets/components/checkoutHeading/checkoutHeading.scss
+++ b/assets/components/checkoutHeading/checkoutHeading.scss
@@ -1,0 +1,22 @@
+.component-checkout-heading {
+  color: #fff;
+
+  .component-left-margin-section__content {
+    background-color: gu-colour(garnett-neutral-1);
+    padding: 0 0 4px ($gu-h-spacing / 2);
+  }
+
+}
+
+.component-checkout-heading__heading {
+  @include gu-fontset-heading-large;
+  margin-bottom: $gu-v-spacing * 3;
+
+  @include mq($from: tablet) {
+    width: 580px;
+  }
+}
+
+.component-checkout-heading__copy {
+  @include gu-fontset-body-sans;
+}

--- a/assets/components/forms/customFields/radioInput.scss
+++ b/assets/components/forms/customFields/radioInput.scss
@@ -7,7 +7,7 @@
   position: relative;
 
   &:hover {
-    .component-radio-input__text:before {
+    .component-radio-input__text::before {
       border-color: gu-colour(garnett-neutral-2);
     }
   }
@@ -26,7 +26,7 @@
   left: 0;
 }
 
-.component-radio-input__text:before {
+.component-radio-input__text::before {
   display: inline-block;
   vertical-align: top;
   content: '';
@@ -38,7 +38,7 @@
   margin-right: 5px;
 }
 
-.component-radio-input__input:checked + .component-radio-input__text:before {
+.component-radio-input__input:checked + .component-radio-input__text::before {
   background-color: gu-colour(green-dark);
   border-color: gu-colour(green-dark);
 }

--- a/assets/components/forms/customFields/radioInput.scss
+++ b/assets/components/forms/customFields/radioInput.scss
@@ -1,6 +1,5 @@
 .component-radio-input {
   display: block;
-  width: 318px;
   font-size: 16px;
   font-family: $gu-text-sans-web;
   cursor: pointer;

--- a/assets/components/forms/customFields/radioInput.scss
+++ b/assets/components/forms/customFields/radioInput.scss
@@ -3,22 +3,43 @@
   width: 318px;
   font-size: 16px;
   font-family: $gu-text-sans-web;
-  padding: ($gu-v-spacing / 2) ($gu-h-spacing / 2);
   cursor: pointer;
-  margin-bottom: $gu-v-spacing;
+  margin-top: $gu-v-spacing;
+  position: relative;
+
+  &:hover {
+    .component-radio-input__text:before {
+      border-color: gu-colour(garnett-neutral-2);
+    }
+  }
 }
 
 .component-radio-input__text {
-  margin-left: ($gu-h-spacing / 2);
   font-weight: bold;
 }
 
 .component-radio-input__input {
-  margin-top: -1px;
-  vertical-align: middle;
-  transition: box-shadow .2s;
+  position: absolute;
+  opacity: 0;
+  height: 0;
+  width: 0;
+  top: 0;
+  left: 0;
+}
 
-  &:hover {
-    box-shadow: 0 0 0 2px lighten(gu-colour(garnett-neutral-4), 6%);
-  }
+.component-radio-input__text:before {
+  display: inline-block;
+  vertical-align: top;
+  content: '';
+  width: 18px;
+  height: 18px;
+  border: 1px solid gu-colour(garnett-neutral-4);
+  box-shadow: inset 0 0 0 3px #fff;
+  border-radius: 60px;
+  margin-right: 5px;
+}
+
+.component-radio-input__input:checked + .component-radio-input__text:before {
+  background-color: gu-colour(green-dark);
+  border-color: gu-colour(green-dark);
 }

--- a/assets/components/forms/formHOCs/withArrow.jsx
+++ b/assets/components/forms/formHOCs/withArrow.jsx
@@ -1,0 +1,28 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+import SvgArrowRightStraight from 'components/svgs/arrowRightStraight';
+
+
+// ----- Component ----- //
+
+function withArrow<Props: { children: React$Node }>(Component: React$ComponentType<Props>): React$ComponentType<Props> {
+
+  return ({ children, ...otherProps }: Props) => (
+    <div className="component-with-arrow">
+      <Component {...otherProps}>
+        {children}
+        <SvgArrowRightStraight />
+      </Component>
+    </div>
+  );
+
+}
+
+
+// ----- Exports ----- //
+
+export { withArrow };

--- a/assets/components/forms/formHOCs/withArrow.scss
+++ b/assets/components/forms/formHOCs/withArrow.scss
@@ -1,0 +1,9 @@
+.component-with-arrow {
+  .svg-arrow-right-straight {
+    height: 45%;
+    display: inline-block;
+    vertical-align: top;
+    margin-left: 16px;
+    margin-right: -10px;
+  }
+}

--- a/assets/components/forms/formHOCs/withError.scss
+++ b/assets/components/forms/formHOCs/withError.scss
@@ -1,9 +1,13 @@
 .component-error {
   display: block;
-  width: 324px;
+  width: calc(100vw - 36px);
   background-color: transparentize(gu-colour(news-garnett-media-main-1), 0.7);
   font-size: 16px;
   font-family: $gu-text-sans-web;
   padding-left: 8px;
   padding-right: 8px;
+
+  @include mq($from: mobileMedium) {
+    width: 324px;
+  }
 }

--- a/assets/components/forms/standardFields/button.scss
+++ b/assets/components/forms/standardFields/button.scss
@@ -8,6 +8,8 @@
   border: none;
   border-radius: 600px;
   cursor: pointer;
+  margin-top: $gu-v-spacing * 2;
+  transition: background-color .2s;
 
   &:hover {
     background-color: gu-colour(highlight-dark);

--- a/assets/components/forms/standardFields/input.scss
+++ b/assets/components/forms/standardFields/input.scss
@@ -6,5 +6,9 @@
   min-height: 38px;
   padding-left: 12px;
   padding-right: 12px;
-  width: 314px;
+  width: calc(100vw - 44px);
+
+  @include mq($from: mobileMedium) {
+    width: 314px;
+  }
 }

--- a/assets/components/forms/standardFields/input.scss
+++ b/assets/components/forms/standardFields/input.scss
@@ -6,7 +6,7 @@
   min-height: 38px;
   padding-left: 12px;
   padding-right: 12px;
-  width: calc(100vw - 44px);
+  width: calc(100vw - 46px);
 
   @include mq($from: mobileMedium) {
     width: 314px;

--- a/assets/components/forms/standardFields/select.scss
+++ b/assets/components/forms/standardFields/select.scss
@@ -6,7 +6,7 @@
   height: 42px;
   padding-left: 8px;
   padding-right: 8px;
-  width: calc(100vw - 16px);
+  width: calc(100vw - 20px);
   appearance: none;
   background-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 19 10"><path d="M1.25.5l-.75.75L9 9.5h.95l8.55-8.25-.75-.75L9.5 7.25z" /></svg>');
   background-repeat: no-repeat;

--- a/assets/components/forms/standardFields/select.scss
+++ b/assets/components/forms/standardFields/select.scss
@@ -6,5 +6,15 @@
   height: 42px;
   padding-left: 8px;
   padding-right: 8px;
-  width: 340px;
+  width: calc(100vw - 16px);
+  appearance: none;
+  background-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 19 10"><path d="M1.25.5l-.75.75L9 9.5h.95l8.55-8.25-.75-.75L9.5 7.25z" /></svg>');
+  background-repeat: no-repeat;
+  background-position: right 10px top 15px;
+  background-size: 20px;
+
+  @include mq($from: mobileMedium) {
+    width: 340px;
+  }
+
 }

--- a/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -14,6 +14,7 @@ import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
 import { Input } from 'components/forms/standardFields/input';
 import { Select } from 'components/forms/standardFields/select';
 import { Fieldset } from 'components/forms/standardFields/fieldset';
+import { Button } from 'components/forms/standardFields/button';
 import { sortedOptions } from 'components/forms/customFields/sortedOptions';
 import { RadioInput } from 'components/forms/customFields/radioInput';
 import { withLabel } from 'components/forms/formHOCs/withLabel';
@@ -157,7 +158,7 @@ function CheckoutForm(props: PropTypes) {
             onChange={() => props.setPaymentMethod('card')}
           />
         </Fieldset>
-        <button onClick={() => props.submitForm()}>Submit</button>
+        <Button onClick={() => props.submitForm()}>Submit</Button>
       </LeftMarginSection>
     </div>
   );

--- a/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -12,7 +12,9 @@ import { type Option } from 'helpers/types/option';
 
 import { Input } from 'components/forms/standardFields/input';
 import { Select } from 'components/forms/standardFields/select';
+import { Fieldset } from 'components/forms/standardFields/fieldset';
 import { sortedOptions } from 'components/forms/customFields/sortedOptions';
+import { RadioInput } from 'components/forms/customFields/radioInput';
 import { withLabel } from 'components/forms/formHOCs/withLabel';
 import { withError } from 'components/forms/formHOCs/withError';
 import { asControlled } from 'components/forms/formHOCs/asControlled';
@@ -118,6 +120,20 @@ function CheckoutForm(props: PropTypes) {
         setValue={props.setTelephone}
         error={firstError('telephone', props.errors)}
       />
+      <Fieldset>
+        <RadioInput
+          text="£11.99 Every month"
+          name="paymentFrequency"
+          checked={props.paymentFrequency === 'monthly'}
+          onChange={() => props.setPaymentFrequency('monthly')}
+        />
+        <RadioInput
+          text="£119.90 Every year"
+          name="paymentFrequency"
+          checked={props.paymentFrequency === 'yearly'}
+          onChange={() => props.setPaymentFrequency('yearly')}
+        />
+      </Fieldset>
       <button onClick={() => props.submitForm()}>Submit</button>
     </div>
   );

--- a/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -143,6 +143,20 @@ function CheckoutForm(props: PropTypes) {
       </LeftMarginSection>
       <LeftMarginSection>
         <h2 className="checkout-form__heading">How would you like to pay?</h2>
+        <Fieldset>
+          <RadioInput
+            text="Direct debit"
+            name="paymentMethod"
+            checked={props.paymentMethod === 'directDebit'}
+            onChange={() => props.setPaymentMethod('directDebit')}
+          />
+          <RadioInput
+            text="Credit/Debit card"
+            name="paymentMethod"
+            checked={props.paymentMethod === 'card'}
+            onChange={() => props.setPaymentMethod('card')}
+          />
+        </Fieldset>
         <button onClick={() => props.submitForm()}>Submit</button>
       </LeftMarginSection>
     </div>

--- a/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -10,6 +10,7 @@ import { countries, usStates, caStates, type IsoCountry } from 'helpers/internat
 import { type FormError, firstError } from 'helpers/subscriptionsForms/validation';
 import { type Option } from 'helpers/types/option';
 
+import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
 import { Input } from 'components/forms/standardFields/input';
 import { Select } from 'components/forms/standardFields/select';
 import { Fieldset } from 'components/forms/standardFields/fieldset';
@@ -74,67 +75,76 @@ function statesForCountry(country: Option<IsoCountry>): React$Node {
 function CheckoutForm(props: PropTypes) {
 
   return (
-    <div>
-      <Input1
-        id="first-name"
-        label="First name"
-        type="text"
-        value={props.firstName}
-        setValue={props.setFirstName}
-        error={firstError('firstName', props.errors)}
-      />
-      <Input1
-        id="last-name"
-        label="Last name"
-        type="text"
-        value={props.lastName}
-        setValue={props.setLastName}
-        error={firstError('lastName', props.errors)}
-      />
-      <Select1
-        id="country"
-        label="Country"
-        value={props.country}
-        setValue={props.setCountry}
-        error={firstError('country', props.errors)}
-      >
-        <option value="">--</option>
-        {sortedOptions(countries)}
-      </Select1>
-      <Select2
-        id="stateProvince"
-        label={props.country === 'CA' ? 'Province/Territory' : 'State'}
-        value={props.stateProvince}
-        setValue={props.setStateProvince}
-        error={firstError('stateProvince', props.errors)}
-        isShown={props.country === 'US' || props.country === 'CA'}
-      >
-        <option value="">--</option>
-        {statesForCountry(props.country)}
-      </Select2>
-      <Input1
-        id="telephone"
-        label="Telephone (optional)"
-        type="tel"
-        value={props.telephone}
-        setValue={props.setTelephone}
-        error={firstError('telephone', props.errors)}
-      />
-      <Fieldset>
-        <RadioInput
-          text="£11.99 Every month"
-          name="paymentFrequency"
-          checked={props.paymentFrequency === 'monthly'}
-          onChange={() => props.setPaymentFrequency('monthly')}
+    <div className="checkout-form">
+      <LeftMarginSection modifierClasses={['your-details']}>
+        <h2 className="checkout-form__heading">Your details</h2>
+        <Input1
+          id="first-name"
+          label="First name"
+          type="text"
+          value={props.firstName}
+          setValue={props.setFirstName}
+          error={firstError('firstName', props.errors)}
         />
-        <RadioInput
-          text="£119.90 Every year"
-          name="paymentFrequency"
-          checked={props.paymentFrequency === 'yearly'}
-          onChange={() => props.setPaymentFrequency('yearly')}
+        <Input1
+          id="last-name"
+          label="Last name"
+          type="text"
+          value={props.lastName}
+          setValue={props.setLastName}
+          error={firstError('lastName', props.errors)}
         />
-      </Fieldset>
-      <button onClick={() => props.submitForm()}>Submit</button>
+        <Select1
+          id="country"
+          label="Country"
+          value={props.country}
+          setValue={props.setCountry}
+          error={firstError('country', props.errors)}
+        >
+          <option value="">--</option>
+          {sortedOptions(countries)}
+        </Select1>
+        <Select2
+          id="stateProvince"
+          label={props.country === 'CA' ? 'Province/Territory' : 'State'}
+          value={props.stateProvince}
+          setValue={props.setStateProvince}
+          error={firstError('stateProvince', props.errors)}
+          isShown={props.country === 'US' || props.country === 'CA'}
+        >
+          <option value="">--</option>
+          {statesForCountry(props.country)}
+        </Select2>
+        <Input1
+          id="telephone"
+          label="Telephone (optional)"
+          type="tel"
+          value={props.telephone}
+          setValue={props.setTelephone}
+          error={firstError('telephone', props.errors)}
+        />
+      </LeftMarginSection>
+      <LeftMarginSection>
+        <h2 className="checkout-form__heading">How often would you like to pay?</h2>
+        <Fieldset>
+          <RadioInput
+            text="£11.99 Every month"
+            name="paymentFrequency"
+            checked={props.paymentFrequency === 'monthly'}
+            onChange={() => props.setPaymentFrequency('monthly')}
+          />
+          <RadioInput
+            text="£119.90 Every year"
+            name="paymentFrequency"
+            checked={props.paymentFrequency === 'yearly'}
+            onChange={() => props.setPaymentFrequency('yearly')}
+          />
+        </Fieldset>
+      </LeftMarginSection>
+      <LeftMarginSection>
+        <h2 className="checkout-form__heading">How would you like to pay?</h2>
+        <button onClick={() => props.submitForm()}>Submit</button>
+      </LeftMarginSection>
     </div>
   );
 

--- a/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -21,6 +21,7 @@ import { RadioInput } from 'components/forms/customFields/radioInput';
 import { withLabel } from 'components/forms/formHOCs/withLabel';
 import { withError } from 'components/forms/formHOCs/withError';
 import { asControlled } from 'components/forms/formHOCs/asControlled';
+import { withArrow } from 'components/forms/formHOCs/withArrow';
 import { canShow } from 'components/forms/formHOCs/canShow';
 
 import {
@@ -57,6 +58,7 @@ function mapStateToProps(state: State) {
 const Input1 = compose(asControlled, withError, withLabel)(Input);
 const Select1 = compose(asControlled, withError, withLabel)(Select);
 const Select2 = canShow(Select1);
+const Button1 = withArrow(Button);
 
 function statesForCountry(country: Option<IsoCountry>): React$Node {
 
@@ -167,7 +169,7 @@ function CheckoutForm(props: PropTypes) {
           strong="Cancel any time you want. "
           copy="There is no set time on your agreement so you can stop your subscription anytime."
         />
-        <Button onClick={() => props.submitForm()}>Submit</Button>
+        <Button1 onClick={() => props.submitForm()}>Continue to payment</Button1>
       </LeftMarginSection>
     </div>
   );

--- a/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -11,6 +11,7 @@ import { type FormError, firstError } from 'helpers/subscriptionsForms/validatio
 import { type Option } from 'helpers/types/option';
 
 import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
+import CheckoutCopy from 'components/checkoutCopy/checkoutCopy';
 import { Input } from 'components/forms/standardFields/input';
 import { Select } from 'components/forms/standardFields/select';
 import { Fieldset } from 'components/forms/standardFields/fieldset';
@@ -158,6 +159,14 @@ function CheckoutForm(props: PropTypes) {
             onChange={() => props.setPaymentMethod('card')}
           />
         </Fieldset>
+        <CheckoutCopy
+          strong="Money Back Guarantee "
+          copy="If you wish to cancel your subscription, we will send you a refund of the unexpired part of your subscription."
+        />
+        <CheckoutCopy
+          strong="Cancel any time you want. "
+          copy="There is no set time on your agreement so you can stop your subscription anytime."
+        />
         <Button onClick={() => props.submitForm()}>Submit</Button>
       </LeftMarginSection>
     </div>

--- a/assets/pages/digital-subscription-checkout/components/checkoutStage.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutStage.jsx
@@ -125,7 +125,7 @@ function CheckoutStage(props: PropTypes) {
             copy="Cancel your subscription at any time"
           />
           <LeftMarginSection modifierClasses={['free-trial']}>
-            <p className="free-trial__copy">
+            <p className="checkout-content__free-trial">
               You can use all the features free for the next 14 days,
               and then your first payment will be taken.
             </p>

--- a/assets/pages/digital-subscription-checkout/components/checkoutStage.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutStage.jsx
@@ -12,6 +12,7 @@ import ProductHero, {
   type GridImages,
   type ImagesByCountry,
 } from 'components/productHero/productHero';
+import CheckoutHeading from 'components/checkoutHeading/checkoutHeading';
 
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
@@ -119,6 +120,10 @@ function CheckoutStage(props: PropTypes) {
     default:
       return (
         <div className="checkout-content">
+          <CheckoutHeading
+            heading="Digital Pack Subscription"
+            copy="Cancel your subscription at any time"
+          />
           <LeftMarginSection modifierClasses={['free-trial']}>
             <p className="free-trial__copy">
               You can use all the features free for the next 14 days,

--- a/assets/pages/digital-subscription-checkout/components/checkoutStage.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutStage.jsx
@@ -118,9 +118,15 @@ function CheckoutStage(props: PropTypes) {
     case 'checkout':
     default:
       return (
-        <LeftMarginSection>
+        <div className="checkout-content">
+          <LeftMarginSection modifierClasses={['free-trial']}>
+            <p className="free-trial__copy">
+              You can use all the features free for the next 14 days,
+              and then your first payment will be taken.
+            </p>
+          </LeftMarginSection>
           <CheckoutForm />
-        </LeftMarginSection>
+        </div>
       );
 
   }

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss
@@ -19,6 +19,7 @@
 @import '~components/productHero/productHero';
 @import '~components/forms/standardFields/input';
 @import '~components/forms/standardFields/select';
+@import '~components/forms/customFields/radioInput';
 @import '~components/forms/formHOCs/withLabel';
 @import '~components/forms/formHOCs/withError';
 

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss
@@ -20,6 +20,7 @@
 @import '~components/productHero/productHero';
 @import '~components/forms/standardFields/input';
 @import '~components/forms/standardFields/select';
+@import '~components/forms/standardFields/button';
 @import '~components/forms/customFields/radioInput';
 @import '~components/forms/formHOCs/withLabel';
 @import '~components/forms/formHOCs/withError';

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss
@@ -12,6 +12,7 @@
 @import '~components/headers/simpleHeader/simpleHeader';
 @import '~components/leftMarginSection/leftMarginSection';
 @import '~components/checkoutHeading/checkoutHeading';
+@import '~components/checkoutCopy/checkoutCopy';
 @import '~components/customerService/customerService';
 @import '~components/subscriptionFaq/subscriptionFaq';
 @import '~components/legal/subscriptionTermsPrivacy/subscriptionTermsPrivacy';

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss
@@ -25,6 +25,7 @@
 @import '~components/forms/customFields/radioInput';
 @import '~components/forms/formHOCs/withLabel';
 @import '~components/forms/formHOCs/withError';
+@import '~components/forms/formHOCs/withArrow';
 
 
 // ----- Page-Specific Styles ----- //

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss
@@ -11,6 +11,7 @@
 @import '~components/footer/footer';
 @import '~components/headers/simpleHeader/simpleHeader';
 @import '~components/leftMarginSection/leftMarginSection';
+@import '~components/checkoutHeading/checkoutHeading';
 @import '~components/customerService/customerService';
 @import '~components/subscriptionFaq/subscriptionFaq';
 @import '~components/legal/subscriptionTermsPrivacy/subscriptionTermsPrivacy';

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss
@@ -50,8 +50,22 @@
   .checkout-content {
     .component-left-margin-section__content {
       box-sizing: border-box;
-      border-left: 1px solid gu-colour(garnett-neutral-3);
+      border-left: 1px solid gu-colour(garnett-neutral-4);
     }
+  }
+
+  .checkout-form {
+    .component-left-margin-section__content {
+      padding-left: $gu-h-spacing / 2;
+      padding-bottom: $gu-v-spacing * 3;
+      border-top: 1px solid gu-colour(garnett-neutral-4);
+    }
+  }
+
+  .checkout-form__heading {
+    @include gu-fontset-body-large;
+
+    margin-bottom: $gu-v-spacing;
   }
 
   .component-left-margin-section--free-trial {
@@ -65,30 +79,19 @@
     font-style: italic;
     font-weight: 300;
     padding-left: $gu-h-spacing / 2;
-    margin-bottom: $gu-v-spacing;
+    margin-bottom: $gu-v-spacing * 2;
 
     @include mq($from: mobileLandscape) {
       width: 460px;
     }
   }
 
-  .checkout-form {
-    .component-left-margin-section__content {
-      padding-left: $gu-h-spacing / 2;
-    }
-  }
-
-  .checkout-form__heading {
-    @include gu-fontset-body-large;
-    margin-top: 2px;
-  }
-
   .component-left-margin-section--your-details {
     .component-left-margin-section__content {
-      background-color: gu-colour(garnett-neutral-3);
-      padding-bottom: $gu-v-spacing * 3;
+      border-top: none;
     }
   }
+ 
 
   // ----- Thank You
 

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss
@@ -44,6 +44,51 @@
     position: relative;
   }
 
+  // ----- Checkout
+
+  .checkout-content {
+    .component-left-margin-section__content {
+      box-sizing: border-box;
+      border-left: 1px solid gu-colour(garnett-neutral-3);
+    }
+  }
+
+  .component-left-margin-section--free-trial {
+    .component-left-margin-section__content {
+      @include multiline-bottom-border;
+    }
+  }
+
+  .free-trial__copy {
+    @include gu-fontset-body-large;
+    font-style: italic;
+    font-weight: 300;
+    padding-left: $gu-h-spacing / 2;
+    margin-bottom: $gu-v-spacing;
+
+    @include mq($from: mobileLandscape) {
+      width: 460px;
+    }
+  }
+
+  .checkout-form {
+    .component-left-margin-section__content {
+      padding-left: $gu-h-spacing / 2;
+    }
+  }
+
+  .checkout-form__heading {
+    @include gu-fontset-body-large;
+    margin-top: 2px;
+  }
+
+  .component-left-margin-section--your-details {
+    .component-left-margin-section__content {
+      background-color: gu-colour(garnett-neutral-3);
+      padding-bottom: $gu-v-spacing * 3;
+    }
+  }
+
   // ----- Thank You
 
   .thank-you-content {

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss
@@ -77,7 +77,7 @@
     }
   }
 
-  .free-trial__copy {
+  .checkout-content__free-trial {
     @include gu-fontset-body-large;
     font-style: italic;
     font-weight: 300;
@@ -94,7 +94,7 @@
       border-top: none;
     }
   }
- 
+
 
   // ----- Thank You
 

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -2,25 +2,20 @@
 
 // ----- Imports ----- //
 
-import { compose, type Dispatch } from 'redux';
+import { compose, combineReducers, type Dispatch } from 'redux';
 
 import { type ReduxState } from 'helpers/page/page';
 import { type Option } from 'helpers/types/option';
+import { detect, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { type Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
+import csrf from 'helpers/csrf/csrfReducer';
+import { createUserReducer, type User as UserState } from 'helpers/user/userReducer';
 import {
   type IsoCountry,
   fromString,
   type StateProvince,
   stateProvinceFromString,
 } from 'helpers/internationalisation/country';
-import { detect, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import { type State as MarketingConsentState } from 'components/marketingConsent/marketingConsentReducer';
-import { type Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
-import csrf from 'helpers/csrf/csrfReducer';
-
-import { createUserReducer, type User as UserState } from 'helpers/user/userReducer';
-import { marketingConsentReducerFor } from 'components/marketingConsent/marketingConsentReducer';
-import { combineReducers } from 'redux';
-
 import {
   validate,
   nonEmptyString,
@@ -28,6 +23,11 @@ import {
   formError,
   type FormError,
 } from 'helpers/subscriptionsForms/validation';
+
+import {
+  marketingConsentReducerFor,
+  type State as MarketingConsentState,
+} from 'components/marketingConsent/marketingConsentReducer';
 
 
 // ----- Types ----- //

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -33,6 +33,7 @@ import {
 // ----- Types ----- //
 
 export type Stage = 'checkout' | 'thankyou';
+type PaymentFrequency = 'monthly' | 'yearly';
 
 export type FormFields = {|
   firstName: string,
@@ -40,6 +41,7 @@ export type FormFields = {|
   country: Option<IsoCountry>,
   stateProvince: Option<StateProvince>,
   telephone: string,
+  paymentFrequency: PaymentFrequency,
 |};
 
 export type FormField = $Keys<FormFields>;
@@ -64,6 +66,7 @@ export type Action =
   | { type: 'SET_TELEPHONE', telephone: string }
   | { type: 'SET_COUNTRY', country: string }
   | { type: 'SET_STATE_PROVINCE', stateProvince: string }
+  | { type: 'SET_PAYMENT_FREQUENCY', paymentFrequency: PaymentFrequency }
   | { type: 'SET_ERRORS', errors: FormError<FormField>[] };
 
 
@@ -76,6 +79,7 @@ function getFormFields(state: State): FormFields {
     country: state.page.checkout.country,
     stateProvince: state.page.checkout.stateProvince,
     telephone: state.page.checkout.telephone,
+    paymentFrequency: state.page.checkout.paymentFrequency,
   };
 }
 
@@ -118,6 +122,7 @@ const formActionCreators = {
   setTelephone: (telephone: string): Action => ({ type: 'SET_TELEPHONE', telephone }),
   setCountry: (country: string): Action => ({ type: 'SET_COUNTRY', country }),
   setStateProvince: (stateProvince: string): Action => ({ type: 'SET_STATE_PROVINCE', stateProvince }),
+  setPaymentFrequency: (paymentFrequency: PaymentFrequency): Action => ({ type: 'SET_PAYMENT_FREQUENCY', paymentFrequency }),
   submitForm: () => (dispatch: Dispatch<Action>, getState: () => State) =>
     compose(dispatch, setFormErrors, getErrors, getFormFields)(getState()),
 };
@@ -134,6 +139,7 @@ const initialState = {
   country: null,
   stateProvince: null,
   telephone: '',
+  paymentFrequency: 'monthly',
   errors: [],
 };
 
@@ -158,6 +164,9 @@ function reducer(state: CheckoutState = initialState, action: Action): CheckoutS
 
     case 'SET_STATE_PROVINCE':
       return { ...state, stateProvince: stateProvinceFromString(state.country, action.stateProvince) };
+
+    case 'SET_PAYMENT_FREQUENCY':
+      return { ...state, paymentFrequency: action.paymentFrequency };
 
     case 'SET_ERRORS':
       return { ...state, errors: action.errors };

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -34,6 +34,7 @@ import {
 
 export type Stage = 'checkout' | 'thankyou';
 type PaymentFrequency = 'monthly' | 'yearly';
+type PaymentMethod = 'card' | 'directDebit';
 
 export type FormFields = {|
   firstName: string,
@@ -42,6 +43,7 @@ export type FormFields = {|
   stateProvince: Option<StateProvince>,
   telephone: string,
   paymentFrequency: PaymentFrequency,
+  paymentMethod: PaymentMethod,
 |};
 
 export type FormField = $Keys<FormFields>;
@@ -67,6 +69,7 @@ export type Action =
   | { type: 'SET_COUNTRY', country: string }
   | { type: 'SET_STATE_PROVINCE', stateProvince: string }
   | { type: 'SET_PAYMENT_FREQUENCY', paymentFrequency: PaymentFrequency }
+  | { type: 'SET_PAYMENT_METHOD', paymentMethod: PaymentMethod }
   | { type: 'SET_ERRORS', errors: FormError<FormField>[] };
 
 
@@ -80,6 +83,7 @@ function getFormFields(state: State): FormFields {
     stateProvince: state.page.checkout.stateProvince,
     telephone: state.page.checkout.telephone,
     paymentFrequency: state.page.checkout.paymentFrequency,
+    paymentMethod: state.page.checkout.paymentMethod,
   };
 }
 
@@ -123,6 +127,7 @@ const formActionCreators = {
   setCountry: (country: string): Action => ({ type: 'SET_COUNTRY', country }),
   setStateProvince: (stateProvince: string): Action => ({ type: 'SET_STATE_PROVINCE', stateProvince }),
   setPaymentFrequency: (paymentFrequency: PaymentFrequency): Action => ({ type: 'SET_PAYMENT_FREQUENCY', paymentFrequency }),
+  setPaymentMethod: (paymentMethod: PaymentMethod): Action => ({ type: 'SET_PAYMENT_METHOD', paymentMethod }),
   submitForm: () => (dispatch: Dispatch<Action>, getState: () => State) =>
     compose(dispatch, setFormErrors, getErrors, getFormFields)(getState()),
 };
@@ -140,6 +145,7 @@ const initialState = {
   stateProvince: null,
   telephone: '',
   paymentFrequency: 'monthly',
+  paymentMethod: 'directDebit',
   errors: [],
 };
 
@@ -167,6 +173,9 @@ function reducer(state: CheckoutState = initialState, action: Action): CheckoutS
 
     case 'SET_PAYMENT_FREQUENCY':
       return { ...state, paymentFrequency: action.paymentFrequency };
+
+    case 'SET_PAYMENT_METHOD':
+      return { ...state, paymentMethod: action.paymentMethod };
 
     case 'SET_ERRORS':
       return { ...state, errors: action.errors };


### PR DESCRIPTION
## Why are you doing this?

Adding payment frequency and payment method radio buttons to the checkout. Also applying styling to the checkout page as a whole.

[**Trello Card**](https://trello.com/c/04Ln5TWR/1506-select-subscription-frequency)

cc @JustinPinner 

## Changes

- Added `CheckoutCopy` and `CheckoutHeading` components for sections with shared styling.
- Updated `RadioInput` to use a custom radio visual.
- Created a `withArrow` HOC to add the right arrow SVG to buttons and links.
- Tweaked the styling of some of the form components (e.g. added a chevron to the `Select` component).
- Added headings to the checkout form; added payment frequency and payment method sections.
- Added heading and free trial copy.
- Refactored some imports.
- Added reducer/action logic and types to handle payment frequency and payment method.

## Screenshots

| Desktop | Mobile |
|-|-|
| ![checkout-desktop](https://user-images.githubusercontent.com/5131341/49013530-03155f00-f175-11e8-8b44-5342397ebbfc.png) | ![checkout-mobile](https://user-images.githubusercontent.com/5131341/49013535-0ad50380-f175-11e8-8932-9cf2a73cf7e7.png) |
