### PR TITLE
Send print options in acquisition events

### DIFF
--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
@@ -99,7 +99,7 @@ object SendAcquisitionEvent {
             case (Collection, Sixday) => PrintProduct.VoucherSixday
             case (Collection, Weekend) => PrintProduct.VoucherWeekend
             case (Collection, Saturday) => PrintProduct.VoucherSaturday
-            case (Collection, Sunday) => PrintProduct.VoucherSunday
+            case _ => PrintProduct.VoucherSunday
           }
         }
 

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
@@ -12,7 +12,7 @@ import com.gu.support.encoding.CustomCodecs._
 import com.gu.support.workers._
 import com.gu.support.workers.states.SendAcquisitionEventState
 import io.circe.generic.auto._
-import ophan.thrift.event.{Product => OphanProduct}
+import ophan.thrift.event.{PrintOptions, PrintProduct, Product => OphanProduct}
 import ophan.thrift.{event => thrift}
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -91,6 +91,14 @@ object SendAcquisitionEvent {
           case _: DigitalPack => (OphanProduct.DigitalSubscription, 0D) //TODO: Send the real amount in the acquisition event
           case _: Paper => (OphanProduct.PrintSubscription, 0D) //TODO: same as above
         }
+
+        val printOptions = state.product match {
+          case p: Paper => Some(PrintOptions(PrintProduct.HomeDeliverySixday, "GB"))
+          case _ => None
+        }
+        SafeLogger.info(s"Sending printoptions: ${printOptions}")
+
+
         Either.fromOption(
           state.acquisitionData.map { data =>
             thrift.Acquisition(


### PR DESCRIPTION
I worked with @walaura on this

## Why are you doing this?
Acquisition events for the paper checkout would currently just be sending that it is some kind of print subscription, but we also need to know voucher|HD and everyday|sixday|etc. That way we can understand our users better and be able to make AV calculations on print acquisitions. 

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/ENjN34vd/2264-analytics)

## Changes

* Send print options in acquisition events.
## Screenshots

