### PR TITLE
Digital subs landing page browserstack testing

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLanding.scss
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLanding.scss
@@ -893,8 +893,6 @@ div.call-to-action__container {
   display: flex;
   padding: 10px 0 50px 10px;
   background-color: #041f4a;
-  max-width: calc(100%-10px);
-  width: calc(100%-10px);
 
   @include mq($from: mobileLandscape) {
     padding-left: 0px;


### PR DESCRIPTION
## Why are you doing this?
These are small changes to address issues found in browserstack testing for the relaunched digital subscriptions landing page.

[**Trello Card**](https://trello.com/c/cUBIYyVf/2688-dp-page-test-plan)

## Changes
Removed the 100% - 10px calculation for the call to action section of the page.

## Screenshots
![Screen Shot 2019-10-21 at 15 24 22](https://user-images.githubusercontent.com/16781258/67214667-08783980-f418-11e9-9705-a5884894b9cc.png)
