### PR TITLE
increase contrast on privacy terms

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.scss
@@ -460,10 +460,10 @@ button {
   margin: 10px 0 10px;
   font-size: 12px;
   line-height: 16px;
-  color: gu-colour(neutral-60);
+  color: gu-colour(neutral-20);
 
   a {
-    color: gu-colour(neutral-46);
+    color: gu-colour(neutral-7);
   }
 
   .component-terms-privacy__change {


### PR DESCRIPTION
## Why are you doing this?
The privacy terms do not pass a colour contrast test, which causes visibility issues for many users. I have not increased the text size for now, although this was recommended, so we might want to consider doing this too.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/cksSem2d)

## Changes

* Use darker colour for text and links

## Screenshots

### Before:
<img width="481" alt="image" src="https://user-images.githubusercontent.com/15648334/72090479-0da5a000-3306-11ea-8fe2-fd0b3c127ccf.png">
<img width="437" alt="image" src="https://user-images.githubusercontent.com/15648334/72090548-2f068c00-3306-11ea-9c33-969f213cdda1.png">


### After: 
<img width="482" alt="image" src="https://user-images.githubusercontent.com/15648334/72090355-ce774f00-3305-11ea-860f-352e4ecaa88b.png">
<img width="387" alt="image" src="https://user-images.githubusercontent.com/15648334/72090592-4180c580-3306-11ea-9042-ef45085442f5.png">
