### PR TITLE
Remove money back guarantee messaging from checkouts

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-checkout/components-checkout/checkoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components-checkout/checkoutForm.jsx
@@ -245,11 +245,6 @@ function CheckoutForm(props: PropTypes) {
           <FormSection>
             <Text>
               <p>
-                <strong>Money Back Guarantee.</strong>
-                If you wish to cancel your subscription, we will send you
-                a refund of the unexpired part of your subscription.
-              </p>
-              <p>
                 <strong>Cancel any time you want.</strong>
                 There is no set time on your agreement so you can stop
                 your subscription anytime


### PR DESCRIPTION
## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->Retention have highlighted that the money back guarantee messaging we have in the checkout sisn't true in all cases, so I've removed it.

## Changes

* Remove "Money Back Guarantee. If you wish to cancel your subscription, we will send you a refund of the unexpired part of your subscription."


## Screenshots
Current (DP example): 
![image](https://user-images.githubusercontent.com/45856485/55481833-1badee00-561b-11e9-890f-58877ec34b5c.png)

New (DP example): 
![image](https://user-images.githubusercontent.com/45856485/55481854-236d9280-561b-11e9-93fc-b68d9eede175.png)


