### PR TITLE
Add the correct non-uk prices for DP flash sale

### DIFF
--- a/support-frontend/assets/helpers/flashSale.js
+++ b/support-frontend/assets/helpers/flashSale.js
@@ -88,12 +88,12 @@ const Sales: Sale[] = [
     endTime: new Date(2020, 8, 23).getTime(), // 23 Sept 2020 - we don't have an end date yet
     saleDetails: {
       GBPCountries: dpSale,
-      UnitedStates: dpSale,
-      International: dpSale,
-      Canada: dpSale,
-      NZDCountries: dpSale,
-      EURCountries: dpSale,
-      AUDCountries: dpSale,
+      UnitedStates: { ...dpSale, price: 9.99 },
+      International: { ...dpSale, price: 9.99 },
+      Canada: { ...dpSale, price: 10.97 },
+      NZDCountries: { ...dpSale, price: 11.75 },
+      EURCountries: { ...dpSale, price: 7.49 },
+      AUDCountries: { ...dpSale, price: 10.75 },
     },
   },
   {


### PR DESCRIPTION
## Why are you doing this?

The Digital Pack flash sale copy data in flashSale.js did not include the correct prices for non-UK countries meaning that the price shown on the subscriptions landing page was wrong (it was the UK price). Prices were correct on the DP landing page and in the checkout and all customers would have been charged the correct price.

[**Trello Card**](https://trello.com/c/V4BOSGgD/2661-incorrect-digital-pack-international-pricing-for-subs-showcase-page)

