### PR TITLE
inline Javascript into the page

### DIFF
--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -114,7 +114,10 @@ class Application(
   private def contributionsHtml(countryCode: String, idUser: Option[IdUser])
     (implicit request: RequestHeader, settings: AllSettings) = {
 
-    val css = CSSElementForStage(assets.getFileContentsAsHtml, stage, RefPath("newContributionsLandingPageStyles.css"))
+    val elementForStage = CSSElementForStage(assets.getFileContentsAsHtml, Stages.CODE)_
+    val css = elementForStage(RefPath("newContributionsLandingPageStyles.css"))
+
+    val js = elementForStage(RefPath("newContributionsLandingPage.js"))
 
     val preload = List("GuardianTextSans-Regular", "GuardianTextSans-Medium", "GHGuardianHeadline-Bold").map { name =>
       Preload(s"//pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/$name.woff2", "font", "font/woff2")
@@ -123,7 +126,7 @@ class Application(
     views.html.newContributions(
       title = "Support the Guardian | Make a Contribution",
       id = s"new-contributions-landing-page-$countryCode",
-      js = RefPath("newContributionsLandingPage.js"),
+      js = js,
       css = css,
       description = stringsConfig.contributionsLandingDescription,
       oneOffDefaultStripeConfig = oneOffStripeConfigProvider.get(false),
@@ -144,7 +147,7 @@ class Application(
     Ok(views.html.main(
       title = "Support the Guardian",
       mainElement = EmptyDiv("showcase-landing-page"),
-      mainJsBundle = RefPath("showcasePage.js"),
+      mainJsBundle = Left(RefPath("showcasePage.js")),
       mainStyleBundle = Left(RefPath("showcasePage.css")),
       description = stringsConfig.showcaseLandingDescription,
       canonicalLink = Some(buildCanonicalShowcaseLink("uk"))
@@ -164,7 +167,7 @@ class Application(
 
 object CSSElementForStage {
 
-  def apply(getFileContentsAsHtml: RefPath => Option[StyleContent], stage: Stage, cssPath: RefPath): Either[RefPath, StyleContent] = {
+  def apply(getFileContentsAsHtml: RefPath => Option[StyleContent], stage: Stage)(cssPath: RefPath): Either[RefPath, StyleContent] = {
     if (stage == Stages.DEV) {
       Left(cssPath)
     } else {

--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -114,7 +114,7 @@ class Application(
   private def contributionsHtml(countryCode: String, idUser: Option[IdUser])
     (implicit request: RequestHeader, settings: AllSettings) = {
 
-    val elementForStage = CSSElementForStage(assets.getFileContentsAsHtml, Stages.CODE)_
+    val elementForStage = CSSElementForStage(assets.getFileContentsAsHtml, stage)_
     val css = elementForStage(RefPath("newContributionsLandingPageStyles.css"))
 
     val js = elementForStage(RefPath("newContributionsLandingPage.js"))

--- a/support-frontend/app/controllers/DigitalSubscription.scala
+++ b/support-frontend/app/controllers/DigitalSubscription.scala
@@ -48,7 +48,7 @@ class DigitalSubscription(
     implicit val settings: AllSettings = settingsProvider.getAllSettings()
     val title = "Support the Guardian | Digital Pack Subscription"
     val mainElement = EmptyDiv("digital-subscription-landing-page-" + countryCode)
-    val js = RefPath("digitalSubscriptionLandingPage.js")
+    val js = Left(RefPath("digitalSubscriptionLandingPage.js"))
     val css = Left(RefPath("digitalSubscriptionLandingPage.css"))
     val description = stringsConfig.digitalPackLandingDescription
     val canonicalLink = Some(buildCanonicalDigitalSubscriptionLink("uk"))
@@ -128,7 +128,7 @@ class DigitalSubscription(
     implicit val settings: AllSettings = settingsProvider.getAllSettings()
     val title = "Support the Guardian | Digital Subscription"
     val mainElement = EmptyDiv("digital-subscription-checkout-page")
-    val js = RefPath("digitalSubscriptionCheckoutPageThankYouExisting.js")
+    val js = Left(RefPath("digitalSubscriptionCheckoutPageThankYouExisting.js"))
     val css = Left(RefPath("digitalSubscriptionCheckoutPageThankYouExisting.css"))
 
     Ok(views.html.main(

--- a/support-frontend/app/controllers/PaperSubscription.scala
+++ b/support-frontend/app/controllers/PaperSubscription.scala
@@ -52,7 +52,7 @@ class PaperSubscription(
     implicit val settings: AllSettings = settingsProvider.getAllSettings()
     val title = "The Guardian Newspaper Subscription | Vouchers and Delivery"
     val mainElement = if (withDelivery) EmptyDiv("paper-subscription-landing-page-delivery") else EmptyDiv("paper-subscription-landing-page-collection")
-    val js = RefPath("paperSubscriptionLandingPage.js")
+    val js = Left(RefPath("paperSubscriptionLandingPage.js"))
     val css = Left(RefPath("paperSubscriptionLandingPage.css"))
     val canonicalLink = Some(buildCanonicalPaperSubscriptionLink())
     val description = stringsConfig.paperLandingDescription

--- a/support-frontend/app/controllers/PayPalOneOff.scala
+++ b/support-frontend/app/controllers/PayPalOneOff.scala
@@ -42,7 +42,7 @@ class PayPalOneOff(
     Ok(views.html.main(
       "Support the Guardian | PayPal Error",
       EmptyDiv("paypal-error-page"),
-      RefPath("payPalErrorPage.js"),
+      Left(RefPath("payPalErrorPage.js")),
       Left(RefPath("payPalErrorPageStyles.css"))
     )()).withSettingsSurrogateKey
   }

--- a/support-frontend/app/controllers/PayPalRegular.scala
+++ b/support-frontend/app/controllers/PayPalRegular.scala
@@ -68,7 +68,7 @@ class PayPalRegular(
     Ok(views.html.main(
       "Support the Guardian | PayPal Error",
       EmptyDiv("paypal-error-page"),
-      RefPath("payPalErrorPage.js"),
+      Left(RefPath("payPalErrorPage.js")),
       Left(RefPath("payPalErrorPageStyles.css"))
     )()).withSettingsSurrogateKey
   }
@@ -81,7 +81,7 @@ class PayPalRegular(
     Ok(views.html.main(
       "Support the Guardian | PayPal Error",
       EmptyDiv("paypal-error-page"),
-      RefPath("payPalErrorPage.js"),
+      Left(RefPath("payPalErrorPage.js")),
       Left(RefPath("payPalErrorPageStyles.css"))
     )()).withSettingsSurrogateKey
   }

--- a/support-frontend/app/controllers/Subscriptions.scala
+++ b/support-frontend/app/controllers/Subscriptions.scala
@@ -40,7 +40,7 @@ class Subscriptions(
     Ok(views.html.main(
       title,
       mainElement,
-      RefPath(js),
+      Left(RefPath(js)),
       Left(RefPath("subscriptionsLandingPageStyles.css")),
       description = stringsConfig.subscriptionsLandingDescription
     )()).withSettingsSurrogateKey
@@ -51,7 +51,7 @@ class Subscriptions(
     implicit val settings: AllSettings = settingsProvider.getAllSettings()
     val title = "Support the Guardian | Premium Tier"
     val mainElement = EmptyDiv("premium-tier-landing-page-" + countryCode)
-    val js = RefPath("premiumTierLandingPage.js")
+    val js = Left(RefPath("premiumTierLandingPage.js"))
     val css = Left(RefPath("premiumTierLandingPageStyles.css"))
     Ok(views.html.main(title, mainElement, js, css)()).withSettingsSurrogateKey
   }
@@ -62,7 +62,7 @@ class Subscriptions(
     implicit val settings: AllSettings = settingsProvider.getAllSettings()
     val title = "The Guardian Weekly Subscriptions | The Guardian"
     val mainElement = EmptyDiv("weekly-landing-page-" + countryCode)
-    val js = RefPath("weeklySubscriptionLandingPage.js")
+    val js = Left(RefPath("weeklySubscriptionLandingPage.js"))
     val css = Left(RefPath("weeklySubscriptionLandingPage.css"))
     val description = stringsConfig.weeklyLandingDescription
     val canonicalLink = Some(buildCanonicalWeeklySubscriptionLink("uk"))

--- a/support-frontend/app/lib/CustomHttpErrorHandler.scala
+++ b/support-frontend/app/lib/CustomHttpErrorHandler.scala
@@ -35,7 +35,7 @@ class CustomHttpErrorHandler(
       NotFound(main(
         "Error 404",
         EmptyDiv("error-404-page"),
-        RefPath("error404Page.js"),
+        Left(RefPath("error404Page.js")),
         Left(RefPath("error404Page.css"))
       )()(assets, request, settingsProvider.getAllSettings()))
         .withHeaders(CacheControl.defaultCacheHeaders(30.seconds, 30.seconds): _*)
@@ -49,7 +49,7 @@ class CustomHttpErrorHandler(
         main(
           "Error 500",
           EmptyDiv("error-500-page"),
-          RefPath("error500Page.js"),
+          Left(RefPath("error500Page.js")),
           Left(RefPath("error500Page.css"))
         )()(assets, request, settingsProvider.getAllSettings()))
         .withHeaders(CacheControl.noCache)

--- a/support-frontend/app/views/main.scala.html
+++ b/support-frontend/app/views/main.scala.html
@@ -4,7 +4,7 @@
 @(
   title: String,
   mainElement: ReactDiv,
-  mainJsBundle: RefPath,
+  mainJsBundle: Either[RefPath, StyleContent],
   mainStyleBundle: Either[RefPath, StyleContent],
   description: Option[String] = None,
   canonicalLink: Option[String] = None,
@@ -82,9 +82,6 @@
 		}
 	</script>
 
-    <script async type="text/javascript" src="@assets("googleTagManagerScript.js")"></script>
-
-    <link rel="preload"  as="script" href="@assets(mainJsBundle)">
 
     </head>
   <body class="header-tweaks">
@@ -110,7 +107,6 @@
     @mainElement.fold(emptyDiv, withContent)
 
     <script src="https://polyfill.io/v2/polyfill.min.js?features=default,Array.prototype.find,fetch,Array.prototype.includes,Number.isInteger,Object.values,Object.entries"></script>
-    <script defer id="stripe-js" src="https://js.stripe.com/v3/"></script>
     <script type="text/javascript">
     window.guardian = window.guardian || {};
     window.guardian.gitCommitId = '@app.BuildInfo.gitCommitId';
@@ -120,7 +116,21 @@
 
     @* This script is intentionally at the bottom of the file. Please check
     all the critical flows work correctly if you change its position *@
-    <script type="text/javascript" src="@assets(mainJsBundle)"></script>
-      <!-- build-commit-id: @app.BuildInfo.gitCommitId -->
+    @linkedJs(path: RefPath) = {
+    <script type="text/javascript" src="@assets(path)"></script>
+  }
+
+    @inlineJs(inlineJs: StyleContent) = {
+    <script type="text/javascript">
+    @inlineJs.value
+    </script>
+  }
+
+    @mainJsBundle.fold(linkedJs, inlineJs)
+
+    <script async type="text/javascript" src="@assets("googleTagManagerScript.js")"></script>
+    <script defer id="stripe-js" src="https://js.stripe.com/v3/"></script>
+
+    <!-- build-commit-id: @app.BuildInfo.gitCommitId -->
   </body>
 </html>

--- a/support-frontend/app/views/newContributions.scala.html
+++ b/support-frontend/app/views/newContributions.scala.html
@@ -8,7 +8,7 @@
 @(
   title: String,
   id: String,
-  js: RefPath,
+  js: Either[RefPath, StyleContent],
   css: Either[RefPath, StyleContent],
   description: Option[String],
   oneOffDefaultStripeConfig: StripeConfig,

--- a/support-frontend/app/views/subscriptionCheckout.scala.html
+++ b/support-frontend/app/views/subscriptionCheckout.scala.html
@@ -27,7 +27,7 @@
   uatPayPalConfig: PayPalConfig
 )(implicit assets: AssetsResolver, requestHeader: RequestHeader, settings: AllSettings)
 
-  @main(title = title, mainJsBundle = RefPath(js), mainElement = mainElement, mainStyleBundle = Left(RefPath(css)), csrf = csrf) {
+  @main(title = title, mainJsBundle = Left(RefPath(js)), mainElement = mainElement, mainStyleBundle = Left(RefPath(css)), csrf = csrf) {
     <script type="text/javascript">
       window.guardian.productPrices = @{Html(outputJson(productPrices))}
       window.guardian = window.guardian || {};


### PR DESCRIPTION
## Why are you doing this?

We are trying to make perf improvements to help people access the page quicker.  This means they are less likely to leave the page before it loads so they are more likely to contribute.

I noticed that with a slow network connection "Fast 3G in chrome", the JS takes 1.9 seconds to download.  Then there is a constant amount of time to get the form on the screen.  See the diagram:
![image](https://user-images.githubusercontent.com/7304387/53893578-60e3fd80-4026-11e9-9ca4-0ed3a959bf91.png)

However if we inline all the JS the connection just gets a clear run from when the main body starts downloading until all the JS is loaded, meaning that there is little contention.
![image](https://user-images.githubusercontent.com/7304387/53893811-dcde4580-4026-11e9-9252-89e72c13c3bb.png)

As you can see the js is fully downloaded 1 second earlier when it's inlined.

Lighthouse difference is small

|before|after|
|---|---|
|![image](https://user-images.githubusercontent.com/7304387/53894027-42323680-4027-11e9-9f95-ef233fe25d67.png)|![image](https://user-images.githubusercontent.com/7304387/53894047-4c543500-4027-11e9-8e8d-883d510a0312.png)|

This is not an AB test, it would be similar difficulty to doing the SSR test, not sure if it's better to just do it, test it, or not do it at all?

The downside could be that people have to download the JS regardless of whether it's been cached.  Although that is flushed out at every deploy anyway, and most people presumably only hit the page once.


[**Trello Card**](https://trello.com/c/8PLMDwNB/358-try-inlining-main-js-bundle-into-html)

