### PR TITLE
Show executions scripts

### DIFF
--- a/support-workers/scripts/show-failed.sh
+++ b/support-workers/scripts/show-failed.sh
@@ -4,7 +4,7 @@ grep executionArn | \
 awk '{print $2;}' | \
 sed 's=^"\(.*\)",$=\1=' | \
 xargs -n1 aws stepfunctions get-execution-history --profile membership --region eu-west-1 --execution-arn | \
-jq '.events[] | select(.type == "LambdaFunctionFailed")' | jq -s '. | .[0].lambdaFunctionFailedEventDetails.cause' | \
+jq '[.events[] | select(.type == "LambdaFunctionFailed")] | .[0].lambdaFunctionFailedEventDetails.cause' | \
 sed 's=\\\\=\\=g' | \
 sed 's=\\"="=g' | \
 sed 's=^"\(.*\)"$=\1=' | \

--- a/support-workers/scripts/show-failed.sh
+++ b/support-workers/scripts/show-failed.sh
@@ -4,4 +4,8 @@ grep executionArn | \
 awk '{print $2;}' | \
 sed 's=^"\(.*\)",$=\1=' | \
 xargs -n1 aws stepfunctions get-execution-history --profile membership --region eu-west-1 --execution-arn | \
-jq '.events[] | select(.type == "LambdaFunctionFailed")' | jq -s '. | .[0]' 
+jq '.events[] | select(.type == "LambdaFunctionFailed")' | jq -s '. | .[0].lambdaFunctionFailedEventDetails.cause' | \
+sed 's=\\\\=\\=g' | \
+sed 's=\\"="=g' | \
+sed 's=^"\(.*\)"$=\1=' | \
+jq '.'

--- a/support-workers/scripts/show-failed.sh
+++ b/support-workers/scripts/show-failed.sh
@@ -1,0 +1,7 @@
+MAX_EXECUTIONS=${1:-5}   
+aws stepfunctions list-executions --status-filter FAILED --state-machine-arn arn:aws:states:eu-west-1:865473395570:stateMachine:support-workers-PROD --max-items $MAX_EXECUTIONS --profile membership --region eu-west-1 | \
+grep executionArn | \
+awk '{print $2;}' | \
+sed 's=^"\(.*\)",$=\1=' | \
+xargs -n1 aws stepfunctions get-execution-history --profile membership --region eu-west-1 --execution-arn | \
+jq '.events[] | select(.type == "LambdaFunctionFailed")' | jq -s '. | .[0]' 

--- a/support-workers/scripts/show-failed.sh
+++ b/support-workers/scripts/show-failed.sh
@@ -1,4 +1,4 @@
-MAX_EXECUTIONS=${1:-5}   
+MAX_EXECUTIONS=${1:-1}   
 aws stepfunctions list-executions --status-filter FAILED --state-machine-arn arn:aws:states:eu-west-1:865473395570:stateMachine:support-workers-PROD --max-items $MAX_EXECUTIONS --profile membership --region eu-west-1 | \
 grep executionArn | \
 awk '{print $2;}' | \

--- a/support-workers/scripts/show-failed.sh
+++ b/support-workers/scripts/show-failed.sh
@@ -4,8 +4,5 @@ grep executionArn | \
 awk '{print $2;}' | \
 sed 's=^"\(.*\)",$=\1=' | \
 xargs -n1 aws stepfunctions get-execution-history --profile membership --region eu-west-1 --execution-arn | \
-jq '[.events[] | select(.type == "LambdaFunctionFailed")] | .[0].lambdaFunctionFailedEventDetails.cause' | \
-sed 's=\\\\=\\=g' | \
-sed 's=\\"="=g' | \
-sed 's=^"\(.*\)"$=\1=' | \
-jq '.'
+jq '[.events[] | select(.type == "LambdaFunctionFailed")] | .[0]' | \
+jq '{ timestamp: (.timestamp | todate), cause: (.lambdaFunctionFailedEventDetails.cause | fromjson) }'

--- a/support-workers/scripts/show-successful.sh
+++ b/support-workers/scripts/show-successful.sh
@@ -4,7 +4,6 @@ grep executionArn | \
 awk '{print $2;}' | \
 sed 's=^"\(.*\)",$=\1=' | \
 xargs -n1 aws stepfunctions get-execution-history --profile membership --region eu-west-1 --execution-arn | \
-jq '.events[-1].executionSucceededEventDetails.output' | \
-sed 's=\\"="=g' | \
-sed 's=^"\(.*\)"$=\1=' | \
-jq '.[0].requestInfo'
+jq '.events[-1] | { timestamp:(.timestamp | todate), output:(.executionSucceededEventDetails.output | fromjson) }' | \
+jq '{ timestamp, requestInfo: (.output[0].requestInfo) }'
+

--- a/support-workers/scripts/show-successful.sh
+++ b/support-workers/scripts/show-successful.sh
@@ -1,0 +1,10 @@
+MAX_EXECUTIONS=${1:-5}   
+aws stepfunctions list-executions --status-filter SUCCEEDED --state-machine-arn arn:aws:states:eu-west-1:865473395570:stateMachine:support-workers-PROD --max-items $MAX_EXECUTIONS --profile membership --region eu-west-1 | \
+grep executionArn | \
+awk '{print $2;}' | \
+sed 's=^"\(.*\)",$=\1=' | \
+xargs -n1 aws stepfunctions get-execution-history --profile membership --region eu-west-1 --execution-arn | \
+jq '.events[-1].executionSucceededEventDetails.output' | \
+sed 's=\\"="=g' | \
+sed 's=^"\(.*\)"$=\1=' | \
+jq '.[0].requestInfo'


