### PR TITLE
A11y validator

### DIFF
--- a/support-frontend/assets/helpers/render.js
+++ b/support-frontend/assets/helpers/render.js
@@ -50,10 +50,14 @@ const renderPage = (content: Object, id: string, callBack?: () => void) => {
   if (element) {
     delete element.dataset.notHydrated;
     try {
-      import('react-axe').then(axe => {
-        axe.default(React, ReactDOM, 1000);
+      if (process.env.NODE_ENV === 'DEV') {
+        import('react-axe').then(axe => {
+          axe.default(React, ReactDOM, 1000);
+          ReactDOM.render(content, element, callBack);
+        });
+      } else {
         ReactDOM.render(content, element, callBack);
-      });
+      }
     } catch (e) {
       renderError(e, id);
     }

--- a/support-frontend/assets/helpers/render.js
+++ b/support-frontend/assets/helpers/render.js
@@ -1,5 +1,5 @@
 // @flow
-
+import React from 'react';
 import ReactDOM from 'react-dom';
 import { logException } from 'helpers/logger';
 
@@ -50,7 +50,10 @@ const renderPage = (content: Object, id: string, callBack?: () => void) => {
   if (element) {
     delete element.dataset.notHydrated;
     try {
-      ReactDOM.render(content, element, callBack);
+      import('react-axe').then(axe => {
+        axe.default(React, ReactDOM, 1000);
+        ReactDOM.render(content, element, callBack);
+      });
     } catch (e) {
       renderError(e, id);
     }

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -67,6 +67,7 @@
     "cssnano": "^4.1.4",
     "fast-sass-loader": "^1.4.7",
     "ophan-tracker-js": "^1.3.17",
+    "react-axe": "^3.3.0",
     "react-redux": "^5.1.1",
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -2978,6 +2978,11 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
+axe-core@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.3.2.tgz#7baf3c55a5cf1621534a2c38735f5a1bf2f7e1a8"
+  integrity sha512-lRdxsRt7yNhqpcXQk1ao1BL73OZDzmFCWOG0mC4tGR/r14ohH2payjHwCMQjHGbBKm924eDlmG7utAGHiX/A6g==
+
 axobject-query@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.0.2.tgz#ea187abe5b9002b377f925d8bf7d1c561adf38f9"
@@ -11585,6 +11590,14 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-axe@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/react-axe/-/react-axe-3.3.0.tgz#b87bff644ed3ed6f1ca12bcc64c00000e359c25b"
+  integrity sha512-JoxU2jcTla37U6MtqIoYnGaRQcAHkNm9JxTjx2wcEgFm8Zd2A2vo9eboxcmpLjklXDKJwJNbyDo2Jcbbme6xwA==
+  dependencies:
+    axe-core "^3.3.2"
+    requestidlecallback "^0.3.0"
+
 react-color@^2.14.1:
   version "2.17.0"
   resolved "https://registry.yarnpkg.com/react-color/-/react-color-2.17.0.tgz#e14b8a11f4e89163f65a34c8b43faf93f7f02aaa"
@@ -12285,6 +12298,11 @@ request@^2.87.0, request@^2.88.0:
     tough-cookie "~2.4.3"
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
+
+requestidlecallback@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/requestidlecallback/-/requestidlecallback-0.3.0.tgz#6fb74e0733f90df3faa4838f9f6a2a5f9b742ac5"
+  integrity sha1-b7dOBzP5DfP6pIOPn2oqX5t0KsU=
 
 require-directory@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
## Why are you doing this?
We would like to automate accessibility checking on our pages, this is a first step towards that ambition. It introduces [React-axe](https://github.com/dequelabs/react-axe) which will test pages running in dev with the axe-core accessibility testing library and show results will in the Chrome DevTools console.

[**Trello Card**](https://trello.com/c/XinU08ZG/2568-spike-tooling-is-there-a-way-to-automatically-validate-our-markup-for-accessibility-and-semantics)

## Screenshots
<img width="946" alt="Screenshot 2019-09-11 at 17 11 11" src="https://user-images.githubusercontent.com/181371/64714824-354f3d80-d4b7-11e9-94ee-75f5a4df454f.png">
**React-axe output for the Digital Pack product page**
