### PR TITLE
Rationalise payment methods

### DIFF
--- a/support-frontend/assets/components/directDebit/directDebitActions.js
+++ b/support-frontend/assets/components/directDebit/directDebitActions.js
@@ -4,6 +4,7 @@ import * as storage from 'helpers/storage';
 import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
 
 import { checkAccount } from './helpers/ajax';
+import { DirectDebit } from 'helpers/paymentMethods';
 
 // ----- Types ----- //
 
@@ -28,7 +29,7 @@ export type Action =
 // ----- Actions ----- //
 
 const openDirectDebitPopUp = (): Action => {
-  storage.setSession('selectedPaymentMethod', 'DirectDebit');
+  storage.setSession('selectedPaymentMethod', DirectDebit);
   return { type: 'DIRECT_DEBIT_POP_UP_OPEN' };
 };
 
@@ -124,7 +125,7 @@ function confirmDirectDebitClicked(onPaymentAuthorisation: PaymentAuthorisation 
     const sortCode = sortCodeArray.join('');
 
     onPaymentAuthorisation({
-      paymentMethod: 'DirectDebit',
+      paymentMethod: DirectDebit,
       accountHolderName,
       sortCode,
       accountNumber,

--- a/support-frontend/assets/components/paypalExpressButton/PayPalExpressButton.jsx
+++ b/support-frontend/assets/components/paypalExpressButton/PayPalExpressButton.jsx
@@ -10,6 +10,7 @@ import { getPayPalOptions, type SetupPayPalRequestType } from 'helpers/paymentIn
 import { type IsoCurrency } from 'helpers/internationalisation/currency';
 import { type PayPalAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
 import type { BillingPeriod } from 'helpers/billingPeriods';
+import { PayPal } from 'helpers/paymentMethods';
 
 type PropTypes = {|
   onPaymentAuthorisation: Function,
@@ -56,7 +57,7 @@ export class PayPalExpressButton extends React.Component<PropTypes> {
     }
 
     const tokenToAuthorisation = (token: string): PayPalAuthorisation => ({
-      paymentMethod: 'PayPal',
+      paymentMethod: PayPal,
       token,
     });
 

--- a/support-frontend/assets/components/subscriptionCheckouts/paymentMethodSelector.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/paymentMethodSelector.jsx
@@ -2,7 +2,6 @@
 
 import React from 'react';
 import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
-import type { PaymentMethod } from 'pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer';
 import { FormSection } from 'components/checkoutForm/checkoutForm';
 import { Fieldset } from 'components/forms/fieldset';
 import { RadioInput } from 'components/forms/customFields/radioInput';
@@ -12,6 +11,7 @@ import DirectDebitPopUpForm from 'components/directDebit/directDebitPopUpForm/di
 import { getQueryParameter } from 'helpers/url';
 import { type Option } from 'helpers/types/option';
 import type { OptimizeExperiments } from 'helpers/optimize/optimize';
+import type { PaymentMethod } from 'helpers/paymentMethods';
 
 type PropTypes = {|
   countrySupportsDirectDebit: boolean,

--- a/support-frontend/assets/components/subscriptionCheckouts/paymentMethodSelector.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/paymentMethodSelector.jsx
@@ -12,6 +12,7 @@ import { getQueryParameter } from 'helpers/url';
 import { type Option } from 'helpers/types/option';
 import type { OptimizeExperiments } from 'helpers/optimize/optimize';
 import type { PaymentMethod } from 'helpers/paymentMethods';
+import { DirectDebit, PayPal, Stripe } from 'helpers/paymentMethods';
 
 type PropTypes = {|
   countrySupportsDirectDebit: boolean,
@@ -42,21 +43,21 @@ function PaymentMethodSelector(props: PropTypes) {
             <RadioInput
               text="Direct debit"
               name="paymentMethod"
-              checked={props.paymentMethod === 'DirectDebit'}
-              onChange={() => props.setPaymentMethod('DirectDebit')}
+              checked={props.paymentMethod === DirectDebit}
+              onChange={() => props.setPaymentMethod(DirectDebit)}
             />}
             <RadioInput
               text="Credit/Debit card"
               name="paymentMethod"
-              checked={props.paymentMethod === 'Stripe'}
-              onChange={() => props.setPaymentMethod('Stripe')}
+              checked={props.paymentMethod === Stripe}
+              onChange={() => props.setPaymentMethod(Stripe)}
             />
             {payPalEnabled &&
             <RadioInput
               text="PayPal"
               name="paymentMethod"
-              checked={props.paymentMethod === 'PayPal'}
-              onChange={() => props.setPaymentMethod('PayPal')}
+              checked={props.paymentMethod === PayPal}
+              onChange={() => props.setPaymentMethod(PayPal)}
             />}
           </Fieldset>
         </div>

--- a/support-frontend/assets/components/subscriptionCheckouts/subscriptionSubmitButtons.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/subscriptionSubmitButtons.jsx
@@ -13,6 +13,7 @@ import { PayPalExpressButton } from 'components/paypalExpressButton/PayPalExpres
 import Button from 'components/button/button';
 import { type Option } from 'helpers/types/option';
 import type { PaymentMethod } from 'helpers/paymentMethods';
+import { PayPal } from 'helpers/paymentMethods';
 
 // ----- Types ----- //
 
@@ -42,7 +43,7 @@ function SubscriptionSubmitButtons(props: PropTypes) {
     <div>
       <div
         id="component-paypal-button-checkout"
-        className={hiddenIf(props.paymentMethod !== 'PayPal', 'component-paypal-button-checkout')}
+        className={hiddenIf(props.paymentMethod !== PayPal, 'component-paypal-button-checkout')}
       >
         <PayPalExpressButton
           onPaymentAuthorisation={props.onPaymentAuthorised}
@@ -61,7 +62,7 @@ function SubscriptionSubmitButtons(props: PropTypes) {
       <Button
         aria-label={null}
         type="submit"
-        modifierClasses={props.paymentMethod === 'PayPal' ? ['hidden'] : []}
+        modifierClasses={props.paymentMethod === PayPal ? ['hidden'] : []}
       >
         Continue to payment
       </Button>

--- a/support-frontend/assets/components/subscriptionCheckouts/subscriptionSubmitButtons.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/subscriptionSubmitButtons.jsx
@@ -5,7 +5,6 @@
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import React from 'react';
 
-import { type PaymentMethod } from 'pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer';
 import { type IsoCurrency } from 'helpers/internationalisation/currency';
 import { hiddenIf } from 'helpers/utilities';
 import { type SetupPayPalRequestType } from 'helpers/paymentIntegrations/payPalRecurringCheckout';
@@ -13,6 +12,7 @@ import type { BillingPeriod } from 'helpers/billingPeriods';
 import { PayPalExpressButton } from 'components/paypalExpressButton/PayPalExpressButton';
 import Button from 'components/button/button';
 import { type Option } from 'helpers/types/option';
+import type { PaymentMethod } from 'helpers/paymentMethods';
 
 // ----- Types ----- //
 

--- a/support-frontend/assets/helpers/__tests__/checkoutsTest.js
+++ b/support-frontend/assets/helpers/__tests__/checkoutsTest.js
@@ -3,6 +3,7 @@
 // ----- Imports ----- //
 
 import { getValidPaymentMethods, getPaymentMethodToSelect } from '../checkouts';
+import { DirectDebit, PayPal, Stripe } from 'helpers/paymentMethods';
 
 // ----- Tests ----- //
 
@@ -40,8 +41,8 @@ describe('checkouts', () => {
     it('should return correct values for Monthly Recurring UK when switches are all on', () => {
       const contributionType = 'MONTHLY';
       const countryId = 'GB';
-      expect(getValidPaymentMethods(contributionType, allSwitchesOn, countryId)).toEqual(['DirectDebit', 'Stripe', 'PayPal']);
-      expect(getPaymentMethodToSelect(contributionType, allSwitchesOn, countryId)).toEqual('DirectDebit');
+      expect(getValidPaymentMethods(contributionType, allSwitchesOn, countryId)).toEqual([DirectDebit, Stripe, PayPal]);
+      expect(getPaymentMethodToSelect(contributionType, allSwitchesOn, countryId)).toEqual(DirectDebit);
 
     });
 
@@ -57,8 +58,8 @@ describe('checkouts', () => {
       const contributionType = 'ONE_OFF';
       const justStripeOn = { ...allSwitchesOff, oneOffPaymentMethods: { ...allSwitchesOff.oneOffPaymentMethods, stripe: 'On' } };
       const countryId = 'US';
-      expect(getValidPaymentMethods(contributionType, justStripeOn, countryId)).toEqual(['Stripe']);
-      expect(getPaymentMethodToSelect(contributionType, justStripeOn, countryId)).toEqual('Stripe');
+      expect(getValidPaymentMethods(contributionType, justStripeOn, countryId)).toEqual([Stripe]);
+      expect(getPaymentMethodToSelect(contributionType, justStripeOn, countryId)).toEqual(Stripe);
 
     });
 

--- a/support-frontend/assets/helpers/checkoutForm/onFormSubmit.js
+++ b/support-frontend/assets/helpers/checkoutForm/onFormSubmit.js
@@ -1,8 +1,9 @@
 // @flow
-import type { ContributionType, PaymentMethod } from 'helpers/contributions';
+import type { ContributionType } from 'helpers/contributions';
 import { invalidReason } from 'helpers/checkoutForm/checkoutForm';
 import type { UserTypeFromIdentityResponse } from 'helpers/identityApis';
 import { trackCheckoutSubmitAttempt } from 'helpers/tracking/ophanComponentEventTracking';
+import type { PaymentMethod } from 'helpers/paymentMethods';
 
 type OldFlowOrNewFlow = 'opf' | 'npf';
 

--- a/support-frontend/assets/helpers/checkoutForm/onFormSubmitOld.js
+++ b/support-frontend/assets/helpers/checkoutForm/onFormSubmitOld.js
@@ -1,8 +1,9 @@
 // @flow
-import type { ContributionType, PaymentMethod } from 'helpers/contributions';
+import type { ContributionType } from 'helpers/contributions';
 import { canContributeWithoutSigningIn, type UserTypeFromIdentityResponse } from 'helpers/identityApis';
 import { formElementIsValid, invalidReason } from 'helpers/checkoutForm/checkoutForm';
 import { trackCheckoutSubmitAttempt } from 'helpers/tracking/ophanComponentEventTracking';
+import type { PaymentMethod } from 'helpers/paymentMethods';
 
 type OldFlowOrNewFlow = 'opf' | 'npf';
 

--- a/support-frontend/assets/helpers/checkouts.js
+++ b/support-frontend/assets/helpers/checkouts.js
@@ -5,7 +5,6 @@
 import { getQueryParameter } from 'helpers/url';
 import {
   type ContributionType, getFrequency,
-  type PaymentMethod,
   toContributionType,
 } from 'helpers/contributions';
 import {
@@ -18,6 +17,7 @@ import type { Currency, IsoCurrency, SpokenCurrency } from 'helpers/internationa
 import { currencies, spokenCurrencies } from 'helpers/internationalisation/currency';
 import type { Amount, SelectedAmounts } from 'helpers/contributions';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import type { PaymentMethod } from 'helpers/paymentMethods';
 
 
 // ----- Types ----- //

--- a/support-frontend/assets/helpers/checkouts.js
+++ b/support-frontend/assets/helpers/checkouts.js
@@ -18,6 +18,7 @@ import { currencies, spokenCurrencies } from 'helpers/internationalisation/curre
 import type { Amount, SelectedAmounts } from 'helpers/contributions';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { PaymentMethod } from 'helpers/paymentMethods';
+import { DirectDebit, PayPal, Stripe } from 'helpers/paymentMethods';
 
 
 // ----- Types ----- //
@@ -32,9 +33,9 @@ export type ThirdPartyPaymentLibrary = StripeHandler;
 
 function toPaymentMethodSwitchNaming(paymentMethod: PaymentMethod): PaymentMethodSwitch | null {
   switch (paymentMethod) {
-    case 'PayPal': return 'payPal';
-    case 'Stripe': return 'stripe';
-    case 'DirectDebit': return 'directDebit';
+    case PayPal: return 'payPal';
+    case Stripe: return 'stripe';
+    case DirectDebit: return 'directDebit';
     default: return null;
   }
 }
@@ -90,8 +91,8 @@ function getContributionTypeFromUrlOrElse(fallback: ContributionType): Contribut
 // i.e the first element in the array will be the default option
 function getPaymentMethods(contributionType: ContributionType, countryId: IsoCountry): PaymentMethod[] {
   return contributionType !== 'ONE_OFF' && countryId === 'GB'
-    ? ['DirectDebit', 'Stripe', 'PayPal']
-    : ['Stripe', 'PayPal'];
+    ? [DirectDebit, Stripe, PayPal]
+    : [Stripe, PayPal];
 }
 
 const switchIsOn =
@@ -127,7 +128,7 @@ function getPaymentMethodFromSession(): ?PaymentMethod {
 
 function getPaymentDescription(contributionType: ContributionType, paymentMethod: PaymentMethod): string {
   if (contributionType === 'ONE_OFF') {
-    if (paymentMethod === 'PayPal') {
+    if (paymentMethod === PayPal) {
       return 'with PayPal';
     }
 
@@ -181,13 +182,13 @@ const getContributeButtonCopyWithPaymentType = (
 
 function getPaymentLabel(paymentMethod: PaymentMethod): string {
   switch (paymentMethod) {
-    case 'Stripe':
+    case Stripe:
       return 'Credit/Debit card';
-    case 'DirectDebit':
+    case DirectDebit:
       return 'Direct debit';
-    case 'PayPal':
+    case PayPal:
     default:
-      return 'PayPal';
+      return PayPal;
   }
 }
 

--- a/support-frontend/assets/helpers/contributions.js
+++ b/support-frontend/assets/helpers/contributions.js
@@ -10,22 +10,9 @@ import { currencies, spokenCurrencies } from 'helpers/internationalisation/curre
 import type { Radio } from 'components/radioToggle/radioToggle';
 import { logException } from 'helpers/logger';
 import { Annual, type BillingPeriod, Monthly } from 'helpers/billingPeriods';
+import type { PaymentMethod, PaymentMethodMap } from 'helpers/paymentMethods';
 
 // ----- Types ----- //
-
-export type PaymentMethodMap<T> = {|
-  Stripe: T,
-  PayPal: T,
-  DirectDebit: T,
-  None: T,
-|};
-
-// This lets us create a union type from the object keys,
-// avoiding the need to specify them separately and keep them in sync!
-// https://flow.org/en/docs/types/utilities/#toc-keys
-// We need to supply the type parameter, but we're only using the keys
-// so it's irrelevant - so we supply null
-export type PaymentMethod = $Keys<PaymentMethodMap<null>>;
 
 export type RegularContributionTypeMap<T> = {|
   MONTHLY: T,

--- a/support-frontend/assets/helpers/paymentIntegrations/payPalRecurringCheckout.js
+++ b/support-frontend/assets/helpers/paymentIntegrations/payPalRecurringCheckout.js
@@ -9,6 +9,7 @@ import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import * as storage from 'helpers/storage';
 import type { BillingPeriod } from 'helpers/billingPeriods';
 import { setPayPalHasLoaded } from 'helpers/paymentIntegrations/payPalActions';
+import { PayPal } from 'helpers/paymentMethods';
 
 export type SetupPayPalRequestType = (
   resolve: string => void,
@@ -61,7 +62,7 @@ const setupRecurringPayPalPayment = (
 ) =>
   (): void => {
     const csrfToken = csrf.token;
-    storage.setSession('selectedPaymentMethod', 'PayPal');
+    storage.setSession('selectedPaymentMethod', PayPal);
     const requestBody = {
       amount,
       billingPeriod,

--- a/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
+++ b/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
@@ -15,6 +15,7 @@ import { type PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOpti
 import { type PaperProductOptions } from 'helpers/productPrice/productOptions';
 
 import { type ThankYouPageStage } from '../../pages/new-contributions-landing/contributionsLandingReducer';
+import { DirectDebit, PayPal, Stripe } from 'helpers/paymentMethods';
 
 // ----- Types ----- //
 
@@ -81,10 +82,14 @@ export type RegularPaymentRequest = {|
 export type StripePaymentMethod = 'StripeCheckout' | 'StripeApplePay' | 'StripePaymentRequestButton';
 export type StripePaymentRequestButtonMethod = 'none' | StripePaymentMethod;
 
-export type StripeAuthorisation = {| paymentMethod: 'Stripe', token: string, stripePaymentMethod: StripePaymentMethod|};
-export type PayPalAuthorisation = {| paymentMethod: 'PayPal', token: string |};
+export type StripeAuthorisation = {|
+  paymentMethod: typeof Stripe,
+  token: string,
+  stripePaymentMethod: StripePaymentMethod
+|};
+export type PayPalAuthorisation = {| paymentMethod: typeof PayPal, token: string |};
 export type DirectDebitAuthorisation = {|
-  paymentMethod: 'DirectDebit',
+  paymentMethod: typeof DirectDebit,
   accountHolderName: string,
   sortCode: string,
   accountNumber: string
@@ -115,11 +120,11 @@ const MAX_POLLS = 10;
 
 function regularPaymentFieldsFromAuthorisation(authorisation: PaymentAuthorisation): RegularPaymentFields {
   switch (authorisation.paymentMethod) {
-    case 'Stripe':
+    case Stripe:
       return { stripeToken: authorisation.token };
-    case 'PayPal':
+    case PayPal:
       return { baid: authorisation.token };
-    case 'DirectDebit':
+    case DirectDebit:
       return {
         accountHolderName: authorisation.accountHolderName,
         sortCode: authorisation.sortCode,

--- a/support-frontend/assets/helpers/paymentIntegrations/stripeCheckout.js
+++ b/support-frontend/assets/helpers/paymentIntegrations/stripeCheckout.js
@@ -20,6 +20,7 @@
 
 import { type IsoCurrency } from 'helpers/internationalisation/currency';
 import type { StripeAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
+import { Stripe } from 'helpers/paymentMethods';
 
 // ----- Types ----- //
 
@@ -65,7 +66,7 @@ function setupStripeCheckout(
   isTestUser: boolean,
 ): Object {
   const handleToken = (token) => {
-    onPaymentAuthorisation({ paymentMethod: 'Stripe', token: token.id, stripePaymentMethod: 'StripeCheckout' });
+    onPaymentAuthorisation({ paymentMethod: Stripe, token: token.id, stripePaymentMethod: 'StripeCheckout' });
   };
 
   const stripeKey = getStripeKey(stripeAccount, currency, isTestUser);

--- a/support-frontend/assets/helpers/paymentMethods.js
+++ b/support-frontend/assets/helpers/paymentMethods.js
@@ -1,0 +1,15 @@
+// @flow
+
+export type PaymentMethodMap<T> = {|
+  Stripe: T,
+  PayPal: T,
+  DirectDebit: T,
+  None: T,
+|};
+
+// This lets us create a union type from the object keys,
+// avoiding the need to specify them separately and keep them in sync!
+// https://flow.org/en/docs/types/utilities/#toc-keys
+// We need to supply the type parameter, but we're only using the keys
+// so it's irrelevant - so we supply null
+export type PaymentMethod = $Keys<PaymentMethodMap<null>>;

--- a/support-frontend/assets/helpers/paymentMethods.js
+++ b/support-frontend/assets/helpers/paymentMethods.js
@@ -1,5 +1,9 @@
 // @flow
 
+const Stripe: 'Stripe' = 'Stripe';
+const PayPal: 'PayPal' = 'PayPal';
+const DirectDebit: 'DirectDebit' = 'DirectDebit';
+
 export type PaymentMethodMap<T> = {|
   Stripe: T,
   PayPal: T,
@@ -13,3 +17,5 @@ export type PaymentMethodMap<T> = {|
 // We need to supply the type parameter, but we're only using the keys
 // so it's irrelevant - so we supply null
 export type PaymentMethod = $Keys<PaymentMethodMap<null>>;
+
+export { Stripe, PayPal, DirectDebit };

--- a/support-frontend/assets/pages/digital-subscription-checkout/__tests__/digitalSubscriptionCheckoutReducerTest.js
+++ b/support-frontend/assets/pages/digital-subscription-checkout/__tests__/digitalSubscriptionCheckoutReducerTest.js
@@ -4,6 +4,7 @@
 
 import { initReducer, type Stage } from '../digitalSubscriptionCheckoutReducer';
 import { setStage, setFormErrors } from '../digitalSubscriptionCheckoutActions';
+import { DirectDebit, Stripe } from 'helpers/paymentMethods';
 
 jest.mock('ophan', () => {});
 jest.mock('font-loader', () => () => ({}));
@@ -15,12 +16,12 @@ describe('Digital Subscription Checkout Reducer', () => {
 
   it('should default to Direct Debit if the country is GB', () => {
     const reducer = initReducer('GB');
-    expect(reducer(undefined, {}).checkout.paymentMethod).toEqual('DirectDebit');
+    expect(reducer(undefined, {}).checkout.paymentMethod).toEqual(DirectDebit);
   });
 
   it('should default to Stripe if the country is US', () => {
     const reducer = initReducer('US');
-    expect(reducer(undefined, {}).checkout.paymentMethod).toEqual('Stripe');
+    expect(reducer(undefined, {}).checkout.paymentMethod).toEqual(Stripe);
   });
 
   it('should handle SET_STAGE to "thankyou"', () => {

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/thankYouContent.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/thankYouContent.jsx
@@ -16,6 +16,7 @@ import {
   getFormFields,
   type FormFields,
 } from '../digitalSubscriptionCheckoutReducer';
+import { DirectDebit } from 'helpers/paymentMethods';
 
 // ----- Types ----- //
 
@@ -35,7 +36,7 @@ function ThankYouContent(props: PropTypes) {
         <Text>
           <LargeParagraph>
             {
-            props.paymentMethod === 'DirectDebit' ?
+            props.paymentMethod === DirectDebit ?
             'Look out for an email within three business days confirming your recurring payment. Your first payment will be taken in 14 days and will appear as \'Guardian Media Group\' on your bank statement.' :
             'We have sent you an email with everything you need to know. Your first payment will be taken in 14 days.'
           }

--- a/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutActions.js
+++ b/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutActions.js
@@ -16,6 +16,7 @@ import { setFormSubmissionDependentValue } from 'pages/digital-subscription-chec
 import { getFormFields } from './digitalSubscriptionCheckoutReducer';
 import type { ErrorReason } from '../../helpers/errorReasons';
 import type { PaymentMethod } from 'helpers/paymentMethods';
+import { PayPal } from 'helpers/paymentMethods';
 
 export type Action =
   | { type: 'SET_STAGE', stage: Stage }
@@ -73,7 +74,7 @@ const formActionCreators = {
   setBillingPeriod: (billingPeriod: DigitalBillingPeriod): Action => ({ type: 'SET_BILLING_PERIOD', billingPeriod }),
   setPaymentMethod: (paymentMethod: PaymentMethod) => (dispatch: Dispatch<Action>, getState: () => State) => {
     const state = getState();
-    if (paymentMethod === 'PayPal' && !state.page.checkout.payPalHasLoaded) {
+    if (paymentMethod === PayPal && !state.page.checkout.payPalHasLoaded) {
       showPayPal(dispatch);
     }
     return dispatch({

--- a/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutActions.js
+++ b/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutActions.js
@@ -13,9 +13,9 @@ import { setCountry } from 'helpers/page/commonActions';
 import type { Dispatch } from 'redux';
 import type { Action as CommonAction } from 'helpers/page/commonActions';
 import { setFormSubmissionDependentValue } from 'pages/digital-subscription-checkout/checkoutFormIsSubmittableActions';
-import type { PaymentMethod } from './digitalSubscriptionCheckoutReducer';
 import { getFormFields } from './digitalSubscriptionCheckoutReducer';
 import type { ErrorReason } from '../../helpers/errorReasons';
+import type { PaymentMethod } from 'helpers/paymentMethods';
 
 export type Action =
   | { type: 'SET_STAGE', stage: Stage }

--- a/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -31,6 +31,7 @@ import type { Action } from './digitalSubscriptionCheckoutActions';
 import { getUser } from './helpers/user';
 import { showPaymentMethod, countrySupportsDirectDebit } from './helpers/paymentProviders';
 import type { PaymentMethod } from 'helpers/paymentMethods';
+import { DirectDebit, Stripe } from 'helpers/paymentMethods';
 
 // ----- Types ----- //
 
@@ -131,7 +132,7 @@ function initReducer(initialCountry: IsoCountry) {
     stateProvince: null,
     telephone: null,
     billingPeriod: initialBillingPeriod,
-    paymentMethod: countrySupportsDirectDebit(initialCountry) ? 'DirectDebit' : 'Stripe',
+    paymentMethod: countrySupportsDirectDebit(initialCountry) ? DirectDebit : Stripe,
     formErrors: [],
     submissionError: null,
     formSubmitted: false,
@@ -184,7 +185,7 @@ function initReducer(initialCountry: IsoCountry) {
         return {
           ...state,
           stateProvince: null,
-          paymentMethod: countrySupportsDirectDebit(action.country) ? 'DirectDebit' : 'Stripe',
+          paymentMethod: countrySupportsDirectDebit(action.country) ? DirectDebit : Stripe,
         };
 
       case 'SET_FORM_ERRORS':

--- a/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -30,11 +30,11 @@ import { validateForm } from 'pages/digital-subscription-checkout/helpers/valida
 import type { Action } from './digitalSubscriptionCheckoutActions';
 import { getUser } from './helpers/user';
 import { showPaymentMethod, countrySupportsDirectDebit } from './helpers/paymentProviders';
+import type { PaymentMethod } from 'helpers/paymentMethods';
 
 // ----- Types ----- //
 
 export type Stage = 'checkout' | 'thankyou' | 'thankyou-pending';
-export type PaymentMethod = 'Stripe' | 'DirectDebit' | 'PayPal'; // TODO: there is another version of this type in contributions.js
 
 export type FormFieldsInState = {|
   firstName: string,

--- a/support-frontend/assets/pages/digital-subscription-checkout/helpers/paymentProviders.js
+++ b/support-frontend/assets/pages/digital-subscription-checkout/helpers/paymentProviders.js
@@ -20,6 +20,7 @@ import { getQueryParameter } from 'helpers/url';
 import { finalPrice as dpFinalPrice } from 'helpers/productPrice/digitalProductPrices';
 import { type State } from '../digitalSubscriptionCheckoutReducer';
 import { setSubmissionError, setFormSubmitted, type Action, setStage } from '../digitalSubscriptionCheckoutActions';
+import { DirectDebit, PayPal, Stripe } from 'helpers/paymentMethods';
 
 function buildRegularPaymentRequest(state: State, paymentAuthorisation: PaymentAuthorisation): RegularPaymentRequest {
   const { currencyId, countryId } = state.common.internationalisation;
@@ -121,13 +122,13 @@ function showPaymentMethod(
   const { paymentMethod } = state.page.checkout;
 
   switch (paymentMethod) {
-    case 'Stripe':
+    case Stripe:
       showStripe(dispatch, state);
       break;
-    case 'DirectDebit':
+    case DirectDebit:
       dispatch(openDirectDebitPopUp());
       break;
-    case 'PayPal':
+    case PayPal:
       // PayPal is more complicated and is handled differently, see PayPalExpressButton component
       break;
     case null:

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -11,7 +11,6 @@ import { classNameWithModifiers } from 'helpers/utilities';
 import {
   type ContributionType,
   type PaymentMatrix,
-  type PaymentMethod,
   logInvalidCombination,
 } from 'helpers/contributions';
 import { type ErrorReason } from 'helpers/errorReasons';
@@ -48,6 +47,7 @@ import {
 } from '../contributionsLandingActions';
 import ContributionErrorMessage from './ContributionErrorMessage';
 import StripePaymentRequestButtonContainer from './StripePaymentRequestButton/StripePaymentRequestButtonContainer';
+import type { PaymentMethod } from 'helpers/paymentMethods';
 
 
 // ----- Types ----- //

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -48,6 +48,7 @@ import {
 import ContributionErrorMessage from './ContributionErrorMessage';
 import StripePaymentRequestButtonContainer from './StripePaymentRequestButton/StripePaymentRequestButtonContainer';
 import type { PaymentMethod } from 'helpers/paymentMethods';
+import { DirectDebit, Stripe } from 'helpers/paymentMethods';
 
 
 // ----- Types ----- //
@@ -168,7 +169,7 @@ const formHandlers: PaymentMatrix<PropTypes => void> = {
         cancelURL: payPalCancelUrl(props.countryGroupId),
       });
     },
-    DirectDebit: () => { logInvalidCombination('ONE_OFF', 'DirectDebit'); },
+    DirectDebit: () => { logInvalidCombination('ONE_OFF', DirectDebit); },
     None: () => { logInvalidCombination('ONE_OFF', 'None'); },
   },
   ANNUAL: {
@@ -189,8 +190,8 @@ function onSubmit(props: PropTypes): Event => void {
     const flowPrefix = 'npf';
     const form = event.target;
 
-    if (props.isPostDeploymentTestUser && props.paymentMethod === 'Stripe') {
-      props.onPaymentAuthorisation({ paymentMethod: 'Stripe', token: 'tok_visa', stripePaymentMethod: 'StripeCheckout' });
+    if (props.isPostDeploymentTestUser && props.paymentMethod === Stripe) {
+      props.onPaymentAuthorisation({ paymentMethod: Stripe, token: 'tok_visa', stripePaymentMethod: 'StripeCheckout' });
     } else {
       const handlePayment = () => formHandlers[props.contributionType][props.paymentMethod](props);
       onFormSubmit({

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
@@ -2,7 +2,7 @@
 
 // ----- Imports ----- //
 
-import type { ContributionType, PaymentMethod } from 'helpers/contributions';
+import type { ContributionType } from 'helpers/contributions';
 import type { Csrf } from 'helpers/csrf/csrfReducer';
 import type { Status } from 'helpers/settings';
 import { isFrontlineCampaign, getQueryParameter } from 'helpers/url';
@@ -29,6 +29,7 @@ import {
   setCheckoutFormHasBeenSubmitted,
   createOneOffPayPalPayment,
 } from '../contributionsLandingActions';
+import type { PaymentMethod } from 'helpers/paymentMethods';
 
 
 // ----- Types ----- //
@@ -148,7 +149,7 @@ function campaignSpecificDetails() {
               That way everyone can learn about the devastating and immediate
               threats to our country and how best to find a solution.
             </span>&nbsp;
-            {/*todo: find out why there's no space between these, unless I put &nbps;*/}
+            {/* todo: find out why there's no space between these, unless I put &nbps; */}
             <span className="bold highlight">
               Please contribute to our new series on Australia’s climate emergency today.
             </span>

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
@@ -19,6 +19,7 @@ import { type State } from '../contributionsLandingReducer';
 import { sendFormSubmitEventForPayPalRecurring } from '../contributionsLandingActions';
 import { ButtonWithRightArrow } from './ButtonWithRightArrow/ButtonWithRightArrow';
 import type { PaymentMethod } from 'helpers/paymentMethods';
+import { PayPal } from 'helpers/paymentMethods';
 
 // ----- Types ----- //
 
@@ -87,7 +88,7 @@ function ContributionSubmit(props: PropTypes) {
   if (props.paymentMethod !== 'None') {
     // if all payment methods are switched off, do not display the button
     const formClassName = 'form--contribution';
-    const showPayPalRecurringButton = props.paymentMethod === 'PayPal' && props.contributionType !== 'ONE_OFF';
+    const showPayPalRecurringButton = props.paymentMethod === PayPal && props.contributionType !== 'ONE_OFF';
 
     const submitButtonCopy = getContributeButtonCopyWithPaymentType(
       props.contributionType,

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
@@ -6,7 +6,7 @@ import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { billingPeriodFromContrib, type ContributionType, getAmount, type PaymentMethod } from 'helpers/contributions';
+import { billingPeriodFromContrib, type ContributionType, getAmount } from 'helpers/contributions';
 import { type IsoCurrency } from 'helpers/internationalisation/currency';
 import { type PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
 import type { SelectedAmounts } from 'helpers/contributions';
@@ -18,6 +18,7 @@ import { PayPalExpressButton } from 'components/paypalExpressButton/PayPalExpres
 import { type State } from '../contributionsLandingReducer';
 import { sendFormSubmitEventForPayPalRecurring } from '../contributionsLandingActions';
 import { ButtonWithRightArrow } from './ButtonWithRightArrow/ButtonWithRightArrow';
+import type { PaymentMethod } from 'helpers/paymentMethods';
 
 // ----- Types ----- //
 

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
@@ -10,6 +10,7 @@ import { ButtonWithRightArrow } from '../ButtonWithRightArrow/ButtonWithRightArr
 import MarketingConsent from '../MarketingConsentContainer';
 import { type Action, setHasSeenDirectDebitThankYouCopy } from '../../contributionsLandingActions';
 import type { PaymentMethod } from 'helpers/paymentMethods';
+import { DirectDebit } from 'helpers/paymentMethods';
 
 // ----- Types ----- //
 
@@ -43,7 +44,7 @@ function ContributionThankYou(props: PropTypes) {
   let directDebitHeaderSuffix = '';
   let directDebitMessageSuffix = '';
 
-  if (props.paymentMethod === 'DirectDebit' && !props.hasSeenDirectDebitThankYouCopy) {
+  if (props.paymentMethod === DirectDebit && !props.hasSeenDirectDebitThankYouCopy) {
     directDebitHeaderSuffix = 'Your Direct Debit has been set up.';
     directDebitMessageSuffix = 'This will appear as \'Guardian Media Group\' on your bank statements';
     props.setHasSeenDirectDebitThankYouCopy();

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
@@ -3,13 +3,13 @@
 // ----- Imports ----- //
 
 import { type Dispatch } from 'redux';
-import type { PaymentMethod } from 'helpers/contributions';
 import React from 'react';
 import { connect } from 'react-redux';
 import { type ContributionType, getSpokenType } from 'helpers/contributions';
 import { ButtonWithRightArrow } from '../ButtonWithRightArrow/ButtonWithRightArrow';
 import MarketingConsent from '../MarketingConsentContainer';
 import { type Action, setHasSeenDirectDebitThankYouCopy } from '../../contributionsLandingActions';
+import type { PaymentMethod } from 'helpers/paymentMethods';
 
 // ----- Types ----- //
 

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYouSetPassword.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYouSetPassword.jsx
@@ -4,10 +4,10 @@
 
 import { type Dispatch } from 'redux';
 import React from 'react';
-import type { PaymentMethod } from 'helpers/contributions';
 import { connect } from 'react-redux';
 import { type Action, setHasSeenDirectDebitThankYouCopy } from '../../contributionsLandingActions';
 import SetPasswordForm from '../SetPasswordForm';
+import type { PaymentMethod } from 'helpers/paymentMethods';
 
 // ----- Types ----- //
 

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYouSetPassword.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYouSetPassword.jsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 import { type Action, setHasSeenDirectDebitThankYouCopy } from '../../contributionsLandingActions';
 import SetPasswordForm from '../SetPasswordForm';
 import type { PaymentMethod } from 'helpers/paymentMethods';
+import { DirectDebit } from 'helpers/paymentMethods';
 
 // ----- Types ----- //
 
@@ -40,7 +41,7 @@ function mapDispatchToProps(dispatch: Dispatch<Action>) {
 // ----- Render ----- //
 
 function ContributionThankYouSetPassword(props: PropTypes) {
-  if (props.paymentMethod === 'DirectDebit' && !props.hasSeenDirectDebitThankYouCopy) {
+  if (props.paymentMethod === DirectDebit && !props.hasSeenDirectDebitThankYouCopy) {
     props.setHasSeenDirectDebitThankYouCopy();
     return (
       <div className="set-password__content">

--- a/support-frontend/assets/pages/new-contributions-landing/components/PaymentMethodSelector.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/PaymentMethodSelector.jsx
@@ -9,7 +9,6 @@ import { type ThirdPartyPaymentLibrary, getPaymentLabel, getValidPaymentMethods 
 import { type Switches } from 'helpers/settings';
 import {
   type ContributionType,
-  type PaymentMethod,
   type ThirdPartyPaymentLibraries,
 } from 'helpers/contributions';
 import { classNameWithModifiers } from 'helpers/utilities';
@@ -23,6 +22,7 @@ import GeneralErrorMessage from 'components/generalErrorMessage/generalErrorMess
 
 import { type State } from '../contributionsLandingReducer';
 import { type Action, updatePaymentMethod, setThirdPartyPaymentLibrary } from '../contributionsLandingActions';
+import type { PaymentMethod } from 'helpers/paymentMethods';
 
 // ----- Types ----- //
 

--- a/support-frontend/assets/pages/new-contributions-landing/components/PaymentMethodSelector.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/PaymentMethodSelector.jsx
@@ -23,6 +23,7 @@ import GeneralErrorMessage from 'components/generalErrorMessage/generalErrorMess
 import { type State } from '../contributionsLandingReducer';
 import { type Action, updatePaymentMethod, setThirdPartyPaymentLibrary } from '../contributionsLandingActions';
 import type { PaymentMethod } from 'helpers/paymentMethods';
+import { DirectDebit, PayPal } from 'helpers/paymentMethods';
 
 // ----- Types ----- //
 
@@ -60,9 +61,9 @@ const mapDispatchToProps = {
 
 function getPaymentMethodLogo(paymentMethod: PaymentMethod) {
   switch (paymentMethod) {
-    case 'PayPal':
+    case PayPal:
       return <SvgPayPal />;
-    case 'DirectDebit':
+    case DirectDebit:
       return <SvgDirectDebitSymbol />;
     default:
       return <SvgNewCreditCard />;

--- a/support-frontend/assets/pages/new-contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -28,6 +28,7 @@ import {
   updateEmail,
 } from '../../contributionsLandingActions';
 import type { PaymentMethod } from 'helpers/paymentMethods';
+import { Stripe } from 'helpers/paymentMethods';
 
 
 // ----- Types -----//
@@ -165,7 +166,7 @@ function setUpPaymentListener(props: PropTypes, paymentRequest: Object, paymentM
       // chose to authorize payment. For example, 'basic-card'."
       trackComponentClick(`${data.methodName}-paymentAuthorised`);
     }
-    props.onPaymentAuthorised({ paymentMethod: 'Stripe', token: tokenId, stripePaymentMethod: paymentMethod })
+    props.onPaymentAuthorised({ paymentMethod: Stripe, token: tokenId, stripePaymentMethod: paymentMethod })
       .then(onComplete(complete));
   });
 }

--- a/support-frontend/assets/pages/new-contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -7,7 +7,7 @@ import { connect } from 'react-redux';
 
 import { PaymentRequestButtonElement, injectStripe } from 'react-stripe-elements';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
-import type { ContributionType, OtherAmounts, PaymentMethod, SelectedAmounts } from 'helpers/contributions';
+import type { ContributionType, OtherAmounts, SelectedAmounts } from 'helpers/contributions';
 import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
 import { checkAmountOrOtherAmount, isValidEmail } from 'helpers/formValidation';
 import {
@@ -27,6 +27,7 @@ import {
   onStripePaymentRequestApiPaymentAuthorised,
   updateEmail,
 } from '../../contributionsLandingActions';
+import type { PaymentMethod } from 'helpers/paymentMethods';
 
 
 // ----- Types -----//

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -10,7 +10,6 @@ import {
   getAmount,
   logInvalidCombination,
   type PaymentMatrix,
-  type PaymentMethod,
 } from 'helpers/contributions';
 import { getUserTypeFromIdentity, type UserTypeFromIdentityResponse } from 'helpers/identityApis';
 import { type CaState, type UsState } from 'helpers/internationalisation/country';
@@ -44,6 +43,7 @@ import { Annual, Monthly } from 'helpers/billingPeriods';
 import type { Action as PayPalAction } from 'helpers/paymentIntegrations/payPalActions';
 import { setFormSubmissionDependentValue } from './checkoutFormIsSubmittableActions';
 import { type State, type ThankYouPageStage, type UserFormData } from './contributionsLandingReducer';
+import type { PaymentMethod } from 'helpers/paymentMethods';
 
 export type Action =
   | { type: 'UPDATE_CONTRIBUTION_TYPE', contributionType: ContributionType }

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLandingActions.js
@@ -44,6 +44,7 @@ import type { Action as PayPalAction } from 'helpers/paymentIntegrations/payPalA
 import { setFormSubmissionDependentValue } from './checkoutFormIsSubmittableActions';
 import { type State, type ThankYouPageStage, type UserFormData } from './contributionsLandingReducer';
 import type { PaymentMethod } from 'helpers/paymentMethods';
+import { DirectDebit, Stripe } from 'helpers/paymentMethods';
 
 export type Action =
   | { type: 'UPDATE_CONTRIBUTION_TYPE', contributionType: ContributionType }
@@ -398,14 +399,14 @@ const paymentAuthorisationHandlers: PaymentMatrix<(
       state: State,
       paymentAuthorisation: PaymentAuthorisation,
     ): Promise<PaymentResult> => {
-      if (paymentAuthorisation.paymentMethod === 'Stripe') {
+      if (paymentAuthorisation.paymentMethod === Stripe) {
         return dispatch(executeStripeOneOffPayment(stripeChargeDataFromAuthorisation(paymentAuthorisation, state)));
       }
       logException(`Invalid payment authorisation: Tried to use the ${paymentAuthorisation.paymentMethod} handler with Stripe`);
       return Promise.resolve(error);
     },
     DirectDebit: () => {
-      logInvalidCombination('ONE_OFF', 'DirectDebit');
+      logInvalidCombination('ONE_OFF', DirectDebit);
       return Promise.resolve(error);
     },
     None: () => {

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -36,6 +36,7 @@ import {
 } from './contributionsLandingActions';
 import { type State } from './contributionsLandingReducer';
 import type { PaymentMethod } from 'helpers/paymentMethods';
+import { Stripe } from 'helpers/paymentMethods';
 
 // ----- Functions ----- //
 
@@ -103,7 +104,7 @@ function initialisePaymentMethods(state: State, dispatch: Function) {
     loadStripe().then(() => {
       ['ONE_OFF', 'ANNUAL', 'MONTHLY'].forEach((contribType) => {
         const validPayments = getValidPaymentMethods(contribType, switches, countryId);
-        if (validPayments.includes('Stripe')) {
+        if (validPayments.includes(Stripe)) {
           initialiseStripeCheckout(
             onPaymentAuthorisation,
             contribType,

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -21,7 +21,7 @@ import {
   getValidPaymentMethods,
   type ThirdPartyPaymentLibrary,
 } from 'helpers/checkouts';
-import { type ContributionType, type PaymentMethod } from 'helpers/contributions';
+import { type ContributionType } from 'helpers/contributions';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import {
@@ -35,6 +35,7 @@ import {
   updateUserFormData,
 } from './contributionsLandingActions';
 import { type State } from './contributionsLandingReducer';
+import type { PaymentMethod } from 'helpers/paymentMethods';
 
 // ----- Functions ----- //
 

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLandingReducer.js
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLandingReducer.js
@@ -4,7 +4,7 @@
 
 import { type ErrorReason } from 'helpers/errorReasons';
 import { combineReducers } from 'redux';
-import { type ContributionType, type PaymentMethod, type ThirdPartyPaymentLibraries } from 'helpers/contributions';
+import { type ContributionType, type ThirdPartyPaymentLibraries } from 'helpers/contributions';
 import csrf from 'helpers/csrf/csrfReducer';
 import { type CommonState } from 'helpers/page/commonReducer';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
@@ -22,6 +22,7 @@ import { type UserTypeFromIdentityResponse } from 'helpers/identityApis';
 import { type Action } from './contributionsLandingActions';
 import { type State as MarketingConsentState } from '../../components/marketingConsent/marketingConsentReducer';
 import { marketingConsentReducerFor } from '../../components/marketingConsent/marketingConsentReducer';
+import type { PaymentMethod } from 'helpers/paymentMethods';
 
 // ----- Types ----- //
 

--- a/support-frontend/assets/pages/paper-subscription-checkout/components-checkout/checkoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components-checkout/checkoutForm.jsx
@@ -46,6 +46,7 @@ import {
   type State,
 } from '../paperSubscriptionCheckoutReducer';
 import { withStore } from './addressFields';
+import { DirectDebit, Stripe } from 'helpers/paymentMethods';
 // ----- Types ----- //
 
 type PropTypes = {|
@@ -218,14 +219,14 @@ function CheckoutForm(props: PropTypes) {
                   <RadioInput
                     text="Direct debit"
                     name="paymentMethod"
-                    checked={props.paymentMethod === 'DirectDebit'}
-                    onChange={() => props.setPaymentMethod('DirectDebit')}
+                    checked={props.paymentMethod === DirectDebit}
+                    onChange={() => props.setPaymentMethod(DirectDebit)}
                   />
                   <RadioInput
                     text="Credit/Debit card"
                     name="paymentMethod"
-                    checked={props.paymentMethod === 'Stripe'}
-                    onChange={() => props.setPaymentMethod('Stripe')}
+                    checked={props.paymentMethod === Stripe}
+                    onChange={() => props.setPaymentMethod(Stripe)}
                   />
                 </Fieldset>
                 {errorState}

--- a/support-frontend/assets/pages/paper-subscription-checkout/helpers/paymentProviders.js
+++ b/support-frontend/assets/pages/paper-subscription-checkout/helpers/paymentProviders.js
@@ -30,6 +30,7 @@ import {
   type Action,
   setStage,
 } from '../paperSubscriptionCheckoutReducer';
+import { DirectDebit, Stripe } from 'helpers/paymentMethods';
 
 const getAddressFieldsState = (from: FormFields) => ({
   lineOne: from.lineOne,
@@ -140,10 +141,10 @@ function showPaymentMethod(
   const { paymentMethod } = state.page.checkout;
 
   switch (paymentMethod) {
-    case 'Stripe':
+    case Stripe:
       showStripe(dispatch, state);
       break;
-    case 'DirectDebit':
+    case DirectDebit:
       dispatch(openDirectDebitPopUp());
       break;
     case null:

--- a/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckoutReducer.js
+++ b/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckoutReducer.js
@@ -41,6 +41,7 @@ import {
   type FormField as AddressFormField,
 } from './components-checkout/addressFieldsStore';
 import type { PaymentMethod } from 'helpers/paymentMethods';
+import { DirectDebit, Stripe } from 'helpers/paymentMethods';
 
 // ----- Types ----- //
 
@@ -235,7 +236,7 @@ function initReducer(initialCountry: IsoCountry, productInUrl: ?string, fulfillm
     lastName: user.lastName || '',
     startDate: null,
     telephone: null,
-    paymentMethod: countrySupportsDirectDebit(initialCountry) ? 'DirectDebit' : 'Stripe',
+    paymentMethod: countrySupportsDirectDebit(initialCountry) ? DirectDebit : Stripe,
     formErrors: [],
     submissionError: null,
     formSubmitted: false,

--- a/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckoutReducer.js
+++ b/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckoutReducer.js
@@ -40,11 +40,11 @@ import {
   type State as AddressState,
   type FormField as AddressFormField,
 } from './components-checkout/addressFieldsStore';
+import type { PaymentMethod } from 'helpers/paymentMethods';
 
 // ----- Types ----- //
 
 export type Stage = 'checkout' | 'thankyou' | 'thankyou-pending';
-type PaymentMethod = 'Stripe' | 'DirectDebit';
 
 type Product = {|
   fulfilmentOption: PaperFulfilmentOptions,


### PR DESCRIPTION
## Why are you doing this?
We currently have 3 almost identical `PaymentMethod` types, one in contributions, one for digital subscriptions and one for paper subscriptions. This PR extracts one type from those and uses it everywhere. I've also introduced constants for the payment methods themselves and used those throughout the codebase.