### PR TITLE
load raven library on demand rather than bundling it

### DIFF
--- a/support-frontend/assets/helpers/logger.js
+++ b/support-frontend/assets/helpers/logger.js
@@ -1,39 +1,45 @@
 // @flow
-import Raven from 'raven-js';
+// import Raven from 'raven-js';
+
+const EventualRaven = import('raven-js');
 
 // ----- Functions ----- //
 
-const init = () => {
+const init = () => EventualRaven.then((Raven) => {
   const dsn: string = 'https://65f7514888b6407881f34a6cf1320d06@sentry.io/1213654';
   const { gitCommitId } = window.guardian;
 
-  Raven.config(dsn, {
+  Raven.default.config(dsn, {
     whitelistUrls: ['support.theguardian.com', 'localhost'],
     release: gitCommitId,
   }).install();
-};
+});
 
 
 const logException = (ex: string, context?: Object): void => {
-  Raven.captureException(
-    new Error(ex),
-    {
-      extra: context,
-    },
-  );
+  EventualRaven.then((Raven) => {
+    Raven.default.captureException(
+      new Error(ex),
+      {
+        extra: context,
+      },
+    );
 
-  if (window.console && console.error) {
-    console.error(ex);
-  }
+    if (window.console && console.error) {
+      console.error(ex);
+    }
+  });
 };
 
 const logInfo = (message: string): void => {
-  Raven.captureMessage(
-    message,
-    {
-      level: 'info',
-    },
-  );
+  EventualRaven.then((Raven) => {
+    Raven.default.captureMessage(
+      message,
+      {
+        level: 'info',
+      },
+    );
+  });
 };
 
 // ----- Exports ----- //


### PR DESCRIPTION
We noticed that the raven library was in the bundle and taking up 39K (13K gzipped).  The rest of the bundle is 280kb (80kb gzipped).  This is about 15% which is something that is non critical to painting the page.

It seems to be working OK locally, just letting the promise run and discarding the result.  I'm not sure whether that is good practice though?  In case the bundle doesn't download, we might not realise.

[**Trello Card**](https://trello.com/c/E5XA4fqR/356-js-raven-load-on-demand)

|PROD|CODE|
|---|---|
|![image](https://user-images.githubusercontent.com/7304387/53975290-66ac1280-40fc-11e9-901d-a2c8016bf7d9.png)|![image](https://user-images.githubusercontent.com/7304387/53975325-788db580-40fc-11e9-9853-0efc797718f5.png)|
|![image](https://user-images.githubusercontent.com/7304387/53975366-8d6a4900-40fc-11e9-92b7-7ef355e39399.png)|![image](https://user-images.githubusercontent.com/7304387/53975389-99eea180-40fc-11e9-86b1-8edc74b22c2b.png)|
|![image](https://user-images.githubusercontent.com/7304387/53975996-ff8f5d80-40fd-11e9-93b7-613070cb7e50.png)|![image](https://user-images.githubusercontent.com/7304387/53975920-d79ffa00-40fd-11e9-84ab-e81bfe29c44e.png)|


