### PR TITLE
Remove the SubscriberKey from email fields

### DIFF
--- a/support-workers/docs/triggered-send-in-exact-target.md
+++ b/support-workers/docs/triggered-send-in-exact-target.md
@@ -61,7 +61,6 @@ The message should have a body similar to the following:
         {
           "To": {
             "Address": "$email",
-            "SubscriberKey": "$email",
             "ContactAttributes": {
               "EmailAddress": "$email",
               "created": "$created",

--- a/support-workers/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
@@ -20,8 +20,7 @@ import com.gu.support.workers._
 //        "Trial period": "14",
 //        "First Name": "first_GOW5hckeqZC86QQx4Rc",
 //        "Last Name": "last_GOW5hckeqZC86QQx4Rc",
-//        "Country": "United Kingdom",
-//        "SubscriberKey": "gow5hckeqzc86qqx4rc@gu.com",
+//        "Country": "United Kingdom"
 //        "Default payment method": "Credit/Debit Card",
 //        "Currency": "£",
 //        "Post Code": "N1 9AG",
@@ -70,7 +69,6 @@ case class DigitalPackEmailFields(
 
   override val fields = List(
     "ZuoraSubscriberId" -> subscriptionNumber,
-    "SubscriberKey" -> user.primaryEmailAddress,
     "EmailAddress" -> user.primaryEmailAddress,
     "Subscription term" -> billingPeriod.noun,
     "Payment amount" -> SubscriptionEmailFieldHelpers.formatPrice(SubscriptionEmailFieldHelpers.firstPayment(paymentSchedule).amount),

--- a/support-workers/src/main/scala/com/gu/emailservices/EmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/EmailFields.scala
@@ -6,7 +6,7 @@ import io.circe.syntax._
 
 // scalastyle:off
 case class EmailPayloadContactAttributes(SubscriberAttributes: Map[String, String])
-case class EmailPayloadTo(Address: String, SubscriberKey: String, ContactAttributes: EmailPayloadContactAttributes)
+case class EmailPayloadTo(Address: String, ContactAttributes: EmailPayloadContactAttributes)
 case class EmailPayload(To: EmailPayloadTo, DataExtensionName: String, SfContactId: Option[String], IdentityUserId: Option[String]) {
   lazy val jsonString: String = this.asJson.toString
 }
@@ -25,7 +25,6 @@ trait EmailFields {
     EmailPayload(
       To = EmailPayloadTo(
         Address = email,
-        SubscriberKey = email,
         ContactAttributes = EmailPayloadContactAttributes(SubscriberAttributes = fields.toMap)
       ),
       DataExtensionName = dataExtensionName,

--- a/support-workers/src/main/scala/com/gu/emailservices/PaperFieldsGenerator.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/PaperFieldsGenerator.scala
@@ -39,7 +39,6 @@ object PaperFieldsGenerator {
 
     val fields = List(
       "ZuoraSubscriberId" -> subscriptionNumber,
-      "SubscriberKey" -> user.primaryEmailAddress,
       "EmailAddress" -> user.primaryEmailAddress,
       "subscriber_id" -> subscriptionNumber,
       "first_name" -> user.firstName,

--- a/support-workers/src/test/scala/com/gu/emailservices/EmailFieldsSpec.scala
+++ b/support-workers/src/test/scala/com/gu/emailservices/EmailFieldsSpec.scala
@@ -1,6 +1,5 @@
 package com.gu.emailservices
 
-import io.circe._
 import io.circe.parser._
 import org.scalatest.{FlatSpec, Matchers}
 
@@ -11,7 +10,6 @@ class EmailFieldsSpec extends FlatSpec with Matchers {
          |{
          |  "To": {
          |    "Address": "email@email.com",
-         |    "SubscriberKey": "email@email.com",
          |    "ContactAttributes": {
          |      "SubscriberAttributes": { "attribute1" : "value1" ,  "attribute2" : "value2" }
          |    }
@@ -26,7 +24,6 @@ class EmailFieldsSpec extends FlatSpec with Matchers {
     val Right(serializedJson) = parse(
       EmailPayload(
       EmailPayloadTo(
-        "email@email.com",
         "email@email.com",
         EmailPayloadContactAttributes(
           Map("attribute1" -> "value1", "attribute2" -> "value2")


### PR DESCRIPTION
## Why are you doing this?
We no longer need to send the SubscriberKey field in the email JSON as this was an ExactTarget thing and now we use Braze, it is not needed.

This PR: https://github.com/guardian/membership-workflow/pull/194 removed it from membership-workflow