### PR TITLE
Fix postcode error messaging

### DIFF
--- a/support-frontend/assets/components/forms/customFields/error.scss
+++ b/support-frontend/assets/components/forms/customFields/error.scss
@@ -5,7 +5,10 @@
   color: gu-colour(state-error);
   display: block;
   margin-top: $gu-v-spacing;
-  width: 80%;
+  
+  @include mq($from: mobileMedium) {
+    width: 80%;
+  }
 }
 
 .component-form-error .component-input:not([type-radio]) {

--- a/support-frontend/assets/components/forms/customFields/error.scss
+++ b/support-frontend/assets/components/forms/customFields/error.scss
@@ -5,7 +5,7 @@
   color: gu-colour(state-error);
   display: block;
   margin-top: $gu-v-spacing;
-  width: 75%;
+  width: 80%;
 }
 
 .component-form-error .component-input:not([type-radio]) {

--- a/support-frontend/assets/components/forms/customFields/error.scss
+++ b/support-frontend/assets/components/forms/customFields/error.scss
@@ -4,7 +4,8 @@
   @include gu-fontset-explainer;
   color: gu-colour(state-error);
   display: block;
-  margin-top: $gu-v-spacing / 4;
+  margin-top: $gu-v-spacing;
+  width: 75%;
 }
 
 .component-form-error .component-input:not([type-radio]) {

--- a/support-frontend/assets/pages/paper-subscription-checkout/components-checkout/postcodeFinderStore.js
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components-checkout/postcodeFinderStore.js
@@ -41,7 +41,7 @@ const postcodeFinderActionCreatorsFor = (scope: Address) => ({
         .catch(() => {
           dispatch({
             type: 'SET_POSTCODE_FINDER_ERROR',
-            error: 'Couldn\'t find your postcode',
+            error: 'We couldn\'t find this postcode, please check and try again or enter your address below.',
             scope,
           });
         });
@@ -100,4 +100,3 @@ const postcodeFinderReducerFor = (scope: Address) => (
 };
 
 export { postcodeFinderReducerFor, postcodeFinderActionCreatorsFor };
-


### PR DESCRIPTION
## Why are you doing this?
This work is detailed in [**Trello Card**](https://trello.com/c/u5tKFLWP/2345-find-your-postcode-error-messages)

## Changes
* Change error message from 'Couldn't find your postcode' to 'We couldn't find this postcode, please check and try again or enter your address below.'
* Increase space above error message
* Manage line turnover to match design

## Screenshots
### Before
![Screen Shot 2019-04-25 at 10 57 25](https://user-images.githubusercontent.com/16781258/56727599-ee032300-6748-11e9-99aa-ec17e0984307.png)

### After
![Screen Shot 2019-04-25 at 10 54 12](https://user-images.githubusercontent.com/16781258/56727401-84831480-6748-11e9-83c4-671da0f4b15e.png)
