### PR TITLE
Fix header for gifting landing page

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.jsx
@@ -73,7 +73,7 @@ const CampaignHeader = (props: {heading: string, orderIsAGift: boolean}) => (
     <div className="weekly-campaign-hero">
       <div className={props.orderIsAGift ? 'weekly-gifting-hero__copy' : 'weekly-campaign-hero__copy'}>
         {props.orderIsAGift ? (
-          <h2>Give The Guardian Weekly</h2>
+          <h2>Give<br />The Guardian Weekly</h2>
           ) : (
             <h2>The Guardian<br />Weekly</h2>
           )


### PR DESCRIPTION
## Why are you doing this?
It didn't look quite right.

[**Trello Card**](https://trello.com/c/2Zl6IW2m/2766-gw-gifting-header-text-on-gift-landing-page-desktop-only)

## Screenshots
![Screen Shot 2019-12-04 at 10 23 29](https://user-images.githubusercontent.com/16781258/70134644-68513980-1680-11ea-8438-dbd0799a9e33.png)

![Screen Shot 2019-12-04 at 10 23 00](https://user-images.githubusercontent.com/16781258/70134651-6b4c2a00-1680-11ea-9bfd-ed186a0091da.png)
