### PR TITLE
Do not load unnecessary payment JS

### DIFF
--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
@@ -148,7 +148,7 @@ function campaignSpecificDetails() {
               That way everyone can learn about the devastating and immediate
               threats to our country and how best to find a solution.
             </span>&nbsp;
-            {/*todo: find out why there's no space between these, unless I put &nbps;*/}
+            {/* todo: find out why there's no space between these, unless I put &nbps; */}
             <span className="bold highlight">
               Please contribute to our new series on Australia’s climate emergency today.
             </span>

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -89,7 +89,7 @@ function initialiseStripeCheckout(
 
 
 function initialisePaymentMethods(state: State, dispatch: Function) {
-  const { countryId, currencyId } = state.common.internationalisation;
+  const { countryId, currencyId, countryGroupId } = state.common.internationalisation;
   const { switches } = state.common.settings;
   const { isTestUser } = state.page.user;
 
@@ -98,9 +98,11 @@ function initialisePaymentMethods(state: State, dispatch: Function) {
     dispatch(onThirdPartyPaymentAuthorised(paymentAuthorisation));
   };
 
+  const contributionTypes = getValidContributionTypes(countryGroupId);
+
   if (getQueryParameter('stripe-checkout-js') !== 'no') {
     loadStripe().then(() => {
-      ['ONE_OFF', 'ANNUAL', 'MONTHLY'].forEach((contribType) => {
+      contributionTypes.forEach((contribType) => {
         const validPayments = getValidPaymentMethods(contribType, switches, countryId);
         if (validPayments.includes('Stripe')) {
           initialiseStripeCheckout(
@@ -115,7 +117,10 @@ function initialisePaymentMethods(state: State, dispatch: Function) {
     });
   }
 
-  if (getQueryParameter('paypal-js') !== 'no') {
+  const hasRecurring = contributionTypes.includes('MONTHLY')
+    || contributionTypes.includes('ANNUAL');
+
+  if (getQueryParameter('paypal-js') !== 'no' && hasRecurring) {
     loadPayPalRecurring().then(() => dispatch(setPayPalHasLoaded()));
   }
 }

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -117,10 +117,10 @@ function initialisePaymentMethods(state: State, dispatch: Function) {
     });
   }
 
-  const hasRecurring = contributionTypes.includes('MONTHLY')
+  const recurringContributionsAvailable = contributionTypes.includes('MONTHLY')
     || contributionTypes.includes('ANNUAL');
 
-  if (getQueryParameter('paypal-js') !== 'no' && hasRecurring) {
+  if (getQueryParameter('paypal-js') !== 'no' && recurringContributionsAvailable) {
     loadPayPalRecurring().then(() => dispatch(setPayPalHasLoaded()));
   }
 }


### PR DESCRIPTION
Just acting on a thought I had, fairly late into the evening!

We're not checking the available contribution types before we initialise third-party libs. Most wastefully, we're loading PayPal recurring JS even on pages which only have one-off available (e.g. the current Australia campaign page). This will definitely have an impact on performance.

We're also running through some unnecessary Stripe logic on pages where particular payment methods are disabled (such as non-UK/US right now). We still have to actually load the main Stripe libs, since Stripe is used on all contribution types, but we shouldn't try and configure the Stripe libs for contribution types which aren't available (though admittedly this probably won't improve performance).