### PR TITLE
actually allow permission to push metrics to cloudwatch

### DIFF
--- a/app/controllers/IdentityController.scala
+++ b/app/controllers/IdentityController.scala
@@ -28,6 +28,12 @@ class IdentityController(
 
   import actionRefiners._
 
+  def warnAndReturn(): Status =
+    warn().fold({ t =>
+      SafeLogger.error(scrub"failed to send metrics", t)
+      InternalServerError
+    }, _ => NotFound)
+
   def submitMarketing(): Action[SendMarketingRequest] = PrivateAction.async(circe.json[SendMarketingRequest]) { implicit request =>
     val result = identityService.sendConsentPreferencesEmail(request.body.email)
     result.map { res =>
@@ -35,9 +41,7 @@ class IdentityController(
         SafeLogger.info(s"Successfully sent consents preferences email for ${request.body.email}")
         Ok
       } else {
-        SafeLogger.error(scrub"Failed to send consents preferences email for ${request.body.email}")
-        warn()
-        NotFound
+        warnAndReturn()
       }
     }
   }
@@ -48,8 +52,7 @@ class IdentityController(
       .fold(
         err => {
           SafeLogger.error(scrub"Failed to set password using guest account registration token ${request.body.guestAccountRegistrationToken}: ${err.toString}")
-          warn()
-          NotFound
+          warnAndReturn()
         },
         cookiesFromResponse => {
           SafeLogger.info(s"Successfully set password using guest account registration token ${request.body.guestAccountRegistrationToken}")

--- a/cloud-formation/cfn.yaml
+++ b/cloud-formation/cfn.yaml
@@ -121,6 +121,13 @@ Resources:
             Version: 2012-10-17
             Statement:
               - Effect: Allow
+                Action: cloudwatch:PutMetricData
+                Resource: '*'
+        - PolicyName: CloudwatchMetrics
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
                 Action:
                 - logs:CreateLogGroup
                 - logs:CreateLogStream
@@ -298,7 +305,7 @@ Resources:
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
-      AlarmName: Warnings support-frontend
+      AlarmName: !Sub Warnings support-frontend in ${Stage}
       AlarmDescription: This alerts when non critical events happen. These should be dealt with in the next sprint.
       MetricName: WarningCount
       Namespace: support-frontend


### PR DESCRIPTION
## Why are you doing this?

The [previous PR](https://github.com/guardian/support-frontend/pull/1259) added code to push metrics to cloudwatch when a non critical event happened (look at next sprint)  However I forgot that I would need to also give IAM permission for the instances to access cloudwatch.

This time I have actually done an end to end test in CODE to make sure the alert email actually arrives.  However I have turned the alarm off in CODE.

[**Trello Card**](https://trello.com/c/IC361x2a/198-investigate-500-errors-should-they-be-500s)

![image](https://user-images.githubusercontent.com/7304387/49578385-8850fe80-f941-11e8-8c14-e54f3ff05022.png)
