### PR TITLE
Prefill the US/CA state code in the Contributions checkout form

### DIFF
--- a/support-frontend/app/actions/CustomActionBuilders.scala
+++ b/support-frontend/app/actions/CustomActionBuilders.scala
@@ -8,7 +8,7 @@ import play.api.mvc.Security.AuthenticatedRequest
 import play.api.mvc._
 import play.filters.csrf._
 import services.AsyncAuthenticationService
-import utils.RequestCountry
+import utils.FastlyGEOIP
 
 import scala.concurrent.ExecutionContext
 
@@ -86,7 +86,7 @@ class CustomActionBuilders(
   val GeoTargetedCachedAction = new CachedAction(
     cc.parsers.defaultBodyParser,
     cc.executionContext,
-    List("Vary" -> RequestCountry.fastlyCountryHeader)
+    List("Vary" -> FastlyGEOIP.fastlyCountryHeader)
   )
 
 }

--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -116,7 +116,7 @@ class Application(
     ).map(_.withSettingsSurrogateKey)
   }
 
-  private def contributionsHtml(countryCode: String, stateCode: Option[String], idUser: Option[IdUser], campaignCode: Option[String])
+  private def contributionsHtml(countryCode: String, stateCode: Option[String], idUser: Option[IdUser], campaignCode: Option[String], guestAccountCreationToken: Option[String])
                                (implicit request: RequestHeader, settings: AllSettings) = {
 
     val elementForStage = CSSElementForStage(assets.getFileContentsAsHtml, stage) _
@@ -152,8 +152,8 @@ class Application(
       existingPaymentOptionsEndpoint = membersDataService.existingPaymentOptionsEndpoint,
       idUser = idUser,
       guestAccountCreationToken = guestAccountCreationToken,
-      countryCode,
-      stateCode
+      countryCode = countryCode,
+      stateCode = stateCode
     )
   }
 

--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -116,7 +116,8 @@ class Application(
     ).map(_.withSettingsSurrogateKey)
   }
 
