### PR TITLE
Fix animated dots

### DIFF
--- a/support-frontend/app/views/test.scala.html
+++ b/support-frontend/app/views/test.scala.html
@@ -274,7 +274,7 @@
                       <div class="component-progress-message__dialog">
 
                         <div class="component-progress-message__message">Loading the page</div>
-                        <div class="component-animated-dots">
+                        <div class="component-animated-dots component-animated-dots--light">
                           <div class="component-animated-dots__bounce1"></div>
                           <div class="component-animated-dots__bounce2"></div>
                           <div class="component-animated-dots__bounce3"></div>


### PR DESCRIPTION
## Why are you doing this?
There was a change to the Animated Dots component that wasn't reflected in the placeholder CSS. This PR fixes it

