### PR TITLE
Add focus and hover states to checkout form widgets

### DIFF
--- a/assets/components/button/button.scss
+++ b/assets/components/button/button.scss
@@ -12,6 +12,7 @@
   border-radius: 600px;
   box-sizing: border-box;
   cursor: pointer;
+  transition: .2s;
 
   &:hover, &:focus {
     outline: 0;
@@ -50,11 +51,17 @@
 .component-button--greenHollow {
   color: gu-colour(green-dark);
   border: 1px solid gu-colour(green-dark);
+  &:hover, &:focus {
+    background: gu-colour(garnett-neutral-3);
+  }
 }
 
 .component-button--greyHollow {
   color: gu-colour(garnett-neutral-1);
   border: 1px solid gu-colour(garnett-neutral-4);
+  &:hover, &:focus {
+    background: gu-colour(garnett-neutral-3);
+  }
 }
 
 .component-button__content,

--- a/assets/components/button/button.scss
+++ b/assets/components/button/button.scss
@@ -82,3 +82,15 @@
 .component-button--hasicon-left svg {
   margin: $gu-v-spacing * -1 $gu-h-spacing * .5 $gu-v-spacing * -1 $gu-h-spacing * -.5;
 }
+
+
+/* icon-specific animations & transitions */
+.component-button {
+  .svg-arrow-right-straight {
+    transition: .2s transform;
+    will-change: transform;
+  }
+  &:hover .svg-arrow-right-straight, &:focus .svg-arrow-right-straight {
+    transform: translateX(5%);
+  }
+}

--- a/assets/components/forms/customFields/radioInput.scss
+++ b/assets/components/forms/customFields/radioInput.scss
@@ -1,13 +1,12 @@
 .component-radio-input {
-  display: block;
   @include gu-fontset-body-sans;
+  display: block;
   cursor: pointer;
   margin-top: $gu-v-spacing;
   position: relative;
-
   &:hover {
     .component-radio-input__text::before {
-      border-color: gu-colour(garnett-neutral-2);
+      box-shadow: inset 0 0 0 3px #fff, 0 0 0 2px lighten(gu-colour(garnett-neutral-4), 6%);
     }
   }
 }
@@ -23,6 +22,9 @@
   width: 0;
   top: 0;
   left: 0;
+  &:focus + .component-radio-input__text::before {
+    box-shadow: inset 0 0 0 3px #fff, 0 0 0 2px lighten(gu-colour(news-garnett-highlight), 6%);
+  }
 }
 
 .component-radio-input__text::before {
@@ -35,6 +37,7 @@
   box-shadow: inset 0 0 0 3px #fff;
   border-radius: 60px;
   margin-right: 5px;
+  transition: .2s box-shadow;
 }
 
 .component-radio-input__input:checked + .component-radio-input__text::before {

--- a/assets/stylesheets/gu-sass/colours.scss
+++ b/assets/stylesheets/gu-sass/colours.scss
@@ -102,7 +102,7 @@ $gu-colours: (
   news-garnett-media-main-1: #ff4e36, // used for kicker on media
   news-garnett-highlight: #ffe500,
   news-faded:  #fff4f2,
-  highlight-dark: #ebd10a,
+  highlight-dark: #ffbb50,
 
   opinion-garnett-main-1: #ed6300,
   opinion-garnett-feature: #f5be2c,

--- a/assets/stylesheets/gu-sass/colours.scss
+++ b/assets/stylesheets/gu-sass/colours.scss
@@ -102,7 +102,7 @@ $gu-colours: (
   news-garnett-media-main-1: #ff4e36, // used for kicker on media
   news-garnett-highlight: #ffe500,
   news-faded:  #fff4f2,
-  highlight-dark: #e8d10a,
+  highlight-dark: #ebd10a,
 
   opinion-garnett-main-1: #ed6300,
   opinion-garnett-feature: #f5be2c,

--- a/assets/stylesheets/gu-sass/colours.scss
+++ b/assets/stylesheets/gu-sass/colours.scss
@@ -141,7 +141,7 @@ $gu-colours: (
   immersive-garnett-main-1: rgba(0, 0, 0, .65),
   analysis-garnett-underline: #ffbac8,
 
-  green-dark: #236925,
+  green-dark: #185E36,
 
   patrons: #a1845c,
   masterclass: #bb3b80


### PR DESCRIPTION
## Why are you doing this?

We were missing a couple, now you can tab through the whole form and know where you are:

<img width="343" alt="screenshot 2019-01-24 at 2 09 05 pm" src="https://user-images.githubusercontent.com/11539094/51683490-e4e7a600-1fe1-11e9-82f7-5b78a7cb04f8.png">
<img width="166" alt="screenshot 2019-01-24 at 2 09 19 pm" src="https://user-images.githubusercontent.com/11539094/51683493-e618d300-1fe1-11e9-8df1-011475b43df5.png">

It also introduces a ✨ new shade of green ✨ bespokedly designed just for us because we are worth it

[**Trello Card**](https://trello.com/c/lndiPTMX/2184-make-sure-all-form-components-have-clear-focus-states)

## Changes

* Outline button hover & focus aligned with @zeftilldeath's design library
* Radio button hover & focus aligned with @zeftilldeath's design library