### PR TITLE
Cloudwatch alarms for contributions

### DIFF
--- a/support-services/src/main/scala/com/gu/aws/AwsCloudWatchMetricPut.scala
+++ b/support-services/src/main/scala/com/gu/aws/AwsCloudWatchMetricPut.scala
@@ -68,7 +68,7 @@ object AwsCloudWatchMetricPut {
       MetricName("PaymentSuccess"),
       Map(
         MetricDimensionName("PaymentProvider") -> MetricDimensionValue(paymentProvider.name),
-        MetricDimensionName("ProductType") -> MetricDimensionValue(ProductType.toString),
+        MetricDimensionName("ProductType") -> MetricDimensionValue(productType.toString),
         MetricDimensionName("Stage") -> MetricDimensionValue(stage.toString)
       )
     )

--- a/support-services/src/main/scala/com/gu/aws/AwsCloudWatchMetricPut.scala
+++ b/support-services/src/main/scala/com/gu/aws/AwsCloudWatchMetricPut.scala
@@ -4,6 +4,7 @@ import com.amazonaws.regions.Regions
 import com.amazonaws.services.cloudwatch.model.{Dimension, MetricDatum, PutMetricDataRequest, StandardUnit}
 import com.amazonaws.services.cloudwatch.{AmazonCloudWatch, AmazonCloudWatchClientBuilder}
 import com.gu.support.config.{Stage, TouchPointEnvironment}
+import ophan.thrift.event.PaymentProvider
 
 import scala.util.Try
 
@@ -60,6 +61,14 @@ object AwsCloudWatchMetricPut {
       Map(
         MetricDimensionName("Environment") -> MetricDimensionValue(environment.toString)
       ))
+
+  def paymentSuccessRequest(paymentProvider: PaymentProvider): MetricRequest =
+    getMetricRequest(
+      MetricName("PaymentSuccess"),
+      Map(
+        MetricDimensionName("PaymentProvider") -> MetricDimensionValue(paymentProvider.name)
+      )
+    )
 
   def getMetricRequest(name: MetricName, dimensions: Map[MetricDimensionName, MetricDimensionValue]) : MetricRequest =
     MetricRequest(

--- a/support-services/src/main/scala/com/gu/aws/AwsCloudWatchMetricPut.scala
+++ b/support-services/src/main/scala/com/gu/aws/AwsCloudWatchMetricPut.scala
@@ -4,6 +4,7 @@ import com.amazonaws.regions.Regions
 import com.amazonaws.services.cloudwatch.model.{Dimension, MetricDatum, PutMetricDataRequest, StandardUnit}
 import com.amazonaws.services.cloudwatch.{AmazonCloudWatch, AmazonCloudWatchClientBuilder}
 import com.gu.support.config.{Stage, TouchPointEnvironment}
+import com.gu.support.workers.ProductType
 import ophan.thrift.event.PaymentProvider
 
 import scala.util.Try
@@ -62,11 +63,13 @@ object AwsCloudWatchMetricPut {
         MetricDimensionName("Environment") -> MetricDimensionValue(environment.toString)
       ))
 
-  def paymentSuccessRequest(paymentProvider: PaymentProvider): MetricRequest =
+  def paymentSuccessRequest(stage: Stage, paymentProvider: PaymentProvider, productType: ProductType): MetricRequest =
     getMetricRequest(
       MetricName("PaymentSuccess"),
       Map(
-        MetricDimensionName("PaymentProvider") -> MetricDimensionValue(paymentProvider.name)
+        MetricDimensionName("PaymentProvider") -> MetricDimensionValue(paymentProvider.name),
+        MetricDimensionName("ProductType") -> MetricDimensionValue(ProductType.toString),
+        MetricDimensionName("Stage") -> MetricDimensionValue(stage.toString)
       )
     )
 

