### PR TITLE
Copy update: "going on holiday"

### DIFF
--- a/assets/pages/paper-subscription-landing/components/content/collectionTab.jsx
+++ b/assets/pages/paper-subscription-landing/components/content/collectionTab.jsx
@@ -38,7 +38,7 @@ const ContentVoucherFaqBlock = () => (
     <ProductPageTextBlock title="Giving you peace of mind">
       <UnorderedList items={[
         'Your newsagent won’t lose out; we’ll pay them the same amount that they receive if you pay cash for your paper',
-        'You can pause your subscription for up to four weeks a year. So if you’re heading away, you won’t have to pay for the papers you’ll miss',
+        'You can pause your subscription for up to four weeks a year. So if you’re going on holiday, you won’t have to pay for the papers you’ll miss',
       ]}
       />
     </ProductPageTextBlock>


### PR DESCRIPTION
## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->
Some of the copy updates to the Print product page were missed. This is one in a series of teeny tiny PRs to clean them up.
[**Trello Card**](https://trello.com/c/MKj2vchm)

## Changes

* Change "heading away" to "going on holiday"

## Screenshots
Current:
![image](https://user-images.githubusercontent.com/45856485/52125426-59df5f00-2624-11e9-8487-25c9b6ad0e6c.png)

New:
![image](https://user-images.githubusercontent.com/45856485/52125447-6794e480-2624-11e9-9415-daffa49cafb2.png)

