### PR TITLE
FIXED PreviewSubscribeRequest from creating duplicate customers & mandates in GoCardless

### DIFF
--- a/support-models/src/main/scala/com/gu/support/zuora/api/PreviewSubscribeRequest.scala
+++ b/support-models/src/main/scala/com/gu/support/zuora/api/PreviewSubscribeRequest.scala
@@ -2,7 +2,6 @@ package com.gu.support.zuora.api
 
 import com.gu.support.encoding.Codec
 import com.gu.support.encoding.Codec._
-import com.gu.support.workers.PaymentMethod
 
 object PreviewSubscribeItem {
   implicit val codec: Codec[PreviewSubscribeItem] = capitalizingCodec
@@ -11,7 +10,6 @@ object PreviewSubscribeItem {
 case class PreviewSubscribeItem(
   account: Account,
   billToContact: ContactDetails,
-  paymentMethod: PaymentMethod,
   subscriptionData: SubscriptionData,
   subscribeOptions: SubscribeOptions,
   previewOptions: PreviewOptions
@@ -25,9 +23,8 @@ object PreviewSubscribeRequest {
     PreviewSubscribeRequest(
       List(
         PreviewSubscribeItem(
-          subscribeItem.account,
+          subscribeItem.account.copy(autoPay = false), //this is to work-around bug in Zuora where duplicate mandate would be created in GoCardless
           subscribeItem.billToContact,
-          subscribeItem.paymentMethod,
           // This hack allows us to preview invoices further into the future (required to get a helpful payment schedule)
           subscribeItem.subscriptionData.copy(subscription = subscribeItem.subscriptionData.subscription.copy(initialTerm = 24)),
           subscribeItem.subscribeOptions,


### PR DESCRIPTION
## Why are you doing this?
Due to what appears to be a really nasty Zuora bug, despite being in **preview mode** Zuora was creating a customer and mandate in GoCardless...
![image](https://user-images.githubusercontent.com/19289579/57635347-dd530980-759e-11e9-916b-b364cc1212c4.png)

Fortunately not double payments, but likely [TBC] creating duplicate direct debit entries in customers online banking etc (one for the real subscription, and another which is 'never used').

## Changes

_(after lots of trial and error)_ removed `PaymentMethod` and forced `AutoPay` to `false` in the `PreviewSubscribeRequest` call