### PR TITLE
Bump webpack-dev-server to 3.1.11

### DIFF
--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -126,7 +126,7 @@
     "sass-mq": "^5.0.0",
     "webpack": "^4.16.2",
     "webpack-cli": "^3.1.0",
-    "webpack-dev-server": "3.1.5",
+    "webpack-dev-server": "3.1.11",
     "webpack-manifest-plugin": "2.0.3",
     "webpack-merge": "^4.1.3",
     "webpack-stats-plugin": "^0.2.1"


### PR DESCRIPTION
## Why are you doing this?

According to Github, version 3.1.5 of webpack-dev-server is affected by CVE-2018-14732. And that warning at the top of the repo is freaking me out.

As far as I can tell this is only used for local development so I think we're good? 