### PR TITLE
Adjusts paper checkout payment selector so no radio button is selected

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckoutReducer.js
+++ b/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckoutReducer.js
@@ -249,7 +249,7 @@ function initReducer(initialCountry: IsoCountry, productInUrl: ?string, fulfillm
     lastName: user.lastName || '',
     startDate: formatMachineDate(days[0]) || null,
     telephone: null,
-    paymentMethod: null,
+    paymentMethod: countrySupportsDirectDebit(initialCountry) ? null : Stripe,
     formErrors: [],
     submissionError: null,
     formSubmitted: false,

--- a/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckoutReducer.js
+++ b/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckoutReducer.js
@@ -41,7 +41,7 @@ import {
   type FormField as AddressFormField,
 } from './components-checkout/addressFieldsStore';
 import type { PaymentMethod } from 'helpers/paymentMethods';
-import { DirectDebit, Stripe } from 'helpers/paymentMethods';
+import { Stripe } from 'helpers/paymentMethods';
 import { paperHasDeliveryEnabled } from 'helpers/subscriptions';
 
 import { getVoucherDays, getDeliveryDays, formatMachineDate } from './helpers/deliveryDays';

--- a/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckoutReducer.js
+++ b/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckoutReducer.js
@@ -249,7 +249,7 @@ function initReducer(initialCountry: IsoCountry, productInUrl: ?string, fulfillm
     lastName: user.lastName || '',
     startDate: formatMachineDate(days[0]) || null,
     telephone: null,
-    paymentMethod: countrySupportsDirectDebit(initialCountry) ? DirectDebit : Stripe,
+    paymentMethod: null,
     formErrors: [],
     submissionError: null,
     formSubmitted: false,


### PR DESCRIPTION
## Why are you doing this?
See the following [**Trello Card**](https://trello.com/c/Bo8QcH71/2369-remove-pre-selection-of-payment-method-in-all-checkouts-when-there-is-more-than-one-option-available)

## Changes
The initial state has changed so it checks whether the country supports direct debit (hence there is a choice in the checkout) in which case it doesn't set either payment type. If there is no choice, it selects Stripe (Credit/Debit card).

## Screenshots
### Before
![Screen Shot 2019-04-25 at 17 05 02](https://user-images.githubusercontent.com/16781258/56750963-c8900c80-677c-11e9-8ad5-906cc2bff365.png)

### After
![Screen Shot 2019-04-25 at 17 04 16](https://user-images.githubusercontent.com/16781258/56750950-c29a2b80-677c-11e9-97d6-a96789a1cff4.png)
