### PR TITLE
Fixed a bug where we used a different billing country than the page's Direct Debit payment method supports

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -350,11 +350,17 @@ const stripeChargeDataFromPaymentIntentAuthorisation = (
   state,
 );
 
-function getBillingCountryAndState(state: State): {
+function getBillingCountryAndState(authorisation: PaymentAuthorisation, state: State): {
   billingCountry: IsoCountry,
   billingState: Option<StateProvince>,
 } {
   const pageBaseCountry = state.common.internationalisation.countryId; // Needed later
+
+  // If the user chose a Direct Debit payment method, then we must use the pageBaseCountry as the billingCountry.
+  if ([DirectDebit, ExistingDirectDebit].includes(authorisation.paymentMethod)) {
+    const { billingState } = state.page.form.formData;
+    return { billingCountry: pageBaseCountry, billingState };
+  }
 
   // If the page form has a billingCountry, then it must have been provided by a wallet, ApplePay or
   // Payment Request Button, which will already have filtered the billingState by stateProvinceFromString,
@@ -386,7 +392,7 @@ function regularPaymentRequestFromAuthorisation(
   state: State,
 ): RegularPaymentRequest {
 
-  const { billingCountry, billingState } = getBillingCountryAndState(state);
+  const { billingCountry, billingState } = getBillingCountryAndState(authorisation, state);
 
   return {
     firstName: state.page.form.formData.firstName || '',


### PR DESCRIPTION
##  Why are you doing this?
This change fixes a bug introduced by https://github.com/guardian/support-frontend/pull/2378 where we used a different billing country than the page's Direct Debit payment method supports.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/qNyxy3in)

## Screenshots
<img width="732" alt="Screen Shot 2020-03-09 at 17 12 02" src="https://user-images.githubusercontent.com/1515970/76239276-30323780-6229-11ea-967d-e2d47912a7fa.png">
