### PR TITLE
Add ophan tracking to why support page and header nav

### DIFF
--- a/support-frontend/assets/components/headers/links/links.jsx
+++ b/support-frontend/assets/components/headers/links/links.jsx
@@ -5,7 +5,7 @@ import { routes } from 'helpers/routes';
 import { getPatronsLink } from 'helpers/externalLinks';
 import { type Option } from 'helpers/types/option';
 import { classNameWithModifiers } from 'helpers/utilities';
-import { clickedEvent } from 'helpers/tracking/clickTracking';
+import { trackComponentClick } from 'helpers/tracking/ophan';
 import { type CountryGroupId, GBPCountries } from 'helpers/internationalisation/countryGroup';
 
 // types
@@ -85,7 +85,7 @@ const Links = ({ location, getRef, countryGroupId }: PropTypes) => (
             }
           >
             <a
-              onClick={() => { clickedEvent(['header-link', trackAs, location].join(' - ')); }}
+              onClick={() => { console.log(['header-link', trackAs, location].join(' - ')); trackComponentClick(['header-link', trackAs, location].join(' - ')); }}
               className="component-header-links__link"
               href={href}
               target={opensInNewWindow ? '_blank' : null}

--- a/support-frontend/assets/components/headers/links/links.jsx
+++ b/support-frontend/assets/components/headers/links/links.jsx
@@ -85,7 +85,7 @@ const Links = ({ location, getRef, countryGroupId }: PropTypes) => (
             }
           >
             <a
-              onClick={() => { console.log(['header-link', trackAs, location].join(' - ')); trackComponentClick(['header-link', trackAs, location].join(' - ')); }}
+              onClick={() => { trackComponentClick(['header-link', trackAs, location].join(' - ')); }}
               className="component-header-links__link"
               href={href}
               target={opensInNewWindow ? '_blank' : null}

--- a/support-frontend/assets/pages/showcase/components/ctaContribute.jsx
+++ b/support-frontend/assets/pages/showcase/components/ctaContribute.jsx
@@ -9,8 +9,9 @@ import ArrowRightStraight from 'components/svgs/arrowRightStraight';
 
 import WithSupport from 'components/svgs/withSupport';
 import OneMillionCircles from 'components/svgs/oneMillionCircles';
+import { trackComponentClick } from 'helpers/tracking/ophan';
 
