### PR TITLE
tidy up for s3 bucket for assets

### DIFF
--- a/support-frontend-static/cfn.yaml
+++ b/support-frontend-static/cfn.yaml
@@ -4,9 +4,7 @@ Resources:
   S3Bucket:
     Type: AWS::S3::Bucket
     Properties:
-      AccessControl: PublicRead
+      AccessControl: Private
       BucketName: support-frontend-static
       MetricsConfigurations: 
         - Id: EntireBucket
-      WebsiteConfiguration:
-        IndexDocument: index.html

--- a/support-frontend/conf/riff-raff.yaml
+++ b/support-frontend/conf/riff-raff.yaml
@@ -7,7 +7,6 @@ deployments:
       bucket: support-frontend-static
       prefixPackage: false
       prefixStack: false
-      prefixStage: true
       cacheControl: public, max-age=31536000
   cfn:
     type: cloud-formation


### PR DESCRIPTION
## Why are you doing this?

This follows on from https://github.com/guardian/support-frontend/pull/2016
I just noticed a few tidyup things that need doing.

- we don't need directory listings enabled
- we aren't actually useing the S3 website functionality, we're just using the standard public HTTP interface
- riffraff does a warning if you specify something to be the default value

I have recloudformed the bucket and it seems to be creating the right bucket, I will deploy to CODE and check the warning has gone and it seems to work still