### PR TITLE
[support-workers] fix intermittent issues with PreparePaymentMethodForReuse step

### DIFF
--- a/support-models/src/main/scala/com/gu/support/workers/PaymentMethods.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/PaymentMethods.scala
@@ -39,7 +39,7 @@ case class CreditCardReferenceTransaction(
   creditCardCountry: Option[Country],
   creditCardExpirationMonth: Int,
   creditCardExpirationYear: Int,
-  creditCardType: String /*TODO: strip spaces?*/ ,
+  creditCardType: Option[String] /*TODO: strip spaces?*/ ,
   paymentGateway: PaymentGateway,
   `type`: String = "CreditCardReferenceTransaction",
   stripePaymentType: Option[StripePaymentType]

--- a/support-models/src/main/scala/com/gu/support/zuora/api/PaymentGateway.scala
+++ b/support-models/src/main/scala/com/gu/support/zuora/api/PaymentGateway.scala
@@ -20,6 +20,7 @@ object PaymentGateway {
     case StripeGatewayAUD.name => StripeGatewayAUD
     case PayPalGateway.name => PayPalGateway
     case DirectDebitGateway.name => DirectDebitGateway
+    case ZuoraInstanceDirectDebitGateway.name => ZuoraInstanceDirectDebitGateway
     case StripeGatewayPaymentIntentsDefault.name => StripeGatewayPaymentIntentsDefault
     case StripeGatewayPaymentIntentsAUD.name => StripeGatewayPaymentIntentsAUD
   }
@@ -55,3 +56,7 @@ case object DirectDebitGateway extends PaymentGateway {
   val name = "GoCardless"
 }
 
+case object ZuoraInstanceDirectDebitGateway extends PaymentGateway {
+  // not sure why there are two GoCardless gateways in Zuora - but having it declared here allows it be re-used
+  val name = "GoCardless - Zuora Instance"
+}

--- a/support-models/src/main/scala/com/gu/support/zuora/api/response/Responses.scala
+++ b/support-models/src/main/scala/com/gu/support/zuora/api/response/Responses.scala
@@ -115,7 +115,7 @@ case class GetPaymentMethodDirectDebitResponse(
 case class GetPaymentMethodCardReferenceResponse(
   `type`: String,
   paymentMethodStatus: String,
-  creditCardType: String,
+  creditCardType: Option[String],
   tokenId: String,
   secondTokenId: String,
   creditCardCountry: Option[String] = None,

--- a/support-models/src/test/scala/com/gu/support/zuora/api/Fixtures.scala
+++ b/support-models/src/test/scala/com/gu/support/zuora/api/Fixtures.scala
@@ -125,7 +125,7 @@ object Fixtures {
     cardNumber,
     Some(Country.UK),
     12, 22,
-    "AmericanExpress",
+    Some("AmericanExpress"),
     StripeGatewayDefault,
     stripePaymentType = Some(StripePaymentType.StripeCheckout))
   val payPalPaymentMethod = PayPalReferenceTransaction(payPalBaid, "test@paypal.com")

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -76,7 +76,7 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
             CountryGroup.countryByCode(card.country),
             card.exp_month,
             card.exp_year,
-            card.brand.zuoraCreditCardType.getOrElse(""),
+            card.brand.zuoraCreditCardType,
             paymentGateway = chargeGateway(currency),
             stripePaymentType = stripePaymentType
           )
@@ -94,7 +94,7 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
             CountryGroup.countryByCode(card.country),
             card.exp_month,
             card.exp_year,
-            card.brand.zuoraCreditCardType.getOrElse(""),
+            card.brand.zuoraCreditCardType,
             paymentGateway = paymentIntentGateway(currency),
             stripePaymentType = stripePaymentType
           )

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/PreparePaymentMethodForReuseSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/PreparePaymentMethodForReuseSpec.scala
@@ -44,7 +44,7 @@ class PreparePaymentMethodForReuseSpec extends AsyncLambdaSpec with MockServices
         creditCardCountry = Some(Country.US),
         creditCardExpirationMonth = 2,
         creditCardExpirationYear = 2022,
-        creditCardType = "Visa",
+        creditCardType = Some("Visa"),
         paymentGateway = StripeGatewayDefault,
         stripePaymentType = None
       )

--- a/support-workers/src/test/scala/com/gu/zuora/Fixtures.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/Fixtures.scala
@@ -57,7 +57,7 @@ object Fixtures {
     cardNumber,
     Some(Country.UK),
     12, 22,
-    "AmericanExpress",
+    Some("AmericanExpress"),
     _: PaymentGateway,
     stripePaymentType = Some(StripePaymentType.StripeCheckout)
   )


### PR DESCRIPTION
There were two reasons for the occasional failures with `PreparePaymentMethodForReuse` step of `support-workers`...

- Some users had missing `creditCardType` on their Zuora `PaymentMethod`s and so we were seeing Decoding failures as this was `String` rather than `Option[String]` (this field type also had to be updated on `CreditCardReferenceTransaction` as posting empty string produces a different error)
_I discovered some of these were creeping in on Amex cards updated via MMA, since the SCA changes - https://github.com/guardian/manage-frontend/pull/371 and https://github.com/guardian/membership-common/pull/606 will fix/prevent the creation of anymore of those_

- For some users their DirectDebit has Zuora payment gateway `GoCardless - Zuora Instance` rather than the main `GoCardless` Zuora payment gateway (there is little knowledge of why there are two different ones, but they point to the same GoCardless account). Fix was simply to add a `PaymentGateway` `case object` to represent it.

**I replicated both these failure scenarios and have tested the fix in `CODE`.** 