### PR TITLE
Update social sharing links and copy

### DIFF
--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -178,7 +178,7 @@ class Application(
       guestAccountCreationToken = guestAccountCreationToken,
       fontLoaderBundle = fontLoaderBundle,
       geoData = geoData,
-      shareImageUrl = "https://media.guim.co.uk/74b15a65c479bfe53151fceeb7d948f125a66af2/0_0_2400_1260/2000.png"
+      shareImageUrl = "https://media.guim.co.uk/661978f14a1cbdd64361e429f058e9b20c8db5bb/0_0_2400_1260/1000.png"
     )
   }
 

--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -178,7 +178,8 @@ class Application(
       guestAccountCreationToken = guestAccountCreationToken,
       fontLoaderBundle = fontLoaderBundle,
       geoData = geoData,
-      shareImageUrl = "https://media.guim.co.uk/661978f14a1cbdd64361e429f058e9b20c8db5bb/0_0_2400_1260/1000.png"
+      shareImageUrl = "https://media.guim.co.uk/661978f14a1cbdd64361e429f058e9b20c8db5bb/0_0_2400_1260/1000.png",
+      url = "https://support.theguardian.com/contribute/climate-pledge-2019"
     )
   }
 

--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -179,7 +179,7 @@ class Application(
       fontLoaderBundle = fontLoaderBundle,
       geoData = geoData,
       shareImageUrl = "https://media.guim.co.uk/661978f14a1cbdd64361e429f058e9b20c8db5bb/0_0_2400_1260/1000.png",
-      url = "https://support.theguardian.com/contribute/climate-pledge-2019"
+      shareUrl = "https://support.theguardian.com/contribute/climate-pledge-2019"
     )
   }
 

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -23,10 +23,12 @@
   guestAccountCreationToken: Option[String],
   fontLoaderBundle: Either[RefPath, StyleContent],
   geoData: GeoData,
-  shareImageUrl: String
+  shareImageUrl: String,
+  url: String,
+
 )(implicit assets: AssetsResolver, request: RequestHeader, settings: AllSettings)
 
