### PR TITLE
Always fire Stripe Payment Request button event

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
@@ -84,6 +84,7 @@ type PropTypes = {|
   createStripePaymentMethod: () => void,
   paymentSecuritySecureTransactionGreyNonUKVariant: paymentSecuritySecureTransactionGreyNonUKVariants,
   recurringStripePaymentRequestButtonTestVariant: RecurringStripePaymentRequestButtonTestVariants,
+  recurringTestVariant: RecurringStripePaymentRequestButtonTestVariants,
 |};
 
 // We only want to use the user state value if the form state value has not been changed since it was initialised,

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
@@ -84,7 +84,6 @@ type PropTypes = {|
   createStripePaymentMethod: () => void,
   paymentSecuritySecureTransactionGreyNonUKVariant: paymentSecuritySecureTransactionGreyNonUKVariants,
   recurringStripePaymentRequestButtonTestVariant: RecurringStripePaymentRequestButtonTestVariants,
-  recurringTestVariant: RecurringStripePaymentRequestButtonTestVariants,
 |};
 
 // We only want to use the user state value if the form state value has not been changed since it was initialised,

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -275,8 +275,11 @@ function initialisePaymentRequest(props: PropTypes) {
     const paymentMethod = availablePaymentRequestButtonPaymentMethod(result);
     if (paymentMethod !== null) {
       trackComponentClick(`${paymentMethod}-loaded`);
-      setUpPaymentListener(props, paymentRequest, paymentMethod);
-      props.setPaymentRequestButtonPaymentMethod(paymentMethod, props.stripeAccount);
+
+      if (props.contributionType === 'ONE_OFF' || props.recurringTestVariant === 'paymentRequestButton') {
+        setUpPaymentListener(props, paymentRequest, paymentMethod);
+        props.setPaymentRequestButtonPaymentMethod(paymentMethod, props.stripeAccount);
+      }
     } else {
       props.setPaymentRequestButtonPaymentMethod('none', props.stripeAccount);
     }

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -59,6 +59,7 @@ import type { StripeAccount } from 'helpers/paymentIntegrations/stripeCheckout';
 import type { ErrorReason } from 'helpers/errorReasons';
 import GeneralErrorMessage
   from 'components/generalErrorMessage/generalErrorMessage';
+import type {RecurringStripePaymentRequestButtonTestVariants} from "helpers/abTests/abtestDefinitions";
 
 // ----- Types -----//
 
@@ -88,6 +89,7 @@ type PropTypes = {|
   stripeAccount: StripeAccount,
   setPaymentWaiting: (isWaiting: boolean) => Action,
   setError: (error: ErrorReason, stripeAccount: StripeAccount) => Action,
+  recurringTestVariant: RecurringStripePaymentRequestButtonTestVariants,
 |};
 
 const mapStateToProps = (state: State, ownProps: PropTypes) => ({

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
@@ -38,9 +38,6 @@ type PropTypes = {|
   recurringTestVariant: RecurringStripePaymentRequestButtonTestVariants,
 |};
 
-const enabledForRecurring = (recurringTestVariant: RecurringStripePaymentRequestButtonTestVariants): boolean =>
-  recurringTestVariant === 'paymentRequestButton';
-
 // ----- Component ----- //
 
 class StripePaymentRequestButtonContainer extends React.Component<PropTypes, void> {
@@ -50,9 +47,7 @@ class StripePaymentRequestButtonContainer extends React.Component<PropTypes, voi
   }
 
   render() {
-    const showStripePaymentRequestButton =
-      isInStripePaymentRequestAllowedCountries(this.props.country) &&
-      (this.props.contributionType === 'ONE_OFF' || enabledForRecurring(this.props.recurringTestVariant));
+    const showStripePaymentRequestButton = isInStripePaymentRequestAllowedCountries(this.props.country);
 
     if (showStripePaymentRequestButton && this.props.stripeHasLoaded) {
       const stripeAccount = stripeAccountForContributionType[this.props.contributionType];
@@ -73,6 +68,7 @@ class StripePaymentRequestButtonContainer extends React.Component<PropTypes, voi
               <StripePaymentRequestButton
                 stripeAccount={stripeAccount}
                 amount={amount}
+                recurringTestVariant={this.props.recurringTestVariant}
               />
             </Elements>
           </StripeProvider>


### PR DESCRIPTION
We are currently running a test for the Payment Request button (and apple pay button) for recurring contributions.
The control does not see the button.
Only some users are able to see the button because it depends on their browser and if they have payments set up. So for the test analysis we need the ability to filter both the control and the variant for only people who can see the button.

This change ensures that the Stripe button is initialised, even if the user is in the control and will not actually see it. This is so that we send an ophan event to indicate that they _could_ see it.
This cannot be done at the time that they're assigned to the test, because we do not know until later on if their browser supports the button.