### PR TITLE
Fixing links for Ts&Cs on the GW page

### DIFF
--- a/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -134,11 +134,11 @@ const content = (
       </ProductPageContentBlock>
       <ProductPageContentBlock>
         <ProductPageTextBlock title="Promotion terms and conditions">
-          <p>Subscriptions available to people aged 18 and over with a valid email address. For full details of Guardian Weekly print subscription services and their terms and conditions - see <a target="_blank" rel="noopener noreferrer" href="https://www.theguardian.com/guardian-weekly-subscription-terms-conditions">theguardian.com/guardian-weekly-subscription-terms-conditions</a>
+          <p>Offer subject to availability. Guardian News and Media Limited (&ldquo;GNM&rdquo;) reserves the right to withdraw this promotion at any time. For full promotion terms and conditions visit <a target="_blank" rel="noopener noreferrer" href={`https://subscribe.theguardian.com/p/WWM99X/terms?country=${subsCountry}`}>subscribe.theguardian.com/p/WWM99X/terms</a>
           </p>
         </ProductPageTextBlock>
         <ProductPageTextBlock title="Guardian Weekly terms and conditions">
-          <p>Offer subject to availability. Guardian News and Media Limited (&ldquo;GNM&rdquo;) reserves the right to withdraw this promotion at any time. For full promotion terms and conditions visit <a target="_blank" rel="noopener noreferrer" href={`https://subscribe.theguardian.com/p/WWM99X/terms?country=${subsCountry}`}>subscribe.theguardian.com/p/WWM99X/terms</a>.
+          <p>Subscriptions available to people aged 18 and over with a valid email address. For full details of Guardian Weekly print subscription services and their terms and conditions - see <a target="_blank" rel="noopener noreferrer" href="https://www.theguardian.com/guardian-weekly-subscription-terms-conditions">theguardian.com/guardian-weekly-subscription-terms-conditions</a>
           </p>
         </ProductPageTextBlock>
       </ProductPageContentBlock>


### PR DESCRIPTION
## Why are you doing this?

_"It's been raised by the CS team at Teleperformance that on this page, the links for the standard and promotional terms and conditions are in fact switched, you can actually see the difference in the links at the bottom of the page."_

## Changes

* Switching links for the standard and promo Ts&Sc on the Guardian Weekly page.
