### PR TITLE
Fix <Menu> on phones and add stories

### DIFF
--- a/support-frontend/assets/components/countryGroupSwitcher/countryGroupSwitcher.jsx
+++ b/support-frontend/assets/components/countryGroupSwitcher/countryGroupSwitcher.jsx
@@ -7,7 +7,7 @@ import React, { Component } from 'react';
 import SvgDropdownArrow from 'components/svgs/dropdownArrow';
 import Dialog from 'components/dialog/dialog';
 import { clickedEvent } from 'helpers/tracking/clickTracking';
-import Menu, { LinkItem } from '../menu/menu';
+import Menu, { LinkItem } from 'components/menu/menu';
 
 import {
   countryGroups,

--- a/support-frontend/assets/components/menu/menu.jsx
+++ b/support-frontend/assets/components/menu/menu.jsx
@@ -3,10 +3,26 @@ import React, { type Node } from 'react';
 import styles from './menu.module.scss';
 import SvgCheckmark from 'components/svgs/checkmark';
 
-const LinkItem = ({ isSelected, children, ...props }: {children: Node, isSelected: boolean}) => (
-  <a {...props} className={styles.item} data-is-selected={isSelected}>
+type itemProps = {children: Node, isSelected: boolean};
+
+const Item = ({
+  isSelected, children, el: El, ...props
+}: {...itemProps, el: string}) => (
+  <El {...props} className={styles.item} data-is-selected={isSelected}>
     {children} {isSelected && [<SvgCheckmark />, <span className="accessibility-hint">Selected</span>]}
-  </a>);
+  </El>);
+
+
+const LinkItem = ({ children, ...props }: {...itemProps, href: string}) => (
+  <Item el="a" {...props}>
+    {children}
+  </Item>);
+
+const ButtonItem = ({ children, ...props }: {...itemProps}) => (
+  <Item el="button" {...props}>
+    {children}
+  </Item>);
+
 
 const Menu = ({ children, ...props }: {children: Node}) => (
   <div {...props} className={styles.root}>
@@ -16,4 +32,4 @@ const Menu = ({ children, ...props }: {children: Node}) => (
 
 export default Menu;
 
-export { LinkItem };
+export { LinkItem, ButtonItem };

--- a/support-frontend/assets/components/menu/menu.module.scss
+++ b/support-frontend/assets/components/menu/menu.module.scss
@@ -12,9 +12,13 @@
     left: 0!important;
     right: 0!important;
     bottom: 0!important;
-    max-height: 80vh;
+    max-height: 70vh;
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
+    /*accomodate iphone safari bottom bar popping out*/
+    padding-bottom: $gu-v-spacing * 5;
+    padding-bottom: 10vh;
+    overflow: auto;
   }
 }
 
@@ -59,4 +63,8 @@
     top: $gu-v-spacing *.85;
     fill: gu-colour(state-success);
   }
+}
+
+.root .item {
+  margin-bottom: -1px;
 }

--- a/support-frontend/stories/_index.js
+++ b/support-frontend/stories/_index.js
@@ -7,6 +7,7 @@ module.exports = () => {
   require('./dialog.jsx');
   require('./form.jsx');
   require('./header.jsx');
+  require('./menu.jsx');
   require('./type.jsx');
   require('./layout.jsx');
   require('./tabs.jsx');

--- a/support-frontend/stories/dialog.jsx
+++ b/support-frontend/stories/dialog.jsx
@@ -11,6 +11,7 @@ import Button from 'components/button/button';
 import Text from 'components/text/text';
 import { withCenterAlignment } from '../.storybook/decorators/withCenterAlignment';
 import WithState from '../.storybook/util/withState';
+import Menu, { ButtonItem } from 'components/menu/menu';
 
 
 // Teeny helpers
@@ -38,10 +39,6 @@ const inlineDialogStyle = bounds => ({
   top: bounds.top,
   left: bounds.left,
   position: 'absolute',
-  background: '#fafafa',
-  border: '1px solid #ddd',
-  padding: '.5em',
-  borderRadius: '1.25em',
 });
 
 
@@ -117,20 +114,20 @@ stories.add('Unstyled dialog', () => (
               blocking={false} // this lets you click outside to close
               styled={false}
             >
-              <div
+              <Menu
                 style={inlineDialogStyle(state.bounds)}
               >
-                <GreyButton>This could be a dropdown menu</GreyButton><br />
-                <GreyButton>Click outside to close</GreyButton><br />
-                <GreyButton>
+                <ButtonItem>This could be a dropdown menu</ButtonItem>
+                <ButtonItem>Click outside to close</ButtonItem>
+                <ButtonItem>
                   BUT! you still need a close button for keyboard + srd users even if its visibly hidden
-                </GreyButton><br />
-                <GreyButton
+                </ButtonItem>
+                <ButtonItem
                   onClick={() => { setState({ open: false }); }}
                 >
                   Close
-                </GreyButton>
-              </div>
+                </ButtonItem>
+              </Menu>
             </Dialog>
           </div>)}
       </WithState>

--- a/support-frontend/stories/menu.jsx
+++ b/support-frontend/stories/menu.jsx
@@ -1,0 +1,21 @@
+// @flow
+
+import React from 'react';
+
+import { storiesOf } from '@storybook/react';
+import Menu, { LinkItem, ButtonItem } from 'components/menu/menu';
+
+import { withCenterAlignment } from '../.storybook/decorators/withCenterAlignment';
+
+const stories = storiesOf('Menu', module)
+  .addDecorator(withCenterAlignment);
+
+stories.add('Menu', () => (
+  <Menu>
+    <ButtonItem>This is a menu</ButtonItem>
+    <ButtonItem>Feed it with items</ButtonItem>
+    <ButtonItem>To make the menu beasts happy</ButtonItem>
+    <ButtonItem isSelected>You can make an item look selected</ButtonItem>
+    <LinkItem href="#">Use LinkItem for links</LinkItem>
+  </Menu>
+));


### PR DESCRIPTION
## Why are you doing this?
The last menu item from #1724 was hard to use on my iPhone X as safari tries to open the bottom bar when you click it, this adds generous padding to make up for it.

I've also added stories because this is quite a useful component to have documented

![Screenshot 2019-03-27 at 10 06 11](https://user-images.githubusercontent.com/11539094/55068353-88ecdc80-5079-11e9-8b58-0e128cb423e9.png)
![Screenshot 2019-03-27 at 10 17 42](https://user-images.githubusercontent.com/11539094/55068367-90ac8100-5079-11e9-9e9a-c76572ca07b5.png)