-export default function CtaContribute(props: { clickHandler: Function }) {
+export default function CtaContribute() {
   return (
     <Content appearance="highlight" modifierClasses={['contribute']}>
       <div className="wrapper">
@@ -42,7 +43,7 @@ export default function CtaContribute(props: { clickHandler: Function }) {
               icon={<ArrowRightStraight />}
               appearance="secondary"
               href="/contribute"
-              onClick={props.clickHandler}
+              onClick={() => trackComponentClick('support-page-cta-contribute')}
             >
             Make a Contribution
             </AnchorButton>

--- a/support-frontend/assets/pages/showcase/components/ctaContribute.jsx
+++ b/support-frontend/assets/pages/showcase/components/ctaContribute.jsx
@@ -9,9 +9,8 @@ import ArrowRightStraight from 'components/svgs/arrowRightStraight';
 
 import WithSupport from 'components/svgs/withSupport';
 import OneMillionCircles from 'components/svgs/oneMillionCircles';
-import { sendClickedEvent } from 'helpers/tracking/clickTracking';
 
-export default function CtaContribute() {
+export default function CtaContribute(props: { clickHandler: Function }) {
   return (
     <Content appearance="highlight" modifierClasses={['contribute']}>
       <div className="wrapper">
@@ -43,7 +42,7 @@ export default function CtaContribute() {
               icon={<ArrowRightStraight />}
               appearance="secondary"
               href="/contribute"
-              onClick={() => sendClickedEvent('support_page_cta_contribute')()}
+              onClick={props.clickHandler}
             >
             Make a Contribution
             </AnchorButton>

--- a/support-frontend/assets/pages/showcase/components/ctaSubscribe.jsx
+++ b/support-frontend/assets/pages/showcase/components/ctaSubscribe.jsx
@@ -7,8 +7,9 @@ import Text from 'components/text/text';
 import GridImage from 'components/gridImage/gridImage';
 import AnchorButton from 'components/button/anchorButton';
 import ArrowRightStraight from 'components/svgs/arrowRightStraight';
+import { trackComponentClick } from 'helpers/tracking/ophan';
 
-export default function CtaSubscribe(props: {clickHandler: Function}) {
+export default function CtaSubscribe() {
   return (
     <Content
       appearance="feature"
@@ -25,7 +26,7 @@ export default function CtaSubscribe(props: {clickHandler: Function}) {
         <AnchorButton
           icon={<ArrowRightStraight />}
           href="/subscribe"
-          onClick={props.clickHandler}
+          onClick={() => trackComponentClick('support-page-cta-subscribe')}
         >
           Choose a Subscription
         </AnchorButton>

--- a/support-frontend/assets/pages/showcase/components/ctaSubscribe.jsx
+++ b/support-frontend/assets/pages/showcase/components/ctaSubscribe.jsx
@@ -7,9 +7,8 @@ import Text from 'components/text/text';
 import GridImage from 'components/gridImage/gridImage';
 import AnchorButton from 'components/button/anchorButton';
 import ArrowRightStraight from 'components/svgs/arrowRightStraight';
-import { sendClickedEvent } from 'helpers/tracking/clickTracking';
 
-export default function CtaSubscribe() {
+export default function CtaSubscribe(props: {clickHandler: Function}) {
   return (
     <Content
       appearance="feature"
@@ -26,7 +25,7 @@ export default function CtaSubscribe() {
         <AnchorButton
           icon={<ArrowRightStraight />}
           href="/subscribe"
-          onClick={() => sendClickedEvent('support_page_cta_subscribe')()}
+          onClick={props.clickHandler}
         >
           Choose a Subscription
         </AnchorButton>

--- a/support-frontend/assets/pages/showcase/showcase.jsx
+++ b/support-frontend/assets/pages/showcase/showcase.jsx
@@ -26,15 +26,6 @@ import ConsentBanner from 'components/consentBanner/consentBanner';
 
 import './showcase.scss';
 import { Provider } from 'react-redux';
-import { sendClickedEvent } from 'helpers/tracking/clickTracking';
-import { trackComponentClick } from 'helpers/tracking/ophan';
-
-// ----- Tracking ----- //
-
-const clickHandler = (ctaType) => {
-  sendClickedEvent(`support_page_cta_${ctaType}`)();
-  trackComponentClick(`support-page-cta-${ctaType}`);
-};
 
 // ----- Page Startup ----- //
 
@@ -54,8 +45,8 @@ const content = (
           Ways you can support The Guardian
         </Heading>
       </Content>
-      <CtaSubscribe clickHandler={() => clickHandler('subscribe')} />
-      <CtaContribute clickHandler={() => clickHandler('contribute')} />
+      <CtaSubscribe />
+      <CtaContribute />
       <OtherProducts />
       <ConsentBanner />
     </Page>

--- a/support-frontend/assets/pages/showcase/showcase.jsx
+++ b/support-frontend/assets/pages/showcase/showcase.jsx
@@ -26,6 +26,15 @@ import ConsentBanner from 'components/consentBanner/consentBanner';
 
 import './showcase.scss';
 import { Provider } from 'react-redux';
+import { sendClickedEvent } from 'helpers/tracking/clickTracking';
+import { trackComponentClick } from 'helpers/tracking/ophan';
+
+// ----- Tracking ----- //
+
+const clickHandler = (ctaType) => {
+  sendClickedEvent(`support_page_cta_${ctaType}`)();
+  trackComponentClick(`support-page-cta-${ctaType}`);
+};
 
 // ----- Page Startup ----- //
 
@@ -45,8 +54,8 @@ const content = (
           Ways you can support The Guardian
         </Heading>
       </Content>
-      <CtaSubscribe />
-      <CtaContribute />
+      <CtaSubscribe clickHandler={() => clickHandler('subscribe')} />
+      <CtaContribute clickHandler={() => clickHandler('contribute')} />
       <OtherProducts />
       <ConsentBanner />
     </Page>


### PR DESCRIPTION
## Why are you doing this?
To make sure that we have GA tracking and Ophan data collection set up for the why support page CTAs and also for the support header navbar.

[**Trello Card**](https://trello.com/c/FjJI3VaI/2455-tracking-audit-implement-tags-to-allow-reporting-from-datalake)