### PR TITLE
Track Stripe Apple Pay Payments 

### DIFF
--- a/assets/components/paymentButtons/stripePopUpButton/stripePopUpButton.jsx
+++ b/assets/components/paymentButtons/stripePopUpButton/stripePopUpButton.jsx
@@ -58,6 +58,7 @@ function Button(props: PropTypes) {
   const tokenToAuthorisation = (token: string): StripeAuthorisation => ({
     paymentMethod: 'Stripe',
     token,
+    stripePaymentMethod: 'StripeCheckout',
   });
 
   const onPaymentAuthorisation = (token: string): void => {

--- a/assets/helpers/paymentIntegrations/newPaymentFlow/oneOffContributions.js
+++ b/assets/helpers/paymentIntegrations/newPaymentFlow/oneOffContributions.js
@@ -60,7 +60,7 @@ export type StripeChargeData = {|
     amount: number,
     token: string,
     email: string,
-    paymentMethod: StripePaymentMethod | null,
+    paymentMethod: StripePaymentMethod,
   },
   acquisitionData: PaymentAPIAcquisitionData,
 |};

--- a/assets/helpers/paymentIntegrations/newPaymentFlow/oneOffContributions.js
+++ b/assets/helpers/paymentIntegrations/newPaymentFlow/oneOffContributions.js
@@ -10,7 +10,7 @@ import { addQueryParamsToURL } from 'helpers/url';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 
 import { PaymentSuccess } from './readerRevenueApis';
-import type { PaymentResult } from './readerRevenueApis';
+import type { PaymentResult, StripePaymentMethod } from './readerRevenueApis';
 
 // ----- Types ----- //
 
@@ -59,7 +59,8 @@ export type StripeChargeData = {|
     currency: IsoCurrency,
     amount: number,
     token: string,
-    email: string
+    email: string,
+    paymentMethod: StripePaymentMethod | null,
   },
   acquisitionData: PaymentAPIAcquisitionData,
 |};

--- a/assets/helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis.js
+++ b/assets/helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis.js
@@ -53,7 +53,10 @@ export type RegularPaymentRequest = {|
   supportAbTests: AcquisitionABTest[]
 |};
 
