### PR TITLE
Add Stripe Payment Request Button support

### DIFF
--- a/assets/pages/new-contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/assets/pages/new-contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -134,7 +134,7 @@ function onClick(event, props: PropTypes) {
 // The value of result will either be:
 // . null - browser has no compatible payment method)
 // . {applePay: true} - applePay is available
-// . {applePay: false} - GooglePay or PaymentRequestApi available
+// . {applePay: false} - GooglePay, Microsoft Pay and PaymentRequestApi available
 const availablePaymentRequestButtonPaymentMethod: Object => (StripePaymentMethod | null) = (result: Object) => {
   if (result && result.applePay === true) {
     return 'StripeApplePay';

--- a/assets/pages/new-contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/assets/pages/new-contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -135,7 +135,7 @@ function onClick(event, props: PropTypes) {
 // . null - browser has no compatible payment method)
 // . {applePay: true} - applePay is available
 // . {applePay: false} - GooglePay, Microsoft Pay and PaymentRequestApi available
-const availablePaymentRequestButtonPaymentMethod: Object => (StripePaymentMethod | null) = (result: Object) => {
+const availablePaymentRequestButtonPaymentMethod = (result: Object): StripePaymentMethod | null => {
   if (result && result.applePay === true) {
     return 'StripeApplePay';
   } else if (result && result.applePay === false) {

--- a/assets/pages/new-contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/assets/pages/new-contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -170,10 +170,9 @@ function initialisePaymentRequest(props: PropTypes) {
     if (paymentMethod !== null) {
       trackComponentClick(`${paymentMethod}-loaded`);
       props.setPaymentRequestButtonPaymentMethod(paymentMethod);
-      setUpPaymentListener(paymentRequest, props, paymentMethod);
+      setUpPaymentListener(props, paymentRequest, paymentMethod);
     }
   });
-
   props.setStripePaymentRequestObject(paymentRequest);
 }
 

--- a/assets/pages/new-contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/assets/pages/new-contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -169,8 +169,8 @@ function initialisePaymentRequest(props: PropTypes) {
     const paymentMethod = availablePaymentRequestButtonPaymentMethod(result);
     if (paymentMethod !== null) {
       trackComponentClick(`${paymentMethod}-loaded`);
-      props.setPaymentRequestButtonPaymentMethod(paymentMethod);
       setUpPaymentListener(props, paymentRequest, paymentMethod);
+      props.setPaymentRequestButtonPaymentMethod(paymentMethod);
     }
   });
   props.setStripePaymentRequestObject(paymentRequest);

--- a/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -20,7 +20,7 @@ import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import { payPalRequestData } from 'helpers/paymentIntegrations/newPaymentFlow/payPalRecurringCheckout';
 import type {
   RegularPaymentRequest,
-  StripeAuthorisation,
+  StripeAuthorisation, StripePaymentMethod,
 } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
 import {
   type PaymentAuthorisation,
@@ -69,7 +69,7 @@ export type Action =
   | { type: 'SET_FORM_IS_SUBMITTABLE', formIsSubmittable: boolean }
   | { type: 'SET_THANK_YOU_PAGE_STAGE', thankYouPageStage: ThankYouPageStage }
   | { type: 'SET_STRIPE_PAYMENT_REQUEST_OBJECT', stripePaymentRequestObject: Object }
-  | { type: 'SET_CAN_MAKE_STRIPE_PAYMENT_REQUEST_PAYMENT', canMakePayment: boolean }
+  | { type: 'SET_PAYMENT_REQUEST_BUTTON_PAYMENT_METHOD', paymentMethod: StripePaymentMethod }
   | { type: 'SET_STRIPE_PAYMENT_REQUEST_BUTTON_CLICKED' }
   | { type: 'SET_STRIPE_V3_HAS_LOADED' }
   | { type: 'SET_PAYPAL_HAS_LOADED' }
@@ -115,8 +115,8 @@ const updateEmail = (email: string): ((Function) => void) =>
 
 const updatePassword = (password: string): Action => ({ type: 'UPDATE_PASSWORD', password });
 
-const setCanMakeStripePaymentRequestPayment =
-  (canMakePayment: boolean): Action => ({ type: 'SET_CAN_MAKE_STRIPE_PAYMENT_REQUEST_PAYMENT', canMakePayment });
+const setPaymentRequestButtonPaymentMethod =
+  (paymentMethod: StripePaymentMethod): Action => ({ type: 'SET_PAYMENT_REQUEST_BUTTON_PAYMENT_METHOD', paymentMethod });
 
 const setStripePaymentRequestObject =
   (stripePaymentRequestObject: Object): Action => ({ type: 'SET_STRIPE_PAYMENT_REQUEST_OBJECT', stripePaymentRequestObject });
@@ -517,7 +517,7 @@ export {
   checkIfEmailHasPassword,
   setFormIsValid,
   sendFormSubmitEventForPayPalRecurring,
-  setCanMakeStripePaymentRequestPayment,
+  setPaymentRequestButtonPaymentMethod,
   setStripePaymentRequestObject,
   onStripePaymentRequestApiPaymentAuthorised,
   setStripePaymentRequestButtonClicked,

--- a/assets/pages/new-contributions-landing/contributionsLandingReducer.js
+++ b/assets/pages/new-contributions-landing/contributionsLandingReducer.js
@@ -12,6 +12,7 @@ import { type UsState, type CaState } from 'helpers/internationalisation/country
 import { createUserReducer, type User as UserState } from 'helpers/user/userReducer';
 import { type DirectDebitState } from 'components/directDebit/directDebitReducer';
 import { directDebitReducer as directDebit } from 'components/directDebit/directDebitReducer';
+import type { StripePaymentMethod } from 'helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis';
 import type { OtherAmounts, SelectedAmounts } from 'helpers/contributions';
 import { type Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import { getContributionTypeFromSessionOrElse } from 'helpers/checkouts';
@@ -52,7 +53,7 @@ type SetPasswordData = {
 }
 
 type StripePaymentRequestButtonData = {
-  canMakeStripePaymentRequestPayment: boolean,
+  paymentMethod: StripePaymentMethod | null,
   stripePaymentRequestObject: Object | null,
   stripePaymentRequestButtonClicked: boolean,
   stripeV3HasLoaded: boolean,
@@ -137,7 +138,7 @@ function createFormReducer(countryGroupId: CountryGroupId) {
       checkoutFormHasBeenSubmitted: false,
     },
     stripePaymentRequestButtonData: {
-      canMakeStripePaymentRequestPayment: false,
+      paymentMethod: null,
       stripePaymentRequestObject: null,
       stripePaymentRequestButtonClicked: false,
       stripeV3HasLoaded: false,
@@ -217,12 +218,12 @@ function createFormReducer(countryGroupId: CountryGroupId) {
       case 'UPDATE_STATE':
         return { ...state, formData: { ...state.formData, state: action.state } };
 
-      case 'SET_CAN_MAKE_STRIPE_PAYMENT_REQUEST_PAYMENT':
+      case 'SET_PAYMENT_REQUEST_BUTTON_PAYMENT_METHOD':
         return {
           ...state,
           stripePaymentRequestButtonData: {
             ...state.stripePaymentRequestButtonData,
-            canMakeStripePaymentRequestPayment: action.canMakePayment,
+            paymentMethod: action.paymentMethod,
           },
         };
 


### PR DESCRIPTION
## Why are you doing this?
Now that the Stripe contract has been updated to take Google Pay into account, we (almost) can allow the Payment Request Button to be used to take one off payments. Woohoo!



| The Stripe Payment Request Button in all it's glory |
|------------|
|![stripe](https://user-images.githubusercontent.com/2844554/51924617-42666300-23e5-11e9-911f-e00996421801.gif)|
