### PR TITLE
Lowercase Newspaper Subscriptions to prevent break at 320px on print landing page

### DIFF
--- a/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
+++ b/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
@@ -56,7 +56,7 @@ const content = (
       footer={<Footer />}
     >
       <ProductPagehero
-        overheading="The Guardian Newspaper Subscriptions"
+        overheading="The Guardian newspaper subscriptions"
         heading="Save up to 31% on The Guardian and The Observer - all year round"
         type="feature"
         modifierClasses={['paper']}


### PR DESCRIPTION
## Why are you doing this?
This:
![screen shot 2018-12-11 at 17 30 51](https://user-images.githubusercontent.com/690395/49819353-1a576d80-fd6d-11e8-9918-273e52688295.png)

upsets people, whereas this:
![screen shot 2018-12-11 at 17 46 39](https://user-images.githubusercontent.com/690395/49819370-23e0d580-fd6d-11e8-8d68-1197705cfc5e.png)

doesn't.

Harmony restored.

## Screenshots
What, you missed the ones above?
