### PR TITLE
install node before homebrew

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -148,6 +148,7 @@ report() {
 main () {
   check_encryption
   create_aws_config
+  install_node
   install_homebrew
   install_nginx
   install_awscli
@@ -155,7 +156,6 @@ main () {
   copy_nginx_config
   install_jdk
   install_sbt
-  install_node
   install_yarn
   install_js_deps
   report


### PR DESCRIPTION
If a user has a really old version of node running it might stop homebrew behaving as expected. Or at least anecdotally the script didn't work (homebrew error) and then ran `nvm use` and re-ran script and it did work...

Moving install node logic before homebrew.

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com)

## Changes

* Change 1
* Change 2

## Screenshots

