### PR TITLE
Accessibility: remove 'required' fields from contribution form

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/ContributionFormFields.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionFormFields.jsx
@@ -109,7 +109,6 @@ function withProps(props: PropTypes) {
         errorMessage="Please provide a valid email address"
         required
         disabled={isSignedIn}
-        showRequiredLabel={!isSignedIn}
       />
       <Signout isSignedIn />
       <MustSignIn
@@ -134,7 +133,6 @@ function withProps(props: PropTypes) {
             formHasBeenSubmitted={checkoutFormHasBeenSubmitted}
             errorMessage="Please provide your first name"
             required
-            showRequiredLabel
           />
           <ContributionTextInput
             id="contributionLastName"
@@ -149,7 +147,6 @@ function withProps(props: PropTypes) {
             formHasBeenSubmitted={checkoutFormHasBeenSubmitted}
             errorMessage="Please provide your last name"
             required
-            showRequiredLabel
           />
         </div> : null
       }
@@ -158,7 +155,6 @@ function withProps(props: PropTypes) {
         selectedState={state}
         isValid={checkState(state)}
         formHasBeenSubmitted={checkoutFormHasBeenSubmitted}
-        showRequiredLabel
       />
     </div>
   );
@@ -175,7 +171,6 @@ function withoutProps() {
         placeholder="example@domain.com"
         icon={<SvgEnvelope />}
         disabled
-        showRequiredLabel
         errorMessage={null}
       />
       <div>
@@ -185,7 +180,6 @@ function withoutProps() {
           label="First name"
           icon={<SvgUser />}
           disabled
-          showRequiredLabel
           errorMessage={null}
         />
         <ContributionTextInput
@@ -194,7 +188,6 @@ function withoutProps() {
           label="Last name"
           icon={<SvgUser />}
           disabled
-          showRequiredLabel
           errorMessage={null}
         />
       </div>

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionState.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionState.jsx
@@ -20,7 +20,6 @@ type PropTypes = {|
   onChange: (Event => void) | false,
   isValid: boolean,
   formHasBeenSubmitted: boolean,
-  showRequiredLabel: boolean,
 |};
 
 const mapStateToProps = (state: State) => ({
@@ -38,12 +37,10 @@ const renderStatesField = (
   onChange: (Event => void) | false,
   showError: boolean,
   label: string,
-  showRequiredLabel: boolean,
 ) => (
   <div className={classNameWithModifiers('form__field', ['contribution-state'])}>
     <label className="form__label" htmlFor="contributionState">
       {label}
-      <span className={showRequiredLabel ? 'form__label__required' : 'hidden'}> required </span>
     </label>
     <span className="form__input-with-icon">
       <select id="contributionState" className={classNameWithModifiers('form__input', selectedState ? [] : ['placeholder'])} onChange={onChange} required>
@@ -68,9 +65,9 @@ function ContributionState(props: PropTypes) {
   const showError = !props.isValid && props.formHasBeenSubmitted;
   switch (props.countryGroupId) {
     case UnitedStates:
-      return renderStatesField(usStates, props.selectedState, props.onChange, showError, 'State', props.showRequiredLabel);
+      return renderStatesField(usStates, props.selectedState, props.onChange, showError, 'State');
     case Canada:
-      return renderStatesField(caStates, props.selectedState, props.onChange, showError, 'Province', props.showRequiredLabel);
+      return renderStatesField(caStates, props.selectedState, props.onChange, showError, 'Province');
     default:
       return null;
   }

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionTextInput.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionTextInput.jsx
@@ -30,7 +30,6 @@ type PropTypes = {|
   step: number | void,
   pattern: string | void,
   disabled: boolean,
-  showRequiredLabel: boolean,
 |};
 
 // ----- Render ----- //
@@ -38,14 +37,14 @@ type PropTypes = {|
 export default function ContributionTextInput(props: PropTypes) {
   const showError = !props.isValid && props.formHasBeenSubmitted;
   const modifiersArray = showError ? ['invalid', props.id] : [props.id];
-  const showRequiredLabel = props.required && props.showRequiredLabel;
+  const showOptionalLabel = (!props.required);
 
   return (
     <div className={classNameWithModifiers('form__field', [props.name])}>
       <label className="form__label" htmlFor={props.id}>
         <span>{props.label}</span>
-        <span className={showRequiredLabel ? 'form__label__required' : 'hidden'}>
-          required
+        <span className={showOptionalLabel ? 'form__label__optional' : 'hidden'}>
+          optional
         </span>
       </label>
       <span className="form__input-with-icon">
@@ -97,5 +96,4 @@ ContributionTextInput.defaultProps = {
   disabled: false,
   formHasBeenSubmitted: false,
   isValid: true,
-  showRequiredLabel: false,
 };

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.scss
@@ -786,7 +786,7 @@ form {
   float: right;
 }
 
-.form__label__required {
+.form__label__optional {
   font-family: $gu-text-sans-web;
   font-style: italic;
   font-size: 15px;


### PR DESCRIPTION
## Why are you doing this?

According to the new [Source Design System](https://zeroheight.com/2a1e5182b/p/35ba96) it is preferable to remove the 'required' label from form fields and display an 'optional' label where applicable instead. 'Required' fields add unnecessary noise for screen readers.

[**Trello Card**](https://trello.com/c/t9D8oECp)

## Changes

* Remove `showRequiredLabel` prop from ContributionTextInput and ContributionState components
* Change function to show 'optional' label instead of 'required' in ContributionTextInput component (it seemed pointless to do this for the ContributionState component as it's only used in one place and is required, but can implement if better practice to do so).

## Screenshots

### Before (US example with state field)

<img width="482" alt="image" src="https://user-images.githubusercontent.com/15648334/71728386-d9793d80-2e34-11ea-94df-c3f24355b25a.png">

### After 

<img width="479" alt="image" src="https://user-images.githubusercontent.com/15648334/71728474-16453480-2e35-11ea-9a53-191ec7fc3ff2.png">



