### PR TITLE
Add custom checkbox component

### DIFF
--- a/support-frontend/assets/components/forms/customFields/checkbox.jsx
+++ b/support-frontend/assets/components/forms/customFields/checkbox.jsx
@@ -15,7 +15,7 @@ type PropTypes = {
 // ----- Component ----- //
 
 function CheckboxInput({
-  text, appearance, ...otherProps
+  text, ...otherProps
 }: PropTypes) {
   return (
     <label className="component-checkbox">

--- a/support-frontend/assets/components/forms/customFields/checkbox.jsx
+++ b/support-frontend/assets/components/forms/customFields/checkbox.jsx
@@ -4,35 +4,26 @@
 
 import React, { type Node } from 'react';
 
-import { classNameWithModifiers } from 'helpers/utilities';
-
 import './checkbox.scss';
 
 // ----- Types ----- //
 
 type PropTypes = {
   text: Node,
-  appearance: 'normal' | 'group',
-  image?: Node,
 };
 
 // ----- Component ----- //
 
-function RadioInput({
-  text, appearance, image, ...otherProps
+function CheckboxInput({
+  text, appearance, ...otherProps
 }: PropTypes) {
   return (
-    <label className={classNameWithModifiers('component-checkbox', [appearance])}>
-      <input className="component-checkbox__input" type="radio" {...otherProps} />
+    <label className="component-checkbox">
+      <input className="component-checkbox__input" type="checkbox" {...otherProps} />
       <span className="component-checkbox__text">{text}</span>
+      <span className="component-checkbox__tick" />
     </label>
   );
 }
 
-// ----- Exports ----- //
-
-RadioInput.defaultProps = {
-  appearance: 'normal',
-  image: null,
-};
-export { RadioInput };
+export { CheckboxInput };

--- a/support-frontend/assets/components/forms/customFields/checkbox.jsx
+++ b/support-frontend/assets/components/forms/customFields/checkbox.jsx
@@ -1,0 +1,38 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React, { type Node } from 'react';
+
+import { classNameWithModifiers } from 'helpers/utilities';
+
+import './checkbox.scss';
+
+// ----- Types ----- //
+
+type PropTypes = {
+  text: Node,
+  appearance: 'normal' | 'group',
+  image?: Node,
+};
+
+// ----- Component ----- //
+
+function RadioInput({
+  text, appearance, image, ...otherProps
+}: PropTypes) {
+  return (
+    <label className={classNameWithModifiers('component-checkbox', [appearance])}>
+      <input className="component-checkbox__input" type="radio" {...otherProps} />
+      <span className="component-checkbox__text">{text}</span>
+    </label>
+  );
+}
+
+// ----- Exports ----- //
+
+RadioInput.defaultProps = {
+  appearance: 'normal',
+  image: null,
+};
+export { RadioInput };

--- a/support-frontend/assets/components/forms/customFields/checkbox.scss
+++ b/support-frontend/assets/components/forms/customFields/checkbox.scss
@@ -1,0 +1,130 @@
+@import '../formFields';
+
+.component-radio-input {
+  @include gu-fontset-body-sans;
+  display: flex;
+  align-items: center;
+  justify-content: stretch;
+  cursor: pointer;
+  position: relative;
+}
+
+.component-radio-input__text {
+  font-weight: bold;
+  display: flex;
+  align-items: center;
+  position: relative;
+}
+
+.component-radio-input__input {
+  position: absolute;
+  opacity: 0;
+  height: 0;
+  width: 0;
+  top: 0;
+  left: 0;
+}
+
+.component-radio-input__image {
+  position: absolute;
+  right: 0;
+}
+
+.component-radio-input__image > .svg-direct-debit-symbol {
+  width: 24px;
+}
+
+.component-radio-input__image > .svg-new-credit-card {
+  width: 24px;
+}
+
+.component-radio-input__image > .svg-paypal {
+  width: 24px;
+  height: 20px;
+}
+
+.component-radio-input__image svg {
+  height: 100%;
+}
+
+.component-radio-input__text:before {
+  display: inline-block;
+  content: '';
+  width: 18px;
+  height: 18px;
+  border: 1px solid gu-colour(neutral-86);
+  box-shadow: inset 0 0 0 3px #fff;
+  border-radius: 60px;
+  margin-right: $gu-h-spacing/2;
+}
+
+.component-radio-input__text:after {
+  display: inline-block;
+  content: '';
+  width: 20px;
+  height: 20px;
+  background: gu-colour(green-main);
+  border-radius: 60px;
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  margin: auto;
+  transform: scale(0.2);
+  opacity: 0;
+  transition: $gu-transition;
+  transition-duration: $gu-animation-speed;
+}
+
+.component-radio-input__input:checked + .component-radio-input__text:before {
+  border-color: gu-colour(green-main);
+}
+.component-radio-input__input:checked + .component-radio-input__text:after {
+  transform: scale(0.6);
+  opacity: 1;
+}
+
+.component-radio-input--normal:hover {
+  .component-radio-input__text:before {
+    box-shadow: inset 0 0 0 3px #fff,
+      0 0 0 2px lighten(gu-colour(neutral-86), 6%);
+  }
+}
+
+.component-radio-input--normal .component-radio-input__input {
+  &:focus + .component-radio-input__text:before {
+    box-shadow: inset 0 0 0 3px #fff,
+      0 0 0 2px lighten(gu-colour(highlight-main), 6%);
+  }
+}
+
+.component-radio-input--group .component-radio-input__text {
+  border: 1px solid gu-colour(neutral-86);
+  min-height: $gu-cta-height;
+  justify-content: stretch;
+  padding: 0 $gu-h-spacing/2 + 2px;
+  border-radius: 9999em;
+  width: 100%;
+  box-sizing: border-box;
+  &:after {
+    left: $gu-h-spacing/2 + 2px;
+  }
+}
+
+.component-radio-input--group
+  .component-radio-input__input:checked
+  + .component-radio-input__text {
+  border-color: gu-colour(green-main);
+}
+.component-radio-input--group:hover {
+  .component-radio-input__text {
+    box-shadow: inset 0 0 0 3px #fff,
+      0 0 0 2px lighten(gu-colour(neutral-86), 6%);
+  }
+}
+.component-radio-input--group
+  .component-radio-input__input:focus
+  + .component-radio-input__text {
+  box-shadow: inset 0 0 0 3px #fff,
+    0 0 0 2px lighten(gu-colour(highlight-main), 6%);
+}

--- a/support-frontend/assets/components/forms/customFields/checkbox.scss
+++ b/support-frontend/assets/components/forms/customFields/checkbox.scss
@@ -1,6 +1,6 @@
 @import '../formFields';
 
-.component-radio-input {
+.component-checkbox {
   @include gu-fontset-body-sans;
   display: flex;
   align-items: center;
@@ -9,14 +9,14 @@
   position: relative;
 }
 
-.component-radio-input__text {
+.component-checkbox__text {
   font-weight: bold;
   display: flex;
   align-items: center;
   position: relative;
 }
 
-.component-radio-input__input {
+.component-checkbox__input {
   position: absolute;
   opacity: 0;
   height: 0;
@@ -25,106 +25,73 @@
   left: 0;
 }
 
-.component-radio-input__image {
-  position: absolute;
-  right: 0;
-}
-
-.component-radio-input__image > .svg-direct-debit-symbol {
-  width: 24px;
-}
-
-.component-radio-input__image > .svg-new-credit-card {
-  width: 24px;
-}
-
-.component-radio-input__image > .svg-paypal {
-  width: 24px;
-  height: 20px;
-}
-
-.component-radio-input__image svg {
-  height: 100%;
-}
-
-.component-radio-input__text:before {
+.component-checkbox__text:before {
   display: inline-block;
   content: '';
   width: 18px;
   height: 18px;
   border: 1px solid gu-colour(neutral-86);
-  box-shadow: inset 0 0 0 3px #fff;
-  border-radius: 60px;
   margin-right: $gu-h-spacing/2;
+  transition: background $gu-animation-speed,
+              box-shadow $gu-animation-speed;
 }
 
-.component-radio-input__text:after {
-  display: inline-block;
-  content: '';
-  width: 20px;
-  height: 20px;
-  background: gu-colour(green-main);
-  border-radius: 60px;
+.component-checkbox__input:checked + .component-checkbox__text:before {
+  background-color: gu-colour(green-main);
+  border-color: transparent;
+}
+
+.component-checkbox__tick {
   position: absolute;
-  top: 0;
-  left: 0;
+  left: 7px;
+  top: 4px;
+  width: 6px;
+  height: 12px;
+  transform: rotate(45deg);
+  z-index: 5;
+}
+
+.component-checkbox__tick:after,
+.component-checkbox__tick:before {
+  position: absolute;
+  display: block;
+  background-color: #fff;
+  transition: all $gu-animation-speed-fast ease-in-out;
+  content: '';
+}
+
+.component-checkbox__tick:before {
+  height: 2px;
   bottom: 0;
-  margin: auto;
-  transform: scale(0.2);
-  opacity: 0;
-  transition: $gu-transition;
-  transition-duration: $gu-animation-speed;
+  left: 0;
+  right: 100%;
+  transition-delay: $gu-animation-speed-fast/2;
 }
 
-.component-radio-input__input:checked + .component-radio-input__text:before {
-  border-color: gu-colour(green-main);
-}
-.component-radio-input__input:checked + .component-radio-input__text:after {
-  transform: scale(0.6);
-  opacity: 1;
+.component-checkbox__tick:after {
+  bottom: 0;
+  right: 0;
+  top: 100%;
+  width: 2px;
+  transition-delay: $gu-animation-speed-fast;
 }
 
-.component-radio-input--normal:hover {
-  .component-radio-input__text:before {
-    box-shadow: inset 0 0 0 3px #fff,
-      0 0 0 2px lighten(gu-colour(neutral-86), 6%);
+.component-checkbox__input:checked ~ .component-checkbox__tick:before {
+  right: 0
+}
+
+.component-checkbox__input:checked ~ .component-checkbox__tick:after {
+  top: 0
+}
+
+.component-checkbox:hover {
+  .component-checkbox__text:before {
+      box-shadow: 0 0 0 2px lighten(gu-colour(neutral-86), 6%);
   }
 }
 
-.component-radio-input--normal .component-radio-input__input {
-  &:focus + .component-radio-input__text:before {
-    box-shadow: inset 0 0 0 3px #fff,
-      0 0 0 2px lighten(gu-colour(highlight-main), 6%);
+.component-checkbox .component-checkbox__input {
+  &:focus + .component-checkbox__text:before {
+    box-shadow: 0 0 0 2px lighten(gu-colour(highlight-main), 6%);
   }
-}
-
-.component-radio-input--group .component-radio-input__text {
-  border: 1px solid gu-colour(neutral-86);
-  min-height: $gu-cta-height;
-  justify-content: stretch;
-  padding: 0 $gu-h-spacing/2 + 2px;
-  border-radius: 9999em;
-  width: 100%;
-  box-sizing: border-box;
-  &:after {
-    left: $gu-h-spacing/2 + 2px;
-  }
-}
-
-.component-radio-input--group
-  .component-radio-input__input:checked
-  + .component-radio-input__text {
-  border-color: gu-colour(green-main);
-}
-.component-radio-input--group:hover {
-  .component-radio-input__text {
-    box-shadow: inset 0 0 0 3px #fff,
-      0 0 0 2px lighten(gu-colour(neutral-86), 6%);
-  }
-}
-.component-radio-input--group
-  .component-radio-input__input:focus
-  + .component-radio-input__text {
-  box-shadow: inset 0 0 0 3px #fff,
-    0 0 0 2px lighten(gu-colour(highlight-main), 6%);
 }

--- a/support-frontend/assets/components/forms/customFields/radioInput.scss
+++ b/support-frontend/assets/components/forms/customFields/radioInput.scss
@@ -56,6 +56,8 @@
   box-shadow: inset 0 0 0 3px #fff;
   border-radius: 60px;
   margin-right: $gu-h-spacing/2;
+  transition: background $gu-animation-speed,
+              box-shadow $gu-animation-speed;
 }
 
 .component-radio-input__text:after {
@@ -106,6 +108,8 @@
   border-radius: 9999em;
   width: 100%;
   box-sizing: border-box;
+  transition: background $gu-animation-speed,
+              box-shadow $gu-animation-speed;
   &:after {
     left: $gu-h-spacing/2 + 2px;
   }

--- a/support-frontend/assets/stylesheets/gu-sass/layout.scss
+++ b/support-frontend/assets/stylesheets/gu-sass/layout.scss
@@ -12,6 +12,7 @@ $gu-v-spacing: 12px;
 // Shared Layout metrics
 // =============================================================================
 $gu-col-width: 60px;
+$gu-animation-speed-fast: .1s;
 $gu-animation-speed: .2s;
 $gu-animation-speed-med: .4s;
 

--- a/support-frontend/stories/form.jsx
+++ b/support-frontend/stories/form.jsx
@@ -10,6 +10,7 @@ import { Label as FormLabel } from 'components/forms/label';
 import { Fieldset } from 'components/forms/fieldset';
 import { Select } from 'components/forms/select';
 import { RadioInput } from 'components/forms/customFields/radioInput';
+import CheckboxInput from 'components/checkboxInput/checkboxInput';
 import { withLabel } from 'hocs/withLabel';
 import { withError } from 'hocs/withError';
 import { withCenterAlignment } from '../.storybook/decorators/withCenterAlignment';
@@ -45,6 +46,13 @@ stories.add('Forms', () => (
         <Rows gap="small">
           <RadioInput id="gdpr" text="Yes" name="gdpr" />
           <RadioInput id="gdpr" text="No" name="gdpr" />
+        </Rows>
+      </Fieldset>
+    </FormLabel>
+    <FormLabel label="Thiis is a label" htmlFor={null}>
+      <Fieldset legend="Thiis is a legend">
+        <Rows gap="small">
+          <CheckboxInput id="2" text="test" name="gdpr" />
         </Rows>
       </Fieldset>
     </FormLabel>

--- a/support-frontend/stories/form.jsx
+++ b/support-frontend/stories/form.jsx
@@ -10,7 +10,7 @@ import { Label as FormLabel } from 'components/forms/label';
 import { Fieldset } from 'components/forms/fieldset';
 import { Select } from 'components/forms/select';
 import { RadioInput } from 'components/forms/customFields/radioInput';
-import CheckboxInput from 'components/checkboxInput/checkboxInput';
+import { CheckboxInput } from 'components/forms/customFields/checkbox';
 import { withLabel } from 'hocs/withLabel';
 import { withError } from 'hocs/withError';
 import { withCenterAlignment } from '../.storybook/decorators/withCenterAlignment';
@@ -49,10 +49,10 @@ stories.add('Forms', () => (
         </Rows>
       </Fieldset>
     </FormLabel>
-    <FormLabel label="Thiis is a label" htmlFor={null}>
-      <Fieldset legend="Thiis is a legend">
+    <FormLabel label="Do you leave the skin on a kiwi fruit?" htmlFor={null}>
+      <Fieldset legend="This is a legend">
         <Rows gap="small">
-          <CheckboxInput id="2" text="test" name="gdpr" />
+          <CheckboxInput id="gift" text="I sure do!" name="gift" />
         </Rows>
       </Fieldset>
     </FormLabel>


### PR DESCRIPTION
## Why are you doing this?

The GW checkout includes a custom checkbox which we hadn't built... UNTIL NOW. I also took the opportunity to tweak the custom radio buttons hover states as they were missing the css transition that our other form UI has.

Pull this branch to view the [Storybook example](https://support-ui.thegulocal.com/?selectedKind=Forms&selectedStory=Forms&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybooks%2Fstorybook-addon-knobs).

## Changes

* Add custom checkbox component
* Add hover states to custom radio button

## Screenshots

**Default**
![Screen Shot 2019-05-08 at 15 30 28](https://user-images.githubusercontent.com/1108991/57384231-1d357d80-71a8-11e9-9560-45c268587eb2.png)

**Checked**
![Screen Shot 2019-05-08 at 15 30 48](https://user-images.githubusercontent.com/1108991/57384250-24f52200-71a8-11e9-9e18-bba4f9030912.png)

