### PR TITLE
Drop monthly contributions test (and remove frequency tabs ordering test)

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -4,7 +4,7 @@ import { annualAmountsLower, annualAmountsFive, annualAmountsOther } from './ann
 
 // ----- Tests ----- //
 
-export type FrequencyTabsTestVariant = 'control' | 'sam' | 'mas' | 'notintest';
+export type DropMonthlyTestVariant = 'control' | 'variant' | 'notintest';
 export type LandingPageCopyTestVariant = 'control' | 'help' | 'notintest';
 
 export const tests: Tests = {
@@ -39,17 +39,14 @@ export const tests: Tests = {
     seed: 3,
   },
 
-  frequencyTabsOrdering: {
+  dropMonthly: {
     type: 'OTHER',
     variants: [
       {
         id: 'control', // SMA
       },
       {
-        id: 'sam',
-      },
-      {
-        id: 'mas',
+        id: 'variant',
       },
     ],
     audiences: {

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -43,7 +43,7 @@ export const tests: Tests = {
     type: 'OTHER',
     variants: [
       {
-        id: 'control', // SMA
+        id: 'control',
       },
       {
         id: 'variant',

--- a/support-frontend/assets/helpers/checkouts.js
+++ b/support-frontend/assets/helpers/checkouts.js
@@ -17,7 +17,7 @@ import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { Currency, IsoCurrency, SpokenCurrency } from 'helpers/internationalisation/currency';
 import { currencies, spokenCurrencies } from 'helpers/internationalisation/currency';
 import type { Amount, SelectedAmounts } from 'helpers/contributions';
-import type { FrequencyTabsTestVariant } from 'helpers/abTests/abtestDefinitions';
+import type { DropMonthlyTestVariant } from 'helpers/abTests/abtestDefinitions';
 
 
 // ----- Types ----- //
@@ -52,14 +52,13 @@ function getValidContributionTypesFromUrlOrElse(fallback: ContributionType[]): C
   return fallback;
 }
 
-function getValidContributionTypes(frequencyTabsOrdering: FrequencyTabsTestVariant): ContributionType[] {
+function getValidContributionTypes(dropMonthly: DropMonthlyTestVariant): ContributionType[] {
   const mappings = {
     notintest: ['ONE_OFF', 'MONTHLY', 'ANNUAL'],
     control: ['ONE_OFF', 'MONTHLY', 'ANNUAL'],
-    mas: ['MONTHLY', 'ANNUAL', 'ONE_OFF'],
-    sam: ['ONE_OFF', 'ANNUAL', 'MONTHLY'],
+    variant: ['ONE_OFF', 'ANNUAL'],
   };
-  return getValidContributionTypesFromUrlOrElse(mappings[frequencyTabsOrdering]);
+  return getValidContributionTypesFromUrlOrElse(mappings[dropMonthly]);
 }
 
 function toHumanReadableContributionType(contributionType: ContributionType): 'Single' | 'Monthly' | 'Annual' {

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionTypeTabs.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionTypeTabs.jsx
@@ -16,7 +16,7 @@ import { trackComponentClick } from 'helpers/tracking/ophanComponentEventTrackin
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { Switches } from 'helpers/settings';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import type { FrequencyTabsTestVariant } from 'helpers/abTests/abtestDefinitions';
+import type { DropMonthlyTestVariant } from 'helpers/abTests/abtestDefinitions';
 import { type State } from '../contributionsLandingReducer';
 import { updateContributionTypeAndPaymentMethod } from '../contributionsLandingActions';
 
@@ -27,7 +27,7 @@ type PropTypes = {|
   countryId: IsoCountry,
   countryGroupId: CountryGroupId,
   switches: Switches,
-  frequencyTabsOrdering: FrequencyTabsTestVariant,
+  dropMonthlyVariant: DropMonthlyTestVariant,
   onSelectContributionType: (ContributionType, Switches, IsoCountry, CountryGroupId) => void,
 |};
 
@@ -36,7 +36,7 @@ const mapStateToProps = (state: State) => ({
   contributionType: state.page.form.contributionType,
   countryId: state.common.internationalisation.countryId,
   switches: state.common.settings.switches,
-  frequencyTabsOrdering: state.common.abParticipations.frequencyTabsOrdering,
+  dropMonthlyVariant: state.common.abParticipations.dropMonthly,
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -59,7 +59,7 @@ function ContributionTypeTabs(props: PropTypes) {
     <fieldset className={classNameWithModifiers('form__radio-group', ['tabs', 'contribution-type'])}>
       <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>Recurrence</legend>
       <ul className="form__radio-group-list form__radio-group-list--border">
-        {getValidContributionTypes(props.frequencyTabsOrdering).map((contributionType: ContributionType) => (
+        {getValidContributionTypes(props.dropMonthlyVariant).map((contributionType: ContributionType) => (
           <li className="form__radio-group-item">
             <input
               id={`contributionType-${contributionType}`}

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -20,8 +20,8 @@ import {
   type ThirdPartyPaymentLibrary,
 } from 'helpers/checkouts';
 import { type ContributionType, type PaymentMethod } from 'helpers/contributions';
+import type { DropMonthlyTestVariant } from 'helpers/abTests/abtestDefinitions';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
-import type { FrequencyTabsTestVariant } from 'helpers/abTests/abtestDefinitions';
 import {
   type Action,
   checkIfEmailHasPassword,
@@ -52,14 +52,14 @@ function getInitialPaymentMethod(
   );
 }
 
-function getInitialContributionType(frequencyTabsOrdering: FrequencyTabsTestVariant): ContributionType {
+function getInitialContributionType(dropMonthlyVariant: DropMonthlyTestVariant): ContributionType {
   const contributionType = getContributionTypeFromUrlOrElse(getContributionTypeFromSessionOrElse('ANNUAL'));
-
+  console.log(contributionType);
   return (
     // make sure we don't select a contribution type which isn't on the page
-    getValidContributionTypes(frequencyTabsOrdering).includes(contributionType)
+    getValidContributionTypes(dropMonthlyVariant).includes(contributionType)
       ? contributionType
-      : getValidContributionTypes(frequencyTabsOrdering)[0]
+      : getValidContributionTypes(dropMonthlyVariant)[0]
   );
 }
 
@@ -132,9 +132,9 @@ function selectInitialAmounts(state: State, dispatch: Function) {
 function selectInitialContributionTypeAndPaymentMethod(state: State, dispatch: Function) {
   const { countryId } = state.common.internationalisation;
   const { switches } = state.common.settings;
-  const { frequencyTabsOrdering } = state.common.abParticipations;
-  if (frequencyTabsOrdering === 'notintest' || frequencyTabsOrdering === 'control' || frequencyTabsOrdering === 'mas' || frequencyTabsOrdering === 'sam') {
-    const contributionType = getInitialContributionType(frequencyTabsOrdering);
+  const dropMonthlyVariant = state.common.abParticipations.dropMonthly;
+  if (dropMonthlyVariant === 'notintest' || dropMonthlyVariant === 'control' || dropMonthlyVariant === 'variant') {
+    const contributionType = getInitialContributionType(dropMonthlyVariant);
     const paymentMethod = getInitialPaymentMethod(contributionType, countryId, switches);
     dispatch(updateContributionTypeAndPaymentMethod(contributionType, paymentMethod));
   }

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -54,7 +54,6 @@ function getInitialPaymentMethod(
 
 function getInitialContributionType(dropMonthlyVariant: DropMonthlyTestVariant): ContributionType {
   const contributionType = getContributionTypeFromUrlOrElse(getContributionTypeFromSessionOrElse('ANNUAL'));
-  console.log(contributionType);
   return (
     // make sure we don't select a contribution type which isn't on the page
     getValidContributionTypes(dropMonthlyVariant).includes(contributionType)


### PR DESCRIPTION
## Why are you doing this?
The Frequency tabs ordering test was underwhelming, so we are dropping it in favour of this "Drop monthly" test.

|Control|Variant|
|---|---|
|![image](https://user-images.githubusercontent.com/2844554/53652499-f1929600-3c40-11e9-9b4d-79a7a4c6bedd.png)|![variant](https://user-images.githubusercontent.com/2844554/53652510-f9523a80-3c40-11e9-8f5f-84df5c43b37c.png)|


(Note: just look at the differences in Contribution Types, not the copy or amounts, those are separate tests that happen to be running)

