### PR TITLE
Display paper specific contact emails in the paper footer.

### DIFF
--- a/support-frontend/assets/components/customerService/customerService.jsx
+++ b/support-frontend/assets/components/customerService/customerService.jsx
@@ -4,39 +4,68 @@
 
 import React from 'react';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { type Option } from 'helpers/types/option';
+import { type SubscriptionProduct } from 'helpers/subscriptions';
+import { type PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import { AUDCountries, GBPCountries, UnitedStates } from 'helpers/internationalisation/countryGroup';
-
 import './customerService.scss';
 
 // ----- Props ----- //
 
 type PropTypes = {|
   selectedCountryGroup: CountryGroupId,
+  subscriptionProduct: SubscriptionProduct,
+  paperFulfilmentOptions: Option<PaperFulfilmentOptions>,
 |};
 
 // ----- Functions ----- //
 
-function DigitalPackEmail(props: { email: string }) {
+function Email(props: { email: string }) {
   return (
-    <a className="component-customer-service__digital-pack-email" href={`mailto:${props.email}`}>
+    <a className="component-customer-service__email" href={`mailto:${props.email}`}>
       {props.email}
     </a>
   );
 }
 
-DigitalPackEmail.defaultProps = {
+function productAndCountrySpecificEmail(
+  selectedCountryGroup: CountryGroupId,
+  subscriptionProduct: SubscriptionProduct,
+  paperFulfilmentOptions: Option<PaperFulfilmentOptions>,
+) {
+  if (subscriptionProduct === 'Paper') {
+    if (paperFulfilmentOptions === 'Collection') {
+      return 'vouchersubs@theguardian.com';
+    }
+    return 'homedelivery@theguardian.com';
+
+  }
+
+  if (selectedCountryGroup === 'AUDCountries') {
+    return 'apac.help@theguardian.com';
+  }
+
+  return 'digitalpack@theguardian.com';
+}
+
+Email.defaultProps = {
   email: 'digitalpack@theguardian.com',
 };
 
 // ----- Component ----- //
 
 function CustomerService(props: PropTypes) {
+  const email = productAndCountrySpecificEmail(
+    props.selectedCountryGroup,
+    props.subscriptionProduct,
+    props.paperFulfilmentOptions,
+  );
   switch (props.selectedCountryGroup) {
     case UnitedStates:
       return (
         <div className="component-customer-service">
           <div className="component-customer-service__text">
-            For help with Guardian and Observer subscription services please email <DigitalPackEmail /> or
+            For help with Guardian and Observer subscription services please email <Email email={email} /> or
             call 1-844-632-2010 (toll free); 917-900-4663 (direct line).
             Lines are open 9:15am-6pm, Monday to Friday (EST/EDT).
           </div>
@@ -46,7 +75,7 @@ function CustomerService(props: PropTypes) {
       return (
         <div className="component-customer-service">
           <div className="component-customer-service__text">
-            For help with Guardian and Observer subscription services please email <DigitalPackEmail /> or
+            For help with Guardian and Observer subscription services please email <Email email={email} /> or
             call 0330 333 6767 (within UK). Lines are open 8am-8pm on weekdays, 8am-6pm at weekends (GMT/BST).
           </div>
         </div>
@@ -56,7 +85,7 @@ function CustomerService(props: PropTypes) {
         <div className="component-customer-service">
           <div className="component-customer-service__text">
             For help with Guardian and Observer subscription services please
-            email <DigitalPackEmail email="apac.help@theguardian.com" /> or
+            email <Email email={email} /> or
             call 1800 773 766 (within Australia) or +61 2 8076 8599 (outside Australia).
             Lines are open 9am-5pm Monday-Friday (AEDT).
           </div>
@@ -66,7 +95,7 @@ function CustomerService(props: PropTypes) {
       return (
         <div className="component-customer-service">
           <div className="component-customer-service__text">
-            For help with Guardian and Observer subscription services please email <DigitalPackEmail /> or
+            For help with Guardian and Observer subscription services please email <Email email={email} /> or
             call +44 (0) 330 333 6767. Lines are open 8am-8pm on weekdays, 8am-6pm at weekends (GMT/BST).
           </div>
         </div>
@@ -74,6 +103,11 @@ function CustomerService(props: PropTypes) {
   }
 }
 
+CustomerService.defaultProps = {
+  selectedCountryGroup: 'GBPCountries',
+  subscriptionProduct: 'DigitalPack',
+  paperFulfilmentOptions: null,
+};
 
 // ----- Exports ----- //
 

--- a/support-frontend/assets/components/customerService/customerService.scss
+++ b/support-frontend/assets/components/customerService/customerService.scss
@@ -7,7 +7,7 @@
   padding: 3px 0;
 }
 
-.component-customer-service__digital-pack-email {
+.component-customer-service__email {
   color: gu-colour(neutral-86);
   text-decoration: none;
 }
@@ -17,7 +17,7 @@
   text-decoration: none;
 }
 
-.component-customer-service__digital-pack-email:hover {
+.component-customer-service__email:hover {
   text-decoration: underline;
 }
 

--- a/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.jsx
@@ -35,7 +35,11 @@ const content = (
       footer={
         <Footer>
           <SubscriptionTermsPrivacy subscriptionProduct="DigitalPack" />
-          <CustomerService selectedCountryGroup={countryGroupId} />
+          <CustomerService
+            selectedCountryGroup={countryGroupId}
+            subscriptionProduct="DigitalPack"
+            paperFulfilmentOptions={null}
+          />
           <SubscriptionFaq subscriptionProduct="DigitalPack" />
         </Footer>}
     >

--- a/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckout.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckout.jsx
@@ -19,6 +19,7 @@ import 'stylesheets/skeleton/skeleton.scss';
 
 import { initReducer } from './paperSubscriptionCheckoutReducer';
 import CheckoutStage from './stage';
+import { type PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import './_legacyImports.scss';
 
 
@@ -34,6 +35,8 @@ const store = pageInit(
 
 const { countryGroupId } = store.getState().common.internationalisation;
 
+const paperFulfilmentOption: PaperFulfilmentOptions = fulfilmentOption === 'HomeDelivery' ? 'HomeDelivery' : 'Collection';
+
 // ----- Render ----- //
 
 const content = (
@@ -43,7 +46,11 @@ const content = (
       footer={
         <Footer>
           <SubscriptionTermsPrivacy subscriptionProduct="Paper" />
-          <CustomerService selectedCountryGroup={countryGroupId} />
+          <CustomerService
+            selectedCountryGroup={countryGroupId}
+            subscriptionProduct="Paper"
+            paperFulfilmentOptions={paperFulfilmentOption}
+          />
           <SubscriptionFaq subscriptionProduct="Paper" />
         </Footer>
       }


### PR DESCRIPTION
## Why are you doing this?
I noticed that in the footer of the paper checkout, that we are directing users to contact digitalpack@theguardian.com 

The checkout on subscribe.theguardian directs users who have selected vouchers to vouchersubs@theguardian.com and those who have selected home delivery to homedelivery@theguardian.com so this changes aims to do the same. 

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/QronTsE0/2306-footer-should-have-correct-contact-email)

## Changes

* The footer now directs users to appropriate contact emails in the paper checkout 

## Screenshots

![image](https://user-images.githubusercontent.com/3072877/54445082-faed2980-473b-11e9-8a57-832c7c289569.png)
![image](https://user-images.githubusercontent.com/3072877/54445357-81097000-473c-11e9-8b6f-5499e1ee7ce7.png)
