### PR TITLE
Work in progress: Transaction fees, client-side including analytics

### DIFF
--- a/support-frontend/assets/components/forms/customFields/checkbox.jsx
+++ b/support-frontend/assets/components/forms/customFields/checkbox.jsx
@@ -9,7 +9,7 @@ import './checkbox.scss';
 // ----- Types ----- //
 
 type PropTypes = {
-  id?: string,
+  id: ?string,
   text: Node
 };
 

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -8,7 +8,7 @@ export type LandingPageCopyReturningSinglesTestVariants = 'control' | 'returning
 export type LandingPageMomentBackgroundColourTestVariants = 'control' | 'yellow' | 'notintest';
 export type LandingPageStripeElementsRecurringTestVariants = 'control' | 'stripeElements' | 'notintest';
 export type PaymentSecurityDesignTestVariants = 'control' | 'V1_securetop' | 'V2_securemiddle' | 'V3_securebottom' | 'V4_grey'
-export type LandingPageTransactionFeeCopyVariants = 'control' | 'pleaseAdd' | 'iAmHappyToAdd' | 'iAmHappyToAddAverage' | 'notintest';
+export type LandingPageTransactionFeeCopyVariants = 'control' | 'pleaseAdd' | 'iAmHappyToAdd' | 'iWillCover' | 'notintest';
 
 const contributionsLandingPageMatch = '/(uk|us|eu|au|ca|nz|int)/contribute(/.*)?$';
 
