### PR TITLE
Temporary offer wording for DP flash sale.jsx

### DIFF
--- a/assets/pages/digital-subscription-landing/components/form.jsx
+++ b/assets/pages/digital-subscription-landing/components/form.jsx
@@ -81,7 +81,7 @@ const billingPeriods = {
   [Monthly]: {
     title: 'Monthly',
     offer: (country: IsoCountry) => getOfferCopy(country, Monthly),
-    copy: (productPrices: ProductPrices, country: IsoCountry) => `14 day free trial, then ${displayPrice(productPrices, Monthly, country)} a month`,
+    copy: (productPrices: ProductPrices, country: IsoCountry) => `14 day free trial, then ${displayPrice(productPrices, Monthly, country)} a month for 12 months`,
   },
   [Annual]: {
     title: 'Annually',
@@ -89,7 +89,7 @@ const billingPeriods = {
     copy: (productPrices: ProductPrices, country: IsoCountry) => {
       const saving = getAnnualSaving(productPrices, country);
       return [
-        `14 day free trial, then ${displayPrice(productPrices, Annual, country)} every 12 months`,
+        `14 day free trial, then ${displayPrice(productPrices, Annual, country)} for the first year`,
         saving ? `(save ${showPrice(saving)} per year)` : null,
       ].join(' ');
     },


### PR DESCRIPTION
## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->The fancy new system for reflecting pricing on product pages means we've temporarily lost wording that makes it clear that the price we're showing is the offer price that customers will pay for a set period of time. This PR covers adding some hard-coded wording that help to make that clearer while we figure out how promo codes should be automatically reflected on product pages in future.

[**Trello Card**](https://trello.com/c/mArnucUy)

## Changes

* Added "for the first 12 months" to the monthly pricing card
* Replaced "every 12 months" with "for the first year" in the annual pricing card

## Screenshots
Current: 
![image](https://user-images.githubusercontent.com/45856485/52964288-d6e73400-3399-11e9-9b7b-eee8508410a2.png)


New: 
![image](https://user-images.githubusercontent.com/45856485/52964554-76a4c200-339a-11e9-9a95-cf15ba78f03b.png)


