### PR TITLE
Don't pass state on the query string for internal links

### DIFF
--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -196,10 +196,10 @@ function buildSubsUrls(
   const countryId = countryGroups[countryGroupId].supportInternationalisationId;
 
   // paper only applies to uk, so hardcode the country
-  const paper = `/uk/subscribe/paper?${buildParamString('Paper', intCmp, referrerAcquisitionData)}`;
+  const paper = '/uk/subscribe/paper';
   const paperDig = `${subsUrl}/p/${promoCodes.PaperAndDigital}?${buildParamString('PaperAndDigital', intCmp, referrerAcquisitionData)}`;
-  const digital = `/${countryId}/subscribe/digital?${buildParamString('DigitalPack', intCmp, null)}`;
-  const weekly = `/${countryId}/subscribe/weekly?${buildParamString('GuardianWeekly', intCmp, referrerAcquisitionData)}`;
+  const digital = `/${countryId}/subscribe/digital`;
+  const weekly = `/${countryId}/subscribe/weekly`;
 
   return {
     DigitalPack: digital,


### PR DESCRIPTION
## Why are you doing this?
If we pass acquisition data around on the query string for internal links we end up duplicating the ab tests array in it. This prevents that.