### PR TITLE
add mid Feb UK digital pack flash sale

### DIFF
--- a/assets/helpers/flashSale.js
+++ b/assets/helpers/flashSale.js
@@ -285,6 +285,39 @@ const Sales: Sale[] = [
 
     },
   },
+  {
+    subscriptionProduct: 'DigitalPack',
+    activeRegions: ['GBPCountries'],
+    startTime: new Date(2019, 0, 18).getTime(), // 18 Feb 2019
+    endTime: new Date(2019, 3, 1).getTime(), // 31 Mar 2019
+    saleDetails: {
+      GBPCountries: {
+        promoCode: 'DDPFM80X',
+        annualPlanPromoCode: 'DDPFMAN80X',
+        intcmp: '',
+        price: 8.99,
+        annualPrice: 107.88,
+        discountPercentage: 0.25,
+        saleCopy: {
+          featuredProduct: {
+            heading: 'Digital Pack',
+            subHeading: 'Save 25% for a year',
+            description: 'Read The Guardian ad-free on all devices, including the Premium App and UK Daily Edition iPad app.',
+          },
+          landingPage: {
+            heading: 'Digital Pack subscriptions',
+            subHeading: 'Save 25% - £8.99/month for a year, then £11.99 a month',
+          },
+          bundle: {
+            heading: 'Digital Pack',
+            subHeading: 'Save 25% for a year',
+            description: 'The Premium App and the daily edition iPad app of the UK newspaper in one pack, plus ad-free reading on all your devices',
+          },
+        },
+        planPrices: [],
+      }
+    },
+  },
 ];
 
 function getTimeTravelDaysOverride() {

--- a/assets/helpers/flashSale.js
+++ b/assets/helpers/flashSale.js
@@ -288,7 +288,7 @@ const Sales: Sale[] = [
   {
     subscriptionProduct: 'DigitalPack',
     activeRegions: ['GBPCountries'],
-    startTime: new Date(2019, 0, 18).getTime(), // 18 Feb 2019
+    startTime: new Date(2019, 1, 18).getTime(), // 18 Feb 2019
     endTime: new Date(2019, 3, 1).getTime(), // 31 Mar 2019
     saleDetails: {
       GBPCountries: {

--- a/assets/helpers/flashSale.js
+++ b/assets/helpers/flashSale.js
@@ -315,7 +315,7 @@ const Sales: Sale[] = [
           },
         },
         planPrices: [],
-      }
+      },
     },
   },
 ];

--- a/assets/helpers/flashSale.js
+++ b/assets/helpers/flashSale.js
@@ -272,7 +272,7 @@ const Sales: Sale[] = [
           },
           landingPage: {
             heading: 'Digital Pack',
-            subHeading: 'Save 25% - $16.13/month for a year, then $21.50/month',
+            subHeading: 'Save 25% on award-winning, independent journalism, ad-free on all of your devices',
           },
           bundle: {
             heading: 'Digital Pack',
@@ -306,7 +306,7 @@ const Sales: Sale[] = [
           },
           landingPage: {
             heading: 'Digital Pack subscriptions',
-            subHeading: 'Save 25% - £8.99/month for a year, then £11.99 a month',
+            subHeading: 'Save 25% on award-winning, independent journalism, ad-free on all of your devices',
           },
           bundle: {
             heading: 'Digital Pack',


### PR DESCRIPTION
## Why are you doing this?
To make a push for Digital Pack acquisition targets. 💰 

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/yV5FjLXB/2159-uk-dp-flash-sale-18th-feb)

## Changes

* Adds in the UK Digital Pack flash sale from mid Feb to end of quarter
* Copy fix for the subheading of the currently running AU Digital Pack flash sale

## Screenshots
![image](https://user-images.githubusercontent.com/3072877/52206453-327dd180-2872-11e9-800b-16d2578a1ab9.png)

Note: countdown timer will not appear after https://github.com/guardian/support-frontend/pull/1455 is merged
