### PR TITLE
Tweak for the layout of the countdown timer on smaller breakpoints

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -410,7 +410,11 @@
 
   .component-flash-sale-countdown-hero {
     position: relative;
-    margin-left: 450px;
+    margin-bottom: 50px;
+    @include mq($from: tablet) {
+      margin-bottom: 0px;
+      margin-left: 450px;
+    }
   }
 }
 


### PR DESCRIPTION
## Why are you doing this?
#1660 Added the countdown timer to the Digital Pack landing page, but @jesseyuen noticed that it didn't look right at smaller breakpoints, this PR fixes that.
**Before:**
![Screen Shot 2019-03-14 at 11 06 25](https://user-images.githubusercontent.com/181371/54352312-4d015280-4649-11e9-92b7-2ee45544107e.png)
**After:**
![Screen Shot 2019-03-14 at 11 03 49](https://user-images.githubusercontent.com/181371/54352265-26431c00-4649-11e9-908e-9b013f956e95.png)

