### PR TITLE
Update contributions copy on showcase page

### DIFF
--- a/support-frontend/assets/pages/showcase/components/ctaContribute.jsx
+++ b/support-frontend/assets/pages/showcase/components/ctaContribute.jsx
@@ -29,12 +29,11 @@ export default function CtaContribute() {
             <p>
               The Guardian{'\''}s open, independent journalism has now been supported by
               over a million people around the world – but we must keep building
-              on this for the years to come. Every contribution, whether big or
-              small, means we can keep investigating and exploring the critical
-              issues of our time.&nbsp;
+              on this for the years to come.&nbsp;
               <strong>
-                Make a contribution from as little as
-                £1, and it only takes a minute.
+                Every contribution, whether big or
+                small, means we can keep investigating and exploring the critical
+                issues of our time. And it only takes a minute.
               </strong>
             </p>
           </Text>


### PR DESCRIPTION
## Why are you doing this?
Small copy change on the showcase page

[**Trello Card**](https://trello.com/c/g78eAUPC/1371-update-the-contribution-text-on-the-why-support-page-to-put-the-right-currency-instead-of-everywhere)

Before:
![Screenshot 2019-08-23 at 16 09 45](https://user-images.githubusercontent.com/1513454/63602924-74792580-c5c0-11e9-9114-f32b2624fafb.png)


After:
![Screenshot 2019-08-23 at 16 08 51](https://user-images.githubusercontent.com/1513454/63602893-64614600-c5c0-11e9-9ed2-a35237492440.png)
