### PR TITLE
Fix 2 fulfilment delay issues

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-checkout/helpers/__tests__/deliveryDays.js
+++ b/support-frontend/assets/pages/paper-subscription-checkout/helpers/__tests__/deliveryDays.js
@@ -11,6 +11,7 @@ const monday = 1551075752198; /* 2019-02-25 */
 const tuesday = 1551175752198; /* 2019-02-26 */
 const wednesday5amGMT = 1551243600000; /* 2019-02-27 05:00 GMT */
 const wednesday = 1551275752198; /* 2019-02-27 */
+const thursday4am = 1551326400000; /* 2019-02-28 04:00 GMT */
 const sunday = 1551577952198; /* 2019-03-03 */
 
 describe('deliveryDays', () => {
@@ -43,8 +44,16 @@ describe('deliveryDays', () => {
       const days = getVoucherDays(wednesday, 'Saturday');
       expect(formatMachineDate(days[0])).toEqual('2019-03-30');
     });
+    it('outside the fast delivery window (early morning), delivers Sixday on the next Monday, four weeks after the preceding Monday', () => {
+      const days = getVoucherDays(thursday4am, 'Sixday');
+      expect(formatMachineDate(days[0])).toEqual('2019-03-25');
+    });
     it('outside the fast delivery window, delivers Sixday on the next Monday, four weeks after the preceding Monday', () => {
       const days = getVoucherDays(wednesday, 'Sixday');
+      expect(formatMachineDate(days[0])).toEqual('2019-03-25');
+    });
+    it('outside the fast delivery window (on a Sunday), delivers Sixday on the next Monday, four weeks after the preceding Monday', () => {
+      const days = getVoucherDays(sunday, 'Sixday');
       expect(formatMachineDate(days[0])).toEqual('2019-03-25');
     });
 

--- a/support-frontend/assets/pages/paper-subscription-checkout/helpers/deliveryDays.js
+++ b/support-frontend/assets/pages/paper-subscription-checkout/helpers/deliveryDays.js
@@ -49,7 +49,9 @@ const getVoucherDays = (today: number, product: ProductOptions): Date[] => {
   const now = new Date(today);
   const [currentWeekday, currentHour] = [now.getDay(), now.getHours()];
   const weeksToAdd =
-    currentWeekday >= voucherExtraDelayCutoffWeekday && currentHour >= voucherExtraDelayCutoffHour
+    currentWeekday > voucherExtraDelayCutoffWeekday ||
+    currentWeekday === 0 || // For fulfilment, Sunday is the last day of the week
+    (currentWeekday === voucherExtraDelayCutoffWeekday && currentHour >= voucherExtraDelayCutoffHour)
       ? voucherExtraDelayWeeks
       : voucherNormalDelayWeeks;
   return getDeliveryDays(

--- a/support-frontend/assets/pages/weekly-subscription-checkout/helpers/__tests__/deliveryDays.js
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/helpers/__tests__/deliveryDays.js
@@ -8,8 +8,9 @@ import { formatMachineDate, formatUserDate } from 'helpers/dateConversions';
 
 // ----- Tests ----- //
 const tuesday = 1551175752198; /* 2019-02-26 */
-const friday = 1551399618000; /* 2019-01-01 */
+const friday = 1551399618000; /* 2019-03-01 */
 const thursday = 1551918018000; /* 2019-03-07 */
+const sunday = 1552176000000; /* 2019-03-10 */
 
 describe('deliveryDays', () => {
 
@@ -31,6 +32,10 @@ describe('deliveryDays', () => {
     it('if you order before wednesday midnight, it delivers the Weekly on Friday week', () => {
       const days = getWeeklyDays(tuesday);
       expect(formatMachineDate(days[0])).toEqual('2019-03-08');
+    });
+    it('if you order on a Sunday, it delivers the Weekly on Friday week', () => {
+      const days = getWeeklyDays(sunday);
+      expect(formatMachineDate(days[0])).toEqual('2019-03-22');
     });
   });
 

--- a/support-frontend/assets/pages/weekly-subscription-checkout/helpers/deliveryDays.js
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/helpers/deliveryDays.js
@@ -14,7 +14,8 @@ const getWeeklyDays = (today: ?number): Date[] => {
   const now = new Date(today || new Date().getTime());
   const currentWeekday = now.getDay();
   const weeksToAdd =
-      currentWeekday > extraDelayCutoffWeekday
+      currentWeekday > extraDelayCutoffWeekday || 
+      currentWeekday === 0 // Sunday is considered the last day of the week
         ? extraDelayWeeks
         : normalDelayWeeks;
   return getDeliveryDays(


### PR DESCRIPTION
## Why are you doing this?
Fixes 2 issues with fulfilment delays for vouchers and Guardian Weekly, namely:

- Sunday was being considered as the first day of the week (day 0) when calculating the additional delay based on cutoff (e.g. extra week if it's after the fulfilment file is generated on a Wednesday for vouchers).
- The condition for the extra delay for vouchers was incorrect, the hour of day should only be considered when it's a Wednesday.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com)

## Changes

* Change 1
* Change 2

## Screenshots

