### PR TITLE
Cancel keyframe animation in motion query

### DIFF
--- a/support-frontend/assets/pages/showcase/components/hero.scss
+++ b/support-frontend/assets/pages/showcase/components/hero.scss
@@ -106,6 +106,7 @@
     &:nth-of-type(4) {
       opacity: 1 !important;
       transform: translateX(0) !important;
+      animation: unset !important;
     }
   }
 


### PR DESCRIPTION
## Why are you doing this?

I forgot that we moved the animation form a transition to a keyframe based approach. This PR cancels out the keyframe animation if _reduced motion_ is selected.  

## Screenshots

