### PR TITLE
Fail build if any of the build script commands fails

### DIFF
--- a/support-frontend/build-tc
+++ b/support-frontend/build-tc
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Exit if any of these commands fail
+set -e
+
 # Installing yarn
 YARN_VERSION="1.12.3"
 YARN_LOCATION="tools/${YARN_VERSION}"


### PR DESCRIPTION
## Why are you doing this?
Currently if we break build-time rendering then it logs the error but the build goes ahead regardless. This means we don't actually notice.

Now, if the `yarn run build-ssr` command fails then the entire script fails:
![Screenshot 2019-08-27 at 11 23 45](https://user-images.githubusercontent.com/1513454/63763746-3d0ac180-c8bd-11e9-9b92-349d359d2f8d.png)

Separate PR [here](https://github.com/guardian/support-frontend/pull/2050) to actually fix `build-ssr`