### PR TITLE
Colour and heading updates to accommodate campaign branding updates

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-landing/components/hero/joyOfPrint.scss
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/hero/joyOfPrint.scss
@@ -25,15 +25,18 @@
     
     h2 {
       font-family: $gu-titlepiece;
-      max-width: gu-span(4);
+      max-width: gu-span(3);
       margin: 0 0 $gu-v-spacing/2 0;
-      color: #AD227E;
+      color: #E94D9E;
     }
     p {
       @include gu-fontset-heading;
     }
-    @include mq($from: tablet) {
-      font-size: 60px;
+  }
+  @include mq($from: desktop) {
+    font-size: 60px;
+    h2 {
+      max-width: gu-span(4);
     }
   }
 }
@@ -88,8 +91,8 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: #ab8b62;
-  color: gu-colour(neutral-100);
+  background: #f8c7d0;
+  color: gu-colour(neutral-7);
   text-align: center;
   border-radius: 50%;
   line-height: 1;


### PR DESCRIPTION
## Why are you doing this?

The hero banner requires updates to match campaign branding updates

## Changes

* Update styles for heading size and colour and roundel bg/text colour 

## Screenshots

**Before**
![Screen Shot 2019-05-07 at 11 35 31](https://user-images.githubusercontent.com/1108991/57293360-690af880-70bc-11e9-9787-0947a3e69bfb.png)

**After**
![Screen Shot 2019-05-07 at 11 35 19](https://user-images.githubusercontent.com/1108991/57293379-758f5100-70bc-11e9-8039-87a287d11c45.png)


