### PR TITLE
Add an error summary to digital pack checkout

### DIFF
--- a/support-frontend/assets/components/forms/customFields/error.scss
+++ b/support-frontend/assets/components/forms/customFields/error.scss
@@ -15,6 +15,7 @@
 }
 
 .component-form-error__summary-error {
+  margin-top: $gu-v-spacing /2;
   &:first-of-type {
     margin-top: $gu-v-spacing;
   }
@@ -26,7 +27,13 @@
 
 .component-form-error__heading {
   font-size: 1rem;
-  font-family: $gu-text-sans-web;
-  margin-top: $gu-v-spacing * 2;
+  @include gu-fontset-heading;
   font-weight: bold;
+}
+
+.component-form-error__border {
+  border: 1px gu-colour(state-error) solid;
+  padding: $gu-v-spacing;
+  margin-top: $gu-v-spacing;
+  background-color: rgba(199, 0, 0, 0.03);
 }

--- a/support-frontend/assets/components/forms/customFields/error.scss
+++ b/support-frontend/assets/components/forms/customFields/error.scss
@@ -33,7 +33,7 @@
 
 .component-form-error__border {
   border: 1px gu-colour(state-error) solid;
-  padding: $gu-v-spacing;
+  padding: $gu-v-spacing / 2 $gu-v-spacing $gu-h-spacing;
   margin-top: $gu-v-spacing;
   background-color: rgba(199, 0, 0, 0.03);
 }

--- a/support-frontend/assets/components/forms/customFields/error.scss
+++ b/support-frontend/assets/components/forms/customFields/error.scss
@@ -1,16 +1,32 @@
 @import '../formFields';
 
-.component-form-error__error {
+.component-form-error__error, .component-form-error__summary-error {
   @include gu-fontset-explainer;
   color: gu-colour(state-error);
   display: block;
-  margin-top: $gu-v-spacing;
   
   @include mq($from: mobileMedium) {
     width: 80%;
   }
 }
 
+.component-form-error__error {
+  margin-top: $gu-v-spacing;
+}
+
+.component-form-error__summary-error {
+  &:first-of-type {
+    margin-top: $gu-v-spacing;
+  }
+}
+
 .component-form-error .component-input:not([type-radio]) {
   border-color: gu-colour(state-error);
+}
+
+.component-form-error__heading {
+  font-size: 1rem;
+  font-family: $gu-text-sans-web;
+  margin-top: $gu-v-spacing * 2;
+  font-weight: bold;
 }

--- a/support-frontend/assets/components/forms/customFields/error.scss
+++ b/support-frontend/assets/components/forms/customFields/error.scss
@@ -15,7 +15,7 @@
 }
 
 .component-form-error__summary-error {
-  margin-top: $gu-v-spacing /2;
+  margin-top: $gu-v-spacing / 2;
   &:first-of-type {
     margin-top: $gu-v-spacing;
   }

--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.js
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.js
@@ -85,15 +85,15 @@ const setFormErrorsFor = (scope: AddressType) => (errors: Array<FormError<FormFi
 const applyAddressRules = (fields: FormFields): FormError<FormField>[] => validate([
   {
     rule: nonEmptyString(fields.lineOne),
-    error: formError('lineOne', 'Please enter an address'),
+    error: formError('lineOne', 'Please enter an address.'),
   },
   {
     rule: nonEmptyString(fields.city),
-    error: formError('city', 'Please enter a city'),
+    error: formError('city', 'Please enter a city.'),
   },
   {
     rule: isPostcodeOptional(fields.country) || nonEmptyString(fields.postCode),
-    error: formError('postCode', 'Please enter a postcode'),
+    error: formError('postCode', 'Please enter a postcode.'),
   },
   {
     rule: notNull(fields.country),

--- a/support-frontend/assets/components/subscriptionCheckouts/subscriptionSubmitButton.scss
+++ b/support-frontend/assets/components/subscriptionCheckouts/subscriptionSubmitButton.scss
@@ -1,9 +1,5 @@
 @import '~stylesheets/gu-sass/gu-sass';
 
-.component-submit-button {
-    margin-bottom: $gu-v-spacing;
-}
-
 .component-submit-button--margin {
     max-width: gu-span(5);
     margin: $gu-v-spacing/2 $gu-h-spacing/2 $gu-v-spacing * 2;

--- a/support-frontend/assets/components/subscriptionCheckouts/subscriptionSubmitButton.scss
+++ b/support-frontend/assets/components/subscriptionCheckouts/subscriptionSubmitButton.scss
@@ -2,5 +2,5 @@
 
 .component-submit-button--margin {
     max-width: gu-span(5);
-    margin: 0 $gu-h-spacing $gu-v-spacing;
+    margin: 0 $gu-h-spacing / 2 $gu-v-spacing * 2;
 }

--- a/support-frontend/assets/components/subscriptionCheckouts/subscriptionSubmitButton.scss
+++ b/support-frontend/assets/components/subscriptionCheckouts/subscriptionSubmitButton.scss
@@ -1,0 +1,10 @@
+@import '~stylesheets/gu-sass/gu-sass';
+
+.component-submit-button {
+    margin-bottom: $gu-v-spacing;
+}
+
+.component-submit-button--margin {
+    max-width: gu-span(5);
+    margin: $gu-v-spacing/2 $gu-h-spacing/2 $gu-v-spacing * 2;
+}

--- a/support-frontend/assets/components/subscriptionCheckouts/subscriptionSubmitButton.scss
+++ b/support-frontend/assets/components/subscriptionCheckouts/subscriptionSubmitButton.scss
@@ -2,5 +2,5 @@
 
 .component-submit-button--margin {
     max-width: gu-span(5);
-    margin: $gu-v-spacing/2 $gu-h-spacing/2 $gu-v-spacing * 2;
+    margin: 0 $gu-h-spacing $gu-v-spacing;
 }

--- a/support-frontend/assets/components/subscriptionCheckouts/subscriptionSubmitButtons.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/subscriptionSubmitButtons.jsx
@@ -16,6 +16,7 @@ import type { PaymentMethod } from 'helpers/paymentMethods';
 import { PayPal } from 'helpers/paymentMethods';
 import { type FormError } from 'helpers/subscriptionsForms/validation';
 import { type FormField } from 'helpers/subscriptionsForms/formFields';
+import Heading from 'components/heading/heading';
 
 import 'components/forms/customFields/error.scss';
 import './subscriptionSubmitButton.scss';
@@ -43,12 +44,14 @@ type ErrorSummaryPropTypes = {
 
 const ErrorSummary = (props: ErrorSummaryPropTypes) => (
   <div className="component-form-error__border">
-    <p className="component-form-error__heading">There is a problem</p>
-    {props.errors.map(error => (
-      <div className="component-form-error__summary-error">
-        {error.message}
-      </div>
-    ))}
+    <Heading className="component-form-error__heading" size={2}>There is a problem</Heading>
+    <ul>
+      {props.errors.map(error => (
+        <li className="component-form-error__summary-error">
+          {error.message}
+        </li>
+      ))}
+    </ul>
   </div>
 
 );

--- a/support-frontend/assets/components/subscriptionCheckouts/subscriptionSubmitButtons.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/subscriptionSubmitButtons.jsx
@@ -18,6 +18,7 @@ import { type FormError } from 'helpers/subscriptionsForms/validation';
 import { type FormField } from 'helpers/subscriptionsForms/formFields';
 
 import 'components/forms/customFields/error.scss';
+import './subscriptionSubmitButton.scss';
 
 // ----- Types ----- //
 
@@ -41,7 +42,7 @@ type ErrorSummaryPropTypes = {
 }
 
 const ErrorSummary = (props: ErrorSummaryPropTypes) => (
-  <div>
+  <div className="component-form-error__border">
     <p className="component-form-error__heading">There is a problem</p>
     {props.errors.map(error => (
       <div className="component-form-error__summary-error">
@@ -60,33 +61,35 @@ function SubscriptionSubmitButtons(props: PropTypes) {
   // because we don't want to destroy and replace the iframe each time.
   // See PayPalExpressButton for more info.
   return (
-    <div>
-      <div
-        id="component-paypal-button-checkout"
-        className={hiddenIf(props.paymentMethod !== PayPal, 'component-paypal-button-checkout')}
-      >
-        <PayPalExpressButton
-          onPaymentAuthorisation={props.onPaymentAuthorised}
-          csrf={props.csrf}
-          currencyId={props.currencyId}
-          hasLoaded={props.payPalHasLoaded}
-          canOpen={props.formIsValid}
-          onClick={props.validateForm}
-          formClassName="form--contribution"
-          isTestUser={props.isTestUser}
-          setupRecurringPayPalPayment={props.setupRecurringPayPalPayment}
-          amount={props.amount}
-          billingPeriod={props.billingPeriod}
-        />
+    <div className="component-submit-button">
+      <div className="component-submit-button--margin">
+        <div
+          id="component-paypal-button-checkout"
+          className={hiddenIf(props.paymentMethod !== PayPal, 'component-paypal-button-checkout')}
+        >
+          <PayPalExpressButton
+            onPaymentAuthorisation={props.onPaymentAuthorised}
+            csrf={props.csrf}
+            currencyId={props.currencyId}
+            hasLoaded={props.payPalHasLoaded}
+            canOpen={props.formIsValid}
+            onClick={props.validateForm}
+            formClassName="form--contribution"
+            isTestUser={props.isTestUser}
+            setupRecurringPayPalPayment={props.setupRecurringPayPalPayment}
+            amount={props.amount}
+            billingPeriod={props.billingPeriod}
+          />
+        </div>
+        <Button
+          id="qa-submit-button"
+          type="submit"
+          modifierClasses={props.paymentMethod === PayPal ? ['hidden'] : []}
+        >
+          Continue to payment
+        </Button>
       </div>
-      <Button
-        id="qa-submit-button"
-        type="submit"
-        modifierClasses={props.paymentMethod === PayPal ? ['hidden'] : []}
-      >
-        Continue to payment
-      </Button>
-      {props.allErrors.length > 0 && <ErrorSummary errors={props.allErrors} />}
+      <span>{props.allErrors.length > 0 && <ErrorSummary errors={props.allErrors} />}</span>
     </div>
   );
 }

--- a/support-frontend/assets/components/subscriptionCheckouts/subscriptionSubmitButtons.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/subscriptionSubmitButtons.jsx
@@ -14,6 +14,10 @@ import Button from 'components/button/button';
 import { type Option } from 'helpers/types/option';
 import type { PaymentMethod } from 'helpers/paymentMethods';
 import { PayPal } from 'helpers/paymentMethods';
+import { type FormError } from 'helpers/subscriptionsForms/validation';
+import { type FormField } from 'helpers/subscriptionsForms/formFields';
+
+import 'components/forms/customFields/error.scss';
 
 // ----- Types ----- //
 
@@ -29,8 +33,24 @@ type PropTypes = {|
   billingPeriod: BillingPeriod,
   validateForm: Function,
   formIsValid: Function,
+  allErrors: FormError<FormField>[],
 |};
 
+type ErrorSummaryPropTypes = {
+  errors: Array<Object>,
+}
+
+const ErrorSummary = (props: ErrorSummaryPropTypes) => (
+  <div>
+    <p className="component-form-error__heading">There is a problem</p>
+    {props.errors.map(error => (
+      <div className="component-form-error__summary-error">
+        {error.message}
+      </div>
+    ))}
+  </div>
+
+);
 
 // ----- Render ----- //
 
@@ -66,6 +86,7 @@ function SubscriptionSubmitButtons(props: PropTypes) {
       >
         Continue to payment
       </Button>
+      {props.allErrors.length > 0 && <ErrorSummary errors={props.allErrors} />}
     </div>
   );
 }

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -200,22 +200,20 @@ function CheckoutForm(props: PropTypes) {
             validationError={firstError('paymentMethod', props.formErrors)}
             submissionError={props.submissionError}
           />
-          <FormSection noBorder>
-            <SubscriptionSubmitButtons
-              paymentMethod={props.paymentMethod}
-              onPaymentAuthorised={props.onPaymentAuthorised}
-              csrf={props.csrf}
-              currencyId={props.currencyId}
-              payPalHasLoaded={props.payPalHasLoaded}
-              formIsValid={props.formIsValid}
-              validateForm={props.validateForm}
-              isTestUser={props.isTestUser}
-              setupRecurringPayPalPayment={props.setupRecurringPayPalPayment}
-              amount={props.amount}
-              billingPeriod={props.billingPeriod}
-              allErrors={[...props.billingErrors, ...props.formErrors]}
-            />
-          </FormSection>
+          <SubscriptionSubmitButtons
+            paymentMethod={props.paymentMethod}
+            onPaymentAuthorised={props.onPaymentAuthorised}
+            csrf={props.csrf}
+            currencyId={props.currencyId}
+            payPalHasLoaded={props.payPalHasLoaded}
+            formIsValid={props.formIsValid}
+            validateForm={props.validateForm}
+            isTestUser={props.isTestUser}
+            setupRecurringPayPalPayment={props.setupRecurringPayPalPayment}
+            amount={props.amount}
+            billingPeriod={props.billingPeriod}
+            allErrors={[...props.billingErrors, ...props.formErrors]}
+          />
           <CancellationSection />
         </Form>
       </CheckoutLayout>

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -81,6 +81,7 @@ type PropTypes = {|
   validateForm: () => Function,
   formIsValid: Function,
   optimizeExperiments: OptimizeExperiments,
+  billingErrors: Array<Object>,
 |};
 
 
@@ -105,6 +106,7 @@ function mapStateToProps(state: CheckoutState) {
     ).price,
     billingPeriod: state.page.checkout.billingPeriod,
     optimizeExperiments: state.common.optimizeExperiments,
+    billingErrors: state.page.billingAddress.fields.formErrors,
   };
 }
 
@@ -211,6 +213,7 @@ function CheckoutForm(props: PropTypes) {
               setupRecurringPayPalPayment={props.setupRecurringPayPalPayment}
               amount={props.amount}
               billingPeriod={props.billingPeriod}
+              allErrors={[...props.billingErrors, ...props.formErrors]}
             />
           </FormSection>
           <CancellationSection />

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/checkoutForm.jsx
@@ -81,7 +81,7 @@ type PropTypes = {|
   validateForm: () => Function,
   formIsValid: Function,
   optimizeExperiments: OptimizeExperiments,
-  billingErrors: Array<Object>,
+  addressErrors: Array<Object>,
 |};
 
 
@@ -106,7 +106,7 @@ function mapStateToProps(state: CheckoutState) {
     ).price,
     billingPeriod: state.page.checkout.billingPeriod,
     optimizeExperiments: state.common.optimizeExperiments,
-    billingErrors: state.page.billingAddress.fields.formErrors,
+    addressErrors: state.page.billingAddress.fields.formErrors,
   };
 }
 
@@ -212,7 +212,7 @@ function CheckoutForm(props: PropTypes) {
             setupRecurringPayPalPayment={props.setupRecurringPayPalPayment}
             amount={props.amount}
             billingPeriod={props.billingPeriod}
-            allErrors={[...props.billingErrors, ...props.formErrors]}
+            allErrors={[...props.addressErrors, ...props.formErrors]}
           />
           <CancellationSection />
         </Form>


### PR DESCRIPTION
## Why are you doing this?
To improve clarity for checkout users, who may wonder why nothing happens when they click the 'Continue to payment' button. More information in this [**Trello Card**](https://trello.com/c/NyB2MIQ0/2498-error-summary-for-checkout-errors)

Instead of the button flashing orange and the page otherwise staying the same, now a summary of the invalid fields appears:

There is [a design for this in Zeplin](https://app.zeplin.io/project/5c3c9a2881e8042985ba9cbe/screen/5d5c097d4d1a189b7e86e8b8).

### Screenshot of completed work (DP checkout only)
![Screen Shot 2019-08-21 at 12 41 34](https://user-images.githubusercontent.com/16781258/63429108-135f1f80-c411-11e9-98ad-29fe89e6385b.png)