### PR TITLE
Digital subscription checkout

### DIFF
--- a/app/views/digitalSubscription.scala.html
+++ b/app/views/digitalSubscription.scala.html
@@ -17,29 +17,33 @@
   payPalConfig: PayPalConfig
 )(implicit assets: AssetsResolver, requestHeader: RequestHeader, settings: Settings)
 
-@scripts = {
-  <script type="text/javascript">
-  window.guardian = window.guardian || {};
+  @scripts = {
+    <script type="text/javascript">
+      window.guardian = window.guardian || {};
 
-    window.guardian.user = {
+      window.guardian.user = {
         firstName: "@user.privateFields.map(_.firstName).getOrElse("")",
         lastName: "@user.privateFields.map(_.secondName).getOrElse("")",
         email: "@user.primaryEmailAddress",
         country: "@user.privateFields.map(_.country).getOrElse("")"
-  };
+      };
 
-  window.guardian.stripeKeyDefaultCurrencies = {
+
+      window.guardian.stripeKeyDefaultCurrencies = {
+        REGULAR: {
           default: "@defaultStripeConfig.forCurrency(None).publicKey",
           uat: "@uatStripeConfig.forCurrency(None).publicKey"
-        };
-        window.guardian.stripeKeyAustralia = {
+        }
+      };
+      window.guardian.stripeKeyAustralia = {
+        REGULAR: {
           default: "@defaultStripeConfig.forCurrency(Some(AUD)).publicKey",
           uat: "@uatStripeConfig.forCurrency(Some(AUD)).publicKey"
-        };
-        window.guardian.payPalEnvironment = "@payPalConfig.payPalEnvironment";
-        window.guardian.csrf = { token: "@CSRF.getToken.value" };
-
+        }
+      };
+      window.guardian.payPalEnvironment = "@payPalConfig.payPalEnvironment";
+      window.guardian.csrf = { token: "@CSRF.getToken.value" };
   </script>
-}
+  }
 
-@main(title = title, scripts = scripts, mainJsBundle = js, mainId = id, mainStyleBundle = css, csrf = csrf)
+  @main(title = title, scripts = scripts, mainJsBundle = js, mainId = id, mainStyleBundle = css, csrf = csrf)

--- a/assets/helpers/billingPeriods.js
+++ b/assets/helpers/billingPeriods.js
@@ -1,0 +1,10 @@
+// @flow
+
+export type Annual = 'Annual';
+export type Monthly = 'Monthly';
+export type Quarterly = 'Quarterly';
+export type SixForSix = 'SixForSix'; // TODO: SixForSix is not a real billing period it's an introductory offer
+export type BillingPeriod = SixForSix | Annual | Monthly | Quarterly;
+export type DigitalBillingPeriod = Monthly | Annual;
+export type WeeklyBillingPeriod = SixForSix | Quarterly | Annual;
+export type ContributionBillingPeriod = Monthly | Annual;

--- a/assets/helpers/billingPeriods.js
+++ b/assets/helpers/billingPeriods.js
@@ -1,10 +1,12 @@
 // @flow
 
-export type Annual = 'Annual';
-export type Monthly = 'Monthly';
-export type Quarterly = 'Quarterly';
-export type SixForSix = 'SixForSix'; // TODO: SixForSix is not a real billing period it's an introductory offer
-export type BillingPeriod = SixForSix | Annual | Monthly | Quarterly;
-export type DigitalBillingPeriod = Monthly | Annual;
-export type WeeklyBillingPeriod = SixForSix | Quarterly | Annual;
-export type ContributionBillingPeriod = Monthly | Annual;
+const Annual: 'Annual' = 'Annual';
+const Monthly: 'Monthly' = 'Monthly';
+const Quarterly: 'Quarterly' = 'Quarterly';
+const SixForSix: 'SixForSix' = 'SixForSix'; // TODO: SixForSix is not a real billing period it's an introductory offer
+export type BillingPeriod = typeof SixForSix | typeof Annual | typeof Monthly | typeof Quarterly;
+export type DigitalBillingPeriod = typeof Monthly | typeof Annual;
+export type WeeklyBillingPeriod = typeof SixForSix | typeof Quarterly | typeof Annual;
+export type ContributionBillingPeriod = typeof Monthly | typeof Annual;
+
+export { Annual, Monthly, Quarterly, SixForSix };

--- a/assets/helpers/contributions.js
+++ b/assets/helpers/contributions.js
@@ -11,6 +11,7 @@ import type { Radio } from 'components/radioToggle/radioToggle';
 import type { AnnualContributionsTestVariant } from 'helpers/abTests/abtestDefinitions';
 import { logException } from 'helpers/logger';
 import { getAnnualAmounts } from 'helpers/abTests/helpers/annualContributions';
+import { BillingPeriod } from 'helpers/billingPeriods';
 
 // ----- Types ----- //
 
@@ -54,8 +55,6 @@ export type ThirdPartyPaymentLibraries = {
   MONTHLY: { Stripe: Object | null, PayPal: Object | null },
   ANNUAL: { Stripe: Object | null, PayPal: Object | null },
 };
-
-export type BillingPeriod = 'Monthly' | 'Annual';
 
 export type Amount = { value: string, spoken: string, isDefault: boolean };
 

--- a/assets/helpers/contributions.js
+++ b/assets/helpers/contributions.js
@@ -11,7 +11,7 @@ import type { Radio } from 'components/radioToggle/radioToggle';
 import type { AnnualContributionsTestVariant } from 'helpers/abTests/abtestDefinitions';
 import { logException } from 'helpers/logger';
 import { getAnnualAmounts } from 'helpers/abTests/helpers/annualContributions';
-import { BillingPeriod } from 'helpers/billingPeriods';
+import { Annual, type BillingPeriod, Monthly } from 'helpers/billingPeriods';
 
 // ----- Types ----- //
 
