### PR TITLE
Checkout tracking

### DIFF
--- a/support-frontend/assets/helpers/checkoutForm/onFormSubmit.js
+++ b/support-frontend/assets/helpers/checkoutForm/onFormSubmit.js
@@ -29,12 +29,12 @@ export const onFormSubmit = (params: FormSubmitParameters) => {
       if (params.handlePayment) {
         params.handlePayment();
       }
-      trackCheckoutSubmitAttempt(componentId, `${params.flowPrefix}-allowed-for-user-type-${userType}`);
+      trackCheckoutSubmitAttempt(componentId, `${params.flowPrefix}-allowed-for-user-type-${userType}`, params.paymentMethod);
     } else {
-      trackCheckoutSubmitAttempt(componentId, `${params.flowPrefix}-blocked-because-user-type-is-${userType}`);
+      trackCheckoutSubmitAttempt(componentId, `${params.flowPrefix}-blocked-because-user-type-is-${userType}`, params.paymentMethod);
     }
   } else {
-    trackCheckoutSubmitAttempt(componentId, `${params.flowPrefix}-blocked-because-form-not-valid${invalidReason(params.form)}`);
+    trackCheckoutSubmitAttempt(componentId, `${params.flowPrefix}-blocked-because-form-not-valid${invalidReason(params.form)}`, params.paymentMethod);
   }
   params.setCheckoutFormHasBeenSubmitted();
 };

