### PR TITLE
Tighten up first/last name field validation

### DIFF
--- a/support-frontend/app/utils/CheckoutValidationRules.scala
+++ b/support-frontend/app/utils/CheckoutValidationRules.scala
@@ -17,10 +17,13 @@ object SimpleCheckoutFormValidation {
 
   def passes(createSupportWorkersRequest: CreateSupportWorkersRequest): Boolean =
     noEmptyNameFields(createSupportWorkersRequest.firstName, createSupportWorkersRequest.lastName) &&
+      noExcessivelyLongNameFields(createSupportWorkersRequest.firstName, createSupportWorkersRequest.lastName) &&
       noEmptyPaymentFields(createSupportWorkersRequest.paymentFields)
 
 
   private def noEmptyNameFields(firstName: String, lastName: String) = !firstName.isEmpty && !lastName.isEmpty
+
+  private def noExcessivelyLongNameFields(firstName: String, lastName: String) = !(firstName.length > 40) && !(lastName.length > 80)
 
   private def noEmptyPaymentFields(paymentFields: PaymentFields): Boolean = paymentFields match {
     case directDebitDetails: DirectDebitPaymentFields =>

--- a/support-frontend/test/utils/CheckoutValidationRulesTest.scala
+++ b/support-frontend/test/utils/CheckoutValidationRulesTest.scala
@@ -21,6 +21,16 @@ class SimpleCheckoutFormValidationTest extends FlatSpec with Matchers {
     SimpleCheckoutFormValidation.passes(requestMissingFirstName) shouldBe false
   }
 
+  it should "reject a first name which is too long" in {
+    val requestWithLongFirstName = validDigitalPackRequest.copy(firstName = "TooLongToBeFirstNameAccordingToSalesforce")
+    SimpleCheckoutFormValidation.passes(requestWithLongFirstName) shouldBe false
+  }
+
+  it should "reject a last name which is too long" in {
+    val requestWithLongLastName = validDigitalPackRequest.copy(lastName = "TooLongToBeLastNameAccordingToSalesforceTooLongToBeLastNameAccordingToSalesforce1")
+    SimpleCheckoutFormValidation.passes(requestWithLongLastName) shouldBe false
+  }
+
 }
 
 class DigitalPackValidationTest extends FlatSpec with Matchers {


### PR DESCRIPTION
## Why are you doing this?

If someone manages to submit the Digital Pack checkout form with a name like ''Anker PowerLine+ Lightning Cable (6ft) Durable and Fast Charging Cable [Double Braided Nylon] for iPhone iPad", we should not invoke the Step Function. (Yes, this really did happen).

[**Trello Card**](https://trello.com/c/Znjwl1F8/2289-improve-server-side-validation-for-name-fields)

## Changes

* Add server side validation for first/last name field length, based on Salesforce limits:

![image](https://user-images.githubusercontent.com/19384074/54018579-f98e9080-4180-11e9-840e-36790996e6bc.png)