### PR TITLE
Ensure that currency and country combination are supported when validating requests

### DIFF
--- a/app/utils/SimpleValidator.scala
+++ b/app/utils/SimpleValidator.scala
@@ -1,7 +1,7 @@
 package utils
 
-import com.gu.i18n.Country
-import com.gu.support.workers.{DirectDebitPaymentFields, PaymentFields, StripePaymentFields}
+import com.gu.i18n.{Country, CountryGroup}
+import com.gu.support.workers.{DirectDebitPaymentFields, StripePaymentFields}
 import services.stepfunctions.CreateSupportWorkersRequest
 
 object SimpleValidator {
@@ -21,8 +21,13 @@ object SimpleValidator {
       case stripeDetails: StripePaymentFields => !stripeDetails.stripeToken.isEmpty
     }
 
+    def currencyIsSupportedForCountry: Boolean = {
+      val countryGroupsForCurrency = CountryGroup.allGroups.filter(_.currency == request.product.currency)
+      countryGroupsForCurrency.flatMap(_.countries).contains(request.country)
+    }
+
     val telephoneNumberShortEnough = request.telephoneNumber.forall(_.length < 40)
 
-    noEmptyNameFields && hasStateIfRequired && noEmptyPaymentFields && telephoneNumberShortEnough
+    noEmptyNameFields && hasStateIfRequired && noEmptyPaymentFields && telephoneNumberShortEnough && currencyIsSupportedForCountry
   }
 }

--- a/test/utils/SimpleValidatorTest.scala
+++ b/test/utils/SimpleValidatorTest.scala
@@ -2,7 +2,7 @@ package utils
 
 import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
 import com.gu.i18n.{Country, Currency}
-import com.gu.support.workers.{DigitalPack, Monthly, StripePaymentFields}
+import com.gu.support.workers.{Annual, DigitalPack, Monthly, StripePaymentFields}
 import org.scalatest.{FlatSpec, Matchers}
 import services.stepfunctions.CreateSupportWorkersRequest
 
@@ -42,12 +42,22 @@ class SimpleValidatorTest extends FlatSpec with Matchers {
   }
 
   "validate" should "pass if there is no state selected and the country is Australia" in {
-    val requestMissingState = validRequest.copy(country = Country.Australia, state = None)
+    val requestMissingState = validRequest.copy(country = Country.Australia, product = DigitalPack(Currency.AUD, Monthly), state = None)
     SimpleValidator.validationPasses(requestMissingState) shouldBe true
   }
 
   "validate" should "fail if the payment field received is an empty string" in {
     val requestMissingState = validRequest.copy(paymentFields = StripePaymentFields(""))
+    SimpleValidator.validationPasses(requestMissingState) shouldBe false
+  }
+
+  "validate" should "succeed for a standard country and currency combination" in {
+    val requestMissingState = validRequest.copy(country = Country.UK, product = DigitalPack(Currency.GBP, Annual), state = None)
+    SimpleValidator.validationPasses(requestMissingState) shouldBe true
+  }
+
+  "validate" should "fail if the country and currency combination is unsupported" in {
+    val requestMissingState = validRequest.copy(country = Country.US, product = DigitalPack(Currency.GBP, Annual), state = None)
     SimpleValidator.validationPasses(requestMissingState) shouldBe false
   }
 


### PR DESCRIPTION
## Why are you doing this?

The client side logic is supposed to update the currency displayed to the user whenever the billing country is updated. If the server receives a request where the country and currency combination is not standard, it is likely that something has gone wrong client side (e.g. we showed the user one price/currency, but will charge them in another). 

In such cases, I think it's better to fail the validation than allow the request to be processed by support-workers.

Obviously there is still some client-side work required to fix the bug which is currently allowing this to happen, but this validation should alert us if we introduce this type of problem again.

[**Trello Card**](https://trello.com/c/GMQmzcBp/2196-investigate-bug-which-allows-users-to-create-digital-pack-subs-with-invalid-country-currency-combinations)

## Changes

* Add function which checks that currency and country combination is valid
* Add unit tests (and fix an old one which fails due to the updated behaviour)