### PR TITLE
Use subscriptions client id

### DIFF
--- a/app/actions/CustomActionBuilders.scala
+++ b/app/actions/CustomActionBuilders.scala
@@ -32,7 +32,7 @@ class CustomActionBuilders(
   import CustomActionBuilders._
 
   val membersIdentityClientId = "members"
-
+  val subscriptionsClientId = "subscriptions"
   val recurringIdentityClientId = "recurringContributions"
 
   // Tells identity to send users back to the checkout immediately after sign-up.

--- a/app/controllers/DigitalSubscription.scala
+++ b/app/controllers/DigitalSubscription.scala
@@ -71,7 +71,7 @@ class DigitalSubscription(
   def digitalGeoRedirect: Action[AnyContent] = geoRedirect("subscribe/digital")
 
   def displayForm(): Action[AnyContent] =
-    authenticatedAction(recurringIdentityClientId).async { implicit request =>
+    authenticatedAction(subscriptionsClientId).async { implicit request =>
       implicit val settings: AllSettings = settingsProvider.getAllSettings()
       identityService.getUser(request.user).fold(
         error => {


### PR DESCRIPTION
## Why are you doing this?

We are currently using the wrong identity client id as part of the new Digital Pack checkout flow. Notably, we display the following text (which doesn't make sense in the context of this flow):

> To complete your contribution, please sign in to your Guardian account or quickly create one.
> 
> This will help you manage future payments. Staying signed in means you’ll no longer see the “since you’re here” messages asking you to support our journalism.

This PR fixes the problem by using our very own client id.

## Changes

* Use correct client id

## Screenshots

Before:
![image](https://user-images.githubusercontent.com/19384074/52477488-f57b4d00-2b99-11e9-94de-bda3d02cc75e.png)

After:
![image](https://user-images.githubusercontent.com/19384074/52477464-e3011380-2b99-11e9-9f93-277e1aecf820.png)

