### PR TITLE
Explicitly set the billing country

### DIFF
--- a/support-frontend/test/selenium/subscriptions/pages/GuardianWeeklyCheckout.scala
+++ b/support-frontend/test/selenium/subscriptions/pages/GuardianWeeklyCheckout.scala
@@ -21,6 +21,7 @@ class GuardianWeeklyCheckout(implicit val webDriver: WebDriver) extends Checkout
   private val billingLineOne = id("billing-lineOne")
   private val billingCity = id("billing-city")
   private val billingPostcode = id("billing-postcode")
+  private val billingCountry = id("billing-country")
 
   def fillForm {
     clickOn(giftCheckbox)
@@ -32,6 +33,7 @@ class GuardianWeeklyCheckout(implicit val webDriver: WebDriver) extends Checkout
     setValue(giftFirstName, "Gifty")
     setValue(giftLastName, "McGiftface")
     clickOn(billingAddressIsDifferent)
+    setValue(billingCountry, "United Kingdom")
     setValue(billingLineOne, "Kings Place")
     setValue(billingCity, "London")
     setValue(billingPostcode, "N19GU")


### PR DESCRIPTION
Running the Guardian Weekly post deploy test is causing step function failures because the currency is being passed through incorrectly. This _seems_ impossible to do as a normal user but we will keep an eye on it to see if it does occur IRL. 

In the meantime the fix is to set the billing country in the test script.