### PR TITLE
Showcase promotions

### DIFF
--- a/support-frontend/app/controllers/Subscriptions.scala
+++ b/support-frontend/app/controllers/Subscriptions.scala
@@ -75,7 +75,8 @@ class Subscriptions(
 
     val weekly = service.getPrices(GuardianWeekly, Nil)(countryGroup)(Domestic)(NoProductOptions)(Quarterly)(countryGroup.currency)
 
-    val digitalSubscription = service.getPrices(DigitalPack, List("DK0NT24WG"))(countryGroup)(NoFulfilmentOptions)(NoProductOptions)(Monthly)(countryGroup.currency)
+    val digitalSubscription = service
+      .getPrices(DigitalPack, List("DK0NT24WG"))(countryGroup)(NoFulfilmentOptions)(NoProductOptions)(Monthly)(countryGroup.currency)
 
     Map(GuardianWeekly.toString -> pricingCopy(weekly), DigitalPack.toString -> pricingCopy(digitalSubscription)) ++ paperMap
   }

--- a/support-frontend/app/controllers/Subscriptions.scala
+++ b/support-frontend/app/controllers/Subscriptions.scala
@@ -86,7 +86,6 @@ class Subscriptions(
     val mainElement = EmptyDiv("subscriptions-landing-page")
     val js = "subscriptionsLandingPage.js"
     val pricingCopy = CountryGroup.byId(countryCode).map(getLandingPrices)
-    val productPrices = priceSummaryServiceProvider.forUser(false).getPrices(Paper, List("GE19SUBS"))
 
     Ok(views.html.main(
       title,
@@ -98,7 +97,6 @@ class Subscriptions(
     ){
       Html(
         s"""<script type="text/javascript">
-              window.guardian.productPrices = ${outputJson(productPrices)}
               window.guardian.pricingCopy = ${outputJson(pricingCopy)}
             </script>""")
     }).withSettingsSurrogateKey

--- a/support-frontend/app/controllers/Subscriptions.scala
+++ b/support-frontend/app/controllers/Subscriptions.scala
@@ -5,11 +5,14 @@ import admin.settings.{AllSettings, AllSettingsProvider, SettingsSurrogateKeySyn
 import assets.{AssetsResolver, RefPath, StyleContent}
 import com.gu.i18n.Country.UK
 import com.gu.i18n.CountryGroup
-import com.gu.support.catalog.GuardianWeekly
+import com.gu.i18n.Currency.GBP
+import com.gu.support.catalog
+import com.gu.support.catalog.{Collection, DigitalPack, Domestic, GuardianWeekly, NoFulfilmentOptions, NoProductOptions, Paper, Sunday}
 import com.gu.support.config.Stage
 import com.gu.support.encoding.CustomCodecs._
-import com.gu.support.pricing.PriceSummaryServiceProvider
-import com.gu.support.promotions.{ProductPromotionCopy, PromotionServiceProvider}
+import com.gu.support.pricing.{PriceSummary, PriceSummaryServiceProvider, ProductPrices}
+import com.gu.support.promotions.{ProductPromotionCopy, PromotionCopy, PromotionServiceProvider}
+import com.gu.support.workers.{Monthly, Quarterly}
 import config.StringsConfig
 import lib.RedirectWithEncodedQueryString
 import play.api.mvc._
@@ -17,6 +20,7 @@ import play.twirl.api.Html
 import services.IdentityService
 import views.EmptyDiv
 import views.ViewHelpers.outputJson
+import com.gu.support.encoding.Codec.deriveCodec
 
 import scala.concurrent.ExecutionContext
 
@@ -46,11 +50,44 @@ class Subscriptions(
     RedirectWithEncodedQueryString("https://subscribe.theguardian.com", request.queryString, status = FOUND)
   }
 
+  case class PriceCopy(price: BigDecimal, discountCopy: String)
+  object PriceCopy {
+    implicit val codec : com.gu.support.encoding.Codec[PriceCopy] = deriveCodec
+  }
+
+  def pricingCopy(priceSummary: PriceSummary, copyField: PromotionCopy => Option[String] = promoCopy => promoCopy.roundel): PriceCopy = {
+    val discountCopy = for {
+      promotion <- priceSummary.promotions.headOption
+      discountedPrice <- promotion.discountedPrice
+    } yield PriceCopy(discountedPrice, promotion.landingPage.flatMap(copyField).getOrElse(""))
+    discountCopy.getOrElse(PriceCopy(priceSummary.price, ""))
+  }
+
+  def getLandingPrices(countryGroup: CountryGroup): Map[String, PriceCopy] = {
+    val service = priceSummaryServiceProvider.forUser(false)
+
+    val paperMap = if (countryGroup == CountryGroup.UK) {
+      val paper = service.getPrices(Paper, List("GE19SUBS"))(CountryGroup.UK)(Collection)(Sunday)(Monthly)(GBP)
+      Map(Paper.toString -> pricingCopy(paper, promoCopy => promoCopy.description))
+    }
+    else
+      Map.empty
+
+    val weekly = service.getPrices(GuardianWeekly, Nil)(countryGroup)(Domestic)(NoProductOptions)(Quarterly)(countryGroup.currency)
+
+    val digitalSubscription = service.getPrices(DigitalPack, List("DK0NT24WG"))(countryGroup)(NoFulfilmentOptions)(NoProductOptions)(Monthly)(countryGroup.currency)
+
+    Map(GuardianWeekly.toString -> pricingCopy(weekly), DigitalPack.toString -> pricingCopy(digitalSubscription)) ++ paperMap
+  }
+
   def landing(countryCode: String): Action[AnyContent] = CachedAction() { implicit request =>
     implicit val settings: AllSettings = settingsProvider.getAllSettings()
     val title = "Support the Guardian | Get a Subscription"
     val mainElement = EmptyDiv("subscriptions-landing-page")
     val js = "subscriptionsLandingPage.js"
+    val pricingCopy = CountryGroup.byId(countryCode).map(getLandingPrices)
+    val productPrices = priceSummaryServiceProvider.forUser(false).getPrices(Paper, List("GE19SUBS"))
+
     Ok(views.html.main(
       title,
       mainElement,
@@ -58,8 +95,13 @@ class Subscriptions(
       Left(RefPath("subscriptionsLandingPage.css")),
       fontLoaderBundle,
       description = stringsConfig.subscriptionsLandingDescription
-    )()).withSettingsSurrogateKey
-
+    ){
+      Html(
+        s"""<script type="text/javascript">
+              window.guardian.productPrices = ${outputJson(productPrices)}
+              window.guardian.pricingCopy = ${outputJson(pricingCopy)}
+            </script>""")
+    }).withSettingsSurrogateKey
   }
 
   def weeklyGeoRedirect(orderIsAGift: Boolean = false): Action[AnyContent] = geoRedirect(

--- a/support-frontend/assets/helpers/routes.js
+++ b/support-frontend/assets/helpers/routes.js
@@ -41,6 +41,9 @@ const routes: {
   createReminder: '/contribute/remind-me',
 };
 
+const countryPath = (countryGroupId: CountryGroupId) =>
+  countryGroups[countryGroupId].supportInternationalisationId;
+
 function postcodeLookupUrl(postcode: string): string {
   return `${getOrigin() + routes.postcodeLookup}/${postcode}`;
 }
@@ -49,12 +52,12 @@ function paperSubsUrl(withDelivery: boolean = false): string {
   return [getOrigin(), 'uk/subscribe/paper', ...(withDelivery ? ['delivery'] : [])].join('/');
 }
 
-function digitalSubscriptionLanding() {
-  return `${getOrigin()}${routes.digitalSubscriptionLanding}`;
+function digitalSubscriptionLanding(countryGroupId: CountryGroupId) {
+  return `${getOrigin()}/${countryPath(countryGroupId)}${routes.digitalSubscriptionLanding}`;
 }
 
-function guardianWeeklyLanding(gift: boolean) {
-  return `${getOrigin()}${gift ? routes.guardianWeeklySubscriptionLandingGift : routes.guardianWeeklySubscriptionLanding}`;
+function guardianWeeklyLanding(countryGroupId: CountryGroupId, gift: boolean) {
+  return `${getOrigin()}/${countryPath(countryGroupId)}${gift ? routes.guardianWeeklySubscriptionLandingGift : routes.guardianWeeklySubscriptionLanding}`;
 }
 
 const promotionTermsUrl = (promoCode: string) => `${getOrigin()}/p/${promoCode}/terms`;
@@ -71,11 +74,11 @@ function paperCheckoutUrl(
 
 // If the user cancels before completing the payment flow, send them back to the contribute page.
 function payPalCancelUrl(cgId: CountryGroupId): string {
-  return `${getOrigin()}/${countryGroups[cgId].supportInternationalisationId}/contribute`;
+  return `${getOrigin()}/${countryPath(cgId)}/contribute`;
 }
 
 function payPalReturnUrl(cgId: CountryGroupId, email: string): string {
-  return `${getOrigin()}/${countryGroups[cgId].supportInternationalisationId}/paypal/rest/return?email=${encodeURIComponent(email)}`;
+  return `${getOrigin()}/${countryPath(cgId)}/paypal/rest/return?email=${encodeURIComponent(email)}`;
 }
 
 // ----- Exports ----- //

--- a/support-frontend/assets/helpers/routes.js
+++ b/support-frontend/assets/helpers/routes.js
@@ -53,6 +53,10 @@ function digitalSubscriptionLanding() {
   return `${getOrigin()}${routes.digitalSubscriptionLanding}`;
 }
 
+function guardianWeeklyLanding(gift: boolean) {
+  return `${getOrigin()}${gift ? routes.guardianWeeklySubscriptionLandingGift : routes.guardianWeeklySubscriptionLanding}`;
+}
+
 const promotionTermsUrl = (promoCode: string) => `${getOrigin()}/p/${promoCode}/terms`;
 
 function paperCheckoutUrl(
@@ -84,5 +88,6 @@ export {
   paperSubsUrl,
   paperCheckoutUrl,
   digitalSubscriptionLanding,
+  guardianWeeklyLanding,
   promotionTermsUrl,
 };

--- a/support-frontend/assets/pages/promotion-terms/DigitalPackTerms.jsx
+++ b/support-frontend/assets/pages/promotion-terms/DigitalPackTerms.jsx
@@ -1,13 +1,21 @@
 // @flow
 
 import React from 'react';
-import type { PromotionTerms } from 'helpers/productPrice/promotions';
 import { formatUserDate } from 'helpers/dateConversions';
 import { digitalSubscriptionLanding } from 'helpers/routes';
 import OrderedList from 'components/list/orderedList';
 import CopyrightText from 'pages/promotion-terms/CopyrightText';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import type { Option } from 'helpers/types/option';
 
-export default function DigitalPackTerms(props: PromotionTerms) {
+type PropTypes = {
+  starts: Date,
+  expires: Option<Date>,
+  promoCode: string,
+  countryGroupId: CountryGroupId,
+}
+
+export default function DigitalPackTerms(props: PropTypes) {
 
   const expiryCopy = props.expires ?
     `The closing date and time of the promotion is ${formatUserDate(props.expires)}. 
@@ -17,7 +25,7 @@ export default function DigitalPackTerms(props: PromotionTerms) {
     'The promotion (the “Promotion”) is open to new Guardian Digital Subscription subscribers aged 18 and over ("you") subject to paragraph 2 below.',
     'By entering the promotion you are accepting these terms and conditions.',
     <div>To enter the promotion, you must: (i) either go to{' '}
-      <a href={digitalSubscriptionLanding()}>support.theguardian.com</a> or call
+      <a href={digitalSubscriptionLanding(props.countryGroupId)}>support.theguardian.com</a> or call
       +44 (0) 330 333 6767 and quote promotion code {props.promoCode} (ii)
       purchase a Guardian Digital Subscription and maintain that subscription for at
       least three months.

--- a/support-frontend/assets/pages/promotion-terms/legalTerms.jsx
+++ b/support-frontend/assets/pages/promotion-terms/legalTerms.jsx
@@ -14,7 +14,10 @@ const getTermsForProduct = (props: PromotionTermsPropTypes) => {
     case GuardianWeekly:
       return <WeeklyTerms {...props} />;
     case DigitalPack:
-      return <DigitalPackTerms {...props.promotionTerms} />;
+      return (<DigitalPackTerms
+        {...props.promotionTerms}
+        countryGroupId={props.countryGroupId}
+      />);
     default:
       return <PaperTerms {...props.promotionTerms} />;
   }

--- a/support-frontend/assets/pages/promotion-terms/promotionTermsReducer.js
+++ b/support-frontend/assets/pages/promotion-terms/promotionTermsReducer.js
@@ -6,10 +6,13 @@ import type { CommonState } from 'helpers/page/commonReducer';
 import { getGlobal, getProductPrices } from 'helpers/globals';
 import type { PromotionTerms } from 'helpers/productPrice/promotions';
 import type { ProductPrices } from 'helpers/productPrice/productPrices';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { detect } from 'helpers/internationalisation/countryGroup';
 
 export type PromotionTermsPropTypes = {
   productPrices: ProductPrices,
   promotionTerms: PromotionTerms,
+  countryGroupId: CountryGroupId,
 };
 
 export type State = {
@@ -23,9 +26,11 @@ export default () => {
   const terms = getGlobal('promotionTerms');
   const expires = terms && terms.expires ? new Date(terms.expires) : null;
   const starts = terms ? new Date(terms.starts) : null;
+  const countryGroupId = detect();
 
   return {
     productPrices,
     promotionTerms: { ...terms, starts, expires },
+    countryGroupId,
   };
 };

--- a/support-frontend/assets/pages/subscriptions-landing/components/subscriptionsLandingContent.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/components/subscriptionsLandingContent.jsx
@@ -5,16 +5,25 @@ import React from 'react';
 // components
 import SubscriptionsProduct from './subscriptionsProduct';
 import FeatureHeader from './featureHeader';
+import State from '../subscriptionsLandingReducer';
 
-import { subscriptionCopy } from '../copy/subscriptionCopy'; // make the first card a feature
+import { getSubscriptionCopy } from '../copy/subscriptionCopy';
+import type { ProductCopy } from '../copy/subscriptionCopy';
+import { connect } from 'react-redux';
 
-const isFeature = index => index === 0;
+type PropTypes = {subscriptionCopy: ProductCopy[]};
 
-const SubscriptionsLandingContent = () => (
+const mapStateToProps = (state: State) => ({
+  subscriptionCopy: getSubscriptionCopy(state),
+});
+
+const isFeature = index => index === 0; // make the first card a feature
+
+const SubscriptionsLandingContent = (props: PropTypes) => (
   <div className="subscriptions-landing-page" id="qa-subscriptions-landing-page">
     <FeatureHeader />
     <div className="subscriptions__product-container">
-      {subscriptionCopy.map((product, index) => (
+      {props.subscriptionCopy.map((product, index) => (
         <SubscriptionsProduct
           title={product.title}
           subtitle={product.subtitle}
@@ -30,4 +39,4 @@ const SubscriptionsLandingContent = () => (
   </div>
 );
 
-export default SubscriptionsLandingContent;
+export default connect(mapStateToProps)(SubscriptionsLandingContent);

--- a/support-frontend/assets/pages/subscriptions-landing/components/subscriptionsLandingContent.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/components/subscriptionsLandingContent.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 // components
 import SubscriptionsProduct from './subscriptionsProduct';
 import FeatureHeader from './featureHeader';
-import State from '../subscriptionsLandingReducer';
+import type { State } from '../subscriptionsLandingReducer';
 
 import { getSubscriptionCopy } from '../copy/subscriptionCopy';
 import type { ProductCopy } from '../copy/subscriptionCopy';
@@ -26,13 +26,13 @@ const SubscriptionsLandingContent = (props: PropTypes) => (
       {props.subscriptionCopy.map((product, index) => (
         <SubscriptionsProduct
           title={product.title}
-          subtitle={product.subtitle}
+          subtitle={product.subtitle || ''}
           description={product.description}
           productImage={product.productImage}
           buttons={product.buttons}
           offer={product.offer || null}
           isFeature={isFeature(index)}
-          classModifier={product.classModifier}
+          classModifier={product.classModifier || []}
         />
       ))}
     </div>

--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
@@ -131,7 +131,7 @@ const digital = (countryGroupId: CountryGroupId, priceCopy: PriceCopy, isTop: bo
   offer: priceCopy.discountCopy,
   buttons: [{
     ctaButtonText: 'Find out more',
-    link: digitalSubscriptionLanding(),
+    link: digitalSubscriptionLanding(countryGroupId),
     analyticsTracking: sendTrackingEventsOnClick('digipack_cta', 'DigitalPack', abTest, 'digital-subscription'),
   }],
   isFeature: true,
@@ -152,12 +152,12 @@ const guardianWeekly = (countryGroupId: CountryGroupId, priceCopy: PriceCopy, is
   buttons: [
     {
       ctaButtonText: 'Find out more',
-      link: guardianWeeklyLanding(false),
+      link: guardianWeeklyLanding(countryGroupId, false),
       analyticsTracking: sendTrackingEventsOnClick('weekly_cta', 'GuardianWeekly', abTest),
     },
     {
       ctaButtonText: 'See gift options',
-      link: guardianWeeklyLanding(true),
+      link: guardianWeeklyLanding(countryGroupId, true),
       analyticsTracking: sendTrackingEventsOnClick('weekly_cta_gift', 'GuardianWeekly', abTest),
       modifierClasses: '',
     },

--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
@@ -78,7 +78,6 @@ export type ProductCopy = {
   productImage: React.Node,
   offer?: string,
   buttons: ProductButton[],
-  isFeature?: boolean,
   classModifier?: string[],
 }
 
@@ -134,7 +133,6 @@ const digital = (countryGroupId: CountryGroupId, priceCopy: PriceCopy, isTop: bo
     link: digitalSubscriptionLanding(countryGroupId),
     analyticsTracking: sendTrackingEventsOnClick('digipack_cta', 'DigitalPack', abTest, 'digital-subscription'),
   }],
-  isFeature: true,
 });
 
 const getWeeklyImage = (isTop: boolean) => {

--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
@@ -188,7 +188,7 @@ const paperAndDigital = (
     getCampaign(referrerAcquisitionData),
     referrerAcquisitionData,
     abParticipations,
-  );
+  ).PaperAndDigital;
   return {
     title: 'Paper+Digital',
     subtitle: `from ${getPrice(countryGroupId, PaperAndDigital, '')}`,

--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
@@ -52,7 +52,7 @@ import {
   glyph,
 } from 'helpers/internationalisation/currency';
 
-import {State} from '../subscriptionsLandingReducer';
+import type { State } from '../subscriptionsLandingReducer';
 import type { PriceCopy } from '../subscriptionsLandingReducer';
 import type { BillingPeriod } from 'helpers/billingPeriods';
 import {
@@ -79,6 +79,7 @@ export type ProductCopy = {
   offer?: string,
   buttons: ProductButton[],
   isFeature?: boolean,
+  classModifier?: string[],
 }
 
 const abTest = null;
@@ -138,12 +139,12 @@ const digital = (countryGroupId: CountryGroupId, priceCopy: PriceCopy, isTop: bo
 
 const getWeeklyImage = (isTop: boolean) => {
   if (isTop) {
-    return <GuardianWeeklyPackShotHero/>;
+    return <GuardianWeeklyPackShotHero />;
   }
   return <GuardianWeeklyPackShot />;
 };
 
-const guardianWeekly = (countryGroupId: CountryGroupId, priceCopy: PriceCopy, isTop: boolean) : ProductCopy => ({
+const guardianWeekly = (countryGroupId: CountryGroupId, priceCopy: PriceCopy, isTop: boolean): ProductCopy => ({
   title: 'The Guardian Weekly',
   subtitle: getDisplayPrice(countryGroupId, priceCopy.price, Quarterly),
   description: 'A weekly, global magazine from The Guardian, with delivery worldwide',
@@ -164,7 +165,7 @@ const guardianWeekly = (countryGroupId: CountryGroupId, priceCopy: PriceCopy, is
   productImage: getWeeklyImage(isTop),
 });
 
-const paper = (countryGroupId: CountryGroupId, priceCopy: PriceCopy) : ProductCopy => ({
+const paper = (countryGroupId: CountryGroupId, priceCopy: PriceCopy): ProductCopy => ({
   title: 'Paper',
   subtitle: `from ${getDisplayPrice(countryGroupId, priceCopy.price)}`,
   description: 'Save on The Guardian and The Observer\'s newspaper retail price all year round',
@@ -181,7 +182,7 @@ const paperAndDigital = (
   countryGroupId: CountryGroupId,
   referrerAcquisitionData: ReferrerAcquisitionData,
   abParticipations: Participations,
-) : ProductCopy => {
+): ProductCopy => {
   const link = getSubsLinks(
     countryGroupId,
     referrerAcquisitionData.campaignCode,
@@ -200,10 +201,10 @@ const paperAndDigital = (
     }],
     productImage: <PaperAndDigitalPackshot />,
     offer: getSaleCopy(PaperAndDigital, countryGroupId).bundle.subHeading,
-  }
+  };
 };
 
-const premiumApp = (countryGroupId: CountryGroupId) : ProductCopy => ({
+const premiumApp = (countryGroupId: CountryGroupId): ProductCopy => ({
   title: 'Premium App',
   subtitle: getPrice(countryGroupId, PremiumTier, '7-day free Trial'),
   description: 'The ad-free, Premium App, designed especially for your smartphone and tablet',
@@ -221,8 +222,13 @@ const premiumApp = (countryGroupId: CountryGroupId) : ProductCopy => ({
   classModifier: ['subscriptions__premuim-app'],
 });
 
-const testOrdering = (state: State) => {
-  const { countryGroupId } = state.common.internationalisation;
+const weeklyInternational = (countryGroupId: CountryGroupId, state: State) => [
+  guardianWeekly(countryGroupId, state.page.pricingCopy[GuardianWeekly], true),
+  digital(countryGroupId, state.page.pricingCopy[DigitalPack], false),
+  premiumApp(countryGroupId),
+];
+
+const testOrdering = (countryGroupId: CountryGroupId, state: State) => {
   const weeklyTop = state.common.abParticipations.subsShowcaseOrderingTest === 'weeklyTop';
   if (weeklyTop) {
     return weeklyInternational(countryGroupId, state);
@@ -234,36 +240,28 @@ const testOrdering = (state: State) => {
   ];
 };
 
-const weeklyInternational = (state: State) => {
-  const { countryGroupId } = state.common.internationalisation;
-  return [
-    guardianWeekly(countryGroupId, state.page.pricingCopy[GuardianWeekly], true),
-    digital(countryGroupId, state.page.pricingCopy[DigitalPack], false),
-    premiumApp(countryGroupId),
-  ]
-};
-
 const orderedProducts = (state: State): ProductCopy[] => {
   const { countryGroupId } = state.common.internationalisation;
-    switch (countryGroupId) {
-      case GBPCountries:
-        return [
-          paper(countryGroupId, state.page.pricingCopy[Paper]),
-          digital(countryGroupId, state.page.pricingCopy[DigitalPack], false),
-          guardianWeekly(countryGroupId, state.page.pricingCopy[GuardianWeekly], false),
-          paperAndDigital(countryGroupId, state.common.referrerAcquisitionData, state.common.abParticipations),
-          premiumApp(countryGroupId),
-        ];
-      case EURCountries:
-      case International:
-        return testOrdering(state);
-      case NZDCountries:
-      case AUDCountries:
-      case Canada:
-      case UnitedStates:
-        return weeklyInternational(state);
-    }
-  };
+  switch (countryGroupId) {
+    case GBPCountries:
+      return [
+        paper(countryGroupId, state.page.pricingCopy[Paper]),
+        digital(countryGroupId, state.page.pricingCopy[DigitalPack], false),
+        guardianWeekly(countryGroupId, state.page.pricingCopy[GuardianWeekly], false),
+        paperAndDigital(countryGroupId, state.common.referrerAcquisitionData, state.common.abParticipations),
+        premiumApp(countryGroupId),
+      ];
+    case EURCountries:
+    case International:
+      return testOrdering(countryGroupId, state);
+    case NZDCountries:
+    case AUDCountries:
+    case Canada:
+    case UnitedStates:
+    default:
+      return weeklyInternational(countryGroupId, state);
+  }
+};
 
 const getSubscriptionCopy = (state: State) =>
   orderedProducts(state);

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
@@ -16,11 +16,13 @@ import ConsentBanner from 'components/consentBanner/consentBanner';
 import './subscriptionsLanding.scss';
 
 import SubscriptionLandingContent from './components/subscriptionsLandingContent';
+import subscriptionsLandingReducer
+  from 'pages/subscriptions-landing/subscriptionsLandingReducer';
 
 // ----- Redux Store ----- //
 
 const countryGroupId: CountryGroupId = detect();
-const store = pageInit();
+const store = pageInit(() => subscriptionsLandingReducer(), true);
 
 const Header = headerWithCountrySwitcherContainer({
   path: '/subscribe',

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLandingReducer.js
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLandingReducer.js
@@ -7,13 +7,6 @@ import type { CommonState } from 'helpers/page/commonReducer';
 import { getGlobal } from 'helpers/globals';
 import type { SubscriptionProduct } from 'helpers/subscriptions';
 
-export type State = {
-  common: CommonState,
-  page: {
-    pricingCopy: PricingCopy,
-  }
-};
-
 export type PriceCopy = {
   price: number,
   discountCopy: string,
@@ -22,6 +15,13 @@ export type PriceCopy = {
 export type PricingCopy = {
   [SubscriptionProduct]: PriceCopy,
 }
+
+export type State = {
+  common: CommonState,
+  page: {
+    pricingCopy: PricingCopy,
+  }
+};
 
 const getPricingCopy = (): ?PricingCopy => getGlobal('pricingCopy');
 

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLandingReducer.js
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLandingReducer.js
@@ -1,0 +1,33 @@
+// @flow
+
+// ----- Imports ----- //
+
+import { combineReducers } from 'redux';
+import type { CommonState } from 'helpers/page/commonReducer';
+import { getGlobal } from 'helpers/globals';
+import type { SubscriptionProduct } from 'helpers/subscriptions';
+
+export type State = {
+  common: CommonState,
+  page: {
+    pricingCopy: PricingCopy,
+  }
+};
+
+export type PriceCopy = {
+  price: number,
+  discountCopy: string,
+}
+
+export type PricingCopy = {
+  [SubscriptionProduct]: PriceCopy,
+}
+
+const getPricingCopy = (): ?PricingCopy => getGlobal('pricingCopy');
+
+// ----- Export ----- //
+
+export default () => combineReducers({
+  pricingCopy: getPricingCopy,
+});
+


### PR DESCRIPTION
## Why are you doing this?

This PR does a couple of things because they are closely linked.
Firstly it removes the additional Redux store initialisation which was happening in subscriptionsCopy.jsx. The store is already being initialised in subscriptionsLanding.jsx so initialising it twice was causing duplicate analytics events. It also breaks the pattern of the page loading its state and then passing that down to connected components.

Secondly I have used the opportunity of this refactor to take the pricing information shown on this page from the Zuora catalog and any promo codes which are active. This means that this page no longer needs to use flashSale.js and all that is required to set up a new flash sale is to set default promo codes in the `Subscriptions` controller.

[**Trello Card**](https://trello.com/c/7t0hPNIV/2773-double-counting-pageviews-in-ga-on-subscriptions-landing-page)
