### PR TITLE
Send gift promo codes to the gift version of the GW product page

### DIFF
--- a/support-frontend/app/controllers/Promotions.scala
+++ b/support-frontend/app/controllers/Promotions.scala
@@ -37,7 +37,7 @@ class Promotions(
     maybePromotionTerms.fold(NotFound("Invalid promo code")
     ) { promotionTerms =>
       val productLandingPage = promotionTerms.product match {
-        case GuardianWeekly => routes.Subscriptions.weeklyGeoRedirect(false).url
+        case GuardianWeekly => routes.Subscriptions.weeklyGeoRedirect(promotionTerms.isGift).url
         case DigitalPack => routes.DigitalSubscription.digitalGeoRedirect().url
         case Paper => routes.PaperSubscription.paper(false).url
       }

--- a/support-frontend/assets/helpers/productPrice/promotions.js
+++ b/support-frontend/assets/helpers/productPrice/promotions.js
@@ -36,6 +36,7 @@ export type PromotionTerms = {
   product: SubscriptionProduct, // actually only GuardianWeekly, Paper or Digital Pack?
   productRatePlans: string[],
   promoCode: string,
+  isGift: boolean,
 }
 
 export type Promotion =

--- a/support-frontend/assets/pages/promotion-terms/promoDetails.jsx
+++ b/support-frontend/assets/pages/promotion-terms/promoDetails.jsx
@@ -7,18 +7,19 @@ import Content from 'components/content/content';
 import { formatUserDate } from 'helpers/dateConversions';
 import UnorderedList from 'components/list/unorderedList';
 import AnchorButton from 'components/button/anchorButton';
-import type { SubscriptionProduct } from 'helpers/subscriptions';
 import { DigitalPack, Paper } from 'helpers/subscriptions';
 import { routes } from 'helpers/routes';
 
-const landingPageForProduct = (product: SubscriptionProduct) => {
-  switch (product) {
+const landingPageForProduct = (props: PromotionTerms) => {
+  switch (props.product) {
     case DigitalPack:
       return routes.digitalSubscriptionLanding;
     case Paper:
       return routes.paperSubscriptionLanding;
     default:
-      return routes.guardianWeeklySubscriptionLanding;
+      return props.isGift ?
+        routes.guardianWeeklySubscriptionLandingGift :
+        routes.guardianWeeklySubscriptionLanding;
   }
 };
 
@@ -43,7 +44,7 @@ export default function PromoDetails(props: PromotionTerms) {
         }
         />
       </LargeParagraph>
-      <AnchorButton href={`${landingPageForProduct(props.product)}?promoCode=${props.promoCode}`}>
+      <AnchorButton href={`${landingPageForProduct(props)}?promoCode=${props.promoCode}`}>
         Get this offer
       </AnchorButton>
     </Content>

--- a/support-services/src/main/scala/com/gu/support/promotions/PromotionTerms.scala
+++ b/support-services/src/main/scala/com/gu/support/promotions/PromotionTerms.scala
@@ -11,7 +11,8 @@ case class PromotionTerms(
   starts: DateTime,
   expires: Option[DateTime],
   product: Product,
-  productRatePlans: List[String]
+  productRatePlans: List[String],
+  isGift: Boolean
 )
 
 object PromotionTerms {
@@ -39,13 +40,19 @@ object PromotionTerms {
       .filter(productRatePlan => includedProductRatePlanIds.contains(productRatePlan.id))
       .map(_.description)
 
+    val isGift = product
+      .getProductRatePlans(environment)
+      .filter(productRatePlan => includedProductRatePlanIds.contains(productRatePlan.id))
+      .forall(_.fixedTerm)
+
     PromotionTerms(
       promotion.promoCode,
       promotion.promotion.description,
       promotion.promotion.starts,
       promotion.promotion.expires,
       product,
-      productRatePlans
+      productRatePlans,
+      isGift
     )
   }
 }


### PR DESCRIPTION
## Why are you doing this?
We have a feature on the site where people can go to the url `/p/[any promo code]` and then be redirected to the product page for the promoted product. We want this endpoint to be aware of gift promotions so that if the promo code is a Guardian Weekly gift offer then the user will be redirected to the gift version of the product page.

I have also updated the promotion terms page so that for gift promotions the 'Get this offer' button goes directly to the gift version of the product page
<img width="844" alt="Screen Shot 2019-12-17 at 17 03 10" src="https://user-images.githubusercontent.com/181371/71017829-251ab000-20ef-11ea-8ab5-56b42ecc0ad7.png">


[**Trello Card**](https://trello.com/c/uo6uhzY2/2770-redirect-gift-promotions-to-the-gifting-page)
