### PR TITLE
Adding survey to thank you page flow

### DIFF
--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionSurvey/ContributionSurvey.scss
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionSurvey/ContributionSurvey.scss
@@ -5,27 +5,8 @@
   margin: 0 -10px;
   padding: 0 10px;
 
-  h3 {
-    font-family: $gu-text-egyptian-web;
-    letter-spacing: -0.5px;
-    font-weight: 900;
-    font-size: 17px;
-    margin: ($gu-v-spacing / 3) 0;
-  }
-
-  .component-contributions-survey__button {
-    display: inline-block;
-    margin-bottom: $gu-v-spacing * 3;
+  .component-button {
     margin-top: $gu-v-spacing;
-
-    .button--survey {
-      background-color: gu-colour(neutral-7);
-      color: white;
-    }
-  }
-
-  .component-cta-link__text {
-    padding-right: 25px;
-    font-size: 16px;
+    margin-bottom: $gu-v-spacing * 2;
   }
 }

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionSurvey/ContributionsSurvey.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionSurvey/ContributionsSurvey.jsx
@@ -3,19 +3,24 @@
 // ----- Imports ----- //
 
 import React from 'react';
+import { type ContributionType } from 'helpers/contributions';
 import AnchorButton from 'components/button/anchorButton';
 
 // ----- Component ----- //
 
