### PR TITLE
Failure emails

### DIFF
--- a/support-workers/src/main/scala/com/gu/emailservices/FailedDigitalPackEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/FailedDigitalPackEmailFields.scala
@@ -6,8 +6,3 @@ case class FailedDigitalPackEmailFields(email: String, identityUserId: IdentityU
   override def userId: Either[SfContactId, IdentityUserId] = Right(identityUserId)
   override def payload: String = super.payload(email, "digipack-failed")
 }
-
-case class FailedPaperEmailFields(email: String, identityUserId: IdentityUserId) extends EmailFields {
-  override def userId: Either[SfContactId, IdentityUserId] = Right(identityUserId)
-  override def payload: String = super.payload(email, "print-failed")
-}

--- a/support-workers/src/main/scala/com/gu/emailservices/FailedDigitalPackEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/FailedDigitalPackEmailFields.scala
@@ -6,3 +6,8 @@ case class FailedDigitalPackEmailFields(email: String, identityUserId: IdentityU
   override def userId: Either[SfContactId, IdentityUserId] = Right(identityUserId)
   override def payload: String = super.payload(email, "digipack-failed")
 }
+
+case class FailedPaperEmailFields(email: String, identityUserId: IdentityUserId) extends EmailFields {
+  override def userId: Either[SfContactId, IdentityUserId] = Right(identityUserId)
+  override def payload: String = super.payload(email, "print-failed")
+}

--- a/support-workers/src/main/scala/com/gu/emailservices/FailedGuardianWeeklyEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/FailedGuardianWeeklyEmailFields.scala
@@ -3,7 +3,6 @@ package com.gu.emailservices
 import com.gu.salesforce.Salesforce.SfContactId
 
 case class FailedGuardianWeeklyEmailFields(email: String, identityUserId: IdentityUserId) extends EmailFields {
-  //TODO: update this once there is an email template for paper sign up failures
   override def payload: String = super.payload(email, "guardian-weekly-failed")
   override def userId: Either[SfContactId, IdentityUserId] = Right(identityUserId)
 }

--- a/support-workers/src/test/scala/com/gu/support/workers/lambdas/FailureHandlerSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/lambdas/FailureHandlerSpec.scala
@@ -3,7 +3,7 @@ package com.gu.support.workers.lambdas
 import java.io.ByteArrayOutputStream
 
 import com.amazonaws.services.sqs.model.SendMessageResult
-import com.gu.emailservices.{EmailService, FailedContributionEmailFields, FailedDigitalPackEmailFields, IdentityUserId}
+import com.gu.emailservices.{EmailService, FailedContributionEmailFields, FailedDigitalPackEmailFields, FailedGuardianWeeklyEmailFields, FailedPaperEmailFields, IdentityUserId}
 import com.gu.monitoring.SafeLogger
 import com.gu.support.workers.CheckoutFailureReasons.{PaymentMethodUnacceptable, Unknown}
 import com.gu.support.workers.JsonFixtures._
@@ -181,6 +181,49 @@ object DigiPackFailureHandlerManualTest extends Matchers {
         sys.exit(0)
       }
   }
-
 }
+
+object GuardianWeeklyFailureHandlerTest extends Matchers {
+
+  implicit val ex = scala.concurrent.ExecutionContext.Implicits.global
+
+  def main(args: Array[String]): Unit = {
+    sendFailureEmail()
+  }
+
+  def sendFailureEmail() {
+    //This test will send a failure email to the address below - useful for quickly testing changes
+    val service = new EmailService
+    val email = "flavian.alexandru.freelancer@guardian.co.uk"
+    service
+      .send(FailedGuardianWeeklyEmailFields(email, IdentityUserId("identityId")))
+      .map { result =>
+        result.getMessageId should not be ""
+        sys.exit(0)
+      }
+  }
+}
+
+
+object PrintFailureHandlerTest extends Matchers {
+
+  implicit val ex = scala.concurrent.ExecutionContext.Implicits.global
+
+  def main(args: Array[String]): Unit = {
+    sendFailureEmail()
+  }
+
+  def sendFailureEmail() {
+    //This test will send a failure email to the address below - useful for quickly testing changes
+    val service = new EmailService
+    val email = "flavian.alexandru.freelancer@guardian.co.uk"
+    service
+      .send(FailedPaperEmailFields(email, IdentityUserId("identityId")))
+      .map { result =>
+        result.getMessageId should not be ""
+        sys.exit(0)
+      }
+  }
+}
+
 


### PR DESCRIPTION
## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

This is a 2 in 1 special PR

- Print failure email Trello Card: [**Trello Card**](https://trello.com/c/Jrau1rZr/2271-print-failure-email)
- Guardian weekly failed email: https://trello.com/c/dLmrZO7r/2337-guardian-weekly-failure-email

## Changes

* Added classes for `GuardianWeeklyFailed` and `PrintFailed` emails.
* Added manual tests to check against live Braze deployment/membership-workflow that they work.

