### PR TITLE
Drop monthly and average amount variants from editorialise amounts test, add in daily variant

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -4,7 +4,7 @@ import type { Tests } from './abtest';
 // ----- Tests ----- //
 
 
-export type EditorialiseAmountsVariant = 'control' | 'averageAnnualAmount' | 'monthlyBreakdownAnnual' | 'weeklyBreakdownAnnual' | 'notintest';
+export type EditorialiseAmountsVariant = 'control' | 'dailyBreakdownAnnual' | 'weeklyBreakdownAnnual' | 'notintest';
 
 export const tests: Tests = {
 

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
@@ -182,7 +182,7 @@ const getEditorialisedAmountsCopy = (
   }
 
   if (editorialiseAmountsVariant === 'weeklyBreakdownAnnual' && contributionType === 'ANNUAL' && amount) {
-    return `Contributing ${currencyString}${amount} works out as${amountFormatted(amount/52.00, currencyString, countryGroupId)} each week`;
+    return `Contributing ${currencyString}${amount} works out as ${amountFormatted(amount/52.00, currencyString, countryGroupId)} each week`;
   }
 
   return '';

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
@@ -144,24 +144,12 @@ const localisedAverageAmountSentence: {
   },
 };
 
-
-function averageAmountVariantCopy(
-  countryGroupId: CountryGroupId,
-  contributionType: ContributionType,
-  currencyString: string,
-) {
-  const localAverageAmountInfo = localisedAverageAmountSentence[countryGroupId];
-  const localAverageAmount = Math.round(localAverageAmountInfo.averageAnnualAmount);
-  const localAverageAmountSentence = localAverageAmountInfo.amountSentence;
-  return `Please select the amount you'd like to contribute each year. ${localAverageAmountSentence} average is ${currencyString}${localAverageAmount}.`;
-}
-
 const amountFormatted = (amount: number, currencyString: string, countryGroupId: CountryGroupId) => {
   if (amount < 1 && countryGroupId === 'GBPCountries') {
     return `${(amount*100).toFixed(0)}p`
   }
   return `${currencyString}${(amount).toFixed(2)}`;
-}
+};
 
 const getEditorialisedAmountsCopy = (
   editorialiseAmountsVariant: EditorialiseAmountsVariant,

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
@@ -156,6 +156,13 @@ function averageAmountVariantCopy(
   return `Please select the amount you'd like to contribute each year. ${localAverageAmountSentence} average is ${currencyString}${localAverageAmount}.`;
 }
 
+const amountFormatted = (amount: number, currencyString: string, countryGroupId: CountryGroupId) => {
+  if (amount < 1 && countryGroupId === 'GBPCountries') {
+    return `${(amount*100).toFixed(0)}p`
+  }
+  return `${currencyString}${(amount).toFixed(2)}`;
+}
+
 const getEditorialisedAmountsCopy = (
   editorialiseAmountsVariant: EditorialiseAmountsVariant,
   contributionType: ContributionType,
@@ -170,16 +177,12 @@ const getEditorialisedAmountsCopy = (
     return '';
   }
 
-  if (editorialiseAmountsVariant === 'averageAnnualAmount' && contributionType === 'ANNUAL') {
-    return averageAmountVariantCopy(countryGroupId, contributionType, currencyString);
-  }
-
-  if (editorialiseAmountsVariant === 'monthlyBreakdownAnnual' && contributionType === 'ANNUAL' && amount) {
-    return `Contributing ${currencyString}${amount} works out as ${currencyString}${(amount / 12.00).toFixed(2)} each month`;
+  if (editorialiseAmountsVariant === 'dailyBreakdownAnnual' && contributionType === 'ANNUAL' && amount) {
+    return `Contributing ${currencyString}${amount} works out as ${amountFormatted(amount/365.00, currencyString, countryGroupId)} a day`;
   }
 
   if (editorialiseAmountsVariant === 'weeklyBreakdownAnnual' && contributionType === 'ANNUAL' && amount) {
-    return `Contributing ${currencyString}${amount} works out as ${currencyString}${(amount / 52.00).toFixed(2)} each week`;
+    return `Contributing ${currencyString}${amount} works out as${amountFormatted(amount/52.00, currencyString, countryGroupId)} each week`;
   }
 
   return '';

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionAmount.jsx
@@ -108,42 +108,6 @@ const iconForCountryGroup = (countryGroupId: CountryGroupId): React$Element<*> =
   }
 };
 
-const localisedAverageAmountSentence: {
-  [CountryGroupId]: {
-    amountSentence: string,
-    averageAnnualAmount: number,
-  }
-} = {
-  GBPCountries: {
-    amountSentence: 'In the UK, the',
-    averageAnnualAmount: 50.37,
-  },
-  UnitedStates: {
-    amountSentence: 'In the US, the',
-    averageAnnualAmount: 50.16,
-  },
-  AUDCountries: {
-    amountSentence: 'In Australia, the',
-    averageAnnualAmount: 82.65,
-  },
-  EURCountries: {
-    amountSentence: 'In Europe, the',
-    averageAnnualAmount: 52.92,
-  },
-  NZDCountries: {
-    amountSentence: 'In New Zealand, the',
-    averageAnnualAmount: 58.51,
-  },
-  Canada: {
-    amountSentence: 'In Canada, the',
-    averageAnnualAmount: 62.68,
-  },
-  International: {
-    amountSentence: 'The',
-    averageAnnualAmount: 61.78,
-  },
-};
-
 const amountFormatted = (amount: number, currencyString: string, countryGroupId: CountryGroupId) => {
   if (amount < 1 && countryGroupId === 'GBPCountries') {
     return `${(amount*100).toFixed(0)}p`


### PR DESCRIPTION
## Why are you doing this?

The weekly variant has been the best variant so far in the [editorialise amounts test](https://github.com/guardian/support-frontend/pull/1661), beating the control significantly in terms of £IYR, but not yet significantly in terms of £AV. 

We want to get that significant £AV result, but we also want to iterate, so we are adding a daily variant to the test, which tests breaking down the annual amount into days. 

In the UK, if the amount is less than £1, we switch to using `xp` rather than `£0.x`

| Daily variant in GB | Daily variant not in GB |
|---|---|
|![UK](https://user-images.githubusercontent.com/2844554/54756023-3cb81d00-4bdf-11e9-9a65-583b00747fd8.png)|![US](https://user-images.githubusercontent.com/2844554/54756024-3cb81d00-4bdf-11e9-8e40-5af4826c903b.png)|
