### PR TITLE
Update alt text and fix 404 image

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
@@ -199,10 +199,10 @@ const SaleHeader = () => (
           <div className="the-moment-hero__graphic">
             <GridImage
               gridId="theMomentDigiHero"
-              srcSizes={[486, 772]}
+              srcSizes={[486]}
               sizes="(max-width: 740px) 315px, 486px"
               imgType="png"
-              altText="A couple sit together sharing one newspaper"
+              altText="A mobile device"
             />
           </div>
 
@@ -214,7 +214,7 @@ const SaleHeader = () => (
                   srcSizes={[486]}
                   sizes="(max-width: 740px) 315px, 486px"
                   imgType="png"
-                  altText="A couple sit together sharing one newspaper"
+                  altText="A mobile device"
                 />
               </div>
               <div className="the-moment-hero__graphic-slider-2">
@@ -223,7 +223,7 @@ const SaleHeader = () => (
                   srcSizes={[486]}
                   sizes="(max-width: 740px) 315px, 486px"
                   imgType="png"
-                  altText="A couple sit together sharing one newspaper"
+                  altText="A mobile device"
                 />
               </div>
               <div className="the-moment-hero__graphic-slider-3">
@@ -232,7 +232,7 @@ const SaleHeader = () => (
                   srcSizes={[486]}
                   sizes="(max-width: 740px) 315px, 486px"
                   imgType="png"
-                  altText="A couple sit together sharing one newspaper"
+                  altText="A mobile device"
                 />
               </div>
 


### PR DESCRIPTION
## Why are you doing this?

After a test on a real device I realised a `srcset` image path was broken for mobile. For good measure I also updated alt text 

[**Trello Card**](https://trello.com/c/J0X4PCRe/2278-digital-pack-hero-panel-designdev)

## Changes

* Fix `srcset` path
* Add alt text

I didn't get a screenshot of the broken layout sorry.
