### PR TITLE
Expanded options on the post contribution reminder

### DIFF
--- a/support-frontend/app/controllers/ReminderController.scala
+++ b/support-frontend/app/controllers/ReminderController.scala
@@ -35,7 +35,7 @@ class ReminderController(components: ControllerComponents,
 
   private def sendToLambda(reminderEventRequest: ReminderEventRequest) =
     sendReminderEmail(reminderEventRequest).map(res =>
-      if (res) Ok else internalServerError(s"Internal Server Error: Request failed for: ${reminderEventRequest.email}"))
+      if (res) Ok else internalServerError(s"Internal Server Error: Request failed for: ${reminderEventRequest}"))
 
   private def internalServerError(message: String) = {
     SafeLogger.warn(message)

--- a/support-frontend/assets/components/contributionsReminder/contributionsReminder.jsx
+++ b/support-frontend/assets/components/contributionsReminder/contributionsReminder.jsx
@@ -3,14 +3,15 @@
 // ----- Imports ----- //
 
 import React, { Component } from 'react';
-import SvgSubscribe from 'components/svgs/subscribe';
-import SvgSubscribed from 'components/svgs/subscribed';
 import TrackableButton from 'components/button/trackableButton';
 import { trackComponentClick, trackComponentLoad } from 'helpers/tracking/behaviour';
 import { connect } from 'react-redux';
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import { routes } from 'helpers/routes';
 import { logException } from 'helpers/logger';
+import { Fieldset } from 'components/forms/fieldset';
+import { RadioInput } from 'components/forms/customFields/radioInput';
+import { Label as FormLabel } from 'components/forms/label';
 
 // ----- Types ----- //
 type PropTypes = {
@@ -22,6 +23,8 @@ type ButtonState = 'initial' | 'pending' | 'success' | 'fail';
 
 type StateTypes = {
   buttonState: ButtonState;
+  selectedDate: string | null;
+  selectedDateAsWord: string | null,
 }
 
 const mapStateToProps = state => ({
@@ -37,17 +40,30 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
 
   state = {
     buttonState: 'initial',
+    selectedDate: null,
+    selectedDateAsWord: null,
   }
 
-  requestIsPending = (): void => {
-    this.setState({
-      buttonState: 'pending',
+  setDateState = (evt: any, date: string, dateAsWord: string) => {
+    if (!evt.target.checked || !date) {
+      return null;
+    }
+
+    return this.setState({
+      selectedDate: date,
+      selectedDateAsWord: dateAsWord,
     });
   }
 
   requestHasSucceeded = (): void => {
     this.setState({
       buttonState: 'success',
+    });
+  }
+
+  requestIsPending = (): void => {
+    this.setState({
+      buttonState: 'pending',
     });
   }
 
@@ -60,7 +76,7 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
   renderButtonCopy = (buttonState: ButtonState): string => {
     switch (buttonState) {
       case 'initial':
-        return 'Remind me in March';
+        return 'Set my reminder';
       case 'pending':
         return 'Pending...';
       case 'success':
@@ -68,12 +84,13 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
       case 'fail':
         return 'Sorry, something went wrong';
       default:
-        return 'Remind me in March';
+        return 'Set my reminder';
     }
   }
 
   render() {
     const { email, csrf } = this.props;
+
     const requestParams = {
       method: 'POST',
       headers: {
@@ -82,16 +99,15 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
       },
       body: {
         email,
-        reminderDate: '2020-03-19 00:00:00',
+        reminderDate: this.state.selectedDate,
       },
     };
 
     if (email && csrf.token) {
-      const isSuccess = this.state.buttonState === 'success';
       const isClicked = this.state.buttonState !== 'initial';
 
       return (
-        <section className="contribution-thank-you-block">
+        <section className="contribution-thank-you-block contribution-thank-you-block--reminders">
           <h3 className="contribution-thank-you-block__title">
             Set up a reminder for the end of the year
           </h3>
@@ -99,11 +115,19 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
             {'Lots of readers choose to make single contributions at various points in the year. Opt in to receive a reminder in case you would like to support our journalism again. This will be a single email, with no obligation.'}
           </p>
 
+          <FormLabel label="Remind me in:" htmlFor={null}>
+            <Fieldset legend="Choose one of the following dates to receive your reminder:">
+              <RadioInput id="march2020" text="March 2020" name="reminder" onChange={evt => this.setDateState(evt, '2020-03-19 00:00:00', 'march2020')} />
+              <RadioInput id="june2020" text="June 2020" name="reminder" onChange={evt => this.setDateState(evt, '2020-06-19 00:00:00', 'june2020')} />
+              <RadioInput id="december2020" text="December 2020" name="reminder" onChange={evt => this.setDateState(evt, '2020-12-19 00:00:00', 'december2020')} />
+            </Fieldset>
+          </FormLabel>
+
           <TrackableButton
-            icon={isSuccess ? <SvgSubscribed /> : <SvgSubscribe />}
+            icon={false}
             aria-label={this.renderButtonCopy(this.state.buttonState)}
-            appearance={isClicked ? 'disabled' : 'primary'}
-            disabled={isClicked}
+            appearance={isClicked ? 'disabled' : 'secondary'}
+            disabled={isClicked || !this.state.selectedDate}
             trackingEvent={
               () => {
                 trackComponentLoad('reminder-test-link-loaded');
@@ -114,6 +138,7 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
                 this.requestIsPending();
 
                 trackComponentClick('reminder-test-link-clicked');
+                if (this.state.selectedDateAsWord) { trackComponentClick(`reminder-test-date-${this.state.selectedDateAsWord}`); }
 
                 fetch(routes.createReminder, {
                   method: requestParams.method,

--- a/support-frontend/assets/components/contributionsReminder/contributionsReminder.jsx
+++ b/support-frontend/assets/components/contributionsReminder/contributionsReminder.jsx
@@ -121,7 +121,7 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
           <FormLabel label="Remind me in:" htmlFor={null}>
             <Fieldset legend="Choose one of the following dates to receive your reminder:">
               {reminderDates.map((reminderDate) => {
-                const dateWithoutSpace = reminderDate.dateName.replace(/\s+/g, '');
+                const dateWithoutSpace = reminderDate.dateName.replace(/\s+/g, '').toLowerCase();
                 return (
                   <RadioInput
                     id={dateWithoutSpace}

--- a/support-frontend/assets/components/contributionsReminder/contributionsReminder.jsx
+++ b/support-frontend/assets/components/contributionsReminder/contributionsReminder.jsx
@@ -97,10 +97,11 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
         'Content-Type': 'application/json',
         'Csrf-Token': csrf.token || '',
       },
-      body: {
-        email,
-        reminderDate: this.state.selectedDate,
-      },
+      body: JSON.stringify({
+          'email': email,
+          'reminderDate': this.state.selectedDate,
+        }
+      ),
     };
 
     if (email && csrf.token) {
@@ -109,7 +110,7 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
       return (
         <section className="contribution-thank-you-block contribution-thank-you-block--reminders">
           <h3 className="contribution-thank-you-block__title">
-            Set up a reminder for the end of the year
+            Set up a reminder to contribute again
           </h3>
           <p className="contribution-thank-you-block__message">
             {'Lots of readers choose to make single contributions at various points in the year. Opt in to receive a reminder in case you would like to support our journalism again. This will be a single email, with no obligation.'}
@@ -118,8 +119,8 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
           <FormLabel label="Remind me in:" htmlFor={null}>
             <Fieldset legend="Choose one of the following dates to receive your reminder:">
               <RadioInput id="march2020" text="March 2020" name="reminder" onChange={evt => this.setDateState(evt, '2020-03-19 00:00:00', 'march2020')} />
-              <RadioInput id="june2020" text="June 2020" name="reminder" onChange={evt => this.setDateState(evt, '2020-06-19 00:00:00', 'june2020')} />
-              <RadioInput id="december2020" text="December 2020" name="reminder" onChange={evt => this.setDateState(evt, '2020-12-19 00:00:00', 'december2020')} />
+              <RadioInput id="june2020" text="June 2020" name="reminder" onChange={evt => this.setDateState(evt, '2020-06-01 00:00:00', 'june2020')} />
+              <RadioInput id="december2020" text="December 2020" name="reminder" onChange={evt => this.setDateState(evt, '2020-12-01 00:00:00', 'december2020')} />
             </Fieldset>
           </FormLabel>
 
@@ -140,11 +141,7 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
                 trackComponentClick('reminder-test-link-clicked');
                 if (this.state.selectedDateAsWord) { trackComponentClick(`reminder-test-date-${this.state.selectedDateAsWord}`); }
 
-                fetch(routes.createReminder, {
-                  method: requestParams.method,
-                  headers: requestParams.headers,
-                  body: JSON.stringify(requestParams.body),
-                }).then((response) => {
+                fetch(routes.createReminder, requestParams).then((response) => {
                   if (response.ok) {
                     this.requestHasSucceeded();
                   } else {

--- a/support-frontend/assets/components/contributionsReminder/contributionsReminder.jsx
+++ b/support-frontend/assets/components/contributionsReminder/contributionsReminder.jsx
@@ -98,10 +98,9 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
         'Csrf-Token': csrf.token || '',
       },
       body: JSON.stringify({
-          'email': email,
-          'reminderDate': this.state.selectedDate,
-        }
-      ),
+        email,
+        reminderDate: this.state.selectedDate,
+      }),
     };
 
     if (email && csrf.token) {

--- a/support-frontend/assets/components/contributionsReminder/contributionsReminder.jsx
+++ b/support-frontend/assets/components/contributionsReminder/contributionsReminder.jsx
@@ -91,17 +91,20 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
   render() {
     const { email, csrf } = this.props;
 
-    const requestParams = {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Csrf-Token': csrf.token || '',
+    const reminderDates = [
+      {
+        dateName: 'March 2020',
+        timeStamp: '2020-03-19 00:00:00',
       },
-      body: JSON.stringify({
-        email,
-        reminderDate: this.state.selectedDate,
-      }),
-    };
+      {
+        dateName: 'June 2020',
+        timeStamp: '2020-03-01 00:00:00',
+      },
+      {
+        dateName: 'December 2020',
+        timeStamp: '2020-12-01 00:00:00',
+      },
+    ];
 
     if (email && csrf.token) {
       const isClicked = this.state.buttonState !== 'initial';
@@ -117,9 +120,17 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
 
           <FormLabel label="Remind me in:" htmlFor={null}>
             <Fieldset legend="Choose one of the following dates to receive your reminder:">
-              <RadioInput id="march2020" text="March 2020" name="reminder" onChange={evt => this.setDateState(evt, '2020-03-19 00:00:00', 'march2020')} />
-              <RadioInput id="june2020" text="June 2020" name="reminder" onChange={evt => this.setDateState(evt, '2020-06-01 00:00:00', 'june2020')} />
-              <RadioInput id="december2020" text="December 2020" name="reminder" onChange={evt => this.setDateState(evt, '2020-12-01 00:00:00', 'december2020')} />
+              {reminderDates.map((reminderDate) => {
+                const dateWithoutSpace = reminderDate.dateName.replace(/\s+/g, '');
+                return (
+                  <RadioInput
+                    id={dateWithoutSpace}
+                    text={reminderDate.dateName}
+                    name="reminder"
+                    onChange={evt => this.setDateState(evt, reminderDate.timeStamp, dateWithoutSpace)}
+                  />
+                );
+              })}
             </Fieldset>
           </FormLabel>
 
@@ -140,7 +151,17 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
                 trackComponentClick('reminder-test-link-clicked');
                 if (this.state.selectedDateAsWord) { trackComponentClick(`reminder-test-date-${this.state.selectedDateAsWord}`); }
 
-                fetch(routes.createReminder, requestParams).then((response) => {
+                fetch(routes.createReminder, {
+                  method: 'POST',
+                  headers: {
+                    'Content-Type': 'application/json',
+                    'Csrf-Token': csrf.token || '',
+                  },
+                  body: JSON.stringify({
+                    email,
+                    reminderDate: this.state.selectedDate,
+                  }),
+                }).then((response) => {
                   if (response.ok) {
                     this.requestHasSucceeded();
                   } else {

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.scss
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.scss
@@ -118,7 +118,7 @@
     }
 
     .component-radio-input {
-      margin-bottom: $gu-v-spacing / 3;
+      margin-bottom: $gu-v-spacing / 2;
     }
   }
 }

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.scss
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.scss
@@ -118,7 +118,7 @@
     }
 
     .component-radio-input {
-      margin-bottom: $gu-v-spacing / 4;
+      margin-bottom: $gu-v-spacing / 3;
     }
   }
 }

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.scss
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.scss
@@ -118,7 +118,11 @@
     }
 
     .component-radio-input {
-      margin-bottom: $gu-v-spacing / 2;
+      margin-bottom: $gu-v-spacing;
+
+      &:first-of-type {
+        margin-top: $gu-v-spacing / 2;
+      }
     }
   }
 }

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.scss
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.scss
@@ -111,4 +111,14 @@
     margin-bottom: $gu-v-spacing;
     line-height: 20px;
   }
+
+  .contribution-thank-you-block--reminders {
+    .component-button {
+      margin-top: $gu-v-spacing;
+    }
+
+    .component-radio-input {
+      margin-bottom: $gu-v-spacing / 4;
+    }
+  }
 }

--- a/support-frontend/test/services/RemindMeServiceSpec.scala
+++ b/support-frontend/test/services/RemindMeServiceSpec.scala
@@ -11,6 +11,7 @@ class RemindMeServiceSpec extends AnyFlatSpec with Matchers with MockitoSugar  {
     val remindMeService = new RemindMeService(DEV)
     val reminderEventRequest = ReminderEventRequest(email = "test@theguardian.com", reminderDate = "2020-12-12 10:10:10")
     remindMeService.contructPayload(reminderEventRequest) shouldBe
-      "{\"ReminderCreatedEvent\":{\"email\":\"test@theguardian.com\",\"reminderDate\":\"2020-12-12 10:10:10\"}}"
+      "{\"ReminderCreatedEvent\":{\"email\":\"test@theguardian.com\",\"reminderDate\":\"2020-12-12 10:10:10\"}," +
+        "\"body\":\"{\\\"email\\\":\\\"test@theguardian.com\\\",\\\"reminderDate\\\":\\\"2020-12-12 10:10:10\\\"}\"}"
   }
 }


### PR DESCRIPTION
## Why are you doing this?
In support of our KR on reminders, we are expanding the post-contribution reminder feature.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/2B3RQXRA/1634-update-the-post-contribution-reminder-to-offer-different-frequencies)

## Changes
Frontend: Adding form elements from support-ui, wiring them to update the request we are sending to the backend

Backend: modifying the event being sent to the lambda to be backwards compatible -- to support the two different lambdas, one of which is in code and one of which is in prod ( cc: @JoemG )

## Screenshots
![set up a reminder](https://user-images.githubusercontent.com/3300789/71735279-f1a58880-2e45-11ea-8e11-9d95c64f1acf.png)

