### PR TITLE
Send Stripe payment type to backend for recurring/subscriptions

### DIFF
--- a/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
+++ b/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
@@ -56,8 +56,14 @@ type ProductFields = RegularContribution | DigitalSubscription | PaperSubscripti
 
 type RegularPayPalPaymentFields = {| baid: string |};
 
-type RegularStripePaymentIntentFields = {| paymentMethod: string |};
-type RegularStripeCheckoutPaymentFields = {| stripeToken: string |};
+type RegularStripePaymentIntentFields = {|
+  paymentMethod: string,                  // The ID of the Stripe Payment Method
+  stripePaymentType: StripePaymentMethod, // The type of Stripe payment, e.g. Apple Pay
+|};
+type RegularStripeCheckoutPaymentFields = {|
+  stripeToken: string,
+  stripePaymentType: StripePaymentMethod,
+|};
 
 type RegularDirectDebitPaymentFields = {|
   accountHolderName: string,
@@ -83,6 +89,7 @@ export type RegularPaymentRequestAddress = {|
   city: Option<string>,
 |};
 
+// The model that is sent to support-workers
 export type RegularPaymentRequest = {|
   title?: Option<Title>,
   firstName: string,
@@ -174,9 +181,15 @@ function regularPaymentFieldsFromAuthorisation(authorisation: PaymentAuthorisati
   switch (authorisation.paymentMethod) {
     case Stripe:
       if (authorisation.paymentMethodId) {
-        return { paymentMethod: authorisation.paymentMethodId };
+        return {
+          paymentMethod: authorisation.paymentMethodId,
+          stripePaymentType: authorisation.stripePaymentMethod
+        };
       } else if (authorisation.token) {
-        return { stripeToken: authorisation.token };
+        return {
+          stripeToken: authorisation.token,
+          stripePaymentType: authorisation.stripePaymentMethod
+        };
       }
       throw new Error('Neither token nor paymentMethod found in authorisation data for Stripe recurring contribution');
     case PayPal:

--- a/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
+++ b/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
@@ -34,6 +34,9 @@ import type { Title } from 'helpers/user/details';
 
 // ----- Types ----- //
 
+export type StripePaymentMethod = 'StripeCheckout' | 'StripeApplePay' | 'StripePaymentRequestButton' | 'StripeElements';
+export type StripePaymentRequestButtonMethod = 'none' | StripePaymentMethod;
+
 type RegularContribution = {|
   amount: number,
   currency: string,
@@ -112,9 +115,6 @@ export type RegularPaymentRequest = {|
   deliveryInstructions?: Option<string>,
   debugInfo?: string,
 |};
-
-export type StripePaymentMethod = 'StripeCheckout' | 'StripeApplePay' | 'StripePaymentRequestButton' | 'StripeElements';
-export type StripePaymentRequestButtonMethod = 'none' | StripePaymentMethod;
 
 // Stripe checkout is currently still used by Payment Request button and recurring
 export type StripeCheckoutAuthorisation = {|


### PR DESCRIPTION
## Why are you doing this?
There are several types of Stripe payments in the [ophan model](https://github.com/guardian/ophan/blob/master/event-model/src/main/thrift/acquisition.thrift#L35).
But only one is currently supported by support-workers for recurring/subscriptions.
We need it to also support `STRIPE_APPLE_PAY` and `STRIPE_PAYMENT_REQUEST_BUTTON` for our analytics.

This change makes the client send a new field, `stripePaymentType`, to support-workers for Stripe payments.
In a separate PR I will change support-workers to receive this field and to set the paymentProvider field appropriately in the acquisition event.

This is the payload being sent to the backend, now with the new field:
<img width="668" alt="Screenshot 2019-11-14 at 12 59 58" src="https://user-images.githubusercontent.com/1513454/68859233-bc4eab00-06de-11ea-9c4a-2d63e308bcd5.png">
