### PR TITLE
Turn off default annual no monthly variant of Contributions Types test

### DIFF
--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -39,7 +39,6 @@ export const tests: Tests = {
     variants: [
       'control',
       'default-annual',
-      'default-annual_no-monthly',
     ],
     audiences: {
       ALL: {

--- a/assets/helpers/checkouts.js
+++ b/assets/helpers/checkouts.js
@@ -18,7 +18,6 @@ import * as storage from 'helpers/storage';
 import { type Switches, type SwitchObject } from 'helpers/settings';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { IsoCountry } from 'helpers/internationalisation/country';
-import type { Participations } from 'helpers/abTests/abtest';
 
 
 // ----- Types ----- //
@@ -73,15 +72,8 @@ function getValidContributionTypesFromUrlOrElse(fallback: ContributionType[]): C
   return fallback;
 }
 
-function getValidContributionTypes(abParticipations: Participations): ContributionType[] {
-  const { globalContributionTypes } = abParticipations;
-  let validContributionTypes;
-  if (globalContributionTypes === 'default-annual_no-monthly') {
-    validContributionTypes = ['ONE_OFF', 'ANNUAL'];
-  } else {
-    validContributionTypes = ['ONE_OFF', 'MONTHLY', 'ANNUAL'];
-  }
-  return getValidContributionTypesFromUrlOrElse(validContributionTypes);
+function getValidContributionTypes(): ContributionType[] {
+  return getValidContributionTypesFromUrlOrElse(['ONE_OFF', 'MONTHLY', 'ANNUAL']);
 }
 
 function toHumanReadableContributionType(contributionType: ContributionType): 'Single' | 'Monthly' | 'Annual' {

--- a/assets/pages/new-contributions-landing/components/ContributionTypeTabs.jsx
+++ b/assets/pages/new-contributions-landing/components/ContributionTypeTabs.jsx
@@ -14,7 +14,6 @@ import {
 
 import { trackComponentClick } from 'helpers/tracking/ophanComponentEventTracking';
 import type { IsoCountry } from 'helpers/internationalisation/country';
-import type { Participations } from 'helpers/abTests/abtest';
 import type { Switches } from 'helpers/settings';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { type State } from '../contributionsLandingReducer';
@@ -28,7 +27,6 @@ type PropTypes = {|
   countryGroupId: CountryGroupId,
   switches: Switches,
   onSelectContributionType: (ContributionType, Switches, IsoCountry, CountryGroupId) => void,
-  abParticipations: Participations,
 |};
 
 const mapStateToProps = (state: State) => ({
@@ -36,7 +34,6 @@ const mapStateToProps = (state: State) => ({
   contributionType: state.page.form.contributionType,
   countryId: state.common.internationalisation.countryId,
   switches: state.common.settings.switches,
-  abParticipations: state.common.abParticipations,
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -59,7 +56,7 @@ function ContributionTypeTabs(props: PropTypes) {
     <fieldset className={classNameWithModifiers('form__radio-group', ['tabs', 'contribution-type'])}>
       <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>Recurrence</legend>
       <ul className="form__radio-group-list">
-        {getValidContributionTypes(props.abParticipations).map((contributionType: ContributionType) => (
+        {getValidContributionTypes().map((contributionType: ContributionType) => (
           <li className="form__radio-group-item">
             <input
               id={`contributionType-${contributionType}`}

--- a/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -64,9 +64,9 @@ function getInitialContributionType(abParticipations: Participations): Contribut
 
   return (
     // make sure we don't select a contribution type which isn't on the page
-    getValidContributionTypes(abParticipations).includes(contributionType)
+    getValidContributionTypes().includes(contributionType)
       ? contributionType
-      : getValidContributionTypes(abParticipations)[0]
+      : getValidContributionTypes()[0]
   );
 }
 


### PR DESCRIPTION
## Why are you doing this?
It was taking a hit in terms of AV (not In Year Revenue, but never mind that for now), so we are removing the variant. This will also mean we get the results for the Default Annual variant quicker. 