### PR TITLE
Increase cookie expiry

### DIFF
--- a/support-frontend/assets/helpers/cookie.js
+++ b/support-frontend/assets/helpers/cookie.js
@@ -45,6 +45,8 @@ export function set(name: string, value: string, daysToLive: ?number): void {
     expires.setDate(1);
   }
 
+  console.log("date:", expires.getMonth(), expires.getDate())
+
   document.cookie = `${name}=${value}; path=/; secure; expires=${expires.toUTCString()};${getDomainAttribute()}`;
 
 }

--- a/support-frontend/assets/helpers/cookie.js
+++ b/support-frontend/assets/helpers/cookie.js
@@ -45,8 +45,6 @@ export function set(name: string, value: string, daysToLive: ?number): void {
     expires.setDate(1);
   }
 
-  console.log("date:", expires.getMonth(), expires.getDate())
-
   document.cookie = `${name}=${value}; path=/; secure; expires=${expires.toUTCString()};${getDomainAttribute()}`;
 
 }

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
@@ -69,11 +69,13 @@ const selectedCountryGroup = countryGroups[countryGroupId];
 
 const ONE_OFF_CONTRIBUTION_COOKIE = 'gu.contributions.contrib-timestamp';
 const currentTimeInEpochMilliseconds: number = Date.now();
+const cookieDaysToLive = 365;
 
 const setOneOffContributionCookie = () => {
   setCookie(
     ONE_OFF_CONTRIBUTION_COOKIE,
     currentTimeInEpochMilliseconds.toString(),
+    cookieDaysToLive,
   );
 };
 

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
@@ -69,7 +69,7 @@ const selectedCountryGroup = countryGroups[countryGroupId];
 
 const ONE_OFF_CONTRIBUTION_COOKIE = 'gu.contributions.contrib-timestamp';
 const currentTimeInEpochMilliseconds: number = Date.now();
-const cookieDaysToLive = 365;
+const cookieDaysToLive = 30*6;
 
 const setOneOffContributionCookie = () => {
   setCookie(


### PR DESCRIPTION
## Why are you doing this?
The `gu.contributions.contrib-timestamp` is currently used to prevent users seeing epic/banner for 6 months.
However, the expiry is currently [defaulting to 5 months](https://github.com/guardian/support-frontend/blob/master/support-frontend/assets/helpers/cookie.js#L44).
