### PR TITLE
Update analytics for cohorts 3, 4, 5

### DIFF
--- a/support-frontend/assets/components/button/trackableAnchorButton.jsx
+++ b/support-frontend/assets/components/button/trackableAnchorButton.jsx
@@ -1,0 +1,40 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React, { Component } from 'react';
+
+import SharedButton, { defaultProps, type SharedButtonPropTypes } from './_sharedButton';
+import './button.scss';
+
+// ----- Render ----- //
+
+export type PropTypes = {
+  ...SharedButtonPropTypes,
+  'aria-label': ?string,
+  href: string,
+  trackingEvent?: () => void
+};
+
+class TrackableAnchorButton extends Component<PropTypes> {
+  static defaultProps = {
+    ...defaultProps,
+  };
+
+  componentDidMount() {
+    if (this.props.trackingEvent) {
+      this.props.trackingEvent();
+    }
+  }
+
+  render() {
+    return (
+      <SharedButton
+        element="button"
+        {...this.props}
+      />
+    );
+  }
+}
+
+export default TrackableAnchorButton;

--- a/support-frontend/assets/components/button/trackableButton.jsx
+++ b/support-frontend/assets/components/button/trackableButton.jsx
@@ -1,0 +1,43 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React, { Component } from 'react';
+
+import SharedButton, { defaultProps, type SharedButtonPropTypes } from './_sharedButton';
+import './button.scss';
+
+// ----- Render ----- //
+
+type PropTypes = {
+  ...SharedButtonPropTypes,
+  'aria-label': ?string,
+  type: ?('button' | 'submit'),
+  disabled: ?boolean,
+  trackingEvent?: () => void
+};
+
+class TrackableButton extends Component<PropTypes> {
+  static defaultProps = {
+    ...defaultProps,
+    type: 'button',
+    disabled: false,
+  };
+
+  componentDidMount() {
+    if (this.props.trackingEvent) {
+      this.props.trackingEvent();
+    }
+  }
+
+  render() {
+    return (
+      <SharedButton
+        element="button"
+        {...this.props}
+      />
+    );
+  }
+}
+
+export default TrackableButton;

--- a/support-frontend/assets/helpers/tracking/ophan.js
+++ b/support-frontend/assets/helpers/tracking/ophan.js
@@ -143,6 +143,23 @@ const trackComponentClick = (componentId: string): void => {
 
 };
 
