### PR TITLE
state/province form field not rendered for one off contributions

### DIFF
--- a/support-frontend/assets/helpers/formValidation.js
+++ b/support-frontend/assets/helpers/formValidation.js
@@ -54,11 +54,12 @@ export const checkAmountOrOtherAmount: (SelectedAmounts, OtherAmounts, Contribut
   return checkAmount(amt, countryGroupId, contributionType);
 };
 
-export const checkStateIfApplicable: ((string | null), CountryGroupId) => boolean = (
+export const checkStateIfApplicable: ((string | null), CountryGroupId, ContributionType) => boolean = (
   state: (string | null),
   countryGroupId: CountryGroupId,
+  contributionType: ContributionType,
 ) => {
-  if (countryGroupId === UnitedStates || countryGroupId === Canada) {
+  if (contributionType !== 'ONE_OFF' && (countryGroupId === UnitedStates || countryGroupId === Canada)) {
     return checkState(state);
   }
   return true;

--- a/support-frontend/assets/pages/contributions-landing/checkoutFormIsSubmittableActions.js
+++ b/support-frontend/assets/pages/contributions-landing/checkoutFormIsSubmittableActions.js
@@ -79,7 +79,7 @@ const getFormIsValid = (formIsValidParameters: FormIsValidParameters) => {
       true
   ) && checkEmail(email)
     && stripeCardFormOk
-    && checkStateIfApplicable(state, countryGroupId)
+    && checkStateIfApplicable(state, countryGroupId, contributionType)
     && checkAmountOrOtherAmount(selectedAmounts, otherAmounts, contributionType, countryGroupId);
 };
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionState.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionState.jsx
@@ -25,7 +25,7 @@ type PropTypes = {|
 
 const mapStateToProps = (state: State) => ({
   countryGroupId: state.common.internationalisation.countryGroupId,
-  contributionType: state.page.form.contributionType
+  contributionType: state.page.form.contributionType,
 });
 
 // ----- Render ----- //
@@ -64,17 +64,17 @@ const renderStatesField = (
 );
 
 
-//toDo change this function so it only appears on recurring....
+// toDo change this function so it only appears on recurring....
 function ContributionState(props: PropTypes) {
   const showError = !props.isValid && props.formHasBeenSubmitted;
-    switch (props.countryGroupId) {
-      case UnitedStates && props.contributionType !== 'ONE_OFF':
-        return renderStatesField(usStates, props.selectedState, props.onChange, showError, 'State');
-      case Canada && props.contributionType !== 'ONE_OFF':
-        return renderStatesField(caStates, props.selectedState, props.onChange, showError, 'Province');
-      default:
-        return null;
-    }
+  switch (props.countryGroupId) {
+    case UnitedStates && props.contributionType !== 'ONE_OFF':
+      return renderStatesField(usStates, props.selectedState, props.onChange, showError, 'State');
+    case Canada && props.contributionType !== 'ONE_OFF':
+      return renderStatesField(caStates, props.selectedState, props.onChange, showError, 'Province');
+    default:
+      return null;
+  }
 }
 
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionState.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionState.jsx
@@ -65,14 +65,18 @@ const renderStatesField = (
 
 function ContributionState(props: PropTypes) {
   const showError = !props.isValid && props.formHasBeenSubmitted;
-  switch (props.countryGroupId) {
-    case UnitedStates && props.contributionType !== 'ONE_OFF':
-      return renderStatesField(usStates, props.selectedState, props.onChange, showError, 'State');
-    case Canada && props.contributionType !== 'ONE_OFF':
-      return renderStatesField(caStates, props.selectedState, props.onChange, showError, 'Province');
-    default:
-      return null;
+  if (props.contributionType !== 'ONE_OFF') {
+    switch (props.countryGroupId) {
+      case UnitedStates:
+        return renderStatesField(usStates, props.selectedState, props.onChange, showError, 'State');
+      case Canada:
+        return renderStatesField(caStates, props.selectedState, props.onChange, showError, 'Province');
+      default:
+        return null;
+    }
   }
+
+  return null;
 }
 
 ContributionState.defaultProps = {

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionState.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionState.jsx
@@ -63,8 +63,6 @@ const renderStatesField = (
   </div>
 );
 
-
-// toDo change this function so it only appears on recurring....
 function ContributionState(props: PropTypes) {
   const showError = !props.isValid && props.formHasBeenSubmitted;
   switch (props.countryGroupId) {
@@ -76,7 +74,6 @@ function ContributionState(props: PropTypes) {
       return null;
   }
 }
-
 
 ContributionState.defaultProps = {
   onChange: false,

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionState.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionState.jsx
@@ -20,10 +20,12 @@ type PropTypes = {|
   onChange: (Event => void) | false,
   isValid: boolean,
   formHasBeenSubmitted: boolean,
+  contributionType: string,
 |};
 
 const mapStateToProps = (state: State) => ({
   countryGroupId: state.common.internationalisation.countryGroupId,
+  contributionType: state.page.form.contributionType
 });
 
 // ----- Render ----- //
@@ -61,16 +63,18 @@ const renderStatesField = (
   </div>
 );
 
+
+//toDo change this function so it only appears on recurring....
 function ContributionState(props: PropTypes) {
   const showError = !props.isValid && props.formHasBeenSubmitted;
-  switch (props.countryGroupId) {
-    case UnitedStates:
-      return renderStatesField(usStates, props.selectedState, props.onChange, showError, 'State');
-    case Canada:
-      return renderStatesField(caStates, props.selectedState, props.onChange, showError, 'Province');
-    default:
-      return null;
-  }
+    switch (props.countryGroupId) {
+      case UnitedStates && props.contributionType !== 'ONE_OFF':
+        return renderStatesField(usStates, props.selectedState, props.onChange, showError, 'State');
+      case Canada && props.contributionType !== 'ONE_OFF':
+        return renderStatesField(caStates, props.selectedState, props.onChange, showError, 'Province');
+      default:
+        return null;
+    }
 }
 
 

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -168,7 +168,7 @@ const updateState = (state: UsState | CaState | null): ((Function) => void) =>
   };
 
 const updateBillingCountry = (billingCountry: IsoCountry): Action =>
-    ({ type: 'UPDATE_BILLING_COUNTRY', billingCountry });
+  ({ type: 'UPDATE_BILLING_COUNTRY', billingCountry });
 
 const selectAmount = (amount: Amount | 'other', contributionType: ContributionType): ((Function) => void) =>
   (dispatch: Function): void => {

--- a/support-frontend/assets/pages/paper-subscription-landing/components/hero/campaignHeader.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/hero/campaignHeader.jsx
@@ -34,7 +34,7 @@ const Roundel = (props: { roundelCopy: string[] }) => (
       <div>
         {props.roundelCopy.map(copy => <span>{ copy }</span>)}
       </div>
-    </div>: null
+    </div> : null
 );
 
 const CampaignHeader = (props: PropTypes) => (

--- a/support-frontend/assets/pages/paper-subscription-landing/components/hero/discountCopy.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/hero/discountCopy.jsx
@@ -18,7 +18,7 @@ const discountCopy = (discountPercentage: number): DiscountCopy => (
     } :
     {
       roundel: [],
-      heading: `Save money with a subscription`,
+      heading: 'Save money with a subscription',
     }
 );
 


### PR DESCRIPTION
## Why are you doing this?

We currently do not send the state/province to payment API, instead we use the geo-IP header to determine the location.

As this appears to be sufficient for our reporting purposes, we should remove the field from the form as it should give increased conversion.


<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/LIej1lCY/1680-remove-the-state-field-from-the-form-for-single-contributions)


## Screenshots

![image](https://user-images.githubusercontent.com/30600967/74235589-49e26c80-4cc7-11ea-8020-a8fdafad4329.png)
