### PR TITLE
Ds slow build investigation

### DIFF
--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -93,6 +93,4 @@ javaOptions in Universal ++= Seq(
 
 javaOptions in Test += "-Dconfig.file=test/selenium/conf/selenium-test.conf"
 
-// unmanagedSourceDirectories in Compile += (baseDirectory.value / "assets")
-
 addCommandAlias("devrun", "run 9210") // Chosen to not clash with other Guardian projects - we can't all use the Play default of 9000!

--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -93,6 +93,6 @@ javaOptions in Universal ++= Seq(
 
 javaOptions in Test += "-Dconfig.file=test/selenium/conf/selenium-test.conf"
 
-unmanagedSourceDirectories in Compile += (baseDirectory.value / "assets")
+// unmanagedSourceDirectories in Compile += (baseDirectory.value / "assets")
 
 addCommandAlias("devrun", "run 9210") // Chosen to not clash with other Guardian projects - we can't all use the Play default of 9000!

--- a/support-frontend/webpack.common.js
+++ b/support-frontend/webpack.common.js
@@ -41,6 +41,25 @@ const cssLoaders = [{
   },
 }];
 
+// Hide mini-css-extract-plugin spam logs
+class CleanUpStatsPlugin {
+  // eslint-disable-next-line class-methods-use-this
+  shouldPickStatChild(child) {
+    return child.name.indexOf('mini-css-extract-plugin') !== 0;
+  }
+
+  apply(compiler) {
+    compiler.hooks.done.tap('CleanUpStatsPlugin', (stats) => {
+      const { children } = stats.compilation;
+      if (Array.isArray(children)) {
+        // eslint-disable-next-line no-param-reassign
+        stats.compilation.children = children
+          .filter(child => this.shouldPickStatChild(child));
+      }
+    });
+  }
+}
+
 module.exports = (cssFilename, outputFilename, minimizeCss) => ({
   plugins: [
     new ManifestPlugin({
@@ -61,6 +80,7 @@ module.exports = (cssFilename, outputFilename, minimizeCss) => ({
       },
       canPrint: true,
     })] : []),
+    new CleanUpStatsPlugin(),
   ],
 
   context: path.resolve(__dirname, 'assets'),

--- a/support-frontend/webpack.dev.js
+++ b/support-frontend/webpack.dev.js
@@ -4,7 +4,7 @@ const common = require('./webpack.common.js');
 
 module.exports = merge(common('[name].css', '[name].js', false), {
   mode: 'development',
-  devtool: 'inline-source-map',
+  devtool: 'cheap-module-eval-source-map',
   devServer: {
     disableHostCheck: true,
     proxy: {


### PR DESCRIPTION
## Why are you doing this?

Over the last 5 months the dev team has experienced unusually slow rebuild of assets e.g. changing one word in a string would result in a 30 second reload as apposed to a 2 second reload.

The problem was the the play app would recompile with every asset change, this is unnecessary because all the assets are served from the node.js `webpack-dev-server`. The reload would wait for the recompile of the play app which would take 30 seconds or so, then the page could render

The reason for the recompile, was a line which referred to `unmanagedSourceDirectories` instructing sbt that the **assets** folder was a source director, this meant that every time a file in the assets folder changed the *play app* would see that change and trigger an auto-reload. 

When the browser requested the new files during the auto-reload it would have to wait for the recompile to complete before it could receive the data to render the page.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/ajxSMqe4/2865-watch-refresh-cycle-is-very-slow)

## Changes

* Removed `unmanagedSourceDirectories` from sbt
* Removed unnecessary Mini CSS logs (The solution originates from webpack-contrib/mini-css-extract-plugin#168)
* changed source map type for faster dev builds ([documentation](https://webpack.js.org/configuration/devtool/#development))

## Screenshots

N/A


