### PR TITLE
Handle 500s on calls to endpoints that create subscriptions

### DIFF
--- a/assets/helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis.js
+++ b/assets/helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis.js
@@ -179,7 +179,8 @@ function postRegularPaymentRequest(
         return ({ paymentStatus: 'failure', error: 'internal_error' });
       }
 
-      return response.json().then(checkRegularStatus(participations, csrf, setGuestAccountCreationToken, setThankYouPageStage));
+      return response.json()
+        .then(checkRegularStatus(participations, csrf, setGuestAccountCreationToken, setThankYouPageStage));
 
     })
     .catch(() => {

--- a/assets/helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis.js
+++ b/assets/helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis.js
@@ -179,7 +179,8 @@ function postRegularPaymentRequest(
         return ({ paymentStatus: 'failure', error: 'internal_error' });
       }
 
-      return checkRegularStatus(participations, csrf, setGuestAccountCreationToken, setThankYouPageStage)(response);
+      return response.json().then(checkRegularStatus(participations, csrf, setGuestAccountCreationToken, setThankYouPageStage));
+
     })
     .catch(() => {
       logException(`Error while trying to interact with ${uri}`);

--- a/assets/helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis.js
+++ b/assets/helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis.js
@@ -172,10 +172,19 @@ function postRegularPaymentRequest(
   setGuestAccountCreationToken: (string) => void,
   setThankYouPageStage: (ThankYouPageStage) => void,
 ): Promise<PaymentResult> {
-  return logPromise(fetchJson(
-    uri,
-    requestOptions(data, 'same-origin', 'POST', csrf),
-  ).then(checkRegularStatus(participations, csrf, setGuestAccountCreationToken, setThankYouPageStage)));
+  return logPromise(fetch(uri, requestOptions(data, 'same-origin', 'POST', csrf)))
+    .then((response) => {
+      if (response.status === 500) {
+        logException(`500 Error while trying to post to ${uri}`);
+        return ({ paymentStatus: 'failure', error: 'internal_error' });
+      }
+
+      return checkRegularStatus(participations, csrf, setGuestAccountCreationToken, setThankYouPageStage)(response);
+    })
+    .catch(() => {
+      logException(`Error while trying to interact with ${uri}`);
+      return ({ paymentStatus: 'failure', error: 'unknown' });
+    });
 }
 
 function setPasswordGuest(


### PR DESCRIPTION
## Why are you doing this?
`POST /subscribe/digital/create `
and 
`POST /contribute/recurring/create`

accept the same request body and both start the process of creating a recurring payment via support-workers. So, `postRegularPaymentRequest()` is used by both the recurring contributions and digital pack checkout. 
Both create endpoints currently may return a 500, but when that happens, this happens:
![image](https://user-images.githubusercontent.com/3072877/51191104-9a787200-18db-11e9-8fba-754da343d144.png)
(and the page hangs)

Try it out: 
- force a 500 response
![image](https://user-images.githubusercontent.com/3072877/51191122-a95f2480-18db-11e9-98a6-ec725bcbf6e6.png)
- go through the checkout in `https://support.thegulocal.com/uk/contribute` 

(the same applies to https://support.thegulocal.com/uk/subscribe/digital/checkout?displayCheckout=true)

then checkout this branch and instead see an error
![image](https://user-images.githubusercontent.com/3072877/51191744-f7c0f300-18dc-11e9-943c-bcf1ab3fd836.png)


<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com) - there isn't one

## Changes

* When calling `POST /subscribe/digital/create ` or `POST /contribute/recurring/create`, now we do not immediately convert the response to a json, so that we can handle a 500. 

## Screenshots

