### PR TITLE
Route alias for optimize

### DIFF
--- a/assets/pages/new-contributions-landing/contributionsLanding.jsx
+++ b/assets/pages/new-contributions-landing/contributionsLanding.jsx
@@ -59,33 +59,26 @@ const setOneOffContributionCookie = () => {
   );
 };
 
-const ContributionLandingPage = (
-  <Page
-    classModifiers={['contribution-form']}
-    header={<RoundelHeader selectedCountryGroup={selectedCountryGroup} />}
-    footer={<Footer disclaimer countryGroupId={countryGroupId} />}
-  >
-    <NewContributionFormContainer
-      thankYouRoute={`/${countryGroups[countryGroupId].supportInternationalisationId}/thankyou`}
-    />
-    <NewContributionBackground />
-  </Page>
-);
-
 const router = (
   <BrowserRouter>
     <Provider store={store}>
       <div>
+        {/* the optional dummy section is so we can do an A/A redirect test in Optimize */}
         <Route
           exact
-          path="/:countryId(uk|us|au|eu|int|nz|ca)/contribute"
-          render={() => ContributionLandingPage}
-        />
-        {/* this is just an alias for the above, so we can do a dummy A/A redirect test in Optimize */ }
-        <Route
-          exact
-          path="/:countryId(uk|us|au|eu|int|nz|ca)/o/contribute"
-          render={() => ContributionLandingPage}
+          path="/:countryId(uk|us|au|eu|int|nz|ca)/:dummy?/contribute"
+          render={() => (
+            <Page
+              classModifiers={['contribution-form']}
+              header={<RoundelHeader selectedCountryGroup={selectedCountryGroup} />}
+              footer={<Footer disclaimer countryGroupId={countryGroupId} />}
+            >
+              <NewContributionFormContainer
+                thankYouRoute={`/${countryGroups[countryGroupId].supportInternationalisationId}/thankyou`}
+              />
+              <NewContributionBackground />
+            </Page>
+          )}
         />
         <Route
           exact

--- a/assets/pages/new-contributions-landing/contributionsLanding.jsx
+++ b/assets/pages/new-contributions-landing/contributionsLanding.jsx
@@ -59,26 +59,33 @@ const setOneOffContributionCookie = () => {
   );
 };
 
+const ContributionLandingPage = (
+  <Page
+    classModifiers={['contribution-form']}
+    header={<RoundelHeader selectedCountryGroup={selectedCountryGroup} />}
+    footer={<Footer disclaimer countryGroupId={countryGroupId} />}
+  >
+    <NewContributionFormContainer
+      thankYouRoute={`/${countryGroups[countryGroupId].supportInternationalisationId}/thankyou`}
+    />
+    <NewContributionBackground />
+  </Page>
+);
+
 const router = (
   <BrowserRouter>
     <Provider store={store}>
       <div>
         <Route
           exact
-          path="/:countryId(uk|us|au|eu|int|nz|ca)/(o/)?contribute"
-          render={() => (
-            <Page
-              classModifiers={['contribution-form']}
-              header={<RoundelHeader selectedCountryGroup={selectedCountryGroup} />}
-              footer={<Footer disclaimer countryGroupId={countryGroupId} />}
-            >
-              <NewContributionFormContainer
-                thankYouRoute={`/${countryGroups[countryGroupId].supportInternationalisationId}/thankyou`}
-              />
-              <NewContributionBackground />
-            </Page>
-          )
-        }
+          path="/:countryId(uk|us|au|eu|int|nz|ca)/contribute"
+          render={() => ContributionLandingPage}
+        />
+        {/* this is just an alias for the above, so we can do a dummy A/A redirect test in Optimize */ }
+        <Route
+          exact
+          path="/:countryId(uk|us|au|eu|int|nz|ca)/o/contribute"
+          render={() => ContributionLandingPage}
         />
         <Route
           exact

--- a/assets/pages/new-contributions-landing/contributionsLanding.jsx
+++ b/assets/pages/new-contributions-landing/contributionsLanding.jsx
@@ -65,7 +65,7 @@ const router = (
       <div>
         <Route
           exact
-          path="/:countryId(uk|us|au|eu|int|nz|ca)/contribute"
+          path="/:countryId(uk|us|au|eu|int|nz|ca)/(o/)?contribute"
           render={() => (
             <Page
               classModifiers={['contribution-form']}

--- a/conf/routes
+++ b/conf/routes
@@ -39,6 +39,8 @@ GET  /monthly-contributions                         controllers.Application.cont
 
 GET  /contribute                                        controllers.Application.contributeGeoRedirect()
 GET  /$country<(uk|us|au|eu|int|nz|ca)>/contribute      controllers.Application.contributionsLanding(country: String)
+# this one is just an alias for the above, so we can do a dummy A/A redirect test in Optimize
+GET  /$country<(uk|us|au|eu|int|nz|ca)>/o/contribute    controllers.Application.contributionsLanding(country: String)
 GET  /$country<(uk|us|au|eu|int|nz|ca)>/thankyou        controllers.Application.contributionsLanding(country: String)
 
 GET  /contribute/recurring                          controllers.RegularContributions.displayFormAuthenticated()


### PR DESCRIPTION
@jessewilkins and I were talking about how the results from the Optimize A/A redirect test are very strange.

Optimize redirects to `?test`, which is supposed to be a dummy parameter. Just to eliminate the possibility that something strange is going on with the query params that's affecting the test, I thought we could try and actually different route that just serves the same page. (I've had a quick look and have no idea what could be going on - it's just to eliminate possibilities)