### PR TITLE
Fix ticker counter for low amounts

### DIFF
--- a/support-frontend/assets/components/ticker/contributionTicker.jsx
+++ b/support-frontend/assets/components/ticker/contributionTicker.jsx
@@ -128,14 +128,17 @@ export default class ContributionTicker extends Component<PropTypes, StateTypes>
   increaseTextCounter = () => {
     const nextCount = this.state.count + Math.floor(this.state.count / 100);
 
-    if (this.dataFromServer.totalContributed &&
-      (nextCount >= this.dataFromServer.totalContributed || nextCount <= this.state.count)) {
+    const finishedCounting = this.dataFromServer.totalContributed &&
+      (nextCount <= this.state.count || //count isn't going up because total is too small
+      nextCount >= this.dataFromServer.totalContributed);
+
+    if (finishedCounting) {
       this.setState({ count: this.dataFromServer.totalContributed });
     } else {
       this.setState({ count: nextCount });
       window.requestAnimationFrame(this.increaseTextCounter);
     }
-  }
+  };
 
   renderContributedSoFar = () => {
     if (!this.goalReached) {

--- a/support-frontend/assets/components/ticker/contributionTicker.jsx
+++ b/support-frontend/assets/components/ticker/contributionTicker.jsx
@@ -128,7 +128,8 @@ export default class ContributionTicker extends Component<PropTypes, StateTypes>
   increaseTextCounter = () => {
     const nextCount = this.state.count + Math.floor(this.state.count / 100);
 
-    if (this.dataFromServer.totalContributed && nextCount >= this.dataFromServer.totalContributed) {
+    if (this.dataFromServer.totalContributed &&
+      (nextCount >= this.dataFromServer.totalContributed || nextCount <= this.state.count)) {
       this.setState({ count: this.dataFromServer.totalContributed });
     } else {
       this.setState({ count: nextCount });

--- a/support-frontend/assets/components/ticker/contributionTicker.jsx
+++ b/support-frontend/assets/components/ticker/contributionTicker.jsx
@@ -129,11 +129,11 @@ export default class ContributionTicker extends Component<PropTypes, StateTypes>
     const nextCount = this.state.count + Math.floor(this.state.count / 100);
 
     const finishedCounting = this.dataFromServer.totalContributed &&
-      (nextCount <= this.state.count || //count isn't going up because total is too small
+      (nextCount <= this.state.count || // count isn't going up because total is too small
       nextCount >= this.dataFromServer.totalContributed);
 
     if (finishedCounting) {
-      this.setState({ count: this.dataFromServer.totalContributed });
+      this.setState({ count: this.dataFromServer.totalContributed || 0});
     } else {
       this.setState({ count: nextCount });
       window.requestAnimationFrame(this.increaseTextCounter);


### PR DESCRIPTION
## Why are you doing this?
The ticker gets stuck if its initial value is below 100 (it's initialised by `totalContributed * 0.8`).
This change makes it jump straight to `totalContributed` if that's the case.

## Screenshots
<img width="494" alt="Screenshot 2019-05-24 at 11 10 36" src="https://user-images.githubusercontent.com/1513454/58320918-a5f12200-7e14-11e9-9fc1-872ac910eb96.png">

