### PR TITLE
Copy update, small layout update a safari fix

### DIFF
--- a/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
+++ b/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
@@ -18,7 +18,7 @@ import SvgChevron from 'components/svgs/chevron';
 import { CirclesLeft, CirclesRight } from 'components/svgs/digitalSubscriptionLandingHeaderCircles';
 import AnchorButton from 'components/button/anchorButton';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import { displayPrice, sendTrackingEventsOnClick, type SubscriptionProduct } from 'helpers/subscriptions';
+import { sendTrackingEventsOnClick, type SubscriptionProduct } from 'helpers/subscriptions';
 import { flashSaleIsActive, getSaleCopy } from 'helpers/flashSale';
 
 import CtaSwitch from './ctaSwitch';

--- a/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
+++ b/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
@@ -152,7 +152,7 @@ function getCopy(product: SubscriptionProduct, country: CountryGroupId) {
   }
   return {
     heading: 'Digital Pack',
-    subHeading: `14-day free trial and then ${displayPrice('DigitalPack', country)}`,
+    subHeading: 'Award-winning, independent journalism, ad-free on all devices',
   };
 }
 

--- a/assets/pages/digital-subscription-landing/components/form.jsx
+++ b/assets/pages/digital-subscription-landing/components/form.jsx
@@ -40,7 +40,7 @@ export const billingPeriods = {
   [Annual]: {
     title: 'Annually',
     offer: 'Save 17%',
-    copy: (countryGroupId: CountryGroupId) => `${getPrice(countryGroupId, Annual)} every 12 months (save ${showPrice(getAnnualSaving(countryGroupId))} per year)`,
+    copy: (countryGroupId: CountryGroupId) => `14 day free trial, then ${getPrice(countryGroupId, Annual)} every 12 months (save ${showPrice(getAnnualSaving(countryGroupId))} per year)`,
   },
 };
 

--- a/assets/pages/digital-subscription-landing/components/productBlock.jsx
+++ b/assets/pages/digital-subscription-landing/components/productBlock.jsx
@@ -110,10 +110,12 @@ function ProductBlock(props: PropTypes) {
   return (
     <div className="product-block">
       <LeftMarginSection>
-        <h2 className="product-block__heading">
-          Read the Guardian ad-free on all your devices, plus get all the
-          benefits of the Premium App and Daily Edition iPad app
-        </h2>
+        <div className="product-block__heading-wrapper">
+          <h2 className="product-block__heading">
+            Read the Guardian ad-free on all your devices, plus get all the
+            benefits of the Premium App and Daily Edition iPad app
+          </h2>
+        </div>
         <Product
           modifierClass="premium-app"
           imageProps={appImages[props.countryGroupId]}

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -40,12 +40,26 @@
   // ----- Product Block
 
   .product-block {
+
+    .product-block__heading-wrapper {
+      @include mq($from: phablet) {
+        width: 100%; 
+      }
+    }
+
     .component-left-margin-section__content {
       position: relative;
+      
+      @include mq($from: phablet) {
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;  
+      }
 
       @include mq($from: desktop) {
         border-left: 1px solid gu-colour(garnett-neutral-4);
       }
+      
     }
 
     .component-grid-image {
@@ -63,6 +77,8 @@
     }
 
     .component-price-cta {
+      width: 100%;
+      
       @include mq($until: desktop) {
         margin-top: $gu-v-spacing * 2;
       }
@@ -323,33 +339,31 @@
     font-family: $gu-headline;
     font-weight: bold;
     margin-left: 10px;
-    padding-top: 2px;
+    padding: $gu-v-spacing/6 0 $gu-v-spacing/2;
     font-size: 22px;
     line-height: 29px;
     min-height: 70px;
     width: 250px;
+    
 
     @include mq($from: mobileMedium, $until: tablet) {
       padding-top: 8px;
       font-size: 28px;
       line-height: 34px;
       width: 380px;
-      height: 80px;
     }
 
     @include mq($from: tablet, $until: leftCol) {
       width: 560px;
       font-size: 42px;
       line-height: 48px;
-      height: 106px;
     }
 
     @include mq($from: leftCol) {
-      width: 600px;
+      width: 560px;
       font-size: 44px;
       line-height: 50px;
       margin-left: 12px;
-      height: 108px;
     }
   }
 


### PR DESCRIPTION
## Why are you doing this?

I missed some copy updates on this card the fist time around and a safari layout issue was noticed whilst updating this page. 

[**Trello Card**](https://trello.com/c/YkggErle/2177-update-incorrect-info-on-annual-option-for-dp-testhttps://trello.com/c/YkggErle/2177-update-incorrect-info-on-annual-option-for-dp-test)

## Changes

* Copy updates
* Remove some fixed height css in `class="digital-subscription-landing-header__wrapper"` 
* Added a wrapper around h2 to which spans full width whilst maintaining a max width of the text within 
* Added css to maintain layout in Safari 11.1.2

## Screenshots

![screen shot 2019-01-25 at 14 24 31](https://user-images.githubusercontent.com/1108991/51751801-b8995b80-20ad-11e9-952a-733f71b1d428.png)
^ broken

![screen shot 2019-01-25 at 14 31 40](https://user-images.githubusercontent.com/1108991/51751906-f302f880-20ad-11e9-9080-13861af462f2.png)
Fixed!
