### PR TITLE
Make the DD form components include their own styling

### DIFF
--- a/support-frontend/assets/components/directDebit/directDebitForm/directDebitForm.jsx
+++ b/support-frontend/assets/components/directDebit/directDebitForm/directDebitForm.jsx
@@ -7,27 +7,35 @@ import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
 import ErrorMessage from 'components/errorMessage/errorMessage';
-import SortCodeInput from 'components/directDebit/directDebitForm/sortCodeInput';
-import DirectDebitGuarantee from 'components/directDebit/directDebitForm/directDebitGuarantee';
+import SortCodeInput
+  from 'components/directDebit/directDebitForm/sortCodeInput';
+import DirectDebitGuarantee
+  from 'components/directDebit/directDebitForm/directDebitGuarantee';
+import type {
+  Action,
+  Phase,
+  SortCodeIndex,
+} from 'components/directDebit/directDebitActions';
 import {
-  updateSortCode,
-  updateAccountNumber,
-  updateAccountHolderName,
-  updateAccountHolderConfirmation,
+  closeDirectDebitGuarantee,
   confirmDirectDebitClicked,
   openDirectDebitGuarantee,
-  closeDirectDebitGuarantee,
   payDirectDebitClicked,
   setDirectDebitFormPhase,
+  updateAccountHolderConfirmation,
+  updateAccountHolderName,
+  updateAccountNumber,
+  updateSortCode,
 } from 'components/directDebit/directDebitActions';
-import type { SortCodeIndex, Phase, Action } from 'components/directDebit/directDebitActions';
 import SvgDirectDebitSymbol from 'components/svgs/directDebitSymbol';
-import SvgDirectDebitSymbolAndText from 'components/svgs/directDebitSymbolAndText';
+import SvgDirectDebitSymbolAndText
+  from 'components/svgs/directDebitSymbolAndText';
 import SvgArrowRightStraight from 'components/svgs/arrowRightStraight';
 import SvgExclamationAlternate from 'components/svgs/exclamationAlternate';
 import { contributionsEmail } from 'helpers/legal';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
+import './directDebitForm.scss';
 
 // ---- Types ----- //
 

