### PR TITLE
QA Test for New Marketing Component

### DIFF
--- a/support-frontend/assets/components/button/_sharedButton.jsx
+++ b/support-frontend/assets/components/button/_sharedButton.jsx
@@ -17,6 +17,7 @@ export const Appearances = {
   green: 'green',
   greenHollow: 'greenHollow',
   greyHollow: 'greyHollow',
+  disabled: 'disabled',
 };
 export const Sides = {
   right: 'right', left: 'left',

--- a/support-frontend/assets/components/button/button.scss
+++ b/support-frontend/assets/components/button/button.scss
@@ -21,12 +21,6 @@
   &:hover, &:focus {
     outline: 0;
   }
-
-  &[disabled], &[data-disabled] {
-    background-color: gu-colour(neutral-100);
-    opacity: .5;
-    pointer-events: none;
-  }
 }
 
 .component-button--non-interactive {
@@ -73,6 +67,15 @@
   &:hover, &:focus {
     background: gu-colour(neutral-97);
   }
+}
+
+.component-button--disabled,
+.component-button[disabled],
+.component-button[data-disabled] {
+  color: gu-colour(neutral-60);
+  background-color: gu-colour(neutral-93);
+  border: 1px solid gu-colour(neutral-86);
+  cursor: not-allowed;
 }
 
 .component-button__content,

--- a/support-frontend/assets/components/button/button.scss
+++ b/support-frontend/assets/components/button/button.scss
@@ -23,6 +23,10 @@
   }
 }
 
+&[data-disabled] {
+  pointer-events: none;
+}
+
 .component-button--non-interactive {
   pointer-events: none;
 }

--- a/support-frontend/assets/components/button/button.scss
+++ b/support-frontend/assets/components/button/button.scss
@@ -21,12 +21,11 @@
   &:hover, &:focus {
     outline: 0;
   }
-}
 
-&[data-disabled] {
-  pointer-events: none;
+  &[data-disabled] {
+    pointer-events: none;
+  }
 }
-
 .component-button--non-interactive {
   pointer-events: none;
 }

--- a/support-frontend/assets/components/forms/customFields/checkbox.jsx
+++ b/support-frontend/assets/components/forms/customFields/checkbox.jsx
@@ -10,7 +10,7 @@ import './checkbox.scss';
 
 type PropTypes = {
   id?: string,
-  text: Node,
+  text: Node
 };
 
 // ----- Component ----- //

--- a/support-frontend/assets/components/marketingConsent/marketingConsent.jsx
+++ b/support-frontend/assets/components/marketingConsent/marketingConsent.jsx
@@ -13,6 +13,7 @@ import { logException } from 'helpers/logger';
 import Button from 'components/button/button';
 import NonInteractiveButton from 'components/button/nonInteractiveButton';
 import 'components/marketingConsent/marketingConsent.scss';
+import type { ThankYouPageMarketingComponentTestVariants } from 'helpers/abTests/abtestDefinitions';
 
 // ----- Types ----- //
 
@@ -20,12 +21,18 @@ type ButtonPropTypes = {|
   confirmOptIn: ?boolean,
   email: string,
   csrf: CsrfState,
-  onClick: (?string, CsrfState) => void,
+  onClick: (?string, CsrfState, ?ThankYouPageMarketingComponentTestVariants) => void,
   requestPending: boolean,
+  marketingComponentVariant?: ThankYouPageMarketingComponentTestVariants,
 |};
 
 type PropTypes = {|
-  ...ButtonPropTypes,
+  confirmOptIn: ?boolean,
+  email: string,
+  csrf: CsrfState,
+  onClick: (?string, CsrfState, ?ThankYouPageMarketingComponentTestVariants) => void,
+  requestPending: boolean,
+  marketingComponentVariant?: ThankYouPageMarketingComponentTestVariants,
   error: boolean,
   render: ({title: string, message: string}) => Node
 |};
