### PR TITLE
Billing period component

### DIFF
--- a/support-frontend/assets/components/subscriptionCheckouts/billingPeriodSelector.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/billingPeriodSelector.jsx
@@ -10,6 +10,7 @@ import type { ProductPrices } from 'helpers/productPrice/productPrices';
 import { getProductPrice } from 'helpers/productPrice/productPrices';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
+import type { Action } from 'helpers/subscriptionsForms/formActions';
 import {
   extendedGlyph,
   fromCountryGroupId,
@@ -25,9 +26,9 @@ type PropTypes = {|
   productPrices: ProductPrices,
   billingPeriods: BillingPeriod[],
   fulfilmentOption?: FulfilmentOptions,
-  country: IsoCountry,
+  billingCountry: IsoCountry,
   selected: BillingPeriod,
-  onChange: (BillingPeriod) => void,
+  onChange: (BillingPeriod) => Action,
 |}
 
 function getTitle(billingPeriod: BillingPeriod) {
@@ -47,14 +48,14 @@ function BillingPeriodSelector(props: PropTypes) {
         {props.billingPeriods.map((billingPeriod) => {
           const productPrice = getProductPrice(
             props.productPrices,
-            props.country,
+            props.billingCountry,
             billingPeriod,
             props.fulfilmentOption,
           );
           return (<RadioInputWithHelper
             text={getTitle(billingPeriod)}
             helper={getPriceDescription(
-              getGlyph(props.country),
+              getGlyph(props.billingCountry),
               productPrice,
               billingPeriod,
             )}

--- a/support-frontend/assets/components/subscriptionCheckouts/billingPeriodSelector.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/billingPeriodSelector.jsx
@@ -1,0 +1,74 @@
+// @flow
+import React from 'react';
+
+import { Fieldset } from 'components/forms/fieldset';
+import { RadioInputWithHelper } from 'components/forms/customFields/radioInputWithHelper';
+import type { BillingPeriod } from 'helpers/billingPeriods';
+import { SixWeekly } from 'helpers/billingPeriods';
+import { FormSection } from 'components/checkoutForm/checkoutForm';
+import type { ProductPrices } from 'helpers/productPrice/productPrices';
+import { getProductPrice } from 'helpers/productPrice/productPrices';
+import type { IsoCountry } from 'helpers/internationalisation/country';
+import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
+import {
+  extendedGlyph,
+  fromCountryGroupId,
+} from 'helpers/internationalisation/currency';
+import { getPriceDescription } from 'helpers/productPrice/priceDescriptions';
+import {
+  fromCountry,
+  GBPCountries,
+} from 'helpers/internationalisation/countryGroup';
+import { Domestic } from 'helpers/productPrice/fulfilmentOptions';
+
+type PropTypes = {|
+  productPrices: ProductPrices,
+  billingPeriods: BillingPeriod[],
+  fulfilmentOption?: FulfilmentOptions,
+  country: IsoCountry,
+  selected: BillingPeriod,
+  onChange: (BillingPeriod) => void,
+|}
+
+function getTitle(billingPeriod: BillingPeriod) {
+  if (billingPeriod === SixWeekly) { return '6 for 6'; }
+  return billingPeriod;
+}
+
+const getGlyph = (country: IsoCountry) => {
+  const currency = fromCountryGroupId(fromCountry(country) || GBPCountries);
+  return extendedGlyph(currency || 'GBP');
+};
+
+function BillingPeriodSelector(props: PropTypes) {
+  return (
+    <FormSection title="How often would you like to pay?">
+      <Fieldset legend="How often would you like to pay?">
+        {props.billingPeriods.map((billingPeriod) => {
+          const productPrice = getProductPrice(
+            props.productPrices,
+            props.country,
+            billingPeriod,
+            props.fulfilmentOption,
+          );
+          return (<RadioInputWithHelper
+            text={getTitle(billingPeriod)}
+            helper={getPriceDescription(
+              getGlyph(props.country),
+              productPrice,
+              billingPeriod,
+            )}
+            name="billingPeriod"
+            checked={billingPeriod === props.selected}
+            onChange={() => props.onChange(billingPeriod)}
+          />);
+        })}
+      </Fieldset>
+    </FormSection>);
+}
+
+BillingPeriodSelector.defaultProps = {
+  fulfilmentOption: Domestic,
+};
+
+export { BillingPeriodSelector };

--- a/support-frontend/assets/components/subscriptionCheckouts/billingPeriodSelector.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/billingPeriodSelector.jsx
@@ -4,29 +4,23 @@ import React from 'react';
 import { Fieldset } from 'components/forms/fieldset';
 import { RadioInputWithHelper } from 'components/forms/customFields/radioInputWithHelper';
 import type { BillingPeriod } from 'helpers/billingPeriods';
-import { Quarterly, SixWeekly } from 'helpers/billingPeriods';
-import { FormSection } from 'components/checkoutForm/checkoutForm';
-import type {
-  ProductPrice,
-  ProductPrices,
-} from 'helpers/productPrice/productPrices';
 import {
-  getAppliedPromo,
-  getProductPrice,
-} from 'helpers/productPrice/productPrices';
+  billingPeriodTitle,
+  Quarterly,
+  SixWeekly,
+} from 'helpers/billingPeriods';
+import { FormSection } from 'components/checkoutForm/checkoutForm';
+import type { ProductPrices } from 'helpers/productPrice/productPrices';
+import { getProductPrice } from 'helpers/productPrice/productPrices';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import { NoFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import type { Action } from 'helpers/subscriptionsForms/formActions';
+import { extendedGlyphForCountry } from 'helpers/internationalisation/currency';
 import {
-  extendedGlyph,
-  fromCountryGroupId,
-} from 'helpers/internationalisation/currency';
-import { getPriceDescription } from 'helpers/productPrice/priceDescriptions';
-import {
-  fromCountry,
-  GBPCountries,
-} from 'helpers/internationalisation/countryGroup';
+  getAppliedPromoDescription,
+  getPriceDescription,
+} from 'helpers/productPrice/priceDescriptions';
 
 type PropTypes = {|
   productPrices: ProductPrices,
@@ -37,28 +31,6 @@ type PropTypes = {|
   onChange: (BillingPeriod) => Action,
 |}
 
-function getTitle(billingPeriod: BillingPeriod) {
-  if (billingPeriod === SixWeekly) { return '6 for 6'; }
-  return billingPeriod;
-}
-
-function getOffer(billingPeriod: BillingPeriod, productPrice: ProductPrice) {
-  const appliedPromo = getAppliedPromo(productPrice.promotions);
-  if (
-    appliedPromo === null ||
-    appliedPromo.introductoryPrice && billingPeriod === Quarterly
-  ){
-    return '';
-  }
-
-  return  appliedPromo.description;
-}
-
-const getGlyph = (country: IsoCountry) => {
-  const currency = fromCountryGroupId(fromCountry(country) || GBPCountries);
-  return extendedGlyph(currency || 'GBP');
-};
-
 function BillingPeriodSelector(props: PropTypes) {
   return (
     <FormSection title="How often would you like to pay?">
@@ -67,18 +39,18 @@ function BillingPeriodSelector(props: PropTypes) {
           const productPrice = getProductPrice(
             props.productPrices,
             props.billingCountry,
-            billingPeriod === SixWeekly ? Quarterly : billingPeriod,
+            billingPeriod === SixWeekly ? Quarterly : billingPeriod, // for 6 for 6 we need the quarterly pricing
             props.fulfilmentOption,
           );
 
           return (<RadioInputWithHelper
-            text={getTitle(billingPeriod)}
+            text={billingPeriodTitle(billingPeriod)}
             helper={getPriceDescription(
-              getGlyph(props.billingCountry),
+              extendedGlyphForCountry(props.billingCountry),
               productPrice,
               billingPeriod,
             )}
-            offer={getOffer(billingPeriod, productPrice)}
+            offer={getAppliedPromoDescription(billingPeriod, productPrice)}
             name="billingPeriod"
             checked={billingPeriod === props.selected}
             onChange={() => props.onChange(billingPeriod)}

--- a/support-frontend/assets/components/subscriptionCheckouts/billingPeriodSelector.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/billingPeriodSelector.jsx
@@ -10,6 +10,7 @@ import type { ProductPrices } from 'helpers/productPrice/productPrices';
 import { getProductPrice } from 'helpers/productPrice/productPrices';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
+import { NoFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import type { Action } from 'helpers/subscriptionsForms/formActions';
 import {
   extendedGlyph,
@@ -20,7 +21,6 @@ import {
   fromCountry,
   GBPCountries,
 } from 'helpers/internationalisation/countryGroup';
-import { Domestic } from 'helpers/productPrice/fulfilmentOptions';
 
 type PropTypes = {|
   productPrices: ProductPrices,
@@ -69,7 +69,7 @@ function BillingPeriodSelector(props: PropTypes) {
 }
 
 BillingPeriodSelector.defaultProps = {
-  fulfilmentOption: Domestic,
+  fulfilmentOption: NoFulfilmentOptions,
 };
 
 export { BillingPeriodSelector };

--- a/support-frontend/assets/components/subscriptionCheckouts/billingPeriodSelector.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/billingPeriodSelector.jsx
@@ -4,10 +4,16 @@ import React from 'react';
 import { Fieldset } from 'components/forms/fieldset';
 import { RadioInputWithHelper } from 'components/forms/customFields/radioInputWithHelper';
 import type { BillingPeriod } from 'helpers/billingPeriods';
-import { SixWeekly } from 'helpers/billingPeriods';
+import { Quarterly, SixWeekly } from 'helpers/billingPeriods';
 import { FormSection } from 'components/checkoutForm/checkoutForm';
-import type { ProductPrices } from 'helpers/productPrice/productPrices';
-import { getProductPrice } from 'helpers/productPrice/productPrices';
+import type {
+  ProductPrice,
+  ProductPrices,
+} from 'helpers/productPrice/productPrices';
+import {
+  getAppliedPromo,
+  getProductPrice,
+} from 'helpers/productPrice/productPrices';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import { NoFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
@@ -36,6 +42,18 @@ function getTitle(billingPeriod: BillingPeriod) {
   return billingPeriod;
 }
 
+function getOffer(billingPeriod: BillingPeriod, productPrice: ProductPrice) {
+  const appliedPromo = getAppliedPromo(productPrice.promotions);
+  if (
+    appliedPromo === null ||
+    appliedPromo.introductoryPrice && billingPeriod === Quarterly
+  ){
+    return '';
+  }
+
+  return  appliedPromo.description;
+}
+
 const getGlyph = (country: IsoCountry) => {
   const currency = fromCountryGroupId(fromCountry(country) || GBPCountries);
   return extendedGlyph(currency || 'GBP');
@@ -49,9 +67,10 @@ function BillingPeriodSelector(props: PropTypes) {
           const productPrice = getProductPrice(
             props.productPrices,
             props.billingCountry,
-            billingPeriod,
+            billingPeriod === SixWeekly ? Quarterly : billingPeriod,
             props.fulfilmentOption,
           );
+
           return (<RadioInputWithHelper
             text={getTitle(billingPeriod)}
             helper={getPriceDescription(
@@ -59,6 +78,7 @@ function BillingPeriodSelector(props: PropTypes) {
               productPrice,
               billingPeriod,
             )}
+            offer={getOffer(billingPeriod, productPrice)}
             name="billingPeriod"
             checked={billingPeriod === props.selected}
             onChange={() => props.onChange(billingPeriod)}

--- a/support-frontend/assets/helpers/billingPeriods.js
+++ b/support-frontend/assets/helpers/billingPeriods.js
@@ -4,7 +4,7 @@ const Annual: 'Annual' = 'Annual';
 const Monthly: 'Monthly' = 'Monthly';
 const Quarterly: 'Quarterly' = 'Quarterly';
 const SixWeekly: 'SixWeekly' = 'SixWeekly';
-const ActiveWeeklyProductTypes = [Quarterly, Annual, SixWeekly];
+const weeklyBillingPeriods = [SixWeekly, Quarterly, Annual];
 export type BillingPeriod = typeof SixWeekly | typeof Annual | typeof Monthly | typeof Quarterly;
 export type DigitalBillingPeriod = typeof Monthly | typeof Annual;
 export type WeeklyBillingPeriod = typeof SixWeekly | typeof Quarterly | typeof Annual;
@@ -23,4 +23,9 @@ function billingPeriodNoun(billingPeriod: BillingPeriod) {
   }
 }
 
-export { Annual, Monthly, Quarterly, SixWeekly, billingPeriodNoun, ActiveWeeklyProductTypes };
+function billingPeriodTitle(billingPeriod: BillingPeriod) {
+  if (billingPeriod === SixWeekly) { return '6 for 6'; }
+  return billingPeriod;
+}
+
+export { Annual, Monthly, Quarterly, SixWeekly, billingPeriodNoun, billingPeriodTitle, weeklyBillingPeriods };

--- a/support-frontend/assets/helpers/internationalisation/currency.js
+++ b/support-frontend/assets/helpers/internationalisation/currency.js
@@ -7,8 +7,9 @@ import { getQueryParameter } from 'helpers/url';
 import {
   type CountryGroup,
   type CountryGroupId,
-  countryGroups,
+  countryGroups, fromCountry, GBPCountries,
 } from './countryGroup';
+import type { IsoCountry } from 'helpers/internationalisation/country';
 
 
 // ----- Types ----- //
@@ -132,6 +133,11 @@ function detect(countryGroup: CountryGroupId): IsoCurrency {
 const glyph = (c: IsoCurrency): string => currencies[c].glyph;
 const extendedGlyph = (c: IsoCurrency): string => currencies[c].extendedGlyph;
 
+const extendedGlyphForCountry = (country: IsoCountry) => {
+  const currency = fromCountryGroupId(fromCountry(country) || GBPCountries);
+  return extendedGlyph(currency || 'GBP');
+};
+
 
 // ----- Exports ----- //
 
@@ -142,4 +148,5 @@ export {
   currencies,
   glyph,
   extendedGlyph,
+  extendedGlyphForCountry,
 };

--- a/support-frontend/assets/helpers/productPrice/__tests__/priceDescriptionsTests.js
+++ b/support-frontend/assets/helpers/productPrice/__tests__/priceDescriptionsTests.js
@@ -1,0 +1,37 @@
+// @flow
+
+// ----- Imports ----- //
+
+import { getPriceDescription } from 'helpers/productPrice/priceDescriptions';
+import { Annual, Quarterly, SixWeekly } from 'helpers/billingPeriods';
+
+jest.mock('ophan', () => {});
+
+// ----- Tests ----- //
+
+describe('getPriceDescription', () => {
+  it('should return a price based on inputs', () => {
+    const gwAnnual = {
+      price: 150,
+      promotions: [
+        {
+          name: '10% Off Annual Guardian Weekly Subs',
+          description: 'Subscribe for 12 months and save 10%',
+          promoCode: '10ANNUAL',
+          discountedPrice: 135,
+          numberOfDiscountedPeriods: 1,
+          discount: { amount: 10, durationMonths: 12 },
+        }],
+    };
+    expect(getPriceDescription('£', gwAnnual, Annual))
+      .toEqual('£135 for 1 year, then standard rate (£150 every year)');
+
+    const gwQuarterly = { price: 37.5, promotions: [] };
+    expect(getPriceDescription('£', gwQuarterly, Quarterly))
+      .toEqual('£37.50 every 3 months');
+
+    const gwSixWeekly = { price: 6, promotions: [] };
+    expect(getPriceDescription('US$', gwSixWeekly, SixWeekly))
+      .toEqual('US$6 for the first 6 issues (then US$81.30 every 3 months)');
+  });
+});

--- a/support-frontend/assets/helpers/productPrice/__tests__/priceDescriptionsTests.js
+++ b/support-frontend/assets/helpers/productPrice/__tests__/priceDescriptionsTests.js
@@ -28,10 +28,31 @@ describe('getPriceDescription', () => {
 
     const gwQuarterly = { price: 37.5, promotions: [] };
     expect(getPriceDescription('£', gwQuarterly, Quarterly))
-      .toEqual('£37.50 every 3 months');
+      .toEqual('£37.50 every quarter');
+
+    const gwQuarterlyWithPromo = {
+      price: 37.5,
+      promotions: [
+        {
+          name: '15% discount - WJWGEX9A8',
+          description: '15% discount - WJWGEX9A8',
+          promoCode: 'WJWGEX9A8',
+          discountedPrice: 31.87,
+          numberOfDiscountedPeriods: 1,
+          discount: { amount: 15, durationMonths: 3 },
+        },
+        {
+          name: 'Six For Six',
+          description: 'Introductory offer',
+          promoCode: '6FOR6',
+          introductoryPrice: { price: 6, periodLength: 6, periodType: 'issue' },
+        }],
+    };
+    expect(getPriceDescription('£', gwQuarterlyWithPromo, Quarterly))
+      .toEqual('£31.87 for 1 quarter, then standard rate (£37.50 every quarter)');
 
     const gwSixWeekly = { price: 81.30, promotions: [] };
     expect(getPriceDescription('US$', gwSixWeekly, SixWeekly))
-      .toEqual('US$6 for the first 6 issues (then US$81.30 every 3 months)');
+      .toEqual('US$6 for the first 6 issues (then US$81.30 every quarter)');
   });
 });

--- a/support-frontend/assets/helpers/productPrice/__tests__/priceDescriptionsTests.js
+++ b/support-frontend/assets/helpers/productPrice/__tests__/priceDescriptionsTests.js
@@ -30,7 +30,7 @@ describe('getPriceDescription', () => {
     expect(getPriceDescription('£', gwQuarterly, Quarterly))
       .toEqual('£37.50 every 3 months');
 
-    const gwSixWeekly = { price: 6, promotions: [] };
+    const gwSixWeekly = { price: 81.30, promotions: [] };
     expect(getPriceDescription('US$', gwSixWeekly, SixWeekly))
       .toEqual('US$6 for the first 6 issues (then US$81.30 every 3 months)');
   });

--- a/support-frontend/assets/helpers/productPrice/__tests__/weeklyProductPrice.js
+++ b/support-frontend/assets/helpers/productPrice/__tests__/weeklyProductPrice.js
@@ -2,7 +2,6 @@
 
 // ----- Imports ----- //
 import {
-  displayBillingPeriods,
   getFulfilmentOption,
   getPromotionPrice,
 } from '../weeklyProductPrice';
@@ -158,7 +157,7 @@ describe('getFulfilmentOption', () => {
 });
 
 
-describe('getpromotionPrice', () => {
+describe('getPromotionPrice', () => {
   it('should return a price based on inputs including a promotion', () => {
     const usdPriceAnnualWithPromo = getPromotionPrice(
       'US', 'Annual',
@@ -172,24 +171,4 @@ describe('getpromotionPrice', () => {
     );
     expect(gbpPriceAnnualWithPromo).toEqual('£135');
   });
-});
-
-describe('displayBillingPeriods', () => {
-  it(
-    'should return a phrase about the price based on the location and product',
-    () => {
-      const annualCopyObject = displayBillingPeriods.Annual;
-      expect(typeof annualCopyObject).toEqual('object');
-      expect(annualCopyObject).toHaveProperty('title');
-      expect(annualCopyObject).toHaveProperty('offer');
-
-      const phraseUSA = annualCopyObject.copy(productPrices, 'US');
-      expect(phraseUSA)
-        .toBe('US$270 for 1 year, then standard rate (US$300 every year)');
-
-      const phraseUK = annualCopyObject.copy(productPrices, 'GB');
-      expect(phraseUK)
-        .toBe('£135 for 1 year, then standard rate (£150 every year)');
-    },
-  );
 });

--- a/support-frontend/assets/helpers/productPrice/priceDescriptions.js
+++ b/support-frontend/assets/helpers/productPrice/priceDescriptions.js
@@ -21,7 +21,7 @@ const billingPeriodQuantifier = (numberOfBillingPeriods: number, noun: string) =
     ` for 1 ${noun}`);
 
 const billingPeriodDescription = (billingPeriod: BillingPeriod) =>
-  ((billingPeriod === Quarterly) ? '3 months' : billingPeriodNoun(billingPeriod).toLowerCase());
+  billingPeriodNoun(billingPeriod).toLowerCase();
 
 const standardRate = (glyph: string, price: number, billingPeriod: BillingPeriod) => `${displayPrice(glyph, price)} every ${billingPeriodDescription(billingPeriod)}`;
 
@@ -72,6 +72,7 @@ function getAppliedPromoDescription(billingPeriod: BillingPeriod, productPrice: 
   const appliedPromo = getAppliedPromo(productPrice.promotions);
   if (
     appliedPromo === null ||
+    billingPeriod === SixWeekly ||
     (appliedPromo.introductoryPrice && billingPeriod === Quarterly)
   ) {
     return '';

--- a/support-frontend/assets/helpers/productPrice/priceDescriptions.js
+++ b/support-frontend/assets/helpers/productPrice/priceDescriptions.js
@@ -1,0 +1,72 @@
+// @flow
+
+import { fixDecimals } from 'helpers/subscriptions';
+import type { BillingPeriod } from 'helpers/billingPeriods';
+import {
+  billingPeriodNoun,
+  Quarterly,
+  SixWeekly,
+} from 'helpers/billingPeriods';
+import type { ProductPrice } from 'helpers/productPrice/productPrices';
+import {
+  getAppliedPromo,
+  hasDiscount,
+} from 'helpers/productPrice/productPrices';
+
+const displayPrice = (glyph: string, price: number) => `${glyph}${fixDecimals(price)}`;
+
+const billingPeriodQuantifier = (numberOfBillingPeriods: number, noun: string) =>
+  (numberOfBillingPeriods > 1 ?
+    `/${noun} for ${numberOfBillingPeriods} ${noun}s` :
+    ` for 1 ${noun}`);
+
+const billingPeriodDescription = (billingPeriod: BillingPeriod) =>
+  ((billingPeriod === Quarterly) ? '3 months' : billingPeriodNoun(billingPeriod).toLowerCase());
+
+const standardRate = (glyph: string, price: number, billingPeriod: BillingPeriod) => `${displayPrice(glyph, price)} every ${billingPeriodDescription(billingPeriod)}`;
+
+function getDiscountDescription(
+  glyph: string,
+  price: number,
+  discountedPrice: number,
+  numberOfDiscountedPeriods: ?number,
+  billingPeriod: BillingPeriod,
+) {
+  const noun = billingPeriodDescription(billingPeriod);
+
+  if (numberOfDiscountedPeriods) {
+    const discountCopy = `${displayPrice(glyph, discountedPrice)}${billingPeriodQuantifier(numberOfDiscountedPeriods, noun)}`;
+    const standardCopy = `then standard rate (${standardRate(glyph, price, billingPeriod)})`;
+    return `${discountCopy}, ${standardCopy}`;
+  }
+
+  return '';
+}
+
+// This function requires the Quarterly price to be passed into it, we can
+// remove it completely once we make 6 for 6 a promotion
+function getSixForSixDescription(glyph: string, productPrice: ProductPrice) {
+  return `${glyph}6 for the first 6 issues (then ${standardRate(glyph, productPrice.price, Quarterly)})`;
+}
+
+function getPriceDescription(
+  glyph: string,
+  productPrice: ProductPrice,
+  billingPeriod: BillingPeriod,
+): string {
+  if (billingPeriod === SixWeekly) {
+    return getSixForSixDescription(glyph, productPrice); // TODO: use promotions
+  }
+  const promotion = getAppliedPromo(productPrice.promotions);
+  return hasDiscount(promotion) ? getDiscountDescription(
+    glyph,
+    productPrice.price,
+    // $FlowIgnore -- We have checked this in hasDiscount
+    promotion.discountedPrice,
+    promotion.numberOfDiscountedPeriods,
+    billingPeriod,
+  ) : standardRate(glyph, productPrice.price, billingPeriod);
+}
+
+
+export { getPriceDescription };

--- a/support-frontend/assets/helpers/productPrice/priceDescriptions.js
+++ b/support-frontend/assets/helpers/productPrice/priceDescriptions.js
@@ -55,7 +55,7 @@ function getPriceDescription(
   billingPeriod: BillingPeriod,
 ): string {
   if (billingPeriod === SixWeekly) {
-    return getSixForSixDescription(glyph, productPrice); // TODO: use promotions
+    return getSixForSixDescription(glyph, productPrice);
   }
   const promotion = getAppliedPromo(productPrice.promotions);
   return hasDiscount(promotion) ? getDiscountDescription(
@@ -68,5 +68,17 @@ function getPriceDescription(
   ) : standardRate(glyph, productPrice.price, billingPeriod);
 }
 
+function getAppliedPromoDescription(billingPeriod: BillingPeriod, productPrice: ProductPrice) {
+  const appliedPromo = getAppliedPromo(productPrice.promotions);
+  if (
+    appliedPromo === null ||
+    (appliedPromo.introductoryPrice && billingPeriod === Quarterly)
+  ) {
+    return '';
+  }
 
-export { getPriceDescription };
+  return appliedPromo.description;
+}
+
+
+export { getPriceDescription, getAppliedPromoDescription };

--- a/support-frontend/assets/helpers/productPrice/priceDescriptions.js
+++ b/support-frontend/assets/helpers/productPrice/priceDescriptions.js
@@ -3,7 +3,7 @@
 import { fixDecimals } from 'helpers/subscriptions';
 import type { BillingPeriod } from 'helpers/billingPeriods';
 import {
-  billingPeriodNoun,
+  billingPeriodNoun as upperCasePeriodNoun,
   Quarterly,
   SixWeekly,
 } from 'helpers/billingPeriods';
@@ -20,10 +20,11 @@ const billingPeriodQuantifier = (numberOfBillingPeriods: number, noun: string) =
     `/${noun} for ${numberOfBillingPeriods} ${noun}s` :
     ` for 1 ${noun}`);
 
-const billingPeriodDescription = (billingPeriod: BillingPeriod) =>
-  billingPeriodNoun(billingPeriod).toLowerCase();
+const billingPeriodNoun = (billingPeriod: BillingPeriod) =>
+  upperCasePeriodNoun(billingPeriod).toLowerCase();
 
-const standardRate = (glyph: string, price: number, billingPeriod: BillingPeriod) => `${displayPrice(glyph, price)} every ${billingPeriodDescription(billingPeriod)}`;
+const standardRate = (glyph: string, price: number, billingPeriod: BillingPeriod) =>
+  `${displayPrice(glyph, price)} every ${billingPeriodNoun(billingPeriod)}`;
 
 function getDiscountDescription(
   glyph: string,
@@ -32,7 +33,7 @@ function getDiscountDescription(
   numberOfDiscountedPeriods: ?number,
   billingPeriod: BillingPeriod,
 ) {
-  const noun = billingPeriodDescription(billingPeriod);
+  const noun = billingPeriodNoun(billingPeriod);
 
   if (numberOfDiscountedPeriods) {
     const discountCopy = `${displayPrice(glyph, discountedPrice)}${billingPeriodQuantifier(numberOfDiscountedPeriods, noun)}`;

--- a/support-frontend/assets/helpers/productPrice/productPrices.js
+++ b/support-frontend/assets/helpers/productPrice/productPrices.js
@@ -30,6 +30,14 @@ export type DiscountBenefit = {
   durationMonths?: number,
 }
 
+export type IntroductoryPeriodType = 'issue';
+
+export type IntroductoryPriceBenefit = {
+  price: number,
+  periodLength: number,
+  periodType: IntroductoryPeriodType,
+}
+
 export type Promotion =
   {
     name: string,
@@ -38,6 +46,7 @@ export type Promotion =
     discountedPrice?: number,
     numberOfDiscountedPeriods?: number,
     discount?: DiscountBenefit,
+    introductoryPrice?: IntroductoryPriceBenefit,
   }
 
 export type ProductPrice = {

--- a/support-frontend/assets/helpers/productPrice/weeklyProductPrice.js
+++ b/support-frontend/assets/helpers/productPrice/weeklyProductPrice.js
@@ -9,14 +9,12 @@ import type {
   BillingPeriod,
   WeeklyBillingPeriod,
 } from 'helpers/billingPeriods';
-import { Annual, Quarterly, SixWeekly } from 'helpers/billingPeriods';
 import type {
   Price,
   ProductPrices,
   Promotion,
 } from 'helpers/productPrice/productPrices';
 import {
-  displayPrice,
   getPromotion as genericGetPromotion,
   regularPrice as genericRegularPrice,
 } from 'helpers/productPrice/productPrices';
@@ -69,25 +67,4 @@ function regularPrice(
 const getFulfilmentOption = (country: IsoCountry) =>
   (countryGroups.International.countries.includes(country) ? RestOfWorld : Domestic);
 
-const displayBillingPeriods = {
-  [SixWeekly]: {
-    title: '6 for 6',
-    offer: 'Introductory offer',
-    copy: (productPrices: ProductPrices, country: IsoCountry) =>
-      `${displayPrice(productPrices, country, SixWeekly, getFulfilmentOption(country))} for the first 6 issues (then 
-      ${displayPrice(productPrices, country, Quarterly, getFulfilmentOption(country))} quarterly)`,
-  },
-  [Quarterly]: {
-    title: 'Quarterly',
-    copy: (productPrices: ProductPrices, country: IsoCountry) =>
-      `${displayPrice(productPrices, country, Quarterly, getFulfilmentOption(country))} every 3 months`,
-  },
-  [Annual]: {
-    title: 'Annually',
-    offer: 'Save 10%',
-    copy: (productPrices: ProductPrices, country: IsoCountry) =>
-      `${getPromotionPrice(country, 'Annual', '10ANNUAL')} for 1 year, then standard rate (${displayPrice(productPrices, country, Annual, getFulfilmentOption(country))} every year)`,
-  },
-};
-
-export { getPromotion, regularPrice, getFulfilmentOption, getPromotionPrice, displayBillingPeriods };
+export { getPromotion, regularPrice, getFulfilmentOption, getPromotionPrice };

--- a/support-frontend/assets/helpers/productPrice/weeklyProductPrice.js
+++ b/support-frontend/assets/helpers/productPrice/weeklyProductPrice.js
@@ -5,14 +5,27 @@ import {
   fromCountry,
   GBPCountries,
 } from 'helpers/internationalisation/countryGroup';
-import type { WeeklyBillingPeriod } from 'helpers/billingPeriods';
+import type {
+  BillingPeriod,
+  WeeklyBillingPeriod,
+} from 'helpers/billingPeriods';
 import { Annual, Quarterly, SixWeekly } from 'helpers/billingPeriods';
-import type { ProductPrices } from 'helpers/productPrice/productPrices';
-import { displayPrice } from 'helpers/productPrice/productPrices';
+import type {
+  Price,
+  ProductPrices,
+  Promotion,
+} from 'helpers/productPrice/productPrices';
+import {
+  displayPrice,
+  getPromotion as genericGetPromotion,
+  regularPrice as genericRegularPrice,
+} from 'helpers/productPrice/productPrices';
 import type { IsoCountry } from 'helpers/internationalisation/country';
+import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import { Domestic, RestOfWorld } from 'helpers/productPrice/fulfilmentOptions';
 import { getPromotionWeeklyProductPrice } from 'helpers/subscriptions';
 import { currencies, detect } from 'helpers/internationalisation/currency';
+import { NoProductOptions } from 'helpers/productPrice/productOptions';
 
 const getPromotionPrice = (country: IsoCountry, period: WeeklyBillingPeriod, promoCode: string) => {
   const countryGroupId = fromCountry(country) || GBPCountries;
@@ -21,6 +34,37 @@ const getPromotionPrice = (country: IsoCountry, period: WeeklyBillingPeriod, pro
     getPromotionWeeklyProductPrice(countryGroupId, period, promoCode),
   ].join('');
 };
+
+function getPromotion(
+  productPrices: ProductPrices,
+  country: IsoCountry,
+  billingPeriod: BillingPeriod,
+  fulfilmentOption: ?FulfilmentOptions,
+): ?Promotion {
+  return genericGetPromotion(
+    productPrices,
+    country,
+    billingPeriod,
+    fulfilmentOption,
+    NoProductOptions,
+  );
+}
+
+function regularPrice(
+  productPrices: ProductPrices,
+  country: IsoCountry,
+  billingPeriod: BillingPeriod,
+  fulfilmentOption: ?FulfilmentOptions,
+): Price {
+  return genericRegularPrice(
+    productPrices,
+    country,
+    billingPeriod,
+    fulfilmentOption,
+    NoProductOptions,
+  );
+}
+
 
 const getFulfilmentOption = (country: IsoCountry) =>
   (countryGroups.International.countries.includes(country) ? RestOfWorld : Domestic);
@@ -46,4 +90,4 @@ const displayBillingPeriods = {
   },
 };
 
-export { getFulfilmentOption, getPromotionPrice, displayBillingPeriods };
+export { getPromotion, regularPrice, getFulfilmentOption, getPromotionPrice, displayBillingPeriods };

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -12,8 +12,6 @@ import {
 } from 'helpers/subscriptionsForms/validation';
 import type { BillingPeriod } from 'helpers/billingPeriods';
 import { Annual, Monthly } from 'helpers/billingPeriods';
-import { Fieldset } from 'components/forms/fieldset';
-import { RadioInput } from 'components/forms/customFields/radioInput';
 import Form, { FormSection } from 'components/checkoutForm/checkoutForm';
 import CheckoutLayout, { Content } from 'components/subscriptionCheckouts/layout';
 import type { ErrorReason } from 'helpers/errorReasons';
@@ -23,8 +21,6 @@ import {
   getPromotion,
   regularPrice,
 } from 'helpers/productPrice/productPrices';
-import { PriceLabel } from 'components/priceLabel/priceLabel';
-import { PromotionSummary } from 'components/promotionSummary/promotionSummary';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import Summary from 'components/subscriptionCheckouts/summary';
 import {
@@ -60,6 +56,7 @@ import {
   validateCheckoutForm,
 } from 'helpers/subscriptionsForms/formValidation';
 import { submitCheckoutForm } from 'helpers/subscriptionsForms/submit';
+import { BillingPeriodSelector } from 'components/subscriptionCheckouts/billingPeriodSelector';
 
 // ----- Types ----- //
 
@@ -129,21 +126,6 @@ const Address = withStore(countries, 'billing', getBillingAddress);
 // ----- Component ----- //
 
 function CheckoutForm(props: PropTypes) {
-  const monthlyPriceLabel = props.country !== null ?
-    (<PriceLabel
-      country={props.country}
-      productPrice={regularPrice(props.productPrices, props.country, Monthly)}
-      promotion={getPromotion(props.productPrices, props.country, Monthly)}
-      billingPeriod={Monthly}
-    />) : '';
-
-  const annualPriceLabel = props.country !== null ?
-    (<PriceLabel
-      country={props.country}
-      productPrice={regularPrice(props.productPrices, props.country, Annual)}
-      promotion={getPromotion(props.productPrices, props.country, Annual)}
-      billingPeriod={Annual}
-    />) : '';
 
   return (
     <Content>
@@ -195,27 +177,13 @@ function CheckoutForm(props: PropTypes) {
           <FormSection title="Address">
             <Address />
           </FormSection>
-          <FormSection title="How often would you like to pay?">
-            <Fieldset legend="How often would you like to pay?">
-              <RadioInput
-                text={monthlyPriceLabel}
-                name="billingPeriod"
-                checked={props.billingPeriod === Monthly}
-                onChange={() => props.setBillingPeriod(Monthly)}
-              />
-              <RadioInput
-                text={annualPriceLabel}
-                name="billingPeriod"
-                checked={props.billingPeriod === Annual}
-                onChange={() => props.setBillingPeriod(Annual)}
-              />
-              <PromotionSummary
-                country={props.country}
-                productPrices={props.productPrices}
-                billingPeriod={props.billingPeriod}
-              />
-            </Fieldset>
-          </FormSection>
+          <BillingPeriodSelector
+            billingCountry={props.country}
+            billingPeriods={[Monthly, Annual]}
+            productPrices={props.productPrices}
+            selected={props.billingPeriod}
+            onChange={billingPeriod => props.setBillingPeriod(billingPeriod)}
+          />
           <PaymentMethodSelector
             country={props.country}
             product={DigitalPack}

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -10,7 +10,7 @@ import {
   firstError,
   type FormError,
 } from 'helpers/subscriptionsForms/validation';
-import { Annual, Quarterly, SixWeekly } from 'helpers/billingPeriods';
+import { weeklyBillingPeriods } from 'helpers/billingPeriods';
 import Rows from 'components/base/rows';
 import Text from 'components/text/text';
 import Button from 'components/button/button';
@@ -243,7 +243,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
           <BillingPeriodSelector
             fulfilmentOption={fulfilmentOption}
             onChange={billingPeriod => props.setBillingPeriod(billingPeriod)}
-            billingPeriods={[Quarterly, Annual, SixWeekly]}
+            billingPeriods={weeklyBillingPeriods}
             billingCountry={props.billingCountry}
             productPrices={props.productPrices}
             selected={props.billingPeriod}


### PR DESCRIPTION
## Why are you doing this?
We have a lot of different places where pricing related copy is defined in the app, this leads to inconsistencies and makes it hard to make changes. This PR tries to centralise all pricing related copy in a new `priceDescription` module and makes that module aware of promotions, particularly introductory price type promotions which are used to model 6 for 6.

I have also created a new component `BillingPeriodSelector` which handles the display of available billing periods and their prices in the DP & GW checkout forms.

[**Trello Card**](https://trello.com/c/Jz30fbFH/2411-guardian-weekly-6-for-6-frontend)
