### PR TITLE
Bump acquisition event producer for new component type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.sublime-workspace
 .vscode
 .metals
+.bloop
 
 node_modules
 npm-debug.log

--- a/project/LibraryVersions.scala
+++ b/project/LibraryVersions.scala
@@ -1,6 +1,6 @@
 
 object LibraryVersions {
-  val circeVersion = "0.11.1"
+  val circeVersion = "0.12.1"
   val awsClientVersion = "1.11.642"
   val catsVersion = "1.4.0"
   val jacksonVersion = "2.10.0"

--- a/support-frontend/app/views/ViewHelpers.scala
+++ b/support-frontend/app/views/ViewHelpers.scala
@@ -9,5 +9,5 @@ object ViewHelpers {
   def outputJson[T : Encoder](value: T): String =
     value
       .asJson
-      .pretty(Printer.noSpaces.copy(dropNullValues = true))
+      .printWith(Printer.noSpaces.copy(dropNullValues = true))
 }

--- a/support-lambdas/stripe-intent/build.sbt
+++ b/support-lambdas/stripe-intent/build.sbt
@@ -13,6 +13,12 @@ riffRaffManifestProjectName := "support:lambdas:Stripe Intent"
 riffRaffArtifactResources += (file("support-lambdas/stripe-intent/cfn.yaml"), "cfn/cfn.yaml")
 riffRaffManifestBranch := Option(System.getenv("BRANCH_NAME")).getOrElse("unknown_branch")
 riffRaffBuildIdentifier := Option(System.getenv("BUILD_NUMBER")).getOrElse("DEV")
+assemblyMergeStrategy in assembly := {
+  case x if x.endsWith("module-info.class") => MergeStrategy.discard
+  case y =>
+    val oldStrategy = (assemblyMergeStrategy in assembly).value
+    oldStrategy(y)
+}
 
 libraryDependencies ++= Seq(
   "io.circe" %% "circe-core",

--- a/support-models/build.sbt
+++ b/support-models/build.sbt
@@ -5,7 +5,7 @@ name := "support-models"
 description := "Scala library to provide shared step-function models to Guardian Support projects."
 
 libraryDependencies ++= Seq(
-  "com.gu" %% "acquisition-event-producer-play26" % "4.0.22", //this should really be split into models and producer
+  "com.gu" %% "acquisition-event-producer-play26" % "4.0.23", //this should really be split into models and producer
                                                               // so we don't have to pull in thrift binary compression libs etc
   "org.typelevel" %% "cats-core" % catsVersion,
   "io.circe" %% "circe-core" % circeVersion,

--- a/support-workers/src/main/scala/com/gu/support/workers/encoding/StateDecoder.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/encoding/StateDecoder.scala
@@ -38,7 +38,7 @@ object StateDecoder extends App with LazyLogging {
   })
 
   def print(output: String): Unit = {
-    val formattedOutput = parse(output).map(_.pretty(Printer.indented(" "))).getOrElse(output)
+    val formattedOutput = parse(output).map(_.printWith(Printer.indented(" "))).getOrElse(output)
     println(s"\n\n$formattedOutput\n\n")
   } // scalastyle:ignore
 }

--- a/support-workers/src/test/scala/com/gu/salesforce/SerialisationSpec.scala
+++ b/support-workers/src/test/scala/com/gu/salesforce/SerialisationSpec.scala
@@ -13,29 +13,29 @@ import org.scalatest.matchers.should.Matchers
 class SerialisationSpec extends AnyFlatSpec with Matchers with LazyLogging {
 
   "UpsertData" should "serialise to correct UK json" in {
-    newContactUK.asJson.pretty(Printer.noSpaces.copy(dropNullValues = true)) should be(parse(upsertJson).right.get.noSpaces)
+    newContactUK.asJson.printWith(Printer.noSpaces.copy(dropNullValues = true)) should be(parse(upsertJson).right.get.noSpaces)
   }
 
   "UpsertData" should "serialise to correct US json" in {
-    newContactUS.asJson.pretty(Printer.noSpaces.copy(dropNullValues = true)) should be(parse(upsertJsonWithState).right.get.noSpaces)
+    newContactUS.asJson.printWith(Printer.noSpaces.copy(dropNullValues = true)) should be(parse(upsertJsonWithState).right.get.noSpaces)
   }
 
   "UpsertData" should "serialise to correct json when telephoneNumber provided" in {
     val newContactWithTelephone = newContactUK.copy(Phone = Some(telephoneNumber))
-    newContactWithTelephone.asJson.pretty(Printer.noSpaces.copy(dropNullValues = true)) should be(parse(upsertJsonWithTelephoneNumber).right.get.noSpaces)
+    newContactWithTelephone.asJson.printWith(Printer.noSpaces.copy(dropNullValues = true)) should be(parse(upsertJsonWithTelephoneNumber).right.get.noSpaces)
   }
 
   "UpsertData" should "serialise to correct json when billing address provided" in {
-    newContactUKWithBillingAddress.asJson.pretty(Printer.noSpaces.copy(dropNullValues = true)) should be(parse(upsertJsonWithBillingAddress).right.get.noSpaces)
+    newContactUKWithBillingAddress.asJson.printWith(Printer.noSpaces.copy(dropNullValues = true)) should be(parse(upsertJsonWithBillingAddress).right.get.noSpaces)
   }
 
   "UpsertData" should "serialise to correct json when billing address and delivery address provided" in {
     newContactUKWithBothAddressesAndTelephone.asJson.
-      pretty(Printer.noSpaces.copy(dropNullValues = true)) should be(parse(upsertJsonWithBillingAndDeliveryAddresses).right.get.noSpaces)
+      printWith(Printer.noSpaces.copy(dropNullValues = true)) should be(parse(upsertJsonWithBillingAndDeliveryAddresses).right.get.noSpaces)
   }
 
   "Gift recipient upsert data" should "serialise to correct json" in {
-    giftRecipientUpsert.asJson.pretty(Printer.noSpaces.copy(dropNullValues = true)) should be(parse(giftRecipientUpsertJson).right.get.noSpaces)
+    giftRecipientUpsert.asJson.printWith(Printer.noSpaces.copy(dropNullValues = true)) should be(parse(giftRecipientUpsertJson).right.get.noSpaces)
   }
 
   "Authentication" should "deserialize correctly" in {


### PR DESCRIPTION
## Why are you doing this?
Using latest version of acquisition event producer library so that we can use the new component type for the subscriptions banner.

There was a transitive dependency bump for circe, so to make things easier I have bumped here too.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com)

## Changes

* Change 1
* Change 2

## Screenshots

