### PR TITLE
Fix checkouts thankyou page navbar

### DIFF
--- a/support-frontend/assets/components/subscriptionCheckouts/headerWrapper.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/headerWrapper.jsx
@@ -1,0 +1,34 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+import { connect } from 'react-redux';
+
+import type { WithDeliveryCheckoutState } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
+import { type Stage } from 'helpers/subscriptionsForms/formFields';
+import Header from 'components/headers/header/header';
+
+// ----- Types ----- //
+
+type PropTypes = {|
+  stage: Stage,
+|};
+
+// ----- State/Props Maps ----- //
+
+function mapStateToProps(state: WithDeliveryCheckoutState) {
+  return {
+    stage: state.page.checkout.stage,
+  };
+}
+
+// ----- Component ----- //
+
+function HeaderWrapper(props: PropTypes) {
+  return <Header display={props.stage === 'checkout' ? 'checkout' : 'guardianLogo'} />;
+}
+
+// ----- Export ----- //
+
+export default connect(mapStateToProps)(HeaderWrapper);

--- a/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.jsx
@@ -9,7 +9,6 @@ import { renderPage } from 'helpers/render';
 import { init as pageInit } from 'helpers/page/page';
 
 import Page from 'components/page/page';
-import Header from 'components/headers/header/header';
 import Footer from 'components/footer/footer';
 import CustomerService from 'components/customerService/customerService';
 import SubscriptionTermsPrivacy from 'components/legal/subscriptionTermsPrivacy/subscriptionTermsPrivacy';
@@ -27,6 +26,7 @@ import { Monthly } from 'helpers/billingPeriods';
 import { createCheckoutReducer } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
 import type { CommonState } from 'helpers/page/commonReducer';
 import { DigitalPack } from 'helpers/subscriptions';
+import HeaderWrapper from 'components/subscriptionCheckouts/headerWrapper';
 
 // ----- Redux Store ----- //
 const billingPeriodInUrl = getQueryParameter('period');
@@ -44,14 +44,13 @@ const reducer = (commonState: CommonState) => createCheckoutReducer(
 const store = pageInit(reducer, true);
 
 const { countryGroupId } = store.getState().common.internationalisation;
-const { stage } = store.getState().page.checkout;
 
 // ----- Render ----- //
 
 const content = (
   <Provider store={store}>
     <Page
-      header={<Header display={stage === 'checkout' ? 'checkout' : 'guardianLogo'} />}
+      header={<HeaderWrapper />}
       footer={
         <Footer>
           <SubscriptionTermsPrivacy subscriptionProduct="DigitalPack" />

--- a/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckout.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckout.jsx
@@ -9,7 +9,6 @@ import { renderPage } from 'helpers/render';
 import { init as pageInit } from 'helpers/page/page';
 
 import Page from 'components/page/page';
-import Header from 'components/headers/header/header';
 import Footer from 'components/footer/footer';
 import CustomerService from 'components/customerService/customerService';
 import SubscriptionTermsPrivacy from 'components/legal/subscriptionTermsPrivacy/subscriptionTermsPrivacy';
@@ -25,6 +24,7 @@ import { createWithDeliveryCheckoutReducer } from 'helpers/subscriptionsForms/su
 import type { CommonState } from 'helpers/page/commonReducer';
 import { Monthly } from 'helpers/billingPeriods';
 import { Paper } from 'helpers/subscriptions';
+import HeaderWrapper from 'components/subscriptionCheckouts/headerWrapper';
 
 // ----- Redux Store ----- //
 
@@ -47,14 +47,13 @@ const store = pageInit(
 );
 
 const { countryGroupId } = store.getState().common.internationalisation;
-const { stage } = store.getState().page.checkout;
 
 // ----- Render ----- //
 
 const content = (
   <Provider store={store}>
     <Page
-      header={<Header display={stage === 'checkout' ? 'checkout' : 'guardianLogo'} />}
+      header={<HeaderWrapper />}
       footer={
         <Footer>
           <SubscriptionTermsPrivacy subscriptionProduct="Paper" />

--- a/support-frontend/assets/pages/weekly-subscription-checkout/weeklySubscriptionCheckout.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/weeklySubscriptionCheckout.jsx
@@ -9,7 +9,6 @@ import { renderPage } from 'helpers/render';
 import { init as pageInit } from 'helpers/page/page';
 
 import Page from 'components/page/page';
-import Header from 'components/headers/header/header';
 import Footer from 'components/footer/footer';
 import CustomerService from 'components/customerService/customerService';
 import SubscriptionTermsPrivacy
@@ -30,6 +29,7 @@ import { getWeeklyDays } from 'pages/weekly-subscription-checkout/helpers/delive
 import { Domestic } from 'helpers/productPrice/fulfilmentOptions';
 import { NoProductOptions } from 'helpers/productPrice/productOptions';
 import { formatMachineDate } from 'helpers/dateConversions';
+import HeaderWrapper from 'components/subscriptionCheckouts/headerWrapper';
 
 // ----- Redux Store ----- //
 const billingPeriodInUrl = getQueryParameter('period');
@@ -53,14 +53,13 @@ const store = pageInit(
 );
 
 const { countryGroupId } = store.getState().common.internationalisation;
-const { stage } = store.getState().page.checkout;
 
 // ----- Render ----- //
 
 const content = (
   <Provider store={store}>
     <Page
-      header={<Header display={stage === 'checkout' ? 'checkout' : 'guardianLogo'} />}
+      header={<HeaderWrapper />}
       footer={
         <Footer>
           <SubscriptionTermsPrivacy subscriptionProduct="GuardianWeekly" />


### PR DESCRIPTION
## Why are you doing this?
The Subs checkouts thank you pages should have a navbar with only the logo, not the lock logo and the word checkout. The checkout stage wasn't getting passed into this component, which meant it wasn't displaying the expected state.

[**Trello Card**](https://trello.com/c/evXvstC2/2493-remove-checkout-and-checkout-styling-from-navbar-in-thank-you-page)

## Changes
This has now been fixed so all three checkouts (digital, print and GW) have the correct navbar in the thank you page.

## Screenshots
![Screen Shot 2019-07-24 at 16 38 55](https://user-images.githubusercontent.com/16781258/61807520-99e40980-ae31-11e9-8428-82f0aa593092.png)