### PR TITLE
fix location of nginx conf symlnk

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -137,7 +137,7 @@ fetch_dev_cert() {
 }
 
 link_nginx_config() {
-  ln -sf ../nginx/support.conf ${NGINX_ROOT}sites-enabled/support.conf
+  ln -sf ${PWD}/nginx/support.conf ${NGINX_ROOT}sites-enabled/support.conf
 }
 
 report() {


### PR DESCRIPTION
Relative symlinks are bad because they're relative to the destination 😄.