### PR TITLE
Copy test for post contribution reminders test

### DIFF
--- a/support-frontend/assets/components/contributionsReminder/contributionsReminder.jsx
+++ b/support-frontend/assets/components/contributionsReminder/contributionsReminder.jsx
@@ -34,7 +34,6 @@ type StateTypes = {
   buttonState: ButtonState,
   selectedDate: string | null,
   selectedDateAsWord: string | null,
-  preselectedDateAsWord: string | null,
 }
 
 const mapStateToProps = state => ({
@@ -83,7 +82,6 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
     buttonState: 'initial',
     selectedDate: null,
     selectedDateAsWord: null,
-    preselectedDateAsWord: null,
   }
 
   componentDidMount = () => {
@@ -93,7 +91,6 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
     this.setState({
       selectedDate: firstOpt.timeStamp,
       selectedDateAsWord: firstOptAsWord,
-      preselectedDateAsWord: firstOptAsWord,
     });
   }
 
@@ -188,10 +185,6 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
                 this.requestIsPending();
 
                 trackComponentClick('reminder-test-link-clicked');
-
-                if (this.state.preselectedDateAsWord) {
-                  trackComponentClick(`reminder-test-preselected-date-${this.state.preselectedDateAsWord}`);
-                }
 
                 if (this.state.selectedDateAsWord) {
                   trackComponentClick(`reminder-test-date-${this.state.selectedDateAsWord}`);

--- a/support-frontend/assets/components/contributionsReminder/contributionsReminder.jsx
+++ b/support-frontend/assets/components/contributionsReminder/contributionsReminder.jsx
@@ -47,19 +47,19 @@ const mapStateToProps = state => ({
 const reminderDates: Array<ReminderDate> = [
   {
     dateName: 'June 2020',
-    control: 'June 2020',
+    control: 'June',
     extendedCopy: 'Three months (June)',
     timeStamp: '2020-06-01 00:00:00',
   },
   {
     dateName: 'September 2020',
-    control: 'September 2020',
-    extendedCopy: 'Three months (September)',
+    control: 'September',
+    extendedCopy: 'Six months (September)',
     timeStamp: '2020-09-01 00:00:00',
   },
   {
     dateName: 'December 2020',
-    control: 'December 2020',
+    control: 'December',
     extendedCopy: 'Nine months (December)',
     timeStamp: '2020-12-01 00:00:00',
   },
@@ -70,8 +70,6 @@ const reminderDates: Array<ReminderDate> = [
     timeStamp: '2021-03-01 00:00:00',
   },
 ];
-
-const randomIndex: number = Math.floor(Math.random() * (reminderDates.length));
 
 const trimAndDowncase = (word: string) => word.replace(/\s+/g, '').toLowerCase();
 // ----- Render ----- //
@@ -168,7 +166,7 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
                     text={reminderDate[postContributionReminderCopyTestVariant]}
                     name="reminder"
                     onChange={evt => this.setDateState(evt, reminderDate.timeStamp, dateWithoutSpace)}
-                    defaultChecked={index === randomIndex}
+                    defaultChecked={index === 0}
                   />
                 );
               })}

--- a/support-frontend/assets/components/contributionsReminder/contributionsReminder.jsx
+++ b/support-frontend/assets/components/contributionsReminder/contributionsReminder.jsx
@@ -11,42 +11,63 @@ import { logException } from 'helpers/logger';
 import { Fieldset } from 'components/forms/fieldset';
 import { RadioInput } from 'components/forms/customFields/radioInput';
 import { Label as FormLabel } from 'components/forms/label';
+import type { PostContributionReminderCopyTestVariants } from 'helpers/abTests/abtestDefinitions';
 
 // ----- Types ----- //
 type PropTypes = {
   email: string | null,
+  postContributionReminderCopyTestVariant: PostContributionReminderCopyTestVariants,
 }
 
+// JTL: NB "control" and "extendedCopy" are only for
+// postContributionReminderCopyTest and should be removed after this test
 type ReminderDate = {
   dateName: string,
+  control: string,
+  extendedCopy: string,
   timeStamp: string,
 }
 
 type ButtonState = 'initial' | 'pending' | 'success' | 'fail';
 
 type StateTypes = {
-  buttonState: ButtonState;
-  selectedDate: string | null;
+  buttonState: ButtonState,
+  selectedDate: string | null,
   selectedDateAsWord: string | null,
   preselectedDateAsWord: string | null,
 }
 
 const mapStateToProps = state => ({
   email: state.page.form.formData.email,
+  postContributionReminderCopyTestVariant: state.common.abParticipations.postContributionReminderCopyTest,
 });
 
