### PR TITLE
feat: remove break in sales-copy

### DIFF
--- a/support-frontend/assets/components/productOption/productOption.scss
+++ b/support-frontend/assets/components/productOption/productOption.scss
@@ -80,7 +80,6 @@
   color: gu-colour(neutral-7);
   line-height: 1.4;
   @include gu-fontset-body-sans;
-  font-weight: bold;
 }  
 
 .product-option__button {
@@ -109,6 +108,14 @@
   font-family: $gu-text-sans-web;
   font-size: 16px;
   line-height: 1.4rem;
+}
+
+.product-option__full-screen-break {
+  display: none;
+
+  @include mq($from: tablet) {
+    display: block;
+  }
 }
 
 .product-option__sales-copy--break {

--- a/support-frontend/assets/components/productOption/productOption.scss
+++ b/support-frontend/assets/components/productOption/productOption.scss
@@ -111,10 +111,10 @@
   line-height: 1.4rem;
 }
 
-.product-option__full-screen-break {
+.product-option__sales-copy--break {
   display: none;
 
-  @include mq($from: tablet) {
+  @include mq($from: mobileLandscape) {
     display: block;
   }
 }

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
@@ -55,7 +55,7 @@ const BILLING_PERIOD = {
       control: () => (
         <span>
           14 day free trial, then <strong>{displayPrice}</strong>
-          &nbsp;for the first year <br />
+          &nbsp;for the first year <br className="product-option__sales-copy--break" />
           (save <strong>{saving}</strong> per year)
         </span>
       ),

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
@@ -33,14 +33,14 @@ const BILLING_PERIOD = {
     singlePeriod: 'month',
     salesCopy: (displayPrice: string, saving?: string) => ({
       control: () => (
-        <span>14 day free trial, then <strong>{displayPrice}</strong> {saving && null}
+        <span>14 day free trial, then <strong>{displayPrice}</strong> {saving && null} a month
           <br className="product-option__full-screen-break" />
           <br className="product-option__full-screen-break" />
         </span>
       ),
       variantA: () => (
         <span>
-          14 day free trial, then <strong>{displayPrice}</strong> {saving && null}
+          14 day free trial, then <strong>{displayPrice}</strong> {saving && null} a month
           <br className="product-option__full-screen-break" />
           <br className="product-option__full-screen-break" />
         </span>

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
@@ -55,8 +55,7 @@ const BILLING_PERIOD = {
       control: () => (
         <span>
           14 day free trial, then <strong>{displayPrice}</strong>
-          &nbsp;for the first year <br className="product-option__sales-copy--break" />
-          (save <strong>{saving}</strong> per year)
+          &nbsp;for the first year (save <strong>{saving}</strong> per year)
         </span>
       ),
       variantA: () => (

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.scss
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.scss
@@ -28,7 +28,7 @@
   @include mq($from: tablet) {
     margin: 0 10px 0 0;
     max-width: 30rem;
-    width: 240px;
+    width: 320px;
   }
 }
 
@@ -37,15 +37,6 @@
 
   @include mq($from: tablet) {
     margin: 0 20px;
-  }
-}
-
-.payment-selection__card.payment-selection__card--variantA-width {
-  margin: 10px;
-
-  @include mq($from: tablet) {
-    margin: 0 20px 0 0 ;
-    width: 320px;
   }
 }
 


### PR DESCRIPTION
## Why are you doing this?
This PR fixes the break in the sales copy on the option-card shown in the screenshots

## Changes

* remove break in sales-copy

## Screenshots
### Old view
![Screen Shot 2019-08-09 at 13 31 48](https://user-images.githubusercontent.com/45875444/62779180-60a2cf00-baaa-11e9-8de7-55849fe35332.png)

### New view
![Screen Shot 2019-08-09 at 13 36 27](https://user-images.githubusercontent.com/45875444/62779302-baa39480-baaa-11e9-98f3-2a1903c7bd0c.png)
