### PR TITLE
Adds a version of navbar for checkout pages

### DIFF
--- a/support-frontend/assets/components/headers/header/header.jsx
+++ b/support-frontend/assets/components/headers/header/header.jsx
@@ -20,8 +20,7 @@ import './header.scss';
 export type PropTypes = {|
   utility: Option<Node>,
   countryGroupId: ?CountryGroupId,
-  displayNavigation: boolean,
-  displayCheckout?: boolean | void,
+  display?: 'navigation' | 'checkout' | void,
 |};
 export type State = {|
   fitsLinksInOneRow: boolean,
@@ -52,13 +51,13 @@ const getMenuStateMetrics = ({ menuRef, logoRef, containerRef }): State => {
 type TopNavPropTypes = {|
   utility: Node,
   getLogoRef: (?Element) => void,
-  displayCheckout: boolean | void,
+  display: 'navigation' | 'checkout' | void,
 |};
 
-const TopNav = ({ displayCheckout, getLogoRef, utility }: TopNavPropTypes) => (
+const TopNav = ({ display, getLogoRef, utility }: TopNavPropTypes) => (
   <div className="component-header-topnav">
     <div className="component-header-topnav__utility">{utility}</div>
-    {displayCheckout && (
+    {display === 'checkout' && (
       <div className="component-header-topnav__checkout">
         <div />
         <div className="component-header-topnav--checkout-text">
@@ -80,8 +79,7 @@ export default class Header extends Component<PropTypes, State> {
   static defaultProps = {
     utility: null,
     countryGroupId: null,
-    displayNavigation: true,
-    displayCheckout: false,
+    display: 'navigation',
   };
 
   state = {
@@ -90,7 +88,7 @@ export default class Header extends Component<PropTypes, State> {
   };
 
   componentDidMount() {
-    if (this.props.displayNavigation && this.menuRef && this.logoRef && this.containerRef) {
+    if (this.props.display === 'navigation' && this.menuRef && this.logoRef && this.containerRef) {
       this.observer = onElementResize(
         [this.logoRef, this.menuRef, this.containerRef],
         ([logoRef, menuRef, containerRef]) => {
@@ -112,9 +110,7 @@ export default class Header extends Component<PropTypes, State> {
   observer: ElementResizer;
 
   render() {
-    const {
-      utility, displayNavigation, countryGroupId, displayCheckout,
-    } = this.props;
+    const { utility, display, countryGroupId } = this.props;
     const { fitsLinksInOneRow, fitsLinksAtAll } = this.state;
 
     return (
@@ -122,20 +118,20 @@ export default class Header extends Component<PropTypes, State> {
         className={
           classNameWithModifiers('component-header', [
             fitsLinksInOneRow ? 'one-row' : null,
-            displayNavigation ? 'display-navigation' : null,
+            display === 'navigation' ? 'display-navigation' : null,
             !fitsLinksAtAll ? 'display-veggie-burger' : null,
-            displayCheckout ? 'display-checkout' : null,
+            display === 'checkout' ? 'display-checkout' : null,
           ])
         }
       >
         <div className="component-header__wrapper" ref={(el) => { this.containerRef = el; }}>
           <div className="component-header__row">
             <TopNav
-              displayCheckout={displayCheckout}
-              utility={(displayNavigation && fitsLinksAtAll) ? utility : null}
+              display={display}
+              utility={(display === 'navigation' && fitsLinksAtAll) ? utility : null}
               getLogoRef={(el) => { this.logoRef = el; }}
             />
-            {displayNavigation &&
+            {display === 'navigation' &&
               <MobileMenuToggler
                 links={<Links countryGroupId={countryGroupId} location="mobile" />}
                 countryGroupId={countryGroupId}
@@ -143,12 +139,12 @@ export default class Header extends Component<PropTypes, State> {
               />
             }
           </div>
-          {displayNavigation &&
+          {display === 'navigation' &&
             <div className="component-header__row">
               <Links countryGroupId={countryGroupId} location="desktop" getRef={(el) => { this.menuRef = el; }} />
             </div>
           }
-          {displayCheckout &&
+          {display === 'checkout' &&
             <div className="component-header__row component-header-checkout--row">
               <div className="component-header--padlock"><Padlock /></div>
               <div>Checkout</div>

--- a/support-frontend/assets/components/headers/header/header.jsx
+++ b/support-frontend/assets/components/headers/header/header.jsx
@@ -20,6 +20,7 @@ export type PropTypes = {|
   utility: Option<Node>,
   countryGroupId: ?CountryGroupId,
   displayNavigation: boolean,
+  displayCheckout?: boolean | void,
 |};
 export type State = {|
   fitsLinksInOneRow: boolean,
@@ -45,16 +46,23 @@ const getMenuStateMetrics = ({ menuRef, logoRef, containerRef }): State => {
 };
 
 
-// ----- Component ----- //
+// ----- Components ----- //
 
 type TopNavPropTypes = {|
   utility: Node,
-  getLogoRef: (?Element) => void
+  getLogoRef: (?Element) => void,
+  displayCheckout: boolean | null,
 |};
 
-const TopNav = ({ getLogoRef, utility }: TopNavPropTypes) => (
+const TopNav = ({ displayCheckout, getLogoRef, utility }: TopNavPropTypes) => (
   <div className="component-header-topnav">
     <div className="component-header-topnav__utility">{utility}</div>
+    {displayCheckout && (
+      <div className="component-header-topnav__checkout">
+        <div className="component-header-topnav--empty" />
+        <div className="component-header-topnav--checkout-text">Checkout</div>
+      </div>
+    )}
     <div className="component-header-topnav-logo" ref={getLogoRef}>
       <a className="component-header-topnav-logo__graun" href="https://www.theguardian.com">
         <div className="accessibility-hint">The Guardian logo</div>
@@ -69,6 +77,7 @@ export default class Header extends Component<PropTypes, State> {
     utility: null,
     countryGroupId: null,
     displayNavigation: true,
+    displayCheckout: null,
   };
 
   state = {
@@ -99,7 +108,9 @@ export default class Header extends Component<PropTypes, State> {
   observer: ElementResizer;
 
   render() {
-    const { utility, displayNavigation, countryGroupId } = this.props;
+    const {
+      utility, displayNavigation, countryGroupId, displayCheckout,
+    } = this.props;
     const { fitsLinksInOneRow, fitsLinksAtAll } = this.state;
 
     return (
@@ -109,12 +120,14 @@ export default class Header extends Component<PropTypes, State> {
             fitsLinksInOneRow ? 'one-row' : null,
             displayNavigation ? 'display-navigation' : null,
             !fitsLinksAtAll ? 'display-veggie-burger' : null,
+            displayCheckout ? 'display-checkout' : null,
           ])
         }
       >
         <div className="component-header__wrapper" ref={(el) => { this.containerRef = el; }}>
           <div className="component-header__row">
             <TopNav
+              displayCheckout={displayCheckout}
               utility={(displayNavigation && fitsLinksAtAll) ? utility : null}
               getLogoRef={(el) => { this.logoRef = el; }}
             />
@@ -129,6 +142,11 @@ export default class Header extends Component<PropTypes, State> {
           {displayNavigation &&
             <div className="component-header__row">
               <Links countryGroupId={countryGroupId} location="desktop" getRef={(el) => { this.menuRef = el; }} />
+            </div>
+          }
+          {displayCheckout &&
+            <div className="component-header__row component-header-checkout--row">
+              Checkout
             </div>
           }
         </div>

--- a/support-frontend/assets/components/headers/header/header.jsx
+++ b/support-frontend/assets/components/headers/header/header.jsx
@@ -60,7 +60,7 @@ const TopNav = ({ displayCheckout, getLogoRef, utility }: TopNavPropTypes) => (
     <div className="component-header-topnav__utility">{utility}</div>
     {displayCheckout && (
       <div className="component-header-topnav__checkout">
-        <div className="component-header-topnav--empty" />
+        <div />
         <div className="component-header-topnav--checkout-text">
           <div className="component-header--padlock"><Padlock /></div>
           <div>Checkout</div>

--- a/support-frontend/assets/components/headers/header/header.jsx
+++ b/support-frontend/assets/components/headers/header/header.jsx
@@ -9,6 +9,7 @@ import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { classNameWithModifiers } from 'helpers/utilities';
 import { onElementResize, type ElementResizer } from 'helpers/layout';
 import SvgGuardianLogo from 'components/svgs/guardianLogo';
+import Padlock from './padlock.svg';
 
 
 import Links from '../links/links';
@@ -46,7 +47,7 @@ const getMenuStateMetrics = ({ menuRef, logoRef, containerRef }): State => {
 };
 
 
-// ----- Components ----- //
+// ----- Component ----- //
 
 type TopNavPropTypes = {|
   utility: Node,
@@ -60,7 +61,10 @@ const TopNav = ({ displayCheckout, getLogoRef, utility }: TopNavPropTypes) => (
     {displayCheckout && (
       <div className="component-header-topnav__checkout">
         <div className="component-header-topnav--empty" />
-        <div className="component-header-topnav--checkout-text">Checkout</div>
+        <div className="component-header-topnav--checkout-text">
+          <div className="component-header--padlock"><Padlock /></div>
+          <div>Checkout</div>
+        </div>
       </div>
     )}
     <div className="component-header-topnav-logo" ref={getLogoRef}>
@@ -146,7 +150,8 @@ export default class Header extends Component<PropTypes, State> {
           }
           {displayCheckout &&
             <div className="component-header__row component-header-checkout--row">
-              Checkout
+              <div className="component-header--padlock"><Padlock /></div>
+              <div>Checkout</div>
             </div>
           }
         </div>

--- a/support-frontend/assets/components/headers/header/header.jsx
+++ b/support-frontend/assets/components/headers/header/header.jsx
@@ -51,7 +51,7 @@ const getMenuStateMetrics = ({ menuRef, logoRef, containerRef }): State => {
 type TopNavPropTypes = {|
   utility: Node,
   getLogoRef: (?Element) => void,
-  displayCheckout: boolean | null,
+  displayCheckout: boolean | void,
 |};
 
 const TopNav = ({ displayCheckout, getLogoRef, utility }: TopNavPropTypes) => (
@@ -77,7 +77,7 @@ export default class Header extends Component<PropTypes, State> {
     utility: null,
     countryGroupId: null,
     displayNavigation: true,
-    displayCheckout: null,
+    displayCheckout: false,
   };
 
   state = {

--- a/support-frontend/assets/components/headers/header/header.scss
+++ b/support-frontend/assets/components/headers/header/header.scss
@@ -262,7 +262,7 @@ $header-links-min-width: gu-span(12);
         .component-header-topnav--checkout-text {
           border-top: 1px solid gu-colour(brand-pastel);
           border-left: 1px solid gu-colour(brand-pastel);
-          padding: $gu-v-spacing;
+          padding: $gu-v-spacing $gu-h-spacing;
           width: 100%;
           align-self: flex-end;
 
@@ -274,8 +274,7 @@ $header-links-min-width: gu-span(12);
           @include mq($until: tablet) {
             border-left: none;
             border-top: none;
-            margin-top: -16px;
-            padding-left: 2px;
+            padding-left: $gu-h-spacing /4;
           }
         }
       

--- a/support-frontend/assets/components/headers/header/header.scss
+++ b/support-frontend/assets/components/headers/header/header.scss
@@ -36,6 +36,12 @@ $header-links-min-width: gu-span(12);
   }
 }
 
+.component-header--padlock {
+  margin-right: $gu-h-spacing /3;
+  display: inline-block;
+  margin-top: 2px;
+}
+
 .component-header-mobile-menu-toggler {
   display: none;
   .component-header--display-veggie-burger & {
@@ -112,6 +118,7 @@ $header-links-min-width: gu-span(12);
 .component-header-topnav-logo {
   @include mq($from: tablet) {
     width: gu-span(5);
+    background-color: gu-colour(brand-main);
     float: right;
     .component-header--one-row & {
       border-left: 1px solid gu-colour(brand-pastel);
@@ -217,7 +224,13 @@ $header-links-min-width: gu-span(12);
   .component-header__wrapper {
     max-width: 50rem;
 
-    @include mq($from: wide) {
+    @include mq($from: tablet, $until: desktop) {
+      max-width: 100%;
+      padding: 0;
+      margin: 0;
+    }
+
+    @include mq($from: leftCol) {
       max-width: 60rem;
     }
 
@@ -255,6 +268,11 @@ $header-links-min-width: gu-span(12);
           border-top: 1px solid gu-colour(brand-pastel);
           border-left: 1px solid gu-colour(brand-pastel);
           padding: $gu-v-spacing;
+
+          :nth-child(2) {
+            display: inline-block;
+            vertical-align: top;
+          }
   
           @include mq($until: tablet) {
             border-left: none;
@@ -268,7 +286,7 @@ $header-links-min-width: gu-span(12);
           display: none;
         }
   
-        @include mq($from: wide) {
+        @include mq($from: leftCol) {
           flex: 0 0 650px;
         }
       }
@@ -279,10 +297,8 @@ $header-links-min-width: gu-span(12);
 
       @include mq($from: desktop) {
         margin-right: -30px;
-
       }
     }
-  
   }
 
   .component-header-topnav-logo {
@@ -297,7 +313,6 @@ $header-links-min-width: gu-span(12);
   @include gu-fontset-body-sans;
   padding: $gu-v-spacing;
   border-top: 1px solid gu-colour(brand-pastel);
-  margin-left: -10px;
 
   @include mq($from: desktop) {
     display: none;
@@ -306,6 +321,4 @@ $header-links-min-width: gu-span(12);
   @include mq($until: tablet) {
     display: none;
   }
-
-  
 }

--- a/support-frontend/assets/components/headers/header/header.scss
+++ b/support-frontend/assets/components/headers/header/header.scss
@@ -248,6 +248,7 @@ $header-links-min-width: gu-span(12);
       }
 
       .component-header-topnav__checkout {
+        display: flex;
         flex: 0 0 490px;
         color: gu-colour(neutral-100);
         @include gu-fontset-body-sans;
@@ -257,17 +258,13 @@ $header-links-min-width: gu-span(12);
           flex: none;
           border-right: none;
         }
-  
-        .component-header-topnav--empty {
-          display: block;
-          width: 100%;
-          height: 60%;
-        }
       
         .component-header-topnav--checkout-text {
           border-top: 1px solid gu-colour(brand-pastel);
           border-left: 1px solid gu-colour(brand-pastel);
           padding: $gu-v-spacing;
+          width: 100%;
+          align-self: flex-end;
 
           :nth-child(2) {
             display: inline-block;

--- a/support-frontend/assets/components/headers/header/header.scss
+++ b/support-frontend/assets/components/headers/header/header.scss
@@ -112,7 +112,6 @@ $header-links-min-width: gu-span(12);
 .component-header-topnav-logo {
   @include mq($from: tablet) {
     width: gu-span(5);
-    background-color: gu-colour(brand-main);
     float: right;
     .component-header--one-row & {
       border-left: 1px solid gu-colour(brand-pastel);
@@ -212,4 +211,101 @@ $header-links-min-width: gu-span(12);
       display: none;
     }
   }
+}
+
+.component-header--display-checkout {
+  .component-header__wrapper {
+    max-width: 50rem;
+
+    @include mq($from: wide) {
+      max-width: 60rem;
+    }
+
+    .component-header-topnav {
+      @include mq($until: tablet) {
+        justify-content: space-between;
+      }
+
+      @include mq($from: tablet, $until: desktop) {
+        justify-content: flex-end;
+      }
+
+      .component-header-topnav__utility {
+        display: none;
+      }
+
+      .component-header-topnav__checkout {
+        flex: 0 0 490px;
+        color: gu-colour(neutral-100);
+        @include gu-fontset-body-sans;
+        border-right: 1px solid gu-colour(brand-pastel);
+  
+        @include mq($until: tablet) {
+          flex: none;
+          border-right: none;
+        }
+  
+        .component-header-topnav--empty {
+          display: block;
+          width: 100%;
+          height: 60%;
+        }
+      
+        .component-header-topnav--checkout-text {
+          border-top: 1px solid gu-colour(brand-pastel);
+          border-left: 1px solid gu-colour(brand-pastel);
+          padding: $gu-v-spacing;
+  
+          @include mq($until: tablet) {
+            border-left: none;
+            border-top: none;
+            margin-top: -16px;
+            padding-left: 2px;
+          }
+        }
+      
+        @include mq($from: tablet, $until: desktop) {
+          display: none;
+        }
+  
+        @include mq($from: wide) {
+          flex: 0 0 650px;
+        }
+      }
+    }
+
+    .component-header-topnav-logo {
+      flex: 0 1 auto;
+
+      @include mq($from: desktop) {
+        margin-right: -30px;
+
+      }
+    }
+  
+  }
+
+  .component-header-topnav-logo {
+    padding-right: $gu-h-spacing /2;
+    padding-top: $gu-v-spacing /2;
+  }
+}
+
+.component-header-checkout--row {
+  width: 100%;
+  color: gu-colour(neutral-100);
+  @include gu-fontset-body-sans;
+  padding: $gu-v-spacing;
+  border-top: 1px solid gu-colour(brand-pastel);
+  margin-left: -10px;
+
+  @include mq($from: desktop) {
+    display: none;
+  }
+
+  @include mq($until: tablet) {
+    display: none;
+  }
+
+  
 }

--- a/support-frontend/assets/components/headers/header/padlock.svg
+++ b/support-frontend/assets/components/headers/header/padlock.svg
@@ -1,0 +1,3 @@
+<svg width="11" height="17" viewBox="0 0 11 17" xmlns="http://www.w3.org/2000/svg" role="presentation" aria-hidden="true" focusable="false">
+    <path d="M2.063 4.813a3.438 3.438 0 0 1 6.875 0V6.53H2.061V4.813zm8.25 0V6.53L11 7.22v8.25l-.688.687H.688L0 15.469v-8.25l.688-.688V4.813a4.813 4.813 0 0 1 9.625 0zm-3.782 5.5c0 .448-.287.83-.687.972v1.434h-.688v-1.434a1.032 1.032 0 1 1 1.375-.973z" fill="#FFF" fill-rule="evenodd" />
+</svg>

--- a/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.jsx
@@ -32,7 +32,7 @@ const { countryGroupId } = store.getState().common.internationalisation;
 const content = (
   <Provider store={store}>
     <Page
-      header={<Header displayNavigation={false} displayCheckout />}
+      header={<Header display="checkout" />}
       footer={
         <Footer>
           <SubscriptionTermsPrivacy subscriptionProduct="DigitalPack" />

--- a/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.jsx
@@ -32,7 +32,7 @@ const { countryGroupId } = store.getState().common.internationalisation;
 const content = (
   <Provider store={store}>
     <Page
-      header={<Header displayNavigation={false} />}
+      header={<Header displayNavigation={false} displayCheckout />}
       footer={
         <Footer>
           <SubscriptionTermsPrivacy subscriptionProduct="DigitalPack" />

--- a/support-frontend/assets/pages/digital-subscription-checkout/thankYouExisting.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/thankYouExisting.jsx
@@ -37,7 +37,7 @@ const { countryGroupId } = store.getState().common.internationalisation;
 const content = (
   <Provider store={store}>
     <Page
-      header={<Header displayNavigation={false} />}
+      header={<Header display={null} />}
       footer={
         <Footer>
           <SubscriptionTermsPrivacy subscriptionProduct="DigitalPack" />

--- a/support-frontend/assets/pages/digital-subscription-checkout/thankYouExisting.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/thankYouExisting.jsx
@@ -37,7 +37,7 @@ const { countryGroupId } = store.getState().common.internationalisation;
 const content = (
   <Provider store={store}>
     <Page
-      header={<Header display={null} />}
+      header={<Header />}
       footer={
         <Footer>
           <SubscriptionTermsPrivacy subscriptionProduct="DigitalPack" />

--- a/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckout.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckout.jsx
@@ -43,7 +43,7 @@ const paperFulfilmentOption: PaperFulfilmentOptions = fulfilmentOption === 'Home
 const content = (
   <Provider store={store}>
     <Page
-      header={<Header displayNavigation={false} />}
+      header={<Header displayNavigation={false} displayCheckout />}
       footer={
         <Footer>
           <SubscriptionTermsPrivacy subscriptionProduct="Paper" />

--- a/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckout.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckout.jsx
@@ -43,7 +43,7 @@ const paperFulfilmentOption: PaperFulfilmentOptions = fulfilmentOption === 'Home
 const content = (
   <Provider store={store}>
     <Page
-      header={<Header displayNavigation={false} displayCheckout />}
+      header={<Header display="checkout" />}
       footer={
         <Footer>
           <SubscriptionTermsPrivacy subscriptionProduct="Paper" />

--- a/support-frontend/stories/header.jsx
+++ b/support-frontend/stories/header.jsx
@@ -13,5 +13,5 @@ stories.add('Header', () => (
 ));
 
 stories.add('Header (no navigation)', () => (
-  <Header displayNavigation={false} />
+  <Header display={null} />
 ));

--- a/support-frontend/stories/header.jsx
+++ b/support-frontend/stories/header.jsx
@@ -13,5 +13,5 @@ stories.add('Header', () => (
 ));
 
 stories.add('Header (no navigation)', () => (
-  <Header display={null} />
+  <Header />
 ));


### PR DESCRIPTION
## Why are you doing this?
The aim here is to add the word 'Checkout' to the navbar for digital and paper checkouts, in a range of different formats for different screens.

The work is details in this [**Trello Card**](https://trello.com/c/rkxkI6rA/2341-checkout-header)

## Changes
* Mobile version of navbar in checkout
* Tablet version of navbar in checkout
* Desktop version of navbar in checkout

## Screenshots
### Mobile
![Screen Shot 2019-05-08 at 12 55 45](https://user-images.githubusercontent.com/16781258/57373610-b5276d00-7190-11e9-98e9-ad5f9d5c0235.png)

### Tablet
![Screen Shot 2019-05-08 at 12 57 36](https://user-images.githubusercontent.com/16781258/57373698-e56f0b80-7190-11e9-9004-d07e71edf72b.png)

### Desktop
![Screen Shot 2019-05-08 at 12 56 07](https://user-images.githubusercontent.com/16781258/57373642-c83a3d00-7190-11e9-92c6-4ae7766022ad.png)
