### PR TITLE
fixed: make sure the right version of node is running in devrun.sh

### DIFF
--- a/support-frontend/devrun.sh
+++ b/support-frontend/devrun.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# source NVM inside script before invoking it
+. ~/.nvm/nvm.sh
+
 nvm use &
 yarn devrun &
 yarn storybook &

--- a/support-frontend/devrun.sh
+++ b/support-frontend/devrun.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+nvm use &
 yarn devrun &
 yarn storybook &
 cd ..; sbt -mem 2048 "project support-frontend" devrun

--- a/support-frontend/devrun.sh
+++ b/support-frontend/devrun.sh
@@ -1,7 +1,20 @@
 #!/usr/bin/env bash
 
 # source NVM inside script before invoking it
-. ~/.nvm/nvm.sh
+nvm_available() {
+  type -t nvm > /dev/null
+}
+
+source_nvm() {
+  if ! nvm_available; then
+    [ -e "/usr/local/opt/nvm/nvm.sh" ] && source /usr/local/opt/nvm/nvm.sh
+  fi
+  if ! nvm_available; then
+    [ -e "$HOME/.nvm/nvm.sh" ] && source $HOME/.nvm/nvm.sh
+  fi
+}
+
+source_nvm
 
 nvm use &
 yarn devrun &


### PR DESCRIPTION
## Why are you doing this?
Properly sourcing `nvm` in the context of the script -- a fix for https://github.com/guardian/support-frontend/pull/2373:
I keep accidentally not switching the version of node before running this script. This will prevent that from happening, assuming everyone uses nvm to manage their node versions.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->
