### PR TITLE
Fix and re-add the Stripe post deployment test

### DIFF
--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -174,7 +174,7 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
               onChange={e => this.handleChange(e)}
             />
             <div className="component-stripe-submit-button">
-              <Button id="qa-submit-button" onClick={event => this.requestStripeToken(event)}>
+              <Button id="qa-stripe-submit-button" onClick={event => this.requestStripeToken(event)}>
                 {this.props.buttonText}
               </Button>
             </div>

--- a/support-frontend/test/selenium/subscriptions/CheckoutsSpec.scala
+++ b/support-frontend/test/selenium/subscriptions/CheckoutsSpec.scala
@@ -26,11 +26,11 @@ class CheckoutsSpec extends FeatureSpec with GivenWhenThen with BeforeAndAfter w
     driverConfig.quit()
   }
 
-  // feature("Digital Pack checkout") {
-  //   scenario("Stripe checkout") {
-  //     testCheckout("Digital Pack", new DigitalPackCheckout, new DigitalPackProductPage, payWithStripe)
-  //   }
-  // }
+   feature("Digital Pack checkout") {
+     scenario("Stripe checkout") {
+       testCheckout("Digital Pack", new DigitalPackCheckout, new DigitalPackProductPage, payWithStripe)
+     }
+   }
 
   feature("Paper checkout") {
     scenario("Direct Debit checkout") {
@@ -93,7 +93,7 @@ class CheckoutsSpec extends FeatureSpec with GivenWhenThen with BeforeAndAfter w
     checkoutPage.fillStripeForm
 
     When("they click to process payment")
-    checkoutPage.clickSubmit
+    checkoutPage.clickStripeSubmit
 
     And("the mock calls the backend using a test Stripe token")
     thankYouPage(checkoutPage)

--- a/support-frontend/test/selenium/subscriptions/pages/CheckoutPage.scala
+++ b/support-frontend/test/selenium/subscriptions/pages/CheckoutPage.scala
@@ -6,6 +6,7 @@ import selenium.util.Browser
 trait CheckoutPage extends Page with Browser {
   private val stripeRadioButton = id("qa-credit-card")
   private val submitButton = id("qa-submit-button")
+  private val stripeSubmitButton = id("qa-stripe-submit-button")
   private val directDebitButton = id("qa-direct-debit")
   private val personalDetails = id("qa-personal-details")
   private val cardNumber = name("cardnumber")
@@ -42,6 +43,8 @@ trait CheckoutPage extends Page with Browser {
   }
 
   def clickSubmit: Unit = clickOn(submitButton)
+
+  def clickStripeSubmit: Unit = clickOn(stripeSubmitButton)
 
   def fillForm: Unit
 }


### PR DESCRIPTION
## Why are you doing this?

When we replaced the old Stripe popup with the new Stripe elements form we couldn't get the post deploy test to pass so we commented out. This PR uncomments the test and fixes it. 

[**Trello Card**](https://trello.com/c/i5euSGE1/2630-reintroduce-post-deploy-test-for-stripe-checkout)