### PR TITLE
fontLoader from node package to local library (using flow)

### DIFF
--- a/support-frontend/assets/helpers/fontLoader.js
+++ b/support-frontend/assets/helpers/fontLoader.js
@@ -3,8 +3,8 @@
 const fetchFonts = (window: Object, document: Document): void => {
   const head: null | HTMLHeadElement = document.querySelector('head');
 
-  const useFont = (font: Object): void => {
-    if (head && font.css) {
+  const useFont = (font: { css: string }): void => {
+    if (head) {
       const style: HTMLStyleElement = document.createElement('style');
       style.innerHTML = font.css;
       head.appendChild(style);

--- a/support-frontend/assets/helpers/fontLoader.js
+++ b/support-frontend/assets/helpers/fontLoader.js
@@ -1,0 +1,47 @@
+// @flow
+
+const fetchFonts = (window: Object, document: Document): void => {
+  const head: null | HTMLHeadElement = document.querySelector('head');
+
+  const useFont = (font: Object): void => {
+    if (head && font.css) {
+      const style: HTMLStyleElement = document.createElement('style');
+      style.innerHTML = font.css;
+      head.appendChild(style);
+    }
+  };
+
+  const loadFonts = (): void => {
+    const iframe = document.createElement('iframe');
+    iframe.src = 'https://theguardian.com/font-loader';
+    // add iframe and wait for message
+    iframe.style.display = 'none';
+    window.addEventListener('message', (e: MessageEvent) => {
+      if (
+        e &&
+        e.data &&
+        e.data.name &&
+        e.data.name === 'guardianFonts' &&
+        e.data.fonts &&
+        e.source === iframe.contentWindow
+      ) {
+        if (Array.isArray(e.data.fonts)) {
+          e.data.fonts.forEach(useFont);
+        }
+      }
+    });
+    if (document.body) {
+      document.body.appendChild(iframe);
+    }
+  };
+
+  if (document.readyState === 'loading') {
+    // Loading hasn't finished yet
+    document.addEventListener('DOMContentLoaded', loadFonts);
+  } else {
+    // DOMContentLoaded has already fired
+    loadFonts();
+  }
+};
+
+export default fetchFonts;

--- a/support-frontend/assets/helpers/fontLoader.js
+++ b/support-frontend/assets/helpers/fontLoader.js
@@ -26,7 +26,11 @@ const fetchFonts = (window: Object, document: Document): void => {
         e.source === iframe.contentWindow
       ) {
         if (Array.isArray(e.data.fonts)) {
-          e.data.fonts.forEach(useFont);
+          e.data.fonts.forEach((font) => {
+            if (font instanceof Object) {
+              useFont(font);
+            }
+          });
         }
       }
     });

--- a/support-frontend/assets/helpers/page/page.js
+++ b/support-frontend/assets/helpers/page/page.js
@@ -3,7 +3,8 @@
 // ----- Imports ----- //
 
 import 'ophan';
-import loadFonts from '@guardian/font-loader';
+
+import loadFonts from 'helpers/fontLoader';
 import type { Store } from 'redux';
 import { applyMiddleware, combineReducers, compose, createStore, type Reducer } from 'redux';
 import thunkMiddleware from 'redux-thunk';

--- a/support-frontend/assets/pages/digital-subscription-checkout/__tests__/digitalSubscriptionCheckoutReducerTest.js
+++ b/support-frontend/assets/pages/digital-subscription-checkout/__tests__/digitalSubscriptionCheckoutReducerTest.js
@@ -7,7 +7,7 @@ import { setStage, setFormErrors } from '../digitalSubscriptionCheckoutActions';
 import { DirectDebit, Stripe } from 'helpers/paymentMethods';
 
 jest.mock('ophan', () => {});
-jest.mock('font-loader', () => () => ({}));
+jest.mock('helpers/fontLoader', () => () => ({}));
 // ----- Tests ----- //
 
 describe('Digital Subscription Checkout Reducer', () => {

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -88,7 +88,6 @@
     "@storybook/addon-options": "^4.1.11",
     "@storybook/addon-storysource": "^4.1.11",
     "@storybook/react": "^4.1.9",
-    "@guardian/font-loader": "^1.0.0",
     "autoprefixer": "^8.6.1",
     "babel-core": "^7.0.0-0",
     "babel-eslint": "^10.0.1",

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -45,8 +45,7 @@
       "assets"
     ],
     "moduleNameMapper": {
-      "ophan(.*)": "<rootDir>/node_modules/ophan-tracker-js/build/ophan.support",
-      "font-loader(.*)": "<rootDir>/node_modules/@guardian/font-loader/index.js"
+      "ophan(.*)": "<rootDir>/node_modules/ophan-tracker-js/build/ophan.support"
     },
     "verbose": true,
     "testEnvironment": "./jestEnvironment"


### PR DESCRIPTION
## Why are you doing this?

fontLoader (npm package) is written in ES6 without a dist version which was causing problems with IE11 (£500-£1000/day). This PR is a bandaid that puts it in our helpers directory (with edits to make it Flow compat) and ensures it gets transpiled properly and runs in IE11.

[**Trello Card**](https://trello.com/b/eDZKuUvg/making-it-easier-to-contribute)

## Changes

* New file: `helpers/fontLoader`
* New import of above in `page.js`
