### PR TITLE
Update copy to incorporate Data Privacy feedback

### DIFF
--- a/assets/components/checkoutHeading/checkoutHeading.jsx
+++ b/assets/components/checkoutHeading/checkoutHeading.jsx
@@ -11,7 +11,6 @@ import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
 
 type PropTypes = {|
   heading: string,
-  copy: string,
 |};
 
 
@@ -23,7 +22,6 @@ function CheckoutHeading(props: PropTypes) {
     <div className="component-checkout-heading">
       <LeftMarginSection>
         <h1 className="component-checkout-heading__heading">{props.heading}</h1>
-        <p className="component-checkout-heading__copy">{props.copy}</p>
       </LeftMarginSection>
     </div>
   );

--- a/assets/components/checkoutHeading/checkoutHeading.scss
+++ b/assets/components/checkoutHeading/checkoutHeading.scss
@@ -17,9 +17,3 @@
     width: gu-span(6);
   }
 }
-
-.component-checkout-heading__copy {
-  @include gu-fontset-body-sans;
-
-  color: gu-colour(news-garnett-highlight);
-}

--- a/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -177,13 +177,18 @@ function CheckoutForm(props: PropTypes) {
           <option value="">--</option>
           {statesForCountry(props.country)}
         </Select2>
-        <Input1
+        <InputWithFooter
           id="telephone"
           label="Telephone (optional)"
           type="tel"
           value={props.telephone}
           setValue={props.setTelephone}
           error={firstError('telephone', props.formErrors)}
+          footer={
+            <CheckoutExpander copy="What will my phone number be used for?">
+              <p>We may use this to get in touch with you about your subscription.</p>
+            </CheckoutExpander>
+          }
         />
       </LeftMarginSection>
       <LeftMarginSection>
@@ -224,7 +229,7 @@ function CheckoutForm(props: PropTypes) {
           </div>
         }
         <CheckoutCopy
-          strong="Money Back Guarantee "
+          strong="Money Back Guarantee. "
           copy="If you wish to cancel your subscription, we will send you a refund of the unexpired part of your subscription."
         />
         <CheckoutCopy

--- a/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -184,11 +184,7 @@ function CheckoutForm(props: PropTypes) {
           value={props.telephone}
           setValue={props.setTelephone}
           error={firstError('telephone', props.formErrors)}
-          footer={
-            <CheckoutExpander copy="What will my phone number be used for?">
-              <p>We may use this to get in touch with you about your subscription.</p>
-            </CheckoutExpander>
-          }
+          footer="We may use this to get in touch with you about your subscription."
         />
       </LeftMarginSection>
       <LeftMarginSection>

--- a/assets/pages/digital-subscription-checkout/components/checkoutStage.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutStage.jsx
@@ -110,7 +110,6 @@ function CheckoutStage(props: PropTypes) {
           />
           <CheckoutHeading
             heading="Your Digital Pack subscription is now live"
-            copy="Thank you for supporting our journalism"
           />
           <ThankYouContent countryGroupId={props.countryGroupId} />
           <ReturnSection />
@@ -122,13 +121,11 @@ function CheckoutStage(props: PropTypes) {
       return (
         <div className="checkout-content">
           <CheckoutHeading
-            heading="Digital Pack Subscription"
-            copy="Cancel your subscription at any time"
+            heading="Digital Pack"
           />
           <LeftMarginSection modifierClasses={['free-trial']}>
             <p className="checkout-content__free-trial">
-              You can use all the features free for the next 14 days,
-              and then your first payment will be taken.
+              Please enter your details below to complete your Digital Pack subscription.
             </p>
           </LeftMarginSection>
           <CheckoutForm />

--- a/assets/pages/digital-subscription-checkout/components/thankYouContent.jsx
+++ b/assets/pages/digital-subscription-checkout/components/thankYouContent.jsx
@@ -40,7 +40,11 @@ function ThankYouContent(props: PropTypes) {
     <div className="thank-you-content">
       <LeftMarginSection>
         <p className={classNameWithModifiers('thank-you-content__copy', ['italic'])}>
-          {props.paymentMethod === 'DirectDebit' ? 'Look out for an email within three business days confirming your recurring payment. This will appear as \'Guardian Media Group\' on your bank statements.' : 'We have sent you an email with everything you need to know'}
+          {
+            props.paymentMethod === 'DirectDebit' ?
+            'Look out for an email within three business days confirming your recurring payment. Your first payment will be taken in 14 days and will appear as \'Guardian Media Group\' on your bank statement.' :
+            'We have sent you an email with everything you need to know. Your first payment will be taken in 14 days.'
+          }
         </p>
       </LeftMarginSection>
       <AppsSection countryGroupId={props.countryGroupId} />
@@ -64,10 +68,6 @@ function AppsSection(props: { countryGroupId: CountryGroupId }) {
       </h2>
       <p className="thank-you-content__copy">
         Just download the apps and log in with your Guardian account details.
-      </p>
-      <p className="thank-you-content__copy">
-        You can use all the features free for the next 14 days,
-        and then your first payment will be taken.
       </p>
       <h3 className="thank-you-content__subheading">
         Premium App


### PR DESCRIPTION
## Why are you doing this?

To incorporate some feedback from Data Privacy into the new Digital Pack checkout flow.

[**Trello Card**](https://trello.com/c/kjp8ldVg/2178-data-privacy-feedback-on-dp-checkout)

## Changes

* Remove copy from CheckoutHeader, since it is no longer required
* Update copy in a few places

## Screenshots

Checkout page:

![image](https://user-images.githubusercontent.com/19384074/51667097-2878ea80-1fb7-11e9-9526-b7f3df8c34f3.png)

Thank you page (card):

![image](https://user-images.githubusercontent.com/19384074/51667204-6b3ac280-1fb7-11e9-8e06-32bb2ce64e7e.png)

Thank you page (direct debit):

![image](https://user-images.githubusercontent.com/19384074/51667311-b9e85c80-1fb7-11e9-9e17-9f2687e8aee5.png)
