### PR TITLE
Make contributionTypes configurable for campaigns

### DIFF
--- a/support-frontend/assets/helpers/campaigns.jsx
+++ b/support-frontend/assets/helpers/campaigns.jsx
@@ -1,6 +1,8 @@
 // @flow
 
 import React from 'react';
+import type {ContributionType, ContributionTypes, ContributionTypeSetting} from 'helpers/contributions';
+import {generateContributionTypes} from 'helpers/contributions';
 
 export type TickerType = 'unlimited' | 'hardstop';
 
@@ -14,6 +16,7 @@ export type CampaignSettings = {
   cssModifiers?: string[],
   cssModifiers?: string[],
   tickerType: TickerType,
+  contributionTypes?: ContributionTypes,
 };
 
 export type Campaigns = {
@@ -77,6 +80,9 @@ export const campaigns: Campaigns = {
     tickerJsonUrl: '/ticker.json',
     tickerType: 'hardstop',
     cssModifiers: [currentCampaignName],
+    contributionTypes: generateContributionTypes([
+      {contributionType: 'ONE_OFF', isDefault: true}
+    ]),
   },
 };
 
@@ -86,4 +92,3 @@ export function getCampaignName(): ?CampaignName {
 
   return window.location.pathname.endsWith(`/${currentCampaignName}`) ? currentCampaignName : undefined;
 }
-

--- a/support-frontend/assets/helpers/campaigns.jsx
+++ b/support-frontend/assets/helpers/campaigns.jsx
@@ -1,8 +1,8 @@
 // @flow
 
 import React from 'react';
-import type {ContributionType, ContributionTypes, ContributionTypeSetting} from 'helpers/contributions';
-import {generateContributionTypes} from 'helpers/contributions';
+import type { ContributionTypes } from 'helpers/contributions';
+import { generateContributionTypes } from 'helpers/contributions';
 
 export type TickerType = 'unlimited' | 'hardstop';
 
@@ -81,7 +81,7 @@ export const campaigns: Campaigns = {
     tickerType: 'hardstop',
     cssModifiers: [currentCampaignName],
     contributionTypes: generateContributionTypes([
-      {contributionType: 'ONE_OFF', isDefault: true}
+      { contributionType: 'ONE_OFF', isDefault: true },
     ]),
   },
 };

--- a/support-frontend/assets/helpers/checkouts.js
+++ b/support-frontend/assets/helpers/checkouts.js
@@ -15,7 +15,6 @@ import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { Currency, IsoCurrency, SpokenCurrency } from 'helpers/internationalisation/currency';
 import { currencies, spokenCurrencies } from 'helpers/internationalisation/currency';
 import type { Amount, SelectedAmounts } from 'helpers/contributions';
-import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { PaymentMethod } from 'helpers/paymentMethods';
 import { DirectDebit, PayPal, Stripe } from 'helpers/paymentMethods';
 import { ExistingCard, ExistingDirectDebit } from './paymentMethods';
@@ -47,13 +46,11 @@ function toPaymentMethodSwitchNaming(paymentMethod: PaymentMethod): PaymentMetho
 function getValidContributionTypesFromUrlOrElse(fallback: ContributionTypes): ContributionTypes {
   const contributionTypesFromUrl = getQueryParameter('contributionTypes');
   if (contributionTypesFromUrl) {
-    return generateContributionTypes(
-      contributionTypesFromUrl
-        .split(',')
-        .map(toContributionType)
-        .filter(Boolean)
-        .map(contributionType => { return {contributionType} })
-    );
+    return generateContributionTypes(contributionTypesFromUrl
+      .split(',')
+      .map(toContributionType)
+      .filter(Boolean)
+      .map(contributionType => ({ contributionType })));
   }
 
   return fallback;

--- a/support-frontend/assets/helpers/checkouts.js
+++ b/support-frontend/assets/helpers/checkouts.js
@@ -4,8 +4,10 @@
 
 import { getQueryParameter } from 'helpers/url';
 import {
-  type ContributionType, getFrequency,
+  type ContributionType, type ContributionTypes,
+  getFrequency,
   toContributionType,
+  generateContributionTypes,
 } from 'helpers/contributions';
 import * as storage from 'helpers/storage';
 import { type Switches } from 'helpers/settings';
@@ -42,32 +44,19 @@ function toPaymentMethodSwitchNaming(paymentMethod: PaymentMethod): PaymentMetho
 }
 
 
