### PR TITLE
6 for 6 Guardian Weekly promotions

### DIFF
--- a/support-frontend/assets/helpers/subscriptionsForms/submit.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.js
@@ -57,6 +57,7 @@ import {
   setupStripeCheckout,
 } from 'helpers/paymentIntegrations/stripeCheckout';
 import { isPostDeployUser } from 'helpers/user/user';
+import { Quarterly, SixWeekly } from 'helpers/billingPeriods';
 
 // ----- Functions ----- //
 
@@ -140,7 +141,7 @@ function buildRegularPaymentRequest(
 
   const product = {
     currency: currencyId,
-    billingPeriod,
+    billingPeriod: billingPeriod === SixWeekly ? Quarterly : billingPeriod,
     ...getOptions(fulfilmentOption, productOption),
   };
 

--- a/support-models/src/main/scala/com/gu/support/catalog/Product.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/Product.scala
@@ -145,26 +145,33 @@ case object GuardianWeekly extends Product {
   lazy val ratePlans: Map[TouchPointEnvironment, List[ProductRatePlan[GuardianWeekly.type]]] =
     Map(
       PROD -> List(
-        ProductRatePlan("2c92a0086619bf8901661ab545f51b21", SixWeekly, RestOfWorld, NoProductOptions), //TODO: remove SixWeekly and use promotions instead
+        ProductRatePlan("2c92a0086619bf8901661ab545f51b21", SixWeekly, RestOfWorld, NoProductOptions,
+          productRatePlanChargeId = Some("2c92a0086619bf8901661ab546091b23")), //TODO: remove SixWeekly and use promotions instead
         ProductRatePlan("2c92a0fe6619b4b601661ab300222651", Annual, RestOfWorld, NoProductOptions),
         ProductRatePlan("2c92a0086619bf8901661ab02752722f", Quarterly, RestOfWorld, NoProductOptions),
-        ProductRatePlan("2c92a0086619bf8901661aaac94257fe", SixWeekly, Domestic, NoProductOptions),
+        ProductRatePlan("2c92a0086619bf8901661aaac94257fe", SixWeekly, Domestic, NoProductOptions,
+          productRatePlanChargeId = Some("2c92a0086619bf8901661aaac95d5800")
+        ),
         ProductRatePlan("2c92a0fe6619b4b901661aa8e66c1692", Annual, Domestic, NoProductOptions),
         ProductRatePlan("2c92a0fe6619b4b301661aa494392ee2", Quarterly, Domestic, NoProductOptions),
       ),
       UAT -> List(
-          ProductRatePlan("2c92c0f9660fc4c70166109dfd08092c", SixWeekly, RestOfWorld, NoProductOptions),
+          ProductRatePlan("2c92c0f9660fc4c70166109dfd08092c", SixWeekly, RestOfWorld, NoProductOptions,
+            productRatePlanChargeId = Some("2c92c0f9660fc4c70166109dfd17092e")),
           ProductRatePlan("2c92c0f9660fc4d70166109a2eb0607c", Annual, RestOfWorld, NoProductOptions),
           ProductRatePlan("2c92c0f9660fc4d70166109c01465f10", Quarterly, RestOfWorld, NoProductOptions),
-          ProductRatePlan("2c92c0f8660fb5dd016610858eb90658", SixWeekly, Domestic, NoProductOptions),
+          ProductRatePlan("2c92c0f8660fb5dd016610858eb90658", SixWeekly, Domestic, NoProductOptions,
+            productRatePlanChargeId = Some("2c92c0f8660fb5dd016610858ed3065a")),
           ProductRatePlan("2c92c0f9660fc4d70166107fa5412641", Annual, Domestic, NoProductOptions),
           ProductRatePlan("2c92c0f8660fb5d601661081ea010391", Quarterly, Domestic, NoProductOptions),
         ),
       SANDBOX -> List(
-        ProductRatePlan("2c92c0f965f2122101660fbc75a16c38", SixWeekly, RestOfWorld, NoProductOptions),
+        ProductRatePlan("2c92c0f965f2122101660fbc75a16c38", SixWeekly, RestOfWorld, NoProductOptions,
+          productRatePlanChargeId = Some("2c92c0f965f2122101660fbc75ba6c3c")),
         ProductRatePlan("2c92c0f965f2122101660fb33ed24a45", Annual, RestOfWorld, NoProductOptions),
         ProductRatePlan("2c92c0f965f2122101660fb81b745a06", Quarterly, RestOfWorld, NoProductOptions),
-        ProductRatePlan("2c92c0f965f212210165f69b94c92d66", SixWeekly, Domestic, NoProductOptions),
+        ProductRatePlan("2c92c0f965f212210165f69b94c92d66", SixWeekly, Domestic, NoProductOptions,
+          productRatePlanChargeId = Some("2c92c0f865f204440165f69f407d66f1")),
         ProductRatePlan("2c92c0f965d280590165f16b1b9946c2", Annual, Domestic, NoProductOptions),
         ProductRatePlan("2c92c0f965dc30640165f150c0956859", Quarterly, Domestic, NoProductOptions),
       )

--- a/support-models/src/main/scala/com/gu/support/catalog/Product.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/Product.scala
@@ -146,7 +146,7 @@ case object GuardianWeekly extends Product {
     Map(
       PROD -> List(
         ProductRatePlan("2c92a0086619bf8901661ab545f51b21", SixWeekly, RestOfWorld, NoProductOptions,
-          productRatePlanChargeId = Some("2c92a0086619bf8901661ab546091b23")), //TODO: remove SixWeekly and use promotions instead
+          productRatePlanChargeId = Some("2c92a0086619bf8901661ab546091b23")),
         ProductRatePlan("2c92a0fe6619b4b601661ab300222651", Annual, RestOfWorld, NoProductOptions),
         ProductRatePlan("2c92a0086619bf8901661ab02752722f", Quarterly, RestOfWorld, NoProductOptions),
         ProductRatePlan("2c92a0086619bf8901661aaac94257fe", SixWeekly, Domestic, NoProductOptions,

--- a/support-models/src/main/scala/com/gu/support/catalog/ProductRatePlan.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/ProductRatePlan.scala
@@ -8,5 +8,8 @@ case class ProductRatePlan[+T <: Product](
   billingPeriod: BillingPeriod,
   fulfilmentOptions: FulfilmentOptions,
   productOptions: ProductOptions,
-  supportedTerritories: List[CountryGroup] = CountryGroup.allGroups
+  supportedTerritories: List[CountryGroup] = CountryGroup.allGroups,
+  // productRatePlanChargeId is only needed for GW 6 for 6. If we implemented 6 for 6 in the same way as
+  // we do discounts we wouldn't need this and we would be able to apply 6 for 6 to other products
+  productRatePlanChargeId: Option[ProductRatePlanChargeId] = None
 )

--- a/support-models/src/main/scala/com/gu/support/zuora/api/SubscriptionData.scala
+++ b/support-models/src/main/scala/com/gu/support/zuora/api/SubscriptionData.scala
@@ -16,6 +16,8 @@ object RatePlanCharge {
   val subscriptionEnd = "SubscriptionEnd"
   val endDateCondition = "EndDateCondition"
   val upToPeriods = "UpToPeriods"
+  val triggerEvent = "TriggerEvent"
+  val specificEvent = "SpecificDate"
 
   implicit val discountEncoder: Encoder[DiscountRatePlanCharge] = capitalizingEncoder[DiscountRatePlanCharge]
     .mapJsonObject { jo =>
@@ -36,7 +38,9 @@ object RatePlanCharge {
       .add(endDateCondition, Json.fromString(subscriptionEnd)))
   implicit val contributionDecoder: Decoder[ContributionRatePlanCharge] = decapitalizingDecoder
 
-  implicit val introductoryPriceEncoder: Encoder[IntroductoryPriceRatePlanCharge] = capitalizingEncoder
+  implicit val introductoryPriceEncoder: Encoder[IntroductoryPriceRatePlanCharge] = capitalizingEncoder[IntroductoryPriceRatePlanCharge]
+    .mapJsonObject(_
+      .add(triggerEvent, Json.fromString(specificEvent)))
   implicit val introductoryPriceDecoder: Decoder[IntroductoryPriceRatePlanCharge] = decapitalizingDecoder
 
   implicit val encodeRatePlanCharge: Encoder[RatePlanCharge] = Encoder.instance {
@@ -72,7 +76,9 @@ case class IntroductoryPriceRatePlanCharge(
   productRatePlanChargeId: ProductRatePlanChargeId,
   price: BigDecimal,
   triggerDate: LocalDate,
-) extends RatePlanCharge
+) extends RatePlanCharge {
+  val TriggerEvent = "SpecificDate"
+}
 
 sealed trait PeriodType
 

--- a/support-models/src/main/scala/com/gu/support/zuora/api/SubscriptionData.scala
+++ b/support-models/src/main/scala/com/gu/support/zuora/api/SubscriptionData.scala
@@ -76,9 +76,7 @@ case class IntroductoryPriceRatePlanCharge(
   productRatePlanChargeId: ProductRatePlanChargeId,
   price: BigDecimal,
   triggerDate: LocalDate,
-) extends RatePlanCharge {
-  val TriggerEvent = "SpecificDate"
-}
+) extends RatePlanCharge
 
 sealed trait PeriodType
 

--- a/support-models/src/test/scala/com/gu/support/zuora/api/SerialisationSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/zuora/api/SerialisationSpec.scala
@@ -98,10 +98,10 @@ class SerialisationSpec extends FlatSpec with SerialisationTestHelpers with Lazy
 
   "IntroductoryPriceRatePlanCharge" should "serialise correctly" in {
     val correct = parse(
-      """{
+      s"""{
         "ProductRatePlanChargeId" : "123",
         "Price" : 6,
-        "TriggerDate" : "2019-06-11",
+        "TriggerDate" : "${LocalDate.now}",
         "TriggerEvent" : "SpecificDate"
       }""").right.get
 

--- a/support-models/src/test/scala/com/gu/support/zuora/api/SerialisationSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/zuora/api/SerialisationSpec.scala
@@ -11,6 +11,7 @@ import com.typesafe.scalalogging.LazyLogging
 import io.circe.Json
 import io.circe.parser._
 import io.circe.syntax._
+import org.joda.time.{DateTime, LocalDate}
 import org.joda.time.Months.months
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -93,6 +94,18 @@ class SerialisationSpec extends FlatSpec with SerialisationTestHelpers with Lazy
         c.price shouldBe 15
       }
     )
+  }
+
+  "IntroductoryPriceRatePlanCharge" should "serialise correctly" in {
+    val correct = parse(
+      """{
+        "ProductRatePlanChargeId" : "123",
+        "Price" : 6,
+        "TriggerDate" : "2019-06-11",
+        "TriggerEvent" : "SpecificDate"
+      }""").right.get
+
+    IntroductoryPriceRatePlanCharge("123", 6, LocalDate.now).asJson shouldBe correct
   }
 
   "InvoiceResult" should "deserialise correctly" in {

--- a/support-services/src/main/scala/com/gu/support/promotions/PromotionApplicator.scala
+++ b/support-services/src/main/scala/com/gu/support/promotions/PromotionApplicator.scala
@@ -60,12 +60,17 @@ class DiscountApplicator(discount: DiscountBenefit, config: PromotionsDiscountCo
 
 class IntroductoryPriceApplicator(introductoryPriceBenefit: IntroductoryPriceBenefit) extends BenefitApplicator {
   def applyTo(subscriptionData: SubscriptionData): SubscriptionData = {
-    introductoryPriceRatePlanData(subscriptionData).map(
+    val subscription = subscriptionData.subscription
+    val result = introductoryPriceRatePlanData(subscriptionData).map(
       ratePlanData =>
         subscriptionData.copy(
-          ratePlanData = subscriptionData.ratePlanData.::(ratePlanData)
+          ratePlanData = subscriptionData.ratePlanData.::(ratePlanData),
+          subscription = subscription.copy(
+            contractAcceptanceDate = subscription.contractAcceptanceDate.plusWeeks(introductoryPriceBenefit.periodLength)
+          )
         )
     ).getOrElse(subscriptionData)
+    result
   }
 
 

--- a/support-services/src/main/scala/com/gu/support/promotions/PromotionApplicator.scala
+++ b/support-services/src/main/scala/com/gu/support/promotions/PromotionApplicator.scala
@@ -86,7 +86,8 @@ class IntroductoryPriceApplicator(introductoryPriceBenefit: IntroductoryPriceBen
     for {
       recurringRatePlan <- subscriptionData.ratePlanData.headOption
       recurringProductRatePlanId = recurringRatePlan.ratePlan.productRatePlanId
-      productRatePlansForEnvironment <- GuardianWeekly.ratePlans.find(_._2.exists(_.id == recurringProductRatePlanId)).map(_._2)
+      weeklyProductRatePlans = GuardianWeekly.ratePlans.values
+      productRatePlansForEnvironment <- weeklyProductRatePlans.find(_.exists(_.id == recurringProductRatePlanId))
       recurringProductRatePlan <- productRatePlansForEnvironment.find(_.id == recurringProductRatePlanId)
       introductoryProductRatePlan <- productRatePlansForEnvironment.find(equivalentSixWeeklyProductRatePlan(recurringProductRatePlan))
       introductoryProductRatePlanChargeId <- introductoryProductRatePlan.productRatePlanChargeId

--- a/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
@@ -6,6 +6,7 @@ import com.gu.i18n.Currency
 import com.gu.i18n.Currency.GBP
 import com.gu.salesforce.Fixtures.{emailAddress, idId}
 import com.gu.support.encoding.CustomCodecs._
+import com.gu.support.promotions.PromoCode
 import com.gu.support.workers.encoding.Conversions.StringInputStreamConversions
 import com.gu.support.workers.encoding.Wrapper
 import io.circe.generic.auto._
@@ -305,7 +306,8 @@ object JsonFixtures {
             }
       """
 
-  def createGuardianWeeklySubscriptionJson(billingPeriod: BillingPeriod): String =
+  def createGuardianWeeklySubscriptionJson(billingPeriod: BillingPeriod, maybePromoCode: Option[PromoCode] = None): String ={
+    val promoJson = maybePromoCode.map(promo => s""""promoCode": "$promo",""").getOrElse("")
     s"""
       {
         $requestIdJson,
@@ -316,10 +318,12 @@ object JsonFixtures {
           "fulfilmentOptions" : "RestOfWorld"
         },
         "firstDeliveryDate": "${LocalDate.now(DateTimeZone.UTC).plusDays(3)}",
+        ${promoJson}
         "paymentMethod": $stripePaymentMethod,
         "salesForceContact": $salesforceContactJson
         }
       """
+    }
 
   val failureJson =
     """{

--- a/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
@@ -317,8 +317,8 @@ object JsonFixtures {
           "billingPeriod" : "$billingPeriod",
           "fulfilmentOptions" : "RestOfWorld"
         },
-        "firstDeliveryDate": "${LocalDate.now(DateTimeZone.UTC).plusDays(3)}",
-        ${promoJson}
+        "firstDeliveryDate": "${LocalDate.now(DateTimeZone.UTC).plusDays(10)}",
+        $promoJson
         "paymentMethod": $stripePaymentMethod,
         "salesForceContact": $salesforceContactJson
         }

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
@@ -4,8 +4,9 @@ import java.io.ByteArrayOutputStream
 
 import com.gu.config.Configuration.{promotionsConfigProvider, zuoraConfigProvider}
 import com.gu.okhttp.RequestRunners.configurableFutureRunner
+import com.gu.support.catalog.GuardianWeekly
 import com.gu.support.encoding.CustomCodecs._
-import com.gu.support.promotions.PromotionService
+import com.gu.support.promotions.{PromotionService, Promotions}
 import com.gu.support.workers.JsonFixtures.{createEverydayPaperSubscriptionJson, _}
 import com.gu.support.workers.encoding.Conversions.FromOutputStream
 import com.gu.support.workers.encoding.Encoding
@@ -59,6 +60,10 @@ class CreateZuoraSubscriptionSpec extends LambdaSpec with MockServicesCreator {
 
   it should "create an Quarterly Guardian Weekly subscription" in {
     createSubscription(createGuardianWeeklySubscriptionJson(Quarterly))
+  }
+
+  it should "create an 6 for 6 Guardian Weekly subscription" in {
+    createSubscription(createGuardianWeeklySubscriptionJson(Quarterly, Some(GuardianWeekly.SixForSixPromoCode)))
   }
 
   private def createSubscription(json: String) = {


### PR DESCRIPTION
## Why are you doing this?
We want to be able to create 6 for 6 subscriptions to Guardian Weekly

I have implemented 6 for 6 slightly differently to the way that it was done in the old site, it is now a promotion of the type `IntroductoryPrice` which has a price and a duration (£6 & 6 weeks). This will allow us to do 'n for n' promotions in the future but there will still be a bit of work needed to support that.

The website should now pass in `Quarterly` as the billing period, which is the subscription that the user will move onto after the introductory period, rather than `SixWeekly` as in the old site.

I've also had to add `productRatePlanChargeIds` for the GW `SixWeekly` billing period as this is used in setting up the introductory pricing period.

I have tested this on code against the old site and the subscriptions it creates are identical as far as I can see.

[**Trello Card**](https://trello.com/c/NQV3JqAa/2338-guardian-weekly-6-for-6-backend)