### PR TITLE
Fix annual promotion summary and add tests

### DIFF
--- a/assets/components/promotionSummary/__tests__/promotionSummaryTests.js
+++ b/assets/components/promotionSummary/__tests__/promotionSummaryTests.js
@@ -1,0 +1,29 @@
+// @flow
+
+// ----- Imports ----- //
+
+import { Annual, Monthly } from 'helpers/billingPeriods';
+// eslint-disable-next-line import/extensions
+import { getSummary } from '../promotionSummary.jsx';
+
+jest.mock('ophan', () => {});
+
+// ----- Tests ----- //
+
+
+describe('promotionSummary', () => {
+
+  it('should generate correct summaries for monthly and annual billing periods', () => {
+    expect(getSummary('£', 11.99, 8.99, 3, Monthly))
+      .toEqual('£8.99/month for 3 months, then standard rate (£11.99/month)');
+
+    expect(getSummary('$', 119.90, 112.41, 1, Annual))
+      .toEqual('$112.41 for 1 year, then standard rate ($119.90/year)');
+  });
+
+  it('should use an empty summary for a promotion without an end date', () => {
+    expect(getSummary('€', 119.90, 112.41, null, Annual))
+      .toEqual(null);
+  });
+
+});

--- a/assets/components/promotionSummary/promotionSummary.jsx
+++ b/assets/components/promotionSummary/promotionSummary.jsx
@@ -24,7 +24,7 @@ const displayPrice = (glyph: string, price: number) => `${glyph}${fixDecimals(pr
 const billingPeriodQuantifier = (numberOfBillingPeriods: number, noun: string) =>
   (numberOfBillingPeriods > 1 ?
     `/${noun} for ${numberOfBillingPeriods} ${noun}s` :
-    `for 1 ${noun}`);
+    ` for 1 ${noun}`);
 
 
 function getSummary(
@@ -42,7 +42,7 @@ function getSummary(
     return `${discountCopy}, ${standardCopy}`;
   }
 
-  return `${discountedPrice}/${noun}`;
+  return null;
 }
 
 function discountSummary(
@@ -75,8 +75,7 @@ function PromotionSummary(props: PropTypes) {
     const productPrice = digitalPackProductPrice(props.productPrices, props.billingPeriod, country);
     if (productPrice.promotion &&
       productPrice.promotion.discountedPrice &&
-      productPrice.promotion.discount &&
-      productPrice.promotion.numberOfDiscountedPeriods) {
+      productPrice.promotion.discount) {
       return discountSummary(
         productPrice.price,
         productPrice.promotion.promoCode,
@@ -92,4 +91,4 @@ function PromotionSummary(props: PropTypes) {
   return null;
 }
 
-export { PromotionSummary };
+export { PromotionSummary, getSummary };


### PR DESCRIPTION
## Why are you doing this?

There were some small bugs with the way that the `PromotionSummary` component handled various promotions. This fixes them and adds tests.

[**Trello Card**](https://trello.com/c/YDhuWZgm/2194-add-jest-test-for-promotion-summaries)