### PR TITLE
Remove Stripe Checkout popup test

### DIFF
--- a/support-frontend/test/selenium/contributions/OneOffContributionsSpec.scala
+++ b/support-frontend/test/selenium/contributions/OneOffContributionsSpec.scala
@@ -63,38 +63,6 @@ class OneOffContributionsSpec extends FeatureSpec with GivenWhenThen with Before
       }
     }
 
-    scenario("Check Stripe pop-up appears") {
-      val testUser = new TestUser {
-        val username = "test-stripe-pop-up"
-        driverConfig.addCookie(name = "GU_TK", value = "1.1") //To avoid consent banner, which messes with selenium
-      }
-
-      val landingPage = ContributionsLanding("au", testUser)
-
-      Given("that a test user goes to the contributions landing page")
-      goTo(landingPage)
-      assert(landingPage.pageHasLoaded)
-      landingPage.clearForm(hasNameFields = false)
-
-      When("the user selects the one-time option")
-      landingPage.clickOneOff
-
-      Given("The user fills in their details correctly")
-      landingPage.fillInPersonalDetails(hasNameFields = false)
-
-      Given("that the user selects to pay with Stripe")
-      When("they press the Stripe payment button")
-      landingPage.selectStripePayment()
-
-      When("they click contribute")
-      landingPage.clickContribute
-
-      Then("the overlay should appear")
-      eventually {
-        assert(landingPage.hasStripeOverlay)
-      }
-    }
-
     scenario("Check browser navigates to paypal") {
       val testUser = new TestUser {
         val username = "test-stripe-pop-up"


### PR DESCRIPTION
## Why are you doing this?
We are currently running an A/B test where one variant uses Stripe Checkout, the other Stripe Elements.
This post-deployment test fails if the user is in the Stripe Elements variant.
We need a new post-deploy test, but for now I'm just removing it so we can continue running the test

