### PR TITLE
Social share and button update on thank you pages

### DIFF
--- a/support-frontend/assets/components/button/button.scss
+++ b/support-frontend/assets/components/button/button.scss
@@ -17,7 +17,6 @@
   transition: $gu-transition;
   justify-content: space-between;
   position: relative;
-  width: fit-content;
 
   &:hover, &:focus {
     outline: 0;

--- a/support-frontend/assets/components/button/button.scss
+++ b/support-frontend/assets/components/button/button.scss
@@ -17,6 +17,8 @@
   transition: $gu-transition;
   justify-content: space-between;
   position: relative;
+  width: fit-content;
+
   &:hover, &:focus {
     outline: 0;
   }

--- a/support-frontend/assets/components/marketingConsentNew/marketingConsent.scss
+++ b/support-frontend/assets/components/marketingConsentNew/marketingConsent.scss
@@ -11,8 +11,8 @@
 }
 
 .component-marketing-consent-confirmation {
-  font-family: $gu-text-sans-web;
   @include gu-fontset-explainer;
   font-style: italic;
   margin-top: $gu-v-spacing/4;
+  font-weight: 100;
 }

--- a/support-frontend/assets/components/socialShare/socialShare.jsx
+++ b/support-frontend/assets/components/socialShare/socialShare.jsx
@@ -14,42 +14,47 @@ import { trackComponentClick } from 'helpers/tracking/ophanComponentEventTrackin
 
 // ---- Types ----- //
 
-type Platform = 'facebook' | 'twitter' | 'linkedin' | 'email';
+type SharePlatform = 'facebook' | 'twitter' | 'linkedin' | 'email';
 
-type PropTypes = {| name: Platform |};
+type PropTypes = {| name: SharePlatform |};
 
 type SocialMedia = {
   link: string,
   svg: Node,
   a11yHint: string,
+  windowFeatures: string
 };
 
-type WindowFeatures = '' | 'menubar=no, toolbar=no, resizable=yes, scrollbars=yes, width=500, height=400';
+const SocialWindowFeatures = 'menubar=no, toolbar=no, resizable=yes, scrollbars=yes, width=500, height=400';
 
 // ----- Setup ----- //
 
 const socialMedia: {
-  [Platform]: SocialMedia,
+  [SharePlatform]: SocialMedia,
 } = {
   facebook: {
-    link: 'https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fsupport.theguardian.com%2Fuk%2Fcontribute',
+    link: 'https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute',
     svg: <SvgFacebook />,
     a11yHint: 'Share on facebook',
+    windowFeatures: SocialWindowFeatures,
   },
   twitter: {
-    link: 'https://twitter.com/intent/tweet?url=https%3A%2F%2Fsupport.theguardian.com%2Fuk%2Fcontribute&text=Join%20me%20and%20over%20one%20million%20others%20in%20supporting%20a%20different%20model%20for%20open%2C%20independent%20journalism.%20Together%20we%20can%20help%20safeguard%20The%20Guardian%E2%80%99s%20future%20%E2%80%93%20so%20more%20people%2C%20across%20the%20world%2C%20can%20keep%20accessing%20factual%20information%20for%20free',
+    link: 'https://twitter.com/intent/tweet?url=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute&text=Join%20me%20and%20over%20one%20million%20others%20in%20supporting%20a%20different%20model%20for%20open%2C%20independent%20journalism.%20Together%20we%20can%20help%20safeguard%20The%20Guardian%E2%80%99s%20future%20%E2%80%93%20so%20more%20people%2C%20across%20the%20world%2C%20can%20keep%20accessing%20factual%20information%20for%20free',
     svg: <SvgTwitter />,
     a11yHint: 'Share on twitter',
+    windowFeatures: SocialWindowFeatures,
   },
   linkedin: {
-    link: 'http://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fsupport.theguardian.com%2Fuk%2Fcontribute&title=Join%20me%20and%20over%20one%20million%20others%20in%20supporting%20a%20different%20model%20for%20open%2C%20independent%20journalism.%20Together%20we%20can%20help%20safeguard%20The%20Guardian%E2%80%99s%20future%20%E2%80%93%20so%20more%20people%2C%20across%20the%20world%2C%20can%20keep%20accessing%20factual%20information%20for%20free',
+    link: 'http://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute&title=Join%20me%20and%20over%20one%20million%20others%20in%20supporting%20a%20different%20model%20for%20open%2C%20independent%20journalism.%20Together%20we%20can%20help%20safeguard%20The%20Guardian%E2%80%99s%20future%20%E2%80%93%20so%20more%20people%2C%20across%20the%20world%2C%20can%20keep%20accessing%20factual%20information%20for%20free',
     svg: <SvgLinkedin />,
     a11yHint: 'Share on linkedin',
+    windowFeatures: SocialWindowFeatures,
   },
   email: {
-    link: 'mailto:?subject=Join%20me%20in%20supporting%20open%2C%20independent%20journalism&body=Join%20me%20and%20over%20one%20million%20others%20in%20supporting%20a%20different%20model%20for%20open%2C%20independent%20journalism.%20Together%20we%20can%20help%20safeguard%20The%20Guardian%E2%80%99s%20future%20%E2%80%93%20so%20more%20people%2C%20across%20the%20world%2C%20can%20keep%20accessing%20factual%20information%20for%20free%3A%20https%3A%2F%2Fsupport.theguardian.com%2Fuk%2Fcontribute',
+    link: 'mailto:?subject=Join%20me%20in%20supporting%20open%2C%20independent%20journalism&body=Join%20me%20and%20over%20one%20million%20others%20in%20supporting%20a%20different%20model%20for%20open%2C%20independent%20journalism.%20Together%20we%20can%20help%20safeguard%20The%20Guardian%E2%80%99s%20future%20%E2%80%93%20so%20more%20people%2C%20across%20the%20world%2C%20can%20keep%20accessing%20factual%20information%20for%20free%3A%20https%3A%2F%2Fsupport.theguardian.com%2Fcontribute',
     svg: <SvgEmail />,
     a11yHint: 'Share by email',
+    windowFeatures: '',
   },
 };
 
