### PR TITLE
Add a post deployment test for Direct Debit

### DIFF
--- a/support-frontend/assets/components/directDebit/directDebitForm/directDebitForm.jsx
+++ b/support-frontend/assets/components/directDebit/directDebitForm/directDebitForm.jsx
@@ -236,6 +236,7 @@ function ConfirmationInput(props: {phase: Phase, checked: boolean, onChange: Fun
           checked={props.checked}
         />
         <label
+          id="qa-confirmation-input"
           className="component-direct-debit-form__confirmation-label"
           htmlFor="confirmation-input"
         />
@@ -284,6 +285,7 @@ function PaymentButton(props: {
   if (props.phase === 'entry') {
     return (
       <button
+        id="qa-submit-button-1"
         className="component-direct-debit-form__cta component-direct-debit-form__cta--pay-button focus-target"
         onClick={props.onPayClick}
       >
@@ -306,6 +308,7 @@ function PaymentButton(props: {
           <span className="component-direct-debit-form__cta-text component-direct-debit-form__cta-text--inverse">Back</span>
         </button>
         <button
+          id="qa-submit-button-2"
           className="component-direct-debit-form__cta component-direct-debit-form__cta--confirm-button focus-target"
           onClick={props.onConfirmClick}
         >

--- a/support-frontend/assets/components/directDebit/directDebitForm/sortCodeInput.jsx
+++ b/support-frontend/assets/components/directDebit/directDebitForm/sortCodeInput.jsx
@@ -15,16 +15,19 @@ function SortCodeInput(props: SortCodePropTypes) {
   const editable = (
     <span>
       <SortCodeField
+        id="qa-sort-code-1"
         value={props.sortCodeArray[0]}
         onChange={event => props.onChange(0, event)}
       />
       <span className="component-direct-debit-form__sort-code-separator">&mdash;</span>
       <SortCodeField
+        id="qa-sort-code-2"
         value={props.sortCodeArray[1]}
         onChange={event => props.onChange(1, event)}
       />
       <span className="component-direct-debit-form__sort-code-separator">&mdash;</span>
       <SortCodeField
+        id="qa-sort-code-3"
         value={props.sortCodeArray[2]}
         onChange={event => props.onChange(2, event)}
       />
@@ -50,12 +53,13 @@ function SortCodeInput(props: SortCodePropTypes) {
 // ----- Auxiliary components ----- //
 
 function SortCodeField(props: {
+  id: string,
   value: string,
   onChange: (SyntheticInputEvent<HTMLInputElement>) => void
 }) {
   return (
     <input
-      id="sort-code-field"
+      id={props.id}
       value={props.value}
       onChange={props.onChange}
       type="tel"

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/checkoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/checkoutForm.jsx
@@ -25,9 +25,6 @@ import { asControlled } from 'hocs/asControlled';
 import Form, { FormSection } from 'components/checkoutForm/checkoutForm';
 import Layout, { Content } from 'components/subscriptionCheckouts/layout';
 import Summary from 'components/subscriptionCheckouts/summary';
-import DirectDebitPopUpForm
-  from 'components/directDebit/directDebitPopUpForm/directDebitPopUpForm';
-import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
 import type { ErrorReason } from 'helpers/errorReasons';
 import type { ProductPrices } from 'helpers/productPrice/productPrices';
 import { getProductPrice } from 'helpers/productPrice/paperProductPrices';
@@ -258,12 +255,6 @@ function CheckoutForm(props: PropTypes) {
             >
               Continue to payment
             </Button>
-            <DirectDebitPopUpForm
-              buttonText="Subscribe with Direct Debit"
-              onPaymentAuthorisation={(pa: PaymentAuthorisation) => {
-                props.onPaymentAuthorised(pa);
-              }}
-            />
           </FormSection>
           <CancellationSection />
         </Form>

--- a/support-frontend/test/selenium/subscriptions/CheckoutsSpec.scala
+++ b/support-frontend/test/selenium/subscriptions/CheckoutsSpec.scala
@@ -3,7 +3,7 @@ package selenium.subscriptions
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.{Minute, Seconds, Span}
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FeatureSpec, GivenWhenThen}
-import selenium.subscriptions.pages.{CheckoutPage, DigitalPackCheckout, DigitalPackSubs, PaperCheckout, Register}
+import selenium.subscriptions.pages._
 import selenium.util._
 
 class CheckoutsSpec extends FeatureSpec with GivenWhenThen with BeforeAndAfter with BeforeAndAfterAll with Browser with Eventually {
@@ -28,17 +28,17 @@ class CheckoutsSpec extends FeatureSpec with GivenWhenThen with BeforeAndAfter w
 
   feature("Digital Pack checkout") {
     scenario("Stripe checkout") {
-      testCheckout("Digital Pack", new DigitalPackCheckout)
+      testCheckout("Digital Pack", new DigitalPackCheckout, payWithStripe)
     }
   }
 
   feature("Paper checkout") {
-    scenario("Stripe checkout") {
-      testCheckout("Paper", new PaperCheckout)
+    scenario("Direct Debit checkout") {
+      testCheckout("Paper", new PaperCheckout, payWithDirectDebit)
     }
   }
 
-  def testCheckout(checkoutName: String, checkoutPage: CheckoutPage): Unit = {
+  def testCheckout(checkoutName: String, checkoutPage: CheckoutPage, paymentFunction: CheckoutPage => Unit): Unit = {
     val testUser = new TestUser(driverConfig)
 
     val landingPage = new DigitalPackSubs()
@@ -73,6 +73,10 @@ class CheckoutsSpec extends FeatureSpec with GivenWhenThen with BeforeAndAfter w
     Given("The user fills in their details correctly")
     checkoutPage.fillForm
 
+    paymentFunction(checkoutPage)
+  }
+
+  def payWithStripe(checkoutPage: CheckoutPage): Unit ={
     Given("that the user selects to pay with Stripe")
     When("they press the Stripe payment button")
     checkoutPage.selectStripePaymentMethod()
@@ -82,7 +86,35 @@ class CheckoutsSpec extends FeatureSpec with GivenWhenThen with BeforeAndAfter w
 
     And("the mock calls the backend using a test Stripe token")
 
-    Then("the thankyou page should display")
+    thankYouPage(checkoutPage)
+  }
+
+  def payWithDirectDebit(checkoutPage: CheckoutPage): Unit ={
+    val directDebit = new DirectDebitForm()
+
+    Given("that the user selects to pay with Direct Debit")
+    When("they press the Direct Debit payment button")
+    checkoutPage.selectDirectDebitPaymentMethod()
+
+    When("they click continue to payment")
+    checkoutPage.clickSubmit
+
+    Then("the direct debit form loads")
+
+    Given("The user fills in their details correctly")
+    directDebit.fillForm
+
+    Then("the second page loads")
+    directDebit.secondPageHasLoaded
+
+    Given("The user confirms their details")
+    directDebit.confirm
+
+    thankYouPage(checkoutPage)
+  }
+
+  def thankYouPage(checkoutPage: CheckoutPage): Unit ={
+    Then("the thank you page should display")
     eventually {
       assert(checkoutPage.thankYouPageHasLoaded)
     }

--- a/support-frontend/test/selenium/subscriptions/pages/CheckoutPage.scala
+++ b/support-frontend/test/selenium/subscriptions/pages/CheckoutPage.scala
@@ -6,8 +6,11 @@ import selenium.util.Browser
 trait CheckoutPage extends Page with Browser {
   private val stripeRadioButton = id("qa-credit-card")
   private val submitButton = id("qa-submit-button")
+  private val directDebitButton = id("qa-direct-debit")
 
   def selectStripePaymentMethod(): Unit = clickOn(stripeRadioButton)
+
+  def selectDirectDebitPaymentMethod(): Unit = clickOn(directDebitButton)
 
   def pageHasLoaded: Boolean = {
     pageHasElement(submitButton)

--- a/support-frontend/test/selenium/subscriptions/pages/DirectDebitForm.scala
+++ b/support-frontend/test/selenium/subscriptions/pages/DirectDebitForm.scala
@@ -1,0 +1,36 @@
+package selenium.subscriptions.pages
+
+import org.openqa.selenium.WebDriver
+import org.scalatest.selenium.Page
+import selenium.util.{Browser, Config}
+
+class DirectDebitForm (implicit val webDriver: WebDriver) extends Page with Browser {
+
+  val url = s"${Config.supportFrontendUrl}/subscribe/digital/checkout"
+
+  private val submitButton1 = id("qa-submit-button-1")
+  private val submitButton2 = id("qa-submit-button-2")
+  private val accountName = id("account-holder-name-input")
+  private val accountNumber = id("account-number-input")
+  private val sortCode1 = id("qa-sort-code-1")
+  private val sortCode2 = id("qa-sort-code-2")
+  private val sortCode3 = id("qa-sort-code-3")
+  private val confirmationCheckBox = id("qa-confirmation-input")
+
+  def fillForm {
+    setValue(accountName, "Test user")
+    setValue(accountNumber, "55779911")
+    setValue(sortCode1, "20")
+    setValue(sortCode2, "20")
+    setValue(sortCode3, "20")
+    clickOn(confirmationCheckBox)
+    clickOn(submitButton1)
+  }
+
+  def pageHasLoaded(): Boolean = pageHasElement(submitButton1)
+
+  def secondPageHasLoaded: Boolean = pageHasElement(submitButton2)
+
+  def confirm: Unit = clickOn(submitButton2)
+
+}


### PR DESCRIPTION
## Why are you doing this?

We want to have a post deployment test which checks that Direct Debit is still working correctly so that we can tell immediately if we break it.

This PR adds Direct Debit as a payment method to the subs checkouts Selenium tests and uses it on the paper checkout. This means that we are now testing
* UK Digital Pack checkout with Stripe
* Paper checkout with Direct Debit

[**Trello Card**](https://trello.com/c/tOADTOUP/2425-add-post-deploy-tests-for-the-subs-checkouts)