### PR TITLE
fix: fixed getGlobal for the switches

### DIFF
--- a/support-frontend/assets/helpers/globals.js
+++ b/support-frontend/assets/helpers/globals.js
@@ -55,7 +55,8 @@ const isSwitchOn = (switchName: string): boolean => {
 };
 
 const isTestSwitchedOn = (testName: string): boolean => {
-  const test = getGlobal(`settings.switches.experiments${testName}`);
+  const test = getGlobal(`settings.switches.experiments.${testName}`);
+
   if (test) {
     return !!(test && test.state && test.state === 'On');
   }


### PR DESCRIPTION
## Why are you doing this?
This PR is all about turning Home Delivery back on, which has been switched off due to off line fulfilment issues, these issues have been resolved so Home Delivery can now be turned back on

[**Trello Card**](https://trello.com/c/XlcAd6cH/2434-turn-home-delivery-back-on-nb-fulfillment-delays-need-fixing)

## Changes

* fixed getGlobal so the switches could be obtained from the window object

## Screenshots
![Screen Shot 2019-07-22 at 14 52 18](https://user-images.githubusercontent.com/45875444/61796548-8169f400-ae1d-11e9-90ce-32b1840a4ad3.png)

