### PR TITLE
Promopage fixes

### DIFF
--- a/support-frontend/app/controllers/Promotions.scala
+++ b/support-frontend/app/controllers/Promotions.scala
@@ -3,10 +3,12 @@ package controllers
 import actions.CustomActionBuilders
 import admin.settings.{AllSettings, AllSettingsProvider}
 import assets.{AssetsResolver, RefPath, StyleContent}
+import com.gu.support.catalog.{DigitalPack, GuardianWeekly, Paper}
 import com.gu.support.config.Stage
 import com.gu.support.encoding.CustomCodecs._
 import com.gu.support.pricing.PriceSummaryServiceProvider
 import com.gu.support.promotions.{PromoCode, PromotionServiceProvider, PromotionTerms}
+import lib.RedirectWithEncodedQueryString
 import play.api.mvc.{AbstractController, Action, AnyContent, ControllerComponents}
 import play.twirl.api.Html
 import services.TestUserService
@@ -27,6 +29,22 @@ class Promotions(
   import actionRefiners._
 
   implicit val a: AssetsResolver = assets
+
+  def promo(promoCode: String): Action[AnyContent] = CachedAction() { implicit request =>
+    val promotionService = promotionServiceProvider.forUser(false)
+    val maybePromotionTerms = PromotionTerms.fromPromoCode(promotionService, stage, promoCode)
+
+    maybePromotionTerms.fold(NotFound("Invalid promo code")
+    ) { promotionTerms =>
+      val productLandingPage = promotionTerms.product match {
+        case GuardianWeekly => routes.Subscriptions.weeklyGeoRedirect().url
+        case DigitalPack => routes.DigitalSubscription.digitalGeoRedirect().url
+        case Paper => routes.PaperSubscription.paper(false).url
+      }
+      val queryString = request.queryString + ("promoCode" -> Seq(promoCode))
+      RedirectWithEncodedQueryString(productLandingPage, queryString, MOVED_PERMANENTLY)
+    }
+  }
 
   def terms(promoCode: String): Action[AnyContent] = CachedAction() { implicit request =>
     implicit val settings: AllSettings = settingsProvider.getAllSettings()

--- a/support-frontend/assets/helpers/externalLinks.js
+++ b/support-frontend/assets/helpers/externalLinks.js
@@ -22,6 +22,7 @@ import type { SubscriptionProduct } from 'helpers/subscriptions';
 import { getAnnualPlanPromoCode, getIntcmp, getPromoCode } from './flashSale';
 import { getOrigin } from './url';
 import { GBPCountries } from './internationalisation/countryGroup';
+import { promoQueryParam } from 'helpers/productPrice/promotions';
 
 // ----- Types ----- //
 
@@ -218,7 +219,7 @@ function getDigitalCheckout(
 ): string {
   const promoCode = getDigitalPackPromoCode(countryGroupId, billingPeriod);
   const params = new URLSearchParams(window.location.search);
-  params.set('promoCode', promoCode);
+  params.set(promoQueryParam, promoCode);
   if (billingPeriod === Annual) {
     params.set('period', Annual);
   }

--- a/support-frontend/assets/helpers/productPrice/promotions.js
+++ b/support-frontend/assets/helpers/productPrice/promotions.js
@@ -48,6 +48,9 @@ export type Promotion =
     discount?: DiscountBenefit,
     introductoryPrice?: IntroductoryPriceBenefit,
   }
+
+const promoQueryParam = 'promoCode';
+
 const hasDiscount = (promotion: ?Promotion): boolean %checks =>
   promotion !== null &&
   promotion !== undefined &&
@@ -74,7 +77,7 @@ function applyDiscount(price: ProductPrice, promotion: ?Promotion) {
 }
 
 const matchesQueryParam = promotion =>
-  getQueryParameter('promoCode') === promotion.promoCode;
+  getQueryParameter(promoQueryParam) === promotion.promoCode;
 const introductoryPrice = promotion =>
   promotion.introductoryPrice !== null && promotion.introductoryPrice !==
   undefined;
@@ -113,4 +116,5 @@ export {
   applyDiscount,
   hasIntroductoryPrice,
   hasDiscount,
+  promoQueryParam,
 };

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
@@ -3,20 +3,30 @@
 // ----- Imports ----- //
 
 import React, { Component } from 'react';
-import { injectStripe, CardNumberElement, CardExpiryElement, CardCVCElement } from 'react-stripe-elements';
+import {
+  CardCVCElement,
+  CardExpiryElement,
+  CardNumberElement,
+  injectStripe,
+} from 'react-stripe-elements';
 import { connect } from 'react-redux';
 import { fetchJson, requestOptions } from 'helpers/fetch';
-import type { State, Stripe3DSResult } from 'pages/contributions-landing/contributionsLandingReducer';
+import type {
+  State,
+  Stripe3DSResult,
+} from 'pages/contributions-landing/contributionsLandingReducer';
 import { Stripe } from 'helpers/paymentMethods';
 import { type PaymentResult } from 'helpers/paymentIntegrations/readerRevenueApis';
-import { setCreateStripePaymentMethod,
-  setHandleStripe3DS,
-  setStripeCardFormComplete,
-  setSetupIntentClientSecret,
+import {
+  type Action,
   onThirdPartyPaymentAuthorised,
   paymentFailure,
   paymentWaiting as setPaymentWaiting,
-  type Action } from 'pages/contributions-landing/contributionsLandingActions';
+  setCreateStripePaymentMethod,
+  setHandleStripe3DS,
+  setSetupIntentClientSecret,
+  setStripeCardFormComplete,
+} from 'pages/contributions-landing/contributionsLandingActions';
 import { type ContributionType } from 'helpers/contributions';
 import type { ErrorReason } from 'helpers/errorReasons';
 import { logException } from 'helpers/logger';
@@ -160,8 +170,8 @@ class CardForm extends Component<PropTypes, StateTypes> {
       } else {
         throw new Error(`Missing client_secret field in response from ${window.guardian.stripeSetupIntentEndpoint}`);
       }
-    }).catch(error => {
-      logException(`Error getting Stripe client secret for recurring contribution: ${error}`)
+    }).catch((error) => {
+      logException(`Error getting Stripe client secret for recurring contribution: ${error}`);
       this.props.paymentFailure('internal_error');
     });
 

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
@@ -16,12 +16,16 @@ import {
   getPriceDescription,
 } from 'helpers/productPrice/priceDescriptions';
 import { getWeeklyFulfilmentOption } from 'helpers/productPrice/fulfilmentOptions';
