### PR TITLE
Correct paypal recurring billing period

### DIFF
--- a/assets/components/paymentButtons/payPalExpressButton/payPalExpressButton.jsx
+++ b/assets/components/paymentButtons/payPalExpressButton/payPalExpressButton.jsx
@@ -13,6 +13,7 @@ import { loadPayPalExpress, setup } from 'helpers/paymentIntegrations/payPalExpr
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
 import type { PayPalAuthorisation } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
+import { type RegularContributionType } from 'helpers/contributions';
 
 // ---- Types ----- //
 
@@ -26,6 +27,7 @@ type PropTypes = {|
   switchStatus: Status,
   canOpen: () => boolean,
   whenUnableToOpen: () => void,
+  regularContributionType: RegularContributionType,
 |};
 
 
@@ -68,6 +70,7 @@ function Button(props: PropTypes) {
     onPaymentAuthorisation,
     props.canOpen,
     props.whenUnableToOpen,
+    props.regularContributionType,
   );
 
 

--- a/assets/helpers/paymentIntegrations/newPaymentFlow/payPalRecurringCheckout.js
+++ b/assets/helpers/paymentIntegrations/newPaymentFlow/payPalRecurringCheckout.js
@@ -6,6 +6,7 @@ import { logException } from 'helpers/logger';
 import { routes } from 'helpers/routes';
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
+import type { ContributionType } from 'helpers/contributions';
 
 // ----- Types ----- //
 
