### PR TITLE
Payment security reassurance test amendment

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -1,13 +1,19 @@
 // @flow
 import type { Tests } from './abtest';
 import { get as getCookie } from 'helpers/cookie';
+import {
+  type CountryGroupId,
+  detect,
+} from 'helpers/internationalisation/countryGroup';
 
 // ----- Tests ----- //
 export type LandingPageCopyReturningSinglesTestVariants = 'control' | 'returningSingle' | 'notintest';
 export type LandingPageStripeElementsRecurringTestVariants = 'control' | 'stripeElements' | 'notintest';
-export type PaymentSecurityDesignTestVariants = 'control' | 'V1_securetop' | 'V2_securemiddle' | 'V3_securebottom' | 'V4_grey'
+export type PaymentSecurityDesignTestVariants = 'control' | 'V1_securetop' | 'V2_securemiddle' | 'V3_securebottom' | 'V4_grey' | 'notintest'
 
 const contributionsLandingPageMatch = '/(uk|us|eu|au|ca|nz|int)/contribute(/.*)?$';
+
+const countryGroupId: CountryGroupId = detect();
 
 export const tests: Tests = {
   landingPageCopyReturningSingles: {
@@ -106,5 +112,6 @@ export const tests: Tests = {
     independent: true,
     seed: 10,
     targetPage: contributionsLandingPageMatch,
+    canRun: () => countryGroupId !== 'GBPCountries',
   },
 };

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
@@ -246,9 +246,9 @@ function withProps(props: PropTypes) {
 
   const classModifiers = ['contribution', 'with-labels'];
 
-  const showSecureStripeContainer: boolean = props.paymentSecurityDesignTestVariant !== 'control';
+  const showSecureStripeContainer: boolean = props.paymentSecurityDesignTestVariant !== 'control' || props.countryGroupId === 'GBPCountries';
   const showSecureButtonBg: boolean = showSecureStripeContainer && props.paymentMethod === Stripe && (props.stripeElementsRecurringTestVariant === 'stripeElements' || props.contributionType === 'ONE_OFF');
-  const showSecureTransactionIndicator: boolean = props.paymentSecurityDesignTestVariant === 'V3_securebottom';
+  const showSecureTransactionIndicator: boolean = props.paymentSecurityDesignTestVariant === 'V3_securebottom' && props.countryGroupId !== 'GBPCountries';
   const secureTransactionIndicatorClassNames: string[] = showSecureButtonBg ? ['bottom-grey'] : ['bottom-regular'];
 
   return (

--- a/support-frontend/assets/pages/contributions-landing/components/PaymentMethodSelector.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/PaymentMethodSelector.jsx
@@ -42,6 +42,10 @@ import {
 } from '../../../helpers/existingPaymentMethods/existingPaymentMethods';
 import SecureTransactionIndicator from 'components/secureTransactionIndicator/secureTransactionIndicator';
 import type { PaymentSecurityDesignTestVariants } from 'helpers/abTests/abtestDefinitions';
+import {
+  type CountryGroupId,
+  detect,
+} from 'helpers/internationalisation/countryGroup';
 
 
 // ----- Types ----- //
@@ -111,11 +115,13 @@ function withProps(props: PropTypes) {
   const fullExistingPaymentMethods: RecentlySignedInExistingPaymentMethod[] =
     ((props.existingPaymentMethods || []).filter(isUsableExistingPaymentMethod): any);
 
+  const countryGroupId: CountryGroupId = detect();
+
   const legendSimple = (
     <legend id="payment_method" className="form__legend"><h3>Payment method</h3></legend>
   );
 
-  const legend = props.paymentSecurityDesignTestVariant === 'V2_securemiddle' ?
+  const legend = props.paymentSecurityDesignTestVariant === 'V2_securemiddle' && countryGroupId !== 'GBPCountries' ?
     (
       <div className="secure-transaction">
         {legendSimple} <SecureTransactionIndicator modifierClasses={['middle']} />

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
@@ -93,6 +93,9 @@ const cssModifiers = campaignName && campaigns[campaignName] && campaigns[campai
 const backgroundImageSrc = campaignName && campaigns[campaignName] && campaigns[campaignName].backgroundImage ?
   campaigns[campaignName].backgroundImage : null;
 
+const showSecureTransactionIndicator = (store.getState().common.abParticipations.paymentSecurityDesignTest === 'V1_securetop' && countryGroupId !== 'GBPCountries')
+|| countryGroupId === 'GBPCountries' ? <SecureTransactionIndicator modifierClasses={['top']} /> : null;
+
 function contributionsLandingPage(campaignCodeParameter: ?string) {
   return (
     <Page
@@ -101,8 +104,7 @@ function contributionsLandingPage(campaignCodeParameter: ?string) {
       footer={<Footer disclaimer countryGroupId={countryGroupId} />}
       backgroundImageSrc={backgroundImageSrc}
     >
-      {store.getState().common.abParticipations.paymentSecurityDesignTest === 'V1_securetop' &&
-      <SecureTransactionIndicator modifierClasses={['top']} />}
+      {showSecureTransactionIndicator}
       <ContributionFormContainer
         thankYouRoute={`/${countryGroups[countryGroupId].supportInternationalisationId}/thankyou`}
         campaignCodeParameter={campaignCodeParameter}

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
@@ -93,7 +93,7 @@ const cssModifiers = campaignName && campaigns[campaignName] && campaigns[campai
 const backgroundImageSrc = campaignName && campaigns[campaignName] && campaigns[campaignName].backgroundImage ?
   campaigns[campaignName].backgroundImage : null;
 
-const showSecureTransactionIndicator = (store.getState().common.abParticipations.paymentSecurityDesignTest === 'V1_securetop' && countryGroupId !== 'GBPCountries')
+const showSecureTransactionIndicator = store.getState().common.abParticipations.paymentSecurityDesignTest === 'V1_securetop'
 || countryGroupId === 'GBPCountries' ? <SecureTransactionIndicator modifierClasses={['top']} /> : null;
 
 function contributionsLandingPage(campaignCodeParameter: ?string) {


### PR DESCRIPTION
## Why are you doing this?

We are amending the test to display the secure transaction indicator to 100% of the audience in the UK to benefit from its good performance so far. The grey background is also performing well and will appear to 100% of the UK audience also.

The test remains the same for the other regions, to allow them to reach significance.

This follows on from this PR: (https://github.com/guardian/support-frontend/pull/2165)
<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/9x3rkdRi)

## Changes

* Remove UK from payment security design test
* Show secure transaction indicator at top of landing page for UK only
* Show grey background on card details for UK

## Screenshots
<img width="783" alt="image" src="https://user-images.githubusercontent.com/15648334/68304077-f693c900-009c-11ea-90b0-3fd733f0a15a.png">

