### PR TITLE
Update version to 0.67-SNAPSHOT

### DIFF
--- a/support-models/version.sbt
+++ b/support-models/version.sbt
@@ -1,1 +1,1 @@
-version := "0.66-SNAPSHOT"
+version := "0.67-SNAPSHOT"


### PR DESCRIPTION
doing this manually because I had to comment out the `pushChanges` step to get it to release, see https://github.com/guardian/support-frontend/pull/2293