### PR TITLE
use sbt 1.3 and scala 2.12.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 scala:
-- 2.12.8
+- 2.12.10
 jdk:
 - openjdk8
 sudo: false

--- a/build.sbt
+++ b/build.sbt
@@ -49,8 +49,7 @@ lazy val commonSettings = Seq(
     "scm:git:git@github.com:guardian/support-frontend.git"
   )),
   // https://www.scala-sbt.org/1.x/docs/Cached-Resolution.html
-  updateOptions := updateOptions.value.withCachedResolution(true),
-  ThisBuild / turbo := true
+  updateOptions := updateOptions.value.withCachedResolution(true)
 )
 
 lazy val commonDependencies = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -30,7 +30,7 @@ lazy val release = Seq[ReleaseStep](
 
 lazy val commonSettings = Seq(
   organization := "com.gu",
-  scalaVersion := "2.12.8",
+  scalaVersion := "2.12.10",
   resolvers ++= Seq(Resolver.sonatypeRepo("releases"), Resolver.bintrayRepo("guardian", "ophan")),
   isSnapshot := false,
   publishTo := {
@@ -49,7 +49,8 @@ lazy val commonSettings = Seq(
     "scm:git:git@github.com:guardian/support-frontend.git"
   )),
   // https://www.scala-sbt.org/1.x/docs/Cached-Resolution.html
-  updateOptions := updateOptions.value.withCachedResolution(true)
+  updateOptions := updateOptions.value.withCachedResolution(true),
+  ThisBuild / turbo := true
 )
 
 lazy val commonDependencies = Seq(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.0


### PR DESCRIPTION
## Why are you doing this?

two new updates are out
Sbt 1.3 https://github.com/sbt/sbt/releases/tag/v1.3.0
scala 2.12.10 https://github.com/scala/scala/releases/tag/v2.12.10

SBT has a new turbo mode that keeps the libraryDependencies warm in a classloader so that if you keep running `test` or `run` in the same sbt session it will start much quicker and the usual JIT benefits over time.  It is experiemental though, and seems to cause the support-workers build to hang, so I have removed it again.  It does make things a lot quicker if you keep running `test` locally.

[**Trello Card**](https://trello.com/c/dMbnejd3/2596-try-sbt-130-poss-big-compile-test-performance-improvement)
