### PR TITLE
Add paypal to paper acquisition alarm

### DIFF
--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -358,7 +358,7 @@ Resources:
 
 
   # This alarm is for the PaymentSuccess metric where
-  # ProductType == Paper AND PaymentProvider in [Stripe, Gocardless]
+  # ProductType == Paper AND PaymentProvider in [Stripe, Gocardless, Paypal]
 
   NoPaperAcquisitionInOneDayAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -369,7 +369,7 @@ Resources:
       AlarmName: !Sub URGENT 9-5 - ${Stage} support-workers No successful paper checkouts in 24h
       Metrics:
         - Id: e1
-          Expression: "SUM([FILL(m1,0),FILL(m2,0)])"
+          Expression: "SUM([FILL(m1,0),FILL(m2,0),FILL(m3,0)])"
           Label: AllPaperConversions
         - Id: m1
           Label: String
@@ -395,6 +395,23 @@ Resources:
               Dimensions:
                 - Name: PaymentProvider
                   Value: Gocardless
+                - Name: ProductType
+                  Value: Paper
+                - Name: Stage
+                  Value: !Ref Stage
+              MetricName: PaymentSuccess
+              Namespace: support-frontend
+            Period: 300
+            Stat: Sum
+            Unit: Count
+          ReturnData: false
+        - Id: m3
+          Label: String
+          MetricStat:
+            Metric:
+              Dimensions:
+                - Name: PaymentProvider
+                  Value: Paypal
                 - Name: ProductType
                   Value: Paper
                 - Name: Stage


### PR DESCRIPTION
## Why are you doing this?
The `no paper acqusitions` alarm went off yesterday and while investigating why that might've been we noticed that we had neglected to add paypal to the metrics behind the alarm since that was added to the paper checkout.

Note: I feel like we also need an alarm like this for GW acquisitions - I'll make a card.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com)

## Changes

* Include paypal metric in the summed metrics for this alarm

## Accessibility test checklist
N/A

## Screenshots
N/A
