### PR TITLE
Move payment failure error message out of PaymentMethodSelector.jsx

### DIFF
--- a/support-frontend/assets/components/checkoutForm/checkoutForm.scss
+++ b/support-frontend/assets/components/checkoutForm/checkoutForm.scss
@@ -42,3 +42,9 @@ div .component-checkout-form-section.component-checkout-form-section--hidden {
   margin-bottom: ($gu-v-spacing * 2);
 }
 
+.component-general-error-message {
+  margin: 0 ($gu-h-spacing / 2);
+  max-width: gu-span(5);
+  border: 1px gu-colour(state-error) solid;
+}
+

--- a/support-frontend/assets/components/subscriptionCheckouts/paymentMethodSelector.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/paymentMethodSelector.jsx
@@ -13,8 +13,6 @@ import SvgDirectDebitSymbol from 'components/svgs/directDebitSymbol';
 import SvgNewCreditCard from 'components/svgs/newCreditCard';
 import SvgPayPal from 'components/svgs/paypal';
 import { FormSection } from 'components/checkoutForm/checkoutForm';
-import GeneralErrorMessage from 'components/generalErrorMessage/generalErrorMessage';
-import type { ErrorReason } from 'helpers/errorReasons';
 import { withError } from 'hocs/withError';
 import type { SubscriptionProduct } from 'helpers/subscriptions';
 import { supportedPaymentMethods } from 'helpers/subscriptionsForms/countryPaymentMethods';
