### PR TITLE
Remove Stripe Checkout for recurring contributions

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -6,7 +6,6 @@ import {
 } from 'helpers/internationalisation/countryGroup';
 
 // ----- Tests ----- //
-export type LandingPageStripeElementsRecurringTestVariants = 'control' | 'stripeElements' | 'notintest';
 export type RecurringStripePaymentRequestButtonTestVariants = 'control' | 'paymentRequestButton' | 'notintest';
 export type paymentSecuritySecureTransactionGreyNonUKVariants = 'control' | 'V1_securetransactiongrey' | 'notintest';
 
@@ -34,28 +33,6 @@ export const tests: Tests = {
     isActive: window.guardian && !!window.guardian.recurringStripePaymentRequestButton,
     independent: true,
     seed: 2,
-    targetPage: contributionsLandingPageMatch,
-  },
-
-  stripeElementsRecurring: {
-    type: 'OTHER',
-    variants: [
-      {
-        id: 'control',
-      },
-      {
-        id: 'stripeElements',
-      },
-    ],
-    audiences: {
-      ALL: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: !!window.guardian && !!window.guardian.stripeElementsRecurring,
-    independent: true,
-    seed: 3,
     targetPage: contributionsLandingPageMatch,
   },
 

--- a/support-frontend/assets/helpers/paymentIntegrations/stripeCheckout.js
+++ b/support-frontend/assets/helpers/paymentIntegrations/stripeCheckout.js
@@ -96,18 +96,9 @@ function setupStripeCheckout(
   });
 }
 
-function openDialogBox(stripeHandler: Object, amount: number, email: string) {
-  stripeHandler.open({
-    // Must be passed in pence.
-    amount: Math.round(amount * 100),
-    email,
-  });
-}
-
 export {
   loadStripe,
   setupStripeCheckout,
-  openDialogBox,
   getStripeKey,
   stripeAccountForContributionType,
 };

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardFormContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardFormContainer.jsx
@@ -13,7 +13,6 @@ import { type PaymentMethod, Stripe } from 'helpers/paymentMethods';
 import { setupStripe } from 'helpers/stripe';
 import AnimatedDots from 'components/spinners/animatedDots';
 import './stripeCardForm.scss';
-import type { LandingPageStripeElementsRecurringTestVariants } from 'helpers/abTests/abtestDefinitions';
 
 // ----- Types -----//
 
@@ -26,7 +25,6 @@ type PropTypes = {|
   paymentMethod: PaymentMethod,
   setStripeHasLoaded: () => void,
   stripeHasLoaded: boolean,
-  stripeElementsRecurringTestVariant: LandingPageStripeElementsRecurringTestVariants,
   showSecureBackground: boolean,
 |};
 
@@ -37,9 +35,7 @@ class StripeCardFormContainer extends React.Component<PropTypes, void> {
   }
 
   render() {
-    if (this.props.paymentMethod === Stripe &&
-      (this.props.contributionType === 'ONE_OFF' || this.props.stripeElementsRecurringTestVariant === 'stripeElements')
-    ) {
+    if (this.props.paymentMethod === Stripe) {
       if (this.props.stripeHasLoaded) {
 
         const stripeAccount = stripeAccountForContributionType[this.props.contributionType];

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.js
@@ -85,6 +85,7 @@ function getInitialContributionType(
     contributionTypes[countryGroupId][0].contributionType;
 }
 
+// Stripe checkout is currently still used by the Payment Request button only
 function initialiseStripeCheckout(
   onPaymentAuthorisation: (paymentAuthorisation: PaymentAuthorisation) => void,
   contributionType: ContributionType,


### PR DESCRIPTION
## Why are you doing this?
We have been running an A/B test to compare Stripe Elements for recurring contributions vs the old Stripe Checkout (popup) implementation.
Stripe Elements has performed better, and so Stripe Checkout can now be removed.

Note - Stripe Checkout is still used by the Payment Request button (though it doesn't use the popup). This is the last thing to be migrated to the SCA-compliant Stripe integration. Then we can clean up any remaining Stripe Checkout code.

I've tested card and Payment Request button payments.

<img width="400" alt="Screenshot 2019-11-19 at 15 44 51" src="https://user-images.githubusercontent.com/1513454/69161756-8bf27c80-0ae3-11ea-8c6b-76ecb2cdb680.png">

