### PR TITLE
make sure the right version of node is running in devrun.sh

### DIFF
--- a/support-frontend/devrun.sh
+++ b/support-frontend/devrun.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+nvm use &
 yarn devrun &
 yarn storybook &
 cd ..; sbt -mem 2048 "project support-frontend" devrun


### PR DESCRIPTION
## Why are you doing this?
I keep accidentally not switching the version of node before running this script. This will prevent that from happening, assuming everyone uses nvm to manage their node versions.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->
