### PR TITLE
Salesforce Address Overwrite Fix

### DIFF
--- a/support-workers/src/main/scala/com/gu/salesforce/SalesforceService.scala
+++ b/support-workers/src/main/scala/com/gu/salesforce/SalesforceService.scala
@@ -89,25 +89,25 @@ class SalesforceService(config: SalesforceConfig, client: FutureHttpClient)(impl
       )
     ).getOrElse(
       NewContact(
-        user.id,
-        user.primaryEmailAddress,
-        user.title,
-        user.firstName,
-        user.lastName,
-        getAddressLine(user.billingAddress),
-        user.billingAddress.city,
-        user.billingAddress.state,
-        user.billingAddress.postCode,
-        user.billingAddress.country.name,
-        getAddressLine(user.deliveryAddress.getOrElse(user.billingAddress)),
-        user.deliveryAddress.flatMap(_.city),
-        user.deliveryAddress.flatMap(_.state),
-        user.deliveryAddress.flatMap(_.postCode),
-        user.deliveryAddress.map(_.country.name),
-        user.telephoneNumber,
-        user.allowMembershipMail,
-        user.allowThirdPartyMail,
-        user.allowGURelatedMail
+        IdentityID__c = user.id,
+        Email = user.primaryEmailAddress,
+        Salutation = user.title,
+        FirstName = user.firstName,
+        LastName = user.lastName,
+        OtherStreet = getAddressLine(user.billingAddress),
+        OtherCity = user.billingAddress.city,
+        OtherState = user.billingAddress.state,
+        OtherPostalCode = user.billingAddress.postCode,
+        OtherCountry = user.billingAddress.country.name,
+        MailingStreet = getAddressLine(user.deliveryAddress.getOrElse(user.billingAddress)),
+        MailingCity = user.deliveryAddress.flatMap(_.city),
+        MailingState = user.deliveryAddress.flatMap(_.state),
+        MailingPostalCode = user.deliveryAddress.flatMap(_.postCode),
+        MailingCountry = user.deliveryAddress.map(_.country.name),
+        Phone = user.telephoneNumber,
+        Allow_Membership_Mail__c = user.allowMembershipMail,
+        Allow_3rd_Party_Mail__c = user.allowThirdPartyMail,
+        Allow_Guardian_Related_Mail__c = user.allowGURelatedMail
       )
     )
 

