### PR TITLE
A couple client side error handling tweaks. 

### DIFF
--- a/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
+++ b/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
@@ -157,8 +157,10 @@ function checkRegularStatus(
         trackConversion(participations, routes.recurringContribPending);
         return PaymentSuccess;
 
-      default:
-        return { paymentStatus: 'failure', error: json.failureReason };
+      default: {
+        const failureReason = json.failureReason ? json.failureReason : 'unknown';
+        return { paymentStatus: 'failure', error: failureReason };
+      }
     }
   };
 

--- a/support-frontend/assets/pages/paper-subscription-checkout/components-checkout/checkoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components-checkout/checkoutForm.jsx
@@ -188,7 +188,6 @@ function CheckoutForm(props: PropTypes) {
                     onChange={() => props.setbillingAddressIsSame(false)}
                   />
                 </Fieldset>
-                {errorState}
               </Rows>
             </FormSection>
             {


### PR DESCRIPTION
## Why are you doing this?

The print checkout makes use of existing client side error handing, but I went through to see that it worked as expected 

|  Scenario |  Expected behaviour | Screenshot  | Code change required? |
|---|---|---|---|
| On `POST /subscribe/create`, the server side validation fails  | Tell the user to check their personal details  | <img src="https://user-images.githubusercontent.com/3072877/54301064-1fb79480-45b6-11e9-8ec7-e0c2b60a3475.png" width=300>  | no |
| `POST /subscribe/create`, returns an internal server error  | Tell the user the default error message  |  <img src="https://user-images.githubusercontent.com/3072877/54301184-5ee5e580-45b6-11e9-8e16-9bc1c6e98afd.png" width=300> | no |
| `GET  /support-workers/status` is returning internal server error  | Keep polling and up on the thankyou-pending page  | n/a  | no | 
| `GET  /support-workers/status` is OK with `status = failure` and a failure status | Show user an error relevant to the failure status  | <img src="https://user-images.githubusercontent.com/3072877/54301487-f5b2a200-45b6-11e9-9e7d-13d128f57266.png" width=300> | no |
| `GET  /support-workers/status` is OK with `status = failure` and failure reason is null | Tell the user the default error message  | <img src="https://user-images.githubusercontent.com/3072877/54301590-2e527b80-45b7-11e9-8ad5-c53ef0479e58.png" width=300> | yes |

As you can see, the client side error handling that is already in place covers our bases with one minor exception. I just noticed that if the polling endpoint `GET  /support-workers/status` returns a failure status but has no failure reason then we can't create an error to show the user and we put them back on the checkout form without any feedback like so:
<img src="https://user-images.githubusercontent.com/3072877/54301844-a3be4c00-45b7-11e9-9b46-a72d0bc899cd.png" width=400>

This PR also removes error reason from the `Is the billing address the same as the delivery address?` section since we have it further down the form. 
![image](https://user-images.githubusercontent.com/3072877/54302162-3fe85300-45b8-11e9-8ef8-069a7191577a.png)

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/9qGNJFwU/2259-client-side-error-handling-for-failed-attempts-to-create-a-hd-voucher-subscription)

## Changes

* If a call to `GET  /support-workers/status` is OK with `status = failure` and failure reason is null, default the failure reason to unknown 
* remove the error state from the `Is the billing address the same as the delivery address?` section

## Screenshots
are above