### PR TITLE
Pass the correct amounts to PayPal for recurring contributions

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -41,7 +41,7 @@ import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import { type Action, type FormActionCreators, formActionCreators } from 'pages/digital-subscription-checkout/digitalSubscriptionCheckoutActions';
 import type { Csrf } from 'helpers/csrf/csrfReducer';
 import type { BillingPeriod } from 'helpers/billingPeriods';
-import { setupRecurringPayPalPayment } from 'helpers/paymentIntegrations/payPalRecurringCheckout';
+import { setupSubscriptionPayPalPayment } from 'helpers/paymentIntegrations/payPalRecurringCheckout';
 import { SubscriptionSubmitButtons } from 'components/subscriptionCheckouts/subscriptionSubmitButtons';
 import { PaymentMethodSelector } from 'components/subscriptionCheckouts/paymentMethodSelector';
 import type { OptimizeExperiments } from 'helpers/optimize/optimize';
@@ -109,7 +109,7 @@ function mapDispatchToProps() {
     formIsValid: () => (dispatch: Dispatch<Action>, getState: () => State) => formIsValid(getState()),
     submitForm: () => (dispatch: Dispatch<Action>, getState: () => State) => submitForm(dispatch, getState()),
     validateForm: () => (dispatch: Dispatch<Action>, getState: () => State) => validateForm(dispatch, getState()),
-    setupRecurringPayPalPayment,
+    setupRecurringPayPalPayment: setupSubscriptionPayPalPayment,
     signOut,
   };
 }

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
@@ -140,7 +140,7 @@ const localisedAverageAmountSentence: {
   },
   International: {
     amountSentence: 'The',
-    averageAnnualAmount:  61.78,
+    averageAnnualAmount: 61.78,
   },
 };
 

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionSubmit.jsx
@@ -12,7 +12,7 @@ import { type PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRev
 import type { SelectedAmounts } from 'helpers/contributions';
 import { getContributeButtonCopyWithPaymentType } from 'helpers/checkouts';
 import { hiddenIf } from 'helpers/utilities';
-import { setupRecurringPayPalPayment, type SetupPayPalRequestType } from 'helpers/paymentIntegrations/payPalRecurringCheckout';
+import { setupRecurringPayPalPayment } from 'helpers/paymentIntegrations/payPalRecurringCheckout';
 import type { BillingPeriod } from 'helpers/billingPeriods';
 import { PayPalExpressButton } from 'components/paypalExpressButton/PayPalExpressButton';
 import { type State } from '../contributionsLandingReducer';
@@ -33,7 +33,7 @@ type PropTypes = {|
   currencyId: IsoCurrency,
   csrf: CsrfState,
   sendFormSubmitEventForPayPalRecurring: () => void,
-  setupRecurringPayPalPayment: SetupPayPalRequestType,
+  setupRecurringPayPalPayment: Function,
   payPalHasLoaded: boolean,
   isTestUser: boolean,
   onPaymentAuthorisation: PaymentAuthorisation => void,
@@ -72,10 +72,8 @@ const mapDispatchToProps = (dispatch: Function) => ({
     reject: Function,
     currencyId: IsoCurrency,
     csrf: CsrfState,
-    amount: number,
-    billingPeriod: BillingPeriod,
   ) => {
-    dispatch(setupRecurringPayPalPayment(resolve, reject, currencyId, csrf, amount, billingPeriod));
+    dispatch(setupRecurringPayPalPayment(resolve, reject, currencyId, csrf));
   },
 });
 


### PR DESCRIPTION
## Why are you doing this?

#1596 introduced a bug whereby PayPal would always be passed the contribution amount which was set on page load, not the amount which the user selected subsequently. 

This PR fixes that by reintroducing the original version of the function which was used to call PayPal, this is not the ideal solution but it is the quickest way to fix the bug, we can tidy up afterwards.
