### PR TITLE
Send ophan view event on landing page when cookie present

### DIFF
--- a/support-frontend/assets/helpers/user/__tests__/userActionsTest.js
+++ b/support-frontend/assets/helpers/user/__tests__/userActionsTest.js
@@ -1,6 +1,8 @@
 // @flow
 import { defaultUserActionFunctions } from '../defaultUserActionFunctions';
 
+jest.mock('ophan', () => () => ({
+}));
 
 describe('actions', () => {
 

--- a/support-frontend/assets/helpers/user/defaultUserActionFunctions.js
+++ b/support-frontend/assets/helpers/user/defaultUserActionFunctions.js
@@ -2,6 +2,7 @@
 
 import { setSession } from 'helpers/storage';
 import { type Action } from './userActions';
+import { trackComponentLoad } from 'helpers/tracking/behaviour';
 
 // ----- Actions Creators ----- //
 
@@ -62,6 +63,14 @@ function setEmailValidated(emailValidated: boolean): Action {
 }
 
 function setIsReturningContributor(isReturningContributor: boolean): Action {
+  // JTL: We want to send an Ophan event when we recognize a user is a returning contributor and on the landing page
+  const isReturningContributorOnLandingPage = isReturningContributor &&
+    !!document.location.pathname.match(/^https:\/\/support\.\w+\.com\/\w\w\/contribute/);
+
+  if (isReturningContributorOnLandingPage) {
+    trackComponentLoad('returning-single-contributor-landing-page-view')
+  }
+
   return { type: 'SET_IS_RETURNING_CONTRIBUTOR', isReturningContributor };
 }
 

--- a/support-frontend/assets/helpers/user/defaultUserActionFunctions.js
+++ b/support-frontend/assets/helpers/user/defaultUserActionFunctions.js
@@ -68,7 +68,7 @@ function setIsReturningContributor(isReturningContributor: boolean): Action {
     !!document.location.pathname.match(/^https:\/\/support\.\w+\.com\/\w\w\/contribute/);
 
   if (isReturningContributorOnLandingPage) {
-    trackComponentLoad('returning-single-contributor-landing-page-view')
+    trackComponentLoad('returning-single-contributor-landing-page-view');
   }
 
   return { type: 'SET_IS_RETURNING_CONTRIBUTOR', isReturningContributor };

--- a/support-frontend/assets/helpers/user/user.js
+++ b/support-frontend/assets/helpers/user/user.js
@@ -130,7 +130,7 @@ const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActi
     dispatch(setPostDeploymentTestUser(true));
   }
 
-  if (getCookie('gu_recurring_contributor')) {
+  if (getCookie('gu_recurring_contributor') === 'true') {
     dispatch(setIsRecurringContributor());
   }
 

--- a/support-frontend/assets/helpers/user/user.js
+++ b/support-frontend/assets/helpers/user/user.js
@@ -130,11 +130,11 @@ const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActi
     dispatch(setPostDeploymentTestUser(true));
   }
 
-  if (getCookie('gu_recurring_contributor') === 'true') {
+  if (!!getCookie('gu_recurring_contributor')) {
     dispatch(setIsRecurringContributor());
   }
 
-  if (cookie.get('gu.contributions.contrib-timestamp')) {
+  if (!!getCookie('gu.contributions.contrib-timestamp')) {
     dispatch(setIsReturningContributor(true));
   }
 

--- a/support-frontend/assets/helpers/user/user.js
+++ b/support-frontend/assets/helpers/user/user.js
@@ -130,11 +130,11 @@ const init = (dispatch: Function, actions: UserSetStateActions = defaultUserActi
     dispatch(setPostDeploymentTestUser(true));
   }
 
-  if (!!getCookie('gu_recurring_contributor')) {
+  if (getCookie('gu_recurring_contributor')) {
     dispatch(setIsRecurringContributor());
   }
 
-  if (!!getCookie('gu.contributions.contrib-timestamp')) {
+  if (getCookie('gu.contributions.contrib-timestamp')) {
     dispatch(setIsReturningContributor(true));
   }
 


### PR DESCRIPTION
## Why are you doing this?

We want to start tracking our RSC landing page views and conversions.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->
