### PR TITLE
Bump acquisition-event-producer-play26 version to 4.0.18

### DIFF
--- a/support-internationalisation/version.sbt
+++ b/support-internationalisation/version.sbt
@@ -1,1 +1,1 @@
-version := "0.13-SNAPSHOT"
+version := "0.12"

--- a/support-models/build.sbt
+++ b/support-models/build.sbt
@@ -5,7 +5,7 @@ name := "support-models"
 description := "Scala library to provide shared step-function models to Guardian Support projects."
 
 libraryDependencies ++= Seq(
-  "com.gu" %% "acquisition-event-producer-play26" % "4.0.17",
+  "com.gu" %% "acquisition-event-producer-play26" % "4.0.18",
   "org.typelevel" %% "cats-core" % catsVersion,
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,


### PR DESCRIPTION
...to include SwG PaymentProvider

## Why are you doing this?

This is to allow payment-api to set `Acquisition` data to `paymentProvider=ophan.thrift.event.PaymentProvider.SubscribeWithGoogle`

[JIRA ticket](https://contribute.atlassian.net/browse/CWG-94)

## Changes

* Bump acquisition-event-producer-play26 version to 4.0.18

## Screenshots

n/a
