### PR TITLE
WIP feat: add mapState to digi pack landing page

### DIFF
--- a/support-frontend/assets/helpers/optimize/optimize.js
+++ b/support-frontend/assets/helpers/optimize/optimize.js
@@ -20,6 +20,8 @@ const EXPERIMENTS_UPDATED = 'OPTIMIZE_EXPERIMENTS_UPDATED';
 
 const OPTIMIZE_QUERY_PARAMETER = 'utm_expid';
 
+const OPTIMIZE_CHECK_TIMEOUT = 4000; // milliseconds
+
 // ----- Functions ----- //
 
 function optimizeIsLoaded() {
@@ -27,7 +29,10 @@ function optimizeIsLoaded() {
 }
 
 function gtag() {
-  let timeoutCount = 0;
+  let optimizeReadyChecks = 0;
+  const interval = 100;
+  const maxOptimizeReadyChecks = OPTIMIZE_CHECK_TIMEOUT / interval;
+
   const checkForDataLayer = setInterval(() => {
 
     if (optimizeIsLoaded()) {
@@ -36,12 +41,12 @@ function gtag() {
       // eslint-disable-next-line prefer-rest-params
       window.dataLayer.push(arguments); // unfortunately Optimize seems to need the Arguments object, not just an array
 
-    } else if (timeoutCount > 40) {
+    } else if (optimizeReadyChecks > maxOptimizeReadyChecks) {
       clearInterval(checkForDataLayer);
     }
-    timeoutCount += 1;
+    optimizeReadyChecks += 1;
 
-  }, 100);
+  }, interval);
 }
 
 function getExperimentsFromApi(callback: (variant: string, id: string) => void) {
@@ -135,6 +140,7 @@ function addOptimizeExperiments(addToStoreCallback: (OptimizeExperiment) => void
 
 export {
   OPTIMIZE_QUERY_PARAMETER,
+  OPTIMIZE_CHECK_TIMEOUT,
   addOptimizeExperiments,
   readExperimentsFromSession,
   getOptimizeExperiments,

--- a/support-frontend/assets/helpers/optimize/optimize.js
+++ b/support-frontend/assets/helpers/optimize/optimize.js
@@ -27,37 +27,24 @@ function optimizeIsLoaded() {
 }
 
 function gtag() {
-  let count = 0;
+  let timeoutCount = 0;
   const checkForDataLayer = setInterval(() => {
+
     if (optimizeIsLoaded()) {
-      console.log('gtag fired');
       clearInterval(checkForDataLayer);
+
       // eslint-disable-next-line prefer-rest-params
       window.dataLayer.push(arguments); // unfortunately Optimize seems to need the Arguments object, not just an array
-    } else if (count > 160) {
-      console.log('gtag called again');
+
+    } else if (timeoutCount > 40) {
       clearInterval(checkForDataLayer);
     }
-    count += 1;
+    timeoutCount += 1;
 
-  }, 16);
-
-  // if (optimizeIsLoaded()) {
-  //   console.log('gtag fired');
-  //   // eslint-disable-next-line prefer-rest-params
-  //   window.dataLayer.push(arguments); // unfortunately Optimize seems to need the Arguments object, not just an array
-  // } else {
-  //   console.log('gtag called again');
-  //   setTimeout(() => {
-  //     // eslint-disable-next-line prefer-spread
-  //     gtag.apply(null, arguments); // eslint-disable-line prefer-rest-params
-  //   }, 250);
-  // }
+  }, 100);
 }
 
 function getExperimentsFromApi(callback: (variant: string, id: string) => void) {
-  // the Timeout is to delay the callback until the eventListener has been added to the DOM
-  console.log('callback', callback);
   // $FlowIgnore
   gtag('event', 'optimize.callback', { callback });
 }
@@ -96,12 +83,9 @@ function storeExperimentInSession(experiment: OptimizeExperiment): boolean {
 }
 
 function addExperimentUpdateListener(addToStoreCallback: OptimizeExperiment => void) {
-  console.log('addExperimentUpdateListener');
   window.addEventListener(
     EXPERIMENTS_UPDATED,
-    (ev) => {
-      addToStoreCallback({ id: ev.detail.id, variant: ev.detail.variant });
-    },
+    ev => addToStoreCallback({ id: ev.detail.id, variant: ev.detail.variant }),
   );
 }
 

--- a/support-frontend/assets/helpers/optimize/optimize.js
+++ b/support-frontend/assets/helpers/optimize/optimize.js
@@ -27,19 +27,39 @@ function optimizeIsLoaded() {
 }
 
 function gtag() {
-  if (optimizeIsLoaded()) {
-    // eslint-disable-next-line prefer-rest-params
-    window.dataLayer.push(arguments); // unfortunately Optimize seems to need the Arguments object, not just an array
-  }
+  let count = 0;
+  const checkForDataLayer = setInterval(() => {
+    if (optimizeIsLoaded()) {
+      console.log('gtag fired');
+      clearInterval(checkForDataLayer);
+      // eslint-disable-next-line prefer-rest-params
+      window.dataLayer.push(arguments); // unfortunately Optimize seems to need the Arguments object, not just an array
+    } else if (count > 160) {
+      console.log('gtag called again');
+      clearInterval(checkForDataLayer);
+    }
+    count += 1;
+
+  }, 16);
+
+  // if (optimizeIsLoaded()) {
+  //   console.log('gtag fired');
+  //   // eslint-disable-next-line prefer-rest-params
+  //   window.dataLayer.push(arguments); // unfortunately Optimize seems to need the Arguments object, not just an array
+  // } else {
+  //   console.log('gtag called again');
+  //   setTimeout(() => {
+  //     // eslint-disable-next-line prefer-spread
+  //     gtag.apply(null, arguments); // eslint-disable-line prefer-rest-params
+  //   }, 250);
+  // }
 }
 
 function getExperimentsFromApi(callback: (variant: string, id: string) => void) {
   // the Timeout is to delay the callback until the eventListener has been added to the DOM
   console.log('callback', callback);
-  setTimeout(() => {
-    // $FlowIgnore
-    gtag('event', 'optimize.callback', { callback });
-  }, 100);
+  // $FlowIgnore
+  gtag('event', 'optimize.callback', { callback });
 }
 
 function readExperimentsFromSession(): OptimizeExperiments {

--- a/support-frontend/assets/helpers/optimize/optimize.js
+++ b/support-frontend/assets/helpers/optimize/optimize.js
@@ -30,6 +30,7 @@ function gtag() {
   if (optimizeIsLoaded()) {
     // eslint-disable-next-line prefer-rest-params
     window.dataLayer.push(arguments); // unfortunately Optimize seems to need the Arguments object, not just an array
+  }
 }
 
 function getExperimentsFromApi(callback: (variant: string, id: string) => void) {
@@ -125,7 +126,6 @@ function addOptimizeExperiments(addToStoreCallback: (OptimizeExperiment) => void
     getOptimizeExperiments();
   }
 }
-
 
 // ----- Exports ----- //
 

--- a/support-frontend/assets/helpers/optimize/optimizeScript.js
+++ b/support-frontend/assets/helpers/optimize/optimizeScript.js
@@ -11,8 +11,6 @@ try {
     ga('create', 'UA-51507017-5', 'auto', {cookieDomain: 'auto', anonymizeIp: true});
     ga('require', 'GTM-NZGXNBL');
 
-    getOptimizeExperiments();
-
 } catch (e) {
   console.log(`Error initialising Optimize script: ${e.message}`);
 }

--- a/support-frontend/assets/helpers/page/page.js
+++ b/support-frontend/assets/helpers/page/page.js
@@ -151,11 +151,16 @@ function init<S, A>(
       combineReducers({ page: pageReducer ? pageReducer(initialState) : null, common: commonReducer }),
       storeEnhancer(thunk),
     );
-
+    // setTimeout(() => {
+    console.log('page js Exp', store.getState().common.optimizeExperiments);
     addOptimizeExperiments((exp: OptimizeExperiment) => {
       trackNewOptimizeExperiment(exp, participations);
+      // const expTest = { id: 'ZVlxqx3wRDGSDw-HYZLiAQ', variant: '1' };
+
       store.dispatch(setExperimentVariant(exp));
+      // console.log({ exp });
     });
+    // }, 5000);
 
     return store;
   } catch (err) {

--- a/support-frontend/assets/helpers/page/page.js
+++ b/support-frontend/assets/helpers/page/page.js
@@ -151,16 +151,11 @@ function init<S, A>(
       combineReducers({ page: pageReducer ? pageReducer(initialState) : null, common: commonReducer }),
       storeEnhancer(thunk),
     );
-    // setTimeout(() => {
-    console.log('page js Exp', store.getState().common.optimizeExperiments);
+
     addOptimizeExperiments((exp: OptimizeExperiment) => {
       trackNewOptimizeExperiment(exp, participations);
-      // const expTest = { id: 'ZVlxqx3wRDGSDw-HYZLiAQ', variant: '1' };
-
       store.dispatch(setExperimentVariant(exp));
-      // console.log({ exp });
     });
-    // }, 5000);
 
     return store;
   } catch (err) {

--- a/support-frontend/assets/pages/digital-subscription-landing/components/theMoment.scss
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/theMoment.scss
@@ -273,6 +273,6 @@
 
   @include mq($from: tablet) {
     font-size: 24px;
-    line-height: 21px;
+    line-height: 28px;
   }
 }

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -90,43 +90,41 @@ type Props = {
 
 type State = {
   showPage: boolean,
-  numOfChecks: number,
+  pageReadyChecks: number,
 }
 
 // ----- Render ----- //
 class LandingPage extends Component<Props, State> {
   state = {
     showPage: this.props.optimizeHasLoaded,
-    numOfChecks: 0,
+    pageReadyChecks: 0,
   }
 
-  wait = () => {
-    const { numOfChecks } = this.state;
+  checkOptimizeIsReady = (interval: number, maxNumberOfChecks: number) => {
+    const { pageReadyChecks } = this.state;
     const { optimizeHasLoaded } = this.props;
 
-    if (optimizeHasLoaded || numOfChecks > 16) {
+    if (optimizeHasLoaded || pageReadyChecks > maxNumberOfChecks) {
       this.setState(() => ({
         showPage: true,
       }));
     } else {
       this.setState(prevState => ({
-        numOfChecks: prevState.numOfChecks + 1,
+        pageReadyChecks: prevState.pageReadyChecks + 1,
       }));
 
       setTimeout(() => {
-        this.wait();
-      }, 250);
+        this.checkOptimizeIsReady(250, 16);
+      }, interval);
     }
-    console.log('numOfChecks:', numOfChecks);
-    console.log('optimizeHasLoaded', optimizeHasLoaded);
   }
 
   render() {
     const { dailyEditionsVariant } = this.props;
-    const { numOfChecks, showPage } = this.state;
+    const { pageReadyChecks, showPage } = this.state;
 
-    if (numOfChecks === 0 && showPage === false) {
-      this.wait();
+    if (pageReadyChecks === 0 && showPage === false) {
+      this.checkOptimizeIsReady(250, 16);
     }
 
     return (

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -4,19 +4,9 @@
 
 import { renderPage } from 'helpers/render';
 import React from 'react';
-import { Provider } from 'react-redux';
-
-import {
-  AUDCountries,
-  Canada,
-  type CountryGroupId,
-  detect,
-  EURCountries,
-  GBPCountries,
-  International,
-  NZDCountries,
-  UnitedStates,
-} from 'helpers/internationalisation/countryGroup';
+import { Provider, connect } from 'react-redux';
+import { detect, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { GBPCountries, AUDCountries, Canada, EURCountries, International, NZDCountries, UnitedStates } from 'helpers/internationalisation/countryGroup';
 import { init as pageInit } from 'helpers/page/page';
 
 import Page from 'components/page/page';
@@ -81,56 +71,70 @@ const CountrySwitcherHeader = headerWithCountrySwitcherContainer({
   ],
 });
 
-const { optimizeExperiments } = store.getState().common;
+const mapStateToProps = (state) => {
+  const { optimizeExperiments } = state.common;
+  const dailyEditionsExperimentId = 'ZVlxqx3wRDGSDw-HYZLiAQ';
+  const dailyEditionsVariant2 = optimizeExperiments
+    .filter(exp => exp.id === dailyEditionsExperimentId && exp.variant === '1').length !== 0;
 
-const dailyEditionsExperimentId = 'zFSCLqNKT4yQKFNEraigAQ';
-const dailyEditionsVariant = optimizeExperiments
-  .filter(exp => exp.id === dailyEditionsExperimentId && exp.variant === '1').length !== 0;
+  return {
+    dailyEditionsVariant: dailyEditionsVariant2 != null ? dailyEditionsVariant2 : false,
+  };
+};
+
+type Props = {
+  dailyEditionsVariant: boolean,
+}
 
 // ----- Render ----- //
+const LandingPage = (props: Props) => (
+  <Page
+    header={<CountrySwitcherHeader />}
+    footer={
+      <Footer>
+        <CustomerService selectedCountryGroup={countryGroupId} />
+        <SubscriptionFaq subscriptionProduct="DigitalPack" />
+      </Footer>}
+  >
+    {console.log(store.getState().common.optimizeExperiments)}
+    <CampaignHeader
+      countryGroupId={countryGroupId}
+      dailyEditionsVariant={props.dailyEditionsVariant}
+    />
+    {props.dailyEditionsVariant ?
+      (
+        <div>
+          <ProductBlockB />
+          <AdFreeSectionB />
+        </div>
+      ) : (
+        <div>
+          <ProductBlock countryGroupId={countryGroupId} />
+          <AdFreeSection headingSize={2} />
+
+          <Content appearance="feature" id="subscribe">
+            <Text title="Subscribe to Digital Pack today">
+              <p>Choose how you’d like to pay</p>
+            </Text>
+            <Form />
+            <ProductPageInfoChip >
+                You can cancel your subscription at any time
+            </ProductPageInfoChip>
+          </Content>
+        </div>
+      )
+    }
+    <IndependentJournalismSection />
+    <PromotionPopUp />
+    <ConsentBanner />
+  </Page>
+);
+
+const ConnectedLandingPage = connect(mapStateToProps)(LandingPage);
 
 const content = (
   <Provider store={store}>
-    <Page
-      header={<CountrySwitcherHeader />}
-      footer={
-        <Footer>
-          <CustomerService selectedCountryGroup={countryGroupId} />
-          <SubscriptionFaq subscriptionProduct="DigitalPack" />
-        </Footer>}
-    >
-
-      <CampaignHeader
-        countryGroupId={countryGroupId}
-        dailyEditionsVariant={dailyEditionsVariant}
-      />
-      {dailyEditionsVariant ?
-        (
-          <div>
-            <ProductBlockB />
-            <AdFreeSectionB />
-          </div>
-        ) : (
-          <div>
-            <ProductBlock countryGroupId={countryGroupId} />
-            <AdFreeSection headingSize={2} />
-
-            <Content appearance="feature" id="subscribe">
-              <Text title="Subscribe to Digital Pack today">
-                <p>Choose how you’d like to pay</p>
-              </Text>
-              <Form />
-              <ProductPageInfoChip >
-                  You can cancel your subscription at any time
-              </ProductPageInfoChip>
-            </Content>
-          </div>
-        )
-      }
-      <IndependentJournalismSection />
-      <PromotionPopUp />
-      <ConsentBanner />
-    </Page>
+    <ConnectedLandingPage />
   </Provider>
 );
 

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -8,6 +8,7 @@ import { Provider, connect } from 'react-redux';
 import { detect, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { GBPCountries, AUDCountries, Canada, EURCountries, International, NZDCountries, UnitedStates } from 'helpers/internationalisation/countryGroup';
 import { init as pageInit } from 'helpers/page/page';
+import { OPTIMIZE_CHECK_TIMEOUT } from 'helpers/optimize/optimize';
 
 import Page from 'components/page/page';
 import headerWithCountrySwitcherContainer
@@ -74,11 +75,11 @@ const CountrySwitcherHeader = headerWithCountrySwitcherContainer({
 const mapStateToProps = (state) => {
   const { optimizeExperiments } = state.common;
   const dailyEditionsExperimentId = 'ZVlxqx3wRDGSDw-HYZLiAQ';
-  const dailyEditionsVariant2 = optimizeExperiments
+  const dailyEditionsVariant = optimizeExperiments
     .filter(exp => exp.id === dailyEditionsExperimentId && exp.variant === '1').length !== 0;
 
   return {
-    dailyEditionsVariant: dailyEditionsVariant2 != null ? dailyEditionsVariant2 : false,
+    dailyEditionsVariant,
     optimizeHasLoaded: optimizeExperiments.length > 0,
   };
 };
@@ -100,7 +101,8 @@ class LandingPage extends Component<Props, State> {
     pageReadyChecks: 0,
   }
 
-  checkOptimizeIsReady = (interval: number, maxNumberOfChecks: number) => {
+  checkOptimizeIsReady = (interval: number) => {
+    const maxNumberOfChecks = OPTIMIZE_CHECK_TIMEOUT / interval;
     const { pageReadyChecks } = this.state;
     const { optimizeHasLoaded } = this.props;
 
@@ -114,7 +116,7 @@ class LandingPage extends Component<Props, State> {
       }));
 
       setTimeout(() => {
-        this.checkOptimizeIsReady(250, 16);
+        this.checkOptimizeIsReady(250);
       }, interval);
     }
   }
@@ -124,7 +126,7 @@ class LandingPage extends Component<Props, State> {
     const { pageReadyChecks, showPage } = this.state;
 
     if (pageReadyChecks === 0 && showPage === false) {
-      this.checkOptimizeIsReady(250, 16);
+      this.checkOptimizeIsReady(250);
     }
 
     return (

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -74,7 +74,7 @@ const CountrySwitcherHeader = headerWithCountrySwitcherContainer({
 
 const mapStateToProps = (state) => {
   const { optimizeExperiments } = state.common;
-  const dailyEditionsExperimentId = 'ZVlxqx3wRDGSDw-HYZLiAQ';
+  const dailyEditionsExperimentId = 'og2J7w-HQ4aFyiY9HwpAdg';
   const dailyEditionsVariant = optimizeExperiments
     .filter(exp => exp.id === dailyEditionsExperimentId && exp.variant === '1').length !== 0;
 
@@ -116,7 +116,7 @@ class LandingPage extends Component<Props, State> {
       }));
 
       setTimeout(() => {
-        this.checkOptimizeIsReady(250);
+        this.checkOptimizeIsReady(interval);
       }, interval);
     }
   }
@@ -124,9 +124,9 @@ class LandingPage extends Component<Props, State> {
   render() {
     const { dailyEditionsVariant } = this.props;
     const { pageReadyChecks, showPage } = this.state;
-
+    const interval = 250;
     if (pageReadyChecks === 0 && showPage === false) {
-      this.checkOptimizeIsReady(250);
+      this.checkOptimizeIsReady(interval);
     }
 
     return (

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -117,6 +117,8 @@ class LandingPage extends Component<Props, State> {
         this.wait();
       }, 250);
     }
+    console.log('numOfChecks:', numOfChecks);
+    console.log('optimizeHasLoaded', optimizeHasLoaded);
   }
 
   render() {

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -126,6 +126,7 @@
     "rimraf": "^2.6.2",
     "sass-loader": "^7.1.0",
     "sass-mq": "^5.0.0",
+    "uglifyjs-webpack-plugin": "^2.1.3",
     "webpack": "^4.16.2",
     "webpack-cli": "^3.1.0",
     "webpack-dev-server": "3.1.11",


### PR DESCRIPTION
After launching the digital pack landing page (which was an A/B test between the first and second screenshot), we noticed that sometimes people would be shown the original page, while being identified to Optimize (the A/B testing platform) as being part of the Variant sample, this meant the results for the test are invalid as we could not be sure which view the user was seeing 

## Why are you doing this?

[**Trello Card**](https://trello.com)

## Changes

- add mapState to digital pack landing page, to allow the page to re-render when there is a change to the redux store
- change LandingPage component to a class Component, in order to as state to facilitate a re-render
- added an anti flicker function to control when the page is shown
- removed a call to optimize.js, so optimize.js it only called once 
- add polling to optimize.js to determine when the Google dataLayer has loaded

**Original**
![Screen Shot 2019-06-10 at 16 32 06](https://user-images.githubusercontent.com/45875444/60596966-f6f41e80-9da1-11e9-9eb2-e63da3012321.png)

**New Variant**
![Screen Shot 2019-06-26 at 17 26 56](https://user-images.githubusercontent.com/45875444/60597333-a7fab900-9da2-11e9-8f76-e9464890453e.png)


