### PR TITLE
Use a local settings file if it exists

### DIFF
--- a/app/admin/SettingsProvider.scala
+++ b/app/admin/SettingsProvider.scala
@@ -32,9 +32,9 @@ class LocalFileSettingsProvider private (initialSettings: Settings) extends Sett
 
 object LocalFileSettingsProvider {
 
-  def fromLocalFile(localFile: SettingsSource.LocalFile): Either[Throwable, SettingsProvider] = {
+  def fromLocalFile(localFile: SettingsSource.LocalFile): Either[Throwable, SettingsProvider] =
     Settings.fromLocalFile(localFile).map(new LocalFileSettingsProvider(_))
-  }
+
 }
 
 class S3SettingsProvider private (

--- a/app/admin/SettingsProvider.scala
+++ b/app/admin/SettingsProvider.scala
@@ -3,21 +3,20 @@ package admin
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicReference
 
+import admin.SettingsProvider._
 import akka.actor.ActorSystem
 import cats.data.EitherT
 import cats.instances.future._
 import com.amazonaws.services.s3.AmazonS3
 import config.{Configuration, FastlyConfig}
 import monitoring.SafeLogger
+import monitoring.SafeLogger._
 import play.api.libs.ws.WSClient
 import play.api.mvc.Result
-
 import services.fastly.FastlyService
+
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
-
-import SettingsProvider._
-import SafeLogger._
 
 abstract class SettingsProvider {
 
@@ -33,8 +32,9 @@ class LocalFileSettingsProvider private (initialSettings: Settings) extends Sett
 
 object LocalFileSettingsProvider {
 
-  def fromLocalFile(localFile: SettingsSource.LocalFile): Either[Throwable, SettingsProvider] =
+  def fromLocalFile(localFile: SettingsSource.LocalFile): Either[Throwable, SettingsProvider] = {
     Settings.fromLocalFile(localFile).map(new LocalFileSettingsProvider(_))
+  }
 }
 
 class S3SettingsProvider private (

--- a/conf/DEV.public.conf
+++ b/conf/DEV.public.conf
@@ -24,5 +24,5 @@ settingsSource.s3 {
   key= "DEV/settings.json"
 }
 
-# Uncomment the line below if you want to override admin settings locally
-# settingsSource.local.path="~/.gu/support-frontend-admin-console/settings.json"
+# To use local admin settings create this file (delete it to load from S3):
+settingsSource.local.path="~/.gu/support-frontend-admin-console/settings.json"


### PR DESCRIPTION
## Why are you doing this?

Currently to use local settings with support-frontend you need to uncomment a line in DEV.public.conf. This is not ideal because it means that you then have an uncommitted change before you do anything else and you need to remember to revert it before committing.

Also I prefer to use local settings all the time as it means you can work on large parts of the site (including all of the subs product pages) without Janus credentials (the only reason you need them is to load settings from S3 which are not needed in DEV)

This PR changes the settings loading behaviour so that the app will load from local settings by default in DEV but will fall back to S3 if the local settings file doesn't exist.
