### PR TITLE
Add a switch for base 64 Encoding

### DIFF
--- a/support-models/src/main/scala/com/gu/support/workers/JsonWrapper.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/JsonWrapper.scala
@@ -1,10 +1,5 @@
 package com.gu.support.workers
 
-/**
- * TODO: Remove this
- * AWS Step Functions expect to be passed valid Json, as we want to encrypt the whole of the
- * state, we need to wrap it in a Json 'wrapper' object as a Base64 encoded String
- */
 case class JsonWrapper(state: String, error: Option[ExecutionError], requestInfo: RequestInfo)
 
 import com.gu.support.encoding.Codec

--- a/support-models/src/main/scala/com/gu/support/workers/RequestInfo.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/RequestInfo.scala
@@ -1,6 +1,6 @@
 package com.gu.support.workers
 
-case class RequestInfo(testUser: Boolean, failed: Boolean, messages: List[String], accountExists: Boolean){
+case class RequestInfo(testUser: Boolean, failed: Boolean, messages: List[String], accountExists: Boolean, base64Encoded: Option[Boolean]){
   def appendMessage(message: String): RequestInfo = copy(messages = messages :+ message)
 }
 

--- a/support-models/src/main/scala/com/gu/support/workers/states/CreateZuoraSubscriptionState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/CreateZuoraSubscriptionState.scala
@@ -16,7 +16,6 @@ case class CreateZuoraSubscriptionState(
   paymentMethod: PaymentMethod,
   firstDeliveryDate: Option[LocalDate],
   promoCode: Option[PromoCode],
-  salesForceContact: SalesforceContactRecord, //TODO: Remove this it is redundant now we have gifting
   salesforceContacts: SalesforceContactRecords,
   acquisitionData: Option[AcquisitionData]
 ) extends StepFunctionUserState

--- a/support-workers/src/main/scala/com/gu/support/workers/encoding/Encoding.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/encoding/Encoding.scala
@@ -6,7 +6,7 @@ import java.util.Base64
 import com.gu.support.encoding.CustomCodecs._
 import com.gu.support.workers.encoding.Wrapper._
 import com.gu.support.workers.lambdas.HandlerResult
-import com.gu.support.workers.{ExecutionError, RequestInfo}
+import com.gu.support.workers.{ExecutionError, JsonWrapper, RequestInfo}
 import io.circe.generic.auto._
 
 import scala.util.Try
@@ -20,10 +20,15 @@ object Encoding {
   def in[T](is: InputStream)(implicit decoder: Decoder[T]): Try[(T, Option[ExecutionError], RequestInfo)] =
     for {
       wrapper <- unWrap(is)
-      state <- Try(Base64.getDecoder.decode(wrapper.state))
-      decrypted <- Try(new String(state, utf8))
-      result <- decode[T](decrypted).toTry
+      state <- Try(base64decode(wrapper))
+      result <- decode[T](state).toTry
     } yield (result, wrapper.error, wrapper.requestInfo)
+
+  private def base64decode(wrapper: JsonWrapper) =
+    if (wrapper.requestInfo.base64Encoded.getOrElse(true))
+      new String(Base64.getDecoder.decode(wrapper.state), utf8)
+    else
+      wrapper.state
 
   def out[T](handlerResult: HandlerResult[T], os: OutputStream)(implicit encoder: Encoder[T]): Try[Unit] = {
     val t = Try(os.write(wrap(handlerResult).asJson.noSpaces.getBytes()))

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateSalesforceContact.scala
@@ -44,7 +44,6 @@ class CreateSalesforceContact extends ServicesHandler[CreateSalesforceContactSta
       state.paymentMethod,
       state.firstDeliveryDate,
       state.promoCode,
-      response.buyer,
       response,
       state.acquisitionData
     )

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/PreparePaymentMethodForReuse.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/PreparePaymentMethodForReuse.scala
@@ -45,7 +45,6 @@ class PreparePaymentMethodForReuse(servicesProvider: ServiceProvider = ServicePr
           paymentMethod =  paymentMethod,
           firstDeliveryDate = None,
           promoCode = None,
-          salesForceContact = sfContact,
           salesforceContacts = SalesforceContactRecords(sfContact, None),
           acquisitionData = state.acquisitionData
         ),

--- a/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
@@ -16,7 +16,9 @@ import org.joda.time.{DateTimeZone, LocalDate}
 object JsonFixtures {
 
   def wrapFixture(string: String): ByteArrayInputStream =
-    Wrapper.wrapString(string, RequestInfo(testUser = false, failed = false, Nil, accountExists = false)).asJson.noSpaces.asInputStream
+    Wrapper
+      .wrapString(string, RequestInfo(testUser = false, failed = false, Nil, accountExists = false, base64Encoded = Some(false)))
+      .asJson.noSpaces.asInputStream
 
   def userJson(id: String = idId): String =
     s"""


### PR DESCRIPTION
## Why are you doing this?
As a follow up to #2335 we now want to remove the base 64 encoding from the state machine json as it is no longer needed.

This PR introduces a new flag `base64Encoded` which is hard coded to false but will default to true if it is missing from the payload. This is to cope with mismatches between support-workers and support-frontend during deployment and can be removed once the two systems are in sync.

This PR doesn't quite get us to where we want to be because the json document we end up with still has the `state` field as a json string rather than a json object but that is going to be a lot harder to migrate to so this is the first step.

[**Trello Card**](https://trello.com/c/ZPylvrLf/2791-remove-encryption-from-support-workers)


