### PR TITLE
Fix paypal

### DIFF
--- a/support-frontend/assets/helpers/contributions.js
+++ b/support-frontend/assets/helpers/contributions.js
@@ -431,6 +431,13 @@ function getContributionAmountRadios(
   }));
 }
 
+const contributionTypeAvailable = (
+  contributionType: ContributionType,
+  countryGroupId: CountryGroupId,
+  contributionTypes: ContributionTypes,
+): boolean =>
+  contributionTypes[countryGroupId].some(settings => settings.contributionType === contributionType);
+
 // ----- Exports ----- //
 
 export {
@@ -450,4 +457,5 @@ export {
   getContributionAmountRadios,
   parseRegularContributionType,
   getAmount,
+  contributionTypeAvailable,
 };

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -21,7 +21,7 @@ import {
   type ThirdPartyPaymentLibrary,
   getValidContributionTypesFromUrlOrElse,
 } from 'helpers/checkouts';
-import { type ContributionType } from 'helpers/contributions';
+import { type ContributionType, contributionTypeAvailable } from 'helpers/contributions';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import {
@@ -162,9 +162,6 @@ function initialisePaymentMethods(state: State, dispatch: Function, contribution
     }
   }
 
-  const contributionTypeAvailable = (contributionType: ContributionType): boolean =>
-    contributionTypes[countryGroupId].some(settings => settings.contributionType === contributionType);
-
   const recurringContributionsAvailable = contributionTypeAvailable('MONTHLY')
     || contributionTypeAvailable('ANNUAL');
 
@@ -215,7 +212,7 @@ const init = (store: Store<State, Action, Function>) => {
 
   const state = store.getState();
 
-  //TODO - move these settings out of the redux store, as they only change once, upon initialisation
+  // TODO - move these settings out of the redux store, as they only change once, upon initialisation
   const contributionTypes = getContributionTypes(state);
   dispatch(setContributionTypes(contributionTypes));
 

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -162,8 +162,11 @@ function initialisePaymentMethods(state: State, dispatch: Function, contribution
     }
   }
 
-  const recurringContributionsAvailable = contributionTypes[countryGroupId].includes('MONTHLY')
-    || contributionTypes[countryGroupId].includes('ANNUAL');
+  const contributionTypeAvailable = (contributionType: ContributionType): boolean =>
+    contributionTypes[countryGroupId].some(settings => settings.contributionType === contributionType);
+
+  const recurringContributionsAvailable = contributionTypeAvailable('MONTHLY')
+    || contributionTypeAvailable('ANNUAL');
 
   if (getQueryParameter('paypal-js') !== 'no' && recurringContributionsAvailable) {
     loadPayPalRecurring().then(() => dispatch(setPayPalHasLoaded()));

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLandingInit.js
@@ -162,8 +162,8 @@ function initialisePaymentMethods(state: State, dispatch: Function, contribution
     }
   }
 
-  const recurringContributionsAvailable = contributionTypeAvailable('MONTHLY')
-    || contributionTypeAvailable('ANNUAL');
+  const recurringContributionsAvailable = contributionTypeAvailable('MONTHLY', countryGroupId, contributionTypes)
+    || contributionTypeAvailable('ANNUAL', countryGroupId, contributionTypes);
 
   if (getQueryParameter('paypal-js') !== 'no' && recurringContributionsAvailable) {
     loadPayPalRecurring().then(() => dispatch(setPayPalHasLoaded()));


### PR DESCRIPTION
## Why are you doing this?
[This PR](https://github.com/guardian/support-frontend/pull/1805/files) broke the paypal button for monthly + annual (not single). This is because `contributionTypes[countryGroupId]` now has an array of objects not strings.

## Screenshots
<img width="492" alt="Screenshot 2019-05-21 at 13 36 59" src="https://user-images.githubusercontent.com/1513454/58096692-9764f980-7bcd-11e9-8f01-9a4883847a45.png">
<img width="492" alt="Screenshot 2019-05-21 at 13 37 10" src="https://user-images.githubusercontent.com/1513454/58096695-97fd9000-7bcd-11e9-8291-742d685e5159.png">
