### PR TITLE
feat: added cloudformation S3 bucket creation

### DIFF
--- a/support-frontend/cloud-formation/CODE-deploy.sh
+++ b/support-frontend/cloud-formation/CODE-deploy.sh
@@ -1,0 +1,8 @@
+# Run this file to test cloudformation in CODE
+
+aws cloudformation deploy \
+    --profile membership \
+    --stack-name support-CODE-frontend \
+    --template-file cfn.yaml \
+    --region eu-west-1 \
+    --capabilities CAPABILITY_IAM

--- a/support-frontend/cloud-formation/cfn.yaml
+++ b/support-frontend/cloud-formation/cfn.yaml
@@ -30,7 +30,7 @@ Conditions:
   CreateCodeResources: !Equals [!Ref "Stage", "CODE"]
 Mappings:
   StageVariables:
-    CODE:
+    CODE: 
       MaxInstances: 2
       MinInstances: 1
       InstanceType: t3.small
@@ -39,6 +39,7 @@ Mappings:
       DynamoDBTables:
       - arn:aws:dynamodb:*:*:table/MembershipSub-Promotions-DEV
       - arn:aws:dynamodb:*:*:table/MembershipSub-Promotions-UAT
+      BucketSuffix: code
     PROD:
       MaxInstances: 6
       MinInstances: 3
@@ -49,6 +50,7 @@ Mappings:
       DynamoDBTables:
       - arn:aws:dynamodb:*:*:table/MembershipSub-Promotions-PROD
       - arn:aws:dynamodb:*:*:table/MembershipSub-Promotions-UAT
+      BucketSuffix: prod
   Constants:
     Alarm:
       Process: Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit
@@ -503,3 +505,18 @@ Resources:
       TreatMissingData: notBreaching
     DependsOn:
     - StateMachineUnavailableMetric
+
+  S3Bucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      AccessControl: PublicRead
+      BucketName: !Join 
+      - '-'
+      - - !Ref Stack
+        - !FindInMap [ StageVariables, !Ref Stage, BucketSuffix ]
+        - !Ref App
+        - static
+      MetricsConfigurations: 
+        - Id: EntireBucket
+      WebsiteConfiguration:
+        IndexDocument: index.html


### PR DESCRIPTION
## Why are you doing this?
When a deploy is happening, there are new instances coming into service as well as old ones which haven't been killed yet.  The requests are distributed between all healthy instances.
For each build, we serve assets with a different URL.  This is the hash in the URL which is introduced to make sure the cache is busted.  Anyone fetching the newly deployed page would request a fresh copy of the assets on the new url in a separate request.

There is currently a problem when a deploy goes out since the main html request and the assets request could be send to different servers running different versions.  This would result in the server returning a 404 as it doesn't understand that version.  The client would then end up with either a blank page or an unstyled page.

The plan is fix this by serving assets from an S3 bucket.

This would work because the new assets would be copied to the bucket before the new instances were started.  Then, regardless of which instance serves the html, the correct assets could be picked up in the S3 bucket.

[**Trello Card**](https://trello.com/c/gj5ZP5YD/2469-create-an-s3-bucket-to-store-the-support-frontend-assets)

## Changes

* added cloudformation S3 bucket creation to cfn.yaml
* added a deploy test script to test the new cloudformation
