### PR TITLE
Remove US end-of-year campaign from landing page

### DIFF
--- a/assets/helpers/internationalisation/contributions.js
+++ b/assets/helpers/internationalisation/contributions.js
@@ -29,7 +29,7 @@ const countryGroupSpecificDetails: {
   },
   UnitedStates: {
     headerCopy: defaultHeaderCopy,
-    headerClasses: defaultContributeCopy,
+    contributeCopy: defaultContributeCopy,
   },
   AUDCountries: {
     headerCopy: 'Help us deliver the independent journalism Australia needs',

--- a/assets/helpers/internationalisation/contributions.js
+++ b/assets/helpers/internationalisation/contributions.js
@@ -28,9 +28,8 @@ const countryGroupSpecificDetails: {
     contributeCopy: defaultContributeCopy,
   },
   UnitedStates: {
-    headerCopy: 'Invest in our independent journalism for 2019 and beyond',
-    headerClasses: 'header__us-campaign',
-    tickerJsonUrl: '/ticker.json',
+    headerCopy: defaultHeaderCopy,
+    headerClasses: defaultContributeCopy,
   },
   AUDCountries: {
     headerCopy: 'Help us deliver the independent journalism Australia needs',

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -291,11 +291,6 @@ body {
   padding: 0 $gu-h-spacing/2 $gu-v-spacing*1.5 $gu-h-spacing/2;
 }
 
-.header__us-campaign {
-  font-size: 27px;
-  border-bottom: none;
-}
-
 input,
 select,
 textarea,


### PR DESCRIPTION
## Why are you doing this?
The campaign is over, we want to go back to the default landing page


## Screenshots
![picture 10](https://user-images.githubusercontent.com/1513454/50832272-9ed5e580-1345-11e9-8bad-656f9c0ae79b.png)


