### PR TITLE
Change the end date for the digipack flash sale

### DIFF
--- a/assets/helpers/flashSale.js
+++ b/assets/helpers/flashSale.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { getQueryParameter } from 'helpers/url';
-import { detect, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { type CountryGroupId, detect } from 'helpers/internationalisation/countryGroup';
 import { fixDecimals } from 'helpers/subscriptions';
 
 import type { SubscriptionProduct } from './subscriptions';
@@ -46,7 +46,7 @@ const Sales: Sale[] = [
     subscriptionProduct: 'DigitalPack',
     activeRegions: ['GBPCountries', 'UnitedStates', 'AUDCountries', 'International'],
     startTime: new Date(2018, 11, 20).getTime(), // 20 Dec 2018
-    endTime: new Date(2019, 0, 3).getTime(), // 3 Jan 2019
+    endTime: new Date(2019, 0, 4).getTime(), // 4 Jan 2019
     saleDetails: {
       GBPCountries: {
         promoCode: 'DDPCS99X',


### PR DESCRIPTION
## Why are you doing this?

The end date we had for the Digital Pack flash sale was incorrect, we had 0:00 on the 3rd of Jan, whereas it should be 0:00 on the 4th.