### PR TITLE
Make featured product hero always Guardian Weekly.

### DIFF
--- a/support-frontend/assets/pages/subscriptions-landing/components/featuredProducts.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/components/featuredProducts.jsx
@@ -160,6 +160,7 @@ const getProducts = (
 
 const getProduct = (subsLinks: SubsUrls, countryGroupId: CountryGroupId): ?Product => {
   const products = getProducts(subsLinks, countryGroupId);
+  const promoteGuardianWeekly = true;
   switch (getQueryParameter('ab_product')) {
     case 'DigitalPack':
       return products.DigitalPack;
@@ -168,21 +169,20 @@ const getProduct = (subsLinks: SubsUrls, countryGroupId: CountryGroupId): ?Produ
     case 'GuardianWeekly':
       return products.GuardianWeekly;
     default:
-      const promoteGuardianWeekly = true;
-      if(promoteGuardianWeekly) {
-        return products.GuardianWeekly
-      } else {
-        if (countryGroupId === GBPCountries && flashSaleIsActive('DigitalPack', GBPCountries)) {
-          return products.DigitalPack;
-        }
-        if (countryGroupId === GBPCountries) {
-          return products.Paper;
-        }
-        if (countryGroupId !== GBPCountries && flashSaleIsActive('DigitalPack', countryGroupId)) {
-          return products.DigitalPack;
-        }
+      if (promoteGuardianWeekly) {
         return products.GuardianWeekly;
       }
+      if (countryGroupId === GBPCountries && flashSaleIsActive('DigitalPack', GBPCountries)) {
+        return products.DigitalPack;
+      }
+      if (countryGroupId === GBPCountries) {
+        return products.Paper;
+      }
+      if (countryGroupId !== GBPCountries && flashSaleIsActive('DigitalPack', countryGroupId)) {
+        return products.DigitalPack;
+      }
+      return products.GuardianWeekly;
+
   }
 };
 

--- a/support-frontend/assets/pages/subscriptions-landing/components/featuredProducts.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/components/featuredProducts.jsx
@@ -168,16 +168,21 @@ const getProduct = (subsLinks: SubsUrls, countryGroupId: CountryGroupId): ?Produ
     case 'GuardianWeekly':
       return products.GuardianWeekly;
     default:
-      if (countryGroupId === GBPCountries && flashSaleIsActive('DigitalPack', GBPCountries)) {
-        return products.DigitalPack;
+      const promoteGuardianWeekly = true;
+      if(promoteGuardianWeekly) {
+        return products.GuardianWeekly
+      } else {
+        if (countryGroupId === GBPCountries && flashSaleIsActive('DigitalPack', GBPCountries)) {
+          return products.DigitalPack;
+        }
+        if (countryGroupId === GBPCountries) {
+          return products.Paper;
+        }
+        if (countryGroupId !== GBPCountries && flashSaleIsActive('DigitalPack', countryGroupId)) {
+          return products.DigitalPack;
+        }
+        return products.GuardianWeekly;
       }
-      if (countryGroupId === GBPCountries) {
-        return products.Paper;
-      }
-      if (countryGroupId !== GBPCountries && flashSaleIsActive('DigitalPack', countryGroupId)) {
-        return products.DigitalPack;
-      }
-      return products.GuardianWeekly;
   }
 };
 

--- a/support-frontend/assets/pages/subscriptions-landing/components/featuredProducts.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/components/featuredProducts.jsx
@@ -160,7 +160,6 @@ const getProducts = (
 
 const getProduct = (subsLinks: SubsUrls, countryGroupId: CountryGroupId): ?Product => {
   const products = getProducts(subsLinks, countryGroupId);
-  const promoteGuardianWeekly = true;
   switch (getQueryParameter('ab_product')) {
     case 'DigitalPack':
       return products.DigitalPack;
@@ -169,14 +168,8 @@ const getProduct = (subsLinks: SubsUrls, countryGroupId: CountryGroupId): ?Produ
     case 'GuardianWeekly':
       return products.GuardianWeekly;
     default:
-      if (promoteGuardianWeekly) {
-        return products.GuardianWeekly;
-      }
       if (flashSaleIsActive('DigitalPack', countryGroupId)) {
         return products.DigitalPack;
-      }
-      if (countryGroupId === GBPCountries) {
-        return products.Paper;
       }
       return products.GuardianWeekly;
   }

--- a/support-frontend/assets/pages/subscriptions-landing/components/featuredProducts.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/components/featuredProducts.jsx
@@ -172,17 +172,13 @@ const getProduct = (subsLinks: SubsUrls, countryGroupId: CountryGroupId): ?Produ
       if (promoteGuardianWeekly) {
         return products.GuardianWeekly;
       }
-      if (countryGroupId === GBPCountries && flashSaleIsActive('DigitalPack', GBPCountries)) {
+      if (flashSaleIsActive('DigitalPack', countryGroupId)) {
         return products.DigitalPack;
       }
       if (countryGroupId === GBPCountries) {
         return products.Paper;
       }
-      if (countryGroupId !== GBPCountries && flashSaleIsActive('DigitalPack', countryGroupId)) {
-        return products.DigitalPack;
-      }
       return products.GuardianWeekly;
-
   }
 };
 


### PR DESCRIPTION
## Why are you doing this?
As we near the end of the quarter, we would prefer to stop promoting Digital Pack

💰 

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/o2YsnqAl/2283-subs-page-march-april-updates-1st-15th-march-31st-march)

## Changes

* Get the featured product hero to always feature Guardian Weekly, unless there is a digital pack flash sale on 

## Screenshots
for  /<uk|us|au|eu|int|nz|ca>/subscribe 

![image](https://user-images.githubusercontent.com/3072877/54349353-fe50ba00-4642-11e9-8ece-ae00a7b138fe.png)
