### PR TITLE
Make support-models depend on released version of support-internation…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -113,8 +113,7 @@ lazy val `support-models` = (project in file("support-models"))
     commonSettings,
     integrationTestSettings,
     libraryDependencies ++= commonDependencies
-  ).dependsOn(`support-internationalisation`)
-  .aggregate(`support-internationalisation`)
+  )
 
 lazy val `support-config` = (project in file("support-config"))
   .configs(IntegrationTest)

--- a/support-models/build.sbt
+++ b/support-models/build.sbt
@@ -7,6 +7,7 @@ description := "Scala library to provide shared step-function models to Guardian
 libraryDependencies ++= Seq(
   "com.gu" %% "acquisition-event-producer-play26" % "4.0.25", //this should really be split into models and producer
                                                               // so we don't have to pull in thrift binary compression libs etc
+  "com.gu" %% "support-internationalisation" % "0.12",
   "org.typelevel" %% "cats-core" % catsVersion,
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,


### PR DESCRIPTION
Currently if you release support-models it tries to release support-internationalisation as well.
Instead, make support-models depend on the released version of support-internationalisation