### PR TITLE
Use firstname rather than displayname for test users

### DIFF
--- a/support-frontend/app/controllers/RegularContributions.scala
+++ b/support-frontend/app/controllers/RegularContributions.scala
@@ -130,7 +130,7 @@ class RegularContributions(
       // TODO: in a subsequent PR set these values based on the respective user.
       allowThirdPartyMail = false,
       allowGURelatedMail = false,
-      isTestUser = testUsers.isTestUser(user.privateFields.firstName)
+      isTestUser = testUsers.isTestUser(user.publicFields.username)
     )
   }
 

--- a/support-frontend/app/controllers/RegularContributions.scala
+++ b/support-frontend/app/controllers/RegularContributions.scala
@@ -67,7 +67,7 @@ class RegularContributions(
     val billingPeriod = request.body.product.billingPeriod
     SafeLogger.info(s"[${request.uuid}] Guest user: ${request.body.email} is attempting to create a new $billingPeriod contribution")
     val result = for {
-      userIdWithOptionalToken <- identityService.getOrCreateUserIdFromEmail(request.body.email)
+      userIdWithOptionalToken <- identityService.getOrCreateUserIdFromEmail(request.body.email, request.body.firstName, request.body.lastName)
       user <- identityService.getUser(IdMinimalUser(userIdWithOptionalToken.userId, None))
       initialStatusResponse <- client.createSubscription(request, contributor(user, request.body), request.uuid).leftMap(_.toString)
     } yield StatusResponse.fromStatusResponseAndToken(initialStatusResponse, userIdWithOptionalToken.guestAccountRegistrationToken)
@@ -130,7 +130,7 @@ class RegularContributions(
       // TODO: in a subsequent PR set these values based on the respective user.
       allowThirdPartyMail = false,
       allowGURelatedMail = false,
-      isTestUser = testUsers.isTestUser(user.publicFields.displayName)
+      isTestUser = testUsers.isTestUser(user.privateFields.firstName)
     )
   }
 

--- a/support-frontend/app/models/identity/requests/CreateGuestAccountRequestBody.scala
+++ b/support-frontend/app/models/identity/requests/CreateGuestAccountRequestBody.scala
@@ -1,7 +1,7 @@
 package models.identity.requests
 
 import akka.util.ByteString
-import com.gu.identity.model.PublicFields
+import com.gu.identity.model.{PrivateFields, PublicFields}
 import play.api.libs.json.{Json, Writes}
 import play.api.libs.ws.{BodyWritable, InMemoryBody}
 
@@ -15,16 +15,11 @@ import play.api.libs.ws.{BodyWritable, InMemoryBody}
 //     "displayName": "a"
 //   }
 // }
