### PR TITLE
Missing comma on thank you page

### DIFF
--- a/support-frontend/assets/components/marketingConsentNew/marketingConsent.jsx
+++ b/support-frontend/assets/components/marketingConsentNew/marketingConsent.jsx
@@ -86,7 +86,7 @@ function MarketingConsent(props: PropTypes) {
       <section className={classNameWithModifiers('component-marketing-consent', ['newsletter'])}>
         {props.render({
           title: 'Contributions, subscriptions and membership',
-          message: 'Get related news and offers – whether you are a contributor subscriber, member or would like to become one',
+          message: 'Get related news and offers – whether you are a contributor, subscriber, member or would like to become one',
         })}
 
         {MarketingButton({


### PR DESCRIPTION
## Why are you doing this?
Grammar police 🚓 

Also an observation: we're using different messaging here to the standard supporter marketing consent - but the guidance is generally to be as consistent as possible, because there is a legal requirement to know what text was shown to a user when they consented.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Changes

Added a comma.

## Screenshots

