### PR TITLE
Clean up legacy routes

### DIFF
--- a/support-frontend/app/controllers/PayPalOneOff.scala
+++ b/support-frontend/app/controllers/PayPalOneOff.scala
@@ -67,7 +67,7 @@ class PayPalOneOff(
 
   def resultFromPaypalSuccess(success: PayPalSuccess, country: String, isTestUser: Boolean)(implicit request: RequestHeader): Result = {
     SafeLogger.info(s"One-off contribution for Paypal payment is successful")
-    val redirect = Redirect("/contribute/one-off/thankyou")
+    val redirect = Redirect(s"/$country/thankyou")
     if (!isTestUser) {
       monitoredRegion(country).map {
         region => verify(TipPath(region, OneOffContribution, PayPal), tipMonitoring.verify)

--- a/support-frontend/app/controllers/PayPalOneOff.scala
+++ b/support-frontend/app/controllers/PayPalOneOff.scala
@@ -65,17 +65,11 @@ class PayPalOneOff(
     }
   }
 
-  def resultFromPaypalSuccess(success: PayPalSuccess, country: Option[String], isTestUser: Boolean)(implicit request: RequestHeader): Result = {
+  def resultFromPaypalSuccess(success: PayPalSuccess, country: String, isTestUser: Boolean)(implicit request: RequestHeader): Result = {
     SafeLogger.info(s"One-off contribution for Paypal payment is successful")
-    val redirect = Redirect {
-      country match {
-        // TODO: more cleanup
-        case Some(c) => s"/$c/thankyou"
-        case None => "/contribute/one-off/thankyou"
-      }
-    }
+    val redirect = Redirect("/contribute/one-off/thankyou")
     if (!isTestUser) {
-      monitoredRegion(country.getOrElse("Unknown")).map {
+      monitoredRegion(country).map {
         region => verify(TipPath(region, OneOffContribution, PayPal), tipMonitoring.verify)
       }
     }
@@ -88,10 +82,7 @@ class PayPalOneOff(
     })
   }
 
-  //TODO - more cleanup
-  def newReturnURL(paymentId: String, PayerID: String, country: String): Action[AnyContent] = returnURL(paymentId, PayerID, Some(country))
-
-  def returnURL(paymentId: String, PayerID: String, country: Option[String] = None): Action[AnyContent] = maybeAuthenticatedAction().async { implicit request =>
+  def returnURL(paymentId: String, PayerID: String, country: String): Action[AnyContent] = maybeAuthenticatedAction().async { implicit request =>
 
     val acquisitionData = (for {
       cookie <- request.cookies.get("acquisition_data")
@@ -132,10 +123,5 @@ class PayPalOneOff(
     emailForUser(request.user)
       .flatMap(paymentAPIService.executePaypalPayment(paymentJSON, acquisitionData, queryStrings, _, isTestUser, userAgent))
       .fold(resultFromPaymentAPIError, success => resultFromPaypalSuccess(success, country, isTestUser))
-  }
-
-  def cancelURL(): Action[AnyContent] = PrivateAction { implicit request =>
-    SafeLogger.info("The user selected cancel payment and decided not to contribute.")
-    Redirect(routes.PayPalOneOff.paypalError())
   }
 }

--- a/support-frontend/app/services/PaymentAPIService.scala
+++ b/support-frontend/app/services/PaymentAPIService.scala
@@ -44,10 +44,6 @@ object ExecutePaymentBody {
   implicit val jf: OFormat[ExecutePaymentBody] = Json.format[ExecutePaymentBody]
 }
 
-object PaymentAPIService {
-  case class Email(value: String)
-}
-
 class PaymentAPIService(wsClient: WSClient, paymentAPIUrl: String)(implicit ec: ExecutionContext) {
 
   private val paypalCreatePaymentPath = "/contribute/one-off/paypal/create-payment"

--- a/support-frontend/assets/helpers/routes.js
+++ b/support-frontend/assets/helpers/routes.js
@@ -49,11 +49,11 @@ function paperCheckoutUrl(fulfilmentOption: FulfilmentOptions, productOptions: P
   return `${getOrigin()}/subscribe/paper/checkout?fulfilment=${fulfilmentOption}&product=${productOptions}`;
 }
 
+// If the user cancels before completing the payment flow, send them back to the contribute page.
 function payPalCancelUrl(cgId: CountryGroupId): string {
   return `${getOrigin()}/${countryGroups[cgId].supportInternationalisationId}/contribute`;
 }
 
-// TODO: cleanup
 function payPalReturnUrl(cgId: CountryGroupId): string {
   return `${getOrigin()}/${countryGroups[cgId].supportInternationalisationId}/paypal/rest/return`;
 }

--- a/support-frontend/conf/routes
+++ b/support-frontend/conf/routes
@@ -126,14 +126,14 @@ GET  /paypal/cancel                                 controllers.PayPalRegular.ca
 
 # For PayPal one-off create a payment by sending a request to the payment API directly.
 # <payment-api-host>/contribute/one-off/paypal/create-payment
-# This requires return and cancel urls depending on whether the user authorized the payment or not.
 # https://github.com/guardian/payment-api/blob/master/src/main/scala/model/paypal/PaypalPaymentData.scala#L74
-GET  /paypal/rest/return                                controllers.PayPalOneOff.returnURL(paymentId: String, PayerID: String, country: Option[String] = None)
-GET  /paypal/rest/cancel                                controllers.PayPalOneOff.cancelURL
-GET  /paypal/rest/error                                 controllers.PayPalOneOff.paypalError
+# When creating the payment, we tell PayPal where to redirect back to if payment succeeds.
+# This endpoint is the return URL we supply to PayPal.
+GET  /$country<(uk|us|au|eu|int|nz|ca)>/paypal/rest/return   controllers.PayPalOneOff.returnURL(paymentId: String, PayerID: String, country: String)
 
-# TODO: more cleanup
-GET  /$country<(uk|us|au|eu|int|nz|ca)>/paypal/rest/return   controllers.PayPalOneOff.newReturnURL(paymentId: String, PayerID: String, country: String)
+# If we get an error back from the execute-payment request to PayPal,
+# we need to redirect the user to a page that tells them their payment failed.
+GET  /paypal/rest/error                                      controllers.PayPalOneOff.paypalError
 
 # ----- Direct Debit ----- #
 


### PR DESCRIPTION
Some long-awaited cleanup of routes no longer used in the new payment flow world.

We don't need a specific route for `cancelURL` even though PayPal does accept one as a parameter with `create-payment` requests, since we just send users back to the contributions page if they cancel.

We do need a specific route for errors, since we need to tell the user their payment has failed. Confusingly, we're the ones who redirect users to this page, not PayPal, because we find this out when we make the `execute-payment` request after the user has completed the PayPal flow.