### PR TITLE
Revert "Revert "New subs showcase page 2""

### DIFF
--- a/support-frontend/assets/components/packshots/feature-packshot.jsx
+++ b/support-frontend/assets/components/packshots/feature-packshot.jsx
@@ -1,3 +1,5 @@
+// @flow
+
 import React from 'react';
 
 import GridImage from 'components/gridImage/gridImage';

--- a/support-frontend/assets/components/packshots/feature-packshot.jsx
+++ b/support-frontend/assets/components/packshots/feature-packshot.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import GridImage from 'components/gridImage/gridImage';
+
+const FeaturePackshot = () => (
+  <div className="subscriptions-feature-packshot">
+    <GridImage
+      gridId="subscriptionFeature"
+      srcSizes={[1000, 500]}
+      sizes="(max-width: 480px) 100px,
+              (max-width: 740px) 100%,
+              (max-width: 1067px) 150%,
+              800px"
+      imgType="png"
+    />
+  </div>
+);
+
+export default FeaturePackshot;

--- a/support-frontend/assets/components/packshots/full-guardian-weekly-packshot.jsx
+++ b/support-frontend/assets/components/packshots/full-guardian-weekly-packshot.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import GridImage from 'components/gridImage/gridImage';
+
+/** NOTE about packshot images
+ * ------
+ * because these images are absolute positioned and thus provide
+ * no width or height information to rest of the DOM
+ * these packshots must have a width applied to allow the
+ * container CSS to center the pack shot as a single image
+ * this is applied using the "subscriptions__guardian-weekly-packshot" class in this instance
+ *  */
+
+
+const FullGuardianWeeklyPackShot = () => (
+  <div className="subscriptions-feature-packshot">
+    <GridImage
+      gridId="subscriptionGuardianWeeklyPackShot"
+      srcSizes={[1000, 500]}
+      sizes="(max-width: 480px) 100px,
+              (max-width: 740px) 100%,
+              (max-width: 1067px) 150%,
+              800px"
+      imgType="png"
+    />
+  </div>
+);
+
+export default FullGuardianWeeklyPackShot;

--- a/support-frontend/assets/components/packshots/full-guardian-weekly-packshot.jsx
+++ b/support-frontend/assets/components/packshots/full-guardian-weekly-packshot.jsx
@@ -1,3 +1,5 @@
+// @flow
+
 import React from 'react';
 
 import GridImage from 'components/gridImage/gridImage';

--- a/support-frontend/assets/components/packshots/guardian-weekly-packshot.jsx
+++ b/support-frontend/assets/components/packshots/guardian-weekly-packshot.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+import GridImage from 'components/gridImage/gridImage';
+
+/** NOTE about packshot images
+ * ------
+ * because these images are absolute positioned and thus provide
+ * no width or height information to rest of the DOM
+ * these packshots must have a width applied to allow the
+ * container CSS to center the pack shot as a single image
+ * this is applied using the "subscriptions__guardian-weekly-packshot" class in this instance
+ *  */
+
+
+const GuardianWeeklyPackShot = () => (
+  <div className="subscriptions__guardian-weekly-packshot">
+    <GridImage
+      gridId="subscriptionWeekly1"
+      srcSizes={[798, 500, 140]}
+      sizes="(max-width: 980px) 175px,
+            250px"
+      imgType="png"
+    />
+    <GridImage
+      gridId="subscriptionWeekly2"
+      srcSizes={[783, 392]}
+      sizes="(max-width: 740px) 100%,
+            (max-width: 980px) 175px,
+            250px"
+      imgType="png"
+    />
+    <GridImage
+      gridId="subscriptionWeekly3"
+      srcSizes={[798, 500, 140]}
+      sizes="(max-width: 980px) 175px,
+            250px"
+      imgType="png"
+    />
+  </div>
+);
+
+export default GuardianWeeklyPackShot;

--- a/support-frontend/assets/components/packshots/guardian-weekly-packshot.jsx
+++ b/support-frontend/assets/components/packshots/guardian-weekly-packshot.jsx
@@ -1,3 +1,5 @@
+// @flow
+
 import React from 'react';
 
 import GridImage from 'components/gridImage/gridImage';

--- a/support-frontend/assets/components/packshots/int-feature-packshot.jsx
+++ b/support-frontend/assets/components/packshots/int-feature-packshot.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import GridImage from 'components/gridImage/gridImage';
+
+const IntFeaturePackshot = () => (
+  <div className="subscriptions-int-feature-packshot">
+    <GridImage
+      gridId="subscriptionFeature"
+      srcSizes={[1000, 500]}
+      sizes="(max-width: 480px) 100px,
+              (max-width: 740px) 100%,
+              (max-width: 1067px) 150%,
+              800px"
+      imgType="png"
+    />
+  </div>
+);
+
+export default IntFeaturePackshot;

--- a/support-frontend/assets/components/packshots/int-feature-packshot.jsx
+++ b/support-frontend/assets/components/packshots/int-feature-packshot.jsx
@@ -1,3 +1,5 @@
+// @flow
+
 import React from 'react';
 
 import GridImage from 'components/gridImage/gridImage';

