### PR TITLE
Disable Toxic America

### DIFF
--- a/support-frontend/assets/helpers/campaigns.jsx
+++ b/support-frontend/assets/helpers/campaigns.jsx
@@ -115,7 +115,7 @@ export const campaigns: Campaigns = {
     goalReachedCopy: null,
     tickerJsonUrl: '/ticker.json',
     tickerType: 'unlimited',
-    cssModifiers: ['campaign-landing', currentCampaignName],
+    cssModifiers: ['campaign-landing', ''],
     contributionTypes: generateContributionTypes([
       { contributionType: 'ONE_OFF', isDefault: true },
     ]),
@@ -127,5 +127,8 @@ export const campaigns: Campaigns = {
 export type CampaignName = $Keys<typeof campaigns>
 
 export function getCampaignName(): ?CampaignName {
-  return window.location.pathname.endsWith(`/${currentCampaignName}`) ? currentCampaignName : undefined;
+  if (currentCampaignName) {
+    return window.location.pathname.endsWith(`/${currentCampaignName}`) ? currentCampaignName : undefined;
+  }
+  return undefined;
 }

--- a/support-frontend/assets/helpers/campaigns.jsx
+++ b/support-frontend/assets/helpers/campaigns.jsx
@@ -115,7 +115,7 @@ export const campaigns: Campaigns = {
     goalReachedCopy: null,
     tickerJsonUrl: '/ticker.json',
     tickerType: 'unlimited',
-    cssModifiers: ['campaign-landing', ''],
+    cssModifiers: ['campaign-landing'],
     contributionTypes: generateContributionTypes([
       { contributionType: 'ONE_OFF', isDefault: true },
     ]),

--- a/support-frontend/assets/helpers/campaigns.jsx
+++ b/support-frontend/assets/helpers/campaigns.jsx
@@ -24,7 +24,7 @@ export type Campaigns = {
   [string]: CampaignSettings,
 };
 
-const currentCampaignName = 'toxicamerica';
+const currentCampaignName = null;
 
 export const campaigns: Campaigns = {
   toxicamerica: {


### PR DESCRIPTION
## Why are you doing this?
Toxic America is no longer running. When launching this campaign, we simplified the routing such that the name for a campaign can just be removed from the code base to end a campaign.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/uWCnyMVS/1194-toxic-america-shut-down-to-do-list)

## Changes

* Remove the campaign name
