### PR TITLE
[WIP] Temporarily disable postcode lookup

### DIFF
--- a/support-frontend/assets/components/subscriptionCheckouts/address/postcodeFinder.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/postcodeFinder.jsx
@@ -76,39 +76,40 @@ class PostcodeFinder extends Component<PropTypes> {
     const {
       id, postcode, results, isLoading, setPostcode, fetchResults, error, onPostcodeUpdate, onAddressUpdate,
     } = this.props;
-    return (
-      <div>
-        <ComposedInputWithButton
-          error={error}
-          label="Postcode"
-          onClick={() => { fetchResults(postcode); }}
-          id={id}
-          setValue={(val) => {
-            setPostcode(val);
-            onPostcodeUpdate(val);
-          }}
-          isLoading={isLoading}
-          value={postcode}
-        />
-        {(results.length > 0) &&
-          <ComposedSelect
-            onChange={(ev) => {
-              if (results[ev.currentTarget.value]) {
-                onAddressUpdate(results[ev.currentTarget.value]);
-              }
-            }}
-            forwardRef={(r) => { this.selectRef = r; }}
-            id="address"
-            label={`${results.length} addresses found`}
-          >
-            <option value={null}>Select an address</option>
-              {results.map((result, key) => (
-                <option value={key}>{[result.lineOne, result.lineTwo].join(', ')}</option>
-              ))}
-          </ComposedSelect>
-        }
-      </div>
-    );
+    return ("")
+    // (
+    //   <div>
+    //     <ComposedInputWithButton
+    //       error={error}
+    //       label="Postcode"
+    //       onClick={() => { fetchResults(postcode); }}
+    //       id={id}
+    //       setValue={(val) => {
+    //         setPostcode(val);
+    //         onPostcodeUpdate(val);
+    //       }}
+    //       isLoading={isLoading}
+    //       value={postcode}
+    //     />
+    //     {(results.length > 0) &&
+    //       <ComposedSelect
+    //         onChange={(ev) => {
+    //           if (results[ev.currentTarget.value]) {
+    //             onAddressUpdate(results[ev.currentTarget.value]);
+    //           }
+    //         }}
+    //         forwardRef={(r) => { this.selectRef = r; }}
+    //         id="address"
+    //         label={`${results.length} addresses found`}
+    //       >
+    //         <option value={null}>Select an address</option>
+    //           {results.map((result, key) => (
+    //             <option value={key}>{[result.lineOne, result.lineTwo].join(', ')}</option>
+    //           ))}
+    //       </ComposedSelect>
+    //     }
+    //   </div>
+    // );
   }
 }
 

--- a/support-frontend/assets/components/subscriptionCheckouts/address/postcodeFinder.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/postcodeFinder.jsx
@@ -76,40 +76,40 @@ class PostcodeFinder extends Component<PropTypes> {
     const {
       id, postcode, results, isLoading, setPostcode, fetchResults, error, onPostcodeUpdate, onAddressUpdate,
     } = this.props;
-    return ("")
-    // (
-    //   <div>
-    //     <ComposedInputWithButton
-    //       error={error}
-    //       label="Postcode"
-    //       onClick={() => { fetchResults(postcode); }}
-    //       id={id}
-    //       setValue={(val) => {
-    //         setPostcode(val);
-    //         onPostcodeUpdate(val);
-    //       }}
-    //       isLoading={isLoading}
-    //       value={postcode}
-    //     />
-    //     {(results.length > 0) &&
-    //       <ComposedSelect
-    //         onChange={(ev) => {
-    //           if (results[ev.currentTarget.value]) {
-    //             onAddressUpdate(results[ev.currentTarget.value]);
-    //           }
-    //         }}
-    //         forwardRef={(r) => { this.selectRef = r; }}
-    //         id="address"
-    //         label={`${results.length} addresses found`}
-    //       >
-    //         <option value={null}>Select an address</option>
-    //           {results.map((result, key) => (
-    //             <option value={key}>{[result.lineOne, result.lineTwo].join(', ')}</option>
-    //           ))}
-    //       </ComposedSelect>
-    //     }
-    //   </div>
-    // );
+    return true ? '' :
+      (
+        <div>
+          <ComposedInputWithButton
+            error={error}
+            label="Postcode"
+            onClick={() => { fetchResults(postcode); }}
+            id={id}
+            setValue={(val) => {
+            setPostcode(val);
+            onPostcodeUpdate(val);
+          }}
+            isLoading={isLoading}
+            value={postcode}
+          />
+          {(results.length > 0) &&
+          <ComposedSelect
+            onChange={(ev) => {
+              if (results[ev.currentTarget.value]) {
+                onAddressUpdate(results[ev.currentTarget.value]);
+              }
+            }}
+            forwardRef={(r) => { this.selectRef = r; }}
+            id="address"
+            label={`${results.length} addresses found`}
+          >
+            <option value={null}>Select an address</option>
+              {results.map((result, key) => (
+                <option value={key}>{[result.lineOne, result.lineTwo].join(', ')}</option>
+              ))}
+          </ComposedSelect>
+        }
+        </div>
+      );
   }
 }
 

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -24,7 +24,7 @@ import {
 import { checkAmountOrOtherAmount, isValidEmail } from 'helpers/formValidation';
 import { type CountryGroupId, Canada, UnitedStates } from 'helpers/internationalisation/countryGroup';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
-import type {CaState, IsoCountry, UsState} from 'helpers/internationalisation/country';
+import type { CaState, IsoCountry, UsState } from 'helpers/internationalisation/country';
 import { logException } from 'helpers/logger';
 import type {
   State,
@@ -144,10 +144,10 @@ function updatePayerState(token: Object, setState: (UsState | CaState | null) =>
   if (state) {
     setState(state);
     return true;
-  } else {
-    logException('Missing address_state in payment request token');
-    return false;
   }
+  logException('Missing address_state in payment request token');
+  return false;
+
 }
 
 // Calling the complete function will close the pop up payment window
@@ -213,7 +213,7 @@ function setUpPaymentListener(props: PropTypes, paymentRequest: Object, paymentM
 
     const stateUpdateOk =
       props.stripeAccount !== 'ONE_OFF' && (props.countryGroupId === UnitedStates || props.countryGroupId === Canada) ?
-      updatePayerState(token, props.updateState) : true;
+        updatePayerState(token, props.updateState) : true;
 
     const nameUpdateOk: boolean = props.stripeAccount !== 'ONE_OFF' ?
       updatePayerName(data, props.updateFirstName, props.updateLastName) : true;


### PR DESCRIPTION
## Why are you doing this?

We appear to have hit our account limit of requests for the address finder service getAddressIO.  This temporarily removes the lookup functionality from checkouts altogether while we update our account.

Next steps:
- Improve error message for when service returns this kind of error (i.e. 5XX)
- Put this removal behind a switch to make this easier if it happens again

## Screenshots

![image](https://user-images.githubusercontent.com/8754692/68198282-9e34cc80-ffb3-11e9-86c3-3e5983b945c1.png)
