### PR TITLE
Make travis retry the selenium tests up to 3 times

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -9,7 +9,7 @@
             "afterSeen": {
                 "travis": {
                     "config": {
-                        "script": "sbt ++$TRAVIS_SCALA_VERSION selenium:test"
+                        "script": "travis_retry sbt ++$TRAVIS_SCALA_VERSION selenium:test"
                     }
                 }
             }


### PR DESCRIPTION
## Why are you doing this?

Selenium tests have been breaking due to networking problems : -( travis_retry is a commandline thing available in the travis environment that will retry a failed command up to 3 times.

See https://docs.travis-ci.com/user/common-build-problems/#timeouts-installing-dependencies

The down side is that if there's a real failure, it will have to run the tests 3 times until it sounds the alarm, which takes quite a bit of time