### PR TITLE
Add missing SEO tags & tracking in paper subs page

### DIFF
--- a/app/config/StringsConfig.scala
+++ b/app/config/StringsConfig.scala
@@ -11,4 +11,5 @@ class StringsConfig {
   val subscriptionsLandingDescription = config.getOptionalString("subscriptionsLanding.description")
   val digitalPackLandingDescription = config.getOptionalString("digitalPackLanding.description")
   val weeklyLandingDescription = config.getOptionalString("weeklyLanding.description")
+  val paperLandingDescription = config.getOptionalString("paperLanding.description")
 }

--- a/app/controllers/Subscriptions.scala
+++ b/app/controllers/Subscriptions.scala
@@ -127,7 +127,7 @@ class Subscriptions(
   }
 
   def paperMethodRedirect(): Action[AnyContent] = Action { implicit request =>
-    Redirect(buildCanonicalPaperSubscriptionLink(), request.queryString, status = FOUND)
+    Redirect(buildCanonicalPaperSubscriptionLink(Some("collection")), request.queryString, status = FOUND)
   }
 
   def paperMethodRedirectTo(method: String): Action[AnyContent] = Action { implicit request =>
@@ -164,7 +164,9 @@ class Subscriptions(
     }
 
   def buildCanonicalPaperSubscriptionLink(method: Option[String] = None): String =
-    s"${supportUrl}/uk/subscribe/paper"
+    method
+      .map(m => s"${supportUrl}/uk/subscribe/paper/${m}")
+      .getOrElse(s"${supportUrl}/uk/subscribe/paper")
 
   def buildCanonicalDigitalSubscriptionLink(countryCode: String): String =
     s"${supportUrl}/${countryCode}/subscribe/digital"

--- a/app/controllers/Subscriptions.scala
+++ b/app/controllers/Subscriptions.scala
@@ -136,11 +136,12 @@ class Subscriptions(
 
   def paper(method: String): Action[AnyContent] = CachedAction() { implicit request =>
     implicit val settings: Settings = settingsProvider.settings()
-    val title = "The Guardian Subscriptions | The Guardian"
+    val title = "The Guardian Newspaper Subscription | Vouchers and Delivery"
     val id = "paper-subscription-landing-page-" + method
     val js = "paperSubscriptionLandingPage.js"
     val css = "paperSubscriptionLandingPage.css"
     val canonicalLink = Some(buildCanonicalPaperSubscriptionLink())
+    val description = stringsConfig.paperLandingDescription
 
     Ok(views.html.main(title, id, js, css, None, canonicalLink)).withSettingsSurrogateKey
   }

--- a/app/controllers/Subscriptions.scala
+++ b/app/controllers/Subscriptions.scala
@@ -126,18 +126,14 @@ class Subscriptions(
     Ok(views.html.main(title, id, js, css, description, canonicalLink, hrefLangLinks)).withSettingsSurrogateKey
   }
 
-  def paperMethodRedirect(): Action[AnyContent] = Action { implicit request =>
-    Redirect(buildCanonicalPaperSubscriptionLink(Some("collection")), request.queryString, status = FOUND)
+  def paperMethodRedirect(withDelivery: Boolean = false): Action[AnyContent] = Action { implicit request =>
+    Redirect(buildCanonicalPaperSubscriptionLink(withDelivery), request.queryString, status = FOUND)
   }
 
-  def paperMethodRedirectTo(method: String): Action[AnyContent] = Action { implicit request =>
-    Redirect(buildCanonicalPaperSubscriptionLink(Some(method)), request.queryString, status = FOUND)
-  }
-
-  def paper(method: String): Action[AnyContent] = CachedAction() { implicit request =>
+  def paper(withDelivery: Boolean = false): Action[AnyContent] = CachedAction() { implicit request =>
     implicit val settings: Settings = settingsProvider.settings()
     val title = "The Guardian Newspaper Subscription | Vouchers and Delivery"
-    val id = "paper-subscription-landing-page-" + method
+    val id = if (withDelivery) "paper-subscription-landing-page-delivery" else "paper-subscription-landing-page-collection"
     val js = "paperSubscriptionLandingPage.js"
     val css = "paperSubscriptionLandingPage.css"
     val canonicalLink = Some(buildCanonicalPaperSubscriptionLink())
@@ -163,10 +159,9 @@ class Subscriptions(
       }
     }
 
-  def buildCanonicalPaperSubscriptionLink(method: Option[String] = None): String =
-    method
-      .map(m => s"${supportUrl}/uk/subscribe/paper/${m}")
-      .getOrElse(s"${supportUrl}/uk/subscribe/paper")
+  def buildCanonicalPaperSubscriptionLink(withDelivery: Boolean = false): String =
+    if (withDelivery) s"${supportUrl}/uk/subscribe/paper/delivery"
+    else s"${supportUrl}/uk/subscribe/paper"
 
   def buildCanonicalDigitalSubscriptionLink(countryCode: String): String =
     s"${supportUrl}/${countryCode}/subscribe/digital"

--- a/app/controllers/Subscriptions.scala
+++ b/app/controllers/Subscriptions.scala
@@ -163,7 +163,7 @@ class Subscriptions(
     }
 
   def buildCanonicalPaperSubscriptionLink(method: Option[String] = None): String =
-    s"${supportUrl}/uk/subscribe/paper/${method.getOrElse("collection")}"
+    s"${supportUrl}/uk/subscribe/paper"
 
   def buildCanonicalDigitalSubscriptionLink(countryCode: String): String =
     s"${supportUrl}/${countryCode}/subscribe/digital"

--- a/assets/helpers/routes.js
+++ b/assets/helpers/routes.js
@@ -5,7 +5,6 @@
 import type { CountryGroupId } from './internationalisation/countryGroup';
 import { countryGroups } from './internationalisation/countryGroup';
 import { getOrigin } from './url';
-import { type PaperDeliveryMethod } from './subscriptions';
 
 const routes: {
   [string]: string,
@@ -28,8 +27,8 @@ const routes: {
   payPalRestReturnURL: '/paypal/rest/return',
 };
 
-function paperSubsUrl(deliveryMethod: PaperDeliveryMethod): string {
-  return `${getOrigin()}/uk/subscribe/paper/${deliveryMethod}`;
+function paperSubsUrl(withDelivery: boolean = false): string {
+  return [getOrigin(), 'uk/subscribe/paper', ...(withDelivery ? ['delivery'] : [])].join('/');
 }
 
 function payPalCancelUrl(cgId: CountryGroupId): string {

--- a/assets/pages/paper-subscription-landing/components/content.jsx
+++ b/assets/pages/paper-subscription-landing/components/content.jsx
@@ -80,7 +80,7 @@ const ContentVoucherFaqBlock = () => (
 const ContentDeliveryFaqBlock = ({ setTabAction }: {setTabAction: typeof setTab}) => {
   const linkToVouchers = (
     <a
-      href={paperSubsUrl('collection')}
+      href={paperSubsUrl(false)}
       onClick={(ev) => {
         ev.preventDefault();
         setTabAction('collection');

--- a/assets/pages/paper-subscription-landing/components/tabs.jsx
+++ b/assets/pages/paper-subscription-landing/components/tabs.jsx
@@ -19,11 +19,11 @@ import { setTab, type TabActions } from '../paperSubscriptionLandingPageActions'
 export const tabs: {[PaperDeliveryMethod]: {name: string, href: string}} = {
   collection: {
     name: 'Voucher Book',
-    href: paperSubsUrl('collection'),
+    href: paperSubsUrl(false),
   },
   delivery: {
     name: 'Home Delivery',
-    href: paperSubsUrl('delivery'),
+    href: paperSubsUrl(true),
   },
 };
 

--- a/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
+++ b/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
@@ -28,7 +28,7 @@ import './paperSubscriptionLandingPage.scss';
 
 // ----- Collection or delivery ----- //
 
-const method: PaperDeliveryMethod = window.location.pathname.includes('collection') ? 'collection' : 'delivery';
+const method: PaperDeliveryMethod = window.location.pathname.includes('delivery') ? 'delivery' : 'collection';
 
 const reactElementId: {
   [PaperDeliveryMethod]: string,

--- a/assets/pages/paper-subscription-landing/paperSubscriptionLandingPageActions.js
+++ b/assets/pages/paper-subscription-landing/paperSubscriptionLandingPageActions.js
@@ -19,6 +19,7 @@ export type TabActions = { type: 'SET_TAB', tab: PaperDeliveryMethod }
 
 const { setPlan } = ProductPagePlanFormActionsFor<PaperBillingPlan>('Paper', 'Paper');
 const setTab = (tab: PaperDeliveryMethod): TabActions => {
+  sendTrackingEventsOnClick(`switch_tab_${tab}`, 'Paper', null)();
   window.history.replaceState({}, null, paperSubsUrl(tab));
   return { type: 'SET_TAB', tab };
 };

--- a/assets/pages/paper-subscription-landing/paperSubscriptionLandingPageActions.js
+++ b/assets/pages/paper-subscription-landing/paperSubscriptionLandingPageActions.js
@@ -20,7 +20,7 @@ export type TabActions = { type: 'SET_TAB', tab: PaperDeliveryMethod }
 const { setPlan } = ProductPagePlanFormActionsFor<PaperBillingPlan>('Paper', 'Paper');
 const setTab = (tab: PaperDeliveryMethod): TabActions => {
   sendTrackingEventsOnClick(`switch_tab_${tab}`, 'Paper', null)();
-  window.history.replaceState({}, null, paperSubsUrl(tab));
+  window.history.replaceState({}, null, paperSubsUrl(tab === 'delivery'));
   return { type: 'SET_TAB', tab };
 };
 

--- a/conf/routes
+++ b/conf/routes
@@ -80,10 +80,10 @@ GET  /$country<(uk|us|au|int)>/subscribe/premium-tier   controllers.Subscription
 GET  /subscribe/weekly                            controllers.Subscriptions.weeklyGeoRedirect()
 GET  /$country<(uk|us|au|int|nz|ca|eu)>/subscribe/weekly   controllers.Subscriptions.weekly(country: String)
 
-GET  /subscribe/paper          controllers.Subscriptions.paperMethodRedirect()
-GET  /uk/subscribe/paper          controllers.Subscriptions.paperMethodRedirect()
-GET  /subscribe/paper/$method<collection|delivery>          controllers.Subscriptions.paperMethodRedirectTo(method)
-GET  /uk/subscribe/paper/$method<collection|delivery>          controllers.Subscriptions.paper(method: String)
+GET  /subscribe/paper          controllers.Subscriptions.paperMethodRedirect(withDelivery: Boolean = false)
+GET  /subscribe/paper/delivery          controllers.Subscriptions.paperMethodRedirect(withDelivery: Boolean = true)
+GET  /uk/subscribe/paper          controllers.Subscriptions.paper(withDelivery: Boolean = false)
+GET  /uk/subscribe/paper/delivery          controllers.Subscriptions.paper(withDelivery: Boolean = true)
 
 
 # ----- Authentication ----- #

--- a/conf/strings.conf
+++ b/conf/strings.conf
@@ -3,3 +3,4 @@ contributionsLanding.description="Help us deliver the independent journalism the
 subscriptionsLanding.description="Help us deliver the independent journalism the world needs. Support the Guardian by getting a subscription."
 digitalPackLanding.description="Subscribe to the Guardian Digital Pack and read the Guardian ad-free on all of your devices. The Digital Pack includes the Premium App and Daily Edition iPad app."
 weeklyLanding.description="Subscribe to The Guardian Weekly and enjoy seven days of international news in one magazine with free worldwide delivery."
+paperLanding.description="Subscribe to The Guardian and The Observer newspapers and save on the retail price all year round  |  Voucher and Home Delivery options available"

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -7,13 +7,6 @@ Disallow: /au/subscribe/premium-tier
 Disallow: /int/subscribe/premium-tier
 Disallow: /contribute/recurring-guest
 
-Disallow: /subscribe/paper
-Disallow: /subscribe/paper/delivery
-Disallow: /subscribe/paper/collection
-Disallow: /uk/subscribe/paper
-Disallow: /uk/subscribe/paper/delivery
-Disallow: /uk/subscribe/paper/collection
-
 Disallow: /uk/subscribe/digital/checkout
 Disallow: /us/subscribe/digital/checkout
 Disallow: /au/subscribe/digital/checkout


### PR DESCRIPTION
## Why are you doing this?
- Adds the proper canonical URL
- Adds a meta description
- Replaces the title with the proper one
- Adds tracking to the tabs
- Switch the urls to `uk/subscribe/paper` (collection) & `uk/subscribe/paper/delivery` (delivery)
- Removes paper pages from `robots.txt`