-case class CreateGuestAccountRequestBody(primaryEmailAddress: String, publicFields: PublicFields)
+case class CreateGuestAccountRequestBody(primaryEmailAddress: String, privateFields: PrivateFields)
 object CreateGuestAccountRequestBody {
 
-  def guestDisplayName(email: String): String = email.split("@").headOption.getOrElse("Guest User")
-
-  def fromEmail(email: String): CreateGuestAccountRequestBody =
-    CreateGuestAccountRequestBody(email, PublicFields(displayName = Some(guestDisplayName(email))))
-
   implicit val writesCreateGuestAccountRequestBody: Writes[CreateGuestAccountRequestBody] = {
-    import com.gu.identity.model.play.WritesInstances.publicFieldsWrites
+    import com.gu.identity.model.play.WritesInstances.privateFieldsWrites
     Json.writes[CreateGuestAccountRequestBody]
   }
   implicit val bodyWriteable: BodyWritable[CreateGuestAccountRequestBody] = BodyWritable[CreateGuestAccountRequestBody](

--- a/support-frontend/app/models/identity/requests/CreateGuestAccountRequestBody.scala
+++ b/support-frontend/app/models/identity/requests/CreateGuestAccountRequestBody.scala
@@ -11,8 +11,9 @@ import play.api.libs.ws.{BodyWritable, InMemoryBody}
 // =================
 // {
 //   "email": "a@b.com",
-//   "publicFields": {
-//     "displayName": "a"
+//   "privateFields": {
+//     "firstName": "a",
+//     "secondName": "b"
 //   }
 // }
 case class CreateGuestAccountRequestBody(primaryEmailAddress: String, privateFields: PrivateFields)

--- a/support-frontend/app/views/testUsers.scala.html
+++ b/support-frontend/app/views/testUsers.scala.html
@@ -11,12 +11,14 @@
     </head>
     <body>
         <h1>New Test User key: @key</h1>
-        Your user will be valid for the next 48H. When registering please populate the following fields with your new test user key.<br/>
-        This test username has also been added as the session cookie _test_username for testing one-off paypal contributions.
+        Your user will be valid for the next 48H.<br/>
+        When registering please populate the following fields with your new test user key.<br/>
+        This test username has also been added as the session cookie _test_username for the client side and for testing one-off paypal contributions.<br/>
+        You must have the cookie present on the client side for the payment providers otherwise the client and server side will use different keys and cause a support workers failure
         <ul>
-            <li><strong>First Name:</strong> @key</li>
-            <li><strong>Username:</strong> @key</li>
-            <li><strong>Email:</strong> @{key}@@gu.com</li>
+            <li><strong>First Name:</strong> @key (only field checked by recurring contributions)</li>
+            <li><strong>Username:</strong> @key (if applicable?)</li>
+            <li><strong>Email:</strong> @{key}@@gu.com (for one off contributions)<li>or alternatively yourname+@{key}@@guardian.co.uk</li>
         </ul>
         <!-- build-commit-id: @app.BuildInfo.gitCommitId -->
     </body>

--- a/support-frontend/test/models/identity/requests/CreateGuestAccountRequestBodyTest.scala
+++ b/support-frontend/test/models/identity/requests/CreateGuestAccountRequestBodyTest.scala
@@ -1,5 +1,6 @@
 package models.identity.requests
 
+import com.gu.identity.model.PrivateFields
 import play.api.libs.json.Json
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
@@ -10,10 +11,10 @@ class CreateGuestAccountRequestBodyTest extends AnyWordSpec with Matchers {
 
     "be serialised as JSON" in {
 
-      val body = CreateGuestAccountRequestBody.fromEmail("test.user@theguardian.com")
+      val body = CreateGuestAccountRequestBody("test.user@theguardian.com", privateFields = PrivateFields(firstName = Some("moo")))
 
       Json.toJson(body).toString shouldEqual
-        """{"primaryEmailAddress":"test.user@theguardian.com","publicFields":{"displayName":"test.user"}}"""
+        """{"primaryEmailAddress":"test.user@theguardian.com","privateFields":{"firstName":"moo"}}"""
     }
   }
 }


### PR DESCRIPTION
## Why are you doing this?

Recently Identity made some changes to make it less likely people would reveal personal information as part of their profile.  The significant part of that was to make it so if we create a guest user with a displayName, the displayName is ignored and returned as "user".  This means we don't detect the user as a test user, and instead process the subscription using prod databases (which fails in support-workers).
Now we are supposed to create with the firstName set to a testUser string, and then read from the username field, which will match if it's a test user.

This PR updates the code to write both first and second/last name to identity on guest checkout.  Then the returned username is used to decide if they are a test user.  The email address is ignored, so people can feel free to use their own email address to test emails.

I have also updated the test users blurb to make it  abit more accurate based on what I know (although a bit more vague)

Further steps might be needed. I'm now not surprised we have so much trouble with support workers failure because the client and server side make separate decisions based on separate information whether it's a test user.  In the old world it was all decided server side based on the logged in user.
There may also need some checks on subs @jfsoul I think you mentioned earlier? I forgot to make a note of exactly what. 