### PR TITLE
Show regular paper prices during flash sale

### DIFF
--- a/assets/helpers/subscriptions.js
+++ b/assets/helpers/subscriptions.js
@@ -264,6 +264,10 @@ function getPromotionWeeklyProductPrice(
   return fixDecimals(subscriptionPromoPricesForGuardianWeekly[promoCode][countryGroupId][billingPeriod]);
 }
 
+function getRegularPaperPrice(billingPlan: PaperBillingPlan): Price {
+  return paperSubscriptionPrices[billingPlan];
+}
+
 function getPaperPrice(billingPlan: PaperBillingPlan): Price {
   const planPrices: PlanPrice[] = getPlanPrices('Paper', 'GBPCountries');
 
@@ -274,7 +278,7 @@ function getPaperPrice(billingPlan: PaperBillingPlan): Price {
     }
   }
 
-  return paperSubscriptionPrices[billingPlan];
+  return getRegularPaperPrice(billingPlan);
 }
 
 function ophanProductFromSubscriptionProduct(product: SubscriptionProduct): OphanSubscriptionsProduct {
@@ -347,5 +351,6 @@ export {
   getNewsstandPrice,
   getDigitalPrice,
   getPaperPrice,
+  getRegularPaperPrice,
   fixDecimals,
 };

--- a/assets/pages/paper-subscription-landing/components/content/form.jsx
+++ b/assets/pages/paper-subscription-landing/components/content/form.jsx
@@ -20,7 +20,6 @@ import { setPlan, redirectToCheckout } from '../../paperSubscriptionLandingPageA
 
 const getRegularPriceStr = (price: Price): string => `You pay ${showPrice(price)} a month`;
 
-
 const getPriceStr = (price: Price): string => {
   if (flashSaleIsActive('Paper', 'GBPCountries')) {
     const duration = getDuration('Paper', 'GBPCountries');
@@ -32,10 +31,19 @@ const getPriceStr = (price: Price): string => {
   return getRegularPriceStr(price);
 };
 
-const getOfferStr = (subscription: Option<number>, newsstand: Option<number>): Option<string> =>
-  (subscription && newsstand && parseFloat(getNewsstandSaving(subscription, newsstand)) > 0 ? `Save £${getNewsstandSaving(subscription, newsstand)} a month on retail price` : null);
+const getOfferStr = (subscription: Option<number>, newsstand: Option<number>): Option<string> => {
+  if ((subscription && newsstand && parseFloat(getNewsstandSaving(subscription, newsstand)) > 0)) {
+    return `Save £${getNewsstandSaving(subscription, newsstand)} a month on retail price`;
+  }
+  return null;
+};
 
-const getSavingStr = (price: Price): Option<string> => (flashSaleIsActive('Paper', 'GBPCountries') && getDuration('Paper', 'GBPCountries') ? `${showPrice(price)} a month thereafter` : null);
+const getSavingStr = (price: Price): Option<string> => {
+  if (flashSaleIsActive('Paper', 'GBPCountries') && getDuration('Paper', 'GBPCountries')) {
+    return `${showPrice(price)} a month thereafter`;
+  }
+  return null;
+};
 
 
 // ---- Plans ----- //

--- a/assets/pages/paper-subscription-landing/components/content/form.jsx
+++ b/assets/pages/paper-subscription-landing/components/content/form.jsx
@@ -6,10 +6,11 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
 import { type Option } from 'helpers/types/option';
-import { getNewsstandSaving, getNewsstandPrice, type PaperBillingPlan, getPaperPrice } from 'helpers/subscriptions';
+import { getNewsstandSaving, getNewsstandPrice, type PaperBillingPlan, getPaperPrice, getRegularPaperPrice } from 'helpers/subscriptions';
 import { showPrice, type Price } from 'helpers/internationalisation/price';
 import { type Action } from 'components/productPage/productPagePlanForm/productPagePlanFormActions';
 import ProductPagePlanForm, { type StatePropTypes, type DispatchPropTypes } from 'components/productPage/productPagePlanForm/productPagePlanForm';
+import { flashSaleIsActive, getDuration } from 'helpers/flashSale';
 
 import { type State } from '../../paperSubscriptionLandingPageReducer';
 import { setPlan, redirectToCheckout } from '../../paperSubscriptionLandingPageActions';
@@ -17,63 +18,87 @@ import { setPlan, redirectToCheckout } from '../../paperSubscriptionLandingPageA
 
 // ---- Helpers ----- //
 
-const getPriceStr = (price: Price): string =>
-  `Monthly price ${showPrice(price)}`;
+const getRegularPriceStr = (price: Price): string => `You pay ${showPrice(price)} a month`;
 
-const getSavingStr = (subscription: Option<number>, newsstand: Option<number>): Option<string> =>
+
+const getPriceStr = (price: Price): string => {
+  if (flashSaleIsActive('Paper', 'GBPCountries')) {
+    const duration = getDuration('Paper', 'GBPCountries');
+    if (duration) {
+      return `You pay ${showPrice(price)} a month for ${duration}`;
+    }
+    return getRegularPriceStr(price);
+  }
+  return getRegularPriceStr(price);
+};
+
+const getOfferStr = (subscription: Option<number>, newsstand: Option<number>): Option<string> =>
   (subscription && newsstand && parseFloat(getNewsstandSaving(subscription, newsstand)) > 0 ? `Save £${getNewsstandSaving(subscription, newsstand)} a month on retail price` : null);
+
+const getSavingStr = (price: Price): Option<string> => (flashSaleIsActive('Paper', 'GBPCountries') && getDuration('Paper', 'GBPCountries') ? `${showPrice(price)} a month thereafter` : null);
 
 
 // ---- Plans ----- //
 
+const collectionCopy = 'Collect your papers from your local retailer';
+const deliveryCopy = 'Have your papers delivered to your home';
+
 const allPlans = {
   collectionEveryday: {
     title: 'Every day',
-    copy: 'Every issue of The Guardian and The Observer, from Monday to Sunday',
+    copy: collectionCopy,
     newsstand: getNewsstandPrice(['weekly', 'saturday', 'sunday']),
     price: getPaperPrice('collectionEveryday'),
+    regularPrice: getRegularPaperPrice('collectionEveryday'),
   },
   collectionSixday: {
     title: 'Monday to Saturday',
-    copy: 'Every issue of The Guardian, from Monday to Saturday',
+    copy: collectionCopy,
     newsstand: getNewsstandPrice(['weekly', 'saturday']),
     price: getPaperPrice('collectionSixday'),
+    regularPrice: getRegularPaperPrice('collectionSixday'),
   },
   collectionWeekend: {
     title: 'Weekend',
-    copy: 'The Guardian every Saturday and The Observer every Sunday',
+    copy: collectionCopy,
     newsstand: getNewsstandPrice(['saturday', 'sunday']),
     price: getPaperPrice('collectionWeekend'),
+    regularPrice: getRegularPaperPrice('collectionWeekend'),
   },
   collectionSunday: {
     title: 'Sunday',
-    copy: 'The Observer every Sunday',
+    copy: collectionCopy,
     newsstand: getNewsstandPrice(['sunday']),
     price: getPaperPrice('collectionSunday'),
+    regularPrice: getRegularPaperPrice('collectionSunday'),
   },
   deliveryEveryday: {
     title: 'Every day',
-    copy: 'Every issue of The Guardian and The Observer, from Monday to Sunday',
+    copy: deliveryCopy,
     newsstand: getNewsstandPrice(['weekly', 'saturday', 'sunday']),
     price: getPaperPrice('deliveryEveryday'),
+    regularPrice: getRegularPaperPrice('deliveryEveryday'),
   },
   deliverySixday: {
     title: 'Monday to Saturday',
-    copy: 'Every issue of The Guardian, from Monday to Saturday',
+    copy: deliveryCopy,
     newsstand: getNewsstandPrice(['weekly', 'saturday']),
     price: getPaperPrice('deliverySixday'),
+    regularPrice: getRegularPaperPrice('deliverySixday'),
   },
   deliveryWeekend: {
     title: 'Weekend',
-    copy: 'The Guardian every Saturday and The Observer every Sunday',
+    copy: deliveryCopy,
     newsstand: getNewsstandPrice(['saturday', 'sunday']),
     price: getPaperPrice('deliveryWeekend'),
+    regularPrice: getRegularPaperPrice('deliveryWeekend'),
   },
   deliverySunday: {
     title: 'Sunday',
-    copy: 'The Observer every Sunday',
+    copy: deliveryCopy,
     newsstand: getNewsstandPrice(['sunday']),
     price: getPaperPrice('deliverySunday'),
+    regularPrice: getRegularPaperPrice('deliverySunday'),
   },
 };
 
@@ -86,8 +111,8 @@ const mapStateToProps = (state: State): StatePropTypes<PaperBillingPlan> => {
       title: allPlans[k].title,
       copy: allPlans[k].copy,
       price: getPriceStr(allPlans[k].price),
-      offer: getSavingStr(allPlans[k].price.value, allPlans[k].newsstand ? allPlans[k].newsstand : null),
-      saving: null,
+      offer: getOfferStr(allPlans[k].price.value, allPlans[k].newsstand ? allPlans[k].newsstand : null),
+      saving: getSavingStr(allPlans[k].regularPrice),
     },
   }), {});
 


### PR DESCRIPTION
## Why are you doing this?

Better highlight the valuer provided

[**Trello Card**](https://trello.com/c/AYwIzZ8R/2191-update-prices-on-cards-for-paper-product)

## Screenshots
![support thegulocal com_uk_subscribe_paper_delivery](https://user-images.githubusercontent.com/11539094/52122543-48de2000-261b-11e9-8bc0-1921468c5fd1.png)

