### PR TITLE
Choice cards round 2 test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -4,7 +4,7 @@ import type { Tests } from './abtest';
 // ----- Tests ----- //
 export type StripePaymentRequestButtonScaTestVariants = 'control' | 'sca' | 'notintest';
 
-export type ChoiceCardsProductSetTestVariants = 'control' | 'rectangles';
+export type ChoiceCardsProductSetTestR2Variants = 'control' | 'rectangles';
 export type PersonalisedThankYouPageTestVariants = 'control' | 'personalised' | 'notintest';
 export type PostContributionReminderCopyTestVariants = 'control' | 'extendedCopy' | 'notintest';
 
@@ -102,7 +102,7 @@ export const tests: Tests = {
     optimizeId: '21HyzxNZSmikdtgJQNnXUw',
   },
 
-  choiceCardsProductSetTest: {
+  choiceCardsProductSetTestR2: {
     type: 'OTHER',
     variants: [
       {

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -4,7 +4,7 @@ import type { Tests } from './abtest';
 // ----- Tests ----- //
 export type StripePaymentRequestButtonScaTestVariants = 'control' | 'sca' | 'notintest';
 
-export type ChoiceCardsProductSetTestVariants = 'control' | 'circles' | 'rectangles';
+export type ChoiceCardsProductSetTestVariants = 'control' | 'rectangles';
 export type PersonalisedThankYouPageTestVariants = 'control' | 'personalised' | 'notintest';
 export type PostContributionReminderCopyTestVariants = 'control' | 'extendedCopy' | 'notintest';
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
@@ -167,36 +167,10 @@ function withProps(props: PropTypes) {
     formatAmount(currencies[props.currency], spokenCurrencies[props.currency], { value: max.toString() }, false);
   const otherAmount = props.otherAmounts[props.contributionType].amount;
 
-  // We are running a test with circular choice cards - this custom CSS is required
-  // to override the default rectangular shape in the design system component.
-  // If the test results indicate that we are to keep the circular variant,
-  // we will request for them to be incorporated into the design system.
-  const renderContribTypeChoiceCards = (shape: string) => {
-    const sharedCss = {
-      display: 'flex',
-      justifyContent: 'flex-start',
-      border: 0,
-    };
-    const circleCss = {
-      label: {
-        borderRadius: '50%',
-        minWidth: '60px',
-        maxWidth: '60px',
-        minHeight: '60px',
-        maxHeight: '60px',
-        padding: '0',
-      },
-    };
-    const cssObj: Object = shape === 'circles' ? {
-      ...sharedCss,
-      ...circleCss,
-    } : sharedCss;
-
-    return (
+  const renderContribAmountChoiceCards = () => (
     <>
       <ChoiceCardGroup
         name="amounts"
-        css={cssObj}
       >
         {validAmounts.map((amount: Amount) => (
           <ChoiceCard
@@ -220,8 +194,7 @@ function withProps(props: PropTypes) {
         />
       </ChoiceCardGroup>
   </>
-    );
-  };
+  );
 
   const renderControl = () => (
     <ul className="form__radio-group-list">
@@ -249,7 +222,7 @@ function withProps(props: PropTypes) {
     <fieldset className={classNameWithModifiers('form__radio-group', ['pills', 'contribution-amount'])}>
       <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>How much would you like to give?</legend>
 
-      {props.choiceCardsVariant !== 'control' ? renderContribTypeChoiceCards(props.choiceCardsVariant) : renderControl()}
+      {props.choiceCardsVariant !== 'control' ? renderContribAmountChoiceCards() : renderControl()}
 
       {showOther ? (
         <ContributionTextInput

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
@@ -26,6 +26,7 @@ import { selectAmount, updateOtherAmount } from '../contributionsLandingActions'
 import ContributionTextInput from './ContributionTextInput';
 import { ChoiceCardGroup, ChoiceCard } from '@guardian/src-choice-card';
 import type { ChoiceCardsProductSetTestVariants } from 'helpers/abTests/abtestDefinitions';
+import { css } from '@emotion/core';
 
 // ----- Types ----- //
 
@@ -171,6 +172,11 @@ function withProps(props: PropTypes) {
     <>
       <ChoiceCardGroup
         name="amounts"
+        cssOverrides={css`
+          > :last-child {
+            margin-right: 0 !important;
+          }
+        `}
       >
         {validAmounts.map((amount: Amount) => (
           <ChoiceCard
@@ -222,7 +228,7 @@ function withProps(props: PropTypes) {
     <fieldset className={classNameWithModifiers('form__radio-group', ['pills', 'contribution-amount'])}>
       <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>How much would you like to give?</legend>
 
-      {props.choiceCardsVariant !== 'control' ? renderContribAmountChoiceCards() : renderControl()}
+      {props.choiceCardsVariant === 'rectangles' ? renderContribAmountChoiceCards() : renderControl()}
 
       {showOther ? (
         <ContributionTextInput

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
@@ -25,7 +25,7 @@ import SvgPound from 'components/svgs/pound';
 import { selectAmount, updateOtherAmount } from '../contributionsLandingActions';
 import ContributionTextInput from './ContributionTextInput';
 import { ChoiceCardGroup, ChoiceCard } from '@guardian/src-choice-card';
-import type { ChoiceCardsProductSetTestVariants } from 'helpers/abTests/abtestDefinitions';
+import type { ChoiceCardsProductSetTestR2Variants } from 'helpers/abTests/abtestDefinitions';
 
 // ----- Types ----- //
 
@@ -42,7 +42,7 @@ type PropTypes = {|
   updateOtherAmount: (string, CountryGroupId, ContributionType) => void,
   checkoutFormHasBeenSubmitted: boolean,
   stripePaymentRequestButtonClicked: boolean,
-  choiceCardsVariant: ChoiceCardsProductSetTestVariants,
+  choiceCardsVariant: ChoiceCardsProductSetTestR2Variants,
 |};
 /* eslint-enable react/no-unused-prop-types */
 
@@ -57,7 +57,7 @@ const mapStateToProps = state => ({
   stripePaymentRequestButtonClicked:
     state.page.form.stripePaymentRequestButtonData.ONE_OFF.stripePaymentRequestButtonClicked ||
     state.page.form.stripePaymentRequestButtonData.REGULAR.stripePaymentRequestButtonClicked,
-  choiceCardsVariant: state.common.abParticipations.choiceCardsProductSetTest,
+  choiceCardsVariant: state.common.abParticipations.choiceCardsProductSetTestR2,
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
@@ -26,7 +26,6 @@ import { selectAmount, updateOtherAmount } from '../contributionsLandingActions'
 import ContributionTextInput from './ContributionTextInput';
 import { ChoiceCardGroup, ChoiceCard } from '@guardian/src-choice-card';
 import type { ChoiceCardsProductSetTestVariants } from 'helpers/abTests/abtestDefinitions';
-import { css } from '@emotion/core';
 
 // ----- Types ----- //
 
@@ -172,11 +171,6 @@ function withProps(props: PropTypes) {
     <>
       <ChoiceCardGroup
         name="amounts"
-        cssOverrides={css`
-          > :last-child {
-            margin-right: 0 !important;
-          }
-        `}
       >
         {validAmounts.map((amount: Amount) => (
           <ChoiceCard

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
@@ -23,7 +23,6 @@ import type {
 } from 'helpers/contributions';
 import { ChoiceCardGroup, ChoiceCard } from '@guardian/src-choice-card';
 import type { ChoiceCardsProductSetTestVariants } from 'helpers/abTests/abtestDefinitions';
-import { css } from '@emotion/core';
 
 // ----- Types ----- //
 
@@ -69,11 +68,6 @@ function withProps(props: PropTypes) {
       <ChoiceCardGroup
         name="contributionTypes"
         orientation="horizontal"
-        cssOverrides={css`
-          > :last-child {
-            margin-right: 0 !important;
-          }
-        `}
       >
         {contributionTypes.map((contributionTypeSetting: ContributionTypeSetting) => {
         const { contributionType } = contributionTypeSetting;

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
@@ -23,6 +23,7 @@ import type {
 } from 'helpers/contributions';
 import { ChoiceCardGroup, ChoiceCard } from '@guardian/src-choice-card';
 import type { ChoiceCardsProductSetTestVariants } from 'helpers/abTests/abtestDefinitions';
+import { css } from '@emotion/core';
 
 // ----- Types ----- //
 
@@ -63,9 +64,17 @@ const mapDispatchToProps = (dispatch: Function) => ({
 function withProps(props: PropTypes) {
   const contributionTypes = props.contributionTypes[props.countryGroupId];
 
-  const renderAmountChoiceCards = () => (
+  const renderContribTypeChoiceCards = () => (
     <>
-      <ChoiceCardGroup name="contributionTypes" orientation="horizontal">
+      <ChoiceCardGroup
+        name="contributionTypes"
+        orientation="horizontal"
+        cssOverrides={css`
+          > :last-child {
+            margin-right: 0 !important;
+          }
+        `}
+      >
         {contributionTypes.map((contributionTypeSetting: ContributionTypeSetting) => {
         const { contributionType } = contributionTypeSetting;
         return (
@@ -126,7 +135,7 @@ function withProps(props: PropTypes) {
   return (
     <fieldset className={classNameWithModifiers('form__radio-group', ['tabs', 'contribution-type'])}>
       <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>How often would you like to contribute?</legend>
-      {props.choiceCardsVariant !== 'control' ? renderAmountChoiceCards() : renderControl()}
+      {props.choiceCardsVariant === 'rectangles' ? renderContribTypeChoiceCards() : renderControl()}
     </fieldset>
   );
 }

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
@@ -22,7 +22,7 @@ import type {
   ContributionTypeSetting,
 } from 'helpers/contributions';
 import { ChoiceCardGroup, ChoiceCard } from '@guardian/src-choice-card';
-import type { ChoiceCardsProductSetTestVariants } from 'helpers/abTests/abtestDefinitions';
+import type { ChoiceCardsProductSetTestR2Variants } from 'helpers/abTests/abtestDefinitions';
 
 // ----- Types ----- //
 
@@ -33,7 +33,7 @@ type PropTypes = {|
   switches: Switches,
   contributionTypes: ContributionTypes,
   onSelectContributionType: (ContributionType, Switches, IsoCountry, CountryGroupId) => void,
-  choiceCardsVariant: ChoiceCardsProductSetTestVariants,
+  choiceCardsVariant: ChoiceCardsProductSetTestR2Variants,
 |};
 
 const mapStateToProps = (state: State) => ({
@@ -42,7 +42,7 @@ const mapStateToProps = (state: State) => ({
   countryId: state.common.internationalisation.countryId,
   switches: state.common.settings.switches,
   contributionTypes: state.common.settings.contributionTypes,
-  choiceCardsVariant: state.common.abParticipations.choiceCardsProductSetTest,
+  choiceCardsVariant: state.common.abParticipations.choiceCardsProductSetTestR2,
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -68,9 +68,9 @@
   "dependencies": {
     "@emotion/core": "^10.0.27",
     "@guardian/pasteup": "^1.0.0-alpha.7",
-    "@guardian/src-choice-card": "0.13.0-alpha.8",
-    "@guardian/src-foundations": "^0.13.0",
-    "@guardian/src-svgs": "^0.13.0",
+    "@guardian/src-choice-card": "^0.14.0-alpha.2",
+    "@guardian/src-foundations": "^0.14.1",
+    "@guardian/src-svgs": "^0.14.0",
     "@sentry/browser": "^5.4.0",
     "cssnano": "^4.1.10",
     "dompurify": "^2.0.7",

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "@emotion/core": "^10.0.27",
     "@guardian/pasteup": "^1.0.0-alpha.7",
-    "@guardian/src-choice-card": "0.13.0-alpha.5",
+    "@guardian/src-choice-card": "0.13.0-alpha.8",
     "@guardian/src-foundations": "^0.13.0",
     "@guardian/src-svgs": "^0.13.0",
     "@sentry/browser": "^5.4.0",

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "@emotion/core": "^10.0.27",
     "@guardian/pasteup": "^1.0.0-alpha.7",
-    "@guardian/src-choice-card": "^0.14.0-alpha.2",
+    "@guardian/src-choice-card": "^0.14.0-alpha.3",
     "@guardian/src-foundations": "^0.14.1",
     "@guardian/src-svgs": "^0.14.0",
     "@sentry/browser": "^5.4.0",

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -1787,10 +1787,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/pasteup/-/pasteup-1.0.0-alpha.7.tgz#680656b92632006d736d0378ae19f8c6943769c8"
   integrity sha512-WSa3gnRYxciFas3QYhtTk8unvj5N9K5IB61LL1CP3bVCJ2euXR13xRRHafI/Vy1dnrDwPa80SaE+apTcwipvpA==
 
-"@guardian/src-choice-card@0.13.0-alpha.5":
-  version "0.13.0-alpha.5"
-  resolved "https://registry.yarnpkg.com/@guardian/src-choice-card/-/src-choice-card-0.13.0-alpha.5.tgz#3e87021eb6ba165ff83b97c60d9edd53b0cde6db"
-  integrity sha512-ZWOcOlmqWmtWDxDEZhgjLTi5EaIHLzRg607MQtRre9QitpQ9Cr9istYRY0jnNI0Yngk/FsdFTvG7epdBRal9+A==
+"@guardian/src-choice-card@0.13.0-alpha.8":
+  version "0.13.0-alpha.8"
+  resolved "https://registry.yarnpkg.com/@guardian/src-choice-card/-/src-choice-card-0.13.0-alpha.8.tgz#1ffdeca4777d3933414338e125d8757565cbe150"
+  integrity sha512-4VG2Kz4EanSQ74RSaXirII0gRhP5c9I7Su3l9rQkcIlIdofanSdvVmYcaomajJr032pX5eAOFukrFv5jZvKvjQ==
 
 "@guardian/src-foundations@^0.13.0":
   version "0.13.0"

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -1787,20 +1787,20 @@
   resolved "https://registry.yarnpkg.com/@guardian/pasteup/-/pasteup-1.0.0-alpha.7.tgz#680656b92632006d736d0378ae19f8c6943769c8"
   integrity sha512-WSa3gnRYxciFas3QYhtTk8unvj5N9K5IB61LL1CP3bVCJ2euXR13xRRHafI/Vy1dnrDwPa80SaE+apTcwipvpA==
 
-"@guardian/src-choice-card@0.13.0-alpha.8":
-  version "0.13.0-alpha.8"
-  resolved "https://registry.yarnpkg.com/@guardian/src-choice-card/-/src-choice-card-0.13.0-alpha.8.tgz#1ffdeca4777d3933414338e125d8757565cbe150"
-  integrity sha512-4VG2Kz4EanSQ74RSaXirII0gRhP5c9I7Su3l9rQkcIlIdofanSdvVmYcaomajJr032pX5eAOFukrFv5jZvKvjQ==
+"@guardian/src-choice-card@^0.14.0-alpha.2":
+  version "0.14.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@guardian/src-choice-card/-/src-choice-card-0.14.0-alpha.2.tgz#bcfdd8ee4d250279e0f1943b4667bf3e6578fd7d"
+  integrity sha512-PphICsTLKVCFE3WhEoa1/Ngadms6RPI44UwA1DDzjvfaM21cOB5EIdVj7Dx2K5oomShQzDlL98I1J24F3ixLUA==
 
-"@guardian/src-foundations@^0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.13.0.tgz#8bfed9b94e2e4f24ecacb754bbe573b6e0cfe088"
-  integrity sha512-8lTZSo49W1lPhBFaaLrg2Eo2jrwUB3VGw6a7ZRI7oBEyTglmlbjFDiciu2Di6WSrzuSWiI+9OJTSSjCP6lTT2A==
+"@guardian/src-foundations@^0.14.1":
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.14.1.tgz#33cf2e95eedf184fdfc40cc75c1dbca4d6d46fdf"
+  integrity sha512-FiH2nsPvHS6wG7b0AePXTGbDCIV+q0aRHZKhsH2X2WeS9K3fZqEF9y+8lTv22nW3r3sv6nSyh4tT7y5+XPC9pA==
 
-"@guardian/src-svgs@^0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@guardian/src-svgs/-/src-svgs-0.13.0.tgz#97d893a6e33feb255666fef6779ffe18a7c4e2f5"
-  integrity sha512-cDIGNOaatYVDk+eWCv2cAdBlXZ2ECDxOcc897GowJYCHmy+HifL0AvzHlHRLKYRQXzVcaPfoXDOjVonA4ViHqw==
+"@guardian/src-svgs@^0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@guardian/src-svgs/-/src-svgs-0.14.0.tgz#3a5a6d385f2639aca884b5302f3d3ae6e919e290"
+  integrity sha512-ZGwVwVlX3YwG62xO1YjxaHyGFJC8Us80GPeyY8CMv5lfshYd0gGDNJN6vjUI3ssULjcP8ckGOTFcTFs3hOUrMw==
 
 "@icons/material@^0.2.4":
   version "0.2.4"

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -1787,10 +1787,10 @@
   resolved "https://registry.yarnpkg.com/@guardian/pasteup/-/pasteup-1.0.0-alpha.7.tgz#680656b92632006d736d0378ae19f8c6943769c8"
   integrity sha512-WSa3gnRYxciFas3QYhtTk8unvj5N9K5IB61LL1CP3bVCJ2euXR13xRRHafI/Vy1dnrDwPa80SaE+apTcwipvpA==
 
-"@guardian/src-choice-card@^0.14.0-alpha.2":
-  version "0.14.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/@guardian/src-choice-card/-/src-choice-card-0.14.0-alpha.2.tgz#bcfdd8ee4d250279e0f1943b4667bf3e6578fd7d"
-  integrity sha512-PphICsTLKVCFE3WhEoa1/Ngadms6RPI44UwA1DDzjvfaM21cOB5EIdVj7Dx2K5oomShQzDlL98I1J24F3ixLUA==
+"@guardian/src-choice-card@^0.14.0-alpha.3":
+  version "0.14.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/@guardian/src-choice-card/-/src-choice-card-0.14.0-alpha.3.tgz#a25c0c83799f7251c96149fd7e487dc85f5a3ecb"
+  integrity sha512-03dsXyWIXGXtToePPR4H6kTyBq+4rtzUKNCVk7Gk6HKjNOYOK2/3iBLo2mLNjSP8Kt0SdSvfiV58FxxOVMDELg==
 
 "@guardian/src-foundations@^0.14.1":
   version "0.14.1"


### PR DESCRIPTION
## Why are you doing this?

This is round 2 of the choice cards test, where we implement only the rectangular variant and the updated design with hover state. The circular amount variant was been removed as it didn't perform as well. 

[**Trello Card**](https://trello.com/c/NaAsLE0h/1867-choice-cards-implement-round-2)

## Changes

* Update test definitions
* Update choice cards to latest design with hover state and new background colour

## Screenshots

### Control
<img width="629" alt="image" src="https://user-images.githubusercontent.com/15648334/75769455-1c289a80-5d3e-11ea-9fe0-a318a3d771d4.png">

### Variant - rectangles (no hover state shown)
<img width="661" alt="image" src="https://user-images.githubusercontent.com/15648334/75694870-1f217d80-5ca1-11ea-82ac-3c75a070bcf6.png">

### Variant - rectangles - with hover state (£50) - desktop
<img width="639" alt="image" src="https://user-images.githubusercontent.com/15648334/75695061-6871cd00-5ca1-11ea-96f6-e1e58e6e99f3.png">

### Variant - rectangles - with hover state (£50) - mobile
<img width="415" alt="image" src="https://user-images.githubusercontent.com/15648334/75695143-8808f580-5ca1-11ea-8e64-1f665eb8e8d6.png">

