### PR TITLE
Fixing link rendering

### DIFF
--- a/support-frontend/assets/components/headers/links/links.jsx
+++ b/support-frontend/assets/components/headers/links/links.jsx
@@ -84,7 +84,7 @@ const links: HeaderNavLink[] = [
 
 function inferCurrencyCode(countryGroupId: ?CountryGroupId = null): ?string {
   switch (countryGroupId) {
-    case UnitedStates | International:
+    case UnitedStates:
       return 'us';
     case Canada:
       return 'ca';
@@ -96,6 +96,8 @@ function inferCurrencyCode(countryGroupId: ?CountryGroupId = null): ?string {
       return 'eu';
     case NZDCountries:
       return 'nz';
+    case International:
+      return "int";
     default:
       return null;
   }

--- a/support-frontend/assets/components/headers/links/links.jsx
+++ b/support-frontend/assets/components/headers/links/links.jsx
@@ -8,12 +8,9 @@ import { type Option } from 'helpers/types/option';
 import { classNameWithModifiers } from 'helpers/utilities';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
 import {
-  AUDCountries,
-  Canada,
-  type CountryGroupId, EURCountries,
-  GBPCountries, International, NZDCountries,
-  UnitedStates,
+  type CountryGroupId, GBPCountries,
 } from 'helpers/internationalisation/countryGroup';
+import { countryGroups } from 'helpers/internationalisation/countryGroup';
 
 // types
 type HeaderNavLink = {
@@ -82,25 +79,8 @@ const links: HeaderNavLink[] = [
 ];
 
 
-function inferCurrencyCode(countryGroupId: ?CountryGroupId = null): ?string {
-  switch (countryGroupId) {
-    case UnitedStates:
-      return 'us';
-    case Canada:
-      return 'ca';
-    case GBPCountries:
-      return 'uk';
-    case AUDCountries:
-      return 'au';
-    case EURCountries:
-      return 'eu';
-    case NZDCountries:
-      return 'nz';
-    case International:
-      return "int";
-    default:
-      return null;
-  }
+function internationalisationID(countryGroupId: ?CountryGroupId = null): ?string {
+  return countryGroups[countryGroupId].supportInternationalisationId;
 }
 
 // Export
@@ -123,13 +103,13 @@ const Links = ({ location, getRef, countryGroupId }: PropTypes) => (
         // Otherwise return true.
         return true;
       }).map((link) => {
-        const currencyPrefix = inferCurrencyCode(countryGroupId);
+        const internationalisationIDValue = internationalisationID(countryGroupId);
 
-        if (currencyPrefix == null || !link.internal) {
+        if (internationalisationIDValue == null || !link.internal) {
           return link;
         }
 
-        return { ...link, href: `/${currencyPrefix}${link.href}` };
+        return { ...link, href: `/${internationalisationIDValue}${link.href}` };
       }).map(({
         href, text, trackAs, opensInNewWindow, additionalClasses,
       }) => (

--- a/support-frontend/assets/components/headers/links/links.jsx
+++ b/support-frontend/assets/components/headers/links/links.jsx
@@ -83,13 +83,9 @@ function internationalisationID(countryGroupId: ?CountryGroupId = null): ?string
 
   if (countryGroupId != null) {
     const group = countryGroups[countryGroupId];
-
-    if (typeof group !== 'undefined' && group != null) {
-      return group.supportInternationalisationId;
-    }
-    return null;
-
+    return group ? group.supportInternationalisationId : null;
   }
+
   return null;
 
 }

--- a/support-frontend/assets/components/headers/links/links.jsx
+++ b/support-frontend/assets/components/headers/links/links.jsx
@@ -80,7 +80,18 @@ const links: HeaderNavLink[] = [
 
 
 function internationalisationID(countryGroupId: ?CountryGroupId = null): ?string {
-  return countryGroups[countryGroupId].supportInternationalisationId;
+
+  if (countryGroupId != null) {
+    let group = countryGroups[countryGroupId];
+
+    if (typeof  group !== 'undefined' && group != null) {
+      return group.supportInternationalisationId
+    } else {
+      return null;
+    }
+  } else {
+    return null
+  }
 }
 
 // Export

--- a/support-frontend/assets/components/headers/links/links.jsx
+++ b/support-frontend/assets/components/headers/links/links.jsx
@@ -7,13 +7,20 @@ import { getPatronsLink } from 'helpers/externalLinks';
 import { type Option } from 'helpers/types/option';
 import { classNameWithModifiers } from 'helpers/utilities';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
-import { type CountryGroupId, GBPCountries } from 'helpers/internationalisation/countryGroup';
+import {
+  AUDCountries,
+  Canada,
+  type CountryGroupId, EURCountries,
+  GBPCountries, International, NZDCountries,
+  UnitedStates,
+} from 'helpers/internationalisation/countryGroup';
 
 // types
 type HeaderNavLink = {
   href: string,
   text: string,
   trackAs: string,
+  internal: boolean,
   opensInNewWindow?: boolean,
   include?: CountryGroupId[],
   additionalClasses?: string,
@@ -31,73 +38,116 @@ const links: HeaderNavLink[] = [
     href: routes.showcase,
     text: 'Support',
     trackAs: 'showcase',
+    internal: true,
   },
   {
     href: routes.recurringContribCheckout,
     text: 'Contributions',
     trackAs: 'contributions',
     additionalClasses: 'component-header-links__li--show-on-tablet',
+    internal: true,
   },
   {
     href: routes.subscriptionsLanding,
     text: 'Subscriptions',
     trackAs: 'subscriptions',
+    internal: true,
   },
   {
     href: routes.digitalSubscriptionLanding,
     text: 'Digital',
     trackAs: 'subscriptions:digital',
+    internal: true,
   },
   {
     href: routes.paperSubscriptionLanding,
     text: 'Paper',
     trackAs: 'subscriptions:paper',
     include: [GBPCountries],
+    internal: true,
   },
   {
     href: routes.guardianWeeklySubscriptionLanding,
     text: 'Guardian Weekly',
     trackAs: 'subscriptions:guardianweekly',
+    internal: true,
   },
   {
     href: getPatronsLink('support-header'),
     text: 'Patrons',
     trackAs: 'patrons',
     opensInNewWindow: true,
+    internal: false,
   },
 ];
 
 
+function inferCurrencyCode(countryGroupId: ?CountryGroupId = null): ?string {
+  switch (countryGroupId) {
+    case UnitedStates:
+      return 'us';
+    case Canada:
+      return 'ca';
+    case GBPCountries:
+      return 'uk';
+    case AUDCountries:
+      return 'au';
+    case EURCountries:
+      return 'eu';
+    case NZDCountries:
+      return 'nz';
+    case International:
+      return 'ca';
+    default:
+      return null;
+  }
+}
+
 // Export
+
 const Links = ({ location, getRef, countryGroupId }: PropTypes) => (
   <nav className={classNameWithModifiers('component-header-links', [location])}>
     <ul className="component-header-links__ul" ref={getRef}>
-      {links.filter(({ include }) => {
+      {
+        links.filter(({ include }) => {
+
+        // If there is no country group ID for the link, return true and include the link in the rendering.
         if (!countryGroupId) {
           return true;
         }
+        // If the link is not meant to be rendered for a specific CountryGroupID, do not include.
         if (include && !include.includes(countryGroupId)) {
           return false;
         }
+
+        // Otherwise return true.
         return true;
+      }).map((link) => {
+        const currencyPrefix = inferCurrencyCode(countryGroupId);
+
+        if (currencyPrefix == null || !link.internal) {
+          return link;
+        }
+
+        return { ...link, href: `/${currencyPrefix}${link.href}` };
       }).map(({
         href, text, trackAs, opensInNewWindow, additionalClasses,
-        }) => (
-          <li
-            className={cx(classNameWithModifiers(
+      }) => (
+        <li
+          className={cx(classNameWithModifiers(
                 'component-header-links__li',
                 [window.location.href.endsWith(href) ? 'active' : null],
               ), additionalClasses)}
+        >
+          <a
+            onClick={() => { trackComponentClick(['header-link', trackAs, location].join(' - ')); }}
+            className="component-header-links__link"
+            href={href}
+            target={opensInNewWindow ? '_blank' : null}
           >
-            <a
-              onClick={() => { trackComponentClick(['header-link', trackAs, location].join(' - ')); }}
-              className="component-header-links__link"
-              href={href}
-              target={opensInNewWindow ? '_blank' : null}
-            >
-              {text}
-            </a>
-          </li>
+            {text}
+          </a>
+        </li>
         ))}
     </ul>
   </nav>

--- a/support-frontend/assets/components/headers/links/links.jsx
+++ b/support-frontend/assets/components/headers/links/links.jsx
@@ -84,7 +84,7 @@ const links: HeaderNavLink[] = [
 
 function inferCurrencyCode(countryGroupId: ?CountryGroupId = null): ?string {
   switch (countryGroupId) {
-    case UnitedStates:
+    case UnitedStates | International:
       return 'us';
     case Canada:
       return 'ca';
@@ -96,8 +96,6 @@ function inferCurrencyCode(countryGroupId: ?CountryGroupId = null): ?string {
       return 'eu';
     case NZDCountries:
       return 'nz';
-    case International:
-      return 'ca';
     default:
       return null;
   }

--- a/support-frontend/assets/components/headers/links/links.jsx
+++ b/support-frontend/assets/components/headers/links/links.jsx
@@ -82,16 +82,16 @@ const links: HeaderNavLink[] = [
 function internationalisationID(countryGroupId: ?CountryGroupId = null): ?string {
 
   if (countryGroupId != null) {
-    let group = countryGroups[countryGroupId];
+    const group = countryGroups[countryGroupId];
 
-    if (typeof  group !== 'undefined' && group != null) {
-      return group.supportInternationalisationId
-    } else {
-      return null;
+    if (typeof group !== 'undefined' && group != null) {
+      return group.supportInternationalisationId;
     }
-  } else {
-    return null
+    return null;
+
   }
+  return null;
+
 }
 
 // Export

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -24,7 +24,7 @@ import {
 import { checkAmountOrOtherAmount, isValidEmail } from 'helpers/formValidation';
 import { type CountryGroupId, Canada, UnitedStates } from 'helpers/internationalisation/countryGroup';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
-import type {CaState, IsoCountry, UsState} from 'helpers/internationalisation/country';
+import type { CaState, IsoCountry, UsState } from 'helpers/internationalisation/country';
 import { logException } from 'helpers/logger';
 import type {
   State,
@@ -144,10 +144,10 @@ function updatePayerState(token: Object, setState: (UsState | CaState | null) =>
   if (state) {
     setState(state);
     return true;
-  } else {
-    logException('Missing address_state in payment request token');
-    return false;
   }
+  logException('Missing address_state in payment request token');
+  return false;
+
 }
 
 // Calling the complete function will close the pop up payment window
@@ -213,7 +213,7 @@ function setUpPaymentListener(props: PropTypes, paymentRequest: Object, paymentM
 
     const stateUpdateOk =
       props.stripeAccount !== 'ONE_OFF' && (props.countryGroupId === UnitedStates || props.countryGroupId === Canada) ?
-      updatePayerState(token, props.updateState) : true;
+        updatePayerState(token, props.updateState) : true;
 
     const nameUpdateOk: boolean = props.stripeAccount !== 'ONE_OFF' ?
       updatePayerName(data, props.updateFirstName, props.updateLastName) : true;


### PR DESCRIPTION
## Why are you doing this?

<!--
Current header navigation links do not account for a geographical/currency setting of the header in subscription navigation links like they do in contributions. This adds a country prefix to all the links in the nav to allow correct geo-targetting.
-->

[**Trello Card**](https://trello.com/c/ZS6DcZpX/2486-refactor-navbar-geolocator-involvement)

## Changes

* Added a function to infer currency code from `CountryGroupId`.
* Added a modified to navigation links to differentiate external and internal links. External links do not need prefixing with currency code/geo-location.

## Screenshots

<img width="1207" alt="Screenshot 2019-11-06 19 39 22" src="https://user-images.githubusercontent.com/1645142/68331630-3bcfef00-00cd-11ea-8412-eb88eff5b819.png">
<img width="1207" alt="Screenshot 2019-11-06 19 39 34" src="https://user-images.githubusercontent.com/1645142/68331634-3d99b280-00cd-11ea-9664-747ccb727f46.png">
