### PR TITLE
Snyk updates

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2859,11 +2859,11 @@ async@^1.4.0, async@^1.5.2:
   integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
 
 async@^2.0.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.6.1.tgz#b245a23ca71930044ec53fa46aa00a3e87c6a610"
-  integrity sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/async/-/async-2.6.2.tgz#18330ea7e6e313887f5d2f2a904bac6fe4dd5381"
+  integrity sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==
   dependencies:
-    lodash "^4.17.10"
+    lodash "^4.17.11"
 
 async@^2.1.4:
   version "2.5.0"


### PR DESCRIPTION
## Why are you doing this?

Snyk was unhappy about the version of `lodash` being pulled in by `fast-sass-loader`:

`Introduced through: support-frontend@1.0.0 › fast-sass-loader@1.4.7 › async@2.6.1 › lodash@4.17.10`

I've removed (`yarn remove fast-sass-loader`) and re-installed (`yarn add fast-sass-loader`) this dependency in an attempt to upgrade beyond the problematic `lodash` version.