### PR TITLE
Remove css controlling banner widths and use line-breaks instead

### DIFF
--- a/support-frontend/assets/components/headingBlock/headingBlock.jsx
+++ b/support-frontend/assets/components/headingBlock/headingBlock.jsx
@@ -11,7 +11,7 @@ import './headingBlock.scss';
 // ----- Types ----- //
 
 type PropTypes = {|
-  overheading: Option<string>,
+  overheading: Option<string> | Node,
   children?: Node,
   orderIsAGift?: boolean,
   overheadingClass?: string,

--- a/support-frontend/assets/components/headingBlock/headingBlock.jsx
+++ b/support-frontend/assets/components/headingBlock/headingBlock.jsx
@@ -32,13 +32,13 @@ function HeadingBlock(props: PropTypes) {
             <h1 className={`component-heading-block__overheading${overheadingClass}`}>{props.overheading}</h1>),
           (
             <div className="component-heading-block__heading">
-              <h2 className="component-heading-block__maxwidth">{props.children}</h2>
+              <h2 className="component-heading-block__fontSize">{props.children}</h2>
             </div>
            ),
          ]
         :
         <div className="component-heading-block__heading">
-          <h1 className="component-heading-block__maxwidth">{props.children}</h1>
+          <h1 className="component-heading-block__fontSize">{props.children}</h1>
         </div>
       }
       </div>

--- a/support-frontend/assets/components/headingBlock/headingBlock.scss
+++ b/support-frontend/assets/components/headingBlock/headingBlock.scss
@@ -53,13 +53,8 @@
   background-color: gu-colour(highlight-main);
 }
 
