### PR TITLE
Cache pre-rendered html in memory

### DIFF
--- a/support-frontend/app/assets/AssetsResolver.scala
+++ b/support-frontend/app/assets/AssetsResolver.scala
@@ -40,7 +40,7 @@ class AssetsResolver(base: String, mapResource: String, env: Environment) {
     }
   }
 
-  private val ssrHtmlCache: Map[String,Html] = {
+  protected def loadSsrHtmlCache: Map[String,Html] = {
     val files = env.getFile("conf/ssr-cache").listFiles.filter(_.getName.endsWith(".html"))
     val loadedHtml = for {
       file <- files
@@ -51,6 +51,8 @@ class AssetsResolver(base: String, mapResource: String, env: Environment) {
 
     loadedHtml.toMap
   }
+
+  private val ssrHtmlCache = loadSsrHtmlCache
 
   def getSsrCacheContentsAsHtml(divId: String, file: String): ReactDiv = {
     ssrHtmlCache.get(file).map(html => SSRContent(divId, html)).getOrElse(EmptyDiv(divId))

--- a/support-frontend/test/fixtures/DisplayFormMocks.scala
+++ b/support-frontend/test/fixtures/DisplayFormMocks.scala
@@ -19,6 +19,7 @@ import config.Configuration.IdentityUrl
 import services.{HttpIdentityService, MembersDataService, TestUserService}
 import services.MembersDataService._
 import fixtures.TestCSRFComponents
+import play.twirl.api.Html
 
 trait DisplayFormMocks extends TestCSRFComponents {
   val credentials = AccessCredentials.Cookies("", None)
@@ -32,6 +33,7 @@ trait DisplayFormMocks extends TestCSRFComponents {
   val assetResolver = new AssetsResolver("", "", mock[Environment]) {
     override def apply(path: String): String = path
     override def apply(path: RefPath): String = path.value
+    override protected def loadSsrHtmlCache: Map[String,Html] = Map()
   }
 
   val idUser = IdUser("123", "test@gu.com", PublicFields(Some("test-user")), None, None)


### PR DESCRIPTION
## Why are you doing this?
We pre-render some of our pages at build-time. At runtime we load the html from file and insert it into the twirl template.

The contributions landing page [will soon use pre-rendering](https://github.com/guardian/support-frontend/pull/1928). We'll be serving a lot of requests with pre-rendered content, so it makes sense to have it in memory.
