### PR TITLE
Add canonical link to support page

### DIFF
--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -34,7 +34,7 @@ class Application(
     settingsProvider: AllSettingsProvider,
     guardianDomain: GuardianDomain,
     stage: Stage
-)(implicit val ec: ExecutionContext) extends AbstractController(components) with SettingsSurrogateKeySyntax with StrictLogging with ServersideAbTestCookie {
+)(implicit val ec: ExecutionContext) extends AbstractController(components) with SettingsSurrogateKeySyntax with CanonicalLinks with StrictLogging with ServersideAbTestCookie {
 
   import actionRefiners._
 
@@ -46,7 +46,7 @@ class Application(
 
   def geoRedirect: Action[AnyContent] = GeoTargetedCachedAction() { implicit request =>
     val redirectUrl = request.fastlyCountry match {
-      case Some(UK) => "/uk/support"
+      case Some(UK) => buildCanonicalShowcaseLink("uk")
       case Some(US) => "/us/contribute"
       case Some(Australia) => "/au/contribute"
       case Some(Europe) => "/eu/contribute"
@@ -151,7 +151,9 @@ class Application(
       mainId = "showcase-landing-page",
       mainJsBundle = "showcasePage.js",
       mainStyleBundle = "showcasePage.css",
-      description = stringsConfig.showcaseLandingDescription
+      description = stringsConfig.showcaseLandingDescription,
+      canonicalLink = Some(buildCanonicalShowcaseLink("uk"))
+
     )).withSettingsSurrogateKey
   }
 

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -35,7 +35,8 @@ class Application(
     guardianDomain: GuardianDomain,
     stage: Stage,
     val supportUrl: String
-)(implicit val ec: ExecutionContext) extends AbstractController(components) with SettingsSurrogateKeySyntax with CanonicalLinks with StrictLogging with ServersideAbTestCookie {
+)(implicit val ec: ExecutionContext) extends AbstractController(components)
+  with SettingsSurrogateKeySyntax with CanonicalLinks with StrictLogging with ServersideAbTestCookie {
 
   import actionRefiners._
 

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -33,7 +33,8 @@ class Application(
     stringsConfig: StringsConfig,
     settingsProvider: AllSettingsProvider,
     guardianDomain: GuardianDomain,
-    stage: Stage
+    stage: Stage,
+    val supportUrl: String
 )(implicit val ec: ExecutionContext) extends AbstractController(components) with SettingsSurrogateKeySyntax with CanonicalLinks with StrictLogging with ServersideAbTestCookie {
 
   import actionRefiners._

--- a/app/controllers/CanonicalLinks.scala
+++ b/app/controllers/CanonicalLinks.scala
@@ -14,4 +14,8 @@ trait CanonicalLinks {
   def buildCanonicalWeeklySubscriptionLink(countryCode: String): String =
     s"${supportUrl}/${countryCode}/subscribe/weekly"
 
+  def buildCanonicalShowcaseLink(countryCode: String): String =
+    s"${supportUrl}/${countryCode}/support"
+
+
 }

--- a/app/wiring/Controllers.scala
+++ b/app/wiring/Controllers.scala
@@ -25,7 +25,8 @@ trait Controllers {
     stringsConfig,
     allSettingsProvider,
     appConfig.guardianDomain,
-    appConfig.stage
+    appConfig.stage,
+    appConfig.supportUrl
   )
 
   lazy val subscriptionsController = new Subscriptions(

--- a/test/controllers/ApplicationTest.scala
+++ b/test/controllers/ApplicationTest.scala
@@ -49,7 +49,8 @@ class ApplicationTest extends WordSpec with MustMatchers with TestCSRFComponents
         mock[StringsConfig],
         mock[AllSettingsProvider],
         mock[GuardianDomain],
-        mock[Stage]
+        mock[Stage],
+        "support.thegulocal.com"
       )(mock[ExecutionContext]).healthcheck.apply(FakeRequest())
       contentAsString(result) mustBe "healthy"
     }
@@ -67,7 +68,8 @@ class ApplicationTest extends WordSpec with MustMatchers with TestCSRFComponents
         mock[StringsConfig],
         mock[AllSettingsProvider],
         mock[GuardianDomain],
-        mock[Stage]
+        mock[Stage],
+        "support.thegulocal.com"
       )(mock[ExecutionContext]).healthcheck.apply(FakeRequest())
       header("Cache-Control", result) mustBe Some("no-cache, private")
     }


### PR DESCRIPTION
## Why are you doing this?

We were missing this for seo reqs

[**Trello Card**](https://trello.com/b/emHrtNJX/support-platform-health)
