### PR TITLE
Weekly landing page

### DIFF
--- a/support-frontend/app/controllers/WeeklySubscription.scala
+++ b/support-frontend/app/controllers/WeeklySubscription.scala
@@ -43,9 +43,7 @@ class WeeklySubscription(
   implicit val a: AssetsResolver = assets
 
 
-  //TODO: remove Google Auth from this endpoint before we go live
-  def displayForm(): Action[AnyContent] =
-    (PrivateAction andThen authAction andThen authenticatedAction(subscriptionsClientId)).async { implicit request =>
+  def displayForm(): Action[AnyContent] = authenticatedAction(subscriptionsClientId).async { implicit request =>
       implicit val settings: AllSettings = settingsProvider.getAllSettings()
       identityService.getUser(request.user).fold(
         error => {

--- a/support-frontend/assets/helpers/globals.js
+++ b/support-frontend/assets/helpers/globals.js
@@ -44,7 +44,7 @@ const getSettings = (): Settings => getGlobal('settings') || {
     NZDCountries: [],
     Canada: [],
   },
-  metricUrl: "",
+  metricUrl: '',
 };
 
 const getProductPrices = (): ?ProductPrices => getGlobal('productPrices');

--- a/support-frontend/assets/helpers/render.js
+++ b/support-frontend/assets/helpers/render.js
@@ -20,7 +20,7 @@ const getElementOrBody = (id: ?string): HTMLElement => {
 };
 
 const renderError = (e: Error, id: ?string) => {
-  fetch(window.guardian.settings.metricUrl, {'mode': 'no-cors'}); // ignore result, fire and forget
+  fetch(window.guardian.settings.metricUrl, { mode: 'no-cors' }); // ignore result, fire and forget
 
   const element = getElementOrBody(id);
 
@@ -48,7 +48,7 @@ const renderPage = (content: Object, id: string, callBack?: () => void) => {
       renderError(e, id);
     }
   } else {
-    fetch(window.guardian.settings.metricUrl, {'mode': 'no-cors'}); // ignore result, fire and forget
+    fetch(window.guardian.settings.metricUrl, { mode: 'no-cors' }); // ignore result, fire and forget
     logException(`Fatal error trying to render a page. id:${id}`);
   }
 };

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.js
@@ -117,10 +117,9 @@ const getOptions = (
     ...(productOptions !== NoProductOptions ? { productOptions } : {}),
   });
 
-const getPromoCode = (billingPeriod: BillingPeriod, promotions: ?Promotion[]) =>
-{
+const getPromoCode = (billingPeriod: BillingPeriod, promotions: ?Promotion[]) => {
   const promotion = getAppliedPromo(promotions);
-  if(!promotion || (promotion.introductoryPrice && billingPeriod === Quarterly)) {
+  if (!promotion || (promotion.introductoryPrice && billingPeriod === Quarterly)) {
     return null;
   }
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
@@ -7,16 +7,22 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { type ContributionType, getSpokenType } from 'helpers/contributions';
 import MarketingConsent from '../MarketingConsentContainer';
-import { type Action, setHasSeenDirectDebitThankYouCopy } from '../../contributionsLandingActions';
+import {
+  type Action,
+  setHasSeenDirectDebitThankYouCopy,
+} from '../../contributionsLandingActions';
 import type { PaymentMethod } from 'helpers/paymentMethods';
+import { DirectDebit } from 'helpers/paymentMethods';
 import { ContributionThankYouBlurb } from './ContributionThankYouBlurb';
 import AnchorButton from 'components/button/anchorButton';
 import SvgArrowLeft from 'components/svgs/arrowLeftStraight';
-import { DirectDebit } from 'helpers/paymentMethods';
 import SpreadTheWord from 'components/spreadTheWord/spreadTheWord';
 import ContributionSurvey from '../ContributionSurvey/ContributionsSurvey';
 import { routes } from 'helpers/routes';
-import { trackComponentClick, trackComponentLoad } from 'helpers/tracking/ophan';
+import {
+  trackComponentClick,
+  trackComponentLoad,
+} from 'helpers/tracking/ophan';
 import TrackableButton from 'components/button/trackableButton';
 
 // ----- Types ----- //
@@ -64,9 +70,9 @@ const createSignInLink = (email: string, csrf: string, contributionType: Contrib
     .then((response) => {
       if (response.ok) {
         return response.json();
-      } else {
-        throw new Error('Identity encryption service error');
       }
+      throw new Error('Identity encryption service error');
+
     })
     .then((data) => {
       if (data && data.signInLink) {

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -6,12 +6,22 @@ import { renderPage } from 'helpers/render';
 import React from 'react';
 import { Provider } from 'react-redux';
 
-import { detect, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import { GBPCountries, AUDCountries, Canada, EURCountries, International, NZDCountries, UnitedStates } from 'helpers/internationalisation/countryGroup';
+import {
+  AUDCountries,
+  Canada,
+  type CountryGroupId,
+  detect,
+  EURCountries,
+  GBPCountries,
+  International,
+  NZDCountries,
+  UnitedStates,
+} from 'helpers/internationalisation/countryGroup';
 import { init as pageInit } from 'helpers/page/page';
 
 import Page from 'components/page/page';
-import headerWithCountrySwitcherContainer from 'components/headers/header/headerWithCountrySwitcher';
+import headerWithCountrySwitcherContainer
+  from 'components/headers/header/headerWithCountrySwitcher';
 import CustomerService from 'components/customerService/customerService';
 import SubscriptionFaq from 'components/subscriptionFaq/subscriptionFaq';
 import Footer from 'components/footer/footer';
@@ -19,12 +29,13 @@ import AdFreeSection from 'components/adFreeSection/adFreeSection';
 import AdFreeSectionB from 'components/adFreeSectionB/adFreeSectionB';
 import Content from 'components/content/content';
 import Text from 'components/text/text';
-import ProductPageInfoChip from 'components/productPage/productPageInfoChip/productPageInfoChip';
+import ProductPageInfoChip
+  from 'components/productPage/productPageInfoChip/productPageInfoChip';
 import 'stylesheets/skeleton/skeleton.scss';
 
-
 import { CampaignHeader } from './components/digitalSubscriptionLandingHeader';
-import IndependentJournalismSection from './components/independentJournalismSection';
+import IndependentJournalismSection
+  from './components/independentJournalismSection';
 import ProductBlock from './components/productBlock';
 import ProductBlockB from './components/productBlockB/productBlockB';
 import PromotionPopUp from './components/promotionPopUp';
@@ -33,7 +44,8 @@ import Form from './components/form';
 import './digitalSubscriptionLanding.scss';
 import './components/theMoment.scss';
 import ConsentBanner from 'components/consentBanner/consentBanner';
-import digitalSubscriptionLandingReducer from './digitalSubscriptionLandingReducer';
+import digitalSubscriptionLandingReducer
+  from './digitalSubscriptionLandingReducer';
 
 // ----- Redux Store ----- //
 
@@ -88,9 +100,9 @@ const content = (
         </Footer>}
     >
 
-      <CampaignHeader 
-        countryGroupId={countryGroupId} 
-        dailyEditionsVariant={dailyEditionsVariant} 
+      <CampaignHeader
+        countryGroupId={countryGroupId}
+        dailyEditionsVariant={dailyEditionsVariant}
       />
       {dailyEditionsVariant ?
         (

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
@@ -24,22 +24,26 @@ import { getOrigin } from 'helpers/url';
 // ---- Plans ----- //
 
 const getCheckoutUrl = ({ billingPeriod, state }: {billingPeriod: WeeklyBillingPeriod, state: CommonState}): string => {
-  const optimizeExperimentId = 'c57s46hkR_iDwL3okpznxg';
+  const optimizeExperimentId = 'buAOTpsxSVucCSSlkwLx6A';
   const {
     internationalisation: { countryGroupId }, referrerAcquisitionData, abParticipations, optimizeExperiments,
   } = state;
 
-  if (state.optimizeExperiments.includes(exp => exp.id === optimizeExperimentId && exp.variant === 1)) {
-    return getWeeklyCheckout(
-      referrerAcquisitionData,
-      billingPeriod,
-      countryGroupId,
-      abParticipations,
-      optimizeExperiments,
-      (billingPeriod === 'Annual' ? getPromoCode('GuardianWeekly', countryGroupId, '10ANNUAL') : null),
-    );
+  const useVariant = state.optimizeExperiments.find(exp => exp.id === optimizeExperimentId && exp.variant === '1');
+
+  if (useVariant) {
+    return `${getOrigin()}/subscribe/weekly/checkout?period=${billingPeriod.toString()}`;
   }
-  return `${getOrigin()}/subscribe/weekly/checkout?billingPeriod=${billingPeriod.toString()}`;
+
+  return getWeeklyCheckout(
+    referrerAcquisitionData,
+    billingPeriod,
+    countryGroupId,
+    abParticipations,
+    optimizeExperiments,
+    (billingPeriod === 'Annual' ? getPromoCode('GuardianWeekly', countryGroupId, '10ANNUAL') : null),
+  );
+
 };
 
 // ----- State/Props Maps ----- //

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
@@ -19,22 +19,27 @@ import {
   getPriceDescription,
 } from 'helpers/productPrice/priceDescriptions';
 import { getWeeklyFulfilmentOption } from 'helpers/productPrice/fulfilmentOptions';
+import { getOrigin } from 'helpers/url';
 
 // ---- Plans ----- //
 
 const getCheckoutUrl = ({ billingPeriod, state }: {billingPeriod: WeeklyBillingPeriod, state: CommonState}): string => {
+  const optimizeExperimentId = "c57s46hkR_iDwL3okpznxg";
   const {
     internationalisation: { countryGroupId }, referrerAcquisitionData, abParticipations, optimizeExperiments,
   } = state;
 
-  return getWeeklyCheckout(
-    referrerAcquisitionData,
-    billingPeriod,
-    countryGroupId,
-    abParticipations,
-    optimizeExperiments,
-    (billingPeriod === 'Annual' ? getPromoCode('GuardianWeekly', countryGroupId, '10ANNUAL') : null),
-  );
+  if(state.optimizeExperiments.includes(exp => exp.id === optimizeExperimentId && exp.variant === 1)){
+    return getWeeklyCheckout(
+      referrerAcquisitionData,
+      billingPeriod,
+      countryGroupId,
+      abParticipations,
+      optimizeExperiments,
+      (billingPeriod === 'Annual' ? getPromoCode('GuardianWeekly', countryGroupId, '10ANNUAL') : null),
+    );
+  }
+  return `${getOrigin()}/subscribe/weekly/checkout?billingPeriod=${billingPeriod.toString()}`;
 };
 
 // ----- State/Props Maps ----- //

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
@@ -24,12 +24,12 @@ import { getOrigin } from 'helpers/url';
 // ---- Plans ----- //
 
 const getCheckoutUrl = ({ billingPeriod, state }: {billingPeriod: WeeklyBillingPeriod, state: CommonState}): string => {
-  const optimizeExperimentId = "c57s46hkR_iDwL3okpznxg";
+  const optimizeExperimentId = 'c57s46hkR_iDwL3okpznxg';
   const {
     internationalisation: { countryGroupId }, referrerAcquisitionData, abParticipations, optimizeExperiments,
   } = state;
 
-  if(state.optimizeExperiments.includes(exp => exp.id === optimizeExperimentId && exp.variant === 1)){
+  if (state.optimizeExperiments.includes(exp => exp.id === optimizeExperimentId && exp.variant === 1)) {
     return getWeeklyCheckout(
       referrerAcquisitionData,
       billingPeriod,

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
@@ -24,7 +24,7 @@ import { getOrigin } from 'helpers/url';
 // ---- Plans ----- //
 
 const getCheckoutUrl = ({ billingPeriod, state }: {billingPeriod: WeeklyBillingPeriod, state: CommonState}): string => {
-  const optimizeExperimentId = 'buAOTpsxSVucCSSlkwLx6A';
+  const optimizeExperimentId = 'bCiv10arQ7OYNMyIyC89MQ';
   const {
     internationalisation: { countryGroupId }, referrerAcquisitionData, abParticipations, optimizeExperiments,
   } = state;

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -6,19 +6,32 @@ import React from 'react';
 import { Provider } from 'react-redux';
 
 import Page from 'components/page/page';
-import headerWithCountrySwitcherContainer from 'components/headers/header/headerWithCountrySwitcher';
+import headerWithCountrySwitcherContainer
+  from 'components/headers/header/headerWithCountrySwitcher';
 import Footer from 'components/footer/footer';
 
-import { detect, countryGroups, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import {
+  AUDCountries,
+  Canada,
+  type CountryGroupId,
+  countryGroups,
+  detect,
+  EURCountries,
+  GBPCountries,
+  International,
+  NZDCountries,
+  UnitedStates,
+} from 'helpers/internationalisation/countryGroup';
 import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
 import Content, { Outset } from 'components/content/content';
 import Text, { LargeParagraph } from 'components/text/text';
-import ProductPageFeatures from 'components/productPage/productPageFeatures/productPageFeatures';
-import ProductPageInfoChip from 'components/productPage/productPageInfoChip/productPageInfoChip';
+import ProductPageFeatures
+  from 'components/productPage/productPageFeatures/productPageFeatures';
+import ProductPageInfoChip
+  from 'components/productPage/productPageInfoChip/productPageInfoChip';
 import SvgInformation from 'components/svgs/information';
 import SvgGift from 'components/svgs/gift';
-import { AUDCountries, Canada, EURCountries, GBPCountries, International, NZDCountries, UnitedStates } from 'helpers/internationalisation/countryGroup';
 import 'stylesheets/skeleton/skeleton.scss';
 
 import { CampaignHeader } from './components/hero/hero';
@@ -103,7 +116,7 @@ const content = (
         </Text>
         <WeeklyForm />
         <ProductPageInfoChip icon={<SvgGift />}>
-              Gifting is available for quarterly and annual subscriptions
+              Gifting is available
         </ProductPageInfoChip>
         <ProductPageInfoChip icon={<SvgInformation />}>
               You can cancel your subscription at any time
@@ -111,7 +124,7 @@ const content = (
       </Content>
       <Content>
         <Text title="Gift subscriptions">
-          <LargeParagraph>A quarterly or annual Guardian Weekly subscription makes a great gift.
+          <LargeParagraph>A Guardian Weekly subscription makes a great gift.
             To&nbsp;buy&nbsp;one, just select the gift option at checkout or get in touch with your local customer
             service team:
           </LargeParagraph>


### PR DESCRIPTION
## Why are you doing this?
To launch GW checkout we need to update the landing page so that it goes to the new checkout. We will then run a test in Optimize to send a proportion of our traffic to the new flow for testing.

## Changes

* Update url generation code to switch between the old an new checkout based on experiment variant
* Update the copy around gifting on the GW landing page
* Remove Google auth from the new checkout page
* There are quite a few small changes which have been made automatically by Eslint


[**Trello Card**](https://trello.com/c/Wjqqlnrp/2436-phased-rollout-gw) & [also]( https://trello.com/c/t9d6wXyW/2428-remove-google-auth-from-gw-checkout-just-before-go-live)

