### PR TITLE
Remove headline prop from productPagehero

### DIFF
--- a/assets/components/productPage/productPageHero/productPageHero.jsx
+++ b/assets/components/productPage/productPageHero/productPageHero.jsx
@@ -16,7 +16,6 @@ type PropTypes = {|
   overheading: string,
   type: 'grey' | 'feature',
   heading: string,
-  headline?: Option<string>,
   cta?: Option<Node>,
   children?: Option<Node>,
   modifierClasses: Array<?string>,
@@ -26,16 +25,11 @@ type PropTypes = {|
 // ----- Render ----- //
 
 const ProductPageHero = ({
-  headline, overheading, heading, cta, modifierClasses, children, type,
+  overheading, heading, cta, modifierClasses, children, type,
 }: PropTypes) => (
   <header>
     <div className={classNameWithModifiers('component-product-page-hero', [...modifierClasses, type])}>
       <LeftMarginSection>
-        {headline &&
-        <p className="component-product-page-hero__headline">
-          {headline}
-        </p>
-        }
         {children}
         <HeadingBlock overheading={overheading} heading={heading} />
       </LeftMarginSection>
@@ -56,7 +50,6 @@ ProductPageHero.defaultProps = {
   modifierClasses: [],
   children: null,
   cta: null,
-  headline: null,
   type: 'grey',
 };
 

--- a/assets/components/productPage/productPageHero/productPageHero.scss
+++ b/assets/components/productPage/productPageHero/productPageHero.scss
@@ -51,23 +51,3 @@
   background: gu-colour(garnett-neutral-1);
   color: #ffffff;
 }
-
-.component-product-page-hero__headline {
-  color: gu-colour(garnett-neutral-7);
-  font-family: $gu-titlepiece;
-  font-weight: 400;
-  line-height: 1;
-  display: block;
-  max-width: 440px;
-  padding: $gu-v-spacing/2  $gu-h-spacing/2;
-  font-size: 30px;
-  @include mq($from: phablet) {
-    font-size: 48px;
-  }
-  @include mq($from: tablet) {
-    margin-bottom: 240px;
-  }
-  @include mq($from: desktop) {
-    font-size: 60px;
-  }
-}


### PR DESCRIPTION
## Why are you doing this?

This prop added a very specific style of headline (`Become a Guardian Weekly subscriber`) that has since gone fallen out of use. It also didn't support different background colours. Even if we were to incorporate this in the future it makes more sense to put it as a child of that particular hero rather than globally.

![screenshot 2019-01-09 at 11 07 07 am](https://user-images.githubusercontent.com/11539094/50895960-81fde880-13ff-11e9-940a-3338c681dda0.png)
