### PR TITLE
add notintest to the ab test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -4,7 +4,7 @@ import { annualAmountsLower, annualAmountsFive, annualAmountsOther } from './ann
 
 // ----- Tests ----- //
 
-export type FrequencyTabsTestVariant = 'control' | 'sam' | 'mas';
+export type FrequencyTabsTestVariant = 'control' | 'sam' | 'mas' | 'notintest';
 
 export const tests: Tests = {
   ssrTwo: {

--- a/support-frontend/assets/helpers/checkouts.js
+++ b/support-frontend/assets/helpers/checkouts.js
@@ -54,6 +54,7 @@ function getValidContributionTypesFromUrlOrElse(fallback: ContributionType[]): C
 
 function getValidContributionTypes(frequencyTabsOrdering: FrequencyTabsTestVariant): ContributionType[] {
   const mappings = {
+    notintest: ['ONE_OFF', 'MONTHLY', 'ANNUAL'],
     control: ['ONE_OFF', 'MONTHLY', 'ANNUAL'],
     mas: ['MONTHLY', 'ANNUAL', 'ONE_OFF'],
     sam: ['ONE_OFF', 'ANNUAL', 'MONTHLY'],


### PR DESCRIPTION
## Why are you doing this?

After this pr: https://github.com/guardian/support-frontend/pull/1551
It turned out I had not included notintest in the handled cases.  This wouldn't usually happen because everyone is in the test, however the post deploy user is always forced to be not in the test, so it was crashing with a horrible error.  The type checker doesn't really have the ability to check that at present.

---

Unfortunately there was no stack trace so I had to just work out by trial and error what was wrong.  I'm not sure if there is a thing swallowing JS errors that we need to update as well?
The console errors for the browser just showing a generic error (copy and pastable version below)
![image](https://user-images.githubusercontent.com/7304387/53412939-acf9c700-39c2-11e9-98f9-dd6958f7238c.png)
```
console.js:35 Fatal error rendering a page id:new-contributions-landing-page-uk
e.(anonymous function) @ console.js:35
i @ logger.js:26
i @ render.js:25
u @ render.js:45
(anonymous) @ contributionsLanding.jsx:114
a @ bootstrap:68
(anonymous) @ bootstrap:238
(anonymous) @ bootstrap:238
VM26738:formatted:43 POST https://sentry.io/api/1213654/store/?sentry_version=7&sentry_client=raven-js%2F3.26.1&sentry_key=65f7514888b6407881f34a6cf1320d06 net::ERR_NAME_NOT_RESOLVED
(anonymous) @ VM26738:formatted:43
(anonymous) @ raven.js:1446
_makeRequest @ raven.js:2155
_sendProcessedPayload @ raven.js:2098
_send @ raven.js:2028
_processException @ raven.js:1783
_handleStackInfo @ raven.js:1644
captureException @ raven.js:527
i @ logger.js:18
i @ render.js:25
u @ render.js:45
(anonymous) @ contributionsLanding.jsx:114
a @ bootstrap:68
(anonymous) @ bootstrap:238
(anonymous) @ bootstrap:238
```

@jranks123 