### PR TITLE
Bugfix on the new landing page template

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/newTemplate.scss
+++ b/support-frontend/assets/pages/contributions-landing/newTemplate.scss
@@ -8,6 +8,10 @@
     margin: 0;
     padding: 0;
     overflow: initial;
+
+    @include mq($from: leftCol) {
+      max-width: 1070px; // magic number for fixing the width of the page as it's no longer on the grid
+    }
   }
   /* */
 
@@ -46,6 +50,7 @@
   .gu-content__form {
     border: 0;
     padding-top: ($gu-v-spacing * 2);
+    margin: 0;
 
     @include mq($from: tablet) {
       max-width: $gu-h-spacing * 19.25;


### PR DESCRIPTION
This template does not use the grid system but still was being affected by it. I'm not sure why it only caused a visible bug on the US landing page but it did. This change fixes the symptom, not the problem, which will take more work.

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Screenshots
US LP Wide:
<img width="1578" alt="US LP Wide" src="https://user-images.githubusercontent.com/3300789/70639734-c955b000-1c32-11ea-88d7-ecaf20a68be7.png">

UK LP Wide:
<img width="1556" alt="UK LP Wide" src="https://user-images.githubusercontent.com/3300789/70639731-c955b000-1c32-11ea-8478-905d7fb380e7.png">

