### PR TITLE
feat: add contributions to the mobile menu

### DIFF
--- a/support-frontend/assets/components/headers/header/header.scss
+++ b/support-frontend/assets/components/headers/header/header.scss
@@ -319,10 +319,11 @@ $header-links-min-width: gu-span(12);
   }
 }
 
-.component-header-links__li.show-on-tablet {
-  display: none;
+.component-header-links__li.component-header-links__li--show-on-tablet {
+  display: block;
 
-  @include mq($until: desktop) {
-    display: block;
+  // custom breakpoint - we are using a 'custom breakpoint' because this is linked to the menu toggle which has a custom break point applied in js
+  @media (min-width: 884px) {
+    display: none;
   }
 }

--- a/support-frontend/assets/components/headers/header/header.scss
+++ b/support-frontend/assets/components/headers/header/header.scss
@@ -253,12 +253,12 @@ $header-links-min-width: gu-span(12);
         color: gu-colour(neutral-100);
         @include gu-fontset-body-sans;
         border-right: 1px solid gu-colour(brand-pastel);
-  
+
         @include mq($until: tablet) {
           flex: none;
           border-right: none;
         }
-      
+
         .component-header-topnav--checkout-text {
           border-top: 1px solid gu-colour(brand-pastel);
           border-left: 1px solid gu-colour(brand-pastel);
@@ -270,18 +270,18 @@ $header-links-min-width: gu-span(12);
             display: inline-block;
             vertical-align: top;
           }
-  
+
           @include mq($until: tablet) {
             border-left: none;
             border-top: none;
             padding-left: $gu-h-spacing /4;
           }
         }
-      
+
         @include mq($from: tablet, $until: desktop) {
           display: none;
         }
-  
+
         @include mq($from: leftCol) {
           flex: 0 0 650px;
         }
@@ -316,5 +316,13 @@ $header-links-min-width: gu-span(12);
 
   @include mq($until: tablet) {
     display: none;
+  }
+}
+
+.component-header-links__li.show-on-tablet {
+  display: none;
+
+  @include mq($until: desktop) {
+    display: block;
   }
 }

--- a/support-frontend/assets/components/headers/links/links.jsx
+++ b/support-frontend/assets/components/headers/links/links.jsx
@@ -7,6 +7,7 @@ import { type Option } from 'helpers/types/option';
 import { classNameWithModifiers } from 'helpers/utilities';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
 import { type CountryGroupId, GBPCountries } from 'helpers/internationalisation/countryGroup';
