### PR TITLE
add new paymentintents gateway to allow reuse

### DIFF
--- a/support-models/src/main/scala/com/gu/support/zuora/api/PaymentGateway.scala
+++ b/support-models/src/main/scala/com/gu/support/zuora/api/PaymentGateway.scala
@@ -20,6 +20,8 @@ object PaymentGateway {
     case StripeGatewayAUD.name => StripeGatewayAUD
     case PayPalGateway.name => PayPalGateway
     case DirectDebitGateway.name => DirectDebitGateway
+    case StripeGatewayPaymentIntentsDefault.name => StripeGatewayPaymentIntentsDefault
+    case StripeGatewayPaymentIntentsAUD.name => StripeGatewayPaymentIntentsAUD
   }
 
   implicit val encoder: Encoder[PaymentGateway] = Encoder.encodeString.contramap[PaymentGateway](_.name)
@@ -35,6 +37,14 @@ case object StripeGatewayDefault extends PaymentGateway {
 
 case object StripeGatewayAUD extends PaymentGateway {
   val name = "Stripe Gateway GNM Membership AUS"
+}
+
+case object StripeGatewayPaymentIntentsDefault extends PaymentGateway {
+  val name = "Stripe PaymentIntents GNM Membership"
+}
+
+case object StripeGatewayPaymentIntentsAUD extends PaymentGateway {
+  val name = "Stripe PaymentIntents GNM Membership AUS"
 }
 
 case object PayPalGateway extends PaymentGateway {


### PR DESCRIPTION
## Why are you doing this?

Now people have stripe paymentintents card details in zuora, after @twrichards updates last week
However it is possible for people to reuse card details, which means that the step functions must pick up the correct gateway together with the card details when fetching the existing account.

Some of this work is already done, to pass through the gatway correctly rather than just assuming the standard stripe gateway (otherwise it would have written incorrect data silently!), however the actual work to add the new gatway names was not present.  This means that when it tried to read the account from zuora, the gatway name was not understood and the lambda threw an error.

This change adds the new payment gateway names so that the step functions can proxy the gateway through for reuse.
