### PR TITLE
Product price card promo text

### DIFF
--- a/support-frontend/assets/helpers/productPrice/priceDescriptions.js
+++ b/support-frontend/assets/helpers/productPrice/priceDescriptions.js
@@ -5,7 +5,6 @@ import type { BillingPeriod } from 'helpers/billingPeriods';
 import {
   billingPeriodNoun as upperCaseNoun,
   Quarterly,
-  SixWeekly,
 } from 'helpers/billingPeriods';
 import type { ProductPrice } from 'helpers/productPrice/productPrices';
 import { extendedGlyph } from 'helpers/internationalisation/currency';
@@ -118,14 +117,10 @@ function getPriceDescription(
 
 function getAppliedPromoDescription(billingPeriod: BillingPeriod, productPrice: ProductPrice) {
   const appliedPromo = getAppliedPromo(productPrice.promotions);
-  if (
-    appliedPromo === null ||
-    billingPeriod === SixWeekly
-  ) {
-    return '';
+  if (appliedPromo && appliedPromo.landingPage && appliedPromo.landingPage.roundel) {
+    return appliedPromo.landingPage.roundel;
   }
-
-  return appliedPromo.landingPage && appliedPromo.landingPage.roundel ? appliedPromo.landingPage.roundel : '';
+  return '';
 }
 
 export {

--- a/support-frontend/assets/helpers/productPrice/priceDescriptions.js
+++ b/support-frontend/assets/helpers/productPrice/priceDescriptions.js
@@ -125,7 +125,7 @@ function getAppliedPromoDescription(billingPeriod: BillingPeriod, productPrice: 
     return '';
   }
 
-  return appliedPromo.description;
+  return appliedPromo.landingPage && appliedPromo.landingPage.roundel ? appliedPromo.landingPage.roundel : '';
 }
 
 export {

--- a/support-frontend/assets/helpers/productPrice/promotions.js
+++ b/support-frontend/assets/helpers/productPrice/promotions.js
@@ -47,6 +47,7 @@ export type Promotion =
     numberOfDiscountedPeriods?: number,
     discount?: DiscountBenefit,
     introductoryPrice?: IntroductoryPriceBenefit,
+    landingPage?: PromotionCopy,
   }
 
 const promoQueryParam = 'promoCode';

--- a/support-services/src/main/scala/com/gu/support/pricing/PriceSummary.scala
+++ b/support-services/src/main/scala/com/gu/support/pricing/PriceSummary.scala
@@ -20,6 +20,7 @@ case class PromotionSummary(
   freeTrialBenefit: Option[FreeTrialBenefit],
   incentive: Option[IncentiveBenefit] = None,
   introductoryPrice: Option[IntroductoryPriceBenefit] = None,
+  landingPage: Option[PromotionCopy] = None
 )
 
 import com.gu.support.encoding.Codec

--- a/support-services/src/main/scala/com/gu/support/pricing/PriceSummaryService.scala
+++ b/support-services/src/main/scala/com/gu/support/pricing/PriceSummaryService.scala
@@ -79,7 +79,8 @@ class PriceSummaryService(promotionService: PromotionService, catalogService: Ca
       discount = promotion.discount,
       freeTrialBenefit = promotion.freeTrial,
       incentive = promotion.incentive,
-      introductoryPrice = promotion.introductoryPrice
+      introductoryPrice = promotion.introductoryPrice,
+      landingPage = promotion.landingPage
     )
   }
 


### PR DESCRIPTION
## Why are you doing this?

Currently promotional text for the product page price cards and promotional text on the checkout summary come from the same promotion field (description). We want to be able to provide different text for these two pages so this PR switches to using the `roundel` promotion field for the product page cards.

[**Trello Card**](https://trello.com/c/Wd4tLxUM/2729-use-separate-promotion-fields-for-the-checkout-summary-and-the-product-page-price-cards)
