### PR TITLE
Update mobile image for non-feature digital subs

### DIFF
--- a/support-frontend/assets/components/packshots/digital-packshot.jsx
+++ b/support-frontend/assets/components/packshots/digital-packshot.jsx
@@ -1,18 +1,30 @@
 import React from 'react';
 
-import GridImage from 'components/gridImage/gridImage';
+import GridPicture from 'components/gridPicture/gridPicture';
 
 const DigitalPackshot = () => (
   <div className="subscriptions-int-daily-packshot">
-    <GridImage
-      classModifiers={['']}
-      gridId="subscriptionDailyPackshot"
-      srcSizes={[1000, 500]}
-      sizes="(max-width: 480px) 100px,
-            (max-width: 740px) 100%,
-            (max-width: 1067px) 150%,
-            800px"
-      imgType="png"
+    <GridPicture
+      sources={[
+        {
+          gridId: 'subscriptioDailyPackshotMobile',
+          srcSizes: [500],
+          imgType: 'png',
+          sizes: '100vw',
+          media: '(max-width: 739px)',
+        },
+        {
+          gridId: 'subscriptionDailyPackshot',
+          srcSizes: [1000, 500],
+          imgType: 'png',
+          sizes: '(min-width: 1000px) 2000px, 1000px',
+          media: '(min-width: 740px)',
+        },
+      ]}
+      fallback="subscriptioDailyPackshotMobile"
+      fallbackSize={1000}
+      altText=""
+      fallbackImgType="png"
     />
   </div>
 );

--- a/support-frontend/assets/components/packshots/digital-packshot.jsx
+++ b/support-frontend/assets/components/packshots/digital-packshot.jsx
@@ -21,7 +21,7 @@ const DigitalPackshot = () => (
           media: '(min-width: 740px)',
         },
       ]}
-      fallback="subscriptioDailyPackshotMobile"
+      fallback="subscriptionDailyPackshotMobile"
       fallbackSize={1000}
       altText=""
       fallbackImgType="png"

--- a/support-frontend/assets/components/packshots/digital-packshot.jsx
+++ b/support-frontend/assets/components/packshots/digital-packshot.jsx
@@ -7,7 +7,7 @@ const DigitalPackshot = () => (
     <GridPicture
       sources={[
         {
-          gridId: 'subscriptioDailyPackshotMobile',
+          gridId: 'subscriptionDailyPackshotMobile',
           srcSizes: [500],
           imgType: 'png',
           sizes: '100vw',

--- a/support-frontend/assets/helpers/theGrid.js
+++ b/support-frontend/assets/helpers/theGrid.js
@@ -95,7 +95,7 @@ export const imageCatalogue: {
   subscriptionPrintDigital: '476a8aadac1f3a971b9b1a9a023b04cb72c8f7ca/0_0_1366_1510',
   subscriptionGuardianWeeklyPackShot: '299d99cb5dc2d98607e9333d5e1e15c9f7d4860f/0_0_1552_921',
   subscriptionDailyPackshot: '241d0d58656ffcd708bba7d2a42ec7b8df9ee25e/0_0_1584_898',
-  subscriptioDailyPackshotMobile: '241d0d58656ffcd708bba7d2a42ec7b8df9ee25e/0_0_898_898',
+  subscriptionDailyPackshotMobile: '241d0d58656ffcd708bba7d2a42ec7b8df9ee25e/0_0_898_898',
   subscriptionDailyMobile: '9b650a7dcc33e30d228ddec7bd27a0594b4ece41/0_0_568_1174',
   printShowcase: '311c4a9dd0e8030b734dd54b71fcd0d4cb2a303b/0_0_1486_750',
   digitalSubsDaily: '38e76951e5fa76f9b3eb02ab84c5d745f6b123b8/0_0_1693_1000',

--- a/support-frontend/assets/helpers/theGrid.js
+++ b/support-frontend/assets/helpers/theGrid.js
@@ -95,6 +95,7 @@ export const imageCatalogue: {
   subscriptionPrintDigital: '476a8aadac1f3a971b9b1a9a023b04cb72c8f7ca/0_0_1366_1510',
   subscriptionGuardianWeeklyPackShot: '299d99cb5dc2d98607e9333d5e1e15c9f7d4860f/0_0_1552_921',
   subscriptionDailyPackshot: '241d0d58656ffcd708bba7d2a42ec7b8df9ee25e/0_0_1584_898',
+  subscriptioDailyPackshotMobile: '241d0d58656ffcd708bba7d2a42ec7b8df9ee25e/0_0_898_898',
   subscriptionDailyMobile: '9b650a7dcc33e30d228ddec7bd27a0594b4ece41/0_0_568_1174',
   printShowcase: '311c4a9dd0e8030b734dd54b71fcd0d4cb2a303b/0_0_1486_750',
   digitalSubsDaily: '38e76951e5fa76f9b3eb02ab84c5d745f6b123b8/0_0_1693_1000',


### PR DESCRIPTION
## Why are you doing this?
This fixes the mobile (non-feature) digital subs packshot on the subs landing page.

[**Trello Card**](https://trello.com/c/bjPb3rd8/2774-fix-digital-subs-showcase-page-mobile-image)

## Screenshots
![Screen Shot 2019-12-16 at 14 14 04](https://user-images.githubusercontent.com/16781258/70914645-4e184380-2010-11ea-8b75-b0b9fcca2bbc.png)

