### PR TITLE
Update promocode for the Print flashsale

### DIFF
--- a/assets/helpers/flashSale.js
+++ b/assets/helpers/flashSale.js
@@ -41,7 +41,7 @@ const saleDetails: SaleDetails = {
     intcmp: '',
   },
   Paper: {
-    promoCode: 'GCA80F',
+    promoCode: 'GCA80Z',
     intcmp: 'gdnwb_macqn_other_subs_SubscribeLandingPagePrintOnlySupporterLandingPagePrintOnly_',
   },
   PaperAndDigital: {


### PR DESCRIPTION
## Why are you doing this?

AS a Marketing Manager
I WANT to link to a page that shows all the Print and Print + Digital options from the featured product header SO THAT customers can see all the available options in one place.

Specifically the print featured product header should use the promo code 'GCA80Z' so the url would be: https://subscribe.theguardian.com/p/GCA80Z 

[**See the Trello ticket here**](https://trello.com/c/NBmyiHc5)

## Question for @rupertbates :

Do we need to create a unique tracking code too, to know the impact of the change?
