### PR TITLE
Bump jackson version

### DIFF
--- a/project/LibraryVersions.scala
+++ b/project/LibraryVersions.scala
@@ -3,6 +3,7 @@ object LibraryVersions {
   val circeVersion = "0.11.1"
   val awsClientVersion = "1.11.226"
   val catsVersion = "1.4.0"
-  val jacksonVersion = "2.9.8"
+  val jacksonDatabindVersion = "2.9.9.3"
+  val jacksonVersion = "2.9.9"
   val okhttpVersion = "3.10.0"
 }

--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -8,7 +8,7 @@ testOptions in SeleniumTest := Seq(Tests.Filter(seleniumTestFilter))
 
 testOptions in Test := Seq(Tests.Filter(unitTestFilter))
 
-import LibraryVersions.{circeVersion, awsClientVersion, jacksonVersion}
+import LibraryVersions.{circeVersion, awsClientVersion, jacksonDatabindVersion, jacksonVersion}
 
 resolvers += "Guardian Platform Bintray" at "https://dl.bintray.com/guardian/platforms"
 
@@ -44,7 +44,7 @@ libraryDependencies ++= Seq(
   "com.gu" %% "tip" % "0.6.1",
   "com.googlecode.libphonenumber" % "libphonenumber" % "8.10.4",
   // This is required to force aws libraries to use the latest version of jackson
-  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
+  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion,
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
   filters,
   ws

--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -44,6 +44,7 @@ libraryDependencies ++= Seq(
   "com.gu" %% "tip" % "0.6.1",
   "com.googlecode.libphonenumber" % "libphonenumber" % "8.10.4",
   // This is required to force aws libraries to use the latest version of jackson
+  // jackson-databind versioning is out of sync with other jackson libraries
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion,
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
   filters,

--- a/support-workers/build.sbt
+++ b/support-workers/build.sbt
@@ -25,6 +25,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-stepfunctions" % awsClientVersion,
   // This is required to force aws libraries to use the latest version of jackson
+  // jackson-databind versioning is out of sync with other jackson libraries
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion,
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,

--- a/support-workers/build.sbt
+++ b/support-workers/build.sbt
@@ -25,7 +25,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-stepfunctions" % awsClientVersion,
   // This is required to force aws libraries to use the latest version of jackson
-  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
+  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion,
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
   "org.mockito" % "mockito-core" % "1.9.5" % "it,test",


### PR DESCRIPTION
## Why are you doing this?
https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-450917
Extra security patches mean that jackson-databind versioning is out of sync with other jackson libraries
