### PR TITLE
Hide PayPal

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -329,12 +329,6 @@ function CheckoutForm(props: PropTypes) {
                       checked={props.paymentMethod === 'Stripe'}
                       onChange={() => props.setPaymentMethod('Stripe')}
                     />
-                    <RadioInput
-                      text="PayPal"
-                      name="paymentMethod"
-                      checked={props.paymentMethod === 'PayPal'}
-                      onChange={() => props.setPaymentMethod('PayPal')}
-                    />
                   </Fieldset>
                 </div>
               }


### PR DESCRIPTION
## Why are you doing this?
I accidently put PayPal live for Digital Pack subscriptions, this switches it off again until we're ready to AB test.
