### PR TITLE
Use smaller image size for premium app

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-landing/components/productBlockB/productBlockB.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/productBlockB/productBlockB.jsx
@@ -82,7 +82,7 @@ function ProductBlockB() {
           <ProductBlockRightContent>
             <GridImage
               gridId="AppPremiumTier"
-              srcSizes={[3608, 500, 140]}
+              srcSizes={[1000, 500, 140]}
               sizes="(min-width: 480px) 100%, (max-width: 660px) 100%, 100%"
               imgType="png"
             />


### PR DESCRIPTION
## Why are you doing this?
We're loading a full size crop of one the images on the digipack product page (variant only).  Reducing that down to a more reasonable 1000px width, which reduces the weight significantly.

To be honest I'm not entirely clear what `sizes="(min-width: 480px) 100%, (max-width: 660px) 100%, 100%"` is trying to achieve.  To me that is saying at any width of viewport set the width of the image to 100% 😕 

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com)

## Changes

* Change 1
* Change 2

## Screenshots
Before (1.2MB):
![image](https://user-images.githubusercontent.com/8754692/60355969-ab1f2f00-99c7-11e9-92d5-5760512014fb.png)

After (161KB):
![image](https://user-images.githubusercontent.com/8754692/60356000-c68a3a00-99c7-11e9-9dbf-8f36b0b76c8c.png)




