### PR TITLE
Guardian Weekly Gifting

### DIFF
--- a/support-frontend/app/controllers/CreateSubscription.scala
+++ b/support-frontend/app/controllers/CreateSubscription.scala
@@ -78,6 +78,7 @@ class CreateSubscription(
     User(
       id = user.id,
       primaryEmailAddress = user.primaryEmailAddress,
+      title = request.title,
       firstName = request.firstName,
       lastName = request.lastName,
       billingAddress = request.billingAddress,

--- a/support-frontend/app/controllers/RegularContributions.scala
+++ b/support-frontend/app/controllers/RegularContributions.scala
@@ -6,6 +6,7 @@ import admin.settings.{AllSettingsProvider, SettingsSurrogateKeySyntax}
 import assets.AssetsResolver
 import cats.data.EitherT
 import cats.implicits._
+import com.gu.i18n.Title
 import com.gu.identity.play.{AuthenticatedIdUser, IdMinimalUser, IdUser}
 import com.gu.support.config.{PayPalConfigProvider, StripeConfigProvider}
 import com.gu.support.workers.{Address, User}
@@ -114,6 +115,7 @@ class RegularContributions(
     User(
       id = user.id,
       primaryEmailAddress = user.primaryEmailAddress,
+      title = Some(Title.Mrs),
       firstName = request.firstName,
       lastName = request.lastName,
       billingAddress = billingAddress(request),

--- a/support-frontend/app/controllers/RegularContributions.scala
+++ b/support-frontend/app/controllers/RegularContributions.scala
@@ -115,7 +115,7 @@ class RegularContributions(
     User(
       id = user.id,
       primaryEmailAddress = user.primaryEmailAddress,
-      title = Some(Title.Mrs),
+      title = request.title,
       firstName = request.firstName,
       lastName = request.lastName,
       billingAddress = billingAddress(request),

--- a/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
+++ b/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
@@ -26,27 +26,37 @@ import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
 
 object CreateSupportWorkersRequest {
+
   import codecs.CirceDecoders._
+
   implicit val codec: Codec[CreateSupportWorkersRequest] = deriveCodec
 }
+
 case class CreateSupportWorkersRequest(
-    firstName: String,
-    lastName: String,
-    billingAddress: Address,
-    deliveryAddress: Option[Address],
-    product: ProductType,
-    firstDeliveryDate: Option[LocalDate],
-    paymentFields: PaymentFields,
-    promoCode: Option[PromoCode],
-    ophanIds: OphanIds,
-    referrerAcquisitionData: ReferrerAcquisitionData,
-    supportAbTests: Set[AbTest],
-    email: String,
-    telephoneNumber: Option[String]
+  title: Option[String],
+  firstName: String,
+  lastName: String,
+  billingAddress: Address,
+  deliveryAddress: Option[Address],
+  titleGiftRecipient: Option[String],
+  firstNameGiftRecipient: String,
+  lastNameGiftRecipient: String,
+  emailGiftRecipient: Option[String],
+  product: ProductType,
+  firstDeliveryDate: Option[LocalDate],
+  paymentFields: PaymentFields,
+  promoCode: Option[PromoCode],
+  ophanIds: OphanIds,
+  referrerAcquisitionData: ReferrerAcquisitionData,
+  supportAbTests: Set[AbTest],
+  email: String,
+  telephoneNumber: Option[String]
 )
 
 object SupportWorkersClient {
+
   sealed trait SupportWorkersError
+
   case object StateMachineFailure extends SupportWorkersError
 
   def apply(
@@ -59,10 +69,10 @@ object SupportWorkersClient {
 }
 
 case class StatusResponse(
-    status: Status,
-    trackingUri: String,
-    failureReason: Option[CheckoutFailureReason] = None,
-    guestAccountCreationToken: Option[String] = None
+  status: Status,
+  trackingUri: String,
+  failureReason: Option[CheckoutFailureReason] = None,
+  guestAccountCreationToken: Option[String] = None
 )
 
 object StatusResponse {
@@ -73,10 +83,10 @@ object StatusResponse {
 }
 
 class SupportWorkersClient(
-    arn: StateMachineArn,
-    stateWrapper: StateWrapper,
-    supportUrl: String,
-    statusCall: String => Call
+  arn: StateMachineArn,
+  stateWrapper: StateWrapper,
+  supportUrl: String,
+  statusCall: String => Call
 )(implicit system: ActorSystem) {
   private implicit val sw = stateWrapper
   private implicit val ec = system.dispatcher

--- a/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
+++ b/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
@@ -8,7 +8,7 @@ import cats.data.EitherT
 import cats.implicits._
 import com.amazonaws.services.stepfunctions.model.StateExitedEventDetails
 import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
-import com.gu.i18n.Country
+import com.gu.i18n.{Country, Title}
 import com.gu.monitoring.SafeLogger
 import com.gu.monitoring.SafeLogger._
 import com.gu.support.encoding.Codec
@@ -33,12 +33,12 @@ object CreateSupportWorkersRequest {
 }
 
 case class CreateSupportWorkersRequest(
-  title: Option[String],
+  title: Option[Title],
   firstName: String,
   lastName: String,
   billingAddress: Address,
   deliveryAddress: Option[Address],
-  titleGiftRecipient: Option[String],
+  titleGiftRecipient: Option[Title],
   firstNameGiftRecipient: Option[String],
   lastNameGiftRecipient: Option[String],
   emailGiftRecipient: Option[String],

--- a/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
+++ b/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
@@ -39,8 +39,8 @@ case class CreateSupportWorkersRequest(
   billingAddress: Address,
   deliveryAddress: Option[Address],
   titleGiftRecipient: Option[String],
-  firstNameGiftRecipient: String,
-  lastNameGiftRecipient: String,
+  firstNameGiftRecipient: Option[String],
+  lastNameGiftRecipient: Option[String],
   emailGiftRecipient: Option[String],
   product: ProductType,
   firstDeliveryDate: Option[LocalDate],
@@ -100,6 +100,18 @@ class SupportWorkersClient(
     request.body.referrerAcquisitionData.copy(hostname = Some(hostname), gaClientId = gaClientId, userAgent = userAgent, ipAddress = Some(ipAddress))
   }
 
+  private def getGiftRecipient(request: CreateSupportWorkersRequest) =
+    for {
+      firstName <- request.firstNameGiftRecipient
+      lastName <- request.lastNameGiftRecipient
+    } yield GiftRecipient(
+      request.titleGiftRecipient,
+      firstName,
+      lastName,
+      request.emailGiftRecipient
+    )
+
+
   def createSubscription(
     request: AnyAuthRequest[CreateSupportWorkersRequest],
     user: User,
@@ -110,6 +122,7 @@ class SupportWorkersClient(
     val createPaymentMethodState = CreatePaymentMethodState(
       requestId = requestId,
       user = user,
+      giftRecipient = getGiftRecipient(request.body),
       product = request.body.product,
       paymentFields = request.body.paymentFields,
       acquisitionData = Some(AcquisitionData(

--- a/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
+++ b/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
@@ -16,6 +16,7 @@ import type { ProductOptions } from 'helpers/productPrice/productOptions';
 
 import { type ThankYouPageStage } from '../../pages/contributions-landing/contributionsLandingReducer';
 import { DirectDebit, ExistingCard, ExistingDirectDebit, PayPal, Stripe } from 'helpers/paymentMethods';
+import type { Title } from 'helpers/user/details';
 
 // ----- Types ----- //
 
@@ -67,11 +68,16 @@ export type RegularPaymentRequestAddress = {|
 |};
 
 export type RegularPaymentRequest = {|
+  title?: Option<Title>,
   firstName: string,
   lastName: string,
   billingAddress: RegularPaymentRequestAddress,
   deliveryAddress: Option<RegularPaymentRequestAddress>,
   email: string,
+  titleGiftRecipient?: Option<Title>,
+  firstNameGiftRecipient?: string,
+  lastNameGiftRecipient?: string,
+  emailGiftRecipient?: Option<string>,
   product: ProductFields,
   firstDeliveryDate: Option<string>,
   paymentFields: RegularPaymentFields,

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.js
@@ -121,10 +121,15 @@ function buildRegularPaymentRequest(
 ): RegularPaymentRequest {
   const { currencyId } = state.common.internationalisation;
   const {
+    title,
     firstName,
     lastName,
     email,
     telephone,
+    titleGiftRecipient,
+    firstNameGiftRecipient,
+    lastNameGiftRecipient,
+    emailGiftRecipient,
     billingPeriod,
     fulfilmentOption,
     productOption,
@@ -149,10 +154,15 @@ function buildRegularPaymentRequest(
   const promotion = getAppliedPromo(price.promotions);
 
   return {
+    title,
     firstName,
     lastName,
     ...getAddresses(state),
     email,
+    titleGiftRecipient,
+    firstNameGiftRecipient,
+    lastNameGiftRecipient,
+    emailGiftRecipient,
     telephoneNumber: telephone,
     product,
     firstDeliveryDate: state.page.checkout.startDate,

--- a/support-frontend/test/utils/CheckoutValidationRulesTest.scala
+++ b/support-frontend/test/utils/CheckoutValidationRulesTest.scala
@@ -177,6 +177,7 @@ class PaperValidationTest extends FlatSpec with Matchers {
 object TestData {
 
   val validDigitalPackRequest = CreateSupportWorkersRequest(
+    title = None,
     firstName = "grace",
     lastName = "hopper",
     product = DigitalPack(Currency.USD, Monthly),
@@ -196,7 +197,11 @@ object TestData {
       postCode = Some("111111"),
       country = Country.US,
     ),
-    deliveryAddress = None
+    deliveryAddress = None,
+    titleGiftRecipient = None,
+    firstNameGiftRecipient = None,
+    lastNameGiftRecipient = None,
+    emailGiftRecipient = None
   )
 
   val someDateNextMonth = new LocalDate().plusMonths(1)
@@ -209,6 +214,7 @@ object TestData {
     country = Country.UK
   )
   val validPaperRequest = CreateSupportWorkersRequest(
+    title = None,
     firstName = "grace",
     lastName = "hopper",
     product = Paper(Currency.GBP, Monthly, HomeDelivery, Everyday),
@@ -221,7 +227,11 @@ object TestData {
     telephoneNumber = None,
     promoCode = None,
     billingAddress = paperAddress,
-    deliveryAddress = Some(paperAddress)
+    deliveryAddress = Some(paperAddress),
+    titleGiftRecipient = None,
+    firstNameGiftRecipient = None,
+    lastNameGiftRecipient = None,
+    emailGiftRecipient = None
   )
 
 }

--- a/support-models/src/main/scala/com/gu/salesforce/AddressLineTransformer.scala
+++ b/support-models/src/main/scala/com/gu/salesforce/AddressLineTransformer.scala
@@ -1,4 +1,7 @@
-package com.gu.support.workers
+package com.gu.salesforce
+
+import com.gu.salesforce.AddressLineTransformer.combinedAddressLine
+import com.gu.support.workers.Address
 
 import scala.util.matching.Regex
 
@@ -48,6 +51,11 @@ object AddressLineTransformer {
 case class AddressLine(streetNumber: Option[String], streetName: String)
 
 object AddressLine {
+
+  def getAddressLine(address: Address): Option[String] = combinedAddressLine(
+    address.lineOne,
+    address.lineTwo
+  ).map(asFormattedString)
 
   def asFormattedString(addressLine: AddressLine): String = {
     val streetNumberString = addressLine.streetNumber match {

--- a/support-models/src/main/scala/com/gu/salesforce/Salesforce.scala
+++ b/support-models/src/main/scala/com/gu/salesforce/Salesforce.scala
@@ -102,7 +102,9 @@ object Salesforce {
 
   case class SalesforceContactResponse(Success: Boolean, ErrorString: Option[String], ContactRecord: SalesforceContactRecord) extends SalesforceResponse
 
-  case class SalesforceContactRecords(buyer: SalesforceContactRecord, giftRecipient: Option[SalesforceContactRecord])
+  case class SalesforceContactRecords(buyer: SalesforceContactRecord, giftRecipient: Option[SalesforceContactRecord]){
+    def recipient: SalesforceContactRecord = giftRecipient.getOrElse(buyer)
+  }
 
   case class SalesforceContactRecordsResponse(buyer: SalesforceContactResponse, giftRecipient: Option[SalesforceContactResponse]) {
     def successful: Boolean = buyer.Success && giftRecipient.forall(_.Success)

--- a/support-models/src/main/scala/com/gu/salesforce/Salesforce.scala
+++ b/support-models/src/main/scala/com/gu/salesforce/Salesforce.scala
@@ -32,9 +32,6 @@ object Salesforce {
       )
   }
 
-  //The odd field names on these class are to match with the Salesforce api and allow us to serialise and deserialise
-  //without a lot of custom mapping code
-
   sealed trait UpsertData
 
   object UpsertData {
@@ -50,6 +47,8 @@ object Salesforce {
       ).reduceLeft(_ or _)
   }
 
+  //The odd field names on these class are to match with the Salesforce api and allow us to serialise and deserialise
+  //without a lot of custom mapping code
   case class NewContact(
     IdentityID__c: String,
     Email: String,

--- a/support-models/src/main/scala/com/gu/salesforce/Salesforce.scala
+++ b/support-models/src/main/scala/com/gu/salesforce/Salesforce.scala
@@ -53,6 +53,7 @@ object Salesforce {
   case class NewContact(
     IdentityID__c: String,
     Email: String,
+    Salutation: Option[Title],
     FirstName: String,
     LastName: String,
     OtherStreet: Option[String],
@@ -74,7 +75,7 @@ object Salesforce {
   case class DeliveryContact(
     AccountId: String,
     Email: Option[String],
-    Title: Option[Title],
+    Salutation: Option[Title],
     FirstName: String,
     LastName: String,
     MailingStreet: Option[String],

--- a/support-models/src/main/scala/com/gu/salesforce/Salesforce.scala
+++ b/support-models/src/main/scala/com/gu/salesforce/Salesforce.scala
@@ -11,17 +11,10 @@ import com.gu.support.workers.SalesforceContactRecord
 import com.gu.support.workers.exceptions.{RetryException, RetryNone, RetryUnlimited}
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.syntax._
-import io.circe.{Decoder, Encoder}
+import io.circe.{Decoder, Encoder, Json}
 import org.joda.time.DateTime
 
 object Salesforce {
-
-  type RecordTypeId = String
-
-  object RecordType {
-    val deliveryRecipientContactId: RecordTypeId = "01220000000VB50AAG"
-    val standardCustomerId: RecordTypeId = "01220000000VB52AAG"
-  }
 
   implicit val salesforceContactRecordCodec: Codec[SalesforceContactRecord] = deriveCodec
 
@@ -32,7 +25,11 @@ object Salesforce {
 
   object DeliveryContact {
     implicit val decoder: Decoder[DeliveryContact] = deriveDecoder
-    implicit val encoder: Encoder[DeliveryContact] = deriveEncoder[DeliveryContact].mapJsonObject(_.wrapObject("newContact"))
+    implicit val encoder: Encoder[DeliveryContact] = deriveEncoder[DeliveryContact]
+      .mapJsonObject(
+        _.add("RecordTypeId", Json.fromString("01220000000VB50AAG"))
+          .wrapObject("newContact")
+      )
   }
 
   //The odd field names on these class are to match with the Salesforce api and allow us to serialise and deserialise
@@ -76,7 +73,6 @@ object Salesforce {
 
   case class DeliveryContact(
     AccountId: String,
-    RecordTypeId: RecordTypeId,
     Email: Option[String],
     Title: Option[Title],
     FirstName: String,

--- a/support-models/src/main/scala/com/gu/support/encoding/CustomCodecs.scala
+++ b/support-models/src/main/scala/com/gu/support/encoding/CustomCodecs.scala
@@ -2,7 +2,7 @@ package com.gu.support.encoding
 
 import java.util.UUID
 
-import com.gu.i18n.{Country, CountryGroup, Currency}
+import com.gu.i18n.{Country, CountryGroup, Currency, Title}
 import io.circe.{Decoder, Encoder, KeyDecoder, KeyEncoder}
 import org.joda.time.{DateTime, Days, LocalDate, Months}
 
@@ -11,6 +11,9 @@ import scala.util.Try
 object CustomCodecs extends InternationalisationCodecs with HelperCodecs
 
 trait InternationalisationCodecs {
+  implicit val encodeTitle: Encoder[Title] = Encoder.encodeString.contramap(_.title)
+  implicit val decodeTitle: Decoder[Title] = Decoder.decodeString.emap(title => Title.fromString(title).toRight(s"Unrecognised title $title"))
+
   implicit val encodeCurrency: Encoder[Currency] = Encoder.encodeString.contramap[Currency](_.iso)
 
   implicit val decodeCurrency: Decoder[Currency] =
@@ -26,7 +29,8 @@ trait InternationalisationCodecs {
 
   implicit val countryGroupEncoder: Encoder[CountryGroup] = Encoder.encodeString.contramap(_.name)
 
-  implicit val countryGroupDecoder: Decoder[CountryGroup] = Decoder.decodeString.emap(id => CountryGroup.byName(id).toRight(s"Unrecognised country group id '$id'"))
+  implicit val countryGroupDecoder: Decoder[CountryGroup] =
+    Decoder.decodeString.emap(id => CountryGroup.byName(id).toRight(s"Unrecognised country group id '$id'"))
 
   implicit val countryGroupKeyEncoder: KeyEncoder[CountryGroup] = (value: CountryGroup) => value.name.toString
 

--- a/support-models/src/main/scala/com/gu/support/encoding/JsonHelpers.scala
+++ b/support-models/src/main/scala/com/gu/support/encoding/JsonHelpers.scala
@@ -42,6 +42,10 @@ object JsonHelpers {
       else
         jsonObject.add(key, default)
 
+    def wrapObject(key: String) =
+      JsonObject.empty.add(key, Json.fromJsonObject(jsonObject))
+
+
     def mapKeys(f: String => String): JsonObject = {
       //ignore intelliJ, this is needed!
       import cats.implicits._

--- a/support-models/src/main/scala/com/gu/support/workers/GiftRecipient.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/GiftRecipient.scala
@@ -1,9 +1,11 @@
 package com.gu.support.workers
 
+import com.gu.i18n.Title
 import com.gu.support.encoding.Codec
 import com.gu.support.encoding.Codec.deriveCodec
+import com.gu.support.encoding.CustomCodecs._
 
-case class GiftRecipient(title: Option[String], firstName: String, lastName: String, email: Option[String])
+case class GiftRecipient(title: Option[Title], firstName: String, lastName: String, email: Option[String])
 
 object GiftRecipient {
   implicit val codec: Codec[GiftRecipient] = deriveCodec

--- a/support-models/src/main/scala/com/gu/support/workers/GiftRecipient.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/GiftRecipient.scala
@@ -1,0 +1,10 @@
+package com.gu.support.workers
+
+import com.gu.support.encoding.Codec
+import com.gu.support.encoding.Codec.deriveCodec
+
+case class GiftRecipient(title: Option[String], firstName: String, lastName: String, email: Option[String])
+
+object GiftRecipient {
+  implicit val codec: Codec[GiftRecipient] = deriveCodec
+}

--- a/support-models/src/main/scala/com/gu/support/workers/User.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/User.scala
@@ -1,12 +1,13 @@
 package com.gu.support.workers
 
-import com.gu.i18n.Country
+import com.gu.i18n.Title
 import com.gu.support.encoding.Codec
 import com.gu.support.encoding.Codec.deriveCodec
 
 case class User(
   id: String,
   primaryEmailAddress: String,
+  title: Option[Title],
   firstName: String,
   lastName: String,
   billingAddress: Address,

--- a/support-models/src/main/scala/com/gu/support/workers/states/CreatePaymentMethodState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/CreatePaymentMethodState.scala
@@ -10,6 +10,7 @@ import com.gu.support.encoding.CustomCodecs.{decodeLocalTime, encodeLocalTime}
 case class CreatePaymentMethodState(
   requestId: UUID,
   user: User,
+  giftRecipient: Option[GiftRecipient],
   product: ProductType,
   paymentFields: PaymentFields,
   firstDeliveryDate: Option[LocalDate],

--- a/support-models/src/main/scala/com/gu/support/workers/states/CreateSalesforceContactState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/CreateSalesforceContactState.scala
@@ -10,6 +10,7 @@ import com.gu.support.encoding.CustomCodecs.{decodeLocalTime, encodeLocalTime}
 case class CreateSalesforceContactState(
   requestId: UUID,
   user: User,
+  giftRecipient: Option[GiftRecipient],
   product: ProductType,
   paymentMethod: PaymentMethod,
   firstDeliveryDate: Option[LocalDate],

--- a/support-models/src/main/scala/com/gu/support/workers/states/CreateZuoraSubscriptionState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/CreateZuoraSubscriptionState.scala
@@ -2,6 +2,7 @@ package com.gu.support.workers.states
 
 import java.util.UUID
 
+import com.gu.salesforce.Salesforce.SalesforceContactRecords
 import com.gu.support.promotions.PromoCode
 import com.gu.support.workers.{PaymentMethod, SalesforceContactRecord, User, _}
 import org.joda.time.LocalDate
@@ -15,7 +16,8 @@ case class CreateZuoraSubscriptionState(
   paymentMethod: PaymentMethod,
   firstDeliveryDate: Option[LocalDate],
   promoCode: Option[PromoCode],
-  salesForceContact: SalesforceContactRecord,
+  salesForceContact: SalesforceContactRecord, //TODO: Remove this it is redundant now we have gifting
+  salesforceContacts: SalesforceContactRecords,
   acquisitionData: Option[AcquisitionData]
 ) extends StepFunctionUserState
 

--- a/support-models/src/main/scala/com/gu/support/workers/states/CreateZuoraSubscriptionState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/CreateZuoraSubscriptionState.scala
@@ -10,6 +10,7 @@ import com.gu.support.encoding.CustomCodecs.{decodeLocalTime, encodeLocalTime}
 case class CreateZuoraSubscriptionState(
   requestId: UUID,
   user: User,
+  giftRecipient: Option[GiftRecipient],
   product: ProductType,
   paymentMethod: PaymentMethod,
   firstDeliveryDate: Option[LocalDate],

--- a/support-models/src/main/scala/com/gu/support/workers/states/PreparePaymentMethodForReuseState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/PreparePaymentMethodForReuseState.scala
@@ -9,6 +9,7 @@ case class PreparePaymentMethodForReuseState(
     product: ProductType,
     paymentFields: ExistingPaymentFields,
     user: User,
+    giftRecipient: Option[GiftRecipient],
     acquisitionData: Option[AcquisitionData]
   ) extends StepFunctionUserState
 

--- a/support-models/src/main/scala/com/gu/support/workers/states/SendThankYouEmailState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/SendThankYouEmailState.scala
@@ -9,6 +9,7 @@ import org.joda.time.LocalDate
 case class SendThankYouEmailState(
   requestId: UUID,
   user: User,
+  giftRecipient: Option[GiftRecipient],
   product: ProductType,
   paymentMethod: PaymentMethod,
   firstDeliveryDate: Option[LocalDate],

--- a/support-models/src/test/scala/com/gu/support/encoding/JsonHelpersSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/encoding/JsonHelpersSpec.scala
@@ -1,0 +1,29 @@
+package com.gu.support.encoding
+
+import io.circe.{Json, JsonObject}
+import org.scalatest.{FlatSpec, Matchers}
+import JsonHelpers._
+import io.circe.parser._
+
+class JsonHelpersSpec extends FlatSpec with Matchers {
+
+  "JsonHelper" should "be able to wrap a JsonObject" in {
+    val initialObject = JsonObject(("name", Json.fromString("Bill")))
+
+
+    val result = initialObject.wrapObject("user")
+
+    val json = Json.fromJsonObject(result)
+
+    val correct =
+      """
+        {
+          "user": {
+            "name": "Bill"
+            }
+        }
+      """
+
+    json shouldBe parse(correct).right.get
+  }
+}

--- a/support-models/src/test/scala/com/gu/support/workers/Fixtures.scala
+++ b/support-models/src/test/scala/com/gu/support/workers/Fixtures.scala
@@ -232,6 +232,19 @@ object Fixtures {
         }
       """
 
+  val salesforceContactsJson =
+    """{
+          "buyer": {
+              "Id": "003g000001UnFItAAN",
+              "AccountId": "001g000001gOR06AAG"
+            },
+          "giftRecipient": {
+              "Id": "003g000001UnFItAAN",
+              "AccountId": "001g000001gOR06AAG"
+            }
+       }
+      """
+
   def createContributionZuoraSubscriptionJson(billingPeriod: BillingPeriod = Monthly): String =
     s"""
           {
@@ -239,7 +252,8 @@ object Fixtures {
             $userJson,
             "product": ${contribution(billingPeriod = billingPeriod)},
             "paymentMethod": $stripePaymentMethod,
-            "salesForceContact": $salesforceContactJson
+            "salesForceContact": $salesforceContactJson,
+            "salesforceContacts": $salesforceContactsJson
             }
         """
   def createDigiPackZuoraSubscriptionJson: String =
@@ -249,7 +263,8 @@ object Fixtures {
             $userJson,
             "product": $digitalPackJson,
             "paymentMethod": $stripePaymentMethod,
-            "salesForceContact": $salesforceContactJson
+            "salesForceContact": $salesforceContactJson,
+            "salesforceContacts": $salesforceContactsJson
             }
         """
 

--- a/support-models/src/test/scala/com/gu/support/zuora/api/Fixtures.scala
+++ b/support-models/src/test/scala/com/gu/support/zuora/api/Fixtures.scala
@@ -177,7 +177,8 @@ object Fixtures {
         "TermType" : "TERMED",
         "InitialPromotionCode__c": "$promoCode",
         "PromotionCode__c": "$promoCode",
-        "CreatedRequestId__c": "id123"
+        "CreatedRequestId__c": "id123",
+        "ReaderType__c": "Direct"
       }
     """
 

--- a/support-models/src/test/scala/com/gu/support/zuora/api/SerialisationSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/zuora/api/SerialisationSpec.scala
@@ -2,7 +2,6 @@ package com.gu.support.zuora.api
 
 import com.gu.i18n.Currency.GBP
 import com.gu.support.SerialisationTestHelpers
-import com.gu.support.SerialisationTestHelpers._
 import com.gu.support.encoding.CustomCodecs._
 import com.gu.support.workers.PaymentFields
 import com.gu.support.zuora.api.Fixtures._
@@ -11,9 +10,9 @@ import com.typesafe.scalalogging.LazyLogging
 import io.circe.Json
 import io.circe.parser._
 import io.circe.syntax._
-import org.joda.time.{DateTime, LocalDate}
+import org.joda.time.LocalDate
 import org.joda.time.Months.months
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.FlatSpec
 
 class SerialisationSpec extends FlatSpec with SerialisationTestHelpers with LazyLogging {
 

--- a/support-workers/src/main/scala/com/gu/salesforce/SalesforceService.scala
+++ b/support-workers/src/main/scala/com/gu/salesforce/SalesforceService.scala
@@ -68,6 +68,7 @@ class SalesforceService(config: SalesforceConfig, client: FutureHttpClient)(impl
     NewContact(
       user.id,
       user.primaryEmailAddress,
+      user.title,
       user.firstName,
       user.lastName,
       getAddressLine(user.billingAddress),

--- a/support-workers/src/main/scala/com/gu/salesforce/SalesforceService.scala
+++ b/support-workers/src/main/scala/com/gu/salesforce/SalesforceService.scala
@@ -11,9 +11,9 @@ import com.gu.support.workers.AddressLine.asFormattedString
 import com.gu.support.workers.AddressLineTransformer.combinedAddressLine
 import com.gu.support.workers.{Address, GiftRecipient, SalesforceContactRecord, User}
 import io.circe
+import io.circe.Decoder
 import io.circe.parser._
 import io.circe.syntax._
-import io.circe.{Decoder, Json}
 import okhttp3.Request
 
 import scala.concurrent.duration._
@@ -90,7 +90,6 @@ class SalesforceService(config: SalesforceConfig, client: FutureHttpClient)(impl
   private def getGiftRecipient(buyerAccountId: String, deliveryAddress: Address, giftRecipient: GiftRecipient) =
     DeliveryContact(
       buyerAccountId,
-      RecordType.deliveryRecipientContactId,
       giftRecipient.email,
       giftRecipient.title,
       giftRecipient.firstName,

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -51,6 +51,7 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
     CreateSalesforceContactState(
       state.requestId,
       state.user,
+      state.giftRecipient,
       state.product,
       paymentMethod,
       state.firstDeliveryDate,

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -4,6 +4,7 @@ import com.amazonaws.services.lambda.runtime.Context
 import com.gu.i18n.{CountryGroup, Currency}
 import com.gu.monitoring.SafeLogger
 import com.gu.paypal.PayPalService
+import com.gu.salesforce.AddressLineTransformer
 import com.gu.services.{ServiceProvider, Services}
 import com.gu.stripe.StripeService
 import com.gu.support.encoding.CustomCodecs._

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
@@ -16,14 +16,14 @@ class CreateSalesforceContact extends ServicesHandler[CreateSalesforceContactSta
     SafeLogger.debug(s"CreateSalesforceContact state: $state")
 
     services.salesforceService.createContactRecords(state.user, state.giftRecipient)
-    .map(response =>
-      if (response.successful) {
-        HandlerResult(getCreateZuoraSubscriptionState(state, response.contactRecords), requestInfo)
-      } else {
-        val errorMessage = response.errorMessage.getOrElse("No error message returned")
-        SafeLogger.warn(s"Error creating Salesforce contact:\n$errorMessage")
-        throw new SalesforceException(errorMessage)
-      })
+      .map(response =>
+        if (response.successful) {
+          HandlerResult(getCreateZuoraSubscriptionState(state, response.contactRecords), requestInfo)
+        } else {
+          val errorMessage = response.errorMessage.getOrElse("No error message returned")
+          SafeLogger.warn(s"Error creating Salesforce contact:\n$errorMessage")
+          throw new SalesforceException(errorMessage)
+        })
   }
 
   private def getCreateZuoraSubscriptionState(state: CreateSalesforceContactState, response: SalesforceContactRecords) =

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
@@ -2,7 +2,7 @@ package com.gu.support.workers.lambdas
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.monitoring.SafeLogger
-import com.gu.salesforce.Salesforce.{DeliveryContact, NewContact, RecordType, SalesforceContactRecords, SalesforceContactResponse}
+import com.gu.salesforce.Salesforce.{DeliveryContact, NewContact, SalesforceContactRecords, SalesforceContactResponse}
 import com.gu.services.{ServiceProvider, Services}
 import com.gu.support.workers.RequestInfo
 import com.gu.support.workers.exceptions.SalesforceException

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
@@ -2,10 +2,8 @@ package com.gu.support.workers.lambdas
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.monitoring.SafeLogger
-import com.gu.salesforce.Salesforce.{SalesforceContactResponse, UpsertData}
+import com.gu.salesforce.Salesforce.{DeliveryContact, NewContact, RecordType, SalesforceContactRecords, SalesforceContactResponse}
 import com.gu.services.{ServiceProvider, Services}
-import com.gu.support.workers.AddressLine.asFormattedString
-import com.gu.support.workers.AddressLineTransformer.combinedAddressLine
 import com.gu.support.workers.RequestInfo
 import com.gu.support.workers.exceptions.SalesforceException
 import com.gu.support.workers.states.{CreateSalesforceContactState, CreateZuoraSubscriptionState}
@@ -17,41 +15,18 @@ class CreateSalesforceContact extends ServicesHandler[CreateSalesforceContactSta
   override protected def servicesHandler(state: CreateSalesforceContactState, requestInfo: RequestInfo, context: Context, services: Services) = {
     SafeLogger.debug(s"CreateSalesforceContact state: $state")
 
-    val billingAddressLine = combinedAddressLine(state.user.billingAddress.lineOne, state.user.billingAddress.lineTwo).map(asFormattedString)
-    val deliveryAddressLine = combinedAddressLine(
-      state.user.deliveryAddress.flatMap(_.lineOne),
-      state.user.deliveryAddress.flatMap(_.lineTwo)).map(asFormattedString)
-
-    services.salesforceService.upsert(UpsertData.create(
-      state.user.id,
-      state.user.primaryEmailAddress,
-      state.user.firstName,
-      state.user.lastName,
-      billingAddressLine,
-      state.user.billingAddress.city,
-      state.user.billingAddress.state,
-      state.user.billingAddress.postCode,
-      state.user.billingAddress.country.name,
-      deliveryAddressLine,
-      state.user.deliveryAddress.flatMap(_.city),
-      state.user.deliveryAddress.flatMap(_.state),
-      state.user.deliveryAddress.flatMap(_.postCode),
-      state.user.deliveryAddress.map(_.country.name),
-      state.user.telephoneNumber,
-      state.user.allowMembershipMail,
-      state.user.allowThirdPartyMail,
-      state.user.allowGURelatedMail
-    )).map(response =>
-      if (response.Success) {
-        HandlerResult(getCreateZuoraSubscriptionState(state, response), requestInfo)
+    services.salesforceService.createContactRecords(state.user, state.giftRecipient)
+    .map(response =>
+      if (response.successful) {
+        HandlerResult(getCreateZuoraSubscriptionState(state, response.contactRecords), requestInfo)
       } else {
-        val errorMessage = response.ErrorString.getOrElse("No error message returned")
+        val errorMessage = response.errorMessage.getOrElse("No error message returned")
         SafeLogger.warn(s"Error creating Salesforce contact:\n$errorMessage")
         throw new SalesforceException(errorMessage)
       })
   }
 
-  private def getCreateZuoraSubscriptionState(state: CreateSalesforceContactState, response: SalesforceContactResponse) =
+  private def getCreateZuoraSubscriptionState(state: CreateSalesforceContactState, response: SalesforceContactRecords) =
     CreateZuoraSubscriptionState(
       state.requestId,
       state.user,
@@ -60,7 +35,8 @@ class CreateSalesforceContact extends ServicesHandler[CreateSalesforceContactSta
       state.paymentMethod,
       state.firstDeliveryDate,
       state.promoCode,
-      response.ContactRecord,
+      response.buyer,
+      response,
       state.acquisitionData
     )
 }

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
@@ -55,6 +55,7 @@ class CreateSalesforceContact extends ServicesHandler[CreateSalesforceContactSta
     CreateZuoraSubscriptionState(
       state.requestId,
       state.user,
+      state.giftRecipient,
       state.product,
       state.paymentMethod,
       state.firstDeliveryDate,

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -86,6 +86,7 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
     SendThankYouEmailState(
       state.requestId,
       state.user,
+      state.giftRecipient,
       state.product,
       state.paymentMethod,
       state.firstDeliveryDate,
@@ -111,6 +112,11 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
   private def buildSubscriptionData(state: CreateZuoraSubscriptionState, promotionService: PromotionService) = {
     val isTestUser = state.user.isTestUser
     val config = zuoraConfigProvider.get(isTestUser)
+    val readerType: ReaderType = state.giftRecipient match  {
+      case _: Some[GiftRecipient] => ReaderType.Gift
+      case _ => ReaderType.Direct
+    }
+
     state.product match {
       case c: Contribution => c.build(state.requestId, config)
       case d: DigitalPack => d.build(state.requestId, config, state.user.billingAddress.country, state.promoCode, promotionService, isTestUser)
@@ -121,6 +127,7 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
         state.promoCode,
         state.firstDeliveryDate,
         promotionService,
+        readerType,
         isTestUser
       )
     }

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -90,7 +90,7 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
       state.product,
       state.paymentMethod,
       state.firstDeliveryDate,
-      state.salesForceContact,
+      state.salesforceContacts.buyer,
       accountNumber.value,
       subscriptionNumber.value,
       paymentSchedule,
@@ -148,12 +148,12 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
   }
 
   private def buildAccount(state: CreateZuoraSubscriptionState) = Account(
-    state.salesForceContact.AccountId, //We store the Salesforce Account id in the name field
-    state.product.currency,
-    state.salesForceContact.AccountId, //Somewhere else we store the Salesforce Account id
-    state.salesForceContact.Id,
-    state.user.id,
-    PaymentGateway.forPaymentMethod(state.paymentMethod, state.product.currency),
-    state.requestId.toString
+    name = state.salesforceContacts.recipient.AccountId, //We store the Salesforce Account id in the name field
+    currency = state.product.currency,
+    crmId = state.salesforceContacts.recipient.AccountId, //Somewhere else we store the Salesforce Account id
+    sfContactId__c = state.salesforceContacts.buyer.Id,
+    identityId__c = state.user.id,
+    paymentGateway = PaymentGateway.forPaymentMethod(state.paymentMethod, state.product.currency),
+    createdRequestId__c = state.requestId.toString
   )
 }

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/PreparePaymentMethodForReuse.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/PreparePaymentMethodForReuse.scala
@@ -38,6 +38,7 @@ class PreparePaymentMethodForReuse(servicesProvider: ServiceProvider = ServicePr
         CreateZuoraSubscriptionState(
           requestId = UUID.randomUUID(),
           user = state.user,
+          giftRecipient = state.giftRecipient,
           product = state.product,
           paymentMethod =  paymentMethod,
           firstDeliveryDate = None,

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/PreparePaymentMethodForReuse.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/PreparePaymentMethodForReuse.scala
@@ -5,6 +5,7 @@ import java.util.UUID
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.gocardless.GoCardlessWorkersService
 import com.gu.i18n.{Country, CountryGroup}
+import com.gu.salesforce.Salesforce.SalesforceContactRecords
 import com.gu.services.{ServiceProvider, Services}
 import com.gu.support.workers._
 import com.gu.support.workers.lambdas.PaymentMethodExtensions.PaymentMethodExtension
@@ -44,6 +45,7 @@ class PreparePaymentMethodForReuse(servicesProvider: ServiceProvider = ServicePr
           firstDeliveryDate = None,
           promoCode = None,
           salesForceContact = sfContact,
+          salesforceContacts = SalesforceContactRecords(sfContact, None),
           acquisitionData = state.acquisitionData
         ),
       requestInfo

--- a/support-workers/src/main/scala/com/gu/zuora/ProductSubscriptionBuilders.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/ProductSubscriptionBuilders.scala
@@ -115,6 +115,7 @@ object ProductSubscriptionBuilders {
       maybePromoCode: Option[PromoCode],
       firstDeliveryDate: Option[LocalDate],
       promotionService: PromotionService,
+      readerType: ReaderType,
       isTestUser: Boolean
     ): SubscriptionData = {
 
@@ -132,6 +133,7 @@ object ProductSubscriptionBuilders {
         productRatePlanId,
         contractAcceptanceDate = contractAcceptanceDate,
         contractEffectiveDate = contractEffectiveDate,
+        readerType = readerType
       )
 
       applyPromoCode(promotionService, maybePromoCode, country, productRatePlanId, subscriptionData)
@@ -147,7 +149,8 @@ trait ProductSubscriptionBuilder {
     productRatePlanId: ProductRatePlanId,
     ratePlanCharges: List[RatePlanChargeData] = Nil,
     contractEffectiveDate: LocalDate = LocalDate.now(DateTimeZone.UTC),
-    contractAcceptanceDate: LocalDate = LocalDate.now(DateTimeZone.UTC)
+    contractAcceptanceDate: LocalDate = LocalDate.now(DateTimeZone.UTC),
+    readerType: ReaderType = ReaderType.Direct
   ) =
     SubscriptionData(
       List(
@@ -157,7 +160,7 @@ trait ProductSubscriptionBuilder {
           Nil
         )
       ),
-      Subscription(contractEffectiveDate, contractAcceptanceDate, contractEffectiveDate, createdRequestId.toString)
+      Subscription(contractEffectiveDate, contractAcceptanceDate, contractEffectiveDate, createdRequestId.toString, readerType = readerType)
     )
 
   protected def applyPromoCode(

--- a/support-workers/src/test/scala/com/gu/salesforce/Fixtures.scala
+++ b/support-workers/src/test/scala/com/gu/salesforce/Fixtures.scala
@@ -6,9 +6,10 @@ import com.gu.salesforce.Salesforce.{DeliveryContact, NewContact}
 object Fixtures {
   val idId = "9999999"
   val salesforceId = "0033E000017rqXsQAI"
-  val emailAddress = "yjcysqxfcqqytuzupjc@gu.com"
+  val salesforceAccountId = "0013E000011gxQuQAI"
+  val emailAddress = "integration-test@gu.com"
   val telephoneNumber = "0123456789"
-  val name = "YJCysqXFCqqYtuzuPJc"
+  val name = "integration-test"
   val street = "123 trash alley"
   val city = "London"
   val postCode = "n1 9gu"
@@ -20,6 +21,7 @@ object Fixtures {
   val newContactUK = NewContact(
     IdentityID__c = idId,
     Email = emailAddress,
+    Salutation= Some(Title.Mrs),
     FirstName = name,
     LastName = name,
     OtherStreet = None,
@@ -57,7 +59,7 @@ object Fixtures {
   val giftRecipientUpsert = DeliveryContact(
     AccountId = salesforceId,
     Email = Some(emailAddress),
-    Title = Some(Title.Mr),
+    Salutation = Some(Title.Mr),
     FirstName = name,
     LastName = name,
     MailingStreet = Some(street),
@@ -73,6 +75,7 @@ object Fixtures {
       "newContact": {
         "IdentityID__c": "$idId",
         "Email": "$emailAddress",
+        "Salutation": "Mrs",
         "FirstName": "$name",
         "LastName": "$name",
         "OtherCountry": "$uk",
@@ -86,6 +89,7 @@ object Fixtures {
       "newContact": {
         "IdentityID__c": "$idId",
         "Email": "$emailAddress",
+        "Salutation": "Mrs",
         "FirstName": "$name",
         "LastName": "$name",
         "OtherState": "$state",
@@ -101,6 +105,7 @@ object Fixtures {
       "newContact": {
         "IdentityID__c": "$idId",
         "Email": "$emailAddress",
+        "Salutation": "Mrs",
         "FirstName": "$name",
         "LastName": "$name",
         "OtherCountry": "$uk",
@@ -116,6 +121,7 @@ object Fixtures {
       "newContact": {
         "IdentityID__c": "$idId",
         "Email": "$emailAddress",
+        "Salutation": "Mrs",
         "FirstName": "$name",
         "LastName": "$name",
         "OtherStreet": "$street",
@@ -133,6 +139,7 @@ object Fixtures {
       "newContact": {
         "IdentityID__c": "$idId",
         "Email": "$emailAddress",
+        "Salutation": "Mrs",
         "FirstName": "$name",
         "LastName": "$name",
         "OtherStreet": "$street",
@@ -155,7 +162,7 @@ object Fixtures {
       "newContact": {
         "AccountId": "$salesforceId",
         "Email": "$emailAddress",
-        "Title": "Mr",
+        "Salutation": "Mr",
         "FirstName": "$name",
         "LastName": "$name",
         "MailingStreet": "$street",

--- a/support-workers/src/test/scala/com/gu/salesforce/Fixtures.scala
+++ b/support-workers/src/test/scala/com/gu/salesforce/Fixtures.scala
@@ -1,6 +1,7 @@
 package com.gu.salesforce
 
-import com.gu.salesforce.Salesforce.NewContact
+import com.gu.i18n.Title
+import com.gu.salesforce.Salesforce.{DeliveryContact, NewContact}
 
 object Fixtures {
   val idId = "9999999"
@@ -16,7 +17,26 @@ object Fixtures {
   val state = "CA"
   val allowMail = false
 
-  val newContactUK = NewContact(idId, emailAddress, name, name, None, None, None, None, uk, None, None, None, None, None, None, allowMail, allowMail, allowMail)
+  val newContactUK = NewContact(
+    IdentityID__c = idId,
+    Email = emailAddress,
+    FirstName = name,
+    LastName = name,
+    OtherStreet = None,
+    OtherCity = None,
+    OtherState = None,
+    OtherPostalCode = None,
+    OtherCountry = uk,
+    MailingStreet = None,
+    MailingCity = None,
+    MailingState = None,
+    MailingPostalCode = None,
+    MailingCountry = None,
+    Phone = None,
+    Allow_Membership_Mail__c = allowMail,
+    Allow_3rd_Party_Mail__c = allowMail,
+    Allow_Guardian_Related_Mail__c = allowMail
+  )
   val newContactUKWithBillingAddress = newContactUK.copy(
     OtherStreet = Some("123 trash alley"),
     OtherCity = Some("London"),
@@ -33,6 +53,19 @@ object Fixtures {
     Phone = Some(telephoneNumber)
   )
   val newContactUS = newContactUK.copy(OtherCountry = us, OtherState = Some(state))
+
+  val giftRecipientUpsert = DeliveryContact(
+    AccountId = salesforceId,
+    Email = Some(emailAddress),
+    Title = Some(Title.Mr),
+    FirstName = name,
+    LastName = name,
+    MailingStreet = Some(street),
+    MailingCity = Some(city),
+    MailingState = None,
+    MailingPostalCode = Some(postCode),
+    MailingCountry = Some(uk)
+  )
 
 
   val upsertJson =
@@ -114,6 +147,22 @@ object Fixtures {
         "Allow_Membership_Mail__c": $allowMail,
         "Allow_3rd_Party_Mail__c": $allowMail,
         "Allow_Guardian_Related_Mail__c": $allowMail
+       }
+      }"""
+
+  val giftRecipientUpsertJson =
+    s"""{
+      "newContact": {
+        "AccountId": "$salesforceId",
+        "Email": "$emailAddress",
+        "Title": "Mr",
+        "FirstName": "$name",
+        "LastName": "$name",
+        "MailingStreet": "$street",
+        "MailingCity": "$city",
+        "MailingPostalCode": "$postCode",
+        "MailingCountry": "$uk",
+        "RecordTypeId": "01220000000VB50AAG"
        }
       }"""
 

--- a/support-workers/src/test/scala/com/gu/salesforce/Fixtures.scala
+++ b/support-workers/src/test/scala/com/gu/salesforce/Fixtures.scala
@@ -4,7 +4,7 @@ import com.gu.salesforce.Salesforce.NewContact
 
 object Fixtures {
   val idId = "9999999"
-  val salesforceId = "0036E00000Uc1IhQAJ"
+  val salesforceId = "0033E000017rqXsQAI"
   val emailAddress = "yjcysqxfcqqytuzupjc@gu.com"
   val telephoneNumber = "0123456789"
   val name = "YJCysqXFCqqYtuzuPJc"

--- a/support-workers/src/test/scala/com/gu/salesforce/Fixtures.scala
+++ b/support-workers/src/test/scala/com/gu/salesforce/Fixtures.scala
@@ -9,6 +9,7 @@ object Fixtures {
   val salesforceAccountId = "0013E000011gxQuQAI"
   val emailAddress = "integration-test@gu.com"
   val telephoneNumber = "0123456789"
+  val title = Title.Mrs
   val name = "integration-test"
   val street = "123 trash alley"
   val city = "London"

--- a/support-workers/src/test/scala/com/gu/salesforce/SalesforceSpec.scala
+++ b/support-workers/src/test/scala/com/gu/salesforce/SalesforceSpec.scala
@@ -3,7 +3,7 @@ package com.gu.salesforce
 import com.gu.config.Configuration
 import com.gu.okhttp.RequestRunners.configurableFutureRunner
 import com.gu.salesforce.Fixtures._
-import com.gu.salesforce.Salesforce.{Authentication, SalesforceContactResponse, UpsertData}
+import com.gu.salesforce.Salesforce.{Authentication, NewContact, SalesforceContactResponse}
 import com.gu.test.tags.annotations.IntegrationTest
 import com.typesafe.scalalogging.LazyLogging
 import org.scalatest.{AsyncFlatSpec, Matchers}
@@ -52,25 +52,25 @@ class SalesforceSpec extends AsyncFlatSpec with Matchers with LazyLogging {
 
   "SalesforceService" should "be able to upsert a customer" in {
     val service = new SalesforceService(Configuration.salesforceConfigProvider.get(), configurableFutureRunner(10.seconds))
-    val upsertData = UpsertData.create(
-      identityId = idId,
-      email = emailAddress,
-      firstName = name,
-      lastName = name,
-      billingStreet = None,
-      billingCity = None,
-      billingPostcode = None,
-      billingState = None,
-      billingCountry = uk,
-      deliveryStreet = None,
-      deliveryCity = None,
-      deliveryPostcode = None,
-      deliveryState = None,
-      deliveryCountry = None,
-      telephoneNumber = None,
-      allowMembershipMail = allowMail,
-      allow3rdPartyMail = allowMail,
-      allowGuardianRelatedMail = allowMail
+    val upsertData = NewContact(
+      IdentityID__c = idId,
+      Email = emailAddress,
+      FirstName = name,
+      LastName = name,
+      OtherStreet = None,
+      OtherCity = None,
+      OtherState = None,
+      OtherPostalCode = None,
+      OtherCountry = uk,
+      MailingStreet = None,
+      MailingCity = None,
+      MailingState = None,
+      MailingPostalCode = None,
+      MailingCountry = None,
+      Phone = None,
+      Allow_Membership_Mail__c = allowMail,
+      Allow_3rd_Party_Mail__c = allowMail,
+      Allow_Guardian_Related_Mail__c = allowMail
     )
 
     service.upsert(upsertData).map { response: SalesforceContactResponse =>
@@ -82,25 +82,25 @@ class SalesforceSpec extends AsyncFlatSpec with Matchers with LazyLogging {
   "SalesforceService" should "be able to upsert a customer that has optional fields" in {
     val service = new SalesforceService(Configuration.salesforceConfigProvider.get(), configurableFutureRunner(10.seconds))
 
-    val upsertData = UpsertData.create(
-      identityId = idId,
-      email = emailAddress,
-      firstName = name,
-      lastName = name,
-      billingStreet = Some(street),
-      billingCity = Some(city),
-      billingPostcode = Some(postCode),
-      billingState = None,
-      billingCountry = uk,
-      deliveryStreet = Some(street),
-      deliveryCity = Some(city),
-      deliveryPostcode = Some(postCode),
-      deliveryState = None,
-      deliveryCountry = Some(uk),
-      telephoneNumber = Some(telephoneNumber),
-      allowMembershipMail = allowMail,
-      allow3rdPartyMail = allowMail,
-      allowGuardianRelatedMail = allowMail
+    val upsertData = NewContact(
+      IdentityID__c = idId,
+      Email = emailAddress,
+      FirstName = name,
+      LastName = name,
+      OtherStreet = Some(street),
+      OtherCity = Some(city),
+      OtherState = Some(postCode),
+      OtherPostalCode = None,
+      OtherCountry = uk,
+      MailingStreet = Some(street),
+      MailingCity = Some(city),
+      MailingState = Some(postCode),
+      MailingPostalCode = None,
+      MailingCountry = Some(uk),
+      Phone = Some(telephoneNumber),
+      Allow_Membership_Mail__c = allowMail,
+      Allow_3rd_Party_Mail__c = allowMail,
+      Allow_Guardian_Related_Mail__c = allowMail
     )
 
     service.upsert(upsertData).map { response: SalesforceContactResponse =>

--- a/support-workers/src/test/scala/com/gu/salesforce/SerialisationSpec.scala
+++ b/support-workers/src/test/scala/com/gu/salesforce/SerialisationSpec.scala
@@ -12,28 +12,25 @@ import org.scalatest.{FlatSpec, Matchers}
 class SerialisationSpec extends FlatSpec with Matchers with LazyLogging {
 
   "UpsertData" should "serialise to correct UK json" in {
-    val upsertData = UpsertData(newContactUK)
-    upsertData.asJson.pretty(Printer.noSpaces.copy(dropNullValues = true)) should be(parse(upsertJson).right.get.noSpaces)
+    newContactUK.asJson.pretty(Printer.noSpaces.copy(dropNullValues = true)) should be(parse(upsertJson).right.get.noSpaces)
   }
 
   "UpsertData" should "serialise to correct US json" in {
-    val upsertData = UpsertData(newContactUS)
-    upsertData.asJson.pretty(Printer.noSpaces.copy(dropNullValues = true)) should be(parse(upsertJsonWithState).right.get.noSpaces)
+    newContactUS.asJson.pretty(Printer.noSpaces.copy(dropNullValues = true)) should be(parse(upsertJsonWithState).right.get.noSpaces)
   }
 
   "UpsertData" should "serialise to correct json when telephoneNumber provided" in {
-    val upsertData = UpsertData(newContactUK.copy(Phone = Some(telephoneNumber)))
-    upsertData.asJson.pretty(Printer.noSpaces.copy(dropNullValues = true)) should be(parse(upsertJsonWithTelephoneNumber).right.get.noSpaces)
+    val newContactWithTelephone = newContactUK.copy(Phone = Some(telephoneNumber))
+    newContactWithTelephone.asJson.pretty(Printer.noSpaces.copy(dropNullValues = true)) should be(parse(upsertJsonWithTelephoneNumber).right.get.noSpaces)
   }
 
   "UpsertData" should "serialise to correct json when billing address provided" in {
-    val upsertData = UpsertData(newContactUKWithBillingAddress)
-    upsertData.asJson.pretty(Printer.noSpaces.copy(dropNullValues = true)) should be(parse(upsertJsonWithBillingAddress).right.get.noSpaces)
+    newContactUKWithBillingAddress.asJson.pretty(Printer.noSpaces.copy(dropNullValues = true)) should be(parse(upsertJsonWithBillingAddress).right.get.noSpaces)
   }
 
   "UpsertData" should "serialise to correct json when billing address and delivery address provided" in {
-    val upsertData = UpsertData(newContactUKWithBothAddressesAndTelephone)
-    upsertData.asJson.pretty(Printer.noSpaces.copy(dropNullValues = true)) should be(parse(upsertJsonWithBillingAndDeliveryAddresses).right.get.noSpaces)
+    newContactUKWithBothAddressesAndTelephone.asJson.
+      pretty(Printer.noSpaces.copy(dropNullValues = true)) should be(parse(upsertJsonWithBillingAndDeliveryAddresses).right.get.noSpaces)
   }
 
   "Authentication" should "deserialize correctly" in {

--- a/support-workers/src/test/scala/com/gu/salesforce/SerialisationSpec.scala
+++ b/support-workers/src/test/scala/com/gu/salesforce/SerialisationSpec.scala
@@ -33,6 +33,10 @@ class SerialisationSpec extends FlatSpec with Matchers with LazyLogging {
       pretty(Printer.noSpaces.copy(dropNullValues = true)) should be(parse(upsertJsonWithBillingAndDeliveryAddresses).right.get.noSpaces)
   }
 
+  "Gift recipient upsert data" should "serialise to correct json" in {
+    giftRecipientUpsert.asJson.pretty(Printer.noSpaces.copy(dropNullValues = true)) should be(parse(giftRecipientUpsertJson).right.get.noSpaces)
+  }
+
   "Authentication" should "deserialize correctly" in {
     val now = DateTime.now()
     val stale = DateTime.parse("1971-02-20")

--- a/support-workers/src/test/scala/com/gu/support/workers/AddressLineTransformerTest.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/AddressLineTransformerTest.scala
@@ -1,8 +1,9 @@
 package com.gu.support.workers
 
 import com.gu.i18n.Currency
-import com.gu.support.workers.AddressLineTransformer.combinedAddressLine
-import com.gu.support.workers.AddressLineTransformer.clipForZuoraStreetNameLimit
+import com.gu.salesforce.AddressLine
+import com.gu.salesforce.AddressLineTransformer.combinedAddressLine
+import com.gu.salesforce.AddressLineTransformer.clipForZuoraStreetNameLimit
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{FlatSpec, Matchers}
 

--- a/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
@@ -218,7 +218,13 @@ object JsonFixtures {
             $requestIdJson,
             ${userJson()},
             "product": ${contribution()},
-            "paymentMethod": $payPalPaymentMethod
+            "paymentMethod": $payPalPaymentMethod,
+            "giftRecipient": {
+              "title": "Mr",
+              "firstName": "Gifty",
+              "lastName": "McRecipent",
+              "email": "gift.recipient@gu.com"
+            }
           }
         """
 
@@ -261,6 +267,20 @@ object JsonFixtures {
         }
       """
 
+  val salesforceContactsJson =
+    """
+       "salesforceContacts": {
+          "buyer": {
+            "Id": "003g000001UnFItAAN",
+            "AccountId": "001g000001gOR06AAG"
+          },
+          "giftRecipient": {
+            "Id": "003g000001UnFItAAN",
+            "AccountId": "001g000001gOR06AAG"
+          }
+        }
+      """
+
   def createContributionZuoraSubscriptionJson(billingPeriod: BillingPeriod = Monthly): String =
     s"""
           {
@@ -268,7 +288,8 @@ object JsonFixtures {
             ${userJson()},
             "product": ${contribution(billingPeriod = billingPeriod)},
             "paymentMethod": $stripePaymentMethod,
-            "salesForceContact": $salesforceContactJson
+            "salesForceContact": $salesforceContactJson,
+            $salesforceContactsJson
             }
         """
   val createDigiPackZuoraSubscriptionJson =
@@ -278,7 +299,8 @@ object JsonFixtures {
             ${userJson()},
             "product": $digitalPackJson,
             "paymentMethod": $stripePaymentMethod,
-            "salesForceContact": $salesforceContactJson
+            "salesForceContact": $salesforceContactJson,
+            $salesforceContactsJson
             }
         """
 
@@ -290,7 +312,8 @@ object JsonFixtures {
             "product": $digitalPackJson,
             "paymentMethod": $stripePaymentMethod,
             "promoCode": "DJP8L27FY",
-            "salesForceContact": $salesforceContactJson
+            "salesForceContact": $salesforceContactJson,
+            $salesforceContactsJson
             }
         """
 
@@ -302,7 +325,8 @@ object JsonFixtures {
             "product": $everydayPaperJson,
             "firstDeliveryDate": "${LocalDate.now(DateTimeZone.UTC)}",
             "paymentMethod": $stripePaymentMethod,
-            "salesForceContact": $salesforceContactJson
+            "salesForceContact": $salesforceContactJson,
+            $salesforceContactsJson
             }
       """
 
@@ -320,7 +344,8 @@ object JsonFixtures {
         "firstDeliveryDate": "${LocalDate.now(DateTimeZone.UTC).plusDays(10)}",
         $promoJson
         "paymentMethod": $stripePaymentMethod,
-        "salesForceContact": $salesforceContactJson
+        "salesForceContact": $salesforceContactJson,
+        $salesforceContactsJson
         }
       """
     }
@@ -342,7 +367,8 @@ object JsonFixtures {
         },
         "firstDeliveryDate": "${LocalDate.now(DateTimeZone.UTC).plusDays(10)}",
         "paymentMethod": $stripePaymentMethod,
-        "salesForceContact": $salesforceContactJson
+        "salesForceContact": $salesforceContactJson,
+        $salesforceContactsJson
         }
       """
 

--- a/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
@@ -325,6 +325,27 @@ object JsonFixtures {
       """
     }
 
+  val guardianWeeklyGiftJson =
+    s"""
+      {
+        $requestIdJson,
+        $userJsonWithDeliveryAddress,
+        "giftRecipient": {
+          "title": "Mr",
+          "firstName": "Harry",
+          "lastName": "Ramsden"
+        },
+        "product": {
+          "currency": "GBP",
+          "billingPeriod" : "Quarterly",
+          "fulfilmentOptions" : "RestOfWorld"
+        },
+        "firstDeliveryDate": "${LocalDate.now(DateTimeZone.UTC).plusDays(10)}",
+        "paymentMethod": $stripePaymentMethod,
+        "salesForceContact": $salesforceContactJson
+        }
+      """
+
   val failureJson =
     """{
           "state": "eyJyZXF1ZXN0SWQiOiI5NjViOTU1Zi00MmQ4LWEwMDEtMDAwMC0wMDAwMDAwMDAwMDIiLCJ1c2VyIjp7ImlkIjoiMTAwMDAzNDUzIiwicHJpbWFyeUVtYWlsQWRkcmVzcyI6InNzbGpmc2Rsa2ZzZGxmQGd1LmNvbSIsImZpcnN0TmFtZSI6InNsZmtzZGtsZiIsImxhc3ROYW1lIjoic2xka2ZqZHNsZmoiLCJiaWxsaW5nQWRkcmVzcyI6eyJjb3VudHJ5IjoiR0IifSwiY291bnRyeSI6IkdCIiwic3RhdGUiOm51bGwsInRlbGVwaG9uZU51bWJlciI6IiIsImFsbG93TWVtYmVyc2hpcE1haWwiOmZhbHNlLCJhbGxvd1RoaXJkUGFydHlNYWlsIjpmYWxzZSwiYWxsb3dHVVJlbGF0ZWRNYWlsIjpmYWxzZSwiaXNUZXN0VXNlciI6ZmFsc2V9LCJwcm9kdWN0Ijp7ImN1cnJlbmN5IjoiR0JQIiwiYmlsbGluZ1BlcmlvZCI6Ik1vbnRobHkifSwicGF5bWVudE1ldGhvZCI6eyJUb2tlbklkIjoiY2FyZF9FUmY1dHcyNDVGY2Q0RiIsIlNlY29uZFRva2VuSWQiOiJjdXNfRVJmNWM2ajJ5OUEwWFYiLCJDcmVkaXRDYXJkTnVtYmVyIjoiNDI0MiIsIkNyZWRpdENhcmRDb3VudHJ5IjoiVVMiLCJDcmVkaXRDYXJkRXhwaXJhdGlvbk1vbnRoIjoyLCJDcmVkaXRDYXJkRXhwaXJhdGlvblllYXIiOjIwMjIsIkNyZWRpdENhcmRUeXBlIjoiVmlzYSIsIlR5cGUiOiJDcmVkaXRDYXJkUmVmZXJlbmNlVHJhbnNhY3Rpb24ifSwicHJvbW9Db2RlIjoiREpSSFlNRFM4Iiwic2FsZXNGb3JjZUNvbnRhY3QiOnsiSWQiOiIwMDM2RTAwMDAwVmxPUERRQTMiLCJBY2NvdW50SWQiOiIwMDE2RTAwMDAwZjE3cFlRQVEifSwiYWNxdWlzaXRpb25EYXRhIjp7Im9waGFuSWRzIjp7InBhZ2V2aWV3SWQiOiJqcmwxcnpyY25qNWdrM2oyMXN0dyIsInZpc2l0SWQiOm51bGwsImJyb3dzZXJJZCI6bnVsbH0sInJlZmVycmVyQWNxdWlzaXRpb25EYXRhIjp7ImNhbXBhaWduQ29kZSI6bnVsbCwicmVmZXJyZXJQYWdldmlld0lkIjpudWxsLCJyZWZlcnJlclVybCI6bnVsbCwiY29tcG9uZW50SWQiOm51bGwsImNvbXBvbmVudFR5cGUiOm51bGwsInNvdXJjZSI6bnVsbCwiYWJUZXN0cyI6bnVsbCwicXVlcnlQYXJhbWV0ZXJzIjpbeyJuYW1lIjoiZGlzcGxheUNoZWNrb3V0IiwidmFsdWUiOiJ0cnVlIn1dLCJob3N0bmFtZSI6InN1cHBvcnQudGhlZ3Vsb2NhbC5jb20iLCJnYUNsaWVudElkIjoiR0ExLjIuMTUwNjcwMTk4OC4xNTQ1NDA5MDcxIiwidXNlckFnZW50IjoiTW96aWxsYS81LjAoTWFjaW50b3NoO0ludGVsTWFjT1NYMTBfMTNfMilBcHBsZVdlYktpdC81MzcuMzYoS0hUTUwsbGlrZUdlY2tvKUNocm9tZS83MS4wLjM1NzguOThTYWZhcmkvNTM3LjM2IiwiaXBBZGRyZXNzIjoiMTI3LjAuMC4xIn0sInN1cHBvcnRBYlRlc3RzIjpbXX19",

--- a/support-workers/src/test/scala/com/gu/support/workers/errors/SalesforceErrorsSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/errors/SalesforceErrorsSpec.scala
@@ -1,6 +1,7 @@
 package com.gu.support.workers.errors
 
 import com.gu.config.Configuration
+import com.gu.i18n.Title
 import com.gu.monitoring.SafeLogger
 import com.gu.okhttp.RequestRunners.configurableFutureRunner
 import com.gu.salesforce.Fixtures._
@@ -26,6 +27,7 @@ class SalesforceErrorsSpec extends AsyncLambdaSpec with Matchers {
   val upsertData = NewContact(
     IdentityID__c = idId,
     Email = emailAddress,
+    Salutation = Some(Title.Ms),
     FirstName = name,
     LastName = name,
     OtherStreet = None,

--- a/support-workers/src/test/scala/com/gu/support/workers/errors/SalesforceErrorsSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/errors/SalesforceErrorsSpec.scala
@@ -4,7 +4,7 @@ import com.gu.config.Configuration
 import com.gu.monitoring.SafeLogger
 import com.gu.okhttp.RequestRunners.configurableFutureRunner
 import com.gu.salesforce.Fixtures._
-import com.gu.salesforce.Salesforce.{Authentication, SalesforceAuthenticationErrorResponse, SalesforceErrorResponse, UpsertData}
+import com.gu.salesforce.Salesforce.{Authentication, NewContact, SalesforceAuthenticationErrorResponse, SalesforceErrorResponse, UpsertData}
 import com.gu.salesforce.{AuthService, SalesforceConfig, SalesforceService}
 import com.gu.support.workers.AsyncLambdaSpec
 import com.gu.test.tags.annotations.IntegrationTest
@@ -23,25 +23,25 @@ class SalesforceErrorsSpec extends AsyncLambdaSpec with Matchers {
     }
   }
 
-  val upsertData = UpsertData.create(
-    idId,
-    emailAddress,
-    name,
-    name,
-    None,
-    None,
-    None,
-    None,
-    us,
-    None,
-    None,
-    None,
-    None,
-    None,
-    None,
-    allowMail,
-    allowMail,
-    allowMail
+  val upsertData = NewContact(
+    IdentityID__c = idId,
+    Email = emailAddress,
+    FirstName = name,
+    LastName = name,
+    OtherStreet = None,
+    OtherCity = None,
+    OtherState = None,
+    OtherPostalCode = None,
+    OtherCountry = us,
+    MailingStreet = None,
+    MailingCity = None,
+    MailingState = None,
+    MailingPostalCode = None,
+    MailingCountry = None,
+    Phone = None,
+    Allow_Membership_Mail__c = allowMail,
+    Allow_3rd_Party_Mail__c = allowMail,
+    Allow_Guardian_Related_Mail__c = allowMail
   )
 
   it should "throw a SalesforceAuthenticationErrorResponse if the authentication fails" in {

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/CreateSalesforceContactSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/CreateSalesforceContactSpec.scala
@@ -25,6 +25,6 @@ class CreateSalesforceContactSpec extends LambdaSpec {
 
     val result = Encoding.in[CreateZuoraSubscriptionState](outStream.toInputStream)
     result.isSuccess should be(true)
-    result.get._1.salesForceContact.Id should be(salesforceId)
+    result.get._1.salesforceContacts.buyer.Id should be(salesforceId)
   }
 }

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/CreateSalesforceContactSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/CreateSalesforceContactSpec.scala
@@ -16,7 +16,7 @@ import io.circe.generic.auto._
 @IntegrationTest
 class CreateSalesforceContactSpec extends LambdaSpec {
 
-  "CreateSalesforceContact lambda" should "retrieve a SalesforceContactRecord" in {
+  "CreateSalesforceContact lambda" should "upsert a SalesforceContactRecord" in {
     val createContact = new CreateSalesforceContact()
 
     val outStream = new ByteArrayOutputStream()
@@ -25,6 +25,9 @@ class CreateSalesforceContactSpec extends LambdaSpec {
 
     val result = Encoding.in[CreateZuoraSubscriptionState](outStream.toInputStream)
     result.isSuccess should be(true)
-    result.get._1.salesforceContacts.buyer.Id should be(salesforceId)
+    val contacts = result.get._1.salesforceContacts
+    contacts.buyer.Id should be(salesforceId)
+    contacts.giftRecipient shouldBe defined
   }
+
 }

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
@@ -66,6 +66,10 @@ class CreateZuoraSubscriptionSpec extends LambdaSpec with MockServicesCreator {
     createSubscription(createGuardianWeeklySubscriptionJson(Quarterly, Some(GuardianWeekly.SixForSixPromoCode)))
   }
 
+  it should "create an Guardian Weekly gift subscription" in {
+    createSubscription(guardianWeeklyGiftJson)
+  }
+
   private def createSubscription(json: String) = {
     val createZuora = new CreateZuoraSubscription(mockServiceProvider)
 

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
@@ -70,7 +70,7 @@ class SendThankYouEmailSpec extends LambdaSpec {
     val addressToSendTo = "rupert.bates+unitTest@theguardian.com"
     val mandateId = "65HK26E"
     val billingAddressWithCountry = Address(lineOne = None, lineTwo = None, city = None, state = None, postCode = None, country = UK)
-    val user = User("1234", addressToSendTo, "Mickey", "Mouse", billingAddress = billingAddressWithCountry)
+    val user = User("1234", addressToSendTo, None, "Mickey", "Mouse", billingAddress = billingAddressWithCountry)
     val ef = DigitalPackEmailFields(
       "A-S00045678",
       Annual,
@@ -100,6 +100,7 @@ class SendThankYouEmailSpec extends LambdaSpec {
     val user = User(
       "1234",
       addressToSendTo,
+      None,
       "Mickey",
       "Mouse",
       billingAddress = billingAddressWithCountry,


### PR DESCRIPTION
## Why are you doing this?

This PR adds gifting to the Guardian Weekly checkout

This is a high level overview of the changes:
* Send gift recipient fields from the checkout form to the `/create` endpoint in the subscribe request
* Add a new `Option[GiftRecipient]` field to several of the support workers states
* When a gift recipient is present add an extra 'Delivery / Recipient Contact' record to Salesforce with the recipient's contact details - in this case do not update the delivery address on the buyer record to avoid overwriting the correct address (if this user already has a Salesforce record) with the gift recipient's address 
* Send the recipient's Salesforce account id to Zuora in the CRM Id - this is either the gift recipient or the buyer.
* Set the correct `ReaderType` on the Zuora account - either Direct or Gift
* Send the buyer's Salesforce id to the email service
* We are also now passing title through to Salesforce for both the buyer and gift recipient


[**Trello Card**](https://trello.com/c/Y8sgB8Gi/2374-gifting-in-gw-checkout-backend)

