### PR TITLE
New A/B test for Payment Request Button

### DIFF
--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -111,8 +111,8 @@
     window.guardian.guestAccountCreationToken = "@guestAccountCreationToken";
   }
 
-  window.guardian.stripeElementsRecurring = @settings.switches.experiments.get("stripeElementsRecurring").exists(_.isOn)
   window.guardian.forceCampaign = @settings.switches.experiments.get("forceCampaign").exists(_.isOn)
+
   window.guardian.recurringStripePaymentRequestButton = @settings.switches.experiments.get("recurringStripePaymentRequestButton").exists(_.isOn)
 
   window.guardian.recaptchaV2 = @settings.switches.experiments.get("recaptchaV2").exists(_.isOn)

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -113,8 +113,6 @@
 
   window.guardian.forceCampaign = @settings.switches.experiments.get("forceCampaign").exists(_.isOn)
 
-  window.guardian.recurringStripePaymentRequestButton = @settings.switches.experiments.get("recurringStripePaymentRequestButton").exists(_.isOn)
-
   window.guardian.recaptchaV2 = @settings.switches.experiments.get("recaptchaV2").exists(_.isOn)
 
   window.guardian.v2recaptchaPublicKey = "@v2recaptchaConfigPublicKey"

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -3,13 +3,10 @@ import type { Tests } from './abtest';
 import { USV1, UKV1Lower, UKV2Higher } from './data/testAmountsData';
 
 // ----- Tests ----- //
-export type StripePaymentRequestButtonScaTestVariants = 'control' | 'sca' | 'notintest';
 export type ChoiceCardsProductSetTestR3Variants = 'control' | 'yellow';
 export type StripePaymentRequestButtonTestVariants = 'control' | 'button';
-export type ChoiceCardsProductSetTestR2Variants = 'control' | 'rectangles';
 export type PersonalisedThankYouPageTestVariants = 'control' | 'personalised' | 'notintest';
 export type PostContributionReminderCopyTestVariants = 'control' | 'extendedCopy' | 'notintest';
-export type recaptchaPresenceTestVariants = 'control' | 'recaptchaPresent';
 
 const contributionsLandingPageMatch = '/(uk|us|eu|au|ca|nz|int)/contribute(/.*)?$';
 const usOnlyLandingPage = '/us/contribute(/.*)?$';

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -5,8 +5,6 @@ import { USV1, UKV1Lower, UKV2Higher } from './data/testAmountsData';
 // ----- Tests ----- //
 export type ChoiceCardsProductSetTestR3Variants = 'control' | 'yellow';
 export type StripePaymentRequestButtonTestVariants = 'control' | 'button';
-export type PersonalisedThankYouPageTestVariants = 'control' | 'personalised' | 'notintest';
-export type PostContributionReminderCopyTestVariants = 'control' | 'extendedCopy' | 'notintest';
 
 const contributionsLandingPageMatch = '/(uk|us|eu|au|ca|nz|int)/contribute(/.*)?$';
 const usOnlyLandingPage = '/us/contribute(/.*)?$';
