### PR TITLE
send redux event history to support-frontend and log it

### DIFF
--- a/support-frontend/app/services/stepfunctions/Client.scala
+++ b/support-frontend/app/services/stepfunctions/Client.scala
@@ -11,6 +11,7 @@ import com.amazonaws.services.stepfunctions.model._
 import com.amazonaws.services.stepfunctions.{AWSStepFunctionsAsync, AWSStepFunctionsAsyncClientBuilder}
 import io.circe.Encoder
 import cats.implicits._
+import com.gu.monitoring.SafeLogger
 import services.stepfunctions.StateMachineErrors.Fail
 
 import scala.collection.JavaConversions._
@@ -35,6 +36,10 @@ class Client(client: AWSStepFunctionsAsync, arn: StateMachineArn) {
 
   private def startExecution(arn: String, input: String)(implicit ec: ExecutionContext): Response[StartExecutionResult] = convertErrors {
     AwsAsync(client.startExecutionAsync, new StartExecutionRequest().withStateMachineArn(arn).withInput(input))
+      .transform { theTry =>
+        SafeLogger.info(s"state machine result: $theTry")
+        theTry
+      }
   }
 
   def triggerExecution[T](input: T, isTestUser: Boolean, isExistingAccount: Boolean = false)(

--- a/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
+++ b/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
@@ -52,7 +52,7 @@ case class CreateSupportWorkersRequest(
   email: String,
   telephoneNumber: Option[String],
   deliveryInstructions: Option[String],
-  debugInfo: Option[String]
+  debugInfo: Option[String] = None
 )
 
 object SupportWorkersClient {

--- a/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
+++ b/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
@@ -120,7 +120,6 @@ class SupportWorkersClient(
     requestId: UUID,
     promoCode: Option[PromoCode] = None
   ): EitherT[Future, SupportWorkersError, StatusResponse] = {
-    SafeLogger.info(s"$requestId: debug info ${request.body.debugInfo}")
 
     val createPaymentMethodState = CreatePaymentMethodState(
       requestId = requestId,

--- a/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
+++ b/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
@@ -120,6 +120,7 @@ class SupportWorkersClient(
     requestId: UUID,
     promoCode: Option[PromoCode] = None
   ): EitherT[Future, SupportWorkersError, StatusResponse] = {
+    SafeLogger.info(s"$requestId: debug info ${request.body.debugInfo}")
 
     val createPaymentMethodState = CreatePaymentMethodState(
       requestId = requestId,
@@ -133,8 +134,7 @@ class SupportWorkersClient(
         supportAbTests = request.body.supportAbTests
       )),
       promoCode = request.body.promoCode,
-      firstDeliveryDate = request.body.firstDeliveryDate,
-      debugInfo = request.body.debugInfo
+      firstDeliveryDate = request.body.firstDeliveryDate
     )
     val isExistingAccount = createPaymentMethodState.paymentFields.isInstanceOf[ExistingPaymentFields]
     underlying.triggerExecution(createPaymentMethodState, user.isTestUser, isExistingAccount).bimap(

--- a/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
+++ b/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
@@ -51,7 +51,8 @@ case class CreateSupportWorkersRequest(
   supportAbTests: Set[AbTest],
   email: String,
   telephoneNumber: Option[String],
-  deliveryInstructions: Option[String]
+  deliveryInstructions: Option[String],
+  debugInfo: Option[String]
 )
 
 object SupportWorkersClient {
@@ -119,6 +120,7 @@ class SupportWorkersClient(
     requestId: UUID,
     promoCode: Option[PromoCode] = None
   ): EitherT[Future, SupportWorkersError, StatusResponse] = {
+    SafeLogger.info(s"$requestId: debug info ${request.body.debugInfo}")
 
     val createPaymentMethodState = CreatePaymentMethodState(
       requestId = requestId,
@@ -132,7 +134,8 @@ class SupportWorkersClient(
         supportAbTests = request.body.supportAbTests
       )),
       promoCode = request.body.promoCode,
-      firstDeliveryDate = request.body.firstDeliveryDate
+      firstDeliveryDate = request.body.firstDeliveryDate,
+      debugInfo = request.body.debugInfo
     )
     val isExistingAccount = createPaymentMethodState.paymentFields.isInstanceOf[ExistingPaymentFields]
     underlying.triggerExecution(createPaymentMethodState, user.isTestUser, isExistingAccount).bimap(

--- a/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
+++ b/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
@@ -101,6 +101,7 @@ export type RegularPaymentRequest = {|
   telephoneNumber: Option<string>,
   promoCode?: Option<string>,
   deliveryInstructions?: Option<string>,
+  debugInfo?: string,
 |};
 
 export type StripePaymentMethod = 'StripeCheckout' | 'StripeApplePay' | 'StripePaymentRequestButton' | 'StripeElements';

--- a/support-frontend/assets/helpers/subscriptionsForms/formFields.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/formFields.js
@@ -52,6 +52,7 @@ export type FormState = {|
   productPrices: ProductPrices,
   payPalHasLoaded: boolean,
   stripeToken: Option<string>,
+  debugInfo: string,
 |};
 
 function getFormFields(state: AnyCheckoutState): FormFields {

--- a/support-frontend/assets/helpers/subscriptionsForms/formReducer.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/formReducer.js
@@ -58,12 +58,15 @@ function createFormReducer(
     orderIsAGift: false,
     stripeToken: null,
     deliveryInstructions: null,
+    debugInfo: '',
   };
 
   const getFulfilmentOption = (action, currentOption) =>
     (action.scope === 'delivery' ? getWeeklyFulfilmentOption(action.country) : currentOption);
 
-  return (state: FormState = initialState, action: Action): FormState => {
+  return (originalState: FormState = initialState, action: Action): FormState => {
+
+    const state = { ...originalState, debugInfo: `${originalState.debugInfo}${JSON.stringify(action)}\n` };
 
     switch (action.type) {
 

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.js
@@ -117,6 +117,7 @@ function buildRegularPaymentRequest(
     productOption,
     productPrices,
     deliveryInstructions,
+    debugInfo,
   } = state.page.checkout;
 
   const price = getProductPrice(
@@ -158,6 +159,7 @@ function buildRegularPaymentRequest(
     ),
     promoCode,
     deliveryInstructions,
+    debugInfo
   };
 }
 

--- a/support-models/src/main/scala/com/gu/support/workers/states/CreatePaymentMethodState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/CreatePaymentMethodState.scala
@@ -15,7 +15,8 @@ case class CreatePaymentMethodState(
   paymentFields: PaymentFields,
   firstDeliveryDate: Option[LocalDate],
   promoCode: Option[PromoCode],
-  acquisitionData: Option[AcquisitionData]
+  acquisitionData: Option[AcquisitionData],
+  debugInfo: Option[String]
 ) extends StepFunctionUserState
 
 import com.gu.support.encoding.Codec

--- a/support-models/src/main/scala/com/gu/support/workers/states/CreatePaymentMethodState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/CreatePaymentMethodState.scala
@@ -15,8 +15,7 @@ case class CreatePaymentMethodState(
   paymentFields: PaymentFields,
   firstDeliveryDate: Option[LocalDate],
   promoCode: Option[PromoCode],
-  acquisitionData: Option[AcquisitionData],
-  debugInfo: Option[String]
+  acquisitionData: Option[AcquisitionData]
 ) extends StepFunctionUserState
 
 import com.gu.support.encoding.Codec


### PR DESCRIPTION
## Why are you doing this?

We have had a few more checkout failures for GW, where people are getting a ROW stripe token and submitting with AUD currency.
We don't really understand why this happens, but pushing the whole redux state to the server might help us to correlate together the steps to reproduce.

This PR just gathers all the action history and pushes it on one big string.  Then we can look at it later and try to reproduce.

We did try putting it into the support workers state, but the encryption only handles 4096KB so we could end up with failures due to the debugging, which would be ironically bad.

this is the post request from client to server
![image](https://user-images.githubusercontent.com/7304387/65877504-bd708680-e383-11e9-866d-31bdde93482b.png)

this is the support-frontend log
```
2019-10-01 17:17:15,567 [application-akka.actor.default-dispatcher-3] INFO  com.gu.monitoring.SafeLogger$ - f64cf20a-9a67-de3e-0000-000000000002: debug info Some({"type":"@@INIT"}
{"scope":"delivery","type":"SET_ADDRESS_LINE_1","lineOne":"sdjkhfgsd"}
{"scope":"delivery","type":"SET_TOWN_CITY","city":"sdjkhfgsd"}
{"type":"SET_POSTCODE","postCode":"sdjkhfgsd","scope":"delivery"}
{"type":"SET_BILLING_ADDRESS_IS_SAME","isSame":true}
{"type":"SET_COUNTRY_INTERNATIONALISATION","country":"GB"}
{"type":"SET_COUNTRY_CHANGED","country":"GB","scope":"billing"}
{"type":"SET_BILLING_PERIOD","billingPeriod":"SixWeekly"}
{"type":"SET_PAYMENT_METHOD","paymentMethod":"DirectDebit","country":"GB"}
{"type":"SET_PAYMENT_METHOD","paymentMethod":"Stripe","country":"GB"}
{"type":"SET_STRIPE_TOKEN","stripeToken":"tok_FudI4YFmYPwgjA"}
)
```