### PR TITLE
Remove duplication in checkout forms

### DIFF
--- a/support-frontend/assets/components/paymentButtons/directDebitPopUpButton/directDebitPopUpButton.jsx
+++ b/support-frontend/assets/components/paymentButtons/directDebitPopUpButton/directDebitPopUpButton.jsx
@@ -76,8 +76,9 @@ function ButtonAndForm(props: PropTypes) {
           whenUnableToOpen={props.whenUnableToOpen}
         />
         <DirectDebitPopUpForm
-          buttonText={"Contribute with Direct Debit"}
-          onPaymentAuthorisation={props.onPaymentAuthorisation} />
+          buttonText="Contribute with Direct Debit"
+          onPaymentAuthorisation={props.onPaymentAuthorisation}
+        />
       </div>
     );
   }

--- a/support-frontend/assets/components/subscriptionCheckouts/cancellationSection.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/cancellationSection.jsx
@@ -1,0 +1,17 @@
+// @flow
+import React from 'react';
+import { FormSection } from 'components/checkoutForm/checkoutForm';
+import Text from 'components/text/text';
+
+export default function CancellationSection() {
+  return (
+    <FormSection>
+      <Text>
+        <p>
+          <strong>Cancel any time you want.</strong>
+          There is no set time on your agreement so you can stop
+          your subscription anytime
+        </p>
+      </Text>
+    </FormSection>);
+}

--- a/support-frontend/assets/components/subscriptionCheckouts/paymentMethodSelector.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/paymentMethodSelector.jsx
@@ -7,28 +7,48 @@ import { RadioInput } from 'components/forms/customFields/radioInput';
 import Rows from 'components/base/rows';
 import DirectDebitPopUpForm from 'components/directDebit/directDebitPopUpForm/directDebitPopUpForm';
 import { type Option } from 'helpers/types/option';
-import type { OptimizeExperiment } from 'helpers/optimize/optimize';
+import type { OptimizeExperiments } from 'helpers/optimize/optimize';
 import type { PaymentMethod } from 'helpers/paymentMethods';
 import { DirectDebit, PayPal, Stripe } from 'helpers/paymentMethods';
 import SvgDirectDebitSymbol from 'components/svgs/directDebitSymbol';
 import SvgNewCreditCard from 'components/svgs/newCreditCard';
 import SvgPayPal from 'components/svgs/paypal';
