### PR TITLE
Update "collection" to "voucher booklet"

### DIFF
--- a/assets/helpers/flashSale.js
+++ b/assets/helpers/flashSale.js
@@ -168,7 +168,7 @@ const Sales: Sale[] = [
           landingPage: {
             heading: 'The Guardian newspaper subscriptions',
             subHeading: 'Subscribe and save on the joy of print',
-            standfirst: 'We offer two different subscription types: collection and home delivery.',
+            standfirst: 'We offer two different subscription types: voucher booklet and home delivery.',
           },
           bundle: {
             heading: 'Paper',


### PR DESCRIPTION
## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->
We should always refer to the Print subscription voucher scheme as "voucher", "vouchers" or "voucher booklet", but we've called it "collection" on the Print product page in error.
[**Trello Card**](https://trello.com/c/ecK4Jpqq)

## Changes

* Changed "collection" to "voucher booklet" in standfirst above the tabs.


## Screenshots
Current: 
![image](https://user-images.githubusercontent.com/45856485/52070876-bcc7ec00-2579-11e9-82e8-03269b29bc95.png)

New:
![image](https://user-images.githubusercontent.com/45856485/52070865-b6d20b00-2579-11e9-830b-1ecec737a0fb.png)
