### PR TITLE
Add daily variant

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -16,10 +16,7 @@ export const tests: Tests = {
         id: 'control',
       },
       {
-        id: 'averageAnnualAmount',
-      },
-      {
-        id: 'monthlyBreakdownAnnual',
+        id: 'dailyBreakdownAnnual',
       },
       {
         id: 'weeklyBreakdownAnnual',


### PR DESCRIPTION
## Why are you doing this?
This fixes a bug whereby noone was actually being assigned to the daily breakdown variant in the editorialise amounts test