### PR TITLE
Switch off the Digital Pack checkout test

### DIFF
--- a/support-frontend/assets/helpers/externalLinks.js
+++ b/support-frontend/assets/helpers/externalLinks.js
@@ -12,7 +12,6 @@ import { Annual, Quarterly, SixForSix, Monthly, type WeeklyBillingPeriod, type D
 import type { PaperBillingPlan, SubscriptionProduct } from 'helpers/subscriptions';
 import { getIntcmp, getPromoCode, getAnnualPlanPromoCode } from './flashSale';
 import { getOrigin } from './url';
-import type { OptimizeExperiment } from './optimize/optimize';
 import { GBPCountries } from './internationalisation/countryGroup';
 
 // ----- Types ----- //
@@ -278,39 +277,16 @@ function getDigitalPackPromoCode(cgId: CountryGroupId, billingPeriod: DigitalBil
 
 // Builds a link to the digital pack checkout.
 function getDigitalCheckout(
-  referrerAcquisitionData: ReferrerAcquisitionData,
-  cgId: CountryGroupId,
-  referringCta: ?string,
-  nativeAbParticipations: Participations,
-  optimizeExperiments: OptimizeExperiments,
+  countryGroupId: CountryGroupId,
   billingPeriod: DigitalBillingPeriod = Monthly,
 ): string {
-
-  function buildUrlForExperiment(params: URLSearchParams): string {
-    const digitalPackCheckoutExperimentId = 'I-M60BjwTLClJegHgJmklw';
-    const optimizeExperiment: Option<OptimizeExperiment> =
-      optimizeExperiments.find(exp => exp.id === digitalPackCheckoutExperimentId) || null;
-    if (optimizeExperiment && optimizeExperiment.variant === '1') {
-      return `${getOrigin()}/subscribe/digital/checkout?${params.toString()}`;
-    }
-    return billingPeriod === Annual ? `${subsUrl}/checkout/digitalpack-digitalpackannual?${params.toString()}` : `${subsUrl}/checkout?${params.toString()}`;
-  }
-
-  const acquisitionData = deriveSubsAcquisitionData(
-    referrerAcquisitionData,
-    nativeAbParticipations,
-    optimizeExperiments,
-  );
-  const promoCode = getDigitalPackPromoCode(cgId, billingPeriod);
+  const promoCode = getDigitalPackPromoCode(countryGroupId, billingPeriod);
   const params = new URLSearchParams(window.location.search);
-  params.set('acquisitionData', JSON.stringify(acquisitionData));
   params.set('promoCode', promoCode);
-  params.set('countryGroup', countryGroups[cgId].supportInternationalisationId);
-  params.set('startTrialButton', referringCta || '');
   if (billingPeriod === Annual) {
     params.set('period', Annual);
   }
-  return buildUrlForExperiment(params);
+  return `${getOrigin()}/subscribe/digital/checkout?${params.toString()}`;
 }
 
 

--- a/support-frontend/assets/pages/digital-subscription-landing/components/priceCtaContainer.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/priceCtaContainer.jsx
@@ -16,18 +16,11 @@ import { getProductPrice } from 'helpers/subscriptions';
 
 function mapStateToProps(state: { common: CommonState }, ownProps: {ctaText: ?string, referringCta: ?string }) {
   const { countryGroupId } = state.common.internationalisation;
-  const { referrerAcquisitionData, abParticipations, optimizeExperiments } = state.common;
   const price = getProductPrice('DigitalPack', countryGroupId);
 
   return {
     ctaText: ownProps.ctaText || 'Start your free trial now',
-    url: getDigitalCheckout(
-      referrerAcquisitionData,
-      countryGroupId,
-      ownProps.referringCta,
-      abParticipations,
-      optimizeExperiments,
-    ),
+    url: getDigitalCheckout(countryGroupId),
     price: `${currencies[state.common.internationalisation.currencyId].glyph}${price}`,
   };
 

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLandingActions.js
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLandingActions.js
@@ -20,18 +20,10 @@ function redirectToDigitalPage() {
     const state = getState();
 
     const { countryGroupId } = state.common.internationalisation;
-    const { referrerAcquisitionData, abParticipations, optimizeExperiments } = state.common;
     const { plan } = state.page.plan;
 
     if (plan) {
-      const location = getDigitalCheckout(
-        referrerAcquisitionData,
-        countryGroupId,
-        null,
-        abParticipations,
-        optimizeExperiments,
-        plan,
-      );
+      const location = getDigitalCheckout(countryGroupId);
 
       sendTrackingEventsOnClick(`main_cta_click_${plan}`, 'DigitalPack', null)();
       window.location.href = location;

--- a/support-frontend/assets/pages/premium-tier-landing/components/priceCtaContainer.jsx
+++ b/support-frontend/assets/pages/premium-tier-landing/components/priceCtaContainer.jsx
@@ -14,20 +14,13 @@ import { getProductPrice } from 'helpers/subscriptions';
 
 // ----- State Maps ----- //
 
-function mapStateToProps(state: { common: CommonState }, ownProps: { referringCta: ?string }) {
+function mapStateToProps(state: { common: CommonState }) {
   const { countryGroupId } = state.common.internationalisation;
-  const { referrerAcquisitionData, abParticipations, optimizeExperiments } = state.common;
   const price = getProductPrice('PremiumTier', countryGroupId);
 
   return {
     ctaText: 'Start a 7 day free trial',
-    url: getDigitalCheckout(
-      referrerAcquisitionData,
-      countryGroupId,
-      ownProps.referringCta,
-      abParticipations,
-      optimizeExperiments,
-    ),
+    url: getDigitalCheckout(countryGroupId),
     price: `${currencies[state.common.internationalisation.currencyId].glyph}${price}`,
   };
 


### PR DESCRIPTION
## Why are you doing this?

We want to switch over to sending 100% of traffic to the new Digital Pack checkout.

[**Trello Card**](https://trello.com/c/SvHHTplZ/2273-end-dp-checkout-ab-test-and-roll-new-dp-checkout-out-to-100-of-traffic)


