### PR TITLE
Allow optional form message

### DIFF
--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -78,7 +78,7 @@ type PropTypes = {|
   isTestUser: boolean,
   country: IsoCountry,
   stripePaymentRequestButtonMethod: StripePaymentRequestButtonMethod,
-  message: ?string,
+  message: ?React$Element<string>,
 |};
 
 // We only want to use the user state value if the form state value has not been changed since it was initialised,
@@ -210,7 +210,7 @@ function ContributionForm(props: PropTypes) {
   return (
     <form onSubmit={onSubmit(props)} className={classNameWithModifiers('form', ['contribution'])} noValidate>
       <div>
-        {props.message ? <div>{props.message}</div> : ''}
+        {props.message ? props.message : null}
         <ContributionTypeTabs />
         <NewContributionAmount
           checkOtherAmount={checkAmount}

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -210,7 +210,7 @@ function ContributionForm(props: PropTypes) {
   return (
     <form onSubmit={onSubmit(props)} className={classNameWithModifiers('form', ['contribution'])} noValidate>
       <div>
-        {props.message ? props.message : null}
+        {props.message ? <div className={classNameWithModifiers('form', ['message'])}>{props.message}</div> : null}
         <ContributionTypeTabs />
         <NewContributionAmount
           checkOtherAmount={checkAmount}

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -78,6 +78,7 @@ type PropTypes = {|
   isTestUser: boolean,
   country: IsoCountry,
   stripePaymentRequestButtonMethod: StripePaymentRequestButtonMethod,
+  message: ?string,
 |};
 
 // We only want to use the user state value if the form state value has not been changed since it was initialised,
@@ -209,6 +210,7 @@ function ContributionForm(props: PropTypes) {
   return (
     <form onSubmit={onSubmit(props)} className={classNameWithModifiers('form', ['contribution'])} noValidate>
       <div>
+        {props.message ? <div>{props.message}</div> : ''}
         <ContributionTypeTabs />
         <NewContributionAmount
           checkOtherAmount={checkAmount}

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
@@ -120,6 +120,7 @@ const defaultCountryGroupSpecificDetails = {
   AUDCountries: {
     ...defaultHeaderCopyAndContributeCopy,
     headerCopy: australiaHeadline,
+    formMessage: 'Make a contribution',
   },
   International: defaultHeaderCopyAndContributeCopy,
   NZDCountries: defaultHeaderCopyAndContributeCopy,
@@ -133,6 +134,7 @@ const helpVariantCountryGroupSpecificDetails = {
   AUDCountries: {
     ...helpVariantHeaderCopyAndContributeCopy,
     headerCopy: australiaHeadline,
+    formMessage: 'Make a contribution',
   },
   International: helpVariantHeaderCopyAndContributeCopy,
   NZDCountries: helpVariantHeaderCopyAndContributeCopy,
@@ -145,6 +147,8 @@ export type CountryMetaData = {
   headerClasses?: string,
   // URL to fetch ticker data from. null/undefined implies no ticker
   tickerJsonUrl?: string,
+  // Optional message to display at the top of the form
+  formMessage?: string,
 };
 
 const countryGroupSpecificDetails: (variant: LandingPageCopyTestVariant) => {
@@ -191,6 +195,7 @@ function ContributionFormContainer(props: PropTypes) {
         <div className="gu-content__form">
           <NewContributionForm
             onPaymentAuthorisation={onPaymentAuthorisation}
+            message={countryGroupDetails.formMessage}
           />
         </div>
         <DirectDebitPopUpForm

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
@@ -120,7 +120,7 @@ const defaultCountryGroupSpecificDetails = {
   AUDCountries: {
     ...defaultHeaderCopyAndContributeCopy,
     headerCopy: australiaHeadline,
-    formMessage: 'Make a contribution',
+    formMessage: (<div><h1>Make a contribution</h1>pls</div>),
   },
   International: defaultHeaderCopyAndContributeCopy,
   NZDCountries: defaultHeaderCopyAndContributeCopy,
@@ -134,7 +134,7 @@ const helpVariantCountryGroupSpecificDetails = {
   AUDCountries: {
     ...helpVariantHeaderCopyAndContributeCopy,
     headerCopy: australiaHeadline,
-    formMessage: 'Make a contribution',
+    formMessage: (<div><h1>Make a contribution</h1>pls</div>),
   },
   International: helpVariantHeaderCopyAndContributeCopy,
   NZDCountries: helpVariantHeaderCopyAndContributeCopy,
@@ -148,7 +148,7 @@ export type CountryMetaData = {
   // URL to fetch ticker data from. null/undefined implies no ticker
   tickerJsonUrl?: string,
   // Optional message to display at the top of the form
-  formMessage?: string,
+  formMessage?: React$Element<string>,
 };
 
 const countryGroupSpecificDetails: (variant: LandingPageCopyTestVariant) => {

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
@@ -84,6 +84,16 @@ const mapDispatchToProps = (dispatch: Function) => ({
 
 // ----- Functions ----- //
 
+export type CountryMetaData = {
+  headerCopy: string,
+  contributeCopy?: React$Element<string>,
+  headerClasses?: string,
+  // URL to fetch ticker data from. null/undefined implies no ticker
+  tickerJsonUrl?: string,
+  // Optional message to display at the top of the form
+  formMessage?: React$Element<string>,
+};
+
 const defaultHeaderCopy = 'Help\xa0us\xa0deliver\nthe\xa0independent\njournalism\xa0the\nworld\xa0needs';
 const defaultContributeCopy = (
   <span>
@@ -91,12 +101,12 @@ const defaultContributeCopy = (
     as and when you feel like it – choose the option that suits you best.
   </span>);
 
-const defaultHeaderCopyAndContributeCopy = {
+const defaultHeaderCopyAndContributeCopy: CountryMetaData = {
   headerCopy: defaultHeaderCopy,
   contributeCopy: defaultContributeCopy,
 };
 
-const helpVariantHeaderCopyAndContributeCopy = {
+const helpVariantHeaderCopyAndContributeCopy: CountryMetaData = {
   headerCopy: defaultHeaderCopy,
   contributeCopy: (
     <span>
@@ -137,16 +147,6 @@ const helpVariantCountryGroupSpecificDetails = {
   International: helpVariantHeaderCopyAndContributeCopy,
   NZDCountries: helpVariantHeaderCopyAndContributeCopy,
   Canada: helpVariantHeaderCopyAndContributeCopy,
-};
-
-export type CountryMetaData = {
-  headerCopy: string,
-  contributeCopy?: React$Element<string>,
-  headerClasses?: string,
-  // URL to fetch ticker data from. null/undefined implies no ticker
-  tickerJsonUrl?: string,
-  // Optional message to display at the top of the form
-  formMessage?: React$Element<string>,
 };
 
 const countryGroupSpecificDetails: (variant: LandingPageCopyTestVariant) => {

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
@@ -120,7 +120,6 @@ const defaultCountryGroupSpecificDetails = {
   AUDCountries: {
     ...defaultHeaderCopyAndContributeCopy,
     headerCopy: australiaHeadline,
-    formMessage: (<div><h1>Make a contribution</h1>pls</div>),
   },
   International: defaultHeaderCopyAndContributeCopy,
   NZDCountries: defaultHeaderCopyAndContributeCopy,
@@ -134,7 +133,6 @@ const helpVariantCountryGroupSpecificDetails = {
   AUDCountries: {
     ...helpVariantHeaderCopyAndContributeCopy,
     headerCopy: australiaHeadline,
-    formMessage: (<div><h1>Make a contribution</h1>pls</div>),
   },
   International: helpVariantHeaderCopyAndContributeCopy,
   NZDCountries: helpVariantHeaderCopyAndContributeCopy,

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -507,6 +507,12 @@ footer[role="contentinfo"] {
   flex-direction: column;
 }
 
+.form--message {
+  margin: 0 -10px;
+  padding: 7px 10px;
+  border-bottom: 1px solid gu-colour(neutral-86);
+}
+
 .form--content {
   padding-top: 10px;
 }


### PR DESCRIPTION
## Why are you doing this?
This change makes it possible to add a message at the top of the form component.
This will be used for the upcoming AU campaign, but for now nothing uses this feature

## Screenshots
**With contribution type tabs:**
<img width="368" alt="picture 9" src="https://user-images.githubusercontent.com/1513454/53870213-ad611600-3ff1-11e9-96ce-4a1fa0b0d005.png">

**Without contribution type tabs:**
<img width="362" alt="picture 10" src="https://user-images.githubusercontent.com/1513454/53870214-ad611600-3ff1-11e9-9ffe-bab616118f31.png">

