### PR TITLE
Test for updating landing page copy for returning singles

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -1,8 +1,30 @@
 // @flow
 import type { Tests } from './abtest';
+import { get as getCookie } from 'helpers/cookie';
 
 // ----- Tests ----- //
+export type LandingPageCopyReturningSinglesTestVariants = 'control' | 'returningSingle' | 'notintest';
 
 export const tests: Tests = {
+  landingPageCopyReturningSingles: {
+    type: 'OTHER',
+    variants: [
+      {
+        id: 'control',
+      },
+      {
+        id: 'returningSingle',
+      },
+    ],
+    audiences: {
+      ALL: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: true,
+    independent: true,
+    seed: 1,
+    canRun: () => !!getCookie('gu.contributions.contrib-timestamp'),
+  },
 };
-

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -1,29 +1,8 @@
 // @flow
 import type { Tests } from './abtest';
 
-export type LandingPageCopyAllContributionsTestVariants = 'control' | 'allContributions' | 'notintest';
 // ----- Tests ----- //
 
 export const tests: Tests = {
-  landingPageCopyAllContributionsRevision1: {
-    type: 'OTHER',
-    variants: [
-      {
-        id: 'control',
-      },
-      {
-        id: 'allContributions',
-      },
-    ],
-    audiences: {
-      ALL: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: true,
-    independent: true,
-    seed: 1,
-  },
 };
 

--- a/support-frontend/assets/helpers/user/user.js
+++ b/support-frontend/assets/helpers/user/user.js
@@ -134,7 +134,7 @@ const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActi
     dispatch(setIsRecurringContributor());
   }
 
-  if (cookie.get('gu.contributions.contrib-timestamp')) {
+  if (getCookie('gu.contributions.contrib-timestamp')) {
     dispatch(setIsReturningContributor(true));
   }
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.jsx
@@ -13,7 +13,6 @@ import { campaigns, getCampaignName } from 'helpers/campaigns';
 import { type State } from '../contributionsLandingReducer';
 import { ContributionForm, EmptyContributionForm } from './ContributionForm';
 import { onThirdPartyPaymentAuthorised, paymentWaiting, setTickerGoalReached } from '../contributionsLandingActions';
-import type { LandingPageCopyAllContributionsTestVariants } from 'helpers/abTests/abtestDefinitions';
 
 // ----- Types ----- //
 /* eslint-disable react/no-unused-prop-types */
@@ -26,7 +25,7 @@ type PropTypes = {|
   setTickerGoalReached: () => void,
   tickerGoalReached: boolean,
   campaignCodeParameter: ?string,
-  landingPageCopyAllContributionsTestVariant: LandingPageCopyAllContributionsTestVariants,
+  isReturningContributor: boolean,
 |};
 
 /* eslint-enable react/no-unused-prop-types */
@@ -35,7 +34,7 @@ const mapStateToProps = (state: State) => ({
   paymentComplete: state.page.form.paymentComplete,
   countryGroupId: state.common.internationalisation.countryGroupId,
   tickerGoalReached: state.page.form.tickerGoalReached,
-  landingPageCopyAllContributionsTestVariant: state.common.abParticipations.landingPageCopyAllContributionsRevision1,
+  isReturningContributor: state.page.user.isReturningContributor,
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -55,20 +54,8 @@ export type CountryMetaData = {
   formMessage?: React$Element<string>,
 };
 
-const defaultHeaderCopy = 'Help\xa0us\xa0deliver\nthe\xa0independent\njournalism\xa0the\nworld\xa0needs';
+const defaultHeaderCopy = 'Support\xa0our\njournalism\xa0with\na\xa0contribution\nof\xa0any\xa0size';
 const defaultContributeCopy = (
-  <span>
-    Readers from around the world, like you, make The Guardian’s work possible. We need your support to
-    deliver quality, investigative journalism – and to keep it open for everyone. At a time when factual,
-    honest reporting is critical, your support is essential in protecting our editorial independence.
-    <span className="gu-content__blurb-blurb-last-sentence"> Your support is critical for the future of Guardian journalism.</span>
-  </span>);
-
-// JTL: These consts (variantHeaderCopy & variantContributeCopy) are part of a hardcoded test for landing page copy:
-// To be removed on completion of the test. The default copy (above) should be replaced by this
-// copy object if the variant (below copy) is successful.
-const variantHeaderCopy = 'Support\xa0our\njournalism\xa0with\na\xa0contribution\nof\xa0any\xa0size';
-const variantContributeCopy = (
   <span>
     Readers from around the world, like you, make The Guardian’s work possible. We need your support to
     deliver quality, investigative journalism – and to keep it open for everyone. At a time when factual,
@@ -76,16 +63,23 @@ const variantContributeCopy = (
     <span className="gu-content__blurb-blurb-last-sentence"> Every contribution, however big or small, is so valuable for our future.</span>
   </span>);
 
+const returningSingleHeaderCopy = 'Help\xa0us\xa0deliver\nthe\xa0independent\njournalism\xa0the\nworld\xa0needs';
+const returningSingleContributeCopy = (
+  <span>
+    Readers from around the world, like you, make The Guardian’s work possible. We need your support to
+    deliver quality, investigative journalism – and to keep it open for everyone. At a time when factual,
+    honest reporting is critical, your support is essential in protecting our editorial independence.
+    <span className="gu-content__blurb-blurb-last-sentence"> Your support is critical for the future of Guardian journalism.</span>
+  </span>);
+
 const defaultHeaderCopyAndContributeCopy: CountryMetaData = {
   headerCopy: defaultHeaderCopy,
   contributeCopy: defaultContributeCopy,
 };
 
-// JTL: This const (variantHeaderCopyAndContributeCopy) is part of a hardcoded test for landing page copy.
-// To be removed on completion of the test:
-const variantHeaderCopyAndContributeCopy: CountryMetaData = {
-  headerCopy: variantHeaderCopy,
-  contributeCopy: variantContributeCopy,
+const returningSingleHeaderCopyAndContributeCopy: CountryMetaData = {
+  headerCopy: returningSingleHeaderCopy,
+  contributeCopy: returningSingleContributeCopy,
 };
 
 const campaignName = getCampaignName();
@@ -100,9 +94,9 @@ function withProps(props: PropTypes) {
     props.onThirdPartyPaymentAuthorised(paymentAuthorisation);
   };
 
-  // JTL: This const (countryGroupSpecificDetailsForVariant) is part of a hardcoded test for landing page copy.
-  // To be removed and refactored into countryGroupDetails object on completion of the test:
-  const landingPageCopy = props.landingPageCopyAllContributionsTestVariant === 'allContributions' ? variantHeaderCopyAndContributeCopy : defaultHeaderCopyAndContributeCopy;
+  const landingPageCopy = props.isReturningContributor ?
+    returningSingleHeaderCopyAndContributeCopy :
+    defaultHeaderCopyAndContributeCopy;
 
   const countryGroupDetails = {
     ...landingPageCopy,

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.jsx
@@ -13,6 +13,7 @@ import { campaigns, getCampaignName } from 'helpers/campaigns';
 import { type State } from '../contributionsLandingReducer';
 import { ContributionForm, EmptyContributionForm } from './ContributionForm';
 import { onThirdPartyPaymentAuthorised, paymentWaiting, setTickerGoalReached } from '../contributionsLandingActions';
+import type { LandingPageCopyReturningSinglesTestVariants } from 'helpers/abTests/abtestDefinitions';
 
 // ----- Types ----- //
 /* eslint-disable react/no-unused-prop-types */
@@ -26,6 +27,7 @@ type PropTypes = {|
   tickerGoalReached: boolean,
   campaignCodeParameter: ?string,
   isReturningContributor: boolean,
+  landingPageCopyReturningSinglesTestVariant: LandingPageCopyReturningSinglesTestVariants,
 |};
 
 /* eslint-enable react/no-unused-prop-types */
@@ -35,6 +37,7 @@ const mapStateToProps = (state: State) => ({
   countryGroupId: state.common.internationalisation.countryGroupId,
   tickerGoalReached: state.page.form.tickerGoalReached,
   isReturningContributor: state.page.user.isReturningContributor,
+  landingPageCopyReturningSinglesTestVariant: state.common.abParticipations.landingPageCopyReturningSingles,
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -93,7 +96,7 @@ function withProps(props: PropTypes) {
     props.onThirdPartyPaymentAuthorised(paymentAuthorisation);
   };
 
-  const landingPageCopy = props.isReturningContributor ?
+  const landingPageCopy = props.isReturningContributor && props.landingPageCopyReturningSinglesTestVariant === 'returningSingle' ?
     returningSingleHeaderCopyAndContributeCopy :
     defaultHeaderCopyAndContributeCopy;
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.jsx
@@ -63,13 +63,12 @@ const defaultContributeCopy = (
     <span className="gu-content__blurb-blurb-last-sentence"> Every contribution, however big or small, is so valuable for our future.</span>
   </span>);
 
-const returningSingleHeaderCopy = 'Help\xa0us\xa0deliver\nthe\xa0independent\njournalism\xa0the\nworld\xa0needs';
+const returningSingleHeaderCopy = 'Thank you for considering another contribution';
 const returningSingleContributeCopy = (
   <span>
-    Readers from around the world, like you, make The Guardian’s work possible. We need your support to
-    deliver quality, investigative journalism – and to keep it open for everyone. At a time when factual,
-    honest reporting is critical, your support is essential in protecting our editorial independence.
-    <span className="gu-content__blurb-blurb-last-sentence"> Your support is critical for the future of Guardian journalism.</span>
+    Returning contributors, like you, make The Guardian’s work possible. We need your ongoing support to
+    keep delivering quality journalism, to maintain our openness and to safeguard our editorial independence.
+    <span className="gu-content__blurb-blurb-last-sentence"> Every contribution, however big or small, is so valuable for our future.</span>
   </span>);
 
 const defaultHeaderCopyAndContributeCopy: CountryMetaData = {


### PR DESCRIPTION
## Why are you doing this?

We have chosen to AB test this: We want to recognize returning single contributors on the landing page and deliver custom content that will hopefully encourage them to contribute now and again in the future.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/RO2yF9l3/1279-thank-you-message-on-landing-page-for-single-returning-contributors)

## Changes

* Introduced a test for copy changes for RSC
* Removed previous landing page copy test, defaulting to new copy

## Screenshots
Test variant: 
![RSC test variant](https://user-images.githubusercontent.com/3300789/61951262-64156100-afa8-11e9-9623-92eee430a339.png)

Test control:
![RSC test control](https://user-images.githubusercontent.com/3300789/62035252-5dc0f800-b1e7-11e9-988a-de027b5dace6.png)

Not in test (same as control):
![RSC test notintest](https://user-images.githubusercontent.com/3300789/61951309-91faa580-afa8-11e9-9a30-8c4a476b9264.png)
