### PR TITLE
A/B test the recurring Payment Request button

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -55,7 +55,7 @@ export const tests: Tests = {
         size: 1,
       },
     },
-    isActive: !!window.guardian.recurringStripePaymentRequestButton,
+    isActive: window.guardian && !!window.guardian.recurringStripePaymentRequestButton,
     independent: true,
     seed: 2,
     targetPage: contributionsLandingPageMatch,

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -10,6 +10,7 @@ import {
 export type LandingPageCopyReturningSinglesTestVariants = 'control' | 'returningSingle' | 'notintest';
 export type LandingPageStripeElementsRecurringTestVariants = 'control' | 'stripeElements' | 'notintest';
 export type PaymentSecurityDesignTestVariants = 'control' | 'V1_securetop' | 'V2_securemiddle' | 'V3_securebottom' | 'V4_grey' | 'notintest'
+export type RecurringStripePaymentRequestButtonTestVariants = 'contro' | 'paymentRequestButton' | 'notintest';
 
 const contributionsLandingPageMatch = '/(uk|us|eu|au|ca|nz|int)/contribute(/.*)?$';
 
@@ -36,6 +37,28 @@ export const tests: Tests = {
     independent: true,
     seed: 1,
     canRun: () => !!getCookie('gu.contributions.contrib-timestamp'),
+  },
+
+  recurringStripePaymentRequestButton: {
+    type: 'OTHER',
+    variants: [
+      {
+        id: 'control',
+      },
+      {
+        id: 'paymentRequestButton',
+      },
+    ],
+    audiences: {
+      ALL: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: !!window.guardian.recurringStripePaymentRequestButton,
+    independent: true,
+    seed: 2,
+    targetPage: contributionsLandingPageMatch,
   },
 
   stripeElementsRecurring: {

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
@@ -54,7 +54,7 @@ import { getCampaignName } from 'helpers/campaigns';
 import type { LandingPageStripeElementsRecurringTestVariants } from 'helpers/abTests/abtestDefinitions';
 
 import SecureTransactionIndicator from 'components/secureTransactionIndicator/secureTransactionIndicator';
-import type { PaymentSecurityDesignTestVariants } from 'helpers/abTests/abtestDefinitions';
+import type { PaymentSecurityDesignTestVariants, RecurringStripePaymentRequestButtonTestVariants } from 'helpers/abTests/abtestDefinitions';
 
 // ----- Types ----- //
 /* eslint-disable react/no-unused-prop-types */
@@ -87,6 +87,7 @@ type PropTypes = {|
   createStripePaymentMethod: () => void,
   stripeElementsRecurringTestVariant: LandingPageStripeElementsRecurringTestVariants,
   paymentSecurityDesignTestVariant: PaymentSecurityDesignTestVariants,
+  recurringStripePaymentRequestButtonTestVariant: RecurringStripePaymentRequestButtonTestVariants,
 |};
 
 // We only want to use the user state value if the form state value has not been changed since it was initialised,
@@ -119,6 +120,7 @@ const mapStateToProps = (state: State) => ({
   stripeV3HasLoaded: state.page.form.stripeV3HasLoaded,
   stripeElementsRecurringTestVariant: state.common.abParticipations.stripeElementsRecurring,
   paymentSecurityDesignTestVariant: state.common.abParticipations.paymentSecurityDesignTest,
+  recurringStripePaymentRequestButtonTestVariant: state.common.abParticipations.recurringStripePaymentRequestButton,
 });
 
 
@@ -269,6 +271,7 @@ function withProps(props: PropTypes) {
         country={props.country}
         otherAmounts={props.otherAmounts}
         selectedAmounts={props.selectedAmounts}
+        recurringTestVariant={props.recurringStripePaymentRequestButtonTestVariant}
       />
       <div className={classNameWithModifiers('form', ['content'])}>
         <ContributionFormFields />

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
@@ -21,6 +21,7 @@ import type { IsoCountry } from 'helpers/internationalisation/country';
 import { isInStripePaymentRequestAllowedCountries } from 'helpers/internationalisation/country';
 import { setupStripe } from 'helpers/stripe';
 import StripePaymentRequestButton from './StripePaymentRequestButton';
+import type { RecurringStripePaymentRequestButtonTestVariants } from 'helpers/abTests/abtestDefinitions';
 
 // ----- Types -----//
 
@@ -34,15 +35,11 @@ type PropTypes = {|
   stripeHasLoaded: boolean,
   selectedAmounts: SelectedAmounts,
   otherAmounts: OtherAmounts,
+  recurringTestVariant: RecurringStripePaymentRequestButtonTestVariants,
 |};
 
-const enabledForRecurring = (): boolean => {
-  const hashUrl = (new URL(document.URL)).hash;
-  if (hashUrl === '#recurringStripePaymentRequestButton') {
-    return true;
-  }
-  return !!window.guardian.recurringStripePaymentRequestButton;
-};
+const enabledForRecurring = (recurringTestVariant: RecurringStripePaymentRequestButtonTestVariants): boolean =>
+  recurringTestVariant === 'paymentRequestButton';
 
 // ----- Component ----- //
 
@@ -55,7 +52,7 @@ class StripePaymentRequestButtonContainer extends React.Component<PropTypes, voi
   render() {
     const showStripePaymentRequestButton =
       isInStripePaymentRequestAllowedCountries(this.props.country) &&
-      (this.props.contributionType === 'ONE_OFF' || enabledForRecurring());
+      (this.props.contributionType === 'ONE_OFF' || enabledForRecurring(this.props.recurringTestVariant));
 
     if (showStripePaymentRequestButton && this.props.stripeHasLoaded) {
       const stripeAccount = stripeAccountForContributionType[this.props.contributionType];


### PR DESCRIPTION
## Why are you doing this?
We've added the Payment Request button for recurring contributions (it was already available for single).
It is currently switched off.
We want to A/B test it to see if it impacts acquisitions.

Control:
<img width="397" alt="Screenshot 2019-11-12 at 10 58 38" src="https://user-images.githubusercontent.com/1513454/68666218-6ab9eb00-053b-11ea-89bf-9a22d6b07e1a.png">


Variant:
<img width="397" alt="Screenshot 2019-11-12 at 10 58 31" src="https://user-images.githubusercontent.com/1513454/68666222-6db4db80-053b-11ea-9091-3e77b979839a.png">
