### PR TITLE
Retry all salesforce errors temporarily

### DIFF
--- a/support-models/src/main/scala/com/gu/salesforce/Salesforce.scala
+++ b/support-models/src/main/scala/com/gu/salesforce/Salesforce.scala
@@ -187,10 +187,12 @@ object Salesforce {
       SalesforceErrorResponse.readOnlyMaintenance
     )
 
-    def asRetryException: RetryException = if (errorsToRetryUnlimited.contains(errorCode))
-      new RetryUnlimited(message, cause = this)
-    else
-      new RetryNone(message, cause = this)
+    // Temporarily retry all errors during a maintenance window
+    def asRetryException: RetryException =
+      // if (errorsToRetryUnlimited.contains(errorCode))
+        new RetryUnlimited(message, cause = this)
+      // else
+      //  new RetryNone(message, cause = this)
   }
 
   object SalesforceAuthenticationErrorResponse {

--- a/support-workers/src/test/scala/com/gu/support/workers/errors/ErrorHandlerSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/errors/ErrorHandlerSpec.scala
@@ -40,11 +40,12 @@ class ErrorHandlerSpec extends AnyFlatSpec with Matchers {
     }
   }
 
-  "ErrorHandler" should "throw an RetryNone when it handles any other Salesforce error" in {
-    an[RetryNone] should be thrownBy {
-      ErrorHandler.handleException(new SalesforceErrorResponse("test", "test"))
-    }
-  }
+  // Temporary
+//  "ErrorHandler" should "throw an RetryNone when it handles any other Salesforce error" in {
+//    an[RetryNone] should be thrownBy {
+//      ErrorHandler.handleException(new SalesforceErrorResponse("test", "test"))
+//    }
+//  }
 
   "ErrorHandler" should "throw an RetryLimited when it handles a 401 authentication error" in {
     an[RetryLimited] should be thrownBy {
@@ -67,7 +68,7 @@ class ErrorHandlerSpec extends AnyFlatSpec with Matchers {
     new SalesforceErrorResponse("test", expiredAuthenticationCode).asRetryException shouldBe a[RetryUnlimited]
     new SalesforceErrorResponse("test", rateLimitExceeded).asRetryException shouldBe a[RetryUnlimited]
     new SalesforceErrorResponse("test", readOnlyMaintenance).asRetryException shouldBe a[RetryUnlimited]
-    new SalesforceErrorResponse("", "").asRetryException shouldBe a[RetryNone]
+    new SalesforceErrorResponse("", "").asRetryException shouldBe a[RetryUnlimited] // Temporary
 
     //Stripe
     new StripeError("card_error", "").asRetryException shouldBe a[RetryNone]


### PR DESCRIPTION
## Why are you doing this?
There is a salesforce maintenance window over the weekend where we are not confident of the specific error that will be thrown.  We're therefore temporarily retrying all salesforce errors.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com)

## Changes

* Change 1
* Change 2

## Screenshots

