### PR TITLE
Paper checkout links

### DIFF
--- a/support-frontend/.eslintrc
+++ b/support-frontend/.eslintrc
@@ -35,6 +35,7 @@
     "import/no-duplicates": "off",
     "import/no-extraneous-dependencies": "off",
     "padded-blocks": "off",
+    "import/first": "off",
     "import/prefer-default-export": "off",
     "jsx-a11y/label-has-for": [ 2, {
       "components": [ "Label" ],

--- a/support-frontend/assets/helpers/externalLinks.js
+++ b/support-frontend/assets/helpers/externalLinks.js
@@ -9,7 +9,7 @@ import type { Participations } from 'helpers/abTests/abtest';
 import { type OptimizeExperiments } from 'helpers/optimize/optimize';
 import { getBaseDomain } from 'helpers/url';
 import { Annual, Quarterly, SixForSix, Monthly, type WeeklyBillingPeriod, type DigitalBillingPeriod } from 'helpers/billingPeriods';
-import type { PaperBillingPlan, SubscriptionProduct } from 'helpers/subscriptions';
+import type { SubscriptionProduct } from 'helpers/subscriptions';
 import { getIntcmp, getPromoCode, getAnnualPlanPromoCode } from './flashSale';
 import { getOrigin } from './url';
 import { GBPCountries } from './internationalisation/countryGroup';

--- a/support-frontend/assets/helpers/externalLinks.js
+++ b/support-frontend/assets/helpers/externalLinks.js
@@ -13,6 +13,9 @@ import type { PaperBillingPlan, SubscriptionProduct } from 'helpers/subscription
 import { getIntcmp, getPromoCode, getAnnualPlanPromoCode } from './flashSale';
 import { getOrigin } from './url';
 import { GBPCountries } from './internationalisation/countryGroup';
+import type { PaperProductOptions } from 'helpers/productPrice/productOptions';
+import type { PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
+import { HomeDelivery } from 'helpers/productPrice/fulfilmentOptions';
 
 // ----- Types ----- //
 
@@ -325,23 +328,15 @@ function getWeeklyCheckout(
 
 // Builds a link to paper subs checkout
 function getPaperCheckout(
-  billingPlan: PaperBillingPlan,
+  productOption: PaperProductOptions,
+  fulfilmentOption: PaperFulfilmentOptions,
   referrerAcquisitionData: ReferrerAcquisitionData,
   nativeAbParticipations: Participations,
   optimizeExperiments: OptimizeExperiments,
 ) {
   const promoCode = getPromoCode('Paper', GBPCountries, defaultPromos.Paper);
 
-  const urls = {
-    collectionEveryday: 'voucher-everyday',
-    collectionSixday: 'voucher-sixday',
-    collectionWeekend: 'voucher-weekend',
-    collectionSunday: 'voucher-sunday',
-    deliveryEveryday: 'delivery-everyday',
-    deliverySixday: 'delivery-sixday',
-    deliveryWeekend: 'delivery-weekend',
-    deliverySunday: 'delivery-sunday',
-  };
+  const fulfilmentPart = fulfilmentOption === HomeDelivery ? 'delivery' : 'voucher';
 
   return withParams({
     referrerAcquisitionData,
@@ -349,7 +344,7 @@ function getPaperCheckout(
     nativeAbParticipations,
     optimizeExperiments,
     promoCode,
-  })([subsUrl, 'checkout', urls[billingPlan]].join('/'));
+  })([subsUrl, 'checkout', fulfilmentPart, productOption.toLowerCase()].join('/'));
 }
 
 

--- a/support-frontend/assets/helpers/externalLinks.js
+++ b/support-frontend/assets/helpers/externalLinks.js
@@ -327,7 +327,7 @@ function getWeeklyCheckout(
 
 
 // Builds a link to paper subs checkout
-function getPaperCheckout(
+function getLegacyPaperCheckout(
   productOption: PaperProductOptions,
   fulfilmentOption: PaperFulfilmentOptions,
   referrerAcquisitionData: ReferrerAcquisitionData,
@@ -399,5 +399,5 @@ export {
   myAccountUrl,
   manageSubsUrl,
   getWeeklyCheckout,
-  getPaperCheckout,
+  getLegacyPaperCheckout,
 };

--- a/support-frontend/assets/helpers/flashSale.js
+++ b/support-frontend/assets/helpers/flashSale.js
@@ -5,7 +5,7 @@ import { type CountryGroupId, detect } from 'helpers/internationalisation/countr
 import { fixDecimals } from 'helpers/subscriptions';
 import { type BillingPeriod } from 'helpers/billingPeriods';
 
-import { type SubscriptionProduct, type PaperBillingPlan } from './subscriptions';
+import { type SubscriptionProduct } from './subscriptions';
 import { AUDCountries, GBPCountries, EURCountries, Canada, International, UnitedStates, NZDCountries } from './internationalisation/countryGroup';
 
 export type SaleCopy = {
@@ -26,10 +26,6 @@ export type SaleCopy = {
   },
 }
 
-export type PlanPrice = {
-  [PaperBillingPlan]: number,
-}
-
 type SaleDetails = {
   [CountryGroupId]: {
     promoCode: string,
@@ -39,7 +35,6 @@ type SaleDetails = {
     annualPrice?: number,
     discountPercentage?: number,
     saleCopy: SaleCopy,
-    planPrices: PlanPrice[],
   },
 };
 
@@ -85,7 +80,6 @@ const Sales: Sale[] = [
             description: 'The Premium App and the daily edition iPad app of the UK newspaper in one pack, plus ad-free reading on all your devices',
           },
         },
-        planPrices: [],
       },
       International: {
         promoCode: 'DDPFMINT80',
@@ -110,7 +104,6 @@ const Sales: Sale[] = [
             description: 'The Premium App and the daily edition iPad app of the UK newspaper in one pack, plus ad-free reading on all your devices',
           },
         },
-        planPrices: [],
       },
       Canada: {
         promoCode: 'DDPFMINT80',
@@ -135,7 +128,6 @@ const Sales: Sale[] = [
             description: 'The Premium App and the daily edition iPad app of the UK newspaper in one pack, plus ad-free reading on all your devices',
           },
         },
-        planPrices: [],
       },
       NZDCountries: {
         promoCode: 'DDPFMINT80',
@@ -160,7 +152,6 @@ const Sales: Sale[] = [
             description: 'The Premium App and the daily edition iPad app of the UK newspaper in one pack, plus ad-free reading on all your devices',
           },
         },
-        planPrices: [],
       },
       EURCountries: {
         promoCode: 'DDPFMINT80',
@@ -185,7 +176,7 @@ const Sales: Sale[] = [
             description: 'The Premium App and the daily edition iPad app of the UK newspaper in one pack, plus ad-free reading on all your devices',
           },
         },
-        planPrices: [],
+
       },
       AUDCountries: {
         promoCode: 'DDPFMINT80',
@@ -210,9 +201,7 @@ const Sales: Sale[] = [
             description: 'The Premium App and the daily edition iPad app of the UK newspaper in one pack, plus ad-free reading on all your devices',
           },
         },
-        planPrices: [],
       },
