### PR TITLE
Fix eu promo copy

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -136,7 +136,8 @@ const getCopy = (promotionCopy: Object, orderIsAGift: boolean): PageCopy => {
 
 const { promotionCopy, orderIsAGift } = store.getState().page;
 const copy = getCopy(promotionCopy, orderIsAGift);
-const promoTerms = promotionTermsUrl(getQueryParameter(promoQueryParam) || '10ANNUAL');
+const defaultPromo = orderIsAGift ? 'GW20GIFT1Y' : '10ANNUAL';
+const promoTerms = promotionTermsUrl(getQueryParameter(promoQueryParam) || defaultPromo);
 
 type GiftHeadingPropTypes = {
   text: string,


### PR DESCRIPTION
## Why are you doing this?

There was a bug with the code which shows promotional copy on the Guardian Weekly product page when there is a valid promotion active. The copy was not being updated in the EU or ROW region for promotions which are only valid in those regions.

The reason for this is that the way that the promo code tool specifies that a promotion is valid in a given region is by setting it as valid for every country in that region (not the region itself). On the product pages we were using the default country for the region to check if a promo code was valid. This was fine for UK, US, AUS, NZ & CA which have a default country but EUR and ROW do not so the check was always failing and the promo code was flagged as invalid.

This PR changes the product page to just pick any country from the region when checking whether the promotion is valid.

[**Trello Card**](https://trello.com/c/Ww0KQzxV/2772-fix-promo-copy-on-gw-product-page-for-eu-region)



