### PR TITLE
support latency metric should be on ApplicationELB not ELB

### DIFF
--- a/support-frontend/cloud-formation/cfn.yaml
+++ b/support-frontend/cloud-formation/cfn.yaml
@@ -356,7 +356,7 @@ Resources:
           Value: !GetAtt ElasticLoadBalancer.LoadBalancerFullName
         - Name: TargetGroup
           Value: !GetAtt TargetGroup.TargetGroupFullName
-      Namespace: AWS/ELB
+      Namespace: AWS/ApplicationELB
       EvaluationPeriods: 2
       Period: 60
       Statistic: Average


### PR DESCRIPTION
## Why are you doing this?

I shipped https://github.com/guardian/support-frontend/pull/1854 but the latency alarm wasn't showing data, because I copied it from an ELB one and forgot to change the type.  This PR fixes that!

correct one is this metric:
![image](https://user-images.githubusercontent.com/7304387/58964720-421d1080-87a7-11e9-8ecf-9e13b8ca1780.png)

and this is the one in the alarm
![image](https://user-images.githubusercontent.com/7304387/58964537-fbc7b180-87a6-11e9-8b79-2d54590ca859.png)