@@ -39,10 +40,16 @@ function payPalRequestData(bodyObj: Object, csrfToken: string) {
 function setupPayment(
   currencyId: IsoCurrency,
   csrf: CsrfState,
-  setupRecurringPayPalPayment: (resolve: string => void, reject: Error => void, IsoCurrency, CsrfState) => void,
+  contributionType: ContributionType,
+  setupRecurringPayPalPayment: (
+    resolve: string => void,
+    reject: Error => void,
+    IsoCurrency, CsrfState,
+    contributionType: ContributionType
+  ) => void,
 ) {
   return (resolve, reject) => {
-    setupRecurringPayPalPayment(resolve, reject, currencyId, csrf);
+    setupRecurringPayPalPayment(resolve, reject, currencyId, csrf, contributionType);
   };
 }
 
@@ -68,7 +75,14 @@ function getPayPalOptions(
   onClick: () => void,
   formClassName: string,
   isTestUser: boolean,
-  setupRecurringPayPalPayment: (resolve: string => void, reject: Error => void, IsoCurrency, CsrfState) => void,
+  contributionType: ContributionType,
+  setupRecurringPayPalPayment: (
+    resolve: string => void,
+    reject: Error => void,
+    IsoCurrency,
+    CsrfState,
+    contributionType: ContributionType
+  ) => void,
 ): Object {
 
   function toggleButton(actions): void {
@@ -115,7 +129,7 @@ function getPayPalOptions(
     },
 
     // This function is called when user clicks the PayPal button.
-    payment: setupPayment(currencyId, csrf, setupRecurringPayPalPayment),
+    payment: setupPayment(currencyId, csrf, contributionType, setupRecurringPayPalPayment),
 
     // This function is called when the user finishes with PayPal interface (approves payment).
     onAuthorize: (data) => {

--- a/assets/helpers/paymentIntegrations/payPalExpressCheckout.js
+++ b/assets/helpers/paymentIntegrations/payPalExpressCheckout.js
@@ -61,7 +61,7 @@ function setupPayment(
     storage.setSession('paymentMethod', 'PayPal');
     const requestBody = {
       amount: amountToPay,
-      billingPeriod: billingPeriod,
+      billingPeriod,
       currency: currencyId,
     };
 

--- a/assets/helpers/paymentIntegrations/payPalExpressCheckout.js
+++ b/assets/helpers/paymentIntegrations/payPalExpressCheckout.js
@@ -8,6 +8,7 @@ import * as storage from 'helpers/storage';
 import { formInputs } from 'helpers/checkoutForm/checkoutForm';
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
+import { type RegularContributionType, billingPeriodFromContrib } from 'helpers/contributions';
 import { formClassName } from '../../pages/regular-contributions/components/formFields';
 
 
@@ -51,14 +52,16 @@ function setupPayment(
   amountToPay: number,
   currencyId: IsoCurrency,
   csrf: CsrfState,
+  regularContributionType: RegularContributionType,
 ) {
   const csrfToken = csrf.token;
+  const billingPeriod = billingPeriodFromContrib(regularContributionType);
 
   return (resolve, reject) => {
     storage.setSession('paymentMethod', 'PayPal');
     const requestBody = {
       amount: amountToPay,
-      billingPeriod: 'monthly',
+      billingPeriod: billingPeriod,
       currency: currencyId,
     };
 
@@ -92,6 +95,7 @@ function setup(
   onPaymentAuthorisation: string => void,
   canOpen: () => boolean,
   whenUnableToOpen: () => void,
+  regularContributionType: RegularContributionType,
 ): Promise<Object> {
 
   const handleBaId = (baid: Object) => {
@@ -144,7 +148,7 @@ function setup(
     },
 
     // This function is called when user clicks the PayPal button.
-    payment: setupPayment(amount, currencyId, csrf),
+    payment: setupPayment(amount, currencyId, csrf, regularContributionType),
 
     // This function is called when the user finishes with PayPal interface (approves payment).
     onAuthorize,

--- a/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
@@ -38,7 +38,13 @@ type PropTypes = {|
   currencyId: IsoCurrency,
   csrf: CsrfState,
   sendFormSubmitEventForPayPalRecurring: () => void,
-  setupRecurringPayPalPayment: (resolve: string => void, reject: Error => void, IsoCurrency, CsrfState) => void,
+  setupRecurringPayPalPayment: (
+    resolve: string => void,
+    reject: Error => void,
+    IsoCurrency,
+    CsrfState,
+    contributionType: ContributionType
+  ) => void,
   payPalHasLoaded: boolean,
   isTestUser: boolean,
   onPaymentAuthorisation: PaymentAuthorisation => void,
@@ -83,7 +89,8 @@ const mapDispatchToProps = (dispatch: Function) => ({
     reject: Function,
     currencyId: IsoCurrency,
     csrf: CsrfState,
-  ) => { dispatch(setupRecurringPayPalPayment(resolve, reject, currencyId, csrf)); },
+    contributionType: ContributionType,
+  ) => { dispatch(setupRecurringPayPalPayment(resolve, reject, currencyId, csrf, contributionType)); },
 });
 
 
@@ -142,6 +149,7 @@ function ContributionSubmit(props: PropTypes) {
             formClassName={formClassName}
             isTestUser={props.isTestUser}
             setupRecurringPayPalPayment={props.setupRecurringPayPalPayment}
+            contributionType={props.contributionType}
           />
         </div>
         <button

--- a/assets/pages/new-contributions-landing/components/PayPalRecurringButton.jsx
+++ b/assets/pages/new-contributions-landing/components/PayPalRecurringButton.jsx
@@ -6,6 +6,7 @@ import ReactDOM from 'react-dom';
 import React from 'react';
 
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
+import { type ContributionType } from 'helpers/contributions';
 import { getPayPalOptions } from 'helpers/paymentIntegrations/newPaymentFlow/payPalRecurringCheckout';
 import { type IsoCurrency } from 'helpers/internationalisation/currency';
 import { type PaymentAuthorisation } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
@@ -20,7 +21,13 @@ type PropTypes = {|
   onClick: () => void,
   formClassName: string,
   isTestUser: boolean,
-  setupRecurringPayPalPayment: (resolve: string => void, reject: Error => void, IsoCurrency, CsrfState) => void,
+  contributionType: ContributionType,
+  setupRecurringPayPalPayment: (
+    resolve: string => void,
+    reject: Error => void,
+    IsoCurrency, CsrfState,
+    regularContributionType: ContributionType
+  ) => void,
 |};
 
 
@@ -73,6 +80,7 @@ export class PayPalRecurringButton extends React.Component<PropTypes> {
         this.props.onClick,
         this.props.formClassName,
         this.props.isTestUser,
+        this.props.contributionType,
         this.props.setupRecurringPayPalPayment,
       ),
     );

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -7,6 +7,7 @@ import { type ThirdPartyPaymentLibrary } from 'helpers/checkouts';
 import {
   type Amount,
   logInvalidCombination,
+  billingPeriodFromContrib,
   type ContributionType,
   type PaymentMethod,
   type PaymentMatrix,
@@ -353,15 +354,17 @@ const setupRecurringPayPalPayment = (
   reject: Error => void,
   currency: IsoCurrency,
   csrf: Csrf,
+  contributionType: ContributionType,
 ) =>
   (dispatch: Function, getState: () => State): void => {
     const state = getState();
     const csrfToken = csrf.token;
     const amount = getAmount(state);
+    const billingPeriod = billingPeriodFromContrib(contributionType);
     storage.setSession('paymentMethod', 'PayPal');
     const requestBody = {
       amount,
-      billingPeriod: 'monthly',
+      billingPeriod,
       currency,
     };
 

--- a/assets/pages/regular-contributions/components/regularContributionsPayment.jsx
+++ b/assets/pages/regular-contributions/components/regularContributionsPayment.jsx
@@ -17,7 +17,7 @@ import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import type { OptimizeExperiments } from 'helpers/optimize/optimize';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import type { Node } from 'react';
-import type { ContributionType } from 'helpers/contributions';
+import type { RegularContributionType } from 'helpers/contributions';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { Participations } from 'helpers/abTests/abtest';
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
@@ -36,7 +36,7 @@ type PropTypes = {|
   errorReason: ?ErrorReason,
   isTestUser: boolean,
   isPostDeploymentTestUser: boolean,
-  contributionType: ContributionType,
+  contributionType: RegularContributionType,
   paymentStatus: PaymentStatus,
   currencyId: IsoCurrency,
   amount: number,
@@ -148,6 +148,7 @@ function RegularContributionsPayment(props: PropTypes, context) {
     switchStatus={props.payPalSwitchStatus}
     canOpen={props.canOpen}
     whenUnableToOpen={props.whenUnableToOpen}
+    regularContributionType={props.contributionType}
   />);
 
   return (

--- a/assets/pages/regular-contributions/components/regularContributionsPayment.jsx
+++ b/assets/pages/regular-contributions/components/regularContributionsPayment.jsx
@@ -36,7 +36,7 @@ type PropTypes = {|
   errorReason: ?ErrorReason,
   isTestUser: boolean,
   isPostDeploymentTestUser: boolean,
-  contributionType: RegularContributionType,
+  regularContributionType: RegularContributionType,
   paymentStatus: PaymentStatus,
   currencyId: IsoCurrency,
   amount: number,
@@ -90,7 +90,7 @@ function RegularContributionsPayment(props: PropTypes, context) {
           props.amount,
           props.csrf,
           props.currencyId,
-          props.contributionType,
+          props.regularContributionType,
           props.dispatch,
           'DirectDebit',
           props.referrerAcquisitionData,
@@ -110,7 +110,7 @@ function RegularContributionsPayment(props: PropTypes, context) {
       props.amount,
       props.csrf,
       props.currencyId,
-      props.contributionType,
+      props.regularContributionType,
       props.dispatch,
       'Stripe',
       props.referrerAcquisitionData,
@@ -136,7 +136,7 @@ function RegularContributionsPayment(props: PropTypes, context) {
       props.amount,
       props.csrf,
       props.currencyId,
-      props.contributionType,
+      props.regularContributionType,
       props.dispatch,
       'PayPal',
       props.referrerAcquisitionData,
@@ -148,7 +148,7 @@ function RegularContributionsPayment(props: PropTypes, context) {
     switchStatus={props.payPalSwitchStatus}
     canOpen={props.canOpen}
     whenUnableToOpen={props.whenUnableToOpen}
-    regularContributionType={props.contributionType}
+    regularContributionType={props.regularContributionType}
   />);
 
   return (
@@ -175,7 +175,7 @@ function mapStateToProps(state) {
     paymentStatus: state.page.regularContrib.paymentStatus,
     amount: state.page.regularContrib.amount,
     currencyId: state.common.internationalisation.currencyId,
-    contributionType: state.page.regularContrib.contributionType,
+    regularContributionType: state.page.regularContrib.contributionType,
     regularContrib: state.page.regularContrib,
     csrf: state.page.csrf,
     country: state.common.internationalisation.countryId,


### PR DESCRIPTION
## Why are you doing this?
Annual contributors see "Guardian Monthly Contributor" in the PayPal popup

It's not a massive thing because you have to click a little box at the top right of the PayPal popup to see the monthly details (see screenshot). But this may have been affecting Annual Contributions numbers

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/ApWr8xuW/85-npf-follow-up-bug-affects-existing-flow-too-we-send-monthly-billing-period-to-paypal-even-for-annual)

## Changes

* Passes through contribution type and uses to set correct billing period for PayPal recurring checkout.


## Screenshots
![screen shot 2018-11-26 at 15 21 34](https://user-images.githubusercontent.com/8484757/49029467-9ada7380-f19c-11e8-8973-f260f6b445ae.jpg)
![screen shot 2018-11-26 at 16 43 29](https://user-images.githubusercontent.com/8484757/49029469-9ada7380-f19c-11e8-87f3-42006a6c474f.jpg)

