### PR TITLE
Fix rounding error

### DIFF
--- a/assets/helpers/paymentIntegrations/newPaymentFlow/stripeCheckout.js
+++ b/assets/helpers/paymentIntegrations/newPaymentFlow/stripeCheckout.js
@@ -85,7 +85,7 @@ function setupStripeCheckout(
 function openDialogBox(stripeHandler: Object, amount: number, email: string) {
   stripeHandler.open({
     // Must be passed in pence.
-    amount: amount * 100,
+    amount: Math.round(amount * 100),
     email,
   });
 }


### PR DESCRIPTION
## Why are you doing this?

This PR fixes an issue which causes us to display the wrong price in Stripe Checkout (see screenshots), presumably because:

```
19.99 * 100
1998.9999999999998
```

## Changes

* Round to nearest penny/cent before passing amount to Stripe.

## Screenshots

Before fix:
![image](https://user-images.githubusercontent.com/19384074/52278766-b8237f00-294f-11e9-8cdc-48ed88256dad.png)

After fix:
![image](https://user-images.githubusercontent.com/19384074/52278776-c07bba00-294f-11e9-8d77-a3141926fc60.png)

