### PR TITLE
Bug fix

### DIFF
--- a/support-frontend/assets/helpers/subscriptionsForms/deliveryDays.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/deliveryDays.js
@@ -25,6 +25,9 @@ const getDateOfDeliveryDayInCurrentWeek = (today: number, day: Day): Date => {
   return new Date(today + (diff * milsInADay));
 };
 
+const getNextDeliveryDay = (previousDeliveryDay: Date) =>
+  new Date(previousDeliveryDay.getTime() + (7 * milsInADay));
+
 const getDeliveryDays = (today: number, day: Day, length: number = numberOfWeeksWeDeliverTo): Date[] => {
   const initial = getDateOfDeliveryDayInCurrentWeek(today, day);
   const deliveryDays = [initial];
@@ -33,9 +36,6 @@ const getDeliveryDays = (today: number, day: Day, length: number = numberOfWeeks
   }
   return deliveryDays;
 };
-
-const getNextDeliveryDay = (previousDeliveryDay: Date) =>
-  new Date(previousDeliveryDay.getTime()  + (7 * milsInADay));
 
 export {
   jsDayToFulfilmentDay,

--- a/support-frontend/assets/helpers/subscriptionsForms/deliveryDays.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/deliveryDays.js
@@ -27,15 +27,19 @@ const getDateOfDeliveryDayInCurrentWeek = (today: number, day: Day): Date => {
 
 const getDeliveryDays = (today: number, day: Day, length: number = numberOfWeeksWeDeliverTo): Date[] => {
   const initial = getDateOfDeliveryDayInCurrentWeek(today, day);
-  const rt = [initial];
+  const deliveryDays = [initial];
   for (let i = 1; i <= length; i += 1) {
-    rt.push(new Date(rt[i - 1].getTime() + (7 * milsInADay)));
+    deliveryDays.push(getNextDeliveryDay(deliveryDays[i - 1]));
   }
-  return rt;
+  return deliveryDays;
 };
+
+const getNextDeliveryDay = (previousDeliveryDay: Date) =>
+  new Date(previousDeliveryDay.getTime()  + (7 * milsInADay));
 
 export {
   jsDayToFulfilmentDay,
   getDeliveryDays,
+  getNextDeliveryDay,
   DeliveryDays,
 };

--- a/support-frontend/assets/pages/weekly-subscription-checkout/helpers/__tests__/deliveryDays.js
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/helpers/__tests__/deliveryDays.js
@@ -41,7 +41,7 @@ describe('deliveryDays', () => {
     it('should not offer the 27th of December as a possible delivery date', () => {
       const days = getWeeklyDays(ninthOfDecember);
       expect(days.find(d => d.getDate() === 27 && d.getMonth === 1)).toEqual(undefined);
-      expect(days.length).toEqual(5)
+      expect(days.length).toEqual(5);
     });
   });
 

--- a/support-frontend/assets/pages/weekly-subscription-checkout/helpers/deliveryDays.js
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/helpers/deliveryDays.js
@@ -1,7 +1,7 @@
 // @flow
 
 import {
-  getDeliveryDays,
+  getDeliveryDays, getNextDeliveryDay,
   numberOfWeeksWeDeliverTo,
 } from 'helpers/subscriptionsForms/deliveryDays';
 import { formatUserDate } from 'helpers/dateConversions';
@@ -28,9 +28,11 @@ const getWeeklyDays = (today: ?number): Date[] => {
 
   const nonChrismassy = allDeliveryDays.filter(d => !isChrismassy(d));
 
-  const numberOfChrismassyDays = allDeliveryDays.length - nonChrismassy.length;
+  if (allDeliveryDays.length > nonChrismassy.length){
+    nonChrismassy.push(getNextDeliveryDay(nonChrismassy[nonChrismassy.length - 1]));
+  }
 
-  return nonChrismassy.splice(weeksToAdd - numberOfChrismassyDays);
+  return nonChrismassy.splice(weeksToAdd);
 };
 
 function getDisplayDays(): string[] {

--- a/support-frontend/assets/pages/weekly-subscription-checkout/helpers/deliveryDays.js
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/helpers/deliveryDays.js
@@ -28,7 +28,7 @@ const getWeeklyDays = (today: ?number): Date[] => {
 
   const nonChrismassy = allDeliveryDays.filter(d => !isChrismassy(d));
 
-  if (allDeliveryDays.length > nonChrismassy.length){
+  if (allDeliveryDays.length > nonChrismassy.length) {
     nonChrismassy.push(getNextDeliveryDay(nonChrismassy[nonChrismassy.length - 1]));
   }
 


### PR DESCRIPTION
## Why are you doing this?
#2273 removed the 27th of December as a delivery option for Guardian Weekly, however it introduced a bug which meant that we were showing a date which is too soon for us to fulfil.

This fixes that.


