### PR TITLE
Address form fixes

### DIFF
--- a/support-frontend/assets/helpers/internationalisation/country.js
+++ b/support-frontend/assets/helpers/internationalisation/country.js
@@ -100,6 +100,20 @@ const caStates: {
   YT: 'Yukon',
 };
 
+const auStates: {
+  [string]: string,
+} = {
+  SA: 'South Australia',
+  TAS: 'Tasmania',
+  NSW: 'New South Wales',
+  VIC: 'Victoria',
+  WA: 'Western Australia',
+  QLD: 'Queensland',
+  ACT: 'Australian Capital Territory',
+  NT: 'Northern Territory',
+  JBT: 'Jervis Bay Territory',
+};
+
 const newspaperCountries = {
   GB: 'United Kingdom',
   IM: 'Isle of Man',
@@ -361,8 +375,9 @@ const countries = {
 
 export type UsState = $Keys<typeof usStates>;
 export type CaState = $Keys<typeof caStates>;
+export type AuState = $Keys<typeof auStates>;
 export type IsoCountry = $Keys<typeof countries>;
-export type StateProvince = UsState | CaState;
+export type StateProvince = UsState | CaState | AuState;
 
 // Annoyingly, this isn't Stripe's documentation, but if you try and submit
 // a country that isn't on this list, you get an error
@@ -415,12 +430,18 @@ function caStateFromString(s: string): Option<CaState> {
   return caStates[s] ? s : null;
 }
 
+function auStateFromString(s: string): Option<AuState> {
+  return auStates[s] ? s : null;
+}
+
 function stateProvinceFromString(country: Option<IsoCountry>, s: string): Option<StateProvince> {
   switch (country) {
     case 'US':
       return usStateFromString(s);
     case 'CA':
       return caStateFromString(s);
+    case 'AU':
+      return auStateFromString(s);
     default:
       return null;
   }
@@ -578,6 +599,7 @@ export {
   setCountry,
   usStates,
   caStates,
+  auStates,
   countries,
   newspaperCountries,
   findIsoCountry,

--- a/support-frontend/assets/helpers/user/user.js
+++ b/support-frontend/assets/helpers/user/user.js
@@ -8,6 +8,7 @@ import { get as getCookie } from 'helpers/cookie';
 import { getSession } from 'helpers/storage';
 import { defaultUserActionFunctions } from 'helpers/user/defaultUserActionFunctions';
 import type { UserSetStateActions } from 'helpers/user/userActions';
+import { getSignoutUrl } from 'helpers/externalLinks';
 
 
 // ----- Functions ----- //
@@ -18,6 +19,8 @@ function isTestUser(): boolean {
   const testCookie = cookie.get('_test_username');
   return isDefined(uatMode) || isDefined(testCookie);
 }
+
+const signOut = () => { window.location.href = getSignoutUrl(); };
 
 const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActionFunctions) => {
 
@@ -94,4 +97,4 @@ const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActi
 
 // ----- Exports ----- //
 
-export { init, isTestUser };
+export { init, isTestUser, signOut };

--- a/support-frontend/assets/pages/digital-subscription-checkout/checkoutFormIsSubmittableActions.js
+++ b/support-frontend/assets/pages/digital-subscription-checkout/checkoutFormIsSubmittableActions.js
@@ -5,6 +5,7 @@
 import { getErrors, getFormFields } from 'pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer';
 import type { State } from './digitalSubscriptionCheckoutReducer';
 import type { Action } from './digitalSubscriptionCheckoutActions';
+import { formIsValid } from 'pages/digital-subscription-checkout/helpers/validation';
 
 // ----- Functions ----- //
 
@@ -16,14 +17,9 @@ const enableOrDisablePayPalExpressCheckoutButton = (formIsSubmittable: boolean) 
   }
 };
 
-const formIsValid = (state: State): boolean => {
-  const errors = getErrors(getFormFields(state));
-  return errors.length === 0;
-};
-
 function enableOrDisableForm() {
   return (dispatch: Function, getState: () => State): void => {
-    enableOrDisablePayPalExpressCheckoutButton(formIsValid(getState()));
+    enableOrDisablePayPalExpressCheckoutButton(formIsValid(getState));
   };
 }
 

--- a/support-frontend/assets/pages/digital-subscription-checkout/checkoutFormIsSubmittableActions.js
+++ b/support-frontend/assets/pages/digital-subscription-checkout/checkoutFormIsSubmittableActions.js
@@ -2,10 +2,9 @@
 
 // ----- Imports ----- //
 
-import { getErrors, getFormFields } from 'pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer';
-import type { State } from './digitalSubscriptionCheckoutReducer';
-import type { Action } from './digitalSubscriptionCheckoutActions';
+import type { State } from 'pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer';
 import { formIsValid } from 'pages/digital-subscription-checkout/helpers/validation';
+import type { Action } from 'pages/digital-subscription-checkout/digitalSubscriptionCheckoutActions';
 
 // ----- Functions ----- //
 
@@ -19,7 +18,7 @@ const enableOrDisablePayPalExpressCheckoutButton = (formIsSubmittable: boolean) 
 
 function enableOrDisableForm() {
   return (dispatch: Function, getState: () => State): void => {
-    enableOrDisablePayPalExpressCheckoutButton(formIsValid(getState));
+    enableOrDisablePayPalExpressCheckoutButton(formIsValid(getState()));
   };
 }
 

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -106,7 +106,7 @@ function mapStateToProps(state: State) {
 function mapDispatchToProps() {
   return {
     ...formActionCreators,
-    formIsValid,
+    formIsValid: () => (dispatch: Dispatch<Action>, getState: () => State) => formIsValid(getState()),
     submitForm: () => (dispatch: Dispatch<Action>, getState: () => State) => submitForm(dispatch, getState()),
     validateForm: () => (dispatch: Dispatch<Action>, getState: () => State) => validateForm(dispatch, getState()),
     setupRecurringPayPalPayment,

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 import type { Dispatch } from 'redux';
 
-import { caStates, countries, type IsoCountry, usStates } from 'helpers/internationalisation/country';
+import { auStates, caStates, countries, type IsoCountry, usStates } from 'helpers/internationalisation/country';
 import { firstError, type FormError } from 'helpers/subscriptionsForms/validation';
 import { type Option } from 'helpers/types/option';
 import { Annual, Monthly } from 'helpers/billingPeriods';
@@ -129,6 +129,8 @@ function statesForCountry(country: Option<IsoCountry>): React$Node {
       return sortedOptions(usStates);
     case 'CA':
       return sortedOptions(caStates);
+    case 'AU':
+      return sortedOptions(auStates);
     default:
       return null;
   }
@@ -268,23 +270,14 @@ function CheckoutForm(props: PropTypes) {
                 value={props.stateProvince}
                 setValue={props.setStateProvince}
                 error={firstError('stateProvince', props.formErrors)}
-                isShown={props.country === 'US' || props.country === 'CA'}
+                isShown={props.country === 'US' || props.country === 'CA' || props.country === 'AU'}
               >
                 <option value="">--</option>
                 {statesForCountry(props.country)}
               </Select2>
               <Input1
-                id="county"
-                label="County"
-                optional
-                type="text"
-                value={props.county}
-                setValue={props.setCounty}
-                error={firstError('county', props.formErrors)}
-              />
-              <Input1
                 id="postcode"
-                label="Postcode"
+                label={props.country === 'US' ? 'ZIP code' : 'Postcode'}
                 type="text"
                 value={props.postcode}
                 setValue={props.setPostcode}

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -45,12 +45,11 @@ import { setupRecurringPayPalPayment } from 'helpers/paymentIntegrations/payPalR
 import { SubscriptionSubmitButtons } from 'components/subscriptionCheckouts/subscriptionSubmitButtons';
 import { PaymentMethodSelector } from 'components/subscriptionCheckouts/paymentMethodSelector';
 import type { OptimizeExperiments } from 'helpers/optimize/optimize';
+import { signOut } from 'helpers/user/user';
+import { isPostcodeOptional, formIsValid, validateForm } from 'pages/digital-subscription-checkout/helpers/validation';
 
 import {
-  formIsValid,
-  validateForm,
   submitForm,
-  signOut,
   type FormField,
   type FormFields,
   getFormFields,
@@ -123,7 +122,6 @@ const Select1 = compose(asControlled, withError, withLabel)(Select);
 const Select2 = canShow(Select1);
 
 function statesForCountry(country: Option<IsoCountry>): React$Node {
-
   switch (country) {
     case 'US':
       return sortedOptions(usStates);
@@ -134,9 +132,7 @@ function statesForCountry(country: Option<IsoCountry>): React$Node {
     default:
       return null;
   }
-
 }
-
 
 // ----- Component ----- //
 
@@ -279,6 +275,7 @@ function CheckoutForm(props: PropTypes) {
                 id="postcode"
                 label={props.country === 'US' ? 'ZIP code' : 'Postcode'}
                 type="text"
+                optional={isPostcodeOptional(props.country)}
                 value={props.postcode}
                 setValue={props.setPostcode}
                 error={firstError('postcode', props.formErrors)}

--- a/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutActions.js
+++ b/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutActions.js
@@ -24,7 +24,6 @@ export type Action =
   | { type: 'SET_ADDRESS_LINE_1', addressLine1: string }
   | { type: 'SET_ADDRESS_LINE_2', addressLine2: string }
   | { type: 'SET_TOWN_CITY', townCity: string }
-  | { type: 'SET_COUNTY', county: string }
   | { type: 'SET_COUNTRY', country: string }
   | { type: 'SET_POSTCODE', postcode: string }
   | { type: 'SET_TELEPHONE', telephone: string }
@@ -70,7 +69,6 @@ const formActionCreators = {
   setAddressLine2: (addressLine2: string): Action => ({ type: 'SET_ADDRESS_LINE_2', addressLine2 }),
   setTownCity: (townCity: string): Function => (setFormSubmissionDependentValue(() => ({ type: 'SET_TOWN_CITY', townCity }))),
   setCountry: (country: string): Action => ({ type: 'SET_COUNTRY', country }),
-  setCounty: (county: string): Action => ({ type: 'SET_COUNTY', county }),
   setPostcode: (postcode: string): Function => (setFormSubmissionDependentValue(() => ({ type: 'SET_POSTCODE', postcode }))),
   setBillingPeriod: (billingPeriod: DigitalBillingPeriod): Action => ({ type: 'SET_BILLING_PERIOD', billingPeriod }),
   setPaymentMethod: (paymentMethod: PaymentMethod) => (dispatch: Dispatch<Action>, getState: () => State) => {

--- a/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -15,20 +15,19 @@ import {
   stateProvinceFromString,
 } from 'helpers/internationalisation/country';
 import { GBPCountries } from 'helpers/internationalisation/countryGroup';
-import { formError, type FormError, nonEmptyString, notNull, validate } from 'helpers/subscriptionsForms/validation';
+import { type FormError } from 'helpers/subscriptionsForms/validation';
 import { directDebitReducer as directDebit } from 'components/directDebit/directDebitReducer';
 import {
   marketingConsentReducerFor,
   type State as MarketingConsentState,
 } from 'components/marketingConsent/marketingConsentReducer';
-import { getSignoutUrl } from 'helpers/externalLinks';
 import { isTestUser } from 'helpers/user/user';
 import type { ErrorReason } from 'helpers/errorReasons';
 import { createUserReducer } from 'helpers/user/userReducer';
 import { fromCountry } from 'helpers/internationalisation/countryGroup';
 import type { ProductPrices } from 'helpers/productPrice/productPrices';
+import { validateForm } from 'pages/digital-subscription-checkout/helpers/validation';
 import type { Action } from './digitalSubscriptionCheckoutActions';
-import { setFormErrors } from './digitalSubscriptionCheckoutActions';
 import { getUser } from './helpers/user';
 import { showPaymentMethod, countrySupportsDirectDebit } from './helpers/paymentProviders';
 
@@ -103,58 +102,6 @@ function getEmail(state: State): string {
 }
 
 // ----- Functions ----- //
-
-function getErrors(fields: FormFields): FormError<FormField>[] {
-  return validate([
-    {
-      rule: nonEmptyString(fields.firstName),
-      error: formError('firstName', 'Please enter a value.'),
-    },
-    {
-      rule: nonEmptyString(fields.lastName),
-      error: formError('lastName', 'Please enter a value.'),
-    },
-    {
-      rule: nonEmptyString(fields.addressLine1),
-      error: formError('addressLine1', 'Please enter a value'),
-    },
-    {
-      rule: nonEmptyString(fields.townCity),
-      error: formError('townCity', 'Please enter a value'),
-    },
-    {
-      rule: nonEmptyString(fields.postcode),
-      error: formError('postcode', 'Please enter a value'),
-    },
-    {
-      rule: notNull(fields.country),
-      error: formError('country', 'Please select a country.'),
-    },
-    {
-      rule: fields.country === 'US' || fields.country === 'CA' ? notNull(fields.stateProvince) : true,
-      error: formError(
-        'stateProvince',
-        fields.country === 'CA' ? 'Please select a province/territory.' : 'Please select a state.',
-      ),
-    },
-  ]);
-}
-
-const formIsValid = () => (dispatch: Function, getState: () => State): boolean => {
-  const errors = getErrors(getFormFields(getState()));
-  return errors.length === 0;
-};
-
-const signOut = () => { window.location.href = getSignoutUrl(); };
-
-function validateForm(dispatch: Dispatch<Action>, state: State) {
-  const errors = getErrors(getFormFields(state));
-  const valid = errors.length === 0;
-  if (!valid) {
-    dispatch(setFormErrors(errors));
-  }
-  return valid;
-}
 
 function submitForm(dispatch: Dispatch<Action>, state: State) {
   if (validateForm(dispatch, state)) {
@@ -271,11 +218,7 @@ function initReducer(initialCountry: IsoCountry) {
 
 export {
   initReducer,
-  getErrors,
   getFormFields,
   getEmail,
-  signOut,
-  formIsValid,
   submitForm,
-  validateForm,
 };

--- a/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -43,7 +43,6 @@ export type FormFieldsInState = {|
   addressLine1: string,
   addressLine2: Option<string>,
   townCity: string,
-  county: Option<string>,
   postcode: string,
   email: string,
   stateProvince: Option<StateProvince>,
@@ -89,7 +88,6 @@ function getFormFields(state: State): FormFields {
     addressLine1: state.page.checkout.addressLine1,
     addressLine2: state.page.checkout.addressLine2,
     townCity: state.page.checkout.townCity,
-    county: state.page.checkout.county,
     postcode: state.page.checkout.postcode,
     country: state.common.internationalisation.countryId,
     stateProvince: state.page.checkout.stateProvince,
@@ -182,7 +180,6 @@ function initReducer(initialCountry: IsoCountry) {
     addressLine1: '',
     addressLine2: null,
     townCity: '',
-    county: '',
     postcode: '',
     stateProvince: null,
     telephone: null,
@@ -217,9 +214,6 @@ function initReducer(initialCountry: IsoCountry) {
 
       case 'SET_TOWN_CITY':
         return { ...state, townCity: action.townCity };
-
-      case 'SET_COUNTY':
-        return { ...state, county: action.county };
 
       case 'SET_POSTCODE':
         return { ...state, postcode: action.postcode };

--- a/support-frontend/assets/pages/digital-subscription-checkout/helpers/validation.js
+++ b/support-frontend/assets/pages/digital-subscription-checkout/helpers/validation.js
@@ -2,7 +2,7 @@
 
 import type { Option } from 'helpers/types/option';
 import type { IsoCountry } from 'helpers/internationalisation/country';
-import { Dispatch } from 'redux';
+import type { Dispatch } from 'redux';
 import type { Action } from 'pages/digital-subscription-checkout/digitalSubscriptionCheckoutActions';
 import { getFormFields, setFormErrors } from 'pages/digital-subscription-checkout/digitalSubscriptionCheckoutActions';
 import type {
@@ -54,8 +54,8 @@ function getErrors(fields: FormFields): FormError<FormField>[] {
   ]);
 }
 
-const formIsValid = () => (dispatch: Function, getState: () => State): boolean => {
-  const errors = getErrors(getFormFields(getState()));
+const formIsValid = (state: State): boolean => {
+  const errors = getErrors(getFormFields(state));
   return errors.length === 0;
 };
 

--- a/support-frontend/assets/pages/digital-subscription-checkout/helpers/validation.js
+++ b/support-frontend/assets/pages/digital-subscription-checkout/helpers/validation.js
@@ -37,7 +37,7 @@ function getErrors(fields: FormFields): FormError<FormField>[] {
       error: formError('townCity', 'Please enter a value'),
     },
     {
-      rule: isPostcodeOptional(fields.country) ? true : nonEmptyString(fields.postcode),
+      rule: isPostcodeOptional(fields.country) || nonEmptyString(fields.postcode),
       error: formError('postcode', 'Please enter a value'),
     },
     {

--- a/support-frontend/assets/pages/digital-subscription-checkout/helpers/validation.js
+++ b/support-frontend/assets/pages/digital-subscription-checkout/helpers/validation.js
@@ -1,0 +1,71 @@
+// @flow
+
+import type { Option } from 'helpers/types/option';
+import type { IsoCountry } from 'helpers/internationalisation/country';
+import { Dispatch } from 'redux';
+import type { Action } from 'pages/digital-subscription-checkout/digitalSubscriptionCheckoutActions';
+import { getFormFields, setFormErrors } from 'pages/digital-subscription-checkout/digitalSubscriptionCheckoutActions';
+import type {
+  FormField,
+  FormFields,
+  State,
+} from 'pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer';
+import type { FormError } from 'helpers/subscriptionsForms/validation';
+
+import { formError, nonEmptyString, notNull, validate } from 'helpers/subscriptionsForms/validation';
+
+function isPostcodeOptional(country: Option<IsoCountry>): boolean {
+  return country !== 'GB' && country !== 'AU' && country !== 'US' && country !== 'CA';
+}
+
+function getErrors(fields: FormFields): FormError<FormField>[] {
+  return validate([
+    {
+      rule: nonEmptyString(fields.firstName),
+      error: formError('firstName', 'Please enter a value.'),
+    },
+    {
+      rule: nonEmptyString(fields.lastName),
+      error: formError('lastName', 'Please enter a value.'),
+    },
+    {
+      rule: nonEmptyString(fields.addressLine1),
+      error: formError('addressLine1', 'Please enter a value'),
+    },
+    {
+      rule: nonEmptyString(fields.townCity),
+      error: formError('townCity', 'Please enter a value'),
+    },
+    {
+      rule: isPostcodeOptional(fields.country) ? true : nonEmptyString(fields.postcode),
+      error: formError('postcode', 'Please enter a value'),
+    },
+    {
+      rule: notNull(fields.country),
+      error: formError('country', 'Please select a country.'),
+    },
+    {
+      rule: fields.country === 'US' || fields.country === 'CA' || fields.country === 'AU' ? notNull(fields.stateProvince) : true,
+      error: formError(
+        'stateProvince',
+        fields.country === 'CA' ? 'Please select a province/territory.' : 'Please select a state.',
+      ),
+    },
+  ]);
+}
+
+const formIsValid = () => (dispatch: Function, getState: () => State): boolean => {
+  const errors = getErrors(getFormFields(getState()));
+  return errors.length === 0;
+};
+
+function validateForm(dispatch: Dispatch<Action>, state: State) {
+  const errors = getErrors(getFormFields(state));
+  const valid = errors.length === 0;
+  if (!valid) {
+    dispatch(setFormErrors(errors));
+  }
+  return valid;
+}
+
+export { isPostcodeOptional, validateForm, formIsValid, getErrors };

--- a/support-frontend/test/utils/CheckoutValidationRulesTest.scala
+++ b/support-frontend/test/utils/CheckoutValidationRulesTest.scala
@@ -16,7 +16,7 @@ class SimpleCheckoutFormValidationTest extends FlatSpec with Matchers {
     SimpleCheckoutFormValidation.passes(validDigitalPackRequest) shouldBe true
   }
 
-  "SimpleCheckoutFormValidation.passes" should "reject empty strings in the name field" in {
+  it should "reject empty strings in the name field" in {
     val requestMissingFirstName = validDigitalPackRequest.copy(firstName = "")
     SimpleCheckoutFormValidation.passes(requestMissingFirstName) shouldBe false
   }
@@ -34,27 +34,67 @@ class DigitalPackValidationTest extends FlatSpec with Matchers {
     DigitalPackValidation.passes(requestMissingState) shouldBe false
   }
 
-  "DigitalPackValidation.passes" should "also fail if the country is Canada and there is no state selected" in {
+  it should "also fail if the country is Canada and there is no state selected" in {
     val requestMissingState = validDigitalPackRequest.copy(
       billingAddress = validDigitalPackRequest.billingAddress.copy(country = Country.Canada, state = None),
     )
     DigitalPackValidation.passes(requestMissingState) shouldBe false
   }
 
-  "DigitalPackValidation.passes" should "pass if there is no state selected and the country is Australia" in {
+  it should "also fail if the country is Australia and there is no state selected" in {
     val requestMissingState = validDigitalPackRequest.copy(
       billingAddress = validDigitalPackRequest.billingAddress.copy(country = Country.Australia, state = None),
       product = DigitalPack(Currency.AUD, Monthly)
     )
-    DigitalPackValidation.passes(requestMissingState) shouldBe true
+    DigitalPackValidation.passes(requestMissingState) shouldBe false
   }
 
-  "DigitalPackValidation.passes" should "fail if the payment field received is an empty string" in {
+  it should "also fail if the country is Australia and there is no postcode" in {
+    val requestMissingPostcode = validDigitalPackRequest.copy(
+      billingAddress = validDigitalPackRequest.billingAddress.copy(country = Country.Australia, postCode = None),
+      product = DigitalPack(Currency.AUD, Monthly)
+    )
+    DigitalPackValidation.passes(requestMissingPostcode) shouldBe false
+  }
+
+  it should "also fail if the country is United Kingdom and there is no postcode" in {
+    val requestMissingPostcode = validDigitalPackRequest.copy(
+      billingAddress = validDigitalPackRequest.billingAddress.copy(country = Country.UK, postCode = None),
+      product = DigitalPack(Currency.GBP, Monthly)
+    )
+    DigitalPackValidation.passes(requestMissingPostcode) shouldBe false
+  }
+
+  it should "also fail if the country is United States and there is no postcode" in {
+    val requestMissingPostcode = validDigitalPackRequest.copy(
+      billingAddress = validDigitalPackRequest.billingAddress.copy(postCode = None),
+      product = DigitalPack(Currency.USD, Monthly)
+    )
+    DigitalPackValidation.passes(requestMissingPostcode) shouldBe false
+  }
+
+  it should "also fail if the country is Canada and there is no postcode" in {
+    val requestMissingPostcode = validDigitalPackRequest.copy(
+      billingAddress = validDigitalPackRequest.billingAddress.copy(country = Country.Canada, postCode = None),
+      product = DigitalPack(Currency.CAD, Monthly)
+    )
+    DigitalPackValidation.passes(requestMissingPostcode) shouldBe false
+  }
+
+  it should "also allow a missing postcode in other countries" in {
+    val requestMissingPostcode = validDigitalPackRequest.copy(
+      billingAddress = validDigitalPackRequest.billingAddress.copy(country = Country.Ireland, postCode = None),
+      product = DigitalPack(Currency.EUR, Monthly)
+    )
+    DigitalPackValidation.passes(requestMissingPostcode) shouldBe true
+  }
+
+  it should "fail if the payment field received is an empty string" in {
     val requestMissingState = validDigitalPackRequest.copy(paymentFields = StripePaymentFields(""))
     DigitalPackValidation.passes(requestMissingState) shouldBe false
   }
 
-  "DigitalPackValidation.passes" should "succeed for a standard country and currency combination" in {
+  it should "succeed for a standard country and currency combination" in {
     val requestMissingState = validDigitalPackRequest.copy(
       billingAddress = validDigitalPackRequest.billingAddress.copy(country = Country.UK, state = None),
       product = DigitalPack(Currency.GBP, Annual),
@@ -62,7 +102,7 @@ class DigitalPackValidationTest extends FlatSpec with Matchers {
     DigitalPackValidation.passes(requestMissingState) shouldBe true
   }
 
-  "DigitalPackValidation.passes" should "fail if the country and currency combination is unsupported" in {
+  it should "fail if the country and currency combination is unsupported" in {
     val requestMissingState = validDigitalPackRequest.copy(
       billingAddress = validDigitalPackRequest.billingAddress.copy(country = Country.US, state = Some("VA")),
       product = DigitalPack(Currency.GBP, Annual)
@@ -81,17 +121,17 @@ class PaperValidationTest extends FlatSpec with Matchers {
     PaperValidation.passes(requestDeliveredToUs) shouldBe false
   }
 
-  "PaperValidation.passes" should "fail if the currency is USD" in {
+  it should "fail if the currency is USD" in {
     val requestDeliveredToUs = validPaperRequest.copy(product = Paper(Currency.USD, Monthly, HomeDelivery, Everyday))
     PaperValidation.passes(requestDeliveredToUs) shouldBe false
   }
 
-  "PaperValidation.passes" should "succeed if the country is UK and the currency is GBP" in {
+  it should "succeed if the country is UK and the currency is GBP" in {
     val requestDeliveredToUs = validPaperRequest
     PaperValidation.passes(requestDeliveredToUs) shouldBe true
   }
 
-  "PaperValidation.passes" should "fail if there is no first delivery date" in {
+  it should "fail if there is no first delivery date" in {
     val requestDeliveredToUs = validPaperRequest.copy(firstDeliveryDate = None)
     PaperValidation.passes(requestDeliveredToUs) shouldBe false
   }
@@ -117,7 +157,7 @@ object TestData {
       None,
       None,
       state = Some("VA"),
-      None,
+      postCode = Some("111111"),
       country = Country.US,
     ),
     deliveryAddress = None


### PR DESCRIPTION
## Why are you doing this?

There were a number of bugs with the address section of the Digital Pack checkout
* Postcode should be 'Zip code' in the US
* Postcode should be optional in countries other than US, UK, AU & CA
* AU should have a mandatory state list

Other changes:
* We have decided that we don't need the county field (it was optional and not actually being saved to Zuora) so I have removed it.
* I have moved all the validation code out of `/digitalSubscriptionCheckoutReducer.js` into its own file.

[**Trello Card**](https://trello.com/c/m8N722T3/2282-bugs-in-the-us-digital-pack-checkout)
