### PR TITLE
Handling 6 for 6 in Weekly checkout

### DIFF
--- a/support-frontend/assets/components/subscriptionCheckouts/billingPeriodSelector.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/billingPeriodSelector.jsx
@@ -29,7 +29,7 @@ type PropTypes = {|
   billingCountry: IsoCountry,
   selected: BillingPeriod,
   onChange: (BillingPeriod) => Action,
-  orderIsAGift?: Option<boolean>,
+  sixWeeklySelected?: Option<boolean>,
 |}
 
 function BillingPeriodSelector(props: PropTypes) {
@@ -43,7 +43,7 @@ function BillingPeriodSelector(props: PropTypes) {
             billingPeriod === SixWeekly ? Quarterly : billingPeriod, // for 6 for 6 we need the quarterly pricing
             props.fulfilmentOption,
           );
-          return props.orderIsAGift && billingPeriod === SixWeekly ? null
+          return billingPeriod === SixWeekly && !props.sixWeeklySelected ? null
             : <RadioInputWithHelper
               text={billingPeriodTitle(billingPeriod)}
               helper={getPriceDescription(
@@ -62,7 +62,7 @@ function BillingPeriodSelector(props: PropTypes) {
 
 BillingPeriodSelector.defaultProps = {
   fulfilmentOption: NoFulfilmentOptions,
-  orderIsAGift: false,
+  sixWeeklySelected: false,
 };
 
 export { BillingPeriodSelector };

--- a/support-frontend/assets/helpers/subscriptionsForms/formActions.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/formActions.js
@@ -42,6 +42,7 @@ export type Action =
   | { type: 'SET_FORM_SUBMITTED', formSubmitted: boolean }
   | { type: 'SET_BILLING_ADDRESS_IS_SAME', isSame: Option<boolean> }
   | { type: 'SET_ORDER_IS_GIFT', orderIsAGift: Option<boolean>}
+  | { type: 'SET_SIX_WEEKLY_SELECTED', sixWeeklySelected: Option<boolean>}
   | AddressAction
   | PayPalAction
   | DDAction;
@@ -103,6 +104,10 @@ const formActionCreators = {
   setGiftStatus: (orderIsAGift: boolean | null): Action => ({
     type: 'SET_ORDER_IS_GIFT',
     orderIsAGift,
+  }),
+  setSixWeeklySelected: (sixWeeklySelected: boolean): Action => ({
+    type: 'SET_SIX_WEEKLY_SELECTED',
+    sixWeeklySelected,
   }),
 };
 

--- a/support-frontend/assets/helpers/subscriptionsForms/formFields.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/formFields.js
@@ -32,6 +32,7 @@ export type FormFields = {|
   product: SubscriptionProduct,
   productOption: ProductOptions,
   orderIsAGift: Option<boolean>,
+  sixWeeklySelected: Option<boolean>,
 |};
 
 export type FormField = $Keys<FormFields>;
@@ -68,6 +69,7 @@ function getFormFields(state: AnyCheckoutState): FormFields {
     product: state.page.checkout.product,
     billingAddressIsSame: state.page.checkout.billingAddressIsSame,
     orderIsAGift: state.page.checkout.orderIsAGift,
+    sixWeeklySelected: state.page.checkout.sixWeeklySelected,
   };
 }
 

--- a/support-frontend/assets/helpers/subscriptionsForms/formReducer.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/formReducer.js
@@ -56,6 +56,7 @@ function createFormReducer(
     fulfilmentOption: fulfilmentOption || NoFulfilmentOptions,
     payPalHasLoaded: false,
     orderIsAGift: false,
+    sixWeeklySelected: false,
   };
 
   const getFulfilmentOption = (action, currentOption) =>
@@ -135,6 +136,9 @@ function createFormReducer(
 
       case 'SET_ORDER_IS_GIFT':
         return { ...state, orderIsAGift: action.orderIsAGift };
+
+      case 'SET_SIX_WEEKLY_SELECTED':
+        return { ...state, sixWeeklySelected: action.sixWeeklySelected };
 
       default:
         return state;

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
@@ -49,6 +49,11 @@ const mapStateToProps = (state: State): PropTypes<WeeklyBillingPeriod> => ({
       billingPeriod,
       getWeeklyFulfilmentOption(countryId),
     ) : { price: 0, currency: 'GBP' };
+    const clickHandler = (bp) => {
+      // The following is a temporary fix until there is a url builder for the weekly checkout
+      window.localStorage.setItem('billingPeriodSelected', bp);
+      sendTrackingEventsOnClick('subscribe_now_cta', 'GuardianWeekly', null, bp);
+    };
     return {
       ...plans,
       [billingPeriod]: {
@@ -59,7 +64,7 @@ const mapStateToProps = (state: State): PropTypes<WeeklyBillingPeriod> => ({
         ),
         offer: getAppliedPromoDescription(billingPeriod, productPrice),
         href: getCheckoutUrl({ billingPeriod, state: state.common }),
-        onClick: sendTrackingEventsOnClick('subscribe_now_cta', 'GuardianWeekly', null, billingPeriod),
+        onClick: () => clickHandler(billingPeriod),
         price: null,
         saving: null,
       },


### PR DESCRIPTION
## Why are you doing this?
If users select 6 for 6 on the GW landing page, we want to give them the full set of options in checkout, so they can still choose to upgrade to Quarterly or Annual. However, if they've selected Quarterly or Annual billing periods already, we don't want to show 6 for 6. To achieve this, we need to keep track of which billing period they've selected on the landing page, so we know whether to display 6 for 6 as an option in checkout.

In addition, gifting and 6 for 6 are now not mutually exclusive. 

Here's a link to the [**Trello Card**](https://trello.com/c/hRu5YhBi/2413-guardian-weekly-checkout-remove-6-6-offer-from-quarterly-and-annual-final-payment-options)

## Changes
* When the user clicks through to the GW checkout via a billing period option, that billing period is recorded (currently in localStorage, later this will be picked up from params)
* In the checkout, the billing period is set dynamically, and an additional prop is set to say whether the user had selected 6 for 6
* If the user selected 6 for 6, all three billing periods are shown as options in the checkout. If they selected annual or quarterly, 6 for 6 is not shown
* Gifting and 6 for 6 are now not mutually exclusive

## User clicks an option on GW landing page
![Screen Shot 2019-06-07 at 15 45 42](https://user-images.githubusercontent.com/16781258/59112807-ad97e700-893b-11e9-8716-9dbd42bac11f.png)

## If user selects 6 for 6, it is shown as an option in checkout
![Screen Shot 2019-06-07 at 15 46 42](https://user-images.githubusercontent.com/16781258/59112867-cd2f0f80-893b-11e9-9651-5642b900a7d4.png)

## If user opts for quarterly or annual, 6 for 6 is not shown
![Screen Shot 2019-06-07 at 15 47 40](https://user-images.githubusercontent.com/16781258/59112904-e6d05700-893b-11e9-9fd2-9485035679a4.png)