### PR TITLE
Update featuredProducts.jsx

### DIFF
--- a/support-frontend/assets/pages/subscriptions-landing/components/featuredProducts.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/components/featuredProducts.jsx
@@ -129,7 +129,7 @@ const getProductHeadingsAndBody = (product: SubscriptionProduct, countryGroupId:
   return {
     headingText: 'Guardian Weekly',
     subheadingText: 'Open up your world view',
-    bodyText: 'Discover our essential new magazine with free worldwide delivery.',
+    bodyText: 'The Guardian's essential news magazine with free worldwide delivery.',
   };
   // }
 };

--- a/support-frontend/assets/pages/subscriptions-landing/components/featuredProducts.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/components/featuredProducts.jsx
@@ -129,7 +129,7 @@ const getProductHeadingsAndBody = (product: SubscriptionProduct, countryGroupId:
   return {
     headingText: 'Guardian Weekly',
     subheadingText: 'Open up your world view',
-    bodyText: 'The Guardian's essential news magazine with free worldwide delivery.',
+    bodyText: 'The Guardian&apos;s essential news magazine with free worldwide delivery.',
   };
   // }
 };


### PR DESCRIPTION
## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->Because GW isn't new anymore.

## Changes

* Update copy on subs landing page banner to: The Guardian's essential news magazine with free worldwide delivery


## Screenshots
Current:
![image](https://user-images.githubusercontent.com/45856485/54526499-df1d9980-496e-11e9-87a1-a07f01e2569d.png)

New:
![image](https://user-images.githubusercontent.com/45856485/54526491-d88f2200-496e-11e9-92e8-380c86ee4bbd.png)

