### PR TITLE
Introductory promotions

### DIFF
--- a/support-frontend/app/controllers/Subscriptions.scala
+++ b/support-frontend/app/controllers/Subscriptions.scala
@@ -65,7 +65,8 @@ class Subscriptions(
     val css = Left(RefPath("weeklySubscriptionLandingPage.css"))
     val description = stringsConfig.weeklyLandingDescription
     val canonicalLink = Some(buildCanonicalWeeklySubscriptionLink("uk"))
-    val promoCodes = request.queryString.get("promoCode").map(_.toList).getOrElse(Nil) ++ List("10ANNUAL", "6FOR6")
+    val promoCodes = request.queryString.get("promoCode").map(_.toList).getOrElse(Nil) ++
+      List(GuardianWeekly.AnnualPromoCode, GuardianWeekly.SixForSixPromoCode)
     val productPrices = priceSummaryServiceProvider.forUser(false).getPrices(GuardianWeekly, promoCodes)
     val hrefLangLinks = Map(
       "en-us" -> buildCanonicalWeeklySubscriptionLink("us"),

--- a/support-frontend/app/controllers/Subscriptions.scala
+++ b/support-frontend/app/controllers/Subscriptions.scala
@@ -65,7 +65,7 @@ class Subscriptions(
     val css = Left(RefPath("weeklySubscriptionLandingPage.css"))
     val description = stringsConfig.weeklyLandingDescription
     val canonicalLink = Some(buildCanonicalWeeklySubscriptionLink("uk"))
-    val promoCodes = request.queryString.get("promoCode").map(_.toList).getOrElse(Nil) :+ "10ANNUAL"
+    val promoCodes = request.queryString.get("promoCode").map(_.toList).getOrElse(Nil) ++ List("10ANNUAL", "6FOR6")
     val productPrices = priceSummaryServiceProvider.forUser(false).getPrices(GuardianWeekly, promoCodes)
     val hrefLangLinks = Map(
       "en-us" -> buildCanonicalWeeklySubscriptionLink("us"),

--- a/support-frontend/app/controllers/WeeklySubscription.scala
+++ b/support-frontend/app/controllers/WeeklySubscription.scala
@@ -65,7 +65,8 @@ class WeeklySubscription(
     val css = "weeklySubscriptionCheckoutPage.css"
     val csrf = CSRF.getToken.value
     val uatMode = testUsers.isTestUser(idUser.publicFields.displayName)
-    val promoCodes = request.queryString.get("promoCode").map(_.toList).getOrElse(Nil) :+ "10ANNUAL"
+    val promoCodes = request.queryString.get("promoCode").map(_.toList).getOrElse(Nil) ++
+      List(GuardianWeekly.AnnualPromoCode, GuardianWeekly.SixForSixPromoCode)
 
     subscriptionCheckout(
       title,

--- a/support-frontend/test/fixtures/TestCSRFComponents.scala
+++ b/support-frontend/test/fixtures/TestCSRFComponents.scala
@@ -9,7 +9,7 @@ import play.api.routing.Router
 import play.core.DefaultWebCommands
 import play.filters.csrf.CSRFComponents
 
-trait TestCSRFComponents {
+trait  TestCSRFComponents {
 
   private lazy val appComponents = {
     val env = Environment.simple(new File("."))

--- a/support-frontend/test/fixtures/TestCSRFComponents.scala
+++ b/support-frontend/test/fixtures/TestCSRFComponents.scala
@@ -9,7 +9,7 @@ import play.api.routing.Router
 import play.core.DefaultWebCommands
 import play.filters.csrf.CSRFComponents
 
-trait  TestCSRFComponents {
+trait TestCSRFComponents {
 
   private lazy val appComponents = {
     val env = Environment.simple(new File("."))

--- a/support-models/src/main/scala/com/gu/support/catalog/Product.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/Product.scala
@@ -139,6 +139,9 @@ case object Paper extends Product {
 
 case object GuardianWeekly extends Product {
 
+  val AnnualPromoCode = "10ANNUAL"
+  val SixForSixPromoCode = "6FOR6"
+
   lazy val ratePlans: Map[TouchPointEnvironment, List[ProductRatePlan[GuardianWeekly.type]]] =
     Map(
       PROD -> List(

--- a/support-models/src/main/scala/com/gu/support/encoding/JsonHelpers.scala
+++ b/support-models/src/main/scala/com/gu/support/encoding/JsonHelpers.scala
@@ -1,6 +1,6 @@
 package com.gu.support.encoding
 
-import com.gu.support.promotions.{DiscountBenefit, FreeTrialBenefit, IncentiveBenefit}
+import com.gu.support.promotions.{DiscountBenefit, FreeTrialBenefit, IncentiveBenefit, IntroductoryPriceBenefit}
 import io.circe.{ACursor, Decoder, Json, JsonObject}
 
 object JsonHelpers {
@@ -65,6 +65,7 @@ object JsonHelpers {
         case DiscountBenefit.jsonName => jsonObject.add("discount", json)
         case FreeTrialBenefit.jsonName => jsonObject.add("freeTrial", json)
         case IncentiveBenefit.jsonName => jsonObject.add("incentive", json)
+        case IntroductoryPriceBenefit.jsonName => jsonObject.add("introductoryPrice", json)
         case "retention" => jsonObject.add("renewalOnly", Json.fromBoolean(true))
         case "tracking" => jsonObject.add("tracking", Json.fromBoolean(true))
         case "double" => extractDouble(json, jsonObject)

--- a/support-models/src/main/scala/com/gu/support/promotions/Benefit.scala
+++ b/support-models/src/main/scala/com/gu/support/promotions/Benefit.scala
@@ -3,10 +3,10 @@ package com.gu.support.promotions
 import cats.syntax.functor._
 import com.gu.support.encoding.Codec
 import com.gu.support.encoding.Codec.deriveCodec
+import com.gu.support.encoding.CustomCodecs._
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder}
 import org.joda.time.{Days, Months}
-import com.gu.support.encoding.CustomCodecs._
 
 sealed trait Benefit
 
@@ -32,6 +32,29 @@ object IncentiveBenefit {
   val jsonName = "incentive"
 
   implicit val incentiveCodec: Codec[IncentiveBenefit] = deriveCodec
+}
+
+sealed trait IntroductoryPeriodType
+
+case object Issue extends IntroductoryPeriodType
+
+object IntroductoryPeriodType {
+  implicit val decodePeriod: Decoder[IntroductoryPeriodType] = Decoder.decodeString.map(code => fromString(code))
+  implicit val encodePeriod: Encoder[IntroductoryPeriodType] = Encoder.encodeString.contramap[IntroductoryPeriodType](_.toString)
+
+  private def fromString(s: String) = {
+    s.toLowerCase match {
+      case "issue" => Issue
+    }
+  }
+}
+
+case class IntroductoryPriceBenefit(price: Double, periodLength: Int, periodType: IntroductoryPeriodType) extends Benefit
+
+object IntroductoryPriceBenefit {
+  val jsonName = "introductory_price"
+
+  implicit val incentiveCodec: Codec[IntroductoryPriceBenefit] = deriveCodec
 }
 
 object Benefit {

--- a/support-models/src/main/scala/com/gu/support/promotions/Benefit.scala
+++ b/support-models/src/main/scala/com/gu/support/promotions/Benefit.scala
@@ -62,11 +62,13 @@ object Benefit {
     case d: DiscountBenefit => d.asJson
     case f: FreeTrialBenefit => f.asJson
     case i: IncentiveBenefit => i.asJson
+    case ip: IntroductoryPriceBenefit => ip.asJson
   }
 
   implicit val decoder: Decoder[Benefit] = List[Decoder[Benefit]](
     Decoder[DiscountBenefit].widen,
     Decoder[FreeTrialBenefit].widen,
-    Decoder[IncentiveBenefit].widen
+    Decoder[IncentiveBenefit].widen,
+    Decoder[IntroductoryPriceBenefit].widen
   ).reduceLeft(_ or _)
 }

--- a/support-models/src/main/scala/com/gu/support/promotions/Benefit.scala
+++ b/support-models/src/main/scala/com/gu/support/promotions/Benefit.scala
@@ -40,7 +40,7 @@ case object Issue extends IntroductoryPeriodType
 
 object IntroductoryPeriodType {
   implicit val decodePeriod: Decoder[IntroductoryPeriodType] = Decoder.decodeString.map(code => fromString(code))
-  implicit val encodePeriod: Encoder[IntroductoryPeriodType] = Encoder.encodeString.contramap[IntroductoryPeriodType](_.toString)
+  implicit val encodePeriod: Encoder[IntroductoryPeriodType] = Encoder.encodeString.contramap[IntroductoryPeriodType](_.toString.toLowerCase)
 
   private def fromString(s: String) = {
     s.toLowerCase match {

--- a/support-models/src/main/scala/com/gu/support/promotions/Promotion.scala
+++ b/support-models/src/main/scala/com/gu/support/promotions/Promotion.scala
@@ -1,5 +1,7 @@
 package com.gu.support.promotions
 
+import com.gu.i18n.CountryGroup
+import com.gu.support.catalog.GuardianWeekly
 import com.gu.support.encoding.JsonHelpers._
 import io.circe.generic.semiauto.deriveDecoder
 import io.circe.{ACursor, Decoder, Json}
@@ -35,4 +37,28 @@ object Promotion {
       .checkKeyExists("tracking", Json.fromBoolean(false))
     )
   }
+}
+
+object Promotions {
+  val SixForSixPromotion = Promotion(
+    name = "Six For Six",
+    description = "Introductory offer",
+    appliesTo = AppliesTo(
+      Set(
+        "2c92a0086619bf8901661ab02752722f",
+        "2c92a0fe6619b4b301661aa494392ee2",
+        "2c92c0f9660fc4d70166109c01465f10",
+        "2c92c0f8660fb5d601661081ea010391",
+        "2c92c0f965f2122101660fb81b745a06",
+        "2c92c0f965dc30640165f150c0956859"
+      ),
+      CountryGroup.countries.toSet
+    ),
+    campaignCode = "Six For Six campaign code",
+    channelCodes = Map("dummy channel" -> Set(GuardianWeekly.SixForSixPromoCode)),
+    starts = new DateTime(1971, 2, 20, 12, 0, 0, 0),
+    expires = None,
+    discount = None, freeTrial = None, incentive = None,
+    introductoryPrice = Some(IntroductoryPriceBenefit(6, 6, Issue))
+  )
 }

--- a/support-models/src/main/scala/com/gu/support/promotions/Promotion.scala
+++ b/support-models/src/main/scala/com/gu/support/promotions/Promotion.scala
@@ -16,6 +16,7 @@ case class Promotion(
   discount: Option[DiscountBenefit],
   freeTrial: Option[FreeTrialBenefit],
   incentive: Option[IncentiveBenefit] = None,
+  introductoryPrice: Option[IntroductoryPriceBenefit] = None,
   renewalOnly: Boolean = false,
   tracking: Boolean = false
 ) {

--- a/support-models/src/test/scala/com/gu/support/promotions/Fixtures.scala
+++ b/support-models/src/test/scala/com/gu/support/promotions/Fixtures.scala
@@ -381,4 +381,41 @@ object Fixtures {
             "campaignCode": "C_IUJPNBPQ"
         }
     """
+
+  val introductoryPricePromotion =
+    s"""
+    {
+      "codes": {
+          "Customer Experience": [
+              "6FOR6"
+          ]
+      },
+      "promotionType": {
+          "price": 6,
+          "periodLength": 6,
+          "periodType": "issue",
+          "name": "introductory_price"
+      },
+      "name": "Six For Six",
+      "appliesTo": {
+          "productRatePlanIds": [
+              "2c92a0086619bf8901661ab02752722f",
+              "2c92a0fe6619b4b301661aa494392ee2",
+              "2c92c0f9660fc4d70166109c01465f10",
+              "2c92c0f8660fb5d601661081ea010391",
+              "2c92c0f965f2122101660fb81b745a06",
+              "2c92c0f965dc30640165f150c0956859"
+          ],
+          "countries": [
+              "AZ",
+              "NF",
+              "PW"
+          ]
+      },
+      "description": "Introductory offer",
+      "starts": "$startDate",
+      "uuid": "b8992d84-dbd3-406c-b3c4-0209b74a66e9",
+      "campaignCode": "C_IZY6K6ZY"
+    }
+  """
 }

--- a/support-models/src/test/scala/com/gu/support/promotions/SerialisationSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/promotions/SerialisationSpec.scala
@@ -69,6 +69,17 @@ class SerialisationSpec extends FlatSpec with SerialisationTestHelpers with Lazy
     )
   }
 
+  it should "be able to decode an introductory price Promotion" in {
+    testDecoding[Promotion](Fixtures.introductoryPricePromotion,
+      promotion => {
+        promotion.introductoryPrice.isDefined shouldBe true
+        promotion.introductoryPrice.get.price shouldBe 6
+        promotion.introductoryPrice.get.periodType shouldBe Issue
+        promotion.introductoryPrice.get.periodLength shouldBe 6
+      }
+    )
+  }
+
   it should "be able to decode a double benefit Promotion containing an incentive" in {
     testDecoding[Promotion](Fixtures.doubleWithIncentive,
       promotion => {

--- a/support-models/src/test/scala/com/gu/support/promotions/SerialisationSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/promotions/SerialisationSpec.scala
@@ -6,6 +6,7 @@ import org.joda.time.Days.days
 import org.joda.time.Months.months
 import org.scalatest.FlatSpec
 
+//noinspection ScalaStyle
 class SerialisationSpec extends FlatSpec with SerialisationTestHelpers with LazyLogging {
 
   "Circe" should "be able to decode a discount Promotion" in {
@@ -64,7 +65,8 @@ class SerialisationSpec extends FlatSpec with SerialisationTestHelpers with Lazy
     testDecoding[Promotion](Fixtures.incentivePromotion,
       promotion => {
         promotion.incentive.isDefined shouldBe true
-        promotion.incentive.get.redemptionInstructions shouldBe "We'll send you an email with instructions on redeeming your English Heritage offer within 35 days."
+        promotion.incentive.get.redemptionInstructions shouldBe
+          "We'll send you an email with instructions on redeeming your English Heritage offer within 35 days."
       }
     )
   }
@@ -72,7 +74,7 @@ class SerialisationSpec extends FlatSpec with SerialisationTestHelpers with Lazy
   it should "be able to decode an introductory price Promotion" in {
     testDecoding[Promotion](Fixtures.introductoryPricePromotion,
       promotion => {
-        promotion.introductoryPrice.isDefined shouldBe true
+        promotion.introductoryPrice shouldBe defined
         promotion.introductoryPrice.get.price shouldBe 6
         promotion.introductoryPrice.get.periodType shouldBe Issue
         promotion.introductoryPrice.get.periodLength shouldBe 6

--- a/support-services/src/main/scala/com/gu/support/pricing/PriceSummary.scala
+++ b/support-services/src/main/scala/com/gu/support/pricing/PriceSummary.scala
@@ -16,7 +16,8 @@ case class PromotionSummary(
   numberOfDiscountedPeriods: Option[Int],
   discount: Option[DiscountBenefit],
   freeTrialBenefit: Option[FreeTrialBenefit],
-  incentive: Option[IncentiveBenefit] = None
+  incentive: Option[IncentiveBenefit] = None,
+  introductoryPrice: Option[IntroductoryPriceBenefit] = None
 )
 
 import com.gu.support.encoding.Codec

--- a/support-services/src/main/scala/com/gu/support/pricing/PriceSummaryService.scala
+++ b/support-services/src/main/scala/com/gu/support/pricing/PriceSummaryService.scala
@@ -61,16 +61,18 @@ class PriceSummaryService(promotionService: PromotionService, catalogService: Ca
     )
   }
 
-  private def getPromotionSummary(promotion: PromotionWithCode, price: Price, billingPeriod: BillingPeriod) = {
+  private def getPromotionSummary(promotionWithCode: PromotionWithCode, price: Price, billingPeriod: BillingPeriod) = {
+    import promotionWithCode._
     PromotionSummary(
-      promotion.promotion.name,
-      promotion.promotion.description,
-      promotion.promoCode,
-      promotion.promotion.discount.map(getDiscountedPrice(price, _, billingPeriod).value),
-      promotion.promotion.discount.flatMap(_.durationMonths).map(getNumberOfDiscountedPeriods(_, billingPeriod)),
-      promotion.promotion.discount,
-      promotion.promotion.freeTrial,
-      promotion.promotion.incentive
+      name = promotion.name,
+      description = promotion.description,
+      promoCode = promoCode,
+      discountedPrice = promotion.discount.map(getDiscountedPrice(price, _, billingPeriod).value),
+      numberOfDiscountedPeriods = promotion.discount.flatMap(_.durationMonths).map(getNumberOfDiscountedPeriods(_, billingPeriod)),
+      discount = promotion.discount,
+      freeTrialBenefit = promotion.freeTrial,
+      incentive = promotion.incentive,
+      introductoryPrice = promotion.introductoryPrice
     )
   }
 

--- a/support-services/src/main/scala/com/gu/support/promotions/PromotionService.scala
+++ b/support-services/src/main/scala/com/gu/support/promotions/PromotionService.scala
@@ -1,41 +1,18 @@
 package com.gu.support.promotions
 
-import com.gu.i18n.{Country, CountryGroup}
-import com.gu.support.catalog.{GuardianWeekly, ProductRatePlanId}
+import com.gu.i18n.Country
+import com.gu.support.catalog.ProductRatePlanId
 import com.gu.support.config.PromotionsConfig
 import com.gu.support.promotions.PromotionValidator.PromotionExtensions
 import com.gu.support.touchpoint.TouchpointService
 import com.gu.support.zuora.api.SubscriptionData
 import com.typesafe.scalalogging.LazyLogging
-import org.joda.time.DateTime
 
 class PromotionService(config: PromotionsConfig, maybeCollection: Option[PromotionCollection] = None) extends TouchpointService with LazyLogging {
   val promotionCollection = maybeCollection.getOrElse(new DynamoPromotionCollection(config.tables))
 
-  val SixForSixPromotion = Promotion(
-    "Six For Six",
-    "Introductory offer",
-    AppliesTo(
-      Set(
-        "2c92a0086619bf8901661ab02752722f",
-        "2c92a0fe6619b4b301661aa494392ee2",
-        "2c92c0f9660fc4d70166109c01465f10",
-        "2c92c0f8660fb5d601661081ea010391",
-        "2c92c0f965f2122101660fb81b745a06",
-        "2c92c0f965dc30640165f150c0956859"
-      ),
-      CountryGroup.countries.toSet
-    ),
-    "Six For Six campaign code",
-    Map("dummy channel" -> Set(GuardianWeekly.SixForSixPromoCode)),
-    new DateTime(1971, 2, 20, 12, 0, 0, 0),
-    None,
-    None, None, None,
-    Some(IntroductoryPriceBenefit(6, 6, Issue))
-  )
-
   //This is a small hack to allow us to start using promotions to handle 6 for 6 without having to build the tooling
-  private def allWith6For6 = promotionCollection.all.toList :+ SixForSixPromotion
+  private def allWith6For6 = promotionCollection.all.toList :+ Promotions.SixForSixPromotion
 
   def findPromotion(promoCode: PromoCode): Option[PromotionWithCode] =
     allWith6For6

--- a/support-services/src/main/scala/com/gu/support/promotions/PromotionService.scala
+++ b/support-services/src/main/scala/com/gu/support/promotions/PromotionService.scala
@@ -1,25 +1,48 @@
 package com.gu.support.promotions
 
-import com.gu.i18n.Country
-import com.gu.support.catalog.ProductRatePlanId
+import com.gu.i18n.{Country, CountryGroup}
+import com.gu.support.catalog.{GuardianWeekly, ProductRatePlanId}
 import com.gu.support.config.PromotionsConfig
 import com.gu.support.promotions.PromotionValidator.PromotionExtensions
 import com.gu.support.touchpoint.TouchpointService
 import com.gu.support.zuora.api.SubscriptionData
 import com.typesafe.scalalogging.LazyLogging
+import org.joda.time.DateTime
 
 class PromotionService(config: PromotionsConfig, maybeCollection: Option[PromotionCollection] = None) extends TouchpointService with LazyLogging {
   val promotionCollection = maybeCollection.getOrElse(new DynamoPromotionCollection(config.tables))
 
+  val SixForSixPromotion = Promotion(
+    "Six for Six",
+    "Introductory offer",
+    AppliesTo(
+      Set(
+        "2c92a0086619bf8901661ab02752722f",
+        "2c92a0fe6619b4b301661aa494392ee2",
+        "2c92c0f9660fc4d70166109c01465f10",
+        "2c92c0f8660fb5d601661081ea010391",
+        "2c92c0f965f2122101660fb81b745a06",
+        "2c92c0f965dc30640165f150c0956859"
+      ),
+      CountryGroup.countries.toSet
+    ),
+    "Six For Six campaign code",
+    Map("dummy channel" -> Set(GuardianWeekly.SixForSixPromoCode)),
+    new DateTime(1971, 2, 20, 12, 0, 0, 0),
+    None,
+    None, None, None,
+    Some(IntroductoryPriceBenefit(6, 6, Issue))
+  )
+
+  private def allWith6For6 = promotionCollection.all.toList :+ SixForSixPromotion
+
   def findPromotion(promoCode: PromoCode): Option[PromotionWithCode] =
-    promotionCollection
-      .all
+    allWith6For6
       .find(_.promoCodes.exists(_ == promoCode))
       .map(PromotionWithCode(promoCode, _))
 
   def findPromotions(promoCodes: List[PromoCode]): List[PromotionWithCode] =
-    promotionCollection
-      .all
+    allWith6For6
       .foldLeft(List.empty[PromotionWithCode]) {
         (acc, promotion) =>
           val maybeCode = promoCodes.intersect(promotion.promoCodes.toList).headOption

--- a/support-services/src/main/scala/com/gu/support/promotions/PromotionService.scala
+++ b/support-services/src/main/scala/com/gu/support/promotions/PromotionService.scala
@@ -13,7 +13,7 @@ class PromotionService(config: PromotionsConfig, maybeCollection: Option[Promoti
   val promotionCollection = maybeCollection.getOrElse(new DynamoPromotionCollection(config.tables))
 
   val SixForSixPromotion = Promotion(
-    "Six for Six",
+    "Six For Six",
     "Introductory offer",
     AppliesTo(
       Set(
@@ -34,6 +34,7 @@ class PromotionService(config: PromotionsConfig, maybeCollection: Option[Promoti
     Some(IntroductoryPriceBenefit(6, 6, Issue))
   )
 
+  //This is a small hack to allow us to start using promotions to handle 6 for 6 without having to build the tooling
   private def allWith6For6 = promotionCollection.all.toList :+ SixForSixPromotion
 
   def findPromotion(promoCode: PromoCode): Option[PromotionWithCode] =

--- a/support-services/src/test/scala/com/gu/support/promotions/PromotionServiceIntegrationSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/promotions/PromotionServiceIntegrationSpec.scala
@@ -20,5 +20,4 @@ class PromotionServiceIntegrationSpec extends FlatSpec with Matchers {
     val promotion = serviceWithDynamo.findPromotion("DISC503")
     promotion.isDefined shouldBe true
   }
-
 }

--- a/support-services/src/test/scala/com/gu/support/promotions/PromotionServiceIntegrationSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/promotions/PromotionServiceIntegrationSpec.scala
@@ -20,4 +20,5 @@ class PromotionServiceIntegrationSpec extends FlatSpec with Matchers {
     val promotion = serviceWithDynamo.findPromotion("DISC503")
     promotion.isDefined shouldBe true
   }
+
 }

--- a/support-services/src/test/scala/com/gu/support/promotions/PromotionServiceSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/promotions/PromotionServiceSpec.scala
@@ -2,6 +2,7 @@ package com.gu.support.promotions
 
 import com.gu.i18n.Country
 import com.gu.i18n.Country.UK
+import com.gu.support.catalog.GuardianWeekly
 import com.gu.support.config.{PromotionsConfigProvider, Stages}
 import com.gu.support.promotions.PromotionServiceSpec._
 import com.gu.support.promotions.ServicesFixtures.{freeTrialPromoCode, _}
@@ -17,7 +18,7 @@ class PromotionServiceSpec extends FlatSpec with Matchers {
   }
 
   it should "find multiple promo codes" in {
-    val promotions = serviceWithFixtures.findPromotions(List(freeTrialPromoCode, guardianWeeklyAnnualPromoCode))
+    val promotions = serviceWithFixtures.findPromotions(List(freeTrialPromoCode, GuardianWeekly.AnnualPromoCode))
     promotions should contain (freeTrialWithCode)
     promotions should contain (guardianWeeklyWithCode)
   }
@@ -25,6 +26,11 @@ class PromotionServiceSpec extends FlatSpec with Matchers {
   it should "handle Nil in findPromotions" in {
     val promotions = serviceWithFixtures.findPromotions(Nil)
     promotions shouldBe Nil
+  }
+
+  it should "find all the Guardian Weekly promotions" in {
+    val promotions = serviceWithFixtures.findPromotions(List(GuardianWeekly.AnnualPromoCode, GuardianWeekly.SixForSixPromoCode))
+    promotions.length shouldBe 2
   }
 
   it should "validate a PromoCode" in {

--- a/support-services/src/test/scala/com/gu/support/promotions/ServicesFixtures.scala
+++ b/support-services/src/test/scala/com/gu/support/promotions/ServicesFixtures.scala
@@ -2,13 +2,10 @@ package com.gu.support.promotions
 
 import com.gu.support.catalog._
 import com.gu.support.config.TouchPointEnvironments
-import com.gu.support.workers.Annual
 import com.gu.support.config.TouchPointEnvironments.PROD
-import com.gu.support.promotions.ServicesFixtures.guardianWeeklyAnnualPromoCode
+import com.gu.support.workers.Annual
 import com.gu.support.zuora.api.{RatePlan, RatePlanData, Subscription, SubscriptionData}
 import org.joda.time.{DateTime, Days, LocalDate, Months}
-import com.gu.support.config.TouchPointEnvironments
-import org.joda.time.{DateTime, Days, LocalDate, Months, Years}
 
 /**
  * Promotions are quite laborious to construct
@@ -22,7 +19,6 @@ object ServicesFixtures {
   val invalidPromoCode = "INVALID_CODE"
   val renewalPromoCode = "RENEWAL_CODE"
   val trackingPromoCode = "TRACKING_CODE"
-  val guardianWeeklyAnnualPromoCode = "10ANNUAL"
 
   val validProductRatePlanIds = Product.allProducts.flatMap(_.ratePlans(PROD).map(_.id))
   val validProductRatePlanId = validProductRatePlanIds.head
@@ -43,10 +39,10 @@ object ServicesFixtures {
     GuardianWeekly
       .getProductRatePlan(TouchPointEnvironments.PROD, Annual, Domestic, NoProductOptions)
       .map(p => List(p.id)).getOrElse(List()),
-    guardianWeeklyAnnualPromoCode,
+    GuardianWeekly.AnnualPromoCode,
     Some(DiscountBenefit(10, Some(Months.TWELVE)))
   )
-  val guardianWeeklyWithCode = PromotionWithCode(guardianWeeklyAnnualPromoCode, guardianWeeklyAnnual)
+  val guardianWeeklyWithCode = PromotionWithCode(GuardianWeekly.AnnualPromoCode, guardianWeeklyAnnual)
 
   val now = LocalDate.now()
   val subscriptionData = SubscriptionData(


### PR DESCRIPTION
## Why are you doing this?

We want to use promotions to implement 6 for 6 rather than a lot of custom code because it allows a lot more flexibility for adding new prices and periods (n for n promotions) and would also mean that we could use them for other products. 

This is a first step towards that, it adds a new `IntroductoryPrice` type of promotion which describes n for n type promotions and hard codes an instance of this type (6 for 6) which applies to Guardian Weekly Quarterly pricing. The reason for hard coding this at this point is to avoid having to build the tooling to handle the new type in the membership promo codes tool.

The next step is to update the various React components to work with this new promotion type.

[**Trello Card**](https://trello.com/c/Jz30fbFH/2411-guardian-weekly-6-for-6-frontend)