### PR TITLE
fix support-workers it tests and make more logging

### DIFF
--- a/support-workers/src/it/resources/logback-test.xml
+++ b/support-workers/src/it/resources/logback-test.xml
@@ -1,3 +1,20 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!-- Turn off logging during tests -->
-<configuration />
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.core.filter.EvaluatorFilter">
+            <evaluator class="ch.qos.logback.classic.boolex.OnMarkerEvaluator">
+                <marker>SENTRY</marker>
+            </evaluator>
+            <onMatch>DENY</onMatch>
+        </filter>
+
+        <encoder>
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss.SSS}] %.-6level %logger{5} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+
+</configuration>

--- a/support-workers/src/main/scala/com/gu/FutureLogging.scala
+++ b/support-workers/src/main/scala/com/gu/FutureLogging.scala
@@ -1,0 +1,22 @@
+package com.gu
+
+import com.typesafe.scalalogging.LazyLogging
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+object FutureLogging extends LazyLogging {
+
+  implicit class LogImplicitFuture[A](op: Future[A]) {
+
+    // this is just a handy method to add logging to the end of any for comprehension
+    def withLogging(message: String): Future[A] = {
+      op.transform { theTry =>
+        logger.info(s"$message: continued processing with value: $theTry")
+        theTry
+      }
+    }
+
+  }
+
+}

