### PR TITLE
AB test for PayPal

### DIFF
--- a/support-frontend/assets/components/subscriptionCheckouts/paymentMethodSelector.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/paymentMethodSelector.jsx
@@ -22,7 +22,7 @@ type PropTypes = {|
 |}
 
 const isPayPalEnabled = (optimizeExperiments: OptimizeExperiments) => {
-  const PayPalExperimentId = "Owuvo_-LQrywVTEhStTFvQ";
+  const PayPalExperimentId = "8IebFnX-SbKRxhlj_tGp-w";
   const enabledByTest = optimizeExperiments.find((exp) => exp.id === PayPalExperimentId && exp.variant === '1');
   const enabledByQueryString = getQueryParameter('payPal') === 'true';
   return enabledByTest || enabledByQueryString;

--- a/support-frontend/assets/components/subscriptionCheckouts/paymentMethodSelector.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/paymentMethodSelector.jsx
@@ -11,16 +11,25 @@ import Rows from 'components/base/rows';
 import DirectDebitPopUpForm from 'components/directDebit/directDebitPopUpForm/directDebitPopUpForm';
 import { getQueryParameter } from 'helpers/url';
 import { type Option } from 'helpers/types/option';
+import type { OptimizeExperiments } from 'helpers/optimize/optimize';
 
 type PropTypes = {|
   countrySupportsDirectDebit: boolean,
   paymentMethod: Option<PaymentMethod>,
   onPaymentAuthorised: Function,
   setPaymentMethod: Function,
+  optimizeExperiments: OptimizeExperiments,
 |}
 
+const isPayPalEnabled = (optimizeExperiments: OptimizeExperiments) => {
+  const PayPalExperimentId = "Owuvo_-LQrywVTEhStTFvQ";
+  const enabledByTest = optimizeExperiments.find((exp) => exp.id === PayPalExperimentId && exp.variant === '1');
+  const enabledByQueryString = getQueryParameter('payPal') === 'true';
+  return enabledByTest || enabledByQueryString;
+};
+
 function PaymentMethodSelector(props: PropTypes) {
-  const payPalEnabled = getQueryParameter('payPal') === 'true';
+  const payPalEnabled = isPayPalEnabled(props.optimizeExperiments);
   const multiplePaymentMethodsEnabled = payPalEnabled || props.countrySupportsDirectDebit;
 
   return (

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -44,6 +44,7 @@ import type { BillingPeriod } from 'helpers/billingPeriods';
 import { setupRecurringPayPalPayment } from 'helpers/paymentIntegrations/payPalRecurringCheckout';
 import { SubscriptionSubmitButtons } from 'components/subscriptionCheckouts/subscriptionSubmitButtons';
 import { PaymentMethodSelector } from 'components/subscriptionCheckouts/paymentMethodSelector';
+import type { OptimizeExperiments } from 'helpers/optimize/optimize';
 
 import {
   formIsValid,
@@ -75,6 +76,7 @@ type PropTypes = {|
   setupRecurringPayPalPayment: Function,
   validateForm: () => Function,
   formIsValid: Function,
+  optimizeExperiments: OptimizeExperiments,
 |};
 
 
@@ -97,6 +99,7 @@ function mapStateToProps(state: State) {
       state.common.internationalisation.countryId,
     ).price,
     billingPeriod: state.page.checkout.billingPeriod,
+    optimizeExperiments: state.common.optimizeExperiments,
   };
 }
 
@@ -314,6 +317,7 @@ function CheckoutForm(props: PropTypes) {
               paymentMethod={props.paymentMethod}
               setPaymentMethod={props.setPaymentMethod}
               onPaymentAuthorised={props.onPaymentAuthorised}
+              optimizeExperiments={props.optimizeExperiments}
             />
             <FormSection>
               {errorState}

--- a/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -236,7 +236,7 @@ function initReducer(initialCountry: IsoCountry) {
       case 'SET_PAYMENT_METHOD':
         return {
           ...state,
-          paymentMethod: countrySupportsDirectDebit(action.country) ? action.paymentMethod : 'Stripe',
+          paymentMethod: action.paymentMethod,
         };
 
       case 'SET_COUNTRY_CHANGED':


### PR DESCRIPTION
## Why are you doing this?
We want to test the effect of adding PayPal as a payment method to the Digital Pack checkout.

The design for this is identical to the one on the contributions landing page; a radio button for payment methods which swaps in the PayPal button when PayPal is selected.
### Credit card selected
![screen shot 2019-03-06 at 17 14 22](https://user-images.githubusercontent.com/181371/53899975-5aa84e00-4033-11e9-85ec-5fe2a940d762.png)
### PayPal selected
![screen shot 2019-03-06 at 17 13 00](https://user-images.githubusercontent.com/181371/53899952-49f7d800-4033-11e9-9a15-402b1f39cb4d.png)


[**Trello Card**](https://trello.com/c/ioIGXQRK/2239-ab-test-for-paypal-on-dp-checkout)

[**Test is here**](https://optimize.google.com/optimize/home/?hl=en-GB#/accounts/1368065808/containers/6827913/experiments/329)

