### PR TITLE
Third party tracking consent

### DIFF
--- a/support-frontend/assets/helpers/tracking/__tests__/thirdPartyTrackingConsentTest.js
+++ b/support-frontend/assets/helpers/tracking/__tests__/thirdPartyTrackingConsentTest.js
@@ -1,0 +1,34 @@
+// @flow
+
+// ----- Imports ----- //
+
+import {
+  ConsentCookieName,
+  getTrackingConsent, OptedIn, OptedOut, Unset,
+} from '../thirdPartyTrackingConsent';
+
+// ----- Tests ----- //
+
+jest.mock('ophan', () => ({ viewId: '123456' }));
+
+describe('thirdPartyTrackingConsent', () => {
+  it('should return the correct ThirdPartyTrackingConsent', () => {
+
+    // When no cookie is present the value should be 'Unset'
+    expect(getTrackingConsent()).toEqual(Unset);
+
+    // When the cookie is present with a value starting with 1 the
+    // user has opted in
+    Object.defineProperty(window.document, 'cookie', {
+      writable: true,
+      value: `${ConsentCookieName}=1.1234567`,
+    });
+    expect(getTrackingConsent()).toEqual(OptedIn);
+
+
+    // When the cookie is present with a value starting with 0 the
+    // user has opted out
+    window.document.cookie = `${ConsentCookieName}=0.1234567`;
+    expect(getTrackingConsent()).toEqual(OptedOut);
+  });
+});

--- a/support-frontend/assets/helpers/tracking/googleTagManager.js
+++ b/support-frontend/assets/helpers/tracking/googleTagManager.js
@@ -7,6 +7,7 @@ import { detect as detectCurrency } from 'helpers/internationalisation/currency'
 import { getQueryParameter } from 'helpers/url';
 import { detect as detectCountryGroup } from 'helpers/internationalisation/countryGroup';
 import type { Participations } from 'helpers/abTests/abtest';
+import { getTrackingConsent } from './thirdPartyTrackingConsent';
 
 
 // ----- Types ----- //
@@ -143,6 +144,7 @@ function sendData(
       internalCampaignCode: getQueryParameter('INTCMP') || undefined,
       experience: getVariantsAsString(participations),
       paymentRequestApiStatus,
+      thirdPartyTrackingConsent: getTrackingConsent(),
       ecommerce: {
         currencyCode: currency,
         purchase: {

--- a/support-frontend/assets/helpers/tracking/thirdPartyTrackingConsent.js
+++ b/support-frontend/assets/helpers/tracking/thirdPartyTrackingConsent.js
@@ -1,0 +1,21 @@
+// @flow
+
+import { get as getCookie } from '../cookie';
+
+const ConsentCookieName = 'GU_TK';
+const OptedIn: 'OptedIn' = 'OptedIn';
+const OptedOut: 'OptedOut' = 'OptedOut';
+const Unset: 'Unset' = 'Unset';
+
+export type ThirdPartyTrackingConsent = typeof OptedIn
+  | typeof OptedOut
+  | typeof Unset;
+
+const getTrackingConsent = (): ThirdPartyTrackingConsent => {
+  const cookieVal: ?string = getCookie(ConsentCookieName);
+  if (cookieVal && cookieVal.split('.')[0] === '1') { return OptedIn; }
+  if (cookieVal && cookieVal.split('.')[0] === '0') { return OptedOut; }
+  return Unset;
+};
+
+export { getTrackingConsent, OptedIn, OptedOut, Unset, ConsentCookieName };


### PR DESCRIPTION
## Why are you doing this?
We want to respect any preference our users have set with regard to third party tracking. 

This PR adds code to read and process the cookie where this information is stored and send the preference to Google Tag Manager where we can use it to determine whether to fire tags or not.

[**Trello Card**](https://trello.com/c/Q6fM1gvZ/1-supporttheguardiancom)
