### PR TITLE
Add in print and print+ flash sale: part 1

### DIFF
--- a/assets/components/subscriptionBundles/paper.jsx
+++ b/assets/components/subscriptionBundles/paper.jsx
@@ -23,7 +23,7 @@ function getCopy() {
     const saleCopy = getSaleCopy('Paper', 'GBPCountries');
     const salePrice = getFormattedFlashSalePrice('Paper', 'GBPCountries');
     return {
-      subHeading: `from ${salePrice}`,
+      subHeading: `from £${salePrice}/Monthly`,
       description: `${saleCopy.bundle.description}`,
     };
   }

--- a/assets/components/subscriptionBundles/paperDigital.jsx
+++ b/assets/components/subscriptionBundles/paperDigital.jsx
@@ -23,7 +23,7 @@ function getCopy() {
   if (flashSaleIsActive('PaperAndDigital', 'GBPCountries')) {
     const flashSaleCopy = getSaleCopy('PaperAndDigital', 'GBPCountries');
     return {
-      subHeading: `from ${getFormattedFlashSalePrice('PaperAndDigital', 'GBPCountries')}`,
+      subHeading: `from £${getFormattedFlashSalePrice('PaperAndDigital', 'GBPCountries')}/Monthly`,
       description: `${flashSaleCopy.bundle.description}`,
     };
   }

--- a/assets/helpers/flashSale.js
+++ b/assets/helpers/flashSale.js
@@ -135,6 +135,64 @@ const Sales: Sale[] = [
 
     },
   },
+  {
+    subscriptionProduct: 'Paper',
+    activeRegions: ['GBPCountries'],
+    startTime: new Date(2019, 0, 5).getTime(), // 4 Jan 2019
+    endTime: new Date(2019, 1, 3).getTime(), // 3 Feb 2019
+    saleDetails: {
+      GBPCountries: {
+        promoCode: 'GCB80X',
+        intcmp: '',
+        price: 8.09,
+        saleCopy: {
+          featuredProduct: {
+            heading: 'Paper subscriptions',
+            subHeading: 'Buy yourself some quality time',
+            description: 'Find analysis, opinions, reviews, recipes and more with a subscription to The Guardian and The Observer. Subscribe now and save 25% for a year.',
+          },
+          landingPage: {
+            heading: 'The Guardian newspaper subscriptions',
+            subHeading: 'Save 25% for a year on subscriptions to The Guardian and The Observer',
+          },
+          bundle: {
+            heading: 'Paper',
+            subHeading: 'From £8.09/month',
+            description: 'Save 25% for a year on subscriptions to The Guardian and The Observer, and get up to an additional £11.91 off the cover price.',
+          },
+        },
+      },
+    },
+  },
+  {
+    subscriptionProduct: 'PaperAndDigital',
+    activeRegions: ['GBPCountries'],
+    startTime: new Date(2019, 0, 5).getTime(), // 4 Jan 2019
+    endTime: new Date(2019, 1, 3).getTime(), // 3 Feb 2019
+    saleDetails: {
+      GBPCountries: {
+        promoCode: 'GCB56X',
+        intcmp: '',
+        price: 16.22,
+        saleCopy: {
+          featuredProduct: {
+            heading: 'Paper subscriptions',
+            subHeading: 'Buy yourself some quality time',
+            description: 'Find analysis, opinions, reviews, recipes and more with a subscription to The Guardian and The Observer. Subscribe now and save 25% for a year.',
+          },
+          landingPage: {
+            heading: 'The Guardian newspaper subscriptions',
+            subHeading: 'Save 25% for a year on subscriptions to The Guardian and The Observer',
+          },
+          bundle: {
+            heading: 'Paper+Digital',
+            subHeading: 'From £16.22/month',
+            description: 'Save 25% for a year on a Paper + Digital subscription and get all the benefits of a paper subscription, plus access to the Digital Pack.',
+          },
+        },
+      },
+    },
+  },
 ];
 
 function sortSalesByStartTimesDescending(a: Sale, b: Sale) {

--- a/assets/helpers/flashSale.js
+++ b/assets/helpers/flashSale.js
@@ -139,7 +139,7 @@ const Sales: Sale[] = [
     subscriptionProduct: 'Paper',
     activeRegions: ['GBPCountries'],
     startTime: new Date(2019, 0, 5).getTime(), // 4 Jan 2019
-    endTime: new Date(2019, 1, 3).getTime(), // 3 Feb 2019
+    endTime: new Date(2019, 1, 4).getTime(), // 3 Feb 2019 (to finish at 0:00 in the morning)
     saleDetails: {
       GBPCountries: {
         promoCode: 'GCB80X',


### PR DESCRIPTION
Existing flash sale work means we just need to add in a new flash sale and it automagically works on `/uk` and `/uk/subscribe`. Yay!

The upcoming print flash sale will require changes `/uk/subscribe/paper` (to follow) and those changes can bump the flash sale date to be valid so that the flash sale doesn't appear on `/uk` and `/uk/subscribe` but not `/uk/subscribe/paper`

So, this is just the part where we add the flash sale to flashSale.js and confirm that the changes don't make anything look wacky on  `/uk` and `/uk/subscribe`.

## Why are you doing this?
To support the flash sale.
<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/AMzW3SFV/2110-print-sale-updates)

## Changes

* Adds the paper and paper+ flash sale to flashSale.js

## Screenshots
Below all with flash sale active

(just to show: the flash sale copy changes haven't introduced glaring CSS bugs)

`/uk`

| mobile-ish        | tablet-ish           | big desktop screen  |
| ------------- |-------------| -----|
| <img src="https://user-images.githubusercontent.com/3072877/50638957-7ae65e80-0f57-11e9-8d40-eab617fc885c.png" height=400>   | <img src="https://user-images.githubusercontent.com/3072877/50638887-3eb2fe00-0f57-11e9-8e5c-40f029611399.png" height=400> | <img src="https://user-images.githubusercontent.com/3072877/50638746-ccdab480-0f56-11e9-8ef8-0096c6858dea.png" height=400> |


`/uk/subscribe`

| mobile-ish        | tablet-ish           | big desktop screen  |
| ------------- |-------------| -----|
| <img src="https://user-images.githubusercontent.com/3072877/50638928-5ee2bd00-0f57-11e9-8847-93700c8ee119.png" height=400> | <img src="https://user-images.githubusercontent.com/3072877/50638863-23e08980-0f57-11e9-84bf-32cea6438492.png" height=400> | <img src="https://user-images.githubusercontent.com/3072877/50638824-07445180-0f57-11e9-86be-70609527d4c5.png" height=400> |