-.component-heading-block__maxwidth {
-  max-width: gu-span(10);
-}
-
 .component-heading-block__gift {
-  .component-heading-block__maxwidth {
-    max-width: gu-span(7);
+  .component-heading-block__fontSize {
 
     @include mq($until: mobileLandscape) {
       font-size: 26px;

--- a/support-frontend/assets/components/productPage/productPageHero/productPageHero.jsx
+++ b/support-frontend/assets/components/productPage/productPageHero/productPageHero.jsx
@@ -24,7 +24,7 @@ type WrapperPropTypes = {|
 type PropTypes = {|
   ...WrapperPropTypes,
   overheading: string,
-  heading: string,
+  heading: string | Node,
   content?: Option<Node>,
   hasCampaign: boolean,
   showProductPageHeroHeader?: boolean,
@@ -35,7 +35,7 @@ type PropTypes = {|
 type ProductPageHeroHeaderTypes = {
   overheading: string,
   hasCampaign: boolean,
-  heading: string,
+  heading: string | Node,
   content?: Option<Node>,
   orderIsAGift?: boolean,
   giftImage?: Node,

--- a/support-frontend/assets/helpers/flashSale.js
+++ b/support-frontend/assets/helpers/flashSale.js
@@ -1,5 +1,7 @@
 // @flow
 
+import { type Node } from 'react';
+
 import { getQueryParameter } from 'helpers/url';
 import { type CountryGroupId, detect } from 'helpers/internationalisation/countryGroup';
 import { fixDecimals } from 'helpers/subscriptions';
@@ -20,7 +22,7 @@ export type SaleCopy = {
     description: string,
   },
   landingPage: {
-    heading: string,
+    heading: string | Node,
     subHeading: string,
     roundel: string[],
   },

--- a/support-frontend/assets/helpers/flashSale.js
+++ b/support-frontend/assets/helpers/flashSale.js
@@ -22,7 +22,7 @@ export type SaleCopy = {
     description: string,
   },
   landingPage: {
-    heading: string | Node,
+    heading: Option<Node>,
     subHeading: string,
     roundel: string[],
   },
@@ -195,7 +195,7 @@ function getSaleCopy(product: SubscriptionProduct, countryGroupId: CountryGroupI
       description: '',
     },
     landingPage: {
-      heading: '',
+      heading: null,
       subHeading: '',
       roundel: [''],
     },

--- a/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
@@ -164,7 +164,7 @@ function getCopy(product: SubscriptionProduct, country: CountryGroupId) {
   if (flashSaleIsActive(product, country)) {
     const saleCopy = getSaleCopy(product, country);
     return {
-      heading: `${saleCopy.landingPage.heading}`,
+      heading: saleCopy.landingPage.heading,
       subHeading: `${saleCopy.landingPage.subHeading}`,
     };
   }

--- a/support-frontend/assets/pages/paper-subscription-landing/components/hero/discountCopy.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/hero/discountCopy.jsx
@@ -1,16 +1,18 @@
 // @flow
 
+import React, { type Node } from 'react';
+
 import { flashSaleIsActive, getSaleCopy } from 'helpers/flashSale';
 import { GBPCountries } from 'helpers/internationalisation/countryGroup';
 
 type DiscountCopy = {
   roundel: string[],
-  heading: string,
+  heading: string | Node,
 };
 
 const discountCopy: DiscountCopy = {
   roundel: ['Save up to', '37%', 'for a year'],
-  heading: 'Save up to 37% for a year on The Guardian and The Observer',
+  heading: <span>Save up to 37% for a year on The Guardian<br />and The Observer</span>,
 };
 
 export const getDiscountCopy = (): DiscountCopy => {

--- a/support-frontend/assets/pages/paper-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/hero/hero.jsx
@@ -19,7 +19,7 @@ import { GBPCountries } from 'helpers/internationalisation/countryGroup';
 import {
   showCountdownTimer,
 } from 'helpers/flashSale';
-import { getDiscountCopy } from '../hero/discountCopy';
+import { getDiscountCopy } from './discountCopy';
 import './joyOfPrint.scss';
 
 const discountCopy = getDiscountCopy();

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.jsx
@@ -2,7 +2,7 @@
 
 // ----- Imports ----- //
 
-import React from 'react';
+import React, { type Node } from 'react';
 import GridPicture from 'components/gridPicture/gridPicture';
 import AnchorButton from 'components/button/anchorButton';
 import SvgChevron from 'components/svgs/chevron';
@@ -50,7 +50,7 @@ const HeroGlobe = () => (
   </div>
 );
 
-const CampaignHeader = (props: {heading: string, orderIsAGift: boolean}) => (
+const CampaignHeader = (props: {heading: string | Node, orderIsAGift: boolean}) => (
   <ProductPageHero
     appearance="campaign"
     overheading="Guardian Weekly subscriptions"

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -49,7 +49,7 @@ import { getQueryParameter } from 'helpers/url';
 import AnchorButton from 'components/button/anchorButton';
 
 type PageCopy = {|
-  title: string,
+  title: string | React.Node,
   firstParagraph: React.Node,
   priceCardSubHeading: string,
 |};
@@ -123,8 +123,8 @@ const getFirstParagraph = (promotionCopy: ?PromotionCopy) => {
 
 const getCopy = (promotionCopy: Object, orderIsAGift: boolean): PageCopy => {
   const defaultTitle = orderIsAGift ?
-    'Give a gift that challenges the status quo'
-    : 'Pause for thought with The Guardian\'s essential news magazine';
+    <span>Give a gift that challenges<br />the status quo</span>
+    : <span>Pause for thought with The Guardian&apos;s<br />essential news magazine</span>;
   return {
     title: promotionCopy && promotionCopy.title ? promotionCopy.title : defaultTitle,
     firstParagraph: getFirstParagraph(promotionCopy),


### PR DESCRIPTION
## Why are you doing this?
The way that we've been managing the line breaks on the landing pages standfirst (the main heading in the black banner) no longer seems the best approach as it was causing one heading to wrap onto three lines. 

So rather that relying on css to manage this, I've updated it to be controlled by line breaks instead, and can thus be handled on a case by case basis.

This has had some knock-on effects to other landing pages (Paper and regular Guardian Weekly) so I have managed the line breaks for these standfirsts also.

[**Trello Card**](https://trello.com/c/dkhRjTXe/2817-standfirst-should-not-wrap-on-gifting-landing-page-on-wide)

## Screenshots
![Screen Shot 2019-12-19 at 13 11 56](https://user-images.githubusercontent.com/16781258/71176279-6af78580-2261-11ea-82d7-046f5ef844ff.png)

![Screen Shot 2019-12-19 at 13 12 12](https://user-images.githubusercontent.com/16781258/71176355-97130680-2261-11ea-8ce2-bbacd04d9cd9.png)

![Screen Shot 2019-12-19 at 13 12 37](https://user-images.githubusercontent.com/16781258/71176361-9a0df700-2261-11ea-8174-a1ea8722ea8f.png)
