### PR TITLE
Graceful-er failures

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -15,6 +15,7 @@ module.file_ext=.css
 module.file_ext=.scss
 module.name_mapper='^containerisableComponents/' -> '<PROJECT_ROOT>/assets/containerisableComponents/'
 module.name_mapper='^components/' -> '<PROJECT_ROOT>/assets/components/'
+module.name_mapper='^pages/' -> '<PROJECT_ROOT>/assets/pages/'
 module.name_mapper='^stylesheets/' -> '<PROJECT_ROOT>/assets/stylesheets/'
 module.name_mapper='^helpers/' -> '<PROJECT_ROOT>/assets/helpers/'
 module.name_mapper='^ophan' -> 'ophan-tracker-js/build/ophan.support'

--- a/assets/components/pageSection/pageSection.jsx
+++ b/assets/components/pageSection/pageSection.jsx
@@ -8,6 +8,7 @@ import { classNameWithModifiers } from 'helpers/utilities';
 
 import type { Node } from 'react';
 
+import './pageSection.scss';
 
 // ----- Props ----- //
 

--- a/assets/components/pageSection/pageSection.scss
+++ b/assets/components/pageSection/pageSection.scss
@@ -1,3 +1,4 @@
+@import '~stylesheets/gu-sass/gu-sass';
 @import '~stylesheets/skeleton/html';
 
 .component-page-section__header {
@@ -14,6 +15,10 @@
 
 .component-page-section__body {
   box-sizing: border-box;
+
+  .component-text {
+    margin: $gu-v-spacing * 3 0;
+  }
 
   @include mq($from: desktop) {
     display: inline-block;

--- a/assets/helpers/render.js
+++ b/assets/helpers/render.js
@@ -7,7 +7,18 @@ const renderPage = (content: Object, id: string, callBack?: () => void) => {
   const element: ?Element = document.getElementById(id);
 
   if (element) {
-    ReactDOM.render(content, element, callBack);
+    try {
+      ReactDOM.render(content, element, callBack);
+    } catch {
+      logException(`Fatal error rendering a page. id:${id}`);
+      import('pages/error/components/errorPage').then(({ default: ErrorPage }) => {
+        ReactDOM.render(ErrorPage({
+          headings: ['Sorry - we seem', 'to be having a', 'problem completing', 'your request'],
+          copy: 'Please try again. If the problem persists,',
+          reportLink: true,
+        }), element, callBack);
+      });
+    }
   } else {
     logException(`Fatal error trying to render a page. id:${id}`);
   }

--- a/assets/pages/error/components/errorPage.jsx
+++ b/assets/pages/error/components/errorPage.jsx
@@ -9,15 +9,16 @@ import Header from 'components/headers/header/header';
 import Footer from 'components/footer/footer';
 import SquaresIntroduction from 'components/introduction/squaresIntroduction';
 import PageSection from 'components/pageSection/pageSection';
-import CtaLink from 'components/ctaLink/ctaLink';
+import Rows from 'components/base/rows';
+import AnchorButton from 'components/button/anchorButton';
 import { contributionsEmail } from 'helpers/legal';
-
+import Text, { LargeParagraph } from 'components/text/text';
 import '../error.scss';
 
 // ----- Types ----- //
 
 type PropTypes = {|
-  errorCode: string,
+  errorCode?: string,
   headings: string[],
   copy: string,
   reportLink?: boolean,
@@ -35,25 +36,32 @@ export default function ErrorPage(props: PropTypes) {
     >
       <SquaresIntroduction
         headings={props.headings}
-        highlights={[`Error ${props.errorCode}`]}
+        highlights={props.errorCode ? [`Error ${props.errorCode}`] : []}
       />
-      <PageSection modifierClass="ctas">
-        <p className="error-copy">
-          <span className="error-copy__text">{props.copy} </span>
-          <ReportLink show={props.reportLink || false} />
-        </p>
-        <CtaLink
-          text="Support The Guardian"
-          accessibilityHint="click here to support The Guardian"
-          url="/"
-          modifierClasses={['support-the-guardian']}
-        />
-        <CtaLink
-          text="Go to The Guardian home page"
-          accessibilityHint="click here to return to The Guardian home page"
-          url="https://www.theguardian.com"
-          modifierClasses={['guardian-home-page', 'border']}
-        />
+      <PageSection>
+        <Text>
+          <LargeParagraph>
+            <span className="error-copy__text">{props.copy} </span>
+            <ReportLink show={props.reportLink || false} />
+          </LargeParagraph>
+          <Rows>
+            <AnchorButton
+              aria-label="click here to support The Guardian"
+              href="/"
+              modifierClasses={['support-the-guardian']}
+            >
+              Support The Guardian
+            </AnchorButton>
+            <br />
+            <AnchorButton
+              aria-label="click here to return to The Guardian home page"
+              href="https://www.theguardian.com"
+              appearance="greyHollow"
+            >
+              Go to The Guardian home page
+            </AnchorButton>
+          </Rows>
+        </Text>
       </PageSection>
     </Page>
   );
@@ -82,4 +90,5 @@ function ReportLink(props: { show: boolean }) {
 
 ErrorPage.defaultProps = {
   reportLink: false,
+  errorCode: null,
 };


### PR DESCRIPTION
## Why are you doing this?
Right now, if we get a runtime error inside the react app everything goes like *sploosh*! *kaboom*! *shebang*! and loads a white page. This is not ideal for several reasons.

This PR adds a try/catch to load a grotesquely ugly error page instead. (we have a separate card to overhaul these) – It's async so it only loads the error page code after things go awry.

<img width="1239" alt="screenshot 2019-02-15 at 3 12 44 pm" src="https://user-images.githubusercontent.com/11539094/52865467-96d34780-3134-11e9-9062-120df373d1cc.png">
