### PR TITLE
Use first delivery date when creating a paper sub.

### DIFF
--- a/support-frontend/app/utils/CheckoutValidationRules.scala
+++ b/support-frontend/app/utils/CheckoutValidationRules.scala
@@ -65,6 +65,8 @@ object PaperValidation {
 
   import AddressAndCurrencyValidationRules._
 
+  def hasFirstDeliveryDate(createSupportWorkersRequest: CreateSupportWorkersRequest): Boolean = createSupportWorkersRequest.firstDeliveryDate.nonEmpty
+
   def passes(createSupportWorkersRequest: CreateSupportWorkersRequest): Boolean = {
     SimpleCheckoutFormValidation.passes(createSupportWorkersRequest) &&
     deliveredToUkAndPaidInGbp(createSupportWorkersRequest.country, createSupportWorkersRequest.product.currency)

--- a/support-frontend/app/utils/CheckoutValidationRules.scala
+++ b/support-frontend/app/utils/CheckoutValidationRules.scala
@@ -69,6 +69,7 @@ object PaperValidation {
 
   def passes(createSupportWorkersRequest: CreateSupportWorkersRequest): Boolean = {
     SimpleCheckoutFormValidation.passes(createSupportWorkersRequest) &&
-    deliveredToUkAndPaidInGbp(createSupportWorkersRequest.country, createSupportWorkersRequest.product.currency)
+    deliveredToUkAndPaidInGbp(createSupportWorkersRequest.country, createSupportWorkersRequest.product.currency) &&
+    hasFirstDeliveryDate(createSupportWorkersRequest)
   }
 }

--- a/support-frontend/test/utils/CheckoutValidationRulesTest.scala
+++ b/support-frontend/test/utils/CheckoutValidationRulesTest.scala
@@ -77,6 +77,11 @@ class PaperValidationTest extends FlatSpec with Matchers {
     PaperValidation.passes(requestDeliveredToUs) shouldBe true
   }
 
+  "PaperValidation.passes" should "fail if there is no first delivery date" in {
+    val requestDeliveredToUs = validPaperRequest.copy(firstDeliveryDate = None)
+    PaperValidation.passes(requestDeliveredToUs) shouldBe false
+  }
+
 }
 
 object TestData {

--- a/support-frontend/test/utils/CheckoutValidationRulesTest.scala
+++ b/support-frontend/test/utils/CheckoutValidationRulesTest.scala
@@ -4,6 +4,7 @@ import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
 import com.gu.i18n.{Country, Currency}
 import com.gu.support.catalog.{Everyday, HomeDelivery}
 import com.gu.support.workers._
+import org.joda.time.LocalDate
 import org.scalatest.{FlatSpec, Matchers}
 import services.stepfunctions.CreateSupportWorkersRequest
 
@@ -107,13 +108,14 @@ object TestData {
     postcode = None
   )
 
+  val someDateNextMonth = new LocalDate().plusMonths(1)
   val validPaperRequest = CreateSupportWorkersRequest(
     firstName = "grace",
     lastName = "hopper",
     country = Country.UK,
     state = None,
     product = Paper(Currency.GBP, Monthly, HomeDelivery, Everyday),
-    firstDeliveryDate = None,
+    firstDeliveryDate = Some(someDateNextMonth),
     paymentFields = StripePaymentFields("test-token"),
     ophanIds = OphanIds(None, None, None),
     referrerAcquisitionData = ReferrerAcquisitionData(None, None, None, None, None, None, None, None, None, None, None, None),

--- a/support-workers/src/main/scala/com/gu/support/workers/exceptions/BadRequestException.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/exceptions/BadRequestException.scala
@@ -1,0 +1,3 @@
+package com.gu.support.workers.exceptions
+
+class BadRequestException(message: String = "", cause: Throwable = None.orNull) extends Throwable(message, cause)

--- a/support-workers/src/main/scala/com/gu/support/workers/exceptions/RetryImplicits.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/exceptions/RetryImplicits.scala
@@ -48,6 +48,10 @@ object RetryImplicits {
     def asRetryException: RetryException = new RetryNone(message = throwable.getMessage, cause = throwable)
   }
 
+  implicit class BadRequestConversions(val throwable: BadRequestException) {
+    def asRetryException: RetryException = new RetryNone(message = throwable.getMessage, cause = throwable)
+  }
+
   implicit class OphanServiceErrorConversions(val error: AnalyticsServiceError) {
     import AnalyticsServiceError._
 

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -112,7 +112,7 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
     state.product match {
       case c: Contribution => c.build(config)
       case d: DigitalPack => d.build(config, state.user.billingAddress.country, state.promoCode, promotionService, isTestUser)
-      case p: Paper => p.build(state.user.billingAddress.country, state.promoCode, promotionService, isTestUser)
+      case p: Paper => p.build(state.user.billingAddress.country, state.promoCode, state.firstDeliveryDate, promotionService, isTestUser)
     }
   }
 


### PR DESCRIPTION
## Why are you doing this?

As of, https://github.com/guardian/support-frontend/pull/1560 requests to create a subscription can send an optional firstDeliveryDate.

This PR uses firstDeliveryDate to create a paper subscription.

The first delivery date is required for paper subscriptions, but irrelevant to digital pack subscriptions. I have added to the validation on `/subscribe/create` so that hopefully we won't end up in that state, but as long as firstDeliveryDate is an option, there's always the possibility it will be a None. 

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/9YE6DIdo/1959-update-support-workers-to-enable-it-to-create-print-subscriptions)

## Changes

* uses firstDeliveryDate to create a paper subscription.

## Screenshots
n/a
