### PR TITLE
Added support for custom checkbox label to span over multiple lines

### DIFF
--- a/support-frontend/assets/components/forms/customFields/checkbox.scss
+++ b/support-frontend/assets/components/forms/customFields/checkbox.scss
@@ -10,9 +10,9 @@
 }
 
 .component-checkbox__text {
-  display: flex;
   align-items: center;
   position: relative;
+  padding: 0 0 0 30px;
 }
 
 .component-checkbox__input {
@@ -25,6 +25,9 @@
 }
 
 .component-checkbox__text:before {
+  position: absolute;
+  left: 0;
+  top: 1px;
   display: inline-block;
   content: '';
   width: 18px;
@@ -43,7 +46,7 @@
 .component-checkbox__tick {
   position: absolute;
   left: 7px;
-  top: 4px;
+  top: 3px;
   width: 6px;
   height: 12px;
   transform: rotate(45deg);


### PR DESCRIPTION
## Why are you doing this?

Yesterday it was observed that a checkbox label spanning multiple lines was causing issues with display of the custom checkbox component. 

## Changes

* Teeny minor style updates to ensure more robust custom checkbox

## Screenshots

**Before**

![Picture 74](https://user-images.githubusercontent.com/1108991/62202640-8da40300-b381-11e9-9914-d24eef4d5181.png)

**After**

Multiline
![Picture 75](https://user-images.githubusercontent.com/1108991/62202658-97c60180-b381-11e9-9f96-39e0952872db.png)

Single line
![Picture 76](https://user-images.githubusercontent.com/1108991/62225013-84ca2600-b3af-11e9-8291-7985e1cccce2.png)
![Picture 77](https://user-images.githubusercontent.com/1108991/62225055-9d3a4080-b3af-11e9-8239-aa4388357d82.png)


