### PR TITLE
Roll out Amazon Pay to 100% of Singe Contribution checkout in the US

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -10,7 +10,6 @@ export type RecurringStripePaymentRequestButtonTestVariants = 'control' | 'payme
 export type PaymentSecuritySecureTransactionGreyNonUKVariants = 'control' | 'V1_securetransactiongrey' | 'notintest';
 export type LandingPageReverseAmountsTestVariant = 'control' | 'reversedAmounts' | 'notintest';
 export type NewLandingPageTemplateTestVariants = 'control' | 'new_template' | 'notintest';
-export type AmazonPaySingleUSTestVariants = 'control' | 'amazonPay' | 'notintest';
 export type UsEoyCopyTestVariants = 'v1' | 'v2' | 'notintest';
 
 const contributionsLandingPageMatch = '/(uk|us|eu|au|ca|nz|int)/contribute(/.*)?$';
@@ -19,28 +18,6 @@ const usContributionsLandingPageMatch = '/us/contribute(/.*)?$';
 const countryGroupId: CountryGroupId = detect();
 
 export const tests: Tests = {
-  amazonPaySingleUS: {
-    type: 'OTHER',
-    variants: [
-      {
-        id: 'control',
-      },
-      {
-        id: 'amazonPay',
-      },
-    ],
-    audiences: {
-      ALL: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: true,
-    independent: true,
-    seed: 1,
-    targetPage: usContributionsLandingPageMatch,
-  },
-
   recurringStripePaymentRequestButton: {
     type: 'OTHER',
     variants: [

--- a/support-frontend/assets/helpers/checkouts.js
+++ b/support-frontend/assets/helpers/checkouts.js
@@ -89,22 +89,19 @@ function getValidPaymentMethods(
   contributionType: ContributionType,
   allSwitches: Switches,
   countryId: IsoCountry,
-  inAmazonPayTest: boolean,
 ): PaymentMethod[] {
   const switchKey = (contributionType === 'ONE_OFF') ? 'oneOffPaymentMethods' : 'recurringPaymentMethods';
   return getPaymentMethods(contributionType, countryId)
     .filter(paymentMethod =>
-      isSwitchOn(`${switchKey}.${toPaymentMethodSwitchNaming(paymentMethod) || '-'}`) &&
-      (paymentMethod !== 'AmazonPay' || inAmazonPayTest));
+      isSwitchOn(`${switchKey}.${toPaymentMethodSwitchNaming(paymentMethod) || '-'}`));
 }
 
 function getPaymentMethodToSelect(
   contributionType: ContributionType,
   allSwitches: Switches,
   countryId: IsoCountry,
-  inAmazonPayTest: boolean,
 ) {
-  const validPaymentMethods = getValidPaymentMethods(contributionType, allSwitches, countryId, inAmazonPayTest);
+  const validPaymentMethods = getValidPaymentMethods(contributionType, allSwitches, countryId);
   return validPaymentMethods[0] || 'None';
 }
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
@@ -30,8 +30,7 @@ type PropTypes = {|
   countryGroupId: CountryGroupId,
   switches: Switches,
   contributionTypes: ContributionTypes,
-  onSelectContributionType: (ContributionType, Switches, IsoCountry, CountryGroupId, boolean) => void,
-  inAmazonPayTest: boolean,
+  onSelectContributionType: (ContributionType, Switches, IsoCountry, CountryGroupId) => void,
 |};
 
 const mapStateToProps = (state: State) => ({
@@ -40,8 +39,6 @@ const mapStateToProps = (state: State) => ({
   countryId: state.common.internationalisation.countryId,
   switches: state.common.settings.switches,
   contributionTypes: state.common.settings.contributionTypes,
-  inAmazonPayTest:
-    state.common.abParticipations.amazonPaySingleUS === 'amazonPay',
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -50,9 +47,8 @@ const mapDispatchToProps = (dispatch: Function) => ({
     switches: Switches,
     countryId: IsoCountry,
     countryGroupId: CountryGroupId,
-    inAmazonPayTest: boolean,
   ) => {
-    const paymentMethodToSelect = getPaymentMethodToSelect(contributionType, switches, countryId, inAmazonPayTest);
+    const paymentMethodToSelect = getPaymentMethodToSelect(contributionType, switches, countryId);
     trackComponentClick(`npf-contribution-type-toggle-${countryGroupId}-${contributionType}`);
     dispatch(updateContributionTypeAndPaymentMethod(contributionType, paymentMethodToSelect));
   },
@@ -64,7 +60,7 @@ function withProps(props: PropTypes) {
   const contributionTypes = props.contributionTypes[props.countryGroupId];
 
   if (contributionTypes.length === 1 && contributionTypes[0].contributionType === 'ONE_OFF') {
-    return (null);
+    return null;
   }
 
   return (
@@ -87,7 +83,6 @@ function withProps(props: PropTypes) {
                     props.switches,
                     props.countryId,
                     props.countryGroupId,
-                    props.inAmazonPayTest,
                   )
                 }
                 checked={props.contributionType === contributionType}

--- a/support-frontend/assets/pages/contributions-landing/components/PaymentMethodSelector.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/PaymentMethodSelector.jsx
@@ -66,7 +66,6 @@ type PropTypes = {|
   isTestUser: boolean,
   switches: Switches,
   paymentSecuritySecureTransactionGreyNonUKVariant: PaymentSecuritySecureTransactionGreyNonUKVariants,
-  inAmazonPayTest: boolean,
 |};
 /* eslint-enable react/no-unused-prop-types */
 
@@ -81,8 +80,6 @@ const mapStateToProps = (state: State) => ({
   switches: state.common.settings.switches,
   paymentSecuritySecureTransactionGreyNonUKVariant:
     state.common.abParticipations.paymentSecuritySecureTransactionGreyNonUK,
-  inAmazonPayTest:
-    state.common.abParticipations.amazonPaySingleUS === 'amazonPay',
 });
 
 const mapDispatchToProps = {
@@ -111,7 +108,7 @@ function getPaymentMethodLogo(paymentMethod: PaymentMethod) {
 function withProps(props: PropTypes) {
 
   const paymentMethods: PaymentMethod[] =
-    getValidPaymentMethods(props.contributionType, props.switches, props.countryId, props.inAmazonPayTest);
+    getValidPaymentMethods(props.contributionType, props.switches, props.countryId);
 
   const noPaymentMethodsErrorMessage =
     (<GeneralErrorMessage

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.js
@@ -56,10 +56,9 @@ function getInitialPaymentMethod(
   contributionType: ContributionType,
   countryId: IsoCountry,
   switches: Switches,
-  inAmazonPayTest: boolean,
 ): PaymentMethod {
   const paymentMethodFromSession = getPaymentMethodFromSession();
-  const validPaymentMethods = getValidPaymentMethods(contributionType, switches, countryId, inAmazonPayTest);
+  const validPaymentMethods = getValidPaymentMethods(contributionType, switches, countryId);
 
   return (
     paymentMethodFromSession && validPaymentMethods.includes(getPaymentMethodFromSession())
@@ -113,7 +112,6 @@ function initialisePaymentMethods(
   state: State,
   dispatch: Function,
   contributionTypes: ContributionTypes,
-  inAmazonPayTest: boolean,
 ) {
 
   const { countryId, currencyId, countryGroupId } = state.common.internationalisation;
@@ -133,7 +131,6 @@ function initialisePaymentMethods(
           contributionTypeSetting.contributionType,
           switches,
           countryId,
-          inAmazonPayTest,
         );
         // Stripe Payment Intents is currently only for one-offs, so always initialise Stripe Checkout for now
         if (validPayments.includes(Stripe)) {
@@ -149,9 +146,7 @@ function initialisePaymentMethods(
       });
     });
 
-    if (inAmazonPayTest) {
-      setupAmazonPay(countryGroupId, dispatch, isTestUser);
-    }
+    setupAmazonPay(countryGroupId, dispatch, isTestUser);
 
     // initiate fetch of existing payment methods
     const userAppearsLoggedIn = doesUserAppearToBeSignedIn();
@@ -214,14 +209,13 @@ function selectInitialContributionTypeAndPaymentMethod(
   state: State,
   dispatch: Function,
   contributionTypes: ContributionTypes,
-  inAmazonPayTest: boolean,
 ) {
 
   const { countryId } = state.common.internationalisation;
   const { switches } = state.common.settings;
   const { countryGroupId } = state.common.internationalisation;
   const contributionType = getInitialContributionType(countryGroupId, contributionTypes);
-  const paymentMethod = getInitialPaymentMethod(contributionType, countryId, switches, inAmazonPayTest);
+  const paymentMethod = getInitialPaymentMethod(contributionType, countryId, switches);
   dispatch(updateContributionTypeAndPaymentMethod(contributionType, paymentMethod));
 }
 
@@ -234,9 +228,7 @@ const init = (store: Store<State, Action, Function>) => {
   const contributionTypes = getContributionTypes(state);
   dispatch(setContributionTypes(contributionTypes));
 
-  const inAmazonPayTest = state.common.abParticipations.amazonPaySingleUS === 'amazonPay';
-
-  initialisePaymentMethods(state, dispatch, contributionTypes, inAmazonPayTest);
+  initialisePaymentMethods(state, dispatch, contributionTypes);
 
   // This will be in window.guardian if it has come from a PayPal one-off contribution,
   // where it is returned by the Payment API to the backend, flashed into the session to preserve
@@ -247,7 +239,7 @@ const init = (store: Store<State, Action, Function>) => {
   }
 
   selectInitialAmounts(state, dispatch);
-  selectInitialContributionTypeAndPaymentMethod(state, dispatch, contributionTypes, inAmazonPayTest);
+  selectInitialContributionTypeAndPaymentMethod(state, dispatch, contributionTypes);
 
   const {
     firstName,


### PR DESCRIPTION
Removal of Amazon Pay A/B test, effectively rolling it out to 100% of Single Contributions in the UnitedStates Country Group.

## Why are you doing this?
We are holding off on making this change as it appears the variant is doing approximately 17% worse than the control, when filtered on AV/landing page impression, new and returning single products, and the US region.

<img width="1270" alt="amazon pay" src="https://user-images.githubusercontent.com/3300789/71523691-fb694200-28c1-11ea-9eb2-c917d7437a15.png">

[**Trello Card**](https://trello.com/c/NU6AYP71)

## Screenshots for US recurring and UK checkout - no Amazon Pay

![Screen Shot 2019-12-27 at 09 26 56](https://user-images.githubusercontent.com/1515970/71511673-17052600-288b-11ea-9a58-6bf93f66444e.png)
![Screen Shot 2019-12-27 at 09 26 45](https://user-images.githubusercontent.com/1515970/71511674-17052600-288b-11ea-8daa-bd3aae7e8579.png)

## Screenshots for US Single checkout - Amazon Pay visible and working
![Screen Shot 2019-12-27 at 09 25 58](https://user-images.githubusercontent.com/1515970/71511680-179dbc80-288b-11ea-9803-60e4b8fd66c9.png)
![Screen Shot 2019-12-27 at 09 26 03](https://user-images.githubusercontent.com/1515970/71511678-179dbc80-288b-11ea-85c4-ed6feaa830dd.png)
![Screen Shot 2019-12-27 at 09 26 17](https://user-images.githubusercontent.com/1515970/71511676-179dbc80-288b-11ea-9fe5-f82a90233a02.png)
![Screen Shot 2019-12-27 at 09 26 32](https://user-images.githubusercontent.com/1515970/71511675-17052600-288b-11ea-9918-af4b46a991c4.png)

## Screenshots for US Single checkout - When Amazon Pay feature switch is turned off
![Screen Shot 2019-12-27 at 09 30 14](https://user-images.githubusercontent.com/1515970/71511807-87ac4280-288b-11ea-8ed1-7e615afceaa3.png)

**Do not merge till 30 December as A/B test will not have reached significance**