### PR TITLE
Post-deploy tests: check that Stripe popup and PayPal page appear (contributions)

### DIFF
--- a/support-frontend/test/selenium/contributions/RecurringContributionsSpec.scala
+++ b/support-frontend/test/selenium/contributions/RecurringContributionsSpec.scala
@@ -26,7 +26,7 @@ class RecurringContributionsSpec extends FeatureSpec with GivenWhenThen with Bef
 
     scenario("Monthly contribution sign-up with Stripe - GBP") {
 
-      val testUser = new TestUser(driverConfig)
+      val testUser = new PostDeployTestUser(driverConfig)
       val landingPage = ContributionsLanding("uk", testUser)
 
       val contributionThankYou = new ContributionThankYou("uk")
@@ -39,7 +39,7 @@ class RecurringContributionsSpec extends FeatureSpec with GivenWhenThen with Bef
       landingPage.clickMonthly
 
       Given("The user fills in their details correctly")
-      landingPage.clearForm()
+      landingPage.clearForm(hasNameFields = true)
       landingPage.fillInPersonalDetails(hasNameFields = true)
 
       Given("that the user selects to pay with Stripe")
@@ -60,7 +60,7 @@ class RecurringContributionsSpec extends FeatureSpec with GivenWhenThen with Bef
 
     scenario("Annual contribution sign-up with Stripe - USD") {
 
-      val testUser = new TestUser(driverConfig)
+      val testUser = new PostDeployTestUser(driverConfig)
       val landingPage = ContributionsLanding("us", testUser)
       val contributionThankYou = new ContributionThankYou("us")
 
@@ -72,7 +72,7 @@ class RecurringContributionsSpec extends FeatureSpec with GivenWhenThen with Bef
       landingPage.clickAnnual
 
       Given("The user fills in their details correctly")
-      landingPage.clearForm()
+      landingPage.clearForm(hasNameFields = true)
       landingPage.fillInPersonalDetails(hasNameFields = true)
       landingPage.selectState
 

--- a/support-frontend/test/selenium/contributions/pages/ContributionsLanding.scala
+++ b/support-frontend/test/selenium/contributions/pages/ContributionsLanding.scala
@@ -24,6 +24,8 @@ case class ContributionsLanding(region: String, testUser: TestUser)(implicit val
   private val payPalSelector = cssSelector(".form__radio-group-label[for='paymentMethodSelector-PayPal']")
   private val stateSelector = id("contributionState")
 
+  private val stripeOverlayIframe = cssSelector(".stripe_checkout_app")
+
   private object RegisterFields {
     private val firstName = id("contributionFirstName")
     private val lastName = id("contributionLastName")
@@ -38,20 +40,24 @@ case class ContributionsLanding(region: String, testUser: TestUser)(implicit val
       }
     }
 
-    def clear(): Unit = {
+    def clear(hasNameFields: Boolean): Unit = {
       clearValue(email)
-      clearValue(firstName)
-      clearValue(lastName)
+      if (hasNameFields) {
+        clearValue(firstName)
+        clearValue(lastName)
+      }
     }
   }
 
   def fillInPersonalDetails(hasNameFields: Boolean) { RegisterFields.fillIn(hasNameFields) }
 
-  def clearForm(): Unit = RegisterFields.clear()
+  def clearForm(hasNameFields: Boolean): Unit = RegisterFields.clear(hasNameFields)
 
   def selectState: Unit = setSingleSelectionValue(stateSelector, "NY")
 
   def selectStripePayment(): Unit = clickOn(stripeSelector)
+
+  def selectPayPalPayment(): Unit = clickOn(payPalSelector)
 
   def pageHasLoaded: Boolean = {
     pageHasElement(contributeButton)
@@ -67,5 +73,10 @@ case class ContributionsLanding(region: String, testUser: TestUser)(implicit val
   def clickOtherAmount: Unit = clickOn(otherAmountButton)
 
   def enterAmount(amount: Double): Unit = setValueSlowly(otherAmount, amount.toString)
+
+  def hasStripeOverlay: Boolean = {
+    Thread.sleep(500)
+    pageHasElement(stripeOverlayIframe)
+  }
 
 }

--- a/support-frontend/test/selenium/subscriptions/CheckoutsSpec.scala
+++ b/support-frontend/test/selenium/subscriptions/CheckoutsSpec.scala
@@ -45,7 +45,7 @@ class CheckoutsSpec extends FeatureSpec with GivenWhenThen with BeforeAndAfter w
   }
 
   def testCheckout(checkoutName: String, checkoutPage: CheckoutPage, productPage: ProductPage, paymentFunction: CheckoutPage => Unit): Unit = {
-    val testUser = new TestUser(driverConfig)
+    val testUser = new PostDeployTestUser(driverConfig)
 
     Given("that a user goes to the UK product page")
     goTo(productPage)

--- a/support-frontend/test/selenium/subscriptions/ProductPagesSpec.scala
+++ b/support-frontend/test/selenium/subscriptions/ProductPagesSpec.scala
@@ -44,7 +44,7 @@ class ProductPagesSpec extends FeatureSpec with GivenWhenThen with BeforeAndAfte
 
   feature("Digital Pack product page") {
     scenario("Basic loading") {
-      val testUser = new TestUser(driverConfig)
+      val testUser = new PostDeployTestUser(driverConfig)
       testPageLoads(new DigitalPackProductPage())
     }
   }

--- a/support-frontend/test/selenium/subscriptions/pages/Register.scala
+++ b/support-frontend/test/selenium/subscriptions/pages/Register.scala
@@ -4,9 +4,9 @@ import org.scalatest.selenium.Page
 import java.net.URLEncoder
 
 import org.openqa.selenium.WebDriver
-import selenium.util.{Browser, Config, TestUser}
+import selenium.util.{Browser, Config, PostDeployTestUser}
 
-case class Register(testUser: TestUser, checkoutType: String)(implicit val webDriver: WebDriver) extends Page with Browser {
+case class Register(testUser: PostDeployTestUser, checkoutType: String)(implicit val webDriver: WebDriver) extends Page with Browser {
   private val returnUrlParam = URLEncoder.encode(s"${Config.supportFrontendUrl}/subscribe/$checkoutType/checkout", "UTF-8")
   val url = s"${Config.identityFrontendUrl}/register?returnUrl=$returnUrlParam&skipConfirmation=true&skipValidationReturn=true&clientId=subscriptions"
 

--- a/support-frontend/test/selenium/util/PostDeployTestUser.scala
+++ b/support-frontend/test/selenium/util/PostDeployTestUser.scala
@@ -4,7 +4,11 @@ import java.time.Duration.ofDays
 
 import com.gu.identity.testing.usernames.TestUsernames
 
-class TestUser(driverConfig: DriverConfig) {
+trait TestUser {
+  val username: String
+}
+
+class PostDeployTestUser(driverConfig: DriverConfig) extends TestUser {
 
   private val testUsers = TestUsernames(
     com.gu.identity.testing.usernames.Encoder.withSecret(Config.testUsersSecret),


### PR DESCRIPTION
## Why are you doing this?
The current post-deployment tests bypass the 3rd party payment inputs.
But we should be verifying that stripe + paypal actually appear when you hit the contribute button.

In the past we've found writing selenium tests for the 3rd party checkout flows unreliable as we do not control the code, so these new tests just check that the stripe popup + paypal page appear.

[**Trello Card**](https://trello.com/c/1SYbMnNz/1124-make-post-deployment-test-click-on-paypal-direct-debit-buttons-confirm-at-least-that-popup-appears)
