### PR TITLE
US campaign copy on /contribute page

### DIFF
--- a/assets/helpers/internationalisation/contributions.js
+++ b/assets/helpers/internationalisation/contributions.js
@@ -1,6 +1,7 @@
 // @flow
 
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { getQueryParameter } from 'helpers/url';
 
 const defaultHeaderCopy = 'Help us deliver the independent journalism the world needs';
 const defaultContributeCopy = `
@@ -8,12 +9,10 @@ const defaultContributeCopy = `
   as and when you feel like it – choose the option that suits you best.
 `;
 
-const usHeaderCopy = 'TODO header';
-const usContributeCopy = 'TODO contribute';
-
 export type CountryMetaData = {
   headerCopy: string,
-  contributeCopy: string,
+  contributeCopy?: string,
+  headerClasses?: string,
 };
 
 const countryGroupSpecificDetails: {
@@ -28,8 +27,8 @@ const countryGroupSpecificDetails: {
     contributeCopy: defaultContributeCopy,
   },
   UnitedStates: {
-    headerCopy: usHeaderCopy,
-    contributeCopy: usContributeCopy,
+    headerCopy: defaultHeaderCopy,
+    contributeCopy: defaultContributeCopy,
   },
   AUDCountries: {
     headerCopy: 'Help us deliver the independent journalism Australia needs',
@@ -49,4 +48,16 @@ const countryGroupSpecificDetails: {
   },
 };
 
-export { countryGroupSpecificDetails };
+const usCampaignDetails: CountryMetaData = {
+  headerCopy: 'Make a year-end gift to The Guardian and invest in our independent journalism for 2019 and beyond.',
+  headerClasses: 'header__us-campaign',
+};
+
+const getCountryGroupSpecificDetails = (countryGroupId: CountryGroupId) => {
+  if (getQueryParameter('INTCMP') === 'TODO') {
+    return usCampaignDetails;
+  }
+  return countryGroupSpecificDetails[countryGroupId];
+};
+
+export { countryGroupSpecificDetails, getCountryGroupSpecificDetails };

--- a/assets/helpers/internationalisation/contributions.js
+++ b/assets/helpers/internationalisation/contributions.js
@@ -53,11 +53,4 @@ const usCampaignDetails: CountryMetaData = {
   headerClasses: 'header__us-campaign',
 };
 
-const getCountryGroupSpecificDetails = (countryGroupId: CountryGroupId) => {
-  if (getQueryParameter('INTCMP') === 'TODO') {
-    return usCampaignDetails;
-  }
-  return countryGroupSpecificDetails[countryGroupId];
-};
-
-export { countryGroupSpecificDetails, getCountryGroupSpecificDetails };
+export { countryGroupSpecificDetails, usCampaignDetails };

--- a/assets/helpers/internationalisation/contributions.js
+++ b/assets/helpers/internationalisation/contributions.js
@@ -1,7 +1,6 @@
 // @flow
 
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import { getQueryParameter } from 'helpers/url';
 
 const defaultHeaderCopy = 'Help us deliver the independent journalism the world needs';
 const defaultContributeCopy = `

--- a/assets/helpers/internationalisation/contributions.js
+++ b/assets/helpers/internationalisation/contributions.js
@@ -8,6 +8,9 @@ const defaultContributeCopy = `
   as and when you feel like it – choose the option that suits you best.
 `;
 
