### PR TITLE
Version of the DP checkout thank you page for order timeout scenarios

### DIFF
--- a/assets/helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis.js
+++ b/assets/helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis.js
@@ -84,6 +84,7 @@ export type PaymentAuthorisation = StripeAuthorisation | PayPalAuthorisation | D
 // because the end of that checkout happens on the backend after the user is redirected to our site.
 export type PaymentResult
   = {| paymentStatus: 'success' |}
+  | {| paymentStatus: 'success', isPending: true |}
   | {| paymentStatus: 'failure', error: ErrorReason |};
 
 // ----- Setup ----- //
@@ -140,7 +141,7 @@ function checkRegularStatus(
   // Exhaustion of the maximum number of polls is considered a payment success
   const handleExhaustedPolls = (error) => {
     if (error === undefined) {
-      return Promise.resolve(PaymentSuccess);
+      return Promise.resolve({ paymentStatus: 'success', isPending: true });
     }
     throw error;
 

--- a/assets/helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis.js
+++ b/assets/helpers/paymentIntegrations/newPaymentFlow/readerRevenueApis.js
@@ -84,7 +84,7 @@ export type PaymentAuthorisation = StripeAuthorisation | PayPalAuthorisation | D
 // because the end of that checkout happens on the backend after the user is redirected to our site.
 export type PaymentResult
   = {| paymentStatus: 'success' |}
-  | {| paymentStatus: 'success', isPending: true |}
+  | {| paymentStatus: 'success', subscriptionCreationPending: true |}
   | {| paymentStatus: 'failure', error: ErrorReason |};
 
 // ----- Setup ----- //
@@ -141,7 +141,7 @@ function checkRegularStatus(
   // Exhaustion of the maximum number of polls is considered a payment success
   const handleExhaustedPolls = (error) => {
     if (error === undefined) {
-      return Promise.resolve({ paymentStatus: 'success', isPending: true });
+      return Promise.resolve({ paymentStatus: 'success', subscriptionCreationPending: true });
     }
     throw error;
 

--- a/assets/pages/digital-subscription-checkout/components/checkoutStage.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutStage.jsx
@@ -19,6 +19,7 @@ import ProductPageTextBlock, { LargeParagraph } from 'components/productPage/pro
 import { type Stage, type State } from '../digitalSubscriptionCheckoutReducer';
 
 import ThankYouContent from './thankYouContent';
+import ThankYouPendingContent from './thankYouPendingContent';
 import CheckoutForm from './checkoutForm';
 import ReturnSection from './returnSection';
 
@@ -117,6 +118,23 @@ function CheckoutStage(props: PropTypes) {
             heading="Your Digital Pack subscription is now live"
           />
           <ThankYouContent countryGroupId={props.countryGroupId} />
+          <ReturnSection />
+        </div>
+      );
+
+    case 'thankyou-pending':
+      return (
+        <div className="thank-you-stage">
+          <ProductHero
+            countryGroupId={props.countryGroupId}
+            imagesByCountry={heroesByCountry}
+            altText="digital subscription"
+            fallbackImgType="png"
+          />
+          <CheckoutHeading
+            heading="Your Digital Pack subscription is being processed"
+          />
+          <ThankYouPendingContent />
           <ReturnSection />
         </div>
       );

--- a/assets/pages/digital-subscription-checkout/components/thankYouPendingContent.jsx
+++ b/assets/pages/digital-subscription-checkout/components/thankYouPendingContent.jsx
@@ -7,6 +7,8 @@ import React from 'react';
 import ProductPageContentBlock from 'components/productPage/productPageContentBlock/productPageContentBlock';
 import ProductPageTextBlock, { LargeParagraph } from 'components/productPage/productPageTextBlock/productPageTextBlock';
 
+import { sendClickedEvent } from 'helpers/tracking/clickTracking';
+
 
 // ----- Component ----- //
 
@@ -23,9 +25,21 @@ function ThankYouPendingContent() {
           </LargeParagraph>
           <p>
             If you require any further assistance, you can visit
-            our <a href="https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions">FAQs page</a> to
-            find answers to common user issues. Alternatively, you can also
-            visit our <a href="https://www.theguardian.com/help">Help page</a> for customer support.
+            our {(
+              <a
+                onClick={sendClickedEvent('dp checkout : faq')}
+                href="https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions"
+              >
+              FAQs page
+              </a>
+            )} to find answers to common user issues. Alternatively, you can also
+            visit our {(
+              <a
+                onClick={sendClickedEvent('dp checkout : help')}
+                href="https://www.theguardian.com/help"
+              >Help page
+              </a>
+            )} for customer support.
           </p>
         </ProductPageTextBlock>
       </ProductPageContentBlock>

--- a/assets/pages/digital-subscription-checkout/components/thankYouPendingContent.jsx
+++ b/assets/pages/digital-subscription-checkout/components/thankYouPendingContent.jsx
@@ -1,0 +1,39 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+import ProductPageContentBlock from 'components/productPage/productPageContentBlock/productPageContentBlock';
+import ProductPageTextBlock, { LargeParagraph } from 'components/productPage/productPageTextBlock/productPageTextBlock';
+
+
+// ----- Component ----- //
+
+function ThankYouPendingContent() {
+
+  return (
+    <div>
+      <ProductPageContentBlock>
+        <ProductPageTextBlock>
+          <LargeParagraph>
+            Thank you for subscribing to the Digital Pack.
+            Your subscription is being processed and you will
+            receive an email when your account is live.
+          </LargeParagraph>
+          <p>
+            If you require any further assistance, you can visit
+            our <a href="https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions">FAQs page</a> to
+            find answers to common user issues. Alternatively, you can also
+            visit our <a href="https://www.theguardian.com/help">Help page</a> for customer support.
+          </p>
+        </ProductPageTextBlock>
+      </ProductPageContentBlock>
+    </div>
+  );
+
+}
+
+// ----- Export ----- //
+
+export default ThankYouPendingContent;

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -35,7 +35,7 @@ import { showPaymentMethod, onPaymentAuthorised, countrySupportsDirectDebit } fr
 
 // ----- Types ----- //
 
-export type Stage = 'checkout' | 'thankyou';
+export type Stage = 'checkout' | 'thankyou' | 'thankyou-pending';
 type PaymentMethod = 'Stripe' | 'DirectDebit';
 
 export type FormFieldsInState = {|

--- a/assets/pages/digital-subscription-checkout/helpers/paymentProviders.js
+++ b/assets/pages/digital-subscription-checkout/helpers/paymentProviders.js
@@ -58,7 +58,12 @@ function onPaymentAuthorised(paymentAuthorisation: PaymentAuthorisation, dispatc
 
   const handleSubscribeResult = (result: PaymentResult) => {
     switch (result.paymentStatus) {
-      case 'success': dispatch(setStage('thankyou'));
+      case 'success':
+        if (result.isPending) {
+          dispatch(setStage('thankyou-pending'));
+        } else {
+          dispatch(setStage('thankyou'));
+        }
         break;
       default: dispatch(setSubmissionError(result.error));
     }

--- a/assets/pages/digital-subscription-checkout/helpers/paymentProviders.js
+++ b/assets/pages/digital-subscription-checkout/helpers/paymentProviders.js
@@ -59,7 +59,7 @@ function onPaymentAuthorised(paymentAuthorisation: PaymentAuthorisation, dispatc
   const handleSubscribeResult = (result: PaymentResult) => {
     switch (result.paymentStatus) {
       case 'success':
-        if (result.isPending) {
+        if (result.subscriptionCreationPending) {
           dispatch(setStage('thankyou-pending'));
         } else {
           dispatch(setStage('thankyou'));


### PR DESCRIPTION
## Why are you doing this?
AS A customer
I WANT you to tell me that my payment is still pending of it's not instantly processed
SO THAT I know my order may not have been processed yet

[**Trello Card**](https://trello.com/c/k1YYFvXn/2124-version-of-the-dp-checkout-thank-you-page-for-order-timeout-scenarios)

## Changes

* new `{| paymentStatus: 'success', isPending: true |}` payment result (i dont like it help)
* new `thankyou-pending` stage

## Screenshots

![screenshot 2019-02-07 at 1 48 36 pm](https://user-images.githubusercontent.com/11539094/52415778-e3d56f00-2adf-11e9-8d7b-1a75171dff43.png)
