### PR TITLE
Feb print flash 2

### DIFF
--- a/assets/helpers/flashSale.js
+++ b/assets/helpers/flashSale.js
@@ -193,7 +193,7 @@ const Sales: Sale[] = [
     subscriptionProduct: 'PaperAndDigital',
     activeRegions: ['GBPCountries'],
     startTime: new Date(2019, 0, 4).getTime(), // 4 Jan 2019
-    endTime: new Date(2019, 0, 4).getTime(), // 3 Feb 2019 (to finish at 0:00 in the morning)
+    endTime: new Date(2019, 1, 4).getTime(), // 3 Feb 2019 (to finish at 0:00 in the morning)
     saleDetails: {
       GBPCountries: {
         promoCode: 'GCB56X',
@@ -223,7 +223,7 @@ const Sales: Sale[] = [
   {
     subscriptionProduct: 'Paper',
     activeRegions: ['GBPCountries'],
-    startTime: new Date(2019, 1, 4).getTime(), // 4 Jan 2019
+    startTime: new Date(2019, 0, 4).getTime(), // 4 Jan 2019
     endTime: new Date(2019, 1, 18).getTime(), // 17 Feb 2019 (to finish at 0:00 in the morning)
     duration: '3 months',
     saleDetails: {

--- a/assets/helpers/flashSale.js
+++ b/assets/helpers/flashSale.js
@@ -223,7 +223,7 @@ const Sales: Sale[] = [
   {
     subscriptionProduct: 'Paper',
     activeRegions: ['GBPCountries'],
-    startTime: new Date(2019, 0, 4).getTime(), // 4 Jan 2019
+    startTime: new Date(2019, 1, 4).getTime(), // 4 Feb 2019
     endTime: new Date(2019, 1, 18).getTime(), // 17 Feb 2019 (to finish at 0:00 in the morning)
     duration: '3 months',
     saleDetails: {

--- a/assets/helpers/flashSale.js
+++ b/assets/helpers/flashSale.js
@@ -299,10 +299,16 @@ function sortSalesByStartTimesDescending(a: Sale, b: Sale) {
   return b.startTime - a.startTime;
 }
 
-function getSales(product: SubscriptionProduct, countryGroupId: CountryGroupId = detect()): Sale[] {
-  return Sales.filter(sale =>
+function getActiveFlashSales(product: SubscriptionProduct, countryGroupId: CountryGroupId = detect()): Sale[] {
+  const now = Date.now();
+
+  const sales = Sales.filter(sale =>
     sale.subscriptionProduct === product &&
     sale.activeRegions.includes(countryGroupId)).sort(sortSalesByStartTimesDescending);
+
+  return sales.filter(sale =>
+    (now > sale.startTime && now < sale.endTime) ||
+    getQueryParameter('flash_sale') === 'true');
 }
 
 function getDiscount(product: SubscriptionProduct, countryGroupId: CountryGroupId): ?number {
@@ -319,15 +325,6 @@ function flashSaleIsActive(product: SubscriptionProduct, countryGroupId: Country
   const sales = getActiveFlashSales(product, countryGroupId);
 
   return sales.length > 0;
-}
-
-function getActiveFlashSales(product: SubscriptionProduct, countryGroupId: CountryGroupId = detect()): boolean {
-  const now = Date.now();
-  const sales = getSales(product, countryGroupId).filter(sale =>
-    (now > sale.startTime && now < sale.endTime) ||
-    getQueryParameter('flash_sale') === 'true');
-
-  return sales;
 }
 
 function getPromoCode(

--- a/assets/helpers/flashSale.js
+++ b/assets/helpers/flashSale.js
@@ -193,7 +193,7 @@ const Sales: Sale[] = [
     subscriptionProduct: 'PaperAndDigital',
     activeRegions: ['GBPCountries'],
     startTime: new Date(2019, 0, 4).getTime(), // 4 Jan 2019
-    endTime: new Date(2019, 1, 4).getTime(), // 3 Feb 2019 (to finish at 0:00 in the morning)
+    endTime: new Date(2019, 0, 4).getTime(), // 3 Feb 2019 (to finish at 0:00 in the morning)
     saleDetails: {
       GBPCountries: {
         promoCode: 'GCB56X',
@@ -220,6 +220,79 @@ const Sales: Sale[] = [
       },
     },
   },
+  {
+    subscriptionProduct: 'Paper',
+    activeRegions: ['GBPCountries'],
+    startTime: new Date(2019, 1, 4).getTime(), // 4 Jan 2019
+    endTime: new Date(2019, 1, 18).getTime(), // 17 Feb 2019 (to finish at 0:00 in the morning)
+    duration: '3 months',
+    saleDetails: {
+      GBPCountries: {
+        promoCode: 'GCC80X',
+        intcmp: '',
+        price: 5.40,
+        discountPercentage: 0.50,
+        saleCopy: {
+          featuredProduct: {
+            heading: 'Paper subscriptions',
+            subHeading: 'Save up to 68% on your newspaper',
+            description: 'Find analysis, opinions, reviews, recipes and more with a subscription to The Guardian and The Observer. Subscribe now and save an additional 50% for your first three months.',
+          },
+          landingPage: {
+            heading: 'The Guardian newspaper subscriptions',
+            subHeading: 'Subscribe and save up to 68% off the retail price of your newspaper',
+            standfirst: 'Subscribers already save up to 37% off the retail price. With this limited time offer, you\'ll enjoy and additional 50% off for the first three months of your subscription. We offer two different subscription types: voucher booklets and home delivery.',
+          },
+          bundle: {
+            heading: 'Paper',
+            subHeading: 'From £5.40/month',
+            description: 'Save an additional 50% for the first three months of your subscription to The Guardian and The Observer',
+          },
+        },
+        planPrices: [
+          { collectionEveryday: 23.81 },
+          { collectionSixday: 20.56 },
+          { collectionWeekend: 10.38 },
+          { collectionSunday: 5.40 },
+          { deliveryEveryday: 31.40 },
+          { deliverySixday: 27.06 },
+          { deliveryWeekend: 12.55 },
+          { deliverySunday: 7.56 },
+        ],
+      },
+    },
+  },
+  {
+    subscriptionProduct: 'PaperAndDigital',
+    activeRegions: ['GBPCountries'],
+    startTime: new Date(2019, 1, 4).getTime(), // 4 Feb 2019
+    endTime: new Date(2019, 1, 18).getTime(), // 17 Feb 2019 (to finish at 0:00 in the morning)
+    saleDetails: {
+      GBPCountries: {
+        promoCode: 'GCC56X',
+        intcmp: '',
+        price: 11.03,
+        saleCopy: {
+          featuredProduct: {
+            heading: 'Paper subscriptions',
+            subHeading: 'Save up to 68% on your newspaper',
+            description: 'Find analysis, opinions, reviews, recipes and more with a subscription to The Guardian and The Observer. Subscribe now and save an additional 50% for your first three months.',
+          },
+          landingPage: {
+            heading: 'The Guardian newspaper subscriptions',
+            subHeading: 'Subscribe and save up to 68% off the retail price of your newspaper',
+            standfirst: 'Subscribers already save up to 37% off the retail price. With this limited time offer, you\'ll enjoy and additional 50% off for the first three months of your subscription. We offer two different subscription types: voucher booklets and home delivery.',
+          },
+          bundle: {
+            heading: 'Paper+Digital',
+            subHeading: 'From £16.22/month',
+            description: 'The Paper + Digital subscription includes all the benefits of a paper subscription, plus access to the Digital Pack. Save 50% for your first three months.',
+          },
+        },
+        planPrices: [],
+      },
+    },
+  },
 ];
 
 function sortSalesByStartTimesDescending(a: Sale, b: Sale) {
@@ -233,22 +306,28 @@ function getSales(product: SubscriptionProduct, countryGroupId: CountryGroupId =
 }
 
 function getDiscount(product: SubscriptionProduct, countryGroupId: CountryGroupId): ?number {
-  const sale = getSales(product, countryGroupId)[0];
+  const sale = getActiveFlashSales(product, countryGroupId)[0];
   return sale && sale.saleDetails[countryGroupId] && sale.saleDetails[countryGroupId].discountPercentage;
 }
 
 function getDuration(product: SubscriptionProduct, countryGroupId: CountryGroupId): ?string {
-  const sale = getSales(product, countryGroupId)[0];
+  const sale = getActiveFlashSales(product, countryGroupId)[0];
   return sale && sale.duration;
 }
 
 function flashSaleIsActive(product: SubscriptionProduct, countryGroupId: CountryGroupId = detect()): boolean {
+  const sales = getActiveFlashSales(product, countryGroupId);
+
+  return sales.length > 0;
+}
+
+function getActiveFlashSales(product: SubscriptionProduct, countryGroupId: CountryGroupId = detect()): boolean {
   const now = Date.now();
   const sales = getSales(product, countryGroupId).filter(sale =>
     (now > sale.startTime && now < sale.endTime) ||
     getQueryParameter('flash_sale') === 'true');
 
-  return sales.length > 0;
+  return sales;
 }
 
 function getPromoCode(
@@ -257,7 +336,7 @@ function getPromoCode(
   defaultCode: string,
 ): string {
   if (flashSaleIsActive(product, countryGroupId)) {
-    const sale = getSales(product, countryGroupId)[0];
+    const sale = getActiveFlashSales(product, countryGroupId)[0];
     return sale && sale.saleDetails[countryGroupId].promoCode;
   }
   return defaultCode;
@@ -270,19 +349,19 @@ function getIntcmp(
   defaultIntcmp: string,
 ): string {
   if (flashSaleIsActive(product)) {
-    const sale = getSales(product, countryGroupId)[0];
+    const sale = getActiveFlashSales(product, countryGroupId)[0];
     return (sale && sale.saleDetails[countryGroupId].intcmp) || intcmp || defaultIntcmp;
   }
   return intcmp || defaultIntcmp;
 }
 
 function getPlanPrices(product: SubscriptionProduct, countryGroupId: CountryGroupId): PlanPrice[] {
-  const sale = getSales(product, countryGroupId)[0];
+  const sale = getActiveFlashSales(product, countryGroupId)[0];
   return sale && sale.saleDetails[countryGroupId].planPrices;
 }
 
 function getEndTime(product: SubscriptionProduct, countryGroupId: CountryGroupId) {
-  const sale = getSales(product, countryGroupId)[0];
+  const sale = getActiveFlashSales(product, countryGroupId)[0];
   return sale && sale.endTime;
 }
 
@@ -304,14 +383,14 @@ function getSaleCopy(product: SubscriptionProduct, countryGroupId: CountryGroupI
     },
   };
   if (flashSaleIsActive(product, countryGroupId)) {
-    const sale = getSales(product, countryGroupId)[0];
+    const sale = getActiveFlashSales(product, countryGroupId)[0];
     return sale.saleDetails[countryGroupId].saleCopy;
   }
   return emptyCopy;
 }
 
 function getFormattedFlashSalePrice(product: SubscriptionProduct, countryGroupId: CountryGroupId): string {
-  const sale = getSales(product, countryGroupId)[0];
+  const sale = getActiveFlashSales(product, countryGroupId)[0];
   return fixDecimals(sale.saleDetails[countryGroupId].price);
 }
 


### PR DESCRIPTION
## Why are you doing this?
🎵 It's the most wonderful time of the year

Time for a print flash sale (again)

Immediately following the current print flash sale, we shall run another, this time 50% off for 3 months. 

This PR assumes the current version of the print product page. @walaura @jesseyuen if I've caused chaos with the print page changes to follow, let me know if I can help.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/VrGs0HFv/2157-print-flash-sale-update-4th-feb)

## Changes

* Add in flash sales for print and print+
* This is the first time we have reason to have two flash sales in the list for the same product. Throughout `flashSale.js` we were getting the list of sales for a given product and country group and then just taking the head of the list. But when we have a back to back sale, then we may fetch details for the expired one. So I opted to get the head of the list of _active_ flash sales for a given product and country group. 

## Screenshots

| voucher on paper landing page, flash sale active  | HD    on paper landing page, flash sale active | 
| ------------- |:-------------:| 
| <img height=200 src="https://user-images.githubusercontent.com/3072877/51996611-01d21c80-24ad-11e9-9ca1-b497c5678ca2.png"> | <img height=200 src="https://user-images.githubusercontent.com/3072877/51997244-44e0bf80-24ae-11e9-8c31-d7edc7c3913e.png"> | 

| `/uk/subscribe`        | `/uk`         | 
| ------------- |:-------------:| 
| <img height=200 src="https://user-images.githubusercontent.com/3072877/51997340-7063aa00-24ae-11e9-82f0-769a3f3ba01c.png"> | <img height=200 src="https://user-images.githubusercontent.com/3072877/51997372-83767a00-24ae-11e9-95d5-d9b3700faafe.png"> | 
