### PR TITLE
Ds daily editions product name, copy and packshot updates

### DIFF
--- a/support-frontend/assets/components/packshots/paper-and-digital-packshot.jsx
+++ b/support-frontend/assets/components/packshots/paper-and-digital-packshot.jsx
@@ -23,8 +23,8 @@ const PaperAndDigitalPackshot = () => (
       imgType="png"
     />
     <GridImage
-      gridId="subscriptionIphone"
-      srcSizes={[578, 527, 264]}
+      gridId="subscriptionDailyMobile"
+      srcSizes={[568, 484, 242]}
       sizes="(max-width: 740px) 100%,
             (max-width: 980px) 100px,
             125px"

--- a/support-frontend/assets/components/packshots/subscription-daily-packshot.jsx
+++ b/support-frontend/assets/components/packshots/subscription-daily-packshot.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import GridImage from 'components/gridImage/gridImage';
+
+const SubscriptionDailyPackshot = () => (
+  <div className="subscriptions-feature-packshot">
+    <GridImage
+      classModifiers={['']}
+      gridId="subscriptionDailyPackshot"
+      srcSizes={[1000]}
+      sizes="(max-width: 480px) 100px,
+            (max-width: 740px) 100%,
+            (max-width: 1067px) 150%,
+            800px"
+      imgType="png"
+    />
+  </div>
+);
+
+export default SubscriptionDailyPackshot;

--- a/support-frontend/assets/components/packshots/subscription-daily-packshot.jsx
+++ b/support-frontend/assets/components/packshots/subscription-daily-packshot.jsx
@@ -7,7 +7,7 @@ const SubscriptionDailyPackshot = () => (
     <GridImage
       classModifiers={['']}
       gridId="subscriptionDailyPackshot"
-      srcSizes={[1000]}
+      srcSizes={[1000, 500, 140]}
       sizes="(max-width: 480px) 100px,
             (max-width: 740px) 100%,
             (max-width: 1067px) 150%,

--- a/support-frontend/assets/components/subscriptionBundles/digitalPack.jsx
+++ b/support-frontend/assets/components/subscriptionBundles/digitalPack.jsx
@@ -49,7 +49,7 @@ function DigitalPack(props: {
   return (
     <SubscriptionBundle
       modifierClass="digital"
-      heading="Digital Pack"
+      heading="Digital Subscription"
       subheading={copy.subHeading}
       headingSize={3}
       benefits={{

--- a/support-frontend/assets/components/subscriptionBundles/paperDigital.jsx
+++ b/support-frontend/assets/components/subscriptionBundles/paperDigital.jsx
@@ -30,7 +30,7 @@ function getCopy() {
   }
   return {
     subHeading: `from ${displayPrice('PaperAndDigital', GBPCountries)}`,
-    description: 'All the benefits of a paper subscription, plus access to the digital pack',
+    description: 'All the benefits of a paper subscription, plus access to the digital subscription',
   };
 }
 

--- a/support-frontend/assets/helpers/theGrid.js
+++ b/support-frontend/assets/helpers/theGrid.js
@@ -95,6 +95,7 @@ export const imageCatalogue: {
   subscriptionPrintDigital: '476a8aadac1f3a971b9b1a9a023b04cb72c8f7ca/0_0_1366_1510',
   subscriptionGuardianWeeklyPackShot: '299d99cb5dc2d98607e9333d5e1e15c9f7d4860f/0_0_1552_921',
   subscriptionDailyPackshot: '241d0d58656ffcd708bba7d2a42ec7b8df9ee25e/0_0_1584_898',
+  subscriptionDailyMobile: '9b650a7dcc33e30d228ddec7bd27a0594b4ece41/0_0_568_1174',
   printShowcase: '311c4a9dd0e8030b734dd54b71fcd0d4cb2a303b/0_0_1486_750',
   digitalSubsDaily: '801bed1ff522395d46276c1882ae3dcac6309a39/0_0_1694_1000',
   digitalSubsDailyMob: '93c8d64b7be3bf455f2f6f57d679c2fdc7df6bf3/0_0_1100_1100',

--- a/support-frontend/assets/helpers/theGrid.js
+++ b/support-frontend/assets/helpers/theGrid.js
@@ -94,6 +94,7 @@ export const imageCatalogue: {
   subscriptionIphone: '8850945f0003d2a7204050644db446d827dead95/0_0_578_1096',
   subscriptionPrintDigital: '476a8aadac1f3a971b9b1a9a023b04cb72c8f7ca/0_0_1366_1510',
   subscriptionGuardianWeeklyPackShot: '299d99cb5dc2d98607e9333d5e1e15c9f7d4860f/0_0_1552_921',
+  subscriptionDailyPackshot: '241d0d58656ffcd708bba7d2a42ec7b8df9ee25e/0_0_1584_898',
   printShowcase: '311c4a9dd0e8030b734dd54b71fcd0d4cb2a303b/0_0_1486_750',
   digitalSubsDaily: '801bed1ff522395d46276c1882ae3dcac6309a39/0_0_1694_1000',
   digitalSubsDailyMob: '93c8d64b7be3bf455f2f6f57d679c2fdc7df6bf3/0_0_1100_1100',

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
@@ -172,8 +172,8 @@ function DigitalCheckoutForm(props: PropTypes) {
               altText=""
             />
             }
-          title="Digital Pack"
-          description="Premium App + iPad daily edition + Ad-free"
+          title="Digital Subscription"
+          description="Premium App + The Guardian Daily + Ad-free"
           productPrice={productPrice}
           billingPeriod={props.billingPeriod}
           product={props.product}

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
@@ -152,7 +152,7 @@ function DigitalCheckoutForm(props: PropTypes) {
   );
   const offerOnSelected = getAppliedPromoDescription(props.billingPeriod, productPrice);
   const helperSelected = getPriceDescription(productPrice, props.billingPeriod);
-  const priceSummary = `${offerOnSelected || 'Enjoy your digital pack free for 14 days, then'} ${helperSelected}.`;
+  const priceSummary = `${offerOnSelected || 'Enjoy your digital subscription free for 14 days, then'} ${helperSelected}.`;
   const submissionErrorHeading = props.submissionError === 'personal_details_incorrect' ? 'Sorry there was a problem' :
     'Sorry we could not process your payment';
 

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
@@ -165,7 +165,7 @@ function DigitalCheckoutForm(props: PropTypes) {
         <Summary
           image={
             <GridImage
-              gridId="checkoutPackshotDigitalPack"
+              gridId="subscriptionDailyPackshot"
               srcSizes={[1000, 500]}
               sizes="(max-width: 740px) 50vw, 500"
               imgType="png"

--- a/support-frontend/assets/pages/digital-subscription-checkout/thankYouContent.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/thankYouContent.jsx
@@ -36,7 +36,7 @@ function ThankYouContent(props: PropTypes) {
       />
       <HeroWrapper appearance="custom">
         <HeadingBlock>
-          Your Digital Pack subscription is now live
+          Your Digital Subscription is now live
         </HeadingBlock>
       </HeroWrapper>
       <Content>

--- a/support-frontend/assets/pages/digital-subscription-checkout/thankYouExisting.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/thankYouExisting.jsx
@@ -49,7 +49,7 @@ const content = (
         <HeroWrapper appearance="custom">
           <ThankYouContent countryGroupId={countryGroupId} />
           <HeadingBlock>
-            Your Digital Pack subscription is already live
+            Your Digital Subscription is already live
           </HeadingBlock>
         </HeroWrapper>
         <ThankYouExistingContent countryGroupId={countryGroupId} />

--- a/support-frontend/assets/pages/digital-subscription-checkout/thankYouPendingContent.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/thankYouPendingContent.jsx
@@ -24,13 +24,13 @@ function ThankYouPendingContent(props: {countryGroupId: CountryGroupId}) {
       />
       <HeroWrapper appearance="custom">
         <HeadingBlock>
-          Your Digital Pack subscription is being processed
+          Your Digital Subscription is being processed
         </HeadingBlock>
       </HeroWrapper>
       <Content>
         <Text>
           <LargeParagraph>
-            Thank you for subscribing to the Digital Pack.
+            Thank you for subscribing to the Digital Subscription.
             Your subscription is being processed and you will
             receive an email when your account is live.
           </LargeParagraph>

--- a/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
@@ -157,7 +157,7 @@ function gridPicture(cgId: CountryGroupId): GridPictureProps {
 function getCopy(product: SubscriptionProduct, country: CountryGroupId) {
   if (showUpgradeMessage()) {
     return {
-      heading: 'Digital Pack',
+      heading: 'Digital Subscription',
       subHeading: 'Upgrade your subscription to Paper+Digital now',
     };
   }
@@ -169,12 +169,13 @@ function getCopy(product: SubscriptionProduct, country: CountryGroupId) {
     };
   }
   return {
-    heading: 'Digital Pack subscriptions',
+    heading: 'Digital Subscriptions',
     subHeading: 'The premium Guardian experience, ad-free on all your devices',
   };
 }
 
 function CampaignHeader() {
+
   return (
     <div className="hope-is-power-hero--wrapper">
       <div className="hope-is-power-hero__marketing-message hope-is-power--centered">
@@ -214,7 +215,14 @@ function DigitalSubscriptionLandingHeader(props: PropTypes) {
         <div className="digital-subscription-landing-header__cta" />
       </LeftMarginSection>
       <HeroHanger>
-        <AnchorButton aria-label="See Subscription options for Digital Pack" onClick={sendTrackingEventsOnClick('options_cta_click', 'DigitalPack', null)} icon={<SvgChevron />} href="#subscribe">See Subscription options</AnchorButton>
+        <AnchorButton
+          aria-label="See Subscription options for Digital Subscription"
+          onClick={sendTrackingEventsOnClick('options_cta_click', 'DigitalPack', null)}
+          icon={<SvgChevron />}
+          href="#subscribe"
+        >
+            See Subscription options
+        </AnchorButton>
       </HeroHanger>
     </div>
   );

--- a/support-frontend/assets/pages/digital-subscription-landing/componentsB/promotionPopUp.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/componentsB/promotionPopUp.jsx
@@ -86,17 +86,17 @@ function Options(props: {
     <ul>
       <OptionItem
         thisOption="Saturday"
-        description="Get the Saturday paper, plus a Digital Pack subscription for just £11.26 extra per month."
+        description="Get the Saturday paper, plus a Digital Subscription for just £11.26 extra per month."
         {...props}
       />
       <OptionItem
         thisOption="Sunday"
-        description="Get the Observer on Sunday, plus a Digital Pack subscription for just £11.27 extra per month"
+        description="Get the Observer on Sunday, plus a Digital Subscription for just £11.27 extra per month"
         {...props}
       />
       <OptionItem
         thisOption="Weekend"
-        description="Get the Saturday paper, the Observer on Sunday, plus a Digital Pack subscription for just £8.66 extra per month."
+        description="Get the Saturday paper, the Observer on Sunday, plus a Digital Subscription for just £8.66 extra per month."
         {...props}
       />
     </ul>

--- a/support-frontend/assets/pages/showcase/components/ctaSubscribe.jsx
+++ b/support-frontend/assets/pages/showcase/components/ctaSubscribe.jsx
@@ -18,7 +18,7 @@ export default function CtaSubscribe() {
     >
       <Text title="Subscribe">
         <p>
-          From the Digital Pack, to the new Guardian Weekly magazine,
+          From the Digital Subscription, to the new Guardian Weekly magazine,
           you can subscribe to the Guardian from wherever you are.
         </p>
       </Text>

--- a/support-frontend/assets/pages/subscriptions-landing/components/featuredProducts.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/components/featuredProducts.jsx
@@ -111,7 +111,7 @@ const getProductHeadingsAndBody = (product: SubscriptionProduct, countryGroupId:
 
   if (product === 'DigitalPack') {
     return {
-      headingText: 'Digital Pack',
+      headingText: 'Digital Subscription',
       subheadingText: 'Screen time well spent',
       bodyText: (countryGroupId === GBPCountries) ?
         'Read the Guardian ad-free on all devices, plus get all the benefits of the Premium App and Daily Edition iPad app of the newspaper.' :

--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
@@ -91,9 +91,9 @@ const chooseImage = images =>
   (countryGroupId === 'GBPCountries' ? images[0] : images[1]);
 
 const digital: ProductCopy = {
-  title: 'Digital Pack',
+  title: 'Digital Subscription',
   subtitle: getPrice(DigitalPack, ''),
-  description: 'The Daily Edition app and Premium app in one pack, plus ad-free reading on all your devices',
+  description: 'The Guardian Daily app and Premium app in one pack, plus ad-free reading on all your devices',
   productImage: chooseImage([<FeaturePackshot />, <IntFeaturePackshot />]),
   offer: getSaleCopy(DigitalPack, countryGroupId).bundle.subHeading,
   buttons: [{
@@ -133,7 +133,7 @@ const paper: ProductCopy = {
 const paperAndDigital: ProductCopy = {
   title: 'Paper+Digital',
   subtitle: `from ${getPrice(PaperAndDigital, '')}`,
-  description: 'All the benefits of a paper subscription, plus access to the digital pack',
+  description: 'All the benefits of a paper subscription, plus access to the digital subscription',
   buttons: [{
     ctaButtonText: 'Find out more',
     link: subsLinks.PaperAndDigital,

--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
@@ -2,18 +2,20 @@
 import * as React from 'react';
 import { init as pageInit } from 'helpers/page/page';
 import { type SubscriptionProduct } from 'helpers/subscriptions';
-import FeaturePackshot from 'components/packshots/feature-packshot';
+import { displayPrice, sendTrackingEventsOnClick, subscriptionPricesForDefaultBillingPeriod } from 'helpers/subscriptions';
+import { getCampaign } from 'helpers/tracking/acquisitions';
+import { getSubsLinks } from 'helpers/externalLinks';
+import { androidAppUrl, getIosAppUrl } from 'helpers/externalLinks';
+import trackAppStoreLink from 'components/subscriptionBundles/appCtaTracking';
+
+// images
 import GuardianWeeklyPackShot from 'components/packshots/guardian-weekly-packshot';
 import PaperPackshot from 'components/packshots/paper-packshot';
 import PremiumAppPackshot from 'components/packshots/premium-app-packshot';
 import PaperAndDigitalPackshot from 'components/packshots/paper-and-digital-packshot';
 import IntFeaturePackshot from 'components/packshots/int-feature-packshot';
 import FullGuardianWeeklyPackShot from 'components/packshots/full-guardian-weekly-packshot';
-import { displayPrice, sendTrackingEventsOnClick, subscriptionPricesForDefaultBillingPeriod } from 'helpers/subscriptions';
-import { getCampaign } from 'helpers/tracking/acquisitions';
-import { getSubsLinks } from 'helpers/externalLinks';
-import { androidAppUrl, getIosAppUrl } from 'helpers/externalLinks';
-import trackAppStoreLink from 'components/subscriptionBundles/appCtaTracking';
+import SubscriptionDailyPackshot from 'components/packshots/subscription-daily-packshot';
 
 // constants
 import { DigitalPack, PremiumTier, GuardianWeekly, Paper, PaperAndDigital } from 'helpers/subscriptions';
@@ -94,7 +96,7 @@ const digital: ProductCopy = {
   title: 'Digital Subscription',
   subtitle: getPrice(DigitalPack, ''),
   description: 'The Guardian Daily app and Premium app in one pack, plus ad-free reading on all your devices',
-  productImage: chooseImage([<FeaturePackshot />, <IntFeaturePackshot />]),
+  productImage: chooseImage([<SubscriptionDailyPackshot />, <IntFeaturePackshot />]),
   offer: getSaleCopy(DigitalPack, countryGroupId).bundle.subHeading,
   buttons: [{
     ctaButtonText: 'Find out more',

--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
@@ -38,7 +38,7 @@ export type ProductButton = {
   analyticsTracking: Function,
 }
 
-export type ProductCopy = {
+type ProductCopy = {
   title: string,
   subtitle: Option<string>,
   description: string,

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.scss
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.scss
@@ -637,7 +637,12 @@
 
   img:nth-child(3) {
     left: 272px;
-    bottom: -40px;
+    bottom: -72px;
+
+    @include mq($until: desktop) {
+      left: 256px;
+      bottom: -40px;
+    }
 
     @include mq($until: tablet) {
       display: none;


### PR DESCRIPTION
## Why are you doing this?
Due to the launch of a new version of "iPad daily editions" which has been renamed as "The Guardian Daily" 

This PR makes changes to all product names and copy which currently has the name "Digital Pack" and changes it to "Digital Subscription" and change "iPad Daily editions"

Also the packshot images have been changed to new packshots that show "The Guardian Daily" images

[**Trello Card**](https://trello.com/c/13SO4QUn/2652-update-product-names-copy-and-packshots-for-16-10-ok-for-14th-oct)

## Changes

* Name and copy changes
* Image changes

## Screenshots
N/A

