### PR TITLE
DP promotion T&Cs link

### DIFF
--- a/support-frontend/assets/components/customerService/customerService.jsx
+++ b/support-frontend/assets/components/customerService/customerService.jsx
@@ -2,12 +2,13 @@
 
 // ----- Imports ----- //
 
-import React from 'react';
+import * as React from 'react';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { type Option } from 'helpers/types/option';
 import { type SubscriptionProduct } from 'helpers/subscriptions';
 import { type PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import { AUDCountries, GBPCountries, UnitedStates } from 'helpers/internationalisation/countryGroup';
+import { promotionTermsUrl } from 'helpers/externalLinks';
 
 // ----- Props ----- //
 
@@ -15,6 +16,7 @@ type PropTypes = {|
   selectedCountryGroup: CountryGroupId,
   subscriptionProduct: SubscriptionProduct,
   paperFulfilmentOptions: Option<PaperFulfilmentOptions>,
+  promoCode?: Option<string>,
 |};
 
 // ----- Functions ----- //
@@ -59,45 +61,64 @@ function CustomerService(props: PropTypes) {
     props.subscriptionProduct,
     props.paperFulfilmentOptions,
   );
+  const promotionTerms = props.promoCode ?
+    (
+      <div>
+        <h2>Promotion terms and conditions</h2>
+        <div className="component-customer-service__text">
+          <p>
+            Offer subject to availability. Guardian News and Media Limited (&quot;GNM&quot;)
+            reserves the right to withdraw this promotion at any time.
+            For full promotion terms and conditions see <a href={promotionTermsUrl(props.promoCode)}>here</a>
+          </p>
+        </div>
+      </div>
+    )
+    : null;
+
+
+  const Faqs = ({ children }: { children: React.Node }) =>
+    (
+      <div className="component-customer-service">
+        {promotionTerms}
+        <h2>FAQs and Help</h2>
+        <div className="component-customer-service__text">
+          {children}
+        </div>
+      </div>
+    );
+
   switch (props.selectedCountryGroup) {
     case UnitedStates:
       return (
-        <div className="component-customer-service">
-          <div className="component-customer-service__text">
-            For help with Guardian and Observer subscription services please email <Email email={email} /> or
-            call 1-844-632-2010 (toll free); 917-900-4663 (direct line).
-            Lines are open 9:15am-6pm, Monday to Friday (EST/EDT).
-          </div>
-        </div>
+        <Faqs>
+          For help with Guardian and Observer subscription services please email <Email email={email} /> or
+          call 1-844-632-2010 (toll free); 917-900-4663 (direct line).
+          Lines are open 9:15am-6pm, Monday to Friday (EST/EDT).
+        </Faqs>
       );
     case GBPCountries:
       return (
-        <div className="component-customer-service">
-          <div className="component-customer-service__text">
+        <Faqs>
             For help with Guardian and Observer subscription services please email <Email email={email} /> or
             call 0330 333 6767 (within UK). Lines are open 8am-8pm on weekdays, 8am-6pm at weekends (GMT/BST).
-          </div>
-        </div>
+        </Faqs>
       );
     case AUDCountries:
       return (
-        <div className="component-customer-service">
-          <div className="component-customer-service__text">
+        <Faqs>
             For help with Guardian and Observer subscription services please
             email <Email email={email} /> or
             call 1800 773 766 (within Australia) or +61 2 8076 8599 (outside Australia).
             Lines are open 9am-5pm Monday-Friday (AEDT).
-          </div>
-        </div>
+        </Faqs>
       );
     default:
       return (
-        <div className="component-customer-service">
-          <div className="component-customer-service__text">
+        <Faqs>
             For help with Guardian and Observer subscription services please email <Email email={email} /> or
             call +44 (0) 330 333 6767. Lines are open 8am-8pm on weekdays, 8am-6pm at weekends (GMT/BST).
-          </div>
-        </div>
+        </Faqs>
       );
   }
 }
@@ -106,6 +127,7 @@ CustomerService.defaultProps = {
   selectedCountryGroup: 'GBPCountries',
   subscriptionProduct: 'DigitalPack',
   paperFulfilmentOptions: null,
+  promoCode: null,
 };
 
 // ----- Exports ----- //

