### PR TITLE
Reinstate Amazon Pay A/B test with a different test name and seed

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -18,7 +18,7 @@ const usContributionsLandingPageMatch = '/us/contribute(/.*)?$';
 const countryGroupId: CountryGroupId = detect();
 
 export const tests: Tests = {
-  amazonPaySingleUS: {
+  amazonPaySingleUS2020: {
     type: 'OTHER',
     variants: [
       {
@@ -34,9 +34,9 @@ export const tests: Tests = {
         size: 1,
       },
     },
-    isActive: false,
+    isActive: true,
     independent: true,
-    seed: 1,
+    seed: 13,
     targetPage: usContributionsLandingPageMatch,
   },
 

--- a/support-frontend/assets/pages/contributions-landing/components/AmazonPay/AmazonPay.scss
+++ b/support-frontend/assets/pages/contributions-landing/components/AmazonPay/AmazonPay.scss
@@ -5,6 +5,6 @@
 
 .walletWidgetDiv {
     margin: 0 auto 20px;
-    width: 80%;
+    width: 100%;
     height: 228px;
 }

--- a/support-frontend/assets/pages/contributions-landing/components/AmazonPay/AmazonPayLoginButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/AmazonPay/AmazonPayLoginButton.jsx
@@ -7,7 +7,7 @@ import { type Action, setAmazonPayHasAccessToken } from 'pages/contributions-lan
 import Button from 'components/button/button';
 import { logException } from 'helpers/logger';
 import AnimatedDots from 'components/spinners/animatedDots';
-import { trackComponentClick } from 'helpers/tracking/behaviour';
+import {trackComponentClick, trackComponentLoad} from 'helpers/tracking/behaviour';
 
 type PropTypes = {|
   amazonPayData: AmazonPayData,
@@ -39,6 +39,7 @@ class AmazonPayLoginButtonComponent extends React.Component<PropTypes> {
   render() {
     const { amazonLoginObject, amazonPaymentsObject } = this.props.amazonPayData.amazonPayLibrary;
     if (amazonLoginObject && amazonPaymentsObject) {
+      trackComponentLoad('amazon-pay-login-displayed');
       return (
         <div>
           <div id="AmazonLoginButton" />

--- a/support-frontend/assets/pages/contributions-landing/components/AmazonPay/AmazonPayLoginButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/AmazonPay/AmazonPayLoginButton.jsx
@@ -39,7 +39,7 @@ class AmazonPayLoginButtonComponent extends React.Component<PropTypes> {
   render() {
     const { amazonLoginObject, amazonPaymentsObject } = this.props.amazonPayData.amazonPayLibrary;
     if (amazonLoginObject && amazonPaymentsObject) {
-      trackComponentLoad('amazon-pay-login-displayed');
+      trackComponentLoad('amazon-pay-login-loaded');
       return (
         <div>
           <div id="AmazonLoginButton" />

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
@@ -41,7 +41,7 @@ const mapStateToProps = (state: State) => ({
   switches: state.common.settings.switches,
   contributionTypes: state.common.settings.contributionTypes,
   inAmazonPayTest:
-    state.common.abParticipations.amazonPaySingleUS === 'amazonPay',
+    state.common.abParticipations.amazonPaySingleUS2020 === 'amazonPay',
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({

--- a/support-frontend/assets/pages/contributions-landing/components/PaymentMethodSelector.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/PaymentMethodSelector.jsx
@@ -82,7 +82,7 @@ const mapStateToProps = (state: State) => ({
   paymentSecuritySecureTransactionGreyNonUKVariant:
     state.common.abParticipations.paymentSecuritySecureTransactionGreyNonUK,
   inAmazonPayTest:
-    state.common.abParticipations.amazonPaySingleUS === 'amazonPay',
+    state.common.abParticipations.amazonPaySingleUS2020 === 'amazonPay',
 });
 
 const mapDispatchToProps = {

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.js
@@ -234,7 +234,7 @@ const init = (store: Store<State, Action, Function>) => {
   const contributionTypes = getContributionTypes(state);
   dispatch(setContributionTypes(contributionTypes));
 
-  const inAmazonPayTest = state.common.abParticipations.amazonPaySingleUS === 'amazonPay';
+  const inAmazonPayTest = state.common.abParticipations.amazonPaySingleUS2020 === 'amazonPay';
 
   initialisePaymentMethods(state, dispatch, contributionTypes, inAmazonPayTest);
 


### PR DESCRIPTION
# Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->
Reinstate Amazon Pay A/B test with a different test name and seed, and added an extra component loaded event to show that the button was there to select.

[**Trello Card**](https://trello.com/c/I7FvdqNu)

## Screenshots
Amazon Pay shows when in the test variant:

![Screen Shot 2020-01-02 at 16 33 47](https://user-images.githubusercontent.com/1515970/71678702-ac1d8880-2d7d-11ea-899d-f2db68445643.png)

And the component event action="VIEW" beacon fires: 
![Screen Shot 2020-01-02 at 17 18 03](https://user-images.githubusercontent.com/1515970/71681166-dd995280-2d83-11ea-8196-1d2993e2d8a3.png)
