### PR TITLE
Fix encoding of stripe errors in support-workers

### DIFF
--- a/support-rest/src/main/scala/com/gu/stripe/StripeError.scala
+++ b/support-rest/src/main/scala/com/gu/stripe/StripeError.scala
@@ -1,6 +1,7 @@
 package com.gu.stripe
 
-import io.circe.generic.semiauto.deriveDecoder
+import io.circe.Json
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 
 //See docs here: https://stripe.com/docs/api/curl#errors
 case class StripeError(
@@ -17,6 +18,8 @@ case class StripeError(
 }
 
 object StripeError {
+
+  implicit val encoder = deriveEncoder[StripeError].mapJson { json => Json.fromFields(List("error" -> json)) }
 
   implicit val decoder = deriveDecoder[StripeError].prepare { _.downField("error") }
 

--- a/support-workers/src/main/scala/com/gu/support/workers/exceptions/RetryImplicits.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/exceptions/RetryImplicits.scala
@@ -6,6 +6,7 @@ import com.amazonaws.services.kms.model._
 import com.amazonaws.services.sqs.model.{AmazonSQSException, InvalidMessageContentsException, QueueDoesNotExistException}
 import com.gu.acquisition.model.errors.AnalyticsServiceError
 import io.circe.{DecodingFailure, ParsingFailure}
+import io.circe.syntax._
 import com.gu.rest.{WebServiceClientError, WebServiceHelperError}
 import com.gu.stripe.StripeError
 
@@ -33,9 +34,9 @@ object RetryImplicits {
 
   implicit class StripeConversions(val throwable: StripeError) extends AnyVal {
     def asRetryException: RetryException = throwable.`type` match {
-      case ("api_connection_error" | "api_error" | "rate_limit_error") => new RetryUnlimited(throwable.getMessage, cause = throwable)
-      case "authentication_error" => new RetryLimited(throwable.getMessage, cause = throwable)
-      case ("card_error" | "invalid_request_error" | "validation_error") => new RetryNone(throwable.getMessage, cause = throwable)
+      case ("api_connection_error" | "api_error" | "rate_limit_error") => new RetryUnlimited(throwable.asJson.noSpaces, cause = throwable)
+      case "authentication_error" => new RetryLimited(throwable.asJson.noSpaces, cause = throwable)
+      case ("card_error" | "invalid_request_error" | "validation_error") => new RetryNone(throwable.asJson.noSpaces, cause = throwable)
     }
   }
 


### PR DESCRIPTION
## Why are you doing this?
This fixes a regression introduced by https://github.com/guardian/support-frontend/pull/2111/files#diff-5df451c12e7db07da6bff1cd98c456f5L35

We have had an increase in support-workers failure alerts because it has been incorrectly ending up in the `FailState` state rather than the `CheckoutFailure` state. Specifically, for stripe payment errors (e.g. wrong cvc code) it should end in the `CheckoutFailure` state and therefore not trigger an alarm.

The `CreatePaymentMethod` step function may return a `StripeError` when it fails.
This becomes the input to `FailureHandler`, which attempts to decode it to a `StripeError`.
But in `CreatePaymentMethod`, the conversion to a `RetryException` currently incorrectly calls `getMessage`, which produces a semi-colon separated string. It should actually match the json structure of the original stripe response.

I tested in CODE by using the `tok_chargeDeclinedIncorrectCvc` [stripe test token ](https://stripe.com/docs/testing) to simulate an incorrect cvc.
### Before
(has empty `messages` field):
![Screenshot 2019-10-29 at 16 45 02](https://user-images.githubusercontent.com/1513454/67789359-c1b7be80-fa6b-11e9-9d72-a163583c78ff.png)
![Screenshot 2019-10-29 at 16 49 27](https://user-images.githubusercontent.com/1513454/67789566-1824fd00-fa6c-11e9-88ce-8d38eb0a1e9f.png)


### After:
![Screenshot 2019-10-29 at 16 46 03](https://user-images.githubusercontent.com/1513454/67789367-c4b2af00-fa6b-11e9-8e2c-8d7431347e34.png)
![Screenshot 2019-10-29 at 16 49 12](https://user-images.githubusercontent.com/1513454/67789580-1b1fed80-fa6c-11e9-97c3-2344b773858b.png)

