### PR TITLE
Remind me in "March" instead of December, new general copy

### DIFF
--- a/support-frontend/assets/components/contributionsReminder/contributionsReminder.jsx
+++ b/support-frontend/assets/components/contributionsReminder/contributionsReminder.jsx
@@ -60,7 +60,7 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
   renderButtonCopy = (buttonState: ButtonState): string => {
     switch (buttonState) {
       case 'initial':
-        return 'Remind me in December';
+        return 'Remind me in March';
       case 'pending':
         return 'Pending...';
       case 'success':
@@ -68,7 +68,7 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
       case 'fail':
         return 'Sorry, something went wrong';
       default:
-        return 'Remind me in December';
+        return 'Remind me in March';
     }
   }
 
@@ -95,7 +95,7 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
             Set up a reminder for the end of the year
           </h3>
           <p className="contribution-thank-you-block__message">
-            {'Lots of readers choose to make single contributions at various points in the year. Opt in to receive a reminder in December, in case you would like to support our journalism again. This will be a single email, with no obligation. Thank you.'}
+            {'Lots of readers choose to make single contributions at various points in the year. Opt in to receive a reminder in case you would like to support our journalism again. This will be a single email, with no obligation.'}
           </p>
 
           <TrackableButton


### PR DESCRIPTION
## Why are you doing this?
It's too close to December to keep collecting email reminders for December! Onto March!
<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/0DxkULlO/1664-light-update-the-poc-copy-only)

## Screenshots
![reminder](https://user-images.githubusercontent.com/3300789/69436047-8e014900-0d38-11ea-8b76-5b018077ee14.png)

