### PR TITLE
update moment naming in code base and url, update terms and conditions copy

### DIFF
--- a/support-frontend/assets/components/legal/termsPrivacy/termsPrivacy.jsx
+++ b/support-frontend/assets/components/legal/termsPrivacy/termsPrivacy.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 
-import { privacyLink, contributionsTermsLinks } from 'helpers/legal';
+import { privacyLink, contributionsTermsLinks, philanthropyContactEmail } from 'helpers/legal';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 import type { ContributionType } from 'helpers/contributions';
@@ -24,9 +24,14 @@ type PropTypes = {|
 function TermsPrivacy(props: PropTypes) {
   const terms = <a href={contributionsTermsLinks[props.countryGroupId]}>Terms and Conditions</a>;
   const privacy = <a href={privacyLink}>Privacy Policy</a>;
+  const isUK = props.countryGroupId === 'GBPCountries';
 
   if (props.campaignName && campaigns[props.campaignName] && campaigns[props.campaignName].termsAndConditions) {
-    return campaigns[props.campaignName].termsAndConditions(contributionsTermsLinks[props.countryGroupId]);
+    return campaigns[props.campaignName].termsAndConditions(
+      contributionsTermsLinks[props.countryGroupId],
+      philanthropyContactEmail[props.countryGroupId],
+      isUK,
+    );
   }
 
   return (

--- a/support-frontend/assets/helpers/campaigns.jsx
+++ b/support-frontend/assets/helpers/campaigns.jsx
@@ -65,16 +65,22 @@ export const campaigns: Campaigns = {
           our <a href="https://www.theguardian.com/help/privacy-policy">Privacy Policy</a>.
         </p>
         {isUK ? (
-          <p>
-            If you would like to make a larger contribution, we have a Patron programme with three levels of
-            support, which brings you closer to our work. For more information, please visit
-            our <a class="underline" href="https://patrons.theguardian.com?INTCMP=environment-pledge-2019-patrons-link">Patrons site</a>.
-          </p>
+          <span>
+            <p>
+              If you would like to make a larger contribution, we have a Patron programme with three levels of
+              support, which brings you closer to our work. For more information, please visit
+              our <a className="underline" href="https://patrons.theguardian.com?INTCMP=environment-pledge-2019-patrons-link">Patrons site</a>.
+            </p>
+            <p>
+              We also accept contributions in support of The Guardian’s journalism from companies and
+              foundations. Please <a href={`mailto:${contactEmail || ''}`}>contact us</a>.
+            </p>
+          </span>
         ) : (
           <p>
             We’re also seeking larger contributions to support The Guardian’s reporting from companies,
             foundations and individuals. If you would like to get involved with this project or provide
-            matching funds, please <a href="mailto:apac.help@theguardian.com">contact us</a>.
+            matching funds, please <a href={`mailto:${contactEmail || ''}`}>contact us</a>.
           </p>
         )}
       </div>

--- a/support-frontend/assets/helpers/campaigns.jsx
+++ b/support-frontend/assets/helpers/campaigns.jsx
@@ -16,7 +16,7 @@ export type CampaignSettings = {
   headerCopy?: string | React$Element<string>,
   contributeCopy?: React$Element<string>,
   formMessage?: React$Element<string>,
-  termsAndConditions?: (contributionsTermsLink: string) => React$Element<string>,
+  termsAndConditions?: (contributionsTermsLink: string, contactEmail: string, isUK: boolean) => React$Element<string>,
   cssModifiers?: string[],
   contributionTypes?: ContributionTypes,
   backgroundImage?: string,
@@ -28,10 +28,10 @@ export type Campaigns = {
   [string]: CampaignSettings,
 };
 
-const currentCampaignName = 'environmentpledge';
+const currentCampaignName = 'climate-pledge-2019';
 
 export const campaigns: Campaigns = {
-  environmentpledge: {
+  [currentCampaignName]: {
     formMessage: (<div />
     ),
     headerCopy: (
@@ -53,7 +53,7 @@ export const campaigns: Campaigns = {
         </p>
       </div>
     ),
-    termsAndConditions: (contributionsTermsLink: string) => (
+    termsAndConditions: (contributionsTermsLink: string, contactEmail: string, isUK: boolean) => (
       <div className="component-terms-privacy component-terms-privacy--campaign-landing">
         <p>
           Monthly contributions are billed each month and annual contributions are billed
@@ -64,18 +64,26 @@ export const campaigns: Campaigns = {
           To find out what personal data we collect and how we use it, please visit
           our <a href="https://www.theguardian.com/help/privacy-policy">Privacy Policy</a>.
         </p>
-        <p>
-          We’re also seeking larger contributions to support The Guardian’s reporting from companies,
-          foundations and individuals. If you would like to get involved with this project or provide
-          matching funds, please <a href="mailto:apac.help@theguardian.com">contact us</a>.
-        </p>
+        {isUK ? (
+          <p>
+            If you would like to make a larger contribution, we have a Patron programme with three levels of
+            support, which brings you closer to our work. For more information, please visit
+            our <a class="underline" href="https://patrons.theguardian.com?INTCMP=environment-pledge-2019-patrons-link">Patrons site</a>.
+          </p>
+        ) : (
+          <p>
+            We’re also seeking larger contributions to support The Guardian’s reporting from companies,
+            foundations and individuals. If you would like to get involved with this project or provide
+            matching funds, please <a href="mailto:apac.help@theguardian.com">contact us</a>.
+          </p>
+        )}
       </div>
     ),
-    cssModifiers: ['environment-moment'],
+    cssModifiers: ['climate-moment'],
     extraComponent: (
-      <div className="environment-moment_image-container">
+      <div className="climate-moment_image-container">
         <img
-          className="environment-moment_image"
+          className="climate-moment_image"
           src="https://media.guim.co.uk/8fe60bf9d30df8481fcbccb91816a3c995279007/0_0_577_840/577.png"
           alt="Support the Guardian's pledge on climate change"
         />

--- a/support-frontend/assets/helpers/legal.js
+++ b/support-frontend/assets/helpers/legal.js
@@ -21,6 +21,23 @@ const contributionsTermsLinks: {
   Canada: defaultContributionTermsLink,
 };
 
+
+// TBD update before moment launch
+const defaultPhilanthropyContactEmail: string = 'australia.philanthropy@theguardian.com';
+
+const philanthropyContactEmail: {
+  [CountryGroupId]: string,
+} = {
+  GBPCountries: defaultPhilanthropyContactEmail,
+  UnitedStates: defaultPhilanthropyContactEmail,
+  AUDCountries: defaultPhilanthropyContactEmail,
+  EURCountries: defaultPhilanthropyContactEmail,
+  International: defaultPhilanthropyContactEmail,
+  NZDCountries: defaultPhilanthropyContactEmail,
+  Canada: defaultPhilanthropyContactEmail,
+};
+
+
 const subscriptionsTermsLinks: {
   [SubscriptionProduct]: string,
 } = {
@@ -59,4 +76,5 @@ export {
   privacyLink,
   copyrightNotice,
   contributionsEmail,
+  philanthropyContactEmail,
 };

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.scss
@@ -12,7 +12,7 @@
 @import '~components/socialShare/socialShare';
 @import '~pages/contributions-landing/components/ContributionThankYou/ContributionThankYou';
 @import '~pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton';
-@import './contributionsLandingEnvironmentMoment';
+@import 'contributionsLandingClimateMoment';
 
 $content-left-margin-leftCol: calc(50% - 480px);
 

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingClimateMoment.scss
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingClimateMoment.scss
@@ -1,8 +1,8 @@
-.gu-content--environment-moment.gu-content--yellow-background {
+.gu-content--climate-moment.gu-content--yellow-background {
   background-color: gu-colour(highlight-main);
 }
 
-.gu-content--environment-moment {
+.gu-content--climate-moment {
   background-color: gu-colour(sport-faded);
 
   .gu-content__main {
@@ -87,7 +87,7 @@
     overflow: visible;
   }
 
-  .environment-moment_image-container {
+  .climate-moment_image-container {
     display: none;
 
     @include mq($from: tablet) {
@@ -109,7 +109,7 @@
     }
   }
 
-  .environment-moment_image {
+  .climate-moment_image {
     transform: scaleX(-1);
     mix-blend-mode: multiply;
     height: auto;


### PR DESCRIPTION
## Why are you doing this?
The moment has been officially named: 'Climate Pledge 2019' so I'm getting rid of all old references to the 'environment pledge'.

There have also been some changes to the Terms and Conditions that I'm including in this PR for the reason that these all fit into the same category of 'fit and finish' changes and aren't features that need their own PR

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/PledEggW/1504-moment-philo-patrons-asks)

## Changes

* Update url name and codebase name to refer to the 'climate moment'
* Add some logic to make the terms and conditions dynamic, update copy and links

## Screenshots
UK:
<img width="481" alt="terms uk" src="https://user-images.githubusercontent.com/3300789/66577058-a1819780-eb70-11e9-9d89-81d5395c958c.png">

ROW:
<img width="479" alt="terms row" src="https://user-images.githubusercontent.com/3300789/66577074-a6dee200-eb70-11e9-9ad9-821fb39bf0a5.png">