-@main(title = title, mainJsBundle = js, fontLoaderBundle = fontLoaderBundle, description = description, mainElement = mainElement, mainStyleBundle = css, shareImageUrl = Some(shareImageUrl)) {
+@main(title = title, mainJsBundle = js, fontLoaderBundle = fontLoaderBundle, description = description, mainElement = mainElement, mainStyleBundle = css, shareImageUrl = Some(shareImageUrl), url=Some(url)) {
   <script type="text/javascript">
   window.guardian = window.guardian || {};
   @idUser.map { user =>

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -24,11 +24,11 @@
   fontLoaderBundle: Either[RefPath, StyleContent],
   geoData: GeoData,
   shareImageUrl: String,
-  url: String,
+  shareUrl: String,
 
 )(implicit assets: AssetsResolver, request: RequestHeader, settings: AllSettings)
 
-@main(title = title, mainJsBundle = js, fontLoaderBundle = fontLoaderBundle, description = description, mainElement = mainElement, mainStyleBundle = css, shareImageUrl = Some(shareImageUrl), url=Some(url)) {
+@main(title = title, mainJsBundle = js, fontLoaderBundle = fontLoaderBundle, description = description, mainElement = mainElement, mainStyleBundle = css, shareImageUrl = Some(shareImageUrl), shareUrl = Some(shareUrl)) {
   <script type="text/javascript">
   window.guardian = window.guardian || {};
   @idUser.map { user =>

--- a/support-frontend/app/views/main.scala.html
+++ b/support-frontend/app/views/main.scala.html
@@ -13,7 +13,7 @@
   hrefLangLinks: Map[String, String] = Map(),
   csrf: Option[String] = None,
   shareImageUrl: Option[String] = None,
-  url: Option[String] = None,
+  shareUrl: Option[String] = None,
 )(body: Html = Html(""))(implicit assets: AssetsResolver, request: RequestHeader, settings: AllSettings)
 
 <!DOCTYPE html>
@@ -43,8 +43,8 @@
       <meta property="og:image:secure_url" content="@imageUrl" />
     }
 
-    @url.map { url =>
-      <meta property="og:url" content="@url" />
+    @shareUrl.map { shareUrl =>
+      <meta property="og:url" content="@shareUrl" />
     }
 
     @canonicalLink.map { definedCanonicalLink =>

--- a/support-frontend/app/views/main.scala.html
+++ b/support-frontend/app/views/main.scala.html
@@ -13,6 +13,7 @@
   hrefLangLinks: Map[String, String] = Map(),
   csrf: Option[String] = None,
   shareImageUrl: Option[String] = None,
+  url: Option[String] = None,
 )(body: Html = Html(""))(implicit assets: AssetsResolver, request: RequestHeader, settings: AllSettings)
 
 <!DOCTYPE html>
@@ -40,6 +41,10 @@
       <meta property="twitter:image" content="@imageUrl" />
       <meta property="og:image" content="@imageUrl" />
       <meta property="og:image:secure_url" content="@imageUrl" />
+    }
+
+    @url.map { url =>
+      <meta property="og:url" content="@url" />
     }
 
     @canonicalLink.map { definedCanonicalLink =>

--- a/support-frontend/assets/components/socialShare/socialShare.jsx
+++ b/support-frontend/assets/components/socialShare/socialShare.jsx
@@ -40,13 +40,13 @@ const socialMedia: {
   [SharePlatform]: SocialMedia,
 } = {
   facebook: {
-    link: 'https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute%2Fclimate-pledge-2019?acquisitionData=%7B%22source%22%3A%22SOCIAL%22%2C%22campaignCode%22%3A%22component-social-facebook%22%2C%22componentId%22%3A%22component-social-facebook%22%7D&INTCMP=component-social-facebook',
+    link: 'https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute%2Fclimate-pledge-2019%3FacquisitionData%3D%7B%22source%22%3A%22SOCIAL%22%2C%22campaignCode%22%3A%22climate_pledge_2019_component_social_facebook%22%2C%22componentId%22%3A%22component-social-facebook%22%7D%26INTCMP%3Dclimate_pledge_2019_component_social_facebook',
     svg: <SvgFacebook />,
     a11yHint: 'Share on facebook',
     windowFeatures: SocialWindowFeatures,
   },
   twitter: {
-    link: 'https://twitter.com/intent/tweet?url=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute%2Fclimate-pledge-2019?INTCMP=component-social-twitter&text=Join%20me%20in%20supporting%20The%20Guardian%E2%80%99s%20pledge%20to%20be%20a%20truthful%20voice%20on%20the%20climate%20crisis',
+    link: 'https://twitter.com/intent/tweet?text=Join%20me%20in%20supporting%20The%20Guardian%E2%80%99s%20pledge%20to%20be%20a%20truthful%20voice%20on%20the%20climate%20crisis&url=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute%2Fclimate-pledge-2019%3FINTCMP%3Dclimate_pledge_2019_component_social_twitter',
     svg: <SvgTwitter />,
     a11yHint: 'Share on twitter',
     windowFeatures: SocialWindowFeatures,
@@ -58,7 +58,7 @@ const socialMedia: {
     windowFeatures: SocialWindowFeatures,
   },
   email: {
-    link: 'mailto:?subject=Join%20me%20in%20supporting%20The%20Guardian%E2%80%99s%20pledge%20to%20be%20a%20truthful%20voice%20on%20the%20climate%20crisis&body=The%20Guardian%20recognises%20the%20climate%20emergency%20as%20the%20defining%20issue%20of%20our%20lifetimes%20%E2%80%93%20and%20pledges%20to%20be%20truthful%2C%20resolute%20and%20undeterred%20in%20pursuing%20their%20reporting%20on%20the%20environment.%20Support%20from%20readers%20makes%20this%20work%20possible%20and%20protects%20The%20Guardian%E2%80%99s%20independence%3A%20https%3A%2F%2Fsupport.theguardian.com%2Fcontribute%2Fclimate-pledge-2019?INTCMP=component-social-email',
+    link: 'mailto:?subject=Join%20me%20in%20supporting%20The%20Guardian%E2%80%99s%20pledge%20to%20be%20a%20truthful%20voice%20on%20the%20climate%20crisis&body=The%20Guardian%20recognises%20the%20climate%20emergency%20as%20the%20defining%20issue%20of%20our%20lifetimes%20%E2%80%93%20and%20pledges%20to%20be%20truthful%2C%20resolute%20and%20undeterred%20in%20pursuing%20their%20reporting%20on%20the%20environment.%20Support%20from%20readers%20makes%20this%20work%20possible%20and%20protects%20The%20Guardian%E2%80%99s%20independence%3A%20https%3A%2F%2Fsupport.theguardian.com%2Fcontribute%2Fclimate-pledge-2019?INTCMP=climate_pledge_2019_component_social_email',
     svg: <SvgEmail />,
     a11yHint: 'Share by email',
     windowFeatures: '',

--- a/support-frontend/assets/components/socialShare/socialShare.jsx
+++ b/support-frontend/assets/components/socialShare/socialShare.jsx
@@ -46,19 +46,19 @@ const socialMedia: {
     windowFeatures: SocialWindowFeatures,
   },
   twitter: {
-    link: 'https://twitter.com/intent/tweet?url=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute?INTCMP=component-social-twitter&text=Join%20me%20and%20over%20one%20million%20others%20in%20supporting%20a%20different%20model%20for%20open%2C%20independent%20journalism.%20Together%20we%20can%20help%20safeguard%20The%20Guardian%E2%80%99s%20future%20%E2%80%93%20so%20more%20people%2C%20across%20the%20world%2C%20can%20keep%20accessing%20factual%20information%20for%20free',
+    link: 'https://twitter.com/intent/tweet?url=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute?INTCMP=component-social-twitter&text=Join%20me%20in%20supporting%20The%20Guardian%E2%80%99s%20pledge%20to%20be%20a%20truthful%20voice%20on%20the%20climate%20crisis',
     svg: <SvgTwitter />,
     a11yHint: 'Share on twitter',
     windowFeatures: SocialWindowFeatures,
   },
   linkedin: {
-    link: 'http://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute&title=Join%20me%20and%20over%20one%20million%20others%20in%20supporting%20a%20different%20model%20for%20open%2C%20independent%20journalism.%20Together%20we%20can%20help%20safeguard%20The%20Guardian%E2%80%99s%20future%20%E2%80%93%20so%20more%20people%2C%20across%20the%20world%2C%20can%20keep%20accessing%20factual%20information%20for%20free',
+    link: 'http://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute',
     svg: <SvgLinkedin />,
     a11yHint: 'Share on linkedin',
     windowFeatures: SocialWindowFeatures,
   },
   email: {
-    link: 'mailto:?subject=Join%20me%20in%20supporting%20open%2C%20independent%20journalism&body=Join%20me%20and%20over%20one%20million%20others%20in%20supporting%20a%20different%20model%20for%20open%2C%20independent%20journalism.%20Together%20we%20can%20help%20safeguard%20The%20Guardian%E2%80%99s%20future%20%E2%80%93%20so%20more%20people%2C%20across%20the%20world%2C%20can%20keep%20accessing%20factual%20information%20for%20free%3A%20https%3A%2F%2Fsupport.theguardian.com%2Fcontribute?INTCMP=component-social-email',
+    link: 'mailto:?subject=Join%20me%20in%20supporting%20The%20Guardian%E2%80%99s%20pledge%20to%20be%20a%20truthful%20voice%20on%20the%20climate%20crisis&body=The%20Guardian%20recognises%20the%20climate%20emergency%20as%20the%20defining%20issue%20of%20our%20lifetimes%20%E2%80%93%20and%20pledges%20to%20be%20truthful%2C%20resolute%20and%20undeterred%20in%20pursuing%20their%20reporting%20on%20the%20environment.%20Support%20from%20readers%20makes%20this%20work%20possible%20and%20protects%20The%20Guardian%E2%80%99s%20independence.%3A%20https%3A%2F%2Fsupport.theguardian.com%2Fcontribute?INTCMP=component-social-email',
     svg: <SvgEmail />,
     a11yHint: 'Share by email',
     windowFeatures: '',

--- a/support-frontend/assets/components/socialShare/socialShare.jsx
+++ b/support-frontend/assets/components/socialShare/socialShare.jsx
@@ -40,7 +40,7 @@ const socialMedia: {
   [SharePlatform]: SocialMedia,
 } = {
   facebook: {
-    link: 'https://www.facebook.com/sharer/sharer.php?u=https://support.theguardian.com/uk/contribute/climate-pledge-2019?acquisitionData=%7B%22source%22%3A%22SOCIAL%22%2C%22componentType%22%3A%22ACQUISITIONS_OTHER%22%2C%22campaignCode%22%3A%22climate_pledge_2019%22%2C%22componentId%22%3A%22climate_pledge_2019_social_facebook%22%7D&INTCMP=climate_pledge_2019',
+    link: 'https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fsupport.theguardian.com%2Fuk%2Fcontribute%2Fclimate-pledge-2019%3FacquisitionData%3D%7B%22source%22%3A%22SOCIAL%22%2C%22componentType%22%3A%22ACQUISITIONS_OTHER%22%2C%22campaignCode%22%3A%22climate_pledge_2019%22%2C%22componentId%22%3A%22climate_pledge_2019_social_facebook%22%7D&INTCMP=climate_pledge_2019',
     svg: <SvgFacebook />,
     a11yHint: 'Share on facebook',
     windowFeatures: SocialWindowFeatures,

--- a/support-frontend/assets/components/socialShare/socialShare.jsx
+++ b/support-frontend/assets/components/socialShare/socialShare.jsx
@@ -40,7 +40,7 @@ const socialMedia: {
   [SharePlatform]: SocialMedia,
 } = {
   facebook: {
-    link: 'https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute%2Fclimate-pledge-2019%3FacquisitionData%3D%7B%22source%22%3A%22SOCIAL%22%2C%22campaignCode%22%3A%22climate_pledge_2019_component_social_facebook%22%2C%22componentId%22%3A%22component-social-facebook%22%7D%26INTCMP%3Dclimate_pledge_2019_component_social_facebook',
+    link: 'https://www.facebook.com/sharer/sharer.php?u=https://support.theguardian.com/uk/contribute/climate-pledge-2019?acquisitionData=%7B%22source%22%3A%22SOCIAL%22%2C%22componentType%22%3A%22ACQUISITIONS_OTHER%22%2C%22campaignCode%22%3A%22climate_pledge_2019%22%2C%22componentId%22%3A%22climate_pledge_2019_social_facebook%22%7D&INTCMP=climate_pledge_2019',
     svg: <SvgFacebook />,
     a11yHint: 'Share on facebook',
     windowFeatures: SocialWindowFeatures,

--- a/support-frontend/assets/components/socialShare/socialShare.jsx
+++ b/support-frontend/assets/components/socialShare/socialShare.jsx
@@ -40,25 +40,25 @@ const socialMedia: {
   [SharePlatform]: SocialMedia,
 } = {
   facebook: {
-    link: 'https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute?acquisitionData=%7B%22source%22%3A%22SOCIAL%22%2C%22campaignCode%22%3A%22component-social-facebook%22%2C%22componentId%22%3A%22component-social-facebook%22%7D&INTCMP=component-social-facebook',
+    link: 'https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute%2Fclimate-pledge-2019?acquisitionData=%7B%22source%22%3A%22SOCIAL%22%2C%22campaignCode%22%3A%22component-social-facebook%22%2C%22componentId%22%3A%22component-social-facebook%22%7D&INTCMP=component-social-facebook',
     svg: <SvgFacebook />,
     a11yHint: 'Share on facebook',
     windowFeatures: SocialWindowFeatures,
   },
   twitter: {
-    link: 'https://twitter.com/intent/tweet?url=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute?INTCMP=component-social-twitter&text=Join%20me%20in%20supporting%20The%20Guardian%E2%80%99s%20pledge%20to%20be%20a%20truthful%20voice%20on%20the%20climate%20crisis',
+    link: 'https://twitter.com/intent/tweet?url=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute%2Fclimate-pledge-2019?INTCMP=component-social-twitter&text=Join%20me%20in%20supporting%20The%20Guardian%E2%80%99s%20pledge%20to%20be%20a%20truthful%20voice%20on%20the%20climate%20crisis',
     svg: <SvgTwitter />,
     a11yHint: 'Share on twitter',
     windowFeatures: SocialWindowFeatures,
   },
   linkedin: {
-    link: 'http://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute',
+    link: 'http://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute%2Fclimate-pledge-2019',
     svg: <SvgLinkedin />,
     a11yHint: 'Share on linkedin',
     windowFeatures: SocialWindowFeatures,
   },
   email: {
-    link: 'mailto:?subject=Join%20me%20in%20supporting%20The%20Guardian%E2%80%99s%20pledge%20to%20be%20a%20truthful%20voice%20on%20the%20climate%20crisis&body=The%20Guardian%20recognises%20the%20climate%20emergency%20as%20the%20defining%20issue%20of%20our%20lifetimes%20%E2%80%93%20and%20pledges%20to%20be%20truthful%2C%20resolute%20and%20undeterred%20in%20pursuing%20their%20reporting%20on%20the%20environment.%20Support%20from%20readers%20makes%20this%20work%20possible%20and%20protects%20The%20Guardian%E2%80%99s%20independence.%3A%20https%3A%2F%2Fsupport.theguardian.com%2Fcontribute?INTCMP=component-social-email',
+    link: 'mailto:?subject=Join%20me%20in%20supporting%20The%20Guardian%E2%80%99s%20pledge%20to%20be%20a%20truthful%20voice%20on%20the%20climate%20crisis&body=The%20Guardian%20recognises%20the%20climate%20emergency%20as%20the%20defining%20issue%20of%20our%20lifetimes%20%E2%80%93%20and%20pledges%20to%20be%20truthful%2C%20resolute%20and%20undeterred%20in%20pursuing%20their%20reporting%20on%20the%20environment.%20Support%20from%20readers%20makes%20this%20work%20possible%20and%20protects%20The%20Guardian%E2%80%99s%20independence.%3A%20https%3A%2F%2Fsupport.theguardian.com%2Fcontribute%2Fclimate-pledge-2019?INTCMP=component-social-email',
     svg: <SvgEmail />,
     a11yHint: 'Share by email',
     windowFeatures: '',

--- a/support-frontend/assets/components/socialShare/socialShare.jsx
+++ b/support-frontend/assets/components/socialShare/socialShare.jsx
@@ -58,7 +58,7 @@ const socialMedia: {
     windowFeatures: SocialWindowFeatures,
   },
   email: {
-    link: 'mailto:?subject=Join%20me%20in%20supporting%20The%20Guardian%E2%80%99s%20pledge%20to%20be%20a%20truthful%20voice%20on%20the%20climate%20crisis&body=The%20Guardian%20recognises%20the%20climate%20emergency%20as%20the%20defining%20issue%20of%20our%20lifetimes%20%E2%80%93%20and%20pledges%20to%20be%20truthful%2C%20resolute%20and%20undeterred%20in%20pursuing%20their%20reporting%20on%20the%20environment.%20Support%20from%20readers%20makes%20this%20work%20possible%20and%20protects%20The%20Guardian%E2%80%99s%20independence.%3A%20https%3A%2F%2Fsupport.theguardian.com%2Fcontribute%2Fclimate-pledge-2019?INTCMP=component-social-email',
+    link: 'mailto:?subject=Join%20me%20in%20supporting%20The%20Guardian%E2%80%99s%20pledge%20to%20be%20a%20truthful%20voice%20on%20the%20climate%20crisis&body=The%20Guardian%20recognises%20the%20climate%20emergency%20as%20the%20defining%20issue%20of%20our%20lifetimes%20%E2%80%93%20and%20pledges%20to%20be%20truthful%2C%20resolute%20and%20undeterred%20in%20pursuing%20their%20reporting%20on%20the%20environment.%20Support%20from%20readers%20makes%20this%20work%20possible%20and%20protects%20The%20Guardian%E2%80%99s%20independence%3A%20https%3A%2F%2Fsupport.theguardian.com%2Fcontribute%2Fclimate-pledge-2019?INTCMP=component-social-email',
     svg: <SvgEmail />,
     a11yHint: 'Share by email',
     windowFeatures: '',

--- a/support-frontend/assets/components/spreadTheWord/spreadTheWord.jsx
+++ b/support-frontend/assets/components/spreadTheWord/spreadTheWord.jsx
@@ -9,8 +9,8 @@ import SocialShare from 'components/socialShare/socialShare';
 // ----- Component ----- //
 
 export default function SpreadTheWord() {
-  const title = 'Invite others to support The Guardian';
-  const message = 'To join you and over one million others in supporting a different model for open, independent journalism – so more people can access factual information for free';
+  const title = 'Help stretch the signal';
+  const message = 'Invite others to support us so that we can deliver truthful, independent reporting on the climate crisis – and keep it open for everyone around the world';
 
   return (
     <div className="contribution-thank-you-block">


### PR DESCRIPTION
## Why are you doing this?
The Moment requires a new og:image and social share copy.
<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/qTfXo0B1)

## Changes

* Change og:image link to new climate crisis design
* Change copy on Thank you page
* Change copy in:
    - Twitter
    - Email
* LinkedIn does not use the copy - it uses the landing page description - so I removed the copy from the link to avoid confusion
* Facebook does not use copy - uses og:image

## Screenshots

### Thank you page:
<img width="1190" alt="image" src="https://user-images.githubusercontent.com/15648334/66403027-c8f42b00-e9dd-11e9-9dd6-2a7f0a115fc4.png">

### Twitter:
Join me in supporting The Guardian’s pledge to be a truthful voice on the climate crisis

### LinkedIn (showing live og:image, but will be replaced by Moment one on Monday):
<img width="584" alt="image" src="https://user-images.githubusercontent.com/15648334/66403159-fe991400-e9dd-11e9-925a-ca98b33ccc88.png">

### Email:
<img width="886" alt="image" src="https://user-images.githubusercontent.com/15648334/66589763-24155180-eb87-11e9-8a6f-a078699ddf01.png">

### Facebook:
<img width="555" alt="image" src="https://user-images.githubusercontent.com/15648334/66499849-7f2c4300-eab8-11e9-8021-8dd7eaf62e0c.png">