### PR TITLE
Throw in a .paparazzirc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ assets/images/inline-svgs/*.svg
 /public/**/*.js.map
 /assets/javascripts/lib/bower-components/
 .yarnclean
+.test-screenshots

--- a/.paparazzirc
+++ b/.paparazzirc
@@ -1,0 +1,32 @@
+{
+	"routes": [
+		"uk",
+		"showcase",
+		"uk/subscribe",
+		"uk/subscribe/paper",
+		"uk/subscribe/digital",
+		"uk/subscribe/weekly",
+		"uk/contribute",
+		"uk/contribute/recurring",
+		"paypal/return"
+	],
+	"out": ".test-screenshots",
+	"prefix": "https://support.thegulocal.com/",
+	"screenshot": {
+		"fullPage": true
+	},
+	"sizes": {
+		"desktop": {
+			"width": 1440,
+			"height": 900
+		},
+		"phone": {
+			"width": 375,
+			"height": 1100
+		},
+		"tablet": {
+			"height": 1024,
+			"width": 768
+		}
+	}
+}


### PR DESCRIPTION
## Why are you doing this?

This lets us use <a href="https://github.com/guardian/paparazzi">paparazzi</a> (`npx @guardian/paparazzi`) to take a burst of screenshots of all routes we desire.

it will also aid us in the development of the tool itself, which right now will outright murder laptops and is probably missing a couple options