### PR TITLE
fix uibutton

### DIFF
--- a/assets/components/marketingConsentNew/marketingConsent.jsx
+++ b/assets/components/marketingConsentNew/marketingConsent.jsx
@@ -39,6 +39,7 @@ function Button(props: ButtonPropTypes) {
       <UiButton
         appearance="greenHollow"
         iconSide="left"
+        isStatic
         icon={<SvgSubscribed />}
       >
         Signed up
@@ -49,6 +50,7 @@ function Button(props: ButtonPropTypes) {
       <UiButton
         appearance="greyHollow"
         iconSide="left"
+        isStatic
         icon={<SvgSubscribe />}
       >
         Pending...

--- a/assets/components/ui/uiButton/uiButton.jsx
+++ b/assets/components/ui/uiButton/uiButton.jsx
@@ -26,6 +26,7 @@ type PropTypes = {|
   type: 'submit' | 'button',
   href: ?string,
   disabled: boolean,
+  isStatic: boolean,
   appearance: 'primary' | 'green' | 'greenHollow' | 'greyHollow',
   iconSide: 'left' | 'right',
   onClick: ?(void => void),
@@ -36,7 +37,7 @@ type PropTypes = {|
 // ----- Render ----- //
 
 const UiButton = ({
-  children, icon, type, onClick, href, disabled, trackingOnClick, appearance, iconSide,
+  children, icon, type, onClick, href, disabled, trackingOnClick, appearance, iconSide, isStatic
 }: PropTypes) => {
 
   const getClassName = (modifiers: string[] = []) =>
@@ -46,7 +47,7 @@ const UiButton = ({
       ...modifiers,
     ]);
 
-  if (!href && !onClick) {
+  if (isStatic) {
     return (
       <div
         className={getClassName(['static'])}
@@ -88,6 +89,7 @@ UiButton.defaultProps = {
   trackingOnClick: null,
   href: null,
   disabled: false,
+  isStatic: false,
   appearance: 'primary',
   iconSide: 'right',
 };

--- a/assets/components/ui/uiButton/uiButton.jsx
+++ b/assets/components/ui/uiButton/uiButton.jsx
@@ -37,7 +37,7 @@ type PropTypes = {|
 // ----- Render ----- //
 
 const UiButton = ({
-  children, icon, type, onClick, href, disabled, trackingOnClick, appearance, iconSide, isStatic
+  children, icon, type, onClick, href, disabled, trackingOnClick, appearance, iconSide, isStatic,
 }: PropTypes) => {
 
   const getClassName = (modifiers: string[] = []) =>


### PR DESCRIPTION
## Why are you doing this?
Earlier today in #1366 I refactored `uiButton` so in the event of it not having an `href` or `onClick` it would render as a div, under the assumption a button with neigher of these elements would always be presentational and not do anything (similar to disabled)

Boy did that backfire, i forgort, forms can have `<button type=submit">` which automatically becomes a form submit button and doesn't need any behaviour.  that PR accidentally turned all of those into divs, making forms impossible to submit. needless to say that was very bad.