### PR TITLE
Remove 6for6 from GW page

### DIFF
--- a/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
+++ b/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
@@ -8,7 +8,7 @@ import { bindActionCreators } from 'redux';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { currencies, detect } from 'helpers/internationalisation/currency';
 import type { WeeklyBillingPeriod } from 'helpers/billingPeriods';
-import { Annual, Quarterly, SixForSix } from 'helpers/billingPeriods';
+import { Annual, Quarterly } from 'helpers/billingPeriods';
 import { getPromotionWeeklyProductPrice, getWeeklyProductPrice } from 'helpers/subscriptions';
 import { type Action } from 'components/productPage/productPagePlanForm/productPagePlanFormActions';
 import ProductPagePlanForm, {
@@ -32,12 +32,7 @@ const getPromotionPrice = (countryGroupId: CountryGroupId, period: WeeklyBilling
   getPromotionWeeklyProductPrice(countryGroupId, period, promoCode),
 ].join('');
 
-export const billingPeriods = {
-  [SixForSix]: {
-    title: '6 for 6',
-    offer: 'Introductory offer',
-    copy: (countryGroupId: CountryGroupId) => `${getPrice(countryGroupId, 'SixForSix')} for the first 6 issues (then ${getPrice(countryGroupId, 'Quarterly')} quarterly)`,
-  },
+export const displayBillingPeriods = {
   [Quarterly]: {
     title: 'Quarterly',
     copy: (countryGroupId: CountryGroupId) => `${getPrice(countryGroupId, 'Quarterly')} every 3 months`,
@@ -53,12 +48,12 @@ export const billingPeriods = {
 // ----- State/Props Maps ----- //
 
 const mapStateToProps = (state: State): StatePropTypes<WeeklyBillingPeriod> => ({
-  plans: Object.keys(billingPeriods).reduce((ps, k) => ({
+  plans: Object.keys(displayBillingPeriods).reduce((ps, k) => ({
     ...ps,
     [k]: {
-      title: billingPeriods[k].title,
-      copy: billingPeriods[k].copy(state.common.internationalisation.countryGroupId),
-      offer: billingPeriods[k].offer || null,
+      title: displayBillingPeriods[k].title,
+      copy: displayBillingPeriods[k].copy(state.common.internationalisation.countryGroupId),
+      offer: displayBillingPeriods[k].offer || null,
       price: null,
       saving: null,
     },

--- a/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingReducer.js
+++ b/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingReducer.js
@@ -20,9 +20,9 @@ export type State = {
 
 const promoInUrl = getQueryParameter('promo');
 
-const initialPeriod: WeeklyBillingPeriod = promoInUrl === 'SixForSix' || promoInUrl === 'Quarterly' || promoInUrl === 'Annual'
+const initialPeriod: WeeklyBillingPeriod = promoInUrl === 'Quarterly' || promoInUrl === 'Annual'
   ? promoInUrl
-  : 'SixForSix';
+  : 'Quarterly';
 
 
 // ----- Export ----- //


### PR DESCRIPTION
## Why are you doing this?

Because journalism is in crisis

[**Trello Card**](https://trello.com/c/nWZR6loN/2202-remove-6-for-6-from-gw-product-page)

## Changes

* Remove the 6for6 price tier
* Default to Quarterly (@SarahLaughton !)
* Rename `billingPeriods` to `displayBillingPeriods` so as to imply that this may be a subset of the periods – we are keeping 6for6 in the data model for a bit longer than this removal so we can't eviscerate all of it just yet.

## Screenshots

![screenshot 2019-02-13 at 1 36 53 pm](https://user-images.githubusercontent.com/11539094/52715594-b9c6f580-2f94-11e9-87c5-ace39325d6bf.png)
