### PR TITLE
Turn off US contributions type test

### DIFF
--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -47,7 +47,7 @@ export const tests: Tests = {
         size: 1,
       },
     },
-    isActive: true,
+    isActive: false,
     independent: true,
     seed: 5,
   },


### PR DESCRIPTION
We have an epic test that might interfere with this test, so we need to turn it off. At hack day, so just flicking the switch for now
