### PR TITLE
Make the form errors red again

### DIFF
--- a/assets/components/forms/standardFields/error.scss
+++ b/assets/components/forms/standardFields/error.scss
@@ -2,7 +2,7 @@
 
 .component-form-error__error {
   @include gu-fontset-body-sans;
-  color: gu-colour(news-main-1);
+  color: gu-colour(error);
   font-size: 14px;
   font-weight: bold;
   display: block;
@@ -10,5 +10,5 @@
 }
 
 .component-form-error .component-input:not([type-radio]) {
-  border-color: gu-colour(news-main-1);
+  border-color: gu-colour(error);
 }


### PR DESCRIPTION
## Why are you doing this?

We weirdly missed this in #1504's merge (I recall changing these to the right ones??) 😿