### PR TITLE
Change text colour to black on yellow variant

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/choiceCardStyles.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/choiceCardStyles.jsx
@@ -4,8 +4,10 @@ export const yellowChoiceCard = css`
   &:checked + label {
     background-color: #FFE500;
     box-shadow: inset 0 0 0 4px #F3C100;
+    color: #121212;
   };
   &:hover + label {
     box-shadow: inset 0 0 0 4px #F3C100;
+    color: #121212;
   }
 `;


### PR DESCRIPTION
## Why are you doing this?

The text colour for the yellow variant was a dark blue instead of black. This is a follow-on from https://github.com/guardian/support-frontend/pull/2393.

## Changes

* Change yellow variant text colour to black (#121212)

## Screenshots

### Before
<img width="488" alt="image" src="https://user-images.githubusercontent.com/15648334/76641249-31c16f80-6549-11ea-8901-9c9d30fd3a7a.png">

### After
<img width="491" alt="image" src="https://user-images.githubusercontent.com/15648334/76641192-1a828200-6549-11ea-88e9-a6df2b18e0ac.png">

