### PR TITLE
Update header and T&C links on weekly page

### DIFF
--- a/assets/helpers/theGrid.js
+++ b/assets/helpers/theGrid.js
@@ -52,7 +52,7 @@ export const imageCatalogue: {
   guardianWeeklyHeroMobile: '0198392d89fac028dfea0c0aba940ef86eafdb10/0_0_1000_666',
   paperHeroDesktop: 'f1040916a71642c924a52c61dc7c4aae2b8dd88d/0_0_1080_784',
   paperHeroMobile: '9b8d348e9ba521c388e3482ece4037e3f0fb3864/0_0_1000_666',
-  weeklyLandingHero: '3a093833e468eec890838eb36d462f0281299f9c/0_0_5060_5350',
+  weeklyLandingHero: '04d26adc380c2d13015ba3b2bebf3cb8a7fe83a3/0_0_7100_3500',
   paperLandingHero: 'c09bbbff7ba75ea91b0d9da4ed750ab437f364c3/0_0_2676_1316',
   paperLandingHeroMobile: '7a1f17792f748c139a22321440e1c9294df82349/0_0_922_656',
   paperDeliveryFeature: 'e7527a726b840eeb1f94cfc6fdd004a31b90df20/0_0_920_820',

--- a/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -152,11 +152,11 @@ const content = (
       </ProductPageContentBlock>
       <ProductPageContentBlock>
         <ProductPageTextBlock title="Promotion terms and conditions">
-          <p>Offer subject to availability. Guardian News and Media Limited (&ldquo;GNM&rdquo;) reserves the right to withdraw this promotion at any time. For full 6 for 6 promotion terms and conditions see <a target="_blank" rel="noopener noreferrer" href={`https://subscribe.theguardian.com/p/WWM99X/terms?country=${subsCountry}`}>here</a>.
+          <p>Offer subject to availability. Guardian News and Media Limited (&ldquo;GNM&rdquo;) reserves the right to withdraw this promotion at any time. For full 6 for 6 promotion terms and conditions, see <a target="_blank" rel="noopener noreferrer" href={`https://subscribe.theguardian.com/p/WWM99X/terms?country=${subsCountry}`}>here</a>.
           </p>
         </ProductPageTextBlock>
         <ProductPageTextBlock title="Guardian Weekly terms and conditions">
-          <p>Subscriptions available to people aged 18 and over with a valid email address. Full details of Guardian Weekly print subscription services and their terms and conditions see <a target="_blank" rel="noopener noreferrer" href="https://www.theguardian.com/guardian-weekly-subscription-terms-conditions">here</a>.
+          <p>Subscriptions available to people aged 18 and over with a valid email address. For full details of Guardian Weekly print subscription services and their terms and conditions, see <a target="_blank" rel="noopener noreferrer" href="https://www.theguardian.com/guardian-weekly-subscription-terms-conditions">here</a>.
           </p>
         </ProductPageTextBlock>
       </ProductPageContentBlock>

--- a/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -152,11 +152,11 @@ const content = (
       </ProductPageContentBlock>
       <ProductPageContentBlock>
         <ProductPageTextBlock title="Promotion terms and conditions">
-          <p>Offer subject to availability. Guardian News and Media Limited (&ldquo;GNM&rdquo;) reserves the right to withdraw this promotion at any time. For full promotion terms and conditions visit <a target="_blank" rel="noopener noreferrer" href={`https://subscribe.theguardian.com/p/WWM99X/terms?country=${subsCountry}`}>subscribe.theguardian.com/p/WWM99X/terms</a>
+          <p>Offer subject to availability. Guardian News and Media Limited (&ldquo;GNM&rdquo;) reserves the right to withdraw this promotion at any time. For full 6 for 6 promotion terms and conditions see <a target="_blank" rel="noopener noreferrer" href={`https://subscribe.theguardian.com/p/WWM99X/terms?country=${subsCountry}`}>here.</a>
           </p>
         </ProductPageTextBlock>
         <ProductPageTextBlock title="Guardian Weekly terms and conditions">
-          <p>Subscriptions available to people aged 18 and over with a valid email address. For full details of Guardian Weekly print subscription services and their terms and conditions - see <a target="_blank" rel="noopener noreferrer" href="https://www.theguardian.com/guardian-weekly-subscription-terms-conditions">theguardian.com/guardian-weekly-subscription-terms-conditions</a>
+          <p>Subscriptions available to people aged 18 and over with a valid email address. Full details of Guardian Weekly print subscription services and their terms and conditions see <a target="_blank" rel="noopener noreferrer" href="https://www.theguardian.com/guardian-weekly-subscription-terms-conditions">here.</a>
           </p>
         </ProductPageTextBlock>
       </ProductPageContentBlock>

--- a/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -152,11 +152,11 @@ const content = (
       </ProductPageContentBlock>
       <ProductPageContentBlock>
         <ProductPageTextBlock title="Promotion terms and conditions">
-          <p>Offer subject to availability. Guardian News and Media Limited (&ldquo;GNM&rdquo;) reserves the right to withdraw this promotion at any time. For full 6 for 6 promotion terms and conditions see <a target="_blank" rel="noopener noreferrer" href={`https://subscribe.theguardian.com/p/WWM99X/terms?country=${subsCountry}`}>here.</a>
+          <p>Offer subject to availability. Guardian News and Media Limited (&ldquo;GNM&rdquo;) reserves the right to withdraw this promotion at any time. For full 6 for 6 promotion terms and conditions see <a target="_blank" rel="noopener noreferrer" href={`https://subscribe.theguardian.com/p/WWM99X/terms?country=${subsCountry}`}>here</a>.
           </p>
         </ProductPageTextBlock>
         <ProductPageTextBlock title="Guardian Weekly terms and conditions">
-          <p>Subscriptions available to people aged 18 and over with a valid email address. Full details of Guardian Weekly print subscription services and their terms and conditions see <a target="_blank" rel="noopener noreferrer" href="https://www.theguardian.com/guardian-weekly-subscription-terms-conditions">here.</a>
+          <p>Subscriptions available to people aged 18 and over with a valid email address. Full details of Guardian Weekly print subscription services and their terms and conditions see <a target="_blank" rel="noopener noreferrer" href="https://www.theguardian.com/guardian-weekly-subscription-terms-conditions">here</a>.
           </p>
         </ProductPageTextBlock>
       </ProductPageContentBlock>

--- a/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -13,7 +13,7 @@ import { detect, countryGroups, type CountryGroupId } from 'helpers/internationa
 import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
 import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
-import GridImage from 'components/gridImage/gridImage';
+import GridPicture from 'components/gridPicture/gridPicture';
 import SvgChevron from 'components/svgs/chevron';
 import ProductPagehero from 'components/productPage/productPageHero/productPageHero';
 import ProductPageContentBlock from 'components/productPage/productPageContentBlock/productPageContentBlock';
@@ -73,18 +73,35 @@ const content = (
       footer={<Footer />}
     >
       <ProductPagehero
-        headline="Become a Guardian Weekly subscriber"
+        type="feature"
         overheading="Guardian Weekly subscriptions"
         heading="Get a clearer, global perspective on the issues that matter, in one magazine."
         modifierClasses={['weekly']}
         cta={<ProductPageButton trackingOnClick={sendTrackingEventsOnClick('options_cta_click', 'GuardianWeekly', null)} icon={<SvgChevron />} href="#subscribe">See Subscription options</ProductPageButton>}
       >
-        <GridImage
-          gridId="weeklyLandingHero"
-          srcSizes={[946, 473]}
-          sizes="(max-width: 740px) 90vw, 600px"
-          imgType="png"
+        <GridPicture
+          sources={[
+            {
+              gridId: 'weeklyLandingHero',
+              srcSizes: [500, 1000],
+              imgType: 'png',
+              sizes: '100vw',
+              media: '(max-width: 739px)',
+            },
+            {
+              gridId: 'weeklyLandingHero',
+              srcSizes: [1000, 2000],
+              imgType: 'png',
+              sizes: '(min-width: 1000px) 2000px, 1000px',
+              media: '(min-width: 740px)',
+            },
+          ]}
+          fallback="weeklyLandingHero"
+          fallbackSize={1000}
+          altText=""
+          fallbackImgType="png"
         />
+
       </ProductPagehero>
       <ProductPageContentBlock>
         <ProductPageTextBlock title="Open up your world view, Weekly">

--- a/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.scss
+++ b/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.scss
@@ -17,24 +17,40 @@
 }
 
 .component-product-page-hero--weekly {
-  .component-grid-image {
-    display: block;
-    width: 90%;
-    max-width: 500px;
-    margin: ($gu-v-spacing * 3) auto -25%;
-    z-index: 9;
-    @include mq($from: tablet) {
-      width: auto;
-      max-width: 100%;
-      height: 100%;
+
+  @include mq($from: tablet) {
+    .component-heading-block {
+      margin-top: 24em;
+    }
+    .component-grid-picture {
       position: absolute;
-      top: 5%;
-      right: -20%;
-      margin: 0;
+      top: 0;
+      min-width: 100%;
+      height: 100%;
+      @include mq($from: wide) {
+        left: gu-span(2) * -1;
+      }
     }
-    @include mq($from: desktop) {
-      left: 450px;
-      right: auto;
+    .component-grid-picture__image {
+      height: 100%;
+      display: block;
     }
+  }
+  @include mq($until: tablet) {
+    .component-grid-picture {
+      max-height: 20em;
+      overflow: hidden;
+      display: block;
+    }
+    .component-grid-picture__image {
+      max-width: gu-span(8);
+      margin: auto;
+      float: none;
+      display: block;
+    }
+  }
+
+  .component-left-margin-section__content {
+    border-left: none;
   }
 }


### PR DESCRIPTION
## Why are you doing this?
Keeping things up to date and tidy. 

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com)

## Changes

* Update header image
* Remove headline from the product page hero
* GridImage -> Grid Picture
* Update the T&C link copy

## Screenshots
(compare to current state of the page here: https://support.theguardian.com/uk/subscribe/weekly)

| mobile        | tablet           | big wide web screen  |
| ------------- |-------------| -----|
| <img src="https://user-images.githubusercontent.com/3072877/50010286-e53b5d00-ffb0-11e8-8023-a8089950f710.png" height=200>    | <img src="https://user-images.githubusercontent.com/3072877/50010346-10be4780-ffb1-11e8-9043-aa59dbe63757.png" height=200> | <img src="https://user-images.githubusercontent.com/3072877/50010371-2e8bac80-ffb1-11e8-83a8-4ea17c0b0163.png" height=200> |

