### PR TITLE
Update print hero roundel.jsx

### DIFF
--- a/assets/pages/paper-subscription-landing/components/hero/hero.jsx
+++ b/assets/pages/paper-subscription-landing/components/hero/hero.jsx
@@ -91,7 +91,7 @@ const SaleHeader = () => (
           <div className="sale-joy-of-print-graphic-inner">
             <div className="sale-joy-of-print-badge">
               <span>Save up to</span>
-              <span>68%</span>
+              <span>31%</span>
               <span>for three months</span>
             </div>
             <div className="sale-joy-of-print-graphic">


### PR DESCRIPTION
## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->The print roundel still states the flash sale saving. It should now state 31%.

[**Trello Card**](https://trello.com)

## Changes

* Updated roundel to say 31% saving


## Screenshots

