### PR TITLE
Fix stripe recurring payments

### DIFF
--- a/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -93,7 +93,8 @@ function initialiseStripeCheckout(
     setupStripeCheckout(
       onPaymentAuthorisation,
       stripeAccountForContributionType[contributionType],
-      currencyId, isTestUser,
+      currencyId,
+      isTestUser,
     );
   dispatch(setThirdPartyPaymentLibrary({ [contributionType]: { Stripe: library } }));
 }


### PR DESCRIPTION
## Why are you doing this?
[This PR](https://github.com/guardian/support-frontend/pull/1335/files) broke recurring Stripe payments, as it broke the mechanism for loading the stripe library into the redux store. 

Essentially, we were trying to store the Stripe library into `thirdPartyPaymentLibraries.STRIPE.REGULAR`, which doesn't exist in our state definition, when really we want to put the regular library into both `thirdPartyPaymentLibraries.STRIPE.MONTHLY` and `thirdPartyPaymentLibraries.STRIPE.ANNUAL`.  

This PR fixes it. I've also added types to the parameters for `initialiseStripeCheckout`, which would have prevented this bug in the first place.