### PR TITLE
Post-deploy test: check all instances of Stripe element

### DIFF
--- a/support-frontend/test/selenium/contributions/pages/ContributionsLanding.scala
+++ b/support-frontend/test/selenium/contributions/pages/ContributionsLanding.scala
@@ -76,7 +76,7 @@ case class ContributionsLanding(region: String, testUser: TestUser)(implicit val
 
   def hasStripeOverlay: Boolean = {
     Thread.sleep(500)
-    pageHasElement(stripeOverlayIframe)
+    pageHasAtLeastOneVisibleElement(stripeOverlayIframe)
   }
 
 }

--- a/support-frontend/test/selenium/util/Browser.scala
+++ b/support-frontend/test/selenium/util/Browser.scala
@@ -1,14 +1,16 @@
 package selenium.util
 
+import com.typesafe.scalalogging.LazyLogging
 import org.openqa.selenium.WebDriver
 import org.openqa.selenium.support.ui.ExpectedConditions.numberOfWindowsToBe
 import org.openqa.selenium.support.ui.{ExpectedCondition, ExpectedConditions, WebDriverWait}
 import org.scalatest.selenium.WebBrowser
+
 import scala.collection.JavaConverters.asScalaSetConverter
 import scala.util.Try
 import scala.collection.JavaConverters._
 
-trait Browser extends WebBrowser {
+trait Browser extends WebBrowser with LazyLogging {
 
   implicit val webDriver: WebDriver
 
@@ -24,6 +26,7 @@ trait Browser extends WebBrowser {
   // If there is more than 1 element matching the query then only one of them needs to be visible
   def pageHasAtLeastOneVisibleElement(q: Query): Boolean = {
     val elements = webDriver.findElements(q.by)
+    logger.info(s"Visibility of element ${q.queryString}: ${elements.asScala.toList.map(_.isDisplayed)}")
     elements.asScala.exists(element => element.isDisplayed)
   }
 

--- a/support-frontend/test/selenium/util/Browser.scala
+++ b/support-frontend/test/selenium/util/Browser.scala
@@ -6,6 +6,7 @@ import org.openqa.selenium.support.ui.{ExpectedCondition, ExpectedConditions, We
 import org.scalatest.selenium.WebBrowser
 import scala.collection.JavaConverters.asScalaSetConverter
 import scala.util.Try
+import scala.collection.JavaConverters._
 
 trait Browser extends WebBrowser {
 
@@ -19,6 +20,12 @@ trait Browser extends WebBrowser {
 
   def pageHasElement(q: Query): Boolean =
     waitUntil(ExpectedConditions.visibilityOfElementLocated(q.by))
+
+  // If there is more than 1 element matching the query then only one of them needs to be visible
+  def pageHasAtLeastOneVisibleElement(q: Query): Boolean = {
+    val elements = webDriver.findElements(q.by)
+    elements.asScala.exists(element => element.isDisplayed)
+  }
 
   def elementIsClickable(q: Query): Boolean =
     waitUntil(ExpectedConditions.elementToBeClickable(q.by))


### PR DESCRIPTION
## Why are you doing this?
This test periodically fails. I can't be certain, but I think it might be because there is always more than one stripe checkout element. So when it checks if the element is visible, it needs to be check each one.

I also want to find out why there's more than one of these elements...
