### PR TITLE
use grey boxes instead of the actual amounts in placeholders

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -109,16 +109,7 @@ class Application(
   }
 
   private def contributionsHtml(countryCode: String, idUser: Option[IdUser], isTest: Boolean)(implicit request: RequestHeader, settings: AllSettings) = {
-    if (isTest) {
-      val annualAmounts: Map[String, (String, String, String, String)] = Map(
-        "uk" -> ("£50", "£100", "£250", "£500"),
-        "us" -> ("$50", "$100", "$250", "$500"),
-        "au" -> ("$100", "$250", "$500", "$750"),
-        "eu" -> ("€50", "€100", "€250", "€500"),
-        "int" -> ("£50", "£100", "£250", "£500"),
-        "nz" -> ("$50", "$100", "$250", "$500"),
-        "ca" -> ("$50", "$100", "$250", "$500")
-      )
+    if (isTest)
       views.html.newContributionsTest(
         title = "Support the Guardian | Make a Contribution",
         id = s"new-contributions-landing-page-$countryCode",
@@ -133,26 +124,25 @@ class Application(
         regularUatPayPalConfig = payPalConfigProvider.get(true),
         paymentApiStripeEndpoint = paymentAPIService.stripeExecutePaymentEndpoint,
         paymentApiPayPalEndpoint = paymentAPIService.payPalCreatePaymentEndpoint,
-        idUser = idUser,
-        annualAmounts = annualAmounts(countryCode)
+        idUser = idUser
       )
-    } else
-    views.html.newContributions(
-      title = "Support the Guardian | Make a Contribution",
-      id = s"new-contributions-landing-page-$countryCode",
-      js = "newContributionsLandingPage.js",
-      css = "newContributionsLandingPageStyles.css",
-      description = stringsConfig.contributionsLandingDescription,
-      oneOffDefaultStripeConfig = oneOffStripeConfigProvider.get(false),
-      oneOffUatStripeConfig = oneOffStripeConfigProvider.get(true),
-      regularDefaultStripeConfig = regularStripeConfigProvider.get(false),
-      regularUatStripeConfig = regularStripeConfigProvider.get(true),
-      regularDefaultPayPalConfig = payPalConfigProvider.get(false),
-      regularUatPayPalConfig = payPalConfigProvider.get(true),
-      paymentApiStripeEndpoint = paymentAPIService.stripeExecutePaymentEndpoint,
-      paymentApiPayPalEndpoint = paymentAPIService.payPalCreatePaymentEndpoint,
-      idUser = idUser
-    )
+    else
+      views.html.newContributions(
+        title = "Support the Guardian | Make a Contribution",
+        id = s"new-contributions-landing-page-$countryCode",
+        js = "newContributionsLandingPage.js",
+        css = "newContributionsLandingPageStyles.css",
+        description = stringsConfig.contributionsLandingDescription,
+        oneOffDefaultStripeConfig = oneOffStripeConfigProvider.get(false),
+        oneOffUatStripeConfig = oneOffStripeConfigProvider.get(true),
+        regularDefaultStripeConfig = regularStripeConfigProvider.get(false),
+        regularUatStripeConfig = regularStripeConfigProvider.get(true),
+        regularDefaultPayPalConfig = payPalConfigProvider.get(false),
+        regularUatPayPalConfig = payPalConfigProvider.get(true),
+        paymentApiStripeEndpoint = paymentAPIService.stripeExecutePaymentEndpoint,
+        paymentApiPayPalEndpoint = paymentAPIService.payPalCreatePaymentEndpoint,
+        idUser = idUser
+      )
   }
 
   def showcase: Action[AnyContent] = CachedAction() { implicit request =>

--- a/app/views/newContributionsTest.scala.html
+++ b/app/views/newContributionsTest.scala.html
@@ -18,8 +18,7 @@
   regularUatPayPalConfig: PayPalConfig,
   paymentApiStripeEndpoint: String,
   paymentApiPayPalEndpoint: String,
-  idUser: Option[IdUser],
-  annualAmounts: (String, String, String, String)
+  idUser: Option[IdUser]
 )(implicit assets: AssetsResolver, request: RequestHeader, settings: AllSettings)
 
 @scripts = {
@@ -68,4 +67,4 @@
   </script>
 }
 
-@test(title = title, scripts = scripts, mainJsBundle = js, description = description, mainId = id, mainStyleBundle = css, annualAmounts = annualAmounts)
+@test(title = title, scripts = scripts, mainJsBundle = js, description = description, mainId = id, mainStyleBundle = css)

--- a/app/views/test.scala.html
+++ b/app/views/test.scala.html
@@ -13,8 +13,7 @@
   styles: Html = Html(""),
   scripts: Html = Html(""),
   data: Map[String, String] = Map.empty,
-  csrf: Option[String] = None,
-  annualAmounts: (String, String, String, String)
+  csrf: Option[String] = None
 )(implicit assets: AssetsResolver, request: RequestHeader, settings: AllSettings)
 
 <!DOCTYPE html>
@@ -1854,6 +1853,12 @@
         cursor: pointer
       }
 
