### PR TITLE
Add ticker to storybook

### DIFF
--- a/support-frontend/assets/components/ticker/contributionTicker.jsx
+++ b/support-frontend/assets/components/ticker/contributionTicker.jsx
@@ -4,6 +4,8 @@
 import React, { Component } from 'react';
 import { classNameWithModifiers } from 'helpers/utilities';
 
+import './contributionTicker.scss';
+
 // ---- Types ----- //
 type StateTypes = {|
   totalSoFar: number,
@@ -36,7 +38,7 @@ const percentageTotalAsNegative = (total: number, goal: number) => {
 
 
 // ----- Component ----- //
-export class ContributionTicker extends Component<PropTypes, StateTypes> {
+export default class ContributionTicker extends Component<PropTypes, StateTypes> {
 
   constructor(props: PropTypes) {
     super(props);

--- a/support-frontend/assets/components/ticker/contributionTicker.scss
+++ b/support-frontend/assets/components/ticker/contributionTicker.scss
@@ -1,4 +1,4 @@
-// -----  gu-sass ----- //
+@import '~stylesheets/gu-sass/gu-sass';
 
 $progess-bar-height: 10px;
 

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
@@ -17,11 +17,11 @@ import { type CreatePaypalPaymentData } from 'helpers/paymentIntegrations/oneOff
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import DirectDebitPopUpForm from 'components/directDebit/directDebitPopUpForm/directDebitPopUpForm';
 import { openDirectDebitPopUp } from 'components/directDebit/directDebitActions';
+import ContributionTicker from 'components/ticker/ContributionTicker';
 import { setPayPalHasLoaded } from 'helpers/paymentIntegrations/payPalActions';
 
 import { type State } from '../contributionsLandingReducer';
 import { NewContributionForm } from './ContributionForm';
-import { ContributionTicker } from './ContributionTicker/ContributionTicker';
 
 import {
   paymentWaiting,

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
@@ -17,7 +17,7 @@ import { type CreatePaypalPaymentData } from 'helpers/paymentIntegrations/oneOff
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import DirectDebitPopUpForm from 'components/directDebit/directDebitPopUpForm/directDebitPopUpForm';
 import { openDirectDebitPopUp } from 'components/directDebit/directDebitActions';
-import ContributionTicker from 'components/ticker/ContributionTicker';
+import ContributionTicker from 'components/ticker/contributionTicker';
 import { setPayPalHasLoaded } from 'helpers/paymentIntegrations/payPalActions';
 
 import { type State } from '../contributionsLandingReducer';
@@ -247,7 +247,7 @@ function ContributionFormContainer(props: PropTypes) {
     // This is because going 'back' to the /contribute page is not helpful, and the client-side routing would redirect
     // back to /thankyou given the current state of the redux store.
     // The effect is that clicking back in the browser will take the user to the page before they arrived at /contribute
-    <Redirect to={props.thankYouRoute} push={false}/>
+    <Redirect to={props.thankYouRoute} push={false} />
     : (
       <div className="gu-content__content gu-content__content-contributions gu-content__content--flex">
         <div className="gu-content__blurb">

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -11,7 +11,6 @@
 @import '~components/button/button';
 @import '~components/marketingConsentNew/marketingConsent';
 @import '~pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYou';
-@import '~pages/new-contributions-landing/components/ContributionTicker/ContributionTicker';
 @import '~pages/new-contributions-landing/components/ButtonWithRightArrow/ButtonWithRightArrow';
 @import '~pages/new-contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton';
 @import '~pages/new-contributions-landing/components/ContributionSurvey/ContributionSurvey';

--- a/support-frontend/stories/_index.js
+++ b/support-frontend/stories/_index.js
@@ -11,4 +11,5 @@ module.exports = () => {
   require('./layout.jsx');
   require('./tabs.jsx');
   require('./animatedDots.jsx');
+  require('./contributionTicker.jsx');
 };

--- a/support-frontend/stories/contributionTicker.jsx
+++ b/support-frontend/stories/contributionTicker.jsx
@@ -1,0 +1,26 @@
+// @flow
+
+import React from 'react';
+
+import { storiesOf } from '@storybook/react';
+
+
+import ContributionTicker from 'components/ticker/contributionTicker';
+import { text, withKnobs } from '@storybook/addon-knobs/src/index';
+import { withCenterAlignment } from '../.storybook/decorators/withCenterAlignment';
+
+
+const tickerJsonUrlInput = () => text('Ticker JSON URL', 'https://support.theguardian.com/ticker.json');
+
+const stories = storiesOf('Tickers', module)
+  .addDecorator(withKnobs)
+  .addDecorator(withCenterAlignment);
+
+stories.add('Contribution ticker', () => (
+  <div style={{width: '100%', maxWidth: '500px'}}>
+    <ContributionTicker
+      tickerJsonUrl={tickerJsonUrlInput()}
+      onGoalReached={() => {}}
+    />
+  </div>
+));

--- a/support-frontend/stories/contributionTicker.jsx
+++ b/support-frontend/stories/contributionTicker.jsx
@@ -17,7 +17,7 @@ const stories = storiesOf('Tickers', module)
   .addDecorator(withCenterAlignment);
 
 stories.add('Contribution ticker', () => (
-  <div style={{width: '100%', maxWidth: '500px'}}>
+  <div style={{ width: '100%', maxWidth: '500px' }}>
     <ContributionTicker
       tickerJsonUrl={tickerJsonUrlInput()}
       onGoalReached={() => {}}


### PR DESCRIPTION
Also

- moves it into a general components directory (`components/ticker`)
- includes CSS directly with ES6 import

In sum: makes the ticker more reusable