### PR TITLE
Payment security design test - remove variants 1 and 3

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -9,8 +9,8 @@ import {
 // ----- Tests ----- //
 export type LandingPageCopyReturningSinglesTestVariants = 'control' | 'returningSingle' | 'notintest';
 export type LandingPageStripeElementsRecurringTestVariants = 'control' | 'stripeElements' | 'notintest';
-export type PaymentSecurityDesignTestVariants = 'control' | 'V1_securetop' | 'V2_securemiddle' | 'V3_securebottom' | 'V4_grey' | 'notintest'
 export type RecurringStripePaymentRequestButtonTestVariants = 'contro' | 'paymentRequestButton' | 'notintest';
+export type PaymentSecurityDesignTestVariants = 'control' | 'V2_securemiddle' | 'V4_grey' | 'notintest';
 
 const contributionsLandingPageMatch = '/(uk|us|eu|au|ca|nz|int)/contribute(/.*)?$';
 
@@ -90,13 +90,7 @@ export const tests: Tests = {
         id: 'control',
       },
       {
-        id: 'V1_securetop',
-      },
-      {
         id: 'V2_securemiddle',
-      },
-      {
-        id: 'V3_securebottom',
       },
       {
         id: 'V4_grey',

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
@@ -52,9 +52,8 @@ import type { PaymentMethod } from 'helpers/paymentMethods';
 import { DirectDebit, Stripe, ExistingCard, ExistingDirectDebit } from 'helpers/paymentMethods';
 import { getCampaignName } from 'helpers/campaigns';
 import type { LandingPageStripeElementsRecurringTestVariants } from 'helpers/abTests/abtestDefinitions';
-
-import SecureTransactionIndicator from 'components/secureTransactionIndicator/secureTransactionIndicator';
 import type { PaymentSecurityDesignTestVariants, RecurringStripePaymentRequestButtonTestVariants } from 'helpers/abTests/abtestDefinitions';
+
 
 // ----- Types ----- //
 /* eslint-disable react/no-unused-prop-types */
@@ -250,8 +249,6 @@ function withProps(props: PropTypes) {
 
   const showSecureStripeContainer: boolean = props.paymentSecurityDesignTestVariant !== 'control' || props.countryGroupId === 'GBPCountries';
   const showSecureButtonBg: boolean = showSecureStripeContainer && props.paymentMethod === Stripe && (props.stripeElementsRecurringTestVariant === 'stripeElements' || props.contributionType === 'ONE_OFF');
-  const showSecureTransactionIndicator: boolean = props.paymentSecurityDesignTestVariant === 'V3_securebottom' && props.countryGroupId !== 'GBPCountries';
-  const secureTransactionIndicatorClassNames: string[] = showSecureButtonBg ? ['bottom-grey'] : ['bottom-regular'];
 
   return (
     <form onSubmit={onSubmit(props)} className={classNameWithModifiers(baseClass, classModifiers)} noValidate>
@@ -294,9 +291,6 @@ function withProps(props: PropTypes) {
           onPaymentAuthorisation={props.onPaymentAuthorisation}
           showSecureBackground={showSecureButtonBg}
         />
-        {showSecureTransactionIndicator &&
-          <SecureTransactionIndicator modifierClasses={secureTransactionIndicatorClassNames} />
-        }
       </div>
 
       <TermsPrivacy

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
@@ -93,8 +93,7 @@ const cssModifiers = campaignName && campaigns[campaignName] && campaigns[campai
 const backgroundImageSrc = campaignName && campaigns[campaignName] && campaigns[campaignName].backgroundImage ?
   campaigns[campaignName].backgroundImage : null;
 
-const showSecureTransactionIndicator = store.getState().common.abParticipations.paymentSecurityDesignTest === 'V1_securetop'
-|| countryGroupId === 'GBPCountries' ? <SecureTransactionIndicator modifierClasses={['top']} /> : null;
+const showSecureTransactionIndicator = countryGroupId === 'GBPCountries' ? <SecureTransactionIndicator modifierClasses={['top']} /> : null;
 
 function contributionsLandingPage(campaignCodeParameter: ?string) {
   return (


### PR DESCRIPTION
## Why are you doing this?
Variants 1 and 3 are peforming the least well, so we are removing them from the test to allow the other variants to reach significance sooner.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/848uxSgV)

## Changes

* Remove V1_securetop
* Remove V3_securebottom



