### PR TITLE
Added test for updated styles on mobile contribution type tabs

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -5,6 +5,7 @@ import type { Tests } from './abtest';
 
 
 export type EditorialiseAmountsVariant = 'control' | 'averageAnnualAmount' | 'monthlyBreakdownAnnual' | 'weeklyBreakdownAnnual' | 'notintest';
+export type VerticalContributionsTabsVariant = 'control' | 'verticalTabsMobile';
 
 export const tests: Tests = {
 
@@ -33,6 +34,27 @@ export const tests: Tests = {
     isActive: true,
     independent: true,
     seed: 3,
+  },
+
+  verticalContributionsTabs: {
+    type: 'OTHER',
+    variants: [
+      {
+        id: 'control',
+      },
+      {
+        id: 'verticalTabsMobile',
+      },
+    ],
+    audiences: {
+      ALL: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: true,
+    independent: true,
+    seed: 4,
   },
 };
 

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -5,7 +5,7 @@ import type { Tests } from './abtest';
 
 
 export type EditorialiseAmountsVariant = 'control' | 'averageAnnualAmount' | 'monthlyBreakdownAnnual' | 'weeklyBreakdownAnnual' | 'notintest';
-export type VerticalContributionsTabsVariant = 'control' | 'verticalTabsMobile';
+export type VerticalContributionsTabsVariant = 'control' | 'verticalTabsMobile' | 'notintest';
 
 export const tests: Tests = {
 

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
@@ -247,7 +247,7 @@ function ContributionFormContainer(props: PropTypes) {
     // This is because going 'back' to the /contribute page is not helpful, and the client-side routing would redirect
     // back to /thankyou given the current state of the redux store.
     // The effect is that clicking back in the browser will take the user to the page before they arrived at /contribute
-    <Redirect to={props.thankYouRoute} push={false}/>
+    <Redirect to={props.thankYouRoute} push={false} />
     : (
       <div className="gu-content__content gu-content__content-contributions gu-content__content--flex">
         <div className="gu-content__blurb">

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionTypeTabs.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionTypeTabs.jsx
@@ -55,7 +55,7 @@ const mapDispatchToProps = (dispatch: Function) => ({
 // ----- Render ----- //
 
 function ContributionTypeTabs(props: PropTypes) {
-  const verticalTabsModifier = props.verticalContributionsTabsVariant === 'control' ? '' : 'mobile-vertical-tabs';
+  const verticalTabsModifier = props.verticalContributionsTabsVariant === 'verticalTabsMobile' ? 'mobile-vertical-tabs' : '';
   const contributionTypes = getValidContributionTypes(props.countryGroupId);
 
   if (contributionTypes.length === 1 && contributionTypes[0] === 'ONE_OFF') {

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionTypeTabs.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionTypeTabs.jsx
@@ -13,6 +13,7 @@ import {
 } from 'helpers/checkouts';
 
 import { trackComponentClick } from 'helpers/tracking/ophanComponentEventTracking';
+import type { VerticalContributionsTabsVariant } from 'helpers/abTests/abtestDefinitions';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { Switches } from 'helpers/settings';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
@@ -27,6 +28,7 @@ type PropTypes = {|
   countryGroupId: CountryGroupId,
   switches: Switches,
   onSelectContributionType: (ContributionType, Switches, IsoCountry, CountryGroupId) => void,
+  verticalContributionsTabsVariant: VerticalContributionsTabsVariant
 |};
 
 const mapStateToProps = (state: State) => ({
@@ -34,6 +36,7 @@ const mapStateToProps = (state: State) => ({
   contributionType: state.page.form.contributionType,
   countryId: state.common.internationalisation.countryId,
   switches: state.common.settings.switches,
+  verticalContributionsTabsVariant: state.common.abParticipations.verticalContributionsTabs,
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -52,6 +55,7 @@ const mapDispatchToProps = (dispatch: Function) => ({
 // ----- Render ----- //
 
 function ContributionTypeTabs(props: PropTypes) {
+  const verticalTabsModifier = props.verticalContributionsTabsVariant === 'control' ? '' : 'mobile-vertical-tabs';
   const contributionTypes = getValidContributionTypes(props.countryGroupId);
 
   if (contributionTypes.length === 1 && contributionTypes[0] === 'ONE_OFF') {
@@ -59,7 +63,7 @@ function ContributionTypeTabs(props: PropTypes) {
   }
 
   return (
-    <fieldset className={classNameWithModifiers('form__radio-group', ['tabs', 'contribution-type'])}>
+    <fieldset className={classNameWithModifiers('form__radio-group', ['tabs', 'contribution-type', verticalTabsModifier])}>
       <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>Recurrence</legend>
       <ul className="form__radio-group-list form__radio-group-list--border">
         {contributionTypes.map((contributionType: ContributionType) => (

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -380,22 +380,12 @@ footer[role="contentinfo"] a {
 }
 
 .form__radio-group-list--border {
-  @include mq($from: mobileLandscape) {
-    border-bottom: 1px solid gu-colour(neutral-86);
-  }
+  border-bottom: 1px solid gu-colour(neutral-86);
 
   li label {
     font-family: $gu-headline;
     font-weight: 600;
     font-size: 22px;
-  }
-}
-
-.form__radio-group-list--border .form__radio-group-item {
-  border-bottom: 1px solid gu-colour(highlight-main);
-
-  @include mq($from: mobileLandscape) {
-    border-bottom: none;
   }
 }
 
@@ -627,13 +617,6 @@ form {
 .form__radio-group--tabs .form__radio-group-list {
   display: flex;
   margin: 0 -10px;
-  flex-flow: column-reverse nowrap;
-  text-align: center;
-
-  @include mq($from: mobileLandscape) {
-    flex-flow: row nowrap;
-    text-align: left;
-  }
 }
 
 .form__radio-group--tabs .form__radio-group-item {
@@ -1219,4 +1202,31 @@ form {
 
 .editorialise-amounts-test-copy:empty {
   display: none;
+}
+
+// Vertical contributions tabs test
+.form__radio-group--mobile-vertical-tabs .form__radio-group-list {
+  flex-flow: column-reverse nowrap;
+  text-align: center;
+
+  @include mq($from: mobileLandscape) {
+    flex-flow: row nowrap;
+    text-align: left;
+  }
+}
+
+.form__radio-group--mobile-vertical-tabs .form__radio-group-list--border {
+  border-bottom: none;
+
+  @include mq($from: mobileLandscape) {
+    border-bottom: 1px solid gu-colour(neutral-86);
+  }
+}
+
+.form__radio-group--mobile-vertical-tabs .form__radio-group-list--border .form__radio-group-item {
+  border-bottom: 1px solid gu-colour(highlight-main);
+
+  @include mq($from: mobileLandscape) {
+    border-bottom: none;
+  }
 }

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -1205,28 +1205,30 @@ form {
 }
 
 // Vertical contributions tabs test
-.form__radio-group--mobile-vertical-tabs .form__radio-group-list {
-  flex-flow: column-reverse nowrap;
-  text-align: center;
+.form__radio-group--mobile-vertical-tabs {
+  .form__radio-group-list {
+    flex-flow: column-reverse nowrap;
+    text-align: center;
 
-  @include mq($from: mobileLandscape) {
-    flex-flow: row nowrap;
-    text-align: left;
+    @include mq($from: mobileLandscape) {
+      flex-flow: row nowrap;
+      text-align: left;
+    }
   }
-}
 
-.form__radio-group--mobile-vertical-tabs .form__radio-group-list--border {
-  border-bottom: none;
-
-  @include mq($from: mobileLandscape) {
-    border-bottom: 1px solid gu-colour(neutral-86);
-  }
-}
-
-.form__radio-group--mobile-vertical-tabs .form__radio-group-list--border .form__radio-group-item {
-  border-bottom: 1px solid gu-colour(highlight-main);
-
-  @include mq($from: mobileLandscape) {
+  .form__radio-group-list--border {
     border-bottom: none;
+
+    @include mq($from: mobileLandscape) {
+      border-bottom: 1px solid gu-colour(neutral-86);
+    }
+  }
+
+  .form__radio-group-list--border .form__radio-group-item {
+    border-bottom: 1px solid gu-colour(highlight-main);
+
+    @include mq($from: mobileLandscape) {
+      border-bottom: none;
+    }
   }
 }

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -380,12 +380,22 @@ footer[role="contentinfo"] a {
 }
 
 .form__radio-group-list--border {
-  border-bottom: 1px solid gu-colour(neutral-86);
+  @include mq($from: mobileLandscape) {
+    border-bottom: 1px solid gu-colour(neutral-86);
+  }
 
   li label {
     font-family: $gu-headline;
     font-weight: 600;
     font-size: 22px;
+  }
+}
+
+.form__radio-group-list--border .form__radio-group-item {
+  border-bottom: 1px solid gu-colour(highlight-main);
+
+  @include mq($from: mobileLandscape) {
+    border-bottom: none;
   }
 }
 
@@ -617,6 +627,13 @@ form {
 .form__radio-group--tabs .form__radio-group-list {
   display: flex;
   margin: 0 -10px;
+  flex-flow: column-reverse nowrap;
+  text-align: center;
+
+  @include mq($from: mobileLandscape) {
+    flex-flow: row nowrap;
+    text-align: left;
+  }
 }
 
 .form__radio-group--tabs .form__radio-group-item {


### PR DESCRIPTION
## Why are you doing this?
Using a test to update to the styles for tabs on mobile devices for 50% of users (vertical instead of horizontal below 440px) - Trello card attached

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/PVwwQgzt/332-implement-on-mobile-stack-frequency-types)

## Changes

* Stacking the contribution tabs below the 440px breakpoint

## Screenshots
Control:
<img width="400" alt="verticalContributionsTest_control" src="https://user-images.githubusercontent.com/3300789/54754287-08daf880-4bdb-11e9-94df-b574a65c26cc.png">

Variant:
<img width="400" alt="verticalContributionsTest_variant" src="https://user-images.githubusercontent.com/3300789/54754295-109a9d00-4bdb-11e9-95f3-ff2e663a9143.png">