### PR TITLE
The user should pay in the currency we allowed them to select

### DIFF
--- a/assets/helpers/page/commonReducer.js
+++ b/assets/helpers/page/commonReducer.js
@@ -10,6 +10,8 @@ import type { Participations } from 'helpers/abTests/abtest';
 import type { Settings } from 'helpers/settings';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { Action } from 'helpers/page/commonActions';
+import { fromCountryGroupId } from 'helpers/internationalisation/currency';
+import { fromCountry } from 'helpers/internationalisation/countryGroup';
 
 export type Internationalisation = {|
   currencyId: IsoCurrency,
@@ -27,6 +29,12 @@ export type CommonState = {
   optimizeExperiments: OptimizeExperiments,
 };
 
+const getInternationalisationFromCountry = (countryId: IsoCountry, state: CommonState) => {
+  const countryGroupId = fromCountry(countryId) || state.internationalisation.countryGroupId;
+  const currencyId = fromCountryGroupId(countryGroupId) || state.internationalisation.currencyId;
+  return { countryGroupId, currencyId, countryId };
+};
+
 // Sets up the common reducer with its initial state.
 function createCommonReducer(initialState: CommonState): (state?: CommonState, action: Action) => CommonState {
 
@@ -40,7 +48,10 @@ function createCommonReducer(initialState: CommonState): (state?: CommonState, a
       case 'SET_COUNTRY':
         return {
           ...state,
-          internationalisation: { ...state.internationalisation, countryId: action.country },
+          internationalisation: {
+            ...state.internationalisation,
+            ...getInternationalisationFromCountry(action.country, state),
+          },
         };
       case 'SET_OPTIMIZE_EXPERIMENT_VARIANT': {
         const optimizeExperiments = state.optimizeExperiments

--- a/assets/helpers/page/commonReducer.js
+++ b/assets/helpers/page/commonReducer.js
@@ -29,9 +29,9 @@ export type CommonState = {
   optimizeExperiments: OptimizeExperiments,
 };
 
-const getInternationalisationFromCountry = (countryId: IsoCountry, state: CommonState) => {
-  const countryGroupId = fromCountry(countryId) || state.internationalisation.countryGroupId;
-  const currencyId = fromCountryGroupId(countryGroupId) || state.internationalisation.currencyId;
+const getInternationalisationFromCountry = (countryId: IsoCountry, internationalisation: Internationalisation) => {
+  const countryGroupId = fromCountry(countryId) || internationalisation.countryGroupId;
+  const currencyId = fromCountryGroupId(countryGroupId) || internationalisation.currencyId;
   return { countryGroupId, currencyId, countryId };
 };
 
@@ -50,7 +50,7 @@ function createCommonReducer(initialState: CommonState): (state?: CommonState, a
           ...state,
           internationalisation: {
             ...state.internationalisation,
-            ...getInternationalisationFromCountry(action.country, state),
+            ...getInternationalisationFromCountry(action.country, state.internationalisation),
           },
         };
       case 'SET_OPTIMIZE_EXPERIMENT_VARIANT': {

--- a/assets/pages/digital-subscription-checkout/helpers/paymentProviders.js
+++ b/assets/pages/digital-subscription-checkout/helpers/paymentProviders.js
@@ -6,8 +6,6 @@ import {
   setupStripeCheckout,
 } from 'helpers/paymentIntegrations/newPaymentFlow/stripeCheckout';
 import { type IsoCountry } from 'helpers/internationalisation/country';
-import { fromCountry } from 'helpers/internationalisation/countryGroup';
-import { fromCountryGroupId } from 'helpers/internationalisation/currency';
 import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
 import {
   type PaymentResult,
@@ -74,37 +72,18 @@ function onPaymentAuthorised(paymentAuthorisation: PaymentAuthorisation, dispatc
   ).then(handleSubscribeResult);
 }
 
-function getISOIdsFromCountry(country: ?string) {
-  if (!country) {
-    throw new Error();
-  }
-  const countryGroupId = fromCountry(country);
-  if (!countryGroupId) {
-    throw new Error();
-  }
-  const currencyId = fromCountryGroupId(countryGroupId);
-  if (!currencyId) {
-    throw new Error();
-  }
-  return { countryGroupId, currencyId };
-}
-
 function showStripe(
   dispatch: Dispatch<Action>,
   state: State,
 ) {
-  try {
-    const { countryGroupId, currencyId } = getISOIdsFromCountry(state.page.checkout.country);
-    const { isTestUser } = state.page.checkout;
-    const price = getDigitalPrice(countryGroupId, state.page.checkout.billingPeriod);
-    const onAuthorised = (pa: PaymentAuthorisation) => onPaymentAuthorised(pa, dispatch, state);
+  const { countryGroupId, currencyId } = state.common.internationalisation;
+  const { isTestUser } = state.page.checkout;
+  const price = getDigitalPrice(countryGroupId, state.page.checkout.billingPeriod);
+  const onAuthorised = (pa: PaymentAuthorisation) => onPaymentAuthorised(pa, dispatch, state);
 
-    loadStripe()
-      .then(() => setupStripeCheckout(onAuthorised, 'REGULAR', currencyId, isTestUser))
-      .then(stripe => openDialogBox(stripe, price.value, state.page.checkout.email));
-  } catch (e) {
-    dispatch(setSubmissionError('unknown'));
-  }
+  loadStripe()
+    .then(() => setupStripeCheckout(onAuthorised, 'REGULAR', currencyId, isTestUser))
+    .then(stripe => openDialogBox(stripe, price.value, state.page.checkout.email));
 }
 
 function showPaymentMethod(

--- a/assets/pages/digital-subscription-checkout/helpers/paymentProviders.js
+++ b/assets/pages/digital-subscription-checkout/helpers/paymentProviders.js
@@ -76,7 +76,7 @@ function showStripe(
   dispatch: Dispatch<Action>,
   state: State,
 ) {
-  const { countryGroupId, currencyId } = state.common.internationalisation;
+  const { currencyId, countryGroupId } = state.common.internationalisation;
   const { isTestUser } = state.page.checkout;
   const price = getDigitalPrice(countryGroupId, state.page.checkout.billingPeriod);
   const onAuthorised = (pa: PaymentAuthorisation) => onPaymentAuthorised(pa, dispatch, state);

--- a/assets/pages/digital-subscription-checkout/helpers/paymentProviders.js
+++ b/assets/pages/digital-subscription-checkout/helpers/paymentProviders.js
@@ -6,6 +6,8 @@ import {
   setupStripeCheckout,
 } from 'helpers/paymentIntegrations/newPaymentFlow/stripeCheckout';
 import { type IsoCountry } from 'helpers/internationalisation/country';
+import { fromCountry } from 'helpers/internationalisation/countryGroup';
+import { fromCountryGroupId } from 'helpers/internationalisation/currency';
 import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
 import {
   type PaymentResult,
@@ -72,18 +74,37 @@ function onPaymentAuthorised(paymentAuthorisation: PaymentAuthorisation, dispatc
   ).then(handleSubscribeResult);
 }
 
+function getISOIdsFromCountry(country: ?string) {
+  if (!country) {
+    throw new Error();
+  }
+  const countryGroupId = fromCountry(country);
+  if (!countryGroupId) {
+    throw new Error();
+  }
+  const currencyId = fromCountryGroupId(countryGroupId);
+  if (!currencyId) {
+    throw new Error();
+  }
+  return { countryGroupId, currencyId };
+}
+
 function showStripe(
   dispatch: Dispatch<Action>,
   state: State,
 ) {
-  const { currencyId, countryGroupId } = state.common.internationalisation;
-  const { isTestUser } = state.page.checkout;
-  const price = getDigitalPrice(countryGroupId, state.page.checkout.billingPeriod);
-  const onAuthorised = (pa: PaymentAuthorisation) => onPaymentAuthorised(pa, dispatch, state);
+  try {
+    const { countryGroupId, currencyId } = getISOIdsFromCountry(state.page.checkout.country);
+    const { isTestUser } = state.page.checkout;
+    const price = getDigitalPrice(countryGroupId, state.page.checkout.billingPeriod);
+    const onAuthorised = (pa: PaymentAuthorisation) => onPaymentAuthorised(pa, dispatch, state);
 
-  loadStripe()
-    .then(() => setupStripeCheckout(onAuthorised, 'REGULAR', currencyId, isTestUser))
-    .then(stripe => openDialogBox(stripe, price.value, state.page.checkout.email));
+    loadStripe()
+      .then(() => setupStripeCheckout(onAuthorised, 'REGULAR', currencyId, isTestUser))
+      .then(stripe => openDialogBox(stripe, price.value, state.page.checkout.email));
+  } catch (e) {
+    dispatch(setSubmissionError('unknown'));
+  }
 }
 
 function showPaymentMethod(


### PR DESCRIPTION
## Why are you doing this?

Solves a bug where stripe was picking up the page's internationalisation instead of the selected country.

We previously spoke about removing urls with the country on them but it has dawned on me we do still want to pass the country to preserve the selection from the landing page. For now i've just done nothing on this as a result

### What else is going on?
Haha so turns out the checkout form was sharing an action name (`SET_COUNTRY`) with the common reducer. I don't believe this was desired behaviour but this fix takes advantage of that to round up the `SET_COUNTRY` method and set the users country in that area. I believe a fully cooked solution for this bug should use that approach (the way I see it, setting the country in the form should dispatch this second `SET_COUNTRY` action rather than just relying on the same name)

[**Trello Card**](https://trello.com/c/fBzNLS2e/2176-the-user-should-pay-in-the-currency-we-allowed-them-to-select)