### PR TITLE
Remove debug statement

### DIFF
--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
@@ -27,7 +27,6 @@ class SendThankYouEmail(thankYouEmailService: EmailService, servicesProvider: Se
     context: Context,
     services: Services
   ): FutureHandlerResult = {
-    SafeLogger.info(s"Number of available processors: ${Runtime.getRuntime.availableProcessors()}")
     for {
       mandateId <- fetchDirectDebitMandateId(state, services.zuoraService)
       emailResult <- sendEmail(state, mandateId)


### PR DESCRIPTION
## Why are you doing this?

This logging is no longer required. 

For context: a year or so ago I was investigating an issue with this lambda and I thought the number of processors might be relevant. I don't think anyone cares about this anymore.
