### PR TITLE
Adds accessibility prompt checklist to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,5 +14,10 @@ the breakage for reference.
 * Change 1
 * Change 2
 
+## Accessibility test checklist
+ - [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
+ - [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
+ - [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)
+
 ## Screenshots
 


### PR DESCRIPTION
## Why are you doing this?
At the most recent accessibility champions meeting, we discussed ways to prompt ourselves to check our code is accessible. Having a list of prompts in the pull request template seems like a good place to add this sort of prompt. This list is copied from the frontend PR template.

## Changes
Adds a list of accessibility prompts to the PR template.
