### PR TITLE
Quick fix to display the featured product image on mobile

### DIFF
--- a/assets/pages/subscriptions-landing/components/featuredProducts.jsx
+++ b/assets/pages/subscriptions-landing/components/featuredProducts.jsx
@@ -29,7 +29,7 @@ const dpImage = (
     sources={[
       {
         gridId: 'digitalPackFlashSaleMobile',
-        srcSizes: [140, 500, 1000],
+        srcSizes: [140, 500],
         imgType: 'png',
         sizes: '90vw',
         media: '(max-width: 739px)',


### PR DESCRIPTION
## Why are you doing this?

We have an issue of product images not appearing in the featured product hero on mobile (both iOS and android). This is due to a long standing bug that is causing the wrong images (=wrong sizes) to display on mobile and desktop (we display 500 on desktop and 1000 on mobile; in the case of the featured product image - the 1000 wide image doesn't even exist).

This PR is a quick fix that will make the product shots appear correctly on mobile (the bug will still need to be addressed though) thanks Akash!

upd. Just tested on code and it seem to have fixed the issue - https://support.code.dev-theguardian.com/us/subscribe .

**Before**

![img_0781](https://user-images.githubusercontent.com/7768243/49082655-3ffb5780-f242-11e8-8d70-aded7ad7b409.PNG)

**After**

![screen shot 2018-11-27 at 12 30 43](https://user-images.githubusercontent.com/7768243/49081953-50123780-f240-11e8-96be-f705bfd94abd.png)
