### PR TITLE
Digipack support workers3

### DIFF
--- a/app/actions/CustomActionBuilders.scala
+++ b/app/actions/CustomActionBuilders.scala
@@ -8,14 +8,15 @@ import play.api.mvc.Security.{AuthenticatedBuilder, AuthenticatedRequest}
 import play.api.mvc._
 import play.filters.csrf._
 import services.TestUserService
+import services.stepfunctions.CreateSupportWorkersRequest
 import utils.RequestCountry
 
-import scala.concurrent.duration._
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 object CustomActionBuilders {
   type AuthRequest[A] = AuthenticatedRequest[A, AuthenticatedIdUser]
   type OptionalAuthRequest[A] = AuthenticatedRequest[A, Option[AuthenticatedIdUser]]
+  type AnyAuthRequest[A] = AuthenticatedRequest[CreateSupportWorkersRequest, _]
 }
 
 class CustomActionBuilders(

--- a/app/actions/CustomActionBuilders.scala
+++ b/app/actions/CustomActionBuilders.scala
@@ -8,7 +8,6 @@ import play.api.mvc.Security.{AuthenticatedBuilder, AuthenticatedRequest}
 import play.api.mvc._
 import play.filters.csrf._
 import services.TestUserService
-import services.stepfunctions.CreateSupportWorkersRequest
 import utils.RequestCountry
 
 import scala.concurrent.ExecutionContext
@@ -16,7 +15,7 @@ import scala.concurrent.ExecutionContext
 object CustomActionBuilders {
   type AuthRequest[A] = AuthenticatedRequest[A, AuthenticatedIdUser]
   type OptionalAuthRequest[A] = AuthenticatedRequest[A, Option[AuthenticatedIdUser]]
-  type AnyAuthRequest[A] = AuthenticatedRequest[CreateSupportWorkersRequest, _]
+  type AnyAuthRequest[A] = AuthenticatedRequest[A, _]
 }
 
 class CustomActionBuilders(

--- a/app/controllers/CanonicalLinks.scala
+++ b/app/controllers/CanonicalLinks.scala
@@ -1,0 +1,17 @@
+package controllers
+
+trait CanonicalLinks {
+
+  val supportUrl: String
+
+  def buildCanonicalPaperSubscriptionLink(withDelivery: Boolean = false): String =
+    if (withDelivery) s"${supportUrl}/uk/subscribe/paper/delivery"
+    else s"${supportUrl}/uk/subscribe/paper"
+
+  def buildCanonicalDigitalSubscriptionLink(countryCode: String): String =
+    s"${supportUrl}/${countryCode}/subscribe/digital"
+
+  def buildCanonicalWeeklySubscriptionLink(countryCode: String): String =
+    s"${supportUrl}/${countryCode}/subscribe/weekly"
+
+}

--- a/app/controllers/DigitalPack.scala
+++ b/app/controllers/DigitalPack.scala
@@ -105,12 +105,12 @@ class DigitalPack(
     )
   }
 
-  def create(countryCode: String): Action[CreateSupportWorkersRequest] =
+  def create: Action[CreateSupportWorkersRequest] =
     authenticatedAction(recurringIdentityClientId).async(circe.json[CreateSupportWorkersRequest]) {
       implicit request =>
         val body = request.body
         val billingPeriod = request.body.product.billingPeriod
-        SafeLogger.info(s"[${request.uuid}] User ${request.user.id} is attempting to create a new $billingPeriod contribution")
+        SafeLogger.info(s"[${request.uuid}] User ${request.user.id} is attempting to create a new $billingPeriod digital subscription")
         val result = for {
           user <- identityService.getUser(request.user)
           statusResponse <- client.createSubscription(request, contributor(user, request.body), request.uuid).leftMap(_.toString)

--- a/app/controllers/DigitalPack.scala
+++ b/app/controllers/DigitalPack.scala
@@ -1,0 +1,83 @@
+package controllers
+
+import actions.CustomActionBuilders
+import admin.{Settings, SettingsProvider, SettingsSurrogateKeySyntax}
+import assets.AssetsResolver
+import cats.implicits._
+import com.gu.identity.play.IdUser
+import config.StringsConfig
+import monitoring.SafeLogger
+import monitoring.SafeLogger._
+import play.api.mvc.{Action, AnyContent, ControllerComponents, RequestHeader}
+import play.twirl.api.Html
+import services.IdentityService
+import views.html.digitalSubscription
+import views.html.helper.CSRF
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class DigitalPack(
+    actionRefiners: CustomActionBuilders,
+    identityService: IdentityService,
+    val assets: AssetsResolver,
+    components: ControllerComponents,
+    stringsConfig: StringsConfig,
+    settingsProvider: SettingsProvider,
+    val supportUrl: String
+)(implicit val ec: ExecutionContext) extends GeoRedirect(components, actionRefiners) with CanonicalLinks with SettingsSurrogateKeySyntax {
+  import actionRefiners._
+
+  implicit val a: AssetsResolver = assets
+
+  def digital(countryCode: String): Action[AnyContent] = CachedAction() { implicit request =>
+    implicit val settings: Settings = settingsProvider.settings()
+    val title = "Support the Guardian | Digital Pack Subscription"
+    val id = "digital-subscription-landing-page-" + countryCode
+    val js = "digitalSubscriptionLandingPage.js"
+    val css = "digitalSubscriptionLandingPageStyles.css"
+    val description = stringsConfig.digitalPackLandingDescription
+    val canonicalLink = Some(buildCanonicalDigitalSubscriptionLink("uk"))
+    val hrefLangLinks = Map(
+      "en-us" -> buildCanonicalDigitalSubscriptionLink("us"),
+      "en-gb" -> buildCanonicalDigitalSubscriptionLink("uk"),
+      "en-au" -> buildCanonicalDigitalSubscriptionLink("au"),
+      "en" -> buildCanonicalDigitalSubscriptionLink("int")
+    )
+
+    Ok(views.html.main(title, id, js, css, description, canonicalLink, hrefLangLinks)).withSettingsSurrogateKey
+  }
+
+  def digitalGeoRedirect: Action[AnyContent] = geoRedirect("subscribe/digital")
+
+  def displayForm(countryCode: String, displayCheckout: Boolean, isCsrf: Boolean = false): Action[AnyContent] =
+    authenticatedAction(recurringIdentityClientId).async { implicit request =>
+      implicit val settings: Settings = settingsProvider.settings()
+      if (displayCheckout) {
+        identityService.getUser(request.user).fold(
+          error => {
+            SafeLogger.error(scrub"Failed to display digital subscriptions form for ${request.user.id} due to error from identityService: $error")
+            InternalServerError
+          },
+          user => Ok(digitalSubscriptionFormHtml(user, countryCode))
+        ).map(_.withSettingsSurrogateKey)
+      } else {
+        Future.successful(Redirect(routes.Subscriptions.geoRedirect))
+      }
+    }
+
+  private def digitalSubscriptionFormHtml(idUser: IdUser, countryCode: String)(implicit request: RequestHeader, settings: Settings): Html = {
+    val title = "Support the Guardian | Digital Subscription"
+    val id = "digital-subscription-checkout-page-" + countryCode
+    val js = "digitalSubscriptionCheckoutPage.js"
+    val css = "digitalSubscriptionCheckoutPageStyles.css"
+    val csrf = CSRF.getToken.value
+
+    digitalSubscription(title, id, js, css, Some(csrf), idUser)
+  }
+
+  def create(countryCode: String): Action[AnyContent] = authenticatedAction(recurringIdentityClientId).async {
+    implicit request =>
+      Future.successful(Ok("test"))
+  }
+
+}

--- a/app/controllers/DigitalSubscription.scala
+++ b/app/controllers/DigitalSubscription.scala
@@ -28,7 +28,7 @@ import views.html.helper.CSRF
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class DigitalPack(
+class DigitalSubscription(
     client: SupportWorkersClient,
     val assets: AssetsResolver,
     val actionRefiners: CustomActionBuilders,

--- a/app/controllers/DigitalSubscription.scala
+++ b/app/controllers/DigitalSubscription.scala
@@ -111,12 +111,12 @@ class DigitalSubscription(
         SafeLogger.info(s"[${request.uuid}] User ${request.user.id} is attempting to create a new $billingPeriod digital subscription")
         val result = for {
           user <- identityService.getUser(request.user)
-          statusResponse <- client.createSubscription(request, contributor(user, request.body), request.uuid).leftMap(_.toString)
+          statusResponse <- client.createSubscription(request, createUser(user, request.body), request.uuid).leftMap(_.toString)
         } yield statusResponse
         respondToClient(result, request.body.product.billingPeriod)
     }
 
-  private def contributor(user: IdUser, request: CreateSupportWorkersRequest) = {
+  private def createUser(user: IdUser, request: CreateSupportWorkersRequest) = {
     User(
       id = user.id,
       primaryEmailAddress = user.primaryEmailAddress,

--- a/app/controllers/GeoRedirect.scala
+++ b/app/controllers/GeoRedirect.scala
@@ -2,9 +2,13 @@ package controllers
 
 import actions.CustomActionBuilders
 import com.gu.i18n.CountryGroup._
-import play.api.mvc.{AbstractController, Action, AnyContent, ControllerComponents}
+import play.api.mvc.{AbstractController, Action, AnyContent}
 import utils.RequestCountry._
-abstract class GeoRedirect(components: ControllerComponents, actionRefiners: CustomActionBuilders) extends AbstractController(components) {
+
+trait GeoRedirect {
+  self: AbstractController =>
+  val actionRefiners: CustomActionBuilders
+
   import actionRefiners._
 
   def geoRedirect(path: String): Action[AnyContent] = GeoTargetedCachedAction() { implicit request =>
@@ -18,7 +22,6 @@ abstract class GeoRedirect(components: ControllerComponents, actionRefiners: Cus
     }
 
     Redirect(redirectUrl, request.queryString, status = FOUND)
-
   }
 
   def geoRedirectAllMarkets(path: String): Action[AnyContent] = GeoTargetedCachedAction() { implicit request =>

--- a/app/controllers/GeoRedirect.scala
+++ b/app/controllers/GeoRedirect.scala
@@ -1,0 +1,37 @@
+package controllers
+
+import actions.CustomActionBuilders
+import com.gu.i18n.CountryGroup._
+import play.api.mvc.{AbstractController, Action, AnyContent, ControllerComponents}
+import utils.RequestCountry._
+abstract class GeoRedirect(components: ControllerComponents, actionRefiners: CustomActionBuilders) extends AbstractController(components) {
+  import actionRefiners._
+
+  def geoRedirect(path: String): Action[AnyContent] = GeoTargetedCachedAction() { implicit request =>
+    // If we implement endpoints for EU, CA & NZ we could replace this match with
+    // request.fastlyCountry.map(_.id).getOrDefault("int")
+    val redirectUrl = request.fastlyCountry match {
+      case Some(UK) => s"/uk/$path"
+      case Some(US) => s"/us/$path"
+      case Some(Australia) => s"/au/$path"
+      case _ => s"/int/$path"
+    }
+
+    Redirect(redirectUrl, request.queryString, status = FOUND)
+
+  }
+
+  def geoRedirectAllMarkets(path: String): Action[AnyContent] = GeoTargetedCachedAction() { implicit request =>
+    val redirectUrl = request.fastlyCountry match {
+      case Some(UK) => s"/uk/$path"
+      case Some(US) => s"/us/$path"
+      case Some(Australia) => s"/au/$path"
+      case Some(Europe) => s"/eu/$path"
+      case Some(Canada) => s"/ca/$path"
+      case Some(NewZealand) => s"/nz/$path"
+      case _ => s"/int/$path"
+    }
+    Redirect(redirectUrl, request.queryString, status = FOUND)
+  }
+
+}

--- a/app/controllers/RegularContributions.scala
+++ b/app/controllers/RegularContributions.scala
@@ -20,7 +20,7 @@ import monitoring.SafeLogger._
 import play.api.libs.circe.Circe
 import play.api.mvc._
 import services.MembersDataService.UserNotFound
-import services.stepfunctions.{CreateSupportWorkersRequest, SupportWorkersClient, StatusResponse}
+import services.stepfunctions.{CreateSupportWorkersRequest, StatusResponse, SupportWorkersClient}
 import services.{IdentityService, MembersDataService, TestUserService}
 import views.html.recurringContributions
 

--- a/app/controllers/Subscriptions.scala
+++ b/app/controllers/Subscriptions.scala
@@ -10,14 +10,14 @@ import services.IdentityService
 import scala.concurrent.ExecutionContext
 
 class Subscriptions(
-    actionRefiners: CustomActionBuilders,
+    val actionRefiners: CustomActionBuilders,
     identityService: IdentityService,
     val assets: AssetsResolver,
     components: ControllerComponents,
     stringsConfig: StringsConfig,
     settingsProvider: SettingsProvider,
     val supportUrl: String
-)(implicit val ec: ExecutionContext) extends GeoRedirect(components, actionRefiners) with CanonicalLinks with SettingsSurrogateKeySyntax {
+)(implicit val ec: ExecutionContext) extends AbstractController(components) with GeoRedirect with CanonicalLinks with SettingsSurrogateKeySyntax {
 
   import actionRefiners._
 

--- a/app/controllers/Subscriptions.scala
+++ b/app/controllers/Subscriptions.scala
@@ -1,23 +1,13 @@
 package controllers
 
 import actions.CustomActionBuilders
+import admin.{Settings, SettingsProvider, SettingsSurrogateKeySyntax}
 import assets.AssetsResolver
-import com.gu.i18n.CountryGroup._
-import com.typesafe.scalalogging.LazyLogging
 import config.StringsConfig
 import play.api.mvc._
-import admin.{Settings, SettingsProvider, SettingsSurrogateKeySyntax}
-import com.gu.identity.play.IdUser
-import play.twirl.api.Html
 import services.IdentityService
-import utils.RequestCountry._
-import views.html.helper.CSRF
-import cats.implicits._
-import monitoring.SafeLogger
-import monitoring.SafeLogger._
 
-import scala.concurrent.{ExecutionContext, Future}
-import views.html.digitalSubscription
+import scala.concurrent.ExecutionContext
 
 class Subscriptions(
     actionRefiners: CustomActionBuilders,
@@ -26,39 +16,14 @@ class Subscriptions(
     components: ControllerComponents,
     stringsConfig: StringsConfig,
     settingsProvider: SettingsProvider,
-    supportUrl: String
-)(implicit val ec: ExecutionContext) extends AbstractController(components) with LazyLogging with SettingsSurrogateKeySyntax {
+    val supportUrl: String
+)(implicit val ec: ExecutionContext) extends GeoRedirect(components, actionRefiners) with CanonicalLinks with SettingsSurrogateKeySyntax {
 
   import actionRefiners._
 
   implicit val a: AssetsResolver = assets
 
   def geoRedirect: Action[AnyContent] = geoRedirect("subscribe")
-
-  def geoRedirect(path: String): Action[AnyContent] = GeoTargetedCachedAction() { implicit request =>
-    // If we implement endpoints for EU, CA & NZ we could replace this match with
-    // request.fastlyCountry.map(_.id).getOrDefault("int")
-    val redirectUrl = request.fastlyCountry match {
-      case Some(UK) => s"/uk/$path"
-      case Some(US) => s"/us/$path"
-      case Some(Australia) => s"/au/$path"
-      case _ => s"/int/$path"
-    }
-    Redirect(redirectUrl, request.queryString, status = FOUND)
-  }
-
-  def geoRedirectAllMarkets(path: String): Action[AnyContent] = GeoTargetedCachedAction() { implicit request =>
-    val redirectUrl = request.fastlyCountry match {
-      case Some(UK) => s"/uk/$path"
-      case Some(US) => s"/us/$path"
-      case Some(Australia) => s"/au/$path"
-      case Some(Europe) => s"/eu/$path"
-      case Some(Canada) => s"/ca/$path"
-      case Some(NewZealand) => s"/nz/$path"
-      case _ => s"/int/$path"
-    }
-    Redirect(redirectUrl, request.queryString, status = FOUND)
-  }
 
   def legacyRedirect(countryCode: String): Action[AnyContent] = CachedAction() { implicit request =>
     // Country code is required here because it's a parameter in the route.
@@ -80,26 +45,6 @@ class Subscriptions(
     )).withSettingsSurrogateKey
 
   }
-
-  def digital(countryCode: String): Action[AnyContent] = CachedAction() { implicit request =>
-    implicit val settings: Settings = settingsProvider.settings()
-    val title = "Support the Guardian | Digital Pack Subscription"
-    val id = "digital-subscription-landing-page-" + countryCode
-    val js = "digitalSubscriptionLandingPage.js"
-    val css = "digitalSubscriptionLandingPageStyles.css"
-    val description = stringsConfig.digitalPackLandingDescription
-    val canonicalLink = Some(buildCanonicalDigitalSubscriptionLink("uk"))
-    val hrefLangLinks = Map(
-      "en-us" -> buildCanonicalDigitalSubscriptionLink("us"),
-      "en-gb" -> buildCanonicalDigitalSubscriptionLink("uk"),
-      "en-au" -> buildCanonicalDigitalSubscriptionLink("au"),
-      "en" -> buildCanonicalDigitalSubscriptionLink("int")
-    )
-
-    Ok(views.html.main(title, id, js, css, description, canonicalLink, hrefLangLinks)).withSettingsSurrogateKey
-  }
-
-  def digitalGeoRedirect: Action[AnyContent] = geoRedirect("subscribe/digital")
 
   def premiumTier(countryCode: String): Action[AnyContent] = CachedAction() { implicit request =>
     implicit val settings: Settings = settingsProvider.settings()
@@ -149,42 +94,5 @@ class Subscriptions(
   }
 
   def premiumTierGeoRedirect: Action[AnyContent] = geoRedirect("subscribe/premium-tier")
-
-  private def digitalSubscriptionFormHtml(idUser: IdUser, countryCode: String)(implicit request: RequestHeader, settings: Settings): Html = {
-    val title = "Support the Guardian | Digital Subscription"
-    val id = "digital-subscription-checkout-page-" + countryCode
-    val js = "digitalSubscriptionCheckoutPage.js"
-    val css = "digitalSubscriptionCheckoutPageStyles.css"
-    val csrf = CSRF.getToken.value
-
-    digitalSubscription(title, id, js, css, Some(csrf), idUser)
-  }
-
-  def displayForm(countryCode: String, displayCheckout: Boolean, isCsrf: Boolean = false): Action[AnyContent] = {
-    authenticatedAction(recurringIdentityClientId).async { implicit request =>
-      implicit val settings: Settings = settingsProvider.settings()
-      if (displayCheckout) {
-        identityService.getUser(request.user).fold(
-          error => {
-            SafeLogger.error(scrub"Failed to display digital subscriptions form for ${request.user.id} due to error from identityService: $error")
-            InternalServerError
-          },
-          user => Ok(digitalSubscriptionFormHtml(user, countryCode))
-        ).map(_.withSettingsSurrogateKey)
-      } else {
-        Future.successful(Redirect(routes.Subscriptions.geoRedirect))
-      }
-    }
-  }
-
-  def buildCanonicalPaperSubscriptionLink(withDelivery: Boolean = false): String =
-    if (withDelivery) s"${supportUrl}/uk/subscribe/paper/delivery"
-    else s"${supportUrl}/uk/subscribe/paper"
-
-  def buildCanonicalDigitalSubscriptionLink(countryCode: String): String =
-    s"${supportUrl}/${countryCode}/subscribe/digital"
-
-  def buildCanonicalWeeklySubscriptionLink(countryCode: String): String =
-    s"${supportUrl}/${countryCode}/subscribe/weekly"
 
 }

--- a/app/services/stepfunctions/SupportWorkersClient.scala
+++ b/app/services/stepfunctions/SupportWorkersClient.scala
@@ -2,7 +2,7 @@ package services.stepfunctions
 
 import java.util.UUID
 
-import actions.CustomActionBuilders.OptionalAuthRequest
+import actions.CustomActionBuilders.AnyAuthRequest
 import akka.actor.ActorSystem
 import cats.data.EitherT
 import cats.implicits._
@@ -77,7 +77,7 @@ class SupportWorkersClient(
   private implicit val ec = system.dispatcher
   private val underlying = Client(arn)
 
-  private def referrerAcquisitionDataWithGAFields(request: OptionalAuthRequest[CreateSupportWorkersRequest]): ReferrerAcquisitionData = {
+  private def referrerAcquisitionDataWithGAFields(request: AnyAuthRequest[CreateSupportWorkersRequest]): ReferrerAcquisitionData = {
     val hostname = request.host
     val gaClientId = request.cookies.get("_ga").map(_.value)
     val userAgent = request.headers.get("user-agent")
@@ -86,7 +86,7 @@ class SupportWorkersClient(
   }
 
   def createSubscription(
-    request: OptionalAuthRequest[CreateSupportWorkersRequest],
+    request: AnyAuthRequest[CreateSupportWorkersRequest],
     user: User,
     requestId: UUID
   ): EitherT[Future, SupportWorkersError, StatusResponse] = {

--- a/app/views/digitalSubscription.scala.html
+++ b/app/views/digitalSubscription.scala.html
@@ -22,12 +22,10 @@
   window.guardian = window.guardian || {};
 
     window.guardian.user = {
-      @for(fields <- user.privateFields; firstName <- fields.firstName; lastName <- fields.secondName; country <- fields.country) {
-        firstName: "@firstName",
-        lastName: "@lastName",
+        firstName: "@user.privateFields.map(_.firstName).getOrElse("")",
+        lastName: "@user.privateFields.map(_.secondName).getOrElse("")",
         email: "@user.primaryEmailAddress",
-        country: "@country"
-      }
+        country: "@user.privateFields.map(_.country).getOrElse("")"
   };
 
   window.guardian.stripeKeyDefaultCurrencies = {

--- a/app/views/digitalSubscription.scala.html
+++ b/app/views/digitalSubscription.scala.html
@@ -1,14 +1,20 @@
-@import assets.AssetsResolver
-@import com.gu.identity.play.IdUser
-
 @import admin.Settings
+@import assets.AssetsResolver
+@import com.gu.i18n.Currency.AUD
+@import com.gu.identity.play.IdUser
+@import com.gu.support.config._
+@import helper.CSRF
 @(
   title: String,
   id: String,
   js: String,
   css: String,
   csrf: Option[String],
-  user: IdUser
+  user: IdUser,
+  uatMode: Boolean,
+  defaultStripeConfig: StripeConfig,
+  uatStripeConfig: StripeConfig,
+  payPalConfig: PayPalConfig
 )(implicit assets: AssetsResolver, requestHeader: RequestHeader, settings: Settings)
 
 @scripts = {
@@ -22,7 +28,18 @@
         email: "@user.primaryEmailAddress",
         country: "@country"
       }
-  }
+  };
+
+  window.guardian.stripeKeyDefaultCurrencies = {
+          default: "@defaultStripeConfig.forCurrency(None).publicKey",
+          uat: "@uatStripeConfig.forCurrency(None).publicKey"
+        };
+        window.guardian.stripeKeyAustralia = {
+          default: "@defaultStripeConfig.forCurrency(Some(AUD)).publicKey",
+          uat: "@uatStripeConfig.forCurrency(Some(AUD)).publicKey"
+        };
+        window.guardian.payPalEnvironment = "@payPalConfig.payPalEnvironment";
+        window.guardian.csrf = { token: "@CSRF.getToken.value" };
 
   </script>
 }

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -1,15 +1,15 @@
 package wiring
 
-import play.api.routing.Router
+import controllers.AssetsComponents
 import filters.{CacheHeadersCheck, SetCookiesCheck}
 import lib.CustomHttpErrorHandler
+import monitoring.{SentryLogging, StateMachineMonitor}
+import play.api.BuiltInComponentsFromContext
 import play.api.libs.ws.ahc.AhcWSComponents
 import play.api.mvc.EssentialFilter
-import play.filters.gzip.GzipFilter
-import play.api.BuiltInComponentsFromContext
-import controllers.AssetsComponents
-import monitoring.{SentryLogging, StateMachineMonitor}
+import play.api.routing.Router
 import play.filters.HttpFiltersComponents
+import play.filters.gzip.GzipFilter
 
 trait AppComponents extends PlayComponents
   with AhcWSComponents
@@ -49,6 +49,7 @@ trait AppComponents extends PlayComponents
     identityController,
     oneOffContributions,
     subscriptionsController,
+    digitalPackController,
     loginController,
     testUsersController,
     payPalRegularController,

--- a/app/wiring/Controllers.scala
+++ b/app/wiring/Controllers.scala
@@ -36,7 +36,7 @@ trait Controllers {
     appConfig.supportUrl
   )
 
-  lazy val digitalPackController = new DigitalPack(
+  lazy val digitalPackController = new DigitalSubscription(
     supportWorkersClient,
     assetsResolver,
     actionRefiners,

--- a/app/wiring/Controllers.scala
+++ b/app/wiring/Controllers.scala
@@ -38,10 +38,12 @@ trait Controllers {
 
   lazy val digitalPackController = new DigitalPack(
     supportWorkersClient,
+    assetsResolver,
     actionRefiners,
     identityService,
     testUsers,
-    assetsResolver,
+    appConfig.regularStripeConfigProvider,
+    appConfig.regularPayPalConfigProvider,
     controllerComponents,
     stringsConfig,
     settingsProvider,

--- a/app/wiring/Controllers.scala
+++ b/app/wiring/Controllers.scala
@@ -36,6 +36,16 @@ trait Controllers {
     appConfig.supportUrl
   )
 
+  lazy val digitalPackController = new DigitalPack(
+    actionRefiners,
+    identityService,
+    assetsResolver,
+    controllerComponents,
+    stringsConfig,
+    settingsProvider,
+    appConfig.supportUrl
+  )
+
   lazy val supportWorkersStatusController = new SupportWorkersStatus(
     supportWorkersClient,
     controllerComponents,

--- a/app/wiring/Controllers.scala
+++ b/app/wiring/Controllers.scala
@@ -37,13 +37,17 @@ trait Controllers {
   )
 
   lazy val digitalPackController = new DigitalPack(
+    supportWorkersClient,
     actionRefiners,
     identityService,
+    testUsers,
     assetsResolver,
     controllerComponents,
     stringsConfig,
     settingsProvider,
-    appConfig.supportUrl
+    appConfig.supportUrl,
+    tipMonitoring,
+    appConfig.guardianDomain
   )
 
   lazy val supportWorkersStatusController = new SupportWorkersStatus(

--- a/assets/helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis.js
+++ b/assets/helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis.js
@@ -1,10 +1,6 @@
 // @flow
 import { routes } from 'helpers/routes';
-import {
-  type AcquisitionABTest,
-  type OphanIds,
-  type ReferrerAcquisitionData,
-} from 'helpers/tracking/acquisitions';
+import { type AcquisitionABTest, type OphanIds, type ReferrerAcquisitionData, } from 'helpers/tracking/acquisitions';
 import { type ErrorReason } from 'helpers/errorReasons';
 import { type Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import { type BillingPeriod } from 'helpers/contributions';
@@ -159,6 +155,7 @@ function checkRegularStatus(
 
 /** Sends a regular payment request to the recurring contribution endpoint and checks the result */
 function postRegularPaymentRequest(
+  uri: string,
   data: RegularPaymentRequest,
   participations: Participations,
   csrf: CsrfState,
@@ -166,7 +163,7 @@ function postRegularPaymentRequest(
   setThankYouPageStage: (ThankYouPageStage) => void,
 ): Promise<PaymentResult> {
   return logPromise(fetchJson(
-    routes.recurringContribCreate,
+    uri,
     requestOptions(data, 'same-origin', 'POST', csrf),
   ).then(checkRegularStatus(participations, csrf, setGuestAccountCreationToken, setThankYouPageStage)));
 }

--- a/assets/helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis.js
+++ b/assets/helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis.js
@@ -1,6 +1,6 @@
 // @flow
 import { routes } from 'helpers/routes';
-import { type AcquisitionABTest, type OphanIds, type ReferrerAcquisitionData, } from 'helpers/tracking/acquisitions';
+import { type AcquisitionABTest, type OphanIds, type ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import { type ErrorReason } from 'helpers/errorReasons';
 import { type Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import { type BillingPeriod } from 'helpers/contributions';
@@ -20,6 +20,13 @@ type RegularContribution = {|
   currency: string,
   billingPeriod: BillingPeriod,
 |};
+
+type DigitalSubscription = {|
+  currency: string,
+  billingPeriod: BillingPeriod,
+|};
+
+type ProductFields = RegularContribution | DigitalSubscription
 
 type RegularPayPalPaymentFields = {| baid: string |};
 
@@ -42,7 +49,7 @@ export type RegularPaymentRequest = {|
   country: IsoCountry,
   state: UsState | CaState | null,
   email: string,
-  product: RegularContribution,
+  product: ProductFields,
   paymentFields: RegularPaymentFields,
   ophanIds: OphanIds,
   referrerAcquisitionData: ReferrerAcquisitionData,

--- a/assets/helpers/routes.js
+++ b/assets/helpers/routes.js
@@ -25,6 +25,7 @@ const routes: {
   payPalCreateAgreement: '/paypal/create-agreement',
   directDebitCheckAccount: '/direct-debit/check-account',
   payPalRestReturnURL: '/paypal/rest/return',
+  digitalSubscriptionCreate: '/subscribe/digital/create',
 };
 
 function paperSubsUrl(withDelivery: boolean = false): string {

--- a/assets/pages/digital-subscription-checkout/__tests__/digitalSubscriptionCheckoutReducerTest.js
+++ b/assets/pages/digital-subscription-checkout/__tests__/digitalSubscriptionCheckoutReducerTest.js
@@ -5,6 +5,7 @@
 import { initReducer, setStage, type Stage } from '../digitalSubscriptionCheckoutReducer';
 import { type User } from '../helpers/user';
 
+jest.mock('ophan', () => {});
 
 // ----- Tests ----- //
 

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -14,13 +14,13 @@ import {
   type StateProvince,
   stateProvinceFromString,
 } from 'helpers/internationalisation/country';
-import { formError, type FormError, nonEmptyString, notNull, validate, } from 'helpers/subscriptionsForms/validation';
+import { formError, type FormError, nonEmptyString, notNull, validate } from 'helpers/subscriptionsForms/validation';
 
 import {
   marketingConsentReducerFor,
   type State as MarketingConsentState,
 } from 'components/marketingConsent/marketingConsentReducer';
-import { showPaymentMethod } from 'pages/digital-subscription-checkout/helpers/paymentProviders';
+import { showPaymentMethod } from './helpers/paymentProviders';
 import { type User } from './helpers/user';
 
 

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -2,7 +2,7 @@
 
 // ----- Imports ----- //
 
-import { combineReducers, compose, type Dispatch } from 'redux';
+import { combineReducers, type Dispatch } from 'redux';
 
 import { type ReduxState } from 'helpers/page/page';
 import { type Option } from 'helpers/types/option';
@@ -126,11 +126,12 @@ const formActionCreators = {
   setPaymentFrequency: (paymentFrequency: DigitalBillingPeriod): Action => ({ type: 'SET_PAYMENT_FREQUENCY', paymentFrequency }),
   setPaymentMethod: (paymentMethod: PaymentMethod): Action => ({ type: 'SET_PAYMENT_METHOD', paymentMethod }),
   submitForm: () => (dispatch: Dispatch<Action>, getState: () => State) => {
-    const errors = compose(getErrors, getFormFields)(getState());
+    const state = getState();
+    const errors = getErrors(getFormFields(state));
     if (errors.length > 0) {
       dispatch(setFormErrors(errors));
     } else {
-      showPaymentMethod();
+      showPaymentMethod(state);
     }
   },
 };

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -2,32 +2,25 @@
 
 // ----- Imports ----- //
 
-import { compose, combineReducers, type Dispatch } from 'redux';
+import { combineReducers, compose, type Dispatch } from 'redux';
 
 import { type ReduxState } from 'helpers/page/page';
 import { type Option } from 'helpers/types/option';
 import { type DigitalBillingPeriod } from 'helpers/subscriptions';
-import { type Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
-import csrf from 'helpers/csrf/csrfReducer';
+import csrf, { type Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import {
-  type IsoCountry,
   fromString,
+  type IsoCountry,
   type StateProvince,
   stateProvinceFromString,
 } from 'helpers/internationalisation/country';
-import {
-  validate,
-  nonEmptyString,
-  notNull,
-  formError,
-  type FormError,
-} from 'helpers/subscriptionsForms/validation';
+import { formError, type FormError, nonEmptyString, notNull, validate, } from 'helpers/subscriptionsForms/validation';
 
 import {
   marketingConsentReducerFor,
   type State as MarketingConsentState,
 } from 'components/marketingConsent/marketingConsentReducer';
-
+import { showPaymentMethod } from 'pages/digital-subscription-checkout/helpers/paymentProviders';
 import { type User } from './helpers/user';
 
 
@@ -132,8 +125,14 @@ const formActionCreators = {
   setStateProvince: (stateProvince: string): Action => ({ type: 'SET_STATE_PROVINCE', stateProvince }),
   setPaymentFrequency: (paymentFrequency: DigitalBillingPeriod): Action => ({ type: 'SET_PAYMENT_FREQUENCY', paymentFrequency }),
   setPaymentMethod: (paymentMethod: PaymentMethod): Action => ({ type: 'SET_PAYMENT_METHOD', paymentMethod }),
-  submitForm: () => (dispatch: Dispatch<Action>, getState: () => State) =>
-    compose(dispatch, setFormErrors, getErrors, getFormFields)(getState()),
+  submitForm: () => (dispatch: Dispatch<Action>, getState: () => State) => {
+    const errors = compose(getErrors, getFormFields)(getState());
+    if (errors.length > 0) {
+      dispatch(setFormErrors(errors));
+    } else {
+      showPaymentMethod();
+    }
+  },
 };
 
 export type FormActionCreators = typeof formActionCreators;

--- a/assets/pages/digital-subscription-checkout/helpers/paymentProviders.js
+++ b/assets/pages/digital-subscription-checkout/helpers/paymentProviders.js
@@ -1,17 +1,10 @@
 // @flow
 
 import { openDialogBox, setupStripeCheckout } from 'helpers/paymentIntegrations/stripeCheckout';
-import { postRegularPaymentRequest, } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
+import { postRegularPaymentRequest } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
 import { routes } from 'helpers/routes';
-import type { State } from 'pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer';
-import { getFormFields } from 'pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer';
 import { getOphanIds, getSupportAbTests } from 'helpers/tracking/acquisitions';
-import type { ThankYouPageStage } from 'pages/new-contributions-landing/contributionsLandingReducer';
-
-function showPaymentMethod(state: State) {
-  setupStripeCheckout((token: string) => create(state, token), null, 'GBP', false)
-    .then(() => openDialogBox(10, 'test@test.com'));
-}
+import { getFormFields, type State } from '../digitalSubscriptionCheckoutReducer';
 
 function create(state: State, token: string) {
   // TODO: if we could harmonize the fields between this file and readerRevenueApis.js we could simplify this mapping
@@ -23,7 +16,7 @@ function create(state: State, token: string) {
   const data = {
     firstName: formFields.firstName,
     lastName: formFields.lastName,
-    country: formFields.country,
+    country: formFields.country || 'GB',
     state: formFields.stateProvince,
     email: state.page.checkout.email,
     product,
@@ -38,9 +31,14 @@ function create(state: State, token: string) {
     data,
     state.common.abParticipations,
     state.page.csrf,
-    (_: string) => null,
-    (_: ThankYouPageStage) => null,
+    () => {},
+    () => {},
   ).then(pr => console.log(pr));
+}
+
+function showPaymentMethod(state: State) {
+  setupStripeCheckout((token: string) => create(state, token), null, 'GBP', false)
+    .then(() => openDialogBox(10, 'test@test.com'));
 }
 
 export {

--- a/assets/pages/digital-subscription-checkout/helpers/paymentProviders.js
+++ b/assets/pages/digital-subscription-checkout/helpers/paymentProviders.js
@@ -1,0 +1,12 @@
+// @flow
+
+import { openDialogBox, setupStripeCheckout } from 'helpers/paymentIntegrations/stripeCheckout';
+
+function showPaymentMethod() {
+  setupStripeCheckout(alert, null, 'GBP', false)
+    .then(() => openDialogBox(10, 'test@test.com'));
+}
+
+export {
+  showPaymentMethod,
+};

--- a/assets/pages/digital-subscription-checkout/helpers/paymentProviders.js
+++ b/assets/pages/digital-subscription-checkout/helpers/paymentProviders.js
@@ -1,10 +1,46 @@
 // @flow
 
 import { openDialogBox, setupStripeCheckout } from 'helpers/paymentIntegrations/stripeCheckout';
+import { postRegularPaymentRequest, } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
+import { routes } from 'helpers/routes';
+import type { State } from 'pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer';
+import { getFormFields } from 'pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer';
+import { getOphanIds, getSupportAbTests } from 'helpers/tracking/acquisitions';
+import type { ThankYouPageStage } from 'pages/new-contributions-landing/contributionsLandingReducer';
 
-function showPaymentMethod() {
-  setupStripeCheckout(alert, null, 'GBP', false)
+function showPaymentMethod(state: State) {
+  setupStripeCheckout((token: string) => create(state, token), null, 'GBP', false)
     .then(() => openDialogBox(10, 'test@test.com'));
+}
+
+function create(state: State, token: string) {
+  // TODO: if we could harmonize the fields between this file and readerRevenueApis.js we could simplify this mapping
+  const formFields = getFormFields(state);
+  const product = {
+    currency: 'GBP',
+    billingPeriod: 'Monthly',
+  };
+  const data = {
+    firstName: formFields.firstName,
+    lastName: formFields.lastName,
+    country: formFields.country,
+    state: formFields.stateProvince,
+    email: state.page.checkout.email,
+    product,
+    paymentFields: { stripeToken: token },
+    ophanIds: getOphanIds(),
+    referrerAcquisitionData: state.common.referrerAcquisitionData,
+    supportAbTests: getSupportAbTests(state.common.abParticipations, state.common.optimizeExperiments),
+  };
+
+  postRegularPaymentRequest(
+    routes.digitalSubscriptionCreate,
+    data,
+    state.common.abParticipations,
+    state.page.csrf,
+    (_: string) => null,
+    (_: ThankYouPageStage) => null,
+  ).then(pr => console.log(pr));
 }
 
 export {

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -34,14 +34,14 @@ import {
 } from 'helpers/paymentIntegrations/newPaymentFlow/oneOffContributions';
 import { routes } from 'helpers/routes';
 import * as storage from 'helpers/storage';
-import { derivePaymentApiAcquisitionData, getOphanIds, getSupportAbTests, } from 'helpers/tracking/acquisitions';
+import { derivePaymentApiAcquisitionData, getOphanIds, getSupportAbTests } from 'helpers/tracking/acquisitions';
 import { logException } from 'helpers/logger';
 import trackConversion from 'helpers/tracking/conversions';
 import { getForm } from 'helpers/checkoutForm/checkoutForm';
 import { type FormSubmitParameters, onFormSubmit } from 'helpers/checkoutForm/onFormSubmit';
 import * as cookie from 'helpers/cookie';
 import { setFormSubmissionDependentValue } from './checkoutFormIsSubmittableActions';
-import { type State, type ThankYouPageStage, type UserFormData, } from './contributionsLandingReducer';
+import { type State, type ThankYouPageStage, type UserFormData } from './contributionsLandingReducer';
 
 
 export type Action =

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -6,23 +6,24 @@ import type { ErrorReason } from 'helpers/errorReasons';
 import { type ThirdPartyPaymentLibrary } from 'helpers/checkouts';
 import {
   type Amount,
-  logInvalidCombination,
   billingPeriodFromContrib,
   type ContributionType,
+  getAmount,
+  logInvalidCombination,
+  type PaymentMatrix,
   type PaymentMethod,
-  type PaymentMatrix, getAmount,
 } from 'helpers/contributions';
 import type { Csrf } from 'helpers/csrf/csrfReducer';
-import { getUserTypeFromIdentity } from 'helpers/identityApis';
+import { getUserTypeFromIdentity, type UserTypeFromIdentityResponse } from 'helpers/identityApis';
 import { type CaState, type UsState } from 'helpers/internationalisation/country';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import { payPalRequestData } from 'helpers/paymentIntegrations/newPaymentFlow/payPalRecurringCheckout';
 import type { RegularPaymentRequest } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
 import {
   type PaymentAuthorisation,
-  regularPaymentFieldsFromAuthorisation,
   type PaymentResult,
   postRegularPaymentRequest,
+  regularPaymentFieldsFromAuthorisation,
 } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
 import type { StripeChargeData } from 'helpers/paymentIntegrations/newPaymentFlow/oneOffContributions';
 import {
@@ -33,23 +34,14 @@ import {
 } from 'helpers/paymentIntegrations/newPaymentFlow/oneOffContributions';
 import { routes } from 'helpers/routes';
 import * as storage from 'helpers/storage';
-import {
-  derivePaymentApiAcquisitionData,
-  getOphanIds,
-  getSupportAbTests,
-} from 'helpers/tracking/acquisitions';
+import { derivePaymentApiAcquisitionData, getOphanIds, getSupportAbTests, } from 'helpers/tracking/acquisitions';
 import { logException } from 'helpers/logger';
 import trackConversion from 'helpers/tracking/conversions';
-import { type UserTypeFromIdentityResponse } from 'helpers/identityApis';
 import { getForm } from 'helpers/checkoutForm/checkoutForm';
-import { onFormSubmit, type FormSubmitParameters } from 'helpers/checkoutForm/onFormSubmit';
+import { type FormSubmitParameters, onFormSubmit } from 'helpers/checkoutForm/onFormSubmit';
 import * as cookie from 'helpers/cookie';
 import { setFormSubmissionDependentValue } from './checkoutFormIsSubmittableActions';
-import {
-  type State,
-  type UserFormData,
-  type ThankYouPageStage,
-} from './contributionsLandingReducer';
+import { type State, type ThankYouPageStage, type UserFormData, } from './contributionsLandingReducer';
 
 
 export type Action =
@@ -401,6 +393,7 @@ function recurringPaymentAuthorisationHandler(
   const request = regularPaymentRequestFromAuthorisation(paymentAuthorisation, state);
 
   return dispatch(onPaymentResult(postRegularPaymentRequest(
+    routes.recurringContribCreate,
     request,
     state.common.abParticipations,
     state.page.csrf,

--- a/conf/routes
+++ b/conf/routes
@@ -75,7 +75,7 @@ GET  /digital                            controllers.DigitalPack.digitalGeoRedir
 GET  /subscribe/digital                            controllers.DigitalPack.digitalGeoRedirect()
 GET  /$country<(uk|us|au|int)>/subscribe/digital   controllers.DigitalPack.digital(country: String)
 GET  /$country<(uk|us|au|int)>/subscribe/digital/checkout  controllers.DigitalPack.displayForm(country: String, displayCheckout: Boolean ?= false)
-POST  /$country<(uk|us|au|int)>/subscribe/digital/create  controllers.DigitalPack.create(country: String)
+POST /subscribe/digital/create  controllers.DigitalPack.create
 
 GET  /premium-tier                            controllers.Subscriptions.premiumTierGeoRedirect()
 GET  /subscribe/premium-tier                            controllers.Subscriptions.premiumTierGeoRedirect()

--- a/conf/routes
+++ b/conf/routes
@@ -71,11 +71,11 @@ GET  /$country<(uk|us|au|int)>/subscribe           controllers.Subscriptions.lan
 # subscribe route. We just redirect to the subscriptions site and let its geolocation handle it.
 GET  /:country/subscribe                           controllers.Subscriptions.legacyRedirect(country: String)
 
-GET  /digital                            controllers.DigitalPack.digitalGeoRedirect()
-GET  /subscribe/digital                            controllers.DigitalPack.digitalGeoRedirect()
-GET  /$country<(uk|us|au|int)>/subscribe/digital   controllers.DigitalPack.digital(country: String)
-GET  /$country<(uk|us|au|int)>/subscribe/digital/checkout  controllers.DigitalPack.displayForm(country: String, displayCheckout: Boolean ?= false)
-POST /subscribe/digital/create  controllers.DigitalPack.create
+GET  /digital                            controllers.DigitalSubscription.digitalGeoRedirect()
+GET  /subscribe/digital                            controllers.DigitalSubscription.digitalGeoRedirect()
+GET  /$country<(uk|us|au|int)>/subscribe/digital   controllers.DigitalSubscription.digital(country: String)
+GET  /$country<(uk|us|au|int)>/subscribe/digital/checkout  controllers.DigitalSubscription.displayForm(country: String, displayCheckout: Boolean ?= false)
+POST /subscribe/digital/create  controllers.DigitalSubscription.create
 
 GET  /premium-tier                            controllers.Subscriptions.premiumTierGeoRedirect()
 GET  /subscribe/premium-tier                            controllers.Subscriptions.premiumTierGeoRedirect()

--- a/conf/routes
+++ b/conf/routes
@@ -71,16 +71,21 @@ GET  /$country<(uk|us|au|int)>/subscribe           controllers.Subscriptions.lan
 # subscribe route. We just redirect to the subscriptions site and let its geolocation handle it.
 GET  /:country/subscribe                           controllers.Subscriptions.legacyRedirect(country: String)
 
-GET  /subscribe/digital                            controllers.Subscriptions.digitalGeoRedirect()
-GET  /$country<(uk|us|au|int)>/subscribe/digital   controllers.Subscriptions.digital(country: String)
-GET  /$country<(uk|us|au|int)>/subscribe/digital/checkout  controllers.Subscriptions.displayForm(country: String, displayCheckout: Boolean ?= false)
+GET  /digital                            controllers.DigitalPack.digitalGeoRedirect()
+GET  /subscribe/digital                            controllers.DigitalPack.digitalGeoRedirect()
+GET  /$country<(uk|us|au|int)>/subscribe/digital   controllers.DigitalPack.digital(country: String)
+GET  /$country<(uk|us|au|int)>/subscribe/digital/checkout  controllers.DigitalPack.displayForm(country: String, displayCheckout: Boolean ?= false)
+POST  /$country<(uk|us|au|int)>/subscribe/digital/create  controllers.DigitalPack.create(country: String)
 
+GET  /premium-tier                            controllers.Subscriptions.premiumTierGeoRedirect()
 GET  /subscribe/premium-tier                            controllers.Subscriptions.premiumTierGeoRedirect()
 GET  /$country<(uk|us|au|int)>/subscribe/premium-tier   controllers.Subscriptions.premiumTier(country: String)
 
+GET  /weekly                            controllers.Subscriptions.weeklyGeoRedirect()
 GET  /subscribe/weekly                            controllers.Subscriptions.weeklyGeoRedirect()
 GET  /$country<(uk|us|au|int|nz|ca|eu)>/subscribe/weekly   controllers.Subscriptions.weekly(country: String)
 
+GET  /paper          controllers.Subscriptions.paperMethodRedirect(withDelivery: Boolean = false)
 GET  /subscribe/paper          controllers.Subscriptions.paperMethodRedirect(withDelivery: Boolean = false)
 GET  /subscribe/paper/delivery          controllers.Subscriptions.paperMethodRedirect(withDelivery: Boolean = true)
 GET  /uk/subscribe/paper          controllers.Subscriptions.paper(withDelivery: Boolean = false)

--- a/test/controllers/SubscriptionsTest.scala
+++ b/test/controllers/SubscriptionsTest.scala
@@ -4,6 +4,8 @@ import actions.CustomActionBuilders
 import admin.SwitchState.On
 import admin.{PaymentMethodsSwitch, Settings, SettingsProvider, Switches}
 import cats.implicits._
+import com.gu.tip.Tip
+import config.Configuration.GuardianDomain
 import config.StringsConfig
 import fixtures.TestCSRFComponents
 import org.mockito.Mockito.when
@@ -13,7 +15,8 @@ import org.scalatest.{MustMatchers, WordSpec}
 import play.api.mvc.Result
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{contentAsString, status, stubControllerComponents, _}
-import services.HttpIdentityService
+import services.stepfunctions.SupportWorkersClient
+import services.{HttpIdentityService, TestUserService}
 
 import scala.concurrent.Future
 
@@ -33,14 +36,22 @@ class SubscriptionsTest extends WordSpec with MustMatchers with TestCSRFComponen
         Settings(Switches(PaymentMethodsSwitch(On, On, None), PaymentMethodsSwitch(On, On, Some(On)), Map.empty, On))
       )
 
+      val client = mock[SupportWorkersClient]
+      val testUserService = mock[TestUserService]
+      val tip = mock[Tip]
+
       new DigitalPack(
+        client,
         actionRefiner,
         identityService,
+        testUserService,
         assetResolver,
         stubControllerComponents(),
         new StringsConfig(),
         settingsProvider,
-        "support.thegulocal.com"
+        "support.thegulocal.com",
+        tip,
+        GuardianDomain(".thegulocal.com")
       )
     }
 

--- a/test/controllers/SubscriptionsTest.scala
+++ b/test/controllers/SubscriptionsTest.scala
@@ -4,11 +4,12 @@ import actions.CustomActionBuilders
 import admin.SwitchState.On
 import admin.{PaymentMethodsSwitch, Settings, SettingsProvider, Switches}
 import cats.implicits._
-import com.gu.support.config.{PayPalConfigProvider, StripeConfigProvider}
+import com.gu.support.config._
 import com.gu.tip.Tip
 import config.Configuration.GuardianDomain
 import config.StringsConfig
 import fixtures.TestCSRFComponents
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatest.OptionValues._
 import org.scalatest.mockito.MockitoSugar.mock
@@ -30,7 +31,7 @@ class SubscriptionsTest extends WordSpec with MustMatchers with TestCSRFComponen
     def fakeDigitalPack(
       actionRefiner: CustomActionBuilders = loggedInActionRefiner,
       identityService: HttpIdentityService = mockedIdentityService(authenticatedIdUser.user -> idUser.asRight[String])
-    ): DigitalPack = {
+    ): DigitalSubscription = {
 
       val settingsProvider = mock[SettingsProvider]
       when(settingsProvider.settings()).thenReturn(
@@ -41,9 +42,14 @@ class SubscriptionsTest extends WordSpec with MustMatchers with TestCSRFComponen
       val testUserService = mock[TestUserService]
       val tip = mock[Tip]
       val stripe = mock[StripeConfigProvider]
+      val stripeAccountConfig = StripeAccountConfig("", "")
+      when(stripe.get(any[Boolean])).thenReturn(
+        StripeConfig(stripeAccountConfig, stripeAccountConfig, None)
+      )
       val payPal = mock[PayPalConfigProvider]
+      when(payPal.get(any[Boolean])).thenReturn(PayPalConfig("", "", "", "", "", ""))
 
-      new DigitalPack(
+      new DigitalSubscription(
         client,
         assetResolver,
         actionRefiner,

--- a/test/controllers/SubscriptionsTest.scala
+++ b/test/controllers/SubscriptionsTest.scala
@@ -1,21 +1,19 @@
 package controllers
 
 import actions.CustomActionBuilders
-import config.StringsConfig
-import org.scalatest.mockito.MockitoSugar.mock
-import play.api.test.Helpers.{contentAsString, status, stubControllerComponents}
-import scala.concurrent.ExecutionContext.Implicits.global
-import cats.implicits._
-import org.scalatest.{MustMatchers, WordSpec}
-import org.scalatest.OptionValues._
-import org.mockito.Mockito.when
-import play.api.test.FakeRequest
-import play.api.test.Helpers._
-import play.api.mvc.Result
-import services.HttpIdentityService
-import fixtures.TestCSRFComponents
 import admin.SwitchState.On
 import admin.{PaymentMethodsSwitch, Settings, SettingsProvider, Switches}
+import cats.implicits._
+import config.StringsConfig
+import fixtures.TestCSRFComponents
+import org.mockito.Mockito.when
+import org.scalatest.OptionValues._
+import org.scalatest.mockito.MockitoSugar.mock
+import org.scalatest.{MustMatchers, WordSpec}
+import play.api.mvc.Result
+import play.api.test.FakeRequest
+import play.api.test.Helpers.{contentAsString, status, stubControllerComponents, _}
+import services.HttpIdentityService
 
 import scala.concurrent.Future
 
@@ -25,17 +23,17 @@ class SubscriptionsTest extends WordSpec with MustMatchers with TestCSRFComponen
 
     val checkoutEndpoint = "subscribe/digital/checkout?displayCheckout=true"
 
-    def fakeSubscriptions(
+    def fakeDigitalPack(
       actionRefiner: CustomActionBuilders = loggedInActionRefiner,
       identityService: HttpIdentityService = mockedIdentityService(authenticatedIdUser.user -> idUser.asRight[String])
-    ): Subscriptions = {
+    ): DigitalPack = {
 
       val settingsProvider = mock[SettingsProvider]
       when(settingsProvider.settings()).thenReturn(
         Settings(Switches(PaymentMethodsSwitch(On, On, None), PaymentMethodsSwitch(On, On, Some(On)), Map.empty, On))
       )
 
-      new Subscriptions(
+      new DigitalPack(
         actionRefiner,
         identityService,
         assetResolver,
@@ -50,7 +48,7 @@ class SubscriptionsTest extends WordSpec with MustMatchers with TestCSRFComponen
       actionRefiner: CustomActionBuilders = loggedInActionRefiner,
       identityService: HttpIdentityService = mockedIdentityService(authenticatedIdUser.user -> idUser.asRight[String])
     ): Future[Result] = {
-      fakeSubscriptions(actionRefiner, identityService).displayForm("UK", true, true)(FakeRequest())
+      fakeDigitalPack(actionRefiner, identityService).displayForm("UK", true, true)(FakeRequest())
     }
   }
 

--- a/test/controllers/SubscriptionsTest.scala
+++ b/test/controllers/SubscriptionsTest.scala
@@ -4,6 +4,7 @@ import actions.CustomActionBuilders
 import admin.SwitchState.On
 import admin.{PaymentMethodsSwitch, Settings, SettingsProvider, Switches}
 import cats.implicits._
+import com.gu.support.config.{PayPalConfigProvider, StripeConfigProvider}
 import com.gu.tip.Tip
 import config.Configuration.GuardianDomain
 import config.StringsConfig
@@ -39,13 +40,17 @@ class SubscriptionsTest extends WordSpec with MustMatchers with TestCSRFComponen
       val client = mock[SupportWorkersClient]
       val testUserService = mock[TestUserService]
       val tip = mock[Tip]
+      val stripe = mock[StripeConfigProvider]
+      val payPal = mock[PayPalConfigProvider]
 
       new DigitalPack(
         client,
+        assetResolver,
         actionRefiner,
         identityService,
         testUserService,
-        assetResolver,
+        stripe,
+        payPal,
         stubControllerComponents(),
         new StringsConfig(),
         settingsProvider,


### PR DESCRIPTION
## Why are you doing this?

This is part 3 of the work to hook support-frontend up to support-workers for Digital Pack creation.
The main part of this PR is the new endpoint for the checkout form to post to to create a state machine execution, but to make sure that this works I've also added basic code to post to it from the checkout form. 

This means we can now actually create a Digital Pack subscription end to end from support-frontend!

See the checklist below for next steps.

[**Trello Card**](https://trello.com/c/5N8LQ5yU/2060-be-able-to-trigger-the-creation-of-a-digital-pack-subscription-via-support-frontend)

## Changes
* Create a new controller for digital subscriptions as the `Subscriptions` one was getting pretty big
* Factor out some behaviour from the Subscriptions controller into a trait so that it can be mixed into both controllers
* Create a new `/create` endpoint in the `DigitalSubscriptions` controller to trigger a step function execution.
* Add code to the Digital Pack checkout page to activate Stripe and then post the form to the new `/create` endpoint

## TODO
- [ ] Error handling
- [ ] Progress indicator on form submission
- [ ] Thank you page
- [ ] Direct debit payment method
- [ ] Convert div to a real form