### PR TITLE
Bumping identity-auth-play

### DIFF
--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -29,7 +29,7 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-generic-extras" % circeVersion,
   "io.circe" %% "circe-parser" % circeVersion,
   "joda-time" % "joda-time" % "2.9.9",
-  "com.gu.identity" %% "identity-auth-play" % "3.192",
+  "com.gu.identity" %% "identity-auth-play" % "3.195",
   "com.gu" %% "identity-test-users" % "0.6",
   "com.google.guava" % "guava" % "25.0-jre",
   "com.netaporter" %% "scala-uri" % "0.4.16",


### PR DESCRIPTION
This bumps identity-auth-play to propagate a bump to http4s which has a ConnectionPool leak - see guardian/identity#1682 for more information

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com)

## Changes

* Change 1
* Change 2

## Screenshots

