### PR TITLE
Reinstates styles on payment failure message in GW checkout

### DIFF
--- a/support-frontend/assets/components/generalErrorMessage/generalErrorMessage.jsx
+++ b/support-frontend/assets/components/generalErrorMessage/generalErrorMessage.jsx
@@ -7,6 +7,8 @@ import { appropriateErrorMessage, type ErrorReason } from 'helpers/errorReasons'
 import { classNameWithModifiers } from 'helpers/utilities';
 import SvgExclamationAlternate from '../svgs/exclamationAlternate';
 
+import './generalErrorMessage.scss';
+
 
 // ---- Types ----- //
 

--- a/support-frontend/assets/components/generalErrorMessage/generalErrorMessage.scss
+++ b/support-frontend/assets/components/generalErrorMessage/generalErrorMessage.scss
@@ -1,3 +1,5 @@
+@import '~stylesheets/gu-sass/gu-sass';
+
 .component-general-error-message {
   padding: ($gu-v-spacing / 2) $gu-h-spacing $gu-v-spacing;
   color: gu-colour(news-main);


### PR DESCRIPTION
## Why are you doing this?
This is a production bug on the payment failure message in GW checkout - the styling of the payment failure message was missing in the component. Details are in this [**Trello Card**](https://trello.com/c/WhIfBnYZ/2472-design-broken-on-payment-failure-on-gw-checkout).

## Broken 😢 
![Screen Shot 2019-07-22 at 15 21 12](https://user-images.githubusercontent.com/16781258/61640291-f8c04c00-ac94-11e9-8fe6-2956a5fc88b1.png)

## Fixed  🎉 
![Screen Shot 2019-07-22 at 15 24 46](https://user-images.githubusercontent.com/16781258/61640312-02e24a80-ac95-11e9-829c-282c7e1d8fd5.png)