### PR TITLE
Use constants for currencies

### DIFF
--- a/assets/helpers/internationalisation/__tests__/currencyTest.js
+++ b/assets/helpers/internationalisation/__tests__/currencyTest.js
@@ -2,8 +2,13 @@
 
 // ----- Imports ----- //
 
-import { detect, type IsoCurrency } from '../currency';
-import { AUDCountries, EURCountries, GBPCountries, UnitedStates } from '../countryGroup';
+import { AUD, EUR, GBP, USD, detect, type IsoCurrency } from 'helpers/internationalisation/currency';
+import {
+  AUDCountries,
+  EURCountries,
+  GBPCountries,
+  UnitedStates,
+} from '../countryGroup';
 
 let mockCurrency: ?IsoCurrency = null;
 
@@ -17,49 +22,49 @@ describe('detect currency', () => {
 
   it('should return the currency for the supplied country group if there is no query parameter set (GBP)', () => {
     mockCurrency = null;
-    expect(detect(GBPCountries)).toEqual('GBP');
+    expect(detect(GBPCountries)).toEqual(GBP);
   });
 
   it('should return the currency for the supplied country group if there is no query parameter set (USD)', () => {
     mockCurrency = null;
-    expect(detect(UnitedStates)).toEqual('USD');
+    expect(detect(UnitedStates)).toEqual(USD);
   });
 
 
   it('should return GBP if the country group is not recognised', () => {
     mockCurrency = null;
     // $FlowIgnore: We would like to test the function behaviour with an incorrect input
-    expect(detect('ZZ')).toEqual('GBP');
+    expect(detect('ZZ')).toEqual(GBP);
   });
 
   it('should return the currency from the query parameter (USD)', () => {
-    mockCurrency = 'USD';
-    expect(detect(GBPCountries)).toEqual('USD');
+    mockCurrency = USD;
+    expect(detect(GBPCountries)).toEqual(USD);
   });
 
   it('should return the currency from the query parameter (GBP)', () => {
-    mockCurrency = 'GBP';
-    expect(detect(UnitedStates)).toEqual('GBP');
+    mockCurrency = GBP;
+    expect(detect(UnitedStates)).toEqual(GBP);
   });
 
   it('should return the currency from the query parameter (AUD)', () => {
-    mockCurrency = 'AUD';
-    expect(detect(UnitedStates)).toEqual('AUD');
+    mockCurrency = AUD;
+    expect(detect(UnitedStates)).toEqual(AUD);
   });
 
   it('should return the currency for the supplied country group if there is no query parameter set (AUDCountries)', () => {
     mockCurrency = null;
-    expect(detect(AUDCountries)).toEqual('AUD');
+    expect(detect(AUDCountries)).toEqual(AUD);
   });
 
   it('should return the currency from the query parameter (EUR)', () => {
-    mockCurrency = 'EUR';
-    expect(detect(UnitedStates)).toEqual('EUR');
+    mockCurrency = EUR;
+    expect(detect(UnitedStates)).toEqual(EUR);
   });
 
   it('should return the currency for the supplied country group if there is no query parameter set (EURCountries)', () => {
     mockCurrency = null;
-    expect(detect(EURCountries)).toEqual('EUR');
+    expect(detect(EURCountries)).toEqual(EUR);
   });
 
 });

--- a/assets/helpers/internationalisation/countryGroup.js
+++ b/assets/helpers/internationalisation/countryGroup.js
@@ -7,6 +7,7 @@ import { getQueryParameter } from 'helpers/url';
 
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
+import { AUD, CAD, EUR, GBP, NZD, USD } from 'helpers/internationalisation/currency';
 
 // ----- Types ----- //
 
