### PR TITLE
Add address line 1 and city to the server side validation and fix initial value of start date. 

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckoutReducer.js
+++ b/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckoutReducer.js
@@ -229,7 +229,7 @@ function initReducer(initialCountry: IsoCountry, productInUrl: ?string, fulfillm
     email: user.email || '',
     firstName: user.firstName || '',
     lastName: user.lastName || '',
-    startDate: '',
+    startDate: null,
     telephone: null,
     paymentMethod: countrySupportsDirectDebit(initialCountry) ? 'DirectDebit' : 'Stripe',
     formErrors: [],

--- a/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckoutReducer.js
+++ b/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckoutReducer.js
@@ -9,7 +9,7 @@ import { type Option } from 'helpers/types/option';
 import csrf, { type Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import { type IsoCountry } from 'helpers/internationalisation/country';
 import { GBPCountries } from 'helpers/internationalisation/countryGroup';
-import { formError, type FormError, nonEmptyString, validate } from 'helpers/subscriptionsForms/validation';
+import { formError, type FormError, nonEmptyString, validate, notNull } from 'helpers/subscriptionsForms/validation';
 import { directDebitReducer as directDebit } from 'components/directDebit/directDebitReducer';
 import { type Action as DDAction } from 'components/directDebit/directDebitActions';
 import {
@@ -54,7 +54,7 @@ export type FormFields = {|
   firstName: string,
   lastName: string,
   email: string,
-  startDate: string,
+  startDate: Option<string>,
   telephone: Option<string>,
   paymentMethod: Option<PaymentMethod>,
 |};
@@ -131,7 +131,7 @@ function getErrors(fields: FormFields): FormError<FormField>[] {
       error: formError('lastName', 'Please enter a last name.'),
     },
     {
-      rule: nonEmptyString(fields.startDate),
+      rule: notNull(fields.startDate),
       error: formError('startDate', 'Please select a start date'),
     },
   ]);

--- a/support-frontend/test/utils/CheckoutValidationRulesTest.scala
+++ b/support-frontend/test/utils/CheckoutValidationRulesTest.scala
@@ -189,9 +189,9 @@ object TestData {
     telephoneNumber = None,
     promoCode = None,
     billingAddress = Address(
+      Some("123 easy street"),
       None,
-      None,
-      None,
+      Some("arlington"),
       state = Some("VA"),
       postCode = Some("111111"),
       country = Country.US,

--- a/support-frontend/test/utils/CheckoutValidationRulesTest.scala
+++ b/support-frontend/test/utils/CheckoutValidationRulesTest.scala
@@ -120,6 +120,19 @@ class DigitalPackValidationTest extends FlatSpec with Matchers {
     DigitalPackValidation.passes(requestMissingState) shouldBe false
   }
 
+  it should "fail when missing an address line or a city for billing address" in {
+    val badBillingAddress = Address(
+      lineOne = None,
+      lineTwo = None,
+      city = None,
+      state = None,
+      postCode = None,
+      country = Country.UK
+    )
+    val requestMissingAddressLineAndCity = validDigitalPackRequest.copy(billingAddress = badBillingAddress)
+    DigitalPackValidation.passes(requestMissingAddressLineAndCity) shouldBe false
+  }
+
 }
 
 class PaperValidationTest extends FlatSpec with Matchers {
@@ -144,6 +157,19 @@ class PaperValidationTest extends FlatSpec with Matchers {
   it should "fail if there is no first delivery date" in {
     val requestDeliveredToUs = validPaperRequest.copy(firstDeliveryDate = None)
     PaperValidation.passes(requestDeliveredToUs) shouldBe false
+  }
+
+  it should "fail when missing an address data for billing and delivery address" in {
+      val emptyAddress = Address(
+        lineOne = None,
+        lineTwo = None,
+        city = None,
+        state = None,
+        postCode = None,
+        country = Country.UK
+      )
+      val requestMissingAddressLineAndCity = validPaperRequest.copy(billingAddress = emptyAddress, deliveryAddress = Some(emptyAddress))
+      DigitalPackValidation.passes(requestMissingAddressLineAndCity) shouldBe false
   }
 
 }


### PR DESCRIPTION
## Why are you doing this?
I was actually looking at what errors got displayed when the server side validation failed and I noticed a couple things

- We require a billing address for digital pack, and both a billing address and a delivery address for paper, but this isn't reflected in the server side validation
- If the user doesn't select a start date and manages to submit the form (there is client side validation that prevents this, but if it fails...), this sends the date as an empty string, it gets parsed as `Some("")` and then `POST /subscribe/create` returns a 500. Setting an initial value of null allows our server side validation to catch a missing start date and return a 400 instead. 

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/9qGNJFwU/2259-client-side-error-handling-for-failed-attempts-to-create-a-hd-voucher-subscription)

## Changes

* Server side validation requires address line 1 and city for billing address (and also for delivery address for paper)
* Initial value of start date is null

## Screenshots

