### PR TITLE
Add 10% promo to GW annual subs

### DIFF
--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -19,7 +19,6 @@ import type {
   SubscriptionProduct,
   WeeklyBillingPeriod,
   PaperBillingPlan,
-  WeeklyPromoCode,
 } from 'helpers/subscriptions';
 
 import { getPromoCode, getIntcmp } from './flashSale';
@@ -100,6 +99,7 @@ const defaultPromos: PromoCodes = {
   DigitalPack: getPromoCode('DigitalPack', 'GBPCountries', 'DXX83X'),
   Paper: getPromoCode('Paper', 'GBPCountries', 'GXX83P'),
   PaperAndDigital: getPromoCode('PaperAndDigital', 'GBPCountries', 'GXX83X'),
+  GuardianWeekly: getPromoCode('GuardianWeekly', 'GBPCountries', '10ANNUAL'),
 };
 
 const customPromos: {
@@ -303,7 +303,7 @@ function getWeeklyCheckout(
   cgId: CountryGroupId,
   nativeAbParticipations: Participations,
   optimizeExperiments: OptimizeExperiments,
-  promoCode?: ?WeeklyPromoCode,
+  promoCode: Option<string>,
 ): string {
   const acquisitionData = deriveSubsAcquisitionData(
     referrerAcquisitionData,

--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -15,7 +15,12 @@ import { type Option } from 'helpers/types/option';
 import type { Participations } from 'helpers/abTests/abtest';
 import { type OptimizeExperiments } from 'helpers/optimize/optimize';
 import { getBaseDomain } from 'helpers/url';
-import type { SubscriptionProduct, WeeklyBillingPeriod, PaperBillingPlan } from 'helpers/subscriptions';
+import type {
+  SubscriptionProduct,
+  WeeklyBillingPeriod,
+  PaperBillingPlan,
+  WeeklyPromoCode,
+} from 'helpers/subscriptions';
 
 import { getPromoCode, getIntcmp } from './flashSale';
 
@@ -298,6 +303,7 @@ function getWeeklyCheckout(
   cgId: CountryGroupId,
   nativeAbParticipations: Participations,
   optimizeExperiments: OptimizeExperiments,
+  promoCode?: ?WeeklyPromoCode,
 ): string {
   const acquisitionData = deriveSubsAcquisitionData(
     referrerAcquisitionData,
@@ -310,6 +316,10 @@ function getWeeklyCheckout(
 
   params.set('acquisitionData', JSON.stringify(acquisitionData));
   params.set('countryGroup', countryGroups[cgId].supportInternationalisationId);
+
+  if (promoCode) {
+    params.set('promoCode', promoCode);
+  }
 
   return `${subsUrl}/checkout/${url}?${params.toString()}`;
 }

--- a/assets/helpers/subscriptions.js
+++ b/assets/helpers/subscriptions.js
@@ -125,6 +125,54 @@ const paperSubscriptionPrices = {
   deliverySunday: GBP(15.12),
 };
 
+export type WeeklyPromoCode = '10ANNUAL';
+
+const subscriptionPromoPricesForGuardianWeekly: {
+  [WeeklyPromoCode]: {
+    [CountryGroupId]: {
+      [WeeklyBillingPeriod]: number,
+    }
+  }
+} = {
+  '10ANNUAL': {
+    GBPCountries: {
+      quarter: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.GBPCountries,
+      sixweek: 6,
+      year: 135,
+    },
+    EURCountries: {
+      quarter: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.EURCountries,
+      sixweek: 6,
+      year: 220.68,
+    },
+    UnitedStates: {
+      quarter: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.UnitedStates,
+      sixweek: 6,
+      year: 270,
+    },
+    Canada: {
+      quarter: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.Canada,
+      sixweek: 6,
+      year: 288,
+    },
+    AUDCountries: {
+      quarter: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.AUDCountries,
+      sixweek: 6,
+      year: 351,
+    },
+    NZDCountries: {
+      quarter: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.NZDCountries,
+      sixweek: 6,
+      year: 442.8,
+    },
+    International: {
+      quarter: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.International,
+      sixweek: 6,
+      year: 292.68,
+    },
+  },
+};
+
 const subscriptionPricesForGuardianWeekly: {
   [CountryGroupId]: {
     [WeeklyBillingPeriod]: number,
@@ -205,6 +253,14 @@ function getWeeklyProductPrice(countryGroupId: CountryGroupId, billingPeriod: We
   return subscriptionPricesForGuardianWeekly[countryGroupId][billingPeriod].toFixed(2);
 }
 
+function getPromotionWeeklyProductPrice(
+  countryGroupId: CountryGroupId,
+  billingPeriod: WeeklyBillingPeriod,
+  promoCode: WeeklyPromoCode,
+): string {
+  return subscriptionPromoPricesForGuardianWeekly[promoCode][countryGroupId][billingPeriod].toFixed(2);
+}
+
 function getPaperPrice(billingPlan: PaperBillingPlan): Price {
   return paperSubscriptionPrices[billingPlan];
 }
@@ -274,6 +330,7 @@ export {
   displayPrice,
   getProductPrice,
   getWeeklyProductPrice,
+  getPromotionWeeklyProductPrice,
   getNewsstandSaving,
   getNewsstandPrice,
   getDigitalPrice,

--- a/assets/helpers/subscriptions.js
+++ b/assets/helpers/subscriptions.js
@@ -125,10 +125,8 @@ const paperSubscriptionPrices = {
   deliverySunday: GBP(15.12),
 };
 
-export type WeeklyPromoCode = '10ANNUAL';
-
 const subscriptionPromoPricesForGuardianWeekly: {
-  [WeeklyPromoCode]: {
+  [string]: {
     [CountryGroupId]: {
       [WeeklyBillingPeriod]: number,
     }
@@ -256,7 +254,7 @@ function getWeeklyProductPrice(countryGroupId: CountryGroupId, billingPeriod: We
 function getPromotionWeeklyProductPrice(
   countryGroupId: CountryGroupId,
   billingPeriod: WeeklyBillingPeriod,
-  promoCode: WeeklyPromoCode,
+  promoCode: string,
 ): string {
   return subscriptionPromoPricesForGuardianWeekly[promoCode][countryGroupId][billingPeriod].toFixed(2);
 }

--- a/assets/helpers/subscriptions.js
+++ b/assets/helpers/subscriptions.js
@@ -248,7 +248,7 @@ function displayPrice(product: SubscriptionProduct, countryGroupId: CountryGroup
 }
 
 function getWeeklyProductPrice(countryGroupId: CountryGroupId, billingPeriod: WeeklyBillingPeriod): string {
-  return subscriptionPricesForGuardianWeekly[countryGroupId][billingPeriod].toFixed(2);
+  return fixDecimals(subscriptionPricesForGuardianWeekly[countryGroupId][billingPeriod]);
 }
 
 function getPromotionWeeklyProductPrice(
@@ -256,7 +256,7 @@ function getPromotionWeeklyProductPrice(
   billingPeriod: WeeklyBillingPeriod,
   promoCode: string,
 ): string {
-  return subscriptionPromoPricesForGuardianWeekly[promoCode][countryGroupId][billingPeriod].toFixed(2);
+  return fixDecimals(subscriptionPromoPricesForGuardianWeekly[promoCode][countryGroupId][billingPeriod]);
 }
 
 function getPaperPrice(billingPlan: PaperBillingPlan): Price {

--- a/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
+++ b/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
@@ -43,6 +43,7 @@ export const billingPeriods = {
   },
   year: {
     title: 'Annually',
+    offer: 'Introductory offer',
     copy: (countryGroupId: CountryGroupId) => `${getPromotionPrice(countryGroupId, 'year', '10ANNUAL')} for 1 year, then standard rate (${getPrice(countryGroupId, 'year')} every year)`,
   },
 };

--- a/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
+++ b/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
@@ -9,7 +9,6 @@ import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { currencies, detect } from 'helpers/internationalisation/currency';
 import {
   type WeeklyBillingPeriod,
-  type WeeklyPromoCode,
   getWeeklyProductPrice,
   getPromotionWeeklyProductPrice,
 } from 'helpers/subscriptions';
@@ -27,7 +26,7 @@ const getPrice = (countryGroupId: CountryGroupId, period: WeeklyBillingPeriod) =
   getWeeklyProductPrice(countryGroupId, period),
 ].join('');
 
-const getPromotionPrice = (countryGroupId: CountryGroupId, period: WeeklyBillingPeriod, promoCode: WeeklyPromoCode) => [
+const getPromotionPrice = (countryGroupId: CountryGroupId, period: WeeklyBillingPeriod, promoCode: string) => [
   currencies[detect(countryGroupId)].extendedGlyph,
   getPromotionWeeklyProductPrice(countryGroupId, period, promoCode),
 ].join('');

--- a/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
+++ b/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
@@ -7,7 +7,12 @@ import { bindActionCreators } from 'redux';
 
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { currencies, detect } from 'helpers/internationalisation/currency';
-import { type WeeklyBillingPeriod, getWeeklyProductPrice } from 'helpers/subscriptions';
+import {
+  type WeeklyBillingPeriod,
+  type WeeklyPromoCode,
+  getWeeklyProductPrice,
+  getPromotionWeeklyProductPrice,
+} from 'helpers/subscriptions';
 import { type Action } from 'components/productPage/productPagePlanForm/productPagePlanFormActions';
 import ProductPagePlanForm, { type StatePropTypes, type DispatchPropTypes } from 'components/productPage/productPagePlanForm/productPagePlanForm';
 
@@ -22,6 +27,11 @@ const getPrice = (countryGroupId: CountryGroupId, period: WeeklyBillingPeriod) =
   getWeeklyProductPrice(countryGroupId, period),
 ].join('');
 
+const getPromotionPrice = (countryGroupId: CountryGroupId, period: WeeklyBillingPeriod, promoCode: WeeklyPromoCode) => [
+  currencies[detect(countryGroupId)].extendedGlyph,
+  getPromotionWeeklyProductPrice(countryGroupId, period, promoCode),
+].join('');
+
 export const billingPeriods = {
   sixweek: {
     title: '6 for 6',
@@ -34,7 +44,7 @@ export const billingPeriods = {
   },
   year: {
     title: 'Annually',
-    copy: (countryGroupId: CountryGroupId) => `${getPrice(countryGroupId, 'year')} every 12 months`,
+    copy: (countryGroupId: CountryGroupId) => `${getPromotionPrice(countryGroupId, 'year', '10ANNUAL')} for 1 year, then standard rate (${getPrice(countryGroupId, 'year')} every year)`,
   },
 };
 

--- a/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
+++ b/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
@@ -43,7 +43,7 @@ export const billingPeriods = {
   },
   year: {
     title: 'Annually',
-    offer: 'Introductory offer',
+    offer: 'Save 10%',
     copy: (countryGroupId: CountryGroupId) => `${getPromotionPrice(countryGroupId, 'year', '10ANNUAL')} for 1 year, then standard rate (${getPrice(countryGroupId, 'year')} every year)`,
   },
 };

--- a/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingActions.js
+++ b/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingActions.js
@@ -24,6 +24,7 @@ function redirectToWeeklyPage() {
       countryGroupId,
       abParticipations,
       optimizeExperiments,
+      (state.page.plan === 'year' ? '10ANNUAL' : undefined),
     ) : null;
 
     if (location) {

--- a/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingActions.js
+++ b/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingActions.js
@@ -6,6 +6,7 @@ import { type WeeklyBillingPeriod } from 'helpers/subscriptions';
 import { getWeeklyCheckout } from 'helpers/externalLinks';
 import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
 import { ProductPagePlanFormActionsFor } from 'components/productPage/productPagePlanForm/productPagePlanFormActions';
+import { getPromoCode } from 'helpers/flashSale';
 
 import { type State } from './weeklySubscriptionLandingReducer';
 
@@ -24,7 +25,7 @@ function redirectToWeeklyPage() {
       countryGroupId,
       abParticipations,
       optimizeExperiments,
-      (state.page.plan === 'year' ? '10ANNUAL' : undefined),
+      (state.page.plan === 'year' ? getPromoCode('GuardianWeekly', countryGroupId, '10ANNUAL') : null),
     ) : null;
 
     if (location) {


### PR DESCRIPTION
_Edited_: updated screen grabs

## Why are you doing this?
We want to activate the 10ANNUAL Guardian Weekly promo from support frontend. This was never brought forward from subscriptions-frontend, so it's a bit of a just-get-it-working approach at the moment.

Caveats:
It may not play nicely alongside flash sales - I haven't tested that yet. We don't have any GW flash sales running (AFAIK) but maybe it'd be better to define this as a long-running/open-ended sale for the weekly product?

It'll need a code change and deploy to remove it again if/when the time comes.

[**Trello Card**](https://trello.com/c/wAe1CS6S/2101-add-10-off-annual-back-into-gw-product-page)

## Changes

* Always use the 10ANNUAL code on weekly annual subs for ALL territories

## Screenshots
**UK**
![screencapture-support-thegulocal-uk-subscribe-weekly-2018-12-21-11_58_35](https://user-images.githubusercontent.com/690395/50341749-f687ea80-0517-11e9-9b24-f5c2de616afc.png)

**US**
![screencapture-support-thegulocal-us-subscribe-weekly-2018-12-21-12_00_41](https://user-images.githubusercontent.com/690395/50341825-57afbe00-0518-11e9-8cd4-9e23a46b1589.png)

## Tested on CODE
Yes