### PR DESCRIPTION
## Why are you doing this?
Add 2 scripts to make it easy to check the outcome of support-workers executions from the command line:
* `show-successful.sh n` will show the request info from the last `n` successful executions to make it easy to see the results of those executions. 
Eg. `./show-successful.sh 3` returns:
``` json
{
  "encrypted": true,
  "testUser": true,
  "failed": false,
  "messages": [
    "Payment method is DirectDebit",
    "Product is Paper-Collection-Everyday"
  ],
  "accountExists": false
}
{
  "encrypted": true,
  "testUser": true,
  "failed": false,
  "messages": [
    "Payment method is Stripe",
    "Product is Monthly-DigitalPack-GBP"
  ],
  "accountExists": false
}
{
  "encrypted": true,
  "testUser": true,
  "failed": false,
  "messages": [
    "Payment method is Stripe",
    "Product is Annual-Contribution-USD-50"
  ],
  "accountExists": false
}
```

* `show-failed.sh n` will output the error message from the last `n` failed executions
Eg. 
`./show-failed.sh 1` returns:

``` json
{
  "errorMessage": "{\"error\":{\"type\":\"invalid_request_error\",\"message\":\"No such token: tok_FMVKoRQpJTLalj; a similar object exists in test mode, but a live mode key was used to make this request.\",\"code\":\"resource_missing\",\"decline_code\":null,\"param\":\"card\"}}",
  "errorType": "com.gu.support.workers.exceptions.RetryNone",
  "stackTrace": [
    "com.gu.stripe.Stripe$StripeError.asRetryException(Stripe.scala:37)",
    "com.gu.support.workers.exceptions.ErrorHandler$$anonfun$1.applyOrElse(ErrorHandler.scala:20)",
    "com.gu.support.workers.exceptions.ErrorHandler$$anonfun$1.applyOrElse(ErrorHandler.scala:18)",
    "scala.runtime.AbstractPartialFunction.apply(AbstractPartialFunction.scala:34)",
    "com.gu.support.workers.lambdas.Handler.handleRequest(Handler.scala:30)",
    "sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)",
    "sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)",
    "sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)",
    "java.lang.reflect.Method.invoke(Method.java:498)"
  ],
  "cause": {
    "errorMessage": "message: No such token: tok_FMVKoRQpJTLalj; a similar object exists in test mode, but a live mode key was used to make this request.; type: invalid_request_error; code: resource_missing; decline_code: ; param: card",
    "errorType": "com.gu.stripe.Stripe$StripeError",
    "stackTrace": [
      "com.gu.stripe.Stripe$StripeError$anon$lazy$macro$363$1$anon$macro$361$1.from(Stripe.scala:17)",
      "com.gu.stripe.Stripe$StripeError$anon$lazy$macro$363$1$anon$macro$361$1.from(Stripe.scala:17)",
      "shapeless.LabelledGeneric$$anon$1.from(generic.scala:229)",
      "shapeless.LabelledGeneric$$anon$1.from(generic.scala:226)",
      "io.circe.generic.decoding.DerivedDecoder$$anon$1.apply(DerivedDecoder.scala:14)",
      "io.circe.Decoder.tryDecode(Decoder.scala:36)",
      "io.circe.Decoder.tryDecode$(Decoder.scala:35)",
      "io.circe.generic.decoding.DerivedDecoder.tryDecode(DerivedDecoder.scala:6)",
      "io.circe.Decoder$$anon$30.tryDecode(Decoder.scala:202)",
      "io.circe.Decoder$$anon$30.apply(Decoder.scala:201)",
      "com.gu.support.encoding.Codec.apply(Codec.scala:15)",
      "io.circe.Decoder.decodeJson(Decoder.scala:52)",
      "io.circe.Decoder.decodeJson$(Decoder.scala:52)",
      "com.gu.support.encoding.Codec.decodeJson(Codec.scala:12)",
      "io.circe.Parser.finishDecode(Parser.scala:12)",
      "io.circe.Parser.finishDecode$(Parser.scala:9)",
      "io.circe.parser.package$.finishDecode(package.scala:5)",
      "io.circe.Parser.decode(Parser.scala:26)",
      "io.circe.Parser.decode$(Parser.scala:25)",
      "io.circe.parser.package$.decode(package.scala:5)",
      "com.gu.helpers.WebServiceHelper.decodeError(WebServiceHelper.scala:76)",
      "com.gu.helpers.WebServiceHelper.decodeError$(WebServiceHelper.scala:76)",
      "com.gu.stripe.StripeService.decodeError(StripeService.scala:11)",
      "com.gu.helpers.WebServiceHelper.$anonfun$request$1(WebServiceHelper.scala:61)",
      "scala.util.Success.$anonfun$map$1(Try.scala:251)",
      "scala.util.Success.map(Try.scala:209)",
      "scala.concurrent.Future.$anonfun$map$1(Future.scala:288)",
      "scala.concurrent.impl.Promise.liftedTree1$1(Promise.scala:29)",
      "scala.concurrent.impl.Promise.$anonfun$transform$1(Promise.scala:29)",
      "scala.concurrent.impl.CallbackRunnable.run(Promise.scala:60)",
      "java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1402)",
      "java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)",
      "java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)",
      "java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)",
      "java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)"
    ]
  }
}
``` 

You will need AWS CLI and fresh Janus credentials for these to work
