### PR TITLE
test hiding the name for 50% of users on one off

### DIFF
--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -78,4 +78,21 @@ export const tests: Tests = {
     independent: true,
     seed: 5,
   },
+
+  showOneOffNameFields: {
+    variants: [
+      'control',
+      'hidden',
+    ],
+    audiences: {
+      ALL: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: true,
+    independent: true,
+    seed: 6,
+  },
+
 };

--- a/assets/pages/new-contributions-landing/checkoutFormIsSubmittableActions.js
+++ b/assets/pages/new-contributions-landing/checkoutFormIsSubmittableActions.js
@@ -70,8 +70,11 @@ const getFormIsValid = (formIsValidParameters: FormIsValidParameters) => {
     showOneOffNameFields,
   } = formIsValidParameters;
 
-  return (!showOneOffNameFields || (checkFirstName(firstName) && checkLastName(lastName)))
-    && checkEmail(email)
+  return (
+    showOneOffNameFields ?
+      checkFirstName(firstName) && checkLastName(lastName) :
+      true
+  ) && checkEmail(email)
     && checkStateIfApplicable(state, countryGroupId)
     && checkAmountOrOtherAmount(selectedAmounts, otherAmounts, contributionType, countryGroupId);
 };
@@ -86,7 +89,7 @@ const formIsValidParameters = (state: State) => ({
   firstName: state.page.form.formData.firstName,
   lastName: state.page.form.formData.lastName,
   email: state.page.form.formData.email,
-  showOneOffNameFields: state.common.abParticipations.showOneOffNameFields === 'control',
+  showOneOffNameFields: state.common.abParticipations.showOneOffNameFields === 'control' || state.page.form.contributionType !== 'ONE_OFF',
 });
 
 function enableOrDisableForm() {

--- a/assets/pages/new-contributions-landing/checkoutFormIsSubmittableActions.js
+++ b/assets/pages/new-contributions-landing/checkoutFormIsSubmittableActions.js
@@ -54,6 +54,7 @@ export type FormIsValidParameters = {
   firstName: string | null,
   lastName: string | null,
   email: string | null,
+  showOneOffNameFields: boolean,
 }
 
 const getFormIsValid = (formIsValidParameters: FormIsValidParameters) => {
@@ -66,10 +67,10 @@ const getFormIsValid = (formIsValidParameters: FormIsValidParameters) => {
     firstName,
     lastName,
     email,
+    showOneOffNameFields,
   } = formIsValidParameters;
 
-  return checkFirstName(firstName)
-    && checkLastName(lastName)
+  return (!showOneOffNameFields || (checkFirstName(firstName) && checkLastName(lastName)))
     && checkEmail(email)
     && checkStateIfApplicable(state, countryGroupId)
     && checkAmountOrOtherAmount(selectedAmounts, otherAmounts, contributionType, countryGroupId);
@@ -85,6 +86,7 @@ const formIsValidParameters = (state: State) => ({
   firstName: state.page.form.formData.firstName,
   lastName: state.page.form.formData.lastName,
   email: state.page.form.formData.email,
+  showOneOffNameFields: state.common.abParticipations.showOneOffNameFields === 'control',
 });
 
 function enableOrDisableForm() {

--- a/assets/pages/new-contributions-landing/components/ContributionFormFields.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionFormFields.jsx
@@ -50,6 +50,7 @@ type PropTypes = {|
   updateState: Event => void,
   checkIfEmailHasPassword: Event => void,
   contributionType: ContributionType,
+  showOneOffNameFields: boolean,
 |};
 
 // We only want to use the user state value if the form state value has not been changed since it was initialised,
@@ -69,6 +70,7 @@ const mapStateToProps = (state: State) => ({
   isRecurringContributor: state.page.user.isRecurringContributor,
   userTypeFromIdentityResponse: state.page.form.userTypeFromIdentityResponse,
   contributionType: state.page.form.contributionType,
+  showOneOffNameFields: state.common.abParticipations.showOneOffNameFields === 'control',
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -90,6 +92,7 @@ function FormFields(props: PropTypes) {
     isSignedIn,
     state,
     checkoutFormHasBeenSubmitted,
+    showOneOffNameFields,
   } = props;
   return (
     <div className="form-fields">
@@ -119,34 +122,38 @@ function FormFields(props: PropTypes) {
         checkoutFormHasBeenSubmitted={props.checkoutFormHasBeenSubmitted}
         email={props.email}
       />
-      <NewContributionTextInput
-        id="contributionFirstName"
-        name="contribution-fname"
-        label="First name"
-        value={firstName}
-        icon={<SvgUser />}
-        autoComplete="given-name"
-        autoCapitalize="words"
-        onInput={props.updateFirstName}
-        isValid={checkFirstName(firstName)}
-        formHasBeenSubmitted={checkoutFormHasBeenSubmitted}
-        errorMessage="Please provide your first name"
-        required
-      />
-      <NewContributionTextInput
-        id="contributionLastName"
-        name="contribution-lname"
-        label="Last name"
-        value={lastName}
-        icon={<SvgUser />}
-        autoComplete="family-name"
-        autoCapitalize="words"
-        onInput={props.updateLastName}
-        isValid={checkLastName(lastName)}
-        formHasBeenSubmitted={checkoutFormHasBeenSubmitted}
-        errorMessage="Please provide your last name"
-        required
-      />
+      {showOneOffNameFields || props.contributionType !== 'ONE_OFF' ?
+        <div>
+          <NewContributionTextInput
+            id="contributionFirstName"
+            name="contribution-fname"
+            label="First name"
+            value={firstName}
+            icon={<SvgUser />}
+            autoComplete="given-name"
+            autoCapitalize="words"
+            onInput={props.updateFirstName}
+            isValid={checkFirstName(firstName)}
+            formHasBeenSubmitted={checkoutFormHasBeenSubmitted}
+            errorMessage="Please provide your first name"
+            required
+          />
+          <NewContributionTextInput
+            id="contributionLastName"
+            name="contribution-lname"
+            label="Last name"
+            value={lastName}
+            icon={<SvgUser />}
+            autoComplete="family-name"
+            autoCapitalize="words"
+            onInput={props.updateLastName}
+            isValid={checkLastName(lastName)}
+            formHasBeenSubmitted={checkoutFormHasBeenSubmitted}
+            errorMessage="Please provide your last name"
+            required
+          />
+        </div> : null
+      }
       <NewContributionState
         onChange={props.updateState}
         selectedState={state}


### PR DESCRIPTION
## Why are you doing this?

We don't use the first and last name for one offs, but we insist on them being entered.  This PR tests what hpapens if we remove them.

[**Trello Card**](https://trello.com/c/vU7sj6vJ/227-remove-name-fields-test-single-contributions)
BEFORE::
![image](https://user-images.githubusercontent.com/7304387/49817692-d1051f00-fd68-11e8-8a76-af44378688ec.png)
AFTER:
![image](https://user-images.githubusercontent.com/7304387/49817653-b8950480-fd68-11e8-96ad-c86a695acb98.png)

@jranks123 