### PR TITLE
To be reversed on Thursday: temporarily disabling amazon pay test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -34,7 +34,7 @@ export const tests: Tests = {
         size: 1,
       },
     },
-    isActive: true,
+    isActive: false,
     independent: true,
     seed: 1,
     targetPage: usContributionsLandingPageMatch,


### PR DESCRIPTION
#1104  Why are you doing this?
We've been asked to disable the losing Amazon Pay test for the biggest days of the year (which are now). To be reversed on Thursday.