### PR TITLE
Update roundel for print header to 12 months

### DIFF
--- a/assets/pages/paper-subscription-landing/components/hero/hero.jsx
+++ b/assets/pages/paper-subscription-landing/components/hero/hero.jsx
@@ -78,7 +78,7 @@ const SaleHeader = () => (
           <div className="sale-joy-of-print-badge">
             <span>Save up to</span>
             <span>52%</span>
-            <span>For 3 months</span>
+            <span>for 12 months</span>
           </div>
           <div className="sale-joy-of-print-graphic">
             <GridImage


### PR DESCRIPTION
## Why are you doing this?

<!--
-->The offer roundel on the updated Print product page is incorrect - it states the discount is 52% off for 3 months, but it is actually 52% off for 12 months.

[**Trello Card**](https://trello.com/c/ecK4Jpqq) 

## Changes

* Updated copy for "For 3 months" to "for 12 months" in the offer roundel

## Screenshots
Current:
![image](https://user-images.githubusercontent.com/45856485/52069154-0f070e00-2576-11e9-8839-e8ae4fd6f0a1.png)
New:
![image](https://user-images.githubusercontent.com/45856485/52069206-3231bd80-2576-11e9-94e5-da671967edaf.png)
