### PR TITLE
Choice architecture test round 1 (labels test)

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -5,6 +5,7 @@ import { get as getCookie } from 'helpers/cookie';
 // ----- Tests ----- //
 export type LandingPageCopyReturningSinglesTestVariants = 'control' | 'returningSingle' | 'notintest';
 export type ThankYouPageMarketingComponentTestVariants = 'control' | 'newMarketingComponent' | 'notintest';
+export type LandingPageChoiceArchitectureLabelsTestVariants = 'control' | 'withLabels' | 'notintest';
 
 export const tests: Tests = {
   landingPageCopyReturningSingles: {
@@ -61,5 +62,26 @@ export const tests: Tests = {
     isActive: true,
     independent: true,
     seed: 2,
+  },
+
+  landingPageChoiceArchitectureLabels: {
+    type: 'OTHER',
+    variants: [
+      {
+        id: 'control',
+      },
+      {
+        id: 'withLabels',
+      },
+    ],
+    audiences: {
+      ALL: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: true,
+    independent: true,
+    seed: 3,
   },
 };

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -64,6 +64,10 @@ export const tests: Tests = {
     seed: 2,
   },
 
+  // JTL - 5 August 2019 - Ab-test: landingPageChoiceArchitectureLabels
+  // file created for this test: abTestContributionsLandingChoiceArchitecture.scss
+  // if variant is successful, we will need to integrate the styles from the test stylesheet
+  // into the main stylesheet: contributionsLanding.scss
   landingPageChoiceArchitectureLabels: {
     type: 'OTHER',
     variants: [

--- a/support-frontend/assets/pages/contributions-landing/abTestContributionsLandingChoiceArchitecture.scss
+++ b/support-frontend/assets/pages/contributions-landing/abTestContributionsLandingChoiceArchitecture.scss
@@ -1,5 +1,6 @@
 @import '~stylesheets/gu-sass/gu-sass';
 
+// Styles for landing page choice architecture round one
 // JTL TBD: integrate this css into ContributionsLanding.scss
 // if the labels variant is successful
 .form--with-labels {
@@ -30,5 +31,11 @@
     text-align: center;
     height: 40px;
     line-height: 40px;
+  }
+
+  .form--content {
+     @include mq($to: tablet) {
+       padding-top: 0;
+     }
   }
 }

--- a/support-frontend/assets/pages/contributions-landing/abTestContributionsLandingChoiceArchitecture.scss
+++ b/support-frontend/assets/pages/contributions-landing/abTestContributionsLandingChoiceArchitecture.scss
@@ -1,0 +1,30 @@
+@import '~stylesheets/gu-sass/gu-sass';
+
+.form--with-labels {
+  .form__radio-group--tabs {
+    margin-top: $gu-v-spacing / 2;
+  }
+
+  .form__radio-group--contribution-amount {
+    margin-top: $gu-v-spacing * 2;
+  }
+
+  .form__legend {
+    @include gu-typeface(headline, 18);
+    font-weight: 700;
+    display: block;
+    margin-bottom: $gu-v-spacing;
+  }
+
+  .form__radio-group-list--border {
+    margin: 0;
+    border: 1px solid gu-colour(neutral-86);
+  }
+
+  .form__radio-group--tabs .form__radio-group-input + .form__radio-group-label,
+  .form__radio-group-list--border li label {
+    @include gu-typeface(textSans, 16);
+    padding: 4px;
+    text-align: center;
+  }
+}

--- a/support-frontend/assets/pages/contributions-landing/abTestContributionsLandingChoiceArchitecture.scss
+++ b/support-frontend/assets/pages/contributions-landing/abTestContributionsLandingChoiceArchitecture.scss
@@ -1,5 +1,7 @@
 @import '~stylesheets/gu-sass/gu-sass';
 
+// JTL TBD: integrate this css into ContributionsLanding.scss
+// if the labels variant is successful
 .form--with-labels {
   .form__radio-group--tabs {
     margin-top: $gu-v-spacing / 2;

--- a/support-frontend/assets/pages/contributions-landing/abTestContributionsLandingChoiceArchitecture.scss
+++ b/support-frontend/assets/pages/contributions-landing/abTestContributionsLandingChoiceArchitecture.scss
@@ -28,5 +28,7 @@
     @include gu-typeface(textSans, 16);
     padding: 4px;
     text-align: center;
+    height: 40px;
+    line-height: 40px;
   }
 }

--- a/support-frontend/assets/pages/contributions-landing/abTestContributionsLandingChoiceArchitecture.scss
+++ b/support-frontend/assets/pages/contributions-landing/abTestContributionsLandingChoiceArchitecture.scss
@@ -34,7 +34,7 @@
   }
 
   .form--content {
-     @include mq($to: tablet) {
+     @include mq($until: tablet) {
        padding-top: 0;
      }
   }

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
@@ -160,7 +160,7 @@ function withProps(props: PropTypes) {
 
   return (
     <fieldset className={classNameWithModifiers('form__radio-group', ['pills', 'contribution-amount'])}>
-      <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>How much would you like to contribute?</legend>
+      <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>How much would you like to give?</legend>
       <ul className="form__radio-group-list">
         {validAmounts.map(renderAmount(currencies[props.currency], spokenCurrencies[props.currency], props))}
         <li className="form__radio-group-item">
@@ -213,7 +213,7 @@ function withProps(props: PropTypes) {
 function withoutProps() {
   return (
     <fieldset className={classNameWithModifiers('form__radio-group', ['pills', 'contribution-amount'])}>
-      <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>How much would you like to contribute?</legend>
+      <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>How much would you like to give?</legend>
       <ul className="form__radio-group-list">
         {
           ['a', 'b', 'c', 'd'].map(renderEmptyAmount)

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
@@ -160,7 +160,7 @@ function withProps(props: PropTypes) {
 
   return (
     <fieldset className={classNameWithModifiers('form__radio-group', ['pills', 'contribution-amount'])}>
-      <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>Amount</legend>
+      <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>How much would you like to contribute?</legend>
       <ul className="form__radio-group-list">
         {validAmounts.map(renderAmount(currencies[props.currency], spokenCurrencies[props.currency], props))}
         <li className="form__radio-group-item">
@@ -213,7 +213,7 @@ function withProps(props: PropTypes) {
 function withoutProps() {
   return (
     <fieldset className={classNameWithModifiers('form__radio-group', ['pills', 'contribution-amount'])}>
-      <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>Amount</legend>
+      <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>How much would you like to contribute?</legend>
       <ul className="form__radio-group-list">
         {
           ['a', 'b', 'c', 'd'].map(renderEmptyAmount)

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
@@ -51,6 +51,7 @@ import type { RecentlySignedInExistingPaymentMethod } from 'helpers/existingPaym
 import type { PaymentMethod } from 'helpers/paymentMethods';
 import { DirectDebit, Stripe, ExistingCard, ExistingDirectDebit } from 'helpers/paymentMethods';
 import { getCampaignName } from 'helpers/campaigns';
+import type { LandingPageChoiceArchitectureLabelsTestVariants } from 'helpers/abTests/abtestDefinitions';
 
 
 // ----- Types ----- //
@@ -82,6 +83,7 @@ type PropTypes = {|
   isTestUser: boolean,
   country: IsoCountry,
   stripePaymentRequestButtonMethod: StripePaymentRequestButtonMethod,
+  landingPageChoiceArchitectureLabelsTestVariant: LandingPageChoiceArchitectureLabelsTestVariants
 |};
 
 // We only want to use the user state value if the form state value has not been changed since it was initialised,
@@ -112,6 +114,7 @@ const mapStateToProps = (state: State) => ({
   country: state.common.internationalisation.countryId,
   stripeV3HasLoaded: state.page.form.stripePaymentRequestButtonData.stripeV3HasLoaded,
   stripePaymentRequestButtonMethod: state.page.form.stripePaymentRequestButtonData.paymentMethod,
+  landingPageChoiceArchitectureLabelsTestVariant: state.common.abParticipations.landingPageChoiceArchitectureLabels,
 });
 
 
@@ -222,9 +225,11 @@ function onSubmit(props: PropTypes): Event => void {
 
 function withProps(props: PropTypes) {
   const campaignName = getCampaignName();
+  const baseClass = 'form';
+  const classModifiers = props.landingPageChoiceArchitectureLabelsTestVariant === 'withLabels' ? ['contribution', 'with-labels'] : ['contribution'];
 
   return (
-    <form onSubmit={onSubmit(props)} className={classNameWithModifiers('form', ['contribution'])} noValidate>
+    <form onSubmit={onSubmit(props)} className={classNameWithModifiers(baseClass, classModifiers)} noValidate>
       <div>
         <ContributionTypeTabs />
         <ContributionAmount

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
@@ -62,7 +62,7 @@ function withProps(props: PropTypes) {
 
   return (
     <fieldset className={classNameWithModifiers('form__radio-group', ['tabs', 'contribution-type'])}>
-      <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>Recurrence</legend>
+      <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>How often would you like to give?</legend>
       <ul className="form__radio-group-list form__radio-group-list--border">
         {contributionTypes.map((contributionTypeSetting: ContributionTypeSetting) => {
           const { contributionType } = contributionTypeSetting;
@@ -97,7 +97,7 @@ function withProps(props: PropTypes) {
 function withoutProps() {
   return (
     <fieldset className={classNameWithModifiers('form__radio-group', ['tabs', 'contribution-type'])}>
-      <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>Recurrence</legend>
+      <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>How often would you like to give?</legend>
       <ul className="form__radio-group-list form__radio-group-list--border">
         {
           ['a', 'b', 'c'].map(id => (

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
@@ -62,7 +62,7 @@ function withProps(props: PropTypes) {
 
   return (
     <fieldset className={classNameWithModifiers('form__radio-group', ['tabs', 'contribution-type'])}>
-      <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>How often would you like to give?</legend>
+      <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>How often would you like to contribute?</legend>
       <ul className="form__radio-group-list form__radio-group-list--border">
         {contributionTypes.map((contributionTypeSetting: ContributionTypeSetting) => {
           const { contributionType } = contributionTypeSetting;
@@ -97,7 +97,7 @@ function withProps(props: PropTypes) {
 function withoutProps() {
   return (
     <fieldset className={classNameWithModifiers('form__radio-group', ['tabs', 'contribution-type'])}>
-      <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>How often would you like to give?</legend>
+      <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>How often would you like to contribute?</legend>
       <ul className="form__radio-group-list form__radio-group-list--border">
         {
           ['a', 'b', 'c'].map(id => (

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
@@ -31,7 +31,7 @@ import ContributionThankYouContainer
 import { setUserStateActions } from './setUserStateActions';
 import ConsentBanner from '../../components/consentBanner/consentBanner';
 import './contributionsLanding.scss';
-import './contributionsLandingChoiceArchitectureTest.scss';
+import './abTestContributionsLandingChoiceArchitecture.scss';
 
 if (!isDetailsSupported) {
   polyfillDetails();

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
@@ -31,6 +31,7 @@ import ContributionThankYouContainer
 import { setUserStateActions } from './setUserStateActions';
 import ConsentBanner from '../../components/consentBanner/consentBanner';
 import './contributionsLanding.scss';
+import './contributionsLandingChoiceArchitectureTest.scss';
 
 if (!isDetailsSupported) {
   polyfillDetails();


### PR DESCRIPTION
## Why are you doing this?
We want to test the performance of adding labels to the contributions form. We will measure the performance of this test by looking at 

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/oNMxdCjp/1242-choice-architecture-r1-add-field-labels)

## Changes

* Added the test (basically was able to complete using SCSS only)
* Updated the legend on the form - applicable for both variants in this test. This change should improve accessibility even when the legend is not visible.

## Screenshots
Control: 
<img width="1108" alt="landingpage labels control" src="https://user-images.githubusercontent.com/3300789/62460337-a9404c80-b779-11e9-8d0f-5033d9883fb6.png">

Variant:
<img width="1125" alt="landingpage labels variant" src="https://user-images.githubusercontent.com/3300789/62466678-cb41cb00-b789-11e9-98dd-562aba0f3392.png">
