### PR TITLE
Make contribution types configurable

### DIFF
--- a/support-frontend/app/admin/settings/ContributionTypes.scala
+++ b/support-frontend/app/admin/settings/ContributionTypes.scala
@@ -1,0 +1,39 @@
+package admin.settings
+
+import com.gu.support.encoding.JsonHelpers
+import io.circe.{Decoder, Encoder}
+
+sealed trait ContributionType
+case object ONE_OFF extends ContributionType
+case object MONTHLY extends ContributionType
+case object ANNUAL extends ContributionType
+
+case object ContributionType {
+  implicit val contributionTypeEncoder: Encoder[ContributionType] = Encoder.encodeString.contramap[ContributionType](_.toString)
+
+  implicit val contributionTypeDecoder: Decoder[ContributionType] = JsonHelpers.decodeStringAndCollect {
+    case "ONE_OFF" => ONE_OFF
+    case "MONTHLY" => MONTHLY
+    case "ANNUAL" => ANNUAL
+  }
+}
+
+case class ContributionTypeSetting(contributionType: ContributionType, isDefault: Option[Boolean])
+
+case class ContributionTypes(
+  GBPCountries: Seq[ContributionTypeSetting],
+  UnitedStates: Seq[ContributionTypeSetting],
+  EURCountries: Seq[ContributionTypeSetting],
+  International: Seq[ContributionTypeSetting],
+  Canada: Seq[ContributionTypeSetting],
+  AUDCountries: Seq[ContributionTypeSetting],
+  NZDCountries: Seq[ContributionTypeSetting]
+)
+
+object ContributionTypes {
+  import io.circe.generic.auto._
+  import ContributionType._
+
+  implicit val contributionTypesDecoder = Decoder[ContributionTypes]
+  implicit val contributionTypesEncoder = Encoder[ContributionTypes]
+}

--- a/support-frontend/app/admin/settings/Settings.scala
+++ b/support-frontend/app/admin/settings/Settings.scala
@@ -17,10 +17,11 @@ import io.circe.{Decoder, Encoder}
 import scala.io.{BufferedSource, Source}
 import scala.util.Try
 
-case class AllSettings(switches: Switches, amounts: AmountsRegions)
+case class AllSettings(switches: Switches, amounts: AmountsRegions, contributionTypes: ContributionTypes)
 
 object AllSettings {
   import Amounts._  // intellij doesn't think this is needed, but it is
+  import ContributionTypes._
 
   implicit val allSettingsCodec: Codec[AllSettings] = deriveCodec[AllSettings]
 }
@@ -50,14 +51,15 @@ object Settings {
     } yield settings
 }
 
-case class SettingsSources(switches: SettingsSource, amounts: SettingsSource)
+case class SettingsSources(switches: SettingsSource, amounts: SettingsSource, contributionTypes: SettingsSource)
 
 object SettingsSources {
   def fromConfig(config: Config, stage: Stage): Either[Throwable, SettingsSources] = {
     for {
       switchesSource <- SettingsSource.fromConfig(config, "switches", stage)
       amountsSource <- SettingsSource.fromConfig(config, "amounts", stage)
-    } yield SettingsSources(switchesSource, amountsSource)
+      contributionTypesSource <- SettingsSource.fromConfig(config, "contributionTypes", stage)
+    } yield SettingsSources(switchesSource, amountsSource, contributionTypesSource)
   }
 }
 

--- a/support-frontend/app/admin/settings/SettingsProvider.scala
+++ b/support-frontend/app/admin/settings/SettingsProvider.scala
@@ -27,20 +27,26 @@ abstract class SettingsProvider[T] {
   def settings(): T
 }
 
