### PR TITLE
Adjust position of image for print feature card on showcase

### DIFF
--- a/support-frontend/assets/components/packshots/print-feature-packshot.jsx
+++ b/support-frontend/assets/components/packshots/print-feature-packshot.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import GridImage from 'components/gridImage/gridImage';
 
 const PrintFeaturePackshot = () => (
-  <div>
+  <div className="subscriptions-print-feature--packshot">
     <GridImage
       classModifiers={['subscriptions-print-feature-image']}
       gridId="printFeaturePackshot"

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.scss
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.scss
@@ -548,6 +548,16 @@
     transform: translate(-50%);
 }
 
+.subscriptions-print-feature--packshot {
+  @include mq($from: tablet) {
+    margin-top: 45px;
+  }
+
+  @include mq($from: leftCol) {
+    margin-top: 20px;
+  }
+}
+
 .component-grid-image--subscriptions-print-feature-image {
   width: 100%;
 


### PR DESCRIPTION
## Why are you doing this?
The position of the image for the print feature had drifted up away from the bottom edge of the blue feature box. This work is meant to keep the image neatly at the edge.

[**Trello Card**](https://trello.com/c/HqXD3q73/2790-image-fix-on-showcase-page)

## Screenshots
![Screen Shot 2019-12-09 at 12 02 16](https://user-images.githubusercontent.com/16781258/70434309-c4023500-1a7b-11ea-8e25-b444d81ebccb.png)
