### PR TITLE
improve spacing of set password form

### DIFF
--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -496,7 +496,6 @@ footer[role="contentinfo"] {
 .form--contribution {
   display: flex;
   flex-direction: column;
-  min-height: 409px;
   justify-content: space-between;
 }
 


### PR DESCRIPTION
## Why are you doing this?

Somehow the spacing of the set password screen was a bit wide.  I thought it was caused by removing the new styling test (as that caused a lot of styling issues!) but actually it turned out it was present in the commit before hand.  But I'm still assuming it wasn't intentional even in that commit!

Rather than searching back throughout all history, I just played around with the CSS until it looked better.

|broken:|in commit `3839783fc10845d40e92da88368ce028c8cc4d86`|after fix|
|---|---|---|
|![image](https://user-images.githubusercontent.com/7304387/53872447-31b59800-3ff6-11e9-8d91-1314fd0648fc.png)|![image](https://user-images.githubusercontent.com/7304387/53872564-74777000-3ff6-11e9-8fea-7ece8c69ca7a.png)|![image](https://user-images.githubusercontent.com/7304387/53872662-996be300-3ff6-11e9-91c4-a15662b8a00f.png)|

