### PR TITLE
fix: added variant to query string

### DIFF
--- a/app/utils/QueryStringUtils.scala
+++ b/app/utils/QueryStringUtils.scala
@@ -4,7 +4,7 @@ import scala.util.Random
 object QueryStringUtils {
   def addServerSideRenderingTestParameterQueryString(queryString: Map[String, Seq[String]]): Map[String, Seq[String]] = {
     val ssrParameterValue = if (Random.nextBoolean()) "on" else "off"
-    val formDesignTestParameterValue = if (Random.nextBoolean()) "on" else "off"
+    val formDesignTestParameterValue = if (Random.nextBoolean()) "control" else "variant"
    queryString + ("ssrTwo" -> Seq(ssrParameterValue)) + ("formDesignTest" -> Seq(formDesignTestParameterValue))
   }
 }


### PR DESCRIPTION
fix: added variant to query string - when the query string is randomly created, it will now be created with “control” or “variant” e.g. formDesignTest=control

## Why are you doing this?
because analytics only works with "control" and "variant" at the moment it is using "on" or "off"

![image](https://user-images.githubusercontent.com/45875444/53029301-7242dc80-3460-11e9-9867-ef8b5b77ac51.png)


