### PR TITLE
Allow the app to access the catalog.json in S3

### DIFF
--- a/cloud-formation/cfn.yaml
+++ b/cloud-formation/cfn.yaml
@@ -101,7 +101,10 @@ Resources:
             Statement:
               - Effect: Allow
                 Action: s3:GetObject
-                Resource: !Sub arn:aws:s3:::membership-private/${Stage}/support-frontend.private.conf
+                Resource:
+                - !Sub arn:aws:s3:::membership-private/${Stage}/support-frontend.private.conf
+                - !Sub arn:aws:s3:::gu-zuora-catalog/PROD/Zuora-PROD/catalog.json
+                - !Sub arn:aws:s3:::gu-zuora-catalog/PROD/Zuora-UAT/catalog.json
         - PolicyName: SettingsBucket
           PolicyDocument:
             Version: 2012-10-17


### PR DESCRIPTION
## Why are you doing this?

The app needs permission to access the catalog.json file in S3. This changes the cloud formation template to allow it.