--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -209,9 +209,8 @@ Resources:
     Condition: CreateProdResources
     Properties:
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
-      AlarmName: !Sub support-workers ${Stage} Recurring contributions with PayPal might be down
-      AlarmDescription: No successful recurring paypal contributions for an hour
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:contributions-dev
+      AlarmName: !Sub support-workers ${Stage} No successful recurring paypal contributions for an hour
       MetricName: PaymentSuccess
       Namespace: support-frontend
       Dimensions:
@@ -223,7 +222,56 @@ Resources:
           Value: ${Stage}
       ComparisonOperator: LessThanOrEqualToThreshold
       Threshold: 0
-      Period: 600
+      Period: 300
       EvaluationPeriods: 12
       Statistic: Sum
       TreatMissingData: breaching
+    DependsOn: SupportWorkersPROD
+
+  NoStripeContributionsInOneHourAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: CreateProdResources
+    Properties:
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:contributions-dev
+      AlarmName: !Sub support-workers ${Stage} No successful recurring stripe contributions for an hour
+      MetricName: PaymentSuccess
+      Namespace: support-frontend
+      Dimensions:
+        - Name: PaymentProvider
+          Value: Stripe
+        - Name: ProductType
+          Value: Contribution
+        - Name: Stage
+          Value: ${Stage}
+      ComparisonOperator: LessThanOrEqualToThreshold
+      Threshold: 0
+      Period: 300
+      EvaluationPeriods: 12
+      Statistic: Sum
+      TreatMissingData: breaching
+    DependsOn: SupportWorkersPROD
+
+  NoGocardlessContributionsInOneHourAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: CreateProdResources
+    Properties:
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:contributions-dev
+      AlarmName: !Sub support-workers ${Stage} No successful recurring Gocardless contributions for an hour
+      MetricName: PaymentSuccess
+      Namespace: support-frontend
+      Dimensions:
+        - Name: PaymentProvider
+          Value: Gocardless
+        - Name: ProductType
+          Value: Contribution
+        - Name: Stage
+          Value: ${Stage}
+      ComparisonOperator: LessThanOrEqualToThreshold
+      Threshold: 0
+      Period: 300
+      EvaluationPeriods: 12
+      Statistic: Sum
+      TreatMissingData: breaching
+    DependsOn: SupportWorkersPROD

--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -203,3 +203,23 @@ Resources:
       EvaluationPeriods: 1
       Statistic: Sum
     DependsOn: SupportWorkersPROD
+
+  NoPaypalPaymentsInTwoHoursAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: CreateProdResources
+    Properties:
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
+      AlarmName: !Sub ${App} ${Stage} CP Recurring contributions with PayPal might be down
+      AlarmDescription: There have been no recurring contributions using paypal in the last 2 hours
+      MetricName: PaymentSuccess
+      Namespace: support-frontend
+      Dimensions:
+        - Name: PaymentProvider
+          Value: Paypal
+      ComparisonOperator: LessThanOrEqualToThreshold
+      Threshold: 0
+      Period: 600
+      EvaluationPeriods: 12
+      Statistic: Sum
+      TreatMissingData: breaching

--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -210,7 +210,7 @@ Resources:
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
-      AlarmName: !Sub ${App} ${Stage} CP Recurring contributions with PayPal might be down
+      AlarmName: !Sub support-workers ${Stage} CP Recurring contributions with PayPal might be down
       AlarmDescription: There have been no recurring contributions using paypal in the last 2 hours
       MetricName: PaymentSuccess
       Namespace: support-frontend

--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -252,13 +252,13 @@ Resources:
       TreatMissingData: breaching
     DependsOn: SupportWorkersPROD
 
-  NoGocardlessContributionsInOneHourAlarm:
+  NoGocardlessContributionsInTwoHoursAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: CreateProdResources
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:contributions-dev
-      AlarmName: !Sub support-workers ${Stage} No successful recurring Gocardless contributions for an hour
+      AlarmName: !Sub support-workers ${Stage} No successful recurring Gocardless contributions for two hours
       MetricName: PaymentSuccess
       Namespace: support-frontend
       Dimensions:
