### PR TITLE
Update headline copy on Print product page

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/hero/hero.jsx
@@ -94,7 +94,7 @@ const SaleHeader = () => (
   >
     <div className="sale-joy-of-print">
       <div className="sale-joy-of-print-copy">
-        <h2>Works with different browsers</h2>
+        <h2>Subscribe to the joy of print</h2>
         <p>Get your hands on journalism that’s really worth keeping.</p>
       </div>
 


### PR DESCRIPTION
## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->Updating the headline on the print product page in line with the new campaign messaging.


## Changes

* Update copy in headline to "subscribe to the joy print"

## Screenshots
Current:
![image](https://user-images.githubusercontent.com/45856485/57290246-ed597d80-70b4-11e9-9269-c05277824a3f.png)

New:
![image](https://user-images.githubusercontent.com/45856485/57290261-f5192200-70b4-11e9-9ffc-c64fd560a0d1.png)
