### PR TITLE
add test to background image

### DIFF
--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -16,7 +16,7 @@ export const tests: Tests = {
         size: 1,
       },
     },
-    isActive: true,
+    isActive: false,
     independent: true,
     seed: 1,
   },

--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -9,7 +9,7 @@ export type AnnualContributionsTestVariant = 'control' | 'annualAmountsA' | 'not
 export const tests: Tests = {
 
   usBackgroundImage: {
-    variants: ['control', 'backgroundImage'],
+    variants: ['backgroundImage'],
     audiences: {
       UnitedStates: {
         offset: 0,

--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -8,6 +8,19 @@ export type AnnualContributionsTestVariant = 'control' | 'annualAmountsA' | 'not
 
 export const tests: Tests = {
 
+  usBackgroundImage: {
+    variants: ['control', 'backgroundImage'],
+    audiences: {
+      UnitedStates: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: true,
+    independent: true,
+    seed: 1,
+  },
+
   usSingleContributionsAmounts: {
     variants: ['control', 'singleD100', 'single3575'],
     audiences: {

--- a/assets/pages/new-contributions-landing/components/ContributionBackground.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionBackground.jsx
@@ -9,42 +9,45 @@ import GridPicture from 'components/gridPicture/gridPicture';
 
 type PropTypes = {|
   countryGroupId: CountryGroupId,
+  usBackgroundTestVariant: string,
 |};
 
 // ----- Render ----- //
 
 function NewContributionBackground(props: PropTypes) {
-  if (props.countryGroupId !== 'UnitedStates') {
+  const showUsBackground = (props.countryGroupId === 'UnitedStates' && props.usBackgroundTestVariant === 'backgroundImage');
+
+  if (showUsBackground) {
     return (
-      <div className="gu-content__bg">
-        <SvgContributionsBgDesktop />
+      <div className="us-campaign__background">
+        <GridPicture
+          sources={[
+            {
+              gridId: 'UsCampaignLanding',
+              srcSizes: [1500, 1500],
+              imgType: 'png',
+              sizes: '100vw',
+              media: '(max-width: 1500px)',
+            },
+            {
+              gridId: 'UsCampaignLanding',
+              srcSizes: [1500, 1500],
+              imgType: 'png',
+              sizes: '(min-width: 1500px) 1500px, 1500px',
+              media: '(min-width: 1500px)',
+            },
+          ]}
+          fallback="UsCampaignLanding"
+          fallbackSize={1500}
+          altText=""
+          fallbackImgType="png"
+        />
       </div>
     );
   }
   return (
-    <div className="us-campaign__background">
-      <GridPicture
-        sources={[
-          {
-           gridId: 'UsCampaignLanding',
-           srcSizes: [1500, 1500],
-           imgType: 'png',
-           sizes: '100vw',
-           media: '(max-width: 1500px)',
-          },
-          {
-           gridId: 'UsCampaignLanding',
-           srcSizes: [1500, 1500],
-           imgType: 'png',
-           sizes: '(min-width: 1500px) 1500px, 1500px',
-           media: '(min-width: 1500px)',
-          },
-          ]}
-        fallback="UsCampaignLanding"
-        fallbackSize={1500}
-        altText=""
-        fallbackImgType="png"
-      />
+    <div className="gu-content__bg">
+      <SvgContributionsBgDesktop />
     </div>
   );
 }

--- a/assets/pages/new-contributions-landing/contributionsLanding.jsx
+++ b/assets/pages/new-contributions-landing/contributionsLanding.jsx
@@ -105,7 +105,10 @@ const router = (
                 footer={<Footer disclaimer countryGroupId={countryGroupId} />}
               >
                 <ContributionThankYouContainer />
-                <NewContributionBackground usBackgroundTestVariant={usBackgroundImage} countryGroupId={countryGroupId} />
+                <NewContributionBackground
+                  usBackgroundTestVariant={usBackgroundImage}
+                  countryGroupId={countryGroupId}
+                />
               </Page>
             );
           }}

--- a/assets/pages/new-contributions-landing/contributionsLanding.jsx
+++ b/assets/pages/new-contributions-landing/contributionsLanding.jsx
@@ -48,7 +48,7 @@ const reactElementId = `new-contributions-landing-page-${countryGroups[countryGr
 
 const selectedCountryGroup = countryGroups[countryGroupId];
 
-const { smallMobileHeaderNotEpicOrBanner } = store.getState().common.abParticipations;
+const { smallMobileHeaderNotEpicOrBanner, usBackgroundImage } = store.getState().common.abParticipations;
 
 let extraClasses = [];
 if (smallMobileHeaderNotEpicOrBanner) {
@@ -85,7 +85,7 @@ const router = (
               <NewContributionFormContainer
                 thankYouRoute={`/${countryGroups[countryGroupId].supportInternationalisationId}/thankyou`}
               />
-              <NewContributionBackground countryGroupId={countryGroupId} />
+              <NewContributionBackground usBackgroundTestVariant={usBackgroundImage} countryGroupId={countryGroupId} />
             </Page>
           )
         }

--- a/assets/pages/new-contributions-landing/contributionsLanding.jsx
+++ b/assets/pages/new-contributions-landing/contributionsLanding.jsx
@@ -105,7 +105,7 @@ const router = (
                 footer={<Footer disclaimer countryGroupId={countryGroupId} />}
               >
                 <ContributionThankYouContainer />
-                <NewContributionBackground countryGroupId={countryGroupId} />
+                <NewContributionBackground usBackgroundTestVariant={usBackgroundImage} countryGroupId={countryGroupId} />
               </Page>
             );
           }}


### PR DESCRIPTION
## Why are you doing this?
Adds logic for ab testing the US background image. Currently **everyone in the US be allocated to the variant displaying the background image** but this change means we can easily make it so that only those in the US _and_ in the test will see the new background by adding a control, and also quickly turn off the background by setting the test activity to false. 

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Changes

* Adds a test and passes variant to background component to determine if should show the custom background. 

This PR doesn't add the image but for context here is what it looks like:
<img width="1007" alt="49509573-a9501b80-f87d-11e8-8ff3-b7ae919353cd" src="https://user-images.githubusercontent.com/8484757/49737893-e1909900-fc85-11e8-86ff-31d28d74b950.png">


![screen shot 2018-12-10 at 10 18 33](https://user-images.githubusercontent.com/8484757/49737850-c32a9d80-fc85-11e8-84e4-b44f071a6aa1.jpg)


