### PR TITLE
Log the product type in the RequestInfo object to make triaging failed executions easier

### DIFF
--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -26,7 +26,9 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
       .map(paymentMethod =>
         HandlerResult(
           getCreateSalesforceContactState(state, paymentMethod),
-          requestInfo.appendMessage(s"Payment method is ${paymentMethod.toFriendlyString}")
+          requestInfo
+            .appendMessage(s"Payment method is ${paymentMethod.toFriendlyString}")
+            .appendMessage(s"Product is ${state.product.describe}")
         ))
   }
 


### PR DESCRIPTION

## Why are you doing this?

Logging the product type into the RequestInfo object will make it easier to see quickly which team needs to investigate when a step function execution fails.
