### PR TITLE
Change email signup to disabled after clicking

### DIFF
--- a/assets/components/marketingConsent/helpers.js
+++ b/assets/components/marketingConsent/helpers.js
@@ -25,15 +25,18 @@ function sendMarketingPreferencesToIdentity(
   csrf: CsrfState,
   scope: string,
 ): void {
-  const { setConfirmMarketingConsent, setAPIError } = marketingConsentActionsFor(scope);
+  const { setConfirmMarketingConsent, setAPIError, setLoading } = marketingConsentActionsFor(scope);
 
   if (!optIn) {
     dispatch(setConfirmMarketingConsent(false));
     return;
   }
 
+  dispatch(setLoading(true));
   fetch(`${routes.contributionsSendMarketing}`, requestData(email, csrf))
     .then((response) => {
+
+      dispatch(setLoading(false));
       if (response.status === 200) {
         dispatch(setConfirmMarketingConsent(optIn));
       } else {
@@ -42,6 +45,7 @@ function sendMarketingPreferencesToIdentity(
       }
     })
     .catch(() => {
+      dispatch(setLoading(false));
       logException('Error while trying to interact with the marketing preference API');
       dispatch(setAPIError(true));
     });

--- a/assets/components/marketingConsent/helpers.js
+++ b/assets/components/marketingConsent/helpers.js
@@ -25,18 +25,18 @@ function sendMarketingPreferencesToIdentity(
   csrf: CsrfState,
   scope: string,
 ): void {
-  const { setConfirmMarketingConsent, setAPIError, setLoading } = marketingConsentActionsFor(scope);
+  const { setConfirmMarketingConsent, setAPIError, setRequestPending } = marketingConsentActionsFor(scope);
 
   if (!optIn) {
     dispatch(setConfirmMarketingConsent(false));
     return;
   }
 
-  dispatch(setLoading(true));
+  dispatch(setRequestPending(true));
   fetch(`${routes.contributionsSendMarketing}`, requestData(email, csrf))
     .then((response) => {
 
-      dispatch(setLoading(false));
+      dispatch(setRequestPending(false));
       if (response.status === 200) {
         dispatch(setConfirmMarketingConsent(optIn));
       } else {
@@ -45,7 +45,7 @@ function sendMarketingPreferencesToIdentity(
       }
     })
     .catch(() => {
-      dispatch(setLoading(false));
+      dispatch(setRequestPending(false));
       logException('Error while trying to interact with the marketing preference API');
       dispatch(setAPIError(true));
     });

--- a/assets/components/marketingConsent/marketingConsentActions.js
+++ b/assets/components/marketingConsent/marketingConsentActions.js
@@ -5,7 +5,7 @@
 export type Action =
   | { type: 'SET_API_ERROR', scope: string, error: boolean }
   | { type: 'SET_CONFIRM_MARKETING_CONSENT', scope: string, confirmOptIn: boolean}
-  | { type: 'SET_LOADING', scope: string, loading: boolean};
+  | { type: 'SET_REQUEST_PENDING', scope: string, requestPending: boolean};
 
 // ----- Action Creators ----- //
 
@@ -18,8 +18,8 @@ function marketingConsentActionsFor(scope: string): Object {
     setConfirmMarketingConsent(confirmOptIn: boolean): Action {
       return { type: 'SET_CONFIRM_MARKETING_CONSENT', scope, confirmOptIn };
     },
-    setLoading(loading: boolean): Action {
-      return { type: 'SET_LOADING', scope, loading };
+    setRequestPending(requestPending: boolean): Action {
+      return { type: 'SET_REQUEST_PENDING', scope, requestPending };
     },
   };
 }

--- a/assets/components/marketingConsent/marketingConsentActions.js
+++ b/assets/components/marketingConsent/marketingConsentActions.js
@@ -4,7 +4,8 @@
 
 export type Action =
   | { type: 'SET_API_ERROR', scope: string, error: boolean }
-  | { type: 'SET_CONFIRM_MARKETING_CONSENT', scope: string, confirmOptIn: boolean};
+  | { type: 'SET_CONFIRM_MARKETING_CONSENT', scope: string, confirmOptIn: boolean}
+  | { type: 'SET_LOADING', scope: string, loading: boolean};
 
 // ----- Action Creators ----- //
 
@@ -16,6 +17,9 @@ function marketingConsentActionsFor(scope: string): Object {
     },
     setConfirmMarketingConsent(confirmOptIn: boolean): Action {
       return { type: 'SET_CONFIRM_MARKETING_CONSENT', scope, confirmOptIn };
+    },
+    setLoading(loading: boolean): Action {
+      return { type: 'SET_LOADING', scope, loading };
     },
   };
 }

--- a/assets/components/marketingConsent/marketingConsentReducer.js
+++ b/assets/components/marketingConsent/marketingConsentReducer.js
@@ -40,8 +40,8 @@ function marketingConsentReducerFor(scope: string): Function {
       case 'SET_CONFIRM_MARKETING_CONSENT':
         return { ...state, confirmOptIn: action.confirmOptIn };
 
-      case 'SET_LOADING':
-        return { ...state, loading: action.loading };
+      case 'SET_REQUEST_PENDING':
+        return { ...state, requestPending: action.requestPending };
 
       default:
         return state;

--- a/assets/components/marketingConsent/marketingConsentReducer.js
+++ b/assets/components/marketingConsent/marketingConsentReducer.js
@@ -10,7 +10,7 @@ import type { Action } from './marketingConsentActions';
 export type State = {
   error: boolean,
   confirmOptIn: ?boolean,
-  loading: boolean,
+  requestPending: boolean,
 };
 
 
@@ -19,7 +19,7 @@ export type State = {
 const initialState: State = {
   error: false,
   confirmOptIn: null,
-  loading: false,
+  requestPending: false,
 };
 
 

--- a/assets/components/marketingConsent/marketingConsentReducer.js
+++ b/assets/components/marketingConsent/marketingConsentReducer.js
@@ -10,6 +10,7 @@ import type { Action } from './marketingConsentActions';
 export type State = {
   error: boolean,
   confirmOptIn: ?boolean,
+  loading: boolean,
 };
 
 
@@ -18,6 +19,7 @@ export type State = {
 const initialState: State = {
   error: false,
   confirmOptIn: null,
+  loading: false,
 };
 
 
@@ -37,6 +39,9 @@ function marketingConsentReducerFor(scope: string): Function {
 
       case 'SET_CONFIRM_MARKETING_CONSENT':
         return { ...state, confirmOptIn: action.confirmOptIn };
+
+      case 'SET_LOADING':
+        return { ...state, loading: action.loading };
 
       default:
         return state;

--- a/assets/components/marketingConsentNew/marketingConsent.jsx
+++ b/assets/components/marketingConsentNew/marketingConsent.jsx
@@ -16,19 +16,22 @@ import { logException } from 'helpers/logger';
 
 // ----- Types ----- //
 
-type PropTypes = {|
+type ButtonPropTypes = {|
   confirmOptIn: ?boolean,
   email: string,
   csrf: CsrfState,
   onClick: (?string, CsrfState) => void,
-  error: boolean,
   loading: boolean,
 |};
 
+type PropTypes = {|
+  ...ButtonPropTypes,
+  error: boolean,
+|};
 
 // ----- Render ----- //
 
-function Button(props: PropTypes) {
+function Button(props: ButtonPropTypes) {
   if (props.confirmOptIn === true) {
     return (
       <button
@@ -83,7 +86,13 @@ function MarketingConsent(props: PropTypes) {
           contributor or would like to become one.
         </p>
 
-        {Button(props)}
+        {Button({
+          confirmOptIn: props.confirmOptIn,
+          email: props.email,
+          csrf: props.csrf,
+          onClick: props.onClick,
+          loading: props.loading,
+        })}
 
         <p className="confirmation__meta">
           <small>

--- a/assets/components/marketingConsentNew/marketingConsent.jsx
+++ b/assets/components/marketingConsentNew/marketingConsent.jsx
@@ -21,7 +21,7 @@ type ButtonPropTypes = {|
   email: string,
   csrf: CsrfState,
   onClick: (?string, CsrfState) => void,
-  loading: boolean,
+  requestPending: boolean,
 |};
 
 type PropTypes = {|
@@ -42,14 +42,14 @@ function Button(props: ButtonPropTypes) {
         Signed up
       </button>
     );
-  } else if (props.loading === true) {
+  } else if (props.requestPending === true) {
     return (
       <button
         disabled="disabled"
-        className={classNameWithModifiers('button', ['newsletter', 'newsletter__loading'])}
+        className={classNameWithModifiers('button', ['newsletter', 'newsletter__request-pending'])}
       >
         <SvgSubscribe />
-        Loading...
+        Pending...
       </button>
     );
   }
@@ -91,7 +91,7 @@ function MarketingConsent(props: PropTypes) {
           email: props.email,
           csrf: props.csrf,
           onClick: props.onClick,
-          loading: props.loading,
+          requestPending: props.requestPending,
         })}
 
         <p className="confirmation__meta">
@@ -116,7 +116,7 @@ function MarketingConsent(props: PropTypes) {
 
 MarketingConsent.defaultProps = {
   error: false,
-  loading: false,
+  requestPending: false,
 };
 
 

--- a/assets/components/marketingConsentNew/marketingConsent.jsx
+++ b/assets/components/marketingConsentNew/marketingConsent.jsx
@@ -22,10 +22,47 @@ type PropTypes = {|
   csrf: CsrfState,
   onClick: (?string, CsrfState) => void,
   error: boolean,
+  loading: boolean,
 |};
 
 
 // ----- Render ----- //
+
+function Button(props: PropTypes) {
+  if (props.confirmOptIn === true) {
+    return (
+      <button
+        disabled="disabled"
+        className={classNameWithModifiers('button', ['newsletter', 'newsletter__subscribed'])}
+      >
+        <SvgSubscribed />
+        Signed up
+      </button>
+    );
+  } else if (props.loading === true) {
+    return (
+      <button
+        disabled="disabled"
+        className={classNameWithModifiers('button', ['newsletter', 'newsletter__loading'])}
+      >
+        <SvgSubscribe />
+        Loading...
+      </button>
+    );
+  }
+  return (
+    <button
+      className={classNameWithModifiers('button', ['newsletter'])}
+      onClick={
+          () => props.onClick(props.email, props.csrf)
+        }
+    >
+      <SvgSubscribe />
+        Sign me up
+    </button>
+  );
+
+}
 
 function MarketingConsent(props: PropTypes) {
 
@@ -46,24 +83,7 @@ function MarketingConsent(props: PropTypes) {
           contributor or would like to become one.
         </p>
 
-        {props.confirmOptIn === true ?
-          <button
-            disabled="disabled"
-            className={classNameWithModifiers('button', ['newsletter', 'newsletter__subscribed'])}
-          >
-            <SvgSubscribed />
-            Signed up
-          </button> :
-          <button
-            className={classNameWithModifiers('button', ['newsletter'])}
-            onClick={
-              () => props.onClick(props.email, props.csrf)
-            }
-          >
-            <SvgSubscribe />
-            Sign me up
-          </button>
-        }
+        {Button(props)}
 
         <p className="confirmation__meta">
           <small>
@@ -87,6 +107,7 @@ function MarketingConsent(props: PropTypes) {
 
 MarketingConsent.defaultProps = {
   error: false,
+  loading: false,
 };
 
 

--- a/assets/pages/new-contributions-landing/components/MarketingConsentContainer.jsx
+++ b/assets/pages/new-contributions-landing/components/MarketingConsentContainer.jsx
@@ -16,6 +16,7 @@ const mapStateToProps = state => ({
   email: state.page.form.formData.email,
   csrf: state.page.csrf,
   error: state.page.marketingConsent.error,
+  loading: state.page.marketingConsent.loading,
 });
 
 function mapDispatchToProps(dispatch: Dispatch<Action>) {

--- a/assets/pages/new-contributions-landing/components/MarketingConsentContainer.jsx
+++ b/assets/pages/new-contributions-landing/components/MarketingConsentContainer.jsx
@@ -16,7 +16,7 @@ const mapStateToProps = state => ({
   email: state.page.form.formData.email,
   csrf: state.page.csrf,
   error: state.page.marketingConsent.error,
-  loading: state.page.marketingConsent.loading,
+  requestPending: state.page.marketingConsent.requestPending,
 });
 
 function mapDispatchToProps(dispatch: Dispatch<Action>) {

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -996,6 +996,11 @@ form {
   background-color: transparent;
 }
 
+.button--newsletter__loading {
+  color: gu-colour(garnett-neutral-4);
+  background-color: transparent;
+}
+
 .button--right-arrow {
   width: 100%;
   padding: 0 50px 0 $gu-h-spacing;

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -996,7 +996,7 @@ form {
   background-color: transparent;
 }
 
-.button--newsletter__loading {
+.button--newsletter__request-pending {
   color: gu-colour(garnett-neutral-4);
   background-color: transparent;
 }

--- a/assets/pages/oneoff-contributions/__tests__/__snapshots__/oneoffContributionsReducersTest.js.snap
+++ b/assets/pages/oneoff-contributions/__tests__/__snapshots__/oneoffContributionsReducersTest.js.snap
@@ -13,6 +13,7 @@ Object {
   "marketingConsent": Object {
     "confirmOptIn": null,
     "error": false,
+    "loading": false,
   },
   "oneoffContrib": Object {
     "amount": 20,

--- a/assets/pages/oneoff-contributions/__tests__/__snapshots__/oneoffContributionsReducersTest.js.snap
+++ b/assets/pages/oneoff-contributions/__tests__/__snapshots__/oneoffContributionsReducersTest.js.snap
@@ -13,7 +13,7 @@ Object {
   "marketingConsent": Object {
     "confirmOptIn": null,
     "error": false,
-    "loading": false,
+    "requestPending": false,
   },
   "oneoffContrib": Object {
     "amount": 20,

--- a/assets/pages/regular-contributions/__tests__/__snapshots__/regularContributionsReducersTest.js.snap
+++ b/assets/pages/regular-contributions/__tests__/__snapshots__/regularContributionsReducersTest.js.snap
@@ -30,6 +30,7 @@ Object {
   "marketingConsent": Object {
     "confirmOptIn": null,
     "error": false,
+    "loading": false,
   },
   "regularContrib": Object {
     "amount": 20,

--- a/assets/pages/regular-contributions/__tests__/__snapshots__/regularContributionsReducersTest.js.snap
+++ b/assets/pages/regular-contributions/__tests__/__snapshots__/regularContributionsReducersTest.js.snap
@@ -30,7 +30,7 @@ Object {
   "marketingConsent": Object {
     "confirmOptIn": null,
     "error": false,
-    "loading": false,
+    "requestPending": false,
   },
   "regularContrib": Object {
     "amount": 20,


### PR DESCRIPTION
## Why are you doing this?
Sometimes when network issues happened, we were getting multiple duplicate requests for the sign up to the emails button.

This was because when they clicked the button it wasn't actually disabled and the visual appearance didn't change, so during slow network conditions they would click it quite a few times.

This PR changes the button to be disabled when they click, until the resonse comes in.
It also changes the button to look different so people know their click was registered.

[**Trello Card**](https://trello.com/c/IC361x2a/198-investigate-500-errors-should-they-be-500s)

before clicking (no change)
![image](https://user-images.githubusercontent.com/7304387/49448070-f8d80e00-f7cf-11e8-9fbf-c17fb7326bcd.png)
new - while loading (used to be the same as before clicking)
![image](https://user-images.githubusercontent.com/7304387/49448096-0beade00-f7d0-11e8-9ab4-568cced2844c.png)
after complete (no change)
![image](https://user-images.githubusercontent.com/7304387/49448247-5f5d2c00-f7d0-11e8-801e-835692a2bc4f.png)
after error (no change)
![image](https://user-images.githubusercontent.com/7304387/49448292-7c91fa80-f7d0-11e8-88d8-db4895dd7180.png)

@jranks123 for tech review and @ionamckendrick for behaviour review please