### PR TITLE
Radio button and form legend accessibility updates

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.scss
@@ -522,7 +522,7 @@ form {
 }
 
 .form__legend--radio-group {
-  display: none;
+  @include accessibility-hint;
 }
 
 .form__radio-group-list {
@@ -533,7 +533,8 @@ form {
 }
 
 .form__radio-group-input {
-  display: none;
+  position: absolute;
+  opacity: 0;
 }
 
 .form__radio-group-label {
@@ -546,6 +547,7 @@ form {
 }
 
 .form__radio-group--tabs .form__radio-group-item {
+  position: relative;
   flex: 1;
 }
 

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.scss
@@ -522,7 +522,7 @@ form {
 }
 
 .form__legend--radio-group {
-  @include accessibility-hint;
+  display: none;
 }
 
 .form__radio-group-list {
@@ -533,8 +533,7 @@ form {
 }
 
 .form__radio-group-input {
-  position: absolute;
-  opacity: 0;
+  display: none;
 }
 
 .form__radio-group-label {
@@ -547,7 +546,6 @@ form {
 }
 
 .form__radio-group--tabs .form__radio-group-item {
-  position: relative;
   flex: 1;
 }
 

--- a/support-frontend/assets/stylesheets/gu-sass/helpers.scss
+++ b/support-frontend/assets/stylesheets/gu-sass/helpers.scss
@@ -89,12 +89,10 @@
 
 // ----- Assistive technologies guidance (non-visible) ----- //
 @mixin accessibility-hint {
-  border: 0;
-	clip: rect(0 0 0 0);
-	height: 1px;
-	margin: -1px !important;
-	overflow: hidden;
-	padding: 0;
-	position: absolute !important;
-	width: 1px;
+  position: absolute;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
 }

--- a/support-frontend/assets/stylesheets/gu-sass/helpers.scss
+++ b/support-frontend/assets/stylesheets/gu-sass/helpers.scss
@@ -89,10 +89,12 @@
 
 // ----- Assistive technologies guidance (non-visible) ----- //
 @mixin accessibility-hint {
-  position: absolute;
-  left: -10000px;
-  top: auto;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
+  border: 0;
+	clip: rect(0 0 0 0);
+	height: 1px;
+	margin: -1px !important;
+	overflow: hidden;
+	padding: 0;
+	position: absolute !important;
+	width: 1px;
 }


### PR DESCRIPTION
## Why are you doing this?

Keyboard only and screen reader users we're unable to:

- Select/change the custom styled radio buttons
- Read the form group legends (Screen reader) 

Semi related to this but not really: [**Trello Card**](https://trello.com/c/XcLbdC4p/1295-implement-the-choice-architecture-r2-flip-order#comment-5d5d520b6184f08ae92a33ef)

## Changes

* Update custom radio buttons to `position: absolute, opacity: 0` 
* Added accessibility hint to form legend to ensure they remain visible hidden yet accessible by assistive technology
* I also updated the accessibility hint css to reflect a more modern approach which doesn't involve positioning DOM objects (REALLY) far outside the viewport. 
