### PR TITLE
warn when something bad happens that doesn't affect conversion

### DIFF
--- a/app/services/aws/AwsCloudwatchMetricPut.scala
+++ b/app/services/aws/AwsCloudwatchMetricPut.scala
@@ -1,0 +1,62 @@
+package services.aws
+
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.cloudwatch.model._
+import com.amazonaws.services.cloudwatch.{AmazonCloudWatch, AmazonCloudWatchClientBuilder}
+import com.gu.support.config.Stage
+import services.aws
+
+import scala.util.Try
+
+object AwsCloudwatchMetricPut {
+  val cloudWatchEffect: AmazonCloudWatch =
+    AmazonCloudWatchClientBuilder
+      .standard()
+      .withRegion(Regions.EU_WEST_1)
+      .withCredentials(aws.CredentialsProvider)
+      .build()
+
+  case class MetricNamespace(value: String) extends AnyVal
+  case class MetricName(value: String) extends AnyVal
+  case class MetricDimensionName(value: String) extends AnyVal
+  case class MetricDimensionValue(value: String) extends AnyVal
+
+  case class MetricRequest(
+      namespace: MetricNamespace,
+      name: MetricName,
+      dimensions: Map[MetricDimensionName, MetricDimensionValue]
+  )
+
+  def apply(s3Client: AmazonCloudWatch)(request: MetricRequest): Try[Unit] = {
+
+    val putMetricDataRequest = new PutMetricDataRequest
+    putMetricDataRequest.setNamespace(request.namespace.value)
+
+    val metricDatum1 = request.dimensions.foldLeft(
+      new MetricDatum()
+        .withMetricName(request.name.value)
+    ) {
+        case (agg, (name, value)) =>
+          agg.withDimensions(
+            new Dimension()
+              .withName(name.value)
+              .withValue(value.value)
+          )
+      }
+    metricDatum1.setValue(1.00)
+    metricDatum1.setUnit(StandardUnit.Count)
+    putMetricDataRequest.getMetricData.add(metricDatum1)
+    Try(s3Client.putMetricData(putMetricDataRequest)).map(_ => ())
+  }
+
+  def setupWarningRequest(stage: Stage): MetricRequest = {
+    MetricRequest(
+      MetricNamespace(s"support-frontend"),
+      MetricName("WarningCount"),
+      Map(
+        MetricDimensionName("Stage") -> MetricDimensionValue(stage.toString)
+      )
+    )
+  }
+
+}

--- a/app/wiring/Controllers.scala
+++ b/app/wiring/Controllers.scala
@@ -2,6 +2,7 @@ package wiring
 
 import controllers._
 import play.api.BuiltInComponentsFromContext
+import services.aws.AwsCloudwatchMetricPut
 
 trait Controllers {
 
@@ -98,7 +99,8 @@ trait Controllers {
     identityService,
     controllerComponents,
     actionRefiners,
-    appConfig.guardianDomain
+    appConfig.guardianDomain,
+    () => AwsCloudwatchMetricPut(AwsCloudwatchMetricPut.cloudWatchEffect)(AwsCloudwatchMetricPut.setupWarningRequest(appConfig.stage))
   )
 
   lazy val directDebitController = new DirectDebit(

--- a/build.sbt
+++ b/build.sbt
@@ -62,6 +62,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-stepfunctions" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-sts" % awsVersion,
   "com.amazonaws" % "aws-java-sdk-s3" % awsVersion,
+  "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsVersion,
   "org.typelevel" %% "cats-core" % "1.0.1",
   "com.dripower" %% "play-circe" % "2609.1",
   "com.gu" %% "support-models" % "0.38",

--- a/cloud-formation/cfn.yaml
+++ b/cloud-formation/cfn.yaml
@@ -292,6 +292,25 @@ Resources:
     - TargetGroup
     - ElasticLoadBalancer
 
+  HighWarningAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: CreateProdResources
+    Properties:
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
+      AlarmName: Warnings support-frontend
+      AlarmDescription: This alerts when non critical events happen. These should be dealt with in the next sprint.
+      MetricName: WarningCount
+      Namespace: support-frontend
+      Dimensions:
+        - Name: Stage
+          Value: !Sub ${Stage}
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Threshold: 3
+      Period: 60
+      EvaluationPeriods: 2
+      Statistic: Sum
+
   StateMachineUnavailableMetric:
     Type: "AWS::Logs::MetricFilter"
     Properties:


### PR DESCRIPTION
## Why are you doing this?

Currently we have a lot of alerts for stuff that shouldn't happen, but isn't as severe as all that.
At the moment we can either shout loudly that something is broken, or hide it completely.
It would be better to have a category for alerts that don't need immediate attention but should be planned in to a sprint.

This PR adds a warning count in cloudwatch and makes it alert when guest password or email sing up don't work.
These are chosen because they don't affect conversion, however they reflect failures that would influence business metrics.

I'm keen to add an alarm into the cloudformation for PROD, but I would want us to decide on a suitable threshold and also wording to make it clear this is an alert to be planned into a sprint rather than an something is on fire one.

[**Trello Card**](https://trello.com/c/IC361x2a/198-investigate-500-errors-should-they-be-500s)

![image](https://user-images.githubusercontent.com/7304387/49455828-ba4a4f80-f7df-11e8-80a2-2a8ac06396fd.png)

