### PR TITLE
Check state and that payment fields are nonempty in server side validation for the digital pack checkout

### DIFF
--- a/app/utils/SimpleValidator.scala
+++ b/app/utils/SimpleValidator.scala
@@ -1,6 +1,7 @@
 package utils
 
 import com.gu.i18n.Country
+import com.gu.support.workers.{DirectDebitPaymentFields, PaymentFields, StripePaymentFields}
 import services.stepfunctions.CreateSupportWorkersRequest
 
 object SimpleValidator {
@@ -14,6 +15,12 @@ object SimpleValidator {
       } else true
     }
 
-    noEmptyNameFields && hasStateIfRequired
+    def noEmptyPaymentFields: Boolean = request.paymentFields match {
+      case directDebitDetails: DirectDebitPaymentFields =>
+        !directDebitDetails.accountHolderName.isEmpty && !directDebitDetails.accountNumber.isEmpty && !directDebitDetails.sortCode.isEmpty
+      case stripeDetails: StripePaymentFields => !stripeDetails.stripeToken.isEmpty
+    }
+
+    noEmptyNameFields && hasStateIfRequired && noEmptyPaymentFields
   }
 }

--- a/app/utils/SimpleValidator.scala
+++ b/app/utils/SimpleValidator.scala
@@ -1,10 +1,19 @@
 package utils
 
+import com.gu.i18n.Country
 import services.stepfunctions.CreateSupportWorkersRequest
 
 object SimpleValidator {
 
   def validationPasses(request: CreateSupportWorkersRequest): Boolean = {
-    !request.firstName.isEmpty && !request.lastName.isEmpty
+    val noEmptyNameFields = !request.firstName.isEmpty && !request.lastName.isEmpty
+
+    def hasStateIfRequired: Boolean = {
+      if (request.country == Country.US || request.country == Country.Canada) {
+        request.state.isDefined
+      } else true
+    }
+
+    noEmptyNameFields && hasStateIfRequired
   }
 }

--- a/test/utils/SimpleValidatorTest.scala
+++ b/test/utils/SimpleValidatorTest.scala
@@ -45,4 +45,9 @@ class SimpleValidatorTest extends FlatSpec with Matchers {
     SimpleValidator.validationPasses(requestMissingState) shouldBe true
   }
 
+  "validate" should "fail if the payment field received is an empty string" in {
+    val requestMissingState = validRequest.copy(paymentFields = StripePaymentFields(""))
+    SimpleValidator.validationPasses(requestMissingState) shouldBe false
+  }
+
 }

--- a/test/utils/SimpleValidatorTest.scala
+++ b/test/utils/SimpleValidatorTest.scala
@@ -30,4 +30,19 @@ class SimpleValidatorTest extends FlatSpec with Matchers {
     SimpleValidator.validationPasses(requestMissingFirstName) shouldBe false
   }
 
+  "validate" should "fail if the country is US and there is no state selected" in {
+    val requestMissingState = validRequest.copy(state = None)
+    SimpleValidator.validationPasses(requestMissingState) shouldBe false
+  }
+
+  "validate" should "also fail if the country is Canada and there is no state selected" in {
+    val requestMissingState = validRequest.copy(country = Country.Canada, state = None)
+    SimpleValidator.validationPasses(requestMissingState) shouldBe false
+  }
+
+  "validate" should "pass if there is no state selected and the country is Australia" in {
+    val requestMissingState = validRequest.copy(country = Country.Australia, state = None)
+    SimpleValidator.validationPasses(requestMissingState) shouldBe true
+  }
+
 }


### PR DESCRIPTION
## Why are you doing this?

On calls to `POST /subscribe/digital/create`, we may know based on the request body that there is no point in triggering the call to create a digital subscription. 

https://github.com/guardian/support-frontend/pull/1367 (and others) added validation so that if firstName or lastName are empty, we return an error (and display an error to the user).

We should also get the user to check their details if they select Canada or the US, but they do not select a state, so this PR adds that check. Also added is that payment details received by `POST /subscribe/digital/create` are not empty strings. 

Note that even if country is left unselected, we default it to the UK here: https://github.com/guardian/support-frontend/blob/master/assets/pages/digital-subscription-checkout/helpers/paymentProviders.js#L41

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/tr3TQ4YH/2033-server-side-validation)

## Changes

* In our server side validation for the digital pack checkout, if the selected country is Canada or the US, there needs to be a value for state. 
* Payment fields cannot be empty

## Screenshots

![image](https://user-images.githubusercontent.com/3072877/51336892-9421fb80-1a7d-11e9-921a-61915245120b.png)

(error message will be more specific about checking the fields provided in the form after https://github.com/guardian/support-frontend/pull/1373 is merged)

(vs making a request to create a digital subscription that will inevitably fail when creating the zuora subscription)