### PR TITLE
Update marketing copy on GW product page

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.jsx
@@ -78,7 +78,7 @@ const CampaignHeader = () => (
   <ProductPagehero
     appearance="campaign"
     overheading="Guardian Weekly subscriptions"
-    heading="The Guardian's essential news magazine"
+    heading="Pause for thought with the Guardian's essential news magazine"
     modifierClasses={['weekly-campaign']}
     content={<AnchorButton onClick={sendTrackingEventsOnClick('options_cta_click', 'GuardianWeekly', null)} icon={<SvgChevron />} href="#subscribe">See Subscription options</AnchorButton>}
     hasCampaign

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.jsx
@@ -86,7 +86,7 @@ const CampaignHeader = () => (
 
     <div className="weekly-campaign-hero">
       <div className="weekly-campaign-hero__copy">
-        <h2>Think globally.<br />Read Weekly.</h2>
+        <h2>The Guardian<br />Weekly</h2>
       </div>
 
       <div className="weekly-campaign-hero__graphic">

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.jsx
@@ -78,7 +78,7 @@ const CampaignHeader = () => (
   <ProductPagehero
     appearance="campaign"
     overheading="Guardian Weekly subscriptions"
-    heading="Pause for thought with the Guardian's essential news magazine"
+    heading="Pause for thought with The Guardian's essential news magazine"
     modifierClasses={['weekly-campaign']}
     content={<AnchorButton onClick={sendTrackingEventsOnClick('options_cta_click', 'GuardianWeekly', null)} icon={<SvgChevron />} href="#subscribe">See Subscription options</AnchorButton>}
     hasCampaign

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -94,7 +94,7 @@ const content = (
           <LargeParagraph>The Guardian Weekly magazine is a round-up of the world news,&#32;
             opinion and long reads that have shaped the week. Inside, the past seven days&apos;&#32;
             most memorable stories are reframed with striking photography and insightful companion&#32;
-            pieces, all handpicked from the Guardian and the Observer.
+            pieces, all handpicked from The Guardian and The Observer.
           </LargeParagraph>
         </Text>
       </Content>
@@ -105,7 +105,7 @@ const content = (
             { title: 'Every issue delivered with up to 35% off the cover price' },
             { title: 'Access to the magazine\'s digital archive' },
             { title: 'A weekly email newsletter from the editor' },
-            { title: 'The very best of the Guardian\'s puzzles' },
+            { title: 'The very best of The Guardian\'s puzzles' },
           ]}
           />
         </Outset>

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -90,11 +90,11 @@ const content = (
     >
       <CampaignHeader />
       <Content>
-        <Text title="Open up your world view, Weekly">
-          <LargeParagraph>Inside the essential magazine from
-          The&nbsp;Guardian, you&rsquo;ll find expert opinion, insight and culture, curated to
-          bring you a progressive, international perspective. You&rsquo;ll also discover
-          challenging new puzzles every week. Subscribe today and get delivery worldwide.
+        <Text title="Catch up on the issues that matter">
+          <LargeParagraph>The Guardian Weekly magazine is a round-up of the world news,&#32;
+            opinion and long reads that have shaped the week. Inside, the past seven days&apos;&#32;
+            most memorable stories are reframed with striking photography and insightful companion&#32;
+            pieces, all handpicked from the Guardian and the Observer.
           </LargeParagraph>
         </Text>
       </Content>


### PR DESCRIPTION
## Why are you doing this?
This adds missing marketing copy updates in the following [**Trello Card**](https://trello.com/c/mz1Uw6d4/2511-update-copy-on-gw-product-page)

## Changes
* Page hero text
* Page headline
* First paragraph title
* First paragraph copy

## Screenshots
### Old copy
![Screen Shot 2019-08-15 at 17 32 17](https://user-images.githubusercontent.com/16781258/63110149-ae27ac00-bf82-11e9-8963-49fd54919e2b.png)

### New copy
![Screen Shot 2019-08-15 at 17 32 05](https://user-images.githubusercontent.com/16781258/63110171-b849aa80-bf82-11e9-9d00-1917c2eb3fa9.png)