### PR TITLE
Allow tests to be enabled from the url only

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtest.js
+++ b/support-frontend/assets/helpers/abTests/abtest.js
@@ -206,9 +206,8 @@ function getParticipations(
       const participationsFromUrl = getParticipationsFromUrl();
       if (participationsFromUrl && participationsFromUrl[testId]) {
         participations[testId] = participationsFromUrl[testId];
-      } else {
-        return;
       }
+      return;
     }
 
     if (testId in currentParticipation) {

--- a/support-frontend/assets/helpers/abTests/abtest.js
+++ b/support-frontend/assets/helpers/abTests/abtest.js
@@ -66,6 +66,7 @@ export type Test = {|
   canRun?: () => boolean,
   independent: boolean,
   seed: number,
+  urlParticipationOnly: boolean,
 |};
 
 export type Tests = { [testId: string]: Test }
@@ -199,6 +200,15 @@ function getParticipations(
 
     if (test.canRun && !test.canRun()) {
       return;
+    }
+
+    if (test.urlParticipationOnly) {
+      const participationsFromUrl = getParticipationsFromUrl();
+      if (participationsFromUrl && participationsFromUrl[testId]) {
+        participations[testId] = participationsFromUrl[testId];
+      } else {
+        return;
+      }
     }
 
     if (testId in currentParticipation) {


### PR DESCRIPTION
## Why are you doing this?
Sometimes it's useful to try out a new test in PROD without opting users into the test.
It means we can integration test with e.g. our Stripe production account before putting it live to users.

Setting `urlParticipationOnly=true` on a test means you can only opt into the test if you set it in the url, e.g. `support.theguardian.com/uk/contribute#ab-stripeElements=stripeCardElement`

TODO - write some unit tests
