### PR TITLE
model a new object for 'paymentFields' (which contains 'billingAccountId' to represent existing payment method)

### DIFF
--- a/support-frontend/app/services/stepfunctions/Client.scala
+++ b/support-frontend/app/services/stepfunctions/Client.scala
@@ -37,13 +37,13 @@ class Client(client: AWSStepFunctionsAsync, arn: StateMachineArn) {
     AwsAsync(client.startExecutionAsync, new StartExecutionRequest().withStateMachineArn(arn).withInput(input))
   }
 
-  def triggerExecution[T](input: T, isTestUser: Boolean)(
+  def triggerExecution[T](input: T, isTestUser: Boolean, isExistingAccount: Boolean = false)(
     implicit
     ec: ExecutionContext,
     encoder: Encoder[T],
     stateWrapper: StateWrapper
   ): Response[StateMachineExecution] = {
-    startExecution(arn.asString, stateWrapper.wrap(input, isTestUser))
+    startExecution(arn.asString, stateWrapper.wrap(input, isTestUser, isExistingAccount))
       .map(StateMachineExecution.fromStartExecution)
   }
 

--- a/support-frontend/app/services/stepfunctions/StateWrapper.scala
+++ b/support-frontend/app/services/stepfunctions/StateWrapper.scala
@@ -21,8 +21,8 @@ class StateWrapper(encryption: EncryptionProvider, useEncryption: Boolean) {
   implicit private val wrapperEncoder = deriveEncoder[JsonWrapper]
   implicit private val wrapperDecoder = deriveDecoder[JsonWrapper]
 
-  def wrap[T](state: T, isTestUser: Boolean)(implicit encoder: Encoder[T]): String = {
-    JsonWrapper(encodeState(state), None, RequestInfo(useEncryption, isTestUser, failed = false, Nil)).asJson.noSpaces
+  def wrap[T](state: T, isTestUser: Boolean, isExistingAccount: Boolean)(implicit encoder: Encoder[T]): String = {
+    JsonWrapper(encodeState(state), None, RequestInfo(useEncryption, isTestUser, failed = false, Nil, isExistingAccount)).asJson.noSpaces
   }
 
   def unWrap[T](s: String)(implicit decoder: Decoder[T]): Try[T] =

--- a/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
+++ b/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
@@ -110,7 +110,8 @@ class SupportWorkersClient(
       promoCode = request.body.promoCode,
       firstDeliveryDate = request.body.firstDeliveryDate
     )
-    underlying.triggerExecution(createPaymentMethodState, user.isTestUser).bimap(
+    val isExistingAccount = createPaymentMethodState.paymentFields.isInstanceOf[ExistingPaymentFields]
+    underlying.triggerExecution(createPaymentMethodState, user.isTestUser, isExistingAccount).bimap(
       { error =>
         SafeLogger.error(scrub"[$requestId] Failed to trigger Step Function execution for ${user.id} - $error")
         StateMachineFailure: SupportWorkersError

--- a/support-models/src/main/scala/com/gu/support/workers/PaymentFields.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/PaymentFields.scala
@@ -18,23 +18,28 @@ case class DirectDebitPaymentFields(
   accountNumber: String
 ) extends PaymentFields
 
+case class ExistingPaymentFields(billingAccountId: String) extends PaymentFields
+
 object PaymentFields {
   //Payment fields are input from support-frontend
   implicit val payPalPaymentFieldsCodec: Codec[PayPalPaymentFields] = deriveCodec
   implicit val stripePaymentFieldsCodec: Codec[StripePaymentFields] = deriveCodec
   implicit val directDebitPaymentFieldsCodec: Codec[DirectDebitPaymentFields] = deriveCodec
+  implicit val existingPaymentFieldsCodec: Codec[ExistingPaymentFields] = deriveCodec
 
   implicit val encodePaymentFields: Encoder[PaymentFields] = Encoder.instance {
     case p: PayPalPaymentFields => p.asJson
     case s: StripePaymentFields => s.asJson
     case d: DirectDebitPaymentFields => d.asJson
+    case e: ExistingPaymentFields => e.asJson
   }
 
   implicit val decodePaymentFields: Decoder[PaymentFields] =
     List[Decoder[PaymentFields]](
       Decoder[PayPalPaymentFields].widen,
       Decoder[StripePaymentFields].widen,
-      Decoder[DirectDebitPaymentFields].widen
+      Decoder[DirectDebitPaymentFields].widen,
+      Decoder[ExistingPaymentFields].widen
     ).reduceLeft(_ or _)
 
 }

--- a/support-models/src/main/scala/com/gu/support/workers/RequestInfo.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/RequestInfo.scala
@@ -1,6 +1,6 @@
 package com.gu.support.workers
 
-case class RequestInfo(encrypted: Boolean, testUser: Boolean, failed: Boolean, messages: List[String]){
+case class RequestInfo(encrypted: Boolean, testUser: Boolean, failed: Boolean, messages: List[String], accountExists: Boolean){
   def appendMessage(message: String) = copy(messages = messages :+ message)
 }
 

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -41,6 +41,8 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
         createPayPalPaymentMethod(paypal, services.payPalService)
       case dd: DirectDebitPaymentFields =>
         createDirectDebitPaymentMethod(dd, state.user)
+      case _: ExistingPaymentFields =>
+        Future.failed(new RuntimeException("Existing payment methods should never make their way to this lambda"))
     }
 
   private def getCreateSalesforceContactState(state: CreatePaymentMethodState, paymentMethod: PaymentMethod) =

--- a/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
@@ -16,7 +16,7 @@ object JsonFixtures {
   val useEncryption = false
 
   def wrapFixture(string: String): ByteArrayInputStream =
-    Wrapper.wrapString(string, RequestInfo(useEncryption, testUser = false, failed = false, Nil)).asJson.noSpaces.asInputStream
+    Wrapper.wrapString(string, RequestInfo(useEncryption, testUser = false, failed = false, Nil, false)).asJson.noSpaces.asInputStream
 
   val userJson =
     s"""
@@ -315,7 +315,8 @@ object JsonFixtures {
             "encrypted": false,
             "testUser": false,
             "failed": false,
-            "messages": []
+            "messages": [],
+            "accountExists": false
           }
         }
      """
@@ -331,7 +332,8 @@ object JsonFixtures {
             "encrypted": false,
             "testUser": false,
             "failed": false,
-            "messages": []
+            "messages": [],
+            "accountExists": false
           }
         }
      """
@@ -346,7 +348,8 @@ object JsonFixtures {
           "encrypted": false,
           "testUser": true,
           "failed": false,
-          "messages": []
+          "messages": [],
+          "accountExists": false
         }
       }
     """
@@ -364,7 +367,8 @@ object JsonFixtures {
         "encrypted": false,
         "testUser": true,
         "failed": false,
-        "messages": []
+        "messages": [],
+        "accountExists": false
       }
     }
   """
@@ -379,7 +383,8 @@ object JsonFixtures {
           "encrypted": false,
           "testUser": true,
           "failed": false,
-          "messages": []
+          "messages": [],
+          "accountExists": false
         }
       }
     """
@@ -399,7 +404,8 @@ object JsonFixtures {
           "encrypted": false,
           "testUser": true,
           "failed": false,
-          "messages": []
+          "messages": [],
+          "accountExists": false
         }
       }
      """
@@ -415,7 +421,8 @@ object JsonFixtures {
           "encrypted": false,
           "testUser": true,
           "failed": false,
-          "messages": []
+          "messages": [],
+          "accountExists": false
         }
       }
     """
@@ -431,7 +438,8 @@ object JsonFixtures {
           "failed": false,
           "messages": [
             "Payment method is Stripe"
-          ]
+          ],
+          "accountExists": false
         }
       }
     """
@@ -457,7 +465,8 @@ object JsonFixtures {
             "failed": false,
             "messages": [
               "Payment method is Stripe"
-            ]
+            ],
+            "accountExists": false
           }
         }
       """.asInputStream


### PR DESCRIPTION
model a new object for 'paymentFields' (which contains 'billingAccountId' to represent existing payment method) PLUS an `accountExists` boolean in the non-encrypted `requestInfo` so that step function can branch accordingly in future

## Why are you doing this?
As prerequisite for https://github.com/guardian/support-frontend/pull/1673 we must ensure that `support-models` can handle a new object value for `paymentFields` (for **existing** payment details) and to expose that the Zuora account already exists with an non-encrypted flag so that step function can branch accordingly in future (see ADD PR ONCE CREATED)
<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Changes

* model a new object for `paymentFields` (which contains `billingAccountId` to represent existing payment method)
* PLUS an `accountExists` boolean in the non-encrypted `requestInfo` so that step function can branch accordingly in future

## Screenshots
_N/A_
