### PR TITLE
Remove legacy landing page circles from SSR template

### DIFF
--- a/support-frontend/app/views/newContributions.scala.html
+++ b/support-frontend/app/views/newContributions.scala.html
@@ -160,8 +160,33 @@
           </form>
         </div>
       </div>
-
-      <div class="gu-content__bg"><svg class="svg-contributions-bg-desktop" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1400 620"><circle fill="#E7D4B9" cx="213" cy="273" r="70"></circle><circle fill="#FEC8D3" cx="1280" cy="369" r="140"></circle><circle fill="#BB3B7F" cx="1152" cy="136" r="125"></circle><circle fill="#00B2FF" cx="138" cy="475" r="145"></circle><circle fill="#FF4E36" cx="748" cy="165" r="58"></circle><circle fill="#FAB375" cx="915" cy="395" r="225"></circle><circle fill="#FFFFFF" cx="1169" cy="549" r="70"></circle></svg></div></main><footer class="component-footer" role="contentinfo"><div class="component-content component-content--dark"><section class="component-left-margin-section"><div class="component-left-margin-section__content"><div class="component-content__content"><div class="component-footer__content"><div class="component-base-rows component-base-rows--normal"><p class="component-contrib-legal">The ultimate owner of the Guardian is The Scott Trust Limited, whose role it is to secure the editorial and financial independence of the Guardian in perpetuity. Reader contributions support the Guardian’s journalism. Please note that your support of the Guardian’s journalism does not constitute a charitable donation, as such your contribution is not eligible for Gift Aid in the UK nor a tax-deduction elsewhere. If you have any questions about contributing to the Guardian, please <a href="mailto:contribution.support@@theguardian.com">contact us here</a>.</p></div></div></div></div></section></div><div class="component-content component-content--dark component-content--force-border"><section class="component-left-margin-section"><div class="component-left-margin-section__content"><div class="component-content__content"><span class="component-footer__copyright">© 2019 Guardian News and Media Limited or its affiliated companies. All rights reserved.</span></div></div></section></div></footer></div></div>
+    </main>
+    <footer class="component-footer" role="contentinfo">
+      <div class="component-content component-content--dark">
+        <section class="component-left-margin-section">
+          <div class="component-left-margin-section__content">
+            <div class="component-content__content">
+              <div class="component-footer__content">
+                <div class="component-base-rows component-base-rows--normal">
+                  <p class="component-contrib-legal">The ultimate owner of the Guardian is The Scott Trust Limited, whose role it is to secure the editorial and financial independence of the Guardian in perpetuity. Reader contributions support the Guardian’s journalism. Please note that your support of the Guardian’s journalism does not constitute a charitable donation, as such your contribution is not eligible for Gift Aid in the UK nor a tax-deduction elsewhere. If you have any questions about contributing to the Guardian, please <a href="mailto:contribution.support@@theguardian.com">contact us here</a>.</p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+      <div class="component-content component-content--dark component-content--force-border">
+        <section class="component-left-margin-section">
+          <div class="component-left-margin-section__content">
+            <div class="component-content__content">
+              <span class="component-footer__copyright">© 2019 Guardian News and Media Limited or its affiliated companies. All rights reserved.</span>
+            </div>
+          </div>
+        </section>
+      </div>
+    </footer>
+    </div>
+  </div>
 
 } { ssr =>
 

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.scss
@@ -52,32 +52,6 @@ body {
   background-color: gu-colour(sport-faded);
 }
 
-.gu-content__bg {
-
-  display: flex;
-  height: 580px;
-  left: 0;
-  position: absolute;
-  top: 245px;
-  width: 100%;
-  z-index: -1;
-
-  .svg-contributions-bg-desktop {
-    display: block;
-    bottom: 0;
-    height: 580px;
-    left: 50%;
-    position: fixed;
-    transform: translate(-50%,0);
-    width: 1400px;
-  }
-
-  @include mq($from: mobile, $until: tablet) {
-    display: none;
-  }
-
-}
-
 /*= HEADER */
 
 


### PR DESCRIPTION
## Why are you doing this?

Removing legacy design stuff in the SSR template and cleaning up the markup to make it more readable
<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->