### PR TITLE
Add workaround for incomplete Zuora response

### DIFF
--- a/support-workers/src/main/scala/com/gu/emailservices/SubscriptionEmailFieldHelpers.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/SubscriptionEmailFieldHelpers.scala
@@ -25,7 +25,10 @@ object SubscriptionEmailFieldHelpers {
   def describe(paymentSchedule: PaymentSchedule, billingPeriod: BillingPeriod, currency: Currency): String = {
     val initialPrice = firstPayment(paymentSchedule).amount
     val (paymentsWithInitialPrice, paymentsWithDifferentPrice) = paymentSchedule.payments.partition(_.amount == initialPrice)
-    if (paymentsWithDifferentPrice.isEmpty) {
+    if (paymentSchedule.payments.size == 1) {
+      s"${priceWithCurrency(currency, initialPrice)} for the first ${billingPeriod.noun}"
+    }
+    else if (paymentsWithDifferentPrice.isEmpty) {
       s"${priceWithCurrency(currency, initialPrice)} every ${billingPeriod.noun}"
     } else {
       val introductoryTimespan = {

--- a/support-workers/src/test/scala/com/gu/emailservices/SubscriptionEmailFieldHelpersSpec.scala
+++ b/support-workers/src/test/scala/com/gu/emailservices/SubscriptionEmailFieldHelpersSpec.scala
@@ -37,11 +37,10 @@ class SubscriptionEmailFieldHelpersSpec extends FlatSpec with Matchers {
     assert(SubscriptionEmailFieldHelpers.describe(PaymentSchedule(schedule), Monthly, EUR) == expected)
   }
 
-  "describe" should "explain a payment schedule correctly if the first year is discounted" in {
+  "describe" should "explain a payment schedule truthfully if we only get information about the first payment" in {
     val discountedDigitalPackPayment = Payment(referenceDate, 100.90)
-    val standardDigitalPackPayment = Payment(referenceDate.plusYears(1), 119.90)
-    val schedule = PaymentSchedule(List(discountedDigitalPackPayment, standardDigitalPackPayment))
-    val expected = "£100.90 for 1 year, then £119.90 every year"
+    val schedule = PaymentSchedule(List(discountedDigitalPackPayment))
+    val expected = "£100.90 for the first year"
     assert(SubscriptionEmailFieldHelpers.describe(schedule, Annual, GBP) == expected)
   }
 


### PR DESCRIPTION
## Why are you doing this?

@twrichards noticed that the email copy for a user who pays annually & has a 12-month discount is misleading e.g.

![image](https://user-images.githubusercontent.com/19384074/54378910-40e4b780-4680-11e9-9722-d28bd2e36ca4.png)

I think this is due to a problem with Zuora, but until I've had chance to prove/disprove this, I've put some temporary copy in place (it's not great but better than the current misleading copy IMO).