### PR TITLE
Send Ophan paymentMethods to GA

### DIFF
--- a/support-frontend/assets/helpers/tracking/__tests__/googleTagManagerTest.js
+++ b/support-frontend/assets/helpers/tracking/__tests__/googleTagManagerTest.js
@@ -1,0 +1,28 @@
+// @flow
+
+// ----- Imports ----- //
+
+import { mapFields } from '../googleTagManager';
+import { DirectDebit } from '../../paymentMethods';
+
+// ----- Tests ----- //
+
+jest.mock('ophan', () => ({ viewId: '123456' }));
+
+describe('googleTagManager', () => {
+  it('should map a support frontend PaymentMethod type to Ophan payment methods', () => {
+
+    const input = {
+      orderId: 1,
+      currency: 'GBP',
+      paymentMethod: DirectDebit,
+    };
+
+    const mapped = mapFields(input);
+    expect(mapped.paymentMethod).toEqual('Gocardless');
+    expect(mapped.currency).toEqual('GBP');
+    expect(mapped.orderId).toEqual(1);
+    expect(Object.keys(mapped).length).toEqual(Object.keys(input).length);
+  });
+});
+


### PR DESCRIPTION
## Why are you doing this?
A lot of the tracking events we send to GA includes the payment method, however we currently send the values associated with our `PaymentMethod` type. 

This does not match up with the values sent in acquisition events from the acquisition-event-producer library as these are the types defined by Ophan https://github.com/guardian/ophan/blob/master/event-model/src/main/thrift/acquisition.thrift#L25

This makes it hard to do end to end analysis of payment methods so this PR changes the GA support-frontend behaviour to send the Ophan type.

