### PR TITLE
[NPF] CSS Refactor(1)

### DIFF
--- a/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYou.scss
+++ b/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYou.scss
@@ -1,6 +1,6 @@
 // -----  gu-sass ----- //
 
-.thank-you__container {
+.thank-you__container .header{
   @include mq($from: mobile, $until: tablet) {
     background-color: gu-colour(news-garnett-highlight);
   }

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -32,8 +32,8 @@ body {
 
 .gu-content__main {
   position: relative;
-   display: flex;
-   flex-direction: column-reverse;
+  display: flex;
+  flex-direction: column-reverse;
 }
 
 .gu-content__bg {

--- a/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -338,6 +338,7 @@ footer[role="contentinfo"] a {
   background: gu-colour(garnett-neutral-5);
   padding: 0 10px;
   overflow: hidden;
+  flex-grow: 1;
 
   @include mq($from: tablet) {
     border-color: gu-colour(garnett-neutral-4);


### PR DESCRIPTION
This PR is the second attempt at merging [this PR](https://github.com/guardian/support-frontend/pulls?q=is%3Apr+is%3Aclosed+author%3Ajranks123.
) 

Here's the original PR description:

This PR refactors the new contributions landing page CSS

Main takeaways:

Removes support for grid. It isn't supported properly on Safari, which accounts for > 20% of our traffic, so it isn't worth the added complexity of having 2 sets of CSS.

Removes all instances where we put multiple classes inside a media query, and moves to the pattern of each class having it's own media queries.

Where possible, moves component specific CSS into it's own file, so as not to bloat the main CSS file.

This has resulted in contributionsLanding.scss going from > 1200 lines to ~800 lines, and sets some standards going forwards.

There should be no visual difference as a result of this PR.