### PR TITLE
Landing page font fix

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/newTemplate.scss
+++ b/support-frontend/assets/pages/contributions-landing/newTemplate.scss
@@ -1,9 +1,6 @@
-@import '~stylesheets/skeleton/skeleton';
 @import '~stylesheets/gu-sass/gu-sass';
 
-
 .gu-content--new-template {
-
   overflow: initial;
 
   /* Page component - contains ContributionFormContainer */


### PR DESCRIPTION
## Why are you doing this?
There was an unnecessary stylesheet being imported into the stylesheet for the new landing page. This was causing a CSS reset to happen after much intentional CSS had been applied. This PR removes that import and fixes the bug.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com)

## Screenshots
Fixed form:
<img width="493" alt="fixed form" src="https://user-images.githubusercontent.com/3300789/70155389-132a1d80-16aa-11ea-91ff-2a221d8e6997.png">
