### PR TITLE
Only send valid state codes down to Step Function

### DIFF
--- a/support-frontend/assets/helpers/errorReasons.js
+++ b/support-frontend/assets/helpers/errorReasons.js
@@ -55,7 +55,7 @@ function appropriateErrorMessage(errorReason: ?ErrorReason): ?string {
     case 'card_authentication_error':
       return 'You have not been charged. Please check your payment details and try again, or choose another payment method.';
     case 'incomplete_payment_request_details':
-      return 'Please complete all fields for your saved credit cards within your browser settings and try your payment again. Alternatively, you can use the form below.';
+      return 'Please complete all relevant fields for your saved cards and billing addresses within your browser settings and try your payment again. Alternatively, you can use the form below.';
     default:
       return 'The transaction was temporarily declined. Please try entering your payment details again. Alternatively, try another payment method.';
   }

--- a/support-frontend/assets/helpers/internationalisation/__tests__/countryTest.js
+++ b/support-frontend/assets/helpers/internationalisation/__tests__/countryTest.js
@@ -2,7 +2,7 @@
 
 // ----- Imports ----- //
 
-import { detect, findIsoCountry } from '../country';
+import { detect, findIsoCountry, stateProvinceFromString } from '../country';
 import { AUDCountries, EURCountries, GBPCountries, UnitedStates } from '../countryGroup';
 
 const { jsdom } = global;
@@ -310,3 +310,33 @@ describe('find iso country', () => {
     expect(findIsoCountry('Simple And Coherent Land')).toBe(null);
   });
 });
+
+describe('find a state for a given country using stateProvinceFromString', () => {
+  it('should return null if no country or state', () => {
+    expect(stateProvinceFromString(null, null)).toBe(null);
+    expect(stateProvinceFromString('US', null)).toBe(null);
+    expect(stateProvinceFromString('US', '')).toBe(null);
+    expect(stateProvinceFromString(null, 'NY')).toBe(null);
+    expect(stateProvinceFromString('', 'NY')).toBe(null);
+  });
+
+  it('should return the StateCode that\'s within a given country\'s set', () => {
+    expect(stateProvinceFromString('US', 'AL')).toBe('AL'); // Alabama
+    expect(stateProvinceFromString('CA', 'AL')).toBe(null); // No state called 'AL' in Canada
+    expect(stateProvinceFromString('AU', 'AL')).toBe(null); // No state called 'AL' in Australia
+
+    expect(stateProvinceFromString('US', 'AB')).toBe(null); // No state called 'AB' in USA
+    expect(stateProvinceFromString('CA', 'AB')).toBe('AB'); // Alberta
+    expect(stateProvinceFromString('AU', 'AB')).toBe(null); // No state called 'AB' in Australia
+
+    expect(stateProvinceFromString('US', 'NT')).toBe(null); // No state called 'NT' in USA
+    expect(stateProvinceFromString('CA', 'NT')).toBe('NT'); // Northwest Territories
+    expect(stateProvinceFromString('AU', 'NT')).toBe('NT'); // Northern Territory
+
+    expect(stateProvinceFromString('CA', 'ON')).toBe('ON'); // Ontario
+    expect(stateProvinceFromString('CA', 'Ontario')).toBe('ON'); // Ontario
+    expect(stateProvinceFromString('CA', 'YT')).toBe('YT'); // Yukon does not start with 2 letter code
+    expect(stateProvinceFromString('CA', 'Yukon')).toBe('YT');
+  });
+});
+

