### PR TITLE
Put some placeholders in for subs failure emails

### DIFF
--- a/support-workers/src/main/scala/com/gu/emailservices/FailedGuardianWeeklyEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/FailedGuardianWeeklyEmailFields.scala
@@ -2,8 +2,8 @@ package com.gu.emailservices
 
 import com.gu.salesforce.Salesforce.SfContactId
 
-case class FailedPaperEmailFields(email: String, identityUserId: IdentityUserId) extends EmailFields {
+case class FailedGuardianWeeklyEmailFields(email: String, identityUserId: IdentityUserId) extends EmailFields {
   //TODO: update this once there is an email template for paper sign up failures
-  override def payload: String = super.payload(email, "paper-failed")
+  override def payload: String = super.payload(email, "guardian-weekly-failed")
   override def userId: Either[SfContactId, IdentityUserId] = Right(identityUserId)
 }

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
@@ -40,8 +40,8 @@ class FailureHandler(emailService: EmailService) extends FutureHandler[FailureHa
       case c: Contribution => FailedContributionEmailFields(email = state.user.primaryEmailAddress, IdentityUserId(state.user.id))
       //TODO: Failure emails for subs products
       case d: DigitalPack => FailedDigitalPackEmailFields(email = state.user.primaryEmailAddress, IdentityUserId(state.user.id))
-      case p: Paper => FailedDigitalPackEmailFields(email = state.user.primaryEmailAddress, IdentityUserId(state.user.id))
-      case g: GuardianWeekly => FailedDigitalPackEmailFields(email = state.user.primaryEmailAddress, IdentityUserId(state.user.id))
+      case p: Paper => FailedPaperEmailFields(email = state.user.primaryEmailAddress, IdentityUserId(state.user.id))
+      case g: GuardianWeekly => FailedGuardianWeeklyEmailFields(email = state.user.primaryEmailAddress, IdentityUserId(state.user.id))
     }
     SafeLogger.info(s"Sending a failure email. Email fields: $emailFields")
     emailService.send(emailFields)

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
@@ -38,10 +38,10 @@ class FailureHandler(emailService: EmailService) extends FutureHandler[FailureHa
   private def sendEmail(state: FailureHandlerState) = {
     val emailFields = state.product match {
       case c: Contribution => FailedContributionEmailFields(email = state.user.primaryEmailAddress, IdentityUserId(state.user.id))
-      //TODO!!! will currently send nothing
+      //TODO: Failure emails for subs products
       case d: DigitalPack => FailedDigitalPackEmailFields(email = state.user.primaryEmailAddress, IdentityUserId(state.user.id))
-      case p: Paper => ???
-      case g: GuardianWeekly => ???
+      case p: Paper => FailedDigitalPackEmailFields(email = state.user.primaryEmailAddress, IdentityUserId(state.user.id))
+      case g: GuardianWeekly => FailedDigitalPackEmailFields(email = state.user.primaryEmailAddress, IdentityUserId(state.user.id))
     }
     SafeLogger.info(s"Sending a failure email. Email fields: $emailFields")
     emailService.send(emailFields)


### PR DESCRIPTION
## Why are you doing this?
We are currently getting errors in the failure handler because of unimplemented function stubs, this PR adds some placeholder code to prevent the errors until a proper implementation can be put in place.
![Screenshot 2019-07-04 at 10 29 59](https://user-images.githubusercontent.com/181371/60656069-b8fd0600-9e46-11e9-87ad-fcda6f682959.png)

