### PR TITLE
Actually send validation email for those who have just set a password

### DIFF
--- a/support-frontend/app/services/HttpIdentityService.scala
+++ b/support-frontend/app/services/HttpIdentityService.scala
@@ -104,10 +104,8 @@ class HttpIdentityService(apiUrl: String, apiClientToken: String)(implicit wsCli
     val payload = Json.obj("password" -> password)
     val headers =
       List("X-Guest-Registration-Token" -> guestAccountRegistrationToken, "Content-Type" -> "application/json")
-    val urlParameters = List("validate-email" -> "0")
     request(s"guest/password")
       .addHttpHeaders(headers: _*)
-      .withQueryStringParameters(urlParameters: _*)
       .put(payload)
       .attemptT
       .leftMap(_.toString)


### PR DESCRIPTION
## Why are you doing this?
Inexplicably (there may well have been a reason once, but it's weird), we were explicitly not sending a "validate your email address" email to people who set a password in the thank you flow (but we were telling people that we were sending them one). 

This PR fixes this.  

@guardian/contributions 