### PR TITLE
Temporarily remove direct debit payment method

### DIFF
--- a/support-frontend/assets/helpers/subscriptionsForms/countryPaymentMethods.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/countryPaymentMethods.js
@@ -9,7 +9,7 @@ import type { Option } from 'helpers/types/option';
 
 function supportedPaymentMethods(country: IsoCountry, product: SubscriptionProduct): PaymentMethod[] {
   const productSpecific: PaymentMethod[] = product === DigitalPack ? [PayPal] : [];
-  const countrySpecific: PaymentMethod[] = country === [Stripe];
+  const countrySpecific: PaymentMethod[] = [Stripe];
 
   return countrySpecific.concat(productSpecific);
 }

--- a/support-frontend/assets/helpers/subscriptionsForms/countryPaymentMethods.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/countryPaymentMethods.js
@@ -9,7 +9,7 @@ import type { Option } from 'helpers/types/option';
 
 function supportedPaymentMethods(country: IsoCountry, product: SubscriptionProduct): PaymentMethod[] {
   const productSpecific: PaymentMethod[] = product === DigitalPack ? [PayPal] : [];
-  const countrySpecific: PaymentMethod[] = country === 'GB' ? [DirectDebit, Stripe] : [Stripe];
+  const countrySpecific: PaymentMethod[] = country === 'NotACountry' ? [DirectDebit, Stripe] : [Stripe];
 
   return countrySpecific.concat(productSpecific);
 }

--- a/support-frontend/assets/helpers/subscriptionsForms/countryPaymentMethods.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/countryPaymentMethods.js
@@ -2,14 +2,14 @@
 
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { PaymentMethod } from 'helpers/paymentMethods';
-import { DirectDebit, PayPal, Stripe } from 'helpers/paymentMethods';
+import { PayPal, Stripe } from 'helpers/paymentMethods';
 import type { SubscriptionProduct } from 'helpers/subscriptions';
 import { DigitalPack } from 'helpers/subscriptions';
 import type { Option } from 'helpers/types/option';
 
 function supportedPaymentMethods(country: IsoCountry, product: SubscriptionProduct): PaymentMethod[] {
   const productSpecific: PaymentMethod[] = product === DigitalPack ? [PayPal] : [];
-  const countrySpecific: PaymentMethod[] = country === 'NotACountry' ? [DirectDebit, Stripe] : [Stripe];
+  const countrySpecific: PaymentMethod[] = country === [Stripe];
 
   return countrySpecific.concat(productSpecific);
 }


### PR DESCRIPTION
## Why are you doing this?
There is going to be 2 GoCardless maintenance periods over the weekend so we are temporarily removing the direct debit payment method.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/q1EZ6694/2402-investigate-gocardless-downtime-implications)

## Screenshots

