### PR TITLE
Remove US landing page test, keeping ticker & copy

### DIFF
--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -9,20 +9,7 @@ export type AnnualContributionsTestVariant = 'control' | 'annualAmountsA' | 'not
 export type ApplePayTestVariant = 'control' | 'applePay' | 'notintest';
 
 export const tests: Tests = {
-
-  usDesktopEOYCampaign: {
-    variants: ['campaignCopy', 'copyAndTicker', 'copyAndTickerAndBackgroundImage'],
-    audiences: {
-      UnitedStates: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: true,
-    independent: true,
-    seed: 2,
-  },
-
+  
   annualContributionsRoundThree: {
     variants: ['control', 'annualAmountsA'],
     audiences: {

--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -9,7 +9,6 @@ export type AnnualContributionsTestVariant = 'control' | 'annualAmountsA' | 'not
 export type ApplePayTestVariant = 'control' | 'applePay' | 'notintest';
 
 export const tests: Tests = {
-  
   annualContributionsRoundThree: {
     variants: ['control', 'annualAmountsA'],
     audiences: {

--- a/assets/helpers/internationalisation/contributions.js
+++ b/assets/helpers/internationalisation/contributions.js
@@ -12,6 +12,8 @@ export type CountryMetaData = {
   headerCopy: string,
   contributeCopy?: string,
   headerClasses?: string,
+  // URL to fetch ticker data from. null/undefined implies no ticker
+  tickerJsonUrl?: string,
 };
 
 const countryGroupSpecificDetails: {
@@ -28,6 +30,7 @@ const countryGroupSpecificDetails: {
   UnitedStates: {
     headerCopy: 'Make a year-end gift to The Guardian and invest in our independent journalism for 2019 and beyond.',
     headerClasses: 'header__us-campaign',
+    tickerJsonUrl: '/ticker.json',
   },
   AUDCountries: {
     headerCopy: 'Help us deliver the independent journalism Australia needs',

--- a/assets/helpers/internationalisation/contributions.js
+++ b/assets/helpers/internationalisation/contributions.js
@@ -26,8 +26,8 @@ const countryGroupSpecificDetails: {
     contributeCopy: defaultContributeCopy,
   },
   UnitedStates: {
-    headerCopy: defaultHeaderCopy,
-    contributeCopy: defaultContributeCopy,
+    headerCopy: 'Make a year-end gift to The Guardian and invest in our independent journalism for 2019 and beyond.',
+    headerClasses: 'header__us-campaign',
   },
   AUDCountries: {
     headerCopy: 'Help us deliver the independent journalism Australia needs',
@@ -47,9 +47,4 @@ const countryGroupSpecificDetails: {
   },
 };
 
-const usCampaignDetails: CountryMetaData = {
-  headerCopy: 'Make a year-end gift to The Guardian and invest in our independent journalism for 2019 and beyond.',
-  headerClasses: 'header__us-campaign',
-};
-
-export { countryGroupSpecificDetails, usCampaignDetails };
+export { countryGroupSpecificDetails };

--- a/assets/pages/new-contributions-landing/components/ContributionBackground.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionBackground.jsx
@@ -3,48 +3,11 @@
 // ----- Imports ----- //
 
 import React from 'react';
-import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import SvgContributionsBgDesktop from 'components/svgs/contributionsBgDesktop';
-import GridPicture from 'components/gridPicture/gridPicture';
-
-type PropTypes = {|
-  countryGroupId: CountryGroupId,
-  usDesktopEOYCampaignVariant: string,
-|};
 
 // ----- Render ----- //
 
-function NewContributionBackground(props: PropTypes) {
-  const showUsBackground = (props.countryGroupId === 'UnitedStates' && props.usDesktopEOYCampaignVariant === 'copyAndTickerAndBackgroundImage');
-
-  if (showUsBackground) {
-    return (
-      <div className="us-campaign__background">
-        <GridPicture
-          sources={[
-            {
-              gridId: 'UsCampaignLanding',
-              srcSizes: [1500, 1500],
-              imgType: 'png',
-              sizes: '100vw',
-              media: '(max-width: 1500px)',
-            },
-            {
-              gridId: 'UsCampaignLanding',
-              srcSizes: [1500, 1500],
-              imgType: 'png',
-              sizes: '(min-width: 1500px) 1500px, 1500px',
-              media: '(min-width: 1500px)',
-            },
-          ]}
-          fallback="UsCampaignLanding"
-          fallbackSize={1500}
-          altText=""
-          fallbackImgType="png"
-        />
-      </div>
-    );
-  }
+function NewContributionBackground() {
   return (
     <div className="gu-content__bg">
       <SvgContributionsBgDesktop />

--- a/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
@@ -20,7 +20,7 @@ import { openDirectDebitPopUp } from 'components/directDebit/directDebitActions'
 
 import { type State } from '../contributionsLandingReducer';
 import { NewContributionForm } from './ContributionForm';
-import { ContributionUsTicker } from './ContributionUsTicker';
+import { ContributionTicker } from './ContributionTicker';
 import { setPayPalHasLoaded } from '../contributionsLandingActions';
 
 import {
@@ -97,7 +97,9 @@ function ContributionFormContainer(props: PropTypes) {
     : (
       <div className="gu-content__content">
         <h1 className={headerClasses}>{countryGroupDetails.headerCopy}</h1>
-        { props.countryGroupId === 'UnitedStates' ? <ContributionUsTicker /> : null }
+        {countryGroupDetails.tickerJsonUrl ?
+          <ContributionTicker tickerJsonUrl={countryGroupDetails.tickerJsonUrl} /> : null
+        }
         { countryGroupDetails.contributeCopy ?
           <p className="blurb">{countryGroupDetails.contributeCopy}</p> : null
         }

--- a/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
@@ -9,7 +9,7 @@ import { type ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import React from 'react';
 import { connect } from 'react-redux';
 import { Redirect } from 'react-router';
-import { countryGroupSpecificDetails, usCampaignDetails } from 'helpers/internationalisation/contributions';
+import { countryGroupSpecificDetails } from 'helpers/internationalisation/contributions';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { type ErrorReason } from 'helpers/errorReasons';
 import { type PaymentAuthorisation } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
@@ -52,7 +52,6 @@ type PropTypes = {|
   paymentMethod: PaymentMethod,
   contributionType: ContributionType,
   referrerAcquisitionData: ReferrerAcquisitionData,
-  usDesktopEOYCampaignVariant: string,
 |};
 
 /* eslint-enable react/no-unused-prop-types */
@@ -69,7 +68,6 @@ const mapStateToProps = (state: State) => ({
   paymentMethod: state.page.form.paymentMethod,
   contributionType: state.page.form.contributionType,
   referrerAcquisitionData: state.common.referrerAcquisitionData,
-  usDesktopEOYCampaignVariant: state.common.abParticipations.usDesktopEOYCampaign,
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -90,21 +88,16 @@ function ContributionFormContainer(props: PropTypes) {
     props.onThirdPartyPaymentAuthorised(paymentAuthorisation);
   };
 
-  const countryGroupDetails = (props.countryGroupId === 'UnitedStates' && props.usDesktopEOYCampaignVariant !== 'notintest') ?
-    usCampaignDetails :
-    countryGroupSpecificDetails[props.countryGroupId];
+  const countryGroupDetails = countryGroupSpecificDetails[props.countryGroupId];
 
   const headerClasses = `header ${countryGroupDetails.headerClasses ? countryGroupDetails.headerClasses : ''}`;
-
-  const isInTickerVariant: boolean = ['copyAndTicker', 'copyAndTickerAndBackgroundImage'].includes(props.usDesktopEOYCampaignVariant);
-  const displayTicker = (props.countryGroupId === 'UnitedStates' && isInTickerVariant);
 
   return props.paymentComplete ?
     <Redirect to={props.thankYouRoute} />
     : (
       <div className="gu-content__content">
         <h1 className={headerClasses}>{countryGroupDetails.headerCopy}</h1>
-        { displayTicker ? <ContributionUsTicker /> : null }
+        { props.countryGroupId === 'UnitedStates' ? <ContributionUsTicker /> : null }
         { countryGroupDetails.contributeCopy ?
           <p className="blurb">{countryGroupDetails.contributeCopy}</p> : null
         }

--- a/assets/pages/new-contributions-landing/components/ContributionTicker.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionTicker.jsx
@@ -10,13 +10,16 @@ type StateTypes = {|
   goal: number,
 |}
 
-type PropTypes = {}
+type PropTypes = {|
+  // URL to fetch ticker JSON from
+  tickerJsonUrl: string,
+|}
 
 
 // ---- Helpers ----- //
 
-const getInitialTickerValues = (): Promise<StateTypes> =>
-  fetch('/ticker.json')
+const getInitialTickerValues = (tickerJsonUrl: string): Promise<StateTypes> =>
+  fetch(tickerJsonUrl)
     .then(resp => resp.json())
     .then((data) => {
       const totalSoFar = parseInt(data.total, 10);
@@ -32,10 +35,12 @@ const percentageTotalAsNegative = (total: number, goal: number) => {
 
 
 // ----- Component ----- //
-export class ContributionUsTicker extends Component<PropTypes, StateTypes> {
+export class ContributionTicker extends Component<PropTypes, StateTypes> {
 
   constructor(props: PropTypes) {
     super(props);
+
+    this.tickerJsonUrl = props.tickerJsonUrl;
 
     this.state = {
       totalSoFar: 0,
@@ -45,7 +50,7 @@ export class ContributionUsTicker extends Component<PropTypes, StateTypes> {
   }
 
   componentDidMount(): void {
-    getInitialTickerValues().then(({ totalSoFar, goal }) => {
+    getInitialTickerValues(this.tickerJsonUrl).then(({ totalSoFar, goal }) => {
       const initialTotal = totalSoFar * 0.8;
       this.count = initialTotal;
       this.totalSoFar = totalSoFar;
@@ -61,6 +66,7 @@ export class ContributionUsTicker extends Component<PropTypes, StateTypes> {
   filledProgressBar: ?HTMLDivElement;
   count = 0;
   totalSoFar: number;
+  tickerJsonUrl: string;
 
   animateBar(totalSoFar: number, goal: number) {
     const progressBarElement = this.filledProgressBar;

--- a/assets/pages/new-contributions-landing/contributionsLanding.jsx
+++ b/assets/pages/new-contributions-landing/contributionsLanding.jsx
@@ -48,7 +48,7 @@ const reactElementId = `new-contributions-landing-page-${countryGroups[countryGr
 
 const selectedCountryGroup = countryGroups[countryGroupId];
 
-const { smallMobileHeaderNotEpicOrBanner, usDesktopEOYCampaign } = store.getState().common.abParticipations;
+const { smallMobileHeaderNotEpicOrBanner } = store.getState().common.abParticipations;
 
 let extraClasses = [];
 if (smallMobileHeaderNotEpicOrBanner) {
@@ -85,10 +85,7 @@ const router = (
               <NewContributionFormContainer
                 thankYouRoute={`/${countryGroups[countryGroupId].supportInternationalisationId}/thankyou`}
               />
-              <NewContributionBackground
-                usDesktopEOYCampaignVariant={usDesktopEOYCampaign}
-                countryGroupId={countryGroupId}
-              />
+              <NewContributionBackground />
             </Page>
           )
         }
@@ -108,10 +105,7 @@ const router = (
                 footer={<Footer disclaimer countryGroupId={countryGroupId} />}
               >
                 <ContributionThankYouContainer />
-                <NewContributionBackground
-                  usDesktopEOYCampaignVariant={usDesktopEOYCampaign}
-                  countryGroupId={countryGroupId}
-                />
+                <NewContributionBackground />
               </Page>
             );
           }}

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -1263,26 +1263,3 @@ form {
     }
   }
 }
-
-.us-campaign__background {
-  display: none;
-  position: absolute;
-  z-index: -1;
-
-  @include mq($from: tablet) {
-    display: block;
-    transform: translate(200px, -135px);
-  }
-
-  @include mq($from: desktop) {
-    transform: translate(200px, -135px);
-  }
-
-  @include mq($from: leftCol) {
-    transform: translate(215px, -225px);
-  }
-
-  @include mq($from: wide) {
-    transform: translate(215px, -300px);
-  }
-}

--- a/public/ticker.json
+++ b/public/ticker.json
@@ -1,0 +1,5 @@
+{
+  "total": 500000,
+  "goal": 1000000,
+  "whyIsThisFileHere?": "This is just a dummy file for local dev. In CODE & PROD Fastly will route this request direct to S3, so this file will not be accessed."
+}


### PR DESCRIPTION
Also makes `ContributionUsTicker` into `ContributionTicker` parameterised on `tickerJsonUrl`, allowing us to put **all** country-specific rendering info into `assets/helpers/internationalisation/contributions.js` 

US page now looks like this for everyone.
![screencapture-support-thegulocal-us-contribute-2018-12-21-13_30_05](https://user-images.githubusercontent.com/5122968/50344814-8cc20d80-0524-11e9-9a3e-492104e83158.png)
