### PR TITLE
Add query param to pre-select billing plan and use correct subs URL based on environment

### DIFF
--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -29,7 +29,7 @@ export type SubsUrls = {
 
 // ----- Setup ----- //
 
-const subsUrl = 'https://subscribe.theguardian.com';
+const subsUrl = `https://subscribe.${getBaseDomain()}`;
 const patronsUrl = 'https://patrons.theguardian.com';
 const profileUrl = `https://profile.${getBaseDomain()}`;
 const defaultIntCmp = 'gdnwb_copts_bundles_landing_default';
@@ -297,6 +297,7 @@ function getDigitalCheckout(
   params.set('startTrialButton', referringCta || '');
 
   if (billingPeriod === Annual) {
+    params.set('period', Annual);
     return `${subsUrl}/checkout/digitalpack-digitalpackannual?${params.toString()}`;
   }
   return `${subsUrl}/checkout?${params.toString()}`;


### PR DESCRIPTION
## Why are you doing this?

These minor changes are required to set up the redirect test for the Digital Pack checkout.

[**Trello Card**](https://trello.com/c/HoZPd10P/1514-a-b-test-on-digital-pack-checkout-flow)

## Changes

* Use correct environment for subs links (CODE digital pack landing page will now redirect to CODE checkouts).
* Set annual query param (where appropriate), so that the correct billing period is [preselected](https://github.com/guardian/support-frontend/blob/master/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js#L193-L197) when users are redirected to the new flow.