### PR TITLE
Don't offer 27th of Dec as a delivery date for GW

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-checkout/helpers/__tests__/deliveryDays.js
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/helpers/__tests__/deliveryDays.js
@@ -11,6 +11,7 @@ const tuesday = 1551175752198; /* 2019-02-26 */
 const friday = 1551399618000; /* 2019-03-01 */
 const thursday = 1551918018000; /* 2019-03-07 */
 const sunday = 1552176000000; /* 2019-03-10 */
+const ninthOfDecember = 1575891520247; /* 2019-12-09 */
 
 describe('deliveryDays', () => {
 
@@ -36,6 +37,11 @@ describe('deliveryDays', () => {
     it('if you order on a Sunday, it delivers the Weekly on Friday week', () => {
       const days = getWeeklyDays(sunday);
       expect(formatMachineDate(days[0])).toEqual('2019-03-22');
+    });
+    it('should not offer the 27th of December as a possible delivery date', () => {
+      const days = getWeeklyDays(ninthOfDecember);
+      expect(days.find(d => d.getDate() === 27 && d.getMonth === 1)).toEqual(undefined);
+      expect(days.length).toEqual(5)
     });
   });
 

--- a/support-frontend/assets/pages/weekly-subscription-checkout/helpers/deliveryDays.js
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/helpers/deliveryDays.js
@@ -13,16 +13,24 @@ const extraDelayWeeks = 2;
 const getWeeklyDays = (today: ?number): Date[] => {
   const now = new Date(today || new Date().getTime());
   const currentWeekday = now.getDay();
+  const isChrismassy = (d: Date) => d.getDate() === 27 && d.getMonth() === 11;
   const weeksToAdd =
       currentWeekday > extraDelayCutoffWeekday ||
       currentWeekday === 0 // Sunday is considered the last day of the week
         ? extraDelayWeeks
         : normalDelayWeeks;
-  return getDeliveryDays(
+
+  const allDeliveryDays = getDeliveryDays(
     now.getTime(),
     5,
     numberOfWeeksWeDeliverTo + weeksToAdd,
-  ).splice(weeksToAdd);
+  );
+
+  const nonChrismassy = allDeliveryDays.filter(d => !isChrismassy(d));
+
+  const numberOfChrismassyDays = allDeliveryDays.length - nonChrismassy.length;
+
+  return nonChrismassy.splice(weeksToAdd - numberOfChrismassyDays);
 };
 
 function getDisplayDays(): string[] {


### PR DESCRIPTION
## Why are you doing this?

There is no Guardian Weekly issue on December the 27th so we shouldn't offer this as a potential delivery date.

[**Trello Card**](https://trello.com/c/pxFZq1ZM/2798-exclude-the-27th-of-dec-from-list-of-delivery-dates-for-guardian-weekly)


