### PR TITLE
Correct the link to the promotion terms and conditions page

### DIFF
--- a/support-frontend/assets/helpers/externalLinks.js
+++ b/support-frontend/assets/helpers/externalLinks.js
@@ -266,7 +266,7 @@ const getProfileUrl = (path: string) => (returnUrl: ?string) => {
 const getSignoutUrl = getProfileUrl('signout');
 const getReauthenticateUrl = getProfileUrl('reauthenticate');
 
-const promotionTermsUrl = (promoCode: string) => `${subsUrl}/${promoCode}/terms`;
+const promotionTermsUrl = (promoCode: string) => `${subsUrl}/p/${promoCode}/terms`;
 
 // ----- Exports ----- //
 


### PR DESCRIPTION
## Why are you doing this?
The link to the promotion terms and conditions page on subscribe was wrong, this fixes it.
