### PR TITLE
use dev-nginx for setting up nginx in DEV

### DIFF
--- a/support-frontend/nginx/Brewfile
+++ b/support-frontend/nginx/Brewfile
@@ -1,0 +1,2 @@
+tap "guardian/devtools"
+brew "guardian/devtools/dev-nginx"

--- a/support-frontend/nginx/README.md
+++ b/support-frontend/nginx/README.md
@@ -1,32 +1,20 @@
 # Support™ NGINX
 
-## Setup Nginx for `Identity-Platform`
-
-Support™ depends on Identity, so **you'll need to perform the**
-[**Nginx setup for identity-platform**](https://github.com/guardian/identity-platform/blob/master/README.md#setup-nginx-for-local-development)
-**first**, before you do anything else.
-
-## Support-specific setup
-
-#### Update your hosts file
-
-Add the following local development domain to your hosts file in `/etc/hosts`:
-
-```
-127.0.0.1   support.thegulocal.com
+- Install dependencies:
+```bash
+brew tap "guardian/devtools"
+brew install "guardian/devtools/dev-nginx"
 ```
 
-#### Run Support's Nginx setup script
-
-Run the Support-specific [setup.sh](setup.sh) script from the root
-of the `support-frontend` project:
+Or from the `nginx` directory:
+```bash
+brew bundle
+```
+- Run [setup.sh](setup.sh) script from the root of the `support-frontend` project:
 
 ```
 ./nginx/setup.sh
 ```
-
-The script doesn't start Nginx. To manually start it run `sudo nginx` or `sudo systemctl start nginx`
-depending on your system.
 
 #### NGINX error messages
 

--- a/support-frontend/nginx/setup.sh
+++ b/support-frontend/nginx/setup.sh
@@ -11,7 +11,6 @@ DOMAINS=(
 
 for domain in ${DOMAINS[@]}; do
   dev-nginx setup-cert $domain
-  dev-nginx add-to-hosts-file $domain
 done
 
 dev-nginx link-config ${SITE_CONFIG}

--- a/support-frontend/nginx/setup.sh
+++ b/support-frontend/nginx/setup.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 DOMAIN=support.thegulocal.com
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SITE_CONFIG=${DIR}/support.conf

--- a/support-frontend/nginx/setup.sh
+++ b/support-frontend/nginx/setup.sh
@@ -1,9 +1,18 @@
-#!/bin/bash -x
+#!/usr/bin/env bash
 
+DOMAIN=support.thegulocal.com
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-NGINX_HOME=$(nginx -V 2>&1 | grep 'configure arguments:' | sed 's#.*conf-path=\([^ ]*\)/nginx\.conf.*#\1#g')
+SITE_CONFIG=${DIR}/support.conf
 
-echo "\n\nUsing NGINX_HOME=$NGINX_HOME"
+DOMAINS=(
+  "support.thegulocal.com"
+  "support-ui.thegulocal.com"
+)
 
-sudo mkdir -p $NGINX_HOME/sites-enabled
-sudo ln -fs $DIR/support.conf $NGINX_HOME/sites-enabled/support.conf
+for domain in ${DOMAINS[@]}; do
+  dev-nginx setup-cert $domain
+  dev-nginx add-to-hosts-file $domain
+done
+
+dev-nginx link-config ${SITE_CONFIG}
+dev-nginx restart-nginx

--- a/support-frontend/nginx/support.conf
+++ b/support-frontend/nginx/support.conf
@@ -2,8 +2,8 @@ server {
     listen 443 ssl;
     server_name support.thegulocal.com;
 
-    ssl_certificate STAR_thegulocal_com_exp2020-01-09.crt; ## Supplied by https://github.com/guardian/identity-platform#setup-nginx-for-local-development
-    ssl_certificate_key STAR_thegulocal_com_exp2020-01-09.key; ## ditto
+    ssl_certificate support.thegulocal.com.crt;
+    ssl_certificate_key support.thegulocal.com.key;
 
     ssl_prefer_server_ciphers on;
 
@@ -39,8 +39,8 @@ server {
     listen 443 ssl;
     server_name support-ui.thegulocal.com;
 
-    ssl_certificate STAR_thegulocal_com_exp2020-01-09.crt; ## Supplied by https://github.com/guardian/identity-platform#setup-nginx-for-local-development
-    ssl_certificate_key STAR_thegulocal_com_exp2020-01-09.key; ## ditto
+    ssl_certificate support-ui.thegulocal.com.crt;
+    ssl_certificate_key support-ui.thegulocal.com.key;
 
     ssl_prefer_server_ciphers on;
 

--- a/support-frontend/setup.sh
+++ b/support-frontend/setup.sh
@@ -133,16 +133,6 @@ install_js_deps() {
   yarn install
 }
 
-fetch_dev_cert() {
-  aws s3 cp s3://identity-local-ssl/STAR_thegulocal_com_exp2020-01-09.crt ${NGINX_ROOT} --profile membership
-  aws s3 cp s3://identity-local-ssl/STAR_thegulocal_com_exp2020-01-09.key ${NGINX_ROOT} --profile membership
-}
-
-link_nginx_config() {
-  mkdir -p ${NGINX_ROOT}sites-enabled
-  ln -sf ${PWD}/nginx/support.conf ${NGINX_ROOT}sites-enabled/support.conf
-}
-
 report() {
   if [[ ${#EXTRA_STEPS[@]} -gt 0 ]]; then
     for i in "${!EXTRA_STEPS[@]}"; do
@@ -158,8 +148,6 @@ main () {
   install_homebrew
   install_nginx
   install_awscli
-  fetch_dev_cert
-  link_nginx_config
   install_jdk
   install_sbt
   install_yarn


### PR DESCRIPTION
## Why are you doing this?
dev-nginx contains a number of generic useful scripts to:
- issue certs locally (and automatically trust them)
- edit hosts file
- symlink nginx configs
- restart nginx

Using dev-nginx means:
- we're creating certificates locally, valid only to a single machine
- we do not need to update certs every year as they expire (https://github.com/guardian/support-frontend/pull/1355), we just need to re-run the script when certs expire
- we do not need an S3 bucket holding certs for local dev

Depends on:
- https://github.com/guardian/dev-nginx/pull/5
- https://github.com/guardian/homebrew-devtools/pull/35
- https://github.com/guardian/dev-nginx/pull/7

We probably could move to using [`setup-app`](https://github.com/guardian/dev-nginx/blob/master/README.md#setup-app) too, removing the `support.conf` file. However it's probably best to make small changes.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/EhggXPfo/2148-investigate-using-mkcert-for-local-certificates)

## Changes

* Change 1 - erm, see above?
* Change 2 - see change 1

## Screenshots
n/a