### PR TITLE
Update ctaSubscribe.jsx

### DIFF
--- a/assets/pages/showcase/components/ctaSubscribe.jsx
+++ b/assets/pages/showcase/components/ctaSubscribe.jsx
@@ -17,8 +17,8 @@ export default function CtaSubscribe() {
     >
       <Text title="Subscribe">
         <p>
-          From the Digital Pack, to the new Guardian Weekly magazine to the daily newspaper,
-          you can subscribe to the Guardian <strong>for as little as 99p a day.</strong>
+          From the Digital Pack, to the new Guardian Weekly magazine,
+          you can subscribe to the Guardian from wherever you are.
         </p>
       </Text>
       <NarrowContent>


### PR DESCRIPTION
## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->The new moment has just gone live and includes a thrasher on all versions of the network front, which links to the showcase page. This page isn't regionalised at the moment, so customers outside the UK will see some references to info that doesn't apply to them. As a result, we need to make the copy generic enough that it applies to readers from any region.

## Changes

* Make subscriptions copy generic

## Screenshots
Current:
![image](https://user-images.githubusercontent.com/45856485/53097322-1b4d0e00-3519-11e9-8228-aa6d671e43aa.png)

New:
![image](https://user-images.githubusercontent.com/45856485/53097341-243ddf80-3519-11e9-855d-8e8ca6e2a754.png)
