### PR TITLE
Merge on Thursday (Jan 2): Revert "temporarily disabling amazon pay test"

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -34,7 +34,7 @@ export const tests: Tests = {
         size: 1,
       },
     },
-    isActive: false,
+    isActive: true,
     independent: true,
     seed: 1,
     targetPage: usContributionsLandingPageMatch,


### PR DESCRIPTION
Reinstating the Amazon Pay test: Reverts guardian/support-frontend#2314