### PR TITLE
Simplify configuration of settingsSource

### DIFF
--- a/support-frontend/app/admin/settings/SettingsProvider.scala
+++ b/support-frontend/app/admin/settings/SettingsProvider.scala
@@ -29,7 +29,9 @@ abstract class SettingsProvider[T] {
 
 class AllSettingsProvider private (switchesProvider: SettingsProvider[Switches], amountsProvider: SettingsProvider[AmountsRegions]) {
   def getAllSettings(): AllSettings = {
-    AllSettings(switchesProvider.settings(), amountsProvider.settings())
+    val s  = AllSettings(switchesProvider.settings(), amountsProvider.settings())
+    println(s)
+    s
   }
 }
 

--- a/support-frontend/app/admin/settings/SettingsProvider.scala
+++ b/support-frontend/app/admin/settings/SettingsProvider.scala
@@ -29,9 +29,7 @@ abstract class SettingsProvider[T] {
 
 class AllSettingsProvider private (switchesProvider: SettingsProvider[Switches], amountsProvider: SettingsProvider[AmountsRegions]) {
   def getAllSettings(): AllSettings = {
-    val s  = AllSettings(switchesProvider.settings(), amountsProvider.settings())
-    println(s)
-    s
+    AllSettings(switchesProvider.settings(), amountsProvider.settings())
   }
 }
 

--- a/support-frontend/app/config/Configuration.scala
+++ b/support-frontend/app/config/Configuration.scala
@@ -42,7 +42,7 @@ class Configuration {
 
   lazy val stepFunctionArn = StateMachineArn.fromString(config.getString("supportWorkers.arn")).get
 
-  lazy val settingsSources: SettingsSources = SettingsSources.fromConfig(config).valueOr(throw _)
+  lazy val settingsSources: SettingsSources = SettingsSources.fromConfig(config, stage).valueOr(throw _)
 
   lazy val fastlyConfig: Option[FastlyConfig] = FastlyConfig.fromConfig(config).valueOr(throw _)
 

--- a/support-frontend/conf/CODE.public.conf
+++ b/support-frontend/conf/CODE.public.conf
@@ -21,12 +21,5 @@ play.filters.headers.contentSecurityPolicy = "default-src 'self' www.paypalobjec
 
 # Settings configurable via the admin console
 settingsSource {
-  switches.s3 {
-    bucket="support-admin-console"
-    key="CODE/switches.json"
-  }
-  amounts.s3 {
-    bucket="support-admin-console"
-    key="CODE/amounts.json"
-  }
+  s3.bucket = "support-admin-console"
 }

--- a/support-frontend/conf/DEV.public.conf
+++ b/support-frontend/conf/DEV.public.conf
@@ -20,21 +20,12 @@ membersDataService.api.url="https://members-data-api.thegulocal.com"
 play.filters.headers.contentSecurityPolicy = "default-src 'self' members-data-api.thegulocal.com www.paypalobjects.com www.paypal.com www.sandbox.paypal.com js.stripe.com pasteup.guim.co.uk ophan.theguardian.com j.ophan.co.uk media.guim.co.uk uploads.guim.co.uk www.google-analytics.com www.googletagmanager.com tagmanager.google.com polyfill.io www.googleadservices.com googleads.g.doubleclick.net www.google.com www.google.co.uk optimize.google.com static.ads-twitter.com bat.bing.com bid.g.doubleclick.net t.co analytics.twitter.com stats.g.doubleclick.net www.youtube-nocookie.com connect.facebook.net www.facebook.com consumer.krxd.net cdn.krxd.net beacon.krxd.net secure.adnxs.com checkout.stripe.com fonts.googleapis.com ssl.gstatic.com www.gstatic.com fonts.gstatic.com sentry.io www.dwin1.com data: wss: 'unsafe-inline' 'unsafe-eval'  q.stripe.com payment.code.dev-guardianapis.com https://interactive.guim.co.uk/ https://www.theguardian.com/ https://theguardian.com/"
 
 settingsSource {
-  switches {
-    # Settings configurable via the admin console
-    s3 {
-      bucket="support-admin-console"
-      key="DEV/switches.json"
-    }
-    # To use local admin settings create this file (delete it to load from S3):
-    local {
-      path="~/.gu/support-admin-console/switches.json"
-    }
-  }
-  amounts {
-    s3 {
-      bucket="support-admin-console"
-      key="DEV/amounts.json"
-    }
-  }
+
+  # Settings configurable via the admin console
+  s3.bucket="support-admin-console"
+
+  # To use local admin settings create this file (delete it to load from S3):
+  switches.local.path="~/.gu/support-admin-console/switches.json"
+
+  amounts.local.path="~/.gu/support-admin-console/amounts.json"
 }

--- a/support-frontend/conf/PROD.public.conf
+++ b/support-frontend/conf/PROD.public.conf
@@ -20,12 +20,5 @@ play.filters.headers.contentSecurityPolicy = "default-src 'self' members-data-ap
 
 # Settings configurable via the admin console
 settingsSource {
-  switches.s3 {
-    bucket="support-admin-console"
-    key="PROD/switches.json"
-  }
-  amounts.s3 {
-    bucket="support-admin-console"
-    key="PROD/amounts.json"
-  }
+  s3.bucket = "support-admin-console"
 }


### PR DESCRIPTION
## Why are you doing this?
I'm about to add another settings type (for contributionTypes).
All of these settings files are going to have very similar bucket/key values (e.g. `support-admin-console/CODE/amounts.json`), so this PR simplifies the configuration of this