--- a/support-frontend/assets/components/packshots/paper-and-digital-packshot.jsx
+++ b/support-frontend/assets/components/packshots/paper-and-digital-packshot.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+import GridImage from 'components/gridImage/gridImage';
+
+const PaperAndDigitalPackshot = () => (
+  <div className="paper-and-digital-packshot">
+    <GridImage
+      gridId="subscriptionIpad"
+      srcSizes={[1000, 500, 140]}
+      sizes="(max-width: 740px) 100%,
+            (max-width: 980px) 275px,
+            300px"
+      imgType="png"
+    />
+    <GridImage
+      gridId="subscriptionPrint"
+      srcSizes={[805, 402]}
+      sizes="(max-width: 740px) 100%,
+            (max-width: 980px) 275px,
+            300px"
+      imgType="png"
+    />
+    <GridImage
+      gridId="subscriptionIphone"
+      srcSizes={[578, 527, 264]}
+      sizes="(max-width: 740px) 100%,
+            (max-width: 980px) 100px,
+            125px"
+      imgType="png"
+    />
+    <GridImage
+      gridId="subscriptionPrintDigital"
+      srcSizes={[452, 905, 1366]}
+      sizes="(max-width: 740px) 100%,
+            (max-width: 980px) 100px,
+            125px"
+      imgType="png"
+    />
+  </div>
+);
+
+export default PaperAndDigitalPackshot;

--- a/support-frontend/assets/components/packshots/paper-and-digital-packshot.jsx
+++ b/support-frontend/assets/components/packshots/paper-and-digital-packshot.jsx
@@ -1,3 +1,5 @@
+// @flow
+
 import React from 'react';
 
 import GridImage from 'components/gridImage/gridImage';

--- a/support-frontend/assets/components/packshots/paper-packshot.jsx
+++ b/support-frontend/assets/components/packshots/paper-packshot.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import GridImage from 'components/gridImage/gridImage';
+
+const PaperPackshot = () => (
+  <div className="subscriptions__paper-packshot">
+    <GridImage
+      gridId="subscriptionFeast"
+      srcSizes={[660, 500, 140]}
+      sizes="(max-width: 980px) 165px,
+            190px"
+      imgType="png"
+    />
+    <GridImage
+      gridId="subscriptionPrint"
+      srcSizes={[805, 402]}
+      sizes="(max-width: 740px) 100%,
+            (max-width: 980px) 275px,
+            300px"
+      imgType="png"
+    />
+    <GridImage
+      gridId="subscriptionG2"
+      srcSizes={[756, 500, 140]}
+      sizes="(max-width: 980px) 195px,
+            220px"
+      imgType="png"
+    />
+  </div>
+);
+
+export default PaperPackshot;

--- a/support-frontend/assets/components/packshots/paper-packshot.jsx
+++ b/support-frontend/assets/components/packshots/paper-packshot.jsx
@@ -1,3 +1,5 @@
+// @flow
+
 import React from 'react';
 import GridImage from 'components/gridImage/gridImage';
 

--- a/support-frontend/assets/components/packshots/premium-app-packshot.jsx
+++ b/support-frontend/assets/components/packshots/premium-app-packshot.jsx
@@ -1,3 +1,5 @@
+// @flow
+
 import React from 'react';
 
 import GridImage from 'components/gridImage/gridImage';

--- a/support-frontend/assets/components/packshots/premium-app-packshot.jsx
+++ b/support-frontend/assets/components/packshots/premium-app-packshot.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import GridImage from 'components/gridImage/gridImage';
+
+const PremiumAppPackshot = () => (
+  <div>
+    <GridImage
+      classModifiers={['subscriptions-premium-image']}
+      gridId="subscriptionIphone"
+      srcSizes={[578, 527, 264]}
+      sizes="(max-width: 480px) 100px,
+              (max-width: 740px) 200px,
+              300px"
+      imgType="png"
+    />
+  </div>
+);
+
+export default PremiumAppPackshot;

--- a/support-frontend/assets/components/subscriptionsProductDescription/subscriptionsProductDescription.jsx
+++ b/support-frontend/assets/components/subscriptionsProductDescription/subscriptionsProductDescription.jsx
@@ -1,0 +1,44 @@
+// @flow
+
+import React from 'react';
+
+import AnchorButton from 'components/button/anchorButton';
+
+// types
+import { type Option } from 'helpers/types/option';
+import type { ProductButton } from 'pages/subscriptions-landing/copy/subscriptionCopy';
+
+type PropTypes = {
+  title: string,
+  subtitle: string,
+  description: string,
+  isFeature: Option<boolean>,
+  offer?: Option<string>,
+  buttons: ProductButton[],
+};
+
+const SubscriptionsProductDescription = ({
+  title, subtitle, description, offer, isFeature, buttons,
+}: PropTypes) => (
+  <div>
+    <h2 className="subscriptions__product-title">{title}</h2>
+    <h3 className="subscriptions__product-subtitle">{subtitle}</h3>
+    {offer && <h4 className="subscriptions__sales">{offer}</h4>}
+    <p className="subscriptions__description">{description}</p>
+    {buttons.map(button => (
+      <AnchorButton
+        href={button.link}
+        modifierClasses={(!isFeature) ? ['subscriptions__product-button'] : []}
+        onClick={button.analyticsTracking}
+      >
+        {button.ctaButtonText}
+      </AnchorButton>
+    ))}
+  </div>
+);
+
+SubscriptionsProductDescription.defaultProps = {
+  offer: null,
+};
+
+export default SubscriptionsProductDescription;

--- a/support-frontend/assets/helpers/flashSale.js
+++ b/support-frontend/assets/helpers/flashSale.js
@@ -9,6 +9,9 @@ import { type SubscriptionProduct } from './subscriptions';
 import { AUDCountries, GBPCountries, EURCountries, Canada, International, UnitedStates, NZDCountries } from './internationalisation/countryGroup';
 import { type FulfilmentOptions } from './productPrice/fulfilmentOptions';
 import { type Option } from 'helpers/types/option';
