### PR TITLE
Remove Object.values

### DIFF
--- a/support-frontend/assets/components/headers/roundelHeader/header.jsx
+++ b/support-frontend/assets/components/headers/roundelHeader/header.jsx
@@ -52,7 +52,11 @@ function RoundelHeader(props: PropTypes) {
             </div>
           </summary>
           <ul className="countryGroups__list">
-            {(Object.values(countryGroups): any).map(renderCountryGroup((props.selectedCountryGroup: any)))}
+            {
+              Object.keys(countryGroups)
+                .map(countryGroup => countryGroups[countryGroup])
+                .map(renderCountryGroup((props.selectedCountryGroup: any)))
+            }
           </ul>
         </details>
       ) : null}

--- a/support-frontend/assets/helpers/fontLoader.js
+++ b/support-frontend/assets/helpers/fontLoader.js
@@ -31,7 +31,7 @@ const fetchFonts = (window: Object, document: Document): void => {
     const fonts = storage.getLocal('guFonts');
     if (fonts) {
       const fontsObject = JSON.parse(fonts);
-      const values = Object.values(fontsObject);
+      const values = Object.keys(fontsObject).map(font => fontsObject[font]);
       values.forEach((value) => {
         if (value instanceof Object && value.fontName && value.css) {
           useFont(value);


### PR DESCRIPTION
## Why are you doing this?
We were getting Sentry errors, proclaiming that `Object.values is not a function`. 

Object.values is not supported by all browsers,  [see here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/values)

Luckily, we only use it twice, so we can just replace them with a slightly more verbose `Object.keys` then `map`

