### PR TITLE
Remove circles from digital subs thank you page

### DIFF
--- a/support-frontend/assets/components/productHero/productHero.jsx
+++ b/support-frontend/assets/components/productHero/productHero.jsx
@@ -11,8 +11,6 @@ import {
   type GridSlot,
   type Source as GridSource,
 } from 'components/gridPicture/gridPicture';
-import SvgCirclesLeft from 'components/svgs/circlesLeft';
-import SvgCirclesRight from 'components/svgs/circlesRight';
 
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { type ImageId as GridId, type ImageType } from 'helpers/theGrid';
@@ -80,8 +78,6 @@ function ProductHero(props: PropTypes) {
   return (
     <div className="component-product-hero">
       <LeftMarginSection>
-        <SvgCirclesLeft />
-        <SvgCirclesRight />
         <GridPicture
           sources={sources}
           fallback={gridImages.fallback}


### PR DESCRIPTION
## Why are you doing this?
Because circles are sooooo yesterday.

[**Trello Card**](https://trello.com/c/YmTB0pSx/2677-remove-circles-design-from-digital-pack-thank-you-page)

## Screenshots
![support thegulocal com_subscribe_digital_checkout_promoCode=DK0NT24WG(wide) (1)](https://user-images.githubusercontent.com/16781258/70138340-f846b180-1687-11ea-9663-1cf7beead791.png)
