### PR TITLE
Send Stripe payment type to ophan for recurring contributions

### DIFF
--- a/support-frontend/test/utils/CheckoutValidationRulesTest.scala
+++ b/support-frontend/test/utils/CheckoutValidationRulesTest.scala
@@ -101,7 +101,7 @@ class DigitalPackValidationTest extends AnyFlatSpec with Matchers {
   }
 
   it should "fail if the source payment field received is an empty string" in {
-    val requestMissingState = validDigitalPackRequest.copy(paymentFields = StripeSourcePaymentFields(""))
+    val requestMissingState = validDigitalPackRequest.copy(paymentFields = StripeSourcePaymentFields("", None))
     DigitalPackValidation.passes(requestMissingState) shouldBe false
   }
 
@@ -183,7 +183,7 @@ object TestData {
     lastName = "hopper",
     product = DigitalPack(Currency.USD, Monthly),
     firstDeliveryDate = None,
-    paymentFields = StripePaymentMethodPaymentFields(PaymentMethodId("test_token").get),
+    paymentFields = StripePaymentMethodPaymentFields(PaymentMethodId("test_token").get, Some(StripePaymentType.StripeCheckout)),
     ophanIds = OphanIds(None, None, None),
     referrerAcquisitionData = ReferrerAcquisitionData(None, None, None, None, None, None, None, None, None, None, None, None),
     supportAbTests = Set(),
@@ -221,7 +221,7 @@ object TestData {
     lastName = "hopper",
     product = Paper(Currency.GBP, Monthly, HomeDelivery, Everyday),
     firstDeliveryDate = Some(someDateNextMonth),
-    paymentFields = StripePaymentMethodPaymentFields(PaymentMethodId("test_token").get),
+    paymentFields = StripePaymentMethodPaymentFields(PaymentMethodId("test_token").get, Some(StripePaymentType.StripeCheckout)),
     ophanIds = OphanIds(None, None, None),
     referrerAcquisitionData = ReferrerAcquisitionData(None, None, None, None, None, None, None, None, None, None, None, None),
     supportAbTests = Set(),

--- a/support-models/src/main/scala/com/gu/support/workers/PaymentFields.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/PaymentFields.scala
@@ -54,7 +54,6 @@ case class ExistingPaymentFields(billingAccountId: String) extends PaymentFields
 
 object PaymentFields {
   //Payment fields are input from support-frontend
-  import StripePaymentType.stripePaymentTypeCodec
   implicit val payPalPaymentFieldsCodec: Codec[PayPalPaymentFields] = deriveCodec
   implicit val stripeSourcePaymentFieldsCodec: Codec[StripeSourcePaymentFields] = deriveCodec
   implicit val stripePaymentMethodPaymentFieldsCodec: Codec[StripePaymentMethodPaymentFields] = deriveCodec

--- a/support-models/src/main/scala/com/gu/support/workers/PaymentFields.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/PaymentFields.scala
@@ -13,8 +13,16 @@ case class PayPalPaymentFields(baid: String) extends PaymentFields
 
 
 sealed trait StripePaymentFields extends PaymentFields
-case class StripeSourcePaymentFields(stripeToken: String) extends StripePaymentFields // pre SCA compatibility
-case class StripePaymentMethodPaymentFields(paymentMethod: PaymentMethodId) extends StripePaymentFields
+
+case class StripeSourcePaymentFields(
+  stripeToken: String,
+  stripePaymentType: Option[CreditCardReferenceTransaction.StripePaymentType]
+) extends StripePaymentFields // pre SCA compatibility
+
+case class StripePaymentMethodPaymentFields(
+  paymentMethod: PaymentMethodId,
+  stripePaymentType: Option[CreditCardReferenceTransaction.StripePaymentType]
+) extends StripePaymentFields
 
 object PaymentMethodId {
 

--- a/support-models/src/main/scala/com/gu/support/workers/PaymentFields.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/PaymentFields.scala
@@ -16,12 +16,12 @@ sealed trait StripePaymentFields extends PaymentFields
 
 case class StripeSourcePaymentFields(
   stripeToken: String,
-  stripePaymentType: Option[CreditCardReferenceTransaction.StripePaymentType]
+  stripePaymentType: Option[StripePaymentType]
 ) extends StripePaymentFields // pre SCA compatibility
 
 case class StripePaymentMethodPaymentFields(
   paymentMethod: PaymentMethodId,
-  stripePaymentType: Option[CreditCardReferenceTransaction.StripePaymentType]
+  stripePaymentType: Option[StripePaymentType]
 ) extends StripePaymentFields
 
 object PaymentMethodId {
@@ -54,6 +54,7 @@ case class ExistingPaymentFields(billingAccountId: String) extends PaymentFields
 
 object PaymentFields {
   //Payment fields are input from support-frontend
+  import StripePaymentType.stripePaymentTypeCodec
   implicit val payPalPaymentFieldsCodec: Codec[PayPalPaymentFields] = deriveCodec
   implicit val stripeSourcePaymentFieldsCodec: Codec[StripeSourcePaymentFields] = deriveCodec
   implicit val stripePaymentMethodPaymentFieldsCodec: Codec[StripePaymentMethodPaymentFields] = deriveCodec

--- a/support-models/src/main/scala/com/gu/support/workers/PaymentMethods.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/PaymentMethods.scala
@@ -13,6 +13,13 @@ sealed trait PaymentMethod {
   def paymentGateway: PaymentGateway
 }
 
+object CreditCardReferenceTransaction {
+  sealed trait StripePaymentType
+  case object StripeCheckout extends StripePaymentType
+  case object StripeApplePay extends StripePaymentType
+  case object StripePaymentRequestButton extends StripePaymentType
+}
+
 case class CreditCardReferenceTransaction(
   tokenId: String, //Stripe Card id
   secondTokenId: String, //Stripe Customer Id
@@ -22,7 +29,8 @@ case class CreditCardReferenceTransaction(
   creditCardExpirationYear: Int,
   creditCardType: String /*TODO: strip spaces?*/ ,
   paymentGateway: PaymentGateway,
-  `type`: String = "CreditCardReferenceTransaction"
+  `type`: String = "CreditCardReferenceTransaction",
+  stripePaymentType: Option[CreditCardReferenceTransaction.StripePaymentType]
 ) extends PaymentMethod
 
 case class PayPalReferenceTransaction(

--- a/support-models/src/main/scala/com/gu/support/workers/PaymentMethods.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/PaymentMethods.scala
@@ -3,7 +3,7 @@ package com.gu.support.workers
 import cats.syntax.functor._
 import com.gu.i18n.Country
 import com.gu.support.encoding.Codec
-import com.gu.support.encoding.Codec.{capitalizingCodec, deriveCodec}
+import com.gu.support.encoding.Codec.capitalizingCodec
 import com.gu.support.zuora.api.{DirectDebitGateway, PayPalGateway, PaymentGateway}
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder}
@@ -20,7 +20,16 @@ object StripePaymentType {
   case object StripeApplePay extends StripePaymentType
   case object StripePaymentRequestButton extends StripePaymentType
 
-  implicit val stripePaymentTypeCodec: Codec[StripePaymentType] = deriveCodec
+  implicit val stripePaymentTypeDecoder: Decoder[StripePaymentType] = Decoder.decodeString.map(code => fromString(code))
+  implicit val stripePaymentTypeEncoder: Encoder[StripePaymentType] = Encoder.encodeString.contramap[StripePaymentType](_.toString)
+
+  private def fromString(s: String) = {
+    s match {
+      case "StripePaymentRequestButton" => StripePaymentRequestButton
+      case "StripeApplePay" => StripeApplePay
+      case _ => StripeCheckout
+    }
+  }
 }
 
 case class CreditCardReferenceTransaction(

--- a/support-models/src/main/scala/com/gu/support/workers/PaymentMethods.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/PaymentMethods.scala
@@ -3,7 +3,7 @@ package com.gu.support.workers
 import cats.syntax.functor._
 import com.gu.i18n.Country
 import com.gu.support.encoding.Codec
-import com.gu.support.encoding.Codec.capitalizingCodec
+import com.gu.support.encoding.Codec.{capitalizingCodec, deriveCodec}
 import com.gu.support.zuora.api.{DirectDebitGateway, PayPalGateway, PaymentGateway}
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder}
@@ -13,11 +13,14 @@ sealed trait PaymentMethod {
   def paymentGateway: PaymentGateway
 }
 
-object CreditCardReferenceTransaction {
-  sealed trait StripePaymentType
+sealed trait StripePaymentType
+
+object StripePaymentType {
   case object StripeCheckout extends StripePaymentType
   case object StripeApplePay extends StripePaymentType
   case object StripePaymentRequestButton extends StripePaymentType
+
+  implicit val stripePaymentTypeCodec: Codec[StripePaymentType] = deriveCodec
 }
 
 case class CreditCardReferenceTransaction(
@@ -30,7 +33,7 @@ case class CreditCardReferenceTransaction(
   creditCardType: String /*TODO: strip spaces?*/ ,
   paymentGateway: PaymentGateway,
   `type`: String = "CreditCardReferenceTransaction",
-  stripePaymentType: Option[CreditCardReferenceTransaction.StripePaymentType]
+  stripePaymentType: Option[StripePaymentType]
 ) extends PaymentMethod
 
 case class PayPalReferenceTransaction(

--- a/support-models/src/test/scala/com/gu/support/zuora/api/Fixtures.scala
+++ b/support-models/src/test/scala/com/gu/support/zuora/api/Fixtures.scala
@@ -2,7 +2,7 @@ package com.gu.support.zuora.api
 
 import com.gu.i18n.Currency.GBP
 import com.gu.i18n.{Country, Currency}
-import com.gu.support.workers.{CreditCardReferenceTransaction, DirectDebitPaymentMethod, PayPalReferenceTransaction}
+import com.gu.support.workers.{CreditCardReferenceTransaction, DirectDebitPaymentMethod, PayPalReferenceTransaction, StripePaymentType}
 import org.joda.time.LocalDate
 
 //noinspection TypeAnnotation
@@ -126,7 +126,8 @@ object Fixtures {
     Some(Country.UK),
     12, 22,
     "AmericanExpress",
-    StripeGatewayDefault)
+    StripeGatewayDefault,
+    stripePaymentType = Some(StripePaymentType.StripeCheckout))
   val payPalPaymentMethod = PayPalReferenceTransaction(payPalBaid, "test@paypal.com")
   val directDebitPaymentMethod = DirectDebitPaymentMethod(
     firstName = "Barry",

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -66,7 +66,7 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
   ): Future[CreditCardReferenceTransaction] = {
     val stripeServiceForCurrency = stripeService.withCurrency(currency)
     (stripe match {
-      case StripeSourcePaymentFields(source) =>
+      case StripeSourcePaymentFields(source, stripePaymentType) =>
         stripeServiceForCurrency.createCustomerFromToken(source).map { customer =>
           val card = customer.source
           CreditCardReferenceTransaction(
@@ -77,10 +77,11 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
             card.exp_month,
             card.exp_year,
             card.brand.zuoraCreditCardType.getOrElse(""),
-            paymentGateway = chargeGateway(currency)
+            paymentGateway = chargeGateway(currency),
+            stripePaymentType = stripePaymentType
           )
         }
-      case StripePaymentMethodPaymentFields(paymentMethod) =>
+      case StripePaymentMethodPaymentFields(paymentMethod, stripePaymentType) =>
         for {
           stripeCustomer <- stripeServiceForCurrency.createCustomerFromPaymentMethod(paymentMethod)
           stripePaymentMethod <- stripeServiceForCurrency.getPaymentMethod(paymentMethod)
@@ -94,7 +95,8 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
             card.exp_month,
             card.exp_year,
             card.brand.zuoraCreditCardType.getOrElse(""),
-            paymentGateway = paymentIntentGateway(currency)
+            paymentGateway = paymentIntentGateway(currency),
+            stripePaymentType = stripePaymentType
           )
         }
     })

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/PreparePaymentMethodForReuse.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/PreparePaymentMethodForReuse.scala
@@ -72,7 +72,8 @@ class PreparePaymentMethodForReuse(servicesProvider: ServiceProvider = ServicePr
           creditCardExpirationMonth = cardResponse.creditCardExpirationMonth,
           creditCardExpirationYear = cardResponse.creditCardExpirationYear,
           creditCardType = cardResponse.creditCardType,
-          paymentGateway = paymentGateway
+          paymentGateway = paymentGateway,
+          stripePaymentType = None
         )
       )
     case directDebitResponse: GetPaymentMethodDirectDebitResponse =>

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
@@ -67,8 +67,12 @@ object SendAcquisitionEvent {
 
   def paymentProviderFromPaymentMethod(paymentMethod: PaymentMethod): thrift.PaymentProvider =
     paymentMethod match {
-      case _: CreditCardReferenceTransaction => thrift.PaymentProvider.Stripe
-      //TODO - check for PRB/Apple
+      case creditCardPayment: CreditCardReferenceTransaction =>
+        creditCardPayment.stripePaymentType match {
+          case Some(StripePaymentType.StripeApplePay) => thrift.PaymentProvider.StripeApplePay
+          case Some(StripePaymentType.StripePaymentRequestButton) => thrift.PaymentProvider.StripePaymentRequestButton
+          case _ => thrift.PaymentProvider.Stripe
+        }
       case _: PayPalReferenceTransaction => thrift.PaymentProvider.Paypal
       case _: DirectDebitPaymentMethod | _: ClonedDirectDebitPaymentMethod => thrift.PaymentProvider.Gocardless
     }

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
@@ -68,6 +68,7 @@ object SendAcquisitionEvent {
   def paymentProviderFromPaymentMethod(paymentMethod: PaymentMethod): thrift.PaymentProvider =
     paymentMethod match {
       case _: CreditCardReferenceTransaction => thrift.PaymentProvider.Stripe
+      //TODO - check for PRB/Apple
       case _: PayPalReferenceTransaction => thrift.PaymentProvider.Paypal
       case _: DirectDebitPaymentMethod | _: ClonedDirectDebitPaymentMethod => thrift.PaymentProvider.Gocardless
     }

--- a/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
@@ -177,14 +177,16 @@ object JsonFixtures {
   val stripeJson =
     s"""
       {
-        "stripeToken": "$stripeToken"
+        "stripeToken": "$stripeToken",
+        "stripePaymentType": "StripeCheckout"
       }
     """
 
   val stripePaymentMethodJson =
     s"""
       {
-        "paymentMethod": "${stripePaymentMethodToken.value}"
+        "paymentMethod": "${stripePaymentMethodToken.value}",
+        "stripePaymentType": "StripeCheckout"
       }
     """
 

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/PreparePaymentMethodForReuseSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/PreparePaymentMethodForReuseSpec.scala
@@ -45,7 +45,8 @@ class PreparePaymentMethodForReuseSpec extends AsyncLambdaSpec with MockServices
         creditCardExpirationMonth = 2,
         creditCardExpirationYear = 2022,
         creditCardType = "Visa",
-        paymentGateway = StripeGatewayDefault
+        paymentGateway = StripeGatewayDefault,
+        stripePaymentType = None
       )
     }
 

--- a/support-workers/src/test/scala/com/gu/support/workers/lambdas/CreatePaymentMethodStateDecoderSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/lambdas/CreatePaymentMethodStateDecoderSpec.scala
@@ -67,7 +67,7 @@ class CreatePaymentMethodStateDecoderSpec extends AnyFlatSpec
       (state.product, state.paymentFields))
     fieldsToTest should be(Right(
       Contribution(5, GBP, Monthly),
-      StripeSourcePaymentFields(stripeToken)
+      StripeSourcePaymentFields(stripeToken, Some(StripePaymentType.StripeCheckout))
     ))
   }
 
@@ -77,7 +77,7 @@ class CreatePaymentMethodStateDecoderSpec extends AnyFlatSpec
       (state.product, state.paymentFields))
     fieldsToTest should be(Right(
       Contribution(5, GBP, Monthly),
-      StripePaymentMethodPaymentFields(stripePaymentMethodToken)
+      StripePaymentMethodPaymentFields(stripePaymentMethodToken, Some(StripePaymentType.StripeCheckout))
     ))
   }
 

--- a/support-workers/src/test/scala/com/gu/zuora/Fixtures.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/Fixtures.scala
@@ -58,7 +58,8 @@ object Fixtures {
     Some(Country.UK),
     12, 22,
     "AmericanExpress",
-    _: PaymentGateway
+    _: PaymentGateway,
+    stripePaymentType = Some(StripePaymentType.StripeCheckout)
   )
   val payPalPaymentMethod = PayPalReferenceTransaction(payPalBaid, "test@paypal.com")
   val directDebitPaymentMethod = DirectDebitPaymentMethod("Barry", "Humphreys", "Barry Humphreys", "200000", "55779911",


### PR DESCRIPTION
## Why are you doing this?
There are several types of Stripe payments in the ophan model.
But only one is currently supported by support-workers for recurring/subscriptions.
We need it to also support `STRIPE_APPLE_PAY` and `STRIPE_PAYMENT_REQUEST_BUTTON` for our analytics.

1. receive the new `stripePaymentType` field from the client
2. add it to the `PaymentFields` object
3. send the new types to ophan in the acquisition event

The client already sends a `stripePaymentType` field - https://github.com/guardian/support-frontend/pull/2217
