### PR TITLE
Use promotion discount text on the showcase page for simplicity

### DIFF
--- a/support-frontend/app/controllers/Subscriptions.scala
+++ b/support-frontend/app/controllers/Subscriptions.scala
@@ -55,11 +55,11 @@ class Subscriptions(
     implicit val codec : com.gu.support.encoding.Codec[PriceCopy] = deriveCodec
   }
 
-  def pricingCopy(priceSummary: PriceSummary, copyField: PromotionCopy => Option[String] = promoCopy => promoCopy.roundel): PriceCopy = {
+  def pricingCopy(priceSummary: PriceSummary): PriceCopy = {
     val discountCopy = for {
       promotion <- priceSummary.promotions.headOption
       discountedPrice <- promotion.discountedPrice
-    } yield PriceCopy(discountedPrice, promotion.landingPage.flatMap(copyField).getOrElse(""))
+    } yield PriceCopy(discountedPrice, promotion.description)
     discountCopy.getOrElse(PriceCopy(priceSummary.price, ""))
   }
 
@@ -68,7 +68,7 @@ class Subscriptions(
 
     val paperMap = if (countryGroup == CountryGroup.UK) {
       val paper = service.getPrices(Paper, List("GE19SUBS"))(CountryGroup.UK)(Collection)(Sunday)(Monthly)(GBP)
-      Map(Paper.toString -> pricingCopy(paper, promoCopy => promoCopy.description))
+      Map(Paper.toString -> pricingCopy(paper))
     }
     else
       Map.empty


### PR DESCRIPTION
## Why are you doing this?
#2292 Changed the showcase page to use promotional copy in the product cards, however it was using a different field for paper to the one used for GW and DS. This is complicated to explain to users and also resulted in a bug because the field used by DS was not specified.

This PR switches the behaviour to use the description field (the same field as used by the checkout summary) for all products. This is simpler to explain and as it is a mandatory field will not result in the bug mentioned above.

[**Trello Card**](https://trello.com/c/ryP1Isc2/2823-change-the-promotion-copy-field-used-on-the-showcase-page)
