### PR TITLE
Update print roundel v2.jsx

### DIFF
--- a/assets/pages/paper-subscription-landing/components/hero/hero.jsx
+++ b/assets/pages/paper-subscription-landing/components/hero/hero.jsx
@@ -91,8 +91,8 @@ const SaleHeader = () => (
           <div className="sale-joy-of-print-graphic-inner">
             <div className="sale-joy-of-print-badge">
               <span>Save up to</span>
-              <span>31%</span>
-              <span>for three months</span>
+              <span>37%</span>
+              <span></span>
             </div>
             <div className="sale-joy-of-print-graphic">
               <GridImage

--- a/assets/pages/paper-subscription-landing/components/hero/hero.jsx
+++ b/assets/pages/paper-subscription-landing/components/hero/hero.jsx
@@ -92,7 +92,6 @@ const SaleHeader = () => (
             <div className="sale-joy-of-print-badge">
               <span>Save up to</span>
               <span>37%</span>
-              <span></span>
             </div>
             <div className="sale-joy-of-print-graphic">
               <GridImage

--- a/assets/pages/paper-subscription-landing/components/hero/hero.jsx
+++ b/assets/pages/paper-subscription-landing/components/hero/hero.jsx
@@ -22,7 +22,7 @@ function getHeading(): string {
     return saleCopy.landingPage.subHeading;
   }
 
-  return 'Save up to 31% on The Guardian and The Observer - all year round';
+  return 'Save up to 37% on The Guardian and The Observer - all year round';
 }
 
 const TimerIfActive = () => (showCountdownTimer('Paper', GBPCountries) ? (


### PR DESCRIPTION
## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->There's no time limit on the "save up to 31%" message, so I've removed "for 3 months" from the roundel, and the saving is actually 37% now because the newsstand price has gone up since we last had BAU pricing on the site.

[**Trello Card**](https://trello.com)

## Changes

* removed "for 3 months" from the roundel
* updated % saving to 37% in the roundel and in the header copy


## Screenshots
<img src = "https://user-images.githubusercontent.com/3072877/52949219-9379cf00-3373-11e9-977f-da1619d11c99.png" width=400>
⬇️ 
<img src = "https://user-images.githubusercontent.com/3072877/52949251-ad1b1680-3373-11e9-8c7d-333cf1f072d0.png" width=400>
