### PR TITLE
add notintest to the ab test part 2

### DIFF
--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -133,7 +133,7 @@ function selectInitialContributionTypeAndPaymentMethod(state: State, dispatch: F
   const { countryId } = state.common.internationalisation;
   const { switches } = state.common.settings;
   const { frequencyTabsOrdering } = state.common.abParticipations;
-  if (frequencyTabsOrdering === 'control' || frequencyTabsOrdering === 'mas' || frequencyTabsOrdering === 'sam') {
+  if (frequencyTabsOrdering === 'notintest' || frequencyTabsOrdering === 'control' || frequencyTabsOrdering === 'mas' || frequencyTabsOrdering === 'sam') {
     const contributionType = getInitialContributionType(frequencyTabsOrdering);
     const paymentMethod = getInitialPaymentMethod(contributionType, countryId, switches);
     dispatch(updateContributionTypeAndPaymentMethod(contributionType, paymentMethod));


### PR DESCRIPTION
## Why are you doing this?

Futher to https://github.com/guardian/support-frontend/pull/1555
I actually didn't look carefully enough.  I needed to also add the notintest into the if statement, as without it it wouldn't show the contribute button at all.
This does make me wonder if we should have put the if statement at all, as it was only needed to keep the type checker happy.

Before:
![image](https://user-images.githubusercontent.com/7304387/53425972-fa376200-39dd-11e9-9153-4763435ed376.png)
After:
![image](https://user-images.githubusercontent.com/7304387/53425982-04596080-39de-11e9-83af-bc87103dad33.png)

@jranks123 
