### PR TITLE
Fix payment request button

### DIFF
--- a/support-frontend/assets/helpers/paymentIntegrations/oneOffContributions.js
+++ b/support-frontend/assets/helpers/paymentIntegrations/oneOffContributions.js
@@ -134,6 +134,19 @@ function paymentResultFromObject(
   return Promise.resolve(PaymentSuccess);
 }
 
+// Sends a one-off payment request to the payment API and standardises the result
+// https://github.com/guardian/payment-api/blob/master/src/main/resources/routes#L17
+function postOneOffStripeExecutePaymentRequest(
+  data: StripeChargeData,
+  setGuestAccountCreationToken: (string) => void,
+  setThankYouPageStage: (ThankYouPageStage) => void,
+): Promise<PaymentResult> {
+  return logPromise(fetchJson(
+    paymentApiEndpointWithMode(`${window.guardian.paymentApiStripeUrl}/contribute/one-off/stripe/execute-payment`),
+    requestOptions(data, 'omit', 'POST', null),
+  ).then(result => paymentResultFromObject(result, setGuestAccountCreationToken, setThankYouPageStage)));
+}
+
 function postStripeCreatePaymentIntentRequest(data: CreateStripePaymentIntentRequest): Promise<Object> {
   return fetchJson(
     paymentApiEndpointWithMode(`${window.guardian.paymentApiStripeUrl}/contribute/one-off/stripe/create-payment`),
@@ -197,6 +210,7 @@ function postOneOffPayPalCreatePaymentRequest(data: CreatePaypalPaymentData): Pr
 }
 
 export {
+  postOneOffStripeExecutePaymentRequest,
   postOneOffPayPalCreatePaymentRequest,
   processStripePaymentIntentRequest,
 };


### PR DESCRIPTION
## Why are you doing this?
[This PR](https://github.com/guardian/support-frontend/pull/2114) removed support for Stripe Checkout for single contributions.
However, it also broke the Payment Request button because it uses shared code from the Stripe Checkout flow. This PR adds some of this logic back in.

I've tested Payment Request button and normal Stripe payments locally + in CODE.

TODO - we badly need tests/post-deploy testing/alarms for Payment Requests. Currently we have no visibility when things go wrong