--- a/support-frontend/assets/helpers/internationalisation/country.js
+++ b/support-frontend/assets/helpers/internationalisation/country.js
@@ -427,7 +427,8 @@ export const isInStripePaymentRequestAllowedCountries = (country: IsoCountry) =>
 // ----- Functions ----- /
 function sateFromMap(l: string, states: {[p: string]: string}): ?StateProvince {
   const s = l.toUpperCase();
-  return states[s] ? s : Object.keys(states).find(key => s.startsWith(key) || states[key] === s);
+  return states[s] ? s :
+    Object.keys(states).find(key => states[key].toUpperCase() === s || (s.length === 3 && s.startsWith(key)));
 }
 
 function usStateFromString(s: string): Option<UsState> {

--- a/support-frontend/assets/helpers/internationalisation/country.js
+++ b/support-frontend/assets/helpers/internationalisation/country.js
@@ -17,7 +17,6 @@ import {
   UnitedStates,
 } from './countryGroup';
 import type { CountryGroupId } from './countryGroup';
-import type { ContributionType } from '../contributions';
 
 // ----- Setup ----- //
 
@@ -115,12 +114,16 @@ const auStates: {
   JBT: 'Jervis Bay Territory',
 };
 
-const newspaperCountries = {
+const newspaperCountries: {
+  [string]: string,
+} = {
   GB: 'United Kingdom',
   IM: 'Isle of Man',
 };
 
-const countries = {
+const countries: {
+  [string]: string,
+} = {
   GB: 'United Kingdom',
   US: 'United States',
   AU: 'Australia',
@@ -421,26 +424,26 @@ const stripePaymentRequestAllowedCountries = [
 export const isInStripePaymentRequestAllowedCountries = (country: IsoCountry) =>
   stripePaymentRequestAllowedCountries.includes(country);
 
-const stateNeededForCountryForRecurring = ['US', 'CA', 'AU'];
-
-export const requiresStateValue = (contributionType: ContributionType, country: IsoCountry) =>
-  contributionType !== 'ONE_OFF' && stateNeededForCountryForRecurring.includes(country);
-
 // ----- Functions ----- /
+function sateFromMap(l: string, states: {[p: string]: string}): ?StateProvince {
+  const s = l.toUpperCase();
+  return states[s] ? s : Object.keys(states).find(key => s.startsWith(key) || states[key] === s);
+}
 
 function usStateFromString(s: string): Option<UsState> {
-  return usStates[s] ? s : null;
+  return sateFromMap(s, usStates) || null;
 }
 
 function caStateFromString(s: string): Option<CaState> {
-  return caStates[s] ? s : null;
+  return sateFromMap(s, caStates) || null;
 }
 
 function auStateFromString(s: string): Option<AuState> {
-  return auStates[s] ? s : null;
+  return sateFromMap(s, auStates) || null;
 }
 
-function stateProvinceFromString(country: Option<IsoCountry>, s: string): Option<StateProvince> {
+function stateProvinceFromString(country: Option<IsoCountry>, s?: string): Option<StateProvince> {
+  if (!s) { return null; }
   switch (country) {
     case 'US':
       return usStateFromString(s);
@@ -467,8 +470,9 @@ function fromString(s: string): ?IsoCountry {
   return null;
 }
 
-function findIsoCountry(country: string): ?IsoCountry {
-  return fromString(country) || Object.entries(countries).find(key => countries[key] === country);
+function findIsoCountry(country?: string): Option<IsoCountry> {
+  if (!country) { return null; }
+  return fromString(country) || Object.keys(countries).find(key => countries[key] === country) || null;
 }
 
 function fromCountryGroup(countryGroupId: ?CountryGroupId = null): ?IsoCountry {

--- a/support-frontend/assets/helpers/internationalisation/country.js
+++ b/support-frontend/assets/helpers/internationalisation/country.js
@@ -17,6 +17,7 @@ import {
   UnitedStates,
 } from './countryGroup';
 import type { CountryGroupId } from './countryGroup';
+import type { ContributionType } from '../contributions';
 
 // ----- Setup ----- //
 
@@ -420,6 +421,11 @@ const stripePaymentRequestAllowedCountries = [
 export const isInStripePaymentRequestAllowedCountries = (country: IsoCountry) =>
   stripePaymentRequestAllowedCountries.includes(country);
 
+const stateNeededForCountryForRecurring = ['US', 'CA', 'AU'];
+
+export const requiresStateValue = (contributionType: ContributionType, country: IsoCountry) =>
+  contributionType !== 'ONE_OFF' && stateNeededForCountryForRecurring.includes(country);
+
 // ----- Functions ----- /
 
 function usStateFromString(s: string): Option<UsState> {
@@ -447,11 +453,6 @@ function stateProvinceFromString(country: Option<IsoCountry>, s: string): Option
   }
 }
 
-function findIsoCountry(country: string): Option<IsoCountry> {
-  const maybeIsoCountry = Object.keys(countries).find(key => countries[key] === country);
-  return maybeIsoCountry !== undefined ? maybeIsoCountry : null;
-}
-
 function fromString(s: string): ?IsoCountry {
   const candidateIso = s.toUpperCase();
   const isoCountryArray: Array<IsoCountry> = Object.keys(countries);
@@ -464,6 +465,10 @@ function fromString(s: string): ?IsoCountry {
     return isoCountryArray[isoIndex];
   }
   return null;
+}
+
+function findIsoCountry(country: string): ?IsoCountry {
+  return fromString(country) || Object.entries(countries).find(key => countries[key] === country);
 }
 
 function fromCountryGroup(countryGroupId: ?CountryGroupId = null): ?IsoCountry {

--- a/support-frontend/assets/helpers/internationalisation/country.js
+++ b/support-frontend/assets/helpers/internationalisation/country.js
@@ -425,22 +425,22 @@ export const isInStripePaymentRequestAllowedCountries = (country: IsoCountry) =>
   stripePaymentRequestAllowedCountries.includes(country);
 
 // ----- Functions ----- /
-function sateFromMap(l: string, states: {[p: string]: string}): ?StateProvince {
+function stateProvinceFromMap(l: string, states: {[p: string]: string}): ?StateProvince {
   const s = l.toUpperCase();
   return states[s] ? s :
     Object.keys(states).find(key => states[key].toUpperCase() === s || (s.length === 3 && s.startsWith(key)));
 }
 
 function usStateFromString(s: string): Option<UsState> {
-  return sateFromMap(s, usStates) || null;
+  return stateProvinceFromMap(s, usStates) || null;
 }
 
 function caStateFromString(s: string): Option<CaState> {
-  return sateFromMap(s, caStates) || null;
+  return stateProvinceFromMap(s, caStates) || null;
 }
 
 function auStateFromString(s: string): Option<AuState> {
-  return sateFromMap(s, auStates) || null;
+  return stateProvinceFromMap(s, auStates) || null;
 }
 
 function stateProvinceFromString(country: Option<IsoCountry>, s?: string): Option<StateProvince> {

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionFormFields.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionFormFields.jsx
@@ -25,7 +25,7 @@ import {
   updateFirstName,
   updateLastName,
   updateEmail,
-  updateState,
+  updateStateOrProvince,
   checkIfEmailHasPassword,
 } from '../contributionsLandingActions';
 
@@ -72,7 +72,7 @@ const mapDispatchToProps = (dispatch: Function) => ({
   updateFirstName: (event) => { dispatch(updateFirstName(event.target.value)); },
   updateLastName: (event) => { dispatch(updateLastName(event.target.value)); },
   updateEmail: (event) => { dispatch(updateEmail(event.target.value)); },
-  updateState: (event) => { dispatch(updateState(event.target.value === '' ? null : event.target.value)); },
+  updateState: (event) => { dispatch(updateStateOrProvince(event.target.value === '' ? null : event.target.value)); },
   checkIfEmailHasPassword: (event) => { dispatch(checkIfEmailHasPassword(event.target.value)); },
 });
 

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -61,7 +61,7 @@ export type Action =
   | { type: 'UPDATE_LAST_NAME', lastName: string }
   | { type: 'UPDATE_EMAIL', email: string }
   | { type: 'UPDATE_PASSWORD', password: string }
-  | { type: 'UPDATE_STATE', state: UsState | CaState | null }
+  | { type: 'UPDATE_STATE_OR_PROVINCE', state: UsState | CaState | null }
   | { type: 'UPDATE_BILLING_COUNTRY', billingCountry: IsoCountry }
   | { type: 'UPDATE_USER_FORM_DATA', userFormData: UserFormData }
   | { type: 'UPDATE_PAYMENT_READY', thirdPartyPaymentLibraryByContrib: { [ContributionType]: { [PaymentMethod]: ThirdPartyPaymentLibrary } } }
@@ -169,9 +169,9 @@ const updateUserFormData = (userFormData: UserFormData): ((Function) => void) =>
     dispatch(setFormSubmissionDependentValue(() => ({ type: 'UPDATE_USER_FORM_DATA', userFormData })));
   };
 
-const updateState = (state: UsState | CaState | null): ((Function) => void) =>
+const updateStateOrProvince = (state: UsState | CaState | null): ((Function) => void) =>
   (dispatch: Function): void => {
-    dispatch(setFormSubmissionDependentValue(() => ({ type: 'UPDATE_STATE', state })));
+    dispatch(setFormSubmissionDependentValue(() => ({ type: 'UPDATE_STATE_OR_PROVINCE', state })));
   };
 
 const updateBillingCountry = (billingCountry: IsoCountry): Action =>
@@ -693,7 +693,7 @@ export {
   updateFirstName,
   updateLastName,
   updateEmail,
-  updateState,
+  updateStateOrProvince,
   updateBillingCountry,
   updateUserFormData,
   setThirdPartyPaymentLibrary,

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
@@ -383,7 +383,7 @@ function createFormReducer() {
       case 'SET_USER_TYPE_FROM_IDENTITY_RESPONSE':
         return { ...state, userTypeFromIdentityResponse: action.userTypeFromIdentityResponse };
 
-      case 'UPDATE_STATE':
+      case 'UPDATE_STATE_OR_PROVINCE':
         return { ...state, formData: { ...state.formData, state: action.state } };
 
       case 'UPDATE_BILLING_COUNTRY':


### PR DESCRIPTION
## Why are you doing this?
We receive at around one AWS alarm per day where the value provided in the State field is incorrect, either in terms of what Zuora can understand (2-letter code or full name), and in the set that matches the provided country (e.g. providing Ontario when country is United States).

This change includes a better lookup function in `country.js` called `stateProvinceFromString` that will search for a state based on a provided string of 2-characters, the full state name, or a 3-letter code (which isn't a validly structured code in USA and CA but is in Australia). The function also ensures that it looks up in the correct set of states, respective to the provided country. If there is no match, it returns null.

I also updated the logic which determines whether a state code is required by Zuora. 
For all other instances, including Single, we will not pass on the state value unless it matches the country's set of states - this is a change from the existing logic that would pass-through whatever value was entered. We see so many unparsable or mismatched values in the DB or Zuora, that the state value not worth collecting if it does not map based on the `stateProvinceFromString` search function.

I also renamed the `updateState` function and `'UPDATE_STATE'` reducer matcher to make it clear it's about the country's state / province rather than anything React related. 
 
<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/pK5SzRGy)

## Screenshots
No change to the UI other than an updated error message.

Before:
![Screen Shot 2020-03-02 at 13 54 06](https://user-images.githubusercontent.com/1515970/75682440-54bc6b80-5c8d-11ea-9a3d-21544122c66c.png)

After:
![Screen Shot 2020-03-02 at 13 53 57](https://user-images.githubusercontent.com/1515970/75682449-584ff280-5c8d-11ea-9477-c8a0781499ee.png)
