### PR TITLE
S&C typography audit after font updates 

### DIFF
--- a/support-frontend/assets/components/ctaLink/ctaLink.scss
+++ b/support-frontend/assets/components/ctaLink/ctaLink.scss
@@ -14,6 +14,7 @@
   padding: 0 $gu-h-spacing;
   position: relative;
   text-decoration: none;
+  font-weight: 700;
 
   &:hover {
     background-color: darken(gu-colour(neutral-7), 5%);

--- a/support-frontend/assets/components/threeSubscriptions/threeSubscriptions.scss
+++ b/support-frontend/assets/components/threeSubscriptions/threeSubscriptions.scss
@@ -108,7 +108,7 @@
   .component-double-heading__subheading {
     font-size: 30px;
     line-height: 1;
-    font-weight: 400;
+    font-weight: 300;
     font-family: $gu-headline;
 
     @include mq($from: phablet, $until: leftCol) {

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -183,12 +183,10 @@
   .product-block__product-description {
     margin: $gu-v-spacing / 2 0 $gu-v-spacing;
     line-height: 1.25;
-    font-family: $gu-headline;
   }
 
   .component-feature-list {
     line-height: 1.25;
-    font-family: $gu-headline;
     list-style-image: svg-url('<svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 10 10"><circle cx="5" cy="5" r="5" fill="#ff4e36"/></svg>');
     margin-left: 26px;
 
@@ -201,9 +199,11 @@
   }
 
   .component-feature-list__heading {
+    font-family: $gu-headline;
     font-weight: bold;
     display: inline;
     vertical-align: top;
+    line-height: 1;
   }
 
   .component-feature-list__item {

--- a/support-frontend/assets/pages/showcase/showcase.scss
+++ b/support-frontend/assets/pages/showcase/showcase.scss
@@ -186,7 +186,9 @@
         }
 
         .product-title {
-          font-size: 20px;
+          font-family: $gu-headline;
+          font-weight: 700;
+          font-size: 1.5rem;
           margin-bottom: $gu-v-spacing;
         }
 

--- a/support-frontend/assets/pages/showcase/showcase.scss
+++ b/support-frontend/assets/pages/showcase/showcase.scss
@@ -188,7 +188,7 @@
         .product-title {
           font-family: $gu-headline;
           font-weight: 700;
-          font-size: 1.5rem;
+          font-size: 1.25rem;
           margin-bottom: $gu-v-spacing;
         }
 


### PR DESCRIPTION
## Why are you doing this?

We are now using the same fonts as `.com`.  This had resulted in some instances of type missing correct styling on our pages. 

## Changes

* Include font-family: "Guardian Text Egyptian Web", Georgia, serif; and correct weights where needed
* Remove references to 'font weight 400' and revert to 300 

## Screenshots

Look at "Masterclasses & Live Events" as an example. 

**Before**
![Screen Shot 2019-03-13 at 14 36 25](https://user-images.githubusercontent.com/1108991/54287366-6c42a600-459d-11e9-9e61-5c7f0096b7d9.png)

**After**
![Screen Shot 2019-03-13 at 14 36 04](https://user-images.githubusercontent.com/1108991/54287382-72d11d80-459d-11e9-802b-64b2342dc5b8.png)


