### PR TITLE
Reverse amounts testing

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -8,7 +8,7 @@ import {
 // ----- Tests ----- //
 export type RecurringStripePaymentRequestButtonTestVariants = 'control' | 'paymentRequestButton' | 'notintest';
 export type paymentSecuritySecureTransactionGreyNonUKVariants = 'control' | 'V1_securetransactiongrey' | 'notintest';
-export type paymentSecuritySecureTransactionGreyNonUKVariants = 'control' | 'reversedAmounts' | 'notintest';
+export type LandingPageReverseAmountsTestVariant = 'control' | 'reversedAmounts' | 'notintest';
 
 const contributionsLandingPageMatch = '/(uk|us|eu|au|ca|nz|int)/contribute(/.*)?$';
 const usContributionsLandingPageMatch = '/us/contribute(/.*)?$';

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -8,8 +8,10 @@ import {
 // ----- Tests ----- //
 export type RecurringStripePaymentRequestButtonTestVariants = 'control' | 'paymentRequestButton' | 'notintest';
 export type paymentSecuritySecureTransactionGreyNonUKVariants = 'control' | 'V1_securetransactiongrey' | 'notintest';
+export type paymentSecuritySecureTransactionGreyNonUKVariants = 'control' | 'reversedAmounts' | 'notintest';
 
 const contributionsLandingPageMatch = '/(uk|us|eu|au|ca|nz|int)/contribute(/.*)?$';
+const usContributionsLandingPageMatch = '/us/contribute(/.*)?$';
 
 const countryGroupId: CountryGroupId = detect();
 
@@ -57,5 +59,28 @@ export const tests: Tests = {
     seed: 10,
     targetPage: contributionsLandingPageMatch,
     canRun: () => countryGroupId !== 'GBPCountries',
+  },
+
+  landingPageReverseAmounts: {
+    type: 'OTHER',
+    variants: [
+      {
+        id: 'control',
+      },
+      {
+        id: 'reversedAmounts',
+      },
+    ],
+    audiences: {
+      ALL: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: true,
+    independent: true,
+    seed: 3,
+    targetPage: usContributionsLandingPageMatch,
+    canRun: () => countryGroupId === 'UnitedStates',
   },
 };

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
@@ -24,6 +24,7 @@ import SvgEuro from 'components/svgs/euro';
 import SvgPound from 'components/svgs/pound';
 import { selectAmount, updateOtherAmount } from '../contributionsLandingActions';
 import ContributionTextInput from './ContributionTextInput';
+import type { LandingPageReverseAmountsTestVariant } from 'helpers/abTests/abtestDefinitions';
 
 // ----- Types ----- //
 
@@ -40,6 +41,7 @@ type PropTypes = {|
   updateOtherAmount: (string, CountryGroupId, ContributionType) => void,
   checkoutFormHasBeenSubmitted: boolean,
   stripePaymentRequestButtonClicked: boolean,
+  landingPageReverseAmountsVariant: LandingPageReverseAmountsTestVariant,
 |};
 /* eslint-enable react/no-unused-prop-types */
 
@@ -54,6 +56,7 @@ const mapStateToProps = state => ({
   stripePaymentRequestButtonClicked:
     state.page.form.stripePaymentRequestButtonData.ONE_OFF.stripePaymentRequestButtonClicked ||
     state.page.form.stripePaymentRequestButtonData.REGULAR.stripePaymentRequestButtonClicked,
+  landingPageReverseAmountsVariant: state.common.abParticipations.landingPageReverseAmounts,
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -163,11 +166,14 @@ function withProps(props: PropTypes) {
     formatAmount(currencies[props.currency], spokenCurrencies[props.currency], { value: max.toString() }, false);
   const otherAmount = props.otherAmounts[props.contributionType].amount;
 
+  // JTL - related to landing page reverse amounts test:
+  const amountsToRender = props.landingPageReverseAmountsVariant === 'reversedAmounts' ? validAmounts.reverse() : validAmounts;
+
   return (
     <fieldset className={classNameWithModifiers('form__radio-group', ['pills', 'contribution-amount'])}>
       <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>How much would you like to give?</legend>
       <ul className="form__radio-group-list">
-        {validAmounts.map(renderAmount(
+        {amountsToRender.map(renderAmount(
           currencies[props.currency],
           spokenCurrencies[props.currency],
           props,


### PR DESCRIPTION
## Why are you doing this?
Requested test for the US landing page

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/lRxnsHth/1662-flip-the-amounts-ordering-on-the-us-landing-page-ab-test)

## Screenshots
Control amounts annual:
![control amounts annual](https://user-images.githubusercontent.com/3300789/69438835-b0499580-0d3d-11ea-9a0d-aae426381541.png)
Control amounts monthly:
![control amounts monthly](https://user-images.githubusercontent.com/3300789/69438837-b0e22c00-0d3d-11ea-8758-a3ad80271327.png)
Control amounts single:
![control amounts single](https://user-images.githubusercontent.com/3300789/69438839-b0e22c00-0d3d-11ea-8101-16a001b43f9f.png)

Reversed amounts annual:
![reversed amounts annual](https://user-images.githubusercontent.com/3300789/69438840-b0e22c00-0d3d-11ea-9ee9-79b0bfafff02.png)
Reversed amounts monthly:
![reversed amounts monthly](https://user-images.githubusercontent.com/3300789/69438841-b0e22c00-0d3d-11ea-9b5d-52b36910e5e5.png)
Reversed amounts single:
![reversed amounts single](https://user-images.githubusercontent.com/3300789/69438844-b0e22c00-0d3d-11ea-9c8c-5d322fdbad65.png)
