### PR TITLE
make the selenium tests handle no names AB test

### DIFF
--- a/test/selenium/contributions/new_flow/OneOffContributionsSpec.scala
+++ b/test/selenium/contributions/new_flow/OneOffContributionsSpec.scala
@@ -45,7 +45,7 @@ class OneOffContributionsSpec extends FeatureSpec with GivenWhenThen with Before
       landingPage.enterAmount(stripePayment)
 
       Given("The user fills in their details correctly")
-      landingPage.fillInPersonalDetails()
+      landingPage.fillInPersonalDetails(hasNameFields = false)
 
       Given("that the user selects to pay with Stripe")
       When("they press the Stripe payment button")

--- a/test/selenium/contributions/new_flow/RecurringContributionsSpec.scala
+++ b/test/selenium/contributions/new_flow/RecurringContributionsSpec.scala
@@ -37,7 +37,7 @@ class RecurringContributionsSpec extends FeatureSpec with GivenWhenThen with Bef
 
       Given("The user fills in their details correctly")
       landingPage.clearForm()
-      landingPage.fillInPersonalDetails()
+      landingPage.fillInPersonalDetails(hasNameFields = true)
 
       Given("that the user selects to pay with Stripe")
       When("they press the Stripe payment button")
@@ -69,7 +69,7 @@ class RecurringContributionsSpec extends FeatureSpec with GivenWhenThen with Bef
 
       Given("The user fills in their details correctly")
       landingPage.clearForm()
-      landingPage.fillInPersonalDetails()
+      landingPage.fillInPersonalDetails(hasNameFields = true)
       landingPage.selectState
 
       Given("that the user selects to pay with PayPal")

--- a/test/selenium/contributions/new_flow/pages/ContributionsLanding.scala
+++ b/test/selenium/contributions/new_flow/pages/ContributionsLanding.scala
@@ -27,11 +27,13 @@ case class ContributionsLanding(region: String, testUser: TestUser)(implicit val
     private val lastName = id("contributionLastName")
     private val email = id("contributionEmail")
 
-    def fillIn() {
+    def fillIn(hasNameFields: Boolean) {
 
       setValue(email, s"${testUser.username}@gu.com", clear = true)
-      setValue(firstName, testUser.username, clear = true)
-      setValue(lastName, testUser.username, clear = true)
+      if (hasNameFields || pageHasElement(firstName)) {
+        setValue(firstName, testUser.username, clear = true)
+        setValue(lastName, testUser.username, clear = true)
+      }
     }
 
     def clear(): Unit = {
@@ -41,7 +43,7 @@ case class ContributionsLanding(region: String, testUser: TestUser)(implicit val
     }
   }
 
-  def fillInPersonalDetails() { RegisterFields.fillIn() }
+  def fillInPersonalDetails(hasNameFields: Boolean) { RegisterFields.fillIn(hasNameFields) }
 
   def clearForm(): Unit = RegisterFields.clear()
 


### PR DESCRIPTION
## Why are you doing this?

In the [AB test for no firstname/lastname](https://github.com/guardian/support-frontend/pull/1299) the tests broke, because they expect the fields.

This just makes the fields optional if the tests are in the one off flow.

Other alternative would be to force the tests into the control bucket, but I thought it's better to make the tests check whatever they are given.

@jranks123 