### PR TITLE
Update thankYou page copy.jsx

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-checkout/components-ty/thankYou.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components-ty/thankYou.jsx
@@ -88,7 +88,7 @@ function ThankYouContent({
         >
           {isPending ?
           `Your subscription to the ${productOption} package is being processed` :
-          `You are now subscribed to the ${productOption} package`
+          `You have now subscribed to the ${productOption} package`
   }
         </HeadingBlock>
       </HeroWrapper>


### PR DESCRIPTION
## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->To improve the English of the confirmation message on the thank you page.

[**Trello Card**](https://trello.com)

## Changes

* Update confirmation copy to say "You have now subscribed..."

## Screenshots
Current:
![image](https://user-images.githubusercontent.com/45856485/56811701-3e55b000-6831-11e9-99c6-9482372eae8c.png)

New:
I can't screenshot this 