@@ -271,7 +271,7 @@ Resources:
       ComparisonOperator: LessThanOrEqualToThreshold
       Threshold: 0
       Period: 300
-      EvaluationPeriods: 12
+      EvaluationPeriods: 24
       Statistic: Sum
       TreatMissingData: breaching
     DependsOn: SupportWorkersPROD

--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -204,19 +204,21 @@ Resources:
       Statistic: Sum
     DependsOn: SupportWorkersPROD
 
-  NoPaypalPaymentsInTwoHoursAlarm:
+  NoPaypalContributionsInOneHourAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: CreateProdResources
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
-      AlarmName: !Sub support-workers ${Stage} CP Recurring contributions with PayPal might be down
-      AlarmDescription: There have been no recurring contributions using paypal in the last 2 hours
+      AlarmName: !Sub support-workers ${Stage} Recurring contributions with PayPal might be down
+      AlarmDescription: No successful recurring paypal contributions for an hour
       MetricName: PaymentSuccess
       Namespace: support-frontend
       Dimensions:
         - Name: PaymentProvider
           Value: Paypal
+        - Name: ProductType
+          Value: Contribution
         - Name: Stage
           Value: ${Stage}
       ComparisonOperator: LessThanOrEqualToThreshold

--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -217,6 +217,8 @@ Resources:
       Dimensions:
         - Name: PaymentProvider
           Value: Paypal