-  private def contributionsHtml(countryCode: String, stateCode: Option[String], idUser: Option[IdUser], campaignCode: Option[String], guestAccountCreationToken: Option[String])
+  private def contributionsHtml(countryCode: String, stateCode: Option[String], idUser: Option[IdUser],
+                                campaignCode: Option[String], guestAccountCreationToken: Option[String])
                                (implicit request: RequestHeader, settings: AllSettings) = {
 
     val elementForStage = CSSElementForStage(assets.getFileContentsAsHtml, stage) _
@@ -139,7 +140,6 @@ class Application(
       mainElement = mainElement,
       js = js,
       css = css,
-      fontLoaderBundle = fontLoaderBundle,
       description = stringsConfig.contributionsLandingDescription,
       oneOffDefaultStripeConfig = oneOffStripeConfigProvider.get(false),
       oneOffUatStripeConfig = oneOffStripeConfigProvider.get(true),
@@ -152,6 +152,7 @@ class Application(
       existingPaymentOptionsEndpoint = membersDataService.existingPaymentOptionsEndpoint,
       idUser = idUser,
       guestAccountCreationToken = guestAccountCreationToken,
+      fontLoaderBundle = fontLoaderBundle,
       countryCode = countryCode,
       stateCode = stateCode
     )

--- a/support-frontend/app/controllers/GeoRedirect.scala
+++ b/support-frontend/app/controllers/GeoRedirect.scala
@@ -1,7 +1,6 @@
 package controllers
 
 import actions.CustomActionBuilders
-import com.gu.i18n.CountryGroup._
 import lib.RedirectWithEncodedQueryString
 import play.api.mvc.{AbstractController, Action, AnyContent}
 import utils.FastlyGEOIP._
@@ -13,7 +12,7 @@ trait GeoRedirect {
   import actionRefiners._
 
   def geoRedirect(path: String): Action[AnyContent] = GeoTargetedCachedAction() { implicit request =>
-    val redirectUrl = s"/${request.fastlyCountry.map(_.id).getOrElse("int")}/$path"
+    val redirectUrl = s"/${request.geoData.countryGroup.map(_.id).getOrElse("int")}/$path"
     RedirectWithEncodedQueryString(redirectUrl, request.queryString, status = FOUND)
   }
 }

--- a/support-frontend/app/controllers/GeoRedirect.scala
+++ b/support-frontend/app/controllers/GeoRedirect.scala
@@ -4,7 +4,7 @@ import actions.CustomActionBuilders
 import com.gu.i18n.CountryGroup._
 import lib.RedirectWithEncodedQueryString
 import play.api.mvc.{AbstractController, Action, AnyContent}
-import utils.RequestCountry._
+import utils.FastlyGEOIP._
 
 trait GeoRedirect {
   self: AbstractController =>

--- a/support-frontend/app/models/GeoData.scala
+++ b/support-frontend/app/models/GeoData.scala
@@ -5,15 +5,10 @@ import com.gu.i18n.{Country, CountryGroup}
 case class GeoData(countryCode: Option[String], stateCode: Option[String]) {
   def countryGroup: Option[CountryGroup] = countryCode.flatMap(CountryGroup.byFastlyCountryCode)
   def country: Option[Country] = countryCode.flatMap(CountryGroup.countryByCode)
-  def validatedStateNameForCountry: Option[String] = for {
-    c <- country
-    r <- stateCode
-    stateName <- c.statesByCode.get(r) orElse c.statesByCode.values.find(_ == r)
-  } yield stateName
   def validatedStateCodeForCountry: Option[String] = for {
     c <- country
     r <- stateCode
-    stateName <- c.statesByCode.keySet.find(_ == r) orElse c.statesByCode.map(_.swap).get(r)
+    stateName <- c.statesByCode.keySet.find(_ == r)
   } yield stateName
 }
 

--- a/support-frontend/app/models/GeoData.scala
+++ b/support-frontend/app/models/GeoData.scala
@@ -1,0 +1,19 @@
+package models
+
+import com.gu.i18n.{Country, CountryGroup}
+
+case class GeoData(countryCode: Option[String], stateCode: Option[String]) {
+  def countryGroup: Option[CountryGroup] = countryCode.flatMap(CountryGroup.byFastlyCountryCode)
+  def country: Option[Country] = countryCode.flatMap(CountryGroup.countryByCode)
+  def validatedStateNameForCountry: Option[String] = for {
+    c <- country
+    r <- stateCode
+    stateName <- c.statesByCode.get(r) orElse c.statesByCode.values.find(_ == r)
+  } yield stateName
+  def validatedStateCodeForCountry: Option[String] = for {
+    c <- country
+    r <- stateCode
+    stateName <- c.statesByCode.keySet.find(_ == r) orElse c.statesByCode.map(_.swap).get(r)
+  } yield stateName
+}
+

--- a/support-frontend/app/utils/FastlyGEOIP.scala
+++ b/support-frontend/app/utils/FastlyGEOIP.scala
@@ -1,6 +1,6 @@
 package utils
 
-import com.gu.i18n.CountryGroup
+import models.GeoData
 import play.api.mvc.Request
 
 object FastlyGEOIP {
@@ -9,8 +9,8 @@ object FastlyGEOIP {
   val fastlyRegionHeader = "X-GU-GeoIP-Region"
 
   implicit class RequestWithFastlyGEOIP(r: Request[_]) {
-    def fastlyCountry: Option[CountryGroup] =
-      r.headers.get(fastlyCountryHeader).flatMap(CountryGroup.byFastlyCountryCode)
+    def fastlyCountry: Option[String] = r.headers.get(fastlyCountryHeader)
     def fastlyRegion: Option[String] = r.headers.get(fastlyRegionHeader)
+    def geoData: GeoData = GeoData(fastlyCountry, fastlyRegion)
   }
 }

--- a/support-frontend/app/utils/FastlyGEOIP.scala
+++ b/support-frontend/app/utils/FastlyGEOIP.scala
@@ -3,12 +3,14 @@ package utils
 import com.gu.i18n.CountryGroup
 import play.api.mvc.Request
 
-object RequestCountry {
+object FastlyGEOIP {
 
   val fastlyCountryHeader = "X-GU-GeoIP-Country-Code"
+  val fastlyRegionHeader = "X-GU-GeoIP-Region"
 
-  implicit class RequestWithFastlyCountry(r: Request[_]) {
+  implicit class RequestWithFastlyGEOIP(r: Request[_]) {
     def fastlyCountry: Option[CountryGroup] =
       r.headers.get(fastlyCountryHeader).flatMap(CountryGroup.byFastlyCountryCode)
+    def fastlyRegion: Option[String] = r.headers.get(fastlyRegionHeader)
   }
 }

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -30,34 +30,33 @@
 
 @main(title = title, mainJsBundle = js, fontLoaderBundle = fontLoaderBundle, description = description, mainElement = mainElement, mainStyleBundle = css) {
   <script type="text/javascript">
-    window.guardian = window.guardian || {};
-    @idUser.map { user =>
-      window.guardian.user = {
-        id: "@user.id",
-        email: "@user.primaryEmailAddress",
-        @user.publicFields.displayName.map { displayName =>
-          displayName: "@displayName",
-        }
-        @for(fields <- user.privateFields; firstName <- fields.firstName; lastName <- fields.secondName) {
-          firstName: "@firstName",
-          lastName: "@lastName",
-        }
-      };
-    };
-    window.guardian.stripeKeyDefaultCurrencies = {
-      ONE_OFF: {
-        default: "@oneOffDefaultStripeConfig.forCurrency(None).publicKey",
-        uat: "@oneOffUatStripeConfig.forCurrency(None).publicKey"
-      },
-      REGULAR: {
-        default: "@regularDefaultStripeConfig.forCurrency(None).publicKey",
-        uat: "@regularUatStripeConfig.forCurrency(None).publicKey"
+  window.guardian = window.guardian || {};
+  @idUser.map { user =>
+    window.guardian.user = {
+      id: "@user.id",
+      email: "@user.primaryEmailAddress",
+      @user.publicFields.displayName.map { displayName =>
+        displayName: "@displayName",
+      }
+      @for(fields <- user.privateFields; firstName <- fields.firstName; lastName <- fields.secondName) {
+        firstName: "@firstName",
+        lastName: "@lastName",
       }
     };
-    window.guardian.geoip = {
-      countryCode: "@countryCode.mkString",
-      stateCode: "@stateCode.mkString"
+  };
+  window.guardian.stripeKeyDefaultCurrencies = {
+    ONE_OFF: {
+      default: "@oneOffDefaultStripeConfig.forCurrency(None).publicKey",
+      uat: "@oneOffUatStripeConfig.forCurrency(None).publicKey"
+    },
+    REGULAR: {
+      default: "@regularDefaultStripeConfig.forCurrency(None).publicKey",
+      uat: "@regularUatStripeConfig.forCurrency(None).publicKey"
     }
+  };
+  window.guardian.geoip = {
+    countryCode: "@countryCode.mkString",
+    stateCode: "@stateCode.mkString"
   };
   window.guardian.stripeKeyAustralia = {
     ONE_OFF: {

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -39,9 +39,14 @@
       @user.publicFields.displayName.map { displayName =>
         displayName: "@displayName",
       }
-      @for(fields <- user.privateFields; firstName <- fields.firstName; lastName <- fields.secondName) {
-        firstName: "@firstName",
-        lastName: "@lastName",
+      @for(fields <- user.privateFields) {
+        @for(firstName <- fields.firstName; lastName <- fields.secondName) {
+          firstName: "@firstName",
+          lastName: "@lastName",
+        }
+        @for(address4 <- fields.address4) {
+          address4: "@address4",
+        }
       }
     };
   }

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -5,6 +5,8 @@
 @import com.gu.support.config.{PayPalConfig, StripeConfig}
 @import helper.CSRF
 @import views.{Preload, SSRContent, ReactDiv}
+@import models.GeoData
+
 @(
   title: String,
   id: String,
@@ -24,8 +26,7 @@
   idUser: Option[IdUser],
   guestAccountCreationToken: Option[String],
   fontLoaderBundle: Either[RefPath, StyleContent],
-  countryCode: String,
-  stateCode: Option[String]
+  geoData: GeoData
 )(implicit assets: AssetsResolver, request: RequestHeader, settings: AllSettings)
 
 @main(title = title, mainJsBundle = js, fontLoaderBundle = fontLoaderBundle, description = description, mainElement = mainElement, mainStyleBundle = css) {
@@ -55,8 +56,9 @@
     }
   };
   window.guardian.geoip = {
-    countryCode: "@countryCode.mkString",
-    stateCode: "@stateCode.mkString"
+    countryGroup: "@geoData.countryGroup.map(_.id).mkString",
+    countryCode: "@geoData.country.map(_.alpha2).mkString",
+    stateCode: "@geoData.validatedStateCodeForCountry.mkString",
   };
   window.guardian.stripeKeyAustralia = {
     ONE_OFF: {

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -43,7 +43,7 @@
           lastName: "@lastName",
         }
       };
-    }
+    };
     window.guardian.stripeKeyDefaultCurrencies = {
       ONE_OFF: {
         default: "@oneOffDefaultStripeConfig.forCurrency(None).publicKey",
@@ -54,18 +54,6 @@
         uat: "@regularUatStripeConfig.forCurrency(None).publicKey"
       }
     };
-    window.guardian.payPalEnvironment = {
-      default: "@regularDefaultPayPalConfig.payPalEnvironment",
-      uat: "@regularUatPayPalConfig.payPalEnvironment"
-    };
-    window.guardian.paymentApiStripeEndpoint = "@paymentApiStripeEndpoint";
-    window.guardian.paymentApiPayPalEndpoint = "@paymentApiPayPalEndpoint";
-    window.guardian.existingPaymentOptionsEndpoint = "@existingPaymentOptionsEndpoint";
-    window.guardian.csrf = { token: "@CSRF.getToken.value" };
-
-    @guestAccountCreationToken.map { guestAccountCreationToken =>
-      window.guardian.guestAccountCreationToken = "@guestAccountCreationToken";
-
     window.guardian.geoip = {
       countryCode: "@countryCode.mkString",
       stateCode: "@stateCode.mkString"

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -45,7 +45,7 @@
           lastName: "@lastName",
         }
         @for(address4 <- fields.address4) {
-          address4: "@address4",
+          address4: "@address4"
         }
       }
     };
@@ -63,7 +63,7 @@
   window.guardian.geoip = {
     countryGroup: "@geoData.countryGroup.map(_.id).mkString",
     countryCode: "@geoData.country.map(_.alpha2).mkString",
-    stateCode: "@geoData.validatedStateCodeForCountry.mkString",
+    stateCode: "@geoData.validatedStateCodeForCountry.mkString"
   };
   window.guardian.stripeKeyAustralia = {
     ONE_OFF: {

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -44,8 +44,11 @@
           firstName: "@firstName",
           lastName: "@lastName",
         }
-        @for(address4 <- fields.address4) {
-          address4: "@address4"
+        @for(address4 <- fields.billingAddress4 orElse fields.address4) {
+          address4: "@address4",
+        }
+        @for(country <- fields.billingCountry orElse fields.country) {
+          country: "@country"
         }
       }
     };

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -24,7 +24,7 @@
   idUser: Option[IdUser],
   guestAccountCreationToken: Option[String],
   fontLoaderBundle: Either[RefPath, StyleContent],
-  countryCode: Option[String],
+  countryCode: String,
   stateCode: Option[String]
 )(implicit assets: AssetsResolver, request: RequestHeader, settings: AllSettings)
 
@@ -43,7 +43,7 @@
         lastName: "@lastName",
       }
     };
-  };
+  }
   window.guardian.stripeKeyDefaultCurrencies = {
     ONE_OFF: {
       default: "@oneOffDefaultStripeConfig.forCurrency(None).publicKey",

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -23,33 +23,52 @@
   existingPaymentOptionsEndpoint: String,
   idUser: Option[IdUser],
   guestAccountCreationToken: Option[String],
-  fontLoaderBundle: Either[RefPath, StyleContent]
+  fontLoaderBundle: Either[RefPath, StyleContent],
+  countryCode: Option[String],
+  stateCode: Option[String]
 )(implicit assets: AssetsResolver, request: RequestHeader, settings: AllSettings)
 
 @main(title = title, mainJsBundle = js, fontLoaderBundle = fontLoaderBundle, description = description, mainElement = mainElement, mainStyleBundle = css) {
   <script type="text/javascript">
-  window.guardian = window.guardian || {};
-  @idUser.map { user =>
-    window.guardian.user = {
-      id: "@user.id",
-      email: "@user.primaryEmailAddress",
-      @user.publicFields.displayName.map { displayName =>
-        displayName: "@displayName",
-      }
-    @for(fields <- user.privateFields; firstName <- fields.firstName; lastName <- fields.secondName) {
-        firstName: "@firstName",
-        lastName: "@lastName",
+    window.guardian = window.guardian || {};
+    @idUser.map { user =>
+      window.guardian.user = {
+        id: "@user.id",
+        email: "@user.primaryEmailAddress",
+        @user.publicFields.displayName.map { displayName =>
+          displayName: "@displayName",
+        }
+        @for(fields <- user.privateFields; firstName <- fields.firstName; lastName <- fields.secondName) {
+          firstName: "@firstName",
+          lastName: "@lastName",
+        }
+      };
+    }
+    window.guardian.stripeKeyDefaultCurrencies = {
+      ONE_OFF: {
+        default: "@oneOffDefaultStripeConfig.forCurrency(None).publicKey",
+        uat: "@oneOffUatStripeConfig.forCurrency(None).publicKey"
+      },
+      REGULAR: {
+        default: "@regularDefaultStripeConfig.forCurrency(None).publicKey",
+        uat: "@regularUatStripeConfig.forCurrency(None).publicKey"
       }
     };
-  };
-  window.guardian.stripeKeyDefaultCurrencies = {
-    ONE_OFF: {
-      default: "@oneOffDefaultStripeConfig.forCurrency(None).publicKey",
-      uat: "@oneOffUatStripeConfig.forCurrency(None).publicKey"
-    },
-    REGULAR: {
-      default: "@regularDefaultStripeConfig.forCurrency(None).publicKey",
-      uat: "@regularUatStripeConfig.forCurrency(None).publicKey"
+    window.guardian.payPalEnvironment = {
+      default: "@regularDefaultPayPalConfig.payPalEnvironment",
+      uat: "@regularUatPayPalConfig.payPalEnvironment"
+    };
+    window.guardian.paymentApiStripeEndpoint = "@paymentApiStripeEndpoint";
+    window.guardian.paymentApiPayPalEndpoint = "@paymentApiPayPalEndpoint";
+    window.guardian.existingPaymentOptionsEndpoint = "@existingPaymentOptionsEndpoint";
+    window.guardian.csrf = { token: "@CSRF.getToken.value" };
+
+    @guestAccountCreationToken.map { guestAccountCreationToken =>
+      window.guardian.guestAccountCreationToken = "@guestAccountCreationToken";
+
+    window.guardian.geoip = {
+      countryCode: "@countryCode.mkString",
+      stateCode: "@stateCode.mkString"
     }
   };
   window.guardian.stripeKeyAustralia = {

--- a/support-frontend/assets/helpers/internationalisation/country.js
+++ b/support-frontend/assets/helpers/internationalisation/country.js
@@ -605,4 +605,5 @@ export {
   findIsoCountry,
   fromString,
   stateProvinceFromString,
+  fromCountryGroup,
 };

--- a/support-frontend/assets/helpers/subscriptionsForms/subscriptionCheckoutReducer.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/subscriptionCheckoutReducer.js
@@ -6,7 +6,6 @@ import { combineReducers } from 'redux';
 import { createFormReducer } from 'helpers/subscriptionsForms/formReducer';
 import type { SubscriptionProduct } from 'helpers/subscriptions';
 import { createUserReducer } from 'helpers/user/userReducer';
-import { fromCountry, GBPCountries } from 'helpers/internationalisation/countryGroup';
 import { directDebitReducer as directDebit } from 'components/directDebit/directDebitReducer';
 import type {
   FormFields as AddressFormFields,
@@ -57,7 +56,7 @@ function createReducer(
       product,
       initialBillingPeriod, startDate, productOption, fulfilmentOption,
     ),
-    user: createUserReducer(fromCountry(initialCountry) || GBPCountries),
+    user: createUserReducer(),
     directDebit,
     ...addressReducers,
     csrf,

--- a/support-frontend/assets/helpers/user/__tests__/userReducerTest.js
+++ b/support-frontend/assets/helpers/user/__tests__/userReducerTest.js
@@ -12,12 +12,12 @@ describe('user reducer tests', () => {
     expect(createUserReducer(GBPCountries)(undefined, {})).toMatchSnapshot();
   });
 
-  it('should have a default state for the US', () => {
-    expect(createUserReducer(UnitedStates)(undefined, {}).stateField).toBe('AK');
+  it('should have a blank default state for the US', () => {
+    expect(createUserReducer(UnitedStates)(undefined, {}).stateField).toBe('');
   });
 
-  it('should have a default province for Canada', () => {
-    expect(createUserReducer(Canada)(undefined, {}).stateField).toBe('AB');
+  it('should have a blank default province for Canada', () => {
+    expect(createUserReducer(Canada)(undefined, {}).stateField).toBe('');
   });
 
   it('should handle SET_DISPLAY_NAME', () => {

--- a/support-frontend/assets/helpers/user/__tests__/userTest.js
+++ b/support-frontend/assets/helpers/user/__tests__/userTest.js
@@ -5,7 +5,7 @@ jest.mock('ophan', () => () => ({
 
 import { getEmailValidatedFromUserCookie } from 'helpers/user/user';
 
-const toCookie = (values) => `${btoa(JSON.stringify(values))}.the-secret-bit-that-we-ignore`;
+const toCookie = values => `${btoa(JSON.stringify(values))}.the-secret-bit-that-we-ignore`;
 
 describe('user tests', () => {
 
@@ -14,17 +14,17 @@ describe('user tests', () => {
   });
 
   it('should return false if cookie is invalid', () => {
-    const cookie = toCookie(["1"]);
+    const cookie = toCookie(['1']);
     expect(getEmailValidatedFromUserCookie(cookie)).toEqual(false);
   });
 
   it('should return false if cookie contains false', () => {
-    const cookie = toCookie([ "1", "", "t f", "", 1, 1, 1, false ]);
+    const cookie = toCookie(['1', '', 't f', '', 1, 1, 1, false]);
     expect(getEmailValidatedFromUserCookie(cookie)).toEqual(false);
   });
 
   it('should return true if cookie contains true', () => {
-    const cookie = toCookie([ "1", "", "t f", "", 1, 1, 1, true ]);
+    const cookie = toCookie(['1', '', 't f', '', 1, 1, 1, true]);
     expect(getEmailValidatedFromUserCookie(cookie)).toEqual(true);
   });
 });

--- a/support-frontend/assets/helpers/user/user.js
+++ b/support-frontend/assets/helpers/user/user.js
@@ -90,6 +90,7 @@ const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActi
     setFullName,
     setIsSignedIn,
     setEmail,
+    setStateField,
     setIsRecurringContributor,
     setTestUser,
     setPostDeploymentTestUser,
@@ -139,6 +140,7 @@ const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActi
     dispatch(setFirstName(window.guardian.user.firstName));
     dispatch(setLastName(window.guardian.user.lastName));
     dispatch(setFullName(`${window.guardian.user.firstName} ${window.guardian.user.lastName}`));
+    dispatch(setStateField(window.guardian.user.county || window.guardian.geoip.stateCode)); // default value from Identity Billing Address, or Fastly GEO-IP
     dispatch(setIsSignedIn(true));
     dispatch(setEmailValidated(getEmailValidatedFromUserCookie(cookie.get('GU_U'))));
   } else if (userAppearsLoggedIn) {
@@ -157,6 +159,9 @@ const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActi
           }
           if (data.displayName) {
             dispatch(setDisplayName(data.displayName));
+          }
+          if (data.state) {
+            // TODO - will see if I can do this in another PR, leaving as default behaviour for now
           }
         });
       }

--- a/support-frontend/assets/helpers/user/user.js
+++ b/support-frontend/assets/helpers/user/user.js
@@ -141,10 +141,10 @@ const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActi
     dispatch(setLastName(window.guardian.user.lastName));
     dispatch(setFullName(`${window.guardian.user.firstName} ${window.guardian.user.lastName}`));
     // default value from Identity Billing Address, or Fastly GEO-IP
-    dispatch(setStateField(window.guardian.user.county || window.guardian.geoip.stateCode));
+    dispatch(setStateField(window.guardian.user.address4 || window.guardian.geoip.stateCode));
     dispatch(setIsSignedIn(true));
     dispatch(setEmailValidated(getEmailValidatedFromUserCookie(cookie.get('GU_U'))));
-  } else if (userAppearsLoggedIn) {
+  } else if (userAppearsLoggedIn) { // TODO - remove in another PR as this condition is deprecated
     fetch(routes.oneOffContribAutofill, { credentials: 'include' }).then((response) => {
       if (response.ok) {
         response.json().then((data) => {
@@ -161,14 +161,14 @@ const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActi
           if (data.displayName) {
             dispatch(setDisplayName(data.displayName));
           }
-          if (data.state) {
-            // TODO - will see if I can do this in another PR, leaving as default behaviour for now
-          }
         });
       }
     });
   } else if (emailFromBrowser) {
     dispatch(setEmail(emailFromBrowser));
+    dispatch(setStateField(window.guardian.geoip.stateCode));
+  } else {
+    dispatch(setStateField(window.guardian.geoip.stateCode));
   }
 };
 

--- a/support-frontend/assets/helpers/user/user.js
+++ b/support-frontend/assets/helpers/user/user.js
@@ -71,7 +71,7 @@ const getEmailValidatedFromUserCookie = (guuCookie: ?string) => {
     const tokens = guuCookie.split('.');
     try {
       const parsed = JSON.parse(atob(tokens[0]));
-      return !!parsed[7]
+      return !!parsed[7];
     } catch (e) {
       return false;
     }

--- a/support-frontend/assets/helpers/user/user.js
+++ b/support-frontend/assets/helpers/user/user.js
@@ -140,7 +140,8 @@ const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActi
     dispatch(setFirstName(window.guardian.user.firstName));
     dispatch(setLastName(window.guardian.user.lastName));
     dispatch(setFullName(`${window.guardian.user.firstName} ${window.guardian.user.lastName}`));
-    dispatch(setStateField(window.guardian.user.county || window.guardian.geoip.stateCode)); // default value from Identity Billing Address, or Fastly GEO-IP
+    // default value from Identity Billing Address, or Fastly GEO-IP
+    dispatch(setStateField(window.guardian.user.county || window.guardian.geoip.stateCode));
     dispatch(setIsSignedIn(true));
     dispatch(setEmailValidated(getEmailValidatedFromUserCookie(cookie.get('GU_U'))));
   } else if (userAppearsLoggedIn) {

--- a/support-frontend/assets/helpers/user/user.js
+++ b/support-frontend/assets/helpers/user/user.js
@@ -164,10 +164,10 @@ const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActi
         });
       }
     });
-  } else if (emailFromBrowser) {
-    dispatch(setEmail(emailFromBrowser));
-    dispatch(setStateField(window.guardian.geoip.stateCode));
   } else {
+    if (emailFromBrowser) {
+      dispatch(setEmail(emailFromBrowser));
+    }
     dispatch(setStateField(window.guardian.geoip.stateCode));
   }
 };

--- a/support-frontend/assets/helpers/user/userActions.js
+++ b/support-frontend/assets/helpers/user/userActions.js
@@ -24,7 +24,7 @@ export type UserSetStateActions = {|
   setLastName: string => Action,
   setFullName: string => Action,
   setEmail: string => Action,
-  setStateField: string => Action,
+  setStateField: string => (Action | (Function => void)),
   setTestUser: boolean => Action,
   setPostDeploymentTestUser: boolean => Action,
   setGnmMarketing: boolean => Action,

--- a/support-frontend/assets/helpers/user/userActions.js
+++ b/support-frontend/assets/helpers/user/userActions.js
@@ -24,7 +24,6 @@ export type UserSetStateActions = {|
   setLastName: string => Action,
   setFullName: string => Action,
   setEmail: string => Action,
-  setStateField: string => (Action | (Function => void)),
   setTestUser: boolean => Action,
   setPostDeploymentTestUser: boolean => Action,
   setGnmMarketing: boolean => Action,
@@ -35,4 +34,5 @@ export type UserSetStateActions = {|
   // contributions landing page state as well as update the user state, hence the union type.
   setIsSignedIn: boolean => (Action | (Function => void)),
   setIsRecurringContributor: () => (Action | (Function => void)),
+  setStateField: string => (Action | (Function => void)),
 |}

--- a/support-frontend/assets/helpers/user/userReducer.js
+++ b/support-frontend/assets/helpers/user/userReducer.js
@@ -20,7 +20,7 @@ export type User = {
   fullName: string,
   isTestUser: ?boolean,
   isPostDeploymentTestUser: boolean,
-  stateField?: string,
+  stateField: string,
   gnmMarketing: boolean,
   isSignedIn: boolean,
   isRecurringContributor: boolean,
@@ -49,28 +49,13 @@ const initialState: User = {
 
 // ----- Functions ----- //
 
-function defaultStateOrProvince(countryGroup: CountryGroupId): string {
-  if (countryGroup === UnitedStates) {
-    return Object.keys(usStates)[0];
-  } else if (countryGroup === Canada) {
-    return Object.keys(caStates)[0];
-  }
-
-  return '';
-}
-
 
 // ----- Reducer ----- //
 
 function createUserReducer(countryGroup: CountryGroupId) {
 
-  const initialStateWithStateOrProvince = {
-    ...initialState,
-    stateField: defaultStateOrProvince(countryGroup),
-  };
-
   return function userReducer(
-    state: User = initialStateWithStateOrProvince,
+    state: User = initialState,
     action: Action,
   ): User {
 

--- a/support-frontend/assets/helpers/user/userReducer.js
+++ b/support-frontend/assets/helpers/user/userReducer.js
@@ -3,10 +3,8 @@
 // ----- Imports ----- //
 
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import { usStates, caStates } from 'helpers/internationalisation/country';
 
 import type { Action } from './userActions';
-import { Canada, UnitedStates } from '../internationalisation/countryGroup';
 
 
 // ----- Types ----- //

--- a/support-frontend/assets/helpers/user/userReducer.js
+++ b/support-frontend/assets/helpers/user/userReducer.js
@@ -48,7 +48,7 @@ const initialState: User = {
 
 // ----- Reducer ----- //
 
-function createUserReducer(countryGroup: CountryGroupId) {
+function createUserReducer() {
 
   return function userReducer(
     state: User = initialState,

--- a/support-frontend/assets/helpers/user/userReducer.js
+++ b/support-frontend/assets/helpers/user/userReducer.js
@@ -37,6 +37,7 @@ const initialState: User = {
   firstName: '',
   lastName: '',
   fullName: '',
+  stateField: '',
   isTestUser: null,
   isPostDeploymentTestUser: false,
   gnmMarketing: false,

--- a/support-frontend/assets/helpers/user/userReducer.js
+++ b/support-frontend/assets/helpers/user/userReducer.js
@@ -2,8 +2,6 @@
 
 // ----- Imports ----- //
 
-import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
-
 import type { Action } from './userActions';
 
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionFormFields.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionFormFields.jsx
@@ -61,7 +61,7 @@ const mapStateToProps = (state: State) => ({
   lastName: getCheckoutFormValue(state.page.form.formData.lastName, state.page.user.lastName),
   email: getCheckoutFormValue(state.page.form.formData.email, state.page.user.email),
   checkoutFormHasBeenSubmitted: state.page.form.formData.checkoutFormHasBeenSubmitted,
-  state: getCheckoutFormValue(state.page.form.formData.state, state.page.user.stateField),
+  state: state.page.form.formData.state,
   isSignedIn: state.page.user.isSignedIn,
   isRecurringContributor: state.page.user.isRecurringContributor,
   userTypeFromIdentityResponse: state.page.form.userTypeFromIdentityResponse,

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionFormFields.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionFormFields.jsx
@@ -61,7 +61,7 @@ const mapStateToProps = (state: State) => ({
   lastName: getCheckoutFormValue(state.page.form.formData.lastName, state.page.user.lastName),
   email: getCheckoutFormValue(state.page.form.formData.email, state.page.user.email),
   checkoutFormHasBeenSubmitted: state.page.form.formData.checkoutFormHasBeenSubmitted,
-  state: state.page.form.formData.state,
+  state: getCheckoutFormValue(state.page.form.formData.state, state.page.user.stateField),
   isSignedIn: state.page.user.isSignedIn,
   isRecurringContributor: state.page.user.isRecurringContributor,
   userTypeFromIdentityResponse: state.page.form.userTypeFromIdentityResponse,

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
@@ -35,7 +35,7 @@ if (!isDetailsSupported) {
 
 const countryGroupId: CountryGroupId = detect();
 
-const store = pageInit(() => initReducer(countryGroupId), true);
+const store = pageInit(() => initReducer(), true);
 
 if (!window.guardian.polyfillScriptLoaded) {
   gaEvent({

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
@@ -55,7 +55,7 @@ if (typeof Object.values !== 'function') {
 
 // We need to initialise in this order, as
 // formInit depends on the user being populated
-user.init(store.dispatch, setUserStateActions);
+user.init(store.dispatch, setUserStateActions(countryGroupId));
 formInit(store);
 
 

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.js
@@ -234,11 +234,13 @@ const init = (store: Store<State, Action, Function>) => {
     firstName,
     lastName,
     email,
-    stateField
+    stateField,
   } = state.page.user;
 
   dispatch(checkIfEmailHasPassword(email));
-  dispatch(updateUserFormData({ firstName, lastName, email, state: stateField }));
+  dispatch(updateUserFormData({
+    firstName, lastName, email, state: stateField,
+  }));
 
 };
 

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.js
@@ -234,10 +234,11 @@ const init = (store: Store<State, Action, Function>) => {
     firstName,
     lastName,
     email,
+    stateField
   } = state.page.user;
 
   dispatch(checkIfEmailHasPassword(email));
-  dispatch(updateUserFormData({ firstName, lastName, email }));
+  dispatch(updateUserFormData({ firstName, lastName, email, state: stateField }));
 
 };
 

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
@@ -30,6 +30,7 @@ export type UserFormData = {
   firstName: string | null,
   lastName: string | null,
   email: string | null,
+  state: string | null,
 }
 
 export type ThankYouPageStageMap<T> = {

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
@@ -7,7 +7,6 @@ import { combineReducers } from 'redux';
 import { type ContributionType, type ThirdPartyPaymentLibraries } from 'helpers/contributions';
 import csrf from 'helpers/csrf/csrfReducer';
 import { type CommonState } from 'helpers/page/commonReducer';
-import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { type UsState, type CaState } from 'helpers/internationalisation/country';
 import { createUserReducer, type User as UserState } from 'helpers/user/userReducer';
 import { type DirectDebitState } from 'components/directDebit/directDebitReducer';
@@ -320,11 +319,11 @@ function createFormReducer() {
   };
 }
 
-function initReducer(countryGroupId: CountryGroupId) {
+function initReducer() {
 
   return combineReducers({
     form: createFormReducer(),
-    user: createUserReducer(countryGroupId),
+    user: createUserReducer(),
     directDebit,
     csrf,
     marketingConsent: marketingConsentReducerFor('MARKETING_CONSENT'),

--- a/support-frontend/assets/pages/contributions-landing/setUserStateActions.js
+++ b/support-frontend/assets/pages/contributions-landing/setUserStateActions.js
@@ -1,9 +1,9 @@
 // @flow
 import { defaultUserActionFunctions } from 'helpers/user/defaultUserActionFunctions';
 import { setFormSubmissionDependentValue } from './checkoutFormIsSubmittableActions';
-import type {UserSetStateActions} from 'helpers/user/userActions';
+import type { UserSetStateActions } from 'helpers/user/userActions';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import { fromCountryGroup, stateProvinceFromString }  from 'helpers/internationalisation/country';
+import { fromCountryGroup, stateProvinceFromString } from 'helpers/internationalisation/country';
 
 
 // ----- Actions Creators ----- //
@@ -18,14 +18,17 @@ const setIsRecurringContributor = (): ((Function) => void) =>
     dispatch(setFormSubmissionDependentValue(() => ({ type: 'SET_IS_RECURRING_CONTRIBUTOR' })));
   };
 
-const setStateFieldSafely = (pageCountryGroupId: CountryGroupId) => (unsafeState: string): ((Function) => void) =>
-  (dispatch: Function): void => {
-    const pageCountry = fromCountryGroup(pageCountryGroupId);
-    const stateField = stateProvinceFromString(pageCountry, unsafeState);
-    if (stateField) {
-      return dispatch(setFormSubmissionDependentValue(() => ({type: 'SET_STATEFIELD', stateField})));
-    }
-  };
+const setStateFieldSafely = (pageCountryGroupId: CountryGroupId) =>
+  (unsafeState: string): ((Function) => void) =>
+    (dispatch: Function): void => {
+      const pageCountry = fromCountryGroup(pageCountryGroupId);
+      if (pageCountry) {
+        const stateField = stateProvinceFromString(pageCountry, unsafeState);
+        if (stateField) {
+          dispatch(setFormSubmissionDependentValue(() => ({ type: 'SET_STATEFIELD', stateField })));
+        }
+      }
+    };
 
 const setUserStateActions = (countryGroupId: CountryGroupId): UserSetStateActions => {
   const setStateField = setStateFieldSafely(countryGroupId);

--- a/support-frontend/assets/pages/contributions-landing/setUserStateActions.js
+++ b/support-frontend/assets/pages/contributions-landing/setUserStateActions.js
@@ -1,6 +1,10 @@
 // @flow
 import { defaultUserActionFunctions } from 'helpers/user/defaultUserActionFunctions';
 import { setFormSubmissionDependentValue } from './checkoutFormIsSubmittableActions';
+import type {UserSetStateActions} from 'helpers/user/userActions';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { fromCountryGroup, stateProvinceFromString }  from 'helpers/internationalisation/country';
+
 
 // ----- Actions Creators ----- //
 
@@ -14,10 +18,23 @@ const setIsRecurringContributor = (): ((Function) => void) =>
     dispatch(setFormSubmissionDependentValue(() => ({ type: 'SET_IS_RECURRING_CONTRIBUTOR' })));
   };
 
-const setUserStateActions = {
-  ...defaultUserActionFunctions,
-  setIsSignedIn,
-  setIsRecurringContributor,
+const setStateFieldSafely = (pageCountryGroupId: CountryGroupId) => (unsafeState: string): ((Function) => void) =>
+  (dispatch: Function): void => {
+    const pageCountry = fromCountryGroup(pageCountryGroupId);
+    const stateField = stateProvinceFromString(pageCountry, unsafeState);
+    if (stateField) {
+      return dispatch(setFormSubmissionDependentValue(() => ({type: 'SET_STATEFIELD', stateField})));
+    }
+  };
+
+const setUserStateActions = (countryGroupId: CountryGroupId): UserSetStateActions => {
+  const setStateField = setStateFieldSafely(countryGroupId);
+  return {
+    ...defaultUserActionFunctions,
+    setIsSignedIn,
+    setIsRecurringContributor,
+    setStateField,
+  };
 };
 
 export { setUserStateActions };

--- a/support-frontend/test/actions/CachedActionTest.scala
+++ b/support-frontend/test/actions/CachedActionTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.{MustMatchers, WordSpec}
 import play.api.mvc.Results.Ok
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import utils.RequestCountry
+import utils.FastlyGEOIP
 
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -19,7 +19,7 @@ class CachedActionTest extends WordSpec with MustMatchers {
   val geoCachedAction = new CachedAction(
     cc.parsers.defaultBodyParser,
     cc.executionContext,
-    List("Vary" -> RequestCountry.fastlyCountryHeader)
+    List("Vary" -> FastlyGEOIP.fastlyCountryHeader)
   )
 
   "with no arguments" should {

--- a/support-internationalisation/src/main/scala/com/gu/i18n/Country.scala
+++ b/support-internationalisation/src/main/scala/com/gu/i18n/Country.scala
@@ -2,98 +2,108 @@ package com.gu.i18n
 
 // ISO 3166 alpha-2, up-to-date as of 23/09/2014
 
-case class Country(alpha2: String, name: String, states: Seq[String] = Nil)
+case class Country(alpha2: String, name: String, statesByCode: Map[String, String] = Map.empty) {
+  // Backwards compatibility, including using the 2/3-character codes for Australian states as the name
+  val states: Seq[String] = if (alpha2 == "AU") statesByCode.keys.toSeq.sorted else statesByCode.values.toSeq.sorted
+}
 
 object Country {
-  val US = Country("US", "United States", states = List(
-    "Alaska",
-    "Alabama",
-    "Arkansas",
-    "Arizona",
-    "California",
-    "Colorado",
-    "Connecticut",
-    "Delaware",
-    "Florida",
-    "Georgia",
-    "Guam",
-    "Hawaii",
-    "Iowa",
-    "Idaho",
-    "Illinois",
-    "Indiana",
-    "Kansas",
-    "Kentucky",
-    "Louisiana",
-    "Massachusetts",
-    "Maryland",
-    "Maine",
-    "Michigan",
-    "Minnesota",
-    "Missouri",
-    "Mississippi",
-    "Montana",
-    "North Carolina",
-    "North Dakota",
-    "Nebraska",
-    "New Hampshire",
-    "New Jersey",
-    "New Mexico",
-    "Nevada",
-    "New York",
-    "Ohio",
-    "Oklahoma",
-    "Oregon",
-    "Pennsylvania",
-    "Puerto Rico",
-    "Rhode Island",
-    "South Carolina",
-    "South Dakota",
-    "Tennessee",
-    "Texas",
-    "Utah",
-    "Virginia",
-    "Virgin Islands",
-    "Vermont",
-    "Washington",
-    "Washington DC",
-    "Wisconsin",
-    "West Virginia",
-    "Wyoming",
-    "Armed Forces America",
-    "Armed Forces",
-    "Armed Forces Pacific"
-  ))
 
-  val Canada = Country("CA", "Canada", states = List(
-    "Alberta",
-    "British Columbia",
-    "Manitoba",
-    "New Brunswick",
-    "Newfoundland and Labrador",
-    "Nova Scotia",
-    "Northwest Territories",
-    "Nunavut",
-    "Ontario",
-    "Prince Edward Island",
-    "Quebec",
-    "Saskatchewan",
-    "Yukon"
-  ))
+  val US = Country("US", "United States",
+    statesByCode = Seq(
+      "AK" -> "Alaska",
+      "AL" -> "Alabama",
+      "AR" -> "Arkansas",
+      "AZ" -> "Arizona",
+      "CA" -> "California",
+      "CO" -> "Colorado",
+      "CT" -> "Connecticut",
+      "DC" -> "Washington DC",
+      "DE" -> "Delaware",
+      "FL" -> "Florida",
+      "GA" -> "Georgia",
+      "GU" -> "Guam",
+      "HI" -> "Hawaii",
+      "IA" -> "Iowa",
+      "ID" -> "Idaho",
+      "IL" -> "Illinois",
+      "IN" -> "Indiana",
+      "KS" -> "Kansas",
+      "KY" -> "Kentucky",
+      "LA" -> "Louisiana",
+      "MA" -> "Massachusetts",
+      "MD" -> "Maryland",
+      "ME" -> "Maine",
+      "MI" -> "Michigan",
+      "MN" -> "Minnesota",
+      "MO" -> "Missouri",
+      "MS" -> "Mississippi",
+      "MT" -> "Montana",
+      "NC" -> "North Carolina",
+      "ND" -> "North Dakota",
+      "NE" -> "Nebraska",
+      "NH" -> "New Hampshire",
+      "NJ" -> "New Jersey",
+      "NM" -> "New Mexico",
+      "NV" -> "Nevada",
+      "NY" -> "New York",
+      "OH" -> "Ohio",
+      "OK" -> "Oklahoma",
+      "OR" -> "Oregon",
+      "PA" -> "Pennsylvania",
+      "PR" -> "Puerto Rico",
+      "RI" -> "Rhode Island",
+      "SC" -> "South Carolina",
+      "SD" -> "South Dakota",
+      "TN" -> "Tennessee",
+      "TX" -> "Texas",
+      "UT" -> "Utah",
+      "VA" -> "Virginia",
+      "VI" -> "Virgin Islands",
+      "VT" -> "Vermont",
+      "WA" -> "Washington",
+      "WI" -> "Wisconsin",
+      "WV" -> "West Virginia",
+      "WY" -> "Wyoming",
+      "AA" -> "Armed Forces America",
+      "AE" -> "Armed Forces",
+      "AP" -> "Armed Forces Pacific"
+    ).toMap
+  )
+
+  val Canada = Country("CA", "Canada",
+    statesByCode = Seq(
+      "AB" -> "Alberta",
+      "BC" -> "British Columbia",
+      "MB" -> "Manitoba",
+      "NB" -> "New Brunswick",
+      "NL" -> "Newfoundland and Labrador",
+      "NS" -> "Nova Scotia",
+      "NT" -> "Northwest Territories",
+      "NU" -> "Nunavut",
+      "ON" -> "Ontario",
+      "PE" -> "Prince Edward Island",
+      "QC" -> "Quebec",
+      "SK" -> "Saskatchewan",
+      "YT" -> "Yukon"
+    ).toMap
+  )
 
   val UK = Country("GB", "United Kingdom")
 
-  val Australia = Country("AU", "Australia", states = List(
-    "SA",
-    "TAS",
-    "NSW",
-    "VIC",
-    "WA",
-    "QLD",
-    "ACT",
-    "NT",
-    "JBT"
-  ))
+  val Australia = Country("AU", "Australia",
+    statesByCode = Seq(
+      "SA" -> "South Australia",
+      "TAS" -> "Tasmania",
+      "NSW" -> "New South Wales",
+      "VIC" -> "Victoria",
+      "WA" -> "Western Australia",
+      "QLD" -> "Queensland",
+      "ACT" -> "Australian Capital Territory",
+      "NT" -> "Northern Territory",
+      "JBT" -> "Jervis Bay Territory",
+    ).toMap
+  )
 
   val NewZealand = Country("NZ", "New Zealand")
 


### PR DESCRIPTION
Pre-fills the US State and Canada Province value on the Contributions flow, defaulting to the user's billing account or GEO-IP value.

## Why are you doing this?
There are thousands of recurring contributions assigned to the Alaska state due to people just picking the first item of the list, and a historical bug which set the state to Alaska back when the field was not required.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->
https://trello.com/c/ZexwHuvs

## Screenshots
<img width="528" alt="Screen Shot 2019-07-08 at 17 29 57" src="https://user-images.githubusercontent.com/1515970/60826651-3e194f80-a1a6-11e9-9ece-41f4aede6b5c.png">

## Considerations
- Check caching settings, if we're varying the checkout by country, we may cache state codes
- The new header needs adding to Fastly (tested on CODE as the header passes through from the browser)