### PR TITLE
Print Subscription sale changes, for general election

### DIFF
--- a/support-frontend/app/controllers/PaperSubscription.scala
+++ b/support-frontend/app/controllers/PaperSubscription.scala
@@ -59,7 +59,7 @@ class PaperSubscription(
     val css = Left(RefPath("paperSubscriptionLandingPage.css"))
     val canonicalLink = Some(buildCanonicalPaperSubscriptionLink())
     val description = stringsConfig.paperLandingDescription
-    val promoCodes = request.queryString.get("promoCode").map(_.toList).getOrElse(Nil) :+ "SEP2512VHD"
+    val promoCodes = request.queryString.get("promoCode").map(_.toList).getOrElse(Nil) :+ "GE19SUBS"
     val productPrices = priceSummaryServiceProvider.forUser(false).getPrices(Paper, promoCodes)
 
     Ok(views.html.main(title, mainElement, js, css, fontLoaderBundle, description, canonicalLink){

--- a/support-frontend/assets/components/headingBlock/headingBlock.scss
+++ b/support-frontend/assets/components/headingBlock/headingBlock.scss
@@ -31,11 +31,14 @@
   line-height: 1;
   font-weight: bold;
   background-color: gu-colour(highlight-main);
-  color: gu-colour(neutral-7);
+  // color: gu-colour(neutral-7);
+  color: gu-colour(neutral-97);
   padding: ($gu-v-spacing/2) ($gu-h-spacing / 2);
 
  .component-product-page-hero-heading--campaign & {
-   background-color: #ffffff;
+   background-color: gu-colour(neutral-7);;
+  //  background-color: #ffffff;
+   top: -25px;
     @supports(transform:translateY(-100%)) {
       transform: translateY(-100%);
       position: absolute;

--- a/support-frontend/assets/components/headingBlock/headingBlock.scss
+++ b/support-frontend/assets/components/headingBlock/headingBlock.scss
@@ -30,15 +30,15 @@
   display: inline-block;
   line-height: 1;
   font-weight: bold;
-  background-color: gu-colour(highlight-main);
-  // color: gu-colour(neutral-7);
-  color: gu-colour(neutral-97);
+  // background-color: gu-colour(highlight-main);
+  color: gu-colour(neutral-7);
+  // color: gu-colour(neutral-97);
   padding: ($gu-v-spacing/2) ($gu-h-spacing / 2);
 
  .component-product-page-hero-heading--campaign & {
-   background-color: gu-colour(neutral-7);;
-  //  background-color: #ffffff;
-   top: -25px;
+  //  background-color: gu-colour(neutral-7);;
+   background-color: #ffffff;
+  //  top: -25px;
     @supports(transform:translateY(-100%)) {
       transform: translateY(-100%);
       position: absolute;

--- a/support-frontend/assets/components/packshots/print-feature-packshot.jsx
+++ b/support-frontend/assets/components/packshots/print-feature-packshot.jsx
@@ -1,0 +1,19 @@
+// @flow
+
+import React from 'react';
+
+import GridImage from 'components/gridImage/gridImage';
+
+const PrintFeaturePackshot = () => (
+  <div>
+    <GridImage
+      classModifiers={['subscriptions-print-feature-image']}
+      gridId="printFeaturePackshot"
+      srcSizes={[1000, 500, 140]}
+      sizes="(min-width: 480px) 100%"
+      imgType="png"
+    />
+  </div>
+);
+
+export default PrintFeaturePackshot;

--- a/support-frontend/assets/components/productPage/productPagePlanForm/productPagePlanFormLabel.jsx
+++ b/support-frontend/assets/components/productPage/productPagePlanForm/productPagePlanFormLabel.jsx
@@ -46,7 +46,7 @@ export default ({
       </div>
         }
       <div className="component-product-page-plan-form-label__cta" >
-        <AnchorButton id={`qa-${title.toLowerCase()}`} onClick={onClick} aria-label={`Subscribe – ${title}`} href={href}>
+        <AnchorButton id={`qa-${title.toLowerCase().replace(' ', '-')}`} onClick={onClick} aria-label={`Subscribe – ${title}`} href={href}>
             Subscribe now
         </AnchorButton>
       </div>

--- a/support-frontend/assets/helpers/flashSale.js
+++ b/support-frontend/assets/helpers/flashSale.js
@@ -99,7 +99,7 @@ const Sales: Sale[] = [
   {
     subscriptionProduct: 'Paper',
     activeRegions: [GBPCountries],
-    startTime: new Date(2019, 9, 29).getTime(), // 29 Sep 2019
+    startTime: new Date(2019, 11, 28).getTime(), // 28 Nov 2019
     endTime: new Date(2019, 12, 16).getTime(), // 16 Dec 2019
     duration: '12 months',
     saleDetails: {

--- a/support-frontend/assets/helpers/flashSale.js
+++ b/support-frontend/assets/helpers/flashSale.js
@@ -99,12 +99,12 @@ const Sales: Sale[] = [
   {
     subscriptionProduct: 'Paper',
     activeRegions: [GBPCountries],
-    startTime: new Date(2019, 8, 23).getTime(), // 23 Sep 2019
-    endTime: new Date(2019, 9, 7).getTime(), // 7 Oct 2019
+    startTime: new Date(2019, 9, 29).getTime(), // 29 Sep 2019
+    endTime: new Date(2019, 12, 16).getTime(), // 16 Dec 2019
     duration: '12 months',
     saleDetails: {
       GBPCountries: {
-        promoCode: 'SEP2512VHD',
+        promoCode: 'GE19SUBS',
         annualPlanPromoCode: '',
         intcmp: '',
         price: 8.09,

--- a/support-frontend/assets/helpers/flashSale.js
+++ b/support-frontend/assets/helpers/flashSale.js
@@ -99,8 +99,8 @@ const Sales: Sale[] = [
   {
     subscriptionProduct: 'Paper',
     activeRegions: [GBPCountries],
-    startTime: new Date(2019, 11, 28).getTime(), // 28 Nov 2019
-    endTime: new Date(2019, 12, 16).getTime(), // 16 Dec 2019
+    startTime: new Date(2019, 10, 28).getTime(), // 28 Nov 2019
+    endTime: new Date(2019, 11, 16).getTime(), // 16 Dec 2019
     duration: '12 months',
     saleDetails: {
       GBPCountries: {

--- a/support-frontend/assets/helpers/subscriptions.js
+++ b/support-frontend/assets/helpers/subscriptions.js
@@ -184,7 +184,7 @@ const getNewsstandSaving = (subscriptionMonthlyCost: number, newsstandWeeklyCost
   fixDecimals(getMonthlyNewsStandPrice(newsstandWeeklyCost) - subscriptionMonthlyCost);
 
 const getNewsstandSavingPercentage = (subscriptionMonthlyCost: number, newsstandWeeklyCost: number) =>
-  Math.round(100 - ((subscriptionMonthlyCost / getMonthlyNewsStandPrice(newsstandWeeklyCost)) * 100));
+  Math.floor(100 - ((subscriptionMonthlyCost / getMonthlyNewsStandPrice(newsstandWeeklyCost)) * 100));
 
 const getNewsstandPrice = (productOption: PaperProductOptions) =>
   newsstandPrices[productOption];

--- a/support-frontend/assets/helpers/theGrid.js
+++ b/support-frontend/assets/helpers/theGrid.js
@@ -101,14 +101,11 @@ export const imageCatalogue: {
   digitalSubsDailyMob: '93c8d64b7be3bf455f2f6f57d679c2fdc7df6bf3/0_0_1100_1100',
   digitalSubsApp: '234f5889b07c7c5d088d8d977e9e717ea8f2e791/0_0_1714_1000',
   digitalSubsAppMob: '59d2d83d9c1ecf8b3c955c63bf94ef2fa80c7353/0_0_1100_1100',
-<<<<<<< HEAD
   gwGiftingPackshot: '3d1cecfdc8c90b2005712e56669afe6e3b8c5e5a/762_0_4232_3184',
   gwGiftingPackshotMob: '3d1cecfdc8c90b2005712e56669afe6e3b8c5e5a/688_87_2481_3102',
   giftingGlobe: '4a7ee6f430a29fc8ac8d9f0667cfafc67b6aba46/145_148_1203_1201',
-=======
   printFeaturePackshot: '017a2f5c27394635b53c414962bbb775ce9b131d/5_39_1572_861',
   printRainbowElection: 'd1fe7341c596e2be4436a93be808f2122b0da469/0_0_732_1006',
->>>>>>> feat: print election sale changes
 };
 
 // Utility type: https://flow.org/en/docs/types/utilities/#toc-keys

--- a/support-frontend/assets/helpers/theGrid.js
+++ b/support-frontend/assets/helpers/theGrid.js
@@ -101,9 +101,14 @@ export const imageCatalogue: {
   digitalSubsDailyMob: '93c8d64b7be3bf455f2f6f57d679c2fdc7df6bf3/0_0_1100_1100',
   digitalSubsApp: '234f5889b07c7c5d088d8d977e9e717ea8f2e791/0_0_1714_1000',
   digitalSubsAppMob: '59d2d83d9c1ecf8b3c955c63bf94ef2fa80c7353/0_0_1100_1100',
+<<<<<<< HEAD
   gwGiftingPackshot: '3d1cecfdc8c90b2005712e56669afe6e3b8c5e5a/762_0_4232_3184',
   gwGiftingPackshotMob: '3d1cecfdc8c90b2005712e56669afe6e3b8c5e5a/688_87_2481_3102',
   giftingGlobe: '4a7ee6f430a29fc8ac8d9f0667cfafc67b6aba46/145_148_1203_1201',
+=======
+  printFeaturePackshot: '017a2f5c27394635b53c414962bbb775ce9b131d/5_39_1572_861',
+  printRainbowElection: 'd1fe7341c596e2be4436a93be808f2122b0da469/0_0_732_1006',
+>>>>>>> feat: print election sale changes
 };
 
 // Utility type: https://flow.org/en/docs/types/utilities/#toc-keys

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/helpers.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/helpers.jsx
@@ -34,7 +34,7 @@ export type ContentTabPropTypes = {|
   getRef: (?HTMLElement)=> void
 |};
 
-const promoTerms = promotionTermsUrl(getQueryParameter(promoQueryParam) || getPromoCode('Paper', GBPCountries, 'GE19SUBS'));
+const promoTermsUrl = promotionTermsUrl(getQueryParameter(promoQueryParam) || getPromoCode('Paper', GBPCountries, 'GE19SUBS'));
 
 // Helper functions
 const getPageInfoChip = (): string => {
@@ -71,7 +71,7 @@ const ContentHelpBlock = ({
     {flashSaleIsActive('Paper', GBPCountries) &&
       <Text title="Promotion terms and conditions">
         <SansParagraph>
-          Offer subject to availability. Guardian News and Media Limited (&ldquo;GNM&rdquo;) reserves the right to withdraw this promotion at any time. For full promotion terms and conditions, see <a target="_blank" rel="noopener noreferrer" href={promoTerms}>here</a>.
+          Offer subject to availability. Guardian News and Media Limited (&ldquo;GNM&rdquo;) reserves the right to withdraw this promotion at any time. For full promotion terms and conditions, see <a target="_blank" rel="noopener noreferrer" href={promoTermsUrl}>here</a>.
         </SansParagraph>
       </Text>
     }

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/helpers.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/helpers.jsx
@@ -9,7 +9,7 @@ import Content from 'components/content/content';
 import Text, { SansParagraph, Callout } from 'components/text/text';
 import ProductPageInfoChip from 'components/productPage/productPageInfoChip/productPageInfoChip';
 import { paperSubsUrl } from 'helpers/routes';
-import { flashSaleIsActive, getDiscount, getDuration } from 'helpers/flashSale';
+import { flashSaleIsActive, getDiscount, getDuration, getPromoCode } from 'helpers/flashSale';
 
 import { type ActiveTabState } from '../../paperSubscriptionLandingPageReducer';
 import { setTab } from '../../paperSubscriptionLandingPageActions';
@@ -19,6 +19,9 @@ import { Collection, HomeDelivery } from 'helpers/productPrice/fulfilmentOptions
 import { paperHasDeliveryEnabled } from 'helpers/subscriptions';
 import { GBPCountries } from 'helpers/internationalisation/countryGroup';
 
+import { promoQueryParam } from 'helpers/productPrice/promotions';
+import { promotionTermsUrl } from 'helpers/routes';
+import { getQueryParameter } from 'helpers/url';
 
 // Types
 export type ContentPropTypes = {|
@@ -31,6 +34,7 @@ export type ContentTabPropTypes = {|
   getRef: (?HTMLElement)=> void
 |};
 
+const promoTerms = promotionTermsUrl(getQueryParameter(promoQueryParam) || getPromoCode('Paper', GBPCountries, 'GE19SUBS'));
 
 // Helper functions
 const getPageInfoChip = (): string => {
@@ -67,7 +71,7 @@ const ContentHelpBlock = ({
     {flashSaleIsActive('Paper', GBPCountries) &&
       <Text title="Promotion terms and conditions">
         <SansParagraph>
-          Offer subject to availability. Guardian News and Media Limited (&ldquo;GNM&rdquo;) reserves the right to withdraw this promotion at any time. For full promotion terms and conditions, see <a target="_blank" rel="noopener noreferrer" href="https://subscribe.theguardian.com/p/SEP2512VHD/terms">here</a>.
+          Offer subject to availability. Guardian News and Media Limited (&ldquo;GNM&rdquo;) reserves the right to withdraw this promotion at any time. For full promotion terms and conditions, see <a target="_blank" rel="noopener noreferrer" href={promoTerms}>here</a>.
         </SansParagraph>
       </Text>
     }

--- a/support-frontend/assets/pages/paper-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/hero/hero.jsx
@@ -90,7 +90,7 @@ const DefaultHeader = () => (
 const CampaignHeader = () => (
   <ProductPagehero
     appearance="campaign"
-    overheading="The Guardian newspaper subscriptions"
+    overheading="Become a Guardian and Observer Subscriber"
     heading={discountCopy.heading}
     modifierClasses={['paper-sale']}
     content={<AnchorButton onClick={sendTrackingEventsOnClick('options_cta_click', 'Paper', null)} icon={<SvgChevron />} href="#subscribe">See Subscription options</AnchorButton>}
@@ -98,14 +98,33 @@ const CampaignHeader = () => (
   >
     <div className="sale-joy-of-print">
       <div className="sale-joy-of-print-copy">
-        <h2><span>Challenge the</span><br /><span>writing on the wall.</span></h2>
-        <p>Become a Guardian and<br />Observer subscriber</p>
+        {/* <h2><span>Challenge the</span><br /><span>writing on the wall.</span></h2>
+          <p>Become a Guardian and<br />Observer subscriber</p> */}
+        <h2 className="sale-joy-of-print__copy-text">
+          The easiest<br />
+          decision<br />
+          you’ll make<br />
+          this election
+        </h2>
       </div>
-
     </div>
     <div className="sale-joy-of-print-graphic-outer">
       <div className="sale-joy-of-print-graphic-inner">
-        <div className="sale-joy-of-print-badge">
+
+        <div className="sale-joy-of-print-graphic">
+          <div className="sale-joy-of-print-badge">
+            <Discount discountCopy={discountCopy.roundel} />
+          </div>
+          <GridImage
+            gridId="printRainbowElection"
+            srcSizes={[728, 364]}
+            sizes="(max-width: 740px) 100vw, 800px"
+            imgType="png"
+            altText="Election rainbow"
+          />
+        </div>
+
+        {/* <div className="sale-joy-of-print-badge">
           <Discount discountCopy={discountCopy.roundel} />
         </div>
         <div className="sale-joy-of-print-graphic">
@@ -116,7 +135,7 @@ const CampaignHeader = () => (
             imgType="jpg"
             altText="Newspapers"
           />
-        </div>
+        </div> */}
       </div>
     </div>
   </ProductPagehero>

--- a/support-frontend/assets/pages/paper-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/hero/hero.jsx
@@ -98,8 +98,6 @@ const CampaignHeader = () => (
   >
     <div className="sale-joy-of-print">
       <div className="sale-joy-of-print-copy">
-        {/* <h2><span>Challenge the</span><br /><span>writing on the wall.</span></h2>
-          <p>Become a Guardian and<br />Observer subscriber</p> */}
         <h2 className="sale-joy-of-print__copy-text">
           The easiest<br />
           decision<br />
@@ -118,24 +116,10 @@ const CampaignHeader = () => (
           <GridImage
             gridId="printRainbowElection"
             srcSizes={[728, 364]}
-            sizes="(max-width: 740px) 100vw, 800px"
             imgType="png"
             altText="Election rainbow"
           />
         </div>
-
-        {/* <div className="sale-joy-of-print-badge">
-          <Discount discountCopy={discountCopy.roundel} />
-        </div>
-        <div className="sale-joy-of-print-graphic">
-          <GridImage
-            gridId="printShowcase"
-            srcSizes={[1000, 500]}
-            sizes="(max-width: 740px) 100vw, 800px"
-            imgType="jpg"
-            altText="Newspapers"
-          />
-        </div> */}
       </div>
     </div>
   </ProductPagehero>

--- a/support-frontend/assets/pages/paper-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/hero/hero.jsx
@@ -116,6 +116,7 @@ const CampaignHeader = () => (
           <GridImage
             gridId="printRainbowElection"
             srcSizes={[728, 364]}
+            sizes="(max-width: 740px) 100vw, 800px"
             imgType="png"
             altText="Election rainbow"
           />

--- a/support-frontend/assets/pages/paper-subscription-landing/components/hero/joyOfPrint.scss
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/hero/joyOfPrint.scss
@@ -19,10 +19,10 @@
   display: none;
   position: relative;
   z-index: 10;
-  margin-top: $gu-v-spacing * 2;
+  // margin-top: $gu-v-spacing * 2;
 
   @include mq($from: leftCol) {
-    margin-top: $gu-v-spacing * 6;
+    // margin-top: $gu-v-spacing * 6;
   }
 
   @include mq($from: phablet) {
@@ -39,18 +39,32 @@
 
 
 .sale-joy-of-print__copy-text {
+  margin: 0;
+  font-size: 16px;
   font-family: $gu-titlepiece;
-  margin: $gu-v-spacing * 2 0;
+
+  @include mq($from: phablet) {
+    font-size: 50px;
+    margin-top: 30px;
+  }
+
+  @include mq($from: desktop) {
+    font-size: 50px;
+    margin-top: 50px;
+  }
+
   span {
     padding: 0 $gu-h-spacing / 2;
     padding-right: $gu-h-spacing / 2;
-    @include mq($from: desktop) {
-      line-height: 50px;
-    }
     background-color: black;
     color: #ffffff;
     padding-bottom: $gu-v-spacing / 2;
+
+    @include mq($from: desktop) {
+      line-height: 50px;
+    }
   }
+
   span:first-of-type {
     position: relative;
     z-index: 5;
@@ -65,15 +79,17 @@
 
   @include mq($from: phablet) {
     justify-content: flex-end;
-    margin-top: -11rem;
+    margin-top: -230px;
+    // margin-top: -11rem;
   }
 
   @include mq($from: desktop) {
-    margin-top: -12rem;
+    margin-top: -250px;
+    // margin-top: -12rem;
   }
 
   @include mq($from: leftCol) {
-    margin-top: -15rem;
+    // margin-top: -280px;
   }
 }
 
@@ -87,14 +103,18 @@
   line-height: 0 !important;
 
   img {
-    max-height: 180px;
+    max-height: 240px;
 
     @include mq($from: phablet) {
-      max-height: 230px;
+      max-height: 330px;
+    }
+
+    @include mq($from: desktop) {
+      max-height: 380px;
     }
 
     @include mq($from: leftCol) {
-      max-height: 280px;
+      max-height: 380px;
     }
   }
 }
@@ -102,7 +122,8 @@
 .sale-joy-of-print-badge {
   position: absolute;
   // margin-bottom: -3rem;
-  margin-left: -44px;
+  margin-left: -40px;
+  margin-top: 20px;
   z-index: 1;
   flex-direction: column;
   display: flex;
@@ -135,9 +156,16 @@
     font-feature-settings: "lnum";
   }
 
+  @include mq($from: phablet) {
+    margin-left: -20px;
+    margin-top: 30px;
+  }
+
   @include mq($from: desktop) {
     width: 8.6rem;
     height: 8.6rem;
+    margin-top: 50px;
+    margin-left: -50px;
     span:nth-child(2) {
       font-size: 3.3rem;
       top: -0.3rem;

--- a/support-frontend/assets/pages/paper-subscription-landing/components/hero/joyOfPrint.scss
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/hero/joyOfPrint.scss
@@ -1,9 +1,10 @@
 @import '~stylesheets/gu-sass/gu-sass';
 
-// "Joy of Print Sale" specific styles below! 
+// "Joy of Print Sale" specific styles below!
 
 .component-product-page-hero--campaign.component-product-page-hero--paper-sale {
-  background: #ffe500;
+  background: gu-colour(news-faded);
+  // background: gu-colour(highlight-main);
   height: auto;
   border-bottom: 1px solid gu-colour(neutral-86);
   min-height: auto;
@@ -23,45 +24,44 @@
   @include mq($from: leftCol) {
     margin-top: $gu-v-spacing * 6;
   }
-  
+
   @include mq($from: phablet) {
     font-size: 35px;
     line-height: 1;
     display: block;
     padding-left: $gu-v-spacing;
-    
-    h2 {
-      font-family: $gu-titlepiece;
-      margin: $gu-v-spacing * 2 0;
-      span {
-        padding: 0 $gu-h-spacing / 2;
-        padding-right: $gu-h-spacing / 2;
-        @include mq($from: desktop) {
-          line-height: 50px;
-        }
-        background-color: black;
-        color: #ffffff;
-        padding-bottom: $gu-v-spacing / 2;
-      }
-      span:first-of-type {
-        position: relative;
-        z-index: 5;
-      }
-    }
-    p {
-      @include gu-fontset-heading;
-      padding-left: $gu-h-spacing / 3;
-    }
   }
+
   @include mq($from: desktop) {
     font-size: 45px;
+  }
+}
+
+
+.sale-joy-of-print__copy-text {
+  font-family: $gu-titlepiece;
+  margin: $gu-v-spacing * 2 0;
+  span {
+    padding: 0 $gu-h-spacing / 2;
+    padding-right: $gu-h-spacing / 2;
+    @include mq($from: desktop) {
+      line-height: 50px;
+    }
+    background-color: black;
+    color: #ffffff;
+    padding-bottom: $gu-v-spacing / 2;
+  }
+  span:first-of-type {
+    position: relative;
+    z-index: 5;
   }
 }
 
 .sale-joy-of-print-graphic-outer {
   display: flex;
   justify-content: center;
-  margin-top: 2rem;
+  max-width: 1040px;
+  // margin-top: 2rem;
 
   @include mq($from: phablet) {
     justify-content: flex-end;
@@ -70,11 +70,11 @@
 
   @include mq($from: desktop) {
     margin-top: -12rem;
-  }  
+  }
 
   @include mq($from: leftCol) {
     margin-top: -15rem;
-  }  
+  }
 }
 
 .sale-joy-of-print-graphic-inner {
@@ -85,21 +85,24 @@
 
 .sale-joy-of-print-graphic {
   line-height: 0 !important;
+
   img {
     max-height: 180px;
-  }
 
-  @include mq($from: leftCol) {
-    img {
+    @include mq($from: phablet) {
+      max-height: 230px;
+    }
+
+    @include mq($from: leftCol) {
       max-height: 280px;
     }
   }
 }
 
 .sale-joy-of-print-badge {
-  margin-bottom: -3rem;
-  margin-left: -4rem;
-  position: relative;
+  position: absolute;
+  // margin-bottom: -3rem;
+  margin-left: -44px;
   z-index: 1;
   flex-direction: column;
   display: flex;
@@ -118,9 +121,9 @@
 
   span {
     display: block;
-    line-height: 1; 
+    line-height: 1;
   }
-  
+
   span:nth-child(2) {
     font-family: $gu-titlepiece;
     position: relative;

--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
@@ -16,6 +16,7 @@ import PaperAndDigitalPackshot from 'components/packshots/paper-and-digital-pack
 import FullGuardianWeeklyPackShot from 'components/packshots/full-guardian-weekly-packshot';
 import SubscriptionDailyPackshot from 'components/packshots/subscription-daily-packshot';
 import InternationalDailyPackshot from 'components/packshots/international-daily-packshot';
+import PrintFeaturePackshot from 'components/packshots/print-feature-packshot';
 
 // constants
 import { DigitalPack, PremiumTier, GuardianWeekly, Paper, PaperAndDigital } from 'helpers/subscriptions';
@@ -66,6 +67,10 @@ const subsLinks = getSubsLinks(
   abParticipations,
 );
 
+const isUK = () => countryGroupId === 'GBPCountries';
+const isEU = () => countryGroupId === 'EURCountries';
+const isInternational = () => countryGroupId === 'International';
+
 const getPrice = (product: SubscriptionProduct, alternativeText: string) => {
 
   if (flashSaleIsActive(product, countryGroupId)) {
@@ -89,7 +94,7 @@ function getGuardianWeeklyOfferCopy() {
 }
 
 const chooseImage = images =>
-  (countryGroupId === 'GBPCountries' || countryGroupId === 'EURCountries' || countryGroupId === 'International' ? images[0] : images[1]);
+  (countryGroupId === 'EURCountries' || countryGroupId === 'International' ? images[0] : images[1]);
 
 const digital: ProductCopy = {
   title: 'Digital Subscription',
@@ -117,7 +122,7 @@ const guardianWeekly: ProductCopy = {
     link: subsLinks.GuardianWeekly,
     analyticsTracking: sendTrackingEventsOnClick('weekly_cta', 'GuardianWeekly', abTest),
   }],
-  productImage: chooseImage([<GuardianWeeklyPackShot />, <FullGuardianWeeklyPackShot />]),
+  productImage: isUK() || isEU() || isInternational() ? <GuardianWeeklyPackShot /> : <FullGuardianWeeklyPackShot />,
 };
 
 const paper: ProductCopy = {
@@ -129,7 +134,7 @@ const paper: ProductCopy = {
     link: subsLinks.Paper,
     analyticsTracking: sendTrackingEventsOnClick('paper_cta', Paper, abTest, 'paper-subscription'),
   }],
-  productImage: <PaperPackshot />,
+  productImage: <PrintFeaturePackshot />,
   offer: getSaleCopy(Paper, countryGroupId).bundle.subHeading,
 };
 
@@ -165,9 +170,9 @@ const premiumApp: ProductCopy = {
 
 const orderedProducts: { [CountryGroupId]: ProductCopy[] } = {
   GBPCountries: [
+    paper,
     digital,
     guardianWeekly,
-    paper,
     paperAndDigital,
     premiumApp,
   ],

--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
@@ -17,6 +17,7 @@ import FullGuardianWeeklyPackShot from 'components/packshots/full-guardian-weekl
 import SubscriptionDailyPackshot from 'components/packshots/subscription-daily-packshot';
 import InternationalDailyPackshot from 'components/packshots/international-daily-packshot';
 import PrintFeaturePackshot from 'components/packshots/print-feature-packshot';
+import { GBPCountries, EURCountries, International, AUDCountries } from 'helpers/internationalisation/countryGroup';
 
 // constants
 import { DigitalPack, PremiumTier, GuardianWeekly, Paper, PaperAndDigital } from 'helpers/subscriptions';
@@ -67,9 +68,10 @@ const subsLinks = getSubsLinks(
   abParticipations,
 );
 
-const isUK = () => countryGroupId === 'GBPCountries';
-const isEU = () => countryGroupId === 'EURCountries';
-const isInternational = () => countryGroupId === 'International';
+const isUK = () => countryGroupId === GBPCountries;
+const isEU = () => countryGroupId === EURCountries;
+const isInternational = () => countryGroupId === International;
+const isAUS = () => countryGroupId === AUDCountries;
 
 const getPrice = (product: SubscriptionProduct, alternativeText: string) => {
 
@@ -93,16 +95,13 @@ function getGuardianWeeklyOfferCopy() {
   return `6 issues for ${currency}6`;
 }
 
-const chooseImage = images =>
-  (countryGroupId === 'EURCountries' || countryGroupId === 'International' ? images[0] : images[1]);
-
 const digital: ProductCopy = {
   title: 'Digital Subscription',
   subtitle: getPrice(DigitalPack, ''),
-  description: countryGroupId === 'AUDCountries'
+  description: isAUS()
     ? 'The UK Guardian Daily, Premium access to The Guardian Live app and ad-free reading on theguardian.com'
     : 'The Guardian Daily, Premium access to The Guardian Live app and ad-free reading on theguardian.com',
-  productImage: chooseImage([<SubscriptionDailyPackshot />, <InternationalDailyPackshot />]),
+  productImage: isEU() || isInternational() ? <SubscriptionDailyPackshot /> : <InternationalDailyPackshot />,
   offer: getSaleCopy(DigitalPack, countryGroupId).bundle.subHeading,
   buttons: [{
     ctaButtonText: 'Find out more',

--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
@@ -10,7 +10,7 @@ import trackAppStoreLink from 'components/subscriptionBundles/appCtaTracking';
 
 // images
 import GuardianWeeklyPackShot from 'components/packshots/guardian-weekly-packshot';
-import PaperPackshot from 'components/packshots/paper-packshot';
+// import PaperPackshot from 'components/packshots/paper-packshot';
 import PremiumAppPackshot from 'components/packshots/premium-app-packshot';
 import PaperAndDigitalPackshot from 'components/packshots/paper-and-digital-packshot';
 import FullGuardianWeeklyPackShot from 'components/packshots/full-guardian-weekly-packshot';

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.scss
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.scss
@@ -500,6 +500,13 @@
     transform: translate(-50%);
 }
 
+.component-grid-image--subscriptions-print-feature-image {
+  width: 100%;
+
+  @include mq($from: tablet) {
+    width: 566px;
+  }
+}
 /****************** packshots ********************/
 .subscriptions-feature-packshot {
   width: 140%;


### PR DESCRIPTION
## Why are you doing this?
These changes are for the upcoming General Election, which involve change the print subscription banner and adding the 25% off sales copy to the print subscription page and showcase page

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/5AGabLoV/2709-voucher-hd-25-off-annual-marketing-campaign-29-11-15-12-around-election)

## Changes
* Print section moved to the top of the showcase page, with sale price shown
* Print Subscription banner changed
* Sale prices on price cards for Vouchers
* Sale prices on price cards for HomeDelivery

## Screenshots

