### PR TITLE
New test for weekly breakdown

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -4,21 +4,21 @@ import type { Tests } from './abtest';
 // ----- Tests ----- //
 
 
-export type EditorialiseAmountsVariant = 'control' | 'dailyBreakdownAnnual' | 'weeklyBreakdownAnnual' | 'notintest';
+export type EditorialiseAmountsRoundTwoVariant = 'control' | 'defaultAnnual' | 'weeklyBreakdownMonthlyAsWell' | 'notintest';
 
 export const tests: Tests = {
 
-  editorialiseAmounts: {
+  editorialiseAmountsRoundTwo: {
     type: 'OTHER',
     variants: [
       {
         id: 'control',
       },
       {
-        id: 'dailyBreakdownAnnual',
+        id: 'defaultAnnual',
       },
       {
-        id: 'weeklyBreakdownAnnual',
+        id: 'weeklyBreakdownMonthlyAsWell',
       },
     ],
     audiences: {

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -1190,12 +1190,12 @@ form {
 
 // Editorialise Amounts Test
 
-.editorialise-amounts-test-copy {
+.amount-per-week-breakdown {
   margin-top: $gu-v-spacing;
   font-style: italic;
   line-height: 20px;
 }
 
-.editorialise-amounts-test-copy:empty {
+.amount-per-week-breakdown:empty {
   display: none;
 }

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -46,6 +46,7 @@ import { setExistingPaymentMethods } from 'helpers/page/commonActions';
 import { doesUserAppearToBeSignedIn } from 'helpers/user/user';
 import { isSwitchOn } from 'helpers/globals';
 import type { ContributionTypes } from 'helpers/contributions';
+import type { EditorialiseAmountsRoundTwoVariant } from '../../helpers/abTests/abtestDefinitions';
 
 // ----- Functions ----- //
 
@@ -67,6 +68,7 @@ function getInitialPaymentMethod(
 function getInitialContributionType(
   countryGroupId: CountryGroupId,
   contributionTypes: ContributionTypes,
+  editorialiseAmountsRoundTwoVariant: string,
 ): ContributionType {
 
   const contributionType = getContributionTypeFromUrl() || getContributionTypeFromSession();
@@ -75,6 +77,10 @@ function getInitialContributionType(
   if (contributionType &&
     contributionTypes[countryGroupId].find(ct => ct.contributionType === contributionType)) {
     return contributionType;
+  }
+
+  if (editorialiseAmountsRoundTwoVariant === 'defaultAnnual') {
+    return 'ANNUAL';
   }
 
   const defaultContributionType = contributionTypes[countryGroupId].find(ct => ct.isDefault);
@@ -187,7 +193,11 @@ function selectInitialContributionTypeAndPaymentMethod(state: State, dispatch: F
   const { countryId } = state.common.internationalisation;
   const { switches, contributionTypes } = state.common.settings;
   const { countryGroupId } = state.common.internationalisation;
-  const contributionType = getInitialContributionType(countryGroupId, contributionTypes);
+  const contributionType = getInitialContributionType(
+    countryGroupId,
+    contributionTypes,
+    state.common.abParticipations.editorialiseAmountsRoundTwo
+  );
   const paymentMethod = getInitialPaymentMethod(contributionType, countryId, switches);
   dispatch(updateContributionTypeAndPaymentMethod(contributionType, paymentMethod));
 }

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -46,7 +46,6 @@ import { setExistingPaymentMethods } from 'helpers/page/commonActions';
 import { doesUserAppearToBeSignedIn } from 'helpers/user/user';
 import { isSwitchOn } from 'helpers/globals';
 import type { ContributionTypes } from 'helpers/contributions';
-import type { EditorialiseAmountsRoundTwoVariant } from '../../helpers/abTests/abtestDefinitions';
 
 // ----- Functions ----- //
 
@@ -196,7 +195,7 @@ function selectInitialContributionTypeAndPaymentMethod(state: State, dispatch: F
   const contributionType = getInitialContributionType(
     countryGroupId,
     contributionTypes,
-    state.common.abParticipations.editorialiseAmountsRoundTwo
+    state.common.abParticipations.editorialiseAmountsRoundTwo,
   );
   const paymentMethod = getInitialPaymentMethod(contributionType, countryId, switches);
   dispatch(updateContributionTypeAndPaymentMethod(contributionType, paymentMethod));

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/checkoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/checkoutForm.jsx
@@ -166,7 +166,8 @@ function CheckoutForm(props: PropTypes) {
               <FieldsetWithError
                 id="billingAddressIsSame"
                 error={firstError('billingAddressIsSame', props.formErrors)}
-                legend="Is the billing address the same as the delivery address?">
+                legend="Is the billing address the same as the delivery address?"
+              >
                 <RadioInput
                   text="Yes"
                   name="billingAddressIsSame"
@@ -184,9 +185,9 @@ function CheckoutForm(props: PropTypes) {
           </FormSection>
           {
             props.billingAddressIsSame === false ?
-            <FormSection title="Where should we bill you?">
-              <BillingAddress />
-            </FormSection>
+              <FormSection title="Where should we bill you?">
+                <BillingAddress />
+              </FormSection>
             : null
           }
           <FormSection title="When would you like your subscription to start?">


### PR DESCRIPTION
We want to test defaulting to annual against defaulting to monthly (= control), but also want to see what effect putting the weekly breakdown on monthly has when monthly is the default and is therefore immediately on the page when people arrive

# control
## default tab
<img width="487" alt="control" src="https://user-images.githubusercontent.com/5122968/57015707-29509680-6c0e-11e9-993a-a4549ee26c66.png">

## annual tab
<img width="487" alt="control-annual" src="https://user-images.githubusercontent.com/5122968/57015708-29509680-6c0e-11e9-90ce-12366782f902.png">

# defaultAnnual
## default tab
<img width="487" alt="default-annual" src="https://user-images.githubusercontent.com/5122968/57015723-366d8580-6c0e-11e9-9008-304e612a0ca2.png">

## monthly tab
<img width="487" alt="Screenshot 2019-05-01 at 12 46 10" src="https://user-images.githubusercontent.com/5122968/57015917-2ace8e80-6c0f-11e9-9e1f-243ae536798c.png">

# weeklyBreakdownMonthlyAsWell
## default tab
<img width="487" alt="weeklyBreakdownMonthlyAsWell" src="https://user-images.githubusercontent.com/5122968/57015731-3ff6ed80-6c0e-11e9-80d0-bd53a1702083.png">

## annual tab
<img width="487" alt="Screenshot 2019-05-01 at 12 44 58" src="https://user-images.githubusercontent.com/5122968/57015880-01adfe00-6c0f-11e9-870b-5e6501a61463.png">


@jessewilkins