### PR TITLE
Query params to omit PayPal and Stripe checkout JS

### DIFF
--- a/support-frontend/app/views/newContributions.scala.html
+++ b/support-frontend/app/views/newContributions.scala.html
@@ -98,83 +98,36 @@
                   </label></span>
               </li>
             </ul>
-          </fieldset><div class="stripe-payment-request-button stripe-payment-request-button--hidden"></div><div class="form form--content"><div class="form-fields"><div class="form__field form__field--contribution-email"><label class="form__label" for="contributionEmail">
-            Email address</label><span class="form__input-with-icon"><input id="contributionEmail" class="form__input form__input--contributionEmail" type="email" autocapitalize="none" autocomplete="email" required="" placeholder="example@@domain.com" pattern="^[a-zA-Z0-9\.!#$%&amp;'*+/=?^_`{|}~-]+@@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$" style="background-image: url(&quot;data: image/png;
+          </fieldset>
+          <div class="stripe-payment-request-button stripe-payment-request-button--hidden"></div>
+          <div class="form form--content">
+            <div class="form-fields">
+              <div class="form__field form__field--contribution-email">
+                <label class="form__label" for="contributionEmail">Email address</label><span class="form__input-with-icon"><input id="contributionEmail" class="form__input form__input--contributionEmail" type="email" autocapitalize="none" autocomplete="email" required="" placeholder="example@@domain.com" pattern="^[a-zA-Z0-9\.!#$%&amp;'*+/=?^_`{|}~-]+@@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$" style="background-image: url(&quot;data: image/png;
             base64, iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAAXNSR0IArs4c6QAAAfBJREFUWAntVk1OwkAUZkoDKza4Utm61iP0AqyIDXahN2BjwiHYGU+gizap4QDuegWN7lyCbMSlCQjU7yO0TOlAi6GwgJc0fT / fzPfmzet0crmD7HsFBAvQbrcrw+Gw5fu+AfOYvgylJ4TwCoVCs1ardYTruqfj8fgV5OUMSVVT93VdP9dAzpVvm5wJHZFbg2LQ2pEYOlZ /oiDvwNcsFoseY4PBwMCrhaeCJyKWZU37KOJcYdi27QdhcuuBIb073BvTNL8ln4NeeR6NRi/ wxZKQcGurQs5oNhqLshzVTMBewW / LMU3TTNlO0ieTiStjYhUIyi6DAp0xbEdgTt+LE0aCKQw24U4llsCs4ZRJrYopB6RwqnpA1YQ5NGFZ1YQ41Z5S8IQQdP5laEBRJcD4Vj5DEsW2gE6s6g3d /YP/ g+BDnT7GNi2qCjTwGd6riBzHaaCEd3Js01vwCPIbmWBRx1nwAN / 1 ov+ / drgFWIlfKpVukyYihtgkXNp4mABK+1 GtVr+SBhJDbBIubVw+Cd /TDgKO2DPiN3YUo6y/ nDCNEIsqTKH1en2tcwA9FKEItyDi3aIh8Gl1sRrVnSDzNFDJT1bAy5xpOYGn5fP5JuL95ZjMIn1ya7j5dPGfv0A5eAnpZUY3n5jXcoec5J67D9q+VuAPM47D3XaSeL4AAAAASUVORK5CYII =&quot;);
             background-repeat: no-repeat;
             background-attachment: scroll;
             background-size: 16px 18px;
             background-position: 98% 50%;
