### PR TITLE
Add the p tag to the list of allowed Markdown tags

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -92,7 +92,7 @@ const getSanitisedHtml = (description: string) =>
   // ensure we don't accidentally inject dangerous html into the page
   DOMPurify.sanitize(
     marked(description),
-    { ALLOWED_TAGS: ['em', 'strong', 'ul', 'li', 'a'] },
+    { ALLOWED_TAGS: ['em', 'strong', 'ul', 'li', 'a', 'p'] },
   );
 
 const getFirstParagraph = (promotionCopy: ?PromotionCopy) => {


### PR DESCRIPTION
## Why are you doing this?

We want users of the promo code tool to be able to add paragraphs into the body copy of the GW landing page. Currently this is disallowed because `p` is not in the list of allowed markdown tags, this PR adds it.
