### PR TITLE
add back some of the styling needed for the thank you page

### DIFF
--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYouContainer.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYouContainer.jsx
@@ -34,7 +34,7 @@ function ContributionThankYouContainer(props: PropTypes) {
 
 
   return (
-    <div className="gu-content__content">
+    <div className="gu-content__content gu-content__content-thankyou">
       {thankYouPageStage[props.thankYouPageStage]}
     </div>
   );

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -321,14 +321,22 @@ footer[role="contentinfo"] a {
 }
 
 .gu-content__content-thankyou {
-  width: 380px;
   background: gu-colour(neutral-100);
   padding: 0 10px;
+  overflow: hidden;
+  flex-grow: 1;
 
   @include mq($from: tablet) {
     border-color: gu-colour(neutral-86);
     border-style: none solid;
     border-width: 0 1px;
+    width: 380px;
+    margin-left: $content-left-margin-tablet
+  }
+
+  @include mq($from: leftCol) {
+    width: 380px;
+    margin-left: $content-left-margin-leftCol
   }
 
 }

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -36,6 +36,11 @@ body {
 
 .gu-content--contribution-thankyou {
   background: gu-colour(highlight-main);
+  .gu-content__main {
+    position: relative;
+    background-color: transparent;
+  }
+
 }
 
 .gu-content__main {
@@ -296,11 +301,7 @@ footer[role="contentinfo"] a {
   overflow: hidden;
   flex-grow: 1;
   margin: 0 auto;
-  width: 100%;
-  max-width: 1015px;
   border: none;
-  padding: 0;
-  background-color: transparent;
 
   @include mq($from: tablet) {
     margin-left: $content-left-margin-tablet
@@ -308,6 +309,26 @@ footer[role="contentinfo"] a {
 
   @include mq($from: leftCol) {
     margin-left: $content-left-margin-leftCol
+  }
+
+}
+
+.gu-content__content-contributions {
+  width: 100%;
+  max-width: 1015px;
+  padding: 0;
+  background-color: transparent;
+}
+
+.gu-content__content-thankyou {
+  width: 380px;
+  background: gu-colour(neutral-100);
+  padding: 0 10px;
+
+  @include mq($from: tablet) {
+    border-color: gu-colour(neutral-86);
+    border-style: none solid;
+    border-width: 0 1px;
   }
 
 }
@@ -369,6 +390,22 @@ footer[role="contentinfo"] a {
 
   @include mq($from: tablet) {
     padding: 0 $gu-h-spacing/2 $gu-v-spacing $gu-h-spacing/2;
+  }
+}
+
+.header {
+  border: 0;
+  left: 10px;
+  padding: $gu-v-spacing/2 $gu-h-spacing/2 $gu-v-spacing $gu-h-spacing/2;
+  width: 100%;
+  margin: 0 -10px;
+  font: bold 22px/1.15 $gu-headline;
+  color: gu-colour(neutral-7);
+
+  @include mq($from: tablet) {
+    border-bottom: 1px solid gu-colour(neutral-86);
+    font-size: 36px;
+    padding: 0 $gu-h-spacing/2 $gu-v-spacing*1.5 $gu-h-spacing/2;
   }
 }
 


### PR DESCRIPTION
## Why are you doing this?

So in https://github.com/guardian/support-frontend/pull/1563 I horribly broke the thank you page by not realising it shared a lot of the main styling.  So this pr basically adds in the cruicial parts that were lost.

### broken
![image](https://user-images.githubusercontent.com/7304387/53581220-11f51e80-3b75-11e9-824b-4d9196000442.png)

---

### originally before I broke it
![image](https://user-images.githubusercontent.com/7304387/53581383-5d0f3180-3b75-11e9-963f-79f708eb6310.png)
### mobile (originally before I broke it):
![image](https://user-images.githubusercontent.com/7304387/53581480-8cbe3980-3b75-11e9-8f5b-9b4488c2463b.png)

---

### this PR:
![image](https://user-images.githubusercontent.com/7304387/53581258-276a4880-3b75-11e9-9388-7128834044c6.png)

### this PR: mobile 320
![image](https://user-images.githubusercontent.com/7304387/53584112-d5c4bc80-3b7a-11e9-8de4-e0f81a7227f6.png)
### this PR: tablet
![image](https://user-images.githubusercontent.com/7304387/53584151-eaa15000-3b7a-11e9-8d2d-5b47131d029b.png)



@jranks123 
