### PR TITLE
Fix styling on contribute page

### DIFF
--- a/support-frontend/app/views/newContributions.scala.html
+++ b/support-frontend/app/views/newContributions.scala.html
@@ -37,7 +37,7 @@
         International (US$)</a></li><li class="countryGroups__item"><a href="/nz/contribute">
         New Zealand (NZ$)</a></li><li class="countryGroups__item"><a href="/ca/contribute">
         Canada (CA$)</a></li></ul></details></header><main role="main" class="gu-content__main">
-      <div class="gu-content__content gu-content__content--flex">
+      <div class="gu-content__content gu-content__content-contributions gu-content__content--flex">
         <div class="gu-content__blurb">
           <h1 class="header ">Help us deliver the independent journalism the world needs</h1>
           <p class="blurb">

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
@@ -177,7 +177,7 @@ function ContributionFormContainer(props: PropTypes) {
   return props.paymentComplete ?
     <Redirect to={props.thankYouRoute} />
     : (
-      <div className="gu-content__content gu-content__content--flex">
+      <div className="gu-content__content gu-content__content-contributions gu-content__content--flex">
         <div className={blurbClass}>
           <h1 className="gu-content__blurb--header">{countryGroupDetails.headerCopy}</h1>
           {countryGroupDetails.tickerJsonUrl ?


### PR DESCRIPTION
## Why are you doing this?

In the [previous PR](https://github.com/guardian/support-frontend/pull/1577) I added back some of the styling needed for the thank you page, but some of the new styling I had to move off to avoid affecting it.  I moved it to the gu-content__content-contributions class but forgot to add that class to the original non thank you page.  That meant the width wasn't limited at higher breakpoints

This PR fixes that.

|before|after|
|---|---|
|![image](https://user-images.githubusercontent.com/7304387/53635230-5e436b80-3c14-11e9-8040-d0c263b136b8.png)|![image](https://user-images.githubusercontent.com/7304387/53635245-67343d00-3c14-11e9-945f-830f018fbbad.png)|

320
![image](https://user-images.githubusercontent.com/7304387/53637015-f1cb6b00-3c19-11e9-93b9-87de84fdf0c8.png)
480
![image](https://user-images.githubusercontent.com/7304387/53637045-06a7fe80-3c1a-11e9-88e8-95ab03e09ea5.png)
740 (this looks a bit squashed but it doesn't seem to be worse than before)
![image](https://user-images.githubusercontent.com/7304387/53637068-17587480-3c1a-11e9-9172-cac2d7a36e71.png)
1250
![image](https://user-images.githubusercontent.com/7304387/53637361-dad94880-3c1a-11e9-96cf-c1c36082b951.png)
2560
![image](https://user-images.githubusercontent.com/7304387/53637338-c5641e80-3c1a-11e9-923e-29740fd733df.png)



[**Trello Card**](https://trello.com/c/i23v7T5J/435-bug-blurb-too-far-to-the-right)

@jranks123 