### PR TITLE
Add postcode lookup flag

### DIFF
--- a/support-frontend/app/controllers/GetAddress.scala
+++ b/support-frontend/app/controllers/GetAddress.scala
@@ -25,7 +25,7 @@ class GetAddress(
         BadRequest //The postcode was invalid
       case error =>
         SafeLogger.error(scrub"Failed to complete postcode lookup via getAddress.io due to: $error")
-        InternalServerError
+
     }
   }
 }

--- a/support-frontend/app/controllers/GetAddress.scala
+++ b/support-frontend/app/controllers/GetAddress.scala
@@ -25,7 +25,7 @@ class GetAddress(
         BadRequest //The postcode was invalid
       case error =>
         SafeLogger.error(scrub"Failed to complete postcode lookup via getAddress.io due to: $error")
-
+        InternalServerError
     }
   }
 }

--- a/support-frontend/app/controllers/GetAddress.scala
+++ b/support-frontend/app/controllers/GetAddress.scala
@@ -11,11 +11,12 @@ import play.api.mvc.{AbstractController, Action, AnyContent, ControllerComponent
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class GetAddress(
-        components: ControllerComponents,
-        getAddressService: GetAddressIOService,
-        actionRefiners: CustomActionBuilders
-      ) extends AbstractController(components) with Circe {
+  components: ControllerComponents,
+  getAddressService: GetAddressIOService,
+  actionRefiners: CustomActionBuilders
+) extends AbstractController(components) with Circe {
   import actionRefiners._
+
   def findAddress(postCode: String): Action[AnyContent] = NoCacheAction().async { implicit request =>
     getAddressService.find(postCode).map { result =>
       Ok(result.asJson)

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -104,6 +104,7 @@
   }
 
   window.guardian.stripeElementsRecurring = @settings.switches.experiments.get("stripeElementsRecurring").exists(_.isOn)
+  window.guardian.checkoutPostcodeLookup = @settings.switches.experiments.get("checkoutPostcodeLookup").exists(_.isOn)
 
   window.guardian.forceCampaign = @settings.switches.experiments.get("forceCampaign").exists(_.isOn)
   window.guardian.recurringStripePaymentRequestButton = @settings.switches.experiments.get("recurringStripePaymentRequestButton").exists(_.isOn)

--- a/support-frontend/assets/components/subscriptionCheckouts/address/postcodeFinderStore.js
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/postcodeFinderStore.js
@@ -45,7 +45,7 @@ const postcodeFinderActionCreatorsFor = (scope: AddressType) => ({
         .catch((reason) => {
           dispatch({
             type: 'SET_POSTCODE_FINDER_ERROR',
-            error: err.message,
+            error: reason.message,
             scope,
           });
         });

--- a/support-frontend/assets/components/subscriptionCheckouts/address/postcodeFinderStore.js
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/postcodeFinderStore.js
@@ -5,6 +5,7 @@ import { type Option } from 'helpers/types/option';
 import { type Scoped } from 'helpers/scoped';
 import { type AddressType } from 'helpers/subscriptionsForms/addressType';
 import {
+
   getAddressesForPostcode,
   type PostcodeFinderResult,
 } from 'components/subscriptionCheckouts/address/postcodeLookup';

--- a/support-frontend/assets/components/subscriptionCheckouts/address/postcodeFinderStore.js
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/postcodeFinderStore.js
@@ -42,10 +42,10 @@ const postcodeFinderActionCreatorsFor = (scope: AddressType) => ({
             scope,
           });
         })
-        .catch(() => {
+        .catch((reason) => {
           dispatch({
             type: 'SET_POSTCODE_FINDER_ERROR',
-            error: 'We couldn\'t find this postcode, please check and try again or enter your address below.',
+            error: err.message,
             scope,
           });
         });

--- a/support-frontend/assets/components/subscriptionCheckouts/address/postcodeLookup.js
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/postcodeLookup.js
@@ -7,14 +7,30 @@ export type PostcodeFinderResult = {|
   city?: string,
 |};
 
+
+function handleErrors(response: Response) {
+  if (response.ok) {
+    return response
+  } else {
+    if (response.status === 500) {
+      throw new Error("External address service temporarily unavailable. Please proceed with checkout. We apologise for the inconvenience")
+    } else if (response.status === 400) {
+      throw new Error('We couldn\'t find this postcode, please check and try again or enter your address below.',)
+    } else {
+      throw new Error("Error while contacting address API: ", response.statusText)
+    }
+  }
+}
+
 const getAddressesForPostcode = (postcode: string): Promise<PostcodeFinderResult[]> => {
 
   if (window.guardian.checkoutPostcodeLookup) {
     return fetch(postcodeLookupUrl(postcode))
-      .then(res => res.json());
+      .then(handleErrors)
+      .then(res => res.json())
   }
-  return Promise.resolve([]);
 
+  return Promise.resolve([]);
 };
 
 export { getAddressesForPostcode };

--- a/support-frontend/assets/components/subscriptionCheckouts/address/postcodeLookup.js
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/postcodeLookup.js
@@ -7,8 +7,14 @@ export type PostcodeFinderResult = {|
   city?: string,
 |};
 
-const getAddressesForPostcode = (postcode: string): Promise<PostcodeFinderResult[]> =>
-  fetch(postcodeLookupUrl(postcode))
-    .then(res => res.json());
+const getAddressesForPostcode = (postcode: string): Promise<PostcodeFinderResult[]> => {
+
+  if (window.guardian.checkoutPostcodeLookup) {
+    return fetch(postcodeLookupUrl(postcode))
+      .then(res => res.json());
+  }
+  return Promise.resolve([]);
+
+};
 
 export { getAddressesForPostcode };

--- a/support-frontend/assets/components/subscriptionCheckouts/address/postcodeLookup.js
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/postcodeLookup.js
@@ -1,5 +1,6 @@
 // @flow
 import { postcodeLookupUrl } from 'helpers/routes';
+import { getGlobal } from 'helpers/globals';
 
 export type PostcodeFinderResult = {|
   lineOne?: string,
@@ -10,24 +11,24 @@ export type PostcodeFinderResult = {|
 
 function handleErrors(response: Response) {
   if (response.ok) {
-    return response
-  } else {
-    if (response.status === 500) {
-      throw new Error("External address service temporarily unavailable. Please proceed with checkout. We apologise for the inconvenience")
-    } else if (response.status === 400) {
-      throw new Error('We couldn\'t find this postcode, please check and try again or enter your address below.',)
-    } else {
-      throw new Error("Error while contacting address API: ", response.statusText)
-    }
+    return response;
   }
+  if (response.status === 500) {
+    throw new Error('External address service temporarily unavailable. Please proceed with checkout. We apologise for the inconvenience');
+  } else if (response.status === 400) {
+    throw new Error('We couldn\'t find this postcode, please check and try again or enter your address below.');
+  } else {
+    throw new Error(`Error while contacting address API: ${response.statusText}`);
+  }
+
 }
 
 const getAddressesForPostcode = (postcode: string): Promise<PostcodeFinderResult[]> => {
 
-  if (window.guardian.checkoutPostcodeLookup) {
+  if (getGlobal('checkoutPostcodeLookup')) {
     return fetch(postcodeLookupUrl(postcode))
       .then(handleErrors)
-      .then(res => res.json())
+      .then(res => res.json());
   }
 
   return Promise.resolve([]);

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -224,7 +224,7 @@ function setUpPaymentListener(props: PropTypes, paymentRequest: Object, paymentM
 
     // We need to do this so that we can offer marketing permissions on the thank you page
     updatePayerEmail(data, props.updateEmail);
-    
+
     const stateUpdateOk = props.countryGroupId === UnitedStates || props.countryGroupId === Canada ?
       updatePayerState(token, props.updateState) : true;
 


### PR DESCRIPTION
## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/OQhOWhfc/2711-put-the-address-finder-aka-postcode-lookup-behind-a-switch)
[**Address lookup error**](https://trello.com/c/wvgdTwTm/2712-add-distinct-error-message-on-the-address-finder-for-an-internal-server-error)

## Changes

* Added a switch called `checkoutPostcodeLookup` to enable/disable using the external address service during postcode lookup.
* Change logic to return `Promise.resolve([])` when postcode lookup is disabled, by-passing the API Call. Designed to be used only when external service is unavailable.
* Not sure how to use `getGlobal` convention on this one. @rupertbates please advise.
* Added switches to `DEV`, `CODE`, and `PROD` on Amazon S3. Can be checked here: https://support.gutools.co.uk/switches
* Added a failure handler to return specific error messages based on `GetAddress` backend route response status codes.
