### PR TITLE
Update sharing tags for daily and app relaunch

### DIFF
--- a/support-frontend/app/controllers/DigitalSubscription.scala
+++ b/support-frontend/app/controllers/DigitalSubscription.scala
@@ -47,7 +47,7 @@ class DigitalSubscription(
 
   def digital(countryCode: String): Action[AnyContent] = CachedAction() { implicit request =>
     implicit val settings: AllSettings = settingsProvider.getAllSettings()
-    val title = "Support the Guardian | Digital Pack Subscription"
+    val title = "Support the Guardian | The Guardian Digital Subscription"
     val mainElement = EmptyDiv("digital-subscription-landing-page-" + countryCode)
     val js = Left(RefPath("digitalSubscriptionLandingPage.js"))
     val css = Left(RefPath("digitalSubscriptionLandingPage.css"))
@@ -101,7 +101,7 @@ class DigitalSubscription(
     }
 
   private def digitalSubscriptionFormHtml(idUser: IdUser)(implicit request: RequestHeader, settings: AllSettings): Html = {
-    val title = "Support the Guardian | Digital Subscription"
+    val title = "Support the Guardian | The Guardian Digital Subscription"
     val id = EmptyDiv("digital-subscription-checkout-page")
     val js = "digitalSubscriptionCheckoutPage.js"
     val css = "digitalSubscriptionCheckoutPage.css"
@@ -129,7 +129,7 @@ class DigitalSubscription(
   def displayThankYouExisting(): Action[AnyContent] = CachedAction() { implicit request =>
 
     implicit val settings: AllSettings = settingsProvider.getAllSettings()
-    val title = "Support the Guardian | Digital Subscription"
+    val title = "Support the Guardian | The Guardian Digital Subscription"
     val mainElement = EmptyDiv("digital-subscription-checkout-page")
     val js = Left(RefPath("digitalSubscriptionCheckoutPageThankYouExisting.js"))
     val css = Left(RefPath("digitalSubscriptionCheckoutPageThankYouExisting.css"))

--- a/support-frontend/conf/strings.conf
+++ b/support-frontend/conf/strings.conf
@@ -1,6 +1,6 @@
 showcaseLanding.description="Help us deliver the independent journalism the world needs. Support the Guardian by making a contribution or getting a subscription."
 contributionsLanding.description="Help us deliver the independent journalism the world needs. Support the Guardian by making a contribution."
 subscriptionsLanding.description="Help us deliver the independent journalism the world needs. Support the Guardian by getting a subscription."
-digitalPackLanding.description="Subscribe to the Guardian Digital Pack and read the Guardian ad-free on all of your devices. The Digital Pack includes the Premium App and Daily Edition iPad app."
+digitalPackLanding.description="Subscribe and enjoy an enhanced experience of The Guardian's digital journalism with access to two innovative apps and ad-free reading on theguardian.com."
 weeklyLanding.description="Subscribe to The Guardian Weekly and enjoy seven days of international news in one magazine with worldwide delivery."
 paperLanding.description="Subscribe to The Guardian and The Observer newspapers and save on the retail price all year round  |  Voucher and Home Delivery options available"


### PR DESCRIPTION
## Why are you doing this?
To update the sharing tags for the relaunch of the Daily and premium app.

[**Trello Card**](https://trello.com/c/qptba6gj/2690-update-digital-subs-sharing-tags)

## Changes
* Update page title
* Update page description

## Screenshots
### Description tag
![Screen Shot 2019-10-22 at 12 06 56](https://user-images.githubusercontent.com/16781258/67280303-c6f19800-f4c4-11e9-82fc-491ca74d61c6.png)

### Title tag
![Screen Shot 2019-10-22 at 12 07 20](https://user-images.githubusercontent.com/16781258/67280306-cb1db580-f4c4-11e9-97cb-c7252e27cb27.png)

