### PR TITLE
Prefill AU State / Province with GEO-IP value on Recurring Contribution checkout

### DIFF
--- a/support-frontend/assets/helpers/internationalisation/country.js
+++ b/support-frontend/assets/helpers/internationalisation/country.js
@@ -443,6 +443,20 @@ function auStateFromString(s: string): Option<AuState> {
   return stateProvinceFromMap(s, auStates) || null;
 }
 
+function stateProvinceFieldFromString(countryGroupId: ?CountryGroupId, s?: string): Option<StateProvince> {
+  if (!s) { return null; }
+  switch (countryGroupId) {
+    case UnitedStates:
+      return usStateFromString(s);
+    case Canada:
+      return caStateFromString(s);
+    case AUDCountries:
+      return auStateFromString(s);
+    default:
+      return null;
+  }
+}
+
 function stateProvinceFromString(country: Option<IsoCountry>, s?: string): Option<StateProvince> {
   if (!s) { return null; }
   switch (country) {
@@ -614,6 +628,7 @@ export {
   newspaperCountries,
   findIsoCountry,
   fromString,
+  stateProvinceFieldFromString,
   stateProvinceFromString,
   fromCountryGroup,
 };

--- a/support-frontend/assets/pages/contributions-landing/setUserStateActions.js
+++ b/support-frontend/assets/pages/contributions-landing/setUserStateActions.js
@@ -3,7 +3,7 @@ import { defaultUserActionFunctions } from 'helpers/user/defaultUserActionFuncti
 import { setFormSubmissionDependentValue } from './checkoutFormIsSubmittableActions';
 import type { UserSetStateActions } from 'helpers/user/userActions';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-import { fromCountryGroup, stateProvinceFromString } from 'helpers/internationalisation/country';
+import { stateProvinceFieldFromString } from 'helpers/internationalisation/country';
 
 
 // ----- Actions Creators ----- //
@@ -21,12 +21,9 @@ const setIsRecurringContributor = (): ((Function) => void) =>
 const setStateFieldSafely = (pageCountryGroupId: CountryGroupId) =>
   (unsafeState: string): ((Function) => void) =>
     (dispatch: Function): void => {
-      const pageCountry = fromCountryGroup(pageCountryGroupId);
-      if (pageCountry) {
-        const stateField = stateProvinceFromString(pageCountry, unsafeState);
-        if (stateField) {
-          dispatch(setFormSubmissionDependentValue(() => ({ type: 'SET_STATEFIELD', stateField })));
-        }
+      const stateField = stateProvinceFieldFromString(pageCountryGroupId, unsafeState);
+      if (stateField) {
+        dispatch(setFormSubmissionDependentValue(() => ({ type: 'SET_STATEFIELD', stateField })));
       }
     };
 


### PR DESCRIPTION
This change fixes how the new compulsory AU State Field (introduced in https://github.com/guardian/support-frontend/pull/2396) gets pre-populated by GEO-IP on page load. The new solution is much simpler, not requiring the `fromCountryGroup` function that should not return AU country for AUDCountries group, because multiple countries in our model use AUD.

## Why are you doing this?
I'm making this change because there has been a small reduction in recurring contribution AV from Australia since the introduction of the field on Friday. It also makes everything consistent with the 3 checkout 'country groups' that require a state.

## Screenshots

![SSB](https://user-images.githubusercontent.com/1515970/76773613-ab9c6780-679a-11ea-86e3-04a2342914a4.png)
![SSA](https://user-images.githubusercontent.com/1515970/76773603-a7704a00-679a-11ea-89de-8a4c6962e4d9.png)