### PR TITLE
make cyclical dependency be a lazy val to avoid NPE

### DIFF
--- a/support-frontend/app/wiring/AppComponents.scala
+++ b/support-frontend/app/wiring/AppComponents.scala
@@ -24,7 +24,7 @@ trait AppComponents extends PlayComponents
   with Monitoring {
   self: BuiltInComponentsFromContext =>
 
-  private val customHandler: CustomHttpErrorHandler = new CustomHttpErrorHandler(
+  private lazy val customHandler: CustomHttpErrorHandler = new CustomHttpErrorHandler(
     environment,
     configuration,
     sourceMapper,


### PR DESCRIPTION
## Why are you doing this?
After shipping https://github.com/guardian/support-frontend/pull/1823 we had a lot of actual 500 errors, this is because the error handler was coming back as null, due to the old favourite initialisation order issue in the class loader.
I didn't notice that because I was just trying the page I expected to intentionally show a 500 error, not realising that if I hit any other error page e/g. 404 it would also error with an actual 500 error!


## Changes

I have changed it to a lazy val and 404 errors are now working
