### PR TITLE
Global Contribution Types test

### DIFF
--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -34,4 +34,21 @@ export const tests: Tests = {
     canRun: () => !isFromEpicOrBanner,
   },
 
+  globalContributionTypes: {
+    variants: [
+      'control',
+      'default-annual',
+      'default-annual_no-monthly',
+    ],
+    audiences: {
+      ALL: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: true,
+    independent: true,
+    seed: 5,
+  },
+
 };

--- a/assets/helpers/checkouts.js
+++ b/assets/helpers/checkouts.js
@@ -75,11 +75,7 @@ function getValidContributionTypesFromUrlOrElse(fallback: ContributionType[]): C
 
 function getValidContributionTypes(abParticipations: Participations): ContributionType[] {
   const { globalContributionTypes } = abParticipations;
-  const params = globalContributionTypes
-    ? globalContributionTypes.split('_')
-    : [];
-
-  if (params.includes('no-monthly')) {
+  if (globalContributionTypes === 'default-annual_no-monthly') {
     return ['ONE_OFF', 'ANNUAL'];
   }
   return getValidContributionTypesFromUrlOrElse(['ONE_OFF', 'MONTHLY', 'ANNUAL']);

--- a/assets/helpers/checkouts.js
+++ b/assets/helpers/checkouts.js
@@ -18,6 +18,7 @@ import * as storage from 'helpers/storage';
 import { type Switches, type SwitchObject } from 'helpers/settings';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { IsoCountry } from 'helpers/internationalisation/country';
+import type { Participations } from 'helpers/abTests/abtest';
 
 
 // ----- Types ----- //
@@ -72,7 +73,15 @@ function getValidContributionTypesFromUrlOrElse(fallback: ContributionType[]): C
   return fallback;
 }
 
-function getValidContributionTypes(): ContributionType[] {
+function getValidContributionTypes(abParticipations: Participations): ContributionType[] {
+  const { globalContributionTypes } = abParticipations;
+  const params = globalContributionTypes
+    ? globalContributionTypes.split('_')
+    : [];
+
+  if (params.includes('no-monthly')) {
+    return ['ONE_OFF', 'ANNUAL'];
+  }
   return getValidContributionTypesFromUrlOrElse(['ONE_OFF', 'MONTHLY', 'ANNUAL']);
 }
 

--- a/assets/pages/new-contributions-landing/components/ContributionTypeTabs.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionTypeTabs.jsx
@@ -14,6 +14,7 @@ import {
 
 import { trackComponentClick } from 'helpers/tracking/ophanComponentEventTracking';
 import type { IsoCountry } from 'helpers/internationalisation/country';
+import type { Participations } from 'helpers/abTests/abtest';
 import type { Switches } from 'helpers/settings';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { type State } from '../contributionsLandingReducer';
@@ -27,6 +28,7 @@ type PropTypes = {|
   countryGroupId: CountryGroupId,
   switches: Switches,
   onSelectContributionType: (ContributionType, Switches, IsoCountry, CountryGroupId) => void,
+  abParticipations: Participations,
 |};
 
 const mapStateToProps = (state: State) => ({
@@ -34,6 +36,7 @@ const mapStateToProps = (state: State) => ({
   contributionType: state.page.form.contributionType,
   countryId: state.common.internationalisation.countryId,
   switches: state.common.settings.switches,
+  abParticipations: state.common.abParticipations,
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -56,7 +59,7 @@ function ContributionTypeTabs(props: PropTypes) {
     <fieldset className={classNameWithModifiers('form__radio-group', ['tabs', 'contribution-type'])}>
       <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>Recurrence</legend>
       <ul className="form__radio-group-list">
-        {getValidContributionTypes().map((contributionType: ContributionType) => (
+        {getValidContributionTypes(props.abParticipations).map((contributionType: ContributionType) => (
           <li className="form__radio-group-item">
             <input
               id={`contributionType-${contributionType}`}

--- a/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -24,15 +24,15 @@ import type { Participations } from 'helpers/abTests/abtest';
 import { type Amount, type ContributionType, type PaymentMethod } from 'helpers/contributions';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import {
-type Action,
-checkIfEmailHasPassword,
-onThirdPartyPaymentAuthorised,
-paymentWaiting,
-selectAmount,
-setPayPalHasLoaded,
-setThirdPartyPaymentLibrary,
-updateContributionTypeAndPaymentMethod,
-updateUserFormData,
+  type Action,
+  checkIfEmailHasPassword,
+  onThirdPartyPaymentAuthorised,
+  paymentWaiting,
+  selectAmount,
+  setPayPalHasLoaded,
+  setThirdPartyPaymentLibrary,
+  updateContributionTypeAndPaymentMethod,
+  updateUserFormData,
 } from './contributionsLandingActions';
 import { type State } from './contributionsLandingReducer';
 

--- a/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -12,28 +12,29 @@ import {
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { Switches } from 'helpers/settings';
 import {
-  getContributionTypeFromSessionOrElse, getContributionTypeFromUrlOrElse,
+  getContributionTypeFromSessionOrElse,
+  getContributionTypeFromUrlOrElse,
   getPaymentMethodFromSession,
   getValidContributionTypes,
   getValidPaymentMethods,
   type ThirdPartyPaymentLibrary,
 } from 'helpers/checkouts';
 import { getAnnualAmounts } from 'helpers/abTests/helpers/annualContributions';
+import type { Participations } from 'helpers/abTests/abtest';
 import { type Amount, type ContributionType, type PaymentMethod } from 'helpers/contributions';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import {
-  type Action,
-  checkIfEmailHasPassword,
-  onThirdPartyPaymentAuthorised,
-  paymentWaiting,
-  selectAmount,
-  setPayPalHasLoaded,
-  setThirdPartyPaymentLibrary,
-  updateContributionTypeAndPaymentMethod,
-  updateUserFormData,
+type Action,
+checkIfEmailHasPassword,
+onThirdPartyPaymentAuthorised,
+paymentWaiting,
+selectAmount,
+setPayPalHasLoaded,
+setThirdPartyPaymentLibrary,
+updateContributionTypeAndPaymentMethod,
+updateUserFormData,
 } from './contributionsLandingActions';
 import { type State } from './contributionsLandingReducer';
-import type { Participations } from 'helpers/abTests/abtest';
 
 // ----- Functions ----- //
 
@@ -62,7 +63,7 @@ function getInitialContributionType(abParticipations: Participations): Contribut
   if (abTestParams.includes('default-annual')) {
     contributionType = getContributionTypeFromSessionOrElse('ANNUAL');
   } else {
-    contributionType = getContributionTypeFromSessionOrElse('MONTHLY');
+    contributionType = getContributionTypeFromUrlOrElse(getContributionTypeFromSessionOrElse('MONTHLY'));
   }
 
   return (


### PR DESCRIPTION
## Why are you doing this?
As a follow up to https://github.com/guardian/support-frontend/pull/1207/files, we want to run a global contributions types test. Although we ran this already in the US, we will rerun it to give us further confidence in the results. 

We will analyse the test from 2 perspectives, US and non-US (combining GB, AU and ROW)

The variants are: 

|Control|
|-------|
|![image](https://user-images.githubusercontent.com/2844554/51542737-d8cdde00-1e53-11e9-846f-d730b3ab43b1.png)|

|Default Annual|
|-------|
|![image](https://user-images.githubusercontent.com/2844554/51542765-ea16ea80-1e53-11e9-9994-42aa128f46e1.png)|

|Default Annual no monthly|
|-------|
|![image](https://user-images.githubusercontent.com/2844554/51542793-fe5ae780-1e53-11e9-8f25-8cc103370d28.png)|




