### PR TITLE
Refactor to use a generic endpoint for creating subscriptions

### DIFF
--- a/app/controllers/CreateSubscription.scala
+++ b/app/controllers/CreateSubscription.scala
@@ -1,0 +1,127 @@
+package controllers
+
+import actions.CustomActionBuilders
+import actions.CustomActionBuilders.AuthRequest
+import admin.settings.{AllSettingsProvider, SettingsSurrogateKeySyntax}
+import cats.data.EitherT
+import cats.implicits._
+import com.gu.identity.play.IdUser
+import com.gu.support.workers.{Address, BillingPeriod, DigitalPack, User}
+import io.circe.syntax._
+import lib.PlayImplicits._
+import monitoring.SafeLogger
+import monitoring.SafeLogger._
+import play.api.libs.circe.Circe
+import play.api.mvc._
+import services.stepfunctions.{CreateSupportWorkersRequest, StatusResponse, SupportWorkersClient}
+import services.{IdentityService, TestUserService}
+import utils.NormalisedTelephoneNumber
+import utils.NormalisedTelephoneNumber.asFormattedString
+import utils.SimpleValidator._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class CreateSubscription(
+  client: SupportWorkersClient,
+  val actionRefiners: CustomActionBuilders,
+  identityService: IdentityService,
+  testUsers: TestUserService,
+  components: ControllerComponents,
+  settingsProvider: AllSettingsProvider,
+  val supportUrl: String
+)(implicit val ec: ExecutionContext) extends AbstractController(components) with GeoRedirect with CanonicalLinks with Circe with SettingsSurrogateKeySyntax {
+
+  import actionRefiners._
+
+  sealed abstract class CreateSubscriptionError(message: String)
+  case class ServerError(message: String) extends CreateSubscriptionError(message)
+  case class RequestValidationError(message: String) extends CreateSubscriptionError(message)
+
+  type ApiResponseOrError[RES] = EitherT[Future, CreateSubscriptionError, RES]
+
+  def create: Action[CreateSupportWorkersRequest] =
+    authenticatedAction(recurringIdentityClientId).async(circe.json[CreateSupportWorkersRequest]) {
+      implicit request: AuthRequest[CreateSupportWorkersRequest] =>
+        val validator: CreateSupportWorkersRequest => Boolean = request.body.product match {
+          case digitalPack: DigitalPack => validationPasses
+          case _ => validationPasses // TODO use a different validator which encompasses HD/Voucher rules
+        }
+        handleCreateSupportWorkersRequest(request, validator)
+    }
+
+  def handleCreateSupportWorkersRequest(
+    implicit request: AuthRequest[CreateSupportWorkersRequest],
+    validator: CreateSupportWorkersRequest => Boolean
+  ): Future[Result] = {
+    SafeLogger.info(s"[${request.uuid}] User ${request.user.id} is attempting to create a new subscription")
+
+    val normalisedTelephoneNumber = NormalisedTelephoneNumber.fromStringAndCountry(request.body.telephoneNumber, request.body.country)
+
+    val createSupportWorkersRequest = request.body.copy(
+      telephoneNumber = normalisedTelephoneNumber.map(asFormattedString)
+    )
+
+    def subscriptionStatusOrError(idUser: IdUser): ApiResponseOrError[StatusResponse] = {
+      client.createSubscription(request, createUser(idUser, createSupportWorkersRequest), request.uuid).leftMap(error => ServerError(error.toString))
+    }
+
+    if (validator(createSupportWorkersRequest)) {
+      val userOrError: ApiResponseOrError[IdUser] = identityService.getUser(request.user).leftMap(ServerError(_))
+
+      val result: ApiResponseOrError[StatusResponse] = for {
+        user <- userOrError
+        statusResponse <- subscriptionStatusOrError(user)
+      } yield statusResponse
+
+      respondToClient(result, createSupportWorkersRequest.product.billingPeriod)
+    } else {
+      respondToClient(EitherT.leftT(RequestValidationError("validation of the request body failed")), createSupportWorkersRequest.product.billingPeriod)
+    }
+  }
+
+  private def createUser(user: IdUser, request: CreateSupportWorkersRequest) = {
+    User(
+      id = user.id,
+      primaryEmailAddress = user.primaryEmailAddress,
+      firstName = request.firstName,
+      lastName = request.lastName,
+      billingAddress = billingAddress(request),
+      telephoneNumber = request.telephoneNumber,
+      allowMembershipMail = false,
+      allowThirdPartyMail = user.statusFields.flatMap(_.receive3rdPartyMarketing).getOrElse(false),
+      allowGURelatedMail = user.statusFields.flatMap(_.receiveGnmMarketing).getOrElse(false),
+      isTestUser = testUsers.isTestUser(user.publicFields.displayName)
+    )
+  }
+
+  private def billingAddress(request: CreateSupportWorkersRequest): Address = {
+    Address(
+      lineOne = request.addressLine1,
+      lineTwo = request.addressLine2,
+      city = request.townCity,
+      state = request.state,
+      postCode = request.postcode,
+      country = request.country
+    )
+  }
+
+  protected def respondToClient(
+    result: EitherT[Future, CreateSubscriptionError, StatusResponse],
+    billingPeriod: BillingPeriod
+ )(implicit request: AuthRequest[CreateSupportWorkersRequest]): Future[Result] =
+    result.fold(
+      { error =>
+        SafeLogger.error(scrub"[${request.uuid}] Failed to create new $billingPeriod subscription, due to $error")
+        error match {
+          case _: RequestValidationError => BadRequest
+          case _: ServerError => InternalServerError
+        }
+      },
+      { statusResponse =>
+        SafeLogger.info(s"[${request.uuid}] Successfully created a support workers execution for a new $billingPeriod subscription")
+        Accepted(statusResponse.asJson)
+      }
+    )
+
+}
+

