### PR TITLE
Fix hollow buttons showing up as grey in safari & ffx

### DIFF
--- a/assets/components/button/button.scss
+++ b/assets/components/button/button.scss
@@ -11,6 +11,7 @@
   border: none;
   border-radius: 600px;
   box-sizing: border-box;
+  background: transparent;
   cursor: pointer;
   transition: .2s;
   justify-content: space-between;


### PR DESCRIPTION
## Why are you doing this?
I mean look at them:

before:
![screenshot 2019-01-30 at 12 36 45 pm](https://user-images.githubusercontent.com/11539094/51981697-c96e1680-248b-11e9-83d0-bfa23cc6144d.png)
after:
![screenshot 2019-01-30 at 12 36 50 pm](https://user-images.githubusercontent.com/11539094/51981693-c7a45300-248b-11e9-9390-e969a46ddd39.png)