### PR TITLE
Payment security test 1B secure transaction indicator with grey background (non-UK)

### DIFF
--- a/support-frontend/assets/components/secureTransactionIndicator/secureTransactionIndicator.scss
+++ b/support-frontend/assets/components/secureTransactionIndicator/secureTransactionIndicator.scss
@@ -40,6 +40,22 @@
   padding-bottom: 15px;
 }
 
+.component-secure-transaction--hideaftermobile {
+  @include mq($from: phablet) {
+    position: absolute;
+    visibility: hidden;
+    display: none;
+  }
+}
+
+.component-secure-transaction--showaftermobile {
+  @include mq($until: phablet) {
+    position: absolute;
+    visibility: hidden;
+    display: none;
+  }
+}
+
 .component-secure-transaction {
   display: flex;
   align-items: center;

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -8,7 +8,7 @@ import {
 // ----- Tests ----- //
 export type LandingPageStripeElementsRecurringTestVariants = 'control' | 'stripeElements' | 'notintest';
 export type RecurringStripePaymentRequestButtonTestVariants = 'control' | 'paymentRequestButton' | 'notintest';
-export type PaymentSecurityDesignTestVariants = 'control' | 'V2_securemiddle' | 'V4_grey' | 'notintest';
+export type PaymentSecurityDesignTest1BVariants = 'control' | 'V1_securemiddlegrey' | 'notintest';
 
 const contributionsLandingPageMatch = '/(uk|us|eu|au|ca|nz|int)/contribute(/.*)?$';
 
@@ -59,17 +59,14 @@ export const tests: Tests = {
     targetPage: contributionsLandingPageMatch,
   },
 
-  paymentSecurityDesignTest: {
+  paymentSecurityDesignTest1B: {
     type: 'OTHER',
     variants: [
       {
         id: 'control',
       },
       {
-        id: 'V2_securemiddle',
-      },
-      {
-        id: 'V4_grey',
+        id: 'V1_securemiddlegrey',
       },
     ],
     audiences: {

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -8,7 +8,7 @@ import {
 // ----- Tests ----- //
 export type LandingPageStripeElementsRecurringTestVariants = 'control' | 'stripeElements' | 'notintest';
 export type RecurringStripePaymentRequestButtonTestVariants = 'control' | 'paymentRequestButton' | 'notintest';
-export type PaymentSecurityDesignTest1BVariants = 'control' | 'V1_securemiddlegrey' | 'notintest';
+export type paymentSecuritySecureTransactionGreyNonUKVariants = 'control' | 'V1_securetransactiongrey' | 'notintest';
 
 const contributionsLandingPageMatch = '/(uk|us|eu|au|ca|nz|int)/contribute(/.*)?$';
 
@@ -59,14 +59,14 @@ export const tests: Tests = {
     targetPage: contributionsLandingPageMatch,
   },
 
-  paymentSecurityDesignTest1B: {
+  paymentSecuritySecureTransactionGreyNonUK: {
     type: 'OTHER',
     variants: [
       {
         id: 'control',
       },
       {
-        id: 'V1_securemiddlegrey',
+        id: 'V1_securetransactiongrey',
       },
     ],
     audiences: {

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
@@ -52,7 +52,7 @@ import type { PaymentMethod } from 'helpers/paymentMethods';
 import { DirectDebit, Stripe, ExistingCard, ExistingDirectDebit } from 'helpers/paymentMethods';
 import { getCampaignName } from 'helpers/campaigns';
 import type { LandingPageStripeElementsRecurringTestVariants } from 'helpers/abTests/abtestDefinitions';
-import type { PaymentSecurityDesignTest1BVariants, RecurringStripePaymentRequestButtonTestVariants } from 'helpers/abTests/abtestDefinitions';
+import type { paymentSecuritySecureTransactionGreyNonUKVariants, RecurringStripePaymentRequestButtonTestVariants } from 'helpers/abTests/abtestDefinitions';
 
 
 // ----- Types ----- //
@@ -85,7 +85,7 @@ type PropTypes = {|
   country: IsoCountry,
   createStripePaymentMethod: () => void,
   stripeElementsRecurringTestVariant: LandingPageStripeElementsRecurringTestVariants,
-  paymentSecurityDesignTest1BVariant: PaymentSecurityDesignTest1BVariants,
+  paymentSecuritySecureTransactionGreyNonUKVariant: paymentSecuritySecureTransactionGreyNonUKVariants,
   recurringStripePaymentRequestButtonTestVariant: RecurringStripePaymentRequestButtonTestVariants,
 |};
 
@@ -118,7 +118,7 @@ const mapStateToProps = (state: State) => ({
   country: state.common.internationalisation.countryId,
   stripeV3HasLoaded: state.page.form.stripeV3HasLoaded,
   stripeElementsRecurringTestVariant: state.common.abParticipations.stripeElementsRecurring,
-  paymentSecurityDesignTest1BVariant: state.common.abParticipations.paymentSecurityDesignTest1B,
+  paymentSecuritySecureTransactionGreyNonUKVariant: state.common.abParticipations.paymentSecuritySecureTransactionGreyNonUK,
   recurringStripePaymentRequestButtonTestVariant: state.common.abParticipations.recurringStripePaymentRequestButton,
 });
 
@@ -247,7 +247,7 @@ function withProps(props: PropTypes) {
 
   const classModifiers = ['contribution', 'with-labels'];
 
-  const showSecureStripeContainer: boolean = props.paymentSecurityDesignTest1BVariant !== 'control' || props.countryGroupId === 'GBPCountries';
+  const showSecureStripeContainer: boolean = props.paymentSecuritySecureTransactionGreyNonUKVariant !== 'control' || props.countryGroupId === 'GBPCountries';
   const showSecureButtonBg: boolean = showSecureStripeContainer && props.paymentMethod === Stripe && (props.stripeElementsRecurringTestVariant === 'stripeElements' || props.contributionType === 'ONE_OFF');
 
   return (

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
@@ -118,7 +118,8 @@ const mapStateToProps = (state: State) => ({
   country: state.common.internationalisation.countryId,
   stripeV3HasLoaded: state.page.form.stripeV3HasLoaded,
   stripeElementsRecurringTestVariant: state.common.abParticipations.stripeElementsRecurring,
-  paymentSecuritySecureTransactionGreyNonUKVariant: state.common.abParticipations.paymentSecuritySecureTransactionGreyNonUK,
+  paymentSecuritySecureTransactionGreyNonUKVariant:
+    state.common.abParticipations.paymentSecuritySecureTransactionGreyNonUK,
   recurringStripePaymentRequestButtonTestVariant: state.common.abParticipations.recurringStripePaymentRequestButton,
 });
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
@@ -52,7 +52,7 @@ import type { PaymentMethod } from 'helpers/paymentMethods';
 import { DirectDebit, Stripe, ExistingCard, ExistingDirectDebit } from 'helpers/paymentMethods';
 import { getCampaignName } from 'helpers/campaigns';
 import type { LandingPageStripeElementsRecurringTestVariants } from 'helpers/abTests/abtestDefinitions';
-import type { PaymentSecurityDesignTestVariants, RecurringStripePaymentRequestButtonTestVariants } from 'helpers/abTests/abtestDefinitions';
+import type { PaymentSecurityDesignTest1BVariants, RecurringStripePaymentRequestButtonTestVariants } from 'helpers/abTests/abtestDefinitions';
 
 
 // ----- Types ----- //
@@ -85,7 +85,7 @@ type PropTypes = {|
   country: IsoCountry,
   createStripePaymentMethod: () => void,
   stripeElementsRecurringTestVariant: LandingPageStripeElementsRecurringTestVariants,
-  paymentSecurityDesignTestVariant: PaymentSecurityDesignTestVariants,
+  paymentSecurityDesignTest1BVariant: PaymentSecurityDesignTest1BVariants,
   recurringStripePaymentRequestButtonTestVariant: RecurringStripePaymentRequestButtonTestVariants,
 |};
 
@@ -118,7 +118,7 @@ const mapStateToProps = (state: State) => ({
   country: state.common.internationalisation.countryId,
   stripeV3HasLoaded: state.page.form.stripeV3HasLoaded,
   stripeElementsRecurringTestVariant: state.common.abParticipations.stripeElementsRecurring,
-  paymentSecurityDesignTestVariant: state.common.abParticipations.paymentSecurityDesignTest,
+  paymentSecurityDesignTest1BVariant: state.common.abParticipations.paymentSecurityDesignTest1B,
   recurringStripePaymentRequestButtonTestVariant: state.common.abParticipations.recurringStripePaymentRequestButton,
 });
 
@@ -247,7 +247,7 @@ function withProps(props: PropTypes) {
 
   const classModifiers = ['contribution', 'with-labels'];
 
-  const showSecureStripeContainer: boolean = props.paymentSecurityDesignTestVariant !== 'control' || props.countryGroupId === 'GBPCountries';
+  const showSecureStripeContainer: boolean = props.paymentSecurityDesignTest1BVariant !== 'control' || props.countryGroupId === 'GBPCountries';
   const showSecureButtonBg: boolean = showSecureStripeContainer && props.paymentMethod === Stripe && (props.stripeElementsRecurringTestVariant === 'stripeElements' || props.contributionType === 'ONE_OFF');
 
   return (

--- a/support-frontend/assets/pages/contributions-landing/components/PaymentMethodSelector.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/PaymentMethodSelector.jsx
@@ -41,7 +41,7 @@ import {
   subscriptionToExplainerPart,
 } from '../../../helpers/existingPaymentMethods/existingPaymentMethods';
 import SecureTransactionIndicator from 'components/secureTransactionIndicator/secureTransactionIndicator';
-import type { PaymentSecurityDesignTestVariants } from 'helpers/abTests/abtestDefinitions';
+import type { PaymentSecurityDesignTest1BVariants } from 'helpers/abTests/abtestDefinitions';
 import {
   type CountryGroupId,
   detect,
@@ -62,7 +62,7 @@ type PropTypes = {|
   updateSelectedExistingPaymentMethod: (RecentlySignedInExistingPaymentMethod | typeof undefined) => Action,
   isTestUser: boolean,
   switches: Switches,
-  paymentSecurityDesignTestVariant: PaymentSecurityDesignTestVariants,
+  paymentSecurityDesignTest1BVariant: PaymentSecurityDesignTest1BVariants,
 |};
 /* eslint-enable react/no-unused-prop-types */
 
@@ -75,7 +75,7 @@ const mapStateToProps = (state: State) => ({
   existingPaymentMethod: state.page.form.existingPaymentMethod,
   isTestUser: state.page.user.isTestUser || false,
   switches: state.common.settings.switches,
-  paymentSecurityDesignTestVariant: state.common.abParticipations.paymentSecurityDesignTest,
+  paymentSecurityDesignTest1BVariant: state.common.abParticipations.paymentSecurityDesignTest1B,
 });
 
 const mapDispatchToProps = {
@@ -121,10 +121,10 @@ function withProps(props: PropTypes) {
     <legend id="payment_method" className="form__legend"><h3>Payment method</h3></legend>
   );
 
-  const legend = props.paymentSecurityDesignTestVariant === 'V2_securemiddle' && countryGroupId !== 'GBPCountries' ?
+  const legend = props.paymentSecurityDesignTest1BVariant === 'V1_securemiddlegrey' && countryGroupId !== 'GBPCountries' ?
     (
       <div className="secure-transaction">
-        {legendSimple} <SecureTransactionIndicator modifierClasses={['middle']} />
+        {legendSimple} <SecureTransactionIndicator modifierClasses={['middle', 'showaftermobile']} />
       </div>
     ) :
     legendSimple;

--- a/support-frontend/assets/pages/contributions-landing/components/PaymentMethodSelector.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/PaymentMethodSelector.jsx
@@ -75,7 +75,8 @@ const mapStateToProps = (state: State) => ({
   existingPaymentMethod: state.page.form.existingPaymentMethod,
   isTestUser: state.page.user.isTestUser || false,
   switches: state.common.settings.switches,
-  paymentSecuritySecureTransactionGreyNonUKVariant: state.common.abParticipations.paymentSecuritySecureTransactionGreyNonUK,
+  paymentSecuritySecureTransactionGreyNonUKVariant:
+    state.common.abParticipations.paymentSecuritySecureTransactionGreyNonUK,
 });
 
 const mapDispatchToProps = {

--- a/support-frontend/assets/pages/contributions-landing/components/PaymentMethodSelector.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/PaymentMethodSelector.jsx
@@ -41,7 +41,7 @@ import {
   subscriptionToExplainerPart,
 } from '../../../helpers/existingPaymentMethods/existingPaymentMethods';
 import SecureTransactionIndicator from 'components/secureTransactionIndicator/secureTransactionIndicator';
-import type { PaymentSecurityDesignTest1BVariants } from 'helpers/abTests/abtestDefinitions';
+import type { paymentSecuritySecureTransactionGreyNonUKVariants } from 'helpers/abTests/abtestDefinitions';
 import {
   type CountryGroupId,
   detect,
@@ -62,7 +62,7 @@ type PropTypes = {|
   updateSelectedExistingPaymentMethod: (RecentlySignedInExistingPaymentMethod | typeof undefined) => Action,
   isTestUser: boolean,
   switches: Switches,
-  paymentSecurityDesignTest1BVariant: PaymentSecurityDesignTest1BVariants,
+  paymentSecuritySecureTransactionGreyNonUKVariant: paymentSecuritySecureTransactionGreyNonUKVariants,
 |};
 /* eslint-enable react/no-unused-prop-types */
 
@@ -75,7 +75,7 @@ const mapStateToProps = (state: State) => ({
   existingPaymentMethod: state.page.form.existingPaymentMethod,
   isTestUser: state.page.user.isTestUser || false,
   switches: state.common.settings.switches,
-  paymentSecurityDesignTest1BVariant: state.common.abParticipations.paymentSecurityDesignTest1B,
+  paymentSecuritySecureTransactionGreyNonUKVariant: state.common.abParticipations.paymentSecuritySecureTransactionGreyNonUK,
 });
 
 const mapDispatchToProps = {
@@ -121,7 +121,7 @@ function withProps(props: PropTypes) {
     <legend id="payment_method" className="form__legend"><h3>Payment method</h3></legend>
   );
 
-  const legend = props.paymentSecurityDesignTest1BVariant === 'V1_securemiddlegrey' && countryGroupId !== 'GBPCountries' ?
+  const legend = props.paymentSecuritySecureTransactionGreyNonUKVariant === 'V1_securetransactiongrey' && countryGroupId !== 'GBPCountries' ?
     (
       <div className="secure-transaction">
         {legendSimple} <SecureTransactionIndicator modifierClasses={['middle', 'showaftermobile']} />

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
@@ -94,7 +94,14 @@ const cssModifiers = campaignName && campaigns[campaignName] && campaigns[campai
 const backgroundImageSrc = campaignName && campaigns[campaignName] && campaigns[campaignName].backgroundImage ?
   campaigns[campaignName].backgroundImage : null;
 
-const showSecureTransactionIndicator = countryGroupId === 'GBPCountries' ? <SecureTransactionIndicator modifierClasses={['top']} /> : null;
+const showSecureTransactionIndicator = () => {
+  if (countryGroupId === 'GBPCountries') {
+    return <SecureTransactionIndicator modifierClasses={['top']} />;
+  } else if (store.getState().common.abParticipations.paymentSecurityDesignTest1B === 'V1_securemiddlegrey') { // in test
+    return <SecureTransactionIndicator modifierClasses={['top', 'hideaftermobile']} />;
+  }
+  return null;
+};
 
 function contributionsLandingPage(campaignCodeParameter: ?string) {
   return (
@@ -104,7 +111,7 @@ function contributionsLandingPage(campaignCodeParameter: ?string) {
       footer={<Footer disclaimer countryGroupId={countryGroupId} />}
       backgroundImageSrc={backgroundImageSrc}
     >
-      {showSecureTransactionIndicator}
+      {showSecureTransactionIndicator()}
       <ContributionFormContainer
         thankYouRoute={`/${countryGroups[countryGroupId].supportInternationalisationId}/thankyou`}
         campaignCodeParameter={campaignCodeParameter}

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
@@ -97,7 +97,7 @@ const backgroundImageSrc = campaignName && campaigns[campaignName] && campaigns[
 const showSecureTransactionIndicator = () => {
   if (countryGroupId === 'GBPCountries') {
     return <SecureTransactionIndicator modifierClasses={['top']} />;
-  } else if (store.getState().common.abParticipations.paymentSecurityDesignTest1B === 'V1_securemiddlegrey') { // in test
+  } else if (store.getState().common.abParticipations.paymentSecurityDesignTest1B === 'V1_securemiddlegrey') {
     return <SecureTransactionIndicator modifierClasses={['top', 'hideaftermobile']} />;
   }
   return null;

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
@@ -97,7 +97,7 @@ const backgroundImageSrc = campaignName && campaigns[campaignName] && campaigns[
 const showSecureTransactionIndicator = () => {
   if (countryGroupId === 'GBPCountries') {
     return <SecureTransactionIndicator modifierClasses={['top']} />;
-  } else if (store.getState().common.abParticipations.paymentSecurityDesignTest1B === 'V1_securemiddlegrey') {
+  } else if (store.getState().common.abParticipations.paymentSecuritySecureTransactionGreyNonUK === 'V1_securetransactiongrey') {
     return <SecureTransactionIndicator modifierClasses={['top', 'hideaftermobile']} />;
   }
   return null;


### PR DESCRIPTION
## Why are you doing this?
We are testing whether showing a secure transaction indicator and grey background on the card fields will improve AV. This test will run everywhere except UK.

The secure transaction indicator will be placed at the top on mobile and in the middle from phablet size onwards.

This follows from: https://github.com/guardian/support-frontend/pull/2165, https://github.com/guardian/support-frontend/pull/2192 and https://github.com/guardian/support-frontend/pull/2211.
<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/etJkZP08)

## Changes

* Control - white background
* V1_securemiddlegrey

## Screenshots

### Control - desktop
<img width="583" alt="image" src="https://user-images.githubusercontent.com/15648334/69076976-7ec68680-0a2c-11ea-82cc-3422fb19a68a.png">

### V1_securemiddlegrey(desktop) - indicator in middle
<img width="566" alt="image" src="https://user-images.githubusercontent.com/15648334/69076862-44f58000-0a2c-11ea-820c-35bc9990ec61.png">

### Control - mobile
<img width="326" alt="image" src="https://user-images.githubusercontent.com/15648334/69077021-9aca2800-0a2c-11ea-8286-518195bd1aa9.png">

### V1_securemiddlegrey (mobile) - indicator at top
<img width="326" alt="image" src="https://user-images.githubusercontent.com/15648334/69076907-5d659a80-0a2c-11ea-8505-c13fcaa3cd56.png">