### PR TITLE
TY page if the user has a DP

### DIFF
--- a/app/controllers/DigitalSubscription.scala
+++ b/app/controllers/DigitalSubscription.scala
@@ -25,7 +25,7 @@ import services.stepfunctions.{CreateSupportWorkersRequest, StatusResponse, Supp
 import services.{IdentityService, MembersDataService, TestUserService}
 import utils.NormalisedTelephoneNumber
 import utils.NormalisedTelephoneNumber.asFormattedString
-import views.html.digitalSubscription
+import views.html.{digitalSubscription, main}
 import views.html.helper.CSRF
 import utils.SimpleValidator._
 
@@ -93,7 +93,7 @@ class DigitalSubscription(
         },
         user => {
           hasDigipack map {
-            case true =>  Redirect("digital/checkout/thankyou/existing", request.queryString, status = FOUND)
+            case true =>  Redirect("/subscribe/digital/checkout/thankyou-existing", request.queryString, status = FOUND)
             case _ => Ok(digitalSubscriptionFormHtml(user))
           }
         }
@@ -122,6 +122,22 @@ class DigitalSubscription(
       stripeConfigProvider.get(true),
       payPalConfigProvider.get(uatMode)
     )
+  }
+
+  def displayThankYouExisting(): Action[AnyContent] = CachedAction() { implicit request =>
+
+    implicit val settings: AllSettings = settingsProvider.getAllSettings()
+    val title = "Support the Guardian | Digital Subscription"
+    val id = "digital-subscription-checkout-page"
+    val js = "digitalSubscriptionCheckoutPageThankYouExisting.js"
+    val css = "digitalSubscriptionCheckoutPageThankYouExisting.css"
+
+    Ok(views.html.main(
+      title,
+      id,
+      js,
+      css
+    ))
   }
 
   sealed abstract class CreateDigitalSubscriptionError(message: String)

--- a/app/services/MembersDataService.scala
+++ b/app/services/MembersDataService.scala
@@ -18,7 +18,7 @@ object MembersDataService {
     implicit val jf: OFormat[ContentAccess] = Json.format[ContentAccess]
   }
 
