### PR TITLE
Copy updates: home delivery details

### DIFF
--- a/assets/pages/paper-subscription-landing/components/content/deliveryTab.jsx
+++ b/assets/pages/paper-subscription-landing/components/content/deliveryTab.jsx
@@ -35,7 +35,7 @@ const ContentDeliveryFaqBlock = ({ setTabAction }: {setTabAction: typeof setTab}
       </p>
       <OrderedList items={[
         'Select your subscription below and checkout',
-        'You'll receive your first newspaper as quickly as five days from you subscribing',
+        'You\'ll receive your first newspaper as quickly as five days from you subscribing',
         ]}
       />
     </ProductPageTextBlock>

--- a/assets/pages/paper-subscription-landing/components/content/deliveryTab.jsx
+++ b/assets/pages/paper-subscription-landing/components/content/deliveryTab.jsx
@@ -35,7 +35,7 @@ const ContentDeliveryFaqBlock = ({ setTabAction }: {setTabAction: typeof setTab}
       </p>
       <OrderedList items={[
         'Select your subscription below and checkout',
-        'You\'ll receive your first newspaper as quickly as five days from you subscribing',
+        'You’ll receive your first newspaper as quickly as five days from you subscribing',
         ]}
       />
     </ProductPageTextBlock>

--- a/assets/pages/paper-subscription-landing/components/content/deliveryTab.jsx
+++ b/assets/pages/paper-subscription-landing/components/content/deliveryTab.jsx
@@ -30,13 +30,12 @@ const ContentDeliveryFaqBlock = ({ setTabAction }: {setTabAction: typeof setTab}
     <ProductPageTextBlock title="How home delivery works">
       <p>
           If you live in Greater London (within the M25), you
-          can use The Guardian’s home delivery service. Don’t
-          worry if you live outside this area you can
+          can use The Guardian’s home delivery service. If don't, you can
           still <LinkTo tab="collection" setTabAction={setTabAction} >subscribe using our voucher scheme</LinkTo>.
       </p>
       <OrderedList items={[
         'Select your subscription below and checkout',
-        'Your subscribing deliveries will begin as quickly as five days from you subscribing',
+        'You'll receive your first newspaper as quickly as five days from you subscribing',
         ]}
       />
     </ProductPageTextBlock>

--- a/assets/pages/paper-subscription-landing/components/content/deliveryTab.jsx
+++ b/assets/pages/paper-subscription-landing/components/content/deliveryTab.jsx
@@ -30,7 +30,7 @@ const ContentDeliveryFaqBlock = ({ setTabAction }: {setTabAction: typeof setTab}
     <ProductPageTextBlock title="How home delivery works">
       <p>
           If you live in Greater London (within the M25), you
-          can use The Guardian’s home delivery service. If don't, you can
+          can use The Guardian’s home delivery service. If not, you can
           still <LinkTo tab="collection" setTabAction={setTabAction} >subscribe using our voucher scheme</LinkTo>.
       </p>
       <OrderedList items={[


### PR DESCRIPTION
## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->
This is the second PR to update copy on the Print product page in line with the copy document. 
[**Trello Card**](https://trello.com/c/MKj2vchm)

## Changes

* Update: "If you live in Greater London (within the M25), you can use The Guardian’s home delivery service. Don’t worry if you live outside this area you can still subscribe using our voucher scheme." to "If you live in Greater London (within the M25), you can use The Guardian’s home delivery service. If you don't, you can still subscribe using our voucher scheme." 
* Update: "Your subscribing deliveries will begin as quickly as five days from you subscribing" to "You'll receive your first newspaper as quickly as five days from you subscribing"

## Screenshots
Current:
![image](https://user-images.githubusercontent.com/45856485/52125817-95c6f400-2625-11e9-9c4d-d9a920dd1f81.png)

New:
![image](https://user-images.githubusercontent.com/45856485/52125831-9e1f2f00-2625-11e9-858b-78a962f78c7f.png)


