### PR TITLE
Add currency to ticker (manually) - longer term strategy to be discussed

### DIFF
--- a/support-frontend/assets/components/ticker/contributionTicker.jsx
+++ b/support-frontend/assets/components/ticker/contributionTicker.jsx
@@ -189,7 +189,7 @@ export default class ContributionTicker extends Component<PropTypes, StateTypes>
         <div className="contributions-landing-ticker__values">
           {this.renderContributedSoFar()}
           <div className="contributions-landing-ticker__goal">
-            <div className="contributions-landing-ticker__count">{ Math.floor(this.state.goal).toLocaleString() }</div>
+            <div className="contributions-landing-ticker__count">${Math.floor(this.state.goal).toLocaleString()}</div>
             <div className="contributions-landing-ticker__count-label contributions-landing-ticker__label">our
               goal
             </div>


### PR DESCRIPTION
## Why are you doing this?

The goal on the ticker was not being populated by a local currency symbol automatically so I added the currency manually, as it's done for the current count. We should discuss if this is desirable in the future - if manual is desirable, the symbol could be moved to the campaign config

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Screenshots
<img width="363" alt="ticker goal with currency" src="https://user-images.githubusercontent.com/3300789/58162251-c5077c80-7c79-11e9-8845-e88a7f27989d.png">

