### PR TITLE
Fix root redirect

### DIFF
--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -65,8 +65,8 @@ class Application(
   def geoRedirect: Action[AnyContent] = GeoTargetedCachedAction() { implicit request =>
     val redirectUrl = request.geoData.countryGroup match {
       case Some(UK) => buildCanonicalShowcaseLink("uk")
-      case Some(US) => "/us/contribute"
-      case Some(Australia) => "/au/contribute"
+      case Some(US) => buildCanonicalShowcaseLink("us")
+      case Some(Australia) => buildCanonicalShowcaseLink("au")
       case Some(Europe) => "/eu/contribute"
       case Some(Canada) => "/ca/contribute"
       case Some(NewZealand) => "/nz/contribute"


### PR DESCRIPTION
## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/2WKwb3o3/2600-root-geo-redirect-still-goes-to-contribute-for-au-and-us-even-though-we-have-why-support-page-for-them)

## Changes

* Changed redirect on `/` to go to support showcase page for `US` and `AU`

## Screenshots

