### PR TITLE
Remove default annual variant

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -4,7 +4,7 @@ import type { Tests } from './abtest';
 // ----- Tests ----- //
 
 
-export type EditorialiseAmountsRoundTwoVariant = 'control' | 'defaultAnnual' | 'weeklyBreakdownMonthlyAsWell' | 'notintest';
+export type EditorialiseAmountsRoundTwoVariant = 'control' | 'weeklyBreakdownMonthlyAsWell' | 'notintest';
 
 export const tests: Tests = {
 
@@ -13,9 +13,6 @@ export const tests: Tests = {
     variants: [
       {
         id: 'control',
-      },
-      {
-        id: 'defaultAnnual',
       },
       {
         id: 'weeklyBreakdownMonthlyAsWell',

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -67,7 +67,6 @@ function getInitialPaymentMethod(
 function getInitialContributionType(
   countryGroupId: CountryGroupId,
   contributionTypes: ContributionTypes,
-  editorialiseAmountsRoundTwoVariant: string,
 ): ContributionType {
 
   const contributionType = getContributionTypeFromUrl() || getContributionTypeFromSession();
@@ -76,10 +75,6 @@ function getInitialContributionType(
   if (contributionType &&
     contributionTypes[countryGroupId].find(ct => ct.contributionType === contributionType)) {
     return contributionType;
-  }
-
-  if (editorialiseAmountsRoundTwoVariant === 'defaultAnnual') {
-    return 'ANNUAL';
   }
 
   const defaultContributionType = contributionTypes[countryGroupId].find(ct => ct.isDefault);
@@ -192,11 +187,7 @@ function selectInitialContributionTypeAndPaymentMethod(state: State, dispatch: F
   const { countryId } = state.common.internationalisation;
   const { switches, contributionTypes } = state.common.settings;
   const { countryGroupId } = state.common.internationalisation;
-  const contributionType = getInitialContributionType(
-    countryGroupId,
-    contributionTypes,
-    state.common.abParticipations.editorialiseAmountsRoundTwo,
-  );
+  const contributionType = getInitialContributionType(countryGroupId, contributionTypes);
   const paymentMethod = getInitialPaymentMethod(contributionType, countryId, switches);
   dispatch(updateContributionTypeAndPaymentMethod(contributionType, paymentMethod));
 }


### PR DESCRIPTION
This variant is losing us money (19% behind control after a week's worth of data), so let's get rid of it

cc @jessewilkins