### PR TITLE
Regionalise DP landing page and showcase WRT daily for Australia

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-landing/components/productBlock.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/productBlock.jsx
@@ -1,9 +1,11 @@
+/* eslint-disable react/no-unused-prop-types */
 // @flow
 import React, { Component, type Node } from 'react';
 import AdFreeSectionC from 'components/adFreeSectionC/adFreeSectionC';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
 import GridPicture from 'components/gridPicture/gridPicture';
 import cx from 'classnames';
+import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 // styles
 import './digitalSubscriptionLanding.scss';
@@ -145,8 +147,11 @@ type StateTypes = {
   showDropDownApp: boolean,
 }
 
-// This is an empty declaration because there were errors without it being passed in
-type PropTypes = {}
+
+type PropTypes = {
+  // eslint-ignore no-unused-prop-types
+  countryGroupId: CountryGroupId,
+}
 
 class ProductBlock extends Component<PropTypes, StateTypes> {
   constructor(props: PropTypes) {
@@ -166,13 +171,13 @@ class ProductBlock extends Component<PropTypes, StateTypes> {
   }
 
   render() {
-    const { state } = this;
+    const { state, props } = this;
     return (
       <div className="hope-is-power__products">
         <section className="product-block__container hope-is-power--centered">
           <div className="product-block__container__label--top">What&apos;s included?</div>
           <ProductCard
-            title="The Guardian Daily"
+            title={props.countryGroupId === 'AUDCountries' ? 'The UK Guardian Daily' : 'The Guardian Daily'}
             subtitle={<span className="product-block__item__subtitle--short-first">Each day&apos;s edition, in one simple, elegant app</span>}
             image={dailyImage}
           />
@@ -182,7 +187,12 @@ class ProductBlock extends Component<PropTypes, StateTypes> {
           >
             <List
               items={[
-                { boldText: 'A new way to read', explainer: 'The newspaper, reimagined for mobile and tablet' },
+                {
+                  boldText: 'A new way to read',
+                  explainer: props.countryGroupId === 'AUDCountries'
+                    ? 'The UK newspaper, reimagined for mobile and tablet'
+                    : 'The newspaper, reimagined for mobile and tablet',
+                },
                 { boldText: 'Published daily', explainer: 'Each edition available to read by 6am (GMT), 7 days a week' },
                 { boldText: 'Easy to navigate', explainer: 'Read the complete edition, or swipe to the sections you care about' },
               ]}

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -88,7 +88,7 @@ function LandingPage() {
         </FooterCentered>}
     >
       <CampaignHeader countryGroupId={countryGroupId} />
-      <ProductBlock />
+      <ProductBlock countryGroupId={countryGroupId} />
       <CallToAction />
       <TermsAndConditions />
       <ConsentBanner />

--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
@@ -94,7 +94,9 @@ const chooseImage = images =>
 const digital: ProductCopy = {
   title: 'Digital Subscription',
   subtitle: getPrice(DigitalPack, ''),
-  description: 'The Guardian Daily, Premium access to The Guardian Live app and ad-free reading on theguardian.com',
+  description: countryGroupId === 'AUDCountries'
+    ? 'The UK Guardian Daily, Premium access to The Guardian Live app and ad-free reading on theguardian.com'
+    : 'The Guardian Daily, Premium access to The Guardian Live app and ad-free reading on theguardian.com',
   productImage: chooseImage([<SubscriptionDailyPackshot />, <InternationalDailyPackshot />]),
   offer: getSaleCopy(DigitalPack, countryGroupId).bundle.subHeading,
   buttons: [{


### PR DESCRIPTION
## Why are you doing this?
It is confusing for Australians to see 'The newspaper' and 'The Guardian Daily' so we're changing the text to be  'The UK newspaper' and 'The UK Guardian Daily' when the country selected is Australia.

[**Trello Card**](https://trello.com/c/1hsBY1Bl/2753-aus-digital-subs-amends-showcase-and-landing)

## Screenshots
![Screen Shot 2019-11-26 at 15 58 26](https://user-images.githubusercontent.com/16781258/69649926-b30df880-1065-11ea-82df-bbac30c97e5b.png)
![Screen Shot 2019-11-26 at 15 58 35](https://user-images.githubusercontent.com/16781258/69649931-b608e900-1065-11ea-9efd-c6d397e11113.png)
![Screen Shot 2019-11-26 at 15 58 54](https://user-images.githubusercontent.com/16781258/69649939-b903d980-1065-11ea-9837-5fc799bfd8d1.png)