@@ -60,17 +65,13 @@ export default function SocialShare(props: PropTypes) {
 
   const a11yId = `component-social-share-a11y-hint-${props.name}`;
 
-  function onShare(eventName: string, eventLink: string): () => void {
+  function onShare(eventName: string, eventLink: string, windowFeatures: string): () => void {
     return (): void => {
-      let features: WindowFeatures = '';
-      if (eventName === 'contributions-share-facebook' || eventName === 'contributions-share-linkedin' || eventName === 'contributions-share-twitter') {
-        features = 'menubar=no, toolbar=no, resizable=yes, scrollbars=yes, width=500, height=400';
-      }
       trackComponentClick(eventName);
       window.open(
         eventLink,
         '',
-        features,
+        windowFeatures,
       );
     };
   }
@@ -80,7 +81,7 @@ export default function SocialShare(props: PropTypes) {
     <button
       className="component-social-share"
       onClick={
-          onShare(`contributions-share-${props.name}`, socialMedia[props.name].link)
+          onShare(`contributions-share-${props.name}`, socialMedia[props.name].link, socialMedia[props.name].windowFeatures)
       }
       aria-labelledby={a11yId}
     >

--- a/support-frontend/assets/components/socialShare/socialShare.jsx
+++ b/support-frontend/assets/components/socialShare/socialShare.jsx
@@ -33,7 +33,7 @@ const SocialWindowFeatures = 'menubar=no, toolbar=no, resizable=yes, scrollbars=
 // below have the following tracking based on what the given platform supports:
 // Facebook: acquisitionData parameter & INTCMP parameter
 // Twitter: INTCMP parameter (does not support object syntax in links / deletes link )
-// Linkedin: INTCMP parameter (does not support object syntax in links / strips out parameter value)
+// Linkedin: None (strips out parameter values whether in object format or plaintext)
 // email: INTCMP parameter ([gmail] decodes object syntax in links / doesn't appear clickable)
 
 const socialMedia: {

--- a/support-frontend/assets/components/socialShare/socialShare.jsx
+++ b/support-frontend/assets/components/socialShare/socialShare.jsx
@@ -10,7 +10,7 @@ import SvgFacebook from 'components/svgs/facebook';
 import SvgTwitter from 'components/svgs/twitter';
 import SvgLinkedin from 'components/svgs/linkedin';
 import SvgEmail from 'components/svgs/email';
-
+import { trackComponentClick } from 'helpers/tracking/ophanComponentEventTracking';
 
 // ---- Types ----- //
 
@@ -24,6 +24,7 @@ type SocialMedia = {
   a11yHint: string,
 };
 
+type WindowFeatures = '' | 'menubar=no, toolbar=no, resizable=yes, scrollbars=yes, width=500, height=400';
 
 // ----- Setup ----- //
 
@@ -31,22 +32,22 @@ const socialMedia: {
   [Platform]: SocialMedia,
 } = {
   facebook: {
-    link: 'https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fsupport.theguardian.com%2F%3FINTCMP%3Dsocial&t=',
+    link: 'https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fsupport.theguardian.com%2Fuk%2Fcontribute',
     svg: <SvgFacebook />,
     a11yHint: 'Share on facebook',
   },
   twitter: {
-    link: 'https://twitter.com/intent/tweet?text=I%27ve+just+contributed+to+the+Guardian.+Join+me+in+supporting+independent+journalism+https%3A%2F%2Fsupport.theguardian.com&amp;related=guardian',
+    link: 'https://twitter.com/intent/tweet?url=https%3A%2F%2Fsupport.theguardian.com%2Fuk%2Fcontribute&text=Join%20me%20and%20over%20one%20million%20others%20in%20supporting%20a%20different%20model%20for%20open%2C%20independent%20journalism.%20Together%20we%20can%20help%20safeguard%20The%20Guardian%E2%80%99s%20future%20%E2%80%93%20so%20more%20people%2C%20across%20the%20world%2C%20can%20keep%20accessing%20factual%20information%20for%20free',
     svg: <SvgTwitter />,
     a11yHint: 'Share on twitter',
   },
   linkedin: {
-    link: 'https://twitter.com/intent/tweet?text=I%27ve+just+contributed+to+the+Guardian.+Join+me+in+supporting+independent+journalism+https%3A%2F%2Fsupport.theguardian.com&amp;related=guardian',
+    link: 'http://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fsupport.theguardian.com%2Fuk%2Fcontribute&title=Join%20me%20and%20over%20one%20million%20others%20in%20supporting%20a%20different%20model%20for%20open%2C%20independent%20journalism.%20Together%20we%20can%20help%20safeguard%20The%20Guardian%E2%80%99s%20future%20%E2%80%93%20so%20more%20people%2C%20across%20the%20world%2C%20can%20keep%20accessing%20factual%20information%20for%20free',
     svg: <SvgLinkedin />,
     a11yHint: 'Share on linkedin',
   },
   email: {
-    link: 'https://twitter.com/intent/tweet?text=I%27ve+just+contributed+to+the+Guardian.+Join+me+in+supporting+independent+journalism+https%3A%2F%2Fsupport.theguardian.com&amp;related=guardian',
+    link: 'mailto:?subject=Join%20me%20in%20supporting%20open%2C%20independent%20journalism&body=Join%20me%20and%20over%20one%20million%20others%20in%20supporting%20a%20different%20model%20for%20open%2C%20independent%20journalism.%20Together%20we%20can%20help%20safeguard%20The%20Guardian%E2%80%99s%20future%20%E2%80%93%20so%20more%20people%2C%20across%20the%20world%2C%20can%20keep%20accessing%20factual%20information%20for%20free%3A%20https%3A%2F%2Fsupport.theguardian.com%2Fuk%2Fcontribute',
     svg: <SvgEmail />,
     a11yHint: 'Share by email',
   },
@@ -59,17 +60,35 @@ export default function SocialShare(props: PropTypes) {
 
   const a11yId = `component-social-share-a11y-hint-${props.name}`;
 
+  function onShare(eventName: string, eventLink: string): () => void {
+    return (): void => {
+      let features: WindowFeatures = '';
+      if (eventName === 'contributions-share-facebook' || eventName === 'contributions-share-linkedin' || eventName === 'contributions-share-twitter') {
+        features = 'menubar=no, toolbar=no, resizable=yes, scrollbars=yes, width=500, height=400';
+      }
+      trackComponentClick(eventName);
+      window.open(
+        eventLink,
+        '',
+        features,
+      );
+    };
+  }
+
+
   return (
-    <a
+    <button
       className="component-social-share"
-      href={socialMedia[props.name].link}
+      onClick={
+          onShare(`contributions-share-${props.name}`, socialMedia[props.name].link)
+      }
       aria-labelledby={a11yId}
     >
       {socialMedia[props.name].svg}
       <p id={a11yId} className="accessibility-hint">
         {socialMedia[props.name].a11yHint}
       </p>
-    </a>
+    </button>
   );
 
 }

--- a/support-frontend/assets/components/socialShare/socialShare.jsx
+++ b/support-frontend/assets/components/socialShare/socialShare.jsx
@@ -29,17 +29,24 @@ const SocialWindowFeatures = 'menubar=no, toolbar=no, resizable=yes, scrollbars=
 
 // ----- Setup ----- //
 
+// The links back to support.theguardian.com embedded within the share links
+// below have the following tracking based on what the given platform supports:
+// Facebook: acquisitionData parameter & INTCMP parameter
+// Twitter: INTCMP parameter (does not support object syntax in links / deletes link )
+// Linkedin: INTCMP parameter (does not support object syntax in links / strips out parameter value)
+// email: INTCMP parameter ([gmail] decodes object syntax in links / doesn't appear clickable)
+
 const socialMedia: {
   [SharePlatform]: SocialMedia,
 } = {
   facebook: {
-    link: 'https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute',
+    link: 'https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute?acquisitionData=%7B%22source%22%3A%22SOCIAL%22%2C%22campaignCode%22%3A%22component-social-facebook%22%2C%22componentId%22%3A%22component-social-facebook%22%7D&INTCMP=component-social-facebook',
     svg: <SvgFacebook />,
     a11yHint: 'Share on facebook',
     windowFeatures: SocialWindowFeatures,
   },
   twitter: {
-    link: 'https://twitter.com/intent/tweet?url=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute&text=Join%20me%20and%20over%20one%20million%20others%20in%20supporting%20a%20different%20model%20for%20open%2C%20independent%20journalism.%20Together%20we%20can%20help%20safeguard%20The%20Guardian%E2%80%99s%20future%20%E2%80%93%20so%20more%20people%2C%20across%20the%20world%2C%20can%20keep%20accessing%20factual%20information%20for%20free',
+    link: 'https://twitter.com/intent/tweet?url=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute?INTCMP=component-social-twitter&text=Join%20me%20and%20over%20one%20million%20others%20in%20supporting%20a%20different%20model%20for%20open%2C%20independent%20journalism.%20Together%20we%20can%20help%20safeguard%20The%20Guardian%E2%80%99s%20future%20%E2%80%93%20so%20more%20people%2C%20across%20the%20world%2C%20can%20keep%20accessing%20factual%20information%20for%20free',
     svg: <SvgTwitter />,
     a11yHint: 'Share on twitter',
     windowFeatures: SocialWindowFeatures,
@@ -51,7 +58,7 @@ const socialMedia: {
     windowFeatures: SocialWindowFeatures,
   },
   email: {
-    link: 'mailto:?subject=Join%20me%20in%20supporting%20open%2C%20independent%20journalism&body=Join%20me%20and%20over%20one%20million%20others%20in%20supporting%20a%20different%20model%20for%20open%2C%20independent%20journalism.%20Together%20we%20can%20help%20safeguard%20The%20Guardian%E2%80%99s%20future%20%E2%80%93%20so%20more%20people%2C%20across%20the%20world%2C%20can%20keep%20accessing%20factual%20information%20for%20free%3A%20https%3A%2F%2Fsupport.theguardian.com%2Fcontribute',
+    link: 'mailto:?subject=Join%20me%20in%20supporting%20open%2C%20independent%20journalism&body=Join%20me%20and%20over%20one%20million%20others%20in%20supporting%20a%20different%20model%20for%20open%2C%20independent%20journalism.%20Together%20we%20can%20help%20safeguard%20The%20Guardian%E2%80%99s%20future%20%E2%80%93%20so%20more%20people%2C%20across%20the%20world%2C%20can%20keep%20accessing%20factual%20information%20for%20free%3A%20https%3A%2F%2Fsupport.theguardian.com%2Fcontribute?INTCMP=component-social-email',
     svg: <SvgEmail />,
     a11yHint: 'Share by email',
     windowFeatures: '',

--- a/support-frontend/assets/components/socialShare/socialShare.scss
+++ b/support-frontend/assets/components/socialShare/socialShare.scss
@@ -4,6 +4,7 @@
   height: 42px;
   width: 42px;
   margin-right: 12px;
+  cursor: pointer;
 
 	svg {
 		height: 25px;

--- a/support-frontend/assets/components/socialShare/socialShare.scss
+++ b/support-frontend/assets/components/socialShare/socialShare.scss
@@ -1,9 +1,13 @@
 .component-social-share {
+  border: 1px solid gu-colour(neutral-86);
+  border-radius: 600px;
+  height: 42px;
+  width: 42px;
+  margin-right: 12px;
+
 	svg {
-		width: 20px;
-		border: 1px solid gu-colour(neutral-86);
-		border-radius: 600px;
-		padding: 8px;
-    margin-right: 6px;
+		height: 25px;
+    line-height: 42px;
+    vertical-align: middle;
 	}
 }

--- a/support-frontend/assets/components/spreadTheWord/spreadTheWord.jsx
+++ b/support-frontend/assets/components/spreadTheWord/spreadTheWord.jsx
@@ -10,13 +10,13 @@ import SocialShare from 'components/socialShare/socialShare';
 // ----- Component ----- //
 
 export default function SpreadTheWord() {
+  const title = 'Invite others to support The Guardian';
+  const message = 'To join you and over one million others in supporting a different model for open, independent journalism – so more people can access factual information for free';
 
   return (
     <div className="component-spread-the-word">
-      <h3 className="component-spread-the-word__title">Share your support for independent journalism</h3>
-      <p className="component-spread-the-word__description">
-          Let your friends, family and followers know that you made a valuable contribution to The Guardian today
-      </p>
+      <h3 className="component-spread-the-word__title">{title}</h3>
+      <p className="component-marketing-consent__message">{message}</p>
       <div className="component-spread-the-word__share">
         <SocialShare name="facebook" />
         <SocialShare name="twitter" />

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
@@ -13,9 +13,7 @@ import { ContributionThankYouBlurb } from './ContributionThankYouBlurb';
 import AnchorButton from 'components/button/anchorButton';
 import SvgArrowLeft from 'components/svgs/arrowLeftStraight';
 import { DirectDebit } from 'helpers/paymentMethods';
-
-//  TBD: Implement Social On this page beneath Marketing Consent:
-// import SpreadTheWord from 'components/spreadTheWord/spreadTheWord';
+import SpreadTheWord from 'components/spreadTheWord/spreadTheWord';
 
 // ----- Types ----- //
 
@@ -66,6 +64,7 @@ function ContributionThankYou(props: PropTypes) {
           </section>
         ) : null}
         <MarketingConsent />
+        <SpreadTheWord />
         <div className="gu-content__return-link">
           <AnchorButton
             href="https://www.theguardian.com"

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYouPasswordSet.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYouPasswordSet.jsx
@@ -7,9 +7,7 @@ import MarketingConsent from '../MarketingConsentContainer';
 import AnchorButton from 'components/button/anchorButton';
 import SvgArrowLeft from 'components/svgs/arrowLeftStraight';
 import { ContributionThankYouBlurb } from './ContributionThankYouBlurb';
-
-//  TBD: Implement Social On this page beneath Marketing Consent:
-// import SpreadTheWord from 'components/spreadTheWord/spreadTheWord';
+import SpreadTheWord from 'components/spreadTheWord/spreadTheWord';
 
 // ----- Render ----- //
 
@@ -25,6 +23,7 @@ function ContributionThankYouPasswordSet() {
           </p>
         </section>
         <MarketingConsent />
+        <SpreadTheWord />
         <div className="gu-content__return-link">
           <AnchorButton
             href="https://www.theguardian.com"

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYouSetPassword.scss
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYouSetPassword.scss
@@ -28,3 +28,8 @@
 .form__field.form__field--contribution-email {
   margin-top: $gu-v-spacing * 2;
 }
+
+.component-button--create-account {
+  margin-top: $gu-v-spacing * 2;
+  margin-bottom: $gu-v-spacing;
+}

--- a/support-frontend/assets/pages/new-contributions-landing/components/SetPasswordForm.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/SetPasswordForm.jsx
@@ -18,7 +18,7 @@ import { trackComponentClick } from 'helpers/tracking/ophanComponentEventTrackin
 import { NewContributionTextInput } from './ContributionTextInput';
 import { type ThankYouPageStage } from '../contributionsLandingReducer';
 import { setThankYouPageStage, setPasswordHasBeenSubmitted, setPasswordError, updatePassword, type Action } from '../contributionsLandingActions';
-import { ButtonWithRightArrow } from './ButtonWithRightArrow/ButtonWithRightArrow';
+import Button from 'components/button/button';
 
 const passwordErrorHeading = 'Account set up failure';
 const passwordErrorMessage = 'Sorry, we are unable to register you at this time. We are working hard to fix the problem and hope to be back up and running soon. Please come back later to complete your registration. Thank you.';
@@ -131,26 +131,24 @@ function SetPasswordForm(props: PropTypes) {
           errorMessage="Please enter a password between 6 and 20 characters long"
           required
         />
-        <ButtonWithRightArrow
-          componentClassName={classNameWithModifiers('form__submit', ['create-account'])}
-          buttonClassName={classNameWithModifiers('form__submit-button', ['create-account'])}
-          accessibilityHintId="accessibility-hint-create-account"
+        <Button
+          modifierClasses={['create-account']}
+          aria-label="Create a guardian account"
           type="submit"
-          buttonCopy="Create a Guardian account"
-        />
-        <ButtonWithRightArrow
-          componentClassName="form_no-submit"
-          buttonClassName="button--no-thanks"
-          accessibilityHintId="accessibility-hint-no-thanks"
-          type="button"
-          buttonCopy="No thank you"
+        >
+          Create a Guardian account
+        </Button>
+        <Button
+          appearance="greyHollow"
+          aria-label="No thank you"
           onClick={
-            () => {
-              trackComponentClick('decline-to-set-password');
-              props.setThankYouPageStage('thankYouPasswordDeclinedToSet');
-            }
-          }
-        />
+          () => {
+            trackComponentClick('decline-to-set-password');
+            props.setThankYouPageStage('thankYouPasswordDeclinedToSet');
+          }}
+        >
+          No thank you
+        </Button>
       </form>
       {props.passwordError === true ?
         <div className="component-password-failure-message component-general-error-message">


### PR DESCRIPTION
## Why are you doing this?

We released the new Thank You page designs knowing we had a few things left to be done. The most major thing to be done was releasing the social share buttons, which this PR addresses. This PR also addresses one minor concern which was that we were using a non-standard button. 

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/oo2MNCqE/959-thank-you-page-redesign-ft-social-share-v2)

## Changes

* Releasing Social Share buttons on "thank you" page and "password set" page
* Using standard `button` component across thank you pages

## Screenshots
Thank you page with share buttons:
![Thank You With Social](https://user-images.githubusercontent.com/3300789/56752772-f7a87d00-6780-11e9-9e77-a8c6edca0e0a.png)

Password set page with share buttons:
![Password Set With Social](https://user-images.githubusercontent.com/3300789/56752797-04c56c00-6781-11e9-94f2-9ef121954ff7.png)

Facebook share window:
![sharefb](https://user-images.githubusercontent.com/3300789/56805866-32aebd00-6822-11e9-941a-e1969c1460de.png)

Twitter share window:
![sharetwitter](https://user-images.githubusercontent.com/3300789/56805872-36424400-6822-11e9-9139-89235427b064.png)

Linkedin share window
![sharelinkedin](https://user-images.githubusercontent.com/3300789/56805876-39d5cb00-6822-11e9-9777-641aeac80224.png)

email share window (w default email set to gmail):
![shareemail](https://user-images.githubusercontent.com/3300789/56805885-3d695200-6822-11e9-914b-3f968bd24237.png)
