### PR TITLE
support workers read details from stripe in SCA mode if requested

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -32,3 +32,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.4.1")
 // needed for riffraff as it uses AWS S3 SDK 1.11 which uses some base64 methods that were removed in JDK11
 // this is not needed for the current build server, but it is a good reason to move to AWS SDK v2
 libraryDependencies += "javax.xml.bind" % "jaxb-api" % "2.3.1"
+
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -32,5 +32,3 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.4.1")
 // needed for riffraff as it uses AWS S3 SDK 1.11 which uses some base64 methods that were removed in JDK11
 // this is not needed for the current build server, but it is a good reason to move to AWS SDK v2
 libraryDependencies += "javax.xml.bind" % "jaxb-api" % "2.3.1"
-
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")

--- a/support-frontend/app/utils/CheckoutValidationRules.scala
+++ b/support-frontend/app/utils/CheckoutValidationRules.scala
@@ -29,7 +29,7 @@ object SimpleCheckoutFormValidation {
   private def noEmptyPaymentFields(paymentFields: PaymentFields): Boolean = paymentFields match {
     case directDebitDetails: DirectDebitPaymentFields =>
       !directDebitDetails.accountHolderName.isEmpty && !directDebitDetails.accountNumber.isEmpty && !directDebitDetails.sortCode.isEmpty
-    case stripeDetails: StripePaymentMethodPaymentFields => !stripeDetails.paymentMethod.isEmpty
+    case _: StripePaymentMethodPaymentFields => true // already validated in PaymentMethodId.apply
     case stripeDetails: StripeSourcePaymentFields => !stripeDetails.stripeToken.isEmpty
     case payPalDetails: PayPalPaymentFields => !payPalDetails.baid.isEmpty
     case existingDetails: ExistingPaymentFields => !existingDetails.billingAccountId.isEmpty

--- a/support-frontend/test/utils/CheckoutValidationRulesTest.scala
+++ b/support-frontend/test/utils/CheckoutValidationRulesTest.scala
@@ -99,11 +99,6 @@ class DigitalPackValidationTest extends FlatSpec with Matchers {
     DigitalPackValidation.passes(requestMissingPostcode) shouldBe true
   }
 
-  it should "fail if the payment method payment field received is an empty string" in {
-    val requestMissingState = validDigitalPackRequest.copy(paymentFields = StripePaymentMethodPaymentFields(""))
-    DigitalPackValidation.passes(requestMissingState) shouldBe false
-  }
-
   it should "fail if the source payment field received is an empty string" in {
     val requestMissingState = validDigitalPackRequest.copy(paymentFields = StripeSourcePaymentFields(""))
     DigitalPackValidation.passes(requestMissingState) shouldBe false
@@ -187,7 +182,7 @@ object TestData {
     lastName = "hopper",
     product = DigitalPack(Currency.USD, Monthly),
     firstDeliveryDate = None,
-    paymentFields = StripePaymentMethodPaymentFields("test-token"),
+    paymentFields = StripePaymentMethodPaymentFields(PaymentMethodId("test_token").get),
     ophanIds = OphanIds(None, None, None),
     referrerAcquisitionData = ReferrerAcquisitionData(None, None, None, None, None, None, None, None, None, None, None, None),
     supportAbTests = Set(),
@@ -225,7 +220,7 @@ object TestData {
     lastName = "hopper",
     product = Paper(Currency.GBP, Monthly, HomeDelivery, Everyday),
     firstDeliveryDate = Some(someDateNextMonth),
-    paymentFields = StripePaymentMethodPaymentFields("test-token"),
+    paymentFields = StripePaymentMethodPaymentFields(PaymentMethodId("test_token").get),
     ophanIds = OphanIds(None, None, None),
     referrerAcquisitionData = ReferrerAcquisitionData(None, None, None, None, None, None, None, None, None, None, None, None),
     supportAbTests = Set(),

--- a/support-models/src/main/scala/com/gu/support/workers/PaymentFields.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/PaymentFields.scala
@@ -18,13 +18,14 @@ case class StripePaymentMethodPaymentFields(paymentMethod: PaymentMethodId) exte
 
 object PaymentMethodId {
 
-  def apply(value: String): Option[PaymentMethodId] ={ println(s"value: $value")
-    if (value.forall { char =>
-      (char >= 'a' && char <= 'z') ||
-        (char >= 'A' && char <= 'Z') ||
-        (char >= '0' && char <= '9') ||
-        char == '_'
-    }) Some(new PaymentMethodId(value)) else None}
+  def apply(value: String): Option[PaymentMethodId] =
+    if (value.nonEmpty &&
+      value.forall { char =>
+        (char >= 'a' && char <= 'z') ||
+          (char >= 'A' && char <= 'Z') ||
+          (char >= '0' && char <= '9') ||
+          char == '_'
+      }) Some(new PaymentMethodId(value)) else None
 
   implicit val decoder: Decoder[PaymentMethodId] = Decoder.decodeString.emap { str =>
     apply(str).toRight(s"PaymentMethodId $str had invalid characters")

--- a/support-models/src/main/scala/com/gu/support/workers/PaymentFields.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/PaymentFields.scala
@@ -1,18 +1,39 @@
 package com.gu.support.workers
 
+import cats.syntax.functor._
 import com.gu.support.encoding.Codec
 import com.gu.support.encoding.Codec.deriveCodec
-import io.circe.{Decoder, Encoder}
+import io.circe.{Encoder, _}
 import io.circe.syntax._
-import cats.syntax.functor._
 
 sealed trait PaymentFields
 
+
 case class PayPalPaymentFields(baid: String) extends PaymentFields
+
 
 sealed trait StripePaymentFields extends PaymentFields
 case class StripeSourcePaymentFields(stripeToken: String) extends StripePaymentFields // pre SCA compatibility
-case class StripePaymentMethodPaymentFields(paymentMethod: String) extends StripePaymentFields
+case class StripePaymentMethodPaymentFields(paymentMethod: PaymentMethodId) extends StripePaymentFields
+
+object PaymentMethodId {
+
+  def apply(value: String): Option[PaymentMethodId] ={ println(s"value: $value")
+    if (value.forall { char =>
+      (char >= 'a' && char <= 'z') ||
+        (char >= 'A' && char <= 'Z') ||
+        (char >= '0' && char <= '9') ||
+        char == '_'
+    }) Some(new PaymentMethodId(value)) else None}
+
+  implicit val decoder: Decoder[PaymentMethodId] = Decoder.decodeString.emap { str =>
+    apply(str).toRight(s"PaymentMethodId $str had invalid characters")
+  }
+  implicit val encoder: Encoder[PaymentMethodId] = Encoder.encodeString.contramap[PaymentMethodId](_.value)
+
+}
+case class PaymentMethodId private (value: String) extends AnyVal
+
 
 case class DirectDebitPaymentFields(
   accountHolderName: String,
@@ -45,6 +66,15 @@ object PaymentFields {
       Decoder[StripePaymentMethodPaymentFields].widen,
       Decoder[DirectDebitPaymentFields].widen,
       Decoder[ExistingPaymentFields].widen
-    ).reduceLeft(_ or _)
+    ).reduceLeft(or(_,_))
+
+  final def or[A, AA >: A](a: Decoder[A], d: => Decoder[AA]): Decoder[AA] = new Decoder[AA] {
+    final def apply(c: HCursor): Decoder.Result[AA] = a(c) match {
+      case r @ Right(_) => r
+      case Left(err)      => d(c).left.map { (decodingFailure: DecodingFailure) =>
+        DecodingFailure(err.message + " OR " + decodingFailure.message, err.history ++ decodingFailure.history)
+      }
+    }
+  }
 
 }

--- a/support-models/src/test/scala/com/gu/support/workers/PaymentMethodIdTest.scala
+++ b/support-models/src/test/scala/com/gu/support/workers/PaymentMethodIdTest.scala
@@ -1,0 +1,19 @@
+package com.gu.support.workers
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class PaymentMethodIdTest extends FlatSpec with Matchers {
+
+  it should "accept a valid id" in {
+    val data = "pm_09AZaz"
+    val result = PaymentMethodId(data)
+    result.map(_.value) should be(Some(data))
+  }
+
+  it should "NOT accept a dangerous id" in {
+    val data = "pm_/09AZaz"
+    val result = PaymentMethodId(data)
+    result should be(None)
+  }
+
+}

--- a/support-workers/src/main/scala/com/gu/stripe/StripeBrand.scala
+++ b/support-workers/src/main/scala/com/gu/stripe/StripeBrand.scala
@@ -3,23 +3,24 @@ package com.gu.stripe
 import io.circe.Decoder
 
 // https://stripe.com/docs/api/payment_methods/object#payment_method_object-card-brand
+// https://stripe.com/docs/api/customers/object#customer_object-sources-data-brand
 // See CreditCardType at https://www.zuora.com/developer/api-reference/#operation/Object_POSTPaymentMethod
-sealed abstract class StripeBrand(val value: String, val zuoraCreditCardType: Option[String])
+sealed abstract class StripeBrand(val customerValue: String, val paymentMethodValue: String, val zuoraCreditCardType: Option[String])
 object StripeBrand {
 
-  case object Amex extends StripeBrand("amex", Some("AmericanExpress"))
-  case object Diners extends StripeBrand("diners", Some("Diners"))
-  case object Discover extends StripeBrand("discover", Some("Discover"))
-  case object Jcb extends StripeBrand("jcb", Some("JCB"))
-  case object Mastercard extends StripeBrand("mastercard", Some("MasterCard"))
-  case object Unionpay extends StripeBrand("unionpay",  None)
-  case object Visa extends StripeBrand("visa", Some("Visa"))
-  case object Unknown extends StripeBrand("unknown", None)
+  //American Express, Diners Club, Discover, JCB, MasterCard, UnionPay, Visa, or Unknown
+  case object Amex extends StripeBrand("American Express", "amex", Some("AmericanExpress"))
+  case object Diners extends StripeBrand("Diners Club","diners", Some("Diners"))
+  case object Discover extends StripeBrand("Discover", "discover", Some("Discover"))
+  case object Jcb extends StripeBrand("JCB", "jcb", Some("JCB"))
+  case object Mastercard extends StripeBrand("MasterCard", "mastercard", Some("MasterCard"))
+  case object Unionpay extends StripeBrand("UnionPay", "unionpay",  None)
+  case object Visa extends StripeBrand("Visa", "visa", Some("Visa"))
+  case object Unknown extends StripeBrand("Unknown", "unknown", None)
 
   val all = Seq(Amex, Diners, Discover, Jcb,Mastercard,Unionpay,Visa,Unknown)
-  def apply(value: String): Option[StripeBrand] = all.find(_.value == value)
 
-  implicit val decoder: Decoder[StripeBrand] = Decoder.decodeString.emap { str =>
-    apply(str).toRight("StripeBrand")
+  def decoder(field: StripeBrand => String): Decoder[StripeBrand] = Decoder.decodeString.emap { str =>
+    all.find(field(_) == str).toRight("StripeBrand")
   }
 }

--- a/support-workers/src/main/scala/com/gu/stripe/StripeBrand.scala
+++ b/support-workers/src/main/scala/com/gu/stripe/StripeBrand.scala
@@ -1,0 +1,25 @@
+package com.gu.stripe
+
+import io.circe.Decoder
+
+// https://stripe.com/docs/api/payment_methods/object#payment_method_object-card-brand
+// See CreditCardType at https://www.zuora.com/developer/api-reference/#operation/Object_POSTPaymentMethod
+sealed abstract class StripeBrand(val value: String, val zuoraCreditCardType: Option[String])
+object StripeBrand {
+
+  case object Amex extends StripeBrand("amex", Some("AmericanExpress"))
+  case object Diners extends StripeBrand("diners", Some("Diners"))
+  case object Discover extends StripeBrand("discover", Some("Discover"))
+  case object Jcb extends StripeBrand("jcb", Some("JCB"))
+  case object Mastercard extends StripeBrand("mastercard", Some("MasterCard"))
+  case object Unionpay extends StripeBrand("unionpay",  None)
+  case object Visa extends StripeBrand("visa", Some("Visa"))
+  case object Unknown extends StripeBrand("unknown", None)
+
+  val all = Seq(Amex, Diners, Discover, Jcb,Mastercard,Unionpay,Visa,Unknown)
+  def apply(value: String): Option[StripeBrand] = all.find(_.value == value)
+
+  implicit val decoder: Decoder[StripeBrand] = Decoder.decodeString.emap { str =>
+    apply(str).toRight("StripeBrand")
+  }
+}

--- a/support-workers/src/main/scala/com/gu/stripe/StripeService.scala
+++ b/support-workers/src/main/scala/com/gu/stripe/StripeService.scala
@@ -2,13 +2,13 @@ package com.gu.stripe
 
 import com.gu.helpers.WebServiceHelper
 import com.gu.i18n.Currency
-import com.gu.i18n.Currency.AUD
 import com.gu.okhttp.RequestRunners._
 import com.gu.stripe.Stripe._
 import com.gu.support.config.StripeConfig
-import com.gu.support.zuora.api.{PaymentGateway, StripeGatewayAUD, StripeGatewayDefault}
+import io.circe.Decoder
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.reflect.ClassTag
 
 class StripeService(val config: StripeConfig, client: FutureHttpClient, baseUrl: String = "https://api.stripe.com/v1")(implicit ec: ExecutionContext)
     extends WebServiceHelper[Stripe.StripeError] {
@@ -21,24 +21,18 @@ class StripeService(val config: StripeConfig, client: FutureHttpClient, baseUrl:
 
 }
 
-object StripeServiceForCurrency {
-
-  def gateway(currency: Currency): PaymentGateway = if (currency == AUD) StripeGatewayAUD else StripeGatewayDefault
-
-}
-
-class StripeServiceForCurrency(stripeService: StripeService, currency: Currency) {
+class StripeServiceForCurrency(val stripeService: StripeService, currency: Currency) {
   import stripeService._
 
-  def createCustomerFromToken(token: String): Future[Customer] =
-    postForm[Customer]("customers", Map(
-      "source" -> Seq(token)
-    ), getHeaders())
+  def get[A](endpoint: String)(implicit decoder: Decoder[A], errorDecoder: Decoder[StripeError], ctag: ClassTag[A]): Future[A] =
+    stripeService.get[A](endpoint, getHeaders())
 
-  def createCustomerFromPaymentMethod(paymentMethod: String): Future[Customer] =
-    postForm[Customer]("customers", Map(
-      "payment_method" -> Seq(paymentMethod)
-    ), getHeaders())
+  def postForm[A](
+    endpoint: String,
+    data: Map[String, Seq[String]]
+  )(implicit decoder: Decoder[A], errorDecoder: Decoder[StripeError], ctag: ClassTag[A]): Future[A] = {
+    stripeService.postForm[A](endpoint, data, getHeaders())
+  }
 
   private def getHeaders() =
     config.version.foldLeft(getAuthorizationHeader()) {
@@ -47,5 +41,11 @@ class StripeServiceForCurrency(stripeService: StripeService, currency: Currency)
 
   private def getAuthorizationHeader() =
     Map("Authorization" -> s"Bearer ${config.forCurrency(Some(currency)).secretKey}")
+
+  val createCustomerFromPaymentMethod = com.gu.stripe.createCustomerFromPaymentMethod.apply(this)_
+
+  val createCustomerFromToken = com.gu.stripe.createCustomerFromToken.apply(this)_
+
+  val getPaymentMethod = com.gu.stripe.getPaymentMethod.apply(this)_
 
 }

--- a/support-workers/src/main/scala/com/gu/stripe/StripeService.scala
+++ b/support-workers/src/main/scala/com/gu/stripe/StripeService.scala
@@ -2,9 +2,11 @@ package com.gu.stripe
 
 import com.gu.helpers.WebServiceHelper
 import com.gu.i18n.Currency
+import com.gu.i18n.Currency.AUD
 import com.gu.okhttp.RequestRunners._
 import com.gu.stripe.Stripe._
 import com.gu.support.config.StripeConfig
+import com.gu.support.zuora.api.{PaymentGateway, StripeGatewayAUD, StripeGatewayDefault, StripeGatewayPaymentIntentsAUD, StripeGatewayPaymentIntentsDefault}
 import io.circe.Decoder
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -18,6 +20,14 @@ class StripeService(val config: StripeConfig, client: FutureHttpClient, baseUrl:
   val httpClient: FutureHttpClient = client
 
   def withCurrency(currency: Currency): StripeServiceForCurrency = new StripeServiceForCurrency(this, currency)
+
+}
+
+object StripeServiceForCurrency {
+
+  def chargeGateway(currency: Currency): PaymentGateway = if (currency == AUD) StripeGatewayAUD else StripeGatewayDefault
+
+  def paymentIntentGateway(currency: Currency): PaymentGateway = if (currency == AUD) StripeGatewayPaymentIntentsAUD else StripeGatewayPaymentIntentsDefault
 
 }
 

--- a/support-workers/src/main/scala/com/gu/stripe/createCustomerFromPaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/stripe/createCustomerFromPaymentMethod.scala
@@ -1,0 +1,22 @@
+package com.gu.stripe
+
+import com.gu.support.encoding.Codec
+import com.gu.support.encoding.Codec.deriveCodec
+import com.gu.support.workers.PaymentMethodId
+
+import scala.concurrent.Future
+
+object createCustomerFromPaymentMethod {
+
+  object Customer {
+    implicit val codec: Codec[Customer] = deriveCodec
+  }
+
+  case class Customer(id: String)
+
+  def apply(stripeService: StripeServiceForCurrency)(paymentMethod: PaymentMethodId): Future[Customer] =
+    stripeService.postForm[Customer]("customers", Map(
+      "payment_method" -> Seq(paymentMethod.value)
+    ))
+
+}

--- a/support-workers/src/main/scala/com/gu/stripe/createCustomerFromToken.scala
+++ b/support-workers/src/main/scala/com/gu/stripe/createCustomerFromToken.scala
@@ -15,6 +15,7 @@ object createCustomerFromToken {
 
     object StripeCard {
 
+      implicit val brandDecoder = StripeBrand.decoder(_.customerValue)
       implicit val decoder: Decoder[StripeCard] = deriveDecoder
 
     }

--- a/support-workers/src/main/scala/com/gu/stripe/createCustomerFromToken.scala
+++ b/support-workers/src/main/scala/com/gu/stripe/createCustomerFromToken.scala
@@ -1,0 +1,39 @@
+package com.gu.stripe
+
+import com.gu.stripe.Stripe.{StripeError, StripeList}
+import com.gu.stripe.createCustomerFromToken.Customer.StripeCard
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+
+import scala.concurrent.Future
+
+object createCustomerFromToken {
+
+  object Customer {
+    implicit val decoder: Decoder[Customer] = deriveDecoder
+
+
+    object StripeCard {
+
+      implicit val decoder: Decoder[StripeCard] = deriveDecoder
+
+    }
+
+    case class StripeCard(id: String, brand: StripeBrand, last4: String, exp_month: Int, exp_year: Int, country: String)
+
+  }
+
+  case class Customer(id: String, sources: StripeList[StripeCard]) {
+    // customers should always have a card
+    if (sources.total_count != 1) {
+      throw StripeError("internal", s"Customer $id has ${sources.total_count} cards, should have exactly one")
+    }
+
+    val source = sources.data.head
+  }
+
+  def apply(stripeService: StripeServiceForCurrency)(token: String): Future[Customer] =
+    stripeService.postForm[Customer]("customers", Map(
+      "source" -> Seq(token)
+    ))
+}

--- a/support-workers/src/main/scala/com/gu/stripe/getPaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/stripe/getPaymentMethod.scala
@@ -15,6 +15,7 @@ object getPaymentMethod {
 
   object StripeCard {
 
+    implicit val brandDecoder = StripeBrand.decoder(_.paymentMethodValue)
     implicit val decoder: Decoder[StripeCard] = deriveDecoder
 
   }

--- a/support-workers/src/main/scala/com/gu/stripe/getPaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/stripe/getPaymentMethod.scala
@@ -1,0 +1,27 @@
+package com.gu.stripe
+
+import com.gu.support.workers.PaymentMethodId
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+
+import scala.concurrent.Future
+
+object getPaymentMethod {
+
+  case class StripePaymentMethod(
+    card: StripeCard
+  )
+  implicit val decoder = deriveDecoder[StripePaymentMethod]
+
+  object StripeCard {
+
+    implicit val decoder: Decoder[StripeCard] = deriveDecoder
+
+  }
+
+  case class StripeCard(brand: StripeBrand, last4: String, exp_month: Int, exp_year: Int, country: String)
+
+  def apply(stripeService: StripeServiceForCurrency)(paymentMethod: PaymentMethodId): Future[StripePaymentMethod] =
+    stripeService.get[StripePaymentMethod](s"payment_methods/${paymentMethod.value}")
+
+}

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -1,18 +1,16 @@
 package com.gu.support.workers.lambdas
 
 import com.amazonaws.services.lambda.runtime.Context
-import com.gu.i18n.Currency.AUD
 import com.gu.i18n.{CountryGroup, Currency}
 import com.gu.monitoring.SafeLogger
 import com.gu.paypal.PayPalService
 import com.gu.salesforce.AddressLineTransformer
 import com.gu.services.{ServiceProvider, Services}
 import com.gu.stripe.StripeService
+import com.gu.stripe.StripeServiceForCurrency._
 import com.gu.support.workers._
-import com.gu.support.workers.lambdas.CreatePaymentMethod._
 import com.gu.support.workers.lambdas.PaymentMethodExtensions.PaymentMethodExtension
 import com.gu.support.workers.states.{CreatePaymentMethodState, CreateSalesforceContactState}
-import com.gu.support.zuora.api._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -124,21 +122,5 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
       streetNumber = addressLine.flatMap(_.streetNumber)
     ))
   }
-
-}
-
-object CreatePaymentMethod {
-
-  def paymentIntentGateway(currency: Currency): PaymentGateway =
-    currency match {
-      case AUD => StripeGatewayPaymentIntentsAUD
-      case _ => StripeGatewayPaymentIntentsDefault
-    }
-
-  def chargeGateway(currency: Currency): PaymentGateway =
-    currency match {
-      case AUD => StripeGatewayAUD
-      case _ => StripeGatewayDefault
-    }
 
 }

--- a/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
@@ -173,7 +173,7 @@ object JsonFixtures {
     """
 
   val stripeToken = "tok_visa"
-  val stripePaymentMethodToken = "tok_visa"
+  val stripePaymentMethodToken = PaymentMethodId("pm_card_visa").get
   val stripeJson =
     s"""
       {
@@ -184,7 +184,7 @@ object JsonFixtures {
   val stripePaymentMethodJson =
     s"""
       {
-        "paymentMethod": "$stripePaymentMethodToken"
+        "paymentMethod": "${stripePaymentMethodToken.value}"
       }
     """
 

--- a/support-workers/src/test/scala/com/gu/zuora/Fixtures.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/Fixtures.scala
@@ -3,11 +3,11 @@ package com.gu.zuora
 import com.gu.config.Configuration
 import com.gu.i18n.Currency.GBP
 import com.gu.i18n.{Country, Currency}
+import com.gu.stripe.StripeServiceForCurrency
 import com.gu.support.catalog
 import com.gu.support.catalog.{Everyday, HomeDelivery}
 import com.gu.support.config.TouchPointEnvironments
 import com.gu.support.workers._
-import com.gu.support.workers.lambdas.CreatePaymentMethod
 import com.gu.support.zuora.api._
 import org.joda.time.LocalDate
 
@@ -98,7 +98,7 @@ object Fixtures {
         account(currency),
         contactDetails,
         None,
-        creditCardPaymentMethod(CreatePaymentMethod.paymentIntentGateway(currency)),
+        creditCardPaymentMethod(StripeServiceForCurrency.paymentIntentGateway(currency)),
         monthlySubscriptionData,
         SubscribeOptions()
       )

--- a/support-workers/src/test/scala/com/gu/zuora/Fixtures.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/Fixtures.scala
@@ -3,11 +3,11 @@ package com.gu.zuora
 import com.gu.config.Configuration
 import com.gu.i18n.Currency.GBP
 import com.gu.i18n.{Country, Currency}
-import com.gu.stripe.StripeServiceForCurrency
 import com.gu.support.catalog
-import com.gu.support.catalog.{Everyday, HomeDelivery, Product, ProductRatePlan}
+import com.gu.support.catalog.{Everyday, HomeDelivery}
 import com.gu.support.config.TouchPointEnvironments
-import com.gu.support.workers.{CreditCardReferenceTransaction, DirectDebitPaymentMethod, Monthly, PayPalReferenceTransaction}
+import com.gu.support.workers._
+import com.gu.support.workers.lambdas.CreatePaymentMethod
 import com.gu.support.zuora.api._
 import org.joda.time.LocalDate
 
@@ -98,7 +98,7 @@ object Fixtures {
         account(currency),
         contactDetails,
         None,
-        creditCardPaymentMethod(StripeServiceForCurrency.gateway(currency)),
+        creditCardPaymentMethod(CreatePaymentMethod.paymentIntentGateway(currency)),
         monthlySubscriptionData,
         SubscribeOptions()
       )


### PR DESCRIPTION
## Why are you doing this?

This PR is part of a series to make our stuff SCA compatible using setupintents/paymentintents. Previous PR https://github.com/guardian/support-frontend/pull/2063

This means we can still take payments after banks start using SCA.  This is split up into smaller tasks.  This one follows on from the one that creates a customer from a payment method id.

Previously we created the customer from the token, which returned the card token/id and the card details e.g. brand, last 4, etc.  We then write those to Zuora.
With creating a customer from a payment method id, we write that id to zuora instead, but we need to call get payment method separately to get the card details.

[**Trello Card**](https://trello.com/c/3EXrocav/2589-make-support-workers-write-to-zuora-in-sca-mode)

This is tested in CODE with digital pack both stripe and gocardless still working in the old mode.
I have also tested in code with a hand crafted `"paymentFields":{"paymentMethod":"pm_card_visa"}` POSTed to the support-frontend, and it worked, the Account in zuora looked ok and I could apply a charge.