### PR TITLE
Refactor config

### DIFF
--- a/app/admin/Settings.scala
+++ b/app/admin/Settings.scala
@@ -84,7 +84,7 @@ object SettingsSource extends LazyLogging {
       .leftMap(err => new Error(s"settingsSource was not correctly set in config. $err"))
 
   private def fromLocalFile(config: Config, name: String): Either[Throwable, SettingsSource] = Either.catchNonFatal {
-    val localFile = expandHomeDirectory(config.getString(s"settings.$name.local.path"))
+    val localFile = expandHomeDirectory(config.getString(s"settingsSource.$name.local.path"))
     if (Files.exists(Paths.get(localFile))) {
       logger.info(s"Loading settings from $localFile")
       LocalFile(localFile)
@@ -101,8 +101,8 @@ object SettingsSource extends LazyLogging {
 
   private def fromS3(config: Config, name: String): Either[Throwable, SettingsSource] = Either.catchNonFatal {
     S3(
-      config.getString(s"settings.$name.s3.bucket"),
-      config.getString(s"settings.$name.s3.key")
+      config.getString(s"settingsSource.$name.s3.bucket"),
+      config.getString(s"settingsSource.$name.s3.key")
     )
   }
 

--- a/app/admin/SettingsProvider.scala
+++ b/app/admin/SettingsProvider.scala
@@ -129,7 +129,8 @@ object S3SettingsProvider {
 
 object SettingsProvider {
 
-  def fromAppConfig[T: Decoder](settingsSource: SettingsSource, config: Configuration)(implicit client: AmazonS3, system: ActorSystem, wsClient: WSClient): Either[Throwable, SettingsProvider[T]] = {
+  def fromAppConfig[T: Decoder](settingsSource: SettingsSource, config: Configuration)
+                               (implicit client: AmazonS3, system: ActorSystem, wsClient: WSClient): Either[Throwable, SettingsProvider[T]] = {
     SafeLogger.info(s"loading settings from $settingsSource")
     settingsSource match {
       case s3: SettingsSource.S3 => S3SettingsProvider.fromS3[T](s3, config.fastlyConfig)

--- a/app/admin/SettingsProvider.scala
+++ b/app/admin/SettingsProvider.scala
@@ -129,8 +129,7 @@ object S3SettingsProvider {
 
 object SettingsProvider {
 
-  def fromAppConfig[T: Decoder](settingsSource: SettingsSource, config: Configuration)
-                               (implicit client: AmazonS3, system: ActorSystem, wsClient: WSClient): Either[Throwable, SettingsProvider[T]] = {
+  def fromAppConfig[T: Decoder](settingsSource: SettingsSource, config: Configuration)(implicit client: AmazonS3, system: ActorSystem, wsClient: WSClient): Either[Throwable, SettingsProvider[T]] = {
     SafeLogger.info(s"loading settings from $settingsSource")
     settingsSource match {
       case s3: SettingsSource.S3 => S3SettingsProvider.fromS3[T](s3, config.fastlyConfig)

--- a/app/config/Configuration.scala
+++ b/app/config/Configuration.scala
@@ -1,6 +1,6 @@
 package config
 
-import admin.SettingsSource
+import admin.{SettingsSource, SettingsSources}
 import cats.syntax.either._
 import com.gu.support.config.{PayPalConfigProvider, Stage, StripeConfigProvider}
 import com.typesafe.config.ConfigFactory
@@ -41,7 +41,7 @@ class Configuration {
 
   lazy val stepFunctionArn = StateMachineArn.fromString(config.getString("supportWorkers.arn")).get
 
-  lazy val settingsSource: SettingsSource = SettingsSource.fromConfig(config).valueOr(throw _)
+  lazy val settingsSources: SettingsSources = SettingsSources.fromConfig(config).valueOr(throw _)
 
   lazy val fastlyConfig: Option[FastlyConfig] = FastlyConfig.fromConfig(config).valueOr(throw _)
 }

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import actions.CustomActionBuilders
-import admin.{ServersideAbTest, Settings, SettingsProvider, SettingsSurrogateKeySyntax}
+import admin.{ServersideAbTest, AllSettings, AllSettingsProvider, SettingsSurrogateKeySyntax}
 import assets.AssetsResolver
 import cats.data.EitherT
 import cats.implicits._
@@ -31,7 +31,7 @@ class Application(
     payPalConfigProvider: PayPalConfigProvider,
     paymentAPIService: PaymentAPIService,
     stringsConfig: StringsConfig,
-    settingsProvider: SettingsProvider,
+    settingsProvider: AllSettingsProvider,
     guardianDomain: GuardianDomain
 )(implicit val ec: ExecutionContext) extends AbstractController(components) with SettingsSurrogateKeySyntax with StrictLogging with ServersideAbTestCookie {
 
@@ -88,7 +88,7 @@ class Application(
   }
 
   def supportLanding(): Action[AnyContent] = CachedAction() { implicit request =>
-    implicit val settings: Settings = settingsProvider.settings()
+    implicit val settings: AllSettings = settingsProvider.getAllSettings()
     Ok(views.html.main(
       title = "Support the Guardian",
       mainId = "support-landing-page",
@@ -101,14 +101,14 @@ class Application(
 
   def contributionsLanding(countryCode: String): Action[AnyContent] = maybeAuthenticatedAction().async { implicit request =>
     type Attempt[A] = EitherT[Future, String, A]
-    implicit val settings: Settings = settingsProvider.settings()
+    implicit val settings: AllSettings = settingsProvider.getAllSettings()
     request.user.traverse[Attempt, IdUser](identityService.getUser(_)).fold(
       _ => Ok(contributionsHtml(countryCode, None)),
       user => Ok(contributionsHtml(countryCode, user))
     ).map(_.withSettingsSurrogateKey)
   }
 
-  private def contributionsHtml(countryCode: String, idUser: Option[IdUser])(implicit request: RequestHeader, settings: Settings) = {
+  private def contributionsHtml(countryCode: String, idUser: Option[IdUser])(implicit request: RequestHeader, settings: AllSettings) = {
     views.html.newContributions(
       title = "Support the Guardian | Make a Contribution",
       id = s"new-contributions-landing-page-$countryCode",
@@ -128,7 +128,7 @@ class Application(
   }
 
   def showcase: Action[AnyContent] = CachedAction() { implicit request =>
-    implicit val settings: Settings = settingsProvider.settings()
+    implicit val settings: AllSettings = settingsProvider.getAllSettings()
     Ok(views.html.main(
       title = "Support the Guardian",
       mainId = "showcase-landing-page",
@@ -139,7 +139,7 @@ class Application(
   }
 
   def reactTemplate(title: String, id: String, js: String, css: String): Action[AnyContent] = CachedAction() { implicit request =>
-    implicit val settings: Settings = settingsProvider.settings()
+    implicit val settings: AllSettings = settingsProvider.getAllSettings()
     Ok(views.html.main(title, id, js, css)).withSettingsSurrogateKey
   }
 

--- a/app/controllers/DigitalSubscription.scala
+++ b/app/controllers/DigitalSubscription.scala
@@ -2,7 +2,7 @@ package controllers
 
 import actions.CustomActionBuilders
 import actions.CustomActionBuilders.AuthRequest
-import admin.{Settings, SettingsProvider, SettingsSurrogateKeySyntax}
+import admin.{AllSettings, AllSettingsProvider, SettingsSurrogateKeySyntax}
 import assets.AssetsResolver
 import cats.data.EitherT
 import cats.implicits._
@@ -37,7 +37,7 @@ class DigitalSubscription(
     payPalConfigProvider: PayPalConfigProvider,
     components: ControllerComponents,
     stringsConfig: StringsConfig,
-    settingsProvider: SettingsProvider,
+    settingsProvider: AllSettingsProvider,
     val supportUrl: String,
     tipMonitoring: Tip,
     guardianDomain: GuardianDomain
@@ -48,7 +48,7 @@ class DigitalSubscription(
   implicit val a: AssetsResolver = assets
 
   def digital(countryCode: String): Action[AnyContent] = CachedAction() { implicit request =>
-    implicit val settings: Settings = settingsProvider.settings()
+    implicit val settings: AllSettings = settingsProvider.getAllSettings()
     val title = "Support the Guardian | Digital Pack Subscription"
     val id = "digital-subscription-landing-page-" + countryCode
     val js = "digitalSubscriptionLandingPage.js"
@@ -69,7 +69,7 @@ class DigitalSubscription(
 
   def displayForm(countryCode: String, displayCheckout: Boolean, isCsrf: Boolean = false): Action[AnyContent] =
     authenticatedAction(recurringIdentityClientId).async { implicit request =>
-      implicit val settings: Settings = settingsProvider.settings()
+      implicit val settings: AllSettings = settingsProvider.getAllSettings()
       if (displayCheckout) {
         identityService.getUser(request.user).fold(
           error => {
@@ -83,7 +83,7 @@ class DigitalSubscription(
       }
     }
 
-  private def digitalSubscriptionFormHtml(idUser: IdUser, countryCode: String)(implicit request: RequestHeader, settings: Settings): Html = {
+  private def digitalSubscriptionFormHtml(idUser: IdUser, countryCode: String)(implicit request: RequestHeader, settings: AllSettings): Html = {
     val title = "Support the Guardian | Digital Subscription"
     val id = "digital-subscription-checkout-page-" + countryCode
     val js = "digitalSubscriptionCheckoutPage.js"

--- a/app/controllers/OneOffContributions.scala
+++ b/app/controllers/OneOffContributions.scala
@@ -16,7 +16,7 @@ import com.gu.identity.play.IdUser
 import models.Autofill
 import io.circe.syntax._
 import play.twirl.api.Html
-import admin.{Settings, SettingsProvider, SettingsSurrogateKeySyntax}
+import admin.{AllSettings, AllSettingsProvider, SettingsSurrogateKeySyntax}
 
 class OneOffContributions(
     val assets: AssetsResolver,
@@ -27,7 +27,7 @@ class OneOffContributions(
     paymentAPIService: PaymentAPIService,
     authAction: AuthAction[AnyContent],
     components: ControllerComponents,
-    settingsProvider: SettingsProvider
+    settingsProvider: AllSettingsProvider
 )(implicit val exec: ExecutionContext) extends AbstractController(components) with Circe with SettingsSurrogateKeySyntax {
 
   import actionRefiners._
@@ -41,7 +41,7 @@ class OneOffContributions(
     )
   }
 
-  private def formHtml(idUser: Option[IdUser])(implicit request: RequestHeader, settings: Settings) = {
+  private def formHtml(idUser: Option[IdUser])(implicit request: RequestHeader, settings: AllSettings) = {
     oneOffContributions(
       title = "Support the Guardian | Single Contribution",
       id = "oneoff-contributions-page",
@@ -56,7 +56,7 @@ class OneOffContributions(
   }
 
   def displayForm(): Action[AnyContent] = maybeAuthenticatedAction().async { implicit request =>
-    implicit val settings: Settings = settingsProvider.settings()
+    implicit val settings: AllSettings = settingsProvider.getAllSettings()
     request.user
       .fold(Future.successful(Ok(formHtml(None)))) { minimalUser =>
         identityService.getUser(minimalUser).fold(

--- a/app/controllers/PayPalOneOff.scala
+++ b/app/controllers/PayPalOneOff.scala
@@ -12,7 +12,7 @@ import cats.data.EitherT
 import cats.implicits._
 import monitoring.SafeLogger
 import monitoring.PathVerification.{TipPath, PayPal, OneOffContribution, monitoredRegion, verify}
-import admin.{Settings, SettingsProvider, SettingsSurrogateKeySyntax}
+import admin.{AllSettings, AllSettingsProvider, SettingsSurrogateKeySyntax}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 import services.{IdentityService, PaymentAPIService, TestUserService}
@@ -25,7 +25,7 @@ class PayPalOneOff(
     components: ControllerComponents,
     paymentAPIService: PaymentAPIService,
     identityService: IdentityService,
-    settingsProvider: SettingsProvider,
+    settingsProvider: AllSettingsProvider,
     tipMonitoring: Tip
 )(implicit val ec: ExecutionContext) extends AbstractController(components) with Circe with SettingsSurrogateKeySyntax {
 
@@ -36,7 +36,7 @@ class PayPalOneOff(
   private val fallbackAcquisitionData: JsValue = JsObject(Seq("platform" -> JsString("SUPPORT")))
 
   def paypalError: Action[AnyContent] = PrivateAction { implicit request =>
-    implicit val settings: Settings = settingsProvider.settings()
+    implicit val settings: AllSettings = settingsProvider.getAllSettings()
     Ok(views.html.main(
       "Support the Guardian | PayPal Error",
       "paypal-error-page",

--- a/app/controllers/PayPalRegular.scala
+++ b/app/controllers/PayPalRegular.scala
@@ -12,7 +12,7 @@ import play.api.mvc._
 import services.paypal.PayPalBillingDetails.codec
 import services.paypal.{PayPalBillingDetails, PayPalNvpServiceProvider, Token}
 import services.{PayPalNvpService, TestUserService}
-import admin.{Settings, SettingsProvider, SettingsSurrogateKeySyntax}
+import admin.{AllSettings, AllSettingsProvider, SettingsSurrogateKeySyntax}
 
 import scala.concurrent.ExecutionContext
 
@@ -22,7 +22,7 @@ class PayPalRegular(
     payPalNvpServiceProvider: PayPalNvpServiceProvider,
     testUsers: TestUserService,
     components: ControllerComponents,
-    settingsProvider: SettingsProvider
+    settingsProvider: AllSettingsProvider
 )(implicit val ec: ExecutionContext) extends AbstractController(components) with Circe with SettingsSurrogateKeySyntax {
 
   import actionBuilders._
@@ -63,7 +63,7 @@ class PayPalRegular(
   // The endpoint corresponding to the PayPal return url, hit if the user is
   // redirected and needs to come back.
   def returnUrl: Action[AnyContent] = PrivateAction { implicit request =>
-    implicit val settings: Settings = settingsProvider.settings()
+    implicit val settings: AllSettings = settingsProvider.getAllSettings()
     SafeLogger.error(scrub"User hit the PayPal returnUrl.")
     Ok(views.html.main(
       "Support the Guardian | PayPal Error",
@@ -77,7 +77,7 @@ class PayPalRegular(
   // redirected and the payment fails.
   def cancelUrl: Action[AnyContent] = PrivateAction { implicit request =>
     SafeLogger.error(scrub"User hit the PayPal cancelUrl, something went wrong.")
-    implicit val settings: Settings = settingsProvider.settings()
+    implicit val settings: AllSettings = settingsProvider.getAllSettings()
     Ok(views.html.main(
       "Support the Guardian | PayPal Error",
       "paypal-error-page",

--- a/app/controllers/Subscriptions.scala
+++ b/app/controllers/Subscriptions.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import actions.CustomActionBuilders
-import admin.{Settings, SettingsProvider, SettingsSurrogateKeySyntax}
+import admin.{AllSettings, AllSettingsProvider, SettingsSurrogateKeySyntax}
 import assets.AssetsResolver
 import config.StringsConfig
 import play.api.mvc._
@@ -15,7 +15,7 @@ class Subscriptions(
     val assets: AssetsResolver,
     components: ControllerComponents,
     stringsConfig: StringsConfig,
-    settingsProvider: SettingsProvider,
+    settingsProvider: AllSettingsProvider,
     val supportUrl: String
 )(implicit val ec: ExecutionContext) extends AbstractController(components) with GeoRedirect with CanonicalLinks with SettingsSurrogateKeySyntax {
 
@@ -32,7 +32,7 @@ class Subscriptions(
   }
 
   def landing(countryCode: String): Action[AnyContent] = CachedAction() { implicit request =>
-    implicit val settings: Settings = settingsProvider.settings()
+    implicit val settings: AllSettings = settingsProvider.getAllSettings()
     val title = "Support the Guardian | Get a Subscription"
     val id = "subscriptions-landing-page"
     val js = "subscriptionsLandingPage.js"
@@ -47,7 +47,7 @@ class Subscriptions(
   }
 
   def premiumTier(countryCode: String): Action[AnyContent] = CachedAction() { implicit request =>
-    implicit val settings: Settings = settingsProvider.settings()
+    implicit val settings: AllSettings = settingsProvider.getAllSettings()
     val title = "Support the Guardian | Premium Tier"
     val id = "premium-tier-landing-page-" + countryCode
     val js = "premiumTierLandingPage.js"
@@ -58,7 +58,7 @@ class Subscriptions(
   def weeklyGeoRedirect: Action[AnyContent] = geoRedirectAllMarkets("subscribe/weekly")
 
   def weekly(countryCode: String): Action[AnyContent] = CachedAction() { implicit request =>
-    implicit val settings: Settings = settingsProvider.settings()
+    implicit val settings: AllSettings = settingsProvider.getAllSettings()
     val title = "The Guardian Weekly Subscriptions | The Guardian"
     val id = "weekly-landing-page-" + countryCode
     val js = "weeklySubscriptionLandingPage.js"
@@ -82,7 +82,7 @@ class Subscriptions(
   }
 
   def paper(withDelivery: Boolean = false): Action[AnyContent] = CachedAction() { implicit request =>
-    implicit val settings: Settings = settingsProvider.settings()
+    implicit val settings: AllSettings = settingsProvider.getAllSettings()
     val title = "The Guardian Newspaper Subscription | Vouchers and Delivery"
     val id = if (withDelivery) "paper-subscription-landing-page-delivery" else "paper-subscription-landing-page-collection"
     val js = "paperSubscriptionLandingPage.js"

--- a/app/lib/CustomHttpErrorHandler.scala
+++ b/app/lib/CustomHttpErrorHandler.scala
@@ -12,7 +12,7 @@ import play.api.mvc.Results.{InternalServerError, NotFound}
 import assets.AssetsResolver
 import views.html.main
 import play.core.SourceMapper
-import admin.{SettingsProvider, SettingsSurrogateKeySyntax}
+import admin.{AllSettingsProvider, SettingsSurrogateKeySyntax}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration._
@@ -23,7 +23,7 @@ class CustomHttpErrorHandler(
     sourceMapper: Option[SourceMapper],
     router: => Option[Router],
     val assets: AssetsResolver,
-    settingsProvider: SettingsProvider
+    settingsProvider: AllSettingsProvider
 )(implicit val ec: ExecutionContext) extends DefaultHttpErrorHandler(env, config, sourceMapper, router) with LazyLogging with SettingsSurrogateKeySyntax {
 
   override def onClientError(request: RequestHeader, statusCode: Int, message: String = ""): Future[Result] =
@@ -31,7 +31,7 @@ class CustomHttpErrorHandler(
 
   override protected def onNotFound(request: RequestHeader, message: String): Future[Result] =
     Future.successful(
-      NotFound(main("Error 404", "error-404-page", "error404Page.js", "error404Page.css")(assets, request, settingsProvider.settings()))
+      NotFound(main("Error 404", "error-404-page", "error404Page.js", "error404Page.css")(assets, request, settingsProvider.getAllSettings()))
         .withHeaders(CacheControl.defaultCacheHeaders(30.seconds, 30.seconds): _*)
         .withSettingsSurrogateKey
     )
@@ -39,7 +39,7 @@ class CustomHttpErrorHandler(
   override protected def onProdServerError(request: RequestHeader, exception: UsefulException): Future[Result] = {
     logServerError(request, exception)
     Future.successful(
-      InternalServerError(main("Error 500", "error-500-page", "error500Page.js", "error500Page.css")(assets, request, settingsProvider.settings()))
+      InternalServerError(main("Error 500", "error-500-page", "error500Page.js", "error500Page.css")(assets, request, settingsProvider.getAllSettings()))
         .withHeaders(CacheControl.noCache)
         .withSettingsSurrogateKey
     )

--- a/app/views/ViewHelpers.scala
+++ b/app/views/ViewHelpers.scala
@@ -2,8 +2,8 @@ package views
 
 import play.api.mvc.RequestHeader
 import play.twirl.api.{HtmlFormat, Html}
-import admin.Settings
-import codecs.CirceDecoders._
+import admin.AllSettings
+import admin.AllSettings.allSettingsCodec
 import io.circe.Printer
 import io.circe.syntax._
 
@@ -14,7 +14,7 @@ object ViewHelpers {
       case (key, value) =>
         Html(s"""data-${HtmlFormat.escape(key.replaceAll("[^a-zA-Z0-9\\-]", ""))}="${HtmlFormat.escape(value)}" """)
     }
-  def printSettings(settings: Settings): String =
+  def printSettings(settings: AllSettings): String =
     settings
       .asJson
       .pretty(Printer.spaces2.copy(dropNullValues = true))

--- a/app/views/digitalSubscription.scala.html
+++ b/app/views/digitalSubscription.scala.html
@@ -1,4 +1,4 @@
-@import admin.Settings
+@import admin.AllSettings
 @import assets.AssetsResolver
 @import com.gu.i18n.Currency.AUD
 @import com.gu.identity.play.IdUser
@@ -15,7 +15,7 @@
   defaultStripeConfig: StripeConfig,
   uatStripeConfig: StripeConfig,
   payPalConfig: PayPalConfig
-)(implicit assets: AssetsResolver, requestHeader: RequestHeader, settings: Settings)
+)(implicit assets: AssetsResolver, requestHeader: RequestHeader, settings: AllSettings)
 
   @scripts = {
     <script type="text/javascript">

--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -1,6 +1,6 @@
 @import assets.AssetsResolver
 @import views.ViewHelpers._
-@import admin.Settings
+@import admin.AllSettings
 
 @(
 	title: String,
@@ -14,7 +14,7 @@
 	scripts: Html = Html(""),
   data: Map[String, String] = Map.empty,
   csrf: Option[String] = None
-)(implicit assets: AssetsResolver, request: RequestHeader, settings: Settings)
+)(implicit assets: AssetsResolver, request: RequestHeader, settings: AllSettings)
 
 <!DOCTYPE html>
 <html lang="en">

--- a/app/views/newContributions.scala.html
+++ b/app/views/newContributions.scala.html
@@ -3,7 +3,7 @@
 @import com.gu.support.config._
 @import helper.CSRF
 @import com.gu.i18n.Currency.AUD
-@import admin.Settings
+@import admin.AllSettings
 @(
   title: String,
   id: String,
@@ -19,7 +19,7 @@
   paymentApiStripeEndpoint: String,
   paymentApiPayPalEndpoint: String,
   idUser: Option[IdUser]
-)(implicit assets: AssetsResolver, request: RequestHeader, settings: Settings)
+)(implicit assets: AssetsResolver, request: RequestHeader, settings: AllSettings)
 
 @scripts = {
   <script type="text/javascript">

--- a/app/views/oneOffContributions.scala.html
+++ b/app/views/oneOffContributions.scala.html
@@ -3,7 +3,7 @@
 @import com.gu.support.config.StripeConfig
 @import helper.CSRF
 @import com.gu.i18n.Currency.AUD
-@import admin.Settings
+@import admin.AllSettings
 @(
         title: String,
         id: String,
@@ -14,7 +14,7 @@
         paymentApiStripeEndpoint: String,
         paymentApiPayPalEndpoint: String,
         idUser: Option[IdUser]
-)(implicit assets: AssetsResolver, request: RequestHeader, settings: Settings, flash: Flash)
+)(implicit assets: AssetsResolver, request: RequestHeader, settings: AllSettings, flash: Flash)
 
 @scripts = {
     <script type="text/javascript">

--- a/app/views/optimizeScript.scala.html
+++ b/app/views/optimizeScript.scala.html
@@ -1,7 +1,7 @@
 @import assets.AssetsResolver
-@import admin.Settings
+@import admin.AllSettings
 @import admin.SwitchState
-@()(implicit assets: AssetsResolver, settings: Settings)
+@()(implicit assets: AssetsResolver, settings: AllSettings)
 @if(settings.switches.optimize == SwitchState.On) {
     <!--- Optimize scripts, see: https://support.google.com/optimize/answer/7359264 -->
     <!-- Page-hiding snippet -->

--- a/app/views/recurringContributions.scala.html
+++ b/app/views/recurringContributions.scala.html
@@ -4,7 +4,7 @@
 @import helper.CSRF
 
 @import com.gu.i18n.Currency.AUD
-@import admin.Settings
+@import admin.AllSettings
 @(
   title: String,
   id: String,
@@ -15,7 +15,7 @@
   defaultStripeConfig: StripeConfig,
   uatStripeConfig: StripeConfig,
   payPalConfig: PayPalConfig
-)(implicit assets: AssetsResolver, requestHeader: RequestHeader, settings: Settings)
+)(implicit assets: AssetsResolver, requestHeader: RequestHeader, settings: AllSettings)
 
 @scripts = {
     <script type="text/javascript">

--- a/app/views/settingsScript.scala.html
+++ b/app/views/settingsScript.scala.html
@@ -1,7 +1,7 @@
-@import admin.Settings
+@import admin.AllSettings
 @import views.ViewHelpers.printSettings
 
-@(settings: Settings)
+@(settings: AllSettings)
 
 <script type="text/javascript">
     window.guardian = window.guardian || {};

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -30,7 +30,7 @@ trait AppComponents extends PlayComponents
     sourceMapper,
     Some(router),
     assetsResolver,
-    settingsProvider
+    allSettingsProvider
   )
 
   override lazy val httpFilters: Seq[EssentialFilter] = Seq(

--- a/app/wiring/Controllers.scala
+++ b/app/wiring/Controllers.scala
@@ -22,7 +22,7 @@ trait Controllers {
     appConfig.regularPayPalConfigProvider,
     paymentAPIService,
     stringsConfig,
-    settingsProvider,
+    allSettingsProvider,
     appConfig.guardianDomain
   )
 
@@ -32,7 +32,7 @@ trait Controllers {
     assetsResolver,
     controllerComponents,
     stringsConfig,
-    settingsProvider,
+    allSettingsProvider,
     appConfig.supportUrl
   )
 
@@ -46,7 +46,7 @@ trait Controllers {
     appConfig.regularPayPalConfigProvider,
     controllerComponents,
     stringsConfig,
-    settingsProvider,
+    allSettingsProvider,
     appConfig.supportUrl,
     tipMonitoring,
     appConfig.guardianDomain
@@ -69,7 +69,7 @@ trait Controllers {
     appConfig.regularPayPalConfigProvider,
     controllerComponents,
     appConfig.guardianDomain,
-    settingsProvider,
+    allSettingsProvider,
     tipMonitoring
   )
 
@@ -79,7 +79,7 @@ trait Controllers {
     payPalNvpServiceProvider,
     testUsers,
     controllerComponents,
-    settingsProvider
+    allSettingsProvider
   )
 
   lazy val payPalOneOffController = new PayPalOneOff(
@@ -89,7 +89,7 @@ trait Controllers {
     controllerComponents,
     paymentAPIService,
     identityService,
-    settingsProvider,
+    allSettingsProvider,
     tipMonitoring
   )
 
@@ -102,7 +102,7 @@ trait Controllers {
     paymentAPIService,
     authAction,
     controllerComponents,
-    settingsProvider
+    allSettingsProvider
   )
 
   lazy val testUsersController = new TestUsersManagement(

--- a/app/wiring/Services.scala
+++ b/app/wiring/Services.scala
@@ -1,13 +1,13 @@
 package wiring
 
-import admin.SettingsProvider
+import admin.{AllSettingsProvider, SettingsProvider}
 import cats.syntax.either._
 import play.api.BuiltInComponentsFromContext
 import play.api.libs.ws.ahc.AhcWSComponents
 import services.{IdentityService, _}
 import services.aws.AwsS3Client.s3
 import services.paypal.PayPalNvpServiceProvider
-import services.stepfunctions.{Encryption, SupportWorkersClient, StateWrapper}
+import services.stepfunctions.{Encryption, StateWrapper, SupportWorkersClient}
 
 trait Services {
   self: BuiltInComponentsFromContext with AhcWSComponents with PlayComponents with ApplicationConfiguration =>
@@ -38,5 +38,5 @@ trait Services {
 
   lazy val paymentAPIService = new PaymentAPIService(wsClient, appConfig.paymentApiUrl)
 
-  lazy val settingsProvider: SettingsProvider = SettingsProvider.fromAppConfig(appConfig).valueOr(throw _)
+  lazy val allSettingsProvider: AllSettingsProvider = AllSettingsProvider.fromConfig(appConfig).valueOr(throw _)
 }

--- a/cloud-formation/cfn.yaml
+++ b/cloud-formation/cfn.yaml
@@ -109,6 +109,13 @@ Resources:
               - Effect: Allow
                 Action: s3:GetObject
                 Resource: !Sub arn:aws:s3:::support-frontend-admin-console/${Stage}/*
+        - PolicyName: SettingsBucket
+            PolicyDocument:
+              Version: 2012-10-17
+              Statement:
+              - Effect: Allow
+                Action: s3:GetObject
+                Resource: !Sub arn:aws:s3:::support-admin-console/${Stage}/*
         - PolicyName: UpdateSSHKeys
           PolicyDocument:
             Version: 2012-10-17

--- a/cloud-formation/cfn.yaml
+++ b/cloud-formation/cfn.yaml
@@ -108,14 +108,9 @@ Resources:
             Statement:
               - Effect: Allow
                 Action: s3:GetObject
-                Resource: !Sub arn:aws:s3:::support-frontend-admin-console/${Stage}/*
-        - PolicyName: SettingsBucket
-            PolicyDocument:
-              Version: 2012-10-17
-              Statement:
-              - Effect: Allow
-                Action: s3:GetObject
-                Resource: !Sub arn:aws:s3:::support-admin-console/${Stage}/*
+                Resource:
+                  - !Sub arn:aws:s3:::support-frontend-admin-console/${Stage}/*
+                  - !Sub arn:aws:s3:::support-admin-console/${Stage}/*
         - PolicyName: UpdateSSHKeys
           PolicyDocument:
             Version: 2012-10-17

--- a/conf/CODE.public.conf
+++ b/conf/CODE.public.conf
@@ -21,7 +21,7 @@ play.filters.headers.contentSecurityPolicy = "default-src 'self' www.paypalobjec
 # Settings configurable via the admin console
 settingsSource {
   switches.s3 {
-    bucket="support-frontend-admin-console"
+    bucket="support-admin-console"
     key= "CODE/switches.json"
   }
 }

--- a/conf/CODE.public.conf
+++ b/conf/CODE.public.conf
@@ -19,7 +19,9 @@ membersDataService.api.url="https://members-data-api.code.dev-theguardian.com"
 play.filters.headers.contentSecurityPolicy = "default-src 'self' www.paypalobjects.com www.paypal.com www.sandbox.paypal.com js.stripe.com pasteup.guim.co.uk ophan.theguardian.com j.ophan.co.uk media.guim.co.uk www.google-analytics.com www.googletagmanager.com tagmanager.google.com polyfill.io www.googleadservices.com googleads.g.doubleclick.net www.google.com www.google.co.uk optimize.google.com static.ads-twitter.com bat.bing.com bid.g.doubleclick.net t.co analytics.twitter.com stats.g.doubleclick.net www.youtube-nocookie.com connect.facebook.net www.facebook.com consumer.krxd.net cdn.krxd.net beacon.krxd.net secure.adnxs.com checkout.stripe.com fonts.googleapis.com ssl.gstatic.com www.gstatic.com fonts.gstatic.com sentry.io www.dwin1.com data: wss: 'unsafe-inline' q.stripe.com payment.code.dev-guardianapis.com https://interactive.guim.co.uk/"
 
 # Settings configurable via the admin console
-settingsSource.s3 {
-  bucket="support-frontend-admin-console"
-  key= "CODE/settings.json"
+settingsSource {
+  switches.s3 {
+    bucket="support-frontend-admin-console"
+    key= "CODE/switches.json"
+  }
 }

--- a/conf/DEV.public.conf
+++ b/conf/DEV.public.conf
@@ -18,7 +18,7 @@ paymentApi.url="https://payment.code.dev-guardianapis.com"
 membersDataService.api.url="https://members-data-api.thegulocal.com"
 play.filters.headers.contentSecurityPolicy = "default-src 'self' www.paypalobjects.com www.paypal.com www.sandbox.paypal.com js.stripe.com pasteup.guim.co.uk ophan.theguardian.com j.ophan.co.uk media.guim.co.uk www.google-analytics.com www.googletagmanager.com tagmanager.google.com polyfill.io www.googleadservices.com googleads.g.doubleclick.net www.google.com www.google.co.uk optimize.google.com static.ads-twitter.com bat.bing.com bid.g.doubleclick.net t.co analytics.twitter.com stats.g.doubleclick.net www.youtube-nocookie.com connect.facebook.net www.facebook.com consumer.krxd.net cdn.krxd.net beacon.krxd.net secure.adnxs.com checkout.stripe.com fonts.googleapis.com ssl.gstatic.com www.gstatic.com fonts.gstatic.com sentry.io www.dwin1.com data: wss: 'unsafe-inline' 'unsafe-eval'  q.stripe.com payment.code.dev-guardianapis.com https://interactive.guim.co.uk/"
 
-settings {
+settingsSource {
   switches {
     # Settings configurable via the admin console
     s3 {

--- a/conf/DEV.public.conf
+++ b/conf/DEV.public.conf
@@ -18,11 +18,16 @@ paymentApi.url="https://payment.code.dev-guardianapis.com"
 membersDataService.api.url="https://members-data-api.thegulocal.com"
 play.filters.headers.contentSecurityPolicy = "default-src 'self' www.paypalobjects.com www.paypal.com www.sandbox.paypal.com js.stripe.com pasteup.guim.co.uk ophan.theguardian.com j.ophan.co.uk media.guim.co.uk www.google-analytics.com www.googletagmanager.com tagmanager.google.com polyfill.io www.googleadservices.com googleads.g.doubleclick.net www.google.com www.google.co.uk optimize.google.com static.ads-twitter.com bat.bing.com bid.g.doubleclick.net t.co analytics.twitter.com stats.g.doubleclick.net www.youtube-nocookie.com connect.facebook.net www.facebook.com consumer.krxd.net cdn.krxd.net beacon.krxd.net secure.adnxs.com checkout.stripe.com fonts.googleapis.com ssl.gstatic.com www.gstatic.com fonts.gstatic.com sentry.io www.dwin1.com data: wss: 'unsafe-inline' 'unsafe-eval'  q.stripe.com payment.code.dev-guardianapis.com https://interactive.guim.co.uk/"
 
-# Settings configurable via the admin console
-settingsSource.s3 {
-  bucket="support-frontend-admin-console"
-  key= "DEV/settings.json"
+settings {
+  switches {
+    # Settings configurable via the admin console
+    s3 {
+      bucket="support-frontend-admin-console"
+      key="DEV/switches.json"
+    }
+    # To use local admin settings create this file (delete it to load from S3):
+    local {
+      path="~/.gu/support-frontend-admin-console/switches.json"
+    }
+  }
 }
-
-# To use local admin settings create this file (delete it to load from S3):
-settingsSource.local.path="~/.gu/support-frontend-admin-console/settings.json"

--- a/conf/DEV.public.conf
+++ b/conf/DEV.public.conf
@@ -22,12 +22,12 @@ settingsSource {
   switches {
     # Settings configurable via the admin console
     s3 {
-      bucket="support-frontend-admin-console"
+      bucket="support-admin-console"
       key="DEV/switches.json"
     }
     # To use local admin settings create this file (delete it to load from S3):
     local {
-      path="~/.gu/support-frontend-admin-console/switches.json"
+      path="~/.gu/support-admin-console/switches.json"
     }
   }
 }

--- a/conf/PROD.public.conf
+++ b/conf/PROD.public.conf
@@ -18,7 +18,9 @@ membersDataService.api.url="https://members-data-api.theguardian.com"
 play.filters.headers.contentSecurityPolicy = "default-src 'self' www.paypalobjects.com www.paypal.com www.sandbox.paypal.com js.stripe.com pasteup.guim.co.uk ophan.theguardian.com j.ophan.co.uk media.guim.co.uk www.google-analytics.com www.googletagmanager.com tagmanager.google.com polyfill.io www.googleadservices.com googleads.g.doubleclick.net www.google.com www.google.co.uk optimize.google.com static.ads-twitter.com bat.bing.com bid.g.doubleclick.net t.co analytics.twitter.com stats.g.doubleclick.net www.youtube-nocookie.com connect.facebook.net www.facebook.com consumer.krxd.net cdn.krxd.net beacon.krxd.net secure.adnxs.com checkout.stripe.com fonts.googleapis.com ssl.gstatic.com www.gstatic.com fonts.gstatic.com sentry.io www.dwin1.com data: wss: 'unsafe-inline' q.stripe.com payment.guardianapis.com https://interactive.guim.co.uk/"
 
 # Settings configurable via the admin console
-settingsSource.s3 {
-  bucket="support-frontend-admin-console"
-  key= "PROD/settings.json"
+settingsSource {
+  switches.s3 {
+    bucket="support-frontend-admin-console"
+    key= "PROD/switches.json"
+  }
 }

--- a/conf/PROD.public.conf
+++ b/conf/PROD.public.conf
@@ -20,7 +20,7 @@ play.filters.headers.contentSecurityPolicy = "default-src 'self' www.paypalobjec
 # Settings configurable via the admin console
 settingsSource {
   switches.s3 {
-    bucket="support-frontend-admin-console"
+    bucket="support-admin-console"
     key= "PROD/switches.json"
   }
 }

--- a/test/codecs/CirceDecodersTest.scala
+++ b/test/codecs/CirceDecodersTest.scala
@@ -161,7 +161,7 @@ class CirceDecodersTest extends WordSpec with MustMatchers {
           |  }
           |}""".stripMargin
 
-      val settings = Settings(
+      val settings = AllSettings(
         Switches(
           oneOffPaymentMethods = PaymentMethodsSwitch(
             stripe = On,
@@ -184,7 +184,7 @@ class CirceDecodersTest extends WordSpec with MustMatchers {
         )
       )
 
-      decode[Settings](json).right.value mustBe settings
+      decode[AllSettings](json).right.value mustBe settings
     }
   }
 }

--- a/test/controllers/ApplicationTest.scala
+++ b/test/controllers/ApplicationTest.scala
@@ -13,7 +13,7 @@ import fixtures.TestCSRFComponents
 import org.scalatest.mockito.MockitoSugar.mock
 import services.{HttpIdentityService, PaymentAPIService, TestUserService}
 import com.gu.support.config.{PayPalConfigProvider, StripeConfigProvider}
-import admin.SettingsProvider
+import admin.AllSettingsProvider
 import config.Configuration.GuardianDomain
 
 import scala.concurrent.ExecutionContext
@@ -47,7 +47,7 @@ class ApplicationTest extends WordSpec with MustMatchers with TestCSRFComponents
         mock[PayPalConfigProvider],
         mock[PaymentAPIService],
         mock[StringsConfig],
-        mock[SettingsProvider],
+        mock[AllSettingsProvider],
         mock[GuardianDomain]
       )(mock[ExecutionContext]).healthcheck.apply(FakeRequest())
       contentAsString(result) mustBe "healthy"
@@ -64,7 +64,7 @@ class ApplicationTest extends WordSpec with MustMatchers with TestCSRFComponents
         mock[PayPalConfigProvider],
         mock[PaymentAPIService],
         mock[StringsConfig],
-        mock[SettingsProvider],
+        mock[AllSettingsProvider],
         mock[GuardianDomain]
       )(mock[ExecutionContext]).healthcheck.apply(FakeRequest())
       header("Cache-Control", result) mustBe Some("no-cache, private")

--- a/test/controllers/OneOffContributionsTest.scala
+++ b/test/controllers/OneOffContributionsTest.scala
@@ -23,7 +23,7 @@ import services.{HttpIdentityService, PaymentAPIService, TestUserService}
 import com.gu.support.config.StripeConfigProvider
 import fixtures.TestCSRFComponents
 import play.api.libs.json.JsString
-import admin.SettingsProvider
+import admin.AllSettingsProvider
 
 class OneOffContributionsTest extends WordSpec with MustMatchers with TestCSRFComponents {
 
@@ -93,7 +93,7 @@ class OneOffContributionsTest extends WordSpec with MustMatchers with TestCSRFCo
           mock[PaymentAPIService],
           mock[AuthAction[AnyContent]],
           stubControllerComponents(),
-          mock[SettingsProvider]
+          mock[AllSettingsProvider]
         ).autofill(FakeRequest())
       }
     }

--- a/test/controllers/RegularContributionsTest.scala
+++ b/test/controllers/RegularContributionsTest.scala
@@ -18,7 +18,7 @@ import services.{HttpIdentityService, MembersDataService}
 import services.MembersDataService._
 import com.gu.support.config._
 import admin.SwitchState.On
-import admin.{PaymentMethodsSwitch, Settings, SettingsProvider, Switches}
+import admin.{PaymentMethodsSwitch, AllSettings, AllSettingsProvider, Switches}
 import com.gu.tip.Tip
 import config.Configuration.GuardianDomain
 
@@ -45,9 +45,9 @@ class RegularContributionsTest extends WordSpec with MustMatchers {
         signature = ""
       ))
 
-      val settingsProvider = mock[SettingsProvider]
-      when(settingsProvider.settings()).thenReturn(
-        Settings(Switches(PaymentMethodsSwitch(On, On, None), PaymentMethodsSwitch(On, On, Some(On)), Map.empty, On))
+      val settingsProvider = mock[AllSettingsProvider]
+      when(settingsProvider.getAllSettings()).thenReturn(
+        AllSettings(Switches(PaymentMethodsSwitch(On, On, None), PaymentMethodsSwitch(On, On, Some(On)), Map.empty, On))
       )
 
       new RegularContributions(

--- a/test/controllers/SubscriptionsTest.scala
+++ b/test/controllers/SubscriptionsTest.scala
@@ -2,7 +2,7 @@ package controllers
 
 import actions.CustomActionBuilders
 import admin.SwitchState.On
-import admin.{PaymentMethodsSwitch, Settings, SettingsProvider, Switches}
+import admin.{PaymentMethodsSwitch, AllSettings, AllSettingsProvider, Switches}
 import cats.implicits._
 import com.gu.support.config._
 import com.gu.tip.Tip
@@ -33,9 +33,9 @@ class SubscriptionsTest extends WordSpec with MustMatchers with TestCSRFComponen
       identityService: HttpIdentityService = mockedIdentityService(authenticatedIdUser.user -> idUser.asRight[String])
     ): DigitalSubscription = {
 
-      val settingsProvider = mock[SettingsProvider]
-      when(settingsProvider.settings()).thenReturn(
-        Settings(Switches(PaymentMethodsSwitch(On, On, None), PaymentMethodsSwitch(On, On, Some(On)), Map.empty, On))
+      val settingsProvider = mock[AllSettingsProvider]
+      when(settingsProvider.getAllSettings()).thenReturn(
+        AllSettings(Switches(PaymentMethodsSwitch(On, On, None), PaymentMethodsSwitch(On, On, Some(On)), Map.empty, On))
       )
 
       val client = mock[SupportWorkersClient]


### PR DESCRIPTION
## Why are you doing this?
Currently the only config loaded from s3 is the switches. It looks like this:
```
{
    "oneOffPaymentMethods": {
        "stripe": "On",
        "payPal": "On"
    },
    "recurringPaymentMethods": {
        "stripe": "On",
        "payPal": "On",
        "directDebit": "On"
    },
    "experiments": {
        "newFlow": {
            "name": "newFlow",
            "description": "Redesign of the payment flow UI",
            "state": "On"
        }
    },
    "optimize": "Off"
}
```

We intend to add more types of configuration (e.g. amounts config), but store them in separate s3 files.

The existing logic creates a `SettingsSource` for a configured location in s3.
It then creates a `SettingsProvider` for this source, which periodically fetches the latest config.

This change means the app can create a `SettingsSource` for each config file, each with a separate `SettingsProvider`. Access to the combined `AllSettings` object is provided by the `AllSettingsProvider`.

<!--