### PR TITLE
Remove reference to 'here's how vouchers work' from print thank you page

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-checkout/components/thankYou/thankYou.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/thankYou/thankYou.jsx
@@ -43,7 +43,7 @@ const whatNext: {[FulfilmentOptions]: Element<*>} = {
           It has everything you need to know about how manage it in the future.
         </span>,
         <span>
-          Your newspaper will be delivered to your door. Here{'\''}s a reminder of how home delivery works.
+          Your newspaper will be delivered to your door.
         </span>,
         ]}
       />
@@ -60,7 +60,6 @@ const whatNext: {[FulfilmentOptions]: Element<*>} = {
           </span>,
           <span>
             You will receive your personalised book of vouchers.
-            Here{'\''}s a reminder of how the voucher booklet works.
           </span>,
           <span>
             Exchange your voucher for a newspaper at your newsagent or wherever you buy your paper


### PR DESCRIPTION
## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->The print (voucher) checkout thank you page current states "here's a reminder of how the voucher scheme works" but has no link. It's also a bit late / too early to do this because they've just purchased but won't be able to start using their vouchers for a few weeks. I've therefore removed the line.

## Changes

* Remove extraneous copy "here's a reminder of how the voucher scheme works" from print checkout thank you page (voucher)