+      .amounts__placeholder {
+        width: 30px;
+        height: 18px;
+        background-color: #eee;
+      }
+
       .form__radio-group--tabs .form__radio-group-list {
         display: -webkit-flex;
         display: flex;
@@ -2224,10 +2229,10 @@
           Monthly</label></li><li class="form__radio-group-item"><input id="contributionType-ANNUAL" class="form__radio-group-input" type="radio" name="contributionType" value="ANNUAL" checked><label for="contributionType-ANNUAL" class="form__radio-group-label">
           Annual</label></li></ul></fieldset><fieldset class="form__radio-group form__radio-group--pills form__radio-group--contribution-amount"><legend class="form__legend form__legend--radio-group">
           Amount</legend><ul class="form__radio-group-list"><li class="form__radio-group-item"><input id="contributionAmount-50" class="form__radio-group-input" type="radio" name="contributionAmount" value="50"><label for="contributionAmount-50" class="form__radio-group-label" aria-label="50 pounds">
-          @{annualAmounts._1}</label></li><li class="form__radio-group-item"><input id="contributionAmount-100" class="form__radio-group-input" type="radio" name="contributionAmount" value="100" checked><label for="contributionAmount-100" class="form__radio-group-label" aria-label="100 pounds">
-        @{annualAmounts._2}</label></li><li class="form__radio-group-item"><input id="contributionAmount-250" class="form__radio-group-input" type="radio" name="contributionAmount" value="250"><label for="contributionAmount-250" class="form__radio-group-label" aria-label="250 pounds">
-        @{annualAmounts._3}</label></li><li class="form__radio-group-item"><input id="contributionAmount-500" class="form__radio-group-input" type="radio" name="contributionAmount" value="500"><label for="contributionAmount-500" class="form__radio-group-label" aria-label="500 pounds">
-        @{annualAmounts._4}</label></li><li class="form__radio-group-item"><input id="contributionAmount-other" class="form__radio-group-input" type="radio" name="contributionAmount" value="other"><label for="contributionAmount-other" class="form__radio-group-label">
+          <span class="amounts__placeholder"></span></label></li><li class="form__radio-group-item"><input id="contributionAmount-100" class="form__radio-group-input" type="radio" name="contributionAmount" value="100" checked><label for="contributionAmount-100" class="form__radio-group-label" aria-label="100 pounds">
+          <span class="amounts__placeholder"></span></label></li><li class="form__radio-group-item"><input id="contributionAmount-250" class="form__radio-group-input" type="radio" name="contributionAmount" value="250"><label for="contributionAmount-250" class="form__radio-group-label" aria-label="250 pounds">
+          <span class="amounts__placeholder"></span></label></li><li class="form__radio-group-item"><input id="contributionAmount-500" class="form__radio-group-input" type="radio" name="contributionAmount" value="500"><label for="contributionAmount-500" class="form__radio-group-label" aria-label="500 pounds">
+          <span class="amounts__placeholder"></span></label></li><li class="form__radio-group-item"><input id="contributionAmount-other" class="form__radio-group-input" type="radio" name="contributionAmount" value="other"><label for="contributionAmount-other" class="form__radio-group-label">
           Other</label></li></ul></fieldset><div class="stripe-payment-request-button stripe-payment-request-button--hidden"></div><div class="form-fields"><div class="form__field form__field--contribution-email"><label class="form__label" for="contributionEmail">
           Email address</label><span class="form__input-with-icon"><input id="contributionEmail" class="form__input form__input--contributionEmail" type="email" autocapitalize="none" autocomplete="email" required="" placeholder="example@@domain.com" pattern="^[a-zA-Z0-9\.!#$%&amp;'*+/=?^_`{|}~-]+@@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$" style="background-image: url(&quot;data: image/png;
           base64, iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAfBJREFUWAntVk1OwkAUZkoDKza4Utm61iP0AqyIDXahN2BjwiHYGU+gizap4QDuegWN7lyCbMSlCQjU7yO0TOlAi6GwgJc0fT / fzPfmzet0crmD7HsFBAvQbrcrw+Gw5fu+AfOYvgylJ4TwCoVCs1ardYTruqfj8fgV5OUMSVVT93VdP9dAzpVvm5wJHZFbg2LQ2pEYOlZ /oiDvwNcsFoseY4PBwMCrhaeCJyKWZU37KOJcYdi27QdhcuuBIb073BvTNL8ln4NeeR6NRi/ wxZKQcGurQs5oNhqLshzVTMBewW / LMU3TTNlO0ieTiStjYhUIyi6DAp0xbEdgTt+LE0aCKQw24U4llsCs4ZRJrYopB6RwqnpA1YQ5NGFZ1YQ41Z5S8IQQdP5laEBRJcD4Vj5DEsW2gE6s6g3d /YP/ g+BDnT7GNi2qCjTwGd6riBzHaaCEd3Js01vwCPIbmWBRx1nwAN / 1 ov+ / drgFWIlfKpVukyYihtgkXNp4mABK+1 GtVr+SBhJDbBIubVw+Cd /TDgKO2DPiN3YUo6y/ nDCNEIsqTKH1en2tcwA9FKEItyDi3aIh8Gl1sRrVnSDzNFDJT1bAy5xpOYGn5fP5JuL95ZjMIn1ya7j5dPGfv0A5eAnpZUY3n5jXcoec5J67D9q+VuAPM47D3XaSeL4AAAAASUVORK5CYII =&quot;);


### PR DESCRIPTION
## Why are you doing this?

Since we are going to test rendering a placeholder before the payment flow appears in https://github.com/guardian/support-frontend/pull/1419
We are rendering the amounts early on so people have something to look at.  However we don't think that will be important and it also makes it a little more difficult to run amounts test (we would need server side test allocation)

This PR changes it to be a grey box which is replaced by the amounts in due course.  I haven't used any paricular grey and it has a 0.6 opacity black cover over it anyway, but this can be tweaked easily.

![image](https://user-images.githubusercontent.com/7304387/52121775-af157380-2618-11e9-82da-332989b6fefa.png)

I haven't done the button at the bottom because it's probably outside of where the user will be paying attention anyway, but it would be possible to add that if necessary.

@ionamckendrick @jranks123 