### PR TITLE
Additional hover affordance added

### DIFF
--- a/assets/components/productPage/productPagePlanForm/productPagePlanFormLabel.scss
+++ b/assets/components/productPage/productPagePlanForm/productPagePlanFormLabel.scss
@@ -35,6 +35,7 @@
   padding: $gu-v-spacing/2.15 $gu-h-spacing/2;
   background-color: gu-colour(garnett-neutral-4);
   position: relative;
+  transition: .2s background;
 }
 
 .component-product-page-plan-form-label__content {
@@ -66,6 +67,10 @@
 .component-product-page-plan-form-label__input:hover + .component-product-page-plan-form-label__box,
 .component-product-page-plan-form-label__input:focus + .component-product-page-plan-form-label__box {
   box-shadow: 0 0 0 2px rgba(gu-colour(garnett-neutral-5),.25);
+}
+.component-product-page-plan-form-label__input:hover + .component-product-page-plan-form-label__box .component-product-page-plan-form-label__title,
+.component-product-page-plan-form-label__input:focus + .component-product-page-plan-form-label__box .component-product-page-plan-form-label__title {
+  background: gu-colour(news-garnett-highlight);
 }
 
 .component-product-page-plan-form-label__input:checked + .component-product-page-plan-form-label__box {


### PR DESCRIPTION
## Why are you doing this?

As part of the Print Page optimisation task we are added a more prominent hover style to the `component-product-page-plan-form__item` card.

[**Trello Card**](https://trello.com/c/ecK4Jpqq/2146-print-product-page-optimisation)

## Changes

* Added a background colour change to the hover and focus style

## Screenshots

![screen shot 2019-01-28 at 14 55 08](https://user-images.githubusercontent.com/1108991/51844291-c7ca1480-230c-11e9-9150-e8d24fa7d4f9.png)