-
     },
   },
   {
@@ -244,7 +233,6 @@ const Sales: Sale[] = [
             description: 'The Premium App and the daily edition iPad app of the UK newspaper in one pack, plus ad-free reading on all your devices',
           },
         },
-        planPrices: [],
       },
     },
   },
@@ -331,11 +319,6 @@ function getIntcmp(
   return intcmp || defaultIntcmp;
 }
 
-function getPlanPrices(product: SubscriptionProduct, countryGroupId: CountryGroupId): PlanPrice[] {
-  const sale = getActiveFlashSales(product, countryGroupId)[0];
-  return sale && sale.saleDetails[countryGroupId].planPrices;
-}
-
 function getEndTime(product: SubscriptionProduct, countryGroupId: CountryGroupId) {
   const sale = getActiveFlashSales(product, countryGroupId)[0];
   return sale && sale.endTime;
@@ -410,7 +393,6 @@ export {
   getEndTime,
   getSaleCopy,
   getFormattedFlashSalePrice,
-  getPlanPrices,
   getDiscount,
   getDuration,
   getTimeTravelDaysOverride,

--- a/support-frontend/assets/helpers/flashSale.js
+++ b/support-frontend/assets/helpers/flashSale.js
@@ -176,7 +176,6 @@ const Sales: Sale[] = [
             description: 'The Premium App and the daily edition iPad app of the UK newspaper in one pack, plus ad-free reading on all your devices',
           },
         },
-
       },
       AUDCountries: {
         promoCode: 'DDPFMINT80',

--- a/support-frontend/assets/helpers/productPrice/productOptions.js
+++ b/support-frontend/assets/helpers/productPrice/productOptions.js
@@ -29,15 +29,12 @@ export type ProductOptions =
 
 export type PaperProductOptions =
   | typeof Saturday
-  | typeof SaturdayPlus
   | typeof Sunday
-  | typeof SundayPlus
   | typeof Weekend
-  | typeof WeekendPlus
   | typeof Sixday
-  | typeof SixdayPlus
-  | typeof Everyday
-  | typeof EverydayPlus;
+  | typeof Everyday;
+
+const PaperProductTypes = [Everyday, Sixday, Weekend, Sunday];
 
 export {
   NoProductOptions,
@@ -51,4 +48,5 @@ export {
   SixdayPlus,
   Everyday,
   EverydayPlus,
+  PaperProductTypes,
 };

--- a/support-frontend/assets/helpers/productPrice/productOptions.js
+++ b/support-frontend/assets/helpers/productPrice/productOptions.js
@@ -34,7 +34,7 @@ export type PaperProductOptions =
   | typeof Sixday
   | typeof Everyday;
 
-const PaperProductTypes = [Everyday, Sixday, Weekend, Sunday];
+const ActivePaperProductTypes = [Everyday, Sixday, Weekend, Sunday];
 
 export {
   NoProductOptions,
@@ -48,5 +48,5 @@ export {
   SixdayPlus,
   Everyday,
   EverydayPlus,
-  PaperProductTypes,
+  ActivePaperProductTypes,
 };

--- a/support-frontend/assets/helpers/routes.js
+++ b/support-frontend/assets/helpers/routes.js
@@ -45,7 +45,7 @@ function paperSubsUrl(withDelivery: boolean = false): string {
 }
 
 function paperCheckoutUrl(fulfilmentOption: FulfilmentOptions, productOptions: ProductOptions) {
-  return `${getOrigin()}/subscribe/paper/checkout?fulfilment=${fulfilmentOption}&product=${productOptions}'`;
+  return `${getOrigin()}/subscribe/paper/checkout?fulfilment=${fulfilmentOption}&product=${productOptions}&displayCheckout=true`; // TODO: remove displayCheckout param when we go live
 }
 
 function payPalCancelUrl(cgId: CountryGroupId): string {

--- a/support-frontend/assets/helpers/routes.js
+++ b/support-frontend/assets/helpers/routes.js
@@ -5,6 +5,8 @@
 import type { CountryGroupId } from './internationalisation/countryGroup';
 import { countryGroups } from './internationalisation/countryGroup';
 import { getOrigin } from './url';
+import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
+import type { ProductOptions } from 'helpers/productPrice/productOptions';
 
 const routes: {
   [string]: string,
@@ -42,6 +44,10 @@ function paperSubsUrl(withDelivery: boolean = false): string {
   return [getOrigin(), 'uk/subscribe/paper', ...(withDelivery ? ['delivery'] : [])].join('/');
 }
 
+function paperCheckoutUrl(fulfilmentOption: FulfilmentOptions, productOptions: ProductOptions) {
+  return `${getOrigin()}/subscribe/paper/checkout?fulfilment=${fulfilmentOption}&product=${productOptions}'`;
+}
+
 function payPalCancelUrl(cgId: CountryGroupId): string {
   return `${getOrigin()}/${countryGroups[cgId].supportInternationalisationId}/contribute`;
 }
@@ -53,4 +59,4 @@ function payPalReturnUrl(cgId: CountryGroupId): string {
 
 // ----- Exports ----- //
 
-export { routes, postcodeLookupUrl, payPalCancelUrl, payPalReturnUrl, paperSubsUrl };
+export { routes, postcodeLookupUrl, payPalCancelUrl, payPalReturnUrl, paperSubsUrl, paperCheckoutUrl };

--- a/support-frontend/assets/helpers/subscriptions.js
+++ b/support-frontend/assets/helpers/subscriptions.js
@@ -17,6 +17,7 @@ import { trackComponentEvents } from './tracking/ophanComponentEventTracking';
 import { gaEvent } from './tracking/googleTagManager';
 import { currencies, detect } from './internationalisation/currency';
 import { GBPCountries } from './internationalisation/countryGroup';
+import type { PaperProductOptions } from 'helpers/productPrice/productOptions';
 
 
 // ----- Types ------ //
@@ -40,14 +41,15 @@ export type PaperBillingPlan =
   'collectionEveryday' | 'collectionSixday' | 'collectionWeekend' | 'collectionSunday' |
   'deliveryEveryday' | 'deliverySixday' | 'deliveryWeekend' | 'deliverySunday';
 
-export type PaperNewsstandTiers = 'weekly' | 'saturday' | 'sunday';
-
-const newsstandPrices: {[PaperNewsstandTiers]: number} = {
-  weekly: 2.20 * 5,
-  saturday: 3.20,
-  sunday: 3.20,
+const dailyNewsstandPrice = 2.20;
+const weekendNewsstandPrice = 3.20;
+const newsstandPrices: {[PaperProductOptions]: number} = {
+  Saturday: weekendNewsstandPrice,
+  Sunday: weekendNewsstandPrice,
+  Everyday: (dailyNewsstandPrice * 5) + (weekendNewsstandPrice * 2),
+  Sixday: (dailyNewsstandPrice * 5) + weekendNewsstandPrice,
+  Weekend: weekendNewsstandPrice * 2,
 };
-
 
 // ----- Config ----- //
 
@@ -307,8 +309,8 @@ const getMonthlyNewsStandPrice = (newsstand: number) => ((newsstand) * 52) / 12;
 const getNewsstandSaving = (subscriptionMonthlyCost: number, newsstandWeeklyCost: number) =>
   fixDecimals(getMonthlyNewsStandPrice(newsstandWeeklyCost) - subscriptionMonthlyCost);
 
-const getNewsstandPrice = (tiers: PaperNewsstandTiers[]) =>
-  tiers.map(tier => newsstandPrices[tier]).reduce((a, b) => a + b, 0);
+const getNewsstandPrice = (productOption: PaperProductOptions) =>
+  newsstandPrices[productOption];
 
 // ----- Exports ----- //
 

--- a/support-frontend/assets/helpers/subscriptions.js
+++ b/support-frontend/assets/helpers/subscriptions.js
@@ -3,7 +3,6 @@
 // ----- Imports ----- //
 
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import { type Price } from 'helpers/productPrice/productPrices';
 import {
   Annual,
   type BillingPeriod,
@@ -12,11 +11,9 @@ import {
   SixForSix,
   type WeeklyBillingPeriod,
 } from 'helpers/billingPeriods';
-import { getPlanPrices, flashSaleIsActive, type PlanPrice } from 'helpers/flashSale';
 import { trackComponentEvents } from './tracking/ophanComponentEventTracking';
 import { gaEvent } from './tracking/googleTagManager';
 import { currencies, detect } from './internationalisation/currency';
-import { GBPCountries } from './internationalisation/countryGroup';
 import type { PaperProductOptions } from 'helpers/productPrice/productOptions';
 
 
@@ -36,10 +33,6 @@ export type ComponentAbTest = {
   name: string,
   variant: string,
 };
-
-export type PaperBillingPlan =
-  'collectionEveryday' | 'collectionSixday' | 'collectionWeekend' | 'collectionSunday' |
-  'deliveryEveryday' | 'deliverySixday' | 'deliveryWeekend' | 'deliverySunday';
 
 const dailyNewsstandPrice = 2.20;
 const weekendNewsstandPrice = 3.20;
@@ -88,17 +81,6 @@ const subscriptionPricesForDefaultBillingPeriod: {
   DailyEdition: {
     GBPCountries: 11.99,
   },
-};
-
-const paperSubscriptionPrices = {
-  collectionEveryday: 47.62,
-  collectionSixday: 41.12,
-  collectionWeekend: 20.76,
-  collectionSunday: 10.79,
-  deliveryEveryday: 62.79,
-  deliverySixday: 54.12,
-  deliveryWeekend: 25.09,
-  deliverySunday: 15.12,
 };
 
 const subscriptionPromoPricesForGuardianWeekly: {
@@ -231,29 +213,6 @@ function getPromotionWeeklyProductPrice(
   return fixDecimals(subscriptionPromoPricesForGuardianWeekly[promoCode][countryGroupId][billingPeriod]);
 }
 
-function getRegularPaperPrice(billingPlan: PaperBillingPlan): Price {
-  return {
-    price: paperSubscriptionPrices[billingPlan],
-    currency: 'GBP',
-  };
-}
-
-function getPaperPrice(billingPlan: PaperBillingPlan): Price {
-  const planPrices: PlanPrice[] = getPlanPrices('Paper', GBPCountries);
-
-  if (flashSaleIsActive('Paper', GBPCountries)) {
-    const discountedPlanPrice = planPrices.find((planPrice: PlanPrice) => planPrice[billingPlan]);
-    if (discountedPlanPrice) {
-      return {
-        price: discountedPlanPrice[billingPlan],
-        currency: 'GBP',
-      };
-    }
-  }
-
-  return getRegularPaperPrice(billingPlan);
-}
-
 function ophanProductFromSubscriptionProduct(product: SubscriptionProduct): OphanSubscriptionsProduct {
 
   switch (product) {
@@ -322,7 +281,5 @@ export {
   getPromotionWeeklyProductPrice,
   getNewsstandSaving,
   getNewsstandPrice,
-  getPaperPrice,
-  getRegularPaperPrice,
   fixDecimals,
 };

--- a/support-frontend/assets/helpers/subscriptions.js
+++ b/support-frontend/assets/helpers/subscriptions.js
@@ -39,7 +39,7 @@ export type ComponentAbTest = {
 export type PaperBillingPlan =
   'collectionEveryday' | 'collectionSixday' | 'collectionWeekend' | 'collectionSunday' |
   'deliveryEveryday' | 'deliverySixday' | 'deliveryWeekend' | 'deliverySunday';
-export type PaperDeliveryMethod = 'collection' | 'delivery';
+
 export type PaperNewsstandTiers = 'weekly' | 'saturday' | 'sunday';
 
 const newsstandPrices: {[PaperNewsstandTiers]: number} = {

--- a/support-frontend/assets/pages/paper-subscription-checkout/components-checkout/checkoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components-checkout/checkoutForm.jsx
@@ -211,7 +211,6 @@ function CheckoutForm(props: PropTypes) {
                   );
                 })}
               </FieldsetWithError>
-              We will
             </FormSection>
             <FormSection title="How would you like to pay?">
               <Rows>

--- a/support-frontend/assets/pages/paper-subscription-checkout/components-checkout/checkoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components-checkout/checkoutForm.jsx
@@ -211,6 +211,7 @@ function CheckoutForm(props: PropTypes) {
                   );
                 })}
               </FieldsetWithError>
+              We will
             </FormSection>
             <FormSection title="How would you like to pay?">
               <Rows>

--- a/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckoutReducer.js
+++ b/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckoutReducer.js
@@ -214,7 +214,7 @@ export type FormActionCreators = typeof formActionCreators;
 const getInitialProduct = (productInUrl: ?string, fulfillmentInUrl: ?string): Product => ({
   productOption:
     ActivePaperProductTypes.includes(productInUrl)
-      // $FlowIgnore
+      // $FlowIgnore - flow doesn't recognise that we've checked the value of productInUrl
       ? (productInUrl: PaperProductOptions)
       : Everyday,
   fulfilmentOption:

--- a/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckoutReducer.js
+++ b/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckoutReducer.js
@@ -24,7 +24,10 @@ import { type PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRev
 import { fromCountry } from 'helpers/internationalisation/countryGroup';
 import type { ProductPrices } from 'helpers/productPrice/productPrices';
 import { Collection, type PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
-import { Everyday, type PaperProductOptions } from 'helpers/productPrice/productOptions';
+import {
+  Everyday,
+  type PaperProductOptions,
+} from 'helpers/productPrice/productOptions';
 import { type Title } from 'helpers/user/details';
 import { getUser } from './helpers/user';
 import { showPaymentMethod, onPaymentAuthorised, countrySupportsDirectDebit } from './helpers/paymentProviders';

--- a/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckoutReducer.js
+++ b/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckoutReducer.js
@@ -26,7 +26,7 @@ import type { ProductPrices } from 'helpers/productPrice/productPrices';
 import { Collection, type PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import {
   Everyday,
-  type PaperProductOptions,
+  type PaperProductOptions, ActivePaperProductTypes,
 } from 'helpers/productPrice/productOptions';
 import { type Title } from 'helpers/user/details';
 import { getUser } from './helpers/user';
@@ -213,16 +213,8 @@ export type FormActionCreators = typeof formActionCreators;
 
 const getInitialProduct = (productInUrl: ?string, fulfillmentInUrl: ?string): Product => ({
   productOption:
-    productInUrl === 'Saturday' ||
-    productInUrl === 'SaturdayPlus' ||
-    productInUrl === 'Sunday' ||
-    productInUrl === 'SundayPlus' ||
-    productInUrl === 'Weekend' ||
-    productInUrl === 'WeekendPlus' ||
-    productInUrl === 'Sixday' ||
-    productInUrl === 'SixdayPlus' ||
-    productInUrl === 'Everyday' ||
-    productInUrl === 'EverydayPlus'
+    ActivePaperProductTypes.includes(productInUrl)
+      // $FlowIgnore
       ? (productInUrl: PaperProductOptions)
       : Everyday,
   fulfilmentOption:

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/content.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/content.jsx
@@ -13,6 +13,7 @@ import { type ContentPropTypes } from './helpers';
 import DeliveryTab from './deliveryTab';
 import CollectionTab from './collectionTab';
 import './content.scss';
+import { Collection } from 'helpers/productPrice/fulfilmentOptions';
 
 
 // ----- Render ----- //
@@ -32,7 +33,7 @@ class Content extends Component<ContentPropTypes> {
   render() {
     const { selectedTab, setTabAction } = this.props;
 
-    return selectedTab === 'collection'
+    return selectedTab === Collection
       ? <CollectionTab
         {...{ selectedTab, setTabAction }}
         getRef={(r) => { if (r) { this.tabRef = r; } }}

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/deliveryTab.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/deliveryTab.jsx
@@ -13,6 +13,7 @@ import { sendClickedEvent } from 'helpers/tracking/clickTracking';
 import { setTab } from '../../paperSubscriptionLandingPageActions';
 
 import { ContentHelpBlock, LinkTo, ContentForm, type ContentTabPropTypes } from './helpers';
+import { Collection } from 'helpers/productPrice/fulfilmentOptions';
 
 
 // ----- Content ----- //
@@ -31,7 +32,7 @@ const ContentDeliveryFaqBlock = ({ setTabAction }: {setTabAction: typeof setTab}
       <p>
           If you live in Greater London (within the M25), you
           can use The Guardian’s home delivery service. If not, you can
-          still <LinkTo tab="collection" setTabAction={setTabAction} >subscribe using our voucher scheme</LinkTo>.
+          still <LinkTo tab={Collection} setTabAction={setTabAction} >subscribe using our voucher scheme</LinkTo>.
       </p>
       <OrderedList items={[
         'Select your subscription below and checkout',

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/form.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/form.jsx
@@ -12,7 +12,7 @@ import { type Price, showPrice } from 'helpers/productPrice/productPrices';
 import { type Action } from 'components/productPage/productPagePlanForm/productPagePlanFormActions';
 import ProductPagePlanForm, {
   type DispatchPropTypes,
-  type StatePropTypes
+  type StatePropTypes,
 } from 'components/productPage/productPagePlanForm/productPagePlanForm';
 import { flashSaleIsActive, getDuration } from 'helpers/flashSale';
 import { GBPCountries } from 'helpers/internationalisation/countryGroup';
@@ -73,8 +73,8 @@ const copy = {
   Collection: 'Collect your papers from your local retailer',
 };
 
-const getPlans = (fulfilmentOption: PaperFulfilmentOptions, productPrices: ProductPrices) => {
-  return ActivePaperProductTypes.reduce((products, productOption) => {
+const getPlans = (fulfilmentOption: PaperFulfilmentOptions, productPrices: ProductPrices) =>
+  ActivePaperProductTypes.reduce((products, productOption) => {
     const price = finalPrice(productPrices, fulfilmentOption, productOption);
     return {
       ...products,
@@ -87,7 +87,6 @@ const getPlans = (fulfilmentOption: PaperFulfilmentOptions, productPrices: Produ
       },
     };
   }, {});
-};
 
 
 // ----- State/Props Maps ----- //

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/form.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/form.jsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
 import { type Option } from 'helpers/types/option';
-import { getNewsstandSaving, getNewsstandPrice, type PaperBillingPlan, getPaperPrice, getRegularPaperPrice } from 'helpers/subscriptions';
+import { getNewsstandSaving, getNewsstandPrice } from 'helpers/subscriptions';
 import { type Price, showPrice } from 'helpers/productPrice/productPrices';
 import { type Action } from 'components/productPage/productPagePlanForm/productPagePlanFormActions';
 import ProductPagePlanForm, { type StatePropTypes, type DispatchPropTypes } from 'components/productPage/productPagePlanForm/productPagePlanForm';
@@ -15,10 +15,16 @@ import { GBPCountries } from 'helpers/internationalisation/countryGroup';
 
 import { type State } from '../../paperSubscriptionLandingPageReducer';
 import { setPlan, redirectToCheckout } from '../../paperSubscriptionLandingPageActions';
+import { Collection } from 'helpers/productPrice/fulfilmentOptions';
+import type { PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
+import { Everyday, PaperProductTypes, Sixday } from 'helpers/productPrice/productOptions';
+import type { ProductPrices } from 'helpers/productPrice/productPrices';
+import { finalPrice, regularPrice } from 'helpers/productPrice/paperProductPrices';
+import type { PaperProductOptions } from 'helpers/productPrice/productOptions';
 
 
 // ---- Helpers ----- //
-
+// TODO: Can we get rid of all these price helpers?
 const getRegularPriceStr = (price: Price): string => `You pay ${showPrice(price)} a month`;
 
 const getPriceStr = (price: Price): string => {
@@ -49,98 +55,47 @@ const getSavingStr = (price: Price): Option<string> => {
 
 // ---- Plans ----- //
 
-const collectionCopy = 'Collect your papers from your local retailer';
-const deliveryCopy = 'Have your papers delivered to your home';
+const getTitle = (productOption: PaperProductOptions) => {
+  switch (productOption) {
+    case Everyday:
+      return 'Every day';
+    case Sixday:
+      return 'Monday to Saturday';
+    default:
+      return productOption;
+  }
+};
 
-const allPlans = {
-  collectionEveryday: {
-    title: 'Every day',
-    copy: collectionCopy,
-    newsstand: getNewsstandPrice(['weekly', 'saturday', 'sunday']),
-    price: getPaperPrice('collectionEveryday'),
-    regularPrice: getRegularPaperPrice('collectionEveryday'),
-  },
-  collectionSixday: {
-    title: 'Monday to Saturday',
-    copy: collectionCopy,
-    newsstand: getNewsstandPrice(['weekly', 'saturday']),
-    price: getPaperPrice('collectionSixday'),
-    regularPrice: getRegularPaperPrice('collectionSixday'),
-  },
-  collectionWeekend: {
-    title: 'Weekend',
-    copy: collectionCopy,
-    newsstand: getNewsstandPrice(['saturday', 'sunday']),
-    price: getPaperPrice('collectionWeekend'),
-    regularPrice: getRegularPaperPrice('collectionWeekend'),
-  },
-  collectionSunday: {
-    title: 'Sunday',
-    copy: collectionCopy,
-    newsstand: getNewsstandPrice(['sunday']),
-    price: getPaperPrice('collectionSunday'),
-    regularPrice: getRegularPaperPrice('collectionSunday'),
-  },
-  deliveryEveryday: {
-    title: 'Every day',
-    copy: deliveryCopy,
-    newsstand: getNewsstandPrice(['weekly', 'saturday', 'sunday']),
-    price: getPaperPrice('deliveryEveryday'),
-    regularPrice: getRegularPaperPrice('deliveryEveryday'),
-  },
-  deliverySixday: {
-    title: 'Monday to Saturday',
-    copy: deliveryCopy,
-    newsstand: getNewsstandPrice(['weekly', 'saturday']),
-    price: getPaperPrice('deliverySixday'),
-    regularPrice: getRegularPaperPrice('deliverySixday'),
-  },
-  deliveryWeekend: {
-    title: 'Weekend',
-    copy: deliveryCopy,
-    newsstand: getNewsstandPrice(['saturday', 'sunday']),
-    price: getPaperPrice('deliveryWeekend'),
-    regularPrice: getRegularPaperPrice('deliveryWeekend'),
-  },
-  deliverySunday: {
-    title: 'Sunday',
-    copy: deliveryCopy,
-    newsstand: getNewsstandPrice(['sunday']),
-    price: getPaperPrice('deliverySunday'),
-    regularPrice: getRegularPaperPrice('deliverySunday'),
-  },
+const copy = {
+  HomeDelivery: 'Have your papers delivered to your home',
+  Collection: 'Collect your papers from your local retailer',
+};
+
+const getPlans = (fulfilmentOption: PaperFulfilmentOptions, productPrices: ProductPrices) => {
+  const plans = PaperProductTypes.reduce((products, productOption) => {
+    const price = finalPrice(productPrices, fulfilmentOption, productOption);
+    return {
+      ...products,
+      [productOption]: {
+        title: getTitle(productOption),
+        copy: copy[fulfilmentOption],
+        price: getPriceStr(price),
+        offer: getOfferStr(price.price, getNewsstandPrice(productOption)),
+        saving: getSavingStr(regularPrice(productPrices, fulfilmentOption, productOption)),
+      },
+    };
+  }, {});
+  return plans;
 };
 
 
 // ----- State/Props Maps ----- //
-const mapStateToProps = (state: State): StatePropTypes<PaperBillingPlan> => {
-  const transformPlans = (plans: $Keys<typeof allPlans>[]) => plans.reduce((ps, k) => ({
-    ...ps,
-    [k]: {
-      title: allPlans[k].title,
-      copy: allPlans[k].copy,
-      price: getPriceStr(allPlans[k].price),
-      offer: getOfferStr(allPlans[k].price.value, allPlans[k].newsstand ? allPlans[k].newsstand : null),
-      saving: getSavingStr(allPlans[k].regularPrice),
-    },
-  }), {});
+const mapStateToProps = (state: State): StatePropTypes<PaperProductOptions> => ({
+  plans: getPlans(state.page.tab, state.page.productPrices),
+  selectedPlan: state.page.plan.plan,
+});
 
-  if (state.page.tab === 'collection') {
-    return {
-      plans: transformPlans(['collectionEveryday', 'collectionSixday', 'collectionWeekend', 'collectionSunday']),
-      selectedPlan: state.page.plan.plan,
-    };
-  }
-
-  return {
-    plans: transformPlans(['deliveryEveryday', 'deliverySixday', 'deliveryWeekend', 'deliverySunday']),
-    selectedPlan: state.page.plan.plan,
-  };
-
-
-};
-
-const mapDispatchToProps = (dispatch: Dispatch<Action<PaperBillingPlan>>): DispatchPropTypes<PaperBillingPlan> =>
+const mapDispatchToProps = (dispatch: Dispatch<Action<PaperProductOptions>>): DispatchPropTypes<PaperProductOptions> =>
   ({
     setPlanAction: bindActionCreators(setPlan, dispatch),
     onSubmitAction: bindActionCreators(redirectToCheckout, dispatch),

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/form.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/form.jsx
@@ -15,9 +15,8 @@ import { GBPCountries } from 'helpers/internationalisation/countryGroup';
 
 import { type State } from '../../paperSubscriptionLandingPageReducer';
 import { setPlan, redirectToCheckout } from '../../paperSubscriptionLandingPageActions';
-import { Collection } from 'helpers/productPrice/fulfilmentOptions';
 import type { PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
-import { Everyday, PaperProductTypes, Sixday } from 'helpers/productPrice/productOptions';
+import { Everyday, ActivePaperProductTypes, Sixday } from 'helpers/productPrice/productOptions';
 import type { ProductPrices } from 'helpers/productPrice/productPrices';
 import { finalPrice, regularPrice } from 'helpers/productPrice/paperProductPrices';
 import type { PaperProductOptions } from 'helpers/productPrice/productOptions';
@@ -72,7 +71,7 @@ const copy = {
 };
 
 const getPlans = (fulfilmentOption: PaperFulfilmentOptions, productPrices: ProductPrices) => {
-  const plans = PaperProductTypes.reduce((products, productOption) => {
+  const plans = ActivePaperProductTypes.reduce((products, productOption) => {
     const price = finalPrice(productPrices, fulfilmentOption, productOption);
     return {
       ...products,

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/form.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/form.jsx
@@ -6,24 +6,27 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
 import { type Option } from 'helpers/types/option';
-import { getNewsstandSaving, getNewsstandPrice } from 'helpers/subscriptions';
+import { getNewsstandPrice, getNewsstandSaving } from 'helpers/subscriptions';
+import type { ProductPrices } from 'helpers/productPrice/productPrices';
 import { type Price, showPrice } from 'helpers/productPrice/productPrices';
 import { type Action } from 'components/productPage/productPagePlanForm/productPagePlanFormActions';
-import ProductPagePlanForm, { type StatePropTypes, type DispatchPropTypes } from 'components/productPage/productPagePlanForm/productPagePlanForm';
+import ProductPagePlanForm, {
+  type DispatchPropTypes,
+  type StatePropTypes
+} from 'components/productPage/productPagePlanForm/productPagePlanForm';
 import { flashSaleIsActive, getDuration } from 'helpers/flashSale';
 import { GBPCountries } from 'helpers/internationalisation/countryGroup';
 
 import { type State } from '../../paperSubscriptionLandingPageReducer';
-import { setPlan, redirectToCheckout } from '../../paperSubscriptionLandingPageActions';
+import { redirectToCheckout, setPlan } from '../../paperSubscriptionLandingPageActions';
 import type { PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
-import { Everyday, ActivePaperProductTypes, Sixday } from 'helpers/productPrice/productOptions';
-import type { ProductPrices } from 'helpers/productPrice/productPrices';
-import { finalPrice, regularPrice } from 'helpers/productPrice/paperProductPrices';
 import type { PaperProductOptions } from 'helpers/productPrice/productOptions';
+import { ActivePaperProductTypes, Everyday, Sixday } from 'helpers/productPrice/productOptions';
+import { finalPrice, regularPrice } from 'helpers/productPrice/paperProductPrices';
 
 
 // ---- Helpers ----- //
-// TODO: Can we get rid of all these price helpers?
+// TODO: We will need to make this work for flash sales
 const getRegularPriceStr = (price: Price): string => `You pay ${showPrice(price)} a month`;
 
 const getPriceStr = (price: Price): string => {
@@ -71,7 +74,7 @@ const copy = {
 };
 
 const getPlans = (fulfilmentOption: PaperFulfilmentOptions, productPrices: ProductPrices) => {
-  const plans = ActivePaperProductTypes.reduce((products, productOption) => {
+  return ActivePaperProductTypes.reduce((products, productOption) => {
     const price = finalPrice(productPrices, fulfilmentOption, productOption);
     return {
       ...products,
@@ -84,7 +87,6 @@ const getPlans = (fulfilmentOption: PaperFulfilmentOptions, productPrices: Produ
       },
     };
   }, {});
-  return plans;
 };
 
 

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/helpers.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/helpers.jsx
@@ -15,6 +15,7 @@ import { type ActiveTabState } from '../../paperSubscriptionLandingPageReducer';
 import { setTab } from '../../paperSubscriptionLandingPageActions';
 
 import Form from './form';
+import { Collection, HomeDelivery } from 'helpers/productPrice/fulfilmentOptions';
 
 
 // Types
@@ -111,9 +112,9 @@ const ContentForm = ({
     <Text>
       <SansParagraph>
         {
-          selectedTab === 'collection'
-            ? <LinkTo tab="delivery" setTabAction={setTabAction}>Switch to Delivery</LinkTo>
-            : <LinkTo tab="collection" setTabAction={setTabAction}>Switch to Vouchers</LinkTo>
+          selectedTab === Collection
+            ? <LinkTo tab={HomeDelivery} setTabAction={setTabAction}>Switch to Delivery</LinkTo>
+            : <LinkTo tab={Collection} setTabAction={setTabAction}>Switch to Vouchers</LinkTo>
         }
       </SansParagraph>
     </Text>

--- a/support-frontend/assets/pages/paper-subscription-landing/components/tabs.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/tabs.jsx
@@ -8,20 +8,20 @@ import { bindActionCreators } from 'redux';
 
 import { Outset } from 'components/content/content';
 import ProductPageTabs from 'components/productPage/productPageTabs/productPageTabs';
-import { type PaperDeliveryMethod } from 'helpers/subscriptions';
 import { paperSubsUrl } from 'helpers/routes';
 
 import { type State } from '../paperSubscriptionLandingPageReducer';
 import { setTab, type TabActions } from '../paperSubscriptionLandingPageActions';
+import type { PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 
 // ----- Tabs ----- //
 
-export const tabs: {[PaperDeliveryMethod]: {name: string, href: string}} = {
-  collection: {
+export const tabs: {[PaperFulfilmentOptions]: {name: string, href: string}} = {
+  Collection: {
     name: 'Voucher Booklet',
     href: paperSubsUrl(false),
   },
-  delivery: {
+  HomeDelivery: {
     name: 'Home Delivery',
     href: paperSubsUrl(true),
   },
@@ -32,7 +32,7 @@ type StatePropTypes = {|
 |};
 
 type DispatchPropTypes = {|
-  setTabAction: (PaperDeliveryMethod) => TabActions,
+  setTabAction: (PaperFulfilmentOptions) => TabActions,
 |};
 
 type PropTypes = {|

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
@@ -16,7 +16,6 @@ import { detect, countryGroups, type CountryGroupId } from 'helpers/internationa
 import { getQueryParameter } from 'helpers/url';
 import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
-import { type PaperDeliveryMethod } from 'helpers/subscriptions';
 import { flashSaleIsActive, getSaleCopy } from 'helpers/flashSale';
 import { GBPCountries } from 'helpers/internationalisation/countryGroup';
 import 'stylesheets/skeleton/skeleton.scss';
@@ -27,16 +26,18 @@ import TabsContent from './components/content/content';
 import reducer from './paperSubscriptionLandingPageReducer';
 
 import './paperSubscriptionLandingPage.scss';
+import type { PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
+import { Collection, HomeDelivery } from 'helpers/productPrice/fulfilmentOptions';
 
 // ----- Collection or delivery ----- //
 
-const method: PaperDeliveryMethod = window.location.pathname.includes('delivery') ? 'delivery' : 'collection';
+const method: PaperFulfilmentOptions = window.location.pathname.includes('delivery') ? HomeDelivery : Collection;
 
 const reactElementId: {
-  [PaperDeliveryMethod]: string,
+  [PaperFulfilmentOptions]: string,
 } = {
-  collection: 'paper-subscription-landing-page-collection',
-  delivery: 'paper-subscription-landing-page-delivery',
+  Collection: 'paper-subscription-landing-page-collection',
+  HomeDelivery: 'paper-subscription-landing-page-delivery',
 };
 
 // ----- Internationalisation ----- //

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
@@ -31,7 +31,8 @@ import { Collection, HomeDelivery } from 'helpers/productPrice/fulfilmentOptions
 
 // ----- Collection or delivery ----- //
 
-const method: PaperFulfilmentOptions = window.location.pathname.includes('delivery') ? HomeDelivery : Collection;
+const fulfilment: PaperFulfilmentOptions = window.location.pathname.includes('delivery') ? HomeDelivery : Collection;
+const product = getQueryParameter('product');
 
 const reactElementId: {
   [PaperFulfilmentOptions]: string,
@@ -46,13 +47,10 @@ const countryGroupId: CountryGroupId = detect();
 const { supportInternationalisationId } = countryGroups[countryGroupId];
 const subsCountry = (['us', 'au'].includes(supportInternationalisationId) ? supportInternationalisationId : 'gb').toUpperCase();
 
-// ----- Initial selection? ----- //
-
-const promoInUrl = getQueryParameter('promo');
 
 // ----- Redux Store ----- //
 
-const store = pageInit(() => reducer(method, promoInUrl), true);
+const store = pageInit(() => reducer(fulfilment, product), true);
 
 
 // ----- Render ----- //
@@ -96,5 +94,5 @@ const content = (
   </Provider>
 );
 
-renderPage(content, reactElementId[method]);
+renderPage(content, reactElementId[fulfilment]);
 

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPageActions.js
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPageActions.js
@@ -4,7 +4,7 @@
 
 import { ProductPagePlanFormActionsFor } from 'components/productPage/productPagePlanForm/productPagePlanFormActions';
 import { paperCheckoutUrl, paperSubsUrl } from 'helpers/routes';
-import { getPaperCheckout } from 'helpers/externalLinks';
+import { getLegacyPaperCheckout } from 'helpers/externalLinks';
 import { sendClickedEvent } from 'helpers/tracking/clickTracking';
 
 import { type State } from './paperSubscriptionLandingPageReducer';
@@ -34,7 +34,7 @@ const getCheckoutUrl = (state: State) => {
   }
 
   const { referrerAcquisitionData, abParticipations, optimizeExperiments } = state.common;
-  return state.page.plan.plan ? getPaperCheckout(
+  return state.page.plan.plan ? getLegacyPaperCheckout(
     state.page.plan.plan,
     state.page.tab,
     referrerAcquisitionData,

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPageActions.js
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPageActions.js
@@ -10,9 +10,9 @@ import { sendClickedEvent } from 'helpers/tracking/clickTracking';
 import { type State } from './paperSubscriptionLandingPageReducer';
 import type { PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import { HomeDelivery } from 'helpers/productPrice/fulfilmentOptions';
-import { Everyday } from 'helpers/productPrice/productOptions';
 import { getQueryParameter } from 'helpers/url';
 import type { PaperProductOptions } from 'helpers/productPrice/productOptions';
+import { Everyday } from 'helpers/productPrice/productOptions';
 
 // ----- Types ----- //
 export type TabActions = { type: 'SET_TAB', tab: PaperFulfilmentOptions }
@@ -29,7 +29,8 @@ const setTab = (tab: PaperFulfilmentOptions): TabActions => {
 
 const getCheckoutUrl = (state: State) => {
   if (getQueryParameter('displayCheckout') === 'true') {
-    return paperCheckoutUrl(HomeDelivery, Everyday);
+    const product = state.page.plan.plan ? state.page.plan.plan : Everyday;
+    return paperCheckoutUrl(state.page.tab, product);
   }
 
   const { referrerAcquisitionData, abParticipations, optimizeExperiments } = state.common;

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPageActions.js
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPageActions.js
@@ -4,37 +4,48 @@
 
 import { type PaperBillingPlan } from 'helpers/subscriptions';
 import { ProductPagePlanFormActionsFor } from 'components/productPage/productPagePlanForm/productPagePlanFormActions';
-import { type PaperDeliveryMethod } from 'helpers/subscriptions';
-import { paperSubsUrl } from 'helpers/routes';
+import { paperCheckoutUrl, paperSubsUrl } from 'helpers/routes';
 import { getPaperCheckout } from 'helpers/externalLinks';
 import { sendClickedEvent } from 'helpers/tracking/clickTracking';
 
 import { type State } from './paperSubscriptionLandingPageReducer';
+import type { PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
+import { HomeDelivery } from 'helpers/productPrice/fulfilmentOptions';
+import { Everyday } from 'helpers/productPrice/productOptions';
+import { getQueryParameter } from 'helpers/url';
 
 // ----- Types ----- //
-export type TabActions = { type: 'SET_TAB', tab: PaperDeliveryMethod }
+export type TabActions = { type: 'SET_TAB', tab: PaperFulfilmentOptions }
 
 
 // ----- Action Creators ----- //
 
 const { setPlan } = ProductPagePlanFormActionsFor<PaperBillingPlan>('Paper', 'Paper');
-const setTab = (tab: PaperDeliveryMethod): TabActions => {
+const setTab = (tab: PaperFulfilmentOptions): TabActions => {
   sendClickedEvent(`paper_subscription_landing_page-switch_tab-${tab}`)();
   window.history.replaceState({}, null, paperSubsUrl(tab === 'delivery'));
   return { type: 'SET_TAB', tab };
+};
+
+const getCheckoutUrl = (state: State) => {
+  if (getQueryParameter('displayCheckout') === 'true') {
+    return paperCheckoutUrl(HomeDelivery, Everyday);
+  }
+
+  const { referrerAcquisitionData, abParticipations, optimizeExperiments } = state.common;
+  return state.page.plan.plan ? getPaperCheckout(
+    state.page.plan.plan,
+    referrerAcquisitionData,
+    abParticipations,
+    optimizeExperiments,
+  ) : null;
 };
 
 const redirectToCheckout = () =>
   (dispatch: Dispatch<{||}>, getState: () => State) => {
     /* this action does not dipatch anything at the moment */
     const state = getState();
-    const { referrerAcquisitionData, abParticipations, optimizeExperiments } = state.common;
-    const location = state.page.plan.plan ? getPaperCheckout(
-      state.page.plan.plan,
-      referrerAcquisitionData,
-      abParticipations,
-      optimizeExperiments,
-    ) : null;
+    const location = getCheckoutUrl(state);
 
     if (location) {
       // this is annoying because we *know* state.page.plan.plan exists --------------v

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPageActions.js
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPageActions.js
@@ -2,7 +2,6 @@
 
 // ----- Imports ----- //
 
-import { type PaperBillingPlan } from 'helpers/subscriptions';
 import { ProductPagePlanFormActionsFor } from 'components/productPage/productPagePlanForm/productPagePlanFormActions';
 import { paperCheckoutUrl, paperSubsUrl } from 'helpers/routes';
 import { getPaperCheckout } from 'helpers/externalLinks';
@@ -13,6 +12,7 @@ import type { PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOpti
 import { HomeDelivery } from 'helpers/productPrice/fulfilmentOptions';
 import { Everyday } from 'helpers/productPrice/productOptions';
 import { getQueryParameter } from 'helpers/url';
+import type { PaperProductOptions } from 'helpers/productPrice/productOptions';
 
 // ----- Types ----- //
 export type TabActions = { type: 'SET_TAB', tab: PaperFulfilmentOptions }
@@ -20,10 +20,10 @@ export type TabActions = { type: 'SET_TAB', tab: PaperFulfilmentOptions }
 
 // ----- Action Creators ----- //
 
-const { setPlan } = ProductPagePlanFormActionsFor<PaperBillingPlan>('Paper', 'Paper');
+const { setPlan } = ProductPagePlanFormActionsFor<PaperProductOptions>('Paper', 'Paper');
 const setTab = (tab: PaperFulfilmentOptions): TabActions => {
   sendClickedEvent(`paper_subscription_landing_page-switch_tab-${tab}`)();
-  window.history.replaceState({}, null, paperSubsUrl(tab === 'delivery'));
+  window.history.replaceState({}, null, paperSubsUrl(tab === HomeDelivery));
   return { type: 'SET_TAB', tab };
 };
 
@@ -35,6 +35,7 @@ const getCheckoutUrl = (state: State) => {
   const { referrerAcquisitionData, abParticipations, optimizeExperiments } = state.common;
   return state.page.plan.plan ? getPaperCheckout(
     state.page.plan.plan,
+    state.page.tab,
     referrerAcquisitionData,
     abParticipations,
     optimizeExperiments,

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPageReducer.js
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPageReducer.js
@@ -4,15 +4,16 @@
 
 import { combineReducers } from 'redux';
 import type { CommonState } from 'helpers/page/commonReducer';
-import { type PaperDeliveryMethod, type PaperBillingPlan } from 'helpers/subscriptions';
+import { type PaperBillingPlan } from 'helpers/subscriptions';
 import { ProductPagePlanFormReducerFor, type State as FormState } from 'components/productPage/productPagePlanForm/productPagePlanFormReducer';
 
 import { type TabActions } from './paperSubscriptionLandingPageActions';
+import type { PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 
 
 // ----- Types ----- //
 
-export type ActiveTabState = PaperDeliveryMethod;
+export type ActiveTabState = PaperFulfilmentOptions;
 
 export type State = {
   common: CommonState,
@@ -25,7 +26,7 @@ export type State = {
 
 // ----- Helpers ----- //
 
-const getTabsReducer = (initialTab: PaperDeliveryMethod) =>
+const getTabsReducer = (initialTab: PaperFulfilmentOptions) =>
   (state: ActiveTabState = initialTab, action: TabActions): ActiveTabState => {
 
     switch (action.type) {
@@ -40,7 +41,7 @@ const getTabsReducer = (initialTab: PaperDeliveryMethod) =>
 
 // ----- Exports ----- //
 
-export default (initialTab: PaperDeliveryMethod, promoInUrl: ?string) => {
+export default (initialTab: PaperFulfilmentOptions, promoInUrl: ?string) => {
 
   const initialPeriod: ?PaperBillingPlan =
     promoInUrl === 'collectionEveryday' || promoInUrl === 'collectionSixday' ||

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPageReducer.js
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPageReducer.js
@@ -10,6 +10,7 @@ import { type TabActions } from './paperSubscriptionLandingPageActions';
 import type { PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import type { PaperProductOptions } from 'helpers/productPrice/productOptions';
 import type { ProductPrices } from 'helpers/productPrice/productPrices';
+import { ActivePaperProductTypes } from 'helpers/productPrice/productOptions';
 
 
 // ----- Types ----- //
@@ -45,11 +46,8 @@ const getTabsReducer = (initialTab: PaperFulfilmentOptions) =>
 
 export default (initialTab: PaperFulfilmentOptions, product: ?string) => {
 
-  const initialProduct: ?PaperProductOptions =
-    product === 'Everyday' ||
-    product === 'Sixday' ||
-    product === 'Weekend' ||
-    product === 'Sunday' ? product : null;
+  const index = ActivePaperProductTypes.findIndex(s => s.toLowerCase() === product.toLowerCase());
+  const initialProduct: ?PaperProductOptions = index > -1 ? ActivePaperProductTypes[index] : null;
 
   const { productPrices } = window.guardian;
 

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPageReducer.js
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPageReducer.js
@@ -4,11 +4,12 @@
 
 import { combineReducers } from 'redux';
 import type { CommonState } from 'helpers/page/commonReducer';
-import { type PaperBillingPlan } from 'helpers/subscriptions';
 import { ProductPagePlanFormReducerFor, type State as FormState } from 'components/productPage/productPagePlanForm/productPagePlanFormReducer';
 
 import { type TabActions } from './paperSubscriptionLandingPageActions';
 import type { PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
+import type { PaperProductOptions } from 'helpers/productPrice/productOptions';
+import type { ProductPrices } from 'helpers/productPrice/productPrices';
 
 
 // ----- Types ----- //
@@ -18,8 +19,9 @@ export type ActiveTabState = PaperFulfilmentOptions;
 export type State = {
   common: CommonState,
   page: {
+    productPrices: ProductPrices,
     tab: ActiveTabState,
-    plan: FormState<PaperBillingPlan>,
+    plan: FormState<PaperProductOptions>,
   }
 };
 
@@ -41,16 +43,19 @@ const getTabsReducer = (initialTab: PaperFulfilmentOptions) =>
 
 // ----- Exports ----- //
 
-export default (initialTab: PaperFulfilmentOptions, promoInUrl: ?string) => {
+export default (initialTab: PaperFulfilmentOptions, product: ?string) => {
 
-  const initialPeriod: ?PaperBillingPlan =
-    promoInUrl === 'collectionEveryday' || promoInUrl === 'collectionSixday' ||
-    promoInUrl === 'collectionWeekend' || promoInUrl === 'collectionSunday' ||
-    promoInUrl === 'deliveryEveryday' || promoInUrl === 'deliverySixday' ||
-    promoInUrl === 'deliveryWeekend' || promoInUrl === 'deliverySunday' ? promoInUrl : null;
+  const initialProduct: ?PaperProductOptions =
+    product === 'Everyday' ||
+    product === 'Sixday' ||
+    product === 'Weekend' ||
+    product === 'Sunday' ? product : null;
+
+  const { productPrices } = window.guardian;
 
   return combineReducers({
-    plan: ProductPagePlanFormReducerFor<?PaperBillingPlan>('Paper', initialPeriod),
+    productPrices: () => productPrices,
+    plan: ProductPagePlanFormReducerFor<?PaperProductOptions>('Paper', initialProduct),
     tab: getTabsReducer(initialTab),
   });
 };

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPageReducer.js
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPageReducer.js
@@ -41,19 +41,22 @@ const getTabsReducer = (initialTab: PaperFulfilmentOptions) =>
 
   };
 
+const findInitialProduct = (product: ?string) => {
+  if (!product) { return null; }
+  // $FlowIgnore - Flow doesn't realise we've already checked product is not null
+  const index = ActivePaperProductTypes.findIndex(s => s.toLowerCase() === product.toLowerCase());
+  return index > -1 ? ActivePaperProductTypes[index] : null;
+};
 
 // ----- Exports ----- //
 
 export default (initialTab: PaperFulfilmentOptions, product: ?string) => {
 
-  const index = ActivePaperProductTypes.findIndex(s => s.toLowerCase() === product.toLowerCase());
-  const initialProduct: ?PaperProductOptions = index > -1 ? ActivePaperProductTypes[index] : null;
-
   const { productPrices } = window.guardian;
 
   return combineReducers({
     productPrices: () => productPrices,
-    plan: ProductPagePlanFormReducerFor<?PaperProductOptions>('Paper', initialProduct),
+    plan: ProductPagePlanFormReducerFor<?PaperProductOptions>('Paper', findInitialProduct(product)),
     tab: getTabsReducer(initialTab),
   });
 };


### PR DESCRIPTION
## Why are you doing this?
To be able to go from the paper landing page to the checkout page we need to pass the selected product and fulfilment options in the url.
This has required quite a large refactor of the paper landing page to make it work with the new `ProductPrices` objects from the catalog but has allowed me to delete quite a bit of the old pricing code from `subscriptions.js`

## Changes
* Load prices from the product catalog on the paper landing page rather than using the old hard coded values
* Update components to use the catalog types
* Generate links to the new paper checkout page when the `displayCheckout=true` query param is present

[**Trello Card**](https://trello.com/c/3FHVlJbc/2297-pass-paper-product-choices-from-landing-page-to-checkout-page)

