### PR TITLE
Message for customers who have signed in to get into checkout but already have Digital Pack - Front

### DIFF
--- a/assets/helpers/url.js
+++ b/assets/helpers/url.js
@@ -91,6 +91,14 @@ function getAbsoluteURL(path: string = ''): string {
   return `${getOrigin()}${path}`;
 }
 
+function getPath(): string[] {
+  return new URL(window.location).pathname.split('/');
+}
+
+function getPathAfterRoute(route: string): string[] {
+  const pathName = getPath();
+  return pathName.splice(pathName.findIndex(r => r === route));
+}
 
 // ----- Exports ----- //
 
@@ -102,4 +110,5 @@ export {
   getBaseDomain,
   addQueryParamsToURL,
   getAbsoluteURL,
+  getPathAfterRoute,
 };

--- a/assets/pages/digital-subscription-checkout/components/checkoutStage.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutStage.jsx
@@ -20,7 +20,7 @@ import { type Stage, type State } from '../digitalSubscriptionCheckoutReducer';
 
 import ThankYouContent from './thankYouContent';
 import ThankYouPendingContent from './thankYouPendingContent';
-import ThankYouAlreadyLiveContent from './thankYouAlreadyLiveContent';
+import ThankYouExistingContent from './thankYouExistingContent';
 import CheckoutForm from './checkoutForm';
 import ReturnSection from './returnSection';
 
@@ -144,7 +144,7 @@ function CheckoutStage(props: PropTypes) {
       );
 
 
-    case 'thankyou-already-live':
+    case 'thankyou-existing':
       return (
         <div className="thank-you-stage">
           <ThankYouHero
@@ -153,7 +153,7 @@ function CheckoutStage(props: PropTypes) {
           <CheckoutHeading
             heading="Your Digital Pack subscription is already live"
           />
-          <ThankYouAlreadyLiveContent countryGroupId={props.countryGroupId} />
+          <ThankYouExistingContent countryGroupId={props.countryGroupId} />
           <ReturnSection />
         </div>
       );

--- a/assets/pages/digital-subscription-checkout/components/checkoutStage.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutStage.jsx
@@ -20,6 +20,7 @@ import { type Stage, type State } from '../digitalSubscriptionCheckoutReducer';
 
 import ThankYouContent from './thankYouContent';
 import ThankYouPendingContent from './thankYouPendingContent';
+import ThankYouAlreadyLiveContent from './thankYouAlreadyLiveContent';
 import CheckoutForm from './checkoutForm';
 import ReturnSection from './returnSection';
 
@@ -85,6 +86,15 @@ const heroesByCountry: ImagesByCountry = {
   },
 };
 
+const ThankYouHero = ({ countryGroupId }: {countryGroupId: CountryGroupId}) => (
+  <ProductHero
+    countryGroupId={countryGroupId}
+    imagesByCountry={heroesByCountry}
+    altText="digital subscription"
+    fallbackImgType="png"
+  />
+);
+
 
 // ----- State/Props Maps ----- //
 
