### PR TITLE
Upgrade ophan-tracker-js to 1.3.17

### DIFF
--- a/support-frontend/assets/helpers/page/page.js
+++ b/support-frontend/assets/helpers/page/page.js
@@ -2,7 +2,7 @@
 
 // ----- Imports ----- //
 
-import 'ophan';
+import * as ophan from 'ophan';
 import type { Store } from 'redux';
 import { applyMiddleware, combineReducers, compose, createStore, type Reducer } from 'redux';
 import thunkMiddleware from 'redux-thunk';
@@ -59,6 +59,7 @@ function analyticsInitialisation(participations: Participations): void {
     googleTagManager.init(participations);
     storeReferrer();
   }
+  ophan.init();
   trackAbTests(participations);
   // Logging.
   logger.init();

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -65,7 +65,7 @@
     "@sentry/browser": "^5.4.0",
     "cssnano": "^4.1.4",
     "fast-sass-loader": "^1.4.7",
-    "ophan-tracker-js": "^1.3.13",
+    "ophan-tracker-js": "^1.3.17",
     "react-redux": "^5.1.1",
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -10264,10 +10264,10 @@ opener@^1.5.1:
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.1.tgz#6d2f0e77f1a0af0032aca716c2c1fbb8e7e8abed"
   integrity sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==
 
-ophan-tracker-js@^1.3.13:
-  version "1.3.13"
-  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.13.tgz#715aa8655c1ec4c8e45379bae55a95b535522ff6"
-  integrity sha512-oxzDPBc01CsHhsHZKt8g839vSevshbJSVo+kXh17lSTYn5nDirLJT/5n8L9LeCoJmpNwP9We6T9AzKbuCbFu8w==
+ophan-tracker-js@^1.3.17:
+  version "1.3.17"
+  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.17.tgz#49bf3984978356f0c5fc719592d1300347311785"
+  integrity sha512-22x+66NntYxML1YGFkJmOc8eErXnhkQg4hKAY1egsjQjJNWHDvT/YGuyMSIz2gl7nZYFLH5nZTCeP3AqZxJRCw==
 
 opn@5.4.0, opn@^5.4.0:
   version "5.4.0"


### PR DESCRIPTION
## Why are you doing this?

To avoid a recurrence of the double page view bug which was fixed in #1976 I have changed ophan-tracker-js to require an explicit `init()` function call to trigger a page view (see https://github.com/guardian/ophan/pull/3378).

This PR upgrades to the latest version of ophan-tracker-js and calls `init()` in page.js `analyticsInitialisation()`.

[**Trello Card**](https://trello.com/c/pGaBYCf5/2483-investigate-double-counting-in-ophan-page-views)