### PR TITLE
Hide contribution type tabs if only one-off is available

### DIFF
--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionTypeTabs.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionTypeTabs.jsx
@@ -55,11 +55,17 @@ const mapDispatchToProps = (dispatch: Function) => ({
 // ----- Render ----- //
 
 function ContributionTypeTabs(props: PropTypes) {
+  const contributionTypes = getValidContributionTypes(props.dropMonthlyVariant);
+
+  if (contributionTypes.length === 1 && contributionTypes[0] === 'ONE_OFF') {
+    return (null);
+  }
+
   return (
     <fieldset className={classNameWithModifiers('form__radio-group', ['tabs', 'contribution-type'])}>
       <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>Recurrence</legend>
       <ul className="form__radio-group-list form__radio-group-list--border">
-        {getValidContributionTypes(props.dropMonthlyVariant).map((contributionType: ContributionType) => (
+        {contributionTypes.map((contributionType: ContributionType) => (
           <li className="form__radio-group-item">
             <input
               id={`contributionType-${contributionType}`}

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -367,6 +367,7 @@ footer[role="contentinfo"] a {
   border-style: none solid;
   border-width: 0 1px;
   border-bottom: 1px solid gu-colour(neutral-86);
+  border-top: 1px solid gu-colour(neutral-86);
   background-color: gu-colour(neutral-100);
 
   @include mq($from: tablet) {
@@ -579,7 +580,6 @@ form {
 }
 
 .form__radio-group--tabs .form__radio-group-item {
-  border-top: 1px solid gu-colour(neutral-86);
   flex: 1;
 }
 


### PR DESCRIPTION
## Why are you doing this?
We sometimes only want to allow one-off contributions. In this case, there is no need to show the contribution type tabs.

## Screenshots
Only one-off:
![picture 6](https://user-images.githubusercontent.com/1513454/53821335-82c97b80-3f65-11e9-97f1-97e33484b931.png)

Others:
![picture 7](https://user-images.githubusercontent.com/1513454/53821336-82c97b80-3f65-11e9-94f7-1b00d067d12b.png)