-export type StripeAuthorisation = {| paymentMethod: 'Stripe', token: string |};
+export type StripePaymentMethod = 'StripeCheckout' | 'StripeApplePay' | 'StripePaymentRequestButton';
+
+
+export type StripeAuthorisation = {| paymentMethod: 'Stripe', token: string, stripePaymentMethod: StripePaymentMethod|};
 export type PayPalAuthorisation = {| paymentMethod: 'PayPal', token: string |};
 export type DirectDebitAuthorisation = {|
   paymentMethod: 'DirectDebit',

--- a/assets/helpers/paymentIntegrations/newPaymentFlow/stripeCheckout.js
+++ b/assets/helpers/paymentIntegrations/newPaymentFlow/stripeCheckout.js
@@ -62,7 +62,7 @@ function setupStripeCheckout(
   isTestUser: boolean,
 ): Object {
   const handleToken = (token) => {
-    onPaymentAuthorisation({ paymentMethod: 'Stripe', token: token.id });
+    onPaymentAuthorisation({ paymentMethod: 'Stripe', token: token.id, stripePaymentMethod: 'StripeCheckout' });
   };
 
   const stripeKey = getStripeKey(contributionType, currency, isTestUser);

--- a/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -190,7 +190,7 @@ function onSubmit(props: PropTypes): Event => void {
     const form = event.target;
 
     if (props.isPostDeploymentTestUser && props.paymentMethod === 'Stripe') {
-      props.onPaymentAuthorisation({ paymentMethod: 'Stripe', token: 'tok_visa' });
+      props.onPaymentAuthorisation({ paymentMethod: 'Stripe', token: 'tok_visa', stripePaymentMethod: 'StripeCheckout' });
     } else {
       const handlePayment = () => formHandlers[props.contributionType][props.paymentMethod](props);
       onFormSubmit({

--- a/assets/pages/new-contributions-landing/components/StripePaymentRequestButton.jsx
+++ b/assets/pages/new-contributions-landing/components/StripePaymentRequestButton.jsx
@@ -160,7 +160,7 @@ function initialisePaymentRequest(props: PropTypes) {
     // We need to do this so that we can offer marketing permissions on the thank you page
     updateUserEmail(data, props.updateEmail);
     const tokenId = props.isTestUser ? 'tok_visa' : token.id;
-    props.onPaymentAuthorised({ paymentMethod: 'Stripe', token: tokenId })
+    props.onPaymentAuthorised({ paymentMethod: 'Stripe', token: tokenId, stripePaymentMethod: 'StripeApplePay' })
       .then(onComplete(complete));
   });
 

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -246,6 +246,8 @@ const stripeChargeDataFromAuthorisation = (
     ),
     token: authorisation.paymentMethod === 'Stripe' ? authorisation.token : '',
     email: state.page.form.formData.email || '',
+    paymentMethod: authorisation.paymentMethod === 'Stripe'
+      ? authorisation.stripePaymentMethod : null,
   },
   acquisitionData: derivePaymentApiAcquisitionData(
     state.common.referrerAcquisitionData,

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -17,7 +17,10 @@ import { getUserTypeFromIdentity } from 'helpers/identityApis';
 import { type CaState, type UsState } from 'helpers/internationalisation/country';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import { payPalRequestData } from 'helpers/paymentIntegrations/newPaymentFlow/payPalRecurringCheckout';
-import type { RegularPaymentRequest } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
+import type {
+  RegularPaymentRequest,
+  StripeAuthorisation,
+} from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
 import {
   type PaymentAuthorisation,
   regularPaymentFieldsFromAuthorisation,
@@ -234,7 +237,7 @@ const sendFormSubmitEventForPayPalRecurring = () =>
   };
 
 const stripeChargeDataFromAuthorisation = (
-  authorisation: PaymentAuthorisation,
+  authorisation: StripeAuthorisation,
   state: State,
 ): StripeChargeData => ({
   paymentData: {
@@ -244,10 +247,9 @@ const stripeChargeDataFromAuthorisation = (
       state.page.form.formData.otherAmounts,
       state.page.form.contributionType,
     ),
-    token: authorisation.paymentMethod === 'Stripe' ? authorisation.token : '',
+    token: authorisation.token,
     email: state.page.form.formData.email || '',
-    paymentMethod: authorisation.paymentMethod === 'Stripe'
-      ? authorisation.stripePaymentMethod : null,
+    paymentMethod: authorisation.stripePaymentMethod,
   },
   acquisitionData: derivePaymentApiAcquisitionData(
     state.common.referrerAcquisitionData,
@@ -440,8 +442,13 @@ const paymentAuthorisationHandlers: PaymentMatrix<(
       dispatch: Dispatch<Action>,
       state: State,
       paymentAuthorisation: PaymentAuthorisation,
-    ): Promise<PaymentResult> =>
-      dispatch(executeStripeOneOffPayment(stripeChargeDataFromAuthorisation(paymentAuthorisation, state))),
+    ): Promise<PaymentResult> => {
+      if (paymentAuthorisation.paymentMethod === 'Stripe') {
+        return dispatch(executeStripeOneOffPayment(stripeChargeDataFromAuthorisation(paymentAuthorisation, state)));
+      }
+      logException(`Invalid payment authorisation: Tried to use the ${paymentAuthorisation.paymentMethod} handler with Stripe`);
+      return Promise.resolve(error);
+    },
     DirectDebit: () => {
       logInvalidCombination('ONE_OFF', 'DirectDebit');
       return Promise.resolve(error);


### PR DESCRIPTION
## Why are you doing this?
Previously, we were tracking Apple Pay payments as Stripe payments. This PR adds an extra bit of metadata to `StripeChargeData`,  `stripePaymentMethod`, so that the `payment-api` can track it separately. 

Soon we will be adding Stripe Payment Request Button payments, so this PR also provisions for that future scenario. 

[Corresponding payment api PR](https://github.com/guardian/payment-api/compare/jr-add-apple-pay?expand=1)