### PR TITLE
Tweak contribution type query parameter

### DIFF
--- a/support-frontend/assets/helpers/checkouts.js
+++ b/support-frontend/assets/helpers/checkouts.js
@@ -44,7 +44,7 @@ function toPaymentMethodSwitchNaming(paymentMethod: PaymentMethod): PaymentMetho
 
 
 function getValidContributionTypesFromUrlOrElse(fallback: ContributionTypes): ContributionTypes {
-  const contributionTypesFromUrl = getQueryParameter('contributionTypes');
+  const contributionTypesFromUrl = getQueryParameter('contribution-types');
   if (contributionTypesFromUrl) {
     return generateContributionTypes(contributionTypesFromUrl
       .split(',')
@@ -66,11 +66,11 @@ function toHumanReadableContributionType(contributionType: ContributionType): 'S
 }
 
 function getContributionTypeFromSession(): ?ContributionType {
-  return toContributionType(storage.getSession('selectedContributionType'));
+  return toContributionType(storage.getSession('selected-contribution-type'));
 }
 
 function getContributionTypeFromUrl(): ?ContributionType {
-  return toContributionType(getQueryParameter('selectedContributionType'));
+  return toContributionType(getQueryParameter('selected-contribution-type'));
 }
 
 // Returns an array of Payment Methods, in the order of preference,

--- a/support-frontend/assets/helpers/contributions.js
+++ b/support-frontend/assets/helpers/contributions.js
@@ -270,6 +270,8 @@ function toContributionType(s: ?string): ?ContributionType {
         return 'MONTHLY';
       case 'ONE_OFF':
         return 'ONE_OFF';
+      case 'SINGLE':
+        return 'ONE_OFF';
       default:
         return null;
     }


### PR DESCRIPTION
## Why are you doing this?
Best practice is to use `kebab-case` instead of `camelCase` for URLs. Also, allowing for the new `single` terminology to be used instead of `one_off`
<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/yd5RqBQQ/1594-landing-page-ab-test-one-product-only-single)