### PR TITLE
Copy update to remove 6 for 6 references

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -160,11 +160,11 @@ const content = (
       </Content>
       <Content>
         <Text title="Promotion terms and conditions">
-          <p>Offer subject to availability. Guardian News and Media Limited (&ldquo;GNM&rdquo;) reserves the right to withdraw this promotion at any time. For full 6 for 6 promotion terms and conditions, see <a target="_blank" rel="noopener noreferrer" href={`https://subscribe.theguardian.com/p/WWM99X/terms?country=${subsCountry}`}>here</a>.
+          <p>Offer subject to availability. Guardian News and Media Limited (&ldquo;GNM&rdquo;) reserves the right to withdraw this promotion at any time. For full annual promotion terms and conditions, see <a target="_blank" rel="noopener noreferrer" href={`https://subscribe.theguardian.com/p/WWM99X/terms?country=${subsCountry}`}>here</a>.
           </p>
         </Text>
         <Text title="Guardian Weekly terms and conditions">
-          <p>Subscriptions available to people aged 18 and over with a valid email address. For full details of Guardian Weekly print subscription services and their terms and conditions, see <a target="_blank" rel="noopener noreferrer" href="https://www.theguardian.com/guardian-weekly-subscription-terms-conditions">here</a>.
+          <p>Subscriptions available to people aged 18 and over with a valid email address. For full details of Guardian Weekly print subscription services and their terms and conditions, see <a target="_blank" rel="noopener noreferrer" href="https://subscribe.theguardian.com/p/10ANNUAL/terms">here</a>.
           </p>
         </Text>
       </Content>


### PR DESCRIPTION
## Why are you doing this?

We're updating copy on the Weekly subs landing page to remove references to 6 for 6.

## Changes

* Copy update

