### PR TITLE
Stripe Payment Method creation errors: stringify error object in log

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
@@ -216,7 +216,7 @@ class CardForm extends Component<PropTypes, StateTypes> {
   handleStripeError(errorData: any): void {
     this.props.setPaymentWaiting(false);
 
-    logException(`Error creating Payment Method: ${errorData}`);
+    logException(`Error creating Payment Method: ${JSON.stringify(errorData)}`);
 
     if (errorData.type === 'validation_error') {
       // This shouldn't be possible as we disable the submit button until all fields are valid, but if it does


### PR DESCRIPTION
I've noticed a few error logs in sentry caused by failure to request a new Payment Method from Stripe. The error logging is currently not very helpful though:
`Error creating Payment Method: [object Object]`