### PR TITLE
Transparent <button>s on the css reset

### DIFF
--- a/assets/stylesheets/skeleton/reset-src.scss
+++ b/assets/stylesheets/skeleton/reset-src.scss
@@ -45,3 +45,6 @@ table {
   border-collapse: collapse;
   border-spacing: 0;
 }
+button {
+  background: transparent;
+}


### PR DESCRIPTION
## Why are you doing this?
because safari makes them grey otherwise. look at this :(

## Screenshots

<img width="1243" alt="screenshot 2019-02-18 at 6 05 02 pm" src="https://user-images.githubusercontent.com/11539094/52969327-dfdf0200-33a7-11e9-8012-8fc7c9a70f80.png">
