### PR TITLE
Added click tracking to the required for fields explainer details.

### DIFF
--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormFields.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormFields.jsx
@@ -18,7 +18,7 @@ import {
   emailRegexPattern,
 } from 'helpers/formValidation';
 import { type UserTypeFromIdentityResponse } from 'helpers/identityApis';
-
+import {trackComponentClick} from 'helpers/tracking/ophanComponentEventTracking';
 import { NewContributionState } from './ContributionState';
 import { NewContributionTextInput } from './ContributionTextInput';
 import { MustSignIn } from './MustSignIn';
@@ -164,7 +164,12 @@ function FormFields(props: PropTypes) {
         formHasBeenSubmitted={checkoutFormHasBeenSubmitted}
         showRequiredLabel={showRequiredLabel}
       />
-      <details className={showRequiredLabel ? 'form-fields__required-explainer' : 'hidden'}>
+      <details
+        className={showRequiredLabel ? 'form-fields__required-explainer' : 'hidden'}
+        onClick={(event) => {
+          trackComponentClick('required-fields-explainer');
+        }}
+      >
         <summary >
           <div className="form-fields__required-explainer--summary-wrapper">
             Why are these details required?

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormFields.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormFields.jsx
@@ -18,7 +18,7 @@ import {
   emailRegexPattern,
 } from 'helpers/formValidation';
 import { type UserTypeFromIdentityResponse } from 'helpers/identityApis';
-import {trackComponentClick} from 'helpers/tracking/ophanComponentEventTracking';
+import { trackComponentClick } from 'helpers/tracking/ophanComponentEventTracking';
 import { NewContributionState } from './ContributionState';
 import { NewContributionTextInput } from './ContributionTextInput';
 import { MustSignIn } from './MustSignIn';
@@ -166,11 +166,19 @@ function FormFields(props: PropTypes) {
       />
       <details
         className={showRequiredLabel ? 'form-fields__required-explainer' : 'hidden'}
-        onClick={(event) => {
-          trackComponentClick('required-fields-explainer');
-        }}
       >
-        <summary >
+        <summary
+          onClick={(event) => {
+            if (event.detail !== 0) {
+              trackComponentClick('required-fields-explainer');
+            }
+          }}
+          onKeyPress={() => {
+            trackComponentClick('required-fields-explainer');
+          }}
+          role="button"
+          tabIndex={0}
+        >
           <div className="form-fields__required-explainer--summary-wrapper">
             Why are these details required?
             <span className="icon icon--arrows">

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -582,6 +582,10 @@ form {
   background: gu-colour(highlight-main);
 }
 
+.form__radio-group--tabs .form__radio-group-input:hover + .form__radio-group-label {
+  background: #E6CE05;
+}
+
 .form__radio-group--pills .form__radio-group-list {
   display: flex;
   flex-wrap: flex-wrap;
@@ -620,6 +624,10 @@ form {
 
 .form__radio-group--pills .form__radio-group-input:checked + .form__radio-group-label {
   background: gu-colour(highlight-main);
+}
+
+.form__radio-group--pills .form__radio-group-input:hover + .form__radio-group-label {
+  background: #E6CE05;
 }
 
 .form__radio-group--buttons .form__radio-group-item + .form__radio-group-item {


### PR DESCRIPTION
Added css hover state to payment frequency tabs and amount buttons with custom colour matching the 'Contribute...' button.

## Why are you doing this?

We think that some users don't realise that they can change the payment frequency and that the hover state will provide a clearer affordance.

We want to track how may users read the required fields explainer.

[**Trello Card for hover**](https://trello.com/c/oZEVCAot/328-implement-hover-states-for-product-type-and-amount-buttons)
[**Trello Card for tracking**](https://trello.com/c/148LzjFX/330-put-tracking-code-in-place-for-expandable-required-fields)

## Screenshots

![image](https://user-images.githubusercontent.com/42343800/53500438-3633fb00-3aa2-11e9-8d85-7f2489b8ce15.png)

