### PR TITLE
Remove weekly from subscribe currency switcher path

### DIFF
--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
@@ -23,7 +23,7 @@ const countryGroupId: CountryGroupId = detect();
 const store = pageInit();
 
 const Header = headerWithCountrySwitcherContainer({
-  path: '/subscribe/weekly',
+  path: '/subscribe',
   countryGroupId,
   listOfCountryGroups: [
     GBPCountries,


### PR DESCRIPTION
## Why are you doing this?
There's been an issue with the subs showcase page where it takes you to the GW page when you change currencies. The aim is to fix this so it stays on the same page and just changes currencies.

We'll need to retro-check that the currency detection is still working correctly post-fix. However, I have tested this locally and it still seems to be working. On local it seems to detect 'int' as the location and it's still reverting to this when I switch tabs.

[**Trello Card**](https://trello.com/c/9eUIEpZe/2647-fix-currency-switcher-bug-from-going-to-gw-as-default)

## Changes
Remove weekly from path in currency switcher on subs showcase page.