### PR TITLE
Elasticsearch retention policy lambda

### DIFF
--- a/support-logs/retention-lambda/Makefile
+++ b/support-logs/retention-lambda/Makefile
@@ -1,0 +1,2 @@
+all:
+	zip -r ../retention-lambda.zip . > /dev/null

--- a/support-logs/retention-lambda/Makefile
+++ b/support-logs/retention-lambda/Makefile
@@ -1,2 +1,4 @@
 all:
 	zip -r ../support-logs-retention-lambda.zip . > /dev/null
+clean:
+	ls | grep -v -E 'cfn.yaml|Makefile|riff-raff.yaml|configure|lambda_function.py' | xargs rm -rf

--- a/support-logs/retention-lambda/Makefile
+++ b/support-logs/retention-lambda/Makefile
@@ -1,2 +1,2 @@
 all:
-	zip -r ../retention-lambda.zip . > /dev/null
+	zip -r ../support-logs-retention-lambda.zip . > /dev/null

--- a/support-logs/retention-lambda/cfn.yaml
+++ b/support-logs/retention-lambda/cfn.yaml
@@ -1,0 +1,84 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Parameters:
+  Stack:
+    Description: Stack name
+    Type: String
+    Default: support
+  App:
+    Description: Application name
+    Type: String
+    Default: support-logs-retention-lambda
+  Stage:
+    Description: Stage name
+    Type: String
+    Default: PROD
+  DeployBucket:
+    Description: Bucket where RiffRaff uploads artifacts on deploy
+    Type: String
+    Default: subscriptions-dist
+  VpcId:
+    Description: Vpc where the lambda is being created
+    Type: AWS::EC2::VPC::Id
+    Default: vpc-e6e00183
+
+Resources:
+  RetentionLambdaSecurityGroup:
+   Type: AWS::EC2::SecurityGroup
+   Properties:
+     GroupDescription: !Sub Security group for the ${App}-${Stage} lambda
+     VpcId: !Ref VpcId
+     SecurityGroupEgress:
+     - IpProtocol: tcp
+       FromPort: 433
+       ToPort: 443
+       SourceSecurityGroupId: sg-05c221879675c1e45
+  RetentionLambda:
+   Type: AWS::Serverless::Function
+   Properties:
+     FunctionName: !Sub ${App}-${Stage}
+     Events:
+       Timer:
+        Type: Schedule
+        Properties:
+          Description: Delete old indices daily at 10
+          Schedule: cron(0 10 * * ? *)
+     Runtime: python3.6
+     Handler: lambda_function.lambda_handler
+     MemorySize: 128
+     Timeout: 30
+     CodeUri:
+       Bucket: !Ref DeployBucket
+       Key: !Sub ${Stack}/${Stage}/${App}/${App}.zip
+     VpcConfig:
+       SecurityGroupIds:
+         - !Ref RetentionLambdaSecurityGroup
+       SubnetIds: 
+         - subnet-0d6f657eea1baf777
+         - subnet-087346aaeef11b924
+     Tags:
+       App: !Ref App
+       Stack: !Ref Stack
+       Stage: !Ref Stage
+     Policies:
+       - Version: '2012-10-17'
+         Statement:
+           - Effect: Allow
+             Action:
+               - es:ESHttpPost
+               - es:ESHttpGet
+               - es:ESHttpPut 
+               - es:ESHttpDelete 
+             Resource: arn:aws:es:eu-west-1:865473395570:domain/support-elk-domain*
+       - Version: '2012-10-17'
+         Statement:
+            - Effect: Allow
+              Action:
+                - logs:CreateLogGroup
+                - logs:CreateLogStream
+                - logs:PutLogEvents
+                - ec2:CreateNetworkInterface
+                - ec2:DescribeNetworkInterfaces
+                - ec2:DeleteNetworkInterface
+              Resource: "*"

