### PR TITLE
GW post deploy test

### DIFF
--- a/support-frontend/assets/components/button/anchorButton.jsx
+++ b/support-frontend/assets/components/button/anchorButton.jsx
@@ -4,14 +4,17 @@
 
 import React from 'react';
 
-import SharedButton, { defaultProps, type SharedButtonPropTypes } from './_sharedButton';
+import SharedButton, {
+  defaultProps,
+  type SharedButtonPropTypes,
+} from './_sharedButton';
 import './button.scss';
 
 // ----- Render ----- //
 
 export type PropTypes = {
   ...SharedButtonPropTypes,
-  'aria-label': ?string,
+  'aria-label'?: ?string,
   href: string,
 };
 
@@ -24,6 +27,7 @@ const AnchorButton = (props: PropTypes) => (
 
 AnchorButton.defaultProps = {
   ...defaultProps,
+  'aria-label': null,
 };
 
 export default AnchorButton;

--- a/support-frontend/assets/components/button/button.jsx
+++ b/support-frontend/assets/components/button/button.jsx
@@ -4,14 +4,17 @@
 
 import React from 'react';
 
-import SharedButton, { defaultProps, type SharedButtonPropTypes } from './_sharedButton';
+import SharedButton, {
+  defaultProps,
+  type SharedButtonPropTypes,
+} from './_sharedButton';
 import './button.scss';
 
 // ----- Render ----- //
 
 type PropTypes = {
   ...SharedButtonPropTypes,
-  'aria-label': ?string,
+  'aria-label'?: ?string,
   type: ?('button' | 'submit'),
   disabled: ?boolean,
 };
@@ -25,6 +28,7 @@ const Button = (props: PropTypes) => (
 
 Button.defaultProps = {
   ...defaultProps,
+  'aria-label': null,
   type: 'button',
   disabled: false,
 };

--- a/support-frontend/assets/components/consentBanner/consentBanner.jsx
+++ b/support-frontend/assets/components/consentBanner/consentBanner.jsx
@@ -2,14 +2,15 @@
 import React from 'react';
 import type { Dispatch } from 'redux';
 import { connect } from 'react-redux';
+import type { ThirdPartyTrackingConsent } from '../../helpers/tracking/thirdPartyTrackingConsent';
 import {
-  OptedIn, Unset,
+  OptedIn,
+  Unset,
 } from '../../helpers/tracking/thirdPartyTrackingConsent';
 import {
   type Action,
   setTrackingConsent,
 } from '../../helpers/page/commonActions';
-import type { ThirdPartyTrackingConsent } from '../../helpers/tracking/thirdPartyTrackingConsent';
 import Roundel from './roundel.svg';
 import Tick from './tick.svg';
 import Button from 'components/button/button';
@@ -59,7 +60,7 @@ function ConsentBanner(props: PropTypes) {
             </p>
           </Text>
           <div className={styles.actions}>
-            <Button aria-label={null} icon={<Tick />} iconSide="left" onClick={props.onAccepted}>
+            <Button icon={<Tick />} iconSide="left" onClick={props.onAccepted}>
               I&#39;m OK with that
             </Button>
             <a

--- a/support-frontend/assets/components/forms/customFields/checkbox.jsx
+++ b/support-frontend/assets/components/forms/customFields/checkbox.jsx
@@ -9,21 +9,26 @@ import './checkbox.scss';
 // ----- Types ----- //
 
 type PropTypes = {
+  id?: string,
   text: Node,
 };
 
 // ----- Component ----- //
 
 function CheckboxInput({
-  text, ...otherProps
+  id, text, ...otherProps
 }: PropTypes) {
   return (
     <label className="component-checkbox">
       <input className="component-checkbox__input" type="checkbox" {...otherProps} />
-      <span className="component-checkbox__text">{text}</span>
+      <span className="component-checkbox__text" id={id}>{text}</span>
       <span className="component-checkbox__tick" />
     </label>
   );
 }
+
+CheckboxInput.defaultProps = {
+  id: null,
+};
 
 export { CheckboxInput };

--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFields.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFields.jsx
@@ -4,7 +4,10 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 
-import { firstError, type FormError } from 'helpers/subscriptionsForms/validation';
+import {
+  firstError,
+  type FormError,
+} from 'helpers/subscriptionsForms/validation';
 
 import { Input } from 'components/forms/input';
 import { Select } from 'components/forms/select';
@@ -31,7 +34,11 @@ import {
 import { canShow } from 'hocs/canShow';
 import type { Option } from 'helpers/types/option';
 import type { IsoCountry } from 'helpers/internationalisation/country';
-import { auStates, caStates, usStates } from 'helpers/internationalisation/country';
+import {
+  auStates,
+  caStates,
+  usStates,
+} from 'helpers/internationalisation/country';
 
 type StatePropTypes<GlobalState> = {|
   ...FormFields,
@@ -155,7 +162,7 @@ class AddressFields<GlobalState> extends Component<PropTypes<GlobalState>> {
           error={firstError('city', props.formErrors)}
         />
         <MaybeSelect
-          id="stateProvince"
+          id={`${scope}-stateProvince`}
           label={props.country === 'CA' ? 'Province/Territory' : 'State'}
           value={props.state}
           setValue={props.setState}
@@ -166,7 +173,7 @@ class AddressFields<GlobalState> extends Component<PropTypes<GlobalState>> {
           {AddressFields.statesForCountry(props.country)}
         </MaybeSelect>
         <MaybeInput
-          id="stateProvince"
+          id={`${scope}-stateProvince`}
           label="State"
           value={props.state}
           setValue={props.setState}

--- a/support-frontend/assets/components/subscriptionCheckouts/address/postcodeFinder.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/postcodeFinder.jsx
@@ -18,8 +18,8 @@ import {
 import { type AddressType } from 'helpers/subscriptionsForms/addressType';
 import { type PostcodeFinderResult } from 'components/subscriptionCheckouts/address/postcodeLookup';
 
-import styles from 'components/subscriptionCheckouts/address/postcodeFinder.module.scss';
-
+import styles
+  from 'components/subscriptionCheckouts/address/postcodeFinder.module.scss';
 
 // Types
 
@@ -52,7 +52,6 @@ const InputWithButton = ({ onClick, isLoading, ...props }) => (
         appearance="greyHollow"
         icon={null}
         onClick={onClick}
-        aria-label={null}
       >
         Find address
       </Button>

--- a/support-frontend/assets/components/subscriptionCheckouts/personalDetails.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/personalDetails.jsx
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import type { FormError } from 'helpers/subscriptionsForms/validation';
 import { firstError } from 'helpers/subscriptionsForms/validation';
 import type { Option } from 'helpers/types/option';
 import { compose } from 'redux';
@@ -7,11 +8,9 @@ import { asControlled } from 'hocs/asControlled';
 import { withError } from 'hocs/withError';
 import { withLabel } from 'hocs/withLabel';
 import { Input } from 'components/forms/input';
-import type { FormError } from 'helpers/subscriptionsForms/validation';
 import Button from 'components/button/button';
 import CheckoutExpander from 'components/checkoutExpander/checkoutExpander';
 import { type FormField } from 'helpers/subscriptionsForms/formFields';
-
 
 export type PropTypes = {
   firstName: string,
@@ -40,7 +39,6 @@ export default function PersonalDetails(props: PropTypes) {
             appearance="greyHollow"
             icon={null}
             type="button"
-            aria-label={null}
             onClick={() => props.signOut()}
           >
             Sign out

--- a/support-frontend/assets/components/subscriptionCheckouts/subscriptionSubmitButtons.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/subscriptionSubmitButtons.jsx
@@ -61,7 +61,6 @@ function SubscriptionSubmitButtons(props: PropTypes) {
       </div>
       <Button
         id="qa-submit-button"
-        aria-label={null}
         type="submit"
         modifierClasses={props.paymentMethod === PayPal ? ['hidden'] : []}
       >

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/checkoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/checkoutForm.jsx
@@ -250,7 +250,6 @@ function CheckoutForm(props: PropTypes) {
           <FormSection noBorder>
             <Button
               id="qa-submit-button"
-              aria-label={null}
               type="submit"
             >
               Continue to payment

--- a/support-frontend/assets/pages/paper-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/hero/hero.jsx
@@ -4,7 +4,11 @@
 
 import React from 'react';
 import GridPicture from 'components/gridPicture/gridPicture';
-import { HeroHanger, HeroWrapper, HeroHeading } from 'components/productPage/productPageHero/productPageHero';
+import ProductPagehero, {
+  HeroHanger,
+  HeroHeading,
+  HeroWrapper,
+} from 'components/productPage/productPageHero/productPageHero';
 import AnchorButton from 'components/button/anchorButton';
 import SvgChevron from 'components/svgs/chevron';
 import GridImage from 'components/gridImage/gridImage';
@@ -13,8 +17,11 @@ import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
 import HeadingBlock from 'components/headingBlock/headingBlock';
 import { GBPCountries } from 'helpers/internationalisation/countryGroup';
 import { getQueryParameter } from 'helpers/url';
-import { flashSaleIsActive, getSaleCopy, showCountdownTimer } from 'helpers/flashSale';
-import ProductPagehero from 'components/productPage/productPageHero/productPageHero';
+import {
+  flashSaleIsActive,
+  getSaleCopy,
+  showCountdownTimer,
+} from 'helpers/flashSale';
 import { getDiscountCopy } from '../hero/discountCopy';
 import './joyOfPrint.scss';
 
@@ -69,7 +76,7 @@ const HeroPicture = () => (
 
 const Footer = () => (
   <HeroHanger>
-    <AnchorButton aria-label={null} onClick={sendTrackingEventsOnClick('options_cta_click', 'Paper', null)} icon={<SvgChevron />} href="#subscribe">See Subscription options</AnchorButton>
+    <AnchorButton onClick={sendTrackingEventsOnClick('options_cta_click', 'Paper', null)} icon={<SvgChevron />} href="#subscribe">See Subscription options</AnchorButton>
   </HeroHanger>
 );
 
@@ -99,7 +106,7 @@ const CampaignHeader = () => (
     overheading="The Guardian newspaper subscriptions"
     heading={getHeading()}
     modifierClasses={['paper-sale']}
-    content={<AnchorButton aria-label={null} onClick={sendTrackingEventsOnClick('options_cta_click', 'Paper', null)} icon={<SvgChevron />} href="#subscribe">See Subscription options</AnchorButton>}
+    content={<AnchorButton onClick={sendTrackingEventsOnClick('options_cta_click', 'Paper', null)} icon={<SvgChevron />} href="#subscribe">See Subscription options</AnchorButton>}
     hasCampaign
   >
     <div className="sale-joy-of-print">

--- a/support-frontend/assets/pages/showcase/components/ctaContribute.jsx
+++ b/support-frontend/assets/pages/showcase/components/ctaContribute.jsx
@@ -40,7 +40,6 @@ export default function CtaContribute() {
           <NarrowContent>
             <AnchorButton
               icon={<ArrowRightStraight />}
-              aria-label={null}
               appearance="secondary"
               href="/contribute"
             >

--- a/support-frontend/assets/pages/showcase/components/ctaSubscribe.jsx
+++ b/support-frontend/assets/pages/showcase/components/ctaSubscribe.jsx
@@ -22,7 +22,7 @@ export default function CtaSubscribe() {
         </p>
       </Text>
       <NarrowContent>
-        <AnchorButton aria-label={null} icon={<ArrowRightStraight />} href="/subscribe">Choose a Subscription</AnchorButton>
+        <AnchorButton icon={<ArrowRightStraight />} href="/subscribe">Choose a Subscription</AnchorButton>
       </NarrowContent>
     </Content>
   );

--- a/support-frontend/assets/pages/showcase/components/otherProduct.jsx
+++ b/support-frontend/assets/pages/showcase/components/otherProduct.jsx
@@ -19,7 +19,6 @@ export default function OtherProduct(props: PropTypes) {
       <Heading size={3} className="product-title">{props.title}</Heading>
       <div>{props.description}</div>
       <AnchorButton
-        aria-label={null}
         icon={<ArrowRightStraight />}
         appearance="greyHollow"
         href={props.destination}

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/thankYou.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/thankYou.jsx
@@ -15,12 +15,21 @@ import Content from 'components/content/content';
 import Text, { LargeParagraph, SansParagraph } from 'components/text/text';
 import { HeroWrapper } from 'components/productPage/productPageHero/productPageHero';
 import HeadingBlock from 'components/headingBlock/headingBlock';
-import { manageSubsUrl, myAccountUrl, homeDeliveryUrl } from 'helpers/externalLinks';
-import typeof MarketingConsent from 'components/subscriptionCheckouts/thankYou/marketingConsentContainer';
-import styles from 'components/subscriptionCheckouts/thankYou/thankYou.module.scss';
+import {
+  homeDeliveryUrl,
+  manageSubsUrl,
+  myAccountUrl,
+} from 'helpers/externalLinks';
+import typeof MarketingConsent
+  from 'components/subscriptionCheckouts/thankYou/marketingConsentContainer';
+import styles
+  from 'components/subscriptionCheckouts/thankYou/thankYou.module.scss';
 import { formatUserDate } from 'helpers/dateConversions';
 
-import { type FormFields, getFormFields } from 'helpers/subscriptionsForms/formFields';
+import {
+  type FormFields,
+  getFormFields,
+} from 'helpers/subscriptionsForms/formFields';
 
 // ----- Types ----- //
 
@@ -51,7 +60,7 @@ function ThankYouContent({
 }: PropTypes) {
   const packageTitle = getPackageTitle(billingPeriod);
   return (
-    <div>
+    <div className="thank-you-stage">
       <HeroWrapper appearance="custom" className={styles.hero}>
         <HeroImage />
         <HeadingBlock

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -231,6 +231,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
                   onChange={() => props.setBillingAddressIsSame(true)}
                 />
                 <RadioInput
+                  inputId="qa-billing-address-different"
                   text="No"
                   name="billingAddressIsSame"
                   checked={props.billingAddressIsSame === false}
@@ -292,7 +293,13 @@ function WeeklyCheckoutForm(props: PropTypes) {
             submissionError={props.submissionError}
           />
           <FormSection noBorder>
-            <Button aria-label={null} type="submit">Continue to payment</Button>
+            <Button
+              id="qa-submit-button"
+              aria-label={null}
+              type="submit"
+            >
+              Continue to payment
+            </Button>
           </FormSection>
           <CancellationSection />
         </Form>

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -296,7 +296,6 @@ function WeeklyCheckoutForm(props: PropTypes) {
           <FormSection noBorder>
             <Button
               id="qa-submit-button"
-              aria-label={null}
               type="submit"
             >
               Continue to payment

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -179,6 +179,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
           </FormSection>
           <FormSection title="Where should we deliver your magazine?">
             <CheckboxInput
+              id="qa-gift-checkbox"
               text="This is a gift"
               checked={props.orderIsAGift}
               onChange={() => props.setGiftStatus(!props.orderIsAGift)}

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.jsx
@@ -8,7 +8,8 @@ import AnchorButton from 'components/button/anchorButton';
 import SvgChevron from 'components/svgs/chevron';
 import GridImage from 'components/gridImage/gridImage';
 import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
-import ProductPagehero from 'components/productPage/productPageHero/productPageHero';
+import ProductPagehero
+  from 'components/productPage/productPageHero/productPageHero';
 
 import './weeklyCampaign.scss';
 
@@ -44,7 +45,7 @@ const DefaultHeader = () => (
       overheading="Guardian Weekly subscriptions"
       heading="Get a clearer, global perspective on the issues that matter, in one magazine."
       modifierClasses={['weekly']}
-      content={<AnchorButton aria-label={null} onClick={sendTrackingEventsOnClick('options_cta_click', 'GuardianWeekly', null)} icon={<SvgChevron />} href="#subscribe">See Subscription options</AnchorButton>}
+      content={<AnchorButton onClick={sendTrackingEventsOnClick('options_cta_click', 'GuardianWeekly', null)} icon={<SvgChevron />} href="#subscribe">See Subscription options</AnchorButton>}
       hasCampaign={false}
     >
       <GridPicture
@@ -79,7 +80,7 @@ const CampaignHeader = () => (
     overheading="Guardian Weekly subscriptions"
     heading="The Guardian's essential news magazine"
     modifierClasses={['weekly-campaign']}
-    content={<AnchorButton aria-label={null} onClick={sendTrackingEventsOnClick('options_cta_click', 'GuardianWeekly', null)} icon={<SvgChevron />} href="#subscribe">See Subscription options</AnchorButton>}
+    content={<AnchorButton onClick={sendTrackingEventsOnClick('options_cta_click', 'GuardianWeekly', null)} icon={<SvgChevron />} href="#subscribe">See Subscription options</AnchorButton>}
     hasCampaign
   >
 

--- a/support-frontend/stories/button.jsx
+++ b/support-frontend/stories/button.jsx
@@ -3,7 +3,7 @@
 import React from 'react';
 
 import { storiesOf } from '@storybook/react';
-import { withKnobs, text, radios } from '@storybook/addon-knobs';
+import { radios, text, withKnobs } from '@storybook/addon-knobs';
 
 import SvgSubscribe from 'components/svgs/subscribe';
 import Button from 'components/button/button';
@@ -25,7 +25,6 @@ const iconSideKnob = () => radios('Icon side', Object.keys(Sides), Object.keys(S
 stories.add('Button button', () => (
   <Button
     appearance={appearanceKnob()}
-    aria-label={null}
     icon={icons[iconsKnob()]}
     iconSide={iconSideKnob()}
   >{text('Label', 'Button label')}
@@ -37,7 +36,6 @@ stories.add('Anchor button', () => (
     href="#"
     onClick={(ev) => { ev.preventDefault(); }}
     appearance={appearanceKnob()}
-    aria-label={null}
     icon={icons[iconsKnob()]}
     iconSide={iconSideKnob()}
   >{text('Label', 'I am a link that looks like a button!')}

--- a/support-frontend/stories/dialog.jsx
+++ b/support-frontend/stories/dialog.jsx
@@ -13,12 +13,10 @@ import { withCenterAlignment } from '../.storybook/decorators/withCenterAlignmen
 import WithState from '../.storybook/util/withState';
 import Menu, { ButtonItem } from 'components/menu/menu';
 
-
 // Teeny helpers
 
 const GreyButton = props => (
   <Button
-    aria-label={null}
     icon={null}
     appearance="greyHollow"
     {...props}

--- a/support-frontend/test/selenium/subscriptions/CheckoutsSpec.scala
+++ b/support-frontend/test/selenium/subscriptions/CheckoutsSpec.scala
@@ -28,22 +28,27 @@ class CheckoutsSpec extends FeatureSpec with GivenWhenThen with BeforeAndAfter w
 
   feature("Digital Pack checkout") {
     scenario("Stripe checkout") {
-      testCheckout("Digital Pack", new DigitalPackCheckout, payWithStripe)
+      testCheckout("Digital Pack", new DigitalPackCheckout, new DigitalPackProductPage, payWithStripe)
     }
   }
 
   feature("Paper checkout") {
     scenario("Direct Debit checkout") {
-      testCheckout("Paper", new PaperCheckout, payWithDirectDebit)
+      testCheckout("Paper", new PaperCheckout, new PaperProductPage, payWithDirectDebit)
     }
   }
 
-  def testCheckout(checkoutName: String, checkoutPage: CheckoutPage, paymentFunction: CheckoutPage => Unit): Unit = {
+  feature("Guardian Weekly checkout") {
+    scenario("Direct Debit checkout") {
+      testCheckout("Guardian Weekly", new GuardianWeeklyCheckout, new WeeklyProductPage, payWithDirectDebit)
+    }
+  }
+
+  def testCheckout(checkoutName: String, checkoutPage: CheckoutPage, productPage: ProductPage, paymentFunction: CheckoutPage => Unit): Unit = {
     val testUser = new TestUser(driverConfig)
 
-    val landingPage = new DigitalPackSubs()
-    Given("that a user goes to the UK landing page")
-    goTo(landingPage)
+    Given("that a user goes to the UK product page")
+    goTo(productPage)
 
     Given(s"that a user goes to the $checkoutName checkout page")
     goTo(checkoutPage)

--- a/support-frontend/test/selenium/subscriptions/ProductPagesSpec.scala
+++ b/support-frontend/test/selenium/subscriptions/ProductPagesSpec.scala
@@ -3,10 +3,10 @@ package selenium.subscriptions
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.{Minute, Seconds, Span}
 import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, FeatureSpec, GivenWhenThen}
-import selenium.subscriptions.pages.{DigitalPackSubs, PaperSubs, ProductPage, SubsLandingPage, WeeklySubs}
+import selenium.subscriptions.pages._
 import selenium.util._
 
-class LandingPagesSpec extends FeatureSpec with GivenWhenThen with BeforeAndAfter with BeforeAndAfterAll with Browser with Eventually {
+class ProductPagesSpec extends FeatureSpec with GivenWhenThen with BeforeAndAfter with BeforeAndAfterAll with Browser with Eventually {
 
   val driverConfig = new DriverConfig
   override implicit val webDriver = driverConfig.webDriver
@@ -22,30 +22,30 @@ class LandingPagesSpec extends FeatureSpec with GivenWhenThen with BeforeAndAfte
 
   override def afterAll(): Unit = { driverConfig.quit() }
 
-  feature("Paper landing page") {
+  feature("Paper product page") {
     scenario("Basic loading") {
-      testPageLoads(new PaperSubs())
+      testPageLoads(new PaperProductPage())
 
     }
   }
 
-  feature("Weekly landing page") {
+  feature("Weekly product page") {
     scenario("Basic loading") {
-      testPageLoads(new WeeklySubs())
+      testPageLoads(new WeeklyProductPage())
 
     }
   }
 
   feature("Subscriptions landing page") {
     scenario("Basic loading") {
-      testPageLoads(new SubsLandingPage())
+      testPageLoads(new SubsLandingPage()())
     }
   }
 
-  feature("Digital Pack landing page") {
+  feature("Digital Pack product page") {
     scenario("Basic loading") {
       val testUser = new TestUser(driverConfig)
-      testPageLoads(new DigitalPackSubs())
+      testPageLoads(new DigitalPackProductPage())
     }
   }
 

--- a/support-frontend/test/selenium/subscriptions/ProductPagesSpec.scala
+++ b/support-frontend/test/selenium/subscriptions/ProductPagesSpec.scala
@@ -38,7 +38,7 @@ class ProductPagesSpec extends FeatureSpec with GivenWhenThen with BeforeAndAfte
 
   feature("Subscriptions landing page") {
     scenario("Basic loading") {
-      testPageLoads(new SubsLandingPage()())
+      testPageLoads(new SubsLandingPage())
     }
   }
 

--- a/support-frontend/test/selenium/subscriptions/pages/DigitalPackProductPage.scala
+++ b/support-frontend/test/selenium/subscriptions/pages/DigitalPackProductPage.scala
@@ -4,14 +4,14 @@ import org.openqa.selenium.WebDriver
 import org.scalatest.selenium.Page
 import selenium.util.{Browser, Config}
 
-class PaperSubs(implicit val webDriver: WebDriver) extends Page with Browser with ProductPage {
+class DigitalPackProductPage(implicit val webDriver: WebDriver) extends Page with Browser with ProductPage {
 
-  val url = s"${Config.supportFrontendUrl}/uk/subscribe/paper"
+  val url = s"${Config.supportFrontendUrl}/uk/subscribe/digital"
 
   private val header = className("component-heading-block")
 
   def pageHasLoaded: Boolean = {
-    pageHasElement(header) && pageHasUrl(s"/uk/subscribe/paper")
+    pageHasElement(header) && pageHasUrl(s"/uk/subscribe/digital")
   }
 
 }

--- a/support-frontend/test/selenium/subscriptions/pages/GuardianWeeklyCheckout.scala
+++ b/support-frontend/test/selenium/subscriptions/pages/GuardianWeeklyCheckout.scala
@@ -1,0 +1,30 @@
+package selenium.subscriptions.pages
+
+import org.openqa.selenium.WebDriver
+import selenium.util.Config
+
+class GuardianWeeklyCheckout(implicit val webDriver: WebDriver) extends CheckoutPage {
+
+  val url = s"${Config.supportFrontendUrl}/subscribe/weekly/checkout"
+
+  private val deliveryLineOne = id("delivery-lineOne")
+  private val deliveryCity = id("delivery-city")
+  private val deliveryPostcode = id("delivery-postcode")
+
+  private val billingLineOne = id("billing-lineOne")
+  private val billingCity = id("billing-city")
+  private val billingPostcode = id("billing-postcode")
+
+  private val billingAddressIsDifferent = id("qa-billing-address-different")
+
+  def fillForm {
+    setValue(deliveryLineOne, "Kings Place")
+    setValue(deliveryCity, "London")
+    setValue(deliveryPostcode, "N19GU")
+    clickOn(billingAddressIsDifferent)
+    setValue(billingLineOne, "My house")
+    setValue(billingCity, "Bristol")
+    setValue(billingPostcode, "BS68QT")
+  }
+
+}

--- a/support-frontend/test/selenium/subscriptions/pages/GuardianWeeklyCheckout.scala
+++ b/support-frontend/test/selenium/subscriptions/pages/GuardianWeeklyCheckout.scala
@@ -10,21 +10,31 @@ class GuardianWeeklyCheckout(implicit val webDriver: WebDriver) extends Checkout
   private val deliveryLineOne = id("delivery-lineOne")
   private val deliveryCity = id("delivery-city")
   private val deliveryPostcode = id("delivery-postcode")
+  private val deliveryCountry = id("delivery-country")
+  private val deliveryState = id("delivery-stateProvince")
 
+  private val giftCheckbox = id("qa-gift-checkbox")
+  private val giftFirstName = id("firstNameGiftRecipient")
+  private val giftLastName = id("lastNameGiftRecipient")
+
+  private val billingAddressIsDifferent = id("qa-billing-address-different")
   private val billingLineOne = id("billing-lineOne")
   private val billingCity = id("billing-city")
   private val billingPostcode = id("billing-postcode")
 
-  private val billingAddressIsDifferent = id("qa-billing-address-different")
-
   def fillForm {
-    setValue(deliveryLineOne, "Kings Place")
-    setValue(deliveryCity, "London")
-    setValue(deliveryPostcode, "N19GU")
+    clickOn(giftCheckbox)
+    setValue(deliveryCountry, "India")
+    setValue(deliveryLineOne, "Red Fort")
+    setValue(deliveryCity, "New Delhi")
+    setValue(deliveryState, "Delhi")
+    setValue(deliveryPostcode, "110006")
+    setValue(giftFirstName, "Gifty")
+    setValue(giftLastName, "McGiftface")
     clickOn(billingAddressIsDifferent)
-    setValue(billingLineOne, "My house")
-    setValue(billingCity, "Bristol")
-    setValue(billingPostcode, "BS68QT")
+    setValue(billingLineOne, "Kings Place")
+    setValue(billingCity, "London")
+    setValue(billingPostcode, "N19GU")
   }
 
 }

--- a/support-frontend/test/selenium/subscriptions/pages/PaperProductPage.scala
+++ b/support-frontend/test/selenium/subscriptions/pages/PaperProductPage.scala
@@ -4,14 +4,14 @@ import org.openqa.selenium.WebDriver
 import org.scalatest.selenium.Page
 import selenium.util.{Browser, Config}
 
-class DigitalPackSubs(implicit val webDriver: WebDriver) extends Page with Browser with ProductPage {
+class PaperProductPage(implicit val webDriver: WebDriver) extends Page with Browser with ProductPage {
 
-  val url = s"${Config.supportFrontendUrl}/uk/subscribe/digital"
+  val url = s"${Config.supportFrontendUrl}/uk/subscribe/paper"
 
   private val header = className("component-heading-block")
-  
+
   def pageHasLoaded: Boolean = {
-    pageHasElement(header) && pageHasUrl(s"/uk/subscribe/digital")
+    pageHasElement(header) && pageHasUrl(s"/uk/subscribe/paper")
   }
 
 }

--- a/support-frontend/test/selenium/subscriptions/pages/WeeklyProductPage.scala
+++ b/support-frontend/test/selenium/subscriptions/pages/WeeklyProductPage.scala
@@ -4,7 +4,7 @@ import org.openqa.selenium.WebDriver
 import org.scalatest.selenium.Page
 import selenium.util.{Browser, Config}
 
-class WeeklySubs(implicit val webDriver: WebDriver) extends Page with Browser with ProductPage {
+class WeeklyProductPage(implicit val webDriver: WebDriver) extends Page with Browser with ProductPage {
 
   val url = s"${Config.supportFrontendUrl}/uk/subscribe/weekly"
 


### PR DESCRIPTION
## Why are you doing this?

Now that the Guardian Weekly checkout is live we want a post deployment test to check that it is working correctly.
I have also standardised the naming of tests related to the product pages as we had a mixture of 'landing page' and 'product page' previously 

[**Trello Card**](https://trello.com/c/8mnN8u2s/2459-add-post-deploy-test-for-guardian-weekly)


