### PR TITLE
Add useful comment to RegularContributions.scala

### DIFF
--- a/app/controllers/RegularContributions.scala
+++ b/app/controllers/RegularContributions.scala
@@ -139,6 +139,8 @@ class RegularContributions(
     result.fold(
       { error =>
         SafeLogger.error(scrub"Failed to create new ${request.body.contribution.billingPeriod} contribution for ${request.body.email}, due to $error")
+        // This means we do not return the guest account registration token, meaning that users will not be able to
+        // set their password on the thank you page
         InternalServerError
       },
       response => {


### PR DESCRIPTION
## Why are you doing this?
At the moment, if the `createContributorAndUser` method returns an` InternalServerError`, rather than a `StatusResponse`, we don't return the GuestAccountRegistrationToken. This PR adds a comment explaining the consequences of this (we could fix it but it's too small an edge case to justify working on it right now)