### PR TITLE
SCA: support stripe PaymentMethod field

### DIFF
--- a/support-frontend/app/monitoring/Tip.scala
+++ b/support-frontend/app/monitoring/Tip.scala
@@ -73,7 +73,7 @@ object PathVerification {
   def monitoredPaymentMethod(paymentFields: PaymentFields): MonitoredPaymentMethod = paymentFields match {
     case DirectDebitPaymentFields(_, _, _) => DirectDebit
     case PayPalPaymentFields(_) => PayPal
-    case StripePaymentFields(_) => Card
+    case _: StripePaymentFields => Card
     case ExistingPaymentFields(_) => ExistingPaymentMethod
   }
 

--- a/support-frontend/app/utils/CheckoutValidationRules.scala
+++ b/support-frontend/app/utils/CheckoutValidationRules.scala
@@ -29,7 +29,8 @@ object SimpleCheckoutFormValidation {
   private def noEmptyPaymentFields(paymentFields: PaymentFields): Boolean = paymentFields match {
     case directDebitDetails: DirectDebitPaymentFields =>
       !directDebitDetails.accountHolderName.isEmpty && !directDebitDetails.accountNumber.isEmpty && !directDebitDetails.sortCode.isEmpty
-    case stripeDetails: StripePaymentFields => !stripeDetails.stripeToken.isEmpty
+    case stripeDetails: StripePaymentMethodPaymentFields => !stripeDetails.paymentMethod.isEmpty
+    case stripeDetails: StripeSourcePaymentFields => !stripeDetails.stripeToken.isEmpty
     case payPalDetails: PayPalPaymentFields => !payPalDetails.baid.isEmpty
     case existingDetails: ExistingPaymentFields => !existingDetails.billingAccountId.isEmpty
   }

--- a/support-frontend/test/utils/CheckoutValidationRulesTest.scala
+++ b/support-frontend/test/utils/CheckoutValidationRulesTest.scala
@@ -99,8 +99,13 @@ class DigitalPackValidationTest extends FlatSpec with Matchers {
     DigitalPackValidation.passes(requestMissingPostcode) shouldBe true
   }
 
-  it should "fail if the payment field received is an empty string" in {
-    val requestMissingState = validDigitalPackRequest.copy(paymentFields = StripePaymentFields(""))
+  it should "fail if the payment method payment field received is an empty string" in {
+    val requestMissingState = validDigitalPackRequest.copy(paymentFields = StripePaymentMethodPaymentFields(""))
+    DigitalPackValidation.passes(requestMissingState) shouldBe false
+  }
+
+  it should "fail if the source payment field received is an empty string" in {
+    val requestMissingState = validDigitalPackRequest.copy(paymentFields = StripeSourcePaymentFields(""))
     DigitalPackValidation.passes(requestMissingState) shouldBe false
   }
 
@@ -182,7 +187,7 @@ object TestData {
     lastName = "hopper",
     product = DigitalPack(Currency.USD, Monthly),
     firstDeliveryDate = None,
-    paymentFields = StripePaymentFields("test-token"),
+    paymentFields = StripePaymentMethodPaymentFields("test-token"),
     ophanIds = OphanIds(None, None, None),
     referrerAcquisitionData = ReferrerAcquisitionData(None, None, None, None, None, None, None, None, None, None, None, None),
     supportAbTests = Set(),
@@ -219,7 +224,7 @@ object TestData {
     lastName = "hopper",
     product = Paper(Currency.GBP, Monthly, HomeDelivery, Everyday),
     firstDeliveryDate = Some(someDateNextMonth),
-    paymentFields = StripePaymentFields("test-token"),
+    paymentFields = StripePaymentMethodPaymentFields("test-token"),
     ophanIds = OphanIds(None, None, None),
     referrerAcquisitionData = ReferrerAcquisitionData(None, None, None, None, None, None, None, None, None, None, None, None),
     supportAbTests = Set(),

--- a/support-workers/src/main/scala/com/gu/stripe/StripeService.scala
+++ b/support-workers/src/main/scala/com/gu/stripe/StripeService.scala
@@ -14,9 +14,12 @@ class StripeService(val config: StripeConfig, client: FutureHttpClient, baseUrl:
   // Stripe URL is the same in all environments
   val wsUrl = baseUrl
   val httpClient: FutureHttpClient = client
+
+  def withCurrency(currency: Currency): StripeServiceForCurrency = new StripeServiceForCurrency(this, currency)
+
 }
 
-case class StripeServiceForCurrency(stripeService: StripeService, currency: Currency) {
+class StripeServiceForCurrency(stripeService: StripeService, currency: Currency) {
   import stripeService._
 
   def createCustomerFromToken(token: String): Future[Customer] =

--- a/support-workers/src/main/scala/com/gu/stripe/StripeService.scala
+++ b/support-workers/src/main/scala/com/gu/stripe/StripeService.scala
@@ -5,49 +5,36 @@ import com.gu.i18n.Currency
 import com.gu.okhttp.RequestRunners._
 import com.gu.stripe.Stripe._
 import com.gu.support.config.StripeConfig
-import io.circe.Decoder
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.reflect.ClassTag
 
-class StripeService(config: StripeConfig, client: FutureHttpClient, baseUrl: String = "https://api.stripe.com/v1")(implicit ec: ExecutionContext)
+class StripeService(val config: StripeConfig, client: FutureHttpClient, baseUrl: String = "https://api.stripe.com/v1")(implicit ec: ExecutionContext)
     extends WebServiceHelper[Stripe.StripeError] {
 
   // Stripe URL is the same in all environments
   val wsUrl = baseUrl
   val httpClient: FutureHttpClient = client
-
-  def withCurrency(currency: Currency): WithCurrency = new WithCurrency(currency)
-  class WithCurrency(currency: Currency) {
-
-    def post[A](
-      endpoint: String,
-      data: Map[String, Seq[String]]
-    )(implicit decoder: Decoder[A], errorDecoder: Decoder[StripeError], ctag: ClassTag[A]): Future[A] =
-      StripeService.super.postForm[A](endpoint, data, getHeaders())
-
-    private def getHeaders() =
-      config.version.foldLeft(getAuthorizationHeader()) {
-        case (map, version) => map + ("Stripe-Version" -> version)
-      }
-
-    private def getAuthorizationHeader() =
-      Map("Authorization" -> s"Bearer ${config.forCurrency(Some(currency)).secretKey}")
-
-  }
 }
 
-object CreateCustomer {
-  // https://stripe.com/docs/api/customers/create
+case class StripeServiceForCurrency(stripeService: StripeService, currency: Currency) {
+  import stripeService._
 
-  def fromSource(token: String): StripeService#WithCurrency => Future[Customer] =
-    _.post[Customer]("customers", Map(
+  def createCustomerFromToken(token: String): Future[Customer] =
+    postForm[Customer]("customers", Map(
       "source" -> Seq(token)
-    ))
+    ), getHeaders())
 
-  def fromPaymentMethod(token: String): StripeService#WithCurrency => Future[Customer] =
-    _.post[Customer]("customers", Map(
-      "payment_method" -> Seq(token)
-    ))
+  def createCustomerFromPaymentMethod(paymentMethod: String): Future[Customer] =
+    postForm[Customer]("customers", Map(
+      "payment_method" -> Seq(paymentMethod)
+    ), getHeaders())
+
+  private def getHeaders() =
+    config.version.foldLeft(getAuthorizationHeader()) {
+      case (map, version) => map + ("Stripe-Version" -> version)
+    }
+
+  private def getAuthorizationHeader() =
+    Map("Authorization" -> s"Bearer ${config.forCurrency(Some(currency)).secretKey}")
 
 }

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -37,7 +37,7 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
   ) =
     state.paymentFields match {
       case stripe: StripePaymentFields =>
-        createStripePaymentMethod(stripe, StripeServiceForCurrency(services.stripeService, state.product.currency))
+        createStripePaymentMethod(stripe, services.stripeService.withCurrency(state.product.currency))
       case paypal: PayPalPaymentFields =>
         createPayPalPaymentMethod(paypal, services.payPalService)
       case dd: DirectDebitPaymentFields =>

--- a/support-workers/src/test/scala/com/gu/support/workers/AddressLineTransformerTest.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/AddressLineTransformerTest.scala
@@ -20,8 +20,6 @@ class AddressLineTransformerTest extends FlatSpec with Matchers with MockitoSuga
     accountNumber = "55779911"
   )
 
-  val stripePaymentFields = StripePaymentFields("test-token")
-
   "combinedAddressLine" should "return an AddressLine when there is only a lineOne" in {
 
     val lineOne = Some("123 trash alley")

--- a/support-workers/src/test/scala/com/gu/support/workers/EndToEndSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/EndToEndSpec.scala
@@ -6,7 +6,7 @@ import com.gu.i18n.Currency
 import com.gu.i18n.Currency.{EUR, GBP}
 import com.gu.monitoring.SafeLogger
 import com.gu.support.encoding.CustomCodecs._
-import com.gu.support.workers.JsonFixtures.{createStripePaymentMethodContributionJson, wrapFixture}
+import com.gu.support.workers.JsonFixtures.{createStripeSourcePaymentMethodContributionJson, wrapFixture}
 import com.gu.support.workers.lambdas._
 import com.gu.test.tags.annotations.IntegrationTest
 import io.circe.generic.auto._
@@ -22,7 +22,7 @@ class EndToEndSpec extends LambdaSpec {
   they should "work with other currencies" in runSignupWithCurrency(EUR)
 
   def runSignupWithCurrency(currency: Currency) {
-    val json = createStripePaymentMethodContributionJson(currency = currency)
+    val json = createStripeSourcePaymentMethodContributionJson(currency = currency)
     SafeLogger.info(json)
     val output = wrapFixture(json)
       .chain(new CreatePaymentMethod())

--- a/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
@@ -171,11 +171,18 @@ object JsonFixtures {
     """
 
   val stripeToken = "tok_visa"
+  val stripePaymentMethodToken = "tok_visa"
   val stripeJson =
     s"""
       {
-        "userId": "12345",
         "stripeToken": "$stripeToken"
+      }
+    """
+
+  val stripePaymentMethodJson =
+    s"""
+      {
+        "paymentMethod": "$stripePaymentMethodToken"
       }
     """
 
@@ -188,12 +195,22 @@ object JsonFixtures {
           "acquisitionData": $acquisitionData
         }"""
 
-  def createStripePaymentMethodContributionJson(billingPeriod: BillingPeriod = Monthly, amount: BigDecimal = 5, currency: Currency = GBP): String =
+  def createStripeSourcePaymentMethodContributionJson(billingPeriod: BillingPeriod = Monthly, amount: BigDecimal = 5, currency: Currency = GBP): String =
     s"""{
           $requestIdJson,
           ${userJson()},
           "product": ${contribution(amount = amount, billingPeriod = billingPeriod, currency = currency)},
           "paymentFields": $stripeJson,
+          "sessionId": "testingToken",
+          "acquisitionData": $acquisitionData
+        }"""
+
+  def createStripePaymentMethodPaymentMethodContributionJson(billingPeriod: BillingPeriod = Monthly, amount: BigDecimal = 5, currency: Currency = GBP): String =
+    s"""{
+          $requestIdJson,
+          ${userJson()},
+          "product": ${contribution(amount = amount, billingPeriod = billingPeriod, currency = currency)},
+          "paymentFields": $stripePaymentMethodJson,
           "sessionId": "testingToken",
           "acquisitionData": $acquisitionData
         }"""

--- a/support-workers/src/test/scala/com/gu/support/workers/errors/StripeErrorsSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/errors/StripeErrorsSpec.scala
@@ -9,7 +9,7 @@ import com.gu.stripe.Stripe.StripeError
 import com.gu.stripe.{Stripe, StripeService}
 import com.gu.support.encoding.CustomCodecs._
 import com.gu.support.encoding.ErrorJson
-import com.gu.support.workers.JsonFixtures.{createStripePaymentMethodContributionJson, wrapFixture}
+import com.gu.support.workers.JsonFixtures.{createStripeSourcePaymentMethodContributionJson, wrapFixture}
 import com.gu.support.workers.exceptions.{RetryNone, RetryUnlimited}
 import com.gu.support.workers.lambdas.CreatePaymentMethod
 import com.gu.support.workers.{JsonFixtures, JsonWrapper, LambdaSpec}
@@ -27,7 +27,7 @@ class StripeErrorsSpec extends LambdaSpec with MockWebServerCreator with MockSer
     val outStream = new ByteArrayOutputStream()
 
     a[RetryUnlimited] should be thrownBy {
-      createPaymentMethod.handleRequest(wrapFixture(createStripePaymentMethodContributionJson()), outStream, context)
+      createPaymentMethod.handleRequest(wrapFixture(createStripeSourcePaymentMethodContributionJson()), outStream, context)
     }
   }
 
@@ -41,7 +41,7 @@ class StripeErrorsSpec extends LambdaSpec with MockWebServerCreator with MockSer
     val outStream = new ByteArrayOutputStream()
 
     a[RetryUnlimited] should be thrownBy {
-      createPaymentMethod.handleRequest(wrapFixture(createStripePaymentMethodContributionJson()), outStream, context)
+      createPaymentMethod.handleRequest(wrapFixture(createStripeSourcePaymentMethodContributionJson()), outStream, context)
     }
 
     // Shut down the server. Instances cannot be reused.
@@ -60,7 +60,7 @@ class StripeErrorsSpec extends LambdaSpec with MockWebServerCreator with MockSer
     val outStream = new ByteArrayOutputStream()
 
     a[RetryNone] should be thrownBy {
-      createPaymentMethod.handleRequest(wrapFixture(createStripePaymentMethodContributionJson()), outStream, context)
+      createPaymentMethod.handleRequest(wrapFixture(createStripeSourcePaymentMethodContributionJson()), outStream, context)
     }
 
     server.shutdown()

--- a/support-workers/src/test/scala/com/gu/support/workers/lambdas/CreatePaymentMethodSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/lambdas/CreatePaymentMethodSpec.scala
@@ -8,8 +8,8 @@ import com.gu.i18n.Currency
 import com.gu.i18n.Currency.GBP
 import com.gu.okhttp.RequestRunners.configurableFutureRunner
 import com.gu.services.{ServiceProvider, Services}
-import com.gu.stripe.Stripe.{StripeError, StripeList}
-import com.gu.stripe.{Stripe, StripeService}
+import com.gu.stripe.Stripe.{Customer, StripeError, StripeList}
+import com.gu.stripe.{CreateCustomer, Stripe, StripeService}
 import com.gu.support.encoding.CustomCodecs._
 import com.gu.support.workers.JsonFixtures.{validBaid, _}
 import com.gu.support.workers._
@@ -18,12 +18,14 @@ import com.gu.support.workers.encoding.Encoding
 import com.gu.support.workers.exceptions.RetryNone
 import com.gu.support.workers.states.CreateSalesforceContactState
 import com.gu.test.tags.objects.IntegrationTest
+import io.circe.Decoder
 import io.circe.generic.auto._
 import org.mockito.Matchers._
 import org.mockito.Mockito._
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import scala.reflect.ClassTag
 
 class CreatePaymentMethodSpec extends AsyncLambdaSpec with MockContext {
 
@@ -52,7 +54,7 @@ class CreatePaymentMethodSpec extends AsyncLambdaSpec with MockContext {
 
     val outStream = new ByteArrayOutputStream()
 
-    createPaymentMethod.handleRequest(wrapFixture(createStripePaymentMethodContributionJson()), outStream, context)
+    createPaymentMethod.handleRequest(wrapFixture(createStripeSourcePaymentMethodContributionJson()), outStream, context)
 
     //Check the output
     val createSalesforceContactState = Encoding.in[CreateSalesforceContactState](outStream.toInputStream)
@@ -82,7 +84,7 @@ class CreatePaymentMethodSpec extends AsyncLambdaSpec with MockContext {
   "StripeService" should "throw a card_declined StripeError" taggedAs IntegrationTest in {
     val service = new StripeService(Configuration.stripeConfigProvider.get(true), configurableFutureRunner(40.seconds))
     val ex = recoverToExceptionIf[StripeError] {
-      service.createCustomer("tok_chargeDeclined", GBP)
+      CreateCustomer.fromSource("tok_chargeDeclined")(service.withCurrency(GBP))
     }
     ex.map(_.code should be(Some("card_declined")))
   }
@@ -92,10 +94,19 @@ class CreatePaymentMethodSpec extends AsyncLambdaSpec with MockContext {
     val serviceProvider = mock[ServiceProvider]
     val services = mock[Services]
     val stripe = mock[StripeService]
+    val stripeWithCurrency = mock[stripe.WithCurrency]
     val card = Stripe.Source("1234", "visa", "1234", 1, 2099, "GB")
     val customer = Stripe.Customer("12345", StripeList(1, Seq(card)))
-    when(stripe.createCustomer(any[String], any[Currency])).thenReturn(Future(customer))
+    when(stripeWithCurrency.post[Customer](
+      any[String],
+      any[Map[String, Seq[String]]]
+    )(
+      any[Decoder[Customer]],
+      any[Decoder[StripeError]],
+      any[ClassTag[Customer]])
+    ).thenReturn(Future(customer))
     when(services.stripeService).thenReturn(stripe)
+    when(stripe.withCurrency(any[Currency])).thenReturn(stripeWithCurrency)
     when(serviceProvider.forUser(any[Boolean])).thenReturn(services)
     serviceProvider
   }

--- a/support-workers/src/test/scala/com/gu/support/workers/lambdas/CreatePaymentMethodStateDecoderSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/lambdas/CreatePaymentMethodStateDecoderSpec.scala
@@ -57,13 +57,23 @@ class CreatePaymentMethodStateDecoderSpec extends FlatSpec with Matchers with Mo
 
   }
 
-  it should "be able to decode a contribution with Stripe payment fields" in {
-    val maybeState = decode[CreatePaymentMethodState](createStripePaymentMethodContributionJson())
+  it should "be able to decode a contribution with Stripe source payment fields" in {
+    val maybeState = decode[CreatePaymentMethodState](createStripeSourcePaymentMethodContributionJson())
     val fieldsToTest = maybeState.map(state =>
       (state.product, state.paymentFields))
     fieldsToTest should be(Right(
       Contribution(5, GBP, Monthly),
-      StripePaymentFields(stripeToken)
+      StripeSourcePaymentFields(stripeToken)
+    ))
+  }
+
+  it should "be able to decode a contribution with Stripe payment method payment fields" in {
+    val maybeState = decode[CreatePaymentMethodState](createStripePaymentMethodPaymentMethodContributionJson())
+    val fieldsToTest = maybeState.map(state =>
+      (state.product, state.paymentFields))
+    fieldsToTest should be(Right(
+      Contribution(5, GBP, Monthly),
+      StripePaymentMethodPaymentFields(stripePaymentMethodToken)
     ))
   }
 


### PR DESCRIPTION
## Why are you doing this?

We want to support the new SCA so that we can still take payments from customers after 14th Sep.
Stripe has a set of great instructions to show to be SCA ready here: https://stripe.com/docs/payments/cards/saving-cards
This PR implements step 5.

At the moment we just take a card token from stripe, and push it into the create customer step in order to be able to charge them multiple times.
The new world requires us to use a payment_method instead of a card token (source).
This change keeps the old functionality so that we don't break existing code, but also means that when someone submits the field from the client side with a paymentMethod instead, it will try to use the SCA method instead.

A small concern is how Zuora will deal with things, as we will have a payment method id and a customer token, rather than a card and customer token so although we can just send things to zuora in the normal way, we don't know exactly what field to put them in and whether it will be a different payment gateway name.  There will be another PR do do this.

See zuora thread: https://community.zuora.com/t5/Zuora-Announcements/PSD2-amp-SCA-how-Zuora-is-helping-you-prepare/ba-p/29434

We will need a second PR to clean up the "old" way once it's no longer used, but it makes sense for the support workers to be agnostic in the mean time.
If it's not clear otherwise, we might want some logging or metrics so that we know when that point is reached though?  I haven't specifically added any yet.

[**Trello Card**](https://trello.com/c/6EtZduO5/2534-add-parameter-to-support-workers-to-trigger-new-intent-confirmation)


@rupertbates @lucymonie @tomrf1 @jfsoul this PR might be worth a review please! Let me know what you think.