### PR TITLE
Do not show recurring message on default thank you page

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
@@ -37,6 +37,7 @@ type PropTypes = {|
   email: string,
   csrf: string,
   emailValidated: boolean,
+  paymentComplete: boolean,
 |};
 /* eslint-enable react/no-unused-prop-types */
 
@@ -48,6 +49,7 @@ const mapStateToProps = state => ({
   email: state.page.form.formData.email,
   csrf: state.page.csrf.token,
   emailValidated: state.page.user.emailValidated,
+  paymentComplete: state.page.form.paymentComplete,
 });
 
 function mapDispatchToProps(dispatch: Dispatch<Action>) {
@@ -170,10 +172,12 @@ function ContributionThankYou(props: PropTypes) {
     return null;
   };
 
+  const showRecurringMessage = props.contributionType !== 'ONE_OFF' && props.paymentComplete;
+
   return (
     <div className="thank-you__container">
       <div className="gu-content__form gu-content__form--thank-you">
-        {props.contributionType !== 'ONE_OFF' ? (
+        {showRecurringMessage ? (
           <section className="contribution-thank-you-block">
             <h3 className="contribution-thank-you-block__title">
               {`${directDebitHeaderSuffix}Look out for an email within three business days confirming your ${getSpokenType(props.contributionType)} recurring payment${directDebitMessageSuffix}`}


### PR DESCRIPTION
## Why are you doing this?
Arriving at the thank you page without the correct state in local storage will cause a recurring payment message to appear. This is because it defaults to monthly. We've had reports of users seeing this and it causes confusion if they've made a one-off contribution.

This change ensures the message is only displayed if `paymentComplete` is true.

[**Trello Card**](https://trello.com/c/b7bxzu6R/1183-ensure-that-the-default-thank-you-page-copy-does-not-reference-contribution-type)


## Screenshots
Default view:
<img width="524" alt="Screenshot 2019-07-11 at 11 56 33" src="https://user-images.githubusercontent.com/1513454/61045574-0511f280-a3d3-11e9-9978-2bc266a37b53.png">


After recurring payment:
<img width="524" alt="Screenshot 2019-07-11 at 11 56 08" src="https://user-images.githubusercontent.com/1513454/61045564-004d3e80-a3d3-11e9-8934-daa3a5ceaaa9.png">

