### PR TITLE
Make primary CTA on thank you page solid

### DIFF
--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -1056,7 +1056,6 @@ form {
   border-bottom: 1px solid gu-colour(garnett-neutral-4);
   margin: 0 -10px;
   padding: 0 10px;
-  color: #121212;
 
   h3 {
     font-family: $gu-text-egyptian-web;
@@ -1072,7 +1071,7 @@ form {
     margin-top: $gu-v-spacing;
 
     .button--survey {
-      background-color: #121212;
+      background-color: gu-colour(garnett-neutral-1);
       color: white;
     }
   }

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -197,7 +197,7 @@ footer[role="contentinfo"] a {
 
 /*= TYPOGRAPHY */
 body {
-  color: gu-colour(media-garnett-main-1);
+  color: gu-colour(garnett-neutral-1);
   font: normal 16px/1.5 $gu-text-egyptian-web;
 }
 

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -1056,6 +1056,7 @@ form {
   border-bottom: 1px solid gu-colour(garnett-neutral-4);
   margin: 0 -10px;
   padding: 0 10px;
+  color: #121212;
 
   h3 {
     font-family: $gu-text-egyptian-web;
@@ -1069,6 +1070,11 @@ form {
     display: inline-block;
     margin-bottom: $gu-v-spacing * 3;
     margin-top: $gu-v-spacing;
+
+    .button--survey {
+      background-color: #121212;
+      color: white;
+    }
   }
 
   .component-cta-link__text {


### PR DESCRIPTION
## Why are you doing this?

The main cta on a page should be solid for usability reasons.  The supplementary ones should generally be hollow.  In the thank you page the Share your thoughts is the main one, although the sign up to email one is also kind of main so can remain solid.

[**Trello Card**](https://trello.com/c/8y47X6If/224-correct-colours-of-the-ctas-on-our-thank-you-pages)

Before:
![image](https://user-images.githubusercontent.com/7304387/49733319-121e0600-fc79-11e8-8c09-bb0522dae2a7.png)
After:
![image](https://user-images.githubusercontent.com/7304387/49738969-a6439980-fc88-11e8-8c9d-4c0da2e6b0bc.png)

@ionamckendrick I think I covered the things you described, please let me know if I forgot any of the tweaks!