### PR TITLE
jy banner update fixes

### DIFF
--- a/support-frontend/assets/components/productPage/productPageHero/productPageHero.scss
+++ b/support-frontend/assets/components/productPage/productPageHero/productPageHero.scss
@@ -29,6 +29,9 @@
   .component-grid-picture__image {
     height: 100%;
   }
+  &.component-product-page-hero--feature {
+    max-height: 600px;
+  }
 }
 
 .component-product-page-hero--feature {

--- a/support-frontend/assets/pages/digital-subscription-landing/components/theMoment.scss
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/theMoment.scss
@@ -1,24 +1,20 @@
 @import '~stylesheets/gu-sass/gu-sass';
 
-// "Joy of Print Sale" specific styles below! 
-
 
 .component-product-page-hero.component-product-page-hero--digital-campaign {
   background: #FCF8F2;
   box-sizing: border-box;
   height: auto;
+  min-height: 200px;
 
   & * {
     box-sizing: border-box;
   }
-
-  // height: auto;
 }
 
 .the-moment-hero {
   display: flex;
   align-items: center;
-  min-height: 360px;
   padding: $gu-v-spacing*2 0 $gu-v-spacing*3;
   
   @include mq($from: tablet) {
@@ -68,7 +64,6 @@
     @include mq($from: tablet) {      
       h2 {
         font-size: 44px;
-        // max-width: 50%;
       }
     }
 
@@ -93,7 +88,7 @@
   align-items: center;
   justify-content: center;
   max-width: gu-span(8);
-  display: none; //TODO: fix image
+  // display: none; //TODO: fix image
   
   @include mq($from: mobileMedium) {
     padding-top: $gu-v-spacing*1;

--- a/support-frontend/assets/pages/digital-subscription-landing/components/theMoment.scss
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/theMoment.scss
@@ -88,7 +88,6 @@
   align-items: center;
   justify-content: center;
   max-width: gu-span(8);
-  // display: none; //TODO: fix image
   
   @include mq($from: mobileMedium) {
     padding-top: $gu-v-spacing*1;


### PR DESCRIPTION
## Why are you doing this?

This commit addresses the stuff that got missed in Fridays merge conflict bonanza. 

[**Trello Card**](https://trello.com/c/J0X4PCRe/2278-digital-pack-hero-panel-design)

## Changes

* Remove commented css
* Add max height ONLY to the standard banner
* Remove display none on the Digital Pack images in the banner.

## Screenshots

![Screen Shot 2019-03-08 at 15 11 44](https://user-images.githubusercontent.com/1108991/54117880-b2ef9f00-43e9-11e9-85e9-19f782624c6f.png)
