### PR TITLE
Fix local Selenium tests

### DIFF
--- a/support-frontend/test/selenium/conf/selenium-test.conf
+++ b/support-frontend/test/selenium/conf/selenium-test.conf
@@ -1,5 +1,8 @@
 include "application"
 
+#### Import private keys
+include file("/etc/gu/support-frontend.private.conf")
+
 // Travis CI environmental variables that override DEV.conf with PROD values
 stage=${?STAGE}
 identity {


### PR DESCRIPTION
## Why are you doing this?

#1897 broke local selenium tests because it stopped the local private config loading by default, this PR loads it in the selenium-test.conf so that it is available to the tests.

