### PR TITLE
Bump akka-agent version

### DIFF
--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -26,7 +26,7 @@ libraryDependencies ++= Seq(
   "org.typelevel" %% "cats-core" % "1.0.1",
   "com.dripower" %% "play-circe" % "2609.1",
   "com.gu" %% "fezziwig" % "1.2",
-  "com.typesafe.akka" %% "akka-agent" % "2.5.14",
+  "com.typesafe.akka" %% "akka-agent" % "2.5.21",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-generic-extras" % circeVersion,


### PR DESCRIPTION
## Why are you doing this?
A recent Play update has caused warnings in the logs because now the akka-agent dependency is behind:
`Detected possible incompatible versions on the classpath. Please note that a given Akka version MUST be the same across all modules of Akka that you are using`

Also, akka-agent is deprecated but can be replaced by https://github.com/guardian/box, but I'm not doing this now

