### PR TITLE
Analytics for Guardian Weekly

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
@@ -59,7 +59,7 @@ const mapStateToProps = (state: State): PropTypes<WeeklyBillingPeriod> => ({
         ),
         offer: getAppliedPromoDescription(billingPeriod, productPrice),
         href: getCheckoutUrl({ billingPeriod, state: state.common }),
-        onClick: sendTrackingEventsOnClick('subscribe_now_cta', 'GuardianWeekly', null, billingPeriod),
+        onClick: sendTrackingEventsOnClick(`subscribe_now_cta-${billingPeriod}`, 'GuardianWeekly', null),
         price: null,
         saving: null,
       },

--- a/support-models/build.sbt
+++ b/support-models/build.sbt
@@ -5,7 +5,7 @@ name := "support-models"
 description := "Scala library to provide shared step-function models to Guardian Support projects."
 
 libraryDependencies ++= Seq(
-  "com.gu" %% "acquisition-event-producer-play26" % "4.0.20",
+  "com.gu" %% "acquisition-event-producer-play26" % "4.0.21",
   "org.typelevel" %% "cats-core" % catsVersion,
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,

--- a/support-models/src/main/scala/com/gu/support/workers/states/SendAcquisitionEventState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/SendAcquisitionEventState.scala
@@ -1,11 +1,14 @@
 package com.gu.support.workers.states
 
+import com.gu.support.promotions.PromoCode
 import com.gu.support.workers.{PaymentMethod, User, _}
 
 case class SendAcquisitionEventState(
   user: User,
+  giftRecipient: Option[GiftRecipient],
   product: ProductType,
   paymentMethod: PaymentMethod,
+  promoCode: Option[PromoCode],
   acquisitionData: Option[AcquisitionData]
 ) extends StepFunctionUserState
 


### PR DESCRIPTION
## Why are you doing this?
Some additional tracking for Guardian Weekly acquisitions:
* Add a label to record whether a subscription is 6 for 6 - this reproduces existing functionality
* Add a label to record whether a subscription is a gift this is represented as a custom dimension in GA and a label in the Data Lake.
* Update the acquisitions-event-producer library to work with these new labels
* Change the click tracking on the GW landing page CTAs to include the billing period in the id, otherwise this information never makes it into the Data Lake.

[**Trello Card**](https://trello.com/c/Q33ZsM7n/2390-analytics)

