### PR TITLE
Ide settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -58,6 +58,10 @@ lazy val commonDependencies = Seq(
 )
 
 lazy val root = (project in file("."))
+  .settings(
+    name := "support-frontend",
+    moduleName := "support-frontend"
+  )
   .aggregate(
     `support-frontend`,
     `support-workers`,

--- a/build.sbt
+++ b/build.sbt
@@ -59,8 +59,8 @@ lazy val commonDependencies = Seq(
 
 lazy val root = (project in file("."))
   .settings(
-    name := "support-frontend",
-    moduleName := "support-frontend"
+    name := "support-frontend-root",
+    moduleName := "support-frontend-root"
   )
   .aggregate(
     `support-frontend`,

--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -95,4 +95,6 @@ javaOptions in Universal ++= Seq(
 
 javaOptions in Test += "-Dconfig.file=test/selenium/conf/selenium-test.conf"
 
+unmanagedSourceDirectories in Compile += (baseDirectory.value / "assets")
+
 addCommandAlias("devrun", "run 9210") // Chosen to not clash with other Guardian projects - we can't all use the Play default of 9000!


### PR DESCRIPTION
## Why are you doing this?

<!--
Every time we refresh the InteliJ build setup right now we need to mark the assets folder in `support-frontend` as a `Sources Directory` in InteliJ, which is annoying and time consuming, yet the only way to make editor code highlighting work. This is also achievable through SBT settings inside `build.sbt`.
-->

[**Trello Card**](https://trello.com/c/SUwE8N6a/2665-intelij-add-sbt-plugin-to-mark-assets-as-sources-root-automatically)

## Changes

* Added another SBT sources directory not directly managed by SBT under the sub-project `build.sbt` definition.
* Add a name and module name for the root project so it's easier to know what's what in InteliJ.