### PR TITLE
Fix the terms and conditions link for print checkout

### DIFF
--- a/support-frontend/assets/helpers/legal.js
+++ b/support-frontend/assets/helpers/legal.js
@@ -28,7 +28,7 @@ const subscriptionsTermsLinks: {
   PremiumTier: 'https://www.theguardian.com/info/2014/aug/06/guardian-observer-digital-subscriptions-terms-conditions',
   DailyEdition: 'https://www.theguardian.com/info/2014/aug/06/guardian-observer-digital-subscriptions-terms-conditions',
   GuardianWeekly: 'https://www.theguardian.com/info/2014/jul/10/guardian-weekly-print-subscription-services-terms-conditions',
-  Paper: 'https://www.theguardian.com/info/2014/jul/10/guardian-weekly-print-subscription-services-terms-conditions',
+  Paper: 'https://www.theguardian.com/subscriber-direct/subscription-terms-and-conditions',
   PaperAndDigital: 'https://www.theguardian.com/info/2014/jul/10/guardian-weekly-print-subscription-services-terms-conditions',
 };
 


### PR DESCRIPTION
## Why are you doing this?
Because the current print checkout has terms and conditions that apply to GW. This updates the link to the print T&C.

[**Trello Card**](https://trello.com/c/3wn616jG/2444-tc-link-on-print-only-checkout-pointing-to-gw-terms)