### PR TITLE
Add NZ & Canada subscribe pages

### DIFF
--- a/app/controllers/GeoRedirect.scala
+++ b/app/controllers/GeoRedirect.scala
@@ -12,30 +12,7 @@ trait GeoRedirect {
   import actionRefiners._
 
   def geoRedirect(path: String): Action[AnyContent] = GeoTargetedCachedAction() { implicit request =>
-    // If we implement endpoints for EU, CA & NZ we could replace this match with
-    // request.fastlyCountry.map(_.id).getOrDefault("int")
-    val redirectUrl = request.fastlyCountry match {
-      case Some(UK) => s"/uk/$path"
-      case Some(US) => s"/us/$path"
-      case Some(Europe) => s"/eu/$path"
-      case Some(Australia) => s"/au/$path"
-      case _ => s"/int/$path"
-    }
-
+    val redirectUrl = s"/${request.fastlyCountry.map(_.id).getOrElse("int")}/$path"
     Redirect(redirectUrl, request.queryString, status = FOUND)
   }
-
-  def geoRedirectAllMarkets(path: String): Action[AnyContent] = GeoTargetedCachedAction() { implicit request =>
-    val redirectUrl = request.fastlyCountry match {
-      case Some(UK) => s"/uk/$path"
-      case Some(US) => s"/us/$path"
-      case Some(Australia) => s"/au/$path"
-      case Some(Europe) => s"/eu/$path"
-      case Some(Canada) => s"/ca/$path"
-      case Some(NewZealand) => s"/nz/$path"
-      case _ => s"/int/$path"
-    }
-    Redirect(redirectUrl, request.queryString, status = FOUND)
-  }
-
 }

--- a/app/controllers/Subscriptions.scala
+++ b/app/controllers/Subscriptions.scala
@@ -55,7 +55,7 @@ class Subscriptions(
     Ok(views.html.main(title, id, js, css)).withSettingsSurrogateKey
   }
 
-  def weeklyGeoRedirect: Action[AnyContent] = geoRedirectAllMarkets("subscribe/weekly")
+  def weeklyGeoRedirect: Action[AnyContent] = geoRedirect("subscribe/weekly")
 
   def weekly(countryCode: String): Action[AnyContent] = CachedAction() { implicit request =>
     implicit val settings: AllSettings = settingsProvider.getAllSettings()

--- a/assets/helpers/internationalisation/countryGroup.js
+++ b/assets/helpers/internationalisation/countryGroup.js
@@ -10,7 +10,22 @@ import type { IsoCurrency } from 'helpers/internationalisation/currency';
 
 // ----- Types ----- //
 
-export type CountryGroupId = 'GBPCountries' | 'UnitedStates' | 'AUDCountries' | 'EURCountries' | 'International' | 'NZDCountries' | 'Canada';
+const GBPCountries: 'GBPCountries' = 'GBPCountries';
+const UnitedStates: 'UnitedStates' = 'UnitedStates';
+const AUDCountries: 'AUDCountries' = 'AUDCountries';
+const EURCountries: 'EURCountries' = 'EURCountries';
+const NZDCountries: 'NZDCountries' = 'NZDCountries';
+const Canada: 'Canada' = 'Canada';
+const International: 'International' = 'International';
+
+export type CountryGroupId =
+  typeof GBPCountries
+  | typeof UnitedStates
+  | typeof AUDCountries
+  | typeof EURCountries
+  | typeof International
+  | typeof NZDCountries
+  | typeof Canada;
 
 export type CountryGroupName = 'United Kingdom' | 'United States' | 'Australia' | 'Europe' | 'International' | 'New Zealand' | 'Canada';
 
@@ -86,7 +101,6 @@ const countryGroups: CountryGroups = {
   },
 };
 
