### PR TITLE
We now have a PROD Stripe public key!

### DIFF
--- a/support-config/src/main/resources/touchpoint.PROD.conf
+++ b/support-config/src/main/resources/touchpoint.PROD.conf
@@ -6,7 +6,7 @@ touchpoint.backend.environments {
         api.key.secret = "dummy-key"
       }
       US {
-        api.key.public = "pk_live_2O6zPMHXNs2AGea4bAmq5R7Z"
+        api.key.public = "pk_live_FCXf4hYCh6eefkHDbwKvvwZR00AFIyucU3"
         api.key.secret = "dummy-key"
       }
       default {


### PR DESCRIPTION
## Why are you doing this?
Enabling use of a US Stripe account on the Single Contributions checkout in PROD. Feature is currently behind a feature switch, and will be off till we've done some e2e testing with Finance team.

[**Trello Card**](https://trello.com/c/dUczXjoJ)
