### PR TITLE
Release support models 62

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,4 @@
-# Support Libraries
-This repo holds shared libraries used by [support-frontend](https://github.com/guardian/support-frontend) and [support-workers](https://github.com/guardian/support-workers)
 
-## [support-config](./support-config/)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu/support-config_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.gu/support-config_2.11)
+Mono-repo for the [supporter platform](https://support.theguardian.com/). 
+All information, including instructions for getting set up **locally**, can be found in the [wiki](https://github.com/guardian/support-frontend/wiki).
 
-## [support-models](./support-models/)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu/support-models_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.gu/support-models_2.11)
-
-## [support-services](./support-services/)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu/support-services_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.gu/support-services_2.12)
-
-## [support-internationalisation](./support-internationalisation/)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu/support-internationalisation_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.gu/support-internationalisation_2.12)
-
-## Tests
-
-`sbt test` - runs unit tests only and excludes integration tests.
-
-`sbt it:test` - runs all tests including integration tests (i.e. those which talk to real services e.g. AWS S3).
-
-## Releasing
-### Releasing to local repo
-
-You can publish all four libraries locally by running:
-
-`sbt publishLocal`
-
-If you really need to publish one library only (for example support-config) then run:
-
-`sbt "project supportConfig" publishLocal`
-
-
-### Releasing to maven
-
-We use sbt to release to Maven. Please check notes here to ensure you are set up to release to Maven:
-https://docs.google.com/document/d/1M_MiE8qntdDn97QIRnIUci5wdVQ8_defCqpeAwoKY8g/edit#heading=h.r815791vmxv5
-
-Currently each library is versioned separately and must be released separately, this can be done using the command:
-
-`sbt "project [the project]" release`

--- a/support-config/README.md
+++ b/support-config/README.md
@@ -1,6 +1,6 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu/support-config_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.gu/support-config_2.11)
 
-This project helps unifies the config settings for support-frontend and https://github.com/guardian/support-workers
+This project helps unify the config settings for support-frontend and https://github.com/guardian/support-workers
 
 ## Concepts
 

--- a/support-config/README.md
+++ b/support-config/README.md
@@ -1,7 +1,6 @@
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu/support-config_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.gu/support-config_2.11)
 
-This project helps unifies the config settings for [support-frontend](https://github.com/guardian/support-frontend) and
-[support-workers](https://github.com/guardian/support-workers)
+This project helps unifies the config settings for support-frontend and https://github.com/guardian/support-workers
 
 ## Concepts
 

--- a/support-frontend/README.md
+++ b/support-frontend/README.md
@@ -1,2 +1,2 @@
-Frontend for the new [supporter platform](https://support.theguardian.com/). All information, including instructions for getting set up **locally**, can be found in the [wiki](https://github.com/guardian/support-frontend/wiki). Alternatively, if you are looking for the backend for this project, it can be found in the [support-workers](https://github.com/guardian/support-workers) repository.
+Frontend for the new [supporter platform](https://support.theguardian.com/).
 

--- a/support-models/README.md
+++ b/support-models/README.md
@@ -2,7 +2,7 @@
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu/support-models_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.gu/support-models_2.11)
 
-Shared models used to interact with support step-functions.  Used by [support-workers](https://github.com/guardian/support-workers) and [support-frontend](https://github.com/guardian/support-frontend)
+Shared models used to interact with support step-functions. 
 
 Releasing to local repo
 ==================

--- a/support-models/build.sbt
+++ b/support-models/build.sbt
@@ -1,4 +1,4 @@
-import LibraryVersions.{catsVersion, circeVersion}
+import LibraryVersions.{circeVersion, catsVersion}
 
 name := "support-models"
 

--- a/support-models/build.sbt
+++ b/support-models/build.sbt
@@ -1,4 +1,4 @@
-import LibraryVersions.{circeVersion, catsVersion}
+import LibraryVersions.{catsVersion, circeVersion}
 
 name := "support-models"
 

--- a/support-models/version.sbt
+++ b/support-models/version.sbt
@@ -1,1 +1,1 @@
-version := "0.61-SNAPSHOT"
+version := "0.66-SNAPSHOT"

--- a/support-services/README.md
+++ b/support-services/README.md
@@ -2,7 +2,7 @@
 
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.gu/support-services_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.gu/support-services_2.12)
 
-Shared services used by [support-workers](https://github.com/guardian/support-workers) and [support-frontend](https://github.com/guardian/support-frontend)
+Shared services used by support-workers and support-frontend
 
 Releasing to local repo
 ==================


### PR DESCRIPTION
## Why are you doing this?

To make the library projects releasable, they have not worked since the move to the mono repo but it turns out we do still need to sometimes release them separately because the payment api depends on support-models.
