### PR TITLE
Removing the ? in the vouchers tab

### DIFF
--- a/assets/pages/paper-subscription-landing/components/content/collectionTab.jsx
+++ b/assets/pages/paper-subscription-landing/components/content/collectionTab.jsx
@@ -26,7 +26,7 @@ const ContentVoucherFaqBlock = () => (
     />
   }
   >
-    <ProductPageTextBlock title="How to use our vouchers?">
+    <ProductPageTextBlock title="How to use our vouchers">
       <OrderedList items={[
         'Pick your subscription package below',
         'We’ll send you a book of vouchers that contain one voucher per paper in your subscription',


### PR DESCRIPTION
## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->
There's a rogue ? in the title "How to use our vouchers" on the Print product page, so I've removed it.
[**Trello Card**](https://trello.com/c/ecK4Jpqq)

## Changes

* Remove the ? from "how to use our vouchers"


## Screenshots
Current:
![image](https://user-images.githubusercontent.com/45856485/52069778-5641ce80-2577-11e9-905e-9d0f2bb514ee.png)

New:
![image](https://user-images.githubusercontent.com/45856485/52069758-4d50fd00-2577-11e9-9adb-c2cdef58a3d5.png)