@@ -27,20 +25,12 @@ type PropTypes = {|
   onPaymentAuthorised: Function,
   setPaymentMethod: Function,
   validationError: Option<string>,
-  submissionError: Option<ErrorReason>,
 |}
 
 const FieldsetWithError = withError(Fieldset);
 
 function PaymentMethodSelector(props: PropTypes) {
-  const errorHeading = props.submissionError === 'personal_details_incorrect' ? 'Failed to Create Subscription' :
-    'Payment Attempt Failed';
-  const errorState = props.submissionError ?
-    <GeneralErrorMessage errorReason={props.submissionError} errorHeading={errorHeading} /> :
-    null;
-
   const paymentMethods = supportedPaymentMethods(props.country, props.product);
-
 
   return (paymentMethods.length > 1 ?
     <FormSection title="How would you like to pay?">
@@ -79,7 +69,6 @@ function PaymentMethodSelector(props: PropTypes) {
             />}
           </FieldsetWithError>
         </div>
-        {errorState}
       </Rows>
       <DirectDebitPopUpForm
         buttonText="Subscribe with Direct Debit"

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
@@ -68,6 +68,8 @@ import {
 } from 'helpers/productPrice/priceDescriptions';
 import { StripeProvider, Elements } from 'react-stripe-elements';
 import { getStripeKey } from 'helpers/paymentIntegrations/stripeCheckout';
+import GeneralErrorMessage
+  from 'components/generalErrorMessage/generalErrorMessage';
 
 
 // ----- Types ----- //
@@ -182,6 +184,8 @@ class DigitalCheckoutForm extends Component<PropTypes, StateTypes> {
     const offerOnSelected = getAppliedPromoDescription(props.billingPeriod, productPrice);
     const helperSelected = getPriceDescription(productPrice, props.billingPeriod);
     const priceSummary = `${offerOnSelected || 'Enjoy your digital pack free for 14 days, then'} ${helperSelected}.`;
+    const submissionErrorHeading = props.submissionError === 'personal_details_incorrect' ? 'Failed to Create Subscription' :
+      'Payment Attempt Failed';
 
     const PriceSummary = () =>
       <p className="component-credit-card-price">{priceSummary}</p>;
@@ -243,7 +247,6 @@ class DigitalCheckoutForm extends Component<PropTypes, StateTypes> {
                   setPaymentMethod={props.setPaymentMethod}
                   onPaymentAuthorised={props.onPaymentAuthorised}
                   validationError={firstError('paymentMethod', props.formErrors)}
-                  submissionError={props.submissionError}
                 />
                 <PayPalSubmitButton
                   paymentMethod={props.paymentMethod}
@@ -282,6 +285,10 @@ class DigitalCheckoutForm extends Component<PropTypes, StateTypes> {
                     buttonText="Start your free trial now"
                   />
                 </FormSectionHiddenUntilSelected>
+                <GeneralErrorMessage
+                  errorReason={props.submissionError}
+                  errorHeading={submissionErrorHeading}
+                />
                 <CancellationSection />
               </Form>
             </CheckoutLayout>

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
@@ -184,8 +184,8 @@ class DigitalCheckoutForm extends Component<PropTypes, StateTypes> {
     const offerOnSelected = getAppliedPromoDescription(props.billingPeriod, productPrice);
     const helperSelected = getPriceDescription(productPrice, props.billingPeriod);
     const priceSummary = `${offerOnSelected || 'Enjoy your digital pack free for 14 days, then'} ${helperSelected}.`;
-    const submissionErrorHeading = props.submissionError === 'personal_details_incorrect' ? 'Failed to Create Subscription' :
-      'Payment Attempt Failed';
+    const submissionErrorHeading = props.submissionError === 'personal_details_incorrect' ? 'Sorry there was a problem' :
+      'Sorry we could not process your payment';
 
     const PriceSummary = () =>
       <p className="component-credit-card-price">{priceSummary}</p>;

--- a/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss
+++ b/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.scss
@@ -33,11 +33,6 @@
 
   // ----- Checkout
 
-  .component-general-error-message {
-    margin-top: $gu-v-spacing * 2;
-    width: auto;
-  }
-
   .component-paypal-button-checkout__container {
     margin: 20px 0;
   }

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
@@ -71,6 +71,8 @@ import type { IsoCountry } from 'helpers/internationalisation/country';
 import { DirectDebit, Stripe } from 'helpers/paymentMethods';
 import StripeForm from 'components/subscriptionCheckouts/stripeForm/stripeForm';
 import { validateWithDeliveryForm } from 'helpers/subscriptionsForms/formValidation';
+import GeneralErrorMessage
+  from 'components/generalErrorMessage/generalErrorMessage';
 
 // ----- Types ----- //
 
@@ -160,6 +162,8 @@ class PaperCheckoutForm extends Component<PropTypes, StateTypes> {
     const fulfilmentOptionDescriptor = props.fulfilmentOption === HomeDelivery ? 'Paper' : 'Voucher booklet';
     const fulfilmentOptionName = props.fulfilmentOption === HomeDelivery ? 'Home delivery' : 'Voucher booklet';
     const deliveryTitle = props.fulfilmentOption === HomeDelivery ? 'Where should we deliver your newspaper?' : 'Where should we deliver your vouchers?';
+    const submissionErrorHeading = props.submissionError === 'personal_details_incorrect' ? 'Failed to Create Subscription' :
+      'Payment Attempt Failed';
 
     return (
       <StripeProvider stripe={this.state.stripe}>
@@ -307,7 +311,6 @@ class PaperCheckoutForm extends Component<PropTypes, StateTypes> {
                   setPaymentMethod={props.setPaymentMethod}
                   onPaymentAuthorised={props.onPaymentAuthorised}
                   validationError={firstError('paymentMethod', props.formErrors)}
-                  submissionError={props.submissionError}
                 />
                 <SubscriptionSubmitButton
                   paymentMethod={props.paymentMethod}
@@ -330,6 +333,10 @@ class PaperCheckoutForm extends Component<PropTypes, StateTypes> {
                     buttonText="Pay now"
                   />
                 </FormSectionHiddenUntilSelected>
+                <GeneralErrorMessage
+                  errorReason={props.submissionError}
+                  errorHeading={submissionErrorHeading}
+                />
                 <CancellationSection />
               </Form>
             </Layout>

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
@@ -162,8 +162,8 @@ class PaperCheckoutForm extends Component<PropTypes, StateTypes> {
     const fulfilmentOptionDescriptor = props.fulfilmentOption === HomeDelivery ? 'Paper' : 'Voucher booklet';
     const fulfilmentOptionName = props.fulfilmentOption === HomeDelivery ? 'Home delivery' : 'Voucher booklet';
     const deliveryTitle = props.fulfilmentOption === HomeDelivery ? 'Where should we deliver your newspaper?' : 'Where should we deliver your vouchers?';
-    const submissionErrorHeading = props.submissionError === 'personal_details_incorrect' ? 'Failed to Create Subscription' :
-      'Payment Attempt Failed';
+    const submissionErrorHeading = props.submissionError === 'personal_details_incorrect' ? 'Sorry there was a problem' :
+      'Sorry we could not process your payment';
 
     return (
       <StripeProvider stripe={this.state.stripe}>

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -73,6 +73,8 @@ import { DirectDebit, Stripe } from 'helpers/paymentMethods';
 import StripeForm from 'components/subscriptionCheckouts/stripeForm/stripeForm';
 import { validateWithDeliveryForm } from 'helpers/subscriptionsForms/formValidation';
 import { StripeProvider, Elements } from 'react-stripe-elements';
+import GeneralErrorMessage
+  from 'components/generalErrorMessage/generalErrorMessage';
 
 // ----- Types ----- //
 
@@ -170,6 +172,8 @@ class WeeklyCheckoutForm extends Component<PropTypes, StateTypes> {
     const fulfilmentOption = getWeeklyFulfilmentOption(props.deliveryCountry);
     const price = getProductPrice(props.productPrices, props.billingCountry, props.billingPeriod, fulfilmentOption);
     const subscriptionStart = `When would you like ${props.orderIsAGift ? 'the' : 'your'} subscription to start?`;
+    const submissionErrorHeading = props.submissionError === 'personal_details_incorrect' ? 'Failed to Create Subscription' :
+      'Payment Attempt Failed';
 
     const setBillingAddressIsSameHandler = () => {
       props.setBillingAddressIsSame(true);
@@ -348,7 +352,6 @@ class WeeklyCheckoutForm extends Component<PropTypes, StateTypes> {
                   setPaymentMethod={props.setPaymentMethod}
                   onPaymentAuthorised={props.onPaymentAuthorised}
                   validationError={firstError('paymentMethod', props.formErrors)}
-                  submissionError={props.submissionError}
                 />
                 <SubscriptionSubmitButton
                   paymentMethod={props.paymentMethod}
@@ -371,6 +374,10 @@ class WeeklyCheckoutForm extends Component<PropTypes, StateTypes> {
                     buttonText="Pay now"
                   />
                 </FormSectionHiddenUntilSelected>
+                <GeneralErrorMessage
+                  errorReason={props.submissionError}
+                  errorHeading={submissionErrorHeading}
+                />
                 <CancellationSection />
               </Form>
             </Layout>

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -172,8 +172,8 @@ class WeeklyCheckoutForm extends Component<PropTypes, StateTypes> {
     const fulfilmentOption = getWeeklyFulfilmentOption(props.deliveryCountry);
     const price = getProductPrice(props.productPrices, props.billingCountry, props.billingPeriod, fulfilmentOption);
     const subscriptionStart = `When would you like ${props.orderIsAGift ? 'the' : 'your'} subscription to start?`;
-    const submissionErrorHeading = props.submissionError === 'personal_details_incorrect' ? 'Failed to Create Subscription' :
-      'Payment Attempt Failed';
+    const submissionErrorHeading = props.submissionError === 'personal_details_incorrect' ? 'Sorry there was a problem' :
+      'Sorry we could not process your payment';
 
     const setBillingAddressIsSameHandler = () => {
       props.setBillingAddressIsSame(true);


### PR DESCRIPTION
## Why are you doing this?

Up until now the error message component which is used when a payment failure occurs was inside the `PaymentMethodSelector` component. This was a problem when there is only one available payment method as it means that the error message is not visible.

This PR moves the error message out of `PaymentMethodSelector` and directly into the form.

[**Trello Card**](https://trello.com/c/BHpPtXww/2639-investigate-gw-australia-failures)

## Screenshots
<img width="492" alt="Screenshot 2019-09-24 at 13 36 30" src="https://user-images.githubusercontent.com/181371/65512040-5dd03200-ded0-11e9-950a-5aa7754bc8bc.png">


