### PR TITLE
Make sure that post deploy subs checkouts are on the UK version of the page

### DIFF
--- a/support-frontend/test/selenium/subscriptions/CheckoutsSpec.scala
+++ b/support-frontend/test/selenium/subscriptions/CheckoutsSpec.scala
@@ -3,7 +3,7 @@ package selenium.subscriptions
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.{Minute, Seconds, Span}
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FeatureSpec, GivenWhenThen}
-import selenium.subscriptions.pages.{CheckoutPage, DigitalPackCheckout, PaperCheckout, Register}
+import selenium.subscriptions.pages.{CheckoutPage, DigitalPackCheckout, DigitalPackSubs, PaperCheckout, Register}
 import selenium.util._
 
 class CheckoutsSpec extends FeatureSpec with GivenWhenThen with BeforeAndAfter with BeforeAndAfterAll with Browser with Eventually {
@@ -40,6 +40,10 @@ class CheckoutsSpec extends FeatureSpec with GivenWhenThen with BeforeAndAfter w
 
   def testCheckout(checkoutName: String, checkoutPage: CheckoutPage): Unit = {
     val testUser = new TestUser(driverConfig)
+
+    val landingPage = new DigitalPackSubs()
+    Given("that a user goes to the UK landing page")
+    goTo(landingPage)
 
     Given(s"that a user goes to the $checkoutName checkout page")
     goTo(checkoutPage)


### PR DESCRIPTION
## Why are you doing this?

The checkout post deployment tests are failing in PROD because geolocation is putting the test client into the US version of the checkout whereas the tests are written to work with the UK version.

This change makes the client go to the UK version of the landing page before the checkout to force it into the correct country.

[**Trello Card**](https://trello.com)

