### PR TITLE
Jy promo link fix

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -161,7 +161,7 @@ const content = (
       </Content>
       <Content>
         <Text title="Promotion terms and conditions">
-          <p>Offer subject to availability. Guardian News and Media Limited (&ldquo;GNM&rdquo;) reserves the right to withdraw this promotion at any time. For full annual promotion terms and conditions, see <a target="_blank" rel="noopener noreferrer" href={`https://subscribe.theguardian.com/p/WWM99X/terms?country=${subsCountry}`}>here</a>.
+          <p>Offer subject to availability. Guardian News and Media Limited (&ldquo;GNM&rdquo;) reserves the right to withdraw this promotion at any time. For full annual promotion terms and conditions, see <a target="_blank" rel="noopener noreferrer" href={`https://subscribe.theguardian.com/p/10ANNUAL/terms?country=${subsCountry}`}>here</a>.
           </p>
         </Text>
         <Text title="Guardian Weekly terms and conditions">


### PR DESCRIPTION
## Why are you doing this?

Marketing supplied a link to a valid promo T&C page for Weekly. I updated one last week but missed the second instance.

## Changes

* Update link

## Screenshots

![Screen Shot 2019-03-11 at 12 00 07](https://user-images.githubusercontent.com/1108991/54122543-3cf13500-43f5-11e9-8e40-d62806cf0f75.png)
