### PR TITLE
Make the text on the DD payment button configurable

### DIFF
--- a/support-frontend/assets/components/directDebit/directDebitForm/directDebitForm.jsx
+++ b/support-frontend/assets/components/directDebit/directDebitForm/directDebitForm.jsx
@@ -32,6 +32,7 @@ import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRev
 // ---- Types ----- //
 
 type PropTypes = {|
+  buttonText: string,
   onPaymentAuthorisation: PaymentAuthorisation => void,
   isDDGuaranteeOpen: boolean,
   sortCodeArray: Array<string>,
@@ -137,6 +138,7 @@ const DirectDebitForm = (props: PropTypes) => (
     />
 
     <PaymentButton
+      buttonText={props.buttonText}
       phase={props.phase}
       onPayClick={() => props.payDirectDebitClicked()}
       onEditClick={() => props.editDirectDebitClicked()}
@@ -273,6 +275,7 @@ function ConfirmationInput(props: {phase: Phase, checked: boolean, onChange: Fun
 }
 
 function PaymentButton(props: {
+  buttonText: string,
   phase: Phase,
   onPayClick: Function,
   onEditClick: Function,
@@ -286,7 +289,7 @@ function PaymentButton(props: {
       >
         <SvgDirectDebitSymbol />
         <span className="component-direct-debit-form__cta-text">
-          Contribute with Direct Debit
+          {props.buttonText}
         </span>
         <SvgArrowRightStraight />
       </button>

--- a/support-frontend/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.jsx
+++ b/support-frontend/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.jsx
@@ -20,6 +20,7 @@ import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRev
 // ---- Types ----- //
 
 type PropTypes = {|
+  buttonText: string,
   onPaymentAuthorisation: PaymentAuthorisation => void,
   isPopUpOpen: boolean,
   closeDirectDebitPopUp: () => void,
@@ -70,7 +71,7 @@ const DirectDebitPopUpForm = (props: PropTypes) => {
               <SvgCross />
             </span>
           </button>
-          <DirectDebitForm onPaymentAuthorisation={props.onPaymentAuthorisation} />
+          <DirectDebitForm buttonText={props.buttonText} onPaymentAuthorisation={props.onPaymentAuthorisation} />
         </div>
       </div>
     );

--- a/support-frontend/assets/components/paymentButtons/directDebitPopUpButton/directDebitPopUpButton.jsx
+++ b/support-frontend/assets/components/paymentButtons/directDebitPopUpButton/directDebitPopUpButton.jsx
@@ -75,7 +75,9 @@ function ButtonAndForm(props: PropTypes) {
           canOpen={props.canOpen}
           whenUnableToOpen={props.whenUnableToOpen}
         />
-        <DirectDebitPopUpForm onPaymentAuthorisation={props.onPaymentAuthorisation} />
+        <DirectDebitPopUpForm
+          buttonText={"Contribute with Direct Debit"}
+          onPaymentAuthorisation={props.onPaymentAuthorisation} />
       </div>
     );
   }

--- a/support-frontend/assets/components/subscriptionCheckouts/paymentMethodSelector.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/paymentMethodSelector.jsx
@@ -59,6 +59,7 @@ function PaymentMethodSelector(props: PropTypes) {
         }
       </Rows>
       <DirectDebitPopUpForm
+        buttonText={"Subscribe with Direct Debit"}
         onPaymentAuthorisation={(pa: PaymentAuthorisation) => {
           props.onPaymentAuthorised(pa);
         }}

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
@@ -233,6 +233,7 @@ function ContributionFormContainer(props: PropTypes) {
           }
         </div>
         <DirectDebitPopUpForm
+          buttonText={"Contribute with Direct Debit"}
           onPaymentAuthorisation={onPaymentAuthorisation}
         />
       </div>

--- a/support-frontend/assets/pages/paper-subscription-checkout/components-checkout/checkoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components-checkout/checkoutForm.jsx
@@ -237,6 +237,7 @@ function CheckoutForm(props: PropTypes) {
           <FormSection>
             <Button aria-label={null} type="submit">Continue to payment</Button>
             <DirectDebitPopUpForm
+              buttonText={"Subscribe with Direct Debit"}
               onPaymentAuthorisation={(pa: PaymentAuthorisation) => {
                 props.onPaymentAuthorised(pa);
               }}


### PR DESCRIPTION
## Why are you doing this?

Previously the payment button on the Direct Debit pop up form was hard coded to say 'Contribute with Direct Debit' even for subscriptions checkouts. This PR makes the text configurable and sets it to 'Subscribe with Direct Debit' for subs checkouts.

[**Trello Card**](https://trello.com/c/9SlcwuMT/2328-update-dd-cta-wording-and-fix-close-button-direct-debit-pop-up-on-new-checkouts)

## Before
![Screenshot 2019-04-09 at 16 03 15](https://user-images.githubusercontent.com/181371/55811722-7646be80-5ae1-11e9-972a-f7db6fb276d3.png)
## After
![Screenshot 2019-04-09 at 16 03 36](https://user-images.githubusercontent.com/181371/55811724-7646be80-5ae1-11e9-9ab2-01ee72953c50.png)