-class AllSettingsProvider private (switchesProvider: SettingsProvider[Switches], amountsProvider: SettingsProvider[AmountsRegions]) {
+class AllSettingsProvider private (
+  switchesProvider: SettingsProvider[Switches],
+  amountsProvider: SettingsProvider[AmountsRegions],
+  contributionTypesProvider: SettingsProvider[ContributionTypes]) {
+
   def getAllSettings(): AllSettings = {
-    AllSettings(switchesProvider.settings(), amountsProvider.settings())
+    AllSettings(switchesProvider.settings(), amountsProvider.settings(), contributionTypesProvider.settings())
   }
 }
 
 object AllSettingsProvider {
   import admin.settings.Amounts.amountsDecoder
+  import admin.settings.ContributionTypes.contributionTypesDecoder
 
   def fromConfig(config: Configuration)(implicit client: AmazonS3, system: ActorSystem, wsClient: WSClient): Either[Throwable, AllSettingsProvider] = {
     for {
       switchesProvider <- SettingsProvider.fromAppConfig[Switches](config.settingsSources.switches, config)
       amountsProvider <- SettingsProvider.fromAppConfig[AmountsRegions](config.settingsSources.amounts, config)
-    } yield new AllSettingsProvider(switchesProvider, amountsProvider)
+      contributionTypesProvider <- SettingsProvider.fromAppConfig[ContributionTypes](config.settingsSources.contributionTypes, config)
+    } yield new AllSettingsProvider(switchesProvider, amountsProvider, contributionTypesProvider)
   }
 }
 

--- a/support-frontend/assets/helpers/checkouts.js
+++ b/support-frontend/assets/helpers/checkouts.js
@@ -7,9 +7,6 @@ import {
   type ContributionType, getFrequency,
   toContributionType,
 } from 'helpers/contributions';
-import {
-  toContributionTypeOrElse,
-} from 'helpers/contributions';
 import * as storage from 'helpers/storage';
 import { type Switches } from 'helpers/settings';
 import type { IsoCountry } from 'helpers/internationalisation/country';
@@ -82,12 +79,12 @@ function toHumanReadableContributionType(contributionType: ContributionType): 'S
   }
 }
 
