### PR TITLE
Fix amounts override logic

### DIFF
--- a/support-frontend/assets/helpers/page/page.js
+++ b/support-frontend/assets/helpers/page/page.js
@@ -99,7 +99,9 @@ function buildInitialState(
   };
 
   // Override the default amounts config with any test participations
-  const amountsWithParticipationOverrides = overrideAmountsForParticipations(abParticipations, settings.amounts);
+  const amountsWithParticipationOverrides = settings.amounts ?
+    overrideAmountsForParticipations(abParticipations, settings.amounts) : settings.amounts;
+
   const trackingConsent = getTrackingConsent();
 
   return {


### PR DESCRIPTION
## Why are you doing this?
The build-time rendering is currently broken (since https://github.com/guardian/support-frontend/pull/2025 was merged). This is because the `overrideAmountsForParticipations` function is being passed an `AmountsRegions` with `undefined` value.
This PR just avoids calling the function if it's undefined.

Follow-up tasks:
1. Make the build fail if build-time rendering fails! Currently it's very easy to miss.
2. I noticed that several pages on the site receive settings that are only required for the contributions landing page (e.g. amounts settings). Only the contributions controller should pass these settings into the `main.scala.html` template.
3. Consider whether we can avoid calling `init` in `page.js` for build-time rendering, as this is where it's trying to setup this state. For the contributions page we have a special `EmptyContributionsLanding` component specifically to avoid this happening.