--- a/app/controllers/PaperSubscription.scala
+++ b/app/controllers/PaperSubscription.scala
@@ -26,20 +26,16 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class PaperSubscription(
   priceSummaryServiceProvider: PriceSummaryServiceProvider,
-  client: SupportWorkersClient,
   val assets: AssetsResolver,
   val actionRefiners: CustomActionBuilders,
   identityService: IdentityService,
   testUsers: TestUserService,
-  membersDataService: MembersDataService,
   stripeConfigProvider: StripeConfigProvider,
   payPalConfigProvider: PayPalConfigProvider,
   components: ControllerComponents,
   stringsConfig: StringsConfig,
   settingsProvider: AllSettingsProvider,
-  val supportUrl: String,
-  tipMonitoring: Tip,
-  guardianDomain: GuardianDomain
+  val supportUrl: String
 )(implicit val ec: ExecutionContext) extends AbstractController(components) with GeoRedirect with Circe with CanonicalLinks with SettingsSurrogateKeySyntax {
 
   import actionRefiners._

--- a/app/services/stepfunctions/SupportWorkersClient.scala
+++ b/app/services/stepfunctions/SupportWorkersClient.scala
@@ -18,6 +18,7 @@ import com.gu.support.workers.{Status, _}
 import monitoring.SafeLogger
 import monitoring.SafeLogger._
 import ophan.thrift.event.AbTest
+import org.joda.time.LocalDate
 import play.api.mvc.Call
 import services.stepfunctions.SupportWorkersClient._
 
@@ -39,6 +40,7 @@ case class CreateSupportWorkersRequest(
     country: Country,
     state: Option[String],
     product: ProductType,
+    firstDeliveryDate: Option[LocalDate],
     paymentFields: PaymentFields,
     promoCode: Option[PromoCode],
     ophanIds: OphanIds,

--- a/app/wiring/AppComponents.scala
+++ b/app/wiring/AppComponents.scala
@@ -49,6 +49,7 @@ trait AppComponents extends PlayComponents
     identityController,
     subscriptionsController,
     digitalPackController,
+    createSubscriptionController,
     paperController,
     loginController,
     testUsersController,

--- a/app/wiring/Controllers.scala
+++ b/app/wiring/Controllers.scala
@@ -41,7 +41,6 @@ trait Controllers {
 
   lazy val digitalPackController = new DigitalSubscription(
     priceSummaryServiceProvider,
-    supportWorkersClient,
     assetsResolver,
     actionRefiners,
     identityService,
@@ -52,27 +51,31 @@ trait Controllers {
     controllerComponents,
     stringsConfig,
     allSettingsProvider,
-    appConfig.supportUrl,
-    tipMonitoring,
-    appConfig.guardianDomain
+    appConfig.supportUrl
   )
 
   lazy val paperController = new PaperSubscription(
     priceSummaryServiceProvider,
-    supportWorkersClient,
     assetsResolver,
     actionRefiners,
     identityService,
     testUsers,
-    membersDataService,
     appConfig.regularStripeConfigProvider,
     appConfig.regularPayPalConfigProvider,
     controllerComponents,
     stringsConfig,
     allSettingsProvider,
-    appConfig.supportUrl,
-    tipMonitoring,
-    appConfig.guardianDomain
+    appConfig.supportUrl
+  )
+
+  lazy val createSubscriptionController = new CreateSubscription(
+    supportWorkersClient,
+    actionRefiners,
+    identityService,
+    testUsers,
+    controllerComponents,
+    allSettingsProvider,
+    appConfig.supportUrl
   )
 
   lazy val supportWorkersStatusController = new SupportWorkersStatus(

--- a/assets/helpers/routes.js
+++ b/assets/helpers/routes.js
@@ -25,7 +25,7 @@ const routes: {
   payPalCreateAgreement: '/paypal/create-agreement',
   directDebitCheckAccount: '/direct-debit/check-account',
   payPalRestReturnURL: '/paypal/rest/return',
-  digitalSubscriptionCreate: '/subscribe/digital/create',
+  digitalSubscriptionCreate: '/subscribe/create',
   showcase: '/support',
   subscriptionsLanding: '/subscribe',
   digitalSubscriptionLanding: '/subscribe/digital',

--- a/conf/routes
+++ b/conf/routes
@@ -94,7 +94,9 @@ GET  /$country<(uk|us|au|eu|int|nz|ca)>/subscribe/digital     controllers.Digita
 GET  /$country<(uk|us|au|eu|int|nz|ca)>/subscribe/digital/checkout  controllers.Application.permanentRedirectWithCountry(country, location="/subscribe/digital/checkout")
 GET  /subscribe/digital/checkout  controllers.DigitalSubscription.displayForm()
 GET  /subscribe/digital/checkout/thankyou-existing  controllers.DigitalSubscription.displayThankYouExisting()
-POST /subscribe/digital/create  controllers.DigitalSubscription.create
+
+# Deprecated, soon all requests to create a subscription should go via /subscribe/create instead
+POST /subscribe/digital/create  controllers.CreateSubscription.create
 
 GET  /premium-tier                            controllers.Subscriptions.premiumTierGeoRedirect()
 GET  /subscribe/premium-tier                            controllers.Subscriptions.premiumTierGeoRedirect()
@@ -111,6 +113,7 @@ GET  /uk/subscribe/paper          controllers.PaperSubscription.paper(withDelive
 GET  /uk/subscribe/paper/delivery          controllers.PaperSubscription.paper(withDelivery: Boolean = true)
 GET  /subscribe/paper/checkout  controllers.PaperSubscription.displayForm(displayCheckout: Boolean ?= false)
 
+POST /subscribe/create  controllers.CreateSubscription.create
 
 # ----- Authentication ----- #
 

--- a/test/controllers/SubscriptionsTest.scala
+++ b/test/controllers/SubscriptionsTest.scala
@@ -98,7 +98,6 @@ class SubscriptionsTest extends WordSpec with MustMatchers with TestCSRFComponen
 
       new DigitalSubscription(
         priceSummaryServiceProvider,
-        client,
         assetResolver,
         actionRefiner,
         identityService,
@@ -109,9 +108,7 @@ class SubscriptionsTest extends WordSpec with MustMatchers with TestCSRFComponen
         stubControllerComponents(),
         new StringsConfig(),
         settingsProvider,
-        "support.thegulocal.com",
-        tip,
-        GuardianDomain(".thegulocal.com")
+        "support.thegulocal.com"
       )
     }
 

--- a/test/utils/SimpleValidatorTest.scala
+++ b/test/utils/SimpleValidatorTest.scala
@@ -14,6 +14,7 @@ class SimpleValidatorTest extends FlatSpec with Matchers {
     country = Country.US,
     state = Some("VA"),
     product = DigitalPack(Currency.USD, Monthly),
+    firstDeliveryDate = None,
     paymentFields = StripePaymentFields("test-token"),
     ophanIds = OphanIds(None, None, None),
     referrerAcquisitionData = ReferrerAcquisitionData(None, None, None, None, None, None, None, None, None, None, None, None),


### PR DESCRIPTION
## Why are you doing this?

We are in the process of migrating the creation of all subscriptions products to use support-frontend/workers. Since the call to create a subscription is going to be very similar for all subscriptions products, this PR refactors the existing code to remove any Digital Pack specifics.

As far as I can tell, the main difference we'll need to take into account when creating different products will be the validation rules that we use, so I've also tried to suggest an approach which allows the validation to be made product-specific.

This PR also adds an optional firstDeliveryDate to the CreateSupportWorkersRequest model, in preparation for https://trello.com/c/oRCVNC3s/2248-print-checkout-component-with-a-list-of-start-dates. Note that this PR doesn't wire that date through to the backend yet - this will follow as a separate change but I wanted to get things ready for @walaura).

[**Trello Card**](https://trello.com/c/NHSxiQqe/2254-add-a-create-endpoint-for-paper)

## Changes

* Add new generic controller (and endpoint) for creating subscriptions and wire it up
* Remove all code for creating subscriptions from Digital Pack controller
* Add optional first delivery date so that the interface is complete for clients (although note that this is not currently wired through to support-workers)
* Start calling the new endpoint for creating Digital Pack subscriptions (client side change), but leave the old endpoint in place until we are sure that noone will call it
* Tidy up some unused clutter from Digital / Paper Controllers
