### PR TITLE
Read/write fonts to and from local storage

### DIFF
--- a/support-frontend/assets/helpers/fontLoader.js
+++ b/support-frontend/assets/helpers/fontLoader.js
@@ -1,17 +1,50 @@
 // @flow
+import * as storage from 'helpers/storage';
+
 
 const fetchFonts = (window: Object, document: Document): void => {
   const head: null | HTMLHeadElement = document.querySelector('head');
 
-  const useFont = (font: { css: string }): void => {
-    if (head) {
+  const useFont = (font: { fontName: string, css: string }): void => {
+    const fontClassName = `gu_font__${font.fontName}`;
+    if (document.getElementsByClassName(fontClassName).length === 0 && head && font.fontName && font.css) {
       const style: HTMLStyleElement = document.createElement('style');
+      style.classList.add(`gu_font__${font.fontName}`);
       style.innerHTML = font.css;
       head.appendChild(style);
     }
   };
 
+  const saveFontToLocalStorage = (font: { fontName: string, css: string }) => {
+    const { fontName } = font;
+    if (fontName) {
+      const currentFontsString = storage.getLocal('guFonts');
+      const currentFonts = currentFontsString ? JSON.parse(currentFontsString) : {};
+      storage.setLocal('guFonts', JSON.stringify({
+        ...currentFonts,
+        [fontName]: font,
+      }));
+    }
+  };
+
+  const loadFontsFromLocalStorage = () => {
+    const fonts = storage.getLocal('guFonts');
+    if (fonts) {
+      const fontsObject = JSON.parse(fonts);
+      const values = Object.values(fontsObject);
+      values.forEach((value) => {
+        if (value instanceof Object && value.fontName && value.css) {
+          useFont(value);
+        }
+      });
+    }
+  };
+
   const loadFonts = (): void => {
+
+    loadFontsFromLocalStorage();
+
+    // even if we do load the fonts from storage, still check the localStorage of gu.com in case there are any new ones
     const iframe = document.createElement('iframe');
     iframe.src = 'https://theguardian.com/font-loader';
     // add iframe and wait for message
@@ -28,6 +61,7 @@ const fetchFonts = (window: Object, document: Document): void => {
         if (Array.isArray(e.data.fonts)) {
           e.data.fonts.forEach((font) => {
             if (font instanceof Object) {
+              saveFontToLocalStorage(font);
               useFont(font);
             }
           });


### PR DESCRIPTION
## Why are you doing this?
Previously, we were getting the fonts from the `gu.com/font-loader` endpoint, inserting them into the template and that was that. This PR also adds the fonts to local storage, and reads them from local storage too. The upshot is that on second page load, you don't get a FOUT (flash of unstyled text). 

Currently, I've set it up to read from localStorage then hit the `gu.com/font-loader` endpoint anyway, regardless of whether it found any fonts in there, as I didn't want to have to encode which fonts we were looking for (as this could potentially change in the future). I do, however, make sure that we don't insert them twice into the template.