### PR TITLE
Make print checkout copy dynamic to account for home delivery

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-checkout/components/checkoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/checkoutForm.jsx
@@ -63,6 +63,7 @@ import {
   getDeliveryAddress,
 } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
 import { submitWithDeliveryForm } from 'helpers/subscriptionsForms/submit';
+import { paperHasDeliveryEnabled } from 'helpers/subscriptions';
 
 // ----- Types ----- //
 
@@ -112,6 +113,7 @@ function CheckoutForm(props: PropTypes) {
   const days = getDays(props.fulfilmentOption, props.productOption);
   const fulfilmentOptionDescriptor = props.fulfilmentOption === HomeDelivery ? 'Paper' : 'Voucher booklet';
   const fulfilmentOptionName = props.fulfilmentOption === HomeDelivery ? 'Home delivery' : 'Voucher booklet';
+  const deliveryTitle = paperHasDeliveryEnabled() ? 'Where should we deliver your newspaper' : 'Where should we deliver your vouchers';
 
   return (
     <Content modifierClasses={['your-details']}>
@@ -173,9 +175,11 @@ function CheckoutForm(props: PropTypes) {
               signOut={props.signOut}
             />
           </FormSection>
-          <FormSection title="Where should we deliver your vouchers?">
+
+          <FormSection title={deliveryTitle}>
             <DeliveryAddress />
           </FormSection>
+
           <FormSection title="Is the billing address the same as the delivery address?">
             <Rows>
               <FieldsetWithError

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/checkoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/checkoutForm.jsx
@@ -63,7 +63,6 @@ import {
   getDeliveryAddress,
 } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
 import { submitWithDeliveryForm } from 'helpers/subscriptionsForms/submit';
-import { paperHasDeliveryEnabled } from 'helpers/subscriptions';
 
 // ----- Types ----- //
 

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/checkoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/checkoutForm.jsx
@@ -112,7 +112,7 @@ function CheckoutForm(props: PropTypes) {
   const days = getDays(props.fulfilmentOption, props.productOption);
   const fulfilmentOptionDescriptor = props.fulfilmentOption === HomeDelivery ? 'Paper' : 'Voucher booklet';
   const fulfilmentOptionName = props.fulfilmentOption === HomeDelivery ? 'Home delivery' : 'Voucher booklet';
-  const deliveryTitle = props.fulfilmentOption === HomeDelivery ? 'Where should we deliver your newspaper' : 'Where should we deliver your vouchers';
+  const deliveryTitle = props.fulfilmentOption === HomeDelivery ? 'Where should we deliver your newspaper?' : 'Where should we deliver your vouchers?';
 
   return (
     <Content modifierClasses={['your-details']}>

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/checkoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/checkoutForm.jsx
@@ -113,7 +113,7 @@ function CheckoutForm(props: PropTypes) {
   const days = getDays(props.fulfilmentOption, props.productOption);
   const fulfilmentOptionDescriptor = props.fulfilmentOption === HomeDelivery ? 'Paper' : 'Voucher booklet';
   const fulfilmentOptionName = props.fulfilmentOption === HomeDelivery ? 'Home delivery' : 'Voucher booklet';
-  const deliveryTitle = paperHasDeliveryEnabled() ? 'Where should we deliver your newspaper' : 'Where should we deliver your vouchers';
+  const deliveryTitle = props.fulfilmentOption === HomeDelivery ? 'Where should we deliver your newspaper' : 'Where should we deliver your vouchers';
 
   return (
     <Content modifierClasses={['your-details']}>

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/thankYou.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/thankYou.jsx
@@ -102,7 +102,7 @@ function ThankYouContent({
           )
         }
         {startDate &&
-          <Text title="You can start using your vouchers from">
+          <Text title={fulfilmentOption === HomeDelivery ? 'You will receive your newspapers from' : 'You can start using your vouchers from'}>
             <LargeParagraph>{formatUserDate(new Date(startDate))}</LargeParagraph>
           </Text>
         }


### PR DESCRIPTION
## Why are you doing this?

Because the paper product page will now offer Home Delivery, the checkout copy has been updated to reflect Home Delivery status 

[**Trello Card**](https://trello.com)

## Changes

* update: added switch between voucher and delivery copy

## Screenshots
Switch between home delivery and vouchers
![Screen Shot 2019-07-25 at 17 51 46](https://user-images.githubusercontent.com/45875444/61893066-1d225f80-af05-11e9-8ae0-b61c772e0d46.png)

![Screen Shot 2019-07-25 at 17 30 46](https://user-images.githubusercontent.com/45875444/61893011-f95f1980-af04-11e9-9c27-88ee43dd6a4a.png)

