### PR TITLE
Display amazon's error message in the widget if InvalidPaymentMethod

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/AmazonPay/AmazonPayWallet.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/AmazonPay/AmazonPayWallet.jsx
@@ -9,7 +9,7 @@ import { logException } from 'helpers/logger';
 
 type PropTypes = {|
   amazonPayData: AmazonPayData,
-  setAmazonPayWalletWidgetReady: () => Action,
+  setAmazonPayWalletWidgetReady: boolean => Action,
   setAmazonPayOrderReferenceId: string => Action,
   setAmazonPayPaymentSelected: boolean => Action,
   isTestUser: boolean,
@@ -20,7 +20,7 @@ const mapStateToProps = (state: State) => ({
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
-  setAmazonPayWalletWidgetReady: () => dispatch(setAmazonPayWalletWidgetReady),
+  setAmazonPayWalletWidgetReady: (isReady: boolean) => dispatch(setAmazonPayWalletWidgetReady(isReady)),
   setAmazonPayOrderReferenceId:
     (orderReferenceId: string) => dispatch(setAmazonPayOrderReferenceId(orderReferenceId)),
   setAmazonPayPaymentSelected: (paymentSelected: boolean) =>
@@ -53,6 +53,7 @@ class AmazonPayWalletComponent extends React.Component<PropTypes, void> {
     new amazonPaymentsObject.Widgets.Wallet({
       sellerId: getSellerId(this.props.isTestUser),
       design: { designMode: 'responsive' },
+      amazonOrderReferenceId: this.props.amazonPayData.orderReferenceId,
       onOrderReferenceCreate: (orderReference) => {
         this.props.setAmazonPayOrderReferenceId(orderReference.getAmazonOrderReferenceId());
       },
@@ -65,7 +66,7 @@ class AmazonPayWalletComponent extends React.Component<PropTypes, void> {
       },
     }).bind('WalletWidgetDiv');
 
-    this.props.setAmazonPayWalletWidgetReady();
+    this.props.setAmazonPayWalletWidgetReady(true);
   }
 
   render() {

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -65,7 +65,7 @@ export type Action =
   | { type: 'UPDATE_PAYMENT_READY', thirdPartyPaymentLibraryByContrib: { [ContributionType]: { [PaymentMethod]: ThirdPartyPaymentLibrary } } }
   | { type: 'SET_AMAZON_PAY_LOGIN_OBJECT', amazonLoginObject: Object }
   | { type: 'SET_AMAZON_PAY_PAYMENTS_OBJECT', amazonPaymentsObject: Object }
-  | { type: 'SET_AMAZON_PAY_WALLET_WIDGET_READY' }
+  | { type: 'SET_AMAZON_PAY_WALLET_WIDGET_READY', isReady: boolean }
   | { type: 'SET_AMAZON_PAY_ORDER_REFERENCE_ID', orderReferenceId: string }
   | { type: 'SET_AMAZON_PAY_PAYMENT_SELECTED', paymentSelected: boolean }
   | { type: 'SET_AMAZON_PAY_HAS_ACCESS_TOKEN' }
@@ -215,7 +215,9 @@ const setAmazonPayPaymentsObject = (amazonPaymentsObject: Object): Action => ({
   amazonPaymentsObject,
 });
 
-const setAmazonPayWalletWidgetReady: Action = ({ type: 'SET_AMAZON_PAY_WALLET_WIDGET_READY' });
+const setAmazonPayWalletWidgetReady = (isReady: boolean): Action =>
+  ({ type: 'SET_AMAZON_PAY_WALLET_WIDGET_READY', isReady });
+
 const setAmazonPayHasAccessToken: Action = ({ type: 'SET_AMAZON_PAY_HAS_ACCESS_TOKEN' });
 const setAmazonPayFatalError: Action = ({ type: 'SET_AMAZON_PAY_FATAL_ERROR' });
 
@@ -421,6 +423,10 @@ const onPaymentResult = (paymentResult: Promise<PaymentResult>, paymentAuthorisa
           } else {
             if (result.error === 'amazon_pay_fatal') {
               dispatch(setAmazonPayFatalError);
+            }
+            if (result.error === 'amazon_pay_try_other_card') {
+              // Must re-render the wallet widget in order to display amazon's error message
+              dispatch(setAmazonPayWalletWidgetReady(false));
             }
             dispatch(paymentFailure(result.error));
           }

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
@@ -281,7 +281,7 @@ function createFormReducer() {
           ...state,
           amazonPayData: {
             ...state.amazonPayData,
-            walletWidgetReady: true,
+            walletWidgetReady: action.isReady,
           },
         };
 


### PR DESCRIPTION
## Why are you doing this?

We display our own error messages in the usual place, but amazon's wallet widget can also display error messages.
In order to do this, we have to re-create the widget, passing in the same orderReferenceId.

Here we can see both our message and amazon's message about card info:
<img width="520" alt="Screenshot 2019-12-18 at 11 30 20" src="https://user-images.githubusercontent.com/1513454/71083446-f520ea80-218a-11ea-9c85-01aa62f88ed0.png">

