### PR TITLE
Be explicit when string is empty

### DIFF
--- a/support-frontend/assets/helpers/tracking/ophanComponentEventTracking.js
+++ b/support-frontend/assets/helpers/tracking/ophanComponentEventTracking.js
@@ -121,7 +121,7 @@ const trackPolyfilledObjectFunction = (when: 'beforePolyfill' | 'afterPolyfill',
   gaEvent({
     category: 'debug',
     action: when,
-    label: objectFunction,
+    label: objectFunction || 'none',
   });
 
   trackComponentEvents({
@@ -130,7 +130,7 @@ const trackPolyfilledObjectFunction = (when: 'beforePolyfill' | 'afterPolyfill',
       id: when,
     },
     action: 'CLICK',
-    value: objectFunction,
+    value: objectFunction || 'none',
   });
 };
 


### PR DESCRIPTION
It's coming through sometimes as `(not set)` in GA, which I'm 90% certain is when we pass an empty string.... but I want to be 100% certain