### PR TITLE
Fix the promo terms link on the DP landing page

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -22,21 +22,30 @@ import {
   type StripePaymentRequestButtonMethod,
 } from 'helpers/paymentIntegrations/readerRevenueApis';
 import { checkAmountOrOtherAmount, isValidEmail } from 'helpers/formValidation';
-import { type CountryGroupId, Canada, UnitedStates } from 'helpers/internationalisation/countryGroup';
+import {
+  Canada,
+  type CountryGroupId,
+  UnitedStates,
+} from 'helpers/internationalisation/countryGroup';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
-import type { CaState, IsoCountry, UsState } from 'helpers/internationalisation/country';
+import type {
+  CaState,
+  IsoCountry,
+  UsState,
+} from 'helpers/internationalisation/country';
 import { logException } from 'helpers/logger';
 import type {
   State,
   StripePaymentRequestButtonData,
 } from 'pages/contributions-landing/contributionsLandingReducer';
+import type { Action } from 'pages/contributions-landing/contributionsLandingActions';
 import {
   onThirdPartyPaymentAuthorised,
+  paymentWaiting as setPaymentWaiting,
   setPaymentRequestButtonPaymentMethod,
   setStripePaymentRequestButtonClicked,
-  setStripePaymentRequestObject,
   setStripePaymentRequestButtonError,
-  paymentWaiting as setPaymentWaiting,
+  setStripePaymentRequestObject,
   updateEmail,
   updateFirstName,
   updateLastName,
@@ -47,9 +56,9 @@ import type { PaymentMethod } from 'helpers/paymentMethods';
 import { Stripe } from 'helpers/paymentMethods';
 import { toHumanReadableContributionType } from 'helpers/checkouts';
 import type { StripeAccount } from 'helpers/paymentIntegrations/stripeCheckout';
-import type { Action } from 'pages/contributions-landing/contributionsLandingActions';
 import type { ErrorReason } from 'helpers/errorReasons';
-import GeneralErrorMessage from 'components/generalErrorMessage/generalErrorMessage';
+import GeneralErrorMessage
+  from 'components/generalErrorMessage/generalErrorMessage';
 
 // ----- Types -----//
 
@@ -224,7 +233,7 @@ function setUpPaymentListener(props: PropTypes, paymentRequest: Object, paymentM
 
     // We need to do this so that we can offer marketing permissions on the thank you page
     updatePayerEmail(data, props.updateEmail);
-    
+
     const stateUpdateOk = props.countryGroupId === UnitedStates || props.countryGroupId === Canada ?
       updatePayerState(token, props.updateState) : true;
 

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
@@ -5,16 +5,22 @@
 // ----- Imports ----- //
 
 import React from 'react';
-import { StripeProvider, Elements } from 'react-stripe-elements';
+import { Elements, StripeProvider } from 'react-stripe-elements';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
-import { getStripeKey, stripeAccountForContributionType } from 'helpers/paymentIntegrations/stripeCheckout';
-import type { ContributionType, OtherAmounts, SelectedAmounts } from 'helpers/contributions';
+import {
+  getStripeKey,
+  stripeAccountForContributionType,
+} from 'helpers/paymentIntegrations/stripeCheckout';
+import type {
+  ContributionType,
+  OtherAmounts,
+  SelectedAmounts,
+} from 'helpers/contributions';
 import { getAmount } from 'helpers/contributions';
-import { isInStripePaymentRequestAllowedCountries } from 'helpers/internationalisation/country';
 import type { IsoCountry } from 'helpers/internationalisation/country';
+import { isInStripePaymentRequestAllowedCountries } from 'helpers/internationalisation/country';
 import { setupStripe } from 'helpers/stripe';
 import StripePaymentRequestButton from './StripePaymentRequestButton';
-
 
 // ----- Types -----//
 
@@ -32,11 +38,11 @@ type PropTypes = {|
 
 const enabledForRecurring = (): boolean => {
   const hashUrl = (new URL(document.URL)).hash;
-  if (hashUrl === "#recurringStripePaymentRequestButton") {
-    return true
+  if (hashUrl === '#recurringStripePaymentRequestButton') {
+    return true;
   }
   return !!window.guardian.recurringStripePaymentRequestButton;
-}
+};
 
 // ----- Component ----- //
 

--- a/support-frontend/assets/pages/digital-subscription-landing/components/faqsAndHelp.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/faqsAndHelp.jsx
@@ -3,11 +3,15 @@
 // ----- Imports ----- //
 
 import * as React from 'react';
-import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import {
+  AUDCountries,
+  type CountryGroupId,
+  GBPCountries,
+  UnitedStates,
+} from 'helpers/internationalisation/countryGroup';
 import { type Option } from 'helpers/types/option';
 import { type SubscriptionProduct } from 'helpers/subscriptions';
 import { type PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
-import { AUDCountries, GBPCountries, UnitedStates } from 'helpers/internationalisation/countryGroup';
 
 // ----- Props ----- //
 
@@ -15,7 +19,6 @@ type PropTypes = {|
   selectedCountryGroup: CountryGroupId,
   subscriptionProduct: SubscriptionProduct,
   paperFulfilmentOptions: Option<PaperFulfilmentOptions>,
-  promoCode?: Option<string>,
 |};
 
 // ----- Functions ----- //
@@ -110,7 +113,6 @@ FaqsAndHelp.defaultProps = {
   selectedCountryGroup: 'GBPCountries',
   subscriptionProduct: 'DigitalPack',
   paperFulfilmentOptions: null,
-  promoCode: null,
 };
 
 // ----- Exports ----- //

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.jsx
@@ -24,8 +24,8 @@ const PaymentSelection = ({ paymentOptions }: PropTypes) => (
   <div className="payment-selection">
     {
         (paymentOptions.map(paymentOption => (
-          <div className={'payment-selection__card payment-selection__card'}>
-            <span className={'product-option__label product-option__label'}>
+          <div className="payment-selection__card payment-selection__card">
+            <span className="product-option__label product-option__label">
               {paymentOption.label}
             </span>
             <ProductOption>

--- a/support-frontend/assets/pages/digital-subscription-landing/components/termsAndConditions.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/termsAndConditions.jsx
@@ -3,14 +3,22 @@ import React from 'react';
 // styles
 import './digitalSubscriptionLanding.scss';
 import { promotionTermsUrl } from 'helpers/routes';
+import { getQueryParameter } from 'helpers/url';
+import { promoQueryParam } from 'helpers/productPrice/promotions';
+import { dpSale } from 'helpers/flashSale';
 
-const TermsAndConditions = () => (
-  <div className="hope-is-power__terms">
-    <div className="hope-is-power--centered">
-      <h3>Promotion terms and conditions</h3>
-      <p>Offer subject to availability. Guardian News and Media Ltd (&quot;GNM&quot;) reserves the right to withdraw this promotion at any time. Full promotion <a href={promotionTermsUrl('DK0NT24WG')}>terms and conditions</a>.</p>
-    </div>
-  </div>
-);
+const TermsAndConditions = () => {
+  const promoUrl = promotionTermsUrl(getQueryParameter(promoQueryParam) || dpSale.promoCode);
+  return (
+    <div className="hope-is-power__terms">
+      <div className="hope-is-power--centered">
+        <h3>Promotion terms and conditions</h3>
+        <p>Offer subject to availability. Guardian News and Media Ltd
+          (&quot;GNM&quot;) reserves the right to withdraw this promotion at any
+          time. Full promotion <a href={promoUrl}>terms and conditions</a>.
+        </p>
+      </div>
+    </div>);
+};
 
 export default TermsAndConditions;

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -33,8 +33,6 @@ import './digitalSubscriptionLanding.scss';
 import ConsentBanner from 'components/consentBanner/consentBanner';
 import digitalSubscriptionLandingReducer
   from './digitalSubscriptionLandingReducer';
-import { dpSale, flashSaleIsActive } from 'helpers/flashSale';
-import { DigitalPack } from 'helpers/subscriptions';
 import CallToAction from './components/cta';
 import TermsAndConditions from './components/termsAndConditions';
 import FaqsAndHelp from './components/faqsAndHelp';
@@ -78,9 +76,6 @@ const CountrySwitcherHeader = headerWithCountrySwitcherContainer({
 // ----- Render ----- //
 function LandingPage() {
 
-  // We can't cope with multiple promo codes in the current design
-  const promoCode = flashSaleIsActive(DigitalPack, countryGroupId) ? dpSale.promoCode : null;
-
   return (
     <Page
       header={<CountrySwitcherHeader />}
@@ -88,7 +83,6 @@ function LandingPage() {
         <FooterCentered>
           <FaqsAndHelp
             selectedCountryGroup={countryGroupId}
-            promoCode={promoCode}
           />
           <SubscriptionFaq subscriptionProduct="DigitalPack" />
         </FooterCentered>}


### PR DESCRIPTION
## Why are you doing this?

Previously the promotion terms and copy text on the DP product page was not showing the correct link if a promo code was present in the url, it was hardcoded to always show the September 2019 promotion. This PR fixes that.

As usual ESLint has made a load of changes so I've highlighted the actual important one

[**Trello Card**](https://trello.com/c/pP1sLPmS/2714-promo-code-tool-support-on-digital-subs-landing-page)


