### PR TITLE
Fix session storage selectedContributionType key

### DIFF
--- a/support-frontend/assets/helpers/checkouts.js
+++ b/support-frontend/assets/helpers/checkouts.js
@@ -66,7 +66,7 @@ function toHumanReadableContributionType(contributionType: ContributionType): 'S
 }
 
 function getContributionTypeFromSession(): ?ContributionType {
-  return toContributionType(storage.getSession('selected-contribution-type'));
+  return toContributionType(storage.getSession('selectedContributionType'));
 }
 
 function getContributionTypeFromUrl(): ?ContributionType {


### PR DESCRIPTION
## Why are you doing this?
The contributions landing page currently doesn't get your selected contribution type from local storage. This fix makes the key name consistent with other places in the codebase