### PR TITLE
Fix state mismatch and console logging bugs

### DIFF
--- a/support-frontend/assets/helpers/formValidation.js
+++ b/support-frontend/assets/helpers/formValidation.js
@@ -24,7 +24,7 @@ export const maxTwoDecimals: string => boolean = input => new RegExp('^\\d+\\.?\
 
 export const checkFirstName: (string | null) => boolean = isNotEmpty;
 export const checkLastName: (string | null) => boolean = isNotEmpty;
-export const checkState: (string | null) => boolean = s => typeof s === 'string' && isNotEmpty(s);
+export const checkBillingState: (string | null) => boolean = s => typeof s === 'string' && isNotEmpty(s);
 export const checkEmail: (string | null) => boolean = input => isNotEmpty(input) && isValidEmail(input);
 
 export const checkOptionalEmail: (string | null) => boolean = input => isEmpty(input) || isValidEmail(input);
@@ -55,12 +55,12 @@ export const checkAmountOrOtherAmount: (SelectedAmounts, OtherAmounts, Contribut
 };
 
 export const checkStateIfApplicable: ((string | null), CountryGroupId, ContributionType) => boolean = (
-  state: (string | null),
+  billingState: (string | null),
   countryGroupId: CountryGroupId,
   contributionType: ContributionType,
 ) => {
   if (contributionType !== 'ONE_OFF' && (countryGroupId === UnitedStates || countryGroupId === Canada)) {
-    return checkState(state);
+    return checkBillingState(billingState);
   }
   return true;
 };

--- a/support-frontend/assets/pages/contributions-landing/checkoutFormIsSubmittableActions.js
+++ b/support-frontend/assets/pages/contributions-landing/checkoutFormIsSubmittableActions.js
@@ -53,7 +53,7 @@ export type FormIsValidParameters = {
   otherAmounts: OtherAmounts,
   countryGroupId: CountryGroupId,
   contributionType: ContributionType,
-  state: UsState | CaState | null,
+  billingState: UsState | CaState | null,
   firstName: string | null,
   lastName: string | null,
   email: string | null,
@@ -66,7 +66,7 @@ const getFormIsValid = (formIsValidParameters: FormIsValidParameters) => {
     otherAmounts,
     countryGroupId,
     contributionType,
-    state,
+    billingState,
     firstName,
     lastName,
     email,
@@ -81,7 +81,7 @@ const getFormIsValid = (formIsValidParameters: FormIsValidParameters) => {
       true
   ) && checkEmail(email)
     && stripeCardFormOk
-    && checkStateIfApplicable(state, countryGroupId, contributionType)
+    && checkStateIfApplicable(billingState, countryGroupId, contributionType)
     && checkAmountOrOtherAmount(selectedAmounts, otherAmounts, contributionType, countryGroupId);
 };
 
@@ -90,7 +90,7 @@ const formIsValidParameters = (state: State) => ({
   otherAmounts: state.page.form.formData.otherAmounts,
   countryGroupId: state.common.internationalisation.countryGroupId,
   contributionType: state.page.form.contributionType,
-  state: state.page.form.formData.state,
+  billingState: state.page.form.formData.billingState,
   firstName: state.page.form.formData.firstName,
   lastName: state.page.form.formData.lastName,
   email: state.page.form.formData.email,

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionFormFields.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionFormFields.jsx
@@ -12,7 +12,7 @@ import Signout from 'components/signout/signout';
 import {
   checkFirstName,
   checkLastName,
-  checkState,
+  checkBillingState,
   checkEmail,
   emailRegexPattern,
 } from 'helpers/formValidation';
@@ -25,7 +25,7 @@ import {
   updateFirstName,
   updateLastName,
   updateEmail,
-  updateStateOrProvince,
+  updateBillingState,
   checkIfEmailHasPassword,
 } from '../contributionsLandingActions';
 
@@ -36,7 +36,7 @@ type PropTypes = {|
   firstName: string,
   lastName: string,
   email: string,
-  state: UsState | CaState | null,
+  billingState: UsState | CaState | null,
   checkoutFormHasBeenSubmitted: boolean,
   isSignedIn: boolean,
   isRecurringContributor: boolean,
@@ -61,7 +61,7 @@ const mapStateToProps = (state: State) => ({
   lastName: getCheckoutFormValue(state.page.form.formData.lastName, state.page.user.lastName),
   email: getCheckoutFormValue(state.page.form.formData.email, state.page.user.email),
   checkoutFormHasBeenSubmitted: state.page.form.formData.checkoutFormHasBeenSubmitted,
-  state: getCheckoutFormValue(state.page.form.formData.state, state.page.user.stateField),
+  billingState: getCheckoutFormValue(state.page.form.formData.billingState, state.page.user.stateField),
   isSignedIn: state.page.user.isSignedIn,
   isRecurringContributor: state.page.user.isRecurringContributor,
   userTypeFromIdentityResponse: state.page.form.userTypeFromIdentityResponse,
@@ -72,7 +72,7 @@ const mapDispatchToProps = (dispatch: Function) => ({
   updateFirstName: (event) => { dispatch(updateFirstName(event.target.value)); },
   updateLastName: (event) => { dispatch(updateLastName(event.target.value)); },
   updateEmail: (event) => { dispatch(updateEmail(event.target.value)); },
-  updateState: (event) => { dispatch(updateStateOrProvince(event.target.value === '' ? null : event.target.value)); },
+  updateBillingState: (event) => { dispatch(updateBillingState(event.target.value === '' ? null : event.target.value)); },
   checkIfEmailHasPassword: (event) => { dispatch(checkIfEmailHasPassword(event.target.value)); },
 });
 
@@ -85,7 +85,7 @@ function withProps(props: PropTypes) {
     lastName,
     email,
     isSignedIn,
-    state,
+    billingState,
     checkoutFormHasBeenSubmitted,
   } = props;
 
@@ -152,8 +152,8 @@ function withProps(props: PropTypes) {
       }
       <ContributionState
         onChange={props.updateState}
-        selectedState={state}
-        isValid={checkState(state)}
+        selectedState={billingState}
+        isValid={checkBillingState(billingState)}
         formHasBeenSubmitted={checkoutFormHasBeenSubmitted}
       />
     </div>

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionFormFields.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionFormFields.jsx
@@ -44,7 +44,7 @@ type PropTypes = {|
   updateFirstName: Event => void,
   updateLastName: Event => void,
   updateEmail: Event => void,
-  updateState: Event => void,
+  updateBillingState: Event => void,
   checkIfEmailHasPassword: Event => void,
   contributionType: ContributionType,
 |};
@@ -151,7 +151,7 @@ function withProps(props: PropTypes) {
         </div> : null
       }
       <ContributionState
-        onChange={props.updateState}
+        onChange={props.updateBillingState}
         selectedState={billingState}
         isValid={checkBillingState(billingState)}
         formHasBeenSubmitted={checkoutFormHasBeenSubmitted}

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -256,10 +256,10 @@ function onPayment(
   let countryAndStateValueOk = !billingAccountRequiresAState; // If Zuora requires a state then we're not OK yet.
   if (validatedCountryFromCard) {
     props.updateBillingCountry(validatedCountryFromCard);
-    const validatedBillingBillingStateFromCard: Option<StateProvince> =
+    const validatedBillingStateFromCard: Option<StateProvince> =
       stateProvinceFromString(validatedCountryFromCard, billingStateFromCard);
-    if (validatedBillingBillingStateFromCard) {
-      props.updateBillingState(validatedBillingBillingStateFromCard);
+    if (validatedBillingStateFromCard) {
+      props.updateBillingState(validatedBillingStateFromCard);
       countryAndStateValueOk = true;
     } else if (billingAccountRequiresAState && !props.billingState) {
       logException('Missing address_state in payment request token and no state/province selected in the form');

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -257,7 +257,8 @@ function onPayment(
 
   let countryAndStateValueOk = !billingAccountRequiresAState; // If Zuora requires a state then we're not OK yet.
   if (validatedCountryFromCard) {
-    const validatedBillingStateFromCard = stateProvinceFromString(validatedCountryFromCard, validatedCountryFromCard);
+    const validatedBillingStateFromCard: Option<StateProvince> =
+      stateProvinceFromString(validatedCountryFromCard, validatedCountryFromCard);
     if (billingAccountRequiresAState && !validatedBillingStateFromCard) {
       logException(`Invalid billing state: ${billingStateFromCard || ''} for billing country: ${billingCountryFromCard || ''}`);
       // Don't update the form, because the user may pick another payment method that doesn't update formData.

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -233,7 +233,7 @@ function onPayment(
   paymentRequestComplete: (string) => void,
   paymentRequestData: Object,
   billingCountryFromCard?: string,
-  billingBillingStateFromCard?: string,
+  billingStateFromCard?: string,
   processPayment: () => void,
 ): void {
   // Always dismiss the payment popup immediately - any pending/success/failure will be displayed on our own page.
@@ -257,7 +257,7 @@ function onPayment(
   if (validatedCountryFromCard) {
     props.updateBillingCountry(validatedCountryFromCard);
     const validatedBillingBillingStateFromCard: Option<StateProvince> =
-      stateProvinceFromString(validatedCountryFromCard, billingBillingStateFromCard);
+      stateProvinceFromString(validatedCountryFromCard, billingStateFromCard);
     if (validatedBillingBillingStateFromCard) {
       props.updateBillingState(validatedBillingBillingStateFromCard);
       countryAndStateValueOk = true;

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -258,7 +258,7 @@ function onPayment(
   let countryAndStateValueOk = !billingAccountRequiresAState; // If Zuora requires a state then we're not OK yet.
   if (validatedCountryFromCard) {
     const validatedBillingStateFromCard: Option<StateProvince> =
-      stateProvinceFromString(validatedCountryFromCard, validatedCountryFromCard);
+      stateProvinceFromString(validatedCountryFromCard, billingStateFromCard);
     if (billingAccountRequiresAState && !validatedBillingStateFromCard) {
       logException(`Invalid billing state: ${billingStateFromCard || ''} for billing country: ${billingCountryFromCard || ''}`);
       // Don't update the form, because the user may pick another payment method that doesn't update formData.

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -360,8 +360,13 @@ function regularPaymentRequestFromAuthorisation(
 
   // if we're going to be taking the country from GEO-IP then we need to take the state from there too
   if (!billingCountry) {
-    billingCountry = fromCountry(guardian.geoip.countryCode);
-    billingState = stateProvinceFromString(billingCountry, guardian.geoip.stateCode);
+    billingCountry = fromCountry(window.guardian.geoip.countryCode);
+
+    // if GEO-IP fails to resolve a country, then get it from the page's internationalisation which will never be null.
+    if (!billingCountry) {
+      billingCountry = state.common.internationalisation.countryId;
+    }
+    billingState = stateProvinceFromString(billingCountry, window.guardian.geoip.stateCode);
   }
 
   return {
@@ -372,9 +377,9 @@ function regularPaymentRequestFromAuthorisation(
       lineOne: null, // required go cardless field
       lineTwo: null, // required go cardless field
       city: null, // required go cardless field
-      state: billingCountry, // required Zuora field if country is US or CA
+      state: billingState, // required Zuora field if country is US or CA
       postCode: null, // required go cardless field
-      country: billingState, // required Zuora field
+      country: billingCountry, // required Zuora field
     },
     deliveryAddress: null,
     product: {

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -476,6 +476,11 @@ const onPaymentResult = (paymentResult: Promise<PaymentResult>, paymentAuthorisa
               // Must re-render the wallet widget in order to display amazon's error message
               dispatch(setAmazonPayWalletWidgetReady(false));
             }
+            // Reset any updates the previous payment method had made to the form's billingCountry or billingState
+            dispatch(updateBillingCountry(null));
+            dispatch(updateBillingState(null));
+
+            // Finally, trigger the form display
             dispatch(paymentFailure(result.error));
           }
 

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -12,7 +12,7 @@ import {
   type PaymentMatrix,
 } from 'helpers/contributions';
 import { getUserTypeFromIdentity, type UserTypeFromIdentityResponse } from 'helpers/identityApis';
-import { type IsoCountry, type CaState, type UsState, stateProvinceFromString, findIsoCountry } from 'helpers/internationalisation/country';
+import { type IsoCountry, type CaState, type UsState, StateProvince, stateProvinceFromString, findIsoCountry } from 'helpers/internationalisation/country';
 import type {
   RegularPaymentRequest,
   StripeCheckoutAuthorisation, StripePaymentIntentAuthorisation, StripePaymentMethod,
@@ -51,8 +51,7 @@ import { AmazonPay, DirectDebit, Stripe } from 'helpers/paymentMethods';
 import type { RecentlySignedInExistingPaymentMethod } from 'helpers/existingPaymentMethods/existingPaymentMethods';
 import { ExistingCard, ExistingDirectDebit } from 'helpers/paymentMethods';
 import { getStripeKey, stripeAccountForContributionType, type StripeAccount } from 'helpers/paymentIntegrations/stripeCheckout';
-import type {Option} from "../../helpers/types/option";
-import type {StateProvince} from "helpers/internationalisation/country";
+import type { Option } from 'helpers/types/option';
 
 export type Action =
   | { type: 'UPDATE_CONTRIBUTION_TYPE', contributionType: ContributionType }

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -351,7 +351,7 @@ const stripeChargeDataFromPaymentIntentAuthorisation = (
 
 function getBillingCountryAndState(state: State): {
   billingCountry: IsoCountry,
-  billingState: string | null,
+  billingState: UsState | CaState | null,
 } {
   // If the form provides a billing country, then it will also provide a billing state field if one is required.
   if (state.page.form.formData.billingCountry) {

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -477,7 +477,7 @@ const onPaymentResult = (paymentResult: Promise<PaymentResult>, paymentAuthorisa
               dispatch(setAmazonPayWalletWidgetReady(false));
             }
             // Reset any updates the previous payment method had made to the form's billingCountry or billingState
-            dispatch(updateBillingCountry(null));
+            dispatch(updateBillingCountry(''));
             dispatch(updateBillingState(null));
 
             // Finally, trigger the form display

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -62,7 +62,7 @@ export type Action =
   | { type: 'UPDATE_EMAIL', email: string }
   | { type: 'UPDATE_PASSWORD', password: string }
   | { type: 'UPDATE_BILLING_STATE', billingState: UsState | CaState | null }
-  | { type: 'UPDATE_BILLING_COUNTRY', billingCountry: IsoCountry }
+  | { type: 'UPDATE_BILLING_COUNTRY', billingCountry: IsoCountry | null }
   | { type: 'UPDATE_USER_FORM_DATA', userFormData: UserFormData }
   | { type: 'UPDATE_PAYMENT_READY', thirdPartyPaymentLibraryByContrib: { [ContributionType]: { [PaymentMethod]: ThirdPartyPaymentLibrary } } }
   | { type: 'SET_AMAZON_PAY_LOGIN_OBJECT', amazonLoginObject: Object }
@@ -174,7 +174,7 @@ const updateBillingState = (billingState: UsState | CaState | null): ((Function)
     dispatch(setFormSubmissionDependentValue(() => ({ type: 'UPDATE_BILLING_STATE', billingState })));
   };
 
-const updateBillingCountry = (billingCountry: IsoCountry): Action =>
+const updateBillingCountry = (billingCountry: IsoCountry | null): Action =>
   ({ type: 'UPDATE_BILLING_COUNTRY', billingCountry });
 
 const selectAmount = (amount: Amount | 'other', contributionType: ContributionType): ((Function) => void) =>
@@ -477,7 +477,7 @@ const onPaymentResult = (paymentResult: Promise<PaymentResult>, paymentAuthorisa
               dispatch(setAmazonPayWalletWidgetReady(false));
             }
             // Reset any updates the previous payment method had made to the form's billingCountry or billingState
-            dispatch(updateBillingCountry(''));
+            dispatch(updateBillingCountry(null));
             dispatch(updateBillingState(null));
 
             // Finally, trigger the form display

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -51,6 +51,8 @@ import { AmazonPay, DirectDebit, Stripe } from 'helpers/paymentMethods';
 import type { RecentlySignedInExistingPaymentMethod } from 'helpers/existingPaymentMethods/existingPaymentMethods';
 import { ExistingCard, ExistingDirectDebit } from 'helpers/paymentMethods';
 import { getStripeKey, stripeAccountForContributionType, type StripeAccount } from 'helpers/paymentIntegrations/stripeCheckout';
+import type {Option} from "../../helpers/types/option";
+import type {StateProvince} from "helpers/internationalisation/country";
 
 export type Action =
   | { type: 'UPDATE_CONTRIBUTION_TYPE', contributionType: ContributionType }
@@ -351,7 +353,7 @@ const stripeChargeDataFromPaymentIntentAuthorisation = (
 
 function getBillingCountryAndState(state: State): {
   billingCountry: IsoCountry,
-  billingState: UsState | CaState | null,
+  billingState: Option<StateProvince>,
 } {
   // If the form provides a billing country, then it will also provide a billing state field if one is required.
   if (state.page.form.formData.billingCountry) {
@@ -360,6 +362,7 @@ function getBillingCountryAndState(state: State): {
       billingState: state.page.form.formData.billingState,
     };
   }
+
   // Else, we need to get the country from GEO-IP or the page's internationalisation context.
   const billingCountry = findIsoCountry(window.guardian.geoip.countryCode) ||
     // If we cannot resolve country by GEO-IP, then use the page's context, which will never be null.

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -12,7 +12,7 @@ import {
   type PaymentMatrix,
 } from 'helpers/contributions';
 import { getUserTypeFromIdentity, type UserTypeFromIdentityResponse } from 'helpers/identityApis';
-import { type IsoCountry, type CaState, type UsState, StateProvince, stateProvinceFromString, findIsoCountry } from 'helpers/internationalisation/country';
+import { type IsoCountry, type CaState, type UsState, type StateProvince, stateProvinceFromString, findIsoCountry } from 'helpers/internationalisation/country';
 import type {
   RegularPaymentRequest,
   StripeCheckoutAuthorisation, StripePaymentIntentAuthorisation, StripePaymentMethod,

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -12,7 +12,7 @@ import {
   type PaymentMatrix,
 } from 'helpers/contributions';
 import { getUserTypeFromIdentity, type UserTypeFromIdentityResponse } from 'helpers/identityApis';
-import { type CaState, type UsState, stateProvinceFromString } from 'helpers/internationalisation/country';
+import { type IsoCountry, type CaState, type UsState, stateProvinceFromString, findIsoCountry } from 'helpers/internationalisation/country';
 import type {
   RegularPaymentRequest,
   StripeCheckoutAuthorisation, StripePaymentIntentAuthorisation, StripePaymentMethod,
@@ -51,8 +51,6 @@ import { AmazonPay, DirectDebit, Stripe } from 'helpers/paymentMethods';
 import type { RecentlySignedInExistingPaymentMethod } from 'helpers/existingPaymentMethods/existingPaymentMethods';
 import { ExistingCard, ExistingDirectDebit } from 'helpers/paymentMethods';
 import { getStripeKey, stripeAccountForContributionType, type StripeAccount } from 'helpers/paymentIntegrations/stripeCheckout';
-import type { IsoCountry } from '../../helpers/internationalisation/country';
-import {fromCountry} from "../../helpers/internationalisation/countryGroup";
 
 export type Action =
   | { type: 'UPDATE_CONTRIBUTION_TYPE', contributionType: ContributionType }
@@ -360,7 +358,7 @@ function regularPaymentRequestFromAuthorisation(
 
   // if we're going to be taking the country from GEO-IP then we need to take the state from there too
   if (!billingCountry) {
-    billingCountry = fromCountry(window.guardian.geoip.countryCode);
+    billingCountry = findIsoCountry(window.guardian.geoip.countryCode);
 
     // if GEO-IP fails to resolve a country, then get it from the page's internationalisation which will never be null.
     if (!billingCountry) {

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.js
@@ -250,7 +250,7 @@ const init = (store: Store<State, Action, Function>) => {
 
   dispatch(checkIfEmailHasPassword(email));
   dispatch(updateUserFormData({
-    firstName, lastName, email, state: stateField,
+    firstName, lastName, email, billingState: stateField,
   }));
 
 };

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
@@ -31,7 +31,7 @@ export type UserFormData = {
   firstName: string | null,
   lastName: string | null,
   email: string | null,
-  state: string | null,
+  billingState: string | null,
 }
 
 export type ThankYouPageStageMap<T> = {
@@ -45,7 +45,7 @@ export type ThankYouPageStage = $Keys<ThankYouPageStageMap<null>>
 
 type FormData = UserFormData & {
   otherAmounts: OtherAmounts,
-  state: UsState | CaState | null,
+  billingState: UsState | CaState | null,
   billingCountry: IsoCountry | null,
   checkoutFormHasBeenSubmitted: boolean,
 };
@@ -176,7 +176,7 @@ function createFormReducer() {
         MONTHLY: { amount: null },
         ANNUAL: { amount: null },
       },
-      state: null,
+      billingState: null,
       billingCountry: null,
       checkoutFormHasBeenSubmitted: false,
     },
@@ -383,8 +383,8 @@ function createFormReducer() {
       case 'SET_USER_TYPE_FROM_IDENTITY_RESPONSE':
         return { ...state, userTypeFromIdentityResponse: action.userTypeFromIdentityResponse };
 
-      case 'UPDATE_STATE_OR_PROVINCE':
-        return { ...state, formData: { ...state.formData, state: action.state } };
+      case 'UPDATE_BILLING_STATE':
+        return { ...state, formData: { ...state.formData, billingState: action.billingState } };
 
       case 'UPDATE_BILLING_COUNTRY':
         return { ...state, formData: { ...state.formData, billingCountry: action.billingCountry } };


### PR DESCRIPTION
## Why are you doing this?
This change fixes 3 bugs and has 1 refactor:

1) A mismatch between the state and country when the user's billing data is sent to Zuora. Before, when somebody chose not to transact in USD, CAD or GBP, but was based in USA or CA (where a state is required), we would read their billing country from their GEO-IP, but then we'd have no state to add alongside the country, as the form for the other currencies do not have a state drop-down, and would submit a blank state which would error in Zuora. This solution also reads the state value from GEO-IP. It's not a perfect solution as the GEO-IP read may fail. A full solution would be to include a billing country and optional state drop-down on all checkouts. That may be a later PR if we still get some of these 'on holiday' errors. This was not introduced by https://github.com/guardian/support-frontend/pull/2372 but it does rename the `'UPDATE_STATE_OR_PROVINCE'` action which was also renamed in that PR.

2) Fixed a bug in the StripePaymentRequestButton.jsx where we would log that we were missing a state value for non US or CA checkouts.

3) Fixed a bug where if the payment from the PRB fails, the country from the PRB would remain in the formData, and be selected with highest precedence. If the user decided to move to using card entry, and it was the US or CA checkout which required a state, then the transaction would be permanently blocked because there was no way to set the billingCountry back to the page internationalisation.

4) Refactored the 2 Actions.js and Reducer.js and formValidation.js classes to name the real-world (not React) 'state' variable 'billingState' in order to distinguish it and be named similar to billingCountry.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/qNyxy3in)

## Screenshots
<img width="1335" alt="Screen Shot 2020-03-04 at 13 33 47" src="https://user-images.githubusercontent.com/1515970/75884583-0342e680-5e1d-11ea-9431-545e9fc1951d.png">

