### PR TITLE
Small landing page copy change

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.jsx
@@ -70,7 +70,7 @@ const defaultContributeCopy = (
 const usEoyHeaderCopy = 'Support our journalism with a year-end gift';
 const usEoyAppealContributeCopy = (
   <span>
-    The Guardian’s open, independent reporting has been supported by hundreds of thousands of US readers like you – we
+    The Guardian’s open, independent reporting has been supported by hundreds of thousands of readers in the US like you – we
     have supporters in each of the fifty states. Thanks to your valuable contributions, tens of millions across America
     read our quality, factual journalism at this critical time.
   </span>);

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.jsx
@@ -70,9 +70,9 @@ const defaultContributeCopy = (
 const usEoyHeaderCopy = 'Support our journalism with a year-end gift';
 const usEoyAppealContributeCopy = (
   <span>
-    The Guardian’s open, independent reporting has been supported by hundreds of thousands of readers in the US like you – we
-    have supporters in each of the fifty states. Thanks to your valuable contributions, tens of millions across America
-    read our quality, factual journalism at this critical time.
+    The Guardian’s open, independent reporting has been supported by hundreds of thousands of readers in the
+    US like you – we have supporters in each of the fifty states. Thanks to your valuable contributions, tens
+    of millions across America read our quality, factual journalism at this critical time.
   </span>);
 
 const defaultHeaderCopyAndContributeCopy: CountryMetaData = {


### PR DESCRIPTION
## Why are you doing this?
I talked with Amanda about changing the language we were using to address readers in the US from "US readers" to "readers in the US" (would have made the suggestion to @ionamckendrick but she's not in)

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

