### PR TITLE
Paper checkout form tweaks

### DIFF
--- a/support-frontend/.flowconfig
+++ b/support-frontend/.flowconfig
@@ -1,6 +1,7 @@
 [ignore]
 .*/node_modules/preact/.*
 .*node_modules/webpack-cli/.*
+.*target/.*
 
 [include]
 assets

--- a/support-frontend/assets/components/checkoutForm/checkoutForm.jsx
+++ b/support-frontend/assets/components/checkoutForm/checkoutForm.jsx
@@ -36,7 +36,7 @@ the top level form itself
 */
 
 type FormPropTypes = {
-  children: ChildrenArray<Element<any>>,
+  children: ChildrenArray<Element<any> | null>,
 };
 const Form = ({ children, ...otherProps }: FormPropTypes) => (<form {...otherProps} className="component-checkout-form">{children}</form>);
 

--- a/support-frontend/assets/components/subscriptionCheckouts/paymentMethodSelector.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/paymentMethodSelector.jsx
@@ -22,8 +22,8 @@ type PropTypes = {|
 |}
 
 const isPayPalEnabled = (optimizeExperiments: OptimizeExperiments) => {
-  const PayPalExperimentId = "8IebFnX-SbKRxhlj_tGp-w";
-  const enabledByTest = optimizeExperiments.find((exp) => exp.id === PayPalExperimentId && exp.variant === '1');
+  const PayPalExperimentId = '8IebFnX-SbKRxhlj_tGp-w';
+  const enabledByTest = optimizeExperiments.find(exp => exp.id === PayPalExperimentId && exp.variant === '1');
   const enabledByQueryString = getQueryParameter('payPal') === 'true';
   return enabledByTest || enabledByQueryString;
 };

