### PR TITLE
Dialog tweaks

### DIFF
--- a/assets/components/button/_sharedButton.jsx
+++ b/assets/components/button/_sharedButton.jsx
@@ -30,6 +30,7 @@ type SharedButtonPropTypes = {|
   icon?: Node,
   appearance: Appearance,
   iconSide: IconSide,
+  getRef?: (?Element) => void,
   modifierClasses: string[],
 |};
 
@@ -41,7 +42,7 @@ type PropTypes = {
 // ----- Render ----- //
 
 const SharedButton = ({
-  element, appearance, iconSide, modifierClasses, children, icon, ...otherProps
+  element, appearance, iconSide, modifierClasses, children, icon, getRef, ...otherProps
 }: PropTypes) => {
 
   const className = classNameWithModifiers('component-button', [
@@ -57,6 +58,7 @@ const SharedButton = ({
 
   return createElement(element, {
     className,
+    ref: getRef,
     ...otherProps,
   }, contents);
 };

--- a/assets/components/dialog/dialog.jsx
+++ b/assets/components/dialog/dialog.jsx
@@ -77,9 +77,9 @@ class Dialog extends Component<PropTypes> {
     const {
       open, children, onStatusChange, blocking, styled, ...otherProps
     } = this.props;
-
     return (
-      <dialog // eslint-disable-line jsx-a11y/no-redundant-roles
+    // eslint-disable-next-line jsx-a11y/no-redundant-roles, jsx-a11y/no-noninteractive-element-interactions
+      <dialog
         className={classNameWithModifiers('component-dialog', [
           open ? 'open' : null,
           styled ? 'styled' : null,
@@ -91,6 +91,11 @@ class Dialog extends Component<PropTypes> {
         onOpen={() => { onStatusChange(true); }}
         onCancel={() => { onStatusChange(false); }}
         ref={(d) => { this.ref = (d: any); }}
+        onKeyUp={((ev) => {
+          if (ev.key === 'Escape') {
+            onStatusChange(false);
+          }
+        })}
         {...otherProps}
       >
         <div className="component-dialog__contents">

--- a/assets/components/dialog/dialog.jsx
+++ b/assets/components/dialog/dialog.jsx
@@ -51,12 +51,18 @@ class Dialog extends Component<PropTypes> {
     if (this.ref && this.ref.showModal) {
       this.ref.showModal();
     }
+    /*
+    if the browser supports <dialog>
+    its gonna be better than us
+    at dealing with auto focus
+    */
+    if (this.ref && !this.ref.showModal) {
+      requestAnimationFrame(() => {
+        if (this.ref) {
+          this.ref.focus();
+        }
+      });
     }
-    requestAnimationFrame(() => {
-      if (this.ref) {
-        this.ref.focus();
-      }
-    });
   }
 
   close() {

--- a/assets/components/dialog/dialog.jsx
+++ b/assets/components/dialog/dialog.jsx
@@ -49,11 +49,8 @@ class Dialog extends Component<PropTypes> {
 
   open() {
     if (this.ref && this.ref.showModal) {
-      if (this.props.modal) {
-        this.ref.showModal();
-      } else {
-        this.ref.show();
-      }
+      this.ref.showModal();
+    }
     }
     requestAnimationFrame(() => {
       if (this.ref) {
@@ -72,13 +69,13 @@ class Dialog extends Component<PropTypes> {
 
   render() {
     const {
-      open, modal, children, onStatusChange, dismissOnBackgroundClick, ...otherProps
+      open, children, onStatusChange, dismissOnBackgroundClick, ...otherProps
     } = this.props;
 
     return (
       <dialog // eslint-disable-line jsx-a11y/no-redundant-roles
-        className={classNameWithModifiers('component-dialog', [modal ? 'modal' : null, open ? 'open' : null])}
-        aria-modal={modal}
+        className={classNameWithModifiers('component-dialog', [open ? 'open' : null])}
+        aria-modal
         aria-hidden={!open}
         tabIndex="-1"
         role="dialog"
@@ -97,13 +94,11 @@ class Dialog extends Component<PropTypes> {
             }}
           />
         </div>
-        {modal &&
-          <div
-            className="component-dialog__backdrop"
-            aria-hidden
-            onClick={() => dismissOnBackgroundClick && onStatusChange(false)}
-          />
-        }
+        <div
+          className="component-dialog__backdrop"
+          aria-hidden
+          onClick={() => dismissOnBackgroundClick && onStatusChange(false)}
+        />
       </dialog>
     );
   }

--- a/assets/components/dialog/dialog.jsx
+++ b/assets/components/dialog/dialog.jsx
@@ -14,10 +14,10 @@ import './dialog.scss';
 
 export type PropTypes = {|
   onStatusChange: (boolean) => void,
-  modal: boolean,
+  styled: boolean,
   open: boolean,
   'aria-label': Option<string>,
-  dismissOnBackgroundClick: boolean,
+  blocking: boolean,
   children: Node
 |};
 
@@ -28,9 +28,9 @@ class Dialog extends Component<PropTypes> {
 
   static defaultProps = {
     onStatusChange: () => {},
-    modal: true,
+    styled: true,
     open: false,
-    dismissOnBackgroundClick: false,
+    blocking: true,
   }
 
   componentDidMount() {
@@ -75,12 +75,15 @@ class Dialog extends Component<PropTypes> {
 
   render() {
     const {
-      open, children, onStatusChange, dismissOnBackgroundClick, ...otherProps
+      open, children, onStatusChange, blocking, styled, ...otherProps
     } = this.props;
 
     return (
       <dialog // eslint-disable-line jsx-a11y/no-redundant-roles
-        className={classNameWithModifiers('component-dialog', [open ? 'open' : null])}
+        className={classNameWithModifiers('component-dialog', [
+          open ? 'open' : null,
+          styled ? 'styled' : null,
+        ])}
         aria-modal
         aria-hidden={!open}
         tabIndex="-1"
@@ -103,7 +106,7 @@ class Dialog extends Component<PropTypes> {
         <div
           className="component-dialog__backdrop"
           aria-hidden
-          onClick={() => dismissOnBackgroundClick && onStatusChange(false)}
+          onClick={() => !blocking && onStatusChange(false)}
         />
       </dialog>
     );

--- a/assets/components/dialog/dialog.scss
+++ b/assets/components/dialog/dialog.scss
@@ -8,20 +8,16 @@
 }
 
 .component-dialog--open {
+  display: flex;
   visibility: visible;
   position: fixed;
   height: auto;
   width: auto;
   top: 0;
   left: 0;
-  z-index: 100;
-  contain: content;
-}
-
-.component-dialog--modal.component-dialog--open {
-  display: flex;
   bottom: 0;
   right: 0;
+  z-index: 100;
   justify-content: center;
   align-items: center;
   contain: strict;
@@ -32,7 +28,7 @@
   z-index: 10;
 }
 
-.component-dialog--modal .component-dialog__backdrop {
+.component-dialog__backdrop {
   background: rgba(0, 0, 0, 0.6);
   position: absolute;
   top: 0;

--- a/assets/components/dialog/dialog.scss
+++ b/assets/components/dialog/dialog.scss
@@ -5,22 +5,27 @@
   height: 0;
   width: 0;
   overflow: hidden;
+  &::backdrop {
+    background: rgba(0,0,0,0);
+  }  
 }
 
 .component-dialog--open {
-  display: flex;
   visibility: visible;
   position: fixed;
-  height: auto;
-  width: auto;
+  height: 100%;
+  width: 100%;
   top: 0;
   left: 0;
   bottom: 0;
   right: 0;
   z-index: 100;
-  justify-content: center;
-  align-items: center;
   contain: strict;
+  &.component-dialog--styled {
+    display: flex;
+    justify-content: center;
+    align-items: center;  
+  }
 }
 
 .component-dialog__contents {
@@ -29,11 +34,15 @@
 }
 
 .component-dialog__backdrop {
-  background: rgba(0, 0, 0, 0.6);
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   bottom: 0;
   right: 0;
   z-index: 9;
+  height: 100%;
+  width: 100%;
+  .component-dialog--styled & {
+    background: rgba(0, 0, 0, 0.6);
+  }
 }

--- a/stories/dialog.jsx
+++ b/stories/dialog.jsx
@@ -12,7 +12,7 @@ import ProductPageTextBlock from 'components/productPage/productPageTextBlock/pr
 import { withCenterAlignment } from '../.storybook/decorators/withCenterAlignment';
 
 // This is a barebones stateful wrapper - <Dialog/> needs to be controlled just like inputs
-class ControlledDialogButton extends Component<{||}, {open: boolean}> {
+class ControlledDialogButton extends Component<{||}, {|open: boolean|}> {
   state = {
     open: false,
   }
@@ -50,7 +50,7 @@ class ControlledDialogButton extends Component<{||}, {open: boolean}> {
   }
 }
 
-class ControlledPopDialogButton extends Component<{}, {open: boolean, pos: number[]}> {
+class ControlledPopDialogButton extends Component<{||}, {|open: boolean, pos: number[]|}> {
   state = {
     open: false,
     pos: [0, 0],

--- a/stories/dialog.jsx
+++ b/stories/dialog.jsx
@@ -1,5 +1,7 @@
 // @flow
 
+/* eslint-disable react/no-multi-comp */
+
 import React, { Component } from 'react';
 
 import { storiesOf } from '@storybook/react';
@@ -10,7 +12,7 @@ import ProductPageTextBlock from 'components/productPage/productPageTextBlock/pr
 import { withCenterAlignment } from '../.storybook/decorators/withCenterAlignment';
 
 // This is a barebones stateful wrapper - <Dialog/> needs to be controlled just like inputs
-class ControlledDialogButton extends Component<{modal: boolean}, {open: boolean}> {
+class ControlledDialogButton extends Component<{||}, {open: boolean}> {
   state = {
     open: false,
   }
@@ -26,20 +28,88 @@ class ControlledDialogButton extends Component<{modal: boolean}, {open: boolean}
         </Button>
         <Dialog
           aria-label="Modal dialog"
-          modal={this.props.modal}
           onStatusChange={(status) => { this.setState({ open: status }); }}
           open={this.state.open}
+          styled
         >
           <div style={{ padding: '1em', background: '#121212', color: '#fff' }}>
             <ProductPageTextBlock title={'I\'m a dialog!'}>
-              I don&#39;t do much on my own :(
+              I don&#39;t do much on my own <span role="img" aria-label="sadface">☹️</span>.
             </ProductPageTextBlock>
             <Button
               icon={null}
               aria-label={null}
-              appearance="primary"
               onClick={() => { this.setState({ open: false }); }}
-            >Close
+            >
+              Close
+            </Button>
+          </div>
+        </Dialog>
+      </div>
+    );
+  }
+}
+
+class ControlledPopDialogButton extends Component<{}, {open: boolean, pos: number[]}> {
+  state = {
+    open: false,
+    pos: [0, 0],
+  }
+  buttonRef: ?Element;
+  render() {
+    return (
+      <div>
+        <Button
+          aria-haspopup="dialog"
+          aria-label={null}
+          appearance="greyHollow"
+          icon={null}
+          getRef={(r) => { this.buttonRef = r; }}
+          onClick={() => {
+            this.setState({ open: true });
+            if (this.buttonRef) {
+              const bounds = (this.buttonRef.getBoundingClientRect());
+              this.setState({
+                pos: [
+                  bounds.left,
+                  bounds.top,
+                ],
+              });
+            }
+          }}
+        >
+          Open dialog
+        </Button>
+        <Dialog
+          aria-label="Modal dialog"
+          onStatusChange={(status) => { this.setState({ open: status }); }}
+          open={this.state.open}
+          blocking={false} // this lets you click outside to close
+          styled={false}
+        >
+          <div
+            style={{
+              top: this.state.pos[1],
+              left: this.state.pos[0],
+              position: 'absolute',
+              background: '#fafafa',
+              border: '1px solid #ddd',
+              padding: '.5em',
+              borderRadius: '1.25em',
+            }}
+          >
+            <Button icon={null} aria-label={null} appearance="greyHollow">This could be a dropdown menu</Button><br />
+            <Button icon={null} aria-label={null} appearance="greyHollow">Click outside to close</Button><br />
+            <Button icon={null} aria-label={null} appearance="greyHollow">
+              BUT! you still need a close button for keyboard + srd users even if its visibly hidden
+            </Button><br />
+            <Button
+              icon={null}
+              aria-label={null}
+              appearance="greyHollow"
+              onClick={() => { this.setState({ open: false }); }}
+            >
+              Close
             </Button>
           </div>
         </Dialog>
@@ -51,21 +121,24 @@ class ControlledDialogButton extends Component<{modal: boolean}, {open: boolean}
 const stories = storiesOf('Dialogs', module)
   .addDecorator(withCenterAlignment);
 
-stories.add('Modal dialog', () => (
-  <ControlledDialogButton modal />
+stories.add('Styled dialog', () => (
+  <div style={{ maxWidth: '30em' }}>
+    <ProductPageTextBlock title="This is an styled dialog example">
+      <p>
+        It pops up in the middle of the screen
+      </p>
+      <ControlledDialogButton />
+    </ProductPageTextBlock>
+  </div>
 ));
 
-stories.add('Non-modal dialog', () => (
-  <div>
-    <ProductPageTextBlock title="This is a non-modal dialog example">
-      <p>It opens up but lets you interact
-        with the page under it while it is open
+stories.add('Unstyled dialog', () => (
+  <div style={{ maxWidth: '30em' }}>
+    <ProductPageTextBlock title="This is an unstyled dialog example">
+      <p>
+        You can make it look like anything.
       </p>
-      <p>You probably do not actually want this,
-        as this dialog does not have the click outside behaviour
-        and makes for a confusing experience for screen readers
-      </p>
-      <ControlledDialogButton modal={false} />
+      <ControlledPopDialogButton />
     </ProductPageTextBlock>
   </div>
 ));


### PR DESCRIPTION
## Why are you doing this?

Implement some of @SiAdcock's suggestions (the easy high api layer impact ones) in the dialog component #1416  

## Changes

* Don't handle browser focus if it supports `<dialog>`
* Remove `modal` prop
* Add new `styled` prop that adds a modal-like appearance (this was previously tangled together with modal-ness. Most appearances will be custom but this makes it more satisfying to implement. (instant dialogs!)
* New default is for dialogs to not dismiss themselves when clicking out – to make implementers think about adding a close button (needed for keyboard users). the prop for this is now called `blocking` for simplicity
* Got carried away writing stories for this!

## Screenshots

<img width="484" alt="screenshot 2019-01-31 at 10 17 14 am" src="https://user-images.githubusercontent.com/11539094/52047659-62ab3480-2541-11e9-8f96-47223d80f9ce.png">
<img width="817" alt="screenshot 2019-01-31 at 10 17 09 am" src="https://user-images.githubusercontent.com/11539094/52047662-6474f800-2541-11e9-87e8-7acc77d0c091.png">
