### PR TITLE
Opt in for recurring payment request button

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
@@ -30,7 +30,13 @@ type PropTypes = {|
   otherAmounts: OtherAmounts,
 |};
 
-const enabledForRecurring = (): boolean => !!window.guardian.recurringStripePaymentRequestButton;
+const enabledForRecurring = (): boolean => {
+  const hashUrl = (new URL(document.URL)).hash;
+  if (hashUrl === "#recurringStripePaymentRequestButton") {
+    return true
+  }
+  return !!window.guardian.recurringStripePaymentRequestButton;
+}
 
 // ----- Component ----- //
 


### PR DESCRIPTION
This is just to allow testing of the recurring Payment Request button in PROD. This feature is currently disabled in PROD, but we need to test apple pay in PROD.
Can be removed after it goes live