### PR TITLE
Landing page template test, round 2

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -109,7 +109,7 @@ export const tests: Tests = {
     optimizeId: 'sj4_I5OAT3SJpqgnxtJ6Xg',
   },
 
-  newLandingPageTemplateTest: {
+  newLandingPageTemplateTestR2: {
     type: 'OTHER',
     variants: [
       {

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.jsx
@@ -43,7 +43,7 @@ const mapStateToProps = (state: State) => ({
   tickerGoalReached: state.page.form.tickerGoalReached,
   isReturningContributor: state.page.user.isReturningContributor,
   countryId: state.common.internationalisation.countryId,
-  newTemplateVariant: state.common.abParticipations.newLandingPageTemplateTest,
+  newTemplateVariant: state.common.abParticipations.newLandingPageTemplateTestR2,
   paymentSecuritySecureTransactionGreyNonUKVariant:
     state.common.abParticipations.paymentSecuritySecureTransactionGreyNonUK,
 });

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
@@ -21,7 +21,6 @@ import { set as setCookie } from 'helpers/cookie';
 import Page from 'components/page/page';
 import Footer from 'components/footer/footer';
 import { RoundelHeader } from 'components/headers/roundelHeader/header';
-import { SlimRoundelHeader } from 'components/headers/slimRoundelHeader/slimRoundelHeader';
 import { campaigns, getCampaignName } from 'helpers/campaigns';
 import { init as formInit } from './contributionsLandingInit';
 import { initReducer } from './contributionsLandingReducer';
@@ -97,7 +96,7 @@ const backgroundImageSrc = campaignName && campaigns[campaignName] && campaigns[
   campaigns[campaignName].backgroundImage : null;
 
 const showSecureTransactionIndicator = () => {
-  if (store.getState().common.abParticipations.newLandingPageTemplateTest === 'control') {
+  if (store.getState().common.abParticipations.newLandingPageTemplateTestR2 === 'control') {
     if (countryGroupId === 'GBPCountries') {
       return <SecureTransactionIndicator modifierClasses={['top']} />;
     } else if (store.getState().common.abParticipations.paymentSecuritySecureTransactionGreyNonUK === 'V1_securetransactiongrey') {
@@ -126,7 +125,7 @@ const originalPage = (campaignCodeParameter: ?string) => (
 const newTemplagePage = (campaignCodeParameter: ?string) => (
   <Page
     classModifiers={['new-template']}
-    header={<SlimRoundelHeader selectedCountryGroup={selectedCountryGroup} />}
+    header={<RoundelHeader selectedCountryGroup={selectedCountryGroup} />}
     footer={<Footer disclaimer countryGroupId={countryGroupId} />}
     backgroundImageSrc={backgroundImageSrc}
   >
@@ -140,7 +139,7 @@ const newTemplagePage = (campaignCodeParameter: ?string) => (
 );
 
 
-const contributionsLandingPage = (campaignCodeParameter: ?string) => (store.getState().common.abParticipations.newLandingPageTemplateTest === 'new_template' ? newTemplagePage(campaignCodeParameter) : originalPage(campaignCodeParameter));
+const contributionsLandingPage = (campaignCodeParameter: ?string) => (store.getState().common.abParticipations.newLandingPageTemplateTestR2 === 'new_template' ? newTemplagePage(campaignCodeParameter) : originalPage(campaignCodeParameter));
 
 const router = (
   <BrowserRouter>

--- a/support-frontend/assets/pages/contributions-landing/newTemplate.scss
+++ b/support-frontend/assets/pages/contributions-landing/newTemplate.scss
@@ -3,42 +3,29 @@
 .gu-content--new-template {
   overflow: initial;
 
-  /* Page component - contains ContributionFormContainer */
-  .gu-content__main {
-    background-color: white;
-  }
-  /* */
-
   /* ContributionFormContainer - contains form and blurb */
   .gu-content__content {
     margin: 0;
     padding: 0;
     overflow: initial;
   }
-
-  .gu-content__content--flex {
-    align-items: flex-start;
-  }
-
-  .gu-content__content-contributions {
-    max-width: 100%;
-  }
   /* */
 
   /* Text on right hand side of landing page */
   .gu-content__blurb {
+    // Magic number alert: copied from 'standard template' calculated width
+    max-width: 388px;
+
     @include mq($from: tablet) {
-      background-color: gu-colour(sport-dark);
-      border: 0; // get rid of yellow top border
+      border: 0; // removes top border from text
       margin-left: 0;
       padding-top: $gu-v-spacing * 5;
       padding-left: $gu-h-spacing * 1.75;
       /* sticky positioning */
       top: 0;
-      position: -webkit-sticky;
       position: sticky;
       align-self: flex-start;
-      height: calc(100vh - 50px);
+      height: auto;
       /* */
     }
 
@@ -51,34 +38,8 @@
     }
   }
 
-  .gu-content__blurb-header {
-    @include mq($from: tablet) {
-      color: white;
-      font-size: 34px;
-      max-width: $gu-h-spacing * 13;
-    }
-
-    @include mq($from: desktop) {
-      font-size: 50px;
-      max-width: $gu-h-spacing * 22;
-    }
-
-    @include mq($from: leftCol) {
-      font-size: 70px;
-      max-width: $gu-h-spacing * 26.75;
-    }
-  }
-
   .gu-content__blurb-blurb {
-    border: 0; // get rid of yellow bottom border
-    color: white;
-    font-size: 16px;
-    max-width: $gu-h-spacing * 13;
-
-    @include mq($from: desktop) {
-      font-size: 17px;
-      max-width: $gu-h-spacing * 23;
-    }
+    border: 0; // removes bottom border from text
   }
   /* */
 
@@ -99,5 +60,19 @@
       max-width: $gu-h-spacing * 32;
       padding: ($gu-v-spacing * 1.5) ($gu-h-spacing * 4.25) 0;
     }
+  }
+}
+
+// Modified header for new template
+.gu-content--new-template .gu-content__header {
+  @include mq($from: leftCol) {
+    padding: 0 85px; // Magic number alert: align the currency selector with the form
+  }
+}
+
+// Modified footer for new template
+.gu-content--new-template .component-footer {
+  .component-left-margin-section::before {
+    max-width: 75px; // Magic number alert: align the footer with the form
   }
 }


### PR DESCRIPTION
## Why are you doing this?
The landing page template test isn't going very well so we are releasing a second round with less variance from the first.
<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/rKzsjt5X/1704-new-round-of-testing-on-the-lp-including-header-and-font-changes)

## Changes

* Changed header to the control version and adapted accordingly to the new layout
* Changed typography to match control version
* Changed colour scheme to match control version
* Adapted footer to fit the new layout

## Screenshots
For comprehensive screenshots, see the previous PR: https://github.com/guardian/support-frontend/pull/2220

Updates reflected below:
![new landing page](https://user-images.githubusercontent.com/3300789/70545209-208d4f00-1b65-11ea-9074-c71b11312e59.png)

