### PR TITLE
Thank you page tracking

### DIFF
--- a/support-frontend/assets/helpers/render.js
+++ b/support-frontend/assets/helpers/render.js
@@ -6,7 +6,7 @@ import { logException } from 'helpers/logger';
 // Without this the build-time pre-rendering breaks, because fetch is undefined when running with node
 const safeFetch = (url: string, opts) => {
   if (typeof fetch !== 'undefined') {
-    fetch(url, opts)
+    fetch(url, opts);
   }
 };
 
@@ -27,7 +27,7 @@ const getElementOrBody = (id: ?string): HTMLElement => {
 };
 
 const renderError = (e: Error, id: ?string) => {
-  safeFetch(window.guardian.settings.metricUrl, {mode: 'no-cors'}); // ignore result, fire and forget
+  safeFetch(window.guardian.settings.metricUrl, { mode: 'no-cors' }); // ignore result, fire and forget
 
   const element = getElementOrBody(id);
 
@@ -55,7 +55,7 @@ const renderPage = (content: Object, id: string, callBack?: () => void) => {
       renderError(e, id);
     }
   } else {
-    safeFetch(window.guardian.settings.metricUrl, {mode: 'no-cors'}); // ignore result, fire and forget
+    safeFetch(window.guardian.settings.metricUrl, { mode: 'no-cors' }); // ignore result, fire and forget
     logException(`Fatal error trying to render a page. id:${id}`);
   }
 };

--- a/support-frontend/assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/__tests__/subscriptionCheckoutReducerTest.js
@@ -5,7 +5,7 @@
 import { createCheckoutReducer } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
 import { setFormErrors, setStage } from 'helpers/subscriptionsForms/formActions';
 
-jest.mock('ophan', () => {});
+jest.mock('ophan', () => () => ({}));
 jest.mock('helpers/fontLoader', () => () => ({}));
 // ----- Tests ----- //
 

