### PR TITLE
Try polyfill v3

### DIFF
--- a/support-frontend/app/views/main.scala.html
+++ b/support-frontend/app/views/main.scala.html
@@ -148,7 +148,7 @@
     </script>
     <script
       id="polyfill-script"
-      src="https://polyfill.io/v2/polyfill.min.js?features=default,Array.prototype.find,fetch,Array.prototype.includes,Number.isInteger,Object.values,Object.entries"
+      src="https://polyfill.io/v3/polyfill.min.js?features=default,Array.prototype.find,fetch,Array.prototype.includes,Number.isInteger,Object.values,Object.entries"
       onload="polyfillOnLoad()"
       onerror="polyfillOnError()"
       onabort="polyfillOnAbort()"

--- a/support-frontend/assets/helpers/tracking/ophanComponentEventTracking.js
+++ b/support-frontend/assets/helpers/tracking/ophanComponentEventTracking.js
@@ -110,7 +110,7 @@ const trackPolyfillScriptStatus = (polyfillScriptStatus: string): void => {
   trackComponentEvents({
     component: {
       componentType: 'ACQUISITIONS_OTHER',
-      id: 'polyfill-script-status',
+      id: 'polyfill-v3-script-status',
     },
     action: 'CLICK',
     value: polyfillScriptStatus || 'empty',
@@ -120,14 +120,14 @@ const trackPolyfillScriptStatus = (polyfillScriptStatus: string): void => {
 const trackPolyfilledObjectFunction = (when: 'beforePolyfill' | 'afterPolyfill', objectFunction: string): void => {
   gaEvent({
     category: 'debug',
-    action: when,
+    action: `${when}-v3`,
     label: objectFunction || 'none',
   });
 
   trackComponentEvents({
     component: {
       componentType: 'ACQUISITIONS_OTHER',
-      id: when,
+      id: `${when}-v3`,
     },
     action: 'CLICK',
     value: objectFunction || 'none',

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
@@ -46,7 +46,7 @@ const store = pageInit(() => initReducer(countryGroupId), true);
 trackPolyfilledObjectFunctions();
 gaEvent({
   category: 'debug',
-  action: 'polyfill-script-status',
+  action: 'polyfill-v3-script-status',
   label: polyfillSuccess || 'empty'
 });
 


### PR DESCRIPTION
We're seeing about 6 cases per half an hour where, even after the polyfill script loads, `Object.values` and `Object.entries` are not available. Extrapolating to a day, this accounts for the number of sentry errors we were seeing for `Object.values is not a function` (approx 250 - 350 per day)

I noticed v3 is actually the latest version. So I thought I'd try that and see if the problematic cases go away.

I've renamed the events so we can clearly distinguish ones from browser using the v3 polyfill