### PR TITLE
Highlight the 6 for 6 offer on the subscriptions landing page

### DIFF
--- a/support-frontend/assets/helpers/campaigns.jsx
+++ b/support-frontend/assets/helpers/campaigns.jsx
@@ -65,7 +65,7 @@ export const campaigns: Campaigns = {
           our <a href="https://www.theguardian.com/help/privacy-policy">Privacy Policy</a>.
         </p>
         {isUK ? (
-          <span className={`component-terms-privacy__divider`}>
+          <span className="component-terms-privacy__divider">
             <p>
               If you would like to make a larger contribution, we have a Patron programme with three levels of
               support, which brings you closer to our work. For more information, please visit
@@ -73,7 +73,7 @@ export const campaigns: Campaigns = {
             </p>
           </span>
         ) : (
-          <span className={`component-terms-privacy__divider`}>
+          <span className="component-terms-privacy__divider">
             <p>
               We also accept larger contributions to support The Guardian’s reporting from companies, foundations and
               individuals. Please  <a href={`mailto:${contactEmail || ''}`}>contact us</a>.

--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
@@ -25,6 +25,10 @@ import {
   getSaleCopy,
 } from 'helpers/flashSale';
 import { Monthly } from 'helpers/billingPeriods';
+import {
+  fromCountryGroupId,
+  glyph,
+} from 'helpers/internationalisation/currency';
 
 // types
 
@@ -74,6 +78,15 @@ const getPrice = (product: SubscriptionProduct, alternativeText: string) => {
   return alternativeText;
 };
 
+function getGuardianWeeklyOfferCopy() {
+  const copy = getSaleCopy(GuardianWeekly, countryGroupId).bundle.subHeading;
+  if (copy !== '') {
+    return copy;
+  }
+  const currency = glyph(fromCountryGroupId(countryGroupId) || 'GBP');
+  return `6 issues for ${currency}6`;
+}
+
 const chooseImage = images =>
   (countryGroupId === 'GBPCountries' ? images[0] : images[1]);
 
@@ -92,10 +105,10 @@ const digital: ProductCopy = {
 };
 
 const guardianWeekly: ProductCopy = {
-  title: 'Guardian Weekly',
+  title: 'The Guardian Weekly',
   subtitle: getPrice(GuardianWeekly, ''),
   description: 'A weekly, global magazine from The Guardian, with delivery worldwide',
-  offer: getSaleCopy(GuardianWeekly, countryGroupId).bundle.subHeading,
+  offer: getGuardianWeeklyOfferCopy(),
   buttons: [{
     ctaButtonText: 'Find out more',
     link: subsLinks.GuardianWeekly,


### PR DESCRIPTION
## Why are you doing this?

To show the 6 for 6 offer on the subscribe page and also to change the name for Guardian Weekly to 'The Guardian Weekly'


[**Trello Card**](https://trello.com/c/XVjlH3iL/2638-add-introductory-offer-to-weekly-on-subs-showcase-page)

## Screenshots
### Before:
<img width="1160" alt="Screenshot 2019-10-14 at 12 13 35" src="https://user-images.githubusercontent.com/181371/66747351-3986c600-ee7c-11e9-97d9-bbcf965b40b7.png">
### After:
<img width="1160" alt="Screenshot 2019-10-14 at 12 13 43" src="https://user-images.githubusercontent.com/181371/66747352-3a1f5c80-ee7c-11e9-836a-2ac5964dbb33.png">
