### PR TITLE
Switch to using the new GW checkout for all traffic

### DIFF
--- a/support-frontend/assets/helpers/externalLinks.js
+++ b/support-frontend/assets/helpers/externalLinks.js
@@ -2,9 +2,15 @@
 
 // ----- Imports ----- //
 
-import { type Campaign, deriveSubsAcquisitionData, type ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
-import { type CountryGroupId, countryGroups } from 'helpers/internationalisation/countryGroup';
-import { type Option } from 'helpers/types/option';
+import {
+  type Campaign,
+  deriveSubsAcquisitionData,
+  type ReferrerAcquisitionData,
+} from 'helpers/tracking/acquisitions';
+import {
+  type CountryGroupId,
+  countryGroups,
+} from 'helpers/internationalisation/countryGroup';
 import type { Participations } from 'helpers/abTests/abtest';
 import { type OptimizeExperiments } from 'helpers/optimize/optimize';
 import { getBaseDomain } from 'helpers/url';
@@ -12,9 +18,6 @@ import {
   Annual,
   type DigitalBillingPeriod,
   Monthly,
-  Quarterly,
-  SixWeekly,
-  type WeeklyBillingPeriod,
 } from 'helpers/billingPeriods';
 import type { SubscriptionProduct } from 'helpers/subscriptions';
 import { getAnnualPlanPromoCode, getIntcmp, getPromoCode } from './flashSale';
@@ -43,54 +46,9 @@ const manageUrl = `https://manage.${getBaseDomain()}`;
 const homeDeliveryUrl = `${getBaseDomain()}/help/2017/dec/11/help-with-delivery#nav1`;
 const defaultIntCmp = 'gdnwb_copts_bundles_landing_default';
 const androidAppUrl = 'https://play.google.com/store/apps/details?id=com.guardian';
-const emailPreferencesUrl = `${profileUrl}/email-prefs`;
 const myAccountUrl = `${profileUrl}/account/edit`;
 const manageSubsUrl = `${manageUrl}/subscriptions`;
 
-
-function getWeeklyZuoraCode(period: WeeklyBillingPeriod, countryGroup: CountryGroupId) {
-
-  const sixWeekDomestic = 'weeklydomestic-gwoct18-sixforsix-domestic';
-  const sixWeekRow = 'weeklyrestofworld-gwoct18-sixforsix-row';
-
-  const quarterDomestic = 'weeklydomestic-gwoct18-quarterly-domestic';
-  const quarterRow = 'weeklyrestofworld-gwoct18-quarterly-row';
-
-  const yearDomestic = 'weeklydomestic-gwoct18-annual-domestic';
-  const yearRow = 'weeklyrestofworld-gwoct18-annual-row';
-
-  const urls = {
-    [SixWeekly]: {
-      GBPCountries: sixWeekDomestic,
-      UnitedStates: sixWeekDomestic,
-      AUDCountries: sixWeekDomestic,
-      NZDCountries: sixWeekDomestic,
-      EURCountries: sixWeekDomestic,
-      Canada: sixWeekDomestic,
-      International: sixWeekRow,
-    },
-    [Quarterly]: {
-      GBPCountries: quarterDomestic,
-      UnitedStates: quarterDomestic,
-      AUDCountries: quarterDomestic,
-      NZDCountries: quarterDomestic,
-      EURCountries: quarterDomestic,
-      Canada: quarterDomestic,
-      International: quarterRow,
-    },
-    [Annual]: {
-      GBPCountries: yearDomestic,
-      UnitedStates: yearDomestic,
-      AUDCountries: yearDomestic,
-      NZDCountries: yearDomestic,
-      EURCountries: yearDomestic,
-      Canada: yearDomestic,
-      International: yearRow,
-    },
-  };
-
-  return urls[period][countryGroup];
-}
 
 const memUrls: {
   [MemProduct]: string,
@@ -270,34 +228,6 @@ function getDigitalCheckout(
 }
 
 
-// Builds a link to the GW checkout.
-function getWeeklyCheckout(
-  referrerAcquisitionData: ReferrerAcquisitionData,
-  period: WeeklyBillingPeriod,
-  cgId: CountryGroupId,
-  nativeAbParticipations: Participations,
-  optimizeExperiments: OptimizeExperiments,
-  promoCode: Option<string>,
-): string {
-  const acquisitionData = deriveSubsAcquisitionData(
-    referrerAcquisitionData,
-    nativeAbParticipations,
-    optimizeExperiments,
-  );
-
-  const url = getWeeklyZuoraCode(period, cgId);
-  const params = new URLSearchParams(window.location.search);
-
-  params.set('acquisitionData', JSON.stringify(acquisitionData));
-  params.set('countryGroup', countryGroups[cgId].supportInternationalisationId);
-
-  if (promoCode) {
-    params.set('promoCode', promoCode);
-  }
-
-  return `${subsUrl}/checkout/${url}?${params.toString()}`;
-}
-
 function convertCountryGroupIdToAppStoreCountryCode(cgId: CountryGroupId) {
   const groupFromId = countryGroups[cgId];
   if (groupFromId) {
@@ -348,9 +278,7 @@ export {
   getDailyEditionUrl,
   getSignoutUrl,
   getReauthenticateUrl,
-  emailPreferencesUrl,
   myAccountUrl,
   manageSubsUrl,
-  getWeeklyCheckout,
   homeDeliveryUrl,
 };

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
@@ -6,10 +6,7 @@ import {
   billingPeriodTitle,
   weeklyBillingPeriods,
 } from 'helpers/billingPeriods';
-import { type CommonState } from 'helpers/page/commonReducer';
-import { getWeeklyCheckout } from 'helpers/externalLinks';
 import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
-import { getPromoCode } from 'helpers/flashSale';
 import ProductPagePlanForm, { type PropTypes } from 'components/productPage/productPagePlanForm/productPagePlanForm';
 
 import { type State } from '../weeklySubscriptionLandingReducer';
@@ -23,28 +20,8 @@ import { getOrigin } from 'helpers/url';
 
 // ---- Plans ----- //
 
-const getCheckoutUrl = ({ billingPeriod, state }: {billingPeriod: WeeklyBillingPeriod, state: CommonState}): string => {
-  const optimizeExperimentId = 'bCiv10arQ7OYNMyIyC89MQ';
-  const {
-    internationalisation: { countryGroupId }, referrerAcquisitionData, abParticipations, optimizeExperiments,
-  } = state;
-
-  const useVariant = state.optimizeExperiments.find(exp => exp.id === optimizeExperimentId && exp.variant === '1');
-
-  if (useVariant) {
-    return `${getOrigin()}/subscribe/weekly/checkout?period=${billingPeriod.toString()}`;
-  }
-
-  return getWeeklyCheckout(
-    referrerAcquisitionData,
-    billingPeriod,
-    countryGroupId,
-    abParticipations,
-    optimizeExperiments,
-    (billingPeriod === 'Annual' ? getPromoCode('GuardianWeekly', countryGroupId, '10ANNUAL') : null),
-  );
-
-};
+const getCheckoutUrl = (billingPeriod: WeeklyBillingPeriod): string =>
+  `${getOrigin()}/subscribe/weekly/checkout?period=${billingPeriod.toString()}`;
 
 // ----- State/Props Maps ----- //
 
@@ -67,7 +44,7 @@ const mapStateToProps = (state: State): PropTypes<WeeklyBillingPeriod> => ({
           billingPeriod,
         ),
         offer: getAppliedPromoDescription(billingPeriod, productPrice),
-        href: getCheckoutUrl({ billingPeriod, state: state.common }),
+        href: getCheckoutUrl(billingPeriod),
         onClick: sendTrackingEventsOnClick(`subscribe_now_cta-${billingPeriod}`, 'GuardianWeekly', null),
         price: null,
         saving: null,


### PR DESCRIPTION
## Why are you doing this?
We want to switch over to using the new Guardian Weekly checkout for all traffic.

[**Trello Card**](https://trello.com/c/Gw0EzkE0/2451-launch-gw)

