### PR TITLE
Update offer roundel from "for 3 months" to "for a year" on Print product page

### DIFF
--- a/assets/pages/paper-subscription-landing/components/hero/hero.jsx
+++ b/assets/pages/paper-subscription-landing/components/hero/hero.jsx
@@ -78,7 +78,7 @@ const SaleHeader = () => (
           <div className="sale-joy-of-print-badge">
             <span>Save up to</span>
             <span>52%</span>
-            <span>For 3 months</span>
+            <span>for a year</span>
           </div>
           <div className="sale-joy-of-print-graphic">
             <GridImage


### PR DESCRIPTION
## Why are you doing this?

<!--
-->The offer roundel on the updated Print product page is incorrect - it states the discount is 52% off for 3 months, but it is actually 52% off for a year.

[**Trello Card**](https://trello.com/c/ecK4Jpqq) 

## Changes

* Updated copy for "For 3 months" to "for a year" in the offer roundel

## Screenshots
Current:
![image](https://user-images.githubusercontent.com/45856485/52069154-0f070e00-2576-11e9-8839-e8ae4fd6f0a1.png)
New:
![image](https://user-images.githubusercontent.com/45856485/52071415-d61d6800-257a-11e9-86f8-0655d39d7407.png)
