### PR TITLE
Fix signout link

### DIFF
--- a/assets/components/signout/signout.jsx
+++ b/assets/components/signout/signout.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
-import { getBaseDomain } from 'helpers/url';
+import { signoutUrl } from 'helpers/routes';
 
 // ---- Types ----- //
 
@@ -13,18 +13,6 @@ type PropTypes = {
   isSignedIn: boolean,
 };
 
-
-// ----- Functions ----- //
-
-// Build signout URL from given return URL or current location.
-function buildUrl(returnUrl: ?string): string {
-
-  const encodedReturn = encodeURIComponent(returnUrl || window.location);
-
-  return `https://profile.${getBaseDomain()}/signout?returnUrl=${encodedReturn}`;
-
-}
-
 // ----- Component ----- //
 
 const Signout = (props: PropTypes) => {
@@ -32,7 +20,7 @@ const Signout = (props: PropTypes) => {
     return null;
   }
   return (
-    <a className="component-signout" href={buildUrl(props.returnUrl)}>
+    <a className="component-signout" href={signoutUrl(props.returnUrl)}>
       Not you? Sign out
     </a>
   );

--- a/assets/components/signout/signout.jsx
+++ b/assets/components/signout/signout.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
-import { signoutUrl } from 'helpers/routes';
+import { getSignoutUrl } from 'helpers/externalLinks';
 
 // ---- Types ----- //
 
@@ -20,7 +20,7 @@ const Signout = (props: PropTypes) => {
     return null;
   }
   return (
-    <a className="component-signout" href={signoutUrl(props.returnUrl)}>
+    <a className="component-signout" href={getSignoutUrl(props.returnUrl)}>
       Not you? Sign out
     </a>
   );

--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -35,7 +35,6 @@ const profileUrl = `https://profile.${getBaseDomain()}`;
 const defaultIntCmp = 'gdnwb_copts_bundles_landing_default';
 const androidAppUrl = 'https://play.google.com/store/apps/details?id=com.guardian';
 const emailPreferencesUrl = `${profileUrl}/email-prefs`;
-const logoutUrl = `${profileUrl}/logout`;
 
 function getWeeklyZuoraCode(period: WeeklyBillingPeriod, countryGroup: CountryGroupId) {
 
@@ -396,7 +395,6 @@ export {
   getDigitalCheckout,
   getIosAppUrl,
   androidAppUrl,
-  logoutUrl,
   getDailyEditionUrl,
   emailPreferencesUrl,
   getWeeklyCheckout,

--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -386,6 +386,11 @@ function getDailyEditionUrl(countryGroupId: CountryGroupId) {
   return getAppleStoreUrl('guardian-observer-daily-edition/id452707806', countryGroupId);
 }
 
+function getSignoutUrl(returnUrl: ?string): string {
+  const encodedReturn = encodeURIComponent(returnUrl || window.location);
+  return `https://profile.${getBaseDomain()}/signout?returnUrl=${encodedReturn}`;
+}
+
 // ----- Exports ----- //
 
 export {
@@ -396,6 +401,7 @@ export {
   getIosAppUrl,
   androidAppUrl,
   getDailyEditionUrl,
+  getSignoutUrl,
   emailPreferencesUrl,
   getWeeklyCheckout,
   getPaperCheckout,

--- a/assets/helpers/routes.js
+++ b/assets/helpers/routes.js
@@ -4,7 +4,7 @@
 
 import type { CountryGroupId } from './internationalisation/countryGroup';
 import { countryGroups } from './internationalisation/countryGroup';
-import { getOrigin } from './url';
+import { getBaseDomain, getOrigin } from './url';
 
 const routes: {
   [string]: string,
@@ -32,6 +32,11 @@ function paperSubsUrl(withDelivery: boolean = false): string {
   return [getOrigin(), 'uk/subscribe/paper', ...(withDelivery ? ['delivery'] : [])].join('/');
 }
 
+function signoutUrl(returnUrl: ?string): string {
+  const encodedReturn = encodeURIComponent(returnUrl || window.location);
+  return `https://profile.${getBaseDomain()}/signout?returnUrl=${encodedReturn}`;
+}
+
 function payPalCancelUrl(cgId: CountryGroupId): string {
   return `${getOrigin()}/${countryGroups[cgId].supportInternationalisationId}/contribute`;
 }
@@ -43,4 +48,4 @@ function payPalReturnUrl(cgId: CountryGroupId): string {
 
 // ----- Exports ----- //
 
-export { routes, payPalCancelUrl, payPalReturnUrl, paperSubsUrl };
+export { routes, signoutUrl, payPalCancelUrl, payPalReturnUrl, paperSubsUrl };

--- a/assets/helpers/routes.js
+++ b/assets/helpers/routes.js
@@ -4,7 +4,7 @@
 
 import type { CountryGroupId } from './internationalisation/countryGroup';
 import { countryGroups } from './internationalisation/countryGroup';
-import { getBaseDomain, getOrigin } from './url';
+import { getOrigin } from './url';
 
 const routes: {
   [string]: string,
@@ -32,11 +32,6 @@ function paperSubsUrl(withDelivery: boolean = false): string {
   return [getOrigin(), 'uk/subscribe/paper', ...(withDelivery ? ['delivery'] : [])].join('/');
 }
 
-function signoutUrl(returnUrl: ?string): string {
-  const encodedReturn = encodeURIComponent(returnUrl || window.location);
-  return `https://profile.${getBaseDomain()}/signout?returnUrl=${encodedReturn}`;
-}
-
 function payPalCancelUrl(cgId: CountryGroupId): string {
   return `${getOrigin()}/${countryGroups[cgId].supportInternationalisationId}/contribute`;
 }
@@ -48,4 +43,4 @@ function payPalReturnUrl(cgId: CountryGroupId): string {
 
 // ----- Exports ----- //
 
-export { routes, signoutUrl, payPalCancelUrl, payPalReturnUrl, paperSubsUrl };
+export { routes, payPalCancelUrl, payPalReturnUrl, paperSubsUrl };

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -22,7 +22,7 @@ import {
   marketingConsentReducerFor,
   type State as MarketingConsentState,
 } from 'components/marketingConsent/marketingConsentReducer';
-import { signoutUrl } from 'helpers/routes';
+import { getSignoutUrl } from 'helpers/externalLinks';
 import { isTestUser } from 'helpers/user/user';
 import type { ErrorReason } from 'helpers/errorReasons';
 import { createUserReducer } from 'helpers/user/userReducer';
@@ -134,7 +134,7 @@ const setFormErrors = (errors: Array<FormError<FormField>>): Action => ({ type: 
 const setSubmissionError = (error: ErrorReason): Action => ({ type: 'SET_SUBMISSION_ERROR', error });
 const setFormSubmitted = (formSubmitted: boolean) => ({ type: 'SET_FORM_SUBMITTED', formSubmitted });
 
-const signOut = () => { window.location.href = signoutUrl(); };
+const signOut = () => { window.location.href = getSignoutUrl(); };
 
 function submitForm(dispatch: Dispatch<Action>, state: State) {
   const errors = getErrors(getFormFields(state));

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -22,9 +22,9 @@ import {
   marketingConsentReducerFor,
   type State as MarketingConsentState,
 } from 'components/marketingConsent/marketingConsentReducer';
+import { signoutUrl } from 'helpers/routes';
 import { isTestUser } from 'helpers/user/user';
 import type { ErrorReason } from 'helpers/errorReasons';
-import { logoutUrl } from 'helpers/externalLinks';
 import { createUserReducer } from 'helpers/user/userReducer';
 import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
@@ -134,7 +134,7 @@ const setFormErrors = (errors: Array<FormError<FormField>>): Action => ({ type: 
 const setSubmissionError = (error: ErrorReason): Action => ({ type: 'SET_SUBMISSION_ERROR', error });
 const setFormSubmitted = (formSubmitted: boolean) => ({ type: 'SET_FORM_SUBMITTED', formSubmitted });
 
-const signOut = () => { window.location.href = logoutUrl; };
+const signOut = () => { window.location.href = signoutUrl(); };
 
 function submitForm(dispatch: Dispatch<Action>, state: State) {
   const errors = getErrors(getFormFields(state));


### PR DESCRIPTION
## Why are you doing this?

Currently the sign out link on the new Digital Pack Checkout flow is broken (results in 404). 

This change allows us to sign users out > drop them into the sign-in flow > back into Digital Pack Checkout.

## Changes

* Reuse function which does this for contributions page
* Remove logout URL