### PR TITLE
Renderable survey component

### DIFF
--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionSurvey/ContributionsSurvey.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionSurvey/ContributionsSurvey.jsx
@@ -8,14 +8,23 @@ import AnchorButton from 'components/button/anchorButton';
 
 // ----- Component ----- //
 
+/* **********************************************************
+In order to display this component, a surveyLink must be
+configured below and the prop 'isRunning' needs to be set to
+`true` where the component is rendered (currently on the
+`ContributionThankYou` and `ContributionThankYouPasswordSet`)
+************************************************************/
+
+
 type PropTypes = {|
   contributionType: ContributionType,
+  isRunning: boolean
 |};
 
 export default function ContributionsSurvey(props: PropTypes) {
-  const surveyLink = props.contributionType === 'ONE_OFF' ? 'https://www.surveymonkey.com/r/SCPJHTW' : 'https://www.surveymonkey.com/r/RY2G6HM';
+  const surveyLink = props.contributionType === 'ONE_OFF' ? null : null;
 
-  return (
+  return props.isRunning && surveyLink ? (
     <div className="component-contributions-survey">
       <h3 className="confirmation__title">Tell us about your contribution</h3>
       <p className="confirmation__message">
@@ -26,8 +35,9 @@ export default function ContributionsSurvey(props: PropTypes) {
         appearance="secondary"
         aria-label="Link to contribution survey"
       >
-        Share your thoughts
+          Share your thoughts
       </AnchorButton>
     </div>
-  );
+  ) : null;
 }
+

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
@@ -64,7 +64,7 @@ function ContributionThankYou(props: PropTypes) {
           </section>
         ) : null}
         <MarketingConsent />
-        <ContributionSurvey contributionType={props.contributionType} />
+        <ContributionSurvey isRunning={false} contributionType={props.contributionType} />
         <SpreadTheWord />
         <div className="gu-content__return-link">
           <AnchorButton

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYouPasswordSet.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYouPasswordSet.jsx
@@ -35,7 +35,7 @@ function ContributionThankYouPasswordSet(props: PropTypes) {
           </p>
         </section>
         <MarketingConsent />
-        <ContributionSurvey contributionType={props.contributionType} />
+        <ContributionSurvey isRunning={false} contributionType={props.contributionType} />
         <SpreadTheWord />
         <div className="gu-content__return-link">
           <AnchorButton


### PR DESCRIPTION
## Why are you doing this?
The current survey has finished running, but it will run again in the future so I've added an option to configure the viewability of the component rather than removing it entirely - this better approach suggested by @tomrf1 

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/pB4N050G/1053-remove-user-survey-post-contribution)

## Changes

*  Made survey component's rendering configurable with an `isRunning:boolean` prop