### PR TITLE
Change the selenium css selector used by the subscriptions landing page

### DIFF
--- a/support-frontend/assets/pages/subscriptions-landing/components/subscriptionsLandingContent.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/components/subscriptionsLandingContent.jsx
@@ -11,7 +11,7 @@ import { subscriptionCopy } from '../copy/subscriptionCopy'; // make the first c
 const isFeature = index => index === 0;
 
 const SubscriptionsLandingContent = () => (
-  <div className="subscriptions-landing-page">
+  <div className="subscriptions-landing-page" id="qa-subscriptions-landing-page">
     <FeatureHeader />
     <div className="subscriptions__product-container">
       {subscriptionCopy.map((product, index) => (

--- a/support-frontend/test/selenium/subscriptions/pages/SubsLandingPage.scala
+++ b/support-frontend/test/selenium/subscriptions/pages/SubsLandingPage.scala
@@ -8,7 +8,7 @@ class SubsLandingPage(implicit val webDriver: WebDriver) extends Page with Brows
 
   val url = s"${Config.supportFrontendUrl}/uk/subscribe"
 
-  private val header = cssSelector("#qa-component-subscriptions-by-country-group")
+  private val header = cssSelector("#qa-subscriptions-landing-page")
 
   def pageHasLoaded: Boolean = {
     pageHasElement(header) && pageHasUrl(s"/uk/subscribe")


### PR DESCRIPTION
## Why are you doing this?

#2109 broke the post deployment test for the subscriptions showcase page because it removed an element from the page which Selenium was looking for to check that the page has loaded correctly. This PR changes the css selector to an element which does exist.