### PR TITLE
Digital Subscriptions Heading

### DIFF
--- a/assets/components/subscriptionsByCountryGroup/components/digitalSection.jsx
+++ b/assets/components/subscriptionsByCountryGroup/components/digitalSection.jsx
@@ -30,7 +30,7 @@ type PropTypes = {|
 
 function DigitalSection(props: PropTypes) {
   return (
-    <ThreeSubscriptions heading="">
+    <ThreeSubscriptions heading="Digital Subscriptions">
       <PremiumTier
         headingSize={props.headingSize}
         referrer={props.appReferrer}


### PR DESCRIPTION
## Why are you doing this?

Adding a heading for "Digital Subscriptions" to the subs landing page (UK only).

[**Trello Card**](https://trello.com/c/f31qOfGL/2090-put-digital-subscriptions-title-back-into-the-uk-subs-landing-page)

## Changes

- Added heading text.

## Screenshots

### Before

![heading-before](https://user-images.githubusercontent.com/5131341/49389754-fa95c900-f71e-11e8-9845-5069384fd271.jpg)

### After

![heading-after](https://user-images.githubusercontent.com/5131341/49389756-fa95c900-f71e-11e8-82db-659d7d7d4719.jpg)
