### PR TITLE
Update minimum pricing copy for paper+digital

### DIFF
--- a/support-frontend/assets/helpers/subscriptions.js
+++ b/support-frontend/assets/helpers/subscriptions.js
@@ -91,7 +91,7 @@ export const subscriptionPricesForDefaultBillingPeriod: {
     GBPCountries: 10.79,
   },
   PaperAndDigital: {
-    GBPCountries: 21.62,
+    GBPCountries: 21.99,
   },
   DailyEdition: {
     GBPCountries: 11.99,


### PR DESCRIPTION
## Why are you doing this?
Paper+Digital pricing information is still hard coded in the site rather than being fetched from the catalog so as the subs prices have now changed, we need to update the minimum price copy on the subs landing page.

[**Trello Card**](https://trello.com/c/vya1IuWF/2827-implement-print-price-rises-for-new-users-on-printdigital)


## Screenshots
### Before
<img width="1154" alt="Screen Shot 2020-02-24 at 13 11 28" src="https://user-images.githubusercontent.com/181371/75161691-23372380-5714-11ea-8242-0c3dfbaef3c9.png">
### After
<img width="1136" alt="Screen Shot 2020-02-24 at 14 44 46" src="https://user-images.githubusercontent.com/181371/75161745-3813b700-5714-11ea-8c43-80d538ea4842.png">


