### PR TITLE
Add Optimize test into native AB test participations

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -98,5 +98,5 @@ export const tests: Tests = {
     isActive: true,
     independent: true,
     seed: 9,
-  }
+  },
 };

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -78,4 +78,25 @@ export const tests: Tests = {
     seed: 7,
     canRun: () => !!getCampaignName(),
   },
+
+  nativeVariantAllocationTest: {
+    type: 'OTHER',
+    variants: [
+      {
+        id: '0',
+      },
+      {
+        id: '1',
+      },
+    ],
+    audiences: {
+      ALL: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: true,
+    independent: true,
+    seed: 9,
+  }
 };

--- a/support-frontend/assets/helpers/campaigns.jsx
+++ b/support-frontend/assets/helpers/campaigns.jsx
@@ -65,7 +65,7 @@ export const campaigns: Campaigns = {
           our <a href="https://www.theguardian.com/help/privacy-policy">Privacy Policy</a>.
         </p>
         {isUK ? (
-          <span className={`component-terms-privacy__divider`}>
+          <span className="component-terms-privacy__divider">
             <p>
               If you would like to make a larger contribution, we have a Patron programme with three levels of
               support, which brings you closer to our work. For more information, please visit
@@ -73,7 +73,7 @@ export const campaigns: Campaigns = {
             </p>
           </span>
         ) : (
-          <span className={`component-terms-privacy__divider`}>
+          <span className="component-terms-privacy__divider">
             <p>
               We also accept larger contributions to support The Guardian’s reporting from companies, foundations and
               individuals. Please  <a href={`mailto:${contactEmail || ''}`}>contact us</a>.

--- a/support-frontend/assets/helpers/page/page.js
+++ b/support-frontend/assets/helpers/page/page.js
@@ -39,16 +39,16 @@ import {
   type CountryGroupId,
   detect as detectCountryGroup,
 } from 'helpers/internationalisation/countryGroup';
-import type { OptimizeExperiment } from 'helpers/optimize/optimize';
-import {
-  addOptimizeExperiments,
-  readExperimentsFromSession,
-} from 'helpers/optimize/optimize';
+// import type { OptimizeExperiment } from 'helpers/optimize/optimize'; TODO: Maybe no longer needed
+// import {
+//   addOptimizeExperiments,
+//   readExperimentsFromSession,
+// } from 'helpers/optimize/optimize';
 import storeReferrer from 'helpers/tracking/awin';
-import { setExperimentVariant } from 'helpers/page/commonActions';
+// import { setExperimentVariant } from 'helpers/page/commonActions'; TODO: Maybe no longer needed
 import {
   trackAbTests,
-  trackNewOptimizeExperiment,
+  // trackNewOptimizeExperiment, TODO: Maybe no longer needed
 } from 'helpers/tracking/ophan';
 import { getTrackingConsent } from '../tracking/thirdPartyTrackingConsent';
 import { getSettings } from 'helpers/globals';
@@ -89,7 +89,7 @@ function buildInitialState(
   settings: Settings,
 ): CommonState {
   const acquisition = getReferrerAcquisitionData();
-  const optimizeExperiments = readExperimentsFromSession();
+  // const optimizeExperiments = readExperimentsFromSession(); TODO: Maybe no longer needed
   const excludedParameters = ['REFPVID', 'INTCMP', 'acquisitionData'];
   const otherQueryParams = getAllQueryParamsWithExclusions(excludedParameters);
   const internationalisation = {
@@ -111,7 +111,7 @@ function buildInitialState(
     internationalisation,
     abParticipations,
     settings: { ...settings, amounts: amountsWithParticipationOverrides },
-    optimizeExperiments,
+    optimizeExperiments: [], // TODO: Maybe no longer needed
     trackingConsent,
   };
 
@@ -123,7 +123,8 @@ function statelessInit() {
   const countryGroupId: CountryGroupId = detectCountryGroup();
   const participations: Participations = abTest.init(country, countryGroupId, window.guardian.settings);
   analyticsInitialisation(participations);
-  addOptimizeExperiments((exp: OptimizeExperiment) => trackNewOptimizeExperiment(exp, participations));
+  // TODO: Maybe no longer needed
+  // addOptimizeExperiments((exp: OptimizeExperiment) => trackNewOptimizeExperiment(exp, participations));
 }
 
 // Enables redux devtools extension and optional redux-thunk.
@@ -170,10 +171,10 @@ function init<S, A>(
       storeEnhancer(thunk),
     );
 
-    addOptimizeExperiments((exp: OptimizeExperiment) => {
-      trackNewOptimizeExperiment(exp, participations);
-      store.dispatch(setExperimentVariant(exp));
-    });
+    // addOptimizeExperiments((exp: OptimizeExperiment) => { TODO: Maybe no longer needed
+    //   trackNewOptimizeExperiment(exp, participations);
+    //   store.dispatch(setExperimentVariant(exp));
+    // });
 
     return store;
   } catch (err) {

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -68,10 +68,26 @@ const CountrySwitcherHeader = headerWithCountrySwitcherContainer({
   ],
 });
 
+const trackOptimizeExperiment = (variant: string) => {
+  const dailyEditionsExperimentId = 'eA8AlzuTTJqe8lm2DXfe1w';
+  gaEvent(
+    {
+      category: 'ab-test-tracking',
+      action: dailyEditionsExperimentId,
+      label: variant,
+    },
+    { // these map to dataLayer variables in GTM
+      experimentId: dailyEditionsExperimentId,
+      experimentVariant: variant,
+    },
+  );
+};
+
+
 const mapStateToProps = (state) => {
   const { nativeVariantAllocationTest } = state.common.abParticipations;
 
-  const dailyEditionsVariant = nativeVariantAllocationTest === "1"
+  const dailyEditionsVariant = nativeVariantAllocationTest === '1'
     && !isPostDeployUser();
 
   trackOptimizeExperiment(nativeVariantAllocationTest);
@@ -79,20 +95,6 @@ const mapStateToProps = (state) => {
   return {
     dailyEditionsVariant,
   };
-};
-
-const trackOptimizeExperiment = (variant: string) => {
-  const dailyEditionsExperimentId = 'eA8AlzuTTJqe8lm2DXfe1w';
-  gaEvent(
-    {
-    category: 'ab-test-tracking',
-    action: dailyEditionsExperimentId,
-    label: variant
-  },
-    { //these map to dataLayer variables in GTM
-      experimentId: dailyEditionsExperimentId,
-      experimentVariant: variant
-    });
 };
 
 type Props = {


### PR DESCRIPTION
## Why are you doing this?

To test using the native AB test framework to allocate users to variants in Optimize tests.

**What I've done:**
- Created a test in Optimize
- Added it into the native ab test list in `abTestDefinitions.js` so the user will get automatically allocated to a variant by the framework
- Added some code to the digi pack landing page to fire a GA event with the `experimentId` and `experimentVariant` datalayer variables set so that the user is assigned to the correct cohort in GA/Optimize

There is quite a bit of scope to improve on this implementation but I want to test that it works before refining the approach any further

[**Trello Card**](https://trello.com/c/PsimymUQ/2674-optmize-rework)