--- a/support-workers/src/main/scala/com/gu/support/workers/GetSubscriptionWithCurrentRequestId.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/GetSubscriptionWithCurrentRequestId.scala
@@ -22,7 +22,7 @@ object GetSubscriptionWithCurrentRequestId {
   )(implicit ec: ExecutionContext): Future[Option[DomainSubscription]] = for {
     accountNumbers <- zuoraService.getAccountFields(identityId, now())
       .withLogging("getAccountFields")
-    subscriptions <- accountNumbers.map(_.accountNumber).map{ zuoraAccountNumber =>
+    subscriptions <- accountNumbers.map(_.accountNumber).map { zuoraAccountNumber =>
       zuoraService.getSubscriptions(zuoraAccountNumber).withLogging(s"getSubscriptions($zuoraAccountNumber)")
     }.combineAll.withLogging("combineAll")
   } yield subscriptions.find(subscription => CreatedBySameRequest(requestId, subscription.existingSubscriptionRequestId))

--- a/support-workers/src/main/scala/com/gu/zuora/ZuoraService.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/ZuoraService.scala
@@ -33,7 +33,7 @@ class ZuoraService(val config: ZuoraConfig, client: FutureHttpClient, baseUrl: O
     get[GetAccountResponse](s"accounts/$accountNumber", authHeaders)
 
   def getAccountFields(identityId: IdentityId, now: OffsetDateTime): Future[List[DomainAccount]] = {
-    val recentDays = 28
+    val recentDays = 28 // the step functions only try for 1 day, so 28 would be ample to find subs already created in this execution
     val recently = now.minusDays(recentDays).format(DateTimeFormatter.ISO_ZONED_DATE_TIME)
     // WARNING constructing queries from strings is inherently dangerous.  Be very careful.
     val queryData = QueryData(s"select AccountNumber, CreatedRequestId__c from account where IdentityId__c = '${identityId.value}' and UpdatedDate > '$recently'")

--- a/support-workers/src/test/resources/logback.xml
+++ b/support-workers/src/test/resources/logback.xml
@@ -9,7 +9,7 @@
         </filter>
 
         <encoder>
-            <pattern>[%d{yyyy-MM-dd HH:mm:ss.SSS}] %X{AWSRequestId:-NO-REQUEST-ID} %.-6level %logger{5} - %msg%n</pattern>
+            <pattern>[%d{yyyy-MM-dd HH:mm:ss.SSS}] %.-6level %logger{5} - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/support-workers/src/test/scala/com/gu/support/workers/EndToEndSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/EndToEndSpec.scala
@@ -6,7 +6,7 @@ import com.gu.i18n.Currency
 import com.gu.i18n.Currency.{EUR, GBP}
 import com.gu.monitoring.SafeLogger
 import com.gu.support.encoding.CustomCodecs._
-import com.gu.support.workers.JsonFixtures.{createPayPalPaymentMethodContributionJson, wrapFixture}
+import com.gu.support.workers.JsonFixtures.{createStripePaymentMethodContributionJson, wrapFixture}
 import com.gu.support.workers.lambdas._
 import com.gu.test.tags.annotations.IntegrationTest
 import io.circe.generic.auto._
@@ -22,8 +22,9 @@ class EndToEndSpec extends LambdaSpec {
   they should "work with other currencies" in runSignupWithCurrency(EUR)
 
   def runSignupWithCurrency(currency: Currency) {
-    SafeLogger.info(createPayPalPaymentMethodContributionJson(currency))
-    val output = wrapFixture(createPayPalPaymentMethodContributionJson(currency))
+    val json = createStripePaymentMethodContributionJson(currency = currency)
+    SafeLogger.info(json)
+    val output = wrapFixture(json)
       .chain(new CreatePaymentMethod())
       .chain(new CreateSalesforceContact())
       .chain(new CreateZuoraSubscription())

--- a/support-workers/src/test/scala/com/gu/support/workers/EndToEndSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/EndToEndSpec.scala
@@ -67,7 +67,9 @@ class EndToEndSpec extends LambdaSpec {
 
     def last(handler: Handler[_, _]): ByteArrayOutputStream = {
       val output = new ByteArrayOutputStream()
+      SafeLogger.info(s"calling handler: ${handler.getClass}")
       handler.handleRequest(stream, output, context)
+      SafeLogger.info(s"finished handler: ${handler.getClass}")
       output
     }
 

--- a/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
@@ -534,7 +534,8 @@ object JsonFixtures {
               "Id": "0036E00000VlOPDQA3",
               "AccountId": "0016E00000f17pYQAQ"
           },
-          "acquisitionData": $acquisitionData
+          "acquisitionData": $acquisitionData,
+          $salesforceContactsJson
       }
       """
 

--- a/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
@@ -1,6 +1,7 @@
 package com.gu.support.workers
 
 import java.io.ByteArrayInputStream
+import java.util.UUID
 
 import com.gu.i18n.Currency
 import com.gu.i18n.Currency.GBP
@@ -64,7 +65,7 @@ object JsonFixtures {
           "isTestUser": false
         }
     """
-  val requestIdJson = "\"requestId\": \"e18f6418-45f2-11e7-8bfa-8faac2182601\""
+  def requestIdJson: String = s""""requestId": "${UUID.randomUUID()}\""""
   val validBaid = "B-23637766K5365543J"
   val payPalEmail = "test@paypal.com"
   val payPalPaymentMethod =
@@ -169,7 +170,7 @@ object JsonFixtures {
       }
     """
 
-  val stripeToken = "tok_AXY4M16p60c2sg"
+  val stripeToken = "tok_visa"
   val stripeJson =
     s"""
       {
@@ -187,13 +188,14 @@ object JsonFixtures {
           "acquisitionData": $acquisitionData
         }"""
 
-  def createStripePaymentMethodContributionJson(billingPeriod: BillingPeriod = Monthly, amount: BigDecimal = 5): String =
+  def createStripePaymentMethodContributionJson(billingPeriod: BillingPeriod = Monthly, amount: BigDecimal = 5, currency: Currency = GBP): String =
     s"""{
           $requestIdJson,
           ${userJson()},
-          "product": ${contribution(amount = amount, billingPeriod = billingPeriod)},
+          "product": ${contribution(amount = amount, billingPeriod = billingPeriod, currency = currency)},
           "paymentFields": $stripeJson,
-          "sessionId": "testingToken"
+          "sessionId": "testingToken",
+          "acquisitionData": $acquisitionData
         }"""
 
   val createPayPalPaymentMethodDigitalPackJson =

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
@@ -1,6 +1,7 @@
 package com.gu.support.workers.integration
 
 import java.io.ByteArrayOutputStream
+import java.time.OffsetDateTime
 
 import com.gu.config.Configuration.{promotionsConfigProvider, zuoraConfigProvider}
 import com.gu.okhttp.RequestRunners.configurableFutureRunner
@@ -90,7 +91,7 @@ class CreateZuoraSubscriptionSpec extends LambdaSpec with MockServicesCreator {
     // Need to return None from the Zuora service `getRecurringSubscription`
     // method or the subscribe step gets skipped
     // if these methods weren't coupled into one class then we could pass them separately and avoid reflection
-    when(mockZuora.getAccountFields(any[IdentityId]))
+    when(mockZuora.getAccountFields(any[IdentityId], any[OffsetDateTime]))
       .thenReturn(Future.successful(Nil))
     when(mockZuora.getSubscriptions(any[ZuoraAccountNumber]))
       .thenReturn(Future.successful(Nil))


### PR DESCRIPTION
## Why are you doing this?

I tried to run the `it:test` in support workers and I was getting 8 failures within these classes
```
[error] 	com.gu.zuora.ZuoraSpec
[error] 	com.gu.support.workers.integration.PreparePaymentMethodForReuseSpec
[error] 	com.gu.support.workers.integration.CreateZuoraSubscriptionSpec
[error] 	com.gu.support.workers.EndToEndSpec
```
I managed to fix some with changes in zuora UAT and DEV, but some I needed to edit the code as well.  Judging by the history I think they have been broke for a good few months, but I don't know if we can automate them easily.

EndToEnd was the hardest one, and it was caused by a change I made nearly a year ago.  It checked first for existing contributions against a hard coded identity id by querying them one by one, then it creates a new contribution against the same id.  Every single time!  we've run the test over 1000 times and we can only query about 600 before the test times out...
The fix done, which affects the prod code, was to only deduplicate subs if they are within the last 28 days.  I considered doing a hack on the tests, but I preferred to think about a way that made sense in prod too.
