### PR TITLE
Configurable Ticker Types 

### DIFF
--- a/support-frontend/assets/components/ticker/contributionTicker.jsx
+++ b/support-frontend/assets/components/ticker/contributionTicker.jsx
@@ -32,9 +32,11 @@ const getInitialTickerValues = (tickerJsonUrl: string): Promise<StateTypes> =>
       return { totalSoFar, goal };
     });
 
-const percentageTotalAsNegative = (total: number, goal: number) => {
+const percentageToTranslate = (total: number, goal: number, tickerType: TickerType) => {
   const percentage = ((total / goal) * 100) - 100;
-  return percentage > 0 ? 0 : percentage;
+  const endOfFillPercentage = tickerType === 'unlimited' ? -15 : 0;
+
+  return percentage > 0 ? endOfFillPercentage : percentage;
 };
 
 
@@ -71,9 +73,7 @@ export default class ContributionTicker extends Component<PropTypes, StateTypes>
       }
 
       this.setState({ totalSoFar: initialTotal, goal });
-      window.setTimeout(() => {
-        window.requestAnimationFrame(this.increaseTextCounter);
-      }, 500);
+      window.requestAnimationFrame(this.increaseTextCounter);
     });
   }
 
@@ -81,6 +81,9 @@ export default class ContributionTicker extends Component<PropTypes, StateTypes>
   tickerJsonUrl: string;
   totalSoFar: number;
   count = 0;
