### PR TITLE
fix help url on GW thank you page

### DIFF
--- a/support-frontend/assets/helpers/externalLinks.js
+++ b/support-frontend/assets/helpers/externalLinks.js
@@ -43,7 +43,7 @@ const subsUrl = `https://subscribe.${getBaseDomain()}`;
 const patronsUrl = 'https://patrons.theguardian.com';
 const profileUrl = `https://profile.${getBaseDomain()}`;
 const manageUrl = `https://manage.${getBaseDomain()}`;
-const homeDeliveryUrl = `${getBaseDomain()}/help/2017/dec/11/help-with-delivery#nav1`;
+const homeDeliveryUrl = `https://www.${getBaseDomain()}/help/2017/dec/11/help-with-delivery#nav1`;
 const defaultIntCmp = 'gdnwb_copts_bundles_landing_default';
 const androidAppUrl = 'https://play.google.com/store/apps/details?id=com.guardian';
 const myAccountUrl = `${profileUrl}/account/edit`;


### PR DESCRIPTION
## Why are you doing this?

At present it goes to a 404 but it should go to https://www.theguardian.com/help/2017/dec/11/help-with-delivery#nav1
