### PR TITLE
handle Salesforce maintenance errors with RetryUnlimited behaviour

### DIFF
--- a/support-workers/src/test/scala/com/gu/support/workers/errors/ErrorHandlerSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/errors/ErrorHandlerSpec.scala
@@ -53,6 +53,7 @@ class ErrorHandlerSpec extends AnyFlatSpec with Matchers {
     //Salesforce
     new SalesforceErrorResponse("test", expiredAuthenticationCode).asRetryException shouldBe a[RetryUnlimited]
     new SalesforceErrorResponse("test", rateLimitExceeded).asRetryException shouldBe a[RetryUnlimited]
+    new SalesforceErrorResponse("test", readOnlyMaintenance).asRetryException shouldBe a[RetryUnlimited]
     new SalesforceErrorResponse("", "").asRetryException shouldBe a[RetryNone]
 
     //Stripe


### PR DESCRIPTION
In light of an upcoming Salesforce maintenance window (where SF will go into ReadOnly mode), we anticipate errors when trying to create contact (during `support-workers` step function) and hence we want to treat the error code **`INSERT_UPDATE_DELETE_NOT_ALLOWED_DURING_MAINTENANCE`** as a **`RetryUnlimited`** scenario (i.e. keep retrying with existing back-off strategy until the request succeeds - at which point customer will get success confirmation email).

_Note `RetryUnlimited` will timeout after 24 hours - at which point customer will get failure email and we will be alerted (via alarm) - however we don't expect this to happen for this upcoming maintenance window._

[**Trello Card**](https://trello.com/c/ivg3G0JE)