### PR TITLE
removed survey links, added documentation for implementing in the future

### DIFF
--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionSurvey/ContributionsSurvey.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionSurvey/ContributionsSurvey.jsx
@@ -13,6 +13,10 @@ type PropTypes = {|
 |};
 
 export default function ContributionsSurvey(props: PropTypes) {
+  /* *******************************************************
+   JTL: Survey links configurable below using payment type
+   make sure to update before launching component again
+   ****************************************************** */
   const surveyLink = props.contributionType === 'ONE_OFF' ? 'https://www.surveymonkey.com/r/SCPJHTW' : 'https://www.surveymonkey.com/r/RY2G6HM';
 
   return (

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
@@ -14,7 +14,6 @@ import AnchorButton from 'components/button/anchorButton';
 import SvgArrowLeft from 'components/svgs/arrowLeftStraight';
 import { DirectDebit } from 'helpers/paymentMethods';
 import SpreadTheWord from 'components/spreadTheWord/spreadTheWord';
-import ContributionSurvey from '../ContributionSurvey/ContributionsSurvey';
 
 // ----- Types ----- //
 
@@ -64,7 +63,6 @@ function ContributionThankYou(props: PropTypes) {
           </section>
         ) : null}
         <MarketingConsent />
-        <ContributionSurvey contributionType={props.contributionType} />
         <SpreadTheWord />
         <div className="gu-content__return-link">
           <AnchorButton

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYouPasswordSet.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYouPasswordSet.jsx
@@ -3,27 +3,14 @@
 // ----- Imports ----- //
 
 import React from 'react';
-import { connect } from 'react-redux';
-import { type ContributionType } from 'helpers/contributions';
 import MarketingConsent from '../MarketingConsentContainer';
 import AnchorButton from 'components/button/anchorButton';
 import SvgArrowLeft from 'components/svgs/arrowLeftStraight';
 import { ContributionThankYouBlurb } from './ContributionThankYouBlurb';
 import SpreadTheWord from 'components/spreadTheWord/spreadTheWord';
-import ContributionSurvey from '../ContributionSurvey/ContributionsSurvey';
-
-type PropTypes = {|
-  contributionType: ContributionType,
-|};
-
-const mapStateToProps = state => ({
-  contributionType: state.page.form.contributionType,
-});
 
 // ----- Render ----- //
-
-function ContributionThankYouPasswordSet(props: PropTypes) {
-
+function ContributionThankYouPasswordSet() {
   return (
     <div className="thank-you__container">
       <div className="gu-content__form gu-content__form--thank-you gu-content__form--password-set">
@@ -35,7 +22,6 @@ function ContributionThankYouPasswordSet(props: PropTypes) {
           </p>
         </section>
         <MarketingConsent />
-        <ContributionSurvey contributionType={props.contributionType} />
         <SpreadTheWord />
         <div className="gu-content__return-link">
           <AnchorButton
@@ -55,4 +41,25 @@ function ContributionThankYouPasswordSet(props: PropTypes) {
   );
 }
 
-export default connect(mapStateToProps)(ContributionThankYouPasswordSet);
+export default ContributionThankYouPasswordSet;
+
+/* *******************************************************
+ JTL: The code below allows for this component to know
+ what kind of contribution the user who set a password
+ has just made. This is useful for sending that user to
+ a particular survey and may have other uses in the future
+******************************************************* */
+// import { connect } from 'react-redux';
+// import { type ContributionType } from 'helpers/contributions';
+// ...
+// type PropTypes = {|
+//   contributionType: ContributionType,
+// |};
+//
+// const mapStateToProps = state => ({
+//   contributionType: state.page.form.contributionType,
+// });
+// ...
+// function ContributionThankYouPasswordSet(props: PropTypes) {
+// ...
+// export default connect(mapStateToProps)(ContributionThankYouPasswordSet);


### PR DESCRIPTION
## Why are you doing this?
The current survey has finished running, so I'm taking those links out and adding in documentation to help re-implement a configurable survey button again in the future

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/pB4N050G/1053-remove-user-survey-post-contribution)

## Changes

* Remove buttons from 'thank you' and 'thank you password set' pages
* Added documentation for adding back configurable survey links in the future, particularly on the 'thank you password set' page, which isn't connected to Redux by default