### PR TITLE
Choice architecture test round 2 (Amounts first test) (#2022)

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -6,6 +6,7 @@ import { get as getCookie } from 'helpers/cookie';
 export type LandingPageCopyReturningSinglesTestVariants = 'control' | 'returningSingle' | 'notintest';
 export type ThankYouPageMarketingComponentTestVariants = 'control' | 'newMarketingComponent' | 'notintest';
 export type LandingPageChoiceArchitectureLabelsTestVariants = 'control' | 'withLabels' | 'notintest';
+export type LandingPageChoiceArchitectureAmountsFirstTestVariants = 'control' | 'amountsFirstSetOne' | 'amountsFirstSetTwo' | 'notintest';
 
 export const tests: Tests = {
   landingPageCopyReturningSingles: {
@@ -87,5 +88,34 @@ export const tests: Tests = {
     isActive: true,
     independent: true,
     seed: 3,
+  },
+
+  // JTL - 5 August 2019 - Ab-test: landingPageChoiceArchitectureAmountsFirst
+  // file used for this test: abTestContributionsLandingChoiceArchitecture.scss
+  // if a variant is successful, we will need to integrate the styles from the test stylesheet
+  // into the main stylesheet: contributionsLanding.scss
+  // This test also involves hardcoded amounts, which will need to be discussed moving forward
+  landingPageChoiceArchitectureAmountsFirst: {
+    type: 'OTHER',
+    variants: [
+      {
+        id: 'control',
+      },
+      {
+        id: 'amountsFirstSetOne',
+      },
+      {
+        id: 'amountsFirstSetTwo',
+      },
+    ],
+    audiences: {
+      ALL: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: true,
+    independent: true,
+    seed: 4,
   },
 };

--- a/support-frontend/assets/helpers/abTests/data/testAmountsData.js
+++ b/support-frontend/assets/helpers/abTests/data/testAmountsData.js
@@ -1,0 +1,226 @@
+export const testAmountsData = {
+  GBPCountries: {
+    amountsFirstSetOne: [
+      {
+        value: 5,
+      },
+      {
+        value: 10,
+        isDefault: true,
+      },
+      {
+        value: 25,
+      },
+      {
+        value: 50,
+      },
+    ],
+    amountsFirstSetTwo: [
+      {
+        value: 10,
+      },
+      {
+        value: 25,
+        isDefault: true,
+      },
+      {
+        value: 50,
+      },
+      {
+        value: 100,
+      },
+    ],
+  },
+  UnitedStates: {
+    amountsFirstSetOne: [
+      {
+        value: 5,
+      },
+      {
+        value: 10,
+        isDefault: true,
+      },
+      {
+        value: 25,
+      },
+      {
+        value: 50,
+      },
+    ],
+    amountsFirstSetTwo: [
+      {
+        value: 10,
+      },
+      {
+        value: 25,
+        isDefault: true,
+      },
+      {
+        value: 50,
+      },
+      {
+        value: 100,
+      },
+    ],
+  },
+  EURCountries: {
+    amountsFirstSetOne: [
+      {
+        value: 5,
+      },
+      {
+        value: 10,
+        isDefault: true,
+      },
+      {
+        value: 25,
+      },
+      {
+        value: 50,
+      },
+    ],
+    amountsFirstSetTwo: [
+      {
+        value: 10,
+      },
+      {
+        value: 25,
+        isDefault: true,
+      },
+      {
+        value: 50,
+      },
+      {
+        value: 100,
+      },
+    ],
+  },
+  AUDCountries: {
+    amountsFirstSetOne: [
+      {
+        value: 5,
+      },
+      {
+        value: 10,
+        isDefault: true,
+      },
+      {
+        value: 25,
+      },
+      {
+        value: 50,
+      },
+    ],
+    amountsFirstSetTwo: [
+      {
+        value: 10,
+      },
+      {
+        value: 25,
+        isDefault: true,
+      },
+      {
+        value: 50,
+      },
+      {
+        value: 100,
+      },
+    ],
+  },
+  International: {
+    amountsFirstSetOne: [
+      {
+        value: 5,
+      },
+      {
+        value: 10,
+        isDefault: true,
+      },
+      {
+        value: 25,
+      },
+      {
+        value: 50,
+      },
+    ],
+    amountsFirstSetTwo: [
+      {
+        value: 10,
+      },
+      {
+        value: 25,
+        isDefault: true,
+      },
+      {
+        value: 50,
+      },
+      {
+        value: 100,
+      },
+    ],
+  },
+  NZDCountries: {
+    amountsFirstSetOne: [
+      {
+        value: 5,
+      },
+      {
+        value: 10,
+        isDefault: true,
+      },
+      {
+        value: 25,
+      },
+      {
+        value: 50,
+      },
+    ],
+    amountsFirstSetTwo: [
+      {
+        value: 10,
+      },
+      {
+        value: 25,
+        isDefault: true,
+      },
+      {
+        value: 50,
+      },
+      {
+        value: 100,
+      },
+    ],
+  },
+  Canada: {
+    amountsFirstSetOne: [
+      {
+        value: 5,
+      },
+      {
+        value: 10,
+        isDefault: true,
+      },
+      {
+        value: 25,
+      },
+      {
+        value: 50,
+      },
+    ],
+    amountsFirstSetTwo: [
+      {
+        value: 10,
+      },
+      {
+        value: 25,
+        isDefault: true,
+      },
+      {
+        value: 50,
+      },
+      {
+        value: 100,
+      },
+    ],
+  },
+};

--- a/support-frontend/assets/pages/contributions-landing/abTestContributionsLandingChoiceArchitecture.scss
+++ b/support-frontend/assets/pages/contributions-landing/abTestContributionsLandingChoiceArchitecture.scss
@@ -39,3 +39,21 @@
      }
   }
 }
+
+// Styles for landing page choice architecture round two
+// JTL TBD: integrate this css into ContributionsLanding.scss
+// if the labels variant is successful
+.form--with-labels.form--amounts-first {
+  .contributions-form-selectors {
+    display: flex;
+    flex-flow: column-reverse;
+  }
+
+  .form__radio-group--tabs {
+    margin-top: $gu-v-spacing;
+  }
+
+  .form__radio-group--contribution-amount {
+    margin-top: $gu-v-spacing / 2;
+  }
+}

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.scss
@@ -1122,13 +1122,12 @@ form {
   border: 1px solid gu-colour(highlight-main);
 }
 
-
-// Editorialise Amounts Test
-
 .amount-per-week-breakdown {
+  font-family: $gu-text-sans-web;
   margin-top: $gu-v-spacing;
   font-style: italic;
   line-height: 20px;
+  font-weight: normal;
 }
 
 .amount-per-week-breakdown:empty {


### PR DESCRIPTION
## Why are you doing this?
We are testing the idea that selecting amounts first might give us an uplift in some regions

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/XcLbdC4p/1295-choice-architecture-r2-flip-order)

## Screenshots (To be updated)
Control:
![amounts first control](https://user-images.githubusercontent.com/3300789/62643635-4cdb5980-b940-11e9-996c-8e181bbe0754.png)

Variant one:
![amounts first variant1](https://user-images.githubusercontent.com/3300789/62643636-4cdb5980-b940-11e9-891e-9461ea94d856.png)

Variant two:
![amounts first variant2](https://user-images.githubusercontent.com/3300789/62643637-4d73f000-b940-11e9-8bbc-645734285b4e.png)