### PR TITLE
Restore print landing page to pre-election state

### DIFF
--- a/support-frontend/app/controllers/PaperSubscription.scala
+++ b/support-frontend/app/controllers/PaperSubscription.scala
@@ -59,7 +59,7 @@ class PaperSubscription(
     val css = Left(RefPath("paperSubscriptionLandingPage.css"))
     val canonicalLink = Some(buildCanonicalPaperSubscriptionLink())
     val description = stringsConfig.paperLandingDescription
-    val promoCodes = request.queryString.get("promoCode").map(_.toList).getOrElse(Nil) :+ "GE19SUBS"
+    val promoCodes = request.queryString.get("promoCode").map(_.toList).getOrElse(Nil) :+ "SEP2512VHD"
     val productPrices = priceSummaryServiceProvider.forUser(false).getPrices(Paper, promoCodes)
 
     Ok(views.html.main(title, mainElement, js, css, fontLoaderBundle, description, canonicalLink){

--- a/support-frontend/assets/components/headingBlock/headingBlock.scss
+++ b/support-frontend/assets/components/headingBlock/headingBlock.scss
@@ -31,11 +31,12 @@
   display: inline-block;
   line-height: 1;
   font-weight: bold;
-  color: gu-colour(neutral-7);
+  background-color: gu-colour(highlight-main);
+  color: gu-colour(neutral-97);
   padding: ($gu-v-spacing/2) ($gu-h-spacing / 2);
 
  .component-product-page-hero-heading--campaign & {
-   background-color: #ffffff;
+  background-color: gu-colour(neutral-7);
     @supports(transform:translateY(-100%)) {
       transform: translateY(-100%);
       position: absolute;

--- a/support-frontend/assets/helpers/flashSale.js
+++ b/support-frontend/assets/helpers/flashSale.js
@@ -96,40 +96,6 @@ const Sales: Sale[] = [
       AUDCountries: { ...dpSale, price: 10.75 },
     },
   },
-  {
-    subscriptionProduct: 'Paper',
-    activeRegions: [GBPCountries],
-    startTime: new Date(2019, 10, 28).getTime(), // 28 Nov 2019
-    endTime: new Date(2019, 10, 16).getTime(), // 16 Dec 2019
-    duration: '12 months',
-    saleDetails: {
-      GBPCountries: {
-        promoCode: 'GE19SUBS',
-        annualPlanPromoCode: '',
-        intcmp: '',
-        price: 8.09,
-        annualPrice: 0,
-        discountPercentage: 0.37,
-        saleCopy: {
-          featuredProduct: {
-            heading: 'Paper',
-            subHeading: 'Save up to 52% for a year',
-            description: 'Save on The Guardian and The Observer\'s newspaper retail price all year round.',
-          },
-          landingPage: {
-            roundel: ['Save up to', '52%', 'for a year'],
-            heading: 'Save up to 52% for a year on The Guardian and The Observer',
-            subHeading: '',
-          },
-          bundle: {
-            heading: 'Paper',
-            subHeading: 'Save up to 52% for a year',
-            description: 'Save on The Guardian and The Observer\'s newspaper retail price all year round.',
-          },
-        },
-      },
-    },
-  },
 ];
 
 function getTimeTravelDaysOverride() {

--- a/support-frontend/assets/helpers/flashSale.js
+++ b/support-frontend/assets/helpers/flashSale.js
@@ -100,7 +100,7 @@ const Sales: Sale[] = [
     subscriptionProduct: 'Paper',
     activeRegions: [GBPCountries],
     startTime: new Date(2019, 10, 28).getTime(), // 28 Nov 2019
-    endTime: new Date(2019, 11, 16).getTime(), // 16 Dec 2019
+    endTime: new Date(2019, 10, 16).getTime(), // 16 Dec 2019
     duration: '12 months',
     saleDetails: {
       GBPCountries: {
@@ -109,7 +109,7 @@ const Sales: Sale[] = [
         intcmp: '',
         price: 8.09,
         annualPrice: 0,
-        discountPercentage: 0.52,
+        discountPercentage: 0.37,
         saleCopy: {
           featuredProduct: {
             heading: 'Paper',

--- a/support-frontend/assets/helpers/theGrid.js
+++ b/support-frontend/assets/helpers/theGrid.js
@@ -105,7 +105,6 @@ export const imageCatalogue: {
   gwGiftingPackshotMob: '3d1cecfdc8c90b2005712e56669afe6e3b8c5e5a/688_87_2481_3102',
   giftingGlobe: '4a7ee6f430a29fc8ac8d9f0667cfafc67b6aba46/145_148_1203_1201',
   printFeaturePackshot: '017a2f5c27394635b53c414962bbb775ce9b131d/5_39_1572_861',
-  printRainbowElection: 'd1fe7341c596e2be4436a93be808f2122b0da469/0_0_732_1006',
 };
 
 // Utility type: https://flow.org/en/docs/types/utilities/#toc-keys

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/form.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/form.jsx
@@ -23,6 +23,8 @@ import { getTitle } from '../../helpers/products';
 import type { ProductPrice, ProductPrices } from 'helpers/productPrice/productPrices';
 import { showPrice } from 'helpers/productPrice/productPrices';
 import { getAppliedPromo } from 'helpers/productPrice/promotions';
+import { flashSaleIsActive } from 'helpers/flashSale';
+import { Paper } from 'helpers/subscriptions';
 
 // ---- Helpers ----- //
 
@@ -72,6 +74,27 @@ const copy = {
   },
 };
 
+const getOfferText = (price, productOption, fulfilmentOption) => {
+  if (flashSaleIsActive(Paper)) {
+    return getOfferStr(price, getNewsstandPrice(productOption));
+  }
+  const offerCopy = {
+    Collection: {
+      Everyday: 'Save 37% on retail price',
+      Sixday: 'Save 33% on retail price',
+      Weekend: 'Save 25% on retail price',
+      Sunday: 'Save 22% on retail price',
+    },
+    HomeDelivery: {
+      Everyday: 'Save 17% on retail price',
+      Sixday: 'Save 12% on retail price',
+      Weekend: 'Save 9% on retail price',
+      Sunday: null,
+    },
+  };
+  return offerCopy[fulfilmentOption][productOption];
+};
+
 const getPlans = (
   fulfilmentOption: PaperFulfilmentOptions,
   productPrices: ProductPrices,
@@ -92,9 +115,11 @@ const getPlans = (
         ),
         title: getTitle(productOption),
         copy: copy[fulfilmentOption][productOption],
-        price: getPriceStr(price),
-        offer: getOfferStr(price.price, getNewsstandPrice(productOption)),
-        saving: getSavingStr(getProductPrice(productPrices, fulfilmentOption, productOption)),
+        price: flashSaleIsActive(Paper) ? getPriceStr(price) : getRegularPriceStr(price),
+        offer: getOfferText(price.price, productOption, fulfilmentOption),
+        saving: flashSaleIsActive(Paper)
+          ? getSavingStr(getProductPrice(productPrices, fulfilmentOption, productOption))
+          : null,
       },
     };
   }, {});

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/helpers.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/helpers.jsx
@@ -34,7 +34,7 @@ export type ContentTabPropTypes = {|
   getRef: (?HTMLElement)=> void
 |};
 
-const promoTermsUrl = promotionTermsUrl(getQueryParameter(promoQueryParam) || getPromoCode('Paper', GBPCountries, 'GE19SUBS'));
+const promoTermsUrl = promotionTermsUrl(getQueryParameter(promoQueryParam) || getPromoCode('Paper', GBPCountries, 'SEP2512VHD'));
 
 // Helper functions
 const getPageInfoChip = (): string => {

--- a/support-frontend/assets/pages/paper-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/hero/hero.jsx
@@ -90,7 +90,7 @@ const DefaultHeader = () => (
 const CampaignHeader = () => (
   <ProductPagehero
     appearance="campaign"
-    overheading="Become a Guardian and Observer Subscriber"
+    overheading="The Guardian newspaper subscriptions"
     heading={discountCopy.heading}
     modifierClasses={['paper-sale']}
     content={<AnchorButton onClick={sendTrackingEventsOnClick('options_cta_click', 'Paper', null)} icon={<SvgChevron />} href="#subscribe">See Subscription options</AnchorButton>}
@@ -98,27 +98,22 @@ const CampaignHeader = () => (
   >
     <div className="sale-joy-of-print">
       <div className="sale-joy-of-print-copy">
-        <h2 className="sale-joy-of-print__copy-text">
-          The easiest<br />
-          decision<br />
-          you’ll make<br />
-          this election
-        </h2>
+        <h2><span>Challenge the</span><br /><span>writing on the wall.</span></h2>
+        <p>Become a Guardian and<br />Observer subscriber</p>
       </div>
     </div>
     <div className="sale-joy-of-print-graphic-outer">
       <div className="sale-joy-of-print-graphic-inner">
-
+        <div className="sale-joy-of-print-badge">
+          <Discount discountCopy={discountCopy.roundel} />
+        </div>
         <div className="sale-joy-of-print-graphic">
-          <div className="sale-joy-of-print-badge">
-            <Discount discountCopy={discountCopy.roundel} />
-          </div>
           <GridImage
-            gridId="printRainbowElection"
-            srcSizes={[728, 364]}
+            gridId="printShowcase"
+            srcSizes={[1000, 500]}
             sizes="(max-width: 740px) 100vw, 800px"
-            imgType="png"
-            altText="Election rainbow"
+            imgType="jpg"
+            altText="Newspapers"
           />
         </div>
       </div>

--- a/support-frontend/assets/pages/paper-subscription-landing/components/hero/joyOfPrint.scss
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/hero/joyOfPrint.scss
@@ -3,8 +3,7 @@
 // "Joy of Print Sale" specific styles below!
 
 .component-product-page-hero--campaign.component-product-page-hero--paper-sale {
-  background: gu-colour(news-faded);
-  // background: gu-colour(highlight-main);
+  background: gu-colour(highlight-main);
   height: auto;
   border-bottom: 1px solid gu-colour(neutral-86);
   min-height: auto;
@@ -19,10 +18,10 @@
   display: none;
   position: relative;
   z-index: 10;
-  // margin-top: $gu-v-spacing * 2;
+  margin-top: $gu-v-spacing * 2;
 
   @include mq($from: leftCol) {
-    // margin-top: $gu-v-spacing * 6;
+    margin-top: $gu-v-spacing * 6;
   }
 
   @include mq($from: phablet) {
@@ -30,6 +29,29 @@
     line-height: 1;
     display: block;
     padding-left: $gu-v-spacing;
+
+    h2 {
+      font-family: $gu-titlepiece;
+      margin: $gu-v-spacing * 2 0;
+      span {
+        padding: 0 $gu-h-spacing / 2;
+        padding-right: $gu-h-spacing / 2;
+        @include mq($from: desktop) {
+          line-height: 50px;
+        }
+        background-color: black;
+        color: #ffffff;
+        padding-bottom: $gu-v-spacing / 2;
+      }
+      span:first-of-type {
+        position: relative;
+        z-index: 5;
+      }
+    }
+    p {
+      @include gu-fontset-heading;
+      padding-left: $gu-h-spacing / 3;
+    }
   }
 
   @include mq($from: desktop) {
@@ -37,59 +59,22 @@
   }
 }
 
-
-.sale-joy-of-print__copy-text {
-  margin: 0;
-  font-size: 16px;
-  font-family: $gu-titlepiece;
-
-  @include mq($from: phablet) {
-    font-size: 50px;
-    margin-top: 30px;
-  }
-
-  @include mq($from: desktop) {
-    font-size: 50px;
-    margin-top: 50px;
-  }
-
-  span {
-    padding: 0 $gu-h-spacing / 2;
-    padding-right: $gu-h-spacing / 2;
-    background-color: black;
-    color: #ffffff;
-    padding-bottom: $gu-v-spacing / 2;
-
-    @include mq($from: desktop) {
-      line-height: 50px;
-    }
-  }
-
-  span:first-of-type {
-    position: relative;
-    z-index: 5;
-  }
-}
-
 .sale-joy-of-print-graphic-outer {
   display: flex;
   justify-content: center;
-  max-width: 1040px;
-  // margin-top: 2rem;
+  margin-top: 2rem;
 
   @include mq($from: phablet) {
     justify-content: flex-end;
-    margin-top: -230px;
-    // margin-top: -11rem;
+    margin-top: -11rem;
   }
 
   @include mq($from: desktop) {
-    margin-top: -250px;
-    // margin-top: -12rem;
+    margin-top: -12rem;
   }
 
   @include mq($from: leftCol) {
-    // margin-top: -280px;
+    margin-top: -15rem;
   }
 }
 
@@ -103,27 +88,18 @@
   line-height: 0 !important;
 
   img {
-    max-height: 240px;
-
-    @include mq($from: phablet) {
-      max-height: 330px;
-    }
-
-    @include mq($from: desktop) {
-      max-height: 380px;
-    }
+    max-height: 180px;
 
     @include mq($from: leftCol) {
-      max-height: 380px;
+      max-height: 280px;
     }
   }
 }
 
 .sale-joy-of-print-badge {
-  position: absolute;
-  // margin-bottom: -3rem;
-  margin-left: -40px;
-  margin-top: 20px;
+  position: relative;
+  margin-bottom: -3rem;
+  margin-left: -4rem;
   z-index: 1;
   flex-direction: column;
   display: flex;
@@ -156,16 +132,9 @@
     font-feature-settings: "lnum";
   }
 
-  @include mq($from: phablet) {
-    margin-left: -20px;
-    margin-top: 30px;
-  }
-
   @include mq($from: desktop) {
     width: 8.6rem;
     height: 8.6rem;
-    margin-top: 50px;
-    margin-left: -50px;
     span:nth-child(2) {
       font-size: 3.3rem;
       top: -0.3rem;

--- a/yarn.lock
+++ b/yarn.lock
@@ -304,7 +304,7 @@ ipaddr.js@1.9.0:
   resolved "https://registry.yarnpkg.com/ipaddr.js/-/ipaddr.js-1.9.0.tgz#37df74e430a0e47550fe54a2defe30d8acd95f65"
   integrity sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==
 
-lodash@^4.17.10:
+lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -512,10 +512,10 @@ vary@~1.1.2:
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=
 
-webpack-bundle-analyzer@^3.0.4:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.3.2.tgz#3da733a900f515914e729fcebcd4c40dde71fc6f"
-  integrity sha512-7qvJLPKB4rRWZGjVp5U1KEjwutbDHSKboAl0IfafnrdXMrgC0tOtZbQD6Rw0u4cmpgRN4O02Fc0t8eAT+FgGzA==
+webpack-bundle-analyzer@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.6.0.tgz#39b3a8f829ca044682bc6f9e011c95deb554aefd"
+  integrity sha512-orUfvVYEfBMDXgEKAKVvab5iQ2wXneIEorGNsyuOyVYpjYrI7CUOhhXNDd3huMwQ3vNNWWlGP+hzflMFYNzi2g==
   dependencies:
     acorn "^6.0.7"
     acorn-walk "^6.1.1"
@@ -526,7 +526,7 @@ webpack-bundle-analyzer@^3.0.4:
     express "^4.16.3"
     filesize "^3.6.1"
     gzip-size "^5.0.0"
-    lodash "^4.17.10"
+    lodash "^4.17.15"
     mkdirp "^0.5.1"
     opener "^1.5.1"
     ws "^6.0.0"


### PR DESCRIPTION
## Why are you doing this?
The election changes for the print landing page were temporary and these changes restore the page to its former state.

**These changes are due to be updated on 16 Dec. Do not merge until then!**

[Trello Card](https://trello.com/c/bzPERL3G/2734-switch-off-print-sale-needed-to-be-switched-off-on-16th-morning)

## Changes
* Heading is back to yellow banner
* Maximum discount is restored to 37% in roundel and headings
* Product cards returned to state without offer text

## Voucher tab
![support thegulocal com_uk_subscribe_paper(wide) (3)](https://user-images.githubusercontent.com/16781258/70715168-9d453800-1ce1-11ea-9048-2b50452b643f.png)

## Home delivery tab
![support thegulocal com_uk_subscribe_paper(wide) (2)](https://user-images.githubusercontent.com/16781258/70715150-974f5700-1ce1-11ea-9fc8-9e2d8df62b24.png)

## Subs landing page
![support thegulocal com_uk_subscribe(wide) (1)](https://user-images.githubusercontent.com/16781258/70715172-a1715580-1ce1-11ea-985f-af189d50fe80.png)
