### PR TITLE
Pass initial CommonState to page reducer

### DIFF
--- a/assets/helpers/page/page.js
+++ b/assets/helpers/page/page.js
@@ -112,7 +112,7 @@ function storeEnhancer(thunk: boolean) {
 
 // Initialises the page.
 function init<S, A>(
-  pageReducer: Reducer<S, A> | null = null,
+  pageReducer?: CommonState => Reducer<S, A> | null,
   thunk?: boolean = false,
 ): Store<*, *, *> {
   const { settings } = window.guardian;

--- a/assets/pages/contributions-landing/contributionsLanding.jsx
+++ b/assets/pages/contributions-landing/contributionsLanding.jsx
@@ -19,7 +19,7 @@ import { createPageReducerFor } from './contributionsLandingReducer';
 
 const countryGroupId: CountryGroupId = detect();
 
-const store = pageInit(createPageReducerFor(countryGroupId));
+const store = pageInit(() => createPageReducerFor(countryGroupId));
 
 
 const reactElementId: {

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.jsx
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.jsx
@@ -36,7 +36,7 @@ const reactElementId: {
 
 // ----- Redux Store ----- //
 
-const store = pageInit(initReducer(countryGroupId), true);
+const store = pageInit(commonState => initReducer(commonState.internationalisation.countryGroupId), true);
 
 // ----- Render ----- //
 

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -30,7 +30,7 @@ import './digitalSubscriptionLanding.scss';
 
 // ----- Redux Store ----- //
 
-const store = pageInit(digitalSubscriptionLandingReducer(null), true);
+const store = pageInit(() => digitalSubscriptionLandingReducer(null), true);
 
 // ----- Internationalisation ----- //
 

--- a/assets/pages/new-contributions-landing/contributionsLanding.jsx
+++ b/assets/pages/new-contributions-landing/contributionsLanding.jsx
@@ -34,7 +34,7 @@ if (!isDetailsSupported) {
 
 const countryGroupId: CountryGroupId = detect();
 
-const store = pageInit(initReducer(countryGroupId), true);
+const store = pageInit(() => initReducer(countryGroupId), true);
 // We need to initialise in this order, as
 // formInit depends on the user being populated
 user.init(store.dispatch, setUserStateActions);

--- a/assets/pages/oneoff-contributions/oneoffContributions.jsx
+++ b/assets/pages/oneoff-contributions/oneoffContributions.jsx
@@ -30,7 +30,7 @@ import type { CountryGroupId } from '../../helpers/internationalisation/countryG
 
 const countryGroupId: CountryGroupId = detectCountryGroupId();
 
-const store = pageInit(reducer(getAmount('ONE_OFF', countryGroupId), countryGroupId), true);
+const store = pageInit(() => reducer(getAmount('ONE_OFF', countryGroupId), countryGroupId), true);
 
 const ONE_OFF_CONTRIBUTION_COOKIE = 'gu.contributions.contrib-timestamp';
 

--- a/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
+++ b/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
@@ -50,7 +50,7 @@ const promoInUrl = getQueryParameter('promo');
 
 // ----- Redux Store ----- //
 
-const store = pageInit(reducer(method, promoInUrl), true);
+const store = pageInit(() => reducer(method, promoInUrl), true);
 
 
 // ----- Render ----- //

--- a/assets/pages/regular-contributions/regularContributions.jsx
+++ b/assets/pages/regular-contributions/regularContributions.jsx
@@ -30,7 +30,7 @@ import { setCheckoutFormHasBeenSubmitted } from './helpers/checkoutForm/checkout
 const contributionType = parseRegularContributionType(getQueryParameter('contribType') || 'MONTHLY');
 const countryGroup = detectCountryGroup();
 
-const store = pageInit(reducer(
+const store = pageInit(() => reducer(
   getAmount(contributionType, countryGroup),
   getPaymentMethodFromSession(),
   contributionType,

--- a/assets/pages/support-landing/supportLanding.jsx
+++ b/assets/pages/support-landing/supportLanding.jsx
@@ -38,7 +38,7 @@ const supporterSectionId = 'supporter-options';
 
 // ----- Redux Store ----- //
 
-const store = pageInit(pageReducer);
+const store = pageInit(() => pageReducer);
 
 
 // ----- Internationalisation ----- //

--- a/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -31,7 +31,7 @@ import './weeklySubscriptionLanding.scss';
 
 // ----- Redux Store ----- //
 
-const store = pageInit(reducer, true);
+const store = pageInit(() => reducer, true);
 
 // ----- Internationalisation ----- //
 


### PR DESCRIPTION
## Why are you doing this?

We sort of need this for #1447 but it's a nice to have solution overall. The use case here is to be able to determine the user's initial country from the initial common state inside our reducer to affect its initial state (determine the payment options available)

Alas, this changes the signature for `pageInit()`, (takes a function with the initial state as the first parameter and returns the reducer) but thanks to the power of flow all the usages have been fixed by yours truly.

## Screenshots

![screenshot 2019-02-04 at 2 08 48 pm](https://user-images.githubusercontent.com/11539094/52213225-682cb580-2886-11e9-8119-672913ed931a.png)
