### PR TITLE
Temporarily ignore scenario which is unstable due to a Redirect Test

### DIFF
--- a/test/selenium/subscriptions/LandingPagesSpec.scala
+++ b/test/selenium/subscriptions/LandingPagesSpec.scala
@@ -23,7 +23,7 @@ class LandingPagesSpec extends FeatureSpec with GivenWhenThen with BeforeAndAfte
   override def afterAll(): Unit = { driverConfig.quit() }
 
   feature("Paper landing page") {
-    scenario("Basic loading") {
+    ignore("Basic loading") {
 
       val paperSubsPage = new PaperSubs()
 
@@ -47,6 +47,5 @@ class LandingPagesSpec extends FeatureSpec with GivenWhenThen with BeforeAndAfte
 
     }
   }
-
 
 }


### PR DESCRIPTION
## Why are you doing this?

This test is currently failing sporadically, because it is not being excluded from an Optimize test (https://github.com/guardian/support-frontend/wiki/AB-Testing-with-google-optimize#avoiding-problems-with-the-post-deploy-tests). 

We can revert this PR on Friday (once the test has finished).