-function getContributionTypeFromSessionOrElse(fallback: ContributionType): ContributionType {
-  return toContributionTypeOrElse(storage.getSession('selectedContributionType'), fallback);
+function getContributionTypeFromSession(): ?ContributionType {
+  return toContributionType(storage.getSession('selectedContributionType'));
 }
 
-function getContributionTypeFromUrlOrElse(fallback: ContributionType): ContributionType {
-  return toContributionTypeOrElse(getQueryParameter('selectedContributionType', fallback), fallback);
+function getContributionTypeFromUrl(): ?ContributionType {
+  return toContributionType(getQueryParameter('selectedContributionType'));
 }
 
 // Returns an array of Payment Methods, in the order of preference,
@@ -201,8 +198,8 @@ export {
   getContributeButtonCopyWithPaymentType,
   formatAmount,
   getValidContributionTypes,
-  getContributionTypeFromSessionOrElse,
-  getContributionTypeFromUrlOrElse,
+  getContributionTypeFromSession,
+  getContributionTypeFromUrl,
   toHumanReadableContributionType,
   getValidPaymentMethods,
   getPaymentMethodToSelect,

--- a/support-frontend/assets/helpers/contributions.js
+++ b/support-frontend/assets/helpers/contributions.js
@@ -261,18 +261,20 @@ function getMinContribution(contributionType: ContributionType, countryGroupId: 
   return config[countryGroupId][contributionType].min;
 }
 
-function toContributionType(s: string): ?ContributionType {
-  switch (s.toUpperCase()) {
-    case 'ANNUAL': return 'ANNUAL';
-    case 'MONTHLY': return 'MONTHLY';
-    case 'ONE_OFF': return 'ONE_OFF';
-    default: return null;
+function toContributionType(s: ?string): ?ContributionType {
+  if (s) {
+    switch (s.toUpperCase()) {
+      case 'ANNUAL':
+        return 'ANNUAL';
+      case 'MONTHLY':
+        return 'MONTHLY';
+      case 'ONE_OFF':
+        return 'ONE_OFF';
+      default:
+        return null;
+    }
   }
-}
-
-function toContributionTypeOrElse(s: ?string, fallback: ContributionType): ContributionType {
-  const contributionType = toContributionType(s || fallback);
-  return contributionType || fallback;
+  return null;
 }
 
 function parseRegularContributionType(s: string): RegularContributionType {
@@ -422,7 +424,6 @@ function getContributionAmountRadios(
 export {
   config,
   toContributionType,
-  toContributionTypeOrElse,
   validateContribution,
   parseContribution,
   getMinContribution,

--- a/support-frontend/assets/helpers/contributions.js
+++ b/support-frontend/assets/helpers/contributions.js
@@ -54,6 +54,15 @@ export type AmountsRegions = {
   [CountryGroupId]: Amounts
 }
 
+export type ContributionTypeSetting = {
+  contributionType: ContributionType,
+  isDefault?: boolean,
+}
+
+export type ContributionTypes = {
+  [CountryGroupId]: ContributionTypeSetting,
+}
+
 type ParseError = 'ParseError';
 export type ValidationError = 'TooMuch' | 'TooLittle';
 export type ContributionError = ParseError | ValidationError;

--- a/support-frontend/assets/helpers/contributions.js
+++ b/support-frontend/assets/helpers/contributions.js
@@ -60,7 +60,7 @@ export type ContributionTypeSetting = {
 }
 
 export type ContributionTypes = {
-  [CountryGroupId]: ContributionTypeSetting,
+  [CountryGroupId]: ContributionTypeSetting[],
 }
 
 type ParseError = 'ParseError';

--- a/support-frontend/assets/helpers/globals.js
+++ b/support-frontend/assets/helpers/globals.js
@@ -57,6 +57,15 @@ const getSettings = (): Settings => getGlobal('settings') || {
       ANNUAL: [],
     },
   },
+  contributionTypes: {
+    GBPCountries: [],
+    UnitedStates: [],
+    EURCountries: [],
+    AUDCountries: [],
+    International: [],
+    NZDCountries: [],
+    Canada: [],
+  },
 };
 
 const getProductPrices = (): ?ProductPrices => getGlobal('productPrices');

--- a/support-frontend/assets/helpers/globals.js
+++ b/support-frontend/assets/helpers/globals.js
@@ -16,46 +16,24 @@ function getGlobal<T>(path: string = ''): ?T {
   return null;
 }
 
+const emptyAmountsSettings = {
+  ONE_OFF: [],
+  MONTHLY: [],
+  ANNUAL: [],
+};
+
 const getSettings = (): Settings => getGlobal('settings') || {
   switches: {
     experiments: {},
   },
   amounts: {
-    GBPCountries: {
-      ONE_OFF: [],
-      MONTHLY: [],
-      ANNUAL: [],
-    },
-    UnitedStates: {
-      ONE_OFF: [],
-      MONTHLY: [],
-      ANNUAL: [],
-    },
-    EURCountries: {
-      ONE_OFF: [],
-      MONTHLY: [],
-      ANNUAL: [],
-    },
-    AUDCountries: {
-      ONE_OFF: [],
-      MONTHLY: [],
-      ANNUAL: [],
-    },
-    International: {
-      ONE_OFF: [],
-      MONTHLY: [],
-      ANNUAL: [],
-    },
-    NZDCountries: {
-      ONE_OFF: [],
-      MONTHLY: [],
-      ANNUAL: [],
-    },
-    Canada: {
-      ONE_OFF: [],
-      MONTHLY: [],
-      ANNUAL: [],
-    },
+    GBPCountries: emptyAmountsSettings,
+    UnitedStates: emptyAmountsSettings,
+    EURCountries: emptyAmountsSettings,
+    AUDCountries: emptyAmountsSettings,
+    International: emptyAmountsSettings,
+    NZDCountries: emptyAmountsSettings,
+    Canada: emptyAmountsSettings,
   },
   contributionTypes: {
     GBPCountries: [],

--- a/support-frontend/assets/helpers/settings.js
+++ b/support-frontend/assets/helpers/settings.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { type AmountsRegions } from 'helpers/contributions';
+import { type AmountsRegions, type ContributionTypes } from 'helpers/contributions';
 
 export type Status = 'On' | 'Off';
 
@@ -22,4 +22,5 @@ export type Switches = {
 export type Settings = {
   switches: Switches,
   amounts: AmountsRegions,
+  contributionTypes: ContributionTypes,
 };

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionTypeTabs.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionTypeTabs.jsx
@@ -17,7 +17,7 @@ import type { Switches } from 'helpers/settings';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { type State } from '../contributionsLandingReducer';
 import { updateContributionTypeAndPaymentMethod } from '../contributionsLandingActions';
-import type { ContributionTypes, ContributionTypeSetting } from '../../../helpers/contributions';
+import type { ContributionTypes, ContributionTypeSetting } from 'helpers/contributions';
 
 // ----- Types ----- //
 

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionTypeTabs.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionTypeTabs.jsx
@@ -8,7 +8,6 @@ import { type ContributionType } from 'helpers/contributions';
 import { classNameWithModifiers } from 'helpers/utilities';
 import {
   getPaymentMethodToSelect,
-  getValidContributionTypes,
   toHumanReadableContributionType,
 } from 'helpers/checkouts';
 
@@ -18,7 +17,7 @@ import type { Switches } from 'helpers/settings';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { type State } from '../contributionsLandingReducer';
 import { updateContributionTypeAndPaymentMethod } from '../contributionsLandingActions';
-import type {ContributionTypes, ContributionTypeSetting} from "../../../helpers/contributions";
+import type { ContributionTypes, ContributionTypeSetting } from '../../../helpers/contributions';
 
 // ----- Types ----- //
 
@@ -66,7 +65,7 @@ function ContributionTypeTabs(props: PropTypes) {
       <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>Recurrence</legend>
       <ul className="form__radio-group-list form__radio-group-list--border">
         {contributionTypes.map((contributionTypeSetting: ContributionTypeSetting) => {
-          const contributionType = contributionTypeSetting.contributionType;
+          const { contributionType } = contributionTypeSetting;
           return (
             <li className="form__radio-group-item">
               <input
@@ -76,14 +75,19 @@ function ContributionTypeTabs(props: PropTypes) {
                 name="contributionType"
                 value={contributionType}
                 onChange={() =>
-                  props.onSelectContributionType(contributionType, props.switches, props.countryId, props.countryGroupId)
+                  props.onSelectContributionType(
+                    contributionType,
+                    props.switches,
+                    props.countryId,
+                    props.countryGroupId,
+                  )
                 }
                 checked={props.contributionType === contributionType}
               />
               <label htmlFor={`contributionType-${contributionType}`} className="form__radio-group-label">
                 {toHumanReadableContributionType(contributionType)}
               </label>
-            </li>)
+            </li>);
         })}
       </ul>
     </fieldset>

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionTypeTabs.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionTypeTabs.jsx
@@ -18,6 +18,7 @@ import type { Switches } from 'helpers/settings';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { type State } from '../contributionsLandingReducer';
 import { updateContributionTypeAndPaymentMethod } from '../contributionsLandingActions';
+import type {ContributionTypes, ContributionTypeSetting} from "../../../helpers/contributions";
 
 // ----- Types ----- //
 
@@ -26,6 +27,7 @@ type PropTypes = {|
   countryId: IsoCountry,
   countryGroupId: CountryGroupId,
   switches: Switches,
+  contributionTypes: ContributionTypes,
   onSelectContributionType: (ContributionType, Switches, IsoCountry, CountryGroupId) => void,
 |};
 
@@ -34,6 +36,7 @@ const mapStateToProps = (state: State) => ({
   contributionType: state.page.form.contributionType,
   countryId: state.common.internationalisation.countryId,
   switches: state.common.settings.switches,
+  contributionTypes: state.common.settings.contributionTypes,
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -52,7 +55,7 @@ const mapDispatchToProps = (dispatch: Function) => ({
 // ----- Render ----- //
 
 function ContributionTypeTabs(props: PropTypes) {
-  const contributionTypes = getValidContributionTypes(props.countryGroupId);
+  const contributionTypes = props.contributionTypes[props.countryGroupId];
 
   if (contributionTypes.length === 1 && contributionTypes[0] === 'ONE_OFF') {
     return (null);
@@ -62,23 +65,26 @@ function ContributionTypeTabs(props: PropTypes) {
     <fieldset className={classNameWithModifiers('form__radio-group', ['tabs', 'contribution-type'])}>
       <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>Recurrence</legend>
       <ul className="form__radio-group-list form__radio-group-list--border">
-        {contributionTypes.map((contributionType: ContributionType) => (
-          <li className="form__radio-group-item">
-            <input
-              id={`contributionType-${contributionType}`}
-              className="form__radio-group-input"
-              type="radio"
-              name="contributionType"
-              value={contributionType}
-              onChange={() =>
-                props.onSelectContributionType(contributionType, props.switches, props.countryId, props.countryGroupId)
-              }
-              checked={props.contributionType === contributionType}
-            />
-            <label htmlFor={`contributionType-${contributionType}`} className="form__radio-group-label">
-              {toHumanReadableContributionType(contributionType)}
-            </label>
-          </li>))}
+        {contributionTypes.map((contributionTypeSetting: ContributionTypeSetting) => {
+          const contributionType = contributionTypeSetting.contributionType;
+          return (
+            <li className="form__radio-group-item">
+              <input
+                id={`contributionType-${contributionType}`}
+                className="form__radio-group-input"
+                type="radio"
+                name="contributionType"
+                value={contributionType}
+                onChange={() =>
+                  props.onSelectContributionType(contributionType, props.switches, props.countryId, props.countryGroupId)
+                }
+                checked={props.contributionType === contributionType}
+              />
+              <label htmlFor={`contributionType-${contributionType}`} className="form__radio-group-label">
+                {toHumanReadableContributionType(contributionType)}
+              </label>
+            </li>)
+        })}
       </ul>
     </fieldset>
   );

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -14,8 +14,8 @@ import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { Switches } from 'helpers/settings';
 import { getQueryParameter } from 'helpers/url';
 import {
-  getContributionTypeFromSessionOrElse,
-  getContributionTypeFromUrlOrElse,
+  getContributionTypeFromSession,
+  getContributionTypeFromUrl,
   getPaymentMethodFromSession,
   getValidContributionTypes,
   getValidPaymentMethods,
@@ -68,22 +68,19 @@ function getInitialContributionType(
   countryGroupId: CountryGroupId,
   contributionTypes: ContributionTypes,
 ): ContributionType {
-  const getDefaultContributionType = () => {
-    const defaultContributionType = contributionTypes[countryGroupId].find(ct => ct.isDefault);
-    return defaultContributionType ?
-      defaultContributionType.contributionType :
-      contributionTypes[countryGroupId][0].contributionType;
-  };
 
-  const contributionType =
-    getContributionTypeFromUrlOrElse(getContributionTypeFromSessionOrElse(getDefaultContributionType()));
+  const contributionType = getContributionTypeFromUrl() || getContributionTypeFromSession();
 
-  return (
-    // make sure we don't select a contribution type which isn't on the page
-    contributionTypes[countryGroupId].find(ct => ct.contributionType === contributionType)
-      ? contributionType
-      : contributionTypes[countryGroupId][0].contributionType
-  );
+  // make sure we don't select a contribution type which isn't on the page
+  if (contributionType &&
+    contributionTypes[countryGroupId].find(ct => ct.contributionType === contributionType)) {
+    return contributionType;
+  }
+
+  const defaultContributionType = contributionTypes[countryGroupId].find(ct => ct.isDefault);
+  return defaultContributionType ?
+    defaultContributionType.contributionType :
+    contributionTypes[countryGroupId][0].contributionType;
 }
 
 const stripeAccountForContributionType: {[ContributionType]: StripeAccount } = {

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -40,12 +40,12 @@ import { Stripe } from 'helpers/paymentMethods';
 import {
   isFullDetailExistingPaymentMethod,
   mapExistingPaymentMethodToPaymentMethod, sendGetExistingPaymentMethodsRequest,
-} from '../../helpers/existingPaymentMethods/existingPaymentMethods';
-import type { ExistingPaymentMethod } from '../../helpers/existingPaymentMethods/existingPaymentMethods';
-import { setExistingPaymentMethods } from '../../helpers/page/commonActions';
-import { doesUserAppearToBeSignedIn } from '../../helpers/user/user';
+} from 'helpers/existingPaymentMethods/existingPaymentMethods';
+import type { ExistingPaymentMethod } from 'helpers/existingPaymentMethods/existingPaymentMethods';
+import { setExistingPaymentMethods } from 'helpers/page/commonActions';
+import { doesUserAppearToBeSignedIn } from 'helpers/user/user';
 import { isSwitchOn } from 'helpers/globals';
-import type { ContributionTypes } from '../../helpers/contributions';
+import type { ContributionTypes } from 'helpers/contributions';
 
 // ----- Functions ----- //
 

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -45,7 +45,7 @@ import type { ExistingPaymentMethod } from '../../helpers/existingPaymentMethods
 import { setExistingPaymentMethods } from '../../helpers/page/commonActions';
 import { doesUserAppearToBeSignedIn } from '../../helpers/user/user';
 import { isSwitchOn } from 'helpers/globals';
-import type {ContributionTypes} from "../../helpers/contributions";
+import type { ContributionTypes } from '../../helpers/contributions';
 
 // ----- Functions ----- //
 
@@ -64,15 +64,19 @@ function getInitialPaymentMethod(
   );
 }
 
-function getInitialContributionType(countryGroupId: CountryGroupId, contributionTypes: ContributionTypes): ContributionType {
+function getInitialContributionType(
+  countryGroupId: CountryGroupId,
+  contributionTypes: ContributionTypes,
+): ContributionType {
   const getDefaultContributionType = () => {
-    const defaultContributionType = contributionTypes[countryGroupId].find(contributionType => contributionType.isDefault);
-    return defaultContributionType ? defaultContributionType.contributionType : contributionTypes[countryGroupId][0].contributionType;
+    const defaultContributionType = contributionTypes[countryGroupId].find(ct => ct.isDefault);
+    return defaultContributionType ?
+      defaultContributionType.contributionType :
+      contributionTypes[countryGroupId][0].contributionType;
   };
 
-  const contributionType = getContributionTypeFromUrlOrElse(getContributionTypeFromSessionOrElse(
-    getDefaultContributionType()
-  ));
+  const contributionType =
+    getContributionTypeFromUrlOrElse(getContributionTypeFromSessionOrElse(getDefaultContributionType()));
 
   return (
     // make sure we don't select a contribution type which isn't on the page

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLandingReducer.js
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLandingReducer.js
@@ -16,7 +16,7 @@ import { directDebitReducer as directDebit } from 'components/directDebit/direct
 import type { StripePaymentMethod } from 'helpers/paymentIntegrations/readerRevenueApis';
 import type { OtherAmounts, SelectedAmounts } from 'helpers/contributions';
 import { type Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
-import { getContributionTypeFromSessionOrElse } from 'helpers/checkouts';
+import { getContributionTypeFromSession } from 'helpers/checkouts';
 import * as storage from 'helpers/storage';
 import { type UserTypeFromIdentityResponse } from 'helpers/identityApis';
 
@@ -105,7 +105,7 @@ function createFormReducer() {
   // ----- Initial state ----- //
 
   const initialState: FormState = {
-    contributionType: getContributionTypeFromSessionOrElse('MONTHLY'),
+    contributionType: getContributionTypeFromSession() || 'MONTHLY',
     paymentMethod: 'None',
     thirdPartyPaymentLibraries: {
       ONE_OFF: {

--- a/support-frontend/conf/DEV.public.conf
+++ b/support-frontend/conf/DEV.public.conf
@@ -28,4 +28,6 @@ settingsSource {
   switches.local.path="~/.gu/support-admin-console/switches.json"
 
   amounts.local.path="~/.gu/support-admin-console/amounts.json"
+
+  contributionTypes.local.path="~/.gu/support-admin-console/contributionTypes.json"
 }

--- a/support-frontend/test/codecs/CirceDecodersTest.scala
+++ b/support-frontend/test/codecs/CirceDecodersTest.scala
@@ -211,6 +211,22 @@ class CirceDecodersTest extends WordSpec with MustMatchers {
         Canada = amounts
       )
 
+      val contributionTypesSettings = List(
+        ContributionTypeSetting(
+          contributionType = ONE_OFF,
+          isDefault = Some(true)
+        )
+      )
+      val contributionTypes = ContributionTypes(
+        GBPCountries = contributionTypesSettings,
+        UnitedStates = contributionTypesSettings,
+        EURCountries = contributionTypesSettings,
+        AUDCountries = contributionTypesSettings,
+        International = contributionTypesSettings,
+        NZDCountries = contributionTypesSettings,
+        Canada = contributionTypesSettings
+      )
+
       val settings = AllSettings(
         Switches(
           oneOffPaymentMethods = PaymentMethodsSwitch(
@@ -236,7 +252,8 @@ class CirceDecodersTest extends WordSpec with MustMatchers {
           ),
           optimize = Off
         ),
-        amountsRegions
+        amountsRegions,
+        contributionTypes
       )
 
       decode[AllSettings](json).right.value mustBe settings

--- a/support-frontend/test/codecs/CirceDecodersTest.scala
+++ b/support-frontend/test/codecs/CirceDecodersTest.scala
@@ -192,7 +192,51 @@ class CirceDecodersTest extends WordSpec with MustMatchers {
           |            { "value": "25", "isDefault": true }
           |        ]
           |    }
-          |  }
+          |  },
+          |  "contributionTypes": {
+          |"GBPCountries": [
+          |{
+          |"contributionType": "ONE_OFF",
+          |"isDefault": true
+          |}
+          |],
+          |"UnitedStates": [
+          |{
+          |"contributionType": "ONE_OFF",
+          |"isDefault": true
+          |}
+          |],
+          |"EURCountries": [
+          |{
+          |"contributionType": "ONE_OFF",
+          |"isDefault": true
+          |}
+          |],
+          |"International": [
+          |{
+          |"contributionType": "ONE_OFF",
+          |"isDefault": true
+          |}
+          |],
+          |"Canada": [
+          |{
+          |"contributionType": "ONE_OFF",
+          |"isDefault": true
+          |}
+          |],
+          |"AUDCountries": [
+          |{
+          |"contributionType": "ONE_OFF",
+          |"isDefault": true
+          |}
+          |],
+          |"NZDCountries": [
+          |{
+          |"contributionType": "ONE_OFF",
+          |"isDefault": true
+          |}
+          |]
+          |}
           |}""".stripMargin
 
       val amount = Amount(value = "25", isDefault = Some(true))

--- a/support-frontend/test/codecs/CirceDecodersTest.scala
+++ b/support-frontend/test/codecs/CirceDecodersTest.scala
@@ -194,49 +194,28 @@ class CirceDecodersTest extends WordSpec with MustMatchers {
           |    }
           |  },
           |  "contributionTypes": {
-          |"GBPCountries": [
-          |{
-          |"contributionType": "ONE_OFF",
-          |"isDefault": true
-          |}
-          |],
-          |"UnitedStates": [
-          |{
-          |"contributionType": "ONE_OFF",
-          |"isDefault": true
-          |}
-          |],
-          |"EURCountries": [
-          |{
-          |"contributionType": "ONE_OFF",
-          |"isDefault": true
-          |}
-          |],
-          |"International": [
-          |{
-          |"contributionType": "ONE_OFF",
-          |"isDefault": true
-          |}
-          |],
-          |"Canada": [
-          |{
-          |"contributionType": "ONE_OFF",
-          |"isDefault": true
-          |}
-          |],
-          |"AUDCountries": [
-          |{
-          |"contributionType": "ONE_OFF",
-          |"isDefault": true
-          |}
-          |],
-          |"NZDCountries": [
-          |{
-          |"contributionType": "ONE_OFF",
-          |"isDefault": true
-          |}
-          |]
-          |}
+          |       "GBPCountries": [
+          |           { "contributionType": "ONE_OFF", "isDefault": true }
+          |       ],
+          |       "UnitedStates": [
+          |           { "contributionType": "ONE_OFF", "isDefault": true }
+          |       ],
+          |       "EURCountries": [
+          |           { "contributionType": "ONE_OFF", "isDefault": true }
+          |       ],
+          |       "International": [
+          |           { "contributionType": "ONE_OFF", "isDefault": true }
+          |       ],
+          |       "Canada": [
+          |           { "contributionType": "ONE_OFF", "isDefault": true }
+          |       ],
+          |       "AUDCountries": [
+          |           { "contributionType": "ONE_OFF", "isDefault": true }
+          |       ],
+          |       "NZDCountries": [
+          |           { "contributionType": "ONE_OFF", "isDefault": true }
+          |       ]
+          |  }
           |}""".stripMargin
 
       val amount = Amount(value = "25", isDefault = Some(true))

--- a/support-frontend/test/controllers/SubscriptionsTest.scala
+++ b/support-frontend/test/controllers/SubscriptionsTest.scala
@@ -59,19 +59,20 @@ class SubscriptionsTest extends WordSpec with MustMatchers with TestCSRFComponen
       membersDataService
     }
 
+    val amounts = Amounts(Nil,Nil,Nil)
+    val allSettings = AllSettings(
+      Switches(PaymentMethodsSwitch(On, On, None, None, None), PaymentMethodsSwitch(On, On, Some(On), Some(On), Some(On)), Map.empty, On),
+      AmountsRegions(amounts,amounts,amounts,amounts,amounts,amounts,amounts),
+      ContributionTypes(Nil,Nil,Nil,Nil,Nil,Nil,Nil)
+    )
+
     def fakeDigitalPack(
       actionRefiner: CustomActionBuilders = loggedInActionRefiner,
       identityService: HttpIdentityService = mockedIdentityService(authenticatedIdUser.user -> idUser.asRight[String]),
       membersDataService: MembersDataService = mockedMembersDataService(hasFailed = false, hasDp = false)
     ): DigitalSubscription = {
-      val amounts = Amounts(Nil,Nil,Nil)
       val settingsProvider = mock[AllSettingsProvider]
-      when(settingsProvider.getAllSettings()).thenReturn(
-        AllSettings(
-          Switches(PaymentMethodsSwitch(On, On, None, None, None), PaymentMethodsSwitch(On, On, Some(On), Some(On), Some(On)), Map.empty, On),
-          AmountsRegions(amounts,amounts,amounts,amounts,amounts,amounts,amounts)
-        )
-      )
+      when(settingsProvider.getAllSettings()).thenReturn(allSettings)
       val client = mock[SupportWorkersClient]
       val testUserService = mock[TestUserService]
       val tip = mock[Tip]

--- a/support-models/src/main/scala/com/gu/support/encoding/JsonHelpers.scala
+++ b/support-models/src/main/scala/com/gu/support/encoding/JsonHelpers.scala
@@ -1,7 +1,7 @@
 package com.gu.support.encoding
 
 import com.gu.support.promotions.{DiscountBenefit, FreeTrialBenefit, IncentiveBenefit}
-import io.circe.{ACursor, Json, JsonObject}
+import io.circe.{ACursor, Decoder, Json, JsonObject}
 
 object JsonHelpers {
 
@@ -96,6 +96,13 @@ object JsonHelpers {
 
   implicit class JsonExtensions(json: Json) {
     def getField(key: String) = json.hcursor.downField(key).focus
+  }
+
+  //Decodes an expected json string to T if the given partial function is defined for the string value
+  def decodeStringAndCollect[T](pf: PartialFunction[String,T]): Decoder[T] = Decoder.decodeString.emap { s =>
+    pf.lift(s)
+      .map(Right.apply)
+      .getOrElse(Left(s"Unexpected value: $s"))
   }
 
 }


### PR DESCRIPTION
## Why are you doing this?
Contribution types (aka frequencies) are now configurable from the Support Admin Console.
This lets us configure which contributionTypes are available in each region, and which is the default.

This change gets the contributionTypes settings from s3 (currently they're in the javascript) and sends them to the client.

## Changes

* Server gets the settings from `contributionTypes.json` (along with switches and amounts settings)
* Client uses the settings in window.guardian.settings


