### PR TITLE
Update marketing opt in copy for single contributors (thank you page)

### DIFF
--- a/support-frontend/assets/components/marketingConsent/marketingConsentWithCheckbox.jsx
+++ b/support-frontend/assets/components/marketingConsent/marketingConsentWithCheckbox.jsx
@@ -93,14 +93,15 @@ function MarketingButton(props: ButtonPropTypes) {
   );
 }
 
-const createRegionalTextVariations = (titleFreq: string, msgFreq: string): { titleFreq: string, msgFreq: string } => ({
-  titleFreq,
-  msgFreq,
-});
-
 const copy = {
-  ukRowRecurring: createRegionalTextVariations('a weekly email', 'from the week '),
-  allSinglePlusUsAusRecurring: createRegionalTextVariations('occasional emails', ''),
+  ukRowRecurring: {
+    titleFreq: 'a weekly email',
+    msgFreq: 'from the week ',
+  },
+  allSinglePlusUsAusRecurring: {
+    titleFreq: 'occasional emails',
+    msgFreq: '',
+  },
 };
 
 const getCopyTexts = (countryGroupId: CountryGroupId, contributionType: ContributionType) => {

--- a/support-frontend/assets/components/marketingConsent/marketingConsentWithCheckbox.jsx
+++ b/support-frontend/assets/components/marketingConsent/marketingConsentWithCheckbox.jsx
@@ -93,8 +93,7 @@ function MarketingButton(props: ButtonPropTypes) {
   );
 }
 
