### PR TITLE
Copy change for gifting messaging

### DIFF
--- a/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -113,14 +113,14 @@ const content = (
         </ProductPageTextBlock>
         <WeeklyForm />
         <ProductPageInfoChip>
-          You can cancel your subscription at any time
+          <p>Gifting is available for quarterly and annual subscriptions</p>
+          <p>You can cancel your subscription at any time</p>
         </ProductPageInfoChip>
       </ProductPageContentBlock>
       <ProductPageContentBlock>
-        <ProductPageTextBlock title="Gift subscriptions">
-          <p className={largeParagraphClassName}>A Guardian Weekly subscription
-          makes a great gift. To&nbsp;buy&nbsp;one, just get in touch with your local customer
-          service team:
+        <ProductPageTextBlock title="Buying as a gift?">
+          <p className={largeParagraphClassName}>If you'd like to buy a Guardian Weekly subscription as a gift,
+            just get in touch with your local customer service team:
           </p>
         </ProductPageTextBlock>
         <ProductPageContentBlockOutset>

--- a/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -119,7 +119,7 @@ const content = (
       </ProductPageContentBlock>
       <ProductPageContentBlock>
         <ProductPageTextBlock title="Buying as a gift?">
-          <p className={largeParagraphClassName}>If you'd like to buy a Guardian Weekly subscription as a gift,
+          <p className={largeParagraphClassName}>If you’d like to buy a Guardian Weekly subscription as a gift,
             just get in touch with your local customer service team:
           </p>
         </ProductPageTextBlock>

--- a/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -118,9 +118,10 @@ const content = (
         </ProductPageInfoChip>
       </ProductPageContentBlock>
       <ProductPageContentBlock>
-        <ProductPageTextBlock title="Buying as a gift?">
-          <p className={largeParagraphClassName}>If you’d like to buy a Guardian Weekly subscription as a gift,
-            just get in touch with your local customer service team:
+        <ProductPageTextBlock title="Gift subscriptions">
+          <p className={largeParagraphClassName}>A quarterly or annual Guardian Weekly subscription makes a great gift.
+            To&nbsp;buy&nbsp;one, just select the gift option at checkout or get in touch with your local customer
+            service team:
           </p>
         </ProductPageTextBlock>
         <ProductPageContentBlockOutset>


### PR DESCRIPTION
## Why are you doing this?
We want to call out gifting options for quarterly and annual GW subs.

This PR updates the copy. I'll open another tomorrow to add and style the SVGs.

[**Trello Card**](https://trello.com/c/oWQe33mN/2119-gifting-copy-updates-for-gw-product-page)

## Screenshots
**Before**
![screen shot 2018-12-13 at 17 06 23](https://user-images.githubusercontent.com/690395/49955232-40f6df00-fefa-11e8-87a3-def105ddc35e.png)

**After**
(updated - was given duff information re. copy in the customer service section)
![screen shot 2018-12-13 at 17 37 09](https://user-images.githubusercontent.com/690395/49957007-7dc4d500-fefe-11e8-81a5-f7b995c9a8e0.png)

