### PR TITLE
prevent alarming on a 1 minute glitch in the state machine

### DIFF
--- a/cloud-formation/cfn.yaml
+++ b/cloud-formation/cfn.yaml
@@ -341,5 +341,6 @@ Resources:
       Period: 60
       EvaluationPeriods: 2
       Statistic: Sum
+      TreatMissingData: notBreaching
     DependsOn:
     - StateMachineUnavailableMetric


### PR DESCRIPTION
## Why are you doing this?

The alarm went off on a one minute outage.
![image](https://user-images.githubusercontent.com/7304387/50277922-ab010e00-043d-11e9-8bbb-53d6c91bda4e.png)

We expect it to need 2 before it actually alarms, but it would be missing data the rest of the time.  It last went off in september
![image](https://user-images.githubusercontent.com/7304387/50278526-1bf4f580-043f-11e9-87f8-f2069a1ff988.png)

[According to AWS](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarms-and-missing-data) it looks backwards if there's missing data and we need more samples.  But in this case there are no such thing as an OK sample, a missing sample is OK.  So we need to treat missing samples as OK.
