### PR TITLE
Remove test to recognize people who gave single contributions in the past

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -1,13 +1,11 @@
 // @flow
 import type { Tests } from './abtest';
-import { get as getCookie } from 'helpers/cookie';
 import {
   type CountryGroupId,
   detect,
 } from 'helpers/internationalisation/countryGroup';
 
 // ----- Tests ----- //
-export type LandingPageCopyReturningSinglesTestVariants = 'control' | 'returningSingle' | 'notintest';
 export type LandingPageStripeElementsRecurringTestVariants = 'control' | 'stripeElements' | 'notintest';
 export type RecurringStripePaymentRequestButtonTestVariants = 'control' | 'paymentRequestButton' | 'notintest';
 export type PaymentSecurityDesignTestVariants = 'control' | 'V2_securemiddle' | 'V4_grey' | 'notintest';
@@ -17,28 +15,6 @@ const contributionsLandingPageMatch = '/(uk|us|eu|au|ca|nz|int)/contribute(/.*)?
 const countryGroupId: CountryGroupId = detect();
 
 export const tests: Tests = {
-  landingPageCopyReturningSingles: {
-    type: 'OTHER',
-    variants: [
-      {
-        id: 'control',
-      },
-      {
-        id: 'returningSingle',
-      },
-    ],
-    audiences: {
-      ALL: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: true,
-    independent: true,
-    seed: 1,
-    canRun: () => !!getCookie('gu.contributions.contrib-timestamp'),
-  },
-
   recurringStripePaymentRequestButton: {
     type: 'OTHER',
     variants: [

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.jsx
@@ -13,7 +13,6 @@ import { campaigns, getCampaignName } from 'helpers/campaigns';
 import { type State } from '../contributionsLandingReducer';
 import { ContributionForm, EmptyContributionForm } from './ContributionForm';
 import { onThirdPartyPaymentAuthorised, paymentWaiting, setTickerGoalReached } from '../contributionsLandingActions';
-import type { LandingPageCopyReturningSinglesTestVariants } from 'helpers/abTests/abtestDefinitions';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 
 // ----- Types ----- //
@@ -28,7 +27,6 @@ type PropTypes = {|
   tickerGoalReached: boolean,
   campaignCodeParameter: ?string,
   isReturningContributor: boolean,
-  landingPageCopyReturningSinglesTestVariant: LandingPageCopyReturningSinglesTestVariants,
   countryId: IsoCountry,
 |};
 
@@ -39,7 +37,6 @@ const mapStateToProps = (state: State) => ({
   countryGroupId: state.common.internationalisation.countryGroupId,
   tickerGoalReached: state.page.form.tickerGoalReached,
   isReturningContributor: state.page.user.isReturningContributor,
-  landingPageCopyReturningSinglesTestVariant: state.common.abParticipations.landingPageCopyReturningSingles,
   countryId: state.common.internationalisation.countryId,
 });
 


### PR DESCRIPTION
## Why are you doing this?
This test, which has been running since August, conflicts with the moment landing page copy changes.

Because of a bunch of fake contributions that made their way into our actual contributions table on 11 September 2019, the test needs to be manually analyzed excluding this date. The big picture when doing this analysis is a global AV uplift of +5% from a very small number of contributors.