### PR TITLE
Fix header on checkout thank you page

### DIFF
--- a/assets/pages/digital-subscription-checkout/components/checkoutStage.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutStage.jsx
@@ -7,7 +7,6 @@ import { connect } from 'react-redux';
 
 import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
 import ReturnSection from 'components/returnSection/returnSection';
-import HeadingBlock from 'components/headingBlock/headingBlock';
 import ProductHero, {
   type GridImages,
   type ImagesByCountry,
@@ -102,18 +101,17 @@ function CheckoutStage(props: PropTypes) {
 
     case 'thankyou':
       return (
-        <div>
+        <div className="thank-you-stage">
           <ProductHero
             countryGroupId={props.countryGroupId}
             imagesByCountry={heroesByCountry}
             altText="digital subscription"
             fallbackImgType="png"
           />
-          <LeftMarginSection>
-            <HeadingBlock overheading="Thank You" heading="Your Digital Pack subscription is now live">
-              <p>Thank you for supporting our journalism</p>
-            </HeadingBlock>
-          </LeftMarginSection>
+          <CheckoutHeading
+            heading="Your Digital Pack subscription is now live"
+            copy="Thank you for supporting our journalism"
+          />
           <ThankYouContent countryGroupId={props.countryGroupId} />
           <ReturnSection />
         </div>

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss
@@ -106,6 +106,16 @@
 
   // ----- Thank You
 
+  .thank-you-stage {
+    .component-checkout-heading {
+      z-index: 10;
+      position: relative;
+      .component-left-margin-section__content {
+        box-sizing: border-box;  
+      }  
+    }
+  }
+
   .thank-you-content {
     // Makes sure the circle SVGs stay behind the heading.
     position: relative;

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss
@@ -108,7 +108,6 @@
 
   .thank-you-stage {
     .component-checkout-heading {
-      z-index: 10;
       position: relative;
       .component-left-margin-section__content {
         box-sizing: border-box;  


### PR DESCRIPTION
## Why are you doing this?
Updates the thank you page header to match the one from the main checkout, this solves an issue with how it displays on mobile and is more closely aligned with the original design:

![screenshot 2019-01-09 at 3 02 46 pm](https://user-images.githubusercontent.com/11539094/50907616-bb465080-141f-11e9-92df-439521a60ec6.png)
