### PR TITLE
Updating country sent to support-workers 

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -63,7 +63,7 @@ import GeneralErrorMessage
   from 'components/generalErrorMessage/generalErrorMessage';
 import { getAvailablePaymentRequestButtonPaymentMethod } from 'helpers/checkouts';
 import type { StripePaymentRequestButtonScaTestVariants } from 'helpers/abTests/abtestDefinitions';
-import { fromString as countryFromString} from "../../../../helpers/internationalisation/country";
+import { fromString as countryFromString } from '../../../../helpers/internationalisation/country';
 
 // ----- Types -----//
 
@@ -198,19 +198,21 @@ function updatePayerCountry(
 ): boolean {
 
 
-  console.log("updating payer country",  countryFromCard,
+  console.log(
+    'updating payer country', countryFromCard,
     countryFromForm,
-    setCountry,);
-  if (!!countryFromCard){
-    console.log("setting country to iso")
-    const isoCountry= countryFromString(countryFromCard);
-    if (!!isoCountry) {
-      console.log("setting country")
+    setCountry,
+  );
+  if (countryFromCard) {
+    console.log('setting country to iso');
+    const isoCountry = countryFromString(countryFromCard);
+    if (isoCountry) {
+      console.log('setting country');
       setCountry(isoCountry);
       return true;
-    } else {
-      return false;
     }
+    return false;
+
   } else if (countryFromForm) {
     return true;
   }
@@ -291,11 +293,11 @@ function onPayment(
   // We need to do this so that we can offer marketing permissions on the thank you page
   updatePayerEmail(paymentRequestData, props.updateEmail);
 
-  console.log("ON PAYMENT", stateOrProvinceFromCard);
-  console.log("ON PAYMENT", countryFromCard);
-  console.log("ON PAYMENT", props.stateOrProvince);
-  console.log("ON PAYMENT", props.updateStateOrProvince);
-  console.log("ON PAYMENT", props.countryGroupId);
+  console.log('ON PAYMENT', stateOrProvinceFromCard);
+  console.log('ON PAYMENT', countryFromCard);
+  console.log('ON PAYMENT', props.stateOrProvince);
+  console.log('ON PAYMENT', props.updateStateOrProvince);
+  console.log('ON PAYMENT', props.countryGroupId);
 
   const stateOrProvinceUpdateOk = props.countryGroupId === UnitedStates || props.countryGroupId === Canada ?
     updatePayerStateOrProvince(stateOrProvinceFromCard, props.stateOrProvince, props.updateStateOrProvince) : true;

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -127,7 +127,7 @@ const mapDispatchToProps = (dispatch: Function) => ({
   updateFirstName: (firstName: string) => dispatch(updateFirstName(firstName)),
   updateLastName: (lastName: string) => dispatch(updateLastName(lastName)),
   updateStateOrProvince: (state: UsState | CaState | null) => dispatch(updateState(state)),
-  updateCountry: (billingCountry: IsoCountry) => dispatch(updateBillingCountry(billingCountry)),
+  updateBillingCountry: (billingCountry: IsoCountry) => dispatch(updateBillingCountry(billingCountry)),
   setStripePaymentRequestButtonClicked: (stripeAccount: StripeAccount) =>
     dispatch(setStripePaymentRequestButtonClicked(stripeAccount)),
   setAssociatedPaymentMethod: () => dispatch(updatePaymentMethod(Stripe)),

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -268,7 +268,7 @@ function onPayment(
   const stateOrProvinceUpdateOk = isUsOrCanadian ?
     updatePayerStateOrProvince(stateOrProvinceFromCard, props.stateOrProvince, props.updateStateOrProvince) : true;
 
-  //We need to update the country so it matches the one on the card
+  // We need to update the country so it matches the state taken from the card
   if (isUsOrCanadian && countryFromCard) {
     const isoCountry = countryFromString(countryFromCard);
     if (isoCountry) {

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -52,7 +52,7 @@ import {
   updateLastName,
   updatePaymentMethod,
   updateState,
-  updateCountry,
+  updateBillingCountry,
 } from 'pages/contributions-landing/contributionsLandingActions';
 import type { PaymentMethod } from 'helpers/paymentMethods';
 import { Stripe } from 'helpers/paymentMethods';
@@ -89,7 +89,7 @@ type PropTypes = {|
   updateFirstName: string => void,
   updateLastName: string => void,
   updateStateOrProvince: (state: UsState | CaState | null) => void,
-  updateCountry: IsoCountry => void,
+  updateBillingCountry: IsoCountry => void,
   paymentMethod: PaymentMethod,
   setAssociatedPaymentMethod: () => (Function) => void,
   stripeAccount: StripeAccount,
@@ -127,7 +127,7 @@ const mapDispatchToProps = (dispatch: Function) => ({
   updateFirstName: (firstName: string) => dispatch(updateFirstName(firstName)),
   updateLastName: (lastName: string) => dispatch(updateLastName(lastName)),
   updateStateOrProvince: (state: UsState | CaState | null) => dispatch(updateState(state)),
-  updateCountry: (country: IsoCountry) => dispatch(updateCountry(country)),
+  updateCountry: (billingCountry: IsoCountry) => dispatch(updateBillingCountry(billingCountry)),
   setStripePaymentRequestButtonClicked: (stripeAccount: StripeAccount) =>
     dispatch(setStripePaymentRequestButtonClicked(stripeAccount)),
   setAssociatedPaymentMethod: () => dispatch(updatePaymentMethod(Stripe)),
@@ -249,7 +249,7 @@ function onPayment(
   props: PropTypes,
   paymentRequestComplete: (string) => void,
   paymentRequestData: Object,
-  countryFromCard?: string,
+  billingCountryFromCard?: string,
   stateOrProvinceFromCard?: string,
   processPayment: () => void,
 ): void {
@@ -269,10 +269,10 @@ function onPayment(
     updatePayerStateOrProvince(stateOrProvinceFromCard, props.stateOrProvince, props.updateStateOrProvince) : true;
 
   // We need to update the country so it matches the state taken from the card
-  if (isUsOrCanadian && countryFromCard) {
-    const isoCountry = countryFromString(countryFromCard);
+  if (isUsOrCanadian && billingCountryFromCard) {
+    const isoCountry = countryFromString(billingCountryFromCard);
     if (isoCountry) {
-      props.updateCountry((isoCountry));
+      props.updateBillingCountry((isoCountry));
     }
   }
 

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -197,17 +197,9 @@ function updatePayerCountry(
   setCountry: IsoCountry => void,
 ): boolean {
 
-
-  console.log(
-    'updating payer country', countryFromCard,
-    countryFromForm,
-    setCountry,
-  );
   if (countryFromCard) {
-    console.log('setting country to iso');
     const isoCountry = countryFromString(countryFromCard);
     if (isoCountry) {
-      console.log('setting country');
       setCountry(isoCountry);
       return true;
     }

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -190,7 +190,7 @@ function updatePayerStateOrProvince(
   return false;
 }
 
-// Attempt to get state/province from the token, otherwise fall back on the value in the form
+// Attempt to get country from the token, otherwise fall back on the value in the form
 function updatePayerCountry(
   countryFromCard?: string,
   countryFromForm: IsoCountry,

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -285,12 +285,6 @@ function onPayment(
   // We need to do this so that we can offer marketing permissions on the thank you page
   updatePayerEmail(paymentRequestData, props.updateEmail);
 
-  console.log('ON PAYMENT', stateOrProvinceFromCard);
-  console.log('ON PAYMENT', countryFromCard);
-  console.log('ON PAYMENT', props.stateOrProvince);
-  console.log('ON PAYMENT', props.updateStateOrProvince);
-  console.log('ON PAYMENT', props.countryGroupId);
-
   const stateOrProvinceUpdateOk = props.countryGroupId === UnitedStates || props.countryGroupId === Canada ?
     updatePayerStateOrProvince(stateOrProvinceFromCard, props.stateOrProvince, props.updateStateOrProvince) : true;
 

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -531,11 +531,6 @@ function recurringPaymentAuthorisationHandler(
   paymentAuthorisation: PaymentAuthorisation,
 ): Promise<PaymentResult> {
   const request = regularPaymentRequestFromAuthorisation(paymentAuthorisation, state);
-  console.log('regularPaymentRequestFromAuthorisation', request.billingAddress);
-  console.log('regularPaymentRequestFromAuthorisation', request.billingAddress.state);
-  console.log('request.billingAddress.country', request.billingAddress.country);
-  console.log('state.common.internationalisation.countryId', state.common.internationalisation.countryId);
-
 
   return dispatch(onPaymentResult(
     postRegularPaymentRequest(
@@ -676,10 +671,7 @@ const paymentAuthorisationHandlers: PaymentMatrix<(
 
 const onThirdPartyPaymentAuthorised = (paymentAuthorisation: PaymentAuthorisation) =>
   (dispatch: Function, getState: () => State): Promise<PaymentResult> => {
-    console.log('in on third party payment');
-    console.log('in on third party payment paymentAuthorisation', paymentAuthorisation);
     const state = getState();
-    console.log('in on third party payment state', state);
     return paymentAuthorisationHandlers[state.page.form.contributionType][state.page.form.paymentMethod](
       dispatch,
       state,

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -358,7 +358,8 @@ const regularPaymentRequestFromAuthorisation = (
     city: null, // required go cardless field
     state: state.page.form.formData.state,
     postCode: null, // required go cardless field
-    country: !!state.page.form.formData.country ? state.page.form.formData.country : state.common.internationalisation.countryId,
+    country:
+      state.page.form.formData.country ? state.page.form.formData.country : state.common.internationalisation.countryId
   },
   deliveryAddress: null,
   product: {

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -359,7 +359,8 @@ const regularPaymentRequestFromAuthorisation = (
     state: state.page.form.formData.state,
     postCode: null, // required go cardless field
     country:
-      state.page.form.formData.billingCountry ? state.page.form.formData.billingCountry : state.common.internationalisation.countryId,
+      state.page.form.formData.billingCountry ?
+        state.page.form.formData.billingCountry : state.common.internationalisation.countryId,
   },
   deliveryAddress: null,
   product: {

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -51,7 +51,7 @@ import { AmazonPay, DirectDebit, Stripe } from 'helpers/paymentMethods';
 import type { RecentlySignedInExistingPaymentMethod } from 'helpers/existingPaymentMethods/existingPaymentMethods';
 import { ExistingCard, ExistingDirectDebit } from 'helpers/paymentMethods';
 import { getStripeKey, stripeAccountForContributionType, type StripeAccount } from 'helpers/paymentIntegrations/stripeCheckout';
-import type {IsoCountry} from "../../helpers/internationalisation/country";
+import type { IsoCountry } from '../../helpers/internationalisation/country';
 
 export type Action =
   | { type: 'UPDATE_CONTRIBUTION_TYPE', contributionType: ContributionType }
@@ -358,7 +358,7 @@ const regularPaymentRequestFromAuthorisation = (
     city: null, // required go cardless field
     state: state.page.form.formData.state,
     postCode: null, // required go cardless field
-    country: state.page.form.formData.country, //state.common.internationalisation.countryId,
+    country: state.page.form.formData.country, // state.common.internationalisation.countryId,
   },
   deliveryAddress: null,
   product: {
@@ -530,10 +530,10 @@ function recurringPaymentAuthorisationHandler(
   paymentAuthorisation: PaymentAuthorisation,
 ): Promise<PaymentResult> {
   const request = regularPaymentRequestFromAuthorisation(paymentAuthorisation, state);
-  console.log("regularPaymentRequestFromAuthorisation" ,request.billingAddress);
-  console.log("regularPaymentRequestFromAuthorisation" ,request.billingAddress.state);
-  console.log("request.billingAddress.country" ,request.billingAddress.country);
-  console.log("state.common.internationalisation.countryId" , state.common.internationalisation.countryId);
+  console.log('regularPaymentRequestFromAuthorisation', request.billingAddress);
+  console.log('regularPaymentRequestFromAuthorisation', request.billingAddress.state);
+  console.log('request.billingAddress.country', request.billingAddress.country);
+  console.log('state.common.internationalisation.countryId', state.common.internationalisation.countryId);
 
 
   return dispatch(onPaymentResult(
@@ -675,10 +675,10 @@ const paymentAuthorisationHandlers: PaymentMatrix<(
 
 const onThirdPartyPaymentAuthorised = (paymentAuthorisation: PaymentAuthorisation) =>
   (dispatch: Function, getState: () => State): Promise<PaymentResult> => {
-  console.log("in on third party payment");
-    console.log("in on third party payment paymentAuthorisation", paymentAuthorisation);
+    console.log('in on third party payment');
+    console.log('in on third party payment paymentAuthorisation', paymentAuthorisation);
     const state = getState();
-    console.log("in on third party payment state", state);
+    console.log('in on third party payment state', state);
     return paymentAuthorisationHandlers[state.page.form.contributionType][state.page.form.paymentMethod](
       dispatch,
       state,

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -359,7 +359,7 @@ const regularPaymentRequestFromAuthorisation = (
     state: state.page.form.formData.state,
     postCode: null, // required go cardless field
     country:
-      state.page.form.formData.country ? state.page.form.formData.country : state.common.internationalisation.countryId
+      state.page.form.formData.country ? state.page.form.formData.country : state.common.internationalisation.countryId,
   },
   deliveryAddress: null,
   product: {

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -167,10 +167,8 @@ const updateState = (state: UsState | CaState | null): ((Function) => void) =>
     dispatch(setFormSubmissionDependentValue(() => ({ type: 'UPDATE_STATE', state })));
   };
 
-const updateBillingCountry = (billingCountry: IsoCountry): ((Function) => void) =>
-  (dispatch: Function): void => {
-    dispatch(setFormSubmissionDependentValue(() => ({ type: 'UPDATE_BILLING_COUNTRY', billingCountry })));
-  };
+const updateBillingCountry = (billingCountry: IsoCountry): Action =>
+    ({ type: 'UPDATE_BILLING_COUNTRY', billingCountry });
 
 const selectAmount = (amount: Amount | 'other', contributionType: ContributionType): ((Function) => void) =>
   (dispatch: Function): void => {

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -62,7 +62,7 @@ export type Action =
   | { type: 'UPDATE_EMAIL', email: string }
   | { type: 'UPDATE_PASSWORD', password: string }
   | { type: 'UPDATE_STATE', state: UsState | CaState | null }
-  | { type: 'UPDATE_COUNTRY', country: IsoCountry }
+  | { type: 'UPDATE_BILLING_COUNTRY', billingCountry: IsoCountry }
   | { type: 'UPDATE_USER_FORM_DATA', userFormData: UserFormData }
   | { type: 'UPDATE_PAYMENT_READY', thirdPartyPaymentLibraryByContrib: { [ContributionType]: { [PaymentMethod]: ThirdPartyPaymentLibrary } } }
   | { type: 'SET_AMAZON_PAY_LOGIN_OBJECT', amazonLoginObject: Object }
@@ -167,9 +167,9 @@ const updateState = (state: UsState | CaState | null): ((Function) => void) =>
     dispatch(setFormSubmissionDependentValue(() => ({ type: 'UPDATE_STATE', state })));
   };
 
-const updateCountry = (country: IsoCountry): ((Function) => void) =>
+const updateBillingCountry = (billingCountry: IsoCountry): ((Function) => void) =>
   (dispatch: Function): void => {
-    dispatch(setFormSubmissionDependentValue(() => ({ type: 'UPDATE_COUNTRY', country })));
+    dispatch(setFormSubmissionDependentValue(() => ({ type: 'UPDATE_BILLING_COUNTRY', billingCountry })));
   };
 
 const selectAmount = (amount: Amount | 'other', contributionType: ContributionType): ((Function) => void) =>
@@ -359,7 +359,7 @@ const regularPaymentRequestFromAuthorisation = (
     state: state.page.form.formData.state,
     postCode: null, // required go cardless field
     country:
-      state.page.form.formData.country ? state.page.form.formData.country : state.common.internationalisation.countryId,
+      state.page.form.formData.billingCountry ? state.page.form.formData.billingCountry : state.common.internationalisation.countryId,
   },
   deliveryAddress: null,
   product: {
@@ -688,7 +688,7 @@ export {
   updateLastName,
   updateEmail,
   updateState,
-  updateCountry,
+  updateBillingCountry,
   updateUserFormData,
   setThirdPartyPaymentLibrary,
   setAmazonPayLoginObject,

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -51,6 +51,7 @@ import { AmazonPay, DirectDebit, Stripe } from 'helpers/paymentMethods';
 import type { RecentlySignedInExistingPaymentMethod } from 'helpers/existingPaymentMethods/existingPaymentMethods';
 import { ExistingCard, ExistingDirectDebit } from 'helpers/paymentMethods';
 import { getStripeKey, stripeAccountForContributionType, type StripeAccount } from 'helpers/paymentIntegrations/stripeCheckout';
+import type {IsoCountry} from "../../helpers/internationalisation/country";
 
 export type Action =
   | { type: 'UPDATE_CONTRIBUTION_TYPE', contributionType: ContributionType }
@@ -61,6 +62,7 @@ export type Action =
   | { type: 'UPDATE_EMAIL', email: string }
   | { type: 'UPDATE_PASSWORD', password: string }
   | { type: 'UPDATE_STATE', state: UsState | CaState | null }
+  | { type: 'UPDATE_COUNTRY', country: IsoCountry }
   | { type: 'UPDATE_USER_FORM_DATA', userFormData: UserFormData }
   | { type: 'UPDATE_PAYMENT_READY', thirdPartyPaymentLibraryByContrib: { [ContributionType]: { [PaymentMethod]: ThirdPartyPaymentLibrary } } }
   | { type: 'SET_AMAZON_PAY_LOGIN_OBJECT', amazonLoginObject: Object }
@@ -163,6 +165,11 @@ const updateUserFormData = (userFormData: UserFormData): ((Function) => void) =>
 const updateState = (state: UsState | CaState | null): ((Function) => void) =>
   (dispatch: Function): void => {
     dispatch(setFormSubmissionDependentValue(() => ({ type: 'UPDATE_STATE', state })));
+  };
+
+const updateCountry = (country: IsoCountry): ((Function) => void) =>
+  (dispatch: Function): void => {
+    dispatch(setFormSubmissionDependentValue(() => ({ type: 'UPDATE_COUNTRY', country })));
   };
 
 const selectAmount = (amount: Amount | 'other', contributionType: ContributionType): ((Function) => void) =>
@@ -351,7 +358,7 @@ const regularPaymentRequestFromAuthorisation = (
     city: null, // required go cardless field
     state: state.page.form.formData.state,
     postCode: null, // required go cardless field
-    country: state.common.internationalisation.countryId,
+    country: state.page.form.formData.country, //state.common.internationalisation.countryId,
   },
   deliveryAddress: null,
   product: {
@@ -523,6 +530,11 @@ function recurringPaymentAuthorisationHandler(
   paymentAuthorisation: PaymentAuthorisation,
 ): Promise<PaymentResult> {
   const request = regularPaymentRequestFromAuthorisation(paymentAuthorisation, state);
+  console.log("regularPaymentRequestFromAuthorisation" ,request.billingAddress);
+  console.log("regularPaymentRequestFromAuthorisation" ,request.billingAddress.state);
+  console.log("request.billingAddress.country" ,request.billingAddress.country);
+  console.log("state.common.internationalisation.countryId" , state.common.internationalisation.countryId);
+
 
   return dispatch(onPaymentResult(
     postRegularPaymentRequest(
@@ -663,7 +675,10 @@ const paymentAuthorisationHandlers: PaymentMatrix<(
 
 const onThirdPartyPaymentAuthorised = (paymentAuthorisation: PaymentAuthorisation) =>
   (dispatch: Function, getState: () => State): Promise<PaymentResult> => {
+  console.log("in on third party payment");
+    console.log("in on third party payment paymentAuthorisation", paymentAuthorisation);
     const state = getState();
+    console.log("in on third party payment state", state);
     return paymentAuthorisationHandlers[state.page.form.contributionType][state.page.form.paymentMethod](
       dispatch,
       state,
@@ -680,6 +695,7 @@ export {
   updateLastName,
   updateEmail,
   updateState,
+  updateCountry,
   updateUserFormData,
   setThirdPartyPaymentLibrary,
   setAmazonPayLoginObject,

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -358,7 +358,7 @@ const regularPaymentRequestFromAuthorisation = (
     city: null, // required go cardless field
     state: state.page.form.formData.state,
     postCode: null, // required go cardless field
-    country: state.page.form.formData.country, // state.common.internationalisation.countryId,
+    country: !!state.page.form.formData.country ? state.page.form.formData.country : state.common.internationalisation.countryId,
   },
   deliveryAddress: null,
   product: {

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
@@ -46,7 +46,7 @@ export type ThankYouPageStage = $Keys<ThankYouPageStageMap<null>>
 type FormData = UserFormData & {
   otherAmounts: OtherAmounts,
   state: UsState | CaState | null,
-  country: IsoCountry | null,
+  billingCountry: IsoCountry | null,
   checkoutFormHasBeenSubmitted: boolean,
 };
 
@@ -176,7 +176,7 @@ function createFormReducer() {
         ANNUAL: { amount: null },
       },
       state: null,
-      country: null,
+      billingCountry: null,
       checkoutFormHasBeenSubmitted: false,
     },
     stripeV3HasLoaded: false,
@@ -384,8 +384,8 @@ function createFormReducer() {
       case 'UPDATE_STATE':
         return { ...state, formData: { ...state.formData, state: action.state } };
 
-      case 'UPDATE_COUNTRY':
-        return { ...state, formData: { ...state.formData, country: action.country } };
+      case 'UPDATE_BILLING_COUNTRY':
+        return { ...state, formData: { ...state.formData, billingCountry: action.billingCountry } };
 
       case 'SET_PAYMENT_REQUEST_BUTTON_PAYMENT_METHOD':
         return {

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
@@ -23,7 +23,7 @@ import { type State as MarketingConsentState } from '../../components/marketingC
 import { marketingConsentReducerFor } from '../../components/marketingConsent/marketingConsentReducer';
 import type { PaymentMethod } from 'helpers/paymentMethods';
 import type { RecentlySignedInExistingPaymentMethod } from '../../helpers/existingPaymentMethods/existingPaymentMethods';
-import type {IsoCountry} from "../../helpers/internationalisation/country";
+import type { IsoCountry } from '../../helpers/internationalisation/country';
 
 // ----- Types ----- //
 

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
@@ -23,6 +23,7 @@ import { type State as MarketingConsentState } from '../../components/marketingC
 import { marketingConsentReducerFor } from '../../components/marketingConsent/marketingConsentReducer';
 import type { PaymentMethod } from 'helpers/paymentMethods';
 import type { RecentlySignedInExistingPaymentMethod } from '../../helpers/existingPaymentMethods/existingPaymentMethods';
+import type {IsoCountry} from "../../helpers/internationalisation/country";
 
 // ----- Types ----- //
 
@@ -45,6 +46,7 @@ export type ThankYouPageStage = $Keys<ThankYouPageStageMap<null>>
 type FormData = UserFormData & {
   otherAmounts: OtherAmounts,
   state: UsState | CaState | null,
+  country: IsoCountry,
   checkoutFormHasBeenSubmitted: boolean,
 };
 
@@ -174,6 +176,7 @@ function createFormReducer() {
         ANNUAL: { amount: null },
       },
       state: null,
+      country: null,
       checkoutFormHasBeenSubmitted: false,
     },
     stripeV3HasLoaded: false,
@@ -380,6 +383,9 @@ function createFormReducer() {
 
       case 'UPDATE_STATE':
         return { ...state, formData: { ...state.formData, state: action.state } };
+
+      case 'UPDATE_COUNTRY':
+        return { ...state, formData: { ...state.formData, country: action.country } };
 
       case 'SET_PAYMENT_REQUEST_BUTTON_PAYMENT_METHOD':
         return {

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
@@ -46,7 +46,7 @@ export type ThankYouPageStage = $Keys<ThankYouPageStageMap<null>>
 type FormData = UserFormData & {
   otherAmounts: OtherAmounts,
   state: UsState | CaState | null,
-  country: IsoCountry,
+  country: IsoCountry | null,
   checkoutFormHasBeenSubmitted: boolean,
 };
 


### PR DESCRIPTION
The payment request button has a bug when used with recurring. It currently uses the country from the page(uri) instead of from the card address. This causes an error in Zuora as we can end up with invalid combinations of province/country mixing Canada and US.

This change is to send the country from the billing address of the card in the authentication response from stripe. As we send the state from the same place, in theory they will always match up in Zuora and prevent invalid combinations.

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/L4G6cyzc/1572-payment-requests-button-send-state-to-backend-for-us-canada)


## Screenshots

![image](https://user-images.githubusercontent.com/30600967/74039978-b8b78100-49ba-11ea-9763-3ad73d917c56.png)

