### PR TITLE
Remove y from "delivery"

### DIFF
--- a/assets/pages/paper-subscription-landing/components/content/deliveryTab.jsx
+++ b/assets/pages/paper-subscription-landing/components/content/deliveryTab.jsx
@@ -44,7 +44,7 @@ const ContentDeliveryFaqBlock = ({ setTabAction }: {setTabAction: typeof setTab}
     <ProductPageTextBlock title="Giving you peace of mind">
       <UnorderedList items={[
         'Your paper will arrive before 7am from Monday to Saturday and before 8.30am on Sunday',
-        'We can’t delivery to individual flats, or apartments within blocks because we need access to your post box to deliver your paper',
+        'We can’t deliver to individual flats, or apartments within blocks because we need access to your post box to deliver your paper',
         'You can pause your subscription for up to 36 days a year. So if you’re going away anywhere, you won’t have to pay for the papers that you miss',
         ]}
       />


### PR DESCRIPTION
## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->
Because there's a sentence that doesn't agree grammatically!
[**Trello Card**](https://trello.com/c/ecK4Jpqq)

## Changes

* Remove "y" to make the sentence "we can't delivery" work


## Screenshots
Current:
![image](https://user-images.githubusercontent.com/45856485/52123384-e5092680-261d-11e9-9504-9c5b75cad92a.png)

New:
![image](https://user-images.githubusercontent.com/45856485/52123396-ed616180-261d-11e9-9959-c75953e671a8.png)