### PR TITLE
Add recurring paths to TiP

### DIFF
--- a/app/monitoring/Tip.scala
+++ b/app/monitoring/Tip.scala
@@ -1,7 +1,9 @@
 package monitoring
 
 import app.BuildInfo
+import com.gu.i18n.Country
 import com.gu.support.config.Stages.PROD
+import com.gu.support.workers.model.{DirectDebitPaymentFields, PayPalPaymentFields, PaymentFields, StripePaymentFields}
 import com.gu.tip.{Tip, TipConfig, TipFactory, TipResponse}
 import config.Configuration
 
@@ -41,10 +43,16 @@ object PathVerification {
   sealed trait MonitoredPaymentMethod { val tipString: String }
   case object DirectDebit extends MonitoredPaymentMethod { val tipString = "Direct Debit" }
   case object PayPal extends MonitoredPaymentMethod { val tipString = "PayPal" }
-  case object Stripe extends MonitoredPaymentMethod { val tipString = "Stripe" }
+  case object Card extends MonitoredPaymentMethod { val tipString = "Card" }
 
-  case class TipPath(region: MonitoredRegion, product: MonitoredProduct, paymentMethod: MonitoredPaymentMethod) {
-    val configPath: String = s"${region.tipString} ${product.tipString} with ${paymentMethod.tipString}"
+  case class TipPath(
+    region: MonitoredRegion,
+    product: MonitoredProduct,
+    paymentMethod: MonitoredPaymentMethod,
+    guestCheckout: Boolean = false
+  ) {
+    val productLabel: String = if (guestCheckout) s"${product.tipString} (Guest)" else product.tipString
+    val configPath: String = s"${region.tipString} $productLabel with ${paymentMethod.tipString}"
   }
 
   def monitoredRegion(country: String): Option[MonitoredRegion] = country.toUpperCase match {
@@ -52,6 +60,19 @@ object PathVerification {
     case "UK" => Some(UK)
     case "US" => Some(US)
     case _ => None
+  }
+
+  def monitoredRegion(country: Country): Option[MonitoredRegion] = country match {
+    case Country.Australia => Some(AU)
+    case Country.UK => Some(UK)
+    case Country.US => Some(US)
+    case _ => None
+  }
+
+  def monitoredPaymentMethod(paymentFields: PaymentFields): MonitoredPaymentMethod = paymentFields match {
+    case DirectDebitPaymentFields(_, _, _) => DirectDebit
+    case PayPalPaymentFields(_) => PayPal
+    case StripePaymentFields(_) => Card
   }
 
   def verify(tipPath: TipPath, verifier: VerifyPath): Future[TipResponse] = {

--- a/app/wiring/Controllers.scala
+++ b/app/wiring/Controllers.scala
@@ -45,7 +45,8 @@ trait Controllers {
     appConfig.regularPayPalConfigProvider,
     controllerComponents,
     appConfig.guardianDomain,
-    settingsProvider
+    settingsProvider,
+    tipMonitoring
   )
 
   lazy val payPalRegularController = new PayPalRegular(

--- a/conf/tip.yaml
+++ b/conf/tip.yaml
@@ -1,3 +1,5 @@
+# One-off Contributions PayPal
+
 - name: US One-off contribution with PayPal
   description: Successful one-off contribution in USD (using PayPal)
 
@@ -6,3 +8,52 @@
 
 - name: AU One-off contribution with PayPal
   description: Successful one-off contribution in AUD (using PayPal)
+
+# Recurring Contributions PayPal
+
+- name: US Recurring contribution with PayPal
+  description: Successful recurring contributions form submission in USD (using PayPal)
+
+- name: US Recurring contribution (Guest) with PayPal
+  description: Successful recurring contributions (guest checkout) form submission in USD (using PayPal)
+
+- name: UK Recurring contribution with PayPal
+  description: Successful recurring contributions form submission in GBP (using PayPal)
+
+- name: UK Recurring contribution (Guest) with PayPal
+  description: Successful recurring contributions (guest checkout) form submission in GBP (using PayPal)
+
+- name: AU Recurring contribution with PayPal
+  description: Successful recurring contributions form submission in AUD (using PayPal)
+
+- name: AU Recurring contribution (Guest) with PayPal
+  description: Successful recurring contributions (guest checkout) form submission in AUD (using PayPal)
+
+# Recurring Contributions Card
+
+- name: US Recurring contribution with Card
+  description: Successful recurring contributions form submission in USD (using Stripe)
+
+- name: US Recurring contribution (Guest) with Card
+  description: Successful recurring contributions (guest checkout) form submission in USD (using Stripe)
+
+- name: UK Recurring contribution with Card
+  description: Successful recurring contributions form submission in GBP (using Stripe)
+
+- name: UK Recurring contribution (Guest) with Card
+  description: Successful recurring contributions (guest checkout) form submission in GBP (using Stripe)
+
+- name: AU Recurring contribution with Card
+  description: Successful recurring contributions form submission in AUD (using Stripe)
+
+- name: AU Recurring contribution (Guest) with Card
+  description: Successful recurring contributions (guest checkout) form submission in AUD (using Stripe)
+
+# Recurring Contributions Direct Debit
+
+- name: UK Recurring contribution with Direct Debit
+  description: Successful recurring contributions form submission in GBP (using GoCardless)
+
+- name: UK Recurring contribution (Guest) with Direct Debit
+  description: Successful recurring contributions (guest checkout) form submission in GBP (using GoCardless)
+

--- a/test/controllers/RegularContributionsTest.scala
+++ b/test/controllers/RegularContributionsTest.scala
@@ -25,6 +25,7 @@ import com.gu.support.config._
 import fixtures.TestCSRFComponents
 import admin.SwitchState.On
 import admin.{PaymentMethodsSwitch, Settings, SettingsProvider, Switches}
+import com.gu.tip.Tip
 import config.Configuration.GuardianDomain
 
 class RegularContributionsTest extends WordSpec with MustMatchers with TestCSRFComponents {
@@ -118,7 +119,8 @@ class RegularContributionsTest extends WordSpec with MustMatchers with TestCSRFC
         payPalConfigProvider,
         stubControllerComponents(),
         guardianDomain = GuardianDomain(".thegulocal.com"),
-        settingsProvider
+        settingsProvider,
+        mock[Tip]
       )
     }
 


### PR DESCRIPTION
## Why are you doing this?

This is a follow up to https://github.com/guardian/support-frontend/pull/1123 and https://github.com/guardian/support-frontend/pull/1160. It allows us to track important recurring contributions flows and updates a [TiP dashboard](https://github.com/guardian/tip#testing-in-production-tip---) accordingly. 

This should make it easier to spot broken permutations of the checkout flow in production (based on real user data).

![image](https://user-images.githubusercontent.com/19384074/49213647-a60bea00-f3bc-11e8-835a-6b73b245d789.png)

Note that there will be a follow up PR which swaps us over to using a centrally hosted TiP service before this dashboard is properly shareable.

## Changes

* Add recurring paths to TiP config
* Verify relevant paths once successful form submission is confirmed
* Refactor response handling (and minor logging changes) to remove duplication