### PR TITLE
Postcode length restriction on delivery and billing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -77,7 +77,6 @@ lazy val `support-frontend` = (project in file("support-frontend"))
     buildInfoPackage := "app",
     buildInfoOptions += BuildInfoOption.ToMap,
     scalastyleFailOnError := true,
-    fork in run := true,
     testScalastyle := scalastyle.in(Compile).toTask("").value,
     (test in Test) := ((test in Test) dependsOn testScalastyle).value,
     (testOnly in Test) := ((testOnly in Test) dependsOn testScalastyle).evaluated,

--- a/build.sbt
+++ b/build.sbt
@@ -77,6 +77,7 @@ lazy val `support-frontend` = (project in file("support-frontend"))
     buildInfoPackage := "app",
     buildInfoOptions += BuildInfoOption.ToMap,
     scalastyleFailOnError := true,
+    fork in run := true,
     testScalastyle := scalastyle.in(Compile).toTask("").value,
     (test in Test) := ((test in Test) dependsOn testScalastyle).value,
     (testOnly in Test) := ((testOnly in Test) dependsOn testScalastyle).evaluated,

--- a/support-frontend/app/services/stepfunctions/Client.scala
+++ b/support-frontend/app/services/stepfunctions/Client.scala
@@ -14,9 +14,9 @@ import cats.implicits._
 import com.gu.monitoring.SafeLogger
 import services.stepfunctions.StateMachineErrors.Fail
 
-import scala.collection.JavaConversions._
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext
+import scala.collection.JavaConverters._
 
 object Client {
 
@@ -77,7 +77,7 @@ class Client(client: AWSStepFunctionsAsync, arn: StateMachineArn) {
   def history(jobId: String)(implicit ec: ExecutionContext, stateWrapper: StateWrapper): Response[List[HistoryEvent]] = {
     toEither(
       AwsAsync(client.getExecutionHistoryAsync, new GetExecutionHistoryRequest().withExecutionArn(arnFromJobId(jobId)).withReverseOrder(true))
-    ).map(_.getEvents.toList)
+    ).map(_.getEvents.asScala.toList)
   }
 
   private def toEither[T](result: Future[T])(implicit ec: ExecutionContext): Response[T] = EitherT {

--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.js
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.js
@@ -76,7 +76,7 @@ const getFormFields = (state: State): FormFields => ({
 const isPostcodeOptional = (country: Option<IsoCountry>): boolean =>
   country !== 'GB' && country !== 'AU' && country !== 'US' && country !== 'CA';
 
-const checkpostCodeLength = (input: string | null): boolean => (input != null && input.length <= 20);
+const checkpostCodeLength = (input: string | null): boolean => ((input == null) || (input.length <= 20));
 
 const isStateNullable = (country: Option<IsoCountry>): boolean =>
   country !== 'AU' && country !== 'US' && country !== 'CA';

--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.js
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.js
@@ -103,7 +103,7 @@ const applyBillingAddressRules = (fields: FormFields, addressType: AddressType):
   },
   {
     rule: checkpostCodeLength(fields.postCode),
-    error: formError('postCode', `Postcode for ${addressType} should not be longer than 20 characters.`),
+    error: formError('postCode', `Please enter a ${addressType} postcode not be longer than 20 characters.`),
   },
   {
     rule: notNull(fields.country),

--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.js
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.js
@@ -102,6 +102,10 @@ const applyBillingAddressRules = (fields: FormFields, addressType: AddressType):
     error: formError('postCode', `Please enter a ${addressType} postcode.`),
   },
   {
+    rule: checkpostCodeLength(fields.postCode),
+    error: formError('postCode', `Postcode for ${addressType} should not be longer than 20 characters.`),
+  },
+  {
     rule: notNull(fields.country),
     error: formError('country', `Please select a ${addressType} country.`),
   },
@@ -111,10 +115,6 @@ const applyBillingAddressRules = (fields: FormFields, addressType: AddressType):
       'state',
       fields.country === 'CA' ? `Please select a ${addressType} province/territory.` : `Please select a ${addressType} state.`,
     ),
-  },
-  {
-    rule: checkpostCodeLength(fields.postCode),
-    error: formError('postCode', `Postcode for ${addressType} should not be longer than 20 characters.`),
   },
 ]);
 

