### PR TITLE
handle 4xx errors specifically in calls from service workers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,8 @@ skip in publish := true
 lazy val integrationTestSettings: Seq[Def.Setting[_]] = Defaults.itSettings ++ Seq(
   scalaSource in IntegrationTest := baseDirectory.value / "src" / "test" / "scala",
   javaSource in IntegrationTest := baseDirectory.value / "src" / "test" / "java",
-  testOptions in Test := Seq(Tests.Argument(TestFrameworks.ScalaTest, "-l", "com.gu.test.tags.annotations.IntegrationTest"))
+  testOptions in Test := Seq(Tests.Argument(TestFrameworks.ScalaTest, "-l", "com.gu.test.tags.annotations.IntegrationTest")),
+  parallelExecution in IntegrationTest := false
 )
 
 lazy val testScalastyle = taskKey[Unit]("testScalastyle")

--- a/build.sbt
+++ b/build.sbt
@@ -7,8 +7,7 @@ skip in publish := true
 lazy val integrationTestSettings: Seq[Def.Setting[_]] = Defaults.itSettings ++ Seq(
   scalaSource in IntegrationTest := baseDirectory.value / "src" / "test" / "scala",
   javaSource in IntegrationTest := baseDirectory.value / "src" / "test" / "java",
-  testOptions in Test := Seq(Tests.Argument(TestFrameworks.ScalaTest, "-l", "com.gu.test.tags.annotations.IntegrationTest")),
-  parallelExecution in IntegrationTest := false
+  testOptions in Test := Seq(Tests.Argument(TestFrameworks.ScalaTest, "-l", "com.gu.test.tags.annotations.IntegrationTest"))
 )
 
 lazy val testScalastyle = taskKey[Unit]("testScalastyle")

--- a/support-workers/src/test/scala/com/gu/support/workers/errors/MockWebServerCreator.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/errors/MockWebServerCreator.scala
@@ -3,12 +3,12 @@ package com.gu.support.workers.errors
 import okhttp3.mockwebserver.{MockResponse, MockWebServer}
 
 trait MockWebServerCreator {
-  protected def createMockServer(responseCode: Int, body: String) = {
+  protected def createMockServer(responseCode: Int, body: String, contentType: String = "application/json") = {
     // Create a MockWebServer. These are lean enough that you can create a new
     // instance for every unit test.
     val server = new MockWebServer
     // Add the response which you want to serve
-    server.enqueue(new MockResponse().setResponseCode(responseCode).setBody(body).setHeader("Content-type", "application/json"))
+    server.enqueue(new MockResponse().setResponseCode(responseCode).setBody(body).setHeader("Content-type", contentType))
     server.start()
     server
   }

--- a/support-workers/src/test/scala/com/gu/support/workers/errors/MockWebServerCreator.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/errors/MockWebServerCreator.scala
@@ -8,7 +8,7 @@ trait MockWebServerCreator {
     // instance for every unit test.
     val server = new MockWebServer
     // Add the response which you want to serve
-    server.enqueue(new MockResponse().setResponseCode(responseCode).setBody(body))
+    server.enqueue(new MockResponse().setResponseCode(responseCode).setBody(body).setHeader("Content-type", "application/json"))
     server.start()
     server
   }


### PR DESCRIPTION
## Why are you doing this?

A while ago I was investigatng a step function that timed out after 24 hours.  It turned out there was a 4xx error occurring in one of the backends, i.e. client error.  I think something was missing (I forget the exact details).
It should have aborted straight away, but the step functions were turning any error when doing an http request as a Helper error, which was turning into a RetryUnlimited (i.e. 24 hours).

This PR separates out client errors (4xx) from general explosions, so that 4xx are always aborted and any other failure is retried.


Tested locally via it testing and remotely in CODE (GW 6 for 6 and contribution)