### PR TITLE
Switch to enable campaign for all contributions landing page views

### DIFF
--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -100,5 +100,6 @@ window.guardian.paymentApiPayPalEndpoint = "@paymentApiPayPalEndpoint";
   }
 
   window.guardian.stripeElements = @settings.switches.experiments.get("stripeElements").exists(_.isOn)
+  window.guardian.forceCampaign = @settings.switches.experiments.get("forceCampaign").exists(_.isOn)
   </script>
 }

--- a/support-frontend/assets/helpers/campaigns.jsx
+++ b/support-frontend/assets/helpers/campaigns.jsx
@@ -99,7 +99,9 @@ export type CampaignName = $Keys<typeof campaigns>
 
 export function getCampaignName(): ?CampaignName {
   if (currentCampaignName) {
-    return window.location.pathname.endsWith(`/${currentCampaignName}`) ? currentCampaignName : undefined;
+    return window.guardian.forceCampaign || window.location.pathname.endsWith(`/${currentCampaignName}`) ?
+      currentCampaignName :
+      undefined;
   }
   return undefined;
 }


### PR DESCRIPTION
## Why are you doing this?
We have a requirement to display the campaign landing page for all users for the duration of the campaign. This is different to previous campaigns, where we've had it behind a special url.

This PR is a proposal for enabling this from a switch, which will be in the admin console.
This means we can easily turn it on/off.
I think this is simpler than using redirects