### PR TITLE
Reset password endpoint & cohort 4 client side work

### DIFF
--- a/support-frontend/app/controllers/IdentityController.scala
+++ b/support-frontend/app/controllers/IdentityController.scala
@@ -61,6 +61,18 @@ class IdentityController(
       )
   }
 
+  def resetPassword(): Action[ResetPasswordRequest] = PrivateAction.async(circe.json[ResetPasswordRequest]) { implicit request =>
+    identityService
+      .resetPassword(request.body.email).map { res =>
+      if (res) {
+        SafeLogger.info(s"Successfully sent consents preferences email for ${request.body.email}")
+        Ok
+      } else {
+        warnAndReturn()
+      }
+    }
+  }
+
   def getUserType(maybeEmail: Option[String]): Action[AnyContent] = PrivateAction.async { implicit request =>
     maybeEmail.fold {
       SafeLogger.error(scrub"No email provided")
@@ -83,12 +95,17 @@ class IdentityController(
   }
 }
 
+case class SendMarketingRequest(email: String)
 object SendMarketingRequest {
   implicit val decoder: Decoder[SendMarketingRequest] = deriveDecoder
 }
-case class SendMarketingRequest(email: String)
 
+case class SetPasswordRequest(password: String, guestAccountRegistrationToken: String)
 object SetPasswordRequest {
   implicit val decoder: Decoder[SetPasswordRequest] = deriveDecoder
 }
-case class SetPasswordRequest(password: String, guestAccountRegistrationToken: String)
+
+case class ResetPasswordRequest(email: String)
+object ResetPasswordRequest {
+  implicit val decoder: Decoder[ResetPasswordRequest] = deriveDecoder
+}

--- a/support-frontend/app/controllers/IdentityController.scala
+++ b/support-frontend/app/controllers/IdentityController.scala
@@ -65,7 +65,7 @@ class IdentityController(
     identityService
       .resetPassword(request.body.email).map { res =>
       if (res) {
-        SafeLogger.info(s"Successfully sent consents preferences email for ${request.body.email}")
+        SafeLogger.info(s"Successfully sent reset password email for ${request.body.email}")
         Ok
       } else {
         warnAndReturn()

--- a/support-frontend/app/services/HttpIdentityService.scala
+++ b/support-frontend/app/services/HttpIdentityService.scala
@@ -88,7 +88,7 @@ class HttpIdentityService(apiUrl: String, apiClientToken: String)(implicit wsCli
   }
 
   def resetPassword(email: String)(implicit ec: ExecutionContext): Future[Boolean] = {
-    val payload = Json.obj("email" -> email)
+    val payload = Json.obj("email-address" -> email)
     request("pwd-reset/send-password-reset-email").post(payload).map { response =>
       val validResponse = response.status >= 200 && response.status < 300
       if (validResponse) SafeLogger.info("Successfully sent reset password email using Identity Reset Password API")

--- a/support-frontend/app/services/StubIdentityService.scala
+++ b/support-frontend/app/services/StubIdentityService.scala
@@ -25,6 +25,11 @@ class StubIdentityService extends IdentityService {
     Future.successful(true)
   }
 
+  def resetPassword(email: String)(implicit ec: ExecutionContext): Future[Boolean] = {
+    SafeLogger.info("Stubbed identity service active. Returning true (Successful response from Identity Reset Password API) ")
+    Future.successful(true)
+  }
+
   def setPasswordGuest(
     password: String,
     guestAccountRegistrationToken: String

--- a/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
+++ b/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
@@ -247,7 +247,7 @@ function postRegularPaymentRequest(
 
 function setPasswordGuest(
   password: string,
-  guestAccountRegistrationToken: string,
+  guestAccountRegistrationToken: ?string,
   csrf: CsrfState,
 ): Promise<boolean> {
 
@@ -273,7 +273,7 @@ function resetPassword(
 ): Promise<boolean> {
 
   const data = { email };
-  return logPromise(fetch(`${routes.contributionsSetPasswordGuest}`, requestOptions(data, 'same-origin', 'POST', csrf)))
+  return logPromise(fetch(`${routes.contributionsResetPassword}`, requestOptions(data, 'same-origin', 'POST', csrf)))
     .then((response) => {
       if (response.status === 200) {
         return true;

--- a/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
+++ b/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
@@ -267,9 +267,31 @@ function setPasswordGuest(
     });
 }
 
+function resetPassword(
+  email: string,
+  csrf: CsrfState,
+): Promise<boolean> {
+
+  const data = { email };
+  return logPromise(fetch(`${routes.contributionsSetPasswordGuest}`, requestOptions(data, 'same-origin', 'POST', csrf)))
+    .then((response) => {
+      if (response.status === 200) {
+        return true;
+      }
+      logException('/contribute/reset-password endpoint returned an error');
+      return false;
+
+    })
+    .catch(() => {
+      logException('Error while trying to interact with /contribute/reset-password');
+      return false;
+    });
+}
+
 export {
   postRegularPaymentRequest,
   regularPaymentFieldsFromAuthorisation,
   PaymentSuccess,
   setPasswordGuest,
+  resetPassword,
 };

--- a/support-frontend/assets/helpers/routes.js
+++ b/support-frontend/assets/helpers/routes.js
@@ -18,6 +18,7 @@ const routes: {
   recurringContribPending: '/contribute/recurring/pending',
   contributionsSendMarketing: '/contribute/send-marketing',
   contributionsSetPasswordGuest: '/identity/set-password-guest',
+  contributionsResetPassword: '/identity/reset-password',
   getUserType: '/identity/get-user-type',
   oneOffContribCheckout: '/contribute/one-off',
   oneOffContribThankyou: '/contribute/one-off/thankyou',

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouPasswordSet.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouPasswordSet.jsx
@@ -14,25 +14,29 @@ import ContributionSurvey from '../ContributionSurvey/ContributionsSurvey';
 
 type PropTypes = {|
   contributionType: ContributionType,
+  guestAccountCreationToken: ?string,
 |};
 
 const mapStateToProps = state => ({
   contributionType: state.page.form.contributionType,
+  guestAccountCreationToken: state.page.form.guestAccountCreationToken,
 });
 
 // ----- Render ----- //
 
 function ContributionThankYouPasswordSet(props: PropTypes) {
-  const title = 'You now have a Guardian account';
-  const body = 'Please check your inbox to validate your email address – it only takes a minute. And then sign in on each of the devices you use to access The Guardian.';
+  const passwordSetTitle = 'You now have a Guardian account';
+  const passwordSetBody = 'Please check your inbox to validate your email address – it only takes a minute. And then sign in on each of the devices you use to access The Guardian.';
+  const passwordResetTitle = 'Check your inbox';
+  const passwordResetBody = 'Please follow the steps in the email to set up a password – it only takes a minute. And then, remember to sign in on each of the devices you use to access The Guardian.';
 
   return (
     <div className="thank-you__container">
       <div className="gu-content__form gu-content__form--thank-you gu-content__form--password-set">
         <section className="confirmation">
-          <h3 className="confirmation__title">{title}</h3>
+          <h3 className="confirmation__title">{props.guestAccountCreationToken ? passwordSetTitle : passwordResetTitle}</h3>
           <p className="confirmation__message">
-            {body}
+            {props.guestAccountCreationToken ? passwordSetBody : passwordResetBody}
           </p>
         </section>
         <MarketingConsent />

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSetPassword.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSetPassword.jsx
@@ -20,6 +20,7 @@ type PropTypes = {|
   passwordFailed: boolean,
   hasSeenDirectDebitThankYouCopy: boolean,
   setHasSeenDirectDebitThankYouCopy: () => void,
+  guestAccountCreationToken: ?string,
 |};
 /* eslint-enable react/no-unused-prop-types */
 
@@ -31,6 +32,7 @@ const mapStateToProps = state => ({
   paymentMethod: state.page.form.paymentMethod,
   passwordFailed: state.page.form.passwordFailed,
   hasSeenDirectDebitThankYouCopy: state.page.hasSeenDirectDebitThankYouCopy,
+  guestAccountCreationToken: state.page.form.guestAccountCreationToken,
 });
 
 function mapDispatchToProps(dispatch: Dispatch<Action>) {
@@ -48,6 +50,9 @@ function ContributionThankYouSetPassword(props: PropTypes) {
   const oneOffBody = 'If you create an account and stay signed in on each of your devices, you’ll notice far fewer messages asking you for financial support. Please make sure you validate your account via your inbox.';
   const recurringTitle = 'Set up a free account to manage your payments';
   const recurringBody = 'If you stay signed in when you’re reading The Guardian as a contributor, you’ll no longer see messages asking you to support our journalism';
+  const resetTitle = 'Finish setting up your Guardian account';
+  const resetBodyP1 = 'As a valued contributor, we want to ensure you are having the best experience on our site. To stop seeing requests for support at the bottom of articles, or in pop-up banners, please sign in on each of the devices you use to access The Guardian – mobile, tablet, laptop or desktop.';
+  const resetBodyP2 = 'We just need to validate your email address and help you set a password – it only takes a minute.';
 
   const setPasswordCopy = {
     ONE_OFF: {
@@ -62,6 +67,10 @@ function ContributionThankYouSetPassword(props: PropTypes) {
       title: recurringTitle,
       body: recurringBody,
     },
+    RESET: {
+      title: resetTitle,
+      body: [resetBodyP1, resetBodyP2],
+    },
   };
 
   const renderDirectDebit = () => {
@@ -75,16 +84,31 @@ function ContributionThankYouSetPassword(props: PropTypes) {
     );
   };
 
+  const renderPasswordCopy = () => (
+    props.guestAccountCreationToken ?
+      <div>
+        <h3 className="set-password__title">{setPasswordCopy[props.contributionType].title}</h3>
+        <p className="set-password__message">
+          {setPasswordCopy[props.contributionType].body}
+        </p>
+      </div> :
+      <div>
+        <h3 className="set-password__title">{setPasswordCopy.RESET.title}</h3>
+        {setPasswordCopy.RESET.body.map(paragraph => (
+          <p className="set-password__message">
+            {paragraph}
+          </p>
+        ))}
+      </div>
+  );
+
   return (
     <div className="thank-you__container">
       <div className="gu-content__form gu-content__form--thank-you gu-content__form--set-password">
         { props.paymentMethod === DirectDebit && !props.hasSeenDirectDebitThankYouCopy ?
             renderDirectDebit() : null }
         <section className="set-password">
-          <h3 className="set-password__title">{setPasswordCopy[props.contributionType].title}</h3>
-          <p className="set-password__message">
-            {setPasswordCopy[props.contributionType].body}
-          </p>
+          {renderPasswordCopy()}
           <SetPasswordForm />
         </section>
       </div>

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSetPassword.scss
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSetPassword.scss
@@ -1,11 +1,11 @@
 .set-password__message {
   font-family: $gu-text-egyptian-web;
   letter-spacing: -0.5px;
-  margin-bottom: $gu-v-spacing * 2;
+  margin-bottom: $gu-v-spacing / 2;
   line-height: 20px;
 }
 
-.set-password__message {
+.set-password__message:last-of-type {
   margin-bottom: 0;
 }
 

--- a/support-frontend/assets/pages/contributions-landing/components/SetPasswordForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/SetPasswordForm.jsx
@@ -220,8 +220,8 @@ function SetPasswordForm(props: PropTypes) {
   return (
     <div className="set-password__form">
       {props.guestAccountCreationToken ?
-      renderNewPasswordForm(props) :
-      renderPasswordResetForm(props)}
+       renderNewPasswordForm(props) :
+       renderPasswordResetForm(props)}
     </div>
   );
 

--- a/support-frontend/assets/pages/contributions-landing/components/SetPasswordForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/SetPasswordForm.jsx
@@ -136,7 +136,7 @@ function renderEmailField(email: string) {
       required
       disabled
     />
-  )
+  );
 }
 
 function renderNewPasswordForm(props: PropTypes) {

--- a/support-frontend/assets/pages/contributions-landing/components/SetPasswordForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/SetPasswordForm.jsx
@@ -30,7 +30,7 @@ const passwordErrorMessage = 'Sorry, we are unable to register you at this time.
 type PropTypes = {|
   email: string,
   password: string,
-  guestAccountCreationToken: string,
+  guestAccountCreationToken: ?string,
   setThankYouPageStage: (ThankYouPageStage) => void,
   setPasswordHasBeenSubmitted: () => void,
   passwordHasBeenSubmitted: boolean,
@@ -102,12 +102,11 @@ function onSubmitResetPassword(props: PropTypes): Event => void {
   return (event) => {
     props.setPasswordHasBeenSubmitted();
     event.preventDefault();
-    trackComponentClick(`set-password-${props.contributionType}`);
+    trackComponentClick(`reset-password-${props.contributionType}`);
     if (!(event.target: any).checkValidity()) {
       return;
     }
 
-    // TODO: send user to thank you page with error if password was not set
     resetPassword(props.email, props.csrf)
       .then((response) => {
         if (response === true) {
@@ -121,25 +120,30 @@ function onSubmitResetPassword(props: PropTypes): Event => void {
 
 
 // ----- Render ----- //
+function renderEmailField(email: string) {
+  return (
+    <ContributionTextInput
+      id="email"
+      name="contribution-email"
+      label="Email address"
+      value={email}
+      isValid={checkEmail(email)}
+      pattern={emailRegexPattern}
+      icon={<SvgEnvelope />}
+      autoComplete="email"
+      type="email"
+      errorMessage="Please enter a valid email address"
+      required
+      disabled
+    />
+  )
+}
 
 function renderNewPasswordForm(props: PropTypes) {
   return (
     <div>
       <form onSubmit={onSubmitSetPasswordGuest(props)} className={classNameWithModifiers('form', ['contribution'])} noValidate>
-        <ContributionTextInput
-          id="email"
-          name="contribution-email"
-          label="Email address"
-          value={props.email}
-          isValid={checkEmail(props.email)}
-          pattern={emailRegexPattern}
-          icon={<SvgEnvelope />}
-          autoComplete="email"
-          type="email"
-          errorMessage="Please enter a valid email address"
-          required
-          disabled
-        />
+        {renderEmailField(props.email)}
         <ContributionTextInput
           id="password"
           type="password"
@@ -180,7 +184,7 @@ function renderNewPasswordForm(props: PropTypes) {
           <SvgExclamationAlternate /><span className="component-general-error-message__error-heading">{passwordErrorHeading}</span>
           <span className="component-general-error-message__small-print">{passwordErrorMessage}</span>
         </div> : null
-  }
+      }
     </div>);
 }
 
@@ -188,27 +192,14 @@ function renderPasswordResetForm(props: PropTypes) {
   return (
     <div>
       <form onSubmit={onSubmitResetPassword(props)} className={classNameWithModifiers('form', ['contribution'])} noValidate>
-        <ContributionTextInput
-          id="email"
-          name="contribution-email"
-          label="Email address"
-          value={props.email}
-          isValid={checkEmail(props.email)}
-          pattern={emailRegexPattern}
-          icon={<SvgEnvelope />}
-          autoComplete="email"
-          type="email"
-          errorMessage="Please enter a valid email address"
-          required
-          disabled
-        />
+        {renderEmailField(props.email)}
         <Button
           appearance="secondary"
           modifierClasses={['create-account']}
           aria-label="Create a guardian account"
           type="submit"
         >
-          Create a Guardian account
+          Validate my email address
         </Button>
         <Button
           appearance="greyHollow"
@@ -216,25 +207,21 @@ function renderPasswordResetForm(props: PropTypes) {
           onClick={
             () => {
               trackComponentClick('decline-to-reset-password');
-              props.setThankYouPageStage('thankYouPasswordDeclinedToSet');
+              props.setThankYouPageStage('thankYou');
             }}
         >
           No thank you
         </Button>
       </form>
-      {props.passwordError === true ?
-        <div className="component-password-failure-message component-general-error-message">
-          <SvgExclamationAlternate /><span className="component-general-error-message__error-heading">{passwordErrorHeading}</span>
-          <span className="component-general-error-message__small-print">{passwordErrorMessage}</span>
-        </div> : null
-      }
     </div>);
 }
 
 function SetPasswordForm(props: PropTypes) {
   return (
     <div className="set-password__form">
-      {renderNewPasswordForm(props)}
+      {props.guestAccountCreationToken ?
+      renderNewPasswordForm(props) :
+      renderPasswordResetForm(props)}
     </div>
   );
 

--- a/support-frontend/conf/routes
+++ b/support-frontend/conf/routes
@@ -69,6 +69,7 @@ POST  /contribute/send-marketing                     controllers.IdentityControl
 # ------ Identity ------ #
 PUT /identity/set-password-guest                 controllers.IdentityController.setPasswordGuest
 GET /identity/get-user-type                      controllers.IdentityController.getUserType(maybeEmail: Option[String])
+POST /identity/reset-password                    controllers.IdentityController.resetPassword
 
 
 # ----- Subscriptions ----- #


### PR DESCRIPTION
## Why are you doing this?

We need to send users through Identity's 'reset password' flow (which recognizes whether or not a user has set a password already and changes its email copy accordingly. This PR also includes the necessary clientside work to integrate this endpoint which will be ready for when we start to recognize cohort4 users and send them to the 'set password' template.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/LBoYGOds/1178-implement-password-reset-endpoint-on-support-frontend)

## Changes

* Added endpoint to support-frontend (paired with @jranks123 )
* Integrated the endpoint on the client

## Screenshots
'Thank you set password':
<img width="1136" alt="reset password screen" src="https://user-images.githubusercontent.com/3300789/59676157-d1baba00-91be-11e9-8514-2838e053f4fa.png">
'Thank you password set': 
<img width="1184" alt="reset password final screen" src="https://user-images.githubusercontent.com/3300789/59676193-eac36b00-91be-11e9-89a0-0d36cf5a8bb2.png">