### PR TITLE
Send everyday voucher print subs to correct checkout endpoint

### DIFF
--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -322,7 +322,7 @@ function getPaperCheckout(
   optimizeExperiments: OptimizeExperiments,
 ) {
   const urls = {
-    collectionEveryday: 'delivery-everyday',
+    collectionEveryday: 'voucher-everyday',
     collectionSixday: 'voucher-sixday',
     collectionWeekend: 'voucher-weekend',
     collectionSunday: 'voucher-sunday',


### PR DESCRIPTION
Opening while I test locally...

## Why are you doing this?
We're sending people to the wrong checkout

[**Trello Card**](https://trello.com)

## Screenshots
To follow
