### PR TITLE
Add giftee name fields to the emails

### DIFF
--- a/support-workers/src/main/scala/com/gu/emailservices/GuardianWeeklyEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/GuardianWeeklyEmailFields.scala
@@ -5,7 +5,7 @@ import com.gu.i18n.Currency
 import com.gu.salesforce.Salesforce.SfContactId
 import com.gu.support.catalog.FulfilmentOptions
 import com.gu.support.promotions.Promotion
-import com.gu.support.workers.{BillingPeriod, PaymentMethod, PaymentSchedule, User}
+import com.gu.support.workers._
 import org.joda.time.LocalDate
 
 case class GuardianWeeklyEmailFields(
@@ -19,7 +19,8 @@ case class GuardianWeeklyEmailFields(
   paymentMethod: PaymentMethod,
   sfContactId: SfContactId,
   directDebitMandateId: Option[String] = None,
-  promotion: Option[Promotion] = None
+  promotion: Option[Promotion] = None,
+  giftRecipient: Option[GiftRecipient] = None
 ) extends EmailFields {
 
   val additionalFields = List(
@@ -27,7 +28,7 @@ case class GuardianWeeklyEmailFields(
   )
 
   override val fields = PaperFieldsGenerator.fieldsFor(
-    subscriptionNumber, billingPeriod, user, paymentSchedule, firstDeliveryDate, currency, paymentMethod, sfContactId, directDebitMandateId, promotion
+    subscriptionNumber, billingPeriod, user, paymentSchedule, firstDeliveryDate, currency, paymentMethod, sfContactId, directDebitMandateId, promotion, giftRecipient
   ) ++ additionalFields.flatten
 
   override def payload: String = super.payload(user.primaryEmailAddress, "guardian-weekly")

--- a/support-workers/src/main/scala/com/gu/emailservices/PaperEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/PaperEmailFields.scala
@@ -19,7 +19,8 @@ case class PaperEmailFields(
   paymentMethod: PaymentMethod,
   sfContactId: SfContactId,
   directDebitMandateId: Option[String] = None,
-  promotion: Option[Promotion] = None
+  promotion: Option[Promotion] = None,
+  giftRecipient: Option[GiftRecipient] = None
 ) extends EmailFields {
 
   val additionalFields = List("package" -> productOptions.toString)
@@ -30,7 +31,7 @@ case class PaperEmailFields(
   }
 
   override val fields = PaperFieldsGenerator.fieldsFor(
-    subscriptionNumber, billingPeriod, user, paymentSchedule, firstDeliveryDate, currency, paymentMethod, sfContactId, directDebitMandateId, promotion
+    subscriptionNumber, billingPeriod, user, paymentSchedule, firstDeliveryDate, currency, paymentMethod, sfContactId, directDebitMandateId, promotion, giftRecipient
   ) ++ additionalFields
 
   override def payload: String = super.payload(user.primaryEmailAddress, dataExtension)

--- a/support-workers/src/main/scala/com/gu/emailservices/PaperFieldsGenerator.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/PaperFieldsGenerator.scala
@@ -19,7 +19,8 @@ object PaperFieldsGenerator {
     paymentMethod: PaymentMethod,
     sfContactId: SfContactId,
     directDebitMandateId: Option[String],
-    promotion: Option[Promotion]
+    promotion: Option[Promotion],
+    giftRecipient: Option[GiftRecipient]
   ): List[(String, String)] = {
 
     val firstPaymentDate = SubscriptionEmailFieldHelpers.firstPayment(paymentSchedule).date
@@ -27,6 +28,14 @@ object PaperFieldsGenerator {
     val paymentFields = getPaymentFields(paymentMethod, directDebitMandateId)
 
     val deliveryAddressFields = getAddressFields(user)
+
+    val giftRecipientFields = giftRecipient.map(
+      recipient =>
+        List(
+          "giftee_first_name" -> recipient.firstName,
+          "giftee_last_name" -> recipient.lastName,
+        )
+    ).getOrElse(Nil)
 
     val fields = List(
       "ZuoraSubscriberId" -> subscriptionNumber,
@@ -38,7 +47,7 @@ object PaperFieldsGenerator {
       "date_of_first_paper" -> SubscriptionEmailFieldHelpers.formatDate(firstDeliveryDate.getOrElse(firstPaymentDate)),
       "date_of_first_payment" -> SubscriptionEmailFieldHelpers.formatDate(firstPaymentDate),
       "subscription_rate" -> SubscriptionEmailFieldHelpers.describe(paymentSchedule, billingPeriod, currency, promotion)
-    ) ++ paymentFields ++ deliveryAddressFields
+    ) ++ paymentFields ++ deliveryAddressFields ++ giftRecipientFields
 
     fields
   }

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
@@ -87,7 +87,8 @@ class SendThankYouEmail(thankYouEmailService: EmailService, servicesProvider: Se
           paymentMethod = state.paymentMethod,
           sfContactId = SfContactId(state.salesForceContact.Id),
           directDebitMandateId = directDebitMandateId,
-          promotion = maybePromotion
+          promotion = maybePromotion,
+          state.giftRecipient
         )
         case g: GuardianWeekly =>
           GuardianWeeklyEmailFields(
@@ -101,7 +102,8 @@ class SendThankYouEmail(thankYouEmailService: EmailService, servicesProvider: Se
             paymentMethod = state.paymentMethod,
             sfContactId = SfContactId(state.salesForceContact.Id),
             directDebitMandateId = directDebitMandateId,
-            promotion = maybePromotion
+            promotion = maybePromotion,
+            state.giftRecipient
           )
       }
     )


### PR DESCRIPTION
## Why are you doing this?
For subscriptions that have been bought as gifts we want to reflect that fact in the thank you email. To do this we need to send the giftee's first and last name to membership workflow which actually sends the email
