### PR TITLE
Aligning S&C tabs with theguardian.com style

### DIFF
--- a/assets/components/productPage/productPageContentBlock/productPageContentBlock.jsx
+++ b/assets/components/productPage/productPageContentBlock/productPageContentBlock.jsx
@@ -17,16 +17,30 @@ type PropTypes = {|
   children: Node,
   image: Option<Node>,
   modifierClasses: Array<string>,
-  needsHigherZindex: boolean
+  needsHigherZindex: boolean,
+  border: Option<boolean>,
 |};
 
 
 // ----- Render ----- //
 
 const ProductPageContentBlock = ({
-  type, children, id, modifierClasses, image, needsHigherZindex,
+  type, children, id, modifierClasses, image, needsHigherZindex, border,
 }: PropTypes) => (
-  <div id={id} className={classNameWithModifiers('component-product-page-content-block', [type, image ? 'overflow-hidden' : null, needsHigherZindex ? 'higher' : null, ...modifierClasses])}>
+  <div
+    id={id}
+    className={classNameWithModifiers(
+'component-product-page-content-block',
+    [
+      type,
+      image ? 'overflow-hidden' : null,
+      needsHigherZindex ? 'higher' : null,
+      border === false ? 'no-border' : null,
+      border === true ? 'force-border' : null,
+      ...modifierClasses,
+    ],
+)}
+  >
     <LeftMarginSection>
       <div className="component-product-page-content-block__content">
         {children}
@@ -44,6 +58,7 @@ ProductPageContentBlock.defaultProps = {
   image: null,
   modifierClasses: [],
   needsHigherZindex: false,
+  border: null,
 };
 
 

--- a/assets/components/productPage/productPageContentBlock/productPageContentBlock.scss
+++ b/assets/components/productPage/productPageContentBlock/productPageContentBlock.scss
@@ -17,37 +17,14 @@
   & .component-product-page-content-block-divider__line {
     @include multiline(4, $border);
   }
-  /*
-  All our ContentBlocks have the behaviour of rendering 
-  with a border between them if there's two with the same 
-  background colour in a row.
-
-  These selectors attempt to enforce this by applying the 
-  border to .selector + .selector (adjacent sibling) 
-  
-  The second selector applies the rule to the first child 
-  of an element wrapped in an extra div if it matches the 
-  classname (because React makes you do that sometimes)
-
-  I hope this explains it:
-
-  +----------------+
-  | blue block     |
-  +----------------+
-  +----------------+
-  | wrapping div   |
-  |+--------------+|
-  || another blue ||
-  || block        ||
-  |+--------------+|
-  +----------------+
-
-  */
-  & + &,
-  & + div > &:first-child  {
+  &.component-product-page-content-block--force-border,
+  & + &  {
     .component-left-margin-section__content {
       border-top: 1px solid $border;
     }
+  }
+  &.component-product-page-content-block--no-border  .component-left-margin-section__content {
+    border-top: 0 !important;  
   }    
 }
 
@@ -150,7 +127,8 @@
   cancel out initial padding
   */
   .component-product-page-content-block__content > .component-product-page-content-block-divider:first-child,
-  .component-checkout {
+  .component-checkout,
+  .component-product-page-tabs {
     margin-top: ($gu-v-spacing*-.5) - 1px;
   }
 }

--- a/assets/components/productPage/productPageTabs/productPageTabs.scss
+++ b/assets/components/productPage/productPageTabs/productPageTabs.scss
@@ -19,14 +19,10 @@
   }
 }
 
