### PR TITLE
Add useful comment to RegularContributions.scala

### DIFF
--- a/app/controllers/RegularContributions.scala
+++ b/app/controllers/RegularContributions.scala
@@ -143,6 +143,8 @@ class RegularContributions(
     result.fold(
       { error =>
         SafeLogger.error(scrub"[${request.uuid}] Failed to create new $billingPeriod contribution, due to $error")
+        // This means we do not return the guest account registration token, meaning that the client won't be able to
+        // use it to create a password for this identity id.
         InternalServerError
       },
       { statusResponse =>


### PR DESCRIPTION
At the moment, if the `createContributorAndUser` method returns an `InternalServerError`, rather than a `StatusResponse`, we don't return the GuestAccountRegistrationToken. This PR adds a comment explaining the consequences of this (we could fix it but it's too small an edge case to justify working on it right now)