### PR TITLE
Add DP sale details for EU/NZ/CA

### DIFF
--- a/assets/helpers/flashSale.js
+++ b/assets/helpers/flashSale.js
@@ -6,7 +6,7 @@ import { fixDecimals } from 'helpers/subscriptions';
 import { type BillingPeriod } from 'helpers/billingPeriods';
 
 import { type SubscriptionProduct, type PaperBillingPlan } from './subscriptions';
-import { AUDCountries, GBPCountries, International, UnitedStates } from './internationalisation/countryGroup';
+import { AUDCountries, GBPCountries, EURCountries, Canada, International, UnitedStates, NZDCountries } from './internationalisation/countryGroup';
 
 export type SaleCopy = {
   featuredProduct: {
@@ -204,7 +204,7 @@ const Sales: Sale[] = [
   },
   {
     subscriptionProduct: 'DigitalPack',
-    activeRegions: [UnitedStates, AUDCountries, International],
+    activeRegions: [UnitedStates, AUDCountries, International, EURCountries, Canada, NZDCountries],
     startTime: new Date(2019, 1, 4).getTime(), // 4 Feb 2019
     endTime: new Date(2019, 3, 1).getTime(), // 31 Mar 2019
     saleDetails: {
@@ -239,6 +239,81 @@ const Sales: Sale[] = [
         intcmp: '',
         price: 14.99,
         annualPrice: 179.87,
+        discountPercentage: 0.25,
+        saleCopy: {
+          featuredProduct: {
+            heading: 'Digital Pack',
+            subHeading: 'Save 25% for a year',
+            description: 'Read The Guardian ad-free on all devices, including the Premium App and UK Daily Edition iPad app.',
+          },
+          landingPage: {
+            heading: 'Digital Pack',
+            subHeading: 'Save 25% on award-winning, independent journalism, ad-free on all of your devices',
+          },
+          bundle: {
+            heading: 'Digital Pack',
+            subHeading: 'Save 25% for a year',
+            description: 'The Premium App and the daily edition iPad app of the UK newspaper in one pack, plus ad-free reading on all your devices',
+          },
+        },
+        planPrices: [],
+      },
+      Canada: {
+        promoCode: 'DDPFMINT80',
+        annualPlanPromoCode: 'DDPFMANINT80',
+        intcmp: '',
+        price: 16.46,
+        annualPrice: 197.48,
+        discountPercentage: 0.25,
+        saleCopy: {
+          featuredProduct: {
+            heading: 'Digital Pack',
+            subHeading: 'Save 25% for a year',
+            description: 'Read The Guardian ad-free on all devices, including the Premium App and UK Daily Edition iPad app.',
+          },
+          landingPage: {
+            heading: 'Digital Pack',
+            subHeading: 'Save 25% on award-winning, independent journalism, ad-free on all of your devices',
+          },
+          bundle: {
+            heading: 'Digital Pack',
+            subHeading: 'Save 25% for a year',
+            description: 'The Premium App and the daily edition iPad app of the UK newspaper in one pack, plus ad-free reading on all your devices',
+          },
+        },
+        planPrices: [],
+      },
+      NZDCountries: {
+        promoCode: 'DDPFMINT80',
+        annualPlanPromoCode: 'DDPFMANINT80',
+        intcmp: '',
+        price: 17.63,
+        annualPrice: 211.43,
+        discountPercentage: 0.25,
+        saleCopy: {
+          featuredProduct: {
+            heading: 'Digital Pack',
+            subHeading: 'Save 25% for a year',
+            description: 'Read The Guardian ad-free on all devices, including the Premium App and UK Daily Edition iPad app.',
+          },
+          landingPage: {
+            heading: 'Digital Pack',
+            subHeading: 'Save 25% on award-winning, independent journalism, ad-free on all of your devices',
+          },
+          bundle: {
+            heading: 'Digital Pack',
+            subHeading: 'Save 25% for a year',
+            description: 'The Premium App and the daily edition iPad app of the UK newspaper in one pack, plus ad-free reading on all your devices',
+          },
+        },
+        planPrices: [],
+      },
+      EURCountries: {
+        promoCode: 'DDPFMINT80',
+        annualPlanPromoCode: 'DDPFMANINT80',
+        intcmp: '',
+        price: 11.24,
+        annualPrice: 134.87,
         discountPercentage: 0.25,
         saleCopy: {
           featuredProduct: {

--- a/assets/helpers/productPrice/productPrices.js
+++ b/assets/helpers/productPrice/productPrices.js
@@ -46,7 +46,7 @@ export type Price = {|
   currency: IsoCurrency,
 |};
 
-const showPrice = (p: Price, isExtended: boolean = false): string => {
+const showPrice = (p: Price, isExtended: boolean = true): string => {
   const showGlyph = isExtended ? extendedGlyph : glyph;
   return `${showGlyph(p.currency)}${p.price.toFixed(2)}`;
 };


### PR DESCRIPTION
## Why are you doing this?

So people down there know there's a sale going!

This also updates the prices to display the country dollars are from as it was getting confusing. @SarahLaughton 

[**Trello Card**](https://trello.com/c/sAZTOf67/2235-dp-flash-sale-pricing-not-reflected-on-ca-nz-or-eu-pages)

## Screenshots

<img width="474" alt="screenshot 2019-02-18 at 3 17 35 pm" src="https://user-images.githubusercontent.com/11539094/52960380-933bfc80-3390-11e9-9708-2a5967abf5c5.png">
<img width="459" alt="screenshot 2019-02-18 at 3 19 32 pm" src="https://user-images.githubusercontent.com/11539094/52960407-a0f18200-3390-11e9-9685-fa83eb561288.png">
<img width="498" alt="screenshot 2019-02-18 at 3 19 40 pm" src="https://user-images.githubusercontent.com/11539094/52960409-a2bb4580-3390-11e9-9208-d59cfcca5598.png">
