### PR TITLE
Fix GW checkout bugs by changing the way we manage billing address state

### DIFF
--- a/support-frontend/assets/helpers/subscriptionsForms/formActions.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/formActions.js
@@ -41,7 +41,7 @@ export type Action =
   | { type: 'SET_FORM_ERRORS', errors: FormError<FormField>[] }
   | { type: 'SET_SUBMISSION_ERROR', error: ErrorReason }
   | { type: 'SET_FORM_SUBMITTED', formSubmitted: boolean }
-  | { type: 'SET_BILLING_ADDRESS_IS_SAME', isSame: Option<boolean> }
+  | { type: 'SET_BILLING_ADDRESS_IS_SAME', isSame: boolean }
   | { type: 'SET_ORDER_IS_GIFT', orderIsAGift: Option<boolean>}
   | { type: 'SET_STRIPE_TOKEN', stripeToken: Option<string> }
   | { type: 'SET_DELIVERY_INSTRUCTIONS', instructions: Option<string>}
@@ -98,7 +98,7 @@ const formActionCreators = {
       country: state.common.internationalisation.countryId,
     });
   },
-  setBillingAddressIsSame: (isSame: boolean | null): Action => ({
+  setBillingAddressIsSame: (isSame: boolean): Action => ({
     type: 'SET_BILLING_ADDRESS_IS_SAME',
     isSame,
   }),

--- a/support-frontend/assets/helpers/subscriptionsForms/formFields.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/formFields.js
@@ -30,7 +30,7 @@ export type FormFields = {|
   billingPeriod: BillingPeriod,
   paymentMethod: Option<PaymentMethod>,
   startDate: Option<string>,
-  billingAddressIsSame: Option<boolean>,
+  billingAddressIsSame: boolean,
   fulfilmentOption: FulfilmentOptions,
   product: SubscriptionProduct,
   productOption: ProductOptions,

--- a/support-frontend/assets/helpers/subscriptionsForms/formReducer.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/formReducer.js
@@ -40,7 +40,7 @@ function createFormReducer(
     lastName: user.lastName || '',
     startDate,
     telephone: null,
-    billingAddressIsSame: null,
+    billingAddressIsSame: true,
     billingPeriod: initialBillingPeriod,
     titleGiftRecipient: null,
     firstNameGiftRecipient: null,

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -146,8 +146,8 @@ function WeeklyCheckoutForm(props: PropTypes) {
   const submissionErrorHeading = props.submissionError === 'personal_details_incorrect' ? 'Sorry there was a problem' :
     'Sorry we could not process your payment';
 
-  const setBillingAddressIsSameHandler = () => {
-    props.setBillingAddressIsSame(true);
+  const setBillingAddressIsSameHandler = (newState) => {
+    props.setBillingAddressIsSame(newState);
     props.setBillingCountry(props.deliveryCountry);
   };
 
@@ -259,14 +259,14 @@ function WeeklyCheckoutForm(props: PropTypes) {
                   text="Yes"
                   name="billingAddressIsSame"
                   checked={props.billingAddressIsSame === true}
-                  onChange={setBillingAddressIsSameHandler}
+                  onChange={() => setBillingAddressIsSameHandler(true)}
                 />
                 <RadioInput
                   inputId="qa-billing-address-different"
                   text="No"
                   name="billingAddressIsSame"
                   checked={props.billingAddressIsSame === false}
-                  onChange={() => props.setBillingAddressIsSame(false)}
+                  onChange={() => setBillingAddressIsSameHandler(false)}
                 />
               </FieldsetWithError>
             </Rows>


### PR DESCRIPTION
## Why are you doing this?
There have been a series of issues in the GW checkout that relate to the billing country of the order. Some of these have been fixed in [previous work](https://github.com/guardian/support-frontend/pull/2112) - @rupertbates is this the correct link? - but there were remaining issues, as detailed in this [Trello Card](https://trello.com/c/Jb5tJnMz/2617-fix-bug-eur-is-not-supported-currency-for-the-bank-transferdirectdebituk-payment-method)

## Changes
* The billing address radio button in the form is now set to default to 'yes, the billing address is the same as the delivery address'
* When the radio buttons are switched, the billing country is updated to be the same as the delivery country, whether the answer is yes or no, which make the behaviour more consistent and predictable.