### PR TITLE
Correct the check for discounted price

### DIFF
--- a/support-frontend/assets/helpers/productPrice/productPrices.js
+++ b/support-frontend/assets/helpers/productPrice/productPrices.js
@@ -61,7 +61,7 @@ function getCurrency(country: IsoCountry): IsoCurrency {
   return currency;
 }
 
-function hasPromotion(promotion: ?Promotion) { return promotion && promotion.discountedPrice !== null; }
+function hasPromotion(promotion: ?Promotion) { return promotion && promotion.discountedPrice }
 
 function applyPromotion(price: Price, promotion: ?Promotion) {
   if (promotion && hasPromotion(promotion)) {


### PR DESCRIPTION
## Why are you doing this?
The `hasPromotion` function used by the `PriceLabel` component was only checking for null when trying to determine whether a promo code is a discount. Actually it should have been checking for `undefined`.