### PR TITLE
DisplayName changes

### DIFF
--- a/support-frontend/app/controllers/CreateSubscription.scala
+++ b/support-frontend/app/controllers/CreateSubscription.scala
@@ -94,7 +94,7 @@ class CreateSubscription(
       // TODO: in a subsequent PR set these values based on the respective user.
       allowThirdPartyMail = false,
       allowGURelatedMail = false,
-      isTestUser = testUsers.isTestUser(user.publicFields.displayName),
+      isTestUser = testUsers.isTestUser(user.publicFields.username),
       deliveryInstructions = request.deliveryInstructions
     )
   }

--- a/support-frontend/app/controllers/DigitalSubscription.scala
+++ b/support-frontend/app/controllers/DigitalSubscription.scala
@@ -107,7 +107,7 @@ class DigitalSubscription(
     val js = "digitalSubscriptionCheckoutPage.js"
     val css = "digitalSubscriptionCheckoutPage.css"
     val csrf = CSRF.getToken.value
-    val uatMode = testUsers.isTestUser(idUser.publicFields.displayName)
+    val uatMode = testUsers.isTestUser(idUser.publicFields.username)
     val promoCodes = request.queryString.get("promoCode").map(_.toList).getOrElse(Nil)
 
     subscriptionCheckout(

--- a/support-frontend/app/controllers/PaperSubscription.scala
+++ b/support-frontend/app/controllers/PaperSubscription.scala
@@ -87,7 +87,7 @@ class PaperSubscription(
     val js = "paperSubscriptionCheckoutPage.js"
     val css = "paperSubscriptionCheckoutPage.css"
     val csrf = CSRF.getToken.value
-    val uatMode = testUsers.isTestUser(idUser.publicFields.displayName)
+    val uatMode = testUsers.isTestUser(idUser.publicFields.username)
     val promoCodes = request.queryString.get("promoCode").map(_.toList).getOrElse(Nil)
 
     subscriptionCheckout(

--- a/support-frontend/app/controllers/RegularContributions.scala
+++ b/support-frontend/app/controllers/RegularContributions.scala
@@ -130,7 +130,7 @@ class RegularContributions(
       // TODO: in a subsequent PR set these values based on the respective user.
       allowThirdPartyMail = false,
       allowGURelatedMail = false,
-      isTestUser = testUsers.isTestUser(user.publicFields.displayName)
+      isTestUser = testUsers.isTestUser(user.publicFields.username)
     )
   }
 

--- a/support-frontend/app/controllers/WeeklySubscription.scala
+++ b/support-frontend/app/controllers/WeeklySubscription.scala
@@ -64,7 +64,7 @@ class WeeklySubscription(
     val js = "weeklySubscriptionCheckoutPage.js"
     val css = "weeklySubscriptionCheckoutPage.css"
     val csrf = CSRF.getToken.value
-    val uatMode = testUsers.isTestUser(idUser.publicFields.displayName)
+    val uatMode = testUsers.isTestUser(idUser.publicFields.username)
     val defaultPromos = if (orderIsAGift) List("GW20GIFT1Y") else List(GuardianWeekly.AnnualPromoCode, GuardianWeekly.SixForSixPromoCode)
     val promoCodes = request.queryString.get("promoCode").map(_.toList).getOrElse(Nil) ++ defaultPromos
 

--- a/support-frontend/app/models/identity/requests/CreateGuestAccountRequestBody.scala
+++ b/support-frontend/app/models/identity/requests/CreateGuestAccountRequestBody.scala
@@ -1,7 +1,6 @@
 package models.identity.requests
 
 import akka.util.ByteString
-import com.gu.identity.model.PublicFields
 import play.api.libs.json.{Json, Writes}
 import play.api.libs.ws.{BodyWritable, InMemoryBody}
 
@@ -10,18 +9,13 @@ import play.api.libs.ws.{BodyWritable, InMemoryBody}
 // Example request:
 // =================
 // {
-//   "email": "a@b.com",
-//   "publicFields": {
-//     "displayName": "a"
-//   }
+//   "email": "a@b.com"
 // }
-case class CreateGuestAccountRequestBody(primaryEmailAddress: String, publicFields: PublicFields)
+case class CreateGuestAccountRequestBody(primaryEmailAddress: String)
 object CreateGuestAccountRequestBody {
 
-  def guestDisplayName(email: String): String = email.split("@").headOption.getOrElse("Guest User")
-
   def fromEmail(email: String): CreateGuestAccountRequestBody =
-    CreateGuestAccountRequestBody(email, PublicFields(displayName = Some(guestDisplayName(email))))
+    CreateGuestAccountRequestBody(email)
 
   implicit val writesCreateGuestAccountRequestBody: Writes[CreateGuestAccountRequestBody] = {
     import com.gu.identity.model.play.WritesInstances.publicFieldsWrites

--- a/support-frontend/app/services/AuthenticationService.scala
+++ b/support-frontend/app/services/AuthenticationService.scala
@@ -70,7 +70,7 @@ object AsyncAuthenticationService {
       case UserCredentials.SCGUUCookie(value) => AccessCredentials.Cookies(scGuU = value)
       case UserCredentials.CryptoAccessToken(value, _) => AccessCredentials.Token(tokenText = value)
     }
-    AuthenticatedIdUser(accessCredentials, IdMinimalUser(user.id, user.publicFields.displayName))
+    AuthenticatedIdUser(accessCredentials, IdMinimalUser(user.id, user.publicFields.username.orElse(user.privateFields.firstName)))
   }
 
   // Logs failure to authenticate a user.

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -36,7 +36,7 @@
     window.guardian.user = {
       id: "@user.id",
       email: "@user.primaryEmailAddress",
-      @user.publicFields.displayName.map { displayName =>
+      @user.publicFields.username.orElse(user.privateFields.firstName).map { displayName =>
         displayName: "@displayName",
       }
       @for(firstName <- user.privateFields.firstName; lastName <- user.privateFields.secondName) {

--- a/support-frontend/test/models/identity/requests/CreateGuestAccountRequestBodyTest.scala
+++ b/support-frontend/test/models/identity/requests/CreateGuestAccountRequestBodyTest.scala
@@ -13,7 +13,7 @@ class CreateGuestAccountRequestBodyTest extends AnyWordSpec with Matchers {
       val body = CreateGuestAccountRequestBody.fromEmail("test.user@theguardian.com")
 
       Json.toJson(body).toString shouldEqual
-        """{"primaryEmailAddress":"test.user@theguardian.com","publicFields":{"displayName":"test.user"}}"""
+        """{"primaryEmailAddress":"test.user@theguardian.com"}"""
     }
   }
 }


### PR DESCRIPTION
## Why are you doing this?

we are deprecating identity displayName. clients will now derive display name from username and firstname

To maintain the current test user flow, the first name of a test user is propagated to the username. Then username can be used to identify if a user is a test user.

https://github.com/guardian/identity/pull/1695

## Changes

* use username to determine if test user
* derive the displayName field from identity username falling back to the first name
