### PR TITLE
Remove Stripe Checkout for single contributions

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -5,7 +5,6 @@ import { getCampaignName } from 'helpers/campaigns';
 
 // ----- Tests ----- //
 export type LandingPageCopyReturningSinglesTestVariants = 'control' | 'returningSingle' | 'notintest';
-export type StripeElementsTestVariants = 'control' | 'stripeCardElement' | 'notintest';
 export type LandingPageMomentBackgroundColourTestVariants = 'control' | 'yellow' | 'notintest';
 
 export const tests: Tests = {
@@ -29,27 +28,6 @@ export const tests: Tests = {
     independent: true,
     seed: 1,
     canRun: () => !!getCookie('gu.contributions.contrib-timestamp'),
-  },
-
-  stripeElements: {
-    type: 'OTHER',
-    variants: [
-      {
-        id: 'control',
-      },
-      {
-        id: 'stripeCardElement',
-      },
-    ],
-    audiences: {
-      ALL: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: window.guardian && window.guardian.stripeElements ? window.guardian.stripeElements : false,
-    independent: true,
-    seed: 3,
   },
 
   landingPageMomentBackgroundColour: {

--- a/support-frontend/assets/helpers/paymentIntegrations/oneOffContributions.js
+++ b/support-frontend/assets/helpers/paymentIntegrations/oneOffContributions.js
@@ -59,7 +59,7 @@ export type StripeChargeData = {|
   paymentData: {
     currency: IsoCurrency,
     amount: number,
-    token: string,
+    token: string, // TODO - remove this field once it has been removed from payment-api
     email: string,
     stripePaymentMethod: StripePaymentMethod,
   },
@@ -134,19 +134,6 @@ function paymentResultFromObject(
   return Promise.resolve(PaymentSuccess);
 }
 
-// Sends a one-off payment request to the payment API and standardises the result
-// https://github.com/guardian/payment-api/blob/master/src/main/resources/routes#L17
-function postOneOffStripeExecutePaymentRequest(
-  data: StripeChargeData,
-  setGuestAccountCreationToken: (string) => void,
-  setThankYouPageStage: (ThankYouPageStage) => void,
-): Promise<PaymentResult> {
-  return logPromise(fetchJson(
-    paymentApiEndpointWithMode(`${window.guardian.paymentApiStripeUrl}/contribute/one-off/stripe/execute-payment`),
-    requestOptions(data, 'omit', 'POST', null),
-  ).then(result => paymentResultFromObject(result, setGuestAccountCreationToken, setThankYouPageStage)));
-}
-
 function postStripeCreatePaymentIntentRequest(data: CreateStripePaymentIntentRequest): Promise<Object> {
   return fetchJson(
     paymentApiEndpointWithMode(`${window.guardian.paymentApiStripeUrl}/contribute/one-off/stripe/create-payment`),
@@ -210,7 +197,6 @@ function postOneOffPayPalCreatePaymentRequest(data: CreatePaypalPaymentData): Pr
 }
 
 export {
-  postOneOffStripeExecutePaymentRequest,
   postOneOffPayPalCreatePaymentRequest,
   processStripePaymentIntentRequest,
 };

--- a/support-frontend/assets/helpers/stripe.js
+++ b/support-frontend/assets/helpers/stripe.js
@@ -22,9 +22,7 @@ export const setupStripe = (setStripeHasLoaded: () => void) => {
 export const stripeCardFormIsIncomplete = (
   contributionType: ContributionType,
   paymentMethod: PaymentMethod,
-  stripeElementsTestVariant: string,
   stripeCardFormComplete: boolean,
 ): boolean => contributionType === 'ONE_OFF' &&
     paymentMethod === Stripe &&
-    stripeElementsTestVariant === 'stripeCardElement' &&
     !(stripeCardFormComplete);

--- a/support-frontend/assets/pages/contributions-landing/checkoutFormIsSubmittableActions.js
+++ b/support-frontend/assets/pages/contributions-landing/checkoutFormIsSubmittableActions.js
@@ -95,7 +95,6 @@ const formIsValidParameters = (state: State) => ({
   stripeCardFormOk: !stripeCardFormIsIncomplete(
     state.page.form.contributionType,
     state.page.form.paymentMethod,
-    state.common.abParticipations.stripeElements,
     state.page.form.stripeCardFormData.formComplete,
   ),
 });

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
@@ -211,7 +211,8 @@ function onSubmit(props: PropTypes): Event => void {
     const flowPrefix = 'npf';
     const form = event.target;
 
-    if (props.isPostDeploymentTestUser && props.paymentMethod === Stripe) {
+    // Only recurring uses stripe checkout
+    if (props.isPostDeploymentTestUser && props.paymentMethod === Stripe && props.contributionType !== 'ONE_OFF') {
       props.onPaymentAuthorisation({ paymentMethod: Stripe, token: 'tok_visa', stripePaymentMethod: 'StripeCheckout' });
     } else {
       const handlePayment = () => formHandlers[props.contributionType][props.paymentMethod](props);

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
@@ -52,7 +52,6 @@ import type { RecentlySignedInExistingPaymentMethod } from 'helpers/existingPaym
 import type { PaymentMethod } from 'helpers/paymentMethods';
 import { DirectDebit, Stripe, ExistingCard, ExistingDirectDebit } from 'helpers/paymentMethods';
 import { getCampaignName } from 'helpers/campaigns';
-import type { StripeElementsTestVariants } from 'helpers/abTests/abtestDefinitions';
 
 
 // ----- Types ----- //
@@ -84,7 +83,6 @@ type PropTypes = {|
   isTestUser: boolean,
   country: IsoCountry,
   stripePaymentRequestButtonMethod: StripePaymentRequestButtonMethod,
-  stripeElementsTestVariant: StripeElementsTestVariants,
   createStripePaymentMethod: () => void,
 |};
 
@@ -117,7 +115,6 @@ const mapStateToProps = (state: State) => ({
   country: state.common.internationalisation.countryId,
   stripeV3HasLoaded: state.page.form.stripeV3HasLoaded,
   stripePaymentRequestButtonMethod: state.page.form.stripePaymentRequestButtonData.paymentMethod,
-  stripeElementsTestVariant: state.common.abParticipations.stripeElements,
 });
 
 
@@ -174,9 +171,7 @@ const formHandlersForRecurring = {
 const formHandlers: PaymentMatrix<PropTypes => void> = {
   ONE_OFF: {
     Stripe: (props: PropTypes) => {
-      if (props.stripeElementsTestVariant !== 'stripeCardElement') {
-        openStripePopup(props);
-      } else if (props.createStripePaymentMethod) {
+      if (props.createStripePaymentMethod) {
         props.createStripePaymentMethod();
       }
     },
@@ -266,7 +261,6 @@ function withProps(props: PropTypes) {
           currency={props.currency}
           contributionType={props.contributionType}
           paymentMethod={props.paymentMethod}
-          stripeElementsTestVariant={props.stripeElementsTestVariant}
           isTestUser={props.isTestUser}
           country={props.country}
         />

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionSubmit.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionSubmit.jsx
@@ -39,7 +39,6 @@ type PropTypes = {|
   onPaymentAuthorisation: PaymentAuthorisation => void,
   formIsSubmittable: boolean,
   amount: number,
-  billingPeriod: BillingPeriod
   billingPeriod: BillingPeriod,
 |};
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionSubmit.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionSubmit.jsx
@@ -40,6 +40,7 @@ type PropTypes = {|
   formIsSubmittable: boolean,
   amount: number,
   billingPeriod: BillingPeriod
+  billingPeriod: BillingPeriod,
 |};
 
 function mapStateToProps(state: State) {

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardFormContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardFormContainer.jsx
@@ -11,7 +11,6 @@ import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { ContributionType } from 'helpers/contributions';
 import { type PaymentMethod, Stripe } from 'helpers/paymentMethods';
 import { setupStripe } from 'helpers/stripe';
-import type { StripeElementsTestVariants } from 'helpers/abTests/abtestDefinitions';
 import AnimatedDots from 'components/spinners/animatedDots';
 import './stripeCardForm.scss';
 
@@ -24,7 +23,6 @@ type PropTypes = {|
   isTestUser: boolean,
   contributionType: ContributionType,
   paymentMethod: PaymentMethod,
-  stripeElementsTestVariant: StripeElementsTestVariants,
   setStripeHasLoaded: () => void,
   stripeHasLoaded: boolean,
 |};
@@ -37,8 +35,7 @@ class StripeCardFormContainer extends React.Component<PropTypes, void> {
 
   render() {
     if (this.props.contributionType === 'ONE_OFF' &&
-      this.props.paymentMethod === Stripe &&
-      this.props.stripeElementsTestVariant === 'stripeCardElement') {
+      this.props.paymentMethod === Stripe) {
 
       if (this.props.stripeHasLoaded) {
 

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -14,8 +14,7 @@ import {
 import { getUserTypeFromIdentity, type UserTypeFromIdentityResponse } from 'helpers/identityApis';
 import { type CaState, type UsState } from 'helpers/internationalisation/country';
 import type {
-  RegularPaymentRequest,
-  StripeCheckoutAuthorisation, StripePaymentIntentAuthorisation, StripePaymentMethod,
+  RegularPaymentRequest, StripePaymentIntentAuthorisation, StripePaymentMethod,
 } from 'helpers/paymentIntegrations/readerRevenueApis';
 import {
   type PaymentAuthorisation,
@@ -278,15 +277,6 @@ const buildStripeChargeDataFromAuthorisation = (
   ),
 });
 
-const stripeChargeDataFromCheckoutAuthorisation = (
-  authorisation: StripeCheckoutAuthorisation,
-  state: State,
-): StripeChargeData => buildStripeChargeDataFromAuthorisation(
-  authorisation.stripePaymentMethod,
-  authorisation.token,
-  state,
-);
-
 const stripeChargeDataFromPaymentIntentAuthorisation = (
   authorisation: StripePaymentIntentAuthorisation,
   state: State,
@@ -397,14 +387,6 @@ const createOneOffPayPalPayment = (data: CreatePaypalPaymentData) =>
     dispatch(onCreateOneOffPayPalPaymentResponse(postOneOffPayPalCreatePaymentRequest(data)));
   };
 
-const executeStripeOneOffPayment = (
-  data: StripeChargeData,
-  setGuestToken: (string) => void,
-  setThankYouPage: (ThankYouPageStage) => void,
-) =>
-  (dispatch: Dispatch<Action>): Promise<PaymentResult> =>
-    dispatch(onPaymentResult(postOneOffStripeExecutePaymentRequest(data, setGuestToken, setThankYouPage)));
-
 const makeCreateStripePaymentIntentRequest = (
   data: CreateStripePaymentIntentRequest,
   setGuestToken: (string) => void,
@@ -464,14 +446,6 @@ const paymentAuthorisationHandlers: PaymentMatrix<(
       paymentAuthorisation: PaymentAuthorisation,
     ): Promise<PaymentResult> => {
       if (paymentAuthorisation.paymentMethod === Stripe) {
-        if (paymentAuthorisation.token) {
-          return dispatch(executeStripeOneOffPayment(
-            stripeChargeDataFromCheckoutAuthorisation(paymentAuthorisation, state),
-            (token: string) => dispatch(setGuestAccountCreationToken(token)),
-            (thankYouPageStage: ThankYouPageStage) => dispatch(setThankYouPageStage(thankYouPageStage)),
-          ));
-        }
-
         if (paymentAuthorisation.paymentMethodId) {
           const { handle3DS } = state.page.form.stripeCardFormData;
           if (handle3DS) {

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -28,7 +28,6 @@ import {
   type CreatePaypalPaymentData,
   type CreatePayPalPaymentResponse,
   postOneOffPayPalCreatePaymentRequest,
-  postOneOffStripeExecutePaymentRequest,
   processStripePaymentIntentRequest,
 } from 'helpers/paymentIntegrations/oneOffContributions';
 import { routes } from 'helpers/routes';

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -463,7 +463,7 @@ const paymentAuthorisationHandlers: PaymentMatrix<(
           logException('Stripe 3DS handler unavailable');
           return Promise.resolve(error);
         }
-        logException(`Invalid payment authorisation: missing ${paymentAuthorisation.paymentMethodId} for Stripe one-off contribution`);
+        logException(`Invalid payment authorisation: missing paymentMethodId for Stripe one-off contribution`);
         return Promise.resolve(error);
       }
       logException(`Invalid payment authorisation: Tried to use the ${paymentAuthorisation.paymentMethod} handler with Stripe`);

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -462,8 +462,9 @@ const paymentAuthorisationHandlers: PaymentMatrix<(
           // It shouldn't be possible to get this far without the handle3DS having been set
           logException('Stripe 3DS handler unavailable');
           return Promise.resolve(error);
-
         }
+        logException(`Invalid payment authorisation: missing ${paymentAuthorisation.paymentMethodId} for Stripe one-off contribution`);
+        return Promise.resolve(error);
       }
       logException(`Invalid payment authorisation: Tried to use the ${paymentAuthorisation.paymentMethod} handler with Stripe`);
       return Promise.resolve(error);

--- a/support-frontend/test/selenium/contributions/OneOffContributionsSpec.scala
+++ b/support-frontend/test/selenium/contributions/OneOffContributionsSpec.scala
@@ -59,47 +59,16 @@ class OneOffContributionsSpec extends FeatureSpec with GivenWhenThen with Before
       When("they press the Stripe payment button")
       landingPage.selectStripePayment()
 
+      And("enter card details")
+      landingPage.fillInCardDetails
+
       When("they click contribute")
       landingPage.clickContribute
-
-      And("the mock calls the backend using a test Stripe token")
 
       Then("the thankyou page should display")
 
       eventually {
         assert(contributionThankYou.pageHasLoaded)
-      }
-    }
-
-    scenario("Check Stripe pop-up appears") {
-      val testUser = new TestUser {
-        val username = "test-stripe-pop-up"
-        driverConfig.addCookie(name = "GU_TK", value = "1.1") //To avoid consent banner, which messes with selenium
-      }
-
-      val landingPage = ContributionsLanding("au", testUser)
-
-      Given("that a test user goes to the contributions landing page")
-      goTo(landingPage)
-      assert(landingPage.pageHasLoaded)
-      landingPage.clearForm(hasNameFields = false)
-
-      When("the user selects the one-time option")
-      landingPage.clickOneOff
-
-      Given("The user fills in their details correctly")
-      landingPage.fillInPersonalDetails(hasNameFields = false)
-
-      Given("that the user selects to pay with Stripe")
-      When("they press the Stripe payment button")
-      landingPage.selectStripePayment()
-
-      When("they click contribute")
-      landingPage.clickContribute
-
-      Then("the overlay should appear")
-      eventually {
-        assert(landingPage.hasStripeOverlay)
       }
     }
 

--- a/support-frontend/test/selenium/contributions/pages/ContributionsLanding.scala
+++ b/support-frontend/test/selenium/contributions/pages/ContributionsLanding.scala
@@ -49,6 +49,32 @@ case class ContributionsLanding(region: String, testUser: TestUser)(implicit val
     }
   }
 
+  private object CardDetailsFields {
+    case class StripeCardField(containerClass: String, inputName: String) {
+      def iframeSelector: CssSelectorQuery = cssSelector(s"#$containerClass iframe")
+      def inputSelector: CssSelectorQuery = cssSelector(s"input[name='$inputName']")
+
+      def set(value: String): Unit = {
+        switchToParentFrame
+
+        switchFrame(iframeSelector)
+        setValueSlowly(inputSelector, value)
+
+        switchToParentFrame
+      }
+    }
+
+    val cardNumber = StripeCardField("stripeCardNumberElement", "cardnumber")
+    val expiryDate = StripeCardField("stripeCardExpiryElement", "exp-date")
+    val cvc = StripeCardField("stripeCardCVCElement", "cvc")
+
+    def fillIn: Unit = {
+      cardNumber.set("4242424242424242")
+      expiryDate.set("0150")
+      cvc.set("111")
+    }
+  }
+
   def fillInPersonalDetails(hasNameFields: Boolean) { RegisterFields.fillIn(hasNameFields) }
 
   def clearForm(hasNameFields: Boolean): Unit = RegisterFields.clear(hasNameFields)
@@ -56,6 +82,8 @@ case class ContributionsLanding(region: String, testUser: TestUser)(implicit val
   def selectState: Unit = setSingleSelectionValue(stateSelector, "NY")
 
   def selectStripePayment(): Unit = clickOn(stripeSelector)
+
+  def fillInCardDetails(): Unit = CardDetailsFields.fillIn
 
   def selectPayPalPayment(): Unit = clickOn(payPalSelector)
 

--- a/support-frontend/test/selenium/contributions/pages/ContributionsLanding.scala
+++ b/support-frontend/test/selenium/contributions/pages/ContributionsLanding.scala
@@ -50,8 +50,8 @@ case class ContributionsLanding(region: String, testUser: TestUser)(implicit val
   }
 
   private object CardDetailsFields {
-    case class StripeCardField(containerClass: String, inputName: String) {
-      def iframeSelector: CssSelectorQuery = cssSelector(s"#$containerClass iframe")
+    case class StripeCardField(containerId: String, inputName: String) {
+      def iframeSelector: CssSelectorQuery = cssSelector(s"#$containerId iframe")
       def inputSelector: CssSelectorQuery = cssSelector(s"input[name='$inputName']")
 
       def set(value: String): Unit = {


### PR DESCRIPTION
## Why are you doing this?
In the past we have used Stripe Checkout for contributions.
We have been running an A/B test to compare Stripe Checkout vs Stripe Elements + Payment Intents API.
This is for SCA compliance. Currently it is for single contributions only.
From the test we have found that the change does not impact revenue, and so are switching to 100% Stripe Elements + Payment Intents API.

This PR removes Stripe Checkout for single contributions. Recurring will be migrated later (it requires some separate backend work)