### PR TITLE
Digipack landing buttons AB test

### DIFF
--- a/app/controllers/DigitalSubscription.scala
+++ b/app/controllers/DigitalSubscription.scala
@@ -51,7 +51,7 @@ class DigitalSubscription(
     val title = "Support the Guardian | Digital Pack Subscription"
     val id = "digital-subscription-landing-page-" + countryCode
     val js = "digitalSubscriptionLandingPage.js"
-    val css = "digitalSubscriptionLandingPageStyles.css"
+    val css = "digitalSubscriptionLandingPage.css"
     val description = stringsConfig.digitalPackLandingDescription
     val canonicalLink = Some(buildCanonicalDigitalSubscriptionLink("uk"))
     val hrefLangLinks = Map(

--- a/assets/components/adFreeSection/adFreeSection.jsx
+++ b/assets/components/adFreeSection/adFreeSection.jsx
@@ -22,12 +22,11 @@ export default function AdFreeSection(props: PropTypes) {
 
   return (
     <div className="component-ad-free-section">
-      <LeftMarginSection modifierClasses={['blue']}>
+      <LeftMarginSection>
         <div className="component-ad-free-section__content">
           <div className="component-ad-free-section__wrapper">
             <div className="component-ad-free-section__col">
               <Heading size={headingSize} className="component-ad-free-section__header">No ads, no interruptions</Heading>
-              <strong className="component-ad-free-section__badge">New</strong>
               <p className="component-ad-free-section__copy">
                 Avoid the adverts and read without interruptions
                 when you&#39;re signed in on your apps and theguardian.com

--- a/assets/components/adFreeSection/adFreeSection.scss
+++ b/assets/components/adFreeSection/adFreeSection.scss
@@ -1,7 +1,7 @@
 .component-ad-free-section {
   font-family: $gu-text-egyptian-web;
   background: gu-colour(neutral-6);
-  border-bottom: 1px solid gu-colour(neutral-4);
+  border-top: 1px solid gu-colour(neutral-4);
 }
 
 .component-ad-free-section__content {

--- a/assets/components/adFreeSection/adFreeSection.scss
+++ b/assets/components/adFreeSection/adFreeSection.scss
@@ -1,6 +1,6 @@
 .component-ad-free-section {
   font-family: $gu-text-egyptian-web;
-  background: gu-colour(neutral-6);
+
   border-top: 1px solid gu-colour(neutral-4);
   border-bottom: 1px solid gu-colour(neutral-4);
 }

--- a/assets/components/adFreeSection/adFreeSection.scss
+++ b/assets/components/adFreeSection/adFreeSection.scss
@@ -2,6 +2,7 @@
   font-family: $gu-text-egyptian-web;
   background: gu-colour(neutral-6);
   border-top: 1px solid gu-colour(neutral-4);
+  border-bottom: 1px solid gu-colour(neutral-4);
 }
 
 .component-ad-free-section__content {

--- a/assets/components/adFreeSection/adFreeSection.scss
+++ b/assets/components/adFreeSection/adFreeSection.scss
@@ -16,15 +16,11 @@
 
 .component-ad-free-section__header {
   width: 100%;
-  font-size: 26px;
-  font-weight: bold;
-  line-height: 1.12;
-  font-family: $gu-headline;
+  @include gu-fontset-heading;
   margin-bottom: 8px;
 
   @include mq($from: leftCol) {
     width: 620px;
-    font-size: 36px;
     line-height: 1.17;
   }
 }
@@ -38,8 +34,7 @@
 }
 
 .component-ad-free-section__copy {
-  font-size: 16px;
-  line-height: 1.25;
+  @include gu-fontset-body;
   display: block;
   @include mq($from: leftCol) {
     width: 90%;

--- a/assets/components/adFreeSection/adFreeSection.scss
+++ b/assets/components/adFreeSection/adFreeSection.scss
@@ -1,5 +1,7 @@
 .component-ad-free-section {
   font-family: $gu-text-egyptian-web;
+  background: gu-colour(neutral-6);
+  border-bottom: 1px solid gu-colour(neutral-4);
 }
 
 .component-ad-free-section__content {
@@ -9,6 +11,7 @@
   padding-top: 2px;
   width: 100%;
   position: relative;
+  border-left: 1px solid gu-colour(neutral-4);
 }
 
 .component-ad-free-section__header {
@@ -18,7 +21,6 @@
   line-height: 1.12;
   font-family: $gu-headline;
   margin-bottom: 8px;
-  color: gu-colour(news-garnett-highlight);
 
   @include mq($from: leftCol) {
     width: 620px;
@@ -60,18 +62,4 @@
     width: 400px;
     margin-right: 40px;
   }
-}
-
-.component-ad-free-section__badge {
-  background: gu-colour(news-garnett-highlight);
-  color: gu-colour(garnett-neutral-1);
-  font-size: 26px;
-  font-weight: bold;
-  font-family: $gu-headline;
-  display: inline-block;
-  padding: 0 10px 1px;
-  top: 0px;
-  left: -92px;
-  position: absolute;
-  transform: rotate(-12deg);
 }

--- a/assets/components/optimizeExperimentWrapper/optimizeExperimentWrapper.jsx
+++ b/assets/components/optimizeExperimentWrapper/optimizeExperimentWrapper.jsx
@@ -5,6 +5,7 @@ import type { OptimizeExperiments, OptimizeExperiment } from 'helpers/optimize/o
 import type { CommonState } from 'helpers/page/commonReducer';
 import type { Node } from 'react';
 import React from 'react';
+import { getQueryParameter } from 'helpers/url';
 
 export type ExperimentWrapperProps = {
   experimentId: string,
@@ -25,11 +26,13 @@ function getExperiment(props: ExperimentWrapperProps): OptimizeExperiment | null
 function OptimizeExperimentWrapper(props: ExperimentWrapperProps) {
   const experiment = getExperiment(props);
 
+  const defaultVariant = Number(getQueryParameter('force_optimize_ab_variant')) || 0;
+
   if (experiment === null) {
-    return React.Children.toArray(props.children)[0];
+    return React.Children.toArray(props.children)[defaultVariant];
   }
 
-  const variant = Number(experiment.variant) || 0;
+  const variant = Number(experiment.variant) || defaultVariant;
   return React.Children.toArray(props.children)[variant];
 }
 

--- a/assets/components/priceCta/priceCta.jsx
+++ b/assets/components/priceCta/priceCta.jsx
@@ -29,7 +29,7 @@ function PriceCta(props: PropTypes) {
     <div className={classNameWithModifiers('component-price-cta', withSecondary ? ['with-secondary'] : [])}>
       <UiButton
         href={props.url}
-        accessibilityHint={`${props.ctaText} for only ${props.price} per month`}
+        aria-label={`${props.ctaText} for only ${props.price} per month`}
       >{props.ctaText}
       </UiButton>
       {withSecondary ? <p className="component-price-cta__secondary">{props.secondaryCopy}</p> : null}

--- a/assets/components/priceCta/priceCta.jsx
+++ b/assets/components/priceCta/priceCta.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 
-import CtaLink from 'components/ctaLink/ctaLink';
+import UiButton from 'components/ui/uiButton/uiButton';
 
 import { classNameWithModifiers } from 'helpers/utilities';
 
@@ -27,12 +27,11 @@ function PriceCta(props: PropTypes) {
 
   return (
     <div className={classNameWithModifiers('component-price-cta', withSecondary ? ['with-secondary'] : [])}>
-      <CtaLink
-        text={props.ctaText}
-        url={props.url}
+      <UiButton
+        href={props.url}
         accessibilityHint={`${props.ctaText} for only ${props.price} per month`}
-        id="price-cta"
-      />
+      >{props.ctaText}
+      </UiButton>
       {withSecondary ? <p className="component-price-cta__secondary">{props.secondaryCopy}</p> : null}
     </div>
   );

--- a/assets/components/priceCta/priceCta.scss
+++ b/assets/components/priceCta/priceCta.scss
@@ -2,29 +2,7 @@
   padding-top: $gu-v-spacing;
   padding-bottom: $gu-v-spacing;
   position: relative;
-
-  .component-cta-link {
-    width: 200px;
-    background-color: gu-colour(news-garnett-highlight);
-    color: gu-colour(garnett-neutral-1);
-    margin-left: $gu-h-spacing / 2;
-
-    &:hover {
-      background-color: darken(gu-colour(news-garnett-highlight), 5%);
-    }
-
-    @include mq($from: mobileMedium) {
-      width: 200px;
-    }
-
-    @include mq($from: desktop) {
-      width: 220px;
-    }
-  }
-
-  .svg-arrow-right-straight {
-    fill: gu-colour(garnett-neutral-1);
-  }
+  padding-left: $gu-h-spacing / 2;
 }
 
 .component-price-cta--with-secondary {
@@ -36,12 +14,10 @@
 }
 
 .component-price-cta__secondary {
-  background-color: gu-colour(garnett-neutral-3);
-  font-size: 14px;
+  @include gu-fontset-body-sans;
   font-style: italic;
-  line-height: 24px;
-  padding-bottom: $gu-v-spacing / 2;
-  padding-left: $gu-h-spacing / 2;
+  padding-bottom: $gu-v-spacing * 2;
+  padding-top: $gu-v-spacing * 2;
   width: 100%;
   box-sizing: border-box;
 }

--- a/assets/components/ui/uiButton/uiButton.jsx
+++ b/assets/components/ui/uiButton/uiButton.jsx
@@ -20,25 +20,22 @@ In that case you can use the `trackingOnClick` prop.
 
 // ---- Types ----- //
 
-type PropTypes = {|
+type PropTypes = {
   children: Node,
   icon?: Node,
-  type: 'submit' | 'button',
-  href: ?string,
-  disabled: boolean,
   isStatic: boolean,
+  href: ?string,
   appearance: 'primary' | 'green' | 'greenHollow' | 'greyHollow',
   iconSide: 'left' | 'right',
-  onClick: ?(void => void),
   trackingOnClick: ?(void => void),
-  accessibilityHint: ?string,
-|};
+  onClick: ?(void => void),
+};
 
 
 // ----- Render ----- //
 
 const UiButton = ({
-  children, icon, type, onClick, href, disabled, trackingOnClick, appearance, iconSide, isStatic, accessibilityHint,
+  children, icon, type, onClick, href, disabled, trackingOnClick, appearance, iconSide, isStatic, ...otherProps
 }: PropTypes) => {
 
   const getClassName = (modifiers: string[] = []) =>
@@ -60,11 +57,10 @@ const UiButton = ({
   } else if (href) {
     return (
       <a
-        href={href}
-        data-disabled={disabled}
-        aria-label={accessibilityHint}
         className={getClassName()}
         onClick={trackingOnClick}
+        href={href}
+        {...otherProps}
       >
         <span className="component-ui-button__content">{children}</span>
         {icon}
@@ -73,10 +69,8 @@ const UiButton = ({
   }
   return (
     <button
-      disabled={disabled}
+      {...otherProps}
       onClick={(ev) => { if (onClick) { onClick(ev); } if (trackingOnClick) { trackingOnClick(); } }}
-      aria-label={accessibilityHint}
-      type={type}
       className={getClassName()}
     >
       <span className="component-ui-button__content">{children}</span>
@@ -87,15 +81,12 @@ const UiButton = ({
 
 UiButton.defaultProps = {
   icon: <SvgArrowRightStraight />,
-  type: 'button',
-  onClick: null,
   trackingOnClick: null,
   href: null,
-  accessibilityHint: null,
-  disabled: false,
   isStatic: false,
   appearance: 'primary',
   iconSide: 'right',
+  onClick: null,
 };
 
 export default UiButton;

--- a/assets/components/ui/uiButton/uiButton.jsx
+++ b/assets/components/ui/uiButton/uiButton.jsx
@@ -31,13 +31,14 @@ type PropTypes = {|
   iconSide: 'left' | 'right',
   onClick: ?(void => void),
   trackingOnClick: ?(void => void),
+  accessibilityHint: ?string,
 |};
 
 
 // ----- Render ----- //
 
 const UiButton = ({
-  children, icon, type, onClick, href, disabled, trackingOnClick, appearance, iconSide, isStatic,
+  children, icon, type, onClick, href, disabled, trackingOnClick, appearance, iconSide, isStatic, accessibilityHint,
 }: PropTypes) => {
 
   const getClassName = (modifiers: string[] = []) =>
@@ -61,6 +62,7 @@ const UiButton = ({
       <a
         href={href}
         data-disabled={disabled}
+        aria-label={accessibilityHint}
         className={getClassName()}
         onClick={trackingOnClick}
       >
@@ -73,6 +75,7 @@ const UiButton = ({
     <button
       disabled={disabled}
       onClick={(ev) => { if (onClick) { onClick(ev); } if (trackingOnClick) { trackingOnClick(); } }}
+      aria-label={accessibilityHint}
       type={type}
       className={getClassName()}
     >
@@ -88,6 +91,7 @@ UiButton.defaultProps = {
   onClick: null,
   trackingOnClick: null,
   href: null,
+  accessibilityHint: null,
   disabled: false,
   isStatic: false,
   appearance: 'primary',

--- a/assets/components/ui/uiButton/uiButton.jsx
+++ b/assets/components/ui/uiButton/uiButton.jsx
@@ -20,16 +20,19 @@ In that case you can use the `trackingOnClick` prop.
 
 // ---- Types ----- //
 
-type PropTypes = {
+type PropTypes = {|
   children: Node,
   icon?: Node,
-  isStatic: boolean,
+  type: 'submit' | 'button',
   href: ?string,
+  disabled: boolean,
+  isStatic: boolean,
   appearance: 'primary' | 'green' | 'greenHollow' | 'greyHollow',
   iconSide: 'left' | 'right',
-  trackingOnClick: ?(void => void),
   onClick: ?(void => void),
-};
+  trackingOnClick: ?(void => void),
+  'aria-label': ?string,
+|};
 
 
 // ----- Render ----- //
@@ -57,10 +60,10 @@ const UiButton = ({
   } else if (href) {
     return (
       <a
+        href={href}
+        data-disabled={disabled}
         className={getClassName()}
         onClick={trackingOnClick}
-        href={href}
-        {...otherProps}
       >
         <span className="component-ui-button__content">{children}</span>
         {icon}
@@ -69,9 +72,11 @@ const UiButton = ({
   }
   return (
     <button
-      {...otherProps}
+      disabled={disabled}
       onClick={(ev) => { if (onClick) { onClick(ev); } if (trackingOnClick) { trackingOnClick(); } }}
+      type={type}
       className={getClassName()}
+      {...otherProps}
     >
       <span className="component-ui-button__content">{children}</span>
       {icon}
@@ -81,12 +86,15 @@ const UiButton = ({
 
 UiButton.defaultProps = {
   icon: <SvgArrowRightStraight />,
+  type: 'button',
+  onClick: null,
   trackingOnClick: null,
   href: null,
+  disabled: false,
   isStatic: false,
   appearance: 'primary',
   iconSide: 'right',
-  onClick: null,
+  'aria-label': null, // eslint-disable-line react/default-props-match-prop-types
 };
 
 export default UiButton;

--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -8,7 +8,7 @@ import { type Option } from 'helpers/types/option';
 import type { Participations } from 'helpers/abTests/abtest';
 import { type OptimizeExperiments } from 'helpers/optimize/optimize';
 import { getBaseDomain } from 'helpers/url';
-import { Annual, Quarterly, SixForSix, type WeeklyBillingPeriod } from 'helpers/billingPeriods';
+import { Annual, Quarterly, SixForSix, Monthly, type WeeklyBillingPeriod, type DigitalBillingPeriod } from 'helpers/billingPeriods';
 import type { PaperBillingPlan, SubscriptionProduct } from 'helpers/subscriptions';
 
 import { getIntcmp, getPromoCode } from './flashSale';
@@ -274,6 +274,7 @@ function getDigitalCheckout(
   referringCta: ?string,
   nativeAbParticipations: Participations,
   optimizeExperiments: OptimizeExperiments,
+  billingPeriod: DigitalBillingPeriod = Monthly,
 ): string {
   const acquisitionData = deriveSubsAcquisitionData(
     referrerAcquisitionData,
@@ -287,6 +288,9 @@ function getDigitalCheckout(
   params.set('countryGroup', countryGroups[cgId].supportInternationalisationId);
   params.set('startTrialButton', referringCta || '');
 
+  if (billingPeriod === Annual) {
+    return `${subsUrl}/checkout/digitalpack-digitalpackannual?${params.toString()}`;
+  }
   return `${subsUrl}/checkout?${params.toString()}`;
 }
 

--- a/assets/pages/digital-subscription-landing/components/ctaAbTestWrapper.jsx
+++ b/assets/pages/digital-subscription-landing/components/ctaAbTestWrapper.jsx
@@ -8,7 +8,7 @@ import OptimizeExperimentWrapper from 'components/optimizeExperimentWrapper/opti
 
 // ----- Component ----- //
 
-const experimentId = '222';
+const experimentId = 'urMo75xQR8y0xRlULWdEVg';
 
 function CtaAbTestWrapper({ children }: {children: Node}) {
 

--- a/assets/pages/digital-subscription-landing/components/ctaAbTestWrapper.jsx
+++ b/assets/pages/digital-subscription-landing/components/ctaAbTestWrapper.jsx
@@ -1,0 +1,26 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React, { type Node } from 'react';
+
+import OptimizeExperimentWrapper from 'components/optimizeExperimentWrapper/optimizeExperimentWrapper';
+
+// ----- Component ----- //
+
+const experimentId = '12244652354235';
+
+function CtaAbTestWrapper({ children }: {children: Node}) {
+
+  return (
+    <OptimizeExperimentWrapper experimentId={experimentId}>
+      {children}
+    </OptimizeExperimentWrapper>
+  );
+
+}
+
+
+// ----- Exports ----- //
+
+export default CtaAbTestWrapper;

--- a/assets/pages/digital-subscription-landing/components/ctaAbTestWrapper.jsx
+++ b/assets/pages/digital-subscription-landing/components/ctaAbTestWrapper.jsx
@@ -8,7 +8,7 @@ import OptimizeExperimentWrapper from 'components/optimizeExperimentWrapper/opti
 
 // ----- Component ----- //
 
-const experimentId = '12244652354235';
+const experimentId = '222';
 
 function CtaAbTestWrapper({ children }: {children: Node}) {
 

--- a/assets/pages/digital-subscription-landing/components/ctaSwitch.jsx
+++ b/assets/pages/digital-subscription-landing/components/ctaSwitch.jsx
@@ -30,7 +30,6 @@ function CtaSwitch(props: { referringCta: string }) {
   return (
     <CtaAbTestWrapper>
       {PriceCta}
-      {PriceCta}
       <div />
     </CtaAbTestWrapper>
   );

--- a/assets/pages/digital-subscription-landing/components/ctaSwitch.jsx
+++ b/assets/pages/digital-subscription-landing/components/ctaSwitch.jsx
@@ -5,11 +5,9 @@
 import React from 'react';
 
 import { flashSaleIsActive } from 'helpers/flashSale';
-import OptimizeExperimentWrapper from 'components/optimizeExperimentWrapper/optimizeExperimentWrapper';
+import CtaAbTestWrapper from './ctaAbTestWrapper';
 import PriceCtaContainer from './priceCtaContainer';
 import FindOutMoreCta from './findOutMoreCta';
-
-import { experimentId } from '../helpers/ctaTypeAb';
 
 import { showUpgradeMessage } from '../helpers/upgradePromotion';
 
@@ -30,11 +28,11 @@ function CtaSwitch(props: { referringCta: string }) {
   );
 
   return (
-    <OptimizeExperimentWrapper experimentId={experimentId}>
+    <CtaAbTestWrapper>
       {PriceCta}
       {PriceCta}
       <div />
-    </OptimizeExperimentWrapper>
+    </CtaAbTestWrapper>
   );
 
 }

--- a/assets/pages/digital-subscription-landing/components/ctaSwitch.jsx
+++ b/assets/pages/digital-subscription-landing/components/ctaSwitch.jsx
@@ -5,8 +5,11 @@
 import React from 'react';
 
 import { flashSaleIsActive } from 'helpers/flashSale';
+import OptimizeExperimentWrapper from 'components/optimizeExperimentWrapper/optimizeExperimentWrapper';
 import PriceCtaContainer from './priceCtaContainer';
 import FindOutMoreCta from './findOutMoreCta';
+
+import { experimentId } from '../helpers/ctaTypeAb';
 
 import { showUpgradeMessage } from '../helpers/upgradePromotion';
 
@@ -19,12 +22,19 @@ function CtaSwitch(props: { referringCta: string }) {
     return <FindOutMoreCta />;
   }
 
+  const PriceCta = (<PriceCtaContainer
+    ctaText={flashSaleIsActive('DigitalPack') ? 'Start your 14-day free trial' : null}
+    referringCta={props.referringCta}
+    secondaryCopy="You can cancel your subscription at any time"
+  />
+  );
+
   return (
-    <PriceCtaContainer
-      ctaText={flashSaleIsActive('DigitalPack') ? 'Start your 14-day free trial' : null}
-      referringCta={props.referringCta}
-      secondaryCopy="You can cancel your subscription at any time"
-    />
+    <OptimizeExperimentWrapper experimentId={experimentId}>
+      {PriceCta}
+      {PriceCta}
+      <div />
+    </OptimizeExperimentWrapper>
   );
 
 }

--- a/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
+++ b/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
@@ -15,7 +15,6 @@ import GridPicture, {
 import { type ImageId as GridId } from 'helpers/theGrid';
 
 import SvgChevron from 'components/svgs/chevron';
-import OptimizeExperimentWrapper from 'components/optimizeExperimentWrapper/optimizeExperimentWrapper';
 import { CirclesLeft, CirclesRight } from 'components/svgs/digitalSubscriptionLandingHeaderCircles';
 import UiButton from 'components/ui/uiButton/uiButton';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
@@ -23,8 +22,8 @@ import { displayPrice, sendTrackingEventsOnClick, type SubscriptionProduct } fro
 import { flashSaleIsActive, getSaleCopy } from 'helpers/flashSale';
 
 import CtaSwitch from './ctaSwitch';
+import CtaAbTestWrapper from './ctaAbTestWrapper';
 import { showUpgradeMessage } from '../helpers/upgradePromotion';
-import { experimentId } from '../helpers/ctaTypeAb';
 
 // ----- Types ----- //
 
@@ -188,13 +187,13 @@ export default function DigitalSubscriptionLandingHeader(props: PropTypes) {
             />
           </div>
         }
-        <OptimizeExperimentWrapper experimentId={experimentId}>
+        <CtaAbTestWrapper>
           <CtaSwitch referringCta="support_digipack_page_header" />
           <CtaSwitch referringCta="support_digipack_page_header" />
           <div className="digital-subscription-landing-header__cta">
             <UiButton trackingOnClick={sendTrackingEventsOnClick('options_cta_click', 'DigitalPack', null)} icon={<SvgChevron />} href="#subscribe">See Subscription options</UiButton>
           </div>
-        </OptimizeExperimentWrapper>
+        </CtaAbTestWrapper>
       </LeftMarginSection>
     </div>
   );

--- a/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
+++ b/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
@@ -13,12 +13,18 @@ import GridPicture, {
   type Source as GridSource,
 } from 'components/gridPicture/gridPicture';
 import { type ImageId as GridId } from 'helpers/theGrid';
+
+import SvgChevron from 'components/svgs/chevron';
+import OptimizeExperimentWrapper from 'components/optimizeExperimentWrapper/optimizeExperimentWrapper';
 import { CirclesLeft, CirclesRight } from 'components/svgs/digitalSubscriptionLandingHeaderCircles';
+import UiButton from 'components/ui/uiButton/uiButton';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import { displayPrice, type SubscriptionProduct } from 'helpers/subscriptions';
+import { displayPrice, sendTrackingEventsOnClick, type SubscriptionProduct } from 'helpers/subscriptions';
 import { flashSaleIsActive, getSaleCopy } from 'helpers/flashSale';
+
 import CtaSwitch from './ctaSwitch';
 import { showUpgradeMessage } from '../helpers/upgradePromotion';
+import { experimentId } from '../helpers/ctaTypeAb';
 
 // ----- Types ----- //
 
@@ -182,7 +188,13 @@ export default function DigitalSubscriptionLandingHeader(props: PropTypes) {
             />
           </div>
         }
-        <CtaSwitch referringCta="support_digipack_page_header" />
+        <OptimizeExperimentWrapper experimentId={experimentId}>
+          <CtaSwitch referringCta="support_digipack_page_header" />
+          <CtaSwitch referringCta="support_digipack_page_header" />
+          <div className="digital-subscription-landing-header__cta">
+            <UiButton trackingOnClick={sendTrackingEventsOnClick('options_cta_click', 'DigitalPack', null)} icon={<SvgChevron />} href="#subscribe">See Subscription options</UiButton>
+          </div>
+        </OptimizeExperimentWrapper>
       </LeftMarginSection>
     </div>
   );

--- a/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
+++ b/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
@@ -189,7 +189,6 @@ export default function DigitalSubscriptionLandingHeader(props: PropTypes) {
         }
         <CtaAbTestWrapper>
           <CtaSwitch referringCta="support_digipack_page_header" />
-          <CtaSwitch referringCta="support_digipack_page_header" />
           <div className="digital-subscription-landing-header__cta">
             <UiButton trackingOnClick={sendTrackingEventsOnClick('options_cta_click', 'DigitalPack', null)} icon={<SvgChevron />} href="#subscribe">See Subscription options</UiButton>
           </div>

--- a/assets/pages/digital-subscription-landing/components/form.jsx
+++ b/assets/pages/digital-subscription-landing/components/form.jsx
@@ -1,0 +1,78 @@
+// @flow
+
+// ----- Imports ----- //
+
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { currencies, detect } from 'helpers/internationalisation/currency';
+import type { WeeklyBillingPeriod } from 'helpers/billingPeriods';
+import { Annual, Quarterly, SixForSix } from 'helpers/billingPeriods';
+import { getPromotionWeeklyProductPrice, getWeeklyProductPrice } from 'helpers/subscriptions';
+import { type Action } from 'components/productPage/productPagePlanForm/productPagePlanFormActions';
+import ProductPagePlanForm, {
+  type DispatchPropTypes,
+  type StatePropTypes,
+} from 'components/productPage/productPagePlanForm/productPagePlanForm';
+
+import { type State } from '../digitalSubscriptionLandingReducer';
+import { redirectToWeeklyPage, setPlan } from '../digitalSubscriptionLandingActions';
+
+
+// ---- Plans ----- //
+
+const getPrice = (countryGroupId: CountryGroupId, period: WeeklyBillingPeriod) => [
+  currencies[detect(countryGroupId)].extendedGlyph,
+  getWeeklyProductPrice(countryGroupId, period),
+].join('');
+
+const getPromotionPrice = (countryGroupId: CountryGroupId, period: WeeklyBillingPeriod, promoCode: string) => [
+  currencies[detect(countryGroupId)].extendedGlyph,
+  getPromotionWeeklyProductPrice(countryGroupId, period, promoCode),
+].join('');
+
+export const billingPeriods = {
+  [SixForSix]: {
+    title: '6 for 6',
+    offer: 'Introductory offer',
+    copy: (countryGroupId: CountryGroupId) => `${getPrice(countryGroupId, 'SixForSix')} for the first 6 issues (then ${getPrice(countryGroupId, 'Quarterly')} quarterly)`,
+  },
+  [Quarterly]: {
+    title: 'Quarterly',
+    copy: (countryGroupId: CountryGroupId) => `${getPrice(countryGroupId, 'Quarterly')} every 3 months`,
+  },
+  [Annual]: {
+    title: 'Annually',
+    offer: 'Save 10%',
+    copy: (countryGroupId: CountryGroupId) => `${getPromotionPrice(countryGroupId, 'Annual', '10ANNUAL')} for 1 year, then standard rate (${getPrice(countryGroupId, 'Annual')} every year)`,
+  },
+};
+
+
+// ----- State/Props Maps ----- //
+
+const mapStateToProps = (state: State): StatePropTypes<WeeklyBillingPeriod> => ({
+  plans: Object.keys(billingPeriods).reduce((ps, k) => ({
+    ...ps,
+    [k]: {
+      title: billingPeriods[k].title,
+      copy: billingPeriods[k].copy(state.common.internationalisation.countryGroupId),
+      offer: billingPeriods[k].offer || null,
+      price: null,
+      saving: null,
+    },
+  }), {}),
+  selectedPlan: state.page.plan.plan,
+});
+
+const mapDispatchToProps = (dispatch: Dispatch<Action<WeeklyBillingPeriod>>): DispatchPropTypes<WeeklyBillingPeriod> =>
+  ({
+    setPlanAction: bindActionCreators(setPlan, dispatch),
+    onSubmitAction: bindActionCreators(redirectToWeeklyPage, dispatch),
+  });
+
+
+// ----- Exports ----- //
+
+export default connect(mapStateToProps, mapDispatchToProps)(ProductPagePlanForm);

--- a/assets/pages/digital-subscription-landing/components/independentJournalismSection.scss
+++ b/assets/pages/digital-subscription-landing/components/independentJournalismSection.scss
@@ -1,5 +1,5 @@
 .component-independent-journalism {
-  font-family: $gu-headline;
+  @include gu-fontset-heading;
   border-top: 1px solid gu-colour(neutral-4);
   color: #121212;
   @include mq($from: desktop) {
@@ -17,27 +17,20 @@
 
 .component-independent-journalism__header {
   width: 100%;
-  font-size: 26px;
   font-weight: bold;
-  line-height: 1.12;
 
   @include mq($from: leftCol) {
-    width: 620px;
-    font-size: 36px;
-    line-height: 1.17;
+    width: gu-span(6);
   }
 }
 
 .component-independent-journalism__copy {
   width: 100%;
-  font-size: 22px;
   font-weight: 300;
-  line-height: 1.18;
   padding-right: 18px;
   @include mq($from: leftCol) {
-    width: 620px;
-    font-size: 36px;
-    line-height: 1.11;
+    width: gu-span(6);
+    margin-right: gu-span(2);
   }
 }
 
@@ -55,7 +48,7 @@
 
 .svg-windrush {
   position: relative;
-  top: -81px;
+  top: -51px;
   margin-bottom: -143px;
   z-index: 1;
   @include mq($until: leftCol) {

--- a/assets/pages/digital-subscription-landing/components/independentJournalismSection.scss
+++ b/assets/pages/digital-subscription-landing/components/independentJournalismSection.scss
@@ -1,6 +1,5 @@
 .component-independent-journalism {
   @include gu-fontset-heading;
-  border-top: 1px solid gu-colour(neutral-4);
   color: #121212;
   @include mq($from: desktop) {
     border-left: 1px solid gu-colour(garnett-neutral-4);

--- a/assets/pages/digital-subscription-landing/components/independentJournalismSection.scss
+++ b/assets/pages/digital-subscription-landing/components/independentJournalismSection.scss
@@ -1,5 +1,6 @@
 .component-independent-journalism {
   font-family: $gu-headline;
+  border-top: 1px solid gu-colour(neutral-4);
   color: #121212;
   @include mq($from: desktop) {
     border-left: 1px solid gu-colour(garnett-neutral-4);

--- a/assets/pages/digital-subscription-landing/components/promotionPopUp.jsx
+++ b/assets/pages/digital-subscription-landing/components/promotionPopUp.jsx
@@ -11,7 +11,7 @@ import SvgChevron from 'components/svgs/chevron';
 import { classNameWithModifiers } from 'helpers/utilities';
 import { type Action, closePopUp } from './promotionPopUpActions';
 import { expandOption, type PromotionOptions } from './promotionPopUpActions';
-import { type State } from './promotionPopUpReducer';
+import { type State } from '../digitalSubscriptionLandingReducer';
 
 type PropTypes = {|
   isPopUpOpen: boolean,
@@ -24,8 +24,8 @@ type PropTypes = {|
 
 function mapStateToProps(state: State) {
   return {
-    isPopUpOpen: state.page.isPopUpOpen,
-    expandedOption: state.page.expandedOption,
+    isPopUpOpen: state.page.promotion.isPopUpOpen,
+    expandedOption: state.page.promotion.expandedOption,
   };
 }
 

--- a/assets/pages/digital-subscription-landing/components/promotionPopUpReducer.js
+++ b/assets/pages/digital-subscription-landing/components/promotionPopUpReducer.js
@@ -2,7 +2,6 @@
 
 // ----- Imports ----- //
 
-import { type CommonState } from 'helpers/page/commonReducer';
 import type { Action, PromotionOptions } from './promotionPopUpActions';
 
 // ----- Setup ----- //
@@ -10,11 +9,6 @@ import type { Action, PromotionOptions } from './promotionPopUpActions';
 export type FindOutMoreState = {
   isPopUpOpen: boolean,
   expandedOption: PromotionOptions,
-};
-
-export type State = {
-  common: CommonState,
-  page: FindOutMoreState,
 };
 
 const initialState: FindOutMoreState = {

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -9,6 +9,7 @@ import { renderPage } from 'helpers/render';
 import { detect, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { init as pageInit } from 'helpers/page/page';
 
+import OptimizeExperimentWrapper from 'components/optimizeExperimentWrapper/optimizeExperimentWrapper';
 import Page from 'components/page/page';
 import simpleHeaderWithCountrySwitcherContainer from 'components/headers/simpleHeader/simpleHeaderWithCountrySwitcher';
 import CustomerService from 'components/customerService/customerService';
@@ -25,6 +26,7 @@ import ProductBlock from './components/productBlock';
 import PromotionPopUp from './components/promotionPopUp';
 import digitalSubscriptionLandingReducer from './digitalSubscriptionLandingReducer';
 import Form from './components/form';
+import { experimentId } from './helpers/ctaTypeAb';
 
 import './digitalSubscriptionLanding.scss';
 
@@ -72,15 +74,19 @@ const content = (
       />
       <ProductBlock countryGroupId={countryGroupId} />
       <AdFreeSection headingSize={2} />
-      <ProductPageContentBlock type="feature" id="subscribe">
-        <ProductPageTextBlock title="Subscribe to Guardian Weekly today">
-          <p>Choose how you’d like to pay</p>
-        </ProductPageTextBlock>
-        <Form />
-        <ProductPageInfoChip >
+      <OptimizeExperimentWrapper experimentId={experimentId}>
+        <div />
+        <div />
+        <ProductPageContentBlock type="feature" id="subscribe">
+          <ProductPageTextBlock title="Subscribe to Guardian Weekly today">
+            <p>Choose how you’d like to pay</p>
+          </ProductPageTextBlock>
+          <Form />
+          <ProductPageInfoChip >
               You can cancel your subscription at any time
-        </ProductPageInfoChip>
-      </ProductPageContentBlock>
+          </ProductPageInfoChip>
+        </ProductPageContentBlock>
+      </OptimizeExperimentWrapper>
       <IndependentJournalismSection />
       <PromotionPopUp />
     </Page>

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -75,7 +75,6 @@ const content = (
       <AdFreeSection headingSize={2} />
       <CtaAbTestWrapper>
         <div />
-        <div />
         <ProductPageContentBlock type="feature" id="subscribe">
           <ProductPageTextBlock title="Subscribe to Digital Pack today">
             <p>Choose how you’d like to pay</p>

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -20,10 +20,13 @@ import IndependentJournalismSection from './components/independentJournalismSect
 import ProductBlock from './components/productBlock';
 import PromotionPopUp from './components/promotionPopUp';
 import digitalSubscriptionLandingReducer from './digitalSubscriptionLandingReducer';
+import Form from './components/form';
+
+import './digitalSubscriptionLanding.scss';
 
 // ----- Redux Store ----- //
 
-const store = pageInit(digitalSubscriptionLandingReducer(null));
+const store = pageInit(digitalSubscriptionLandingReducer(null), true);
 
 // ----- Internationalisation ----- //
 
@@ -63,6 +66,7 @@ const content = (
       <DigitalSubscriptionLandingHeader
         countryGroupId={countryGroupId}
       />
+      <Form />
       <ProductBlock countryGroupId={countryGroupId} />
       <AdFreeSection headingSize={2} />
       <IndependentJournalismSection />

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -9,7 +9,6 @@ import { renderPage } from 'helpers/render';
 import { detect, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { init as pageInit } from 'helpers/page/page';
 
-import OptimizeExperimentWrapper from 'components/optimizeExperimentWrapper/optimizeExperimentWrapper';
 import Page from 'components/page/page';
 import simpleHeaderWithCountrySwitcherContainer from 'components/headers/simpleHeader/simpleHeaderWithCountrySwitcher';
 import CustomerService from 'components/customerService/customerService';
@@ -26,7 +25,7 @@ import ProductBlock from './components/productBlock';
 import PromotionPopUp from './components/promotionPopUp';
 import digitalSubscriptionLandingReducer from './digitalSubscriptionLandingReducer';
 import Form from './components/form';
-import { experimentId } from './helpers/ctaTypeAb';
+import CtaAbTestWrapper from './components/ctaAbTestWrapper';
 
 import './digitalSubscriptionLanding.scss';
 
@@ -74,7 +73,7 @@ const content = (
       />
       <ProductBlock countryGroupId={countryGroupId} />
       <AdFreeSection headingSize={2} />
-      <OptimizeExperimentWrapper experimentId={experimentId}>
+      <CtaAbTestWrapper>
         <div />
         <div />
         <ProductPageContentBlock type="feature" id="subscribe">
@@ -86,7 +85,7 @@ const content = (
               You can cancel your subscription at any time
           </ProductPageInfoChip>
         </ProductPageContentBlock>
-      </OptimizeExperimentWrapper>
+      </CtaAbTestWrapper>
       <IndependentJournalismSection />
       <PromotionPopUp />
     </Page>

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -78,7 +78,7 @@ const content = (
         <div />
         <div />
         <ProductPageContentBlock type="feature" id="subscribe">
-          <ProductPageTextBlock title="Subscribe to Guardian Weekly today">
+          <ProductPageTextBlock title="Subscribe to Digital Pack today">
             <p>Choose how you’d like to pay</p>
           </ProductPageTextBlock>
           <Form />

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -19,12 +19,11 @@ import DigitalSubscriptionLandingHeader from './components/digitalSubscriptionLa
 import IndependentJournalismSection from './components/independentJournalismSection';
 import ProductBlock from './components/productBlock';
 import PromotionPopUp from './components/promotionPopUp';
-import promotionPopUpReducer from './components/promotionPopUpReducer';
-
+import digitalSubscriptionLandingReducer from './digitalSubscriptionLandingReducer';
 
 // ----- Redux Store ----- //
 
-const store = pageInit(promotionPopUpReducer);
+const store = pageInit(digitalSubscriptionLandingReducer(null));
 
 // ----- Internationalisation ----- //
 

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -15,6 +15,10 @@ import CustomerService from 'components/customerService/customerService';
 import SubscriptionFaq from 'components/subscriptionFaq/subscriptionFaq';
 import Footer from 'components/footer/footer';
 import AdFreeSection from 'components/adFreeSection/adFreeSection';
+import ProductPageContentBlock from 'components/productPage/productPageContentBlock/productPageContentBlock';
+import ProductPageTextBlock from 'components/productPage/productPageTextBlock/productPageTextBlock';
+import ProductPageInfoChip from 'components/productPage/productPageInfoChip/productPageInfoChip';
+
 import DigitalSubscriptionLandingHeader from './components/digitalSubscriptionLandingHeader';
 import IndependentJournalismSection from './components/independentJournalismSection';
 import ProductBlock from './components/productBlock';
@@ -66,8 +70,16 @@ const content = (
       <DigitalSubscriptionLandingHeader
         countryGroupId={countryGroupId}
       />
-      <Form />
       <ProductBlock countryGroupId={countryGroupId} />
+      <ProductPageContentBlock type="feature" id="subscribe">
+        <ProductPageTextBlock title="Subscribe to Guardian Weekly today">
+          <p>Choose how you’d like to pay</p>
+        </ProductPageTextBlock>
+        <Form />
+        <ProductPageInfoChip >
+              You can cancel your subscription at any time
+        </ProductPageInfoChip>
+      </ProductPageContentBlock>
       <AdFreeSection headingSize={2} />
       <IndependentJournalismSection />
       <PromotionPopUp />

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -71,6 +71,7 @@ const content = (
         countryGroupId={countryGroupId}
       />
       <ProductBlock countryGroupId={countryGroupId} />
+      <AdFreeSection headingSize={2} />
       <ProductPageContentBlock type="feature" id="subscribe">
         <ProductPageTextBlock title="Subscribe to Guardian Weekly today">
           <p>Choose how you’d like to pay</p>
@@ -80,7 +81,6 @@ const content = (
               You can cancel your subscription at any time
         </ProductPageInfoChip>
       </ProductPageContentBlock>
-      <AdFreeSection headingSize={2} />
       <IndependentJournalismSection />
       <PromotionPopUp />
     </Page>

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -256,7 +256,9 @@
       border-top: 1px solid #fff;
     }
     .component-price-cta__secondary {
-      border-left: 1px solid gu-colour(garnett-neutral-4);
+      color: gu-colour(garnett-neutral-3);
+      padding: ($gu-v-spacing / 2) 0;
+      font-size: .9em;
     }
     .component-flash-sale-countdown {
       z-index: 10;

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -22,6 +22,10 @@
 
 // ----- Page-Specific Styles ----- //
 
+:root {
+  scroll-behavior: smooth;
+}
+
 #digital-subscription-landing-page-int,
 #digital-subscription-landing-page-uk,
 #digital-subscription-landing-page-us,
@@ -290,6 +294,13 @@
     }
   }
 
+  .digital-subscription-landing-header__cta {
+    position: relative;
+    background-color: gu-colour(garnett-neutral-1);
+    border-top: 1px solid #fff;
+    padding: $gu-v-spacing $gu-v-spacing;
+  }
+
   .digital-subscription-landing-header__product {
     background-color: gu-colour(news-garnett-highlight);
     position: absolute;
@@ -441,4 +452,5 @@
 
 .component-left-margin-section--grey {
   background: gu-colour(neutral-6);
+  overflow: hidden;
 }

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -137,6 +137,7 @@
 
   .product-block__copy {
     padding: 0 ($gu-h-spacing / 2) $gu-v-spacing;
+    font-size: 17px;
   }
 
   .product-block__product-heading {
@@ -150,22 +151,20 @@
 
   .product-block__product-description {
     margin: $gu-v-spacing / 2 0 $gu-v-spacing;
-    font-size: 16px;
     line-height: 1.25;
     font-family: $gu-headline;
   }
 
   .component-feature-list {
-    font-size: 16px;
     line-height: 1.25;
     font-family: $gu-headline;
     list-style-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 10 10"><circle cx="5" cy="5" r="5" fill="#ff4e36"/></svg>');
     margin-left: 26px;
-    display: flex;
-    flex-flow: column wrap;
 
-    @include mq($from: leftCol) {
-      height: 200px;
+    @include mq($from: desktop) {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      grid-row-gap: $gu-v-spacing;
     }
 
   }
@@ -179,8 +178,8 @@
   .component-feature-list__item {
     margin-bottom: $gu-v-spacing / 2;
 
-    @include mq($from: leftCol) {
-      width: 200px;
+    @include mq($from: desktop) {
+      padding-right: 40px;
     }
   }
 

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLandingActions.js
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLandingActions.js
@@ -1,10 +1,13 @@
 // @flow
 
 // ----- Imports ----- //
+import { type Dispatch } from 'redux';
 
 import { type DigitalBillingPeriod } from 'helpers/billingPeriods';
 import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
 import { ProductPagePlanFormActionsFor } from 'components/productPage/productPagePlanForm/productPagePlanFormActions';
+import { getDigitalCheckout } from 'helpers/externalLinks';
+import { type State } from './digitalSubscriptionLandingReducer';
 
 
 // ----- Action Creators ----- //
@@ -12,8 +15,20 @@ import { ProductPagePlanFormActionsFor } from 'components/productPage/productPag
 const { setPlan } = ProductPagePlanFormActionsFor<DigitalBillingPeriod>('GuardianWeekly', 'GuardianWeekly');
 
 function redirectToDigitalPage() {
-  return () => {
-    const location = null;
+  return (dispatch: Dispatch<any>, getState: () => State) => {
+
+    const state = getState();
+
+    const { countryGroupId } = state.common.internationalisation;
+    const { referrerAcquisitionData, abParticipations, optimizeExperiments } = state.common;
+
+    const location = getDigitalCheckout(
+      referrerAcquisitionData,
+      countryGroupId,
+      null,
+      abParticipations,
+      optimizeExperiments,
+    );
 
     if (location) {
       sendTrackingEventsOnClick('main_cta_click', 'DigitalPack', null)();

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLandingActions.js
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLandingActions.js
@@ -2,34 +2,21 @@
 
 // ----- Imports ----- //
 
-import { type WeeklyBillingPeriod } from 'helpers/billingPeriods';
-import { getWeeklyCheckout } from 'helpers/externalLinks';
+import { type DigitalBillingPeriod } from 'helpers/billingPeriods';
 import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
 import { ProductPagePlanFormActionsFor } from 'components/productPage/productPagePlanForm/productPagePlanFormActions';
-import { getPromoCode } from 'helpers/flashSale';
 
-import { type State } from './digitalSubscriptionLandingReducer';
 
 // ----- Action Creators ----- //
 
-const { setPlan } = ProductPagePlanFormActionsFor<WeeklyBillingPeriod>('GuardianWeekly', 'GuardianWeekly');
+const { setPlan } = ProductPagePlanFormActionsFor<DigitalBillingPeriod>('GuardianWeekly', 'GuardianWeekly');
 
-function redirectToWeeklyPage() {
-  return (dispatch: Function, getState: () => State) => {
-    const state = getState();
-    const { countryGroupId } = state.common.internationalisation;
-    const { referrerAcquisitionData, abParticipations, optimizeExperiments } = state.common;
-    const location = state.page.plan.plan ? getWeeklyCheckout(
-      referrerAcquisitionData,
-      state.page.plan.plan,
-      countryGroupId,
-      abParticipations,
-      optimizeExperiments,
-      (state.page.plan === 'Annual' ? getPromoCode('GuardianWeekly', countryGroupId, '10ANNUAL') : null),
-    ) : null;
+function redirectToDigitalPage() {
+  return () => {
+    const location = null;
 
     if (location) {
-      sendTrackingEventsOnClick('main_cta_click', 'GuardianWeekly', null)();
+      sendTrackingEventsOnClick('main_cta_click', 'DigitalPack', null)();
       window.location.href = location;
     }
   };
@@ -38,4 +25,4 @@ function redirectToWeeklyPage() {
 
 // ----- Exports ----- //
 
-export { setPlan, redirectToWeeklyPage };
+export { setPlan, redirectToDigitalPage };

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLandingActions.js
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLandingActions.js
@@ -21,17 +21,20 @@ function redirectToDigitalPage() {
 
     const { countryGroupId } = state.common.internationalisation;
     const { referrerAcquisitionData, abParticipations, optimizeExperiments } = state.common;
+    const { plan } = state.page.plan;
 
-    const location = getDigitalCheckout(
-      referrerAcquisitionData,
-      countryGroupId,
-      null,
-      abParticipations,
-      optimizeExperiments,
-    );
+    if (plan) {
 
-    if (location) {
-      sendTrackingEventsOnClick('main_cta_click', 'DigitalPack', null)();
+      const location = getDigitalCheckout(
+        referrerAcquisitionData,
+        countryGroupId,
+        null,
+        abParticipations,
+        optimizeExperiments,
+        plan,
+      );
+
+      sendTrackingEventsOnClick(`main_cta_click_${plan}`, 'DigitalPack', null)();
       window.location.href = location;
     }
   };

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLandingActions.js
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLandingActions.js
@@ -1,0 +1,41 @@
+// @flow
+
+// ----- Imports ----- //
+
+import { type WeeklyBillingPeriod } from 'helpers/billingPeriods';
+import { getWeeklyCheckout } from 'helpers/externalLinks';
+import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
+import { ProductPagePlanFormActionsFor } from 'components/productPage/productPagePlanForm/productPagePlanFormActions';
+import { getPromoCode } from 'helpers/flashSale';
+
+import { type State } from './digitalSubscriptionLandingReducer';
+
+// ----- Action Creators ----- //
+
+const { setPlan } = ProductPagePlanFormActionsFor<WeeklyBillingPeriod>('GuardianWeekly', 'GuardianWeekly');
+
+function redirectToWeeklyPage() {
+  return (dispatch: Function, getState: () => State) => {
+    const state = getState();
+    const { countryGroupId } = state.common.internationalisation;
+    const { referrerAcquisitionData, abParticipations, optimizeExperiments } = state.common;
+    const location = state.page.plan.plan ? getWeeklyCheckout(
+      referrerAcquisitionData,
+      state.page.plan.plan,
+      countryGroupId,
+      abParticipations,
+      optimizeExperiments,
+      (state.page.plan === 'Annual' ? getPromoCode('GuardianWeekly', countryGroupId, '10ANNUAL') : null),
+    ) : null;
+
+    if (location) {
+      sendTrackingEventsOnClick('main_cta_click', 'GuardianWeekly', null)();
+      window.location.href = location;
+    }
+  };
+}
+
+
+// ----- Exports ----- //
+
+export { setPlan, redirectToWeeklyPage };

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLandingReducer.js
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLandingReducer.js
@@ -1,0 +1,35 @@
+// @flow
+
+// ----- Imports ----- //
+
+import { combineReducers } from 'redux';
+import type { CommonState } from 'helpers/page/commonReducer';
+import { type WeeklyBillingPeriod } from 'helpers/billingPeriods';
+import {
+  ProductPagePlanFormReducerFor,
+  type State as FormState,
+} from 'components/productPage/productPagePlanForm/productPagePlanFormReducer';
+import promotionPopUpReducer, { type FindOutMoreState } from './components/promotionPopUpReducer';
+
+export type State = {
+  common: CommonState,
+  page: {
+    plan: FormState<WeeklyBillingPeriod>,
+    promotion: FindOutMoreState
+  }
+};
+
+
+// ----- Export ----- //
+
+export default (promoInUrl: ?string) => {
+
+  const initialPeriod: WeeklyBillingPeriod = promoInUrl === 'SixForSix' || promoInUrl === 'Quarterly' || promoInUrl === 'Annual'
+    ? promoInUrl
+    : 'SixForSix';
+
+  return combineReducers({
+    plan: ProductPagePlanFormReducerFor<WeeklyBillingPeriod>('GuardianWeekly', initialPeriod),
+    promotion: promotionPopUpReducer,
+  });
+};

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLandingReducer.js
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLandingReducer.js
@@ -4,7 +4,7 @@
 
 import { combineReducers } from 'redux';
 import type { CommonState } from 'helpers/page/commonReducer';
-import { type WeeklyBillingPeriod } from 'helpers/billingPeriods';
+import { type DigitalBillingPeriod } from 'helpers/billingPeriods';
 import {
   ProductPagePlanFormReducerFor,
   type State as FormState,
@@ -14,7 +14,7 @@ import promotionPopUpReducer, { type FindOutMoreState } from './components/promo
 export type State = {
   common: CommonState,
   page: {
-    plan: FormState<WeeklyBillingPeriod>,
+    plan: FormState<DigitalBillingPeriod>,
     promotion: FindOutMoreState
   }
 };
@@ -24,12 +24,12 @@ export type State = {
 
 export default (promoInUrl: ?string) => {
 
-  const initialPeriod: WeeklyBillingPeriod = promoInUrl === 'SixForSix' || promoInUrl === 'Quarterly' || promoInUrl === 'Annual'
+  const initialPeriod: DigitalBillingPeriod = promoInUrl === 'Monthly' || promoInUrl === 'Annual'
     ? promoInUrl
-    : 'SixForSix';
+    : 'Annual';
 
   return combineReducers({
-    plan: ProductPagePlanFormReducerFor<WeeklyBillingPeriod>('GuardianWeekly', initialPeriod),
+    plan: ProductPagePlanFormReducerFor<DigitalBillingPeriod>('GuardianWeekly', initialPeriod),
     promotion: promotionPopUpReducer,
   });
 };

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLandingReducer.js
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLandingReducer.js
@@ -24,12 +24,12 @@ export type State = {
 
 export default (promoInUrl: ?string) => {
 
-  const initialPeriod: DigitalBillingPeriod = promoInUrl === 'Monthly' || promoInUrl === 'Annual'
+  const initialPeriod: ?DigitalBillingPeriod = promoInUrl === 'Monthly' || promoInUrl === 'Annual'
     ? promoInUrl
-    : 'Annual';
+    : null;
 
   return combineReducers({
-    plan: ProductPagePlanFormReducerFor<DigitalBillingPeriod>('GuardianWeekly', initialPeriod),
+    plan: ProductPagePlanFormReducerFor<?DigitalBillingPeriod>('GuardianWeekly', initialPeriod),
     promotion: promotionPopUpReducer,
   });
 };

--- a/assets/pages/digital-subscription-landing/helpers/ctaTypeAb.js
+++ b/assets/pages/digital-subscription-landing/helpers/ctaTypeAb.js
@@ -1,1 +1,0 @@
-export const experimentId = '12244652354235';

--- a/assets/pages/digital-subscription-landing/helpers/ctaTypeAb.js
+++ b/assets/pages/digital-subscription-landing/helpers/ctaTypeAb.js
@@ -1,0 +1,1 @@
+export const experimentId = '12244652354235';


### PR DESCRIPTION
## Why are you doing this?
Sorry for the massive PR,  this updates the DP page to accommodate the AB test about choosing frequency on the page itself. ([trello](https://trello.com/c/vavDkdpk/1983-show-monthly-and-annual-pricing-options-on-dp-product-page)) Doing this comes with some caveats:

- The redux store's shape has been changed to allow for the selected pack to be stored
- The design has been tweaked all over for both variants in terms of fonts and sizes to match the new templates. (thanks @jesseyuen !!!)
- The ad-free block is white now so as to not outshine the payment options block, which makes it a bit weird on the original variant.
- I've tweaked the optimize component to be able to pass a `force_optimize_ab_variant` parameter to enrol yourself in a variant id in testing, this only applies if there's no test running but I can undo this if needed.

## Screenshots
### Control
![screenshot 2019-01-16 at 1 49 00 pm](https://user-images.githubusercontent.com/11539094/51253373-facbea00-1995-11e9-855d-743b57a8d2f5.png)

### Variant
![screenshot 2019-01-16 at 1 48 52 pm](https://user-images.githubusercontent.com/11539094/51253368-f9022680-1995-11e9-8fa0-fea594d45e10.png)

### How does it look with css grid disabled?
The bullet points stack:

<img width="927" alt="screenshot 2019-01-17 at 12 37 38 pm" src="https://user-images.githubusercontent.com/11539094/51319367-bd7a6180-1a54-11e9-926d-eba784a6867a.png">
