### PR TITLE
Remove mention of hosts file

### DIFF
--- a/support-frontend/nginx/README.md
+++ b/support-frontend/nginx/README.md
@@ -8,14 +8,6 @@ Support™ depends on Identity, so **you'll need to perform the**
 
 ## Support-specific setup
 
-#### Update your hosts file
-
-Add the following local development domain to your hosts file in `/etc/hosts`:
-
-```
-127.0.0.1   support.thegulocal.com
-```
-
 #### Run Support's Nginx setup script
 
 Run the Support-specific [setup.sh](setup.sh) script from the root


### PR DESCRIPTION
## Why are you doing this?
Hosts file changes should no longer be necessary as we are adding *.thegulocal.com DNS entry.  Note: the intention is to change this domain to support.local.dev-theguardian.com for consistency in the medium term.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

