### PR TITLE
Update print checkout so no radio button is selected for billing address y / n

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-checkout/components-checkout/checkoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components-checkout/checkoutForm.jsx
@@ -162,27 +162,31 @@ function CheckoutForm(props: PropTypes) {
           </FormSection>
           <FormSection title="Is the billing address the same as the delivery address?">
             <Rows>
-              <Fieldset legend="Is the billing address the same as the delivery address?">
+              <FieldsetWithError
+                id="billingAddressIsSame"
+                error={firstError('billingAddressIsSame', props.formErrors)}
+                legend="Is the billing address the same as the delivery address?">
                 <RadioInput
                   text="Yes"
                   name="billingAddressIsSame"
-                  checked={props.billingAddressIsSame}
+                  checked={props.billingAddressIsSame === true}
                   onChange={() => props.setbillingAddressIsSame(true)}
                 />
                 <RadioInput
                   text="No"
                   name="billingAddressIsSame"
-                  checked={!props.billingAddressIsSame}
+                  checked={props.billingAddressIsSame === false}
                   onChange={() => props.setbillingAddressIsSame(false)}
                 />
-              </Fieldset>
+              </FieldsetWithError>
             </Rows>
           </FormSection>
           {
-            props.billingAddressIsSame ? null :
+            props.billingAddressIsSame === false ?
             <FormSection title="Where should we bill you?">
               <BillingAddress />
             </FormSection>
+            : null
           }
           <FormSection title="When would you like your subscription to start?">
             <Rows>

--- a/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckoutReducer.js
+++ b/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckoutReducer.js
@@ -65,7 +65,7 @@ export type FormFields = {|
   startDate: Option<string>,
   telephone: Option<string>,
   paymentMethod: Option<PaymentMethod>,
-  billingAddressIsSame: boolean,
+  billingAddressIsSame: boolean | null,
 |};
 
 export type FormField = $Keys<FormFields>;
@@ -101,7 +101,7 @@ export type Action =
   | { type: 'SET_FORM_ERRORS', errors: FormError<FormField>[] }
   | { type: 'SET_SUBMISSION_ERROR', error: ErrorReason }
   | { type: 'SET_FORM_SUBMITTED', formSubmitted: boolean }
-  | { type: 'SET_BILLING_ADDRESS_IS_SAME', isSame: boolean }
+  | { type: 'SET_BILLING_ADDRESS_IS_SAME', isSame: boolean | null }
   | DDAction
   | AddressAction;
 
@@ -222,7 +222,7 @@ const formActionCreators = {
   onPaymentAuthorised: (authorisation: PaymentAuthorisation) => (dispatch: Dispatch<Action>, getState: () => State) =>
     onPaymentAuthorised(authorisation, dispatch, getState()),
   submitForm: () => (dispatch: Dispatch<Action>, getState: () => State) => submitForm(dispatch, getState()),
-  setbillingAddressIsSame: (isSame: boolean): Action => ({ type: 'SET_BILLING_ADDRESS_IS_SAME', isSame }),
+  setbillingAddressIsSame: (isSame: boolean | null): Action => ({ type: 'SET_BILLING_ADDRESS_IS_SAME', isSame }),
 };
 
 export type FormActionCreators = typeof formActionCreators;

--- a/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckoutReducer.js
+++ b/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckoutReducer.js
@@ -145,6 +145,13 @@ function getErrors(fields: FormFields): FormError<FormField>[] {
       rule: notNull(fields.startDate),
       error: formError('startDate', 'Please select a start date'),
     },
+    {
+      rule: notNull(fields.billingAddressIsSame),
+      error: formError(
+        'billingAddressIsSame',
+        'Please indicate whether the billing address is the same as the delivery address',
+      ),
+    },
   ]);
 }
 
@@ -256,7 +263,7 @@ function initReducer(initialCountry: IsoCountry, productInUrl: ?string, fulfillm
     isTestUser: isTestUser(),
     ...product,
     productPrices,
-    billingAddressIsSame: true,
+    billingAddressIsSame: null,
   };
 
   function reducer(state: CheckoutState = initialState, action: Action): CheckoutState {


### PR DESCRIPTION
## Why are you doing this?
The work is detailed in this [**Trello Card**](https://trello.com/c/yptRgLHj/2368-remove-pre-selection-of-is-billing-address-the-same-as-delivery-address-in-print-checkout)

## Changes
* Removes the preselected 'yes' to the question 'Is the billing address the same as the delivery address?'
* Adds an error if the user does not select an option, asking them to pick

## Screenshots
### Before
![Screen Shot 2019-04-26 at 13 39 13](https://user-images.githubusercontent.com/16781258/56808150-b53a7b00-6828-11e9-9a45-7da8d7a92925.png)

### After
![Screen Shot 2019-04-26 at 13 38 08](https://user-images.githubusercontent.com/16781258/56808165-ba97c580-6828-11e9-8ddc-2a94b36f3589.png)

### Error state
![Screen Shot 2019-04-26 at 13 38 26](https://user-images.githubusercontent.com/16781258/56808174-bf5c7980-6828-11e9-9c2f-5a9a14d9a4b6.png)