--- a/support-frontend/assets/helpers/externalLinks.js
+++ b/support-frontend/assets/helpers/externalLinks.js
@@ -32,9 +32,13 @@ export type SubsUrls = {
 const subsUrl = `https://subscribe.${getBaseDomain()}`;
 const patronsUrl = 'https://patrons.theguardian.com';
 const profileUrl = `https://profile.${getBaseDomain()}`;
+const manageUrl = `https://manage.${getBaseDomain()}`;
 const defaultIntCmp = 'gdnwb_copts_bundles_landing_default';
 const androidAppUrl = 'https://play.google.com/store/apps/details?id=com.guardian';
 const emailPreferencesUrl = `${profileUrl}/email-prefs`;
+const myAccountUrl = `${profileUrl}/account/edit`;
+const manageSubsUrl = `${manageUrl}/subscriptions`;
+
 
 function getWeeklyZuoraCode(period: WeeklyBillingPeriod, countryGroup: CountryGroupId) {
 
@@ -397,6 +401,8 @@ export {
   getDailyEditionUrl,
   getSignoutUrl,
   emailPreferencesUrl,
+  myAccountUrl,
+  manageSubsUrl,
   getWeeklyCheckout,
   getPaperCheckout,
 };

--- a/support-frontend/assets/pages/paper-subscription-checkout/components-checkout/addressFields.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components-checkout/addressFields.jsx
@@ -112,6 +112,14 @@ class AddressFields<GlobalState> extends Component<PropTypes<GlobalState>> {
           setValue={props.setTownCity}
           error={firstError('city', props.formErrors)}
         />
+        <InputWithError
+          id={`${scope}-postcode`}
+          label="Postcode"
+          type="text"
+          value={props.postCode}
+          setValue={props.setPostCode}
+          error={firstError('postCode', props.formErrors)}
+        />
         <SelectWithError
           id={`${scope}-country`}
           label="Country"

--- a/support-frontend/assets/pages/paper-subscription-checkout/components-checkout/addressFields.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components-checkout/addressFields.jsx
@@ -117,7 +117,7 @@ class AddressFields<GlobalState> extends Component<PropTypes<GlobalState>> {
           label="Postcode"
           type="text"
           value={props.postCode}
-          setValue={props.setPostCode}
+          setValue={props.setPostcode}
           error={firstError('postCode', props.formErrors)}
         />
         <SelectWithError

--- a/support-frontend/assets/pages/paper-subscription-checkout/components-checkout/checkoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components-checkout/checkoutForm.jsx
@@ -171,9 +171,31 @@ function CheckoutForm(props: PropTypes) {
             <FormSection title="Where should we deliver your newspapers?">
               <DeliveryAddress />
             </FormSection>
-            <FormSection title="Where should we bill you?">
-              <BillingAddress />
+            <FormSection title="Is the billing address the same as the delivery address?">
+              <Rows>
+                <Fieldset legend="Is the billing address the same as the delivery address?">
+                  <RadioInput
+                    text="Yes"
+                    name="billingAddressIsSame"
+                    checked={props.billingAddressIsSame}
+                    onChange={() => props.setbillingAddressIsSame(true)}
+                  />
+                  <RadioInput
+                    text="No"
+                    name="billingAddressIsSame"
+                    checked={!props.billingAddressIsSame}
+                    onChange={() => props.setbillingAddressIsSame(false)}
+                  />
+                </Fieldset>
+                {errorState}
+              </Rows>
             </FormSection>
+            {
+              props.billingAddressIsSame ? null :
+              <FormSection title="Where should we bill you?">
+                <BillingAddress />
+              </FormSection>
+            }
             <FormSection title="When would you like your subscription to start?">
               <FieldsetWithError id="startDate" error={firstError('startDate', props.formErrors)} legend="When would you like your subscription to start?">
                 {days.map((day) => {

--- a/support-frontend/assets/pages/paper-subscription-checkout/components-checkout/postcodeFinder.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components-checkout/postcodeFinder.jsx
@@ -50,7 +50,7 @@ const InputWithButton = ({ onClick, isLoading, ...props }) => (
         onClick={onClick}
         aria-label={null}
       >
-        Find it
+        Find address
       </Button>
     }
   </div>

--- a/support-frontend/assets/pages/paper-subscription-checkout/components-ty/thankYou.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components-ty/thankYou.jsx
@@ -14,6 +14,7 @@ import Content from 'components/content/content';
 import Text, { SansParagraph, LargeParagraph } from 'components/text/text';
 import { HeroWrapper } from 'components/productPage/productPageHero/productPageHero';
 import HeadingBlock from 'components/headingBlock/headingBlock';
+import { manageSubsUrl, myAccountUrl } from 'helpers/externalLinks';
 import typeof MarketingConsent from './marketingConsentContainer';
 import styles from './thankYou.module.scss';
 import { formatUserDate } from '../helpers/deliveryDays';
@@ -111,7 +112,8 @@ function ThankYouContent({
       <Content>
         <Text>
           <SansParagraph>
-            You can manage your subscription by visiting our Manage section or accessing it via your Guardian account.
+            You can manage your subscription by visiting our <a href={manageSubsUrl}>Manage section</a> or accessing
+            it via <a href={myAccountUrl}>your Guardian account</a>.
           </SansParagraph>
         </Text>
       </Content>

--- a/support-frontend/assets/pages/paper-subscription-checkout/helpers/paymentProviders.js
+++ b/support-frontend/assets/pages/paper-subscription-checkout/helpers/paymentProviders.js
@@ -45,6 +45,7 @@ function buildRegularPaymentRequest(state: State, paymentAuthorisation: PaymentA
     lastName,
     email,
     telephone,
+    billingAddressIsSame,
   } = state.page.checkout;
 
   const product = {
@@ -56,14 +57,14 @@ function buildRegularPaymentRequest(state: State, paymentAuthorisation: PaymentA
 
   const paymentFields = regularPaymentFieldsFromAuthorisation(paymentAuthorisation);
 
-  const billingAddress = {
-    ...getAddressFieldsState(getFormFields(getBillingAddress(state))),
+  const deliveryAddress = {
+    ...getAddressFieldsState(getFormFields(getDeliveryAddress(state))),
     state: null,
     country: countryId,
   };
 
-  const deliveryAddress = {
-    ...getAddressFieldsState(getFormFields(getDeliveryAddress(state))),
+  const billingAddress = billingAddressIsSame ? deliveryAddress : {
+    ...getAddressFieldsState(getFormFields(getBillingAddress(state))),
     state: null,
     country: countryId,
   };

--- a/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckoutReducer.js
+++ b/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckoutReducer.js
@@ -158,20 +158,25 @@ function submitForm(dispatch: Dispatch<Action>, state: State) {
     dispatcher: any => Action,
   }
 
+  const formFields: FormFields = getFormFields(state);
+
   const allErrors: (Error<AddressFormField> | Error<FormField>)[] = [
     ({
-      errors: getErrors(getFormFields(state)),
+      errors: getErrors(formFields),
       dispatcher: setFormErrors,
     }: Error<FormField>),
     ({
       errors: getAddressFormErrors(getAddressFormFields(getDeliveryAddress(state))),
       dispatcher: setAddressFormErrorsFor('delivery'),
     }: Error<AddressFormField>),
-    ({
+  ].filter(({ errors }) => errors.length > 0);
+
+  if (!formFields.billingAddressIsSame) {
+    allErrors.push(({
       errors: getAddressFormErrors(getAddressFormFields(getBillingAddress(state))),
       dispatcher: setAddressFormErrorsFor('billing'),
-    }: Error<AddressFormField>),
-  ].filter(({ errors }) => errors.length > 0);
+    }: Error<AddressFormField>));
+  }
 
   if (allErrors.length > 0) {
     allErrors.forEach(({ errors, dispatcher }) => {

--- a/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckoutReducer.js
+++ b/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckoutReducer.js
@@ -57,6 +57,7 @@ export type FormFields = {|
   startDate: Option<string>,
   telephone: Option<string>,
   paymentMethod: Option<PaymentMethod>,
+  billingAddressIsSame: boolean,
 |};
 
 export type FormField = $Keys<FormFields>;
@@ -92,6 +93,7 @@ export type Action =
   | { type: 'SET_FORM_ERRORS', errors: FormError<FormField>[] }
   | { type: 'SET_SUBMISSION_ERROR', error: ErrorReason }
   | { type: 'SET_FORM_SUBMITTED', formSubmitted: boolean }
+  | { type: 'SET_BILLING_ADDRESS_IS_SAME', isSame: boolean }
   | DDAction
   | AddressAction;
 
@@ -108,6 +110,7 @@ function getFormFields(state: State): FormFields {
     paymentMethod: state.page.checkout.paymentMethod,
     fulfilmentOption: state.page.checkout.fulfilmentOption,
     productOption: state.page.checkout.productOption,
+    billingAddressIsSame: state.page.checkout.billingAddressIsSame,
   };
 }
 
@@ -193,6 +196,7 @@ const formActionCreators = {
   onPaymentAuthorised: (authorisation: PaymentAuthorisation) => (dispatch: Dispatch<Action>, getState: () => State) =>
     onPaymentAuthorised(authorisation, dispatch, getState()),
   submitForm: () => (dispatch: Dispatch<Action>, getState: () => State) => submitForm(dispatch, getState()),
+  setbillingAddressIsSame: (isSame: boolean): Action => ({ type: 'SET_BILLING_ADDRESS_IS_SAME', isSame }),
 };
 
 export type FormActionCreators = typeof formActionCreators;
@@ -238,6 +242,7 @@ function initReducer(initialCountry: IsoCountry, productInUrl: ?string, fulfillm
     isTestUser: isTestUser(),
     ...getInitialProduct(productInUrl, fulfillmentInUrl),
     productPrices,
+    billingAddressIsSame: true,
   };
 
   function reducer(state: CheckoutState = initialState, action: Action): CheckoutState {
@@ -274,6 +279,9 @@ function initReducer(initialCountry: IsoCountry, productInUrl: ?string, fulfillm
 
       case 'SET_FORM_SUBMITTED':
         return { ...state, formSubmitted: action.formSubmitted };
+
+      case 'SET_BILLING_ADDRESS_IS_SAME':
+        return { ...state, billingAddressIsSame: action.isSame };
 
       default:
         return state;


### PR DESCRIPTION
## Why are you doing this?
A few changes for the paper subs checkout:
* Update wording on the postcode lookup button
* Hide the billing address fields unless the user tells us that it is different from the delivery address
* Add a postcode field into the main address form as well as the postcode finder field
* Add links to manage subscription and edit profile to the thank you page

**Address form now looks like this:**
![Screen Shot 2019-03-11 at 16 50 29](https://user-images.githubusercontent.com/181371/54141563-d7656e80-441d-11e9-851f-5d9473f563ad.png)

**Thank you text now looks like this:**
![Screen Shot 2019-03-11 at 17 19 51](https://user-images.githubusercontent.com/181371/54143614-1a294580-4422-11e9-9d53-89fd2a5e69af.png)


[**Trello Card**](https://trello.com/c/kpRzL7zH/2288-checkout-ux-paper-cuts)
