### PR TITLE
Set Content-Type in AllowHeaders

### DIFF
--- a/support-lambdas/stripe-intent/cfn.yaml
+++ b/support-lambdas/stripe-intent/cfn.yaml
@@ -33,7 +33,7 @@ Globals:
   Api:
     Cors:
       AllowOrigin: !FindInMap [ StageMap, !Ref Stage, CorsOrigin ]
-      AllowHeaders: "'*'"
+      AllowHeaders: "'Content-Type'"
       AllowMethods: "'*'"
 
 Resources:


### PR DESCRIPTION
## Why are you doing this?
In safari the recurring contributions page is failing to send the request to create a stripe Setup Intent.
The error is:
`Request header field Content-Type is not allowed by Access-Control-Allow-Headers`

I'm not sure why the wildcard doesn't work here, or why it's working in other browsers, but this does fix it (tested in CODE before and after).

