### PR TITLE
Ds remove subs banner ab test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtest.js
+++ b/support-frontend/assets/helpers/abTests/abtest.js
@@ -237,8 +237,11 @@ function assignUserToVariant(
 
   if (referrerControlled && acquisitionDataTest != null) {
     const acquisitionVariant = acquisitionDataTest.variant;
+
     const index = test.variants.findIndex(variant => variant.id === acquisitionVariant);
-    if (!index) {
+    const variantFound = index > -1;
+
+    if (!variantFound) {
       console.error('Variant not found for A/B test in acquistion data');
     }
     return index;

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -9,7 +9,6 @@ export type PersonalisedThankYouPageTestVariants = 'control' | 'personalised' | 
 export type PostContributionReminderCopyTestVariants = 'control' | 'extendedCopy' | 'notintest';
 
 const contributionsLandingPageMatch = '/(uk|us|eu|au|ca|nz|int)/contribute(/.*)?$';
-const digitalLandingPageMatch = '/(uk|us|eu|au|ca|nz|int)/subscribe/digital(/.*)?$';
 
 export const tests: Tests = {
 
@@ -79,6 +78,7 @@ export const tests: Tests = {
     targetPage: contributionsLandingPageMatch,
   },
 
+<<<<<<< HEAD
   SubsBannerNewYearCopyTest: {
     type: 'OTHER',
     variants: [
@@ -103,6 +103,9 @@ export const tests: Tests = {
   },
 
   choiceCardsProductSetTestR2: {
+=======
+  choiceCardsProductSetTest: {
+>>>>>>> feat: removed subs banner test
     type: 'OTHER',
     variants: [
       {

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -78,34 +78,7 @@ export const tests: Tests = {
     targetPage: contributionsLandingPageMatch,
   },
 
-<<<<<<< HEAD
-  SubsBannerNewYearCopyTest: {
-    type: 'OTHER',
-    variants: [
-      {
-        id: 'control',
-      },
-      {
-        id: 'variant',
-      },
-    ],
-    audiences: {
-      ALL: {
-        offset: 0,
-        size: 0,
-      },
-    },
-    isActive: true,
-    referrerControlled: true,
-    seed: 12,
-    targetPage: digitalLandingPageMatch,
-    optimizeId: '21HyzxNZSmikdtgJQNnXUw',
-  },
-
-  choiceCardsProductSetTestR2: {
-=======
   choiceCardsProductSetTest: {
->>>>>>> feat: removed subs banner test
     type: 'OTHER',
     variants: [
       {

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -78,7 +78,7 @@ export const tests: Tests = {
     targetPage: contributionsLandingPageMatch,
   },
 
-  choiceCardsProductSetTest: {
+  choiceCardsProductSetTestR2: {
     type: 'OTHER',
     variants: [
       {

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -55,8 +55,7 @@
       "ophan(.*)": "<rootDir>/node_modules/ophan-tracker-js/build/ophan.support"
     },
     "verbose": true,
-    "testEnvironment": "./jestEnvironment",
-    "testURL": "https://www.somthing.com/test.html"
+    "testEnvironment": "./jestEnvironment"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Why are you doing this?
This PR is connected to [ds-remove-subs-banner-ab-test](https://github.com/guardian/frontend/pull/22368) PR on `frontend`, this required we remove the ab-test object `SubsBannerNewYearCopyTest`

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/fSvMOs3M/2891-turn-off-subs-banner-ab-test)

## Changes

* remove ab-test object

## Screenshots
N/A
