### PR TITLE
Add additional tracking for the product checkout

### DIFF
--- a/support-frontend/assets/helpers/checkoutForm/onFormSubmit.js
+++ b/support-frontend/assets/helpers/checkoutForm/onFormSubmit.js
@@ -29,12 +29,12 @@ export const onFormSubmit = (params: FormSubmitParameters) => {
       if (params.handlePayment) {
         params.handlePayment();
       }
-      trackCheckoutSubmitAttempt(componentId, `${params.flowPrefix}-allowed-for-user-type-${userType}`, params.paymentMethod);
+      trackCheckoutSubmitAttempt(componentId, `${params.flowPrefix}-allowed-for-user-type-${userType}`, params.paymentMethod, 'Contribution');
     } else {
-      trackCheckoutSubmitAttempt(componentId, `${params.flowPrefix}-blocked-because-user-type-is-${userType}`, params.paymentMethod);
+      trackCheckoutSubmitAttempt(componentId, `${params.flowPrefix}-blocked-because-user-type-is-${userType}`, params.paymentMethod, 'Contribution');
     }
   } else {
-    trackCheckoutSubmitAttempt(componentId, `${params.flowPrefix}-blocked-because-form-not-valid${invalidReason(params.form)}`, params.paymentMethod);
+    trackCheckoutSubmitAttempt(componentId, `${params.flowPrefix}-blocked-because-form-not-valid${invalidReason(params.form)}`, params.paymentMethod, 'Contribution');
   }
   params.setCheckoutFormHasBeenSubmitted();
 };

--- a/support-frontend/assets/helpers/checkoutForm/onFormSubmitOld.js
+++ b/support-frontend/assets/helpers/checkoutForm/onFormSubmitOld.js
@@ -1,7 +1,13 @@
 // @flow
 import type { ContributionType } from 'helpers/contributions';
-import { canContributeWithoutSigningIn, type UserTypeFromIdentityResponse } from 'helpers/identityApis';
-import { formElementIsValid, invalidReason } from 'helpers/checkoutForm/checkoutForm';
+import {
+  canContributeWithoutSigningIn,
+  type UserTypeFromIdentityResponse,
+} from 'helpers/identityApis';
+import {
+  formElementIsValid,
+  invalidReason,
+} from 'helpers/checkoutForm/checkoutForm';
 import { trackCheckoutSubmitAttempt } from 'helpers/tracking/behaviour';
 import type { PaymentMethod } from 'helpers/paymentMethods';
 
@@ -32,13 +38,13 @@ export const onFormSubmit = (params: FormSubmitParameters) => {
       if (params.handlePayment) {
         params.handlePayment();
       }
-      trackCheckoutSubmitAttempt(componentId, `${params.flowPrefix}-allowed-for-user-type-${userType}`, params.paymentMethod);
+      trackCheckoutSubmitAttempt(componentId, `${params.flowPrefix}-allowed-for-user-type-${userType}`, params.paymentMethod, 'Contribution');
     } else {
-      trackCheckoutSubmitAttempt(componentId, `${params.flowPrefix}-blocked-because-user-type-is-${userType}`, params.paymentMethod);
+      trackCheckoutSubmitAttempt(componentId, `${params.flowPrefix}-blocked-because-user-type-is-${userType}`, params.paymentMethod, 'Contribution');
     }
   } else {
     params.setFormIsValid(false);
-    trackCheckoutSubmitAttempt(componentId, `${params.flowPrefix}-blocked-because-form-not-valid${invalidReason(params.form)}`, params.paymentMethod);
+    trackCheckoutSubmitAttempt(componentId, `${params.flowPrefix}-blocked-because-form-not-valid${invalidReason(params.form)}`, params.paymentMethod, 'Contribution');
   }
   params.setCheckoutFormHasBeenSubmitted();
 };

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.js
@@ -243,7 +243,7 @@ function showPaymentMethod(
 
 function trackSubmitAttempt(paymentMethod: ?PaymentMethod, productType: SubscriptionProduct) {
   const componentId = `subs-checkout-submit-${productType}-${paymentMethod || ''}`;
-  trackCheckoutSubmitAttempt(componentId, productType, paymentMethod);
+  trackCheckoutSubmitAttempt(componentId, productType, paymentMethod, productType);
 }
 
 function submitForm(

--- a/support-frontend/assets/helpers/tracking/behaviour.js
+++ b/support-frontend/assets/helpers/tracking/behaviour.js
@@ -2,6 +2,7 @@
 import { trackComponentEvents } from 'helpers/tracking/ophan';
 import { gaEvent } from 'helpers/tracking/googleTagManager';
 import type { PaymentMethod } from 'helpers/paymentMethods';
+import type { SubscriptionProduct } from 'helpers/subscriptions';
 
 const trackPaymentMethodSelected = (paymentMethod: PaymentMethod): void => {
   gaEvent({
@@ -20,12 +21,19 @@ const trackPaymentMethodSelected = (paymentMethod: PaymentMethod): void => {
   });
 };
 
-const trackCheckoutSubmitAttempt = (componentId: string, eventDetails: string, paymentMethod: ?PaymentMethod): void => {
+export type ProductCheckout = 'Contribution' | SubscriptionProduct;
+
+const trackCheckoutSubmitAttempt = (
+  componentId: string,
+  eventDetails: string,
+  paymentMethod: ?PaymentMethod,
+  productCheckout: ProductCheckout,
+): void => {
   gaEvent({
     category: 'click',
     action: eventDetails,
     label: componentId,
-  }, { paymentMethod });
+  }, { paymentMethod, productCheckout });
 
   trackComponentEvents({
     component: {

--- a/support-models/build.sbt
+++ b/support-models/build.sbt
@@ -5,7 +5,7 @@ name := "support-models"
 description := "Scala library to provide shared step-function models to Guardian Support projects."
 
 libraryDependencies ++= Seq(
-  "com.gu" %% "acquisition-event-producer-play26" % "4.0.21",
+  "com.gu" %% "acquisition-event-producer-play26" % "4.0.22",
   "org.typelevel" %% "cats-core" % catsVersion,
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,


### PR DESCRIPTION
## Why are you doing this?

Add a `productCheckout` custom dimension to the GA tracking to allow us to distinguish between different checkouts in analyses.

Related PR here: https://github.com/guardian/acquisition-event-producer/pull/51

[**Trello Card**](https://trello.com/c/nCpd0NnR/2447-dev-add-tracking-to-digital-pack-checkout)
