### PR TITLE
Paper savings

### DIFF
--- a/support-frontend/assets/helpers/productPrice/__tests__/productPricesTests.js
+++ b/support-frontend/assets/helpers/productPrice/__tests__/productPricesTests.js
@@ -3,6 +3,7 @@
 // ----- Imports ----- //
 import { isNumeric } from 'helpers/productPrice/productPrices';
 import { hasDiscount } from 'helpers/productPrice/promotions';
+import { getBiggestSavingVsRetail } from 'helpers/productPrice/paperProductPrices';
 
 // ----- Tests ----- //
 
@@ -16,6 +17,159 @@ describe('productPrices', () => {
     expect(isNumeric(undefined)).toEqual(false);
     expect(isNumeric(0)).toEqual(true);
     expect(isNumeric(50)).toEqual(true);
+  });
+
+  describe('getBiggestSavingVsRetail', () => {
+    const productPrices = {
+      'United Kingdom': {
+        Collection: {
+          SixdayPlus: {
+            Monthly: {
+              GBP: {
+                price: 27.36, savingVsRetail: 35, currency: 'GBP', fixedTerm: false, promotions: [],
+              },
+            },
+          },
+          SundayPlus: {
+            Monthly: {
+              GBP: {
+                price: 22.06, savingVsRetail: 15, currency: 'GBP', fixedTerm: false, promotions: [],
+              },
+            },
+          },
+          SaturdayPlus: {
+            Monthly: {
+              GBP: {
+                price: 21.62, savingVsRetail: 16, currency: 'GBP', fixedTerm: false, promotions: [],
+              },
+            },
+          },
+          Saturday: {
+            Monthly: {
+              GBP: {
+                price: 10.36, savingVsRetail: 13, currency: 'GBP', fixedTerm: false, promotions: [],
+              },
+            },
+          },
+          Sixday: {
+            Monthly: {
+              GBP: {
+                price: 41.12, savingVsRetail: 26, currency: 'GBP', fixedTerm: false, promotions: [],
+              },
+            },
+          },
+          Weekend: {
+            Monthly: {
+              GBP: {
+                price: 20.76, savingVsRetail: 20, currency: 'GBP', fixedTerm: false, promotions: [],
+              },
+            },
+          },
+          Sunday: {
+            Monthly: {
+              GBP: {
+                price: 10.79, savingVsRetail: 13, currency: 'GBP', fixedTerm: false, promotions: [],
+              },
+            },
+          },
+          WeekendPlus: {
+            Monthly: {
+              GBP: {
+                price: 12.56, savingVsRetail: 26, currency: 'GBP', fixedTerm: false, promotions: [],
+              },
+            },
+          },
+          Everyday: {
+            Monthly: {
+              GBP: {
+                price: 47.62, savingVsRetail: 29, currency: 'GBP', fixedTerm: false, promotions: [],
+              },
+            },
+          },
+          EverydayPlus: {
+            Monthly: {
+              GBP: {
+                price: 29.20, savingVsRetail: 41, currency: 'GBP', fixedTerm: false, promotions: [],
+              },
+            },
+          },
+        },
+        HomeDelivery: {
+          SixdayPlus: {
+            Monthly: {
+              GBP: {
+                price: 30.36, currency: 'GBP', fixedTerm: false, promotions: [],
+              },
+            },
+          },
+          SundayPlus: {
+            Monthly: {
+              GBP: {
+                price: 26.39, currency: 'GBP', fixedTerm: false, promotions: [],
+              },
+            },
+          },
+          SaturdayPlus: {
+            Monthly: {
+              GBP: {
+                price: 25.96, currency: 'GBP', fixedTerm: false, promotions: [],
+              },
+            },
+          },
+          Saturday: {
+            Monthly: {
+              GBP: {
+                price: 14.69, currency: 'GBP', fixedTerm: false, promotions: [],
+              },
+            },
+          },
+          Sixday: {
+            Monthly: {
+              GBP: {
+                price: 54.12, savingVsRetail: 5, currency: 'GBP', fixedTerm: false, promotions: [],
+              },
+            },
+          },
+          Weekend: {
+            Monthly: {
+              GBP: {
+                price: 25.09, savingVsRetail: 2, currency: 'GBP', fixedTerm: false, promotions: [],
+              },
+            },
+          },
+          Sunday: {
+            Monthly: {
+              GBP: {
+                price: 15.12, currency: 'GBP', fixedTerm: false, promotions: [],
+              },
+            },
+          },
+          WeekendPlus: {
+            Monthly: {
+              GBP: {
+                price: 12.57, currency: 'GBP', fixedTerm: false, promotions: [],
+              },
+            },
+          },
+          Everyday: {
+            Monthly: {
+              GBP: {
+                price: 62.79, savingVsRetail: 9, currency: 'GBP', fixedTerm: false, promotions: [],
+              },
+            },
+          },
+          EverydayPlus: {
+            Monthly: {
+              GBP: {
+                price: 29.19, currency: 'GBP', fixedTerm: false, promotions: [],
+              },
+            },
+          },
+        },
+      },
+    };
+
+    expect(getBiggestSavingVsRetail(productPrices)).toEqual(29);
   });
 
   describe('hasDiscount', () => {

--- a/support-frontend/assets/helpers/productPrice/__tests__/productPricesTests.js
+++ b/support-frontend/assets/helpers/productPrice/__tests__/productPricesTests.js
@@ -3,7 +3,7 @@
 // ----- Imports ----- //
 import { isNumeric } from 'helpers/productPrice/productPrices';
 import { hasDiscount } from 'helpers/productPrice/promotions';
-import { getBiggestSavingVsRetail } from 'helpers/productPrice/paperProductPrices';
+import { getMaxSavingVsRetail } from 'helpers/productPrice/paperProductPrices';
 
 // ----- Tests ----- //
 
@@ -19,7 +19,7 @@ describe('productPrices', () => {
     expect(isNumeric(50)).toEqual(true);
   });
 
-  describe('getBiggestSavingVsRetail', () => {
+  describe('getMaxSavingVsRetail', () => {
     const productPrices = {
       'United Kingdom': {
         Collection: {
@@ -169,7 +169,7 @@ describe('productPrices', () => {
       },
     };
 
-    expect(getBiggestSavingVsRetail(productPrices)).toEqual(29);
+    expect(getMaxSavingVsRetail(productPrices)).toEqual(29);
   });
 
   describe('hasDiscount', () => {

--- a/support-frontend/assets/helpers/productPrice/paperProductPrices.js
+++ b/support-frontend/assets/helpers/productPrice/paperProductPrices.js
@@ -2,8 +2,14 @@
 
 import { Monthly } from 'helpers/billingPeriods';
 import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
+import {
+  Collection,
+  HomeDelivery,
+} from 'helpers/productPrice/fulfilmentOptions';
 import type { ProductOptions } from 'helpers/productPrice/productOptions';
+import { ActivePaperProductTypes } from 'helpers/productPrice/productOptions';
 import type {
+  CountryGroupPrices,
   ProductPrice,
   ProductPrices,
 } from 'helpers/productPrice/productPrices';
@@ -43,4 +49,21 @@ function finalPrice(
   );
 }
 
-export { getProductPrice, finalPrice };
+function getSavingsForFulfilmentOption(
+  prices: CountryGroupPrices,
+  fulfilmentOption: FulfilmentOptions,
+) {
+  return ActivePaperProductTypes.map((productOption) => {
+    const price = prices[fulfilmentOption][productOption].Monthly.GBP;
+    return price.savingVsRetail || 0;
+  });
+}
+
+function getBiggestSavingVsRetail(productPrices: ProductPrices): number {
+  const countryPrices = productPrices['United Kingdom'];
+  const allSavings = getSavingsForFulfilmentOption(countryPrices, Collection)
+    .concat(getSavingsForFulfilmentOption(countryPrices, HomeDelivery));
+  return Math.max(...allSavings);
+}
+
+export { getProductPrice, finalPrice, getBiggestSavingVsRetail };

--- a/support-frontend/assets/helpers/productPrice/paperProductPrices.js
+++ b/support-frontend/assets/helpers/productPrice/paperProductPrices.js
@@ -59,11 +59,11 @@ function getSavingsForFulfilmentOption(
   });
 }
 
-function getBiggestSavingVsRetail(productPrices: ProductPrices): number {
+function getMaxSavingVsRetail(productPrices: ProductPrices): number {
   const countryPrices = productPrices['United Kingdom'];
   const allSavings = getSavingsForFulfilmentOption(countryPrices, Collection)
     .concat(getSavingsForFulfilmentOption(countryPrices, HomeDelivery));
   return Math.max(...allSavings);
 }
 
-export { getProductPrice, finalPrice, getBiggestSavingVsRetail };
+export { getProductPrice, finalPrice, getMaxSavingVsRetail };

--- a/support-frontend/assets/helpers/productPrice/productPrices.js
+++ b/support-frontend/assets/helpers/productPrice/productPrices.js
@@ -27,7 +27,7 @@ import { applyDiscount, getPromotion } from 'helpers/productPrice/promotions';
 
 export type ProductPrice = {
   price: number,
-  saving?: number,
+  savingVsRetail?: number,
   currency: IsoCurrency,
   fixedTerm: boolean,
   promotions?: Promotion[],

--- a/support-frontend/assets/helpers/productPrice/productPrices.js
+++ b/support-frontend/assets/helpers/productPrice/productPrices.js
@@ -27,6 +27,7 @@ import { applyDiscount, getPromotion } from 'helpers/productPrice/promotions';
 
 export type ProductPrice = {
   price: number,
+  saving: number,
   currency: IsoCurrency,
   fixedTerm: boolean,
   promotions?: Promotion[],

--- a/support-frontend/assets/helpers/productPrice/productPrices.js
+++ b/support-frontend/assets/helpers/productPrice/productPrices.js
@@ -27,7 +27,7 @@ import { applyDiscount, getPromotion } from 'helpers/productPrice/promotions';
 
 export type ProductPrice = {
   price: number,
-  saving: number,
+  saving?: number,
   currency: IsoCurrency,
   fixedTerm: boolean,
   promotions?: Promotion[],

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/thankYou.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/thankYou.jsx
@@ -6,7 +6,7 @@ import React, { type Element } from 'react';
 
 import { connect } from 'react-redux';
 
-import { HeroPicture } from 'pages/paper-subscription-landing/components/hero/hero';
+import { HeroPicture } from 'pages/paper-subscription-landing/components/hero/heroPicture';
 import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import { Collection, HomeDelivery } from 'helpers/productPrice/fulfilmentOptions';
 import { sendTrackingEventsOnClick } from 'helpers/subscriptions';

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/form.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/form.jsx
@@ -18,7 +18,6 @@ import { type State } from '../../paperSubscriptionLandingPageReducer';
 import type { PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import type {
   PaperProductOptions,
-  ProductOptions,
 } from 'helpers/productPrice/productOptions';
 import { ActivePaperProductTypes } from 'helpers/productPrice/productOptions';
 import { paperCheckoutUrl } from 'helpers/routes';
@@ -77,11 +76,11 @@ const copy = {
   },
 };
 
-const getOfferText = (price: ProductPrice, productOption: ProductOptions) => {
+const getOfferText = (price: ProductPrice, productOption: PaperProductOptions) => {
   if (flashSaleIsActive(Paper)) {
     return getOfferStr(price.price, getNewsstandPrice(productOption));
   }
-  if (price.saving > 0) { return `Save ${price.saving}% on retail price`; }
+  if (price.saving && price.saving > 0) { return `Save ${price.saving}% on retail price`; }
 
   return null;
 };

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/form.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/form.jsx
@@ -16,7 +16,10 @@ import ProductPagePlanForm, { type PropTypes } from 'components/productPage/prod
 
 import { type State } from '../../paperSubscriptionLandingPageReducer';
 import type { PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
-import type { PaperProductOptions } from 'helpers/productPrice/productOptions';
+import type {
+  PaperProductOptions,
+  ProductOptions,
+} from 'helpers/productPrice/productOptions';
 import { ActivePaperProductTypes } from 'helpers/productPrice/productOptions';
 import { paperCheckoutUrl } from 'helpers/routes';
 import { getTitle } from '../../helpers/products';
@@ -74,25 +77,13 @@ const copy = {
   },
 };
 
-const getOfferText = (price, productOption, fulfilmentOption) => {
+const getOfferText = (price: ProductPrice, productOption: ProductOptions) => {
   if (flashSaleIsActive(Paper)) {
-    return getOfferStr(price, getNewsstandPrice(productOption));
+    return getOfferStr(price.price, getNewsstandPrice(productOption));
   }
-  const offerCopy = {
-    Collection: {
-      Everyday: 'Save 37% on retail price',
-      Sixday: 'Save 33% on retail price',
-      Weekend: 'Save 25% on retail price',
-      Sunday: 'Save 22% on retail price',
-    },
-    HomeDelivery: {
-      Everyday: 'Save 17% on retail price',
-      Sixday: 'Save 12% on retail price',
-      Weekend: 'Save 9% on retail price',
-      Sunday: null,
-    },
-  };
-  return offerCopy[fulfilmentOption][productOption];
+  if (price.saving > 0) { return `Save ${price.saving}% on retail price`; }
+
+  return null;
 };
 
 const getPlans = (
@@ -116,7 +107,7 @@ const getPlans = (
         title: getTitle(productOption),
         copy: copy[fulfilmentOption][productOption],
         price: flashSaleIsActive(Paper) ? getPriceStr(price) : getRegularPriceStr(price),
-        offer: getOfferText(price.price, productOption, fulfilmentOption),
+        offer: getOfferText(price, productOption),
         saving: flashSaleIsActive(Paper)
           ? getSavingStr(getProductPrice(productPrices, fulfilmentOption, productOption))
           : null,

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/form.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/form.jsx
@@ -80,7 +80,7 @@ const getOfferText = (price: ProductPrice, productOption: PaperProductOptions) =
   if (flashSaleIsActive(Paper)) {
     return getOfferStr(price.price, getNewsstandPrice(productOption));
   }
-  if (price.saving && price.saving > 0) { return `Save ${price.saving}% on retail price`; }
+  if (price.savingVsRetail && price.savingVsRetail > 0) { return `Save ${price.savingVsRetail}% on retail price`; }
 
   return null;
 };

--- a/support-frontend/assets/pages/paper-subscription-landing/components/hero/campaignHeader.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/hero/campaignHeader.jsx
@@ -21,16 +21,20 @@ type PropTypes = {
 }
 
 const mapStateToProps = (state: State) => {
-  const maxSavingVsRetail = getMaxSavingVsRetail(state.page.productPrices);
+  const maxSavingVsRetail = state.page.productPrices ?
+    getMaxSavingVsRetail(state.page.productPrices) : 0;
   return {
     discountCopy: getDiscountCopy(maxSavingVsRetail),
   };
 };
 
-const Discount = (props: { discountCopy: string[] }) => (
-  <div>
-    {props.discountCopy.map(copy => <span>{ copy }</span>)}
-  </div>
+const Roundel = (props: { roundelCopy: string[] }) => (
+  props.roundelCopy.length > 0 ?
+    <div className="sale-joy-of-print-badge">
+      <div>
+        {props.roundelCopy.map(copy => <span>{ copy }</span>)}
+      </div>
+    </div>: null
 );
 
 const CampaignHeader = (props: PropTypes) => (
@@ -50,9 +54,7 @@ const CampaignHeader = (props: PropTypes) => (
     </div>
     <div className="sale-joy-of-print-graphic-outer">
       <div className="sale-joy-of-print-graphic-inner">
-        <div className="sale-joy-of-print-badge">
-          <Discount discountCopy={props.discountCopy.roundel} />
-        </div>
+        <Roundel roundelCopy={props.discountCopy.roundel} />
         <div className="sale-joy-of-print-graphic">
           <GridImage
             gridId="printCampaign2020"

--- a/support-frontend/assets/pages/paper-subscription-landing/components/hero/campaignHeader.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/hero/campaignHeader.jsx
@@ -4,7 +4,6 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
-import GridPicture from 'components/gridPicture/gridPicture';
 import ProductPagehero
   from 'components/productPage/productPageHero/productPageHero';
 import AnchorButton from 'components/button/anchorButton';
@@ -25,38 +24,13 @@ const mapStateToProps = (state: State) => {
   const maxSavingVsRetail = getMaxSavingVsRetail(state.page.productPrices);
   return {
     discountCopy: getDiscountCopy(maxSavingVsRetail),
-  }
+  };
 };
 
 const Discount = (props: { discountCopy: string[] }) => (
   <div>
     {props.discountCopy.map(copy => <span>{ copy }</span>)}
   </div>
-);
-
-const HeroPicture = () => (
-  <GridPicture
-    sources={[
-      {
-        gridId: 'paperLandingHeroMobile',
-        srcSizes: [500, 922],
-        imgType: 'png',
-        sizes: '100vw',
-        media: '(max-width: 739px)',
-      },
-      {
-        gridId: 'paperLandingHero',
-        srcSizes: [1000, 2000],
-        imgType: 'png',
-        sizes: '(min-width: 1000px) 2000px, 1000px',
-        media: '(min-width: 740px)',
-      },
-    ]}
-    fallback="paperLandingHero"
-    fallbackSize={1000}
-    altText=""
-    fallbackImgType="png"
-  />
 );
 
 const CampaignHeader = (props: PropTypes) => (
@@ -94,5 +68,3 @@ const CampaignHeader = (props: PropTypes) => (
 );
 
 export default connect(mapStateToProps)(CampaignHeader);
-
-export {  HeroPicture };

--- a/support-frontend/assets/pages/paper-subscription-landing/components/hero/discountCopy.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/hero/discountCopy.jsx
@@ -5,20 +5,20 @@ import { type Node } from 'react';
 import { flashSaleIsActive, getSaleCopy } from 'helpers/flashSale';
 import { GBPCountries } from 'helpers/internationalisation/countryGroup';
 
-type DiscountCopy = {
+export type DiscountCopy = {
   roundel: string[],
   heading: string | Node,
 };
 
-const discountCopy: DiscountCopy = {
-  roundel: ['Save up to', '37%', 'a year'],
-  heading: 'Save up to 37% a year with a subscription',
-};
+const discountCopy = (discountPercentage: number): DiscountCopy => ({
+  roundel: ['Save up to', `${discountPercentage}%`, 'a year'],
+  heading: `Save up to ${discountPercentage}% a year with a subscription`,
+});
 
-export const getDiscountCopy = (): DiscountCopy => {
+export const getDiscountCopy = (discountPercentage: number): DiscountCopy => {
   if (flashSaleIsActive('Paper', GBPCountries)) {
     const saleCopy = getSaleCopy('Paper', GBPCountries);
     return saleCopy.landingPage;
   }
-  return discountCopy;
+  return discountCopy(discountPercentage);
 };

--- a/support-frontend/assets/pages/paper-subscription-landing/components/hero/discountCopy.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/hero/discountCopy.jsx
@@ -10,10 +10,17 @@ export type DiscountCopy = {
   heading: string | Node,
 };
 
-const discountCopy = (discountPercentage: number): DiscountCopy => ({
-  roundel: ['Save up to', `${discountPercentage}%`, 'a year'],
-  heading: `Save up to ${discountPercentage}% a year with a subscription`,
-});
+const discountCopy = (discountPercentage: number): DiscountCopy => (
+  discountPercentage > 0 ?
+    {
+      roundel: ['Save up to', `${discountPercentage}%`, 'a year'],
+      heading: `Save up to ${discountPercentage}% a year with a subscription`,
+    } :
+    {
+      roundel: [],
+      heading: `Save money with a subscription`,
+    }
+);
 
 export const getDiscountCopy = (discountPercentage: number): DiscountCopy => {
   if (flashSaleIsActive('Paper', GBPCountries)) {

--- a/support-frontend/assets/pages/paper-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/hero/hero.jsx
@@ -3,38 +3,36 @@
 // ----- Imports ----- //
 
 import React from 'react';
+import { connect } from 'react-redux';
 import GridPicture from 'components/gridPicture/gridPicture';
-import ProductPagehero, {
-  HeroHanger,
-  HeroHeading,
-  HeroWrapper,
-} from 'components/productPage/productPageHero/productPageHero';
+import ProductPagehero
+  from 'components/productPage/productPageHero/productPageHero';
 import AnchorButton from 'components/button/anchorButton';
 import SvgChevron from 'components/svgs/chevron';
 import GridImage from 'components/gridImage/gridImage';
-import { FlashSaleCountdownInHero } from 'components/flashSaleCountdown/flashSaleCountdown';
 import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
-import HeadingBlock from 'components/headingBlock/headingBlock';
-import { GBPCountries } from 'helpers/internationalisation/countryGroup';
-import {
-  showCountdownTimer,
-} from 'helpers/flashSale';
 import { getDiscountCopy } from './discountCopy';
 import './joyOfPrint.scss';
+import type { State } from 'pages/paper-subscription-landing/paperSubscriptionLandingPageReducer';
+import { getMaxSavingVsRetail } from 'helpers/productPrice/paperProductPrices';
+import type { DiscountCopy } from 'pages/paper-subscription-landing/components/hero/discountCopy';
 
-const discountCopy = getDiscountCopy();
+type PropTypes = {
+  discountCopy: DiscountCopy,
+}
+
+const mapStateToProps = (state: State) => {
+  const maxSavingVsRetail = getMaxSavingVsRetail(state.page.productPrices);
+  return {
+    discountCopy: getDiscountCopy(maxSavingVsRetail),
+  }
+};
 
 const Discount = (props: { discountCopy: string[] }) => (
   <div>
     {props.discountCopy.map(copy => <span>{ copy }</span>)}
   </div>
 );
-
-const TimerIfActive = () => (showCountdownTimer('Paper', GBPCountries) ? (
-  <FlashSaleCountdownInHero
-    product="Paper"
-    countryGroupId="GBPCountries"
-  />) : null);
 
 const HeroPicture = () => (
   <GridPicture
@@ -61,37 +59,11 @@ const HeroPicture = () => (
   />
 );
 
-const Footer = () => (
-  <HeroHanger>
-    <AnchorButton onClick={sendTrackingEventsOnClick('options_cta_click', 'Paper', null)} icon={<SvgChevron />} href="#subscribe">See Subscription options</AnchorButton>
-  </HeroHanger>
-);
-
-const Heading = () => (
-  <HeroHeading hasCampaign={false}>
-    <HeadingBlock overheading="The Guardian newspaper subscriptions">{discountCopy.heading}</HeadingBlock>
-  </HeroHeading>
-);
-
-const DefaultHeader = () => (
-  <header>
-    <HeroWrapper
-      appearance="feature"
-      modifierClasses={['paper']}
-    >
-      <HeroPicture />
-      <TimerIfActive />
-    </HeroWrapper>
-    <Heading />
-    <Footer />
-  </header>
-);
-
-const CampaignHeader = () => (
+const CampaignHeader = (props: PropTypes) => (
   <ProductPagehero
     appearance="campaign"
     overheading="Newspaper subscriptions"
-    heading={discountCopy.heading}
+    heading={props.discountCopy.heading}
     modifierClasses={['paper-sale']}
     content={<AnchorButton onClick={sendTrackingEventsOnClick('options_cta_click', 'Paper', null)} icon={<SvgChevron />} href="#subscribe">See Subscription options</AnchorButton>}
     hasCampaign
@@ -105,7 +77,7 @@ const CampaignHeader = () => (
     <div className="sale-joy-of-print-graphic-outer">
       <div className="sale-joy-of-print-graphic-inner">
         <div className="sale-joy-of-print-badge">
-          <Discount discountCopy={discountCopy.roundel} />
+          <Discount discountCopy={props.discountCopy.roundel} />
         </div>
         <div className="sale-joy-of-print-graphic">
           <GridImage
@@ -121,4 +93,6 @@ const CampaignHeader = () => (
   </ProductPagehero>
 );
 
-export { DefaultHeader, CampaignHeader, HeroPicture };
+export default connect(mapStateToProps)(CampaignHeader);
+
+export {  HeroPicture };

--- a/support-frontend/assets/pages/paper-subscription-landing/components/hero/heroPicture.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/hero/heroPicture.jsx
@@ -1,0 +1,31 @@
+// @flow
+
+import React from 'react';
+import GridPicture from 'components/gridPicture/gridPicture';
+
+const HeroPicture = () => (
+  <GridPicture
+    sources={[
+      {
+        gridId: 'paperLandingHeroMobile',
+        srcSizes: [500, 922],
+        imgType: 'png',
+        sizes: '100vw',
+        media: '(max-width: 739px)',
+      },
+      {
+        gridId: 'paperLandingHero',
+        srcSizes: [1000, 2000],
+        imgType: 'png',
+        sizes: '(min-width: 1000px) 2000px, 1000px',
+        media: '(min-width: 740px)',
+      },
+    ]}
+    fallback="paperLandingHero"
+    fallbackSize={1000}
+    altText=""
+    fallbackImgType="png"
+  />
+);
+
+export { HeroPicture };

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
@@ -15,7 +15,7 @@ import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
 import 'stylesheets/skeleton/skeleton.scss';
 
-import { CampaignHeader } from './components/hero/hero';
+import CampaignHeader from './components/hero/hero';
 import Tabs from './components/tabs';
 import TabsContent from './components/content/content';
 import reducer from './paperSubscriptionLandingPageReducer';

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
@@ -15,7 +15,7 @@ import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
 import 'stylesheets/skeleton/skeleton.scss';
 
-import CampaignHeader from './components/hero/hero';
+import CampaignHeader from 'pages/paper-subscription-landing/components/hero/campaignHeader';
 import Tabs from './components/tabs';
 import TabsContent from './components/content/content';
 import reducer from './paperSubscriptionLandingPageReducer';

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPageReducer.js
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPageReducer.js
@@ -19,7 +19,7 @@ export type ActiveTabState = PaperFulfilmentOptions;
 export type State = {
   common: CommonState,
   page: {
-    productPrices: ?ProductPrices,
+    productPrices: ProductPrices,
     tab: ActiveTabState,
   }
 };

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPageReducer.js
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPageReducer.js
@@ -19,7 +19,7 @@ export type ActiveTabState = PaperFulfilmentOptions;
 export type State = {
   common: CommonState,
   page: {
-    productPrices: ProductPrices,
+    productPrices: ?ProductPrices,
     tab: ActiveTabState,
   }
 };

--- a/support-frontend/test/controllers/SubscriptionsTest.scala
+++ b/support-frontend/test/controllers/SubscriptionsTest.scala
@@ -99,7 +99,7 @@ class SubscriptionsTest extends AnyWordSpec with Matchers with TestCSRFComponent
           Map(NoFulfilmentOptions ->
             Map(NoProductOptions ->
               Map(Monthly ->
-                Map(GBP -> PriceSummary(10, GBP, fixedTerm = false, Nil))))))
+                Map(GBP -> PriceSummary(10, 0, GBP, fixedTerm = false, Nil))))))
       val priceSummaryServiceProvider = mock[PriceSummaryServiceProvider]
       val priceSummaryService = mock[PriceSummaryService]
       when(priceSummaryService.getPrices(any[com.gu.support.catalog.Product], any[List[PromoCode]], any[Boolean])).thenReturn(prices)

--- a/support-frontend/test/controllers/SubscriptionsTest.scala
+++ b/support-frontend/test/controllers/SubscriptionsTest.scala
@@ -99,7 +99,7 @@ class SubscriptionsTest extends AnyWordSpec with Matchers with TestCSRFComponent
           Map(NoFulfilmentOptions ->
             Map(NoProductOptions ->
               Map(Monthly ->
-                Map(GBP -> PriceSummary(10, 0, GBP, fixedTerm = false, Nil))))))
+                Map(GBP -> PriceSummary(10, None, GBP, fixedTerm = false, Nil))))))
       val priceSummaryServiceProvider = mock[PriceSummaryServiceProvider]
       val priceSummaryService = mock[PriceSummaryService]
       when(priceSummaryService.getPrices(any[com.gu.support.catalog.Product], any[List[PromoCode]], any[Boolean])).thenReturn(prices)

--- a/support-models/src/main/scala/com/gu/support/catalog/Catalog.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/Catalog.scala
@@ -1,12 +1,12 @@
 package com.gu.support.catalog
 
 import com.gu.i18n.Currency
-import com.gu.support.encoding.JsonHelpers._
 import com.gu.support.config.TouchPointEnvironments.{PROD, SANDBOX, UAT}
 import io.circe.Json.fromString
 import io.circe._
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.syntax._
+import com.gu.support.encoding.JsonHelpers._
 
 case class Catalog(
   prices: List[Pricelist]
@@ -34,13 +34,21 @@ object Catalog {
       productRatePlan =>
         val priceList = sumPriceLists(productRatePlan.\\("pricing"))
         val id = productRatePlan.getField("id").getOrElse(Json.Null)
+        val saving = getSaving(productRatePlan)
         Json.obj(
           ("productRatePlanId", id),
+          ("saving", Json.fromInt(saving)),
           ("prices", Json.fromValues(priceList))
         )
     }
     Json.obj(("prices", Json.fromValues(prices)))
   }
+
+  def getSaving(json: Json) =
+    json.getField("Saving__c").getOrElse(Json.fromInt(0)).asString.getOrElse("0") match {
+      case "null" => 0
+      case i: String => i.toInt
+    }
 
   def sumPriceLists(priceLists: List[Json]): Iterable[Json] = {
     // Paper products such as Everyday are represented in the catalog as multiple

--- a/support-models/src/main/scala/com/gu/support/catalog/Catalog.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/Catalog.scala
@@ -37,7 +37,7 @@ object Catalog {
         val saving = getSaving(productRatePlan)
         Json.obj(
           ("productRatePlanId", id),
-          ("saving", Json.fromInt(saving)),
+          ("savingVsRetail", saving),
           ("prices", Json.fromValues(priceList))
         )
     }
@@ -46,8 +46,8 @@ object Catalog {
 
   def getSaving(json: Json) =
     json.getField("Saving__c").getOrElse(Json.fromInt(0)).asString.getOrElse("0") match {
-      case "null" => 0
-      case i: String => i.toInt
+      case "null" => Json.Null
+      case i: String => Json.fromInt(i.toInt)
     }
 
   def sumPriceLists(priceLists: List[Json]): Iterable[Json] = {

--- a/support-models/src/main/scala/com/gu/support/catalog/Catalog.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/Catalog.scala
@@ -45,7 +45,9 @@ object Catalog {
   }
 
   def getSaving(json: Json) =
-    json.getField("Saving__c").getOrElse(Json.fromInt(0)).asString.getOrElse("0") match {
+    json.getField("Saving__c")
+      .getOrElse(Json.fromString("null"))
+      .asString.getOrElse("null") match {
       case "null" => Json.Null
       case i: String => Json.fromInt(i.toInt)
     }

--- a/support-models/src/main/scala/com/gu/support/catalog/Pricelist.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/Pricelist.scala
@@ -1,6 +1,6 @@
 package com.gu.support.catalog
 
-case class Pricelist(productRatePlanId: ProductRatePlanId, saving: Int, prices: List[Price])
+case class Pricelist(productRatePlanId: ProductRatePlanId, savingVsRetail: Option[Int], prices: List[Price])
 
 import com.gu.support.encoding.Codec
 import com.gu.support.encoding.Codec._

--- a/support-models/src/main/scala/com/gu/support/catalog/Pricelist.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/Pricelist.scala
@@ -1,6 +1,6 @@
 package com.gu.support.catalog
 
-case class Pricelist(productRatePlanId: ProductRatePlanId, prices: List[Price])
+case class Pricelist(productRatePlanId: ProductRatePlanId, saving: Int, prices: List[Price])
 
 import com.gu.support.encoding.Codec
 import com.gu.support.encoding.Codec._

--- a/support-services/src/main/scala/com/gu/support/catalog/CatalogService.scala
+++ b/support-services/src/main/scala/com/gu/support/catalog/CatalogService.scala
@@ -23,7 +23,7 @@ class CatalogService(val environment: TouchPointEnvironment, jsonProvider: Catal
     sixWeeklyPriceList: Pricelist,
     catalogPrices: List[Pricelist]
   ) = {
-    Pricelist(sixWeeklyPriceList.productRatePlanId,
+    Pricelist(sixWeeklyPriceList.productRatePlanId, 0,
       catalogPrices.find(_.productRatePlanId == quarterlyId).map(_.prices).getOrElse(sixWeeklyPriceList.prices)
     )
   }

--- a/support-services/src/main/scala/com/gu/support/catalog/CatalogService.scala
+++ b/support-services/src/main/scala/com/gu/support/catalog/CatalogService.scala
@@ -23,7 +23,7 @@ class CatalogService(val environment: TouchPointEnvironment, jsonProvider: Catal
     sixWeeklyPriceList: Pricelist,
     catalogPrices: List[Pricelist]
   ) = {
-    Pricelist(sixWeeklyPriceList.productRatePlanId, 0,
+    Pricelist(sixWeeklyPriceList.productRatePlanId, sixWeeklyPriceList.savingVsRetail,
       catalogPrices.find(_.productRatePlanId == quarterlyId).map(_.prices).getOrElse(sixWeeklyPriceList.prices)
     )
   }

--- a/support-services/src/main/scala/com/gu/support/pricing/PriceSummary.scala
+++ b/support-services/src/main/scala/com/gu/support/pricing/PriceSummary.scala
@@ -6,7 +6,7 @@ import com.gu.support.promotions._
 
 case class PriceSummary(
   price: BigDecimal,
-  saving: Int,
+  savingVsRetail: Option[Int],
   currency: Currency,
   fixedTerm: Boolean,
   promotions: List[PromotionSummary]

--- a/support-services/src/main/scala/com/gu/support/pricing/PriceSummary.scala
+++ b/support-services/src/main/scala/com/gu/support/pricing/PriceSummary.scala
@@ -6,6 +6,7 @@ import com.gu.support.promotions._
 
 case class PriceSummary(
   price: BigDecimal,
+  saving: Int,
   currency: Currency,
   fixedTerm: Boolean,
   promotions: List[PromotionSummary]

--- a/support-services/src/main/scala/com/gu/support/pricing/PriceSummaryService.scala
+++ b/support-services/src/main/scala/com/gu/support/pricing/PriceSummaryService.scala
@@ -34,7 +34,7 @@ class PriceSummaryService(promotionService: PromotionService, catalogService: Ca
         val priceSummaries = for {
           productRatePlan <- getSupportedRatePlansForCountryGroup(productRatePlans, countryGroup)
           price <- filterCurrencies(catalogService.getPriceList(productRatePlan).map(_.prices), countryGroup)
-          saving <- catalogService.getPriceList(productRatePlan).map(_.saving)
+          saving <- catalogService.getPriceList(productRatePlan).map(_.savingVsRetail)
         } yield getPriceSummary(promotions, countryGroup, productRatePlan, price, saving)
         (keys, priceSummaries.toMap)
     }
@@ -50,7 +50,12 @@ class PriceSummaryService(promotionService: PromotionService, catalogService: Ca
       .getOrElse(Nil)
       .filter(price => countryGroup.supportedCurrencies.contains(price.currency))
 
-  private def getPriceSummary(promotions: List[PromotionWithCode], countryGroup: CountryGroup, productRatePlan: ProductRatePlan[Product], price: Price, saving: Int) = {
+  private def getPriceSummary(promotions: List[PromotionWithCode],
+    countryGroup: CountryGroup,
+    productRatePlan: ProductRatePlan[Product],
+    price: Price,
+    saving: Option[Int]
+  ) = {
     val promotionSummaries: List[PromotionSummary] = for {
       promotion <- promotions
       country <- countryGroup.defaultCountry.orElse(countryGroup.countries.headOption)

--- a/support-services/src/main/scala/com/gu/support/pricing/PriceSummaryService.scala
+++ b/support-services/src/main/scala/com/gu/support/pricing/PriceSummaryService.scala
@@ -34,7 +34,8 @@ class PriceSummaryService(promotionService: PromotionService, catalogService: Ca
         val priceSummaries = for {
           productRatePlan <- getSupportedRatePlansForCountryGroup(productRatePlans, countryGroup)
           price <- filterCurrencies(catalogService.getPriceList(productRatePlan).map(_.prices), countryGroup)
-        } yield getPriceSummary(promotions, countryGroup, productRatePlan, price)
+          saving <- catalogService.getPriceList(productRatePlan).map(_.saving)
+        } yield getPriceSummary(promotions, countryGroup, productRatePlan, price, saving)
         (keys, priceSummaries.toMap)
     }
     nestPriceLists(grouped)
@@ -49,7 +50,7 @@ class PriceSummaryService(promotionService: PromotionService, catalogService: Ca
       .getOrElse(Nil)
       .filter(price => countryGroup.supportedCurrencies.contains(price.currency))
 
-  private def getPriceSummary(promotions: List[PromotionWithCode], countryGroup: CountryGroup, productRatePlan: ProductRatePlan[Product], price: Price) = {
+  private def getPriceSummary(promotions: List[PromotionWithCode], countryGroup: CountryGroup, productRatePlan: ProductRatePlan[Product], price: Price, saving: Int) = {
     val promotionSummaries: List[PromotionSummary] = for {
       promotion <- promotions
       country <- countryGroup.defaultCountry.orElse(countryGroup.countries.headOption)
@@ -63,6 +64,7 @@ class PriceSummaryService(promotionService: PromotionService, catalogService: Ca
 
     price.currency -> PriceSummary(
       price.value,
+      saving,
       price.currency,
       productRatePlan.fixedTerm,
       promotionSummaries

--- a/support-services/src/test/scala/com/gu/support/catalog/CatalogServiceSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/catalog/CatalogServiceSpec.scala
@@ -55,7 +55,7 @@ class CatalogServiceSpec extends AsyncFlatSpec with Matchers {
     (for {
       voucherEveryday <- Paper.getProductRatePlan(PROD, Monthly, Collection, Everyday)
       priceList <- serviceWithFixtures.getPriceList(voucherEveryday)
-    } yield priceList.saving shouldBe 31).getOrElse(fail())
+    } yield priceList.savingVsRetail shouldBe Some(31)).getOrElse(fail())
 
   }
 }

--- a/support-services/src/test/scala/com/gu/support/catalog/CatalogServiceSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/catalog/CatalogServiceSpec.scala
@@ -3,9 +3,9 @@ package com.gu.support.catalog
 import com.gu.i18n.Currency.{GBP, USD}
 import com.gu.support.workers.{Annual, Monthly, Quarterly}
 import io.circe.parser._
-
 import CatalogServiceSpec.serviceWithFixtures
 import com.gu.support.config.TouchPointEnvironments.PROD
+import ophan.thrift.event.PrintProduct.VoucherEveryday
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -52,6 +52,12 @@ class CatalogServiceSpec extends AsyncFlatSpec with Matchers {
       RestOfWorld,
       NoProductOptions
     ) shouldBe Some(Price(325.20, USD))
+
+    (for {
+      voucherEveryday <- Paper.getProductRatePlan(PROD, Monthly, Collection, Everyday)
+      priceList <- serviceWithFixtures.getPriceList(voucherEveryday)
+    } yield priceList.saving shouldBe 31).getOrElse(fail())
+
   }
 }
 

--- a/support-services/src/test/scala/com/gu/support/catalog/CatalogServiceSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/catalog/CatalogServiceSpec.scala
@@ -5,7 +5,6 @@ import com.gu.support.workers.{Annual, Monthly, Quarterly}
 import io.circe.parser._
 import CatalogServiceSpec.serviceWithFixtures
 import com.gu.support.config.TouchPointEnvironments.PROD
-import ophan.thrift.event.PrintProduct.VoucherEveryday
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 

--- a/support-services/src/test/scala/com/gu/support/pricing/PriceSummaryServiceSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/pricing/PriceSummaryServiceSpec.scala
@@ -116,7 +116,7 @@ class PriceSummaryServiceSpec extends AsyncFlatSpec with Matchers {
   it should "find the retail saving for print products" in {
     val service = new PriceSummaryService(PromotionServiceSpec.serviceWithFixtures, CatalogServiceSpec.serviceWithFixtures)
     val prices = service.getPricesForCountryGroup(Paper, UK, Nil)
-    prices(Collection)(Sixday)(Monthly)(GBP).saving shouldBe 26
+    prices(Collection)(Sixday)(Monthly)(GBP).savingVsRetail shouldBe 26
     succeed
   }
 

--- a/support-services/src/test/scala/com/gu/support/pricing/PriceSummaryServiceSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/pricing/PriceSummaryServiceSpec.scala
@@ -113,6 +113,13 @@ class PriceSummaryServiceSpec extends AsyncFlatSpec with Matchers {
     getNumberOfDiscountedPeriods(Months.months(13), Annual) shouldBe 2
   }
 
+  it should "find the retail saving for print products" in {
+    val service = new PriceSummaryService(PromotionServiceSpec.serviceWithFixtures, CatalogServiceSpec.serviceWithFixtures)
+    val prices = service.getPricesForCountryGroup(Paper, UK, Nil)
+    prices(Collection)(Sixday)(Monthly)(GBP).saving shouldBe 26
+    succeed
+  }
+
   def checkPrice(discount: DiscountBenefit, original: BigDecimal, expected: BigDecimal, billingPeriod: BillingPeriod): Assertion =
     PriceSummaryService.getDiscountedPrice(Price(original, GBP), discount, billingPeriod).value shouldBe expected
 }

--- a/support-services/src/test/scala/com/gu/support/pricing/PriceSummaryServiceSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/pricing/PriceSummaryServiceSpec.scala
@@ -116,7 +116,7 @@ class PriceSummaryServiceSpec extends AsyncFlatSpec with Matchers {
   it should "find the retail saving for print products" in {
     val service = new PriceSummaryService(PromotionServiceSpec.serviceWithFixtures, CatalogServiceSpec.serviceWithFixtures)
     val prices = service.getPricesForCountryGroup(Paper, UK, Nil)
-    prices(Collection)(Sixday)(Monthly)(GBP).savingVsRetail shouldBe 26
+    prices(Collection)(Sixday)(Monthly)(GBP).savingVsRetail shouldBe Some(26)
     succeed
   }
 


### PR DESCRIPTION
## Why are you doing this?
The paper product page has various pieces of copy which show the savings a subscriber would make vs the retail price of the paper. These are currently set in code unlike the prices themselves which are stored in Zuora. This means that if we change the prices we also need to deploy a code change to update this copy.

It would be much easier if we specified the saving vs retail in Zuora as well so that we can change all price information in one place and have the site pick it up without a PR/deploy.

![support thegulocal com_uk_subscribe_paper](https://user-images.githubusercontent.com/181371/73551814-05d9a700-443f-11ea-9f98-038e7ccd1bc7.png)


[**Trello Card**](https://trello.com/c/cGKePEXi/2858-implement-print-price-rises-for-new-users-on-print)

