### PR TITLE
Show countdown timer for last 7 days on the DP product page during a flash sale. 

### DIFF
--- a/assets/helpers/__tests__/flashSaleTest.js
+++ b/assets/helpers/__tests__/flashSaleTest.js
@@ -1,13 +1,13 @@
 // @flow
 
 // ----- Imports ----- //
-import { countdownTimerActive } from '../flashSale';
+import { countdownTimerIsActive } from '../flashSale';
 
 // ----- Tests ----- //
 
 jest.mock('ophan', () => ({ viewId: '123456' }));
 
-describe('countdownTimerActive', () => {
+describe('countdownTimerIsActive', () => {
 
   const now = new Date();
 
@@ -15,15 +15,15 @@ describe('countdownTimerActive', () => {
   const endTimeThreeDaysFromNow = now.setDate(now.getDate() + 3);
 
   it('return false if the flash sale is not active', () => {
-    expect(countdownTimerActive(false, 7, now.getTime())).toEqual(false);
+    expect(countdownTimerIsActive(false, 7, now.getTime())).toEqual(false);
   });
 
   it('return true if the end time is three days from now', () => {
-    expect(countdownTimerActive(false, 7, endTimeThreeDaysFromNow)).toEqual(false);
+    expect(countdownTimerIsActive(false, 7, endTimeThreeDaysFromNow)).toEqual(false);
   });
 
   it('return false if the end time too far away', () => {
-    expect(countdownTimerActive(false, 7, endTimeMoreThanAWeekFromNow)).toEqual(false);
+    expect(countdownTimerIsActive(false, 7, endTimeMoreThanAWeekFromNow)).toEqual(false);
   });
 
 });

--- a/assets/helpers/__tests__/flashSaleTest.js
+++ b/assets/helpers/__tests__/flashSaleTest.js
@@ -1,13 +1,13 @@
 // @flow
 
 // ----- Imports ----- //
-import { showCountdownTimer } from '../flashSale';
+import { countdownTimerActive } from '../flashSale';
 
 // ----- Tests ----- //
 
 jest.mock('ophan', () => ({ viewId: '123456' }));
 
-describe('showCountdownTimer', () => {
+describe('countdownTimerActive', () => {
 
   const now = new Date();
 
@@ -15,15 +15,15 @@ describe('showCountdownTimer', () => {
   const endTimeThreeDaysFromNow = now.setDate(now.getDate() + 3);
 
   it('return false if the flash sale is not active', () => {
-    expect(showCountdownTimer(false, 7, now.getTime())).toEqual(false);
+    expect(countdownTimerActive(false, 7, now.getTime())).toEqual(false);
   });
 
   it('return true if the end time is three days from now', () => {
-    expect(showCountdownTimer(false, 7, endTimeThreeDaysFromNow)).toEqual(false);
+    expect(countdownTimerActive(false, 7, endTimeThreeDaysFromNow)).toEqual(false);
   });
 
   it('return false if the end time too far away', () => {
-    expect(showCountdownTimer(false, 7, endTimeMoreThanAWeekFromNow)).toEqual(false);
+    expect(countdownTimerActive(false, 7, endTimeMoreThanAWeekFromNow)).toEqual(false);
   });
 
 });

--- a/assets/helpers/__tests__/flashSaleTest.js
+++ b/assets/helpers/__tests__/flashSaleTest.js
@@ -1,0 +1,29 @@
+// @flow
+
+// ----- Imports ----- //
+import { showCountdownTimer } from '../flashSale';
+
+// ----- Tests ----- //
+
+jest.mock('ophan', () => ({ viewId: '123456' }));
+
+describe('showCountdownTimer', () => {
+
+  const now = new Date();
+
+  const endTimeMoreThanAWeekFromNow = now.setDate(now.getDate() + 8);
+  const endTimeThreeDaysFromNow = now.setDate(now.getDate() + 3);
+
+  it('return false if the flash sale is not active', () => {
+    expect(showCountdownTimer(false, 7, now.getTime())).toEqual(false);
+  });
+
+  it('return true if the end time is three days from now', () => {
+    expect(showCountdownTimer(false, 7, endTimeThreeDaysFromNow)).toEqual(false);
+  });
+
+  it('return false if the end time too far away', () => {
+    expect(showCountdownTimer(false, 7, endTimeMoreThanAWeekFromNow)).toEqual(false);
+  });
+
+});

--- a/assets/helpers/flashSale.js
+++ b/assets/helpers/flashSale.js
@@ -419,7 +419,7 @@ function getFormattedFlashSalePrice(
   return fixDecimals(sale.saleDetails[countryGroupId].price);
 }
 
-function countdownTimerActive(flashSaleActive: boolean, showForHowManyDays: number, endTime: number): boolean {
+function countdownTimerIsActive(flashSaleActive: boolean, showForHowManyDays: number, endTime: number): boolean {
   if (flashSaleActive) {
     const now = new Date();
     const daysFromNow = now.setDate(now.getDate() + showForHowManyDays);
@@ -443,5 +443,5 @@ export {
   getDuration,
   getTimeTravelDaysOverride,
   getFlashSaleActiveOverride,
-  countdownTimerActive,
+  countdownTimerIsActive,
 };

--- a/assets/helpers/flashSale.js
+++ b/assets/helpers/flashSale.js
@@ -419,8 +419,8 @@ function getFormattedFlashSalePrice(
   return fixDecimals(sale.saleDetails[countryGroupId].price);
 }
 
-function showCountdownTimer(flashSaleIsActive: boolean, showForHowManyDays: number, endTime: number): boolean {
-  if(flashSaleIsActive) {
+function showCountdownTimer(flashSaleActive: boolean, showForHowManyDays: number, endTime: number): boolean {
+  if (flashSaleActive) {
     const now = new Date();
     const daysFromNow = now.setDate(now.getDate() + showForHowManyDays);
 

--- a/assets/helpers/flashSale.js
+++ b/assets/helpers/flashSale.js
@@ -421,7 +421,8 @@ function getFormattedFlashSalePrice(
 
 function countdownTimerIsActive(flashSaleActive: boolean, showForHowManyDays: number, endTime: number): boolean {
   if (flashSaleActive) {
-    const now = new Date();
+    const timeTravelDays = getTimeTravelDaysOverride();
+    const now = timeTravelDays ? Date.now() + (timeTravelDays * 86400000) : Date.now();
     const daysFromNow = now.setDate(now.getDate() + showForHowManyDays);
 
     return daysFromNow - endTime > 0;

--- a/assets/helpers/flashSale.js
+++ b/assets/helpers/flashSale.js
@@ -422,8 +422,9 @@ function getFormattedFlashSalePrice(
 function countdownTimerIsActive(flashSaleActive: boolean, showForHowManyDays: number, endTime: number): boolean {
   if (flashSaleActive) {
     const timeTravelDays = getTimeTravelDaysOverride();
-    const now = timeTravelDays ? Date.now() + (timeTravelDays * 86400000) : Date.now();
-    const daysFromNow = now.setDate(now.getDate() + showForHowManyDays);
+    const oneDayInMillis = 86400000;
+    const now = timeTravelDays ? Date.now() + (timeTravelDays * oneDayInMillis) : Date.now();
+    const daysFromNow = now + (showForHowManyDays * oneDayInMillis);
 
     return daysFromNow - endTime > 0;
   }

--- a/assets/helpers/flashSale.js
+++ b/assets/helpers/flashSale.js
@@ -419,6 +419,16 @@ function getFormattedFlashSalePrice(
   return fixDecimals(sale.saleDetails[countryGroupId].price);
 }
 
+function showCountdownTimer(flashSaleIsActive: boolean, showForHowManyDays: number, endTime: number): boolean {
+  if(flashSaleIsActive) {
+    const now = new Date();
+    const daysFromNow = now.setDate(now.getDate() + showForHowManyDays);
+
+    return daysFromNow - endTime > 0;
+  }
+  return false;
+}
+
 
 export {
   flashSaleIsActive,
@@ -433,4 +443,5 @@ export {
   getDuration,
   getTimeTravelDaysOverride,
   getFlashSaleActiveOverride,
+  showCountdownTimer,
 };

--- a/assets/helpers/flashSale.js
+++ b/assets/helpers/flashSale.js
@@ -419,7 +419,7 @@ function getFormattedFlashSalePrice(
   return fixDecimals(sale.saleDetails[countryGroupId].price);
 }
 
-function showCountdownTimer(flashSaleActive: boolean, showForHowManyDays: number, endTime: number): boolean {
+function countdownTimerActive(flashSaleActive: boolean, showForHowManyDays: number, endTime: number): boolean {
   if (flashSaleActive) {
     const now = new Date();
     const daysFromNow = now.setDate(now.getDate() + showForHowManyDays);
@@ -443,5 +443,5 @@ export {
   getDuration,
   getTimeTravelDaysOverride,
   getFlashSaleActiveOverride,
-  showCountdownTimer,
+  countdownTimerActive,
 };

--- a/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
+++ b/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
@@ -19,7 +19,7 @@ import { CirclesLeft, CirclesRight } from 'components/svgs/digitalSubscriptionLa
 import AnchorButton from 'components/button/anchorButton';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { sendTrackingEventsOnClick, type SubscriptionProduct } from 'helpers/subscriptions';
-import { flashSaleIsActive, getSaleCopy, getEndTime, countdownTimerActive } from 'helpers/flashSale';
+import { flashSaleIsActive, getSaleCopy, getEndTime, countdownTimerIsActive } from 'helpers/flashSale';
 
 import { showUpgradeMessage } from '../helpers/upgradePromotion';
 
@@ -158,7 +158,7 @@ function showTimer(product: SubscriptionProduct, countryGroupId: CountryGroupId)
   const flashSaleActive = flashSaleIsActive(product, countryGroupId);
   const flashSaleEndTime = getEndTime(product, countryGroupId);
 
-  return countdownTimerActive(flashSaleActive, 7, flashSaleEndTime);
+  return countdownTimerIsActive(flashSaleActive, 7, flashSaleEndTime);
 }
 
 // ----- Component ----- //

--- a/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
+++ b/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
@@ -19,7 +19,7 @@ import { CirclesLeft, CirclesRight } from 'components/svgs/digitalSubscriptionLa
 import AnchorButton from 'components/button/anchorButton';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { sendTrackingEventsOnClick, type SubscriptionProduct } from 'helpers/subscriptions';
-import { flashSaleIsActive, getSaleCopy, getEndTime, showCountdownTimer } from 'helpers/flashSale';
+import { flashSaleIsActive, getSaleCopy, getEndTime, countdownTimerActive } from 'helpers/flashSale';
 
 import { showUpgradeMessage } from '../helpers/upgradePromotion';
 
@@ -158,7 +158,7 @@ function showTimer(product: SubscriptionProduct, countryGroupId: CountryGroupId)
   const flashSaleActive = flashSaleIsActive(product, countryGroupId);
   const flashSaleEndTime = getEndTime(product, countryGroupId);
 
-  return showCountdownTimer(flashSaleActive, 7, flashSaleEndTime);
+  return countdownTimerActive(flashSaleActive, 7, flashSaleEndTime);
 }
 
 // ----- Component ----- //

--- a/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
+++ b/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
@@ -19,7 +19,7 @@ import { CirclesLeft, CirclesRight } from 'components/svgs/digitalSubscriptionLa
 import AnchorButton from 'components/button/anchorButton';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { sendTrackingEventsOnClick, type SubscriptionProduct } from 'helpers/subscriptions';
-import { flashSaleIsActive, getSaleCopy } from 'helpers/flashSale';
+import { flashSaleIsActive, getSaleCopy, getEndTime, showCountdownTimer } from 'helpers/flashSale';
 
 import { showUpgradeMessage } from '../helpers/upgradePromotion';
 
@@ -154,6 +154,13 @@ function getCopy(product: SubscriptionProduct, country: CountryGroupId) {
   };
 }
 
+function showTimer(product: SubscriptionProduct, countryGroupId: CountryGroupId): boolean {
+  const flashSaleActive = flashSaleIsActive(product, countryGroupId);
+  const flashSaleEndTime = getEndTime(product, countryGroupId);
+
+  return showCountdownTimer(flashSaleActive, 7, flashSaleEndTime);
+}
+
 // ----- Component ----- //
 
 export default function DigitalSubscriptionLandingHeader(props: PropTypes) {
@@ -177,7 +184,7 @@ export default function DigitalSubscriptionLandingHeader(props: PropTypes) {
             </p>
           </div>
         </div>
-        {flashSaleIsActive(product, props.countryGroupId) &&
+        {showTimer(product, props.countryGroupId) &&
           <div className="digital-subscription-landing-header__countdown">
             <FlashSaleCountdown
               product={product}


### PR DESCRIPTION
## Why are you doing this?
<img src="https://user-images.githubusercontent.com/3072877/52205286-7373e700-286e-11e9-91ab-4093580f87d8.png" height=200>

doesn't look terribly urgent
<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/NyBumRDL/2134-countdown-timer-should-only-appear-during-the-last-week-of-the-print-sale)

## Changes

* Adds a function that determines if the now is x days from the end of the sale so that we can use it to determine if we should show the countdown timer
* Use this new function to only show the countdown timer 7 days before the end of the digital pack flash sale

## Screenshots
This is just changing the conditions by which we show the countdown timer or not, so n/a I think
