### PR TITLE
Updates to the print product page for the print flash sale.

### DIFF
--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -345,7 +345,7 @@ function getPaperCheckout(
     cgId: null,
     nativeAbParticipations,
     optimizeExperiments,
-    promoCode
+    promoCode,
   })([subsUrl, 'checkout', urls[billingPlan]].join('/'));
 }
 

--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -240,11 +240,13 @@ const withParams = ({
   cgId,
   nativeAbParticipations,
   optimizeExperiments,
+  promoCode,
 }: {
   referrerAcquisitionData: ReferrerAcquisitionData,
   cgId: Option<CountryGroupId>,
   nativeAbParticipations: Participations,
   optimizeExperiments: OptimizeExperiments,
+  promoCode: Option<string>,
 }) => (url: string) => {
   const acquisitionData = deriveSubsAcquisitionData(
     referrerAcquisitionData,
@@ -257,6 +259,9 @@ const withParams = ({
   params.set('acquisitionData', JSON.stringify(acquisitionData));
   if (cgId) {
     params.set('countryGroup', countryGroups[cgId].supportInternationalisationId);
+  }
+  if (promoCode) {
+    params.set('promoCode', promoCode);
   }
   return [url, params.toString()].join('?');
 };
@@ -321,7 +326,10 @@ function getPaperCheckout(
   referrerAcquisitionData: ReferrerAcquisitionData,
   nativeAbParticipations: Participations,
   optimizeExperiments: OptimizeExperiments,
+  optimizeExperiments: OptimizeExperiments,
 ) {
+  const promoCode = getPromoCode('Paper', 'GBPCountries', defaultPromos.Paper);
+
   const urls = {
     collectionEveryday: 'voucher-everyday',
     collectionSixday: 'voucher-sixday',
@@ -338,6 +346,7 @@ function getPaperCheckout(
     cgId: null,
     nativeAbParticipations,
     optimizeExperiments,
+    promoCode
   })([subsUrl, 'checkout', urls[billingPlan]].join('/'));
 }
 

--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -326,7 +326,6 @@ function getPaperCheckout(
   referrerAcquisitionData: ReferrerAcquisitionData,
   nativeAbParticipations: Participations,
   optimizeExperiments: OptimizeExperiments,
-  optimizeExperiments: OptimizeExperiments,
 ) {
   const promoCode = getPromoCode('Paper', 'GBPCountries', defaultPromos.Paper);
 

--- a/assets/helpers/flashSale.js
+++ b/assets/helpers/flashSale.js
@@ -3,8 +3,10 @@
 import { getQueryParameter } from 'helpers/url';
 import { type CountryGroupId, detect } from 'helpers/internationalisation/countryGroup';
 import { fixDecimals } from 'helpers/subscriptions';
+import { type Option } from 'helpers/types/option';
 
 import type { SubscriptionProduct } from './subscriptions';
+import { PaperBillingPlan } from "./subscriptions";
 
 export type SaleCopy = {
   featuredProduct: {
@@ -29,6 +31,7 @@ type SaleDetails = {
     intcmp: string,
     price: number,
     saleCopy: SaleCopy,
+    planPrices: Option<PlanPrices>,
   },
 };
 
@@ -39,6 +42,11 @@ type Sale = {
   endTime: number,
   saleDetails: SaleDetails,
 };
+
+
+type PlanPrices = {
+  [PaperBillingPlan]: number,
+}
 
 // Days are 1 based, months are 0 based
 const Sales: Sale[] = [
@@ -138,8 +146,8 @@ const Sales: Sale[] = [
   {
     subscriptionProduct: 'Paper',
     activeRegions: ['GBPCountries'],
-    startTime: new Date(2019, 0, 5).getTime(), // 4 Jan 2019
-    endTime: new Date(2019, 1, 4).getTime(), // 3 Feb 2019 (to finish at 0:00 in the morning)
+    startTime: new Date(2019, 0, 4).getTime(), // 4 Jan 2019
+    endTime: new Date(2019, 1, 4).getTime(), // 3 Feb 2019
     saleDetails: {
       GBPCountries: {
         promoCode: 'GCB80X',
@@ -162,13 +170,23 @@ const Sales: Sale[] = [
           },
         },
       },
+      planPrices: {
+        collectionEveryday: 35.71,
+        collectionSixday: 30.84,
+        collectionWeekend: 15.57,
+        collectionSunday: 8.09,
+        deliveryEveryday: 47.09,
+        deliverySixday: 40.69,
+        deliveryWeekend: 18.82,
+        deliverySunday: 11.34,
+      }
     },
   },
   {
     subscriptionProduct: 'PaperAndDigital',
     activeRegions: ['GBPCountries'],
-    startTime: new Date(2019, 0, 5).getTime(), // 4 Jan 2019
-    endTime: new Date(2019, 1, 3).getTime(), // 3 Feb 2019
+    startTime: new Date(2019, 0, 4).getTime(), // 4 Jan 2019
+    endTime: new Date(2019, 1, 4).getTime(), // 3 Feb 2019
     saleDetails: {
       GBPCountries: {
         promoCode: 'GCB56X',
@@ -239,6 +257,11 @@ function getIntcmp(
   return intcmp || defaultIntcmp;
 }
 
+function getPlanPrices(product: SubscriptionProduct, countryGroupId: CountryGroupId): PlanPrices {
+  const sale = getSales(product, countryGroupId)[0];
+  return sale && sale.saleDetails.planPrices;
+}
+
 function getEndTime(product: SubscriptionProduct, countryGroupId: CountryGroupId) {
   const sale = getSales(product, countryGroupId)[0];
   return sale && sale.endTime;
@@ -280,4 +303,5 @@ export {
   getEndTime,
   getSaleCopy,
   getFormattedFlashSalePrice,
+  getPlanPrices,
 };

--- a/assets/helpers/flashSale.js
+++ b/assets/helpers/flashSale.js
@@ -147,7 +147,7 @@ const Sales: Sale[] = [
     subscriptionProduct: 'Paper',
     activeRegions: ['GBPCountries'],
     startTime: new Date(2019, 0, 4).getTime(), // 4 Jan 2019
-    endTime: new Date(2019, 1, 4).getTime(), // 3 Feb 2019
+    endTime: new Date(2019, 1, 4).getTime(), // 3 Feb 2019 (to finish at 0:00 in the morning)
     saleDetails: {
       GBPCountries: {
         promoCode: 'GCB80X',
@@ -186,7 +186,7 @@ const Sales: Sale[] = [
     subscriptionProduct: 'PaperAndDigital',
     activeRegions: ['GBPCountries'],
     startTime: new Date(2019, 0, 4).getTime(), // 4 Jan 2019
-    endTime: new Date(2019, 1, 4).getTime(), // 3 Feb 2019
+    endTime: new Date(2019, 1, 4).getTime(), // 3 Feb 2019 (to finish at 0:00 in the morning)
     saleDetails: {
       GBPCountries: {
         promoCode: 'GCB56X',

--- a/assets/helpers/flashSale.js
+++ b/assets/helpers/flashSale.js
@@ -167,7 +167,7 @@ const Sales: Sale[] = [
           bundle: {
             heading: 'Paper',
             subHeading: 'From £8.09/month',
-            description: 'Save 25% for a year on subscriptions to The Guardian and The Observer, and get up to an additional £11.91 off the cover price.',
+            description: 'Save 25% for a year on subscriptions to The Guardian and The Observer',
           },
         },
         planPrices: [

--- a/assets/helpers/flashSale.js
+++ b/assets/helpers/flashSale.js
@@ -5,8 +5,7 @@ import { type CountryGroupId, detect } from 'helpers/internationalisation/countr
 import { fixDecimals } from 'helpers/subscriptions';
 import { type Option } from 'helpers/types/option';
 
-import type { SubscriptionProduct } from './subscriptions';
-import { PaperBillingPlan } from "./subscriptions";
+import { type SubscriptionProduct, type PaperBillingPlan } from './subscriptions';
 
 export type SaleCopy = {
   featuredProduct: {
@@ -23,6 +22,10 @@ export type SaleCopy = {
     subHeading: string,
     description: string,
   },
+}
+
+type PlanPrices = {
+  [PaperBillingPlan]: number,
 }
 
 type SaleDetails = {
@@ -42,11 +45,6 @@ type Sale = {
   endTime: number,
   saleDetails: SaleDetails,
 };
-
-
-type PlanPrices = {
-  [PaperBillingPlan]: number,
-}
 
 // Days are 1 based, months are 0 based
 const Sales: Sale[] = [
@@ -76,6 +74,7 @@ const Sales: Sale[] = [
             description: 'The Premium App and the daily edition iPad app in one pack, plus ad-free reading on all your devices',
           },
         },
+        planPrices: null,
       },
       UnitedStates: {
         promoCode: 'DDPCS99X',
@@ -97,6 +96,7 @@ const Sales: Sale[] = [
             description: 'The Premium App and the daily edition iPad app of the UK newspaper in one pack, plus ad-free reading on all your devices',
           },
         },
+        planPrices: null,
       },
       International: {
         promoCode: 'DDPCS99X',
@@ -118,6 +118,7 @@ const Sales: Sale[] = [
             description: 'The Premium App and the daily edition iPad app of the UK newspaper in one pack, plus ad-free reading on all your devices',
           },
         },
+        planPrices: null,
       },
       AUDCountries: {
         promoCode: 'DDPCS99X',
@@ -139,6 +140,7 @@ const Sales: Sale[] = [
             description: 'The Premium App and the daily edition iPad app of the UK newspaper in one pack, plus ad-free reading on all your devices',
           },
         },
+        planPrices: null,
       },
 
     },
@@ -179,7 +181,7 @@ const Sales: Sale[] = [
         deliverySixday: 40.69,
         deliveryWeekend: 18.82,
         deliverySunday: 11.34,
-      }
+      },
     },
   },
   {
@@ -208,6 +210,7 @@ const Sales: Sale[] = [
             description: 'Save 25% for a year on a Paper + Digital subscription and get all the benefits of a paper subscription, plus access to the Digital Pack.',
           },
         },
+        planPrices: null,
       },
     },
   },

--- a/assets/helpers/subscriptions.js
+++ b/assets/helpers/subscriptions.js
@@ -13,10 +13,10 @@ import {
   SixForSix,
   type WeeklyBillingPeriod,
 } from 'helpers/billingPeriods';
+import { getPlanPrices, flashSaleIsActive } from 'helpers/flashSale';
 import { trackComponentEvents } from './tracking/ophanComponentEventTracking';
 import { gaEvent } from './tracking/googleTagManager';
 import { currencies, detect } from './internationalisation/currency';
-import { getPlanPrices, flashSaleIsActive } from 'helpers/flashSale';
 
 
 // ----- Types ------ //
@@ -267,7 +267,7 @@ function getPromotionWeeklyProductPrice(
 function getPaperPrice(billingPlan: PaperBillingPlan): Price {
   const planPrices = getPlanPrices('Paper', 'GBPCountries');
 
-  if(flashSaleIsActive('Paper', 'GBPCountries')) {
+  if (flashSaleIsActive('Paper', 'GBPCountries')) {
     return GBP(planPrices[billingPlan]);
   }
 

--- a/assets/helpers/subscriptions.js
+++ b/assets/helpers/subscriptions.js
@@ -16,6 +16,8 @@ import {
 import { trackComponentEvents } from './tracking/ophanComponentEventTracking';
 import { gaEvent } from './tracking/googleTagManager';
 import { currencies, detect } from './internationalisation/currency';
+import { getPlanPrices, flashSaleIsActive } from 'helpers/flashSale';
+
 
 // ----- Types ------ //
 
@@ -263,6 +265,12 @@ function getPromotionWeeklyProductPrice(
 }
 
 function getPaperPrice(billingPlan: PaperBillingPlan): Price {
+  const planPrices = getPlanPrices('Paper', 'GBPCountries');
+
+  if(flashSaleIsActive('Paper', 'GBPCountries')) {
+    return GBP(planPrices[billingPlan]);
+  }
+
   return paperSubscriptionPrices[billingPlan];
 }
 

--- a/assets/pages/paper-subscription-landing/components/content.jsx
+++ b/assets/pages/paper-subscription-landing/components/content.jsx
@@ -17,6 +17,7 @@ import { sendClickedEvent } from 'helpers/tracking/clickTracking';
 
 import { type State } from '../paperSubscriptionLandingPageReducer';
 import { setTab, type TabActions } from '../paperSubscriptionLandingPageActions';
+import { flashSaleIsActive } from 'helpers/flashSale';
 
 import Form from './form';
 
@@ -41,6 +42,12 @@ const ContentHelpBlock = ({ faqLink, telephoneLink }: {faqLink: Element<string>,
   </ProductPageContentBlock>
 );
 
+function flashSaleAwareProductPageInfoChip(): string {
+  if(flashSaleIsActive('Paper', 'GBPCountries')){
+    return "You can cancel your subscription at any time. Offer is for the first year. Standard subscription rates apply thereafter.";
+  }
+  return "You can cancel your subscription at any time.";
+}
 
 const ContentForm = ({ title, text }: {title: string, text?: Option<string>}) => (
   <ProductPageContentBlock type="feature">
@@ -52,7 +59,7 @@ const ContentForm = ({ title, text }: {title: string, text?: Option<string>}) =>
     }
     <Form />
     <ProductPageInfoChip>
-      You can cancel your subscription at any time
+      {flashSaleAwareProductPageInfoChip()}
     </ProductPageInfoChip>
   </ProductPageContentBlock>
 );

--- a/assets/pages/paper-subscription-landing/components/content.jsx
+++ b/assets/pages/paper-subscription-landing/components/content.jsx
@@ -14,10 +14,10 @@ import ProductPageInfoChip from 'components/productPage/productPageInfoChip/prod
 import GridImage from 'components/gridImage/gridImage';
 import { paperSubsUrl } from 'helpers/routes';
 import { sendClickedEvent } from 'helpers/tracking/clickTracking';
+import { flashSaleIsActive } from 'helpers/flashSale';
 
 import { type State } from '../paperSubscriptionLandingPageReducer';
 import { setTab, type TabActions } from '../paperSubscriptionLandingPageActions';
-import { flashSaleIsActive } from 'helpers/flashSale';
 
 import Form from './form';
 
@@ -43,10 +43,10 @@ const ContentHelpBlock = ({ faqLink, telephoneLink }: {faqLink: Element<string>,
 );
 
 function flashSaleAwareProductPageInfoChip(): string {
-  if(flashSaleIsActive('Paper', 'GBPCountries')){
-    return "You can cancel your subscription at any time. Offer is for the first year. Standard subscription rates apply thereafter.";
+  if (flashSaleIsActive('Paper', 'GBPCountries')) {
+    return 'You can cancel your subscription at any time. Offer is for the first year. Standard subscription rates apply thereafter.';
   }
-  return "You can cancel your subscription at any time.";
+  return 'You can cancel your subscription at any time.';
 }
 
 const ContentForm = ({ title, text }: {title: string, text?: Option<string>}) => (

--- a/assets/pages/paper-subscription-landing/components/content.jsx
+++ b/assets/pages/paper-subscription-landing/components/content.jsx
@@ -42,7 +42,7 @@ const ContentHelpBlock = ({ faqLink, telephoneLink }: {faqLink: Element<string>,
   </ProductPageContentBlock>
 );
 
-function flashSaleAwareProductPageInfoChip(): string {
+function getPageInfoChip(): string {
   if (flashSaleIsActive('Paper', 'GBPCountries')) {
     return 'You can cancel your subscription at any time. Offer is for the first year. Standard subscription rates apply thereafter.';
   }
@@ -59,7 +59,7 @@ const ContentForm = ({ title, text }: {title: string, text?: Option<string>}) =>
     }
     <Form />
     <ProductPageInfoChip>
-      {flashSaleAwareProductPageInfoChip()}
+      {getPageInfoChip()}
     </ProductPageInfoChip>
   </ProductPageContentBlock>
 );

--- a/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
+++ b/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
@@ -51,12 +51,12 @@ const store = pageInit(reducer(method, promoInUrl), true);
 // ----- Render ----- //
 
 function flashSaleAwareHeading(): string {
-  if(flashSaleIsActive('Paper', 'GBPCountries')) {
+  if (flashSaleIsActive('Paper', 'GBPCountries')) {
     const saleCopy = getSaleCopy('Paper', 'GBPCountries');
     return saleCopy.landingPage.subHeading;
   }
 
-  return "Save up to 31% on The Guardian and The Observer - all year round";
+  return 'Save up to 31% on The Guardian and The Observer - all year round';
 }
 
 const content = (

--- a/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
+++ b/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
@@ -17,6 +17,7 @@ import { getQueryParameter } from 'helpers/url';
 import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
 import { type PaperDeliveryMethod } from 'helpers/subscriptions';
+import { flashSaleIsActive, getSaleCopy } from 'helpers/flashSale';
 
 
 import Tabs from './components/tabs';
@@ -49,6 +50,15 @@ const store = pageInit(reducer(method, promoInUrl), true);
 
 // ----- Render ----- //
 
+function flashSaleAwareHeading(): string {
+  if(flashSaleIsActive('Paper', 'GBPCountries')) {
+    const saleCopy = getSaleCopy('Paper', 'GBPCountries');
+    return saleCopy.landingPage.subHeading;
+  }
+
+  return "Save up to 31% on The Guardian and The Observer - all year round";
+}
+
 const content = (
   <Provider store={store}>
     <Page
@@ -57,7 +67,7 @@ const content = (
     >
       <ProductPagehero
         overheading="The Guardian newspaper subscriptions"
-        heading="Save up to 31% on The Guardian and The Observer - all year round"
+        heading={flashSaleAwareHeading()}
         type="feature"
         modifierClasses={['paper']}
       >

--- a/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
+++ b/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
@@ -50,7 +50,7 @@ const store = pageInit(reducer(method, promoInUrl), true);
 
 // ----- Render ----- //
 
-function flashSaleAwareHeading(): string {
+function getHeading(): string {
   if (flashSaleIsActive('Paper', 'GBPCountries')) {
     const saleCopy = getSaleCopy('Paper', 'GBPCountries');
     return saleCopy.landingPage.subHeading;
@@ -67,7 +67,7 @@ const content = (
     >
       <ProductPagehero
         overheading="The Guardian newspaper subscriptions"
-        heading={flashSaleAwareHeading()}
+        heading={getHeading()}
         type="feature"
         modifierClasses={['paper']}
       >


### PR DESCRIPTION
## Why are you doing this?
To support the print flash sale. 

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/AMzW3SFV/2110-print-sale-updates)

## Changes
During a flash sale
* Updated heading 
* Updated prices displayed
* Once the user selects a plan, we send them to the appropriate checkout page on subs-frontend with the promo code applied
* Details of "Offer is for the first year. Standard subscription rates apply thereafter." added below the plans. 

note: paired with @jacobwinch 

## Screenshots
Compare to when flash sale is not on: https://support.theguardian.com/uk/subscribe/paper

`/uk/subscribe/paper`

| mobile-ish        | tablet-ish           | big desktop screen  |
| ------------- |-------------| -----|
| <img src="https://user-images.githubusercontent.com/3072877/50653104-5a7eca00-0f80-11e9-82b1-2ecc8be97862.png" height=400>   | <img src="https://user-images.githubusercontent.com/3072877/50653071-433fdc80-0f80-11e9-8860-1a831823b04d.png" height=400> | <img src="https://user-images.githubusercontent.com/3072877/50652985-0a076c80-0f80-11e9-9f98-ba4551b19b59.png" height=400> |

`/uk/subscribe/paper/delivery`

| mobile-ish        | tablet-ish           | big desktop screen  |
| ------------- |-------------| -----|
| <img src="https://user-images.githubusercontent.com/3072877/50653112-61a5d800-0f80-11e9-87b5-bdac87f49e50.png" height=400>   | <img src="https://user-images.githubusercontent.com/3072877/50653059-3b803800-0f80-11e9-9442-081c446e0f80.png" height=400> | <img src="https://user-images.githubusercontent.com/3072877/50653026-22778700-0f80-11e9-9aab-4d3e91e7ecb6.png" height=400> |
