### PR TITLE
Fix error with css override on Other card

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
@@ -159,7 +159,7 @@ function withProps(props: PropTypes) {
         ))
       }
         <ChoiceCard
-          cssOverrides={yellowChoiceCard}
+          cssOverrides={cssOverrides}
           id="contributionAmount-other"
           name="contributionAmount"
           value="other"


### PR DESCRIPTION
## Why are you doing this?
This is a fix for https://github.com/guardian/support-frontend/pull/2393 where the yellow variant was being rendered when 'Other' selected in the control.

## Before
<img width="500" alt="image" src="https://user-images.githubusercontent.com/15648334/76534576-94473c80-6471-11ea-9c1f-3d69abf9df69.png">

## After
<img width="507" alt="image" src="https://user-images.githubusercontent.com/15648334/76534632-a6c17600-6471-11ea-887a-0e437a54d471.png">

