### PR TITLE
Add gifting to Weekly checkout

### DIFF
--- a/support-frontend/assets/components/forms/customFields/checkbox.scss
+++ b/support-frontend/assets/components/forms/customFields/checkbox.scss
@@ -10,7 +10,6 @@
 }
 
 .component-checkbox__text {
-  font-weight: bold;
   display: flex;
   align-items: center;
   position: relative;

--- a/support-frontend/assets/components/subscriptionCheckouts/billingPeriodSelector.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/billingPeriodSelector.jsx
@@ -44,8 +44,8 @@ function BillingPeriodSelector(props: PropTypes) {
             billingPeriod === SixWeekly ? Quarterly : billingPeriod, // for 6 for 6 we need the quarterly pricing
             props.fulfilmentOption,
           );
-          return !props.orderIsAGift || billingPeriod !== SixWeekly ?
-            <RadioInputWithHelper
+          return props.orderIsAGift && billingPeriod === SixWeekly ? null
+            : <RadioInputWithHelper
               text={billingPeriodTitle(billingPeriod)}
               helper={getPriceDescription(
                 extendedGlyphForCountry(props.billingCountry),
@@ -56,8 +56,7 @@ function BillingPeriodSelector(props: PropTypes) {
               name="billingPeriod"
               checked={billingPeriod === props.selected}
               onChange={() => props.onChange(billingPeriod)}
-            />
-          : null;
+            />;
         })}
       </Fieldset>
     </FormSection>);

--- a/support-frontend/assets/components/subscriptionCheckouts/billingPeriodSelector.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/billingPeriodSelector.jsx
@@ -29,6 +29,7 @@ type PropTypes = {|
   billingCountry: IsoCountry,
   selected: BillingPeriod,
   onChange: (BillingPeriod) => Action,
+  orderIsAGift?: boolean | null,
 |}
 
 function BillingPeriodSelector(props: PropTypes) {
@@ -42,19 +43,20 @@ function BillingPeriodSelector(props: PropTypes) {
             billingPeriod === SixWeekly ? Quarterly : billingPeriod, // for 6 for 6 we need the quarterly pricing
             props.fulfilmentOption,
           );
-
-          return (<RadioInputWithHelper
-            text={billingPeriodTitle(billingPeriod)}
-            helper={getPriceDescription(
-              extendedGlyphForCountry(props.billingCountry),
-              productPrice,
-              billingPeriod,
-            )}
-            offer={getAppliedPromoDescription(billingPeriod, productPrice)}
-            name="billingPeriod"
-            checked={billingPeriod === props.selected}
-            onChange={() => props.onChange(billingPeriod)}
-          />);
+          return !props.orderIsAGift || billingPeriod !== SixWeekly ?
+            <RadioInputWithHelper
+              text={billingPeriodTitle(billingPeriod)}
+              helper={getPriceDescription(
+                extendedGlyphForCountry(props.billingCountry),
+                productPrice,
+                billingPeriod,
+              )}
+              offer={getAppliedPromoDescription(billingPeriod, productPrice)}
+              name="billingPeriod"
+              checked={billingPeriod === props.selected}
+              onChange={() => props.onChange(billingPeriod)}
+            />
+          : null;
         })}
       </Fieldset>
     </FormSection>);
