### PR TITLE
Update contributionsLanding.scss

### DIFF
--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -379,7 +379,8 @@ footer[role="contentinfo"] a {
   border-bottom: 1px solid gu-colour(neutral-86);
 
   li label {
-    font-family: $gu-titlepiece;
+    font-family: $gu-headline;
+    font-weight: 600;
     font-size: 22px;
   }
 }


### PR DESCRIPTION
Change to the contributions landing page: We shouldn't use Titlepiece for smaller font sizes, so we are changing the tab labels to Headline.

Current:
<img width="456" alt="screen shot 2019-03-05 at 08 27 58" src="https://user-images.githubusercontent.com/20684719/53791235-d36ab580-3f20-11e9-9644-cf726ff46a68.png">

Update:
<img width="452" alt="screen_shot_2019-03-01_at_15 57 50" src="https://user-images.githubusercontent.com/20684719/53791293-eed5c080-3f20-11e9-8c1b-d208824dcef1.png">