+import cx from 'classnames';
 
 // types
 type HeaderNavLink = {
@@ -35,7 +36,7 @@ const links: HeaderNavLink[] = [
     href: routes.recurringContribCheckout,
     text: 'Contributions',
     trackAs: 'contributions',
-    additionalClasses: 'show-on-tablet',
+    additionalClasses: 'component-header-links__li--show-on-tablet',
   },
   {
     href: routes.subscriptionsLanding,
@@ -83,13 +84,10 @@ const Links = ({ location, getRef, countryGroupId }: PropTypes) => (
         href, text, trackAs, opensInNewWindow, additionalClasses,
         }) => (
           <li
-            className={[
-              classNameWithModifiers(
+            className={cx(classNameWithModifiers(
                 'component-header-links__li',
                 [window.location.href.endsWith(href) ? 'active' : null],
-              ), (additionalClasses || null),
-            ].join(' ')
-            }
+              ), additionalClasses)}
           >
             <a
               onClick={() => { trackComponentClick(['header-link', trackAs, location].join(' - ')); }}

--- a/support-frontend/assets/components/headers/links/links.jsx
+++ b/support-frontend/assets/components/headers/links/links.jsx
@@ -15,6 +15,7 @@ type HeaderNavLink = {
   trackAs: string,
   opensInNewWindow?: boolean,
   include?: CountryGroupId[],
+  additionalClasses?: string,
 }
 
 type PropTypes = {|
@@ -29,6 +30,12 @@ const links: HeaderNavLink[] = [
     href: routes.showcase,
     text: 'Support',
     trackAs: 'showcase',
+  },
+  {
+    href: routes.recurringContribCheckout,
+    text: 'Contributions',
+    trackAs: 'contributions',
+    additionalClasses: 'show-on-tablet',
   },
   {
     href: routes.subscriptionsLanding,
@@ -52,11 +59,6 @@ const links: HeaderNavLink[] = [
     trackAs: 'subscriptions:guardianweekly',
   },
   {
-    href: routes.recurringContribCheckout,
-    text: 'Contributions',
-    trackAs: 'contributions',
-  },
-  {
     href: getPatronsLink('support-header'),
     text: 'Patrons',
     trackAs: 'patrons',
@@ -78,14 +80,15 @@ const Links = ({ location, getRef, countryGroupId }: PropTypes) => (
         }
         return true;
       }).map(({
-        href, text, trackAs, opensInNewWindow,
+        href, text, trackAs, opensInNewWindow, additionalClasses,
         }) => (
           <li
-            className={
+            className={[
               classNameWithModifiers(
                 'component-header-links__li',
                 [window.location.href.endsWith(href) ? 'active' : null],
-              )
+              ), (additionalClasses || null),
+            ].join(' ')
             }
           >
             <a

--- a/support-frontend/assets/components/headers/links/links.jsx
+++ b/support-frontend/assets/components/headers/links/links.jsx
@@ -52,6 +52,11 @@ const links: HeaderNavLink[] = [
     trackAs: 'subscriptions:guardianweekly',
   },
   {
+    href: routes.recurringContribCheckout,
+    text: 'Contributions',
+    trackAs: 'contributions',
+  },
+  {
     href: getPatronsLink('support-header'),
     text: 'Patrons',
     trackAs: 'patrons',

--- a/support-frontend/assets/components/headers/links/links.jsx
+++ b/support-frontend/assets/components/headers/links/links.jsx
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import cx from 'classnames';
 
 import { routes } from 'helpers/routes';
 import { getPatronsLink } from 'helpers/externalLinks';
@@ -7,7 +8,6 @@ import { type Option } from 'helpers/types/option';
 import { classNameWithModifiers } from 'helpers/utilities';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
 import { type CountryGroupId, GBPCountries } from 'helpers/internationalisation/countryGroup';
-import cx from 'classnames';
 
 // types
 type HeaderNavLink = {

--- a/support-frontend/assets/components/headers/mobileMenu/mobileMenu.scss
+++ b/support-frontend/assets/components/headers/mobileMenu/mobileMenu.scss
@@ -23,7 +23,7 @@ $mobile-menu-gutter: ($gu-h-spacing*2.5);
     box-sizing: border-box;
     padding: $gu-v-spacing/2 0 $gu-v-spacing*2;
   }
-  
+
 }
 
 .component-header-links--mobile {
@@ -56,6 +56,14 @@ $mobile-menu-gutter: ($gu-h-spacing*2.5);
     border-top: 1px solid gu-colour(brand-pastel);
     &:first-child {
       border-top: none;
+    }
+
+    &.show-on-tablet {
+      display: block;
+
+      @include mq($until: tablet) {
+        display: none;
+      }
     }
   }
 }

--- a/support-frontend/assets/components/headers/mobileMenu/mobileMenu.scss
+++ b/support-frontend/assets/components/headers/mobileMenu/mobileMenu.scss
@@ -57,14 +57,6 @@ $mobile-menu-gutter: ($gu-h-spacing*2.5);
     &:first-child {
       border-top: none;
     }
-
-    &.show-on-tablet {
-      display: block;
-
-      @include mq($until: tablet) {
-        display: none;
-      }
-    }
   }
 }
 

--- a/support-frontend/assets/helpers/deliveryCheck.js
+++ b/support-frontend/assets/helpers/deliveryCheck.js
@@ -5,7 +5,7 @@ const M25_POSTCODE_PREFIXES = [
   'CR0', 'CR2', 'CR3', 'CR4', 'CR5', 'CR6', 'CR7', 'CR8', 'CR9',
   'DA1', 'DA14', 'DA15', 'DA16', 'DA18', 'DA5', 'DA7', 'DA8', 'DA17',
   'E1', 'E10', 'E11', 'E12', 'E13', 'E14', 'E15', 'E16', 'E17', 'E18', 'E20', 'E1W', 'E2', 'E3', 'E4', 'E5', 'E6', 'E7', 'E8', 'E9', 'E98',
-  'EC1A', 'EC1M', 'EC1N', 'EC1R', 'EC1V', 'EC1Y', 'EC2A', 'EC2M', 'EC2N', 'EC2R', 'EC2V', 'EC2Y', 'EC3A', 'EC3M', 'EC3N', 'EC3P', 'EC3R', 'EC3V', 'EC4A', 'EC4M', 'EC4N', 'EC4P', 'EC4R', 'EC4V','EC4Y',
+  'EC1A', 'EC1M', 'EC1N', 'EC1R', 'EC1V', 'EC1Y', 'EC2A', 'EC2M', 'EC2N', 'EC2R', 'EC2V', 'EC2Y', 'EC3A', 'EC3M', 'EC3N', 'EC3P', 'EC3R', 'EC3V', 'EC4A', 'EC4M', 'EC4N', 'EC4P', 'EC4R', 'EC4V', 'EC4Y',
   'EN1', 'EN2', 'EN3', 'EN4', 'EN5',
   'HA0', 'HA1', 'HA2', 'HA3', 'HA4', 'HA5', 'HA6', 'HA7', 'HA8', 'HA9',
   'IG1', 'IG10', 'IG11', 'IG2', 'IG3', 'IG5', 'IG6', 'IG7', 'IG8', 'IG9',


### PR DESCRIPTION
## Why are you doing this?
As part of the traffic drivers for subscriptions, the mobile header cta now links to subscriptions, this means that getting to contributions (where the previous mobile header cta linked to) will need to be accessed from subscriptions. This PR puts a link to contributions in the mobile menu

[**Trello Card**](https://trello.com/c/aXNyBKDt/2587-add-contributions-to-the-mobile-nav-on-support-frontend)

## Changes

* feat: add contributions to the mobile menu

## Screenshots
![Screen Shot 2019-09-02 at 15 34 44](https://user-images.githubusercontent.com/45875444/64121639-57e6a580-cd97-11e9-96b4-d14c00e2afd3.png)
