### PR TITLE
Add basic validation for PayPal

### DIFF
--- a/app/utils/SimpleValidator.scala
+++ b/app/utils/SimpleValidator.scala
@@ -1,7 +1,7 @@
 package utils
 
 import com.gu.i18n.{Country, CountryGroup}
-import com.gu.support.workers.{DirectDebitPaymentFields, StripePaymentFields}
+import com.gu.support.workers.{DirectDebitPaymentFields, PayPalPaymentFields, StripePaymentFields}
 import services.stepfunctions.CreateSupportWorkersRequest
 
 object SimpleValidator {
@@ -19,6 +19,7 @@ object SimpleValidator {
       case directDebitDetails: DirectDebitPaymentFields =>
         !directDebitDetails.accountHolderName.isEmpty && !directDebitDetails.accountNumber.isEmpty && !directDebitDetails.sortCode.isEmpty
       case stripeDetails: StripePaymentFields => !stripeDetails.stripeToken.isEmpty
+      case payPalDetails: PayPalPaymentFields => !payPalDetails.baid.isEmpty
     }
 
     def currencyIsSupportedForCountry: Boolean = {


### PR DESCRIPTION
## Why are you doing this?

I noticed a non-exhaustive match which would have thrown an exception when requests to create Digital Packs with PayPal were received.

## Changes

* Ensure that BAID is not empty if the user tries to buy a Digital Pack with PayPal