### PR TITLE
add extra Ts and Cs for the landing pages

### DIFF
--- a/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
+++ b/assets/components/contributionPaymentCtas/contributionPaymentCtas.jsx
@@ -82,7 +82,7 @@ export default function ContributionPaymentCtas(props: PropTypes) {
         />
         <OneOffCta {...props} />
         <ErrorMessage message={props.error} />
-        <TermsPrivacy countryGroupId={props.countryGroupId} />
+        <TermsPrivacy countryGroupId={props.countryGroupId} contributionType={props.contributionType} />
       </div>
     );
 

--- a/assets/components/contributionsCheckout/contributionsCheckout.jsx
+++ b/assets/components/contributionsCheckout/contributionsCheckout.jsx
@@ -56,7 +56,9 @@ export default function ContributionsCheckout(props: PropTypes) {
         <PageSection heading="Payment methods" modifierClass="payment-methods">
           {props.payment}
         </PageSection>
-        <LegalSectionContainer />
+        <LegalSectionContainer
+          contributionType={props.contributionType}
+        />
       </Page>
     </div>
   );

--- a/assets/components/legal/legalSection/legalSection.jsx
+++ b/assets/components/legal/legalSection/legalSection.jsx
@@ -7,6 +7,8 @@ import React from 'react';
 import PageSection from 'components/pageSection/pageSection';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
+import type { ContributionType } from 'helpers/contributions';
+
 import TermsPrivacy from '../termsPrivacy/termsPrivacy';
 import ContribLegal from '../contribLegal/contribLegal';
 
@@ -15,6 +17,7 @@ import ContribLegal from '../contribLegal/contribLegal';
 
 type PropTypes = {|
   countryGroupId: CountryGroupId,
+  contributionType: ContributionType,
 |};
 
 
