### PR TITLE
Put Stripe Elements test behind feature switch

### DIFF
--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -101,5 +101,7 @@
   @guestAccountCreationToken.map { guestAccountCreationToken =>
     window.guardian.guestAccountCreationToken = "@guestAccountCreationToken";
   }
+
+  window.guardian.stripeElements = @settings.switches.experiments.get("stripeElements").exists(_.isOn)
   </script>
 }

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -91,7 +91,7 @@ export const tests: Tests = {
         size: 1,
       },
     },
-    isActive: window.guardian.stripeElements,
+    isActive: window.guardian && window.guardian.stripeElements ? window.guardian.stripeElements : false,
     independent: true,
     seed: 3,
   },

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -91,7 +91,7 @@ export const tests: Tests = {
         size: 1,
       },
     },
-    isActive: false,
+    isActive: window.guardian.stripeElements,
     independent: true,
     seed: 3,
   },


### PR DESCRIPTION
The SCA/stripe elements change is being run as an a/b test.
But we also want the ability to enable/disable quickly from the support-admin-console