-.component-product-page-tabs__li:last-child {
-  box-shadow: 1px 0 0 0 gu-colour(garnett-neutral-4);
-}
-
 .component-product-page-tabs__li + .component-product-page-tabs__li .component-product-page-tabs__tab {
   &:before {
     position: absolute;
-    bottom: 1.0625rem;
+    bottom: $gu-h-spacing*0.8;
     left: 0;
     width: 1px;
     height: 100%;
@@ -36,6 +32,7 @@
 }
 
 .component-product-page-tabs__tab {
+  @include gu-fontset-tabs;
   position: relative;
   text-decoration: none;
   padding: ($gu-v-spacing)*1.3 $gu-h-spacing/2;
@@ -50,8 +47,6 @@
   appearance: none;
   box-sizing: border-box;
   transition: box-shadow 0.2s;
-  font-family: $gu-headline;
-  font-weight: 700;
   line-height: 1;
 
   cursor: pointer;

--- a/assets/components/productPage/productPageTabs/productPageTabs.scss
+++ b/assets/components/productPage/productPageTabs/productPageTabs.scss
@@ -13,24 +13,47 @@
 }
 
 .component-product-page-tabs__li {
+  overflow: hidden;
   @include mq($until:phablet) {
     flex: 1 1 0;
   }
 }
 
+.component-product-page-tabs__li:last-child {
+  box-shadow: 1px 0 0 0 gu-colour(garnett-neutral-4);
+}
+
+.component-product-page-tabs__li + .component-product-page-tabs__li .component-product-page-tabs__tab {
+  &:before {
+    position: absolute;
+    bottom: 1.0625rem;
+    left: 0;
+    width: 1px;
+    height: 100%;
+    background: gu-colour(garnett-neutral-4);
+    content: '';
+  }
+}
+
 .component-product-page-tabs__tab {
-  @include gu-fontset-heading-sans;
+  position: relative;
   text-decoration: none;
-  padding: ($gu-v-spacing)/1.25 $gu-h-spacing/2 ($gu-v-spacing)/1.5;
+  padding: ($gu-v-spacing)*1.3 $gu-h-spacing/2;
+  margin: 0 -1px 0 0;
   display: block;
   width: 100%;
   border: 0;
   margin-right: -1px;
-  box-shadow: inset 0 0 0 1px gu-colour(garnett-neutral-4); 
+  box-shadow: inset 0 1px 0 0 gu-colour(garnett-neutral-4);
   color: gu-colour(garnett-neutral-1);
   text-align: left;
   appearance: none;
   box-sizing: border-box;
+  transition: box-shadow 0.2s;
+  font-family: $gu-headline;
+  font-weight: 700;
+  line-height: 1;
+
   cursor: pointer;
   @include mq($from:phablet) {
     min-width: gu-span(3) + $gu-h-spacing/2;
@@ -42,7 +65,7 @@
 }
 
 .component-product-page-tabs__tab--active {
-  box-shadow: inset 0 4px 0 0 gu-colour(news-garnett-highlight), inset 1px 0 0 0 gu-colour(garnett-neutral-4), inset -1px 0 0 0 gu-colour(garnett-neutral-4), inset 0 -1px 0 0 gu-colour(garnett-neutral-5) ;
+  box-shadow: inset 0 4px 0 0 gu-colour(news-garnett-highlight);
   text-decoration: none;
   pointer-events: none;
   cursor: default;
@@ -50,5 +73,5 @@
 
 .component-product-page-tabs__tab:focus,
 .component-product-page-tabs__tab:hover {
-  box-shadow: inset 0 4px 0 0 gu-colour(garnett-neutral-4), inset 0 0 0 1px gu-colour(garnett-neutral-4);
+  box-shadow: inset 0 4px 0 0 gu-colour(garnett-neutral-4);
 }

--- a/assets/pages/paper-subscription-landing/components/content.jsx
+++ b/assets/pages/paper-subscription-landing/components/content.jsx
@@ -85,12 +85,14 @@ ContentForm.defaultProps = { text: null };
 
 
 const ContentVoucherFaqBlock = () => (
-  <ProductPageContentBlock image={<GridImage
-    gridId="paperVoucherFeature"
-    srcSizes={[920, 500, 140]}
-    sizes="(max-width: 740px) 100vw, 500px"
-    imgType="png"
-  />
+  <ProductPageContentBlock
+    border
+    image={<GridImage
+      gridId="paperVoucherFeature"
+      srcSizes={[920, 500, 140]}
+      sizes="(max-width: 740px) 100vw, 500px"
+      imgType="png"
+    />
   }
   >
     <ProductPageTextBlock title="How do vouchers work?">
@@ -119,12 +121,14 @@ const ContentDeliveryFaqBlock = ({ setTabAction }: {setTabAction: typeof setTab}
   );
 
   return (
-    <ProductPageContentBlock image={<GridImage
-      gridId="paperDeliveryFeature"
-      srcSizes={[920, 500, 140]}
-      sizes="(max-width: 740px) 100vw, 500px"
-      imgType="png"
-    />
+    <ProductPageContentBlock
+      border
+      image={<GridImage
+        gridId="paperDeliveryFeature"
+        srcSizes={[920, 500, 140]}
+        sizes="(max-width: 740px) 100vw, 500px"
+        imgType="png"
+      />
     }
     >
       <ProductPageTextBlock title="How does delivery work?">

--- a/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
+++ b/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
@@ -110,6 +110,9 @@ const content = (
             {getStandfirst()}
           </LargeParagraph>
         </ProductPageTextBlock>
+
+      </ProductPageContentBlock>
+      <ProductPageContentBlock>
         <Tabs />
       </ProductPageContentBlock>
       <Content />

--- a/assets/stylesheets/gu-sass/typography.scss
+++ b/assets/stylesheets/gu-sass/typography.scss
@@ -27,6 +27,7 @@ $gu-fonts: (
 		family: $gu-headline,
 		sizes: (
 			16: 18px,
+			18: 20px,
 			20: 24px,
 			22: 26px,
 			24: 28px,
@@ -128,6 +129,12 @@ $gu-fonts: (
 	}
 	@if $size-only == false {
 		font-weight: 400;
+	}
+}
+@mixin gu-fontset-tabs($size-only: false) {
+	@include gu-typeface(headline, 17, $size-only);
+	@if $size-only == false {
+		font-weight: 700;
 	}
 }
 


### PR DESCRIPTION
## Why are you doing this?

The tab component in S&C needed visual alignment with .com.

It's not yet as tidy as it can be and will be revisited before it goes into Storybook but will do for now!

[**Trello Card**](https://trello.com/c/ecK4Jpqq/2146-print-product-page-optimisation)

## Changes

* Style updates to tab component

## Screenshots

![screen shot 2019-01-29 at 13 49 41](https://user-images.githubusercontent.com/1108991/51912659-bf391300-23cc-11e9-86ff-2f70f0bd1e96.png)