### PR TITLE
Stop two separate Ophan pageviews being fired per page load

### DIFF
--- a/support-frontend/assets/helpers/page/page.js
+++ b/support-frontend/assets/helpers/page/page.js
@@ -4,26 +4,47 @@
 
 import 'ophan';
 import type { Store } from 'redux';
-import { applyMiddleware, combineReducers, compose, createStore, type Reducer } from 'redux';
+import {
+  applyMiddleware,
+  combineReducers,
+  compose,
+  createStore,
+  type Reducer,
+} from 'redux';
 import thunkMiddleware from 'redux-thunk';
 
 import type { Participations } from 'helpers/abTests/abtest';
-import { renderError } from 'helpers/render';
 import * as abTest from 'helpers/abTests/abtest';
+import { renderError } from 'helpers/render';
 import { overrideAmountsForParticipations } from 'helpers/abTests/helpers';
 import type { Settings } from 'helpers/settings';
 import * as logger from 'helpers/logger';
 import * as googleTagManager from 'helpers/tracking/googleTagManager';
-import { detect as detectCountry, type IsoCountry } from 'helpers/internationalisation/country';
-import { detect as detectCurrency, type IsoCurrency } from 'helpers/internationalisation/currency';
+import {
+  detect as detectCountry,
+  type IsoCountry,
+} from 'helpers/internationalisation/country';
+import {
+  detect as detectCurrency,
+  type IsoCurrency,
+} from 'helpers/internationalisation/currency';
 import { getAllQueryParamsWithExclusions } from 'helpers/url';
 import type { CommonState } from 'helpers/page/commonReducer';
 import { createCommonReducer } from 'helpers/page/commonReducer';
-import { getCampaign, getReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
-import { type CountryGroupId, detect as detectCountryGroup } from 'helpers/internationalisation/countryGroup';
-import { addOptimizeExperiments, readExperimentsFromSession } from 'helpers/optimize/optimize';
-import storeReferrer from 'helpers/tracking/awin';
+import {
+  getCampaign,
+  getReferrerAcquisitionData,
+} from 'helpers/tracking/acquisitions';
+import {
+  type CountryGroupId,
+  detect as detectCountryGroup,
+} from 'helpers/internationalisation/countryGroup';
 import type { OptimizeExperiment } from 'helpers/optimize/optimize';
+import {
+  addOptimizeExperiments,
+  readExperimentsFromSession,
+} from 'helpers/optimize/optimize';
+import storeReferrer from 'helpers/tracking/awin';
 import { setExperimentVariant } from 'helpers/page/commonActions';
 import {
   trackAbTests,
@@ -31,6 +52,7 @@ import {
 } from 'helpers/tracking/ophan';
 import { getTrackingConsent } from '../tracking/thirdPartyTrackingConsent';
 import { getSettings } from 'helpers/globals';
+import doNotTrack from 'helpers/tracking/doNotTrack';
 
 if (process.env.NODE_ENV === 'DEV') {
   import('preact/devtools');
@@ -45,13 +67,6 @@ export type ReduxState<PageState> = {|
 
 
 // ----- Functions ----- //
-
-function doNotTrack(): boolean {
-  // $FlowIgnore
-  const doNotTrackFlag = navigator.doNotTrack || window.doNotTrack || navigator.msDoNotTrack;
-
-  return doNotTrackFlag === '1' || doNotTrackFlag === 'yes';
-}
 
 // Sets up GA and logging.
 function analyticsInitialisation(participations: Participations): void {

--- a/support-frontend/assets/helpers/tracking/doNotTrack.js
+++ b/support-frontend/assets/helpers/tracking/doNotTrack.js
@@ -1,0 +1,8 @@
+// @flow
+
+export default function doNotTrack(): boolean {
+  // $FlowIgnore
+  const doNotTrackFlag = navigator.doNotTrack || window.doNotTrack || navigator.msDoNotTrack;
+
+  return doNotTrackFlag === '1' || doNotTrackFlag === 'yes';
+}

--- a/support-frontend/assets/helpers/tracking/googleTagManagerScript.js
+++ b/support-frontend/assets/helpers/tracking/googleTagManagerScript.js
@@ -1,6 +1,7 @@
 // Google Tag Manager
 /* eslint-disable */
-import { doNotTrack } from 'helpers/page/page';
+import doNotTrack from 'helpers/tracking/doNotTrack';
+
 if(!doNotTrack()) {
   (function (w, d, s, l, i) {
     w[l] = w[l] || [];


### PR DESCRIPTION
## Why are you doing this?
I have spotted that we are firing two Ophan page views per page with different viewIds. 
This is down to the way that Ophan is triggered just by importing it into a file: Because the googleTagManagerScript.js file imported the `doNotTrack` function from page.js (which fires the first page view) it meant that it was being fired twice.

[**Trello Card**](https://trello.com/c/pGaBYCf5/2483-investigate-double-counting-in-ophan-page-views)

