### PR TITLE
Don't reference recurring contributions in SupportWorkersClient

### DIFF
--- a/app/services/stepfunctions/SupportWorkersClient.scala
+++ b/app/services/stepfunctions/SupportWorkersClient.scala
@@ -105,18 +105,18 @@ class SupportWorkersClient(
     )
     underlying.triggerExecution(createPaymentMethodState, user.isTestUser).bimap(
       { error =>
-        SafeLogger.error(scrub"[$requestId] Failed to create regular contribution for ${user.id} - $error")
+        SafeLogger.error(scrub"[$requestId] Failed to trigger Step Function execution for ${user.id} - $error")
         StateMachineFailure: SupportWorkersError
       },
       { success =>
-        SafeLogger.info(s"[$requestId] Creating regular contribution for ${user.id} ($success)")
+        SafeLogger.info(s"[$requestId] Successfully triggered Step Function execution for ${user.id} ($success)")
         underlying.jobIdFromArn(success.arn).map { jobId =>
           StatusResponse(
             status = Status.Pending,
             trackingUri = supportUrl + statusCall(jobId).url
           )
         } getOrElse {
-          SafeLogger.error(scrub"[$requestId] Failed to parse ${success.arn} to a jobId when creating new regular contribution for ${user.id} $request")
+          SafeLogger.error(scrub"[$requestId] Failed to parse ${success.arn} to a jobId after triggering Step Function execution for ${user.id} $request")
           StatusResponse(
             status = Status.Failure,
             trackingUri = "",


### PR DESCRIPTION
## Why are you doing this?

This client is now used to create Digital Pack subs (and will soon support other subscriptions products), so the logging should not reference contributions.

## Changes

* Improve log messages

## Screenshots
N/A
