### PR TITLE
switched googletagmanager to from async to defer

### DIFF
--- a/support-frontend/app/views/main.scala.html
+++ b/support-frontend/app/views/main.scala.html
@@ -124,7 +124,7 @@
 
     @mainJsBundle.fold(linkedJs, inlineJs)
 
-    <script async type="text/javascript" src="@assets("googleTagManagerScript.js")"></script>
+    <script defer type="text/javascript" src="@assets("googleTagManagerScript.js")"></script>
     <script defer id="stripe-js" src="https://js.stripe.com/v3/"></script>
 
     <!-- build-commit-id: @app.BuildInfo.gitCommitId -->


### PR DESCRIPTION
## Why are you doing this?

`async` interrupts HTML/CSS parsing to interpret the JS as soon as it's downloaded, `defer` will still download the file asynchronously but not interpret it until the DOM, CSSOM, and previous JS have been parsed. This is not an improvement for users with slow connections (as they will have parsed the DOM/CSSOM anyway by the time this is loaded) but will fix the behavior we want for users with very fast connections (when downloads are faster than their processor)

[**Trello Card**](https://trello.com/c/Fs4QxCir/354-js-load-googletagmanagerscript-after-main-js)

## Changes

changed the word `async` to `defer` in scala template :)

## Screenshots

