### PR TITLE
Disable the countdown timer.

### DIFF
--- a/assets/pages/subscriptions-landing/components/featuredProductAb.jsx
+++ b/assets/pages/subscriptions-landing/components/featuredProductAb.jsx
@@ -83,7 +83,7 @@ function FeaturedProductAb(props: PropTypes) {
       cta={getCta(product)}
       headingSize={headingSize}
       product={product.name}
-      hasTimer={flashSaleIsActive(product.name, countryGroupId)}
+      hasTimer={false}
       countryGroupId={countryGroupId}
     />) : null;
 

--- a/assets/pages/subscriptions-landing/components/featuredProductAb.jsx
+++ b/assets/pages/subscriptions-landing/components/featuredProductAb.jsx
@@ -16,7 +16,6 @@ import { type Participations } from 'helpers/abTests/abtest';
 import { type OptimizeExperiments } from 'helpers/optimize/optimize';
 import { type CommonState } from 'helpers/page/commonReducer';
 import FeaturedProductHero from 'components/featuredProductHero/featuredProductHero';
-import { flashSaleIsActive } from 'helpers/flashSale';
 import { getProduct, type Product } from './featuredProducts';
 
 


### PR DESCRIPTION
## Why are you doing this?
https://github.com/guardian/support-frontend/pull/1346

⬆️ There is a print flash sale starting today, but we'd like the countdown timer to appear later on. TBD if we will raise a PR just to add it back in whenever we want it, or some kind of feature to enable it x days before the end of the sale. Regardless, we should disable it for now. 

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/NyBumRDL/2134-countdown-timer-should-only-appear-during-the-last-week-of-the-sale)

## Changes

* Disable the countdown timer. There is a trello card about enabling it linked above. 

## Screenshots

| timer on (before this PR)  | timer back off (after this PR)       |
| ------------- |-------------| 
| <img src="https://user-images.githubusercontent.com/3072877/50689488-d3822e00-1021-11e9-8ce8-5497f1e447fb.png" height=400>   | <img src="https://user-images.githubusercontent.com/3072877/50689465-bea59a80-1021-11e9-8b06-e0320ed41c13.png" height=400> | 
