### PR TITLE
Gw landing copy

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -3,6 +3,7 @@
 // ----- Imports ----- //
 
 import * as React from 'react';
+import type { Element } from 'react';
 import { Provider } from 'react-redux';
 import marked from 'marked';
 import DOMPurify from 'dompurify';
@@ -121,10 +122,15 @@ const getFirstParagraph = (promotionCopy: ?PromotionCopy) => {
     </LargeParagraph>);
 };
 
+const getRegionalCopyFor = (region: CountryGroupId): Element<'span'> => (region === GBPCountries ?
+  <span>Pause for thought with The Guardian&apos;s<br />essential news magazine</span> :
+  <span>Read The Guardian in print. <br /> Subscribe to The Guardian Weekly today</span>);
+
 const getCopy = (promotionCopy: Object, orderIsAGift: boolean): PageCopy => {
+  const currentRegion = detect();
   const defaultTitle = orderIsAGift ?
     <span>Give a gift that challenges<br />the status quo</span>
-    : <span>Pause for thought with The Guardian&apos;s<br />essential news magazine</span>;
+    : getRegionalCopyFor(currentRegion);
   return {
     title: promotionCopy && promotionCopy.title ? promotionCopy.title : defaultTitle,
     firstParagraph: getFirstParagraph(promotionCopy),

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -124,7 +124,7 @@ const getFirstParagraph = (promotionCopy: ?PromotionCopy) => {
 
 const getRegionalCopyFor = (region: CountryGroupId): Element<'span'> => (region === GBPCountries ?
   <span>Pause for thought with The Guardian&apos;s<br />essential news magazine</span> :
-  <span>Read The Guardian in print. <br /> Subscribe to The Guardian Weekly today</span>);
+  <span>Read The Guardian in print. <br className="gw-temp-break" /> Subscribe to The Guardian Weekly today</span>);
 
 const getCopy = (promotionCopy: Object, orderIsAGift: boolean): PageCopy => {
   const currentRegion = detect();

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -124,7 +124,7 @@ const getFirstParagraph = (promotionCopy: ?PromotionCopy) => {
 
 const getRegionalCopyFor = (region: CountryGroupId): Element<'span'> => (region === GBPCountries ?
   <span>Pause for thought with The Guardian&apos;s<br />essential news magazine</span> :
-  <span>Read The Guardian in print. <br className="gw-temp-break" /> Subscribe to The Guardian Weekly today</span>);
+  <span>Read The Guardian in print. Subscribe to<br className="gw-temp-break" />The Guardian Weekly today</span>);
 
 const getCopy = (promotionCopy: Object, orderIsAGift: boolean): PageCopy => {
   const currentRegion = detect();

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -208,11 +208,11 @@ const content = (
         <WeeklyForm />
         {!orderIsAGift &&
           <ProductPageInfoChip icon={<SvgGift />}>
-                Gifting is available
+            Gifting is available
           </ProductPageInfoChip>
         }
         <ProductPageInfoChip icon={<SvgInformation />}>
-              Delivery cost included. {!orderIsAGift && 'You can cancel your subscription at any time'}
+          Delivery cost included. {!orderIsAGift && 'You can cancel your subscription at any time'}
         </ProductPageInfoChip>
       </Content>
       <Content>

--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.scss
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.scss
@@ -105,3 +105,11 @@
 .component-button--with-margin-bottom {
   margin-bottom: 20px;
 }
+
+.gw-temp-break {
+
+  display: block;
+  @include mq($until: phablet) {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Why are you doing this?
On the 17 February, the Awareness team are activating a marketing campaign localised to Berlin, during the same time, Guardian Weekly will be refreshing much of it's off-platform marketing. To align with both strands of activity and maintain a coherent customer journey, the headlines on regional landing pages for GW have been updated.

[**Trello Card**](https://trello.com/c/VkNuKVGG/2851-customise-copy-on-non-uk-gw-landing-pages-copy-change-only)

## Changes

* Copy change for GW headline

Note from Lucy: I have updated the line-break for tablet plus view as reequesteed by @cloerose 

## Screenshots
Old Copy
![Screen Shot 2020-02-10 at 16 15 07](https://user-images.githubusercontent.com/45875444/74167732-8e66fd00-4c20-11ea-8a43-26c1cc9a6152.png)

New Copy
![Screen Shot 2020-02-17 at 12 28 58](https://user-images.githubusercontent.com/16781258/74654097-755ece80-5181-11ea-85a0-730e50e607cb.png)
