### PR TITLE
Add dev-nginx installation to support-frontned/setup.sh

### DIFF
--- a/support-frontend/setup.sh
+++ b/support-frontend/setup.sh
@@ -106,6 +106,8 @@ install_nginx() {
     EXTRA_STEPS+=("nginx is installed. Ensure you have 'include sites-enabled/*' in your nginx configuration ${NGINX_ROOT}/nginx.conf and add '127.0.0.1 support.thegulocal.com' and '127.0.0.1 support-ui.thegulocal.com' to /etc/hosts")
   fi
 
+  install_dev_nginx 
+
   ./nginx/setup.sh
 }
 
@@ -114,6 +116,14 @@ install_awscli() {
     brew install awscli
   fi
 }
+
+install_dev_nginx() {
+  if ! installed dev-nginx; then
+    brew tap "guardian/devtools"
+    brew install "guardian/devtools/dev-nginx"
+  fi
+}
+
 
 install_sbt() {
   if ! installed sbt; then


### PR DESCRIPTION
## Why are you doing this?
Adds the installation of `[dev-ngnix](https://github.com/guardian/dev-nginx)` to `./setup.sh`. 

This is required by `nginx/setup.sh`, which is now called from the main setup script