-            cursor: auto;"><span class="form__icon"><svg class="svg-envelope" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 10" preserveAspectRatio="xMinYMid"><path d="M.902 0L8 6.213 15.098 0H.902zM0 .787v8.42l4.787-4.232L0 .787zm16 0l-4.787 4.188L16 9.206V.787zM5.689 5.763L.896 10h14.208L10.31 5.763 8.378 7.456a.575.575 0 0 1-.756 0L5.689 5.763z"></path></svg></span></span></div><div><div class="form__field form__field--contribution-fname"><label class="form__label" for="contributionFirstName">
-            First name</label><span class="form__input-with-icon"><input id="contributionFirstName" class="form__input form__input--contributionFirstName" type="text" autocapitalize="words" autocomplete="given-name" required=""><span class="form__icon"><svg class="svg-user" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" preserveAspectRatio="xMinYMid"><path d="M10 8.3c1.55 0 3.4-1.75 3.4-3.9S12.15 1 10 1 6.6 2.25 6.6 4.4s2 3.9 3.4 3.9zm5.86 3.4l-.86-.82c-1.67-.58-3.14-.88-5-.88-1.87 0-3.32.3-5 .86l-.86.85L2 18.16l.86.84h14.28l.86-.86-2.14-6.42v-.02z"></path></svg></span></span></div><div class="form__field form__field--contribution-lname"><label class="form__label" for="contributionLastName">
-            Last name</label><span class="form__input-with-icon"><input id="contributionLastName" class="form__input form__input--contributionLastName" type="text" autocapitalize="words" autocomplete="family-name" required=""><span class="form__icon"><svg class="svg-user" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" preserveAspectRatio="xMinYMid"><path d="M10 8.3c1.55 0 3.4-1.75 3.4-3.9S12.15 1 10 1 6.6 2.25 6.6 4.4s2 3.9 3.4 3.9zm5.86 3.4l-.86-.82c-1.67-.58-3.14-.88-5-.88-1.87 0-3.32.3-5 .86l-.86.85L2 18.16l.86.84h14.28l.86-.86-2.14-6.42v-.02z"></path></svg></span></span></div></div></div></div><fieldset class="form__radio-group form__radio-group--buttons form__radio-group--contribution-pay"><legend class="form__legend">
+            cursor: auto;"><span class="form__icon"><svg class="svg-envelope" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 10" preserveAspectRatio="xMinYMid"><path d="M.902 0L8 6.213 15.098 0H.902zM0 .787v8.42l4.787-4.232L0 .787zm16 0l-4.787 4.188L16 9.206V.787zM5.689 5.763L.896 10h14.208L10.31 5.763 8.378 7.456a.575.575 0 0 1-.756 0L5.689 5.763z"></path></svg></span></span>
+              </div>
+              <div>
+                <div class="form__field form__field--contribution-fname">
+                  <label class="form__label" for="contributionFirstName">First name</label><span class="form__input-with-icon"><input id="contributionFirstName" class="form__input form__input--contributionFirstName" type="text" autocapitalize="words" autocomplete="given-name" required=""><span class="form__icon"><svg class="svg-user" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" preserveAspectRatio="xMinYMid"><path d="M10 8.3c1.55 0 3.4-1.75 3.4-3.9S12.15 1 10 1 6.6 2.25 6.6 4.4s2 3.9 3.4 3.9zm5.86 3.4l-.86-.82c-1.67-.58-3.14-.88-5-.88-1.87 0-3.32.3-5 .86l-.86.85L2 18.16l.86.84h14.28l.86-.86-2.14-6.42v-.02z"></path></svg></span></span>
+                </div>
+                <div class="form__field form__field--contribution-lname">
+                  <label class="form__label" for="contributionLastName">Last name</label><span class="form__input-with-icon"><input id="contributionLastName" class="form__input form__input--contributionLastName" type="text" autocapitalize="words" autocomplete="family-name" required=""><span class="form__icon"><svg class="svg-user" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" preserveAspectRatio="xMinYMid"><path d="M10 8.3c1.55 0 3.4-1.75 3.4-3.9S12.15 1 10 1 6.6 2.25 6.6 4.4s2 3.9 3.4 3.9zm5.86 3.4l-.86-.82c-1.67-.58-3.14-.88-5-.88-1.87 0-3.32.3-5 .86l-.86.85L2 18.16l.86.84h14.28l.86-.86-2.14-6.42v-.02z"></path></svg></span></span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <fieldset class="form__radio-group form__radio-group--buttons form__radio-group--contribution-pay"><legend class="form__legend">
             Payment method</legend><ul class="form__radio-group-list"><li class="form__radio-group-item"><input id="paymentMethodSelector-DirectDebit" class="form__radio-group-input" name="paymentMethodSelector" type="radio" value="DirectDebit"><label for="paymentMethodSelector-DirectDebit" class="form__radio-group-label"><span class="radio-ui"></span><span class="radio-ui__label">
             Direct debit</span><svg class="svg-new-credit-card" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 14" preserveAspectRatio="xMinYMid"><path d="M22 3.652H0V1.326C0 .594.58 0 1.295 0h19.41C21.42 0 22 .594 22 1.326v2.326zm0 1.826v7.196c0 .733-.58 1.326-1.295 1.326H1.295C.58 14 0 13.407 0 12.674V5.478h22zM2.494 9.74a.609.609 0 0 0 0 1.218h3.183a.609.609 0 1 0 0-1.218H2.494z" fill="#00B2FF"></path></svg></label></li><li class="form__radio-group-item"><input id="paymentMethodSelector-Stripe" class="form__radio-group-input" name="paymentMethodSelector" type="radio" value="Stripe"><label for="paymentMethodSelector-Stripe" class="form__radio-group-label"><span class="radio-ui"></span><span class="radio-ui__label">
             Credit/Debit card</span><svg class="svg-new-credit-card" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 22 14" preserveAspectRatio="xMinYMid"><path d="M22 3.652H0V1.326C0 .594.58 0 1.295 0h19.41C21.42 0 22 .594 22 1.326v2.326zm0 1.826v7.196c0 .733-.58 1.326-1.295 1.326H1.295C.58 14 0 13.407 0 12.674V5.478h22zM2.494 9.74a.609.609 0 0 0 0 1.218h3.183a.609.609 0 1 0 0-1.218H2.494z" fill="#00B2FF"></path></svg></label></li><li class="form__radio-group-item"><input id="paymentMethodSelector-PayPal" class="form__radio-group-input" name="paymentMethodSelector" type="radio" value="PayPal"><label for="paymentMethodSelector-PayPal" class="form__radio-group-label"><span class="radio-ui"></span><span class="radio-ui__label">
