### PR TITLE
Bugfix: Breakpoints on contributions landing page

### DIFF
--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -107,7 +107,7 @@ header[role="banner"] {
 
   @include mq($from: tablet) {
     height: 115px;
-    padding: 0 0 0 $content-left-margin-tablet;
+    //padding: 0 0 0 $content-left-margin-tablet;
   }
 
   @include mq($from: leftCol) {
@@ -312,7 +312,7 @@ footer[role="contentinfo"] a {
   border: none;
 
   @include mq($from: tablet) {
-    margin-left: $content-left-margin-tablet
+    //margin-left: $content-left-margin-tablet
   }
 
   @include mq($from: leftCol) {
@@ -358,8 +358,12 @@ footer[role="contentinfo"] a {
 
 .gu-content__content--flex {
   display: flex;
-  justify-content: space-between;
+  justify-content: space-around;
   flex-direction: row-reverse;
+
+  @include mq($from: leftCol) {
+    justify-content: flex-end;
+  }
 }
 
 .gu-content__form {
@@ -374,8 +378,8 @@ footer[role="contentinfo"] a {
   background-color: gu-colour(neutral-100);
 
   @include mq($from: tablet) {
-    width: 40%;
-    margin: 30px 10px;
+    margin: 30px 0 0 10px;
+    flex: 0 1 40%;
   }
 }
 
@@ -391,13 +395,16 @@ footer[role="contentinfo"] a {
 
 .gu-content__blurb {
   display: none;
-  border-top: 10px solid gu-colour(highlight-main);
-  margin-left: auto;
-  max-width: 404px;
 
   @include mq($from: tablet) {
     display: block;
-    margin: 30px 120px 30px 10px;
+    border-top: 10px solid gu-colour(highlight-main);
+    margin-top: 30px;
+    flex: 0 1 40%;
+  }
+
+  @include mq($from: leftCol) {
+    margin-left: 80px;
   }
 }
 

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -107,7 +107,6 @@ header[role="banner"] {
 
   @include mq($from: tablet) {
     height: 115px;
-    //padding: 0 0 0 $content-left-margin-tablet;
   }
 
   @include mq($from: leftCol) {
@@ -310,10 +309,6 @@ footer[role="contentinfo"] a {
   flex-grow: 1;
   margin: 0 auto;
   border: none;
-
-  @include mq($from: tablet) {
-    //margin-left: $content-left-margin-tablet
-  }
 
   @include mq($from: leftCol) {
     margin-left: $content-left-margin-leftCol


### PR DESCRIPTION
## Why are you doing this?

The styling was broken for tablets. This file still requires a refactor/overhaul but this bugfix is an incremental step in the right direction IMO.
<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/vHssPxtl/370-fix-tablet-break-point-layout-and-others)

## Screenshots
|Before (ipad):|After (ipad):|
|---|---|
|![tabletBreakpoint_before](https://user-images.githubusercontent.com/3300789/54768117-734d6200-4bf6-11e9-8071-685c8cb7fe0a.png)|![tabletBreakpoint_after](https://user-images.githubusercontent.com/3300789/54768141-7cd6ca00-4bf6-11e9-9a73-189234248bec.png)|

|Before (ipad pro):|After (ipad pro):|
|---|---|
|![tabletBreakpoint_before2](https://user-images.githubusercontent.com/3300789/54768185-92e48a80-4bf6-11e9-94c7-177d37f2f7ec.png)|![tabletBreakpoint_after2](https://user-images.githubusercontent.com/3300789/54768195-98da6b80-4bf6-11e9-8c55-9270b07a3135.png)|