-import { getOrigin } from 'helpers/url';
+import { getOrigin, getQueryParameter } from 'helpers/url';
+import { promoQueryParam } from 'helpers/productPrice/promotions';
 
 // ---- Plans ----- //
 
-const getCheckoutUrl = (billingPeriod: WeeklyBillingPeriod): string =>
-  `${getOrigin()}/subscribe/weekly/checkout?period=${billingPeriod.toString()}`;
+const getCheckoutUrl = (billingPeriod: WeeklyBillingPeriod): string => {
+  const promoCode = getQueryParameter(promoQueryParam, null);
+  const promoQuery = promoCode ? `&${promoQueryParam}=${promoCode}` : '';
+  return `${getOrigin()}/subscribe/weekly/checkout?period=${billingPeriod.toString()}${promoQuery}`;
+};
 
 // ----- State/Props Maps ----- //
 

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
@@ -22,7 +22,7 @@ import { promoQueryParam } from 'helpers/productPrice/promotions';
 // ---- Plans ----- //
 
 const getCheckoutUrl = (billingPeriod: WeeklyBillingPeriod): string => {
-  const promoCode = getQueryParameter(promoQueryParam, null);
+  const promoCode = getQueryParameter(promoQueryParam);
   const promoQuery = promoCode ? `&${promoQueryParam}=${promoCode}` : '';
   return `${getOrigin()}/subscribe/weekly/checkout?period=${billingPeriod.toString()}${promoQuery}`;
 };

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -15,7 +15,6 @@ import {
   AUDCountries,
   Canada,
   type CountryGroupId,
-  countryGroups,
   detect,
   EURCountries,
   GBPCountries,
@@ -44,6 +43,9 @@ import ConsentBanner from 'components/consentBanner/consentBanner';
 
 import './weeklySubscriptionLanding.scss';
 import type { PromotionCopy } from 'helpers/productPrice/promotions';
+import { promoQueryParam } from 'helpers/productPrice/promotions';
+import { promotionTermsUrl } from 'helpers/routes';
+import { getQueryParameter } from 'helpers/url';
 
 type PageCopy = {|
   title: string,
@@ -57,8 +59,6 @@ const store = pageInit(() => reducer, true);
 // ----- Internationalisation ----- //
 
 const countryGroupId: CountryGroupId = detect();
-const { supportInternationalisationId } = countryGroups[countryGroupId];
-const subsCountry = (['us', 'au'].includes(supportInternationalisationId) ? supportInternationalisationId : 'gb').toUpperCase();
 
 const reactElementId: {
   [CountryGroupId]: string,
@@ -131,6 +131,7 @@ const getCopy = (state: State): PageCopy => {
 // ----- Render ----- //
 
 const copy = getCopy(store.getState());
+const promoTerms = promotionTermsUrl(getQueryParameter(promoQueryParam) || '10ANNUAL');
 
 const content = (
   <Provider store={store}>
@@ -186,7 +187,7 @@ const content = (
       </Content>
       <Content>
         <Text title="Promotion terms and conditions">
-          <p>Offer subject to availability. Guardian News and Media Limited (&ldquo;GNM&rdquo;) reserves the right to withdraw this promotion at any time. For full annual promotion terms and conditions, see <a target="_blank" rel="noopener noreferrer" href={`https://subscribe.theguardian.com/p/10ANNUAL/terms?country=${subsCountry}`}>here</a>.
+          <p>Offer subject to availability. Guardian News and Media Limited (&ldquo;GNM&rdquo;) reserves the right to withdraw this promotion at any time. For full annual promotion terms and conditions, see <a target="_blank" rel="noopener noreferrer" href={promoTerms}>here</a>.
           </p>
         </Text>
         <Text title="Guardian Weekly terms and conditions">

--- a/support-frontend/conf/routes
+++ b/support-frontend/conf/routes
@@ -142,6 +142,7 @@ POST /direct-debit/check-account                                   controllers.D
 
 # ----- Promotions ----- #
 GET /p/:promoCode/terms                                           controllers.Promotions.terms(promoCode)
+GET /p/:promoCode                                                 controllers.Promotions.promo(promoCode)
 
 # ----- Verification ----- #
 


### PR DESCRIPTION
## Why are you doing this?
This PR has a number of enhancements to the Guardian Weekly product page promotion functionalily.
 
* Add a new endpoint `/p/[promocode]` which immediately redirects to the appropriate product landing page. This is a convenience for the marketing team.
* Carry any promo code which is present on the Guardian Weekly product page over to the checkout when users click through.
* If there is a promo code in effect on the GW product page, link to the T&Cs for that promotion in the promotions section, otherwise link to 10ANNUAL

[**Trello Card**](https://trello.com/c/T0iKX0XW/2697-gw-promotions-landing-page-fixes)
