### PR TITLE
remove the name fields completely from single contribtuions

### DIFF
--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -54,22 +54,6 @@ export const tests: Tests = {
     seed: 5,
   },
 
-  showOneOffNameFields: {
-    variants: [
-      'control',
-      'hidden',
-    ],
-    audiences: {
-      ALL: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: true,
-    independent: true,
-    seed: 6,
-  },
-
   applePay: {
     variants: ['control', 'applePay'],
     audiences: {

--- a/assets/pages/new-contributions-landing/checkoutFormIsSubmittableActions.js
+++ b/assets/pages/new-contributions-landing/checkoutFormIsSubmittableActions.js
@@ -89,7 +89,7 @@ const formIsValidParameters = (state: State) => ({
   firstName: state.page.form.formData.firstName,
   lastName: state.page.form.formData.lastName,
   email: state.page.form.formData.email,
-  showOneOffNameFields: state.common.abParticipations.showOneOffNameFields === 'control' || state.page.form.contributionType !== 'ONE_OFF',
+  showOneOffNameFields: state.page.form.contributionType !== 'ONE_OFF',
 });
 
 function enableOrDisableForm() {

--- a/assets/pages/new-contributions-landing/components/ContributionFormFields.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionFormFields.jsx
@@ -50,7 +50,6 @@ type PropTypes = {|
   updateState: Event => void,
   checkIfEmailHasPassword: Event => void,
   contributionType: ContributionType,
-  showOneOffNameFields: boolean,
 |};
 
 // We only want to use the user state value if the form state value has not been changed since it was initialised,
@@ -70,7 +69,6 @@ const mapStateToProps = (state: State) => ({
   isRecurringContributor: state.page.user.isRecurringContributor,
   userTypeFromIdentityResponse: state.page.form.userTypeFromIdentityResponse,
   contributionType: state.page.form.contributionType,
-  showOneOffNameFields: state.common.abParticipations.showOneOffNameFields === 'control',
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -92,7 +90,6 @@ function FormFields(props: PropTypes) {
     isSignedIn,
     state,
     checkoutFormHasBeenSubmitted,
-    showOneOffNameFields,
   } = props;
   return (
     <div className="form-fields">
@@ -122,7 +119,7 @@ function FormFields(props: PropTypes) {
         checkoutFormHasBeenSubmitted={props.checkoutFormHasBeenSubmitted}
         email={props.email}
       />
-      {showOneOffNameFields || props.contributionType !== 'ONE_OFF' ?
+      {props.contributionType !== 'ONE_OFF' ?
         <div>
           <NewContributionTextInput
             id="contributionFirstName"

--- a/test/selenium/contributions/new_flow/pages/ContributionsLanding.scala
+++ b/test/selenium/contributions/new_flow/pages/ContributionsLanding.scala
@@ -30,7 +30,7 @@ case class ContributionsLanding(region: String, testUser: TestUser)(implicit val
     def fillIn(hasNameFields: Boolean) {
 
       setValue(email, s"${testUser.username}@gu.com", clear = true)
-      if (hasNameFields || pageHasElement(firstName)) {
+      if (hasNameFields) {
         setValue(firstName, testUser.username, clear = true)
         setValue(lastName, testUser.username, clear = true)
       }


### PR DESCRIPTION
## Why are you doing this?

This test showed no real change from taking out the name fields, and those fields are not used for anything anyway.  This frees up the space to use for something else in future.
test pr was here: https://github.com/guardian/support-frontend/pull/1299

same trello card:
[**Trello Card**](https://trello.com/c/vU7sj6vJ/227-remove-name-fields-test-single-contributions-make-this-control)

updated screenshot has no change
![image](https://user-images.githubusercontent.com/7304387/50651220-9dd63a00-0f7a-11e9-8f42-cb4dbffddff8.png)

however the recurring still has the fields
![image](https://user-images.githubusercontent.com/7304387/50651241-aaf32900-0f7a-11e9-889f-fac5103eb2ba.png)


@jranks123 