### PR TITLE
Temporarily add a second version of Digital Pack landing page to support Optimize test

### DIFF
--- a/app/controllers/DigitalSubscription.scala
+++ b/app/controllers/DigitalSubscription.scala
@@ -78,6 +78,7 @@ class DigitalSubscription(
   }
 
   def digitalGeoRedirect: Action[AnyContent] = geoRedirect("subscribe/digital")
+  def digitalNewGeoRedirect: Action[AnyContent] = geoRedirect("subscribe/digital/new")
 
   def displayForm(): Action[AnyContent] =
     authenticatedAction(subscriptionsClientId).async { implicit request =>

--- a/app/controllers/DigitalSubscription.scala
+++ b/app/controllers/DigitalSubscription.scala
@@ -50,7 +50,7 @@ class DigitalSubscription(
 
   implicit val a: AssetsResolver = assets
 
-  def digital(countryCode: String): Action[AnyContent] = CachedAction() { implicit request =>
+  def digital(countryCode: String, shouldLinkToNewCheckout: Boolean): Action[AnyContent] = CachedAction() { implicit request =>
     implicit val settings: AllSettings = settingsProvider.getAllSettings()
     val title = "Support the Guardian | Digital Pack Subscription"
     val id = "digital-subscription-landing-page-" + countryCode
@@ -65,7 +65,16 @@ class DigitalSubscription(
       "en" -> buildCanonicalDigitalSubscriptionLink("int")
     )
 
-    Ok(views.html.main(title, id, js, css, description, canonicalLink, hrefLangLinks)).withSettingsSurrogateKey
+    Ok(views.html.digitalSubscriptionLanding(
+      title,
+      id,
+      js,
+      css,
+      description,
+      canonicalLink,
+      hrefLangLinks,
+      shouldLinkToNewCheckout
+    )).withSettingsSurrogateKey
   }
 
   def digitalGeoRedirect: Action[AnyContent] = geoRedirect("subscribe/digital")

--- a/app/views/digitalSubscriptionLanding.scala.html
+++ b/app/views/digitalSubscriptionLanding.scala.html
@@ -1,0 +1,30 @@
+@import admin.settings.AllSettings
+@import assets.AssetsResolver
+@import com.gu.i18n.Currency.AUD
+@import com.gu.identity.play.IdUser
+@import com.gu.support.config._
+@import helper.CSRF
+@import com.gu.support.pricing.ProductPrices
+@import views.ViewHelpers._
+@import io.circe.syntax._
+@import com.gu.support.encoding.CustomCodecs._
+
+@(
+  title: String,
+  id: String,
+  js: String,
+  css: String,
+  description: Option[String],
+  canonicalLink: Option[String] = None,
+  hrefLangLinks: Map[String, String],
+  shouldLinkToNewCheckout: Boolean
+)(implicit assets: AssetsResolver, requestHeader: RequestHeader, settings: AllSettings)
+
+  @scripts = {
+    <script type="text/javascript">
+      window.guardian = window.guardian || {};
+      window.guardian.newCheckout = @shouldLinkToNewCheckout;
+    </script>
+  }
+
+  @main(title, id, js, css, description, canonicalLink, hrefLangLinks, scripts = scripts)

--- a/assets/helpers/externalLinks.js
+++ b/assets/helpers/externalLinks.js
@@ -12,6 +12,7 @@ import { Annual, Quarterly, SixForSix, Monthly, type WeeklyBillingPeriod, type D
 import type { PaperBillingPlan, SubscriptionProduct } from 'helpers/subscriptions';
 
 import { getIntcmp, getPromoCode, getAnnualPlanPromoCode } from './flashSale';
+import { getOrigin } from './url';
 
 
 // ----- Types ----- //
@@ -283,7 +284,16 @@ function getDigitalCheckout(
   nativeAbParticipations: Participations,
   optimizeExperiments: OptimizeExperiments,
   billingPeriod: DigitalBillingPeriod = Monthly,
+  newCheckoutFlow: boolean = false,
 ): string {
+
+  function buildUrl(params: URLSearchParams): string {
+    if (newCheckoutFlow) {
+      return `${getOrigin()}/subscribe/digital/checkout?${params.toString()}`;
+    }
+    return billingPeriod === Annual ? `${subsUrl}/checkout/digitalpack-digitalpackannual?${params.toString()}` : `${subsUrl}/checkout?${params.toString()}`;
+  }
+
   const acquisitionData = deriveSubsAcquisitionData(
     referrerAcquisitionData,
     nativeAbParticipations,
@@ -295,14 +305,11 @@ function getDigitalCheckout(
   params.set('promoCode', promoCode);
   params.set('countryGroup', countryGroups[cgId].supportInternationalisationId);
   params.set('startTrialButton', referringCta || '');
-
   if (billingPeriod === Annual) {
     params.set('period', Annual);
-    return `${subsUrl}/checkout/digitalpack-digitalpackannual?${params.toString()}`;
   }
-  return `${subsUrl}/checkout?${params.toString()}`;
+  return buildUrl(params);
 }
-
 
 // Builds a link to the GW checkout.
 function getWeeklyCheckout(

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLandingActions.js
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLandingActions.js
@@ -31,6 +31,7 @@ function redirectToDigitalPage() {
         abParticipations,
         optimizeExperiments,
         plan,
+        window.guardian.newCheckout,
       );
 
       sendTrackingEventsOnClick(`main_cta_click_${plan}`, 'DigitalPack', null)();

--- a/conf/routes
+++ b/conf/routes
@@ -88,7 +88,8 @@ GET  /:country/subscribe                           controllers.Subscriptions.leg
 
 GET  /digital                            controllers.DigitalSubscription.digitalGeoRedirect()
 GET  /subscribe/digital                            controllers.DigitalSubscription.digitalGeoRedirect()
-GET  /$country<(uk|us|au|int)>/subscribe/digital   controllers.DigitalSubscription.digital(country: String)
+GET  /$country<(uk|us|au|int)>/subscribe/digital   controllers.DigitalSubscription.digital(country: String, shouldLinkToNewCheckout: Boolean = false)
+GET  /$country<(uk|us|au|int)>/subscribe/digital/new   controllers.DigitalSubscription.digital(country: String, shouldLinkToNewCheckout: Boolean = true)
 
 # redirect from old checkout urls
 GET  /$country<(uk|us|au|int)>/subscribe/digital/checkout  controllers.Application.permanentRedirectWithCountry(country, location="/subscribe/digital/checkout")

--- a/conf/routes
+++ b/conf/routes
@@ -88,6 +88,7 @@ GET  /:country/subscribe                           controllers.Subscriptions.leg
 
 GET  /digital                            controllers.DigitalSubscription.digitalGeoRedirect()
 GET  /subscribe/digital                            controllers.DigitalSubscription.digitalGeoRedirect()
+GET  /subscribe/digital/new                        controllers.DigitalSubscription.digitalNewGeoRedirect()
 GET  /$country<(uk|us|au|int)>/subscribe/digital   controllers.DigitalSubscription.digital(country: String, shouldLinkToNewCheckout: Boolean = false)
 GET  /$country<(uk|us|au|int)>/subscribe/digital/new   controllers.DigitalSubscription.digital(country: String, shouldLinkToNewCheckout: Boolean = true)
 


### PR DESCRIPTION
## Why are you doing this?

The current setup of our Digital Pack checkout experiment is problematic, because it is not recording the behaviour of users who drop out of the flow after hitting the Identity sign in/sign up step. This is likely to unfairly skew the result in favour of the new flow. 

In order to work around this problem, this PR introduces a second version of the Digital Pack landing page. This allows us to set up a new test which uses the Digital Pack landing page as the entry point. In such a test, 50% of users will see the existing landing page <region>/subscribe/digital (which links out to the old checkout flow), and the other 50% will be redirected* to <region>/subscribe/digital/new (which links out to the new checkout flow). 

All users will now be served a page on support.theguardian.com _before_ any redirects to identity occur, which should ensure that a user's session is included in the experiment, even if they drop out of the flow after moving to the identity step. 

_*Unfortunately Optimize will only allow us to specify a single URL for the redirect test, which means that two redirects are actually required to get the user to the landing page. We'll get something like this:_

_User makes request to /uk/subscribe/digital > support-frontend serves the page > Optimize redirects to /subscribe/digital/new > support-frontend serves /uk/subscribe/digital/new._