### PR TITLE
add a new route to render the prod 500 error page in dev

### DIFF
--- a/support-frontend/app/lib/CustomHttpErrorHandler.scala
+++ b/support-frontend/app/lib/CustomHttpErrorHandler.scala
@@ -67,6 +67,8 @@ class CustomHttpErrorHandler(
     )
   }
 
+  val renderErrorInDev = onProdServerError _
+
   override protected def onBadRequest(request: RequestHeader, message: String): Future[Result] =
     super.onBadRequest(request, message).map(_.withHeaders(CacheControl.noCache))
 

--- a/support-frontend/app/lib/ErrorController.scala
+++ b/support-frontend/app/lib/ErrorController.scala
@@ -1,0 +1,17 @@
+package lib
+
+import actions.CustomActionBuilders
+import play.api.UsefulException
+import play.api.mvc._
+
+class ErrorController(
+ actionRefiners: CustomActionBuilders,
+ customHttpErrorHandler: CustomHttpErrorHandler
+) {
+
+  import actionRefiners._
+  def error500(): Action[AnyContent] = NoCacheAction().async { request =>
+    customHttpErrorHandler.renderErrorInDev(request, new UsefulException("test error") {})
+  }
+
+}

--- a/support-frontend/app/wiring/AppComponents.scala
+++ b/support-frontend/app/wiring/AppComponents.scala
@@ -2,7 +2,7 @@ package wiring
 
 import controllers.AssetsComponents
 import filters.{CacheHeadersCheck, SetCookiesCheck}
-import lib.CustomHttpErrorHandler
+import lib.{CustomHttpErrorHandler, ErrorController}
 import monitoring.{SentryLogging, StateMachineMonitor}
 import play.api.BuiltInComponentsFromContext
 import play.api.libs.ws.ahc.AhcWSComponents
@@ -24,7 +24,7 @@ trait AppComponents extends PlayComponents
   with Monitoring {
   self: BuiltInComponentsFromContext =>
 
-  override lazy val httpErrorHandler = new CustomHttpErrorHandler(
+  private val customHandler: CustomHttpErrorHandler = new CustomHttpErrorHandler(
     environment,
     configuration,
     sourceMapper,
@@ -33,6 +33,8 @@ trait AppComponents extends PlayComponents
     allSettingsProvider,
     appConfig.stage
   )
+  override lazy val httpErrorHandler = customHandler
+  override lazy val errorController = new ErrorController(actionRefiners, customHandler)
 
   override lazy val httpFilters: Seq[EssentialFilter] = Seq(
     new SetCookiesCheck(),
@@ -44,6 +46,7 @@ trait AppComponents extends PlayComponents
   override lazy val router: Router = new _root_.router.Routes(
     httpErrorHandler,
     applicationController,
+    errorController,
     siteMapController,
     regularContributionsController,
     supportWorkersStatusController,

--- a/support-frontend/app/wiring/Controllers.scala
+++ b/support-frontend/app/wiring/Controllers.scala
@@ -4,6 +4,7 @@ import assets.RefPath
 import com.gu.aws.AwsCloudWatchMetricPut
 import com.gu.aws.AwsCloudWatchMetricPut.{client, setupWarningRequest}
 import controllers.{CSSElementForStage, _}
+import lib.ErrorController
 import play.api.BuiltInComponentsFromContext
 
 trait Controllers {
@@ -14,6 +15,7 @@ trait Controllers {
 
   lazy val assetController = new controllers.Assets(httpErrorHandler, assetsMetadata)
   lazy val faviconController = new controllers.Favicon(actionRefiners, appConfig.stage)(fileMimeTypes)
+  def errorController: ErrorController
   lazy val elementForStage = CSSElementForStage(assetsResolver.getFileContentsAsHtml, appConfig.stage)_
   lazy val fontLoader = elementForStage(RefPath("fontLoader.js"))
 

--- a/support-frontend/conf/routes
+++ b/support-frontend/conf/routes
@@ -1,6 +1,7 @@
 # ----- System ----- #
 
 GET /healthcheck                                    controllers.Application.healthcheck
+GET /error500                                       lib.ErrorController.error500
 
 # ----- Unsupported Browsers ----- #
 


### PR DESCRIPTION
## Why are you doing this?

I want to make sentry flag every time a real person hits a 500 error.  The first problem was testing it, so I have added a new route so we can see the 500 error page in dev easily.

Normally it would show a stack trace, and running in runProd mode doesn't have hot reloading or the ability to quit play without killing sbt.

[**Trello Card**](https://trello.com/c/ecHp74BG/2356-spike-investigate-what-we-can-do-with-putting-error-page-alerts-into-sentry-to-make-it-obvious-that-something-is-a-p1-issue-incl)


## Screenshots

![image](https://user-images.githubusercontent.com/7304387/58173085-4bc85380-7c92-11e9-9776-3c269601b8da.png)
