### PR TITLE
Additional analytics to show which date is preselected for the reminder

### DIFF
--- a/support-frontend/assets/components/contributionsReminder/contributionsReminder.jsx
+++ b/support-frontend/assets/components/contributionsReminder/contributionsReminder.jsx
@@ -28,6 +28,7 @@ type StateTypes = {
   buttonState: ButtonState;
   selectedDate: string | null;
   selectedDateAsWord: string | null,
+  preselectedDateAsWord: string | null,
 }
 
 const mapStateToProps = state => ({
@@ -62,12 +63,14 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
     buttonState: 'initial',
     selectedDate: null,
     selectedDateAsWord: null,
+    preselectedDateAsWord: null,
   }
 
   componentDidMount = () => {
     this.setState({
       selectedDate: reminderDates[randomIndex].timeStamp,
       selectedDateAsWord: trimAndDowncase(reminderDates[randomIndex].dateName),
+      preselectedDateAsWord: trimAndDowncase(reminderDates[randomIndex].dateName),
     });
   }
 
@@ -117,6 +120,7 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
 
   render() {
     const { email } = this.props;
+    const { selectedDateAsWord, preselectedDateAsWord, } = this.state
 
     if (email) {
       const isClicked = this.state.buttonState !== 'initial';
@@ -155,6 +159,10 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
             trackingEvent={
               () => {
                 trackComponentLoad('reminder-test-link-loaded');
+
+                if (this.state.preselectedDateAsWord){
+                  trackComponentLoad(`reminder-test-preselected-date${this.state.preselectedDateAsWord}`);
+                }
               }
             }
             onClick={
@@ -162,7 +170,10 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
                 this.requestIsPending();
 
                 trackComponentClick('reminder-test-link-clicked');
-                if (this.state.selectedDateAsWord) { trackComponentClick(`reminder-test-date-${this.state.selectedDateAsWord}`); }
+
+                if (this.state.selectedDateAsWord) {
+                  trackComponentClick(`reminder-test-date-${this.state.selectedDateAsWord}`);
+                }
 
                 fetch(createReminderEndpoint, {
                   method: 'POST',

--- a/support-frontend/assets/components/contributionsReminder/contributionsReminder.jsx
+++ b/support-frontend/assets/components/contributionsReminder/contributionsReminder.jsx
@@ -120,7 +120,6 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
 
   render() {
     const { email } = this.props;
-    const { selectedDateAsWord, preselectedDateAsWord, } = this.state
 
     if (email) {
       const isClicked = this.state.buttonState !== 'initial';
@@ -160,7 +159,7 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
               () => {
                 trackComponentLoad('reminder-test-link-loaded');
 
-                if (this.state.preselectedDateAsWord){
+                if (this.state.preselectedDateAsWord) {
                   trackComponentLoad(`reminder-test-preselected-date${this.state.preselectedDateAsWord}`);
                 }
               }

--- a/support-frontend/assets/components/contributionsReminder/contributionsReminder.jsx
+++ b/support-frontend/assets/components/contributionsReminder/contributionsReminder.jsx
@@ -67,10 +67,13 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
   }
 
   componentDidMount = () => {
+    const randomDate = reminderDates[randomIndex];
+    const randomDateAsWord = trimAndDowncase(randomDate.dateName);
+
     this.setState({
-      selectedDate: reminderDates[randomIndex].timeStamp,
-      selectedDateAsWord: trimAndDowncase(reminderDates[randomIndex].dateName),
-      preselectedDateAsWord: trimAndDowncase(reminderDates[randomIndex].dateName),
+      selectedDate: randomDate.timeStamp,
+      selectedDateAsWord: randomDateAsWord,
+      preselectedDateAsWord: randomDateAsWord,
     });
   }
 
@@ -158,10 +161,6 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
             trackingEvent={
               () => {
                 trackComponentLoad('reminder-test-link-loaded');
-
-                if (this.state.preselectedDateAsWord) {
-                  trackComponentLoad(`reminder-test-preselected-date${this.state.preselectedDateAsWord}`);
-                }
               }
             }
             onClick={
@@ -169,6 +168,10 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
                 this.requestIsPending();
 
                 trackComponentClick('reminder-test-link-clicked');
+
+                if (this.state.preselectedDateAsWord) {
+                  trackComponentClick(`reminder-test-preselected-date-${this.state.preselectedDateAsWord}`);
+                }
 
                 if (this.state.selectedDateAsWord) {
                   trackComponentClick(`reminder-test-date-${this.state.selectedDateAsWord}`);


### PR DESCRIPTION
## Why are you doing this?
Product wants to know what event is preselected as well as which is eventually selected for the post-contribution reminder

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/kMukIefU/1802-analytics-for)

