### PR TITLE
existing-payment-options: tweaks to Direct Debit cloning

### DIFF
--- a/support-models/src/main/scala/com/gu/support/workers/states/PreparePaymentMethodForReuseState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/PreparePaymentMethodForReuseState.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 import com.gu.support.encoding.Codec.deriveCodec
 import com.gu.support.workers.{User, _}
 
-case class GetPaymentMethodState(
+case class PreparePaymentMethodForReuseState(
     requestId: UUID,
     product: ProductType,
     paymentFields: ExistingPaymentFields,
@@ -14,6 +14,6 @@ case class GetPaymentMethodState(
 
 import com.gu.support.encoding.Codec
 
-object GetPaymentMethodState {
-  implicit val codec: Codec[GetPaymentMethodState] = deriveCodec
+object PreparePaymentMethodForReuseState {
+  implicit val codec: Codec[PreparePaymentMethodForReuseState] = deriveCodec
 }

--- a/support-workers/cloud-formation/src/templates/state-machine.yaml
+++ b/support-workers/cloud-formation/src/templates/state-machine.yaml
@@ -7,12 +7,12 @@ States:
     Choices:
       - Variable: "$.requestInfo.accountExists"
         BooleanEquals: true
-        Next: GetPaymentMethod
+        Next: PreparePaymentMethodForReuse
     Default: CreatePaymentMethod
 
-  GetPaymentMethod:
+  PreparePaymentMethodForReuse:
     Type: Task
-    Resource: "${GetPaymentMethodLambda.Arn}"
+    Resource: "${PreparePaymentMethodForReuseLambda.Arn}"
     Next: CreateZuoraSubscription
     {{> retry}}
     {{> catch}}

--- a/support-workers/cloud-formation/src/view.yaml
+++ b/support-workers/cloud-formation/src/view.yaml
@@ -13,5 +13,5 @@ lambdas:
   description: Send thank-you email
 - name: SendAcquisitionEvent
   description: Submit Acquisition events to Ophan
-- name: GetPaymentMethod
+- name: PreparePaymentMethodForReuse
   description: Retrieves payment details for existing account and clones mandate in case of direct debit

--- a/support-workers/riff-raff.yaml
+++ b/support-workers/riff-raff.yaml
@@ -17,6 +17,6 @@ deployments:
         - "-SendThankYouEmailLambda-"
         - "-FailureHandlerLambda-"
         - "-SendAcquisitionEventLambda-"
-        - "-GetPaymentMethodLambda-"
+        - "-PreparePaymentMethodForReuseLambda-"
       fileName: support-workers.jar
     dependencies: [cfn]

--- a/support-workers/src/main/scala/com/gu/emailservices/ContributionEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/ContributionEmailFields.scala
@@ -29,8 +29,9 @@ case class ContributionEmailFields(
     )
     case dd: ClonedDirectDebitPaymentMethod => List(
       "account name" -> dd.bankTransferAccountName,
+      "account number" -> mask(dd.bankTransferAccountNumber),
       "sort code" -> hyphenate(dd.bankCode),
-      "Mandate ID" -> directDebitMandateId.getOrElse(""),
+      "Mandate ID" -> dd.mandateId,
       "first payment date" -> formatDate(created.plusDays(10).toLocalDate),
       "payment method" -> "Direct Debit"
     )

--- a/support-workers/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
@@ -56,9 +56,10 @@ case class DigitalPackEmailFields(
     )
     case dd: ClonedDirectDebitPaymentMethod => List(
       "Sort Code" -> hyphenate(dd.bankCode),
+      "Account number" -> mask(dd.bankTransferAccountNumber),
       "Account Name" -> dd.bankTransferAccountName,
       "Default payment method" -> "Direct Debit",
-      "MandateID" -> directDebitMandateId.getOrElse("")
+      "MandateID" -> dd.mandateId
     )
     case _: CreditCardReferenceTransaction => List("Default payment method" -> "Credit/Debit Card")
     case _: PayPalReferenceTransaction => Seq("Default payment method" -> "PayPal")

--- a/support-workers/src/main/scala/com/gu/emailservices/PaperEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/PaperEmailFields.scala
@@ -36,10 +36,11 @@ case class PaperEmailFields(
       "mandate_id" -> directDebitMandateId.getOrElse("")
     )
     case dd: ClonedDirectDebitPaymentMethod => List(
+      "bank_account_no" -> mask(dd.bankTransferAccountNumber),
       "bank_sort_code" -> hyphenate(dd.bankCode),
       "account_holder" -> dd.bankTransferAccountName,
       "payment_method" -> "Direct Debit",
-      "mandate_id" -> directDebitMandateId.getOrElse("")
+      "mandate_id" -> dd.mandateId
     )
     case _: CreditCardReferenceTransaction => List("payment_method" -> "Credit/Debit Card")
     case _: PayPalReferenceTransaction => List("payment_method" -> "PayPal")

--- a/support-workers/src/main/scala/com/gu/support/workers/exceptions/RetryImplicits.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/exceptions/RetryImplicits.scala
@@ -16,7 +16,7 @@ object RetryImplicits {
       case e @ (_: SocketTimeoutException | _: SocketException | _: WebServiceHelperError[_]) => new RetryUnlimited(message = e.getMessage, cause = throwable)
 
       //Invalid Json
-      case e: ParsingFailure => new RetryNone(message = e.getMessage, cause = throwable)
+      case e @ (_: ParsingFailure | _: MatchError) => new RetryNone(message = e.getMessage, cause = throwable)
 
       //Any Exception that we haven't specifically handled
       case e: Throwable => new RetryLimited(message = e.getMessage, cause = throwable)

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/PaymentMethodExtensions.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/PaymentMethodExtensions.scala
@@ -1,13 +1,19 @@
 package com.gu.support.workers.lambdas
 
-import com.gu.support.workers.{CreditCardReferenceTransaction, DirectDebitPaymentMethod, PayPalReferenceTransaction, PaymentMethod}
+import com.gu.support.workers.{
+  ClonedDirectDebitPaymentMethod,
+  CreditCardReferenceTransaction,
+  DirectDebitPaymentMethod,
+  PayPalReferenceTransaction,
+  PaymentMethod
+}
 
 object PaymentMethodExtensions {
   implicit class PaymentMethodExtension[T <: PaymentMethod](self: T) {
     def toFriendlyString: String = self match {
       case _: CreditCardReferenceTransaction => "Stripe"
       case _: PayPalReferenceTransaction => "PayPal"
-      case _: DirectDebitPaymentMethod => "DirectDebit"
+      case _: DirectDebitPaymentMethod | _: ClonedDirectDebitPaymentMethod => "DirectDebit"
     }
   }
 }

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/PreparePaymentMethodForReuse.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/PreparePaymentMethodForReuse.scala
@@ -8,18 +8,18 @@ import com.gu.i18n.{Country, CountryGroup}
 import com.gu.services.{ServiceProvider, Services}
 import com.gu.support.workers._
 import com.gu.support.workers.lambdas.PaymentMethodExtensions.PaymentMethodExtension
-import com.gu.support.workers.states.{CreateZuoraSubscriptionState, GetPaymentMethodState}
+import com.gu.support.workers.states.{CreateZuoraSubscriptionState, PreparePaymentMethodForReuseState}
 import com.gu.support.zuora.api.response.{GetPaymentMethodCardReferenceResponse, GetPaymentMethodDirectDebitResponse, GetPaymentMethodResponse}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-class GetPaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
-    extends ServicesHandler[GetPaymentMethodState, CreateZuoraSubscriptionState](servicesProvider) {
+class PreparePaymentMethodForReuse(servicesProvider: ServiceProvider = ServiceProvider)
+    extends ServicesHandler[PreparePaymentMethodForReuseState, CreateZuoraSubscriptionState](servicesProvider) {
 
   def this() = this(ServiceProvider)
 
-  override protected def servicesHandler(state: GetPaymentMethodState, requestInfo: RequestInfo, context: Context, services: Services) = {
+  override protected def servicesHandler(state: PreparePaymentMethodForReuseState, requestInfo: RequestInfo, context: Context, services: Services) = {
 
     val zuoraService = services.zuoraService
     val accountId = state.paymentFields.billingAccountId

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/PreparePaymentMethodForReuseSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/PreparePaymentMethodForReuseSpec.scala
@@ -10,7 +10,7 @@ import com.gu.support.workers.JsonFixtures._
 import com.gu.support.workers.encoding.Conversions.FromOutputStream
 import com.gu.support.workers.encoding.Encoding
 import com.gu.support.workers.errors.MockServicesCreator
-import com.gu.support.workers.lambdas.GetPaymentMethod
+import com.gu.support.workers.lambdas.PreparePaymentMethodForReuse
 import com.gu.support.workers.states.CreateZuoraSubscriptionState
 import com.gu.support.workers.{CreditCardReferenceTransaction, LambdaSpec}
 import com.gu.test.tags.annotations.IntegrationTest
@@ -23,10 +23,10 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
 @IntegrationTest
-class GetPaymentMethodSpec extends LambdaSpec with MockServicesCreator {
+class PreparePaymentMethodForReuseSpec extends LambdaSpec with MockServicesCreator {
 
   "ClonePaymentMethod lambda" should "clone CreditCard Payment Method" in {
-    val addZuoraSubscription = new GetPaymentMethod(mockServiceProvider)
+    val addZuoraSubscription = new PreparePaymentMethodForReuse(mockServiceProvider)
 
     val outStream = new ByteArrayOutputStream()
     val cardAccount = "2c92c0f869330b7a01694982970a2b34"


### PR DESCRIPTION
There was a long delay before I merged https://github.com/guardian/support-frontend/pull/1772 and another PR snuck in with a pattern match on `PaymentMethod`, which then became non-exhaustive when I finally merged https://github.com/guardian/support-frontend/pull/1772.

_NOTE, this only affects re-use of Direct Debit payment methods for contributions (for signed in users with existing products) but this was **already disabled** because of the support switches. Once this PR is merged and tested, hopefully we can turn this on._

Unfortunately it's not possible to make SBT error on **only** non-exhaustive pattern matches (it's either make all warnings into errors or none - which is a real shame) - this would've caught this in the merge build (i.e. failed and therefore wouldn't be deployable)
https://stackoverflow.com/questions/28327383/make-compile-fail-on-non-exhaustive-match-in-sbt  
... so **instead** I've made `MatchError` map to `RetryNone` (to prevent something that will never succeed from being retried - especially important if that thing has side-effects, like the mutations in GoCardless added in https://github.com/guardian/support-frontend/pull/1772).

Also **renamed** `GetPaymentMethod` lambda to `PreparePaymentMethodForReuse` (now that it does some mutation in GoCardless the name was misleading).

Also corrected the fields passed to the email to ensure parity with a brand new direct debit.