+  tickerType: TickerType;
+  classModifiers: Array<?string>;
+  goalReached: boolean;
 
   increaseTextCounter = () => {
     const { totalSoFar } = this;
@@ -95,7 +98,6 @@ export default class ContributionTicker extends Component<PropTypes, StateTypes>
   }
 
   renderContributedSoFar = () => {
-    console.log(this.goalReached)
     if (!this.goalReached) {
       return (
         <div className="contributions-landing-ticker__so-far">
@@ -131,7 +133,7 @@ export default class ContributionTicker extends Component<PropTypes, StateTypes>
     const allClassModifiers = readyToRender ? this.classModifiers : [...this.classModifiers, 'hidden'];
     const baseClassName = 'contributions-landing-ticker';
     const wrapperClassName = classNameWithModifiers(baseClassName, allClassModifiers);
-    const progressBarAnimation = `translateX(${percentageTotalAsNegative(this.state.totalSoFar, this.state.goal)}%)`;
+    const progressBarAnimation = `translate3d(${percentageToTranslate(this.state.totalSoFar, this.state.goal, this.tickerType)}%, 0, 0)`;
 
     return (
       <div className={wrapperClassName}>
@@ -148,7 +150,7 @@ export default class ContributionTicker extends Component<PropTypes, StateTypes>
           <div className="contributions-landing-ticker__progress">
             <div
               className="contributions-landing-ticker__filled-progress"
-              style={{transform: progressBarAnimation}}
+              style={{ transform: progressBarAnimation }}
             />
           </div>
         </div>

--- a/support-frontend/assets/components/ticker/contributionTicker.scss
+++ b/support-frontend/assets/components/ticker/contributionTicker.scss
@@ -1,6 +1,6 @@
 @import '~stylesheets/gu-sass/gu-sass';
 
-$progess-bar-height: 10px;
+$progress-bar-height: 10px;
 
 .contributions-landing-ticker {
   padding: 18px 0 28px 0;
@@ -66,7 +66,7 @@ $progess-bar-height: 10px;
 
 .contributions-landing-ticker__progress {
   width: calc(100%);
-  height: $progess-bar-height;
+  height: $progress-bar-height;
   overflow: hidden;
   background-color: #dcdcdc;
   position: absolute;
@@ -92,7 +92,7 @@ $progess-bar-height: 10px;
   width: 2px;
   height: 15px;
   right: 0;
-  bottom: -$progess-bar-height;
+  bottom: -$progress-bar-height;
 }
 
 // "Unlimited" post-goal style

--- a/support-frontend/assets/components/ticker/contributionTicker.scss
+++ b/support-frontend/assets/components/ticker/contributionTicker.scss
@@ -82,3 +82,25 @@ $progess-bar-height: 10px;
   transform: translateX(-100%);
   transition: transform 3s cubic-bezier(.25, .55, .2, .85);
 }
+
+// Post-goal styles:
+// Default post-goal style (hard stop)
+.contributions-landing-ticker--goal-reached .contributions-landing-ticker__progress-bar::after {
+  content: '';
+  position: absolute;
+  background: gu-colour(neutral-7);
+  width: 2px;
+  height: 15px;
+  right: 0;
+  bottom: -$progess-bar-height;
+}
+
+// "Unlimited" post-goal style
+.contributions-landing-ticker--goal-reached.contributions-landing-ticker--unlimited .contributions-landing-ticker__progress-bar::after {
+  right: 20%;
+}
+
+// Post-goal copy
+.contributions-landing-ticker--goal-reached .contributions-landing-ticker__count {
+  font-size: 16px;
+}

--- a/support-frontend/assets/helpers/url.js
+++ b/support-frontend/assets/helpers/url.js
@@ -2,6 +2,8 @@
 
 // ----- Types ----- //
 
+import { frontlineCampaign, toxinsCampaign } from 'pages/new-contributions-landing/campaigns';
+
 export type Domain
   = 'thegulocal.com'
   | 'code.dev-theguardian.com'
@@ -101,7 +103,11 @@ function getPathAfterRoute(route: string): string[] {
 }
 
 function isFrontlineCampaign(): boolean {
-  return getQueryParameter('frontline-campaign') === 'true';
+  return getQueryParameter(frontlineCampaign) === 'true';
+}
+
+function isToxinsCampaign(): boolean {
+  return getQueryParameter(toxinsCampaign) === 'true';
 }
 
 // ----- Exports ----- //

--- a/support-frontend/assets/helpers/url.js
+++ b/support-frontend/assets/helpers/url.js
@@ -1,9 +1,6 @@
 // @flow
 
 // ----- Types ----- //
-
-import { frontlineCampaign } from 'pages/new-contributions-landing/campaigns';
-
 export type Domain
   = 'thegulocal.com'
   | 'code.dev-theguardian.com'
@@ -104,7 +101,7 @@ function getPathAfterRoute(route: string): string[] {
 
 // Campaign pages currently implemented by query param, as follows:
 function isFrontlineCampaign(): boolean {
-  return getQueryParameter(frontlineCampaign) === 'true';
+  return getQueryParameter('frontline-campaign') === 'true';
 }
 
 // ----- Exports ----- //

--- a/support-frontend/assets/helpers/url.js
+++ b/support-frontend/assets/helpers/url.js
@@ -2,7 +2,7 @@
 
 // ----- Types ----- //
 
-import { frontlineCampaign, toxinsCampaign } from 'pages/new-contributions-landing/campaigns';
+import { frontlineCampaign } from 'pages/new-contributions-landing/campaigns';
 
 export type Domain
   = 'thegulocal.com'
@@ -102,12 +102,9 @@ function getPathAfterRoute(route: string): string[] {
   return pathName.splice(pathName.findIndex(r => r === route));
 }
 
+// Campaign pages currently implemented by query param, as follows:
 function isFrontlineCampaign(): boolean {
   return getQueryParameter(frontlineCampaign) === 'true';
-}
-
-function isToxinsCampaign(): boolean {
-  return getQueryParameter(toxinsCampaign) === 'true';
 }
 
 // ----- Exports ----- //

--- a/support-frontend/assets/pages/new-contributions-landing/campaigns.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/campaigns.jsx
@@ -3,6 +3,8 @@
 import React from 'react';
 import { isFrontlineCampaign, getQueryParameter } from 'helpers/url';
 
+export type TickerType = 'unlimited' | 'hardstop';
+
 export type CampaignSettings = {
   headerCopy?: string,
   contributeCopy?: React$Element<string>,
@@ -11,11 +13,15 @@ export type CampaignSettings = {
 
   tickerJsonUrl?: string,
   cssModifiers?: string[],
+  tickerType: TickerType,
 };
 
 export type Campaigns = {
   [string]: CampaignSettings,
 };
+
+export const frontlineCampaign = 'frontline-campaign';
+export const toxinsCampaign = 'toxins-campaign';
 
 export const campaigns: Campaigns = {
   thefrontline: {
@@ -69,6 +75,7 @@ export const campaigns: Campaigns = {
       </div>
     ),
     tickerJsonUrl: '/ticker.json',
+    tickerType: 'hardstop',
     cssModifiers: ['frontline-campaign'],
   },
 };

--- a/support-frontend/assets/pages/new-contributions-landing/campaigns.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/campaigns.jsx
@@ -21,7 +21,6 @@ export type Campaigns = {
 };
 
 export const frontlineCampaign = 'frontline-campaign';
-export const toxinsCampaign = 'toxins-campaign';
 
 export const campaigns: Campaigns = {
   thefrontline: {

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionForm.jsx
@@ -20,7 +20,6 @@ import { type PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRev
 import { type CreatePaypalPaymentData } from 'helpers/paymentIntegrations/oneOffContributions';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import { payPalCancelUrl, payPalReturnUrl } from 'helpers/routes';
-import { type CampaignName } from 'pages/new-contributions-landing/campaigns';
 
 import ProgressMessage from 'components/progressMessage/progressMessage';
 import { openDirectDebitPopUp } from 'components/directDebit/directDebitActions';
@@ -51,6 +50,7 @@ import StripePaymentRequestButtonContainer from './StripePaymentRequestButton/St
 import type { FullDetailExistingPaymentMethod } from '../../../helpers/existingPaymentMethods/existingPaymentMethods';
 import type { PaymentMethod } from 'helpers/paymentMethods';
 import { DirectDebit, Stripe, ExistingCard, ExistingDirectDebit } from 'helpers/paymentMethods';
+import { getCampaignName } from 'pages/new-contributions-landing/campaigns';
 
 
 // ----- Types ----- //
@@ -82,7 +82,6 @@ type PropTypes = {|
   isTestUser: boolean,
   country: IsoCountry,
   stripePaymentRequestButtonMethod: StripePaymentRequestButtonMethod,
-  campaignName: ?CampaignName,
 |};
 
 // We only want to use the user state value if the form state value has not been changed since it was initialised,
@@ -113,7 +112,6 @@ const mapStateToProps = (state: State) => ({
   country: state.common.internationalisation.countryId,
   stripeV3HasLoaded: state.page.form.stripePaymentRequestButtonData.stripeV3HasLoaded,
   stripePaymentRequestButtonMethod: state.page.form.stripePaymentRequestButtonData.paymentMethod,
-  campaignName: state.page.form.campaignName,
 });
 
 
@@ -223,6 +221,8 @@ function onSubmit(props: PropTypes): Event => void {
 // ----- Render ----- //
 
 function ContributionForm(props: PropTypes) {
+  const campaignName = getCampaignName();
+
   return (
     <form onSubmit={onSubmit(props)} className={classNameWithModifiers('form', ['contribution'])} noValidate>
       <div>
@@ -251,7 +251,7 @@ function ContributionForm(props: PropTypes) {
         <TermsPrivacy
           countryGroupId={props.countryGroupId}
           contributionType={props.contributionType}
-          campaignName={props.campaignName}
+          campaignName={campaignName}
         />
         {props.isWaiting ? <ProgressMessage message={['Processing transaction', 'Please wait']} /> : null}
       </div>

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
@@ -172,9 +172,8 @@ function goalReachedTemplate() {
 }
 
 const showTicker: boolean = getQueryParameter('ticker') === 'true';
-const campaignName = isFrontlineCampaign() ? "thefrontline" : '';
+const campaignName = isFrontlineCampaign() ? 'thefrontline' : '';
 const campaign = campaigns[campaignName];
-
 
 
 // ----- Render ----- //
@@ -188,7 +187,7 @@ function ContributionFormContainer(props: PropTypes) {
 
   const countryGroupDetails = {
     ...countryGroupSpecificDetails[props.countryGroupId],
-    ...props.campaignName ? campaigns[props.campaignName] : {}
+    ...campaignName ? campaigns[campaignName] : {},
   };
 
   return props.paymentComplete ?
@@ -207,7 +206,7 @@ function ContributionFormContainer(props: PropTypes) {
         </div>
 
         <div className="gu-content__form">
-          {showTicker && campaign ?
+          {showTicker && campaign && campaign.tickerJsonUrl ?
             <ContributionTicker
               tickerJsonUrl={campaign.tickerJsonUrl}
               onGoalReached={props.setTickerGoalReached}

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
@@ -5,7 +5,7 @@
 import type { ContributionType } from 'helpers/contributions';
 import type { Csrf } from 'helpers/csrf/csrfReducer';
 import type { Status } from 'helpers/settings';
-import { isFrontlineCampaign, getQueryParameter } from 'helpers/url';
+import { isFrontlineCampaign } from 'helpers/url';
 import { type ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 import React from 'react';
 import { connect } from 'react-redux';
@@ -19,7 +19,7 @@ import DirectDebitPopUpForm from 'components/directDebit/directDebitPopUpForm/di
 import { openDirectDebitPopUp } from 'components/directDebit/directDebitActions';
 import ContributionTicker from 'components/ticker/contributionTicker';
 import { setPayPalHasLoaded } from 'helpers/paymentIntegrations/payPalActions';
-import { campaigns } from 'pages/new-contributions-landing/campaigns';
+import { campaigns, getCampaignName } from 'pages/new-contributions-landing/campaigns';
 
 import { type State } from '../contributionsLandingReducer';
 import { NewContributionForm } from './ContributionForm';
@@ -171,9 +171,8 @@ function goalReachedTemplate() {
   return null;
 }
 
-const showTicker: boolean = getQueryParameter('ticker') === 'true';
-const campaignName = isFrontlineCampaign() ? 'thefrontline' : '';
-const campaign = campaigns[campaignName];
+const campaignName = getCampaignName();
+const campaign = campaignName ? campaigns[campaignName] : null;
 
 
 // ----- Render ----- //
@@ -206,7 +205,7 @@ function ContributionFormContainer(props: PropTypes) {
         </div>
 
         <div className="gu-content__form">
-          {showTicker && campaign && campaign.tickerJsonUrl ?
+          {campaign && campaign.tickerJsonUrl ?
             <ContributionTicker
               tickerJsonUrl={campaign.tickerJsonUrl}
               onGoalReached={props.setTickerGoalReached}

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionFormContainer.jsx
@@ -19,7 +19,7 @@ import DirectDebitPopUpForm from 'components/directDebit/directDebitPopUpForm/di
 import { openDirectDebitPopUp } from 'components/directDebit/directDebitActions';
 import ContributionTicker from 'components/ticker/contributionTicker';
 import { setPayPalHasLoaded } from 'helpers/paymentIntegrations/payPalActions';
-import { type CampaignName, campaigns } from 'pages/new-contributions-landing/campaigns';
+import { campaigns } from 'pages/new-contributions-landing/campaigns';
 
 import { type State } from '../contributionsLandingReducer';
 import { NewContributionForm } from './ContributionForm';
@@ -58,7 +58,6 @@ type PropTypes = {|
   contributionType: ContributionType,
   referrerAcquisitionData: ReferrerAcquisitionData,
   tickerGoalReached: boolean,
-  campaignName: ?CampaignName,
 |};
 
 /* eslint-enable react/no-unused-prop-types */
@@ -76,7 +75,6 @@ const mapStateToProps = (state: State) => ({
   contributionType: state.page.form.contributionType,
   referrerAcquisitionData: state.common.referrerAcquisitionData,
   tickerGoalReached: state.page.form.tickerGoalReached,
-  campaignName: state.page.form.campaignName,
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -173,15 +171,10 @@ function goalReachedTemplate() {
   return null;
 }
 
-function urlSpecificDetails() {
-  if (getQueryParameter('ticker') === 'true') {
-    return {
-      tickerJsonUrl: '/ticker.json',
-    };
-  }
+const showTicker: boolean = getQueryParameter('ticker') === 'true';
+const campaignName = isFrontlineCampaign() ? "thefrontline" : '';
+const campaign = campaigns[campaignName];
 
-  return {};
-}
 
 
 // ----- Render ----- //
@@ -195,8 +188,7 @@ function ContributionFormContainer(props: PropTypes) {
 
   const countryGroupDetails = {
     ...countryGroupSpecificDetails[props.countryGroupId],
-    ...props.campaignName ? campaigns[props.campaignName] : {},
-    ...urlSpecificDetails(),
+    ...props.campaignName ? campaigns[props.campaignName] : {}
   };
 
   return props.paymentComplete ?
@@ -215,10 +207,11 @@ function ContributionFormContainer(props: PropTypes) {
         </div>
 
         <div className="gu-content__form">
-          {countryGroupDetails.tickerJsonUrl ?
+          {showTicker && campaign ?
             <ContributionTicker
-              tickerJsonUrl={countryGroupDetails.tickerJsonUrl}
+              tickerJsonUrl={campaign.tickerJsonUrl}
               onGoalReached={props.setTickerGoalReached}
+              tickerType={campaign.tickerType}
             /> : null
           }
           {props.tickerGoalReached ? goalReachedTemplate() :

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionSurvey/ContributionsSurvey.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionSurvey/ContributionsSurvey.jsx
@@ -13,7 +13,7 @@ In order to display this component, a surveyLink must be
 configured below and the prop 'isRunning' needs to be set to
 `true` where the component is rendered (currently on the
 `ContributionThankYou` and `ContributionThankYouPasswordSet`)
-************************************************************/
+*********************************************************** */
 
 
 type PropTypes = {|

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.jsx
@@ -16,7 +16,7 @@ import { set as setCookie } from 'helpers/cookie';
 import Page from 'components/page/page';
 import Footer from 'components/footer/footer';
 import { RoundelHeader } from 'components/headers/roundelHeader/header';
-import { campaigns } from 'pages/new-contributions-landing/campaigns';
+import { campaigns, getCampaignName } from 'pages/new-contributions-landing/campaigns';
 
 import { init as formInit } from './contributionsLandingInit';
 import { initReducer } from './contributionsLandingReducer';
@@ -26,7 +26,6 @@ import ContributionThankYouContainer from './components/ContributionThankYou/Con
 import { setUserStateActions } from './setUserStateActions';
 import ConsentBanner from '../../components/consentBanner/consentBanner';
 import './contributionsLanding.scss';
-import { isFrontlineCampaign } from 'helpers/url';
 
 if (!isDetailsSupported) {
   polyfillDetails();
@@ -61,7 +60,7 @@ const setOneOffContributionCookie = () => {
   );
 };
 
-const campaignName = isFrontlineCampaign() ? "thefrontline" : '';
+const campaignName = getCampaignName();
 const cssModifiers = campaignName && campaigns[campaignName].cssModifiers ?
   campaigns[campaignName].cssModifiers : [];
 

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.jsx
@@ -26,6 +26,7 @@ import ContributionThankYouContainer from './components/ContributionThankYou/Con
 import { setUserStateActions } from './setUserStateActions';
 import ConsentBanner from '../../components/consentBanner/consentBanner';
 import './contributionsLanding.scss';
+import { isFrontlineCampaign } from 'helpers/url';
 
 if (!isDetailsSupported) {
   polyfillDetails();
@@ -60,7 +61,7 @@ const setOneOffContributionCookie = () => {
   );
 };
 
-const { campaignName } = store.getState().page.form;
+const campaignName = isFrontlineCampaign() ? "thefrontline" : '';
 const cssModifiers = campaignName && campaigns[campaignName].cssModifiers ?
   campaigns[campaignName].cssModifiers : [];
 

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLandingReducer.js
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLandingReducer.js
@@ -5,7 +5,6 @@
 import { type ErrorReason } from 'helpers/errorReasons';
 import { combineReducers } from 'redux';
 import { type ContributionType, type ThirdPartyPaymentLibraries } from 'helpers/contributions';
-import { type CampaignName, getCampaignName } from 'pages/new-contributions-landing/campaigns';
 import csrf from 'helpers/csrf/csrfReducer';
 import { type CommonState } from 'helpers/page/commonReducer';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLandingReducer.js
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLandingReducer.js
@@ -82,7 +82,6 @@ type FormState = {
   formIsValid: boolean,
   formIsSubmittable: boolean,
   tickerGoalReached: boolean,
-  campaignName: ?CampaignName,
 };
 
 type PageState = {
@@ -156,7 +155,6 @@ function createFormReducer() {
     formIsValid: true,
     formIsSubmittable: true,
     tickerGoalReached: false,
-    campaignName: getCampaignName(),
   };
 
   return function formReducer(state: FormState = initialState, action: Action): FormState {

--- a/support-frontend/stories/contributionTicker.jsx
+++ b/support-frontend/stories/contributionTicker.jsx
@@ -21,6 +21,7 @@ stories.add('Contribution ticker', () => (
     <ContributionTicker
       tickerJsonUrl={tickerJsonUrlInput()}
       onGoalReached={() => {}}
+      tickerType="unlimited"
     />
   </div>
 ));


### PR DESCRIPTION
## Why are you doing this?
Campaign tickers can "end" with either a "hardstop" or an "unlimited" configuration, so the React component to reflect these variations. This was done in a way to reflect the move to centralize the configuration into `campaigns.jsx`

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/9ZJcIjsB/1036-refactor-campaign-ticker-add-configurable-hard-stop-and-unlimited-types)

## Changes

* Added the configuration option to `campaigns.jsx`
* Updated the component to reflect the styles of the different configurations
* Moved campaign name out of shared state

## Screenshots
In progress:
![postgoal-pregoal](https://user-images.githubusercontent.com/3300789/57466759-26424f80-7279-11e9-87d4-0c1f2ef2ae30.png)

"Hardstop" ending:
![postgoal-hardstop](https://user-images.githubusercontent.com/3300789/57466783-31957b00-7279-11e9-9580-0538122f4af2.png)

"Unlimited" ending:
![postgoal-unlimited](https://user-images.githubusercontent.com/3300789/57466849-4eca4980-7279-11e9-83bf-a57f573a0723.png)
