### PR TITLE
Update js-yaml to address snyk issue

### DIFF
--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -141,5 +141,10 @@
     "webpack-manifest-plugin": "2.0.3",
     "webpack-merge": "^4.1.3",
     "webpack-stats-plugin": "^0.2.1"
+  },
+  "resolutions": {
+    "cssnano/cosmiconfig/js-yaml": "3.13.1",
+    "optimize-css-assets-webpack-plugin/**/js-yaml": "3.13.1",
+    "postcss-load-config/cosmiconfig/js-yaml": "3.13.1"
   }
 }

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -8749,15 +8749,7 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.12.0, js-yaml@^3.9.0:
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
-  integrity sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^4.0.0"
-
-js-yaml@^3.13.0, js-yaml@^3.13.1:
+js-yaml@3.13.1, js-yaml@^3.12.0, js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.9.0:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==


### PR DESCRIPTION
## Why are you doing this?
This [snyk issue](https://app.snyk.io/org/the-guardian-cuu/project/4945d58e-89a9-4577-9acf-4831f0e0231a#issue-SNYK-JS-JSYAML-174129) suggests updating js-yaml, which is a sub-dependency of cssnano.

It turns out that js-yaml is a sub-dependency of a number of node modules, so there are various places where it might need to be updated.

It wasn't updated in every case - in some places there seems to be a dependency on a specific version of it.