### PR TITLE
More lenient geolocation detection

### DIFF
--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -131,7 +131,7 @@ class Application(
 
     views.html.contributions(
       title = "Support the Guardian | Make a Contribution",
-      id = s"contributions-landing-page-$countryCode",
+      id = s"contributions-landing-page",
       js = js,
       css = css,
       fontLoaderBundle = fontLoaderBundle,

--- a/support-frontend/assets/helpers/internationalisation/countryGroup.js
+++ b/support-frontend/assets/helpers/internationalisation/countryGroup.js
@@ -103,20 +103,21 @@ const countryGroups: CountryGroups = {
 
 // ----- Functions ----- //
 
-function fromPath(path: string = window.location.pathname): ?CountryGroupId {
-  if (path === '/uk' || path.startsWith('/uk/')) {
+function fromUrl(): ?CountryGroupId {
+  const url = window.location.href;
+  if (url.includes('/uk')) {
     return GBPCountries;
-  } else if (path === '/us' || path.startsWith('/us/')) {
+  } else if (url.includes('/us')) {
     return UnitedStates;
-  } else if (path === '/au' || path.startsWith('/au/')) {
+  } else if (url.includes('/au')) {
     return AUDCountries;
-  } else if (path === '/eu' || path.startsWith('/eu/')) {
+  } else if (url.includes('/eu')) {
     return EURCountries;
-  } else if (path === '/int' || path.startsWith('/int/')) {
+  } else if (url.includes('/int')) {
     return International;
-  } else if (path === '/nz' || path.startsWith('/nz/')) {
+  } else if (url.includes('/nz')) {
     return NZDCountries;
-  } else if (path === '/ca' || path.startsWith('/ca/')) {
+  } else if (url.includes('/ca')) {
     return Canada;
   }
   return null;
@@ -172,7 +173,7 @@ function fromGeolocation(): ?CountryGroupId {
 }
 
 function detect(): CountryGroupId {
-  return fromPath() || fromQueryParameter() || fromCookie() || fromGeolocation() || GBPCountries;
+  return fromUrl() || fromQueryParameter() || fromCookie() || fromGeolocation() || GBPCountries;
 }
 
 function stringToCountryGroupId(countryGroupId: string): CountryGroupId {

--- a/support-frontend/assets/helpers/render.js
+++ b/support-frontend/assets/helpers/render.js
@@ -46,7 +46,7 @@ const renderPage = (content: Object, id: string, callBack?: () => void) => {
       renderError(e, id);
     }
   } else {
-    logException(`Fatal error trying to render a page. id:${id}`);
+    logException(`Could not find element with id ${id} to render react app into`);
   }
 };
 

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
@@ -59,8 +59,6 @@ user.init(store.dispatch, setUserStateActions);
 formInit(store);
 
 
-const reactElementId = `contributions-landing-page-${countryGroups[countryGroupId].supportInternationalisationId}`;
-
 // ----- Internationalisation ----- //
 
 const selectedCountryGroup = countryGroups[countryGroupId];
@@ -139,4 +137,4 @@ const router = (
   </BrowserRouter>
 );
 
-renderPage(router, reactElementId, () => store.dispatch(enableOrDisableForm()));
+renderPage(router, 'contributions-landing-page', () => store.dispatch(enableOrDisableForm()));


### PR DESCRIPTION
Viewing the contributions landing page through Google Translate doesn't work because the element that it renders the react app into contains a country code, and this country code detection doesn't work because the URL is in different (it's embedded as a parameter inside a Google Translate URL).

So
1. Don't put the country code in the id. This id isn't used by anything, there's no reason for it to be there
2. Look at the whole URL for the country code string anywhere, rather than the stricter check we currently have (it has to be the entire path, or the start of the path)
3. Fix the unhelpful error message `Fatal error trying to render a page`