### PR TITLE
Jtl ticker fix

### DIFF
--- a/support-frontend/assets/components/ticker/contributionTicker.jsx
+++ b/support-frontend/assets/components/ticker/contributionTicker.jsx
@@ -179,7 +179,7 @@ export default class ContributionTicker extends Component<PropTypes, StateTypes>
       https://davidwalsh.name/translate3d
       *************************************************************** */
     const progressBarAnimation = `translate3d(${percentageToTranslate(this.dataFromServer.totalContributed || 0, this.dataFromServer.goal || 0, this.tickerType)}%, 0, 0)`;
-    const readyToRender = (this.state && this.state.count && this.state.count !== 0);
+    const readyToRender = (this.state && !isNaN(this.state.count) && this.state.count > -1);
     const allClassModifiers = readyToRender ? this.classModifiers : [...this.classModifiers, 'hidden'];
     const baseClassName = 'contributions-landing-ticker';
     const wrapperClassName = classNameWithModifiers(baseClassName, allClassModifiers);

--- a/support-frontend/assets/components/ticker/contributionTicker.jsx
+++ b/support-frontend/assets/components/ticker/contributionTicker.jsx
@@ -179,7 +179,7 @@ export default class ContributionTicker extends Component<PropTypes, StateTypes>
       https://davidwalsh.name/translate3d
       *************************************************************** */
     const progressBarAnimation = `translate3d(${percentageToTranslate(this.dataFromServer.totalContributed || 0, this.dataFromServer.goal || 0, this.tickerType)}%, 0, 0)`;
-    const readyToRender = (this.state && !isNaN(this.state.count) && this.state.count > -1);
+    const readyToRender = (this.state && !Number.isNaN(this.state.count) && this.state.count > -1);
     const allClassModifiers = readyToRender ? this.classModifiers : [...this.classModifiers, 'hidden'];
     const baseClassName = 'contributions-landing-ticker';
     const wrapperClassName = classNameWithModifiers(baseClassName, allClassModifiers);

--- a/support-frontend/assets/helpers/campaigns.jsx
+++ b/support-frontend/assets/helpers/campaigns.jsx
@@ -81,9 +81,9 @@ export const campaigns: Campaigns = {
     termsAndConditions: (contributionsTermsLink: string) => (
       <div className="component-terms-privacy component-terms-privacy--campaign-landing">
         <p>
-          By proceeding, you’re agreeing to our <span className="bold">Terms and Conditions</span>.
-          If we hit our goal of $150,000, The Guardian will allocate this amount to its core
-          operations which will help fund the completion of Toxic America series, including
+          By proceeding, you’re agreeing to our Terms and Conditions. If we hit our goal of
+          $150,000, The Guardian will allocate this amount to its core operations which will
+          help fund the completion of Toxic America series, including
           editing, reporting, graphics, and new commissions. If we exceed our goal, additional
           funds will be directed to The Guardian’s core operations and newsroom to support
           The Guardian’s independent journalism. Contributions will fund news, investigative


### PR DESCRIPTION
## Why are you doing this?

The ticker wasn't displaying when the amount was zero (falsey in JS). This hasn't been a problem previously because we've always had an initial amount. (Also apologies to reviewers for shoe-horning in a small copy change on this branch)

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Screenshots
<img width="1098" alt="zeroed ticker" src="https://user-images.githubusercontent.com/3300789/58112734-fe91a680-7beb-11e9-8888-c7f6534684ce.png">