-export default function ContributionsSurvey(props) {
+type PropTypes = {|
+  contributionType: ContributionType,
+|};
+
+export default function ContributionsSurvey(props: PropTypes) {
   const surveyLink = props.contributionType === 'ONE_OFF' ? 'https://www.surveymonkey.com/r/SCPJHTW' : 'https://www.surveymonkey.com/r/RY2G6HM';
 
   return (
     <div className="component-contributions-survey">
-        <h3 className="confirmation__title">Tell us about your contribution</h3>
-        <p className="confirmation__message">
+      <h3 className="confirmation__title">Tell us about your contribution</h3>
+      <p className="confirmation__message">
           Please fill out this short form to help us learn a little more about your support for The Guardian
-        </p>
+      </p>
       <AnchorButton
         href={surveyLink}
         appearance="secondary"

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionSurvey/ContributionsSurvey.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionSurvey/ContributionsSurvey.jsx
@@ -8,7 +8,7 @@ import AnchorButton from 'components/button/anchorButton';
 // ----- Component ----- //
 
 export default function ContributionsSurvey(props) {
-  const surveyLink = props.contributionType === 'ONE_OFF' ? 'https://google.com' : 'https://yahoo.com'
+  const surveyLink = props.contributionType === 'ONE_OFF' ? 'https://www.surveymonkey.com/r/SCPJHTW' : 'https://www.surveymonkey.com/r/RY2G6HM';
 
   return (
     <div className="component-contributions-survey">

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionSurvey/ContributionsSurvey.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionSurvey/ContributionsSurvey.jsx
@@ -3,30 +3,26 @@
 // ----- Imports ----- //
 
 import React from 'react';
-
-import { ButtonWithRightArrow } from '../ButtonWithRightArrow/ButtonWithRightArrow';
+import AnchorButton from 'components/button/anchorButton';
 
 // ----- Component ----- //
 
-export default function ContributionsSurvey() {
+export default function ContributionsSurvey(props) {
+  const surveyLink = props.contributionType === 'ONE_OFF' ? 'https://google.com' : 'https://yahoo.com'
 
   return (
     <div className="component-contributions-survey">
-      <h3>
-        Please tell us about your contribution to The Guardian by filling out this short form.
-      </h3>
-      <ButtonWithRightArrow
-        componentClassName="component-contributions-survey__button"
-        buttonClassName="button--survey"
-        accessibilityHintId="Please tell us about your contribution to The Guardian by filling out this short form."
-        type="button"
-        buttonCopy="Share your thoughts"
-        onClick={
-          () => {
-            window.location.assign('https://www.surveymonkey.co.uk/r/QVKCKXQ');
-          }
-        }
-      />
+        <h3 className="confirmation__title">Tell us about your contribution</h3>
+        <p className="confirmation__message">
+          Please fill out this short form to help us learn a little more about your support for The Guardian
+        </p>
+      <AnchorButton
+        href={surveyLink}
+        appearance="secondary"
+        aria-label="Link to contribution survey"
+      >
+        Share your thoughts
+      </AnchorButton>
     </div>
   );
 

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionSurvey/ContributionsSurvey.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionSurvey/ContributionsSurvey.jsx
@@ -25,5 +25,4 @@ export default function ContributionsSurvey(props) {
       </AnchorButton>
     </div>
   );
-
 }

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
@@ -44,7 +44,6 @@ function mapDispatchToProps(dispatch: Dispatch<Action>) {
 // ----- Render ----- //
 
 function ContributionThankYou(props: PropTypes) {
-
   let directDebitHeaderSuffix = '';
   let directDebitMessageSuffix = '';
 
@@ -65,7 +64,7 @@ function ContributionThankYou(props: PropTypes) {
           </section>
         ) : null}
         <MarketingConsent />
-        <ContributionSurvey contributionType={props.contributionType}/>
+        <ContributionSurvey contributionType={props.contributionType} />
         <SpreadTheWord />
         <div className="gu-content__return-link">
           <AnchorButton

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
@@ -14,6 +14,7 @@ import AnchorButton from 'components/button/anchorButton';
 import SvgArrowLeft from 'components/svgs/arrowLeftStraight';
 import { DirectDebit } from 'helpers/paymentMethods';
 import SpreadTheWord from 'components/spreadTheWord/spreadTheWord';
+import ContributionSurvey from '../ContributionSurvey/ContributionsSurvey';
 
 // ----- Types ----- //
 
@@ -64,6 +65,7 @@ function ContributionThankYou(props: PropTypes) {
           </section>
         ) : null}
         <MarketingConsent />
+        <ContributionSurvey contributionType={props.contributionType}/>
         <SpreadTheWord />
         <div className="gu-content__return-link">
           <AnchorButton

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYouPasswordSet.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYouPasswordSet.jsx
@@ -8,10 +8,11 @@ import AnchorButton from 'components/button/anchorButton';
 import SvgArrowLeft from 'components/svgs/arrowLeftStraight';
 import { ContributionThankYouBlurb } from './ContributionThankYouBlurb';
 import SpreadTheWord from 'components/spreadTheWord/spreadTheWord';
+import ContributionSurvey from '../ContributionSurvey/ContributionsSurvey';
 
 // ----- Render ----- //
 
-function ContributionThankYouPasswordSet() {
+function ContributionThankYouPasswordSet(props: PropTypes) {
   return (
     <div className="thank-you__container">
       <div className="gu-content__form gu-content__form--thank-you gu-content__form--password-set">
@@ -23,6 +24,7 @@ function ContributionThankYouPasswordSet() {
           </p>
         </section>
         <MarketingConsent />
+        <ContributionSurvey contributionType={props.contributionType}/>
         <SpreadTheWord />
         <div className="gu-content__return-link">
           <AnchorButton

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYouPasswordSet.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYouPasswordSet.jsx
@@ -3,6 +3,8 @@
 // ----- Imports ----- //
 
 import React from 'react';
+import { connect } from 'react-redux';
+import { type ContributionType } from 'helpers/contributions';
 import MarketingConsent from '../MarketingConsentContainer';
 import AnchorButton from 'components/button/anchorButton';
 import SvgArrowLeft from 'components/svgs/arrowLeftStraight';
@@ -10,9 +12,18 @@ import { ContributionThankYouBlurb } from './ContributionThankYouBlurb';
 import SpreadTheWord from 'components/spreadTheWord/spreadTheWord';
 import ContributionSurvey from '../ContributionSurvey/ContributionsSurvey';
 
+type PropTypes = {|
+  contributionType: ContributionType,
+|};
+
+const mapStateToProps = state => ({
+  contributionType: state.page.form.contributionType,
+});
+
 // ----- Render ----- //
 
 function ContributionThankYouPasswordSet(props: PropTypes) {
+
   return (
     <div className="thank-you__container">
       <div className="gu-content__form gu-content__form--thank-you gu-content__form--password-set">
@@ -24,7 +35,7 @@ function ContributionThankYouPasswordSet(props: PropTypes) {
           </p>
         </section>
         <MarketingConsent />
-        <ContributionSurvey contributionType={props.contributionType}/>
+        <ContributionSurvey contributionType={props.contributionType} />
         <SpreadTheWord />
         <div className="gu-content__return-link">
           <AnchorButton
@@ -44,4 +55,4 @@ function ContributionThankYouPasswordSet(props: PropTypes) {
   );
 }
 
-export default ContributionThankYouPasswordSet;
+export default connect(mapStateToProps)(ContributionThankYouPasswordSet);


### PR DESCRIPTION
## Why are you doing this?
We are running a survey for our contributors with separate links for one-offs and recurring, respectively.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/yu5QLGBG/1012-implement-survey-button-on-new-thank-you-page)

## Changes

* Rewrite of the survey component
* Adding survey link component to thank you page and password set page

## Screenshots
Thank you page:
<img width="1241" alt="survey_thankyou" src="https://user-images.githubusercontent.com/3300789/56815296-e4f17f00-6838-11e9-9e71-3a81de5e56b2.png">

Password set page:
<img width="1196" alt="survey_passwordset" src="https://user-images.githubusercontent.com/3300789/56815232-b673a400-6838-11e9-8031-313fe40d461a.png">
