### PR TITLE
correcting typo in date

### DIFF
--- a/support-frontend/assets/components/contributionsReminder/contributionsReminder.jsx
+++ b/support-frontend/assets/components/contributionsReminder/contributionsReminder.jsx
@@ -41,7 +41,7 @@ const reminderDates: Array<ReminderDate> = [
   },
   {
     dateName: 'June 2020',
-    timeStamp: '2020-03-01 00:00:00',
+    timeStamp: '2020-06-01 00:00:00',
   },
   {
     dateName: 'December 2020',


### PR DESCRIPTION
## Why are you doing this?

The June date had a typo making it a March date.

The 1st of March date will need to be changed in the DB to 1st June after this has been deployed

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/trKq1BFj/1780-update-the-timestamp-of-the-june-reminder)

## Changes

* Change 1
* Change 2

## Screenshots

