### PR TITLE
Remove scalariform

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -125,18 +125,4 @@ javaOptions in Universal ++= Seq(
 
 javaOptions in Test += "-Dconfig.file=test/selenium/conf/selenium-test.conf"
 
-import com.typesafe.sbt.SbtScalariform.ScalariformKeys
-import scalariform.formatter.preferences.{DanglingCloseParenthesis, DoubleIndentConstructorArguments, Force, SpacesAroundMultiImports}
-
-ScalariformKeys.preferences := ScalariformKeys.preferences.value
-  .setPreference(SpacesAroundMultiImports, false)
-  .setPreference(DoubleIndentConstructorArguments, true)
-  .setPreference(DanglingCloseParenthesis, Force)
-
-excludeFilter in scalariformFormat := (excludeFilter in scalariformFormat).value ||
-  "Routes.scala" ||
-  "ReverseRoutes.scala" ||
-  "JavaScriptReverseRoutes.scala" ||
-  "RoutesPrefix.scala"
-
 addCommandAlias("devrun", "run 9210") // Chosen to not clash with other Guardian projects - we can't all use the Play default of 9000!

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -10,8 +10,6 @@ libraryDependencies += "org.vafer" % "jdeb" % "1.5" artifacts (Artifact("jdeb", 
 
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0" excludeAll ExclusionRule(organization = "com.danieltrinh"))
 
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.1")
-
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.3")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.3")


### PR DESCRIPTION
## Why are you doing this?
Scalariform and scalastyle contradict each other. One of them has to go.

The problematic case I have discovered is where the line is too long for scalastyle, but scalariform doesn't allow you to split it across 2 lines.