--- a/support-frontend/assets/helpers/checkoutForm/onFormSubmitOld.js
+++ b/support-frontend/assets/helpers/checkoutForm/onFormSubmitOld.js
@@ -32,13 +32,13 @@ export const onFormSubmit = (params: FormSubmitParameters) => {
       if (params.handlePayment) {
         params.handlePayment();
       }
-      trackCheckoutSubmitAttempt(componentId, `${params.flowPrefix}-allowed-for-user-type-${userType}`);
+      trackCheckoutSubmitAttempt(componentId, `${params.flowPrefix}-allowed-for-user-type-${userType}`, params.paymentMethod);
     } else {
-      trackCheckoutSubmitAttempt(componentId, `${params.flowPrefix}-blocked-because-user-type-is-${userType}`);
+      trackCheckoutSubmitAttempt(componentId, `${params.flowPrefix}-blocked-because-user-type-is-${userType}`, params.paymentMethod);
     }
   } else {
     params.setFormIsValid(false);
-    trackCheckoutSubmitAttempt(componentId, `${params.flowPrefix}-blocked-because-form-not-valid${invalidReason(params.form)}`);
+    trackCheckoutSubmitAttempt(componentId, `${params.flowPrefix}-blocked-because-form-not-valid${invalidReason(params.form)}`, params.paymentMethod);
   }
   params.setCheckoutFormHasBeenSubmitted();
 };

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.js
@@ -241,7 +241,7 @@ function showPaymentMethod(
 
 function trackSubmitAttempt(paymentMethod: ?PaymentMethod, productType: SubscriptionProduct) {
   const componentId = `subs-checkout-submit-${productType}-${paymentMethod || ''}`;
-  trackCheckoutSubmitAttempt(componentId, componentId, paymentMethod);
+  trackCheckoutSubmitAttempt(componentId, productType, paymentMethod);
 }
 
 function submitForm(

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.js
@@ -241,7 +241,7 @@ function showPaymentMethod(
 
 function trackSubmitAttempt(paymentMethod: ?PaymentMethod, productType: SubscriptionProduct) {
   const componentId = `subs-checkout-submit-${productType}-${paymentMethod || ''}`;
-  trackCheckoutSubmitAttempt(componentId, componentId);
+  trackCheckoutSubmitAttempt(componentId, componentId, paymentMethod);
 }
 
 function submitForm(

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.js
@@ -60,6 +60,8 @@ import {
 import { isPostDeployUser } from 'helpers/user/user';
 import type { BillingPeriod } from 'helpers/billingPeriods';
 import { Quarterly, SixWeekly } from 'helpers/billingPeriods';
+import { trackCheckoutSubmitAttempt } from '../tracking/behaviour';
+import { type SubscriptionProduct } from 'helpers/subscriptions';
 
 // ----- Functions ----- //
 
@@ -237,11 +239,20 @@ function showPaymentMethod(
   }
 }
 
+function trackSubmitAttempt(paymentMethod: ?PaymentMethod, productType: SubscriptionProduct) {
+  const componentId = `subs-checkout-submit-${productType}-${paymentMethod || ''}`;
+  trackCheckoutSubmitAttempt(componentId, componentId);
+}
+
 function submitForm(
   dispatch: Dispatch<Action>,
   state: AnyCheckoutState,
 ) {
-  const testUser = state.page.checkout.isTestUser;
+  const {
+    paymentMethod, email, product, isTestUser,
+  } = state.page.checkout;
+
+  trackSubmitAttempt(paymentMethod, product);
 
   const { price, currency } = finalPrice(
     state.page.checkout.productPrices,
@@ -259,9 +270,8 @@ function submitForm(
       state.common.abParticipations,
     );
 
-  const { paymentMethod, email } = state.page.checkout;
   showPaymentMethod(
-    dispatch, onAuthorised, testUser, price, currency,
+    dispatch, onAuthorised, isTestUser, price, currency,
     paymentMethod, email,
   );
 }

--- a/support-frontend/assets/helpers/tracking/behaviour.js
+++ b/support-frontend/assets/helpers/tracking/behaviour.js
@@ -20,12 +20,12 @@ const trackPaymentMethodSelected = (paymentMethod: PaymentMethod): void => {
   });
 };
 
-const trackCheckoutSubmitAttempt = (componentId: string, eventDetails: string): void => {
+const trackCheckoutSubmitAttempt = (componentId: string, eventDetails: string, paymentMethod: ?PaymentMethod): void => {
   gaEvent({
     category: 'click',
     action: eventDetails,
     label: componentId,
-  });
+  }, { paymentMethod });
 
   trackComponentEvents({
     component: {

--- a/support-frontend/assets/helpers/tracking/behaviour.js
+++ b/support-frontend/assets/helpers/tracking/behaviour.js
@@ -8,7 +8,7 @@ const trackPaymentMethodSelected = (paymentMethod: PaymentMethod): void => {
     category: 'click',
     action: 'payment-method-selected',
     label: paymentMethod,
-  });
+  }, { paymentMethod });
 
   trackComponentEvents({
     component: {

--- a/support-frontend/assets/helpers/tracking/googleTagManager.js
+++ b/support-frontend/assets/helpers/tracking/googleTagManager.js
@@ -202,7 +202,7 @@ function successfulConversion(participations: Participations) {
   sendData('SuccessfulConversion', participations);
 }
 
-function gaEvent(gaEventData: GaEventData) {
+function gaEvent(gaEventData: GaEventData, additionalFields: ?Object) {
   maybeTrack(() => {
     if (window.googleTagManagerDataLayer) {
       window.googleTagManagerDataLayer.push({
@@ -210,6 +210,7 @@ function gaEvent(gaEventData: GaEventData) {
         eventCategory: gaEventData.category,
         eventAction: gaEventData.action,
         eventLabel: gaEventData.label,
+        ...additionalFields,
       });
     }
   });


### PR DESCRIPTION
## Why are you doing this?

We want to track the payment method that a user chooses to checkout with so that we can evaluate the drop out rate of each method.

This PR fires the `trackCheckoutSubmitAttempt` function when a user clicks the 'Proceed to payment' button tracking the product type and payment method. 

We are also now setting the paymentMethod custom dimension on the `trackCheckoutSubmitAttempt` and `trackPaymentMethodSelected` events as this makes some analyses easier. 

[**Trello Card**](https://trello.com/c/nCpd0NnR/2447-dev-add-tracking-to-digital-pack-checkout)