+const trackComponentLoad = (componentId: string): void => {
+  gaEvent({
+    category: 'component_load',
+    action: componentId,
+    label: componentId,
+  });
+
+  trackComponentEvents({
+    component: {
+      componentType: 'ACQUISITIONS_OTHER',
+      id: componentId,
+    },
+    action: 'VIEW',
+  });
+
+};
+
 function pageView(url: string, referrer: string) {
   try {
     ophan.sendInitialEvent(
@@ -199,4 +216,5 @@ export {
   trackAbTests,
   trackNewOptimizeExperiment,
   trackPaymentMethodSelected,
+  trackComponentLoad
 };

--- a/support-frontend/assets/helpers/tracking/ophan.js
+++ b/support-frontend/assets/helpers/tracking/ophan.js
@@ -216,5 +216,5 @@ export {
   trackAbTests,
   trackNewOptimizeExperiment,
   trackPaymentMethodSelected,
-  trackComponentLoad
+  trackComponentLoad,
 };

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
@@ -16,7 +16,9 @@ import SvgArrowLeft from 'components/svgs/arrowLeftStraight';
 import { DirectDebit } from 'helpers/paymentMethods';
 import SpreadTheWord from 'components/spreadTheWord/spreadTheWord';
 import ContributionSurvey from '../ContributionSurvey/ContributionsSurvey';
-import { trackComponentClick } from 'helpers/tracking/ophan';
+import { trackComponentClick, trackComponentLoad } from 'helpers/tracking/ophan';
+import TrackableButton from 'components/button/trackableButton';
+
 
 // ----- Types ----- //
 
@@ -77,17 +79,22 @@ function ContributionThankYou(props: PropTypes) {
               far fewer requests for support, please sign in on each of the devices you use to access The
               Guardian – mobile, tablet, laptop or desktop. Please make sure you’ve verified your email address.
             </p>
-            <Button
+            <TrackableButton
               aria-label="Sign into The Guardian"
               appearance="secondary"
+              trackingEvent={
+                () => {
+                  trackComponentLoad(`sign-into-the-guardian-link-loaded-${props.contributionType}`)
+                }
+              }
               onClick={
                 () => {
-                  trackComponentClick(`sign-into-the-guardian-link-${props.contributionType}`);
+                  trackComponentClick(`sign-into-the-guardian-link-clicked-${props.contributionType}`);
                   window.location.href = 'https://profile.theguardian.com/signin';
                 }}
             >
               Sign in now
-            </Button>
+            </TrackableButton>
           </section> : null }
         <MarketingConsent />
         <ContributionSurvey isRunning={false} contributionType={props.contributionType} />

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
@@ -11,7 +11,6 @@ import { type Action, setHasSeenDirectDebitThankYouCopy } from '../../contributi
 import type { PaymentMethod } from 'helpers/paymentMethods';
 import { ContributionThankYouBlurb } from './ContributionThankYouBlurb';
 import AnchorButton from 'components/button/anchorButton';
-import Button from 'components/button/button';
 import SvgArrowLeft from 'components/svgs/arrowLeftStraight';
 import { DirectDebit } from 'helpers/paymentMethods';
 import SpreadTheWord from 'components/spreadTheWord/spreadTheWord';
@@ -84,7 +83,7 @@ function ContributionThankYou(props: PropTypes) {
               appearance="secondary"
               trackingEvent={
                 () => {
-                  trackComponentLoad(`sign-into-the-guardian-link-loaded-${props.contributionType}`)
+                  trackComponentLoad(`sign-into-the-guardian-link-loaded-${props.contributionType}`);
                 }
               }
               onClick={

--- a/support-frontend/assets/pages/contributions-landing/components/SetPasswordForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/SetPasswordForm.jsx
@@ -20,7 +20,8 @@ import ContributionTextInput from './ContributionTextInput';
 import { type ThankYouPageStage } from '../contributionsLandingReducer';
 import { setThankYouPageStage, setPasswordHasBeenSubmitted, setPasswordError, updatePassword, type Action } from '../contributionsLandingActions';
 import Button from 'components/button/button';
-import TrackableButton from 'assets/components/button/trackableButton';
+import TrackableButton from 'components/button/trackableButton';
+import { trackComponentLoad } from 'helpers/tracking/ophan';
 
 const passwordErrorHeading = 'Account set up failure';
 const passwordErrorMessage = 'Sorry, we are unable to register you at this time. We are working hard to fix the problem and hope to be back up and running soon. Please come back later to complete your registration. Thank you.';

--- a/support-frontend/assets/pages/contributions-landing/components/SetPasswordForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/SetPasswordForm.jsx
@@ -20,6 +20,7 @@ import ContributionTextInput from './ContributionTextInput';
 import { type ThankYouPageStage } from '../contributionsLandingReducer';
 import { setThankYouPageStage, setPasswordHasBeenSubmitted, setPasswordError, updatePassword, type Action } from '../contributionsLandingActions';
 import Button from 'components/button/button';
+import TrackableButton from 'assets/components/button/trackableButton';
 
 const passwordErrorHeading = 'Account set up failure';
 const passwordErrorMessage = 'Sorry, we are unable to register you at this time. We are working hard to fix the problem and hope to be back up and running soon. Please come back later to complete your registration. Thank you.';
@@ -134,14 +135,19 @@ function SetPasswordForm(props: PropTypes) {
           errorMessage="Please enter a password between 6 and 20 characters long"
           required
         />
-        <Button
+        <TrackableButton
           appearance="secondary"
           modifierClasses={['create-account']}
           aria-label="Create a guardian account"
           type="submit"
+          trackingEvent={
+            () => {
+              trackComponentLoad(`set-password-loaded-${props.contributionType}`);
+            }
+          }
         >
           Create a Guardian account
-        </Button>
+        </TrackableButton>
         <Button
           appearance="greyHollow"
           aria-label="No thank you"

--- a/support-frontend/assets/pages/contributions-landing/components/SetPasswordForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/SetPasswordForm.jsx
@@ -147,7 +147,7 @@ function SetPasswordForm(props: PropTypes) {
           aria-label="No thank you"
           onClick={
           () => {
-            trackComponentClick('decline-to-set-password');
+            trackComponentClick(`decline-to-set-password-${props.contributionType}`);
             props.setThankYouPageStage('thankYouPasswordDeclinedToSet');
           }}
         >


### PR DESCRIPTION
## Why are you doing this?
1. We need to get numbers for how many users are seeing the "sign in" button to get a sense of the percentage that are 'converting' to signed in
2. It makes sense to track the 'decline to set password' across the same dimension (contribution type) that we are now tracking those who do set a password
<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/b/QVWhizic/contributions)

## Changes

* Added a tracking event to `ophan.js` for components loading
* Made trackable versions of the reusable button component using the `componentDidMount` lifecycle hook
* Integrated new tracking event and trackable button on the thank you page
* Updated the tracking on 'decline to set password' link to include contribution type