### PR TITLE
Catalog warnings

### DIFF
--- a/support-frontend/app/wiring/Controllers.scala
+++ b/support-frontend/app/wiring/Controllers.scala
@@ -2,6 +2,7 @@ package wiring
 
 import assets.RefPath
 import com.gu.aws.AwsCloudWatchMetricPut
+import com.gu.aws.AwsCloudWatchMetricPut.{client, setupWarningRequest}
 import controllers.{CSSElementForStage, _}
 import play.api.BuiltInComponentsFromContext
 
@@ -147,7 +148,7 @@ trait Controllers {
     controllerComponents,
     actionRefiners,
     appConfig.guardianDomain,
-    () => AwsCloudWatchMetricPut(AwsCloudWatchMetricPut.client)(AwsCloudWatchMetricPut.setupWarningRequest(appConfig.stage))
+    () => AwsCloudWatchMetricPut(client)(setupWarningRequest(appConfig.stage))
   )
 
   lazy val directDebitController = new DirectDebit(

--- a/support-frontend/app/wiring/Controllers.scala
+++ b/support-frontend/app/wiring/Controllers.scala
@@ -1,9 +1,9 @@
 package wiring
 
 import assets.RefPath
+import com.gu.aws.AwsCloudWatchMetricPut
 import controllers.{CSSElementForStage, _}
 import play.api.BuiltInComponentsFromContext
-import services.aws.AwsCloudwatchMetricPut
 
 trait Controllers {
 
@@ -147,7 +147,7 @@ trait Controllers {
     controllerComponents,
     actionRefiners,
     appConfig.guardianDomain,
-    () => AwsCloudwatchMetricPut(AwsCloudwatchMetricPut.cloudWatchEffect)(AwsCloudwatchMetricPut.setupWarningRequest(appConfig.stage))
+    () => AwsCloudWatchMetricPut(AwsCloudWatchMetricPut.client)(AwsCloudWatchMetricPut.setupWarningRequest(appConfig.stage))
   )
 
   lazy val directDebitController = new DirectDebit(

--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -20,7 +20,6 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-stepfunctions" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-sts" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-s3" % awsClientVersion,
-  "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion,
   "org.typelevel" %% "cats-core" % "1.0.1",
   "com.dripower" %% "play-circe" % "2609.1",
   "com.gu" %% "fezziwig" % "0.8",

--- a/support-frontend/cloud-formation/cfn.yaml
+++ b/support-frontend/cloud-formation/cfn.yaml
@@ -217,8 +217,6 @@ Resources:
       Name: !Sub ${Stack}-${Stage}-${App}
       Port: 9000
       Protocol: HTTP
-      VpcId:
-        Ref: VpcId
       HealthCheckIntervalSeconds: 10
       HealthCheckPath: /healthcheck
       HealthCheckPort: 9000
@@ -318,6 +316,24 @@ Resources:
     DependsOn:
     - TargetGroup
     - ElasticLoadBalancer
+
+  CatalogLoadingFailureAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: CreateProdResources
+    Properties:
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
+      AlarmName: Support Frontend Catalog Load Failure
+      MetricName: CatalogLoadingFailure
+      Namespace: support-frontend
+      Dimensions:
+        - Name: Environment
+          Value: PROD
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Threshold: 1
+      Period: 60
+      EvaluationPeriods: 1
+      Statistic: Average
 
   StateMachineUnavailableMetric:
     Type: "AWS::Logs::MetricFilter"

--- a/support-frontend/cloud-formation/cfn.yaml
+++ b/support-frontend/cloud-formation/cfn.yaml
@@ -324,6 +324,7 @@ Resources:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
       AlarmName: Support Frontend Catalog Load Failure
+      AlarmDescription: Fires an alarm if we fail to load the Zuora catalog pricing information from S3
       MetricName: CatalogLoadingFailure
       Namespace: support-frontend
       Dimensions:

--- a/support-services/build.sbt
+++ b/support-services/build.sbt
@@ -7,6 +7,7 @@ description := "Scala library to provide shared services to Guardian Support pro
 libraryDependencies ++= Seq(
   "com.typesafe.scala-logging" %% "scala-logging" % "3.7.2",
   "com.amazonaws" % "aws-java-sdk-dynamodb" % awsClientVersion,
+  "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion,
   "org.typelevel" %% "cats-core" % catsVersion,
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,

--- a/support-services/src/main/scala/com/gu/aws/AwsCloudWatchMetricPut.scala
+++ b/support-services/src/main/scala/com/gu/aws/AwsCloudWatchMetricPut.scala
@@ -1,19 +1,18 @@
-package services.aws
+package com.gu.aws
 
 import com.amazonaws.regions.Regions
-import com.amazonaws.services.cloudwatch.model._
+import com.amazonaws.services.cloudwatch.model.{Dimension, MetricDatum, PutMetricDataRequest, StandardUnit}
 import com.amazonaws.services.cloudwatch.{AmazonCloudWatch, AmazonCloudWatchClientBuilder}
 import com.gu.support.config.Stage
-import services.aws
 
 import scala.util.Try
 
-object AwsCloudwatchMetricPut {
-  val cloudWatchEffect: AmazonCloudWatch =
+object AwsCloudWatchMetricPut {
+  val client: AmazonCloudWatch =
     AmazonCloudWatchClientBuilder
       .standard()
       .withRegion(Regions.EU_WEST_1)
-      .withCredentials(aws.CredentialsProvider)
+      .withCredentials(CredentialsProvider)
       .build()
 
   case class MetricNamespace(value: String) extends AnyVal
@@ -27,7 +26,7 @@ object AwsCloudwatchMetricPut {
       dimensions: Map[MetricDimensionName, MetricDimensionValue]
   )
 
-  def apply(s3Client: AmazonCloudWatch)(request: MetricRequest): Try[Unit] = {
+  def apply(client: AmazonCloudWatch)(request: MetricRequest): Try[Unit] = {
 
     val putMetricDataRequest = new PutMetricDataRequest
     putMetricDataRequest.setNamespace(request.namespace.value)
@@ -46,7 +45,7 @@ object AwsCloudwatchMetricPut {
     metricDatum1.setValue(1.00)
     metricDatum1.setUnit(StandardUnit.Count)
     putMetricDataRequest.getMetricData.add(metricDatum1)
-    Try(s3Client.putMetricData(putMetricDataRequest)).map(_ => ())
+    Try(client.putMetricData(putMetricDataRequest)).map(_ => ())
   }
 
   def setupWarningRequest(stage: Stage): MetricRequest = {

--- a/support-services/src/main/scala/com/gu/aws/AwsCloudWatchMetricPut.scala
+++ b/support-services/src/main/scala/com/gu/aws/AwsCloudWatchMetricPut.scala
@@ -4,11 +4,10 @@ import com.amazonaws.regions.Regions
 import com.amazonaws.services.cloudwatch.model.{Dimension, MetricDatum, PutMetricDataRequest, StandardUnit}
 import com.amazonaws.services.cloudwatch.{AmazonCloudWatch, AmazonCloudWatchClientBuilder}
 import com.gu.support.config.{Stage, TouchPointEnvironment}
-import com.typesafe.scalalogging.LazyLogging
 
 import scala.util.Try
 
-object AwsCloudWatchMetricPut  extends LazyLogging {
+object AwsCloudWatchMetricPut {
   val client: AmazonCloudWatch =
     AmazonCloudWatchClientBuilder
       .standard()

--- a/support-services/src/main/scala/com/gu/support/catalog/CatalogService.scala
+++ b/support-services/src/main/scala/com/gu/support/catalog/CatalogService.scala
@@ -1,8 +1,10 @@
 package com.gu.support.catalog
 
+import com.gu.aws.AwsCloudWatchMetricPut
+import com.gu.aws.AwsCloudWatchMetricPut.{catalogFailureRequest, client}
 import com.gu.i18n.Currency
 import com.gu.support.catalog.FulfilmentOptions._
-import com.gu.support.config.TouchPointEnvironment
+import com.gu.support.config.{Stages, TouchPointEnvironment}
 import com.gu.support.workers.BillingPeriod
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.generic.auto._
@@ -19,6 +21,7 @@ class CatalogService(val environment: TouchPointEnvironment, jsonProvider: Catal
       attempt.fold(
         err => {
           logger.error(s"Failed to load the catalog, error was: $err")
+          AwsCloudWatchMetricPut(client)(catalogFailureRequest(environment))
           None
         },
         c => {

--- a/support-services/src/test/scala/com/gu/aws/AwsCloudWatchMetricPutSpec.scala
+++ b/support-services/src/test/scala/com/gu/aws/AwsCloudWatchMetricPutSpec.scala
@@ -1,0 +1,18 @@
+package com.gu.aws
+
+import com.gu.aws.AwsCloudWatchMetricPut.{catalogFailureRequest, client}
+import com.gu.support.config.TouchPointEnvironments
+import com.gu.test.tags.annotations.IntegrationTest
+import org.scalatest.{AsyncFlatSpec, Matchers}
+
+@IntegrationTest
+class AwsCloudWatchMetricPutSpec extends AsyncFlatSpec with Matchers {
+
+  "CatalogFailures" should "be logged to CloudWatch" in {
+    AwsCloudWatchMetricPut(client)(catalogFailureRequest(TouchPointEnvironments.SANDBOX))
+      .fold(
+        err => fail(err),
+        _ => succeed
+      )
+  }
+}


### PR DESCRIPTION
## Why are you doing this?

If the Zuora catalog fails to load on app start this is a big problem for subs because pricing information will be unavailable, this PR adds a CloudWatch alarm so that we will get notified if that happens.

[**Trello Card**](https://trello.com/c/RLwKIy8d/2218-handle-catalog-load-failures-gracefully)

## Changes

* Send an event to CloudWatch to record catalog load failures in PROD
* Add a CloudWatch alarm to fire on failure

