### PR TITLE
Store experiment ids which are in the query string from redirect tests

### DIFF
--- a/assets/helpers/tracking/acquisitions.js
+++ b/assets/helpers/tracking/acquisitions.js
@@ -11,6 +11,7 @@ import type { Participations } from 'helpers/abTests/abtest';
 import * as storage from 'helpers/storage';
 import { getAllQueryParamsWithExclusions } from 'helpers/url';
 import type { OptimizeExperiments } from 'helpers/optimize/optimize';
+import { OPTIMIZE_QUERY_PARAMETER } from 'helpers/optimize/optimize';
 
 
 // ----- Types ----- //
@@ -189,7 +190,7 @@ function buildReferrerAcquisitionData(acquisitionData: Object = {}): ReferrerAcq
     getQueryParameter('INTCMP');
 
   const parameterExclusions =
-    ['REFPVID', 'INTCMP', 'acquisitionData', 'contributionValue', 'contribType', 'currency', 'utm_expid'];
+    ['REFPVID', 'INTCMP', 'acquisitionData', 'contributionValue', 'contribType', 'currency', OPTIMIZE_QUERY_PARAMETER];
 
   const queryParameters =
     acquisitionData.queryParameters ||


### PR DESCRIPTION
## Why are you doing this?

When I switched our Optimize tracking to use the Javascript api [here](https://github.com/guardian/support-frontend/pull/1156), I didn't realise that the api only returns variant data for AB tests, not redirect tests. This means that information about redirect tests does not end up in the data lake.
This PR fixes the problem.
[**Trello Card**](https://trello.com/c/cufbYZRz/2097-add-data-lake-tracking-to-support-for-redirect-tests)
