### PR TITLE
Update Print product page Ts&Cs copy + link

### DIFF
--- a/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
+++ b/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
@@ -85,7 +85,7 @@ const content = (
       {flashSaleIsActive('Paper', 'GBPCountries') &&
         <ProductPageContentBlock>
           <ProductPageTextBlock title="Promotion terms and conditions">
-            <p>Offer subject to availability. Guardian News and Media Limited (&ldquo;GNM&rdquo;) reserves the right to withdraw this promotion at any time. For full 6 for 6 promotion terms and conditions, see <a target="_blank" rel="noopener noreferrer" href={`https://subscribe.theguardian.com/p/WWM99X/terms?country=${subsCountry}`}>here</a>.
+            <p>Offer subject to availability. Guardian News and Media Limited (&ldquo;GNM&rdquo;) reserves the right to withdraw this promotion at any time. For full promotion terms and conditions, see <a target="_blank" rel="noopener noreferrer" href={`https://subscribe.theguardian.com/p/GCB80X/terms?country=${subsCountry}`}>here</a>.
             </p>
           </ProductPageTextBlock>
         </ProductPageContentBlock>


### PR DESCRIPTION
## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->
The copy and link to offer terms and conditions on the Print product page are incorrect and need to be updated to relate to the 25% off for 12 months offer.
[**Trello Card**](https://trello.com/c/fvlfJSdm)

## Changes

* Remove reference to "6 for 6" promotion. This means that the copy won't need to be updated in future because it refers generically to "promotion terms and conditions"
* Update Ts&Cs link from 6 for 6 to https://subscribe.theguardian.com/p/GCB80X/terms?country=GB (Ts&Cs page for 25% off for 12 months offer)

## Screenshots
Current:
![image](https://user-images.githubusercontent.com/45856485/52114709-a74bd400-2604-11e9-996b-5aa88599536f.png)

New:
![image](https://user-images.githubusercontent.com/45856485/52114722-b2066900-2604-11e9-89d4-18d273cab5a7.png)

