### PR TITLE
return a bad request if we know the request to /subscribe/digital/create is missing information

### DIFF
--- a/app/controllers/DigitalSubscription.scala
+++ b/app/controllers/DigitalSubscription.scala
@@ -105,6 +105,16 @@ class DigitalSubscription(
     )
   }
 
+  sealed trait CreateDigitalSubscriptionError {
+    def asString: String
+  }
+  case class ServerError(message: String) extends CreateDigitalSubscriptionError {
+    override def asString: String = message
+  }
+  case class RequestValidationError(message: String) extends CreateDigitalSubscriptionError {
+    override def asString: String = message
+  }
+
   def create: Action[CreateSupportWorkersRequest] =
     authenticatedAction(recurringIdentityClientId).async(circe.json[CreateSupportWorkersRequest]) {
       implicit request: AuthRequest[CreateSupportWorkersRequest] =>
@@ -112,13 +122,19 @@ class DigitalSubscription(
         SafeLogger.info(s"[${request.uuid}] User ${request.user.id} is attempting to create a new $billingPeriod digital subscription")
 
         if (validationPasses(request.body)) {
-          val result: EitherT[Future, String, StatusResponse] = for {
-            user <- identityService.getUser(request.user)
-            statusResponse <- client.createSubscription(request, createUser(user, request.body), request.uuid).leftMap(_.toString)
+          val userOrError: EitherT[Future, CreateDigitalSubscriptionError, IdUser] = identityService.getUser(request.user).leftMap(ServerError(_))
+          def subscriptionStatusOrError(idUser: IdUser): EitherT[Future, CreateDigitalSubscriptionError, StatusResponse] = {
+            client.createSubscription(request, createUser(idUser, request.body), request.uuid).leftMap(error => ServerError(error.toString))
+          }
+
+          val result: EitherT[Future, CreateDigitalSubscriptionError, StatusResponse] = for {
+            user <- identityService.getUser(request.user).leftMap(ServerError(_))
+            statusResponse <- subscriptionStatusOrError(user)
           } yield statusResponse
+
           respondToClient(result, request.body.product.billingPeriod)
         } else {
-          respondToClient(EitherT.leftT("validation of the request body failed"), request.body.product.billingPeriod)
+          respondToClient(EitherT.leftT(RequestValidationError("validation of the request body failed")), request.body.product.billingPeriod)
         }
 
     }
@@ -139,13 +155,16 @@ class DigitalSubscription(
   }
 
   protected def respondToClient(
-    result: EitherT[Future, String, StatusResponse],
+    result: EitherT[Future, CreateDigitalSubscriptionError, StatusResponse],
     billingPeriod: BillingPeriod
   )(implicit request: AuthRequest[CreateSupportWorkersRequest]): Future[Result] =
     result.fold(
       { error =>
         SafeLogger.error(scrub"[${request.uuid}] Failed to create new $billingPeriod Digital Subscription, due to $error")
-        InternalServerError
+        error match {
+          case _: RequestValidationError => BadRequest
+          case _: ServerError => InternalServerError
+        }
       },
       { statusResponse =>
         SafeLogger.info(s"[${request.uuid}] Successfully created a support workers execution for a new $billingPeriod Digital Subscription")

--- a/app/controllers/DigitalSubscription.scala
+++ b/app/controllers/DigitalSubscription.scala
@@ -123,7 +123,7 @@ class DigitalSubscription(
             client.createSubscription(request, createUser(idUser, request.body), request.uuid).leftMap(error => ServerError(error.toString))
           }
 
-          val result: EitherT[Future, CreateDigitalSubscriptionError, StatusResponse] = for {
+          val result: ApiResponseOrError[StatusResponse] = for {
             user <- userOrError
             statusResponse <- subscriptionStatusOrError(user)
           } yield statusResponse

--- a/app/controllers/DigitalSubscription.scala
+++ b/app/controllers/DigitalSubscription.scala
@@ -105,7 +105,7 @@ class DigitalSubscription(
     )
   }
 
-  sealed class CreateDigitalSubscriptionError(message: String)
+  sealed abstract class CreateDigitalSubscriptionError(message: String)
   case class ServerError(message: String) extends CreateDigitalSubscriptionError(message)
   case class RequestValidationError(message: String) extends CreateDigitalSubscriptionError(message)
 


### PR DESCRIPTION
## Why are you doing this?
In the digital pack checkout, we want to add some server side validation in case the client side validation doesn't run for some reason. 

Currently, if the first name or last name comes through as an empty string in the request, we wish to just short circuit and return an error because it's not even worth trying to create a digital subscription. Some basic request body validation was added here: https://github.com/guardian/support-frontend/pull/1367

But if the validation fails, we should return a 400 rather than a 500.

That way, we can display a more useful error message to the user, prompting them to check the details they gave us in the form, rather than the default "Sorry, something has gone wrong." message. 

That's what this PR is about. 

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/tr3TQ4YH/2033-server-side-validation)

## Changes

* If a request to `POST /subscribe/digital/create` has a request body that fails the request body validation added in https://github.com/guardian/support-frontend/pull/1367, it will return a 400 (handled on the client side already here: https://github.com/guardian/support-frontend/blob/master/assets/helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis.js#L180)

## Screenshots
 
![image](https://user-images.githubusercontent.com/3072877/51332543-d8a89980-1a73-11e9-9a54-9e59f12b3e7f.png)

 