### PR TITLE
feat: optimize test for product cards

### DIFF
--- a/support-frontend/assets/components/productOption/productOption.jsx
+++ b/support-frontend/assets/components/productOption/productOption.jsx
@@ -15,6 +15,7 @@ type Props = {
 type WrappedProps = {
   ...PropTypes,
   salesCopy: Node,
+  dailyEditionsVariant: boolean
 }
 
 type ProductOptionType = {

--- a/support-frontend/assets/components/productOption/productOption.jsx
+++ b/support-frontend/assets/components/productOption/productOption.jsx
@@ -17,9 +17,21 @@ type WrappedProps = {
   salesCopy: Node,
 }
 
+type ProductOptionType = {
+  children: Node,
+  onClick: Function,
+  href: string
+}
+
+type ProductOptionOfferType = {
+  dailyEditionsVariant: boolean,
+  children: Node,
+  hidden: boolean
+}
+
 // hocs
 const withProductOptionsStyle = WrappedComponent => (props: WrappedProps) => (
-  <div className="product-option__button">
+  <div className={cx('product-option__button', { 'product-option__button--variantB': props.dailyEditionsVariant })}>
     <div className="product-option__sales-copy">{props.salesCopy}</div>
     <WrappedComponent {...props} />
   </div>
@@ -39,17 +51,21 @@ export const ProductOptionPrice = ({ children }: { children: Node}) => (
 );
 
 export const ProductOptionCopy = ({ children, bold }: { children: Node, bold?: boolean }) => (
-  <span className={cx({ 'product-option__copy': true, 'product-option__copy--bold': bold })}>{ children }</span>
+  <span className={cx('product-option__copy', { 'product-option__copy--bold': bold })}>{ children }</span>
 );
 
-export const ProductOptionOffer = ({ children, hidden }: { children: Node, hidden: boolean }) => (
-  <div className={cx({ 'product-option__offer-container': true, 'product-option__sales-copy--hidden': hidden })}>
-    <span className="product-option__offer">{ children }</span>
+export const ProductOptionOffer = ({ dailyEditionsVariant, children, hidden }: ProductOptionOfferType) => (
+  <div className={cx('product-option__offer-container', { 'product-option__sales-copy--hidden': hidden })}>
+    <span className={cx('product-option__offer', { 'product-option__offer--variantB': dailyEditionsVariant })}>{ children }</span>
   </div>
 
 );
 
 export const ProductOptionButton = withProductOptionsStyle(AnchorButton);
+
+const ProductOption = ({ onClick, href, children }: ProductOptionType) => (
+  <a href={href} onClick={onClick} className="product-option">{ children }</a>
+);
 
 // default props
 ProductOptionCopy.defaultProps = {
@@ -59,10 +75,5 @@ ProductOptionCopy.defaultProps = {
 ProductOptionButton.defaultProps = {
   ...defaultProps,
 };
-
-// default component
-const ProductOption = ({ onClick, href, children }: { children: Node, onClick: Function, href: string }) => (
-  <a href={href} onClick={onClick} className="product-option">{ children }</a>
-);
 
 export default ProductOption;

--- a/support-frontend/assets/components/productOption/productOption.jsx
+++ b/support-frontend/assets/components/productOption/productOption.jsx
@@ -32,7 +32,7 @@ type ProductOptionOfferType = {
 
 // hocs
 const withProductOptionsStyle = WrappedComponent => (props: WrappedProps) => (
-  <div className={cx('product-option__button', { 'product-option__button--variantB': props.dailyEditionsVariant })}>
+  <div className={cx('product-option__button', { 'product-option__button--variantA': props.dailyEditionsVariant })}>
     <div className="product-option__sales-copy">{props.salesCopy}</div>
     <WrappedComponent {...props} />
   </div>
@@ -57,7 +57,7 @@ export const ProductOptionCopy = ({ children, bold }: { children: Node, bold?: b
 
 export const ProductOptionOffer = ({ dailyEditionsVariant, children, hidden }: ProductOptionOfferType) => (
   <div className={cx('product-option__offer-container', { 'product-option__sales-copy--hidden': hidden })}>
-    <span className={cx('product-option__offer', { 'product-option__offer--variantB': dailyEditionsVariant })}>{ children }</span>
+    <span className={cx('product-option__offer', { 'product-option__offer--variantA': dailyEditionsVariant })}>{ children }</span>
   </div>
 
 );

--- a/support-frontend/assets/components/productOption/productOption.scss
+++ b/support-frontend/assets/components/productOption/productOption.scss
@@ -117,3 +117,13 @@
     display: block;
   }
 }
+
+.product-option__button--variantB {
+  .component-button {
+    max-width: 210px;
+  }
+}
+
+.product-option__offer--variantB {
+  font-weight: bold;
+}

--- a/support-frontend/assets/components/productOption/productOption.scss
+++ b/support-frontend/assets/components/productOption/productOption.scss
@@ -118,12 +118,12 @@
   }
 }
 
-.product-option__button--variantB {
+.product-option__button--variantA {
   .component-button {
     max-width: 210px;
   }
 }
 
-.product-option__offer--variantB {
+.product-option__offer--variantA {
   font-weight: bold;
 }

--- a/support-frontend/assets/components/productPage/productPageHero/productPageHero.jsx
+++ b/support-frontend/assets/components/productPage/productPageHero/productPageHero.jsx
@@ -28,7 +28,7 @@ type PropTypes = {|
   heading: string,
   content?: Option<Node>,
   hasCampaign: boolean,
-  dailyEditionsVariant?: boolean
+  dailyEditionsVariant: boolean
 |};
 
 // ----- Render ----- //
@@ -94,6 +94,7 @@ ProductPageHero.defaultProps = {
   children: null,
   content: null,
   ...HeroWrapper.defaultProps,
+  dailyEditionsVariant: false,
 };
 
 export { HeroHanger, HeroWrapper, HeroHeading };

--- a/support-frontend/assets/components/productPage/productPageHero/productPageHero.jsx
+++ b/support-frontend/assets/components/productPage/productPageHero/productPageHero.jsx
@@ -7,7 +7,6 @@ import { classNameWithModifiers } from 'helpers/utilities';
 import { type Option } from 'helpers/types/option';
 
 // ----- Component Imports ----- //
-import HeadingBlock from 'components/headingBlock/headingBlock';
 import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
 
 import PaymentSelection from 'pages/digital-subscription-landing/components/paymentSelection/paymentSelection';
@@ -72,32 +71,22 @@ const HeroHeading = ({
   </div>
 );
 
-const PaymentSelectionContainer = () => (
+const PaymentSelectionContainer = ({ dailyEditionsVariant }: { dailyEditionsVariant: boolean }) => (
   <div className="payment-selection-container">
     <LeftMarginSection>
-      <PaymentSelection />
+      <PaymentSelection dailyEditionsVariant={dailyEditionsVariant} />
     </LeftMarginSection>
   </div>
 );
 
 const ProductPageHero = ({
-  overheading, heading, content, modifierClasses, children, appearance, hasCampaign, dailyEditionsVariant,
+  modifierClasses, children, appearance, dailyEditionsVariant,
 }: PropTypes) => (
   <header>
     <HeroWrapper {...{ modifierClasses, appearance }}>
       {children}
     </HeroWrapper>
-
-    {dailyEditionsVariant ? (
-      <PaymentSelectionContainer />
-      ) : (
-        <div>
-          <HeroHeading {...{ hasCampaign }}>
-            <HeadingBlock overheading={overheading} >{heading}</HeadingBlock>
-          </HeroHeading>
-          {content && <HeroHanger>{content}</HeroHanger>}
-        </div>
-      )}
+    <PaymentSelectionContainer dailyEditionsVariant={dailyEditionsVariant} />
   </header>
 );
 

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
@@ -74,7 +74,7 @@ export type PaymentOption = {
   title: string,
   singlePeriod: string,
   href: string,
-  salesCopy: Element<'span'>,
+  salesCopy: { control: () => Element<'span'>, variantB: () => Element<'span'>},
   offer: Option<string>,
   price: Option<string>,
   onClick: Function,

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
@@ -31,21 +31,41 @@ const BILLING_PERIOD = {
   [Monthly]: {
     title: 'Monthly',
     singlePeriod: 'month',
-    salesCopy: (displayPrice: string, saving?: string) => (
-      <span>14 day free trial, then <strong>{displayPrice}</strong> a month for 12 months {saving && null}
-        <br className="product-option__full-screen-break" />
-      </span>
+    salesCopy: (displayPrice: string, saving?: string) => ({
+      control: () => (
+        <span>14 day free trial, then <strong>{displayPrice}</strong> {saving && null}
+          <br className="product-option__full-screen-break" />
+          <br className="product-option__full-screen-break" />
+        </span>
+      ),
+      variantB: () => (
+        <span>
+          14 day free trial, then <strong>{displayPrice}</strong> {saving && null}
+          <br className="product-option__full-screen-break" />
+          <br className="product-option__full-screen-break" />
+        </span>
+      ),
+    }
     ),
   },
   [Annual]: {
-    title: 'Annually',
+    title: 'Annual',
     singlePeriod: 'year',
-    salesCopy: (displayPrice: string, saving?: string) => (
-      <span>
-        14 day free trial, then <strong>{displayPrice}</strong>
-        &nbsp;for the first year<br />
-        (save <strong>{saving}</strong> per year)
-      </span>
+    salesCopy: (displayPrice: string, saving?: string) => ({
+      control: () => (
+        <span>
+          14 day free trial, then <strong>{displayPrice}</strong>
+          &nbsp;for the first year <br />
+          (save <strong>{saving}</strong> per year)
+        </span>
+      ),
+      variantB: () => (
+        <span>
+          14 day free trial, then <strong>{displayPrice}</strong>
+          &nbsp;for the first year (save <strong>{saving}</strong> per year)
+        </span>
+      ),
+    }
     ),
   },
 };

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
@@ -38,7 +38,7 @@ const BILLING_PERIOD = {
           <br className="product-option__full-screen-break" />
         </span>
       ),
-      variantB: () => (
+      variantA: () => (
         <span>
           14 day free trial, then <strong>{displayPrice}</strong> {saving && null}
           <br className="product-option__full-screen-break" />
@@ -59,7 +59,7 @@ const BILLING_PERIOD = {
           (save <strong>{saving}</strong> per year)
         </span>
       ),
-      variantB: () => (
+      variantA: () => (
         <span>
           14 day free trial, then <strong>{displayPrice}</strong>
           &nbsp;for the first year (save <strong>{saving}</strong> per year)
@@ -74,7 +74,7 @@ export type PaymentOption = {
   title: string,
   singlePeriod: string,
   href: string,
-  salesCopy: { control: () => Element<'span'>, variantB: () => Element<'span'>},
+  salesCopy: { control: () => Element<'span'>, variantA: () => Element<'span'>},
   offer: Option<string>,
   price: Option<string>,
   onClick: Function,

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.jsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
+import cx from 'classnames';
 
 // components
 import ProductOption, {
@@ -19,32 +20,47 @@ import { type PaymentOption } from './helpers/paymentSelection';
 
 type PropTypes = {
   paymentOptions: Array<PaymentOption>;
+  dailyEditionsVariant: boolean,
 }
 
-const PaymentSelection = ({ paymentOptions }: PropTypes) => (
-  <div className="payment-selection">
-    {paymentOptions.map(paymentOption => (
-      <div className="payment-selection__card">
-        <ProductOption
-          href={paymentOption.href}
-          onClick={paymentOption.onClick}
-        >
-          <ProductOptionContent>
-            <ProductOptionTitle>{paymentOption.title}</ProductOptionTitle>
-            <ProductOptionOffer hidden={paymentOption.title === 'Monthly'} >Save {paymentOption.offer}</ProductOptionOffer>
-          </ProductOptionContent>
-          <ProductOptionButton
-            href={paymentOption.href}
-            onClick={paymentOption.onClick}
-            aria-label="Subscribe-button"
-            salesCopy={paymentOption.salesCopy}
-          >
-            Subscribe now
-          </ProductOptionButton>
-        </ProductOption>
-      </div>
-    ))}
-  </div>
-);
+const PaymentSelection = ({ paymentOptions, dailyEditionsVariant }: PropTypes) => {
+  const variantCopy = dailyEditionsVariant ? 'variantB' : 'control';
+
+  return (
+    <div className="payment-selection">
+      {
+        (paymentOptions.map(paymentOption => (
+          <div className={cx('payment-selection__card', { 'payment-selection__card--variantB-width': dailyEditionsVariant })}>
+            <ProductOption
+              href={paymentOption.href}
+              onClick={paymentOption.onClick}
+              dailyEditionsVariant={dailyEditionsVariant}
+            >
+              <ProductOptionContent>
+                <ProductOptionTitle>{paymentOption.title}</ProductOptionTitle>
+                <ProductOptionOffer
+                  dailyEditionsVariant={dailyEditionsVariant}
+                  hidden={paymentOption.title === 'Monthly'}
+                >
+                    Save {paymentOption.offer}
+                </ProductOptionOffer>
+              </ProductOptionContent>
+              <ProductOptionButton
+                href={paymentOption.href}
+                onClick={paymentOption.onClick}
+                aria-label="Subscribe-button"
+                salesCopy={paymentOption.salesCopy[variantCopy]()}
+                dailyEditionsVariant={dailyEditionsVariant}
+              >
+                {dailyEditionsVariant ? 'Start free trial now' : 'Subscribe now' }
+              </ProductOptionButton>
+            </ProductOption>
+          </div>
+        )))
+      }
+      <p className="payment-selection_cancel-text">You can cancel your subscription at any time</p>
+    </div>
+  );
+};
 
 export default connect(mapStateToProps)(PaymentSelection);

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.jsx
@@ -24,13 +24,13 @@ type PropTypes = {
 }
 
 const PaymentSelection = ({ paymentOptions, dailyEditionsVariant }: PropTypes) => {
-  const variantCopy = dailyEditionsVariant ? 'variantB' : 'control';
+  const variantCopy = dailyEditionsVariant ? 'variantA' : 'control';
 
   return (
     <div className="payment-selection">
       {
         (paymentOptions.map(paymentOption => (
-          <div className={cx('payment-selection__card', { 'payment-selection__card--variantB-width': dailyEditionsVariant })}>
+          <div className={cx('payment-selection__card', { 'payment-selection__card--variantA-width': dailyEditionsVariant })}>
             <ProductOption
               href={paymentOption.href}
               onClick={paymentOption.onClick}

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.scss
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.scss
@@ -30,7 +30,7 @@
   }
 }
 
-.payment-selection__card--variantB-width {
+.payment-selection__card--variantA-width {
   width: 320px;
 }
 

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.scss
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.scss
@@ -29,3 +29,18 @@
     width: 240px;
   }
 }
+
+.payment-selection__card--variantB-width {
+  width: 320px;
+}
+
+.payment-selection_cancel-text {
+  width: 100%;
+  @include gu-fontset-body-sans;
+  font-style: italic;
+  margin: 0 10px;
+
+  @include mq($from: tablet) {
+    margin: 0;
+  }
+}

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -16,21 +16,15 @@ import headerWithCountrySwitcherContainer
 import CustomerService from 'components/customerService/customerService';
 import SubscriptionFaq from 'components/subscriptionFaq/subscriptionFaq';
 import Footer from 'components/footer/footer';
-import AdFreeSection from 'components/adFreeSection/adFreeSection';
 import AdFreeSectionB from 'components/adFreeSectionB/adFreeSectionB';
-import Content from 'components/content/content';
-import Text from 'components/text/text';
-import ProductPageInfoChip
-  from 'components/productPage/productPageInfoChip/productPageInfoChip';
+
 import 'stylesheets/skeleton/skeleton.scss';
 
 import { CampaignHeader } from './components/digitalSubscriptionLandingHeader';
 import IndependentJournalismSection
   from './components/independentJournalismSection';
-import ProductBlock from './components/productBlock';
 import ProductBlockB from './components/productBlockB/productBlockB';
 import PromotionPopUp from './components/promotionPopUp';
-import Form from './components/form';
 
 import './digitalSubscriptionLanding.scss';
 import './components/theMoment.scss';
@@ -145,30 +139,10 @@ class LandingPage extends Component<Props, State> {
             countryGroupId={countryGroupId}
             dailyEditionsVariant={dailyEditionsVariant}
           />
-          {
-          dailyEditionsVariant ?
-            (
-              <div>
-                <ProductBlockB />
-                <AdFreeSectionB />
-              </div>
-            ) : (
-              <div>
-                <ProductBlock countryGroupId={countryGroupId} />
-                <AdFreeSection headingSize={2} />
-
-                <Content appearance="feature" id="subscribe">
-                  <Text title="Subscribe to Digital Pack today">
-                    <p>Choose how you’d like to pay</p>
-                  </Text>
-                  <Form />
-                  <ProductPageInfoChip >
-                      You can cancel your subscription at any time
-                  </ProductPageInfoChip>
-                </Content>
-              </div>
-            )
-        }
+          <div>
+            <ProductBlockB />
+            <AdFreeSectionB />
+          </div>
           <IndependentJournalismSection />
           <PromotionPopUp />
           <ConsentBanner />

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -68,7 +68,7 @@ const CountrySwitcherHeader = headerWithCountrySwitcherContainer({
 
 const mapStateToProps = (state) => {
   const { optimizeExperiments } = state.common;
-  const dailyEditionsExperimentId = 'xOzjpaFDQlO5L6_ORotRWA';
+  const dailyEditionsExperimentId = '0jH0ZTgGSGOIJNskvmTSww';
   const dailyEditionsVariant = optimizeExperiments
     .filter(exp => exp.id === dailyEditionsExperimentId && exp.variant === '1').length !== 0
     && !isPostDeployUser();

--- a/support-frontend/stories/cards.jsx
+++ b/support-frontend/stories/cards.jsx
@@ -50,9 +50,9 @@ stories.add('Product Option', () => (
           £11.99&nbsp;
           <ProductOptionCopy>/month</ProductOptionCopy>
         </ProductOptionPrice>
-        <ProductOptionOffer hidden={false}>Save 22% a month on <br />&nbsp;retail price</ProductOptionOffer>
+        <ProductOptionOffer dailyEditionsVariant={false} hidden={false}>Save 22% a month on <br />&nbsp;retail price</ProductOptionOffer>
       </ProductOptionContent>
-      <ProductOptionButton salesCopy={<span>This is sales copy</span>} href="#" aria-label="Subscribe-button">Subscribe now</ProductOptionButton>
+      <ProductOptionButton dailyEditionsVariant={false} salesCopy={<span>This is sales copy</span>} href="#" aria-label="Subscribe-button">Subscribe now</ProductOptionButton>
     </ProductOption>
   </div>
 ));

--- a/support-frontend/stories/cards.jsx
+++ b/support-frontend/stories/cards.jsx
@@ -50,9 +50,21 @@ stories.add('Product Option', () => (
           £11.99&nbsp;
           <ProductOptionCopy>/month</ProductOptionCopy>
         </ProductOptionPrice>
-        <ProductOptionOffer dailyEditionsVariant={false} hidden={false}>Save 22% a month on <br />&nbsp;retail price</ProductOptionOffer>
+        <ProductOptionOffer
+          dailyEditionsVariant={false}
+          hidden={false}
+        >
+            Save 22% a month on <br />&nbsp;retail price
+        </ProductOptionOffer>
       </ProductOptionContent>
-      <ProductOptionButton dailyEditionsVariant={false} salesCopy={<span>This is sales copy</span>} href="#" aria-label="Subscribe-button">Subscribe now</ProductOptionButton>
+      <ProductOptionButton
+        dailyEditionsVariant={false}
+        salesCopy={<span>This is sales copy</span>}
+        href="#"
+        aria-label="Subscribe-button"
+      >
+        Subscribe now
+      </ProductOptionButton>
     </ProductOption>
   </div>
 ));


### PR DESCRIPTION
## Why are you doing this?
We are adding a new experiment, which is to test if a change to the copy on the product option cards will improve conversion rates

[**Trello Card**](https://trello.com/c/Tm2rzQ30/2513-updates-to-cards-for-next-ab-test)

## Changes

* product option button card copy
* product option card size
* added optimize experiments to product option cards

## Screenshots
### Old Product cards 
![Screen Shot 2019-08-02 at 15 25 24](https://user-images.githubusercontent.com/45875444/62377255-59277700-b53a-11e9-8355-959c2d080275.png)

### New Product cards
![Screen Shot 2019-08-02 at 15 28 46](https://user-images.githubusercontent.com/45875444/62377283-62184880-b53a-11e9-8925-12422cbf2cf8.png)

