### PR TITLE
Enable ticker for AU

### DIFF
--- a/support-frontend/assets/helpers/checkouts.js
+++ b/support-frontend/assets/helpers/checkouts.js
@@ -60,7 +60,7 @@ function getValidContributionTypes(countryGroupId: CountryGroupId): Contribution
   const mappings = {
     GBPCountries: defaultContributionTypes,
     UnitedStates: defaultContributionTypes,
-    AUDCountries: contributionTypesNoMonthly,
+    AUDCountries: ['ONE_OFF'],
     EURCountries: contributionTypesNoMonthly,
     International: contributionTypesNoMonthly,
     NZDCountries: contributionTypesNoMonthly,

--- a/support-frontend/assets/helpers/checkouts.js
+++ b/support-frontend/assets/helpers/checkouts.js
@@ -60,7 +60,7 @@ function getValidContributionTypes(countryGroupId: CountryGroupId): Contribution
   const mappings = {
     GBPCountries: defaultContributionTypes,
     UnitedStates: defaultContributionTypes,
-    AUDCountries: ['ONE_OFF'],
+    AUDCountries: contributionTypesNoMonthly,
     EURCountries: contributionTypesNoMonthly,
     International: contributionTypesNoMonthly,
     NZDCountries: contributionTypesNoMonthly,

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -78,7 +78,6 @@ type PropTypes = {|
   isTestUser: boolean,
   country: IsoCountry,
   stripePaymentRequestButtonMethod: StripePaymentRequestButtonMethod,
-  message: ?React$Element<string>,
 |};
 
 // We only want to use the user state value if the form state value has not been changed since it was initialised,
@@ -210,7 +209,6 @@ function ContributionForm(props: PropTypes) {
   return (
     <form onSubmit={onSubmit(props)} className={classNameWithModifiers('form', ['contribution'])} noValidate>
       <div>
-        {props.message ? <div className={classNameWithModifiers('form', ['message'])}>{props.message}</div> : null}
         <ContributionTypeTabs />
         <NewContributionAmount
           checkOtherAmount={checkAmount}

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
@@ -116,6 +116,7 @@ const countryGroupSpecificDetails: {
   AUDCountries: {
     ...defaultHeaderCopyAndContributeCopy,
     headerCopy: australiaHeadline,
+    tickerJsonUrl: '/ticker.json',
   },
   International: defaultHeaderCopyAndContributeCopy,
   NZDCountries: defaultHeaderCopyAndContributeCopy,

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
@@ -107,10 +107,10 @@ const defaultHeaderCopyAndContributeCopy: CountryMetaData = {
 
 const australiaHeadline = 'Help\xa0us\xa0deliver\nthe\xa0independent\njournalism\nAustralia\xa0needs';
 
-const ausCampaignFormMessage = (
-  <div>
-    <div>Make a contribution</div>
-    <div>to our dedicated series ’Climate Crunch’</div>
+const australiaClimateCampaignFormMessage = (
+  <div className="climate-crunch">
+    <div className="climate-crunch__headline">Make a contribution</div>
+    <div className="climate-crunch__body">to our dedicated series ‘Climate Crunch’</div>
   </div>
 );
 
@@ -124,7 +124,7 @@ const countryGroupSpecificDetails: {
     ...defaultHeaderCopyAndContributeCopy,
     headerCopy: australiaHeadline,
     tickerJsonUrl: '/ticker.json',
-    formMessage: ausCampaignFormMessage,
+    formMessage: australiaClimateCampaignFormMessage,
   },
   International: defaultHeaderCopyAndContributeCopy,
   NZDCountries: defaultHeaderCopyAndContributeCopy,
@@ -157,9 +157,11 @@ function ContributionFormContainer(props: PropTypes) {
           {countryGroupDetails.tickerJsonUrl ?
             <ContributionTicker tickerJsonUrl={countryGroupDetails.tickerJsonUrl} /> : null
           }
+          {countryGroupDetails.formMessage ?
+            <div className="gu-content__form__message">{countryGroupDetails.formMessage}</div> : null
+          }
           <NewContributionForm
             onPaymentAuthorisation={onPaymentAuthorisation}
-            message={countryGroupDetails.formMessage}
           />
         </div>
         <DirectDebitPopUpForm

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
@@ -140,15 +140,15 @@ function ContributionFormContainer(props: PropTypes) {
       <div className="gu-content__content gu-content__content-contributions gu-content__content--flex">
         <div className="gu-content__blurb">
           <h1 className="gu-content__blurb-header">{countryGroupDetails.headerCopy}</h1>
-          {countryGroupDetails.tickerJsonUrl ?
-            <ContributionTicker tickerJsonUrl={countryGroupDetails.tickerJsonUrl} /> : null
-          }
           { countryGroupDetails.contributeCopy ?
             <p className="gu-content__blurb-blurb">{countryGroupDetails.contributeCopy}</p> : null
           }
         </div>
 
         <div className="gu-content__form">
+          {countryGroupDetails.tickerJsonUrl ?
+            <ContributionTicker tickerJsonUrl={countryGroupDetails.tickerJsonUrl} /> : null
+          }
           <NewContributionForm
             onPaymentAuthorisation={onPaymentAuthorisation}
             message={countryGroupDetails.formMessage}

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
@@ -107,6 +107,13 @@ const defaultHeaderCopyAndContributeCopy: CountryMetaData = {
 
 const australiaHeadline = 'Help\xa0us\xa0deliver\nthe\xa0independent\njournalism\nAustralia\xa0needs';
 
+const ausCampaignFormMessage = (
+  <div>
+    <div>Make a contribution</div>
+    <div>to our dedicated series ’Climate Crunch’</div>
+  </div>
+);
+
 const countryGroupSpecificDetails: {
   [CountryGroupId]: CountryMetaData
 } = {
@@ -117,6 +124,7 @@ const countryGroupSpecificDetails: {
     ...defaultHeaderCopyAndContributeCopy,
     headerCopy: australiaHeadline,
     tickerJsonUrl: '/ticker.json',
+    formMessage: ausCampaignFormMessage,
   },
   International: defaultHeaderCopyAndContributeCopy,
   NZDCountries: defaultHeaderCopyAndContributeCopy,

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
@@ -5,6 +5,7 @@
 import type { ContributionType, PaymentMethod } from 'helpers/contributions';
 import type { Csrf } from 'helpers/csrf/csrfReducer';
 import type { Status } from 'helpers/settings';
+import { getPathAfterRoute } from 'helpers/url';
 import { type ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -142,6 +143,8 @@ function ContributionFormContainer(props: PropTypes) {
 
   const countryGroupDetails = countryGroupSpecificDetails[props.countryGroupId];
 
+  const tickerUrl = countryGroupDetails.tickerJsonUrl || getPathAfterRoute() ? '/ticker.json' : undefined;
+
   return props.paymentComplete ?
     <Redirect to={props.thankYouRoute} />
     : (
@@ -154,8 +157,8 @@ function ContributionFormContainer(props: PropTypes) {
         </div>
 
         <div className="gu-content__form">
-          {countryGroupDetails.tickerJsonUrl ?
-            <ContributionTicker tickerJsonUrl={countryGroupDetails.tickerJsonUrl} /> : null
+          {tickerUrl ?
+            <ContributionTicker tickerJsonUrl={tickerUrl} /> : null
           }
           {countryGroupDetails.formMessage ?
             <div className="gu-content__form__message">{countryGroupDetails.formMessage}</div> : null

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
@@ -5,7 +5,7 @@
 import type { ContributionType, PaymentMethod } from 'helpers/contributions';
 import type { Csrf } from 'helpers/csrf/csrfReducer';
 import type { Status } from 'helpers/settings';
-import { getPathAfterRoute } from 'helpers/url';
+import { isFrontlineCampaign, getQueryParameter } from 'helpers/url';
 import { type ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -108,10 +108,10 @@ const defaultHeaderCopyAndContributeCopy: CountryMetaData = {
 
 const australiaHeadline = 'Help\xa0us\xa0deliver\nthe\xa0independent\njournalism\nAustralia\xa0needs';
 
-const australiaClimateCampaignFormMessage = (
-  <div className="climate-crunch">
-    <div className="climate-crunch__headline">Make a contribution</div>
-    <div className="climate-crunch__body">to our dedicated series ‘Climate Crunch’</div>
+const australiaFrontlineFormMessage = (
+  <div className="frontline-campaign">
+    <div className="frontline-campaign__headline">Make a contribution</div>
+    <div className="frontline-campaign__body">to our dedicated series ‘Climate Crunch’</div>
   </div>
 );
 
@@ -124,8 +124,6 @@ const countryGroupSpecificDetails: {
   AUDCountries: {
     ...defaultHeaderCopyAndContributeCopy,
     headerCopy: australiaHeadline,
-    tickerJsonUrl: '/ticker.json',
-    formMessage: australiaClimateCampaignFormMessage,
   },
   International: defaultHeaderCopyAndContributeCopy,
   NZDCountries: defaultHeaderCopyAndContributeCopy,
@@ -143,7 +141,13 @@ function ContributionFormContainer(props: PropTypes) {
 
   const countryGroupDetails = countryGroupSpecificDetails[props.countryGroupId];
 
-  const tickerUrl = countryGroupDetails.tickerJsonUrl || getPathAfterRoute() ? '/ticker.json' : undefined;
+  const tickerUrl =
+    countryGroupDetails.tickerJsonUrl ||
+    getQueryParameter('ticker') === 'true' ? '/ticker.json' : undefined;
+
+  const formMessage =
+    countryGroupDetails.formMessage ||
+    isFrontlineCampaign() ? australiaFrontlineFormMessage : undefined;
 
   return props.paymentComplete ?
     <Redirect to={props.thankYouRoute} />
@@ -160,8 +164,8 @@ function ContributionFormContainer(props: PropTypes) {
           {tickerUrl ?
             <ContributionTicker tickerJsonUrl={tickerUrl} /> : null
           }
-          {countryGroupDetails.formMessage ?
-            <div className="gu-content__form__message">{countryGroupDetails.formMessage}</div> : null
+          {formMessage ?
+            <div className="gu-content__form__message">{formMessage}</div> : null
           }
           <NewContributionForm
             onPaymentAuthorisation={onPaymentAuthorisation}

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionTicker/ContributionTicker.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionTicker/ContributionTicker.jsx
@@ -96,7 +96,6 @@ export class ContributionTicker extends Component<PropTypes, StateTypes> {
 
     return (
       <div className={wrapperClassName}>
-        <div className="contributions-landing-ticker__border" />
         <div className="contributions-landing-ticker__values">
           <div className="contributions-landing-ticker__so-far">
             <div className="contributions-landing-ticker__count">${Math.floor(this.state.totalSoFar).toLocaleString()}</div>

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionTicker/ContributionTicker.scss
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionTicker/ContributionTicker.scss
@@ -6,6 +6,7 @@ $progess-bar-height: 10px;
   padding: 18px 0 28px 0;
   margin: 0 -10px;
   border-bottom: 1px solid gu-colour(neutral-86);
+  font-family: $gu-headline;
 }
 
 .contributions-landing-ticker--hidden {
@@ -43,7 +44,6 @@ $progess-bar-height: 10px;
 }
 
 .contributions-landing-ticker__so-far .contributions-landing-ticker__count {
-  font-family: $gu-titlepiece;
   font-size: 24px;
   font-weight: 800;
 }

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionTicker/ContributionTicker.scss
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionTicker/ContributionTicker.scss
@@ -3,12 +3,9 @@
 $progess-bar-height: 10px;
 
 .contributions-landing-ticker {
-  padding-bottom: $gu-h-spacing;
-}
-
-.contributions-landing-ticker__border {
+  padding-top: 20px;
+  margin: 0 -10px 30px -10px;
   border-top: 1px solid gu-colour(neutral-86);
-  margin: 0 -10px;
 }
 
 .contributions-landing-ticker--hidden {
@@ -27,10 +24,17 @@ $progess-bar-height: 10px;
   flex-direction: column;
 }
 
+.contributions-landing-ticker__values,
+.contributions-landing-ticker__progress-bar {
+  margin: 0 10px;
+}
+
 .contributions-landing-ticker__values {
   display: flex;
   justify-content: space-between;
   align-items: flex-end;
+  padding-bottom: 6px;
+  line-height: 1;
 }
 
 .contributions-landing-ticker__goal, .contributions-landing-ticker__so-far {
@@ -40,9 +44,8 @@ $progess-bar-height: 10px;
 
 .contributions-landing-ticker__so-far .contributions-landing-ticker__count {
   font-family: $gu-titlepiece;
-  font-size: 32px;
+  font-size: 24px;
   font-weight: 800;
-  //color: gu-colour(opinion-bright);
 }
 
 .contributions-landing-ticker__goal {

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionTicker/ContributionTicker.scss
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionTicker/ContributionTicker.scss
@@ -42,7 +42,7 @@ $progess-bar-height: 10px;
   font-family: $gu-titlepiece;
   font-size: 32px;
   font-weight: 800;
-  color: gu-colour(opinion-bright);
+  //color: gu-colour(opinion-bright);
 }
 
 .contributions-landing-ticker__goal {
@@ -70,7 +70,7 @@ $progess-bar-height: 10px;
 }
 
 .contributions-landing-ticker__filled-progress {
-  background-color: gu-colour(opinion-bright);
+  background-color: gu-colour(highlight-main);
   position: absolute;
   top: 0;
   left: 0;

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionTicker/ContributionTicker.scss
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionTicker/ContributionTicker.scss
@@ -3,9 +3,9 @@
 $progess-bar-height: 10px;
 
 .contributions-landing-ticker {
-  padding-top: 20px;
-  margin: 0 -10px 30px -10px;
-  border-top: 1px solid gu-colour(neutral-86);
+  padding: 18px 0 28px 0;
+  margin: 0 -10px;
+  border-bottom: 1px solid gu-colour(neutral-86);
 }
 
 .contributions-landing-ticker--hidden {

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -504,19 +504,21 @@ footer[role="contentinfo"] {
 
 .gu-content__form__message {
   margin: 0 -10px;
-  padding: 7px 10px;
+  padding: 12px 10px 11px 10px;
   border-bottom: 1px solid gu-colour(neutral-86);
 }
 
 .climate-crunch {
-  line-height: 1;
+  font-family: $gu-headline;
 }
 .climate-crunch__headline {
   font-size: 24px;
+  line-height: 26px;
   font-weight: bold;
 }
 .climate-crunch__body {
   font-size: 16px;
+  line-height: 18px;
   font-style: italic;
 }
 

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -502,10 +502,22 @@ footer[role="contentinfo"] {
   flex-direction: column;
 }
 
-.form--message {
+.gu-content__form__message {
   margin: 0 -10px;
   padding: 7px 10px;
   border-bottom: 1px solid gu-colour(neutral-86);
+}
+
+.climate-crunch {
+  line-height: 1;
+}
+.climate-crunch__headline {
+  font-size: 24px;
+  font-weight: bold;
+}
+.climate-crunch__body {
+  font-size: 16px;
+  font-style: italic;
 }
 
 .form--content {

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -508,15 +508,15 @@ footer[role="contentinfo"] {
   border-bottom: 1px solid gu-colour(neutral-86);
 }
 
-.climate-crunch {
+.frontline-campaign {
   font-family: $gu-headline;
 }
-.climate-crunch__headline {
+.frontline-campaign__headline {
   font-size: 24px;
   line-height: 26px;
   font-weight: bold;
 }
-.climate-crunch__body {
+.frontline-campaign__body {
   font-size: 16px;
   line-height: 18px;
   font-style: italic;


### PR DESCRIPTION
## Why are you doing this?
We are reviving the ticker for an upcoming AU campaign


## Changes

1. Updated ticker styling
2. Ticker can be enabled by adding `ticker=true` in the url query string
3. Adding `frontline-campaign=true` to the url query string adds custom campaign to the form (below the ticker)

## Screenshots
<img width="423" alt="picture 4" src="https://user-images.githubusercontent.com/1513454/53886344-bd8bec00-4017-11e9-94a4-44a5c60e9df4.png">

