### PR TITLE
ignore assets file in the root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ support-frontend/public/compiled-assets/
 support-frontend/tools/
 tools/
 
+conf/assets.map
 assets/images/inline-svgs/*.svg
 /assets/images/svg-sprite.svg
 /public/compiled-assets/


### PR DESCRIPTION
## Why are you doing this?

When I do a "yarn build-prod" I always get a file that should proably be ignored.
`/conf/assets.map`

it contains this:
```json
{
  "main.css": "stylesheets/main.css",
  "main.js": "main.3ca69c0ccd35ca697315.bundle.js",
  "runtime~main.js": "runtime~main.3ca69c0ccd35ca697315.bundle.js",
  "vendors~main.js": "vendors~main.3ca69c0ccd35ca697315.bundle.js",
  "3.3ca69c0ccd35ca697315.bundle.js": "3.3ca69c0ccd35ca697315.bundle.js",
  "iframe.html": "iframe.html",
  "stats.json": "stats.json"
}
```
