### PR TITLE
Adds styling for processing overlay in weekly checkout

### DIFF
--- a/support-frontend/assets/components/progressMessage/progressMessage.jsx
+++ b/support-frontend/assets/components/progressMessage/progressMessage.jsx
@@ -5,6 +5,8 @@
 import React from 'react';
 import AnimatedDots from 'components/spinners/animatedDots';
 
+import './progressMessage.scss';
+
 // ---- Types ----- //
 
 type PropTypes = {|

--- a/support-frontend/assets/components/progressMessage/progressMessage.scss
+++ b/support-frontend/assets/components/progressMessage/progressMessage.scss
@@ -1,3 +1,5 @@
+@import '~stylesheets/gu-sass/gu-sass';
+
 .component-progress-message {
   z-index: 10000;
   display: block;
@@ -14,7 +16,7 @@
   width: 100%;
   height: 100%;
   text-align: center;
-  font-family: $gu-text-sans-web;
+  @include gu-fontset-body-sans;
 
   .component-progress-message__dialog {
     font-size: 20px;


### PR DESCRIPTION
## Why are you doing this?
When a user is in the GW checkout and has entered payment details and pressed 'Pay £6', they see a processing state in the modal, then the modal closes and they should see the checkout page with a darker overlay over the page and a message that says 'Processing transaction, please wait' and some loading dots. When the processing is complete, they are moved on to the thank you page.

The work involved was to apply the correct styling to this (already existing) payment state. 

[**Trello Card**](https://trello.com)

## Changes
Applies the styling that was already in existence but not attached to the component.

## Old look
(You can see the text, unstyled, at the bottom left)

![Screen Shot 2019-06-17 at 13 26 36](https://user-images.githubusercontent.com/16781258/59604257-9313f980-9103-11e9-9ec7-1caba16fc6bb.png)

## New look
![Screen Shot 2019-06-17 at 13 23 12](https://user-images.githubusercontent.com/16781258/59604184-5516d580-9103-11e9-91b5-92d23be33e1d.png)
