### PR TITLE
Small fixes for the print campaign

### DIFF
--- a/support-frontend/assets/components/threeSubscriptions/threeSubscriptions.scss
+++ b/support-frontend/assets/components/threeSubscriptions/threeSubscriptions.scss
@@ -30,6 +30,15 @@
 
   .component-subscription-bundle--yellow {
     background-color: #ffe500;
+    margin-left: $gu-h-spacing * 1.5;
+
+    @include mq($from: leftCol) {
+      margin-left: 0;
+    }
+
+    @include mq($until: phablet) {
+      margin-left: 0;
+    }
   }
 
   .component-subscription-bundle__content {

--- a/support-frontend/assets/helpers/flashSale.js
+++ b/support-frontend/assets/helpers/flashSale.js
@@ -114,7 +114,7 @@ const Sales: Sale[] = [
           },
           landingPage: {
             heading: 'Print',
-            subHeading: 'Save up to 52% on The Guardian and The Observer for a year',
+            subHeading: 'Save up to 52% for a year on The Guardian and The Observer',
           },
           bundle: {
             heading: 'Paper',

--- a/support-frontend/assets/pages/paper-subscription-landing/components/hero/discountCopy.js
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/hero/discountCopy.js
@@ -4,7 +4,7 @@
 export const discountCopyChoices = {
   control: {
     roundel: ['Save up to', '52%', 'for a year'],
-    heading: 'Save up to 52% on The Guardian and The Observer - all year round',
+    heading: 'Save up to 52% for a year on The Guardian and The Observer',
     offer: [
       'Save 37% a month on retail price',
       'Save 33% a month on retail price',


### PR DESCRIPTION
## Why are you doing this?
These are some small changes requested by Elena and Chris.

## Changes
* Change to text of main marketing message so text reads: 'Save up to 52% for a year on The Guardian and The Observer'
* Fix indentation of highlighted message on subs landing page

Following screenshot shows the problem:
![Screen Shot 2019-09-23 at 13 11 27](https://user-images.githubusercontent.com/16781258/65424562-bede0400-de03-11e9-818b-527431d9221b.png)

## Screenshots
![Screen Shot 2019-09-23 at 13 07 28](https://user-images.githubusercontent.com/16781258/65424353-39f2ea80-de03-11e9-9f24-8587af0716f5.png)

![Screen Shot 2019-09-23 at 13 09 03](https://user-images.githubusercontent.com/16781258/65424383-57c04f80-de03-11e9-88f4-ad3b45a52b1f.png)

