### PR TITLE
Design tweaks for digital subs landing page

### DIFF
--- a/support-frontend/assets/components/content/content.scss
+++ b/support-frontend/assets/components/content/content.scss
@@ -129,18 +129,25 @@
     }
 
     @include mq($from: tablet) {
-      padding-left: 45px;
+      padding-left: 30px;
     }
   
     @include mq($from: desktop) {
       max-width: gu-span(8);
       padding-left: 70px;
     }
+
+    @include mq($from: leftCol) {
+      padding-left: 90px;
+    }
   
     @include mq($from: wide) {
-      padding-left: 0px;
+      padding-left: 20px;
       max-width: 1170px;
-      margin-left: -10px;
+    }
+
+    @include mq($from: 1396px) {
+      padding-left: 50px;
     }
   
     .component-content__content--centered-handler {

--- a/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLanding.scss
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLanding.scss
@@ -1082,16 +1082,16 @@ div.call-to-action__container {
 
     @include mq($from: desktop) {
       padding-left: 0px;
-      margin-left: -5px;
+      margin-left: 20px;
     }
 
     @include mq($from: leftCol) {
-      padding-left: 10px;
+      padding-left: 25px;
       margin-left: 0;
     }
 
     @include mq($from: wide) {
-      padding-left: 0px;
+      padding-left: 25px;
     }
   }
 

--- a/support-frontend/assets/pages/digital-subscription-landing/components/productBlock.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/productBlock.jsx
@@ -40,7 +40,11 @@ type DropdownPropTypes = {
 const Dropdown = ({
   children, showDropDown, product,
 }: DropdownPropTypes) => (
-  <div id={`product-details-${product}`} className={`product-block__dropdown${showDropDown ? '--show' : '--hide'}`}>
+  <div
+    id={`product-details-${product}`}
+    className={`product-block__dropdown${showDropDown ? '--show' : '--hide'}`}
+    aria-hidden={showDropDown ? 'false' : 'true'}
+  >
     <span className="product-block__ul-handler">
       {children}
     </span>

--- a/support-frontend/assets/pages/digital-subscription-landing/components/productBlock.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/productBlock.jsx
@@ -3,6 +3,7 @@ import React, { Component, type Node } from 'react';
 import AdFreeSectionC from 'components/adFreeSectionC/adFreeSectionC';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
 import GridPicture from 'components/gridPicture/gridPicture';
+import cx from 'classnames';
 
 // styles
 import './digitalSubscriptionLanding.scss';
@@ -42,7 +43,7 @@ const Dropdown = ({
 }: DropdownPropTypes) => (
   <div
     id={`product-details-${product}`}
-    className={`product-block__dropdown${showDropDown ? '--show' : '--hide'}`}
+    className={cx('product-block__dropdown--hide', { 'product-block__dropdown--show': showDropDown })}
     aria-hidden={showDropDown ? 'false' : 'true'}
   >
     <span className="product-block__ul-handler">
@@ -64,7 +65,7 @@ const Button = ({
     aria-controls={`product-details-${product}`}
     aria-expanded={showDropDown ? 'true' : 'false'}
     onClick={handleClick}
-    className={`product-block__button${showDropDown ? '--show' : '--hide'}`}
+    className={cx('product-block__button--hide', { 'product-block__button--show': showDropDown })}
   >
     <span className="product-block__button__text">
       <div className={showDropDown ? 'product-block__arrow--up' : 'product-block__arrow--down'}>{arrowSvg}</div>


### PR DESCRIPTION
## Why are you doing this?
To fix some wonky alignment in the relaunched digital subs page.

[**Trello Card**](https://trello.com/c/gE2y7vNm/2686-design-tweaks-to-new-product-page)

## Changes
* Update left padding in the terms section at wider breakpoints
* Update left padding in faqs
* Add aria-hidden attribute to dropdown panels