### PR TITLE
Remove mentions of free delivery

### DIFF
--- a/support-frontend/assets/components/subscriptionBundles/weekly.jsx
+++ b/support-frontend/assets/components/subscriptionBundles/weekly.jsx
@@ -33,7 +33,7 @@ function Weekly(props: PropTypes) {
       headingSize={props.headingSize}
       benefits={{
         list: false,
-        copy: 'A weekly, global magazine from The Guardian, with free delivery worldwide',
+        copy: 'A weekly, global magazine from The Guardian, with delivery worldwide',
       }}
       gridImage={{
         gridId: 'weeklyCircle',

--- a/support-frontend/assets/pages/subscriptions-landing/components/featuredProducts.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/components/featuredProducts.jsx
@@ -134,7 +134,7 @@ const getProductHeadingsAndBody = (product: SubscriptionProduct, countryGroupId:
   return {
     headingText: 'Guardian Weekly',
     subheadingText: `6 issues for ${showPrice(sixPrice)}`,
-    bodyText: 'The Guardian\'s essential news magazine with free worldwide delivery.',
+    bodyText: 'The Guardian\'s essential news magazine with worldwide delivery.',
   };
   // }
 };

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -94,7 +94,7 @@ const content = (
           <LargeParagraph>Inside the essential magazine from
           The&nbsp;Guardian, you&rsquo;ll find expert opinion, insight and culture, curated to
           bring you a progressive, international perspective. You&rsquo;ll also discover
-          challenging new puzzles every week. Subscribe today and get free delivery, worldwide.
+          challenging new puzzles every week. Subscribe today and get delivery worldwide.
           </LargeParagraph>
         </Text>
       </Content>

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -102,10 +102,10 @@ const content = (
         <Text title="As a subscriber you’ll enjoy" />
         <Outset>
           <ProductPageFeatures features={[
-            { title: 'Up to 35% off the retail cover price' },
-            { title: 'Free international shipping' },
+            { title: 'Every issue delivered with up to 35% off the cover price' },
+            { title: 'Access to the magazine\'s digital archive' },
             { title: 'A weekly email newsletter from the editor' },
-            { title: 'Access to every edition on any device, through PressReader' },
+            { title: 'The very best of the Guardian\'s puzzles' },
           ]}
           />
         </Outset>
@@ -119,7 +119,7 @@ const content = (
               Gifting is available
         </ProductPageInfoChip>
         <ProductPageInfoChip icon={<SvgInformation />}>
-              You can cancel your subscription at any time
+              Delivery cost included. You can cancel your subscription at any time
         </ProductPageInfoChip>
       </Content>
       <Content>

--- a/support-frontend/conf/strings.conf
+++ b/support-frontend/conf/strings.conf
@@ -2,5 +2,5 @@ showcaseLanding.description="Help us deliver the independent journalism the worl
 contributionsLanding.description="Help us deliver the independent journalism the world needs. Support the Guardian by making a contribution."
 subscriptionsLanding.description="Help us deliver the independent journalism the world needs. Support the Guardian by getting a subscription."
 digitalPackLanding.description="Subscribe to the Guardian Digital Pack and read the Guardian ad-free on all of your devices. The Digital Pack includes the Premium App and Daily Edition iPad app."
-weeklyLanding.description="Subscribe to The Guardian Weekly and enjoy seven days of international news in one magazine with free worldwide delivery."
+weeklyLanding.description="Subscribe to The Guardian Weekly and enjoy seven days of international news in one magazine with worldwide delivery."
 paperLanding.description="Subscribe to The Guardian and The Observer newspapers and save on the retail price all year round  |  Voucher and Home Delivery options available"


### PR DESCRIPTION
## Why are you doing this?
Apparently delivery of the Guardian Weekly is not free, instead it is factored into the price, so we need to remove this erroneous claim. Marketing also snuck in some other copy changes on the GW product page.

[**Trello Card**](https://trello.com/c/mz1Uw6d4/2511-update-copy-on-gw-product-page)

## Changes
* Guardian weekly product page: updated copy for reasons to buy, remove free delivery and instead say delivery cost included.
* Subs landing page: removal of two mentions of free delivery and an additional one from the metadata.
