### PR TITLE
Remove page hiding snippet and extra container id

### DIFF
--- a/assets/helpers/optimize/optimizeScript.js
+++ b/assets/helpers/optimize/optimizeScript.js
@@ -2,18 +2,6 @@
 import { getOptimizeExperiments } from './optimize';
 
 try {
-  var db = indexedDB.open("test");
-  // Check if Firefox Private Browsing is enabled
-  // because the page hiding snippet doesn't work
-  // properly in FF PB mode, see here:
-  // https://www.en.advertisercommunity.com/t5/Google-Optimize-Implement/Optimize-Page-Hiding-Snippet-Unhide-delay-issue-in-Firefox/td-p/1106919
-  db.onsuccess = function() {
-    // Not in FF PB mode
-    (function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;
-      h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
-      (a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;
-    })(window,document.documentElement,'async-hide','dataLayer',4000,
-      {'GTM-KGKKPS4':true, 'GTM-NZGXNBL':true});
 
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
@@ -22,10 +10,9 @@ try {
 
     ga('create', 'UA-51507017-5', 'auto', {cookieDomain: 'auto', anonymizeIp: true});
     ga('require', 'GTM-NZGXNBL');
-    ga('require', 'GTM-KGKKPS4');
 
     getOptimizeExperiments();
-  };
+
 } catch (e) {
   console.log(`Error initialising Optimize script: ${e.message}`);
 }


### PR DESCRIPTION
## Why are you doing this?
Up until now we have been checking two Optimize containers for tests, this is unnecessary because one of them is never used, so I have removed it.

I have also removed the page hiding snippet as it makes the site appear slow for users with ad blockers or in some incognito modes. I've run quite a few tests with different connection speeds and the flicker behaviour actually appears no worse than before, however it is something that we will need to keep an eye on when setting up AB tests.
