### PR TITLE
make tests that involve futures wait for the future single threadedly

### DIFF
--- a/support-workers/src/main/scala/com/gu/support/workers/exceptions/ErrorHandler.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/exceptions/ErrorHandler.scala
@@ -15,7 +15,7 @@ import com.gu.support.zuora.api.response.ZuoraErrorResponse
  * see support-workers/docs/error-handling.md
  */
 object ErrorHandler {
-  val handleException: PartialFunction[Throwable, Any] = {
+  val handleException: Throwable => Nothing = {
     //Stripe
     case e: Stripe.StripeError => logAndRethrow(e.asRetryException)
     //PayPal
@@ -32,7 +32,7 @@ object ErrorHandler {
     case e: Throwable => logAndRethrow(e.asRetryException)
   }
 
-  def logAndRethrow(t: RetryException): Unit = {
+  def logAndRethrow(t: RetryException): Nothing = {
     SafeLogger.error(scrub"${t.getMessage}", t)
     throw t
   }

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
@@ -17,7 +17,7 @@ import io.circe.parser.decode
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class FailureHandler(emailService: EmailService) extends FutureHandler[FailureHandlerState, CheckoutFailureState] {
+class FailureHandler(emailService: EmailService) extends Handler[FailureHandlerState, CheckoutFailureState] {
 
   def this() = this(new EmailService)
 

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/Handler.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/Handler.scala
@@ -2,6 +2,7 @@ package com.gu.support.workers.lambdas
 
 import java.io.{InputStream, OutputStream}
 
+import cats.{Applicative, Functor, Id}
 import com.amazonaws.services.lambda.runtime.{Context, RequestStreamHandler}
 import com.gu.support.workers.exceptions.ErrorHandler
 import com.gu.support.workers.{ExecutionError, RequestInfo}
@@ -9,44 +10,54 @@ import io.circe.{Decoder, Encoder}
 
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.language.higherKinds
 
-abstract class Handler[T, R](implicit decoder: Decoder[T], encoder: Encoder[R]) extends RequestStreamHandler {
+abstract class Handler[T, R](
+  implicit
+  decoder: Decoder[T],
+  encoder: Encoder[R],
+  ec: ExecutionContext
+) extends RequestStreamHandler {
 
   import com.gu.support.workers.encoding.Encoding._
 
   type HandlerResult = (R, RequestInfo)
 
-  def HandlerResult(r: R, ri: RequestInfo): HandlerResult = (r, ri) // scalastyle:ignore method.name
-
-  protected def handler(input: T, error: Option[ExecutionError], requestInfo: RequestInfo, context: Context): HandlerResult
-
-  def handleRequest(is: InputStream, os: OutputStream, context: Context): Unit =
-    try {
-      in(is).flatMap {
-        case (i, error, requestInfo) =>
-          val result = handler(i, error, requestInfo, context)
-          out(result._1, result._2, os)
-      }.get
-    } catch ErrorHandler.handleException
-}
-
-abstract class FutureHandler[T, R](d: Option[Duration] = None)(
-    implicit
-    decoder: Decoder[T],
-    encoder: Encoder[R],
-    ec: ExecutionContext
-) extends Handler[T, R] {
-
   type FutureHandlerResult = Future[(R, RequestInfo)]
+
+  def HandlerResult(r: R, ri: RequestInfo): HandlerResult = (r, ri) // scalastyle:ignore method.name
 
   def FutureHandlerResult(r: R, ri: RequestInfo): FutureHandlerResult = Future.successful((r, ri)) // scalastyle:ignore method.name
 
+  override def handleRequest(is: InputStream, os: OutputStream, context: Context): Unit =
+    handleRequestExtractFunctor[Id](is, os, context, await(context)_)
+
+  def handleRequestExtractFunctor[F[_] : Applicative](
+    is: InputStream,
+    os: OutputStream,
+    context: Context,
+    resultToResult: FutureHandlerResult => F[HandlerResult]
+  ): F[Unit] = {
+    try {
+      in(is).map {
+        case (input, error, requestInfo) =>
+          implicitly[Functor[F]].map(resultToResult(handlerFuture(input, error, requestInfo, context))) { result =>
+            out(result._1, result._2, os).get
+          }
+      }.get
+    } catch {
+      case t: Throwable/*TODO all throwables?*/ => ErrorHandler.handleException(t)
+      implicitly[Applicative[F]].pure(()) // hmm, still need a future if we throw an exception? TODO think harder
+    }
+  }
+
   protected def handlerFuture(input: T, error: Option[ExecutionError], requestInfo: RequestInfo, context: Context): FutureHandlerResult
 
-  override protected def handler(input: T, error: Option[ExecutionError], requestInfo: RequestInfo, context: Context): HandlerResult =
+  protected def await(context: Context)(futureHandlerResult: FutureHandlerResult): Id[HandlerResult] =
     Await.result(
-      handlerFuture(input, error, requestInfo, context),
-      d.getOrElse(Duration(context.getRemainingTimeInMillis.toLong, MILLISECONDS))
+      futureHandlerResult,
+      Duration(context.getRemainingTimeInMillis.toLong, MILLISECONDS)
     )
+
 }
 

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/ServicesHandler.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/ServicesHandler.scala
@@ -9,12 +9,12 @@ import io.circe.{Decoder, Encoder}
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
-abstract class ServicesHandler[T <: StepFunctionUserState, R](servicesProvider: ServiceProvider, d: Option[Duration] = None)(
+abstract class ServicesHandler[T <: StepFunctionUserState, R](servicesProvider: ServiceProvider)(
     implicit
     decoder: Decoder[T],
     encoder: Encoder[R],
     ec: ExecutionContext
-) extends FutureHandler[T, R] {
+) extends Handler[T, R] {
 
   override protected def handlerFuture(input: T, error: Option[ExecutionError], requestInfo: RequestInfo, context: Context) = {
     servicesHandler(input, requestInfo, context, servicesProvider.forUser(input.user.isTestUser))

--- a/support-workers/src/test/scala/com/gu/support/workers/LambdaSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/LambdaSpec.scala
@@ -8,7 +8,7 @@ import org.scalatest.{AsyncFlatSpec, FlatSpec, Matchers}
 abstract class LambdaSpec extends FlatSpec with Matchers with MockContext
 
 abstract class AsyncLambdaSpec extends AsyncFlatSpec with Matchers {
-  implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
+  //implicit override def executionContext = scala.concurrent.ExecutionContext.Implicits.global
 }
 
 trait MockContext extends MockitoSugar {

--- a/support-workers/src/test/scala/com/gu/support/workers/lambdas/SendAcquisitionEventSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/lambdas/SendAcquisitionEventSpec.scala
@@ -12,6 +12,9 @@ import com.gu.test.tags.objects.IntegrationTest
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito.when
 import org.scalatest.mockito.MockitoSugar
+import cats.implicits._
+
+import scala.concurrent.Future
 
 class SendAcquisitionEventSpec extends AsyncLambdaSpec with MockContext {
 
@@ -20,12 +23,13 @@ class SendAcquisitionEventSpec extends AsyncLambdaSpec with MockContext {
 
     val outStream = new ByteArrayOutputStream()
 
-    sendAcquisitionEvent.handleRequest(sendAcquisitionEventJson, outStream, context)
+    sendAcquisitionEvent.handleRequestExtractFunctor[Future](sendAcquisitionEventJson, outStream, context, identity).map { _ =>
 
-    //Check the output
-    val out = Encoding.in[Unit](outStream.toInputStream)
+      //Check the output
+      val out = Encoding.in[Unit](outStream.toInputStream)
 
-    out.isSuccess should be(true)
+      out.isSuccess should be(true)
+    }
   }
 
 }


### PR DESCRIPTION
TODO
- flesh out description more with some links
- tidy up the code (this is the concept to get feedback, but there are probably syntactic and other low level simplifications even if we stick with the overall approach)
- test in CODE

## Why are you doing this?

This PR is a rough sketch (that works in testing) in order to get feedback on the approach.

----

Some test runs for support-workers were failing with a concurrency error.  This seems to be a scalatest bug, but triggered by us using a non serial execution context.  Someone else has hit it, and exploring the source code, scalatest doesn't seem to wait for the result properly (and may even not notice test failures) https://github.com/typelevel/cats-effect/issues/49

There's no reason we shouldn't use the built in serial one, so I decided to take the easy option, and make it work serially (it was suffering thread starvation in the Await call)  As otherwise we will end in concurrency whack a mole.  The concurrency issue was discovered during the migration to mono repo, but I'm not sure of any more background https://github.com/guardian/support-frontend/commit/d9f89a63274aad81457f9c355aa361e698cb49ca

See discussion on RR dev channel.

[**Trello Card**](https://trello.com/c/pBeYMyJn/2603-fix-parallel-execution-bug-in-tests)


