### PR TITLE
Add a little info to logging when a support-workers execution is started for a subscription

### DIFF
--- a/support-frontend/app/controllers/CreateSubscription.scala
+++ b/support-frontend/app/controllers/CreateSubscription.scala
@@ -93,20 +93,21 @@ class CreateSubscription(
   protected def respondToClient(
     result: EitherT[Future, CreateSubscriptionError, StatusResponse],
     billingPeriod: BillingPeriod
- )(implicit request: AuthRequest[CreateSupportWorkersRequest]): Future[Result] =
+ )(implicit request: AuthRequest[CreateSupportWorkersRequest]): Future[Result] = {
+    val product = request.body.product.describe
     result.fold(
       { error =>
-        SafeLogger.error(scrub"[${request.uuid}] Failed to create new $billingPeriod subscription, due to $error")
+        SafeLogger.error(scrub"[${request.uuid}] Failed to create new $billingPeriod $product subscription, due to $error")
         error match {
           case _: RequestValidationError => BadRequest
           case _: ServerError => InternalServerError
         }
       },
       { statusResponse =>
-        SafeLogger.info(s"[${request.uuid}] Successfully created a support workers execution for a new $billingPeriod subscription")
+        SafeLogger.info(s"[${request.uuid}] Successfully created a support workers execution for a new $billingPeriod $product subscription")
         Accepted(statusResponse.asJson)
       }
     )
-
+  }
 }
 


### PR DESCRIPTION

## Why are you doing this?
Just wanted to make it a little easier to look at the logs and see subscription signups, and for which product. 👀 

We are currently just logging billing period.


<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com) - none


