### PR TITLE
pre-select country in the digital pack checkout

### DIFF
--- a/app/views/digitalSubscription.scala.html
+++ b/app/views/digitalSubscription.scala.html
@@ -16,10 +16,11 @@
   window.guardian = window.guardian || {};
 
     window.guardian.user = {
-      @for(fields <- user.privateFields; firstName <- fields.firstName; lastName <- fields.secondName) {
+      @for(fields <- user.privateFields; firstName <- fields.firstName; lastName <- fields.secondName; country <- fields.country) {
         firstName: "@firstName",
         lastName: "@lastName",
-        email: "@user.primaryEmailAddress"
+        email: "@user.primaryEmailAddress",
+        country: "@country"
       }
   }
 

--- a/assets/helpers/internationalisation/__tests__/countryTest.js
+++ b/assets/helpers/internationalisation/__tests__/countryTest.js
@@ -2,7 +2,7 @@
 
 // ----- Imports ----- //
 
-import { detect } from '../country';
+import { detect, findIsoCountry } from '../country';
 
 const { jsdom } = global;
 
@@ -300,3 +300,12 @@ describe('detect country', () => {
   });
 });
 
+describe('find iso country', () => {
+  it('should return the isoCountry for a country name as a string, if it is in the list of countries', () => {
+    expect(findIsoCountry('France')).toBe('FR');
+  });
+
+  it('should return null for a country name as a string that is not in the list of countries', () => {
+    expect(findIsoCountry('Simple And Coherent Land')).toBe(null);
+  });
+});

--- a/assets/helpers/internationalisation/country.js
+++ b/assets/helpers/internationalisation/country.js
@@ -344,8 +344,6 @@ const countries = {
   SH: 'Saint Helena',
 };
 
-const isoCountries = Object.keys(countries).reduce((obj, key) => Object.assign({}, obj, { [countries[key]]: key }), {});
-
 // ----- Types ----- //
 
 export type UsState = $Keys<typeof usStates>;
@@ -415,6 +413,11 @@ function stateProvinceFromString(country: Option<IsoCountry>, s: string): Option
       return null;
   }
 
