### PR TITLE
Log lambda execution results to Elasticsearch

### DIFF
--- a/support-models/src/main/scala/com/gu/support/encoding/JsonHelpers.scala
+++ b/support-models/src/main/scala/com/gu/support/encoding/JsonHelpers.scala
@@ -25,6 +25,15 @@ object JsonHelpers {
         .remove(key)
         .add(key, json)
 
+    def unNest(parentKey: String, childKey: String): JsonObject = {
+      val newObject = for {
+        parent <- jsonObject(parentKey)
+        parentObject <- parent.asObject
+        child <- parentObject(childKey)
+      } yield jsonObject.add(childKey, child)
+      newObject.getOrElse(jsonObject)
+    }
+
     def removeIfNull(key: String): JsonObject =
       jsonObject(key)
         .filter(_ == Json.Null)

--- a/support-models/src/main/scala/com/gu/support/workers/PaymentFields.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/PaymentFields.scala
@@ -3,8 +3,8 @@ package com.gu.support.workers
 import cats.syntax.functor._
 import com.gu.support.encoding.Codec
 import com.gu.support.encoding.Codec.deriveCodec
-import io.circe.{Encoder, _}
 import io.circe.syntax._
+import io.circe.{Encoder, _}
 
 sealed trait PaymentFields
 
@@ -12,7 +12,9 @@ sealed trait PaymentFields
 case class PayPalPaymentFields(baid: String) extends PaymentFields
 
 
-sealed trait StripePaymentFields extends PaymentFields
+sealed trait StripePaymentFields extends PaymentFields {
+  val stripePaymentType: Option[StripePaymentType]
+}
 
 case class StripeSourcePaymentFields(
   stripeToken: String,
@@ -80,7 +82,7 @@ object PaymentFields {
   final def or[A, AA >: A](a: Decoder[A], d: => Decoder[AA]): Decoder[AA] = new Decoder[AA] {
     final def apply(c: HCursor): Decoder.Result[AA] = a(c) match {
       case r @ Right(_) => r
-      case Left(err)      => d(c).left.map { (decodingFailure: DecodingFailure) =>
+      case Left(err)      => d(c).left.map { decodingFailure: DecodingFailure =>
         DecodingFailure(err.message + " OR " + decodingFailure.message, err.history ++ decodingFailure.history)
       }
     }

--- a/support-models/src/main/scala/com/gu/support/workers/Products.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/Products.scala
@@ -7,7 +7,7 @@ import com.gu.support.catalog.{FulfilmentOptions, ProductOptions}
 import com.gu.support.encoding.Codec
 import com.gu.support.encoding.Codec.deriveCodec
 import io.circe.syntax._
-import io.circe.{Decoder, Encoder}
+import io.circe.{Decoder, Encoder, Json}
 
 
 sealed trait ProductType {
@@ -63,10 +63,10 @@ object ProductType {
   implicit val codecGuardianWeekly: Codec[GuardianWeekly] = deriveCodec
 
   implicit val encodeProduct: Encoder[ProductType] = Encoder.instance {
-    case d: DigitalPack => d.asJson
-    case c: Contribution => c.asJson
-    case p: Paper => p.asJson
-    case g: GuardianWeekly => g.asJson
+    case d: DigitalPack => d.asJson.asObject.map(_.add("productType", Json.fromString("DigitalPack"))).asJson
+    case c: Contribution => c.asJson.asObject.map( _.add("productType", Json.fromString("Contribution"))).asJson
+    case p: Paper => p.asJson.asObject.map(_.add("productType", Json.fromString("Paper"))).asJson
+    case g: GuardianWeekly => g.asJson.asObject.map(_.add("productType", Json.fromString("GuardianWeekly"))).asJson
   }
 
   implicit val decodeProduct: Decoder[ProductType] =

--- a/support-models/src/main/scala/com/gu/support/workers/states/FailureHandlerState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/FailureHandlerState.scala
@@ -2,16 +2,24 @@ package com.gu.support.workers.states
 
 import java.util.UUID
 
+import com.gu.support.promotions.PromoCode
 import com.gu.support.workers.{User, _}
+import org.joda.time.LocalDate
 
 case class FailureHandlerState(
   requestId: UUID,
   user: User,
-  product: ProductType
+  giftRecipient: Option[GiftRecipient],
+  product: ProductType,
+  paymentFields: Option[PaymentFields], //Will be present if CreatePaymentMethod failed
+  paymentMethod: Option[PaymentMethod], //Will be present if anything after CreatePaymentMethod failed
+  firstDeliveryDate: Option[LocalDate],
+  promoCode: Option[PromoCode]
 ) extends StepFunctionUserState
 
 import com.gu.support.encoding.Codec
 import com.gu.support.encoding.Codec._
+import com.gu.support.encoding.CustomCodecs.{decodeLocalTime, encodeLocalTime}
 
 object FailureHandlerState {
   implicit val codec: Codec[FailureHandlerState] = deriveCodec

--- a/support-models/src/main/scala/com/gu/support/workers/states/SendAcquisitionEventState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/SendAcquisitionEventState.scala
@@ -2,6 +2,7 @@ package com.gu.support.workers.states
 
 import java.util.UUID
 
+import com.gu.support.encoding.CustomCodecs._
 import com.gu.support.promotions.PromoCode
 import com.gu.support.workers.{PaymentMethod, User, _}
 import org.joda.time.LocalDate

--- a/support-models/src/main/scala/com/gu/support/workers/states/SendAcquisitionEventState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/SendAcquisitionEventState.scala
@@ -1,13 +1,18 @@
 package com.gu.support.workers.states
 
+import java.util.UUID
+
 import com.gu.support.promotions.PromoCode
 import com.gu.support.workers.{PaymentMethod, User, _}
+import org.joda.time.LocalDate
 
 case class SendAcquisitionEventState(
+  requestId: UUID,
   user: User,
   giftRecipient: Option[GiftRecipient],
   product: ProductType,
   paymentMethod: PaymentMethod,
+  firstDeliveryDate: Option[LocalDate],
   promoCode: Option[PromoCode],
   acquisitionData: Option[AcquisitionData]
 ) extends StepFunctionUserState

--- a/support-models/src/test/scala/com/gu/support/workers/SerialisationSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/workers/SerialisationSpec.scala
@@ -5,7 +5,7 @@ import com.gu.support.SerialisationTestHelpers
 import com.gu.support.catalog.RestOfWorld
 import com.gu.support.encoding.CustomCodecs._
 import com.gu.support.workers.Fixtures._
-import com.gu.support.workers.states.{CreatePaymentMethodState, CreateSalesforceContactState, CreateZuoraSubscriptionState, SendThankYouEmailState}
+import com.gu.support.workers.states._
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.generic.auto._
 import org.scalatest.FlatSpec
@@ -44,6 +44,15 @@ class SerialisationSpec extends FlatSpec with SerialisationTestHelpers with Lazy
 
   "SendThankYouEmailState" should "deserialise correctly" in {
     testDecoding[SendThankYouEmailState](thankYouEmailJson())
+  }
+
+  "FailureHandlerState" should "deserialise correctly from any lambda" in {
+    testDecoding[FailureHandlerState](createPayPalPaymentMethodDigitalPackJson,
+      state => state.paymentFields.isDefined shouldBe true
+    )
+    testDecoding[FailureHandlerState](createContributionZuoraSubscriptionJson(Annual),
+      state => state.paymentMethod.isDefined shouldBe true
+    )
   }
 
 }

--- a/support-workers/elasticsearch/cloudWatchToElasticSearchLambda.js
+++ b/support-workers/elasticsearch/cloudWatchToElasticSearchLambda.js
@@ -1,0 +1,261 @@
+// v1.1.2
+var https = require('https');
+var zlib = require('zlib');
+var crypto = require('crypto');
+
+var endpoint = 'vpc-support-elk-domain-vcesheatvi6xspmp4sd6dnfkq4.eu-west-1.es.amazonaws.com';
+
+// Set this to true if you want to debug why data isn't making it to
+// your Elasticsearch cluster. This will enable logging of failed items
+// to CloudWatch Logs.
+var logFailedResponses = false;
+
+exports.handler = function(input, context) {
+  // decode input from base64
+  var zippedInput = new Buffer.from(input.awslogs.data, 'base64');
+
+  // decompress the input
+  zlib.gunzip(zippedInput, function(error, buffer) {
+    if (error) { context.fail(error); return; }
+
+    // parse the input from JSON
+    var awslogsData = JSON.parse(buffer.toString('utf8'));
+
+    // transform the input to Elasticsearch documents
+    var elasticsearchBulkData = transform(awslogsData);
+
+    // skip control messages
+    if (!elasticsearchBulkData) {
+      console.log('Received a control message');
+      context.succeed('Control message handled successfully');
+      return;
+    }
+
+    // post documents to the Amazon Elasticsearch Service
+    post(elasticsearchBulkData, function(error, success, statusCode, failedItems) {
+      console.log('Response: ' + JSON.stringify({
+        "statusCode": statusCode
+      }));
+
+      if (error) {
+        logFailure(error, failedItems);
+        context.fail(JSON.stringify(error));
+      } else {
+        console.log('Success: ' + JSON.stringify(success));
+        context.succeed('Success');
+      }
+    });
+  });
+};
+
+function transform(payload) {
+  if (payload.messageType === 'CONTROL_MESSAGE') {
+    return null;
+  }
+
+  var bulkRequestBody = '';
+
+  payload.logEvents.forEach(function(logEvent) {
+    var timestamp = new Date(1 * logEvent.timestamp);
+
+    // index name format: cwl-YYYY.MM.DD
+    var indexName = [
+      'cwl-' + timestamp.getUTCFullYear(),              // year
+      ('0' + (timestamp.getUTCMonth() + 1)).slice(-2),  // month
+      ('0' + timestamp.getUTCDate()).slice(-2)          // day
+    ].join('.');
+
+    var source = buildSource(logEvent.message, logEvent.extractedFields);
+    source['@id'] = logEvent.id;
+    source['@timestamp'] = new Date(1 * logEvent.timestamp).toISOString();
+    source['@message'] = logEvent.message;
+    source['@owner'] = payload.owner;
+    source['@log_group'] = payload.logGroup;
+    source['@log_stream'] = payload.logStream;
+
+    var action = { "index": {} };
+    action.index._index = indexName;
+    action.index._id = logEvent.id;
+
+    bulkRequestBody += [
+      JSON.stringify(action),
+      JSON.stringify(source),
+    ].join('\n') + '\n';
+  });
+  return bulkRequestBody;
+}
+
+function buildSource(message, extractedFields) {
+  if (extractedFields) {
+    var source = {};
+
+    for (var key in extractedFields) {
+      if (extractedFields.hasOwnProperty(key) && extractedFields[key]) {
+        var value = extractedFields[key];
+
+        if (isNumeric(value)) {
+          source[key] = 1 * value;
+          continue;
+        }
+
+        jsonSubString = extractJson(value);
+        if (jsonSubString !== null) {
+          source['$' + key] = JSON.parse(jsonSubString);
+        }
+
+        source[key] = value;
+      }
+    }
+    return source;
+  }
+
+  jsonSubString = extractJson(message);
+  if (jsonSubString !== null) {
+    return JSON.parse(jsonSubString);
+  }
+
+  return {};
+}
+
+function extractJson(message) {
+  var jsonStart = message.indexOf('{');
+  if (jsonStart < 0) return null;
+  var jsonSubString = message.substring(jsonStart);
+  return isValidJson(jsonSubString) ? jsonSubString : null;
+}
+
+function isValidJson(message) {
+  try {
+    JSON.parse(message);
+  } catch (e) { return false; }
+  return true;
+}
+
+function isNumeric(n) {
+  return !isNaN(parseFloat(n)) && isFinite(n);
+}
+
+function post(body, callback) {
+  var requestParams = buildRequest(endpoint, body);
+
+  var request = https.request(requestParams, function(response) {
+    var responseBody = '';
+    response.on('data', function(chunk) {
+      responseBody += chunk;
+    });
+
+    response.on('end', function() {
+      var info = JSON.parse(responseBody);
+      var failedItems;
+      var success;
+      var error;
+
+      if (response.statusCode >= 200 && response.statusCode < 299) {
+        failedItems = info.items.filter(function(x) {
+          return x.index.status >= 300;
+        });
+
+        success = {
+          "attemptedItems": info.items.length,
+          "successfulItems": info.items.length - failedItems.length,
+          "failedItems": failedItems.length
+        };
+      }
+
+      if (response.statusCode !== 200 || info.errors === true) {
+        // prevents logging of failed entries, but allows logging
+        // of other errors such as access restrictions
+        delete info.items;
+        error = {
+          statusCode: response.statusCode,
+          responseBody: info
+        };
+      }
+
+      callback(error, success, response.statusCode, failedItems);
+    });
+  }).on('error', function(e) {
+    callback(e);
+  });
+  request.end(requestParams.body);
+}
+
+function buildRequest(endpoint, body) {
+  var endpointParts = endpoint.match(/^([^\.]+)\.?([^\.]*)\.?([^\.]*)\.amazonaws\.com$/);
+  var region = endpointParts[2];
+  var service = endpointParts[3];
+  var datetime = (new Date()).toISOString().replace(/[:\-]|\.\d{3}/g, '');
+  var date = datetime.substr(0, 8);
+  var kDate = hmac('AWS4' + process.env.AWS_SECRET_ACCESS_KEY, date);
+  var kRegion = hmac(kDate, region);
+  var kService = hmac(kRegion, service);
+  var kSigning = hmac(kService, 'aws4_request');
+
+  var request = {
+    host: endpoint,
+    method: 'POST',
+    path: '/_bulk',
+    body: body,
+    headers: {
+      'Content-Type': 'application/json',
+      'Host': endpoint,
+      'Content-Length': Buffer.byteLength(body),
+      'X-Amz-Security-Token': process.env.AWS_SESSION_TOKEN,
+      'X-Amz-Date': datetime
+    }
+  };
+
+  var canonicalHeaders = Object.keys(request.headers)
+  .sort(function(a, b) { return a.toLowerCase() < b.toLowerCase() ? -1 : 1; })
+  .map(function(k) { return k.toLowerCase() + ':' + request.headers[k]; })
+  .join('\n');
+
+  var signedHeaders = Object.keys(request.headers)
+  .map(function(k) { return k.toLowerCase(); })
+  .sort()
+  .join(';');
+
+  var canonicalString = [
+    request.method,
+    request.path, '',
+    canonicalHeaders, '',
+    signedHeaders,
+    hash(request.body, 'hex'),
+  ].join('\n');
+
+  var credentialString = [ date, region, service, 'aws4_request' ].join('/');
+
+  var stringToSign = [
+    'AWS4-HMAC-SHA256',
+    datetime,
+    credentialString,
+    hash(canonicalString, 'hex')
+  ] .join('\n');
+
+  request.headers.Authorization = [
+    'AWS4-HMAC-SHA256 Credential=' + process.env.AWS_ACCESS_KEY_ID + '/' + credentialString,
+    'SignedHeaders=' + signedHeaders,
+    'Signature=' + hmac(kSigning, stringToSign, 'hex')
+  ].join(', ');
+
+  return request;
+}
+
+function hmac(key, str, encoding) {
+  return crypto.createHmac('sha256', key).update(str, 'utf8').digest(encoding);
+}
+
+function hash(str, encoding) {
+  return crypto.createHash('sha256').update(str, 'utf8').digest(encoding);
+}
+
+function logFailure(error, failedItems) {
+  if (logFailedResponses) {
+    console.log('Error: ' + JSON.stringify(error, null, 2));
+
+    if (failedItems && failedItems.length > 0) {
+      console.log("Failed Items: " +
+        JSON.stringify(failedItems, null, 2));
+    }
+  }
+}

--- a/support-workers/elasticsearch/readme.md
+++ b/support-workers/elasticsearch/readme.md
@@ -1,0 +1,38 @@
+All step functions executions are logged to Elasticsearch to allow easy querying and analysis.
+
+The way that this works is 
+* We log the result of each lambda execution to CloudWatch as Json (see `LambdaExecutionResult.scala`)
+* A CloudWatch subscription sends all log messages matching a particular filter to Elasticsearch (via the LogsToElasticsearch_support-elk-domain lambda. See `cloudWatchToElasticSearchLambda.js`) 
+* Elasticsearch has a pipeline set up which extracts the Json into separate fields. This can be defined via the Kibana dev tools with the following request:
+
+```
+PUT _ingest/pipeline/extractJsonPipeline
+{
+    "description": "Extract the lambda execution json into separate fields",
+    "processors": [
+        {
+            "grok": {
+                "field": "@message",
+                "patterns": [
+                    "^.*\\$ - LambdaExecutionResult: (?<lambdaJson>.*)"
+                ]
+            }
+        },
+        {
+            "json": {
+                "field": "lambdaJson",
+                "add_to_root": true
+            }
+        },
+        {
+            "remove": {
+                "field": [
+                    "lambdaJson",
+                    "@message",
+                    "@owner"
+                ]
+            }
+        }
+    ]
+}
+```

--- a/support-workers/src/main/scala/com/gu/monitoring/LambdaExecutionResult.scala
+++ b/support-workers/src/main/scala/com/gu/monitoring/LambdaExecutionResult.scala
@@ -97,7 +97,7 @@ case class LambdaExecutionResult(
 object LambdaExecutionResult {
 
   def logResult(lambdaExecutionResult: LambdaExecutionResult): Unit = {
-    SafeLogger.info(s"LambdaExecutionResult: ${lambdaExecutionResult.asJson}")
+    SafeLogger.info(s"LambdaExecutionResult: ${lambdaExecutionResult.asJson.noSpaces}")
   }
 
   implicit val encoder: Encoder[LambdaExecutionResult] = deriveEncoder[LambdaExecutionResult]

--- a/support-workers/src/main/scala/com/gu/monitoring/LambdaExecutionResult.scala
+++ b/support-workers/src/main/scala/com/gu/monitoring/LambdaExecutionResult.scala
@@ -7,6 +7,7 @@ import com.gu.monitoring.LambdaExecutionResult.PaymentProvider
 import com.gu.support.encoding.CustomCodecs._
 import com.gu.support.encoding.JsonHelpers._
 import com.gu.support.promotions.PromoCode
+import com.gu.support.workers.CheckoutFailureReasons.CheckoutFailureReason
 import com.gu.support.workers._
 import io.circe.generic.semiauto.deriveEncoder
 import io.circe.syntax._
@@ -21,9 +22,11 @@ case object PaymentFailure extends LambdaExecutionStatus
 
 case object Error extends LambdaExecutionStatus
 
+case object IgnoredError extends LambdaExecutionStatus
+
 object LambdaExecutionStatus {
   def fromString(code: String): Option[LambdaExecutionStatus] = {
-    List(Success, PaymentFailure, Error).find(_.getClass.getSimpleName == s"$code$$")
+    List(Success, PaymentFailure, Error, IgnoredError).find(_.getClass.getSimpleName == s"$code$$")
   }
 
   implicit val decoder: Decoder[LambdaExecutionStatus] =
@@ -37,13 +40,14 @@ case class LambdaExecutionResult(
   status: LambdaExecutionStatus,
   isTestUser: Boolean,
   product: ProductType,
-  paymentDetails: PaymentProvider,
+  paymentDetails: Option[PaymentProvider],
   firstDeliveryDate: Option[LocalDate],
   isGift: Boolean,
   promoCode: Option[PromoCode],
   billingCountry: Country,
   deliveryCountry: Option[Country],
-  errorMessage: Option[String],
+  checkoutFailureReason: Option[CheckoutFailureReason],
+  error: Option[ExecutionError],
 )
 
 object LambdaExecutionResult {

--- a/support-workers/src/main/scala/com/gu/monitoring/LambdaExecutionResult.scala
+++ b/support-workers/src/main/scala/com/gu/monitoring/LambdaExecutionResult.scala
@@ -8,7 +8,6 @@ import com.gu.support.encoding.CustomCodecs._
 import com.gu.support.encoding.JsonHelpers._
 import com.gu.support.promotions.PromoCode
 import com.gu.support.workers._
-import com.typesafe.scalalogging.LazyLogging
 import io.circe.generic.semiauto.deriveEncoder
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder}
@@ -47,10 +46,10 @@ case class LambdaExecutionResult(
   errorMessage: Option[String],
 )
 
-object LambdaExecutionResult extends LazyLogging{
+object LambdaExecutionResult {
 
-  def logResult(lambdaExecutionResult: LambdaExecutionResult) = {
-    logger.info(s"LambdaExecutionResult: ${lambdaExecutionResult.asJson}")
+  def logResult(lambdaExecutionResult: LambdaExecutionResult): Unit = {
+    SafeLogger.info(s"LambdaExecutionResult: ${lambdaExecutionResult.asJson}")
   }
 
   type PaymentProvider = Either[PaymentFields, PaymentMethod]
@@ -74,6 +73,7 @@ object LambdaExecutionResult extends LazyLogging{
   implicit val encoder: Encoder[LambdaExecutionResult] = deriveEncoder[LambdaExecutionResult]
     .mapJsonObject(
       _.unNest("product", "amount")
+        .unNest("product", "productType")
         .unNest("product", "currency")
         .unNest("product", "billingPeriod")
         .unNest("product", "fulfilmentOptions")

--- a/support-workers/src/main/scala/com/gu/monitoring/LambdaExecutionResult.scala
+++ b/support-workers/src/main/scala/com/gu/monitoring/LambdaExecutionResult.scala
@@ -3,7 +3,6 @@ package com.gu.monitoring
 import java.util.UUID
 
 import com.gu.i18n.Country
-import com.gu.monitoring.LambdaExecutionResult.PaymentProvider
 import com.gu.support.encoding.CustomCodecs._
 import com.gu.support.encoding.JsonHelpers._
 import com.gu.support.promotions.PromoCode
@@ -35,6 +34,51 @@ object LambdaExecutionStatus {
   implicit val encoder: Encoder[LambdaExecutionStatus] = Encoder.encodeString.contramap[LambdaExecutionStatus](_.toString)
 }
 
+sealed trait PaymentProvider
+
+case object Stripe extends PaymentProvider
+
+case object StripeApplePay extends PaymentProvider
+
+case object PayPal extends PaymentProvider
+
+case object DirectDebit extends PaymentProvider
+
+case object Existing extends PaymentProvider
+
+object PaymentProvider {
+  def fromString(code: String): Option[PaymentProvider] = {
+    List(Stripe, PayPal, DirectDebit, Existing).find(_.getClass.getSimpleName == s"$code$$")
+  }
+
+  implicit val decoder: Decoder[PaymentProvider] =
+    Decoder.decodeString.emap(code => PaymentProvider.fromString(code).toRight(s"unrecognised payment provider '$code'"))
+
+  implicit val encoder: Encoder[PaymentProvider] = Encoder.encodeString.contramap[PaymentProvider](_.toString)
+
+  def fromPaymentFields(paymentFields: PaymentFields): PaymentProvider = paymentFields match {
+    case stripe: StripePaymentFields => stripe.stripePaymentType match {
+      case Some(StripePaymentType.StripeApplePay) => StripeApplePay
+      case _ => Stripe
+    }
+    case _: PayPalPaymentFields => PayPal
+    case _: DirectDebitPaymentFields => DirectDebit
+    case _: ExistingPaymentFields => Existing
+  }
+
+  def fromPaymentMethod(paymentMethod: PaymentMethod): PaymentProvider = paymentMethod match {
+    case creditCardPayment: CreditCardReferenceTransaction =>
+      creditCardPayment.stripePaymentType match {
+        case Some(StripePaymentType.StripeApplePay) => StripeApplePay
+        case _ => Stripe
+      }
+    case _: PayPalReferenceTransaction => PayPal
+    case _: DirectDebitPaymentMethod => DirectDebit
+    case _: ClonedDirectDebitPaymentMethod => Existing
+  }
+
+}
+
 case class LambdaExecutionResult(
   requestId: UUID,
   status: LambdaExecutionStatus,
@@ -56,24 +100,6 @@ object LambdaExecutionResult {
     SafeLogger.info(s"LambdaExecutionResult: ${lambdaExecutionResult.asJson}")
   }
 
-  type PaymentProvider = Either[PaymentFields, PaymentMethod]
-  def paymentProviderString(paymentProvider: PaymentProvider) = {
-    paymentProvider.fold(
-      {
-        case _: StripePaymentFields => "Stripe"
-        case _: PayPalPaymentFields => "PayPal"
-        case _: DirectDebitPaymentFields => "DirectDebit"
-        case _: ExistingPaymentFields => "Existing"
-      },
-      {
-        case _: CreditCardReferenceTransaction => "Stripe"
-        case _: PayPalReferenceTransaction => "PayPal"
-        case _: DirectDebitPaymentMethod => "DirectDebit"
-        case _: ClonedDirectDebitPaymentMethod => "Existing"
-      }
-    )
-  }
-  implicit val paymentEncoder: Encoder[PaymentProvider] = Encoder.encodeString.contramap[Either[PaymentFields, PaymentMethod]](paymentProviderString)
   implicit val encoder: Encoder[LambdaExecutionResult] = deriveEncoder[LambdaExecutionResult]
     .mapJsonObject(
       _.unNest("product", "amount")

--- a/support-workers/src/main/scala/com/gu/monitoring/LambdaExecutionResult.scala
+++ b/support-workers/src/main/scala/com/gu/monitoring/LambdaExecutionResult.scala
@@ -1,0 +1,84 @@
+package com.gu.monitoring
+
+import java.util.UUID
+
+import com.gu.i18n.Country
+import com.gu.monitoring.LambdaExecutionResult.PaymentProvider
+import com.gu.support.encoding.CustomCodecs._
+import com.gu.support.encoding.JsonHelpers._
+import com.gu.support.promotions.PromoCode
+import com.gu.support.workers._
+import com.typesafe.scalalogging.LazyLogging
+import io.circe.generic.semiauto.deriveEncoder
+import io.circe.syntax._
+import io.circe.{Decoder, Encoder}
+import org.joda.time.LocalDate
+
+sealed trait LambdaExecutionStatus
+
+case object Success extends LambdaExecutionStatus
+
+case object PaymentFailure extends LambdaExecutionStatus
+
+case object Error extends LambdaExecutionStatus
+
+object LambdaExecutionStatus {
+  def fromString(code: String): Option[LambdaExecutionStatus] = {
+    List(Success, PaymentFailure, Error).find(_.getClass.getSimpleName == s"$code$$")
+  }
+
+  implicit val decoder: Decoder[LambdaExecutionStatus] =
+    Decoder.decodeString.emap(code => LambdaExecutionStatus.fromString(code).toRight(s"unrecognised execution status '$code'"))
+
+  implicit val encoder: Encoder[LambdaExecutionStatus] = Encoder.encodeString.contramap[LambdaExecutionStatus](_.toString)
+}
+
+case class LambdaExecutionResult(
+  requestId: UUID,
+  status: LambdaExecutionStatus,
+  isTestUser: Boolean,
+  product: ProductType,
+  paymentDetails: PaymentProvider,
+  firstDeliveryDate: Option[LocalDate],
+  isGift: Boolean,
+  promoCode: Option[PromoCode],
+  billingCountry: Country,
+  deliveryCountry: Option[Country],
+  errorMessage: Option[String],
+)
+
+object LambdaExecutionResult extends LazyLogging{
+
+  def logResult(lambdaExecutionResult: LambdaExecutionResult) = {
+    logger.info(s"LambdaExecutionResult: ${lambdaExecutionResult.asJson}")
+  }
+
+  type PaymentProvider = Either[PaymentFields, PaymentMethod]
+  def paymentProviderString(paymentProvider: PaymentProvider) = {
+    paymentProvider.fold(
+      {
+        case _: StripePaymentFields => "Stripe"
+        case _: PayPalPaymentFields => "PayPal"
+        case _: DirectDebitPaymentFields => "DirectDebit"
+        case _: ExistingPaymentFields => "Existing"
+      },
+      {
+        case _: CreditCardReferenceTransaction => "Stripe"
+        case _: PayPalReferenceTransaction => "PayPal"
+        case _: DirectDebitPaymentMethod => "DirectDebit"
+        case _: ClonedDirectDebitPaymentMethod => "Existing"
+      }
+    )
+  }
+  implicit val paymentEncoder: Encoder[PaymentProvider] = Encoder.encodeString.contramap[Either[PaymentFields, PaymentMethod]](paymentProviderString)
+  implicit val encoder: Encoder[LambdaExecutionResult] = deriveEncoder[LambdaExecutionResult]
+    .mapJsonObject(
+      _.unNest("product", "amount")
+        .unNest("product", "currency")
+        .unNest("product", "billingPeriod")
+        .unNest("product", "fulfilmentOptions")
+        .unNest("product", "productOptions")
+        .remove("product")
+    )
+}
+

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
@@ -4,6 +4,7 @@ import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.sqs.model.SendMessageResult
 import com.gu.emailservices._
 import com.gu.helpers.FutureExtensions._
+import com.gu.monitoring.PaymentProvider.{fromPaymentFields, fromPaymentMethod}
 import com.gu.monitoring.{Error, IgnoredError, LambdaExecutionResult, LambdaExecutionStatus, PaymentFailure, SafeLogger}
 import com.gu.stripe.StripeError
 import com.gu.support.encoding.CustomCodecs._
@@ -92,7 +93,9 @@ class FailureHandler(emailService: EmailService) extends Handler[FailureHandlerS
     checkoutFailureReason: CheckoutFailureReason,
     error: Option[ExecutionError]
   ): Unit = {
-    val paymentDetails = state.paymentMethod.map(Right(_)).orElse(state.paymentFields.map(Left(_)))
+    val maybePaymentProvider = state.paymentMethod.map(fromPaymentMethod)
+      .orElse(state.paymentFields.map(fromPaymentFields))
+
     // Log the result of this execution to Elasticsearch
     LambdaExecutionResult.logResult(
       LambdaExecutionResult(
@@ -100,7 +103,7 @@ class FailureHandler(emailService: EmailService) extends Handler[FailureHandlerS
         status,
         state.user.isTestUser,
         state.product,
-        paymentDetails,
+        maybePaymentProvider,
         state.firstDeliveryDate,
         state.giftRecipient.isDefined,
         state.promoCode,

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/FailureHandler.scala
@@ -93,6 +93,7 @@ class FailureHandler(emailService: EmailService) extends Handler[FailureHandlerS
     error: Option[ExecutionError]
   ): Unit = {
     val paymentDetails = state.paymentMethod.map(Right(_)).orElse(state.paymentFields.map(Left(_)))
+    // Log the result of this execution to Elasticsearch
     LambdaExecutionResult.logResult(
       LambdaExecutionResult(
         state.requestId,

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
@@ -10,7 +10,7 @@ import com.gu.aws.AwsCloudWatchMetricPut
 import com.gu.aws.AwsCloudWatchMetricPut.{client, paymentSuccessRequest}
 import com.gu.config.Configuration
 import com.gu.i18n.Country
-import com.gu.monitoring.{LambdaExecutionResult, SafeLogger, Success}
+import com.gu.monitoring.{LambdaExecutionResult, PaymentProvider, SafeLogger, Success}
 import com.gu.services.{ServiceProvider, Services}
 import com.gu.support.catalog.{GuardianWeekly, Contribution => _, DigitalPack => _, Paper => _, _}
 import com.gu.support.encoding.CustomCodecs._
@@ -46,7 +46,7 @@ class SendAcquisitionEvent(serviceProvider: ServiceProvider = ServiceProvider)
         Success,
         state.user.isTestUser,
         state.product,
-        Some(Right(state.paymentMethod)),
+        Some(PaymentProvider.fromPaymentMethod(state.paymentMethod)),
         state.firstDeliveryDate,
         state.giftRecipient.isDefined,
         state.promoCode,

--- a/support-workers/src/test/scala/com/gu/monitoring/LambdaExecutionResultFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/monitoring/LambdaExecutionResultFixtures.scala
@@ -3,21 +3,22 @@ package com.gu.monitoring
 object LambdaExecutionResultFixtures {
   val successfulContribution =
     """
-      {
-        "requestId" : "e18f6418-45f2-11e7-8bfa-8faac2182601",
-        "status" : "Success",
-        "isTestUser" : false,
-        "paymentDetails" : "PayPal",
-        "firstDeliveryDate" : null,
-        "productType" : "Contribution",
-        "isGift" : false,
-        "promoCode" : null,
-        "billingCountry" : "GB",
-        "deliveryCountry" : null,
-        "errorMessage" : null,
-        "amount" : 20,
-        "currency" : "GBP",
-        "billingPeriod" : "Monthly"
-      }
+    {
+      "requestId" : "e18f6418-45f2-11e7-8bfa-8faac2182601",
+      "status" : "Success",
+      "isTestUser" : false,
+      "paymentDetails" : "PayPal",
+      "firstDeliveryDate" : null,
+      "isGift" : false,
+      "promoCode" : null,
+      "billingCountry" : "GB",
+      "deliveryCountry" : null,
+      "checkoutFailureReason" : null,
+      "error" : null,
+      "amount" : 20,
+      "productType" : "Contribution",
+      "currency" : "GBP",
+      "billingPeriod" : "Monthly"
+    }
     """
 }

--- a/support-workers/src/test/scala/com/gu/monitoring/LambdaExecutionResultFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/monitoring/LambdaExecutionResultFixtures.scala
@@ -1,0 +1,22 @@
+package com.gu.monitoring
+
+object LambdaExecutionResultFixtures {
+  val successfulContribution =
+    """
+      {
+        "requestId" : "e18f6418-45f2-11e7-8bfa-8faac2182601",
+        "status" : "Success",
+        "isTestUser" : false,
+        "paymentDetails" : "PayPal",
+        "firstDeliveryDate" : null,
+        "isGift" : false,
+        "promoCode" : null,
+        "billingCountry" : "GB",
+        "deliveryCountry" : null,
+        "errorMessage" : null,
+        "amount" : 20,
+        "currency" : "GBP",
+        "billingPeriod" : "Monthly"
+      }
+    """
+}

--- a/support-workers/src/test/scala/com/gu/monitoring/LambdaExecutionResultFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/monitoring/LambdaExecutionResultFixtures.scala
@@ -9,6 +9,7 @@ object LambdaExecutionResultFixtures {
         "isTestUser" : false,
         "paymentDetails" : "PayPal",
         "firstDeliveryDate" : null,
+        "productType" : "Contribution",
         "isGift" : false,
         "promoCode" : null,
         "billingCountry" : "GB",

--- a/support-workers/src/test/scala/com/gu/monitoring/LambdaExecutionResultSpec.scala
+++ b/support-workers/src/test/scala/com/gu/monitoring/LambdaExecutionResultSpec.scala
@@ -14,11 +14,11 @@ class LambdaExecutionResultSpec extends AnyFlatSpec with Matchers {
   "LambdaExecutionResult" should "serialise correctly" in {
     val requestId = UUID.fromString("e18f6418-45f2-11e7-8bfa-8faac2182601")
     val success = LambdaExecutionResult(
-      requestId, Success, false,
+      requestId, Success, isTestUser = false,
       Contribution(20, GBP, Monthly),
-      Left(PayPalPaymentFields("1234")),
-      None, false, None,
-      Country.UK, None, None
+      Some(Left(PayPalPaymentFields("1234"))),
+      None, isGift = false, None,
+      Country.UK, None, None, None
     )
 
     success.asJson shouldBe parse(LambdaExecutionResultFixtures.successfulContribution).right.get

--- a/support-workers/src/test/scala/com/gu/monitoring/LambdaExecutionResultSpec.scala
+++ b/support-workers/src/test/scala/com/gu/monitoring/LambdaExecutionResultSpec.scala
@@ -10,8 +10,8 @@ import io.circe.syntax._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-class LambdaExecutionResultSpec extends AnyFlatSpec with Matchers{
-  "LambdaExecutionResult" should "create a correct log message" in {
+class LambdaExecutionResultSpec extends AnyFlatSpec with Matchers {
+  "LambdaExecutionResult" should "serialise correctly" in {
     val requestId = UUID.fromString("e18f6418-45f2-11e7-8bfa-8faac2182601")
     val success = LambdaExecutionResult(
       requestId, Success, false,

--- a/support-workers/src/test/scala/com/gu/monitoring/LambdaExecutionResultSpec.scala
+++ b/support-workers/src/test/scala/com/gu/monitoring/LambdaExecutionResultSpec.scala
@@ -1,0 +1,26 @@
+package com.gu.monitoring
+
+import java.util.UUID
+
+import com.gu.i18n.Country
+import com.gu.i18n.Currency.GBP
+import com.gu.support.workers.{Contribution, Monthly, PayPalPaymentFields}
+import io.circe.parser._
+import io.circe.syntax._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class LambdaExecutionResultSpec extends AnyFlatSpec with Matchers{
+  "LambdaExecutionResult" should "create a correct log message" in {
+    val requestId = UUID.fromString("e18f6418-45f2-11e7-8bfa-8faac2182601")
+    val success = LambdaExecutionResult(
+      requestId, Success, false,
+      Contribution(20, GBP, Monthly),
+      Left(PayPalPaymentFields("1234")),
+      None, false, None,
+      Country.UK, None, None
+    )
+
+    success.asJson shouldBe parse(LambdaExecutionResultFixtures.successfulContribution).right.get
+  }
+}

--- a/support-workers/src/test/scala/com/gu/monitoring/LambdaExecutionResultSpec.scala
+++ b/support-workers/src/test/scala/com/gu/monitoring/LambdaExecutionResultSpec.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 
 import com.gu.i18n.Country
 import com.gu.i18n.Currency.GBP
-import com.gu.support.workers.{Contribution, Monthly, PayPalPaymentFields}
+import com.gu.support.workers.{Contribution, Monthly}
 import io.circe.parser._
 import io.circe.syntax._
 import org.scalatest.flatspec.AnyFlatSpec
@@ -16,7 +16,7 @@ class LambdaExecutionResultSpec extends AnyFlatSpec with Matchers {
     val success = LambdaExecutionResult(
       requestId, Success, isTestUser = false,
       Contribution(20, GBP, Monthly),
-      Some(Left(PayPalPaymentFields("1234"))),
+      Some(PayPal),
       None, isGift = false, None,
       Country.UK, None, None, None
     )


### PR DESCRIPTION
## Why are you doing this?
As part of our health OKR for this quarter we want to start logging all step functions executions to Elasticsearch so that we can do analysis of them more easily.

The way that this works is 
* We log the result of each lambda execution to CloudWatch as Json
* A CloudWatch subscription sends all log messages matching a particular filter to Elasticsearch (via the LogsToElasticsearch_support-elk-domain lambda) 
* Elasticsearch has a pipeline set up which extracts the Json into separate fields

[**Trello Card**](https://trello.com/c/99hEG7T9/2637-failure-reporting-tool)

## Changes
* Create a `LambdaExecutionResult` class to capture the data we are interested in
* Log results from the `FailureHandler` and `SendAcquisitionEvent` lambdas - these are the two exit points for the step function