@@ -62,6 +64,7 @@ function BillingPeriodSelector(props: PropTypes) {
 
 BillingPeriodSelector.defaultProps = {
   fulfilmentOption: NoFulfilmentOptions,
+  orderIsAGift: false,
 };
 
 export { BillingPeriodSelector };

--- a/support-frontend/assets/components/subscriptionCheckouts/billingPeriodSelector.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/billingPeriodSelector.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { Fieldset } from 'components/forms/fieldset';
 import { RadioInputWithHelper } from 'components/forms/customFields/radioInputWithHelper';
 import type { BillingPeriod } from 'helpers/billingPeriods';
+import { type Option } from 'helpers/types/option';
 import {
   billingPeriodTitle,
   Quarterly,
@@ -29,7 +30,7 @@ type PropTypes = {|
   billingCountry: IsoCountry,
   selected: BillingPeriod,
   onChange: (BillingPeriod) => Action,
-  orderIsAGift?: boolean | null,
+  orderIsAGift?: Option<boolean>,
 |}
 
 function BillingPeriodSelector(props: PropTypes) {

--- a/support-frontend/assets/components/subscriptionCheckouts/cancellationSection.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/cancellationSection.jsx
@@ -8,9 +8,8 @@ export default function CancellationSection() {
     <FormSection>
       <Text>
         <p>
-          <strong>Cancel any time you want.</strong>
-          There is no set time on your agreement so you can stop
-          your subscription anytime
+          <strong>Cancel at any point.</strong> There is no set time on your agreement with us so you can end
+          your subscription whenever you wish
         </p>
       </Text>
     </FormSection>);

--- a/support-frontend/assets/components/subscriptionCheckouts/personalDetails.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/personalDetails.jsx
@@ -10,9 +10,8 @@ import { Input } from 'components/forms/input';
 import type { FormError } from 'helpers/subscriptionsForms/validation';
 import Button from 'components/button/button';
 import CheckoutExpander from 'components/checkoutExpander/checkoutExpander';
+import { type FormField } from 'helpers/subscriptionsForms/formFields';
 
-
-export type FormField = 'firstName' | 'lastName' | 'email' | 'telephone';
 
 export type PropTypes = {
   firstName: string,

--- a/support-frontend/assets/components/subscriptionCheckouts/personalDetailsGift.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/personalDetailsGift.jsx
@@ -23,7 +23,7 @@ export type PropTypes = {
 const InputWithLabel = withLabel(Input);
 const InputWithError = compose(asControlled, withError)(InputWithLabel);
 
-export default function PersonalDetails(props: PropTypes) {
+export default function PersonalDetailsGift(props: PropTypes) {
   return (
     <div>
       <InputWithError

--- a/support-frontend/assets/components/subscriptionCheckouts/personalDetailsGift.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/personalDetailsGift.jsx
@@ -1,0 +1,53 @@
+// @flow
+import React from 'react';
+import { firstError } from 'helpers/subscriptionsForms/validation';
+import { compose } from 'redux';
+import { asControlled } from 'hocs/asControlled';
+import { withError } from 'hocs/withError';
+import { withLabel } from 'hocs/withLabel';
+import { Input } from 'components/forms/input';
+import type { FormError } from 'helpers/subscriptionsForms/validation';
+
+
+export type FormField = 'firstName' | 'lastName' | 'email' | 'telephone';
+
+export type PropTypes = {
+  firstName: string,
+  setFirstName: Function,
+  lastName: string,
+  setLastName: Function,
+  email: string,
+  formErrors: FormError<FormField>[],
+}
+
+const InputWithLabel = withLabel(Input);
+const InputWithError = compose(asControlled, withError)(InputWithLabel);
+
+export default function PersonalDetails(props: PropTypes) {
+  return (
+    <div>
+      <InputWithError
+        id="first-name"
+        label="First name"
+        type="text"
+        value={props.firstName}
+        setValue={props.setFirstName}
+        error={firstError('firstName', props.formErrors)}
+      />
+      <InputWithError
+        id="last-name"
+        label="Last name"
+        type="text"
+        value={props.lastName}
+        setValue={props.setLastName}
+        error={firstError('lastName', props.formErrors)}
+      />
+      <InputWithLabel
+        id="email"
+        label="Email"
+        type="email"
+        value={props.email}
+      />
+    </div>
+  );
+}

--- a/support-frontend/assets/components/subscriptionCheckouts/personalDetailsGift.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/personalDetailsGift.jsx
@@ -7,9 +7,8 @@ import { withError } from 'hocs/withError';
 import { withLabel } from 'hocs/withLabel';
 import { Input } from 'components/forms/input';
 import type { FormError } from 'helpers/subscriptionsForms/validation';
+import { type FormField } from 'helpers/subscriptionsForms/formFields';
 
-
-export type FormFieldGift = 'firstNameGiftRecipient' | 'lastNameGiftRecipient' | 'emailGiftRecipient';
 
 export type PropTypes = {
   firstNameGiftRecipient: string,
@@ -18,7 +17,7 @@ export type PropTypes = {
   setLastNameGift: Function,
   emailGiftRecipient: string,
   setEmailGift: Function,
-  formErrors: FormError<FormFieldGift>[],
+  formErrors: FormError<FormField>[],
 }
 
 const InputWithLabel = withLabel(Input);

--- a/support-frontend/assets/components/subscriptionCheckouts/personalDetailsGift.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/personalDetailsGift.jsx
@@ -48,6 +48,7 @@ export default function PersonalDetailsGift(props: PropTypes) {
         type="emailGiftRecipient"
         value={props.emailGiftRecipient}
         setValue={props.setEmailGift}
+        optional
         error={firstError('emailGiftRecipient', props.formErrors)}
       />
     </div>

--- a/support-frontend/assets/components/subscriptionCheckouts/personalDetailsGift.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/personalDetailsGift.jsx
@@ -9,15 +9,16 @@ import { Input } from 'components/forms/input';
 import type { FormError } from 'helpers/subscriptionsForms/validation';
 
 
-export type FormField = 'firstName' | 'lastName' | 'email' | 'telephone';
+export type FormFieldGift = 'firstNameGiftRecipient' | 'lastNameGiftRecipient' | 'emailGiftRecipient';
 
 export type PropTypes = {
-  firstName: string,
-  setFirstName: Function,
-  lastName: string,
-  setLastName: Function,
-  email: string,
-  formErrors: FormError<FormField>[],
+  firstNameGiftRecipient: string,
+  setFirstNameGift: Function,
+  lastNameGiftRecipient: string,
+  setLastNameGift: Function,
+  emailGiftRecipient: string,
+  setEmailGift: Function,
+  formErrors: FormError<FormFieldGift>[],
 }
 
 const InputWithLabel = withLabel(Input);
@@ -27,26 +28,28 @@ export default function PersonalDetailsGift(props: PropTypes) {
   return (
     <div>
       <InputWithError
-        id="first-name"
+        id="firstNameGiftRecipient"
         label="First name"
         type="text"
-        value={props.firstName}
-        setValue={props.setFirstName}
-        error={firstError('firstName', props.formErrors)}
+        value={props.firstNameGiftRecipient}
+        setValue={props.setFirstNameGift}
+        error={firstError('firstNameGiftRecipient', props.formErrors)}
       />
       <InputWithError
-        id="last-name"
+        id="lastNameGiftRecipient"
         label="Last name"
         type="text"
-        value={props.lastName}
-        setValue={props.setLastName}
-        error={firstError('lastName', props.formErrors)}
+        value={props.lastNameGiftRecipient}
+        setValue={props.setLastNameGift}
+        error={firstError('lastNameGiftRecipient', props.formErrors)}
       />
-      <InputWithLabel
-        id="email"
+      <InputWithError
+        id="emailGiftRecipient"
         label="Email"
-        type="email"
-        value={props.email}
+        type="emailGiftRecipient"
+        value={props.emailGiftRecipient}
+        setValue={props.setEmailGift}
+        error={firstError('emailGiftRecipient', props.formErrors)}
       />
     </div>
   );

--- a/support-frontend/assets/helpers/subscriptionsForms/formActions.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/formActions.js
@@ -29,6 +29,10 @@ export type Action =
   | { type: 'SET_FIRST_NAME', firstName: string }
   | { type: 'SET_LAST_NAME', lastName: string }
   | { type: 'SET_TELEPHONE', telephone: string }
+  | { type: 'SET_TITLE_GIFT', titleGiftRecipient: Option<Title> }
+  | { type: 'SET_FIRST_NAME_GIFT', firstNameGiftRecipient: string }
+  | { type: 'SET_LAST_NAME_GIFT', lastNameGiftRecipient: string }
+  | { type: 'SET_EMAIL_GIFT', emailGiftRecipient: string }
   | { type: 'SET_COUNTRY_CHANGED', country: IsoCountry }
   | { type: 'SET_START_DATE', startDate: string }
   | { type: 'SET_BILLING_PERIOD', billingPeriod: BillingPeriod }
@@ -37,6 +41,7 @@ export type Action =
   | { type: 'SET_SUBMISSION_ERROR', error: ErrorReason }
   | { type: 'SET_FORM_SUBMITTED', formSubmitted: boolean }
   | { type: 'SET_BILLING_ADDRESS_IS_SAME', isSame: Option<boolean> }
+  | { type: 'SET_ORDER_IS_GIFT', orderIsAGift: Option<boolean>}
   | AddressAction
   | PayPalAction
   | DDAction;
@@ -62,6 +67,10 @@ const formActionCreators = {
   setFirstName: (firstName: string): Function => (setFormSubmissionDependentValue(() => ({ type: 'SET_FIRST_NAME', firstName }))),
   setLastName: (lastName: string): Function => (setFormSubmissionDependentValue(() => ({ type: 'SET_LAST_NAME', lastName }))),
   setTelephone: (telephone: string): Action => ({ type: 'SET_TELEPHONE', telephone }),
+  setTitleGift: (titleGiftRecipient: string): Action => ({ type: 'SET_TITLE_GIFT', titleGiftRecipient }),
+  setFirstNameGift: (firstNameGiftRecipient: string): Function => (setFormSubmissionDependentValue(() => ({ type: 'SET_FIRST_NAME_GIFT', firstNameGiftRecipient }))),
+  setLastNameGift: (lastNameGiftRecipient: string): Function => (setFormSubmissionDependentValue(() => ({ type: 'SET_LAST_NAME_GIFT', lastNameGiftRecipient }))),
+  setEmailGift: (emailGiftRecipient: string): Action => ({ type: 'SET_EMAIL_GIFT', emailGiftRecipient }),
   setStartDate: (startDate: string): Action => ({ type: 'SET_START_DATE', startDate }),
   setBillingPeriod: (billingPeriod: BillingPeriod): Action => ({ type: 'SET_BILLING_PERIOD', billingPeriod }),
   setPaymentMethod: (paymentMethod: PaymentMethod) => (dispatch: Dispatch<Action>, getState: () => CheckoutState) => {
@@ -91,7 +100,10 @@ const formActionCreators = {
         state.common.abParticipations,
       );
     },
-
+  setGiftStatus: (orderIsAGift: boolean | null): Action => ({
+    type: 'SET_ORDER_IS_GIFT',
+    orderIsAGift,
+  }),
 };
 
 export type FormActionCreators = typeof formActionCreators;

--- a/support-frontend/assets/helpers/subscriptionsForms/formFields.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/formFields.js
@@ -20,6 +20,10 @@ export type FormFields = {|
   lastName: string,
   email: string,
   telephone: Option<string>,
+  titleGiftRecipient: Option<Title>,
+  firstNameGiftRecipient: string,
+  lastNameGiftRecipient: string,
+  emailGiftRecipient: string,
   billingPeriod: BillingPeriod,
   paymentMethod: Option<PaymentMethod>,
   startDate: Option<string>,
@@ -27,6 +31,7 @@ export type FormFields = {|
   fulfilmentOption: FulfilmentOptions,
   product: SubscriptionProduct,
   productOption: ProductOptions,
+  orderIsAGift: Option<boolean>,
 |};
 
 export type FormField = $Keys<FormFields>;
@@ -48,9 +53,13 @@ function getFormFields(state: AnyCheckoutState): FormFields {
   return {
     title: state.page.checkout.title,
     firstName: state.page.checkout.firstName,
-    email: state.page.checkout.email,
     lastName: state.page.checkout.lastName,
+    email: state.page.checkout.email,
     telephone: state.page.checkout.telephone,
+    titleGiftRecipient: state.page.checkout.titleGiftRecipient,
+    firstNameGiftRecipient: state.page.checkout.firstNameGiftRecipient,
+    lastNameGiftRecipient: state.page.checkout.lastNameGiftRecipient,
+    emailGiftRecipient: state.page.checkout.emailGiftRecipient,
     startDate: state.page.checkout.startDate,
     billingPeriod: state.page.checkout.billingPeriod,
     paymentMethod: state.page.checkout.paymentMethod,
@@ -58,6 +67,7 @@ function getFormFields(state: AnyCheckoutState): FormFields {
     productOption: state.page.checkout.productOption,
     product: state.page.checkout.product,
     billingAddressIsSame: state.page.checkout.billingAddressIsSame,
+    orderIsAGift: state.page.checkout.orderIsAGift,
   };
 }
 

--- a/support-frontend/assets/helpers/subscriptionsForms/formReducer.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/formReducer.js
@@ -39,6 +39,10 @@ function createFormReducer(
     telephone: null,
     billingAddressIsSame: null,
     billingPeriod: initialBillingPeriod,
+    titleGiftRecipient: null,
+    firstNameGiftRecipient: '',
+    lastNameGiftRecipient: '',
+    emailGiftRecipient: '',
     paymentMethod: defaultPaymentMethod(initialCountry, product),
     formErrors: [],
     submissionError: null,
@@ -48,6 +52,7 @@ function createFormReducer(
     productOption: productOption || NoProductOptions,
     fulfilmentOption: fulfilmentOption || NoFulfilmentOptions,
     payPalHasLoaded: false,
+    orderIsAGift: false,
   };
 
 
@@ -69,6 +74,18 @@ function createFormReducer(
 
       case 'SET_TELEPHONE':
         return { ...state, telephone: action.telephone };
+
+      case 'SET_TITLE_GIFT':
+        return { ...state, titleGiftRecipient: action.titleGiftRecipient };
+
+      case 'SET_FIRST_NAME_GIFT':
+        return { ...state, firstNameGiftRecipient: action.firstNameGiftRecipient, formErrors: removeError('firstName', state.formErrors) };
+
+      case 'SET_LAST_NAME_GIFT':
+        return { ...state, lastNameGiftRecipient: action.lastNameGiftRecipient, formErrors: removeError('lastName', state.formErrors) };
+
+      case 'SET_EMAIL_GIFT':
+        return { ...state, emailGiftRecipient: action.emailGiftRecipient };
 
       case 'SET_START_DATE':
         return { ...state, startDate: action.startDate };
@@ -108,6 +125,9 @@ function createFormReducer(
       case 'SET_PAYPAL_HAS_LOADED':
         return { ...state, payPalHasLoaded: true };
 
+      case 'SET_ORDER_IS_GIFT':
+        return { ...state, orderIsAGift: action.orderIsAGift };
+
       default:
         return state;
     }
@@ -115,4 +135,3 @@ function createFormReducer(
 }
 
 export { createFormReducer };
-

--- a/support-frontend/assets/helpers/subscriptionsForms/formReducer.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/formReducer.js
@@ -85,7 +85,7 @@ function createFormReducer(
         return { ...state, lastNameGiftRecipient: action.lastNameGiftRecipient, formErrors: removeError('lastNameGiftRecipient', state.formErrors) };
 
       case 'SET_EMAIL_GIFT':
-        return { ...state, emailGiftRecipient: action.emailGiftRecipient, formErrors: removeError('emailGiftRecipient', state.formErrors) };
+        return { ...state, emailGiftRecipient: action.emailGiftRecipient };
 
       case 'SET_START_DATE':
         return { ...state, startDate: action.startDate };

--- a/support-frontend/assets/helpers/subscriptionsForms/formReducer.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/formReducer.js
@@ -79,13 +79,13 @@ function createFormReducer(
         return { ...state, titleGiftRecipient: action.titleGiftRecipient };
 
       case 'SET_FIRST_NAME_GIFT':
-        return { ...state, firstNameGiftRecipient: action.firstNameGiftRecipient, formErrors: removeError('firstName', state.formErrors) };
+        return { ...state, firstNameGiftRecipient: action.firstNameGiftRecipient, formErrors: removeError('firstNameGiftRecipient', state.formErrors) };
 
       case 'SET_LAST_NAME_GIFT':
-        return { ...state, lastNameGiftRecipient: action.lastNameGiftRecipient, formErrors: removeError('lastName', state.formErrors) };
+        return { ...state, lastNameGiftRecipient: action.lastNameGiftRecipient, formErrors: removeError('lastNameGiftRecipient', state.formErrors) };
 
       case 'SET_EMAIL_GIFT':
-        return { ...state, emailGiftRecipient: action.emailGiftRecipient };
+        return { ...state, emailGiftRecipient: action.emailGiftRecipient, formErrors: removeError('emailGiftRecipient', state.formErrors) };
 
       case 'SET_START_DATE':
         return { ...state, startDate: action.startDate };

--- a/support-frontend/assets/helpers/subscriptionsForms/rules.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/rules.js
@@ -29,10 +29,6 @@ function applyCheckoutRules(fields: FormFields): FormError<FormField>[] {
       rule: nonEmptyString(fields.lastNameGiftRecipient),
       error: formError('lastNameGiftRecipient', 'Please enter the recipient\'s last name.'),
     },
-    {
-      rule: nonEmptyString(fields.emailGiftRecipient),
-      error: formError('emailGiftRecipient', 'Please enter the recipient\'s email address.'),
-    },
   ];
   const formFieldsToCheck = orderIsAGift ?
     [...userFormFields, ...giftFormFields]

--- a/support-frontend/assets/helpers/subscriptionsForms/rules.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/rules.js
@@ -5,20 +5,40 @@ import type { FormField, FormFields } from './formFields';
 import type { FormError } from './validation';
 
 function applyCheckoutRules(fields: FormFields): FormError<FormField>[] {
-  return validate([
+  const { orderIsAGift } = fields;
+  const userFormFields = [
     {
       rule: nonEmptyString(fields.firstName),
-      error: formError('firstName', 'Please enter a value.'),
+      error: formError('firstName', 'Please enter a first name.'),
     },
     {
       rule: nonEmptyString(fields.lastName),
-      error: formError('lastName', 'Please enter a value.'),
+      error: formError('lastName', 'Please enter a last name.'),
     },
     {
       rule: notNull(fields.paymentMethod),
       error: formError('paymentMethod', 'Please select a payment method.'),
     },
-  ]);
+  ];
+  const giftFormFields = [
+    {
+      rule: nonEmptyString(fields.firstNameGiftRecipient),
+      error: formError('firstNameGiftRecipient', 'Please enter the recipient\'s first name.'),
+    },
+    {
+      rule: nonEmptyString(fields.lastNameGiftRecipient),
+      error: formError('lastNameGiftRecipient', 'Please enter the recipient\'s last name.'),
+    },
+    {
+      rule: nonEmptyString(fields.emailGiftRecipient),
+      error: formError('emailGiftRecipient', 'Please enter the recipient\'s email address.'),
+    },
+  ];
+  const formFieldsToCheck = orderIsAGift ?
+    [...userFormFields, ...giftFormFields]
+    : [...userFormFields];
+
+  return validate(formFieldsToCheck);
 }
 
 function applyDeliveryRules(fields: FormFields): FormError<FormField>[] {

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -41,7 +41,7 @@ import {
   type FormFields,
   getFormFields,
 } from 'helpers/subscriptionsForms/formFields';
-import type { FormField as PersonalDetailsFormField } from 'components/subscriptionCheckouts/personalDetails';
+import { type FormField as PersonalDetailsFormField } from 'helpers/subscriptionsForms/formFields';
 import PersonalDetails from 'components/subscriptionCheckouts/personalDetails';
 import CancellationSection
   from 'components/subscriptionCheckouts/cancellationSection';

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/checkoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/checkoutForm.jsx
@@ -52,7 +52,7 @@ import {
 
 import { withStore } from 'components/subscriptionCheckouts/address/addressFields';
 import GridImage from 'components/gridImage/gridImage';
-import type { FormField as PersonalDetailsFormField } from 'components/subscriptionCheckouts/personalDetails';
+import { type FormField as PersonalDetailsFormField } from 'helpers/subscriptionsForms/formFields';
 import PersonalDetails from 'components/subscriptionCheckouts/personalDetails';
 import { PaymentMethodSelector } from 'components/subscriptionCheckouts/paymentMethodSelector';
 import CancellationSection

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -37,8 +37,7 @@ import {
 import { titles } from 'helpers/user/details';
 import { withStore } from 'components/subscriptionCheckouts/address/addressFields';
 import GridImage from 'components/gridImage/gridImage';
-import type { FormField as PersonalDetailsFormField } from 'components/subscriptionCheckouts/personalDetails';
-import type { FormFieldGift as PersonalDetailsGiftFormField } from 'components/subscriptionCheckouts/personalDetailsGift';
+import { type FormField as PersonalDetailsFormField } from 'helpers/subscriptionsForms/formFields';
 import PersonalDetails from 'components/subscriptionCheckouts/personalDetails';
 import PersonalDetailsGift from 'components/subscriptionCheckouts/personalDetailsGift';
 import type { IsoCountry } from 'helpers/internationalisation/country';
@@ -213,7 +212,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
                   setLastNameGift={props.setLastNameGift}
                   emailGiftRecipient={props.emailGiftRecipient}
                   setEmailGift={props.setEmailGift}
-                  formErrors={((props.formErrors: any): FormError<PersonalDetailsGiftFormField>[])}
+                  formErrors={((props.formErrors: any): FormError<PersonalDetailsFormField>[])}
                   isGiftRecipient
                 />
               </FormSection>

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -123,6 +123,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
   const fulfilmentOption = getFulfilmentOption(props.deliveryCountry);
   const price = regularPrice(props.productPrices, props.billingCountry, props.billingPeriod, fulfilmentOption);
   const promotion = getPromotion(props.productPrices, props.billingCountry, props.billingPeriod, fulfilmentOption);
+  const subscriptionStart = `When would you like ${props.orderIsAGift ? 'the' : 'your'} subscription to start?`;
 
   return (
     <Content modifierClasses={['your-details']}>
@@ -252,9 +253,9 @@ function WeeklyCheckoutForm(props: PropTypes) {
               </FormSection>
             : null
           }
-          <FormSection title={`When would you like ${props.orderIsAGift ? 'the' : 'your'} subscription to start?`}>
+          <FormSection title={subscriptionStart}>
             <Rows>
-              <FieldsetWithError id="startDate" error={firstError('startDate', props.formErrors)} legend="When would you like your subscription to start?">
+              <FieldsetWithError id="startDate" error={firstError('startDate', props.formErrors)} legend={subscriptionStart}>
                 {days.map((day) => {
                   const [userDate, machineDate] = [formatUserDate(day), formatMachineDate(day)];
                   return (

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -38,6 +38,7 @@ import { titles } from 'helpers/user/details';
 import { withStore } from 'components/subscriptionCheckouts/address/addressFields';
 import GridImage from 'components/gridImage/gridImage';
 import type { FormField as PersonalDetailsFormField } from 'components/subscriptionCheckouts/personalDetails';
+import type { FormFieldGift as PersonalDetailsGiftFormField } from 'components/subscriptionCheckouts/personalDetailsGift';
 import PersonalDetails from 'components/subscriptionCheckouts/personalDetails';
 import PersonalDetailsGift from 'components/subscriptionCheckouts/personalDetailsGift';
 import type { IsoCountry } from 'helpers/internationalisation/country';
@@ -206,13 +207,13 @@ function WeeklyCheckoutForm(props: PropTypes) {
                   {options(titles)}
                 </SelectWithLabel>
                 <PersonalDetailsGift
-                  firstName={props.firstNameGiftRecipient}
-                  setFirstName={props.setFirstNameGift}
-                  lastName={props.lastNameGiftRecipient}
-                  setLastName={props.setLastNameGift}
-                  email={props.emailGiftRecipient}
+                  firstNameGiftRecipient={props.firstNameGiftRecipient}
+                  setFirstNameGift={props.setFirstNameGift}
+                  lastNameGiftRecipient={props.lastNameGiftRecipient}
+                  setLastNameGift={props.setLastNameGift}
+                  emailGiftRecipient={props.emailGiftRecipient}
                   setEmailGift={props.setEmailGift}
-                  formErrors={((props.formErrors: any): FormError<PersonalDetailsFormField>[])}
+                  formErrors={((props.formErrors: any): FormError<PersonalDetailsGiftFormField>[])}
                   isGiftRecipient
                 />
               </FormSection>


### PR DESCRIPTION
## Why are you doing this?
The intention is that users can give Guardian Weekly as a gift, and specify this in the checkout.

There are a number of assumptions underpinning the changes, which are listed in the [**Trello Card**](https://trello.com/c/JwbDPHwv/2412-gifting-in-gw-checkout-frontend)

## Changes
* There's a checkbox that users can select that indicates the order is a gift
* Users who select 6 for 6 won't see the gifting option
* Users who select the gifting option won't see 6 for 6 as an alternative option further down in the checkout
* When the user checks the gifting box, additional fields appear asking for the gift recipient's details and a form for the recipient's address (aka the delivery address). There's still a section asking if billing is the same as delivery address, but the wording is slightly different to reflect that delivery is to a gift recipient.

It's worth noting that as a result of Rupert's work, the delivery cost is determined by the delivery country, but the currency is determined by the billing country.

## Work that's out of scope
There's additional business logic to be applied to the checkout around the billing period selected by the user and which other options should be visible in the checkout (ie if the user has selected Quarterly in the landing page, we don't show 6 for 6 as an option in the checkout).

## Not a gift (screenshots)

![Screen Shot 2019-06-04 at 14 36 57](https://user-images.githubusercontent.com/16781258/58883404-46c5c400-86d6-11e9-8a3b-747365f46a1d.png)
...
...
...
![Screen Shot 2019-06-04 at 14 43 05](https://user-images.githubusercontent.com/16781258/58883831-1e8a9500-86d7-11e9-902a-3abc5180840f.png)

## Gift (screenshots)
![Screen Shot 2019-06-04 at 14 41 02](https://user-images.githubusercontent.com/16781258/58883688-d3708200-86d6-11e9-872e-4b4be2a3e49e.png)
![Screen Shot 2019-06-04 at 14 36 09](https://user-images.githubusercontent.com/16781258/58883435-547b4980-86d6-11e9-9226-d7cd9fc23588.png)
...
...
...
![Screen Shot 2019-06-05 at 10 42 46](https://user-images.githubusercontent.com/16781258/58946864-b2fc0280-877e-11e9-8803-ceea8ee2620f.png)