### PR TITLE
Put back six for six

### DIFF
--- a/support-frontend/assets/pages/subscriptions-landing/components/featuredProducts.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/components/featuredProducts.jsx
@@ -7,11 +7,13 @@ import { type SubsUrls } from 'helpers/externalLinks';
 import { getQueryParameter } from 'helpers/url';
 import { type SubscriptionProduct } from 'helpers/subscriptions';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { findIsoCountry } from 'helpers/internationalisation/country';
 
 import GridPicture from 'components/gridPicture/gridPicture';
 import { flashSaleIsActive, getSaleCopy } from 'helpers/flashSale';
 import { GBPCountries } from 'helpers/internationalisation/countryGroup';
-
+import { showPrice, getCurrency, type Price } from 'helpers/productPrice/productPrices';
+import { fromCountryGroupId } from '../../../helpers/internationalisation/currency';
 
 // ----- Types ----- //
 type Product = {|
@@ -125,10 +127,15 @@ const getProductHeadingsAndBody = (product: SubscriptionProduct, countryGroupId:
     };
   }
 
+  const maybeCurrency = fromCountryGroupId(countryGroupId);
+  const thePrice: Price = {
+    price: 6,
+    currency: maybeCurrency !== null && maybeCurrency !== undefined ? maybeCurrency : 'GBP',
+  };
   // if (product === 'GuardianWeekly') {
   return {
     headingText: 'Guardian Weekly',
-    subheadingText: 'Open up your world view',
+    subheadingText: `6 issues for ${showPrice(thePrice)}`,
     bodyText: 'The Guardian\'s essential news magazine with free worldwide delivery.',
   };
   // }

--- a/support-frontend/assets/pages/subscriptions-landing/components/featuredProducts.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/components/featuredProducts.jsx
@@ -7,12 +7,10 @@ import { type SubsUrls } from 'helpers/externalLinks';
 import { getQueryParameter } from 'helpers/url';
 import { type SubscriptionProduct } from 'helpers/subscriptions';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import { findIsoCountry } from 'helpers/internationalisation/country';
-
 import GridPicture from 'components/gridPicture/gridPicture';
 import { flashSaleIsActive, getSaleCopy } from 'helpers/flashSale';
 import { GBPCountries } from 'helpers/internationalisation/countryGroup';
-import { showPrice, getCurrency, type Price } from 'helpers/productPrice/productPrices';
+import { showPrice, type Price } from 'helpers/productPrice/productPrices';
 import { fromCountryGroupId } from '../../../helpers/internationalisation/currency';
 
 // ----- Types ----- //
@@ -128,14 +126,14 @@ const getProductHeadingsAndBody = (product: SubscriptionProduct, countryGroupId:
   }
 
   const maybeCurrency = fromCountryGroupId(countryGroupId);
-  const thePrice: Price = {
+  const sixPrice: Price = {
     price: 6,
     currency: maybeCurrency !== null && maybeCurrency !== undefined ? maybeCurrency : 'GBP',
   };
   // if (product === 'GuardianWeekly') {
   return {
     headingText: 'Guardian Weekly',
-    subheadingText: `6 issues for ${showPrice(thePrice)}`,
+    subheadingText: `6 issues for ${showPrice(sixPrice)}`,
     bodyText: 'The Guardian\'s essential news magazine with free worldwide delivery.',
   };
   // }

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
@@ -5,7 +5,7 @@ import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { currencies, detect } from 'helpers/internationalisation/currency';
 import type { WeeklyBillingPeriod } from 'helpers/billingPeriods';
 import { type CommonState } from 'helpers/page/commonReducer';
-import { Annual, Quarterly } from 'helpers/billingPeriods';
+import { Annual, Quarterly, SixForSix } from 'helpers/billingPeriods';
 import { getWeeklyCheckout } from 'helpers/externalLinks';
 import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
 import { getPromoCode } from 'helpers/flashSale';
@@ -44,6 +44,11 @@ const getPromotionPrice = (countryGroupId: CountryGroupId, period: WeeklyBilling
 ].join('');
 
 export const displayBillingPeriods = {
+  [SixForSix]: {
+    title: '6 for 6',
+    offer: 'Introductory offer',
+    copy: (countryGroupId: CountryGroupId) => `${getPrice(countryGroupId, 'SixForSix')} for the first 6 issues (then ${getPrice(countryGroupId, 'Quarterly')} quarterly)`,
+  },
   [Quarterly]: {
     title: 'Quarterly',
     copy: (countryGroupId: CountryGroupId) => `${getPrice(countryGroupId, 'Quarterly')} every 3 months`,


### PR DESCRIPTION
Note: to be merged morning of April 1

## Why are you doing this?

https://github.com/guardian/support-frontend/pull/1510/files removed six for six but now we want it back 


<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/OyMrOMzD/2286-subs-page-march-april-updates-1st-april)

## Changes

* Put back six for six on the weekly landing page
* Update copy to reference six for six in the featured product hero on the subs landing page

## Screenshots
**/subscribe/weekly**

here are a couple examples: (this is not new functionality; it is just reinstating https://github.com/guardian/support-frontend/pull/1510/files)

|  eu  |  us |
|---|---|
|  <img src="https://user-images.githubusercontent.com/3072877/55071064-89887180-507f-11e9-8634-7fd3c5b7ae57.png" height=300> | <img src="https://user-images.githubusercontent.com/3072877/55071163-bf2d5a80-507f-11e9-8c59-f37efed96665.png" height=300>  |  

**(uk|us|au|eu|int|nz|ca)/subscribe**

| region | img | 
|---|---|
| uk | <img src="https://user-images.githubusercontent.com/3072877/55071418-79bd5d00-5080-11e9-834b-93c8d3c8dc28.png" height=300> | 
| us | <img src="https://user-images.githubusercontent.com/3072877/55071473-9b1e4900-5080-11e9-90d1-5277a57ecf3a.png" height=300>  |
| eu | <img src="https://user-images.githubusercontent.com/3072877/55071524-cbfe7e00-5080-11e9-8210-95833d7df5c7.png" height=300>  |
| au | <img src="https://user-images.githubusercontent.com/3072877/55071490-a83b3800-5080-11e9-9af4-68e450a771a3.png" height=300>  | 
| nz | <img src="https://user-images.githubusercontent.com/3072877/55071600-f3ede180-5080-11e9-8c9e-378ba334c6bf.png" height=300>  | 
| ca |  <img src="https://user-images.githubusercontent.com/3072877/55071609-f7816880-5080-11e9-9360-ce90a732d0a3.png" height=300>  | 
| int | <img src="https://user-images.githubusercontent.com/3072877/55071611-f8b29580-5080-11e9-9fab-a2c86414fd01.png" height=300>  |  



