### PR TITLE
Reinstate dp on subs landing page

### DIFF
--- a/support-frontend/assets/helpers/flashSale.js
+++ b/support-frontend/assets/helpers/flashSale.js
@@ -55,6 +55,22 @@ const dpSale = {
   promoCode: 'DK0NT24WG',
   intcmp: '',
   price: 0,
+  saleCopy: {
+    featuredProduct: {
+      heading: 'Digital Pack',
+      subHeading: 'Save 25% for a year',
+      description: 'Read The Guardian ad-free on all devices, including the Premium App and UK Daily Edition iPad app.',
+    },
+    landingPage: {
+      heading: 'Digital Pack subscriptions',
+      subHeading: 'Save 25% on award-winning, independent journalism, ad-free on all of your devices',
+    },
+    bundle: {
+      heading: 'Digital Pack',
+      subHeading: 'Save 25% for a year',
+      description: 'The Premium App and the daily edition iPad app of the UK newspaper in one pack, plus ad-free reading on all your devices',
+    },
+  },
 };
 
 const Sales: Sale[] = [


### PR DESCRIPTION
## Why are you doing this?
To reinstate some missing copy from the subs landing page for digital pack.

## Screenshots
![Screen Shot 2019-09-23 at 10 48 36](https://user-images.githubusercontent.com/16781258/65416647-43268c00-ddf0-11e9-9ad1-b2dc65c777c7.png)