### PR TITLE
Internationalize digi pack product page

### DIFF
--- a/app/controllers/DigitalSubscription.scala
+++ b/app/controllers/DigitalSubscription.scala
@@ -64,6 +64,7 @@ class DigitalSubscription(
       "en-us" -> buildCanonicalDigitalSubscriptionLink("us"),
       "en-gb" -> buildCanonicalDigitalSubscriptionLink("uk"),
       "en-au" -> buildCanonicalDigitalSubscriptionLink("au"),
+      "en-eu" -> buildCanonicalDigitalSubscriptionLink("eu"),
       "en" -> buildCanonicalDigitalSubscriptionLink("int")
     )
 

--- a/app/controllers/DigitalSubscription.scala
+++ b/app/controllers/DigitalSubscription.scala
@@ -64,7 +64,6 @@ class DigitalSubscription(
       "en-us" -> buildCanonicalDigitalSubscriptionLink("us"),
       "en-gb" -> buildCanonicalDigitalSubscriptionLink("uk"),
       "en-au" -> buildCanonicalDigitalSubscriptionLink("au"),
-      "en-eu" -> buildCanonicalDigitalSubscriptionLink("eu"),
       "en" -> buildCanonicalDigitalSubscriptionLink("int")
     )
 

--- a/app/controllers/GeoRedirect.scala
+++ b/app/controllers/GeoRedirect.scala
@@ -17,6 +17,7 @@ trait GeoRedirect {
     val redirectUrl = request.fastlyCountry match {
       case Some(UK) => s"/uk/$path"
       case Some(US) => s"/us/$path"
+      case Some(Europe) => s"/eu/$path"
       case Some(Australia) => s"/au/$path"
       case _ => s"/int/$path"
     }

--- a/assets/components/gridImage/gridImage.jsx
+++ b/assets/components/gridImage/gridImage.jsx
@@ -37,7 +37,7 @@ type PropTypes = GridImg;
 // ----- Component ----- //
 
 export default function GridImage(props: PropTypes) {
-
+  console.log(props);
   if (props.srcSizes.length < 1) {
     return null;
   }

--- a/assets/components/gridImage/gridImage.jsx
+++ b/assets/components/gridImage/gridImage.jsx
@@ -37,7 +37,6 @@ type PropTypes = GridImg;
 // ----- Component ----- //
 
 export default function GridImage(props: PropTypes) {
-  console.log(props);
   if (props.srcSizes.length < 1) {
     return null;
   }

--- a/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
+++ b/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
@@ -119,7 +119,6 @@ const gridSlots: GridSlots = {
 function gridPicture(cgId: CountryGroupId): GridPictureProps {
 
   const gridImages: GridImages = gridImagesByCountry[cgId];
-  console.log(gridImages);
   const sources: GridSource[] = [
     { ...gridSlots.mobile, ...gridImages.breakpoints.mobile },
     { ...gridSlots.tablet, ...gridImages.breakpoints.tablet },

--- a/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
+++ b/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
@@ -75,6 +75,7 @@ const gridImagesByCountry: {
   GBPCountries: defaultImages,
   UnitedStates: defaultImages,
   International: defaultImages,
+  EURCountries: defaultImages,
   AUDCountries: {
     breakpoints: {
       mobile: {
@@ -118,7 +119,7 @@ const gridSlots: GridSlots = {
 function gridPicture(cgId: CountryGroupId): GridPictureProps {
 
   const gridImages: GridImages = gridImagesByCountry[cgId];
-
+  console.log(gridImages);
   const sources: GridSource[] = [
     { ...gridSlots.mobile, ...gridImages.breakpoints.mobile },
     { ...gridSlots.tablet, ...gridImages.breakpoints.tablet },

--- a/assets/pages/digital-subscription-landing/components/productBlock.jsx
+++ b/assets/pages/digital-subscription-landing/components/productBlock.jsx
@@ -51,6 +51,7 @@ const appFeatures: {
   GBPCountries: defaultFeatures,
   UnitedStates: defaultFeatures,
   International: defaultFeatures,
+  EURCountries: defaultFeatures,
   AUDCountries: [
     {
       heading: ['Live news and sport ', <mark className="product-block__highlight">New</mark>],
@@ -81,6 +82,7 @@ const appImages: {
   GBPCountries: defaultAppImage,
   UnitedStates: defaultAppImage,
   International: defaultAppImage,
+  EURCountries: defaultAppImage,
   AUDCountries: {
     ...defaultAppImage,
     gridId: 'premiumTierAU',

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -36,7 +36,7 @@ const store = pageInit(() => digitalSubscriptionLandingReducer(null), true);
 // ----- Internationalisation ----- //
 
 const countryGroupId: CountryGroupId = detect();
-console.log({ countryGroupId });
+
 const reactElementId: {
   [CountryGroupId]: string,
 } = {

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -36,13 +36,14 @@ const store = pageInit(() => digitalSubscriptionLandingReducer(null), true);
 // ----- Internationalisation ----- //
 
 const countryGroupId: CountryGroupId = detect();
-
+console.log({ countryGroupId });
 const reactElementId: {
   [CountryGroupId]: string,
 } = {
   GBPCountries: 'digital-subscription-landing-page-uk',
   UnitedStates: 'digital-subscription-landing-page-us',
   AUDCountries: 'digital-subscription-landing-page-au',
+  EURCountries: 'digital-subscription-landing-page-eu',
   International: 'digital-subscription-landing-page-int',
 };
 
@@ -52,6 +53,7 @@ const CountrySwitcherHeader = headerWithCountrySwitcherContainer(
     'GBPCountries',
     'UnitedStates',
     'AUDCountries',
+    'EURCountries',
     'International',
   ],
 );

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -24,7 +24,8 @@
 #digital-subscription-landing-page-int,
 #digital-subscription-landing-page-uk,
 #digital-subscription-landing-page-us,
-#digital-subscription-landing-page-au {
+#digital-subscription-landing-page-au,
+#digital-subscription-landing-page-eu {
   .component-left-margin-section__content {
     overflow-x: hidden;
     @include mq($from: leftCol) {

--- a/conf/routes
+++ b/conf/routes
@@ -86,9 +86,9 @@ GET  /$country<(uk|us|au|int)>/subscribe           controllers.Subscriptions.lan
 # subscribe route. We just redirect to the subscriptions site and let its geolocation handle it.
 GET  /:country/subscribe                           controllers.Subscriptions.legacyRedirect(country: String)
 
-GET  /digital                            controllers.DigitalSubscription.digitalGeoRedirect()
-GET  /subscribe/digital                            controllers.DigitalSubscription.digitalGeoRedirect()
-GET  /$country<(uk|us|au|int)>/subscribe/digital   controllers.DigitalSubscription.digital(country: String)
+GET  /digital                                           controllers.DigitalSubscription.digitalGeoRedirect()
+GET  /subscribe/digital                                 controllers.DigitalSubscription.digitalGeoRedirect()
+GET  /$country<(uk|us|au|eu|int)>/subscribe/digital     controllers.DigitalSubscription.digital(country: String)
 
 # redirect from old checkout urls
 GET  /$country<(uk|us|au|int)>/subscribe/digital/checkout  controllers.Application.permanentRedirectWithCountry(country, location="/subscribe/digital/checkout")


### PR DESCRIPTION
## Why are you doing this?

This will allow urls with the European country symbol to show Euros as the currency, on the digi pack product page.


<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**internationalise-digital-pack-product-page** Trello Card](https://trello.com/c/ZfGLlSyQ/2186-internationalise-digital-pack-product-page)

## Changes

* I have made changes to the Play routes to allow eu/subscribe/digital to work
* The product-block and associated css has been updated to include EURCountries

## Screenshots
eu url 
![screen shot 2019-02-13 at 11 34 48](https://user-images.githubusercontent.com/45875444/52709016-7d3ece00-2f83-11e9-8105-ef22046d1d9d.png)

eu pricing
![screen shot 2019-02-13 at 11 35 03](https://user-images.githubusercontent.com/45875444/52709043-90ea3480-2f83-11e9-95cd-ff8cc4053f9e.png)

