### PR TITLE
Add email play back and signout option to Digital Pack checkout

### DIFF
--- a/app/admin/SettingsProvider.scala
+++ b/app/admin/SettingsProvider.scala
@@ -129,7 +129,8 @@ object S3SettingsProvider {
 
 object SettingsProvider {
 
-  def fromAppConfig[T: Decoder](settingsSource: SettingsSource, config: Configuration)(implicit client: AmazonS3, system: ActorSystem, wsClient: WSClient): Either[Throwable, SettingsProvider[T]] = {
+  def fromAppConfig[T: Decoder](settingsSource: SettingsSource, config: Configuration)
+                               (implicit client: AmazonS3, system: ActorSystem, wsClient: WSClient): Either[Throwable, SettingsProvider[T]] = {
     SafeLogger.info(s"loading settings from $settingsSource")
     settingsSource match {
       case s3: SettingsSource.S3 => S3SettingsProvider.fromS3[T](s3, config.fastlyConfig)

--- a/app/admin/SettingsProvider.scala
+++ b/app/admin/SettingsProvider.scala
@@ -129,8 +129,7 @@ object S3SettingsProvider {
 
 object SettingsProvider {
 
-  def fromAppConfig[T: Decoder](settingsSource: SettingsSource, config: Configuration)
-                               (implicit client: AmazonS3, system: ActorSystem, wsClient: WSClient): Either[Throwable, SettingsProvider[T]] = {
+  def fromAppConfig[T: Decoder](settingsSource: SettingsSource, config: Configuration)(implicit client: AmazonS3, system: ActorSystem, wsClient: WSClient): Either[Throwable, SettingsProvider[T]] = {
     SafeLogger.info(s"loading settings from $settingsSource")
     settingsSource match {
       case s3: SettingsSource.S3 => S3SettingsProvider.fromS3[T](s3, config.fastlyConfig)

--- a/app/controllers/DigitalSubscription.scala
+++ b/app/controllers/DigitalSubscription.scala
@@ -87,7 +87,7 @@ class DigitalSubscription(
     val title = "Support the Guardian | Digital Subscription"
     val id = "digital-subscription-checkout-page-" + countryCode
     val js = "digitalSubscriptionCheckoutPage.js"
-    val css = "digitalSubscriptionCheckoutPageStyles.css"
+    val css = "digitalSubscriptionCheckoutPage.css"
     val csrf = CSRF.getToken.value
     val uatMode = testUsers.isTestUser(idUser.publicFields.displayName)
 

--- a/assets/components/checkoutExpander/checkoutExpander.jsx
+++ b/assets/components/checkoutExpander/checkoutExpander.jsx
@@ -1,0 +1,31 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React, { type Node } from 'react';
+
+import './checkoutExpander.scss';
+
+// ----- Types ----- //
+
+type ExpanderPropTypes = {|
+  copy: string,
+  children: Node,
+|};
+
+
+// ----- Component ----- //
+
+const CheckoutExpander = ({ copy, children }: ExpanderPropTypes) => (
+  <details className="component-checkout-expander">
+    <summary className="component-checkout-expander__summary">
+      <strong className="component-checkout-expander__strong">{copy}</strong>
+    </summary>
+    <div className="component-checkout-expander__expando">{children}</div>
+  </details>
+);
+
+
+// ----- Exports ----- //
+
+export default CheckoutExpander;

--- a/assets/components/checkoutExpander/checkoutExpander.scss
+++ b/assets/components/checkoutExpander/checkoutExpander.scss
@@ -18,7 +18,7 @@
 
 .component-checkout-expander__expando {
   margin-bottom: $gu-v-spacing;
-  button {
+  .component-button {
     margin-right: $gu-h-spacing /4;
   }
 }

--- a/assets/components/checkoutExpander/checkoutExpander.scss
+++ b/assets/components/checkoutExpander/checkoutExpander.scss
@@ -1,0 +1,24 @@
+@import '~stylesheets/gu-sass/gu-sass';
+
+.component-checkout-expander ::-webkit-details-marker {
+  display:none;
+}
+
+.component-checkout-expander__summary {
+  display: block;
+  cursor: pointer;
+  margin-top: $gu-v-spacing / 2;
+  margin-bottom: $gu-v-spacing / 4;
+}
+
+.component-checkout-expander__strong {
+  text-decoration: underline;
+  font-weight: 600;
+}
+
+.component-checkout-expander__expando {
+  margin-bottom: $gu-v-spacing;
+  button {
+    margin-right: $gu-h-spacing /4;
+  }
+}

--- a/assets/components/forms/formHOCs/withFooter.jsx
+++ b/assets/components/forms/formHOCs/withFooter.jsx
@@ -1,0 +1,35 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React, { type Node } from 'react';
+
+import './withFooter.scss';
+
+// ----- Types ----- //
+
+type AugmentedProps<Props> = Props & {
+  footer: Node,
+};
+
+type In<Props> = React$ComponentType<Props>;
+type Out<Props> = React$ComponentType<AugmentedProps<Props>>;
+
+
+// ----- Component ----- //
+
+function withFooter<Props: { id: string }>(Component: In<Props>): Out<Props> {
+  return ({ footer, ...props }: AugmentedProps<Props>) => (
+    <div>
+      <Component {...props} />
+      <div className="component-form-footer">
+        {footer}
+      </div>
+    </div>
+  );
+}
+
+
+// ----- Exports ----- //
+
+export { withFooter };

--- a/assets/components/forms/formHOCs/withFooter.scss
+++ b/assets/components/forms/formHOCs/withFooter.scss
@@ -1,0 +1,9 @@
+@import '~stylesheets/gu-sass/gu-sass';
+
+.component-form-footer {
+  width: calc(100vw - 46px);
+  @include gu-fontset-body-sans;
+  @include mq($from: mobileMedium) {
+    width: 314px;
+  }
+}

--- a/assets/components/forms/standardFields/formFields.scss
+++ b/assets/components/forms/standardFields/formFields.scss
@@ -3,13 +3,21 @@
   font-family: $gu-text-sans-web;
   border: 1px solid gu-colour(garnett-neutral-4);
   transition: box-shadow .2s;
+  background-color: gu-colour(garnett-neutral-5);
+  border-radius: 0;
 
   &:hover {
     box-shadow: 0 0 0 2px lighten(gu-colour(garnett-neutral-4), 6%);
   }
 
   &:focus, &:active {
+    outline-color: rgba(255,255,255,0);
     box-shadow: 0 0 0 2px lighten(gu-colour(news-garnett-highlight), 6%);
+  }
+
+  &[disabled] {
+    pointer-events: none;
+    background-color: gu-colour(garnett-neutral-3);
   }
 }
 

--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -31,9 +31,11 @@ export type SubsUrls = {
 
 const subsUrl = 'https://subscribe.theguardian.com';
 const patronsUrl = 'https://patrons.theguardian.com';
+const profileUrl = `https://profile.${getBaseDomain()}`;
 const defaultIntCmp = 'gdnwb_copts_bundles_landing_default';
 const androidAppUrl = 'https://play.google.com/store/apps/details?id=com.guardian';
-const emailPreferencesUrl = `https://profile.${getBaseDomain()}/email-prefs`;
+const emailPreferencesUrl = `${profileUrl}/email-prefs`;
+const logoutUrl = `${profileUrl}/logout`;
 
 function getWeeklyZuoraCode(period: WeeklyBillingPeriod, countryGroup: CountryGroupId) {
 
@@ -394,6 +396,7 @@ export {
   getDigitalCheckout,
   getIosAppUrl,
   androidAppUrl,
+  logoutUrl,
   getDailyEditionUrl,
   emailPreferencesUrl,
   getWeeklyCheckout,

--- a/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -23,6 +23,7 @@ import { Button } from 'components/forms/standardFields/button';
 import { sortedOptions } from 'components/forms/customFields/sortedOptions';
 import { RadioInput } from 'components/forms/customFields/radioInput';
 import { withLabel } from 'components/forms/formHOCs/withLabel';
+import { withFooter } from 'components/forms/formHOCs/withFooter';
 import { withError } from 'components/forms/formHOCs/withError';
 import { asControlled } from 'components/forms/formHOCs/asControlled';
 import { withArrow } from 'components/forms/formHOCs/withArrow';
@@ -82,7 +83,9 @@ function getPrice(country: Option<IsoCountry>, frequency: DigitalBillingPeriod):
 
 // ----- Form Fields ----- //
 
-const Input1 = compose(asControlled, withError, withLabel)(Input);
+const InputWithLabel = withLabel(Input);
+const InputWithFooter = withFooter(InputWithLabel);
+const Input1 = compose(asControlled, withError)(InputWithLabel);
 const Select1 = compose(asControlled, withError, withLabel)(Select);
 const Select2 = canShow(Select1);
 const Button1 = withArrow(Button);
@@ -130,6 +133,16 @@ function CheckoutForm(props: PropTypes) {
           value={props.lastName}
           setValue={props.setLastName}
           error={firstError('lastName', props.formErrors)}
+        />
+        <InputWithFooter
+          id="email"
+          label="Email"
+          type="email"
+          disabled
+          value={props.email}
+          footer={(
+            <span>not your email?</span>
+          )}
         />
         <Select1
           id="country"

--- a/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -16,17 +16,17 @@ import { showPrice } from 'helpers/internationalisation/price';
 
 import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
 import CheckoutCopy from 'components/checkoutCopy/checkoutCopy';
+import CheckoutExpander from 'components/checkoutExpander/checkoutExpander';
+import Button from 'components/button/button';
 import { Input } from 'components/forms/standardFields/input';
 import { Select } from 'components/forms/standardFields/select';
 import { Fieldset } from 'components/forms/standardFields/fieldset';
-import { Button } from 'components/forms/standardFields/button';
 import { sortedOptions } from 'components/forms/customFields/sortedOptions';
 import { RadioInput } from 'components/forms/customFields/radioInput';
 import { withLabel } from 'components/forms/formHOCs/withLabel';
 import { withFooter } from 'components/forms/formHOCs/withFooter';
 import { withError } from 'components/forms/formHOCs/withError';
 import { asControlled } from 'components/forms/formHOCs/asControlled';
-import { withArrow } from 'components/forms/formHOCs/withArrow';
 import { canShow } from 'components/forms/formHOCs/canShow';
 import GeneralErrorMessage from 'components/generalErrorMessage/generalErrorMessage';
 import DirectDebitPopUpForm from 'components/directDebit/directDebitPopUpForm/directDebitPopUpForm';
@@ -88,7 +88,6 @@ const InputWithFooter = withFooter(InputWithLabel);
 const Input1 = compose(asControlled, withError)(InputWithLabel);
 const Select1 = compose(asControlled, withError, withLabel)(Select);
 const Select2 = canShow(Select1);
-const Button1 = withArrow(Button);
 
 function statesForCountry(country: Option<IsoCountry>): React$Node {
 
@@ -141,7 +140,16 @@ function CheckoutForm(props: PropTypes) {
           disabled
           value={props.email}
           footer={(
-            <span>not your email?</span>
+            <span>
+              <CheckoutExpander copy="Want to use a different email address?">
+                <p>You will be able to edit this in your account once you have completed this checkout.</p>
+              </CheckoutExpander>
+              <CheckoutExpander copy="Not you?">
+                <p>
+                  <Button appearance="greyHollow" icon={null} type="button" aria-label={null} onClick={() => props.signOut()}>Sign out</Button> and create a new account.
+                </p>
+              </CheckoutExpander>
+            </span>
           )}
         />
         <Select1
@@ -216,7 +224,9 @@ function CheckoutForm(props: PropTypes) {
           copy="There is no set time on your agreement so you can stop your subscription anytime."
         />
         {errorState}
-        <Button1 onClick={() => props.submitForm()}>Continue to payment</Button1>
+        <div className="checkout-form__actions">
+          <Button aria-label={null} onClick={() => props.submitForm()}>Continue to payment</Button>
+        </div>
         <DirectDebitPopUpForm
           onPaymentAuthorisation={(pa: PaymentAuthorisation) => { props.onPaymentAuthorised(pa); }}
         />

--- a/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -36,6 +36,7 @@ import type { ErrorReason } from 'helpers/errorReasons';
 import {
   type FormActionCreators,
   formActionCreators,
+  signOut,
   type FormField,
   type FormFields,
   getFormFields,
@@ -46,6 +47,7 @@ import {
 
 type PropTypes = {|
   ...FormFields,
+  signOut: typeof signOut,
   formErrors: FormError<FormField>[],
   submissionError: ErrorReason | null,
   ...FormActionCreators,
@@ -239,4 +241,4 @@ function CheckoutForm(props: PropTypes) {
 
 // ----- Exports ----- //
 
-export default connect(mapStateToProps, formActionCreators)(CheckoutForm);
+export default connect(mapStateToProps, { ...formActionCreators, signOut })(CheckoutForm);

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.jsx
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.jsx
@@ -19,6 +19,8 @@ import SubscriptionFaq from 'components/subscriptionFaq/subscriptionFaq';
 import { initReducer } from './digitalSubscriptionCheckoutReducer';
 import CheckoutStage from './components/checkoutStage';
 
+import './digitalSubscriptionCheckout.scss';
+
 // ----- Internationalisation ----- //
 
 const countryGroupId: CountryGroupId = detect();

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss
@@ -21,7 +21,6 @@
 @import '~components/productHero/productHero';
 @import '~components/forms/standardFields/input';
 @import '~components/forms/standardFields/select';
-@import '~components/forms/standardFields/button';
 @import '~components/forms/customFields/radioInput';
 @import '~components/forms/formHOCs/withLabel';
 @import '~components/forms/formHOCs/withError';
@@ -32,7 +31,6 @@
 @import '~components/generalErrorMessage/generalErrorMessage';
 @import '~components/directDebit/directDebitPopUpForm/directDebitPopUpForm';
 @import '~components/directDebit/directDebitForm/directDebitForm';
-@import '~components/button/button';
 
 
 // ----- Page-Specific Styles ----- //
@@ -69,6 +67,12 @@
       padding-left: $gu-h-spacing / 2;
       padding-bottom: $gu-v-spacing * 3;
       border-top: 1px solid gu-colour(garnett-neutral-4);
+    }
+  }
+
+  .checkout-form__actions {
+    .component-button {
+      margin-top: $gu-v-spacing * 2;
     }
   }
 

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -23,6 +23,7 @@ import {
 } from 'components/marketingConsent/marketingConsentReducer';
 import { isTestUser } from 'helpers/user/user';
 import type { ErrorReason } from 'helpers/errorReasons';
+import { logoutUrl } from 'helpers/externalLinks';
 import { createUserReducer } from 'helpers/user/userReducer';
 import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
@@ -133,6 +134,8 @@ const setFormErrors = (errors: Array<FormError<FormField>>): Action => ({ type: 
 const setSubmissionError = (error: ErrorReason): Action => ({ type: 'SET_SUBMISSION_ERROR', error });
 const setFormSubmitted = (formSubmitted: boolean) => ({ type: 'SET_FORM_SUBMITTED', formSubmitted });
 
+const signOut = () => { window.location.href = logoutUrl; };
+
 function submitForm(dispatch: Dispatch<Action>, state: State) {
   const errors = getErrors(getFormFields(state));
   if (errors.length > 0) {
@@ -239,5 +242,6 @@ export {
   getEmail,
   setSubmissionError,
   setFormSubmitted,
+  signOut,
   formActionCreators,
 };

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -38,6 +38,7 @@ type PaymentMethod = 'Stripe' | 'DirectDebit';
 export type FormFields = {|
   firstName: string,
   lastName: string,
+  email: string,
   country: Option<IsoCountry>,
   stateProvince: Option<StateProvince>,
   telephone: string,
@@ -83,6 +84,7 @@ export type Action =
 function getFormFields(state: State): FormFields {
   return {
     firstName: state.page.checkout.firstName,
+    email: state.page.checkout.email,
     lastName: state.page.checkout.lastName,
     country: state.page.checkout.country,
     stateProvince: state.page.checkout.stateProvince,

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -43,7 +43,6 @@ module.exports = (cssFilename, outputFilename, minimizeCss) => ({
     digitalSubscriptionLandingPage: 'pages/digital-subscription-landing/digitalSubscriptionLanding.jsx',
     digitalSubscriptionLandingPageStyles: 'pages/digital-subscription-landing/digitalSubscriptionLanding.scss',
     digitalSubscriptionCheckoutPage: 'pages/digital-subscription-checkout/digitalSubscriptionCheckout.jsx',
-    digitalSubscriptionCheckoutPageStyles: 'pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss',
     paperSubscriptionLandingPage: 'pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx',
     weeklySubscriptionLandingPage: 'pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx',
     premiumTierLandingPage: 'pages/premium-tier-landing/premiumTierLanding.jsx',


### PR DESCRIPTION
## Why are you doing this?

Add a 'ghost' email field to the checkout page and two links to get help changing the feld or signing out

[**Trello Card**](https://trello.com/c/vz1dS1Vb/2091-add-email-play-back-and-signout-option-to-digital-pack-checkout)

## Screenshots

![screenshot 2019-01-22 at 1 47 40 pm](https://user-images.githubusercontent.com/11539094/51539839-e59b0380-1e4c-11e9-883f-553ca01364a7.png)

![screenshot 2019-01-22 at 1 47 43 pm](https://user-images.githubusercontent.com/11539094/51539676-82a96c80-1e4c-11e9-9ef1-dc344be23178.png)