@@ -146,7 +146,7 @@ export const tests: Tests = {
         id: 'iAmHappyToAdd',
       },
       {
-        id: 'iAmHappyToAddAverage',
+        id: 'iWillCover',
       },
     ],
     audiences: {

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -8,6 +8,7 @@ export type LandingPageCopyReturningSinglesTestVariants = 'control' | 'returning
 export type LandingPageMomentBackgroundColourTestVariants = 'control' | 'yellow' | 'notintest';
 export type LandingPageStripeElementsRecurringTestVariants = 'control' | 'stripeElements' | 'notintest';
 export type PaymentSecurityDesignTestVariants = 'control' | 'V1_securetop' | 'V2_securemiddle' | 'V3_securebottom' | 'V4_grey'
+export type LandingPageTransactionFeeCopyVariants = 'control' | 'pleaseAdd' | 'iAmHappyToAdd' | 'iAmHappyToAddAverage' | 'notintest';
 
 const contributionsLandingPageMatch = '/(uk|us|eu|au|ca|nz|int)/contribute(/.*)?$';
 
@@ -135,6 +136,9 @@ export const tests: Tests = {
   landingPageTransactionFeeCopy: {
     type: 'OTHER',
     variants: [
+      {
+        id: 'control',
+      },
       {
         id: 'pleaseAdd',
       },

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -100,6 +100,7 @@ export const tests: Tests = {
     targetPage: '/(uk|us|eu|au|ca|nz|int)/subscribe/digital$',
     optimizeId: 'emQ5nZJCS5mZkhtwwqfx5Q',
   },
+
   paymentSecurityDesignTest: {
     type: 'OTHER',
     variants: [
@@ -128,6 +129,31 @@ export const tests: Tests = {
     isActive: true,
     independent: true,
     seed: 10,
+    targetPage: contributionsLandingPageMatch,
+  },
+
+  landingPageTransactionFeeCopy: {
+    type: 'OTHER',
+    variants: [
+      {
+        id: 'pleaseAdd',
+      },
+      {
+        id: 'iAmHappyToAdd',
+      },
+      {
+        id: 'iAmHappyToAddAverage',
+      },
+    ],
+    audiences: {
+      ALL: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: true,
+    independent: true,
+    seed: 2,
     targetPage: contributionsLandingPageMatch,
   },
 };

--- a/support-frontend/assets/helpers/checkouts.js
+++ b/support-frontend/assets/helpers/checkouts.js
@@ -14,7 +14,6 @@ import { type Switches } from 'helpers/settings';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { Currency, IsoCurrency, SpokenCurrency } from 'helpers/internationalisation/currency';
 import { currencies, spokenCurrencies } from 'helpers/internationalisation/currency';
-import type { Amount, SelectedAmounts } from 'helpers/contributions';
 import type { PaymentMethod } from 'helpers/paymentMethods';
 import { DirectDebit, PayPal, Stripe } from 'helpers/paymentMethods';
 import { ExistingCard, ExistingDirectDebit } from './paymentMethods';
@@ -122,31 +121,27 @@ function getPaymentDescription(contributionType: ContributionType, paymentMethod
   return '';
 }
 
-const formatAmount = (currency: Currency, spokenCurrency: SpokenCurrency, amount: Amount, verbose: boolean) =>
-  (verbose ?
-    `${amount.value} ${amount.value === 1 ? spokenCurrency.singular : spokenCurrency.plural}` :
-    `${currency.glyph}${amount.value}`);
+const formatAmount = (currency: Currency, spokenCurrency: SpokenCurrency, amount: string, verbose: boolean) => {
+  const numericAmount = Number(amount);
+  return (verbose ?
+    `${numericAmount} ${numericAmount === 1 ? spokenCurrency.singular : spokenCurrency.plural}` :
+    `${currency.glyph}${numericAmount % 1 ? numericAmount.toFixed(2) : numericAmount}`);
+};
 
 
 const getContributeButtonCopy = (
   contributionType: ContributionType,
-  maybeOtherAmount: string | null,
-  selectedAmounts: SelectedAmounts,
+  amount: number,
   currency: IsoCurrency,
 ) => {
   const frequency = getFrequency(contributionType);
-  const otherAmount = maybeOtherAmount ? {
-    value: maybeOtherAmount,
-    spoken: '',
-    isDefault: false,
-  } : null;
-  const amount = selectedAmounts[contributionType] === 'other' ? otherAmount : selectedAmounts[contributionType];
+  const amountAsString = amount.toString();
 
   const amountCopy = amount ?
     formatAmount(
       currencies[currency],
       spokenCurrencies[currency],
-      amount,
+      amountAsString,
       false,
     ) : '';
   return `Contribute ${amountCopy} ${frequency}`;
@@ -154,13 +149,12 @@ const getContributeButtonCopy = (
 
 const getContributeButtonCopyWithPaymentType = (
   contributionType: ContributionType,
-  maybeOtherAmount: string | null,
-  selectedAmounts: SelectedAmounts,
+  amount: number,
   currency: IsoCurrency,
   paymentMethod: PaymentMethod,
 ) => {
   const paymentDescriptionCopy = getPaymentDescription(contributionType, paymentMethod);
-  const contributionButtonCopy = getContributeButtonCopy(contributionType, maybeOtherAmount, selectedAmounts, currency);
+  const contributionButtonCopy = getContributeButtonCopy(contributionType, amount, currency);
   return `${contributionButtonCopy} ${paymentDescriptionCopy}`;
 };
 

--- a/support-frontend/assets/helpers/contributions.js
+++ b/support-frontend/assets/helpers/contributions.js
@@ -90,16 +90,6 @@ export type OtherAmounts = {
 
 export type SelectedAmounts = { [ContributionType]: Amount | 'other' };
 
-
-const getAmount = (
-  selectedAmounts: SelectedAmounts,
-  otherAmounts: OtherAmounts,
-  contributionType: ContributionType,
-) =>
-  parseFloat(selectedAmounts[contributionType] === 'other'
-    ? otherAmounts[contributionType].amount
-    : selectedAmounts[contributionType].value);
-
 const getTransactionFee = (baseAmount: number): number => {
   if (baseAmount < 20 && baseAmount > 0) {
     // Return a 9% transaction fee (made up number)
@@ -117,6 +107,23 @@ const getAmountWithoutTransactionFee = (
   parseFloat(selectedAmounts[contributionType] === 'other'
     ? otherAmounts[contributionType].amount
     : selectedAmounts[contributionType].value);
+
+const getAmount = (
+  selectedAmounts: SelectedAmounts,
+  otherAmounts: OtherAmounts,
+  contributionType: ContributionType,
+  transactionFeeConsent?: boolean,
+) => {
+  const baseContributionAmount: number =
+    getAmountWithoutTransactionFee(selectedAmounts, otherAmounts, contributionType);
+
+  if (transactionFeeConsent) {
+    const transactionFee: number = getTransactionFee(baseContributionAmount);
+    return (baseContributionAmount + transactionFee);
+  }
+
+  return baseContributionAmount;
+};
 
 const getFormattedAmount = (amount: number, currencyString: string, countryGroupId: CountryGroupId) => {
   if (amount < 1 && countryGroupId === 'GBPCountries') {

--- a/support-frontend/assets/helpers/contributions.js
+++ b/support-frontend/assets/helpers/contributions.js
@@ -91,7 +91,29 @@ export type OtherAmounts = {
 export type SelectedAmounts = { [ContributionType]: Amount | 'other' };
 
 
-const getAmount = (selectedAmounts: SelectedAmounts, otherAmounts: OtherAmounts, contributionType: ContributionType) =>
+const getAmount = (
+  selectedAmounts: SelectedAmounts,
+  otherAmounts: OtherAmounts,
+  contributionType: ContributionType,
+) =>
+  parseFloat(selectedAmounts[contributionType] === 'other'
+    ? otherAmounts[contributionType].amount
+    : selectedAmounts[contributionType].value);
+
+const getTransactionFee = (baseAmount: number): number => {
+  if (baseAmount < 20 && baseAmount > 0) {
+    // Return a 9% transaction fee (made up number)
+    return baseAmount * 0.09;
+  }
+  // Return a 3% transaction fee (made up number)
+  return baseAmount * 0.03;
+};
+
+const getAmountWithoutTransactionFee = (
+  selectedAmounts: SelectedAmounts,
+  otherAmounts: OtherAmounts,
+  contributionType: ContributionType,
+) =>
   parseFloat(selectedAmounts[contributionType] === 'other'
     ? otherAmounts[contributionType].amount
     : selectedAmounts[contributionType].value);
@@ -457,5 +479,7 @@ export {
   getContributionAmountRadios,
   parseRegularContributionType,
   getAmount,
+  getTransactionFee,
+  getAmountWithoutTransactionFee,
   contributionTypeAvailable,
 };

--- a/support-frontend/assets/helpers/contributions.js
+++ b/support-frontend/assets/helpers/contributions.js
@@ -118,6 +118,13 @@ const getAmountWithoutTransactionFee = (
     ? otherAmounts[contributionType].amount
     : selectedAmounts[contributionType].value);
 
+const getFormattedAmount = (amount: number, currencyString: string, countryGroupId: CountryGroupId) => {
+  if (amount < 1 && countryGroupId === 'GBPCountries') {
+    return `${(amount * 100).toFixed(0)}p`;
+  }
+  return `${currencyString}${(amount).toFixed(2)}`;
+};
+
 // ----- Setup ----- //
 
 /* eslint-disable quote-props */
@@ -481,5 +488,6 @@ export {
   getAmount,
   getTransactionFee,
   getAmountWithoutTransactionFee,
+  getFormattedAmount,
   contributionTypeAvailable,
 };

--- a/support-frontend/assets/helpers/paymentIntegrations/payPalRecurringCheckout.js
+++ b/support-frontend/assets/helpers/paymentIntegrations/payPalRecurringCheckout.js
@@ -71,6 +71,7 @@ const setupRecurringPayPalPayment = (
       state.page.form.selectedAmounts,
       state.page.form.formData.otherAmounts,
       contributionType,
+      state.page.form.transactionFeeConsent,
     );
     const billingPeriod = billingPeriodFromContrib(contributionType);
     storage.setSession('selectedPaymentMethod', 'PayPal');

--- a/support-frontend/assets/helpers/tracking/__tests__/__snapshots__/acquisitionsTest.js.snap
+++ b/support-frontend/assets/helpers/tracking/__tests__/__snapshots__/acquisitionsTest.js.snap
@@ -32,6 +32,7 @@ Object {
   "referrerPageviewId": "123456",
   "referrerUrl": "https://example.com",
   "source": "exampleSource",
+  "transactionFee": undefined,
   "visitId": null,
 }
 `;

--- a/support-frontend/assets/helpers/tracking/__tests__/acquisitionsTest.js
+++ b/support-frontend/assets/helpers/tracking/__tests__/acquisitionsTest.js
@@ -41,7 +41,7 @@ describe('acquisitions', () => {
       const baseAmount: number = 50;
 
       const paymentApiAcquisitionData =
-        derivePaymentApiAcquisitionData(referrerAcquisitionData, nativeAbParticipations, baseAmount, true);
+        derivePaymentApiAcquisitionData(referrerAcquisitionData, nativeAbParticipations, baseAmount, false);
 
       expect(paymentApiAcquisitionData).toMatchSnapshot();
 

--- a/support-frontend/assets/helpers/tracking/__tests__/acquisitionsTest.js
+++ b/support-frontend/assets/helpers/tracking/__tests__/acquisitionsTest.js
@@ -38,8 +38,10 @@ describe('acquisitions', () => {
         testId3: 'variant3',
       };
 
+      const baseAmount: number = 50;
+
       const paymentApiAcquisitionData =
-        derivePaymentApiAcquisitionData(referrerAcquisitionData, nativeAbParticipations);
+        derivePaymentApiAcquisitionData(referrerAcquisitionData, nativeAbParticipations, baseAmount, true);
 
       expect(paymentApiAcquisitionData).toMatchSnapshot();
 

--- a/support-frontend/assets/helpers/tracking/acquisitions.js
+++ b/support-frontend/assets/helpers/tracking/acquisitions.js
@@ -11,6 +11,7 @@ import type { Participations } from 'helpers/abTests/abtest';
 import * as storage from 'helpers/storage';
 import { getAllQueryParamsWithExclusions } from 'helpers/url';
 import { getCampaignName } from 'helpers/campaigns';
+import { getTransactionFee } from 'helpers/contributions';
 
 // ----- Types ----- //
 
@@ -59,6 +60,7 @@ export type PaymentAPIAcquisitionData = {|
   source: ?string,
   abTests: ?AcquisitionABTest[],
   gaId: ?string,
+  transactionFee?: number,
 |};
 
 // ----- Setup ----- //
@@ -223,6 +225,8 @@ const getAbTests = (
 function derivePaymentApiAcquisitionData(
   referrerAcquisitionData: ReferrerAcquisitionData,
   nativeAbParticipations: Participations,
+  baseContributionAmount?: number,
+  transactionFeeConsent?: boolean,
 ): PaymentAPIAcquisitionData {
   const ophanIds: OphanIds = getOphanIds();
 
@@ -230,6 +234,9 @@ function derivePaymentApiAcquisitionData(
 
   const campaignCodes = referrerAcquisitionData.campaignCode ?
     [referrerAcquisitionData.campaignCode] : [];
+
+  const transactionFee =
+    baseContributionAmount && transactionFeeConsent ? getTransactionFee(baseContributionAmount) : undefined;
 
   return {
     platform: 'SUPPORT',
@@ -244,6 +251,7 @@ function derivePaymentApiAcquisitionData(
     source: referrerAcquisitionData.source,
     abTests,
     gaId: getCookie('_ga'),
+    transactionFee,
   };
 }
 

--- a/support-frontend/assets/helpers/tracking/acquisitions.js
+++ b/support-frontend/assets/helpers/tracking/acquisitions.js
@@ -225,8 +225,8 @@ const getAbTests = (
 function derivePaymentApiAcquisitionData(
   referrerAcquisitionData: ReferrerAcquisitionData,
   nativeAbParticipations: Participations,
-  baseContributionAmount?: number,
-  transactionFeeConsent?: boolean,
+  baseContributionAmount: number,
+  transactionFeeConsent: boolean,
 ): PaymentAPIAcquisitionData {
   const ophanIds: OphanIds = getOphanIds();
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
@@ -104,7 +104,7 @@ const renderAmount = (
         }
       />
       <label htmlFor={`contributionAmount-${amount.value}`} className="form__radio-group-label" aria-label={formatAmount(currency, spokenCurrency, amount, true)}>
-        {formatAmount(currency, spokenCurrency, amount, false)}
+        {formatAmount(currency, spokenCurrency, amount.value, false)}
       </label>
     </li>
   );
@@ -158,9 +158,9 @@ function withProps(props: PropTypes) {
   const showWeeklyBreakdown: boolean = props.contributionType === 'MONTHLY' || props.contributionType === 'ANNUAL';
   const { min, max } = config[props.countryGroupId][props.contributionType]; // eslint-disable-line react/prop-types
   const minAmount: string =
-    formatAmount(currencies[props.currency], spokenCurrencies[props.currency], { value: min.toString() }, false);
+    formatAmount(currencies[props.currency], spokenCurrencies[props.currency], min.toString(), false);
   const maxAmount: string =
-    formatAmount(currencies[props.currency], spokenCurrencies[props.currency], { value: max.toString() }, false);
+    formatAmount(currencies[props.currency], spokenCurrencies[props.currency], max.toString(), false);
   const otherAmount = props.otherAmounts[props.contributionType].amount;
 
   return (

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
@@ -5,7 +5,14 @@
 import type { OtherAmounts, SelectedAmounts } from 'helpers/contributions';
 import React from 'react';
 import { connect } from 'react-redux';
-import { config, type AmountsRegions, type Amount, type ContributionType, getAmount } from 'helpers/contributions';
+import {
+  config,
+  type AmountsRegions,
+  type Amount,
+  type ContributionType,
+  getAmount,
+  getFormattedAmount
+} from 'helpers/contributions';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import {
   type IsoCurrency,
@@ -122,13 +129,6 @@ const iconForCountryGroup = (countryGroupId: CountryGroupId): React$Element<*> =
   }
 };
 
-const amountFormatted = (amount: number, currencyString: string, countryGroupId: CountryGroupId) => {
-  if (amount < 1 && countryGroupId === 'GBPCountries') {
-    return `${(amount * 100).toFixed(0)}p`;
-  }
-  return `${currencyString}${(amount).toFixed(2)}`;
-};
-
 export const getAmountPerWeekBreakdown = (
   contributionType: ContributionType,
   countryGroupId: CountryGroupId,
@@ -146,7 +146,7 @@ export const getAmountPerWeekBreakdown = (
   }
 
   if (amount && weeklyAmount) {
-    return `Contributing ${currencyString}${amount} works out as ${amountFormatted(weeklyAmount, currencyString, countryGroupId)} each week`;
+    return `Contributing ${currencyString}${amount} works out as ${getFormattedAmount(weeklyAmount, currencyString, countryGroupId)} each week`;
   }
 
   return '';

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
@@ -103,7 +103,7 @@ const renderAmount = (
           props.selectAmount(amount, props.countryGroupId, props.contributionType)
         }
       />
-      <label htmlFor={`contributionAmount-${amount.value}`} className="form__radio-group-label" aria-label={formatAmount(currency, spokenCurrency, amount, true)}>
+      <label htmlFor={`contributionAmount-${amount.value}`} className="form__radio-group-label" aria-label={formatAmount(currency, spokenCurrency, amount.value, true)}>
         {formatAmount(currency, spokenCurrency, amount.value, false)}
       </label>
     </li>

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
@@ -10,8 +10,7 @@ import {
   type AmountsRegions,
   type Amount,
   type ContributionType,
-  getAmount,
-  getFormattedAmount,
+  getFormattedAmount, getAmountWithoutTransactionFee,
 } from 'helpers/contributions';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import {
@@ -136,7 +135,7 @@ export const getAmountPerWeekBreakdown = (
   otherAmounts: OtherAmounts,
 ): string => {
   const currencyString = currencies[detect(countryGroupId)].glyph;
-  const amount = getAmount(selectedAmounts, otherAmounts, contributionType);
+  const amount = getAmountWithoutTransactionFee(selectedAmounts, otherAmounts, contributionType);
 
   let weeklyAmount: number;
   if (contributionType === 'ANNUAL') {

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
@@ -11,7 +11,7 @@ import {
   type Amount,
   type ContributionType,
   getAmount,
-  getFormattedAmount
+  getFormattedAmount,
 } from 'helpers/contributions';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import {

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
@@ -52,9 +52,9 @@ import type { PaymentMethod } from 'helpers/paymentMethods';
 import { DirectDebit, Stripe, ExistingCard, ExistingDirectDebit } from 'helpers/paymentMethods';
 import { getCampaignName } from 'helpers/campaigns';
 import type { LandingPageStripeElementsRecurringTestVariants } from 'helpers/abTests/abtestDefinitions';
-
 import SecureTransactionIndicator from 'components/secureTransactionIndicator/secureTransactionIndicator';
 import type { PaymentSecurityDesignTestVariants } from 'helpers/abTests/abtestDefinitions';
+import { ContributionTransactionFeeOption } from './ContributionTransactionFeeOption';
 
 // ----- Types ----- //
 /* eslint-disable react/no-unused-prop-types */

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
@@ -258,6 +258,7 @@ function withProps(props: PropTypes) {
         <ContributionAmount
           checkOtherAmount={checkAmount}
         />
+        <ContributionTransactionFeeOption />
       </div>
       <StripePaymentRequestButtonContainer
         setStripeHasLoaded={props.setStripeV3HasLoaded}

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
@@ -87,6 +87,7 @@ type PropTypes = {|
   createStripePaymentMethod: () => void,
   stripeElementsRecurringTestVariant: LandingPageStripeElementsRecurringTestVariants,
   paymentSecurityDesignTestVariant: PaymentSecurityDesignTestVariants,
+  transactionFeeConsent: boolean,
 |};
 
 // We only want to use the user state value if the form state value has not been changed since it was initialised,
@@ -119,6 +120,7 @@ const mapStateToProps = (state: State) => ({
   stripeV3HasLoaded: state.page.form.stripeV3HasLoaded,
   stripeElementsRecurringTestVariant: state.common.abParticipations.stripeElementsRecurring,
   paymentSecurityDesignTestVariant: state.common.abParticipations.paymentSecurityDesignTest,
+  transactionFeeConsent: state.page.form.transactionFeeConsent,
 });
 
 
@@ -269,6 +271,7 @@ function withProps(props: PropTypes) {
         country={props.country}
         otherAmounts={props.otherAmounts}
         selectedAmounts={props.selectedAmounts}
+        transactionFeeConsent={props.transactionFeeConsent}
       />
       <div className={classNameWithModifiers('form', ['content'])}>
         <ContributionFormFields />

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
@@ -145,6 +145,7 @@ function openStripePopup(props: PropTypes) {
         props.selectedAmounts,
         props.otherAmounts,
         props.contributionType,
+        props.transactionFeeConsent,
       ),
       props.email,
     );
@@ -197,6 +198,7 @@ const formHandlers: PaymentMatrix<PropTypes => void> = {
           props.selectedAmounts,
           props.otherAmounts,
           props.contributionType,
+          props.transactionFeeConsent,
         ),
         returnURL: payPalReturnUrl(props.countryGroupId, props.email),
         cancelURL: payPalCancelUrl(props.countryGroupId),

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionSubmit.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionSubmit.jsx
@@ -9,7 +9,6 @@ import { connect } from 'react-redux';
 import { billingPeriodFromContrib, type ContributionType, getAmount } from 'helpers/contributions';
 import { type IsoCurrency } from 'helpers/internationalisation/currency';
 import { type PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
-import type { SelectedAmounts } from 'helpers/contributions';
 import { getContributeButtonCopyWithPaymentType } from 'helpers/checkouts';
 import { hiddenIf } from 'helpers/utilities';
 import { setupRecurringPayPalPayment } from 'helpers/paymentIntegrations/payPalRecurringCheckout';
@@ -28,8 +27,6 @@ type PropTypes = {|
   paymentMethod: PaymentMethod,
   currency: IsoCurrency,
   isWaiting: boolean,
-  selectedAmounts: SelectedAmounts,
-  otherAmount: string | null,
   currencyId: IsoCurrency,
   csrf: CsrfState,
   sendFormSubmitEventForPayPalRecurring: () => void,
@@ -50,8 +47,6 @@ function mapStateToProps(state: State) {
     contributionType,
     isWaiting: state.page.form.isWaiting,
     paymentMethod: state.page.form.paymentMethod,
-    selectedAmounts: state.page.form.selectedAmounts,
-    otherAmount: state.page.form.formData.otherAmounts[contributionType].amount,
     currencyId: state.common.internationalisation.currencyId,
     csrf: state.page.csrf,
     payPalHasLoaded: state.page.form.payPalHasLoaded,
@@ -61,6 +56,7 @@ function mapStateToProps(state: State) {
       state.page.form.selectedAmounts,
       state.page.form.formData.otherAmounts,
       contributionType,
+      state.page.form.transactionFeeConsent,
     ),
     billingPeriod: billingPeriodFromContrib(contributionType),
   });
@@ -90,8 +86,7 @@ function withProps(props: PropTypes) {
 
     const submitButtonCopy = getContributeButtonCopyWithPaymentType(
       props.contributionType,
-      props.otherAmount,
-      props.selectedAmounts,
+      props.amount,
       props.currency,
       props.paymentMethod,
     );

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionTransactionFeeOption.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionTransactionFeeOption.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
-import { getAmount } from 'helpers/contributions';
+import { getAmountWithoutTransactionFee, getTransactionFee } from 'helpers/contributions';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import {
   currencies, detect,
@@ -12,29 +12,37 @@ import {
 } from 'helpers/internationalisation/currency';
 import { classNameWithModifiers } from 'helpers/utilities';
 import { CheckboxInput } from 'components/forms/customFields/checkbox';
+import type { ContributionType, OtherAmounts, SelectedAmounts } from 'helpers/contributions';
+import { updateTransactionFeeConsent } from 'pages/contributions-landing/contributionsLandingActions';
 // import { trackComponentClick } from 'helpers/tracking/behaviour';
 
 // ----- Types ----- //
 
 /* eslint-disable react/no-unused-prop-types */
 type PropTypes = {|
-  amount: number,
+  selectedAmounts: SelectedAmounts,
+  otherAmounts: OtherAmounts,
+  contributionType: ContributionType,
   currency: IsoCurrency,
   countryGroupId: CountryGroupId,
+  transactionFeeConsent: boolean => void,
 |};
 /* eslint-enable react/no-unused-prop-types */
 
 const mapStateToProps = state => ({
-  amount: getAmount(
-    state.page.form.selectedAmounts,
-    state.page.form.formData.otherAmounts,
-    state.page.form.contributionType,
-  ),
+  selectedAmounts: state.page.form.selectedAmounts,
+  otherAmounts: state.page.form.formData.otherAmounts,
+  contributionType: state.page.form.contributionType,
   currency: state.common.internationalisation.currencyId,
   countryGroupId: state.common.internationalisation.countryGroupId,
 });
 
-// const mapDispatchToProps = (dispatch: Function) => ({});
+const mapDispatchToProps = (dispatch: Function) => ({
+  transactionFeeConsent: (transactionFeeConsent: boolean) => {
+    dispatch(updateTransactionFeeConsent(transactionFeeConsent))
+  },
+
+});
 
 // ----- Render ----- //
 const amountFormatted = (amount: number, currencyString: string, countryGroupId: CountryGroupId) => {
@@ -44,28 +52,31 @@ const amountFormatted = (amount: number, currencyString: string, countryGroupId:
   return `${currencyString}${(amount).toFixed(2)}`;
 };
 
-const calculateTransactionFee = (amount: number): number => {
-  if (amount < 20 && amount > 0) {
-    // Return a 9% transaction fee (made up number)
-    return amount * 0.09;
-  }
-  // Return a 3% transaction fee (made up number)
-  return amount * 0.03;
-};
-
 function withProps(props: PropTypes) {
-  const { amount, countryGroupId } = props;
+  const {
+    selectedAmounts, otherAmounts, contributionType, countryGroupId, transactionFeeConsent,
+  } = props;
+  const baseAmount = getAmountWithoutTransactionFee(
+    selectedAmounts,
+    otherAmounts,
+    contributionType,
+  );
   const currencyString = currencies[detect(countryGroupId)].glyph;
-  const transactionFee = calculateTransactionFee(amount);
+  const transactionFee = getTransactionFee(baseAmount);
+  const formattedTransactionFee = amountFormatted(transactionFee, currencyString, countryGroupId);
 
   return (
     <fieldset className={classNameWithModifiers('form__checkbox', ['contribution-transaction-fee'])}>
       <legend className="form__legend">Would you like to cover the transaction fee?</legend>
-      {amount && amount > 0 && transactionFee &&
-      <CheckboxInput text={`The transaction fee for ${currencyString}${props.amount} is ${amountFormatted(transactionFee, currencyString, countryGroupId)}`} />
+      {baseAmount && baseAmount > 0 && transactionFee &&
+      <CheckboxInput
+        text={`The transaction fee for ${currencyString}${baseAmount} is ${formattedTransactionFee}`}
+        onChange={(event) => transactionFeeConsent(event.target.checked)}
+      />
       }
     </fieldset>
   );
+
 }
 
 function withoutProps() {
@@ -76,6 +87,6 @@ function withoutProps() {
   );
 }
 
-// export const ContributionTransactionFeeOption = connect(mapStateToProps, mapDispatchToProps)(withProps);
-export const ContributionTransactionFeeOption = connect(mapStateToProps)(withProps);
+export const ContributionTransactionFeeOption = connect(mapStateToProps, mapDispatchToProps)(withProps);
+// export const ContributionTransactionFeeOption = connect(mapStateToProps)(withProps);
 export const EmptyContributionTransactionFeeOption = withoutProps;

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionTransactionFeeOption.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionTransactionFeeOption.jsx
@@ -70,16 +70,18 @@ function withProps(props: PropTypes) {
 
   const copyVariants = {
     pleaseAdd: `Please add ${formattedTransactionFee} to my contribution to cover the transaction fees`,
-    iAmHappyToAdd: `Yes, I am happy to add ${formattedTransactionFee} to my contribution to cover the transaction fees`,
-    iAmHappyToAddAverage: `I’m happy to add the average transaction fees of ${formattedTransactionFee} to my contribution`,
+    iAmHappyToAdd: `Yes, I am happy to cover the transaction fees for my contribution (+ ${formattedTransactionFee})`,
+    iWillCover: `I will cover the transaction fees so more of my contribution goes directly to The Guardian (+ ${formattedTransactionFee})`,
   };
 
-  return contributionType === 'ONE_OFF' && landingPageTransactionFeeCopyVariant !== 'control' ? (
+  return contributionType === 'ONE_OFF' &&
+    landingPageTransactionFeeCopyVariant !== 'control' &&
+    landingPageTransactionFeeCopyVariant !== 'notintest' ? (
     <fieldset className={classNameWithModifiers('form__checkbox', ['contribution-transaction-fee'])}>
       <legend className="form__legend">Would you like to cover the transaction fee?</legend>
       {baseAmount && baseAmount > 0 && transactionFee &&
       <CheckboxInput
-        text={`The transaction fee for ${currencyString}${baseAmount} is ${formattedTransactionFee}`}
+        text={copyVariants[landingPageTransactionFeeCopyVariant]}
         onChange={(event) => transactionFeeConsent(event.target.checked)}
       />
       }

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionTransactionFeeOption.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionTransactionFeeOption.jsx
@@ -42,16 +42,20 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = (dispatch: Function) => ({
   transactionFeeConsent: (transactionFeeConsent: boolean) => {
-    dispatch(updateTransactionFeeConsent(transactionFeeConsent))
+    dispatch(updateTransactionFeeConsent(transactionFeeConsent));
   },
-
 });
 
 // ----- Render ----- //
 
 function withProps(props: PropTypes) {
   const {
-    selectedAmounts, otherAmounts, contributionType, countryGroupId, transactionFeeConsent, landingPageTransactionFeeCopyVariant,
+    selectedAmounts,
+    otherAmounts,
+    contributionType,
+    countryGroupId,
+    transactionFeeConsent,
+    landingPageTransactionFeeCopyVariant,
   } = props;
   const baseAmount = getAmountWithoutTransactionFee(
     selectedAmounts,
@@ -64,23 +68,23 @@ function withProps(props: PropTypes) {
 
   const copyVariants = {
     pleaseAdd: `Please add ${formattedTransactionFee} to my contribution to cover the transaction fees`,
-    iAmHappyToAdd: `Yes, I am happy to cover the transaction fees for my contribution (+ ${formattedTransactionFee})`,
+    iAmHappyToAdd: `Yes, I am happy to cover the transaction fees (+ ${formattedTransactionFee})`,
     iWillCover: `I will cover the transaction fees so more of my contribution goes directly to The Guardian (+ ${formattedTransactionFee})`,
   };
 
   return contributionType === 'ONE_OFF' &&
     landingPageTransactionFeeCopyVariant !== 'control' &&
     landingPageTransactionFeeCopyVariant !== 'notintest' ? (
-    <fieldset className={classNameWithModifiers('form__checkbox', ['contribution-transaction-fee'])}>
-      <legend className="form__legend">Would you like to cover the transaction fee?</legend>
-      {baseAmount && baseAmount > 0 && transactionFee &&
-      <CheckboxInput
-        text={copyVariants[landingPageTransactionFeeCopyVariant]}
-        onChange={(event) => transactionFeeConsent(event.target.checked)}
-      />
+      <fieldset className={classNameWithModifiers('form__checkbox', ['contribution-transaction-fee'])}>
+        <legend className="form__legend">Would you like to cover the transaction fee?</legend>
+        {baseAmount && baseAmount > 0 && transactionFee &&
+        <CheckboxInput
+          text={copyVariants[landingPageTransactionFeeCopyVariant]}
+          onChange={event => transactionFeeConsent(event.target.checked)}
+        />
       }
-    </fieldset>
-  ) : null;
+      </fieldset>
+    ) : null;
 }
 
 function withoutProps() {

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionTransactionFeeOption.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionTransactionFeeOption.jsx
@@ -4,7 +4,7 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
-import { getAmountWithoutTransactionFee, getTransactionFee } from 'helpers/contributions';
+import { getAmountWithoutTransactionFee, getFormattedAmount, getTransactionFee } from 'helpers/contributions';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import {
   currencies, detect,
@@ -48,12 +48,6 @@ const mapDispatchToProps = (dispatch: Function) => ({
 });
 
 // ----- Render ----- //
-const amountFormatted = (amount: number, currencyString: string, countryGroupId: CountryGroupId) => {
-  if (amount < 1 && countryGroupId === 'GBPCountries') {
-    return `${(amount * 100).toFixed(0)}p`;
-  }
-  return `${currencyString}${(amount).toFixed(2)}`;
-};
 
 function withProps(props: PropTypes) {
   const {
@@ -66,7 +60,7 @@ function withProps(props: PropTypes) {
   );
   const currencyString = currencies[detect(countryGroupId)].glyph;
   const transactionFee = getTransactionFee(baseAmount);
-  const formattedTransactionFee = amountFormatted(transactionFee, currencyString, countryGroupId);
+  const formattedTransactionFee = getFormattedAmount(transactionFee, currencyString, countryGroupId);
 
   const copyVariants = {
     pleaseAdd: `Please add ${formattedTransactionFee} to my contribution to cover the transaction fees`,

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionTransactionFeeOption.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionTransactionFeeOption.jsx
@@ -14,6 +14,7 @@ import { classNameWithModifiers } from 'helpers/utilities';
 import { CheckboxInput } from 'components/forms/customFields/checkbox';
 import type { ContributionType, OtherAmounts, SelectedAmounts } from 'helpers/contributions';
 import { updateTransactionFeeConsent } from 'pages/contributions-landing/contributionsLandingActions';
+import type { LandingPageTransactionFeeCopyVariants } from 'helpers/abTests/abtestDefinitions';
 // import { trackComponentClick } from 'helpers/tracking/behaviour';
 
 // ----- Types ----- //
@@ -26,6 +27,7 @@ type PropTypes = {|
   currency: IsoCurrency,
   countryGroupId: CountryGroupId,
   transactionFeeConsent: boolean => void,
+  landingPageTransactionFeeCopyVariant: LandingPageTransactionFeeCopyVariants,
 |};
 /* eslint-enable react/no-unused-prop-types */
 
@@ -35,6 +37,7 @@ const mapStateToProps = state => ({
   contributionType: state.page.form.contributionType,
   currency: state.common.internationalisation.currencyId,
   countryGroupId: state.common.internationalisation.countryGroupId,
+  landingPageTransactionFeeCopyVariant: state.common.abParticipations.landingPageTransactionFeeCopy,
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -54,7 +57,7 @@ const amountFormatted = (amount: number, currencyString: string, countryGroupId:
 
 function withProps(props: PropTypes) {
   const {
-    selectedAmounts, otherAmounts, contributionType, countryGroupId, transactionFeeConsent,
+    selectedAmounts, otherAmounts, contributionType, countryGroupId, transactionFeeConsent, landingPageTransactionFeeCopyVariant,
   } = props;
   const baseAmount = getAmountWithoutTransactionFee(
     selectedAmounts,
@@ -65,7 +68,13 @@ function withProps(props: PropTypes) {
   const transactionFee = getTransactionFee(baseAmount);
   const formattedTransactionFee = amountFormatted(transactionFee, currencyString, countryGroupId);
 
-  return (
+  const copyVariants = {
+    pleaseAdd: `Please add ${formattedTransactionFee} to my contribution to cover the transaction fees`,
+    iAmHappyToAdd: `Yes, I am happy to add ${formattedTransactionFee} to my contribution to cover the transaction fees`,
+    iAmHappyToAddAverage: `I’m happy to add the average transaction fees of ${formattedTransactionFee} to my contribution`,
+  };
+
+  return contributionType === 'ONE_OFF' && landingPageTransactionFeeCopyVariant !== 'control' ? (
     <fieldset className={classNameWithModifiers('form__checkbox', ['contribution-transaction-fee'])}>
       <legend className="form__legend">Would you like to cover the transaction fee?</legend>
       {baseAmount && baseAmount > 0 && transactionFee &&
@@ -75,8 +84,7 @@ function withProps(props: PropTypes) {
       />
       }
     </fieldset>
-  );
-
+  ) : null;
 }
 
 function withoutProps() {

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionTransactionFeeOption.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionTransactionFeeOption.jsx
@@ -1,0 +1,159 @@
+// @flow
+
+// ----- Imports ----- //
+
+import type { OtherAmounts, SelectedAmounts } from 'helpers/contributions';
+import React from 'react';
+import { connect } from 'react-redux';
+import { config, type AmountsRegions, type Amount, type ContributionType, getAmount } from 'helpers/contributions';
+import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import {
+  type IsoCurrency,
+  type Currency,
+  type SpokenCurrency,
+  currencies,
+  spokenCurrencies,
+  detect,
+} from 'helpers/internationalisation/currency';
+import { classNameWithModifiers } from 'helpers/utilities';
+import { trackComponentClick } from 'helpers/tracking/behaviour';
+import { EURCountries, GBPCountries } from 'helpers/internationalisation/countryGroup';
+import { formatAmount } from 'helpers/checkouts';
+import SvgDollar from 'components/svgs/dollar';
+import SvgEuro from 'components/svgs/euro';
+import SvgPound from 'components/svgs/pound';
+import { selectAmount, updateOtherAmount } from '../contributionsLandingActions';
+import ContributionTextInput from './ContributionTextInput';
+
+// ----- Types ----- //
+
+/* eslint-disable react/no-unused-prop-types */
+type PropTypes = {|
+  countryGroupId: CountryGroupId,
+  currency: IsoCurrency,
+  contributionType: ContributionType,
+  amounts: AmountsRegions,
+  selectedAmounts: SelectedAmounts,
+  selectAmount: (Amount | 'other', CountryGroupId, ContributionType) => (() => void),
+  otherAmounts: OtherAmounts,
+  checkOtherAmount: (string, CountryGroupId, ContributionType) => boolean,
+  updateOtherAmount: (string, CountryGroupId, ContributionType) => void,
+  checkoutFormHasBeenSubmitted: boolean,
+  stripePaymentRequestButtonClicked: boolean,
+|};
+/* eslint-enable react/no-unused-prop-types */
+
+const mapStateToProps = state => ({
+  countryGroupId: state.common.internationalisation.countryGroupId,
+  currency: state.common.internationalisation.currencyId,
+  contributionType: state.page.form.contributionType,
+  amounts: state.common.settings.amounts,
+  selectedAmounts: state.page.form.selectedAmounts,
+  otherAmounts: state.page.form.formData.otherAmounts,
+  checkoutFormHasBeenSubmitted: state.page.form.formData.checkoutFormHasBeenSubmitted,
+  stripePaymentRequestButtonClicked:
+    state.page.form.stripePaymentRequestButtonData.ONE_OFF.stripePaymentRequestButtonClicked ||
+    state.page.form.stripePaymentRequestButtonData.REGULAR.stripePaymentRequestButtonClicked,
+});
+
+const mapDispatchToProps = (dispatch: Function) => ({
+  selectAmount: (amount, countryGroupId, contributionType) => () => {
+    trackComponentClick(`npf-contribution-amount-toggle-${countryGroupId}-${contributionType}-${amount.value || amount}`);
+    dispatch(selectAmount(amount, contributionType));
+  },
+  updateOtherAmount: (amount, countryGroupId, contributionType) => {
+    trackComponentClick(`npf-contribution-amount-toggle-${countryGroupId}-${contributionType}-${amount}`);
+    dispatch(updateOtherAmount(amount, contributionType));
+  },
+});
+
+// ----- Render ----- //
+
+const isSelected = (amount: Amount, props: PropTypes) => {
+  if (props.selectedAmounts[props.contributionType]) {
+    return props.selectedAmounts[props.contributionType] !== 'other' &&
+      amount.value === props.selectedAmounts[props.contributionType].value;
+  }
+  return amount.isDefault;
+};
+
+const renderAmount = (
+  currency: Currency,
+  spokenCurrency: SpokenCurrency,
+  props: PropTypes,
+) =>
+  (amount: Amount) => (
+    <li className="form__radio-group-item">
+      <input
+        id={`contributionAmount-${amount.value}`}
+        className="form__radio-group-input"
+        type="radio"
+        name="contributionAmount"
+        value={amount.value}
+      /* eslint-disable react/prop-types */
+        checked={isSelected(amount, props)}
+        onChange={
+          props.selectAmount(amount, props.countryGroupId, props.contributionType)
+        }
+      />
+      <label htmlFor={`contributionAmount-${amount.value}`} className="form__radio-group-label" aria-label={formatAmount(currency, spokenCurrency, amount, true)}>
+        {formatAmount(currency, spokenCurrency, amount, false)}
+      </label>
+    </li>
+  );
+
+const renderEmptyAmount = (id: string) => (
+  <li className="form__radio-group-item amounts__placeholder">
+    <input
+      id={`contributionAmount-${id}`}
+      className="form__radio-group-input"
+      type="radio"
+      name="contributionAmount"
+    />
+    <label htmlFor={`contributionAmount-${id}`} className="form__radio-group-label">&nbsp;</label>
+  </li>
+);
+
+const iconForCountryGroup = (countryGroupId: CountryGroupId): React$Element<*> => {
+  switch (countryGroupId) {
+    case GBPCountries: return <SvgPound />;
+    case EURCountries: return <SvgEuro />;
+    default: return <SvgDollar />;
+  }
+};
+
+const amountFormatted = (amount: number, currencyString: string, countryGroupId: CountryGroupId) => {
+  if (amount < 1 && countryGroupId === 'GBPCountries') {
+    return `${(amount * 100).toFixed(0)}p`;
+  }
+  return `${currencyString}${(amount).toFixed(2)}`;
+};
+
+function withProps(props: PropTypes) {
+  const validAmounts: Amount[] = props.amounts[props.countryGroupId][props.contributionType];
+  const showOther: boolean = props.selectedAmounts[props.contributionType] === 'other';
+  const showWeeklyBreakdown: boolean = props.contributionType === 'MONTHLY' || props.contributionType === 'ANNUAL';
+  const { min, max } = config[props.countryGroupId][props.contributionType]; // eslint-disable-line react/prop-types
+  const minAmount: string =
+    formatAmount(currencies[props.currency], spokenCurrencies[props.currency], { value: min.toString() }, false);
+  const maxAmount: string =
+    formatAmount(currencies[props.currency], spokenCurrencies[props.currency], { value: max.toString() }, false);
+  const otherAmount = props.otherAmounts[props.contributionType].amount;
+
+  return (
+    <fieldset className={classNameWithModifiers('form__checkbox', ['contribution-transaction-fee'])}>
+      <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>Would you like to cover the transaction fee?</legend>
+    </fieldset>
+  );
+}
+
+function withoutProps() {
+  return (
+    <fieldset className={classNameWithModifiers('form__radio-group', ['pills', 'contribution-amount'])}>
+      <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>Would you like to cover the transaction fee?</legend>
+    </fieldset>
+  );
+}
+
+export const ContributionAmount = connect(mapStateToProps, mapDispatchToProps)(withProps);
+export const EmptyContributionAmount = withoutProps;

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionTransactionFeeOption.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionTransactionFeeOption.jsx
@@ -2,126 +2,40 @@
 
 // ----- Imports ----- //
 
-import type { OtherAmounts, SelectedAmounts } from 'helpers/contributions';
 import React from 'react';
 import { connect } from 'react-redux';
-import { config, type AmountsRegions, type Amount, type ContributionType, getAmount } from 'helpers/contributions';
+import { getAmount } from 'helpers/contributions';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import {
   type IsoCurrency,
-  type Currency,
-  type SpokenCurrency,
-  currencies,
-  spokenCurrencies,
-  detect,
 } from 'helpers/internationalisation/currency';
 import { classNameWithModifiers } from 'helpers/utilities';
-import { trackComponentClick } from 'helpers/tracking/behaviour';
-import { EURCountries, GBPCountries } from 'helpers/internationalisation/countryGroup';
-import { formatAmount } from 'helpers/checkouts';
-import SvgDollar from 'components/svgs/dollar';
-import SvgEuro from 'components/svgs/euro';
-import SvgPound from 'components/svgs/pound';
-import { selectAmount, updateOtherAmount } from '../contributionsLandingActions';
-import ContributionTextInput from './ContributionTextInput';
+import { CheckboxInput } from 'components/forms/customFields/checkbox';
+// import { trackComponentClick } from 'helpers/tracking/behaviour';
 
 // ----- Types ----- //
 
 /* eslint-disable react/no-unused-prop-types */
 type PropTypes = {|
-  countryGroupId: CountryGroupId,
+  amount: number,
   currency: IsoCurrency,
-  contributionType: ContributionType,
-  amounts: AmountsRegions,
-  selectedAmounts: SelectedAmounts,
-  selectAmount: (Amount | 'other', CountryGroupId, ContributionType) => (() => void),
-  otherAmounts: OtherAmounts,
-  checkOtherAmount: (string, CountryGroupId, ContributionType) => boolean,
-  updateOtherAmount: (string, CountryGroupId, ContributionType) => void,
-  checkoutFormHasBeenSubmitted: boolean,
-  stripePaymentRequestButtonClicked: boolean,
+  countryGroupId: CountryGroupId,
 |};
 /* eslint-enable react/no-unused-prop-types */
 
 const mapStateToProps = state => ({
-  countryGroupId: state.common.internationalisation.countryGroupId,
+  amount: getAmount(
+    state.page.form.selectedAmounts,
+    state.page.form.formData.otherAmounts,
+    state.page.form.contributionType,
+  ),
   currency: state.common.internationalisation.currencyId,
-  contributionType: state.page.form.contributionType,
-  amounts: state.common.settings.amounts,
-  selectedAmounts: state.page.form.selectedAmounts,
-  otherAmounts: state.page.form.formData.otherAmounts,
-  checkoutFormHasBeenSubmitted: state.page.form.formData.checkoutFormHasBeenSubmitted,
-  stripePaymentRequestButtonClicked:
-    state.page.form.stripePaymentRequestButtonData.ONE_OFF.stripePaymentRequestButtonClicked ||
-    state.page.form.stripePaymentRequestButtonData.REGULAR.stripePaymentRequestButtonClicked,
+  countryGroupId: state.common.internationalisation.countryGroupId,
 });
 
-const mapDispatchToProps = (dispatch: Function) => ({
-  selectAmount: (amount, countryGroupId, contributionType) => () => {
-    trackComponentClick(`npf-contribution-amount-toggle-${countryGroupId}-${contributionType}-${amount.value || amount}`);
-    dispatch(selectAmount(amount, contributionType));
-  },
-  updateOtherAmount: (amount, countryGroupId, contributionType) => {
-    trackComponentClick(`npf-contribution-amount-toggle-${countryGroupId}-${contributionType}-${amount}`);
-    dispatch(updateOtherAmount(amount, contributionType));
-  },
-});
+// const mapDispatchToProps = (dispatch: Function) => ({});
 
 // ----- Render ----- //
-
-const isSelected = (amount: Amount, props: PropTypes) => {
-  if (props.selectedAmounts[props.contributionType]) {
-    return props.selectedAmounts[props.contributionType] !== 'other' &&
-      amount.value === props.selectedAmounts[props.contributionType].value;
-  }
-  return amount.isDefault;
-};
-
-const renderAmount = (
-  currency: Currency,
-  spokenCurrency: SpokenCurrency,
-  props: PropTypes,
-) =>
-  (amount: Amount) => (
-    <li className="form__radio-group-item">
-      <input
-        id={`contributionAmount-${amount.value}`}
-        className="form__radio-group-input"
-        type="radio"
-        name="contributionAmount"
-        value={amount.value}
-      /* eslint-disable react/prop-types */
-        checked={isSelected(amount, props)}
-        onChange={
-          props.selectAmount(amount, props.countryGroupId, props.contributionType)
-        }
-      />
-      <label htmlFor={`contributionAmount-${amount.value}`} className="form__radio-group-label" aria-label={formatAmount(currency, spokenCurrency, amount, true)}>
-        {formatAmount(currency, spokenCurrency, amount, false)}
-      </label>
-    </li>
-  );
-
-const renderEmptyAmount = (id: string) => (
-  <li className="form__radio-group-item amounts__placeholder">
-    <input
-      id={`contributionAmount-${id}`}
-      className="form__radio-group-input"
-      type="radio"
-      name="contributionAmount"
-    />
-    <label htmlFor={`contributionAmount-${id}`} className="form__radio-group-label">&nbsp;</label>
-  </li>
-);
-
-const iconForCountryGroup = (countryGroupId: CountryGroupId): React$Element<*> => {
-  switch (countryGroupId) {
-    case GBPCountries: return <SvgPound />;
-    case EURCountries: return <SvgEuro />;
-    default: return <SvgDollar />;
-  }
-};
-
 const amountFormatted = (amount: number, currencyString: string, countryGroupId: CountryGroupId) => {
   if (amount < 1 && countryGroupId === 'GBPCountries') {
     return `${(amount * 100).toFixed(0)}p`;
@@ -129,31 +43,34 @@ const amountFormatted = (amount: number, currencyString: string, countryGroupId:
   return `${currencyString}${(amount).toFixed(2)}`;
 };
 
-function withProps(props: PropTypes) {
-  const validAmounts: Amount[] = props.amounts[props.countryGroupId][props.contributionType];
-  const showOther: boolean = props.selectedAmounts[props.contributionType] === 'other';
-  const showWeeklyBreakdown: boolean = props.contributionType === 'MONTHLY' || props.contributionType === 'ANNUAL';
-  const { min, max } = config[props.countryGroupId][props.contributionType]; // eslint-disable-line react/prop-types
-  const minAmount: string =
-    formatAmount(currencies[props.currency], spokenCurrencies[props.currency], { value: min.toString() }, false);
-  const maxAmount: string =
-    formatAmount(currencies[props.currency], spokenCurrencies[props.currency], { value: max.toString() }, false);
-  const otherAmount = props.otherAmounts[props.contributionType].amount;
+const getTransactionFeeString = (amount: number, countryGroupId: CountryGroupId): string => {
+  if (amount < 20 && amount > 0) {
+    // Return a 9% transaction fee (made up number)
+    return amountFormatted(amount * 0.09, '$', countryGroupId);
+  }
+  // Return a 3% transaction fee (made up number)
+  return amountFormatted(amount * 0.09, '$', countryGroupId);
+};
 
+function withProps(props: PropTypes) {
   return (
     <fieldset className={classNameWithModifiers('form__checkbox', ['contribution-transaction-fee'])}>
-      <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>Would you like to cover the transaction fee?</legend>
+      <legend className="form__legend">Would you like to cover the transaction fee?</legend>
+      {props.amount && props.amount > 0 &&
+      <CheckboxInput text={`The transaction fee for ${props.amount} is ${getTransactionFeeString(props.amount, props.countryGroupId)}`} />
+      }
     </fieldset>
   );
 }
 
 function withoutProps() {
   return (
-    <fieldset className={classNameWithModifiers('form__radio-group', ['pills', 'contribution-amount'])}>
-      <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>Would you like to cover the transaction fee?</legend>
+    <fieldset className={classNameWithModifiers('form__checkbox', ['contribution-transaction-fee'])}>
+      <legend className="form__legend">Would you like to cover the transaction fee?</legend>
     </fieldset>
   );
 }
 
-export const ContributionAmount = connect(mapStateToProps, mapDispatchToProps)(withProps);
-export const EmptyContributionAmount = withoutProps;
+// export const ContributionTransactionFeeOption = connect(mapStateToProps, mapDispatchToProps)(withProps);
+export const ContributionTransactionFeeOption = connect(mapStateToProps)(withProps);
+export const EmptyContributionTransactionFeeOption = withoutProps;

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionTransactionFeeOption.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionTransactionFeeOption.jsx
@@ -7,6 +7,7 @@ import { connect } from 'react-redux';
 import { getAmount } from 'helpers/contributions';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import {
+  currencies, detect,
   type IsoCurrency,
 } from 'helpers/internationalisation/currency';
 import { classNameWithModifiers } from 'helpers/utilities';
@@ -43,21 +44,25 @@ const amountFormatted = (amount: number, currencyString: string, countryGroupId:
   return `${currencyString}${(amount).toFixed(2)}`;
 };
 
-const getTransactionFeeString = (amount: number, countryGroupId: CountryGroupId): string => {
+const calculateTransactionFee = (amount: number): number => {
   if (amount < 20 && amount > 0) {
     // Return a 9% transaction fee (made up number)
-    return amountFormatted(amount * 0.09, '$', countryGroupId);
+    return amount * 0.09;
   }
   // Return a 3% transaction fee (made up number)
-  return amountFormatted(amount * 0.09, '$', countryGroupId);
+  return amount * 0.03;
 };
 
 function withProps(props: PropTypes) {
+  const { amount, countryGroupId } = props;
+  const currencyString = currencies[detect(countryGroupId)].glyph;
+  const transactionFee = calculateTransactionFee(amount);
+
   return (
     <fieldset className={classNameWithModifiers('form__checkbox', ['contribution-transaction-fee'])}>
       <legend className="form__legend">Would you like to cover the transaction fee?</legend>
-      {props.amount && props.amount > 0 &&
-      <CheckboxInput text={`The transaction fee for ${props.amount} is ${getTransactionFeeString(props.amount, props.countryGroupId)}`} />
+      {amount && amount > 0 && transactionFee &&
+      <CheckboxInput text={`The transaction fee for ${currencyString}${props.amount} is ${amountFormatted(transactionFee, currencyString, countryGroupId)}`} />
       }
     </fieldset>
   );

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
@@ -28,6 +28,7 @@ type PropTypes = {|
   stripeHasLoaded: boolean,
   selectedAmounts: SelectedAmounts,
   otherAmounts: OtherAmounts,
+  transactionFeeConsent: boolean,
 |};
 
 const enabledForRecurring = (): boolean => !!window.guardian.recurringStripePaymentRequestButton;
@@ -48,7 +49,12 @@ class StripePaymentRequestButtonContainer extends React.Component<PropTypes, voi
     if (showStripePaymentRequestButton && this.props.stripeHasLoaded) {
       const stripeAccount = stripeAccountForContributionType[this.props.contributionType];
       const apiKey = getStripeKey(stripeAccount, this.props.country, this.props.isTestUser);
-      const amount = getAmount(this.props.selectedAmounts, this.props.otherAmounts, this.props.contributionType);
+      const amount = getAmount(
+        this.props.selectedAmounts,
+        this.props.otherAmounts,
+        this.props.contributionType,
+        this.props.transactionFeeConsent,
+      );
 
       /**
        * The `key` attribute is necessary here because you cannot modify the apiKey on StripeProvider.

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.scss
@@ -523,7 +523,8 @@ form {
   height: 0;
 }
 
-.form__legend--radio-group {
+.form__legend--radio-group,
+.form__legend {
   @include accessibility-hint;
 }
 

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -86,6 +86,7 @@ export type Action =
   | { type: 'SET_USER_TYPE_FROM_IDENTITY_RESPONSE', userTypeFromIdentityResponse: UserTypeFromIdentityResponse }
   | { type: 'SET_FORM_IS_VALID', isValid: boolean }
   | { type: 'SET_TICKER_GOAL_REACHED', tickerGoalReached: boolean }
+  | { type: 'UPDATE_TRANSACTION_FEE_CONSENT', transactionFeeConsent: boolean }
 
 const setFormIsValid = (isValid: boolean): Action => ({ type: 'SET_FORM_IS_VALID', isValid });
 
@@ -138,6 +139,9 @@ const setStripePaymentRequestObject =
     ({ type: 'SET_STRIPE_PAYMENT_REQUEST_OBJECT', stripePaymentRequestObject, stripeAccount });
 
 const setStripeV3HasLoaded = (): Action => ({ type: 'SET_STRIPE_V3_HAS_LOADED' });
+
+// UPDATE_TRANSACTION_FEE_CONSENT
+const updateTransactionFeeConsent = (transactionFeeConsent: boolean): Action => ({ type: 'UPDATE_TRANSACTION_FEE_CONSENT', transactionFeeConsent });
 
 const setStripePaymentRequestButtonClicked = (stripeAccount: StripeAccount): Action =>
   ({ type: 'SET_STRIPE_PAYMENT_REQUEST_BUTTON_CLICKED', stripeAccount });
@@ -577,6 +581,7 @@ export {
   setStripePaymentRequestObject,
   setStripePaymentRequestButtonClicked,
   setStripeV3HasLoaded,
+  updateTransactionFeeConsent,
   setTickerGoalReached,
   setCreateStripePaymentMethod,
   setHandleStripe3DS,

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -343,6 +343,7 @@ const regularPaymentRequestFromAuthorisation = (
       state.page.form.selectedAmounts,
       state.page.form.formData.otherAmounts,
       state.page.form.contributionType,
+      state.page.form.transactionFeeConsent,
     ),
     currency: state.common.internationalisation.currencyId,
     billingPeriod: state.page.form.contributionType === 'MONTHLY' ? Monthly : Annual,

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
@@ -73,12 +73,7 @@ export type StripeCardFormData = {
   // These callbacks must be initialised after the StripeCardForm component has been created
   createPaymentMethod: ((email: string) => void) | null,
   handle3DS: ((clientSecret: string) => Promise<Stripe3DSResult>) | null,
-}
-
-export type TransactionFee = {
-  fee?: number,
-  consent: boolean
-}
+};
 
 type FormState = {
   contributionType: ContributionType,
@@ -105,7 +100,7 @@ type FormState = {
   formIsValid: boolean,
   formIsSubmittable: boolean,
   tickerGoalReached: boolean,
-  transactionFee: TransactionFee
+  transactionFeeConsent: boolean,
 };
 
 type PageState = {
@@ -192,9 +187,7 @@ function createFormReducer() {
     formIsValid: true,
     formIsSubmittable: true,
     tickerGoalReached: false,
-    transactionFee: {
-      consent: false,
-    }
+    transactionFeeConsent: false,
   };
 
   return function formReducer(state: FormState = initialState, action: Action): FormState {
@@ -333,6 +326,12 @@ function createFormReducer() {
         return {
           ...state,
           stripeV3HasLoaded: true,
+        };
+
+      case 'UPDATE_TRANSACTION_FEE_CONSENT':
+        return {
+          ...state,
+          transactionFeeConsent: action.transactionFeeConsent,
         };
 
       case 'UPDATE_USER_FORM_DATA':

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
@@ -75,6 +75,11 @@ export type StripeCardFormData = {
   handle3DS: ((clientSecret: string) => Promise<Stripe3DSResult>) | null,
 }
 
+export type TransactionFee = {
+  fee?: number,
+  consent: boolean
+}
+
 type FormState = {
   contributionType: ContributionType,
   paymentMethod: PaymentMethod,
@@ -100,6 +105,7 @@ type FormState = {
   formIsValid: boolean,
   formIsSubmittable: boolean,
   tickerGoalReached: boolean,
+  transactionFee: TransactionFee
 };
 
 type PageState = {
@@ -186,6 +192,9 @@ function createFormReducer() {
     formIsValid: true,
     formIsSubmittable: true,
     tickerGoalReached: false,
+    transactionFee: {
+      consent: false,
+    }
   };
 
   return function formReducer(state: FormState = initialState, action: Action): FormState {


### PR DESCRIPTION
## Why are you doing this?
We are introducing the ability for contributors to cover transaction fees, pending analysis from finance. This adds the fee to the contribution and sends the fee amount as part of the acquisition data object.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com)

## Changes

* Change 1
* Change 2

## Screenshots

