### PR TITLE
Support page: show Patrons and MC links for the UK only

### DIFF
--- a/support-frontend/assets/pages/showcase/showcase.jsx
+++ b/support-frontend/assets/pages/showcase/showcase.jsx
@@ -69,7 +69,7 @@ const content = (
       </Content>
       <CtaSubscribe />
       <CtaContribute />
-      <OtherProducts />
+      {countryGroupId === 'GBPCountries' && <OtherProducts />}
       <ConsentBanner />
     </Page>
   </Provider>


### PR DESCRIPTION
## Why are you doing this?
On the why support page, the Masterclass and events and Patrons links are not available or customised to non-UK audiences. Given this, they should not be shown to users outside the UK.

The change in this pull requests means that the 'Other ways to support us' is only shown to users in the UK.

[**Trello Card**](https://trello.com/c/Zp5O37FG/2558-remove-events-mc-links-in-why-support-page-for-us-and-australia-page)

## Screenshot - UK
![Screen Shot 2019-08-21 at 17 06 35](https://user-images.githubusercontent.com/16781258/63448585-220bfd80-c436-11e9-8ccf-d34e7715ea3a.png)

## Screenshot - ROW
![Screen Shot 2019-08-21 at 17 06 59](https://user-images.githubusercontent.com/16781258/63448603-2b956580-c436-11e9-89c1-77f7ad891877.png)