+        - Name: Stage
+          Value: ${Stage}
       ComparisonOperator: LessThanOrEqualToThreshold
       Threshold: 0
       Period: 600

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
@@ -43,7 +43,7 @@ class SendAcquisitionEvent(serviceProvider: ServiceProvider = ServiceProvider)
     ).fold(
       errors => throw AnalyticsServiceErrorList(errors),
       _ => {
-        val cloudwatchEvent = paymentSuccessRequest(Configuration.stage, paymentProviderFromPaymentMethod(state.paymentMethod))
+        val cloudwatchEvent = paymentSuccessRequest(Configuration.stage, paymentProviderFromPaymentMethod(state.paymentMethod), state.product)
         AwsCloudWatchMetricPut(client)(cloudwatchEvent)
 
         HandlerResult(Unit, requestInfo)

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
@@ -8,6 +8,7 @@ import com.gu.acquisition.model.{GAData, OphanIds}
 import com.gu.acquisition.typeclasses.AcquisitionSubmissionBuilder
 import com.gu.aws.AwsCloudWatchMetricPut
 import com.gu.aws.AwsCloudWatchMetricPut.{client, paymentSuccessRequest}
+import com.gu.config.Configuration
 import com.gu.i18n.Country
 import com.gu.monitoring.SafeLogger
 import com.gu.services.{ServiceProvider, Services}
@@ -42,7 +43,7 @@ class SendAcquisitionEvent(serviceProvider: ServiceProvider = ServiceProvider)
     ).fold(
       errors => throw AnalyticsServiceErrorList(errors),
       _ => {
-        val cloudwatchEvent = paymentSuccessRequest(paymentProviderFromPaymentMethod(state.paymentMethod))
+        val cloudwatchEvent = paymentSuccessRequest(Configuration.stage, paymentProviderFromPaymentMethod(state.paymentMethod))
         AwsCloudWatchMetricPut(client)(cloudwatchEvent)
 
         HandlerResult(Unit, requestInfo)

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
@@ -6,6 +6,8 @@ import com.amazonaws.services.lambda.runtime.Context
 import com.gu.acquisition.model.errors.AnalyticsServiceError
 import com.gu.acquisition.model.{GAData, OphanIds}
 import com.gu.acquisition.typeclasses.AcquisitionSubmissionBuilder
+import com.gu.aws.AwsCloudWatchMetricPut
+import com.gu.aws.AwsCloudWatchMetricPut.{client, paymentSuccessRequest}
 import com.gu.i18n.Country
 import com.gu.monitoring.SafeLogger
 import com.gu.services.{ServiceProvider, Services}
@@ -38,7 +40,13 @@ class SendAcquisitionEvent(serviceProvider: ServiceProvider = ServiceProvider)
     services.acquisitionService.submit(
       SendAcquisitionEventStateAndRequestInfo(state, requestInfo)
     ).fold(
-      errors => throw AnalyticsServiceErrorList(errors), _ => HandlerResult(Unit, requestInfo)
+      errors => throw AnalyticsServiceErrorList(errors),
+      _ => {
+        val cloudwatchEvent = paymentSuccessRequest(paymentProviderFromPaymentMethod(state.paymentMethod))
+        AwsCloudWatchMetricPut(client)(cloudwatchEvent)
+
+        HandlerResult(Unit, requestInfo)
+      }
     )
   }
 }
@@ -53,6 +61,13 @@ object SendAcquisitionEvent {
   case class AnalyticsServiceErrorList(errors: List[AnalyticsServiceError]) extends Throwable {
     override def getMessage: String = errors.map(_.getMessage).mkString(". ")
   }
+
+  def paymentProviderFromPaymentMethod(paymentMethod: PaymentMethod): thrift.PaymentProvider =
+    paymentMethod match {
+      case _: CreditCardReferenceTransaction => thrift.PaymentProvider.Stripe
+      case _: PayPalReferenceTransaction => thrift.PaymentProvider.Paypal
+      case _: DirectDebitPaymentMethod | _: ClonedDirectDebitPaymentMethod => thrift.PaymentProvider.Gocardless
+    }
 
   // Typeclass instance used by the Ophan service to attempt to build a submission from the state.
   private implicit val stateAcquisitionSubmissionBuilder: AcquisitionSubmissionBuilder[SendAcquisitionEventStateAndRequestInfo] =
@@ -87,13 +102,6 @@ object SendAcquisitionEvent {
           case Monthly => thrift.PaymentFrequency.Monthly
           case Quarterly => thrift.PaymentFrequency.Quarterly
           case Annual => thrift.PaymentFrequency.Annually
-        }
-
-      def paymentProviderFromPaymentMethod(paymentMethod: PaymentMethod): thrift.PaymentProvider =
-        paymentMethod match {
-          case _: CreditCardReferenceTransaction => thrift.PaymentProvider.Stripe
-          case _: PayPalReferenceTransaction => thrift.PaymentProvider.Paypal
-          case _: DirectDebitPaymentMethod | _: ClonedDirectDebitPaymentMethod => thrift.PaymentProvider.Gocardless
         }
 
       def printOptionsFromProduct(product: ProductType, deliveryCountry: Option[Country]): Option[PrintOptions] = {

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
@@ -46,7 +46,7 @@ class SendAcquisitionEvent(serviceProvider: ServiceProvider = ServiceProvider)
         val cloudwatchEvent = paymentSuccessRequest(Configuration.stage, paymentProviderFromPaymentMethod(state.paymentMethod), state.product)
         AwsCloudWatchMetricPut(client)(cloudwatchEvent)
 
-        HandlerResult(Unit, requestInfo)
+        HandlerResult((), requestInfo)
       }
     )
   }


### PR DESCRIPTION
## Why are you doing this?
Currently we have alarms to warn us if we have had no one-off contributions for an hour (in payment-api), but not for recurring.

This branch changes the `SendAcquisitionEvent` step to write cloudwatch metrics with name `PaymentSuccess`, and with the `PaymentProvider` and `ProductType` values as dimensions. 

The new cloudwatch alarms are for contributions only, but it would be easy to add more.

[**Trello Card**](https://trello.com/c/JEM3mVdt/1086-add-alarms-to-repeat-contributions)
