### PR TITLE
Subs showcase page hero product

### DIFF
--- a/support-frontend/assets/pages/subscriptions-landing/components/featuredProducts.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/components/featuredProducts.jsx
@@ -6,7 +6,10 @@ import React, { type Node } from 'react';
 import { type SubsUrls } from 'helpers/externalLinks';
 import { getQueryParameter } from 'helpers/url';
 import { type SubscriptionProduct } from 'helpers/subscriptions';
-import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import {
+  type CountryGroupId,
+  International,
+} from 'helpers/internationalisation/countryGroup';
 import GridPicture from 'components/gridPicture/gridPicture';
 import { flashSaleIsActive, getSaleCopy } from 'helpers/flashSale';
 import { GBPCountries } from 'helpers/internationalisation/countryGroup';
@@ -173,7 +176,10 @@ const getProduct = (subsLinks: SubsUrls, countryGroupId: CountryGroupId): ?Produ
     case 'GuardianWeekly':
       return products.GuardianWeekly;
     default:
-      if (flashSaleIsActive('DigitalPack', countryGroupId)) {
+      if (
+        (countryGroupId === GBPCountries || countryGroupId === International) &&
+        flashSaleIsActive('DigitalPack', countryGroupId)
+      ) {
         return products.DigitalPack;
       }
       return products.GuardianWeekly;

--- a/support-frontend/assets/pages/subscriptions-landing/components/featuredProducts.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/components/featuredProducts.jsx
@@ -8,7 +8,6 @@ import { getQueryParameter } from 'helpers/url';
 import { type SubscriptionProduct } from 'helpers/subscriptions';
 import {
   type CountryGroupId,
-  International,
 } from 'helpers/internationalisation/countryGroup';
 import GridPicture from 'components/gridPicture/gridPicture';
 import { flashSaleIsActive, getSaleCopy } from 'helpers/flashSale';

--- a/support-frontend/assets/pages/subscriptions-landing/components/featuredProducts.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/components/featuredProducts.jsx
@@ -177,7 +177,7 @@ const getProduct = (subsLinks: SubsUrls, countryGroupId: CountryGroupId): ?Produ
       return products.GuardianWeekly;
     default:
       if (
-        (countryGroupId === GBPCountries || countryGroupId === International) &&
+        (countryGroupId === GBPCountries) &&
         flashSaleIsActive('DigitalPack', countryGroupId)
       ) {
         return products.DigitalPack;


### PR DESCRIPTION
## Why are you doing this?
We only want to show the Digital Pack in the hero position for the UK, people in US, CA, AU, NZ & ROW should still see Guardian Weekly as the hero.

[**Trello Card**](https://trello.com/c/t0AJxCgF/2644-showcase-hero-product)
