### PR TITLE
Increase gocardless missing data alarm to 10 hours

### DIFF
--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -204,13 +204,13 @@ Resources:
       Statistic: Sum
     DependsOn: SupportWorkersPROD
 
-  NoPaypalContributionsInOneHourAlarm:
+  NoPaypalContributionsInTwoHoursAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: CreateProdResources
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:contributions-dev
-      AlarmName: !Sub support-workers ${Stage} No successful recurring paypal contributions for an hour
+      AlarmName: !Sub support-workers ${Stage} No successful recurring paypal contributions for two hours
       MetricName: PaymentSuccess
       Namespace: support-frontend
       Dimensions:
@@ -223,18 +223,18 @@ Resources:
       ComparisonOperator: LessThanOrEqualToThreshold
       Threshold: 0
       Period: 3600
-      EvaluationPeriods: 1
+      EvaluationPeriods: 2
       Statistic: Sum
       TreatMissingData: breaching
     DependsOn: SupportWorkersPROD
 
-  NoStripeContributionsInOneHourAlarm:
+  NoStripeContributionsInTwoHoursAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: CreateProdResources
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:contributions-dev
-      AlarmName: !Sub support-workers ${Stage} No successful recurring stripe contributions for an hour
+      AlarmName: !Sub support-workers ${Stage} No successful recurring stripe contributions for two hours
       MetricName: PaymentSuccess
       Namespace: support-frontend
       Dimensions:
@@ -247,7 +247,7 @@ Resources:
       ComparisonOperator: LessThanOrEqualToThreshold
       Threshold: 0
       Period: 3600
-      EvaluationPeriods: 1
+      EvaluationPeriods: 2
       Statistic: Sum
       TreatMissingData: breaching
     DependsOn: SupportWorkersPROD
@@ -263,13 +263,13 @@ Resources:
   # and payment_provider='GOCARDLESS'
   # order by hours_between_go_cardless_acquisitions desc;
   #
-  NoGocardlessContributionsInTwoHoursAlarm:
+  NoGocardlessContributionsInTenHoursAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: CreateProdResources
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:contributions-dev
-      AlarmName: !Sub support-workers ${Stage} No successful recurring Gocardless contributions for three hours
+      AlarmName: !Sub support-workers ${Stage} No successful recurring Gocardless contributions for ten hours
       MetricName: PaymentSuccess
       Namespace: support-frontend
       Dimensions:

--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -252,6 +252,17 @@ Resources:
       TreatMissingData: breaching
     DependsOn: SupportWorkersPROD
 
+  # Why 10 hours for gocardless? Well...
+  #
+  # select
+  # event_timestamp,
+  # (to_unixtime(event_timestamp) - lag(to_unixtime(event_timestamp)) over (order by event_timestamp))/60/60 as hours_between_go_cardless_acquisitions
+  # from acquisitions
+  # where received_date>date'2019-04-01'
+  # and received_date<date'2019-05-01'
+  # and payment_provider='GOCARDLESS'
+  # order by hours_between_go_cardless_acquisitions desc;
+  #
   NoGocardlessContributionsInTwoHoursAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: CreateProdResources
@@ -271,7 +282,7 @@ Resources:
       ComparisonOperator: LessThanOrEqualToThreshold
       Threshold: 0
       Period: 3600
-      EvaluationPeriods: 3
+      EvaluationPeriods: 10
       Statistic: Sum
       TreatMissingData: breaching
     DependsOn: SupportWorkersPROD

--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -222,8 +222,8 @@ Resources:
           Value: !Ref Stage
       ComparisonOperator: LessThanOrEqualToThreshold
       Threshold: 0
-      Period: 300
-      EvaluationPeriods: 12
+      Period: 3600
+      EvaluationPeriods: 1
       Statistic: Sum
       TreatMissingData: breaching
     DependsOn: SupportWorkersPROD
@@ -246,8 +246,8 @@ Resources:
           Value: !Ref Stage
       ComparisonOperator: LessThanOrEqualToThreshold
       Threshold: 0
-      Period: 300
-      EvaluationPeriods: 12
+      Period: 3600
+      EvaluationPeriods: 1
       Statistic: Sum
       TreatMissingData: breaching
     DependsOn: SupportWorkersPROD
@@ -258,7 +258,7 @@ Resources:
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:contributions-dev
-      AlarmName: !Sub support-workers ${Stage} No successful recurring Gocardless contributions for two hours
+      AlarmName: !Sub support-workers ${Stage} No successful recurring Gocardless contributions for three hours
       MetricName: PaymentSuccess
       Namespace: support-frontend
       Dimensions:
@@ -270,8 +270,8 @@ Resources:
           Value: !Ref Stage
       ComparisonOperator: LessThanOrEqualToThreshold
       Threshold: 0
-      Period: 300
-      EvaluationPeriods: 24
+      Period: 3600
+      EvaluationPeriods: 3
       Statistic: Sum
       TreatMissingData: breaching
     DependsOn: SupportWorkersPROD


### PR DESCRIPTION
## Why are you doing this?
Make the alarm less noisy - we do sometimes go 2 hours without any gocardless contributions

Also simplified the period configuration a bit