### PR TITLE
Use scalatest version 3.2.0-M1 in all projects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,7 @@ lazy val commonSettings = Seq(
 
 lazy val commonDependencies = Seq(
   "com.typesafe" % "config" % "1.3.2",
-  "org.scalatest" %% "scalatest" % "3.0.8" % "it, test"
+  "org.scalatest" %% "scalatest" % "3.2.0-M1" % "it, test"
 )
 
 lazy val root = (project in file("."))

--- a/support-config/src/test/scala/com/gu/support/config/PromotionsConfigSpec.scala
+++ b/support-config/src/test/scala/com/gu/support/config/PromotionsConfigSpec.scala
@@ -1,9 +1,11 @@
 package com.gu.support.config
 
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class PromotionsConfigSpec extends FlatSpec with Matchers{
+
+class PromotionsConfigSpec extends AsyncFlatSpec with Matchers{
   "PromotionsTablesConfigProvider" should "load successfully" in {
     val devConfig = new PromotionsConfigProvider(ConfigFactory.load(), Stages.DEV).get()
     devConfig.tables.promotions shouldBe "MembershipSub-Promotions-DEV"

--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -15,7 +15,6 @@ resolvers += "Guardian Platform Bintray" at "https://dl.bintray.com/guardian/pla
 libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.3.2",
   "com.gu" %% "simple-configuration-ssm" % "1.5.1",
-  "org.scalatest" %% "scalatest" % "3.2.0-M1" % "test",
   "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test,
   "org.mockito" % "mockito-core" % "2.28.2" % Test,
   "io.sentry" % "sentry-logback" % "1.7.5",

--- a/support-internationalisation/src/test/scala/com/gu/i18n/CountryGroupTest.scala
+++ b/support-internationalisation/src/test/scala/com/gu/i18n/CountryGroupTest.scala
@@ -1,49 +1,49 @@
 package com.gu.i18n
 
 
-import Currency._
-import org.scalatest.FlatSpec
+import com.gu.i18n.Currency._
+import org.scalatest.Inspectors
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class CountryGroupTest extends FlatSpec {
+
+class CountryGroupTest extends AsyncFlatSpec with Matchers with Inspectors {
 
   "A CountryGroup" should "be found by id" in {
-    assert(CountryGroup.byId("ie") === None)
-    assert(CountryGroup.byId("eu") === Some(CountryGroup.Europe))
-    assert(CountryGroup.byId("int") === Some(CountryGroup.RestOfTheWorld))
+    CountryGroup.byId("ie") shouldBe None
+    CountryGroup.byId("eu") shouldBe Some(CountryGroup.Europe)
+    CountryGroup.byId("int") shouldBe Some(CountryGroup.RestOfTheWorld)
   }
 
   it should "be found by its countries names and codes" in {
-    assert(CountryGroup.byCountryNameOrCode(Country.Australia.alpha2) === Some(CountryGroup.Australia))
-    assert(CountryGroup.byCountryNameOrCode(Country.Australia.name) === Some(CountryGroup.Australia))
-    assert(CountryGroup.byCountryNameOrCode(Country.US.alpha2) === Some(CountryGroup.US))
-    assert(CountryGroup.byCountryNameOrCode(Country.US.name) === Some(CountryGroup.US))
-    assert(CountryGroup.byCountryNameOrCode("Italy") === Some(CountryGroup.Europe))
-    assert(CountryGroup.byCountryNameOrCode("IT") === Some(CountryGroup.Europe))
-    assert(CountryGroup.byCountryNameOrCode("AF") === Some(CountryGroup.RestOfTheWorld))
-    assert(CountryGroup.byCountryNameOrCode("Afghanistan") === Some(CountryGroup.RestOfTheWorld))
-    assert(CountryGroup.byCountryNameOrCode("IE") === Some(CountryGroup.Europe))
+    CountryGroup.byCountryNameOrCode(Country.Australia.alpha2) shouldBe Some(CountryGroup.Australia)
+    CountryGroup.byCountryNameOrCode(Country.Australia.name) shouldBe Some(CountryGroup.Australia)
+    CountryGroup.byCountryNameOrCode(Country.US.alpha2) shouldBe Some(CountryGroup.US)
+    CountryGroup.byCountryNameOrCode(Country.US.name) shouldBe Some(CountryGroup.US)
+    CountryGroup.byCountryNameOrCode("Italy") shouldBe Some(CountryGroup.Europe)
+    CountryGroup.byCountryNameOrCode("IT") shouldBe Some(CountryGroup.Europe)
+    CountryGroup.byCountryNameOrCode("AF") shouldBe Some(CountryGroup.RestOfTheWorld)
+    CountryGroup.byCountryNameOrCode("Afghanistan") shouldBe Some(CountryGroup.RestOfTheWorld)
+    CountryGroup.byCountryNameOrCode("IE") shouldBe Some(CountryGroup.Europe)
   }
 
   it should "correctly identify its currencies" in {
-    assert(CountryGroup.availableCurrency(Set.empty)(Country.UK) === None)
-    assert(CountryGroup.availableCurrency(Set(GBP, AUD))(Country.US) === None)
-    assert(CountryGroup.availableCurrency(Set(GBP, AUD))(Country.UK) === Some(GBP))
-    assert(CountryGroup.availableCurrency(Set(GBP, AUD))(Country.Australia) === Some(AUD))
+    CountryGroup.availableCurrency(Set.empty)(Country.UK) shouldBe None
+    CountryGroup.availableCurrency(Set(GBP, AUD))(Country.US) shouldBe None
+    CountryGroup.availableCurrency(Set(GBP, AUD))(Country.UK) shouldBe Some(GBP)
+    CountryGroup.availableCurrency(Set(GBP, AUD))(Country.Australia) shouldBe Some(AUD)
   }
 
   it should "identify countries correctly" in {
-    CountryGroup.countries.map { c =>
-      assert(
-        CountryGroup.byOptimisticCountryNameOrCode(c.name) === Some(c)
-      )
-      assert(
-        CountryGroup.byOptimisticCountryNameOrCode(c.alpha2) === Some(c)
-      )
+    forAll(CountryGroup.countries) { c =>
+        CountryGroup.byOptimisticCountryNameOrCode(c.name) shouldBe Some(c)
+        CountryGroup.byOptimisticCountryNameOrCode(c.alpha2) shouldBe Some(c)
     }
   }
 
   it should "handle null and return None" in {
-    CountryGroup.byOptimisticCountryNameOrCode(null) === None
+    //noinspection ScalaStyle
+    CountryGroup.byOptimisticCountryNameOrCode(null) shouldBe None
   }
 
   it should "identify countries from common alternatives" in {
@@ -61,7 +61,10 @@ class CountryGroupTest extends FlatSpec {
       "united states of america" -> Country.US,
       "trinidad and tobago" -> CountryGroup.countryByCode("TT").get
     )
-    tests.map { case (name: String, country: Country) => assert(CountryGroup.byOptimisticCountryNameOrCode(name) === Some(country)) }
+    forAll(tests){
+      case (name: String, country: Country) =>
+        CountryGroup.byOptimisticCountryNameOrCode(name) shouldBe Some(country)
+    }
   }
 
 

--- a/support-lambdas/stripe-intent/src/test/scala/com/gu/stripeIntent/HandlerITSpec.scala
+++ b/support-lambdas/stripe-intent/src/test/scala/com/gu/stripeIntent/HandlerITSpec.scala
@@ -3,7 +3,8 @@ package com.gu.stripeIntent
 import com.gu.handler.{ApiGatewayRequest, ApiGatewayResponse}
 import com.gu.support.config.Stages
 import com.gu.test.tags.annotations.IntegrationTest
-import org.scalatest.{AsyncFlatSpec, Matchers}
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 @IntegrationTest
 class HandlerITSpec extends AsyncFlatSpec with Matchers {

--- a/support-lambdas/stripe-intent/src/test/scala/com/gu/stripeIntent/HandlerSpec.scala
+++ b/support-lambdas/stripe-intent/src/test/scala/com/gu/stripeIntent/HandlerSpec.scala
@@ -2,11 +2,12 @@ package com.gu.stripeIntent
 
 import java.nio.charset.Charset
 
-import com.gu.handler.{ApiGatewayResponse}
+import com.gu.handler.ApiGatewayResponse
 import com.gu.support.config.Stages
 import okhttp3.{MediaType, Protocol, Request, Response}
 import okio.{Buffer, BufferedSource}
-import org.scalatest.{AsyncFlatSpec, Matchers}
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.collection.JavaConverters._
 import scala.concurrent.Future

--- a/support-models/src/test/scala/com/gu/support/SerialisationTestHelpers.scala
+++ b/support-models/src/test/scala/com/gu/support/SerialisationTestHelpers.scala
@@ -3,7 +3,8 @@ package com.gu.support
 import io.circe.{Decoder, Encoder, Error}
 import io.circe.parser.decode
 import io.circe.syntax._
-import org.scalatest.{Assertion, Matchers}
+import org.scalatest.Assertion
+import org.scalatest.matchers.should.Matchers
 
 trait SerialisationTestHelpers extends Matchers {
   def testDecoding[T : Decoder](fixture: String, objectChecks: T => Assertion = (_: T) => succeed): Assertion = {

--- a/support-models/src/test/scala/com/gu/support/catalog/SerialisationSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/catalog/SerialisationSpec.scala
@@ -3,12 +3,13 @@ package com.gu.support.catalog
 import com.gu.i18n.Currency
 import com.gu.i18n.Currency.GBP
 import com.gu.support.SerialisationTestHelpers
-import com.gu.support.encoding.CustomCodecs.decodeCurrency
 import com.gu.support.config.TouchPointEnvironments.PROD
+import com.gu.support.encoding.CustomCodecs.decodeCurrency
 import com.typesafe.scalalogging.LazyLogging
-import org.scalatest.FlatSpec
+import org.scalatest.Assertion
+import org.scalatest.flatspec.AsyncFlatSpec
 
-class SerialisationSpec extends FlatSpec with SerialisationTestHelpers with LazyLogging {
+class SerialisationSpec extends AsyncFlatSpec with SerialisationTestHelpers with LazyLogging {
 
   "The full Catalog" should "decode successfully" in {
     val digitalPackId = "2c92a0fb4edd70c8014edeaa4eae220a"
@@ -23,7 +24,7 @@ class SerialisationSpec extends FlatSpec with SerialisationTestHelpers with Lazy
       })
   }
 
-  def checkPrice(catalog: Catalog, productRatePlanId: ProductRatePlanId, currency: Currency, value: BigDecimal)={
+  def checkPrice(catalog: Catalog, productRatePlanId: ProductRatePlanId, currency: Currency, value: BigDecimal): Assertion ={
     catalog.prices
       .find(_.productRatePlanId == productRatePlanId)
       .getOrElse(fail())

--- a/support-models/src/test/scala/com/gu/support/encoding/EncoderSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/encoding/EncoderSpec.scala
@@ -6,10 +6,12 @@ import com.gu.support.zuora.api.response.{Invoice, InvoiceResult}
 import com.typesafe.scalalogging.LazyLogging
 import io.circe._
 import io.circe.syntax._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class EncoderSpec extends FlatSpec with Matchers with LazyLogging with SerialisationTestHelpers {
-  implicit val encoder: ObjectEncoder[TestClass] = capitalizingEncoder[TestClass]
+
+class EncoderSpec extends AsyncFlatSpec with Matchers with LazyLogging with SerialisationTestHelpers {
+  implicit val encoder: Encoder[TestClass] = capitalizingEncoder[TestClass]
   implicit val decoderTestClass: Decoder[TestClass] = decapitalizingDecoder[TestClass]
   implicit val decoderOuterClass: Decoder[OuterClass] = decapitalizingDecoder[OuterClass]
   implicit val decodeInvoice: Decoder[Invoice] = decapitalizingDecoder[Invoice]

--- a/support-models/src/test/scala/com/gu/support/encoding/JsonHelpersSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/encoding/JsonHelpersSpec.scala
@@ -1,11 +1,13 @@
 package com.gu.support.encoding
 
 import io.circe.{Json, JsonObject}
-import org.scalatest.{FlatSpec, Matchers}
+
 import JsonHelpers._
 import io.circe.parser._
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class JsonHelpersSpec extends FlatSpec with Matchers {
+class JsonHelpersSpec extends AsyncFlatSpec with Matchers {
 
   "JsonHelper" should "be able to wrap a JsonObject" in {
     val initialObject = JsonObject(("name", Json.fromString("Bill")))

--- a/support-models/src/test/scala/com/gu/support/encoding/PaymentMethodEncoderSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/encoding/PaymentMethodEncoderSpec.scala
@@ -5,9 +5,11 @@ import com.gu.support.encoding.Codec._
 import com.gu.support.workers.{ClonedDirectDebitPaymentMethod, DirectDebitPaymentMethod, PaymentMethod}
 import com.typesafe.scalalogging.LazyLogging
 import io.circe._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class PaymentMethodEncoderSpec extends FlatSpec with Matchers with LazyLogging with SerialisationTestHelpers {
+
+class PaymentMethodEncoderSpec extends AsyncFlatSpec with Matchers with LazyLogging with SerialisationTestHelpers {
 
   it should "correctly decode DirectDebitPaymentMethod" in {
     val json = s"""{

--- a/support-models/src/test/scala/com/gu/support/promotions/SerialisationSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/promotions/SerialisationSpec.scala
@@ -6,10 +6,11 @@ import com.typesafe.scalalogging.LazyLogging
 import org.joda.time.DateTime
 import org.joda.time.Days.days
 import org.joda.time.Months.months
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AsyncFlatSpec
+
 
 //noinspection ScalaStyle
-class SerialisationSpec extends FlatSpec with SerialisationTestHelpers with LazyLogging {
+class SerialisationSpec extends AsyncFlatSpec with SerialisationTestHelpers with LazyLogging {
 
   "Circe" should "be able to decode a discount Promotion" in {
     testDecoding[Promotion](Fixtures.discountPromotion,

--- a/support-models/src/test/scala/com/gu/support/workers/PaymentMethodIdTest.scala
+++ b/support-models/src/test/scala/com/gu/support/workers/PaymentMethodIdTest.scala
@@ -1,19 +1,21 @@
 package com.gu.support.workers
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-import org.scalatest.{FlatSpec, Matchers}
 
-class PaymentMethodIdTest extends FlatSpec with Matchers {
+
+class PaymentMethodIdTest extends AsyncFlatSpec with Matchers {
 
   it should "accept a valid id" in {
     val data = "pm_09AZaz"
     val result = PaymentMethodId(data)
-    result.map(_.value) should be(Some(data))
+    result.map(_.value) shouldBe Some(data)
   }
 
   it should "NOT accept a dangerous id" in {
     val data = "pm_/09AZaz"
     val result = PaymentMethodId(data)
-    result should be(None)
+    result shouldBe None
   }
 
 }

--- a/support-models/src/test/scala/com/gu/support/workers/ProductTypeDecoderTest.scala
+++ b/support-models/src/test/scala/com/gu/support/workers/ProductTypeDecoderTest.scala
@@ -4,9 +4,9 @@ import com.gu.i18n.Currency
 import com.gu.support.SerialisationTestHelpers
 import com.gu.support.catalog.{Collection, RestOfWorld, Sunday}
 import com.gu.support.workers.ProductType._
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
-class ProductTypeDecoderTest extends WordSpec with SerialisationTestHelpers {
+class ProductTypeDecoderTest extends AnyWordSpec with SerialisationTestHelpers {
 
   "ProductTypeDecoder" should {
     "decode a contribution" in {

--- a/support-models/src/test/scala/com/gu/support/workers/ProductTypeRatePlansSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/workers/ProductTypeRatePlansSpec.scala
@@ -5,9 +5,11 @@ import com.gu.support.catalog.{Domestic, Everyday, HomeDelivery}
 import com.gu.support.config.TouchPointEnvironments.SANDBOX
 import com.gu.support.workers.ProductTypeRatePlans._
 import org.scalatest.OptionValues._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ProductTypeRatePlansSpec extends FlatSpec with Matchers{
+
+class ProductTypeRatePlansSpec extends AsyncFlatSpec with Matchers{
 
   "ProductTypeRatePlans type class" should "return the correct product rate plan for a given product type" in {
     val weekly = GuardianWeekly(GBP, Annual, Domestic)

--- a/support-models/src/test/scala/com/gu/support/workers/SerialisationSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/workers/SerialisationSpec.scala
@@ -8,9 +8,10 @@ import com.gu.support.workers.Fixtures._
 import com.gu.support.workers.states._
 import com.typesafe.scalalogging.LazyLogging
 import io.circe.generic.auto._
-import org.scalatest.FlatSpec
+import org.scalatest.flatspec.AsyncFlatSpec
 
-class SerialisationSpec extends FlatSpec with SerialisationTestHelpers with LazyLogging {
+
+class SerialisationSpec extends AsyncFlatSpec with SerialisationTestHelpers with LazyLogging {
 
   "Contribution JSON with a billing period set" should "be decoded correctly" in {
     val input = contribution(billingPeriod = Annual)

--- a/support-models/src/test/scala/com/gu/support/zuora/api/SerialisationSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/zuora/api/SerialisationSpec.scala
@@ -12,9 +12,11 @@ import io.circe.parser._
 import io.circe.syntax._
 import org.joda.time.LocalDate
 import org.joda.time.Months.months
-import org.scalatest.FlatSpec
+import org.scalatest.{Inspectors, Succeeded}
+import org.scalatest.flatspec.AsyncFlatSpec
 
-class SerialisationSpec extends FlatSpec with SerialisationTestHelpers with LazyLogging {
+
+class SerialisationSpec extends AsyncFlatSpec with SerialisationTestHelpers with LazyLogging with Inspectors {
 
   "Account" should "serialise to correct json" in {
     val json = account(GBP).asJson
@@ -124,6 +126,7 @@ class SerialisationSpec extends FlatSpec with SerialisationTestHelpers with Lazy
     val encoded = subscription.asJson
     (encoded \\ "InitialPromotionCode__c").map(_ shouldBe Json.fromString(promoCode))
     (encoded \\ "PromotionCode__c").map(_ shouldBe Json.fromString(promoCode))
+    succeed
   }
 
   "SubscribeResponseAccount" should "deserialise correctly" in {

--- a/support-services/src/test/scala/com/gu/aws/AwsCloudWatchMetricPutSpec.scala
+++ b/support-services/src/test/scala/com/gu/aws/AwsCloudWatchMetricPutSpec.scala
@@ -3,7 +3,8 @@ package com.gu.aws
 import com.gu.aws.AwsCloudWatchMetricPut.{catalogFailureRequest, client}
 import com.gu.support.config.TouchPointEnvironments
 import com.gu.test.tags.annotations.IntegrationTest
-import org.scalatest.{AsyncFlatSpec, Matchers}
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 @IntegrationTest
 class AwsCloudWatchMetricPutSpec extends AsyncFlatSpec with Matchers {

--- a/support-services/src/test/scala/com/gu/support/catalog/CatalogServiceIntegrationSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/catalog/CatalogServiceIntegrationSpec.scala
@@ -3,10 +3,13 @@ package com.gu.support.catalog
 import com.gu.support.config.TouchPointEnvironment
 import com.gu.support.config.TouchPointEnvironments.{PROD, SANDBOX, UAT}
 import com.gu.test.tags.annotations.IntegrationTest
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.Inspectors
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
 
 @IntegrationTest
-class CatalogServiceIntegrationSpec extends FlatSpec with Matchers {
+class CatalogServiceIntegrationSpec extends AsyncFlatSpec with Matchers with Inspectors {
 
   "CatalogService" should "load the correct catalog for the given environment" in {
     Console.println("Testing PROD")
@@ -25,7 +28,7 @@ class CatalogServiceIntegrationSpec extends FlatSpec with Matchers {
   }
 
   private def testProductAndEnvironment(service: CatalogService, product: Product, environment: TouchPointEnvironment) =
-    product.ratePlans(environment).map(
+    forAll(product.ratePlans(environment))(
       ratePlan =>
         service.getPriceList(ratePlan).fold {
           Console.println(s"Failed to find a catalog price list for $environment > $product > ${ratePlan.id}")

--- a/support-services/src/test/scala/com/gu/support/catalog/CatalogServiceSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/catalog/CatalogServiceSpec.scala
@@ -3,11 +3,14 @@ package com.gu.support.catalog
 import com.gu.i18n.Currency.{GBP, USD}
 import com.gu.support.workers.{Annual, Monthly, Quarterly}
 import io.circe.parser._
-import org.scalatest.{FlatSpec, Matchers}
+
 import CatalogServiceSpec.serviceWithFixtures
 import com.gu.support.config.TouchPointEnvironments.PROD
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class CatalogServiceSpec extends FlatSpec with Matchers {
+
+class CatalogServiceSpec extends AsyncFlatSpec with Matchers {
 
   "CatalogService" should "load the catalog" in {
     serviceWithFixtures.getPrice(

--- a/support-services/src/test/scala/com/gu/support/getaddressio/GetAddressIOServiceSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/getaddressio/GetAddressIOServiceSpec.scala
@@ -5,7 +5,8 @@ import com.gu.okhttp.RequestRunners
 import com.gu.support.config.GetAddressIOConfig
 import com.gu.test.tags.annotations.IntegrationTest
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{AsyncFlatSpec, Matchers}
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 @IntegrationTest
 class GetAddressIOServiceSpec extends AsyncFlatSpec with Matchers {

--- a/support-services/src/test/scala/com/gu/support/pricing/PriceSummaryServiceIntegrationSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/pricing/PriceSummaryServiceIntegrationSpec.scala
@@ -7,10 +7,12 @@ import com.gu.support.promotions.PromotionServiceSpec
 import com.gu.support.workers.{Annual, Quarterly}
 import com.gu.test.tags.annotations.IntegrationTest
 import com.typesafe.scalalogging.LazyLogging
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
 
 @IntegrationTest
-class PriceSummaryServiceIntegrationSpec  extends FlatSpec with Matchers with LazyLogging {
+class PriceSummaryServiceIntegrationSpec  extends AsyncFlatSpec with Matchers with LazyLogging {
   val service = new PriceSummaryService(PromotionServiceSpec.serviceWithDynamo, CatalogService(TouchPointEnvironments.SANDBOX))
 
   "PriceSummaryService" should "return prices" in {

--- a/support-services/src/test/scala/com/gu/support/pricing/PriceSummaryServiceSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/pricing/PriceSummaryServiceSpec.scala
@@ -10,9 +10,11 @@ import com.gu.support.promotions.{DiscountBenefit, PromotionServiceSpec}
 import com.gu.support.workers.{DigitalPack => _, GuardianWeekly => _, Paper => _, _}
 import org.joda.time.Months
 import org.scalatest.OptionValues._
-import org.scalatest.{Assertion, FlatSpec, Matchers}
+import org.scalatest.Assertion
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class PriceSummaryServiceSpec extends FlatSpec with Matchers {
+class PriceSummaryServiceSpec extends AsyncFlatSpec with Matchers {
 
   "PriceSummaryService" should "return prices" in {
 

--- a/support-services/src/test/scala/com/gu/support/promotions/PromotionApplicatorSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/promotions/PromotionApplicatorSpec.scala
@@ -2,9 +2,11 @@ package com.gu.support.promotions
 
 import com.gu.support.config.PromotionsDiscountConfig
 import com.gu.support.promotions.ServicesFixtures._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class PromotionApplicatorSpec extends FlatSpec with Matchers {
+
+class PromotionApplicatorSpec extends AsyncFlatSpec with Matchers {
   val config = PromotionsDiscountConfig(validProductRatePlanId, "112233")
   val correctDate = subscriptionData.subscription.contractEffectiveDate.plusDays(freeTrial.freeTrial.get.duration.getDays)
 

--- a/support-services/src/test/scala/com/gu/support/promotions/PromotionCacheSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/promotions/PromotionCacheSpec.scala
@@ -1,9 +1,11 @@
 package com.gu.support.promotions
 
 import org.joda.time.DateTime
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class PromotionCacheSpec extends FlatSpec with Matchers {
+
+class PromotionCacheSpec extends AsyncFlatSpec with Matchers {
 
   "PromotionCache" should "return cached promotions when they are fresh" in {
     PromotionCache.set(Nil)

--- a/support-services/src/test/scala/com/gu/support/promotions/PromotionServiceIntegrationSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/promotions/PromotionServiceIntegrationSpec.scala
@@ -4,10 +4,12 @@ import com.gu.i18n.Country.UK
 import com.gu.support.promotions.PromotionServiceSpec.serviceWithDynamo
 import com.gu.support.promotions.ServicesFixtures.subscriptionData
 import com.gu.test.tags.annotations.IntegrationTest
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
 
 @IntegrationTest
-class PromotionServiceIntegrationSpec extends FlatSpec with Matchers {
+class PromotionServiceIntegrationSpec extends AsyncFlatSpec with Matchers {
   "PromotionService" should "apply a real promo code" in {
     val realPromoCode = "DJP8L27FY"
     val digipackMonthlyProductRatePlanId = "2c92c0f84bbfec8b014bc655f4852d9d"

--- a/support-services/src/test/scala/com/gu/support/promotions/PromotionServiceSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/promotions/PromotionServiceSpec.scala
@@ -7,10 +7,12 @@ import com.gu.support.config.{PromotionsConfigProvider, Stages}
 import com.gu.support.promotions.PromotionServiceSpec._
 import com.gu.support.promotions.ServicesFixtures.{freeTrialPromoCode, _}
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
 
 //noinspection NameBooleanParameters
-class PromotionServiceSpec extends FlatSpec with Matchers {
+class PromotionServiceSpec extends AsyncFlatSpec with Matchers {
 
   "PromotionService" should "find a PromoCode" in {
     serviceWithFixtures.findPromotion(freeTrialPromoCode) should be(Some(freeTrialWithCode))

--- a/support-services/src/test/scala/com/gu/support/promotions/PromotionTermsSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/promotions/PromotionTermsSpec.scala
@@ -3,9 +3,11 @@ package com.gu.support.promotions
 import com.gu.support.catalog.GuardianWeekly
 import com.gu.support.config.Stages.PROD
 import com.gu.support.promotions.ServicesFixtures.{guardianWeeklyAnnual, guardianWeeklyAnnualGift}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class PromotionTermsSpec extends FlatSpec with Matchers {
+
+class PromotionTermsSpec extends AsyncFlatSpec with Matchers {
   "PromotionTerms object" should "be able to extract the promotion terms from a Promotion" in {
     val promotionTerms = PromotionTerms
       .promotionTermsFromPromotion(PROD)(PromotionWithCode(GuardianWeekly.AnnualPromoCode, guardianWeeklyAnnual))

--- a/support-services/src/test/scala/com/gu/support/promotions/PromotionValidatorSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/promotions/PromotionValidatorSpec.scala
@@ -1,14 +1,14 @@
 package com.gu.support.promotions
 
 import com.gu.i18n.Country.{UK, US}
-import com.gu.support.promotions.ServicesFixtures.{promotion, _}
 import com.gu.support.promotions.PromotionValidator.PromotionExtensions
+import com.gu.support.promotions.ServicesFixtures.{promotion, _}
 import org.joda.time.DateTime
-import org.scalatest.FlatSpec
-import org.scalatest.Matchers._
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 //noinspection NameBooleanParameters
-class PromotionValidatorSpec extends FlatSpec {
+class PromotionValidatorSpec extends AsyncFlatSpec with Matchers {
   val NoErrors = Nil
 
   val thisMorning = DateTime.now().withTimeAtStartOfDay()

--- a/support-services/src/test/scala/com/gu/support/promotions/dynamo/DynamoServiceSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/promotions/dynamo/DynamoServiceSpec.scala
@@ -6,10 +6,12 @@ import com.gu.support.config.Stages.PROD
 import com.gu.test.tags.annotations.IntegrationTest
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.LazyLogging
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
 
 @IntegrationTest
-class DynamoServiceSpec extends FlatSpec with Matchers with LazyLogging {
+class DynamoServiceSpec extends AsyncFlatSpec with Matchers with LazyLogging {
 
   "DynamoService" should "work" ignore {
     val config = new PromotionsConfigProvider(ConfigFactory.load(), PROD).get()


### PR DESCRIPTION
## Why are you doing this?

#2137 upgraded scalatest in support-frontend to 3.2.0-M1 but all the other projects were still using 3.0.8. 

This was causing `NoClassDefFoundError` when using the `SerialisationTestHelpers` class from `support-models` in other projects so I have upgraded all the projects to use version 3.2.0-M1

[**Trello Card**](https://trello.com/c/AAgmcmce/2809-upgrade-scalatest-in-support-frontend)

