### PR TITLE
Cache list of promotions in memory

### DIFF
--- a/support-services/build.sbt
+++ b/support-services/build.sbt
@@ -13,5 +13,6 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-generic-extras" % circeVersion,
   "io.circe" %% "circe-parser" % circeVersion,
-  "com.squareup.okhttp3" % "okhttp" % okhttpVersion
+  "com.squareup.okhttp3" % "okhttp" % okhttpVersion,
+  "org.scala-stm" %% "scala-stm" % "0.8",
 )

--- a/support-services/src/main/scala/com/gu/support/promotions/PromotionCache.scala
+++ b/support-services/src/main/scala/com/gu/support/promotions/PromotionCache.scala
@@ -1,0 +1,23 @@
+package com.gu.support.promotions
+
+import com.gu.monitoring.SafeLogger
+import org.joda.time.{DateTime, Minutes}
+
+import scala.concurrent.stm.{Ref, atomic}
+
+case class PromotionCache(fetched: DateTime, promotions: Iterable[Promotion]){
+  def isFresh: Boolean = DateTime.now.getMillis - fetched.getMillis < PromotionCache.maxAge
+}
+
+object PromotionCache {
+  val maxAge = Minutes.ONE.toStandardDuration.getMillis
+
+  val promotionsRef = Ref[Option[PromotionCache]](None)
+
+  def get: Option[Iterable[Promotion]] = promotionsRef.single().filter(_.isFresh).map(_.promotions)
+
+  def set(promotions: Iterable[Promotion], fetched: DateTime = DateTime.now): Unit = atomic { implicit txn =>
+    SafeLogger.info(s"Adding promotions to the cache")
+    promotionsRef() = Some(PromotionCache(fetched, promotions))
+  }
+}

--- a/support-services/src/main/scala/com/gu/support/promotions/PromotionCollection.scala
+++ b/support-services/src/main/scala/com/gu/support/promotions/PromotionCollection.scala
@@ -15,3 +15,15 @@ class DynamoPromotionCollection(config: PromotionsTablesConfig) extends
   DynamoService[Promotion](DynamoTables.getTable(config.promotions)) with
   PromotionCollection
 
+class CachedDynamoPromotionCollection(config: PromotionsTablesConfig) extends
+  DynamoPromotionCollection(config) with PromotionCollection {
+
+  override def all: Iterator[Promotion] = PromotionCache.get.getOrElse(fetchAndCache).toIterator
+
+  private def fetchAndCache = {
+    val promotions = super.all.toList
+    PromotionCache.set(promotions)
+    promotions
+  }
+}
+

--- a/support-services/src/main/scala/com/gu/support/promotions/PromotionService.scala
+++ b/support-services/src/main/scala/com/gu/support/promotions/PromotionService.scala
@@ -9,7 +9,7 @@ import com.gu.support.zuora.api.SubscriptionData
 import com.typesafe.scalalogging.LazyLogging
 
 class PromotionService(config: PromotionsConfig, maybeCollection: Option[PromotionCollection] = None) extends TouchpointService with LazyLogging {
-  val promotionCollection = maybeCollection.getOrElse(new DynamoPromotionCollection(config.tables))
+  val promotionCollection = maybeCollection.getOrElse(new CachedDynamoPromotionCollection(config.tables))
 
   //This is a small hack to allow us to start using promotions to handle 6 for 6 without having to build the tooling
   private def allWith6For6 = promotionCollection.all.toList :+ Promotions.SixForSixPromotion

--- a/support-services/src/test/scala/com/gu/support/promotions/PromotionCacheSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/promotions/PromotionCacheSpec.scala
@@ -1,0 +1,17 @@
+package com.gu.support.promotions
+
+import org.joda.time.DateTime
+import org.scalatest.{FlatSpec, Matchers}
+
+class PromotionCacheSpec extends FlatSpec with Matchers {
+
+  "PromotionCache" should "return cached promotions when they are fresh" in {
+    PromotionCache.set(Nil)
+    PromotionCache.get shouldBe Some(Nil)
+  }
+
+  it should "return None if they are stale" in {
+    PromotionCache.set(Nil, DateTime.now().minusSeconds(61))
+    PromotionCache.get shouldBe None
+  }
+}


### PR DESCRIPTION
## Why are you doing this?

To lookup promo codes we currently need to do a full scan of the Dynamo DB table where they are stored. This is because the promo code itself is within a Json blob that needs to be deserialised before we can search against it. 

This causes scalability issues on uncached pages, so to prevent these we want to cache the deserialised promotions in memory and search against those rather than hitting Dynamo every time.

To avoid threading issues I am using [Scala-STM](https://nbronson.github.io/scala-stm/) to manage the cached promotions and initially I am caching the promotions for 1 minute.