### PR TITLE
Show red border for errors in stripe elements inputs

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
@@ -159,6 +159,16 @@ class CardForm extends Component<PropTypes, StateTypes> {
     this.state.Expiry.name === 'Complete' &&
     this.state.CVC.name === 'Complete';
 
+  getFieldBorder = (fieldName: CardFieldName): string => {
+    if (this.state.currentlySelected === fieldName) {
+      return 'form__input-enabled'
+    } else if (this.state[fieldName].name === 'Error') {
+      return 'form__input--invalid'
+    } else {
+      return '';
+    }
+  };
+
   render() {
     const errorMessage: ?string =
       errorMessageFromState(this.state.CardNumber) ||
@@ -166,7 +176,7 @@ class CardForm extends Component<PropTypes, StateTypes> {
       errorMessageFromState(this.state.CVC);
 
     const getClasses = (fieldName: CardFieldName): string =>
-      `form__input ${this.state.currentlySelected === fieldName ? 'form__input-enabled' : ''}`;
+      `form__input ${this.getFieldBorder(fieldName)}`;
 
     return (
       <div className="form__fields">

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
@@ -154,7 +154,7 @@ class CardForm extends Component<PropTypes, StateTypes> {
     });
   };
 
-  getFieldBorder = (fieldName: CardFieldName): string => {
+  getFieldBorderClass = (fieldName: CardFieldName): string => {
     if (this.state.currentlySelected === fieldName) {
       return 'form__input-enabled';
     } else if (this.state[fieldName].name === 'Error') {
@@ -175,7 +175,7 @@ class CardForm extends Component<PropTypes, StateTypes> {
       errorMessageFromState(this.state.CVC);
 
     const getClasses = (fieldName: CardFieldName): string =>
-      `form__input ${this.getFieldBorder(fieldName)}`;
+      `form__input ${this.getFieldBorderClass(fieldName)}`;
 
     return (
       <div className="form__fields">

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
@@ -154,20 +154,19 @@ class CardForm extends Component<PropTypes, StateTypes> {
     });
   };
 
+  getFieldBorder = (fieldName: CardFieldName): string => {
+    if (this.state.currentlySelected === fieldName) {
+      return 'form__input-enabled';
+    } else if (this.state[fieldName].name === 'Error') {
+      return 'form__input--invalid';
+    }
+    return '';
+  };
+
   formIsComplete = () =>
     this.state.CardNumber.name === 'Complete' &&
     this.state.Expiry.name === 'Complete' &&
     this.state.CVC.name === 'Complete';
-
-  getFieldBorder = (fieldName: CardFieldName): string => {
-    if (this.state.currentlySelected === fieldName) {
-      return 'form__input-enabled'
-    } else if (this.state[fieldName].name === 'Error') {
-      return 'form__input--invalid'
-    } else {
-      return '';
-    }
-  };
 
   render() {
     const errorMessage: ?string =


### PR DESCRIPTION
## Why are you doing this?
To be consistent with other fields in the form

## Screenshots

Selected, no error:
<img width="492" alt="Screenshot 2019-09-10 at 15 26 43" src="https://user-images.githubusercontent.com/1513454/64622575-73792e00-d3df-11e9-8ce4-998ee16cc3eb.png">

Not selected, error:
<img width="492" alt="Screenshot 2019-09-10 at 15 26 47" src="https://user-images.githubusercontent.com/1513454/64622577-73792e00-d3df-11e9-9c37-9aeb64a4ad1d.png">

Selected, error:
<img width="492" alt="Screenshot 2019-09-10 at 15 26 53" src="https://user-images.githubusercontent.com/1513454/64622578-73792e00-d3df-11e9-8a4b-ae01f543cf51.png">
