### PR TITLE
Replace Object.entries with Object.keys

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/ContributionState.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionState.jsx
@@ -28,13 +28,12 @@ const mapStateToProps = (state: State) => ({
 });
 
 // ----- Render ----- //
-
-const renderState = (selectedState: CaState | UsState | null) => ([stateValue, stateName]: [string, string]) => (
-  <option value={stateValue} selected={selectedState === stateValue}>{stateName}</option>
+const renderState = (selectedState: CaState | UsState | null) => (state: {abbreviation: string, name: string}) => (
+  <option value={state.abbreviation} selected={selectedState === state.abbreviation}>{state.name}</option>
 );
 
 const renderStatesField = (
-  states: { [string]: string },
+  states: {[string]: string},
   selectedState: UsState | CaState | null,
   onChange: (Event => void) | false,
   showError: boolean,
@@ -49,7 +48,9 @@ const renderStatesField = (
     <span className="form__input-with-icon">
       <select id="contributionState" className={classNameWithModifiers('form__input', selectedState ? [] : ['placeholder'])} onChange={onChange} required>
         <option value="">Please select your {label.toLowerCase()}</option>
-        {(Object.entries(states): any).map(renderState(selectedState))}
+        {Object.keys(states)
+          .map(key => ({abbreviation: key, name: states[key]}))
+          .map(renderState(selectedState))}
       </select>
       <span className="form__icon">
         <SvgGlobe />


### PR DESCRIPTION
Until we understand why/when our polyfill isn't working, we're going to be defensive about our use of `Object.entries` and `Object.values` which are the ones throwing Sentry errors.

There are other uses of `Object.entries` in the codebase, but they're in storybook or build pipeline code, not code executed in users' browsers