### PR TITLE
SCA Stripe API payments integration for support frontend

### DIFF
--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -104,6 +104,7 @@
   }
 
   window.guardian.stripeElementsRecurring = @settings.switches.experiments.get("stripeElementsRecurring").exists(_.isOn)
+
   window.guardian.forceCampaign = @settings.switches.experiments.get("forceCampaign").exists(_.isOn)
   window.guardian.recurringStripePaymentRequestButton = @settings.switches.experiments.get("recurringStripePaymentRequestButton").exists(_.isOn)
   </script>

--- a/support-frontend/app/views/subscriptionCheckout.scala.html
+++ b/support-frontend/app/views/subscriptionCheckout.scala.html
@@ -61,7 +61,7 @@
       };
       window.guardian.csrf = { token: "@CSRF.getToken.value" };
       window.guardian.stripeSetupIntentEndpoint = "@stripeSetupIntentEndpoint";
-      window.guardian.stripeElementsRecurring = @settings.switches.experiments.get("stripeElementsRecurring").exists(_.isOn);
+      window.guardian.stripeElementsSubscriptions = @settings.switches.experiments.get("stripeElementsSubscriptions").exists(_.isOn)
   </script>
 
   }

--- a/support-frontend/app/views/subscriptionCheckout.scala.html
+++ b/support-frontend/app/views/subscriptionCheckout.scala.html
@@ -61,6 +61,7 @@
       };
       window.guardian.csrf = { token: "@CSRF.getToken.value" };
       window.guardian.stripeSetupIntentEndpoint = "@stripeSetupIntentEndpoint";
+      window.guardian.stripeElementsRecurring = @settings.switches.experiments.get("stripeElementsRecurring").exists(_.isOn);
   </script>
 
   }

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -25,7 +25,7 @@ export type StripeFormPropTypes = {
   stripe: Object,
   allErrors: FormError<FormField>[],
   setStripeToken: Function,
-  setPaymentMethod: Function,
+  setStripePaymentMethod: Function,
   submitForm: Function,
   name: string,
   validateForm: Function,
@@ -133,15 +133,6 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
       // TODO (flavian):
       this.setState({ cardErrors: [...this.state.cardErrors, 'internal_error'] });
     });
-
-    this.setCreateStripePaymentMethod(() => {
-      this.setState({paymentWaiting: true});
-
-      // If clientSecret is not yet available then handleCardSetupForRecurring will be called when it is
-      if (this.state.setupIntentClientSecret) {
-        this.handleCardSetup(this.state.setupIntentClientSecret);
-      }
-    });
   }
 
   handleCardErrors = () => {
@@ -232,6 +223,7 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
       const { stripe } = this.props;
 
       this.handleCardSetup(this.state.setupIntentClientSecret)
+        .then((paymentMethod) => this.props.setStripePaymentMethod(paymentMethod))
         .then(() => this.props.submitForm());
     }
   }

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -17,6 +17,7 @@ import './stripeForm.scss';
 import { fetchJson, requestOptions } from 'helpers/fetch';
 import { logException } from 'helpers/logger';
 import type { IsoCountry } from 'helpers/internationalisation/country';
+import type { Option } from 'helpers/types/option';
 
 // Types
 
@@ -39,7 +40,7 @@ type StateTypes = {
   cardExpiry: Object,
   cardCvc: Object,
   cardErrors: Array<Object>,
-  setupIntentClientSecret: string | null,
+  setupIntentClientSecret: Option<string>,
   paymentWaiting: boolean
 }
 
@@ -133,7 +134,7 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
       logException(`Error getting Stripe client secret for recurring contribution: ${error}`);
 
       this.setState({
-        cardErrors: [...this.state.cardErrors, { field: 'cardNumber', message: 'internal_error' }]
+        cardErrors: [...this.state.cardErrors, { field: 'cardNumber', message: 'internal_error' }],
       });
 
 
@@ -190,24 +191,23 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
       // This shouldn't be possible as we disable the submit button until all fields are valid, but if it does
       // happen then display a generic error about card details
       this.setState({
-        cardErrors: [...this.state.cardErrors, { field: 'cardNumber', message: 'payment_details_incorrect' }]
+        cardErrors: [...this.state.cardErrors, { field: 'cardNumber', message: 'payment_details_incorrect' }],
       });
     } else {
       // This is probably a Stripe or network problem
       this.setState({
-        cardErrors: [...this.state.cardErrors, { field: 'cardNumber', message: 'payment_provider_unavailable' }]
+        cardErrors: [...this.state.cardErrors, { field: 'cardNumber', message: 'payment_provider_unavailable' }],
       });
     }
   }
 
-  handleCardSetup(clientSecret: string): Promise<string> {
-    this.props.stripe.handleCardSetup(clientSecret).then((result) => {
+  handleCardSetup(clientSecret: Option<string>): Promise<string> {
+    return this.props.stripe.handleCardSetup(clientSecret).then((result) => {
       if (result.error) {
         this.handleStripeError(result.error);
-        return Promise.fail(result.error);
+        return Promise.resolve(result.error);
       }
       return result.setupIntent.payment_method;
-
     });
   }
 

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -15,7 +15,6 @@ import { withLabel } from 'hocs/withLabel';
 import './stripeForm.scss';
 import { fetchJson, requestOptions } from 'helpers/fetch';
 import { logException } from 'helpers/logger';
-import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { Option } from 'helpers/types/option';
 
 // Types

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -206,8 +206,9 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
       if (result.error) {
         this.handleStripeError(result.error);
         return Promise.resolve(result.error);
+      } else {
+        return result.setupIntent.payment_method;
       }
-      return result.setupIntent.payment_method;
     });
   }
 
