### PR TITLE
SaleHeader updates

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
@@ -171,7 +171,7 @@ function getCopy(product: SubscriptionProduct, country: CountryGroupId) {
     };
   }
   return {
-    heading: 'Digital Pack',
+    heading: 'Digital Pack subscriptions',
     subHeading: 'The premium Guardian experience, ad-free on all your devices',
   };
 }

--- a/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
@@ -176,13 +176,14 @@ function getCopy(product: SubscriptionProduct, country: CountryGroupId) {
   };
 }
 
-function SaleHeader(props: PropTypes) {
+function CampaignHeader(props: PropTypes) {
   const product: SubscriptionProduct = 'DigitalPack';
+  const copy = getCopy(product, props.countryGroupId);
   return (
     <ProductPagehero
       appearance="campaign"
-      overheading="Digital Pack subscriptions"
-      heading="The premium Guardian experience, ad-free on all your devices"
+      overheading={copy.heading}
+      heading={copy.subHeading}
       modifierClasses={['digital-campaign']}
       content={<AnchorButton aria-label="See Subscription options for Digital Pack" onClick={sendTrackingEventsOnClick('options_cta_click', 'DigitalPack', null)} icon={<SvgChevron />} href="#subscribe">See Subscription options</AnchorButton>}
       hasCampaign
@@ -283,4 +284,4 @@ function DigitalSubscriptionLandingHeader(props: PropTypes) {
   );
 }
 
-export { SaleHeader, DigitalSubscriptionLandingHeader };
+export { CampaignHeader, DigitalSubscriptionLandingHeader };

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -22,7 +22,7 @@ import ProductPageInfoChip from 'components/productPage/productPageInfoChip/prod
 import 'stylesheets/skeleton/skeleton.scss';
 
 
-import { SaleHeader } from './components/digitalSubscriptionLandingHeader';
+import { CampaignHeader } from './components/digitalSubscriptionLandingHeader';
 import IndependentJournalismSection from './components/independentJournalismSection';
 import ProductBlock from './components/productBlock';
 import PromotionPopUp from './components/promotionPopUp';
@@ -80,7 +80,7 @@ const content = (
         </Footer>}
     >
 
-      <SaleHeader countryGroupId={countryGroupId} />
+      <CampaignHeader countryGroupId={countryGroupId} />
 
       <ProductBlock countryGroupId={countryGroupId} />
       <AdFreeSection headingSize={2} />

--- a/support-frontend/assets/pages/paper-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/hero/hero.jsx
@@ -24,6 +24,7 @@ function getHeading(): string {
   }
 
   return 'Save up to 37% on The Guardian and The Observer - all year round';
+
 }
 
 const TimerIfActive = () => (showCountdownTimer('Paper', GBPCountries) ? (
@@ -83,11 +84,11 @@ const DefaultHeader = () => (
   </header>
 );
 
-const SaleHeader = () => (
+const CampaignHeader = () => (
   <ProductPagehero
     appearance="campaign"
     overheading="The Guardian newspaper subscriptions"
-    heading="Save up to 37% on The Guardian and The Observer - all year round"
+    heading={getHeading()}
     modifierClasses={['paper-sale']}
     content={<AnchorButton aria-label={null} onClick={sendTrackingEventsOnClick('options_cta_click', 'Paper', null)} icon={<SvgChevron />} href="#subscribe">See Subscription options</AnchorButton>}
     hasCampaign
@@ -120,4 +121,4 @@ const SaleHeader = () => (
   </ProductPagehero>
 );
 
-export { DefaultHeader, SaleHeader, HeroPicture };
+export { DefaultHeader, CampaignHeader, HeroPicture };

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
@@ -19,7 +19,7 @@ import { flashSaleIsActive, getSaleCopy } from 'helpers/flashSale';
 import { GBPCountries } from 'helpers/internationalisation/countryGroup';
 import 'stylesheets/skeleton/skeleton.scss';
 
-import { SaleHeader } from './components/hero/hero';
+import { CampaignHeader } from './components/hero/hero';
 import Tabs from './components/tabs';
 import TabsContent from './components/content/content';
 import reducer from './paperSubscriptionLandingPageReducer';
@@ -66,7 +66,7 @@ const content = (
       header={<Header />}
       footer={<Footer />}
     >
-      <SaleHeader />
+      <CampaignHeader />
       {paperHasDeliveryEnabled() &&
         <Content needsHigherZindex>
           <Text>

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.jsx
@@ -48,7 +48,7 @@ const DefaultHeader = () => (
   </header>
 );
 
-const SaleHeader = () => (
+const CampaignHeader = () => (
   <ProductPagehero
     appearance="campaign"
     overheading="Guardian Weekly subscriptions"
@@ -80,4 +80,4 @@ const SaleHeader = () => (
 );
 
 
-export { DefaultHeader, SaleHeader };
+export { DefaultHeader, CampaignHeader };

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -21,7 +21,7 @@ import SvgGift from 'components/svgs/gift';
 import { AUDCountries, Canada, EURCountries, GBPCountries, International, NZDCountries, UnitedStates } from 'helpers/internationalisation/countryGroup';
 import 'stylesheets/skeleton/skeleton.scss';
 
-import { SaleHeader } from './components/hero/hero';
+import { CampaignHeader } from './components/hero/hero';
 
 import WeeklyForm from './components/weeklyForm';
 import reducer from './weeklySubscriptionLandingReducer';
@@ -75,7 +75,7 @@ const content = (
       header={<Header />}
       footer={<Footer />}
     >
-      <SaleHeader />
+      <CampaignHeader />
       <Content>
         <Text title="Open up your world view, Weekly">
           <LargeParagraph>Inside the essential magazine from


### PR DESCRIPTION
## Why are you doing this?

Each product page has two banner options Default and Campaign. The campaign banner was confusingingly called SaleHeader even though it was not related to a _sales_ as such. 

The Campaign Banner also had not been updated to include flash sale text.

## Changes

* Rename SaleHeader to CampaignHeader because it makes more sense
* Introduce flash sale text to CampaignHeader

