### PR TITLE
Subs landing banner and layout tweaks

### DIFF
--- a/assets/components/featuredProductHero/featuredProductHero.scss
+++ b/assets/components/featuredProductHero/featuredProductHero.scss
@@ -113,15 +113,7 @@
   }
 
   @include mq($from: desktop) {
-    padding-left: 186px;
-  }
-
-  @include mq($from: leftCol) {
-    padding-left: 218px;
-  }
-
-  @include mq($from: wide) {
-    padding-left: 250px;
+    padding-left: 0;
   }
 }
 
@@ -154,9 +146,6 @@
   z-index: 10;
   bottom: 0;
   right: 0;
-  @include mq($from: leftCol) {
-    left: 5%;
-  }
   @include mq($until: tablet) {
     position: absolute;
   }
@@ -192,13 +181,6 @@
 }
 .component-featured-product-hero--paper {
   @include with-colour(sport-garnett-media-main-1);
-
-  .component-featured-product-hero__content {
-  
-    @include mq($from: desktop) {
-      padding-left: 0;
-    }
-  }
 }
 .component-featured-product-hero--guardian-weekly {
   @include with-colour(opinion-garnett-media-main-1);

--- a/assets/components/featuredProductHero/featuredProductHero.scss
+++ b/assets/components/featuredProductHero/featuredProductHero.scss
@@ -1,4 +1,5 @@
 @import '~stylesheets/skeleton/html';
+@import '~stylesheets/gu-sass/gu-sass';
 
 @mixin with-colour($color) {
   & .component-featured-product-hero__heading,
@@ -128,18 +129,19 @@
   @extend .gu-content-margin;
   position: relative;
 
-  @include mq($from: tablet) {
-    flex: 0 0 400px;
+  @include mq($from: mobileLandscape) {
+    padding-left: 0;
   }
 
   @include mq($from: desktop) {
     margin: 10px 0 0;
     padding-right: 0;
-    padding-left: 21px;
+    padding-left: $gu-h-spacing*2;
   }
 
   @include mq($from: leftCol) {
     min-height: 350px;
+    padding-left: $gu-h-spacing*1.5;
   }
 
   @include mq($from: wide) {
@@ -152,9 +154,6 @@
   z-index: 10;
   bottom: 0;
   right: 0;
-  @include mq($from: tablet, $until: leftCol) {
-    left: -5%;
-  }
   @include mq($from: leftCol) {
     left: 5%;
   }
@@ -163,31 +162,14 @@
   }
 }
 
-.component-featured-product-hero__title {
-  font-size: 48px;
-  line-height: 48px;
-  font-family: $gu-headline;
-  font-weight: bold;
-  @include mq($from: tablet) {
-    font-size: 54px;
-    line-height: 58px;
-  }
-}
-
 .component-featured-product-hero__heading {
-  @extend .component-featured-product-hero__title;
+  @include gu-fontset-heading-large;
   margin-top: 8px;
-  @include mq($from: phablet) {
-    max-width: 350px;
-  }
 }
 
-.component-featured-product-hero__subheading{
-  @extend .component-featured-product-hero__title;
+.component-featured-product-hero__subheading {
+  @include gu-fontset-heading-large;
   margin-bottom: 12px;
-  @include mq($from: phablet) {
-    max-width: 350px;
-  }
 }
 
 .component-featured-product-hero__copy {
@@ -197,7 +179,7 @@
   z-index: 1;
   position: relative;
   @include mq($from: phablet) {
-    max-width: 250px;
+    max-width: 350px;
   }
 }
 
@@ -210,6 +192,13 @@
 }
 .component-featured-product-hero--paper {
   @include with-colour(sport-garnett-media-main-1);
+
+  .component-featured-product-hero__content {
+  
+    @include mq($from: desktop) {
+      padding-left: 0;
+    }
+  }
 }
 .component-featured-product-hero--guardian-weekly {
   @include with-colour(opinion-garnett-media-main-1);

--- a/assets/components/featuredProductHero/featuredProductHero.scss
+++ b/assets/components/featuredProductHero/featuredProductHero.scss
@@ -1,5 +1,4 @@
 @import '~stylesheets/skeleton/html';
-@import '~stylesheets/gu-sass/gu-sass';
 
 @mixin with-colour($color) {
   & .component-featured-product-hero__heading,
@@ -129,19 +128,18 @@
   @extend .gu-content-margin;
   position: relative;
 
-  @include mq($from: mobileLandscape) {
-    padding-left: 0;
+  @include mq($from: tablet) {
+    flex: 0 0 400px;
   }
 
   @include mq($from: desktop) {
     margin: 10px 0 0;
     padding-right: 0;
-    padding-left: $gu-h-spacing*2;
+    padding-left: 21px;
   }
 
   @include mq($from: leftCol) {
     min-height: 350px;
-    padding-left: $gu-h-spacing*1.5;
   }
 
   @include mq($from: wide) {
@@ -154,6 +152,9 @@
   z-index: 10;
   bottom: 0;
   right: 0;
+  @include mq($from: tablet, $until: leftCol) {
+    left: -5%;
+  }
   @include mq($from: leftCol) {
     left: 5%;
   }
@@ -162,14 +163,31 @@
   }
 }
 
-.component-featured-product-hero__heading {
-  @include gu-fontset-heading-large;
-  margin-top: 8px;
+.component-featured-product-hero__title {
+  font-size: 48px;
+  line-height: 48px;
+  font-family: $gu-headline;
+  font-weight: bold;
+  @include mq($from: tablet) {
+    font-size: 54px;
+    line-height: 58px;
+  }
 }
 
-.component-featured-product-hero__subheading {
-  @include gu-fontset-heading-large;
+.component-featured-product-hero__heading {
+  @extend .component-featured-product-hero__title;
+  margin-top: 8px;
+  @include mq($from: phablet) {
+    max-width: 350px;
+  }
+}
+
+.component-featured-product-hero__subheading{
+  @extend .component-featured-product-hero__title;
   margin-bottom: 12px;
+  @include mq($from: phablet) {
+    max-width: 350px;
+  }
 }
 
 .component-featured-product-hero__copy {
@@ -179,7 +197,7 @@
   z-index: 1;
   position: relative;
   @include mq($from: phablet) {
-    max-width: 350px;
+    max-width: 250px;
   }
 }
 
@@ -192,13 +210,6 @@
 }
 .component-featured-product-hero--paper {
   @include with-colour(sport-garnett-media-main-1);
-
-  .component-featured-product-hero__content {
-  
-    @include mq($from: desktop) {
-      padding-left: 0;
-    }
-  }
 }
 .component-featured-product-hero--guardian-weekly {
   @include with-colour(opinion-garnett-media-main-1);

--- a/assets/components/subscriptionsByCountryGroup/components/internationalSection.jsx
+++ b/assets/components/subscriptionsByCountryGroup/components/internationalSection.jsx
@@ -23,7 +23,7 @@ function InternationalSection(props: {
 }) {
 
   return (
-    <ThreeSubscriptions heading="">
+    <ThreeSubscriptions heading="Our Subscriptions">
       <PremiumTier
         headingSize={props.headingSize}
         referrer={props.appReferrer}

--- a/assets/components/threeSubscriptions/threeSubscriptions.scss
+++ b/assets/components/threeSubscriptions/threeSubscriptions.scss
@@ -11,6 +11,7 @@
     font-size: 24px;
     line-height: 1.17;
     font-weight: bold;
+    margin-top: $gu-v-spacing;
   }
 
   .component-page-section__body {

--- a/assets/stylesheets/skeleton/html.scss
+++ b/assets/stylesheets/skeleton/html.scss
@@ -24,10 +24,12 @@ Standard sizes and margins for the content and headers.
 
   @include mq($from: desktop) {
     width: gu-breakpoint(desktop);
+    padding: 0 $gu-h-spacing 0 $gu-h-spacing*2;
   }
 
   @include mq($from: leftCol) {
     width: gu-breakpoint(leftCol);
+    padding: 0 $gu-h-spacing*1.5;
   }
 
   @include mq($from: wide) {

--- a/assets/stylesheets/skeleton/html.scss
+++ b/assets/stylesheets/skeleton/html.scss
@@ -24,12 +24,10 @@ Standard sizes and margins for the content and headers.
 
   @include mq($from: desktop) {
     width: gu-breakpoint(desktop);
-    padding: 0 $gu-h-spacing 0 $gu-h-spacing*2;
   }
 
   @include mq($from: leftCol) {
     width: gu-breakpoint(leftCol);
-    padding: 0 $gu-h-spacing*1.5;
   }
 
   @include mq($from: wide) {


### PR DESCRIPTION
## Why are you doing this?

The subs landing page layout looked a bit broken after the new nav was added. The subs landing is not on the new template so the fixes will be enough to make the layout feel more _coherent_ whilst avoiding a significant refractor. I've tried to be unobtrusive as possible so hopefully haven't broken anything else  

It's still not quite perfect but looks a lot better and I think it will help until we eventually redesign and move this page onto the new template.

P.S. - I'm only interested in fixing alignment in the **UK banner** at this stage. 

P.P.S - My commit messages are a bit vaguer than I wanted them to be, sorry. 

[**Trello Card**](https://trello.com/c/hvM44uZc/2220-subs-landing-layout-needs-adjustment)

## Changes

* Padding/width changes to the subs landing her panel
* Type updates on the headings in the banner to align with updated font sizes
* Minor padding updates to general containers to assist in new nav alignment

## Screenshots

**Before**

![screen shot 2019-02-08 at 10 05 00](https://user-images.githubusercontent.com/1108991/52473302-55b7c200-2b8d-11e9-9885-38975da6bbfe.png)

**After**

![screen shot 2019-02-08 at 10 04 51](https://user-images.githubusercontent.com/1108991/52473334-6b2cec00-2b8d-11e9-8aaa-e01baca4c5ce.png)
