### PR TITLE
Track PayPal subs form submissions

### DIFF
--- a/support-frontend/assets/helpers/subscriptionsForms/submit.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.js
@@ -51,7 +51,10 @@ import {
   validateCheckoutForm,
   validateWithDeliveryForm,
 } from 'helpers/subscriptionsForms/formValidation';
-import { isPhysicalProduct } from 'helpers/subscriptions';
+import {
+  isPhysicalProduct,
+  type SubscriptionProduct,
+} from 'helpers/subscriptions';
 import {
   loadStripe,
   openDialogBox,
@@ -61,7 +64,6 @@ import { isPostDeployUser } from 'helpers/user/user';
 import type { BillingPeriod } from 'helpers/billingPeriods';
 import { Quarterly, SixWeekly } from 'helpers/billingPeriods';
 import { trackCheckoutSubmitAttempt } from '../tracking/behaviour';
-import { type SubscriptionProduct } from 'helpers/subscriptions';
 
 // ----- Functions ----- //
 
@@ -316,4 +318,5 @@ export {
   showStripe,
   submitCheckoutForm,
   submitWithDeliveryForm,
+  trackSubmitAttempt,
 };

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
@@ -4,12 +4,16 @@
 
 import React from 'react';
 import { Provider } from 'react-redux';
-import { Route, BrowserRouter } from 'react-router-dom';
+import { BrowserRouter, Route } from 'react-router-dom';
 
 import { isDetailsSupported, polyfillDetails } from 'helpers/details';
 import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
-import { detect, countryGroups, type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import {
+  type CountryGroupId,
+  countryGroups,
+  detect,
+} from 'helpers/internationalisation/countryGroup';
 import * as user from 'helpers/user/user';
 import { gaEvent } from 'helpers/tracking/googleTagManager';
 import * as storage from 'helpers/storage';
@@ -22,7 +26,8 @@ import { init as formInit } from './contributionsLandingInit';
 import { initReducer } from './contributionsLandingReducer';
 import { ContributionFormContainer } from './components/ContributionFormContainer';
 import { enableOrDisableForm } from './checkoutFormIsSubmittableActions';
-import ContributionThankYouContainer from './components/ContributionThankYou/ContributionThankYouContainer';
+import ContributionThankYouContainer
+  from './components/ContributionThankYou/ContributionThankYouContainer';
 import { setUserStateActions } from './setUserStateActions';
 import ConsentBanner from '../../components/consentBanner/consentBanner';
 import './contributionsLanding.scss';
@@ -69,7 +74,7 @@ const selectedCountryGroup = countryGroups[countryGroupId];
 
 const ONE_OFF_CONTRIBUTION_COOKIE = 'gu.contributions.contrib-timestamp';
 const currentTimeInEpochMilliseconds: number = Date.now();
-const cookieDaysToLive = 30*6;
+const cookieDaysToLive = 30 * 6;
 
 const setOneOffContributionCookie = () => {
   setCookie(

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -58,6 +58,7 @@ import {
   trackSubmitAttempt,
 } from 'helpers/subscriptionsForms/submit';
 import { BillingPeriodSelector } from 'components/subscriptionCheckouts/billingPeriodSelector';
+import { PayPal } from 'helpers/paymentMethods';
 
 // ----- Types ----- //
 
@@ -120,7 +121,7 @@ function mapDispatchToProps() {
       // We need to track PayPal payment attempts here because PayPal behaves
       // differently to other payment methods. All others are tracked in submit.js
       const { paymentMethod } = state.page.checkout;
-      if(paymentMethod === PayPal) {
+      if (paymentMethod === PayPal) {
         trackSubmitAttempt(PayPal, DigitalPack);
       }
     },

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -53,7 +53,10 @@ import {
   checkoutFormIsValid,
   validateCheckoutForm,
 } from 'helpers/subscriptionsForms/formValidation';
-import { submitCheckoutForm } from 'helpers/subscriptionsForms/submit';
+import {
+  submitCheckoutForm,
+  trackSubmitAttempt,
+} from 'helpers/subscriptionsForms/submit';
 import { BillingPeriodSelector } from 'components/subscriptionCheckouts/billingPeriodSelector';
 
 // ----- Types ----- //
@@ -111,8 +114,16 @@ function mapDispatchToProps() {
     formIsValid: () => (dispatch: Dispatch<Action>, getState: () => CheckoutState) => checkoutFormIsValid(getState()),
     submitForm: () => (dispatch: Dispatch<Action>, getState: () => CheckoutState) =>
       submitCheckoutForm(dispatch, getState()),
-    validateForm: () => (dispatch: Dispatch<Action>, getState: () => CheckoutState) =>
-      validateCheckoutForm(dispatch, getState()),
+    validateForm: () => (dispatch: Dispatch<Action>, getState: () => CheckoutState) => {
+      const state = getState();
+      validateCheckoutForm(dispatch, state);
+      // We need to track PayPal payment attempts here because PayPal behaves
+      // differently to other payment methods. All others are tracked in submit.js
+      const { paymentMethod } = state.page.checkout;
+      if(paymentMethod === PayPal) {
+        trackSubmitAttempt(PayPal, DigitalPack);
+      }
+    },
     setupRecurringPayPalPayment: setupSubscriptionPayPalPayment,
     signOut,
   };


### PR DESCRIPTION
## Why are you doing this?
PayPal payments work differently to the other payment methods because PayPal provides its own button so it's a bit more tricky to track click events.
This PR adds PayPal button click tracking into the Digital Pack page which is the only one that currently has PayPal. If/when we add PayPal to the other products then we will have to add similar tracking to the other checkout forms.

[**Trello Card**](https://trello.com/c/nCpd0NnR/2447-dev-add-tracking-to-digital-pack-checkout)
