### PR TITLE
Thank you 'set password' screen UX updates

### DIFF
--- a/support-frontend/assets/components/page/page.jsx
+++ b/support-frontend/assets/components/page/page.jsx
@@ -3,12 +3,10 @@
 // ----- Imports ----- //
 
 import React, { type Node } from 'react';
-
 import { classNameWithModifiers } from 'helpers/utilities';
-
 import TimeTravelBanner from 'components/headerBanners/timeTravelBanner';
 import { connect } from 'react-redux';
-import type { State, ThankYouPageStage } from '../../pages/new-contributions-landing/contributionsLandingReducer';
+import type { State, ThankYouPageStage } from 'pages/new-contributions-landing/contributionsLandingReducer';
 
 
 // ----- Types ----- //

--- a/support-frontend/assets/components/page/page.jsx
+++ b/support-frontend/assets/components/page/page.jsx
@@ -7,6 +7,8 @@ import React, { type Node } from 'react';
 import { classNameWithModifiers } from 'helpers/utilities';
 
 import TimeTravelBanner from 'components/headerBanners/timeTravelBanner';
+import { connect } from 'react-redux';
+import type { State, ThankYouPageStage } from '../../pages/new-contributions-landing/contributionsLandingReducer';
 
 
 // ----- Types ----- //
@@ -18,12 +20,20 @@ type PropTypes = {|
   children: Node,
   classModifiers: Array<?string>,
   backgroundImageSrc: ?string,
+  thankYouPageStage: ThankYouPageStage,
 |};
+
+const mapStateToProps = (state: State) => ({
+  thankYouPageStage: state.page.form.thankYouPageStage,
+});
 
 
 // ----- Component ----- //
 
-export default function Page(props: PropTypes) {
+function Page(props: PropTypes) {
+  // Set password screen shouldn't inherit new page-level classnames, unlike other pages in thank you flow
+  const classMods = props.thankYouPageStage === 'thankYouSetPassword' ? [] : props.classModifiers;
+
   const backgroundImage = props.backgroundImageSrc ? (
     <div className="background-image-container">
       <img className="background-image" alt="landing page background illustration" src={props.backgroundImageSrc} />
@@ -31,7 +41,7 @@ export default function Page(props: PropTypes) {
   ) : null;
 
   return (
-    <div id={props.id} className={classNameWithModifiers('gu-content', props.classModifiers)}>
+    <div id={props.id} className={classNameWithModifiers('gu-content', classMods)}>
       <TimeTravelBanner />
       {props.header}
       <main role="main" className="gu-content__main">
@@ -52,3 +62,5 @@ Page.defaultProps = {
   classModifiers: [],
   backgroundImageSrc: null,
 };
+
+export default connect(mapStateToProps)(Page);

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYouContainer.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYouContainer.jsx
@@ -8,6 +8,7 @@ import { type ThankYouPageStageMap, type ThankYouPageStage } from '../../contrib
 import ContributionThankYou from './ContributionThankYou';
 import ContributionThankYouSetPassword from './ContributionThankYouSetPassword';
 import ContributionThankYouPasswordSet from './ContributionThankYouPasswordSet';
+import { classNameWithModifiers } from 'helpers/utilities';
 
 // ----- Types ----- //
 
@@ -24,6 +25,14 @@ const mapStateToProps = state => ({
 // ----- Render ----- //
 
 function ContributionThankYouContainer(props: PropTypes) {
+  const classModifiers = {
+    thankYou: ['thankyou'],
+    thankYouSetPassword: [],
+    thankYouPasswordDeclinedToSet: ['thankyou'],
+    thankYouPasswordSet: ['thankyou'],
+  };
+
+  const classNames = classNameWithModifiers('gu-content__content', classModifiers[props.thankYouPageStage]);
 
   const thankYouPageStage: ThankYouPageStageMap<React$Element<*>> = {
     thankYou: (<ContributionThankYou />),
@@ -33,7 +42,7 @@ function ContributionThankYouContainer(props: PropTypes) {
   };
 
   return (
-    <div className="gu-content__content gu-content__content-thankyou">
+    <div className={classNames}>
       {thankYouPageStage[props.thankYouPageStage]}
     </div>
   );

--- a/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYouSetPassword.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/components/ContributionThankYou/ContributionThankYouSetPassword.jsx
@@ -68,7 +68,7 @@ function ContributionThankYouSetPassword(props: PropTypes) {
       </div>
 
       <div className="gu-content__blurb gu-content__blurb--thank-you">
-        <h1 className="gu-content__blurb-header">Set up a free <br className="gu-content__blurb-header-break" />Guardian <br className="gu-content__blurb-header-break" />account</h1>
+        <h1 className="gu-content__blurb-header">Set up a free <br className="gu-content__blurb-header-break" />Guardian account</h1>
       </div>
     </div>
   );

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.jsx
@@ -89,14 +89,12 @@ const router = (
         <Route
           exact
           path="/:countryId(uk|us|au|eu|int|nz|ca)/contribute/"
-          render={() => contributionsLandingPage()
-          }
+          render={() => contributionsLandingPage()}
         />
         <Route
           exact
           path="/:countryId(uk|us|au|eu|int|nz|ca)/contribute/:campaignCode"
-          render={() => contributionsLandingPage()
-        }
+          render={() => contributionsLandingPage()}
         />
         <Route
           exact

--- a/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.jsx
+++ b/support-frontend/assets/pages/new-contributions-landing/contributionsLanding.jsx
@@ -108,7 +108,7 @@ const router = (
               <Page
                 classModifiers={['contribution-thankyou']}
                 header={<RoundelHeader />}
-                footer={<Footer disclaimer countryGroupId={countryGroupId} />}
+                footer={<Footer appearance="dark" disclaimer countryGroupId={countryGroupId} />}
               >
                 <ContributionThankYouContainer />
               </Page>


### PR DESCRIPTION
## Why are you doing this?
UX design changes requested by @ionamckendrick to indicate that the user isn't on the 'final' thank you page they will see, but still in part of the flow.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/b7e7Lhue/1105-visual-design-and-implementation-for-set-password-sign-up-screens)

## Changes

* Removing page-level class for thank you set password screen
* Introducing component-level class granularity to make these screens more customizable in the future (as might be the case with forthcoming updates to the flow)

## Screenshots
![set password page](https://user-images.githubusercontent.com/3300789/58709339-dc4d1500-83b1-11e9-981d-c9c5baf9c167.png)