### PR TITLE
Fix typeface for mobile view of subs heading

### DIFF
--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.scss
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.scss
@@ -78,15 +78,13 @@
 
   @include mq($from: mobileLandscape) {
     max-width: 500px;
-    font-size: 36px;
-    line-height: 38px;
+    font-size: 40px;
+    line-height: 42px;
     padding-right: 20px;
   }
 
   @include mq($from: tablet) {
     max-width: 700px;
-    padding-left: 40px;
-    font-size: 42px;
     line-height: 45px;
   }
 


### PR DESCRIPTION
## Why are you doing this?
The typeface of the page heading was looking quite odd on mobile.

[**Trello Card**](https://trello.com/c/ZU5OemXO/2819-typography-fix-change-on-mobile-for-subs-landing-page)

## Screenshots
![Screen Shot 2019-12-19 at 15 04 11](https://user-images.githubusercontent.com/16781258/71184263-689d2780-2271-11ea-9509-70755137ee90.png)
