### PR TITLE
small fix for setup script

### DIFF
--- a/support-frontend/setup.sh
+++ b/support-frontend/setup.sh
@@ -137,6 +137,7 @@ fetch_dev_cert() {
 }
 
 link_nginx_config() {
+  mkdir -p ${NGINX_ROOT}sites-enabled
   ln -sf ${PWD}/nginx/support.conf ${NGINX_ROOT}sites-enabled/support.conf
 }
 


### PR DESCRIPTION
## Why are you doing this?
The setup script fails if the Nginx sites-enabled doesn't exist. With this change the directory would be created if it doesn't exist

