### PR TITLE
fixed non-responsive rule in template for EOY campaign

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingEOY2019.scss
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingEOY2019.scss
@@ -3,10 +3,6 @@
 //$campaign-red: #E94F3E;
 
 .gu-content--eoy2019 {
-  .gu-content__blurb {
-    display: block;
-  }
-
   .gu-content__blurb-header {
     font-family: $gu-titlepiece;
     margin: 0;


### PR DESCRIPTION
## Why are you doing this?
@tjsilver helpfully pointed out that the current layout for the end of year campaign is not responsive. I found the rule breaking the responsivity of the page, removed it, and re-tested it.