+const usHeaderCopy = 'TODO header';
+const usContributeCopy = 'TODO contribute';
+
 export type CountryMetaData = {
   headerCopy: string,
   contributeCopy: string,
@@ -25,8 +28,8 @@ const countryGroupSpecificDetails: {
     contributeCopy: defaultContributeCopy,
   },
   UnitedStates: {
-    headerCopy: defaultHeaderCopy,
-    contributeCopy: defaultContributeCopy,
+    headerCopy: usHeaderCopy,
+    contributeCopy: usContributeCopy,
   },
   AUDCountries: {
     headerCopy: 'Help us deliver the independent journalism Australia needs',

--- a/assets/helpers/tracking/acquisitions.js
+++ b/assets/helpers/tracking/acquisitions.js
@@ -282,6 +282,19 @@ function getReferrerAcquisitionData(): ReferrerAcquisitionData {
   return referrerAcquisitionData;
 }
 
+const usCampaignVariants = ['us_eoy_top_ticker', 'us_eoy_bottom_ticker', 'us_eoy_bottom_ticker_two'];
+
+function isUsCampaignTest(referrerAcquisitionData: ReferrerAcquisitionData): boolean {
+  if (referrerAcquisitionData.abTests) {
+    const index = referrerAcquisitionData.abTests.findIndex((test: AcquisitionABTest) =>
+      test.name === 'AcquisitionsEpicUsEndOfYearRound2' &&
+      usCampaignVariants.includes(test.variant));
+
+    return index >= 0;
+  }
+  return false;
+}
+
 
 // ----- Exports ----- //
 
@@ -294,4 +307,5 @@ export {
   derivePaymentApiAcquisitionData,
   deriveSubsAcquisitionData,
   getSupportAbTests,
+  isUsCampaignTest,
 };

--- a/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
@@ -8,7 +8,7 @@ import type { Status } from 'helpers/settings';
 import React from 'react';
 import { connect } from 'react-redux';
 import { Redirect } from 'react-router';
-import { countryGroupSpecificDetails } from 'helpers/internationalisation/contributions';
+import { getCountryGroupSpecificDetails } from 'helpers/internationalisation/contributions';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { type ErrorReason } from 'helpers/errorReasons';
 import { type PaymentAuthorisation } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
@@ -84,12 +84,17 @@ function ContributionFormContainer(props: PropTypes) {
     props.onThirdPartyPaymentAuthorised(paymentAuthorisation);
   };
 
+  const countryGroupDetails = getCountryGroupSpecificDetails(props.countryGroupId);
+  const headerClasses = `header ${countryGroupDetails.headerClasses ? countryGroupDetails.headerClasses : ''}`;
+
   return props.paymentComplete ?
     <Redirect to={props.thankYouRoute} />
     : (
       <div className="gu-content__content">
-        <h1 className="header">{countryGroupSpecificDetails[props.countryGroupId].headerCopy}</h1>
-        <p className="blurb">{countryGroupSpecificDetails[props.countryGroupId].contributeCopy}</p>
+        <h1 className={headerClasses}>{countryGroupDetails.headerCopy}</h1>
+        { countryGroupDetails.contributeCopy ?
+          <p className="blurb">{countryGroupDetails.contributeCopy}</p> : null
+        }
         <NewContributionForm
           onPaymentAuthorisation={onPaymentAuthorisation}
         />

--- a/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
@@ -5,10 +5,11 @@
 import type { ContributionType, PaymentMethod } from 'helpers/contributions';
 import type { Csrf } from 'helpers/csrf/csrfReducer';
 import type { Status } from 'helpers/settings';
+import { isUsCampaignTest, type ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import React from 'react';
 import { connect } from 'react-redux';
 import { Redirect } from 'react-router';
-import { getCountryGroupSpecificDetails } from 'helpers/internationalisation/contributions';
+import { countryGroupSpecificDetails, usCampaignDetails } from 'helpers/internationalisation/contributions';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { type ErrorReason } from 'helpers/errorReasons';
 import { type PaymentAuthorisation } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
@@ -49,6 +50,7 @@ type PropTypes = {|
   isTestUser: boolean,
   paymentMethod: PaymentMethod,
   contributionType: ContributionType,
+  referrerAcquisitionData: ReferrerAcquisitionData,
 |};
 
 /* eslint-enable react/no-unused-prop-types */
@@ -64,6 +66,7 @@ const mapStateToProps = (state: State) => ({
   isTestUser: state.page.user.isTestUser,
   paymentMethod: state.page.form.paymentMethod,
   contributionType: state.page.form.contributionType,
+  referrerAcquisitionData: state.common.referrerAcquisitionData,
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -84,7 +87,10 @@ function ContributionFormContainer(props: PropTypes) {
     props.onThirdPartyPaymentAuthorised(paymentAuthorisation);
   };
 
-  const countryGroupDetails = getCountryGroupSpecificDetails(props.countryGroupId);
+  const countryGroupDetails = isUsCampaignTest(props.referrerAcquisitionData) ?
+    usCampaignDetails :
+    countryGroupSpecificDetails[props.countryGroupId];
+
   const headerClasses = `header ${countryGroupDetails.headerClasses ? countryGroupDetails.headerClasses : ''}`;
 
   return props.paymentComplete ?

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -210,6 +210,11 @@ body {
   padding: 0 $gu-h-spacing/2 $gu-v-spacing*1.5 $gu-h-spacing/2;
 }
 
+.header__us-campaign {
+  font-size: 27px;
+  border-bottom: none;
+}
+
 input,
 select,
 textarea,


### PR DESCRIPTION
## Why are you doing this?
If a user is referred by a US campaign epic, display a different message on the /contribute page. This means users who come from the control epic will see the old copy.

[**Trello Card**](https://trello.com/c/yTsOtQOQ/216-update-copy-on-us-landing-page)

## Changes

* Adds function `isUsCampaignTest`, which uses the `abTest` provided in the query string to decide which copy to show. This will be used for other design changes later.
* Make the text below the headline optional

## Screenshots
<img width="436" alt="picture 18" src="https://user-images.githubusercontent.com/1513454/49011714-16253080-f16f-11e8-937a-18e6b4761ac6.png">

