### PR TITLE
Rolling out countdown timer for Digital Pack & Featured product

### DIFF
--- a/assets/components/featuredProductHero/featuredProductHero.jsx
+++ b/assets/components/featuredProductHero/featuredProductHero.jsx
@@ -14,7 +14,6 @@ import type { HeadingSize } from 'components/heading/heading';
 // ----- Types ----- //
 
 type PropTypes = {
-  hasTimer?: boolean,
   headingSize: HeadingSize,
   headingText: string,
   subheadingText?: ?string,
@@ -27,7 +26,6 @@ type PropTypes = {
 export default function FeaturedProductHero(props: PropTypes) {
 
   const {
-    hasTimer,
     headingSize,
     headingText,
     subheadingText,
@@ -87,6 +85,5 @@ FeaturedProductHero.defaultProps = {
   subheadingText: null,
   cta: null,
   image: null,
-  hasTimer: false,
   product: null,
 };

--- a/assets/components/featuredProductHero/featuredProductHero.jsx
+++ b/assets/components/featuredProductHero/featuredProductHero.jsx
@@ -35,7 +35,8 @@ export default function FeaturedProductHero(props: PropTypes) {
     product,
   } = props;
 
-  const timerClassName = classNameWithModifiers('component-featured-product-hero__countdownbox', product === 'DigitalPack' ? [] : ['hidden']);
+  const hasTimer = product === 'DigitalPack';
+  const timerClassName = classNameWithModifiers('component-featured-product-hero__countdownbox', hasTimer ? [] : ['hidden']);
   const rootClassName = classNameWithModifiers(
     'component-featured-product-hero',
     [

--- a/assets/components/featuredProductHero/featuredProductHero.jsx
+++ b/assets/components/featuredProductHero/featuredProductHero.jsx
@@ -37,7 +37,7 @@ export default function FeaturedProductHero(props: PropTypes) {
     product,
   } = props;
 
-  const timerClassName = classNameWithModifiers('component-featured-product-hero__countdownbox', hasTimer ? [] : ['hidden']);
+  const timerClassName = classNameWithModifiers('component-featured-product-hero__countdownbox', product === 'DigitalPack' ? [] : ['hidden']);
   const rootClassName = classNameWithModifiers(
     'component-featured-product-hero',
     [

--- a/assets/components/featuredProductHero/featuredProductHero.jsx
+++ b/assets/components/featuredProductHero/featuredProductHero.jsx
@@ -14,6 +14,7 @@ import type { HeadingSize } from 'components/heading/heading';
 // ----- Types ----- //
 
 type PropTypes = {
+  hasTimer?: boolean,
   headingSize: HeadingSize,
   headingText: string,
   subheadingText?: ?string,
@@ -26,6 +27,7 @@ type PropTypes = {
 export default function FeaturedProductHero(props: PropTypes) {
 
   const {
+    hasTimer,
     headingSize,
     headingText,
     subheadingText,
@@ -35,7 +37,6 @@ export default function FeaturedProductHero(props: PropTypes) {
     product,
   } = props;
 
-  const hasTimer = product === 'DigitalPack';
   const timerClassName = classNameWithModifiers('component-featured-product-hero__countdownbox', hasTimer ? [] : ['hidden']);
   const rootClassName = classNameWithModifiers(
     'component-featured-product-hero',
@@ -85,6 +86,7 @@ export default function FeaturedProductHero(props: PropTypes) {
 FeaturedProductHero.defaultProps = {
   subheadingText: null,
   cta: null,
+  hasTimer: false,
   image: null,
   product: null,
 };

--- a/assets/components/flashSaleCountdown/flashSaleCountdown.scss
+++ b/assets/components/flashSaleCountdown/flashSaleCountdown.scss
@@ -1,5 +1,5 @@
 .component-flash-sale-countdown {
-  font-size: 14px;
+  font-size: 1em;
   line-height: 16px;
   font-family: $gu-text-egyptian-web;
   overflow: hidden;

--- a/assets/components/flashSaleCountdown/flashSaleCountdown.scss
+++ b/assets/components/flashSaleCountdown/flashSaleCountdown.scss
@@ -1,5 +1,5 @@
 .component-flash-sale-countdown {
-  font-size: 1em;
+  font-size: 17px;
   line-height: 16px;
   font-family: $gu-text-egyptian-web;
   overflow: hidden;

--- a/assets/pages/subscriptions-landing/components/featuredProductAb.jsx
+++ b/assets/pages/subscriptions-landing/components/featuredProductAb.jsx
@@ -82,6 +82,7 @@ function FeaturedProductAb(props: PropTypes) {
       cta={getCta(product)}
       headingSize={headingSize}
       product={product.name}
+      hasTimer={product.name === 'DigitalPack'}
     />) : null;
 
 }


### PR DESCRIPTION
Making the countdown timer look more prominent and rolling it out as default for the featured product header - Digital Pack (US, AU, RoW only).

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/R64yrpsc)

## Screenshots
**Before:**

![screen shot 2018-11-26 at 16 21 28](https://user-images.githubusercontent.com/7768243/49027220-9e1f3080-f197-11e8-9bad-b06fdebebe9a.png)

**After:**
![screen shot 2018-11-26 at 16 21 38](https://user-images.githubusercontent.com/7768243/49027221-9eb7c700-f197-11e8-9648-0accf30902aa.png)

**Before:**
![screen shot 2018-11-26 at 16 22 45](https://user-images.githubusercontent.com/7768243/49027223-9eb7c700-f197-11e8-8dba-96ff6e8f0739.png)

**After:**
![screen shot 2018-11-26 at 16 21 45](https://user-images.githubusercontent.com/7768243/49027222-9eb7c700-f197-11e8-83df-ffb1f4af2fdb.png)


