### PR TITLE
 Add monthly contribution type back 

### DIFF
--- a/support-frontend/assets/helpers/checkouts.js
+++ b/support-frontend/assets/helpers/checkouts.js
@@ -56,16 +56,15 @@ function getValidContributionTypesFromUrlOrElse(fallback: ContributionType[]): C
 function getValidContributionTypes(countryGroupId: CountryGroupId): ContributionType[] {
 
   const defaultContributionTypes = ['ONE_OFF', 'MONTHLY', 'ANNUAL'];
-  const contributionTypesNoMonthly = ['ONE_OFF', 'ANNUAL'];
 
   const mappings = {
     GBPCountries: defaultContributionTypes,
     UnitedStates: defaultContributionTypes,
-    AUDCountries: contributionTypesNoMonthly,
-    EURCountries: contributionTypesNoMonthly,
-    International: contributionTypesNoMonthly,
-    NZDCountries: contributionTypesNoMonthly,
-    Canada: contributionTypesNoMonthly,
+    AUDCountries: defaultContributionTypes,
+    EURCountries: defaultContributionTypes,
+    International: defaultContributionTypes,
+    NZDCountries: defaultContributionTypes,
+    Canada: defaultContributionTypes,
   };
   return getValidContributionTypesFromUrlOrElse(mappings[countryGroupId]);
 }

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -56,7 +56,7 @@ function getInitialPaymentMethod(
 }
 
 function getInitialContributionType(countryGroupId: CountryGroupId): ContributionType {
-  const contributionType = getContributionTypeFromUrlOrElse(getContributionTypeFromSessionOrElse('ANNUAL'));
+  const contributionType = getContributionTypeFromUrlOrElse(getContributionTypeFromSessionOrElse('MONTHLY'));
   return (
     // make sure we don't select a contribution type which isn't on the page
     getValidContributionTypes(countryGroupId).includes(contributionType)


### PR DESCRIPTION
## Why are you doing this?
We temporarily removed the monthly option for some regions - this adds it back.
Monthly will also now be the default for all regions.

