### PR TITLE
Add alerts for DigiPack and Paper checkout flows

### DIFF
--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -286,3 +286,138 @@ Resources:
       Statistic: Sum
       TreatMissingData: breaching
     DependsOn: SupportWorkersPROD
+
+
+  # This alarm is for the PaymentSuccess metric where
+  # ProductType == DigitalPack AND PaymentProvider in [Stripe, Gocardless, Paypal]
+  #
+  # The general idea here is
+  # a) Have a calculated metric which is a sum of all the payment method metrics for digipack [1]
+  # b) Use a fill rather than the metric directly, so we get zeros for every period instead of missing data
+  #
+  # [1] PaymentProvider is set as a dimension in the PaymentSuccess metric, but the way
+  #     cloudwatch handles that is to create a new metric for every value dimension value
+
+
+  NoDigipackAcquisitionInEightHoursAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: CreateProdResources
+    Properties:
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
+      AlarmName: !Sub URGENT 9-5 - ${Stage} support-workers No successful digipack checkouts in 8h
+      Metrics:
+        - Id: e1
+          Expression: "SUM([FILL(m1,0),FILL(m2,0),FILL(m3,0)])"
+          Label: AllDigiPackConversions
+        - Id: m1
+          Label: String
+          MetricStat:
+            Metric:
+              Dimensions:
+                - Name: PaymentProvider
+                  Value: Stripe
+                - Name: ProductType
+                  Value: DigitalPack
+                - Name: Stage
+                  Value: !Ref Stage
+              MetricName: PaymentSuccess
+              Namespace: support-frontend
+            Period: 300
+            Stat: Sum
+            Unit: Count
+          ReturnData: false
+        - Id: m2
+          Label: String
+          MetricStat:
+            Metric:
+              Dimensions:
+                - Name: PaymentProvider
+                  Value: Gocardless
+                - Name: ProductType
+                  Value: DigitalPack
+                - Name: Stage
+                  Value: !Ref Stage
+              MetricName: PaymentSuccess
+              Namespace: support-frontend
+            Period: 300
+            Stat: Sum
+            Unit: Count
+          ReturnData: false
+        - Id: m3
+          Label: String
+          MetricStat:
+            Metric:
+              Dimensions:
+                - Name: PaymentProvider
+                  Value: Paypal
+                - Name: ProductType
+                  Value: DigitalPack
+                - Name: Stage
+                  Value: !Ref Stage
+              MetricName: PaymentSuccess
+              Namespace: support-frontend
+            Period: 300
+            Stat: Sum
+            Unit: Count
+          ReturnData: false
+      ComparisonOperator: LessThanOrEqualToThreshold
+      Threshold: 0
+      EvaluationPeriods: 96
+      TreatMissingData: breaching
+    DependsOn: SupportWorkersPROD
+
+
+  # This alarm is for the PaymentSuccess metric where
+  # ProductType == Paper AND PaymentProvider in [Stripe, Gocardless]
+
+  NoPaperAcquisitionInOneDayAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: CreateProdResources
+    Properties:
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
+      AlarmName: !Sub URGENT 9-5 - ${Stage} support-workers No successful paper checkouts in 24h
+      Metrics:
+        - Id: e1
+          Expression: "SUM([FILL(m1,0),FILL(m2,0)])"
+          Label: AllPaperConversions
+        - Id: m1
+          Label: String
+          MetricStat:
+            Metric:
+              Dimensions:
+                - Name: PaymentProvider
+                  Value: Stripe
+                - Name: ProductType
+                  Value: Paper
+                - Name: Stage
+                  Value: !Ref Stage
+              MetricName: PaymentSuccess
+              Namespace: support-frontend
+            Period: 300
+            Stat: Sum
+            Unit: Count
+          ReturnData: false
+        - Id: m2
+          Label: String
+          MetricStat:
+            Metric:
+              Dimensions:
+                - Name: PaymentProvider
+                  Value: Gocardless
+                - Name: ProductType
+                  Value: Paper
+                - Name: Stage
+                  Value: !Ref Stage
+              MetricName: PaymentSuccess
+              Namespace: support-frontend
+            Period: 300
+            Stat: Sum
+            Unit: Count
+          ReturnData: false
+      ComparisonOperator: LessThanOrEqualToThreshold
+      Threshold: 0
+      EvaluationPeriods: 288
+      TreatMissingData: breaching
+    DependsOn: SupportWorkersPROD


### PR DESCRIPTION
## Why are you doing this?

We've recently had an outage where paper checkout was down for 11am one day to 17h the next day. We've been wanting to add a cloud watch alarm that goes off when acquisition flatlines for a while now, but after that outage this was bumped in priority.

[**Trello Card**](https://trello.com/c/5vAIlA4j/2419-add-alarms-for-no-conversions-within-x-hours-days-to-all-variants)

## Changes

* Adds two alarms NoPaperAcquisitionInOneDayAlarm and NoDigipackAcquisitionInEightHoursAlarm. So that's 24h and 8h for paper and digipack respectively.
* The general idea is to use a calculate metric that sums all the individual payment type metrics. This allows us to have a global alert, on all acquisition, rather than independent alerts per payment type. The implementation is slightly obscure, if anyone knows of a clearer way to define them I'd be happy to refactor
* The emails have subjects
  *  ` URGENT 9-5 - ${Stage} support-workers No successful digipack checkouts in 8h`
  * `URGENT 9-5 - ${Stage} support-workers No successful paper checkouts in 24h`

