### PR TITLE
Modifications to enable a third US-based Stripe account

### DIFF
--- a/support-config/src/main/resources/touchpoint.PROD.conf
+++ b/support-config/src/main/resources/touchpoint.PROD.conf
@@ -1,8 +1,12 @@
 touchpoint.backend.environments {
   PROD {
     stripe {
-      AUD {
+      AU {
         api.key.public = "pk_live_57xV50eFjPIA990PEGWJwoHp"
+        api.key.secret = "dummy-key"
+      }
+      US {
+        api.key.public = "pk_live_2O6zPMHXNs2AGea4bAmq5R7Z"
         api.key.secret = "dummy-key"
       }
       default {

--- a/support-config/src/main/resources/touchpoint.SANDBOX.conf
+++ b/support-config/src/main/resources/touchpoint.SANDBOX.conf
@@ -1,8 +1,12 @@
 touchpoint.backend.environments {
   SANDBOX {
     stripe {
-      AUD {
+      AU {
         api.key.public = "pk_test_m0sjR1tGM22fpaz48csa49us"
+        api.key.secret = "dummy-key"
+      }
+      US {
+        api.key.public = "pk_test_Qm3CGRdrV4WfGYCpm0sftR0f"
         api.key.secret = "dummy-key"
       }
       default {

--- a/support-config/src/main/resources/touchpoint.UAT.conf
+++ b/support-config/src/main/resources/touchpoint.UAT.conf
@@ -1,8 +1,12 @@
 touchpoint.backend.environments {
   UAT {
     stripe {
-      AUD {
+      AU {
         api.key.public = "pk_test_m0sjR1tGM22fpaz48csa49us"
+        api.key.secret = "dummy-key"
+      }
+      US {
+        api.key.public = "pk_test_Qm3CGRdrV4WfGYCpm0sftR0f"
         api.key.secret = "dummy-key"
       }
       default {

--- a/support-config/src/main/scala/com/gu/support/config/StripeConfig.scala
+++ b/support-config/src/main/scala/com/gu/support/config/StripeConfig.scala
@@ -1,24 +1,47 @@
 package com.gu.support.config
 
-import com.gu.i18n.Currency
+import com.gu.i18n.{Country, Currency}
 import com.gu.i18n.Currency.AUD
 import com.gu.monitoring.SafeLogger
 import com.typesafe.config.Config
 
 
-case class StripeConfig(defaultAccount: StripeAccountConfig, australiaAccount: StripeAccountConfig, version: Option[String] = None)
+case class StripeConfig(defaultAccount: StripeAccountConfig,
+                        australiaAccount: StripeAccountConfig,
+                        unitedStatesAccount: StripeAccountConfig,
+                        version: Option[String])
   extends TouchpointConfig {
-  def forCurrency(maybeCurrency: Option[Currency]): StripeAccountConfig =
+
+  // Still needed for SupportWorkers (recurring products) which don't support a US Stripe account yet.
+  def forCurrency(maybeCurrency: Option[Currency]): StripeAccountConfig = {
     maybeCurrency match {
       case Some(AUD) => {
-        SafeLogger.info(s"StripeConfig: getting AU stripe account for $maybeCurrency")
+        SafeLogger.info(s"StripeConfig: getting AU stripe account for AUD")
         australiaAccount
       }
       case _ => {
-        SafeLogger.info(s"StripeConfig: getting default stripe account for $maybeCurrency")
+        SafeLogger.info(s"StripeConfig: getting default stripe account for ${maybeCurrency.map(_.iso).mkString}")
         defaultAccount
       }
     }
+  }
+
+  def forCountry(maybeCountry: Option[Country]): StripeAccountConfig = {
+    maybeCountry match {
+      case Some(Country.Australia) => {
+        SafeLogger.info(s"StripeConfig: getting AU stripe account for Australia")
+        australiaAccount
+      }
+      case Some(Country.US) => {
+        SafeLogger.info(s"StripeConfig: getting US stripe account for United States")
+        unitedStatesAccount
+      }
+      case _ => {
+        SafeLogger.info(s"StripeConfig: getting default stripe account for ${maybeCountry.map(_.name).mkString}")
+        defaultAccount
+      }
+    }
+  }
 }
 
 case class StripeAccountConfig(secretKey: String, publicKey: String)
@@ -27,7 +50,8 @@ class StripeConfigProvider(config: Config, defaultStage: Stage, prefix: String =
   extends TouchpointConfigProvider[StripeConfig](config, defaultStage) {
   def fromConfig(config: Config): StripeConfig = StripeConfig(
     accountFromConfig(config, prefix, "default"),
-    accountFromConfig(config, prefix, "AUD"),
+    accountFromConfig(config, prefix, Country.Australia.alpha2),
+    accountFromConfig(config, prefix, Country.US.alpha2),
     version = stripeVersion(config)
   )
 

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -1,6 +1,6 @@
 @import admin.settings.AllSettings
 @import assets.{AssetsResolver, RefPath, StyleContent}
-@import com.gu.i18n.Currency.AUD
+@import com.gu.i18n.Country
 @import com.gu.identity.model.{User => IdUser}
 @import com.gu.support.config.{PayPalConfig, StripeConfig}
 @import helper.CSRF
@@ -51,30 +51,43 @@
       }
     };
   }
-  window.guardian.stripeKeyDefaultCurrencies = {
-    ONE_OFF: {
-      default: "@oneOffDefaultStripeConfig.forCurrency(None).publicKey",
-      uat: "@oneOffUatStripeConfig.forCurrency(None).publicKey"
-    },
-    REGULAR: {
-      default: "@regularDefaultStripeConfig.forCurrency(None).publicKey",
-      uat: "@regularUatStripeConfig.forCurrency(None).publicKey"
-    }
-  };
+
   window.guardian.geoip = {
     countryGroup: "@geoData.countryGroup.map(_.id).mkString",
     countryCode: "@geoData.country.map(_.alpha2).mkString",
     stateCode: "@geoData.validatedStateCodeForCountry.mkString"
   };
-  window.guardian.stripeKeyAustralia = {
+
+  window.guardian.stripeKeyDefaultCurrencies = {
     ONE_OFF: {
-      default: "@oneOffDefaultStripeConfig.forCurrency(Some(AUD)).publicKey",
-      uat: "@oneOffUatStripeConfig.forCurrency(Some(AUD)).publicKey"
+      default: "@oneOffDefaultStripeConfig.defaultAccount.publicKey",
+      uat: "@oneOffUatStripeConfig.defaultAccount.publicKey"
     },
     REGULAR: {
-      default: "@regularDefaultStripeConfig.forCurrency(Some(AUD)).publicKey",
-      uat: "@regularUatStripeConfig.forCurrency(Some(AUD)).publicKey"
+      default: "@regularDefaultStripeConfig.defaultAccount.publicKey",
+      uat: "@regularUatStripeConfig.defaultAccount.publicKey"
     }
+  };
+  window.guardian.stripeKeyAustralia = {
+    ONE_OFF: {
+      default: "@oneOffDefaultStripeConfig.forCountry(Some(Country.Australia)).publicKey",
+      uat: "@oneOffUatStripeConfig.forCountry(Some(Country.Australia)).publicKey"
+    },
+    REGULAR: {
+      default: "@regularDefaultStripeConfig.forCountry(Some(Country.Australia)).publicKey",
+      uat: "@regularUatStripeConfig.forCountry(Some(Country.Australia)).publicKey"
+    }
+  };
+  window.guardian.stripeKeyUnitedStates = {
+    @if(settings.switches.experiments.get("usStripeAccountForSingle").exists(_.isOn)) {
+        ONE_OFF: {
+            default: "@oneOffDefaultStripeConfig.forCountry(Some(Country.US)).publicKey",
+            uat: "@oneOffUatStripeConfig.forCountry(Some(Country.US)).publicKey"
+        },
+    } else {
+      ONE_OFF: window.guardian.stripeKeyDefaultCurrencies.ONE_OFF,
+    }
+    REGULAR: window.guardian.stripeKeyDefaultCurrencies.REGULAR
   };
   window.guardian.payPalEnvironment = {
     default: "@regularDefaultPayPalConfig.payPalEnvironment",

--- a/support-frontend/app/views/subscriptionCheckout.scala.html
+++ b/support-frontend/app/views/subscriptionCheckout.scala.html
@@ -53,6 +53,7 @@
           uat: "@uatStripeConfig.forCurrency(Some(AUD)).publicKey"
         }
       };
+      window.guardian.stripeKeyUnitedStates = window.guardian.stripeKeyDefaultCurrencies,
       window.guardian.payPalEnvironment = {
         default: "@defaultPayPalConfig.payPalEnvironment",
         uat: "@uatPayPalConfig.payPalEnvironment"

--- a/support-frontend/assets/helpers/paymentIntegrations/oneOffContributions.js
+++ b/support-frontend/assets/helpers/paymentIntegrations/oneOffContributions.js
@@ -64,6 +64,7 @@ export type StripeChargeData = {|
     stripePaymentMethod: StripePaymentMethod,
   },
   acquisitionData: PaymentAPIAcquisitionData,
+  publicKey: string
 |};
 
 

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
@@ -54,7 +54,7 @@ function StripePaymentRequestButtonContainer(props: PropTypes) {
       return null;
     }
 
-    const key = getStripeKey('ONE_OFF', props.currency, props.isTestUser);
+    const key = getStripeKey('ONE_OFF', props.country, props.isTestUser);
     const amount = getAmount(props.selectedAmounts, props.otherAmounts, props.contributionType);
 
     return (

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -46,7 +46,8 @@ import { type State, type ThankYouPageStage, type UserFormData } from './contrib
 import type { PaymentMethod } from 'helpers/paymentMethods';
 import { DirectDebit, Stripe } from 'helpers/paymentMethods';
 import type { RecentlySignedInExistingPaymentMethod } from 'helpers/existingPaymentMethods/existingPaymentMethods';
-import { ExistingCard, ExistingDirectDebit } from '../../helpers/paymentMethods';
+import { ExistingCard, ExistingDirectDebit } from 'helpers/paymentMethods';
+import { getStripeKey, stripeAccountForContributionType } from 'helpers/paymentIntegrations/stripeCheckout';
 
 export type Action =
   | { type: 'UPDATE_CONTRIBUTION_TYPE', contributionType: ContributionType }
@@ -254,6 +255,11 @@ const stripeChargeDataFromAuthorisation = (
     state.common.abParticipations,
     state.common.optimizeExperiments,
   ),
+  publicKey: getStripeKey(
+    stripeAccountForContributionType[state.page.form.contributionType],
+    state.common.internationalisation.countryId,
+    state.page.user.isTestUser || false
+  )
 });
 
 const regularPaymentRequestFromAuthorisation = (

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.js
@@ -8,7 +8,6 @@ import { setPayPalHasLoaded } from 'helpers/paymentIntegrations/payPalActions';
 import {
   loadStripe,
   setupStripeCheckout,
-  type StripeAccount,
 } from 'helpers/paymentIntegrations/stripeCheckout';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { Switches } from 'helpers/settings';
@@ -48,6 +47,7 @@ import { doesUserAppearToBeSignedIn } from 'helpers/user/user';
 import { isSwitchOn } from 'helpers/globals';
 import type { ContributionTypes } from 'helpers/contributions';
 import { campaigns, getCampaignName } from 'helpers/campaigns';
+import { stripeAccountForContributionType } from 'helpers/paymentIntegrations/stripeCheckout';
 
 // ----- Functions ----- //
 
@@ -85,17 +85,11 @@ function getInitialContributionType(
     contributionTypes[countryGroupId][0].contributionType;
 }
 
-const stripeAccountForContributionType: {[ContributionType]: StripeAccount } = {
-  ONE_OFF: 'ONE_OFF',
-  MONTHLY: 'REGULAR',
-  ANNUAL: 'REGULAR',
-};
-
-
 function initialiseStripeCheckout(
   onPaymentAuthorisation: (paymentAuthorisation: PaymentAuthorisation) => void,
   contributionType: ContributionType,
   currencyId: IsoCurrency,
+  countryId: IsoCountry,
   isTestUser: boolean,
   dispatch: Function,
 ) {
@@ -104,6 +98,7 @@ function initialiseStripeCheckout(
       onPaymentAuthorisation,
       stripeAccountForContributionType[contributionType],
       currencyId,
+      countryId,
       isTestUser,
     );
   dispatch(setThirdPartyPaymentLibrary({ [contributionType]: { Stripe: library } }));
@@ -130,6 +125,7 @@ function initialisePaymentMethods(state: State, dispatch: Function, contribution
             onPaymentAuthorisation,
             contributionTypeSetting.contributionType,
             currencyId,
+            countryId,
             !!isTestUser,
             dispatch,
           );

--- a/support-frontend/test/controllers/SubscriptionsTest.scala
+++ b/support-frontend/test/controllers/SubscriptionsTest.scala
@@ -79,7 +79,7 @@ class SubscriptionsTest extends WordSpec with MustMatchers with TestCSRFComponen
       val stripe = mock[StripeConfigProvider]
       val stripeAccountConfig = StripeAccountConfig("", "")
       when(stripe.get(any[Boolean])).thenReturn(
-        StripeConfig(stripeAccountConfig, stripeAccountConfig, None)
+        StripeConfig(stripeAccountConfig, stripeAccountConfig, stripeAccountConfig, None)
       )
       val payPal = mock[PayPalConfigProvider]
       when(payPal.get(any[Boolean])).thenReturn(PayPalConfig("", "", "", "", "", ""))


### PR DESCRIPTION
Reverts guardian/support-frontend#2064, re-enabling, now that support-workers configs have been properly set:

Modifications to enable a third US-based Stripe account. Main changes are that the public key is chosen based on the page's country not the transacting currency. Also that the public key needs to be transmitted along with the payment and analytics information over to the Payment API so that it can be completely sure which account the token is generated from, and doesn't duplicate the based-on-country algorithm.

Use of the new key is controlled by a new 'Payment Method' feature switch which I need to add to the [admin console](https://github.com/guardian/support-admin-console).

## Why are you doing this?
To enable Discover and Diners Club cards to be used by USA customers. Also to move less money around in the back-office between UK and US-based USD company bank accounts.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/23rljvzx)

## Screenshots
No fundamental changes to UX other than new cards (Diners and Discover) will be accepted. 

Before / with the Feature Switch off:
![Screen Shot 2019-09-02 at 13 21 26](https://user-images.githubusercontent.com/1515970/64114517-13eaa500-cd85-11e9-94b2-eef6b120b8f9.png)
![Screen Shot 2019-09-02 at 13 20 33](https://user-images.githubusercontent.com/1515970/64114393-bd7d6680-cd84-11e9-9786-8e79d093ffd4.png)
![Screen Shot 2019-09-02 at 13 21 12](https://user-images.githubusercontent.com/1515970/64114416-ca9a5580-cd84-11e9-8134-3115f9fb7441.png)

After / with the Feature Switch on:
![Screen Shot 2019-09-02 at 10 22 26](https://user-images.githubusercontent.com/1515970/64114528-1a791c80-cd85-11e9-84d1-a198305e6f96.png)
![Screen Shot 2019-09-02 at 13 20 07](https://user-images.githubusercontent.com/1515970/64114450-e4d43380-cd84-11e9-9d90-483997fbac39.png)
![Screen Shot 2019-09-02 at 13 19 44](https://user-images.githubusercontent.com/1515970/64114445-e140ac80-cd84-11e9-878d-eee2d85aefef.png)



