### PR TITLE
Update digital banner to make text editable

### DIFF
--- a/support-frontend/assets/helpers/theGrid.js
+++ b/support-frontend/assets/helpers/theGrid.js
@@ -65,9 +65,9 @@ export const imageCatalogue: {
   showcaseZuckEyes: '8435fc940815a0baefeb67329f62d54a80c45e81/887_556_1005_659',
   showcaseChris: 'a4bdbc721484d1ee3db785b9b469910ba6612112/299_10_4744_2846',
   showcaseBrit: 'e1134ec267edf4a3bbd18271ee271069bbbcec06/0_151_6350_3809',
-  theMomentDigiHero: '5795b5aa7e60c9a9bce411e69fe134850bc84847/0_0_486_772',
-  theMomentDigiHero2: '7779d8c0e000900c4fd31fa24e0942b11882921e/0_0_486_772',
-  theMomentDigiHero3: 'bfb170762564a39330fce685e938d69976bfe38e/0_0_486_772',
+  theMomentDigiHero: 'a57b0a878d77c8a89517e0f2be34772cd6327d4c/0_0_486_772',
+  theMomentDigiHero2: 'e3d9430189ee850a49edeed8554a11a38761cdff/0_0_486_772',
+  theMomentDigiHero3: 'f73e9336a0fb62916921c2956d12dd29a0f43d30/0_0_486_772',
   weeklyCampaignHeroImg: '3d4bf412afdf3c91faed55c9507a6d741575e3c5/0_0_1358_954',
 };
 

--- a/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
@@ -189,14 +189,18 @@ function SaleHeader(props: PropTypes) {
     >
       <div className="the-moment-hero">
         <div className="the-moment-hero__copy">
-          <h2>A better way to fund journalism. <br />
-            <span>A better way to read it.
+          <h2>A better way to fund journalism <br />
+            <span>A better way to read it
             </span>
           </h2>
         </div>
 
         <div className="the-moment-hero__graphic-outer">
           <div className="the-moment-hero__graphic-inner">
+            <div className="the-moment-hero__badge">
+              <span className="the-moment-hero__badge-lgeCopy">14 Day</span>
+              <span>Free trial</span>
+            </div>
             <div className="the-moment-hero__graphic">
               <GridImage
                 gridId="theMomentDigiHero"

--- a/support-frontend/assets/pages/digital-subscription-landing/components/theMoment.scss
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/theMoment.scss
@@ -27,7 +27,6 @@
     line-height: 1;
     max-width: gu-span(6);
     padding-left: $gu-v-spacing;
-    // display: none;
     
     h2 {
       font-family: $gu-titlepiece;
@@ -38,14 +37,6 @@
         color: #0084C6
       }
     }
-
-    // @include mq($from: mobile) {
-    //   max-width: 60%;
-    // }
-    
-    // @include mq($from: mobileMedium) {
-    //   max-width: 50%;
-    // }
 
     @include mq($until: mobileLandscape) {
       display: none;
@@ -239,10 +230,6 @@
     -webkit-font-feature-settings: "lnum";
     font-feature-settings: "lnum";
   }
-
-  // @include mq($from: mobileMedium) {
-  //   top: 2rem;
-  // }
   
   @include mq($from: mobileMedium) {
     top: 1.8rem;

--- a/support-frontend/assets/pages/digital-subscription-landing/components/theMoment.scss
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/theMoment.scss
@@ -25,9 +25,9 @@
 
 .the-moment-hero__copy {
     line-height: 1;
-    display: block;
     max-width: gu-span(6);
     padding-left: $gu-v-spacing;
+    // display: none;
     
     h2 {
       font-family: $gu-titlepiece;
@@ -39,16 +39,22 @@
       }
     }
 
-    @include mq($from: mobile) {
-      max-width: 60%;
-    }
+    // @include mq($from: mobile) {
+    //   max-width: 60%;
+    // }
     
-    @include mq($from: mobileMedium) {
-      max-width: 50%;
+    // @include mq($from: mobileMedium) {
+    //   max-width: 50%;
+    // }
+
+    @include mq($until: mobileLandscape) {
+      display: none;
     }
 
+    
     @include mq($from: mobileLandscape) {
       max-width: 50%;
+      
       h2 {
         font-size: 38px;
       }
@@ -79,6 +85,7 @@
         font-size: 56px;
       }
     }
+    
 }
 
 .the-moment-hero__graphic-outer {
@@ -199,5 +206,63 @@
   }
   .the-moment-hero__graphic-slider {
     display: none;
+  }
+}
+
+.the-moment-hero__badge {
+  position: absolute;
+  flex-direction: column;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: gu-colour(neutral-100);
+  text-align: center;
+  line-height: 1;
+  font-family: $gu-headline;
+  font-size: 1rem;
+  font-weight: 700;
+  z-index: 10;
+  width: 100%;
+  top: 1.4rem;
+  
+  span {
+    display: block;
+    line-height: 1; 
+  }
+  
+  .the-moment-hero__badge-lgeCopy {
+    font-family: $gu-titlepiece;
+    position: relative;
+    font-size: 1.6rem;
+    font-variant-numeric: lining-nums;
+    -moz-font-feature-settings: "lnum";
+    -webkit-font-feature-settings: "lnum";
+    font-feature-settings: "lnum";
+  }
+
+  // @include mq($from: mobileMedium) {
+  //   top: 2rem;
+  // }
+  
+  @include mq($from: mobileMedium) {
+    top: 1.8rem;
+    font-size: 1rem;
+
+    .the-moment-hero__badge-lgeCopy {
+      font-size: 2.2rem;
+    }
+  }
+  
+  @include mq($from: tablet) {
+    top: 2.2rem;
+    font-size: 1.2rem;
+  }
+  
+  @include mq($from: leftCol) {
+    top: 3.25rem;
+
+    .the-moment-hero__badge-lgeCopy {
+      font-size: 2.8rem;
+    }
   }
 }


### PR DESCRIPTION
## Why are you doing this?

The text in the roundel needed to be editable. This PR makes it editable and removes the legacy sale text that I had originally included in the png asset.

## Changes

* Remove text from image asset and include the text via markup instead.

## Screenshots

![Screen Shot 2019-03-18 at 12 05 08](https://user-images.githubusercontent.com/1108991/54529005-92d65780-4976-11e9-939b-cf21b8125d71.png)
