### PR TITLE
DO NOT MERGE: Display new digital pack checkout without requiring query param

### DIFF
--- a/app/controllers/DigitalSubscription.scala
+++ b/app/controllers/DigitalSubscription.scala
@@ -67,20 +67,16 @@ class DigitalSubscription(
 
   def digitalGeoRedirect: Action[AnyContent] = geoRedirect("subscribe/digital")
 
-  def displayForm(countryCode: String, displayCheckout: Boolean, isCsrf: Boolean = false): Action[AnyContent] =
+  def displayForm(countryCode: String): Action[AnyContent] =
     authenticatedAction(recurringIdentityClientId).async { implicit request =>
       implicit val settings: AllSettings = settingsProvider.getAllSettings()
-      if (displayCheckout) {
-        identityService.getUser(request.user).fold(
-          error => {
-            SafeLogger.error(scrub"Failed to display digital subscriptions form for ${request.user.id} due to error from identityService: $error")
-            InternalServerError
-          },
-          user => Ok(digitalSubscriptionFormHtml(user, countryCode))
-        ).map(_.withSettingsSurrogateKey)
-      } else {
-        Future.successful(Redirect(routes.Subscriptions.geoRedirect))
-      }
+      identityService.getUser(request.user).fold(
+        error => {
+          SafeLogger.error(scrub"Failed to display digital subscriptions form for ${request.user.id} due to error from identityService: $error")
+          InternalServerError
+        },
+        user => Ok(digitalSubscriptionFormHtml(user, countryCode))
+      ).map(_.withSettingsSurrogateKey)
     }
 
   private def digitalSubscriptionFormHtml(idUser: IdUser, countryCode: String)(implicit request: RequestHeader, settings: AllSettings): Html = {

--- a/conf/routes
+++ b/conf/routes
@@ -74,7 +74,7 @@ GET  /:country/subscribe                           controllers.Subscriptions.leg
 GET  /digital                            controllers.DigitalSubscription.digitalGeoRedirect()
 GET  /subscribe/digital                            controllers.DigitalSubscription.digitalGeoRedirect()
 GET  /$country<(uk|us|au|int)>/subscribe/digital   controllers.DigitalSubscription.digital(country: String)
-GET  /$country<(uk|us|au|int)>/subscribe/digital/checkout  controllers.DigitalSubscription.displayForm(country: String, displayCheckout: Boolean ?= false)
+GET  /$country<(uk|us|au|int)>/subscribe/digital/checkout  controllers.DigitalSubscription.displayForm(country: String)
 POST /subscribe/digital/create  controllers.DigitalSubscription.create
 
 GET  /premium-tier                            controllers.Subscriptions.premiumTierGeoRedirect()


### PR DESCRIPTION
## Why are you doing this?

We're almost ready to drive some real traffic to the new digital pack checkout flow, so we'll need to drop this query param soon.

## Changes

* Drop showCheckout query param
* Drop unused isCsrf query param

## Screenshots
N/A