@@ -229,11 +230,12 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
     this.handleCardErrors();
 
     if (this.props.stripe && this.props.allErrors.length === 0 && this.state.cardErrors.length === 0) {
-      console.log(this.props.setStripePaymentMethod);
 
       this.handleCardSetup(this.state.setupIntentClientSecret)
-        .then(paymentMethod => this.props.setStripePaymentMethod(paymentMethod))
-        .then(() => this.props.submitForm());
+        .then((paymentMethod) => {
+            console.log("Payment method:", paymentMethod);
+            this.props.setStripePaymentMethod(paymentMethod)
+        }).then(() => this.props.submitForm());
     }
   };
 

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -31,7 +31,7 @@ export type StripeFormPropTypes = {
   name: string,
   validateForm: Function,
   buttonText: string,
-  stripeSetupIntentEndpoint: String,
+  stripeSetupIntentEndpoint: string,
 }
 
 type StateTypes = {
@@ -123,7 +123,7 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
           this.handleCardSetup(result.client_secret);
         }
       } else {
-        throw new Error(`Missing client_secret field in response from ${window.guardian.stripeSetupIntentEndpoint}`);
+        throw new Error(`Missing client_secret field in response from ${this.props.stripeSetupIntentEndpoint}`);
       }
     }).catch((error) => {
       logException(`Error getting Stripe client secret for recurring contribution: ${error}`);

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -233,7 +233,6 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
 
       this.handleCardSetup(this.state.setupIntentClientSecret)
         .then((paymentMethod) => {
-            console.log("Payment method:", paymentMethod);
             this.props.setStripePaymentMethod(paymentMethod)
         }).then(() => this.props.submitForm());
     }

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -233,14 +233,11 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
 
   requestStripePaymentAuthorisation = (event) => {
     if (window.guardian.stripeElementsSubscriptions) {
-      console.log('Stripe SCA payments experiment enabled, using Stripe SCA payments API');
       this.requestSCAPaymentMethod(event);
     } else {
-      console.log('Stripe SCA payments experiment disabled, using old Stripe Checkout API');
       this.requestStripeToken(event);
     }
   };
-
 
   render() {
     if (this.props.stripe) {

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -229,6 +229,7 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
     this.handleCardErrors();
 
     if (this.props.stripe && this.props.allErrors.length === 0 && this.state.cardErrors.length === 0) {
+      console.log(this.props.setStripePaymentMethod);
 
       this.handleCardSetup(this.state.setupIntentClientSecret)
         .then(paymentMethod => this.props.setStripePaymentMethod(paymentMethod))

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -31,6 +31,7 @@ export type StripeFormPropTypes = {
   name: string,
   validateForm: Function,
   buttonText: string,
+  stripeSetupIntentEndpoint: String,
 }
 
 type StateTypes = {
@@ -111,11 +112,10 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
     // it's possible for it to arrive after the user clicks 'Contribute'. This eventuality
     // is handled in the callback below by checking the value of paymentWaiting.
     fetchJson(
-      window.guardian.stripeSetupIntentEndpoint,
+      this.props.stripeSetupIntentEndpoint,
       requestOptions({ publicKey: this.props.stripeKey }, 'omit', 'POST', null),
     ).then((result) => {
       if (result.client_secret) {
-        // this.setSetupIntentClientSecret(result.client_secret);
         this.setState({ setupIntentClientSecret: result.client_secret });
 
         // If user has already clicked contribute then handle card setup now

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -206,9 +206,9 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
       if (result.error) {
         this.handleStripeError(result.error);
         return Promise.resolve(result.error);
-      } else {
-        return result.setupIntent.payment_method;
       }
+      return result.setupIntent.payment_method;
+
     });
   }
 
@@ -231,20 +231,19 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
 
     if (this.props.stripe && this.props.allErrors.length === 0 && this.state.cardErrors.length === 0) {
 
-      this.handleCardSetup(this.state.setupIntentClientSecret)
-        .then((paymentMethod) => {
-            this.props.setStripePaymentMethod(paymentMethod)
-        }).then(() => this.props.submitForm());
+      this.handleCardSetup(this.state.setupIntentClientSecret).then((paymentMethod) => {
+        this.props.setStripePaymentMethod(paymentMethod);
+      }).then(() => this.props.submitForm());
     }
   };
 
   requestStripePaymentAuthorisation = (event) => {
     if (window.guardian.stripeElementsSubscriptions) {
-      console.log("Stripe SCA payments experiment enabled, using Stripe SCA payments API");
-      this.requestSCAPaymentMethod(event)
+      console.log('Stripe SCA payments experiment enabled, using Stripe SCA payments API');
+      this.requestSCAPaymentMethod(event);
     } else {
-      console.log("Stripe SCA payments experiment disabled, using old Stripe Checkout API");
-      this.requestStripeToken(event)
+      console.log('Stripe SCA payments experiment disabled, using old Stripe Checkout API');
+      this.requestStripeToken(event);
     }
   };
 

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -11,7 +11,6 @@ import { type FormField } from 'helpers/subscriptionsForms/formFields';
 import { CardNumberElement, CardExpiryElement, CardCvcElement } from 'react-stripe-elements';
 import { withError } from 'hocs/withError';
 import { withLabel } from 'hocs/withLabel';
-import { getStripeKey } from 'helpers/paymentIntegrations/stripeCheckout';
 
 import './stripeForm.scss';
 import { fetchJson, requestOptions } from 'helpers/fetch';
@@ -25,14 +24,13 @@ export type StripeFormPropTypes = {
   component: Node,
   stripe: Object,
   allErrors: FormError<FormField>[],
+  stripeKey: string,
   setStripeToken: Function,
   setStripePaymentMethod: Function,
   submitForm: Function,
   name: string,
   validateForm: Function,
   buttonText: string,
-  country: IsoCountry,
-  isTestUser: boolean,
 }
 
 type StateTypes = {
@@ -112,12 +110,9 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
     // Note - because this value is requested asynchronously when the component loads,
     // it's possible for it to arrive after the user clicks 'Contribute'. This eventuality
     // is handled in the callback below by checking the value of paymentWaiting.
-
-    const stripeKey = getStripeKey('REGULAR', this.props.country, this.props.isTestUser);
-
     fetchJson(
       window.guardian.stripeSetupIntentEndpoint,
-      requestOptions({ publicKey: stripeKey }, 'omit', 'POST', null),
+      requestOptions({ publicKey: this.props.stripeKey }, 'omit', 'POST', null),
     ).then((result) => {
       if (result.client_secret) {
         // this.setSetupIntentClientSecret(result.client_secret);

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -240,12 +240,13 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
   };
 
   render() {
-    if (this.props.stripe) {
-      this.props.stripe.elements();
-    }
+    const { stripe } = this.props;
+    if (stripe) {
+      stripe.elements();
+
     return (
       <span>
-        {this.props.stripe && (
+        {stripe && (
           <fieldset>
             <CardNumberWithError
               id="card-number"

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -243,46 +243,46 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
     const { stripe } = this.props;
     if (stripe) {
       stripe.elements();
+    }
 
     return (
       <span>
         {stripe && (
-          <fieldset>
-            <CardNumberWithError
-              id="card-number"
-              error={this.state.cardNumber.error}
-              label="Card number"
-              style={{ base: { ...baseStyles }, invalid: { ...invalidStyles } }}
-              onChange={e => this.handleChange(e)}
-            />
-            <CardExpiryWithError
-              id="card-expiry"
-              error={this.state.cardExpiry.error}
-              label="Expiry date"
-              style={{ base: { ...baseStyles }, invalid: { ...invalidStyles } }}
-              onChange={e => this.handleChange(e)}
-            />
-            <CardCvcWithError
-              id="cvc"
-              error={this.state.cardCvc.error}
-              label="CVC"
-              style={{ base: { ...baseStyles }, invalid: { ...invalidStyles } }}
-              onChange={e => this.handleChange(e)}
-            />
-            <div className="component-stripe-submit-button">
-              <Button id="qa-stripe-submit-button" onClick={event => this.requestStripePaymentAuthorisation(event)}>
-                {this.props.buttonText}
-              </Button>
-            </div>
-            <span>{this.props.component}</span>
-            {(this.state.cardErrors.length > 0 || this.props.allErrors.length > 0)
-              && <ErrorSummary errors={[...this.props.allErrors, ...this.state.cardErrors]} />}
-          </fieldset>
-        )}
+        <fieldset>
+          <CardNumberWithError
+            id="card-number"
+            error={this.state.cardNumber.error}
+            label="Card number"
+            style={{ base: { ...baseStyles }, invalid: { ...invalidStyles } }}
+            onChange={e => this.handleChange(e)}
+          />
+          <CardExpiryWithError
+            id="card-expiry"
+            error={this.state.cardExpiry.error}
+            label="Expiry date"
+            style={{ base: { ...baseStyles }, invalid: { ...invalidStyles } }}
+            onChange={e => this.handleChange(e)}
+          />
+          <CardCvcWithError
+            id="cvc"
+            error={this.state.cardCvc.error}
+            label="CVC"
+            style={{ base: { ...baseStyles }, invalid: { ...invalidStyles } }}
+            onChange={e => this.handleChange(e)}
+          />
+          <div className="component-stripe-submit-button">
+            <Button id="qa-stripe-submit-button" onClick={event => this.requestStripePaymentAuthorisation(event)}>
+              {this.props.buttonText}
+            </Button>
+          </div>
+          <span>{this.props.component}</span>
+          {(this.state.cardErrors.length > 0 || this.props.allErrors.length > 0)
+          && <ErrorSummary errors={[...this.props.allErrors, ...this.state.cardErrors]} />}
+        </fieldset>
+      )}
       </span>
     );
   }
-
 }
 
 export default injectStripe(StripeForm);

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -238,6 +238,17 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
     }
   };
 
+  requestStripePaymentAuthorisation = (event) => {
+    if (window.guardian.stripeElementsSubscriptions) {
+      console.log("Stripe SCA payments experiment enabled, using Stripe SCA payments API");
+      this.requestSCAPaymentMethod(event)
+    } else {
+      console.log("Stripe SCA payments experiment disabled, using old Stripe Checkout API");
+      this.requestStripeToken(event)
+    }
+  };
+
+
   render() {
     if (this.props.stripe) {
       this.props.stripe.elements();
@@ -268,7 +279,7 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
               onChange={e => this.handleChange(e)}
             />
             <div className="component-stripe-submit-button">
-              <Button id="qa-stripe-submit-button" onClick={event => this.requestSCAPaymentMethod(event)}>
+              <Button id="qa-stripe-submit-button" onClick={event => this.requestStripePaymentAuthorisation(event)}>
                 {this.props.buttonText}
               </Button>
             </div>

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -90,7 +90,7 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
       cardErrors.push({ field: [field], message: this.state[field].error });
     }
     return cardErrors;
-  }, [])
+  }, []);
 
   handleCardErrors = () => {
     // eslint-disable-next-line array-callback-return
@@ -112,7 +112,7 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
       }
       this.setState({ cardErrors: this.getAllCardErrors() });
     });
-  }
+  };
 
   handleChange = (event) => {
     if (this.state[event.elementType].error) {
@@ -131,7 +131,7 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
         },
       });
     }
