### PR TITLE
Get the paper checkout to call the create endpoint to create paper subs.

### DIFF
--- a/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
+++ b/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
@@ -11,6 +11,8 @@ import { logPromise, pollUntilPromise } from 'helpers/promise';
 import { logException } from 'helpers/logger';
 import { fetchJson, getRequestOptions, requestOptions } from 'helpers/fetch';
 import trackConversion from 'helpers/tracking/conversions';
+import { type PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
+import { type PaperProductOptions } from 'helpers/productPrice/productOptions';
 
 import { type ThankYouPageStage } from '../../pages/new-contributions-landing/contributionsLandingReducer';
 
@@ -27,7 +29,14 @@ type DigitalSubscription = {|
   billingPeriod: BillingPeriod,
 |};
 
-type ProductFields = RegularContribution | DigitalSubscription
+type PaperSubscription = {|
+  currency: string,
+  billingPeriod: BillingPeriod,
+  fulfilmentOptions: PaperFulfilmentOptions,
+  productOptions: PaperProductOptions,
+|};
+
+type ProductFields = RegularContribution | DigitalSubscription | PaperSubscription
 
 type RegularPayPalPaymentFields = {| baid: string |};
 
@@ -60,6 +69,7 @@ export type RegularPaymentRequest = {|
   deliveryAddress: Option<RegularPaymentRequestAddress>,
   email: string,
   product: ProductFields,
+  firstDeliveryDate: Option<string>,
   paymentFields: RegularPaymentFields,
   ophanIds: OphanIds,
   referrerAcquisitionData: ReferrerAcquisitionData,

--- a/support-frontend/assets/helpers/routes.js
+++ b/support-frontend/assets/helpers/routes.js
@@ -25,7 +25,7 @@ const routes: {
   payPalCreateAgreement: '/paypal/create-agreement',
   directDebitCheckAccount: '/direct-debit/check-account',
   payPalRestReturnURL: '/paypal/rest/return',
-  digitalSubscriptionCreate: '/subscribe/create',
+  subscriptionCreate: '/subscribe/create',
   showcase: '/support',
   subscriptionsLanding: '/subscribe',
   digitalSubscriptionLanding: '/subscribe/digital',

--- a/support-frontend/assets/pages/digital-subscription-checkout/helpers/paymentProviders.js
+++ b/support-frontend/assets/pages/digital-subscription-checkout/helpers/paymentProviders.js
@@ -84,7 +84,7 @@ function onPaymentAuthorised(paymentAuthorisation: PaymentAuthorisation, dispatc
 
   dispatch(setFormSubmitted(true));
   postRegularPaymentRequest(
-    routes.digitalSubscriptionCreate,
+    routes.subscriptionCreate,
     data,
     state.common.abParticipations,
     state.page.csrf,

--- a/support-frontend/assets/pages/digital-subscription-checkout/helpers/paymentProviders.js
+++ b/support-frontend/assets/pages/digital-subscription-checkout/helpers/paymentProviders.js
@@ -57,6 +57,7 @@ function buildRegularPaymentRequest(state: State, paymentAuthorisation: PaymentA
     email,
     telephoneNumber: telephone,
     product,
+    firstDeliveryDate: null,
     paymentFields,
     ophanIds: getOphanIds(),
     referrerAcquisitionData: state.common.referrerAcquisitionData,

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -276,6 +276,7 @@ const regularPaymentRequestFromAuthorisation = (
     currency: state.common.internationalisation.currencyId,
     billingPeriod: state.page.form.contributionType === 'MONTHLY' ? Monthly : Annual,
   },
+  firstDeliveryDate: null,
   paymentFields: regularPaymentFieldsFromAuthorisation(authorisation),
   ophanIds: getOphanIds(),
   referrerAcquisitionData: state.common.referrerAcquisitionData,

--- a/support-frontend/assets/pages/paper-subscription-checkout/helpers/paymentProviders.js
+++ b/support-frontend/assets/pages/paper-subscription-checkout/helpers/paymentProviders.js
@@ -6,16 +6,76 @@ import {
   setupStripeCheckout,
 } from 'helpers/paymentIntegrations/stripeCheckout';
 import { type IsoCountry } from 'helpers/internationalisation/country';
-import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
+import { type PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
 import {
   type PaymentResult,
+  type RegularPaymentRequest,
+  postRegularPaymentRequest, regularPaymentFieldsFromAuthorisation,
 } from 'helpers/paymentIntegrations/readerRevenueApis';
 import { type Dispatch } from 'redux';
 import { openDirectDebitPopUp } from 'components/directDebit/directDebitActions';
 import { finalPrice as paperFinalPrice } from 'helpers/productPrice/paperProductPrices';
+import { routes } from 'helpers/routes';
+import { getQueryParameter } from 'helpers/url';
+import { getOphanIds, getSupportAbTests } from 'helpers/tracking/acquisitions';
 import { type State, setSubmissionError, setFormSubmitted, type Action, setStage } from '../paperSubscriptionCheckoutReducer';
 
-function onPaymentAuthorised(paymentAuthorisation: PaymentAuthorisation, dispatch: Dispatch<Action>) {
+function buildRegularPaymentRequest(state: State, paymentAuthorisation: PaymentAuthorisation): RegularPaymentRequest {
+  const { currencyId, countryId } = state.common.internationalisation;
+  const {
+    firstName,
+    lastName,
+    billingAddressLine1,
+    billingAddressLine2,
+    billingTownCity,
+    billingPostcode,
+    email,
+    telephone,
+  } = state.page.checkout;
+
+  const product = {
+    currency: currencyId,
+    billingPeriod: 'Monthly',
+    fulfilmentOptions: state.page.checkout.fulfilmentOption,
+    productOptions: state.page.checkout.productOption,
+  };
+
+  console.log(product);
+
+  const paymentFields = regularPaymentFieldsFromAuthorisation(paymentAuthorisation);
+
+  return {
+    firstName,
+    lastName,
+    billingAddress: {
+      lineOne: billingAddressLine1,
+      lineTwo: billingAddressLine2,
+      city: billingTownCity,
+      state: null,
+      postCode: billingPostcode,
+      country: countryId,
+    },
+    deliveryAddress: {
+      lineOne: billingAddressLine1,
+      lineTwo: billingAddressLine2,
+      city: billingTownCity,
+      state: null,
+      postCode: billingPostcode,
+      country: countryId,
+    },
+    email,
+    telephoneNumber: telephone,
+    product,
+    firstDeliveryDate: state.page.checkout.startDate,
+    paymentFields,
+    ophanIds: getOphanIds(),
+    referrerAcquisitionData: state.common.referrerAcquisitionData,
+    supportAbTests: getSupportAbTests(state.common.abParticipations, state.common.optimizeExperiments),
+    promoCode: getQueryParameter('promoCode'),
+  };
+}
+
+function onPaymentAuthorised(paymentAuthorisation: PaymentAuthorisation, dispatch: Dispatch<Action>, state: State) {
   const handleSubscribeResult = (result: PaymentResult) => {
     switch (result.paymentStatus) {
       case 'success':
@@ -30,7 +90,18 @@ function onPaymentAuthorised(paymentAuthorisation: PaymentAuthorisation, dispatc
   };
 
   dispatch(setFormSubmitted(true));
-  Promise.resolve({ paymentStatus: 'success' }).then(handleSubscribeResult);
+
+  const data = buildRegularPaymentRequest(state, paymentAuthorisation);
+
+  postRegularPaymentRequest(
+    routes.digitalSubscriptionCreate,
+    data,
+    state.common.abParticipations,
+    state.page.csrf,
+    () => {},
+    () => {},
+  ).then(handleSubscribeResult);
+  // Promise.resolve({ paymentStatus: 'success' }).then(handleSubscribeResult);
 }
 
 function showStripe(
@@ -45,7 +116,7 @@ function showStripe(
     state.page.checkout.productOption,
   );
 
-  const onAuthorised = (pa: PaymentAuthorisation) => onPaymentAuthorised(pa, dispatch);
+  const onAuthorised = (pa: PaymentAuthorisation) => onPaymentAuthorised(pa, dispatch, state);
 
   loadStripe()
     .then(() => setupStripeCheckout(onAuthorised, 'REGULAR', currency, isTestUser))

--- a/support-frontend/assets/pages/paper-subscription-checkout/helpers/paymentProviders.js
+++ b/support-frontend/assets/pages/paper-subscription-checkout/helpers/paymentProviders.js
@@ -101,7 +101,6 @@ function onPaymentAuthorised(paymentAuthorisation: PaymentAuthorisation, dispatc
     () => {},
     () => {},
   ).then(handleSubscribeResult);
-  // Promise.resolve({ paymentStatus: 'success' }).then(handleSubscribeResult);
 }
 
 function showStripe(

--- a/support-frontend/assets/pages/paper-subscription-checkout/helpers/paymentProviders.js
+++ b/support-frontend/assets/pages/paper-subscription-checkout/helpers/paymentProviders.js
@@ -44,25 +44,29 @@ function buildRegularPaymentRequest(state: State, paymentAuthorisation: PaymentA
 
   const paymentFields = regularPaymentFieldsFromAuthorisation(paymentAuthorisation);
 
+  const billingAddress = {
+    lineOne: billingAddressLine1,
+    lineTwo: billingAddressLine2,
+    city: billingTownCity,
+    state: null,
+    postCode: billingPostcode,
+    country: countryId,
+  };
+
+  const deliveryAddress = {
+    lineOne: billingAddressLine1,
+    lineTwo: billingAddressLine2,
+    city: billingTownCity,
+    state: null,
+    postCode: billingPostcode,
+    country: countryId,
+  };
+
   return {
     firstName,
     lastName,
-    billingAddress: {
-      lineOne: billingAddressLine1,
-      lineTwo: billingAddressLine2,
-      city: billingTownCity,
-      state: null,
-      postCode: billingPostcode,
-      country: countryId,
-    },
-    deliveryAddress: {
-      lineOne: billingAddressLine1,
-      lineTwo: billingAddressLine2,
-      city: billingTownCity,
-      state: null,
-      postCode: billingPostcode,
-      country: countryId,
-    },
+    billingAddress,
+    deliveryAddress,
     email,
     telephoneNumber: telephone,
     product,
@@ -94,7 +98,7 @@ function onPaymentAuthorised(paymentAuthorisation: PaymentAuthorisation, dispatc
   const data = buildRegularPaymentRequest(state, paymentAuthorisation);
 
   postRegularPaymentRequest(
-    routes.digitalSubscriptionCreate,
+    routes.subscriptionCreate,
     data,
     state.common.abParticipations,
     state.page.csrf,

--- a/support-frontend/assets/pages/paper-subscription-checkout/helpers/paymentProviders.js
+++ b/support-frontend/assets/pages/paper-subscription-checkout/helpers/paymentProviders.js
@@ -18,6 +18,8 @@ import { finalPrice as paperFinalPrice } from 'helpers/productPrice/paperProduct
 import { routes } from 'helpers/routes';
 import { getQueryParameter } from 'helpers/url';
 import { getOphanIds, getSupportAbTests } from 'helpers/tracking/acquisitions';
+import { Monthly } from 'helpers/billingPeriods';
+
 import { type State, setSubmissionError, setFormSubmitted, type Action, setStage } from '../paperSubscriptionCheckoutReducer';
 
 function buildRegularPaymentRequest(state: State, paymentAuthorisation: PaymentAuthorisation): RegularPaymentRequest {
@@ -35,12 +37,10 @@ function buildRegularPaymentRequest(state: State, paymentAuthorisation: PaymentA
 
   const product = {
     currency: currencyId,
-    billingPeriod: 'Monthly',
+    billingPeriod: Monthly,
     fulfilmentOptions: state.page.checkout.fulfilmentOption,
     productOptions: state.page.checkout.productOption,
   };
-
-  console.log(product);
 
   const paymentFields = regularPaymentFieldsFromAuthorisation(paymentAuthorisation);
 

--- a/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckoutReducer.js
+++ b/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckoutReducer.js
@@ -207,8 +207,8 @@ const formActionCreators = {
       type: 'SET_PAYMENT_METHOD',
       paymentMethod,
     }),
-  onPaymentAuthorised: (authorisation: PaymentAuthorisation) => (dispatch: Dispatch<Action>) =>
-    onPaymentAuthorised(authorisation, dispatch),
+  onPaymentAuthorised: (authorisation: PaymentAuthorisation) => (dispatch: Dispatch<Action>, getState: () => State) =>
+    onPaymentAuthorised(authorisation, dispatch, getState()),
   submitForm: () => (dispatch: Dispatch<Action>, getState: () => State) => submitForm(dispatch, getState()),
 };
 


### PR DESCRIPTION
## Why are you doing this?
So that using the paper checkout will result in the ajax call `POST /subscribe/create`, which will in turn create a paper subscription via `support-workers`

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/s3bTXdKj/2281-get-the-paper-checkout-to-call-the-create-endpoint-to-create-paper-subs)

## Changes
* `onPaymentAuthorised` now makes a regular payment request 

Note: currently copies the same address as both billing and delivery address.

## Screenshots

