### PR TITLE
feat: moved paymentSelection from productPageHero

### DIFF
--- a/support-frontend/assets/components/productPage/productPageHero/productPageHero.jsx
+++ b/support-frontend/assets/components/productPage/productPageHero/productPageHero.jsx
@@ -7,7 +7,6 @@ import { classNameWithModifiers } from 'helpers/utilities';
 import { type Option } from 'helpers/types/option';
 
 // ----- Component Imports ----- //
-import HeadingBlock from 'components/headingBlock/headingBlock';
 import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
 
 import './productPageHero.scss';

--- a/support-frontend/assets/components/productPage/productPageHero/productPageHero.jsx
+++ b/support-frontend/assets/components/productPage/productPageHero/productPageHero.jsx
@@ -10,8 +10,6 @@ import { type Option } from 'helpers/types/option';
 import HeadingBlock from 'components/headingBlock/headingBlock';
 import LeftMarginSection from 'components/leftMarginSection/leftMarginSection';
 
-import PaymentSelection from 'pages/digital-subscription-landing/components/paymentSelection/paymentSelection';
-
 import './productPageHero.scss';
 
 
@@ -72,32 +70,13 @@ const HeroHeading = ({
   </div>
 );
 
-const PaymentSelectionContainer = () => (
-  <div className="payment-selection-container">
-    <LeftMarginSection>
-      <PaymentSelection />
-    </LeftMarginSection>
-  </div>
-);
-
 const ProductPageHero = ({
-  overheading, heading, content, modifierClasses, children, appearance, hasCampaign, dailyEditionsVariant,
+  modifierClasses, children, appearance,
 }: PropTypes) => (
   <header>
     <HeroWrapper {...{ modifierClasses, appearance }}>
       {children}
     </HeroWrapper>
-
-    {dailyEditionsVariant ? (
-      <PaymentSelectionContainer />
-      ) : (
-        <div>
-          <HeroHeading {...{ hasCampaign }}>
-            <HeadingBlock overheading={overheading} >{heading}</HeadingBlock>
-          </HeroHeading>
-          {content && <HeroHanger>{content}</HeroHanger>}
-        </div>
-      )}
   </header>
 );
 

--- a/support-frontend/assets/components/productPage/productPageHero/productPageHero.scss
+++ b/support-frontend/assets/components/productPage/productPageHero/productPageHero.scss
@@ -81,5 +81,9 @@
 
 .payment-selection-container {
   position: relative;
-  margin: -95px 0 0 0;
+  margin: 0;
+  
+  @include mq($from: tablet) {
+    margin: -95px 0 0 0;
+  }
 }

--- a/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
@@ -22,6 +22,8 @@ import { sendTrackingEventsOnClick, type SubscriptionProduct } from 'helpers/sub
 import { flashSaleIsActive, getSaleCopy } from 'helpers/flashSale';
 import { HeroHanger } from 'components/productPage/productPageHero/productPageHero';
 
+import PaymentSelection from 'pages/digital-subscription-landing/components/paymentSelection/paymentSelection';
+
 import ProductPagehero from 'components/productPage/productPageHero/productPageHero';
 import GridImage, { type GridImg } from 'components/gridImage/gridImage';
 
@@ -177,91 +179,102 @@ function getCopy(product: SubscriptionProduct, country: CountryGroupId) {
   };
 }
 
