### PR TITLE
Fix flash sale pricing issues

### DIFF
--- a/assets/helpers/flashSale.js
+++ b/assets/helpers/flashSale.js
@@ -212,7 +212,7 @@ const Sales: Sale[] = [
         annualPlanPromoCode: 'DDPFMANINT80',
         intcmp: '',
         price: 14.99,
-        annualPrice: 179.85,
+        annualPrice: 179.87,
         discountPercentage: 0.25,
         saleCopy: {
           featuredProduct: {
@@ -237,7 +237,7 @@ const Sales: Sale[] = [
         annualPlanPromoCode: 'DDPFMANINT80',
         intcmp: '',
         price: 14.99,
-        annualPrice: 179.85,
+        annualPrice: 179.87,
         discountPercentage: 0.25,
         saleCopy: {
           featuredProduct: {
@@ -261,8 +261,8 @@ const Sales: Sale[] = [
         promoCode: 'DDPFMINT80',
         annualPlanPromoCode: 'DDPFMANINT80',
         intcmp: '',
-        price: 16.13,
-        annualPrice: 193.44,
+        price: 16.12,
+        annualPrice: 193.46,
         discountPercentage: 0.25,
         saleCopy: {
           featuredProduct: {


### PR DESCRIPTION
## Why are you doing this?

There are a few rounding errors and inconsistencies between the landing and checkout pages. This eliminates those inconsistencies.

Note that in some cases we will charge a user one cent or pence _less_ than advertised, but this is better than the current situation (where we are charging users slightly more than the price displayed).

## Changes

* Fix landing page pricing