-            PayPal</span><svg class="svg-paypal" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 15 18" preserveAspectRatio="xMinYMid"><path d="M2.334.637L.01 15.407c-.074.458.27.687 1.032.687h2.875l.804-5.483c.114-.366.313-.549.597-.549h2.674C11 9.735 12.835 8.029 13.5 4.942 14.495.313 10.031 0 8.783 0H3.036C2.8.048 2.631.124 2.53.23a.773.773 0 0 0-.196.407z" fill="#27346A"></path><path d="M5.633 4.554l-1.925 12.85c-.061.397.224.596.855.596h2.382c.34-.073.537-.205.59-.395.053-.19.298-1.628.734-4.312.087-.21.27-.314.55-.314s.891-.04 1.836-.12c2.268-.355 3.676-1.875 4.226-4.56C15.706 4.274 12.01 4 10.975 4h-4.76c-.196.041-.335.108-.419.2a.687.687 0 0 0-.163.354z" fill="#2790C3"></path><path d="M13.564 4.604a7.13 7.13 0 0 1-.065.338c-.664 3.087-2.5 4.793-5.507 5.12H5.318c-.276 0-.472.173-.588.52l.903-6.028a.687.687 0 0 1 .163-.354c.084-.092.223-.159.419-.2h4.76c.506 0 1.65.065 2.589.604zm-9.067 7.53l-.58 3.96h-.013l.593-3.96z" fill="#1F264F"></path></svg></label></li></ul></fieldset><div class="form__submit"><div id="component-paypal-button-checkout" class="component-paypal-button-checkout component-paypal-button-checkout--hidden"><div><div id="zoid-paypal-button-261ab8a12b" class="paypal-button paypal-button-context-iframe paypal-button-label-pay paypal-button-size-responsive paypal-button-layout-horizontal" style="height: 33px;"><style>
-            #zoid-paypal-button-261ab8a12b {
-              font-size: 0;
-              width: 100%;
-              overflow: hidden;
-              min-width: 75px;
-            }
-
-            #zoid-paypal-button-261ab8a12b.paypal-button-size-responsive {
-              text-align: center;
-            }
-
-            #zoid-paypal-button-261ab8a12b > .zoid-outlet {
-              display: inline-block;
-              min-width: 75px;
-              max-width: 750px;
-              position: relative;
-            }
-
-            #zoid-paypal-button-261ab8a12b.paypal-button-layout-vertical > .zoid-outlet {
-              min-width: 75px;
-            }
-
-            #zoid-paypal-button-261ab8a12b > .zoid-outlet {
-              width: 150px;
-              height: 25px;
-            }
-
-            #zoid-paypal-button-261ab8a12b.paypal-button-size-responsive > .zoid-outlet {
-              width: 100%;
-            }
-
-            #zoid-paypal-button-261ab8a12b > .zoid-outlet > iframe {
-              min-width: 100%;
-              max-width: 100%;
-              width: 75px;
-              height: 100%;
-              position: absolute;
-              top: 0;
-              left: 0;
-            }
-
-            #zoid-paypal-button-261ab8a12b > .zoid-outlet > iframe.zoid-component-frame {
-              z-index: 100;
-            }
-
-            #zoid-paypal-button-261ab8a12b > .zoid-outlet > iframe.zoid-prerender-frame {
-              transition: opacity .2s linear;
-              z-index: 200;
-            }
-
-            #zoid-paypal-button-261ab8a12b > .zoid-outlet > iframe.zoid-visible {
-              opacity: 1;
-            }
-
-            #zoid-paypal-button-261ab8a12b > .zoid-outlet > iframe.zoid-invisible {
-              opacity: 0;
-              pointer-events: none;
-            }
-          </style>
-            <div class="zoid-outlet" style="height: 33px; transition: all 0.5s ease-in-out 0.3s;">
-              <iframe class="zoid-component-frame zoid-visible" frameborder="0" allowtransparency="true" name="xcomponent__ppbutton__4__pmrhk2leei5ceyzxgy4tiyzvmfrdeirmej2gczzchirhaylzobqwyllcov2hi33oeiwcey3pnvyg63tfnz2faylsmvxhiir2pmrhezlgei5ce5dpoarh2lbcojsw4zdfojigc4tfnz2ceot3ejzgkzrchirhi33qej6syitqojxxa4zchj5se5dzobsseorcojqxoirmej3gc3dvmurdu6zcmvxhmir2ejyhe33eovrxi2lpnyrcyittor4wyzjchj5sey3pnrxxeir2ejrgy5lfeiwce43jpjsseorcojsxg4dpnzzws5tfeiwce3dbmjswyir2ejygc6jcfqrgyylzn52xiir2ejug64tjpjxw45dbnqrcyitgovxgi2lom5uwg33oomrduztbnrzwk7jmejrw63lnnf2ceotuoj2wklbcozqwy2lemf2gkir2pmrf6x3upfygkx27ei5cex27mz2w4y3unfxw4x27ej6syitgovxgi2lom4rdu6zcmfwgy33xmvsceos3luwcezdjonqwy3dpo5swiir2lmrgg4tfmruxiirmej3gk3tnn4rf2lbcojsw2zlnmjsxezleei5fwitqmf4xaylmeiwcey3smvsgs5bcluwce4tfnvsw2ytfoirdu6zcl5pxi6lqmvpv6ir2ejpv6ztvnzrxi2lpnzpv6it5puwce33oinwgsy3lei5hwis7l52hs4dfl5pseorcl5pwm5lomn2gs33ol5pse7jmejygc6lnmvxhiir2pmrf6x3upfygkx27ei5cex27mz2w4y3unfxw4x27ej6syitpnzaxk5din5zgs6tfei5hwis7l52hs4dfl5pseorcl5pwm5lomn2gs33ol5pse7jmejsg63lbnfxceorcon2xa4dpoj2c45dimvtxkylsmruwc3romnxw2irmejzwk43tnfxw4skeei5cemjymyzwcmbqgu4dgx3hme2hi5lnpj4wq2jsoryselbcmj2xi5dpnzjwk43tnfxw4skeei5cenzqgbtdgodgg5rdox3hme2hi5lnpj4wq2jsoryselbcnvsxiyjchj5x2lbconxxk4tdmurduitnmfxhkylmeiwce4dsmvtgk5ddnbgg6z3jnyrduztbnrzwklbcn5xfezlomrsxeir2pmrf6x3upfygkx27ei5cex27mz2w4y3unfxw4x27ej6syitpnzcxe4tpoirdu6zcl5pxi6lqmvpv6ir2ejpv6ztvnzrxi2lpnzpv6it5fqrg63sdmfxggzlmei5hwis7l52hs4dfl5pseorcl5pwm5lomn2gs33ol5pse7jmejwg6y3bnrsseorcmvxf6vkteiwce3dpm5ggk5tfnqrduitxmfzg4irmejqxoyljorig64dvobbhe2lem5sseot3ejpv65dzobsv6xzchirf6x3govxgg5djn5xf6xzcpuwce43vobygyzlnmvxhiir2pmrgozlukbqxs3lfnz2e64dunfxw44zchj5sex27or4xazk7l4rduis7l5thk3tdoruw63s7l4rh2lbcmfsgiudbpfwwk3tuirsxiyljnrzseot3ejpv65dzobsv6xzchirf6x3govxgg5djn5xf6xzcpuwcez3forigc6lnmvxhirdforqws3dtei5hwis7l52hs4dfl5pseorcl5pwm5lomn2gs33ol5pse7l5fqrhizltoqrdu6zcmfrxi2lpnyrduitdnbswg23pov2ce7jmej2wszbchirdenrrmfrdqyjrgjrcelbcozsxe43jn5xceorcgqrh27jmejuwiir2eiydqyzvmi3dgmdcgercyiten5wwc2loei5ce2duoryhgorpf5zxk4dqn5zhiltunbswo5lbojsgsylofzrw63jcpu__" title="ppbutton" scrolling="no" allowpaymentrequest="allowpaymentrequest" src="https://www.paypal.com/webapps/hermes/button?env=production&amp;style.color=blue&amp;style.size=responsive&amp;style.label=pay&amp;style.layout=horizontal&amp;style.fundingicons=false&amp;commit=1&amp;funding.disallowed=credit%2Cvenmo&amp;funding.remembered=paypal%2Ccredit&amp;domain=support.theguardian.com&amp;sessionID=18f3a00583_ga4tumzyhi2tq&amp;buttonSessionID=700f38f7b7_ga4tumzyhi2tq&amp;locale.x=en_US&amp;logLevel=warn&amp;sdkMeta=eyJ1cmwiOiJodHRwczovL3d3dy5wYXlwYWxvYmplY3RzLmNvbS9hcGkvY2hlY2tvdXQuanMifQ%3D%3D&amp;uid=261ab8a12b&amp;version=4&amp;xcomponent=1" style="background-color: transparent;"></iframe>
-            </div></div>
-          </div></div>
+            PayPal</span><svg class="svg-paypal" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 15 18" preserveAspectRatio="xMinYMid"><path d="M2.334.637L.01 15.407c-.074.458.27.687 1.032.687h2.875l.804-5.483c.114-.366.313-.549.597-.549h2.674C11 9.735 12.835 8.029 13.5 4.942 14.495.313 10.031 0 8.783 0H3.036C2.8.048 2.631.124 2.53.23a.773.773 0 0 0-.196.407z" fill="#27346A"></path><path d="M5.633 4.554l-1.925 12.85c-.061.397.224.596.855.596h2.382c.34-.073.537-.205.59-.395.053-.19.298-1.628.734-4.312.087-.21.27-.314.55-.314s.891-.04 1.836-.12c2.268-.355 3.676-1.875 4.226-4.56C15.706 4.274 12.01 4 10.975 4h-4.76c-.196.041-.335.108-.419.2a.687.687 0 0 0-.163.354z" fill="#2790C3"></path><path d="M13.564 4.604a7.13 7.13 0 0 1-.065.338c-.664 3.087-2.5 4.793-5.507 5.12H5.318c-.276 0-.472.173-.588.52l.903-6.028a.687.687 0 0 1 .163-.354c.084-.092.223-.159.419-.2h4.76c.506 0 1.65.065 2.589.604zm-9.067 7.53l-.58 3.96h-.013l.593-3.96z" fill="#1F264F"></path></svg></label></li></ul>
+          </fieldset>
+          <div class="form__submit">
             <div class="form__submit--contribution">
               <button class="button button--right-arrow form__submit-button" type="submit" aria-describedby="accessibility-hint-submit-contribution">&nbsp;</button>
             </div>

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -12,6 +12,7 @@ import {
 } from 'helpers/paymentIntegrations/stripeCheckout';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { Switches } from 'helpers/settings';
