### PR TITLE
If we collect a telephone number, send it with the request to create a digital pack. 

### DIFF
--- a/app/controllers/DigitalSubscription.scala
+++ b/app/controllers/DigitalSubscription.scala
@@ -143,7 +143,7 @@ class DigitalSubscription(
       lastName = request.lastName,
       country = request.country,
       state = request.state,
-      telephoneNumber = request.telephone,
+      telephoneNumber = request.telephoneNumber,
       allowMembershipMail = false,
       allowThirdPartyMail = user.statusFields.flatMap(_.receive3rdPartyMarketing).getOrElse(false),
       allowGURelatedMail = user.statusFields.flatMap(_.receiveGnmMarketing).getOrElse(false),

--- a/app/controllers/DigitalSubscription.scala
+++ b/app/controllers/DigitalSubscription.scala
@@ -143,6 +143,7 @@ class DigitalSubscription(
       lastName = request.lastName,
       country = request.country,
       state = request.state,
+      telephoneNumber = request.telephone,
       allowMembershipMail = false,
       allowThirdPartyMail = user.statusFields.flatMap(_.receive3rdPartyMarketing).getOrElse(false),
       allowGURelatedMail = user.statusFields.flatMap(_.receiveGnmMarketing).getOrElse(false),

--- a/app/services/stepfunctions/SupportWorkersClient.scala
+++ b/app/services/stepfunctions/SupportWorkersClient.scala
@@ -37,7 +37,8 @@ case class CreateSupportWorkersRequest(
     ophanIds: OphanIds,
     referrerAcquisitionData: ReferrerAcquisitionData,
     supportAbTests: Set[AbTest],
-    email: String
+    email: String,
+    telephoneNumber: Option[String]
 )
 
 object SupportWorkersClient {

--- a/app/utils/SimpleValidator.scala
+++ b/app/utils/SimpleValidator.scala
@@ -21,6 +21,8 @@ object SimpleValidator {
       case stripeDetails: StripePaymentFields => !stripeDetails.stripeToken.isEmpty
     }
 
-    noEmptyNameFields && hasStateIfRequired && noEmptyPaymentFields
+    val telephoneNumberShortEnough = request.telephoneNumber.forall(_.length < 40)
+
+    noEmptyNameFields && hasStateIfRequired && noEmptyPaymentFields && telephoneNumberShortEnough
   }
 }

--- a/assets/helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis.js
+++ b/assets/helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis.js
@@ -6,6 +6,7 @@ import { type Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import { type BillingPeriod } from 'helpers/billingPeriods';
 import { type Participations } from 'helpers/abTests/abtest';
 import { type CaState, type IsoCountry, type UsState } from 'helpers/internationalisation/country';
+import { type Option } from 'helpers/types/option';
 import { logPromise, pollUntilPromise } from 'helpers/promise';
 import { logException } from 'helpers/logger';
 import { fetchJson, getRequestOptions, requestOptions } from 'helpers/fetch';
@@ -53,7 +54,8 @@ export type RegularPaymentRequest = {|
   paymentFields: RegularPaymentFields,
   ophanIds: OphanIds,
   referrerAcquisitionData: ReferrerAcquisitionData,
-  supportAbTests: AcquisitionABTest[]
+  supportAbTests: AcquisitionABTest[],
+  telephoneNumber: Option<string>,
 |};
 
 export type StripePaymentMethod = 'StripeCheckout' | 'StripeApplePay' | 'StripePaymentRequestButton';

--- a/assets/pages/digital-subscription-checkout/helpers/paymentProviders.js
+++ b/assets/pages/digital-subscription-checkout/helpers/paymentProviders.js
@@ -27,6 +27,7 @@ function buildRegularPaymentRequest(state: State, paymentAuthorisation: PaymentA
     country,
     stateProvince,
     billingPeriod,
+    telephone,
   } = state.page.checkout;
 
   const product = {
@@ -42,6 +43,7 @@ function buildRegularPaymentRequest(state: State, paymentAuthorisation: PaymentA
     country: country || 'GB',
     state: stateProvince,
     email,
+    telephoneNumber: telephone,
     product,
     paymentFields,
     ophanIds: getOphanIds(),

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -272,6 +272,7 @@ const regularPaymentRequestFromAuthorisation = (
   ophanIds: getOphanIds(),
   referrerAcquisitionData: state.common.referrerAcquisitionData,
   supportAbTests: getSupportAbTests(state.common.abParticipations, state.common.optimizeExperiments),
+  telephoneNumber: null,
 });
 
 // A PaymentResult represents the end state of the checkout process,

--- a/build.sbt
+++ b/build.sbt
@@ -67,7 +67,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsVersion,
   "org.typelevel" %% "cats-core" % "1.0.1",
   "com.dripower" %% "play-circe" % "2609.1",
-  "com.gu" %% "support-models" % "0.43",
+  "com.gu" %% "support-models" % "0.49",
   "com.gu" %% "support-config" % "0.16",
   "com.gu" %% "fezziwig" % "0.8",
   "com.typesafe.akka" %% "akka-agent" % "2.5.14",

--- a/test/utils/SimpleValidatorTest.scala
+++ b/test/utils/SimpleValidatorTest.scala
@@ -18,7 +18,8 @@ class SimpleValidatorTest extends FlatSpec with Matchers {
     ophanIds = OphanIds(None, None, None),
     referrerAcquisitionData = ReferrerAcquisitionData(None, None, None, None, None, None, None, None, None, None, None, None),
     supportAbTests = Set(),
-    email = "grace@gracehopper.com"
+    email = "grace@gracehopper.com",
+    telephoneNumber = None
   )
 
   "validate" should "return true when there are no empty strings" in {
@@ -48,6 +49,16 @@ class SimpleValidatorTest extends FlatSpec with Matchers {
   "validate" should "fail if the payment field received is an empty string" in {
     val requestMissingState = validRequest.copy(paymentFields = StripePaymentFields(""))
     SimpleValidator.validationPasses(requestMissingState) shouldBe false
+  }
+
+  "validate" should "fail if the telephone number is longer than 40 characters " in {
+    val requestWithTooLongTelephoneNumber = validRequest.copy(telephoneNumber = Some("12345678901234567890123456789012345678901"))
+    SimpleValidator.validationPasses(requestWithTooLongTelephoneNumber) shouldBe false
+  }
+
+  "validate" should "not check what the characters are in a telephone number" in {
+    val requestWithTooLongTelephoneNumber = validRequest.copy(telephoneNumber = Some("abcdef"))
+    SimpleValidator.validationPasses(requestWithTooLongTelephoneNumber) shouldBe true
   }
 
 }


### PR DESCRIPTION
## Why are you doing this?
As of https://github.com/guardian/support-workers/pull/170, we can include a telephone number in the request to support-workers to create a digital pack, and it will get added to the salesforce contact. 

So, if someone in the checkout provides us with the telephone number, we should send it with the request so that it's added to the salesforce contact. 

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/zcaNKssy/2156-make-sure-telephone-number-if-provided-makes-its-way-to-salesforce)

## Changes

* Use latest version of support-models
* Include telephone number in the request to `/subscribe/digital/create` so that it will be included in the request to support-workers to create a digital pack, and added to the salesforce contact.

## Screenshots
![image](https://user-images.githubusercontent.com/3072877/51672190-ca520480-1fc2-11e9-9de6-17cf7498d778.png)
⬇️ 
![image](https://user-images.githubusercontent.com/3072877/51671938-2e27fd80-1fc2-11e9-86d9-e6f7348bd6a4.png)

🎉 

related PRs:
https://github.com/guardian/support-workers/pull/170
https://github.com/guardian/support-libraries/pull/16
