### PR TITLE
Update Guardian Weekly T&Cs link

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -144,7 +144,7 @@ const content = (
           </p>
         </Text>
         <Text title="Guardian Weekly terms and conditions">
-          <p>Subscriptions available to people aged 18 and over with a valid email address. For full details of Guardian Weekly print subscription services and their terms and conditions, see <a target="_blank" rel="noopener noreferrer" href="https://subscribe.theguardian.com/p/10ANNUAL/terms">here</a>.
+          <p>Subscriptions available to people aged 18 and over with a valid email address. For full details of Guardian Weekly print subscription services and their terms and conditions, see <a target="_blank" rel="noopener noreferrer" href="https://www.theguardian.com/info/2014/jul/10/guardian-weekly-print-subscription-services-terms-conditions">here</a>.
           </p>
         </Text>
       </Content>


### PR DESCRIPTION
## Why are you doing this?

The terms and conditions link was wrong on the Guardian Weekly product page

[**Trello Card**](https://trello.com/c/IrpvbRbb/2516-change-gw-tcs-link)

