### PR TITLE
Packshot updates

### DIFF
--- a/support-frontend/assets/components/packshots/guardian-weekly-packshot.jsx
+++ b/support-frontend/assets/components/packshots/guardian-weekly-packshot.jsx
@@ -19,23 +19,28 @@ const GuardianWeeklyPackShot = () => (
     <GridImage
       gridId="subscriptionWeekly1"
       srcSizes={[798, 500, 140]}
-      sizes="(max-width: 980px) 175px,
-            250px"
+      sizes="(max-width: 740px) 100%,
+             (max-width: 980px) 200px,
+             (max-width: 1140px) 240px,
+             266px"
       imgType="png"
     />
     <GridImage
       gridId="subscriptionWeekly2"
       srcSizes={[783, 392]}
       sizes="(max-width: 740px) 100%,
-            (max-width: 980px) 175px,
-            250px"
+             (max-width: 980px) 200px,
+             (max-width: 1140px) 240px,
+             267px"
       imgType="png"
     />
     <GridImage
       gridId="subscriptionWeekly3"
       srcSizes={[798, 500, 140]}
-      sizes="(max-width: 980px) 175px,
-            250px"
+      sizes="(max-width: 740px) 100%,
+             (max-width: 980px) 200px,
+             (max-width: 1140px) 240px,
+             266px"
       imgType="png"
     />
   </div>

--- a/support-frontend/assets/components/packshots/paper-and-digital-packshot.jsx
+++ b/support-frontend/assets/components/packshots/paper-and-digital-packshot.jsx
@@ -10,7 +10,8 @@ const PaperAndDigitalPackshot = () => (
       gridId="subscriptionIpad"
       srcSizes={[1000, 500, 140]}
       sizes="(max-width: 740px) 100%,
-            (max-width: 980px) 275px,
+            (max-width: 980px) 243px,
+            (max-width: 1140px) 270px,
             300px"
       imgType="png"
     />
@@ -18,8 +19,9 @@ const PaperAndDigitalPackshot = () => (
       gridId="subscriptionPrint"
       srcSizes={[805, 402]}
       sizes="(max-width: 740px) 100%,
-            (max-width: 980px) 275px,
-            300px"
+             (max-width: 980px) 253px,
+             (max-width: 1140px) 281px,
+             312px"
       imgType="png"
     />
     <GridImage
@@ -34,7 +36,8 @@ const PaperAndDigitalPackshot = () => (
       gridId="subscriptionPrintDigital"
       srcSizes={[452, 905, 1366]}
       sizes="(max-width: 740px) 100%,
-            (max-width: 980px) 100px,
+            (max-width: 980px) 102px,
+            (max-width: 1140px) 113px,
             125px"
       imgType="png"
     />

--- a/support-frontend/assets/components/packshots/paper-packshot.jsx
+++ b/support-frontend/assets/components/packshots/paper-packshot.jsx
@@ -8,23 +8,28 @@ const PaperPackshot = () => (
     <GridImage
       gridId="subscriptionFeast"
       srcSizes={[660, 500, 140]}
-      sizes="(max-width: 980px) 165px,
-            190px"
+      sizes="(max-width: 740px) 100%,
+             (max-width: 980px) 178px,
+             (max-width: 1140px) 198px,
+             220px"
       imgType="png"
     />
     <GridImage
       gridId="subscriptionPrint"
       srcSizes={[805, 402]}
       sizes="(max-width: 740px) 100%,
-            (max-width: 980px) 275px,
-            300px"
+             (max-width: 980px) 240px,
+             (max-width: 1140px) 311px,
+             346px"
       imgType="png"
     />
     <GridImage
       gridId="subscriptionG2"
       srcSizes={[756, 500, 140]}
-      sizes="(max-width: 980px) 195px,
-            220px"
+      sizes="(max-width: 740px) 100%,
+             (max-width: 980px) 204px,
+             (max-width: 1140px) 227px,
+             252px"
       imgType="png"
     />
   </div>

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.scss
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.scss
@@ -78,7 +78,7 @@
   @include mq($from: leftCol, $until: 1400px) {
     margin-left: 100px;
   }
-  
+
   @include mq($until: leftCol) {
     margin-left: 70px;
   }
@@ -181,6 +181,7 @@
   border: none;
   padding-top: 10px;
   background-color: gu-colour('brand-main');
+  overflow: hidden;
 
   @include mq($until: tablet) {
     padding-top: 0;
@@ -232,30 +233,30 @@
 }
 
 .subscriptions__image-container.subscriptions__product--feature {
-  background-color: gu-colour('brand-main');
-  width: 50%;
+  padding: 10px 10px 0 10px;
+  width: 100%;
+  margin-bottom: -40px;
 
-  @media (min-width: 740px) and (max-width: 1067px) {
-    padding: 22% 0;
-  }
-  @media (min-width: 1067px) {
-    height: 447px;
-  }
-  @include mq($until: tablet) {
+  @include mq($from: tablet) {
     position: relative;
-    width: 100%;
+    // bottom: -56px;
+    right: -15px;
+    width: 50%;
+    padding: 0;
   }
 
-  @include mq($until: mobileLandscape) {
-    position: relative;
-    width: 100%;
+  @media (min-width: 881px) {
+    bottom: 0;
   }
 
-  @include mq($until: mobile) {
-    position: relative;
-    width: 100%;
-    bottom: -50px;
+  @include mq($from: desktop) {
+    right: -50px;
   }
+
+  @include mq($from: leftCol) {
+    right: -80px;
+  }
+
 }
 
 .subscriptions__copy-container.subscriptions__product--feature {
@@ -268,8 +269,9 @@
   }
 
   .subscriptions__copy-wrapper {
-    @include mq($until: desktop) {
-      padding: 0 30px 30px;
+    padding: 0 10px 10px;
+    @include mq($from: tablet) {
+      padding: 0 20px 20px 20px
     }
   }
 
@@ -455,19 +457,12 @@
 /****************** product-image ********************/
 
 .subscriptions-packshot {
-  position: absolute;
-  bottom: 0;
-  left: 50%;
-  transform: translateX(-50%);
+  width: 100%;
+  padding: 6px;
 
-  @include mq($until: tablet) {
-    position: static;
-    top: 0;
-    width: 100%;
-    // margin: 0;
-    transform: translateX(0);
-    padding: 6px;
-  }
+  // @include mq($until: tablet) {
+
+  // }
 }
 
 /****************** subscriptions__product-button ********************/
@@ -506,37 +501,64 @@
 
 /****************** packshots ********************/
 .subscriptions-feature-packshot {
-  position: absolute;
-  bottom: -40px;
-  right: -230px;
+  width: 100%;
 
-  @media (max-width: 1067px) {
-    width: 150%;
-    right: initial;
-  }
-
-  @include mq($until: tablet) {
-    position: relative;
-    bottom: initial;
-    padding: 20px 10% 0;
-    margin-bottom: -50px;
-  }
-
-  @include mq($until: mobileLandscape) {
-    margin-bottom: -40px;
+  @include mq($from: tablet) {
+    width: 600px;
   }
 
   img {
     width: 100%;
-    height: 100%;
+
+
+    @include mq($from: desktop) {
+      width: 600px;
+      right: -50px;
+    }
+
+    @include mq($from: leftCol) {
+      width: 700px;
+      right: -80px;
+    }
+
+    @include mq($from: wide) {
+      width: 800px;
+    }
+
+    @include mq($from: tablet) {
+      // margin-bottom: -55px;
+    }
   }
+
+  // position: absolute;
+  // bottom: -40px;
+  // right: -230px;
+
+  // @media (max-width: 1067px) {
+  //   width: 150%;
+  //   right: initial;
+  // }
+
+  // @include mq($until: tablet) {
+  //   position: relative;
+  //   bottom: initial;
+  //   padding: 20px 10% 0;
+  //   margin-bottom: -50px;
+  // }
+
+  // @include mq($until: mobileLandscape) {
+  //   margin-bottom: -40px;
+  // }
+
+
 }
 
 .subscriptions__guardian-weekly-packshot {
-  width: 429px;
+  width: 100%;
+  // height: 400px;
 
   @include mq($until: desktop) {
-    width: 354px;
+    // width: 354px;
   }
 
   @include mq($until: tablet) {
@@ -550,23 +572,44 @@
   }
 
   img:nth-child(1) {
+    left: 80px;
+
+    @include mq($until: leftCol) {
+      left: 50px;
+    }
+
+    @include mq($until: desktop) {
+      left: 20px;
+    }
+
     @include mq($until: tablet) {
       display: none;
     }
   }
 
   img:nth-child(2) {
-    left: 95px;
-    bottom: -60px;
+    bottom: -50px;
+    left: 50%;
+    transform: translateX(-50%);
 
     @include mq($until: tablet) {
       position: static;
       width: 100%;
+      left: 0;
+      transform: none;
     }
   }
 
   img:nth-child(3) {
-    left: 180px;
+    right: 80px;
+
+    @include mq($until: leftCol) {
+      right: 50px;
+    }
+
+    @include mq($until: desktop) {
+      right: 20px;
+    }
 
     @include mq($until: tablet) {
       display: none;
@@ -594,6 +637,16 @@
 
   img:nth-child(1) {
     z-index: 2;
+    left: 80px;
+
+    @include mq($until: leftCol) {
+      left: 50px;
+    }
+
+    @include mq($until: desktop) {
+      left: 20px;
+    }
+
     @include mq($until: tablet) {
       display: none;
     }
@@ -601,17 +654,36 @@
 
   img:nth-child(2) {
     z-index: 1;
-    left: 32px;
-    bottom: -120px;
+    left: 50%;
+    transform: translateX(-50%);
+    bottom: -150px;
+
+    @include mq($until: leftCol) {
+      bottom: -120px;
+    }
+
+    @include mq($until: desktop) {
+      bottom: -80px;
+    }
 
     @include mq($until: tablet) {
       position: static;
       width: 100%;
+      left: 0;
+      transform: none;
     }
   }
 
   img:nth-child(3) {
-    left: 166px;
+    right: 80px;
+
+    @include mq($until: leftCol) {
+      right: 50px;
+    }
+
+    @include mq($until: desktop) {
+      right: 20px;
+    }
 
     @include mq($until: tablet) {
       display: none;
@@ -638,14 +710,25 @@
 
   img:nth-child(1) {
     bottom: -37px;
+    left: 80px;
+
+    @include mq($until: leftCol) {
+      left: 50px;
+    }
+
+    @include mq($until: desktop) {
+      left: 20px;
+    }
+
     @include mq($until: tablet) {
       display: none;
     }
   }
 
   img:nth-child(2) {
-    left: 55px;
-    bottom: -130px;
+    bottom: -120px;
+    left: 50%;
+    transform: translateX(-50%);
 
     @include mq($until: tablet) {
       position: static;
@@ -655,12 +738,17 @@
   }
 
   img:nth-child(3) {
-    left: 272px;
     bottom: -72px;
+    right: 80px;
+
+    @include mq($until: leftCol) {
+      bottom: -86px;
+      right: 50px;
+    }
 
     @include mq($until: desktop) {
-      left: 256px;
-      bottom: -40px;
+      right: 20px;
+      bottom: -56px;
     }
 
     @include mq($until: tablet) {
@@ -715,16 +803,28 @@
 }
 
 .subscriptions-int-daily-packshot {
-  width: 366px;
+  position: relative;
+  width: 100%;
 
   img {
-    display: block;
+    bottom: -25px;
     width: 100%;
   }
 
-  @include mq($until: tablet) {
-    width: 100%;
+  @include mq($from: tablet) {
+    position: absolute;
+    bottom: -6px;
+    padding: 0 20px;
   }
+
+  @include mq($from: desktop) {
+    padding: 0 50px;
+  }
+
+  @include mq($from: leftCol) {
+    padding: 0 80px;
+  }
+
 }
 
 /**** FOOTER HACK ****/

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.scss
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.scss
@@ -459,10 +459,6 @@
 .subscriptions-packshot {
   width: 100%;
   padding: 6px;
-
-  // @include mq($until: tablet) {
-
-  // }
 }
 
 /****************** subscriptions__product-button ********************/
@@ -526,40 +522,13 @@
     }
 
     @include mq($from: tablet) {
-      // margin-bottom: -55px;
     }
   }
-
-  // position: absolute;
-  // bottom: -40px;
-  // right: -230px;
-
-  // @media (max-width: 1067px) {
-  //   width: 150%;
-  //   right: initial;
-  // }
-
-  // @include mq($until: tablet) {
-  //   position: relative;
-  //   bottom: initial;
-  //   padding: 20px 10% 0;
-  //   margin-bottom: -50px;
-  // }
-
-  // @include mq($until: mobileLandscape) {
-  //   margin-bottom: -40px;
-  // }
-
 
 }
 
 .subscriptions__guardian-weekly-packshot {
   width: 100%;
-  // height: 400px;
-
-  @include mq($until: desktop) {
-    // width: 354px;
-  }
 
   @include mq($until: tablet) {
     position: static;


### PR DESCRIPTION
## Why are you doing this?
The pack shots on the showcase page currently don't fully follow the design, this PR changes the way pack shots are positioned so they are easier to update and updates the pack shots so they follow the design

[**Trello Card**](https://trello.com/c/wPAHegYx/2694-tweak-showcase-page-packshots)

## Changes

* All the pack shots have been updated

## Screenshots

**Old showcase page**
![support theguardian com_uk_subscribe](https://user-images.githubusercontent.com/45875444/67320038-9a11a500-f505-11e9-8e8c-715fea66aedf.png)

**New showcase page**
![support thegulocal com_uk_subscribe (2)](https://user-images.githubusercontent.com/45875444/67320259-e230c780-f505-11e9-9854-a13be57c28ca.png)

