### PR TITLE
Subs landing page post deployment test

### DIFF
--- a/support-frontend/assets/components/subscriptionsByCountryGroup/subscriptionsByCountryGroup.jsx
+++ b/support-frontend/assets/components/subscriptionsByCountryGroup/subscriptionsByCountryGroup.jsx
@@ -76,7 +76,7 @@ function SubscriptionsByCountryGroup(props: PropTypes) {
 
   if (countryGroupId === GBPCountries) {
     return (
-      <div className={className} {...otherProps}>
+      <div id='qa-component-subscriptions-by-country-group' className={className} {...otherProps}>
         <DigitalSection
           headingSize={headingSize}
           subsLinks={subsLinks}

--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -34,7 +34,7 @@ libraryDependencies ++= Seq(
   "com.google.guava" % "guava" % "25.0-jre",
   "com.netaporter" %% "scala-uri" % "0.4.16",
   "com.gu" %% "play-googleauth" % "0.7.6",
-  "io.github.bonigarcia" % "webdrivermanager" % "2.1.0" % "test",
+  "io.github.bonigarcia" % "webdrivermanager" % "3.3.0" % "test",
   "org.seleniumhq.selenium" % "selenium-java" % "3.8.1" % "test",
   "com.squareup.okhttp3" % "okhttp" % "3.9.0",
   "com.gocardless" % "gocardless-pro" % "2.8.0",

--- a/support-frontend/test/selenium/subscriptions/LandingPagesSpec.scala
+++ b/support-frontend/test/selenium/subscriptions/LandingPagesSpec.scala
@@ -3,7 +3,7 @@ package selenium.subscriptions
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.{Minute, Seconds, Span}
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FeatureSpec, GivenWhenThen}
-import selenium.subscriptions.pages.{PaperSubs, WeeklySubs}
+import selenium.subscriptions.pages.{DigitalPackSubs, PaperSubs, ProductPage, SubsLandingPage, WeeklySubs}
 import selenium.util._
 
 class LandingPagesSpec extends FeatureSpec with GivenWhenThen with BeforeAndAfter with BeforeAndAfterAll with Browser with Eventually {
@@ -24,28 +24,36 @@ class LandingPagesSpec extends FeatureSpec with GivenWhenThen with BeforeAndAfte
 
   feature("Paper landing page") {
     scenario("Basic loading") {
-
-      val paperSubsPage = new PaperSubs()
-
-      Given("that a user goes to the page")
-      goTo(paperSubsPage)
-      Then("it should display")
-      assert(paperSubsPage.pageHasLoaded)
+      testPageLoads(new PaperSubs())
 
     }
   }
 
   feature("Weekly landing page") {
     scenario("Basic loading") {
-
-      val weeklySubsPage = new WeeklySubs()
-
-      Given("that a user goes to the page")
-      goTo(weeklySubsPage)
-      Then("it should display")
-      assert(weeklySubsPage.pageHasLoaded)
+      testPageLoads(new WeeklySubs())
 
     }
+  }
+
+  feature("Subscriptions landing page") {
+    scenario("Basic loading") {
+      testPageLoads(new SubsLandingPage())
+    }
+  }
+
+  feature("Digital Pack landing page") {
+    scenario("Basic loading") {
+      testPageLoads(new DigitalPackSubs())
+    }
+  }
+
+
+  def testPageLoads(page: ProductPage): Unit ={
+    Given("that a user goes to the page")
+    goTo(page)
+    Then("it should display")
+    assert(page.pageHasLoaded)
   }
 
 

--- a/support-frontend/test/selenium/subscriptions/pages/DigitalPackSubs.scala
+++ b/support-frontend/test/selenium/subscriptions/pages/DigitalPackSubs.scala
@@ -4,14 +4,14 @@ import org.openqa.selenium.WebDriver
 import org.scalatest.selenium.Page
 import selenium.util.{Browser, Config}
 
-class WeeklySubs(implicit val webDriver: WebDriver) extends Page with Browser with ProductPage {
+class DigitalPackSubs(implicit val webDriver: WebDriver) extends Page with Browser with ProductPage {
 
-  val url = s"${Config.supportFrontendUrl}/uk/subscribe/weekly"
+  val url = s"${Config.supportFrontendUrl}/uk/subscribe/digital"
 
   private val header = className("component-heading-block")
 
   def pageHasLoaded: Boolean = {
-    pageHasElement(header) && pageHasUrl(s"/uk/subscribe/weekly")
+    pageHasElement(header) && pageHasUrl(s"/uk/subscribe/digital")
   }
 
 }

--- a/support-frontend/test/selenium/subscriptions/pages/PaperSubs.scala
+++ b/support-frontend/test/selenium/subscriptions/pages/PaperSubs.scala
@@ -4,7 +4,7 @@ import org.openqa.selenium.WebDriver
 import org.scalatest.selenium.Page
 import selenium.util.{Browser, Config}
 
-class PaperSubs(implicit val webDriver: WebDriver) extends Page with Browser {
+class PaperSubs(implicit val webDriver: WebDriver) extends Page with Browser with ProductPage {
 
   val url = s"${Config.supportFrontendUrl}/uk/subscribe/paper"
 

--- a/support-frontend/test/selenium/subscriptions/pages/ProductPage.scala
+++ b/support-frontend/test/selenium/subscriptions/pages/ProductPage.scala
@@ -1,0 +1,7 @@
+package selenium.subscriptions.pages
+
+import org.scalatest.selenium.Page
+
+trait ProductPage extends Page {
+  def pageHasLoaded: Boolean
+}

--- a/support-frontend/test/selenium/subscriptions/pages/SubsLandingPage.scala
+++ b/support-frontend/test/selenium/subscriptions/pages/SubsLandingPage.scala
@@ -4,14 +4,14 @@ import org.openqa.selenium.WebDriver
 import org.scalatest.selenium.Page
 import selenium.util.{Browser, Config}
 
-class WeeklySubs(implicit val webDriver: WebDriver) extends Page with Browser with ProductPage {
+class SubsLandingPage(implicit val webDriver: WebDriver) extends Page with Browser with ProductPage {
 
-  val url = s"${Config.supportFrontendUrl}/uk/subscribe/weekly"
+  val url = s"${Config.supportFrontendUrl}/uk/subscribe"
 
   private val header = className("component-heading-block")
 
   def pageHasLoaded: Boolean = {
-    pageHasElement(header) && pageHasUrl(s"/uk/subscribe/weekly")
+    pageHasElement(header) && pageHasUrl(s"/uk/subscribe")
   }
 
 }

--- a/support-frontend/test/selenium/subscriptions/pages/SubsLandingPage.scala
+++ b/support-frontend/test/selenium/subscriptions/pages/SubsLandingPage.scala
@@ -8,7 +8,7 @@ class SubsLandingPage(implicit val webDriver: WebDriver) extends Page with Brows
 
   val url = s"${Config.supportFrontendUrl}/uk/subscribe"
 
-  private val header = className("component-heading-block")
+  private val header = cssSelector("#qa-component-subscriptions-by-country-group")
 
   def pageHasLoaded: Boolean = {
     pageHasElement(header) && pageHasUrl(s"/uk/subscribe")

--- a/support-frontend/test/selenium/util/DriverConfig.scala
+++ b/support-frontend/test/selenium/util/DriverConfig.scala
@@ -2,7 +2,8 @@ package selenium.util
 
 import java.net.URL
 import java.util.Date
-import io.github.bonigarcia.wdm.ChromeDriverManager
+
+import io.github.bonigarcia.wdm.{ChromeDriverManager, WebDriverManager}
 import org.openqa.selenium.chrome.{ChromeDriver, ChromeOptions}
 import org.openqa.selenium.remote.RemoteWebDriver
 import org.openqa.selenium.{Cookie, JavascriptExecutor, WebDriver}
@@ -19,7 +20,7 @@ class DriverConfig {
 
   // Used in dev to run tests locally
   private def instantiateLocalBrowser(): WebDriver = {
-    ChromeDriverManager.getInstance().setup()
+    WebDriverManager.chromedriver().setup()
     new ChromeDriver()
   }
 


### PR DESCRIPTION
## Why are you doing this?
We already have post deployment tests for the paper and Guardian Weekly product pages, this adds equivalent tests for the Digital Pack page and the subscriptions landing page. 