### PR TITLE
Fix stripe elements placeholder font colour

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
@@ -70,6 +70,9 @@ const fieldStyle = {
   base: {
     fontFamily: '\'Guardian Text Sans Web\', \'Helvetica Neue\', Helvetica, Arial, \'Lucida Grande\', sans-serif',
     fontSize: '16px',
+    '::placeholder': {
+      color: '#999999',
+    },
     lineHeight: '24px',
   },
 };


### PR DESCRIPTION
A minor style change, to make the placeholder text colour match that of the other fields in the page

<img width="492" alt="Screenshot 2019-09-06 at 12 33 23" src="https://user-images.githubusercontent.com/1513454/64425031-971c3b80-d0a2-11e9-91be-f7e5fbda3fa2.png">
