### PR TITLE
Only fire events on polyfill failures

### DIFF
--- a/support-frontend/app/views/main.scala.html
+++ b/support-frontend/app/views/main.scala.html
@@ -121,47 +121,18 @@
     @mainElement.fold(emptyDiv, withContent)
 
     <script>
-      function polyfillOnLoad() {
-        window.guardian.polyfillScriptStatus = 'loaded'
+      function polyfillLoaded() {
+        window.guardian.polyfillScriptLoaded = true;
       }
     </script>
 
-    <script>
-      function polyfillOnError() {
-        window.guardian.polyfillScriptStatus = 'error'
-      }
-    </script>
-
-    <script>
-      function polyfillOnAbort() {
-        window.guardian.polyfillScriptStatus = 'aborted'
-      }
-    </script>
-    <script>
-      window.guardian.beforePolyfill = {};
-      if (Object.values) {
-        window.guardian.beforePolyfill.objectValues = true;
-      }
-      if (Object.entries) {
-        window.guardian.beforePolyfill.objectEntries = true;
-      }
-    </script>
-    <script
-      id="polyfill-script"
-      src="https://polyfill.io/v3/polyfill.min.js?features=default,Array.prototype.find,fetch,Array.prototype.includes,Number.isInteger,Object.values,Object.entries"
-      onload="polyfillOnLoad()"
-      onerror="polyfillOnError()"
-      onabort="polyfillOnAbort()"
-    >
-    </script>
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=default,Array.prototype.find,fetch,Array.prototype.includes,Number.isInteger,Object.values,Object.entries&callback=polyfillLoaded"></script>
     <script type="text/javascript">
       window.guardian = window.guardian || {};
       window.guardian.gitCommitId = '@app.BuildInfo.gitCommitId';
     </script>
 
     @body
-
-
 
     @mainJsBundle.fold(linkedJs, inlineJs)
 

--- a/support-frontend/assets/helpers/tracking/ophan.js
+++ b/support-frontend/assets/helpers/tracking/ophan.js
@@ -108,54 +108,6 @@ const trackPaymentMethodSelected = (paymentMethod: PaymentMethod): void => {
   });
 };
 
-const trackPolyfillScriptStatus = (polyfillScriptStatus: string): void => {
-  trackComponentEvents({
-    component: {
-      componentType: 'ACQUISITIONS_OTHER',
-      id: 'polyfill-v3-script-status',
-    },
-    action: 'CLICK',
-    value: polyfillScriptStatus || 'empty',
-  });
-};
-
-const trackPolyfilledObjectFunction = (when: 'beforePolyfill' | 'afterPolyfill', objectFunction: string): void => {
-  gaEvent({
-    category: 'debug',
-    action: `${when}-v3`,
-    label: objectFunction || 'none',
-  });
-
-  trackComponentEvents({
-    component: {
-      componentType: 'ACQUISITIONS_OTHER',
-      id: `${when}-v3`,
-    },
-    action: 'CLICK',
-    value: objectFunction || 'none',
-  });
-};
-
-const trackPolyfilledObjectFunctions = (): void => {
-  const beforePolyfill = [];
-  if (window.guardian.beforePolyfill.objectEntries) {
-    beforePolyfill.push('entries');
-  }
-  if (window.guardian.beforePolyfill.objectValues) {
-    beforePolyfill.push('values');
-  }
-  trackPolyfilledObjectFunction('beforePolyfill', beforePolyfill.join(','));
-
-  const afterPolyfill = [];
-  if (Object.entries) {
-    afterPolyfill.push('entries');
-  }
-  if (Object.values) {
-    afterPolyfill.push('values');
-  }
-  trackPolyfilledObjectFunction('afterPolyfill', afterPolyfill.join(','));
-};
-
 const trackCheckoutSubmitAttempt = (componentId: string, eventDetails: string): void => {
   gaEvent({
     category: 'click',
@@ -247,6 +199,4 @@ export {
   trackAbTests,
   trackNewOptimizeExperiment,
   trackPaymentMethodSelected,
-  trackPolyfillScriptStatus,
-  trackPolyfilledObjectFunctions,
 };

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
@@ -2,7 +2,6 @@
 
 // ----- Imports ----- //
 
-import { trackPolyfillScriptStatus } from 'helpers/tracking/ophan';
 import React from 'react';
 import { Provider } from 'react-redux';
 import { Route, BrowserRouter } from 'react-router-dom';
@@ -27,15 +26,10 @@ import ContributionThankYouContainer from './components/ContributionThankYou/Con
 import { setUserStateActions } from './setUserStateActions';
 import ConsentBanner from '../../components/consentBanner/consentBanner';
 import './contributionsLanding.scss';
-import { trackPolyfilledObjectFunctions } from '../../helpers/tracking/ophan';
-
-const polyfillSuccess = window.guardian.polyfillScriptStatus;
-trackPolyfillScriptStatus(polyfillSuccess);
 
 if (!isDetailsSupported) {
   polyfillDetails();
 }
-
 
 // ----- Redux Store ----- //
 
@@ -43,12 +37,21 @@ const countryGroupId: CountryGroupId = detect();
 
 const store = pageInit(() => initReducer(countryGroupId), true);
 
-trackPolyfilledObjectFunctions();
-gaEvent({
-  category: 'debug',
-  action: 'polyfill-v3-script-status',
-  label: polyfillSuccess || 'empty',
-});
+if (!window.guardian.polyfillScriptLoaded) {
+  gaEvent({
+    category: 'polyfill',
+    action: 'not loaded',
+    label: '',
+  });
+}
+
+if (typeof Object.values !== 'function') {
+  gaEvent({
+    category: 'polyfill',
+    action: 'Object.values not available after polyfill',
+    label: '',
+  });
+}
 
 // We need to initialise in this order, as
 // formInit depends on the user being populated


### PR DESCRIPTION
We're putting through over 100,000 of the "debug" events per day right now (since we fire 3 per pageview). I'm a bit worried about GA costs.

Conclusions so far:
- 30 to 40 script loading errors per day, in a variety of countries & browsers (probably connectivity issues, nothing we can do here)
- 100 to 150 sessions per day where `Object.values` and `Object.entries` are unavailable after polyfill. 98% of these are in France on one specific version of chrome. weird!
- 0 cases where only one of `Object.values` or `Object.entries` was available before or after polyfill (either both or neither)

All we really need to track is the failure cases. I also don't think we're ever going to use the data lake to analyse this data. So I've just got GA tracking:

- when `Object.values` is unavailable after polyfill
- when the polyfill callback is not executed. this should capture all the script loading errors above, plus maybe more