### PR TITLE
Digital Checkout Internationalise Prices

### DIFF
--- a/assets/helpers/internationalisation/countryGroup.js
+++ b/assets/helpers/internationalisation/countryGroup.js
@@ -170,4 +170,5 @@ export {
   countryGroups,
   detect,
   stringToCountryGroupId,
+  fromCountry,
 };

--- a/assets/helpers/subscriptions.js
+++ b/assets/helpers/subscriptions.js
@@ -10,6 +10,7 @@ import { currencies, detect } from './internationalisation/currency';
 
 
 // ----- Types ------ //
+
 export type SubscriptionProduct =
   'DigitalPack' |
   'PremiumTier' |
@@ -25,8 +26,7 @@ export type ComponentAbTest = {
   variant: string,
 };
 
-
-// ----- Config ----- //
+export type DigitalBillingPeriod = 'monthly' | 'yearly';
 export type BillingPeriod = 'sixweek' | 'quarter' | 'year' | 'month';
 export type WeeklyBillingPeriod = 'sixweek' | 'quarter' | 'year';
 
@@ -41,6 +41,9 @@ const newsstandPrices: {[PaperNewsstandTiers]: number} = {
   saturday: 2.9,
   sunday: 3,
 };
+
+
+// ----- Config ----- //
 
 const subscriptionPricesForDefaultBillingPeriod: {
   [SubscriptionProduct]: {
@@ -98,6 +101,37 @@ const discountPricesForDefaultBillingPeriod: {
   },
 };
 
+const digitalSubscriptionPrices = {
+  GBPCountries: {
+    monthly: 11.99,
+    yearly: 119.90,
+  },
+  UnitedStates: {
+    monthly: 19.99,
+    yearly: 199.90,
+  },
+  AUDCountries: {
+    monthly: 21.50,
+    yearly: 215.00,
+  },
+  EURCountries: {
+    monthly: 14.99,
+    yearly: 149.90,
+  },
+  International: {
+    monthly: 19.99,
+    yearly: 199.90,
+  },
+  NZDCountries: {
+    monthly: 23.50,
+    yearly: 235.00,
+  },
+  Canada: {
+    monthly: 21.95,
+    yearly: 219.50,
+  },
+};
+
 const subscriptionPricesForGuardianWeekly: {
   [CountryGroupId]: {
     [WeeklyBillingPeriod]: number,
@@ -140,7 +174,6 @@ const subscriptionPricesForGuardianWeekly: {
   },
 };
 
-
 const defaultBillingPeriods: {
   [SubscriptionProduct]: BillingPeriod
 } = {
@@ -160,6 +193,10 @@ function fixDecimals(number: number): string {
     return number.toString();
   }
   return number.toFixed(2);
+}
+
+function getDigitalPrice(cgId: CountryGroupId, frequency: DigitalBillingPeriod): number {
+  return digitalSubscriptionPrices[cgId][frequency];
 }
 
 function getProductPrice(product: SubscriptionProduct, countryGroupId: CountryGroupId): string {
@@ -253,4 +290,5 @@ export {
   getWeeklyProductPrice,
   getNewsstandSaving,
   getNewsstandPrice,
+  getDigitalPrice,
 };

--- a/assets/helpers/subscriptions.js
+++ b/assets/helpers/subscriptions.js
@@ -26,7 +26,7 @@ export type ComponentAbTest = {
   variant: string,
 };
 
-export type DigitalBillingPeriod = 'monthly' | 'yearly';
+export type DigitalBillingPeriod = 'month' | 'year';
 export type BillingPeriod = 'sixweek' | 'quarter' | 'year' | 'month';
 export type WeeklyBillingPeriod = 'sixweek' | 'quarter' | 'year';
 
@@ -103,32 +103,32 @@ const discountPricesForDefaultBillingPeriod: {
 
 const digitalSubscriptionPrices = {
   GBPCountries: {
-    monthly: 11.99,
-    yearly: 119.90,
+    month: 11.99,
+    year: 119.90,
   },
   UnitedStates: {
-    monthly: 19.99,
-    yearly: 199.90,
+    month: 19.99,
+    year: 199.90,
   },
   AUDCountries: {
-    monthly: 21.50,
-    yearly: 215.00,
+    month: 21.50,
+    year: 215.00,
   },
   EURCountries: {
-    monthly: 14.99,
-    yearly: 149.90,
+    month: 14.99,
+    year: 149.90,
   },
   International: {
-    monthly: 19.99,
-    yearly: 199.90,
+    month: 19.99,
+    year: 199.90,
   },
   NZDCountries: {
-    monthly: 23.50,
-    yearly: 235.00,
+    month: 23.50,
+    year: 235.00,
   },
   Canada: {
-    monthly: 21.95,
-    yearly: 219.50,
+    month: 21.95,
+    year: 219.50,
   },
 };
 

--- a/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -153,16 +153,16 @@ function CheckoutForm(props: PropTypes) {
         <h2 className="checkout-form__heading">How often would you like to pay?</h2>
         <Fieldset>
           <RadioInput
-            text={`${getPrice(props.country, 'monthly')}Every month`}
+            text={`${getPrice(props.country, 'month')}Every month`}
             name="paymentFrequency"
-            checked={props.paymentFrequency === 'monthly'}
-            onChange={() => props.setPaymentFrequency('monthly')}
+            checked={props.paymentFrequency === 'month'}
+            onChange={() => props.setPaymentFrequency('month')}
           />
           <RadioInput
-            text={`${getPrice(props.country, 'yearly')}Every year`}
+            text={`${getPrice(props.country, 'year')}Every year`}
             name="paymentFrequency"
-            checked={props.paymentFrequency === 'yearly'}
-            onChange={() => props.setPaymentFrequency('yearly')}
+            checked={props.paymentFrequency === 'year'}
+            onChange={() => props.setPaymentFrequency('year')}
           />
         </Fieldset>
       </LeftMarginSection>

--- a/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -9,6 +9,9 @@ import { compose } from 'redux';
 import { countries, usStates, caStates, type IsoCountry } from 'helpers/internationalisation/country';
 import { type FormError, firstError } from 'helpers/subscriptionsForms/validation';
 import { type Option } from 'helpers/types/option';
+import { fromCountry, countryGroups, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { getDigitalPrice, type DigitalBillingPeriod } from 'helpers/subscriptions';
+import { currencies } from 'helpers/internationalisation/currency';
 
 import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
 import CheckoutCopy from 'components/checkoutCopy/checkoutCopy';
@@ -50,6 +53,24 @@ function mapStateToProps(state: State) {
     ...getFormFields(state),
     errors: state.page.checkout.errors,
   };
+}
+
+
+// ----- Functions ----- //
+
+function getPrice(country: Option<IsoCountry>, frequency: DigitalBillingPeriod): string {
+
+  const cgId: ?CountryGroupId = fromCountry(country || '');
+
+  if (cgId) {
+
+    const glyph = currencies[countryGroups[cgId].currency].extendedGlyph;
+    const price = getDigitalPrice(cgId, frequency).toFixed(2);
+    return `${glyph}${price} `;
+
+  }
+
+  return '';
 }
 
 
@@ -132,13 +153,13 @@ function CheckoutForm(props: PropTypes) {
         <h2 className="checkout-form__heading">How often would you like to pay?</h2>
         <Fieldset>
           <RadioInput
-            text="£11.99 Every month"
+            text={`${getPrice(props.country, 'monthly')}Every month`}
             name="paymentFrequency"
             checked={props.paymentFrequency === 'monthly'}
             onChange={() => props.setPaymentFrequency('monthly')}
           />
           <RadioInput
-            text="£119.90 Every year"
+            text={`${getPrice(props.country, 'yearly')}Every year`}
             name="paymentFrequency"
             checked={props.paymentFrequency === 'yearly'}
             onChange={() => props.setPaymentFrequency('yearly')}

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -144,7 +144,7 @@ const initialState = {
   country: null,
   stateProvince: null,
   telephone: '',
-  paymentFrequency: 'monthly',
+  paymentFrequency: 'month',
   paymentMethod: 'directDebit',
   errors: [],
 };

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -7,6 +7,7 @@ import { compose, combineReducers, type Dispatch } from 'redux';
 import { type ReduxState } from 'helpers/page/page';
 import { type Option } from 'helpers/types/option';
 import { detect, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { type DigitalBillingPeriod } from 'helpers/subscriptions';
 import { type Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import csrf from 'helpers/csrf/csrfReducer';
 import { createUserReducer, type User as UserState } from 'helpers/user/userReducer';
@@ -33,7 +34,6 @@ import {
 // ----- Types ----- //
 
 export type Stage = 'checkout' | 'thankyou';
-type PaymentFrequency = 'monthly' | 'yearly';
 type PaymentMethod = 'card' | 'directDebit';
 
 export type FormFields = {|
@@ -42,7 +42,7 @@ export type FormFields = {|
   country: Option<IsoCountry>,
   stateProvince: Option<StateProvince>,
   telephone: string,
-  paymentFrequency: PaymentFrequency,
+  paymentFrequency: DigitalBillingPeriod,
   paymentMethod: PaymentMethod,
 |};
 
@@ -68,7 +68,7 @@ export type Action =
   | { type: 'SET_TELEPHONE', telephone: string }
   | { type: 'SET_COUNTRY', country: string }
   | { type: 'SET_STATE_PROVINCE', stateProvince: string }
-  | { type: 'SET_PAYMENT_FREQUENCY', paymentFrequency: PaymentFrequency }
+  | { type: 'SET_PAYMENT_FREQUENCY', paymentFrequency: DigitalBillingPeriod }
   | { type: 'SET_PAYMENT_METHOD', paymentMethod: PaymentMethod }
   | { type: 'SET_ERRORS', errors: FormError<FormField>[] };
 
@@ -126,7 +126,7 @@ const formActionCreators = {
   setTelephone: (telephone: string): Action => ({ type: 'SET_TELEPHONE', telephone }),
   setCountry: (country: string): Action => ({ type: 'SET_COUNTRY', country }),
   setStateProvince: (stateProvince: string): Action => ({ type: 'SET_STATE_PROVINCE', stateProvince }),
-  setPaymentFrequency: (paymentFrequency: PaymentFrequency): Action => ({ type: 'SET_PAYMENT_FREQUENCY', paymentFrequency }),
+  setPaymentFrequency: (paymentFrequency: DigitalBillingPeriod): Action => ({ type: 'SET_PAYMENT_FREQUENCY', paymentFrequency }),
   setPaymentMethod: (paymentMethod: PaymentMethod): Action => ({ type: 'SET_PAYMENT_METHOD', paymentMethod }),
   submitForm: () => (dispatch: Dispatch<Action>, getState: () => State) =>
     compose(dispatch, setFormErrors, getErrors, getFormFields)(getState()),


### PR DESCRIPTION
## Why are you doing this?

Display prices on the digital checkout.

[**Trello Card**](https://trello.com/c/04Ln5TWR/1506-select-subscription-frequency)

## Changes

- Exported `fromCountry` from the `countryGroup` helper.
- Configured digital subscription prices and created a helper to retrieve them.
- Moved digital billing period type in `subscriptions` helper.
- Displayed prices in the payment frequency section of the checkout.

## Screenshots

|UK|US|AU|None|
|-|-|-|-
|![price-uk](https://user-images.githubusercontent.com/5131341/49513759-f1753b00-f889-11e8-859b-0e26b2ac6703.png)|![price-us](https://user-images.githubusercontent.com/5131341/49513768-f934df80-f889-11e8-9a6b-88290d2a3da9.png)|![price-au](https://user-images.githubusercontent.com/5131341/49513776-ffc35700-f889-11e8-9ce4-35eb42693351.png)|![price-none](https://user-images.githubusercontent.com/5131341/49513785-05b93800-f88a-11e8-9219-10170d62444d.png)|
