### PR TITLE
Support viewing of an A/B test using the url, even if the test is off

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtest.js
+++ b/support-frontend/assets/helpers/abTests/abtest.js
@@ -222,9 +222,10 @@ const init = (
   const mvt: number = getMvtId();
   const participations: Participations = getParticipations(abTests, mvt, country, countryGroupId);
   const urlParticipations: ?Participations = getParticipationsFromUrl();
-  setLocalStorageParticipations({ ...participations, ...urlParticipations });
+  const combinedParticipations: Participations = { ...participations, ...urlParticipations };
+  setLocalStorageParticipations(combinedParticipations);
 
-  return participations;
+  return combinedParticipations;
 };
 
 const getVariantsAsString = (participation: Participations): string => {


### PR DESCRIPTION
## Why are you doing this?
Sometimes it's useful to try out a new test in PROD without opting users into the test.
It means we can integration test with e.g. our Stripe production account before putting it live to users.

Previously `urlParticipations` was only being used to set a local storage value, so if the ab test was switch off then it had no effect.
This change means that even if an ab test is switched off, if you set `#ab-<test-name>=<variant-name>` in the url than you'll be in the ab test.