### PR TITLE
Get emailValidated from cookie

### DIFF
--- a/support-frontend/assets/helpers/user/__tests__/__snapshots__/userReducerTest.js.snap
+++ b/support-frontend/assets/helpers/user/__tests__/__snapshots__/userReducerTest.js.snap
@@ -4,6 +4,7 @@ exports[`user reducer tests should return the initial state 1`] = `
 Object {
   "displayName": "",
   "email": "",
+  "emailValidated": false,
   "firstName": "",
   "fullName": "",
   "gnmMarketing": false,

--- a/support-frontend/assets/helpers/user/__tests__/userTest.js
+++ b/support-frontend/assets/helpers/user/__tests__/userTest.js
@@ -1,0 +1,30 @@
+// @flow
+
+jest.mock('ophan', () => () => ({
+}));
+
+import { getEmailValidatedFromUserCookie } from 'helpers/user/user';
+
+const toCookie = (values) => `${btoa(JSON.stringify(values))}.the-secret-bit-that-we-ignore`;
+
+describe('user tests', () => {
+
+  it('should return false if no cookie', () => {
+    expect(getEmailValidatedFromUserCookie(undefined)).toEqual(false);
+  });
+
+  it('should return false if cookie is invalid', () => {
+    const cookie = toCookie(["1"]);
+    expect(getEmailValidatedFromUserCookie(cookie)).toEqual(false);
+  });
+
+  it('should return false if cookie contains false', () => {
+    const cookie = toCookie([ "1", "", "t f", "", 1, 1, 1, false ]);
+    expect(getEmailValidatedFromUserCookie(cookie)).toEqual(false);
+  });
+
+  it('should return true if cookie contains true', () => {
+    const cookie = toCookie([ "1", "", "t f", "", 1, 1, 1, true ]);
+    expect(getEmailValidatedFromUserCookie(cookie)).toEqual(true);
+  });
+});

--- a/support-frontend/assets/helpers/user/defaultUserActionFunctions.js
+++ b/support-frontend/assets/helpers/user/defaultUserActionFunctions.js
@@ -2,6 +2,7 @@
 
 import { setSession } from 'helpers/storage';
 import { type Action } from './userActions';
+import type {SignInDetails} from "assets/helpers/user/userReducer";
 
 // ----- Actions Creators ----- //
 
@@ -57,6 +58,10 @@ function setGnmMarketing(preference: boolean): Action {
   return { type: 'SET_GNM_MARKETING', preference };
 }
 
+function setSignInDetails(signInDetails: SignInDetails): Action {
+  return { type: 'SET_SIGN_IN_DETAILS', signInDetails };
+}
+
 const defaultUserActionFunctions = {
   setId,
   setDisplayName,
@@ -70,6 +75,7 @@ const defaultUserActionFunctions = {
   setTestUser,
   setPostDeploymentTestUser,
   setGnmMarketing,
+  setSignInDetails,
 };
 
 export { defaultUserActionFunctions };

--- a/support-frontend/assets/helpers/user/defaultUserActionFunctions.js
+++ b/support-frontend/assets/helpers/user/defaultUserActionFunctions.js
@@ -2,7 +2,6 @@
 
 import { setSession } from 'helpers/storage';
 import { type Action } from './userActions';
-import type {SignInDetails} from "assets/helpers/user/userReducer";
 
 // ----- Actions Creators ----- //
 
@@ -58,8 +57,8 @@ function setGnmMarketing(preference: boolean): Action {
   return { type: 'SET_GNM_MARKETING', preference };
 }
 
-function setSignInDetails(signInDetails: SignInDetails): Action {
-  return { type: 'SET_SIGN_IN_DETAILS', signInDetails };
+function setEmailValidated(emailValidated: boolean): Action {
+  return { type: 'SET_EMAIL_VALIDATED', emailValidated };
 }
 
 const defaultUserActionFunctions = {
@@ -75,7 +74,7 @@ const defaultUserActionFunctions = {
   setTestUser,
   setPostDeploymentTestUser,
   setGnmMarketing,
-  setSignInDetails,
+  setEmailValidated,
 };
 
 export { defaultUserActionFunctions };

--- a/support-frontend/assets/helpers/user/user.js
+++ b/support-frontend/assets/helpers/user/user.js
@@ -58,6 +58,14 @@ const signOut = () => { window.location.href = getSignoutUrl(); };
 
 const doesUserAppearToBeSignedIn = () => !!cookie.get('GU_U');
 
+// JTL: The user cookie is built to have particular values at
+// particular indices by design. Index 7 in the cookie object represents
+// whether a signed in user is validated or not. Though it's not ideal
+// to grab values at unnamed indexes, this is a decision made a long
+// time ago, on which a lot of other code relies, so it's unlikely
+// there will be a breaking change affecting our base without some advance
+// communication to a broader segment of engineering that also uses
+// the user cookie.
 const getEmailValidatedFromUserCookie = (guuCookie: ?string) => {
   if (guuCookie) {
     const tokens = guuCookie.split('.');

--- a/support-frontend/assets/helpers/user/user.js
+++ b/support-frontend/assets/helpers/user/user.js
@@ -58,12 +58,12 @@ const signOut = () => { window.location.href = getSignoutUrl(); };
 
 const doesUserAppearToBeSignedIn = () => !!cookie.get('GU_U');
 
-const getEmailValidatedFromUserCookie = () => {
-  const guu = cookie.get('GU_U');
-  if (guu) {
-    const tokens = guu.split('.');
+const getEmailValidatedFromUserCookie = (guuCookie: ?string) => {
+  if (guuCookie) {
+    const tokens = guuCookie.split('.');
     try {
-      return JSON.parse(atob(tokens[0]))[7];
+      const parsed = JSON.parse(atob(tokens[0]));
+      return !!parsed[7]
     } catch (e) {
       return false;
     }
@@ -132,7 +132,7 @@ const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActi
     dispatch(setLastName(window.guardian.user.lastName));
     dispatch(setFullName(`${window.guardian.user.firstName} ${window.guardian.user.lastName}`));
     dispatch(setIsSignedIn(true));
-    dispatch(setEmailValidated(getEmailValidatedFromUserCookie()));
+    dispatch(setEmailValidated(getEmailValidatedFromUserCookie(cookie.get('GU_U'))));
   } else if (userAppearsLoggedIn) {
     fetch(routes.oneOffContribAutofill, { credentials: 'include' }).then((response) => {
       if (response.ok) {
@@ -168,4 +168,5 @@ export {
   isPostDeployUser,
   signOut,
   doesUserAppearToBeSignedIn,
+  getEmailValidatedFromUserCookie,
 };

--- a/support-frontend/assets/helpers/user/user.js
+++ b/support-frontend/assets/helpers/user/user.js
@@ -64,12 +64,12 @@ const getEmailValidatedFromUserCookie = () => {
     const tokens = guu.split('.');
     try {
       return JSON.parse(atob(tokens[0]))[7];
-    } catch(e) {
-      return false
+    } catch (e) {
+      return false;
     }
   }
 
-  return false
+  return false;
 };
 
 const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActionFunctions) => {
@@ -132,7 +132,7 @@ const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActi
     dispatch(setLastName(window.guardian.user.lastName));
     dispatch(setFullName(`${window.guardian.user.firstName} ${window.guardian.user.lastName}`));
     dispatch(setIsSignedIn(true));
-    dispatch(setEmailValidated(getEmailValidatedFromUserCookie()))
+    dispatch(setEmailValidated(getEmailValidatedFromUserCookie()));
   } else if (userAppearsLoggedIn) {
     fetch(routes.oneOffContribAutofill, { credentials: 'include' }).then((response) => {
       if (response.ok) {

--- a/support-frontend/assets/helpers/user/user.js
+++ b/support-frontend/assets/helpers/user/user.js
@@ -58,6 +58,15 @@ const signOut = () => { window.location.href = getSignoutUrl(); };
 
 const doesUserAppearToBeSignedIn = () => !!cookie.get('GU_U');
 
+const getUserEmailValidatedFromCookie = () => {
+  const guu = cookie.get('GU_U');
+  if (guu) {
+    debugger
+  } else {
+    return false
+  }
+};
+
 const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActionFunctions) => {
 
   const {
@@ -71,7 +80,7 @@ const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActi
     setIsRecurringContributor,
     setTestUser,
     setPostDeploymentTestUser,
-    setSignInDetails,
+    setEmailValidated,
   } = actions;
 
   const windowHasUser = window.guardian && window.guardian.user;
@@ -111,6 +120,7 @@ const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActi
   }
 
   if (windowHasUser) {
+    debugger
     dispatch(setId(window.guardian.user.id));
     dispatch(setEmail(window.guardian.user.email));
     dispatch(setDisplayName(window.guardian.user.displayName));
@@ -118,7 +128,10 @@ const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActi
     dispatch(setLastName(window.guardian.user.lastName));
     dispatch(setFullName(`${window.guardian.user.firstName} ${window.guardian.user.lastName}`));
     dispatch(setIsSignedIn(true));
-    dispatch(setSignInDetails(window.guardian.user.signInDetails))
+    //TODO - get emailValidated from cookie
+
+    const emailValidated = getUserEmailValidatedFromCookie();
+    dispatch(setEmailValidated(emailValidated))
   } else if (userAppearsLoggedIn) {
     fetch(routes.oneOffContribAutofill, { credentials: 'include' }).then((response) => {
       if (response.ok) {

--- a/support-frontend/assets/helpers/user/user.js
+++ b/support-frontend/assets/helpers/user/user.js
@@ -71,6 +71,7 @@ const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActi
     setIsRecurringContributor,
     setTestUser,
     setPostDeploymentTestUser,
+    setSignInDetails,
   } = actions;
 
   const windowHasUser = window.guardian && window.guardian.user;
@@ -117,6 +118,7 @@ const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActi
     dispatch(setLastName(window.guardian.user.lastName));
     dispatch(setFullName(`${window.guardian.user.firstName} ${window.guardian.user.lastName}`));
     dispatch(setIsSignedIn(true));
+    dispatch(setSignInDetails(window.guardian.user.signInDetails))
   } else if (userAppearsLoggedIn) {
     fetch(routes.oneOffContribAutofill, { credentials: 'include' }).then((response) => {
       if (response.ok) {

--- a/support-frontend/assets/helpers/user/user.js
+++ b/support-frontend/assets/helpers/user/user.js
@@ -58,13 +58,18 @@ const signOut = () => { window.location.href = getSignoutUrl(); };
 
 const doesUserAppearToBeSignedIn = () => !!cookie.get('GU_U');
 
-const getUserEmailValidatedFromCookie = () => {
+const getEmailValidatedFromUserCookie = () => {
   const guu = cookie.get('GU_U');
   if (guu) {
-    debugger
-  } else {
-    return false
+    const tokens = guu.split('.');
+    try {
+      return JSON.parse(atob(tokens[0]))[7];
+    } catch(e) {
+      return false
+    }
   }
+
+  return false
 };
 
 const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActionFunctions) => {
@@ -120,7 +125,6 @@ const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActi
   }
 
   if (windowHasUser) {
-    debugger
     dispatch(setId(window.guardian.user.id));
     dispatch(setEmail(window.guardian.user.email));
     dispatch(setDisplayName(window.guardian.user.displayName));
@@ -128,10 +132,7 @@ const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActi
     dispatch(setLastName(window.guardian.user.lastName));
     dispatch(setFullName(`${window.guardian.user.firstName} ${window.guardian.user.lastName}`));
     dispatch(setIsSignedIn(true));
-    //TODO - get emailValidated from cookie
-
-    const emailValidated = getUserEmailValidatedFromCookie();
-    dispatch(setEmailValidated(emailValidated))
+    dispatch(setEmailValidated(getEmailValidatedFromUserCookie()))
   } else if (userAppearsLoggedIn) {
     fetch(routes.oneOffContribAutofill, { credentials: 'include' }).then((response) => {
       if (response.ok) {

--- a/support-frontend/assets/helpers/user/userActions.js
+++ b/support-frontend/assets/helpers/user/userActions.js
@@ -1,6 +1,8 @@
 // @flow
 
 // ----- Types ----- //
+import type {SignInDetails} from "assets/helpers/user/userReducer";
+
 export type Action =
   | { type: 'SET_USER_ID', id: string }
   | { type: 'SET_DISPLAY_NAME', name: string }
@@ -13,7 +15,8 @@ export type Action =
   | { type: 'SET_IS_RECURRING_CONTRIBUTOR' }
   | { type: 'SET_POST_DEPLOYMENT_TEST_USER', postDeploymentTestUser: boolean }
   | { type: 'SET_GNM_MARKETING', preference: boolean }
-  | { type: 'SET_IS_SIGNED_IN', isSignedIn: boolean };
+  | { type: 'SET_IS_SIGNED_IN', isSignedIn: boolean }
+  | { type: 'SET_SIGN_IN_DETAILS', signInDetails: SignInDetails };
 
 export type UserSetStateActions = {|
   setId: string => Action,
@@ -26,6 +29,7 @@ export type UserSetStateActions = {|
   setTestUser: boolean => Action,
   setPostDeploymentTestUser: boolean => Action,
   setGnmMarketing: boolean => Action,
+  setSignInDetails: SignInDetails => Action,
 
   // When we change either of these in the context of the contributions landing page,
   // we need to dispatch some additional actions to update some state in the

--- a/support-frontend/assets/helpers/user/userActions.js
+++ b/support-frontend/assets/helpers/user/userActions.js
@@ -15,7 +15,7 @@ export type Action =
   | { type: 'SET_POST_DEPLOYMENT_TEST_USER', postDeploymentTestUser: boolean }
   | { type: 'SET_GNM_MARKETING', preference: boolean }
   | { type: 'SET_IS_SIGNED_IN', isSignedIn: boolean }
-  | { type: 'SET_EMAIL_VALIDATD', emailValidated: boolean };
+  | { type: 'SET_EMAIL_VALIDATED', emailValidated: boolean };
 
 export type UserSetStateActions = {|
   setId: string => Action,
@@ -28,7 +28,7 @@ export type UserSetStateActions = {|
   setTestUser: boolean => Action,
   setPostDeploymentTestUser: boolean => Action,
   setGnmMarketing: boolean => Action,
-  emailValidated: boolean => Action,
+  setEmailValidated: boolean => Action,
 
   // When we change either of these in the context of the contributions landing page,
   // we need to dispatch some additional actions to update some state in the

--- a/support-frontend/assets/helpers/user/userActions.js
+++ b/support-frontend/assets/helpers/user/userActions.js
@@ -1,7 +1,6 @@
 // @flow
 
 // ----- Types ----- //
-import type {SignInDetails} from "assets/helpers/user/userReducer";
 
 export type Action =
   | { type: 'SET_USER_ID', id: string }
@@ -16,7 +15,7 @@ export type Action =
   | { type: 'SET_POST_DEPLOYMENT_TEST_USER', postDeploymentTestUser: boolean }
   | { type: 'SET_GNM_MARKETING', preference: boolean }
   | { type: 'SET_IS_SIGNED_IN', isSignedIn: boolean }
-  | { type: 'SET_SIGN_IN_DETAILS', signInDetails: SignInDetails };
+  | { type: 'SET_EMAIL_VALIDATD', emailValidated: boolean };
 
 export type UserSetStateActions = {|
   setId: string => Action,
@@ -29,7 +28,7 @@ export type UserSetStateActions = {|
   setTestUser: boolean => Action,
   setPostDeploymentTestUser: boolean => Action,
   setGnmMarketing: boolean => Action,
-  setSignInDetails: SignInDetails => Action,
+  emailValidated: boolean => Action,
 
   // When we change either of these in the context of the contributions landing page,
   // we need to dispatch some additional actions to update some state in the

--- a/support-frontend/assets/helpers/user/userReducer.js
+++ b/support-frontend/assets/helpers/user/userReducer.js
@@ -11,6 +11,14 @@ import { Canada, UnitedStates } from '../internationalisation/countryGroup';
 
 // ----- Types ----- //
 
+export type SignInDetails = {
+  hasAccount: boolean,
+  hasFacebookSocialAccount: boolean,
+  hasGoogleSocialAccount: boolean,
+  hasPassword: boolean,
+  isUserEmailValidated: boolean,
+};
+
 export type User = {
   id: ?string,
   email: string,
@@ -24,6 +32,7 @@ export type User = {
   gnmMarketing: boolean,
   isSignedIn: boolean,
   isRecurringContributor: boolean,
+  signInDetails: SignInDetails,
 };
 
 
@@ -41,6 +50,13 @@ const initialState: User = {
   gnmMarketing: false,
   isSignedIn: false,
   isRecurringContributor: false,
+  signInDetails: {
+    hasAccount: false,
+    hasFacebookSocialAccount: false,
+    hasGoogleSocialAccount: false,
+    hasPassword: false,
+    isUserEmailValidated: false,
+  }
 };
 
 
@@ -107,6 +123,9 @@ function createUserReducer(countryGroup: CountryGroupId) {
 
       case 'SET_IS_RECURRING_CONTRIBUTOR':
         return { ...state, isRecurringContributor: true };
+
+      case 'SET_SIGN_IN_DETAILS':
+        return { ...state, signInDetails: action.signInDetails };
 
       default:
         return state;

--- a/support-frontend/assets/helpers/user/userReducer.js
+++ b/support-frontend/assets/helpers/user/userReducer.js
@@ -11,14 +11,6 @@ import { Canada, UnitedStates } from '../internationalisation/countryGroup';
 
 // ----- Types ----- //
 
-export type SignInDetails = {
-  hasAccount: boolean,
-  hasFacebookSocialAccount: boolean,
-  hasGoogleSocialAccount: boolean,
-  hasPassword: boolean,
-  isUserEmailValidated: boolean,
-};
-
 export type User = {
   id: ?string,
   email: string,
@@ -32,7 +24,7 @@ export type User = {
   gnmMarketing: boolean,
   isSignedIn: boolean,
   isRecurringContributor: boolean,
-  signInDetails: SignInDetails,
+  emailValidated: boolean,
 };
 
 
@@ -50,13 +42,7 @@ const initialState: User = {
   gnmMarketing: false,
   isSignedIn: false,
   isRecurringContributor: false,
-  signInDetails: {
-    hasAccount: false,
-    hasFacebookSocialAccount: false,
-    hasGoogleSocialAccount: false,
-    hasPassword: false,
-    isUserEmailValidated: false,
-  }
+  emailValidated: false,
 };
 
 
@@ -124,8 +110,8 @@ function createUserReducer(countryGroup: CountryGroupId) {
       case 'SET_IS_RECURRING_CONTRIBUTOR':
         return { ...state, isRecurringContributor: true };
 
-      case 'SET_SIGN_IN_DETAILS':
-        return { ...state, signInDetails: action.signInDetails };
+      case 'SET_EMAIL_VALIDATED':
+        return { ...state, emailValidated: action.emailValidated };
 
       default:
         return state;

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
@@ -103,6 +103,73 @@ function ContributionThankYou(props: PropTypes) {
     props.setHasSeenDirectDebitThankYouCopy();
   }
 
+  const renderIdentityCTA = () => {
+    // Invite signed out contributors to sign in:
+    if (!props.isSignedIn) {
+      return (
+        <section className="contribution-thank-you-block">
+          <h3 className="contribution-thank-you-block__title">
+            Stay signed in to The Guardian
+          </h3>
+          <p className="contribution-thank-you-block__message">
+            As a valued contributor, we want to ensure you are having the best experience on our site. To see
+            far fewer requests for support, please sign in on each of the devices you use to access The
+            Guardian – mobile, tablet, laptop or desktop. Please make sure you’ve verified your email address.
+          </p>
+          <TrackableButton
+            aria-label="Sign into The Guardian"
+            appearance="secondary"
+            trackingEvent={
+              () => {
+                trackComponentLoad(`sign-into-the-guardian-link-loaded-${props.contributionType}`);
+              }
+            }
+            onClick={
+              () => {
+                createSignInLink(props.email, props.csrf, props.contributionType);
+              }}
+          >
+            Sign in now
+          </TrackableButton>
+        </section>
+      );
+    }
+
+    // Invite signed in, unvalidated contributors to validate their accounts
+    if (props.isSignedIn && !props.emailValidated) {
+      return (
+        <section className="contribution-thank-you-block">
+          <h3 className="contribution-thank-you-block__title">
+            Please verify your email address
+          </h3>
+          <p className="contribution-thank-you-block__message">
+            As a valued contributor, we want to ensure you are having the best experience on our site. To see
+            far fewer requests for support, please verify the email address associated with your account and
+            sign in on each of the devices you use to access The Guardian – mobile, tablet, laptop or desktop.
+          </p>
+          <TrackableButton
+            aria-label="Validate your account"
+            appearance="secondary"
+            trackingEvent={
+              () => {
+                trackComponentLoad(`verify-email-link-loaded-${props.contributionType}`);
+              }
+            }
+            onClick={
+              () => {
+                trackComponentClick(`verify-email-link-${props.contributionType}`);
+                window.location.href = 'https://profile.theguardian.com/verify-email';
+              }}
+          >
+            Verify now
+          </TrackableButton>
+        </section>
+      );
+    }
+
+    return null;
+  };
+
   return (
     <div className="thank-you__container">
       <div className="gu-content__form gu-content__form--thank-you">
@@ -113,32 +180,7 @@ function ContributionThankYou(props: PropTypes) {
             </h3>
           </section>
         ) : null}
-        {!props.isSignedIn ?
-          <section className="contribution-thank-you-block">
-            <h3 className="contribution-thank-you-block__title">
-              Stay signed in to The Guardian
-            </h3>
-            <p className="contribution-thank-you-block__message">
-              As a valued contributor, we want to ensure you are having the best experience on our site. To see
-              far fewer requests for support, please sign in on each of the devices you use to access The
-              Guardian – mobile, tablet, laptop or desktop. Please make sure you’ve verified your email address.
-            </p>
-            <TrackableButton
-              aria-label="Sign into The Guardian"
-              appearance="secondary"
-              trackingEvent={
-                () => {
-                  trackComponentLoad(`sign-into-the-guardian-link-loaded-${props.contributionType}`);
-                }
-              }
-              onClick={
-                () => {
-                  createSignInLink(props.email, props.csrf, props.contributionType);
-                }}
-            >
-              Sign in now
-            </TrackableButton>
-          </section> : null }
+        { renderIdentityCTA() }
         <MarketingConsent />
         <ContributionSurvey isRunning={false} contributionType={props.contributionType} />
         <SpreadTheWord />

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
@@ -36,7 +36,7 @@ type PropTypes = {|
   isSignedIn: boolean,
   email: string,
   csrf: string,
-  signInDetails: SignInDetails,
+  emailValidated: boolean,
 |};
 /* eslint-enable react/no-unused-prop-types */
 
@@ -47,7 +47,7 @@ const mapStateToProps = state => ({
   isSignedIn: state.page.user.isSignedIn,
   email: state.page.form.formData.email,
   csrf: state.page.csrf.token,
-  signInDetails: state.page.user.signInDetails,
+  emailValidated: state.page.user.emailValidated,
 });
 
 function mapDispatchToProps(dispatch: Dispatch<Action>) {

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
@@ -36,6 +36,7 @@ type PropTypes = {|
   isSignedIn: boolean,
   email: string,
   csrf: string,
+  signInDetails: SignInDetails,
 |};
 /* eslint-enable react/no-unused-prop-types */
 
@@ -46,6 +47,7 @@ const mapStateToProps = state => ({
   isSignedIn: state.page.user.isSignedIn,
   email: state.page.form.formData.email,
   csrf: state.page.csrf.token,
+  signInDetails: state.page.user.signInDetails,
 });
 
 function mapDispatchToProps(dispatch: Dispatch<Action>) {


### PR DESCRIPTION
## Why are you doing this?
If the user is logged in then the `GU_U` cookie has the `emailValidated` field. This means we know whether to tell the user to validate (aka verify) their email before getting the benefits of being signed in.

This also includes CTA for signed in, unverified users to click. The CTA loading is being tracked (loading) `sign-into-the-guardian-link-loaded-{payment-type}` (clicked) `sign-into-the-guardian-link-{payment-type}`

## Screenshots
<img width="1287" alt="verification CTA" src="https://user-images.githubusercontent.com/3300789/60670461-9a0f6b80-9e68-11e9-9fb0-a64fc641f474.png">