### PR TITLE
Default to annual contributions

### DIFF
--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -1,5 +1,4 @@
 // @flow
-import { getQueryParameter } from 'helpers/url';
 import type { Tests } from './abtest';
 
 // ----- Tests ----- //
@@ -18,23 +17,6 @@ export const tests: Tests = {
     isActive: false,
     independent: true,
     seed: 3,
-  },
-
-  globalContributionTypes: {
-    variants: [
-      'control',
-      'default-annual',
-    ],
-    audiences: {
-      ALL: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: true,
-    independent: true,
-    seed: 5,
-    canRun: () => !getQueryParameter('contributionTypes') && !getQueryParameter('selectedContributionType'),
   },
 
 };

--- a/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -20,7 +20,6 @@ import {
   type ThirdPartyPaymentLibrary,
 } from 'helpers/checkouts';
 import { getAnnualAmounts } from 'helpers/abTests/helpers/annualContributions';
-import type { Participations } from 'helpers/abTests/abtest';
 import { type Amount, type ContributionType, type PaymentMethod } from 'helpers/contributions';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import {
@@ -53,14 +52,8 @@ function getInitialPaymentMethod(
   );
 }
 
-function getInitialContributionType(abParticipations: Participations): ContributionType {
-  const { globalContributionTypes } = abParticipations;
-  const abTestParams = globalContributionTypes
-    ? globalContributionTypes.split('_')
-    : [];
-
-  const fallback = abTestParams.includes('default-annual') ? 'ANNUAL' : 'MONTHLY';
-  const contributionType = getContributionTypeFromUrlOrElse(getContributionTypeFromSessionOrElse(fallback));
+function getInitialContributionType(): ContributionType {
+  const contributionType = getContributionTypeFromUrlOrElse(getContributionTypeFromSessionOrElse('ANNUAL'));
 
   return (
     // make sure we don't select a contribution type which isn't on the page
@@ -138,8 +131,7 @@ function selectInitialAnnualAmount(state: State, dispatch: Function) {
 function selectInitialContributionTypeAndPaymentMethod(state: State, dispatch: Function) {
   const { countryId } = state.common.internationalisation;
   const { switches } = state.common.settings;
-  const { abParticipations } = state.common;
-  const contributionType = getInitialContributionType(abParticipations);
+  const contributionType = getInitialContributionType();
   const paymentMethod = getInitialPaymentMethod(contributionType, countryId, switches);
 
   dispatch(updateContributionTypeAndPaymentMethod(contributionType, paymentMethod));


### PR DESCRIPTION
## Why are you doing this?
Following [this test](https://github.com/guardian/support-frontend/pull/1382), we have decided to default to annual contributions, globally. 