+import {
+  fromCountryGroupId, glyph,
+} from 'helpers/internationalisation/currency';
 
 export type SaleCopy = {
   featuredProduct: {
@@ -57,7 +60,7 @@ type Sale = {
 const dpSale = {
   promoCode: 'DK0NT24WG',
   intcmp: '',
-  price: 0,
+  price: 5.99,
   saleCopy: {
     featuredProduct: {
       heading: 'Digital Pack',
@@ -255,6 +258,16 @@ function getFormattedFlashSalePrice(
   return fixDecimals(sale.saleDetails[countryGroupId].price);
 }
 
+function getDisplayFlashSalePrice(
+  product: SubscriptionProduct,
+  countryGroupId: CountryGroupId,
+  period: BillingPeriod,
+): string {
+  const currency = glyph(fromCountryGroupId(countryGroupId) || 'GBP');
+  const price = getFormattedFlashSalePrice(product, countryGroupId, period);
+  return `${currency}${price}/${period}`;
+}
+
 function countdownTimerIsActive(flashSaleActive: boolean, showForHowManyDays: number, endTime: number): boolean {
   if (flashSaleActive) {
     const timeTravelDays = getTimeTravelDaysOverride();
@@ -277,6 +290,7 @@ function showCountdownTimer(product: SubscriptionProduct, countryGroupId: Countr
 
 export {
   flashSaleIsActive,
+  getDisplayFlashSalePrice,
   getPromoCode,
   getAnnualPlanPromoCode,
   getIntcmp,

--- a/support-frontend/assets/helpers/subscriptions.js
+++ b/support-frontend/assets/helpers/subscriptions.js
@@ -61,7 +61,7 @@ const newsstandPrices: {[PaperProductOptions]: number} = {
 
 // ----- Config ----- //
 
-const subscriptionPricesForDefaultBillingPeriod: {
+export const subscriptionPricesForDefaultBillingPeriod: {
   [SubscriptionProduct]: {
     [CountryGroupId]: number,
   }

--- a/support-frontend/assets/helpers/theGrid.js
+++ b/support-frontend/assets/helpers/theGrid.js
@@ -83,6 +83,17 @@ export const imageCatalogue: {
   showcaseUKChris: 'd80f77ff8069d1f39071a00a752cb2e8728d082a/381_0_2004_2004',
   showcaseUKFloods: 'cb8d5002ec1ac03e64da32d87fe7f804fc900dfb/163_1119_3136_789',
   showcaseUKWindrushGroup: '2ec9dab8f39d1e9b12b9c7625b5ad2b058f3420b/1175_287_3335_3335',
+  subscriptionFeature: '432b55d4401dde2b58f6ce61e7c9ddf50958962a/0_0_1584_954',
+  subscriptionWeekly1: 'cf47a92149f2b347fcd43e825e6e48c6601820f5/0_0_798_675',
+  subscriptionWeekly2: '67d8da6245b1436aa767a5b5eaf853dddf1ce8ad/0_0_2035_2598',
+  subscriptionWeekly3: 'd72bdce2c96e259939b33cc8a9c43e43d0129f7f/0_0_798_675',
+  subscriptionFeast: '4fac3988229d109512b4dfa0930b126e36985a2c/0_0_660_636',
+  subscriptionPrint: '/0575f214ad20536c7731172e36f349778df168c7/0_0_877_1090',
+  subscriptionG2: 'f1cafef5a6bda2835f050042b9336645a24228ff/0_0_756_645',
+  subscriptionIpad: 'c2843d4ec6bc7644c62c8691b6c7e83e76c93e0e/0_0_1302_998',
+  subscriptionIphone: '8850945f0003d2a7204050644db446d827dead95/0_0_578_1096',
+  subscriptionPrintDigital: '476a8aadac1f3a971b9b1a9a023b04cb72c8f7ca/0_0_1366_1510',
+  subscriptionGuardianWeeklyPackShot: '299d99cb5dc2d98607e9333d5e1e15c9f7d4860f/0_0_1552_921',
   printShowcase: '311c4a9dd0e8030b734dd54b71fcd0d4cb2a303b/0_0_1486_750',
 };
 

--- a/support-frontend/assets/pages/subscriptions-landing/components/featureHeader.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/components/featureHeader.jsx
@@ -1,3 +1,5 @@
+// @flow
+
 import React from 'react';
 
 const FeatureHeader = () => (

--- a/support-frontend/assets/pages/subscriptions-landing/components/featureHeader.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/components/featureHeader.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const FeatureHeader = () => (
+  <div className="subscriptions__feature">
+    <div className="subscriptions__feature-container">
+      <h2 className="subscriptions__feature-text">Support the Guardian with a print or digital subscription.</h2>
+    </div>
+  </div>
+);
+
+export default FeatureHeader;

--- a/support-frontend/assets/pages/subscriptions-landing/components/subscriptionsLandingContent.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/components/subscriptionsLandingContent.jsx
@@ -1,0 +1,33 @@
+// @flow
+
+import React from 'react';
+
+// components
+import SubscriptionsProduct from './subscriptionsProduct';
+import FeatureHeader from './featureHeader';
+
+import { subscriptionCopy } from '../copy/subscriptionCopy'; // make the first card a feature
+
+const isFeature = index => index === 0;
+
+const SubscriptionsLandingContent = () => (
+  <div className="subscriptions-landing-page">
+    <FeatureHeader />
+    <div className="subscriptions__product-container">
+      {subscriptionCopy.map((product, index) => (
+        <SubscriptionsProduct
+          title={product.title}
+          subtitle={product.subtitle}
+          description={product.description}
+          productImage={product.productImage}
+          buttons={product.buttons}
+          offer={product.offer || null}
+          isFeature={isFeature(index)}
+          classModifier={product.classModifier}
+        />
+      ))}
+    </div>
+  </div>
+);
+
+export default SubscriptionsLandingContent;

--- a/support-frontend/assets/pages/subscriptions-landing/components/subscriptionsProduct.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/components/subscriptionsProduct.jsx
@@ -1,0 +1,49 @@
+// @flow
+
+import React from 'react';
+import type { Node } from 'react';
+import cx from 'classnames';
+import { type Option } from 'helpers/types/option';
+
+import SubscriptionsProductDescription from 'components/subscriptionsProductDescription/subscriptionsProductDescription';
+import type { ProductButton } from 'pages/subscriptions-landing/copy/subscriptionCopy';
+
+type PropTypes = {
+  title: string,
+  subtitle: string,
+  description: string,
+  buttons: ProductButton[],
+  productImage: Node,
+  offer?: Option<string>,
+  isFeature?: Option<boolean>,
+  classModifier: string[],
+}
+
+const SubscriptionsProduct = ({
+  classModifier, productImage, isFeature, ...props
+}: PropTypes) => (
+  <div className={cx('subscriptions__product', { 'subscriptions__product--feature': isFeature }, classModifier)}>
+
+    <div className={cx('subscriptions__image-container', { 'subscriptions__product--feature': isFeature })}>
+      <div className={isFeature ? 'subscriptions__feature-image-wrapper' : 'subscriptions-packshot'}>
+        {productImage}
+      </div>
+    </div>
+
+    <div className={cx('subscriptions__copy-container', { 'subscriptions__product--feature': isFeature })} >
+      <div className="subscriptions__copy-wrapper">
+        <SubscriptionsProductDescription
+          {...props}
+          isFeature={isFeature}
+        />
+      </div>
+    </div>
+  </div>
+);
+
+SubscriptionsProduct.defaultProps = {
+  offer: null,
+  isFeature: false,
+};
+
+export default SubscriptionsProduct;

--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
@@ -138,7 +138,6 @@ const premiumApp: ProductCopy = {
     ctaButtonText: 'Buy in App Store',
     link: getIosAppUrl(countryGroupId),
     analyticsTracking: trackAppStoreLink('premium_tier_ios_cta', 'PremiumTier', abTest),
-    // these buttons need a change there css so the text fits at 320px width
   }, {
     ctaButtonText: 'Buy on Google Play',
     link: androidAppUrl,

--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
@@ -1,0 +1,192 @@
+// @flow
+import * as React from 'react';
+import { init as pageInit } from 'helpers/page/page';
+
+// type
+import { type SubscriptionProduct } from 'helpers/subscriptions';
+
+// images
+import FeaturePackshot from 'components/packshots/feature-packshot';
+import GuardianWeeklyPackShot from 'components/packshots/guardian-weekly-packshot';
+import PaperPackshot from 'components/packshots/paper-packshot';
+import PremiumAppPackshot from 'components/packshots/premium-app-packshot';
+import PaperAndDigitalPackshot from 'components/packshots/paper-and-digital-packshot';
+import IntFeaturePackshot from 'components/packshots/int-feature-packshot';
+import FullGuardianWeeklyPackShot from 'components/packshots/full-guardian-weekly-packshot';
+
+// helpers
+import { displayPrice, sendTrackingEventsOnClick, subscriptionPricesForDefaultBillingPeriod } from 'helpers/subscriptions';
+import { getCampaign } from 'helpers/tracking/acquisitions';
+import { getSubsLinks } from 'helpers/externalLinks';
+import { androidAppUrl, getIosAppUrl } from 'helpers/externalLinks';
+import trackAppStoreLink from 'components/subscriptionBundles/appCtaTracking';
+
+// constants
+import { DigitalPack, PremiumTier, GuardianWeekly, Paper, PaperAndDigital } from 'helpers/subscriptions';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import type { Option } from 'helpers/types/option';
+
+// types
+
+export type ProductButton = {
+  ctaButtonText: string,
+  link: string,
+  analyticsTracking: Function,
+}
+
+export type ProductCopy = {
+  title: string,
+  subtitle: Option<string>,
+  description: string,
+  productImage: React.Node,
+  offer?: string,
+  buttons: ProductButton[],
+  isFeature?: boolean,
+}
+
+// store
+const store = pageInit();
+const commonStore = store.getState().common;
+const { countryGroupId } = commonStore.internationalisation;
+const { referrerAcquisitionData, abParticipations, optimizeExperiments } = commonStore;
+
+const abTest = null;
+
+const subsLinks = getSubsLinks(
+  countryGroupId,
+  referrerAcquisitionData.campaignCode,
+  getCampaign(referrerAcquisitionData),
+  referrerAcquisitionData,
+  abParticipations,
+  optimizeExperiments,
+);
+
+const PREMIUM_APP_ALT_TEXT = '7-day free Trial';
+
+const hasPrice = (product: SubscriptionProduct, alternativeText: string) => { // add Flow types
+
+  if (subscriptionPricesForDefaultBillingPeriod[product][countryGroupId]) {
+    return `${displayPrice(product, countryGroupId)}`;
+  }
+
+  return alternativeText;
+};
+
+const isUkProduct = product =>
+  (countryGroupId === 'GBPCountries' ? `from ${displayPrice(product, countryGroupId)}` : null);
+
+const chooseImage = images =>
+  (countryGroupId === 'GBPCountries' ? images[0] : images[1]);
+
+const digital: ProductCopy = {
+  title: 'Digital Pack',
+  subtitle: hasPrice(DigitalPack, ''),
+  description: 'The Daily Edition app and Premium app in one pack, plus ad-free reading on all your devices',
+  productImage: chooseImage([<FeaturePackshot />, <IntFeaturePackshot />]),
+  offer: '50% off for 3 months',
+  buttons: [{
+    ctaButtonText: 'Find out more',
+    link: subsLinks.DigitalPack,
+    analyticsTracking: sendTrackingEventsOnClick('digipack_cta', 'DigitalPack', abTest, 'digital-subscription'),
+  }],
+  isFeature: true,
+};
+
+const guardianWeekly: ProductCopy = {
+  title: 'Guardian Weekly',
+  subtitle: hasPrice(GuardianWeekly, ''),
+  description: 'A weekly, global magazine from The Guardian, with delivery worldwide',
+  buttons: [{
+    ctaButtonText: 'Find out more',
+    link: subsLinks.GuardianWeekly,
+    analyticsTracking: sendTrackingEventsOnClick('weekly_cta', 'GuardianWeekly', abTest),
+  }],
+  productImage: chooseImage([<GuardianWeeklyPackShot />, <FullGuardianWeeklyPackShot />]),
+};
+
+const paper: ProductCopy = {
+  title: 'Paper',
+  subtitle: isUkProduct(Paper),
+  description: 'Save on The Guardian and The Observer\'s newspaper retail price all year round',
+  buttons: [{
+    ctaButtonText: 'Find out more',
+    link: subsLinks.Paper,
+    analyticsTracking: sendTrackingEventsOnClick('paper_cta', Paper, abTest, 'paper-subscription'),
+  }],
+  productImage: <PaperPackshot />,
+  offer: 'Save up to 52% for a year',
+};
+
+const paperAndDigital: ProductCopy = {
+  title: 'Paper+Digital',
+  subtitle: isUkProduct(PaperAndDigital),
+  description: 'All the benefits of a paper subscription, plus access to the digital pack',
+  buttons: [{
+    ctaButtonText: 'Find out more',
+    link: subsLinks.PaperAndDigital,
+    analyticsTracking: sendTrackingEventsOnClick('paper_digital_cta', PaperAndDigital, abTest, 'paper-and-digital-subscription'),
+  }],
+  productImage: <PaperAndDigitalPackshot />,
+};
+
+const premiumApp: ProductCopy = {
+  title: 'Premium App',
+  subtitle: hasPrice(PremiumTier, PREMIUM_APP_ALT_TEXT),
+  description: 'The ad-free, Premium App, designed especially for your smartphone and tablet',
+  buttons: [{
+    ctaButtonText: 'Buy in App Store',
+    link: getIosAppUrl(countryGroupId),
+    analyticsTracking: trackAppStoreLink('premium_tier_ios_cta', 'PremiumTier', abTest),
+    // these buttons need a change there css so the text fits at 320px width
+  }, {
+    ctaButtonText: 'Buy on Google Play',
+    link: androidAppUrl,
+    analyticsTracking: trackAppStoreLink('premium_tier_android_cta', 'PremiumTier', abTest),
+  }],
+  productImage: <PremiumAppPackshot />,
+  classModifier: ['subscriptions__premuim-app'],
+};
+
+const orderedProducts: { [CountryGroupId]: ProductCopy[] } = {
+  GBPCountries: [
+    digital,
+    guardianWeekly,
+    paper,
+    paperAndDigital,
+    premiumApp,
+  ],
+  UnitedStates: [
+    guardianWeekly,
+    digital,
+    premiumApp,
+  ],
+  International: [
+    guardianWeekly,
+    digital,
+    premiumApp,
+  ],
+  AUDCountries: [
+    guardianWeekly,
+    digital,
+    premiumApp,
+  ],
+  EURCountries: [
+    guardianWeekly,
+    digital,
+    premiumApp,
+  ],
+  NZDCountries: [
+    guardianWeekly,
+    digital,
+    premiumApp,
+  ],
+  Canada: [
+    guardianWeekly,
+    digital,
+    premiumApp,
+  ],
+};
+
+const subscriptionCopy = orderedProducts[countryGroupId];
+
+export { subscriptionCopy };

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
@@ -8,14 +8,16 @@ import { Provider } from 'react-redux';
 import Page from 'components/page/page';
 import FooterContainer from 'components/footer/footerContainer';
 import { detect, type CountryGroupId, AUDCountries, Canada, EURCountries, GBPCountries, International, NZDCountries, UnitedStates } from 'helpers/internationalisation/countryGroup';
-import SubscriptionsByCountryGroup from 'components/subscriptionsByCountryGroup/subscriptionsByCountryGroup';
+// import SubscriptionsByCountryGroup from 'components/subscriptionsByCountryGroup/subscriptionsByCountryGroup';
 import headerWithCountrySwitcherContainer from 'components/headers/header/headerWithCountrySwitcher';
 
 import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
-import FeaturedProductAb from './components/featuredProductAb';
+// import FeaturedProductAb from './components/featuredProductAb';
 import ConsentBanner from 'components/consentBanner/consentBanner';
 import './subscriptionsLanding.scss';
+
+import SubscriptionLandingContent from './components/subscriptionsLandingContent';
 
 // ----- Redux Store ----- //
 
@@ -46,10 +48,13 @@ const content = (
       header={<Header />}
       footer={<FooterContainer disclaimer privacyPolicy />}
     >
-      <FeaturedProductAb
-        headingSize={3}
-      />
-      <SubscriptionsByCountryGroup headingSize={3} appMedium="subscribe_landing_page" />
+      <SubscriptionLandingContent />
+      {/*
+        <FeaturedProductAb
+          headingSize={3}
+        />
+        <SubscriptionsByCountryGroup headingSize={3} appMedium="subscribe_landing_page" />
+      */}
       <ConsentBanner />
     </Page>
   </Provider>

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
@@ -8,12 +8,10 @@ import { Provider } from 'react-redux';
 import Page from 'components/page/page';
 import FooterContainer from 'components/footer/footerContainer';
 import { detect, type CountryGroupId, AUDCountries, Canada, EURCountries, GBPCountries, International, NZDCountries, UnitedStates } from 'helpers/internationalisation/countryGroup';
-// import SubscriptionsByCountryGroup from 'components/subscriptionsByCountryGroup/subscriptionsByCountryGroup';
 import headerWithCountrySwitcherContainer from 'components/headers/header/headerWithCountrySwitcher';
 
 import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
-// import FeaturedProductAb from './components/featuredProductAb';
 import ConsentBanner from 'components/consentBanner/consentBanner';
 import './subscriptionsLanding.scss';
 
@@ -49,12 +47,6 @@ const content = (
       footer={<FooterContainer disclaimer privacyPolicy />}
     >
       <SubscriptionLandingContent />
-      {/*
-        <FeaturedProductAb
-          headingSize={3}
-        />
-        <SubscriptionsByCountryGroup headingSize={3} appMedium="subscribe_landing_page" />
-      */}
       <ConsentBanner />
     </Page>
   </Provider>

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.scss
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.scss
@@ -37,3 +37,673 @@
   }
 
 }
+
+[class^="subscriptions"] {
+  box-sizing: border-box;
+}
+
+.subscriptions-landing-page {
+  width: 100%;
+}
+
+.subscriptions__feature {
+  padding: 50px 0 55px;
+  width: 100%;
+  background-color: gu-colour('highlight-main');
+
+  @include mq($until: tablet) {
+    padding: 30px 0 30px 50px;
+  }
+}
+
+.subscriptions__feature-container {
+  max-width: 1290px;
+  margin: 0 auto;
+  width: 100%;
+  max-width: 1290px;
+}
+
+.subscriptions__feature-text {
+  font-size: 50px;
+  font-family: $gu-titlepiece;
+  font-weight: bold;
+  max-width: 700px;
+  line-height: 55px;
+  margin-left: 80px;
+
+  @include mq($until: leftCol) {
+    margin-left: 50px;
+  }
+
+  @include mq($until: desktop) {
+    font-size: 42px;
+    line-height: 45px;
+    margin-left: 30px;
+  }
+
+  @include mq($until: tablet) {
+    margin-left: 0;
+    font-size: 28px;
+    line-height: 30px;
+    max-width: 80%;
+  }
+}
+
+/****************** subscriptions product-container ********************/
+
+.subscriptions__product-container {
+  position: relative;
+  margin-bottom: 40px;
+}
+
+.subscriptions__product-container::after {
+  content: ' ';
+  position: absolute;
+  width: 100%;
+  height: 100px;
+  background-color: gu-colour('highlight-main');
+  display: block;
+  z-index: -1;
+  top: 0;
+}
+
+/****************** subscriptions product ********************/
+.subscriptions__product {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+  margin: 0 auto;
+  flex-wrap: wrap;
+  max-width: 1290px;
+  border: 1px solid gu-colour(neutral-86);
+  border-top: none;
+  min-height: 320px;
+
+  @include mq($until: desktop) {
+    min-height: 250px;
+  }
+
+  @include mq($until: tablet) {
+    margin: 0 auto;
+    width: calc(100% - 40px);
+    min-height: 0;
+    border: none;
+  }
+
+  @include mq($until: mobileLandscape) {
+    width: calc(100% - 20px);
+  }
+}
+
+.subscriptions__product:nth-child(odd) {
+  @include mq($from: tablet) {
+    flex-direction: row-reverse
+  }
+}
+
+.subscriptions__product::before {
+  content: ' ';
+  position: absolute;
+  width: 1px;
+  height: calc(100% - 24px);
+  top: 12px;
+  left: 50%;
+  z-index: 4;
+  background-color: gu-colour(neutral-86);
+
+  @include mq($until: tablet) {
+    content: none;
+    z-index: 1;
+  }
+}
+
+.subscriptions__product--reverse {
+  @include mq($until: tablet) {
+    padding-bottom: 30px;
+  }
+}
+/****************** subscriptions product--feature ********************/
+
+.subscriptions__product.subscriptions__product--feature {
+  color: gu-colour('neutral-100');
+  // min-height: 500px;
+  border: none;
+  padding-top: 70px;
+  background-color: gu-colour('brand-main');
+
+  @include mq($until: tablet) {
+    padding-top: 0;
+  }
+}
+
+.subscriptions__product.subscriptions__product--feature::before{
+  content: none;
+}
+
+.subscriptions__feature-image-wrapper {
+  overflow: hidden;
+  display: initial;
+}
+
+/****************** subscriptions copy-container / image-container ********************/
+
+.subscriptions__copy-container {
+  position: relative;
+  width: 70%;
+
+  @include mq($until: tablet) {
+    z-index: 1;
+  }
+
+  @include mq($until: mobileMedium) {
+    width: 65%;
+  }
+}
+
+.subscriptions__image-container {
+  position: relative;
+  overflow: hidden;
+  width: 30%;
+
+  @include mq($until: mobileMedium) {
+    width: 35%;
+  }
+
+}
+
+.subscriptions__copy-container,
+.subscriptions__image-container {
+  @include mq($from: tablet) {
+    width: 50%;
+  }
+}
+
+.subscriptions__image-container.subscriptions__product--feature {
+  background-color: gu-colour('brand-main');
+  width: 50%;
+
+  @media (min-width: 740px) and (max-width: 1067px) {
+    padding: 22% 0;
+  }
+  @media (min-width: 1067px) {
+    height: 447px;
+  }
+  @include mq($until: tablet) {
+    position: relative;
+    width: 100%;
+    // bottom: -80px;
+  }
+
+  @include mq($until: mobileLandscape) {
+    position: relative;
+    width: 100%;
+  }
+
+  @include mq($until: mobile) {
+    position: relative;
+    width: 100%;
+    bottom: -50px;
+  }
+}
+
+.subscriptions__copy-container.subscriptions__product--feature {
+  position: relative;
+  width: 100%;
+  background-color: gu-colour('brand-main');
+
+  @include mq($from: tablet) {
+    width: 50%;
+  }
+
+  .subscriptions__copy-wrapper {
+    @include mq($until: desktop) {
+      padding: 0 30px 30px;
+    }
+  }
+
+  @include mq($until: tablet) {
+    position: relative;
+    width: 100%;
+  }
+}
+
+/****************** Copy ********************/
+.subscriptions__product--feature .subscriptions__copy-wrapper {
+  top: 0;
+  transform: none;
+  // margin-top: 80px;
+}
+
+.subscriptions__copy-wrapper {
+  position: relative;
+  top: 50%;
+  transform: translateY(-50%);
+  padding: 0 80px;
+
+  @include mq($until: leftCol) {
+    padding: 0 50px;
+  }
+
+  @include mq($until: desktop) {
+    padding: 30px;
+  }
+
+  @include mq($until: tablet) {
+    padding: 10px 20px 20px;
+    top: 0;
+    transform: translateY(0);
+  }
+
+  @include mq($until: phablet) {
+    padding: 10px 0 20px 10px;
+    position: static;
+    transform: none;
+  }
+}
+
+.subscriptions__copy-container.subscriptions__product--feature .subscriptions__product-title {
+  font-size: 42px;
+  border-top: solid gu-colour('brand-pastel') 1px;
+
+  @include mq($until: tablet) {
+    font-size: 34px;
+    line-height: 34px;
+    padding-top: 15px;
+  }
+
+  @include mq($until: mobileLandscape) {
+    font-size: 24px;
+    line-height: 28px;
+  }
+
+  @include mq($until: mobileMedium) {
+    font-size: 22px;
+    line-height: 22px;
+  }
+}
+
+.subscriptions__product-title {
+  font-size: 34px;
+  line-height: 30px;
+  font-weight: bold;
+  font-family: $gu-headline;
+  margin: 0;
+  border-top: 1px solid gu-colour(neutral-86);
+  line-height: 1.2;
+  vertical-align: middle;
+
+  @include mq($until: desktop) {
+    font-size: 32px;
+  }
+
+  @include mq($until: tablet) {
+    font-size: 34px;
+    line-height: 34px;
+    padding-top: 15px;
+  }
+
+  @include mq($until: mobileLandscape) {
+    font-size: 24px;
+    line-height: 28px;
+  }
+
+  @include mq($until: mobileMedium) {
+    font-size: 22px;
+    line-height: 22px;
+  }
+}
+
+.subscriptions__product-subtitle {
+  font-size: 28px;
+  line-height: 30px;
+  font-weight: 300;
+  font-family: $gu-headline;
+
+  @include mq($until: desktop) {
+    font-size: 24px;
+  }
+
+  @include mq($until: tablet) {
+    font-size: 24px;
+    line-height: 30px;
+  }
+
+  @include mq($until: mobileLandscape) {
+    font-size: 20px;
+    line-height: 24px;
+  }
+}
+
+.subscriptions__description {
+  font-weight: 400;
+  max-width: 350px;
+  margin: 23px 20px 25px 0;
+  font-size: 17px;
+  line-height: 21px;
+
+  @include mq($until: desktop) {
+    margin: 27px 20px 25px 0;
+    font-size: 16px;
+    line-height: 18px;
+  }
+
+  @include mq($until: tablet) {
+    max-width: 100%;
+  }
+
+  @include mq($until: mobileLandscape) {
+    font-size: 14px;
+    line-height: 16px;
+    margin: 16px 20px 18px 0;
+  }
+
+  @include mq($until: mobileMedium) {
+    margin: 16px 10px 18px 0;
+  }
+
+}
+
+.subscriptions__sales {
+  font-size: 24px;
+  line-height: 27px;
+  display: inline-block;
+  background-color: gu-colour('highlight-main');
+  vertical-align: middle;
+  padding: 0px 7px 5px;
+  margin-top: 10px;
+
+  @include mq($until: desktop) {
+    font-size: 20px;
+  }
+
+  @include mq($until: mobileLandscape) {
+    font-size: 18px;
+    line-height: 24px;
+  }
+
+  @include mq($until: mobileMedium) {
+    font-size: 16px;
+    line-height: 20px;
+  }
+
+}
+
+.subscriptions__product--feature .subscriptions__sales {
+  color: gu-colour(neutral-7);
+}
+/****************** product-image ********************/
+
+.subscriptions-packshot {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  transform: translateX(-50%);
+
+  @include mq($until: tablet) {
+    position: static;
+    top: 0;
+    width: 100%;
+    // margin: 0;
+    transform: translateX(0);
+    padding: 10px 0 0 0;
+  }
+}
+
+/****************** subscriptions__product-button ********************/
+
+.component-button--subscriptions__product-button {
+  background-color: gu-colour(neutral-7);
+  color: gu-colour(neutral-100);
+
+  @include mq($until: mobileMedium) {
+    font-size: 12px;
+  }
+}
+
+/****************** premium app ********************/
+
+.subscriptions__premuim-app {
+  display: none;
+
+  @include mq($until: tablet) {
+    display: flex;
+  }
+}
+
+.subscriptions__premuim-app .component-button--subscriptions__product-button:first-of-type {
+  margin: 0 20px 20px 0;
+}
+
+.component-grid-image--subscriptions-premium-image {
+    position: relative;
+    width: 100%;
+    max-width: 130px;
+    top: 0;
+    left: 50%;
+    transform: translate(-50%);
+}
+
+/****************** packshots ********************/
+.subscriptions-feature-packshot {
+  position: absolute;
+  bottom: -40px;
+  right: -210px;
+
+  @media (max-width: 1067px) {
+    width: 150%;
+    right: initial;
+  }
+
+  @include mq($until: tablet) {
+    position: relative;
+    width: 100%;
+    bottom: initial;
+    padding: 20px 10% 0;
+    margin-bottom: -50px;
+  }
+
+  @include mq($until: mobileLandscape) {
+    margin-bottom: -40px;
+  }
+
+  img {
+    width: 100%;
+    height: 100%;
+  }
+}
+
+.subscriptions__guardian-weekly-packshot {
+  width: 429px;
+
+  @include mq($until: desktop) {
+    width: 354px;
+  }
+
+  @include mq($until: tablet) {
+    position: static;
+    width: 100%;
+  }
+
+  img {
+    position: absolute;
+    bottom: 0;
+  }
+
+  img:nth-child(1) {
+    @include mq($until: tablet) {
+      display: none;
+    }
+  }
+
+  img:nth-child(2) {
+    left: 95px;
+    bottom: -60px;
+
+    @include mq($until: tablet) {
+      position: static;
+      width: 100%;
+    }
+  }
+
+  img:nth-child(3) {
+    left: 180px;
+
+    @include mq($until: tablet) {
+      display: none;
+    }
+  }
+
+}
+
+.subscriptions__paper-packshot {
+  width: 382px;
+
+  @include mq($until: desktop) {
+    width: 357px;
+  }
+
+  @include mq($until: tablet) {
+    position: static;
+    width: 100%;
+  }
+
+  img {
+    position: absolute;
+    bottom: 0;
+  }
+
+  img:nth-child(1) {
+    z-index: 2;
+    @include mq($until: tablet) {
+      display: none;
+    }
+  }
+
+  img:nth-child(2) {
+    z-index: 1;
+    left: 32px;
+    bottom: -120px;
+
+    @include mq($until: tablet) {
+      position: static;
+      width: 100%;
+    }
+  }
+
+  img:nth-child(3) {
+    left: 166px;
+
+    @include mq($until: tablet) {
+      display: none;
+    }
+  }
+}
+
+.paper-and-digital-packshot {
+  width: 370px;
+
+  @include mq($until: desktop) {
+    width: 357px;
+  }
+
+  @include mq($until: tablet) {
+    position: static;
+    width: 100%;
+  }
+
+  img {
+    position: absolute;
+    bottom: 0;
+  }
+
+  img:nth-child(1) {
+    bottom: -37px;
+    @include mq($until: tablet) {
+      display: none;
+    }
+  }
+
+  img:nth-child(2) {
+    left: 55px;
+    bottom: -130px;
+
+    @include mq($until: tablet) {
+      position: static;
+      width: 100%;
+      display: none;
+    }
+  }
+
+  img:nth-child(3) {
+    left: 272px;
+    bottom: -40px;
+
+    @include mq($until: tablet) {
+      display: none;
+    }
+  }
+
+  img:nth-child(4) {
+    display: none;
+    top: 0;
+    width: 100%;
+    padding-top: 9px;
+
+    @include mq($until: tablet) {
+      display: block;
+    }
+  }
+}
+
+.subscriptions-int-feature-packshot {
+  position: absolute;
+  bottom: -30px;
+  // right: -184px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 450px;
+
+  @include mq($until: desktop) {
+    width: 377px;
+    left: 45%;
+    transform: translateX(-45%);
+  }
+
+  @include mq($until: tablet) {
+    position: static;
+    bottom: 0;
+    width: 100%;
+    left: 0;
+    transform: translateX(0);
+  }
+
+  img {
+    width: 450px;
+
+    @include mq($until: desktop) {
+      width: 90%;
+    }
+
+    @include mq($until: tablet) {
+      width: 100%;
+    }
+  }
+}
+
+/**** FOOTER HACK ****/
+#subscriptions-landing-page {
+  .component-left-margin-section:before {
+    content: none;
+  }
+
+  .component-content.component-content--feature,
+  .component-left-margin-section__content {
+    margin: 0 auto;
+    max-width: 1290px;
+  }
+
+  .component-footer {
+    background-color: gu-colour('brand-main');
+  }
+}


### PR DESCRIPTION
Reverts guardian/support-frontend#2108
Reapplies https://github.com/guardian/support-frontend/pull/2092

This relaunches the new subscription showcase page with pricing that takes account of flash sales.

![support thegulocal com_uk_subscribe_flash_sale_time_travel=-0](https://user-images.githubusercontent.com/181371/66136278-1b56d580-e5f3-11e9-9f5e-0609156de43a.png)
