### PR TITLE
Do not use test stripe token if logged in

### DIFF
--- a/support-frontend/assets/helpers/user/user.js
+++ b/support-frontend/assets/helpers/user/user.js
@@ -82,7 +82,8 @@ const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActi
 
   const emailFromBrowser = getEmailFromBrowser();
 
-  if (isTestUser()) {
+  // Prevent use of test stripe token if logged in, as support-workers will try it in live mode if the identity cookie present
+  if (isTestUser() && !userAppearsLoggedIn) {
     dispatch(setTestUser(true));
   }
 

--- a/support-frontend/assets/helpers/user/user.js
+++ b/support-frontend/assets/helpers/user/user.js
@@ -82,7 +82,10 @@ const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActi
 
   const emailFromBrowser = getEmailFromBrowser();
 
-  // Prevent use of test stripe token if logged in, as support-workers will try it in live mode if the identity cookie present
+  /*
+   * Prevent use of the test stripe token if user us logged in, as support-workers will try it in live mode
+   * if the identity cookie is present
+   */
   if (isTestUser() && !userAppearsLoggedIn) {
     dispatch(setTestUser(true));
   }

--- a/support-frontend/assets/helpers/user/user.js
+++ b/support-frontend/assets/helpers/user/user.js
@@ -83,10 +83,17 @@ const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActi
   const emailFromBrowser = getEmailFromBrowser();
 
   /*
-   * Prevent use of the test stripe token if user us logged in, as support-workers will try it in live mode
+   * Prevent use of the test stripe token if user is logged in, as support-workers will try it in live mode
    * if the identity cookie is present
    */
-  const emailMatchesTestUser = () => emailFromBrowser && emailFromBrowser.startsWith(cookie.get('_test_username'));
+  const emailMatchesTestUser = (): boolean => {
+    const testUsername = cookie.get('_test_username');
+    if (emailFromBrowser && testUsername) {
+      return emailFromBrowser.toLowerCase().startsWith(testUsername.toLowerCase())
+    }
+    return false
+  };
+
   if (isTestUser() && (!userAppearsLoggedIn || emailMatchesTestUser())) {
     dispatch(setTestUser(true));
   }

--- a/support-frontend/assets/helpers/user/user.js
+++ b/support-frontend/assets/helpers/user/user.js
@@ -86,7 +86,8 @@ const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActi
    * Prevent use of the test stripe token if user us logged in, as support-workers will try it in live mode
    * if the identity cookie is present
    */
-  if (isTestUser() && !userAppearsLoggedIn) {
+  const emailMatchesTestUser = () => emailFromBrowser && emailFromBrowser.startsWith(cookie.get('_test_username'));
+  if (isTestUser() && (!userAppearsLoggedIn || emailMatchesTestUser())) {
     dispatch(setTestUser(true));
   }
 


### PR DESCRIPTION
## Why are you doing this?
If you make a stripe payment while logged in but also have the `_test_username` cookie set then it causes an alarm. This is because the client uses the stripe test token, but the backend (support-workers) uses it in live mode if the identity cookie is present.

This change prevents the client from using the stripe test token if you're logged in.

[**Trello Card**](https://trello.com/c/n6sD0Xv6/1054-fix-intermittent-stripe-test-live-mode-crossover-errors-in-step-functions)

