### PR TITLE
Fix image display on support page header

### DIFF
--- a/support-frontend/assets/pages/showcase/components/hero.jsx
+++ b/support-frontend/assets/pages/showcase/components/hero.jsx
@@ -43,7 +43,7 @@ export default function Hero(props: { countryGroupId: CountryGroupId }) {
         <div className="showcase-hero-heading">
           <h1 className="visually-hidden">Support the guardian</h1>
           <h2 className="visually-hidden">Help us support investigative independent journalism</h2>
-          <HeroImg />
+          <div className="showcase-hero-heading__image-wrapper"><HeroImg /></div>
         </div>
         <div className="showcase-hero--left">
           <div className="showcase-hero__image showcase-hero__image--first">

--- a/support-frontend/assets/pages/showcase/components/hero.scss
+++ b/support-frontend/assets/pages/showcase/components/hero.scss
@@ -13,6 +13,8 @@
   margin: $gu-v-spacing 0 $gu-v-spacing * 2 $gu-v-spacing;
 }
 
+.showcase-hero-heading__image-wrapper
+
 // Media agnostic caption styles
 
 .showcase-hero__caption {
@@ -129,6 +131,14 @@
     border-right: 1px solid rgba(0, 0, 0, .1);
   }
 
+  .showcase-hero__caption {
+    display: block;
+    text-align: left;
+    @include gu-fontset-explainer;
+    margin: $gu-h-spacing $gu-h-spacing $gu-h-spacing / 2;
+    font-size: 14px;
+  }
+
   .showcase-hero__image {
     height: 37vw;
     width: 47%;
@@ -224,6 +234,10 @@
       margin: $gu-h-spacing;
       padding-left: 0;
 
+      .showcase-hero-heading__image-wrapper {
+        max-width: 480px;
+      }
+
       svg {
         min-width: 460px;
       }
@@ -231,6 +245,7 @@
     }
 
     .showcase-hero__caption {
+      @include gu-fontset-explainer;
       width: gu-span(3);
       margin-top: 0;
       margin-left: 0;

--- a/support-frontend/assets/pages/showcase/components/hero.scss
+++ b/support-frontend/assets/pages/showcase/components/hero.scss
@@ -13,8 +13,6 @@
   margin: $gu-v-spacing 0 $gu-v-spacing * 2 $gu-v-spacing;
 }
 
-.showcase-hero-heading__image-wrapper
-
 // Media agnostic caption styles
 
 .showcase-hero__caption {


### PR DESCRIPTION
## Why are you doing this?
Because it's broken.

[**Trello Card**](https://trello.com/c/NAtisKoO/2787-display-issue-on-why-support-page-in-firefox)

## Screenshots
Fixed on Firefox:

![Screen Shot 2019-12-02 at 15 45 19](https://user-images.githubusercontent.com/16781258/69973070-c5cb7600-151a-11ea-8ff3-6a974852cdb2.png)

Still looking nice on Chrome:

![Screen Shot 2019-12-02 at 15 44 04](https://user-images.githubusercontent.com/16781258/69973022-a2a0c680-151a-11ea-8619-218b330ff476.png)

