### PR TITLE
Choice architecture round three (product first, static amounts, more options)

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -1,6 +1,7 @@
 // @flow
 import type { Tests } from './abtest';
 import { get as getCookie } from 'helpers/cookie';
+import { SetOne, SetTwo, SetThree } from 'helpers/abTests/data/testAmountsData';
 
 // ----- Tests ----- //
 export type LandingPageCopyReturningSinglesTestVariants = 'control' | 'returningSingle' | 'notintest';
@@ -48,5 +49,40 @@ export const tests: Tests = {
     isActive: window.guardian && window.guardian.stripeElements ? window.guardian.stripeElements : false,
     independent: true,
     seed: 3,
+  },
+
+  // JTL - 5 August 2019 - Ab-test: landingPageChoiceArchitectureAmountsFirst
+  // file used for this test: abTestContributionsLandingChoiceArchitecture.scss
+  // if a variant is successful, we will need to integrate the styles from the test stylesheet
+  // into the main stylesheet: contributionsLanding.scss
+  // This test also involves hardcoded amounts, which will need to be discussed moving forward
+  LandingPageChoiceArchitectureStaticAmounts: {
+    type: 'AMOUNTS',
+    variants: [
+      {
+        id: 'control',
+      },
+      {
+        id: 'setOne',
+        amountsRegions: SetOne,
+      },
+      {
+        id: 'setTwo',
+        amountsRegions: SetTwo,
+      },
+      {
+        id: 'setThree',
+        amountsRegions: SetThree,
+      },
+    ],
+    audiences: {
+      ALL: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: true,
+    independent: true,
+    seed: 4,
   },
 };

