### PR TITLE
Global helper

### DIFF
--- a/support-frontend/assets/helpers/checkouts.js
+++ b/support-frontend/assets/helpers/checkouts.js
@@ -11,7 +11,7 @@ import {
   toContributionTypeOrElse,
 } from 'helpers/contributions';
 import * as storage from 'helpers/storage';
-import { type Switches, type SwitchObject } from 'helpers/settings';
+import { type Switches } from 'helpers/settings';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { Currency, IsoCurrency, SpokenCurrency } from 'helpers/internationalisation/currency';
 import { currencies, spokenCurrencies } from 'helpers/internationalisation/currency';
@@ -20,6 +20,7 @@ import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { PaymentMethod } from 'helpers/paymentMethods';
 import { DirectDebit, PayPal, Stripe } from 'helpers/paymentMethods';
 import { ExistingCard, ExistingDirectDebit } from './paymentMethods';
+import { isSwitchOn } from 'helpers/globals';
 
 
 // ----- Types ----- //
@@ -98,18 +99,15 @@ function getPaymentMethods(contributionType: ContributionType, countryId: IsoCou
     : [Stripe, PayPal];
 }
 
-const switchIsOn =
-  (switches: SwitchObject, switchName: PaymentMethodSwitch | null) =>
-    switchName && switches[switchName] && switches[switchName] === 'On';
-
 function getValidPaymentMethods(
   contributionType: ContributionType,
   allSwitches: Switches,
   countryId: IsoCountry,
 ): PaymentMethod[] {
-  const switches = (contributionType === 'ONE_OFF') ? allSwitches.oneOffPaymentMethods : allSwitches.recurringPaymentMethods;
+  const switchKey = (contributionType === 'ONE_OFF') ? 'oneOffPaymentMethods' : 'recurringPaymentMethods';
   return getPaymentMethods(contributionType, countryId)
-    .filter(paymentMethod => switchIsOn(switches, toPaymentMethodSwitchNaming(paymentMethod)));
+    .filter(paymentMethod =>
+      isSwitchOn(`${switchKey}.${toPaymentMethodSwitchNaming(paymentMethod) || '-'}`));
 }
 
 function getPaymentMethodToSelect(
@@ -212,5 +210,4 @@ export {
   getPaymentMethodFromSession,
   getPaymentDescription,
   getPaymentLabel,
-  switchIsOn,
 };

--- a/support-frontend/assets/helpers/globals.js
+++ b/support-frontend/assets/helpers/globals.js
@@ -2,10 +2,17 @@
 import type { ProductPrices } from 'helpers/productPrice/productPrices';
 import { type Settings } from 'helpers/settings';
 
-function getGlobal<T>(key: string): ?T {
-  if (window.guardian && window.guardian[key]) {
-    return window.guardian[key];
+function getGlobal<T>(path: string = ''): ?T {
+
+  const value = path
+    .replace(/\[(.+?)\]/g, '.$1')
+    .split('.')
+    .reduce((o, key: any) => o && o[key], window.guardian);
+
+  if (value) {
+    return ((value: any): T);
   }
+
   return null;
 }
 
@@ -23,7 +30,6 @@ const getSettings = (): Settings => getGlobal('settings') || {
       ONE_OFF: [],
       MONTHLY: [],
       ANNUAL: [],
-
     },
     EURCountries: {
       ONE_OFF: [],
@@ -55,14 +61,18 @@ const getSettings = (): Settings => getGlobal('settings') || {
 
 const getProductPrices = (): ?ProductPrices => getGlobal('productPrices');
 
+const isSwitchOn = (switchName: string): boolean => {
+  const sw = getGlobal(`settings.switches.${switchName}`);
+  return !!(sw && sw === 'On');
+};
+
 const isTestSwitchedOn = (testName: string): boolean => {
-  const settings = getGlobal('settings');
-  if (settings && settings.switches.experiments && settings.switches.experiments[testName]) {
-    const test = settings.switches.experiments[testName];
+  const test = getGlobal(`settings.switches.experiments${testName}`);
+  if (test) {
     return !!(test && test.state && test.state === 'On');
   }
   return false;
 };
 
 
-export { getProductPrices, getGlobal, isTestSwitchedOn, getSettings };
+export { getProductPrices, getGlobal, isTestSwitchedOn, getSettings, isSwitchOn };

--- a/support-frontend/assets/helpers/globals.js
+++ b/support-frontend/assets/helpers/globals.js
@@ -1,5 +1,6 @@
 // @flow
 import type { ProductPrices } from 'helpers/productPrice/productPrices';
+import { type Settings } from 'helpers/settings';
 
 function getGlobal<T>(key: string): ?T {
   if (window.guardian && window.guardian[key]) {
@@ -7,6 +8,13 @@ function getGlobal<T>(key: string): ?T {
   }
   return null;
 }
+
+const getSettings = (): Settings => getGlobal('settings') || {
+  switches: {
+    experiments: {},
+  },
+  amounts: {},
+};
 
 const getProductPrices = (): ?ProductPrices => getGlobal('productPrices');
 
@@ -20,4 +28,4 @@ const isTestSwitchedOn = (testName: string): boolean => {
 };
 
 
-export { getProductPrices, getGlobal, isTestSwitchedOn };
+export { getProductPrices, getGlobal, isTestSwitchedOn, getSettings };

--- a/support-frontend/assets/helpers/globals.js
+++ b/support-frontend/assets/helpers/globals.js
@@ -10,4 +10,16 @@ function getGlobal<T>(key: string): ?T {
 
 const getProductPrices = (): ?ProductPrices => getGlobal('productPrices');
 
-export { getProductPrices, getGlobal };
+
+type ExperimentSwitch = {
+  state: ?string,
+}
+const getExperimentSwitch = (key: string): ExperimentSwitch => {
+  const settings = getGlobal('settings');
+  if (settings && settings.switches.experiments && settings.switches.experiments[key]) {
+    return settings.switches.experiments[key];
+  }
+  return { state: null };
+};
+
+export { getProductPrices, getGlobal, getExperimentSwitch };

--- a/support-frontend/assets/helpers/globals.js
+++ b/support-frontend/assets/helpers/globals.js
@@ -1,0 +1,13 @@
+// @flow
+import type { ProductPrices } from 'helpers/productPrice/productPrices';
+
+function getGlobal<T>(key: string): ?T {
+  if (window.guardian && window.guardian[key]) {
+    return window.guardian[key];
+  }
+  return null;
+}
+
+const getProductPrices = (): ?ProductPrices => getGlobal('productPrices');
+
+export { getProductPrices, getGlobal };

--- a/support-frontend/assets/helpers/globals.js
+++ b/support-frontend/assets/helpers/globals.js
@@ -13,7 +13,44 @@ const getSettings = (): Settings => getGlobal('settings') || {
   switches: {
     experiments: {},
   },
-  amounts: {},
+  amounts: {
+    GBPCountries: {
+      ONE_OFF: [],
+      MONTHLY: [],
+      ANNUAL: [],
+    },
+    UnitedStates: {
+      ONE_OFF: [],
+      MONTHLY: [],
+      ANNUAL: [],
+
+    },
+    EURCountries: {
+      ONE_OFF: [],
+      MONTHLY: [],
+      ANNUAL: [],
+    },
+    AUDCountries: {
+      ONE_OFF: [],
+      MONTHLY: [],
+      ANNUAL: [],
+    },
+    International: {
+      ONE_OFF: [],
+      MONTHLY: [],
+      ANNUAL: [],
+    },
+    NZDCountries: {
+      ONE_OFF: [],
+      MONTHLY: [],
+      ANNUAL: [],
+    },
+    Canada: {
+      ONE_OFF: [],
+      MONTHLY: [],
+      ANNUAL: [],
+    },
+  },
 };
 
 const getProductPrices = (): ?ProductPrices => getGlobal('productPrices');

--- a/support-frontend/assets/helpers/globals.js
+++ b/support-frontend/assets/helpers/globals.js
@@ -10,16 +10,14 @@ function getGlobal<T>(key: string): ?T {
 
 const getProductPrices = (): ?ProductPrices => getGlobal('productPrices');
 
-
-type ExperimentSwitch = {
-  state: ?string,
-}
-const getExperimentSwitch = (key: string): ExperimentSwitch => {
+const isTestSwitchedOn = (testName: string): boolean => {
   const settings = getGlobal('settings');
-  if (settings && settings.switches.experiments && settings.switches.experiments[key]) {
-    return settings.switches.experiments[key];
+  if (settings && settings.switches.experiments && settings.switches.experiments[testName]) {
+    const test = settings.switches.experiments[testName];
+    return !!(test && test.state && test.state === 'On');
   }
-  return { state: null };
+  return false;
 };
 
-export { getProductPrices, getGlobal, getExperimentSwitch };
+
+export { getProductPrices, getGlobal, isTestSwitchedOn };

--- a/support-frontend/assets/helpers/page/page.js
+++ b/support-frontend/assets/helpers/page/page.js
@@ -30,6 +30,7 @@ import {
   trackNewOptimizeExperiment,
 } from 'helpers/tracking/ophanComponentEventTracking';
 import { getTrackingConsent } from '../tracking/thirdPartyTrackingConsent';
+import { getSettings } from 'helpers/globals';
 
 if (process.env.NODE_ENV === 'DEV') {
   import('preact/devtools');
@@ -130,7 +131,7 @@ function init<S, A>(
 ): Store<*, *, *> {
 
   try {
-    const { settings } = window.guardian;
+    const settings = getSettings();
     const countryGroupId: CountryGroupId = detectCountryGroup();
     const countryId: IsoCountry = detectCountry();
     const currencyId: IsoCurrency = detectCurrency(countryGroupId);

--- a/support-frontend/assets/helpers/settings.js
+++ b/support-frontend/assets/helpers/settings.js
@@ -23,9 +23,3 @@ export type Settings = {
   switches: Switches,
   amounts: AmountsRegions,
 };
-
-export function isTestSwitchedOn(settings: Settings, testName: string): boolean {
-  const { experiments } = settings.switches;
-  const test = experiments[testName];
-  return !!(test && test.state && test.state === 'On');
-}

--- a/support-frontend/assets/helpers/subscriptions.js
+++ b/support-frontend/assets/helpers/subscriptions.js
@@ -14,7 +14,7 @@ import {
 import { trackComponentEvents } from './tracking/ophanComponentEventTracking';
 import { gaEvent } from './tracking/googleTagManager';
 import { currencies, detect } from './internationalisation/currency';
-import { getExperimentSwitch } from 'helpers/globals';
+import { isTestSwitchedOn } from 'helpers/globals';
 import type { PaperProductOptions } from 'helpers/productPrice/productOptions';
 
 
@@ -274,14 +274,7 @@ const getNewsstandPrice = (productOption: PaperProductOptions) =>
 
 
 // Paper product
-
-const paperHasDeliveryEnabled = (): boolean => {
-  try {
-    return getExperimentSwitch('paperHomeDeliveryEnabled').state === 'On';
-  } catch {
-    return true;
-  }
-};
+const paperHasDeliveryEnabled = (): boolean => isTestSwitchedOn('paperHomeDeliveryEnabled');
 
 
 // ----- Exports ----- //

--- a/support-frontend/assets/helpers/subscriptions.js
+++ b/support-frontend/assets/helpers/subscriptions.js
@@ -14,6 +14,7 @@ import {
 import { trackComponentEvents } from './tracking/ophanComponentEventTracking';
 import { gaEvent } from './tracking/googleTagManager';
 import { currencies, detect } from './internationalisation/currency';
+import { getExperimentSwitch } from 'helpers/globals';
 import type { PaperProductOptions } from 'helpers/productPrice/productOptions';
 
 
@@ -276,7 +277,7 @@ const getNewsstandPrice = (productOption: PaperProductOptions) =>
 
 const paperHasDeliveryEnabled = (): boolean => {
   try {
-    return window.guardian.settings.switches.experiments.paperHomeDeliveryEnabled.state === 'On';
+    return getExperimentSwitch('paperHomeDeliveryEnabled').state === 'On';
   } catch {
     return true;
   }

--- a/support-frontend/assets/pages/digital-subscription-landing/components/form.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/form.jsx
@@ -92,20 +92,26 @@ const billingPeriods = {
 
 // ----- State/Props Maps ----- //
 
-const mapStateToProps = (state: State): PropTypes<DigitalBillingPeriod> => ({
-  plans: Object.keys(billingPeriods).reduce((ps, k) => ({
-    ...ps,
-    [k]: {
-      title: billingPeriods[k].title,
-      copy: billingPeriods[k].copy(state.page.productPrices, state.common.internationalisation.countryId),
-      offer: billingPeriods[k].offer(state.common.internationalisation.countryId) || null,
-      href: getDigitalCheckout(state.common.internationalisation.countryGroupId, k),
-      onClick: sendTrackingEventsOnClick('subscribe_now_cta', 'DigitalPack', null, k),
-      price: null,
-      saving: null,
-    },
-  }), {}),
-});
+const mapStateToProps = (state: State): PropTypes<DigitalBillingPeriod> => {
+  const { productPrices } = state.page;
+  if (productPrices) {
+    return ({
+      plans: Object.keys(billingPeriods).reduce((ps, k) => ({
+        ...ps,
+        [k]: {
+          title: billingPeriods[k].title,
+          copy: billingPeriods[k].copy(productPrices, state.common.internationalisation.countryId),
+          offer: billingPeriods[k].offer(state.common.internationalisation.countryId) || null,
+          href: getDigitalCheckout(state.common.internationalisation.countryGroupId, k),
+          onClick: sendTrackingEventsOnClick('subscribe_now_cta', 'DigitalPack', null, k),
+          price: null,
+          saving: null,
+        },
+      }), {}),
+    });
+  }
+  return { plans: {} };
+};
 
 // ----- Exports ----- //
 

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLandingReducer.js
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLandingReducer.js
@@ -6,6 +6,7 @@ import { combineReducers } from 'redux';
 import type { CommonState } from 'helpers/page/commonReducer';
 import type { ProductPrices } from 'helpers/productPrice/productPrices';
 import promotionPopUpReducer, { type FindOutMoreState } from './components/promotionPopUpReducer';
+import { getProductPrices } from 'helpers/globals';
 
 export type State = {
   common: CommonState,
@@ -18,11 +19,6 @@ export type State = {
 
 // ----- Export ----- //
 
-
-  const { productPrices } = window.guardian;
-
-  return combineReducers({
-    productPrices: () => productPrices,
 export default () => combineReducers({
   productPrices: getProductPrices,
   promotion: promotionPopUpReducer,

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLandingReducer.js
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLandingReducer.js
@@ -18,12 +18,12 @@ export type State = {
 
 // ----- Export ----- //
 
-export default () => {
 
   const { productPrices } = window.guardian;
 
   return combineReducers({
     productPrices: () => productPrices,
-    promotion: promotionPopUpReducer,
-  });
-};
+export default () => combineReducers({
+  productPrices: getProductPrices,
+  promotion: promotionPopUpReducer,
+});

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -41,10 +41,10 @@ import {
   isFullDetailExistingPaymentMethod,
   mapExistingPaymentMethodToPaymentMethod, sendGetExistingPaymentMethodsRequest,
 } from '../../helpers/existingPaymentMethods/existingPaymentMethods';
-import { switchIsOn } from '../../helpers/checkouts';
 import type { ExistingPaymentMethod } from '../../helpers/existingPaymentMethods/existingPaymentMethods';
 import { setExistingPaymentMethods } from '../../helpers/page/commonActions';
-import {doesUserAppearToBeSignedIn} from "../../helpers/user/user";
+import { doesUserAppearToBeSignedIn } from '../../helpers/user/user';
+import { isSwitchOn } from 'helpers/globals';
 
 // ----- Functions ----- //
 
@@ -128,8 +128,8 @@ function initialisePaymentMethods(state: State, dispatch: Function) {
 
     // initiate fetch of existing payment methods
     const userAppearsLoggedIn = doesUserAppearToBeSignedIn();
-    const existingDirectDebitON = switchIsOn(switches.recurringPaymentMethods, 'existingDirectDebit');
-    const existingCardON = switchIsOn(switches.recurringPaymentMethods, 'existingCard');
+    const existingDirectDebitON = isSwitchOn('recurringPaymentMethods.existingDirectDebit');
+    const existingCardON = isSwitchOn('recurringPaymentMethods.existingCard');
     const existingPaymentsEnabledViaUrlParam = getQueryParameter('displayExistingPaymentOptions') === 'true';
     if (userAppearsLoggedIn && (existingCardON || existingDirectDebitON) && existingPaymentsEnabledViaUrlParam) {
       sendGetExistingPaymentMethodsRequest(

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/form.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/form.jsx
@@ -115,7 +115,7 @@ const getPlans = (
 
 // ----- State/Props Maps ----- //
 const mapStateToProps = (state: State): PropTypes<PaperProductOptions> => ({
-  plans: getPlans(state.page.tab, state.page.productPrices, state.common),
+  plans: state.page.productPrices ? getPlans(state.page.tab, state.page.productPrices, state.common) : {},
 });
 
 // ----- Exports ----- //

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPageReducer.js
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPageReducer.js
@@ -9,6 +9,7 @@ import { type TabActions } from './paperSubscriptionLandingPageActions';
 import { Collection, type PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import type { ProductPrices } from 'helpers/productPrice/productPrices';
 import { paperHasDeliveryEnabled } from 'helpers/subscriptions';
+import { getProductPrices } from 'helpers/globals';
 
 
 // ----- Types ----- //
@@ -18,7 +19,7 @@ export type ActiveTabState = PaperFulfilmentOptions;
 export type State = {
   common: CommonState,
   page: {
-    productPrices: ProductPrices,
+    productPrices: ?ProductPrices,
     tab: ActiveTabState,
   }
 };
@@ -40,12 +41,7 @@ const getTabsReducer = (initialTab: PaperFulfilmentOptions) =>
 
 // ----- Exports ----- //
 
-export default (initialTab: PaperFulfilmentOptions) => {
-
-  const { productPrices } = window.guardian;
-
-  return combineReducers({
-    productPrices: () => productPrices,
-    tab: getTabsReducer(paperHasDeliveryEnabled() ? initialTab : Collection),
-  });
-};
+export default (initialTab: PaperFulfilmentOptions) => combineReducers({
+  productPrices: getProductPrices,
+  tab: getTabsReducer(paperHasDeliveryEnabled() ? initialTab : Collection),
+});


### PR DESCRIPTION
## Why are you doing this?
Adds a new set of helpers (copied from [gu.com](https://github.com/guardian/frontend/blob/master/static/src/javascripts/lib/config.js)) to load globals in a nullable and type-safer way. This allows pages to be rendered without having access to the `window.guardian` object.

This PR doesn't replace all calls or makes everything nullable (Namely, conbtribution amounts are giving me trouble when trying to render contributions without window.guardian) but it's a start.