--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.js
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.js
@@ -76,6 +76,8 @@ const getFormFields = (state: State): FormFields => ({
 const isPostcodeOptional = (country: Option<IsoCountry>): boolean =>
   country !== 'GB' && country !== 'AU' && country !== 'US' && country !== 'CA';
 
+const checkpostCodeLength = (input: String): boolean => input.length <= 20;
+
 const isStateNullable = (country: Option<IsoCountry>): boolean =>
   country !== 'AU' && country !== 'US' && country !== 'CA';
 
@@ -110,6 +112,10 @@ const applyBillingAddressRules = (fields: FormFields, addressType: AddressType):
       fields.country === 'CA' ? `Please select a ${addressType} province/territory.` : `Please select a ${addressType} state.`,
     ),
   },
+  {
+    rule: checkpostCodeLength(fields.postCode),
+    error: formError('postCode', `Postcode should not be longer than 20 characters.`),
+  }
 ]);
 
 const applyDeliveryAddressRules = (

--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.js
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.js
@@ -76,7 +76,7 @@ const getFormFields = (state: State): FormFields => ({
 const isPostcodeOptional = (country: Option<IsoCountry>): boolean =>
   country !== 'GB' && country !== 'AU' && country !== 'US' && country !== 'CA';
 
-const checkpostCodeLength = (input: String): boolean => input.length <= 20;
+const checkpostCodeLength = (input: string | null) : boolean => input.length <= 20;
 
 const isStateNullable = (country: Option<IsoCountry>): boolean =>
   country !== 'AU' && country !== 'US' && country !== 'CA';
@@ -114,8 +114,8 @@ const applyBillingAddressRules = (fields: FormFields, addressType: AddressType):
   },
   {
     rule: checkpostCodeLength(fields.postCode),
-    error: formError('postCode', `Postcode should not be longer than 20 characters.`),
-  }
+    error: formError('postCode', `Postcode for ${addressType} should not be longer than 20 characters.`),
+  },
 ]);
 
 const applyDeliveryAddressRules = (

--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.js
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.js
@@ -103,7 +103,7 @@ const applyBillingAddressRules = (fields: FormFields, addressType: AddressType):
   },
   {
     rule: checkpostCodeLength(fields.postCode),
-    error: formError('postCode', `Please enter a ${addressType} postcode not be longer than 20 characters.`),
+    error: formError('postCode', `Please enter a ${addressType} postcode no longer than 20 characters.`),
   },
   {
     rule: notNull(fields.country),

--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.js
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.js
@@ -76,7 +76,7 @@ const getFormFields = (state: State): FormFields => ({
 const isPostcodeOptional = (country: Option<IsoCountry>): boolean =>
   country !== 'GB' && country !== 'AU' && country !== 'US' && country !== 'CA';
 
-const checkpostCodeLength = (input: string | null) : boolean => input.length <= 20;
+const checkpostCodeLength = (input: string | null): boolean => (input != null && input.length <= 20);
 
 const isStateNullable = (country: Option<IsoCountry>): boolean =>
   country !== 'AU' && country !== 'US' && country !== 'CA';

--- a/support-frontend/assets/components/subscriptionCheckouts/personalDetailsGift.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/personalDetailsGift.jsx
@@ -8,7 +8,8 @@ import { withLabel } from 'hocs/withLabel';
 import { Input } from 'components/forms/input';
 import type { FormError } from 'helpers/subscriptionsForms/validation';
 import { type FormField } from 'helpers/subscriptionsForms/formFields';
-
+import ContributionTextInput from "../../pages/contributions-landing/components/ContributionTextInput";
+import {checkOptionalEmail, emailRegexPattern} from 'helpers/formValidation';
 
 export type PropTypes = {
   firstNameGiftRecipient: string,
@@ -48,6 +49,8 @@ export default function PersonalDetailsGift(props: PropTypes) {
         type="emailGiftRecipient"
         value={props.emailGiftRecipient}
         setValue={props.setEmailGift}
+        isValid={checkOptionalEmail(props.emailGiftRecipient)}
+        pattern={emailRegexPattern}
         optional
         error={firstError('emailGiftRecipient', props.formErrors)}
       />

--- a/support-frontend/assets/components/subscriptionCheckouts/personalDetailsGift.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/personalDetailsGift.jsx
@@ -49,8 +49,6 @@ export default function PersonalDetailsGift(props: PropTypes) {
         type="emailGiftRecipient"
         value={props.emailGiftRecipient}
         setValue={props.setEmailGift}
-        isValid={checkOptionalEmail(props.emailGiftRecipient)}
-        pattern={emailRegexPattern}
         optional
         error={firstError('emailGiftRecipient', props.formErrors)}
       />

--- a/support-frontend/assets/components/subscriptionCheckouts/personalDetailsGift.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/personalDetailsGift.jsx
@@ -49,6 +49,7 @@ export default function PersonalDetailsGift(props: PropTypes) {
         type="emailGiftRecipient"
         value={props.emailGiftRecipient}
         setValue={props.setEmailGift}
+        optional
         error={firstError('emailGiftRecipient', props.formErrors)}
       />
     </div>

--- a/support-frontend/assets/components/subscriptionCheckouts/personalDetailsGift.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/personalDetailsGift.jsx
@@ -49,7 +49,6 @@ export default function PersonalDetailsGift(props: PropTypes) {
         type="emailGiftRecipient"
         value={props.emailGiftRecipient}
         setValue={props.setEmailGift}
-        optional
         error={firstError('emailGiftRecipient', props.formErrors)}
       />
     </div>

--- a/support-frontend/assets/components/subscriptionCheckouts/personalDetailsGift.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/personalDetailsGift.jsx
@@ -8,8 +8,6 @@ import { withLabel } from 'hocs/withLabel';
 import { Input } from 'components/forms/input';
 import type { FormError } from 'helpers/subscriptionsForms/validation';
 import { type FormField } from 'helpers/subscriptionsForms/formFields';
-import ContributionTextInput from "../../pages/contributions-landing/components/ContributionTextInput";
-import {checkOptionalEmail, emailRegexPattern} from 'helpers/formValidation';
 
 export type PropTypes = {
   firstNameGiftRecipient: string,

--- a/support-frontend/assets/helpers/formValidation.js
+++ b/support-frontend/assets/helpers/formValidation.js
@@ -27,9 +27,7 @@ export const checkLastName: (string | null) => boolean = isNotEmpty;
 export const checkState: (string | null) => boolean = s => typeof s === 'string' && isNotEmpty(s);
 export const checkEmail: (string | null) => boolean = input => isNotEmpty(input) && isValidEmail(input);
 
-export const checkOptionalEmail: (string | null) => boolean = input => {
- isEmpty(input) || isValidEmail(input);
-};
+export const checkOptionalEmail: (string | null) => boolean = input => isEmpty(input) || isValidEmail(input);
 
 export const checkAmount: (string, CountryGroupId, ContributionType) =>
   boolean = (input: string, countryGroupId: CountryGroupId, contributionType: ContributionType) =>

--- a/support-frontend/assets/helpers/formValidation.js
+++ b/support-frontend/assets/helpers/formValidation.js
@@ -12,8 +12,6 @@ import { Canada, UnitedStates } from './internationalisation/countryGroup';
 
 export const emailRegexPattern = '^[a-zA-Z0-9\\.!#$%&\'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$';
 
-export const isNotEmpty: (string | null) => boolean = input => !!input && input.trim() !== '';
-
 export const isEmpty: (string | null) => boolean = input =>
   typeof input === 'undefined' || input == null || input.trim().length === 0;
 
@@ -22,10 +20,10 @@ export const isLargerOrEqual: (number, string) => boolean = (min, input) => min 
 export const isSmallerOrEqual: (number, string) => boolean = (max, input) => parseFloat(input) <= max;
 export const maxTwoDecimals: string => boolean = input => new RegExp('^\\d+\\.?\\d{0,2}$').test(input);
 
-export const checkFirstName: (string | null) => boolean = isNotEmpty;
-export const checkLastName: (string | null) => boolean = isNotEmpty;
-export const checkState: (string | null) => boolean = s => typeof s === 'string' && isNotEmpty(s);
-export const checkEmail: (string | null) => boolean = input => isNotEmpty(input) && isValidEmail(input);
+export const checkFirstName: (string | null) => boolean = !isEmpty;
+export const checkLastName: (string | null) => boolean = !isEmpty;
+export const checkState: (string | null) => boolean = s => typeof s === 'string' && (!isEmpty(s));
+export const checkEmail: (string | null) => boolean = input => !isEmpty(input) && isValidEmail(input);
 
 export const checkOptionalEmail: (string | null) => boolean = input => {
   isEmpty(input) || isValidEmail(input);
@@ -33,7 +31,7 @@ export const checkOptionalEmail: (string | null) => boolean = input => {
 
 export const checkAmount: (string, CountryGroupId, ContributionType) =>
   boolean = (input: string, countryGroupId: CountryGroupId, contributionType: ContributionType) =>
-    isNotEmpty(input)
+    !isEmpty(input)
     && isLargerOrEqual(config[countryGroupId][contributionType].min, input)
     && isSmallerOrEqual(config[countryGroupId][contributionType].max, input)
     && maxTwoDecimals(input);

--- a/support-frontend/assets/helpers/formValidation.js
+++ b/support-frontend/assets/helpers/formValidation.js
@@ -28,9 +28,7 @@ export const checkState: (string | null) => boolean = s => typeof s === 'string'
 export const checkEmail: (string | null) => boolean = input => isNotEmpty(input) && isValidEmail(input);
 
 export const checkOptionalEmail: (string | null) => boolean = input => {
-  let output = isEmpty(input) || isValidEmail(input);
-  console.log("Email is valid or empty" +  input + " status:" + output);
-  return output
+  isEmpty(input) || isValidEmail(input);
 };
 
 export const checkAmount: (string, CountryGroupId, ContributionType) =>

--- a/support-frontend/assets/helpers/formValidation.js
+++ b/support-frontend/assets/helpers/formValidation.js
@@ -13,7 +13,10 @@ import { Canada, UnitedStates } from './internationalisation/countryGroup';
 export const emailRegexPattern = '^[a-zA-Z0-9\\.!#$%&\'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$';
 
 export const isNotEmpty: (string | null) => boolean = input => !!input && input.trim() !== '';
-export const isEmpty: (string | null) => boolean = input => input.trim().length === 0;
+
+export const isEmpty: (string | null) => boolean = input =>
+  typeof input === 'undefined' || input == null || input.trim().length === 0;
+
 export const isValidEmail: (string | null) => boolean = input => !!input && new RegExp(emailRegexPattern).test(input);
 export const isLargerOrEqual: (number, string) => boolean = (min, input) => min <= parseFloat(input);
 export const isSmallerOrEqual: (number, string) => boolean = (max, input) => parseFloat(input) <= max;
@@ -25,7 +28,9 @@ export const checkState: (string | null) => boolean = s => typeof s === 'string'
 export const checkEmail: (string | null) => boolean = input => isNotEmpty(input) && isValidEmail(input);
 
 export const checkOptionalEmail: (string | null) => boolean = input => {
-  isEmpty(input) || isValidEmail(input);
+  let output = isEmpty(input) || isValidEmail(input);
+  console.log("Email is valid or empty" +  input + " status:" + output);
+  return output
 };
 
 export const checkAmount: (string, CountryGroupId, ContributionType) =>

--- a/support-frontend/assets/helpers/formValidation.js
+++ b/support-frontend/assets/helpers/formValidation.js
@@ -13,6 +13,7 @@ import { Canada, UnitedStates } from './internationalisation/countryGroup';
 export const emailRegexPattern = '^[a-zA-Z0-9\\.!#$%&\'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$';
 
 export const isNotEmpty: (string | null) => boolean = input => !!input && input.trim() !== '';
+export const isEmpty: (string | null) => boolean = input => input.trim().length === 0;
 export const isValidEmail: (string | null) => boolean = input => !!input && new RegExp(emailRegexPattern).test(input);
 export const isLargerOrEqual: (number, string) => boolean = (min, input) => min <= parseFloat(input);
 export const isSmallerOrEqual: (number, string) => boolean = (max, input) => parseFloat(input) <= max;
@@ -23,6 +24,9 @@ export const checkLastName: (string | null) => boolean = isNotEmpty;
 export const checkState: (string | null) => boolean = s => typeof s === 'string' && isNotEmpty(s);
 export const checkEmail: (string | null) => boolean = input => isNotEmpty(input) && isValidEmail(input);
 
+export const checkOptionalEmail: (string | null) => boolean = input => {
+  isEmpty(input) || isValidEmail(input);
+};
 
 export const checkAmount: (string, CountryGroupId, ContributionType) =>
   boolean = (input: string, countryGroupId: CountryGroupId, contributionType: ContributionType) =>

--- a/support-frontend/assets/helpers/formValidation.js
+++ b/support-frontend/assets/helpers/formValidation.js
@@ -15,23 +15,25 @@ export const emailRegexPattern = '^[a-zA-Z0-9\\.!#$%&\'*+/=?^_`{|}~-]+@[a-zA-Z0-
 export const isEmpty: (string | null) => boolean = input =>
   typeof input === 'undefined' || input == null || input.trim().length === 0;
 
+export const isNotEmpty: (string | null) => boolean = input => !isEmpty(input);
+
 export const isValidEmail: (string | null) => boolean = input => !!input && new RegExp(emailRegexPattern).test(input);
 export const isLargerOrEqual: (number, string) => boolean = (min, input) => min <= parseFloat(input);
 export const isSmallerOrEqual: (number, string) => boolean = (max, input) => parseFloat(input) <= max;
 export const maxTwoDecimals: string => boolean = input => new RegExp('^\\d+\\.?\\d{0,2}$').test(input);
 
-export const checkFirstName: (string | null) => boolean = !isEmpty;
-export const checkLastName: (string | null) => boolean = !isEmpty;
-export const checkState: (string | null) => boolean = s => typeof s === 'string' && (!isEmpty(s));
-export const checkEmail: (string | null) => boolean = input => !isEmpty(input) && isValidEmail(input);
+export const checkFirstName: (string | null) => boolean = isNotEmpty;
+export const checkLastName: (string | null) => boolean = isNotEmpty;
+export const checkState: (string | null) => boolean = s => typeof s === 'string' && isNotEmpty(s);
+export const checkEmail: (string | null) => boolean = input => isNotEmpty(input) && isValidEmail(input);
 
 export const checkOptionalEmail: (string | null) => boolean = input => {
-  isEmpty(input) || isValidEmail(input);
+ isEmpty(input) || isValidEmail(input);
 };
 
 export const checkAmount: (string, CountryGroupId, ContributionType) =>
   boolean = (input: string, countryGroupId: CountryGroupId, contributionType: ContributionType) =>
-    !isEmpty(input)
+    isNotEmpty(input)
     && isLargerOrEqual(config[countryGroupId][contributionType].min, input)
     && isSmallerOrEqual(config[countryGroupId][contributionType].max, input)
     && maxTwoDecimals(input);

--- a/support-frontend/assets/helpers/subscriptionsForms/formActions.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/formActions.js
@@ -82,7 +82,7 @@ const formActionCreators = {
   setTitleGift: (titleGiftRecipient: string): Action => ({ type: 'SET_TITLE_GIFT', titleGiftRecipient }),
   setFirstNameGift: (firstNameGiftRecipient: string): Function => (setFormSubmissionDependentValue(() => ({ type: 'SET_FIRST_NAME_GIFT', firstNameGiftRecipient }))),
   setLastNameGift: (lastNameGiftRecipient: string): Function => (setFormSubmissionDependentValue(() => ({ type: 'SET_LAST_NAME_GIFT', lastNameGiftRecipient }))),
-  setEmailGift: (emailGiftRecipient: string): Action => ({ type: 'SET_EMAIL_GIFT', emailGiftRecipient }),
+  setEmailGift: (emailGiftRecipient: string): Function => (setFormSubmissionDependentValue(() => ({ type: 'SET_EMAIL_GIFT', emailGiftRecipient }))),
   setStartDate: (startDate: string): Action => ({ type: 'SET_START_DATE', startDate }),
   setBillingPeriod: (billingPeriod: BillingPeriod): Action => ({ type: 'SET_BILLING_PERIOD', billingPeriod }),
   setPaymentMethod: (paymentMethod: PaymentMethod) => (dispatch: Dispatch<Action>, getState: () => CheckoutState) => {

--- a/support-frontend/assets/helpers/subscriptionsForms/formReducer.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/formReducer.js
@@ -95,7 +95,7 @@ function createFormReducer(
         return { ...state, lastNameGiftRecipient: action.lastNameGiftRecipient, formErrors: removeError('lastNameGiftRecipient', state.formErrors) };
 
       case 'SET_EMAIL_GIFT':
-        return { ...state, emailGiftRecipient: action.emailGiftRecipient };
+        return { ...state, emailGiftRecipient: action.emailGiftRecipient, formErrors: removeError('emailGiftRecipient', state.formErrors) };
 
       case 'SET_START_DATE':
         return { ...state, startDate: action.startDate };

--- a/support-frontend/assets/helpers/subscriptionsForms/rules.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/rules.js
@@ -3,7 +3,7 @@
 import { formError, nonEmptyString, notNull, validate } from './validation';
 import type { FormField, FormFields } from './formFields';
 import type { FormError } from './validation';
-import {checkOptionalEmail} from "../formValidation";
+import { checkOptionalEmail } from '../formValidation';
 
 function applyCheckoutRules(fields: FormFields): FormError<FormField>[] {
   const { orderIsAGift } = fields;

--- a/support-frontend/assets/helpers/subscriptionsForms/rules.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/rules.js
@@ -3,7 +3,7 @@
 import { formError, nonEmptyString, notNull, validate } from './validation';
 import type { FormField, FormFields } from './formFields';
 import type { FormError } from './validation';
-import { checkOptionalEmail } from '../formValidation';
+import { checkOptionalEmail } from 'helpers/formValidation';
 
 function applyCheckoutRules(fields: FormFields): FormError<FormField>[] {
   const { orderIsAGift } = fields;

--- a/support-frontend/assets/helpers/subscriptionsForms/rules.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/rules.js
@@ -3,6 +3,7 @@
 import { formError, nonEmptyString, notNull, validate } from './validation';
 import type { FormField, FormFields } from './formFields';
 import type { FormError } from './validation';
+import {checkOptionalEmail} from "../formValidation";
 
 function applyCheckoutRules(fields: FormFields): FormError<FormField>[] {
   const { orderIsAGift } = fields;
@@ -28,6 +29,10 @@ function applyCheckoutRules(fields: FormFields): FormError<FormField>[] {
     {
       rule: nonEmptyString(fields.lastNameGiftRecipient),
       error: formError('lastNameGiftRecipient', 'Please enter the recipient\'s last name.'),
+    },
+    {
+      rule: checkOptionalEmail(fields.emailGiftRecipient),
+      error: formError('emailGiftRecipient', 'Please use a valid email address for the recipient.'),
     },
   ];
   const formFieldsToCheck = orderIsAGift ?

--- a/support-frontend/assets/helpers/subscriptionsForms/validation.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/validation.js
@@ -26,12 +26,8 @@ function notNull<A>(value: A): boolean {
 // ----- Functions ----- //
 
 function firstError<FieldType>(field: FieldType, errors: FormError<FieldType>[]): Option<string> {
-
-
   const msgs = errors.filter(err => err.field === field).map(err => err.message);
-
   return headOption(msgs);
-
 }
 
 function removeError<FieldType>(field: FieldType, formErrors: FormError<FieldType>[]): FormError<FieldType>[] {

--- a/support-frontend/assets/helpers/subscriptionsForms/validation.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/validation.js
@@ -27,7 +27,9 @@ function notNull<A>(value: A): boolean {
 
 function firstError<FieldType>(field: FieldType, errors: FormError<FieldType>[]): Option<string> {
 
+
   const msgs = errors.filter(err => err.field === field).map(err => err.message);
+
   return headOption(msgs);
 
 }

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -463,7 +463,7 @@ const paymentAuthorisationHandlers: PaymentMatrix<(
           logException('Stripe 3DS handler unavailable');
           return Promise.resolve(error);
         }
-        logException(`Invalid payment authorisation: missing paymentMethodId for Stripe one-off contribution`);
+        logException('Invalid payment authorisation: missing paymentMethodId for Stripe one-off contribution');
         return Promise.resolve(error);
       }
       logException(`Invalid payment authorisation: Tried to use the ${paymentAuthorisation.paymentMethod} handler with Stripe`);

--- a/support-models/src/test/scala/com/gu/support/SerialisationTestHelpers.scala
+++ b/support-models/src/test/scala/com/gu/support/SerialisationTestHelpers.scala
@@ -6,7 +6,7 @@ import io.circe.syntax._
 import org.scalatest.{Assertion, Matchers}
 
 trait SerialisationTestHelpers extends Matchers {
-  def testDecoding[T](fixture: String, objectChecks: T => Assertion = (_: T) => succeed)(implicit decoder: Decoder[T]): Assertion = {
+  def testDecoding[T : Decoder](fixture: String, objectChecks: T => Assertion = (_: T) => succeed): Assertion = {
     val decodeResult = decode[T](fixture)
     assertDecodingSucceeded(decodeResult, objectChecks)
   }

--- a/support-models/src/test/scala/com/gu/support/encoding/PaymentMethodEncoderSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/encoding/PaymentMethodEncoderSpec.scala
@@ -27,7 +27,7 @@ class PaymentMethodEncoderSpec extends FlatSpec with Matchers with LazyLogging w
       "paymentGateway": "GoCardless"
     }"""
 
-    testDecoding[PaymentMethod](json, {case _: DirectDebitPaymentMethod => succeed})
+    testDecoding[PaymentMethod](json, { case _ : DirectDebitPaymentMethod => succeed })
   }
 
   it should "decode ClonedDirectDebitPaymentMethod" in {
@@ -46,7 +46,7 @@ class PaymentMethodEncoderSpec extends FlatSpec with Matchers with LazyLogging w
       "paymentGateway": "GoCardless"
     }"""
 
-    testDecoding[PaymentMethod](json, {case _: ClonedDirectDebitPaymentMethod => succeed})
+    testDecoding[PaymentMethod](json, { case _ : ClonedDirectDebitPaymentMethod => succeed })
   }
 
 }


### PR DESCRIPTION
## Why are you doing this?

Support workers experience issues submitting subscriptions to Salesforce where the postcode length is over 20 characters. This is also likely to be accidental user input, and we need to protect against it with a character limit in the postcode field.


[**Trello Card**](https://trello.com/c/ONmjZVen/2565-clientside-validate-checkout-fields-to-avoid-salesforce-errors)

## Changes

* Added postcode maximum length rule for billing and delivery postcode.

## Screenshots

![UNADJUSTEDNONRAW_thumb_2](https://user-images.githubusercontent.com/1645142/66499332-8f8fee00-eab7-11e9-8ca7-a07d3a84bdd7.jpg)

