### PR TITLE
Landing page copy test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -1,10 +1,29 @@
 // @flow
 import type { Tests } from './abtest';
 
+export type LandingPageCopyAllContributionsTestVariants = 'control' | 'allContributions' | 'notintest';
 // ----- Tests ----- //
 
-
 export const tests: Tests = {
-
+  landingPageCopyAllContributions: {
+    type: 'OTHER',
+    variants: [
+      {
+        id: 'control',
+      },
+      {
+        id: 'allContributions',
+      },
+    ],
+    audiences: {
+      ALL: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: true,
+    independent: true,
+    seed: 1,
+  },
 };
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.jsx
@@ -12,8 +12,8 @@ import ContributionTicker from 'components/ticker/contributionTicker';
 import { campaigns, getCampaignName } from 'helpers/campaigns';
 import { type State } from '../contributionsLandingReducer';
 import { ContributionForm, EmptyContributionForm } from './ContributionForm';
-
 import { onThirdPartyPaymentAuthorised, paymentWaiting, setTickerGoalReached } from '../contributionsLandingActions';
+import type { LandingPageCopyAllContributionsTestVariants } from 'helpers/abTests/abtestDefinitions';
 
 // ----- Types ----- //
 /* eslint-disable react/no-unused-prop-types */
@@ -26,6 +26,7 @@ type PropTypes = {|
   setTickerGoalReached: () => void,
   tickerGoalReached: boolean,
   campaignCodeParameter: ?string,
+  landingPageCopyAllContributionsTestVariant: LandingPageCopyAllContributionsTestVariants,
 |};
 
 /* eslint-enable react/no-unused-prop-types */
@@ -34,6 +35,7 @@ const mapStateToProps = (state: State) => ({
   paymentComplete: state.page.form.paymentComplete,
   countryGroupId: state.common.internationalisation.countryGroupId,
   tickerGoalReached: state.page.form.tickerGoalReached,
+  landingPageCopyAllContributionsTestVariant: state.common.abParticipations.landingPageCopyAllContributions,
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -64,9 +66,29 @@ const defaultContributeCopy = (
     <span className="gu-content__blurb-blurb-last-sentence"> Your support is critical for the future of Guardian journalism.</span>
   </span>);
 
+// JTL: This const (variantContributeCopy) is part of a hardcoded test for landing page copy:
+// To be removed on completion of the test. The default copy (above) should be replaced by this
+// copy object if the variant (below copy) is successful.
+const variantContributeCopy = (
+  <span>
+    The Guardian is editorially independent, meaning we set our own agenda. Our journalism is free from commercial
+    bias and not influenced by billionaire owners, politicians or shareholders. No one edits our editor. No one
+    steers our opinion. This is important as it enables us to give a voice to those less heard, challenge the
+    powerful and hold them to account. It’s what makes us different to so many others in the media, at a time when
+    factual, honest reporting is crucial.
+    <span className="gu-content__blurb-blurb-last-sentence"> Every contribution from our readers, big or small is is critical for the future of Guardian journalism.</span>
+  </span>);
+
 const defaultHeaderCopyAndContributeCopy: CountryMetaData = {
   headerCopy: defaultHeaderCopy,
   contributeCopy: defaultContributeCopy,
+};
+
+// JTL: This const (variantHeaderCopyAndContributeCopy) is part of a hardcoded test for landing page copy.
+// To be removed on completion of the test:
+const variantHeaderCopyAndContributeCopy: CountryMetaData = {
+  headerCopy: defaultHeaderCopy,
+  contributeCopy: variantContributeCopy,
 };
 
 const countryGroupSpecificDetails: {
@@ -84,6 +106,23 @@ const countryGroupSpecificDetails: {
   Canada: defaultHeaderCopyAndContributeCopy,
 };
 
+// JTL: This const (countryGroupSpecificDetailsForVariant) is part of a hardcoded test for landing page copy.
+// To be removed on completion of the test:
+const variantCountryGroupSpecificDetails: {
+  [CountryGroupId]: CountryMetaData
+} = {
+  GBPCountries: variantHeaderCopyAndContributeCopy,
+  EURCountries: variantHeaderCopyAndContributeCopy,
+  UnitedStates: variantHeaderCopyAndContributeCopy,
+  AUDCountries: {
+    ...variantHeaderCopyAndContributeCopy,
+    headerCopy: 'Help\xa0us\xa0deliver\nthe\xa0independent\njournalism\nAustralia\xa0needs',
+  },
+  International: variantHeaderCopyAndContributeCopy,
+  NZDCountries: variantHeaderCopyAndContributeCopy,
+  Canada: variantHeaderCopyAndContributeCopy,
+};
+
 const campaignName = getCampaignName();
 const campaign = campaignName && campaigns[campaignName] ? campaigns[campaignName] : null;
 
@@ -96,8 +135,12 @@ function withProps(props: PropTypes) {
     props.onThirdPartyPaymentAuthorised(paymentAuthorisation);
   };
 
+  // JTL: This const (countryGroupSpecificDetailsForVariant) is part of a hardcoded test for landing page copy.
+  // To be removed and refactored into countryGroupDetails object on completion of the test:
+  const landingPageCopy = props.landingPageCopyAllContributionsTestVariant === 'allContributions' ? variantCountryGroupSpecificDetails[props.countryGroupId] : countryGroupSpecificDetails[props.countryGroupId];
+
   const countryGroupDetails = {
-    ...countryGroupSpecificDetails[props.countryGroupId],
+    ...landingPageCopy,
     ...campaign || {},
   };
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.jsx
@@ -76,7 +76,7 @@ const variantContributeCopy = (
     steers our opinion. This is important as it enables us to give a voice to those less heard, challenge the
     powerful and hold them to account. It’s what makes us different to so many others in the media, at a time when
     factual, honest reporting is crucial.
-    <span className="gu-content__blurb-blurb-last-sentence"> Every contribution from our readers, big or small is is critical for the future of Guardian journalism.</span>
+    <span className="gu-content__blurb-blurb-last-sentence"> Every contribution from our readers, big or small is critical for the future of Guardian journalism.</span>
   </span>);
 
 const defaultHeaderCopyAndContributeCopy: CountryMetaData = {

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.jsx
@@ -71,12 +71,10 @@ const defaultContributeCopy = (
 // copy object if the variant (below copy) is successful.
 const variantContributeCopy = (
   <span>
-    The Guardian is editorially independent, meaning we set our own agenda. Our journalism is free from commercial
-    bias and not influenced by billionaire owners, politicians or shareholders. No one edits our editor. No one
-    steers our opinion. This is important as it enables us to give a voice to those less heard, challenge the
-    powerful and hold them to account. It’s what makes us different to so many others in the media, at a time when
-    factual, honest reporting is crucial.
-    <span className="gu-content__blurb-blurb-last-sentence"> Every contribution from our readers, big or small is critical for the future of Guardian journalism.</span>
+    Readers from around the world, like you, make The&nbsp;Guardian’s work possible. We need your support to deliver
+    quality, investigative journalism – and to keep it open for everyone. At a time when factual, honest reporting
+    is critical, your support is essential in protecting our editorial independence.
+    <span className="gu-content__blurb-blurb-last-sentence"> Every reader contribution, however big or small, is so valuable.</span>
   </span>);
 
 const defaultHeaderCopyAndContributeCopy: CountryMetaData = {


### PR DESCRIPTION
## Why are you doing this?
We want to test the performance (on singles and AV) of reminding people that giving small donations is appreciated and welcome

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/Ieir5ArE/1206-test-adding-line-all-contributions-big-and-small-on-landing-page)

## Changes

* Defined abtest
* Integrated into contributions landing page

## Screenshots
Control and 'Not in Test':
![landing page control](https://user-images.githubusercontent.com/3300789/61358516-5ce8a780-a872-11e9-8ef7-eab83c4d009c.png)

Variant (named 'allContributions'):
<img width="1114" alt="landing page test variant" src="https://user-images.githubusercontent.com/3300789/61379775-16aa3d00-a8a0-11e9-9738-e7b6b3e66866.png">