### PR TITLE
Post message to chat when post deployment tests fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,4 @@ before_cache:
   - find $HOME/.sbt -name "*.lock" -type f -delete -print
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" -type f -delete -print
 script: travis_retry 1 sbt ++$TRAVIS_SCALA_VERSION selenium:test
+after_failure: ./support-frontend/scripts/post_test_results_to_chat.sh

--- a/support-frontend/scripts/post_test_results_to_chat.sh
+++ b/support-frontend/scripts/post_test_results_to_chat.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+curl -X POST -H 'Content-Type: application/json' "${GOOGLE_CHAT_WEB_HOOK}" -d '{"text": " ❌ The post deployment tests for support frontend have failed! \n \n 👉 <https://travis-ci.org/guardian/support-frontend|Travis build> \n 🤖 <https://automate.browserstack.com/dashboard/v2/builds/31f35a1d9bccc9d45360aa7bfd651fcd9e1499d0|Browser stack test results> \n \n 📖 <https://github.com/guardian/support-frontend/wiki/Post-deployment-test-runbook|Check the runbook for a step by step guide>"}'


### PR DESCRIPTION
## Why are you doing this?

On the retro for our last incident we decided to try raising the visibility of when post deployment tests fail by posting it to the chat room (see https://docs.google.com/document/d/1OIiEfgEJ3Xw3_rnUt-kCIG0lFkLHBIJ7QqxtoGnXf9o/edit)

This is a PR to do just that! I found an easy way to do it on the travis side (rather than having to change prout, for instance), as there's a hook to run a bash script when a build fails.

I've also started writing a runbook alongside which is a total WIP https://github.com/guardian/support-frontend/wiki/Post-deployment-test-runbook

## Screenshots

![Test_-_Chat](https://user-images.githubusercontent.com/1672034/75034058-3fcd2480-54a4-11ea-9209-ae16eaeb0593.png)