+const PaymentSelectionContainer = ({ dailyEditionsVariant }: { dailyEditionsVariant: boolean }) => (
+  <div className="payment-selection-container">
+    <LeftMarginSection>
+      <PaymentSelection dailyEditionsVariant={dailyEditionsVariant} />
+    </LeftMarginSection>
+  </div>
+);
+
 function CampaignHeader(props: PropTypes) {
   const product: SubscriptionProduct = 'DigitalPack';
   const copy = getCopy(product, props.countryGroupId);
   return (
-    <ProductPagehero
-      appearance="campaign"
-      overheading={copy.heading}
-      heading={copy.subHeading}
-      modifierClasses={['digital-campaign']}
-      content={<AnchorButton id="qa-subscription-options" aria-label="See Subscription options for Digital Pack" onClick={sendTrackingEventsOnClick('options_cta_click', 'DigitalPack', null)} icon={<SvgChevron />} href="#subscribe">See Subscription options</AnchorButton>}
-      hasCampaign
-      dailyEditionsVariant={props.dailyEditionsVariant}
-    >
-      <div className="the-moment-hero">
-        <div className="the-moment-hero__copy">
-          <h2>A better way to fund journalism <br />
-            <span>A better way to read it
-            </span>
-          </h2>
-        </div>
+    <div>
+      <ProductPagehero
+        appearance="campaign"
+        overheading={copy.heading}
+        heading={copy.subHeading}
+        modifierClasses={['digital-campaign']}
+        content={<AnchorButton id="qa-subscription-options" aria-label="See Subscription options for Digital Pack" onClick={sendTrackingEventsOnClick('options_cta_click', 'DigitalPack', null)} icon={<SvgChevron />} href="#subscribe">See Subscription options</AnchorButton>}
+        hasCampaign
+        dailyEditionsVariant={props.dailyEditionsVariant}
+      >
+        <div className="the-moment-hero">
+          <div className="the-moment-hero__copy">
+            <h2>A better way to fund journalism <br />
+              <span>A better way to read it
+              </span>
+            </h2>
+          </div>
 
-        <div className="the-moment-hero__graphic-outer">
-          <div className="the-moment-hero__graphic-inner">
-            <div className="the-moment-hero__badge">
-              <span className="the-moment-hero__badge-lgeCopy">14 Day</span>
-              <span>Free trial</span>
-            </div>
-            <div className="the-moment-hero__graphic">
-              <GridImage
-                gridId="theMomentDigiHero"
-                srcSizes={[486]}
-                sizes="(max-width: 740px) 315px, 486px"
-                imgType="png"
-                altText="A mobile device"
-              />
-            </div>
-            <div className="the-moment-hero__graphic-slider">
-              <div className="the-moment-hero__graphic-slider-inner">
-                <div className="the-moment-hero__graphic-slider-1">
-                  <GridImage
-                    gridId="theMomentDigiHero"
-                    srcSizes={[486]}
-                    sizes="(max-width: 740px) 315px, 486px"
-                    imgType="png"
-                    altText="A mobile device"
-                  />
-                </div>
-                <div className="the-moment-hero__graphic-slider-2">
-                  <GridImage
-                    gridId="theMomentDigiHero2"
-                    srcSizes={[486]}
-                    sizes="(max-width: 740px) 315px, 486px"
-                    imgType="png"
-                    altText="A mobile device"
-                  />
-                </div>
-                <div className="the-moment-hero__graphic-slider-3">
-                  <GridImage
-                    gridId="theMomentDigiHero3"
-                    srcSizes={[486]}
-                    sizes="(max-width: 740px) 315px, 486px"
-                    imgType="png"
-                    altText="A mobile device"
-                  />
+          <div className="the-moment-hero__graphic-outer">
+            <div className="the-moment-hero__graphic-inner">
+              <div className="the-moment-hero__badge">
+                <span className="the-moment-hero__badge-lgeCopy">14 Day</span>
+                <span>Free trial</span>
+              </div>
+              <div className="the-moment-hero__graphic">
+                <GridImage
+                  gridId="theMomentDigiHero"
+                  srcSizes={[486]}
+                  sizes="(max-width: 740px) 315px, 486px"
+                  imgType="png"
+                  altText="A mobile device"
+                />
+              </div>
+              <div className="the-moment-hero__graphic-slider">
+                <div className="the-moment-hero__graphic-slider-inner">
+                  <div className="the-moment-hero__graphic-slider-1">
+                    <GridImage
+                      gridId="theMomentDigiHero"
+                      srcSizes={[486]}
+                      sizes="(max-width: 740px) 315px, 486px"
+                      imgType="png"
+                      altText="A mobile device"
+                    />
+                  </div>
+                  <div className="the-moment-hero__graphic-slider-2">
+                    <GridImage
+                      gridId="theMomentDigiHero2"
+                      srcSizes={[486]}
+                      sizes="(max-width: 740px) 315px, 486px"
+                      imgType="png"
+                      altText="A mobile device"
+                    />
+                  </div>
+                  <div className="the-moment-hero__graphic-slider-3">
+                    <GridImage
+                      gridId="theMomentDigiHero3"
+                      srcSizes={[486]}
+                      sizes="(max-width: 740px) 315px, 486px"
+                      imgType="png"
+                      altText="A mobile device"
+                    />
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
-      {props.dailyEditionsVariant && (
-        <div className="payment-selection__title-container" >
-          <h2 className="payment-selection__title">
-            The Premium App and the Daily Edition iPad app in one pack, plus ad-free reading on all your devices
-          </h2>
-        </div>
-      )}
+        {props.dailyEditionsVariant && (
+          <div className="payment-selection__title-container" >
+            <h2 className="payment-selection__title">
+              The Premium App and the Daily Edition iPad app in one pack, plus ad-free reading on all your devices
+            </h2>
+          </div>
+        )}
 
-      {showCountdownTimer(product, props.countryGroupId) &&
-      <FlashSaleCountdownInHero
-        product={product}
-        countryGroupId={props.countryGroupId}
-      />
-      }
-    </ProductPagehero>
+        {showCountdownTimer(product, props.countryGroupId) &&
+        <FlashSaleCountdownInHero
+          product={product}
+          countryGroupId={props.countryGroupId}
+        />
+        }
+      </ProductPagehero>
+      <PaymentSelectionContainer dailyEditionsVariant={props.dailyEditionsVariant} />
+    </div>
   );
 }
 

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.scss
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.scss
@@ -17,15 +17,34 @@
 
 .payment-selection__card {
   width: 100%;
-
-  margin: 0 20px 20px 10px;
+  margin: 20px 10px 0;
   display: flex;
   @include mq($from: tablet) {
     margin-left: 0;
     max-width: 30rem;
   }
+  
+  @include mq($from: tablet) {
+    margin: 0 20px 20px 10px;
+    width: 240px;
+  }
+}
+
+.payment-selection__card:last-of-type {
+  margin-bottom: 20px;
+}
+
+.payment-selection__card--variantA-width {
+  width: 320px;
+}
+
+.payment-selection_cancel-text {
+  width: 100%;
+  @include gu-fontset-body-sans;
+  font-style: italic;
+  margin: 0 10px;
 
   @include mq($from: tablet) {
-    width: 240px;
+    margin: 0;
   }
 }


### PR DESCRIPTION
## Why are you doing this?

the digital pack product cards are being called for all product pages, this is because  the paymentSelection component which renders these cards is call as part of the product-page-hero (which is a component rendered by all product pages)

The problem is the data received by the paymentSelection component (from redux) is only available on the digital pack page, this means all the other product pages that render the product-page-hero fail to render as they don't have access the correct data

the main fix is to remove the paymentSelection component from the render path for the other pages, basically remove it (<paymentSelection />) from product-page-hero 

[**Trello Card**](https://trello.com/c/memRoUZa/2522-fix-a-b-breaking-the-product-pages)

## Changes

* moved paymentSelection from productPageHero to digitalSubscriptionLandingHeader

## Screenshots
N/A 

## Output
The product pages are no longer breaking
