### PR TITLE
Support CSS modules

### DIFF
--- a/support-frontend/scripts/css.js
+++ b/support-frontend/scripts/css.js
@@ -1,0 +1,25 @@
+const path = require('path');
+
+const camelCaseToDash = str =>
+  str.replace(/([a-zA-Z])(?=[A-Z])/g, '$1-').toLowerCase();
+
+const getClassName = (resource, localName) => {
+  const { dir, name } = path.parse(resource);
+  const getStartingName = (p) => {
+    if (p === 'pages') { return null; } else if (p === 'components') { return 'component'; }
+    return p;
+  };
+  let identity =
+    camelCaseToDash([
+      getStartingName(dir.split(path.sep).splice(1, 1)[0]),
+      ...dir.split(path.sep).splice(2),
+      name.substr(0, name.indexOf('.')),
+    ].filter(Boolean).join('-'));
+
+  if (localName !== 'root') {
+    identity += `__${camelCaseToDash(localName)}`;
+  }
+  return identity;
+};
+
+module.exports = { getClassName };


### PR DESCRIPTION
## Why are you doing this?
Enables us to use `*.module.scss` files like Create-React-App does to get scoped classnames rather than type them ourselves. This is opt-in and only affects `.module.scss` files. I'm keen to try this for some things.

The classnames get compiled by webpack to a BEM-like scoped human readable form based on the folder they are in, with a couple extra rules.

- `.root` should be the top level style for a component and won't show up 
- `/components` and `/pages` become singular

### example use:

```jsx

import styles from './test.module.scss';

const InputWithButton = ({ onClick, ...props }) => (
  <div className={styles.root}>
    <div className={styles.header}>Test</div>
  </div>
```

```css
.root {
  color: red;
}
.header {
  color: blue;
}
```

results in
```html
  <div className="component-test">
    <div className="component-test__header">Test</div>
  </div>
```