### PR TITLE
remove warnings alarm - this will come from a dashboard in future

### DIFF
--- a/cloud-formation/cfn.yaml
+++ b/cloud-formation/cfn.yaml
@@ -299,25 +299,6 @@ Resources:
     - TargetGroup
     - ElasticLoadBalancer
 
-  HighWarningAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Condition: CreateProdResources
-    Properties:
-      AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
-      AlarmName: !Sub Warnings support-frontend in ${Stage}
-      AlarmDescription: This alerts when non critical events happen. These should be dealt with in the next sprint.
-      MetricName: WarningCount
-      Namespace: support-frontend
-      Dimensions:
-        - Name: Stage
-          Value: !Sub ${Stage}
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      Threshold: 3
-      Period: 60
-      EvaluationPeriods: 2
-      Statistic: Sum
-
   StateMachineUnavailableMetric:
     Type: "AWS::Logs::MetricFilter"
     Properties:


### PR DESCRIPTION
## Why are you doing this?
We have decided that email should only be used for alarms that need an instant response.  The warnings will be analysed at the end of the previous sprint through a new Cloudwatch Dashboard in AWS.  We can then plan into a sprint.
[**Trello Card**](https://trello.com)

@joelochlann @tomrf1 @jranks123 