### PR TITLE
Bump Play to 2.6.23

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.16")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.23")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
 

--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -32,7 +32,7 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-generic-extras" % circeVersion,
   "io.circe" %% "circe-parser" % circeVersion,
   "joda-time" % "joda-time" % "2.9.9",
-  "com.gu.identity" %% "identity-auth-play" % "3.184-M7",
+  "com.gu.identity" %% "identity-auth-play" % "3.184",
   "com.gu" %% "identity-test-users" % "0.6",
   "com.google.guava" % "guava" % "25.0-jre",
   "com.netaporter" %% "scala-uri" % "0.4.16",


### PR DESCRIPTION
The latest Play 2.6.*

The current version triggers a snyk error relating to an older version of akka:
https://app.snyk.io/vuln/SNYK-JAVA-COMTYPESAFEAKKA-451679

The latest `identity-auth-play` also brings in the newer version of play