+// JTL: NB "control" and "extendedCopy" are only for
+// postContributionReminderCopyTest and should be removed after this test
 const reminderDates: Array<ReminderDate> = [
   {
-    dateName: 'March 2020',
-    timeStamp: '2020-03-19 00:00:00',
-  },
-  {
     dateName: 'June 2020',
+    control: 'June 2020',
+    extendedCopy: 'Three months (June)',
     timeStamp: '2020-06-01 00:00:00',
   },
   {
+    dateName: 'September 2020',
+    control: 'September 2020',
+    extendedCopy: 'Three months (September)',
+    timeStamp: '2020-09-01 00:00:00',
+  },
+  {
     dateName: 'December 2020',
+    control: 'December 2020',
+    extendedCopy: 'Nine months (December)',
     timeStamp: '2020-12-01 00:00:00',
+  },
+  {
+    dateName: 'March 2021',
+    control: 'March 2021',
+    extendedCopy: 'One year (March 2021)',
+    timeStamp: '2021-03-01 00:00:00',
   },
 ];
 
@@ -57,6 +78,7 @@ const trimAndDowncase = (word: string) => word.replace(/\s+/g, '').toLowerCase()
 class ContributionsReminder extends Component<PropTypes, StateTypes> {
   static defaultProps = {
     email: null,
+    postContributionReminderCopyTestVariant: 'notintest',
   }
 
   state = {
@@ -67,13 +89,13 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
   }
 
   componentDidMount = () => {
-    const randomDate = reminderDates[randomIndex];
-    const randomDateAsWord = trimAndDowncase(randomDate.dateName);
+    const firstOpt = reminderDates[0];
+    const firstOptAsWord = trimAndDowncase(firstOpt.dateName);
 
     this.setState({
-      selectedDate: randomDate.timeStamp,
-      selectedDateAsWord: randomDateAsWord,
-      preselectedDateAsWord: randomDateAsWord,
+      selectedDate: firstOpt.timeStamp,
+      selectedDateAsWord: firstOptAsWord,
+      preselectedDateAsWord: firstOptAsWord,
     });
   }
 
@@ -122,9 +144,9 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
   }
 
   render() {
-    const { email } = this.props;
+    const { email, postContributionReminderCopyTestVariant } = this.props;
 
-    if (email) {
+    if (email && postContributionReminderCopyTestVariant !== 'notintest') {
       const isClicked = this.state.buttonState !== 'initial';
 
       return (
@@ -136,14 +158,14 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
             {'Lots of readers choose to make single contributions at various points in the year. Opt in to receive a reminder in case you would like to support our journalism again. This will be a single email, with no obligation.'}
           </p>
 
-          <FormLabel label="Remind me in:" htmlFor={null}>
+          <FormLabel label="I’d like to be reminded in:" htmlFor={null}>
             <Fieldset legend="Choose one of the following dates to receive your reminder:">
               {reminderDates.map((reminderDate, index) => {
                 const dateWithoutSpace = trimAndDowncase(reminderDate.dateName);
                 return (
                   <RadioInput
                     id={dateWithoutSpace}
-                    text={reminderDate.dateName}
+                    text={reminderDate[postContributionReminderCopyTestVariant]}
                     name="reminder"
                     onChange={evt => this.setDateState(evt, reminderDate.timeStamp, dateWithoutSpace)}
                     defaultChecked={index === randomIndex}

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -6,6 +6,7 @@ export type StripePaymentRequestButtonScaTestVariants = 'control' | 'sca' | 'not
 
 export type ChoiceCardsProductSetTestVariants = 'control' | 'circles' | 'rectangles';
 export type PersonalisedThankYouPageTestVariants = 'control' | 'personalised' | 'notintest';
+export type PostContributionReminderCopyTestVariants = 'control' | 'extendedCopy' | 'notintest';
 
 const contributionsLandingPageMatch = '/(uk|us|eu|au|ca|nz|int)/contribute(/.*)?$';
 const digitalLandingPageMatch = '/(uk|us|eu|au|ca|nz|int)/subscribe/digital(/.*)?$';
@@ -31,6 +32,28 @@ export const tests: Tests = {
     isActive: true,
     referrerControlled: false,
     seed: 1,
+    targetPage: contributionsLandingPageMatch,
+  },
+
+  postContributionReminderCopyTest: {
+    type: 'OTHER',
+    variants: [
+      {
+        id: 'control',
+      },
+      {
+        id: 'extendedCopy',
+      },
+    ],
+    audiences: {
+      ALL: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: true,
+    referrerControlled: false,
+    seed: 4,
     targetPage: contributionsLandingPageMatch,
   },
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.scss
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.scss
@@ -124,5 +124,9 @@
         margin-top: $gu-v-spacing / 2;
       }
     }
+
+    .component-radio-input__text {
+      font-weight: normal;
+    }
   }
 }


### PR DESCRIPTION
## Why are you doing this?
We want to know if we will increase our post-contribution reminder sign ups by saying for instance "three months (June)" or just "June" -- this test will require manual analysis at the end of the March

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/n0z8UcQs/1858-post-contribution-reminder-update-phase-3a)

## Screenshots
Control:
<img width="434" alt="reminder test control copy" src="https://user-images.githubusercontent.com/3300789/75368820-34219980-58ba-11ea-89c5-0a44e93f28a2.png">

Extended:
<img width="435" alt="reminder test extended copy" src="https://user-images.githubusercontent.com/3300789/75368831-37b52080-58ba-11ea-993b-f1cddb38e26f.png">