@@ -108,11 +118,8 @@ function CheckoutStage(props: PropTypes) {
     case 'thankyou':
       return (
         <div className="thank-you-stage">
-          <ProductHero
+          <ThankYouHero
             countryGroupId={props.countryGroupId}
-            imagesByCountry={heroesByCountry}
-            altText="digital subscription"
-            fallbackImgType="png"
           />
           <CheckoutHeading
             heading="Your Digital Pack subscription is now live"
@@ -125,16 +132,28 @@ function CheckoutStage(props: PropTypes) {
     case 'thankyou-pending':
       return (
         <div className="thank-you-stage">
-          <ProductHero
+          <ThankYouHero
             countryGroupId={props.countryGroupId}
-            imagesByCountry={heroesByCountry}
-            altText="digital subscription"
-            fallbackImgType="png"
           />
           <CheckoutHeading
             heading="Your Digital Pack subscription is being processed"
           />
           <ThankYouPendingContent />
+          <ReturnSection />
+        </div>
+      );
+
+
+    case 'thankyou-already-live':
+      return (
+        <div className="thank-you-stage">
+          <ThankYouHero
+            countryGroupId={props.countryGroupId}
+          />
+          <CheckoutHeading
+            heading="Your Digital Pack subscription is already live"
+          />
+          <ThankYouAlreadyLiveContent countryGroupId={props.countryGroupId} />
           <ReturnSection />
         </div>
       );

--- a/assets/pages/digital-subscription-checkout/components/thankYou/appsSection.jsx
+++ b/assets/pages/digital-subscription-checkout/components/thankYou/appsSection.jsx
@@ -14,7 +14,7 @@ import {
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
 
-import ProductPageTextBlock, { LargeParagraph } from 'components/productPage/productPageTextBlock/productPageTextBlock';
+import ProductPageTextBlock from 'components/productPage/productPageTextBlock/productPageTextBlock';
 import AnchorButton from 'components/button/anchorButton';
 
 // ----- Types ----- //

--- a/assets/pages/digital-subscription-checkout/components/thankYou/appsSection.jsx
+++ b/assets/pages/digital-subscription-checkout/components/thankYou/appsSection.jsx
@@ -1,0 +1,74 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+import {
+  getIosAppUrl,
+  androidAppUrl,
+  getDailyEditionUrl,
+} from 'helpers/externalLinks';
+
+
+import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
+
+import ProductPageTextBlock, { LargeParagraph } from 'components/productPage/productPageTextBlock/productPageTextBlock';
+import AnchorButton from 'components/button/anchorButton';
+
+// ----- Types ----- //
+
+type PropTypes = {
+  countryGroupId: CountryGroupId,
+};
+
+
+// ----- Component ----- //
+
+const AppsSection = ({ countryGroupId }: PropTypes) => (
+  <div>
+    <ProductPageTextBlock title="Premium App" headingSize={3}>
+      <p>
+          Your enhanced experience of The Guardian
+          for mobile and tablet, with exclusive features and ad-free reading.
+      </p>
+      <div className="thank-you-stage__ctas">
+        <AnchorButton
+          appearance="greyHollow"
+          aria-label="Click to download the app on the Apple App Store"
+          href={getIosAppUrl(countryGroupId)}
+          onClick={sendTrackingEventsOnClick('checkout_thankyou_app_store', 'DigitalPack', null)}
+        >
+            Download from the App Store
+        </AnchorButton>
+        <AnchorButton
+          aria-label="Click to download the app on the Google Play store"
+          appearance="greyHollow"
+          href={androidAppUrl}
+          onClick={sendTrackingEventsOnClick('checkout_thankyou_play_store', 'DigitalPack', null)}
+        >
+            Download from Google Play
+        </AnchorButton>
+      </div>
+    </ProductPageTextBlock>
+    <ProductPageTextBlock title="Daily Edition (iPad only)" headingSize={3}>
+      <p>Every issue of The Guardian and Observer, designed for your iPad and available offline.</p>
+      <div className="thank-you-stage__ctas">
+        <AnchorButton
+          appearance="greyHollow"
+          aria-label="Click to download the Daily Tablet Edition app on the Apple App Store"
+          href={getDailyEditionUrl(countryGroupId)}
+          onClick={sendTrackingEventsOnClick('checkout_thankyou_daily_edition', 'DigitalPack', null)}
+        >
+            Download the Daily Edition
+        </AnchorButton>
+      </div>
+    </ProductPageTextBlock>
+  </div>
+);
+
+
+// ----- Export ----- //
+
+export default AppsSection;

--- a/assets/pages/digital-subscription-checkout/components/thankYou/marketingConsentContainer.jsx
+++ b/assets/pages/digital-subscription-checkout/components/thankYou/marketingConsentContainer.jsx
@@ -9,7 +9,7 @@ import type { Dispatch } from 'redux';
 import type { Action } from 'helpers/user/userActions';
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import { sendMarketingPreferencesToIdentity } from 'components/marketingConsent/helpers';
-import { getEmail } from '../digitalSubscriptionCheckoutReducer';
+import { getEmail } from '../../digitalSubscriptionCheckoutReducer';
 
 
 const mapStateToProps = state => ({

--- a/assets/pages/digital-subscription-checkout/components/thankYouAlreadyLiveContent.jsx
+++ b/assets/pages/digital-subscription-checkout/components/thankYouAlreadyLiveContent.jsx
@@ -1,0 +1,40 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+import ProductPageContentBlock from 'components/productPage/productPageContentBlock/productPageContentBlock';
+import ProductPageTextBlock, { LargeParagraph } from 'components/productPage/productPageTextBlock/productPageTextBlock';
+import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+
+import AppsSection from './thankYou/appsSection';
+
+// ----- Types ----- //
+
+type PropTypes = {
+  countryGroupId: CountryGroupId,
+};
+
+// ----- Component ----- //
+
+function ThankYouPendingContent({ countryGroupId }: PropTypes) {
+
+  return (
+    <div>
+      <ProductPageContentBlock>
+        <ProductPageTextBlock>
+          <LargeParagraph>
+            You have access to the following products
+          </LargeParagraph>
+        </ProductPageTextBlock>
+        <AppsSection countryGroupId={countryGroupId} />
+      </ProductPageContentBlock>
+    </div>
+  );
+
+}
+
+// ----- Export ----- //
+
+export default ThankYouPendingContent;

--- a/assets/pages/digital-subscription-checkout/components/thankYouContent.jsx
+++ b/assets/pages/digital-subscription-checkout/components/thankYouContent.jsx
@@ -5,20 +5,12 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import {
-  getIosAppUrl,
-  androidAppUrl,
-  getDailyEditionUrl,
-} from 'helpers/externalLinks';
-
-
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
 
 import ProductPageContentBlock from 'components/productPage/productPageContentBlock/productPageContentBlock';
 import ProductPageTextBlock, { LargeParagraph } from 'components/productPage/productPageTextBlock/productPageTextBlock';
-import AnchorButton from 'components/button/anchorButton';
-import MarketingConsent from './MarketingConsentContainer';
+import MarketingConsent from './thankYou/marketingConsentContainer';
+import AppsSection from './thankYou/appsSection';
 
 import {
   getFormFields,
@@ -51,6 +43,11 @@ function ThankYouContent(props: PropTypes) {
         </ProductPageTextBlock>
       </ProductPageContentBlock>
       <ProductPageContentBlock>
+        <ProductPageTextBlock title="Can&#39;t wait to get started?">
+          <LargeParagraph>
+            Just download the apps and log in with your Guardian account details.
+          </LargeParagraph>
+        </ProductPageTextBlock>
         <AppsSection countryGroupId={props.countryGroupId} />
       </ProductPageContentBlock>
       <ProductPageContentBlock>
@@ -63,61 +60,6 @@ function ThankYouContent(props: PropTypes) {
   );
 
 }
-
-
-// ----- Auxiliary Components ----- //
-
-function AppsSection(props: { countryGroupId: CountryGroupId }) {
-
-  return (
-    <div>
-      <ProductPageTextBlock title="Can&#39;t wait to get started?">
-        <LargeParagraph>
-        Just download the apps and log in with your Guardian account details.
-        </LargeParagraph>
-      </ProductPageTextBlock>
-      <ProductPageTextBlock title="Premium App" headingSize={3}>
-        <p>
-          Your enhanced experience of The Guardian
-          for mobile and tablet, with exclusive features and ad-free reading.
-        </p>
-        <div className="thank-you-stage__ctas">
-          <AnchorButton
-            appearance="greyHollow"
-            aria-label="Click to download the app on the Apple App Store"
-            href={getIosAppUrl(props.countryGroupId)}
-            onClick={sendTrackingEventsOnClick('checkout_thankyou_app_store', 'DigitalPack', null)}
-          >
-            Download from the App Store
-          </AnchorButton>
-          <AnchorButton
-            aria-label="Click to download the app on the Google Play store"
-            appearance="greyHollow"
-            href={androidAppUrl}
-            onClick={sendTrackingEventsOnClick('checkout_thankyou_play_store', 'DigitalPack', null)}
-          >
-            Download from Google Play
-          </AnchorButton>
-        </div>
-      </ProductPageTextBlock>
-      <ProductPageTextBlock title="Daily Edition (iPad only)" headingSize={3}>
-        <p>Every issue of The Guardian and Observer, designed for your iPad and available offline.</p>
-        <div className="thank-you-stage__ctas">
-          <AnchorButton
-            appearance="greyHollow"
-            aria-label="Click to download the Daily Tablet Edition app on the Apple App Store"
-            href={getDailyEditionUrl(props.countryGroupId)}
-            onClick={sendTrackingEventsOnClick('checkout_thankyou_daily_edition', 'DigitalPack', null)}
-          >
-            Download the Daily Edition
-          </AnchorButton>
-        </div>
-      </ProductPageTextBlock>
-    </div>
-  );
-
-}
-
 
 // ----- Export ----- //
 

--- a/assets/pages/digital-subscription-checkout/components/thankYouExistingContent.jsx
+++ b/assets/pages/digital-subscription-checkout/components/thankYouExistingContent.jsx
@@ -25,7 +25,7 @@ function ThankYouExistingContent({ countryGroupId }: PropTypes) {
       <ProductPageContentBlock>
         <ProductPageTextBlock>
           <LargeParagraph>
-            You have access to the following products
+            You have access to the following products:
           </LargeParagraph>
         </ProductPageTextBlock>
         <AppsSection countryGroupId={countryGroupId} />

--- a/assets/pages/digital-subscription-checkout/components/thankYouExistingContent.jsx
+++ b/assets/pages/digital-subscription-checkout/components/thankYouExistingContent.jsx
@@ -18,7 +18,7 @@ type PropTypes = {
 
 // ----- Component ----- //
 
-function ThankYouPendingContent({ countryGroupId }: PropTypes) {
+function ThankYouExistingContent({ countryGroupId }: PropTypes) {
 
   return (
     <div>
@@ -37,4 +37,4 @@ function ThankYouPendingContent({ countryGroupId }: PropTypes) {
 
 // ----- Export ----- //
 
-export default ThankYouPendingContent;
+export default ThankYouExistingContent;

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -35,7 +35,7 @@ import { showPaymentMethod, onPaymentAuthorised, countrySupportsDirectDebit } fr
 
 // ----- Types ----- //
 
-export type Stage = 'checkout' | 'thankyou' | 'thankyou-pending';
+export type Stage = 'checkout' | 'thankyou' | 'thankyou-pending' | 'thankyou-already-live';
 type PaymentMethod = 'Stripe' | 'DirectDebit';
 
 export type FormFieldsInState = {|

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -35,7 +35,7 @@ import { showPaymentMethod, onPaymentAuthorised, countrySupportsDirectDebit } fr
 
 // ----- Types ----- //
 
-export type Stage = 'checkout' | 'thankyou' | 'thankyou-pending' | 'thankyou-already-live';
+export type Stage = 'checkout' | 'thankyou' | 'thankyou-pending' | 'thankyou-existing';
 type PaymentMethod = 'Stripe' | 'DirectDebit';
 
 export type FormFieldsInState = {|
@@ -234,7 +234,7 @@ function initReducer(initialCountry: IsoCountry) {
   const checkoutPathName: string = getPathAfterRoute('checkout').pop();
 
   const initialState = {
-    stage: checkoutPathName === 'existing' ? 'thankyou-already-live' : 'checkout',
+    stage: checkoutPathName === 'existing' ? 'thankyou-existing' : 'checkout',
     email: user.email || '',
     firstName: user.firstName || '',
     lastName: user.lastName || '',

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -7,7 +7,7 @@ import { combineReducers, type Dispatch } from 'redux';
 import { type ReduxState } from 'helpers/page/page';
 import { type Option } from 'helpers/types/option';
 import { type DigitalBillingPeriod, Monthly } from 'helpers/billingPeriods';
-import { getQueryParameter } from 'helpers/url';
+import { getQueryParameter, getPathAfterRoute } from 'helpers/url';
 import csrf, { type Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import {
   fromString,
@@ -231,8 +231,7 @@ function initReducer(initialCountry: IsoCountry) {
     : Monthly;
   const { productPrices } = window.guardian;
 
-  const pathName = new URL(window.location).pathname.split('/');
-  const checkoutPathName: string = pathName.splice(pathName.findIndex(c => c === 'checkout')).pop();
+  const checkoutPathName: string = getPathAfterRoute('checkout').pop();
 
   const initialState = {
     stage: checkoutPathName === 'existing' ? 'thankyou-already-live' : 'checkout',

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -231,8 +231,11 @@ function initReducer(initialCountry: IsoCountry) {
     : Monthly;
   const { productPrices } = window.guardian;
 
+  const pathName = new URL(window.location).pathname.split('/');
+  const checkoutPathName: string = pathName.splice(pathName.findIndex(c => c === 'checkout')).pop();
+
   const initialState = {
-    stage: 'checkout',
+    stage: checkoutPathName === 'existing' ? 'thankyou-already-live' : 'checkout',
     email: user.email || '',
     firstName: user.firstName || '',
     lastName: user.lastName || '',

--- a/conf/routes
+++ b/conf/routes
@@ -93,6 +93,7 @@ GET  /$country<(uk|us|au|int)>/subscribe/digital   controllers.DigitalSubscripti
 # redirect from old checkout urls
 GET  /$country<(uk|us|au|int)>/subscribe/digital/checkout  controllers.Application.permanentRedirectWithCountry(country, location="/subscribe/digital/checkout")
 GET  /subscribe/digital/checkout  controllers.DigitalSubscription.displayForm()
+GET  /subscribe/digital/checkout/existing  controllers.DigitalSubscription.displayForm()
 POST /subscribe/digital/create  controllers.DigitalSubscription.create
 
 GET  /premium-tier                            controllers.Subscriptions.premiumTierGeoRedirect()


### PR DESCRIPTION
## Why are you doing this?
AS A customer I WANT to be shown a message when I'm trying to buy Digital Pack but already have it SO THAT I don't end up buying it twice in error.

This PR includes a new stage for the checkout, accessible at `subscribe/digital/checkout/existing` should we do a server side redirect.

[**Trello Card**](https://trello.com/c/06A5kQwD/2226-message-for-customers-who-have-signed-in-to-get-into-checkout-but-already-have-digital-pack-ty-page)

## Screenshots

![screenshot 2019-02-12 at 3 06 58 pm](https://user-images.githubusercontent.com/11539094/52646904-8d9b6e00-2edb-11e9-91a5-5cd4bac09370.png)