-const createTitleText = () => {
-  const { countryGroupId, contributionType } = this.props;
+const createTitleText = (countryGroupId: CountryGroupId, contributionType: ContributionType) => {
   const titleTexts = {
     UsAllPlusRowRecurring: 'a weekly email',
     AuAll: 'an occasional email',
@@ -110,8 +109,6 @@ const createTitleText = () => {
   }
   return titleTexts.UsAllPlusRowRecurring;
 };
-
-const emailFrequency = createTitleText();
 
 const renderMessage = ({ title, message }: {title: string, message: string}) => (
   <div>
@@ -133,6 +130,7 @@ class MarketingConsentWithCheckbox extends Component<PropTypes, StateTypes> {
   }
 
   render() {
+    const emailFrequency = createTitleText(this.props.countryGroupId, this.props.contributionType);
 
     if (this.props.error) {
       return (<GeneralErrorMessage

--- a/support-frontend/assets/components/marketingConsent/marketingConsentWithCheckbox.jsx
+++ b/support-frontend/assets/components/marketingConsent/marketingConsentWithCheckbox.jsx
@@ -93,16 +93,17 @@ function MarketingButton(props: ButtonPropTypes) {
   );
 }
 
-const createRegionalCopy = (titleFreq: string, msgFreq: string): { titleFreq: string, msgFreq: string } => ({
+const createRegionalTextVariations = (titleFreq: string, msgFreq: string): { titleFreq: string, msgFreq: string } => ({
   titleFreq,
   msgFreq,
 });
 
+const copy = {
+  ukRowRecurring: createRegionalTextVariations('a weekly email', 'from the week '),
+  allSinglePlusUsAusRecurring: createRegionalTextVariations('occasional emails', ''),
+};
+
 const getCopyTexts = (countryGroupId: CountryGroupId, contributionType: ContributionType) => {
-  const copy = {
-    ukRowRecurring: createRegionalCopy('a weekly email', 'from the week '),
-    allSinglePlusUsAusRecurring: createRegionalCopy('occasional emails', ''),
-  };
 
   if (contributionType === 'ONE_OFF' || countryGroupId === 'UnitedStates' || countryGroupId === 'AUDCountries') {
     return copy.allSinglePlusUsAusRecurring;

--- a/support-frontend/assets/components/marketingConsent/marketingConsentWithCheckbox.jsx
+++ b/support-frontend/assets/components/marketingConsent/marketingConsentWithCheckbox.jsx
@@ -93,21 +93,21 @@ function MarketingButton(props: ButtonPropTypes) {
   );
 }
 
-const createTitleText = (countryGroupId: CountryGroupId, contributionType: ContributionType) => {
-  const titleTexts = {
-    UsAllPlusRowRecurring: 'a weekly email',
-    AuAll: 'an occasional email',
-    UkRowSingle: 'occasional emails',
+const createRegionalCopy = (titleFreq: string, msgFreq: string): { titleFreq: string, msgFreq: string } => ({
+  titleFreq,
+  msgFreq,
+});
+
+const getCopyTexts = (countryGroupId: CountryGroupId, contributionType: ContributionType) => {
+  const copy = {
+    ukRowRecurring: createRegionalCopy('a weekly email', 'from the week '),
+    allSinglePlusUsAusRecurring: createRegionalCopy('occasional emails', ''),
   };
 
-  if (countryGroupId === 'UnitedStates') {
-    return titleTexts.UsAllPlusRowRecurring;
-  } else if (countryGroupId === 'AUDCountries') {
-    return titleTexts.AuAll;
-  } else if (contributionType === 'ONE_OFF') {
-    return titleTexts.UkRowSingle;
+  if (contributionType === 'ONE_OFF' || countryGroupId === 'UnitedStates' || countryGroupId === 'AUDCountries') {
+    return copy.allSinglePlusUsAusRecurring;
   }
-  return titleTexts.UsAllPlusRowRecurring;
+  return copy.ukRowRecurring;
 };
 
 const renderMessage = ({ title, message }: {title: string, message: string}) => (
@@ -130,7 +130,7 @@ class MarketingConsentWithCheckbox extends Component<PropTypes, StateTypes> {
   }
 
   render() {
-    const emailFrequency = createTitleText(this.props.countryGroupId, this.props.contributionType);
+    const frequencyCopy: { titleFreq: string, msgFreq: string } = getCopyTexts(this.props.countryGroupId, this.props.contributionType);
 
     if (this.props.error) {
       return (<GeneralErrorMessage
@@ -144,8 +144,8 @@ class MarketingConsentWithCheckbox extends Component<PropTypes, StateTypes> {
       return (
         <section className={classNameWithModifiers('component-marketing-consent', ['newsletter', 'with-checkbox'])}>
           {this.props.renderMessage({
-            title: `Would you like to receive ${emailFrequency} from inside The Guardian?`,
-            message: 'Our membership editor will discuss the most important news stories from the week and suggest compelling articles to read. Opt in below to receive this and more information on ways to support The Guardian.',
+            title: `Would you like to receive ${frequencyCopy.titleFreq} from inside The Guardian?`,
+            message: `Our membership editor will discuss the most important news stories ${frequencyCopy.msgFreq}and suggest compelling articles to read. Opt in below to receive this and more information on ways to support The Guardian.`,
           })}
 
           <CheckboxInput

--- a/support-frontend/assets/components/marketingConsent/marketingConsentWithCheckbox.jsx
+++ b/support-frontend/assets/components/marketingConsent/marketingConsentWithCheckbox.jsx
@@ -93,6 +93,26 @@ function MarketingButton(props: ButtonPropTypes) {
   );
 }
 
+const createTitleText = () => {
+  const { countryGroupId, contributionType } = this.props;
+  const titleTexts = {
+    UsAllPlusRowRecurring: 'a weekly email',
+    AuAll: 'an occasional email',
+    UkRowSingle: 'occasional emails',
+  };
+
+  if (countryGroupId === 'UnitedStates') {
+    return titleTexts.UsAllPlusRowRecurring;
+  } else if (countryGroupId === 'AUDCountries') {
+    return titleTexts.AuAll;
+  } else if (contributionType === 'ONE_OFF') {
+    return titleTexts.UkRowSingle;
+  }
+  return titleTexts.UsAllPlusRowRecurring;
+};
+
+const emailFrequency = createTitleText();
+
 const renderMessage = ({ title, message }: {title: string, message: string}) => (
   <div>
     <h3 className="contribution-thank-you-block__title">{title}</h3>
@@ -113,25 +133,6 @@ class MarketingConsentWithCheckbox extends Component<PropTypes, StateTypes> {
   }
 
   render() {
-    const createTitleText = () => {
-      const { countryGroupId, contributionType } = this.props;
-      const titleTexts = {
-        UsAllPlusRowRecurring: 'a weekly email',
-        AuAll: 'an occasional email',
-        UkRowSingle: 'occasional emails',
-      };
-
-      if (countryGroupId === 'UnitedStates') {
-        return titleTexts.UsAllPlusRowRecurring;
-      } else if (countryGroupId === 'AUDCountries') {
-        return titleTexts.AuAll;
-      } else if (contributionType === 'ONE_OFF') {
-        return titleTexts.UkRowSingle;
-      }
-      return titleTexts.UsAllPlusRowRecurring;
-    };
-
-    const emailFrequency = createTitleText();
 
     if (this.props.error) {
       return (<GeneralErrorMessage

--- a/support-frontend/assets/components/marketingConsent/marketingConsentWithCheckbox.jsx
+++ b/support-frontend/assets/components/marketingConsent/marketingConsentWithCheckbox.jsx
@@ -15,7 +15,7 @@ import NonInteractiveButton from 'components/button/nonInteractiveButton';
 import { CheckboxInput } from 'components/forms/customFields/checkbox';
 import 'components/marketingConsent/marketingConsent.scss';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-
+import type { ContributionType } from 'helpers/contributions';
 // ----- Types ----- //
 
 type SharedPropTypes = {|
@@ -36,6 +36,7 @@ type PropTypes = {|
   error: boolean,
   renderMessage: ({title: string, message: string}) => Node,
   countryGroupId: CountryGroupId,
+  contributionType: ContributionType,
 |};
 
 type StateTypes ={|
@@ -112,7 +113,25 @@ class MarketingConsentWithCheckbox extends Component<PropTypes, StateTypes> {
   }
 
   render() {
-    const emailFrequency = this.props.countryGroupId === 'AUDCountries' ? 'an occasional' : 'a weekly';
+    const createTitleText = () => {
+      const { countryGroupId, contributionType } = this.props;
+      const titleTexts = {
+        UsAllPlusRowRecurring: 'a weekly email',
+        AuAll: 'an occasional email',
+        UkRowSingle: 'occasional emails',
+      };
+
+      if (countryGroupId === 'UnitedStates') {
+        return titleTexts.UsAllPlusRowRecurring;
+      } else if (countryGroupId === 'AUDCountries') {
+        return titleTexts.AuAll;
+      } else if (contributionType === 'ONE_OFF') {
+        return titleTexts.UkRowSingle;
+      }
+      return titleTexts.UsAllPlusRowRecurring;
+    };
+
+    const emailFrequency = createTitleText();
 
     if (this.props.error) {
       return (<GeneralErrorMessage
@@ -126,7 +145,7 @@ class MarketingConsentWithCheckbox extends Component<PropTypes, StateTypes> {
       return (
         <section className={classNameWithModifiers('component-marketing-consent', ['newsletter', 'with-checkbox'])}>
           {this.props.renderMessage({
-            title: `Would you like to receive ${emailFrequency} email from inside The Guardian?`,
+            title: `Would you like to receive ${emailFrequency} from inside The Guardian?`,
             message: 'Our membership editor will discuss the most important news stories from the week and suggest compelling articles to read. Opt in below to receive this and more information on ways to support The Guardian.',
           })}
 

--- a/support-frontend/assets/components/marketingConsent/marketingConsentWithCheckbox.jsx
+++ b/support-frontend/assets/components/marketingConsent/marketingConsentWithCheckbox.jsx
@@ -130,7 +130,8 @@ class MarketingConsentWithCheckbox extends Component<PropTypes, StateTypes> {
   }
 
   render() {
-    const frequencyCopy: { titleFreq: string, msgFreq: string } = getCopyTexts(this.props.countryGroupId, this.props.contributionType);
+    const frequencyCopy: { titleFreq: string, msgFreq: string } =
+    getCopyTexts(this.props.countryGroupId, this.props.contributionType);
 
     if (this.props.error) {
       return (<GeneralErrorMessage

--- a/support-frontend/assets/pages/contributions-landing/components/AmazonPay/AmazonPayLoginButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/AmazonPay/AmazonPayLoginButton.jsx
@@ -7,7 +7,7 @@ import { type Action, setAmazonPayHasAccessToken } from 'pages/contributions-lan
 import Button from 'components/button/button';
 import { logException } from 'helpers/logger';
 import AnimatedDots from 'components/spinners/animatedDots';
-import {trackComponentClick, trackComponentLoad} from 'helpers/tracking/behaviour';
+import { trackComponentClick, trackComponentLoad } from 'helpers/tracking/behaviour';
 
 type PropTypes = {|
   amazonPayData: AmazonPayData,

--- a/support-frontend/assets/pages/contributions-landing/components/MarketingConsentContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/MarketingConsentContainer.jsx
@@ -17,6 +17,7 @@ const mapStateToProps = state => ({
   error: state.page.marketingConsent.error,
   requestPending: state.page.marketingConsent.requestPending,
   countryGroupId: state.common.internationalisation.countryGroupId,
+  contributionType: state.page.form.contributionType,
 });
 
 function mapDispatchToProps(dispatch: Dispatch<Action>) {


### PR DESCRIPTION
## Why are you doing this?
We cannot show the "receive a weekly newsletter" copy alongside the opt in on the thank you page to single contributors, since we only send this to recurring contributors. 

This PR updates the title text for all single contributors and recurring US/Aus contributors "... receive occasional emails...", plus removal of 'from the week' from the message body.

The remaining recurring contributors continue to see the existing "... receive a weekly email..." copy.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/wYeQmMhY)

## Changes

* Change copy for all single contributors and US/Aus returning contributors.

## Screenshots

### Single (all regions) and US/Aus recurring
<img width="483" alt="image" src="https://user-images.githubusercontent.com/15648334/72001384-462d7700-323d-11ea-924e-d9e109fa28ff.png">

### Recurring (all regions except US/Aus)
<img width="484" alt="image" src="https://user-images.githubusercontent.com/15648334/72001523-90165d00-323d-11ea-8e41-e6158c3b278e.png">

