### PR TITLE
Adds tracking for support page CTAs

### DIFF
--- a/support-frontend/assets/components/button/_sharedButton.jsx
+++ b/support-frontend/assets/components/button/_sharedButton.jsx
@@ -39,7 +39,6 @@ type SharedButtonPropTypes = {|
   getRef?: (?Element) => void,
   modifierClasses: string[],
   postDeploymentTestID?: string,
-  onClick?: Function,
 |};
 
 type PropTypes = {
@@ -77,7 +76,6 @@ export const defaultProps = {
   appearance: Object.keys(Appearances)[0],
   iconSide: Object.keys(Sides)[0],
   modifierClasses: [],
-  onClick: null,
 };
 
 SharedButton.defaultProps = { ...defaultProps };

--- a/support-frontend/assets/components/button/_sharedButton.jsx
+++ b/support-frontend/assets/components/button/_sharedButton.jsx
@@ -39,6 +39,7 @@ type SharedButtonPropTypes = {|
   getRef?: (?Element) => void,
   modifierClasses: string[],
   postDeploymentTestID?: string,
+  onClick?: Function,
 |};
 
 type PropTypes = {
@@ -76,6 +77,7 @@ export const defaultProps = {
   appearance: Object.keys(Appearances)[0],
   iconSide: Object.keys(Sides)[0],
   modifierClasses: [],
+  onClick: null,
 };
 
 SharedButton.defaultProps = { ...defaultProps };

--- a/support-frontend/assets/pages/showcase/components/ctaContribute.jsx
+++ b/support-frontend/assets/pages/showcase/components/ctaContribute.jsx
@@ -9,6 +9,7 @@ import ArrowRightStraight from 'components/svgs/arrowRightStraight';
 
 import WithSupport from 'components/svgs/withSupport';
 import OneMillionCircles from 'components/svgs/oneMillionCircles';
+import { sendClickedEvent } from 'helpers/tracking/clickTracking';
 
 export default function CtaContribute() {
   return (
@@ -43,6 +44,7 @@ export default function CtaContribute() {
               aria-label={null}
               appearance="secondary"
               href="/contribute"
+              onClick={() => sendClickedEvent('support_page_cta_contribute')()}
             >
             Make a Contribution
             </AnchorButton>

--- a/support-frontend/assets/pages/showcase/components/ctaSubscribe.jsx
+++ b/support-frontend/assets/pages/showcase/components/ctaSubscribe.jsx
@@ -7,6 +7,7 @@ import Text from 'components/text/text';
 import GridImage from 'components/gridImage/gridImage';
 import AnchorButton from 'components/button/anchorButton';
 import ArrowRightStraight from 'components/svgs/arrowRightStraight';
+import { sendClickedEvent } from 'helpers/tracking/clickTracking';
 
 export default function CtaSubscribe() {
   return (
@@ -22,7 +23,14 @@ export default function CtaSubscribe() {
         </p>
       </Text>
       <NarrowContent>
-        <AnchorButton aria-label={null} icon={<ArrowRightStraight />} href="/subscribe">Choose a Subscription</AnchorButton>
+        <AnchorButton
+          aria-label={null}
+          icon={<ArrowRightStraight />}
+          href="/subscribe"
+          onClick={() => sendClickedEvent('support_header_page_cta_subscribe')()}
+        >
+          Choose a Subscription
+        </AnchorButton>
       </NarrowContent>
     </Content>
   );

--- a/support-frontend/assets/pages/showcase/components/ctaSubscribe.jsx
+++ b/support-frontend/assets/pages/showcase/components/ctaSubscribe.jsx
@@ -27,7 +27,7 @@ export default function CtaSubscribe() {
           aria-label={null}
           icon={<ArrowRightStraight />}
           href="/subscribe"
-          onClick={() => sendClickedEvent('support_header_page_cta_subscribe')()}
+          onClick={() => sendClickedEvent('support_page_cta_subscribe')()}
         >
           Choose a Subscription
         </AnchorButton>


### PR DESCRIPTION
## Why are you doing this?
The aim is to improve visibility of clicks on support page call-to-action buttons.

[**Trello Card**](https://trello.com/c/AZktsdvl/2454-dev-add-ga-tracking-to-subscribe-and-contribute-cta-buttons-in-why-support-page)