### PR TITLE
Implement open graph image for share links

### DIFF
--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -8,7 +8,7 @@ import cats.implicits._
 import com.gu.i18n.CountryGroup
 import com.gu.i18n.CountryGroup._
 import com.gu.identity.model.{User => IdUser}
-import com.gu.support.config.{PayPalConfigProvider, Stage, Stages, StripeConfigProvider}
+import com.gu.support.config.{PayPalConfig, PayPalConfigProvider, Stage, Stages, StripeConfig, StripeConfigProvider}
 import com.typesafe.scalalogging.StrictLogging
 import config.Configuration.GuardianDomain
 import config.StringsConfig
@@ -22,7 +22,17 @@ import services.{IdentityService, MembersDataService, PaymentAPIService}
 import utils.BrowserCheck
 import utils.FastlyGEOIP._
 import views.{EmptyDiv, Preload}
+
 import scala.concurrent.{ExecutionContext, Future}
+
+case class ContributionsPaymentMethodConfigs(
+  oneOffDefaultStripeConfig: StripeConfig,
+  oneOffUatStripeConfig: StripeConfig,
+  regularDefaultStripeConfig: StripeConfig,
+  regularUatStripeConfig: StripeConfig,
+  regularDefaultPayPalConfig: PayPalConfig,
+  regularUatPayPalConfig: PayPalConfig
+)
 
 class Application(
     actionRefiners: CustomActionBuilders,
@@ -153,12 +163,14 @@ class Application(
       js = js,
       css = css,
       description = stringsConfig.contributionsLandingDescription,
-      oneOffDefaultStripeConfig = oneOffStripeConfigProvider.get(false),
-      oneOffUatStripeConfig = oneOffStripeConfigProvider.get(true),
-      regularDefaultStripeConfig = regularStripeConfigProvider.get(false),
-      regularUatStripeConfig = regularStripeConfigProvider.get(true),
-      regularDefaultPayPalConfig = payPalConfigProvider.get(false),
-      regularUatPayPalConfig = payPalConfigProvider.get(true),
+      paymentMethodConfigs = ContributionsPaymentMethodConfigs(
+        oneOffDefaultStripeConfig = oneOffStripeConfigProvider.get(false),
+        oneOffUatStripeConfig = oneOffStripeConfigProvider.get(true),
+        regularDefaultStripeConfig = regularStripeConfigProvider.get(false),
+        regularUatStripeConfig = regularStripeConfigProvider.get(true),
+        regularDefaultPayPalConfig = payPalConfigProvider.get(false),
+        regularUatPayPalConfig = payPalConfigProvider.get(true),
+      ),
       paymentApiStripeUrl = paymentAPIService.stripeUrl,
       paymentApiPayPalEndpoint = paymentAPIService.payPalCreatePaymentEndpoint,
       existingPaymentOptionsEndpoint = membersDataService.existingPaymentOptionsEndpoint,
@@ -166,7 +178,7 @@ class Application(
       guestAccountCreationToken = guestAccountCreationToken,
       fontLoaderBundle = fontLoaderBundle,
       geoData = geoData,
-      shareImageUrl = ""
+      shareImageUrl = "https://media.guim.co.uk/74b15a65c479bfe53151fceeb7d948f125a66af2/0_0_2400_1260/2000.png"
     )
   }
 

--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -165,7 +165,8 @@ class Application(
       idUser = idUser,
       guestAccountCreationToken = guestAccountCreationToken,
       fontLoaderBundle = fontLoaderBundle,
-      geoData = geoData
+      geoData = geoData,
+      shareImageUrl = ""
     )
   }
 

