### PR TITLE
Redirect /support to regional versions

### DIFF
--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -67,13 +67,13 @@ class Application(
   }
 
   def supportGeoRedirect: Action[AnyContent] = GeoTargetedCachedAction() { implicit request =>
-    val redirectUrl = request.geoData.countryGroup match {
-      case Some(US) => buildCanonicalShowcaseLink("us")
-      case Some(Australia) => buildCanonicalShowcaseLink("au")
-      case _ => buildCanonicalShowcaseLink("uk")
+    val supportPageVariant = request.geoData.countryGroup match {
+      case Some(US) => "us"
+      case Some(Australia) => "au"
+      case _ => "uk"
     }
 
-    RedirectWithEncodedQueryString(redirectUrl, request.queryString, status = FOUND)
+    RedirectWithEncodedQueryString(buildCanonicalShowcaseLink(supportPageVariant), request.queryString, status = FOUND)
   }
 
   def contributeGeoRedirect(campaignCode: String): Action[AnyContent] = GeoTargetedCachedAction() { implicit request =>

--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -66,6 +66,16 @@ class Application(
     RedirectWithEncodedQueryString(redirectUrl, request.queryString, status = FOUND)
   }
 
+  def supportGeoRedirect: Action[AnyContent] = GeoTargetedCachedAction() { implicit request =>
+    val redirectUrl = request.geoData.countryGroup match {
+      case Some(US) => buildCanonicalShowcaseLink("us")
+      case Some(Australia) => buildCanonicalShowcaseLink("au")
+      case _ => buildCanonicalShowcaseLink("uk")
+    }
+
+    RedirectWithEncodedQueryString(redirectUrl, request.queryString, status = FOUND)
+  }
+
   def contributeGeoRedirect(campaignCode: String): Action[AnyContent] = GeoTargetedCachedAction() { implicit request =>
     val url = List(getContributeRedirectUrl(request.geoData.countryGroup), campaignCode)
       .filter(_.nonEmpty)

--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -67,7 +67,7 @@ class Application(
   }
 
   def contributeGeoRedirect(campaignCode: String): Action[AnyContent] = GeoTargetedCachedAction() { implicit request =>
-    val url = List(getRedirectUrl(request.geoData.countryGroup), campaignCode)
+    val url = List(getContributeRedirectUrl(request.geoData.countryGroup), campaignCode)
       .filter(_.nonEmpty)
       .mkString("/")
 
@@ -183,7 +183,7 @@ class Application(
   }
 
 
-  private def getRedirectUrl(fastlyCountry: Option[CountryGroup]): String = {
+  private def getContributeRedirectUrl(fastlyCountry: Option[CountryGroup]): String = {
     fastlyCountry match {
       case Some(UK) => "/uk/contribute"
       case Some(US) => "/us/contribute"

--- a/support-frontend/conf/routes
+++ b/support-frontend/conf/routes
@@ -29,7 +29,7 @@ GET /                                                              controllers.A
 
 # ----- Bundles Landing Page ----- #
 
-GET /support                                                       controllers.Application.redirect(location="/uk/support")
+GET /support                                                       controllers.Application.supportGeoRedirect()
 GET /$country<(uk|us|au|eu|int|nz|ca)>/support                     controllers.Application.showcase(country: String)
 # redirect from old ab test
 GET /showcase                                                      controllers.Application.permanentRedirect(location="/uk/support")


### PR DESCRIPTION
## Why are you doing this?
We recently added regional versions of the "Why Support" page at `/au/support` and `/uk/support`, but we hadn't yet changed the redirection from defaulting to `/uk/support`.  This does that so that when you navigate using the nav from Aus/US you should end up on the region-specific page.



[**Trello Card**](https://trello.com/c/DEsu2DM8/2586-why-support-redirect-support-always-goes-to-uk-version)

## Screenshots

![image](https://user-images.githubusercontent.com/8754692/64023536-726b1580-cb30-11e9-9bae-d90b982cb846.png)