@@ -25,7 +28,7 @@ export default function LegalSection(props: PropTypes) {
   return (
     <div className="component-legal-section">
       <PageSection>
-        <TermsPrivacy countryGroupId={props.countryGroupId} />
+        <TermsPrivacy countryGroupId={props.countryGroupId} contributionType={props.contributionType} />
         <ContribLegal countryGroupId={props.countryGroupId} />
       </PageSection>
     </div>

--- a/assets/components/legal/legalSection/legalSection.scss
+++ b/assets/components/legal/legalSection/legalSection.scss
@@ -19,6 +19,10 @@
     line-height: 18px;
     color: gu-colour(media-garnett-main-1);
 
+    .component-terms-privacy__change {
+      padding-bottom: 4px;
+    }
+
     @include mq($from: desktop) {
       width: 550px;
     }

--- a/assets/components/legal/legalSection/legalSectionContainer.js
+++ b/assets/components/legal/legalSection/legalSectionContainer.js
@@ -4,21 +4,14 @@
 
 import { connect } from 'react-redux';
 
-import type { CommonState } from 'helpers/page/commonReducer';
-
 import LegalSection from './legalSection';
-
 
 // ----- State Maps ----- //
 
-function mapStateToProps(state: { common: CommonState }) {
-
-  return {
-    countryGroupId: state.common.internationalisation.countryGroupId,
-  };
-
-}
-
+const mapStateToProps = state => ({
+  countryGroupId: state.common.internationalisation.countryGroupId,
+  contributionType: state.page.form.contributionType,
+});
 
 // ----- Exports ----- //
 

--- a/assets/components/legal/legalSection/legalSectionContainer.js
+++ b/assets/components/legal/legalSection/legalSectionContainer.js
@@ -10,7 +10,7 @@ import LegalSection from './legalSection';
 
 const mapStateToProps = state => ({
   countryGroupId: state.common.internationalisation.countryGroupId,
-  contributionType: state.page.form.contributionType,
+  contributionType: state.page.form ? state.page.form.contributionType : '',
 });
 
 // ----- Exports ----- //

--- a/assets/components/legal/legalSection/legalSectionContainer.js
+++ b/assets/components/legal/legalSection/legalSectionContainer.js
@@ -10,7 +10,6 @@ import LegalSection from './legalSection';
 
 const mapStateToProps = state => ({
   countryGroupId: state.common.internationalisation.countryGroupId,
-  contributionType: state.page.form ? state.page.form.contributionType : '',
 });
 
 // ----- Exports ----- //

--- a/assets/components/legal/termsPrivacy/termsPrivacy.jsx
+++ b/assets/components/legal/termsPrivacy/termsPrivacy.jsx
@@ -7,10 +7,13 @@ import React from 'react';
 import { privacyLink, contributionsTermsLinks } from 'helpers/legal';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
+import type { ContributionType } from 'helpers/contributions';
+
 // ---- Types ----- //
 
 type PropTypes = {|
   countryGroupId: CountryGroupId,
+  contributionType: ContributionType,
 |};
 
 
@@ -22,8 +25,13 @@ function TermsPrivacy(props: PropTypes) {
 
   return (
     <div className="component-terms-privacy">
-      Monthly contributions are billed each month and annual contributions are billed once a year.
-      You can change how much you give or cancel your contributions at any time.<br />
+      {props.contributionType !== 'ONE_OFF' ?
+        <div>
+          Monthly contributions are billed each month and annual contributions are billed once a year.
+          You can change how much you give or cancel your contributions at any time.
+        </div>
+        : null
+      }
       By proceeding, you are agreeing to our {terms}. To find out what personal data we collect and how we use it,
         please visit our {privacy}.
     </div>

--- a/assets/components/legal/termsPrivacy/termsPrivacy.jsx
+++ b/assets/components/legal/termsPrivacy/termsPrivacy.jsx
@@ -22,6 +22,8 @@ function TermsPrivacy(props: PropTypes) {
 
   return (
     <div className="component-terms-privacy">
+      Monthly contributions are billed each month and annual contributions are billed once a year.
+      You can change how much you give or cancel your contributions at any time.<br />
       By proceeding, you are agreeing to our {terms}. To find out what personal data we collect and how we use it,
         please visit our {privacy}.
     </div>

--- a/assets/components/legal/termsPrivacy/termsPrivacy.jsx
+++ b/assets/components/legal/termsPrivacy/termsPrivacy.jsx
@@ -26,14 +26,16 @@ function TermsPrivacy(props: PropTypes) {
   return (
     <div className="component-terms-privacy">
       {props.contributionType !== 'ONE_OFF' ?
-        <div>
+        <div className="component-terms-privacy__change">
           Monthly contributions are billed each month and annual contributions are billed once a year.
           You can change how much you give or cancel your contributions at any time.
         </div>
         : null
       }
-      By proceeding, you are agreeing to our {terms}. To find out what personal data we collect and how we use it,
+      <div className="component-terms-privacy__terms">
+        By proceeding, you are agreeing to our {terms}. To find out what personal data we collect and how we use it,
         please visit our {privacy}.
+      </div>
     </div>
   );
 

--- a/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -200,7 +200,7 @@ function ContributionForm(props: PropTypes) {
       <NewPaymentMethodSelector onPaymentAuthorisation={props.onPaymentAuthorisation} />
       <ContributionErrorMessage />
       <NewContributionSubmit onPaymentAuthorisation={props.onPaymentAuthorisation} />
-      <TermsPrivacy countryGroupId={props.countryGroupId} />
+      <TermsPrivacy countryGroupId={props.countryGroupId} contributionType={props.contributionType} />
       {props.isWaiting ? <ProgressMessage message={['Processing transaction', 'Please wait']} /> : null}
     </form>
   );

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -657,6 +657,11 @@ header[role="banner"] {
   a {
     color: gu-colour(neutral-2);
   }
+
+  .component-terms-privacy__change {
+    padding-bottom: 4px;
+  }
+
 }
 
 /*= TYPOGRAPHY */

--- a/assets/pages/regular-contributions/components/contributionsGuestCheckout.jsx
+++ b/assets/pages/regular-contributions/components/contributionsGuestCheckout.jsx
@@ -106,7 +106,9 @@ export default function ContributionsCheckout(props: PropTypes) {
           currencyId={props.currencyId}
         />
         {checkoutStage()}
-        <LegalSectionContainer />
+        <LegalSectionContainer
+          contributionType={props.contributionType}
+        />
       </Page>
     </div>
   );


### PR DESCRIPTION
## Why are you doing this?

New T&C are required in california to clarify cancellation and frequency, so we might as well add them everywhere as it makes things clearer.

[**Trello Card**](https://trello.com/c/Tbv8uop2/226-update-in-line-terms-conditions)

[Main checkout flow](https://support.theguardian.com/uk/contribute)
BEFORE:
![image](https://user-images.githubusercontent.com/7304387/49793502-46eb9500-fd2d-11e8-9aaa-25ebf18c0f5e.png)
AFTER:
![image](https://user-images.githubusercontent.com/7304387/49867658-09593b80-fe03-11e8-88e2-fa6e4d07f0ab.png)



---
[old checkout flow](https://support.theguardian.com/contribute/recurring-guest?contributionValue=5&contribType=MONTHLY&currency=GBP)
BEFORE:
![image](https://user-images.githubusercontent.com/7304387/49793472-30ddd480-fd2d-11e8-932a-4ab98e029de3.png)
AFTER:
![image](https://user-images.githubusercontent.com/7304387/49867935-d9f6fe80-fe03-11e8-87cd-a5193efa9ee7.png)


@ionamckendrick does that look about right?  Those are the only two pages I could find on support-frontend, but there is subscribe-frontend where there are other T&C for the print&digital products