### PR TITLE
Fix apple pay tracking

### DIFF
--- a/assets/helpers/paymentIntegrations/newPaymentFlow/oneOffContributions.js
+++ b/assets/helpers/paymentIntegrations/newPaymentFlow/oneOffContributions.js
@@ -60,7 +60,7 @@ export type StripeChargeData = {|
     amount: number,
     token: string,
     email: string,
-    paymentMethod: StripePaymentMethod,
+    stripePaymentMethod: StripePaymentMethod,
   },
   acquisitionData: PaymentAPIAcquisitionData,
 |};

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -249,7 +249,7 @@ const stripeChargeDataFromAuthorisation = (
     ),
     token: authorisation.token,
     email: state.page.form.formData.email || '',
-    paymentMethod: authorisation.stripePaymentMethod,
+    stripePaymentMethod: authorisation.stripePaymentMethod,
   },
   acquisitionData: derivePaymentApiAcquisitionData(
     state.common.referrerAcquisitionData,


### PR DESCRIPTION
## Why are you doing this?
A typo in the `StripeChargeData` meant that the payment api wasn't able to read the `stripePaymentMethod` field. 

Thus, all Apple Pay transactions were logged as normal Stripe transactions (the pre-exisiting behaviour).

This PR fixes it
