### PR TITLE
bugfix: added defensiveness around object checking in `checkAmountOrOtherAmount`

### DIFF
--- a/support-frontend/assets/components/subscriptionsByCountryGroup/subscriptionsByCountryGroup.jsx
+++ b/support-frontend/assets/components/subscriptionsByCountryGroup/subscriptionsByCountryGroup.jsx
@@ -76,7 +76,7 @@ function SubscriptionsByCountryGroup(props: PropTypes) {
 
   if (countryGroupId === GBPCountries) {
     return (
-      <div id='qa-component-subscriptions-by-country-group' className={className} {...otherProps}>
+      <div id="qa-component-subscriptions-by-country-group" className={className} {...otherProps}>
         <DigitalSection
           headingSize={headingSize}
           subsLinks={subsLinks}

--- a/support-frontend/assets/helpers/formValidation.js
+++ b/support-frontend/assets/helpers/formValidation.js
@@ -38,10 +38,15 @@ export const checkAmountOrOtherAmount: (SelectedAmounts, OtherAmounts, Contribut
   contributionType: ContributionType,
   countryGroupId: CountryGroupId,
 ) => {
-  const amount = selectedAmounts[contributionType] === 'other'
-    ? otherAmounts[contributionType].amount || ''
-    : selectedAmounts[contributionType].value || '';
-  return checkAmount(amount, countryGroupId, contributionType);
+  let amt = '';
+  if (selectedAmounts[contributionType] && selectedAmounts[contributionType] === 'other') {
+    if (otherAmounts[contributionType] && otherAmounts[contributionType].amount) {
+      amt = otherAmounts[contributionType].amount;
+    }
+  } else if (selectedAmounts[contributionType] && selectedAmounts[contributionType].value) {
+    amt = selectedAmounts[contributionType].value;
+  }
+  return checkAmount(amt, countryGroupId, contributionType);
 };
 
 export const checkStateIfApplicable: ((string | null), CountryGroupId) => boolean = (


### PR DESCRIPTION
## Why are you doing this?

Landing page was breaking on local and code after one-off contributions because object was undefined. I added checks to make sure the object exists before we try to pull values from it. Larger analysis required to understand what changes were made that were caused this problem and why it only seems to affect local and code.
<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Changes

* Added checks for object existing
* Linted code base
