### PR TITLE
removed vertical mobile tabs test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -5,7 +5,6 @@ import type { Tests } from './abtest';
 
 
 export type EditorialiseAmountsVariant = 'control' | 'dailyBreakdownAnnual' | 'weeklyBreakdownAnnual' | 'notintest';
-export type VerticalContributionsTabsVariant = 'control' | 'verticalTabsMobile' | 'notintest';
 
 export const tests: Tests = {
 
@@ -31,27 +30,6 @@ export const tests: Tests = {
     isActive: true,
     independent: true,
     seed: 3,
-  },
-
-  verticalContributionsTabs: {
-    type: 'OTHER',
-    variants: [
-      {
-        id: 'control',
-      },
-      {
-        id: 'verticalTabsMobile',
-      },
-    ],
-    audiences: {
-      ALL: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: true,
-    independent: true,
-    seed: 4,
   },
 };
 

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionTypeTabs.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionTypeTabs.jsx
@@ -13,7 +13,6 @@ import {
 } from 'helpers/checkouts';
 
 import { trackComponentClick } from 'helpers/tracking/ophanComponentEventTracking';
-import type { VerticalContributionsTabsVariant } from 'helpers/abTests/abtestDefinitions';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { Switches } from 'helpers/settings';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
@@ -28,7 +27,6 @@ type PropTypes = {|
   countryGroupId: CountryGroupId,
   switches: Switches,
   onSelectContributionType: (ContributionType, Switches, IsoCountry, CountryGroupId) => void,
-  verticalContributionsTabsVariant: VerticalContributionsTabsVariant
 |};
 
 const mapStateToProps = (state: State) => ({
@@ -36,7 +34,6 @@ const mapStateToProps = (state: State) => ({
   contributionType: state.page.form.contributionType,
   countryId: state.common.internationalisation.countryId,
   switches: state.common.settings.switches,
-  verticalContributionsTabsVariant: state.common.abParticipations.verticalContributionsTabs,
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -55,7 +52,6 @@ const mapDispatchToProps = (dispatch: Function) => ({
 // ----- Render ----- //
 
 function ContributionTypeTabs(props: PropTypes) {
-  const verticalTabsModifier = props.verticalContributionsTabsVariant === 'verticalTabsMobile' ? 'mobile-vertical-tabs' : '';
   const contributionTypes = getValidContributionTypes(props.countryGroupId);
 
   if (contributionTypes.length === 1 && contributionTypes[0] === 'ONE_OFF') {
@@ -63,7 +59,7 @@ function ContributionTypeTabs(props: PropTypes) {
   }
 
   return (
-    <fieldset className={classNameWithModifiers('form__radio-group', ['tabs', 'contribution-type', verticalTabsModifier])}>
+    <fieldset className={classNameWithModifiers('form__radio-group', ['tabs', 'contribution-type'])}>
       <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>Recurrence</legend>
       <ul className="form__radio-group-list form__radio-group-list--border">
         {contributionTypes.map((contributionType: ContributionType) => (

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -1199,32 +1199,3 @@ form {
 .editorialise-amounts-test-copy:empty {
   display: none;
 }
-
-// Vertical contributions tabs test
-.form__radio-group--mobile-vertical-tabs {
-  .form__radio-group-list {
-    flex-flow: column-reverse nowrap;
-    text-align: center;
-
-    @include mq($from: mobileLandscape) {
-      flex-flow: row nowrap;
-      text-align: left;
-    }
-  }
-
-  .form__radio-group-list--border {
-    border-bottom: none;
-
-    @include mq($from: mobileLandscape) {
-      border-bottom: 1px solid gu-colour(neutral-86);
-    }
-  }
-
-  .form__radio-group-list--border .form__radio-group-item {
-    border-bottom: 1px solid gu-colour(highlight-main);
-
-    @include mq($from: mobileLandscape) {
-      border-bottom: none;
-    }
-  }
-}


### PR DESCRIPTION
## Why are you doing this?

Vertical mobile tabs test variant was not performing better than control, so UX decided we should remove before the What If? work. This undoes this PR [here](https://github.com/guardian/support-frontend/pull/1697/)

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Changes

* removed vertical mobile tabs test JS and styles
