### PR TITLE
Copy updates to DP product page

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
@@ -172,7 +172,7 @@ function getCopy(product: SubscriptionProduct, country: CountryGroupId) {
   }
   return {
     heading: 'Digital Pack',
-    subHeading: 'Award-winning, independent journalism, ad-free on all devices',
+    subHeading: 'The premium Guardian experience, ad-free on all your devices',
   };
 }
 
@@ -180,9 +180,9 @@ const SaleHeader = () => (
   <ProductPagehero
     appearance="campaign"
     overheading="Digital Pack subscriptions"
-    heading="The Guardian, ad-free on all of your devices"
+    heading="The premium Guardian experience, ad-free on all your devices"
     modifierClasses={['digital-campaign']}
-    content={<AnchorButton aria-label="See Subscription options for Digital Pack" onClick={sendTrackingEventsOnClick('options_cta_click', 'DigitalPack', null)} icon={<SvgChevron />} href="#subscribe">Start your 14 day free trial</AnchorButton>}
+    content={<AnchorButton aria-label="See Subscription options for Digital Pack" onClick={sendTrackingEventsOnClick('options_cta_click', 'DigitalPack', null)} icon={<SvgChevron />} href="#subscribe">See Subscription options</AnchorButton>}
     hasCampaign
   >
 


### PR DESCRIPTION
## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->There are few copy changes we need to make on the Digital Pack product page to make the messaging clearer.

[**Trello Card**](https://trello.com/c/upwHBvin)

## Changes

* Updated CTA copy
* Updated header copy for for sale and BAU

## Screenshots
Current:
![image](https://user-images.githubusercontent.com/45856485/54218783-1b23ab00-44e6-11e9-89a3-5b4812a17ad6.png)

New:
![image](https://user-images.githubusercontent.com/45856485/54218807-24147c80-44e6-11e9-8fc5-061a020ba196.png)


