### PR TITLE
Fix deployment of KibanaProxy

### DIFF
--- a/support-logs/cfn.yaml
+++ b/support-logs/cfn.yaml
@@ -2,10 +2,9 @@ AWSTemplateFormatVersion: '2010-09-09'
 Description: Proxy instance for kibana
 
 Parameters:
-  NginxAMI:
-    Description: AMI ID (may be replaced by RiffRaff for latest baked AMI)
+  AMI:
+    Description: AMI ID (will be set by RiffRaff to the latest baked AMI)
     Type: String
-    Default: ami-0a15b21aee4d9a317
   VpcId:
     Description: "ID of the VPC onto which to launch the instance eg. vpc-1234abcd"
     Type: AWS::EC2::VPC::Id
@@ -73,7 +72,7 @@ Resources:
   KibanaProxyInstance:
     Type: AWS::EC2::Instance
     Properties:
-        ImageId: !Ref NginxAMI
+        ImageId: !Ref AMI
         InstanceType: t2.micro
         IamInstanceProfile: !Ref KibanaProxyInstanceProfile
         BlockDeviceMappings:

--- a/support-logs/cfn.yaml
+++ b/support-logs/cfn.yaml
@@ -101,6 +101,8 @@ Resources:
                 ssl_ciphers HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;
                 ssl_prefer_server_ciphers on;
 
+                access_log  /dev/null;
+                error_log   /dev/null   crit;
 
                 location ^~ /_plugin/kibana {
                     # Forward requests to Kibana

--- a/support-logs/riff-raff.yaml
+++ b/support-logs/riff-raff.yaml
@@ -6,9 +6,7 @@ deployments:
     type: cloud-formation
     parameters:
       templatePath: cfn.yaml
-      amiParametersToTags:
-        NginxAMI:
-          BuiltBy: amigo
-          AmigoStage: PROD
-          Recipe: ubuntu-xenial-with-nginx
+      amiTags:
+        AmigoStage: PROD
+        Recipe: ubuntu-xenial-with-nginx
       amiEncrypted: true

--- a/support-logs/riff-raff.yaml
+++ b/support-logs/riff-raff.yaml
@@ -9,4 +9,3 @@ deployments:
       amiTags:
         AmigoStage: PROD
         Recipe: ubuntu-xenial-with-nginx
-      amiEncrypted: true


### PR DESCRIPTION
## Why are you doing this?

I've been investigating why KibanaProxy was running an out of date ami, and realised the riff raff yaml was misconfigured. It had `amiEncrypted` set to true, which is not the case for the `ubuntu-xenial-with-nginx`

In the process of debugging this I actually ended up simplifying the set up slightly, so I kept those changes as well.

I should also add that I added a scheduled deployment to the project so the ami doesn't get stale. [I've set it to weekly](https://riffraff.gutools.co.uk/deployment/schedule/fd7ed3b5-d93a-4c95-95ca-8f9057d0a140/edit)