### PR TITLE
update sentry client side lib to the new one

### DIFF
--- a/support-frontend/assets/helpers/logger.js
+++ b/support-frontend/assets/helpers/logger.js
@@ -1,24 +1,25 @@
 // @flow
 // import Raven from 'raven-js';
 
-const EventualRaven = import('raven-js');
+const EventualSentry = import('@sentry/browser');
 
 // ----- Functions ----- //
 
-const init = () => EventualRaven.then((Raven) => {
+const init = () => EventualSentry.then((Sentry) => {
   const dsn: string = 'https://65f7514888b6407881f34a6cf1320d06@sentry.io/1213654';
   const { gitCommitId } = window.guardian;
 
-  Raven.default.config(dsn, {
-    whitelistUrls: ['support.theguardian.com', 'localhost'],
+  Sentry.init({
+    dsn,
+    whitelistUrls: ['support.theguardian.com'],
     release: gitCommitId,
-  }).install();
+  });
 });
 
 
 const logException = (ex: string, context?: Object): void => {
-  EventualRaven.then((Raven) => {
-    Raven.default.captureException(
+  EventualSentry.then((Sentry) => {
+    Sentry.captureException(
       new Error(ex),
       {
         extra: context,
@@ -26,14 +27,14 @@ const logException = (ex: string, context?: Object): void => {
     );
 
     if (window.console && console.error) {
-      console.error(ex);
+      console.error('sentry', ex);
     }
   });
 };
 
 const logInfo = (message: string): void => {
-  EventualRaven.then((Raven) => {
-    Raven.default.captureMessage(
+  EventualSentry.then((Sentry) => {
+    Sentry.captureMessage(
       message,
       {
         level: 'info',

--- a/support-frontend/assets/helpers/logger.js
+++ b/support-frontend/assets/helpers/logger.js
@@ -26,7 +26,7 @@ const logException = (ex: string, context?: Object): void => {
     );
 
     if (window.console && console.error) {
-      console.error('sentry', ex);
+      console.error('sentry exception: ', ex);
     }
   });
 };

--- a/support-frontend/assets/helpers/logger.js
+++ b/support-frontend/assets/helpers/logger.js
@@ -1,5 +1,4 @@
 // @flow
-// import Raven from 'raven-js';
 
 const EventualSentry = import('@sentry/browser');
 

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -62,10 +62,10 @@
   },
   "dependencies": {
     "@guardian/pasteup": "^1.0.0-alpha.7",
+    "@sentry/browser": "^5.4.0",
     "cssnano": "^4.1.4",
     "fast-sass-loader": "^1.4.7",
     "ophan-tracker-js": "^1.3.13",
-    "raven-js": "^3.26.1",
     "react-redux": "^5.1.1",
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -1620,6 +1620,58 @@
     node-fetch "^2.1.1"
     url-template "^2.0.8"
 
+"@sentry/browser@^5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.4.0.tgz#4c553e4769555e09a34f8f86c6af27ebec74c715"
+  integrity sha512-lsGJqryHXrnWRkdahnep0m+m65zyMJGCmB2T8pGS+SFcSXdx94TaK4PiPaCl6XUCT5ejuQUHoXsEBmK/3S6beA==
+  dependencies:
+    "@sentry/core" "5.4.0"
+    "@sentry/types" "5.4.0"
+    "@sentry/utils" "5.4.0"
+    tslib "^1.9.3"
+
+"@sentry/core@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.4.0.tgz#c40969ace80d637195bcc0ae6e5819f0c5e8ae46"
+  integrity sha512-luIJPftVnrW0ZKqs9W6YCpzKZVbOgQv8Ae7KB0Acsvqeoqjtx4zHHfVfu5VPkfhrOYN3NsM1IpApXtSdMiJCfg==
+  dependencies:
+    "@sentry/hub" "5.4.0"
+    "@sentry/minimal" "5.4.0"
+    "@sentry/types" "5.4.0"
+    "@sentry/utils" "5.4.0"
+    tslib "^1.9.3"
+
+"@sentry/hub@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.4.0.tgz#03ab154bf2e2c33cb80d951b464de84ad2a6fbf9"
+  integrity sha512-X0iLNcouXcLWzuOJz2YjTn1E11b7pzcG98/iFTHW3AKPjnJNt92XRpjsDI2iT8+ODUDiFqaFmACSn2oZK80WGQ==
+  dependencies:
+    "@sentry/types" "5.4.0"
+    "@sentry/utils" "5.4.0"
+    tslib "^1.9.3"
+
+"@sentry/minimal@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.4.0.tgz#e3c569c68d6c09aad533832b2c713ad94bb2a511"
+  integrity sha512-MuOLavHHTXXWKyfTcwqpjhkdYlJDyOfjfcf+b/d38+8cs064rpNScxTZyYj2KKxNGcCqDgUsY175fNp/D1fyMw==
+  dependencies:
+    "@sentry/hub" "5.4.0"
+    "@sentry/types" "5.4.0"
+    tslib "^1.9.3"
+
+"@sentry/types@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.4.0.tgz#340854be18618e4435f9c168adfa2c9e407fbcb3"
+  integrity sha512-R8IFM77rzp0ngR/XQFLsXUK2uE7jLf21MsU9mpUwLtxcJp8rs7I77HgzA5MEerdG9Sbxw5RaLq9wO7noHGfUmQ==
+
+"@sentry/utils@5.4.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.4.0.tgz#32882f16cd516f341ba1dafeb020614aaf6d4b5c"
+  integrity sha512-NlYMAyiI9iIItLDxJ17tLMtuu7261t93tcOGSMdDQZlmryR6ZAMenbCKTf5MrpA2iHfX84gyfmr67lh8uSHkPg==
+  dependencies:
+    "@sentry/types" "5.4.0"
+    tslib "^1.9.3"
+
 "@storybook/addon-knobs@^4.1.9":
   version "4.1.9"
   resolved "https://registry.yarnpkg.com/@storybook/addon-knobs/-/addon-knobs-4.1.9.tgz#ae06d91b314a9ed005c0c41e61653000d6a53f45"
@@ -11434,11 +11486,6 @@ range-parser@^1.0.3, range-parser@~1.2.0:
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
   integrity sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=
 
-raven-js@^3.26.1:
-  version "3.26.1"
-  resolved "https://registry.yarnpkg.com/raven-js/-/raven-js-3.26.1.tgz#13f78804f2bed524a7283382e1bca7ab423950a3"
-  integrity sha512-63M3F/8xJCTZlouVLWX7RqpmqBL0k4UYKlx5XI+6HpHWJ9trexDXGEQ2A78DnWIEx7wo2/ZEnECksgH/0XNRXQ==
-
 raw-body@2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.3.2.tgz#bcd60c77d3eb93cde0050295c3f379389bc88f89"
@@ -13642,6 +13689,11 @@ tslib@^1.9.0:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.2.tgz#8be0cc9a1f6dc7727c38deb16c2ebd1a2892988e"
   integrity sha512-AVP5Xol3WivEr7hnssHDsaM+lVrVXWUvd1cfXTRkTj80b//6g2wIFEH6hZG0muGZRnHGrfttpdzRk3YlBkWjKw==
+
+tslib@^1.9.3:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
+  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
 tty-browserify@0.0.0:
   version "0.0.0"


### PR DESCRIPTION
## Why are you doing this?

The [old official Raven library](https://docs.sentry.io/clients/javascript/) is deprecated, the new one is called [Sentry](https://docs.sentry.io/error-reporting/quickstart/?platform=browser).

[**Trello Card**](https://trello.com/c/ckxSy7oV/2427-update-raven-to-sentry-library)


## Screenshots

I got it working locally
![image](https://user-images.githubusercontent.com/7304387/59439451-3952bd00-8ded-11e9-881d-c791e5660c10.png)

