### PR TITLE
Add a little bit of margin to the top of paragraphs in the GW promotion description section

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.scss
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.scss
@@ -50,6 +50,9 @@
 }
 
 .promotion-description {
+  p {
+    margin-top: 14px;
+  }
   em {
     font-style: italic;
   }


### PR DESCRIPTION
## Why are you doing this?

Marketing can now edit some of the copy on the GW product page via the promo tool, however paragraphs in the copy they add are not styled correctly meaning that it ends up looking like a single block of text. This PR fixes that.

## Screenshots
**Before**
![Screen Shot 2019-11-06 at 14 26 26](https://user-images.githubusercontent.com/181371/68306600-c13daa00-00a1-11ea-83df-5c6761a08836.png)
**After**
![Screen Shot 2019-11-06 at 14 25 23](https://user-images.githubusercontent.com/181371/68306599-c13daa00-00a1-11ea-91c2-759739818e5b.png)




