### PR TITLE
Restructure product cards

### DIFF
--- a/support-frontend/assets/components/productOption/productOption.jsx
+++ b/support-frontend/assets/components/productOption/productOption.jsx
@@ -19,8 +19,6 @@ type WrappedProps = {
 
 type ProductOptionType = {
   children: Node,
-  onClick: Function,
-  href: string
 }
 
 type ProductOptionOfferType = {
@@ -62,8 +60,8 @@ export const ProductOptionOffer = ({ children, hidden }: ProductOptionOfferType)
 
 export const ProductOptionButton = withProductOptionsStyle(AnchorButton);
 
-const ProductOption = ({ onClick, href, children }: ProductOptionType) => (
-  <a href={href} onClick={onClick} className="product-option">{ children }</a>
+const ProductOption = ({ children }: ProductOptionType) => (
+  <div className="product-option">{ children }</div>
 );
 
 // default props

--- a/support-frontend/assets/components/productOption/productOption.scss
+++ b/support-frontend/assets/components/productOption/productOption.scss
@@ -3,7 +3,9 @@
 
 .product-option {
   box-sizing: border-box;
-  display: block;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
   width: 100%;
   background-color: gu-colour(neutral-100);
   border: 1px solid gu-colour(neutral-86);
@@ -15,6 +17,7 @@
 
   & * {
     box-sizing: border-box;
+    z-index: 2;
   }
 
   &:hover,
@@ -39,7 +42,7 @@
   position: relative;
 
   @include mq(tablet) {
-    font-size: 20px;
+    font-size: 28px;
   }
 
   @include mq($from: desktop) {
@@ -56,7 +59,12 @@
 .product-option__price {
   font-family: $gu-headline;
   font-weight: bold;
-  font-size: 40px;
+  font-size: 32px;
+
+  @include mq(tablet) {
+    font-size: 40px;
+  }
+
 }
 
 .product-option__price-detail {
@@ -103,7 +111,8 @@
   padding: 6px 6px 15px 0;
 
   .component-button {
-    margin-top: 35px;
+    position: static;
+    margin-top: 20px;
     width: 100%;
     max-width: 210px;
     
@@ -113,6 +122,14 @@
       right: 0;
       bottom: 0;
       left: 0;
+      content: '';
+      z-index: 1;
+    }
+  }
+
+  @include mq($from: tablet) {
+    .component-button {
+      margin-top: 35px;
     }
   }
 
@@ -161,11 +178,12 @@
   top: 1px;
   transform: translateY(-100%);
   text-align: center;
-  padding: 0 4px;
+  padding: 0 5px;
   background: gu-colour(neutral-7);
   font-family: $gu-headline;
   font-weight: bold;
   font-size: 16px;
+  line-height: 1.4;
   color: #fff;
 }
 

--- a/support-frontend/assets/components/productOption/productOption.scss
+++ b/support-frontend/assets/components/productOption/productOption.scss
@@ -93,7 +93,7 @@
 
 .product-option__offer-container {
   border-top: 1px solid gu-colour(neutral-86);
-  padding: 6px 24px 0 0;
+  padding: 4px 24px 0 0;
 }
 
 .product-option__offer {
@@ -112,7 +112,7 @@
 
   .component-button {
     position: static;
-    margin-top: 20px;
+    margin-top: 15px;
     width: 100%;
     max-width: 210px;
     
@@ -124,12 +124,6 @@
       left: 0;
       content: '';
       z-index: 1;
-    }
-  }
-
-  @include mq($from: tablet) {
-    .component-button {
-      margin-top: 35px;
     }
   }
 
@@ -149,11 +143,14 @@
   font-size: 16px;
   line-height: 1.4rem;
 
-  & > span {
-    display: flex;
-    align-items: flex-start;
+  & span {
+    display: block;
     width: 100%;
   }
+}
+
+.product-option__price-detail {
+  padding: 12px 0 0 0;
 }
 
 .product-option__full-screen-break {
@@ -174,11 +171,11 @@
 
 .product-option__label {
   position: absolute;
-  right: 0;
+  left: 0;
   top: 1px;
   transform: translateY(-100%);
   text-align: center;
-  padding: 0 5px;
+  padding: 0 25px;
   background: gu-colour(neutral-7);
   font-family: $gu-headline;
   font-weight: bold;

--- a/support-frontend/assets/components/productOption/productOption.scss
+++ b/support-frontend/assets/components/productOption/productOption.scss
@@ -131,9 +131,10 @@
 .product-option__label {
   position: absolute;
   right: 0;
-  top: -10px;
+  top: 1px;
+  transform: translateY(-100%);
   text-align: center;
-  padding: 2px 4px;
+  padding: 0 4px;
   background: gu-colour(neutral-7);
   font-family: $gu-headline;
   font-weight: bold;

--- a/support-frontend/assets/components/productOption/productOption.scss
+++ b/support-frontend/assets/components/productOption/productOption.scss
@@ -13,42 +13,54 @@
   text-decoration: none;
   color: gu-colour(neutral-7);
 
-  &:hover {
+  & * {
+    box-sizing: border-box;
+  }
+
+  &:hover,
+  &:focus {
     box-shadow: 0px 2px 10px 0px rgba(153,153,153,0.3);
     border: 1px solid gu-colour(neutral-60);
     .product-option__button {
       .component-button--primary {
         background-color: gu-colour(highlight-dark);
+        
+        .svg-arrow-right-straight {
+          transform: translateX(20%);
+        }
       }
     }
   }
 }
 
 .product-option__title {
-  @include gu-fontset-heading-sans;
-  margin-bottom: 10px;
+  @include gu-fontset-heading;
+  margin-bottom: 24px;
   position: relative;
-  transition: .2s background;
 
   @include mq(tablet) {
     font-size: 20px;
   }
 
   @include mq($from: desktop) {
-    font-size: 26px;
+    font-size: 28px;
   }
 }
 
 .product-option__content {
   // padding: 15px 24px;
-  padding: 15px 24px 15px 0;
+  padding: 6px 0 15px 0;
   margin-left: 24px;
 }
 
 .product-option__price {
-  @include gu-fontset-body-sans;
-  font-size: 36px;
-  font-weight: 600;
+  font-family: $gu-headline;
+  font-weight: bold;
+  font-size: 40px;
+}
+
+.product-option__price-detail {
+  padding: 0 0 0 10px;
 }
 
 .product-option__copy {
@@ -72,7 +84,8 @@
 }
 
 .product-option__offer-container {
-  margin-top: 15px;
+  border-top: 1px solid gu-colour(neutral-86);
+  padding: 6px 24px 0 0;
 }
 
 .product-option__offer {
@@ -87,12 +100,20 @@
 .product-option__button {
   border-top: 1px solid gu-colour(neutral-86);
   margin-left: 24px;
-  padding: 15px 24px 15px 0;
+  padding: 6px 6px 15px 0;
 
   .component-button {
-    margin-top: 20px;
+    margin-top: 35px;
     width: 100%;
     max-width: 210px;
+    
+    &:after {
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+    }
   }
 
 }
@@ -110,6 +131,12 @@
   font-family: $gu-text-sans-web;
   font-size: 16px;
   line-height: 1.4rem;
+
+  & > span {
+    display: flex;
+    align-items: flex-start;
+    width: 100%;
+  }
 }
 
 .product-option__full-screen-break {

--- a/support-frontend/assets/components/productOption/productOption.scss
+++ b/support-frontend/assets/components/productOption/productOption.scss
@@ -40,7 +40,9 @@
 }
 
 .product-option__content {
-  padding: 15px 24px;
+  // padding: 15px 24px;
+  padding: 15px 24px 15px 0;
+  margin-left: 24px;
 }
 
 .product-option__price {
@@ -74,12 +76,12 @@
 }
 
 .product-option__offer {
-  padding: 5px;
+  @include gu-fontset-body-sans;
+  padding: 5px 0;
   margin-top: 20px;
-  background: gu-colour(highlight-main);
   color: gu-colour(neutral-7);
   line-height: 1.4;
-  @include gu-fontset-body-sans;
+  font-weight: bold;
 }
 
 .product-option__button {
@@ -124,5 +126,18 @@
   @include mq($from: mobileLandscape) {
     display: block;
   }
+}
+
+.product-option__label {
+  position: absolute;
+  right: 0;
+  top: -10px;
+  text-align: center;
+  padding: 2px 4px;
+  background: gu-colour(neutral-7);
+  font-family: $gu-headline;
+  font-weight: bold;
+  font-size: 16px;
+  color: #fff;
 }
 

--- a/support-frontend/assets/components/productPage/productPageHero/productPageHero.scss
+++ b/support-frontend/assets/components/productPage/productPageHero/productPageHero.scss
@@ -84,6 +84,6 @@
   margin: 0;
 
   @include mq($from: tablet) {
-    margin-top: -95px;
+    margin-top: -60px;
   }
 }

--- a/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
@@ -274,7 +274,7 @@ function CampaignHeader(props: PropTypes) {
           <h2 className="payment-selection__title">
           Choose one of our special offers and subscribe today
           </h2>
-          <p className="payment-selection_cancel-text">You can cancel your subscription at any time</p>
+          <p className="payment-selection_cancel-text">Start your 14 day free trial <br /> You can cancel your subscription at any time</p>
         </div>
 
         {showCountdownTimer(product, props.countryGroupId) &&

--- a/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
@@ -274,7 +274,7 @@ function CampaignHeader(props: PropTypes) {
           <h2 className="payment-selection__title">
           Choose one of our special offers and subscribe today
           </h2>
-          <p className="payment-selection_cancel-text">Start your 14 day free trial <br /> You can cancel your subscription at any time</p>
+          <p className="payment-selection_cancel-text">After your 14-day free trial, your subscription will begin automatically and you can cancel any time</p>
         </div>
 
         {showCountdownTimer(product, props.countryGroupId) &&

--- a/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
@@ -272,8 +272,9 @@ function CampaignHeader(props: PropTypes) {
 
         <div className="payment-selection__title-container" >
           <h2 className="payment-selection__title">
-            The Premium App and the Daily Edition iPad app in one pack, plus ad-free reading on all your devices
+          Choose one of our special offers and subscribe today
           </h2>
+          <p className="payment-selection_cancel-text">You can cancel your subscription at any time</p>
         </div>
 
         {showCountdownTimer(product, props.countryGroupId) &&

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/__tests__/paymentSelectionTests.js
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/__tests__/paymentSelectionTests.js
@@ -74,7 +74,7 @@ describe('PaymentSelection', () => {
     const BillingPeriod = 'Monthly';
     const currencyId = 'GBP';
 
-    expect(getProductPrice(productOptions, BillingPeriod, currencyId)).toBe(17.99);
+    expect(getProductPrice(productOptions, BillingPeriod, currencyId).price).toBe(17.99);
   });
 
   it('should return saving percentage', () => {

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
@@ -83,7 +83,7 @@ const BILLING_PERIOD = {
         :
         <span>
           <span className="product-option__price">{display(displayPrice)}</span>
-          <span className="product-option__price-detail">equivalent of {display(displayPrice / 12)}/month</span>
+          <span className="product-option__price-detail">{display(displayPrice / 12)}/month</span>
         </span>;
     },
     offer: 'Save an additional 21%',

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
@@ -59,13 +59,13 @@ const BILLING_PERIOD = {
       const display = price => getDisplayPrice(currencyId, price);
       return promotionalPrice ?
         <span>
-          <strong>
-            {display(promotionalPrice)}
-          </strong> then {display(displayPrice)}/month
+          <span className="product-option__price">{display(promotionalPrice)}</span>
+          <span className="product-option__price-detail">then {display(displayPrice)}/month</span>
         </span>
         :
         <span>
-          14 day free trial, then <strong>{display(displayPrice)}</strong>
+          <span className="product-option__price">{display(displayPrice)}</span>
+          <span className="product-option__price-detail">14 day free trial</span>
         </span>;
     },
     offer: 'null',
@@ -77,15 +77,13 @@ const BILLING_PERIOD = {
       const display = price => getDisplayPrice(currencyId, price);
       return promotionalPrice ?
         <span>
-          <strong>
-            {display(promotionalPrice)}
-          </strong> then {display(displayPrice)}/year
+          <span className="product-option__price">{display(promotionalPrice)}</span>
+          <span className="product-option__price-detail">then {display(displayPrice)}/year</span>
         </span>
         :
         <span>
-          <strong>
-            {display(displayPrice)}
-          </strong> equivalent of {display(displayPrice / 12)}/month
+          <span className="product-option__price">{display(displayPrice)}</span>
+          <span className="product-option__price-detail">equivalent of {display(displayPrice / 12)}/month</span>
         </span>;
     },
     offer: 'Save an additional 21% - Best Deal',

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
@@ -69,7 +69,7 @@ const BILLING_PERIOD = {
         </span>;
     },
     offer: null,
-    label: 'Popular',
+    label: null,
   },
   [Annual]: {
     title: 'Annual',
@@ -86,8 +86,8 @@ const BILLING_PERIOD = {
           <span className="product-option__price-detail">equivalent of {display(displayPrice / 12)}/month</span>
         </span>;
     },
-    offer: 'Save an additional 21% - Best Deal',
-    label: null,
+    offer: 'Save an additional 21%',
+    label: 'Best Deal',
   },
 };
 

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
@@ -68,7 +68,7 @@ const BILLING_PERIOD = {
           <span className="product-option__price-detail">14 day free trial</span>
         </span>;
     },
-    offer: 'null',
+    offer: null,
     label: 'Popular',
   },
   [Annual]: {

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
@@ -56,7 +56,7 @@ const BILLING_PERIOD = {
   [Monthly]: {
     title: 'Monthly',
     salesCopy: (currencyId: IsoCurrency, displayPrice: number, promotionalPrice: Option<number>) => {
-      const display = (price) => getDisplayPrice(currencyId, price);
+      const display = price => getDisplayPrice(currencyId, price);
       return promotionalPrice ?
         <span>
           <strong>
@@ -66,15 +66,15 @@ const BILLING_PERIOD = {
         :
         <span>
           14 day free trial, then <strong>{display(displayPrice)}</strong>
-        </span>
+        </span>;
     },
-    offer: null,
+    offer: 'null',
     label: 'Popular',
   },
   [Annual]: {
     title: 'Annual',
     salesCopy: (currencyId: IsoCurrency, displayPrice: number, promotionalPrice: Option<number>) => {
-      const display = (price) => getDisplayPrice(currencyId, price);
+      const display = price => getDisplayPrice(currencyId, price);
       return promotionalPrice ?
         <span>
           <strong>
@@ -86,7 +86,7 @@ const BILLING_PERIOD = {
           <strong>
             {display(displayPrice)}
           </strong> equivalent of {display(displayPrice / 12)}/month
-        </span>
+        </span>;
     },
     offer: 'Save an additional 21% - Best Deal',
     label: null,

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
@@ -55,37 +55,39 @@ export const getSavingPercentage = (annualCost: number, monthlyCostAnnualized: n
 const BILLING_PERIOD = {
   [Monthly]: {
     title: 'Monthly',
-    salesCopy: (currencyId: IsoCurrency, displayPrice: number, promotionalPrice: Option<number>) => (
-      promotionalPrice ?
+    salesCopy: (currencyId: IsoCurrency, displayPrice: number, promotionalPrice: Option<number>) => {
+      const display = (price) => getDisplayPrice(currencyId, price);
+      return promotionalPrice ?
         <span>
           <strong>
-            {getDisplayPrice(currencyId, promotionalPrice)}
-          </strong> then {getDisplayPrice(currencyId, displayPrice)}/month
+            {display(promotionalPrice)}
+          </strong> then {display(displayPrice)}/month
         </span>
         :
         <span>
-          14 day free trial, then <strong>{getDisplayPrice(currencyId, displayPrice)}</strong>
+          14 day free trial, then <strong>{display(displayPrice)}</strong>
         </span>
-    ),
+    },
     offer: null,
     label: 'Popular',
   },
   [Annual]: {
     title: 'Annual',
-    salesCopy: (currencyId: IsoCurrency, displayPrice: number, promotionalPrice: Option<number>) => (
-      promotionalPrice ?
+    salesCopy: (currencyId: IsoCurrency, displayPrice: number, promotionalPrice: Option<number>) => {
+      const display = (price) => getDisplayPrice(currencyId, price);
+      return promotionalPrice ?
         <span>
           <strong>
-            {getDisplayPrice(currencyId, promotionalPrice)}
-          </strong> then {getDisplayPrice(currencyId, displayPrice)}/year
+            {display(promotionalPrice)}
+          </strong> then {display(displayPrice)}/year
         </span>
         :
         <span>
           <strong>
-            {getDisplayPrice(currencyId, displayPrice)}
-          </strong> equivalent of {getDisplayPrice(currencyId, displayPrice / 12)}/month
+            {display(displayPrice)}
+          </strong> equivalent of {display(displayPrice / 12)}/month
         </span>
-    ),
+    },
     offer: 'Save an additional 21% - Best Deal',
     label: null,
   },

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.jsx
@@ -26,6 +26,7 @@ const PaymentSelection = ({ paymentOptions }: PropTypes) => (
     {
         (paymentOptions.map(paymentOption => (
           <div className="payment-selection__card">
+            <span>{paymentOption.label}</span>
             <ProductOption
               href={paymentOption.href}
               onClick={paymentOption.onClick}
@@ -33,9 +34,9 @@ const PaymentSelection = ({ paymentOptions }: PropTypes) => (
               <ProductOptionContent>
                 <ProductOptionTitle>{paymentOption.title}</ProductOptionTitle>
                 <ProductOptionOffer
-                  hidden={paymentOption.title === 'Monthly'}
+                  hidden={!paymentOption.offer}
                 >
-                    Save {paymentOption.offer}
+                  {paymentOption.offer}
                 </ProductOptionOffer>
               </ProductOptionContent>
               <ProductOptionButton

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.jsx
@@ -48,7 +48,6 @@ const PaymentSelection = ({ paymentOptions }: PropTypes) => (
           </div>
         )))
       }
-    <p className="payment-selection_cancel-text">You can cancel your subscription at any time</p>
   </div>
 );
 

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.jsx
@@ -26,7 +26,7 @@ const PaymentSelection = ({ paymentOptions }: PropTypes) => (
     {
         (paymentOptions.map(paymentOption => (
           <div className="payment-selection__card">
-            <span>{paymentOption.label}</span>
+            <span className="product-option__label">{paymentOption.label}</span>
             <ProductOption>
               <ProductOptionContent>
                 <ProductOptionTitle>{paymentOption.title}</ProductOptionTitle>

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.jsx
@@ -27,10 +27,7 @@ const PaymentSelection = ({ paymentOptions }: PropTypes) => (
         (paymentOptions.map(paymentOption => (
           <div className="payment-selection__card">
             <span>{paymentOption.label}</span>
-            <ProductOption
-              href={paymentOption.href}
-              onClick={paymentOption.onClick}
-            >
+            <ProductOption>
               <ProductOptionContent>
                 <ProductOptionTitle>{paymentOption.title}</ProductOptionTitle>
                 <ProductOptionOffer

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.scss
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.scss
@@ -3,7 +3,6 @@
 .payment-selection {
   display: flex;
   flex-wrap: wrap;
-  // justify-content: center;
   margin: -80px 0 24px;
 
   @include mq($from: phablet) {

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.scss
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.scss
@@ -21,12 +21,13 @@
 }
 
 .payment-selection__card {
+  position: relative;
   width: 100%;
   display: flex;
   margin: 10px;
 
   @include mq($from: tablet) {
-    margin: 0 10px 0 0;
+    margin: 0;
     max-width: 30rem;
     width: 320px;
   }
@@ -36,7 +37,7 @@
   margin: 0 10px 20px 10px;
 
   @include mq($from: tablet) {
-    margin: 0 20px;
+    margin: 0 0 0 20px;
   }
 }
 

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.scss
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.scss
@@ -4,7 +4,7 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
-  margin-top: -100px;
+  margin: -80px 0 24px;
 
   @include mq($from: phablet) {
     justify-content: left;
@@ -23,6 +23,7 @@
 .payment-selection__card {
   position: relative;
   width: 100%;
+  max-width: 32.5rem;
   display: flex;
   margin: 10px;
 
@@ -42,12 +43,7 @@
 }
 
 .payment-selection_cancel-text {
-  width: 100%;
   @include gu-fontset-body-sans;
-  font-style: italic;
-  margin: 0 10px;
-
-  @include mq($from: tablet) {
-    margin: 20px 0 0 0;
-  }
+  width: 100%;
+  margin: 10px 0 0 0;
 }

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.scss
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.scss
@@ -3,7 +3,7 @@
 .payment-selection {
   display: flex;
   flex-wrap: wrap;
-  justify-content: center;
+  // justify-content: center;
   margin: -80px 0 24px;
 
   @include mq($from: phablet) {
@@ -35,7 +35,7 @@
 }
 
 .payment-selection__card:last-of-type {
-  margin: 0 10px 20px 10px;
+  margin: 30px 10px 20px 10px;
 
   @include mq($from: tablet) {
     margin: 0 0 0 20px;

--- a/support-frontend/assets/pages/digital-subscription-landing/components/productBlockB/productBlockB.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/productBlockB/productBlockB.jsx
@@ -64,6 +64,12 @@ const ProductBlockRightContent = ({ children }: ChildProps) => (
   </div>
 );
 
+const ProductBlockRoundel = ({ children }: ChildProps) => (
+  <div className="product-block__roundel">
+    { children }
+  </div>
+);
+
 function ProductBlockB() {
   return (
     <div className="product-block product-block--margin">
@@ -126,6 +132,7 @@ function ProductBlockB() {
           </ProductBlockSubTitleText>
 
           <ProductBlockRightContent>
+            <ProductBlockRoundel><p>Available soon on all devices</p></ProductBlockRoundel>
             <GridImage
               gridId="editionsProductBlock"
               srcSizes={[1000, 500, 140]}

--- a/support-frontend/assets/pages/digital-subscription-landing/components/productBlockB/productBlockB.scss
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/productBlockB/productBlockB.scss
@@ -162,8 +162,6 @@ $content-padding: 10px;
   margin-top: 2px;
 }
 
-// This is a override for "#digital-subscription-landing-page-int .product-block .component-grid-image"
-// #digital-subscription-landing-page-int
 .product-block #product-block__right-content img.component-grid-image {
   width: 100%;
 }

--- a/support-frontend/assets/pages/digital-subscription-landing/components/productBlockB/productBlockB.scss
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/productBlockB/productBlockB.scss
@@ -116,24 +116,38 @@ $content-padding: 10px;
 }
 
 .product-block__right-content {
+  position: relative;
   padding:0 $content-padding 30px $content-padding;
-  max-width: 32.5rem;
 
-  @include mq($from: tablet) {
-    padding-right: 80px;
+  @include mq($from: phablet) {
+    max-width: 32.5rem;
   }
+  @include mq($from: desktop) {
+    padding-right: 80px;
+    max-width: 50%;
+  }
+  @include mq($from: wide) {
+    max-width: 32.5rem;
+  }
+
 }
 
 .product-block__left-content {
   display: flex;
   flex-wrap: wrap;
-  width: 32.5rem;
   padding: 0 $content-padding 30px;
 
-  @include mq($from: tablet) {
+  @include mq($from: phablet) {
+    max-width: 32.5rem;
+  }
+  @include mq($from: desktop) {
+    max-width: 50%;
     .component-list-ul {
       padding-right: 80px;
     }
+  }
+  @include mq($from: wide) {
+    max-width: 32.5rem;
   }
 }
 
@@ -149,15 +163,50 @@ $content-padding: 10px;
 }
 
 // This is a override for "#digital-subscription-landing-page-int .product-block .component-grid-image"
-#digital-subscription-landing-page-int
-.product-block #product-block__right-content
-img.component-grid-image {
+// #digital-subscription-landing-page-int
+.product-block #product-block__right-content img.component-grid-image {
   width: 100%;
 }
 
 .component-left-margin-section__content {
   width: 100px;
 }
+
+.product-block__roundel {
+  position: absolute;
+  top: -1.5rem;
+  right: -0.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 110px;
+  height: 110px;
+  background: gu-colour(highlight-main);
+  border-radius: 50%;
+  padding: 10px;
+  
+  @include mq($from: phablet) {
+    top: -2.2rem;
+    right: -1rem;
+    width: 125px;
+    height: 125px;
+  }
+  @include mq($from: desktop) {
+    right: 2.2rem;
+  }
+}
+
+.product-block__roundel p {
+  font-family: $gu-headline;
+  font-weight: bold;
+  font-size: 16px;
+  text-align: center;
+  line-height: 1.2;
+
+  @include mq($from: phablet) {
+    font-size: 18px;
+  }
+} 
 
 // this is a hack to override the left border on the .component-left-margin-section__content because the new design calls this to start at desktop instead of the leftCol breakpoint
 #digital-subscription-landing-page-int,

--- a/support-frontend/assets/pages/digital-subscription-landing/components/theMoment.scss
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/theMoment.scss
@@ -270,6 +270,7 @@
   font-family: $gu-headline;
   font-weight: 600;
   font-size: 18px;
+  line-height: 1.3;
 
   @include mq($from: tablet) {
     font-size: 24px;


### PR DESCRIPTION
## Why are you doing this?

 This PR updates the pricing card style, adds a roundel and makes the pricing cards aware of applied promotions.

[**Trello Card**](https://trello.com/c/ZnyA5qp2/2601-brand-campaign-update-the-current-dp-page-checkout-with-new-pricing-option-for-23rd-sep)

## Changes

* Add roundel
* Update pricing card style

## Screenshots

**Cards - Before**
![Picture 194](https://user-images.githubusercontent.com/1108991/65313382-2be76480-db8c-11e9-846b-5b90d174d856.png)

**Cards - After**
![Picture 197](https://user-images.githubusercontent.com/1108991/65313475-520d0480-db8c-11e9-910f-cd15759d3d0d.png)

**No roundel**
![Picture 195](https://user-images.githubusercontent.com/1108991/65313507-5f29f380-db8c-11e9-98b2-d53ec6cbdfc3.png)

**Now with roundel**
![Picture 196](https://user-images.githubusercontent.com/1108991/65313531-681ac500-db8c-11e9-9654-4ac8cae9926c.png)


