### PR TITLE
Regex to detect Safari and prevent it from using Axe to render locally

### DIFF
--- a/support-frontend/assets/helpers/render.js
+++ b/support-frontend/assets/helpers/render.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { logException } from 'helpers/logger';
+import { isSafari } from 'helpers/userAgent';
 
 // Without this the build-time pre-rendering breaks, because fetch is undefined when running with node
 const safeFetch = (url: string, opts) => {
@@ -50,7 +51,7 @@ const renderPage = (content: Object, id: string, callBack?: () => void) => {
   if (element) {
     delete element.dataset.notHydrated;
     try {
-      if (process.env.NODE_ENV === 'DEV') {
+      if (process.env.NODE_ENV === 'DEV' && !isSafari) {
         import('react-axe').then((axe) => {
           console.log('Loading react-axe for accessibility analysis');
           axe.default(React, ReactDOM, 1000);

--- a/support-frontend/assets/helpers/userAgent.js
+++ b/support-frontend/assets/helpers/userAgent.js
@@ -1,0 +1,18 @@
+// @flow
+
+// ----- Types ----- //
+
+// ----- Setup ----- //
+
+// ----- Functions ----- //
+const userAgent = window.navigator.userAgent || '';
+
+// scans user agent for presence of 'safari' and absence of 'chrome' or 'android'
+// (chrome and android browsers also include 'safari' in the UA string)
+const isSafari = /^((?!chrome|android).)*safari/i.test(userAgent);
+
+// ----- Exports ----- //
+
+export {
+  isSafari,
+};


### PR DESCRIPTION
## Why are you doing this?
Axe (dev dependency library that warns about accessibility issues) was preventing us from demoing and testing the support site locally. I've added a new helper file to detect the user agent (specifically to detect if it is safari) and re-route the render accordingly.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com)