### PR TITLE
Fix one-off contributions deployment tests

### DIFF
--- a/support-frontend/conf/DEV.public.conf
+++ b/support-frontend/conf/DEV.public.conf
@@ -6,7 +6,7 @@
 
 stage="DEV"
 
-identity.webapp.url="https://profile.code.dev-theguardian.com"
+identity.webapp.url="https://profile.thegulocal.com"
 identity.api.url="https://idapi.code.dev-theguardian.com"
 identity.production.keys=false
 identity.useStub=false

--- a/support-frontend/conf/DEV.public.conf
+++ b/support-frontend/conf/DEV.public.conf
@@ -6,7 +6,7 @@
 
 stage="DEV"
 
-identity.webapp.url="https://profile.thegulocal.com"
+identity.webapp.url="https://profile.code.dev-theguardian.com"
 identity.api.url="https://idapi.code.dev-theguardian.com"
 identity.production.keys=false
 identity.useStub=false


### PR DESCRIPTION
## Why are you doing this?
We're currently running an A/B test on the one-off contributions page, with Stripe Elements.
This breaks these post-deploy tests.
This is a temporary fix to force the browser into the control variant (with stripe checkout). I've also reinstated the "Check Stripe pop-up appears" test.

TODO - rewrite tests for stripe elements
