### PR TITLE
URI encode the email in PayPal return URL

### DIFF
--- a/support-frontend/assets/helpers/routes.js
+++ b/support-frontend/assets/helpers/routes.js
@@ -55,7 +55,7 @@ function payPalCancelUrl(cgId: CountryGroupId): string {
 }
 
 function payPalReturnUrl(cgId: CountryGroupId, email: string): string {
-  return `${getOrigin()}/${countryGroups[cgId].supportInternationalisationId}/paypal/rest/return?email=${email}`;
+  return `${getOrigin()}/${countryGroups[cgId].supportInternationalisationId}/paypal/rest/return?email=${encodeURIComponent(email)}`;
 }
 
 // ----- Exports ----- //


### PR DESCRIPTION
This is needed to escape any URL-special characters email may contain (e.g. `+`!)