--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -169,7 +169,7 @@ class Application(
         regularDefaultStripeConfig = regularStripeConfigProvider.get(false),
         regularUatStripeConfig = regularStripeConfigProvider.get(true),
         regularDefaultPayPalConfig = payPalConfigProvider.get(false),
-        regularUatPayPalConfig = payPalConfigProvider.get(true),
+        regularUatPayPalConfig = payPalConfigProvider.get(true)
       ),
       paymentApiStripeUrl = paymentAPIService.stripeUrl,
       paymentApiPayPalEndpoint = paymentAPIService.payPalCreatePaymentEndpoint,

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -26,10 +26,11 @@
   idUser: Option[IdUser],
   guestAccountCreationToken: Option[String],
   fontLoaderBundle: Either[RefPath, StyleContent],
-  geoData: GeoData
+  geoData: GeoData,
+  shareImageUrl: String
 )(implicit assets: AssetsResolver, request: RequestHeader, settings: AllSettings)
 
-@main(title = title, mainJsBundle = js, fontLoaderBundle = fontLoaderBundle, description = description, mainElement = mainElement, mainStyleBundle = css) {
+@main(title = title, mainJsBundle = js, fontLoaderBundle = fontLoaderBundle, description = description, mainElement = mainElement, mainStyleBundle = css, shareImageUrl = Some(shareImageUrl)) {
   <script type="text/javascript">
   window.guardian = window.guardian || {};
   @idUser.map { user =>

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -6,6 +6,7 @@
 @import helper.CSRF
 @import views.{Preload, SSRContent, ReactDiv}
 @import models.GeoData
+@import controllers.ContributionsPaymentMethodConfigs
 
 @(
   title: String,
@@ -14,12 +15,7 @@
   js: Either[RefPath, StyleContent],
   css: Either[RefPath, StyleContent],
   description: Option[String],
-  oneOffDefaultStripeConfig: StripeConfig,
-  oneOffUatStripeConfig: StripeConfig,
-  regularDefaultStripeConfig: StripeConfig,
-  regularUatStripeConfig: StripeConfig,
-  regularDefaultPayPalConfig: PayPalConfig,
-  regularUatPayPalConfig: PayPalConfig,
+  paymentMethodConfigs: ContributionsPaymentMethodConfigs,
   paymentApiStripeUrl: String,
   paymentApiPayPalEndpoint: String,
   existingPaymentOptionsEndpoint: String,
@@ -61,29 +57,29 @@
 
   window.guardian.stripeKeyDefaultCurrencies = {
     ONE_OFF: {
-      default: "@oneOffDefaultStripeConfig.defaultAccount.publicKey",
-      uat: "@oneOffUatStripeConfig.defaultAccount.publicKey"
+      default: "@paymentMethodConfigs.oneOffDefaultStripeConfig.defaultAccount.publicKey",
+      uat: "@paymentMethodConfigs.oneOffUatStripeConfig.defaultAccount.publicKey"
     },
     REGULAR: {
-      default: "@regularDefaultStripeConfig.defaultAccount.publicKey",
-      uat: "@regularUatStripeConfig.defaultAccount.publicKey"
+      default: "@paymentMethodConfigs.regularDefaultStripeConfig.defaultAccount.publicKey",
+      uat: "@paymentMethodConfigs.regularUatStripeConfig.defaultAccount.publicKey"
     }
   };
   window.guardian.stripeKeyAustralia = {
     ONE_OFF: {
-      default: "@oneOffDefaultStripeConfig.forCountry(Some(Country.Australia)).publicKey",
-      uat: "@oneOffUatStripeConfig.forCountry(Some(Country.Australia)).publicKey"
+      default: "@paymentMethodConfigs.oneOffDefaultStripeConfig.forCountry(Some(Country.Australia)).publicKey",
+      uat: "@paymentMethodConfigs.oneOffUatStripeConfig.forCountry(Some(Country.Australia)).publicKey"
     },
     REGULAR: {
-      default: "@regularDefaultStripeConfig.forCountry(Some(Country.Australia)).publicKey",
-      uat: "@regularUatStripeConfig.forCountry(Some(Country.Australia)).publicKey"
+      default: "@paymentMethodConfigs.regularDefaultStripeConfig.forCountry(Some(Country.Australia)).publicKey",
+      uat: "@paymentMethodConfigs.regularUatStripeConfig.forCountry(Some(Country.Australia)).publicKey"
     }
   };
   window.guardian.stripeKeyUnitedStates = {
     @if(settings.switches.experiments.get("usStripeAccountForSingle").exists(_.isOn)) {
         ONE_OFF: {
-            default: "@oneOffDefaultStripeConfig.forCountry(Some(Country.US)).publicKey",
-            uat: "@oneOffUatStripeConfig.forCountry(Some(Country.US)).publicKey"
+            default: "@paymentMethodConfigs.oneOffDefaultStripeConfig.forCountry(Some(Country.US)).publicKey",
+            uat: "@paymentMethodConfigs.oneOffUatStripeConfig.forCountry(Some(Country.US)).publicKey"
         },
     } else {
       ONE_OFF: window.guardian.stripeKeyDefaultCurrencies.ONE_OFF,
@@ -91,11 +87,11 @@
     REGULAR: window.guardian.stripeKeyDefaultCurrencies.REGULAR
   };
   window.guardian.payPalEnvironment = {
-    default: "@regularDefaultPayPalConfig.payPalEnvironment",
-    uat: "@regularUatPayPalConfig.payPalEnvironment"
+    default: "@paymentMethodConfigs.regularDefaultPayPalConfig.payPalEnvironment",
+    uat: "@paymentMethodConfigs.regularUatPayPalConfig.payPalEnvironment"
   };
   window.guardian.paymentApiStripeUrl = "@paymentApiStripeUrl";
-  window.guardian.paymentApiPayPalEndpoint = "@paymentApiPayPalEndpoint";
+window.guardian.paymentApiPayPalEndpoint = "@paymentApiPayPalEndpoint";
   window.guardian.existingPaymentOptionsEndpoint = "@existingPaymentOptionsEndpoint";
   window.guardian.csrf = { token: "@CSRF.getToken.value" };
 

--- a/support-frontend/app/views/main.scala.html
+++ b/support-frontend/app/views/main.scala.html
@@ -36,6 +36,12 @@
       <meta property="og:description" content="@definedDescription" />
     }
 
+    @shareImageUrl.map { imageUrl =>
+      <meta property="twitter:image" content="@imageUrl" />
+      <meta property="og:image" content="@imageUrl" />
+      <meta property="og:image:secure_url" content="@imageUrl" />
+    }
+
     @canonicalLink.map { definedCanonicalLink =>
       <link rel="canonical" href="@definedCanonicalLink" />
     }

--- a/support-frontend/app/views/main.scala.html
+++ b/support-frontend/app/views/main.scala.html
@@ -12,6 +12,7 @@
   canonicalLink: Option[String] = None,
   hrefLangLinks: Map[String, String] = Map(),
   csrf: Option[String] = None,
+  shareImageUrl: Option[String] = None,
 )(body: Html = Html(""))(implicit assets: AssetsResolver, request: RequestHeader, settings: AllSettings)
 
 <!DOCTYPE html>
@@ -29,7 +30,7 @@
         }
       </script>
     }
-    
+
     @description.map { definedDescription =>
       <meta name="description" content="@definedDescription" />
       <meta property="og:description" content="@definedDescription" />


### PR DESCRIPTION
## Why are you doing this?
We'd like to make our shared content more compelling by using an image. In order to make that happen, we had to slightly refactor the twirl templates as there is a maximum number of parameters that be used in a given template (22).

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/nSR1mo9D/1477-implement-general-social-share-image)
[**Related Trello Card**](https://trello.com/c/qTfXo0B1/1424-moment-social-sharing)

## Changes

* implemented the open graph tags
* refactored the twirl template to accept a new parameter

## Screenshots
**screenshots to come - this needs to go live first so we can tell facebook and twitter to purge their current information about the site and use this new header to construct their cards**
