### PR TITLE
Go to the correct promo T&Cs page for gifts

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -136,7 +136,8 @@ const getCopy = (promotionCopy: Object, orderIsAGift: boolean): PageCopy => {
 
 const { promotionCopy, orderIsAGift } = store.getState().page;
 const copy = getCopy(promotionCopy, orderIsAGift);
-const promoTerms = promotionTermsUrl(getQueryParameter(promoQueryParam) || '10ANNUAL');
+const defaultPromo = orderIsAGift ? 'GW20GIFT1Y' : '10ANNUAL';
+const promoTerms = promotionTermsUrl(getQueryParameter(promoQueryParam) || defaultPromo);
 
 type GiftHeadingPropTypes = {
   text: string,


### PR DESCRIPTION
## Why are you doing this?

We are currently linking to the non-gift promotion T&Cs page from the GW gift promo page. This fixes that.

[**Trello Card**](https://trello.com/c/xh3l1Jjd/2762-gift-promo-tcs-link)