@@ -34,27 +32,6 @@ export const tests: Tests = {
     referrerControlled: false,
     targetPage: usOnlyLandingPage,
     seed: 5,
-  },
-  postContributionReminderCopyTest: {
-    type: 'OTHER',
-    variants: [
-      {
-        id: 'control',
-      },
-      {
-        id: 'extendedCopy',
-      },
-    ],
-    audiences: {
-      ALL: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: true,
-    referrerControlled: false,
-    seed: 4,
-    targetPage: contributionsLandingPageMatch,
   },
 
   stripePaymentRequestButtonVsNoButton: {

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -4,8 +4,12 @@ import { USV1, UKV1Lower, UKV2Higher } from './data/testAmountsData';
 
 // ----- Tests ----- //
 export type StripePaymentRequestButtonScaTestVariants = 'control' | 'sca' | 'notintest';
-
 export type ChoiceCardsProductSetTestR3Variants = 'control' | 'yellow';
+export type StripePaymentRequestButtonTestVariants = 'control' | 'button';
+export type ChoiceCardsProductSetTestR2Variants = 'control' | 'rectangles';
+export type PersonalisedThankYouPageTestVariants = 'control' | 'personalised' | 'notintest';
+export type PostContributionReminderCopyTestVariants = 'control' | 'extendedCopy' | 'notintest';
+export type recaptchaPresenceTestVariants = 'control' | 'recaptchaPresent';
 
 const contributionsLandingPageMatch = '/(uk|us|eu|au|ca|nz|int)/contribute(/.*)?$';
 const usOnlyLandingPage = '/us/contribute(/.*)?$';

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -34,15 +34,14 @@ export const tests: Tests = {
     targetPage: usOnlyLandingPage,
     seed: 5,
   },
-
-  stripePaymentRequestButtonSca: {
+  postContributionReminderCopyTest: {
     type: 'OTHER',
     variants: [
       {
         id: 'control',
       },
       {
-        id: 'sca',
+        id: 'extendedCopy',
       },
     ],
     audiences: {
@@ -51,7 +50,29 @@ export const tests: Tests = {
         size: 1,
       },
     },
-    isActive: window.guardian && !!window.guardian.recurringStripePaymentRequestButton,
+    isActive: true,
+    referrerControlled: false,
+    seed: 4,
+    targetPage: contributionsLandingPageMatch,
+  },
+
+  stripePaymentRequestButtonVsNoButton: {
+    type: 'OTHER',
+    variants: [
+      {
+        id: 'control',
+      },
+      {
+        id: 'button',
+      },
+    ],
+    audiences: {
+      ALL: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: true,
     referrerControlled: false,
     seed: 2,
     targetPage: contributionsLandingPageMatch,

--- a/support-frontend/assets/helpers/stripe.js
+++ b/support-frontend/assets/helpers/stripe.js
@@ -16,3 +16,9 @@ export const setupStripe = (setStripeHasLoaded: () => void) => {
     }
   }
 };
+export const stripeCardFormIsIncomplete = (
+  paymentMethod: PaymentMethod,
+  stripeCardFormComplete: boolean,
+): boolean =>
+  paymentMethod === Stripe &&
+  !(stripeCardFormComplete);

--- a/support-frontend/assets/helpers/stripe.js
+++ b/support-frontend/assets/helpers/stripe.js
@@ -1,5 +1,6 @@
 // @flow
 import { logException } from 'helpers/logger';
+import { type PaymentMethod, Stripe } from 'helpers/paymentMethods';
 
 export const setupStripe = (setStripeHasLoaded: () => void) => {
   if (window.Stripe) {

--- a/support-frontend/assets/pages/contributions-landing/checkoutFormIsSubmittableActions.js
+++ b/support-frontend/assets/pages/contributions-landing/checkoutFormIsSubmittableActions.js
@@ -25,7 +25,7 @@ import {
   setFormIsValid,
 } from './contributionsLandingActions';
 import { recaptchaEnabled } from 'helpers/recaptcha';
-import { Stripe } from 'helpers/paymentMethods';
+import { stripeCardFormIsIncomplete } from 'helpers/stripe';
 
 // ----- Types ----- //
 

--- a/support-frontend/assets/pages/contributions-landing/checkoutFormIsSubmittableActions.js
+++ b/support-frontend/assets/pages/contributions-landing/checkoutFormIsSubmittableActions.js
@@ -94,7 +94,10 @@ const formIsValidParameters = (state: State) => ({
   firstName: state.page.form.formData.firstName,
   lastName: state.page.form.formData.lastName,
   email: state.page.form.formData.email,
-  stripeCardFormOk: state.page.form.paymentMethod !== Stripe || state.page.form.stripeCardFormData.formComplete,
+  stripeCardFormOk: !stripeCardFormIsIncomplete(
+    state.page.form.paymentMethod,
+    state.page.form.stripeCardFormData.formComplete,
+  ),
 });
 
 function enableOrDisableForm() {

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -48,7 +48,7 @@ import type { StripeAccount } from 'helpers/paymentIntegrations/stripeCheckout';
 import type { ErrorReason } from 'helpers/errorReasons';
 import GeneralErrorMessage from 'components/generalErrorMessage/generalErrorMessage';
 import { toHumanReadableContributionType, getAvailablePaymentRequestButtonPaymentMethod } from 'helpers/checkouts';
-import type { StripePaymentRequestButtonScaTestVariants } from 'helpers/abTests/abtestDefinitions';
+import type { StripePaymentRequestButtonTestVariants } from 'helpers/abTests/abtestDefinitions';
 import type { Option } from 'helpers/types/option';
 import type { Csrf as CsrfState } from '../../../../helpers/csrf/csrfReducer';
 
@@ -84,7 +84,7 @@ type PropTypes = {|
   setPaymentWaiting: (isWaiting: boolean) => Action,
   setError: (error: ErrorReason, stripeAccount: StripeAccount) => Action,
   setHandleStripe3DS: ((clientSecret: string) => Promise<Stripe3DSResult>) => Action,
-  scaTestVariant: StripePaymentRequestButtonScaTestVariants,
+  abTestButtonVsNoButton: StripePaymentRequestButtonTestVariants,
   csrf: CsrfState,
 |};
 

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -343,10 +343,12 @@ function initialisePaymentRequest(props: PropTypes) {
   paymentRequest.canMakePayment().then((result) => {
     const paymentMethod = getAvailablePaymentRequestButtonPaymentMethod(result, props.contributionType);
     if (paymentMethod) {
-      props.setPaymentRequestButtonPaymentMethod(paymentMethod, props.stripeAccount);
-      trackComponentClick(`${paymentMethod}-loaded`);
       if (paymentMethod === 'StripeApplePay' || props.abTestButtonVsNoButton === 'button') {
+        trackComponentLoad(`${paymentMethod}-displayed`);
+        props.setPaymentRequestButtonPaymentMethod(paymentMethod, props.stripeAccount);
         setUpPaymentListenerSca(props, paymentRequest, paymentMethod);
+      } else {
+        trackComponentLoad(`${paymentMethod}-hidden`);
       }
     } else {
       props.setPaymentRequestButtonPaymentMethod('none', props.stripeAccount);

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -349,6 +349,7 @@ function initialisePaymentRequest(props: PropTypes) {
         setUpPaymentListenerSca(props, paymentRequest, paymentMethod);
       } else {
         trackComponentLoad(`${paymentMethod}-hidden`);
+        props.setPaymentRequestButtonPaymentMethod('none', props.stripeAccount);
       }
     } else {
       props.setPaymentRequestButtonPaymentMethod('none', props.stripeAccount);

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -44,10 +44,10 @@ import {
 } from 'pages/contributions-landing/contributionsLandingActions';
 import type { PaymentMethod } from 'helpers/paymentMethods';
 import { Stripe } from 'helpers/paymentMethods';
-import { getAvailablePaymentRequestButtonPaymentMethod, toHumanReadableContributionType } from 'helpers/checkouts';
 import type { StripeAccount } from 'helpers/paymentIntegrations/stripeCheckout';
 import type { ErrorReason } from 'helpers/errorReasons';
 import GeneralErrorMessage from 'components/generalErrorMessage/generalErrorMessage';
+import { toHumanReadableContributionType, getAvailablePaymentRequestButtonPaymentMethod } from 'helpers/checkouts';
 import type { StripePaymentRequestButtonScaTestVariants } from 'helpers/abTests/abtestDefinitions';
 import type { Option } from 'helpers/types/option';
 import type { Csrf as CsrfState } from '../../../../helpers/csrf/csrfReducer';
@@ -100,7 +100,7 @@ const mapStateToProps = (state: State, ownProps: PropTypes) => ({
   contributionType: state.page.form.contributionType,
   paymentMethod: state.page.form.paymentMethod,
   switches: state.common.settings.switches,
-  scaTestVariant: state.common.abParticipations.stripePaymentRequestButtonSca,
+  abTestButtonVsNoButton: state.common.abParticipations.stripePaymentRequestButtonVsNoButton,
   csrf: state.page.csrf,
 });
 
@@ -277,26 +277,6 @@ function onPayment(
   }
 }
 
-function setUpPaymentListenerNonSca(props: PropTypes, paymentRequest: Object, paymentMethod: StripePaymentMethod) {
-  paymentRequest.on('token', ({ complete, token, ...data }) => {
-
-    const processPayment = () => {
-      const tokenId = props.isTestUser ? 'tok_visa' : token.id;
-      props.onPaymentAuthorised({ paymentMethod: Stripe, token: tokenId, stripePaymentMethod: paymentMethod })
-        .then(onComplete);
-    };
-
-    onPayment(
-      props,
-      complete,
-      data,
-      token.card.address_country,
-      token.card.address_state,
-      processPayment,
-    );
-  });
-}
-
 function setUpPaymentListenerSca(props: PropTypes, paymentRequest: Object, stripePaymentMethod: StripePaymentMethod) {
   paymentRequest.on('paymentmethod', ({ complete, paymentMethod, ...data }) => {
 
@@ -357,7 +337,7 @@ function initialisePaymentRequest(props: PropTypes) {
       amount: props.amount * 100,
     },
     requestPayerEmail: true,
-    requestPayerName: props.stripeAccount !== 'ONE_OFF',
+    requestPayerName: props.contributionType !== 'ONE_OFF',
   });
 
   paymentRequest.canMakePayment().then((result) => {
@@ -365,11 +345,8 @@ function initialisePaymentRequest(props: PropTypes) {
     if (paymentMethod) {
       props.setPaymentRequestButtonPaymentMethod(paymentMethod, props.stripeAccount);
       trackComponentClick(`${paymentMethod}-loaded`);
-
-      if (props.scaTestVariant === 'sca') {
+      if (paymentMethod === 'StripeApplePay' || props.abTestButtonVsNoButton === 'button') {
         setUpPaymentListenerSca(props, paymentRequest, paymentMethod);
-      } else {
-        setUpPaymentListenerNonSca(props, paymentRequest, paymentMethod);
       }
     } else {
       props.setPaymentRequestButtonPaymentMethod('none', props.stripeAccount);


### PR DESCRIPTION
## Why are you doing this?
We want to see if the Payment Request Button really is worth using or not. It may be that its presence is a net detractor. Apple Pay remains fully rolled out if it's available on the browser.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com)

## Changes

* This change sets up a new A/B test for the Payment Request Button across both checkouts. To simplify things, it also fully enables the SCA variant of the Payment Request Button as that variant is performing equally as well as the non-SCA version.

## Accessibility test checklist - N/A

## Screenshots - N/A

## Testing
 - [x] Locally
 - [x] CODE