+import { FormSection } from 'components/checkoutForm/checkoutForm';
+import { getQueryParameter } from 'helpers/url';
+import GeneralErrorMessage from 'components/generalErrorMessage/generalErrorMessage';
+import type { ErrorReason } from 'helpers/errorReasons';
 
 type PropTypes = {|
   countrySupportsDirectDebit: boolean,
   paymentMethod: Option<PaymentMethod>,
   onPaymentAuthorised: Function,
   setPaymentMethod: Function,
-  payPalEnabled: OptimizeExperiment | boolean,
-  multiplePaymentMethodsEnabled: OptimizeExperiment | boolean,
+  submissionError: ErrorReason | null,
+  optimizeExperiments: ?OptimizeExperiments,
 |}
 
 function PaymentMethodSelector(props: PropTypes) {
+  const errorHeading = props.submissionError === 'personal_details_incorrect' ? 'Failed to Create Subscription' :
+    'Payment Attempt Failed';
+  const errorState = props.submissionError ?
+    <GeneralErrorMessage errorReason={props.submissionError} errorHeading={errorHeading} /> :
+    null;
+
+  const isPayPalEnabled = (optimizeExperiments: ?OptimizeExperiments) => {
+    const PayPalExperimentId = '36Fk0f-QTtqmMqRVWDtBVg';
+    const enabledByTest = optimizeExperiments &&
+      optimizeExperiments.find(exp => exp.id === PayPalExperimentId && exp.variant === '1');
+    const enabledByQueryString = getQueryParameter('payPal') === 'true';
+    return enabledByTest || enabledByQueryString;
+  };
+
+  const payPalEnabled = isPayPalEnabled(props.optimizeExperiments);
+  const multiplePaymentMethodsEnabled = payPalEnabled || props.countrySupportsDirectDebit;
 
   return (
-    <>
+    <FormSection title={multiplePaymentMethodsEnabled ? 'How would you like to pay?' : null}>
       <Rows gap="large">
-        {props.multiplePaymentMethodsEnabled &&
+        {multiplePaymentMethodsEnabled &&
         <div>
           <Fieldset legend="How would you like to pay?">
             {props.countrySupportsDirectDebit &&
@@ -46,7 +66,7 @@ function PaymentMethodSelector(props: PropTypes) {
               checked={props.paymentMethod === Stripe}
               onChange={() => props.setPaymentMethod(Stripe)}
             />
-            {props.payPalEnabled &&
+            {payPalEnabled &&
             <RadioInput
               image={<SvgPayPal />}
               text="PayPal"
@@ -57,14 +77,15 @@ function PaymentMethodSelector(props: PropTypes) {
           </Fieldset>
         </div>
         }
+        {errorState}
       </Rows>
       <DirectDebitPopUpForm
-        buttonText={"Subscribe with Direct Debit"}
+        buttonText="Subscribe with Direct Debit"
         onPaymentAuthorisation={(pa: PaymentAuthorisation) => {
           props.onPaymentAuthorised(pa);
         }}
       />
-    </>
+    </FormSection>
   );
 }
 

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -46,8 +46,8 @@ import {
   type State,
   submitForm,
 } from '../digitalSubscriptionCheckoutReducer';
-import type { FormField as PersonalDetailsFormField } from '../../../components/subscriptionCheckouts/personalDetails';
-import PersonalDetails from '../../../components/subscriptionCheckouts/personalDetails';
+import type { FormField as PersonalDetailsFormField } from 'components/subscriptionCheckouts/personalDetails';
+import PersonalDetails from 'components/subscriptionCheckouts/personalDetails';
 import CancellationSection from 'components/subscriptionCheckouts/cancellationSection';
 
 // ----- Types ----- //

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
@@ -233,7 +233,7 @@ function ContributionFormContainer(props: PropTypes) {
           }
         </div>
         <DirectDebitPopUpForm
-          buttonText={"Contribute with Direct Debit"}
+          buttonText="Contribute with Direct Debit"
           onPaymentAuthorisation={onPaymentAuthorisation}
         />
       </div>

--- a/support-frontend/assets/pages/paper-subscription-checkout/components-checkout/checkoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components-checkout/checkoutForm.jsx
@@ -7,7 +7,10 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 
 import { firstError, type FormError } from 'helpers/subscriptionsForms/validation';
-import { regularPrice as paperRegularPrice, promotion as paperPromotion } from 'helpers/productPrice/paperProductPrices';
+import {
+  promotion as paperPromotion,
+  regularPrice as paperRegularPrice,
+} from 'helpers/productPrice/paperProductPrices';
 import { routes } from 'helpers/routes';
 
 import Rows from 'components/base/rows';
@@ -23,32 +26,32 @@ import { asControlled } from 'hocs/asControlled';
 import Form, { FormSection } from 'components/checkoutForm/checkoutForm';
 import Layout, { Content } from 'components/subscriptionCheckouts/layout';
 import Summary from 'components/subscriptionCheckouts/summary';
-import GeneralErrorMessage from 'components/generalErrorMessage/generalErrorMessage';
 import DirectDebitPopUpForm from 'components/directDebit/directDebitPopUpForm/directDebitPopUpForm';
 import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
 import type { ErrorReason } from 'helpers/errorReasons';
 import type { ProductPrices } from 'helpers/productPrice/productPrices';
-import { getTitle, getShortDescription } from '../../paper-subscription-landing/helpers/products';
+import { getShortDescription, getTitle } from '../../paper-subscription-landing/helpers/products';
 import { HomeDelivery } from 'helpers/productPrice/fulfilmentOptions';
 import { titles } from 'helpers/user/details';
-import { formatUserDate, formatMachineDate } from '../helpers/deliveryDays';
+import { formatMachineDate, formatUserDate } from '../helpers/deliveryDays';
 import {
   type FormActionCreators,
   formActionCreators,
-  signOut,
   type FormField,
   type FormFields,
-  getFormFields,
-  getDeliveryAddress,
   getBillingAddress,
-  type State,
   getDays,
+  getDeliveryAddress,
+  getFormFields,
+  signOut,
+  type State,
 } from '../paperSubscriptionCheckoutReducer';
 import { withStore } from './addressFields';
-import { DirectDebit, Stripe } from 'helpers/paymentMethods';
 import GridImage from 'components/gridImage/gridImage';
 import type { FormField as PersonalDetailsFormField } from 'components/subscriptionCheckouts/personalDetails';
 import PersonalDetails from 'components/subscriptionCheckouts/personalDetails';
+import { PaymentMethodSelector } from 'components/subscriptionCheckouts/paymentMethodSelector';
+import CancellationSection from 'components/subscriptionCheckouts/cancellationSection';
 
 
 // ----- Types ----- //
@@ -87,13 +90,6 @@ const BillingAddress = withStore('billing', getBillingAddress);
 function CheckoutForm(props: PropTypes) {
 
   const days = getDays(props.fulfilmentOption, props.productOption);
-
-  const errorHeading = props.submissionError === 'personal_details_incorrect' ? 'Failed to Create Subscription' :
-    'Payment Attempt Failed';
-  const errorState = props.submissionError ?
-    <GeneralErrorMessage errorReason={props.submissionError} errorHeading={errorHeading} /> :
-    null;
-
   const fulfilmentOptionDescriptor = props.fulfilmentOption === HomeDelivery ? 'Paper' : 'Voucher booklet';
   const fulfilmentOptionName = props.fulfilmentOption === HomeDelivery ? 'Home delivery' : 'Voucher booklet';
 
@@ -215,43 +211,24 @@ function CheckoutForm(props: PropTypes) {
               </Text>
             </Rows>
           </FormSection>
-          <FormSection title="How would you like to pay?">
-            <Rows>
-              <Fieldset legend="How would you like to pay?">
-                <RadioInput
-                  text="Direct debit"
-                  name="paymentMethod"
-                  checked={props.paymentMethod === DirectDebit}
-                  onChange={() => props.setPaymentMethod(DirectDebit)}
-                />
-                <RadioInput
-                  text="Credit/Debit card"
-                  name="paymentMethod"
-                  checked={props.paymentMethod === Stripe}
-                  onChange={() => props.setPaymentMethod(Stripe)}
-                />
-              </Fieldset>
-              {errorState}
-            </Rows>
-          </FormSection>
+          <PaymentMethodSelector
+            countrySupportsDirectDebit
+            paymentMethod={props.paymentMethod}
+            setPaymentMethod={props.setPaymentMethod}
+            onPaymentAuthorised={props.onPaymentAuthorised}
+            optimizeExperiments={null}
+            submissionError={props.submissionError}
+          />
           <FormSection>
             <Button aria-label={null} type="submit">Continue to payment</Button>
             <DirectDebitPopUpForm
-              buttonText={"Subscribe with Direct Debit"}
+              buttonText="Subscribe with Direct Debit"
               onPaymentAuthorisation={(pa: PaymentAuthorisation) => {
                 props.onPaymentAuthorised(pa);
               }}
             />
           </FormSection>
-          <FormSection>
-            <Text>
-              <p>
-                <strong>Cancel any time you want.</strong>
-                There is no set time on your agreement so you can stop
-                your subscription anytime
-              </p>
-            </Text>
-          </FormSection>
+          <CancellationSection />
         </Form>
       </Layout>
     </Content>


### PR DESCRIPTION
## Why are you doing this?
When changing the Direct Debit button text I noticed some duplication between the paper and DP checkout forms so I've refactored it out.


