### PR TITLE
Fix problem with incorrect currency on GW checkout

### DIFF
--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.js
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.js
@@ -109,7 +109,7 @@ const applyAddressRules = (fields: FormFields): FormError<FormField>[] => valida
 // ----- Action Creators ----- //
 
 const addressActionCreatorsFor = (scope: AddressType) => ({
-  setCountry: (countryRaw: string) => (dispatch: Dispatch<Action | CommonAction>) => {
+  setCountry: (countryRaw: string) => (dispatch: Dispatch<{ type: 'SET_COUNTRY_CHANGED', country: IsoCountry, ...Scoped<AddressType> } | CommonAction>) => {
     const country = fromString(countryRaw);
     if (country) {
       dispatch(setCountry(country));

--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.js
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.js
@@ -4,7 +4,7 @@
 import { combineReducers, type Dispatch } from 'redux';
 
 import { fromString, type IsoCountry } from 'helpers/internationalisation/country';
-import { type Action as CommonAction, setCountry } from 'helpers/page/commonActions';
+import { type SetCountryAction, setCountry } from 'helpers/page/commonActions';
 import {
   formError,
   type FormError,
@@ -42,12 +42,14 @@ export type State = {|
   postcode: PostcodeFinderState
 |};
 
+export type SetCountryChangedAction = { type: 'SET_COUNTRY_CHANGED', country: IsoCountry, ...Scoped<AddressType> };
+
 export type Action =
   | { type: 'SET_ADDRESS_LINE_1', lineOne: string, ...Scoped<AddressType> }
   | { type: 'SET_ADDRESS_LINE_2', lineTwo: string, ...Scoped<AddressType> }
   | { type: 'SET_TOWN_CITY', city: string, ...Scoped<AddressType> }
   | { type: 'SET_STATE', state: string, ...Scoped<AddressType> }
-  | { type: 'SET_COUNTRY_CHANGED', country: IsoCountry, ...Scoped<AddressType> }
+  | SetCountryChangedAction
   | { type: 'SET_ADDRESS_FORM_ERRORS', errors: FormError<FormField>[], ...Scoped<AddressType> }
   | { type: 'SET_POSTCODE', postCode: string, ...Scoped<AddressType> };
 
@@ -109,7 +111,7 @@ const applyAddressRules = (fields: FormFields): FormError<FormField>[] => valida
 // ----- Action Creators ----- //
 
 const addressActionCreatorsFor = (scope: AddressType) => ({
-  setCountry: (countryRaw: string) => (dispatch: Dispatch<{ type: 'SET_COUNTRY_CHANGED', country: IsoCountry, ...Scoped<AddressType> } | CommonAction>) => {
+  setCountry: (countryRaw: string) => (dispatch: Dispatch<SetCountryChangedAction | SetCountryAction>) => {
     const country = fromString(countryRaw);
     if (country) {
       dispatch(setCountry(country));

--- a/support-frontend/assets/helpers/page/commonActions.js
+++ b/support-frontend/assets/helpers/page/commonActions.js
@@ -14,8 +14,10 @@ import {
 
 // ----- Types ----- //
 
+export type SetCountryAction = { type: 'SET_COUNTRY', country: IsoCountry };
+
 export type Action =
-  | { type: 'SET_COUNTRY', country: IsoCountry }
+  | SetCountryAction
   | { type: 'SET_OPTIMIZE_EXPERIMENT_VARIANT', experiment: OptimizeExperiment }
   | { type: 'SET_EXISTING_PAYMENT_METHODS', existingPaymentMethods: ExistingPaymentMethod[] }
   | { type: 'SET_TRACKING_CONSENT', trackingConsent: ThirdPartyTrackingConsent }
@@ -24,7 +26,7 @@ export type Action =
 
 // ----- Action Creators ----- //
 
-function setCountry(country: IsoCountry): Action {
+function setCountry(country: IsoCountry): SetCountryAction {
   return { type: 'SET_COUNTRY', country };
 }
 

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -127,7 +127,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
   const price = getProductPrice(props.productPrices, props.billingCountry, props.billingPeriod, fulfilmentOption);
   const subscriptionStart = `When would you like ${props.orderIsAGift ? 'the' : 'your'} subscription to start?`;
 
-  const changeHandler = () => {
+  const setBillingAddressIsSameHandler = () => {
     props.setBillingAddressIsSame(true);
     props.setBillingCountry(props.deliveryCountry);
   };
@@ -240,7 +240,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
                   text="Yes"
                   name="billingAddressIsSame"
                   checked={props.billingAddressIsSame === true}
-                  onChange={() => changeHandler()}
+                  onChange={setBillingAddressIsSameHandler}
                 />
                 <RadioInput
                   inputId="qa-billing-address-different"

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -65,6 +65,7 @@ import { routes } from 'helpers/routes';
 import { BillingPeriodSelector } from 'components/subscriptionCheckouts/billingPeriodSelector';
 import { getWeeklyFulfilmentOption } from 'helpers/productPrice/fulfilmentOptions';
 import { CheckboxInput } from 'components/forms/customFields/checkbox';
+import { addressActionCreatorsFor } from '../../../components/subscriptionCheckouts/address/addressFieldsStore';
 
 // ----- Types ----- //
 
@@ -78,6 +79,7 @@ type PropTypes = {|
   productPrices: ProductPrices,
   ...FormActionCreators,
   submitForm: Function,
+  setBillingCountry: Function,
 |};
 
 
@@ -97,11 +99,13 @@ function mapStateToProps(state: WithDeliveryCheckoutState) {
 }
 
 function mapDispatchToProps() {
+  const { setCountry } = addressActionCreatorsFor('billing');
   return {
     ...formActionCreators,
     submitForm: () => (dispatch: Dispatch<Action>, getState: () => WithDeliveryCheckoutState) =>
       submitWithDeliveryForm(dispatch, getState()),
     signOut,
+    setBillingCountry: country => (dispatch: Dispatch<{ type: 'SET_COUNTRY_CHANGED', country: IsoCountry, ...Scoped<AddressType> }>) => setCountry(country)(dispatch),
   };
 }
 
@@ -120,6 +124,11 @@ function WeeklyCheckoutForm(props: PropTypes) {
   const fulfilmentOption = getWeeklyFulfilmentOption(props.deliveryCountry);
   const price = getProductPrice(props.productPrices, props.billingCountry, props.billingPeriod, fulfilmentOption);
   const subscriptionStart = `When would you like ${props.orderIsAGift ? 'the' : 'your'} subscription to start?`;
+
+  const changeHandler = () => {
+    props.setBillingAddressIsSame(true);
+    props.setBillingCountry(props.deliveryCountry);
+  };
 
   return (
     <Content modifierClasses={['your-details']}>
@@ -229,7 +238,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
                   text="Yes"
                   name="billingAddressIsSame"
                   checked={props.billingAddressIsSame === true}
-                  onChange={() => props.setBillingAddressIsSame(true)}
+                  onChange={() => changeHandler()}
                 />
                 <RadioInput
                   inputId="qa-billing-address-different"

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -65,7 +65,8 @@ import { routes } from 'helpers/routes';
 import { BillingPeriodSelector } from 'components/subscriptionCheckouts/billingPeriodSelector';
 import { getWeeklyFulfilmentOption } from 'helpers/productPrice/fulfilmentOptions';
 import { CheckboxInput } from 'components/forms/customFields/checkbox';
-import { addressActionCreatorsFor } from '../../../components/subscriptionCheckouts/address/addressFieldsStore';
+import { addressActionCreatorsFor, type SetCountryChangedAction } from 'components/subscriptionCheckouts/address/addressFieldsStore';
+import { type SetCountryAction } from 'helpers/page/commonActions';
 
 // ----- Types ----- //
 
@@ -105,7 +106,8 @@ function mapDispatchToProps() {
     submitForm: () => (dispatch: Dispatch<Action>, getState: () => WithDeliveryCheckoutState) =>
       submitWithDeliveryForm(dispatch, getState()),
     signOut,
-    setBillingCountry: country => (dispatch: Dispatch<{ type: 'SET_COUNTRY_CHANGED', country: IsoCountry, ...Scoped<AddressType> }>) => setCountry(country)(dispatch),
+    setBillingCountry: country => (dispatch: Dispatch<SetCountryChangedAction | SetCountryAction>) =>
+      setCountry(country)(dispatch),
   };
 }
 


### PR DESCRIPTION
## Why are you doing this?
We have found a bug in the GW checkout:
- go to the subscription page with a non-AU/NZ region selected
- enter a delivery address in AU or NZ
- change the Is the billing address same as delivery to "Yes"
- Press the Buy button
- After entering the card details, the checkout will fail with an error in the step function because it uses the wrong Stripe key to obtain a token.

[**Trello Card**](https://trello.com/c/VyjhhAyX/2480-aud-gw-bug)

