### PR TITLE
Fix ticker behaviour when it exceeds goal

### DIFF
--- a/support-frontend/assets/components/ticker/contributionTicker.jsx
+++ b/support-frontend/assets/components/ticker/contributionTicker.jsx
@@ -205,11 +205,11 @@ export default class ContributionTicker extends Component<PropTypes, StateTypes>
               className="contributions-landing-ticker__filled-progress"
               style={{ transform: progressBarAnimation }}
             />
-            <div
-              className="contributions-landing-ticker__marker"
-              style={{ transform: markerAnimation }}
-            />
           </div>
+          <div
+            className="contributions-landing-ticker__marker"
+            style={{ transform: markerAnimation }}
+          />
         </div>
       </div>
     );

--- a/support-frontend/assets/components/ticker/contributionTicker.jsx
+++ b/support-frontend/assets/components/ticker/contributionTicker.jsx
@@ -196,8 +196,8 @@ export default class ContributionTicker extends Component<PropTypes, StateTypes>
           {this.renderContributedSoFar()}
           <div className="contributions-landing-ticker__goal">
             <div className="contributions-landing-ticker__count">{this.props.currencySymbol}{Math.floor(goalValue).toLocaleString()}</div>
-            <div className="contributions-landing-ticker__count-label contributions-landing-ticker__label">our
-              goal
+            <div className="contributions-landing-ticker__count-label contributions-landing-ticker__label">
+              { (this.tickerType === 'unlimited' && total > goal) ? 'contributed' : 'our goal' }
             </div>
           </div>
         </div>

--- a/support-frontend/assets/components/ticker/contributionTicker.jsx
+++ b/support-frontend/assets/components/ticker/contributionTicker.jsx
@@ -45,15 +45,12 @@ by finding the percentage of the goal that has been fulfilled:
 ((total / goal) * 100) and then subtracting 100 from it.
 Eg. if 40% of our goal has been fulfilled, we want to translate
 the progress bar from -100% left to -60% left. The translation
-grows nearer to 0 which represents 100% fulfilled. The max this
-number can be is 0 but when the goal is 'unlimited' the max
-is -15% (representing 85% filled)
+grows nearer to 0 which represents 100% fulfilled.
 *************************************************************** */
-const percentageToTranslate = (total: number, goal: number, tickerType: TickerType) => {
-  const percentage = ((total / goal) * 100) - 100;
-  const endOfFillPercentage = tickerType === 'unlimited' ? -15 : 0;
+const percentageToTranslate = (total: number, end: number, tickerType: TickerType) => {
+  const percentage = ((total / end) * 100) - 100;
 
-  return percentage > 0 ? endOfFillPercentage : percentage;
+  return percentage > 0 ? 0 : percentage;
 };
 
 
@@ -166,8 +163,12 @@ export default class ContributionTicker extends Component<PropTypes, StateTypes>
     return (<div className="contributions-landing-ticker__so-far" />);
   }
 
