### PR TITLE
Separate public/private subnets

### DIFF
--- a/support-frontend/cloud-formation/cfn.yaml
+++ b/support-frontend/cloud-formation/cfn.yaml
@@ -5,10 +5,12 @@ Parameters:
     Type: String
     Description: VpcId of your existing Virtual Private Cloud (VPC)
     Default: vpc-e6e00183
-  Subnets:
-    Type: CommaDelimitedList
-    Description: The list of SubnetIds in your Virtual Private Cloud (VPC)
-    Default: subnet-cb91ae8d, subnet-a7b74ac2, subnet-179e8063
+  PrivateVpcSubnets:
+    Description: Private subnets to use for EC2 instances
+    Type: List<AWS::EC2::Subnet::Id>
+  PublicVpcSubnets:
+    Description: Public subnets to use for the ELB
+    Type: List<AWS::EC2::Subnet::Id>
   Stack:
     Description: Applied directly as a tag
     Type: String
@@ -50,8 +52,7 @@ Resources:
   AutoScalingGroup:
     Type: AWS::AutoScaling::AutoScalingGroup
     Properties:
-      AvailabilityZones: !GetAZs
-      VPCZoneIdentifier: !Ref Subnets
+      VPCZoneIdentifier: !Ref PrivateVpcSubnets
       LaunchConfigurationName: !Ref LaunchConfig
       MinSize: !FindInMap [ StageVariables, !Ref Stage, MinInstances ]
       MaxSize: !FindInMap [ StageVariables, !Ref Stage, MaxInstances ]
@@ -186,7 +187,7 @@ Resources:
     Type: AWS::ElasticLoadBalancingV2::LoadBalancer
     Properties:
       Name: !Sub ${Stack}-${Stage}-${App}
-      Subnets: !Ref Subnets
+      Subnets: !Ref PublicVpcSubnets
       SecurityGroups:
         - !Ref LoadBalancerSecurityGroup
       Tags:


### PR DESCRIPTION
As part of reconfiguring the Membership VPC to have public & private subnets, I'm going to placing load balancers in the public subnet and instances in the private subnet, as per best security practices. (The original motivation for this was to give [lambdas access to the internet as well as entities within the VPC](https://aws.amazon.com/premiumsupport/knowledge-center/internet-access-lambda-function/), but having a subnet which is unreachable from the internet has other security benefits too, and is in fact how the Subscriptions VPC is set up.)

As a first step for this, I need to separate out these params in CloudFormation for all of our apps. I'll need to manually upload the new CloudFormation in the console because I need to supply values for these params. When I do this, I'll leave the instances in the current public subnets, but move the load balancer into the new public subnets I've created. Once I've done this for all our ASGs, the final step is to attach new routing tables to the current public subnets, making them private (i.e. the default route goes to a NAT gateway rather than an internet gateway).

- [x] Stack updated for CODE
- [x] Stack updated for PROD