--- a/support-frontend/assets/components/directDebit/directDebitForm/directDebitForm.scss
+++ b/support-frontend/assets/components/directDebit/directDebitForm/directDebitForm.scss
@@ -1,3 +1,6 @@
+// -----  gu-sass ----- //
+@import '~stylesheets/gu-sass/gu-sass';
+
 .component-direct-debit-form {
   clear: left;
   margin-top: 80px;

--- a/support-frontend/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.jsx
+++ b/support-frontend/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.jsx
@@ -6,16 +6,17 @@ import React from 'react';
 import { connect } from 'react-redux';
 import type { Dispatch } from 'redux';
 
+import type { Phase } from 'components/directDebit/directDebitActions';
 import {
+  type Action,
   closeDirectDebitPopUp,
   resetDirectDebitFormError,
-  type Action,
 } from 'components/directDebit/directDebitActions';
-import DirectDebitForm from 'components/directDebit/directDebitForm/directDebitForm';
+import DirectDebitForm
+  from 'components/directDebit/directDebitForm/directDebitForm';
 import SvgCross from 'components/svgs/cross';
-
-import type { Phase } from 'components/directDebit/directDebitActions';
 import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
+import './directDebitPopUpForm.scss';
 
 // ---- Types ----- //
 

--- a/support-frontend/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.scss
+++ b/support-frontend/assets/components/directDebit/directDebitPopUpForm/directDebitPopUpForm.scss
@@ -1,3 +1,7 @@
+// -----  gu-sass ----- //
+@import '~stylesheets/gu-sass/gu-sass';
+
+
 .component-direct-debit-pop-up-form {
   z-index: 7500;
   display: block;

--- a/support-frontend/assets/helpers/user/__tests__/userTest.js
+++ b/support-frontend/assets/helpers/user/__tests__/userTest.js
@@ -5,7 +5,7 @@ jest.mock('ophan', () => () => ({
 
 import { getEmailValidatedFromUserCookie } from 'helpers/user/user';
 
-const toCookie = (values) => `${btoa(JSON.stringify(values))}.the-secret-bit-that-we-ignore`;
+const toCookie = values => `${btoa(JSON.stringify(values))}.the-secret-bit-that-we-ignore`;
 
 describe('user tests', () => {
 
@@ -14,17 +14,17 @@ describe('user tests', () => {
   });
 
   it('should return false if cookie is invalid', () => {
-    const cookie = toCookie(["1"]);
+    const cookie = toCookie(['1']);
     expect(getEmailValidatedFromUserCookie(cookie)).toEqual(false);
   });
 
   it('should return false if cookie contains false', () => {
-    const cookie = toCookie([ "1", "", "t f", "", 1, 1, 1, false ]);
+    const cookie = toCookie(['1', '', 't f', '', 1, 1, 1, false]);
     expect(getEmailValidatedFromUserCookie(cookie)).toEqual(false);
   });
 
   it('should return true if cookie contains true', () => {
-    const cookie = toCookie([ "1", "", "t f", "", 1, 1, 1, true ]);
+    const cookie = toCookie(['1', '', 't f', '', 1, 1, 1, true]);
     expect(getEmailValidatedFromUserCookie(cookie)).toEqual(true);
   });
 });

--- a/support-frontend/assets/helpers/user/user.js
+++ b/support-frontend/assets/helpers/user/user.js
@@ -71,7 +71,7 @@ const getEmailValidatedFromUserCookie = (guuCookie: ?string) => {
     const tokens = guuCookie.split('.');
     try {
       const parsed = JSON.parse(atob(tokens[0]));
-      return !!parsed[7]
+      return !!parsed[7];
     } catch (e) {
       return false;
     }

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.scss
@@ -3,8 +3,6 @@
 @import '~stylesheets/gu-sass/gu-sass';
 @import '~components/progressMessage/progressMessage';
 @import '~components/spinners/animatedDots';
-@import '~components/directDebit/directDebitPopUpForm/directDebitPopUpForm';
-@import '~components/directDebit/directDebitForm/directDebitForm';
 @import '~components/errorMessage/errorMessage';
 @import '~components/ctaLink/ctaLink';
 @import '~components/generalErrorMessage/generalErrorMessage';

--- a/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss
+++ b/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss
@@ -8,8 +8,6 @@
 @import '~components/progressMessage/progressMessage';
 @import '~components/spinners/animatedDots';
 @import '~components/generalErrorMessage/generalErrorMessage';
-@import '~components/directDebit/directDebitPopUpForm/directDebitPopUpForm';
-@import '~components/directDebit/directDebitForm/directDebitForm';
 @import '~components/promotionSummary/promotionSummary';
 
 
@@ -39,7 +37,7 @@
     margin-top: $gu-v-spacing * 2;
     width: auto;
   }
-  
+
   .component-paypal-button-checkout__container {
     margin: 20px 0;
   }

--- a/support-frontend/assets/pages/paper-subscription-checkout/_legacyImports.scss
+++ b/support-frontend/assets/pages/paper-subscription-checkout/_legacyImports.scss
@@ -3,5 +3,3 @@
 @import '~components/productHero/productHero';
 @import '~components/progressMessage/progressMessage';
 @import '~components/generalErrorMessage/generalErrorMessage';
-@import '~components/directDebit/directDebitPopUpForm/directDebitPopUpForm';
-@import '~components/directDebit/directDebitForm/directDebitForm';

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -24,9 +24,6 @@ import { asControlled } from 'hocs/asControlled';
 import Form, { FormSection } from 'components/checkoutForm/checkoutForm';
 import Layout, { Content } from 'components/subscriptionCheckouts/layout';
 import Summary from 'components/subscriptionCheckouts/summary';
-import DirectDebitPopUpForm
-  from 'components/directDebit/directDebitPopUpForm/directDebitPopUpForm';
-import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
 import type { ErrorReason } from 'helpers/errorReasons';
 import {
   getProductPrice,
@@ -296,12 +293,6 @@ function WeeklyCheckoutForm(props: PropTypes) {
           />
           <FormSection noBorder>
             <Button aria-label={null} type="submit">Continue to payment</Button>
-            <DirectDebitPopUpForm
-              buttonText="Subscribe with Direct Debit"
-              onPaymentAuthorisation={(pa: PaymentAuthorisation) => {
-                props.onPaymentAuthorised(pa);
-              }}
-            />
           </FormSection>
           <CancellationSection />
         </Form>


### PR DESCRIPTION
## Why are you doing this?

The Direct Debit form on the Guardian Weekly checkout is missing its styling. To fix this I've changed the DD components to include their own styling rather than relying on the page css to import it for them, then I've removed the page level imports from Paper and Digital Pack.
## Screenshots
**Before**
![Screenshot 2019-07-09 at 11 01 05](https://user-images.githubusercontent.com/181371/60879280-3fe02300-a239-11e9-88c8-0de50bcf5e94.png)
**After**
![Screenshot 2019-07-09 at 11 01 58](https://user-images.githubusercontent.com/181371/60879307-51c1c600-a239-11e9-8849-92410e3de412.png)


