### PR TITLE
Hook up Direct Debit in the Digital Pack checkout

### DIFF
--- a/assets/pages/digital-subscription-checkout/__tests__/digitalSubscriptionCheckoutReducerTest.js
+++ b/assets/pages/digital-subscription-checkout/__tests__/digitalSubscriptionCheckoutReducerTest.js
@@ -3,7 +3,6 @@
 // ----- Imports ----- //
 
 import { initReducer, setStage, type Stage } from '../digitalSubscriptionCheckoutReducer';
-import { type User } from '../helpers/user';
 
 jest.mock('ophan', () => {});
 
@@ -15,14 +14,8 @@ describe('Digital Subscription Checkout Reducer', () => {
 
     const stage: Stage = 'thankyou';
     const action = setStage(stage);
-    const user: User = {
-      email: null,
-      firstName: null,
-      lastName: null,
-      country: null,
-    };
 
-    const newState = initReducer(user)(undefined, action);
+    const newState = initReducer('GBPCountries')(undefined, action);
 
     expect(newState.checkout.stage).toEqual(stage);
 
@@ -32,14 +25,8 @@ describe('Digital Subscription Checkout Reducer', () => {
 
     const stage: Stage = 'checkout';
     const action = setStage(stage);
-    const user: User = {
-      email: null,
-      firstName: null,
-      lastName: null,
-      country: null,
-    };
 
-    const newState = initReducer(user)(undefined, action);
+    const newState = initReducer('GBPCountries')(undefined, action);
 
     expect(newState.checkout.stage).toEqual(stage);
 

--- a/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -28,6 +28,8 @@ import { asControlled } from 'components/forms/formHOCs/asControlled';
 import { withArrow } from 'components/forms/formHOCs/withArrow';
 import { canShow } from 'components/forms/formHOCs/canShow';
 import GeneralErrorMessage from 'components/generalErrorMessage/generalErrorMessage';
+import DirectDebitPopUpForm from 'components/directDebit/directDebitPopUpForm/directDebitPopUpForm';
+
 import type { ErrorReason } from 'helpers/errorReasons';
 import {
   type FormActionCreators,
@@ -200,6 +202,9 @@ function CheckoutForm(props: PropTypes) {
         />
         {errorState}
         <Button1 onClick={() => props.submitForm()}>Continue to payment</Button1>
+        <DirectDebitPopUpForm
+          onPaymentAuthorisation={(pr) => { props.onPaymentAuthorised(pr); }}
+        />
       </LeftMarginSection>
     </div>
   );

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.jsx
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.jsx
@@ -18,7 +18,6 @@ import SubscriptionFaq from 'components/subscriptionFaq/subscriptionFaq';
 
 import { initReducer } from './digitalSubscriptionCheckoutReducer';
 import CheckoutStage from './components/checkoutStage';
-import { getUser } from './helpers/user';
 
 // ----- Internationalisation ----- //
 
@@ -35,7 +34,7 @@ const reactElementId: {
 
 // ----- Redux Store ----- //
 
-const store = pageInit(initReducer(getUser(countryGroupId)), true);
+const store = pageInit(initReducer(countryGroupId), true);
 
 // ----- Render ----- //
 

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss
@@ -29,6 +29,8 @@
 @import '~components/progressMessage/progressMessage';
 @import '~components/spinners/animatedDots';
 @import '~components/generalErrorMessage/generalErrorMessage';
+@import '~components/directDebit/directDebitPopUpForm/directDebitPopUpForm';
+@import '~components/directDebit/directDebitForm/directDebitForm';
 
 
 // ----- Page-Specific Styles ----- //


### PR DESCRIPTION
## Why are you doing this?

Adds support for Direct Debit payments to the Digital Pack checkout

[**Trello Card**](https://trello.com/c/G2M6wk8Q/1511-pay-by-direct-debit)

### TODO
Refactor the digitalSubscriptionCheckoutReducer to remove the user fields an use the user reducer instead.
