### PR TITLE
Wire up first delivery date

### DIFF
--- a/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
+++ b/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
@@ -112,7 +112,8 @@ class SupportWorkersClient(
         referrerAcquisitionData = referrerAcquisitionDataWithGAFields(request),
         supportAbTests = request.body.supportAbTests
       )),
-      promoCode = request.body.promoCode
+      promoCode = request.body.promoCode,
+      firstDeliveryDate = request.body.firstDeliveryDate
     )
     underlying.triggerExecution(createPaymentMethodState, user.isTestUser).bimap(
       { error =>

--- a/support-models/src/main/scala/com/gu/support/workers/states/CreatePaymentMethodState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/CreatePaymentMethodState.scala
@@ -4,12 +4,15 @@ import java.util.UUID
 
 import com.gu.support.promotions.PromoCode
 import com.gu.support.workers.{User, _}
+import org.joda.time.LocalDate
+import com.gu.support.encoding.CustomCodecs.{decodeLocalTime, encodeLocalTime}
 
 case class CreatePaymentMethodState(
   requestId: UUID,
   user: User,
   product: ProductType,
   paymentFields: PaymentFields,
+  firstDeliveryDate: Option[LocalDate],
   promoCode: Option[PromoCode],
   acquisitionData: Option[AcquisitionData]
 ) extends StepFunctionUserState

--- a/support-models/src/main/scala/com/gu/support/workers/states/CreateSalesforceContactState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/CreateSalesforceContactState.scala
@@ -4,12 +4,15 @@ import java.util.UUID
 
 import com.gu.support.promotions.PromoCode
 import com.gu.support.workers.{PaymentMethod, User, _}
+import org.joda.time.LocalDate
+import com.gu.support.encoding.CustomCodecs.{decodeLocalTime, encodeLocalTime}
 
 case class CreateSalesforceContactState(
   requestId: UUID,
   user: User,
   product: ProductType,
   paymentMethod: PaymentMethod,
+  firstDeliveryDate: Option[LocalDate],
   promoCode: Option[PromoCode],
   acquisitionData: Option[AcquisitionData]
 ) extends StepFunctionUserState

--- a/support-models/src/main/scala/com/gu/support/workers/states/CreateZuoraSubscriptionState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/CreateZuoraSubscriptionState.scala
@@ -4,12 +4,15 @@ import java.util.UUID
 
 import com.gu.support.promotions.PromoCode
 import com.gu.support.workers.{PaymentMethod, SalesforceContactRecord, User, _}
+import org.joda.time.LocalDate
+import com.gu.support.encoding.CustomCodecs.{decodeLocalTime, encodeLocalTime}
 
 case class CreateZuoraSubscriptionState(
   requestId: UUID,
   user: User,
   product: ProductType,
   paymentMethod: PaymentMethod,
+  firstDeliveryDate: Option[LocalDate],
   promoCode: Option[PromoCode],
   salesForceContact: SalesforceContactRecord,
   acquisitionData: Option[AcquisitionData]

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -49,6 +49,7 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
       state.user,
       state.product,
       paymentMethod,
+      state.firstDeliveryDate,
       state.promoCode,
       state.acquisitionData
     )

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
@@ -50,6 +50,7 @@ class CreateSalesforceContact extends ServicesHandler[CreateSalesforceContactSta
       state.user,
       state.product,
       state.paymentMethod,
+      state.firstDeliveryDate,
       state.promoCode,
       response.ContactRecord,
       state.acquisitionData


### PR DESCRIPTION
## Why are you doing this?

When clients start sending a first delivery date to `/subscribe/create`, this will need to be wired through to the CreateZuoraSubscription lambda so that paper/magazine fulfilment can be set up correctly.

[**Trello Card**](https://trello.com/b/TjUElW0B/simple-and-coherent-product-supporting-the-guardian)

## Changes

* Pass (optional) first delivery date through to CreateZuoraSubscription lambda

