### PR TITLE
Fix post offer copy

### DIFF
--- a/support-frontend/assets/components/forms/customFields/radioInput.scss
+++ b/support-frontend/assets/components/forms/customFields/radioInput.scss
@@ -31,10 +31,9 @@
 .component-radio-input__helper {
   margin-left: $gu-h-spacing * 1.5;
   margin-bottom: $gu-v-spacing;
-}
-
-.component-radio-input__offer {
-  font-weight: bold;
+  @include mq($from: phablet) {
+    padding-right: $gu-h-spacing * 2;
+  }
 }
 
 .component-radio-input__input {


### PR DESCRIPTION
## Why are you doing this?
The flow of the offer text in the DP checkout was janky, as detailed in the [**Trello Card**](https://trello.com/c/rFrvkNJy/2462-dp-checkout-fix-post-offer-copy)

## Changes
* Text in [Memsub](https://memsub-promotions.gutools.co.uk/#/promotion/d809d7ca-ba4f-4e3f-9fbf-a313c503be07) has been updated from 'Enjoy your digital pack free for 14 days' to 'Enjoy your digital pack free for 14 days, then' 
* Remove bold from offer text so the text looks cohesive on the page
* Small css tweak for desktop view

## Screenshots of the problem(s) 😢 
![Screen Shot 2019-08-15 at 14 41 55](https://user-images.githubusercontent.com/16781258/63098493-ede29980-bf6a-11e9-8867-60720c6ba82c.png)

![Screen Shot 2019-08-15 at 14 43 50](https://user-images.githubusercontent.com/16781258/63098594-208c9200-bf6b-11e9-9cb1-37139b57b167.png)

## Corrected: desktop
![Screen Shot 2019-08-15 at 14 30 48](https://user-images.githubusercontent.com/16781258/63098676-474ac880-bf6b-11e9-9846-193674f4152d.png)

## Corrected: mobile
![Screen Shot 2019-08-15 at 12 42 16](https://user-images.githubusercontent.com/16781258/63098708-5d588900-bf6b-11e9-82cc-9f075f9ce711.png)