### PR TITLE
remove unnecessary imports

### DIFF
--- a/assets/pages/showcase/showcase.scss
+++ b/assets/pages/showcase/showcase.scss
@@ -5,16 +5,9 @@
 // ----- Shared Components ----- //
 @import '~components/footer/footer';
 @import '~components/headers/simpleHeader/simpleHeader';
-
 @import '~components/svgs/svg';
-
 @import '~components/headingBlock/headingBlock';
 @import '~components/leftMarginSection/leftMarginSection';
-@import '~components/productPage/productPageHero/productPageHero';
-@import '~components/productPage/productPageContentBlock/productPageContentBlock';
-@import '~components/productPage/productPageTextBlock/productPageTextBlock';
-@import '~components/productPage/productPageButton/productPageButton';
-@import '~components/productPage/productPageFeatures/productPageFeatures';
 
 :root {
   scroll-behavior: smooth;


### PR DESCRIPTION
this also fixes the logo's padding in the header of the showcase page

## Screenshots
Before
![image](https://user-images.githubusercontent.com/836140/49799513-0c89f400-fd3d-11e8-975f-92cf3701a499.png)

After
![image](https://user-images.githubusercontent.com/836140/49799501-0267f580-fd3d-11e8-8f23-c3b91ebf6b9a.png)

