### PR TITLE
Guardian Weekly thank you email

### DIFF
--- a/support-models/src/main/scala/com/gu/support/workers/Products.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/Products.scala
@@ -1,13 +1,13 @@
 package com.gu.support.workers
 
-import com.gu.i18n.Currency
-import com.gu.support.encoding.Codec
-import com.gu.support.encoding.Codec.deriveCodec
-import io.circe.{Decoder, Encoder}
-import io.circe.syntax._
 import cats.syntax.functor._
+import com.gu.i18n.Currency
 import com.gu.i18n.Currency.GBP
 import com.gu.support.catalog.{FulfilmentOptions, ProductOptions}
+import com.gu.support.encoding.Codec
+import com.gu.support.encoding.Codec.deriveCodec
+import io.circe.syntax._
+import io.circe.{Decoder, Encoder}
 
 
 sealed trait ProductType {
@@ -16,6 +16,7 @@ sealed trait ProductType {
 
   override def toString: String = this.getClass.getSimpleName
   def describe: String
+  val catalogType: com.gu.support.catalog.Product
 }
 
 case class Contribution(
@@ -23,6 +24,7 @@ case class Contribution(
   currency: Currency,
   billingPeriod: BillingPeriod
 ) extends ProductType {
+  override val catalogType = com.gu.support.catalog.Contribution
   override def describe: String = s"$billingPeriod-Contribution-$currency-$amount"
 }
 
@@ -30,6 +32,7 @@ case class DigitalPack(
   currency: Currency,
   billingPeriod: BillingPeriod
 ) extends ProductType {
+  override val catalogType = com.gu.support.catalog.DigitalPack
   override def describe: String = s"$billingPeriod-DigitalPack-$currency"
 }
 
@@ -39,6 +42,7 @@ case class Paper(
   fulfilmentOptions: FulfilmentOptions,
   productOptions: ProductOptions
 ) extends ProductType {
+  override val catalogType = com.gu.support.catalog.Paper
   override def describe: String = s"Paper-$fulfilmentOptions-$productOptions"
 }
 
@@ -47,6 +51,7 @@ case class GuardianWeekly(
   billingPeriod: BillingPeriod,
   fulfilmentOptions: FulfilmentOptions,
 ) extends ProductType {
+  override val catalogType = com.gu.support.catalog.GuardianWeekly
   override def describe: String = s"$billingPeriod-GuardianWeekly-$fulfilmentOptions-$currency"
 }
 

--- a/support-models/src/main/scala/com/gu/support/workers/states/SendThankYouEmailState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/SendThankYouEmailState.scala
@@ -2,8 +2,9 @@ package com.gu.support.workers.states
 
 import java.util.UUID
 
-import com.gu.support.workers.{PaymentMethod, SalesforceContactRecord, User, _}
 import com.gu.support.encoding.CustomCodecs.{decodeLocalTime, encodeLocalTime}
+import com.gu.support.promotions.PromoCode
+import com.gu.support.workers.{PaymentMethod, SalesforceContactRecord, User, _}
 import org.joda.time.LocalDate
 
 case class SendThankYouEmailState(
@@ -13,6 +14,7 @@ case class SendThankYouEmailState(
   product: ProductType,
   paymentMethod: PaymentMethod,
   firstDeliveryDate: Option[LocalDate],
+  promoCode: Option[PromoCode],
   salesForceContact: SalesforceContactRecord,
   accountNumber: String,
   subscriptionNumber: String,

--- a/support-workers/src/main/scala/com/gu/emailservices/ContributionEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/ContributionEmailFields.scala
@@ -1,5 +1,6 @@
 package com.gu.emailservices
 
+import com.gu.emailservices.SubscriptionEmailFieldHelpers.{formatDate, hyphenate, mask}
 import com.gu.i18n.Currency
 import com.gu.salesforce.Salesforce.SfContactId
 import com.gu.support.workers._

--- a/support-workers/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
@@ -3,6 +3,7 @@ package com.gu.emailservices
 import com.gu.emailservices.SubscriptionEmailFieldHelpers._
 import com.gu.i18n.Currency
 import com.gu.salesforce.Salesforce.SfContactId
+import com.gu.support.promotions.Promotion
 import com.gu.support.workers._
 
 // Output Json should look like this:
@@ -44,7 +45,8 @@ case class DigitalPackEmailFields(
     currency: Currency,
     paymentMethod: PaymentMethod,
     sfContactId: SfContactId,
-    directDebitMandateId: Option[String] = None
+    directDebitMandateId: Option[String] = None,
+    promotion: Option[Promotion] = None
 ) extends EmailFields {
 
   val paymentFields = paymentMethod match {
@@ -82,7 +84,7 @@ case class DigitalPackEmailFields(
     "Date of first payment" -> formatDate(SubscriptionEmailFieldHelpers.firstPayment(paymentSchedule).date),
     "Currency" -> currency.glyph,
     "Trial period" -> "14", //TODO: depends on Promo code
-    "Subscription details" -> SubscriptionEmailFieldHelpers.describe(paymentSchedule, billingPeriod, currency)
+    "Subscription details" -> SubscriptionEmailFieldHelpers.describe(paymentSchedule, billingPeriod, currency, None)
   ) ++ paymentFields
 
   override def payload: String = super.payload(user.primaryEmailAddress, "digipack")

--- a/support-workers/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
@@ -84,7 +84,7 @@ case class DigitalPackEmailFields(
     "Date of first payment" -> formatDate(SubscriptionEmailFieldHelpers.firstPayment(paymentSchedule).date),
     "Currency" -> currency.glyph,
     "Trial period" -> "14", //TODO: depends on Promo code
-    "Subscription details" -> SubscriptionEmailFieldHelpers.describe(paymentSchedule, billingPeriod, currency, None)
+    "Subscription details" -> SubscriptionEmailFieldHelpers.describe(paymentSchedule, billingPeriod, currency, promotion)
   ) ++ paymentFields
 
   override def payload: String = super.payload(user.primaryEmailAddress, "digipack")

--- a/support-workers/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
@@ -1,5 +1,6 @@
 package com.gu.emailservices
 
+import com.gu.emailservices.SubscriptionEmailFieldHelpers._
 import com.gu.i18n.Currency
 import com.gu.salesforce.Salesforce.SfContactId
 import com.gu.support.workers._

--- a/support-workers/src/main/scala/com/gu/emailservices/EmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/EmailFields.scala
@@ -1,10 +1,8 @@
 package com.gu.emailservices
 
-import org.joda.time.LocalDate
-import org.joda.time.format.DateTimeFormat
+import com.gu.salesforce.Salesforce.SfContactId
 import io.circe.generic.auto._
 import io.circe.syntax._
-import com.gu.salesforce.Salesforce.SfContactId
 
 // scalastyle:off
 case class EmailPayloadContactAttributes(SubscriberAttributes: Map[String, String])
@@ -36,7 +34,4 @@ trait EmailFields {
     ).jsonString
   }
 
-  protected def mask(s: String): String = s.replace(s.substring(0, 6), "******")
-  protected def hyphenate(s: String): String = s"${s.substring(0, 2)}-${s.substring(2, 4)}-${s.substring(4, 6)}"
-  protected def formatDate(d: LocalDate): String = DateTimeFormat.forPattern("EEEE, d MMMM yyyy").print(d)
 }

--- a/support-workers/src/main/scala/com/gu/emailservices/GuardianWeeklyEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/GuardianWeeklyEmailFields.scala
@@ -7,7 +7,7 @@ import com.gu.support.catalog.FulfilmentOptions
 import com.gu.support.workers.{BillingPeriod, PaymentMethod, PaymentSchedule, User}
 import org.joda.time.LocalDate
 
-class GuardianWeeklyEmailFields(
+case class GuardianWeeklyEmailFields(
   subscriptionNumber: String,
   fulfilmentOptions: FulfilmentOptions,
   billingPeriod: BillingPeriod,

--- a/support-workers/src/main/scala/com/gu/emailservices/GuardianWeeklyEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/GuardianWeeklyEmailFields.scala
@@ -1,15 +1,15 @@
 package com.gu.emailservices
 
+import com.gu.emailservices.SubscriptionEmailFieldHelpers.formatDate
 import com.gu.i18n.Currency
 import com.gu.salesforce.Salesforce.SfContactId
-import com.gu.support.catalog.{FulfilmentOptions, HomeDelivery, ProductOptions}
-import com.gu.support.workers._
+import com.gu.support.catalog.FulfilmentOptions
+import com.gu.support.workers.{BillingPeriod, PaymentMethod, PaymentSchedule, User}
 import org.joda.time.LocalDate
 
-case class PaperEmailFields(
+class GuardianWeeklyEmailFields(
   subscriptionNumber: String,
   fulfilmentOptions: FulfilmentOptions,
-  productOptions: ProductOptions,
   billingPeriod: BillingPeriod,
   user: User,
   paymentSchedule: PaymentSchedule,
@@ -20,17 +20,15 @@ case class PaperEmailFields(
   directDebitMandateId: Option[String] = None
 ) extends EmailFields {
 
-  val additionalFields = List("package" -> productOptions.toString)
-
-  val dataExtension = fulfilmentOptions match {
-    case HomeDelivery => "paper-delivery"
-    case _ => "paper-voucher"
-  }
+  val additionalFields = List(
+    paymentSchedule.payments.lift(1).map(payment => "date_of_second_payment" -> formatDate(payment.date))
+  )
 
   override val fields = PaperFieldsGenerator.fieldsFor(
     subscriptionNumber, billingPeriod, user, paymentSchedule, firstDeliveryDate, currency, paymentMethod, sfContactId, directDebitMandateId
-  ) ++ additionalFields
+  ) ++ additionalFields.flatten
 
-  override def payload: String = super.payload(user.primaryEmailAddress, dataExtension)
+  override def payload: String = super.payload(user.primaryEmailAddress, "guardian-weekly")
   override def userId: Either[SfContactId, IdentityUserId] = Left(sfContactId)
 }
+

--- a/support-workers/src/main/scala/com/gu/emailservices/GuardianWeeklyEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/GuardianWeeklyEmailFields.scala
@@ -4,6 +4,7 @@ import com.gu.emailservices.SubscriptionEmailFieldHelpers.formatDate
 import com.gu.i18n.Currency
 import com.gu.salesforce.Salesforce.SfContactId
 import com.gu.support.catalog.FulfilmentOptions
+import com.gu.support.promotions.Promotion
 import com.gu.support.workers.{BillingPeriod, PaymentMethod, PaymentSchedule, User}
 import org.joda.time.LocalDate
 
@@ -17,7 +18,8 @@ case class GuardianWeeklyEmailFields(
   currency: Currency,
   paymentMethod: PaymentMethod,
   sfContactId: SfContactId,
-  directDebitMandateId: Option[String] = None
+  directDebitMandateId: Option[String] = None,
+  promotion: Option[Promotion] = None
 ) extends EmailFields {
 
   val additionalFields = List(
@@ -25,7 +27,7 @@ case class GuardianWeeklyEmailFields(
   )
 
   override val fields = PaperFieldsGenerator.fieldsFor(
-    subscriptionNumber, billingPeriod, user, paymentSchedule, firstDeliveryDate, currency, paymentMethod, sfContactId, directDebitMandateId
+    subscriptionNumber, billingPeriod, user, paymentSchedule, firstDeliveryDate, currency, paymentMethod, sfContactId, directDebitMandateId, promotion
   ) ++ additionalFields.flatten
 
   override def payload: String = super.payload(user.primaryEmailAddress, "guardian-weekly")

--- a/support-workers/src/main/scala/com/gu/emailservices/PaperEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/PaperEmailFields.scala
@@ -30,7 +30,7 @@ case class PaperEmailFields(
   }
 
   override val fields = PaperFieldsGenerator.fieldsFor(
-    subscriptionNumber, billingPeriod, user, paymentSchedule, firstDeliveryDate, currency, paymentMethod, sfContactId, directDebitMandateId
+    subscriptionNumber, billingPeriod, user, paymentSchedule, firstDeliveryDate, currency, paymentMethod, sfContactId, directDebitMandateId, promotion
   ) ++ additionalFields
 
   override def payload: String = super.payload(user.primaryEmailAddress, dataExtension)

--- a/support-workers/src/main/scala/com/gu/emailservices/PaperEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/PaperEmailFields.scala
@@ -3,6 +3,7 @@ package com.gu.emailservices
 import com.gu.i18n.Currency
 import com.gu.salesforce.Salesforce.SfContactId
 import com.gu.support.catalog.{FulfilmentOptions, HomeDelivery, ProductOptions}
+import com.gu.support.promotions.Promotion
 import com.gu.support.workers._
 import org.joda.time.LocalDate
 
@@ -17,7 +18,8 @@ case class PaperEmailFields(
   currency: Currency,
   paymentMethod: PaymentMethod,
   sfContactId: SfContactId,
-  directDebitMandateId: Option[String] = None
+  directDebitMandateId: Option[String] = None,
+  promotion: Option[Promotion] = None
 ) extends EmailFields {
 
   val additionalFields = List("package" -> productOptions.toString)

--- a/support-workers/src/main/scala/com/gu/emailservices/PaperFieldsGenerator.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/PaperFieldsGenerator.scala
@@ -18,8 +18,8 @@ object PaperFieldsGenerator {
     currency: Currency,
     paymentMethod: PaymentMethod,
     sfContactId: SfContactId,
-    directDebitMandateId: Option[String] = None,
-    promotion: Option[Promotion] = None
+    directDebitMandateId: Option[String],
+    promotion: Option[Promotion]
   ): List[(String, String)] = {
 
     val firstPaymentDate = SubscriptionEmailFieldHelpers.firstPayment(paymentSchedule).date

--- a/support-workers/src/main/scala/com/gu/emailservices/PaperFieldsGenerator.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/PaperFieldsGenerator.scala
@@ -2,6 +2,7 @@ package com.gu.emailservices
 
 import com.gu.i18n.Currency
 import com.gu.salesforce.Salesforce.SfContactId
+import com.gu.support.promotions.Promotion
 import com.gu.support.workers._
 import org.joda.time.LocalDate
 
@@ -17,7 +18,8 @@ object PaperFieldsGenerator {
     currency: Currency,
     paymentMethod: PaymentMethod,
     sfContactId: SfContactId,
-    directDebitMandateId: Option[String] = None
+    directDebitMandateId: Option[String] = None,
+    promotion: Option[Promotion] = None
   ): List[(String, String)] = {
 
     val firstPaymentDate = SubscriptionEmailFieldHelpers.firstPayment(paymentSchedule).date
@@ -35,7 +37,7 @@ object PaperFieldsGenerator {
       "last_name" -> user.lastName,
       "date_of_first_paper" -> SubscriptionEmailFieldHelpers.formatDate(firstDeliveryDate.getOrElse(firstPaymentDate)),
       "date_of_first_payment" -> SubscriptionEmailFieldHelpers.formatDate(firstPaymentDate),
-      "subscription_rate" -> SubscriptionEmailFieldHelpers.describe(paymentSchedule, billingPeriod, currency)
+      "subscription_rate" -> SubscriptionEmailFieldHelpers.describe(paymentSchedule, billingPeriod, currency, promotion)
     ) ++ paymentFields ++ deliveryAddressFields
 
     fields

--- a/support-workers/src/main/scala/com/gu/emailservices/PaperFieldsGenerator.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/PaperFieldsGenerator.scala
@@ -1,0 +1,75 @@
+package com.gu.emailservices
+
+import com.gu.i18n.Currency
+import com.gu.salesforce.Salesforce.SfContactId
+import com.gu.support.workers._
+import org.joda.time.LocalDate
+
+//noinspection ScalaStyle
+object PaperFieldsGenerator {
+
+  def fieldsFor(
+    subscriptionNumber: String,
+    billingPeriod: BillingPeriod,
+    user: User,
+    paymentSchedule: PaymentSchedule,
+    firstDeliveryDate: Option[LocalDate],
+    currency: Currency,
+    paymentMethod: PaymentMethod,
+    sfContactId: SfContactId,
+    directDebitMandateId: Option[String] = None
+  ): List[(String, String)] = {
+
+    val firstPaymentDate = SubscriptionEmailFieldHelpers.firstPayment(paymentSchedule).date
+
+    val paymentFields = getPaymentFields(paymentMethod, directDebitMandateId)
+
+    val deliveryAddressFields = getAddressFields(user)
+
+    val fields = List(
+      "ZuoraSubscriberId" -> subscriptionNumber,
+      "SubscriberKey" -> user.primaryEmailAddress,
+      "EmailAddress" -> user.primaryEmailAddress,
+      "subscriber_id" -> subscriptionNumber,
+      "first_name" -> user.firstName,
+      "last_name" -> user.lastName,
+      "date_of_first_paper" -> SubscriptionEmailFieldHelpers.formatDate(firstDeliveryDate.getOrElse(firstPaymentDate)),
+      "date_of_first_payment" -> SubscriptionEmailFieldHelpers.formatDate(firstPaymentDate),
+      "subscription_rate" -> SubscriptionEmailFieldHelpers.describe(paymentSchedule, billingPeriod, currency)
+    ) ++ paymentFields ++ deliveryAddressFields
+
+    fields
+  }
+
+  protected def getAddressFields(user: User)= {
+    val address = user.deliveryAddress.getOrElse(user.billingAddress)
+
+    List(
+      "delivery_address_line_1" -> address.lineOne.getOrElse(""),
+      "delivery_address_line_2" -> address.lineTwo.getOrElse(""),
+      "delivery_address_town" -> address.city.getOrElse(""),
+      "delivery_postcode" -> address.postCode.getOrElse(""),
+      "delivery_country" -> address.country.name
+    )
+  }
+
+  protected def getPaymentFields(paymentMethod: PaymentMethod, directDebitMandateId: Option[String]) = paymentMethod match {
+    case dd: DirectDebitPaymentMethod => List(
+      "bank_account_no" -> SubscriptionEmailFieldHelpers.mask(dd.bankTransferAccountNumber),
+      "bank_sort_code" -> SubscriptionEmailFieldHelpers.hyphenate(dd.bankCode),
+      "account_holder" -> dd.bankTransferAccountName,
+      "payment_method" -> "Direct Debit",
+      "mandate_id" -> directDebitMandateId.getOrElse("")
+    )
+    case dd: ClonedDirectDebitPaymentMethod => List(
+      "bank_account_no" -> SubscriptionEmailFieldHelpers.mask(dd.bankTransferAccountNumber),
+      "bank_sort_code" -> SubscriptionEmailFieldHelpers.hyphenate(dd.bankCode),
+      "account_holder" -> dd.bankTransferAccountName,
+      "payment_method" -> "Direct Debit",
+      "mandate_id" -> dd.mandateId
+    )
+    case _: CreditCardReferenceTransaction => List("payment_method" -> "Credit/Debit Card")
+    case _: PayPalReferenceTransaction => List("payment_method" -> "PayPal")
+  }
+
+}

--- a/support-workers/src/main/scala/com/gu/emailservices/SubscriptionEmailFieldHelpers.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/SubscriptionEmailFieldHelpers.scala
@@ -1,8 +1,10 @@
 package com.gu.emailservices
 
 import java.text.DecimalFormat
+
 import com.gu.i18n.Currency
 import com.gu.support.workers._
+import org.joda.time.format.DateTimeFormat
 import org.joda.time.{LocalDate, Months}
 
 object SubscriptionEmailFieldHelpers {
@@ -47,4 +49,9 @@ object SubscriptionEmailFieldHelpers {
     }
   }
 
+  def formatDate(d: LocalDate): String = DateTimeFormat.forPattern("EEEE, d MMMM yyyy").print(d)
+
+  def mask(s: String): String = s.replace(s.substring(0, 6), "******")
+
+  def hyphenate(s: String): String = s"${s.substring(0, 2)}-${s.substring(2, 4)}-${s.substring(4, 6)}"
 }

--- a/support-workers/src/main/scala/com/gu/emailservices/SubscriptionEmailFieldHelpers.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/SubscriptionEmailFieldHelpers.scala
@@ -3,9 +3,12 @@ package com.gu.emailservices
 import java.text.DecimalFormat
 
 import com.gu.i18n.Currency
+import com.gu.support.promotions.{IntroductoryPriceBenefit, Promotion}
 import com.gu.support.workers._
 import org.joda.time.format.DateTimeFormat
 import org.joda.time.{LocalDate, Months}
+
+import scala.util.Try
 
 object SubscriptionEmailFieldHelpers {
 
@@ -19,14 +22,29 @@ object SubscriptionEmailFieldHelpers {
 
   def firstPayment(paymentSchedule: PaymentSchedule): Payment = paymentSchedule.payments.minBy(_.date)
 
-  def introductoryPeriod(introductoryBillingPeriods: Int, billingPeriod: BillingPeriod): String = {
-    val pluraliseIfRequired = if (introductoryBillingPeriods > 1) "s" else ""
-    s"$introductoryBillingPeriods ${billingPeriod.noun}$pluraliseIfRequired"
+  def pluralise(num: Int, thing: String) = if(num > 1) s"$num ${thing}s" else s"$num $thing"
+
+  def introductoryPeriod(introductoryBillingPeriods: Int, billingPeriod: BillingPeriod): String =
+    s"${pluralise(introductoryBillingPeriods, billingPeriod.noun)}"
+
+
+  def describe(paymentSchedule: PaymentSchedule, billingPeriod: BillingPeriod, currency: Currency, promotion: Option[Promotion]): String = {
+    promotion.flatMap(_.introductoryPrice)
+      .map(introductoryPrice => introductoryPriceDescription(paymentSchedule, billingPeriod, currency, introductoryPrice))
+      .getOrElse(standardDescription(paymentSchedule, billingPeriod, currency))
   }
 
-  def describe(paymentSchedule: PaymentSchedule, billingPeriod: BillingPeriod, currency: Currency): String = {
+  def introductoryPriceDescription(paymentSchedule: PaymentSchedule, billingPeriod: BillingPeriod, currency: Currency, benefit: IntroductoryPriceBenefit) =
+    Try(paymentSchedule.payments.tail.head).fold(
+      _ => "",
+      payment => s"${priceWithCurrency(currency, benefit.price)} for ${pluralise(benefit.periodLength, benefit.periodType.toString.toLowerCase)}, " +
+        s"then ${priceWithCurrency(currency, payment.amount)} every ${billingPeriod.noun}"
+    )
+
+  def standardDescription(paymentSchedule: PaymentSchedule, billingPeriod: BillingPeriod, currency: Currency): String = {
     val initialPrice = firstPayment(paymentSchedule).amount
     val (paymentsWithInitialPrice, paymentsWithDifferentPrice) = paymentSchedule.payments.partition(_.amount == initialPrice)
+
     if (paymentSchedule.payments.size == 1) {
       s"${priceWithCurrency(currency, initialPrice)} for the first ${billingPeriod.noun}"
     }
@@ -47,6 +65,7 @@ object SubscriptionEmailFieldHelpers {
       s"${priceWithCurrency(currency, initialPrice)} for $introductoryTimespan, " +
         s"then ${priceWithCurrency(currency, paymentsWithDifferentPrice.head.amount)} every ${billingPeriod.noun}"
     }
+
   }
 
   def formatDate(d: LocalDate): String = DateTimeFormat.forPattern("EEEE, d MMMM yyyy").print(d)

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -90,6 +90,7 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
       state.product,
       state.paymentMethod,
       state.firstDeliveryDate,
+      state.promoCode,
       state.salesforceContacts.buyer,
       accountNumber.value,
       subscriptionNumber.value,

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
@@ -2,10 +2,9 @@ package com.gu.support.workers.lambdas
 
 import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.sqs.model.SendMessageResult
-import com.gu.emailservices.{ContributionEmailFields, DigitalPackEmailFields, EmailService, PaperEmailFields}
+import com.gu.emailservices._
 import com.gu.salesforce.Salesforce.SfContactId
 import com.gu.services.{ServiceProvider, Services}
-import com.gu.support.catalog.{Collection, HomeDelivery}
 import com.gu.support.encoding.CustomCodecs._
 import com.gu.support.workers._
 import com.gu.support.workers.states.SendThankYouEmailState
@@ -77,7 +76,18 @@ class SendThankYouEmail(thankYouEmailService: EmailService, servicesProvider: Se
           directDebitMandateId = directDebitMandateId,
           sfContactId = SfContactId(state.salesForceContact.Id)
         )
-        case g: GuardianWeekly => ??? //TODO: Emails for Guardian Weekly
+        case g: GuardianWeekly => GuardianWeeklyEmailFields(
+          subscriptionNumber = state.subscriptionNumber,
+          fulfilmentOptions = g.fulfilmentOptions,
+          billingPeriod = g.billingPeriod,
+          user = state.user,
+          paymentSchedule = state.paymentSchedule,
+          firstDeliveryDate = state.firstDeliveryDate,
+          currency = g.currency,
+          paymentMethod = state.paymentMethod,
+          directDebitMandateId = directDebitMandateId,
+          sfContactId = SfContactId(state.salesForceContact.Id)
+        )
       }
     )
 

--- a/support-workers/src/test/scala/com/gu/emailservices/SubscriptionEmailFieldHelpersSpec.scala
+++ b/support-workers/src/test/scala/com/gu/emailservices/SubscriptionEmailFieldHelpersSpec.scala
@@ -1,7 +1,8 @@
 package com.gu.emailservices
 
 import com.gu.i18n.Currency.{EUR, GBP, USD}
-import com.gu.support.workers.{Annual, Monthly, Payment, PaymentSchedule, Quarterly}
+import com.gu.support.promotions.Promotions.SixForSixPromotion
+import com.gu.support.workers._
 import org.joda.time.LocalDate
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -20,28 +21,28 @@ class SubscriptionEmailFieldHelpersSpec extends FlatSpec with Matchers {
     val standardDigitalPackPayment = Payment(referenceDate, 119.90)
     val schedule = payments(standardDigitalPackPayment, List(12))
     val expected = "£119.90 every year"
-    assert(SubscriptionEmailFieldHelpers.describe(PaymentSchedule(schedule), Annual, GBP) == expected)
+    assert(SubscriptionEmailFieldHelpers.describe(PaymentSchedule(schedule), Annual, GBP, None) == expected)
   }
 
   "describe" should "explain a simple quarterly payment schedule correctly" in {
     val standardDigitalPackPayment = Payment(referenceDate, 57.50)
     val schedule = payments(standardDigitalPackPayment, List(3, 6, 9))
     val expected = "$57.50 every quarter"
-    assert(SubscriptionEmailFieldHelpers.describe(PaymentSchedule(schedule), Quarterly, USD) == expected)
+    assert(SubscriptionEmailFieldHelpers.describe(PaymentSchedule(schedule), Quarterly, USD, None) == expected)
   }
 
   "describe" should "explain a simple monthly payment schedule correctly" in {
     val standardDigitalPackPayment = Payment(referenceDate, 11.99)
     val schedule = payments(standardDigitalPackPayment, List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12))
     val expected = "€11.99 every month"
-    assert(SubscriptionEmailFieldHelpers.describe(PaymentSchedule(schedule), Monthly, EUR) == expected)
+    assert(SubscriptionEmailFieldHelpers.describe(PaymentSchedule(schedule), Monthly, EUR, None) == expected)
   }
 
   "describe" should "explain a payment schedule truthfully if we only get information about the first payment" in {
     val discountedDigitalPackPayment = Payment(referenceDate, 100.90)
     val schedule = PaymentSchedule(List(discountedDigitalPackPayment))
     val expected = "£100.90 for the first year"
-    assert(SubscriptionEmailFieldHelpers.describe(schedule, Annual, GBP) == expected)
+    assert(SubscriptionEmailFieldHelpers.describe(schedule, Annual, GBP, None) == expected)
   }
 
   "describe" should "explain a payment schedule correctly if the first 3 months are discounted" in {
@@ -49,7 +50,7 @@ class SubscriptionEmailFieldHelpersSpec extends FlatSpec with Matchers {
     val firstFullPricePayment = Payment(referenceDate.plusMonths(3), 11.99)
     val schedule: List[Payment] = payments(firstDiscountedPayment, List(1, 2)) ++ payments(firstFullPricePayment, List(1, 2, 3, 4, 5, 6, 7, 8, 9))
     val expected = "£5.99 for 3 months, then £11.99 every month"
-    assert(SubscriptionEmailFieldHelpers.describe(PaymentSchedule(schedule), Monthly, GBP) == expected)
+    assert(SubscriptionEmailFieldHelpers.describe(PaymentSchedule(schedule), Monthly, GBP, None) == expected)
   }
 
   "describe" should "explain a payment schedule correctly if the first 2 quarters are discounted" in {
@@ -57,7 +58,15 @@ class SubscriptionEmailFieldHelpersSpec extends FlatSpec with Matchers {
     val firstFullPricePayment = Payment(referenceDate.plusMonths(6), 37.50)
     val schedule: List[Payment] = payments(firstDiscountedPayment, List(3)) ++ payments(firstFullPricePayment, List(3, 6))
     val expected = "£30.00 for 2 quarters, then £37.50 every quarter"
-    assert(SubscriptionEmailFieldHelpers.describe(PaymentSchedule(schedule), Quarterly, GBP) == expected)
+    assert(SubscriptionEmailFieldHelpers.describe(PaymentSchedule(schedule), Quarterly, GBP, None) == expected)
+  }
+
+  "describe" should "explain a 6 for 6 subscription correctly" in {
+    val firstPayment = Payment(referenceDate, 6)
+    val fullPricePayment = Payment(referenceDate.plusWeeks(6), 37.50)
+    val schedule: List[Payment] = List(firstPayment, fullPricePayment, fullPricePayment.copy(fullPricePayment.date.plusMonths(3)))
+    val expected = "£6.00 for 6 issues, then £37.50 every quarter"
+    assert(SubscriptionEmailFieldHelpers.describe(PaymentSchedule(schedule), Quarterly, GBP, Some(SixForSixPromotion)) == expected)
   }
 
 }

--- a/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
@@ -42,7 +42,7 @@ object JsonFixtures {
     s"""
       "user":{
           "id": "$idId",
-          "primaryEmailAddress": "$emailAddress",
+          "primaryEmailAddress": "rupert.bates@theguardian.com",
           "firstName": "test",
           "lastName": "user",
           "country": "GB",

--- a/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
@@ -42,7 +42,7 @@ object JsonFixtures {
     s"""
       "user":{
           "id": "$idId",
-          "primaryEmailAddress": "rupert.bates@theguardian.com",
+          "primaryEmailAddress": "$emailAddress",
           "firstName": "test",
           "lastName": "user",
           "country": "GB",

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
@@ -6,14 +6,14 @@ import com.gu.config.Configuration.{promotionsConfigProvider, zuoraConfigProvide
 import com.gu.okhttp.RequestRunners.configurableFutureRunner
 import com.gu.support.catalog.GuardianWeekly
 import com.gu.support.encoding.CustomCodecs._
-import com.gu.support.promotions.{PromotionService, Promotions}
+import com.gu.support.promotions.PromotionService
 import com.gu.support.workers.JsonFixtures.{createEverydayPaperSubscriptionJson, _}
+import com.gu.support.workers._
 import com.gu.support.workers.encoding.Conversions.FromOutputStream
 import com.gu.support.workers.encoding.Encoding
 import com.gu.support.workers.errors.MockServicesCreator
 import com.gu.support.workers.lambdas.CreateZuoraSubscription
 import com.gu.support.workers.states.SendThankYouEmailState
-import com.gu.support.workers.{Annual, IdentityId, LambdaSpec, Monthly, Quarterly}
 import com.gu.support.zuora.api.response.ZuoraAccountNumber
 import com.gu.support.zuora.api.{PreviewSubscribeRequest, SubscribeRequest}
 import com.gu.test.tags.annotations.IntegrationTest
@@ -62,7 +62,7 @@ class CreateZuoraSubscriptionSpec extends LambdaSpec with MockServicesCreator {
     createSubscription(createGuardianWeeklySubscriptionJson(Quarterly))
   }
 
-  it should "create an 6 for 6 Guardian Weekly subscription" in {
+  it should "create a 6 for 6 Guardian Weekly subscription" in {
     createSubscription(createGuardianWeeklySubscriptionJson(Quarterly, Some(GuardianWeekly.SixForSixPromoCode)))
   }
 


### PR DESCRIPTION
## Why are you doing this?

When a user purchases a Guardian Weekly subscription we want to send them an email confirming what they have purchased.

Changes:
* Pass the promo code through to the `SendThankYouEmail` lambda so that we can tell when a subscription is 6 for 6.
* Add a `GuardianWeeklyEmailFields` case class to generate the necessary data for the email
* Update the `SubscriptionEmailFieldHelpers.describe` method to cope with 6 for 6

[**Trello Card**](https://trello.com/c/uTIjJqm5/2336-guardian-weekly-thank-you-email)