-
   render() {
+    const goal = this.dataFromServer.goal || 0;
+    const total = this.dataFromServer.totalContributed || 0;
+    // If we've exceeded the goal then extend the bar 15% beyond the total
+    const end = total > goal ? total + (total * 0.15) : goal;
+
     /* *************************************************************
       `translate3d` is preferred to `translateX` because it uses the
       gpu to accelerate the animation. This is especially helpful for
@@ -179,7 +180,9 @@ export default class ContributionTicker extends Component<PropTypes, StateTypes>
       https://blog.teamtreehouse.com/increase-your-sites-performance-with-hardware-accelerated-css
       https://davidwalsh.name/translate3d
       *************************************************************** */
-    const progressBarAnimation = `translate3d(${percentageToTranslate(this.dataFromServer.totalContributed || 0, this.dataFromServer.goal || 0, this.tickerType)}%, 0, 0)`;
+    const progressBarAnimation = `translate3d(${percentageToTranslate(total, end, this.tickerType)}%, 0, 0)`;
+    const markerAnimation = `translate3d(${(goal / end) * 100 - 100}%, 0, 0)`;
+
     const readyToRender = (this.state && !Number.isNaN(this.state.count) && this.state.count > -1);
     const allClassModifiers = readyToRender ? this.classModifiers : [...this.classModifiers, 'hidden'];
     const baseClassName = 'contributions-landing-ticker';
@@ -202,6 +205,9 @@ export default class ContributionTicker extends Component<PropTypes, StateTypes>
               className="contributions-landing-ticker__filled-progress"
               style={{ transform: progressBarAnimation }}
             />
+            <div className="contributions-landing-ticker__marker"
+                 style={{ transform: markerAnimation }}
+            ></div>
           </div>
         </div>
       </div>

--- a/support-frontend/assets/components/ticker/contributionTicker.jsx
+++ b/support-frontend/assets/components/ticker/contributionTicker.jsx
@@ -47,7 +47,7 @@ Eg. if 40% of our goal has been fulfilled, we want to translate
 the progress bar from -100% left to -60% left. The translation
 grows nearer to 0 which represents 100% fulfilled.
 *************************************************************** */
-const percentageToTranslate = (total: number, end: number, tickerType: TickerType) => {
+const percentageToTranslate = (total: number, end: number) => {
   const percentage = ((total / end) * 100) - 100;
 
   return percentage > 0 ? 0 : percentage;
@@ -167,7 +167,7 @@ export default class ContributionTicker extends Component<PropTypes, StateTypes>
     const goal = this.dataFromServer.goal || 0;
     const total = this.dataFromServer.totalContributed || 0;
     // If we've exceeded the goal then extend the bar 15% beyond the total
-    const end = total > goal ? total + (total * 0.15) : goal;
+    const end = this.tickerType === 'unlimited' && total > goal ? total + (total * 0.15) : goal;
 
     /* *************************************************************
       `translate3d` is preferred to `translateX` because it uses the
@@ -180,8 +180,8 @@ export default class ContributionTicker extends Component<PropTypes, StateTypes>
       https://blog.teamtreehouse.com/increase-your-sites-performance-with-hardware-accelerated-css
       https://davidwalsh.name/translate3d
       *************************************************************** */
-    const progressBarAnimation = `translate3d(${percentageToTranslate(total, end, this.tickerType)}%, 0, 0)`;
-    const markerAnimation = `translate3d(${(goal / end) * 100 - 100}%, 0, 0)`;
+    const progressBarAnimation = `translate3d(${percentageToTranslate(total, end)}%, 0, 0)`;
+    const markerAnimation = `translate3d(${((goal / end) * 100) - 100}%, 0, 0)`;
 
     const readyToRender = (this.state && !Number.isNaN(this.state.count) && this.state.count > -1);
     const allClassModifiers = readyToRender ? this.classModifiers : [...this.classModifiers, 'hidden'];
@@ -205,9 +205,10 @@ export default class ContributionTicker extends Component<PropTypes, StateTypes>
               className="contributions-landing-ticker__filled-progress"
               style={{ transform: progressBarAnimation }}
             />
-            <div className="contributions-landing-ticker__marker"
-                 style={{ transform: markerAnimation }}
-            ></div>
+            <div
+              className="contributions-landing-ticker__marker"
+              style={{ transform: markerAnimation }}
+            />
           </div>
         </div>
       </div>

--- a/support-frontend/assets/components/ticker/contributionTicker.jsx
+++ b/support-frontend/assets/components/ticker/contributionTicker.jsx
@@ -188,12 +188,14 @@ export default class ContributionTicker extends Component<PropTypes, StateTypes>
     const baseClassName = 'contributions-landing-ticker';
     const wrapperClassName = classNameWithModifiers(baseClassName, allClassModifiers);
 
+    const goalValue = (this.tickerType === 'unlimited' && total > goal) ? total : this.state.goal;
+
     return (
       <div className={wrapperClassName}>
         <div className="contributions-landing-ticker__values">
           {this.renderContributedSoFar()}
           <div className="contributions-landing-ticker__goal">
-            <div className="contributions-landing-ticker__count">{this.props.currencySymbol}{Math.floor(this.state.goal).toLocaleString()}</div>
+            <div className="contributions-landing-ticker__count">{this.props.currencySymbol}{Math.floor(goalValue).toLocaleString()}</div>
             <div className="contributions-landing-ticker__count-label contributions-landing-ticker__label">our
               goal
             </div>

--- a/support-frontend/assets/components/ticker/contributionTicker.scss
+++ b/support-frontend/assets/components/ticker/contributionTicker.scss
@@ -83,21 +83,17 @@ $progress-bar-height: 10px;
   transition: transform 3s cubic-bezier(.25, .55, .2, .85);
 }
 
-// Post-goal styles:
-// Default post-goal style (hard stop)
-.contributions-landing-ticker--goal-reached .contributions-landing-ticker__progress-bar::after {
-  content: '';
-  position: absolute;
-  background: gu-colour(neutral-7);
-  width: 2px;
+.contributions-landing-ticker__marker {
+  visibility: hidden;
+  border-right: 2px solid gu-colour(neutral-7);
+  content: ' ';
+  display: block;
   height: 15px;
-  right: 0;
-  bottom: -$progress-bar-height;
+  margin-top: -5px;
 }
 
-// "Unlimited" post-goal style
-.contributions-landing-ticker--goal-reached.contributions-landing-ticker--unlimited .contributions-landing-ticker__progress-bar::after {
-  right: 20%;
+.contributions-landing-ticker--goal-reached .contributions-landing-ticker__marker {
+  visibility: visible;
 }
 
 // Post-goal copy

--- a/support-frontend/assets/components/ticker/contributionTicker.scss
+++ b/support-frontend/assets/components/ticker/contributionTicker.scss
@@ -88,8 +88,8 @@ $progress-bar-height: 10px;
   border-right: 2px solid gu-colour(neutral-7);
   content: ' ';
   display: block;
-  height: 15px;
-  margin-top: -5px;
+  height: 12px;
+  margin-top: -2px;
 }
 
 .contributions-landing-ticker--goal-reached .contributions-landing-ticker__marker {

--- a/support-frontend/public/ticker.json
+++ b/support-frontend/public/ticker.json
@@ -1,5 +1,5 @@
 {
-  "total": 10000,
+  "total": 101000,
   "goal": 100000,
   "whyIsThisFileHere?": "This is just a dummy file for local dev. In CODE & PROD Fastly will route this request direct to S3, so this file will not be accessed."
 }

--- a/support-frontend/public/ticker.json
+++ b/support-frontend/public/ticker.json
@@ -1,5 +1,5 @@
 {
-  "total": 101100,
+  "total": 100001,
   "goal": 100000,
   "whyIsThisFileHere?": "This is just a dummy file for local dev. In CODE & PROD Fastly will route this request direct to S3, so this file will not be accessed."
 }

--- a/support-frontend/public/ticker.json
+++ b/support-frontend/public/ticker.json
@@ -1,5 +1,5 @@
 {
-  "total": 101000,
+  "total": 101100,
   "goal": 100000,
   "whyIsThisFileHere?": "This is just a dummy file for local dev. In CODE & PROD Fastly will route this request direct to S3, so this file will not be accessed."
 }


### PR DESCRIPTION
## Why are you doing this?
The position of the progress bar relative to the marker is currently incorrect when we exceed the goal.
This PR fixes it, following the original logic in frontend introduced here https://github.com/guardian/frontend/pull/20874/files
I've had to make the marker a `div` rather than an `after` so that it can be transformed.

I've also fixed it so that it displays the current amount instead of the goal.

Before fix, for a very small amount above the goal it would exceed the marker by too much:
<img width="491" alt="Screenshot 2019-05-24 at 17 26 59" src="https://user-images.githubusercontent.com/1513454/58342913-aeb01b00-7e49-11e9-89ce-830ccc9a6b8f.png">


## Screenshots
Above goal:
<img width="489" alt="Screenshot 2019-05-24 at 17 40 29" src="https://user-images.githubusercontent.com/1513454/58343597-511cce00-7e4b-11e9-9484-66d75660892b.png">



Below goal:
<img width="492" alt="Screenshot 2019-05-24 at 16 57 09" src="https://user-images.githubusercontent.com/1513454/58340951-026c3580-7e45-11e9-8364-9baa1178c305.png">