--- a/support-frontend/assets/helpers/externalLinks.js
+++ b/support-frontend/assets/helpers/externalLinks.js
@@ -266,6 +266,8 @@ const getProfileUrl = (path: string) => (returnUrl: ?string) => {
 const getSignoutUrl = getProfileUrl('signout');
 const getReauthenticateUrl = getProfileUrl('reauthenticate');
 
+const promotionTermsUrl = (promoCode: string) => `${subsUrl}/${promoCode}/terms`;
+
 // ----- Exports ----- //
 
 export {
@@ -281,4 +283,5 @@ export {
   myAccountUrl,
   manageSubsUrl,
   homeDeliveryUrl,
+  promotionTermsUrl,
 };

--- a/support-frontend/assets/helpers/flashSale.js
+++ b/support-frontend/assets/helpers/flashSale.js
@@ -236,4 +236,5 @@ export {
   getFlashSaleActiveOverride,
   countdownTimerIsActive,
   showCountdownTimer,
+  dpSale,
 };

--- a/support-frontend/assets/helpers/flashSale.js
+++ b/support-frontend/assets/helpers/flashSale.js
@@ -55,6 +55,22 @@ const dpSale = {
   promoCode: 'DK0NT24WG',
   intcmp: '',
   price: 0,
+  saleCopy: {
+    featuredProduct: {
+      heading: 'Digital Pack',
+      subHeading: 'Save 25% for a year',
+      description: 'Read The Guardian ad-free on all devices, including the Premium App and UK Daily Edition iPad app.',
+    },
+    landingPage: {
+      heading: 'Digital Pack subscriptions',
+      subHeading: 'Save 25% on award-winning, independent journalism, ad-free on all of your devices',
+    },
+    bundle: {
+      heading: 'Digital Pack',
+      subHeading: 'Save 25% for a year',
+      description: 'The Premium App and the daily edition iPad app of the UK newspaper in one pack, plus ad-free reading on all your devices',
+    },
+  },
 };
 
 const Sales: Sale[] = [

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -31,6 +31,8 @@ import './components/theMoment.scss';
 import ConsentBanner from 'components/consentBanner/consentBanner';
 import digitalSubscriptionLandingReducer from './digitalSubscriptionLandingReducer';
 import { isPostDeployUser } from 'helpers/user/user';
+import { dpSale, flashSaleIsActive } from 'helpers/flashSale';
+import { DigitalPack } from 'helpers/subscriptions';
 
 // ----- Redux Store ----- //
 
@@ -115,7 +117,7 @@ class LandingPage extends Component<Props, State> {
         this.checkOptimizeIsReady(interval);
       }, interval);
     }
-  }
+  };
 
   render() {
     const { dailyEditionsVariant } = this.props;
@@ -124,6 +126,9 @@ class LandingPage extends Component<Props, State> {
     if (pageReadyChecks === 0 && showPage === false) {
       this.checkOptimizeIsReady(interval);
     }
+    // We can't cope with multiple promo codes in the current design
+
+    const promoCode = flashSaleIsActive(DigitalPack, countryGroupId) ? dpSale.promoCode : null;
 
     return (
       <div>
@@ -132,7 +137,10 @@ class LandingPage extends Component<Props, State> {
           header={<CountrySwitcherHeader />}
           footer={
             <Footer>
-              <CustomerService selectedCountryGroup={countryGroupId} />
+              <CustomerService
+                selectedCountryGroup={countryGroupId}
+                promoCode={promoCode}
+              />
               <SubscriptionFaq subscriptionProduct="DigitalPack" />
             </Footer>}
         >

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -422,3 +422,8 @@
   overflow: hidden;
   margin-left: -1px;
 }
+
+.component-customer-service h2 {
+  margin-top: 4px;
+  font-weight: bold;
+}

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.scss
@@ -424,6 +424,6 @@
 }
 
 .component-customer-service h2 {
-  margin-top: 4px;
+  margin-top: $gu-v-spacing;
   font-weight: bold;
 }


### PR DESCRIPTION
## Why are you doing this?

The Digital Pack Landing page needs to show a link to the terms and conditions of the current promotion when there is one running.

[**Trello Card**](https://trello.com/c/GINUZJaK/2626-add-promotion-terms-copy-to-dp-and-print-landing-pages)

## Screenshots
**Page footer with no active promotion:**
![Screenshot 2019-09-20 at 17 08 54](https://user-images.githubusercontent.com/181371/65341898-602d4600-dbc9-11e9-8662-980d469b254a.png)

**Page footer during the sale period:**
![Screenshot 2019-09-20 at 17 09 45](https://user-images.githubusercontent.com/181371/65341921-79ce8d80-dbc9-11e9-8f42-2ec818bdebc8.png)

