### PR TITLE
Fix tab highlight issue

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
@@ -63,6 +63,7 @@ const mapDispatchToProps = (dispatch: Function) => ({
 function withProps(props: PropTypes) {
   const contributionTypes = props.contributionTypes[props.countryGroupId];
 
+
   const renderContribTypeChoiceCards = () => (
     <>
       <ChoiceCardGroup

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
@@ -32,6 +32,8 @@ import { setUserStateActions } from './setUserStateActions';
 import ConsentBanner from 'components/consentBanner/consentBanner';
 import './contributionsLanding.scss';
 import './newContributionsLandingTemplate.scss';
+import { FocusStyleManager } from '@guardian/src-utilities';
+
 
 if (!isDetailsSupported) {
   polyfillDetails();
@@ -85,6 +87,7 @@ const setOneOffContributionCookie = () => {
   );
 };
 
+
 const campaignName = getCampaignName();
 
 const cssModifiers = campaignName && campaigns[campaignName] && campaigns[campaignName].cssModifiers ?
@@ -92,6 +95,8 @@ const cssModifiers = campaignName && campaigns[campaignName] && campaigns[campai
 
 const backgroundImageSrc = campaignName && campaigns[campaignName] && campaigns[campaignName].backgroundImage ?
   campaigns[campaignName].backgroundImage : null;
+
+FocusStyleManager.onlyShowFocusOnTabs(); // https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility
 
 const contributionsLandingPage = (campaignCodeParameter: ?string) => (
   <Page

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -70,6 +70,7 @@
     "@guardian/src-choice-card": "^0.14.0-alpha.3",
     "@guardian/src-foundations": "^0.14.1",
     "@guardian/src-svgs": "^0.14.0",
+    "@guardian/src-utilities": "^0.14.0",
     "@sentry/browser": "^5.4.0",
     "cssnano": "^4.1.10",
     "dompurify": "^2.0.7",

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -1802,6 +1802,11 @@
   resolved "https://registry.yarnpkg.com/@guardian/src-svgs/-/src-svgs-0.14.0.tgz#3a5a6d385f2639aca884b5302f3d3ae6e919e290"
   integrity sha512-ZGwVwVlX3YwG62xO1YjxaHyGFJC8Us80GPeyY8CMv5lfshYd0gGDNJN6vjUI3ssULjcP8ckGOTFcTFs3hOUrMw==
 
+"@guardian/src-utilities@^0.14.0":
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/@guardian/src-utilities/-/src-utilities-0.14.0.tgz#681a3f306d80bec95553e4e398a290d2ce9ef7a9"
+  integrity sha512-UgVTfNmX9ao9fWa8hfixsy9zezyE/77xtWAuvdBLFRXOKmxpXUwl9uWLPtMQgbAlhOwef5sX1AXxe3KAeVYMMg==
+
 "@icons/material@^0.2.4":
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/@icons/material/-/material-0.2.4.tgz#e90c9f71768b3736e76d7dd6783fc6c2afa88bc8"


### PR DESCRIPTION
## Why are you doing this?

There was an issue on Chrome and Edge where clicking on a card with the mouse caused the tab highlight to appear and persist until another click was made. The tab highlight should only show for keyboard navigation on tabbing. This PR fixes that issue.

## Changes

* Fix tab highlight issue

## Screenshots
### before - tab highlight persisting on mouse click (Chrome/Edge)
![image](https://user-images.githubusercontent.com/15648334/75994509-fee8fd00-5ef2-11ea-8427-b688db122ab1.png)

### after
![image](https://user-images.githubusercontent.com/15648334/75995149-ea593480-5ef3-11ea-8b25-956265759761.png)



