### PR TITLE
Hide ticker due to issue

### DIFF
--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
@@ -155,7 +155,8 @@ function campaignSpecificDetails() {
           </p>
         </div>
       ),
-      tickerJsonUrl: '/ticker.json',
+      // TODO: uncomment the below
+      // tickerJsonUrl: '/ticker.json',
       // stuff for campaign that's not set here:
       // - CSS class (contributionsLanding.jsx)
       // - Terms & Conditions
@@ -168,9 +169,11 @@ function campaignSpecificDetails() {
 
 function urlSpecificDetails() {
   if (getQueryParameter('ticker') === 'true') {
-    return {
-      tickerJsonUrl: '/ticker.json',
-    };
+    // TODO: uncomment the below
+    // return {
+    //   tickerJsonUrl: '/ticker.json',
+    // };
+    return {};
   }
 
   return {};


### PR DESCRIPTION
The ticker isn't updating. Raw events in `acquisition_events_prod` don't have any campaignCodes against them, which means nothing will match the conditions for this campaign.

We'll fix tomorrow but right now we need to switch it off