### PR TITLE
Promotion terms page

### DIFF
--- a/support-frontend/app/controllers/Promotions.scala
+++ b/support-frontend/app/controllers/Promotions.scala
@@ -1,20 +1,17 @@
 package controllers
 
-import actions.{CacheControl, CustomActionBuilders}
+import actions.CustomActionBuilders
 import admin.settings.{AllSettings, AllSettingsProvider}
 import assets.{AssetsResolver, RefPath, StyleContent}
-import com.gu.support.catalog.GuardianWeekly
 import com.gu.support.config.Stage
-import com.gu.support.pricing.{PriceSummaryServiceProvider, ProductPrices}
+import com.gu.support.encoding.CustomCodecs._
+import com.gu.support.pricing.PriceSummaryServiceProvider
 import com.gu.support.promotions.{PromoCode, PromotionServiceProvider, PromotionTerms}
-import play.api.mvc.{AbstractController, ControllerComponents}
+import play.api.mvc.{AbstractController, Action, AnyContent, ControllerComponents}
 import play.twirl.api.Html
 import services.TestUserService
 import views.EmptyDiv
 import views.ViewHelpers.outputJson
-import com.gu.support.encoding.CustomCodecs._
-import play.api.mvc.Results.NotFound
-import views.html.main
 
 class Promotions(
   promotionServiceProvider: PromotionServiceProvider,
@@ -31,7 +28,7 @@ class Promotions(
 
   implicit val a: AssetsResolver = assets
 
-  def terms(promoCode: String) = CachedAction() { implicit request =>
+  def terms(promoCode: String): Action[AnyContent] = CachedAction() { implicit request =>
     implicit val settings: AllSettings = settingsProvider.getAllSettings()
     val title = "Support the Guardian | Digital Pack Subscription"
     val mainElement = EmptyDiv("promotion-terms")

--- a/support-frontend/app/controllers/Promotions.scala
+++ b/support-frontend/app/controllers/Promotions.scala
@@ -1,0 +1,43 @@
+package controllers
+
+import actions.CustomActionBuilders
+import admin.settings.{AllSettings, AllSettingsProvider}
+import assets.{AssetsResolver, RefPath, StyleContent}
+import com.gu.support.promotions.PromotionServiceProvider
+import play.api.mvc.{AbstractController, ControllerComponents}
+import play.twirl.api.Html
+import services.TestUserService
+import views.EmptyDiv
+import views.ViewHelpers.outputJson
+
+class Promotions(
+  promotionServiceProvider: PromotionServiceProvider,
+  val assets: AssetsResolver,
+  val actionRefiners: CustomActionBuilders,
+  testUsers: TestUserService,  //Remove?
+  components: ControllerComponents,
+  fontLoaderBundle: Either[RefPath, StyleContent],
+  settingsProvider: AllSettingsProvider,
+) extends AbstractController(components){
+  import actionRefiners._
+
+  implicit val a: AssetsResolver = assets
+
+  def terms(promoCode: String) = CachedAction() { implicit request =>
+    implicit val settings: AllSettings = settingsProvider.getAllSettings()
+    val title = "Support the Guardian | Digital Pack Subscription"
+    val mainElement = EmptyDiv("promotion-terms")
+    val js = Left(RefPath("promotionTerms.js"))
+    val css = Left(RefPath("promotionTerms.css"))
+    val promotionService = promotionServiceProvider.forUser(false)
+    val maybePromotion = promotionService.findPromotion(promoCode)
+
+    Ok(views.html.main(
+      title, mainElement, js, css, fontLoaderBundle
+    ){
+      Html(s"""<script type="text/javascript">window.guardian.promotion = ${maybePromotion.map(outputJson(_))}</script>""")
+    })
+  }
+
+
+}

--- a/support-frontend/app/wiring/AppComponents.scala
+++ b/support-frontend/app/wiring/AppComponents.scala
@@ -63,6 +63,7 @@ trait AppComponents extends PlayComponents
     payPalRegularController,
     payPalOneOffController,
     directDebitController,
+    promotionsController,
     assetController,
     faviconController
   )

--- a/support-frontend/app/wiring/Controllers.scala
+++ b/support-frontend/app/wiring/Controllers.scala
@@ -190,6 +190,7 @@ trait Controllers {
 
   lazy val promotionsController = new Promotions(
     promotionServiceProvider,
+    priceSummaryServiceProvider,
     assetsResolver,
     actionRefiners,
     testUsers,

--- a/support-frontend/app/wiring/Controllers.scala
+++ b/support-frontend/app/wiring/Controllers.scala
@@ -188,4 +188,15 @@ trait Controllers {
 
   lazy val reminderController = new ReminderController(controllerComponents, actionRefiners, sendReminderEmailService)
 
+  lazy val promotionsController = new Promotions(
+    promotionServiceProvider,
+    assetsResolver,
+    actionRefiners,
+    testUsers,
+    controllerComponents,
+    fontLoader,
+    allSettingsProvider,
+    appConfig.stage
+  )
+
 }

--- a/support-frontend/assets/components/customerService/customerService.jsx
+++ b/support-frontend/assets/components/customerService/customerService.jsx
@@ -3,12 +3,16 @@
 // ----- Imports ----- //
 
 import * as React from 'react';
-import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import {
+  AUDCountries,
+  type CountryGroupId,
+  GBPCountries,
+  UnitedStates,
+} from 'helpers/internationalisation/countryGroup';
 import { type Option } from 'helpers/types/option';
 import { type SubscriptionProduct } from 'helpers/subscriptions';
 import { type PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
-import { AUDCountries, GBPCountries, UnitedStates } from 'helpers/internationalisation/countryGroup';
-import { promotionTermsUrl } from 'helpers/externalLinks';
+import { promotionTermsUrl } from 'helpers/routes';
 
 // ----- Props ----- //
 

--- a/support-frontend/assets/helpers/externalLinks.js
+++ b/support-frontend/assets/helpers/externalLinks.js
@@ -267,8 +267,6 @@ const getProfileUrl = (path: string) => (returnUrl: ?string) => {
 const getSignoutUrl = getProfileUrl('signout');
 const getReauthenticateUrl = getProfileUrl('reauthenticate');
 
-const promotionTermsUrl = (promoCode: string) => `${subsUrl}/p/${promoCode}/terms`;
-
 // ----- Exports ----- //
 
 export {
@@ -285,5 +283,4 @@ export {
   myAccountUrl,
   manageSubsUrl,
   homeDeliveryUrl,
-  promotionTermsUrl,
 };

--- a/support-frontend/assets/helpers/globals.js
+++ b/support-frontend/assets/helpers/globals.js
@@ -3,7 +3,6 @@ import type { ProductPrices } from 'helpers/productPrice/productPrices';
 import { type Settings } from 'helpers/settings';
 import type {
   PromotionCopy,
-  PromotionTerms,
 } from 'helpers/productPrice/promotions';
 
 function getGlobal<T>(path: string = ''): ?T {

--- a/support-frontend/assets/helpers/globals.js
+++ b/support-frontend/assets/helpers/globals.js
@@ -1,7 +1,10 @@
 // @flow
 import type { ProductPrices } from 'helpers/productPrice/productPrices';
 import { type Settings } from 'helpers/settings';
-import type { PromotionCopy } from 'helpers/productPrice/promotions';
+import type {
+  PromotionCopy,
+  PromotionTerms,
+} from 'helpers/productPrice/promotions';
 
 function getGlobal<T>(path: string = ''): ?T {
 
@@ -66,5 +69,11 @@ const isTestSwitchedOn = (testName: string): boolean => {
   return false;
 };
 
-
-export { getProductPrices, getPromotionCopy, getGlobal, isTestSwitchedOn, getSettings, isSwitchOn };
+export {
+  getProductPrices,
+  getPromotionCopy,
+  getGlobal,
+  isTestSwitchedOn,
+  getSettings,
+  isSwitchOn,
+};

--- a/support-frontend/assets/helpers/internationalisation/__tests__/countryGroupTest.js
+++ b/support-frontend/assets/helpers/internationalisation/__tests__/countryGroupTest.js
@@ -2,7 +2,15 @@
 
 // ----- Imports ----- //
 
-import { AUDCountries, detect, EURCountries, GBPCountries, International, UnitedStates } from '../countryGroup';
+import {
+  AUDCountries,
+  detect,
+  EURCountries,
+  fromCountryGroupName,
+  GBPCountries,
+  International,
+  UnitedStates,
+} from '../countryGroup';
 
 const { jsdom } = global;
 
@@ -140,6 +148,10 @@ describe('detect countryGroup', () => {
 
     expect(detect()).toEqual(GBPCountries);
 
+  });
+
+  it('should find the correct country group from the name', () => {
+    expect(fromCountryGroupName('United Kingdom').name).toEqual('United Kingdom');
   });
 
 });

--- a/support-frontend/assets/helpers/internationalisation/countryGroup.js
+++ b/support-frontend/assets/helpers/internationalisation/countryGroup.js
@@ -179,6 +179,13 @@ function stringToCountryGroupId(countryGroupId: string): CountryGroupId {
   return fromString(countryGroupId) || GBPCountries;
 }
 
+function fromCountryGroupName(name: CountryGroupName): CountryGroup {
+  const groupId: ?CountryGroupId = Object
+    .keys(countryGroups)
+    .find(key => countryGroups[key].name === name);
+  return groupId ? countryGroups[groupId] : countryGroups.GBPCountries;
+}
+
 // ----- Exports ----- //
 
 export {
@@ -186,6 +193,7 @@ export {
   detect,
   stringToCountryGroupId,
   fromCountry,
+  fromCountryGroupName,
   GBPCountries,
   UnitedStates,
   AUDCountries,

--- a/support-frontend/assets/helpers/productPrice/productPrices.js
+++ b/support-frontend/assets/helpers/productPrice/productPrices.js
@@ -32,16 +32,18 @@ export type ProductPrice = {
   promotions?: Promotion[],
 }
 
-export type ProductPrices = {
-  [CountryGroupName]: {
-    [FulfilmentOptions]: {
-      [ProductOptions]: {
-        [BillingPeriod]: {
-          [IsoCurrency]: ProductPrice
-        }
+export type CountryGroupPrices = {
+  [FulfilmentOptions]: {
+    [ProductOptions]: {
+      [BillingPeriod]: {
+        [IsoCurrency]: ProductPrice
       }
     }
   }
+};
+
+export type ProductPrices = {
+  [CountryGroupName]: CountryGroupPrices,
 }
 
 export type BillingPeriods = {

--- a/support-frontend/assets/helpers/productPrice/promotions.js
+++ b/support-frontend/assets/helpers/productPrice/promotions.js
@@ -31,7 +31,8 @@ export type PromotionCopy = {
 
 export type PromotionTerms = {
   description: string,
-  expires: Date,
+  starts: Date,
+  expires: Option<Date>,
   product: SubscriptionProduct, // actually only GuardianWeekly, Paper or Digital Pack?
   productRatePlans: string[],
   promoCode: string,

--- a/support-frontend/assets/helpers/productPrice/promotions.js
+++ b/support-frontend/assets/helpers/productPrice/promotions.js
@@ -11,6 +11,7 @@ import type {
   ProductPrices,
 } from 'helpers/productPrice/productPrices';
 import { getProductPrice, isNumeric } from 'helpers/productPrice/productPrices';
+import type { SubscriptionProduct } from 'helpers/subscriptions';
 
 export type DiscountBenefit = {
   amount: number,
@@ -27,6 +28,15 @@ export type PromotionCopy = {
   description?: string,
   roundel?: string,
 }
+
+export type PromotionTerms = {
+  description: string,
+  expires: Date,
+  product: SubscriptionProduct, // actually only GuardianWeekly, Paper or Digital Pack?
+  productRatePlans: string[],
+  promoCode: string,
+}
+
 export type Promotion =
   {
     name: string,

--- a/support-frontend/assets/helpers/routes.js
+++ b/support-frontend/assets/helpers/routes.js
@@ -48,6 +48,10 @@ function paperSubsUrl(withDelivery: boolean = false): string {
   return [getOrigin(), 'uk/subscribe/paper', ...(withDelivery ? ['delivery'] : [])].join('/');
 }
 
+function digitalSubscriptionLanding() {
+  return `${getOrigin()}${routes.digitalSubscriptionLanding}`;
+}
+
 function paperCheckoutUrl(
   fulfilmentOption: FulfilmentOptions,
   productOptions: ProductOptions,
@@ -69,4 +73,12 @@ function payPalReturnUrl(cgId: CountryGroupId, email: string): string {
 
 // ----- Exports ----- //
 
-export { routes, postcodeLookupUrl, payPalCancelUrl, payPalReturnUrl, paperSubsUrl, paperCheckoutUrl };
+export {
+  routes,
+  postcodeLookupUrl,
+  payPalCancelUrl,
+  payPalReturnUrl,
+  paperSubsUrl,
+  paperCheckoutUrl,
+  digitalSubscriptionLanding,
+};

--- a/support-frontend/assets/helpers/routes.js
+++ b/support-frontend/assets/helpers/routes.js
@@ -52,6 +52,8 @@ function digitalSubscriptionLanding() {
   return `${getOrigin()}${routes.digitalSubscriptionLanding}`;
 }
 
+const promotionTermsUrl = (promoCode: string) => `${getOrigin()}/p/${promoCode}/terms`;
+
 function paperCheckoutUrl(
   fulfilmentOption: FulfilmentOptions,
   productOptions: ProductOptions,
@@ -81,4 +83,5 @@ export {
   paperSubsUrl,
   paperCheckoutUrl,
   digitalSubscriptionLanding,
+  promotionTermsUrl,
 };

--- a/support-frontend/assets/pages/digital-subscription-landing/components/termsAndConditions.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/termsAndConditions.jsx
@@ -1,9 +1,8 @@
 // @flow
 import React from 'react';
-
 // styles
 import './digitalSubscriptionLanding.scss';
-import { promotionTermsUrl } from 'helpers/externalLinks';
+import { promotionTermsUrl } from 'helpers/routes';
 
 const TermsAndConditions = () => (
   <div className="hope-is-power__terms">

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/deliveryTab.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/deliveryTab.jsx
@@ -47,6 +47,7 @@ const ContentDeliveryFaqBlock = ({ setTabAction }: {setTabAction: typeof setTab}
         'Your paper will arrive before 7am from Monday to Saturday and before 8.30am on Sunday',
         'We can’t deliver to individual flats, or apartments within blocks because we need access to your post box to deliver your paper',
         'You can pause your subscription for up to 36 days a year. So if you’re going away anywhere, you won’t have to pay for the papers that you miss',
+        'blah',
         ]}
       />
     </Text>

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/deliveryTab.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/deliveryTab.jsx
@@ -12,10 +12,14 @@ import { sendClickedEvent } from 'helpers/tracking/clickTracking';
 
 import { setTab } from '../../paperSubscriptionLandingPageActions';
 
-import { ContentHelpBlock, LinkTo, ContentForm, type ContentTabPropTypes } from './helpers';
+import {
+  ContentForm,
+  ContentHelpBlock,
+  type ContentTabPropTypes,
+  LinkTo,
+} from './helpers';
 import { Collection } from 'helpers/productPrice/fulfilmentOptions';
 import { paperHasDeliveryEnabled } from 'helpers/subscriptions';
-
 
 // ----- Content ----- //
 const ContentDeliveryFaqBlock = ({ setTabAction }: {setTabAction: typeof setTab}) => (
@@ -47,7 +51,6 @@ const ContentDeliveryFaqBlock = ({ setTabAction }: {setTabAction: typeof setTab}
         'Your paper will arrive before 7am from Monday to Saturday and before 8.30am on Sunday',
         'We can’t deliver to individual flats, or apartments within blocks because we need access to your post box to deliver your paper',
         'You can pause your subscription for up to 36 days a year. So if you’re going away anywhere, you won’t have to pay for the papers that you miss',
-        'blah',
         ]}
       />
     </Text>

--- a/support-frontend/assets/pages/promotion-terms/CopyrightText.jsx
+++ b/support-frontend/assets/pages/promotion-terms/CopyrightText.jsx
@@ -1,0 +1,13 @@
+// @flow
+
+import React from 'react';
+import Text from 'components/text/text';
+
+export default function CopyrightText() {
+  return (
+    <Text>
+      © Guardian News and Media Limited – a member of Guardian Media Group plc.
+      Registered office: Kings Place, 90 York Way, London, N1 9GU. Registered in England No. 908396
+    </Text>
+  );
+}

--- a/support-frontend/assets/pages/promotion-terms/DigitalPackTerms.jsx
+++ b/support-frontend/assets/pages/promotion-terms/DigitalPackTerms.jsx
@@ -1,0 +1,49 @@
+// @flow
+
+import React from 'react';
+import type { PromotionTerms } from 'helpers/productPrice/promotions';
+import { formatUserDate } from 'helpers/dateConversions';
+import { LargeParagraph, SansParagraph } from 'components/text/text';
+import { digitalSubscriptionLanding } from 'helpers/routes';
+import OrderedList from 'components/list/orderedList';
+import CopyrightText from 'pages/promotion-terms/CopyrightText';
+
+export default function DigitalPackTerms(props: PromotionTerms) {
+
+  const expiryCopy = props.expires ?
+    `The closing date and time of the promotion is ${formatUserDate(
+      props.expires)}. 
+    Purchases after that date and time will not be eligible for the promotion.`
+    : '';
+  const copy = [
+    'The promotion (the “Promotion”) is open to new Digital Pack subscribers aged 18 and over ("you") subject to paragraph 2 below.',
+    'By entering the promotion you are accepting these terms and conditions.',
+    <div>To enter the promotion, you must: (i) either go to <a
+      href={digitalSubscriptionLanding()}>support.theguardian.com</a> or call
+      +44 (0) 330 333 6767 and quote promotion code {props.promoCode} (ii)
+      purchase a Digital Pack subscription and maintain that subscription for at
+      least three months.</div>,
+    'Entry to this promotion is available only to new subscribers: this means that you must not already have a subscription to the Digital Pack to be eligible to participate in this Promotion.',
+    <div>Please note that purchasing a subscription as referred to in paragraph
+      4 above will also be subject to the terms and conditions for Guardian and
+      Observer Digital subscriptions available at <a
+        href='https://www.theguardian.com/digital-subscriptions-terms-conditions'>theguardian.com/digital-subscriptions-terms-conditions</a>
+    </div>,
+    `The opening date and time of the Promotion is ${formatUserDate(
+      props.starts)}. ${expiryCopy}`,
+    'If you opt to use the SMS response service to place your order you will be charged your standard network rate.',
+    'Only one entry to this Promotion per person. Entries on behalf of another person will not be accepted.',
+    'We take no responsibility for entries that are lost, delayed, misdirected or incomplete or cannot be delivered or entered for any technical or other reason. Proof of delivery of the entry is not proof of receipt.',
+    'The Promoter of the Promotion is Guardian News & Media Limited whose address is Kings Place, 90 York Way, London N1 9GU. Any complaints regarding the Promotion should be sent to this address.',
+    'Nothing in these terms and conditions shall exclude the liability of GNM for death, personal injury, fraud or fraudulent misrepresentation as a result of its negligence.',
+    'GNM accepts no responsibility for any damage, loss, liabilities, injury or disappointment incurred or suffered by you as a result of entering the Promotion. GNM further disclaims liability for any injury or damage to you or any other person’s computer relating to or resulting from participation in the Promotion.',
+    'GNM reserves the right at any time and from time to time to modify or discontinue, temporarily or permanently, this Promotion with or without prior notice due to reasons outside its control (including, without limitation, in the case of anticipated, suspected or actual fraud). The decision of GNM in all matters under its control is final and binding.',
+    'GNM shall not be liable for any failure to comply with its obligations where the failure is caused by something outside its reasonable control. Such circumstances shall include, but not be limited to, weather conditions, fire, flood, hurricane, strike, industrial dispute, war, hostilities, political unrest, riots, civil commotion, inevitable accidents, supervening legislation or any other circumstances amounting to force majeure.',
+  ];
+  return (
+    <div>
+      <OrderedList items={copy}/>
+      <CopyrightText/>
+    </div>
+  );
+};

--- a/support-frontend/assets/pages/promotion-terms/DigitalPackTerms.jsx
+++ b/support-frontend/assets/pages/promotion-terms/DigitalPackTerms.jsx
@@ -14,15 +14,15 @@ export default function DigitalPackTerms(props: PromotionTerms) {
     Purchases after that date and time will not be eligible for the promotion.`
     : '';
   const copy = [
-    'The promotion (the “Promotion”) is open to new Digital Pack subscribers aged 18 and over ("you") subject to paragraph 2 below.',
+    'The promotion (the “Promotion”) is open to new Guardian Digital Subscription subscribers aged 18 and over ("you") subject to paragraph 2 below.',
     'By entering the promotion you are accepting these terms and conditions.',
     <div>To enter the promotion, you must: (i) either go to{' '}
       <a href={digitalSubscriptionLanding()}>support.theguardian.com</a> or call
       +44 (0) 330 333 6767 and quote promotion code {props.promoCode} (ii)
-      purchase a Digital Pack subscription and maintain that subscription for at
+      purchase a Guardian Digital Subscription and maintain that subscription for at
       least three months.
     </div>,
-    'Entry to this promotion is available only to new subscribers: this means that you must not already have a subscription to the Digital Pack to be eligible to participate in this Promotion.',
+    'Entry to this promotion is available only to new subscribers: this means that you must not already have a subscription to the Guardian Digital Subscription to be eligible to participate in this Promotion.',
     <div>Please note that purchasing a subscription as referred to in paragraph
       4 above will also be subject to the terms and conditions for Guardian and
       Observer Digital subscriptions available at{' '}

--- a/support-frontend/assets/pages/promotion-terms/PaperTerms.jsx
+++ b/support-frontend/assets/pages/promotion-terms/PaperTerms.jsx
@@ -3,31 +3,32 @@
 import React from 'react';
 import type { PromotionTerms } from 'helpers/productPrice/promotions';
 import { formatUserDate } from 'helpers/dateConversions';
-import { digitalSubscriptionLanding } from 'helpers/routes';
+import { paperSubsUrl } from 'helpers/routes';
 import OrderedList from 'components/list/orderedList';
 import CopyrightText from 'pages/promotion-terms/CopyrightText';
 
-export default function DigitalPackTerms(props: PromotionTerms) {
+export default function PaperTerms(props: PromotionTerms) {
 
   const expiryCopy = props.expires ?
     `The closing date and time of the promotion is ${formatUserDate(props.expires)}. 
     Purchases after that date and time will not be eligible for the promotion.`
     : '';
   const copy = [
-    'The promotion (the “Promotion”) is open to new Digital Pack subscribers aged 18 and over ("you") subject to paragraph 2 below.',
+    'The promotion (the “Promotion”) is open to UK residents aged 18 and over ("you") subject to paragraph 2 below.',
     'By entering the promotion you are accepting these terms and conditions.',
     <div>To enter the promotion, you must: (i) either go to{' '}
-      <a href={digitalSubscriptionLanding()}>support.theguardian.com</a> or call
-      +44 (0) 330 333 6767 and quote promotion code {props.promoCode} (ii)
-      purchase a Digital Pack subscription and maintain that subscription for at
-      least three months.
+      <a href={paperSubsUrl()}>support.theguardian.com</a> or call
+      0330 333 6767 and quote promotion code {props.promoCode} (ii)
+      purchase a print or print + digital editions subscription package to
+      either the Guardian and Observer (excludes digital-only subscriptions) and
+      maintain that subscription for at least three months.
     </div>,
-    'Entry to this promotion is available only to new subscribers: this means that you must not already have a subscription to the Digital Pack to be eligible to participate in this Promotion.',
+    'Entry to this promotion is available only to new subscribers: this means that you must not already have a subscription to the Guardian and/or Observer to be eligible to participate in this Promotion.',
     <div>Please note that purchasing a subscription as referred to in paragraph
       4 above will also be subject to the terms and conditions for Guardian and
-      Observer Digital subscriptions available at{' '}
-      <a href="https://www.theguardian.com/digital-subscriptions-terms-conditions">
-        theguardian.com/digital-subscriptions-terms-conditions
+      Observer subscriptions available at{' '}
+      <a href="https://www.theguardian.com/subscriber-direct/subscription-terms-and-conditions">
+        theguardian.com/subscriber-direct/subscription-terms-and-conditions
       </a>
     </div>,
     `The opening date and time of the Promotion is ${formatUserDate(props.starts)}. ${expiryCopy}`,

--- a/support-frontend/assets/pages/promotion-terms/PromoDetails.jsx
+++ b/support-frontend/assets/pages/promotion-terms/PromoDetails.jsx
@@ -1,0 +1,35 @@
+// @flow
+
+import React from 'react';
+import type { PromotionTerms } from 'helpers/productPrice/promotions';
+import { connect } from 'react-redux';
+import type { State } from 'pages/promotion-terms/promotionTermsReducer';
+import { LargeParagraph, Title } from 'components/text/text';
+import Content from 'components/content/content';
+import { formatUserDate } from 'helpers/dateConversions';
+import UnorderedList from 'components/list/unorderedList';
+
+const mapStateToProps = (state: State) => state.page.promotionTerms;
+
+const PromoDetails = (props: PromotionTerms) => {
+  const validUntil = props.expires ? (
+    <LargeParagraph>
+      <strong>Valid until:</strong> {formatUserDate(props.expires)}
+    </LargeParagraph>) : null;
+
+  return (
+    <Content>
+      <Title>Promotional code: {props.promoCode}</Title>
+      <LargeParagraph>
+        <strong>Promotion details:</strong> {props.description}
+      </LargeParagraph>
+      {validUntil}
+      <LargeParagraph>
+        <strong>Applies to products:</strong>
+        <UnorderedList items={props.productRatePlans}/>
+      </LargeParagraph>
+    </Content>
+  );
+};
+
+export default connect(mapStateToProps)(PromoDetails);

--- a/support-frontend/assets/pages/promotion-terms/PromoDetails.jsx
+++ b/support-frontend/assets/pages/promotion-terms/PromoDetails.jsx
@@ -5,7 +5,7 @@ import type { PromotionTerms } from 'helpers/productPrice/promotions';
 import { connect } from 'react-redux';
 import type { State } from 'pages/promotion-terms/promotionTermsReducer';
 import { LargeParagraph, Title } from 'components/text/text';
-import Content from 'components/content/content';
+import Content, { Divider } from 'components/content/content';
 import { formatUserDate } from 'helpers/dateConversions';
 import UnorderedList from 'components/list/unorderedList';
 
@@ -19,7 +19,7 @@ const PromoDetails = (props: PromotionTerms) => {
 
   return (
     <Content>
-      <Title>Promotional code: {props.promoCode}</Title>
+      <Title size={1}>Promotional code: {props.promoCode}</Title>
       <LargeParagraph>
         <strong>Promotion details:</strong> {props.description}
       </LargeParagraph>
@@ -28,6 +28,8 @@ const PromoDetails = (props: PromotionTerms) => {
         <strong>Applies to products:</strong>
         <UnorderedList items={props.productRatePlans}/>
       </LargeParagraph>
+      <Divider />
+      <Title size={1}>Promotion terms and conditions</Title>
     </Content>
   );
 };

--- a/support-frontend/assets/pages/promotion-terms/legalTerms.jsx
+++ b/support-frontend/assets/pages/promotion-terms/legalTerms.jsx
@@ -1,0 +1,27 @@
+// @flow
+
+import React from 'react';
+import Content, { Divider } from 'components/content/content';
+import { Title } from 'components/text/text';
+import { GuardianWeekly } from 'helpers/subscriptions';
+import WeeklyTerms from 'pages/promotion-terms/weeklyTerms';
+import type { PromotionTermsPropTypes } from 'pages/promotion-terms/promotionTermsReducer';
+
+const getTermsForProduct = (props: PromotionTermsPropTypes) => {
+  switch (props.promotionTerms.product) {
+    case GuardianWeekly:
+      return <WeeklyTerms {...props} />;
+    default: return null;
+  }
+};
+
+export default function LegalTerms(props: PromotionTermsPropTypes) {
+
+  return (
+    <Content>
+      <Divider />
+      <Title size={1}>Promotion terms and conditions</Title>
+      {getTermsForProduct(props)}
+    </Content>
+  );
+}

--- a/support-frontend/assets/pages/promotion-terms/legalTerms.jsx
+++ b/support-frontend/assets/pages/promotion-terms/legalTerms.jsx
@@ -3,14 +3,17 @@
 import React from 'react';
 import Content, { Divider } from 'components/content/content';
 import { Title } from 'components/text/text';
-import { GuardianWeekly } from 'helpers/subscriptions';
+import { DigitalPack, GuardianWeekly } from 'helpers/subscriptions';
 import WeeklyTerms from 'pages/promotion-terms/weeklyTerms';
 import type { PromotionTermsPropTypes } from 'pages/promotion-terms/promotionTermsReducer';
+import DigitalPackTerms from 'pages/promotion-terms/DigitalPackTerms';
 
 const getTermsForProduct = (props: PromotionTermsPropTypes) => {
   switch (props.promotionTerms.product) {
     case GuardianWeekly:
       return <WeeklyTerms {...props} />;
+    case DigitalPack:
+      return <DigitalPackTerms {...props.promotionTerms} />
     default: return null;
   }
 };

--- a/support-frontend/assets/pages/promotion-terms/legalTerms.jsx
+++ b/support-frontend/assets/pages/promotion-terms/legalTerms.jsx
@@ -7,19 +7,20 @@ import { DigitalPack, GuardianWeekly } from 'helpers/subscriptions';
 import WeeklyTerms from 'pages/promotion-terms/weeklyTerms';
 import type { PromotionTermsPropTypes } from 'pages/promotion-terms/promotionTermsReducer';
 import DigitalPackTerms from 'pages/promotion-terms/DigitalPackTerms';
+import PaperTerms from 'pages/promotion-terms/PaperTerms';
 
 const getTermsForProduct = (props: PromotionTermsPropTypes) => {
   switch (props.promotionTerms.product) {
     case GuardianWeekly:
       return <WeeklyTerms {...props} />;
     case DigitalPack:
-      return <DigitalPackTerms {...props.promotionTerms} />
-    default: return null;
+      return <DigitalPackTerms {...props.promotionTerms} />;
+    default:
+      return <PaperTerms {...props.promotionTerms} />;
   }
 };
 
 export default function LegalTerms(props: PromotionTermsPropTypes) {
-
   return (
     <Content>
       <Divider />

--- a/support-frontend/assets/pages/promotion-terms/promoDetails.jsx
+++ b/support-frontend/assets/pages/promotion-terms/promoDetails.jsx
@@ -43,7 +43,7 @@ export default function PromoDetails(props: PromotionTerms) {
         }
         />
       </LargeParagraph>
-      <AnchorButton href={landingPageForProduct(props.product) + '?promoCode=' + props.promoCode}>
+      <AnchorButton href={`${landingPageForProduct(props.product)}?promoCode=${props.promoCode}`}>
         Get this offer
       </AnchorButton>
     </Content>

--- a/support-frontend/assets/pages/promotion-terms/promoDetails.jsx
+++ b/support-frontend/assets/pages/promotion-terms/promoDetails.jsx
@@ -43,7 +43,9 @@ export default function PromoDetails(props: PromotionTerms) {
         }
         />
       </LargeParagraph>
-      <AnchorButton href={landingPageForProduct(props.product)}>Get this offer</AnchorButton>
+      <AnchorButton href={landingPageForProduct(props.product) + '?promoCode=' + props.promoCode}>
+        Get this offer
+      </AnchorButton>
     </Content>
   );
 }

--- a/support-frontend/assets/pages/promotion-terms/promoDetails.jsx
+++ b/support-frontend/assets/pages/promotion-terms/promoDetails.jsx
@@ -6,6 +6,21 @@ import { LargeParagraph, Title } from 'components/text/text';
 import Content from 'components/content/content';
 import { formatUserDate } from 'helpers/dateConversions';
 import UnorderedList from 'components/list/unorderedList';
+import AnchorButton from 'components/button/anchorButton';
+import type { SubscriptionProduct } from 'helpers/subscriptions';
+import { DigitalPack, Paper } from 'helpers/subscriptions';
+import { routes } from 'helpers/routes';
+
+const landingPageForProduct = (product: SubscriptionProduct) => {
+  switch (product) {
+    case DigitalPack:
+      return routes.digitalSubscriptionLanding;
+    case Paper:
+      return routes.paperSubscriptionLanding;
+    default:
+      return routes.guardianWeeklySubscriptionLanding;
+  }
+};
 
 export default function PromoDetails(props: PromotionTerms) {
   const validUntil = props.expires ? (
@@ -28,6 +43,8 @@ export default function PromoDetails(props: PromotionTerms) {
         }
         />
       </LargeParagraph>
+      <AnchorButton href={landingPageForProduct(props.product)}>Get this offer</AnchorButton>
     </Content>
   );
 }
+

--- a/support-frontend/assets/pages/promotion-terms/promoDetails.jsx
+++ b/support-frontend/assets/pages/promotion-terms/promoDetails.jsx
@@ -2,16 +2,12 @@
 
 import React from 'react';
 import type { PromotionTerms } from 'helpers/productPrice/promotions';
-import { connect } from 'react-redux';
-import type { State } from 'pages/promotion-terms/promotionTermsReducer';
 import { LargeParagraph, Title } from 'components/text/text';
-import Content, { Divider } from 'components/content/content';
+import Content from 'components/content/content';
 import { formatUserDate } from 'helpers/dateConversions';
 import UnorderedList from 'components/list/unorderedList';
 
-const mapStateToProps = (state: State) => state.page.promotionTerms;
-
-const PromoDetails = (props: PromotionTerms) => {
+export default function PromoDetails(props: PromotionTerms) {
   const validUntil = props.expires ? (
     <LargeParagraph>
       <strong>Valid until:</strong> {formatUserDate(props.expires)}
@@ -26,12 +22,12 @@ const PromoDetails = (props: PromotionTerms) => {
       {validUntil}
       <LargeParagraph>
         <strong>Applies to products:</strong>
-        <UnorderedList items={props.productRatePlans}/>
+        <UnorderedList items={
+          // $FlowIgnore
+          props.productRatePlans
+        }
+        />
       </LargeParagraph>
-      <Divider />
-      <Title size={1}>Promotion terms and conditions</Title>
     </Content>
   );
-};
-
-export default connect(mapStateToProps)(PromoDetails);
+}

--- a/support-frontend/assets/pages/promotion-terms/promotionTerms.jsx
+++ b/support-frontend/assets/pages/promotion-terms/promotionTerms.jsx
@@ -4,6 +4,7 @@ import { renderPage } from 'helpers/render';
 import React from 'react';
 import './promotionTerms.scss';
 import { init as pageInit } from 'helpers/page/page';
+import type { State } from './promotionTermsReducer';
 import reducer from './promotionTermsReducer';
 import Page from 'components/page/page';
 import Footer from 'components/footer/footer';
@@ -11,9 +12,6 @@ import Header from 'components/headers/header/header';
 import { Provider } from 'react-redux';
 import PromoDetails from 'pages/promotion-terms/promoDetails';
 import LegalTerms from 'pages/promotion-terms/legalTerms';
-import type { State } from './promotionTermsReducer';
-import Text from 'components/text/text';
-import Content from 'components/content/content';
 
 // ----- Redux Store ----- //
 

--- a/support-frontend/assets/pages/promotion-terms/promotionTerms.jsx
+++ b/support-frontend/assets/pages/promotion-terms/promotionTerms.jsx
@@ -2,15 +2,31 @@
 
 import { renderPage } from 'helpers/render';
 import React from 'react';
-import { statelessInit } from 'helpers/page/page';
 import './promotionTerms.scss';
+import { init as pageInit } from 'helpers/page/page';
+import reducer from './promotionTermsReducer';
+import Page from 'components/page/page';
+import Footer from 'components/footer/footer';
+import Header from 'components/headers/header/header';
+import { Provider } from 'react-redux';
+import PromoDetails from 'pages/promotion-terms/PromoDetails';
 
-statelessInit();
+// ----- Redux Store ----- //
+
+const store = pageInit(() => reducer, true);
+
 
 // ----- Render ----- //
 
 const content = (
-  <div>Hello</div>
+  <Provider store={store}>
+    <Page
+      header={<Header />}
+      footer={<Footer />}
+    >
+      <PromoDetails />
+    </Page>
+  </Provider>
 );
 
 renderPage(content, 'promotion-terms');

--- a/support-frontend/assets/pages/promotion-terms/promotionTerms.jsx
+++ b/support-frontend/assets/pages/promotion-terms/promotionTerms.jsx
@@ -12,6 +12,8 @@ import { Provider } from 'react-redux';
 import PromoDetails from 'pages/promotion-terms/promoDetails';
 import LegalTerms from 'pages/promotion-terms/legalTerms';
 import type { State } from './promotionTermsReducer';
+import Text from 'components/text/text';
+import Content from 'components/content/content';
 
 // ----- Redux Store ----- //
 

--- a/support-frontend/assets/pages/promotion-terms/promotionTerms.jsx
+++ b/support-frontend/assets/pages/promotion-terms/promotionTerms.jsx
@@ -9,7 +9,9 @@ import Page from 'components/page/page';
 import Footer from 'components/footer/footer';
 import Header from 'components/headers/header/header';
 import { Provider } from 'react-redux';
-import PromoDetails from 'pages/promotion-terms/PromoDetails';
+import PromoDetails from 'pages/promotion-terms/promoDetails';
+import LegalTerms from 'pages/promotion-terms/legalTerms';
+import type { State } from './promotionTermsReducer';
 
 // ----- Redux Store ----- //
 
@@ -18,16 +20,17 @@ const store = pageInit(() => reducer, true);
 
 // ----- Render ----- //
 
-const content = (
+const PromotionTermsPage = (props: State) => (
   <Provider store={store}>
     <Page
       header={<Header />}
       footer={<Footer />}
     >
-      <PromoDetails />
+      <PromoDetails {...props.page.promotionTerms} />
+      <LegalTerms {...props.page} />
     </Page>
   </Provider>
 );
 
-renderPage(content, 'promotion-terms');
+renderPage(PromotionTermsPage(store.getState()), 'promotion-terms');
 

--- a/support-frontend/assets/pages/promotion-terms/promotionTerms.jsx
+++ b/support-frontend/assets/pages/promotion-terms/promotionTerms.jsx
@@ -1,0 +1,17 @@
+// @flow
+
+import { renderPage } from 'helpers/render';
+import React from 'react';
+import { statelessInit } from 'helpers/page/page';
+import './promotionTerms.scss';
+
+statelessInit();
+
+// ----- Render ----- //
+
+const content = (
+  <div>Hello</div>
+);
+
+renderPage(content, 'promotion-terms');
+

--- a/support-frontend/assets/pages/promotion-terms/promotionTerms.scss
+++ b/support-frontend/assets/pages/promotion-terms/promotionTerms.scss
@@ -16,6 +16,10 @@
   margin-top: $gu-v-spacing / 2;
 }
 
+.component-text__sans {
+  margin-top: $gu-v-spacing;
+}
+
 .component-list-ul {
   margin-top: $gu-v-spacing / 2;
 }

--- a/support-frontend/assets/pages/promotion-terms/promotionTerms.scss
+++ b/support-frontend/assets/pages/promotion-terms/promotionTerms.scss
@@ -13,7 +13,7 @@
 }
 
 .component-text__large {
-  margin-top: $gu-v-spacing / 2;
+  margin-top: $gu-v-spacing;
 }
 
 .component-text__sans {

--- a/support-frontend/assets/pages/promotion-terms/promotionTerms.scss
+++ b/support-frontend/assets/pages/promotion-terms/promotionTerms.scss
@@ -1,0 +1,13 @@
+// -----  gu-sass ----- //
+@import '~stylesheets/gu-sass/gu-sass';
+
+// ----- Shared Components ----- //
+@import '~components/footer/footer';
+
+@import '~stylesheets/skeleton/skeleton.scss';
+
+@import '~stylesheets/skeleton/skeleton.scss';
+
+.promotion-terms {
+
+}

--- a/support-frontend/assets/pages/promotion-terms/promotionTerms.scss
+++ b/support-frontend/assets/pages/promotion-terms/promotionTerms.scss
@@ -8,6 +8,14 @@
 
 @import '~stylesheets/skeleton/skeleton.scss';
 
-.promotion-terms {
+.component-text__heading{
+  margin-top: $gu-v-spacing;
+}
 
+.component-text__large {
+  margin-top: $gu-v-spacing / 2;
+}
+
+.component-list-ul {
+  margin-top: $gu-v-spacing / 2;
 }

--- a/support-frontend/assets/pages/promotion-terms/promotionTerms.scss
+++ b/support-frontend/assets/pages/promotion-terms/promotionTerms.scss
@@ -21,9 +21,14 @@
 }
 
 .component-list-ul {
-  margin-top: $gu-v-spacing / 2;
+  margin-top: $gu-v-spacing;
 }
 
 .component-weekly-terms-copyright-footer {
   margin-top: $gu-v-spacing;
+}
+
+.component-button {
+  margin-top: $gu-v-spacing * 2;
+  margin-bottom: $gu-v-spacing;
 }

--- a/support-frontend/assets/pages/promotion-terms/promotionTerms.scss
+++ b/support-frontend/assets/pages/promotion-terms/promotionTerms.scss
@@ -23,3 +23,7 @@
 .component-list-ul {
   margin-top: $gu-v-spacing / 2;
 }
+
+.component-weekly-terms-copyright-footer {
+  margin-top: $gu-v-spacing;
+}

--- a/support-frontend/assets/pages/promotion-terms/promotionTermsReducer.js
+++ b/support-frontend/assets/pages/promotion-terms/promotionTermsReducer.js
@@ -16,7 +16,8 @@ export type State = {
 // ----- Export ----- //
 export default () => {
   const terms = getGlobal('promotionTerms');
+  const expires = terms && terms.expires ? new Date(terms.expires) : null;
   return {
-    promotionTerms: { ...terms, expires: new Date(terms.expires) },
+    promotionTerms: { ...terms, expires },
   };
 };

--- a/support-frontend/assets/pages/promotion-terms/promotionTermsReducer.js
+++ b/support-frontend/assets/pages/promotion-terms/promotionTermsReducer.js
@@ -1,0 +1,22 @@
+// @flow
+
+// ----- Imports ----- //
+
+import type { CommonState } from 'helpers/page/commonReducer';
+import { getGlobal } from 'helpers/globals';
+import type { PromotionTerms } from 'helpers/productPrice/promotions';
+
+export type State = {
+  common: CommonState,
+  page: {
+    promotionTerms: ?PromotionTerms,
+  }
+};
+
+// ----- Export ----- //
+export default () => {
+  const terms = getGlobal('promotionTerms');
+  return {
+    promotionTerms: { ...terms, expires: new Date(terms.expires) },
+  };
+};

--- a/support-frontend/assets/pages/promotion-terms/promotionTermsReducer.js
+++ b/support-frontend/assets/pages/promotion-terms/promotionTermsReducer.js
@@ -3,21 +3,27 @@
 // ----- Imports ----- //
 
 import type { CommonState } from 'helpers/page/commonReducer';
-import { getGlobal } from 'helpers/globals';
+import { getGlobal, getProductPrices } from 'helpers/globals';
 import type { PromotionTerms } from 'helpers/productPrice/promotions';
+import type { ProductPrices } from 'helpers/productPrice/productPrices';
+
+export type PromotionTermsPropTypes = {
+  productPrices: ProductPrices,
+  promotionTerms: PromotionTerms,
+};
 
 export type State = {
   common: CommonState,
-  page: {
-    promotionTerms: ?PromotionTerms,
-  }
+  page: PromotionTermsPropTypes,
 };
 
 // ----- Export ----- //
 export default () => {
+  const productPrices = getProductPrices();
   const terms = getGlobal('promotionTerms');
   const expires = terms && terms.expires ? new Date(terms.expires) : null;
   return {
+    productPrices,
     promotionTerms: { ...terms, expires },
   };
 };

--- a/support-frontend/assets/pages/promotion-terms/promotionTermsReducer.js
+++ b/support-frontend/assets/pages/promotion-terms/promotionTermsReducer.js
@@ -22,8 +22,10 @@ export default () => {
   const productPrices = getProductPrices();
   const terms = getGlobal('promotionTerms');
   const expires = terms && terms.expires ? new Date(terms.expires) : null;
+  const starts = terms ? new Date(terms.starts) : null;
+
   return {
     productPrices,
-    promotionTerms: { ...terms, expires },
+    promotionTerms: { ...terms, starts, expires },
   };
 };

--- a/support-frontend/assets/pages/promotion-terms/weeklyTerms.jsx
+++ b/support-frontend/assets/pages/promotion-terms/weeklyTerms.jsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import Text, { SansParagraph } from 'components/text/text';
 import type { PromotionTermsPropTypes } from 'pages/promotion-terms/promotionTermsReducer';
+import type { CountryGroupName } from 'helpers/internationalisation/countryGroup';
 import {
   fromCountryGroupName,
   International,
@@ -11,10 +12,9 @@ import { Domestic, RestOfWorld } from 'helpers/productPrice/fulfilmentOptions';
 import { NoProductOptions } from 'helpers/productPrice/productOptions';
 import { Annual, Quarterly } from 'helpers/billingPeriods';
 import { glyph } from 'helpers/internationalisation/currency';
+import type { CountryGroupPrices } from 'helpers/productPrice/productPrices';
 import { showPrice } from 'helpers/productPrice/productPrices';
 import { Divider } from 'components/content/content';
-import type { CountryGroupName } from 'helpers/internationalisation/countryGroup';
-import type { CountryGroupPrices } from 'helpers/productPrice/productPrices';
 import CopyrightText from 'pages/promotion-terms/CopyrightText';
 
 const orderedCountryGroupNames = [
@@ -28,7 +28,7 @@ const orderedCountryGroupNames = [
 
 function FullTermsLink() {
   return (
-    <div className='component-weekly-terms-copyright-footer'>
+    <div className="component-weekly-terms-copyright-footer">
       <Divider />
       <Text>
         For full subscription terms and conditions visit{' '}

--- a/support-frontend/assets/pages/promotion-terms/weeklyTerms.jsx
+++ b/support-frontend/assets/pages/promotion-terms/weeklyTerms.jsx
@@ -17,14 +17,17 @@ import { showPrice } from 'helpers/productPrice/productPrices';
 import { Divider } from 'components/content/content';
 import CopyrightText from 'pages/promotion-terms/CopyrightText';
 
-const orderedCountryGroupNames = [
-  'United Kingdom',
-  'United States',
-  'Australia',
-  'Europe',
-  'International',
-  'New Zealand',
-  'Canada'];
+type NameAndSaving = {name: CountryGroupName, saving: ?string};
+
+const orderedCountryGroupNames: NameAndSaving[] = [
+  { name: 'United Kingdom', saving: '35%' },
+  { name: 'United States', saving: '31%' },
+  { name: 'Australia', saving: '31%' },
+  { name: 'Europe', saving: '26%' },
+  { name: 'New Zealand', saving: '20%' },
+  { name: 'Canada', saving: '16%' },
+  { name: 'International', saving: null },
+];
 
 function FullTermsLink() {
   return (
@@ -69,25 +72,31 @@ function getCountryPrice(countryGroupName: CountryGroupName, prices: CountryGrou
   };
 }
 
-function StandardCountryPrice(countryGroupName: CountryGroupName, prices: CountryGroupPrices) {
-  const { quarterlyPrice, annualPrice } = getCountryPrice(countryGroupName, prices);
+function getSaving(saving: ?string) {
+  if (saving) {
+    return `, saving ${saving} off the cover price.`;
+  }
+  return '.';
+}
+
+function StandardCountryPrice(nameAndSaving: NameAndSaving, prices: CountryGroupPrices) {
+  const { quarterlyPrice, annualPrice } = getCountryPrice(nameAndSaving.name, prices);
   return (
     <SansParagraph>
-      <strong>{countryGroupName}:</strong>{' '}
+      <strong>{nameAndSaving.name}:</strong>{' '}
       Quarterly (13 weeks) subscription rate {showPrice(quarterlyPrice)},
-      or annual rate {showPrice(annualPrice)}, saving 35% off the cover price.
+      or annual rate {showPrice(annualPrice)}{getSaving(nameAndSaving.saving)}
     </SansParagraph>
   );
 }
 
-function SixForSixCountryPrice(countryGroupName, prices: CountryGroupPrices) {
-  const { currencyGlyph, quarterlyPrice } = getCountryPrice(countryGroupName, prices);
+function SixForSixCountryPrice(nameAndSaving: NameAndSaving, prices: CountryGroupPrices) {
+  const { currencyGlyph, quarterlyPrice } = getCountryPrice(nameAndSaving.name, prices);
   return (
     <SansParagraph>
-      <strong>{countryGroupName}:</strong>{' '}
+      <strong>{nameAndSaving.name}:</strong>{' '}
       Offer is {currencyGlyph}6 for the first 6 issues followed by quarterly (13 weeks)
-      subscription payments of {showPrice(quarterlyPrice)} thereafter,
-      saving 35% off the cover price.
+      subscription payments of {showPrice(quarterlyPrice)} thereafter{getSaving(nameAndSaving.saving)}
     </SansParagraph>
   );
 }
@@ -103,7 +112,8 @@ function StandardTerms(props: PromotionTermsPropTypes) {
         You must be 18+ to be eligible for a Guardian Weekly subscription.
       </SansParagraph>
       {
-        orderedCountryGroupNames.map(name => StandardCountryPrice(name, props.productPrices[name]))
+        orderedCountryGroupNames.map(nameAndSaving =>
+          StandardCountryPrice(nameAndSaving, props.productPrices[nameAndSaving.name]))
       }
       <FullTermsLink />
     </div>
@@ -123,7 +133,8 @@ function SixForSix(props: PromotionTermsPropTypes) {
         Guardian Weekly reserve the right to end this offer at any time.
       </SansParagraph>
       {
-        orderedCountryGroupNames.map(name => SixForSixCountryPrice(name, props.productPrices[name]))
+        orderedCountryGroupNames.map(nameAndSaving =>
+          SixForSixCountryPrice(nameAndSaving, props.productPrices[nameAndSaving.name]))
       }
       <FullTermsLink />
     </div>

--- a/support-frontend/assets/pages/promotion-terms/weeklyTerms.jsx
+++ b/support-frontend/assets/pages/promotion-terms/weeklyTerms.jsx
@@ -11,7 +11,7 @@ import {
 import { Domestic, RestOfWorld } from 'helpers/productPrice/fulfilmentOptions';
 import { NoProductOptions } from 'helpers/productPrice/productOptions';
 import { Annual, Quarterly } from 'helpers/billingPeriods';
-import { glyph } from 'helpers/internationalisation/currency';
+import { extendedGlyph } from 'helpers/internationalisation/currency';
 import type { CountryGroupPrices } from 'helpers/productPrice/productPrices';
 import { showPrice } from 'helpers/productPrice/productPrices';
 import { Divider } from 'components/content/content';
@@ -58,7 +58,7 @@ export default function WeeklyTerms(props: PromotionTermsPropTypes) {
 
 function getCountryPrice(countryGroupName: CountryGroupName, prices: CountryGroupPrices) {
   const { currency } = fromCountryGroupName(countryGroupName);
-  const currencyGlyph = glyph(currency);
+  const currencyGlyph = extendedGlyph(currency);
   const fulfilmentOption = countryGroupName === International ? RestOfWorld : Domestic;
   const quarterlyPrice = prices[fulfilmentOption][NoProductOptions][Quarterly][currency];
   const annualPrice = prices[fulfilmentOption][NoProductOptions][Annual][currency];
@@ -74,8 +74,8 @@ function StandardCountryPrice(countryGroupName: CountryGroupName, prices: Countr
   return (
     <SansParagraph>
       <strong>{countryGroupName}:</strong>{' '}
-      Quarterly (13 weeks) subscription rate {showPrice(quarterlyPrice, false)},
-      or annual rate {showPrice(annualPrice, false)}, saving 35% off the cover price.
+      Quarterly (13 weeks) subscription rate {showPrice(quarterlyPrice)},
+      or annual rate {showPrice(annualPrice)}, saving 35% off the cover price.
     </SansParagraph>
   );
 }
@@ -86,7 +86,7 @@ function SixForSixCountryPrice(countryGroupName, prices: CountryGroupPrices) {
     <SansParagraph>
       <strong>{countryGroupName}:</strong>{' '}
       Offer is {currencyGlyph}6 for the first 6 issues followed by quarterly (13 weeks)
-      subscription payments of {showPrice(quarterlyPrice, false)} thereafter,
+      subscription payments of {showPrice(quarterlyPrice)} thereafter,
       saving 35% off the cover price.
     </SansParagraph>
   );

--- a/support-frontend/assets/pages/promotion-terms/weeklyTerms.jsx
+++ b/support-frontend/assets/pages/promotion-terms/weeklyTerms.jsx
@@ -9,12 +9,43 @@ import {
 } from 'helpers/internationalisation/countryGroup';
 import { Domestic, RestOfWorld } from 'helpers/productPrice/fulfilmentOptions';
 import { NoProductOptions } from 'helpers/productPrice/productOptions';
-import { Quarterly } from 'helpers/billingPeriods';
+import { Annual, Quarterly } from 'helpers/billingPeriods';
 import { glyph } from 'helpers/internationalisation/currency';
 import { showPrice } from 'helpers/productPrice/productPrices';
 import { Divider } from 'components/content/content';
 import type { CountryGroupName } from 'helpers/internationalisation/countryGroup';
 import type { CountryGroupPrices } from 'helpers/productPrice/productPrices';
+
+const orderedCountryGroupNames = [
+  'United Kingdom',
+  'United States',
+  'Australia',
+  'Europe',
+  'International',
+  'New Zealand',
+  'Canada'];
+
+function CopyrightFooter() {
+  return (
+    <div className='component-weekly-terms-copyright-footer'>
+      <Divider />
+      <Text>
+        For full subscription terms and conditions visit{' '}
+        <a
+          href="https://www.theguardian.com/guardian-weekly-subscription-terms-conditions"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          theguardian.com/guardian-weekly-subscription-terms-conditions
+        </a>
+      </Text>
+      <Text>
+        © Guardian News and Media Limited – a member of Guardian Media Group plc.
+        Registered office: Kings Place, 90 York Way, London, N1 9GU. Registered in England No. 908396
+      </Text>
+    </div>
+  );
+}
 
 export default function WeeklyTerms(props: PromotionTermsPropTypes) {
 
@@ -24,27 +55,60 @@ export default function WeeklyTerms(props: PromotionTermsPropTypes) {
   if (includes6For6) {
     return <SixForSix {...props} />;
   }
+  return <StandardTerms {...props} />;
+}
+
+function getCountryPrice(countryGroupName: CountryGroupName, prices: CountryGroupPrices) {
+  const { currency } = fromCountryGroupName(countryGroupName);
+  const currencyGlyph = glyph(currency);
+  const fulfilmentOption = countryGroupName === International ? RestOfWorld : Domestic;
+  const quarterlyPrice = prices[fulfilmentOption][NoProductOptions][Quarterly][currency];
+  const annualPrice = prices[fulfilmentOption][NoProductOptions][Annual][currency];
+  return {
+    currencyGlyph,
+    quarterlyPrice,
+    annualPrice,
+  };
+}
+
+function StandardCountryPrice(countryGroupName: CountryGroupName, prices: CountryGroupPrices) {
+  const { quarterlyPrice, annualPrice } = getCountryPrice(countryGroupName, prices);
+  return (
+    <SansParagraph>
+      <strong>{countryGroupName}:</strong>{' '}
+      Quarterly (13 weeks) subscription rate {showPrice(quarterlyPrice, false)},
+      or annual rate {showPrice(annualPrice, false)}, saving 35% off the cover price.
+    </SansParagraph>
+  );
+}
+
+function SixForSixCountryPrice(countryGroupName, prices: CountryGroupPrices) {
+  const { currencyGlyph, quarterlyPrice } = getCountryPrice(countryGroupName, prices);
+  return (
+    <SansParagraph>
+      <strong>{countryGroupName}:</strong>{' '}
+      Offer is {currencyGlyph}6 for the first 6 issues followed by quarterly (13 weeks)
+      subscription payments of {showPrice(quarterlyPrice, false)} thereafter,
+      saving 35% off the cover price.
+    </SansParagraph>
+  );
+}
+
+function StandardTerms(props: PromotionTermsPropTypes) {
   return (
     <div>
       <SansParagraph>
         Offer subject to availability. Guardian News and Media Limited (&quot;GNM&quot;)
         reserves the right to withdraw this promotion at any time.
       </SansParagraph>
+      <SansParagraph>
+        You must be 18+ to be eligible for a Guardian Weekly subscription.
+      </SansParagraph>
+      {
+        orderedCountryGroupNames.map(name => StandardCountryPrice(name, props.productPrices[name]))
+      }
+      <CopyrightFooter />
     </div>
-  );
-}
-
-function CountryPricing(countryGroupName: CountryGroupName, prices: CountryGroupPrices) {
-  const { currency } = fromCountryGroupName(countryGroupName);
-  const currencyGlyph = glyph(currency);
-  const fulfilmentOption = countryGroupName === International ? RestOfWorld : Domestic;
-  const quarterly = prices[fulfilmentOption][NoProductOptions][Quarterly][currency];
-  return (
-    <SansParagraph>
-      <strong>{countryGroupName}:</strong> Offer is {currencyGlyph}6 for the first 6 issues followed
-      by quarterly (13 weeks) subscription payments of {showPrice(quarterly)} thereafter,
-      saving 35% off the cover price.
-    </SansParagraph>
   );
 }
 
@@ -61,24 +125,9 @@ function SixForSix(props: PromotionTermsPropTypes) {
         Guardian Weekly reserve the right to end this offer at any time.
       </SansParagraph>
       {
-        Object.keys(props.productPrices)
-        .map(name => CountryPricing(name, props.productPrices[name]))
+        orderedCountryGroupNames.map(name => SixForSixCountryPrice(name, props.productPrices[name]))
       }
-      <Divider />
-      <Text>
-        For full subscription terms and conditions visit
-        <a
-          href="https://www.theguardian.com/guardian-weekly-subscription-terms-conditions"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          theguardian.com/guardian-weekly-subscription-terms-conditions
-        </a>
-      </Text>
-      <Text>
-        © Guardian News and Media Limited – a member of Guardian Media Group plc.
-        Registered office: Kings Place, 90 York Way, London, N1 9GU. Registered in England No. 908396
-      </Text>
+      <CopyrightFooter />
     </div>
   );
 }

--- a/support-frontend/assets/pages/promotion-terms/weeklyTerms.jsx
+++ b/support-frontend/assets/pages/promotion-terms/weeklyTerms.jsx
@@ -1,0 +1,84 @@
+// @flow
+
+import React from 'react';
+import Text, { SansParagraph } from 'components/text/text';
+import type { PromotionTermsPropTypes } from 'pages/promotion-terms/promotionTermsReducer';
+import {
+  fromCountryGroupName,
+  International,
+} from 'helpers/internationalisation/countryGroup';
+import { Domestic, RestOfWorld } from 'helpers/productPrice/fulfilmentOptions';
+import { NoProductOptions } from 'helpers/productPrice/productOptions';
+import { Quarterly } from 'helpers/billingPeriods';
+import { glyph } from 'helpers/internationalisation/currency';
+import { showPrice } from 'helpers/productPrice/productPrices';
+import { Divider } from 'components/content/content';
+import type { CountryGroupName } from 'helpers/internationalisation/countryGroup';
+import type { CountryGroupPrices } from 'helpers/productPrice/productPrices';
+
+export default function WeeklyTerms(props: PromotionTermsPropTypes) {
+
+  const includes6For6 = props.promotionTerms.productRatePlans
+    .filter(ratePlan => ratePlan.includes('6 for 6')).length > 0;
+
+  if (includes6For6) {
+    return <SixForSix {...props} />;
+  }
+  return (
+    <div>
+      <SansParagraph>
+        Offer subject to availability. Guardian News and Media Limited (&quot;GNM&quot;)
+        reserves the right to withdraw this promotion at any time.
+      </SansParagraph>
+    </div>
+  );
+}
+
+function CountryPricing(countryGroupName: CountryGroupName, prices: CountryGroupPrices) {
+  const { currency } = fromCountryGroupName(countryGroupName);
+  const currencyGlyph = glyph(currency);
+  const fulfilmentOption = countryGroupName === International ? RestOfWorld : Domestic;
+  const quarterly = prices[fulfilmentOption][NoProductOptions][Quarterly][currency];
+  return (
+    <SansParagraph>
+      <strong>{countryGroupName}:</strong> Offer is {currencyGlyph}6 for the first 6 issues followed
+      by quarterly (13 weeks) subscription payments of {showPrice(quarterly)} thereafter,
+      saving 35% off the cover price.
+    </SansParagraph>
+  );
+}
+
+function SixForSix(props: PromotionTermsPropTypes) {
+  return (
+    <div>
+      <SansParagraph>
+        Offer subject to availability. Guardian News and Media Limited (&quot;GNM&quot;)
+        reserves the right to withdraw this promotion at any time.
+      </SansParagraph>
+      <SansParagraph>
+        Offer not available to current subscribers of Guardian Weekly.
+        You must be 18+ to be eligible for this offer.
+        Guardian Weekly reserve the right to end this offer at any time.
+      </SansParagraph>
+      {
+        Object.keys(props.productPrices)
+        .map(name => CountryPricing(name, props.productPrices[name]))
+      }
+      <Divider />
+      <Text>
+        For full subscription terms and conditions visit
+        <a
+          href="https://www.theguardian.com/guardian-weekly-subscription-terms-conditions"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          theguardian.com/guardian-weekly-subscription-terms-conditions
+        </a>
+      </Text>
+      <Text>
+        © Guardian News and Media Limited – a member of Guardian Media Group plc.
+        Registered office: Kings Place, 90 York Way, London, N1 9GU. Registered in England No. 908396
+      </Text>
+    </div>
+  );
+}

--- a/support-frontend/assets/pages/promotion-terms/weeklyTerms.jsx
+++ b/support-frontend/assets/pages/promotion-terms/weeklyTerms.jsx
@@ -15,6 +15,7 @@ import { showPrice } from 'helpers/productPrice/productPrices';
 import { Divider } from 'components/content/content';
 import type { CountryGroupName } from 'helpers/internationalisation/countryGroup';
 import type { CountryGroupPrices } from 'helpers/productPrice/productPrices';
+import CopyrightText from 'pages/promotion-terms/CopyrightText';
 
 const orderedCountryGroupNames = [
   'United Kingdom',
@@ -25,7 +26,7 @@ const orderedCountryGroupNames = [
   'New Zealand',
   'Canada'];
 
-function CopyrightFooter() {
+function FullTermsLink() {
   return (
     <div className='component-weekly-terms-copyright-footer'>
       <Divider />
@@ -39,10 +40,7 @@ function CopyrightFooter() {
           theguardian.com/guardian-weekly-subscription-terms-conditions
         </a>
       </Text>
-      <Text>
-        © Guardian News and Media Limited – a member of Guardian Media Group plc.
-        Registered office: Kings Place, 90 York Way, London, N1 9GU. Registered in England No. 908396
-      </Text>
+      <CopyrightText />
     </div>
   );
 }
@@ -107,7 +105,7 @@ function StandardTerms(props: PromotionTermsPropTypes) {
       {
         orderedCountryGroupNames.map(name => StandardCountryPrice(name, props.productPrices[name]))
       }
-      <CopyrightFooter />
+      <FullTermsLink />
     </div>
   );
 }
@@ -127,7 +125,7 @@ function SixForSix(props: PromotionTermsPropTypes) {
       {
         orderedCountryGroupNames.map(name => SixForSixCountryPrice(name, props.productPrices[name]))
       }
-      <CopyrightFooter />
+      <FullTermsLink />
     </div>
   );
 }

--- a/support-frontend/conf/routes
+++ b/support-frontend/conf/routes
@@ -140,6 +140,9 @@ GET  /paypal/rest/error                                            controllers.P
 
 POST /direct-debit/check-account                                   controllers.DirectDebit.checkAccount
 
+# ----- Promotions ----- #
+GET /p/:promoCode/terms                                           controllers.Promotions.terms(promoCode)
+
 # ----- Verification ----- #
 
 GET  /.well-known/*file                                            controllers.Assets.at(path="/public", file)

--- a/support-frontend/webpack.common.js
+++ b/support-frontend/webpack.common.js
@@ -90,6 +90,7 @@ module.exports = (cssFilename, outputFilename, minimizeCss) => ({
     error500Page: 'pages/error/error500.jsx',
     unsupportedBrowserStyles: 'stylesheets/fallback-pages/unsupportedBrowser.scss',
     contributionsRedirectStyles: 'stylesheets/fallback-pages/contributionsRedirect.scss',
+    promotionTerms: 'pages/promotion-terms/promotionTerms.jsx',
   },
 
   output: {

--- a/support-models/src/main/scala/com/gu/support/catalog/Product.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/Product.scala
@@ -22,6 +22,8 @@ sealed trait Product {
         prp.productOptions == productOptions
     )
 
+  def getProductRatePlans(environment: TouchPointEnvironment) = ratePlans(environment)
+
   def getProductRatePlanIds(environment: TouchPointEnvironment) = ratePlans(environment).map(_.id)
 
   def supportedCountries(environment: TouchPointEnvironment): List[CountryGroup] =
@@ -34,16 +36,16 @@ case object DigitalPack extends Product {
   lazy val ratePlans: Map[TouchPointEnvironment, List[ProductRatePlan[DigitalPack.type]]] =
     Map(
       PROD -> List(
-        ProductRatePlan("2c92a0fb4edd70c8014edeaa4eae220a", Monthly, NoFulfilmentOptions, NoProductOptions),
-        ProductRatePlan("2c92a0fb4edd70c8014edeaa4e972204", Annual, NoFulfilmentOptions, NoProductOptions),
+        ProductRatePlan("2c92a0fb4edd70c8014edeaa4eae220a", Monthly, NoFulfilmentOptions, NoProductOptions, "Digital Subscription Monthly"),
+        ProductRatePlan("2c92a0fb4edd70c8014edeaa4e972204", Annual, NoFulfilmentOptions, NoProductOptions, "Digital Subscription Annual"),
       ),
       UAT -> List(
-        ProductRatePlan("2c92c0f94f2acf73014f2c908f671591", Monthly, NoFulfilmentOptions, NoProductOptions),
-        ProductRatePlan("2c92c0f84f2ac59d014f2c94aea9199e", Annual, NoFulfilmentOptions, NoProductOptions),
+        ProductRatePlan("2c92c0f94f2acf73014f2c908f671591", Monthly, NoFulfilmentOptions, NoProductOptions, "Digital Subscription Monthly"),
+        ProductRatePlan("2c92c0f84f2ac59d014f2c94aea9199e", Annual, NoFulfilmentOptions, NoProductOptions, "Digital Subscription Annual"),
       ),
       SANDBOX -> List(
-        ProductRatePlan("2c92c0f84bbfec8b014bc655f4852d9d", Monthly, NoFulfilmentOptions, NoProductOptions),
-        ProductRatePlan("2c92c0f94bbffaaa014bc6a4212e205b", Annual, NoFulfilmentOptions, NoProductOptions),
+        ProductRatePlan("2c92c0f84bbfec8b014bc655f4852d9d", Monthly, NoFulfilmentOptions, NoProductOptions, "Digital Subscription Monthly"),
+        ProductRatePlan("2c92c0f94bbffaaa014bc6a4212e205b", Annual, NoFulfilmentOptions, NoProductOptions, "Digital Subscription Annual"),
       ))
 }
 
@@ -51,16 +53,16 @@ case object Contribution extends Product {
   lazy val ratePlans: Map[TouchPointEnvironment, List[ProductRatePlan[Contribution.type]]] =
     Map(
       PROD -> List(
-        ProductRatePlan("2c92a0fb4edd70c8014edeaa4eae220a", Monthly, NoFulfilmentOptions, NoProductOptions),
-        ProductRatePlan("2c92a0fb4edd70c8014edeaa4e972204", Annual, NoFulfilmentOptions, NoProductOptions),
+        ProductRatePlan("2c92a0fb4edd70c8014edeaa4eae220a", Monthly, NoFulfilmentOptions, NoProductOptions, "Monthly Contribution"),
+        ProductRatePlan("2c92a0fb4edd70c8014edeaa4e972204", Annual, NoFulfilmentOptions, NoProductOptions, "Annual Contribution"),
       ),
       UAT -> List(
-        ProductRatePlan("2c92c0f85ab269be015acd9d014549b7", Monthly, NoFulfilmentOptions, NoProductOptions),
-        ProductRatePlan("2c92c0f95e1d5c9c015e38f8c87d19a1", Annual, NoFulfilmentOptions, NoProductOptions),
+        ProductRatePlan("2c92c0f85ab269be015acd9d014549b7", Monthly, NoFulfilmentOptions, NoProductOptions, "Monthly Contribution"),
+        ProductRatePlan("2c92c0f95e1d5c9c015e38f8c87d19a1", Annual, NoFulfilmentOptions, NoProductOptions, "Annual Contribution"),
       ),
       SANDBOX -> List(
-        ProductRatePlan("2c92c0f85a6b134e015a7fcd9f0c7855", Monthly, NoFulfilmentOptions, NoProductOptions),
-        ProductRatePlan("2c92c0f85e2d19af015e3896e824092c", Annual, NoFulfilmentOptions, NoProductOptions),
+        ProductRatePlan("2c92c0f85a6b134e015a7fcd9f0c7855", Monthly, NoFulfilmentOptions, NoProductOptions, "Monthly Contribution"),
+        ProductRatePlan("2c92c0f85e2d19af015e3896e824092c", Annual, NoFulfilmentOptions, NoProductOptions, "Annual Contribution"),
       )
     )
 }
@@ -71,70 +73,70 @@ case object Paper extends Product {
   lazy val ratePlans: Map[TouchPointEnvironment, List[ProductRatePlan[Paper.type]]] =
     Map(
       PROD -> List(
-        ProductRatePlan("2c92a0fd6205707201621fa1350710e3", Monthly, Collection, SaturdayPlus, ukOnly),
-        ProductRatePlan("2c92a0fd6205707201621f9f6d7e0116", Monthly, Collection, Saturday, ukOnly),
-        ProductRatePlan("2c92a0fe56fe33ff0157040d4b824168", Monthly, Collection, SundayPlus, ukOnly),
-        ProductRatePlan("2c92a0fe5af9a6b9015b0fe1ecc0116c", Monthly, Collection, Sunday, ukOnly),
-        ProductRatePlan("2c92a0fd56fe26b60157040cdd323f76", Monthly, Collection, WeekendPlus, ukOnly),
-        ProductRatePlan("2c92a0ff56fe33f00157040f9a537f4b", Monthly, Collection, Weekend, ukOnly),
-        ProductRatePlan("2c92a0fc56fe26ba0157040c5ea17f6a", Monthly, Collection, SixdayPlus, ukOnly),
-        ProductRatePlan("2c92a0fd56fe270b0157040e42e536ef", Monthly, Collection, Sixday, ukOnly),
-        ProductRatePlan("2c92a0ff56fe33f50157040bbdcf3ae4", Monthly, Collection, EverydayPlus, ukOnly),
-        ProductRatePlan("2c92a0fd56fe270b0157040dd79b35da", Monthly, Collection, Everyday, ukOnly),
-        ProductRatePlan("2c92a0ff6205708e01622484bb2c4613", Monthly, HomeDelivery, SaturdayPlus, ukOnly),
-        ProductRatePlan("2c92a0fd5e1dcf0d015e3cb39d0a7ddb", Monthly, HomeDelivery, Saturday, ukOnly),
-        ProductRatePlan("2c92a0fd560d13880156136b8e490f8b", Monthly, HomeDelivery, SundayPlus, ukOnly),
-        ProductRatePlan("2c92a0ff5af9b657015b0fea5b653f81", Monthly, HomeDelivery, Sunday, ukOnly),
-        ProductRatePlan("2c92a0ff560d311b0156136b9f5c3968", Monthly, HomeDelivery, WeekendPlus, ukOnly),
-        ProductRatePlan("2c92a0fd5614305c01561dc88f3275be", Monthly, HomeDelivery, Weekend, ukOnly),
-        ProductRatePlan("2c92a0ff560d311b0156136b697438a9", Monthly, HomeDelivery, SixdayPlus, ukOnly),
-        ProductRatePlan("2c92a0ff560d311b0156136f2afe5315", Monthly, HomeDelivery, Sixday, ukOnly),
-        ProductRatePlan("2c92a0fd560d132301560e43cf041a3c", Monthly, HomeDelivery, EverydayPlus, ukOnly),
-        ProductRatePlan("2c92a0fd560d13880156136b72e50f0c", Monthly, HomeDelivery, Everyday, ukOnly),
+        ProductRatePlan("2c92a0fd6205707201621fa1350710e3", Monthly, Collection, SaturdayPlus, "Saturday paper plus the Digital Subscription", ukOnly),
+        ProductRatePlan("2c92a0fd6205707201621f9f6d7e0116", Monthly, Collection, Saturday, "Saturday paper", ukOnly),
+        ProductRatePlan("2c92a0fe56fe33ff0157040d4b824168", Monthly, Collection, SundayPlus, "Sunday paper plus the Digital Subscription", ukOnly),
+        ProductRatePlan("2c92a0fe5af9a6b9015b0fe1ecc0116c", Monthly, Collection, Sunday, "Sunday paper", ukOnly),
+        ProductRatePlan("2c92a0fd56fe26b60157040cdd323f76", Monthly, Collection, WeekendPlus, "Saturday Guardian and Observer papers plus the Digital Subscription", ukOnly),
+        ProductRatePlan("2c92a0ff56fe33f00157040f9a537f4b", Monthly, Collection, Weekend, "Saturday Guardian and Observer papers", ukOnly),
+        ProductRatePlan("2c92a0fc56fe26ba0157040c5ea17f6a", Monthly, Collection, SixdayPlus, "Guardian papers plus the Digital Subscription", ukOnly),
+        ProductRatePlan("2c92a0fd56fe270b0157040e42e536ef", Monthly, Collection, Sixday, "Guardian papers", ukOnly),
+        ProductRatePlan("2c92a0ff56fe33f50157040bbdcf3ae4", Monthly, Collection, EverydayPlus, "Guardian papers plus the Digital Subscription", ukOnly),
+        ProductRatePlan("2c92a0fd56fe270b0157040dd79b35da", Monthly, Collection, Everyday, "Guardian papers", ukOnly),
+        ProductRatePlan("2c92a0ff6205708e01622484bb2c4613", Monthly, HomeDelivery, SaturdayPlus, "Saturday paper delivered plus the Digital Subscription", ukOnly),
+        ProductRatePlan("2c92a0fd5e1dcf0d015e3cb39d0a7ddb", Monthly, HomeDelivery, Saturday, "Saturday paper delivered", ukOnly),
+        ProductRatePlan("2c92a0fd560d13880156136b8e490f8b", Monthly, HomeDelivery, SundayPlus, "Sunday paper delivered plus the Digital Subscription", ukOnly),
+        ProductRatePlan("2c92a0ff5af9b657015b0fea5b653f81", Monthly, HomeDelivery, Sunday, "Sunday paper delivered", ukOnly),
+        ProductRatePlan("2c92a0ff560d311b0156136b9f5c3968", Monthly, HomeDelivery, WeekendPlus, "Saturday Guardian and Observer papers delivered plus the Digital Subscription", ukOnly),
+        ProductRatePlan("2c92a0fd5614305c01561dc88f3275be", Monthly, HomeDelivery, Weekend, "Saturday Guardian and Observer papers delivered", ukOnly),
+        ProductRatePlan("2c92a0ff560d311b0156136b697438a9", Monthly, HomeDelivery, SixdayPlus, "Guardian papers delivered plus the Digital Subscription", ukOnly),
+        ProductRatePlan("2c92a0ff560d311b0156136f2afe5315", Monthly, HomeDelivery, Sixday, "Guardian papers delivered", ukOnly),
+        ProductRatePlan("2c92a0fd560d132301560e43cf041a3c", Monthly, HomeDelivery, EverydayPlus, "Guardian papers delivered plus the Digital Subscription", ukOnly),
+        ProductRatePlan("2c92a0fd560d13880156136b72e50f0c", Monthly, HomeDelivery, Everyday, "Guardian papers delivered", ukOnly),
       ),
       UAT -> List(
-        ProductRatePlan("2c92c0f961f9cf350161fc0454283f3e", Monthly, Collection, SaturdayPlus, ukOnly),
-        ProductRatePlan("2c92c0f961f9cf300161fc02a7d805c9", Monthly, Collection, Saturday, ukOnly),
-        ProductRatePlan("2c92c0f858aa38af0158b9dae19110a3", Monthly, Collection, SundayPlus, ukOnly),
-        ProductRatePlan("2c92c0f95aff3b54015b0ee0eb500b2e", Monthly, Collection, Sunday, ukOnly),
-        ProductRatePlan("2c92c0f855c9f4b20155d9f1dd0651ab", Monthly, Collection, WeekendPlus, ukOnly),
-        ProductRatePlan("2c92c0f855c9f4b20155d9f1db9b5199", Monthly, Collection, Weekend, ukOnly),
-        ProductRatePlan("2c92c0f855c9f4540155da2607db6402", Monthly, Collection, SixdayPlus, ukOnly),
-        ProductRatePlan("2c92c0f955ca02910155da254a641fb3", Monthly, Collection, Sixday, ukOnly),
-        ProductRatePlan("2c92c0f955ca02920155da240cdb4399", Monthly, Collection, EverydayPlus, ukOnly),
-        ProductRatePlan("2c92c0f855c9f4b20155d9f1d3d4512a", Monthly, Collection, Everyday, ukOnly),
-        ProductRatePlan("2c92c0f961f9cf300161fbfa943b6f54", Monthly, HomeDelivery, SaturdayPlus, ukOnly),
-        ProductRatePlan("2c92c0f85b8fa30e015b9108a83253c7", Monthly, HomeDelivery, Saturday, ukOnly),
-        ProductRatePlan("2c92c0f955ca02900155da27f4872d4d", Monthly, HomeDelivery, SundayPlus, ukOnly),
-        ProductRatePlan("2c92c0f95aff3b54015b0ede33bc04f2", Monthly, HomeDelivery, Sunday, ukOnly),
-        ProductRatePlan("2c92c0f955ca02900155da27f9402dad", Monthly, HomeDelivery, WeekendPlus, ukOnly),
-        ProductRatePlan("2c92c0f955ca02900155da27f83c2d9b", Monthly, HomeDelivery, Weekend, ukOnly),
-        ProductRatePlan("2c92c0f955ca02900155da27f29e2d13", Monthly, HomeDelivery, SixdayPlus, ukOnly),
-        ProductRatePlan("2c92c0f955ca02900155da27ff142e01", Monthly, HomeDelivery, Sixday, ukOnly),
-        ProductRatePlan("2c92c0f955ca02900155da2803b02e33", Monthly, HomeDelivery, EverydayPlus, ukOnly),
-        ProductRatePlan("2c92c0f955ca02900155da27f55b2d5f", Monthly, HomeDelivery, Everyday, ukOnly),
+        ProductRatePlan("2c92c0f961f9cf350161fc0454283f3e", Monthly, Collection, SaturdayPlus, "Saturday paper plus the Digital Subscription", ukOnly),
+        ProductRatePlan("2c92c0f961f9cf300161fc02a7d805c9", Monthly, Collection, Saturday, "Saturday paper", ukOnly),
+        ProductRatePlan("2c92c0f858aa38af0158b9dae19110a3", Monthly, Collection, SundayPlus, "Sunday paper plus the Digital Subscription", ukOnly),
+        ProductRatePlan("2c92c0f95aff3b54015b0ee0eb500b2e", Monthly, Collection, Sunday, "Sunday paper", ukOnly),
+        ProductRatePlan("2c92c0f855c9f4b20155d9f1dd0651ab", Monthly, Collection, WeekendPlus, "Saturday Guardian and Observer papers plus the Digital Subscription", ukOnly),
+        ProductRatePlan("2c92c0f855c9f4b20155d9f1db9b5199", Monthly, Collection, Weekend, "Saturday Guardian and Observer papers", ukOnly),
+        ProductRatePlan("2c92c0f855c9f4540155da2607db6402", Monthly, Collection, SixdayPlus, "Guardian papers plus the Digital Subscription", ukOnly),
+        ProductRatePlan("2c92c0f955ca02910155da254a641fb3", Monthly, Collection, Sixday, "Guardian papers", ukOnly),
+        ProductRatePlan("2c92c0f955ca02920155da240cdb4399", Monthly, Collection, EverydayPlus, "Guardian papers plus the Digital Subscription", ukOnly),
+        ProductRatePlan("2c92c0f855c9f4b20155d9f1d3d4512a", Monthly, Collection, Everyday, "Guardian papers", ukOnly),
+        ProductRatePlan("2c92c0f961f9cf300161fbfa943b6f54", Monthly, HomeDelivery, SaturdayPlus, "Saturday paper delivered plus the Digital Subscription", ukOnly),
+        ProductRatePlan("2c92c0f85b8fa30e015b9108a83253c7", Monthly, HomeDelivery, Saturday, "Saturday paper delivered", ukOnly),
+        ProductRatePlan("2c92c0f955ca02900155da27f4872d4d", Monthly, HomeDelivery, SundayPlus, "Sunday paper delivered plus the Digital Subscription", ukOnly),
+        ProductRatePlan("2c92c0f95aff3b54015b0ede33bc04f2", Monthly, HomeDelivery, Sunday, "Sunday paper delivered", ukOnly),
+        ProductRatePlan("2c92c0f955ca02900155da27f9402dad", Monthly, HomeDelivery, WeekendPlus, "Saturday Guardian and Observer papers delivered plus the Digital Subscription", ukOnly),
+        ProductRatePlan("2c92c0f955ca02900155da27f83c2d9b", Monthly, HomeDelivery, Weekend, "Saturday Guardian and Observer papers delivered", ukOnly),
+        ProductRatePlan("2c92c0f955ca02900155da27f29e2d13", Monthly, HomeDelivery, SixdayPlus, "Guardian papers delivered plus the Digital Subscription", ukOnly),
+        ProductRatePlan("2c92c0f955ca02900155da27ff142e01", Monthly, HomeDelivery, Sixday, "Guardian papers delivered", ukOnly),
+        ProductRatePlan("2c92c0f955ca02900155da2803b02e33", Monthly, HomeDelivery, EverydayPlus, "Guardian papers delivered plus the Digital Subscription", ukOnly),
+        ProductRatePlan("2c92c0f955ca02900155da27f55b2d5f", Monthly, HomeDelivery, Everyday, "Guardian papers delivered", ukOnly),
       ),
       SANDBOX -> List(
-        ProductRatePlan("2c92c0f961f9cf300161fc44f2661258", Monthly, Collection, SaturdayPlus, ukOnly),
-        ProductRatePlan("2c92c0f861f9c26d0161fc434bfe004c", Monthly, Collection, Saturday, ukOnly),
-        ProductRatePlan("2c92c0f955a0b5bf0155b62623846fc8", Monthly, Collection, SundayPlus, ukOnly),
-        ProductRatePlan("2c92c0f95aff3b56015b1045fb9332d2", Monthly, Collection, Sunday, ukOnly),
-        ProductRatePlan("2c92c0f95aff3b54015b1047efaa2ac3", Monthly, Collection, WeekendPlus, ukOnly),
-        ProductRatePlan("2c92c0f8555ce5cf01556e7f01b81b94", Monthly, Collection, Weekend, ukOnly),
-        ProductRatePlan("2c92c0f855c3b8190155c585a95e6f5a", Monthly, Collection, SixdayPlus, ukOnly),
-        ProductRatePlan("2c92c0f8555ce5cf01556e7f01771b8a", Monthly, Collection, Sixday, ukOnly),
-        ProductRatePlan("2c92c0f95aff3b53015b10469bbf5f5f", Monthly, Collection, EverydayPlus, ukOnly),
-        ProductRatePlan("2c92c0f9555cf10501556e84a70440e2", Monthly, Collection, Everyday, ukOnly),
-        ProductRatePlan("2c92c0f961f9cf300161fc4f71473a34", Monthly, HomeDelivery, SaturdayPlus, ukOnly),
-        ProductRatePlan("2c92c0f961f9cf300161fc4d2e3e3664", Monthly, HomeDelivery, Saturday, ukOnly),
-        ProductRatePlan("2c92c0f955c3cf0f0155c5d9e83a3cb7", Monthly, HomeDelivery, SundayPlus, ukOnly),
-        ProductRatePlan("2c92c0f85aff3453015b1041dfd2317f", Monthly, HomeDelivery, Sunday, ukOnly),
-        ProductRatePlan("2c92c0f95aff3b56015b104aa9a13ea5", Monthly, HomeDelivery, WeekendPlus, ukOnly),
-        ProductRatePlan("2c92c0f955c3cf0f0155c5d9df433bf7", Monthly, HomeDelivery, Weekend, ukOnly),
-        ProductRatePlan("2c92c0f85aff33ff015b1042d4ba0a05", Monthly, HomeDelivery, SixdayPlus, ukOnly),
-        ProductRatePlan("2c92c0f955c3cf0f0155c5d9ddf13bc5", Monthly, HomeDelivery, Sixday, ukOnly),
-        ProductRatePlan("2c92c0f85aff3453015b10496b5e3d17", Monthly, HomeDelivery, EverydayPlus, ukOnly),
-        ProductRatePlan("2c92c0f955c3cf0f0155c5d9e2493c43", Monthly, HomeDelivery, Everyday, ukOnly),
+        ProductRatePlan("2c92c0f961f9cf300161fc44f2661258", Monthly, Collection, SaturdayPlus, "Saturday paper plus the Digital Subscription", ukOnly),
+        ProductRatePlan("2c92c0f861f9c26d0161fc434bfe004c", Monthly, Collection, Saturday, "Saturday paper", ukOnly),
+        ProductRatePlan("2c92c0f955a0b5bf0155b62623846fc8", Monthly, Collection, SundayPlus, "Sunday paper plus the Digital Subscription", ukOnly),
+        ProductRatePlan("2c92c0f95aff3b56015b1045fb9332d2", Monthly, Collection, Sunday, "Sunday paper", ukOnly),
+        ProductRatePlan("2c92c0f95aff3b54015b1047efaa2ac3", Monthly, Collection, WeekendPlus, "Saturday Guardian and Observer papers plus the Digital Subscription", ukOnly),
+        ProductRatePlan("2c92c0f8555ce5cf01556e7f01b81b94", Monthly, Collection, Weekend, "Saturday Guardian and Observer papers", ukOnly),
+        ProductRatePlan("2c92c0f855c3b8190155c585a95e6f5a", Monthly, Collection, SixdayPlus, "Guardian papers plus the Digital Subscription", ukOnly),
+        ProductRatePlan("2c92c0f8555ce5cf01556e7f01771b8a", Monthly, Collection, Sixday, "Guardian papers", ukOnly),
+        ProductRatePlan("2c92c0f95aff3b53015b10469bbf5f5f", Monthly, Collection, EverydayPlus, "Guardian papers plus the Digital Subscription", ukOnly),
+        ProductRatePlan("2c92c0f9555cf10501556e84a70440e2", Monthly, Collection, Everyday, "Guardian papers", ukOnly),
+        ProductRatePlan("2c92c0f961f9cf300161fc4f71473a34", Monthly, HomeDelivery, SaturdayPlus, "Saturday paper delivered plus the Digital Subscription", ukOnly),
+        ProductRatePlan("2c92c0f961f9cf300161fc4d2e3e3664", Monthly, HomeDelivery, Saturday, "Saturday paper delivered", ukOnly),
+        ProductRatePlan("2c92c0f955c3cf0f0155c5d9e83a3cb7", Monthly, HomeDelivery, SundayPlus, "Sunday paper delivered plus the Digital Subscription", ukOnly),
+        ProductRatePlan("2c92c0f85aff3453015b1041dfd2317f", Monthly, HomeDelivery, Sunday, "Sunday paper delivered", ukOnly),
+        ProductRatePlan("2c92c0f95aff3b56015b104aa9a13ea5", Monthly, HomeDelivery, WeekendPlus, "Saturday Guardian and Observer papers delivered plus the Digital Subscription", ukOnly),
+        ProductRatePlan("2c92c0f955c3cf0f0155c5d9df433bf7", Monthly, HomeDelivery, Weekend, "Saturday Guardian and Observer papers delivered", ukOnly),
+        ProductRatePlan("2c92c0f85aff33ff015b1042d4ba0a05", Monthly, HomeDelivery, SixdayPlus, "Guardian papers delivered plus the Digital Subscription", ukOnly),
+        ProductRatePlan("2c92c0f955c3cf0f0155c5d9ddf13bc5", Monthly, HomeDelivery, Sixday, "Guardian papers delivered", ukOnly),
+        ProductRatePlan("2c92c0f85aff3453015b10496b5e3d17", Monthly, HomeDelivery, EverydayPlus, "Guardian papers delivered plus the Digital Subscription", ukOnly),
+        ProductRatePlan("2c92c0f955c3cf0f0155c5d9e2493c43", Monthly, HomeDelivery, Everyday, "Guardian papers delivered", ukOnly),
       )
     )
 }
@@ -147,35 +149,35 @@ case object GuardianWeekly extends Product {
   lazy val ratePlans: Map[TouchPointEnvironment, List[ProductRatePlan[GuardianWeekly.type]]] =
     Map(
       PROD -> List(
-        ProductRatePlan("2c92a0086619bf8901661ab545f51b21", SixWeekly, RestOfWorld, NoProductOptions,
+        ProductRatePlan("2c92a0086619bf8901661ab545f51b21", SixWeekly, RestOfWorld, NoProductOptions, "Guardian Weekly 6 for 6, rest of world delivery",
           productRatePlanChargeId = Some("2c92a0086619bf8901661ab546091b23")),
-        ProductRatePlan("2c92a0fe6619b4b601661ab300222651", Annual, RestOfWorld, NoProductOptions),
-        ProductRatePlan("2c92a0086619bf8901661ab02752722f", Quarterly, RestOfWorld, NoProductOptions),
-        ProductRatePlan("2c92a0086619bf8901661aaac94257fe", SixWeekly, Domestic, NoProductOptions,
+        ProductRatePlan("2c92a0fe6619b4b601661ab300222651", Annual, RestOfWorld, NoProductOptions, "Guardian Weekly annual, rest of world delivery"),
+        ProductRatePlan("2c92a0086619bf8901661ab02752722f", Quarterly, RestOfWorld, NoProductOptions, "Guardian Weekly quarterly, rest of world delivery"),
+        ProductRatePlan("2c92a0086619bf8901661aaac94257fe", SixWeekly, Domestic, NoProductOptions, "Guardian Weekly 6 for 6, domestic delivery",
           productRatePlanChargeId = Some("2c92a0086619bf8901661aaac95d5800")
         ),
-        ProductRatePlan("2c92a0fe6619b4b901661aa8e66c1692", Annual, Domestic, NoProductOptions),
-        ProductRatePlan("2c92a0fe6619b4b301661aa494392ee2", Quarterly, Domestic, NoProductOptions),
+        ProductRatePlan("2c92a0fe6619b4b901661aa8e66c1692", Annual, Domestic, NoProductOptions, "Guardian Weekly annual, domestic delivery"),
+        ProductRatePlan("2c92a0fe6619b4b301661aa494392ee2", Quarterly, Domestic, NoProductOptions, "Guardian Weekly quarterly, rest of world delivery")
       ),
       UAT -> List(
-          ProductRatePlan("2c92c0f9660fc4c70166109dfd08092c", SixWeekly, RestOfWorld, NoProductOptions,
+          ProductRatePlan("2c92c0f9660fc4c70166109dfd08092c", SixWeekly, RestOfWorld, NoProductOptions, "Guardian Weekly 6 for 6, rest of world delivery",
             productRatePlanChargeId = Some("2c92c0f9660fc4c70166109dfd17092e")),
-          ProductRatePlan("2c92c0f9660fc4d70166109a2eb0607c", Annual, RestOfWorld, NoProductOptions),
-          ProductRatePlan("2c92c0f9660fc4d70166109c01465f10", Quarterly, RestOfWorld, NoProductOptions),
-          ProductRatePlan("2c92c0f8660fb5dd016610858eb90658", SixWeekly, Domestic, NoProductOptions,
+          ProductRatePlan("2c92c0f9660fc4d70166109a2eb0607c", Annual, RestOfWorld, NoProductOptions, "Guardian Weekly annual, rest of world delivery"),
+          ProductRatePlan("2c92c0f9660fc4d70166109c01465f10", Quarterly, RestOfWorld, NoProductOptions, "Guardian Weekly quarterly, rest of world delivery"),
+          ProductRatePlan("2c92c0f8660fb5dd016610858eb90658", SixWeekly, Domestic, NoProductOptions, "Guardian Weekly 6 for 6, domestic delivery",
             productRatePlanChargeId = Some("2c92c0f8660fb5dd016610858ed3065a")),
-          ProductRatePlan("2c92c0f9660fc4d70166107fa5412641", Annual, Domestic, NoProductOptions),
-          ProductRatePlan("2c92c0f8660fb5d601661081ea010391", Quarterly, Domestic, NoProductOptions),
+          ProductRatePlan("2c92c0f9660fc4d70166107fa5412641", Annual, Domestic, NoProductOptions, "Guardian Weekly annual, domestic delivery"),
+          ProductRatePlan("2c92c0f8660fb5d601661081ea010391", Quarterly, Domestic, NoProductOptions, "Guardian Weekly quarterly, rest of world delivery")
         ),
       SANDBOX -> List(
-        ProductRatePlan("2c92c0f965f2122101660fbc75a16c38", SixWeekly, RestOfWorld, NoProductOptions,
+        ProductRatePlan("2c92c0f965f2122101660fbc75a16c38", SixWeekly, RestOfWorld, NoProductOptions, "Guardian Weekly 6 for 6, rest of world delivery",
           productRatePlanChargeId = Some("2c92c0f965f2122101660fbc75ba6c3c")),
-        ProductRatePlan("2c92c0f965f2122101660fb33ed24a45", Annual, RestOfWorld, NoProductOptions),
-        ProductRatePlan("2c92c0f965f2122101660fb81b745a06", Quarterly, RestOfWorld, NoProductOptions),
-        ProductRatePlan("2c92c0f965f212210165f69b94c92d66", SixWeekly, Domestic, NoProductOptions,
+        ProductRatePlan("2c92c0f965f2122101660fb33ed24a45", Annual, RestOfWorld, NoProductOptions, "Guardian Weekly annual, rest of world delivery"),
+        ProductRatePlan("2c92c0f965f2122101660fb81b745a06", Quarterly, RestOfWorld, NoProductOptions, "Guardian Weekly quarterly, rest of world delivery"),
+        ProductRatePlan("2c92c0f965f212210165f69b94c92d66", SixWeekly, Domestic, NoProductOptions, "Guardian Weekly 6 for 6, domestic delivery",
           productRatePlanChargeId = Some("2c92c0f865f204440165f69f407d66f1")),
-        ProductRatePlan("2c92c0f965d280590165f16b1b9946c2", Annual, Domestic, NoProductOptions),
-        ProductRatePlan("2c92c0f965dc30640165f150c0956859", Quarterly, Domestic, NoProductOptions),
+        ProductRatePlan("2c92c0f965d280590165f16b1b9946c2", Annual, Domestic, NoProductOptions, "Guardian Weekly annual, domestic delivery"),
+        ProductRatePlan("2c92c0f965dc30640165f150c0956859", Quarterly, Domestic, NoProductOptions, "Guardian Weekly quarterly, rest of world delivery"),
       )
     )
 }

--- a/support-models/src/main/scala/com/gu/support/catalog/ProductRatePlan.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/ProductRatePlan.scala
@@ -8,6 +8,7 @@ case class ProductRatePlan[+T <: Product](
   billingPeriod: BillingPeriod,
   fulfilmentOptions: FulfilmentOptions,
   productOptions: ProductOptions,
+  description: String,
   supportedTerritories: List[CountryGroup] = CountryGroup.allGroups,
   // productRatePlanChargeId is only needed for GW 6 for 6. If we implemented 6 for 6 in the same way as
   // we do discounts we wouldn't need this and we would be able to apply 6 for 6 to other products

--- a/support-services/src/main/scala/com/gu/support/pricing/PriceSummary.scala
+++ b/support-services/src/main/scala/com/gu/support/pricing/PriceSummary.scala
@@ -19,7 +19,7 @@ case class PromotionSummary(
   discount: Option[DiscountBenefit],
   freeTrialBenefit: Option[FreeTrialBenefit],
   incentive: Option[IncentiveBenefit] = None,
-  introductoryPrice: Option[IntroductoryPriceBenefit] = None
+  introductoryPrice: Option[IntroductoryPriceBenefit] = None,
 )
 
 import com.gu.support.encoding.Codec

--- a/support-services/src/main/scala/com/gu/support/promotions/PromotionTerms.scala
+++ b/support-services/src/main/scala/com/gu/support/promotions/PromotionTerms.scala
@@ -5,7 +5,14 @@ import com.gu.support.config.{Stage, TouchPointEnvironments}
 import com.gu.support.encoding.Codec
 import org.joda.time.DateTime
 
-case class PromotionTerms(promoCode: PromoCode, description: String, expires: Option[DateTime], product: Product, productRatePlans: List[String])
+case class PromotionTerms(
+  promoCode: PromoCode,
+  description: String,
+  starts: DateTime,
+  expires: Option[DateTime],
+  product: Product,
+  productRatePlans: List[String]
+)
 
 object PromotionTerms {
 
@@ -35,6 +42,7 @@ object PromotionTerms {
     PromotionTerms(
       promotion.promoCode,
       promotion.promotion.description,
+      promotion.promotion.starts,
       promotion.promotion.expires,
       product,
       productRatePlans

--- a/support-services/src/main/scala/com/gu/support/promotions/PromotionTerms.scala
+++ b/support-services/src/main/scala/com/gu/support/promotions/PromotionTerms.scala
@@ -1,0 +1,41 @@
+package com.gu.support.promotions
+
+import com.gu.support.catalog.{DigitalPack, Product}
+import com.gu.support.config.{Stage, TouchPointEnvironments}
+import com.gu.support.encoding.Codec
+import org.joda.time.DateTime
+
+case class PromotionTerms(promoCode: PromoCode, description: String, expires: Option[DateTime], product: Product, productRatePlans: List[String])
+
+object PromotionTerms {
+
+  import com.gu.support.encoding.CustomCodecs.{encodeDateTime, decodeDateTime}
+
+  implicit val codec: Codec[PromotionTerms] = Codec.deriveCodec
+
+  def fromPromoCode(promotionService: PromotionService, stage: Stage, promoCode: PromoCode): Option[PromotionTerms] = {
+    promotionService.findPromotion(promoCode).map { promotion =>
+      val environment = TouchPointEnvironments.fromStage(stage)
+      val includedProductRatePlanIds = promotion.promotion.appliesTo.productRatePlanIds
+
+      val product = Product.allProducts.find (_
+        .getProductRatePlanIds(environment).toSet
+        .intersect(includedProductRatePlanIds)
+        .nonEmpty
+      ).getOrElse(DigitalPack)
+
+      val productRatePlans = product
+        .getProductRatePlans(environment)
+        .filter(productRatePlan => includedProductRatePlanIds.contains(productRatePlan.id))
+        .map(_.description)
+
+      PromotionTerms(
+        promoCode,
+        promotion.promotion.description,
+        promotion.promotion.expires,
+        product,
+        productRatePlans
+      )
+    }
+  }
+}

--- a/support-services/src/test/scala/com/gu/support/pricing/PriceSummaryServiceSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/pricing/PriceSummaryServiceSpec.scala
@@ -36,7 +36,7 @@ class PriceSummaryServiceSpec extends FlatSpec with Matchers {
     val guardianWeekly = service.getPrices(GuardianWeekly, List(discountPromoCode, GuardianWeekly.AnnualPromoCode, GuardianWeekly.SixForSixPromoCode))
 
     //Quarterly should have the 6 for 6 introductory promotion
-    guardianWeekly(UK)(Domestic)(NoProductOptions)(Quarterly)(GBP).promotions.size shouldBe 2
+    guardianWeekly(UK)(Domestic)(NoProductOptions)(Quarterly)(GBP).promotions.size shouldBe 3
 
     guardianWeekly(UK)(Domestic)(NoProductOptions)(Quarterly)(GBP).price shouldBe 37.50
     guardianWeekly(UK)(Domestic)(NoProductOptions)(Quarterly)(GBP).promotions

--- a/support-services/src/test/scala/com/gu/support/promotions/PromotionTermsSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/promotions/PromotionTermsSpec.scala
@@ -1,0 +1,14 @@
+package com.gu.support.promotions
+
+import com.gu.support.catalog.GuardianWeekly
+import com.gu.support.config.Stages.PROD
+import com.gu.support.promotions.ServicesFixtures.guardianWeeklyAnnual
+import org.scalatest.{FlatSpec, Matchers}
+
+class PromotionTermsSpec extends FlatSpec with Matchers {
+  "PromotionTerms object" should "be able to extract the promotion terms from a Promotion" in {
+    val promotionTerms = PromotionTerms
+      .promotionTermsFromPromotion(PROD)(PromotionWithCode(GuardianWeekly.AnnualPromoCode, guardianWeeklyAnnual))
+    promotionTerms.productRatePlans.length shouldBe (6)
+  }
+}

--- a/support-services/src/test/scala/com/gu/support/promotions/ServicesFixtures.scala
+++ b/support-services/src/test/scala/com/gu/support/promotions/ServicesFixtures.scala
@@ -37,9 +37,7 @@ object ServicesFixtures {
   val tracking = PromotionWithCode(trackingPromoCode, promotion(validProductRatePlanIds, trackingPromoCode, tracking = true))
   val renewal = PromotionWithCode(renewalPromoCode, promotion(validProductRatePlanIds, renewalPromoCode, discountBenefit, renewal = true))
   val guardianWeeklyAnnual = promotion(
-    GuardianWeekly
-      .getProductRatePlan(TouchPointEnvironments.PROD, Annual, Domestic, NoProductOptions)
-      .map(p => List(p.id)).getOrElse(List()),
+    GuardianWeekly.getProductRatePlanIds(TouchPointEnvironments.PROD),
     GuardianWeekly.AnnualPromoCode,
     Some(DiscountBenefit(10, Some(Months.TWELVE)))
   )


### PR DESCRIPTION
## Why are you doing this?

This PR moves the promo code terms page from subscribe.theguardian.com to support.

There are 4 different types of content, one for each of Paper and Digital Pack, and two for Guardian Weekly - 6 for 6 & non 6 for 6

Screenshots of the new and old screens are below:


## Newspaper
**old**
![sub thegulocal com_p_SEP2512VHD_terms](https://user-images.githubusercontent.com/181371/67109185-dffa0080-f1c7-11e9-8fa4-c8cbe1c153c0.png)
**new**
![support thegulocal com_p_SEP2512VHD_terms](https://user-images.githubusercontent.com/181371/67107972-64974f80-f1c5-11e9-876f-4ec47c7075ef.png)
## Digital Subscription
**old**
![sub thegulocal com_p_DK0NT24WG_terms](https://user-images.githubusercontent.com/181371/67109109-ba6cf700-f1c7-11e9-8ba0-6e77d5a746c7.png)
**new**
![support thegulocal com_p_DK0NT24WG_terms](https://user-images.githubusercontent.com/181371/67107974-64974f80-f1c5-11e9-90e8-1c71f9ee1ebb.png)
## Guardian Weekly (non 6 for 6)
**old**
![sub thegulocal com_p_WJWGEX9A8_terms](https://user-images.githubusercontent.com/181371/67108911-59452380-f1c7-11e9-90d8-8e0c984260a1.png)
**new**
![support thegulocal com_p_WJWGEX9A8_terms](https://user-images.githubusercontent.com/181371/67107978-64974f80-f1c5-11e9-8c04-a8243c71e2dd.png)
## Guardian Weekly (6 for 6)
**old**
![sub thegulocal com_p_WJWGEX9A8_terms (1)](https://user-images.githubusercontent.com/181371/67108850-45012680-f1c7-11e9-9813-509b1e5a899b.png)
**new**
![support thegulocal com_p_WJWGEX9A8_terms (1)](https://user-images.githubusercontent.com/181371/67108052-901a3a00-f1c5-11e9-87e6-0be61e44d789.png)


[**Trello Card**](https://trello.com/c/MIye64M1/2692-promotion-terms-page)