-function getValidContributionTypesFromUrlOrElse(fallback: ContributionType[]): ContributionType[] {
+function getValidContributionTypesFromUrlOrElse(fallback: ContributionTypes): ContributionTypes {
   const contributionTypesFromUrl = getQueryParameter('contributionTypes');
   if (contributionTypesFromUrl) {
-    return contributionTypesFromUrl
-      .split(',')
-      .map(toContributionType)
-      .filter(Boolean);
+    return generateContributionTypes(
+      contributionTypesFromUrl
+        .split(',')
+        .map(toContributionType)
+        .filter(Boolean)
+        .map(contributionType => { return {contributionType} })
+    );
   }
 
   return fallback;
-}
-
-function getValidContributionTypes(countryGroupId: CountryGroupId): ContributionType[] {
-
-  const defaultContributionTypes = ['ONE_OFF', 'MONTHLY', 'ANNUAL'];
-
-  const mappings = {
-    GBPCountries: defaultContributionTypes,
-    UnitedStates: defaultContributionTypes,
-    AUDCountries: defaultContributionTypes,
-    EURCountries: defaultContributionTypes,
-    International: defaultContributionTypes,
-    NZDCountries: defaultContributionTypes,
-    Canada: defaultContributionTypes,
-  };
-  return getValidContributionTypesFromUrlOrElse(mappings[countryGroupId]);
 }
 
 function toHumanReadableContributionType(contributionType: ContributionType): 'Single' | 'Monthly' | 'Annual' {
@@ -197,7 +186,7 @@ export {
   getContributeButtonCopy,
   getContributeButtonCopyWithPaymentType,
   formatAmount,
-  getValidContributionTypes,
+  getValidContributionTypesFromUrlOrElse,
   getContributionTypeFromSession,
   getContributionTypeFromUrl,
   toHumanReadableContributionType,

--- a/support-frontend/assets/helpers/contributions.js
+++ b/support-frontend/assets/helpers/contributions.js
@@ -277,6 +277,18 @@ function toContributionType(s: ?string): ?ContributionType {
   return null;
 }
 
+function generateContributionTypes(contributionTypes: ContributionTypeSetting[]): ContributionTypes {
+  return {
+    GBPCountries: contributionTypes,
+    UnitedStates: contributionTypes,
+    AUDCountries: contributionTypes,
+    EURCountries: contributionTypes,
+    NZDCountries: contributionTypes,
+    Canada: contributionTypes,
+    International: contributionTypes,
+  };
+}
+
 function parseRegularContributionType(s: string): RegularContributionType {
   if (s === 'ANNUAL') {
     return 'ANNUAL';
@@ -424,6 +436,7 @@ function getContributionAmountRadios(
 export {
   config,
   toContributionType,
+  generateContributionTypes,
   validateContribution,
   parseContribution,
   getMinContribution,

--- a/support-frontend/assets/helpers/internationalisation/countryGroup.js
+++ b/support-frontend/assets/helpers/internationalisation/countryGroup.js
@@ -42,7 +42,7 @@ export type CountryGroup = {
   supportInternationalisationId: string,
 };
 
-type CountryGroups = {
+export type CountryGroups = {
   [CountryGroupId]: CountryGroup
 }
 

--- a/support-frontend/assets/helpers/internationalisation/countryGroup.js
+++ b/support-frontend/assets/helpers/internationalisation/countryGroup.js
@@ -42,7 +42,7 @@ export type CountryGroup = {
   supportInternationalisationId: string,
 };
 
-export type CountryGroups = {
+type CountryGroups = {
   [CountryGroupId]: CountryGroup
 }
 

--- a/support-frontend/assets/helpers/page/commonActions.js
+++ b/support-frontend/assets/helpers/page/commonActions.js
@@ -5,6 +5,7 @@
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { OptimizeExperiment } from 'helpers/optimize/optimize';
 import type { ExistingPaymentMethod } from 'helpers/existingPaymentMethods/existingPaymentMethods';
+import type { ContributionTypes } from 'helpers/contributions';
 import {
   type ThirdPartyTrackingConsent,
   writeTrackingConsentCookie,
@@ -17,7 +18,8 @@ export type Action =
   | { type: 'SET_COUNTRY', country: IsoCountry }
   | { type: 'SET_OPTIMIZE_EXPERIMENT_VARIANT', experiment: OptimizeExperiment }
   | { type: 'SET_EXISTING_PAYMENT_METHODS', existingPaymentMethods: ExistingPaymentMethod[] }
-  | { type: 'SET_TRACKING_CONSENT', trackingConsent: ThirdPartyTrackingConsent };
+  | { type: 'SET_TRACKING_CONSENT', trackingConsent: ThirdPartyTrackingConsent }
+  | { type: 'SET_CONTRIBUTION_TYPES', contributionTypes: ContributionTypes };
 
 
 // ----- Action Creators ----- //
@@ -39,6 +41,10 @@ function setTrackingConsent(trackingConsent: ThirdPartyTrackingConsent) {
   return { type: 'SET_TRACKING_CONSENT', trackingConsent };
 }
 
+function setContributionTypes(contributionTypes: ContributionTypes) {
+  return { type: 'SET_CONTRIBUTION_TYPES', contributionTypes };
+}
+
 // ----- Exports ----- //
 
 export {
@@ -46,4 +52,5 @@ export {
   setExperimentVariant,
   setExistingPaymentMethods,
   setTrackingConsent,
+  setContributionTypes,
 };

--- a/support-frontend/assets/helpers/page/commonReducer.js
+++ b/support-frontend/assets/helpers/page/commonReducer.js
@@ -72,6 +72,16 @@ function createCommonReducer(initialState: CommonState): (state?: CommonState, a
         return { ...state, trackingConsent: action.trackingConsent };
       }
 
+      case 'SET_CONTRIBUTION_TYPES': {
+        return {
+          ...state,
+          settings: {
+            ...state.settings,
+            contributionTypes: action.contributionTypes,
+          },
+        };
+      }
+
       default:
         return state;
     }

--- a/support-frontend/assets/helpers/user/user.js
+++ b/support-frontend/assets/helpers/user/user.js
@@ -89,9 +89,9 @@ const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActi
   const emailMatchesTestUser = (): boolean => {
     const testUsername = cookie.get('_test_username');
     if (emailFromBrowser && testUsername) {
-      return emailFromBrowser.toLowerCase().startsWith(testUsername.toLowerCase())
+      return emailFromBrowser.toLowerCase().startsWith(testUsername.toLowerCase());
     }
-    return false
+    return false;
   };
 
   if (isTestUser() && (!userAppearsLoggedIn || emailMatchesTestUser())) {

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionTypeTabs.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionTypeTabs.jsx
@@ -56,7 +56,7 @@ const mapDispatchToProps = (dispatch: Function) => ({
 function ContributionTypeTabs(props: PropTypes) {
   const contributionTypes = props.contributionTypes[props.countryGroupId];
 
-  if (contributionTypes.length === 1 && contributionTypes[0] === 'ONE_OFF') {
+  if (contributionTypes.length === 1 && contributionTypes[0].contributionType === 'ONE_OFF') {
     return (null);
   }
 

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -109,9 +109,9 @@ function initialiseStripeCheckout(
 }
 
 
-function initialisePaymentMethods(state: State, dispatch: Function) {
+function initialisePaymentMethods(state: State, dispatch: Function, contributionTypes: ContributionTypes) {
   const { countryId, currencyId, countryGroupId } = state.common.internationalisation;
-  const { switches, contributionTypes } = state.common.settings;
+  const { switches } = state.common.settings;
   const { isTestUser } = state.page.user;
 
   const onPaymentAuthorisation = (paymentAuthorisation: PaymentAuthorisation) => {
@@ -212,10 +212,10 @@ const init = (store: Store<State, Action, Function>) => {
 
   const state = store.getState();
 
-  initialisePaymentMethods(state, dispatch);
-
   const contributionTypes = getContributionTypes(state);
   dispatch(setContributionTypes(contributionTypes));
+
+  initialisePaymentMethods(state, dispatch, contributionTypes);
 
   selectInitialAmounts(state, dispatch);
   selectInitialContributionTypeAndPaymentMethod(state, dispatch, contributionTypes);

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -193,7 +193,12 @@ function getContributionTypes(state: State): ContributionTypes {
   return getValidContributionTypesFromUrlOrElse(state.common.settings.contributionTypes);
 }
 
-function selectInitialContributionTypeAndPaymentMethod(state: State, dispatch: Function, contributionTypes: ContributionTypes) {
+function selectInitialContributionTypeAndPaymentMethod(
+  state: State,
+  dispatch: Function,
+  contributionTypes: ContributionTypes,
+) {
+
   const { countryId } = state.common.internationalisation;
   const { switches } = state.common.settings;
   const { countryGroupId } = state.common.internationalisation;

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -212,6 +212,7 @@ const init = (store: Store<State, Action, Function>) => {
 
   const state = store.getState();
 
+  //TODO - move these settings out of the redux store, as they only change once, upon initialisation
   const contributionTypes = getContributionTypes(state);
   dispatch(setContributionTypes(contributionTypes));
 

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -17,9 +17,9 @@ import {
   getContributionTypeFromSession,
   getContributionTypeFromUrl,
   getPaymentMethodFromSession,
-  getValidContributionTypes,
   getValidPaymentMethods,
   type ThirdPartyPaymentLibrary,
+  getValidContributionTypesFromUrlOrElse,
 } from 'helpers/checkouts';
 import { type ContributionType } from 'helpers/contributions';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
@@ -42,10 +42,11 @@ import {
   mapExistingPaymentMethodToPaymentMethod, sendGetExistingPaymentMethodsRequest,
 } from 'helpers/existingPaymentMethods/existingPaymentMethods';
 import type { ExistingPaymentMethod } from 'helpers/existingPaymentMethods/existingPaymentMethods';
-import { setExistingPaymentMethods } from 'helpers/page/commonActions';
+import { setExistingPaymentMethods, setContributionTypes } from 'helpers/page/commonActions';
 import { doesUserAppearToBeSignedIn } from 'helpers/user/user';
 import { isSwitchOn } from 'helpers/globals';
 import type { ContributionTypes } from 'helpers/contributions';
+import { campaigns, getCampaignName } from 'helpers/campaigns';
 
 // ----- Functions ----- //
 
@@ -110,7 +111,7 @@ function initialiseStripeCheckout(
 
 function initialisePaymentMethods(state: State, dispatch: Function) {
   const { countryId, currencyId, countryGroupId } = state.common.internationalisation;
-  const { switches } = state.common.settings;
+  const { switches, contributionTypes } = state.common.settings;
   const { isTestUser } = state.page.user;
 
   const onPaymentAuthorisation = (paymentAuthorisation: PaymentAuthorisation) => {
@@ -118,16 +119,15 @@ function initialisePaymentMethods(state: State, dispatch: Function) {
     dispatch(onThirdPartyPaymentAuthorised(paymentAuthorisation));
   };
 
-  const contributionTypes = getValidContributionTypes(countryGroupId);
 
   if (getQueryParameter('stripe-checkout-js') !== 'no') {
     loadStripe().then(() => {
-      contributionTypes.forEach((contribType) => {
-        const validPayments = getValidPaymentMethods(contribType, switches, countryId);
+      contributionTypes[countryGroupId].forEach((contributionTypeSetting) => {
+        const validPayments = getValidPaymentMethods(contributionTypeSetting.contributionType, switches, countryId);
         if (validPayments.includes(Stripe)) {
           initialiseStripeCheckout(
             onPaymentAuthorisation,
-            contribType,
+            contributionTypeSetting.contributionType,
             currencyId,
             !!isTestUser,
             dispatch,
@@ -162,8 +162,8 @@ function initialisePaymentMethods(state: State, dispatch: Function) {
     }
   }
 
-  const recurringContributionsAvailable = contributionTypes.includes('MONTHLY')
-    || contributionTypes.includes('ANNUAL');
+  const recurringContributionsAvailable = contributionTypes[countryGroupId].includes('MONTHLY')
+    || contributionTypes[countryGroupId].includes('ANNUAL');
 
   if (getQueryParameter('paypal-js') !== 'no' && recurringContributionsAvailable) {
     loadPayPalRecurring().then(() => dispatch(setPayPalHasLoaded()));
@@ -183,9 +183,19 @@ function selectInitialAmounts(state: State, dispatch: Function) {
   });
 }
 
-function selectInitialContributionTypeAndPaymentMethod(state: State, dispatch: Function) {
+// Override the settings from the server if contributionTypes are defined in url params or campaign settings
+function getContributionTypes(state: State): ContributionTypes {
+  const campaignName = getCampaignName();
+  if (campaignName && campaigns[campaignName] && campaigns[campaignName].contributionTypes) {
+    return campaigns[campaignName].contributionTypes;
+  }
+
+  return getValidContributionTypesFromUrlOrElse(state.common.settings.contributionTypes);
+}
+
+function selectInitialContributionTypeAndPaymentMethod(state: State, dispatch: Function, contributionTypes: ContributionTypes) {
   const { countryId } = state.common.internationalisation;
-  const { switches, contributionTypes } = state.common.settings;
+  const { switches } = state.common.settings;
   const { countryGroupId } = state.common.internationalisation;
   const contributionType = getInitialContributionType(countryGroupId, contributionTypes);
   const paymentMethod = getInitialPaymentMethod(contributionType, countryId, switches);
@@ -199,8 +209,11 @@ const init = (store: Store<State, Action, Function>) => {
 
   initialisePaymentMethods(state, dispatch);
 
+  const contributionTypes = getContributionTypes(state);
+  dispatch(setContributionTypes(contributionTypes));
+
   selectInitialAmounts(state, dispatch);
-  selectInitialContributionTypeAndPaymentMethod(state, dispatch);
+  selectInitialContributionTypeAndPaymentMethod(state, dispatch, contributionTypes);
 
   const {
     firstName,


### PR DESCRIPTION
## Why are you doing this?
In the past we used the `contributionTypes` query parameter to limit a campaign to one-offs only.
This change adds an optional `contributionTypes` field to the `Campaign` model, which overrides whatever is in the settings provided by the server.
It's still possible to do this from query parameters.

We already store the contributionTypes settings for all regions in `state.common.settings.contributionTypes`. This is initialised to the value from `window.guardian.settings`, but it is now overridden by `contributionsLandingInit.js` if there is a campaign.

[**Trello Card**](https://trello.com/c/SOyNM6vg/1074-make-contribution-types-configurable-from-campaign-settings)

## Screenshots
![Screenshot 2019-05-16 at 13 41 31](https://user-images.githubusercontent.com/1513454/57854673-b97f0600-77e0-11e9-8854-278d937741b6.png)