--- a/support-workers/src/main/scala/com/gu/salesforce/SalesforceService.scala
+++ b/support-workers/src/main/scala/com/gu/salesforce/SalesforceService.scala
@@ -99,7 +99,7 @@ class SalesforceService(config: SalesforceConfig, client: FutureHttpClient)(impl
         OtherState = user.billingAddress.state,
         OtherPostalCode = user.billingAddress.postCode,
         OtherCountry = user.billingAddress.country.name,
-        MailingStreet = getAddressLine(user.deliveryAddress.getOrElse(user.billingAddress)),
+        MailingStreet = user.deliveryAddress.flatMap(getAddressLine),
         MailingCity = user.deliveryAddress.flatMap(_.city),
         MailingState = user.deliveryAddress.flatMap(_.state),
         MailingPostalCode = user.deliveryAddress.flatMap(_.postCode),

--- a/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
@@ -27,7 +27,34 @@ object JsonFixtures {
           "lastName": "user",
           "country": "GB",
           "billingAddress": {
-            "country": "GB"
+            "country": "GB",
+            "lineOne": "The Guardian",
+            "lineTwo": "Kings Place",
+            "city": "london",
+            "postCode": "n1 9gu"
+          },
+          "allowMembershipMail": false,
+          "allowThirdPartyMail": false,
+          "allowGURelatedMail": false,
+          "isTestUser": false,
+          "deliveryInstructions": "Leave with neighbour"
+        }
+    """
+
+  def userJsonAlternate(id: String = idId): String =
+    s"""
+      "user":{
+          "id": "$id",
+          "primaryEmailAddress": "$emailAddress",
+          "firstName": "test",
+          "lastName": "user",
+          "country": "GB",
+          "billingAddress": {
+            "country": "GB",
+            "lineOne": "22 Monkey Street",
+            "lineTwo": "",
+            "city": "Birmingham",
+            "postCode": "BM66AJ"
           },
           "allowMembershipMail": false,
           "allowThirdPartyMail": false,
@@ -235,6 +262,16 @@ object JsonFixtures {
         }"""
 
   val createSalesForceContactJson =
+    s"""
+          {
+            $requestIdJson,
+            ${userJson(	"200001969")},
+            "product": ${contribution()},
+            "paymentMethod": $payPalPaymentMethod
+          }
+        """
+
+  val createSalesForceGiftContactJson =
     s"""
           {
             $requestIdJson,

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/CreateSalesforceContactSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/CreateSalesforceContactSpec.scala
@@ -4,7 +4,7 @@ import java.io.ByteArrayOutputStream
 
 import com.gu.salesforce.Fixtures.salesforceId
 import com.gu.support.workers.{AsyncLambdaSpec, MockContext}
-import com.gu.support.workers.JsonFixtures.{createSalesForceContactJson, wrapFixture}
+import com.gu.support.workers.JsonFixtures.{createSalesForceGiftContactJson, createSalesForceContactJson, wrapFixture}
 import com.gu.support.workers.encoding.Conversions.FromOutputStream
 import com.gu.support.workers.encoding.Encoding
 import com.gu.support.workers.lambdas.CreateSalesforceContact
@@ -20,6 +20,20 @@ class CreateSalesforceContactSpec extends AsyncLambdaSpec with MockContext {
     val outStream = new ByteArrayOutputStream()
 
     createContact.handleRequestFuture(wrapFixture(createSalesForceContactJson), outStream, context).map { _ =>
+
+      val result = Encoding.in[CreateZuoraSubscriptionState](outStream.toInputStream)
+      result.isSuccess should be(true)
+      val contacts = result.get._1.salesforceContacts
+      contacts.buyer.Id should be("0033E00001CVatAQAT")
+    }
+  }
+
+  it should "upsert a gift SalesforceContactRecord" in {
+    val createContact = new CreateSalesforceContact()
+
+    val outStream = new ByteArrayOutputStream()
+
+    createContact.handleRequestFuture(wrapFixture(createSalesForceGiftContactJson), outStream, context).map { _ =>
 
       val result = Encoding.in[CreateZuoraSubscriptionState](outStream.toInputStream)
       result.isSuccess should be(true)

--- a/support-workers/src/test/scala/com/gu/support/workers/lambdas/CreateSalesforceContactDecoderSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/lambdas/CreateSalesforceContactDecoderSpec.scala
@@ -14,7 +14,7 @@ import org.scalatestplus.mockito.MockitoSugar
 class CreateSalesforceContactDecoderSpec extends AnyFlatSpec with Matchers with MockitoSugar with LazyLogging {
 
   "CreateSalesforceContactDecoder" should "be able to decode a CreateSalesforceContactState" in {
-    val state = decode[CreateSalesforceContactState](createSalesForceContactJson)
+    val state = decode[CreateSalesforceContactState](createSalesForceGiftContactJson)
     val result = state.right.get
     result.product match {
       case contribution: Contribution => contribution.amount should be(5)


### PR DESCRIPTION
## Why are you doing this?
This PR is a fix for the following bug:

* User signs up for a Guardian Weekly subscription (or any sub with a delivery address)
* User subsequently signs up for digital subscription with a different billing address to the previous subscription's delivery address
* The first line of the user's delivery address will be overwritten by the new billing address potentially rendering it useless

## An example of this bug
### GW subscription before purchasing a digital sub
![Picture 114](https://user-images.githubusercontent.com/181371/75987338-ae1fd700-5ee7-11ea-8ca6-c6a49298273a.png)
### GW subscription after purchasing a digital sub
![Picture 115](https://user-images.githubusercontent.com/181371/75987341-afe99a80-5ee7-11ea-89b6-5f2b8f2c6bd0.png)

[**Trello Card**](https://trello.com/c/V8ZDHGWq/2885-spike-replicate-potential-bug-when-user-has-a-print-product-and-buys-a-subsequent-digital-product)
