### PR TITLE
Bugfix for webpack-dev-server 3.1.11

### DIFF
--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -11,7 +11,7 @@
     "build-ssr": "webpack --config webpack.ssr.js && node scripts/ssrScript.js",
     "build-prod": "npm-run-all clean validate test storybook-static 'webpack --config webpack.prod.js --env.prod'",
     "webpack": "webpack",
-    "webpack-dev-server": "webpack-dev-server --config webpack.dev.js --port 9211 --public support.thegulocal.com",
+    "webpack-dev-server": "webpack-dev-server --config webpack.dev.js --port 9211 --public support.thegulocal.com --disable-host-check",
     "devrun": "npm-run-all clean webpack-dev-server",
     "test": "echo 'Running JS tests' && jest",
     "stat": "yarn build-prod && webpack-bundle-analyzer public/compiled-assets/stats.json",


### PR DESCRIPTION
Upgrading webpack-dev-server to 3.1.11 causes constant console logging due to new security features. The current best supported work around is to add the `--disable-host-check` flag to the 
script in `package.json`

Please see webpack-dev-server's documentation of this issue [**here**](https://github.com/webpack/webpack-dev-server/issues/1604)

**TBD**: check to see if this flag is still necessary next time we upgrade webpack-dev-server