### PR TITLE
Don't pass a promocode into the pricing lookup 

### DIFF
--- a/support-frontend/app/controllers/Subscriptions.scala
+++ b/support-frontend/app/controllers/Subscriptions.scala
@@ -65,8 +65,7 @@ class Subscriptions(
     val css = Left(RefPath("weeklySubscriptionLandingPage.css"))
     val description = stringsConfig.weeklyLandingDescription
     val canonicalLink = Some(buildCanonicalWeeklySubscriptionLink("uk"))
-    val promoCode = request.queryString.get("promoCode").flatMap(_.headOption)
-    val productPrices = priceSummaryServiceProvider.forUser(false).getPrices(GuardianWeekly, promoCode)
+    val productPrices = priceSummaryServiceProvider.forUser(false).getPrices(GuardianWeekly, None) //TODO: support promo codes
     val hrefLangLinks = Map(
       "en-us" -> buildCanonicalWeeklySubscriptionLink("us"),
       "en-gb" -> buildCanonicalWeeklySubscriptionLink("uk"),


### PR DESCRIPTION
Passing a promo code into the pricing lookup on the Guardian Weekly landing page is causing it to respond very slowly so we are going to stop passing them in while we investigate.