### PR TITLE
add latency/5xx alarms and improve descriptions

### DIFF
--- a/support-frontend/cloud-formation/cfn.yaml
+++ b/support-frontend/cloud-formation/cfn.yaml
@@ -278,7 +278,8 @@ Resources:
     Properties:
       AlarmActions:
       - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
-      AlarmName: !Sub No healthy instances for support-frontend in ${Stage}
+      AlarmName: !Sub HIGH severity - No healthy instances for support-frontend in ${Stage}
+      AlarmDescription: Impact - Cannot sell any subscriptions or contributions products. https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit
       MetricName: HealthyHostCount
       Namespace: AWS/ApplicationELB
       Dimensions:
@@ -301,7 +302,8 @@ Resources:
     Properties:
       AlarmActions:
       - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
-      AlarmName: !Sub High 5XX rate for support-frontend in ${Stage}
+      AlarmName: !Sub HIGH severity - support-frontend instances are returning 5XX errors in ${Stage}
+      AlarmDescription: Impact - Some or all actions on support website are failing. https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit
       MetricName: HTTPCode_Target_5XX_Count
       Namespace: AWS/ApplicationELB
       Dimensions:
@@ -318,14 +320,57 @@ Resources:
     - TargetGroup
     - ElasticLoadBalancer
 
+  HighELB5XXRateAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: CreateProdResources
+    Properties:
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
+      AlarmName: !Sub HIGH severity - support-frontend ELB is returning 5XX errors in ${Stage}
+      AlarmDescription: Impact - Some or all actions on support website are failing. https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit
+      MetricName: HTTPCode_ELB_5XX_Count
+      Namespace: AWS/ApplicationELB
+      Dimensions:
+        - Name: LoadBalancer
+          Value: !GetAtt ElasticLoadBalancer.LoadBalancerFullName
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Threshold: 3
+      Period: 60
+      EvaluationPeriods: 2
+      Statistic: Sum
+    DependsOn:
+      - TargetGroup
+      - ElasticLoadBalancer
+
+  LatencyNotificationAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: CreateProdResources
+    Properties:
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
+      AlarmName: !Sub HIGH severity - support-frontend has high latency ${Stage}
+      AlarmDescription: Impact - support-frontend users are seeing slow responses. https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit
+      MetricName: TargetResponseTime
+      Dimensions:
+        - Name: LoadBalancer
+          Value: !GetAtt ElasticLoadBalancer.LoadBalancerFullName
+        - Name: TargetGroup
+          Value: !GetAtt TargetGroup.TargetGroupFullName
+      Namespace: AWS/ELB
+      EvaluationPeriods: 2
+      Period: 60
+      Statistic: Average
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+
   CatalogLoadingFailureAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: CreateProdResources
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
-      AlarmName: Support Frontend Catalog Load Failure
-      AlarmDescription: Fires an alarm if we fail to load the Zuora catalog pricing information from S3
+      AlarmName: !Sub HIGH severity - support-frontend could not load the Zuora catalog from S3 in ${Stage}
+      AlarmDescription: Impact - Cannot sell any subscriptions products. https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit
       MetricName: CatalogLoadingFailure
       Namespace: support-frontend
       Dimensions:
@@ -352,7 +397,8 @@ Resources:
     Properties:
       AlarmActions:
       - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
-      AlarmName: !Sub Regular contributions state machine unavailable in ${Stage}
+      AlarmName: !Sub HIGH severity - support-workers state machine unavailable in ${Stage}
+      AlarmDescription: Impact - Cannot sell any subscriptions or contributions products. https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit
       MetricName: state-machine-unavailable
       Namespace: !Sub support-frontend-${Stage}
       ComparisonOperator: GreaterThanOrEqualToThreshold

--- a/support-frontend/cloud-formation/cfn.yaml
+++ b/support-frontend/cloud-formation/cfn.yaml
@@ -279,7 +279,7 @@ Resources:
       AlarmActions:
       - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
       AlarmName: !Sub HIGH severity - No healthy instances for support-frontend in ${Stage}
-      AlarmDescription: Impact - Cannot sell any subscriptions or contributions products. https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit
+      AlarmDescription: Impact - Cannot sell any subscriptions or contributions products. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit
       MetricName: HealthyHostCount
       Namespace: AWS/ApplicationELB
       Dimensions:
@@ -303,7 +303,7 @@ Resources:
       AlarmActions:
       - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
       AlarmName: !Sub HIGH severity - support-frontend instances are returning 5XX errors in ${Stage}
-      AlarmDescription: Impact - Some or all actions on support website are failing. https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit
+      AlarmDescription: Impact - Some or all actions on support website are failing. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit
       MetricName: HTTPCode_Target_5XX_Count
       Namespace: AWS/ApplicationELB
       Dimensions:
@@ -327,7 +327,7 @@ Resources:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
       AlarmName: !Sub HIGH severity - support-frontend ELB is returning 5XX errors in ${Stage}
-      AlarmDescription: Impact - Some or all actions on support website are failing. https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit
+      AlarmDescription: Impact - Some or all actions on support website are failing. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit
       MetricName: HTTPCode_ELB_5XX_Count
       Namespace: AWS/ApplicationELB
       Dimensions:
@@ -349,7 +349,7 @@ Resources:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
       AlarmName: !Sub HIGH severity - support-frontend has high latency ${Stage}
-      AlarmDescription: Impact - support-frontend users are seeing slow responses. https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit
+      AlarmDescription: Impact - support-frontend users are seeing slow responses. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit
       MetricName: TargetResponseTime
       Dimensions:
         - Name: LoadBalancer
@@ -370,7 +370,7 @@ Resources:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
       AlarmName: !Sub HIGH severity - support-frontend could not load the Zuora catalog from S3 in ${Stage}
-      AlarmDescription: Impact - Cannot sell any subscriptions products. https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit
+      AlarmDescription: Impact - Cannot sell any subscriptions products. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit
       MetricName: CatalogLoadingFailure
       Namespace: support-frontend
       Dimensions:
@@ -398,7 +398,7 @@ Resources:
       AlarmActions:
       - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
       AlarmName: !Sub HIGH severity - support-workers state machine unavailable in ${Stage}
-      AlarmDescription: Impact - Cannot sell any subscriptions or contributions products. https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit
+      AlarmDescription: Impact - Cannot sell any subscriptions or contributions products. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit
       MetricName: state-machine-unavailable
       Namespace: !Sub support-frontend-${Stage}
       ComparisonOperator: GreaterThanOrEqualToThreshold


### PR DESCRIPTION
## Why are you doing this?

Two reasons:

1. Following the outage on fri 24th may, we didn't actually get an alarm when the instances were sick.  This is because latency skyrocketed and the ELB was throwing 5xx errors, however our alarm is only on instance 5xx errors.  (in any case, 5xx errors were being thrown around that time due to another issue that hadn't been rolled back)
This PR adds both alarms above, and defines them as high severity in the [alerts doc.](https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit)

2. I have also taken the opportunity to move away from a technical notation of the alerts and more towards and action and impact based notation.
The essence is that every alarm name is of the form
`HIGH severity - <service> <what is happening>`
and every description is of the form
`Impact - <what is degraded or broken for the end user>. Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit`

[**Trello Card**](https://trello.com/c/jYtcYsmQ/2414-did-we-and-should-we-get-alarms-for-the-initial-and-later-incidents-on-25th-may#)


