### PR TITLE
Use correct log level for success messages

### DIFF
--- a/app/controllers/DigitalSubscription.scala
+++ b/app/controllers/DigitalSubscription.scala
@@ -141,7 +141,7 @@ class DigitalSubscription(
         InternalServerError
       },
       { statusResponse =>
-        SafeLogger.error(scrub"[${request.uuid}] Successfully created a support workers execution for a new $billingPeriod Digital Subscription")
+        SafeLogger.info("[${request.uuid}] Successfully created a support workers execution for a new $billingPeriod Digital Subscription")
         Accepted(statusResponse.asJson)
       }
     )


### PR DESCRIPTION
## Why are you doing this?

I noticed that this log level was incorrect (Sentry emailed me about it whilst I was testing).
