### PR TITLE
log level INFO for failed authentication if user not signed in

### DIFF
--- a/support-frontend/app/actions/AsyncAuthenticatedBuilder.scala
+++ b/support-frontend/app/actions/AsyncAuthenticatedBuilder.scala
@@ -1,8 +1,6 @@
 package actions
 
-import com.gu.monitoring.SafeLogger
-import com.gu.monitoring.SafeLogger._
-import services.AsyncAuthenticationService.isUserNotSignedInError
+import services.AsyncAuthenticationService.logUserAuthenticationError
 import play.api.mvc.Security.AuthenticatedRequest
 import play.api.mvc._
 
@@ -35,10 +33,7 @@ class AsyncAuthenticatedBuilder[U](
     userinfo(request)
       .flatMap(user => block(new AuthenticatedRequest(user, request)))
       .recover { case err =>
-        // User shouldn't necessarily be signed in,
-        // therefore, don't log failure to authenticate as a result of this with log level ERROR.
-        if (isUserNotSignedInError(err)) SafeLogger.info(s"unable to authorize user - $err")
-        else SafeLogger.error(scrub"unable to authorize user", err)
+        logUserAuthenticationError(err)
         onUnauthorized(request)
       }
   }

--- a/support-frontend/app/actions/AsyncAuthenticatedBuilder.scala
+++ b/support-frontend/app/actions/AsyncAuthenticatedBuilder.scala
@@ -1,7 +1,8 @@
 package actions
 
+import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.SafeLogger._
 import services.AsyncAuthenticationService.isUserNotSignedInError
-import com.typesafe.scalalogging.LazyLogging
 import play.api.mvc.Security.AuthenticatedRequest
 import play.api.mvc._
 
@@ -20,7 +21,7 @@ class AsyncAuthenticatedBuilder[U](
     defaultParser: BodyParser[AnyContent],
     onUnauthorized: RequestHeader => Result
 )(implicit val executionContext: ExecutionContext)
-  extends ActionBuilder[({ type R[A] = AuthenticatedRequest[A, U] })#R, AnyContent] with LazyLogging { // scalastyle:ignore
+  extends ActionBuilder[({ type R[A] = AuthenticatedRequest[A, U] })#R, AnyContent] { // scalastyle:ignore
 
   lazy val parser = defaultParser
 
@@ -36,8 +37,8 @@ class AsyncAuthenticatedBuilder[U](
       .recover { case err =>
         // User shouldn't necessarily be signed in,
         // therefore, don't log failure to authenticate as a result of this with log level ERROR.
-        if (isUserNotSignedInError(err)) logger.info(s"unable to authorize user - $err")
-        else logger.error(s"unable to authorize user - $err")
+        if (isUserNotSignedInError(err)) SafeLogger.info(s"unable to authorize user - $err")
+        else SafeLogger.error(scrub"unable to authorize user", err)
         onUnauthorized(request)
       }
   }

--- a/support-frontend/app/services/AuthenticationService.scala
+++ b/support-frontend/app/services/AuthenticationService.scala
@@ -5,7 +5,8 @@ import com.gu.identity.auth.UserCredentials
 import com.gu.identity.model.User
 import com.gu.identity.play.IdentityPlayAuthService
 import com.gu.identity.play.IdentityPlayAuthService.UserCredentialsMissingError
-import com.typesafe.scalalogging.LazyLogging
+import com.gu.monitoring.SafeLogger
+import com.gu.monitoring.SafeLogger._
 import config.Identity
 import org.http4s.Uri
 import play.api.mvc.{Cookie, RequestHeader}
@@ -32,7 +33,7 @@ case class AuthenticatedIdUser(credentials: AccessCredentials, minimalUser: IdMi
 class AsyncAuthenticationService(
     identityPlayAuthService: IdentityPlayAuthService,
     testUserService: TestUserService
-)(implicit ec: ExecutionContext) extends LazyLogging {
+)(implicit ec: ExecutionContext) {
 
   import AsyncAuthenticationService._
 
@@ -47,8 +48,8 @@ class AsyncAuthenticationService(
       .handleError { err =>
         // User shouldn't necessarily be signed in,
         // therefore, don't log failure to authenticate as a result of this with log level ERROR.
-        if (isUserNotSignedInError(err)) logger.info(s"unable to authorize user - $err")
-        else logger.error(s"unable to authorize user - $err")
+        if (isUserNotSignedInError(err)) SafeLogger.info(s"unable to authorize user - $err")
+        else SafeLogger.error(scrub"unable to authorize user", err)
         None
       }
 

--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -32,7 +32,7 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-generic-extras" % circeVersion,
   "io.circe" %% "circe-parser" % circeVersion,
   "joda-time" % "joda-time" % "2.9.9",
-  "com.gu.identity" %% "identity-auth-play" % "3.184-M5",
+  "com.gu.identity" %% "identity-auth-play" % "3.184-M6",
   "com.gu" %% "identity-test-users" % "0.6",
   "com.google.guava" % "guava" % "25.0-jre",
   "com.netaporter" %% "scala-uri" % "0.4.16",


### PR DESCRIPTION
Follow up to #1984. Don't log failure to authenticate with level ERROR if it's because the user isn't signed in.

Also in this PR, I've interpolated the exception in the error message string, rather than including it as a separate argument, since the exception would be sent as a separate log entry to cloud watch. It's seems that interpolating the exception as part of the error message is common practice for this code base anyway.