### PR TITLE
acquisition-event-producer 4.0.18 => 4.0.19

### DIFF
--- a/support-models/build.sbt
+++ b/support-models/build.sbt
@@ -5,7 +5,7 @@ name := "support-models"
 description := "Scala library to provide shared step-function models to Guardian Support projects."
 
 libraryDependencies ++= Seq(
-  "com.gu" %% "acquisition-event-producer-play26" % "4.0.18",
+  "com.gu" %% "acquisition-event-producer-play26" % "4.0.19",
   "org.typelevel" %% "cats-core" % catsVersion,
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,


### PR DESCRIPTION
To release this Thrift enum update: https://github.com/guardian/acquisition-event-producer/pull/48

@johnduffell am I right in thinking this the only version bump needed to ensure that this makes its way into support-workers?