### PR TITLE
DIsable direct debit if country doesn't support it

### DIFF
--- a/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -40,6 +40,8 @@ import {
   getFormFields,
   type State,
 } from '../digitalSubscriptionCheckoutReducer';
+import { countrySupportsDirectDebit } from '../helpers/paymentProviders';
+
 
 // ----- Types ----- //
 
@@ -179,21 +181,25 @@ function CheckoutForm(props: PropTypes) {
         </Fieldset>
       </LeftMarginSection>
       <LeftMarginSection>
-        <h2 className="checkout-form__heading">How would you like to pay?</h2>
-        <Fieldset>
-          <RadioInput
-            text="Direct debit"
-            name="paymentMethod"
-            checked={props.paymentMethod === 'DirectDebit'}
-            onChange={() => props.setPaymentMethod('DirectDebit')}
-          />
-          <RadioInput
-            text="Credit/Debit card"
-            name="paymentMethod"
-            checked={props.paymentMethod === 'Stripe'}
-            onChange={() => props.setPaymentMethod('Stripe')}
-          />
-        </Fieldset>
+        {countrySupportsDirectDebit(props.country) &&
+          <div>
+            <h2 className="checkout-form__heading">How would you like to pay?</h2>
+            <Fieldset>
+              <RadioInput
+                text="Direct debit"
+                name="paymentMethod"
+                checked={props.paymentMethod === 'DirectDebit'}
+                onChange={() => props.setPaymentMethod('DirectDebit')}
+              />
+              <RadioInput
+                text="Credit/Debit card"
+                name="paymentMethod"
+                checked={props.paymentMethod === 'Stripe'}
+                onChange={() => props.setPaymentMethod('Stripe')}
+              />
+            </Fieldset>
+          </div>
+        }
         <CheckoutCopy
           strong="Money Back Guarantee "
           copy="If you wish to cancel your subscription, we will send you a refund of the unexpired part of your subscription."

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -6,8 +6,7 @@ import { combineReducers, type Dispatch } from 'redux';
 
 import { type ReduxState } from 'helpers/page/page';
 import { type Option } from 'helpers/types/option';
-import { type DigitalBillingPeriod, Monthly, Annual } from 'helpers/billingPeriods';
-import { getQueryParameter } from 'helpers/url';
+import { type DigitalBillingPeriod, Monthly } from 'helpers/billingPeriods';
 import csrf, { type Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import {
   fromString,
@@ -155,15 +154,11 @@ const formActionCreators = {
 
 export type FormActionCreators = typeof formActionCreators;
 
+
 // ----- Reducer ----- //
 
 function initReducer(countryGroupId: CountryGroupId) {
-  const billingPeriodInurl = getQueryParameter('period');
   const user = getUser(countryGroupId); // TODO: this is unnecessary, it should use the user reducer
-  const initialBillingPeriod: DigitalBillingPeriod = billingPeriodInurl === Monthly || billingPeriodInurl === Annual
-    ? billingPeriodInurl
-    : Monthly;
-
   const initialState = {
     stage: 'checkout',
     email: user.email || '',
@@ -172,7 +167,7 @@ function initReducer(countryGroupId: CountryGroupId) {
     country: user.country || null,
     stateProvince: null,
     telephone: '',
-    billingPeriod: initialBillingPeriod,
+    billingPeriod: Monthly,
     paymentMethod: 'DirectDebit',
     formErrors: [],
     submissionError: null,

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -6,7 +6,8 @@ import { combineReducers, type Dispatch } from 'redux';
 
 import { type ReduxState } from 'helpers/page/page';
 import { type Option } from 'helpers/types/option';
-import { type DigitalBillingPeriod, Monthly } from 'helpers/billingPeriods';
+import { type DigitalBillingPeriod, Monthly, Annual } from 'helpers/billingPeriods';
+import { getQueryParameter } from 'helpers/url';
 import csrf, { type Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import {
   fromString,
@@ -154,11 +155,15 @@ const formActionCreators = {
 
 export type FormActionCreators = typeof formActionCreators;
 
-
 // ----- Reducer ----- //
 
 function initReducer(countryGroupId: CountryGroupId) {
+  const billingPeriodInurl = getQueryParameter('period');
   const user = getUser(countryGroupId); // TODO: this is unnecessary, it should use the user reducer
+  const initialBillingPeriod: DigitalBillingPeriod = billingPeriodInurl === Monthly || billingPeriodInurl === Annual
+    ? billingPeriodInurl
+    : Monthly;
+
   const initialState = {
     stage: 'checkout',
     email: user.email || '',
@@ -167,7 +172,7 @@ function initReducer(countryGroupId: CountryGroupId) {
     country: user.country || null,
     stateProvince: null,
     telephone: '',
-    billingPeriod: Monthly,
+    billingPeriod: initialBillingPeriod,
     paymentMethod: 'DirectDebit',
     formErrors: [],
     submissionError: null,

--- a/assets/pages/digital-subscription-checkout/helpers/paymentProviders.js
+++ b/assets/pages/digital-subscription-checkout/helpers/paymentProviders.js
@@ -5,6 +5,7 @@ import {
   openDialogBox,
   setupStripeCheckout,
 } from 'helpers/paymentIntegrations/newPaymentFlow/stripeCheckout';
+import { type IsoCountry } from 'helpers/internationalisation/country';
 import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
 import {
   type PaymentResult,
@@ -103,4 +104,6 @@ function showPaymentMethod(
   }
 }
 
-export { showPaymentMethod, onPaymentAuthorised };
+const countrySupportsDirectDebit = (country: ?IsoCountry) => country && country === 'GB';
+
+export { showPaymentMethod, onPaymentAuthorised, countrySupportsDirectDebit };


### PR DESCRIPTION
## Why are you doing this?
Because people in those countries cant use it

[**Trello Card**](https://trello.com/c/Xaq1bzCy/2175-hide-direct-debit-payment-option-if-country-other-than-uk-is-selected)

## Changes

* Always payment method to Stripe if country doesn't support DD
* Reset payment method to Stripe if country switches and the country doesn't support DD
* Hide form if country doesn't support DD

## Screenshots

![screenshot 2019-01-22 at 2 10 51 pm](https://user-images.githubusercontent.com/11539094/51541024-b6d25c80-1e4f-11e9-90dc-ee2406a257e8.png)
![screenshot 2019-01-22 at 2 10 58 pm](https://user-images.githubusercontent.com/11539094/51541026-b89c2000-1e4f-11e9-91fb-53760b5f7c43.png)