--- a/support-logs/retention-lambda/configure
+++ b/support-logs/retention-lambda/configure
@@ -1,0 +1,2 @@
+#!/bin/bash
+pip3 install -t ./ elasticsearch elasticsearch-curator

--- a/support-logs/retention-lambda/lambda_function.py
+++ b/support-logs/retention-lambda/lambda_function.py
@@ -24,7 +24,7 @@ def lambda_handler(event, context):
     index_list = curator.IndexList(es)
 
     # Filters by age, anything with a time stamp older than 30 days in the index name.
-    index_list.filter_by_age(source='name', direction='older', timestring='%Y.%m.%d', unit='days', unit_count=24)
+    index_list.filter_by_age(source='name', direction='older', timestring='%Y.%m.%d', unit='days', unit_count=90)
 
     print("Found %s indices to delete" % len(index_list.indices))
 

--- a/support-logs/retention-lambda/lambda_function.py
+++ b/support-logs/retention-lambda/lambda_function.py
@@ -1,0 +1,33 @@
+import boto3
+from requests_aws4auth import AWS4Auth
+from elasticsearch import Elasticsearch, RequestsHttpConnection
+import curator
+
+host = 'vpc-support-elk-domain-vcesheatvi6xspmp4sd6dnfkq4.eu-west-1.es.amazonaws.com'
+region = 'eu-west-1'
+service = 'es'
+credentials = boto3.Session().get_credentials()
+awsauth = AWS4Auth(credentials.access_key, credentials.secret_key, region, service, session_token=credentials.token)
+
+# Lambda execution starts here.
+def lambda_handler(event, context):
+
+    # Build the Elasticsearch client.
+    es = Elasticsearch(
+        hosts = [{'host': host, 'port': 443}],
+        http_auth = awsauth,
+        use_ssl = True,
+        verify_certs = True,
+        connection_class = RequestsHttpConnection
+    )
+
+    index_list = curator.IndexList(es)
+
+    # Filters by age, anything with a time stamp older than 30 days in the index name.
+    index_list.filter_by_age(source='name', direction='older', timestring='%Y.%m.%d', unit='days', unit_count=24)
+
+    print("Found %s indices to delete" % len(index_list.indices))
+
+    # If our filtered list contains any indices, delete them.
+    if index_list.indices:
+        curator.DeleteIndices(index_list).do_action()

--- a/support-logs/retention-lambda/riff-raff.yaml
+++ b/support-logs/retention-lambda/riff-raff.yaml
@@ -6,7 +6,7 @@ deployments:
     app: support-logs-retention-lambda
     parameters:
       templatePath: cfn.yaml
-  support-logs-retention-lambda-files:
+  support-logs-retention-lambda-code:
     app: support-logs-retention-lambda
     type: aws-lambda
     parameters:

--- a/support-logs/retention-lambda/riff-raff.yaml
+++ b/support-logs/retention-lambda/riff-raff.yaml
@@ -1,7 +1,7 @@
 stacks: [support]
 regions: [eu-west-1]
 deployments:
-  support-logs-retention-lambda-files:
+  support-logs-retention-lambda-cfn:
     type: cloud-formation
     app: support-logs-retention-lambda
     parameters:

--- a/support-logs/retention-lambda/riff-raff.yaml
+++ b/support-logs/retention-lambda/riff-raff.yaml
@@ -12,5 +12,5 @@ deployments:
     parameters:
       bucket: subscriptions-dist
       fileName: support-logs-retention-lambda.zip
-      functionNames: [supports-logs-retention-lambda-]
+      functionNames: [support-logs-retention-lambda-]
       prefixStack: false

--- a/support-logs/retention-lambda/riff-raff.yaml
+++ b/support-logs/retention-lambda/riff-raff.yaml
@@ -13,3 +13,4 @@ deployments:
       bucket: subscriptions-dist
       fileName: support-logs-retention-lambda.zip
       functionNames: [supports-logs-retention-lambda-]
+      prefixStack: false