+import { getQueryParameter } from 'helpers/url';
 import {
   getContributionTypeFromSessionOrElse,
   getContributionTypeFromUrlOrElse,
@@ -97,23 +98,26 @@ function initialisePaymentMethods(state: State, dispatch: Function) {
     dispatch(onThirdPartyPaymentAuthorised(paymentAuthorisation));
   };
 
-  loadStripe().then(() => {
-    ['ONE_OFF', 'ANNUAL', 'MONTHLY'].forEach((contribType) => {
-      const validPayments = getValidPaymentMethods(contribType, switches, countryId);
-      if (validPayments.includes('Stripe')) {
-        initialiseStripeCheckout(
-          onPaymentAuthorisation,
-          contribType,
-          currencyId,
-          !!isTestUser,
-          dispatch,
-        );
-      }
+  if (getQueryParameter('stripe-checkout-js') !== 'no') {
+    loadStripe().then(() => {
+      ['ONE_OFF', 'ANNUAL', 'MONTHLY'].forEach((contribType) => {
+        const validPayments = getValidPaymentMethods(contribType, switches, countryId);
+        if (validPayments.includes('Stripe')) {
+          initialiseStripeCheckout(
+            onPaymentAuthorisation,
+            contribType,
+            currencyId,
+            !!isTestUser,
+            dispatch,
+          );
+        }
+      });
     });
-  });
+  }
 
-  // DISABLED to test performance improvement
-  // loadPayPalRecurring().then(() => dispatch(setPayPalHasLoaded()));
+  if (getQueryParameter('paypal-js') !== 'no') {
+    loadPayPalRecurring().then(() => dispatch(setPayPalHasLoaded()));
+  }
 }
 
 function selectInitialAmounts(state: State, dispatch: Function) {

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -112,7 +112,8 @@ function initialisePaymentMethods(state: State, dispatch: Function) {
     });
   });
 
-  loadPayPalRecurring().then(() => dispatch(setPayPalHasLoaded()));
+  // DISABLED to test performance improvement
+  // loadPayPalRecurring().then(() => dispatch(setPayPalHasLoaded()));
 }
 
 function selectInitialAmounts(state: State, dispatch: Function) {


### PR DESCRIPTION
Looks like this has a pretty big impact on Time To Interactive, while leaving FCP and FMP unchanged (as we'd expect)

# before, loading PayPal & Stripe checkout JS as normal
<img width="660" alt="picture 455" src="https://user-images.githubusercontent.com/5122968/53946745-49575400-40bc-11e9-8f67-a3e13cbabbb2.png">

# after, without loading PayPal & Stripe checkout JS
## (also has PayPal iframe removed from serverside-rendered template)
<img width="657" alt="picture 453" src="https://user-images.githubusercontent.com/5122968/53946746-49575400-40bc-11e9-994e-bf2f09b5808f.png">
