### PR TITLE
Generic sign in on thank you page

### DIFF
--- a/support-frontend/assets/components/marketingConsentNew/marketingConsent.jsx
+++ b/support-frontend/assets/components/marketingConsentNew/marketingConsent.jsx
@@ -121,8 +121,8 @@ MarketingConsent.defaultProps = {
   requestPending: false,
   render: ({ title, message }: {title: string, message: string}) => (
     <div>
-      <h3 className="component-marketing-consent__title">{title}</h3>
-      <p className="component-marketing-consent__message">
+      <h3 className="contribution-thank-you-block__title">{title}</h3>
+      <p className="contribution-thank-you-block__message">
         {message}
       </p>
     </div>

--- a/support-frontend/assets/components/spreadTheWord/spreadTheWord.jsx
+++ b/support-frontend/assets/components/spreadTheWord/spreadTheWord.jsx
@@ -3,7 +3,6 @@
 // ----- Imports ----- //
 
 import React from 'react';
-
 import SocialShare from 'components/socialShare/socialShare';
 
 
@@ -14,9 +13,9 @@ export default function SpreadTheWord() {
   const message = 'To join you and over one million others in supporting a different model for open, independent journalism – so more people can access factual information for free';
 
   return (
-    <div className="component-spread-the-word">
-      <h3 className="component-spread-the-word__title">{title}</h3>
-      <p className="component-marketing-consent__message">{message}</p>
+    <div className="contribution-thank-you-block">
+      <h3 className="contribution-thank-you-block__title">{title}</h3>
+      <p className="contribution-thank-you-block__message">{message}</p>
       <div className="component-spread-the-word__share">
         <SocialShare name="facebook" />
         <SocialShare name="twitter" />

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionSurvey/ContributionsSurvey.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionSurvey/ContributionsSurvey.jsx
@@ -26,8 +26,8 @@ export default function ContributionsSurvey(props: PropTypes) {
 
   return props.isRunning && surveyLink ? (
     <div className="component-contributions-survey">
-      <h3 className="confirmation__title">Tell us about your contribution</h3>
-      <p className="confirmation__message">
+      <h3 className="contribution-thank-you-block__title">Tell us about your contribution</h3>
+      <p className="contribution-thank-you-block__message">
           Please fill out this short form to help us learn a little more about your support for The Guardian
       </p>
       <AnchorButton

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
@@ -11,10 +11,12 @@ import { type Action, setHasSeenDirectDebitThankYouCopy } from '../../contributi
 import type { PaymentMethod } from 'helpers/paymentMethods';
 import { ContributionThankYouBlurb } from './ContributionThankYouBlurb';
 import AnchorButton from 'components/button/anchorButton';
+import Button from 'components/button/button';
 import SvgArrowLeft from 'components/svgs/arrowLeftStraight';
 import { DirectDebit } from 'helpers/paymentMethods';
 import SpreadTheWord from 'components/spreadTheWord/spreadTheWord';
 import ContributionSurvey from '../ContributionSurvey/ContributionsSurvey';
+import { trackComponentClick } from 'helpers/tracking/ophan';
 
 // ----- Types ----- //
 
@@ -61,8 +63,8 @@ function ContributionThankYou(props: PropTypes) {
     <div className="thank-you__container">
       <div className="gu-content__form gu-content__form--thank-you">
         {props.contributionType !== 'ONE_OFF' ? (
-          <section className="confirmation">
-            <h3 className="confirmation__title">
+          <section className="contribution-thank-you-block">
+            <h3 className="contribution-thank-you-block__title">
               {`${directDebitHeaderSuffix}Look out for an email within three business days confirming your ${getSpokenType(props.contributionType)} recurring payment${directDebitMessageSuffix}`}
             </h3>
           </section>
@@ -70,15 +72,24 @@ function ContributionThankYou(props: PropTypes) {
         {!props.isSignedIn ?
           <section className="contribution-thank-you-block">
             <h3 className="contribution-thank-you-block__title">
-              Sign into The Guardian
+              Stay signed in to The Guardian
             </h3>
-            <p className="contribution-thank-you-block__message">If you stay signed into a validated account on each of your devices, you’ll notice far fewer messages asking you for financial support.</p>
-            <AnchorButton
-              href={`https://profile.theguardian.com/signin?email=${props.email}`}
+            <p className="contribution-thank-you-block__message">
+              As a valued contributor, we want to ensure you are having the best experience on our site.
+              To stop seeing requests for support at the bottom of articles, or in pop-up banners, please sign in
+              on each of the devices you use to access The Guardian – mobile, tablet, laptop or desktop.
+            </p>
+            <Button
               aria-label="Sign into The Guardian"
+              appearance="secondary"
+              onClick={
+                () => {
+                  trackComponentClick(`sign-into-the-guardian-link-${props.contributionType}`);
+                  window.location.href = `https://profile.theguardian.com/signin?email=${props.email}`;
+                }}
             >
               Sign in now
-            </AnchorButton>
+            </Button>
           </section> : null }
         <MarketingConsent />
         <ContributionSurvey isRunning={false} contributionType={props.contributionType} />

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
@@ -24,13 +24,17 @@ type PropTypes = {|
   paymentMethod: PaymentMethod,
   hasSeenDirectDebitThankYouCopy: boolean,
   setHasSeenDirectDebitThankYouCopy: () => void,
-  |};
+  isSignedIn: boolean,
+  email: string,
+|};
 /* eslint-enable react/no-unused-prop-types */
 
 const mapStateToProps = state => ({
   contributionType: state.page.form.contributionType,
   paymentMethod: state.page.form.paymentMethod,
   hasSeenDirectDebitThankYouCopy: state.page.hasSeenDirectDebitThankYouCopy,
+  isSignedIn: state.page.user.isSignedIn,
+  email: state.page.user.email,
 });
 
 function mapDispatchToProps(dispatch: Dispatch<Action>) {
@@ -63,6 +67,19 @@ function ContributionThankYou(props: PropTypes) {
             </h3>
           </section>
         ) : null}
+        {!props.isSignedIn ?
+          <section className="confirmation">
+            <h3 className="component-marketing-consent__title">
+              Sign into The Guardian
+            </h3>
+            <p className="component-marketing-consent__message">If you stay signed into a validated account on each of your devices, you’ll notice far fewer messages asking you for financial support.</p>
+            <AnchorButton
+              href={`https://profile.theguardian.com/signin?email=${props.email}`}
+              aria-label="Sign into The Guardian"
+            >
+              Sign in now
+            </AnchorButton>
+          </section> : null }
         <MarketingConsent />
         <ContributionSurvey isRunning={false} contributionType={props.contributionType} />
         <SpreadTheWord />

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
@@ -73,9 +73,9 @@ function ContributionThankYou(props: PropTypes) {
               Stay signed in to The Guardian
             </h3>
             <p className="contribution-thank-you-block__message">
-              As a valued contributor, we want to ensure you are having the best experience on our site.
-              To stop seeing requests for support at the bottom of articles, or in pop-up banners, please sign in
-              on each of the devices you use to access The Guardian – mobile, tablet, laptop or desktop.
+              As a valued contributor, we want to ensure you are having the best experience on our site. To see
+              far fewer requests for support, please sign in on each of the devices you use to access The
+              Guardian – mobile, tablet, laptop or desktop. Please make sure you’ve verified your email address.
             </p>
             <Button
               aria-label="Sign into The Guardian"
@@ -83,7 +83,7 @@ function ContributionThankYou(props: PropTypes) {
               onClick={
                 () => {
                   trackComponentClick(`sign-into-the-guardian-link-${props.contributionType}`);
-                  window.location.href = `https://profile.theguardian.com/signin`;
+                  window.location.href = 'https://profile.theguardian.com/signin';
                 }}
             >
               Sign in now

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
@@ -34,7 +34,7 @@ const mapStateToProps = state => ({
   paymentMethod: state.page.form.paymentMethod,
   hasSeenDirectDebitThankYouCopy: state.page.hasSeenDirectDebitThankYouCopy,
   isSignedIn: state.page.user.isSignedIn,
-  email: state.page.user.email,
+  email: state.page.form.formData.email,
 });
 
 function mapDispatchToProps(dispatch: Dispatch<Action>) {
@@ -68,11 +68,11 @@ function ContributionThankYou(props: PropTypes) {
           </section>
         ) : null}
         {!props.isSignedIn ?
-          <section className="confirmation">
-            <h3 className="component-marketing-consent__title">
+          <section className="contribution-thank-you-block">
+            <h3 className="contribution-thank-you-block__title">
               Sign into The Guardian
             </h3>
-            <p className="component-marketing-consent__message">If you stay signed into a validated account on each of your devices, you’ll notice far fewer messages asking you for financial support.</p>
+            <p className="contribution-thank-you-block__message">If you stay signed into a validated account on each of your devices, you’ll notice far fewer messages asking you for financial support.</p>
             <AnchorButton
               href={`https://profile.theguardian.com/signin?email=${props.email}`}
               aria-label="Sign into The Guardian"

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
@@ -27,7 +27,6 @@ type PropTypes = {|
   hasSeenDirectDebitThankYouCopy: boolean,
   setHasSeenDirectDebitThankYouCopy: () => void,
   isSignedIn: boolean,
-  email: string,
 |};
 /* eslint-enable react/no-unused-prop-types */
 
@@ -36,7 +35,6 @@ const mapStateToProps = state => ({
   paymentMethod: state.page.form.paymentMethod,
   hasSeenDirectDebitThankYouCopy: state.page.hasSeenDirectDebitThankYouCopy,
   isSignedIn: state.page.user.isSignedIn,
-  email: state.page.form.formData.email,
 });
 
 function mapDispatchToProps(dispatch: Dispatch<Action>) {
@@ -85,7 +83,7 @@ function ContributionThankYou(props: PropTypes) {
               onClick={
                 () => {
                   trackComponentClick(`sign-into-the-guardian-link-${props.contributionType}`);
-                  window.location.href = `https://profile.theguardian.com/signin?email=${props.email}`;
+                  window.location.href = `https://profile.theguardian.com/signin`;
                 }}
             >
               Sign in now

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.scss
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.scss
@@ -89,35 +89,6 @@
     line-height: 22px;
   }
 
-  .confirmation {
-    border-bottom: 1px solid gu-colour(neutral-86);
-    font-weight: 300;
-    margin: 0 -10px;
-    padding: 0 10px ($gu-v-spacing * 2);
-  }
-
-  .confirmation__title {
-    font-family: $gu-text-egyptian-web;
-    letter-spacing: -0.5px;
-    font-weight: 900;
-    font-size: 17px;
-    line-height: 22px;
-    margin: ($gu-v-spacing / 3) 0;
-  }
-
-  .confirmation__message {
-    font-family: $gu-text-egyptian-web;
-    letter-spacing: -0.5px;
-    line-height: 20px;
-  }
-
-  .confirmation__message--direct-debit {
-    margin-left: -10px;
-    margin-right: -10px;
-    padding: 0 10px $gu-v-spacing;
-    border-bottom: 1px solid gu-colour(neutral-86);
-  }
-
   .contribution-thank-you-block {
     border-bottom: 1px solid gu-colour(neutral-86);
     font-weight: 300;

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.scss
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.scss
@@ -117,4 +117,27 @@
     padding: 0 10px $gu-v-spacing;
     border-bottom: 1px solid gu-colour(neutral-86);
   }
+
+  .contribution-thank-you-block {
+    border-bottom: 1px solid gu-colour(neutral-86);
+    font-weight: 300;
+    margin: 0 -10px;
+    padding: 0 10px ($gu-v-spacing * 2);
+  }
+
+  .contribution-thank-you-block__title {
+    font-family: $gu-text-egyptian-web;
+    letter-spacing: -0.5px;
+    font-weight: 900;
+    font-size: 17px;
+    margin: ($gu-v-spacing / 3) 0;
+    line-height: 22px;
+  }
+
+  .contribution-thank-you-block__message {
+    font-family: $gu-text-egyptian-web;
+    letter-spacing: -0.5px;
+    margin-bottom: $gu-v-spacing;
+    line-height: 20px;
+  }
 }

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouPasswordSet.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouPasswordSet.jsx
@@ -29,9 +29,9 @@ function ContributionThankYouPasswordSet(props: PropTypes) {
   return (
     <div className="thank-you__container">
       <div className="gu-content__form gu-content__form--thank-you gu-content__form--password-set">
-        <section className="confirmation">
-          <h3 className="confirmation__title">{title}</h3>
-          <p className="confirmation__message">
+        <section className="contribution-thank-you-block">
+          <h3 className="contribution-thank-you-block__title">{title}</h3>
+          <p className="contribution-thank-you-block__message">
             {body}
           </p>
         </section>

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSetPassword.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSetPassword.jsx
@@ -67,8 +67,8 @@ function ContributionThankYouSetPassword(props: PropTypes) {
   const renderDirectDebit = () => {
     props.setHasSeenDirectDebitThankYouCopy();
     return (
-      <section className="confirmation">
-        <h3 className="confirmation__title">
+      <section className="contribution-thank-you-block">
+        <h3 className="contribution-thank-you-block__title">
           {'Your Direct Debit has been set up. Look out for an email within three business days confirming your recurring payment. This will appear as \'Guardian Media Group\' on your bank statements'}
         </h3>
       </section>


### PR DESCRIPTION
## Why are you doing this?

We want as many people to sign in as possible. This is a tracked link with copy to go to profile.theguardian.com with email prefilled that renders for people who are not signed in. Hopefully this will up our number of people we can recognize on site after they've contributed.
<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/dxrQCGzW/1186-thank-you-page-for-cohorts-34-sign-in)

## Screenshots
![generic sign in cta](https://user-images.githubusercontent.com/3300789/59864193-2ce6db00-937e-11e9-8a56-63c8f2d8d1c6.png)