--- a/support-logs/retention-lambda/riff-raff.yaml
+++ b/support-logs/retention-lambda/riff-raff.yaml
@@ -2,9 +2,14 @@ stacks: [support]
 regions: [eu-west-1]
 deployments:
   support-logs-retention-lambda-files:
+    type: cloud-formation
+    app: support-logs-retention-lambda
+    parameters:
+      templatePath: cfn.yaml
+  support-logs-retention-lambda-files:
     app: support-logs-retention-lambda
     type: aws-lambda
     parameters:
       bucket: subscriptions-dist
-      fileName: retention-lambda.zip
+      fileName: support-logs-retention-lambda.zip
       functionNames: [supports-logs-retention-lambda-]

--- a/support-logs/retention-lambda/riff-raff.yaml
+++ b/support-logs/retention-lambda/riff-raff.yaml
@@ -1,0 +1,10 @@
+stacks: [support]
+regions: [eu-west-1]
+deployments:
+  support-logs-retention-lambda-files:
+    app: support-logs-retention-lambda
+    type: aws-lambda
+    parameters:
+      bucket: subscriptions-dist
+      fileName: retention-lambda.zip
+      functionNames: supports-logs-retention-lambda

--- a/support-logs/retention-lambda/riff-raff.yaml
+++ b/support-logs/retention-lambda/riff-raff.yaml
@@ -7,4 +7,4 @@ deployments:
     parameters:
       bucket: subscriptions-dist
       fileName: retention-lambda.zip
-      functionNames: supports-logs-retention-lambda
+      functionNames: [supports-logs-retention-lambda-]


### PR DESCRIPTION
## Why are you doing this?

Now that we have [serious logs](https://github.com/guardian/support-frontend/pull/2251) being streamed to kibana, it's important to have a retention policy applied to the data.

Kibana has a "turn key" solution for this called [Index Lifecycle Policies](https://www.elastic.co/guide/en/kibana/current/index-lifecycle-policies.html), which is unfortunately not available in AWS's elasticsearch service. Reason being that aws uses the open-source version of elasticsearch, and ILP is an x-pack feature available [on the Basic plan and above](https://www.elastic.co/subscriptions).

Luckily,  [amazon's documentation](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/curator.html) sketches out a solution to this using lambda and the elasticsearch python library (specifically a package called _curator_). This PR is an implementation of that solution exactly as described in the docs. The idea is for the lambda to delete indices older than 30 days and for it to run every day.

On the cloudformation front, I've opted to use the AWS Serverless Application Model (AWS SAM) to specify the lambda which greatly simplifies the code. Still, the configuration might be a bit hard to follow. Some key ideas:

For the lambda to be able to make API calls to Kibana (in the VPC), it needs to both have a networking path to get there and appropriate "API credentials". To make this work:
- The lambda is in the VPC in the same subnets as the ProxyInstance. Its security group is locked down to only allows outbound HTTPS calls to the kibana security group.
- A policy to give lambda permissions to use the elastic search API

The serverless template has built-in functionality to set a cron rule to trigger the execution. In the background, aws is actually setting up a cloudwatch event.

It's also worth noting that when using the serverless template, we're actually creating a _lambda application_ rather than just a function. To it shows up under the Applications section. I'll add a screenshot.

On the build and deploy side, this PR includes a configure script to install dependencies, a makefile to zip up the code, a riff-raff.yaml with the deployment definition and a corresponding [TeamCity job](https://teamcity.gutools.co.uk/viewType.html?buildTypeId=memsub_Support_SupportLogsRetention).

## Screenshots

How the retention fits in with [the proxying infrastructure](https://github.com/guardian/support-frontend/pull/2285).

![Cloudera_EDH_-_VP_Online](https://user-images.githubusercontent.com/1672034/70806318-f335e080-1db2-11ea-9934-387cd0baa672.png)


How it shows up in aws

![Lambda_Management_Console](https://user-images.githubusercontent.com/1672034/70805986-2e83df80-1db2-11ea-832b-4f3a9c77db92.png)
