### PR TITLE
Digipack support workers

### DIFF
--- a/app/controllers/RegularContributions.scala
+++ b/app/controllers/RegularContributions.scala
@@ -94,16 +94,6 @@ class RegularContributions(
       request.user.fold(displayFormWithoutUser())(displayFormWithUser).map(_.withSettingsSurrogateKey)
     }
 
-  def status(jobId: String): Action[AnyContent] = maybeAuthenticatedAction().async { implicit request =>
-    client.status(jobId, request.uuid).fold(
-      { error =>
-        SafeLogger.error(scrub"Failed to get status of step function execution for job ${jobId} due to $error")
-        InternalServerError
-      },
-      response => Ok(response.asJson)
-    )
-  }
-
   def create: Action[CreateSupportWorkersRequest] = maybeAuthenticatedAction().async(circe.json[CreateSupportWorkersRequest]) {
     implicit request =>
       request.user.fold {

--- a/app/controllers/SupportWorkersStatus.scala
+++ b/app/controllers/SupportWorkersStatus.scala
@@ -1,0 +1,31 @@
+package controllers
+
+import actions.CustomActionBuilders
+import cats.instances.future._
+import codecs.CirceDecoders.statusEncoder
+import io.circe.syntax._
+import lib.PlayImplicits._
+import monitoring.SafeLogger
+import monitoring.SafeLogger._
+import play.api.libs.circe.Circe
+import play.api.mvc._
+import services.stepfunctions.SupportWorkersClient
+
+import scala.concurrent.ExecutionContext
+
+class SupportWorkersStatus(
+    client: SupportWorkersClient,
+    components: ControllerComponents,
+    actionRefiners: CustomActionBuilders
+)(implicit val exec: ExecutionContext) extends AbstractController(components) with Circe {
+  import actionRefiners._
+  def status(jobId: String): Action[AnyContent] = maybeAuthenticatedAction().async { implicit request =>
+    client.status(jobId, request.uuid).fold(
+      { error =>
+        SafeLogger.error(scrub"Failed to get status of step function execution for job ${jobId} due to $error")
+        InternalServerError
+      },
+      response => Ok(response.asJson)
+    )
+  }
+}

--- a/app/monitoring/StateMachineMonitor.scala
+++ b/app/monitoring/StateMachineMonitor.scala
@@ -1,12 +1,12 @@
 package monitoring
 
 import akka.actor.ActorSystem
-import services.stepfunctions.RegularContributionsClient
+import services.stepfunctions.SupportWorkersClient
 import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 import SafeLogger._
 
-class StateMachineMonitor(client: RegularContributionsClient, actorSystem: ActorSystem) {
+class StateMachineMonitor(client: SupportWorkersClient, actorSystem: ActorSystem) {
 
   val cloudwatchMetricsPattern = "regular-contributions-state-machine-unavailable"
 

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -45,6 +45,7 @@ trait AppComponents extends PlayComponents
     applicationController,
     siteMapController,
     regularContributionsController,
+    supportWorkersStatusController,
     identityController,
     oneOffContributions,
     subscriptionsController,
@@ -57,5 +58,5 @@ trait AppComponents extends PlayComponents
   )
 
   SentryLogging.init(appConfig)
-  new StateMachineMonitor(regularContributionsClient, actorSystem).start()
+  new StateMachineMonitor(supportWorkersClient, actorSystem).start()
 }

--- a/app/wiring/Controllers.scala
+++ b/app/wiring/Controllers.scala
@@ -36,8 +36,14 @@ trait Controllers {
     appConfig.supportUrl
   )
 
+  lazy val supportWorkersStatusController = new SupportWorkersStatus(
+    supportWorkersClient,
+    controllerComponents,
+    actionRefiners
+  )
+
   lazy val regularContributionsController = new RegularContributions(
-    regularContributionsClient,
+    supportWorkersClient,
     assetsResolver,
     actionRefiners,
     membersDataService,

--- a/app/wiring/Services.scala
+++ b/app/wiring/Services.scala
@@ -7,7 +7,7 @@ import play.api.libs.ws.ahc.AhcWSComponents
 import services.{IdentityService, _}
 import services.aws.AwsS3Client.s3
 import services.paypal.PayPalNvpServiceProvider
-import services.stepfunctions.{Encryption, RegularContributionsClient, StateWrapper}
+import services.stepfunctions.{Encryption, SupportWorkersClient, StateWrapper}
 
 trait Services {
   self: BuiltInComponentsFromContext with AhcWSComponents with PlayComponents with ApplicationConfiguration =>
@@ -24,7 +24,7 @@ trait Services {
 
   lazy val regularContributionsClient = {
     val stateWrapper = new StateWrapper(Encryption.getProvider(appConfig.aws), appConfig.aws.useEncryption)
-    RegularContributionsClient(
+    SupportWorkersClient(
       appConfig.stepFunctionArn,
       stateWrapper,
       appConfig.supportUrl,

--- a/app/wiring/Services.scala
+++ b/app/wiring/Services.scala
@@ -22,13 +22,13 @@ trait Services {
 
   lazy val goCardlessServiceProvider = new GoCardlessServiceProvider(appConfig.goCardlessConfigProvider)
 
-  lazy val regularContributionsClient = {
+  lazy val supportWorkersClient = {
     val stateWrapper = new StateWrapper(Encryption.getProvider(appConfig.aws), appConfig.aws.useEncryption)
     SupportWorkersClient(
       appConfig.stepFunctionArn,
       stateWrapper,
       appConfig.supportUrl,
-      controllers.routes.RegularContributions.status
+      controllers.routes.SupportWorkersStatus.status
     )
   }
 

--- a/assets/helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis.js
+++ b/assets/helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis.js
@@ -46,7 +46,7 @@ export type RegularPaymentRequest = {|
   country: IsoCountry,
   state: UsState | CaState | null,
   email: string,
-  contribution: RegularContribution,
+  product: RegularContribution,
   paymentFields: RegularPaymentFields,
   ophanIds: OphanIds,
   referrerAcquisitionData: ReferrerAcquisitionData,

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -263,7 +263,7 @@ const regularPaymentRequestFromAuthorisation = (
   country: state.common.internationalisation.countryId,
   state: state.page.form.formData.state,
   email: state.page.form.formData.email || '',
-  contribution: {
+  product: {
     amount: getAmount(
       state.page.form.selectedAmounts,
       state.page.form.formData.otherAmounts,

--- a/assets/pages/regular-contributions/helpers/ajax.js
+++ b/assets/pages/regular-contributions/helpers/ajax.js
@@ -57,7 +57,7 @@ type RegularContribFields = {|
   lastName: ?string,
   country: IsoCountry,
   state?: UsState,
-  contribution: ContributionRequest,
+  product: ContributionRequest,
   paymentFields: PayPalDetails | StripeDetails | DirectDebitDetails,
   ophanIds: OphanIds,
   referrerAcquisitionData: ReferrerAcquisitionData,
@@ -155,7 +155,7 @@ function requestData(
     firstName: user.firstName,
     lastName: user.lastName,
     country,
-    contribution: {
+    product: {
       amount,
       currency,
       billingPeriod: billingPeriodFromContrib(contributionType),

--- a/conf/routes
+++ b/conf/routes
@@ -46,7 +46,7 @@ GET  /contribute/recurring-guest                    controllers.RegularContribut
 GET  /contribute/recurring/thankyou                 controllers.RegularContributions.displayFormMaybeAuthenticated()
 GET  /contribute/recurring/existing                 controllers.Application.reactTemplate(title="Support the Guardian | Existing Contributor", id="regular-contributions-existing-page", js="regularContributionsExistingPage.js", css="regularContributionsExistingPageStyles.css")
 POST /contribute/recurring/create                   controllers.RegularContributions.create
-GET  /contribute/recurring/status                   controllers.RegularContributions.status(jobId: String)
+GET  /contribute/recurring/status                   controllers.SupportWorkersStatus.status(jobId: String)
 GET  /contribute/recurring/pending                  controllers.RegularContributions.displayFormMaybeAuthenticated()
 
 # this endpoint should be removed once identity remove

--- a/conf/routes
+++ b/conf/routes
@@ -46,7 +46,7 @@ GET  /contribute/recurring-guest                    controllers.RegularContribut
 GET  /contribute/recurring/thankyou                 controllers.RegularContributions.displayFormMaybeAuthenticated()
 GET  /contribute/recurring/existing                 controllers.Application.reactTemplate(title="Support the Guardian | Existing Contributor", id="regular-contributions-existing-page", js="regularContributionsExistingPage.js", css="regularContributionsExistingPageStyles.css")
 POST /contribute/recurring/create                   controllers.RegularContributions.create
-GET  /contribute/recurring/status                   controllers.SupportWorkersStatus.status(jobId: String)
+GET  /support-workers/status                        controllers.SupportWorkersStatus.status(jobId: String)
 GET  /contribute/recurring/pending                  controllers.RegularContributions.displayFormMaybeAuthenticated()
 
 # this endpoint should be removed once identity remove

--- a/test/controllers/RegularContributionsTest.scala
+++ b/test/controllers/RegularContributionsTest.scala
@@ -13,7 +13,7 @@ import org.mockito.ArgumentMatchers.any
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import play.api.mvc.Result
-import services.stepfunctions.RegularContributionsClient
+import services.stepfunctions.SupportWorkersClient
 import services.{HttpIdentityService, MembersDataService}
 import services.MembersDataService._
 import com.gu.support.config._
@@ -51,7 +51,7 @@ class RegularContributionsTest extends WordSpec with MustMatchers {
       )
 
       new RegularContributions(
-        mock[RegularContributionsClient],
+        mock[SupportWorkersClient],
         assetResolver,
         actionRefiner,
         membersDataService,

--- a/test/services/stepfunctions/SupportWorkersClientTest.scala
+++ b/test/services/stepfunctions/SupportWorkersClientTest.scala
@@ -18,7 +18,7 @@ object StatusResults {
   val pending = StatusResponse(Status.Pending, "tracking123", None)
 }
 
-class RegularContributionsClientTest extends FlatSpec with Matchers with MockitoSugar {
+class SupportWorkersClientTest extends FlatSpec with Matchers with MockitoSugar {
 
   val mockStateWrapper = mock[StateWrapper]
 


### PR DESCRIPTION
## Why are you doing this?
As a first step in wiring up the new Digital Pack checkout to support-workers I'm refactoring a few things in preparation:

## Changes

* Rename the `RegularContributionsClient` to `SupportWorkersClient` as this class will handle interactions with support-workers for all product types
* Move the `/status` endpoint which is polled for the state of support-workers executions into its own controller as it is not specific to recurring contributions
* Rename `contribution` to `product` in the json payload which is sent to the recurring contributions `create` endpoint, to prepare for sending other products 

[**Trello Card**](https://trello.com/c/5N8LQ5yU/2060-be-able-to-trigger-the-creation-of-a-digital-pack-subscription-via-support-frontend)

I've successfully tested Stripe, PayPal and DD in both contributions flows 
