### PR TITLE
Take down moment landing page

### DIFF
--- a/support-frontend/assets/helpers/campaigns.jsx
+++ b/support-frontend/assets/helpers/campaigns.jsx
@@ -33,7 +33,7 @@ const currentCampaignName = null;
 const campaignEditorialLink = null;
 
 export const campaigns: Campaigns = {
-  [currentCampaignName]: {
+  [currentCampaignName || '']: {
     formMessage: (<div />
     ),
     headerCopy: (

--- a/support-frontend/assets/helpers/campaigns.jsx
+++ b/support-frontend/assets/helpers/campaigns.jsx
@@ -28,9 +28,9 @@ export type Campaigns = {
   [string]: CampaignSettings,
 };
 
-const currentCampaignName = 'climate-pledge-2019';
+const currentCampaignName = null;
 
-const climatePledgeUrl = 'https://www.theguardian.com/environment/ng-interactive/2019/oct/16/the-guardians-climate-pledge-2019?acquisitionData=%7B%22source%22%3A%22GUARDIAN_WEB%22%2C%22componentType%22%3A%22ACQUISITIONS_EDITORIAL_LINK%22%2C%22campaignCode%22%3A%22climate_pledge_2019%22%2C%22componentId%22%3A%22climate_pledge_2019_landing_page%22%7D&INTCMP=climate_pledge_2019';
+const campaignEditorialLink = null;
 
 export const campaigns: Campaigns = {
   [currentCampaignName]: {
@@ -51,7 +51,7 @@ export const campaigns: Campaigns = {
         <p>
           <span className="bold">The climate emergency is the defining issue of our times.</span> This is
           The Guardian’s pledge: we will be truthful, resolute and undeterred in pursuing our journalism
-          on the environment. Support from our readers makes this work possible. <a className="underline" href={climatePledgeUrl}>Read our pledge in full</a>.
+          on the environment. Support from our readers makes this work possible. <a className="underline" href={campaignEditorialLink}>Read our pledge in full</a>.
         </p>
       </div>
     ),


### PR DESCRIPTION
## Why are you doing this?
The moment is over!

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/YJHfRi2W/1619-turn-off-the-landing-page-version-for-the-moment)

## Changes

* Removed the camaign name
* TBD: turn off 'force campaign' switch in support-admin-console