+}
+
+function findIsoCountry(country: string): Option<IsoCountry> {
+  const maybeIsoCountry = Object.keys(countries).find(key => countries[key] === country);
+  return maybeIsoCountry !== undefined ? maybeIsoCountry : null;
 }
 
 function fromString(s: string): ?IsoCountry {
@@ -555,7 +558,7 @@ export {
   usStates,
   caStates,
   countries,
-  isoCountries,
+  findIsoCountry,
   fromString,
   stateProvinceFromString,
 };

--- a/assets/helpers/internationalisation/country.js
+++ b/assets/helpers/internationalisation/country.js
@@ -344,6 +344,8 @@ const countries = {
   SH: 'Saint Helena',
 };
 
+const isoCountries = Object.keys(countries).reduce((obj, key) => Object.assign({}, obj, { [countries[key]]: key }), {});
+
 // ----- Types ----- //
 
 export type UsState = $Keys<typeof usStates>;
@@ -553,6 +555,7 @@ export {
   usStates,
   caStates,
   countries,
+  isoCountries,
   fromString,
   stateProvinceFromString,
 };

--- a/assets/pages/digital-subscription-checkout/__tests__/digitalSubscriptionCheckoutReducerTest.js
+++ b/assets/pages/digital-subscription-checkout/__tests__/digitalSubscriptionCheckoutReducerTest.js
@@ -18,6 +18,7 @@ describe('Digital Subscription Checkout Reducer', () => {
       email: null,
       firstName: null,
       lastName: null,
+      country: null,
     };
 
     const newState = initReducer(user)(undefined, action);
@@ -34,6 +35,7 @@ describe('Digital Subscription Checkout Reducer', () => {
       email: null,
       firstName: null,
       lastName: null,
+      country: null,
     };
 
     const newState = initReducer(user)(undefined, action);

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.jsx
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.jsx
@@ -20,10 +20,6 @@ import { initReducer } from './digitalSubscriptionCheckoutReducer';
 import CheckoutStage from './components/checkoutStage';
 import { getUser } from './helpers/user';
 
-// ----- Redux Store ----- //
-
-const store = pageInit(initReducer(getUser()), true);
-
 // ----- Internationalisation ----- //
 
 const countryGroupId: CountryGroupId = detect();
@@ -37,6 +33,9 @@ const reactElementId: {
   International: 'digital-subscription-checkout-page-int',
 };
 
+// ----- Redux Store ----- //
+
+const store = pageInit(initReducer(getUser(countryGroupId)), true);
 
 // ----- Render ----- //
 

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -147,7 +147,7 @@ function initReducer(user: User) {
     email: user.email || '',
     firstName: user.firstName || '',
     lastName: user.lastName || '',
-    country: null,
+    country: user.country || null,
     stateProvince: null,
     telephone: '',
     paymentFrequency: 'month',

--- a/assets/pages/digital-subscription-checkout/helpers/__tests__/userTest.js
+++ b/assets/pages/digital-subscription-checkout/helpers/__tests__/userTest.js
@@ -1,0 +1,25 @@
+// @flow
+
+// ----- Imports ----- //
+import { getCountry } from '../user';
+
+// ----- Tests ----- //
+
+describe('user', () => {
+
+  describe('getCountry', () => {
+
+    it('returns the isoCountry via the value from identity, if it exists', () => {
+      expect(getCountry('United Kingdom', 'GBPCountries')).toBe('GB');
+      expect(getCountry('France', 'EURCountries')).toBe('FR');
+      expect(getCountry('United Kingdom', 'UnitedStates')).toBe('GB');
+    });
+
+    it('returns the isoCountry via the country group id if there is no value from identity', () => {
+      expect(getCountry(null, 'GBPCountries')).toBe('GB');
+      expect(getCountry(null, 'EURCountries')).toBe('DE');
+    });
+
+  });
+
+});

--- a/assets/pages/digital-subscription-checkout/helpers/user.js
+++ b/assets/pages/digital-subscription-checkout/helpers/user.js
@@ -1,7 +1,7 @@
 // @flow
 import { type Option } from 'helpers/types/option';
 import {
-  isoCountries,
+  findIsoCountry,
   detect,
   type IsoCountry,
   fromString,
@@ -16,8 +16,8 @@ export type User = {|
 |};
 
 function getCountry(country: Option<string>, countryGroupId: CountryGroupId): Option<IsoCountry> {
-  const countryCode = country != null ? isoCountries[country] : null;
-  const maybeCountryFromIdentity = countryCode != null ? fromString(countryCode) : null;
+  const countryCode = country !== null ? findIsoCountry(country) : null;
+  const maybeCountryFromIdentity = countryCode !== null ? fromString(countryCode) : null;
   const optionCountryFromIdentity = typeof maybeCountryFromIdentity === 'string' ? maybeCountryFromIdentity : null;
   const countryFromCountryGroupId = detect(countryGroupId);
 
@@ -36,7 +36,7 @@ function getUser(countryGroupId: CountryGroupId): User {
       firstName: typeof firstName === 'string' ? firstName : null,
       lastName: typeof lastName === 'string' ? lastName : null,
       email: typeof email === 'string' ? email : null,
-      country: getCountry(country, countryGroupId),
+      country: typeof country === 'string' ? getCountry(country, countryGroupId) : null,
     };
   }
 

--- a/assets/pages/digital-subscription-checkout/helpers/user.js
+++ b/assets/pages/digital-subscription-checkout/helpers/user.js
@@ -1,22 +1,42 @@
 // @flow
 import { type Option } from 'helpers/types/option';
+import {
+  isoCountries,
+  detect,
+  type IsoCountry,
+  fromString,
+} from 'helpers/internationalisation/country';
+import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 export type User = {|
   firstName: Option<string>,
   lastName: Option<string>,
   email: Option<string>,
+  country: Option<IsoCountry>,
 |};
 
-function getUser(): User {
+function getCountry(country: Option<string>, countryGroupId: CountryGroupId): Option<IsoCountry> {
+  const countryCode = country != null ? isoCountries[country] : null;
+  const maybeCountryFromIdentity = countryCode != null ? fromString(countryCode) : null;
+  const optionCountryFromIdentity = maybeCountryFromIdentity != null && typeof maybeCountryFromIdentity === 'string' ? maybeCountryFromIdentity : null;
+  const countryFromCountryGroupId = detect(countryGroupId);
+
+  return optionCountryFromIdentity || countryFromCountryGroupId;
+}
+
+function getUser(countryGroupId: CountryGroupId): User {
 
   if (window && window.guardian && window.guardian.user) {
 
-    const { firstName, lastName, email } = window.guardian.user;
+    const {
+      firstName, lastName, email, country,
+    } = window.guardian.user;
 
     return {
       firstName: typeof firstName === 'string' ? firstName : null,
       lastName: typeof lastName === 'string' ? lastName : null,
       email: typeof email === 'string' ? email : null,
+      country: getCountry(country, countryGroupId),
     };
   }
 
@@ -24,8 +44,9 @@ function getUser(): User {
     firstName: null,
     lastName: null,
     email: null,
+    country: null,
   };
 
 }
 
-export { getUser };
+export { getUser, getCountry };

--- a/assets/pages/digital-subscription-checkout/helpers/user.js
+++ b/assets/pages/digital-subscription-checkout/helpers/user.js
@@ -36,7 +36,7 @@ function getUser(countryGroupId: CountryGroupId): User {
       firstName: typeof firstName === 'string' ? firstName : null,
       lastName: typeof lastName === 'string' ? lastName : null,
       email: typeof email === 'string' ? email : null,
-      country: typeof country === 'string' ? getCountry(country, countryGroupId) : null,
+      country: typeof country === 'string' ? getCountry(country, countryGroupId) : getCountry(null, countryGroupId),
     };
   }
 

--- a/assets/pages/digital-subscription-checkout/helpers/user.js
+++ b/assets/pages/digital-subscription-checkout/helpers/user.js
@@ -18,7 +18,7 @@ export type User = {|
 function getCountry(country: Option<string>, countryGroupId: CountryGroupId): Option<IsoCountry> {
   const countryCode = country != null ? isoCountries[country] : null;
   const maybeCountryFromIdentity = countryCode != null ? fromString(countryCode) : null;
-  const optionCountryFromIdentity = maybeCountryFromIdentity != null && typeof maybeCountryFromIdentity === 'string' ? maybeCountryFromIdentity : null;
+  const optionCountryFromIdentity = typeof maybeCountryFromIdentity === 'string' ? maybeCountryFromIdentity : null;
   const countryFromCountryGroupId = detect(countryGroupId);
 
   return optionCountryFromIdentity || countryFromCountryGroupId;


### PR DESCRIPTION
## Why are you doing this?
We should make it as easy as possible for users to sign up for a digital pack. So let's pre-select their country, and allow them to change it if they need.

If we know their country based on what's stored in identity, we preselect that. Otherwise, we select based on their countryGroupId. 
(Using the detect function here: https://github.com/guardian/support-frontend/blob/master/assets/helpers/internationalisation/country.js#L522)

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/sJDnpz0S/2093-pre-populate-checkout-fields)

## Changes

* Also saves country in the window
* Pre-selects country in the digital pack checkout based on the country stored in identity, or failing that, what we know based on their countryGroupId/path/cookie/query param

## Screenshots
Just like the digital pack checkout form, but the country is pre-selected as described above. 