### PR TITLE
Re-enable contribute button for single payment flow

### DIFF
--- a/support-frontend/assets/helpers/subscriptionsForms/submit.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.js
@@ -159,7 +159,7 @@ function buildRegularPaymentRequest(
     ),
     promoCode,
     deliveryInstructions,
-    debugInfo
+    debugInfo,
   };
 }
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionSubmit.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionSubmit.jsx
@@ -19,7 +19,6 @@ import { type State } from '../contributionsLandingReducer';
 import { sendFormSubmitEventForPayPalRecurring } from '../contributionsLandingActions';
 import type { PaymentMethod } from 'helpers/paymentMethods';
 import { PayPal } from 'helpers/paymentMethods';
-import type { StripeElementsTestVariants } from 'helpers/abTests/abtestDefinitions';
 import Button from 'components/button/button';
 
 // ----- Types ----- //
@@ -62,7 +61,7 @@ function mapStateToProps(state: State) {
       state.page.form.formData.otherAmounts,
       contributionType,
     ),
-    billingPeriod: billingPeriodFromContrib(contributionType)
+    billingPeriod: billingPeriodFromContrib(contributionType),
   });
 }
 
@@ -83,7 +82,7 @@ const mapDispatchToProps = (dispatch: Function) => ({
 
 function withProps(props: PropTypes) {
 
- if (props.paymentMethod !== 'None') {
+  if (props.paymentMethod !== 'None') {
     // if all payment methods are switched off, do not display the button
     const formClassName = 'form--contribution';
     const showPayPalRecurringButton = props.paymentMethod === PayPal && props.contributionType !== 'ONE_OFF';

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionSubmit.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionSubmit.jsx
@@ -20,7 +20,6 @@ import { sendFormSubmitEventForPayPalRecurring } from '../contributionsLandingAc
 import type { PaymentMethod } from 'helpers/paymentMethods';
 import { PayPal } from 'helpers/paymentMethods';
 import type { StripeElementsTestVariants } from 'helpers/abTests/abtestDefinitions';
-import { stripeCardFormIsIncomplete } from 'helpers/stripe';
 import Button from 'components/button/button';
 
 // ----- Types ----- //
@@ -41,9 +40,7 @@ type PropTypes = {|
   onPaymentAuthorisation: PaymentAuthorisation => void,
   formIsSubmittable: boolean,
   amount: number,
-  billingPeriod: BillingPeriod,
-  stripeCardFormComplete: boolean,
-  stripeElementsTestVariant: StripeElementsTestVariants,
+  billingPeriod: BillingPeriod
 |};
 
 function mapStateToProps(state: State) {
@@ -65,9 +62,7 @@ function mapStateToProps(state: State) {
       state.page.form.formData.otherAmounts,
       contributionType,
     ),
-    billingPeriod: billingPeriodFromContrib(contributionType),
-    stripeCardFormComplete: state.page.form.stripeCardFormData.formComplete,
-    stripeElementsTestVariant: state.common.abParticipations.stripeElements,
+    billingPeriod: billingPeriodFromContrib(contributionType)
   });
 }
 
@@ -88,16 +83,7 @@ const mapDispatchToProps = (dispatch: Function) => ({
 
 function withProps(props: PropTypes) {
 
-  const buttonDisabled = (): boolean =>
-    props.isWaiting ||
-    stripeCardFormIsIncomplete(
-      props.contributionType,
-      props.paymentMethod,
-      props.stripeElementsTestVariant,
-      props.stripeCardFormComplete,
-    );
-
-  if (props.paymentMethod !== 'None') {
+ if (props.paymentMethod !== 'None') {
     // if all payment methods are switched off, do not display the button
     const formClassName = 'form--contribution';
     const showPayPalRecurringButton = props.paymentMethod === PayPal && props.contributionType !== 'ONE_OFF';
@@ -137,7 +123,7 @@ function withProps(props: PropTypes) {
           <Button
             type="submit"
             aria-label={submitButtonCopy}
-            disabled={buttonDisabled()}
+            disabled={props.isWaiting}
             postDeploymentTestID="contributions-landing-submit-contribution-button"
           >
             {submitButtonCopy}

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
@@ -33,10 +33,13 @@ type PropTypes = {|
   setHandleStripe3DS: ((clientSecret: string) => Promise<Stripe3DSResult>) => Action,
   paymentWaiting: (isWaiting: boolean) => Action,
   setStripeCardFormComplete: (isComplete: boolean) => Action,
+  checkoutFormHasBeenSubmitted: boolean,
+
 |};
 
 const mapStateToProps = (state: State) => ({
   contributionType: state.page.form.contributionType,
+  checkoutFormHasBeenSubmitted: state.page.form.formData.checkoutFormHasBeenSubmitted,
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -169,10 +172,26 @@ class CardForm extends Component<PropTypes, StateTypes> {
     this.state.CVC.name === 'Complete';
 
   render() {
-    const errorMessage: ?string =
+    const fieldError: ?string =
       errorMessageFromState(this.state.CardNumber) ||
       errorMessageFromState(this.state.Expiry) ||
       errorMessageFromState(this.state.CVC);
+
+    const incompleteMessage = (): ?string => {
+      if (
+        this.props.checkoutFormHasBeenSubmitted &&
+        (
+          this.state.CardNumber.name === 'Incomplete' ||
+          this.state.Expiry.name === 'Incomplete' ||
+          this.state.CVC.name === 'Incomplete'
+        )
+      ) {
+        return 'Please complete your card details';
+      }
+      return undefined;
+    };
+
+    const errorMessage: ?string = fieldError || incompleteMessage();
 
     const getClasses = (fieldName: CardFieldName): string =>
       `form__input ${this.getFieldBorderClass(fieldName)}`;
@@ -180,7 +199,6 @@ class CardForm extends Component<PropTypes, StateTypes> {
     return (
       <div className="form__fields">
         <legend className="form__legend">Your card details</legend>
-
         <div className="form__field">
           <label className="form__label" htmlFor="stripeCardNumberElement">
             <span>Card number</span>
@@ -195,7 +213,6 @@ class CardForm extends Component<PropTypes, StateTypes> {
             />
           </span>
         </div>
-
         <div className="stripe-card-element-container__inline-fields">
           <div className="form__field">
             <label className="form__label" htmlFor="stripeCardExpiryElement">
@@ -211,7 +228,6 @@ class CardForm extends Component<PropTypes, StateTypes> {
               />
             </span>
           </div>
-
           <div className="form__field">
             <label className="form__label" htmlFor="stripeCardCVCElement">
               <span>CVC</span>
@@ -228,7 +244,6 @@ class CardForm extends Component<PropTypes, StateTypes> {
             </span>
           </div>
         </div>
-
         {errorMessage ? <div className="form__error">{errorMessage}</div> : null}
       </div>
     );


### PR DESCRIPTION
## Why are you doing this?

It was decided that it would be better to make the single payment 'contribute' button always-enabled for consistency with the other tabs.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/f3mIxwTq)

## Screenshots

### Before
<img width="473" alt="image" src="https://user-images.githubusercontent.com/15648334/66059940-bd63b880-e534-11e9-93d1-0f61a0a9a0dc.png">

### After 
<img width="481" alt="image" src="https://user-images.githubusercontent.com/15648334/66060005-dbc9b400-e534-11e9-9b3a-679f58a7872d.png">
