### PR TITLE
Send Optimize experiments to the Ophan pageview tracking

### DIFF
--- a/assets/helpers/abTests/abtest.js
+++ b/assets/helpers/abTests/abtest.js
@@ -6,7 +6,6 @@ import type { IsoCountry } from 'helpers/internationalisation/country';
 
 import seedrandom from 'seedrandom';
 
-import * as ophan from 'ophan';
 import * as cookie from 'helpers/cookie';
 import * as storage from 'helpers/storage';
 import { type Settings } from 'helpers/settings';
@@ -18,13 +17,7 @@ import { tests } from './abtestDefinitions';
 
 // ----- Types ----- //
 
-type TestId = $Keys<typeof tests>;
-
-type OphanABEvent = {
-  variantName: string,
-  complete: boolean,
-  campaignCodes?: string[],
-};
+export type TestId = $Keys<typeof tests>;
 
 const breakpoints = {
   mobile: 320,
@@ -47,10 +40,6 @@ type BreakpointRange = {|
 export type Participations = {
   [TestId]: string,
 }
-
-type OphanABPayload = {
-  [TestId]: OphanABEvent,
-};
 
 type Audience = {
   offset: number,
@@ -237,23 +226,6 @@ function getParticipations(
   return { ...participations, ...getSSRParticipationsFromQuery() };
 }
 
-const buildOphanPayload = (participations: Participations, complete: boolean): OphanABPayload =>
-  Object.keys(participations).reduce((payload, participation) => {
-    const ophanABEvent: OphanABEvent = {
-      variantName: participations[participation],
-      complete,
-      campaignCodes: [],
-    };
-
-    return Object.assign({}, payload, { [participation]: ophanABEvent });
-  }, {});
-
-const trackABOphan = (participations: Participations, complete: boolean): void => {
-  ophan.record({
-    abTestRegister: buildOphanPayload(participations, complete),
-  });
-};
-
 const init = (
   country: IsoCountry,
   countryGroupId: CountryGroupId,
@@ -264,8 +236,6 @@ const init = (
   const participations: Participations = getParticipations(abTests, mvt, country, countryGroupId);
   const urlParticipations: ?Participations = getParticipationsFromUrl();
   setLocalStorageParticipations({ ...participations, ...urlParticipations });
-
-  trackABOphan(participations, false);
 
   return participations;
 };

--- a/assets/helpers/tracking/acquisitions.js
+++ b/assets/helpers/tracking/acquisitions.js
@@ -10,7 +10,7 @@ import { deserialiseJsonObject } from 'helpers/utilities';
 import type { Participations } from 'helpers/abTests/abtest';
 import * as storage from 'helpers/storage';
 import { getAllQueryParamsWithExclusions } from 'helpers/url';
-import type { OptimizeExperiments } from 'helpers/optimize/optimize';
+import type { OptimizeExperiment, OptimizeExperiments } from 'helpers/optimize/optimize';
 import { OPTIMIZE_QUERY_PARAMETER } from 'helpers/optimize/optimize';
 
 
@@ -171,11 +171,15 @@ const participationsToAcquisitionABTest = (participations: Participations): Acqu
 
 // Prepends all the experiment names (the keys) with 'optimize$$' to be able to
 // differentiate from native tests, and returns as array of AB tests.
+const optimizeIdToTestName = (id: string) => `optimize$$${id}`;
+
+const optimizeExperimentToAcquisitionABTest = (exp: OptimizeExperiment) => ({
+  name: optimizeIdToTestName(exp.id),
+  variant: exp.variant,
+});
+
 function optimizeExperimentsToAcquisitionABTest(opt: OptimizeExperiments): AcquisitionABTest[] {
-  return opt.map(exp => ({
-    name: `optimize$$${exp.id}`,
-    variant: exp.variant,
-  }));
+  return opt.map(exp => optimizeExperimentToAcquisitionABTest(exp));
 }
 
 // Builds the acquisition object from data and other sources.
@@ -294,4 +298,5 @@ export {
   derivePaymentApiAcquisitionData,
   deriveSubsAcquisitionData,
   getSupportAbTests,
+  optimizeIdToTestName,
 };

--- a/assets/helpers/tracking/ophanComponentEventTracking.js
+++ b/assets/helpers/tracking/ophanComponentEventTracking.js
@@ -135,21 +135,21 @@ function pageView(url: string, referrer: string) {
   }
 }
 
-const buildOphanPayload = (participations: Participations, complete: boolean): OphanABPayload =>
+const buildOphanPayload = (participations: Participations): OphanABPayload =>
   Object.keys(participations)
     .reduce((payload, participation) => {
       const ophanABEvent: OphanABEvent = {
         variantName: participations[participation],
-        complete,
+        complete: false,
         campaignCodes: [],
       };
 
       return Object.assign({}, payload, { [participation]: ophanABEvent });
     }, {});
 
-const trackNativeABTests = (participations: Participations, complete: boolean): void => {
+const trackNativeABTests = (participations: Participations): void => {
   ophan.record({
-    abTestRegister: buildOphanPayload(participations, complete),
+    abTestRegister: buildOphanPayload(participations),
   });
 };
 


### PR DESCRIPTION
## Why are you doing this?
Up until now we haven't been sending Optimize experiments to the Ophan pageview tracking. This has made it impossible to do things like funnel analysis in the Data Lake for Optimize tests.

This PR changes the app so that we now send any Optimize test information which is stored in session storage to Ophan along with the native AB tests. Because of the way that Optimize tests on the current page are loaded however, there is also now a callback which is fired when a new test is found.
 
[**Trello Card**](https://trello.com/c/4kEtf6ia/2181-ab-test-tracking)