@@ -352,8 +352,8 @@ function parseRegularContributionType(s: string): RegularContributionType {
 
 function billingPeriodFromContrib(contributionType: ContributionType): BillingPeriod {
   switch (contributionType) {
-    case 'ANNUAL': return 'Annual';
-    default: return 'Monthly';
+    case 'ANNUAL': return Annual;
+    default: return Monthly;
   }
 }
 

--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -2,26 +2,16 @@
 
 // ----- Imports ----- //
 
-import {
-  type Campaign,
-  type ReferrerAcquisitionData,
-  deriveSubsAcquisitionData,
-} from 'helpers/tracking/acquisitions';
-import {
-  countryGroups,
-  type CountryGroupId,
-} from 'helpers/internationalisation/countryGroup';
+import { type Campaign, deriveSubsAcquisitionData, type ReferrerAcquisitionData, } from 'helpers/tracking/acquisitions';
+import { type CountryGroupId, countryGroups, } from 'helpers/internationalisation/countryGroup';
 import { type Option } from 'helpers/types/option';
 import type { Participations } from 'helpers/abTests/abtest';
 import { type OptimizeExperiments } from 'helpers/optimize/optimize';
 import { getBaseDomain } from 'helpers/url';
-import type {
-  SubscriptionProduct,
-  WeeklyBillingPeriod,
-  PaperBillingPlan,
-} from 'helpers/subscriptions';
+import { WeeklyBillingPeriod } from 'helpers/billingPeriods';
+import type { PaperBillingPlan, SubscriptionProduct, } from 'helpers/subscriptions';
 
-import { getPromoCode, getIntcmp } from './flashSale';
+import { getIntcmp, getPromoCode } from './flashSale';
 
 
 // ----- Types ----- //

--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -2,14 +2,14 @@
 
 // ----- Imports ----- //
 
-import { type Campaign, deriveSubsAcquisitionData, type ReferrerAcquisitionData, } from 'helpers/tracking/acquisitions';
-import { type CountryGroupId, countryGroups, } from 'helpers/internationalisation/countryGroup';
+import { type Campaign, deriveSubsAcquisitionData, type ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
+import { type CountryGroupId, countryGroups } from 'helpers/internationalisation/countryGroup';
 import { type Option } from 'helpers/types/option';
 import type { Participations } from 'helpers/abTests/abtest';
 import { type OptimizeExperiments } from 'helpers/optimize/optimize';
 import { getBaseDomain } from 'helpers/url';
-import { WeeklyBillingPeriod } from 'helpers/billingPeriods';
-import type { PaperBillingPlan, SubscriptionProduct, } from 'helpers/subscriptions';
+import { Annual, Quarterly, SixForSix, type WeeklyBillingPeriod } from 'helpers/billingPeriods';
+import type { PaperBillingPlan, SubscriptionProduct } from 'helpers/subscriptions';
 
 import { getIntcmp, getPromoCode } from './flashSale';
 
@@ -47,7 +47,7 @@ function getWeeklyZuoraCode(period: WeeklyBillingPeriod, countryGroup: CountryGr
   const yearRow = 'weeklyrestofworld-gwoct18-quarterly-row';
 
   const urls = {
-    sixweek: {
+    [SixForSix]: {
       GBPCountries: sixWeekDomestic,
       UnitedStates: sixWeekDomestic,
       AUDCountries: sixWeekDomestic,
@@ -56,7 +56,7 @@ function getWeeklyZuoraCode(period: WeeklyBillingPeriod, countryGroup: CountryGr
       Canada: sixWeekDomestic,
       International: sixWeekRow,
     },
-    quarter: {
+    [Quarterly]: {
       GBPCountries: quarterDomestic,
       UnitedStates: quarterDomestic,
       AUDCountries: quarterDomestic,
@@ -65,7 +65,7 @@ function getWeeklyZuoraCode(period: WeeklyBillingPeriod, countryGroup: CountryGr
       Canada: quarterDomestic,
       International: quarterRow,
     },
-    year: {
+    [Annual]: {
       GBPCountries: yearDomestic,
       UnitedStates: yearDomestic,
       AUDCountries: yearDomestic,

--- a/assets/helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis.js
+++ b/assets/helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis.js
@@ -3,7 +3,7 @@ import { routes } from 'helpers/routes';
 import { type AcquisitionABTest, type OphanIds, type ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import { type ErrorReason } from 'helpers/errorReasons';
 import { type Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
-import { type BillingPeriod } from 'helpers/contributions';
+import { type BillingPeriod } from 'helpers/billingPeriods';
 import { type Participations } from 'helpers/abTests/abtest';
 import { type CaState, type IsoCountry, type UsState } from 'helpers/internationalisation/country';
 import { logPromise, pollUntilPromise } from 'helpers/promise';

--- a/assets/helpers/paymentIntegrations/newPaymentFlow/stripeCheckout.js
+++ b/assets/helpers/paymentIntegrations/newPaymentFlow/stripeCheckout.js
@@ -19,7 +19,7 @@
  */
 
 import { type IsoCurrency } from 'helpers/internationalisation/currency';
-import { type PaymentAuthorisation } from './readerRevenueApis';
+import type { StripeAuthorisation } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
 
 // ----- Types ----- //
 
@@ -59,7 +59,7 @@ function getStripeKey(stripeAccount: StripeAccount, currency: IsoCurrency, isTes
 }
 
 function setupStripeCheckout(
-  onPaymentAuthorisation: PaymentAuthorisation => void,
+  onPaymentAuthorisation: StripeAuthorisation => void,
   stripeAccount: StripeAccount,
   currency: IsoCurrency,
   isTestUser: boolean,

--- a/assets/helpers/paymentIntegrations/newPaymentFlow/stripeCheckout.js
+++ b/assets/helpers/paymentIntegrations/newPaymentFlow/stripeCheckout.js
@@ -19,8 +19,11 @@
  */
 
 import { type IsoCurrency } from 'helpers/internationalisation/currency';
-import { type ContributionType } from 'helpers/contributions';
 import { type PaymentAuthorisation } from './readerRevenueApis';
+
+// ----- Types ----- //
+
+export type StripeAccount = 'ONE_OFF' | 'REGULAR';
 
 // ----- Functions ----- //
 
@@ -42,22 +45,22 @@ function loadStripe(): Promise<void> {
 
 }
 
-function getStripeKey(contributionType: ContributionType, currency: IsoCurrency, isTestUser: boolean): string {
-  const key = contributionType === 'ONE_OFF' ? contributionType : 'REGULAR';
+function getStripeKey(stripeAccount: StripeAccount, currency: IsoCurrency, isTestUser: boolean): string {
   switch (currency) {
     case 'AUD':
       return isTestUser ?
-        window.guardian.stripeKeyAustralia[key].uat : window.guardian.stripeKeyAustralia[key].default;
+        window.guardian.stripeKeyAustralia[stripeAccount].uat :
+        window.guardian.stripeKeyAustralia[stripeAccount].default;
     default:
       return isTestUser ?
-        window.guardian.stripeKeyDefaultCurrencies[key].uat :
-        window.guardian.stripeKeyDefaultCurrencies[key].default;
+        window.guardian.stripeKeyDefaultCurrencies[stripeAccount].uat :
+        window.guardian.stripeKeyDefaultCurrencies[stripeAccount].default;
   }
 }
 
 function setupStripeCheckout(
   onPaymentAuthorisation: PaymentAuthorisation => void,
-  contributionType: ContributionType,
+  stripeAccount: StripeAccount,
   currency: IsoCurrency,
   isTestUser: boolean,
 ): Object {
@@ -65,7 +68,7 @@ function setupStripeCheckout(
     onPaymentAuthorisation({ paymentMethod: 'Stripe', token: token.id, stripePaymentMethod: 'StripeCheckout' });
   };
 
-  const stripeKey = getStripeKey(contributionType, currency, isTestUser);
+  const stripeKey = getStripeKey(stripeAccount, currency, isTestUser);
 
   return window.StripeCheckout.configure({
     name: 'Guardian',

--- a/assets/helpers/subscriptions.js
+++ b/assets/helpers/subscriptions.js
@@ -3,8 +3,8 @@
 // ----- Imports ----- //
 
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import { type Price, GBP, USD, AUD, EUR, NZD, CAD } from 'helpers/internationalisation/price';
-
+import { AUD, CAD, EUR, GBP, NZD, type Price, USD } from 'helpers/internationalisation/price';
+import { BillingPeriod, DigitalBillingPeriod, WeeklyBillingPeriod } from 'helpers/billingPeriods';
 import { trackComponentEvents } from './tracking/ophanComponentEventTracking';
 import { gaEvent } from './tracking/googleTagManager';
 import { currencies, detect } from './internationalisation/currency';
@@ -26,10 +26,6 @@ export type ComponentAbTest = {
   name: string,
   variant: string,
 };
-
-export type DigitalBillingPeriod = 'month' | 'year';
-export type BillingPeriod = 'sixweek' | 'quarter' | 'year' | 'month';
-export type WeeklyBillingPeriod = 'sixweek' | 'quarter' | 'year';
 
 export type PaperBillingPlan =
   'collectionEveryday' | 'collectionSixday' | 'collectionWeekend' | 'collectionSunday' |
@@ -85,32 +81,32 @@ const subscriptionPricesForDefaultBillingPeriod: {
 
 const digitalSubscriptionPrices = {
   GBPCountries: {
-    month: GBP(11.99),
-    year: GBP(119.90),
+    Monthly: GBP(11.99),
+    Annual: GBP(119.90),
   },
   UnitedStates: {
-    month: USD(19.99),
-    year: USD(199.90),
+    Monthly: USD(19.99),
+    Annual: USD(199.90),
   },
   AUDCountries: {
-    month: AUD(21.50),
-    year: AUD(215.00),
+    Monthly: AUD(21.50),
+    Annual: AUD(215.00),
   },
   EURCountries: {
-    month: EUR(14.99),
-    year: EUR(149.90),
+    Monthly: EUR(14.99),
+    Annual: EUR(149.90),
   },
   International: {
-    month: USD(19.99),
-    year: USD(199.90),
+    Monthly: USD(19.99),
+    Annual: USD(199.90),
   },
   NZDCountries: {
-    month: NZD(23.50),
-    year: NZD(235.00),
+    Monthly: NZD(23.50),
+    Annual: NZD(235.00),
   },
   Canada: {
-    month: CAD(21.95),
-    year: CAD(219.50),
+    Monthly: CAD(21.95),
+    Annual: CAD(219.50),
   },
 };
 
@@ -134,39 +130,39 @@ const subscriptionPromoPricesForGuardianWeekly: {
 } = {
   '10ANNUAL': {
     GBPCountries: {
-      quarter: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.GBPCountries,
-      sixweek: 6,
-      year: 135,
+      Quarterly: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.GBPCountries,
+      SixForSix: 6,
+      Annual: 135,
     },
     EURCountries: {
-      quarter: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.EURCountries,
-      sixweek: 6,
-      year: 220.68,
+      Quarterly: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.EURCountries,
+      SixForSix: 6,
+      Annual: 220.68,
     },
     UnitedStates: {
-      quarter: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.UnitedStates,
-      sixweek: 6,
-      year: 270,
+      Quarterly: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.UnitedStates,
+      SixForSix: 6,
+      Annual: 270,
     },
     Canada: {
-      quarter: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.Canada,
-      sixweek: 6,
-      year: 288,
+      Quarterly: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.Canada,
+      SixForSix: 6,
+      Annual: 288,
     },
     AUDCountries: {
-      quarter: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.AUDCountries,
-      sixweek: 6,
-      year: 351,
+      Quarterly: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.AUDCountries,
+      SixForSix: 6,
+      Annual: 351,
     },
     NZDCountries: {
-      quarter: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.NZDCountries,
-      sixweek: 6,
-      year: 442.8,
+      Quarterly: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.NZDCountries,
+      SixForSix: 6,
+      Annual: 442.8,
     },
     International: {
-      quarter: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.International,
-      sixweek: 6,
-      year: 292.68,
+      Quarterly: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.International,
+      SixForSix: 6,
+      Annual: 292.68,
     },
   },
 };
@@ -177,51 +173,51 @@ const subscriptionPricesForGuardianWeekly: {
   }
 } = {
   GBPCountries: {
-    quarter: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.GBPCountries,
-    sixweek: 6,
-    year: 150,
+    Quarterly: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.GBPCountries,
+    SixForSix: 6,
+    Annual: 150,
   },
   EURCountries: {
-    quarter: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.EURCountries,
-    sixweek: 6,
-    year: 245.20,
+    Quarterly: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.EURCountries,
+    SixForSix: 6,
+    Annual: 245.20,
   },
   UnitedStates: {
-    quarter: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.UnitedStates,
-    sixweek: 6,
-    year: 300,
+    Quarterly: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.UnitedStates,
+    SixForSix: 6,
+    Annual: 300,
   },
   Canada: {
-    quarter: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.Canada,
-    sixweek: 6,
-    year: 320,
+    Quarterly: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.Canada,
+    SixForSix: 6,
+    Annual: 320,
   },
   AUDCountries: {
-    quarter: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.AUDCountries,
-    sixweek: 6,
-    year: 390,
+    Quarterly: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.AUDCountries,
+    SixForSix: 6,
+    Annual: 390,
   },
   NZDCountries: {
-    quarter: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.NZDCountries,
-    sixweek: 6,
-    year: 492,
+    Quarterly: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.NZDCountries,
+    SixForSix: 6,
+    Annual: 492,
   },
   International: {
-    quarter: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.International,
-    sixweek: 6,
-    year: 325.20,
+    Quarterly: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.International,
+    SixForSix: 6,
+    Annual: 325.20,
   },
 };
 
 const defaultBillingPeriods: {
   [SubscriptionProduct]: BillingPeriod
 } = {
-  PremiumTier: 'month',
-  DigitalPack: 'month',
-  GuardianWeekly: 'quarter',
-  Paper: 'month',
-  PaperAndDigital: 'month',
-  DailyEdition: 'month',
+  PremiumTier: 'Monthly',
+  DigitalPack: 'Monthly',
+  GuardianWeekly: 'Quarterly',
+  Paper: 'Monthly',
+  PaperAndDigital: 'Monthly',
+  DailyEdition: 'Monthly',
 };
 
 

--- a/assets/helpers/subscriptions.js
+++ b/assets/helpers/subscriptions.js
@@ -4,11 +4,18 @@
 
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { AUD, CAD, EUR, GBP, NZD, type Price, USD } from 'helpers/internationalisation/price';
-import { BillingPeriod, DigitalBillingPeriod, WeeklyBillingPeriod } from 'helpers/billingPeriods';
+import {
+  Annual,
+  type BillingPeriod,
+  type DigitalBillingPeriod,
+  Monthly,
+  Quarterly,
+  SixForSix,
+  type WeeklyBillingPeriod,
+} from 'helpers/billingPeriods';
 import { trackComponentEvents } from './tracking/ophanComponentEventTracking';
 import { gaEvent } from './tracking/googleTagManager';
 import { currencies, detect } from './internationalisation/currency';
-
 
 // ----- Types ------ //
 
@@ -81,32 +88,32 @@ const subscriptionPricesForDefaultBillingPeriod: {
 
 const digitalSubscriptionPrices = {
   GBPCountries: {
-    Monthly: GBP(11.99),
-    Annual: GBP(119.90),
+    [Monthly]: GBP(11.99),
+    [Annual]: GBP(119.90),
   },
   UnitedStates: {
-    Monthly: USD(19.99),
-    Annual: USD(199.90),
+    [Monthly]: USD(19.99),
+    [Annual]: USD(199.90),
   },
   AUDCountries: {
-    Monthly: AUD(21.50),
-    Annual: AUD(215.00),
+    [Monthly]: AUD(21.50),
+    [Annual]: AUD(215.00),
   },
   EURCountries: {
-    Monthly: EUR(14.99),
-    Annual: EUR(149.90),
+    [Monthly]: EUR(14.99),
+    [Annual]: EUR(149.90),
   },
   International: {
-    Monthly: USD(19.99),
-    Annual: USD(199.90),
+    [Monthly]: USD(19.99),
+    [Annual]: USD(199.90),
   },
   NZDCountries: {
-    Monthly: NZD(23.50),
-    Annual: NZD(235.00),
+    [Monthly]: NZD(23.50),
+    [Annual]: NZD(235.00),
   },
   Canada: {
-    Monthly: CAD(21.95),
-    Annual: CAD(219.50),
+    [Monthly]: CAD(21.95),
+    [Annual]: CAD(219.50),
   },
 };
 
@@ -130,39 +137,39 @@ const subscriptionPromoPricesForGuardianWeekly: {
 } = {
   '10ANNUAL': {
     GBPCountries: {
-      Quarterly: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.GBPCountries,
-      SixForSix: 6,
-      Annual: 135,
+      [Quarterly]: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.GBPCountries,
+      [SixForSix]: 6,
+      [Annual]: 135,
     },
     EURCountries: {
-      Quarterly: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.EURCountries,
-      SixForSix: 6,
-      Annual: 220.68,
+      [Quarterly]: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.EURCountries,
+      [SixForSix]: 6,
+      [Annual]: 220.68,
     },
     UnitedStates: {
-      Quarterly: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.UnitedStates,
-      SixForSix: 6,
-      Annual: 270,
+      [Quarterly]: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.UnitedStates,
+      [SixForSix]: 6,
+      [Annual]: 270,
     },
     Canada: {
-      Quarterly: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.Canada,
-      SixForSix: 6,
-      Annual: 288,
+      [Quarterly]: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.Canada,
+      [SixForSix]: 6,
+      [Annual]: 288,
     },
     AUDCountries: {
-      Quarterly: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.AUDCountries,
-      SixForSix: 6,
-      Annual: 351,
+      [Quarterly]: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.AUDCountries,
+      [SixForSix]: 6,
+      [Annual]: 351,
     },
     NZDCountries: {
-      Quarterly: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.NZDCountries,
-      SixForSix: 6,
-      Annual: 442.8,
+      [Quarterly]: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.NZDCountries,
+      [SixForSix]: 6,
+      [Annual]: 442.8,
     },
     International: {
-      Quarterly: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.International,
-      SixForSix: 6,
-      Annual: 292.68,
+      [Quarterly]: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.International,
+      [SixForSix]: 6,
+      [Annual]: 292.68,
     },
   },
 };
@@ -173,51 +180,51 @@ const subscriptionPricesForGuardianWeekly: {
   }
 } = {
   GBPCountries: {
-    Quarterly: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.GBPCountries,
-    SixForSix: 6,
-    Annual: 150,
+    [Quarterly]: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.GBPCountries,
+    [SixForSix]: 6,
+    [Annual]: 150,
   },
   EURCountries: {
-    Quarterly: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.EURCountries,
-    SixForSix: 6,
-    Annual: 245.20,
+    [Quarterly]: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.EURCountries,
+    [SixForSix]: 6,
+    [Annual]: 245.20,
   },
   UnitedStates: {
-    Quarterly: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.UnitedStates,
-    SixForSix: 6,
-    Annual: 300,
+    [Quarterly]: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.UnitedStates,
+    [SixForSix]: 6,
+    [Annual]: 300,
   },
   Canada: {
-    Quarterly: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.Canada,
-    SixForSix: 6,
-    Annual: 320,
+    [Quarterly]: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.Canada,
+    [SixForSix]: 6,
+    [Annual]: 320,
   },
   AUDCountries: {
-    Quarterly: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.AUDCountries,
-    SixForSix: 6,
-    Annual: 390,
+    [Quarterly]: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.AUDCountries,
+    [SixForSix]: 6,
+    [Annual]: 390,
   },
   NZDCountries: {
-    Quarterly: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.NZDCountries,
-    SixForSix: 6,
-    Annual: 492,
+    [Quarterly]: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.NZDCountries,
+    [SixForSix]: 6,
+    [Annual]: 492,
   },
   International: {
-    Quarterly: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.International,
-    SixForSix: 6,
-    Annual: 325.20,
+    [Quarterly]: subscriptionPricesForDefaultBillingPeriod.GuardianWeekly.International,
+    [SixForSix]: 6,
+    [Annual]: 325.20,
   },
 };
 
 const defaultBillingPeriods: {
   [SubscriptionProduct]: BillingPeriod
 } = {
-  PremiumTier: 'Monthly',
-  DigitalPack: 'Monthly',
-  GuardianWeekly: 'Quarterly',
-  Paper: 'Monthly',
-  PaperAndDigital: 'Monthly',
-  DailyEdition: 'Monthly',
+  PremiumTier: Monthly,
+  DigitalPack: Monthly,
+  GuardianWeekly: Quarterly,
+  Paper: Monthly,
+  PaperAndDigital: Monthly,
+  DailyEdition: Monthly,
 };
 
 

--- a/assets/helpers/user/user.js
+++ b/assets/helpers/user/user.js
@@ -4,13 +4,20 @@
 
 import { routes } from 'helpers/routes';
 import * as cookie from 'helpers/cookie';
-import { getSession } from 'helpers/storage';
 import { get as getCookie } from 'helpers/cookie';
+import { getSession } from 'helpers/storage';
 import { defaultUserActionFunctions } from 'helpers/user/defaultUserActionFunctions';
 import type { UserSetStateActions } from 'helpers/user/userActions';
 
 
 // ----- Functions ----- //
+
+function isTestUser(): boolean {
+  const isDefined = x => x !== null && x !== undefined;
+  const uatMode = window.guardian && window.guardian.uatMode;
+  const testCookie = cookie.get('_test_username');
+  return isDefined(uatMode) || isDefined(testCookie);
+}
 
 const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActionFunctions) => {
 
@@ -30,8 +37,6 @@ const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActi
   const windowHasUser = window.guardian && window.guardian.user;
   const userAppearsLoggedIn = cookie.get('GU_U');
 
-  const uatMode = window.guardian && window.guardian.uatMode;
-
   function getEmailFromBrowser(): ?string {
     if (window.guardian && window.guardian.email) {
       return window.guardian.email;
@@ -41,15 +46,11 @@ const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActi
 
   const emailFromBrowser = getEmailFromBrowser();
 
-  const isUndefinedOrNull = x => x === null || x === undefined;
-
-  const testUserCondition = (isUndefinedOrNull(uatMode) && cookie.get('_test_username')) || uatMode;
-
-  if (testUserCondition) {
+  if (isTestUser()) {
     dispatch(setTestUser(true));
   }
 
-  if (testUserCondition && cookie.get('_post_deploy_user')) {
+  if (isTestUser() && cookie.get('_post_deploy_user')) {
     dispatch(setPostDeploymentTestUser(true));
   }
 
@@ -93,4 +94,4 @@ const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActi
 
 // ----- Exports ----- //
 
-export { init };
+export { init, isTestUser };

--- a/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -10,7 +10,7 @@ import { caStates, countries, type IsoCountry, usStates } from 'helpers/internat
 import { firstError, type FormError } from 'helpers/subscriptionsForms/validation';
 import { type Option } from 'helpers/types/option';
 import { type CountryGroupId, fromCountry } from 'helpers/internationalisation/countryGroup';
-import { DigitalBillingPeriod } from 'helpers/billingPeriods';
+import { Annual, type DigitalBillingPeriod, Monthly } from 'helpers/billingPeriods';
 import { getDigitalPrice } from 'helpers/subscriptions';
 import { showPrice } from 'helpers/internationalisation/price';
 
@@ -154,16 +154,16 @@ function CheckoutForm(props: PropTypes) {
         <h2 className="checkout-form__heading">How often would you like to pay?</h2>
         <Fieldset>
           <RadioInput
-            text={`${getPrice(props.country, 'Monthly')}Every month`}
+            text={`${getPrice(props.country, Monthly)}Every month`}
             name="billingPeriod"
-            checked={props.billingPeriod === 'Monthly'}
-            onChange={() => props.setBillingPeriod('Monthly')}
+            checked={props.billingPeriod === Monthly}
+            onChange={() => props.setBillingPeriod(Monthly)}
           />
           <RadioInput
-            text={`${getPrice(props.country, 'Annual')}Every year`}
+            text={`${getPrice(props.country, Annual)}Every year`}
             name="billingPeriod"
-            checked={props.billingPeriod === 'Annual'}
-            onChange={() => props.setBillingPeriod('Annual')}
+            checked={props.billingPeriod === Annual}
+            onChange={() => props.setBillingPeriod(Annual)}
           />
         </Fieldset>
       </LeftMarginSection>

--- a/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -155,15 +155,15 @@ function CheckoutForm(props: PropTypes) {
         <Fieldset>
           <RadioInput
             text={`${getPrice(props.country, 'Monthly')}Every month`}
-            name="paymentFrequency"
-            checked={props.paymentFrequency === 'Monthly'}
-            onChange={() => props.setPaymentFrequency('Monthly')}
+            name="billingPeriod"
+            checked={props.billingPeriod === 'Monthly'}
+            onChange={() => props.setBillingPeriod('Monthly')}
           />
           <RadioInput
             text={`${getPrice(props.country, 'Annual')}Every year`}
-            name="paymentFrequency"
-            checked={props.paymentFrequency === 'Annual'}
-            onChange={() => props.setPaymentFrequency('Annual')}
+            name="billingPeriod"
+            checked={props.billingPeriod === 'Annual'}
+            onChange={() => props.setBillingPeriod('Annual')}
           />
         </Fieldset>
       </LeftMarginSection>

--- a/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -6,11 +6,12 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 
-import { countries, usStates, caStates, type IsoCountry } from 'helpers/internationalisation/country';
-import { type FormError, firstError } from 'helpers/subscriptionsForms/validation';
+import { caStates, countries, type IsoCountry, usStates } from 'helpers/internationalisation/country';
+import { firstError, type FormError } from 'helpers/subscriptionsForms/validation';
 import { type Option } from 'helpers/types/option';
-import { fromCountry, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import { getDigitalPrice, type DigitalBillingPeriod } from 'helpers/subscriptions';
+import { type CountryGroupId, fromCountry } from 'helpers/internationalisation/countryGroup';
+import { DigitalBillingPeriod } from 'helpers/billingPeriods';
+import { getDigitalPrice } from 'helpers/subscriptions';
 import { showPrice } from 'helpers/internationalisation/price';
 
 import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
@@ -28,12 +29,12 @@ import { withArrow } from 'components/forms/formHOCs/withArrow';
 import { canShow } from 'components/forms/formHOCs/canShow';
 
 import {
-  type State,
-  type FormFields,
-  type FormField,
   type FormActionCreators,
-  getFormFields,
   formActionCreators,
+  type FormField,
+  type FormFields,
+  getFormFields,
+  type State,
 } from '../digitalSubscriptionCheckoutReducer';
 
 
@@ -153,16 +154,16 @@ function CheckoutForm(props: PropTypes) {
         <h2 className="checkout-form__heading">How often would you like to pay?</h2>
         <Fieldset>
           <RadioInput
-            text={`${getPrice(props.country, 'month')}Every month`}
+            text={`${getPrice(props.country, 'Monthly')}Every month`}
             name="paymentFrequency"
-            checked={props.paymentFrequency === 'month'}
-            onChange={() => props.setPaymentFrequency('month')}
+            checked={props.paymentFrequency === 'Monthly'}
+            onChange={() => props.setPaymentFrequency('Monthly')}
           />
           <RadioInput
-            text={`${getPrice(props.country, 'year')}Every year`}
+            text={`${getPrice(props.country, 'Annual')}Every year`}
             name="paymentFrequency"
-            checked={props.paymentFrequency === 'year'}
-            onChange={() => props.setPaymentFrequency('year')}
+            checked={props.paymentFrequency === 'Annual'}
+            onChange={() => props.setPaymentFrequency('Annual')}
           />
         </Fieldset>
       </LeftMarginSection>
@@ -172,14 +173,14 @@ function CheckoutForm(props: PropTypes) {
           <RadioInput
             text="Direct debit"
             name="paymentMethod"
-            checked={props.paymentMethod === 'directDebit'}
-            onChange={() => props.setPaymentMethod('directDebit')}
+            checked={props.paymentMethod === 'DirectDebit'}
+            onChange={() => props.setPaymentMethod('DirectDebit')}
           />
           <RadioInput
             text="Credit/Debit card"
             name="paymentMethod"
-            checked={props.paymentMethod === 'card'}
-            onChange={() => props.setPaymentMethod('card')}
+            checked={props.paymentMethod === 'Stripe'}
+            onChange={() => props.setPaymentMethod('Stripe')}
           />
         </Fieldset>
         <CheckoutCopy

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -6,7 +6,7 @@ import { combineReducers, type Dispatch } from 'redux';
 
 import { type ReduxState } from 'helpers/page/page';
 import { type Option } from 'helpers/types/option';
-import { type DigitalBillingPeriod } from 'helpers/billingPeriods';
+import { type DigitalBillingPeriod, Monthly } from 'helpers/billingPeriods';
 import csrf, { type Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import {
   fromString,
@@ -152,7 +152,7 @@ function initReducer(user: User) {
     country: user.country || null,
     stateProvince: null,
     telephone: '',
-    billingPeriod: 'Monthly',
+    billingPeriod: Monthly,
     paymentMethod: 'DirectDebit',
     errors: [],
     isTestUser: isTestUser(),

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -6,7 +6,7 @@ import { combineReducers, type Dispatch } from 'redux';
 
 import { type ReduxState } from 'helpers/page/page';
 import { type Option } from 'helpers/types/option';
-import { type DigitalBillingPeriod } from 'helpers/subscriptions';
+import { type DigitalBillingPeriod } from 'helpers/billingPeriods';
 import csrf, { type Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import {
   fromString,
@@ -20,6 +20,7 @@ import {
   marketingConsentReducerFor,
   type State as MarketingConsentState,
 } from 'components/marketingConsent/marketingConsentReducer';
+import { isTestUser } from 'helpers/user/user';
 import { showPaymentMethod } from './helpers/paymentProviders';
 import { type User } from './helpers/user';
 
@@ -27,7 +28,7 @@ import { type User } from './helpers/user';
 // ----- Types ----- //
 
 export type Stage = 'checkout' | 'thankyou';
-type PaymentMethod = 'card' | 'directDebit';
+type PaymentMethod = 'Stripe' | 'DirectDebit';
 
 export type FormFields = {|
   firstName: string,
@@ -46,6 +47,7 @@ type CheckoutState = {|
   ...FormFields,
   email: string,
   errors: FormError<FormField>[],
+  isTestUser: boolean,
 |};
 
 export type State = ReduxState<{|
@@ -150,9 +152,10 @@ function initReducer(user: User) {
     country: user.country || null,
     stateProvince: null,
     telephone: '',
-    paymentFrequency: 'month',
-    paymentMethod: 'directDebit',
+    paymentFrequency: 'Monthly',
+    paymentMethod: 'DirectDebit',
     errors: [],
+    isTestUser: isTestUser(),
   };
 
   function reducer(state: CheckoutState = initialState, action: Action): CheckoutState {
@@ -188,9 +191,7 @@ function initReducer(user: User) {
 
       default:
         return state;
-
     }
-
   }
 
   return combineReducers({

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -36,7 +36,7 @@ export type FormFields = {|
   country: Option<IsoCountry>,
   stateProvince: Option<StateProvince>,
   telephone: string,
-  paymentFrequency: DigitalBillingPeriod,
+  billingPeriod: DigitalBillingPeriod,
   paymentMethod: PaymentMethod,
 |};
 
@@ -63,7 +63,7 @@ export type Action =
   | { type: 'SET_TELEPHONE', telephone: string }
   | { type: 'SET_COUNTRY', country: string }
   | { type: 'SET_STATE_PROVINCE', stateProvince: string }
-  | { type: 'SET_PAYMENT_FREQUENCY', paymentFrequency: DigitalBillingPeriod }
+  | { type: 'SET_BILLING_PERIOD', billingPeriod: DigitalBillingPeriod }
   | { type: 'SET_PAYMENT_METHOD', paymentMethod: PaymentMethod }
   | { type: 'SET_ERRORS', errors: FormError<FormField>[] };
 
@@ -77,7 +77,7 @@ function getFormFields(state: State): FormFields {
     country: state.page.checkout.country,
     stateProvince: state.page.checkout.stateProvince,
     telephone: state.page.checkout.telephone,
-    paymentFrequency: state.page.checkout.paymentFrequency,
+    billingPeriod: state.page.checkout.billingPeriod,
     paymentMethod: state.page.checkout.paymentMethod,
   };
 }
@@ -125,7 +125,7 @@ const formActionCreators = {
   setTelephone: (telephone: string): Action => ({ type: 'SET_TELEPHONE', telephone }),
   setCountry: (country: string): Action => ({ type: 'SET_COUNTRY', country }),
   setStateProvince: (stateProvince: string): Action => ({ type: 'SET_STATE_PROVINCE', stateProvince }),
-  setPaymentFrequency: (paymentFrequency: DigitalBillingPeriod): Action => ({ type: 'SET_PAYMENT_FREQUENCY', paymentFrequency }),
+  setBillingPeriod: (billingPeriod: DigitalBillingPeriod): Action => ({ type: 'SET_BILLING_PERIOD', billingPeriod }),
   setPaymentMethod: (paymentMethod: PaymentMethod): Action => ({ type: 'SET_PAYMENT_METHOD', paymentMethod }),
   submitForm: () => (dispatch: Dispatch<Action>, getState: () => State) => {
     const state = getState();
@@ -152,7 +152,7 @@ function initReducer(user: User) {
     country: user.country || null,
     stateProvince: null,
     telephone: '',
-    paymentFrequency: 'Monthly',
+    billingPeriod: 'Monthly',
     paymentMethod: 'DirectDebit',
     errors: [],
     isTestUser: isTestUser(),
@@ -180,8 +180,8 @@ function initReducer(user: User) {
       case 'SET_STATE_PROVINCE':
         return { ...state, stateProvince: stateProvinceFromString(state.country, action.stateProvince) };
 
-      case 'SET_PAYMENT_FREQUENCY':
-        return { ...state, paymentFrequency: action.paymentFrequency };
+      case 'SET_BILLING_PERIOD':
+        return { ...state, billingPeriod: action.billingPeriod };
 
       case 'SET_PAYMENT_METHOD':
         return { ...state, paymentMethod: action.paymentMethod };

--- a/assets/pages/digital-subscription-checkout/helpers/paymentProviders.js
+++ b/assets/pages/digital-subscription-checkout/helpers/paymentProviders.js
@@ -63,7 +63,7 @@ function showPaymentMethod(state: State) {
     case 'Stripe':
       loadStripe()
         .then(() => setupStripeCheckout((authorisation: StripeAuthorisation) => create(state, authorisation.token), 'REGULAR', currencyId, isTestUser))
-        .then(stripe => openDialogBox(stripe, price, state.page.checkout.email));
+        .then(stripe => openDialogBox(stripe, price.value, state.page.checkout.email));
       break;
     case 'DirectDebit':
       console.log('Direct Debit');

--- a/assets/pages/digital-subscription-checkout/helpers/paymentProviders.js
+++ b/assets/pages/digital-subscription-checkout/helpers/paymentProviders.js
@@ -20,12 +20,12 @@ function buildRegularPaymentRequest(state: State, token: string) {
     email,
     country,
     stateProvince,
-    paymentFrequency,
+    billingPeriod,
   } = state.page.checkout;
 
   const product = {
     currency: currencyId,
-    billingPeriod: paymentFrequency,
+    billingPeriod,
   };
   return {
     firstName,
@@ -58,7 +58,7 @@ function create(state: State, token: string) {
 function showPaymentMethod(state: State) {
   const { currencyId, countryGroupId } = state.common.internationalisation;
   const { paymentMethod, isTestUser } = state.page.checkout;
-  const price = getDigitalPrice(countryGroupId, state.page.checkout.paymentFrequency);
+  const price = getDigitalPrice(countryGroupId, state.page.checkout.billingPeriod);
   switch (paymentMethod) {
     case 'Stripe':
       loadStripe()

--- a/assets/pages/digital-subscription-checkout/helpers/paymentProviders.js
+++ b/assets/pages/digital-subscription-checkout/helpers/paymentProviders.js
@@ -1,30 +1,49 @@
 // @flow
 
-import { openDialogBox, setupStripeCheckout } from 'helpers/paymentIntegrations/stripeCheckout';
+import {
+  loadStripe,
+  openDialogBox,
+  setupStripeCheckout,
+} from 'helpers/paymentIntegrations/newPaymentFlow/stripeCheckout';
+import type { StripeAuthorisation } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
 import { postRegularPaymentRequest } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
 import { routes } from 'helpers/routes';
 import { getOphanIds, getSupportAbTests } from 'helpers/tracking/acquisitions';
-import { getFormFields, type State } from '../digitalSubscriptionCheckoutReducer';
+import { getDigitalPrice } from 'helpers/subscriptions';
+import { type State } from '../digitalSubscriptionCheckoutReducer';
 
-function create(state: State, token: string) {
-  // TODO: if we could harmonize the fields between this file and readerRevenueApis.js we could simplify this mapping
-  const formFields = getFormFields(state);
+function buildRegularPaymentRequest(state: State, token: string) {
+  const { currencyId } = state.common.internationalisation;
+  const {
+    firstName,
+    lastName,
+    email,
+    country,
+    stateProvince,
+    paymentFrequency,
+  } = state.page.checkout;
+
   const product = {
-    currency: 'GBP',
-    billingPeriod: 'Monthly',
+    currency: currencyId,
+    billingPeriod: paymentFrequency,
   };
-  const data = {
-    firstName: formFields.firstName,
-    lastName: formFields.lastName,
-    country: formFields.country || 'GB',
-    state: formFields.stateProvince,
-    email: state.page.checkout.email,
+  return {
+    firstName,
+    lastName,
+    country: country || 'GB',
+    state: stateProvince,
+    email,
     product,
     paymentFields: { stripeToken: token },
     ophanIds: getOphanIds(),
     referrerAcquisitionData: state.common.referrerAcquisitionData,
     supportAbTests: getSupportAbTests(state.common.abParticipations, state.common.optimizeExperiments),
   };
+}
+
+function create(state: State, token: string) {
+
+  const data = buildRegularPaymentRequest(state, token);
 
   postRegularPaymentRequest(
     routes.digitalSubscriptionCreate,
@@ -37,8 +56,21 @@ function create(state: State, token: string) {
 }
 
 function showPaymentMethod(state: State) {
-  setupStripeCheckout((token: string) => create(state, token), null, 'GBP', false)
-    .then(() => openDialogBox(10, 'test@test.com'));
+  const { currencyId, countryGroupId } = state.common.internationalisation;
+  const { paymentMethod, isTestUser } = state.page.checkout;
+  const price = getDigitalPrice(countryGroupId, state.page.checkout.paymentFrequency);
+  switch (paymentMethod) {
+    case 'Stripe':
+      loadStripe()
+        .then(() => setupStripeCheckout((authorisation: StripeAuthorisation) => create(state, authorisation.token), 'REGULAR', currencyId, isTestUser))
+        .then(stripe => openDialogBox(stripe, price, state.page.checkout.email));
+      break;
+    case 'DirectDebit':
+      console.log('Direct Debit');
+      break;
+    default:
+      console.log(`Unknown payment method ${paymentMethod}`);
+  }
 }
 
 export {

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -43,9 +43,9 @@ import trackConversion from 'helpers/tracking/conversions';
 import { getForm } from 'helpers/checkoutForm/checkoutForm';
 import { type FormSubmitParameters, onFormSubmit } from 'helpers/checkoutForm/onFormSubmit';
 import * as cookie from 'helpers/cookie';
+import { Annual, Monthly } from 'helpers/billingPeriods';
 import { setFormSubmissionDependentValue } from './checkoutFormIsSubmittableActions';
 import { type State, type ThankYouPageStage, type UserFormData } from './contributionsLandingReducer';
-
 
 export type Action =
   | { type: 'UPDATE_CONTRIBUTION_TYPE', contributionType: ContributionType }
@@ -266,7 +266,7 @@ const regularPaymentRequestFromAuthorisation = (
       state.page.form.contributionType,
     ),
     currency: state.common.internationalisation.currencyId,
-    billingPeriod: state.page.form.contributionType === 'MONTHLY' ? 'Monthly' : 'Annual',
+    billingPeriod: state.page.form.contributionType === 'MONTHLY' ? Monthly : Annual,
   },
   paymentFields: regularPaymentFieldsFromAuthorisation(authorisation),
   ophanIds: getOphanIds(),

--- a/assets/pages/regular-contributions/helpers/ajax.js
+++ b/assets/pages/regular-contributions/helpers/ajax.js
@@ -4,23 +4,28 @@
 
 
 import { routes } from 'helpers/routes';
-import { getOphanIds } from 'helpers/tracking/acquisitions';
+import type { AcquisitionABTest, OphanIds, ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
+import { getOphanIds, getSupportAbTests } from 'helpers/tracking/acquisitions';
 import type { Dispatch } from 'redux';
-import type { BillingPeriod, ContributionType } from 'helpers/contributions';
-import type { ReferrerAcquisitionData, OphanIds, AcquisitionABTest } from 'helpers/tracking/acquisitions';
-import type { UsState, IsoCountry } from 'helpers/internationalisation/country';
-import { getSupportAbTests } from 'helpers/tracking/acquisitions';
+import type { BillingPeriod } from 'helpers/billingPeriods';
+import type { ContributionType, PaymentMethod } from 'helpers/contributions';
+import { billingPeriodFromContrib } from 'helpers/contributions';
+import type { IsoCountry, UsState } from 'helpers/internationalisation/country';
 import type { User as UserState } from 'helpers/user/userReducer';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import type { Participations } from 'helpers/abTests/abtest';
 import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
 import type { ErrorReason } from 'helpers/errorReasons';
 import trackConversion from 'helpers/tracking/conversions';
-import { billingPeriodFromContrib } from 'helpers/contributions';
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
-import type { PaymentMethod } from 'helpers/contributions';
 import type { OptimizeExperiments } from 'helpers/optimize/optimize';
-import { checkoutPending, checkoutSuccess, checkoutError, creatingContributor, setGuestAccountCreationToken } from '../regularContributionsActions';
+import {
+  checkoutError,
+  checkoutPending,
+  checkoutSuccess,
+  creatingContributor,
+  setGuestAccountCreationToken
+} from '../regularContributionsActions';
 
 // ----- Setup ----- //
 

--- a/assets/pages/regular-contributions/helpers/ajax.js
+++ b/assets/pages/regular-contributions/helpers/ajax.js
@@ -24,7 +24,7 @@ import {
   checkoutPending,
   checkoutSuccess,
   creatingContributor,
-  setGuestAccountCreationToken
+  setGuestAccountCreationToken,
 } from '../regularContributionsActions';
 
 // ----- Setup ----- //

--- a/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
+++ b/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
@@ -8,11 +8,12 @@ import { bindActionCreators } from 'redux';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { currencies, detect } from 'helpers/internationalisation/currency';
 import type { WeeklyBillingPeriod } from 'helpers/billingPeriods';
-import { getPromotionWeeklyProductPrice, getWeeklyProductPrice, } from 'helpers/subscriptions';
+import { Annual, Quarterly, SixForSix } from 'helpers/billingPeriods';
+import { getPromotionWeeklyProductPrice, getWeeklyProductPrice } from 'helpers/subscriptions';
 import { type Action } from 'components/productPage/productPagePlanForm/productPagePlanFormActions';
 import ProductPagePlanForm, {
   type DispatchPropTypes,
-  type StatePropTypes
+  type StatePropTypes,
 } from 'components/productPage/productPagePlanForm/productPagePlanForm';
 
 import { type State } from '../weeklySubscriptionLandingReducer';
@@ -32,16 +33,16 @@ const getPromotionPrice = (countryGroupId: CountryGroupId, period: WeeklyBilling
 ].join('');
 
 export const billingPeriods = {
-  sixweek: {
+  [SixForSix]: {
     title: '6 for 6',
     offer: 'Introductory offer',
     copy: (countryGroupId: CountryGroupId) => `${getPrice(countryGroupId, 'SixForSix')} for the first 6 issues (then ${getPrice(countryGroupId, 'Quarterly')} quarterly)`,
   },
-  quarter: {
+  [Quarterly]: {
     title: 'Quarterly',
     copy: (countryGroupId: CountryGroupId) => `${getPrice(countryGroupId, 'Quarterly')} every 3 months`,
   },
-  year: {
+  [Annual]: {
     title: 'Annually',
     offer: 'Save 10%',
     copy: (countryGroupId: CountryGroupId) => `${getPromotionPrice(countryGroupId, 'Annual', '10ANNUAL')} for 1 year, then standard rate (${getPrice(countryGroupId, 'Annual')} every year)`,

--- a/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
+++ b/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
@@ -7,13 +7,13 @@ import { bindActionCreators } from 'redux';
 
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { currencies, detect } from 'helpers/internationalisation/currency';
-import {
-  type WeeklyBillingPeriod,
-  getWeeklyProductPrice,
-  getPromotionWeeklyProductPrice,
-} from 'helpers/subscriptions';
+import type { WeeklyBillingPeriod } from 'helpers/billingPeriods';
+import { getPromotionWeeklyProductPrice, getWeeklyProductPrice, } from 'helpers/subscriptions';
 import { type Action } from 'components/productPage/productPagePlanForm/productPagePlanFormActions';
-import ProductPagePlanForm, { type StatePropTypes, type DispatchPropTypes } from 'components/productPage/productPagePlanForm/productPagePlanForm';
+import ProductPagePlanForm, {
+  type DispatchPropTypes,
+  type StatePropTypes
+} from 'components/productPage/productPagePlanForm/productPagePlanForm';
 
 import { type State } from '../weeklySubscriptionLandingReducer';
 import { redirectToWeeklyPage, setPlan } from '../weeklySubscriptionLandingActions';
@@ -35,16 +35,16 @@ export const billingPeriods = {
   sixweek: {
     title: '6 for 6',
     offer: 'Introductory offer',
-    copy: (countryGroupId: CountryGroupId) => `${getPrice(countryGroupId, 'sixweek')} for the first 6 issues (then ${getPrice(countryGroupId, 'quarter')} quarterly)`,
+    copy: (countryGroupId: CountryGroupId) => `${getPrice(countryGroupId, 'SixForSix')} for the first 6 issues (then ${getPrice(countryGroupId, 'Quarterly')} quarterly)`,
   },
   quarter: {
     title: 'Quarterly',
-    copy: (countryGroupId: CountryGroupId) => `${getPrice(countryGroupId, 'quarter')} every 3 months`,
+    copy: (countryGroupId: CountryGroupId) => `${getPrice(countryGroupId, 'Quarterly')} every 3 months`,
   },
   year: {
     title: 'Annually',
     offer: 'Save 10%',
-    copy: (countryGroupId: CountryGroupId) => `${getPromotionPrice(countryGroupId, 'year', '10ANNUAL')} for 1 year, then standard rate (${getPrice(countryGroupId, 'year')} every year)`,
+    copy: (countryGroupId: CountryGroupId) => `${getPromotionPrice(countryGroupId, 'Annual', '10ANNUAL')} for 1 year, then standard rate (${getPrice(countryGroupId, 'Annual')} every year)`,
   },
 };
 

--- a/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingActions.js
+++ b/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingActions.js
@@ -2,7 +2,7 @@
 
 // ----- Imports ----- //
 
-import { type WeeklyBillingPeriod } from 'helpers/subscriptions';
+import { type WeeklyBillingPeriod } from 'helpers/billingPeriods';
 import { getWeeklyCheckout } from 'helpers/externalLinks';
 import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
 import { ProductPagePlanFormActionsFor } from 'components/productPage/productPagePlanForm/productPagePlanFormActions';
@@ -25,7 +25,7 @@ function redirectToWeeklyPage() {
       countryGroupId,
       abParticipations,
       optimizeExperiments,
-      (state.page.plan === 'year' ? getPromoCode('GuardianWeekly', countryGroupId, '10ANNUAL') : null),
+      (state.page.plan === 'Annual' ? getPromoCode('GuardianWeekly', countryGroupId, '10ANNUAL') : null),
     ) : null;
 
     if (location) {

--- a/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingReducer.js
+++ b/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingReducer.js
@@ -3,9 +3,12 @@
 // ----- Imports ----- //
 
 import type { CommonState } from 'helpers/page/commonReducer';
-import { type WeeklyBillingPeriod } from 'helpers/subscriptions';
+import { type WeeklyBillingPeriod } from 'helpers/billingPeriods';
 import { getQueryParameter } from 'helpers/url';
-import { ProductPagePlanFormReducerFor, type State as FormState } from 'components/productPage/productPagePlanForm/productPagePlanFormReducer';
+import {
+  ProductPagePlanFormReducerFor,
+  type State as FormState
+} from 'components/productPage/productPagePlanForm/productPagePlanFormReducer';
 
 export type State = {
   common: CommonState,
@@ -17,9 +20,9 @@ export type State = {
 
 const promoInUrl = getQueryParameter('promo');
 
-const initialPeriod: WeeklyBillingPeriod = promoInUrl === 'sixweek' || promoInUrl === 'quarter' || promoInUrl === 'year'
+const initialPeriod: WeeklyBillingPeriod = promoInUrl === 'SixForSix' || promoInUrl === 'Quarterly' || promoInUrl === 'Annual'
   ? promoInUrl
-  : 'sixweek';
+  : 'SixForSix';
 
 
 // ----- Export ----- //

--- a/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingReducer.js
+++ b/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingReducer.js
@@ -7,7 +7,7 @@ import { type WeeklyBillingPeriod } from 'helpers/billingPeriods';
 import { getQueryParameter } from 'helpers/url';
 import {
   ProductPagePlanFormReducerFor,
-  type State as FormState
+  type State as FormState,
 } from 'components/productPage/productPagePlanForm/productPagePlanFormReducer';
 
 export type State = {


### PR DESCRIPTION
## Why are you doing this?

This is the next step in wiring up the Digital Pack checkout.

Most of this PR is taken up with a refactor of the way that billing periods are represented in support frontend. Previously we've had 2 separate types representing billing periods; one for contributions and one for subscriptions, this limits code reuse, is different to the back end where there is only one type and is generally a bad idea!

I have now consolidated the `BillingPeriod` types and values in a new file billingPeriod.js and used these throughout the codebase. I will probably do the same for payment methods next as this is similarly fragmented.

This PR also removes hard coded dummy values from the Digital Pack checkout and replaces them with the correct values.

[**Trello Card**](https://trello.com/c/vPu51Rgj/2131-call-the-endpoint-to-create-a-digital-pack-subscription-from-the-checkout)

