### PR TITLE
Put sign-in details in user object

### DIFF
--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -119,10 +119,7 @@ class Application(
     implicit val settings: AllSettings = settingsProvider.getAllSettings()
     request.user.traverse[Attempt, UserWithSignInDetails](identityService.getUserWithSignInDetails(_)).fold(
       _ => Ok(contributionsHtml(countryCode, None, campaignCodeOption, guestAccountCreationToken)),
-      user => {
-
-        Ok(contributionsHtml(countryCode, user, campaignCodeOption, guestAccountCreationToken))
-      }
+      userWithSignInDetails => Ok(contributionsHtml(countryCode, userWithSignInDetails, campaignCodeOption, guestAccountCreationToken))
     ).map(_.withSettingsSurrogateKey)
   }
 

--- a/support-frontend/app/models/identity/UserWithSignInDetails.scala
+++ b/support-frontend/app/models/identity/UserWithSignInDetails.scala
@@ -1,0 +1,8 @@
+package models.identity
+
+import com.gu.identity.play.IdUser
+import models.identity.responses.UserSignInDetailsResponse.UserSignInDetails
+
+case class UserWithSignInDetails(user: IdUser, signInDetails: UserSignInDetails)
+
+

--- a/support-frontend/app/models/identity/responses/UserSignInDetailsResponse.scala
+++ b/support-frontend/app/models/identity/responses/UserSignInDetailsResponse.scala
@@ -1,0 +1,35 @@
+package models.identity.responses
+
+import play.api.libs.json.{Json, Reads}
+
+// Models the response of successfully looking up user details via email address.
+//
+// Example response:
+// =================
+// {
+//   "status": "ok",
+//   "userSignInDetails": {
+//     "hasAccount": true,
+//     "hasPassword": true,
+//     "isUserEmailValidated": true,
+//     "hasGoogleSocialLink": false,
+//     "hasFacebookSocialLink": false
+//   }
+// }
+case class UserSignInDetailsResponse(userSignInDetails: UserSignInDetailsResponse.UserSignInDetails)
+
+object UserSignInDetailsResponse {
+
+  implicit val readsUserSignInDetailsResponse: Reads[UserSignInDetailsResponse] = Json.reads[UserSignInDetailsResponse]
+  case class UserSignInDetails(
+    hasAccount: Boolean,
+    hasPassword: Boolean,
+    isUserEmailValidated: Boolean,
+    hasGoogleSocialLink: Boolean,
+    hasFacebookSocialLink: Boolean
+  )
+
+  object UserSignInDetails {
+    implicit val readsUserSignInDetails: Reads[UserSignInDetails] = Json.reads[UserSignInDetails]
+  }
+}

--- a/support-frontend/app/services/StubIdentityService.scala
+++ b/support-frontend/app/services/StubIdentityService.scala
@@ -3,9 +3,10 @@ package services
 import cats.data.EitherT
 import cats.implicits._
 import com.gu.identity.play.{IdMinimalUser, IdUser, PrivateFields, PublicFields}
-import models.identity.UserIdWithGuestAccountToken
+import models.identity.{UserIdWithGuestAccountToken, UserWithSignInDetails}
 import models.identity.responses.SetGuestPasswordResponseCookies
 import com.gu.monitoring.SafeLogger
+import models.identity.responses.UserSignInDetailsResponse.UserSignInDetails
 import play.api.mvc.RequestHeader
 import org.joda.time.DateTime
 
