### PR TITLE
Images in paper subs page

### DIFF
--- a/assets/components/productPage/productPageContentBlock/productPageContentBlock.jsx
+++ b/assets/components/productPage/productPageContentBlock/productPageContentBlock.jsx
@@ -5,6 +5,7 @@
 import React, { type Node } from 'react';
 import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
 import { classNameWithModifiers } from 'helpers/utilities';
+import { type Option } from 'helpers/types/option';
 
 import './productPageContentBlock.scss';
 
@@ -12,21 +13,25 @@ import './productPageContentBlock.scss';
 
 type PropTypes = {|
   type: 'white' | 'grey' | 'feature' | 'dark',
-  id?: ?string,
+  id?: Option<string>,
   children: Node,
-  modifierClasses: Array<?string>,
+  image: Option<Node>,
+  modifierClasses: Array<string>,
 |};
 
 
 // ----- Render ----- //
 
 const ProductPageContentBlock = ({
-  type, children, id, modifierClasses,
+  type, children, id, modifierClasses, image,
 }: PropTypes) => (
   <div id={id} className={classNameWithModifiers('component-product-page-content-block', [type, ...modifierClasses])}>
     <LeftMarginSection>
       <div className="component-product-page-content-block__content">
         {children}
+        {image &&
+          <div className="component-product-page-content-block__image">{image}</div>
+        }
       </div>
     </LeftMarginSection>
   </div>
@@ -35,6 +40,7 @@ const ProductPageContentBlock = ({
 ProductPageContentBlock.defaultProps = {
   type: 'white',
   id: null,
+  image: null,
   modifierClasses: [],
 };
 

--- a/assets/components/productPage/productPageContentBlock/productPageContentBlock.scss
+++ b/assets/components/productPage/productPageContentBlock/productPageContentBlock.scss
@@ -2,6 +2,7 @@
 
 .component-product-page-content-block .component-left-margin-section__content {
   max-width: 100%;
+  overflow: hidden;
   @include mq($from: tablet) {
     border-left: 1px solid gu-colour(garnett-neutral-4);
   }
@@ -54,12 +55,14 @@
 .component-product-page-content-block__content {
   max-width: gu-span(12);
   padding: ($gu-v-spacing/2) ($gu-h-spacing / 2) 0;
+  position: relative;
 }
 
 .component-product-page-content-block__outset {
   margin-left: ($gu-h-spacing / 2 * -1);
   margin-right: ($gu-h-spacing / 2 * -1);
 }
+
 
 // ----- Vertical rhythm ------ //
 
@@ -68,5 +71,27 @@
   .component-product-page-plan-form,
   .component-product-page-info-chip {
     margin-bottom: ($gu-v-spacing*2)
+  }
+}
+
+
+// ----- Images ------ //
+
+.component-product-page-content-block__image {
+  max-width: gu-span(6);
+  @include mq($from: tablet) {
+    position: absolute;
+    left: gu-span(7) + $gu-h-spacing;
+  }
+  @include mq($from: desktop) {
+    left: gu-span(8) + $gu-h-spacing;
+  }
+  @include mq($from: wide) {
+    width: gu-span(5);
+  }
+  bottom: ($gu-v-spacing*2)*-1;
+  .component-grid-image {
+    display: block;
+    width: 100%;
   }
 }

--- a/assets/components/productPage/productPageHero/productPageHero.scss
+++ b/assets/components/productPage/productPageHero/productPageHero.scss
@@ -3,9 +3,9 @@
 .component-product-page-hero {
   overflow: hidden;
   .component-left-margin-section__content {
+    position: relative;
     @include mq($from: tablet) {
       border-left: 1px solid;
-      position: relative;
       .component-heading-block {
         margin-left: -1px;
       }    

--- a/assets/components/productPage/productPageTextBlock/productPageTextBlock.scss
+++ b/assets/components/productPage/productPageTextBlock/productPageTextBlock.scss
@@ -14,7 +14,7 @@
   @include gu-fontset-body;
   overflow-wrap: break-word;
   max-width: gu-span(7);
-  @include mq($from: tablet) {
+  @include mq($from: desktop) {
     max-width: gu-span(8);
   }
 }

--- a/assets/helpers/theGrid.js
+++ b/assets/helpers/theGrid.js
@@ -55,6 +55,8 @@ export const imageCatalogue: {
   weeklyLandingHero: '3a093833e468eec890838eb36d462f0281299f9c/0_0_5060_5350',
   paperLandingHero: 'cf91f9718b1f8397eaa10eae1d02ae3f143f261f/0_0_2600_1192',
   paperLandingHeroMobile: 'c662f53516b202d56fed0a08c8f1cdbd1d132a92/0_0_924_696',
+  paperDeliveryFeature: '7cd44415801daf5bcb379bb0ba348c6ed7601c01/0_0_920_820',
+  paperVoucherFeature: '33ce22d8c3b65e830b91ab089f5c0670cbd6a7d9/0_0_920_820',
 };
 
 // Utility type: https://flow.org/en/docs/types/utilities/#toc-keys

--- a/assets/helpers/theGrid.js
+++ b/assets/helpers/theGrid.js
@@ -53,6 +53,8 @@ export const imageCatalogue: {
   paperHeroDesktop: 'f1040916a71642c924a52c61dc7c4aae2b8dd88d/0_0_1080_784',
   paperHeroMobile: '9b8d348e9ba521c388e3482ece4037e3f0fb3864/0_0_1000_666',
   weeklyLandingHero: '3a093833e468eec890838eb36d462f0281299f9c/0_0_5060_5350',
+  paperLandingHero: 'cf91f9718b1f8397eaa10eae1d02ae3f143f261f/0_0_2600_1192',
+  paperLandingHeroMobile: 'c662f53516b202d56fed0a08c8f1cdbd1d132a92/0_0_924_696',
 };
 
 // Utility type: https://flow.org/en/docs/types/utilities/#toc-keys

--- a/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
+++ b/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
@@ -14,6 +14,7 @@ import { renderPage } from 'helpers/render';
 
 import SvgInfo from 'components/svgs/information';
 import GridPicture from 'components/gridPicture/gridPicture';
+import GridImage from 'components/gridImage/gridImage';
 import ProductPagehero from 'components/productPage/productPageHero/productPageHero';
 import ProductPageContentBlock from 'components/productPage/productPageContentBlock/productPageContentBlock';
 import ProductPageTextBlock, { largeParagraphClassName, sansParagraphClassName } from 'components/productPage/productPageTextBlock/productPageTextBlock';
@@ -91,7 +92,14 @@ const content = (
         </ProductPageTextBlock>
         <Tabs />
       </ProductPageContentBlock>
-      <ProductPageContentBlock>
+      <ProductPageContentBlock image={<GridImage
+        gridId="paperVoucherFeature"
+        srcSizes={[920, 500, 140]}
+        sizes="(max-width: 740px) 100vw, 500px"
+        imgType="png"
+      />
+      }
+      >
         <ProductPageTextBlock title="How do vouchers work?">
           <ProductPageTextBlockList items={[
             `When you take out a voucher subscription, we’ll send you a book of vouchers.

--- a/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
+++ b/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
@@ -13,6 +13,7 @@ import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
 
 import SvgInfo from 'components/svgs/information';
+import GridPicture from 'components/gridPicture/gridPicture';
 import ProductPagehero from 'components/productPage/productPageHero/productPageHero';
 import ProductPageContentBlock from 'components/productPage/productPageContentBlock/productPageContentBlock';
 import ProductPageTextBlock, { largeParagraphClassName, sansParagraphClassName } from 'components/productPage/productPageTextBlock/productPageTextBlock';
@@ -57,7 +58,30 @@ const content = (
         heading="Save up to 31% on the Guardian and the Observer’s newspaper retail price all year round"
         type="feature"
         modifierClasses={['paper']}
-      />
+      >
+        <GridPicture
+          sources={[
+            {
+              gridId: 'paperLandingHeroMobile',
+              srcSizes: [500, 924],
+              imgType: 'png',
+              sizes: '100vw',
+              media: '(max-width: 739px)',
+            },
+            {
+              gridId: 'paperLandingHero',
+              srcSizes: [1000, 2000],
+              imgType: 'png',
+              sizes: '(min-width: 1000px) 2000px, 1000px',
+              media: '(min-width: 740px)',
+            },
+          ]}
+          fallback="paperLandingHero"
+          fallbackSize={1000}
+          altText=""
+          fallbackImgType="png"
+        />
+      </ProductPagehero>
       <ProductPageContentBlock>
         <ProductPageTextBlock>
           <p className={largeParagraphClassName}>Pick between voucher and home delivery.

--- a/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.scss
+++ b/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.scss
@@ -14,6 +14,36 @@
   scroll-behavior: smooth;
 }
 
-.component-product-page-hero--paper .component-left-margin-section__content {
-  padding-top: 20em;
+.component-product-page-hero--paper {
+  @include mq($from: tablet) {
+    .component-heading-block {
+      margin-top: 24em;
+    }
+    .component-grid-picture {
+      position: absolute;
+      top: 0;
+      min-width: 100%;
+      height: 100%;
+      @include mq($from: wide) {
+        left: gu-span(2) * -1;
+      }
+    }
+    .component-grid-picture__image {
+      height: 100%;
+      display: block;
+    }
+  }
+  @include mq($until: tablet) {
+    .component-grid-picture {
+      max-height: 20em;
+      overflow: hidden;
+      display: block;
+    }
+    .component-grid-picture__image {
+      max-width: gu-span(8);
+      margin: auto;
+      float: none;
+      display: block;
+    }
+  }
 }


### PR DESCRIPTION
## Why are you doing this?

They are needed for launch. This PR depends on #1228 for final tweaks as there is no 2 tab structure on master yet to place both content images on. This PR brings a generic-ish slot for them that will hold either.

## Screenshots
<img width="1473" alt="screenshot 2018-11-26 at 4 35 37 pm" src="https://user-images.githubusercontent.com/11539094/49028106-8b0d6000-f199-11e8-963f-8fb1c30bca65.png">
<img width="1473" alt="screenshot 2018-11-26 at 4 35 39 pm" src="https://user-images.githubusercontent.com/11539094/49028110-8c3e8d00-f199-11e8-974d-bc40aecd407c.png">
