### PR TITLE
remove static asset S3 buckets from support frontend

### DIFF
--- a/support-frontend/cloud-formation/cfn.yaml
+++ b/support-frontend/cloud-formation/cfn.yaml
@@ -30,7 +30,7 @@ Conditions:
   CreateCodeResources: !Equals [!Ref "Stage", "CODE"]
 Mappings:
   StageVariables:
-    CODE: 
+    CODE:
       MaxInstances: 2
       MinInstances: 1
       InstanceType: t3.small
@@ -39,7 +39,6 @@ Mappings:
       DynamoDBTables:
       - arn:aws:dynamodb:*:*:table/MembershipSub-Promotions-DEV
       - arn:aws:dynamodb:*:*:table/MembershipSub-Promotions-UAT
-      BucketSuffix: code
     PROD:
       MaxInstances: 6
       MinInstances: 3
@@ -50,7 +49,6 @@ Mappings:
       DynamoDBTables:
       - arn:aws:dynamodb:*:*:table/MembershipSub-Promotions-PROD
       - arn:aws:dynamodb:*:*:table/MembershipSub-Promotions-UAT
-      BucketSuffix: prod
   Constants:
     Alarm:
       Process: Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit
@@ -505,18 +503,3 @@ Resources:
       TreatMissingData: notBreaching
     DependsOn:
     - StateMachineUnavailableMetric
-
-  S3Bucket:
-    Type: AWS::S3::Bucket
-    Properties:
-      AccessControl: PublicRead
-      BucketName: !Join 
-      - '-'
-      - - !Ref Stack
-        - !FindInMap [ StageVariables, !Ref Stage, BucketSuffix ]
-        - !Ref App
-        - static
-      MetricsConfigurations: 
-        - Id: EntireBucket
-      WebsiteConfiguration:
-        IndexDocument: index.html


### PR DESCRIPTION
## Why are you doing this?

We planned to serve the assets from an S3 bucket so that there couldn't be a mistmatch between the deployed instances on separate requests as this would cause a blank or unstyled page.

Originally we planned to have an S3 bucket per env and upload to that, but riffraff doesn't support a per env bucket when it uploads the files as part of the deploy.

In the end we went for a single bucket in a separate cfn, so this original background work is no longer needed.

previous PR with explanation: https://github.com/guardian/support-frontend/pull/2016
