### PR TITLE
Contributions social share - reverted text, added new image

### DIFF
--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -180,8 +180,8 @@ class Application(
       guestAccountCreationToken = guestAccountCreationToken,
       fontLoaderBundle = fontLoaderBundle,
       geoData = geoData,
-      shareImageUrl = "https://media.guim.co.uk/661978f14a1cbdd64361e429f058e9b20c8db5bb/0_0_2400_1260/1000.png",
-      shareUrl = "https://support.theguardian.com/contribute/climate-pledge-2019"
+      shareImageUrl = "https://media.guim.co.uk/74b15a65c479bfe53151fceeb7d948f125a66af2/0_0_2400_1260/1000.png",
+      shareUrl = "https://support.theguardian.com/contribute"
     )
   }
 

--- a/support-frontend/assets/components/socialShare/socialShare.jsx
+++ b/support-frontend/assets/components/socialShare/socialShare.jsx
@@ -40,25 +40,25 @@ const socialMedia: {
   [SharePlatform]: SocialMedia,
 } = {
   facebook: {
-    link: 'https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fsupport.theguardian.com%2Fuk%2Fcontribute%2Fclimate-pledge-2019%3FacquisitionData%3D%7B%22source%22%3A%22SOCIAL%22%2C%22componentType%22%3A%22ACQUISITIONS_OTHER%22%2C%22campaignCode%22%3A%22climate_pledge_2019%22%2C%22componentId%22%3A%22climate_pledge_2019_social_facebook%22%7D&INTCMP=climate_pledge_2019',
+    link: 'https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute?acquisitionData=%7B%22source%22%3A%22SOCIAL%22%2C%22campaignCode%22%3A%22component-social-facebook%22%2C%22componentId%22%3A%22component-social-facebook%22%7D&INTCMP=component-social-facebook',
     svg: <SvgFacebook />,
     a11yHint: 'Share on facebook',
     windowFeatures: SocialWindowFeatures,
   },
   twitter: {
-    link: 'https://twitter.com/intent/tweet?text=Join%20me%20in%20supporting%20The%20Guardian%E2%80%99s%20pledge%20to%20be%20a%20truthful%20voice%20on%20the%20climate%20crisis&url=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute%2Fclimate-pledge-2019%3FINTCMP%3Dclimate_pledge_2019_component_social_twitter',
+    link: 'https://twitter.com/intent/tweet?url=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute?INTCMP=component-social-twitter&text=Join%20me%20and%20over%20one%20million%20others%20in%20supporting%20a%20different%20model%20for%20open%2C%20independent%20journalism.%20Together%20we%20can%20help%20safeguard%20The%20Guardian%E2%80%99s%20future%20%E2%80%93%20so%20more%20people%2C%20across%20the%20world%2C%20can%20keep%20accessing%20factual%20information%20for%20free',
     svg: <SvgTwitter />,
     a11yHint: 'Share on twitter',
     windowFeatures: SocialWindowFeatures,
   },
   linkedin: {
-    link: 'http://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute%2Fclimate-pledge-2019',
+    link: 'http://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute',
     svg: <SvgLinkedin />,
     a11yHint: 'Share on linkedin',
     windowFeatures: SocialWindowFeatures,
   },
   email: {
-    link: 'mailto:?subject=Join%20me%20in%20supporting%20The%20Guardian%E2%80%99s%20pledge%20to%20be%20a%20truthful%20voice%20on%20the%20climate%20crisis&body=The%20Guardian%20recognises%20the%20climate%20emergency%20as%20the%20defining%20issue%20of%20our%20lifetimes%20%E2%80%93%20and%20pledges%20to%20be%20truthful%2C%20resolute%20and%20undeterred%20in%20pursuing%20their%20reporting%20on%20the%20environment.%20Support%20from%20readers%20makes%20this%20work%20possible%20and%20protects%20The%20Guardian%E2%80%99s%20independence%3A%20https%3A%2F%2Fsupport.theguardian.com%2Fcontribute%2Fclimate-pledge-2019?INTCMP=climate_pledge_2019_component_social_email',
+    link: 'mailto:?subject=Join%20me%20in%20supporting%20open%2C%20independent%20journalism&body=Join%20me%20and%20over%20one%20million%20others%20in%20supporting%20a%20different%20model%20for%20open%2C%20independent%20journalism.%20Together%20we%20can%20help%20safeguard%20The%20Guardian%E2%80%99s%20future%20%E2%80%93%20so%20more%20people%2C%20across%20the%20world%2C%20can%20keep%20accessing%20factual%20information%20for%20free%3A%20https%3A%2F%2Fsupport.theguardian.com%2Fcontribute?INTCMP=component-social-email',
     svg: <SvgEmail />,
     a11yHint: 'Share by email',
     windowFeatures: '',

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
@@ -220,7 +220,7 @@ function withProps(props: PropTypes) {
   const baseClass = 'form';
 
   const classModifiers = ['contribution', 'with-labels'];
-  
+
   const showSecureStripeContainer: boolean = props.paymentSecuritySecureTransactionGreyNonUKVariant !== 'control' || props.countryGroupId === 'GBPCountries';
   const showSecureButtonBg: boolean = showSecureStripeContainer && props.paymentMethod === Stripe;
 


### PR DESCRIPTION
## Why are you doing this?
We forgot to revert the links and image to the standard share links and the new, general share image following the moment. This commit fixes that.
<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Screenshots
![image](https://user-images.githubusercontent.com/3300789/69336486-86697380-0c56-11ea-966d-9eb025cd16e5.png)
