### PR TITLE
Reapply "New Guardian Weekly gifting v 1.0"

### DIFF
--- a/support-frontend/app/controllers/Promotions.scala
+++ b/support-frontend/app/controllers/Promotions.scala
@@ -37,7 +37,7 @@ class Promotions(
     maybePromotionTerms.fold(NotFound("Invalid promo code")
     ) { promotionTerms =>
       val productLandingPage = promotionTerms.product match {
-        case GuardianWeekly => routes.Subscriptions.weeklyGeoRedirect().url
+        case GuardianWeekly => routes.Subscriptions.weeklyGeoRedirect(false).url
         case DigitalPack => routes.DigitalSubscription.digitalGeoRedirect().url
         case Paper => routes.PaperSubscription.paper(false).url
       }

--- a/support-frontend/app/controllers/Subscriptions.scala
+++ b/support-frontend/app/controllers/Subscriptions.scala
@@ -61,19 +61,22 @@ class Subscriptions(
 
   }
 
-  def weeklyGeoRedirect: Action[AnyContent] = geoRedirect("subscribe/weekly")
+  def weeklyGeoRedirect(orderIsAGift: Boolean = false): Action[AnyContent] = geoRedirect(
+    if (orderIsAGift) "subscribe/weekly/gift" else "subscribe/weekly"
+  )
 
-  def weekly(countryCode: String): Action[AnyContent] = CachedAction() { implicit request =>
+  def weekly(countryCode: String, orderIsAGift: Boolean): Action[AnyContent] = CachedAction() { implicit request =>
     implicit val settings: AllSettings = settingsProvider.getAllSettings()
-    val title = "The Guardian Weekly Subscriptions | The Guardian"
+    val title = if (orderIsAGift) "The Guardian Weekly Gift Subscription | The Guardian" else "The Guardian Weekly Subscriptions | The Guardian"
     val mainElement = EmptyDiv("weekly-landing-page-" + countryCode)
     val js = Left(RefPath("weeklySubscriptionLandingPage.js"))
     val css = Left(RefPath("weeklySubscriptionLandingPage.css"))
     val description = stringsConfig.weeklyLandingDescription
     val canonicalLink = Some(buildCanonicalWeeklySubscriptionLink("uk"))
+    val defaultPromos = if (orderIsAGift) List("GW20GIFT1Y") else List(GuardianWeekly.AnnualPromoCode, GuardianWeekly.SixForSixPromoCode)
     val queryPromos = request.queryString.get("promoCode").map(_.toList).getOrElse(Nil)
-    val promoCodes =  queryPromos ++ List(GuardianWeekly.AnnualPromoCode, GuardianWeekly.SixForSixPromoCode)
-    val productPrices = priceSummaryServiceProvider.forUser(false).getPrices(GuardianWeekly, promoCodes)
+    val promoCodes = defaultPromos ++ queryPromos
+    val productPrices = priceSummaryServiceProvider.forUser(false).getPrices(GuardianWeekly, promoCodes, orderIsAGift)
     val maybePromotionCopy = queryPromos.headOption.flatMap(promoCode =>
       ProductPromotionCopy(promotionServiceProvider.forUser(false), stage)
         .getCopyForPromoCode(promoCode, GuardianWeekly, CountryGroup.countryByCode(countryCode).getOrElse(Country.UK))
@@ -92,6 +95,7 @@ class Subscriptions(
         s"""<script type="text/javascript">
               window.guardian.productPrices = ${outputJson(productPrices)}
               window.guardian.promotionCopy = ${outputJson(maybePromotionCopy)}
+              window.guardian.orderIsAGift = $orderIsAGift
             </script>""")
     }).withSettingsSurrogateKey
   }

--- a/support-frontend/app/views/subscriptionCheckout.scala.html
+++ b/support-frontend/app/views/subscriptionCheckout.scala.html
@@ -27,7 +27,8 @@
   uatStripeConfig: StripeConfig,
   defaultPayPalConfig: PayPalConfig,
   uatPayPalConfig: PayPalConfig,
-  stripeSetupIntentEndpoint: String
+  stripeSetupIntentEndpoint: String,
+  orderIsAGift: Boolean = false,
 )(implicit assets: AssetsResolver, requestHeader: RequestHeader, settings: AllSettings)
 
   @main(title = title, mainJsBundle = Left(RefPath(js)), mainElement = mainElement, mainStyleBundle = Left(RefPath(css)), fontLoaderBundle = fontLoaderBundle, csrf = csrf) {
@@ -35,6 +36,8 @@
       window.guardian = window.guardian || {};
 
       window.guardian.productPrices = @{Html(outputJson(productPrices))}
+
+      window.guardian.orderIsAGift = @orderIsAGift
 
       window.guardian.user = {
         firstName: "@user.privateFields.firstName",

--- a/support-frontend/assets/components/button/_sharedButton.jsx
+++ b/support-frontend/assets/components/button/_sharedButton.jsx
@@ -15,6 +15,7 @@ export const Appearances = {
   primary: 'primary',
   secondary: 'secondary',
   green: 'green',
+  blue: 'blue',
   greenHollow: 'greenHollow',
   greyHollow: 'greyHollow',
   disabled: 'disabled',

--- a/support-frontend/assets/components/button/button.scss
+++ b/support-frontend/assets/components/button/button.scss
@@ -56,6 +56,16 @@
   }
 }
 
+.component-button--blue {
+  color:#052962;
+  background-color:#C1D8FC;
+
+  &:hover, &:focus {
+    color:#fff;
+    background-color: #4e77bd;
+  }
+}
+
 .component-button--greenHollow {
   color: gu-colour(green-main);
   border: 1px solid gu-colour(neutral-86);

--- a/support-frontend/assets/components/checkoutForm/checkoutForm.jsx
+++ b/support-frontend/assets/components/checkoutForm/checkoutForm.jsx
@@ -12,16 +12,17 @@ Form "blocks". you need at least one of these.
 */
 
 type FormSectionPropTypes = {|
+  id?: string,
   title: Option<string>,
   children: Node,
   headingSize: HeadingSize,
-  noBorder: boolean,
+  border: 'full' | 'bottom' | 'top' | 'none',
 |};
 
 const FormSection = ({
-  children, title, headingSize, noBorder,
+  children, title, headingSize, border, id,
 }: FormSectionPropTypes) => (
-  <div className={`component-checkout-form-section ${noBorder ? 'component-checkout-form-section--no-border' : ''}`}>
+  <div id={id} className={`component-checkout-form-section component-checkout-form-section--${border}`}>
     <div className="component-checkout-form-section__wrap">
       {title && <Heading className="component-checkout-form-section__heading" size={headingSize}>{title}</Heading>}
       {children}
@@ -32,7 +33,8 @@ const FormSection = ({
 FormSection.defaultProps = {
   headingSize: 2,
   title: null,
-  noBorder: false,
+  border: 'full',
+  id: '',
 };
 
 // Hidden version of form section

--- a/support-frontend/assets/components/checkoutForm/checkoutForm.scss
+++ b/support-frontend/assets/components/checkoutForm/checkoutForm.scss
@@ -29,8 +29,17 @@
   border-top: 1px solid gu-colour(neutral-86);
 }
 
-div .component-checkout-form-section.component-checkout-form-section--no-border {
+div .component-checkout-form-section.component-checkout-form-section--bottom {
   border-top: none;
+}
+
+div .component-checkout-form-section.component-checkout-form-section--top {
+  border-bottom: none;
+}
+
+div .component-checkout-form-section.component-checkout-form-section--none {
+  border-top: none;
+  border-bottom: none;
 }
 
 div .component-checkout-form-section.component-checkout-form-section--hidden {

--- a/support-frontend/assets/components/headingBlock/headingBlock.jsx
+++ b/support-frontend/assets/components/headingBlock/headingBlock.jsx
@@ -13,15 +13,16 @@ import './headingBlock.scss';
 type PropTypes = {|
   overheading: Option<string>,
   children?: Node,
+  orderIsAGift?: boolean,
 |};
 
 
 // ----- Component ----- //
 
 function HeadingBlock(props: PropTypes) {
-
+  const giftOrder = props.orderIsAGift ? '__gift' : '';
   return (
-    <div className="component-heading-block">
+    <div className={`component-heading-block${giftOrder}`}>
       <div className="component-heading-block__content">
         {props.overheading ?
         [
@@ -48,6 +49,7 @@ function HeadingBlock(props: PropTypes) {
 HeadingBlock.defaultProps = {
   children: null,
   overheading: null,
+  orderIsAGift: false,
 };
 
 

--- a/support-frontend/assets/components/headingBlock/headingBlock.scss
+++ b/support-frontend/assets/components/headingBlock/headingBlock.scss
@@ -2,7 +2,7 @@
 
 .component-product-page-hero-heading {
   position: relative;
-  
+
   .component-left-margin-section__content {
     position: relative;
     @include mq($from: tablet) {
@@ -17,7 +17,7 @@
     @include mq($from: desktop) {
       margin-top: -6.5rem;
     }
-    
+
     @include mq($from: leftCol) {
       margin-top: -7.5rem;
     }
@@ -50,6 +50,22 @@
 
 .component-heading-block__maxwidth {
   max-width: gu-span(10);
+}
+
+.component-heading-block__gift {
+  .component-heading-block__maxwidth {
+    max-width: gu-span(7);
+
+    @include mq($until: mobileLandscape) {
+      font-size: 26px;
+      line-height: 30px;
+    }
+
+    @include mq($until: mobileMedium) {
+      font-size: 24px;
+      line-height: 28px;
+    }
+  }
 }
 
 %component-heading-block__card {

--- a/support-frontend/assets/components/priceLabel/priceLabel.jsx
+++ b/support-frontend/assets/components/priceLabel/priceLabel.jsx
@@ -14,23 +14,34 @@ import { getAppliedPromo, hasDiscount } from 'helpers/productPrice/promotions';
 export type PropTypes = {
   productPrice: ProductPrice,
   billingPeriod: BillingPeriod,
+  orderIsAGift?: boolean,
+  giftStyles?: Object,
 }
 
 function PriceLabel({
-  productPrice, billingPeriod, ...props
+  productPrice,
+  billingPeriod,
+  orderIsAGift,
+  giftStyles,
+  ...props
 }: PropTypes) {
   const description = getPriceDescription(productPrice, billingPeriod, true);
 
   const promotion = getAppliedPromo(productPrice.promotions);
-
-  if (hasDiscount(promotion)) {
-    return (
-      <span {...props}>
-        <del aria-hidden="true">{showPrice(productPrice)}</del>{' '}
-        {description}
-      </span>);
-  }
-  return (<span {...props}>{description}</span>);
+  return (
+    <span {...props}>
+      {
+        hasDiscount(promotion) && (
+          <del aria-hidden="true">{showPrice(productPrice)}</del>
+        )
+      }
+      <span className={orderIsAGift && giftStyles}>{` ${description}`}</span>
+    </span>);
 }
+
+PriceLabel.defaultProps = {
+  giftStyles: {},
+  orderIsAGift: false,
+};
 
 export { PriceLabel };

--- a/support-frontend/assets/components/productPage/productPageHero/productPageHero.jsx
+++ b/support-frontend/assets/components/productPage/productPageHero/productPageHero.jsx
@@ -28,6 +28,8 @@ type PropTypes = {|
   content?: Option<Node>,
   hasCampaign: boolean,
   showProductPageHeroHeader?: boolean,
+  orderIsAGift?: boolean,
+  giftImage?: Node,
 |};
 
 type ProductPageHeroHeaderTypes = {
@@ -35,6 +37,8 @@ type ProductPageHeroHeaderTypes = {
   hasCampaign: boolean,
   heading: string,
   content?: Option<Node>,
+  orderIsAGift?: boolean,
+  giftImage?: Node,
 }
 
 // ----- Render ----- //
@@ -69,13 +73,21 @@ const HeroHanger = ({
 const HeroHeading = ({
   children,
   hasCampaign,
-}: {children: Node, hasCampaign: boolean}) => (
+  orderIsAGift,
+  giftImage,
+}: {children: Node, hasCampaign: boolean, orderIsAGift?: boolean, giftImage?: Node}) => (
   <div className={classNameWithModifiers('component-product-page-hero-heading', [hasCampaign ? 'campaign' : null])}>
     <LeftMarginSection>
+      {orderIsAGift && giftImage}
       {children}
     </LeftMarginSection>
   </div>
 );
+
+HeroHeading.defaultProps = {
+  orderIsAGift: false,
+  giftImage: null,
+};
 
 const ProductPageHero = ({
   modifierClasses, children, appearance, showProductPageHeroHeader, ...props
@@ -89,11 +101,16 @@ const ProductPageHero = ({
 );
 
 const ProductPageHeroHeader = ({
-  overheading, heading, content, hasCampaign,
+  overheading, heading, content, hasCampaign, orderIsAGift, giftImage,
 }: ProductPageHeroHeaderTypes) => (
   <div>
-    <HeroHeading {...{ hasCampaign }}>
-      <HeadingBlock overheading={overheading} >{heading}</HeadingBlock>
+    <HeroHeading {...{ hasCampaign, orderIsAGift, giftImage }}>
+      <HeadingBlock
+        overheading={orderIsAGift ? 'The Guardian Weekly gift subscription' : overheading}
+        orderIsAGift={orderIsAGift}
+      >
+        {heading}
+      </HeadingBlock>
     </HeroHeading>
     {content && <HeroHanger>{content}</HeroHanger>}
   </div>
@@ -108,6 +125,8 @@ ProductPageHero.defaultProps = {
 
 ProductPageHeroHeader.defaultProps = {
   content: null,
+  orderIsAGift: false,
+  giftImage: null,
 };
 
 export { HeroHanger, HeroWrapper, HeroHeading, ProductPageHeroHeader };

--- a/support-frontend/assets/components/productPage/productPageList/productPageList.jsx
+++ b/support-frontend/assets/components/productPage/productPageList/productPageList.jsx
@@ -1,0 +1,34 @@
+// @flow
+import React from 'react';
+
+// styles
+import './productPageList.scss';
+
+type ListPropTypes = {
+  items: Array<Object>,
+}
+
+const List = ({ items }: ListPropTypes) => (
+  <ul className="product-block__list-item__ul--simple">
+    {items.map(item => (
+      <li className="product-block__list-item__li--simple">
+        <span className="product-block__list-item__bullet" />
+        <span className="product-block__list-item__explainer--simple">{item.explainer}</span>
+      </li>
+    ))}
+  </ul>
+);
+
+const ListHeading = ({ items }: ListPropTypes) => (
+  <ul className="product-block__list-item__ul">
+    {items.map(item => (
+      <li className="product-block__list-item__li">
+        <div className="product-block__list-item__bullet" />
+        <span className="product-block__list-item--bold">{item.boldText}</span><br />
+        <div className="product-block__list-item__explainer">{item.explainer}</div>
+      </li>
+    ))}
+  </ul>
+);
+
+export { List, ListHeading };

--- a/support-frontend/assets/components/productPage/productPageList/productPageList.scss
+++ b/support-frontend/assets/components/productPage/productPageList/productPageList.scss
@@ -1,0 +1,83 @@
+@import '~stylesheets/gu-sass/gu-sass';
+
+.product-block__list-item__ul,
+.product-block__list-item__ul--simple {
+  margin-top: 15px;
+
+  @include mq($from: desktop) {
+    margin-top: 20px;
+  }
+}
+
+.product-block__list-item__ul--simple {
+  margin: 0 0 20px;
+
+  @include mq($from: tablet) {
+    margin: 0 0 30px;
+  }
+}
+
+.product-block__list-item__li, .product-block__list-item__li--simple {
+  margin: 0 10px 15px 5px;
+  font-size: 15px;
+
+  @include mq($from: tablet) {
+    margin-left: 18px;
+    font-size: 17px;
+  }
+
+  .product-block__list-item--bold {
+    font-weight: 600;
+    margin-left: 8px;
+  }
+
+  .product-block__list-item__explainer {
+    margin-left: 23px;
+    font-size: 14px;
+
+    @include mq($from: tablet) {
+      font-size: 16px;
+    }
+  }
+}
+
+.product-block__list-item__li--simple {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  margin-left: 0;
+  margin-bottom: 5px;
+  @include gu-fontset-heading;
+  font-weight: 300;
+
+  .product-block__list-item__explainer--simple {
+    display: inline-flex;
+    max-width: 90%;
+    margin-left: 8px;
+    font-size: 18px;
+    line-height: 24px;
+
+    @include mq($from: tablet) {
+      font-size: 22px;
+      margin-left: 10px;
+      line-height: 26px;
+    }
+  }
+
+  .product-block__list-item__bullet {
+    margin-top: 4px;
+  }
+}
+
+.product-block__list-item__bullet {
+  display: inline-block;
+  width: 13px;
+  height: 13px;
+  border-radius: 50%;
+  background-color: #ffe500;
+
+  @include mq($from: tablet) {
+    width: 15px;
+    height: 15px;
+  }
+}

--- a/support-frontend/assets/components/subscriptionCheckouts/summary.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/summary.jsx
@@ -1,10 +1,7 @@
 // @flow
 
 import React, { Component } from 'react';
-import {
-  type ProductPrice,
-
-} from 'helpers/productPrice/productPrices';
+import { type ProductPrice } from 'helpers/productPrice/productPrices';
 import type { BillingPeriod } from 'helpers/billingPeriods';
 import styles from './summary.module.scss';
 import { PriceLabel } from 'components/priceLabel/priceLabel';
@@ -12,8 +9,8 @@ import typeof GridImageType from 'components/gridImage/gridImage';
 import { type GridImg } from 'components/gridImage/gridImage';
 import SvgDropdownArrowUp from './dropDownArrowUp.svg';
 import type { SubscriptionProduct } from 'helpers/subscriptions';
-import { getAppliedPromo, hasDiscount } from 'helpers/productPrice/promotions';
 import type { Promotion } from 'helpers/productPrice/promotions';
+import { getAppliedPromo, hasDiscount } from 'helpers/productPrice/promotions';
 
 // Types
 
@@ -22,7 +19,7 @@ export type DataListItem = {
   value: string,
 }
 
-type PropTypes = {|
+type PropTypes = {
   billingPeriod: BillingPeriod,
   changeSubscription?: string | null,
   dataList: DataListItem[],
@@ -32,7 +29,8 @@ type PropTypes = {|
   title: string,
   // eslint-disable-next-line react/no-unused-prop-types
   product: SubscriptionProduct,
-|};
+  orderIsAGift?: boolean,
+};
 
 type StateTypes = {
   showDropDown: boolean,
@@ -94,7 +92,9 @@ const TabletAndDesktop = (props: PropTypes) => (
     <div className={styles.content}>
       <h1 className={styles.header}>Order summary</h1>
       <header>
-        <h2 className={styles.title} title={`your subscription is ${props.title}`}>{props.title}</h2>
+        <h2 className={styles.title} title={`your subscription is ${props.title}`}>
+          {!props.orderIsAGift && 'The '}{props.title}{props.orderIsAGift && ' Gift Subscription'}
+        </h2>
         {props.description &&
           <h3 className={styles.titleDescription}>{props.description}</h3>
         }
@@ -106,9 +106,9 @@ const TabletAndDesktop = (props: PropTypes) => (
           billingPeriod={props.billingPeriod}
         />
         <PromotionDiscount promotion={getAppliedPromo(props.productPrice.promotions)} />
-        {props.dataList ?
+        {props.dataList &&
           <DataList dataList={props.dataList} />
-        : null}
+        }
       </div>
       {props.changeSubscription ?
         <ChangeSubscription route={props.changeSubscription} />
@@ -120,6 +120,7 @@ const TabletAndDesktop = (props: PropTypes) => (
 TabletAndDesktop.defaultProps = {
   changeSubscription: null,
   dataList: [],
+  orderIsAGift: false,
 };
 
 const HideDropDown = (props: {
@@ -157,6 +158,10 @@ const ShowDropDown = (props: {
   deliveryMethod: string | null,
   onClick: Function,
   showDropDown: boolean,
+  productPrice: ProductPrice,
+  billingPeriod: BillingPeriod,
+  orderIsAGift: boolean,
+  title: string,
 }) => (
   <div className={styles.contentWrapper}>
     <h1 className={styles.headerShowDetails}>Order summary</h1>
@@ -172,6 +177,7 @@ const ShowDropDown = (props: {
         className={styles.data}
         productPrice={props.productPrice}
         billingPeriod={props.billingPeriod}
+        giftStyles={styles.gift}
       />
     </div>
     {props.deliveryMethod ?
@@ -203,7 +209,8 @@ export default class Summary extends Component<PropTypes, StateTypes> {
   static defaultProps = {
     changeSubscription: null,
     dataList: [],
-  }
+    orderIsAGift: false,
+  };
 
   constructor(props: PropTypes) {
     super(props);
@@ -213,11 +220,11 @@ export default class Summary extends Component<PropTypes, StateTypes> {
     };
   }
 
-  getDeliveryMethod = () => this.props.dataList.filter(item => item.title === 'Delivery method').pop().value
+  getDeliveryMethod = () => this.props.dataList.filter(item => item.title === 'Delivery method').pop().value;
 
   toggleDetails = () => {
     this.setState({ showDropDown: !this.state.showDropDown });
-  }
+  };
 
   render() {
     const { product } = this.props;

--- a/support-frontend/assets/components/subscriptionCheckouts/summary.module.scss
+++ b/support-frontend/assets/components/subscriptionCheckouts/summary.module.scss
@@ -99,7 +99,7 @@
     @include gu-typeface(headline, 18, $size-only: true);
   }
   @include mq($from:leftCol) {
-    @include gu-typeface(headline, 32, $size-only: true);
+    @include gu-typeface(headline, 24, $size-only: true);
   }
 }
 
@@ -117,6 +117,7 @@
   border: none;
   padding: 0;
   text-align: left;
+  align-self: end;
 }
 
 .changeSub, :visited {
@@ -129,6 +130,7 @@
   @include gu-fontset-body-sans;
   font-size: 14px;
   font-weight: 600;
+
   @include mq($from: tablet) {
     @include gu-fontset-heading;
     font-weight: 400;
@@ -156,7 +158,11 @@
 .data {
   @include gu-fontset-body-sans;
   display: grid;
-  grid-template-columns: max-content 1fr;
+  grid-template-columns: minmax(max-content 1fr);
+
+  @include mq($from: tablet) {
+    grid-template-columns: max-content 1fr;
+  }
 }
 
 .data dt, .dataUnderline, .dataBold {
@@ -185,6 +191,7 @@
 .promo {
   @include gu-fontset-body-sans;
   color: gu-colour(neutral-46);
+  margin-top: 4px;
 }
 
 .promoTitle {

--- a/support-frontend/assets/components/text/text.scss
+++ b/support-frontend/assets/components/text/text.scss
@@ -36,7 +36,14 @@
 }
 
 .component-text__large {
-  @include gu-fontset-body-large;
+  @include gu-fontset-heading;
+  font-size: 18px;
+  font-weight: 300;
+  line-height: 24px;
+
+  @include mq($from: tablet) {
+    @include gu-fontset-body-large;
+  }
 }
 
 .component-text__sans {

--- a/support-frontend/assets/helpers/billingPeriods.js
+++ b/support-frontend/assets/helpers/billingPeriods.js
@@ -8,14 +8,15 @@ const weeklyBillingPeriods = [SixWeekly, Quarterly, Annual];
 export type BillingPeriod = typeof SixWeekly | typeof Annual | typeof Monthly | typeof Quarterly;
 export type DigitalBillingPeriod = typeof Monthly | typeof Annual;
 export type WeeklyBillingPeriod = typeof SixWeekly | typeof Quarterly | typeof Annual;
+
 export type ContributionBillingPeriod = typeof Monthly | typeof Annual;
 
-function billingPeriodNoun(billingPeriod: BillingPeriod) {
+function billingPeriodNoun(billingPeriod: BillingPeriod, fixedTerm: boolean = false) {
   switch (billingPeriod) {
     case Annual:
-      return 'Year';
+      return fixedTerm ? '12 months' : 'Year';
     case Quarterly:
-      return 'Quarter';
+      return fixedTerm ? '3 months' : 'Quarter';
     case SixWeekly:
       return 'Six issues';
     default:
@@ -23,9 +24,25 @@ function billingPeriodNoun(billingPeriod: BillingPeriod) {
   }
 }
 
-function billingPeriodTitle(billingPeriod: BillingPeriod) {
-  if (billingPeriod === SixWeekly) { return '6 for 6'; }
-  return billingPeriod;
+function billingPeriodTitle(billingPeriod: BillingPeriod, fixedTerm: boolean = false) {
+  switch (billingPeriod) {
+    case Annual:
+      return fixedTerm ? '12 months' : billingPeriod;
+    case Quarterly:
+      return fixedTerm ? '3 months' : billingPeriod;
+    case SixWeekly:
+      return '6 for 6';
+    default:
+      return billingPeriod;
+  }
 }
 
-export { Annual, Monthly, Quarterly, SixWeekly, billingPeriodNoun, billingPeriodTitle, weeklyBillingPeriods };
+export {
+  Annual,
+  Monthly,
+  Quarterly,
+  SixWeekly,
+  billingPeriodNoun,
+  billingPeriodTitle,
+  weeklyBillingPeriods,
+};

--- a/support-frontend/assets/helpers/productPrice/productPrices.js
+++ b/support-frontend/assets/helpers/productPrice/productPrices.js
@@ -28,6 +28,7 @@ import { applyDiscount, getPromotion } from 'helpers/productPrice/promotions';
 export type ProductPrice = {
   price: number,
   currency: IsoCurrency,
+  fixedTerm: boolean,
   promotions?: Promotion[],
 }
 

--- a/support-frontend/assets/helpers/routes.js
+++ b/support-frontend/assets/helpers/routes.js
@@ -35,6 +35,7 @@ const routes: {
   paperSubscriptionLanding: '/subscribe/paper',
   paperSubscriptionProductChoices: '/subscribe/paper#subscribe',
   guardianWeeklySubscriptionLanding: '/subscribe/weekly',
+  guardianWeeklySubscriptionLandingGift: '/subscribe/weekly/gift',
   postcodeLookup: '/postcode-lookup',
   createSignInUrl: '/identity/signin-url',
   createReminder: '/contribute/remind-me',

--- a/support-frontend/assets/helpers/subscriptionsForms/formReducer.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/formReducer.js
@@ -29,7 +29,7 @@ function createFormReducer(
   fulfilmentOption: Option<FulfilmentOptions>,
 ) {
   const user = getUser(); // TODO: Is this unnecessary? It could use the user reducer
-  const { productPrices } = window.guardian;
+  const { productPrices, orderIsAGift } = window.guardian;
 
   const initialState = {
     stage: 'checkout',
@@ -55,7 +55,7 @@ function createFormReducer(
     productOption: productOption || NoProductOptions,
     fulfilmentOption: fulfilmentOption || NoFulfilmentOptions,
     payPalHasLoaded: false,
-    orderIsAGift: false,
+    orderIsAGift,
     stripePaymentMethod: null,
     deliveryInstructions: null,
     debugInfo: '',

--- a/support-frontend/assets/helpers/theGrid.js
+++ b/support-frontend/assets/helpers/theGrid.js
@@ -101,6 +101,9 @@ export const imageCatalogue: {
   digitalSubsDailyMob: '93c8d64b7be3bf455f2f6f57d679c2fdc7df6bf3/0_0_1100_1100',
   digitalSubsApp: '234f5889b07c7c5d088d8d977e9e717ea8f2e791/0_0_1714_1000',
   digitalSubsAppMob: '59d2d83d9c1ecf8b3c955c63bf94ef2fa80c7353/0_0_1100_1100',
+  gwGiftingPackshot: '3d1cecfdc8c90b2005712e56669afe6e3b8c5e5a/762_0_4232_3184',
+  gwGiftingPackshotMob: '3d1cecfdc8c90b2005712e56669afe6e3b8c5e5a/688_87_2481_3102',
+  giftingGlobe: '4a7ee6f430a29fc8ac8d9f0667cfafc67b6aba46/145_148_1203_1201',
 };
 
 // Utility type: https://flow.org/en/docs/types/utilities/#toc-keys

--- a/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLanding.scss
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLanding.scss
@@ -586,14 +586,6 @@
       }
     }
 
-    ul {
-      margin-top: 15px;
-
-      @include mq($from: desktop) {
-        margin-top: 20px;
-      }
-    }
-
     ul:nth-of-type(2) {
       margin-top: 0;
 
@@ -608,44 +600,6 @@
 
       @include mq($from: wide) {
         margin-left: 100px;
-      }
-    }
-
-    li {
-      margin: 0 10px 15px 5px;
-      font-size: 15px;
-      line-height: 20px;
-
-      @include mq($from: tablet) {
-        margin-left: 18px;
-        font-size: 17px;
-      }
-
-      .product-block__list-item--bold {
-        font-weight: 600;
-        margin-left: 8px;
-      }
-
-      .product-block__list-item__explainer {
-        margin-left: 23px;
-        font-size: 14px;
-
-        @include mq($from: tablet) {
-          font-size: 16px;
-        }
-      }
-
-      .product-block__list-item__bullet {
-        width: 13px;
-        height: 13px;
-        border-radius: 50%;
-        background-color: #ffe500;
-        display: inline-block;
-
-        @include mq($from: tablet) {
-          width: 15px;
-        height: 15px;
-        }
       }
     }
   }

--- a/support-frontend/assets/pages/digital-subscription-landing/components/form.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/form.jsx
@@ -29,9 +29,11 @@ const getPrice = (productPrices: ProductPrices, period: DigitalBillingPeriod, co
   const countryGroupId = fromCountry(country);
 
   if (countryGroupId && flashSaleIsActive('DigitalPack', countryGroupId)) {
+    // TODO: this should be using promotions not hard coded prices
     const price: number = Number(getFormattedFlashSalePrice('DigitalPack', countryGroupId, period));
     return {
       price,
+      fixedTerm: false,
       currency: getCurrency(country),
     };
   }

--- a/support-frontend/assets/pages/digital-subscription-landing/components/productBlock.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/productBlock.jsx
@@ -4,6 +4,7 @@ import AdFreeSectionC from 'components/adFreeSectionC/adFreeSectionC';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
 import GridPicture from 'components/gridPicture/gridPicture';
 import cx from 'classnames';
+import { ListHeading } from 'components/productPage/productPageList/productPageList';
 
 // styles
 import './digitalSubscriptionLanding.scss';
@@ -15,22 +16,6 @@ const arrowSvg = (
     <defs><path d="M16 0l1.427 1.428-7.035 7.036.035.035L9 9.927l-.035-.035-.036.035L7.5 8.5l.036-.035L.5 1.428 1.928 0l7.036 7.036L15.999 0z" id="a" /></defs>
     <use fill="#121212" xlinkHref="#a" fillRule="evenodd" />
   </svg>);
-
-type ListPropTypes = {
-  items: Array<Object>,
-}
-
-const List = ({ items }: ListPropTypes) => (
-  <ul>
-    {items.map(item => (
-      <li>
-        <div className="product-block__list-item__bullet" />
-        <span className="product-block__list-item--bold">{item.boldText}</span><br />
-        <div className="product-block__list-item__explainer">{item.explainer}</div>
-      </li>
-    ))}
-  </ul>
-);
 
 type DropdownPropTypes = {
   children: Node,
@@ -180,14 +165,14 @@ class ProductBlock extends Component<PropTypes, StateTypes> {
             showDropDown={state.showDropDownDaily}
             product="daily"
           >
-            <List
+            <ListHeading
               items={[
                 { boldText: 'A new way to read', explainer: 'The newspaper, reimagined for mobile and tablet' },
                 { boldText: 'Published daily', explainer: 'Each edition available to read by 6am (GMT), 7 days a week' },
                 { boldText: 'Easy to navigate', explainer: 'Read the complete edition, or swipe to the sections you care about' },
               ]}
             />
-            <List
+            <ListHeading
               items={[
                 { boldText: 'Multiple devices', explainer: 'Beautifully designed for your mobile or tablet on iOS and Android' },
                 { boldText: 'Read offline', explainer: 'Download and read whenever it suits you' },
@@ -210,14 +195,14 @@ class ProductBlock extends Component<PropTypes, StateTypes> {
             showDropDown={state.showDropDownApp}
             product="app"
           >
-            <List
+            <ListHeading
               items={[
                 { boldText: 'Live', explainer: 'Follow a live feed of breaking news and sport, as it happens' },
                 { boldText: 'Discover', explainer: 'Explore stories you might have missed, tailored to you' },
                 { boldText: 'Enhanced offline reading', explainer: 'Download the news whenever it suits you' },
               ]}
             />
-            <List
+            <ListHeading
               items={[
                 { boldText: 'Daily Crossword', explainer: 'Play the daily crossword wherever you are' },
                 { boldText: 'Ad-free', explainer: 'Enjoy our journalism uninterrupted, without adverts' },

--- a/support-frontend/assets/pages/subscriptions-landing/components/featuredProducts.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/components/featuredProducts.jsx
@@ -8,11 +8,14 @@ import { getQueryParameter } from 'helpers/url';
 import { type SubscriptionProduct } from 'helpers/subscriptions';
 import {
   type CountryGroupId,
+  GBPCountries,
 } from 'helpers/internationalisation/countryGroup';
 import GridPicture from 'components/gridPicture/gridPicture';
 import { flashSaleIsActive, getSaleCopy } from 'helpers/flashSale';
-import { GBPCountries } from 'helpers/internationalisation/countryGroup';
-import { showPrice, type ProductPrice } from 'helpers/productPrice/productPrices';
+import {
+  type ProductPrice,
+  showPrice,
+} from 'helpers/productPrice/productPrices';
 import { fromCountryGroupId } from '../../../helpers/internationalisation/currency';
 
 // ----- Types ----- //
@@ -130,6 +133,7 @@ const getProductHeadingsAndBody = (product: SubscriptionProduct, countryGroupId:
   const maybeCurrency = fromCountryGroupId(countryGroupId);
   const sixPrice: ProductPrice = {
     price: 6,
+    fixedTerm: false,
     currency: maybeCurrency !== null && maybeCurrency !== undefined ? maybeCurrency : 'GBP',
   };
   // if (product === 'GuardianWeekly') {

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/thankYou.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/thankYou.jsx
@@ -30,12 +30,14 @@ import {
   type FormFields,
   getFormFields,
 } from 'helpers/subscriptionsForms/formFields';
+import type { Option } from 'helpers/types/option';
 
 // ----- Types ----- //
 
 type PropTypes = {
     ...FormFields,
     isPending: boolean,
+    orderIsGift: boolean,
 };
 
 
@@ -54,22 +56,66 @@ const getPackageTitle = (billingPeriod) => {
   }
 };
 
+const getHeading = (billingPeriod, isPending, orderIsGift) => {
+  if (orderIsGift) {
+    return isPending ?
+      'Your Guardian Weekly gift subscription is being processed' :
+      'Your purchase of a Guardian Weekly gift subscription is now complete';
+  }
+  const packageTitle = getPackageTitle(billingPeriod);
+  return isPending ?
+    `Your subscription to the Guardian Weekly ${packageTitle} is being processed` :
+    `You have now subscribed to the Guardian Weekly ${packageTitle}`;
+};
+
+const StartDateCopy = ({ startDate, orderIsGift }: {startDate: Option<string>, orderIsGift: boolean}) => {
+  if (startDate) {
+    const title = orderIsGift ?
+      'The gift recipient will receive their first issue on' :
+      'You will receive your first issue on';
+    return (
+      <Text title={title}>
+        <LargeParagraph>{formatUserDate(new Date(startDate))}</LargeParagraph>
+      </Text>);
+  }
+  return null;
+};
 
 function ThankYouContent({
-  billingPeriod, startDate, isPending,
+  billingPeriod, startDate, isPending, orderIsGift,
 }: PropTypes) {
-  const packageTitle = getPackageTitle(billingPeriod);
+
+  const whatHappensNextItems = orderIsGift ?
+    [
+      <span>
+        Look out for an email from us confirming your subscription.
+      </span>,
+      <span>
+        We&apos;re unable to contact the gift recipient directly - make sure to let them know the gift is on its way.
+      </span>,
+      <span>
+        Each copy will be delivered to the gift recipient&apos;s door.{' '}
+        <a className="thank-you-link" href={homeDeliveryUrl}>Here&apos;s a reminder of how home delivery works</a>.
+      </span>,
+    ] :
+    [
+      <span>
+        Look out for an email from us confirming your subscription.
+        It has everything you need to know about how to manage it in the future.
+      </span>,
+      <span>
+        Your magazine will be delivered to your door.{' '}
+        <a className="thank-you-link" href={homeDeliveryUrl}>Here&apos;s a reminder of how home delivery works</a>.
+      </span>,
+    ];
+
+
   return (
     <div className="thank-you-stage">
       <HeroWrapper appearance="custom" className={styles.hero}>
         <HeroImage />
-        <HeadingBlock
-          overheading="Thank you for supporting our journalism!"
-        >
-          {isPending ?
-          `Your subscription to the Guardian Weekly ${packageTitle} is being processed` :
-          `You have now subscribed to the Guardian Weekly ${packageTitle}`
-  }
+        <HeadingBlock overheading="Thank you for supporting our journalism!">
+          {getHeading(billingPeriod, isPending, orderIsGift)}
         </HeadingBlock>
       </HeroWrapper>
       <Content>
@@ -83,22 +129,9 @@ function ThankYouContent({
             </Text>
           )
         }
-        {startDate &&
-          <Text title="You will receive your first issue on">
-            <LargeParagraph>{formatUserDate(new Date(startDate))}</LargeParagraph>
-          </Text>
-        }
+        <StartDateCopy orderIsGift={orderIsGift} startDate={startDate} />
         <Text title="What happens next?">
-          <OrderedList items={[
-            <span>
-              Look out for an email from us confirming your subscription.
-              It has everything you need to know about how to manage it in the future.
-            </span>,
-            <span>
-              Your magazine will be delivered to your door. <a className="thank-you-link" href={homeDeliveryUrl}>Here&apos;s a reminder of how home delivery works</a>.
-            </span>,
-            ]}
-          />
+          <OrderedList items={whatHappensNextItems} />
         </Text>
       </Content>
       <Content>

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckout.scss
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckout.scss
@@ -1,0 +1,16 @@
+@import '~stylesheets/gu-sass/gu-sass';
+
+#weekly-checkout__heading-form-section,
+#weekly-checkout__heading-form-section--second {
+  h1.component-checkout-form-section__heading.component-heading--gift,
+  h2.component-checkout-form-section__heading.component-heading--gift {
+    font-size: 28px;
+    line-height: 28px;
+    margin-bottom: 0;
+
+    @include mq($from: tablet) {
+      font-size: 32px;
+    }
+  }
+}
+

--- a/support-frontend/assets/pages/weekly-subscription-checkout/weeklySubscriptionCheckout.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/weeklySubscriptionCheckout.jsx
@@ -17,7 +17,8 @@ import SubscriptionFaq from 'components/subscriptionFaq/subscriptionFaq';
 import 'stylesheets/skeleton/skeleton.scss';
 import CheckoutStage from 'components/subscriptionCheckouts/stage';
 import ThankYouContent from './components/thankYou';
-import CheckoutForm from './components/weeklyCheckoutForm';
+import WeeklyCheckoutForm from './components/weeklyCheckoutForm';
+import WeeklyCheckoutFormGifting from './components/weeklyCheckoutFormGifting';
 import ConsentBanner from '../../components/consentBanner/consentBanner';
 import type { CommonState } from 'helpers/page/commonReducer';
 import { createWithDeliveryCheckoutReducer } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
@@ -53,6 +54,7 @@ const store = pageInit(
 );
 
 const { countryGroupId } = store.getState().common.internationalisation;
+const { orderIsAGift } = store.getState().page.checkout;
 
 // ----- Render ----- //
 
@@ -72,9 +74,9 @@ const content = (
       }
     >
       <CheckoutStage
-        checkoutForm={<CheckoutForm />}
-        thankYouContentPending={<ThankYouContent isPending />}
-        thankYouContent={<ThankYouContent isPending={false} />}
+        checkoutForm={orderIsAGift ? <WeeklyCheckoutFormGifting /> : <WeeklyCheckoutForm />}
+        thankYouContentPending={<ThankYouContent isPending orderIsGift={orderIsAGift} />}
+        thankYouContent={<ThankYouContent isPending={false} orderIsGift={orderIsAGift} />}
         subscriptionProduct="GuardianWeekly"
       />
       <ConsentBanner />

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.jsx
@@ -8,7 +8,7 @@ import AnchorButton from 'components/button/anchorButton';
 import SvgChevron from 'components/svgs/chevron';
 import GridImage from 'components/gridImage/gridImage';
 import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
-import ProductPagehero
+import ProductPageHero
   from 'components/productPage/productPageHero/productPageHero';
 
 import './weeklyCampaign.scss';
@@ -38,36 +38,88 @@ const HeroImage = () => (
   />
 );
 
-const CampaignHeader = (props: {heading: string}) => (
+const HeroGlobe = () => (
+  <div className="weekly-gifting-hero__globe">
+    <GridImage
+      gridId="giftingGlobe"
+      srcSizes={[1000]}
+      sizes="(max-width: 740px) 1000px"
+      imgType="png"
+      altText=""
+    />
+  </div>
+);
 
-  <ProductPagehero
+const CampaignHeader = (props: {heading: string, orderIsAGift: boolean}) => (
+  <ProductPageHero
     appearance="campaign"
     overheading="Guardian Weekly subscriptions"
     heading={props.heading}
-    modifierClasses={['weekly-campaign']}
-    content={<AnchorButton onClick={sendTrackingEventsOnClick('options_cta_click', 'GuardianWeekly', null)} icon={<SvgChevron />} href="#subscribe">See Subscription options</AnchorButton>}
+    modifierClasses={props.orderIsAGift ? ['weekly-gift'] : ['weekly-campaign']}
+    content={!props.orderIsAGift &&
+      <AnchorButton
+        onClick={sendTrackingEventsOnClick('options_cta_click', 'GuardianWeekly', null)}
+        icon={<SvgChevron />}
+        href="#subscribe"
+      >
+        See Subscription options
+      </AnchorButton>
+    }
     hasCampaign
+    orderIsAGift={props.orderIsAGift}
+    giftImage={<HeroGlobe />}
   >
 
     <div className="weekly-campaign-hero">
-      <div className="weekly-campaign-hero__copy">
-        <h2>The Guardian<br />Weekly</h2>
+      <div className={props.orderIsAGift ? 'weekly-gifting-hero__copy' : 'weekly-campaign-hero__copy'}>
+        {props.orderIsAGift ? (
+          <h2>Give The Guardian Weekly</h2>
+          ) : (
+            <h2>The Guardian<br />Weekly</h2>
+          )
+        }
       </div>
 
-      <div className="weekly-campaign-hero__graphic">
-        <GridImage
-          gridId="weeklyCampaignHeroImg"
-          srcSizes={[1000, 1358]}
-          sizes="(max-width: 740px) 1000px, 1358px"
-          imgType="png"
-          altText="A collection of Guardian Weekly magazines"
-        />
-      </div>
+      {!props.orderIsAGift && (
+        <div className="weekly-campaign-hero__graphic">
+          <GridImage
+            gridId="weeklyCampaignHeroImg"
+            srcSizes={[1000, 1358]}
+            sizes="(max-width: 740px) 1000px, 1358px"
+            imgType="png"
+            altText="A collection of Guardian Weekly magazines"
+          />
+        </div>
+      )}
+
+      {props.orderIsAGift && (
+        <div className="weekly-campaign-hero__graphic weekly-gift-hero--desktop">
+          <GridImage
+            gridId="gwGiftingPackshot"
+            srcSizes={[1000]}
+            sizes="(max-width: 740px) 1000px"
+            imgType="png"
+            altText="A collection of Guardian Weekly magazines"
+          />
+        </div>
+      )}
+
+      {props.orderIsAGift && (
+        <div className="weekly-campaign-hero__graphic weekly-gift-hero--mobile">
+          <GridImage
+            gridId="gwGiftingPackshotMob"
+            srcSizes={[400]}
+            sizes="(max-width: 400px) 400px"
+            imgType="png"
+            altText="A collection of Guardian Weekly magazines"
+          />
+        </div>
+      )}
 
     </div>
 
 
-  </ProductPagehero>
+  </ProductPageHero>
 );
 
 

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/hero/weeklyCampaign.scss
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/hero/weeklyCampaign.scss
@@ -1,11 +1,119 @@
 @import '~stylesheets/gu-sass/gu-sass';
 
 .component-product-page-hero.component-product-page-hero--weekly-campaign {
-  position: relative;
-  box-sizing: border-box;
   background: #283942;
   color: #fff;
+}
 
+.component-product-page-hero.component-product-page-hero--weekly-gift {
+  background: #FBF6EF;
+  color: #333333;
+
+  .weekly-campaign-hero__graphic {
+    padding-top: 0;
+    position: relative;
+    max-height: 100%;
+    height: 100%;
+    max-width: 100%;
+
+    img {
+      height: 100%;
+      max-height: 100%;
+    }
+  }
+
+  .weekly-gift-hero--desktop {
+    display: none;
+
+    @include mq($from: phablet) {
+      display: block;
+    }
+  }
+
+  .weekly-gift-hero--mobile {
+    display: block;
+    img {
+      max-height: calc(100% - 0.5rem);
+    }
+
+    @include mq($from: phablet) {
+      display: none;
+    }
+  }
+
+  .weekly-gifting-hero__copy {
+    width: gu-span(12);
+
+    @include mq($until: desktop) {
+      width: gu-span(8);
+      margin-bottom: 0;
+      h2 {
+        font-size: 34px;
+      }
+    }
+
+    @include mq($until: mobileLandscape) {
+      width: gu-span(1.5);
+      margin-bottom: 0;
+      h2 {
+        font-size: 30px;
+      }
+    }
+
+    @include mq($until: mobileMedium) {
+      h2 {
+        font-size: 22px;
+      }
+    }
+  }
+}
+
+.weekly-gifting-hero__globe {
+  display: none;
+
+  @include mq($from: desktop) {
+    display: block;
+    position: absolute;
+    bottom: 85px;
+    left: -80px;
+    width: 80px;
+    height: 80px;
+    img {
+      width: 100%;
+      height: auto;
+    }
+  }
+
+  @include mq($from: leftCol) {
+    bottom: 105px;
+  }
+
+  @include mq($from: wide) {
+    bottom: 85px;
+    width: 150px;
+    height: 150px;
+    left: -160px;
+  }
+
+  @include mq($from: 1410px) {
+    bottom: 70px;
+    width: 200px;
+    height: 200px;
+    left: -210px;
+  }
+
+  @include mq($from: 1530px) {
+    bottom: 67px;
+    width: 220px;
+    height: 220px;
+    left: -230px;
+  }
+}
+
+.component-product-page-hero.component-product-page-hero--weekly-campaign,
+.component-product-page-hero.component-product-page-hero--weekly-gift {
+  position: relative;
+  box-sizing: border-box;
   max-height: 550px;
 
   & * {
@@ -22,13 +130,24 @@
 }
 
 .weekly-campaign-hero__copy {
+  h2 {
+    color: #fff;
+  }
+}
+
+.weekly-gifting-hero__copy {
+  h2 {
+    color: #333333;
+  }
+}
+
+.weekly-campaign-hero__copy, .weekly-gifting-hero__copy {
   display: block;
   max-width: 50%;
   padding: $gu-v-spacing*2 0 $gu-v-spacing*2 $gu-v-spacing;
-  margin-bottom: auto; 
-  
+  margin-bottom: auto;
+
   h2 {
-    color: #fff;
     font-family: $gu-titlepiece;
     font-size: 34px;
     line-height: 1;
@@ -37,19 +156,19 @@
   @include mq($from: mobileMedium) {
     max-width: 60%;
   }
-  
+
   @include mq($from: mobileLandscape) {
-    margin-bottom: 0; 
+    margin-bottom: 0;
     padding-top: 0;
   }
-  
+
   @include mq($from: phablet) {
-    max-width: gu-span(10);      
+    max-width: gu-span(10);
     h2 {
       font-size: 40px;
     }
   }
-  
+
   @include mq($from: tablet) {
     h2 {
       font-size: 44px;
@@ -61,7 +180,7 @@
       font-size: 50px;
     }
   }
-  
+
   @include mq($from: leftCol) {
     h2 {
       font-size: 56px;
@@ -77,7 +196,7 @@
   width: 100%;
   max-width: 80%;
   padding-top: $gu-v-spacing*2;
-  
+
   img {
     position: absolute;
     bottom: 0;

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyForm.jsx
@@ -1,10 +1,11 @@
 // @flow
 import { connect } from 'react-redux';
 
-import type { WeeklyBillingPeriod } from 'helpers/billingPeriods';
 import {
+  SixWeekly,
   billingPeriodTitle,
   weeklyBillingPeriods,
+  type WeeklyBillingPeriod,
 } from 'helpers/billingPeriods';
 import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
 import ProductPagePlanForm, { type PropTypes } from 'components/productPage/productPagePlanForm/productPagePlanForm';
@@ -21,41 +22,47 @@ import { promoQueryParam } from 'helpers/productPrice/promotions';
 
 // ---- Plans ----- //
 
-const getCheckoutUrl = (billingPeriod: WeeklyBillingPeriod): string => {
+const getCheckoutUrl = (billingPeriod: WeeklyBillingPeriod, orderIsGift: boolean): string => {
   const promoCode = getQueryParameter(promoQueryParam);
   const promoQuery = promoCode ? `&${promoQueryParam}=${promoCode}` : '';
-  return `${getOrigin()}/subscribe/weekly/checkout?period=${billingPeriod.toString()}${promoQuery}`;
+  const gift = orderIsGift ? '/gift' : '';
+  return `${getOrigin()}/subscribe/weekly/checkout${gift}?period=${billingPeriod.toString()}${promoQuery}`;
 };
 
 // ----- State/Props Maps ----- //
 
-const mapStateToProps = (state: State): PropTypes<WeeklyBillingPeriod> => ({
-  plans: weeklyBillingPeriods.reduce((plans, billingPeriod) => {
-    const { countryId } = state.common.internationalisation;
-    const { productPrices } = state.page;
-    const productPrice = productPrices ? getProductPrice(
-      productPrices,
-      countryId,
-      billingPeriod,
-      getWeeklyFulfilmentOption(countryId),
-    ) : { price: 0, currency: 'GBP' };
-    return {
-      ...plans,
-      [billingPeriod]: {
-        title: billingPeriodTitle(billingPeriod),
-        copy: getPriceDescription(
-          productPrice,
-          billingPeriod,
-        ),
-        offer: getAppliedPromoDescription(billingPeriod, productPrice),
-        href: getCheckoutUrl(billingPeriod),
-        onClick: sendTrackingEventsOnClick(`subscribe_now_cta-${billingPeriod}`, 'GuardianWeekly', null),
-        price: null,
-        saving: null,
-      },
-    };
-  }, {}),
-});
+const mapStateToProps = (state: State): PropTypes<WeeklyBillingPeriod> => {
+  const { countryId } = state.common.internationalisation;
+  const { productPrices, orderIsAGift } = state.page;
+  const billingPeriodsToUse = weeklyBillingPeriods.filter(billingPeriod =>
+    !(state.page.orderIsAGift && billingPeriod === SixWeekly));
+
+  return {
+    plans: billingPeriodsToUse.reduce((plans, billingPeriod) => {
+      const productPrice = productPrices ? getProductPrice(
+        productPrices,
+        countryId,
+        billingPeriod,
+        getWeeklyFulfilmentOption(countryId),
+      ) : { price: 0, fixedTerm: false, currency: 'GBP' };
+      return {
+        ...plans,
+        [billingPeriod]: {
+          title: billingPeriodTitle(billingPeriod, orderIsAGift),
+          copy: getPriceDescription(
+            productPrice,
+            billingPeriod,
+          ),
+          offer: getAppliedPromoDescription(billingPeriod, productPrice),
+          href: getCheckoutUrl(billingPeriod, orderIsAGift),
+          onClick: sendTrackingEventsOnClick(`subscribe_now_cta-${billingPeriod}`, 'GuardianWeekly', null),
+          price: null,
+          saving: null,
+        },
+      };
+    }, {}),
+  };
+};
 
 
 // ----- Exports ----- //

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -10,6 +10,7 @@ import Page from 'components/page/page';
 import headerWithCountrySwitcherContainer
   from 'components/headers/header/headerWithCountrySwitcher';
 import Footer from 'components/footer/footer';
+import { List } from 'components/productPage/productPageList/productPageList';
 
 import {
   AUDCountries,
@@ -37,19 +38,20 @@ import 'stylesheets/skeleton/skeleton.scss';
 import { CampaignHeader } from './components/hero/hero';
 
 import WeeklyForm from './components/weeklyForm';
-import type { State } from './weeklySubscriptionLandingReducer';
 import reducer from './weeklySubscriptionLandingReducer';
 import ConsentBanner from 'components/consentBanner/consentBanner';
 
 import './weeklySubscriptionLanding.scss';
 import type { PromotionCopy } from 'helpers/productPrice/promotions';
 import { promoQueryParam } from 'helpers/productPrice/promotions';
-import { promotionTermsUrl } from 'helpers/routes';
+import { promotionTermsUrl, routes } from 'helpers/routes';
 import { getQueryParameter } from 'helpers/url';
+import AnchorButton from 'components/button/anchorButton';
 
 type PageCopy = {|
   title: string,
-  firstParagraph: React.Node
+  firstParagraph: React.Node,
+  priceCardSubHeading: string,
 |};
 
 // ----- Redux Store ----- //
@@ -111,7 +113,7 @@ const getFirstParagraph = (promotionCopy: ?PromotionCopy) => {
     /* eslint-enable react/no-danger */
   }
   return (
-    <LargeParagraph>
+    <LargeParagraph modifierClasses={['mobile-text-resize']}>
       The Guardian Weekly magazine is a round-up of the world news,
       opinion and long reads that have shaped the week. Inside, the past seven days&#39;
       most memorable stories are reframed with striking photography and insightful companion
@@ -119,19 +121,31 @@ const getFirstParagraph = (promotionCopy: ?PromotionCopy) => {
     </LargeParagraph>);
 };
 
-const getCopy = (state: State): PageCopy => {
-  const { promotionCopy } = state.page;
-  const defaultTitle = 'Pause for thought with The Guardian\'s essential news magazine';
+const getCopy = (promotionCopy: Object, orderIsAGift: boolean): PageCopy => {
+  const defaultTitle = orderIsAGift ?
+    'Give a gift that challenges the status quo'
+    : 'Pause for thought with The Guardian\'s essential news magazine';
   return {
     title: promotionCopy && promotionCopy.title ? promotionCopy.title : defaultTitle,
     firstParagraph: getFirstParagraph(promotionCopy),
+    priceCardSubHeading: orderIsAGift ? 'Select a gift period' : 'Choose how you\'d like to pay',
   };
 };
 
 // ----- Render ----- //
 
-const copy = getCopy(store.getState());
+const { promotionCopy, orderIsAGift } = store.getState().page;
+const copy = getCopy(promotionCopy, orderIsAGift);
 const promoTerms = promotionTermsUrl(getQueryParameter(promoQueryParam) || '10ANNUAL');
+
+type GiftHeadingPropTypes = {
+  text: string,
+}
+
+const GiftHeading = (props: GiftHeadingPropTypes) => (
+  <h2 className="component-text">{props.text}</h2>
+);
+
 
 const content = (
   <Provider store={store}>
@@ -139,51 +153,72 @@ const content = (
       header={<Header />}
       footer={<Footer />}
     >
-      <CampaignHeader heading={copy.title} />
+      <CampaignHeader heading={copy.title} orderIsAGift={orderIsAGift} />
       <Content>
         <Text title="Catch up on the issues that matter">
           {copy.firstParagraph}
         </Text>
       </Content>
-      <Content id="benefits">
-        <Text title="As a subscriber you’ll enjoy" />
-        <Outset>
-          <ProductPageFeatures features={[
-            { title: 'Every issue delivered with up to 35% off the cover price' },
-            { title: 'Access to the magazine\'s digital archive' },
-            { title: 'A weekly email newsletter from the editor' },
-            { title: 'The very best of The Guardian\'s puzzles' },
+      {!orderIsAGift &&
+        <Content id="benefits">
+          <Text title="As a subscriber you’ll enjoy" />
+          <Outset>
+            <ProductPageFeatures features={[
+              { title: 'Every issue delivered with up to 35% off the cover price' },
+              { title: 'Access to the magazine\'s digital archive' },
+              { title: 'A weekly email newsletter from the editor' },
+              { title: 'The very best of The Guardian\'s puzzles' },
+            ]}
+            />
+          </Outset>
+        </Content>
+      }
+      {orderIsAGift &&
+        <Content id="gift-benefits-them">
+          <GiftHeading text="What they'll get:" />
+          <List items={[
+            { explainer: 'The Guardian Weekly delivered, wherever they are in the world' },
+            { explainer: 'The Guardian\'s global journalism to keep them informed' },
+            { explainer: 'The very best of The Guardian\'s puzzles' },
           ]}
           />
-        </Outset>
-      </Content>
+        </Content>}
+      {orderIsAGift &&
+        <Content id="gift-benefits-you">
+          <GiftHeading text="What you'll get:" />
+          <List items={[
+            { explainer: 'Your gift supports The Guardian\'s independent journalism' },
+            { explainer: 'Access to the magazine\'s digital archive' },
+            { explainer: '35% off the cover price' },
+          ]}
+          />
+        </Content>
+      }
       <Content appearance="feature" id="subscribe">
         <Text title="Subscribe to Guardian Weekly today">
-          <p>Choose how you’d like to pay</p>
+          <p>{copy.priceCardSubHeading}</p>
         </Text>
         <WeeklyForm />
-        <ProductPageInfoChip icon={<SvgGift />}>
-              Gifting is available
-        </ProductPageInfoChip>
+        {!orderIsAGift &&
+          <ProductPageInfoChip icon={<SvgGift />}>
+                Gifting is available
+          </ProductPageInfoChip>
+        }
         <ProductPageInfoChip icon={<SvgInformation />}>
-              Delivery cost included. You can cancel your subscription at any time
+              Delivery cost included. {!orderIsAGift && 'You can cancel your subscription at any time'}
         </ProductPageInfoChip>
       </Content>
       <Content>
-        <Text title="Gift subscriptions">
-          <LargeParagraph>A Guardian Weekly subscription makes a great gift.
-            To&nbsp;buy&nbsp;one, just select the gift option at checkout or get in touch with your local customer
-            service team:
-          </LargeParagraph>
+        <Text title={orderIsAGift ? 'Looking for a personal subscription?' : 'Gift subscriptions'}>
+          {!orderIsAGift && <LargeParagraph>A Guardian Weekly subscription makes a great gift.</LargeParagraph>}
         </Text>
-        <Outset>
-          <ProductPageFeatures features={[
-            { title: 'UK, Europe and Rest of World', copy: '+44 (0) 330 333 6767' },
-            { title: 'Australia and New Zealand', copy: '+61 2 8076 8599' },
-            { title: 'USA and Canada', copy: '+1 917-900-4663' },
-          ]}
-          />
-        </Outset>
+        <AnchorButton
+          modifierClasses={['with-margin-bottom']}
+          appearance="blue"
+          href={orderIsAGift ? routes.guardianWeeklySubscriptionLanding : routes.guardianWeeklySubscriptionLandingGift}
+        >
+          {orderIsAGift ? 'See all subscriptions' : 'See all gift subscriptions'}
+        </AnchorButton>
       </Content>
       <Content>
         <Text title="Promotion terms and conditions">

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.scss
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.scss
@@ -90,3 +90,18 @@
     }
   }
 }
+
+#gift-benefits-them, #gift-benefits-you {
+  .component-text {
+    @include gu-fontset-heading;
+    overflow-wrap: break-word;
+    margin-bottom: 10px;
+    font-size: 24px;
+    font-weight: 700;
+    line-height: 28px;
+  }
+}
+
+.component-button--with-margin-bottom {
+  margin-bottom: 20px;
+}

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingReducer.js
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLandingReducer.js
@@ -12,11 +12,15 @@ export type State = {
   page: {
     productPrices: ?ProductPrices,
     promotionCopy: ?PromotionCopy,
+    orderIsAGift: boolean,
   }
 };
+
+const { orderIsAGift } = window.guardian;
 
 // ----- Export ----- //
 export default () => ({
   productPrices: getProductPrices(),
   promotionCopy: getPromotionCopy(),
+  orderIsAGift,
 });

--- a/support-frontend/conf/routes
+++ b/support-frontend/conf/routes
@@ -91,10 +91,13 @@ GET  /$country<(uk|us|au|eu|int|nz|ca)>/subscribe/digital/checkout controllers.A
 GET  /subscribe/digital/checkout                                   controllers.DigitalSubscription.displayForm()
 GET  /subscribe/digital/checkout/thankyou-existing                 controllers.DigitalSubscription.displayThankYouExisting()
 
-GET  /weekly                                                       controllers.Subscriptions.weeklyGeoRedirect()
-GET  /subscribe/weekly                                             controllers.Subscriptions.weeklyGeoRedirect()
-GET  /subscribe/weekly/checkout                                    controllers.WeeklySubscription.displayForm()
-GET  /$country<(uk|us|au|int|nz|ca|eu)>/subscribe/weekly           controllers.Subscriptions.weekly(country: String)
+GET  /weekly                                                       controllers.Subscriptions.weeklyGeoRedirect(orderIsAGift: Boolean = false)
+GET  /subscribe/weekly                                             controllers.Subscriptions.weeklyGeoRedirect(orderIsAGift: Boolean = false)
+GET  /subscribe/weekly/gift                                        controllers.Subscriptions.weeklyGeoRedirect(orderIsAGift: Boolean = true)
+GET  /subscribe/weekly/checkout                                    controllers.WeeklySubscription.displayForm(orderIsAGift: Boolean = false)
+GET  /subscribe/weekly/checkout/gift                               controllers.WeeklySubscription.displayForm(orderIsAGift: Boolean = true)
+GET  /$country<(uk|us|au|int|nz|ca|eu)>/subscribe/weekly           controllers.Subscriptions.weekly(country: String, orderIsAGift: Boolean = false)
+GET  /$country<(uk|us|au|int|nz|ca|eu)>/subscribe/weekly/gift      controllers.Subscriptions.weekly(country: String, orderIsAGift: Boolean = true)
 
 GET  /paper                                                        controllers.PaperSubscription.paperMethodRedirect(withDelivery: Boolean = false)
 GET  /subscribe/paper                                              controllers.PaperSubscription.paperMethodRedirect(withDelivery: Boolean = false)

--- a/support-frontend/test/controllers/SubscriptionsTest.scala
+++ b/support-frontend/test/controllers/SubscriptionsTest.scala
@@ -1,8 +1,8 @@
 package controllers
 
 import actions.CustomActionBuilders
-import admin.settings._
 import admin.settings.SwitchState.On
+import admin.settings._
 import assets.RefPath
 import cats.data.EitherT
 import cats.implicits._
@@ -15,12 +15,14 @@ import com.gu.support.promotions.PromoCode
 import com.gu.support.workers.Monthly
 import com.gu.tip.Tip
 import com.typesafe.config.ConfigFactory
-import config.Configuration.{GuardianDomain, MetricUrl}
+import config.Configuration.MetricUrl
 import config.StringsConfig
 import fixtures.TestCSRFComponents
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatest.OptionValues._
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar.mock
 import play.api.mvc.Result
 import play.api.test.FakeRequest
@@ -30,9 +32,6 @@ import services.stepfunctions.SupportWorkersClient
 import services.{AccessCredentials, IdentityService, MembersDataService, TestUserService}
 
 import scala.concurrent.Future
-import org.scalatest.wordspec.AnyWordSpec
-import org.scalatest.matchers.must.Matchers
-import play.api.ConfigLoader
 
 class SubscriptionsTest extends AnyWordSpec with Matchers with TestCSRFComponents {
 
@@ -96,7 +95,7 @@ class SubscriptionsTest extends AnyWordSpec with Matchers with TestCSRFComponent
           Map(NoFulfilmentOptions ->
             Map(NoProductOptions ->
               Map(Monthly ->
-                Map(GBP -> PriceSummary(10, GBP, Nil))))))
+                Map(GBP -> PriceSummary(10, GBP, fixedTerm = false, Nil))))))
       val priceSummaryServiceProvider = mock[PriceSummaryServiceProvider]
       val priceSummaryService = mock[PriceSummaryService]
       when(priceSummaryService.getPrices(any[com.gu.support.catalog.Product], any[List[PromoCode]], any[Boolean])).thenReturn(prices)

--- a/support-models/src/main/scala/com/gu/support/zuora/api/PreviewSubscribeRequest.scala
+++ b/support-models/src/main/scala/com/gu/support/zuora/api/PreviewSubscribeRequest.scala
@@ -26,7 +26,10 @@ object PreviewSubscribeRequest {
           subscribeItem.account.copy(autoPay = false), //this is to work-around bug in Zuora where duplicate mandate would be created in GoCardless
           subscribeItem.billToContact,
           // This hack allows us to preview invoices further into the future (required to get a helpful payment schedule)
-          subscribeItem.subscriptionData.copy(subscription = subscribeItem.subscriptionData.subscription.copy(initialTerm = 24)),
+          if (numberOfBillingPeriodsToPreview > 1)
+            subscribeItem.subscriptionData.copy(subscription = subscribeItem.subscriptionData.subscription.copy(initialTerm = 24))
+          else
+            subscribeItem.subscriptionData,
           subscribeItem.subscribeOptions,
           PreviewOptions(numberOfPeriods = numberOfBillingPeriodsToPreview)
         )

--- a/support-models/src/main/scala/com/gu/support/zuora/api/PreviewSubscribeRequest.scala
+++ b/support-models/src/main/scala/com/gu/support/zuora/api/PreviewSubscribeRequest.scala
@@ -26,10 +26,7 @@ object PreviewSubscribeRequest {
           subscribeItem.account.copy(autoPay = false), //this is to work-around bug in Zuora where duplicate mandate would be created in GoCardless
           subscribeItem.billToContact,
           // This hack allows us to preview invoices further into the future (required to get a helpful payment schedule)
-          if (numberOfBillingPeriodsToPreview > 1)
-            subscribeItem.subscriptionData.copy(subscription = subscribeItem.subscriptionData.subscription.copy(initialTerm = 24))
-          else
-            subscribeItem.subscriptionData,
+          subscribeItem.subscriptionData.copy(subscription = subscribeItem.subscriptionData.subscription.copy(initialTerm = 24)),
           subscribeItem.subscribeOptions,
           PreviewOptions(numberOfPeriods = numberOfBillingPeriodsToPreview)
         )

--- a/support-models/src/main/scala/com/gu/support/zuora/api/PreviewSubscribeRequest.scala
+++ b/support-models/src/main/scala/com/gu/support/zuora/api/PreviewSubscribeRequest.scala
@@ -20,13 +20,14 @@ object PreviewSubscribeRequest {
   implicit val codec: Codec[PreviewSubscribeRequest] = deriveCodec
 
   def fromSubscribe(subscribeItem: SubscribeItem, numberOfBillingPeriodsToPreview: Int): PreviewSubscribeRequest = {
+    val initialTerm = subscribeItem.subscriptionData.subscription.initialTerm
     PreviewSubscribeRequest(
       List(
         PreviewSubscribeItem(
           subscribeItem.account.copy(autoPay = false), //this is to work-around bug in Zuora where duplicate mandate would be created in GoCardless
           subscribeItem.billToContact,
           // This hack allows us to preview invoices further into the future (required to get a helpful payment schedule)
-          subscribeItem.subscriptionData.copy(subscription = subscribeItem.subscriptionData.subscription.copy(initialTerm = 24)),
+          subscribeItem.subscriptionData.copy(subscription = subscribeItem.subscriptionData.subscription.copy(initialTerm = initialTerm * 2)),
           subscribeItem.subscribeOptions,
           PreviewOptions(numberOfPeriods = numberOfBillingPeriodsToPreview)
         )

--- a/support-models/src/main/scala/com/gu/support/zuora/api/response/Responses.scala
+++ b/support-models/src/main/scala/com/gu/support/zuora/api/response/Responses.scala
@@ -194,7 +194,7 @@ case class Charge(serviceStartDate: LocalDate, serviceEndDate: LocalDate, taxAmo
 
 object PreviewSubscribeResponse {
   implicit val decoder: Decoder[PreviewSubscribeResponse] = decapitalizingDecoder[PreviewSubscribeResponse].prepare(_.withFocus(
-    _.mapObject(_.checkKeyExists("invoiceData", Json.fromValues(Vector[Json]())))
+    _.mapObject(_.checkKeyExists("InvoiceData", Json.fromValues(Vector[Json]())))
   ))
   implicit val encoder: Encoder[PreviewSubscribeResponse] = capitalizingEncoder
 }

--- a/support-models/src/main/scala/com/gu/support/zuora/api/response/Responses.scala
+++ b/support-models/src/main/scala/com/gu/support/zuora/api/response/Responses.scala
@@ -1,15 +1,15 @@
 package com.gu.support.zuora.api.response
 
-import com.gu.support.encoding.Codec
-import io.circe.parser._
-import io.circe.syntax._
 import com.gu.support.encoding.Codec._
 import com.gu.support.encoding.CustomCodecs.{decodeLocalTime, encodeLocalTime}
-import com.gu.support.encoding.ErrorJson
+import com.gu.support.encoding.JsonHelpers._
+import com.gu.support.encoding.{Codec, ErrorJson}
 import com.gu.support.workers.exceptions.{RetryException, RetryNone, RetryUnlimited}
 import com.gu.support.zuora.api.PaymentGateway
 import io.circe.Decoder.Result
-import io.circe.{Decoder, HCursor}
+import io.circe.parser._
+import io.circe.syntax._
+import io.circe.{Decoder, Encoder, HCursor, Json}
 import org.joda.time.LocalDate
 
 sealed trait ZuoraResponse {
@@ -193,7 +193,10 @@ object Charge {
 case class Charge(serviceStartDate: LocalDate, serviceEndDate: LocalDate, taxAmount: Double, chargeAmount: Double)
 
 object PreviewSubscribeResponse {
-  implicit val codec: Codec[PreviewSubscribeResponse] = capitalizingCodec
+  implicit val decoder: Decoder[PreviewSubscribeResponse] = decapitalizingDecoder[PreviewSubscribeResponse].prepare(_.withFocus(
+    _.mapObject(_.checkKeyExists("invoiceData", Json.fromValues(Vector[Json]())))
+  ))
+  implicit val encoder: Encoder[PreviewSubscribeResponse] = capitalizingEncoder
 }
 
 case class PreviewSubscribeResponse(invoiceData: List[InvoiceDataItem], success: Boolean) extends ZuoraResponse

--- a/support-models/src/test/scala/com/gu/support/zuora/api/Fixtures.scala
+++ b/support-models/src/test/scala/com/gu/support/zuora/api/Fixtures.scala
@@ -349,39 +349,23 @@ object Fixtures {
       ]
    """
 
-  val previewSubscribeResponse =
+  val previewSubscribeResponseJson =
     """
       [
         {
             "Success": true,
-            "TotalMrr": 0,
             "InvoiceData": [
                 {
                     "InvoiceItem": [
                         {
-                            "ProductId": "2c92a0ff6619bf8901661aa3247c4b1d",
                             "ServiceEndDate": "2020-04-02",
                             "ServiceStartDate": "2020-01-03",
-                            "ChargeDate": "2019-11-25T16:58:01.322+00:00",
-                            "AccountingCode": "Deferred Revenue - Guardian Weekly",
                             "TaxAmount": 0,
-                            "ChargeName": "GW Oct 18 - 3 Month - Domestic",
-                            "UnitPrice": 37.5,
-                            "TaxExemptAmount": 0,
-                            "Quantity": 1,
-                            "ProductRatePlanChargeId": "2c92a00e6dd988e2016df853875d74c6",
                             "ChargeAmount": 37.5
                         }
-                    ],
-                    "Invoice": {
-                        "AccountId": "2c92a0fe6e88007b016ea37fa1fc315a",
-                        "Amount": 37.5,
-                        "TaxAmount": 0,
-                        "AmountWithoutTax": 37.5
-                    }
+                    ]
                 }
-            ],
-            "TotalTcv": 37.5
+            ]
         }
     ]
     """

--- a/support-models/src/test/scala/com/gu/support/zuora/api/Fixtures.scala
+++ b/support-models/src/test/scala/com/gu/support/zuora/api/Fixtures.scala
@@ -341,6 +341,14 @@ object Fixtures {
         }
       ]
    """
+
+  val previewSubscribeResponseAnnual =
+    """
+      [
+        {"Success":true,"TotalMrr":0,"TotalTcv":37.5}
+      ]
+   """
+
   val error =
     """
       {

--- a/support-models/src/test/scala/com/gu/support/zuora/api/Fixtures.scala
+++ b/support-models/src/test/scala/com/gu/support/zuora/api/Fixtures.scala
@@ -342,12 +342,49 @@ object Fixtures {
       ]
    """
 
-  val previewSubscribeResponseAnnual =
+  val previewSubscribeResponseNoInvoice =
     """
       [
         {"Success":true,"TotalMrr":0,"TotalTcv":37.5}
       ]
    """
+
+  val previewSubscribeResponse =
+    """
+      [
+        {
+            "Success": true,
+            "TotalMrr": 0,
+            "InvoiceData": [
+                {
+                    "InvoiceItem": [
+                        {
+                            "ProductId": "2c92a0ff6619bf8901661aa3247c4b1d",
+                            "ServiceEndDate": "2020-04-02",
+                            "ServiceStartDate": "2020-01-03",
+                            "ChargeDate": "2019-11-25T16:58:01.322+00:00",
+                            "AccountingCode": "Deferred Revenue - Guardian Weekly",
+                            "TaxAmount": 0,
+                            "ChargeName": "GW Oct 18 - 3 Month - Domestic",
+                            "UnitPrice": 37.5,
+                            "TaxExemptAmount": 0,
+                            "Quantity": 1,
+                            "ProductRatePlanChargeId": "2c92a00e6dd988e2016df853875d74c6",
+                            "ChargeAmount": 37.5
+                        }
+                    ],
+                    "Invoice": {
+                        "AccountId": "2c92a0fe6e88007b016ea37fa1fc315a",
+                        "Amount": 37.5,
+                        "TaxAmount": 0,
+                        "AmountWithoutTax": 37.5
+                    }
+                }
+            ],
+            "TotalTcv": 37.5
+        }
+    ]
+    """
 
   val error =
     """

--- a/support-models/src/test/scala/com/gu/support/zuora/api/SerialisationSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/zuora/api/SerialisationSpec.scala
@@ -135,7 +135,14 @@ class SerialisationSpec extends FlatSpec with SerialisationTestHelpers with Lazy
   }
 
   "PreviewSubscribeResponse" should "deserialise correctly when there is no invoice data" in {
-    testDecoding[List[PreviewSubscribeResponse]](previewSubscribeResponseAnnual)
+    testDecoding[List[PreviewSubscribeResponse]](previewSubscribeResponseNoInvoice)
+  }
+
+  "PreviewSubscribeResponse" should "deserialise correctly when there is invoice data" in {
+    testDecoding[List[PreviewSubscribeResponse]](previewSubscribeResponse, p => p.headOption.fold
+      (fail())
+      (_.invoiceData.length shouldBe 1)
+    )
   }
 
   "GetAccountResponse" should "deserialise from json" in {

--- a/support-models/src/test/scala/com/gu/support/zuora/api/SerialisationSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/zuora/api/SerialisationSpec.scala
@@ -134,6 +134,10 @@ class SerialisationSpec extends FlatSpec with SerialisationTestHelpers with Lazy
     testDecoding[List[SubscribeResponseAccount]](subscribeResponseAnnual)
   }
 
+  "PreviewSubscribeResponse" should "deserialise correctly when there is no invoice data" in {
+    testDecoding[List[PreviewSubscribeResponse]](previewSubscribeResponseAnnual)
+  }
+
   "GetAccountResponse" should "deserialise from json" in {
     testDecoding[GetAccountResponse](
       Fixtures.getAccountResponse,

--- a/support-models/src/test/scala/com/gu/support/zuora/api/SerialisationSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/zuora/api/SerialisationSpec.scala
@@ -139,10 +139,12 @@ class SerialisationSpec extends FlatSpec with SerialisationTestHelpers with Lazy
   }
 
   "PreviewSubscribeResponse" should "deserialise correctly when there is invoice data" in {
-    testDecoding[List[PreviewSubscribeResponse]](previewSubscribeResponse, p => p.headOption.fold
-      (fail())
-      (_.invoiceData.length shouldBe 1)
-    )
+    testDecoding[List[PreviewSubscribeResponse]](previewSubscribeResponseJson, response => {
+      response.headOption.fold(fail()) { previewSubscribeResponse =>
+        previewSubscribeResponse.invoiceData.length shouldBe 1
+      }
+      response.asJson shouldBe parse(previewSubscribeResponseJson).right.get
+    })
   }
 
   "GetAccountResponse" should "deserialise from json" in {

--- a/support-rest/src/main/scala/com/gu/rest/WebServiceHelper.scala
+++ b/support-rest/src/main/scala/com/gu/rest/WebServiceHelper.scala
@@ -85,7 +85,7 @@ trait WebServiceHelper[Error <: Throwable] {
       contentType <- Option(body.contentType()).toRight(WebServiceHelperError(CodeBody(code, ""), "no content type")).toTry
       responseBody <- Try(body.string())
       codeBody = CodeBody(code, responseBody)
-      _ = SafeLogger.info(s"response $code body: ${responseBody.length} bytes")
+      _ = SafeLogger.info(s"response $code body: ${responseBody}")
       _ <-
         if ((contentType.`type`(), contentType.subtype()) == ("application", "json")) Success(())
         else Failure(WebServiceHelperError(codeBody, s"wrong content type"))

--- a/support-rest/src/main/scala/com/gu/rest/WebServiceHelper.scala
+++ b/support-rest/src/main/scala/com/gu/rest/WebServiceHelper.scala
@@ -104,11 +104,11 @@ trait WebServiceHelper[Error <: Throwable] {
       case "2xx" =>
         decode[A](responseBody).left.map { err =>
           decodeError(responseBody).right.getOrElse(
-            WebServiceHelperError[A](codeBody, s"failed to parse response: $err", err)
+            WebServiceHelperError[A](codeBody, s"failed to parse response. Error was: $err, Response was: $responseBody", err)
           )
         }.toTry
       case "4xx" =>
-        Failure((decodeError(responseBody).right.toOption).getOrElse(
+        Failure(decodeError(responseBody).right.toOption.getOrElse(
           WebServiceClientError(codeBody))
         )
       case statusCode =>
@@ -138,6 +138,7 @@ trait WebServiceHelper[Error <: Throwable] {
     params: ParamMap = empty
   )(implicit reads: Decoder[A], error: Decoder[Error], ctag: ClassTag[A]): Future[A] = {
     val json = data.pretty(Printer.noSpaces.copy(dropNullValues = true))
+    SafeLogger.info(s"Issuing request POST $endpoint $json")
     val body = RequestBody.create(MediaType.parse("application/json; charset=utf-8"), json)
     request[A](buildRequest(endpoint, headers, params).post(body))
   }

--- a/support-services/src/main/scala/com/gu/support/pricing/PriceSummary.scala
+++ b/support-services/src/main/scala/com/gu/support/pricing/PriceSummary.scala
@@ -7,6 +7,7 @@ import com.gu.support.promotions._
 case class PriceSummary(
   price: BigDecimal,
   currency: Currency,
+  fixedTerm: Boolean,
   promotions: List[PromotionSummary]
 )
 

--- a/support-services/src/main/scala/com/gu/support/pricing/PriceSummaryService.scala
+++ b/support-services/src/main/scala/com/gu/support/pricing/PriceSummaryService.scala
@@ -64,6 +64,7 @@ class PriceSummaryService(promotionService: PromotionService, catalogService: Ca
     price.currency -> PriceSummary(
       price.value,
       price.currency,
+      productRatePlan.fixedTerm,
       promotionSummaries
     )
   }

--- a/support-workers/src/main/scala/com/gu/emailservices/GuardianWeeklyEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/GuardianWeeklyEmailFields.scala
@@ -8,6 +8,8 @@ import com.gu.support.promotions.Promotion
 import com.gu.support.workers._
 import org.joda.time.LocalDate
 
+import scala.collection.immutable
+
 case class GuardianWeeklyEmailFields(
   subscriptionNumber: String,
   fulfilmentOptions: FulfilmentOptions,
@@ -23,9 +25,9 @@ case class GuardianWeeklyEmailFields(
   giftRecipient: Option[GiftRecipient] = None
 ) extends EmailFields {
 
-  val additionalFields = List(
-    paymentSchedule.payments.lift(1).map(payment => "date_of_second_payment" -> formatDate(payment.date))
-  )
+  val additionalFields: immutable.Seq[(String, String)] = paymentSchedule.payments.lift(1).map(
+    payment => List("date_of_second_payment" -> formatDate(payment.date))
+  ).getOrElse(Nil)
 
   override val fields: List[(String, String)] = PaperFieldsGenerator.fieldsFor(
     subscriptionNumber,
@@ -39,7 +41,7 @@ case class GuardianWeeklyEmailFields(
     directDebitMandateId,
     promotion,
     giftRecipient
-  ) ++ additionalFields.flatten
+  ) ++ additionalFields
 
   override def payload: String = super.payload(user.primaryEmailAddress, "guardian-weekly")
   override def userId: Either[SfContactId, IdentityUserId] = Left(sfContactId)

--- a/support-workers/src/main/scala/com/gu/emailservices/PaperFieldsGenerator.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/PaperFieldsGenerator.scala
@@ -45,7 +45,7 @@ object PaperFieldsGenerator {
       "last_name" -> user.lastName,
       "date_of_first_paper" -> SubscriptionEmailFieldHelpers.formatDate(firstDeliveryDate.getOrElse(firstPaymentDate)),
       "date_of_first_payment" -> SubscriptionEmailFieldHelpers.formatDate(firstPaymentDate),
-      "subscription_rate" -> SubscriptionEmailFieldHelpers.describe(paymentSchedule, billingPeriod, currency, promotion)
+      "subscription_rate" -> SubscriptionEmailFieldHelpers.describe(paymentSchedule, billingPeriod, currency, promotion, giftRecipient.isDefined)
     ) ++ paymentFields ++ deliveryAddressFields ++ giftRecipientFields
 
     fields

--- a/support-workers/src/main/scala/com/gu/support/workers/PreviewPaymentSchedule.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/PreviewPaymentSchedule.scala
@@ -5,8 +5,8 @@ import com.gu.support.zuora.api.response.{Charge, PreviewSubscribeResponse}
 import com.gu.support.zuora.api.{PreviewSubscribeRequest, SubscribeItem}
 import org.joda.time.LocalDate
 
-import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 object PreviewPaymentSchedule {
 

--- a/support-workers/src/main/scala/com/gu/zuora/ProductSubscriptionBuilders.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/ProductSubscriptionBuilders.scala
@@ -20,7 +20,7 @@ import scala.util.{Failure, Success, Try}
 
 object ProductSubscriptionBuilders {
 
-  val allowFixedTermSubs = false // Feature flag to allow us to merge without switching to the new behaviour
+  val allowFixedTermSubs = true // TODO: remove this flag once we're live
 
   def validateRatePlan(maybeProductRatePlan: Option[ProductRatePlan[catalog.Product]], productDescription: String): ProductRatePlanId =
     maybeProductRatePlan.map(_.id) match {

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
@@ -3,12 +3,12 @@ package com.gu.support.workers.integration
 import java.io.ByteArrayOutputStream
 
 import com.amazonaws.services.sqs.model.SendMessageResult
-import com.gu.emailservices.{ContributionEmailFields, DigitalPackEmailFields, EmailService, PaperEmailFields}
+import com.gu.emailservices._
 import com.gu.i18n.Country.UK
 import com.gu.i18n.Currency.GBP
 import com.gu.i18n.{Country, Currency}
 import com.gu.salesforce.Salesforce.SfContactId
-import com.gu.support.catalog.{Collection, Saturday}
+import com.gu.support.catalog.{Collection, Domestic, Saturday}
 import com.gu.support.workers.JsonFixtures.{thankYouEmailJson, wrapFixture}
 import com.gu.support.workers._
 import com.gu.support.workers.encoding.Conversions.FromOutputStream
@@ -82,11 +82,14 @@ object SendThankYouEmailManualTest {
 
   //This test will send a thank you email to the address below - useful for quickly testing changes
   val addressToSendTo = "rupert.bates+unitTest@theguardian.com"
+  val salesforceContactId = SfContactId("0033E00001BRKTTQA5")
 
   def main(args: Array[String]): Unit = {
     sendContributionEmail()
     sendDigitalPackEmail()
     sendPaperSubscriptionEmail()
+    sendWeeklySubscriptionEmail()
+    sendWeeklySubscriptionGiftEmail()
   }
 
   def sendContributionEmail() {
@@ -96,7 +99,7 @@ object SendThankYouEmailManualTest {
       new DateTime(1999, 12, 31, 11, 59),
       20,
       Currency.GBP,
-      "UK", "", Monthly, SfContactId("0036E00000WK8fDQAT"), directDebitPaymentMethod, Some(mandateId)
+      "UK", "", Monthly, salesforceContactId, directDebitPaymentMethod, Some(mandateId)
     )
     val service = new EmailService
     service.send(ef)
@@ -113,7 +116,7 @@ object SendThankYouEmailManualTest {
       PaymentSchedule(List(Payment(new LocalDate(2019, 1, 14), 119.90))),
       GBP,
       directDebitPaymentMethod,
-      SfContactId("0036E00000WK8fDQAT"),
+      salesforceContactId,
       Some(mandateId)
     )
     val service = new EmailService
@@ -149,8 +152,82 @@ object SendThankYouEmailManualTest {
       Some(new LocalDate(2019, 3, 26)),
       GBP,
       directDebitPaymentMethod,
-      SfContactId("0036E00000WK8fDQAT"),
+      salesforceContactId,
       Some(mandateId)
+    )
+    val service = new EmailService
+    service.send(ef)
+  }
+
+  def sendWeeklySubscriptionEmail() {
+    val mandateId = "65HK26E"
+    val billingAddressWithCountry = Address(
+      lineOne = Some("90 York Way"),
+      lineTwo = None,
+      city = Some("London"),
+      state = None,
+      postCode = Some("N1 9AG"),
+      country = UK
+    )
+    val user = User(
+      "1234",
+      addressToSendTo,
+      None,
+      "Mickey",
+      "Mouse",
+      billingAddress = billingAddressWithCountry,
+      deliveryAddress = Some(billingAddressWithCountry)
+    )
+    val ef = GuardianWeeklyEmailFields(
+      "A-S00045678",
+      Domestic,
+      Quarterly,
+      user,
+      PaymentSchedule(List(
+        Payment(new LocalDate(2019, 3, 25), 37.50),
+        Payment(new LocalDate(2019, 6, 25), 37.50)
+      )),
+      Some(new LocalDate(2019, 3, 26)),
+      GBP,
+      directDebitPaymentMethod,
+      salesforceContactId,
+      Some(mandateId),
+    )
+    val service = new EmailService
+    service.send(ef)
+  }
+
+  def sendWeeklySubscriptionGiftEmail() {
+    val mandateId = "65HK26E"
+    val billingAddressWithCountry = Address(
+      lineOne = Some("90 York Way"),
+      lineTwo = None,
+      city = Some("London"),
+      state = None,
+      postCode = Some("N1 9AG"),
+      country = UK
+    )
+    val user = User(
+      "1234",
+      addressToSendTo,
+      None,
+      "Mickey",
+      "Mouse",
+      billingAddress = billingAddressWithCountry,
+      deliveryAddress = Some(billingAddressWithCountry)
+    )
+    val ef = GuardianWeeklyEmailFields(
+      "A-S00045678",
+      Domestic,
+      Quarterly,
+      user,
+      PaymentSchedule(List(Payment(new LocalDate(2019, 3, 25), 37.50))),
+      Some(new LocalDate(2019, 3, 26)),
+      GBP,
+      directDebitPaymentMethod,
+      salesforceContactId,
+      Some(mandateId),
+      giftRecipient = Some(GiftRecipient(None, "Earl", "Palmer", None))
     )
     val service = new EmailService
     service.send(ef)
@@ -168,7 +245,7 @@ object TestData {
     bankTransferAccountNumber = "55779911",
     country = Country.UK,
     city = Some("London"),
-    postalCode = Some("post cde"),
+    postalCode = Some("post code"),
     state = None,
     streetName = Some("streetname"),
     streetNumber = Some("123")


### PR DESCRIPTION
Reverts guardian/support-frontend#2245

The bug this time was because the preview functionality sets the term length to '24' for the purposes of retrieving invoice data. This made sense for recurring subscriptions where the term type is set in months, however for fixed term subscriptions the term has to be set in days so setting it to 24 days meant that often the first delivery date (contract acceptance date) is after the end of the subscription term which is an error and meant that Zuora returned no invoice data. This in turn caused the email to fail because it couldn't find a value for the amount paid.