### PR TITLE
Landing page choice architecture R1b

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -33,7 +33,7 @@ export const tests: Tests = {
   // file created for this test: abTestContributionsLandingChoiceArchitecture.scss
   // if variant is successful, we will need to integrate the styles from the test stylesheet
   // into the main stylesheet: contributionsLanding.scss
-  landingPageChoiceArchitectureLabels: {
+  landingPageChoiceArchitectureLabels1b: {
     type: 'OTHER',
     variants: [
       {

--- a/support-frontend/assets/helpers/checkouts.js
+++ b/support-frontend/assets/helpers/checkouts.js
@@ -65,16 +65,6 @@ function toHumanReadableContributionType(contributionType: ContributionType): 'S
   }
 }
 
-// JTL - TBD: Remove after landing page choice architecture test
-function toHumanReadableContributionTypeAbTest(contributionType: ContributionType): 'Once' | 'Monthly' | 'Annually' {
-  switch (contributionType) {
-    case 'ONE_OFF': return 'Once';
-    case 'MONTHLY': return 'Monthly';
-    case 'ANNUAL': return 'Annually';
-    default: return 'Monthly';
-  }
-}
-
 function getContributionTypeFromSession(): ?ContributionType {
   return toContributionType(storage.getSession('selectedContributionType'));
 }
@@ -197,7 +187,6 @@ export {
   getContributionTypeFromSession,
   getContributionTypeFromUrl,
   toHumanReadableContributionType,
-  toHumanReadableContributionTypeAbTest,
   getValidPaymentMethods,
   getPaymentMethodToSelect,
   getPaymentMethodFromSession,

--- a/support-frontend/assets/pages/contributions-landing/abTestContributionsLandingChoiceArchitecture.scss
+++ b/support-frontend/assets/pages/contributions-landing/abTestContributionsLandingChoiceArchitecture.scss
@@ -5,17 +5,16 @@
 // if the labels variant is successful
 .form--with-labels {
   .form__radio-group--tabs {
-    margin-top: $gu-v-spacing / 2;
+    margin-top: $gu-v-spacing;
   }
 
   .form__radio-group--contribution-amount {
-    margin-top: $gu-v-spacing * 2;
+    margin-top: 18px;
   }
 
   .form__legend {
     @include gu-typeface(headline, 18);
     font-weight: 700;
-    display: block;
     margin-bottom: $gu-v-spacing;
   }
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
@@ -114,7 +114,7 @@ const mapStateToProps = (state: State) => ({
   country: state.common.internationalisation.countryId,
   stripeV3HasLoaded: state.page.form.stripePaymentRequestButtonData.stripeV3HasLoaded,
   stripePaymentRequestButtonMethod: state.page.form.stripePaymentRequestButtonData.paymentMethod,
-  landingPageChoiceArchitectureLabelsTestVariant: state.common.abParticipations.landingPageChoiceArchitectureLabels,
+  landingPageChoiceArchitectureLabelsTestVariant: state.common.abParticipations.landingPageChoiceArchitectureLabels1b,
 });
 
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
@@ -59,10 +59,6 @@ const mapDispatchToProps = (dispatch: Function) => ({
 
 function withProps(props: PropTypes) {
   const contributionTypes = props.contributionTypes[props.countryGroupId];
-  const isLabelTestVariant = props.landingPageChoiceArchitectureLabelsTestVariants === 'withLabels';
-  const createContributionTypeLabel = isLabelTestVariant ?
-    toHumanReadableContributionTypeAbTest :
-    toHumanReadableContributionType;
 
   if (contributionTypes.length === 1 && contributionTypes[0].contributionType === 'ONE_OFF') {
     return (null);
@@ -93,7 +89,7 @@ function withProps(props: PropTypes) {
                 checked={props.contributionType === contributionType}
               />
               <label htmlFor={`contributionType-${contributionType}`} className="form__radio-group-label">
-                {createContributionTypeLabel(contributionType)}
+                {toHumanReadableContributionType(contributionType)}
               </label>
             </li>);
         })}

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
@@ -18,7 +18,6 @@ import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { type State } from '../contributionsLandingReducer';
 import { updateContributionTypeAndPaymentMethod } from '../contributionsLandingActions';
 import type { ContributionTypes, ContributionTypeSetting } from 'helpers/contributions';
-import type { LandingPageChoiceArchitectureLabelsTestVariants } from 'helpers/abTests/abtestDefinitions';
 
 // ----- Types ----- //
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
@@ -9,7 +9,6 @@ import { classNameWithModifiers } from 'helpers/utilities';
 import {
   getPaymentMethodToSelect,
   toHumanReadableContributionType,
-  toHumanReadableContributionTypeAbTest,
 } from 'helpers/checkouts';
 
 import { trackComponentClick } from 'helpers/tracking/behaviour';
@@ -30,7 +29,6 @@ type PropTypes = {|
   switches: Switches,
   contributionTypes: ContributionTypes,
   onSelectContributionType: (ContributionType, Switches, IsoCountry, CountryGroupId) => void,
-  landingPageChoiceArchitectureLabelsTestVariants: LandingPageChoiceArchitectureLabelsTestVariants
 |};
 
 const mapStateToProps = (state: State) => ({
@@ -39,7 +37,6 @@ const mapStateToProps = (state: State) => ({
   countryId: state.common.internationalisation.countryId,
   switches: state.common.settings.switches,
   contributionTypes: state.common.settings.contributionTypes,
-  landingPageChoiceArchitectureLabelsTestVariants: state.common.abParticipations.landingPageChoiceArchitectureLabels,
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({


### PR DESCRIPTION
## Why are you doing this?
The previous version of this test introduced labels above the contribution type and amounts selectors. This has had a negative impact.
This change removes the labels and adjusts the margins.

[**Trello Card**](https://trello.com/c/WYtS686A/1346-implement-choice-architecture-round-1b)

## Screenshots
control:
![Screenshot 2019-08-14 at 11 39 56](https://user-images.githubusercontent.com/1513454/63015215-4725cc80-be88-11e9-892e-3c46c18ea79f.png)


variant:
![Screenshot 2019-08-14 at 11 36 47](https://user-images.githubusercontent.com/1513454/63015186-34ab9300-be88-11e9-9941-a3f406093722.png)