--- a/support-frontend/assets/helpers/abTests/data/testAmountsData.js
+++ b/support-frontend/assets/helpers/abTests/data/testAmountsData.js
@@ -1,0 +1,139 @@
+// @flow
+
+const USSetOne = [{ value: '10' }, { value: '15', isDefault: true }, { value: '25' }, { value: '50' }];
+const GBSetOne = [{ value: '2' }, { value: '7', isDefault: true }, { value: '25' }, { value: '50' }];
+const AUSetOne = [{ value: '10' }, { value: '25', isDefault: true }, { value: '50' }, { value: '100' }];
+const EURSetOne = [{ value: '6' }, { value: '15', isDefault: true }, { value: '35' }, { value: '100' }];
+const INTSetOne = [{ value: '5' }, { value: '15', isDefault: true }, { value: '35' }, { value: '100' }];
+const NZSetOne = [{ value: '10' }, { value: '25', isDefault: true }, { value: '50' }, { value: '100' }];
+const CASetOne = [{ value: '5' }, { value: '15', isDefault: true }, { value: '35' }, { value: '100' }];
+
+export const SetOne = {
+  GBPCountries: {
+    ONE_OFF: GBSetOne,
+    MONTHLY: GBSetOne,
+    ANNUAL: GBSetOne,
+  },
+  UnitedStates: {
+    ONE_OFF: USSetOne,
+    MONTHLY: USSetOne,
+    ANNUAL: USSetOne,
+  },
+  EURCountries: {
+    ONE_OFF: EURSetOne,
+    MONTHLY: EURSetOne,
+    ANNUAL: EURSetOne,
+  },
+  AUDCountries: {
+    ONE_OFF: AUSetOne,
+    MONTHLY: AUSetOne,
+    ANNUAL: AUSetOne,
+  },
+  International: {
+    ONE_OFF: INTSetOne,
+    MONTHLY: INTSetOne,
+    ANNUAL: INTSetOne,
+  },
+  NZDCountries: {
+    ONE_OFF: NZSetOne,
+    MONTHLY: NZSetOne,
+    ANNUAL: NZSetOne,
+  },
+  Canada: {
+    ONE_OFF: CASetOne,
+    MONTHLY: CASetOne,
+    ANNUAL: CASetOne,
+  },
+};
+
+const USSetTwo = [{ value: '5' }, { value: '10' }, { value: '15', isDefault: true }, { value: '25' }, { value: '50' }, { value: '75' }, { value: '100' }];
+const GBSetTwo = [{ value: '2' }, { value: '5' }, { value: '7', isDefault: true }, { value: '10' }, { value: '20' }, { value: '50' }, { value: '100' }];
+const AUSetTwo = [{ value: '5' }, { value: '10' }, { value: '15' }, { value: '25', isDefault: true }, { value: '50' }, { value: '75' }, { value: '100' }];
+const EURSetTwo = [{ value: '5' }, { value: '10' }, { value: '15', isDefault: true }, { value: '35' }, { value: '50' }, { value: '75' }, { value: '100' }];
+const INTSetTwo = [{ value: '5' }, { value: '10' }, { value: '15', isDefault: true }, { value: '35' }, { value: '50' }, { value: '75' }, { value: '100' }];
+const NZSetTwo = [{ value: '5' }, { value: '10' }, { value: '15' }, { value: '25', isDefault: true }, { value: '50' }, { value: '75' }, { value: '100' }];
+const CASetTwo = [{ value: '5' }, { value: '10' }, { value: '15', isDefault: true }, { value: '35' }, { value: '50' }, { value: '75' }, { value: '100' }];
+
+export const SetTwo = {
+  GBPCountries: {
+    ONE_OFF: GBSetTwo,
+    MONTHLY: GBSetTwo,
+    ANNUAL: GBSetTwo,
+  },
+  UnitedStates: {
+    ONE_OFF: USSetTwo,
+    MONTHLY: USSetTwo,
+    ANNUAL: USSetTwo,
+  },
+  EURCountries: {
+    ONE_OFF: EURSetTwo,
+    MONTHLY: EURSetTwo,
+    ANNUAL: EURSetTwo,
+  },
+  AUDCountries: {
+    ONE_OFF: AUSetTwo,
+    MONTHLY: AUSetTwo,
+    ANNUAL: AUSetTwo,
+  },
+  International: {
+    ONE_OFF: INTSetTwo,
+    MONTHLY: INTSetTwo,
+    ANNUAL: INTSetTwo,
+  },
+  NZDCountries: {
+    ONE_OFF: NZSetTwo,
+    MONTHLY: NZSetTwo,
+    ANNUAL: NZSetTwo,
+  },
+  Canada: {
+    ONE_OFF: CASetTwo,
+    MONTHLY: CASetTwo,
+    ANNUAL: CASetTwo,
+  },
+};
+
+const USSetThree = [{ value: '5' }, { value: '10' }, { value: '15', isDefault: true }, { value: '25' }, { value: '35' }, { value: '50' }, { value: '75' }, { value: '100' }, { value: '250' }];
+const GBSetThree = [{ value: '2' }, { value: '5' }, { value: '7', isDefault: true }, { value: '10' }, { value: '20' }, { value: '30' }, { value: '50' }, { value: '100' }, { value: '250' }];
+const AUSetThree = [{ value: '5' }, { value: '10' }, { value: '15' }, { value: '25', isDefault: true }, { value: '35' }, { value: '50' }, { value: '75' }, { value: '100' }, { value: '250' }];
+const EURSetThree = [{ value: '5' }, { value: '10' }, { value: '15', isDefault: true }, { value: '25' }, { value: '35' }, { value: '50' }, { value: '75' }, { value: '100' }, { value: '250' }];
+const INTSetThree = [{ value: '5' }, { value: '10' }, { value: '15', isDefault: true }, { value: '25' }, { value: '35' }, { value: '50' }, { value: '75' }, { value: '100' }, { value: '250' }];
+const NZSetThree = [{ value: '5' }, { value: '10' }, { value: '15' }, { value: '25', isDefault: true }, { value: '35' }, { value: '50' }, { value: '75' }, { value: '100' }, { value: '250' }];
+const CASetThree = [{ value: '5' }, { value: '10' }, { value: '15', isDefault: true }, { value: '25' }, { value: '35' }, { value: '50' }, { value: '75' }, { value: '100' }, { value: '250' }];
+
+export const SetThree = {
+  GBPCountries: {
+    ONE_OFF: GBSetThree,
+    MONTHLY: GBSetThree,
+    ANNUAL: GBSetThree,
+  },
+  UnitedStates: {
+    ONE_OFF: USSetThree,
+    MONTHLY: USSetThree,
+    ANNUAL: USSetThree,
+  },
+  EURCountries: {
+    ONE_OFF: EURSetThree,
+    MONTHLY: EURSetThree,
+    ANNUAL: EURSetThree,
+  },
+  AUDCountries: {
+    ONE_OFF: AUSetThree,
+    MONTHLY: AUSetThree,
+    ANNUAL: AUSetThree,
+  },
+  International: {
+    ONE_OFF: INTSetThree,
+    MONTHLY: INTSetThree,
+    ANNUAL: INTSetThree,
+  },
+  NZDCountries: {
+    ONE_OFF: NZSetThree,
+    MONTHLY: NZSetThree,
+    ANNUAL: NZSetThree,
+  },
+  Canada: {
+    ONE_OFF: CASetThree,
+    MONTHLY: CASetThree,
+    ANNUAL: CASetThree,
+  },
+};

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.scss
@@ -573,15 +573,18 @@ form {
 .form__radio-group--pills .form__radio-group-list {
   display: flex;
   flex-wrap: flex-wrap;
+  max-width: 320px;
 }
 
 .form__radio-group--pills .form__radio-group-item {
   width: 50px;
   height: 50px;
+  margin-right: $gu-v-spacing / 2;
+  margin-bottom: $gu-v-spacing / 2;
 }
 
-.form__radio-group--pills .form__radio-group-item + .form__radio-group-item {
-  margin-left: 10px;
+.form__radio-group--pills .form__radio-group-item:last-child {
+  margin-right: 0;
 }
 
 .form__radio-group--pills .form__radio-group-input + .form__radio-group-label {


### PR DESCRIPTION
## Why are you doing this?
We are running a final choice architecture test, informed by earlier tests run this quarter, to see what impact we can have by running larger sets of amounts that remain static across products.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com)

## Changes

* Introduce the amounts
* Come up with a universal style solution with flexbox

## Screenshots
Control, desktop
![choice architecture round thre desktop 0control](https://user-images.githubusercontent.com/3300789/65035921-357d8c00-d942-11e9-8c1a-b01b63310b4b.png)

Set one, desktop
![choice architecture round thre desktop 1setOne](https://user-images.githubusercontent.com/3300789/65035922-357d8c00-d942-11e9-824c-34ecd66f38bd.png)

Set two, desktop
![choice architecture round thre desktop 2setTwo](https://user-images.githubusercontent.com/3300789/65035923-36162280-d942-11e9-9e80-9a05f0c4645b.png)

Set three, desktop
![choice architecture round thre desktop 3setThree](https://user-images.githubusercontent.com/3300789/65035924-36162280-d942-11e9-8983-862582922613.png)

Control, mobile
![choice architecture round thre mobile 0control](https://user-images.githubusercontent.com/3300789/65035926-36162280-d942-11e9-8422-ccc242487758.png)

Set one, mobile
![choice architecture round thre mobile 1setOne](https://user-images.githubusercontent.com/3300789/65035927-36162280-d942-11e9-99a2-1640f5d7101d.png)

Set two, mobile
![choice architecture round thre mobile 2setTwo](https://user-images.githubusercontent.com/3300789/65035928-36162280-d942-11e9-965f-9891557357aa.png)

Set three, mobile
![choice architecture round thre mobile 3setThree](https://user-images.githubusercontent.com/3300789/65035929-36162280-d942-11e9-8bfa-101ce715f2d6.png)