### PR TITLE
Fix ab test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -12,6 +12,7 @@ export type NewLandingPageTemplateTestVariants = 'control' | 'new_template' | 'n
 export type AmazonPaySingleUSTestVariants = 'control' | 'amazonPay' | 'notintest';
 
 const contributionsLandingPageMatch = '/(uk|us|eu|au|ca|nz|int)/contribute(/.*)?$';
+const usContributionsLandingPageMatch = '/us/contribute(/.*)?$';
 const subsShowcasePageMatch = '/(eu|int)/subscribe(/.*)?$';
 
 const countryGroupId: CountryGroupId = detect();


### PR DESCRIPTION
[This line](https://github.com/guardian/support-frontend/pull/2254/files#diff-4d1709d642d3327cb582515d95827c21R16) got removed by the merge commit, presumably because another change had removed it