### PR TITLE
US single contribution amounts & default test

### DIFF
--- a/assets/components/contributionSelection/contributionSelection.jsx
+++ b/assets/components/contributionSelection/contributionSelection.jsx
@@ -42,6 +42,7 @@ type PropTypes = {|
   onKeyPress: Object => void,
   error: ContributionError,
   annualTestVariant: AnnualContributionsTestVariant,
+  usSingleContributionsTestVariant: string,
 |};
 
 
@@ -72,6 +73,7 @@ function ContributionSelection(props: PropTypes) {
               props.currencyId,
               props.countryGroupId,
               props.annualTestVariant,
+              props.usSingleContributionsTestVariant,
             )}
           checked={props.isCustomAmount ? null : props.selectedAmount.toString()}
           toggleAction={props.setAmount}

--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -7,6 +7,20 @@ import type { Tests } from './abtest';
 export type AnnualContributionsTestVariant = 'control' | 'annualAmountsA' | 'notintest';
 
 export const tests: Tests = {
+
+  usSingleContributionsAmounts: {
+    variants: ['control', 'singleD100', 'single3575'],
+    audiences: {
+      UnitedStates: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: true,
+    independent: true,
+    seed: 5,
+  },
+
   annualContributionsRoundThree: {
     variants: ['control', 'annualAmountsA'],
     audiences: {

--- a/assets/helpers/abTests/helpers/usSingleContributionsAmounts.js
+++ b/assets/helpers/abTests/helpers/usSingleContributionsAmounts.js
@@ -1,6 +1,8 @@
 // @flow
+import type { Amount } from 'helpers/contributions';
 
 /* eslint-disable quote-props */
+
 const numbersInWords = {
   '25': 'twenty five',
   '35': 'thirty five',
@@ -13,28 +15,28 @@ const numbersInWords = {
 };
 /* eslint-enable  quote-props */
 
-const VariantA = [
+const VariantA: Array<Amount> = [
   { value: '25', spoken: numbersInWords['25'], isDefault: false },
   { value: '50', spoken: numbersInWords['50'], isDefault: false },
   { value: '100', spoken: numbersInWords['100'], isDefault: true },
   { value: '250', spoken: numbersInWords['250'], isDefault: false },
 ];
 
-const VariantB = [
+const VariantB: Array<Amount> = [
   { value: '35', spoken: numbersInWords['35'], isDefault: false },
   { value: '75', spoken: numbersInWords['75'], isDefault: true },
   { value: '125', spoken: numbersInWords['125'], isDefault: false },
   { value: '250', spoken: numbersInWords['250'], isDefault: false },
 ];
 
-const Control = [
+const Control: Array<Amount> = [
   { value: '25', spoken: numbersInWords['25'], isDefault: false },
   { value: '50', spoken: numbersInWords['50'], isDefault: true },
   { value: '100', spoken: numbersInWords['100'], isDefault: false },
   { value: '250', spoken: numbersInWords['250'], isDefault: false },
 ];
 
-export const getUsSingleAmounts = (usSingleAmountsTestVariant: string) => {
+export const getUsSingleAmounts = (usSingleAmountsTestVariant: string): Array<Amount> => {
   if (usSingleAmountsTestVariant === 'singleD100') {
     return VariantA;
   } else if (usSingleAmountsTestVariant === 'single3575') {

--- a/assets/helpers/abTests/helpers/usSingleContributionsAmounts.js
+++ b/assets/helpers/abTests/helpers/usSingleContributionsAmounts.js
@@ -1,0 +1,45 @@
+// @flow
+
+/* eslint-disable quote-props */
+const numbersInWords = {
+  '25': 'twenty five',
+  '35': 'thirty five',
+  '50': 'fifty',
+  '75': 'seventy five',
+  '100': 'one hundred',
+  '125': 'one hundred and twenty five',
+  '250': 'two hundred and fifty',
+  '275': 'two hundred and seventy five',
+};
+/* eslint-enable  quote-props */
+
+const VariantA = [
+  { value: '25', spoken: numbersInWords['25'], isDefault: false },
+  { value: '50', spoken: numbersInWords['50'], isDefault: false },
+  { value: '100', spoken: numbersInWords['100'], isDefault: true },
+  { value: '250', spoken: numbersInWords['250'], isDefault: false },
+];
+
+const VariantB = [
+  { value: '35', spoken: numbersInWords['35'], isDefault: false },
+  { value: '75', spoken: numbersInWords['75'], isDefault: true },
+  { value: '125', spoken: numbersInWords['125'], isDefault: false },
+  { value: '250', spoken: numbersInWords['250'], isDefault: false },
+];
+
+const Control = [
+  { value: '25', spoken: numbersInWords['25'], isDefault: false },
+  { value: '50', spoken: numbersInWords['50'], isDefault: true },
+  { value: '100', spoken: numbersInWords['100'], isDefault: false },
+  { value: '250', spoken: numbersInWords['250'], isDefault: false },
+];
+
+export const getUsSingleAmounts = (usSingleAmountsTestVariant: string) => {
+  if (usSingleAmountsTestVariant === 'singleD100') {
+    return VariantA;
+  } else if (usSingleAmountsTestVariant === 'single3575') {
+    return VariantB;
+  }
+  return Control;
+};
+

--- a/assets/helpers/contributions.js
+++ b/assets/helpers/contributions.js
@@ -11,6 +11,7 @@ import type { Radio } from 'components/radioToggle/radioToggle';
 import type { AnnualContributionsTestVariant } from 'helpers/abTests/abtestDefinitions';
 import { logException } from 'helpers/logger';
 import { getAnnualAmounts } from 'helpers/abTests/helpers/annualContributions';
+import { getUsSingleAmounts } from 'helpers/abTests/helpers/usSingleContributionsAmounts';
 
 // ----- Types ----- //
 
@@ -228,10 +229,10 @@ const defaultMonthlyAmount = [
   { value: '30', spoken: numbersInWords['30'], isDefault: false },
 ];
 
-const amounts = (annualTestVariant: string) => ({
+const amounts = (annualTestVariant: string, usSingleAmountTestVariant: string) => ({
   ONE_OFF: {
     GBPCountries: defaultOneOffAmount,
-    UnitedStates: defaultOneOffAmount,
+    UnitedStates: getUsSingleAmounts(usSingleAmountTestVariant),
     EURCountries: defaultOneOffAmount,
     AUDCountries: [
       { value: '50', spoken: numbersInWords['50'], isDefault: false },
@@ -465,9 +466,10 @@ function getContributionAmountRadios(
   currencyId: IsoCurrency,
   countryGroupId: CountryGroupId,
   annualTestVariant: AnnualContributionsTestVariant,
+  usSingleAmountTestVariant: string,
 ): Radio[] {
 
-  return amounts(annualTestVariant)[contributionType][countryGroupId].map(amount => ({
+  return amounts(annualTestVariant, usSingleAmountTestVariant)[contributionType][countryGroupId].map(amount => ({
     value: amount.value,
     text: `${currencies[currencyId].glyph}${amount.value}`,
     accessibilityHint: getAmountA11yHint(contributionType, currencyId, amount.spoken),

--- a/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
@@ -33,6 +33,7 @@ type PropTypes = {|
   updateOtherAmount: (string, CountryGroupId, ContributionType) => void,
   checkoutFormHasBeenSubmitted: boolean,
   annualTestVariant: AnnualContributionsTestVariant,
+  usSingleContributionsTestVariant: string,
 |};
 
 /* eslint-enable react/no-unused-prop-types */
@@ -45,6 +46,7 @@ const mapStateToProps = state => ({
   otherAmount: state.page.form.formData.otherAmounts[state.page.form.contributionType].amount,
   checkoutFormHasBeenSubmitted: state.page.form.formData.checkoutFormHasBeenSubmitted,
   annualTestVariant: state.common.abParticipations.annualContributionsRoundThree,
+  usSingleContributionsTestVariant: state.common.abParticipations.usSingleContributionsAmounts,
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -94,7 +96,10 @@ const iconForCountryGroup = (countryGroupId: CountryGroupId): React$Element<*> =
 
 
 function ContributionAmount(props: PropTypes) {
-  const validAmounts: Amount[] = amounts(props.annualTestVariant)[props.contributionType][props.countryGroupId];
+  const validAmounts: Amount[] = amounts(
+    props.annualTestVariant,
+    props.usSingleContributionsTestVariant,
+  )[props.contributionType][props.countryGroupId];
   const showOther: boolean = props.selectedAmounts[props.contributionType] === 'other';
   const { min, max } = config[props.countryGroupId][props.contributionType]; // eslint-disable-line react/prop-types
   const minAmount: string = formatAmount(currencies[props.currency], spokenCurrencies[props.currency], { value: min.toString(), spoken: '', isDefault: false }, false);

--- a/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -15,7 +15,9 @@ import {
   getContributionTypeFromSessionOrElse,
 } from 'helpers/checkouts';
 import { type Participations } from 'helpers/abTests/abtest';
-import { amounts, type Amount, type PaymentMethod, type ContributionType } from 'helpers/contributions';
+import { getUsSingleAmounts } from 'helpers/abTests/helpers/usSingleContributionsAmounts';
+import { getAnnualAmounts } from 'helpers/abTests/helpers/annualContributions';
+import { type Amount, type PaymentMethod, type ContributionType } from 'helpers/contributions';
 import {
   type Action,
   paymentWaiting,
@@ -102,9 +104,19 @@ function selectInitialAnnualAmount(state: State, dispatch: Function) {
   const annualTestVariant = state.common.abParticipations.annualContributionsRoundThree;
 
   if (annualTestVariant) {
-    const annualAmounts: Amount[] = amounts(annualTestVariant).ANNUAL[countryGroupId];
+    const annualAmounts: Amount[] = getAnnualAmounts(annualTestVariant)[countryGroupId];
 
     dispatch(selectAmount(annualAmounts.find(amount => amount.isDefault) || annualAmounts[0], 'ANNUAL'));
+  }
+}
+
+function selectInitialUsSingleAmount(state: State, dispatch: Function) {
+  const usSingleContributionAmountsTestVariant = state.common.abParticipations.usSingleContributionsAmounts;
+
+  if (usSingleContributionAmountsTestVariant) {
+    const usSingleAmounts: Amount[] = getUsSingleAmounts(usSingleContributionAmountsTestVariant);
+
+    dispatch(selectAmount(usSingleAmounts.find(amount => amount.isDefault) || usSingleAmounts[1], 'ONE_OFF'));
   }
 }
 
@@ -127,6 +139,7 @@ const init = (store: Store<State, Action, Function>) => {
   initialisePaymentMethods(state, dispatch);
 
   selectInitialAnnualAmount(state, dispatch);
+  selectInitialUsSingleAmount(state, dispatch);
   selectInitialContributionTypeAndPaymentMethod(state, dispatch);
 
   const {

--- a/assets/pages/new-contributions-landing/contributionsLandingReducer.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingReducer.js
@@ -87,9 +87,9 @@ export type State = {
 
 function createFormReducer(countryGroupId: CountryGroupId) {
   const amountsForCountry: { [ContributionType]: Amount[] } = {
-    ONE_OFF: amounts('notintest').ONE_OFF[countryGroupId],
-    MONTHLY: amounts('notintest').MONTHLY[countryGroupId],
-    ANNUAL: amounts('notintest').ANNUAL[countryGroupId],
+    ONE_OFF: amounts('notintest', 'notintest').ONE_OFF[countryGroupId],
+    MONTHLY: amounts('notintest', 'notintest').MONTHLY[countryGroupId],
+    ANNUAL: amounts('notintest', 'notintest').ANNUAL[countryGroupId],
   };
 
   const initialAmount: { [ContributionType]: Amount | 'other' } = {


### PR DESCRIPTION
## Why are you doing this?
We would like to run two single amounts test variants against the current control for the US-only.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/wJQmqRZL/212-implement-us-singles-amounts-test-for-us-second-priority-friday)

## Changes

* Adds an AB for the amounts and default amount on US page 
* Logic in contributionsLandingInit updates the values with those determined by the user's abtest participation (as per annual test).
* No logic for old design because if you select US you are always on the new design. 

If you want to test locally use: https://support.thegulocal.com/us/contribute#ab-usSingleContributionsAmounts=single3575
https://support.thegulocal.com/us/contribute#ab-usSingleContributionsAmounts=singleD100


## Screenshots

Single_3575 (default 75)
![screen shot 2018-11-30 at 19 19 49](https://user-images.githubusercontent.com/8484757/49373406-f608ea80-f6f5-11e8-8770-7b8121a931c7.jpg)

Single_D100
![screen shot 2018-11-30 at 19 21 01](https://user-images.githubusercontent.com/8484757/49373407-f608ea80-f6f5-11e8-8304-beafe074260a.jpg)

Control
![screen shot 2018-11-30 at 19 21 36](https://user-images.githubusercontent.com/8484757/49373408-f608ea80-f6f5-11e8-88ae-fc1dee48b037.jpg)

