### PR TITLE
bump version of identity-auth-play

### DIFF
--- a/support-frontend/app/services/AuthenticationService.scala
+++ b/support-frontend/app/services/AuthenticationService.scala
@@ -60,7 +60,8 @@ object AsyncAuthenticationService {
 
   def apply(config: Identity, testUserService: TestUserService)(implicit ec: ExecutionContext): AsyncAuthenticationService = {
     val apiUrl = Uri.unsafeFromString(config.apiUrl)
-    val identityPlayAuthService = IdentityPlayAuthService.unsafeInit(apiUrl, config.apiClientToken, targetClient = "membership")
+    // TOOD: targetClient could probably be None - check and release in subsequent PR.
+    val identityPlayAuthService = IdentityPlayAuthService.unsafeInit(apiUrl, config.apiClientToken, targetClient = Some("membership"))
     new AsyncAuthenticationService(identityPlayAuthService, testUserService)
   }
 

--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -32,7 +32,7 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-generic-extras" % circeVersion,
   "io.circe" %% "circe-parser" % circeVersion,
   "joda-time" % "joda-time" % "2.9.9",
-  "com.gu.identity" %% "identity-auth-play" % "3.184-M6",
+  "com.gu.identity" %% "identity-auth-play" % "3.184-M7",
   "com.gu" %% "identity-test-users" % "0.6",
   "com.google.guava" % "guava" % "25.0-jre",
   "com.netaporter" %% "scala-uri" % "0.4.16",


### PR DESCRIPTION
## Why are you doing this?

@jfsoul remarked that in a few instances, #1984 had introduced a sign-in loop. This was due to a failure to deserialise a user response from identity API due to an unexpected date time format. The new library versions that's being imported can handle the date time format that was causing the issue. See [#1581](https://github.com/guardian/identity/pull/1581) in identity for more context.
