### PR TITLE
Client work for one-off Stripe payment guest account creation

### DIFF
--- a/support-frontend/assets/helpers/paymentIntegrations/oneOffContributions.js
+++ b/support-frontend/assets/helpers/paymentIntegrations/oneOffContributions.js
@@ -103,7 +103,11 @@ function paymentApiEndpointWithMode(url: string) {
 // Object is expected to have structure:
 // { type: "error", error: { failureReason: string } }, or
 // { type: "success", data: { currency: string, amount: number } }
-function paymentResultFromObject(json: Object, setGuestAccountCreationToken: (string) => void, setThankYouPageStage: (ThankYouPageStage) => void): Promise<PaymentResult> {
+function paymentResultFromObject(
+  json: Object,
+  setGuestAccountCreationToken: (string) => void,
+  setThankYouPageStage: (ThankYouPageStage) => void,
+): Promise<PaymentResult> {
   if (json.error) {
     const failureReason: ErrorReason = json.error.failureReason ? json.error.failureReason : 'unknown';
     return Promise.resolve({ paymentStatus: 'failure', error: failureReason });

--- a/support-frontend/assets/helpers/paymentIntegrations/oneOffContributions.js
+++ b/support-frontend/assets/helpers/paymentIntegrations/oneOffContributions.js
@@ -102,21 +102,36 @@ function paymentApiEndpointWithMode(url: string) {
 // Object is expected to have structure:
 // { type: "error", error: { failureReason: string } }, or
 // { type: "success", data: { currency: string, amount: number } }
-function paymentResultFromObject(json: Object): Promise<PaymentResult> {
+function paymentResultFromObject(json: Object, setGuestAccountCreationToken: (string) => void): Promise<PaymentResult> {
   if (json.error) {
     const failureReason: ErrorReason = json.error.failureReason ? json.error.failureReason : 'unknown';
     return Promise.resolve({ paymentStatus: 'failure', error: failureReason });
+  }
+
+  // TBD: REMOVE
+  /* eslint-disable */
+  if (json.data && !json.data.guestAccountRegistrationToken) {
+    json.data.guestAccountRegistrationToken = 'dataToken';
+  }
+  /* eslint-enable */
+  // REMOVE ABOVE
+
+  if (json.data && json.data.guestAccountRegistrationToken) {
+    setGuestAccountCreationToken(json.data.guestAccountRegistrationToken);
   }
   return Promise.resolve(PaymentSuccess);
 }
 
 // Sends a one-off payment request to the payment API and standardises the result
 // https://github.com/guardian/payment-api/blob/master/src/main/resources/routes#L17
-function postOneOffStripeExecutePaymentRequest(data: StripeChargeData): Promise<PaymentResult> {
+function postOneOffStripeExecutePaymentRequest(
+  data: StripeChargeData,
+  setGuestAccountCreationToken: (string) => void,
+): Promise<PaymentResult> {
   return logPromise(fetchJson(
     paymentApiEndpointWithMode(window.guardian.paymentApiStripeEndpoint),
     requestOptions(data, 'omit', 'POST', null),
-  ).then(paymentResultFromObject));
+  ).then(result => paymentResultFromObject(result, setGuestAccountCreationToken)));
 }
 
 // Object is expected to have structure:

--- a/support-frontend/assets/helpers/paymentIntegrations/oneOffContributions.js
+++ b/support-frontend/assets/helpers/paymentIntegrations/oneOffContributions.js
@@ -113,16 +113,8 @@ function paymentResultFromObject(
     return Promise.resolve({ paymentStatus: 'failure', error: failureReason });
   }
 
-  // TBD: REMOVE
-  /* eslint-disable */
-  if (json.data && !json.data.guestAccountRegistrationToken) {
-    json.data.guestAccountRegistrationToken = 'dataToken';
-  }
-  /* eslint-enable */
-  // REMOVE ABOVE
-
-  if (json.data && json.data.guestAccountRegistrationToken) {
-    setGuestAccountCreationToken(json.data.guestAccountRegistrationToken);
+  if (json.data && json.data.guestAccountToken) {
+    setGuestAccountCreationToken(json.data.guestAccountToken);
     setThankYouPageStage('thankYouSetPassword');
   } else {
     setThankYouPageStage('thankYou');

--- a/support-frontend/assets/helpers/paymentIntegrations/oneOffContributions.js
+++ b/support-frontend/assets/helpers/paymentIntegrations/oneOffContributions.js
@@ -11,7 +11,7 @@ import type { IsoCurrency } from 'helpers/internationalisation/currency';
 
 import { PaymentSuccess } from './readerRevenueApis';
 import type { PaymentResult, StripePaymentMethod } from './readerRevenueApis';
-import type { ThankYouPageStage } from '../../pages/new-contributions-landing/contributionsLandingReducer';
+import type { ThankYouPageStage } from 'pages/contributions-landing/contributionsLandingReducer';
 
 // ----- Types ----- //
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
@@ -83,7 +83,6 @@ type PropTypes = {|
   isTestUser: boolean,
   country: IsoCountry,
   stripePaymentRequestButtonMethod: StripePaymentRequestButtonMethod,
-  campaignName: ?CampaignName,
   setThankYouPageStage: (ThankYouPageStage) => void,
 |};
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
@@ -37,7 +37,7 @@ import ContributionAmount from './ContributionAmount';
 import PaymentMethodSelector from './PaymentMethodSelector';
 import ContributionSubmit from './ContributionSubmit';
 
-import { type State, type ThankYouPageStage } from '../contributionsLandingReducer';
+import { type State, type ThankYouPageStage } from 'pages/new-contributions-landing/contributionsLandingReducer';
 
 import {
   paymentWaiting,
@@ -45,10 +45,10 @@ import {
   createOneOffPayPalPayment,
   setStripeV3HasLoaded,
   setThankYouPageStage,
-} from '../contributionsLandingActions';
+} from 'pages/new-contributions-landing/contributionsLandingActions';
 import ContributionErrorMessage from './ContributionErrorMessage';
 import StripePaymentRequestButtonContainer from './StripePaymentRequestButton/StripePaymentRequestButtonContainer';
-import type { RecentlySignedInExistingPaymentMethod } from '../../../helpers/existingPaymentMethods/existingPaymentMethods';
+import type { FullDetailExistingPaymentMethod } from 'helpers/existingPaymentMethods/existingPaymentMethods';
 import type { PaymentMethod } from 'helpers/paymentMethods';
 import { DirectDebit, Stripe, ExistingCard, ExistingDirectDebit } from 'helpers/paymentMethods';
 import { getCampaignName } from 'helpers/campaigns';

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
@@ -48,7 +48,7 @@ import {
 } from 'pages/new-contributions-landing/contributionsLandingActions';
 import ContributionErrorMessage from './ContributionErrorMessage';
 import StripePaymentRequestButtonContainer from './StripePaymentRequestButton/StripePaymentRequestButtonContainer';
-import type { FullDetailExistingPaymentMethod } from 'helpers/existingPaymentMethods/existingPaymentMethods';
+import type { RecentlySignedInExistingPaymentMethod } from 'helpers/existingPaymentMethods/existingPaymentMethods';
 import type { PaymentMethod } from 'helpers/paymentMethods';
 import { DirectDebit, Stripe, ExistingCard, ExistingDirectDebit } from 'helpers/paymentMethods';
 import { getCampaignName } from 'helpers/campaigns';

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
@@ -37,14 +37,13 @@ import ContributionAmount from './ContributionAmount';
 import PaymentMethodSelector from './PaymentMethodSelector';
 import ContributionSubmit from './ContributionSubmit';
 
-import { type State, type ThankYouPageStage } from 'pages/new-contributions-landing/contributionsLandingReducer';
+import { type State } from 'pages/new-contributions-landing/contributionsLandingReducer';
 
 import {
   paymentWaiting,
   setCheckoutFormHasBeenSubmitted,
   createOneOffPayPalPayment,
   setStripeV3HasLoaded,
-  setThankYouPageStage,
 } from 'pages/new-contributions-landing/contributionsLandingActions';
 import ContributionErrorMessage from './ContributionErrorMessage';
 import StripePaymentRequestButtonContainer from './StripePaymentRequestButton/StripePaymentRequestButtonContainer';
@@ -83,7 +82,6 @@ type PropTypes = {|
   isTestUser: boolean,
   country: IsoCountry,
   stripePaymentRequestButtonMethod: StripePaymentRequestButtonMethod,
-  setThankYouPageStage: (ThankYouPageStage) => void,
 |};
 
 // We only want to use the user state value if the form state value has not been changed since it was initialised,
@@ -123,9 +121,6 @@ const mapDispatchToProps = (dispatch: Function) => ({
   setCheckoutFormHasBeenSubmitted: () => { dispatch(setCheckoutFormHasBeenSubmitted()); },
   createOneOffPayPalPayment: (data: CreatePaypalPaymentData) => { dispatch(createOneOffPayPalPayment(data)); },
   setStripeV3HasLoaded: () => { dispatch(setStripeV3HasLoaded); },
-  setThankYouPageStage: (thankYouPageStage: ThankYouPageStage) => {
-    dispatch(setThankYouPageStage(thankYouPageStage));
-  },
 });
 
 // ----- Functions ----- //
@@ -212,8 +207,6 @@ function onSubmit(props: PropTypes): Event => void {
     if (props.isPostDeploymentTestUser && props.paymentMethod === Stripe) {
       props.onPaymentAuthorisation({ paymentMethod: Stripe, token: 'tok_visa', stripePaymentMethod: 'StripeCheckout' });
     } else {
-      props.setThankYouPageStage('thankYouSetPassword');
-
       const handlePayment = () => formHandlers[props.contributionType][props.paymentMethod](props);
       onFormSubmit({
         ...props,

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
@@ -37,14 +37,14 @@ import ContributionAmount from './ContributionAmount';
 import PaymentMethodSelector from './PaymentMethodSelector';
 import ContributionSubmit from './ContributionSubmit';
 
-import { type State } from 'pages/new-contributions-landing/contributionsLandingReducer';
+import { type State } from 'pages/contributions-landing/contributionsLandingReducer';
 
 import {
   paymentWaiting,
   setCheckoutFormHasBeenSubmitted,
   createOneOffPayPalPayment,
   setStripeV3HasLoaded,
-} from 'pages/new-contributions-landing/contributionsLandingActions';
+} from 'pages/contributions-landing/contributionsLandingActions';
 import ContributionErrorMessage from './ContributionErrorMessage';
 import StripePaymentRequestButtonContainer from './StripePaymentRequestButton/StripePaymentRequestButtonContainer';
 import type { RecentlySignedInExistingPaymentMethod } from 'helpers/existingPaymentMethods/existingPaymentMethods';

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
@@ -37,13 +37,14 @@ import ContributionAmount from './ContributionAmount';
 import PaymentMethodSelector from './PaymentMethodSelector';
 import ContributionSubmit from './ContributionSubmit';
 
-import { type State } from '../contributionsLandingReducer';
+import { type State, type ThankYouPageStage } from '../contributionsLandingReducer';
 
 import {
   paymentWaiting,
   setCheckoutFormHasBeenSubmitted,
   createOneOffPayPalPayment,
   setStripeV3HasLoaded,
+  setThankYouPageStage,
 } from '../contributionsLandingActions';
 import ContributionErrorMessage from './ContributionErrorMessage';
 import StripePaymentRequestButtonContainer from './StripePaymentRequestButton/StripePaymentRequestButtonContainer';
@@ -82,6 +83,8 @@ type PropTypes = {|
   isTestUser: boolean,
   country: IsoCountry,
   stripePaymentRequestButtonMethod: StripePaymentRequestButtonMethod,
+  campaignName: ?CampaignName,
+  setThankYouPageStage: (ThankYouPageStage) => void,
 |};
 
 // We only want to use the user state value if the form state value has not been changed since it was initialised,
@@ -121,6 +124,9 @@ const mapDispatchToProps = (dispatch: Function) => ({
   setCheckoutFormHasBeenSubmitted: () => { dispatch(setCheckoutFormHasBeenSubmitted()); },
   createOneOffPayPalPayment: (data: CreatePaypalPaymentData) => { dispatch(createOneOffPayPalPayment(data)); },
   setStripeV3HasLoaded: () => { dispatch(setStripeV3HasLoaded); },
+  setThankYouPageStage: (thankYouPageStage: ThankYouPageStage) => {
+    dispatch(setThankYouPageStage(thankYouPageStage));
+  },
 });
 
 // ----- Functions ----- //
@@ -207,6 +213,8 @@ function onSubmit(props: PropTypes): Event => void {
     if (props.isPostDeploymentTestUser && props.paymentMethod === Stripe) {
       props.onPaymentAuthorisation({ paymentMethod: Stripe, token: 'tok_visa', stripePaymentMethod: 'StripeCheckout' });
     } else {
+      props.setThankYouPageStage('thankYouSetPassword');
+
       const handlePayment = () => formHandlers[props.contributionType][props.paymentMethod](props);
       onFormSubmit({
         ...props,

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouPasswordSet.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouPasswordSet.jsx
@@ -23,7 +23,7 @@ const mapStateToProps = state => ({
 // ----- Render ----- //
 
 function ContributionThankYouPasswordSet(props: PropTypes) {
-  const title = 'Set up a free account to manage your payments';
+  const title = 'You now have a Guardian account';
   const body = 'Please check your inbox to validate your email address – it only takes a minute. And then sign in on each of the devices you use to access The Guardian.';
 
   return (

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouPasswordSet.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouPasswordSet.jsx
@@ -24,30 +24,15 @@ const mapStateToProps = state => ({
 
 function ContributionThankYouPasswordSet(props: PropTypes) {
   const title = 'Set up a free account to manage your payments';
-  const recurringBody = 'Stay signed in on all your devices to easily manage your contributions and to stop seeing our appeals for support';
-
-  const passwordSetCopy = {
-    ONE_OFF: {
-      title,
-      body: 'Remember to stay signed in on each of your devices to see fewer support messages, and to make contributing again even easier.',
-    },
-    MONTHLY: {
-      title,
-      body: recurringBody,
-    },
-    ANNUAL: {
-      title,
-      body: recurringBody,
-    },
-  };
+  const body = 'Please check your inbox to validate your email address – it only takes a minute. And then sign in on each of the devices you use to access The Guardian.';
 
   return (
     <div className="thank-you__container">
       <div className="gu-content__form gu-content__form--thank-you gu-content__form--password-set">
         <section className="confirmation">
-          <h3 className="confirmation__title">{passwordSetCopy[props.contributionType].title}</h3>
+          <h3 className="confirmation__title">{title}</h3>
           <p className="confirmation__message">
-            {passwordSetCopy[props.contributionType].body}
+            {body}
           </p>
         </section>
         <MarketingConsent />

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouPasswordSet.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouPasswordSet.jsx
@@ -23,15 +23,31 @@ const mapStateToProps = state => ({
 // ----- Render ----- //
 
 function ContributionThankYouPasswordSet(props: PropTypes) {
+  const title = 'Set up a free account to manage your payments';
+  const recurringBody = 'Stay signed in on all your devices to easily manage your contributions and to stop seeing our appeals for support';
+
+  const passwordSetCopy = {
+    ONE_OFF: {
+      title,
+      body: 'Remember to stay signed in on each of your devices to see fewer support messages, and to make contributing again even easier.',
+    },
+    MONTHLY: {
+      title,
+      body: recurringBody,
+    },
+    ANNUAL: {
+      title,
+      body: recurringBody,
+    },
+  };
 
   return (
     <div className="thank-you__container">
       <div className="gu-content__form gu-content__form--thank-you gu-content__form--password-set">
         <section className="confirmation">
-          <h3 className="confirmation__title">You now have a Guardian account</h3>
+          <h3 className="confirmation__title">{passwordSetCopy[props.contributionType].title}</h3>
           <p className="confirmation__message">
-            Stay signed in on all your devices to easily manage your
-            contributions and to stop seeing our appeals for support
+            {passwordSetCopy[props.contributionType].body}
           </p>
         </section>
         <MarketingConsent />

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSetPassword.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSetPassword.jsx
@@ -45,7 +45,7 @@ function mapDispatchToProps(dispatch: Dispatch<Action>) {
 
 function ContributionThankYouSetPassword(props: PropTypes) {
   const oneOffTitle = 'Complete your Guardian account';
-  const oneOffBody = 'Having an account means you’ll notice far fewer messages asking you for financial support. And if you want to support us again in the future, making a contribution will be even easier. Please make sure you validate your account via your inbox, and stay signed in on each of your devices.';
+  const oneOffBody = 'If you create an account and stay signed in on each of your devices, you’ll notice far fewer messages asking you for financial support. Please make sure you validate your account via your inbox.';
   const recurringTitle = 'Set up a free account to manage your payments';
   const recurringBody = 'If you stay signed in when you’re reading The Guardian as a contributor, you’ll no longer see messages asking you to support our journalism';
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSetPassword.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSetPassword.jsx
@@ -47,7 +47,7 @@ function ContributionThankYouSetPassword(props: PropTypes) {
   const recurringTitle = 'Set up a free account to manage your payments';
   const recurringBody = 'If you stay signed in when you’re reading The Guardian as a contributor, you’ll no longer see messages asking you to support our journalism';
 
-  const setPasswordContents = {
+  const setPasswordCopy = {
     ONE_OFF: {
       title: 'Set up a free Guardian account',
       body: 'Having an account means you’ll notice far fewer messages asking you for financial support. And, if you do want to support us again in the future, making a contribution will be even easier. Please make sure you validate your account via your inbox, and stay signed in on each of your devices.',
@@ -79,9 +79,9 @@ function ContributionThankYouSetPassword(props: PropTypes) {
         { props.paymentMethod === DirectDebit && !props.hasSeenDirectDebitThankYouCopy ?
             renderDirectDebit() : null }
         <section className="set-password">
-          <h3 className="set-password__title">{setPasswordContents[props.contributionType].title}</h3>
+          <h3 className="set-password__title">{setPasswordCopy[props.contributionType].title}</h3>
           <p className="set-password__message">
-            {setPasswordContents[props.contributionType].body}
+            {setPasswordCopy[props.contributionType].body}
           </p>
           <SetPasswordForm />
         </section>

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSetPassword.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSetPassword.jsx
@@ -44,6 +44,24 @@ function mapDispatchToProps(dispatch: Dispatch<Action>) {
 // ----- Render ----- //
 
 function ContributionThankYouSetPassword(props: PropTypes) {
+  const recurringTitle = 'Set up a free account to manage your payments';
+  const recurringBody = 'If you stay signed in when you’re reading The Guardian as a contributor, you’ll no longer see messages asking you to support our journalism';
+
+  const setPasswordContents = {
+    ONE_OFF: {
+      title: 'Set up a free Guardian account',
+      body: 'Having an account means you’ll notice far fewer messages asking you for financial support. And, if you do want to support us again in the future, making a contribution will be even easier. Please make sure you validate your account via your inbox, and stay signed in on each of your devices.',
+    },
+    MONTHLY: {
+      title: recurringTitle,
+      body: recurringBody,
+    },
+    ANNUAL: {
+      title: recurringTitle,
+      body: recurringBody,
+    },
+  };
+
   const renderDirectDebit = () => {
     props.setHasSeenDirectDebitThankYouCopy();
     return (
@@ -61,10 +79,9 @@ function ContributionThankYouSetPassword(props: PropTypes) {
         { props.paymentMethod === DirectDebit && !props.hasSeenDirectDebitThankYouCopy ?
             renderDirectDebit() : null }
         <section className="set-password">
-          <h3 className="set-password__title">Set up a free account to manage your payments</h3>
+          <h3 className="set-password__title">{setPasswordContents[props.contributionType].title}</h3>
           <p className="set-password__message">
-            If you stay signed in when you’re reading The Guardian as a contributor,
-            you’ll no longer see messages asking you to support our journalism
+            {setPasswordContents[props.contributionType].body}
           </p>
           <SetPasswordForm />
         </section>

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSetPassword.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSetPassword.jsx
@@ -44,13 +44,15 @@ function mapDispatchToProps(dispatch: Dispatch<Action>) {
 // ----- Render ----- //
 
 function ContributionThankYouSetPassword(props: PropTypes) {
+  const oneOffTitle = 'Complete your Guardian account';
+  const oneOffBody = 'Having an account means you’ll notice far fewer messages asking you for financial support. And if you want to support us again in the future, making a contribution will be even easier. Please make sure you validate your account via your inbox, and stay signed in on each of your devices.';
   const recurringTitle = 'Set up a free account to manage your payments';
   const recurringBody = 'If you stay signed in when you’re reading The Guardian as a contributor, you’ll no longer see messages asking you to support our journalism';
 
   const setPasswordCopy = {
     ONE_OFF: {
-      title: 'Set up a free Guardian account',
-      body: 'Having an account means you’ll notice far fewer messages asking you for financial support. And, if you do want to support us again in the future, making a contribution will be even easier. Please make sure you validate your account via your inbox, and stay signed in on each of your devices.',
+      title: oneOffTitle,
+      body: oneOffBody,
     },
     MONTHLY: {
       title: recurringTitle,

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSetPassword.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSetPassword.jsx
@@ -9,7 +9,7 @@ import { type Action, setHasSeenDirectDebitThankYouCopy } from '../../contributi
 import SetPasswordForm from '../SetPasswordForm';
 import type { PaymentMethod } from 'helpers/paymentMethods';
 import { DirectDebit } from 'helpers/paymentMethods';
-import type { ContributionType } from '../../../../helpers/contributions';
+import type { ContributionType } from 'helpers/contributions';
 
 // ----- Types ----- //
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSetPassword.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSetPassword.jsx
@@ -9,11 +9,13 @@ import { type Action, setHasSeenDirectDebitThankYouCopy } from '../../contributi
 import SetPasswordForm from '../SetPasswordForm';
 import type { PaymentMethod } from 'helpers/paymentMethods';
 import { DirectDebit } from 'helpers/paymentMethods';
+import type { ContributionType } from '../../../../helpers/contributions';
 
 // ----- Types ----- //
 
 /* eslint-disable react/no-unused-prop-types */
 type PropTypes = {|
+  contributionType: ContributionType,
   paymentMethod: PaymentMethod,
   passwordFailed: boolean,
   hasSeenDirectDebitThankYouCopy: boolean,
@@ -25,6 +27,7 @@ type PropTypes = {|
 // ----- State Maps ----- //
 
 const mapStateToProps = state => ({
+  contributionType: state.page.form.contributionType,
   paymentMethod: state.page.form.paymentMethod,
   passwordFailed: state.page.form.passwordFailed,
   hasSeenDirectDebitThankYouCopy: state.page.hasSeenDirectDebitThankYouCopy,

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -357,9 +357,9 @@ const createOneOffPayPalPayment = (data: CreatePaypalPaymentData) =>
     dispatch(onCreateOneOffPayPalPaymentResponse(postOneOffPayPalCreatePaymentRequest(data)));
   };
 
-const executeStripeOneOffPayment = (data: StripeChargeData, setGuestToken: (string) => void) =>
+const executeStripeOneOffPayment = (data: StripeChargeData, setGuestToken: (string) => void, setThankYouPageStage: (ThankYouPageStage) => void) =>
   (dispatch: Dispatch<Action>): Promise<PaymentResult> =>
-    dispatch(onPaymentResult(postOneOffStripeExecutePaymentRequest(data, setGuestToken)));
+    dispatch(onPaymentResult(postOneOffStripeExecutePaymentRequest(data, setGuestToken, setThankYouPageStage)));
 
 
 function recurringPaymentAuthorisationHandler(
@@ -415,6 +415,7 @@ const paymentAuthorisationHandlers: PaymentMatrix<(
         return dispatch(executeStripeOneOffPayment(
           stripeChargeDataFromAuthorisation(paymentAuthorisation, state),
           (token: string) => dispatch(setGuestAccountCreationToken(token)),
+          (thankYouPageStage: ThankYouPageStage) => dispatch(setThankYouPageStage(thankYouPageStage)),
         ));
       }
       logException(`Invalid payment authorisation: Tried to use the ${paymentAuthorisation.paymentMethod} handler with Stripe`);

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -357,9 +357,10 @@ const createOneOffPayPalPayment = (data: CreatePaypalPaymentData) =>
     dispatch(onCreateOneOffPayPalPaymentResponse(postOneOffPayPalCreatePaymentRequest(data)));
   };
 
-const executeStripeOneOffPayment = (data: StripeChargeData) =>
+const executeStripeOneOffPayment = (data: StripeChargeData, setGuestToken: (string) => void) =>
   (dispatch: Dispatch<Action>): Promise<PaymentResult> =>
-    dispatch(onPaymentResult(postOneOffStripeExecutePaymentRequest(data)));
+    dispatch(onPaymentResult(postOneOffStripeExecutePaymentRequest(data, setGuestToken)));
+
 
 function recurringPaymentAuthorisationHandler(
   dispatch: Dispatch<Action>,
@@ -411,7 +412,10 @@ const paymentAuthorisationHandlers: PaymentMatrix<(
       paymentAuthorisation: PaymentAuthorisation,
     ): Promise<PaymentResult> => {
       if (paymentAuthorisation.paymentMethod === Stripe) {
-        return dispatch(executeStripeOneOffPayment(stripeChargeDataFromAuthorisation(paymentAuthorisation, state)));
+        return dispatch(executeStripeOneOffPayment(
+          stripeChargeDataFromAuthorisation(paymentAuthorisation, state),
+          (token: string) => dispatch(setGuestAccountCreationToken(token)),
+        ));
       }
       logException(`Invalid payment authorisation: Tried to use the ${paymentAuthorisation.paymentMethod} handler with Stripe`);
       return Promise.resolve(error);

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -357,9 +357,13 @@ const createOneOffPayPalPayment = (data: CreatePaypalPaymentData) =>
     dispatch(onCreateOneOffPayPalPaymentResponse(postOneOffPayPalCreatePaymentRequest(data)));
   };
 
-const executeStripeOneOffPayment = (data: StripeChargeData, setGuestToken: (string) => void, setThankYouPageStage: (ThankYouPageStage) => void) =>
+const executeStripeOneOffPayment = (
+  data: StripeChargeData,
+  setGuestToken: (string) => void,
+  setThankYouPage: (ThankYouPageStage) => void,
+) =>
   (dispatch: Dispatch<Action>): Promise<PaymentResult> =>
-    dispatch(onPaymentResult(postOneOffStripeExecutePaymentRequest(data, setGuestToken, setThankYouPageStage)));
+    dispatch(onPaymentResult(postOneOffStripeExecutePaymentRequest(data, setGuestToken, setThankYouPage)));
 
 
 function recurringPaymentAuthorisationHandler(

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
@@ -308,8 +308,8 @@ function createFormReducer() {
       // Don't allow the stage to be set to thankYouSetPassword unless both an email and
       // guest registration token is present
       case 'SET_THANK_YOU_PAGE_STAGE':
+        console.log('state.guestAccountCreationToken', state.guestAccountCreationToken);
         if ((action.thankYouPageStage === 'thankYouSetPassword')
-          && state.contributionType !== 'ONE_OFF'
           && (!state.guestAccountCreationToken || !state.formData.email)) {
           return { ...state, thankYouPageStage: 'thankYou' };
         }

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
@@ -308,7 +308,6 @@ function createFormReducer() {
       // Don't allow the stage to be set to thankYouSetPassword unless both an email and
       // guest registration token is present
       case 'SET_THANK_YOU_PAGE_STAGE':
-        console.log('state.guestAccountCreationToken', state.guestAccountCreationToken);
         if ((action.thankYouPageStage === 'thankYouSetPassword')
           && (!state.guestAccountCreationToken || !state.formData.email)) {
           return { ...state, thankYouPageStage: 'thankYou' };

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
@@ -305,11 +305,10 @@ function createFormReducer() {
       case 'SET_GUEST_ACCOUNT_CREATION_TOKEN':
         return { ...state, guestAccountCreationToken: action.guestAccountCreationToken };
 
-      // For recurring, don't allow the stage to be set to thankYouSetPassword unless both an email and
+      // Don't allow the stage to be set to thankYouSetPassword unless both an email and
       // guest registration token is present
       case 'SET_THANK_YOU_PAGE_STAGE':
         if ((action.thankYouPageStage === 'thankYouSetPassword')
-          && state.contributionType !== 'ONE_OFF'
           && (!state.guestAccountCreationToken || !state.formData.email)) {
           return { ...state, thankYouPageStage: 'thankYou' };
         }

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
@@ -309,6 +309,7 @@ function createFormReducer() {
       // guest registration token is present
       case 'SET_THANK_YOU_PAGE_STAGE':
         if ((action.thankYouPageStage === 'thankYouSetPassword')
+          && state.contributionType !== 'ONE_OFF'
           && (!state.guestAccountCreationToken || !state.formData.email)) {
           return { ...state, thankYouPageStage: 'thankYou' };
         }

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
@@ -305,10 +305,11 @@ function createFormReducer() {
       case 'SET_GUEST_ACCOUNT_CREATION_TOKEN':
         return { ...state, guestAccountCreationToken: action.guestAccountCreationToken };
 
-      // Don't allow the stage to be set to thankYouSetPassword unless both an email and
+      // For recurring, don't allow the stage to be set to thankYouSetPassword unless both an email and
       // guest registration token is present
       case 'SET_THANK_YOU_PAGE_STAGE':
         if ((action.thankYouPageStage === 'thankYouSetPassword')
+          && state.contributionType !== 'ONE_OFF'
           && (!state.guestAccountCreationToken || !state.formData.email)) {
           return { ...state, thankYouPageStage: 'thankYou' };
         }


### PR DESCRIPTION
## Why are you doing this?
This is the client-side work required for retrieving the guest account creation token and adding in the "set password" screen for one-off contributions from cohort 5 (email not recognised, no password) using Stripe
<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/3Go4Ramh/1088-add-password-setting-thank-you-page-for-one-off)

## Screenshots
Flow, screen one:
![single password 1](https://user-images.githubusercontent.com/3300789/58947370-b0e67380-877f-11e9-9d74-01dc17348576.png)
Flow, screen two:
![single password 2](https://user-images.githubusercontent.com/3300789/58959947-0fbae580-879e-11e9-8f1e-ca7b47c16e48.png)
Flow, screen three:
![single password 3](https://user-images.githubusercontent.com/3300789/58959956-134e6c80-879e-11e9-87c0-3e503d0a4edd.png)
Testing that sign in works for the account created on code:
![single password 4](https://user-images.githubusercontent.com/3300789/58947373-b17f0a00-877f-11e9-946e-454e9d8ba831.png)


