### PR TITLE
us campaign desktop tests

### DIFF
--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -8,30 +8,17 @@ export type AnnualContributionsTestVariant = 'control' | 'annualAmountsA' | 'not
 
 export const tests: Tests = {
 
-  usTickerLandingPage: {
-    variants: ['ticker'],
+  usDesktopEOYCampaign: {
+    variants: ['campaignCopy', 'copyAndTicker', 'copyAndTickerAndBackgroundImage'],
     audiences: {
       UnitedStates: {
         offset: 0,
         size: 1,
       },
     },
-    isActive: false,
+    isActive: true,
     independent: true,
     seed: 2,
-  },
-
-  usBackgroundImage: {
-    variants: ['backgroundImage'],
-    audiences: {
-      UnitedStates: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: false,
-    independent: true,
-    seed: 1,
   },
 
   usSingleContributionsAmounts: {

--- a/assets/helpers/tracking/acquisitions.js
+++ b/assets/helpers/tracking/acquisitions.js
@@ -282,20 +282,6 @@ function getReferrerAcquisitionData(): ReferrerAcquisitionData {
   return referrerAcquisitionData;
 }
 
-const usCampaignVariants = ['us_eoy_top_ticker', 'us_eoy_bottom_ticker', 'us_eoy_bottom_ticker_two'];
-
-function isUsCampaignTest(referrerAcquisitionData: ReferrerAcquisitionData): boolean {
-  if (referrerAcquisitionData.abTests) {
-    const index = referrerAcquisitionData.abTests.findIndex((test: AcquisitionABTest) =>
-      test.name === 'AcquisitionsEpicUsEndOfYearRound2' &&
-      usCampaignVariants.includes(test.variant));
-
-    return index >= 0;
-  }
-  return false;
-}
-
-
 // ----- Exports ----- //
 
 export {
@@ -307,5 +293,4 @@ export {
   derivePaymentApiAcquisitionData,
   deriveSubsAcquisitionData,
   getSupportAbTests,
-  isUsCampaignTest,
 };

--- a/assets/pages/new-contributions-landing/components/ContributionBackground.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionBackground.jsx
@@ -9,13 +9,13 @@ import GridPicture from 'components/gridPicture/gridPicture';
 
 type PropTypes = {|
   countryGroupId: CountryGroupId,
-  usBackgroundTestVariant: string,
+  usDesktopEOYCampaignVariant: string,
 |};
 
 // ----- Render ----- //
 
 function NewContributionBackground(props: PropTypes) {
-  const showUsBackground = (props.countryGroupId === 'UnitedStates' && props.usBackgroundTestVariant === 'backgroundImage');
+  const showUsBackground = (props.countryGroupId === 'UnitedStates' && props.usDesktopEOYCampaignVariant === 'copyAndTickerAndBackgroundImage');
 
   if (showUsBackground) {
     return (

--- a/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
@@ -5,7 +5,7 @@
 import type { ContributionType, PaymentMethod } from 'helpers/contributions';
 import type { Csrf } from 'helpers/csrf/csrfReducer';
 import type { Status } from 'helpers/settings';
-import { isUsCampaignTest, type ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
+import { type ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import React from 'react';
 import { connect } from 'react-redux';
 import { Redirect } from 'react-router';
@@ -90,7 +90,6 @@ function ContributionFormContainer(props: PropTypes) {
     props.onThirdPartyPaymentAuthorised(paymentAuthorisation);
   };
 
-  console.log('variant: ', props.usDesktopEOYCampaignVariant);
   const countryGroupDetails = props.usDesktopEOYCampaignVariant ?
     usCampaignDetails :
     countryGroupSpecificDetails[props.countryGroupId];

--- a/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
@@ -52,7 +52,7 @@ type PropTypes = {|
   paymentMethod: PaymentMethod,
   contributionType: ContributionType,
   referrerAcquisitionData: ReferrerAcquisitionData,
-  usTickerLandingPageTestVariant: string,
+  usDesktopEOYCampaignVariant: string,
 |};
 
 /* eslint-enable react/no-unused-prop-types */
@@ -69,7 +69,7 @@ const mapStateToProps = (state: State) => ({
   paymentMethod: state.page.form.paymentMethod,
   contributionType: state.page.form.contributionType,
   referrerAcquisitionData: state.common.referrerAcquisitionData,
-  usTickerLandingPageTestVariant: state.common.abParticipations.usTickerLandingPage,
+  usDesktopEOYCampaignVariant: state.common.abParticipations.usDesktopEOYCampaign,
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -90,13 +90,15 @@ function ContributionFormContainer(props: PropTypes) {
     props.onThirdPartyPaymentAuthorised(paymentAuthorisation);
   };
 
-  const countryGroupDetails = isUsCampaignTest(props.referrerAcquisitionData) ?
+  console.log('variant: ', props.usDesktopEOYCampaignVariant);
+  const countryGroupDetails = props.usDesktopEOYCampaignVariant ?
     usCampaignDetails :
     countryGroupSpecificDetails[props.countryGroupId];
 
   const headerClasses = `header ${countryGroupDetails.headerClasses ? countryGroupDetails.headerClasses : ''}`;
 
-  const displayTicker = (props.countryGroupId === 'UnitedStates' && props.usTickerLandingPageTestVariant === 'ticker');
+  const isInTickerVariant: boolean = ['copyAndTicker', 'copyAndTickerAndBackgroundImage'].includes(props.usDesktopEOYCampaignVariant);
+  const displayTicker = (props.countryGroupId === 'UnitedStates' && isInTickerVariant);
 
   return props.paymentComplete ?
     <Redirect to={props.thankYouRoute} />

--- a/assets/pages/new-contributions-landing/components/ContributionUsTicker.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionUsTicker.jsx
@@ -15,7 +15,7 @@ type PropTypes = {}
 
 // ---- Helpers ----- //
 
-const getInitialTickerValues = (): Promise<{| totalSoFar: number, goal: number |}> =>
+const getInitialTickerValues = (): Promise<StateTypes> =>
   fetch('https://interactive.guim.co.uk/docsdata-test/1ySn7Ol2NQLvvSw_eAnVrPuuRnaGOxUmaUs6svtu_irU.json')
     .then(resp => resp.json())
     .then((data) => {
@@ -45,12 +45,11 @@ export class ContributionUsTicker extends Component<PropTypes, StateTypes> {
   }
 
   componentDidMount(): void {
-    const self = this;
     getInitialTickerValues().then(({ totalSoFar, goal }) => {
       const initialTotal = totalSoFar * 0.8;
       this.count = initialTotal;
       this.totalSoFar = totalSoFar;
-      self.setState({ totalSoFar: initialTotal, goal });
+      this.setState({ totalSoFar: initialTotal, goal });
       window.setTimeout(() => {
         window.requestAnimationFrame(this.increaseCounter);
         this.animateBar(totalSoFar, goal);
@@ -91,6 +90,7 @@ export class ContributionUsTicker extends Component<PropTypes, StateTypes> {
 
     return (
       <div className={wrapperClassName}>
+        <div className="contributions-landing-ticker__border" />
         <div className="contributions-landing-ticker__values">
           <div className="contributions-landing-ticker__so-far">
             <div className="contributions-landing-ticker__count">${Math.floor(this.state.totalSoFar).toLocaleString()}</div>
@@ -111,7 +111,6 @@ export class ContributionUsTicker extends Component<PropTypes, StateTypes> {
             />
           </div>
         </div>
-        <div className="contributions-landing-ticker__border" />
       </div>
     );
   }

--- a/assets/pages/new-contributions-landing/contributionsLanding.jsx
+++ b/assets/pages/new-contributions-landing/contributionsLanding.jsx
@@ -48,7 +48,7 @@ const reactElementId = `new-contributions-landing-page-${countryGroups[countryGr
 
 const selectedCountryGroup = countryGroups[countryGroupId];
 
-const { smallMobileHeaderNotEpicOrBanner, usDesktopEOYCampaign} = store.getState().common.abParticipations;
+const { smallMobileHeaderNotEpicOrBanner, usDesktopEOYCampaign } = store.getState().common.abParticipations;
 
 let extraClasses = [];
 if (smallMobileHeaderNotEpicOrBanner) {
@@ -85,7 +85,10 @@ const router = (
               <NewContributionFormContainer
                 thankYouRoute={`/${countryGroups[countryGroupId].supportInternationalisationId}/thankyou`}
               />
-              <NewContributionBackground usDesktopEOYCampaignVariant={usDesktopEOYCampaign} countryGroupId={countryGroupId} />
+              <NewContributionBackground
+                usDesktopEOYCampaignVariant={usDesktopEOYCampaign}
+                countryGroupId={countryGroupId}
+              />
             </Page>
           )
         }

--- a/assets/pages/new-contributions-landing/contributionsLanding.jsx
+++ b/assets/pages/new-contributions-landing/contributionsLanding.jsx
@@ -48,7 +48,7 @@ const reactElementId = `new-contributions-landing-page-${countryGroups[countryGr
 
 const selectedCountryGroup = countryGroups[countryGroupId];
 
-const { smallMobileHeaderNotEpicOrBanner, usBackgroundImage } = store.getState().common.abParticipations;
+const { smallMobileHeaderNotEpicOrBanner, usDesktopEOYCampaign} = store.getState().common.abParticipations;
 
 let extraClasses = [];
 if (smallMobileHeaderNotEpicOrBanner) {
@@ -85,7 +85,7 @@ const router = (
               <NewContributionFormContainer
                 thankYouRoute={`/${countryGroups[countryGroupId].supportInternationalisationId}/thankyou`}
               />
-              <NewContributionBackground usBackgroundTestVariant={usBackgroundImage} countryGroupId={countryGroupId} />
+              <NewContributionBackground usDesktopEOYCampaignVariant={usDesktopEOYCampaign} countryGroupId={countryGroupId} />
             </Page>
           )
         }
@@ -106,7 +106,7 @@ const router = (
               >
                 <ContributionThankYouContainer />
                 <NewContributionBackground
-                  usBackgroundTestVariant={usBackgroundImage}
+                  usDesktopEOYCampaignVariant={usDesktopEOYCampaign}
                   countryGroupId={countryGroupId}
                 />
               </Page>

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -192,6 +192,15 @@ footer[role="contentinfo"] a {
 
 $progess-bar-height: 10px;
 
+.contributions-landing-ticker {
+  padding-bottom: $gu-v-spacing;
+}
+
+.contributions-landing-ticker__border {
+  border-top: 1px solid gu-colour(garnett-neutral-4);
+  margin: 0 -10px;
+}
+
 .contributions-landing-ticker--hidden {
   visibility: hidden;
   .contributions-landing-ticker__border {
@@ -259,12 +268,6 @@ $progess-bar-height: 10px;
   bottom: 0;
   transform: translateX(-100%);
   transition: transform 3s cubic-bezier(.25, .55, .2, .85);
-}
-
-.contributions-landing-ticker__border {
-  border-bottom: 1px solid gu-colour(garnett-neutral-4);
-  margin: 0 -10px;
-  padding: $gu-v-spacing 0;
 }
 
 /*= CONTENT */

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -193,7 +193,7 @@ footer[role="contentinfo"] a {
 $progess-bar-height: 10px;
 
 .contributions-landing-ticker {
-  padding-bottom: $gu-v-spacing;
+  padding-bottom: $gu-h-spacing;
 }
 
 .contributions-landing-ticker__border {


### PR DESCRIPTION
## Why are you doing this?
Adds an ab test for the new us EOY campaign features. 

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Changes

* Set the ticker and background image as variants in a us-only ab test. These will only appear to desktop users.
* The campaign copy is set as the control - everyone in the US sees the campaign copy on desktop and mobile (unless they are also in a `ab-smallMobileHeaderNotEpicOrBanner` variant which does not display it).
* Removes referral logic given everyone sees the campaign copy. 

## Screenshots

Current (not referred from epic / banner)
![screen shot 2018-12-10 at 15 19 26](https://user-images.githubusercontent.com/8484757/49744735-5f0fd580-fc95-11e8-93d5-19a20c227fd4.jpg)

| campaignCopy  | copyAndTicker | copyAndTickerAndBackgroundImage |
| ------------- | ------------- |------------- |
| ![screen shot 2018-12-10 at 15 53 46](https://user-images.githubusercontent.com/8484757/49744777-78b11d00-fc95-11e8-95a0-6b89ccf7f1bd.jpg) | ![screen shot 2018-12-10 at 16 36 33](https://user-images.githubusercontent.com/8484757/49746822-e8c1a200-fc99-11e8-9f2a-6396d10fa565.jpg) | ![screen shot 2018-12-10 at 16 42 11](https://user-images.githubusercontent.com/8484757/49747110-92a12e80-fc9a-11e8-9d8c-7942863342fd.jpg) |
| ![screen shot 2018-12-10 at 16 13 21](https://user-images.githubusercontent.com/8484757/49745551-24a73800-fc97-11e8-9ca6-db86907a2819.jpg) |   | ![screen shot 2018-12-10 at 15 54 41](https://user-images.githubusercontent.com/8484757/49744819-9088a100-fc95-11e8-9601-f02e7ff36327.jpg) |


