### PR TITLE
Send tracking events when a user selects a payment method

### DIFF
--- a/support-frontend/assets/helpers/tracking/ophanComponentEventTracking.js
+++ b/support-frontend/assets/helpers/tracking/ophanComponentEventTracking.js
@@ -3,11 +3,11 @@
 
 import * as ophan from 'ophan';
 import { gaEvent } from 'helpers/tracking/googleTagManager';
-import type { Participations } from 'helpers/abTests/abtest';
+import type { Participations, TestId } from 'helpers/abTests/abtest';
 import { optimizeIdToTestName } from 'helpers/tracking/acquisitions';
 import type { OptimizeExperiment, OptimizeExperiments } from 'helpers/optimize/optimize';
-import type { TestId } from 'helpers/abTests/abtest';
 import { readExperimentsFromSession } from 'helpers/optimize/optimize';
+import type { PaymentMethod } from 'helpers/paymentMethods';
 
 // ----- Types ----- //
 
@@ -86,6 +86,23 @@ type OphanABPayload = {
 const trackComponentEvents = (componentEvent: OphanComponentEvent) => {
   ophan.record({
     componentEvent,
+  });
+};
+
+const trackPaymentMethodSelected = (paymentMethod: PaymentMethod): void => {
+  gaEvent({
+    category: 'click',
+    action: 'payment-method-selected',
+    label: paymentMethod,
+  });
+
+  trackComponentEvents({
+    component: {
+      componentType: 'ACQUISITIONS_OTHER',
+      id: 'subscriptions-payment-method-selector',
+    },
+    action: 'CLICK',
+    value: paymentMethod,
   });
 };
 
@@ -179,4 +196,5 @@ export {
   trackCheckoutSubmitAttempt,
   trackAbTests,
   trackNewOptimizeExperiment,
+  trackPaymentMethodSelected,
 };

--- a/support-frontend/assets/pages/digital-subscription-checkout/__tests__/digitalSubscriptionCheckoutReducerTest.js
+++ b/support-frontend/assets/pages/digital-subscription-checkout/__tests__/digitalSubscriptionCheckoutReducerTest.js
@@ -3,8 +3,7 @@
 // ----- Imports ----- //
 
 import { initReducer, type Stage } from '../digitalSubscriptionCheckoutReducer';
-import { setStage, setFormErrors } from '../digitalSubscriptionCheckoutActions';
-import { DirectDebit, Stripe } from 'helpers/paymentMethods';
+import { setFormErrors, setStage } from '../digitalSubscriptionCheckoutActions';
 
 jest.mock('ophan', () => {});
 jest.mock('helpers/fontLoader', () => () => ({}));
@@ -14,15 +13,6 @@ describe('Digital Subscription Checkout Reducer', () => {
 
   global.guardian = { productPrices: null };
 
-  it('should default to Direct Debit if the country is GB', () => {
-    const reducer = initReducer('GB');
-    expect(reducer(undefined, {}).checkout.paymentMethod).toEqual(DirectDebit);
-  });
-
-  it('should default to Stripe if the country is US', () => {
-    const reducer = initReducer('US');
-    expect(reducer(undefined, {}).checkout.paymentMethod).toEqual(Stripe);
-  });
 
   it('should handle SET_STAGE to "thankyou"', () => {
 

--- a/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutActions.js
+++ b/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutActions.js
@@ -15,6 +15,8 @@ import type { ErrorReason } from '../../helpers/errorReasons';
 import type { PaymentMethod } from 'helpers/paymentMethods';
 import { PayPal } from 'helpers/paymentMethods';
 import type { Action as AddressAction } from 'components/subscriptionCheckouts/address/addressFieldsStore';
+import * as storage from 'helpers/storage';
+import { trackPaymentMethodSelected } from 'helpers/tracking/ophanComponentEventTracking';
 
 export type Action =
   | { type: 'SET_STAGE', stage: Stage }
@@ -45,6 +47,8 @@ const formActionCreators = {
   setBillingPeriod: (billingPeriod: DigitalBillingPeriod): Action => ({ type: 'SET_BILLING_PERIOD', billingPeriod }),
   setPaymentMethod: (paymentMethod: PaymentMethod) => (dispatch: Dispatch<Action>, getState: () => State) => {
     const state = getState();
+    storage.setSession('selectedPaymentMethod', paymentMethod);
+    trackPaymentMethodSelected(paymentMethod);
     if (paymentMethod === PayPal && !state.page.checkout.payPalHasLoaded) {
       showPayPal(dispatch);
     }

--- a/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
+++ b/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckoutReducer.js
@@ -26,7 +26,6 @@ import type { Action } from './digitalSubscriptionCheckoutActions';
 import { getUser } from './helpers/user';
 import { countrySupportsDirectDebit, showPaymentMethod } from './helpers/paymentProviders';
 import type { PaymentMethod } from 'helpers/paymentMethods';
-import { DirectDebit, Stripe } from 'helpers/paymentMethods';
 import type {
   FormFields as AddressFormFields,
   State as AddressState,
@@ -122,7 +121,7 @@ function initReducer(initialCountry: IsoCountry) {
     lastName: user.lastName || '',
     telephone: null,
     billingPeriod: initialBillingPeriod,
-    paymentMethod: countrySupportsDirectDebit(initialCountry) ? DirectDebit : Stripe,
+    paymentMethod: null,
     formErrors: [],
     submissionError: null,
     formSubmitted: false,


### PR DESCRIPTION
## Why are you doing this?
We want to track what payment methods users are selecting on the Digital Pack checkout page so that we can analyse drop off rates for each method.
