### PR TITLE
Include 6 for 6 and gifting

### DIFF
--- a/support-frontend/assets/components/subscriptionCheckouts/billingPeriodSelector.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/billingPeriodSelector.jsx
@@ -4,7 +4,6 @@ import React from 'react';
 import { Fieldset } from 'components/forms/fieldset';
 import { RadioInputWithHelper } from 'components/forms/customFields/radioInputWithHelper';
 import type { BillingPeriod } from 'helpers/billingPeriods';
-import { type Option } from 'helpers/types/option';
 import {
   billingPeriodTitle,
   Quarterly,
@@ -29,7 +28,6 @@ type PropTypes = {|
   billingCountry: IsoCountry,
   selected: BillingPeriod,
   onChange: (BillingPeriod) => Action,
-  orderIsAGift?: Option<boolean>,
 |}
 
 function BillingPeriodSelector(props: PropTypes) {
@@ -43,18 +41,17 @@ function BillingPeriodSelector(props: PropTypes) {
             billingPeriod === SixWeekly ? Quarterly : billingPeriod, // for 6 for 6 we need the quarterly pricing
             props.fulfilmentOption,
           );
-          return props.orderIsAGift && billingPeriod === SixWeekly ? null
-            : <RadioInputWithHelper
-              text={billingPeriodTitle(billingPeriod)}
-              helper={getPriceDescription(
-                productPrice,
-                billingPeriod,
-              )}
-              offer={getAppliedPromoDescription(billingPeriod, productPrice)}
-              name="billingPeriod"
-              checked={billingPeriod === props.selected}
-              onChange={() => props.onChange(billingPeriod)}
-            />;
+          return (<RadioInputWithHelper
+            text={billingPeriodTitle(billingPeriod)}
+            helper={getPriceDescription(
+              productPrice,
+              billingPeriod,
+            )}
+            offer={getAppliedPromoDescription(billingPeriod, productPrice)}
+            name="billingPeriod"
+            checked={billingPeriod === props.selected}
+            onChange={() => props.onChange(billingPeriod)}
+          />);
         })}
       </Fieldset>
     </FormSection>);
@@ -62,7 +59,6 @@ function BillingPeriodSelector(props: PropTypes) {
 
 BillingPeriodSelector.defaultProps = {
   fulfilmentOption: NoFulfilmentOptions,
-  orderIsAGift: false,
 };
 
 export { BillingPeriodSelector };

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -181,13 +181,11 @@ function WeeklyCheckoutForm(props: PropTypes) {
             />
           </FormSection>
           <FormSection title="Where should we deliver your magazine?">
-            {props.billingPeriod !== 'SixWeekly' ?
-              <CheckboxInput
-                text="This is a gift"
-                checked={props.orderIsAGift}
-                onChange={() => props.setGiftStatus(!props.orderIsAGift)}
-              />
-            : null}
+            <CheckboxInput
+              text="This is a gift"
+              checked={props.orderIsAGift}
+              onChange={() => props.setGiftStatus(!props.orderIsAGift)}
+            />
             {!props.orderIsAGift ? <DeliveryAddress /> : null}
           </FormSection>
           {props.orderIsAGift ? (
@@ -286,7 +284,6 @@ function WeeklyCheckoutForm(props: PropTypes) {
             billingCountry={props.billingCountry}
             productPrices={props.productPrices}
             selected={props.billingPeriod}
-            orderIsAGift={props.orderIsAGift}
           />
           <PaymentMethodSelector
             country={props.billingCountry}


### PR DESCRIPTION
## Why are you doing this?
The idea is to make the GW checkout as straightforward as possible, so no matter which billing period the user selects, we show gifting in the checkout, and we show 6 for 6 even if they selected quarterly or annual on the landing page. Based on this [**Trello Card**](https://trello.com/b/TjUElW0B/simple-and-coherent-product-supporting-the-guardian)

## Changes
* Removes the code that hides gifting if the user selects 6 for 6 
* Removes the code that hides 6 for 6 if the user selects gifting

## Screenshots
![Screen Shot 2019-06-28 at 16 47 06](https://user-images.githubusercontent.com/16781258/60354562-66de5f80-99c4-11e9-89fd-0f56f06ed898.png)
![Screen Shot 2019-06-28 at 16 44 16](https://user-images.githubusercontent.com/16781258/60354418-1404a800-99c4-11e9-9dc6-fefc8579dba9.png)
