### PR TITLE
default to stripe if country does not support dd

### DIFF
--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -178,7 +178,7 @@ function initReducer(countryGroupId: CountryGroupId) {
     stateProvince: null,
     telephone: '',
     billingPeriod: initialBillingPeriod,
-    paymentMethod: 'DirectDebit',
+    paymentMethod: countrySupportsDirectDebit(user.country || null) ? 'DirectDebit' : 'Stripe',
     formErrors: [],
     submissionError: null,
     formSubmitted: false,


### PR DESCRIPTION
If the user lands on an intl checkout they will have direct debit preselected as their payment option