### PR TITLE
use latest sbt version

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.0
+sbt.version=1.3.2


### PR DESCRIPTION
## Why are you doing this?

After https://github.com/guardian/support-frontend/pull/2082 there is a new version out: https://github.com/sbt/sbt/releases

I know some people had memory issues, and issues getting out of ./devrun.sh script, but I don't think either of those issues will be fixed by this.

However it's a good idea to keep up to date, as it's not much effort, and being on an old version has risks.