### PR TITLE
Reading single contributor cookie and putting in state

### DIFF
--- a/support-frontend/assets/helpers/user/__tests__/__snapshots__/userReducerTest.js.snap
+++ b/support-frontend/assets/helpers/user/__tests__/__snapshots__/userReducerTest.js.snap
@@ -11,6 +11,7 @@ Object {
   "id": "",
   "isPostDeploymentTestUser": false,
   "isRecurringContributor": false,
+  "isReturningContributor": false,
   "isSignedIn": false,
   "isTestUser": null,
   "lastName": "",

--- a/support-frontend/assets/helpers/user/__tests__/userActionsTest.js
+++ b/support-frontend/assets/helpers/user/__tests__/userActionsTest.js
@@ -15,6 +15,8 @@ describe('actions', () => {
     setPostDeploymentTestUser,
     setGnmMarketing,
     setStateField,
+    setIsReturningContributor,
+    setEmailValidated
   } = defaultUserActionFunctions;
 
   it('should create SET_DISPLAY_NAME action', () => {
@@ -105,5 +107,23 @@ describe('actions', () => {
       isSignedIn,
     };
     expect(setIsSignedIn(isSignedIn)).toEqual(expectedAction);
+  });
+
+  it('should create SET_EMAIL_VALIDATED action', () => {
+    const emailValidated: boolean = true;
+    const expectedAction = {
+      type: 'SET_EMAIL_VALIDATED',
+      emailValidated,
+    };
+    expect(setEmailValidated(emailValidated)).toEqual(expectedAction);
+  });
+
+  it('should create SET_IS_RETURNING_CONTRIBUTOR action', () => {
+    const isReturningContributor: boolean = true;
+    const expectedAction = {
+      type: 'SET_IS_RETURNING_CONTRIBUTOR',
+      isReturningContributor,
+    };
+    expect(setIsReturningContributor(isReturningContributor)).toEqual(expectedAction);
   });
 });

--- a/support-frontend/assets/helpers/user/__tests__/userReducerTest.js
+++ b/support-frontend/assets/helpers/user/__tests__/userReducerTest.js
@@ -130,4 +130,16 @@ describe('user reducer tests', () => {
     const newState = createUserReducer(GBPCountries)(undefined, action);
     expect(newState.gnmMarketing).toEqual(preference);
   });
+
+  it('should handle SET_IS_RETURNING_CONTRIBUTOR', () => {
+    const isReturningContributor = true;
+
+    const action = {
+      type: 'SET_IS_RETURNING_CONTRIBUTOR',
+      isReturningContributor,
+    };
+
+    const newState = createUserReducer(GBPCountries)(undefined, action);
+    expect(newState.isReturningContributor).toEqual(isReturningContributor);
+  });
 });

--- a/support-frontend/assets/helpers/user/defaultUserActionFunctions.js
+++ b/support-frontend/assets/helpers/user/defaultUserActionFunctions.js
@@ -61,6 +61,10 @@ function setEmailValidated(emailValidated: boolean): Action {
   return { type: 'SET_EMAIL_VALIDATED', emailValidated };
 }
 
+function setIsReturningContributor(isReturningContributor: boolean): Action {
+  return { type: 'SET_IS_RETURNING_CONTRIBUTOR', isReturningContributor };
+}
+
 const defaultUserActionFunctions = {
   setId,
   setDisplayName,
@@ -75,6 +79,7 @@ const defaultUserActionFunctions = {
   setPostDeploymentTestUser,
   setGnmMarketing,
   setEmailValidated,
+  setIsReturningContributor
 };
 
 export { defaultUserActionFunctions };

--- a/support-frontend/assets/helpers/user/user.js
+++ b/support-frontend/assets/helpers/user/user.js
@@ -95,6 +95,7 @@ const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActi
     setTestUser,
     setPostDeploymentTestUser,
     setEmailValidated,
+    setIsReturningContributor,
   } = actions;
 
   const windowHasUser = window.guardian && window.guardian.user;
@@ -131,6 +132,10 @@ const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActi
 
   if (getCookie('gu_recurring_contributor') === 'true') {
     dispatch(setIsRecurringContributor());
+  }
+
+  if (!!cookie.get('gu.contributions.contrib-timestamp')) {
+    dispatch(setIsReturningContributor(true));
   }
 
   if (windowHasUser) {

--- a/support-frontend/assets/helpers/user/userActions.js
+++ b/support-frontend/assets/helpers/user/userActions.js
@@ -15,7 +15,8 @@ export type Action =
   | { type: 'SET_POST_DEPLOYMENT_TEST_USER', postDeploymentTestUser: boolean }
   | { type: 'SET_GNM_MARKETING', preference: boolean }
   | { type: 'SET_IS_SIGNED_IN', isSignedIn: boolean }
-  | { type: 'SET_EMAIL_VALIDATED', emailValidated: boolean };
+  | { type: 'SET_EMAIL_VALIDATED', emailValidated: boolean }
+  | { type: 'SET_IS_RETURNING_CONTRIBUTOR', isReturningContributor: boolean };
 
 export type UserSetStateActions = {|
   setId: string => Action,
@@ -28,6 +29,7 @@ export type UserSetStateActions = {|
   setPostDeploymentTestUser: boolean => Action,
   setGnmMarketing: boolean => Action,
   setEmailValidated: boolean => Action,
+  setIsReturningContributor: boolean => Action,
 
   // When we change either of these in the context of the contributions landing page,
   // we need to dispatch some additional actions to update some state in the

--- a/support-frontend/assets/helpers/user/userReducer.js
+++ b/support-frontend/assets/helpers/user/userReducer.js
@@ -21,6 +21,7 @@ export type User = {
   isSignedIn: boolean,
   isRecurringContributor: boolean,
   emailValidated: boolean,
+  isReturningContributor: boolean,
 };
 
 
@@ -40,6 +41,7 @@ const initialState: User = {
   isSignedIn: false,
   isRecurringContributor: false,
   emailValidated: false,
+  isReturningContributor: false,
 };
 
 
@@ -94,6 +96,9 @@ function createUserReducer() {
 
       case 'SET_EMAIL_VALIDATED':
         return { ...state, emailValidated: action.emailValidated };
+
+      case 'SET_IS_RETURNING_CONTRIBUTOR':
+        return { ...state, isReturningContributor: action.isReturningContributor };
 
       default:
         return state;


### PR DESCRIPTION
## Why are you doing this?
We want to know if a user has given a single contribution before so we can customize messaging on the landing and thank you pages. This is the first step to enable this work - we will probably also want to request information contribution history for returning contributors.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/gnO74GFW/1270-recognize-single-contributors-on-landing-page-using-cookie)

## Changes

* Testing presence of cookie and adding to state using Redux
* Expanding user reducer and actions tests

