### PR TITLE
Don't show the consent banner during post deploy tests

### DIFF
--- a/support-frontend/assets/components/consentBanner/consentBanner.jsx
+++ b/support-frontend/assets/components/consentBanner/consentBanner.jsx
@@ -15,6 +15,7 @@ import Tick from './tick.svg';
 import Button from 'components/button/button';
 import Text from 'components/text/text';
 import styles from 'components/consentBanner/consentBanner.module.scss';
+import { get as getCookie } from '../../helpers/cookie';
 
 export type PropTypes = {
   trackingConsent: ThirdPartyTrackingConsent,
@@ -36,7 +37,8 @@ function mapDispatchToProps(dispatch: Dispatch<Action>) {
 }
 
 function ConsentBanner(props: PropTypes) {
-  if (props.trackingConsent === Unset) {
+  const showBanner = props.trackingConsent === Unset && getCookie('_post_deploy_user') !== 'true';
+  if (showBanner) {
     return (
       <div className={styles.root}>
         <div className={styles.copy}>

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.jsx
@@ -28,7 +28,7 @@ import ContributionThankYouContainer from './components/ContributionThankYou/Con
 import { NewContributionBackground } from './components/ContributionBackground';
 import { setUserStateActions } from './setUserStateActions';
 import ConsentBanner from '../../components/consentBanner/consentBanner';
-import './contributionsLanding.scss'
+import './contributionsLanding.scss';
 
 if (!isDetailsSupported) {
   polyfillDetails();


### PR DESCRIPTION
## Why are you doing this?

The new consent banner introduced in #1677 is causing problems with the post deploy tests, this PR prevents it from showing during them.

