### PR TITLE
Make the Payment Request button work for recurring contributions

### DIFF
--- a/support-config/src/main/scala/com/gu/support/config/StripeConfig.scala
+++ b/support-config/src/main/scala/com/gu/support/config/StripeConfig.scala
@@ -16,11 +16,11 @@ case class StripeConfig(defaultAccount: StripeAccountConfig,
   def forCurrency(maybeCurrency: Option[Currency]): StripeAccountConfig = {
     maybeCurrency match {
       case Some(AUD) => {
-        SafeLogger.info(s"StripeConfig: getting AU stripe account for AUD")
+        SafeLogger.debug(s"StripeConfig: getting AU stripe account for AUD")
         australiaAccount
       }
       case _ => {
-        SafeLogger.info(s"StripeConfig: getting default stripe account for ${maybeCurrency.map(_.iso).mkString}")
+        SafeLogger.debug(s"StripeConfig: getting default stripe account for ${maybeCurrency.map(_.iso).mkString}")
         defaultAccount
       }
     }
@@ -29,15 +29,15 @@ case class StripeConfig(defaultAccount: StripeAccountConfig,
   def forCountry(maybeCountry: Option[Country]): StripeAccountConfig = {
     maybeCountry match {
       case Some(Country.Australia) => {
-        SafeLogger.info(s"StripeConfig: getting AU stripe account for Australia")
+        SafeLogger.debug(s"StripeConfig: getting AU stripe account for Australia")
         australiaAccount
       }
       case Some(Country.US) => {
-        SafeLogger.info(s"StripeConfig: getting US stripe account for United States")
+        SafeLogger.debug(s"StripeConfig: getting US stripe account for United States")
         unitedStatesAccount
       }
       case _ => {
-        SafeLogger.info(s"StripeConfig: getting default stripe account for ${maybeCountry.map(_.name).mkString}")
+        SafeLogger.debug(s"StripeConfig: getting default stripe account for ${maybeCountry.map(_.name).mkString}")
         defaultAccount
       }
     }

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -103,5 +103,6 @@ window.guardian.paymentApiPayPalEndpoint = "@paymentApiPayPalEndpoint";
 
   window.guardian.stripeElements = @settings.switches.experiments.get("stripeElements").exists(_.isOn)
   window.guardian.forceCampaign = @settings.switches.experiments.get("forceCampaign").exists(_.isOn)
+  window.guardian.recurringStripePaymentRequestButton = @settings.switches.experiments.get("recurringStripePaymentRequestButton").exists(_.isOn)
   </script>
 }

--- a/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
+++ b/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
@@ -205,8 +205,6 @@ function checkRegularStatus(
   setThankYouPageStage: (ThankYouPageStage) => void,
 ): Object => Promise<PaymentResult> {
   const handleCompletion = (json) => {
-    console.log('handleCompletion', json);
-
     switch (json.status) {
       case 'success':
       case 'pending':
@@ -230,8 +228,6 @@ function checkRegularStatus(
   };
 
   return (json) => {
-    console.log('checkRegularStatus', json);
-
     if (json.guestAccountCreationToken) {
       setGuestAccountCreationToken(json.guestAccountCreationToken);
       setThankYouPageStage('thankYouSetPassword');

--- a/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
+++ b/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
@@ -205,6 +205,8 @@ function checkRegularStatus(
   setThankYouPageStage: (ThankYouPageStage) => void,
 ): Object => Promise<PaymentResult> {
   const handleCompletion = (json) => {
+    console.log('handleCompletion', json);
+
     switch (json.status) {
       case 'success':
       case 'pending':
@@ -228,6 +230,8 @@ function checkRegularStatus(
   };
 
   return (json) => {
+    console.log('checkRegularStatus', json);
+
     if (json.guestAccountCreationToken) {
       setGuestAccountCreationToken(json.guestAccountCreationToken);
       setThankYouPageStage('thankYouSetPassword');

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
@@ -51,7 +51,9 @@ const mapStateToProps = state => ({
   selectedAmounts: state.page.form.selectedAmounts,
   otherAmounts: state.page.form.formData.otherAmounts,
   checkoutFormHasBeenSubmitted: state.page.form.formData.checkoutFormHasBeenSubmitted,
-  stripePaymentRequestButtonClicked: state.page.form.stripePaymentRequestButtonData.stripePaymentRequestButtonClicked,
+  stripePaymentRequestButtonClicked:
+    state.page.form.stripePaymentRequestButtonData.ONE_OFF.stripePaymentRequestButtonClicked ||
+    state.page.form.stripePaymentRequestButtonData.REGULAR.stripePaymentRequestButtonClicked,
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
@@ -29,7 +29,6 @@ import { checkAmount } from 'helpers/formValidation';
 import { onFormSubmit } from 'helpers/checkoutForm/onFormSubmit';
 import { type UserTypeFromIdentityResponse } from 'helpers/identityApis';
 import type { OtherAmounts, SelectedAmounts } from 'helpers/contributions';
-import type { StripePaymentRequestButtonMethod } from 'helpers/paymentIntegrations/readerRevenueApis';
 
 import { ContributionFormFields, EmptyContributionFormFields } from './ContributionFormFields';
 import { ContributionTypeTabs, EmptyContributionTypeTabs } from './ContributionTypeTabs';
@@ -82,7 +81,6 @@ type PropTypes = {|
   formIsSubmittable: boolean,
   isTestUser: boolean,
   country: IsoCountry,
-  stripePaymentRequestButtonMethod: StripePaymentRequestButtonMethod,
   createStripePaymentMethod: () => void,
 |};
 
@@ -114,7 +112,6 @@ const mapStateToProps = (state: State) => ({
   isTestUser: state.page.user.isTestUser || false,
   country: state.common.internationalisation.countryId,
   stripeV3HasLoaded: state.page.form.stripeV3HasLoaded,
-  stripePaymentRequestButtonMethod: state.page.form.stripePaymentRequestButtonData.paymentMethod,
 });
 
 

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -134,7 +134,7 @@ const onComplete = (complete: Function) => (res: PaymentResult) => {
 };
 
 
-function updatePaymentRequest(amount: number, paymentRequest: Object | null, contributionType: ContributionType) {
+function updatePaymentRequest(amount: number, paymentRequest: Object | null) {
   // When the other tab is clicked, the value of amount is NaN
   if (!Number.isNaN(amount) && paymentRequest) {
     paymentRequest.update({

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -142,6 +142,7 @@ function updateAmount(amount: number, paymentRequest: Object | null) {
         label: 'The Guardian',
         amount: amount * 100,
       },
+      requestPayerName: (props.contributionType !== 'ONE_OFF'),
     });
   }
 }

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -24,7 +24,7 @@ import {
   setPaymentRequestButtonPaymentMethod,
   setStripePaymentRequestButtonClicked,
   setStripePaymentRequestObject,
-  onStripePaymentRequestApiPaymentAuthorised,
+  onThirdPartyPaymentAuthorised,
   updateEmail,
 } from '../../contributionsLandingActions';
 import type { PaymentMethod } from 'helpers/paymentMethods';
@@ -71,7 +71,7 @@ const mapStateToProps = (state: State) => ({
 const mapDispatchToProps = (dispatch: Function) => ({
   onPaymentAuthorised:
     (paymentAuthorisation: PaymentAuthorisation) =>
-      dispatch(onStripePaymentRequestApiPaymentAuthorised(paymentAuthorisation)),
+      dispatch(onThirdPartyPaymentAuthorised(paymentAuthorisation)),
   setPaymentRequestButtonPaymentMethod:
     (paymentMethod: StripePaymentRequestButtonMethod) => {
       dispatch(setPaymentRequestButtonPaymentMethod(paymentMethod));
@@ -177,7 +177,7 @@ function initialisePaymentRequest(props: PropTypes) {
     currency: props.currency.toLowerCase(),
     total: {
       label: 'The Guardian',
-      amount: props.amount,
+      amount: props.amount * 100,
     },
     requestPayerEmail: true,
   });

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -134,7 +134,7 @@ const onComplete = (complete: Function) => (res: PaymentResult) => {
 };
 
 
-function updatePaymentRequest(amount: number, paymentRequest: Object | null) {
+function updateAmount(amount: number, paymentRequest: Object | null) {
   // When the other tab is clicked, the value of amount is NaN
   if (!Number.isNaN(amount) && paymentRequest) {
     paymentRequest.update({
@@ -151,7 +151,7 @@ function updatePaymentRequest(amount: number, paymentRequest: Object | null) {
 function onClick(event, props: PropTypes) {
   event.preventDefault();
   trackComponentClick('apple-pay-clicked');
-  updatePaymentRequest(props.amount, props.stripePaymentRequestObject, props.contributionType);
+  updateAmount(props.amount, props.stripePaymentRequestObject);
   props.setAssociatedPaymentMethod();
   props.setStripePaymentRequestButtonClicked();
   const amountIsValid =

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -134,7 +134,7 @@ const onComplete = (complete: Function) => (res: PaymentResult) => {
 };
 
 
-function updateAmount(amount: number, paymentRequest: Object | null) {
+function updatePaymentRequest(amount: number, paymentRequest: Object | null, contributionType: ContributionType) {
   // When the other tab is clicked, the value of amount is NaN
   if (!Number.isNaN(amount) && paymentRequest) {
     paymentRequest.update({
@@ -142,7 +142,7 @@ function updateAmount(amount: number, paymentRequest: Object | null) {
         label: 'The Guardian',
         amount: amount * 100,
       },
-      requestPayerName: (props.contributionType !== 'ONE_OFF'),
+      requestPayerName: (contributionType !== 'ONE_OFF'),
     });
   }
 }
@@ -152,7 +152,7 @@ function updateAmount(amount: number, paymentRequest: Object | null) {
 function onClick(event, props: PropTypes) {
   event.preventDefault();
   trackComponentClick('apple-pay-clicked');
-  updateAmount(props.amount, props.stripePaymentRequestObject);
+  updatePaymentRequest(props.amount, props.stripePaymentRequestObject, props.contributionType);
   props.setAssociatedPaymentMethod();
   props.setStripePaymentRequestButtonClicked();
   const amountIsValid =
@@ -208,8 +208,7 @@ function initialisePaymentRequest(props: PropTypes) {
       label: 'The Guardian',
       amount: props.amount * 100,
     },
-    requestPayerEmail: true,
-    requestPayerName: (props.contributionType !== 'ONE_OFF'),
+    requestPayerEmail: true
   });
 
   paymentRequest.canMakePayment().then((result) => {

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -35,7 +35,7 @@ import { Stripe } from 'helpers/paymentMethods';
 import {
   toHumanReadableContributionType,
 } from 'helpers/checkouts';
-import type {StripeAccount} from "helpers/paymentIntegrations/stripeCheckout";
+import type { StripeAccount } from 'helpers/paymentIntegrations/stripeCheckout';
 
 // ----- Types -----//
 
@@ -77,22 +77,19 @@ const mapStateToProps = (state: State, ownProps: PropTypes) => ({
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
-  onPaymentAuthorised:
-    (paymentAuthorisation: PaymentAuthorisation) =>
-      dispatch(onThirdPartyPaymentAuthorised(paymentAuthorisation)),
+  onPaymentAuthorised: (paymentAuthorisation: PaymentAuthorisation) =>
+    dispatch(onThirdPartyPaymentAuthorised(paymentAuthorisation)),
   setPaymentRequestButtonPaymentMethod:
-    (paymentMethod: StripePaymentRequestButtonMethod, stripeAccount: StripeAccount) => {
-      dispatch(setPaymentRequestButtonPaymentMethod(paymentMethod, stripeAccount));
-    },
-  setStripePaymentRequestObject:
-    (paymentRequest: Object, stripeAccount: StripeAccount) => {
-      dispatch(setStripePaymentRequestObject(paymentRequest, stripeAccount))
-    },
-  updateEmail: (email: string) => { dispatch(updateEmail(email)); },
-  updateFirstName: (firstName: string) => { dispatch(updateFirstName(firstName)); },
-  updateLastName: (lastName: string) => { dispatch(updateLastName(lastName)); },
-  setStripePaymentRequestButtonClicked: (stripeAccount: StripeAccount) => { dispatch(setStripePaymentRequestButtonClicked(stripeAccount)); },
-  setAssociatedPaymentMethod: () => { dispatch(updatePaymentMethod(Stripe)); },
+    (paymentMethod: StripePaymentRequestButtonMethod, stripeAccount: StripeAccount) =>
+      dispatch(setPaymentRequestButtonPaymentMethod(paymentMethod, stripeAccount)),
+  setStripePaymentRequestObject: (paymentRequest: Object, stripeAccount: StripeAccount) =>
+    dispatch(setStripePaymentRequestObject(paymentRequest, stripeAccount)),
+  updateEmail: (email: string) => dispatch(updateEmail(email)),
+  updateFirstName: (firstName: string) => dispatch(updateFirstName(firstName)),
+  updateLastName: (lastName: string) => dispatch(updateLastName(lastName)),
+  setStripePaymentRequestButtonClicked: (stripeAccount: StripeAccount) =>
+    dispatch(setStripePaymentRequestButtonClicked(stripeAccount)),
+  setAssociatedPaymentMethod: () => dispatch(updatePaymentMethod(Stripe)),
 });
 
 
@@ -121,7 +118,7 @@ function updatePayerName(data: Object, setFirstName: string => void, setLastName
     setFirstName(nameParts[0]);
     setLastName(nameParts[1]);
   } else if (nameParts.length === 1) {
-    logException('Failed to set name: no spaces in data object: ' + nameParts.join(''));
+    logException(`Failed to set name: no spaces in data object: ${nameParts.join('')}`);
   } else {
     logException('Failed to set name: no name in data object');
   }
@@ -255,9 +252,11 @@ function PaymentRequestButton(props: PropTypes) {
   }
 
   return (
-    <div className="stripe-payment-request-button__container"
-         data-for-stripe-account={props.stripeAccount}
-         data-for-contribution-type={props.contributionType}>
+    <div
+      className="stripe-payment-request-button__container"
+      data-for-stripe-account={props.stripeAccount}
+      data-for-contribution-type={props.contributionType}
+    >
       <PaymentRequestButtonElement
         paymentRequest={props.stripePaymentRequestButtonData.stripePaymentRequestObject}
         className="stripe-payment-request-button__button"

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -210,7 +210,7 @@ function initialisePaymentRequest(props: PropTypes) {
       amount: props.amount * 100,
     },
     requestPayerEmail: true,
-    requestPayerName: true,
+    requestPayerName: props.contributionType !== 'ONE_OFF',
   });
 
   paymentRequest.canMakePayment().then((result) => {
@@ -249,7 +249,7 @@ function PaymentRequestButton(props: PropTypes) {
   }
 
   return (
-    <div className="stripe-payment-request-button__container">
+    <div className="stripe-payment-request-button__container" data-for-contribution-type={props.contributionType}>
       <PaymentRequestButtonElement
         paymentRequest={props.stripePaymentRequestObject}
         className="stripe-payment-request-button__button"

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -238,7 +238,6 @@ function PaymentRequestButton(props: PropTypes) {
 
   // If we haven't initialised the payment request, initialise it and return null, as we can't insert the button
   // until the async canMakePayment() function has been called on the stripePaymentRequestObject object.
-  // debugger
   if (!props.stripePaymentRequestButtonData.stripePaymentRequestObject) {
     initialisePaymentRequest({ ...props });
     return null;

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -142,7 +142,6 @@ function updatePaymentRequest(amount: number, paymentRequest: Object | null, con
         label: 'The Guardian',
         amount: amount * 100,
       },
-      requestPayerName: (contributionType !== 'ONE_OFF'),
     });
   }
 }
@@ -208,7 +207,8 @@ function initialisePaymentRequest(props: PropTypes) {
       label: 'The Guardian',
       amount: props.amount * 100,
     },
-    requestPayerEmail: true
+    requestPayerEmail: true,
+    requestPayerName: true,
   });
 
   paymentRequest.canMakePayment().then((result) => {

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -32,7 +32,9 @@ import {
 } from '../../contributionsLandingActions';
 import type { PaymentMethod } from 'helpers/paymentMethods';
 import { Stripe } from 'helpers/paymentMethods';
-
+import {
+  toHumanReadableContributionType,
+} from 'helpers/checkouts';
 
 // ----- Types -----//
 
@@ -134,13 +136,13 @@ const onComplete = (complete: Function) => (res: PaymentResult) => {
 };
 
 
-function updateAmount(amount: number, paymentRequest: Object | null) {
+function updateTotal(props: PropTypes) {
   // When the other tab is clicked, the value of amount is NaN
-  if (!Number.isNaN(amount) && paymentRequest) {
-    paymentRequest.update({
+  if (!Number.isNaN(props.amount) && props.stripePaymentRequestObject) {
+    props.stripePaymentRequestObject.update({
       total: {
-        label: 'The Guardian',
-        amount: amount * 100,
+        label: `${toHumanReadableContributionType(props.contributionType)} Contribution`,
+        amount: props.amount * 100,
       },
     });
   }
@@ -151,7 +153,7 @@ function updateAmount(amount: number, paymentRequest: Object | null) {
 function onClick(event, props: PropTypes) {
   event.preventDefault();
   trackComponentClick('apple-pay-clicked');
-  updateAmount(props.amount, props.stripePaymentRequestObject);
+  updateTotal(props);
   props.setAssociatedPaymentMethod();
   props.setStripePaymentRequestButtonClicked();
   const amountIsValid =
@@ -204,7 +206,7 @@ function initialisePaymentRequest(props: PropTypes) {
     country: props.country,
     currency: props.currency.toLowerCase(),
     total: {
-      label: 'The Guardian',
+      label: `${toHumanReadableContributionType(props.contributionType)} Contribution`,
       amount: props.amount * 100,
     },
     requestPayerEmail: true,

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -26,6 +26,7 @@ import {
   setStripePaymentRequestObject,
   onThirdPartyPaymentAuthorised,
   updateEmail,
+  updatePaymentMethod,
 } from '../../contributionsLandingActions';
 import type { PaymentMethod } from 'helpers/paymentMethods';
 import { Stripe } from 'helpers/paymentMethods';
@@ -53,6 +54,7 @@ type PropTypes = {|
   toggleOtherPaymentMethods: () => void,
   updateEmail: string => void,
   paymentMethod: PaymentMethod,
+  setAssociatedPaymentMethod: () => (Function) => void,
 |};
 
 const mapStateToProps = (state: State) => ({
@@ -80,6 +82,7 @@ const mapDispatchToProps = (dispatch: Function) => ({
     (paymentRequest: Object) => { dispatch(setStripePaymentRequestObject(paymentRequest)); },
   updateEmail: (email: string) => { dispatch(updateEmail(email)); },
   setStripePaymentRequestButtonClicked: () => { dispatch(setStripePaymentRequestButtonClicked()); },
+  setAssociatedPaymentMethod: () => { dispatch(updatePaymentMethod(Stripe)); },
 });
 
 
@@ -128,6 +131,7 @@ function onClick(event, props: PropTypes) {
   event.preventDefault();
   trackComponentClick('apple-pay-clicked');
   updateAmount(props.amount, props.stripePaymentRequestObject);
+  props.setAssociatedPaymentMethod();
   props.setStripePaymentRequestButtonClicked();
   const amountIsValid =
     checkAmountOrOtherAmount(

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -54,7 +54,7 @@ type PropTypes = {|
   setPaymentRequestButtonPaymentMethod: (StripePaymentRequestButtonMethod, StripeAccount) => void,
   setStripePaymentRequestObject: (paymentRequest: Object, stripeAccount: StripeAccount) => void,
   onPaymentAuthorised: (PaymentAuthorisation) => Promise<PaymentResult>,
-  setStripePaymentRequestButtonClicked: () => void,
+  setStripePaymentRequestButtonClicked: (stripeAccount: StripeAccount) => void,
   toggleOtherPaymentMethods: () => void,
   updateEmail: string => void,
   updateFirstName: string => void,
@@ -91,7 +91,7 @@ const mapDispatchToProps = (dispatch: Function) => ({
   updateEmail: (email: string) => { dispatch(updateEmail(email)); },
   updateFirstName: (firstName: string) => { dispatch(updateFirstName(firstName)); },
   updateLastName: (lastName: string) => { dispatch(updateLastName(lastName)); },
-  setStripePaymentRequestButtonClicked: () => { dispatch(setStripePaymentRequestButtonClicked()); },
+  setStripePaymentRequestButtonClicked: (stripeAccount: StripeAccount) => { dispatch(setStripePaymentRequestButtonClicked(stripeAccount)); },
   setAssociatedPaymentMethod: () => { dispatch(updatePaymentMethod(Stripe)); },
 });
 
@@ -157,7 +157,7 @@ function onClick(event, props: PropTypes) {
   trackComponentClick('apple-pay-clicked');
   updateTotal(props);
   props.setAssociatedPaymentMethod();
-  props.setStripePaymentRequestButtonClicked();
+  props.setStripePaymentRequestButtonClicked(props.stripeAccount);
   const amountIsValid =
     checkAmountOrOtherAmount(
       props.selectedAmounts,

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
@@ -48,7 +48,7 @@ class StripePaymentRequestButtonContainer extends React.Component<PropTypes, voi
 
       return (
         <div className="stripe-payment-request-button">
-          <StripeProvider apiKey={apiKey} key={apiKey}>
+          <StripeProvider apiKey={apiKey} key={stripeAccount}>
             <Elements>
               <StripePaymentRequestButton
                 stripeAccount={stripeAccount}

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
@@ -30,6 +30,8 @@ type PropTypes = {|
   otherAmounts: OtherAmounts,
 |};
 
+const enabledForRecurring = (): boolean => !!window.guardian.recurringStripePaymentRequestButton;
+
 // ----- Component ----- //
 
 class StripePaymentRequestButtonContainer extends React.Component<PropTypes, void> {
@@ -39,7 +41,9 @@ class StripePaymentRequestButtonContainer extends React.Component<PropTypes, voi
   }
 
   render() {
-    const showStripePaymentRequestButton = isInStripePaymentRequestAllowedCountries(this.props.country);
+    const showStripePaymentRequestButton =
+      isInStripePaymentRequestAllowedCountries(this.props.country) &&
+      (this.props.contributionType === 'ONE_OFF' || enabledForRecurring());
 
     if (showStripePaymentRequestButton && this.props.stripeHasLoaded) {
       const stripeAccount = stripeAccountForContributionType[this.props.contributionType];

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import { StripeProvider, Elements } from 'react-stripe-elements';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
- import { getStripeKey, stripeAccountForContributionType } from 'helpers/paymentIntegrations/stripeCheckout';
+import { getStripeKey } from 'helpers/paymentIntegrations/stripeCheckout';
 import type { ContributionType, OtherAmounts, SelectedAmounts } from 'helpers/contributions';
 import { getAmount } from 'helpers/contributions';
 import { isInStripePaymentRequestAllowedCountries } from 'helpers/internationalisation/country';

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
@@ -48,7 +48,7 @@ class StripePaymentRequestButtonContainer extends React.Component<PropTypes, voi
 
       return (
         <div className="stripe-payment-request-button">
-          <StripeProvider apiKey={apiKey}>
+          <StripeProvider apiKey={apiKey} key={apiKey}>
             <Elements>
               <StripePaymentRequestButton
                 stripeAccount={stripeAccount}

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import { StripeProvider, Elements } from 'react-stripe-elements';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
-import { getStripeKey } from 'helpers/paymentIntegrations/stripeCheckout';
+import { getStripeKey, stripeAccountForContributionType } from 'helpers/paymentIntegrations/stripeCheckout';
 import type { ContributionType, OtherAmounts, SelectedAmounts } from 'helpers/contributions';
 import { getAmount } from 'helpers/contributions';
 import { isInStripePaymentRequestAllowedCountries } from 'helpers/internationalisation/country';
@@ -42,30 +42,20 @@ class StripePaymentRequestButtonContainer extends React.Component<PropTypes, voi
     const showStripePaymentRequestButton = isInStripePaymentRequestAllowedCountries(this.props.country);
 
     if (showStripePaymentRequestButton && this.props.stripeHasLoaded) {
-      const singleKey = getStripeKey('ONE_OFF', this.props.country, this.props.isTestUser);
-      const recurringKey =  getStripeKey('REGULAR', this.props.country, this.props.isTestUser);
+      const stripeAccount = stripeAccountForContributionType[this.props.contributionType];
+      const apiKey = getStripeKey(stripeAccount, this.props.country, this.props.isTestUser);
       const amount = getAmount(this.props.selectedAmounts, this.props.otherAmounts, this.props.contributionType);
 
       return (
         <div className="stripe-payment-request-button">
-          {
-            this.props.contributionType === 'ONE_OFF' ?
-              <StripeProvider apiKey={singleKey}>
-                <Elements>
-                  <StripePaymentRequestButton
-                    amount={amount}
-                  />
-                </Elements>
-              </StripeProvider>
-            :
-              <StripeProvider apiKey={recurringKey}>
-                <Elements>
-                  <StripePaymentRequestButton
-                    amount={amount}
-                  />
-                </Elements>
-              </StripeProvider>
-          }
+          <StripeProvider apiKey={apiKey}>
+            <Elements>
+              <StripePaymentRequestButton
+                stripeAccount={stripeAccount}
+                amount={amount}
+              />
+            </Elements>
+          </StripeProvider>
         </div>
       );
     }

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
@@ -47,7 +47,7 @@ class StripePaymentRequestButtonContainer extends React.Component<PropTypes, voi
       const amount = getAmount(this.props.selectedAmounts, this.props.otherAmounts, this.props.contributionType);
 
       return (
-        <div className="stripe-payment-request-button" amount={amount}>
+        <div className="stripe-payment-request-button">
           <StripeProvider apiKey={key}>
             <Elements>
               <StripePaymentRequestButton

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
@@ -46,6 +46,13 @@ class StripePaymentRequestButtonContainer extends React.Component<PropTypes, voi
       const apiKey = getStripeKey(stripeAccount, this.props.country, this.props.isTestUser);
       const amount = getAmount(this.props.selectedAmounts, this.props.otherAmounts, this.props.contributionType);
 
+      /**
+       * The `key` attribute is necessary here because you cannot modify the apiKey on StripeProvider.
+       * Instead, we must create separate instances for ONE_OFF and REGULAR.
+       *
+       * This means that e.g. switching from monthly to one-off would cause it to create a new ONE_OFF StripeProvider
+       * with new children. However, switching back to monthly/annual would not then re-create the REGULAR instance.
+       */
       return (
         <div className="stripe-payment-request-button">
           <StripeProvider apiKey={apiKey} key={stripeAccount}>

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
@@ -42,20 +42,32 @@ class StripePaymentRequestButtonContainer extends React.Component<PropTypes, voi
     const showStripePaymentRequestButton = isInStripePaymentRequestAllowedCountries(this.props.country);
 
     if (showStripePaymentRequestButton && this.props.stripeHasLoaded) {
-      const stripeAccount = stripeAccountForContributionType[this.props.contributionType];
-      const key = getStripeKey(stripeAccount, this.props.country, this.props.isTestUser);
+      const singleKey = getStripeKey('ONE_OFF', this.props.country, this.props.isTestUser);
+      const recurringKey =  getStripeKey('REGULAR', this.props.country, this.props.isTestUser);
       const amount = getAmount(this.props.selectedAmounts, this.props.otherAmounts, this.props.contributionType);
 
       return (
         <div className="stripe-payment-request-button">
-          <StripeProvider apiKey={key}>
-            <Elements>
-              <StripePaymentRequestButton
-                amount={amount}
-              />
-            </Elements>
-          </StripeProvider>
+          {
+            this.props.contributionType === 'ONE_OFF' ?
+              <StripeProvider apiKey={singleKey}>
+                <Elements>
+                  <StripePaymentRequestButton
+                    amount={amount}
+                  />
+                </Elements>
+              </StripeProvider>
+            :
+              <StripeProvider apiKey={recurringKey}>
+                <Elements>
+                  <StripePaymentRequestButton
+                    amount={amount}
+                  />
+                </Elements>
+              </StripeProvider>
+          }
         </div>
+
       );
     }
     return null;

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
@@ -7,7 +7,7 @@
 import React from 'react';
 import { StripeProvider, Elements } from 'react-stripe-elements';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
-import { getStripeKey } from 'helpers/paymentIntegrations/stripeCheckout';
+ import { getStripeKey, stripeAccountForContributionType } from 'helpers/paymentIntegrations/stripeCheckout';
 import type { ContributionType, OtherAmounts, SelectedAmounts } from 'helpers/contributions';
 import { getAmount } from 'helpers/contributions';
 import { isInStripePaymentRequestAllowedCountries } from 'helpers/internationalisation/country';
@@ -43,11 +43,11 @@ class StripePaymentRequestButtonContainer extends React.Component<PropTypes, voi
     const showStripePaymentRequestButton = isInStripePaymentRequestAllowedCountries(this.props.country);
 
     if (showStripePaymentRequestButton && this.props.stripeHasLoaded) {
-      const key = getStripeKey('ONE_OFF', this.props.country, this.props.isTestUser);
+      const key = getStripeKey(stripeAccountForContributionType[this.props.contributionType], this.props.country, this.props.isTestUser);
       const amount = getAmount(this.props.selectedAmounts, this.props.otherAmounts, this.props.contributionType);
 
       return (
-        <div className={hiddenIf(this.props.contributionType !== 'ONE_OFF', 'stripe-payment-request-button')}>
+        <div className="stripe-payment-request-button" amount={amount}>
           <StripeProvider apiKey={key}>
             <Elements>
               <StripePaymentRequestButton

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
@@ -48,15 +48,25 @@ class StripePaymentRequestButtonContainer extends React.Component<PropTypes, voi
 
       return (
         <div className="stripe-payment-request-button">
-          <StripeProvider apiKey={this.props.contributionType === 'ONE_OFF' ? singleKey : recurringKey}>
-            <Elements>
-              <StripePaymentRequestButton
-                amount={amount}
-              />
-            </Elements>
-          </StripeProvider>
+          {
+            this.props.contributionType === 'ONE_OFF' ?
+              <StripeProvider apiKey={singleKey}>
+                <Elements>
+                  <StripePaymentRequestButton
+                    amount={amount}
+                  />
+                </Elements>
+              </StripeProvider>
+            :
+              <StripeProvider apiKey={recurringKey}>
+                <Elements>
+                  <StripePaymentRequestButton
+                    amount={amount}
+                  />
+                </Elements>
+              </StripeProvider>
+          }
         </div>
-
       );
     }
     return null;

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
@@ -48,24 +48,13 @@ class StripePaymentRequestButtonContainer extends React.Component<PropTypes, voi
 
       return (
         <div className="stripe-payment-request-button">
-          {
-            this.props.contributionType === 'ONE_OFF' ?
-              <StripeProvider apiKey={singleKey}>
-                <Elements>
-                  <StripePaymentRequestButton
-                    amount={amount}
-                  />
-                </Elements>
-              </StripeProvider>
-            :
-              <StripeProvider apiKey={recurringKey}>
-                <Elements>
-                  <StripePaymentRequestButton
-                    amount={amount}
-                  />
-                </Elements>
-              </StripeProvider>
-          }
+          <StripeProvider apiKey={this.props.contributionType === 'ONE_OFF' ? singleKey : recurringKey}>
+            <Elements>
+              <StripePaymentRequestButton
+                amount={amount}
+              />
+            </Elements>
+          </StripeProvider>
         </div>
 
       );

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
@@ -12,7 +12,6 @@ import type { ContributionType, OtherAmounts, SelectedAmounts } from 'helpers/co
 import { getAmount } from 'helpers/contributions';
 import { isInStripePaymentRequestAllowedCountries } from 'helpers/internationalisation/country';
 import type { IsoCountry } from 'helpers/internationalisation/country';
-import { hiddenIf } from 'helpers/utilities';
 import { setupStripe } from 'helpers/stripe';
 import StripePaymentRequestButton from './StripePaymentRequestButton';
 
@@ -43,7 +42,8 @@ class StripePaymentRequestButtonContainer extends React.Component<PropTypes, voi
     const showStripePaymentRequestButton = isInStripePaymentRequestAllowedCountries(this.props.country);
 
     if (showStripePaymentRequestButton && this.props.stripeHasLoaded) {
-      const key = getStripeKey(stripeAccountForContributionType[this.props.contributionType], this.props.country, this.props.isTestUser);
+      const stripeAccount = stripeAccountForContributionType[this.props.contributionType];
+      const key = getStripeKey(stripeAccount, this.props.country, this.props.isTestUser);
       const amount = getAmount(this.props.selectedAmounts, this.props.otherAmounts, this.props.contributionType);
 
       return (

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -48,7 +48,7 @@ import type { PaymentMethod } from 'helpers/paymentMethods';
 import { DirectDebit, Stripe } from 'helpers/paymentMethods';
 import type { RecentlySignedInExistingPaymentMethod } from 'helpers/existingPaymentMethods/existingPaymentMethods';
 import { ExistingCard, ExistingDirectDebit } from 'helpers/paymentMethods';
-import { getStripeKey, stripeAccountForContributionType } from 'helpers/paymentIntegrations/stripeCheckout';
+import { getStripeKey, stripeAccountForContributionType, type StripeAccount } from 'helpers/paymentIntegrations/stripeCheckout';
 
 export type Action =
   | { type: 'UPDATE_CONTRIBUTION_TYPE', contributionType: ContributionType }
@@ -72,10 +72,9 @@ export type Action =
   | { type: 'SET_GUEST_ACCOUNT_CREATION_TOKEN', guestAccountCreationToken: string }
   | { type: 'SET_FORM_IS_SUBMITTABLE', formIsSubmittable: boolean }
   | { type: 'SET_THANK_YOU_PAGE_STAGE', thankYouPageStage: ThankYouPageStage }
-  | { type: 'SET_STRIPE_PAYMENT_REQUEST_OBJECT_ONE_OFF', stripePaymentRequestObject: Object }
-  | { type: 'SET_STRIPE_PAYMENT_REQUEST_OBJECT_REGULAR', stripePaymentRequestObject: Object }
-  | { type: 'SET_PAYMENT_REQUEST_BUTTON_PAYMENT_METHOD', paymentMethod: StripePaymentRequestButtonMethod }
-  | { type: 'SET_STRIPE_PAYMENT_REQUEST_BUTTON_CLICKED' }
+  | { type: 'SET_STRIPE_PAYMENT_REQUEST_OBJECT', stripePaymentRequestObject: Object, stripeAccount: StripeAccount }
+  | { type: 'SET_PAYMENT_REQUEST_BUTTON_PAYMENT_METHOD', paymentMethod: StripePaymentRequestButtonMethod, stripeAccount: StripeAccount }
+  | { type: 'SET_STRIPE_PAYMENT_REQUEST_BUTTON_CLICKED', stripeAccount: StripeAccount }
   | { type: 'SET_STRIPE_V3_HAS_LOADED' }
   | { type: 'SET_CREATE_STRIPE_PAYMENT_METHOD', createStripePaymentMethod: (email: string) => void }
   | { type: 'SET_HANDLE_STRIPE_3DS', handleStripe3DS: (clientSecret: string) => Promise<Stripe3DSResult> }
@@ -129,17 +128,18 @@ const updateEmail = (email: string): ((Function) => void) =>
 const updatePassword = (password: string): Action => ({ type: 'UPDATE_PASSWORD', password });
 
 const setPaymentRequestButtonPaymentMethod =
-  (paymentMethod: 'none' | StripePaymentMethod): Action => ({ type: 'SET_PAYMENT_REQUEST_BUTTON_PAYMENT_METHOD', paymentMethod });
+  (paymentMethod: 'none' | StripePaymentMethod, stripeAccount: StripeAccount): Action =>
+    ({ type: 'SET_PAYMENT_REQUEST_BUTTON_PAYMENT_METHOD', paymentMethod, stripeAccount });
 
-const setStripePaymentRequestObjectOneOff =
-  (stripePaymentRequestObject: Object): Action => ({ type: 'SET_STRIPE_PAYMENT_REQUEST_OBJECT_ONE_OFF', stripePaymentRequestObject });
 
-const setStripePaymentRequestObjectRegular =
-  (stripePaymentRequestObject: Object): Action => ({ type: 'SET_STRIPE_PAYMENT_REQUEST_OBJECT_REGULAR', stripePaymentRequestObject });
+const setStripePaymentRequestObject =
+  (stripePaymentRequestObject: Object, stripeAccount: StripeAccount): Action =>
+    ({ type: 'SET_STRIPE_PAYMENT_REQUEST_OBJECT', stripePaymentRequestObject, stripeAccount });
 
 const setStripeV3HasLoaded = (): Action => ({ type: 'SET_STRIPE_V3_HAS_LOADED' });
 
-const setStripePaymentRequestButtonClicked = (): Action => ({ type: 'SET_STRIPE_PAYMENT_REQUEST_BUTTON_CLICKED' });
+const setStripePaymentRequestButtonClicked = (stripeAccount: StripeAccount): Action =>
+  ({ type: 'SET_STRIPE_PAYMENT_REQUEST_BUTTON_CLICKED', stripeAccount });
 
 const updateUserFormData = (userFormData: UserFormData): ((Function) => void) =>
   (dispatch: Function): void => {
@@ -570,8 +570,7 @@ export {
   setFormIsValid,
   sendFormSubmitEventForPayPalRecurring,
   setPaymentRequestButtonPaymentMethod,
-  setStripePaymentRequestObjectOneOff,
-  setStripePaymentRequestObjectRegular,
+  setStripePaymentRequestObject,
   setStripePaymentRequestButtonClicked,
   setStripeV3HasLoaded,
   setTickerGoalReached,

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -537,16 +537,6 @@ const onThirdPartyPaymentAuthorised = (paymentAuthorisation: PaymentAuthorisatio
     );
   };
 
-const onStripePaymentRequestApiPaymentAuthorised =
-  (paymentAuthorisation: PaymentAuthorisation) =>
-    (dispatch: Function, getState: () => State): Promise<PaymentResult> => {
-      const state = getState();
-      return paymentAuthorisationHandlers.ONE_OFF.Stripe(
-        dispatch,
-        state,
-        paymentAuthorisation,
-      );
-    };
 
 export {
   updateContributionTypeAndPaymentMethod,
@@ -577,7 +567,6 @@ export {
   sendFormSubmitEventForPayPalRecurring,
   setPaymentRequestButtonPaymentMethod,
   setStripePaymentRequestObject,
-  onStripePaymentRequestApiPaymentAuthorised,
   setStripePaymentRequestButtonClicked,
   setStripeV3HasLoaded,
   setTickerGoalReached,

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -425,9 +425,7 @@ function recurringPaymentAuthorisationHandler(
     state.common.abParticipations,
     state.page.csrf,
     (token: string) => dispatch(setGuestAccountCreationToken(token)),
-    (thankYouPageStage: ThankYouPageStage) => {
-      dispatch(setThankYouPageStage(thankYouPageStage))
-    },
+    (thankYouPageStage: ThankYouPageStage) => dispatch(setThankYouPageStage(thankYouPageStage)),
   )));
 }
 

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -341,8 +341,6 @@ const onPaymentResult = (paymentResult: Promise<PaymentResult>) =>
       switch (result.paymentStatus) {
         case 'success':
           trackConversion(state.common.abParticipations, '/contribute/thankyou');
-          console.log('onPaymentResult', result);
-
           dispatch(paymentSuccess());
           break;
 
@@ -428,7 +426,6 @@ function recurringPaymentAuthorisationHandler(
     state.page.csrf,
     (token: string) => dispatch(setGuestAccountCreationToken(token)),
     (thankYouPageStage: ThankYouPageStage) => {
-      console.log('recurringPaymentAuthorisationHandler', thankYouPageStage);
       dispatch(setThankYouPageStage(thankYouPageStage))
     },
   )));

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -72,7 +72,8 @@ export type Action =
   | { type: 'SET_GUEST_ACCOUNT_CREATION_TOKEN', guestAccountCreationToken: string }
   | { type: 'SET_FORM_IS_SUBMITTABLE', formIsSubmittable: boolean }
   | { type: 'SET_THANK_YOU_PAGE_STAGE', thankYouPageStage: ThankYouPageStage }
-  | { type: 'SET_STRIPE_PAYMENT_REQUEST_OBJECT', stripePaymentRequestObject: Object }
+  | { type: 'SET_STRIPE_PAYMENT_REQUEST_OBJECT_ONE_OFF', stripePaymentRequestObject: Object }
+  | { type: 'SET_STRIPE_PAYMENT_REQUEST_OBJECT_REGULAR', stripePaymentRequestObject: Object }
   | { type: 'SET_PAYMENT_REQUEST_BUTTON_PAYMENT_METHOD', paymentMethod: StripePaymentRequestButtonMethod }
   | { type: 'SET_STRIPE_PAYMENT_REQUEST_BUTTON_CLICKED' }
   | { type: 'SET_STRIPE_V3_HAS_LOADED' }
@@ -130,8 +131,11 @@ const updatePassword = (password: string): Action => ({ type: 'UPDATE_PASSWORD',
 const setPaymentRequestButtonPaymentMethod =
   (paymentMethod: 'none' | StripePaymentMethod): Action => ({ type: 'SET_PAYMENT_REQUEST_BUTTON_PAYMENT_METHOD', paymentMethod });
 
-const setStripePaymentRequestObject =
-  (stripePaymentRequestObject: Object): Action => ({ type: 'SET_STRIPE_PAYMENT_REQUEST_OBJECT', stripePaymentRequestObject });
+const setStripePaymentRequestObjectOneOff =
+  (stripePaymentRequestObject: Object): Action => ({ type: 'SET_STRIPE_PAYMENT_REQUEST_OBJECT_ONE_OFF', stripePaymentRequestObject });
+
+const setStripePaymentRequestObjectRegular =
+  (stripePaymentRequestObject: Object): Action => ({ type: 'SET_STRIPE_PAYMENT_REQUEST_OBJECT_REGULAR', stripePaymentRequestObject });
 
 const setStripeV3HasLoaded = (): Action => ({ type: 'SET_STRIPE_V3_HAS_LOADED' });
 
@@ -566,7 +570,8 @@ export {
   setFormIsValid,
   sendFormSubmitEventForPayPalRecurring,
   setPaymentRequestButtonPaymentMethod,
-  setStripePaymentRequestObject,
+  setStripePaymentRequestObjectOneOff,
+  setStripePaymentRequestObjectRegular,
   setStripePaymentRequestButtonClicked,
   setStripeV3HasLoaded,
   setTickerGoalReached,

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -341,6 +341,8 @@ const onPaymentResult = (paymentResult: Promise<PaymentResult>) =>
       switch (result.paymentStatus) {
         case 'success':
           trackConversion(state.common.abParticipations, '/contribute/thankyou');
+          console.log('onPaymentResult', result);
+
           dispatch(paymentSuccess());
           break;
 
@@ -425,7 +427,10 @@ function recurringPaymentAuthorisationHandler(
     state.common.abParticipations,
     state.page.csrf,
     (token: string) => dispatch(setGuestAccountCreationToken(token)),
-    (thankYouPageStage: ThankYouPageStage) => dispatch(setThankYouPageStage(thankYouPageStage)),
+    (thankYouPageStage: ThankYouPageStage) => {
+      console.log('recurringPaymentAuthorisationHandler', thankYouPageStage);
+      dispatch(setThankYouPageStage(thankYouPageStage))
+    },
   )));
 }
 

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
@@ -56,7 +56,10 @@ type SetPasswordData = {
 
 type StripePaymentRequestButtonData = {
   paymentMethod: 'none' | StripePaymentMethod | null,
-  stripePaymentRequestObject: Object | null,
+  stripePaymentRequestObject: {
+    ONE_OFF: Object | null,
+    REGULAR: Object | null,
+  },
   stripePaymentRequestButtonClicked: boolean,
 }
 
@@ -148,7 +151,10 @@ function createFormReducer() {
     stripeV3HasLoaded: false,
     stripePaymentRequestButtonData: {
       paymentMethod: null,
-      stripePaymentRequestObject: null,
+      stripePaymentRequestObject: {
+        ONE_OFF: null,
+        REGULAR: null,
+      },
       stripePaymentRequestButtonClicked: false,
     },
     stripeCardFormData: {
@@ -271,12 +277,27 @@ function createFormReducer() {
           },
         };
 
-      case 'SET_STRIPE_PAYMENT_REQUEST_OBJECT':
+      case 'SET_STRIPE_PAYMENT_REQUEST_OBJECT_ONE_OFF':
         return {
           ...state,
           stripePaymentRequestButtonData: {
             ...state.stripePaymentRequestButtonData,
-            stripePaymentRequestObject: action.stripePaymentRequestObject,
+            stripePaymentRequestObject: {
+              ...state.stripePaymentRequestButtonData.stripePaymentRequestObject,
+              ONE_OFF: action.stripePaymentRequestObject,
+            },
+          },
+        };
+
+      case 'SET_STRIPE_PAYMENT_REQUEST_OBJECT_REGULAR':
+        return {
+          ...state,
+          stripePaymentRequestButtonData: {
+            ...state.stripePaymentRequestButtonData,
+            stripePaymentRequestObject: {
+              ...state.stripePaymentRequestButtonData.stripePaymentRequestObject,
+              REGULAR: action.stripePaymentRequestObject,
+            },
           },
         };
 

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
@@ -54,7 +54,7 @@ type SetPasswordData = {
   passwordError: boolean,
 }
 
-type StripePaymentRequestButtonData = {
+export type StripePaymentRequestButtonData = {
   paymentMethod: 'none' | StripePaymentMethod | null,
   stripePaymentRequestObject: Object | null,
   stripePaymentRequestButtonClicked: boolean,

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
@@ -56,10 +56,7 @@ type SetPasswordData = {
 
 type StripePaymentRequestButtonData = {
   paymentMethod: 'none' | StripePaymentMethod | null,
-  stripePaymentRequestObject: {
-    ONE_OFF: Object | null,
-    REGULAR: Object | null,
-  },
+  stripePaymentRequestObject: Object | null,
   stripePaymentRequestButtonClicked: boolean,
 }
 
@@ -86,7 +83,10 @@ type FormState = {
   isWaiting: boolean,
   formData: FormData,
   stripeV3HasLoaded: boolean,
-  stripePaymentRequestButtonData: StripePaymentRequestButtonData,
+  stripePaymentRequestButtonData: {
+    ONE_OFF: StripePaymentRequestButtonData,
+    REGULAR: StripePaymentRequestButtonData,
+  },
   stripeCardFormData: StripeCardFormData,
   setPasswordData: SetPasswordData,
   paymentComplete: boolean,
@@ -150,12 +150,16 @@ function createFormReducer() {
     },
     stripeV3HasLoaded: false,
     stripePaymentRequestButtonData: {
-      paymentMethod: null,
-      stripePaymentRequestObject: {
-        ONE_OFF: null,
-        REGULAR: null,
+      ONE_OFF: {
+        paymentMethod: null,
+        stripePaymentRequestObject: null,
+        stripePaymentRequestButtonClicked: false,
       },
-      stripePaymentRequestButtonClicked: false,
+      REGULAR: {
+        paymentMethod: null,
+        stripePaymentRequestObject: null,
+        stripePaymentRequestButtonClicked: false,
+      },
     },
     stripeCardFormData: {
       formComplete: false,
@@ -273,30 +277,21 @@ function createFormReducer() {
           ...state,
           stripePaymentRequestButtonData: {
             ...state.stripePaymentRequestButtonData,
-            paymentMethod: action.paymentMethod,
-          },
-        };
-
-      case 'SET_STRIPE_PAYMENT_REQUEST_OBJECT_ONE_OFF':
-        return {
-          ...state,
-          stripePaymentRequestButtonData: {
-            ...state.stripePaymentRequestButtonData,
-            stripePaymentRequestObject: {
-              ...state.stripePaymentRequestButtonData.stripePaymentRequestObject,
-              ONE_OFF: action.stripePaymentRequestObject,
+            [action.stripeAccount]: {
+              ...state.stripePaymentRequestButtonData[action.stripeAccount],
+              paymentMethod: action.paymentMethod,
             },
           },
         };
 
-      case 'SET_STRIPE_PAYMENT_REQUEST_OBJECT_REGULAR':
+      case 'SET_STRIPE_PAYMENT_REQUEST_OBJECT':
         return {
           ...state,
           stripePaymentRequestButtonData: {
             ...state.stripePaymentRequestButtonData,
-            stripePaymentRequestObject: {
-              ...state.stripePaymentRequestButtonData.stripePaymentRequestObject,
-              REGULAR: action.stripePaymentRequestObject,
+            [action.stripeAccount]: {
+              ...state.stripePaymentRequestButtonData[action.stripeAccount],
+              stripePaymentRequestObject: action.stripePaymentRequestObject,
             },
           },
         };
@@ -306,7 +301,10 @@ function createFormReducer() {
           ...state,
           stripePaymentRequestButtonData: {
             ...state.stripePaymentRequestButtonData,
-            stripePaymentRequestButtonClicked: true,
+            [action.stripeAccount]: {
+              ...state.stripePaymentRequestButtonData[action.stripeAccount],
+              stripePaymentRequestButtonClicked: true,
+            },
           },
         };
 

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -74,7 +74,7 @@
     "react-redux": "^5.1.1",
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",
-    "react-stripe-elements": "^4.0.1",
+    "react-stripe-elements": "^5.0.1",
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0",
     "seedrandom": "^2.4.3",

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -11350,6 +11350,15 @@ prompts@^0.1.9:
     kleur "^2.0.1"
     sisteransi "^0.1.1"
 
+prop-types@15.7.2:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
+  integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.8.1"
+
 prop-types@^15.5.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.8, prop-types@^15.5.9, prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
@@ -11692,6 +11701,11 @@ react-is@^16.3.2, react-is@^16.6.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.3.tgz#d2d7462fcfcbe6ec0da56ad69047e47e56e7eac0"
   integrity sha512-u7FDWtthB4rWibG/+mFbVd5FvdI20yde86qKGx4lVUTWmPlSWQ4QxbBIrrs+HnXGbxOUlUzTAP/VDmvCwaP2yA==
 
+react-is@^16.8.1:
+  version "16.10.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.10.2.tgz#984120fd4d16800e9a738208ab1fba422d23b5ab"
+  integrity sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA==
+
 react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
@@ -11763,12 +11777,12 @@ react-split-pane@^0.1.84:
     react-lifecycles-compat "^3.0.4"
     react-style-proptype "^3.0.0"
 
-react-stripe-elements@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/react-stripe-elements/-/react-stripe-elements-4.0.1.tgz#89b52c909a80f17afc7907313c3b3c3f21fa125d"
-  integrity sha512-S+O2+hphs6ASz29l85nj6mpS7YWTa3NMwZTonIMt4+8xrfS/jET+0Xd3cNdJoGkHiCtLEId6UimqivONK+liOw==
+react-stripe-elements@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/react-stripe-elements/-/react-stripe-elements-5.0.1.tgz#9030eb84ca06ecda4009769d09937e1cd65d2ec7"
+  integrity sha512-4fKjN1jXIo1T19lp7TE/Zwad6wolNVRzzQBxwounm6pDcJPdNeYVTr3TS4D1blVo9StGdf1Q8WbVa1nx1E7Yng==
   dependencies:
-    prop-types "^15.5.10"
+    prop-types "15.7.2"
 
 react-style-proptype@^3.0.0:
   version "3.2.2"


### PR DESCRIPTION
Enable the Payment Request button work for recurring contributions checkout page, and also confirm the payment frequency in its title.

The payment method in Zuora looks identical to if the card was tokenised via Stripe Checkout so there should be no downstream issue for the customer, other than when the button does eventually be used for Apple Pay, that won't be available in the manage-my-account portal.

I have made 3 trade-off decisions as part of this change:

1) I have added the requirement that we request the contributor's name via the Payment Request button. This means if they don't have a name set up in their system then the button won't show. I'm 99% sure this should have a negligible impact on the Apple Pay button showing up when single contribution is the default.
2) As browsers just store the name as 1 field, I have assumed the contributor's first name is the first word in that field (when split by `' '`) and the last name is all the other words.
3) This change does **not** release the button on the recurring tabs as an A/B test.

## Why are you doing this?
Apple Pay leverages the Payment Request button, so this is a stepping stone to enable Apple Pay for recurring too.

[**Trello Card**](https://trello.com/c/0f3yqsoz)

## To do
- [ ] Decide how State will work in the US/CA

## Screenshots

![Screen Shot 2019-10-10 at 15 21 39](https://user-images.githubusercontent.com/1515970/66577652-adba2480-eb71-11e9-8557-25d3259dd910.png)

![Screen Shot 2019-10-11 at 17 17 47](https://user-images.githubusercontent.com/1515970/66667518-1aedb880-ec4b-11e9-9368-a359ae07b4d0.png)

![Screen Shot 2019-10-11 at 17 15 21](https://user-images.githubusercontent.com/1515970/66667457-f4c81880-ec4a-11e9-899d-73e24096ad0c.png)

![Screen Shot 2019-10-11 at 17 17 58](https://user-images.githubusercontent.com/1515970/66667527-1e813f80-ec4b-11e9-80cb-d46c169f2098.png)
