### PR TITLE
fix copy selection logic

### DIFF
--- a/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
@@ -90,7 +90,7 @@ function ContributionFormContainer(props: PropTypes) {
     props.onThirdPartyPaymentAuthorised(paymentAuthorisation);
   };
 
-  const countryGroupDetails = props.usDesktopEOYCampaignVariant ?
+  const countryGroupDetails = (props.countryGroupId === 'UnitedStates' && props.usDesktopEOYCampaignVariant !== 'notintest') ?
     usCampaignDetails :
     countryGroupSpecificDetails[props.countryGroupId];
 


### PR DESCRIPTION
## Why are you doing this?
To ensure users see the correct copy for their chosen country group. Fixing issue introduced here: #1285


<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Changes

* Checks user is in US and not 'notintest' and sets campaign copy
* Fixes broken logic that assumed you could use variant to determine if someone was in a test, this does not work because 'notintest' is assigned to users... not in test.

## Screenshots
| US  | UK | AUS |
| ------------- | ------------- | ----|
| ![screen shot 2018-12-11 at 09 17 15](https://user-images.githubusercontent.com/8484757/49790547-6501c700-fd26-11e8-841a-a8e3dd285928.jpg) | ![screen shot 2018-12-11 at 09 17 23](https://user-images.githubusercontent.com/8484757/49790575-76e36a00-fd26-11e8-82cf-ba6961dc1d53.jpg) | ![screen shot 2018-12-11 at 09 17 31](https://user-images.githubusercontent.com/8484757/49790579-7b0f8780-fd26-11e8-84c2-9b07b8318649.jpg) |
