### PR TITLE
Redirect with encoded query string on application and subscription controllers

### DIFF
--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -15,6 +15,7 @@ import config.StringsConfig
 import cookies.ServersideAbTestCookie
 import com.gu.monitoring.SafeLogger
 import com.gu.monitoring.SafeLogger._
+import lib.RedirectWithEncodedQueryString
 import play.api.mvc._
 import services.{IdentityService, MembersDataService, PaymentAPIService}
 import utils.BrowserCheck
@@ -49,13 +50,6 @@ class Application(
     Ok(views.html.contributionsRedirect())
   }
 
-  //Encode the querystring parameter keys, as Play only encodes the values
-  def redirectWithEncodedQueryString(url: String, queryString: Map[String, Seq[String]] = Map.empty, status: Int = SEE_OTHER): Result = Redirect(
-    url = url,
-    queryString = queryString.map { case (k,v) => java.net.URLEncoder.encode(k, "utf-8") -> v },
-    status = status
-  )
-
   def geoRedirect: Action[AnyContent] = GeoTargetedCachedAction() { implicit request =>
     val redirectUrl = request.fastlyCountry match {
       case Some(UK) => buildCanonicalShowcaseLink("uk")
@@ -68,7 +62,7 @@ class Application(
       case _ => "/uk/contribute"
     }
 
-    redirectWithEncodedQueryString(redirectUrl, request.queryString, status = FOUND)
+    RedirectWithEncodedQueryString(redirectUrl, request.queryString, status = FOUND)
   }
 
   def contributeGeoRedirect(campaignCode: String): Action[AnyContent] = GeoTargetedCachedAction() { implicit request =>
@@ -76,25 +70,25 @@ class Application(
       .filter(_.nonEmpty)
       .mkString("/")
 
-    redirectWithEncodedQueryString(url, request.queryString, status = FOUND)
+    RedirectWithEncodedQueryString(url, request.queryString, status = FOUND)
   }
 
 
   def redirect(location: String): Action[AnyContent] = CachedAction() { implicit request =>
-    redirectWithEncodedQueryString(location, request.queryString, status = FOUND)
+    RedirectWithEncodedQueryString(location, request.queryString, status = FOUND)
   }
 
   def permanentRedirect(location: String): Action[AnyContent] = CachedAction() { implicit request =>
-    redirectWithEncodedQueryString(location, request.queryString, status = MOVED_PERMANENTLY)
+    RedirectWithEncodedQueryString(location, request.queryString, status = MOVED_PERMANENTLY)
   }
 
   // Country code is required here because it's a parameter in the route.
   def permanentRedirectWithCountry(country: String, location: String): Action[AnyContent] = CachedAction() { implicit request =>
-    redirectWithEncodedQueryString(location, request.queryString, status = MOVED_PERMANENTLY)
+    RedirectWithEncodedQueryString(location, request.queryString, status = MOVED_PERMANENTLY)
   }
 
   def redirectPath(location: String, path: String): Action[AnyContent] = CachedAction() { implicit request =>
-    redirectWithEncodedQueryString(location + path, request.queryString)
+    RedirectWithEncodedQueryString(location + path, request.queryString)
   }
 
   def unsupportedBrowser: Action[AnyContent] = NoCacheAction() { implicit request =>
@@ -171,7 +165,7 @@ class Application(
   // Remove trailing slashes so that /uk/ redirects to /uk
   def removeTrailingSlash(path: String): Action[AnyContent] = CachedAction() {
     request =>
-      redirectWithEncodedQueryString("/" + path, request.queryString, MOVED_PERMANENTLY)
+      RedirectWithEncodedQueryString("/" + path, request.queryString, MOVED_PERMANENTLY)
   }
 
 

--- a/support-frontend/app/controllers/GeoRedirect.scala
+++ b/support-frontend/app/controllers/GeoRedirect.scala
@@ -2,6 +2,7 @@ package controllers
 
 import actions.CustomActionBuilders
 import com.gu.i18n.CountryGroup._
+import lib.RedirectWithEncodedQueryString
 import play.api.mvc.{AbstractController, Action, AnyContent}
 import utils.RequestCountry._
 
@@ -13,6 +14,6 @@ trait GeoRedirect {
 
   def geoRedirect(path: String): Action[AnyContent] = GeoTargetedCachedAction() { implicit request =>
     val redirectUrl = s"/${request.fastlyCountry.map(_.id).getOrElse("int")}/$path"
-    Redirect(redirectUrl, request.queryString, status = FOUND)
+    RedirectWithEncodedQueryString(redirectUrl, request.queryString, status = FOUND)
   }
 }

--- a/support-frontend/app/controllers/Subscriptions.scala
+++ b/support-frontend/app/controllers/Subscriptions.scala
@@ -7,6 +7,7 @@ import com.gu.support.catalog.GuardianWeekly
 import com.gu.support.encoding.CustomCodecs._
 import com.gu.support.pricing.PriceSummaryServiceProvider
 import config.StringsConfig
+import lib.RedirectWithEncodedQueryString
 import play.api.mvc._
 import play.twirl.api.Html
 import services.IdentityService
@@ -36,7 +37,7 @@ class Subscriptions(
   def legacyRedirect(countryCode: String): Action[AnyContent] = CachedAction() { implicit request =>
     // Country code is required here because it's a parameter in the route.
     // But we don't actually use it.
-    Redirect("https://subscribe.theguardian.com", request.queryString, status = FOUND)
+    RedirectWithEncodedQueryString("https://subscribe.theguardian.com", request.queryString, status = FOUND)
   }
 
   def landing(countryCode: String): Action[AnyContent] = CachedAction() { implicit request =>

--- a/support-frontend/app/lib/RedirectWithEncodedQueryString.scala
+++ b/support-frontend/app/lib/RedirectWithEncodedQueryString.scala
@@ -1,0 +1,14 @@
+package lib
+
+import play.api.http.Status
+import play.api.mvc.{Result, Results}
+
+object RedirectWithEncodedQueryString extends Results with Status {
+  //Encode the querystring parameter keys, as Play only encodes the values
+  def apply(url: String, queryString: Map[String, Seq[String]] = Map.empty, status: Int = SEE_OTHER): Result = Redirect(
+    url = url,
+    queryString = queryString.map { case (k,v) => java.net.URLEncoder.encode(k, "utf-8") -> v },
+    status = status
+  )
+}
+


### PR DESCRIPTION
## Why are you doing this?
Extending @tomrf1 's work here: https://github.com/guardian/support-frontend/pull/1884

Which will eliminate 500 errors when users come to the site from a URL which includes a dash in the query parameters

Tested the offending urls: 
https://support.thegulocal.com/contribute?INTCMP=side_menu_support_contribute&acquisitionData=%7B&quo.%E2%80%99

https://support.thegulocal.com/subscribe?INTCMP=side_menu_support_contribute&acquisitionData=%7B&quo.%E2%80%99
