### PR TITLE
Remove an unstable test

### DIFF
--- a/assets/helpers/__tests__/promiseTest.js
+++ b/assets/helpers/__tests__/promiseTest.js
@@ -4,9 +4,7 @@
 
 import {
   repeatPromise,
-  sleepPromise,
   pollUntilPromise,
-  // logPromise,
   bracketPromise,
 } from '../promise';
 
@@ -55,19 +53,6 @@ describe('promise', () => {
     });
 
   });
-
-  // Don't know how if it's possible to mock Raven?
-  // describe('logging', () => {
-
-  //   it('log and rethrow exceptions', done => {
-
-  //     const error = new Error('Oh noes!')
-
-  //     logPromise(Promise.reject(error)).catch(done);
-
-  //   });
-
-  // });
 
   describe('bracket', () => {
 

--- a/assets/helpers/__tests__/promiseTest.js
+++ b/assets/helpers/__tests__/promiseTest.js
@@ -41,20 +41,6 @@ describe('promise', () => {
 
   });
 
-  describe('sleepPromise', () => {
-
-    it('should run the promise after 100ms', (done) => {
-
-      const t1 = Date.now();
-
-      sleepPromise(100, () => Promise.resolve(Date.now()))
-        .then(t2 => expect(t2 - t1).toBeGreaterThanOrEqual(100))
-        .then(done);
-
-    });
-
-  });
-
   describe('polling', () => {
 
     it('return a successful action', (done, fail) => {


### PR DESCRIPTION
## Why are you doing this?

This test is unstable and has broken the build several times. 

The polling functionality is still being tested here https://github.com/guardian/support-frontend/blob/master/assets/helpers/__tests__/promiseTest.js#L58-L71 (pollUntilPromise calls sleepPromise) so I think this is superfluous anyway.

## Changes

* Remove unstable test