-  case class ContentAccess(recurringContributor: Boolean)
+  case class ContentAccess(recurringContributor: Boolean, digitalPack: Boolean)
 
   object UserAttributes {
     implicit val jf: OFormat[UserAttributes] = Json.format[UserAttributes]

--- a/app/wiring/Controllers.scala
+++ b/app/wiring/Controllers.scala
@@ -46,6 +46,7 @@ trait Controllers {
     actionRefiners,
     identityService,
     testUsers,
+    membersDataService,
     appConfig.regularStripeConfigProvider,
     appConfig.regularPayPalConfigProvider,
     controllerComponents,

--- a/assets/pages/digital-subscription-checkout/components/checkoutStage.jsx
+++ b/assets/pages/digital-subscription-checkout/components/checkoutStage.jsx
@@ -5,10 +5,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import ProductHero, {
-  type GridImages,
-  type ImagesByCountry,
-} from 'components/productHero/productHero';
 import HeadingBlock from 'components/headingBlock/headingBlock';
 import { HeroWrapper } from 'components/productPage/productPageHero/productPageHero';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
@@ -21,9 +17,9 @@ import { type Stage, type State } from '../digitalSubscriptionCheckoutReducer';
 
 import ThankYouContent from './thankYouContent';
 import ThankYouPendingContent from './thankYouPendingContent';
-import ThankYouExistingContent from './thankYouExistingContent';
 import CheckoutForm from './checkoutForm';
 import ReturnSection from './returnSection';
+import ThankYouHero from './thankYou/hero';
 
 
 // ----- Types ----- //
@@ -33,68 +29,6 @@ type PropTypes = {|
   formSubmitted: boolean,
   countryGroupId: CountryGroupId,
 |};
-
-
-// ----- Setup ----- //
-
-const defaultHeroes: GridImages = {
-  breakpoints: {
-    mobile: {
-      gridId: 'digitalSubscriptionHeaderMobile',
-      srcSizes: [342, 684, 1200],
-      imgType: 'png',
-    },
-    tablet: {
-      gridId: 'digitalSubscriptionHeaderTablet',
-      srcSizes: [500, 1000, 2000],
-      imgType: 'png',
-    },
-    desktop: {
-      gridId: 'digitalSubscriptionHeaderDesktop',
-      srcSizes: [500, 1000, 2000, 4045],
-      imgType: 'png',
-    },
-  },
-  fallback: 'digitalSubscriptionHeaderDesktop',
-};
-
-const heroesByCountry: ImagesByCountry = {
-  GBPCountries: defaultHeroes,
-  UnitedStates: defaultHeroes,
-  International: defaultHeroes,
-  EURCountries: defaultHeroes,
-  NZDCountries: defaultHeroes,
-  Canada: defaultHeroes,
-  AUDCountries: {
-    breakpoints: {
-      mobile: {
-        gridId: 'digitalSubscriptionHeaderMobileAU',
-        srcSizes: [310, 620, 1088],
-        imgType: 'png',
-      },
-      tablet: {
-        gridId: 'digitalSubscriptionHeaderTabletAU',
-        srcSizes: [500, 1000, 2000],
-        imgType: 'png',
-      },
-      desktop: {
-        gridId: 'digitalSubscriptionHeaderDesktopAU',
-        srcSizes: [500, 1000, 2000, 4045],
-        imgType: 'png',
-      },
-    },
-    fallback: 'digitalSubscriptionHeaderDesktopAU',
-  },
-};
-
-const ThankYouHero = ({ countryGroupId }: {countryGroupId: CountryGroupId}) => (
-  <ProductHero
-    countryGroupId={countryGroupId}
-    imagesByCountry={heroesByCountry}
-    altText="digital subscription"
-    fallbackImgType="png"
-  />
-);
 
 
 // ----- State/Props Maps ----- //
@@ -144,23 +78,6 @@ function CheckoutStage(props: PropTypes) {
             </HeadingBlock>
           </HeroWrapper>
           <ThankYouPendingContent />
-          <ReturnSection />
-        </div>
-      );
-
-
-    case 'thankyou-existing':
-      return (
-        <div className="thank-you-stage">
-          <ThankYouHero
-            countryGroupId={props.countryGroupId}
-          />
-          <HeroWrapper appearance="custom">
-            <HeadingBlock>
-              Your Digital Pack subscription is already live
-            </HeadingBlock>
-          </HeroWrapper>
-          <ThankYouExistingContent countryGroupId={props.countryGroupId} />
           <ReturnSection />
         </div>
       );

--- a/assets/pages/digital-subscription-checkout/components/thankYou/hero.jsx
+++ b/assets/pages/digital-subscription-checkout/components/thankYou/hero.jsx
@@ -1,0 +1,78 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+
+
+import ProductHero, {
+  type GridImages,
+  type ImagesByCountry,
+} from 'components/productHero/productHero';
+import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+
+// ----- Setup ----- //
+
+const defaultHeroes: GridImages = {
+  breakpoints: {
+    mobile: {
+      gridId: 'digitalSubscriptionHeaderMobile',
+      srcSizes: [342, 684, 1200],
+      imgType: 'png',
+    },
+    tablet: {
+      gridId: 'digitalSubscriptionHeaderTablet',
+      srcSizes: [500, 1000, 2000],
+      imgType: 'png',
+    },
+    desktop: {
+      gridId: 'digitalSubscriptionHeaderDesktop',
+      srcSizes: [500, 1000, 2000, 4045],
+      imgType: 'png',
+    },
+  },
+  fallback: 'digitalSubscriptionHeaderDesktop',
+};
+
+const heroesByCountry: ImagesByCountry = {
+  GBPCountries: defaultHeroes,
+  UnitedStates: defaultHeroes,
+  International: defaultHeroes,
+  EURCountries: defaultHeroes,
+  NZDCountries: defaultHeroes,
+  Canada: defaultHeroes,
+  AUDCountries: {
+    breakpoints: {
+      mobile: {
+        gridId: 'digitalSubscriptionHeaderMobileAU',
+        srcSizes: [310, 620, 1088],
+        imgType: 'png',
+      },
+      tablet: {
+        gridId: 'digitalSubscriptionHeaderTabletAU',
+        srcSizes: [500, 1000, 2000],
+        imgType: 'png',
+      },
+      desktop: {
+        gridId: 'digitalSubscriptionHeaderDesktopAU',
+        srcSizes: [500, 1000, 2000, 4045],
+        imgType: 'png',
+      },
+    },
+    fallback: 'digitalSubscriptionHeaderDesktopAU',
+  },
+};
+
+const ThankYouHero = ({ countryGroupId }: {countryGroupId: CountryGroupId}) => (
+  <ProductHero
+    countryGroupId={countryGroupId}
+    imagesByCountry={heroesByCountry}
+    altText="digital subscription"
+    fallbackImgType="png"
+  />
+);
+
+
+// ----- Export ----- //
+
+export default ThankYouHero;

--- a/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -7,7 +7,7 @@ import { combineReducers, type Dispatch } from 'redux';
 import { type ReduxState } from 'helpers/page/page';
 import { type Option } from 'helpers/types/option';
 import { type DigitalBillingPeriod, Monthly } from 'helpers/billingPeriods';
-import { getQueryParameter, getPathAfterRoute } from 'helpers/url';
+import { getQueryParameter } from 'helpers/url';
 import csrf, { type Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import {
   fromString,
@@ -35,7 +35,7 @@ import { showPaymentMethod, onPaymentAuthorised, countrySupportsDirectDebit } fr
 
 // ----- Types ----- //
 
-export type Stage = 'checkout' | 'thankyou' | 'thankyou-pending' | 'thankyou-existing';
+export type Stage = 'checkout' | 'thankyou' | 'thankyou-pending';
 type PaymentMethod = 'Stripe' | 'DirectDebit';
 
 export type FormFieldsInState = {|
@@ -231,10 +231,8 @@ function initReducer(initialCountry: IsoCountry) {
     : Monthly;
   const { productPrices } = window.guardian;
 
-  const checkoutPathName: string = getPathAfterRoute('checkout').pop();
-
   const initialState = {
-    stage: checkoutPathName === 'existing' ? 'thankyou-existing' : 'checkout',
+    stage: 'checkout',
     email: user.email || '',
     firstName: user.firstName || '',
     lastName: user.lastName || '',

--- a/assets/pages/digital-subscription-checkout/thankYouExisting.jsx
+++ b/assets/pages/digital-subscription-checkout/thankYouExisting.jsx
@@ -1,0 +1,62 @@
+
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+import { Provider } from 'react-redux';
+
+import { renderPage } from 'helpers/render';
+import { init as pageInit } from 'helpers/page/page';
+
+import Page from 'components/page/page';
+import Header from 'components/headers/header/header';
+import Footer from 'components/footer/footer';
+import CustomerService from 'components/customerService/customerService';
+import SubscriptionTermsPrivacy from 'components/legal/subscriptionTermsPrivacy/subscriptionTermsPrivacy';
+import SubscriptionFaq from 'components/subscriptionFaq/subscriptionFaq';
+import 'stylesheets/skeleton/skeleton.scss';
+
+import HeadingBlock from 'components/headingBlock/headingBlock';
+import { HeroWrapper } from 'components/productPage/productPageHero/productPageHero';
+
+import ReturnSection from './components/returnSection';
+import ThankYouExistingContent from './components/thankYouExistingContent';
+import ThankYouContent from './components/thankYou/hero';
+
+import './digitalSubscriptionCheckout.scss';
+
+// ----- Redux Store ----- //
+
+const store = pageInit();
+
+const { countryGroupId } = store.getState().common.internationalisation;
+
+// ----- Render ----- //
+
+const content = (
+  <Provider store={store}>
+    <Page
+      header={<Header displayNavigation={false} />}
+      footer={
+        <Footer>
+          <SubscriptionTermsPrivacy subscriptionProduct="DigitalPack" />
+          <CustomerService selectedCountryGroup={countryGroupId} />
+          <SubscriptionFaq subscriptionProduct="DigitalPack" />
+        </Footer>}
+    >
+      <div className="thank-you-stage">
+        <HeroWrapper appearance="custom">
+          <ThankYouContent countryGroupId={countryGroupId} />
+          <HeadingBlock>
+            Your Digital Pack subscription is already live
+          </HeadingBlock>
+        </HeroWrapper>
+        <ThankYouExistingContent countryGroupId={countryGroupId} />
+        <ReturnSection />
+      </div>
+    </Page>
+  </Provider>
+);
+
+renderPage(content, 'digital-subscription-checkout-page');

--- a/conf/routes
+++ b/conf/routes
@@ -93,7 +93,7 @@ GET  /$country<(uk|us|au|eu|int)>/subscribe/digital     controllers.DigitalSubsc
 # redirect from old checkout urls
 GET  /$country<(uk|us|au|int)>/subscribe/digital/checkout  controllers.Application.permanentRedirectWithCountry(country, location="/subscribe/digital/checkout")
 GET  /subscribe/digital/checkout  controllers.DigitalSubscription.displayForm()
-GET  /subscribe/digital/checkout/existing  controllers.DigitalSubscription.displayForm()
+GET  /subscribe/digital/checkout/thankyou-existing  controllers.DigitalSubscription.displayThankYouExisting()
 POST /subscribe/digital/create  controllers.DigitalSubscription.create
 
 GET  /premium-tier                            controllers.Subscriptions.premiumTierGeoRedirect()

--- a/test/controllers/SubscriptionsTest.scala
+++ b/test/controllers/SubscriptionsTest.scala
@@ -24,7 +24,7 @@ import play.api.mvc.Result
 import play.api.test.FakeRequest
 import play.api.test.Helpers.{contentAsString, status, stubControllerComponents, _}
 import services.stepfunctions.SupportWorkersClient
-import services.{HttpIdentityService, TestUserService}
+import services.{HttpIdentityService, MembersDataService, TestUserService}
 
 import scala.concurrent.Future
 
@@ -49,6 +49,7 @@ class SubscriptionsTest extends WordSpec with MustMatchers with TestCSRFComponen
 
       val client = mock[SupportWorkersClient]
       val testUserService = mock[TestUserService]
+      val membersDataService = mock[MembersDataService]
       val tip = mock[Tip]
       val stripe = mock[StripeConfigProvider]
       val stripeAccountConfig = StripeAccountConfig("", "")
@@ -76,6 +77,7 @@ class SubscriptionsTest extends WordSpec with MustMatchers with TestCSRFComponen
         actionRefiner,
         identityService,
         testUserService,
+        membersDataService,
         stripe,
         payPal,
         stubControllerComponents(),

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -38,6 +38,7 @@ module.exports = (cssFilename, outputFilename, minimizeCss) => ({
     digitalSubscriptionLandingPage: 'pages/digital-subscription-landing/digitalSubscriptionLanding.jsx',
     digitalSubscriptionLandingPageStyles: 'pages/digital-subscription-landing/digitalSubscriptionLanding.scss',
     digitalSubscriptionCheckoutPage: 'pages/digital-subscription-checkout/digitalSubscriptionCheckout.jsx',
+    digitalSubscriptionCheckoutPageThankYouExisting: 'pages/digital-subscription-checkout/thankYouExisting.jsx',
     paperSubscriptionLandingPage: 'pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx',
     weeklySubscriptionLandingPage: 'pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx',
     premiumTierLandingPage: 'pages/premium-tier-landing/premiumTierLanding.jsx',


### PR DESCRIPTION
## Why are you doing this?
Second bit of #1506 

Fun stuff: we had to create this page its own route in both scala and react because otherwise it was weirdly entangled with the checkout code.

**Do not merge yet** we are writing tests

[**Trello Card**](https://trello.com/c/06A5kQwD/2226-message-for-customers-who-have-signed-in-to-get-into-checkout-but-already-have-digital-pack-ty-page)

## Screenshots

![screenshot 2019-02-12 at 3 06 58 pm](https://user-images.githubusercontent.com/11539094/52646904-8d9b6e00-2edb-11e9-91a5-5cd4bac09370.png)