### PR TITLE
Roll out Apple Pay to 100% for Recurring Contributions!

### DIFF
--- a/support-frontend/app/admin/settings/Settings.scala
+++ b/support-frontend/app/admin/settings/Settings.scala
@@ -114,6 +114,8 @@ object SettingsSource extends LazyLogging {
 
 case class PaymentMethodsSwitch(
   stripe: SwitchState,
+  stripeApplePay: SwitchState,
+  stripePaymentRequestButton: SwitchState,
   payPal: SwitchState,
   directDebit: Option[SwitchState],
   existingCard: Option[SwitchState],
@@ -135,6 +137,8 @@ object PaymentMethodsSwitch {
   def fromConfig(config: Config): PaymentMethodsSwitch =
     PaymentMethodsSwitch(
       SwitchState.fromConfig(config, "stripe"),
+      SwitchState.fromConfig(config, "stripeApplePay"),
+      SwitchState.fromConfig(config, "stripePaymentRequestButton"),
       SwitchState.fromConfig(config, "payPal"),
       SwitchState.optionFromConfig(config, "directDebit"),
       SwitchState.optionFromConfig(config, "existingCard"),

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -6,7 +6,6 @@ import {
 } from 'helpers/internationalisation/countryGroup';
 
 // ----- Tests ----- //
-export type RecurringStripePaymentRequestButtonTestVariants = 'control' | 'paymentRequestButton' | 'notintest';
 export type PaymentSecuritySecureTransactionGreyNonUKVariants = 'control' | 'V1_securetransactiongrey' | 'notintest';
 export type LandingPageReverseAmountsTestVariant = 'control' | 'reversedAmounts' | 'notintest';
 export type NewLandingPageTemplateTestVariants = 'control' | 'new_template' | 'notintest';

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
@@ -50,7 +50,7 @@ import type { RecentlySignedInExistingPaymentMethod } from 'helpers/existingPaym
 import type { PaymentMethod } from 'helpers/paymentMethods';
 import { DirectDebit, Stripe, ExistingCard, ExistingDirectDebit, AmazonPay } from 'helpers/paymentMethods';
 import { getCampaignName } from 'helpers/campaigns';
-import type { PaymentSecuritySecureTransactionGreyNonUKVariants, RecurringStripePaymentRequestButtonTestVariants } from 'helpers/abTests/abtestDefinitions';
+import type { PaymentSecuritySecureTransactionGreyNonUKVariants } from 'helpers/abTests/abtestDefinitions';
 import { logException } from 'helpers/logger';
 
 
@@ -84,7 +84,6 @@ type PropTypes = {|
   country: IsoCountry,
   createStripePaymentMethod: () => void,
   paymentSecuritySecureTransactionGreyNonUKVariant: PaymentSecuritySecureTransactionGreyNonUKVariants,
-  recurringStripePaymentRequestButtonTestVariant: RecurringStripePaymentRequestButtonTestVariants,
   amazonPayOrderReferenceId: string | null,
 |};
 
@@ -118,7 +117,6 @@ const mapStateToProps = (state: State) => ({
   stripeV3HasLoaded: state.page.form.stripeV3HasLoaded,
   paymentSecuritySecureTransactionGreyNonUKVariant:
     state.common.abParticipations.paymentSecuritySecureTransactionGreyNonUK,
-  recurringStripePaymentRequestButtonTestVariant: state.common.abParticipations.recurringStripePaymentRequestButton,
   amazonPayOrderReferenceId: state.page.form.amazonPayData.orderReferenceId,
 });
 
@@ -255,7 +253,6 @@ function withProps(props: PropTypes) {
         country={props.country}
         otherAmounts={props.otherAmounts}
         selectedAmounts={props.selectedAmounts}
-        recurringTestVariant={props.recurringStripePaymentRequestButtonTestVariant}
       />
       <div className={classNameWithModifiers('form', ['content'])}>
         <ContributionFormFields />

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
@@ -21,7 +21,6 @@ import type { IsoCountry } from 'helpers/internationalisation/country';
 import { isInStripePaymentRequestAllowedCountries } from 'helpers/internationalisation/country';
 import { setupStripe } from 'helpers/stripe';
 import StripePaymentRequestButton from './StripePaymentRequestButton';
-import type { RecurringStripePaymentRequestButtonTestVariants } from 'helpers/abTests/abtestDefinitions';
 
 // ----- Types -----//
 
@@ -35,7 +34,6 @@ type PropTypes = {|
   stripeHasLoaded: boolean,
   selectedAmounts: SelectedAmounts,
   otherAmounts: OtherAmounts,
-  recurringTestVariant: RecurringStripePaymentRequestButtonTestVariants,
 |};
 
 // ----- Component ----- //
@@ -68,7 +66,6 @@ class StripePaymentRequestButtonContainer extends React.Component<PropTypes, voi
               <StripePaymentRequestButton
                 stripeAccount={stripeAccount}
                 amount={amount}
-                recurringTestVariant={this.props.recurringTestVariant}
               />
             </Elements>
           </StripeProvider>

--- a/support-frontend/test/codecs/CirceDecodersTest.scala
+++ b/support-frontend/test/codecs/CirceDecodersTest.scala
@@ -101,6 +101,7 @@ class CirceDecodersTest extends AnyWordSpec with Matchers {
           |      "stripeApplePay": "On",
           |      "stripePaymentRequestButton": "On",
           |      "payPal": "On"
+          |      "amazonPay": "On"
           |    },
           |    "recurringPaymentMethods": {
           |      "stripe": "On",
@@ -266,12 +267,12 @@ class CirceDecodersTest extends AnyWordSpec with Matchers {
             directDebit = None,
             existingCard = None,
             existingDirectDebit = None,
-            amazonPay = None
+            amazonPay = Some(On)
           ),
           recurringPaymentMethods = PaymentMethodsSwitch(
             stripe = On,
             stripeApplePay = On,
-            stripePaymentRequestButton = On,
+            stripePaymentRequestButton = Off,
             payPal = On,
             directDebit = Some(On),
             existingCard = Some(On),

--- a/support-frontend/test/codecs/CirceDecodersTest.scala
+++ b/support-frontend/test/codecs/CirceDecodersTest.scala
@@ -98,10 +98,14 @@ class CirceDecodersTest extends AnyWordSpec with Matchers {
           |  "switches": {
           |    "oneOffPaymentMethods": {
           |      "stripe": "On",
+          |      "stripeApplePay": "On",
+          |      "stripePaymentRequestButton": "On",
           |      "payPal": "On"
           |    },
           |    "recurringPaymentMethods": {
           |      "stripe": "On",
+          |      "stripeApplePay": "On",
+          |      "stripePaymentRequestButton": "Off",
           |      "payPal": "On",
           |      "directDebit": "On",
           |      "existingCard": "On",
@@ -256,6 +260,8 @@ class CirceDecodersTest extends AnyWordSpec with Matchers {
         Switches(
           oneOffPaymentMethods = PaymentMethodsSwitch(
             stripe = On,
+            stripeApplePay = On,
+            stripePaymentRequestButton = On,
             payPal = On,
             directDebit = None,
             existingCard = None,
@@ -264,6 +270,8 @@ class CirceDecodersTest extends AnyWordSpec with Matchers {
           ),
           recurringPaymentMethods = PaymentMethodsSwitch(
             stripe = On,
+            stripeApplePay = On,
+            stripePaymentRequestButton = On,
             payPal = On,
             directDebit = Some(On),
             existingCard = Some(On),

--- a/support-frontend/test/codecs/CirceDecodersTest.scala
+++ b/support-frontend/test/codecs/CirceDecodersTest.scala
@@ -100,7 +100,7 @@ class CirceDecodersTest extends AnyWordSpec with Matchers {
           |      "stripe": "On",
           |      "stripeApplePay": "On",
           |      "stripePaymentRequestButton": "On",
-          |      "payPal": "On"
+          |      "payPal": "On",
           |      "amazonPay": "On"
           |    },
           |    "recurringPaymentMethods": {

--- a/support-frontend/test/controllers/SubscriptionsTest.scala
+++ b/support-frontend/test/controllers/SubscriptionsTest.scala
@@ -66,7 +66,11 @@ class SubscriptionsTest extends AnyWordSpec with Matchers with TestCSRFComponent
 
     val amounts = Amounts(Nil, Nil, Nil)
     val allSettings = AllSettings(
-      Switches(PaymentMethodsSwitch(On, On, None, None, None, None), PaymentMethodsSwitch(On, On, Some(On), Some(On), Some(On), None), Map.empty),
+      Switches(
+        oneOffPaymentMethods = PaymentMethodsSwitch(On, On, On, On, None, None, None, None),
+        recurringPaymentMethods = PaymentMethodsSwitch(On, On, On, On, Some(On), Some(On), Some(On), None),
+        experiments = Map.empty
+      ),
       AmountsRegions(amounts, amounts, amounts, amounts, amounts, amounts, amounts),
       ContributionTypes(Nil, Nil, Nil, Nil, Nil, Nil, Nil),
       MetricUrl("http://localhost")


### PR DESCRIPTION
This PR rolls out Apple Pay and the Stripe Payment Request Button to 100% for Recurring Contributions, and puts them behind a feature switch.

## Why are you doing this?

Apple Pay test variant yielded 300% increase over the control! PRB made no significant difference.

[**Trello Card**](https://trello.com/c/cXTbe8wQ)

## Changes

* Removed A/B test for Apple Pay / Stripe Payment Request Button for recurring contributions.
* Added Apple Pay and the Stripe Payment Request Button between 4 independent feature switches - 2 switches for single and 2 for recurring.

## Screenshots

[I'll add these after the fact as it's hard to get my iPhone into the test variant!]

**Do not deploy this to PROD till 10am on Friday 27th**