### PR TITLE
Fix currency passed to payment method

### DIFF
--- a/support-frontend/assets/helpers/page/__tests__/__snapshots__/pageTest.js.snap
+++ b/support-frontend/assets/helpers/page/__tests__/__snapshots__/pageTest.js.snap
@@ -1,12 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`reducer tests should handle SET_COUNTRY to US 1`] = `null`;
+exports[`reducer tests should handle SET_COUNTRY_INTERNATIONALISATION to US 1`] = `null`;
 
-exports[`reducer tests should handle SET_COUNTRY to US 2`] = `"dummy_campaign"`;
+exports[`reducer tests should handle SET_COUNTRY_INTERNATIONALISATION to US 2`] = `"dummy_campaign"`;
 
-exports[`reducer tests should handle SET_COUNTRY to US 3`] = `null`;
+exports[`reducer tests should handle SET_COUNTRY_INTERNATIONALISATION to US 3`] = `null`;
 
-exports[`reducer tests should handle SET_COUNTRY to US 4`] = `Object {}`;
+exports[`reducer tests should handle SET_COUNTRY_INTERNATIONALISATION to US 4`] = `Object {}`;
 
 exports[`reducer tests should return the initial state 1`] = `
 Object {

--- a/support-frontend/assets/helpers/page/__tests__/pageTest.js
+++ b/support-frontend/assets/helpers/page/__tests__/pageTest.js
@@ -50,14 +50,14 @@ describe('reducer tests', () => {
   });
 
   it('should return the initial state', () => {
-    expect(global.reducer(undefined, { type: 'SET_COUNTRY', country: 'GB' })).toMatchSnapshot();
+    expect(global.reducer(undefined, { type: 'SET_COUNTRY_INTERNATIONALISATION', country: 'GB' })).toMatchSnapshot();
   });
 
-  it('should handle SET_COUNTRY to US', () => {
+  it('should handle SET_COUNTRY_INTERNATIONALISATION to US', () => {
 
     const country: IsoCountry = 'US';
     const action = {
-      type: 'SET_COUNTRY',
+      type: 'SET_COUNTRY_INTERNATIONALISATION',
       country,
     };
 

--- a/support-frontend/assets/helpers/page/commonActions.js
+++ b/support-frontend/assets/helpers/page/commonActions.js
@@ -14,7 +14,7 @@ import {
 
 // ----- Types ----- //
 
-export type SetCountryAction = { type: 'SET_COUNTRY', country: IsoCountry };
+export type SetCountryAction = { type: 'SET_COUNTRY_INTERNATIONALISATION', country: IsoCountry };
 
 export type Action =
   | SetCountryAction
@@ -27,7 +27,7 @@ export type Action =
 // ----- Action Creators ----- //
 
 function setCountry(country: IsoCountry): SetCountryAction {
-  return { type: 'SET_COUNTRY', country };
+  return { type: 'SET_COUNTRY_INTERNATIONALISATION', country };
 }
 
 function setExperimentVariant(experiment: OptimizeExperiment): Action {

--- a/support-frontend/assets/helpers/page/commonReducer.js
+++ b/support-frontend/assets/helpers/page/commonReducer.js
@@ -49,7 +49,7 @@ function createCommonReducer(initialState: CommonState): (state?: CommonState, a
 
     switch (action.type) {
 
-      case 'SET_COUNTRY':
+      case 'SET_COUNTRY_INTERNATIONALISATION':
         return {
           ...state,
           internationalisation: {


### PR DESCRIPTION
## Why are you doing this?
This issue is explained in this [**Trello Card**](https://trello.com/c/p8mDfVJT/2542-bug-editing-delivery-address-changes-currency).

In the Guardian Weekly checkout, a user who enters
- a billing country with one currency, and 
- a delivery country with another

Should see a price that is:
- calculated for the cost of delivery to the delivery country, and
- in the currency of the billing country

The customer should be able to use the payment options of the billing country (eg if the billing country is UK, they can use direct debit or a credit/debit card).

There was a problem occurring where a user who entered a billing address that was in the UK and then entered a delivery address that was in Australia, and would experience a payment failure when paying by credit card.

The cause of the issue was the function `buildRegularPaymentRequest` in `submit.js`, which was taking `state.common.internationalisation.currencyId`, which was showing up as 'AUD'. This is because this more general country specifier merely picks up the country most recently specified, whether it was the delivery or billing address. This was causing a payment failure since the billing address meant the user could pay by credit card, but the current being passed in was AUD.

I fixed the problem by making sure that the currency that's passed in is the one relating to the billing address, and falling back to the delivery address if the two addresses are the same.

The card for this work suggests changing the actions for the updating of addresses, believing this to be the cause of the issue. However, this actually isn't the cause of the problem. 

When each type of address is updated, the action contains a property 'scope', which indicates whether the address being updated is a billing address or a delivery address. This sets up the addresses in state as they should be. Given this, I don't plan to refactor this part of the code.

Redux inspector shows that the actions specify which type of address is being updated, which allows us to reuse the address forms for both types of addresses:
![Screen Shot 2019-08-19 at 13 26 17](https://user-images.githubusercontent.com/16781258/63268289-bd14a400-c28b-11e9-8317-511bed94e7a0.png)
![Screen Shot 2019-08-19 at 13 26 44](https://user-images.githubusercontent.com/16781258/63268295-c30a8500-c28b-11e9-97ae-191e239bded0.png)