### PR TITLE
Update contribution type labels for choice architecture abtest round 1 (labels test)

### DIFF
--- a/support-frontend/assets/helpers/checkouts.js
+++ b/support-frontend/assets/helpers/checkouts.js
@@ -61,17 +61,17 @@ function toHumanReadableContributionType(contributionType: ContributionType): 'S
     case 'ONE_OFF': return 'Single';
     case 'MONTHLY': return 'Monthly';
     case 'ANNUAL': return 'Annual';
-    default: return 'Annual';
+    default: return 'Monthly';
   }
 }
 
 // JTL - TBD: Remove after landing page choice architecture test
-function toHumanReadableContributionTypeAbTest(contributionType: ContributionType): 'Once' | 'Monthly' | 'Yearly' {
+function toHumanReadableContributionTypeAbTest(contributionType: ContributionType): 'Once' | 'Monthly' | 'Annually' {
   switch (contributionType) {
     case 'ONE_OFF': return 'Once';
     case 'MONTHLY': return 'Monthly';
-    case 'ANNUAL': return 'Yearly';
-    default: return 'Annual';
+    case 'ANNUAL': return 'Annually';
+    default: return 'Monthly';
   }
 }
 

--- a/support-frontend/assets/helpers/checkouts.js
+++ b/support-frontend/assets/helpers/checkouts.js
@@ -65,6 +65,16 @@ function toHumanReadableContributionType(contributionType: ContributionType): 'S
   }
 }
 
+// JTL - TBD: Remove after landing page choice architecture test
+function toHumanReadableContributionTypeAbTest(contributionType: ContributionType): 'Once' | 'Monthly' | 'Yearly' {
+  switch (contributionType) {
+    case 'ONE_OFF': return 'Once';
+    case 'MONTHLY': return 'Monthly';
+    case 'ANNUAL': return 'Yearly';
+    default: return 'Annual';
+  }
+}
+
 function getContributionTypeFromSession(): ?ContributionType {
   return toContributionType(storage.getSession('selectedContributionType'));
 }
@@ -187,6 +197,7 @@ export {
   getContributionTypeFromSession,
   getContributionTypeFromUrl,
   toHumanReadableContributionType,
+  toHumanReadableContributionTypeAbTest,
   getValidPaymentMethods,
   getPaymentMethodToSelect,
   getPaymentMethodFromSession,

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
@@ -9,6 +9,7 @@ import { classNameWithModifiers } from 'helpers/utilities';
 import {
   getPaymentMethodToSelect,
   toHumanReadableContributionType,
+  toHumanReadableContributionTypeAbTest,
 } from 'helpers/checkouts';
 
 import { trackComponentClick } from 'helpers/tracking/behaviour';
@@ -18,6 +19,7 @@ import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { type State } from '../contributionsLandingReducer';
 import { updateContributionTypeAndPaymentMethod } from '../contributionsLandingActions';
 import type { ContributionTypes, ContributionTypeSetting } from 'helpers/contributions';
+import type { LandingPageChoiceArchitectureLabelsTestVariants } from 'helpers/abTests/abtestDefinitions';
 
 // ----- Types ----- //
 
@@ -28,6 +30,7 @@ type PropTypes = {|
   switches: Switches,
   contributionTypes: ContributionTypes,
   onSelectContributionType: (ContributionType, Switches, IsoCountry, CountryGroupId) => void,
+  landingPageChoiceArchitectureLabelsTestVariants: LandingPageChoiceArchitectureLabelsTestVariants
 |};
 
 const mapStateToProps = (state: State) => ({
@@ -36,6 +39,7 @@ const mapStateToProps = (state: State) => ({
   countryId: state.common.internationalisation.countryId,
   switches: state.common.settings.switches,
   contributionTypes: state.common.settings.contributionTypes,
+  landingPageChoiceArchitectureLabelsTestVariants: state.common.abParticipations.landingPageChoiceArchitectureLabels,
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -55,6 +59,8 @@ const mapDispatchToProps = (dispatch: Function) => ({
 
 function withProps(props: PropTypes) {
   const contributionTypes = props.contributionTypes[props.countryGroupId];
+  const isLabelTestVariant = props.landingPageChoiceArchitectureLabelsTestVariants === 'withLabels';
+  const createContributionTypeLabel = isLabelTestVariant ?  toHumanReadableContributionTypeAbTest : toHumanReadableContributionType;
 
   if (contributionTypes.length === 1 && contributionTypes[0].contributionType === 'ONE_OFF') {
     return (null);
@@ -85,7 +91,7 @@ function withProps(props: PropTypes) {
                 checked={props.contributionType === contributionType}
               />
               <label htmlFor={`contributionType-${contributionType}`} className="form__radio-group-label">
-                {toHumanReadableContributionType(contributionType)}
+                {createContributionTypeLabel(contributionType)}
               </label>
             </li>);
         })}

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
@@ -60,7 +60,9 @@ const mapDispatchToProps = (dispatch: Function) => ({
 function withProps(props: PropTypes) {
   const contributionTypes = props.contributionTypes[props.countryGroupId];
   const isLabelTestVariant = props.landingPageChoiceArchitectureLabelsTestVariants === 'withLabels';
-  const createContributionTypeLabel = isLabelTestVariant ?  toHumanReadableContributionTypeAbTest : toHumanReadableContributionType;
+  const createContributionTypeLabel = isLabelTestVariant ?
+    toHumanReadableContributionTypeAbTest :
+    toHumanReadableContributionType;
 
   if (contributionTypes.length === 1 && contributionTypes[0].contributionType === 'ONE_OFF') {
     return (null);


### PR DESCRIPTION
## Why are you doing this?

We need to update the language on the page -- in particular, the labels for contribution types -- in accordance with which test participation a user is in. This change makes it so those who see a form that is labelled with questions have answers that make semantic sense.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Screenshots
Control:
![choice architecture labels control](https://user-images.githubusercontent.com/3300789/62559933-dffa8d80-b873-11e9-9681-def46fb24012.png)

Variant:
<img width="1118" alt="choice architecture labels variant" src="https://user-images.githubusercontent.com/3300789/62610182-0c0d2180-b8fb-11e9-8526-a6e68655b45d.png">

