### PR TITLE
Add social images for subscription landing pages

### DIFF
--- a/support-frontend/app/controllers/DigitalSubscription.scala
+++ b/support-frontend/app/controllers/DigitalSubscription.scala
@@ -63,9 +63,7 @@ class DigitalSubscription(
       "en" -> buildCanonicalDigitalSubscriptionLink("int")
     )
     val productPrices = priceSummaryServiceProvider.forUser(false).getPrices(DigitalPack, promoCodes)
-    //noinspection ScalaStyle
-    val shareImageUrl =
-      Some("https://i.guim.co.uk/img/media/1033800a75851058d619bc0519b0b7b48a53dcf5/0_0_1200_1200/1200.jpg?width=1200&height=1200&quality=85&auto=format&fit=crop&s=0d50dd49d1fedeacff8a3e437332c2bf")
+    val shareImageUrl = Some("https://i.guim.co.uk/img/media/1033800a75851058d619bc0519b0b7b48a53dcf5/0_0_1200_1200/1200.jpg?width=1200&height=1200&quality=85&auto=format&fit=crop&s=0d50dd49d1fedeacff8a3e437332c2bf") // scalastyle:ignore
 
     Ok(views.html.main(
       title = title,

--- a/support-frontend/app/controllers/DigitalSubscription.scala
+++ b/support-frontend/app/controllers/DigitalSubscription.scala
@@ -63,9 +63,21 @@ class DigitalSubscription(
       "en" -> buildCanonicalDigitalSubscriptionLink("int")
     )
     val productPrices = priceSummaryServiceProvider.forUser(false).getPrices(DigitalPack, promoCodes)
+    //noinspection ScalaStyle
+    val shareImageUrl =
+      Some("https://i.guim.co.uk/img/media/1033800a75851058d619bc0519b0b7b48a53dcf5/0_0_1200_1200/1200.jpg?width=1200&height=1200&quality=85&auto=format&fit=crop&s=0d50dd49d1fedeacff8a3e437332c2bf")
 
     Ok(views.html.main(
-      title, mainElement, js, css, fontLoaderBundle, description, canonicalLink, hrefLangLinks
+      title = title,
+      mainElement = mainElement,
+      mainJsBundle = js,
+      mainStyleBundle = css,
+      fontLoaderBundle = fontLoaderBundle,
+      description = description,
+      canonicalLink = canonicalLink,
+      hrefLangLinks = hrefLangLinks,
+      shareImageUrl = shareImageUrl,
+      shareUrl = canonicalLink
     ) {
       Html(s"""<script type="text/javascript">window.guardian.productPrices = ${outputJson(productPrices)}</script>""")
     }).withSettingsSurrogateKey

--- a/support-frontend/app/controllers/PaperSubscription.scala
+++ b/support-frontend/app/controllers/PaperSubscription.scala
@@ -61,8 +61,21 @@ class PaperSubscription(
     val description = stringsConfig.paperLandingDescription
     val promoCodes = request.queryString.get("promoCode").map(_.toList).getOrElse(Nil) :+ "SEP2512VHD"
     val productPrices = priceSummaryServiceProvider.forUser(false).getPrices(Paper, promoCodes)
+    //noinspection ScalaStyle
+    val shareImageUrl =
+      Some("https://i.guim.co.uk/img/media/0a1ffb0ec7e4dbbab40421b74e4bcf5d628f4708/0_0_1200_1200/1200.jpg?width=1200&height=1200&quality=85&auto=format&fit=crop&s=c6c7f5b373a1ae54bc66c876a9a60031")
 
-    Ok(views.html.main(title, mainElement, js, css, fontLoaderBundle, description, canonicalLink){
+    Ok(views.html.main(
+      title = title,
+      mainElement = mainElement,
+      mainJsBundle = js,
+      mainStyleBundle = css,
+      fontLoaderBundle = fontLoaderBundle,
+      description = description,
+      canonicalLink = canonicalLink,
+      shareImageUrl = shareImageUrl,
+      shareUrl = canonicalLink
+    ){
       Html(s"""<script type="text/javascript">window.guardian.productPrices = ${outputJson(productPrices)}</script>""")
     }).withSettingsSurrogateKey
   }

--- a/support-frontend/app/controllers/PaperSubscription.scala
+++ b/support-frontend/app/controllers/PaperSubscription.scala
@@ -61,9 +61,7 @@ class PaperSubscription(
     val description = stringsConfig.paperLandingDescription
     val promoCodes = request.queryString.get("promoCode").map(_.toList).getOrElse(Nil) :+ "SEP2512VHD"
     val productPrices = priceSummaryServiceProvider.forUser(false).getPrices(Paper, promoCodes)
-    //noinspection ScalaStyle
-    val shareImageUrl =
-      Some("https://i.guim.co.uk/img/media/0a1ffb0ec7e4dbbab40421b74e4bcf5d628f4708/0_0_1200_1200/1200.jpg?width=1200&height=1200&quality=85&auto=format&fit=crop&s=c6c7f5b373a1ae54bc66c876a9a60031")
+    val shareImageUrl = Some("https://i.guim.co.uk/img/media/0a1ffb0ec7e4dbbab40421b74e4bcf5d628f4708/0_0_1200_1200/1200.jpg?width=1200&height=1200&quality=85&auto=format&fit=crop&s=c6c7f5b373a1ae54bc66c876a9a60031") // scalastyle:ignore
 
     Ok(views.html.main(
       title = title,

--- a/support-frontend/app/controllers/Promotions.scala
+++ b/support-frontend/app/controllers/Promotions.scala
@@ -37,7 +37,7 @@ class Promotions(
     maybePromotionTerms.fold(NotFound("Invalid promo code")
     ) { promotionTerms =>
       val productLandingPage = promotionTerms.product match {
-        case GuardianWeekly => routes.Subscriptions.weeklyGeoRedirect(promotionTerms.isGift).url
+        case GuardianWeekly => routes.WeeklySubscription.weeklyGeoRedirect(promotionTerms.isGift).url
         case DigitalPack => routes.DigitalSubscription.digitalGeoRedirect().url
         case Paper => routes.PaperSubscription.paper(false).url
       }

--- a/support-frontend/app/controllers/Subscriptions.scala
+++ b/support-frontend/app/controllers/Subscriptions.scala
@@ -103,6 +103,17 @@ class Subscriptions(
     }).withSettingsSurrogateKey
   }
 
+  val weeklyHrefLangLinks: Map[String, String] =
+    Map(
+      "en-us" -> buildCanonicalWeeklySubscriptionLink("us"),
+      "en-gb" -> buildCanonicalWeeklySubscriptionLink("uk"),
+      "en-au" -> buildCanonicalWeeklySubscriptionLink("au"),
+      "en-nz" -> buildCanonicalWeeklySubscriptionLink("nz"),
+      "en-ca" -> buildCanonicalWeeklySubscriptionLink("ca"),
+      "en" -> buildCanonicalWeeklySubscriptionLink("int"),
+      "en" -> buildCanonicalWeeklySubscriptionLink("eu")
+    )
+
   def weeklyGeoRedirect(orderIsAGift: Boolean = false): Action[AnyContent] = geoRedirect(
     if (orderIsAGift) "subscribe/weekly/gift" else "subscribe/weekly"
   )
@@ -132,16 +143,22 @@ class Subscriptions(
         .forUser(false), stage)
         .getCopyForPromoCode(promoCode, GuardianWeekly, country)
     )
-    val hrefLangLinks = Map(
-      "en-us" -> buildCanonicalWeeklySubscriptionLink("us"),
-      "en-gb" -> buildCanonicalWeeklySubscriptionLink("uk"),
-      "en-au" -> buildCanonicalWeeklySubscriptionLink("au"),
-      "en-nz" -> buildCanonicalWeeklySubscriptionLink("nz"),
-      "en-ca" -> buildCanonicalWeeklySubscriptionLink("ca"),
-      "en" -> buildCanonicalWeeklySubscriptionLink("int"),
-      "en" -> buildCanonicalWeeklySubscriptionLink("eu")
-    )
-    Ok(views.html.main(title, mainElement, js, css, fontLoaderBundle, description, canonicalLink, hrefLangLinks){
+    //noinspection ScalaStyle
+    val shareImageUrl =
+      Some("https://i.guim.co.uk/img/media/00cb294c1f1e5140c63008d7a55b105ef2a786e6/0_0_1200_1200/1200.jpg?width=1200&height=1200&quality=85&auto=format&fit=crop&s=0034a6a7408ca4d162620f2c8b6bf2b9")
+
+    Ok(views.html.main(
+      title = title,
+      mainElement = mainElement,
+      mainJsBundle = js,
+      mainStyleBundle = css,
+      fontLoaderBundle = fontLoaderBundle,
+      description = description,
+      canonicalLink = canonicalLink,
+      hrefLangLinks = weeklyHrefLangLinks,
+      shareImageUrl = shareImageUrl,
+      shareUrl = canonicalLink
+    ){
       Html(
         s"""<script type="text/javascript">
               window.guardian.productPrices = ${outputJson(productPrices)}

--- a/support-frontend/app/controllers/Subscriptions.scala
+++ b/support-frontend/app/controllers/Subscriptions.scala
@@ -3,15 +3,11 @@ package controllers
 import actions.CustomActionBuilders
 import admin.settings.{AllSettings, AllSettingsProvider, SettingsSurrogateKeySyntax}
 import assets.{AssetsResolver, RefPath, StyleContent}
-import com.gu.i18n.Country.UK
 import com.gu.i18n.CountryGroup
 import com.gu.i18n.Currency.GBP
-import com.gu.support.catalog
-import com.gu.support.catalog.{Collection, DigitalPack, Domestic, GuardianWeekly, NoFulfilmentOptions, NoProductOptions, Paper, Sunday}
-import com.gu.support.config.Stage
-import com.gu.support.encoding.CustomCodecs._
-import com.gu.support.pricing.{PriceSummary, PriceSummaryServiceProvider, ProductPrices}
-import com.gu.support.promotions.{ProductPromotionCopy, PromotionCopy, PromotionServiceProvider}
+import com.gu.support.catalog._
+import com.gu.support.encoding.Codec.deriveCodec
+import com.gu.support.pricing.{PriceSummary, PriceSummaryServiceProvider}
 import com.gu.support.workers.{Monthly, Quarterly}
 import config.StringsConfig
 import lib.RedirectWithEncodedQueryString
@@ -20,7 +16,6 @@ import play.twirl.api.Html
 import services.IdentityService
 import views.EmptyDiv
 import views.ViewHelpers.outputJson
-import com.gu.support.encoding.Codec.deriveCodec
 
 import scala.concurrent.ExecutionContext
 

--- a/support-frontend/app/controllers/WeeklySubscription.scala
+++ b/support-frontend/app/controllers/WeeklySubscription.scala
@@ -5,18 +5,22 @@ import admin.settings.{AllSettings, AllSettingsProvider, SettingsSurrogateKeySyn
 import assets.{AssetsResolver, RefPath, StyleContent}
 import cats.implicits._
 import com.gu.googleauth.AuthAction
+import com.gu.i18n.Country.UK
+import com.gu.i18n.CountryGroup
 import com.gu.identity.model.{User => IdUser}
 import com.gu.monitoring.SafeLogger
 import com.gu.monitoring.SafeLogger._
 import com.gu.support.catalog.GuardianWeekly
-import com.gu.support.config.{PayPalConfigProvider, StripeConfigProvider}
+import com.gu.support.config.{PayPalConfigProvider, Stage, StripeConfigProvider}
 import com.gu.support.pricing.PriceSummaryServiceProvider
+import com.gu.support.promotions.{ProductPromotionCopy, PromotionServiceProvider}
 import config.StringsConfig
 import play.api.libs.circe.Circe
 import play.api.mvc._
 import play.twirl.api.Html
 import services.{IdentityService, TestUserService}
 import views.EmptyDiv
+import views.ViewHelpers.outputJson
 import views.html.helper.CSRF
 import views.html.subscriptionCheckout
 
@@ -25,6 +29,7 @@ import scala.concurrent.{ExecutionContext, Future}
 class WeeklySubscription(
   authAction: AuthAction[AnyContent],
   priceSummaryServiceProvider: PriceSummaryServiceProvider,
+  promotionServiceProvider: PromotionServiceProvider,
   val assets: AssetsResolver,
   val actionRefiners: CustomActionBuilders,
   identityService: IdentityService,
@@ -36,12 +41,76 @@ class WeeklySubscription(
   settingsProvider: AllSettingsProvider,
   val supportUrl: String,
   fontLoaderBundle: Either[RefPath, StyleContent],
-  stripeSetupIntentEndpoint: String
+  stripeSetupIntentEndpoint: String,
+  stage: Stage
 )(implicit val ec: ExecutionContext) extends AbstractController(components) with GeoRedirect with Circe with CanonicalLinks with SettingsSurrogateKeySyntax {
 
   import actionRefiners._
 
   implicit val a: AssetsResolver = assets
+
+  val weeklyHrefLangLinks: Map[String, String] =
+    Map(
+      "en-us" -> buildCanonicalWeeklySubscriptionLink("us"),
+      "en-gb" -> buildCanonicalWeeklySubscriptionLink("uk"),
+      "en-au" -> buildCanonicalWeeklySubscriptionLink("au"),
+      "en-nz" -> buildCanonicalWeeklySubscriptionLink("nz"),
+      "en-ca" -> buildCanonicalWeeklySubscriptionLink("ca"),
+      "en" -> buildCanonicalWeeklySubscriptionLink("int"),
+      "en" -> buildCanonicalWeeklySubscriptionLink("eu")
+    )
+
+  def weeklyGeoRedirect(orderIsAGift: Boolean = false): Action[AnyContent] = geoRedirect(
+    if (orderIsAGift) "subscribe/weekly/gift" else "subscribe/weekly"
+  )
+
+  def weekly(countryCode: String, orderIsAGift: Boolean): Action[AnyContent] = CachedAction() { implicit request =>
+    implicit val settings: AllSettings = settingsProvider.getAllSettings()
+    val title = if (orderIsAGift) "The Guardian Weekly Gift Subscription | The Guardian" else "The Guardian Weekly Subscriptions | The Guardian"
+    val mainElement = EmptyDiv("weekly-landing-page-" + countryCode)
+    val js = Left(RefPath("weeklySubscriptionLandingPage.js"))
+    val css = Left(RefPath("weeklySubscriptionLandingPage.css"))
+    val description = stringsConfig.weeklyLandingDescription
+    val canonicalLink = Some(buildCanonicalWeeklySubscriptionLink("uk"))
+    val defaultPromos = if (orderIsAGift) List("GW20GIFT1Y") else List(GuardianWeekly.AnnualPromoCode, GuardianWeekly.SixForSixPromoCode)
+    val queryPromos = request.queryString.get("promoCode").map(_.toList).getOrElse(Nil)
+    val promoCodes = defaultPromos ++ queryPromos
+    val productPrices = priceSummaryServiceProvider.forUser(false).getPrices(GuardianWeekly, promoCodes, orderIsAGift)
+    // To see if there is any promotional copy in place for this page we need to get a country in the current region (country group)
+    // this is because promotions apply to countries not regions. We can use any country however because the promo tool UI only deals
+    // with regions and then adds all the countries for that region to the promotion
+    val country = (for {
+      countryGroup <- CountryGroup.byId(countryCode)
+      country <- countryGroup.countries.headOption
+    } yield country).getOrElse(UK)
+
+    val maybePromotionCopy = queryPromos.headOption.flatMap(promoCode =>
+      ProductPromotionCopy(promotionServiceProvider
+        .forUser(false), stage)
+        .getCopyForPromoCode(promoCode, GuardianWeekly, country)
+    )
+    val shareImageUrl = Some("https://i.guim.co.uk/img/media/00cb294c1f1e5140c63008d7a55b105ef2a786e6/0_0_1200_1200/1200.jpg?width=1200&height=1200&quality=85&auto=format&fit=crop&s=0034a6a7408ca4d162620f2c8b6bf2b9") // scalastyle:ignore
+
+    Ok(views.html.main(
+      title = title,
+      mainElement = mainElement,
+      mainJsBundle = js,
+      mainStyleBundle = css,
+      fontLoaderBundle = fontLoaderBundle,
+      description = description,
+      canonicalLink = canonicalLink,
+      hrefLangLinks = weeklyHrefLangLinks,
+      shareImageUrl = shareImageUrl,
+      shareUrl = canonicalLink
+    ){
+      Html(
+        s"""<script type="text/javascript">
+              window.guardian.productPrices = ${outputJson(productPrices)}
+              window.guardian.promotionCopy = ${outputJson(maybePromotionCopy)}
+              window.guardian.orderIsAGift = $orderIsAGift
+            </script>""")
+    }).withSettingsSurrogateKey
+  }
 
   def displayForm(orderIsAGift: Boolean): Action[AnyContent] = authenticatedAction(subscriptionsClientId).async { implicit request =>
       implicit val settings: AllSettings = settingsProvider.getAllSettings()

--- a/support-frontend/app/controllers/WeeklySubscription.scala
+++ b/support-frontend/app/controllers/WeeklySubscription.scala
@@ -12,6 +12,7 @@ import com.gu.monitoring.SafeLogger
 import com.gu.monitoring.SafeLogger._
 import com.gu.support.catalog.GuardianWeekly
 import com.gu.support.config.{PayPalConfigProvider, Stage, StripeConfigProvider}
+import com.gu.support.encoding.CustomCodecs._
 import com.gu.support.pricing.PriceSummaryServiceProvider
 import com.gu.support.promotions.{ProductPromotionCopy, PromotionServiceProvider}
 import config.StringsConfig

--- a/support-frontend/app/views/main.scala.html
+++ b/support-frontend/app/views/main.scala.html
@@ -32,7 +32,10 @@
       </script>
     }
 
+    <meta property="og:type" content="website" />
     <meta property="twitter:card" content="summary" />
+    <meta property="fb:app_id" content="180444840287" />
+
 
     @description.map { definedDescription =>
       <meta name="description" content="@definedDescription" />

--- a/support-frontend/app/views/main.scala.html
+++ b/support-frontend/app/views/main.scala.html
@@ -32,6 +32,8 @@
       </script>
     }
 
+    <meta property="twitter:card" content="summary" />
+
     @description.map { definedDescription =>
       <meta name="description" content="@definedDescription" />
       <meta property="og:description" content="@definedDescription" />

--- a/support-frontend/app/wiring/Controllers.scala
+++ b/support-frontend/app/wiring/Controllers.scala
@@ -43,14 +43,12 @@ trait Controllers {
     actionRefiners,
     identityService,
     priceSummaryServiceProvider,
-    promotionServiceProvider,
     assetsResolver,
     controllerComponents,
     stringsConfig,
     allSettingsProvider,
     appConfig.supportUrl,
-    fontLoader,
-    appConfig.stage
+    fontLoader
   )
 
   lazy val digitalPackController = new DigitalSubscription(

--- a/support-frontend/app/wiring/Controllers.scala
+++ b/support-frontend/app/wiring/Controllers.scala
@@ -89,6 +89,7 @@ trait Controllers {
   lazy val weeklyController = new WeeklySubscription(
     authAction,
     priceSummaryServiceProvider,
+    promotionServiceProvider,
     assetsResolver,
     actionRefiners,
     identityService,
@@ -100,7 +101,8 @@ trait Controllers {
     allSettingsProvider,
     appConfig.supportUrl,
     fontLoader,
-    appConfig.stripeIntentUrl
+    appConfig.stripeIntentUrl,
+    appConfig.stage
   )
 
   lazy val createSubscriptionController = new CreateSubscription(

--- a/support-frontend/conf/routes
+++ b/support-frontend/conf/routes
@@ -89,13 +89,13 @@ GET  /$country<(uk|us|au|eu|int|nz|ca)>/subscribe/digital/checkout controllers.A
 GET  /subscribe/digital/checkout                                   controllers.DigitalSubscription.displayForm()
 GET  /subscribe/digital/checkout/thankyou-existing                 controllers.DigitalSubscription.displayThankYouExisting()
 
-GET  /weekly                                                       controllers.Subscriptions.weeklyGeoRedirect(orderIsAGift: Boolean = false)
-GET  /subscribe/weekly                                             controllers.Subscriptions.weeklyGeoRedirect(orderIsAGift: Boolean = false)
-GET  /subscribe/weekly/gift                                        controllers.Subscriptions.weeklyGeoRedirect(orderIsAGift: Boolean = true)
+GET  /weekly                                                       controllers.WeeklySubscription.weeklyGeoRedirect(orderIsAGift: Boolean = false)
+GET  /subscribe/weekly                                             controllers.WeeklySubscription.weeklyGeoRedirect(orderIsAGift: Boolean = false)
+GET  /subscribe/weekly/gift                                        controllers.WeeklySubscription.weeklyGeoRedirect(orderIsAGift: Boolean = true)
 GET  /subscribe/weekly/checkout                                    controllers.WeeklySubscription.displayForm(orderIsAGift: Boolean = false)
 GET  /subscribe/weekly/checkout/gift                               controllers.WeeklySubscription.displayForm(orderIsAGift: Boolean = true)
-GET  /$country<(uk|us|au|int|nz|ca|eu)>/subscribe/weekly           controllers.Subscriptions.weekly(country: String, orderIsAGift: Boolean = false)
-GET  /$country<(uk|us|au|int|nz|ca|eu)>/subscribe/weekly/gift      controllers.Subscriptions.weekly(country: String, orderIsAGift: Boolean = true)
+GET  /$country<(uk|us|au|int|nz|ca|eu)>/subscribe/weekly           controllers.WeeklySubscription.weekly(country: String, orderIsAGift: Boolean = false)
+GET  /$country<(uk|us|au|int|nz|ca|eu)>/subscribe/weekly/gift      controllers.WeeklySubscription.weekly(country: String, orderIsAGift: Boolean = true)
 
 GET  /paper                                                        controllers.PaperSubscription.paperMethodRedirect(withDelivery: Boolean = false)
 GET  /subscribe/paper                                              controllers.PaperSubscription.paperMethodRedirect(withDelivery: Boolean = false)


### PR DESCRIPTION
## Why are you doing this?
When subscription landing pages are shared on facebook/twitter etc we'd like the shared item to include a relevant image to market ourselves a bit more effectively.

While I was there, I noticed that we don't even provide twitter with a card type to use, so I've added that which should be a start for meaningful twitter shares.

I also did a little code reshuffle - moving GW routes into the GW controller which is more consistent with paper and digital.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/nYyzs11c/2384-open-graph-tag-optimisation)

## Changes

* Add specific open graph images to product pages
* Refactor controller methods (move for consistency)

## Screenshots
![image](https://user-images.githubusercontent.com/8754692/75699177-efc23f00-5ca7-11ea-93b5-9ffbe8894423.png)
![image](https://user-images.githubusercontent.com/8754692/75762468-9d7a3000-5d32-11ea-87d2-3dd10ecfbf9d.png)