@@ -49,25 +50,25 @@ type CountryGroups = {
 const countryGroups: CountryGroups = {
   GBPCountries: {
     name: 'United Kingdom',
-    currency: 'GBP',
+    currency: GBP,
     countries: ['GB', 'FK', 'GI', 'GG', 'IM', 'JE', 'SH'],
     supportInternationalisationId: 'uk',
   },
   UnitedStates: {
     name: 'United States',
-    currency: 'USD',
+    currency: USD,
     countries: ['US'],
     supportInternationalisationId: 'us',
   },
   AUDCountries: {
     name: 'Australia',
-    currency: 'AUD',
+    currency: AUD,
     countries: ['AU', 'KI', 'NR', 'NF', 'TV'],
     supportInternationalisationId: 'au',
   },
   EURCountries: {
     name: 'Europe',
-    currency: 'EUR',
+    currency: EUR,
     countries: ['AD', 'AL', 'AT', 'BA', 'BE', 'BG', 'BL', 'CH', 'CY', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI', 'FO', 'FR',
       'GF', 'GL', 'GP', 'GR', 'HR', 'HU', 'IE', 'IT', 'LI', 'LT', 'LU', 'LV', 'MC', 'ME', 'MF', 'IS', 'MQ', 'MT', 'NL',
       'NO', 'PF', 'PL', 'PM', 'PT', 'RE', 'RO', 'RS', 'SE', 'SI', 'SJ', 'SK', 'SM', 'TF', 'TR', 'WF', 'YT', 'VA', 'AX'],
@@ -75,7 +76,7 @@ const countryGroups: CountryGroups = {
   },
   International: {
     name: 'International',
-    currency: 'USD',
+    currency: USD,
     countries: ['AE', 'AF', 'AG', 'AI', 'AM', 'AO', 'AQ', 'AR', 'AS', 'AW', 'AZ', 'BB', 'BD', 'BF', 'BH', 'BI', 'BJ', 'BM',
       'BN', 'BO', 'BQ', 'BR', 'BS', 'BT', 'BV', 'BW', 'BY', 'BZ', 'CC', 'CD', 'CF', 'CG', 'CI', 'CL', 'CM', 'CN', 'CO', 'CR',
       'CU', 'CV', 'CW', 'CX', 'DJ', 'DM', 'DO', 'DZ', 'EC', 'EG', 'EH', 'ER', 'ET', 'FJ', 'FM', 'GA', 'GD', 'GE', 'GH', 'GM',
@@ -89,13 +90,13 @@ const countryGroups: CountryGroups = {
   },
   NZDCountries: {
     name: 'New Zealand',
-    currency: 'NZD',
+    currency: NZD,
     countries: ['NZ', 'CK'],
     supportInternationalisationId: 'nz',
   },
   Canada: {
     name: 'Canada',
-    currency: 'CAD',
+    currency: CAD,
     countries: ['CA'],
     supportInternationalisationId: 'ca',
   },

--- a/assets/helpers/internationalisation/currency.js
+++ b/assets/helpers/internationalisation/currency.js
@@ -13,13 +13,21 @@ import {
 
 // ----- Types ----- //
 
+const GBP: 'GBP' = 'GBP';
+const USD: 'USD' = 'USD';
+const AUD: 'AUD' = 'AUD';
+const EUR: 'EUR' = 'EUR';
+const NZD: 'NZD' = 'NZD';
+const CAD: 'CAD' = 'CAD';
+
+
 export type IsoCurrency =
-  | 'GBP'
-  | 'USD'
-  | 'AUD'
-  | 'EUR'
-  | 'NZD'
-  | 'CAD';
+  | typeof GBP
+  | typeof USD
+  | typeof AUD
+  | typeof EUR
+  | typeof NZD
+  | typeof CAD;
 
 export type Currency = {|
   glyph: string,
@@ -107,12 +115,12 @@ function fromCountryGroupId(countryGroupId: CountryGroupId): ?IsoCurrency {
 
 function fromString(s: string): ?IsoCurrency {
   switch (s.toLowerCase()) {
-    case 'gbp': return 'GBP';
-    case 'usd': return 'USD';
-    case 'aud': return 'AUD';
-    case 'eur': return 'EUR';
-    case 'nzd': return 'NZD';
-    case 'cad': return 'CAD';
+    case 'gbp': return GBP;
+    case 'usd': return USD;
+    case 'aud': return AUD;
+    case 'eur': return EUR;
+    case 'nzd': return NZD;
+    case 'cad': return CAD;
     default: return null;
   }
 }
@@ -126,7 +134,7 @@ function fromQueryParameter(): ?IsoCurrency {
 }
 
 function detect(countryGroup: CountryGroupId): IsoCurrency {
-  return fromQueryParameter() || fromCountryGroupId(countryGroup) || 'GBP';
+  return fromQueryParameter() || fromCountryGroupId(countryGroup) || GBP;
 }
 
 const glyph = (c: IsoCurrency): string => currencies[c].glyph;
@@ -142,4 +150,10 @@ export {
   currencies,
   glyph,
   extendedGlyph,
+  GBP,
+  USD,
+  EUR,
+  AUD,
+  NZD,
+  CAD,
 };

--- a/assets/helpers/internationalisation/price.js
+++ b/assets/helpers/internationalisation/price.js
@@ -2,9 +2,24 @@
 
 // ----- Imports ----- //
 
-import { type IsoCurrency, glyph, extendedGlyph } from './currency';
-import { AUDCountries, Canada, type CountryGroupId, GBPCountries, International, NZDCountries, UnitedStates } from './countryGroup';
-
+import {
+  AUD,
+  CAD,
+  EUR,
+  GBP,
+  NZD,
+  USD,
+} from 'helpers/internationalisation/currency';
+import { extendedGlyph, glyph, type IsoCurrency } from './currency';
+import {
+  AUDCountries,
+  Canada,
+  type CountryGroupId, EURCountries,
+  GBPCountries,
+  International,
+  NZDCountries,
+  UnitedStates,
+} from './countryGroup';
 
 // ----- Types ----- //
 
@@ -16,22 +31,23 @@ export type Price = $ReadOnly<{|
 
 // ----- Functions ----- //
 
-const GBP = (value: number): Price => ({ value, currency: 'GBP' });
-const USD = (value: number): Price => ({ value, currency: 'USD' });
-const AUD = (value: number): Price => ({ value, currency: 'AUD' });
-const EUR = (value: number): Price => ({ value, currency: 'EUR' });
-const NZD = (value: number): Price => ({ value, currency: 'NZD' });
-const CAD = (value: number): Price => ({ value, currency: 'CAD' });
+const GBPPrice = (value: number): Price => ({ value, currency: GBP });
+const USDPrice = (value: number): Price => ({ value, currency: USD });
+const AUDPrice = (value: number): Price => ({ value, currency: AUD });
+const EURPrice = (value: number): Price => ({ value, currency: EUR });
+const NZDPrice = (value: number): Price => ({ value, currency: NZD });
+const CADPrice = (value: number): Price => ({ value, currency: CAD });
 
 function priceByCountryGroupId(countryGroupId: CountryGroupId, price: number): Price {
   switch (countryGroupId) {
-    case GBPCountries: return GBP(price);
-    case AUDCountries: return AUD(price);
-    case International: return USD(price);
-    case NZDCountries: return NZD(price);
-    case Canada: return CAD(price);
+    case GBPCountries: return GBPPrice(price);
+    case AUDCountries: return AUDPrice(price);
+    case International: return USDPrice(price);
+    case NZDCountries: return NZDPrice(price);
+    case EURCountries: return EURPrice(price);
+    case Canada: return CADPrice(price);
     default:
-    case UnitedStates: return USD(price);
+    case UnitedStates: return USDPrice(price);
   }
 }
 

--- a/assets/helpers/page/__tests__/pageTest.js
+++ b/assets/helpers/page/__tests__/pageTest.js
@@ -3,7 +3,7 @@
 // ----- Imports ----- //
 
 import type { IsoCountry } from 'helpers/internationalisation/country';
-
+import { GBP } from 'helpers/internationalisation/currency';
 import { createCommonReducer } from '../commonReducer';
 import { GBPCountries } from '../../internationalisation/countryGroup';
 
@@ -30,7 +30,7 @@ describe('reducer tests', () => {
       internationalisation: {
         countryId: 'GB',
         countryGroupId: GBPCountries,
-        currencyId: 'GBP',
+        currencyId: GBP,
       },
       abParticipations: {},
       otherQueryParams: [],

--- a/assets/helpers/paymentIntegrations/stripeCheckout.js
+++ b/assets/helpers/paymentIntegrations/stripeCheckout.js
@@ -20,6 +20,7 @@
 
 import { type IsoCurrency } from 'helpers/internationalisation/currency';
 import type { StripeAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
+import { AUD } from 'helpers/internationalisation/currency';
 
 // ----- Types ----- //
 
@@ -47,7 +48,7 @@ function loadStripe(): Promise<void> {
 
 function getStripeKey(stripeAccount: StripeAccount, currency: IsoCurrency, isTestUser: boolean): string {
   switch (currency) {
-    case 'AUD':
+    case AUD:
       return isTestUser ?
         window.guardian.stripeKeyAustralia[stripeAccount].uat :
         window.guardian.stripeKeyAustralia[stripeAccount].default;

--- a/assets/helpers/subscriptions.js
+++ b/assets/helpers/subscriptions.js
@@ -15,7 +15,7 @@ import {
 import { getPlanPrices, flashSaleIsActive, type PlanPrice } from 'helpers/flashSale';
 import { trackComponentEvents } from './tracking/ophanComponentEventTracking';
 import { gaEvent } from './tracking/googleTagManager';
-import { currencies, detect } from './internationalisation/currency';
+import { currencies, detect, GBP } from './internationalisation/currency';
 import { GBPCountries } from './internationalisation/countryGroup';
 
 
@@ -232,7 +232,7 @@ function getPromotionWeeklyProductPrice(
 function getRegularPaperPrice(billingPlan: PaperBillingPlan): Price {
   return {
     price: paperSubscriptionPrices[billingPlan],
-    currency: 'GBP',
+    currency: GBP,
   };
 }
 
@@ -244,7 +244,7 @@ function getPaperPrice(billingPlan: PaperBillingPlan): Price {
     if (discountedPlanPrice) {
       return {
         price: discountedPlanPrice[billingPlan],
-        currency: 'GBP',
+        currency: GBP,
       };
     }
   }

--- a/assets/helpers/tracking/googleTagManager.js
+++ b/assets/helpers/tracking/googleTagManager.js
@@ -6,8 +6,8 @@ import { getVariantsAsString } from 'helpers/abTests/abtest';
 import { detect as detectCurrency } from 'helpers/internationalisation/currency';
 import { getQueryParameter } from 'helpers/url';
 import { detect as detectCountryGroup } from 'helpers/internationalisation/countryGroup';
+import { GBP } from 'helpers/internationalisation/currency';
 import type { Participations } from 'helpers/abTests/abtest';
-
 
 // ----- Types ----- //
 type EventType = 'DataLayerReady' | 'SuccessfulConversion' | 'GAEvent' | 'AppStoreCtaClick';
@@ -54,7 +54,7 @@ function getCurrency(): string {
   if (currency) {
     storage.setSession('currency', currency);
   }
-  return storage.getSession('currency') || 'GBP';
+  return storage.getSession('currency') || GBP;
 }
 
 function getContributionValue(): number {


### PR DESCRIPTION
## Why are you doing this?
Same idea as #1521

Introduce a set of constants for currency values which means we don't need to sprinkle string representations throughout the app.

This is better because it is less prone to typos and allows IDEs to do refactoring and code analysis like 'find usages' much more successfully.
