### PR TITLE
Removed rounding and update saving amount

### DIFF
--- a/assets/pages/digital-subscription-landing/components/form.jsx
+++ b/assets/pages/digital-subscription-landing/components/form.jsx
@@ -25,11 +25,11 @@ import { redirectToDigitalPage, setPlan } from '../digitalSubscriptionLandingAct
 const getPrice = (countryGroupId: CountryGroupId, period: DigitalBillingPeriod) =>
   showPrice(getDigitalPrice(countryGroupId, period));
 
-const getAnnualSaving = (countryGroupId: CountryGroupId): Price => {
+  const getAnnualSaving = (countryGroupId: CountryGroupId): Price => {
   const annualizedMonthlyCost = getDigitalPrice(countryGroupId, Monthly).value * 12;
   const annualCost = getDigitalPrice(countryGroupId, Annual);
 
-  return { ...annualCost, value: Math.ceil(annualizedMonthlyCost - annualCost.value) };
+  return { ...annualCost, value: (annualizedMonthlyCost - annualCost.value) };
 };
 
 export const billingPeriods = {
@@ -39,7 +39,7 @@ export const billingPeriods = {
   },
   [Annual]: {
     title: 'Annually',
-    offer: 'Now save 20%',
+    offer: 'Save 17%',
     copy: (countryGroupId: CountryGroupId) => `${getPrice(countryGroupId, Annual)} every 12 months (save ${showPrice(getAnnualSaving(countryGroupId))} per year)`,
   },
 };

--- a/assets/pages/digital-subscription-landing/components/form.jsx
+++ b/assets/pages/digital-subscription-landing/components/form.jsx
@@ -25,7 +25,7 @@ import { redirectToDigitalPage, setPlan } from '../digitalSubscriptionLandingAct
 const getPrice = (countryGroupId: CountryGroupId, period: DigitalBillingPeriod) =>
   showPrice(getDigitalPrice(countryGroupId, period));
 
-  const getAnnualSaving = (countryGroupId: CountryGroupId): Price => {
+const getAnnualSaving = (countryGroupId: CountryGroupId): Price => {
   const annualizedMonthlyCost = getDigitalPrice(countryGroupId, Monthly).value * 12;
   const annualCost = getDigitalPrice(countryGroupId, Annual);
 


### PR DESCRIPTION
## Why are you doing this?

There was a accuracy update required based on incorrect design assets.

[**Trello Card**](https://trello.com/c/YkggErle/2177-update-incorrect-info-on-annual-option-for-dp-test)

## Changes

* Copy update to sale savings
* Removed rounding part of the `showDiscount` function

## Screenshots
<img width="627" alt="screen shot 2019-01-23 at 17 04 28" src="https://user-images.githubusercontent.com/1108991/51623611-03419900-1f31-11e9-9ee4-063fbac07974.png">

