### PR TITLE
401 retry

### DIFF
--- a/support-workers/cloud-formation/src/templates/retries.yaml
+++ b/support-workers/cloud-formation/src/templates/retries.yaml
@@ -5,8 +5,8 @@ Retry:
 - ErrorEquals:
   - com.gu.support.workers.exceptions.RetryLimited
   IntervalSeconds: 1
-  MaxAttempts: 3
-  BackoffRate: 5 #Retry after 1, 5 and 25 seconds
+  MaxAttempts: 5
+  BackoffRate: 10 #Retry after 1 sec, 10 sec, 100 sec, 16 mins and 2 hours 46 mins
 - ErrorEquals:
   - com.gu.support.workers.exceptions.RetryUnlimited
   IntervalSeconds: 1

--- a/support-workers/cloud-formation/src/templates/retries.yaml
+++ b/support-workers/cloud-formation/src/templates/retries.yaml
@@ -6,7 +6,7 @@ Retry:
   - com.gu.support.workers.exceptions.RetryLimited
   IntervalSeconds: 1
   MaxAttempts: 3
-  BackoffRate: 2
+  BackoffRate: 5 #Retry after 1, 5 and 25 seconds
 - ErrorEquals:
   - com.gu.support.workers.exceptions.RetryUnlimited
   IntervalSeconds: 1

--- a/support-workers/src/test/scala/com/gu/support/workers/errors/ErrorHandlerSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/errors/ErrorHandlerSpec.scala
@@ -52,6 +52,12 @@ class ErrorHandlerSpec extends AnyFlatSpec with Matchers {
     }
   }
 
+  "ErrorHandler" should "throw an RetryNone when it handles a 403 unauthorized error" in {
+    an[RetryNone] should be thrownBy {
+      ErrorHandler.handleException(WebServiceClientError(CodeBody("403", "Unauthorized")))
+    }
+  }
+
   "asRetryException method" should "allow us to work out retries" in {
     //General
     new SocketTimeoutException().asRetryException shouldBe a[RetryUnlimited]

--- a/support-workers/src/test/scala/com/gu/support/workers/errors/ErrorHandlerSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/errors/ErrorHandlerSpec.scala
@@ -4,6 +4,7 @@ import java.net.{SocketException, SocketTimeoutException}
 
 import com.amazonaws.services.kms.model._
 import com.gu.paypal.PayPalError
+import com.gu.rest.{CodeBody, WebServiceClientError}
 import com.gu.salesforce.Salesforce.SalesforceErrorResponse
 import com.gu.salesforce.Salesforce.SalesforceErrorResponse._
 import com.gu.stripe.StripeError
@@ -42,6 +43,12 @@ class ErrorHandlerSpec extends AnyFlatSpec with Matchers {
   "ErrorHandler" should "throw an RetryNone when it handles any other Salesforce error" in {
     an[RetryNone] should be thrownBy {
       ErrorHandler.handleException(new SalesforceErrorResponse("test", "test"))
+    }
+  }
+
+  "ErrorHandler" should "throw an RetryLimited when it handles a 401 authentication error" in {
+    an[RetryLimited] should be thrownBy {
+      ErrorHandler.handleException(WebServiceClientError(CodeBody("401", "Authentication error")))
     }
   }
 


### PR DESCRIPTION
## Why are you doing this?
We have been getting regular 401 authentication errors from Zuora which have been causing step function executions to fail. We think that it is likely that these are temporary glitches and that a retry would succeed so this PR changes the error mapping between http errors and retry types to make a 401 response map to `RetryLimited`.

I have also increased the time between retry attempts for `RetryLimited` errors to give the systems which are experiencing problems a bit longer to recover.

[**Trello Card**](https://trello.com/c/XtArUSWE/2795-alter-retry-behaviour-of-zuora-authentication-errors)