-  }
+  };
 
   setupRecurringHandlers(): void {
     // Start by requesting the client_secret for a new Payment Method.
@@ -152,7 +152,7 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
         throw new Error(`Missing client_secret field in response from ${window.guardian.stripeSetupIntentEndpoint}`);
       }
     }).catch(error => {
-      logException(`Error getting Stripe client secret for recurring contribution: ${error}`)
+      logException(`Error getting Stripe client secret for recurring contribution: ${error}`);
       this.props.paymentFailure('internal_error');
     });
 
@@ -186,7 +186,7 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
         .then(({ token }) => this.props.setStripeToken(token.id))
         .then(() => this.props.submitForm());
     }
-  }
+  };
 
   componentDidMount() {
     this.setupRecurringHandlers();

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeProviderForCountry.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeProviderForCountry.jsx
@@ -25,6 +25,7 @@ function StripeProviderForCountry(props: PropTypes) {
           submitForm={props.submitForm}
           allErrors={props.allErrors}
           setStripeToken={props.setStripeToken}
+          setStripePaymentMethod={props.setStripePaymentMethod}
           name={props.name}
           validateForm={props.validateForm}
           buttonText={props.buttonText}

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeProviderForCountry.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeProviderForCountry.jsx
@@ -24,13 +24,12 @@ function StripeProviderForCountry(props: PropTypes) {
           component={props.component}
           submitForm={props.submitForm}
           allErrors={props.allErrors}
+          stripeKey={stripeKey}
           setStripeToken={props.setStripeToken}
           setStripePaymentMethod={props.setStripePaymentMethod}
           name={props.name}
           validateForm={props.validateForm}
           buttonText={props.buttonText}
-          country={props.country}
-          isTestUser={props.isTestUser}
         />
       </Elements>
     </StripeProvider>

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeProviderForCountry.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeProviderForCountry.jsx
@@ -28,6 +28,8 @@ function StripeProviderForCountry(props: PropTypes) {
           name={props.name}
           validateForm={props.validateForm}
           buttonText={props.buttonText}
+          country={props.country}
+          isTestUser={props.isTestUser}
         />
       </Elements>
     </StripeProvider>

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeProviderForCountry.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeProviderForCountry.jsx
@@ -27,6 +27,7 @@ function StripeProviderForCountry(props: PropTypes) {
           stripeKey={stripeKey}
           setStripeToken={props.setStripeToken}
           setStripePaymentMethod={props.setStripePaymentMethod}
+          stripeSetupIntentEndpoint={props.stripeSetupIntentEndpoint}
           name={props.name}
           validateForm={props.validateForm}
           buttonText={props.buttonText}

--- a/support-frontend/assets/helpers/subscriptionsForms/formActions.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/formActions.js
@@ -45,6 +45,7 @@ export type Action =
   | { type: 'SET_ORDER_IS_GIFT', orderIsAGift: Option<boolean>}
   | { type: 'SET_STRIPE_TOKEN', stripeToken: Option<string> }
   | { type: 'SET_DELIVERY_INSTRUCTIONS', instructions: Option<string>}
+  | { type: 'SET_STRIPE_PAYMENT_METHOD', stripePaymentMethod: string}
   | AddressAction
   | PayPalAction
   | DDAction;
@@ -118,6 +119,10 @@ const formActionCreators = {
   setStripeToken: (stripeToken: Option<string>): Action => ({
     type: 'SET_STRIPE_TOKEN',
     stripeToken,
+  }),
+  setStripePaymentMethod: (stripePaymentMethod: string): Action => ({
+    type: 'SET_STRIPE_PAYMENT_METHOD',
+    stripePaymentMethod,
   }),
   setDeliveryInstructions: (instructions: string | null): Action => ({
     type: 'SET_DELIVERY_INSTRUCTIONS',

--- a/support-frontend/assets/helpers/subscriptionsForms/formActions.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/formActions.js
@@ -45,7 +45,7 @@ export type Action =
   | { type: 'SET_ORDER_IS_GIFT', orderIsAGift: Option<boolean>}
   | { type: 'SET_STRIPE_TOKEN', stripeToken: Option<string> }
   | { type: 'SET_DELIVERY_INSTRUCTIONS', instructions: Option<string>}
-  | { type: 'SET_STRIPE_PAYMENT_METHOD', stripePaymentMethod: string}
+  | { type: 'SET_STRIPE_PAYMENT_METHOD', stripePaymentMethod: Option<string>}
   | AddressAction
   | PayPalAction
   | DDAction;
@@ -120,7 +120,7 @@ const formActionCreators = {
     type: 'SET_STRIPE_TOKEN',
     stripeToken,
   }),
-  setStripePaymentMethod: (stripePaymentMethod: string): Action => ({
+  setStripePaymentMethod: (stripePaymentMethod: Option<string>): Action => ({
     type: 'SET_STRIPE_PAYMENT_METHOD',
     stripePaymentMethod,
   }),

--- a/support-frontend/assets/helpers/subscriptionsForms/formFields.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/formFields.js
@@ -52,6 +52,7 @@ export type FormState = {|
   productPrices: ProductPrices,
   payPalHasLoaded: boolean,
   stripeToken: Option<string>,
+  stripePaymentMethod: Option<string>,
   debugInfo: string,
 |};
 

--- a/support-frontend/assets/helpers/subscriptionsForms/formReducer.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/formReducer.js
@@ -57,6 +57,7 @@ function createFormReducer(
     payPalHasLoaded: false,
     orderIsAGift: false,
     stripeToken: null,
+    stripePaymentMethod: null,
     deliveryInstructions: null,
     debugInfo: '',
   };

--- a/support-frontend/assets/helpers/subscriptionsForms/formReducer.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/formReducer.js
@@ -143,6 +143,10 @@ function createFormReducer(
 
       case 'SET_STRIPE_TOKEN':
         return { ...state, stripeToken: action.stripeToken };
+
+      case 'SET_STRIPE_PAYMENT_METHOD':
+        return { ...state, stripePaymentMethod: action.stripePaymentMethod };
+
       case 'SET_DELIVERY_INSTRUCTIONS':
         return { ...state, deliveryInstructions: action.instructions };
 

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.js
@@ -204,8 +204,6 @@ function checkStripeUserType(
   stripePaymentMethodId: Option<string>,
 ) {
 
-  console.log("On deploy payment method: ", stripePaymentMethodId);
-
   if (isPostDeployUser()) {
     if (stripePaymentMethodId != null) {
       onAuthorised({

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.js
@@ -305,8 +305,6 @@ function submitForm(
   const stripeToken = paymentMethod === Stripe ? state.page.checkout.stripeToken : null;
   const stripePaymentMethod = paymentMethod === Stripe ? state.page.checkout.stripePaymentMethod : null;
 
-  console.log('On submission check tokens:', 'Stripe Token:', stripeToken, 'Stripe payment method', stripePaymentMethod);
-
   const onAuthorised = (paymentAuthorisation: PaymentAuthorisation) =>
     onPaymentAuthorised(
       paymentAuthorisation,

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.js
@@ -296,8 +296,14 @@ function submitForm(
     );
 
   showPaymentMethod(
-    dispatch, onAuthorised, isTestUser, price, currency, billingCountry,
-    paymentMethod, stripeToken,
+    dispatch,
+    onAuthorised,
+    isTestUser,
+    price,
+    currency,
+    billingCountry,
+    paymentMethod,
+    stripeToken,
   );
 }
 

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.js
@@ -218,20 +218,18 @@ function checkStripeUserType(
         stripePaymentMethod: 'StripeCheckout',
       });
     }
+  } else if (window.guardian.stripeElementsSubscriptions) {
+    onAuthorised({
+      paymentMethod: Stripe,
+      stripePaymentMethod: 'StripeElements',
+      paymentMethodId: stripePaymentMethodId,
+    });
   } else {
-    if (window.guardian.stripeElementsSubscriptions) {
-      onAuthorised({
-        paymentMethod: Stripe,
-        stripePaymentMethod: 'StripeElements',
-        paymentMethodId: stripePaymentMethodId,
-      });
-    } else {
-      onAuthorised({
-        paymentMethod: Stripe,
-        token: stripeToken || '',
-        stripePaymentMethod: 'StripeElements',
-      });
-    }
+    onAuthorised({
+      paymentMethod: Stripe,
+      token: stripeToken || '',
+      stripePaymentMethod: 'StripeElements',
+    });
   }
 }
 
@@ -307,7 +305,7 @@ function submitForm(
   const stripeToken = paymentMethod === Stripe ? state.page.checkout.stripeToken : null;
   const stripePaymentMethod = paymentMethod === Stripe ? state.page.checkout.stripePaymentMethod : null;
 
-  console.log("On submission check tokens:", "Stripe Token:", stripeToken, "Stripe payment method", stripePaymentMethod);
+  console.log('On submission check tokens:', 'Stripe Token:', stripeToken, 'Stripe payment method', stripePaymentMethod);
 
   const onAuthorised = (paymentAuthorisation: PaymentAuthorisation) =>
     onPaymentAuthorised(

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.js
@@ -205,7 +205,7 @@ function checkStripeUserType(
 ) {
 
   if (isPostDeployUser()) {
-    if (window.guardian.stripeElementsSubscriptions) {
+    if (window.guardian.stripeElementsSubscriptions && (stripePaymentMethodId != null)) {
       onAuthorised({
         paymentMethod: Stripe,
         stripePaymentMethod: 'StripeElements',
@@ -218,7 +218,7 @@ function checkStripeUserType(
         stripePaymentMethod: 'StripeCheckout',
       });
     }
-  } else if (window.guardian.stripeElementsSubscriptions) {
+  } else if (window.guardian.stripeElementsSubscriptions && (stripePaymentMethodId != null)) {
     onAuthorised({
       paymentMethod: Stripe,
       stripePaymentMethod: 'StripeElements',

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.js
@@ -201,13 +201,23 @@ function checkStripeUserType(
   price: number,
   currency: IsoCurrency,
   stripeToken: Option<string>,
+  stripePaymentMethod: Option<string>,
 ) {
+
   if (isPostDeployUser()) {
-    onAuthorised({
-      paymentMethod: Stripe,
-      token: 'tok_visa',
-      stripePaymentMethod: 'StripeCheckout',
-    });
+    if (stripePaymentMethod) {
+      onAuthorised({
+        paymentMethod: Stripe,
+        stripePaymentMethod: 'StripeCheckout',
+        paymentMethodId: stripePaymentMethod,
+      });
+    } else {
+      onAuthorised({
+        paymentMethod: Stripe,
+        token: 'tok_visa',
+        stripePaymentMethod: 'StripeCheckout',
+      });
+    }
   } else {
     onAuthorised({
       paymentMethod: Stripe,
@@ -226,10 +236,11 @@ function showPaymentMethod(
   country: IsoCountry,
   paymentMethod: Option<PaymentMethod>,
   stripeToken: Option<string>,
+  stripePaymentMethod: Option<string>,
 ): void {
   switch (paymentMethod) {
     case Stripe:
-      checkStripeUserType(onAuthorised, isTestUser, price, currency, stripeToken);
+      checkStripeUserType(onAuthorised, isTestUser, price, currency, stripeToken, stripePaymentMethod);
       break;
     case DirectDebit:
       dispatch(openDirectDebitPopUp());
@@ -286,6 +297,7 @@ function submitForm(
   const { price, currency } = priceDetails;
   const currencyId = getCurrency(billingCountry);
   const stripeToken = paymentMethod === Stripe ? state.page.checkout.stripeToken : null;
+  const stripePaymentMethod = paymentMethod === Stripe ? state.page.checkout.stripePaymentMethod : null;
 
   const onAuthorised = (paymentAuthorisation: PaymentAuthorisation) =>
     onPaymentAuthorised(
@@ -304,6 +316,7 @@ function submitForm(
     billingCountry,
     paymentMethod,
     stripeToken,
+    stripePaymentMethod,
   );
 }
 

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.js
@@ -205,7 +205,7 @@ function checkStripeUserType(
 ) {
 
   if (isPostDeployUser()) {
-    if (stripePaymentMethodId != null) {
+    if (window.guardian.stripeElementsSubscriptions) {
       onAuthorised({
         paymentMethod: Stripe,
         stripePaymentMethod: 'StripeElements',
@@ -219,7 +219,7 @@ function checkStripeUserType(
       });
     }
   } else {
-    if (stripePaymentMethodId != null) {
+    if (window.guardian.stripeElementsSubscriptions) {
       onAuthorised({
         paymentMethod: Stripe,
         stripePaymentMethod: 'StripeElements',

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.js
@@ -201,15 +201,17 @@ function checkStripeUserType(
   price: number,
   currency: IsoCurrency,
   stripeToken: Option<string>,
-  stripePaymentMethod: Option<string>,
+  stripePaymentMethodId: Option<string>,
 ) {
 
+  console.log("On deploy payment method: ", stripePaymentMethodId);
+
   if (isPostDeployUser()) {
-    if (stripePaymentMethod) {
+    if (stripePaymentMethodId != null) {
       onAuthorised({
         paymentMethod: Stripe,
-        stripePaymentMethod: 'StripeCheckout',
-        paymentMethodId: stripePaymentMethod,
+        stripePaymentMethod: 'StripeElements',
+        paymentMethodId: stripePaymentMethodId,
       });
     } else {
       onAuthorised({
@@ -219,11 +221,19 @@ function checkStripeUserType(
       });
     }
   } else {
-    onAuthorised({
-      paymentMethod: Stripe,
-      token: stripeToken || '',
-      stripePaymentMethod: 'StripeElements',
-    });
+    if (stripePaymentMethodId != null) {
+      onAuthorised({
+        paymentMethod: Stripe,
+        stripePaymentMethod: 'StripeElements',
+        paymentMethodId: stripePaymentMethodId,
+      });
+    } else {
+      onAuthorised({
+        paymentMethod: Stripe,
+        token: stripeToken || '',
+        stripePaymentMethod: 'StripeElements',
+      });
+    }
   }
 }
 
@@ -298,6 +308,8 @@ function submitForm(
   const currencyId = getCurrency(billingCountry);
   const stripeToken = paymentMethod === Stripe ? state.page.checkout.stripeToken : null;
   const stripePaymentMethod = paymentMethod === Stripe ? state.page.checkout.stripePaymentMethod : null;
+
+  console.log("On submission check tokens:", "Stripe Token:", stripeToken, "Stripe payment method", stripePaymentMethod);
 
   const onAuthorised = (paymentAuthorisation: PaymentAuthorisation) =>
     onPaymentAuthorised(

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
@@ -75,6 +75,7 @@ type PropTypes = {|
   country: IsoCountry,
   signOut: typeof signOut,
   submitForm: Function,
+
   formErrors: FormError<FormField>[],
   submissionError: ErrorReason | null,
   productPrices: ProductPrices,
@@ -245,6 +246,7 @@ function DigitalCheckoutForm(props: PropTypes) {
               submitForm={props.submitForm}
               allErrors={[...props.addressErrors]}
               setStripeToken={props.setStripeToken}
+              setStripePaymentMethod={props.setStripePaymentMethod}
               name={`${props.firstName} ${props.lastName}`}
               validateForm={props.validateForm}
               buttonText="Start your free trial now"

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
@@ -66,7 +66,7 @@ import {
 import GeneralErrorMessage
   from 'components/generalErrorMessage/generalErrorMessage';
 import { StripeProviderForCountry } from 'components/subscriptionCheckouts/stripeForm/stripeProviderForCountry';
-import {getGlobal} from "helpers/globals";
+import { getGlobal } from 'helpers/globals';
 
 
 // ----- Types ----- //
@@ -91,6 +91,7 @@ type PropTypes = {|
   validateForm: () => Function,
   formIsValid: Function,
   addressErrors: Array<Object>,
+  stripeSetupIntentEndpoint: string,
 |};
 
 // ----- Map State/Props ----- //
@@ -114,7 +115,7 @@ function mapStateToProps(state: CheckoutState) {
     ).price,
     billingPeriod: state.page.checkout.billingPeriod,
     addressErrors: state.page.billingAddress.fields.formErrors,
-    stripeSetupIntentEndpoint: getGlobal("stripeSetupIntentEndpoint"),
+    stripeSetupIntentEndpoint: getGlobal('stripeSetupIntentEndpoint'),
   };
 }
 

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
@@ -66,6 +66,7 @@ import {
 import GeneralErrorMessage
   from 'components/generalErrorMessage/generalErrorMessage';
 import { StripeProviderForCountry } from 'components/subscriptionCheckouts/stripeForm/stripeProviderForCountry';
+import {getGlobal} from "helpers/globals";
 
 
 // ----- Types ----- //
@@ -113,6 +114,7 @@ function mapStateToProps(state: CheckoutState) {
     ).price,
     billingPeriod: state.page.checkout.billingPeriod,
     addressErrors: state.page.billingAddress.fields.formErrors,
+    stripeSetupIntentEndpoint: getGlobal("stripeSetupIntentEndpoint"),
   };
 }
 
@@ -247,6 +249,7 @@ function DigitalCheckoutForm(props: PropTypes) {
               allErrors={[...props.addressErrors]}
               setStripeToken={props.setStripeToken}
               setStripePaymentMethod={props.setStripePaymentMethod}
+              stripeSetupIntentEndpoint={props.stripeSetupIntentEndpoint}
               name={`${props.firstName} ${props.lastName}`}
               validateForm={props.validateForm}
               buttonText="Start your free trial now"

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
@@ -70,7 +70,7 @@ import { validateWithDeliveryForm } from 'helpers/subscriptionsForms/formValidat
 import GeneralErrorMessage
   from 'components/generalErrorMessage/generalErrorMessage';
 import { StripeProviderForCountry } from 'components/subscriptionCheckouts/stripeForm/stripeProviderForCountry';
-import {getGlobal} from "helpers/globals";
+import { getGlobal } from 'helpers/globals';
 
 // ----- Types ----- //
 
@@ -87,6 +87,7 @@ type PropTypes = {|
   country: IsoCountry,
   isTestUser: boolean,
   validateForm: () => Function,
+  stripeSetupIntentEndpoint: string,
 |};
 
 // ----- Map State/Props ----- //
@@ -101,7 +102,7 @@ function mapStateToProps(state: WithDeliveryCheckoutState) {
     deliveryAddressErrors: state.page.billingAddress.fields.formErrors,
     isTestUser: state.page.checkout.isTestUser,
     country: state.common.internationalisation.countryId,
-    stripeSetupIntentEndpoint: getGlobal("stripeSetupIntentEndpoint"),
+    stripeSetupIntentEndpoint: getGlobal('stripeSetupIntentEndpoint'),
   };
 }
 

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
@@ -297,6 +297,7 @@ function PaperCheckoutForm(props: PropTypes) {
               submitForm={props.submitForm}
               allErrors={[...props.billingAddressErrors, ...props.deliveryAddressErrors, ...props.formErrors]}
               setStripeToken={props.setStripeToken}
+              setStripePaymentMethod={props.setStripePaymentMethod}
               name={`${props.firstName} ${props.lastName}`}
               validateForm={props.validateForm}
               buttonText="Pay now"

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
@@ -70,6 +70,7 @@ import { validateWithDeliveryForm } from 'helpers/subscriptionsForms/formValidat
 import GeneralErrorMessage
   from 'components/generalErrorMessage/generalErrorMessage';
 import { StripeProviderForCountry } from 'components/subscriptionCheckouts/stripeForm/stripeProviderForCountry';
+import {getGlobal} from "helpers/globals";
 
 // ----- Types ----- //
 
@@ -100,6 +101,7 @@ function mapStateToProps(state: WithDeliveryCheckoutState) {
     deliveryAddressErrors: state.page.billingAddress.fields.formErrors,
     isTestUser: state.page.checkout.isTestUser,
     country: state.common.internationalisation.countryId,
+    stripeSetupIntentEndpoint: getGlobal("stripeSetupIntentEndpoint"),
   };
 }
 
@@ -298,6 +300,7 @@ function PaperCheckoutForm(props: PropTypes) {
               allErrors={[...props.billingAddressErrors, ...props.deliveryAddressErrors, ...props.formErrors]}
               setStripeToken={props.setStripeToken}
               setStripePaymentMethod={props.setStripePaymentMethod}
+              stripeSetupIntentEndpoint={props.stripeSetupIntentEndpoint}
               name={`${props.firstName} ${props.lastName}`}
               validateForm={props.validateForm}
               buttonText="Pay now"

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -339,6 +339,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
               submitForm={props.submitForm}
               allErrors={[...props.billingAddressErrors, ...props.deliveryAddressErrors, ...props.formErrors]}
               setStripeToken={props.setStripeToken}
+              setStripePaymentMethod={props.setStripePaymentMethod}
               name={`${props.firstName} ${props.lastName}`}
               validateForm={props.validateForm}
               buttonText="Pay now"

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -72,6 +72,7 @@ import { validateWithDeliveryForm } from 'helpers/subscriptionsForms/formValidat
 import GeneralErrorMessage
   from 'components/generalErrorMessage/generalErrorMessage';
 import { StripeProviderForCountry } from 'components/subscriptionCheckouts/stripeForm/stripeProviderForCountry';
+import {getGlobal} from "helpers/globals";
 
 // ----- Types ----- //
 
@@ -109,6 +110,7 @@ function mapStateToProps(state: WithDeliveryCheckoutState) {
     billingAddressErrors: state.page.billingAddress.fields.formErrors,
     isTestUser: state.page.checkout.isTestUser,
     country: state.common.internationalisation.countryId,
+    stripeSetupIntentEndpoint: getGlobal("stripeSetupIntentEndpoint"),
   };
 }
 
@@ -340,6 +342,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
               allErrors={[...props.billingAddressErrors, ...props.deliveryAddressErrors, ...props.formErrors]}
               setStripeToken={props.setStripeToken}
               setStripePaymentMethod={props.setStripePaymentMethod}
+              stripeSetupIntentEndpoint={props.stripeSetupIntentEndpoint}
               name={`${props.firstName} ${props.lastName}`}
               validateForm={props.validateForm}
               buttonText="Pay now"

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -72,7 +72,7 @@ import { validateWithDeliveryForm } from 'helpers/subscriptionsForms/formValidat
 import GeneralErrorMessage
   from 'components/generalErrorMessage/generalErrorMessage';
 import { StripeProviderForCountry } from 'components/subscriptionCheckouts/stripeForm/stripeProviderForCountry';
-import {getGlobal} from "helpers/globals";
+import { getGlobal } from 'helpers/globals';
 
 // ----- Types ----- //
 
@@ -92,6 +92,7 @@ type PropTypes = {|
   country: IsoCountry,
   isTestUser: boolean,
   validateForm: () => Function,
+  stripeSetupIntentEndpoint: string
 |};
 
 // ----- Map State/Props ----- //
@@ -110,7 +111,7 @@ function mapStateToProps(state: WithDeliveryCheckoutState) {
     billingAddressErrors: state.page.billingAddress.fields.formErrors,
     isTestUser: state.page.checkout.isTestUser,
     country: state.common.internationalisation.countryId,
-    stripeSetupIntentEndpoint: getGlobal("stripeSetupIntentEndpoint"),
+    stripeSetupIntentEndpoint: getGlobal('stripeSetupIntentEndpoint'),
   };
 }
 

--- a/support-frontend/test/selenium/subscriptions/pages/CheckoutPage.scala
+++ b/support-frontend/test/selenium/subscriptions/pages/CheckoutPage.scala
@@ -26,7 +26,7 @@ trait CheckoutPage extends Page with Browser {
     pageHasElement(cardNumber)
   }
 
-  def fillStripeForm(): Unit = {
+  def fillStripeForm: Unit = {
     for (_ <- 1 to 8) setValue(cardNumber, "42")
     switchToParentFrame
     switchToFrame(1)

--- a/support-frontend/test/selenium/subscriptions/pages/CheckoutPage.scala
+++ b/support-frontend/test/selenium/subscriptions/pages/CheckoutPage.scala
@@ -26,7 +26,7 @@ trait CheckoutPage extends Page with Browser {
     pageHasElement(cardNumber)
   }
 
-  def fillStripeForm: Unit = {
+  def fillStripeForm(): Unit = {
     for (_ <- 1 to 8) setValue(cardNumber, "42")
     switchToParentFrame
     switchToFrame(1)
@@ -42,9 +42,9 @@ trait CheckoutPage extends Page with Browser {
     pageHasElement(className("thank-you-stage"))
   }
 
-  def clickSubmit: Unit = clickOn(submitButton)
+  def clickSubmit(): Unit = clickOn(submitButton)
 
-  def clickStripeSubmit: Unit = clickOn(stripeSubmitButton)
+  def clickStripeSubmit(): Unit = clickOn(stripeSubmitButton)
 
-  def fillForm: Unit
+  def fillForm(): Unit
 }

--- a/support-frontend/test/selenium/subscriptions/pages/DigitalPackCheckout.scala
+++ b/support-frontend/test/selenium/subscriptions/pages/DigitalPackCheckout.scala
@@ -11,7 +11,7 @@ class DigitalPackCheckout(implicit val webDriver: WebDriver) extends CheckoutPag
   private val city = id("billing-city")
   private val postcode = id("billing-postcode")
 
-  def fillForm {
+  def fillForm(): Unit = {
     setValue(addressLineOne, "Kings Place")
     setValue(city, "London")
     setValue(postcode, "N19GU")


### PR DESCRIPTION
## Why are you doing this?

<!--

-->

[**Trello Card**](https://trello.com/c/p5IsHsZn/2579-connect-stripe-elements-to-intent-client-secret-for-client-side)

## Changes

* Add stripe elements frontend API integration in addition to payment token API now deprecated.
* Add stripe intent token lambda API integration.
* Enabling SCA payments for next generation secure Stripe API usage.
* Upgraded front end client logic to enable SCA payments.
* Added a feature flag to allow switching between `StripeCheckout` and `StripeElements` API with payment intent/SCA payments usage.