-
 // ----- Functions ----- //
 
 function fromPath(path: string = window.location.pathname): ?CountryGroupId {
@@ -110,14 +124,22 @@ function fromPath(path: string = window.location.pathname): ?CountryGroupId {
 
 function fromString(countryGroup: string): ?CountryGroupId {
   switch (countryGroup) {
-    case 'GBPCountries': return 'GBPCountries';
-    case 'UnitedStates': return 'UnitedStates';
-    case 'AUDCountries': return 'AUDCountries';
-    case 'EURCountries': return 'EURCountries';
-    case 'International': return 'International';
-    case 'NZDCountries': return 'NZDCountries';
-    case 'Canada': return 'Canada';
-    default: return null;
+    case 'GBPCountries':
+      return 'GBPCountries';
+    case 'UnitedStates':
+      return 'UnitedStates';
+    case 'AUDCountries':
+      return 'AUDCountries';
+    case 'EURCountries':
+      return 'EURCountries';
+    case 'International':
+      return 'International';
+    case 'NZDCountries':
+      return 'NZDCountries';
+    case 'Canada':
+      return 'Canada';
+    default:
+      return null;
   }
 }
 
@@ -172,4 +194,11 @@ export {
   detect,
   stringToCountryGroupId,
   fromCountry,
+  GBPCountries,
+  UnitedStates,
+  AUDCountries,
+  EURCountries,
+  NZDCountries,
+  Canada,
+  International,
 };

--- a/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
+++ b/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
@@ -78,6 +78,8 @@ const gridImagesByCountry: {
   UnitedStates: defaultImages,
   International: defaultImages,
   EURCountries: defaultImages,
+  NZDCountries: defaultImages,
+  Canada: defaultImages,
   AUDCountries: {
     breakpoints: {
       mobile: {

--- a/assets/pages/digital-subscription-landing/components/productBlock.jsx
+++ b/assets/pages/digital-subscription-landing/components/productBlock.jsx
@@ -13,6 +13,7 @@ import SvgPennyFarthingCircles from 'components/svgs/pennyFarthingCircles';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 import CtaSwitch from './ctaSwitch';
+import { GBPCountries } from '../../../helpers/internationalisation/countryGroup';
 
 
 // ----- Types ----- //
@@ -52,6 +53,8 @@ const appFeatures: {
   UnitedStates: defaultFeatures,
   International: defaultFeatures,
   EURCountries: defaultFeatures,
+  NZDCountries: defaultFeatures,
+  Canada: defaultFeatures,
   AUDCountries: [
     {
       heading: ['Live news and sport ', <mark className="product-block__highlight">New</mark>],
@@ -83,6 +86,8 @@ const appImages: {
   UnitedStates: defaultAppImage,
   International: defaultAppImage,
   EURCountries: defaultAppImage,
+  NZDCountries: defaultAppImage,
+  Canada: defaultAppImage,
   AUDCountries: {
     ...defaultAppImage,
     gridId: 'premiumTierAU',
@@ -91,7 +96,7 @@ const appImages: {
 };
 
 function getDailyEditionCopy(countryGroupId: CountryGroupId) {
-  if (countryGroupId === 'GBPCountries') {
+  if (countryGroupId === GBPCountries) {
     return {
       description: 'Every issue of The Guardian and Observer, designed for your iPad and available offline',
       onTheGoText: 'Your complete daily newspaper, beautifully designed for your iPad',

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -7,6 +7,7 @@ import { Provider } from 'react-redux';
 
 import { renderPage } from 'helpers/render';
 import { detect, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { GBPCountries, AUDCountries, Canada, EURCountries, International, NZDCountries, UnitedStates } from 'helpers/internationalisation/countryGroup';
 import { init as pageInit } from 'helpers/page/page';
 
 import Page from 'components/page/page';
@@ -44,17 +45,21 @@ const reactElementId: {
   UnitedStates: 'digital-subscription-landing-page-us',
   AUDCountries: 'digital-subscription-landing-page-au',
   EURCountries: 'digital-subscription-landing-page-eu',
+  NZDCountries: 'digital-subscription-landing-page-nz',
+  Canada: 'digital-subscription-landing-page-ca',
   International: 'digital-subscription-landing-page-int',
 };
 
 const CountrySwitcherHeader = headerWithCountrySwitcherContainer(
   '/subscribe/digital',
   [
-    'GBPCountries',
-    'UnitedStates',
-    'AUDCountries',
-    'EURCountries',
-    'International',
+    GBPCountries,
+    UnitedStates,
+    AUDCountries,
+    EURCountries,
+    NZDCountries,
+    Canada,
+    International,
   ],
 );
 

--- a/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -25,7 +25,9 @@
 #digital-subscription-landing-page-uk,
 #digital-subscription-landing-page-us,
 #digital-subscription-landing-page-au,
-#digital-subscription-landing-page-eu {
+#digital-subscription-landing-page-eu,
+#digital-subscription-landing-page-nz,
+#digital-subscription-landing-page-ca {
   .component-left-margin-section__content {
     overflow-x: hidden;
     @include mq($from: leftCol) {
@@ -39,23 +41,23 @@
 
     .product-block__heading-wrapper {
       @include mq($from: phablet) {
-        width: 100%; 
+        width: 100%;
       }
     }
 
     .component-left-margin-section__content {
       position: relative;
-      
+
       @include mq($from: phablet) {
         display: flex;
         flex-direction: row;
-        flex-wrap: wrap;  
+        flex-wrap: wrap;
       }
 
       @include mq($from: desktop) {
         border-left: 1px solid gu-colour(brightness-86);
       }
-      
+
     }
 
     .component-grid-image {
@@ -74,7 +76,7 @@
 
     .component-price-cta {
       width: 100%;
-      
+
       @include mq($until: desktop) {
         margin-top: $gu-v-spacing * 2;
       }
@@ -99,10 +101,10 @@
       max-width: 520px;
     }
   }
-  
+
   .product-block__copy {
-    padding: 0 ($gu-h-spacing / 2) $gu-v-spacing;	
-    font-size: 17px;	
+    padding: 0 ($gu-h-spacing / 2) $gu-v-spacing;
+    font-size: 17px;
   }
 
   .product-block__image {

--- a/conf/routes
+++ b/conf/routes
@@ -80,7 +80,7 @@ GET /identity/get-user-type                      controllers.IdentityController.
 # ----- Subscriptions ----- #
 
 GET  /subscribe                                    controllers.Subscriptions.geoRedirect()
-GET  /$country<(uk|us|au|int)>/subscribe           controllers.Subscriptions.landing(country: String)
+GET  /$country<(uk|us|au|eu|int|nz|ca)>/subscribe           controllers.Subscriptions.landing(country: String)
 
 # This is just a fallback in case someone accidentally uses an unsupported country-specific
 # subscribe route. We just redirect to the subscriptions site and let its geolocation handle it.
@@ -88,17 +88,17 @@ GET  /:country/subscribe                           controllers.Subscriptions.leg
 
 GET  /digital                                           controllers.DigitalSubscription.digitalGeoRedirect()
 GET  /subscribe/digital                                 controllers.DigitalSubscription.digitalGeoRedirect()
-GET  /$country<(uk|us|au|eu|int)>/subscribe/digital     controllers.DigitalSubscription.digital(country: String)
+GET  /$country<(uk|us|au|eu|int|nz|ca)>/subscribe/digital     controllers.DigitalSubscription.digital(country: String)
 
 # redirect from old checkout urls
-GET  /$country<(uk|us|au|int)>/subscribe/digital/checkout  controllers.Application.permanentRedirectWithCountry(country, location="/subscribe/digital/checkout")
+GET  /$country<(uk|us|au|eu|int|nz|ca)>/subscribe/digital/checkout  controllers.Application.permanentRedirectWithCountry(country, location="/subscribe/digital/checkout")
 GET  /subscribe/digital/checkout  controllers.DigitalSubscription.displayForm()
 GET  /subscribe/digital/checkout/existing  controllers.DigitalSubscription.displayForm()
 POST /subscribe/digital/create  controllers.DigitalSubscription.create
 
 GET  /premium-tier                            controllers.Subscriptions.premiumTierGeoRedirect()
 GET  /subscribe/premium-tier                            controllers.Subscriptions.premiumTierGeoRedirect()
-GET  /$country<(uk|us|au|int)>/subscribe/premium-tier   controllers.Subscriptions.premiumTier(country: String)
+GET  /$country<(uk|us|au|eu|int|nz|ca)>/subscribe/premium-tier   controllers.Subscriptions.premiumTier(country: String)
 
 GET  /weekly                            controllers.Subscriptions.weeklyGeoRedirect()
 GET  /subscribe/weekly                            controllers.Subscriptions.weeklyGeoRedirect()


### PR DESCRIPTION
## Why are you doing this?

So that customers in New Zealand and Canada have localised subscribe pages and correct prices in their local currency for the Digital Pack.

[**Trello Card**](https://trello.com/c/ZfGLlSyQ/2186-internationalise-digital-pack-product-page)
