### PR TITLE
Set contribution types through URL parameters

### DIFF
--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -36,24 +36,6 @@ export const tests: Tests = {
     canRun: () => !isFromEpicOrBanner,
   },
 
-  usContributionTypes: {
-    variants: [
-      'control',
-      'default-annual',
-      'default-single',
-      'default-annual_no-monthly',
-    ],
-    audiences: {
-      UnitedStates: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: false,
-    independent: true,
-    seed: 5,
-  },
-
   applePay: {
     variants: ['control', 'applePay'],
     audiences: {

--- a/assets/helpers/checkouts.js
+++ b/assets/helpers/checkouts.js
@@ -6,7 +6,7 @@ import { getQueryParameter } from 'helpers/url';
 import {
   type ContributionType,
   type PaymentMethod,
-  toContributionType
+  toContributionType,
 } from 'helpers/contributions';
 import {
   getMinContribution,
@@ -18,7 +18,6 @@ import * as storage from 'helpers/storage';
 import { type Switches, type SwitchObject } from 'helpers/settings';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { IsoCountry } from 'helpers/internationalisation/country';
-import type { Participations } from 'helpers/abTests/abtest';
 
 
 // ----- Types ----- //

--- a/assets/helpers/contributions.js
+++ b/assets/helpers/contributions.js
@@ -331,23 +331,26 @@ function getMinContribution(contributionType: ContributionType, countryGroupId: 
   return config[countryGroupId][contributionType].min;
 }
 
-function toContributionTypeOrElse(s: ?string, fallback: ContributionType): ContributionType {
-  switch ((s || fallback).toUpperCase()) {
+function toContributionType(s: string): ?ContributionType {
+  switch (s.toUpperCase()) {
     case 'ANNUAL': return 'ANNUAL';
     case 'MONTHLY': return 'MONTHLY';
     case 'ONE_OFF': return 'ONE_OFF';
-    default: return fallback;
+    default: return null;
   }
 }
 
-function parseRegularContributionType(s: string): RegularContributionType {
+function toContributionTypeOrElse(s: ?string, fallback: ContributionType): ContributionType {
+  const contributionType = toContributionType(s || fallback);
+  return contributionType || fallback;
+}
 
+function parseRegularContributionType(s: string): RegularContributionType {
   if (s === 'ANNUAL') {
     return 'ANNUAL';
   }
 
   return 'MONTHLY';
-
 }
 
 function billingPeriodFromContrib(contributionType: ContributionType): BillingPeriod {
@@ -493,6 +496,7 @@ function getContributionAmountRadios(
 export {
   config,
   amounts,
+  toContributionType,
   toContributionTypeOrElse,
   validateContribution,
   parseContribution,

--- a/assets/pages/new-contributions-landing/components/ContributionTypeTabs.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionTypeTabs.jsx
@@ -5,7 +5,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { type ContributionType } from 'helpers/contributions';
-import { type Participations } from 'helpers/abTests/abtest';
 import { classNameWithModifiers } from 'helpers/utilities';
 import {
   getPaymentMethodToSelect,
@@ -28,7 +27,6 @@ type PropTypes = {|
   countryGroupId: CountryGroupId,
   switches: Switches,
   onSelectContributionType: (ContributionType, Switches, IsoCountry, CountryGroupId) => void,
-  abParticipations: Participations,
 |};
 
 const mapStateToProps = (state: State) => ({
@@ -36,7 +34,6 @@ const mapStateToProps = (state: State) => ({
   contributionType: state.page.form.contributionType,
   countryId: state.common.internationalisation.countryId,
   switches: state.common.settings.switches,
-  abParticipations: state.common.abParticipations,
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -59,7 +56,7 @@ function ContributionTypeTabs(props: PropTypes) {
     <fieldset className={classNameWithModifiers('form__radio-group', ['tabs', 'contribution-type'])}>
       <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>Recurrence</legend>
       <ul className="form__radio-group-list">
-        {getValidContributionTypes(props.abParticipations).map((contributionType: ContributionType) => (
+        {getValidContributionTypes().map((contributionType: ContributionType) => (
           <li className="form__radio-group-item">
             <input
               id={`contributionType-${contributionType}`}

--- a/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -12,7 +12,7 @@ import {
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { Switches } from 'helpers/settings';
 import {
-  getContributionTypeFromSessionOrElse,
+  getContributionTypeFromSessionOrElse, getContributionTypeFromUrlOrElse,
   getPaymentMethodFromSession,
   getValidContributionTypes,
   getValidPaymentMethods,
@@ -53,19 +53,8 @@ function getInitialPaymentMethod(
 }
 
 function getInitialContributionType(abParticipations: Participations): ContributionType {
-  const { usContributionTypes } = abParticipations;
-  const abTestParams = usContributionTypes
-    ? usContributionTypes.split('_')
-    : [];
-
-  let contributionType: ContributionType;
-  if (abTestParams.includes('default-annual')) {
-    contributionType = getContributionTypeFromSessionOrElse('ANNUAL');
-  } else if (abTestParams.includes('default-single')) {
-    contributionType = getContributionTypeFromSessionOrElse('ONE_OFF');
-  } else {
-    contributionType = getContributionTypeFromSessionOrElse('MONTHLY');
-  }
+  const contributionType: ContributionType =
+    getContributionTypeFromUrlOrElse(getContributionTypeFromSessionOrElse('MONTHLY'));
 
   return (
     // make sure we don't select a contribution type which isn't on the page

--- a/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -18,7 +18,6 @@ import {
   getValidPaymentMethods,
   type ThirdPartyPaymentLibrary,
 } from 'helpers/checkouts';
-import { type Participations } from 'helpers/abTests/abtest';
 import { getAnnualAmounts } from 'helpers/abTests/helpers/annualContributions';
 import { type Amount, type ContributionType, type PaymentMethod } from 'helpers/contributions';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
@@ -52,15 +51,15 @@ function getInitialPaymentMethod(
   );
 }
 
-function getInitialContributionType(abParticipations: Participations): ContributionType {
+function getInitialContributionType(): ContributionType {
   const contributionType: ContributionType =
     getContributionTypeFromUrlOrElse(getContributionTypeFromSessionOrElse('MONTHLY'));
 
   return (
     // make sure we don't select a contribution type which isn't on the page
-    getValidContributionTypes(abParticipations).includes(contributionType)
+    getValidContributionTypes().includes(contributionType)
       ? contributionType
-      : getValidContributionTypes(abParticipations)[0]
+      : getValidContributionTypes()[0]
   );
 }
 
@@ -130,11 +129,10 @@ function selectInitialAnnualAmount(state: State, dispatch: Function) {
 }
 
 function selectInitialContributionTypeAndPaymentMethod(state: State, dispatch: Function) {
-  const { abParticipations } = state.common;
   const { countryId } = state.common.internationalisation;
   const { switches } = state.common.settings;
 
-  const contributionType = getInitialContributionType(abParticipations);
+  const contributionType = getInitialContributionType();
   const paymentMethod = getInitialPaymentMethod(contributionType, countryId, switches);
 
   dispatch(updateContributionTypeAndPaymentMethod(contributionType, paymentMethod));


### PR DESCRIPTION
Serves customised versions of the site based on two URL parameters:
- `contributionTypes`: this is a comma-separated list of contribution types (must be `one_off`, `annual`, or `monthly`)
- `defaultContributionType`: this a contribution type (`one_off`, `annual` or `monthly`) which must be in the available contributionTypes, if limited by the URL

e.g.
- https://support.theguardian.com/uk/contribute?defaultContributionType=annual&contributionTypes=one_off,annual