--- a/support-frontend/assets/helpers/subscriptionsForms/formActions.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/formActions.js
@@ -54,7 +54,9 @@ const setStage = (
   product: SubscriptionProduct,
   paymentMethod: ?PaymentMethod,
 ): Action => {
-  trackThankYouPageLoaded(product, paymentMethod);
+  if (stage === 'thankyou' || stage === 'thankyou-pending'){
+    trackThankYouPageLoaded(product, paymentMethod);
+  }
   return { type: 'SET_STAGE', stage };
 };
 const setFormErrors = (errors: Array<FormError<FormField>>): Action => ({

--- a/support-frontend/assets/helpers/subscriptionsForms/formActions.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/formActions.js
@@ -54,7 +54,7 @@ const setStage = (
   product: SubscriptionProduct,
   paymentMethod: ?PaymentMethod,
 ): Action => {
-  if (stage === 'thankyou' || stage === 'thankyou-pending'){
+  if (stage === 'thankyou' || stage === 'thankyou-pending') {
     trackThankYouPageLoaded(product, paymentMethod);
   }
   return { type: 'SET_STAGE', stage };

--- a/support-frontend/assets/helpers/subscriptionsForms/formActions.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/formActions.js
@@ -9,7 +9,10 @@ import type { ErrorReason } from 'helpers/errorReasons';
 import type { FormField, Stage } from './formFields';
 import type { BillingPeriod } from 'helpers/billingPeriods';
 import * as storage from 'helpers/storage';
-import { trackPaymentMethodSelected } from 'helpers/tracking/behaviour';
+import {
+  trackPaymentMethodSelected,
+  trackThankYouPageLoaded,
+} from 'helpers/tracking/behaviour';
 import { showPayPal } from 'helpers/paymentIntegrations/payPalRecurringCheckout';
 import type { PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
 import type { IsoCountry } from 'helpers/internationalisation/country';
@@ -17,11 +20,9 @@ import type { Action as DDAction } from 'components/directDebit/directDebitActio
 import type { Action as PayPalAction } from 'helpers/paymentIntegrations/payPalActions';
 import type { Action as AddressAction } from 'components/subscriptionCheckouts/address/addressFieldsStore';
 import type { CheckoutState } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
-import {
-  buildRegularPaymentRequest,
-  onPaymentAuthorised,
-} from 'helpers/subscriptionsForms/submit';
+import { onPaymentAuthorised } from 'helpers/subscriptionsForms/submit';
 import { setFormSubmissionDependentValue } from 'helpers/subscriptionsForms/checkoutFormIsSubmittableActions';
+import type { SubscriptionProduct } from 'helpers/subscriptions';
 
 export type Action =
   | { type: 'SET_STAGE', stage: Stage }
@@ -48,7 +49,14 @@ export type Action =
 
 // ----- Action Creators ----- //
 
-const setStage = (stage: Stage): Action => ({ type: 'SET_STAGE', stage });
+const setStage = (
+  stage: Stage,
+  product: SubscriptionProduct,
+  paymentMethod: ?PaymentMethod,
+): Action => {
+  trackThankYouPageLoaded(product, paymentMethod);
+  return { type: 'SET_STAGE', stage };
+};
 const setFormErrors = (errors: Array<FormError<FormField>>): Action => ({
   type: 'SET_FORM_ERRORS',
   errors,
@@ -94,10 +102,9 @@ const formActionCreators = {
     (dispatch: Dispatch<Action>, getState: () => CheckoutState) => {
       const state = getState();
       onPaymentAuthorised(
+        authorisation,
         dispatch,
-        buildRegularPaymentRequest(state, authorisation),
-        state.page.csrf,
-        state.common.abParticipations,
+        state,
       );
     },
   setGiftStatus: (orderIsAGift: boolean | null): Action => ({

--- a/support-frontend/assets/helpers/tracking/behaviour.js
+++ b/support-frontend/assets/helpers/tracking/behaviour.js
@@ -46,6 +46,27 @@ const trackCheckoutSubmitAttempt = (
   });
 };
 
+const trackThankYouPageLoaded = (
+  productCheckout: SubscriptionProduct,
+  paymentMethod: ?PaymentMethod,
+) => {
+  gaEvent({
+    category: 'Thank you page load',
+    action: productCheckout,
+    label: paymentMethod,
+  }, { paymentMethod, productCheckout });
+
+  trackComponentEvents({
+    component: {
+      componentType: 'ACQUISITIONS_OTHER',
+      id: 'thank-you-page',
+      labels: ['checkout-submit'],
+    },
+    action: 'VIEW',
+    value: `thank-you-page-loaded-${productCheckout}-${paymentMethod || ''}`,
+  });
+};
+
 const trackComponentClick = (componentId: string): void => {
   gaEvent({
     category: 'click',
@@ -82,6 +103,7 @@ const trackComponentLoad = (componentId: string): void => {
 
 export {
   trackPaymentMethodSelected,
+  trackThankYouPageLoaded,
   trackComponentClick,
   trackCheckoutSubmitAttempt,
   trackComponentLoad,

--- a/support-frontend/assets/helpers/tracking/behaviour.js
+++ b/support-frontend/assets/helpers/tracking/behaviour.js
@@ -56,15 +56,17 @@ const trackThankYouPageLoaded = (
     label: paymentMethod,
   }, { paymentMethod, productCheckout });
 
-  trackComponentEvents({
-    component: {
-      componentType: 'ACQUISITIONS_OTHER',
-      id: 'thank-you-page',
-      labels: ['checkout-submit'],
-    },
-    action: 'VIEW',
-    value: `thank-you-page-loaded-${productCheckout}-${paymentMethod || ''}`,
-  });
+  if (trackComponentEvents) {
+    trackComponentEvents({
+      component: {
+        componentType: 'ACQUISITIONS_OTHER',
+        id: 'thank-you-page',
+        labels: ['checkout-submit'],
+      },
+      action: 'VIEW',
+      value: `thank-you-page-loaded-${productCheckout}-${paymentMethod || ''}`,
+    });
+  }
 };
 
 const trackComponentClick = (componentId: string): void => {

--- a/support-frontend/assets/helpers/tracking/googleTagManager.js
+++ b/support-frontend/assets/helpers/tracking/googleTagManager.js
@@ -2,15 +2,14 @@
 
 import uuidv4 from 'uuid';
 import * as storage from 'helpers/storage';
+import type { Participations } from 'helpers/abTests/abtest';
 import { getVariantsAsString } from 'helpers/abTests/abtest';
 import { detect as detectCurrency } from 'helpers/internationalisation/currency';
 import { getQueryParameter } from 'helpers/url';
 import { detect as detectCountryGroup } from 'helpers/internationalisation/countryGroup';
-import type { Participations } from 'helpers/abTests/abtest';
 import { getTrackingConsent } from './thirdPartyTrackingConsent';
 import { maybeTrack } from './doNotTrack';
-import { type PaymentMethod, DirectDebit, PayPal } from '../paymentMethods';
-
+import { DirectDebit, type PaymentMethod, PayPal } from '../paymentMethods';
 
 // ----- Types ----- //
 type EventType = 'DataLayerReady' | 'SuccessfulConversion' | 'GAEvent' | 'AppStoreCtaClick';
@@ -42,14 +41,6 @@ function getOrderId() {
     storage.setSession('orderId', value);
   }
   return value;
-}
-
-function getContributionType() {
-  const param = getQueryParameter('contribType');
-  if (param) {
-    storage.setSession('contribType', param);
-  }
-  return (storage.getSession('contribType') || 'one_off').toLowerCase(); // PayPal route doesn't set the contribType
 }
 
 function getCurrency(): string {
@@ -173,21 +164,6 @@ function getData(
     experience: getVariantsAsString(participations),
     paymentRequestApiStatus,
     thirdPartyTrackingConsent: getTrackingConsent(),
-    ecommerce: {
-      currencyCode: currency,
-      purchase: {
-        actionField: {
-          id: orderId,
-          revenue: value, // Total transaction value (incl. tax and shipping)
-        },
-        products: [{
-          name: `${getContributionType()}_contribution`,
-          category: 'contribution',
-          price: value,
-          quantity: 1,
-        }],
-      },
-    },
   };
 }
 

--- a/support-frontend/assets/pages/weekly-subscription-checkout/helpers/deliveryDays.js
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/helpers/deliveryDays.js
@@ -14,7 +14,7 @@ const getWeeklyDays = (today: ?number): Date[] => {
   const now = new Date(today || new Date().getTime());
   const currentWeekday = now.getDay();
   const weeksToAdd =
-      currentWeekday > extraDelayCutoffWeekday || 
+      currentWeekday > extraDelayCutoffWeekday ||
       currentWeekday === 0 // Sunday is considered the last day of the week
         ? extraDelayWeeks
         : normalDelayWeeks;


### PR DESCRIPTION
## Why are you doing this?
In order to get an accurate conversion rate for our checkouts we need a client side success event otherwise the conversion rates will appear better than they are because of consent settings and ad blockers.

This PR also removes the client side ecommerce tracking code as this is now managed server side.

[**Trello Card**](https://trello.com/c/cpyidHc0/2521-add-a-client-side-conversion-metric)
