### PR TITLE
fix ssr tracking

### DIFF
--- a/assets/helpers/abTests/abtest.js
+++ b/assets/helpers/abTests/abtest.js
@@ -123,7 +123,7 @@ function getParticipationsFromUrl(): ?Participations {
   return null;
 }
 
-function getParticipationsFromQuery(): ?Participations {
+function getSSRParticipationsFromQuery(): ?Participations {
 
   const hashUrl = (new URL(document.URL)).search;
   const index = hashUrl.indexOf('ssr');
@@ -259,12 +259,17 @@ const init = (
   const mvt: number = getMvtId();
   const participations: Participations = getParticipations(abTests, mvt, country, countryGroupId);
   const urlParticipations: ?Participations = getParticipationsFromUrl();
-  const queryParticipations: ?Participations = getParticipationsFromQuery();
-  setLocalStorageParticipations(Object.assign({}, participations, urlParticipations, queryParticipations));
+  const ssrParticipation: ?Participations = getSSRParticipationsFromQuery();
+  const allParticipations = {
+    ...participations,
+    ...urlParticipations,
+    ...ssrParticipation,
+  };
+  setLocalStorageParticipations(allParticipations);
 
-  trackABOphan(participations, false);
+  trackABOphan(allParticipations, false);
 
-  return participations;
+  return allParticipations;
 };
 
 const getVariantsAsString = (participation: Participations): string => {

--- a/assets/helpers/abTests/abtest.js
+++ b/assets/helpers/abTests/abtest.js
@@ -230,7 +230,7 @@ function getParticipations(
     }
   });
 
-  return participations;
+  return { ...participations, ...getSSRParticipationsFromQuery() };
 }
 
 const buildOphanPayload = (participations: Participations, complete: boolean): OphanABPayload =>
@@ -259,17 +259,11 @@ const init = (
   const mvt: number = getMvtId();
   const participations: Participations = getParticipations(abTests, mvt, country, countryGroupId);
   const urlParticipations: ?Participations = getParticipationsFromUrl();
-  const ssrParticipation: ?Participations = getSSRParticipationsFromQuery();
-  const allParticipations = {
-    ...participations,
-    ...urlParticipations,
-    ...ssrParticipation,
-  };
-  setLocalStorageParticipations(allParticipations);
+  setLocalStorageParticipations({ ...participations, ...urlParticipations });
 
-  trackABOphan(allParticipations, false);
+  trackABOphan(participations, false);
 
-  return allParticipations;
+  return participations;
 };
 
 const getVariantsAsString = (participation: Participations): string => {


### PR DESCRIPTION
## Why are you doing this? 
Previously, we were just saving the participation of the SSR test to the storage, but in nearly all cases, not actually tracking people through GA or the datalake (the only cases where we would have tracked it is when people came back to the page after visiting once).

This PR fixes this bug. 

