### PR TITLE
AB test improvements

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtest.js
+++ b/support-frontend/assets/helpers/abTests/abtest.js
@@ -14,7 +14,6 @@ import { type AmountsRegions } from 'helpers/contributions';
 
 import { tests } from './abtestDefinitions';
 
-
 // ----- Types ----- //
 
 export type TestId = $Keys<typeof tests>;
@@ -66,6 +65,9 @@ export type Test = {|
   canRun?: () => boolean,
   independent: boolean,
   seed: number,
+  // An optional regex that will be tested against the path of the current page
+  // before activating this test eg. '/(uk|us|au|ca|nz)/subscribe$'
+  targetPage?: string,
 |};
 
 export type Tests = { [testId: string]: Test }
@@ -179,6 +181,12 @@ function assignUserToVariant(mvtId: number, test: Test): string {
   return test.variants[variantIndex].id;
 }
 
+function targetPageMatches(targetPage: ?string) {
+  if (!targetPage) { return true; }
+
+  return new URL(window.location).pathname.match(targetPage) != null;
+}
+
 function getParticipations(
   abTests: Tests,
   mvtId: number,
@@ -198,6 +206,10 @@ function getParticipations(
     }
 
     if (test.canRun && !test.canRun()) {
+      return;
+    }
+
+    if (!targetPageMatches(test.targetPage)) {
       return;
     }
 
@@ -246,4 +258,5 @@ export {
   init,
   getVariantsAsString,
   getCurrentParticipations,
+  targetPageMatches,
 };

--- a/support-frontend/assets/helpers/abTests/abtest.js
+++ b/support-frontend/assets/helpers/abTests/abtest.js
@@ -69,7 +69,7 @@ export type Test = {|
   // An optional regex that will be tested against the path of the current page
   // before activating this test eg. '/(uk|us|au|ca|nz)/subscribe$'
   targetPage?: string,
-  optimizeId?: string, // The id of the Optimize test which this test maps to
+  optimizeId?: string, // The id of the Optimize experiment which this test maps to
 |};
 
 export type Tests = { [testId: string]: Test }
@@ -201,7 +201,7 @@ function assignUserToVariant(
 function targetPageMatches(targetPage: ?string) {
   if (!targetPage) { return true; }
 
-  return new URL(window.location).pathname.match(targetPage) != null;
+  return window.location.pathname.match(targetPage) != null;
 }
 
 function getParticipations(

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -98,5 +98,6 @@ export const tests: Tests = {
     isActive: true,
     independent: true,
     seed: 9,
+    targetPage: '/(uk|us|au|ca|nz)/subscribe$',
   },
 };

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -79,14 +79,14 @@ export const tests: Tests = {
     canRun: () => !!getCampaignName(),
   },
 
-  nativeVariantAllocationTest: {
+  digitalPackProductPageTest: {
     type: 'OTHER',
     variants: [
       {
-        id: '0',
+        id: 'control',
       },
       {
-        id: '1',
+        id: 'newPage',
       },
     ],
     audiences: {
@@ -98,6 +98,7 @@ export const tests: Tests = {
     isActive: true,
     independent: true,
     seed: 9,
-    targetPage: '/(uk|us|au|ca|nz)/subscribe$',
+    targetPage: '/(uk|us|eu|au|ca|nz|int)/subscribe/digital$',
+    optimizeId: 'emQ5nZJCS5mZkhtwwqfx5Q',
   },
 };

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -32,7 +32,6 @@ import digitalSubscriptionLandingReducer from './digitalSubscriptionLandingReduc
 import { isPostDeployUser } from 'helpers/user/user';
 import { dpSale, flashSaleIsActive } from 'helpers/flashSale';
 import { DigitalPack } from 'helpers/subscriptions';
-import { gaEvent } from 'helpers/tracking/googleTagManager';
 
 // ----- Redux Store ----- //
 
@@ -68,29 +67,11 @@ const CountrySwitcherHeader = headerWithCountrySwitcherContainer({
   ],
 });
 
-const trackOptimizeExperiment = (variant: string) => {
-  const dailyEditionsExperimentId = 'eA8AlzuTTJqe8lm2DXfe1w';
-  gaEvent(
-    {
-      category: 'ab-test-tracking',
-      action: dailyEditionsExperimentId,
-      label: variant,
-    },
-    { // these map to dataLayer variables in GTM
-      experimentId: dailyEditionsExperimentId,
-      experimentVariant: variant,
-    },
-  );
-};
-
-
 const mapStateToProps = (state) => {
-  const { nativeVariantAllocationTest } = state.common.abParticipations;
+  const { digitalPackProductPageTest } = state.common.abParticipations;
 
-  const dailyEditionsVariant = nativeVariantAllocationTest === '1'
+  const dailyEditionsVariant = digitalPackProductPageTest === 'newPage'
     && !isPostDeployUser();
-
-  trackOptimizeExperiment(nativeVariantAllocationTest);
 
   return {
     dailyEditionsVariant,


### PR DESCRIPTION
## Why are you doing this?
This PR adds two new capabilities to the AB test framework
### Target page property
It is now possible to set an optional `targetPage` field on AB tests which specifies which page they should load on. This is to stop users who never visit a particular page from being included in the cohort for tests running on that page. This field should contain a regex containing a path which will be matched against the current page path when evaluating whether to run the test, eg. `'/(uk|us|eu|au|ca|nz|int)/subscribe/digital$'`. 

### Optimize Id 
It is now possible to add an `optimizeId` field to AB tests which allows the linking of a test set up through the native test framework to an experiment running in Optimize. When a test with an optimizeId is initialised we send a GA event to set the appropriate experiment and variant data for the user.

This PR also adds a test for the upcoming Digital Pack product page test

[**Trello Card**](https://trello.com/c/PsimymUQ/2674-optimize-rework)
