### PR TITLE
Subs landing hero image bug

### DIFF
--- a/support-frontend/assets/components/productPage/productPageHero/productPageHero.scss
+++ b/support-frontend/assets/components/productPage/productPageHero/productPageHero.scss
@@ -25,10 +25,6 @@
   .component-left-margin-section {
     height: 100%;
   }
-  .component-grid-picture,
-  .component-grid-picture__image {
-    height: 100%;
-  }
   &.component-product-page-hero--feature {
     max-height: 600px;
   }


### PR DESCRIPTION
## Why are you doing this?

I noticed a bug in Chrome where sometimes the subscriptions landing hero image wasn't displaying (yet it was being fetched correctly). It wasn't a consistent bug but would most commonly be replicated if you toggled between the subs landing and another page.

## Changes

* Removing the height on the parent container seems to fix it (🤷‍♂️) The CSS around this component also feels a bit like a remnant of something being absolutely positioned there in the past? Regardless, the styles aren't needed now!

## Screenshots

### Before (sometimes)

![Screen Shot 2019-04-17 at 16 21 45](https://user-images.githubusercontent.com/1108991/56300857-95bb9800-612e-11e9-9c4f-605a84150eef.png)

### After 

![Screen Shot 2019-04-17 at 16 45 27](https://user-images.githubusercontent.com/1108991/56301711-41b1b300-6130-11e9-9a3c-cf533379e230.png)
