### PR TITLE
Enable amounts tests

### DIFF
--- a/assets/helpers/abTests/__tests__/abtestTest.js
+++ b/assets/helpers/abTests/__tests__/abtestTest.js
@@ -29,7 +29,8 @@ describe('basic behaviour of init', () => {
 
     const tests = {
       mockTest: {
-        variants: ['control', 'variant'],
+        type: 'OTHER',
+        variants: [{ id: 'control' }, { id: 'variant' }],
         audiences: {
           GB: {
             offset: 0,
@@ -55,7 +56,8 @@ describe('basic behaviour of init', () => {
 
     const tests = {
       mockTest: {
-        variants: ['control', 'variant'],
+        type: 'OTHER',
+        variants: [{ id: 'control' }, { id: 'variant' }],
         audiences: {
           GB: {
             offset: 0,
@@ -81,7 +83,8 @@ describe('basic behaviour of init', () => {
 
     const tests = {
       mockTest: {
-        variants: ['control', 'variant'],
+        type: 'OTHER',
+        variants: [{ id: 'control' }, { id: 'variant' }],
         audiences: {
           GB: {
             offset: 0,
@@ -108,7 +111,8 @@ describe('basic behaviour of init', () => {
 
     const tests = {
       mockTest: {
-        variants: ['control', 'variant'],
+        type: 'OTHER',
+        variants: [{ id: 'control' }, { id: 'variant' }],
         audiences: {
           GB: {
             offset: 0,
@@ -134,7 +138,8 @@ describe('basic behaviour of init', () => {
 
     const tests = {
       mockTest: {
-        variants: ['control', 'variant'],
+        type: 'OTHER',
+        variants: [{ id: 'control' }, { id: 'variant' }],
         audiences: {
           US: {
             offset: 0,
@@ -167,7 +172,8 @@ describe('basic behaviour of init', () => {
 
     const tests = {
       mockTest: {
-        variants: ['control', 'variant'],
+        type: 'OTHER',
+        variants: [{ id: 'control' }, { id: 'variant' }],
         audiences: {
           US: {
             offset: 0,
@@ -199,7 +205,8 @@ describe('basic behaviour of init', () => {
 
     const tests = {
       mockTest: {
-        variants: ['control', 'variant'],
+        type: 'OTHER',
+        variants: [{ id: 'control' }, { id: 'variant' }],
         audiences: {
           US: {
             offset: 0,
@@ -232,7 +239,8 @@ describe('basic behaviour of init', () => {
 
     const tests = {
       mockTest: {
-        variants: ['control', 'variant'],
+        type: 'OTHER',
+        variants: [{ id: 'control' }, { id: 'variant' }],
         audiences: {
           US: {
             offset: 0,
@@ -264,7 +272,8 @@ describe('basic behaviour of init', () => {
 
     const tests = {
       mockTest: {
-        variants: ['control', 'variant'],
+        type: 'OTHER',
+        variants: [{ id: 'control' }, { id: 'variant' }],
         audiences: {
           GBPCountries: {
             offset: 0,
@@ -291,7 +300,8 @@ describe('basic behaviour of init', () => {
 
     const tests = {
       mockTest: {
-        variants: ['control', 'variant'],
+        type: 'OTHER',
+        variants: [{ id: 'control' }, { id: 'variant' }],
         audiences: {
           US: {
             offset: 0,
@@ -332,7 +342,8 @@ describe('basic behaviour of init', () => {
 
     const tests = {
       mockTest: {
-        variants: ['control', 'variant'],
+        type: 'OTHER',
+        variants: [{ id: 'control' }, { id: 'variant' }],
         audiences: {
           GB: {
             offset: 0,
@@ -370,7 +381,8 @@ describe('Correct allocation in a multi test environment', () => {
 
   const tests = {
     mockTest: {
-      variants: ['control', 'variant'],
+      type: 'OTHER',
+      variants: [{ id: 'control' }, { id: 'variant' }],
       audiences: {
         GB: {
           offset: 0,
@@ -387,7 +399,8 @@ describe('Correct allocation in a multi test environment', () => {
     },
 
     mockTest2: {
-      variants: ['control', 'variant'],
+      type: 'OTHER',
+      variants: [{ id: 'control' }, { id: 'variant' }],
       audiences: {
         US: {
           offset: 0.2,
@@ -400,7 +413,8 @@ describe('Correct allocation in a multi test environment', () => {
     },
 
     mockTest3: {
-      variants: ['control', 'variant'],
+      type: 'OTHER',
+      variants: [{ id: 'control' }, { id: 'variant' }],
       audiences: {
         GB: {
           offset: 0,

--- a/assets/helpers/abTests/abtest.js
+++ b/assets/helpers/abTests/abtest.js
@@ -11,6 +11,7 @@ import * as cookie from 'helpers/cookie';
 import * as storage from 'helpers/storage';
 import { type Settings } from 'helpers/settings';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { type AmountsRegions } from 'helpers/contributions';
 
 import { tests } from './abtestDefinitions';
 
@@ -61,8 +62,16 @@ type Audiences = {
   [IsoCountry | CountryGroupId | 'ALL']: Audience
 };
 
+export type Variant = {
+  id: string,
+  amountsRegions?: AmountsRegions,
+}
+
+export type TestType = 'AMOUNTS' | 'OTHER';
+
 export type Test = {|
-  variants: string[],
+  type: TestType,
+  variants: Variant[],
   audiences: Audiences,
   isActive: boolean,
   canRun?: () => boolean,
@@ -188,7 +197,7 @@ function assignUserToVariant(mvtId: number, test: Test): string {
 
   const variantIndex = randomNumber(mvtId, independent, seed) % test.variants.length;
 
-  return test.variants[variantIndex];
+  return test.variants[variantIndex].id;
 }
 
 function getParticipations(

--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -1,8 +1,9 @@
 // @flow
 import type { Tests } from './abtest';
-import { annualAmountsA } from './annualAmountsTest';
+import { annualAmountsLower, annualAmountsFive, annualAmountsOther } from './annualAmountsTest';
 
 // ----- Tests ----- //
+
 
 export const tests: Tests = {
   ssrTwo: {
@@ -26,8 +27,16 @@ export const tests: Tests = {
         id: 'control',
       },
       {
-        id: 'annualAmountsA',
-        amountsRegions: annualAmountsA,
+        id: 'lower',
+        amountsRegions: annualAmountsLower,
+      },
+      {
+        id: 'five',
+        amountsRegions: annualAmountsFive,
+      },
+      {
+        id: 'other',
+        amountsRegions: annualAmountsOther,
       },
     ],
     audiences: {

--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -37,7 +37,7 @@ export const tests: Tests = {
         size: 1,
       },
     },
-    isActive: true,
+    isActive: false,
     independent: true,
     seed: 3,
   },

--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -1,11 +1,13 @@
 // @flow
 import type { Tests } from './abtest';
+import { annualAmountsControl, annualAmountsA } from './annualAmountsTest';
 
 // ----- Tests ----- //
 
 export const tests: Tests = {
   ssrTwo: {
-    variants: ['off', 'on'],
+    type: 'OTHER',
+    variants: [{ id: 'off' }, { id: 'on' }],
     audiences: {
       ALL: {
         offset: 0,
@@ -15,6 +17,29 @@ export const tests: Tests = {
     isActive: true,
     independent: true,
     seed: 4,
+  },
+
+  annualContributionsRoundFour: {
+    type: 'AMOUNTS',
+    variants: [
+      {
+        id: 'control',
+        amountsRegions: annualAmountsControl,
+      },
+      {
+        id: 'annualAmountsA',
+        amountsRegions: annualAmountsA,
+      },
+    ],
+    audiences: {
+      ALL: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: true,
+    independent: true,
+    seed: 3,
   },
 
 };

--- a/assets/helpers/abTests/abtestDefinitions.js
+++ b/assets/helpers/abTests/abtestDefinitions.js
@@ -1,6 +1,6 @@
 // @flow
 import type { Tests } from './abtest';
-import { annualAmountsControl, annualAmountsA } from './annualAmountsTest';
+import { annualAmountsA } from './annualAmountsTest';
 
 // ----- Tests ----- //
 
@@ -24,7 +24,6 @@ export const tests: Tests = {
     variants: [
       {
         id: 'control',
-        amountsRegions: annualAmountsControl,
       },
       {
         id: 'annualAmountsA',
@@ -37,7 +36,7 @@ export const tests: Tests = {
         size: 1,
       },
     },
-    isActive: false,
+    isActive: true,
     independent: true,
     seed: 3,
   },

--- a/assets/helpers/abTests/annualAmountsTest.js
+++ b/assets/helpers/abTests/annualAmountsTest.js
@@ -2,10 +2,6 @@
 
 import { type AmountsRegions } from 'helpers/contributions';
 
-export const annualAmountsControl: AmountsRegions = {
-  // Use the config from server
-};
-
 export const annualAmountsA: AmountsRegions = {
   GBPCountries: {
     ANNUAL: [

--- a/assets/helpers/abTests/annualAmountsTest.js
+++ b/assets/helpers/abTests/annualAmountsTest.js
@@ -1,0 +1,129 @@
+// @flow
+
+import { type AmountsRegions } from 'helpers/contributions';
+
+export const annualAmountsControl: AmountsRegions = {
+  // Use the config from server
+};
+
+export const annualAmountsA: AmountsRegions = {
+  GBPCountries: {
+    ANNUAL: [
+      {
+        value: '50',
+      },
+      {
+        value: '77',
+        isDefault: true,
+      },
+      {
+        value: '250',
+      },
+      {
+        value: '500',
+      },
+    ],
+  },
+  UnitedStates: {
+    ANNUAL: [
+      {
+        value: '50',
+      },
+      {
+        value: '100',
+        isDefault: true,
+      },
+      {
+        value: '250',
+      },
+      {
+        value: '500',
+      },
+    ],
+  },
+  EURCountries: {
+    ANNUAL: [
+      {
+        value: '50',
+      },
+      {
+        value: '100',
+        isDefault: true,
+      },
+      {
+        value: '250',
+      },
+      {
+        value: '500',
+      },
+    ],
+  },
+  AUDCountries: {
+    ANNUAL: [
+      {
+        value: '100',
+        isDefault: true,
+      },
+      {
+        value: '250',
+      },
+      {
+        value: '500',
+      },
+      {
+        value: '750',
+      },
+    ],
+  },
+  International: {
+    ANNUAL: [
+      {
+        value: '50',
+      },
+      {
+        value: '100',
+        isDefault: true,
+      },
+      {
+        value: '250',
+      },
+      {
+        value: '500',
+      },
+    ],
+  },
+  NZDCountries: {
+    ANNUAL: [
+      {
+        value: '50',
+        isDefault: true,
+      },
+      {
+        value: '100',
+      },
+      {
+        value: '250',
+      },
+      {
+        value: '500',
+      },
+    ],
+  },
+  Canada: {
+    ANNUAL: [
+      {
+        value: '50',
+      },
+      {
+        value: '100',
+        isDefault: true,
+      },
+      {
+        value: '250',
+      },
+      {
+        value: '500',
+      },
+    ],
+  },
+};

--- a/assets/helpers/abTests/annualAmountsTest.js
+++ b/assets/helpers/abTests/annualAmountsTest.js
@@ -2,14 +2,139 @@
 
 import { type AmountsRegions } from 'helpers/contributions';
 
-export const annualAmountsA: AmountsRegions = {
+export const annualAmountsLower: AmountsRegions = {
   GBPCountries: {
+    ANNUAL: [
+      {
+        value: '25',
+      },
+      {
+        value: '50',
+      },
+      {
+        value: '100',
+        isDefault: true,
+      },
+      {
+        value: '250',
+      },
+    ],
+  },
+  UnitedStates: {
+    ANNUAL: [
+      {
+        value: '35',
+      },
+      {
+        value: '50',
+      },
+      {
+        value: '100',
+        isDefault: true,
+      },
+      {
+        value: '250',
+      },
+    ],
+  },
+  EURCountries: {
+    ANNUAL: [
+      {
+        value: '25',
+      },
+      {
+        value: '50',
+      },
+      {
+        value: '100',
+        isDefault: true,
+      },
+      {
+        value: '250',
+      },
+    ],
+  },
+  AUDCountries: {
     ANNUAL: [
       {
         value: '50',
       },
       {
-        value: '77',
+        value: '100',
+        isDefault: true,
+      },
+      {
+        value: '250',
+      },
+      {
+        value: '500',
+      },
+    ],
+  },
+  International: {
+    ANNUAL: [
+      {
+        value: '35',
+      },
+      {
+        value: '50',
+      },
+      {
+        value: '100',
+        isDefault: true,
+      },
+      {
+        value: '250',
+      },
+    ],
+  },
+  NZDCountries: {
+    ANNUAL: [
+      {
+        value: '35',
+      },
+      {
+        value: '50',
+      },
+      {
+        value: '100',
+        isDefault: true,
+      },
+      {
+        value: '250',
+      },
+    ],
+  },
+  Canada: {
+    ANNUAL: [
+      {
+        value: '35',
+      },
+      {
+        value: '50',
+      },
+      {
+        value: '100',
+        isDefault: true,
+      },
+      {
+        value: '250',
+      },
+    ],
+  },
+};
+
+export const annualAmountsFive: AmountsRegions = {
+  GBPCountries: {
+    ANNUAL: [
+      {
+        value: '25',
+      },
+      {
+        value: '50',
+      },
+      {
+        value: '100',
         isDefault: true,
       },
       {
@@ -22,6 +147,9 @@ export const annualAmountsA: AmountsRegions = {
   },
   UnitedStates: {
     ANNUAL: [
+      {
+        value: '25',
+      },
       {
         value: '50',
       },
@@ -40,6 +168,29 @@ export const annualAmountsA: AmountsRegions = {
   EURCountries: {
     ANNUAL: [
       {
+        value: '25',
+      },
+      {
+        value: '50',
+      },
+      {
+        value: '100',
+        isDefault: true,
+      },
+      {
+        value: '150',
+      },
+      {
+        value: '250',
+      },
+    ],
+  },
+  AUDCountries: {
+    ANNUAL: [
+      {
+        value: '25',
+      },
+      {
         value: '50',
       },
       {
@@ -54,25 +205,11 @@ export const annualAmountsA: AmountsRegions = {
       },
     ],
   },
-  AUDCountries: {
-    ANNUAL: [
-      {
-        value: '100',
-        isDefault: true,
-      },
-      {
-        value: '250',
-      },
-      {
-        value: '500',
-      },
-      {
-        value: '750',
-      },
-    ],
-  },
   International: {
     ANNUAL: [
+      {
+        value: '25',
+      },
       {
         value: '50',
       },
@@ -91,11 +228,14 @@ export const annualAmountsA: AmountsRegions = {
   NZDCountries: {
     ANNUAL: [
       {
+        value: '25',
+      },
+      {
         value: '50',
-        isDefault: true,
       },
       {
         value: '100',
+        isDefault: true,
       },
       {
         value: '250',
@@ -108,6 +248,9 @@ export const annualAmountsA: AmountsRegions = {
   Canada: {
     ANNUAL: [
       {
+        value: '25',
+      },
+      {
         value: '50',
       },
       {
@@ -119,6 +262,128 @@ export const annualAmountsA: AmountsRegions = {
       },
       {
         value: '500',
+      },
+    ],
+  },
+};
+
+export const annualAmountsOther: AmountsRegions = {
+  GBPCountries: {
+    ANNUAL: [
+      {
+        value: '250',
+      },
+      {
+        value: '100',
+        isDefault: true,
+      },
+      {
+        value: '50',
+      },
+      {
+        value: '25',
+      },
+    ],
+  },
+  UnitedStates: {
+    ANNUAL: [
+      {
+        value: '250',
+      },
+      {
+        value: '100',
+        isDefault: true,
+      },
+      {
+        value: '50',
+      },
+      {
+        value: '25',
+      },
+    ],
+  },
+  EURCountries: {
+    ANNUAL: [
+      {
+        value: '250',
+      },
+      {
+        value: '100',
+        isDefault: true,
+      },
+      {
+        value: '50',
+      },
+      {
+        value: '25',
+      },
+    ],
+  },
+  AUDCountries: {
+    ANNUAL: [
+      {
+        value: '125',
+        isDefault: true,
+      },
+      {
+        value: '300',
+      },
+      {
+        value: '500',
+      },
+      {
+        value: '750',
+      },
+    ],
+  },
+  International: {
+    ANNUAL: [
+      {
+        value: '250',
+      },
+      {
+        value: '100',
+        isDefault: true,
+      },
+      {
+        value: '50',
+      },
+      {
+        value: '25',
+      },
+    ],
+  },
+  NZDCountries: {
+    ANNUAL: [
+      {
+        value: '250',
+      },
+      {
+        value: '100',
+        isDefault: true,
+      },
+      {
+        value: '50',
+      },
+      {
+        value: '25',
+      },
+    ],
+  },
+  Canada: {
+    ANNUAL: [
+      {
+        value: '250',
+      },
+      {
+        value: '100',
+        isDefault: true,
+      },
+      {
+        value: '50',
+      },
+      {
+        value: '25',
       },
     ],
   },

--- a/assets/helpers/abTests/helpers.js
+++ b/assets/helpers/abTests/helpers.js
@@ -10,12 +10,11 @@ function overrideAmountsForTest(
   currentAmountsRegions: AmountsRegions,
 ): AmountsRegions {
 
-  const newAmountsRegions = { ...currentAmountsRegions };
-
   const variant = abTest.variants.find(v => v.id === variantId);
 
   if (variant && variant.amountsRegions) {
     const { amountsRegions } = variant;
+    const newAmountsRegions = { ...currentAmountsRegions };
 
     Object.keys(amountsRegions).forEach((countryGroupId) => {
 
@@ -24,9 +23,11 @@ function overrideAmountsForTest(
         newAmountsRegions[countryGroupId][contributionType] = amountsRegions[countryGroupId][contributionType];
       });
     });
+
+    return newAmountsRegions;
   }
 
-  return newAmountsRegions;
+  return currentAmountsRegions;
 }
 
 // Returns a new AmountsRegions by combining currentAmountsRegions with any test participation amounts

--- a/assets/helpers/abTests/helpers.js
+++ b/assets/helpers/abTests/helpers.js
@@ -1,0 +1,49 @@
+// @flow
+
+import { tests as allTests } from 'helpers/abTests/abtestDefinitions';
+import { type AmountsRegions } from 'helpers/contributions';
+import type { Test, Participations } from 'helpers/abTests/abtest';
+
+function overrideAmountsForTest(
+  variantId: string,
+  abTest: Test,
+  currentAmountsRegions: AmountsRegions,
+): AmountsRegions {
+
+  const newAmountsRegions = { ...currentAmountsRegions };
+
+  const variant = abTest.variants.find(v => v.id === variantId);
+
+  if (variant && variant.amountsRegions) {
+    const { amountsRegions } = variant;
+
+    Object.keys(amountsRegions).forEach((countryGroupId) => {
+
+      Object.keys(amountsRegions[countryGroupId]).forEach((contributionType) => {
+
+        newAmountsRegions[countryGroupId][contributionType] = amountsRegions[countryGroupId][contributionType];
+      });
+    });
+  }
+
+  return newAmountsRegions;
+}
+
+// Returns a new AmountsRegions by combining currentAmountsRegions with any test participation amounts
+export function overrideAmountsForParticipations(
+  abParticipations: Participations,
+  currentAmountsRegions: AmountsRegions,
+): AmountsRegions {
+
+  return Object.keys(abParticipations).reduce((amountsRegions, testName) => {
+    const test = allTests[testName];
+
+    if (test && test.type === 'AMOUNTS') {
+      const variant = abParticipations[testName];
+      return overrideAmountsForTest(variant, test, amountsRegions);
+    }
+
+    return amountsRegions;
+
+  }, currentAmountsRegions);
+}

--- a/assets/helpers/page/page.js
+++ b/assets/helpers/page/page.js
@@ -9,6 +9,7 @@ import thunkMiddleware from 'redux-thunk';
 
 import type { Participations } from 'helpers/abTests/abtest';
 import * as abTest from 'helpers/abTests/abtest';
+import { overrideAmountsForParticipations } from 'helpers/abTests/helpers';
 import type { Settings } from 'helpers/settings';
 import * as logger from 'helpers/logger';
 import * as googleTagManager from 'helpers/tracking/googleTagManager';
@@ -74,13 +75,16 @@ function buildInitialState(
     currencyId,
   };
 
+  // Override the default amounts config with any test participations
+  const amountsWithParticipations = overrideAmountsForParticipations(abParticipations, settings.amounts);
+
   return {
     campaign: acquisition ? getCampaign(acquisition) : null,
     referrerAcquisitionData: acquisition,
     otherQueryParams,
     internationalisation,
     abParticipations,
-    settings,
+    settings: { ...settings, amounts: amountsWithParticipations },
     optimizeExperiments,
   };
 

--- a/assets/helpers/page/page.js
+++ b/assets/helpers/page/page.js
@@ -76,7 +76,7 @@ function buildInitialState(
   };
 
   // Override the default amounts config with any test participations
-  const amountsWithParticipations = overrideAmountsForParticipations(abParticipations, settings.amounts);
+  const amountsWithParticipationOverrides = overrideAmountsForParticipations(abParticipations, settings.amounts);
 
   return {
     campaign: acquisition ? getCampaign(acquisition) : null,
@@ -84,7 +84,7 @@ function buildInitialState(
     otherQueryParams,
     internationalisation,
     abParticipations,
-    settings: { ...settings, amounts: amountsWithParticipations },
+    settings: { ...settings, amounts: amountsWithParticipationOverrides },
     optimizeExperiments,
   };
 


### PR DESCRIPTION
## Why are you doing this?
Amounts are configured using an s3 file (soon to be managed from Support Admin Console).
We also need the ability to run amounts tests which override the configured defaults.
For now, test amounts will be configured in the code (client-side).

Note - we are running a new annual amounts test this week, but have not decided on the exact config yet. I'll update assets/helpers/abTests/annualAmountsTest.js when this has been decided.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/dWLgtddF/339-enable-amounts-tests-to-override-sac-configured-amounts)

