### PR TITLE
Rename Step Function

### DIFF
--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -166,6 +166,7 @@ Resources:
     Type: "AWS::StepFunctions::StateMachine"
     Condition: CreateCodeResources
     Properties:
+      StateMachineName: !Sub support-workers-${Stage}
       DefinitionString:
         !Sub
           - |-

--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -162,6 +162,18 @@ Resources:
           - {}
       RoleArn: !GetAtt [ StatesExecutionRole, Arn ]
 
+  SupportWorkersCODE:
+    Type: "AWS::StepFunctions::StateMachine"
+    Condition: CreateCodeResources
+    Properties:
+      DefinitionString:
+        !Sub
+          - |-
+            {{> stateMachine}}
+
+          - {}
+      RoleArn: !GetAtt [ StatesExecutionRole, Arn ]
+
   ExecutionFailureAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: CreateProdResources

--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -150,6 +150,19 @@ Resources:
           - {}
       RoleArn: !GetAtt [ StatesExecutionRole, Arn ]
 
+  SupportWorkersPROD:
+    Type: "AWS::StepFunctions::StateMachine"
+    Condition: CreateProdResources
+    Properties:
+      StateMachineName: !Sub support-workers-${Stage}
+      DefinitionString:
+        !Sub
+          - |-
+            {{> stateMachine}}
+
+          - {}
+      RoleArn: !GetAtt [ StatesExecutionRole, Arn ]
+
   MonthlyContributionsCODE:
     Type: "AWS::StepFunctions::StateMachine"
     Condition: CreateCodeResources

--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -201,13 +201,13 @@ Resources:
       Namespace: AWS/States
       Dimensions:
         - Name: StateMachineArn
-          Value: !Ref MonthlyContributionsPROD
+          Value: !Ref SupportWorkersPROD
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Threshold: 1
       Period: 60
       EvaluationPeriods: 1
       Statistic: Sum
-    DependsOn: MonthlyContributionsPROD
+    DependsOn: SupportWorkersPROD
 
   TimeoutAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -222,10 +222,10 @@ Resources:
       Namespace: AWS/States
       Dimensions:
         - Name: StateMachineArn
-          Value: !Ref MonthlyContributionsPROD
+          Value: !Ref SupportWorkersPROD
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Threshold: 1
       Period: 60
       EvaluationPeriods: 1
       Statistic: Sum
-    DependsOn: MonthlyContributionsPROD
+    DependsOn: SupportWorkersPROD


### PR DESCRIPTION
## Why are you doing this?

The support-workers project still creates a Step Function called `MonthlyContributions-{random string}`, even though it is now responsible for setting up multiple products. 

There are several steps involved because renaming = creating a brand new Step Function and deleting the old one.

- [x] Deploy to CODE (to create a new Step Function)
- [x] Update DEV and CODE private config to use the new CODE Step Function's arn
- [x] Redeploy CODE to start using the new Step Function
- [ ] Deploy to PROD (to create a new Step Function)
- [ ] Update PROD private config to use the new PROD Step Function's arn (after merging this)
- [ ] Redeploy PROD to start using the new Step Function
- [ ] Separate PR (once two weeks have passed) - delete the old Step Functions completely