### PR TITLE
Revert "disabled reverse amounts test (#2282)"

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -8,6 +8,7 @@ import {
 // ----- Tests ----- //
 export type RecurringStripePaymentRequestButtonTestVariants = 'control' | 'paymentRequestButton' | 'notintest';
 export type PaymentSecuritySecureTransactionGreyNonUKVariants = 'control' | 'V1_securetransactiongrey' | 'notintest';
+export type LandingPageReverseAmountsTestVariant = 'control' | 'reversedAmounts' | 'notintest';
 export type NewLandingPageTemplateTestVariants = 'control' | 'new_template' | 'notintest';
 export type AmazonPaySingleUSTestVariants = 'control' | 'amazonPay' | 'notintest';
 export type UsEoyCopyTestVariants = 'v1' | 'v2' | 'notintest';
@@ -82,6 +83,29 @@ export const tests: Tests = {
     independent: true,
     seed: 3,
     targetPage: usContributionsLandingPageMatch,
+  },
+
+  landingPageReverseAmounts: {
+    type: 'OTHER',
+    variants: [
+      {
+        id: 'control',
+      },
+      {
+        id: 'reversedAmounts',
+      },
+    ],
+    audiences: {
+      ALL: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: true,
+    independent: true,
+    seed: 4,
+    targetPage: usContributionsLandingPageMatch,
+    canRun: () => countryGroupId === 'UnitedStates',
   },
 
   paymentSecuritySecureTransactionGreyNonUK: {

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
@@ -24,6 +24,7 @@ import SvgEuro from 'components/svgs/euro';
 import SvgPound from 'components/svgs/pound';
 import { selectAmount, updateOtherAmount } from '../contributionsLandingActions';
 import ContributionTextInput from './ContributionTextInput';
+import type { LandingPageReverseAmountsTestVariant } from 'helpers/abTests/abtestDefinitions';
 
 // ----- Types ----- //
 
@@ -40,6 +41,7 @@ type PropTypes = {|
   updateOtherAmount: (string, CountryGroupId, ContributionType) => void,
   checkoutFormHasBeenSubmitted: boolean,
   stripePaymentRequestButtonClicked: boolean,
+  landingPageReverseAmountsVariant: LandingPageReverseAmountsTestVariant,
 |};
 /* eslint-enable react/no-unused-prop-types */
 
@@ -54,6 +56,7 @@ const mapStateToProps = state => ({
   stripePaymentRequestButtonClicked:
     state.page.form.stripePaymentRequestButtonData.ONE_OFF.stripePaymentRequestButtonClicked ||
     state.page.form.stripePaymentRequestButtonData.REGULAR.stripePaymentRequestButtonClicked,
+  landingPageReverseAmountsVariant: state.common.abParticipations.landingPageReverseAmounts,
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -163,11 +166,14 @@ function withProps(props: PropTypes) {
     formatAmount(currencies[props.currency], spokenCurrencies[props.currency], { value: max.toString() }, false);
   const otherAmount = props.otherAmounts[props.contributionType].amount;
 
+  // JTL - related to landing page reverse amounts test:
+  const amountsToRender = props.landingPageReverseAmountsVariant === 'reversedAmounts' ? validAmounts.reverse() : validAmounts;
+
   return (
     <fieldset className={classNameWithModifiers('form__radio-group', ['pills', 'contribution-amount'])}>
       <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>How much would you like to give?</legend>
       <ul className="form__radio-group-list">
-        {validAmounts.map(renderAmount(
+        {amountsToRender.map(renderAmount(
           currencies[props.currency],
           spokenCurrencies[props.currency],
           props,


### PR DESCRIPTION
This reverts commit bd577a4a69fdfc014a0ec85ac7250001772a7243.
We want to run this test again for EOY in US
<img width="535" alt="Screenshot 2019-12-20 at 10 29 35" src="https://user-images.githubusercontent.com/1513454/71249442-0bf34880-2315-11ea-82b6-4c049e4d8efe.png">

