### PR TITLE
Price Type

### DIFF
--- a/assets/helpers/internationalisation/currency.js
+++ b/assets/helpers/internationalisation/currency.js
@@ -134,6 +134,11 @@ function detect(countryGroup: CountryGroupId): IsoCurrency {
   return fromQueryParameter() || fromCountryGroupId(countryGroup) || 'GBP';
 }
 
+function showPrice(p: Price, extendedGlyph: boolean = false): string {
+  const glyph = currencies[p.currency][extendedGlyph ? 'extendedGlyph' : 'glyph'];
+  return `${glyph}${p.value.toFixed(2)}`;
+}
+
 const GBP = (value: number): Price => ({ value, currency: 'GBP' });
 const USD = (value: number): Price => ({ value, currency: 'USD' });
 const AUD = (value: number): Price => ({ value, currency: 'AUD' });
@@ -149,6 +154,7 @@ export {
   spokenCurrencies,
   fromCountryGroupId,
   currencies,
+  showPrice,
   GBP,
   USD,
   AUD,

--- a/assets/helpers/internationalisation/currency.js
+++ b/assets/helpers/internationalisation/currency.js
@@ -1,10 +1,17 @@
 // @flow
 
+// ----- Imports ----- //
+
 import { getQueryParameter } from 'helpers/url';
-import { countryGroups } from './countryGroup';
 
-import type { CountryGroup, CountryGroupId } from './countryGroup';
+import {
+  type CountryGroup,
+  type CountryGroupId,
+  countryGroups,
+} from './countryGroup';
 
+
+// ----- Types ----- //
 
 export type IsoCurrency =
   | 'GBP'
@@ -23,6 +30,9 @@ export type SpokenCurrency = {|
   singular: string,
   plural: string,
 |};
+
+
+// ----- Config ----- //
 
 const currencies: {
   [IsoCurrency]: Currency,
@@ -82,6 +92,9 @@ const spokenCurrencies: {
   },
 };
 
+
+// ----- Functions ----- //
+
 function fromCountryGroupId(countryGroupId: CountryGroupId): ?IsoCurrency {
   const countryGroup: ?CountryGroup = countryGroups[countryGroupId];
 
@@ -91,7 +104,6 @@ function fromCountryGroupId(countryGroupId: CountryGroupId): ?IsoCurrency {
 
   return countryGroup.currency;
 }
-
 
 function fromString(s: string): ?IsoCurrency {
   switch (s.toLowerCase()) {
@@ -116,6 +128,9 @@ function fromQueryParameter(): ?IsoCurrency {
 function detect(countryGroup: CountryGroupId): IsoCurrency {
   return fromQueryParameter() || fromCountryGroupId(countryGroup) || 'GBP';
 }
+
+
+// ----- Exports ----- //
 
 export {
   detect,

--- a/assets/helpers/internationalisation/currency.js
+++ b/assets/helpers/internationalisation/currency.js
@@ -31,11 +31,6 @@ export type SpokenCurrency = {|
   plural: string,
 |};
 
-export type Price = $ReadOnly<{|
-  value: number,
-  currency: IsoCurrency,
-|}>;
-
 
 // ----- Config ----- //
 
@@ -134,17 +129,8 @@ function detect(countryGroup: CountryGroupId): IsoCurrency {
   return fromQueryParameter() || fromCountryGroupId(countryGroup) || 'GBP';
 }
 
-function showPrice(p: Price, extendedGlyph: boolean = false): string {
-  const glyph = currencies[p.currency][extendedGlyph ? 'extendedGlyph' : 'glyph'];
-  return `${glyph}${p.value.toFixed(2)}`;
-}
-
-const GBP = (value: number): Price => ({ value, currency: 'GBP' });
-const USD = (value: number): Price => ({ value, currency: 'USD' });
-const AUD = (value: number): Price => ({ value, currency: 'AUD' });
-const EUR = (value: number): Price => ({ value, currency: 'EUR' });
-const NZD = (value: number): Price => ({ value, currency: 'NZD' });
-const CAD = (value: number): Price => ({ value, currency: 'CAD' });
+const glyph = (c: IsoCurrency): string => currencies[c].glyph;
+const extendedGlyph = (c: IsoCurrency): string => currencies[c].extendedGlyph;
 
 
 // ----- Exports ----- //
@@ -154,11 +140,6 @@ export {
   spokenCurrencies,
   fromCountryGroupId,
   currencies,
-  showPrice,
-  GBP,
-  USD,
-  AUD,
-  EUR,
-  NZD,
-  CAD,
+  glyph,
+  extendedGlyph,
 };

--- a/assets/helpers/internationalisation/currency.js
+++ b/assets/helpers/internationalisation/currency.js
@@ -31,6 +31,11 @@ export type SpokenCurrency = {|
   plural: string,
 |};
 
+export type Price = $ReadOnly<{|
+  value: number,
+  currency: IsoCurrency,
+|}>;
+
 
 // ----- Config ----- //
 
@@ -129,6 +134,13 @@ function detect(countryGroup: CountryGroupId): IsoCurrency {
   return fromQueryParameter() || fromCountryGroupId(countryGroup) || 'GBP';
 }
 
+const GBP = (value: number): Price => ({ value, currency: 'GBP' });
+const USD = (value: number): Price => ({ value, currency: 'USD' });
+const AUD = (value: number): Price => ({ value, currency: 'AUD' });
+const EUR = (value: number): Price => ({ value, currency: 'EUR' });
+const NZD = (value: number): Price => ({ value, currency: 'NZD' });
+const CAD = (value: number): Price => ({ value, currency: 'CAD' });
+
 
 // ----- Exports ----- //
 
@@ -137,4 +149,10 @@ export {
   spokenCurrencies,
   fromCountryGroupId,
   currencies,
+  GBP,
+  USD,
+  AUD,
+  EUR,
+  NZD,
+  CAD,
 };

--- a/assets/helpers/internationalisation/price.js
+++ b/assets/helpers/internationalisation/price.js
@@ -22,9 +22,9 @@ const EUR = (value: number): Price => ({ value, currency: 'EUR' });
 const NZD = (value: number): Price => ({ value, currency: 'NZD' });
 const CAD = (value: number): Price => ({ value, currency: 'CAD' });
 
-function showPrice(p: Price, extended: boolean = false): string {
+function showPrice(p: Price, isExtended: boolean = false): string {
 
-  const showGlyph = extended ? extendedGlyph : glyph;
+  const showGlyph = isExtended ? extendedGlyph : glyph;
   return `${showGlyph(p.currency)}${p.value.toFixed(2)}`;
 
 }

--- a/assets/helpers/internationalisation/price.js
+++ b/assets/helpers/internationalisation/price.js
@@ -1,0 +1,43 @@
+// @flow
+
+// ----- Imports ----- //
+
+import { type IsoCurrency, glyph, extendedGlyph } from './currency';
+
+
+// ----- Types ----- //
+
+export type Price = $ReadOnly<{|
+  value: number,
+  currency: IsoCurrency,
+|}>;
+
+
+// ----- Functions ----- //
+
+const GBP = (value: number): Price => ({ value, currency: 'GBP' });
+const USD = (value: number): Price => ({ value, currency: 'USD' });
+const AUD = (value: number): Price => ({ value, currency: 'AUD' });
+const EUR = (value: number): Price => ({ value, currency: 'EUR' });
+const NZD = (value: number): Price => ({ value, currency: 'NZD' });
+const CAD = (value: number): Price => ({ value, currency: 'CAD' });
+
+function showPrice(p: Price, extended: boolean = false): string {
+
+  const showGlyph = extended ? extendedGlyph : glyph;
+  return `${showGlyph(p.currency)}${p.value.toFixed(2)}`;
+
+}
+
+
+// ----- Exports ----- //
+
+export {
+  GBP,
+  USD,
+  AUD,
+  EUR,
+  NZD,
+  CAD,
+  showPrice,
+};

--- a/assets/helpers/subscriptions.js
+++ b/assets/helpers/subscriptions.js
@@ -3,20 +3,11 @@
 // ----- Imports ----- //
 
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { type Price, GBP, USD, AUD, EUR, NZD, CAD } from 'helpers/internationalisation/price';
 
 import { trackComponentEvents } from './tracking/ophanComponentEventTracking';
 import { gaEvent } from './tracking/googleTagManager';
-import {
-  type Price,
-  currencies,
-  detect,
-  GBP,
-  USD,
-  AUD,
-  EUR,
-  NZD,
-  CAD,
-} from './internationalisation/currency';
+import { currencies, detect } from './internationalisation/currency';
 
 
 // ----- Types ------ //

--- a/assets/helpers/subscriptions.js
+++ b/assets/helpers/subscriptions.js
@@ -6,7 +6,17 @@ import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 import { trackComponentEvents } from './tracking/ophanComponentEventTracking';
 import { gaEvent } from './tracking/googleTagManager';
-import { currencies, detect } from './internationalisation/currency';
+import {
+  type Price,
+  currencies,
+  detect,
+  GBP,
+  USD,
+  AUD,
+  EUR,
+  NZD,
+  CAD,
+} from './internationalisation/currency';
 
 
 // ----- Types ------ //
@@ -103,32 +113,32 @@ const discountPricesForDefaultBillingPeriod: {
 
 const digitalSubscriptionPrices = {
   GBPCountries: {
-    month: 11.99,
-    year: 119.90,
+    month: GBP(11.99),
+    year: GBP(119.90),
   },
   UnitedStates: {
-    month: 19.99,
-    year: 199.90,
+    month: USD(19.99),
+    year: USD(199.90),
   },
   AUDCountries: {
-    month: 21.50,
-    year: 215.00,
+    month: AUD(21.50),
+    year: AUD(215.00),
   },
   EURCountries: {
-    month: 14.99,
-    year: 149.90,
+    month: EUR(14.99),
+    year: EUR(149.90),
   },
   International: {
-    month: 19.99,
-    year: 199.90,
+    month: USD(19.99),
+    year: USD(199.90),
   },
   NZDCountries: {
-    month: 23.50,
-    year: 235.00,
+    month: NZD(23.50),
+    year: NZD(235.00),
   },
   Canada: {
-    month: 21.95,
-    year: 219.50,
+    month: CAD(21.95),
+    year: CAD(219.50),
   },
 };
 
@@ -195,7 +205,7 @@ function fixDecimals(number: number): string {
   return number.toFixed(2);
 }
 
-function getDigitalPrice(cgId: CountryGroupId, frequency: DigitalBillingPeriod): number {
+function getDigitalPrice(cgId: CountryGroupId, frequency: DigitalBillingPeriod): Price {
   return digitalSubscriptionPrices[cgId][frequency];
 }
 

--- a/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -11,7 +11,7 @@ import { type FormError, firstError } from 'helpers/subscriptionsForms/validatio
 import { type Option } from 'helpers/types/option';
 import { fromCountry, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { getDigitalPrice, type DigitalBillingPeriod } from 'helpers/subscriptions';
-import { currencies } from 'helpers/internationalisation/currency';
+import { showPrice } from 'helpers/internationalisation/currency';
 
 import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
 import CheckoutCopy from 'components/checkoutCopy/checkoutCopy';
@@ -65,12 +65,12 @@ function getPrice(country: Option<IsoCountry>, frequency: DigitalBillingPeriod):
   if (cgId) {
 
     const price = getDigitalPrice(cgId, frequency);
-    const glyph = currencies[price.currency].extendedGlyph;
-    return `${glyph}${price.value.toFixed(2)} `;
+    return `${showPrice(price, true)} `;
 
   }
 
   return '';
+
 }
 
 

--- a/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -64,9 +64,9 @@ function getPrice(country: Option<IsoCountry>, frequency: DigitalBillingPeriod):
 
   if (cgId) {
 
-    const glyph = currencies[countryGroups[cgId].currency].extendedGlyph;
-    const price = getDigitalPrice(cgId, frequency).toFixed(2);
-    return `${glyph}${price} `;
+    const price = getDigitalPrice(cgId, frequency);
+    const glyph = currencies[price.currency].extendedGlyph;
+    return `${glyph}${price.value.toFixed(2)} `;
 
   }
 

--- a/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -11,7 +11,7 @@ import { type FormError, firstError } from 'helpers/subscriptionsForms/validatio
 import { type Option } from 'helpers/types/option';
 import { fromCountry, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { getDigitalPrice, type DigitalBillingPeriod } from 'helpers/subscriptions';
-import { showPrice } from 'helpers/internationalisation/currency';
+import { showPrice } from 'helpers/internationalisation/price';
 
 import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
 import CheckoutCopy from 'components/checkoutCopy/checkoutCopy';

--- a/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -9,7 +9,7 @@ import { compose } from 'redux';
 import { countries, usStates, caStates, type IsoCountry } from 'helpers/internationalisation/country';
 import { type FormError, firstError } from 'helpers/subscriptionsForms/validation';
 import { type Option } from 'helpers/types/option';
-import { fromCountry, countryGroups, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { fromCountry, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { getDigitalPrice, type DigitalBillingPeriod } from 'helpers/subscriptions';
 import { currencies } from 'helpers/internationalisation/currency';
 


### PR DESCRIPTION
## Why are you doing this?

Adding a type to handle prices, contains the amount and currency. To be used on the digital checkout.

## Changes

- Tidied up the currency helper, and added helper functions to retrieve the glyphs for a given `IsoCurrency`.
- Added a new `Price` type and corresponding helper file, with helpers to create a `Price` for a given currency and one to display the price as a string.
- Updated the digital subscriptions prices to use the new `Price` type.