@@ -60,15 +67,18 @@ function MarketingButton(props: ButtonPropTypes) {
       iconSide="right"
       aria-label="Sign me up to news and offers from The Guardian"
       onClick={
-          () => props.onClick(props.email, props.csrf)
+          () => props.onClick(props.email, props.csrf, props.marketingComponentVariant)
         }
       icon={<SvgSubscribe />}
     >
         Sign me up
     </Button>
   );
-
 }
+
+MarketingButton.defaultProps = {
+  marketingComponentVariant: 'notintest',
+};
 
 function MarketingConsent(props: PropTypes) {
 
@@ -94,6 +104,7 @@ function MarketingConsent(props: PropTypes) {
           csrf: props.csrf,
           onClick: props.onClick,
           requestPending: props.requestPending,
+          marketingComponentVariant: props.marketingComponentVariant,
         })}
 
         <p className="component-marketing-consent-confirmation">
@@ -118,6 +129,7 @@ function MarketingConsent(props: PropTypes) {
 MarketingConsent.defaultProps = {
   error: false,
   requestPending: false,
+  marketingComponentVariant: 'notintest',
   render: ({ title, message }: {title: string, message: string}) => (
     <div>
       <h3 className="contribution-thank-you-block__title">{title}</h3>

--- a/support-frontend/assets/components/marketingConsent/marketingConsent.scss
+++ b/support-frontend/assets/components/marketingConsent/marketingConsent.scss
@@ -16,3 +16,24 @@
   margin-top: $gu-v-spacing/4;
   font-weight: 100;
 }
+
+.component-marketing-consent--with-checkbox .component-checkbox__text {
+  @include gu-typeface(textSans, 14);
+  display: initial ;
+  align-items: initial;
+  position: relative;
+  padding-left: 30px;
+  line-height: 16px;
+  margin-bottom: $gu-v-spacing;
+}
+
+.component-marketing-consent--with-checkbox .component-checkbox__text:before {
+  display: block;
+  position: absolute;
+  left: 0;
+  top: 2px;
+}
+
+.component-marketing-consent--with-checkbox .component-checkbox__tick {
+  top: 5px;
+}

--- a/support-frontend/assets/components/marketingConsent/marketingConsent.scss
+++ b/support-frontend/assets/components/marketingConsent/marketingConsent.scss
@@ -5,6 +5,7 @@
   font-weight: 300;
   margin: 0 -10px;
   padding: 0 10px ($gu-v-spacing * 2);
+
   .svg-newsletters {
     width: 100%;
   }
@@ -19,21 +20,6 @@
 
 .component-marketing-consent--with-checkbox .component-checkbox__text {
   @include gu-typeface(textSans, 14);
-  display: initial ;
-  align-items: initial;
-  position: relative;
-  padding-left: 30px;
   line-height: 16px;
   margin-bottom: $gu-v-spacing;
-}
-
-.component-marketing-consent--with-checkbox .component-checkbox__text:before {
-  display: block;
-  position: absolute;
-  left: 0;
-  top: 2px;
-}
-
-.component-marketing-consent--with-checkbox .component-checkbox__tick {
-  top: 5px;
 }

--- a/support-frontend/assets/components/marketingConsent/marketingConsentWithCheckbox.jsx
+++ b/support-frontend/assets/components/marketingConsent/marketingConsentWithCheckbox.jsx
@@ -14,6 +14,7 @@ import Button from 'components/button/button';
 import NonInteractiveButton from 'components/button/nonInteractiveButton';
 import { CheckboxInput } from 'components/forms/customFields/checkbox';
 import 'components/marketingConsent/marketingConsent.scss';
+import type { ThankYouPageMarketingComponentTestVariants } from 'helpers/abTests/abtestDefinitions';
 
 // ----- Types ----- //
 
@@ -21,13 +22,19 @@ type ButtonPropTypes = {|
   confirmOptIn: ?boolean,
   email: string,
   csrf: CsrfState,
-  onClick: (?string, CsrfState) => void,
+  onClick: (?string, CsrfState, ?ThankYouPageMarketingComponentTestVariants) => void,
   requestPending: boolean,
+  marketingComponentVariant?: ThankYouPageMarketingComponentTestVariants,
   checkboxChecked: boolean,
 |};
 
 type PropTypes = {|
-  ...ButtonPropTypes,
+  confirmOptIn: ?boolean,
+  email: string,
+  csrf: CsrfState,
+  onClick: (?string, CsrfState, ?ThankYouPageMarketingComponentTestVariants) => void,
+  requestPending: boolean,
+  marketingComponentVariant?: ThankYouPageMarketingComponentTestVariants,
   error: boolean,
   renderMessage: ({title: string, message: string}) => Node
 |};
@@ -77,15 +84,18 @@ function MarketingButton(props: ButtonPropTypes) {
       iconSide="right"
       aria-label="Sign me up to news and offers from The Guardian"
       onClick={
-          () => props.onClick(props.email, props.csrf)
+          () => props.onClick(props.email, props.csrf, props.marketingComponentVariant)
         }
       icon={<SvgSubscribe />}
     >
         Sign me up
     </Button>
   );
-
 }
+
+MarketingButton.defaultProps = {
+  marketingComponentVariant: 'notintest',
+};
 
 const renderMessage = ({ title, message }: {title: string, message: string}) => (
   <div>
@@ -100,6 +110,7 @@ class MarketingConsentWithCheckbox extends Component<PropTypes, StateTypes> {
     error: false,
     requestPending: false,
     renderMessage,
+    marketingComponentVariant: 'notintest',
   };
 
   state = {
@@ -139,6 +150,7 @@ class MarketingConsentWithCheckbox extends Component<PropTypes, StateTypes> {
             csrf: this.props.csrf,
             onClick: this.props.onClick,
             requestPending: this.props.requestPending,
+            marketingComponentVariant: this.props.marketingComponentVariant,
             checkboxChecked: this.state.checkboxChecked,
           })}
 

--- a/support-frontend/assets/components/marketingConsent/marketingConsentWithCheckbox.jsx
+++ b/support-frontend/assets/components/marketingConsent/marketingConsentWithCheckbox.jsx
@@ -17,7 +17,7 @@ import 'components/marketingConsent/marketingConsent.scss';
 
 // ----- Types ----- //
 
-type ButtonPropTypes = {|
+export type ButtonPropTypes = {|
   confirmOptIn: ?boolean,
   email: string,
   csrf: CsrfState,
@@ -26,13 +26,13 @@ type ButtonPropTypes = {|
   checkboxChecked: boolean,
 |};
 
-type PropTypes = {|
+export type PropTypes = {|
   ...ButtonPropTypes,
   error: boolean,
-  render: ({title: string, message: string}) => Node
+  renderMessage: ({title: string, message: string}) => Node
 |};
 
-type StateTypes ={|
+export type StateTypes ={|
   checkboxChecked: boolean,
 |}
 
@@ -87,18 +87,19 @@ function MarketingButton(props: ButtonPropTypes) {
 
 }
 
+const renderMessage = ({ title, message }: {title: string, message: string}) => (
+  <div>
+    <h3 className="contribution-thank-you-block__title">{title}</h3>
+    <p className="contribution-thank-you-block__message">
+      {message}
+    </p>
+  </div>);
+
 class MarketingConsentWithCheckbox extends Component<PropTypes, StateTypes> {
   static defaultProps = {
     error: false,
     requestPending: false,
-    render: ({ title, message }: {title: string, message: string}) => (
-      <div>
-        <h3 className="contribution-thank-you-block__title">{title}</h3>
-        <p className="contribution-thank-you-block__message">
-          {message}
-        </p>
-      </div>
-    ),
+    renderMessage,
   };
 
   state = {
@@ -117,7 +118,7 @@ class MarketingConsentWithCheckbox extends Component<PropTypes, StateTypes> {
     if (checkEmail(this.props.email)) {
       return (
         <section className={classNameWithModifiers('component-marketing-consent', ['newsletter', 'with-checkbox'])}>
-          {this.props.render({
+          {this.props.renderMessage({
             title: 'Would you like to receive a weekly email from inside The Guardian? ',
             message: 'Our membership editor will discuss the most important news stories from the week and suggest compelling articles to read. Opt in below to receive this and more information on ways to support The Guardian.',
           })}
@@ -138,7 +139,7 @@ class MarketingConsentWithCheckbox extends Component<PropTypes, StateTypes> {
             csrf: this.props.csrf,
             onClick: this.props.onClick,
             requestPending: this.props.requestPending,
-            checkboxChecked: this.state.checkboxChecked || false,
+            checkboxChecked: this.state.checkboxChecked,
           })}
 
           <p className="component-marketing-consent-confirmation">

--- a/support-frontend/assets/components/marketingConsent/marketingConsentWithCheckbox.jsx
+++ b/support-frontend/assets/components/marketingConsent/marketingConsentWithCheckbox.jsx
@@ -1,0 +1,164 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React, { Component, type Node } from 'react';
+import { classNameWithModifiers } from 'helpers/utilities';
+import SvgSubscribe from 'components/svgs/subscribe';
+import SvgSubscribed from 'components/svgs/subscribed';
+import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
+import GeneralErrorMessage from 'components/generalErrorMessage/generalErrorMessage';
+import { checkEmail } from 'helpers/formValidation';
+import { logException } from 'helpers/logger';
+import Button from 'components/button/button';
+import NonInteractiveButton from 'components/button/nonInteractiveButton';
+import { CheckboxInput } from 'components/forms/customFields/checkbox';
+import 'components/marketingConsent/marketingConsent.scss';
+
+// ----- Types ----- //
+
+type ButtonPropTypes = {|
+  confirmOptIn: ?boolean,
+  email: string,
+  csrf: CsrfState,
+  onClick: (?string, CsrfState) => void,
+  requestPending: boolean,
+  checkboxChecked: boolean,
+|};
+
+type PropTypes = {|
+  ...ButtonPropTypes,
+  error: boolean,
+  render: ({title: string, message: string}) => Node
+|};
+
+type StateTypes ={|
+  checkboxChecked: boolean,
+|}
+
+// ----- Render ----- //
+
+function MarketingButton(props: ButtonPropTypes) {
+  if (props.confirmOptIn === true) {
+    return (
+      <NonInteractiveButton
+        appearance="greyHollow"
+        iconSide="right"
+        icon={<SvgSubscribed />}
+      >
+        Signed up
+      </NonInteractiveButton>
+    );
+  } else if (props.requestPending === true) {
+    return (
+      <NonInteractiveButton
+        appearance="greyHollow"
+        iconSide="right"
+        icon={<SvgSubscribe />}
+      >
+        Pending...
+      </NonInteractiveButton>
+    );
+  } else if (!props.checkboxChecked) {
+    return (
+      <Button
+        disabled
+        appearance="disabled"
+        iconSide="right"
+        icon={<SvgSubscribe />}
+      >
+        Sign me up
+      </Button>
+    );
+  }
+  return (
+    <Button
+      appearance="greyHollow"
+      iconSide="right"
+      aria-label="Sign me up to news and offers from The Guardian"
+      onClick={
+          () => props.onClick(props.email, props.csrf)
+        }
+      icon={<SvgSubscribe />}
+    >
+        Sign me up
+    </Button>
+  );
+
+}
+
+class MarketingConsentWithCheckbox extends Component<PropTypes, StateTypes> {
+  static defaultProps = {
+    error: false,
+    requestPending: false,
+    render: ({ title, message }: {title: string, message: string}) => (
+      <div>
+        <h3 className="contribution-thank-you-block__title">{title}</h3>
+        <p className="contribution-thank-you-block__message">
+          {message}
+        </p>
+      </div>
+    ),
+  };
+
+  state = {
+    checkboxChecked: false,
+  }
+
+  render() {
+    if (this.props.error) {
+      return (<GeneralErrorMessage
+        classModifiers={['marketing_consent_api_error']}
+        errorHeading="Sorry, something went wrong"
+        errorReason="marketing_consent_api_error"
+      />);
+    }
+
+    if (checkEmail(this.props.email)) {
+      return (
+        <section className={classNameWithModifiers('component-marketing-consent', ['newsletter', 'with-checkbox'])}>
+          {this.props.render({
+            title: 'Would you like to receive a weekly email from inside The Guardian? ',
+            message: 'Our membership editor will discuss the most important news stories from the week and suggest compelling articles to read. Opt in below to receive this and more information on ways to support The Guardian.',
+          })}
+
+          <CheckboxInput
+            id="marketing-checkbox"
+            text="Contributions, subscriptions and membership: Get related news and offers – whether you are a contributor, subscriber, member or would like to become one. You can unsubscribe at any time."
+            onChange={(e) => {
+              this.setState({
+                checkboxChecked: e.target.checked,
+              });
+            }}
+          />
+
+          {MarketingButton({
+            confirmOptIn: this.props.confirmOptIn,
+            email: this.props.email,
+            csrf: this.props.csrf,
+            onClick: this.props.onClick,
+            requestPending: this.props.requestPending,
+            checkboxChecked: this.state.checkboxChecked || false,
+          })}
+
+          <p className="component-marketing-consent-confirmation">
+            <small>
+              {this.props.confirmOptIn === true ?
+                'We\'ll be in touch. Check your inbox for a confirmation link.' :
+                <div>
+                  <span className="component-marketing-consent-confirmation__message">You can unsubscribe at any time</span>
+                </div>
+              }
+            </small>
+          </p>
+        </section>
+      );
+    }
+
+    logException('Unable to display marketing consent button due to not having a valid email address to send to the API');
+    return null;
+  }
+}
+
+// ----- Exports ----- //
+export default MarketingConsentWithCheckbox;

--- a/support-frontend/assets/components/marketingConsent/marketingConsentWithCheckbox.jsx
+++ b/support-frontend/assets/components/marketingConsent/marketingConsentWithCheckbox.jsx
@@ -17,7 +17,7 @@ import 'components/marketingConsent/marketingConsent.scss';
 
 // ----- Types ----- //
 
-export type ButtonPropTypes = {|
+type ButtonPropTypes = {|
   confirmOptIn: ?boolean,
   email: string,
   csrf: CsrfState,
@@ -26,13 +26,13 @@ export type ButtonPropTypes = {|
   checkboxChecked: boolean,
 |};
 
-export type PropTypes = {|
+type PropTypes = {|
   ...ButtonPropTypes,
   error: boolean,
   renderMessage: ({title: string, message: string}) => Node
 |};
 
-export type StateTypes ={|
+type StateTypes ={|
   checkboxChecked: boolean,
 |}
 

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -29,6 +29,16 @@ export const tests: Tests = {
     canRun: () => !!getCookie('gu.contributions.contrib-timestamp'),
   },
 
+  // JTL - 31 July 2019 - Ab-test: thankYouPageMarketingComponent
+  // files related to this test:
+  // - 'MarketingConsentContainer.jsx' became 'MarketingConsentControlContainer.jsx' and
+  //    'MarketingConsentVariantContainer.jsx'
+  // - 'MarketingConsentControlContainer.jsx renders the MarketingComponent (which
+  //    should not be deleted regardless of this test's results because subscriptions
+  //    uses it)
+  // - 'MarketingConsentVariantContainer.jsx renders the MarketingComponent (which should become
+  //    our default if it succeeds)
+
   thankYouPageMarketingComponent: {
     type: 'OTHER',
     variants: [

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -38,6 +38,9 @@ export const tests: Tests = {
   //    uses it)
   // - 'MarketingConsentVariantContainer.jsx renders the MarketingComponent (which should become
   //    our default if it succeeds)
+  // - 'ContributionsThankYouContainer', 'ContributionsThankYou', and
+  //    'ContributionsThankYouPasswordSet' all incorporate the variants to control which
+  //    marketing component is rendered on the thank you pages
 
   thankYouPageMarketingComponent: {
     type: 'OTHER',

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -4,6 +4,7 @@ import { get as getCookie } from 'helpers/cookie';
 
 // ----- Tests ----- //
 export type LandingPageCopyReturningSinglesTestVariants = 'control' | 'returningSingle' | 'notintest';
+export type ThankYouPageMarketingComponentTestVariants = 'control' | 'newMarketingComponent' | 'notintest';
 
 export const tests: Tests = {
   landingPageCopyReturningSingles: {
@@ -26,5 +27,26 @@ export const tests: Tests = {
     independent: true,
     seed: 1,
     canRun: () => !!getCookie('gu.contributions.contrib-timestamp'),
+  },
+
+  thankYouPageMarketingComponent: {
+    type: 'OTHER',
+    variants: [
+      {
+        id: 'control',
+      },
+      {
+        id: 'newMarketingComponent',
+      },
+    ],
+    audiences: {
+      ALL: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: true,
+    independent: true,
+    seed: 2,
   },
 };

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
@@ -6,7 +6,8 @@ import { type Dispatch } from 'redux';
 import React from 'react';
 import { connect } from 'react-redux';
 import { type ContributionType, getSpokenType } from 'helpers/contributions';
-import MarketingConsent from '../MarketingConsentContainer';
+import MarketingConsentControl from 'pages/contributions-landing/components/MarketingConsentControlContainer';
+import MarketingConsentVariant from 'pages/contributions-landing/components/MarketingConsentVariantContainer';
 import {
   type Action,
   setHasSeenDirectDebitThankYouCopy,
@@ -24,6 +25,7 @@ import {
   trackComponentLoad,
 } from 'helpers/tracking/behaviour';
 import TrackableButton from 'components/button/trackableButton';
+import type { ThankYouPageMarketingComponentTestVariants } from 'helpers/abTests/abtestDefinitions';
 
 // ----- Types ----- //
 
@@ -38,6 +40,7 @@ type PropTypes = {|
   csrf: string,
   emailValidated: boolean,
   paymentComplete: boolean,
+  marketingComponentVariant: ThankYouPageMarketingComponentTestVariants,
 |};
 /* eslint-enable react/no-unused-prop-types */
 
@@ -185,7 +188,13 @@ function ContributionThankYou(props: PropTypes) {
           </section>
         ) : null}
         { renderIdentityCTA() }
-        <MarketingConsent />
+        {props.marketingComponentVariant === 'newMarketingComponent' ? (
+          <MarketingConsentVariant />
+          )
+         : (
+           <MarketingConsentControl />
+        )
+        }
         <ContributionSurvey isRunning={false} />
         <SpreadTheWord />
         <div className="gu-content__return-link">

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouContainer.jsx
@@ -8,17 +8,20 @@ import { type ThankYouPageStageMap, type ThankYouPageStage } from '../../contrib
 import ContributionThankYou from './ContributionThankYou';
 import ContributionThankYouSetPassword from './ContributionThankYouSetPassword';
 import ContributionThankYouPasswordSet from './ContributionThankYouPasswordSet';
+import type { ThankYouPageMarketingComponentTestVariants } from 'helpers/abTests/abtestDefinitions';
 
 // ----- Types ----- //
 
 /* eslint-disable react/no-unused-prop-types */
 type PropTypes = {|
   thankYouPageStage: ThankYouPageStage,
+  marketingComponentVariant: ThankYouPageMarketingComponentTestVariants,
 |};
 /* eslint-enable react/no-unused-prop-types */
 
 const mapStateToProps = state => ({
   thankYouPageStage: state.page.form.thankYouPageStage,
+  marketingComponentVariant: state.common.abParticipations.thankYouPageMarketingComponent,
 });
 
 // ----- Render ----- //
@@ -26,10 +29,18 @@ const mapStateToProps = state => ({
 function ContributionThankYouContainer(props: PropTypes) {
 
   const thankYouPageStage: ThankYouPageStageMap<React$Element<*>> = {
-    thankYou: (<ContributionThankYou />),
-    thankYouSetPassword: (<ContributionThankYouSetPassword />),
-    thankYouPasswordDeclinedToSet: (<ContributionThankYou />),
-    thankYouPasswordSet: (<ContributionThankYouPasswordSet />),
+    thankYou: (
+      <ContributionThankYou marketingComponentVariant={props.marketingComponentVariant} />
+    ),
+    thankYouSetPassword: (
+      <ContributionThankYouSetPassword />
+    ),
+    thankYouPasswordDeclinedToSet: (
+      <ContributionThankYou marketingComponentVariant={props.marketingComponentVariant} />
+    ),
+    thankYouPasswordSet: (
+      <ContributionThankYouPasswordSet marketingComponentVariant={props.marketingComponentVariant} />
+    ),
   };
 
   return (

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouPasswordSet.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouPasswordSet.jsx
@@ -3,16 +3,24 @@
 // ----- Imports ----- //
 
 import React from 'react';
-import MarketingConsent from '../MarketingConsentContainer';
+import MarketingConsentControl from 'pages/contributions-landing/components/MarketingConsentControlContainer';
+import MarketingConsentVariant from 'pages/contributions-landing/components/MarketingConsentVariantContainer';
 import AnchorButton from 'components/button/anchorButton';
 import SvgArrowLeft from 'components/svgs/arrowLeftStraight';
 import { ContributionThankYouBlurb } from './ContributionThankYouBlurb';
 import SpreadTheWord from 'components/spreadTheWord/spreadTheWord';
 import ContributionSurvey from '../ContributionSurvey/ContributionsSurvey';
+import type { ThankYouPageMarketingComponentTestVariants } from 'helpers/abTests/abtestDefinitions';
+
+// ----- Types ----- //
+
+type PropTypes = {|
+  marketingComponentVariant: ThankYouPageMarketingComponentTestVariants,
+|};
 
 // ----- Render ----- //
 
-function ContributionThankYouPasswordSet() {
+function ContributionThankYouPasswordSet(props: PropTypes) {
   const title = 'You now have a Guardian account';
   const body = 'Please check your inbox to validate your email address – it only takes a minute. And then sign in on each of the devices you use to access The Guardian.';
 
@@ -25,7 +33,13 @@ function ContributionThankYouPasswordSet() {
             {body}
           </p>
         </section>
-        <MarketingConsent />
+        {props.marketingComponentVariant === 'newMarketingComponent' ? (
+          <MarketingConsentVariant />
+          )
+          : (
+            <MarketingConsentControl />
+          )
+        }
         <ContributionSurvey isRunning={false} />
         <SpreadTheWord />
         <div className="gu-content__return-link">

--- a/support-frontend/assets/pages/contributions-landing/components/MarketingConsentContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/MarketingConsentContainer.jsx
@@ -3,7 +3,7 @@
 // ----- Imports ----- //
 
 import { connect } from 'react-redux';
-import MarketingConsent from 'components/marketingConsent/marketingConsent';
+import MarketingConsentWithCheckbox from 'components/marketingConsent/marketingConsentWithCheckbox';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
 import type { Dispatch } from 'redux';
 import type { Action } from 'helpers/user/userActions';
@@ -35,4 +35,4 @@ function mapDispatchToProps(dispatch: Dispatch<Action>) {
 }
 
 
-export default connect(mapStateToProps, mapDispatchToProps)(MarketingConsent);
+export default connect(mapStateToProps, mapDispatchToProps)(MarketingConsentWithCheckbox);

--- a/support-frontend/assets/pages/contributions-landing/components/MarketingConsentControlContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/MarketingConsentControlContainer.jsx
@@ -3,12 +3,13 @@
 // ----- Imports ----- //
 
 import { connect } from 'react-redux';
-import MarketingConsentWithCheckbox from 'components/marketingConsent/marketingConsentWithCheckbox';
+import MarketingConsent from 'components/marketingConsent/marketingConsent';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
 import type { Dispatch } from 'redux';
 import type { Action } from 'helpers/user/userActions';
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import { sendMarketingPreferencesToIdentity } from 'components/marketingConsent/helpers';
+import type { ThankYouPageMarketingComponentTestVariants } from 'helpers/abTests/abtestDefinitions';
 
 
 const mapStateToProps = state => ({
@@ -17,12 +18,20 @@ const mapStateToProps = state => ({
   csrf: state.page.csrf,
   error: state.page.marketingConsent.error,
   requestPending: state.page.marketingConsent.requestPending,
+  marketingComponentVariant: state.common.abParticipations.thankYouPageMarketingComponent,
 });
 
 function mapDispatchToProps(dispatch: Dispatch<Action>) {
   return {
-    onClick: (email: string, csrf: CsrfState) => {
+    onClick: (
+      email: string,
+      csrf: CsrfState,
+      marketingComponentVariant?: ThankYouPageMarketingComponentTestVariants,
+    ) => {
       trackComponentClick('marketing-permissions');
+      if (marketingComponentVariant && marketingComponentVariant !== 'notintest') {
+        trackComponentClick(`marketing-permissions-abtest-${marketingComponentVariant}`);
+      }
       sendMarketingPreferencesToIdentity(
         true, // it's TRUE because the button says Sign Me Up!
         email,
@@ -35,4 +44,4 @@ function mapDispatchToProps(dispatch: Dispatch<Action>) {
 }
 
 
-export default connect(mapStateToProps, mapDispatchToProps)(MarketingConsentWithCheckbox);
+export default connect(mapStateToProps, mapDispatchToProps)(MarketingConsent);

--- a/support-frontend/assets/pages/contributions-landing/components/MarketingConsentVariantContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/MarketingConsentVariantContainer.jsx
@@ -1,0 +1,47 @@
+// @flow
+
+// ----- Imports ----- //
+
+import { connect } from 'react-redux';
+import MarketingConsentWithCheckbox from 'components/marketingConsent/marketingConsentWithCheckbox';
+import { trackComponentClick } from 'helpers/tracking/behaviour';
+import type { Dispatch } from 'redux';
+import type { Action } from 'helpers/user/userActions';
+import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
+import { sendMarketingPreferencesToIdentity } from 'components/marketingConsent/helpers';
+import type { ThankYouPageMarketingComponentTestVariants } from 'helpers/abTests/abtestDefinitions';
+
+
+const mapStateToProps = state => ({
+  confirmOptIn: state.page.marketingConsent.confirmOptIn,
+  email: state.page.form.formData.email,
+  csrf: state.page.csrf,
+  error: state.page.marketingConsent.error,
+  requestPending: state.page.marketingConsent.requestPending,
+  marketingComponentVariant: state.common.abParticipations.thankYouPageMarketingComponent,
+});
+
+function mapDispatchToProps(dispatch: Dispatch<Action>) {
+  return {
+    onClick: (
+      email: string,
+      csrf: CsrfState,
+      marketingComponentVariant?: ThankYouPageMarketingComponentTestVariants,
+    ) => {
+      trackComponentClick('marketing-permissions');
+      if (marketingComponentVariant && marketingComponentVariant !== 'notintest') {
+        trackComponentClick(`marketing-permissions-abtest-${marketingComponentVariant}`);
+      }
+      sendMarketingPreferencesToIdentity(
+        true, // it's TRUE because the button says Sign Me Up!
+        email,
+        dispatch,
+        csrf,
+        'MARKETING_CONSENT',
+      );
+    },
+  };
+}
+
+
+export default connect(mapStateToProps, mapDispatchToProps)(MarketingConsentWithCheckbox);


### PR DESCRIPTION
## Why are you doing this?

We have a design for a new marketing component and this needs to be 'QA tested' alongside our current marketing component. We aren't looking for anything scientific in this test, just want to watch the two alongside each other for a couple days to make sure we are getting opt-ins through both. Then we will be able to switch over to the 'newer' component (with checkbox).

Doing this as an A/B test was unexpectedly complicated and involved touching a lot of files that I didn't expect to need to touch. I have added inline documentation to help with removing this as a test when that time comes.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com)

## Changes

* Created new marketing option as `MarketingComponentWithCheckbox`
* Implemented it across contributions thank you pages as an AB test against the current `MarketingComponent`

## Screenshots
Control:
![marketing abtest control](https://user-images.githubusercontent.com/3300789/62302618-945e7300-b472-11e9-8aec-bd9e6850cc92.png)

Variant ("new"):
![marketing abtest variant](https://user-images.githubusercontent.com/3300789/62302624-97f1fa00-b472-11e9-8db6-3b610b1ed893.png)