@@ -18,6 +19,36 @@ class StubIdentityService extends IdentityService {
 
     SafeLogger.info(s"Stubbed identity service active. Returning test names $privateFields")
     EitherT.rightT[Future, String](stubTestUser)
+  }
+
+  def getUserSignInDetails(email: String)(implicit ec: ExecutionContext): EitherT[Future, String, UserSignInDetails] = {
+    val stubTestUserSignInDetails: UserSignInDetails = UserSignInDetails(
+      hasAccount = true,
+      hasPassword = true,
+      isUserEmailValidated = false,
+      hasGoogleSocialLink = false,
+      hasFacebookSocialLink = false
+    )
+
+    SafeLogger.info(s"Stubbed identity service active. Returning sign-in details")
+    EitherT.rightT[Future, String](stubTestUserSignInDetails)
+  }
+
+  def getUserWithSignInDetails(user: IdMinimalUser)(implicit req: RequestHeader, ec: ExecutionContext): EitherT[Future, String, UserWithSignInDetails] = {
+    val privateFields = PrivateFields(firstName = Some("Frosty"), secondName = Some("The Snowman"))
+    val stubTestUserWithSignInDetails: UserWithSignInDetails = UserWithSignInDetails(
+      IdUser("123456", "nonsense@gu.com", PublicFields(None), Some(privateFields), None),
+      UserSignInDetails(
+        hasAccount = true,
+        hasPassword = true,
+        isUserEmailValidated = false,
+        hasGoogleSocialLink = false,
+        hasFacebookSocialLink = false
+      )
+    )
+
+    SafeLogger.info(s"Stubbed identity service active. Returning test names $privateFields")
+    EitherT.rightT[Future, String](stubTestUserWithSignInDetails)
   }
 
   def sendConsentPreferencesEmail(email: String)(implicit ec: ExecutionContext): Future[Boolean] = {

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -5,6 +5,7 @@
 @import com.gu.support.config.{PayPalConfig, StripeConfig}
 @import helper.CSRF
 @import views.{Preload, SSRContent}
+@import models.identity.UserWithSignInDetails
 @(
   title: String,
   id: String,
@@ -20,7 +21,7 @@
   paymentApiStripeEndpoint: String,
   paymentApiPayPalEndpoint: String,
   existingPaymentOptionsEndpoint: String,
-  idUser: Option[IdUser],
+  userWithSignInDetails: Option[UserWithSignInDetails],
   campaignCodeModifier: Option[String],
   guestAccountCreationToken: Option[String],
   fontLoaderBundle: Either[RefPath, StyleContent]
@@ -194,14 +195,21 @@
 @main(title = title, mainJsBundle = js, fontLoaderBundle = fontLoaderBundle, description = description, mainElement = SSRContent(id, ssr), mainStyleBundle = css) {
   <script type="text/javascript">
     window.guardian = window.guardian || {};
-    @idUser.map { user =>
+    @userWithSignInDetails.map { userWithSignInDetails =>
       window.guardian.user = {
-        id: "@user.id",
-        email: "@user.primaryEmailAddress",
-        @user.publicFields.displayName.map { displayName =>
+        id: "@userWithSignInDetails.user.id",
+        email: "@userWithSignInDetails.user.primaryEmailAddress",
+        @userWithSignInDetails.user.publicFields.displayName.map { displayName =>
           displayName: "@displayName",
         }
-    @for(fields <- user.privateFields; firstName <- fields.firstName; lastName <- fields.secondName) {
+        signInDetails: {
+          hasAccount: "@userWithSignInDetails.signInDetails.hasAccount",
+          hasPassword: "@userWithSignInDetails.signInDetails.hasPassword",
+          isUserEmailValidated: "@userWithSignInDetails.signInDetails.isUserEmailValidated",
+          hasGoogleSocialLink: "@userWithSignInDetails.signInDetails.hasGoogleSocialLink",
+          hasFacebookSocialLink: "@userWithSignInDetails.signInDetails.hasFacebookSocialLink"
+        },
+    @for(fields <- userWithSignInDetails.user.privateFields; firstName <- fields.firstName; lastName <- fields.secondName) {
           firstName: "@firstName",
           lastName: "@lastName",
         }


### PR DESCRIPTION
We want the user's validation status (that is, whether they've validated their account by clicking on a link in an email) to be available in the client so that we can direct signed-in users who aren't validated to validate their address.

#### User object (which is, as before, only populated if the user is logged in) now looks like this:

<img width="578" alt="Screenshot 2019-06-20 at 23 30 03" src="https://user-images.githubusercontent.com/5122968/59885514-7271cb00-93b3-11e9-8d75-d676633a5259.png">


### why should they validate?
The members-data-api does not take account of one-off contributions history for unvalidated accounts, because we can't be sure that the owner of the email also made the contribution. We're encouraging people to sign-in so they don't see supporter asks anymore, but this won't happen for unvalidated one-off contributors.

### what about recurring?
The members-data-api exposes information on recurring contributors even if they're not validated. This is because we have the protection of forcing sign-in for people with passwords before a recurring contribution is made. However, if we make it clear to users that they need to validate and provide an easy way to do so, we might be able to add the same validation restriction on recurring contribution info from the members-data-api, and thereby remove the sign-in requirement to contribute. This would reduce friction and boost conversion (we have data to support this hypothesis)