### PR TITLE
Removes line above continue to payment button inb subs checkout

### DIFF
--- a/support-frontend/assets/components/checkoutForm/checkoutForm.jsx
+++ b/support-frontend/assets/components/checkoutForm/checkoutForm.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { type Node, type Element, type ChildrenArray } from 'react';
+import React, { type Node, type Element, type ChildrenArray, type Boolean } from 'react';
 import { type Option } from 'helpers/types/option';
 import Heading, { type HeadingSize } from 'components/heading/heading';
 
@@ -15,19 +15,24 @@ type FormSectionPropTypes = {|
   title: Option<string>,
   children: Node,
   headingSize: HeadingSize,
+  noBorder: Boolean,
 |};
 
-const FormSection = ({ children, title, headingSize }: FormSectionPropTypes) => (
-  <div className="component-checkout-form-section">
+const FormSection = ({
+  children, title, headingSize, noBorder,
+}: FormSectionPropTypes) => (
+  <div className={`component-checkout-form-section ${noBorder ? 'component-checkout-form-section--no-border' : ''}`}>
     <div className="component-checkout-form-section__wrap">
       {title && <Heading className="component-checkout-form-section__heading" size={headingSize}>{title}</Heading>}
       {children}
     </div>
   </div>
 );
+
 FormSection.defaultProps = {
   headingSize: 2,
   title: null,
+  noBorder: false,
 };
 
 /*

--- a/support-frontend/assets/components/checkoutForm/checkoutForm.jsx
+++ b/support-frontend/assets/components/checkoutForm/checkoutForm.jsx
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { type Node, type Element, type ChildrenArray, type Boolean } from 'react';
+import React, { type Node, type Element, type ChildrenArray } from 'react';
 import { type Option } from 'helpers/types/option';
 import Heading, { type HeadingSize } from 'components/heading/heading';
 
@@ -15,7 +15,7 @@ type FormSectionPropTypes = {|
   title: Option<string>,
   children: Node,
   headingSize: HeadingSize,
-  noBorder: Boolean,
+  noBorder: boolean,
 |};
 
 const FormSection = ({
@@ -47,4 +47,3 @@ const Form = ({ children, ...otherProps }: FormPropTypes) => (<form {...otherPro
 
 export default Form;
 export { FormSection };
-

--- a/support-frontend/assets/components/checkoutForm/checkoutForm.scss
+++ b/support-frontend/assets/components/checkoutForm/checkoutForm.scss
@@ -25,8 +25,12 @@
   }
 }
 
-.component-checkout-form-section + .component-checkout-form-section {
+.component-checkout-form-section ~ .component-checkout-form-section {
   border-top: 1px solid gu-colour(neutral-86);
+}
+
+div .component-checkout-form-section.component-checkout-form-section--no-border {
+  border-top: none;
 }
 
 .component-checkout-form-section__heading {

--- a/support-frontend/assets/components/subscriptionCheckouts/paymentMethodSelector.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/paymentMethodSelector.jsx
@@ -45,7 +45,7 @@ function PaymentMethodSelector(props: PropTypes) {
   const payPalEnabled = isPayPalEnabled(props.optimizeExperiments);
   const multiplePaymentMethodsEnabled = payPalEnabled || props.countrySupportsDirectDebit;
 
-  return (
+  return (multiplePaymentMethodsEnabled ?
     <FormSection title={multiplePaymentMethodsEnabled ? 'How would you like to pay?' : null}>
       <Rows gap="large">
         {multiplePaymentMethodsEnabled &&
@@ -86,7 +86,7 @@ function PaymentMethodSelector(props: PropTypes) {
         }}
       />
     </FormSection>
-  );
+    : null);
 }
 
 export { PaymentMethodSelector };

--- a/support-frontend/assets/components/subscriptionCheckouts/subscriptionSubmitButtons.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/subscriptionSubmitButtons.jsx
@@ -40,7 +40,7 @@ function SubscriptionSubmitButtons(props: PropTypes) {
   // because we don't want to destroy and replace the iframe each time.
   // See PayPalExpressButton for more info.
   return (
-    <div className="component-paypal-button-checkout__container">
+    <div>
       <div
         id="component-paypal-button-checkout"
         className={hiddenIf(props.paymentMethod !== PayPal, 'component-paypal-button-checkout')}

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
-import type { Dispatch, Boolean } from 'redux';
+import type { Dispatch } from 'redux';
 
 import { type FormError } from 'helpers/subscriptionsForms/validation';
 import type { BillingPeriod } from 'helpers/billingPeriods';
@@ -62,7 +62,7 @@ type PropTypes = {|
   currencyId: IsoCurrency,
   ...FormActionCreators,
   csrf: Csrf,
-  payPalHasLoaded: Boolean,
+  payPalHasLoaded: boolean,
   isTestUser: boolean,
   amount: number,
   billingPeriod: BillingPeriod,
@@ -129,7 +129,6 @@ function CheckoutForm(props: PropTypes) {
       billingPeriod={Annual}
     />) : '';
 
-  const { payPalHasLoaded } = props;
 
   return (
     <Content>
@@ -215,14 +214,14 @@ function CheckoutForm(props: PropTypes) {
               />
             </Fieldset>
           </FormSection>
-          {payPalHasLoaded && <PaymentMethodSelector
+          <PaymentMethodSelector
             countrySupportsDirectDebit={props.countrySupportsDirectDebit}
             paymentMethod={props.paymentMethod}
             setPaymentMethod={props.setPaymentMethod}
             onPaymentAuthorised={props.onPaymentAuthorised}
             optimizeExperiments={props.optimizeExperiments}
             submissionError={props.submissionError}
-          />}
+          />
           <FormSection noBorder>
             <SubscriptionSubmitButtons
               paymentMethod={props.paymentMethod}

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -129,6 +129,8 @@ function CheckoutForm(props: PropTypes) {
       billingPeriod={Annual}
     />) : '';
 
+  const { payPalHasLoaded } = props;
+
   return (
     <Content>
       <CheckoutLayout aside={(
@@ -213,15 +215,15 @@ function CheckoutForm(props: PropTypes) {
               />
             </Fieldset>
           </FormSection>
-          <PaymentMethodSelector
+          {payPalHasLoaded && <PaymentMethodSelector
             countrySupportsDirectDebit={props.countrySupportsDirectDebit}
             paymentMethod={props.paymentMethod}
             setPaymentMethod={props.setPaymentMethod}
             onPaymentAuthorised={props.onPaymentAuthorised}
             optimizeExperiments={props.optimizeExperiments}
             submissionError={props.submissionError}
-          />
-          <FormSection>
+          />}
+          <FormSection noBorder>
             <SubscriptionSubmitButtons
               paymentMethod={props.paymentMethod}
               onPaymentAuthorised={props.onPaymentAuthorised}

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
-import type { Dispatch } from 'redux';
+import type { Dispatch, Boolean } from 'redux';
 
 import { type FormError } from 'helpers/subscriptionsForms/validation';
 import type { BillingPeriod } from 'helpers/billingPeriods';
@@ -62,7 +62,7 @@ type PropTypes = {|
   currencyId: IsoCurrency,
   ...FormActionCreators,
   csrf: Csrf,
-  payPalHasLoaded: boolean,
+  payPalHasLoaded: Boolean,
   isTestUser: boolean,
   amount: number,
   billingPeriod: BillingPeriod,

--- a/support-frontend/assets/pages/paper-subscription-checkout/components-checkout/checkoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components-checkout/checkoutForm.jsx
@@ -219,7 +219,7 @@ function CheckoutForm(props: PropTypes) {
             optimizeExperiments={null}
             submissionError={props.submissionError}
           />
-          <FormSection>
+          <FormSection noBorder>
             <Button aria-label={null} type="submit">Continue to payment</Button>
             <DirectDebitPopUpForm
               buttonText="Subscribe with Direct Debit"


### PR DESCRIPTION
## Why are you doing this?
This is work detailed in [**Trello Card**](https://trello.com/c/zWp8H655/2342-remove-border-above-button-and-standardise-vertical-spacing)

## Changes
* Remove line in paper checkout
* Remove line and adjust spacing in digital checkout

## Screenshots
### Before
#### Digital
![Screen Shot 2019-04-24 at 12 01 29](https://user-images.githubusercontent.com/16781258/56654778-cea4c100-6688-11e9-84b6-c109c5e2432a.png)

#### Paper
![Screen Shot 2019-04-24 at 12 01 13](https://user-images.githubusercontent.com/16781258/56654790-d82e2900-6688-11e9-8e9b-68afe5d864a4.png)

### After
#### Digital
![Screen Shot 2019-04-24 at 11 39 01](https://user-images.githubusercontent.com/16781258/56654590-62c25880-6688-11e9-8803-086704fc6c73.png)

#### Paper
![Screen Shot 2019-04-24 at 11 39 34](https://user-images.githubusercontent.com/16781258/56654612-6a81fd00-6688-11e9-803b-fa1c13c86d6a.png)