### PR TITLE
Change instance type of nginx proxy to t3

### DIFF
--- a/support-logs/cfn.yaml
+++ b/support-logs/cfn.yaml
@@ -73,7 +73,7 @@ Resources:
     Type: AWS::EC2::Instance
     Properties:
         ImageId: !Ref AMI
-        InstanceType: t2.micro
+        InstanceType: t3.micro
         IamInstanceProfile: !Ref KibanaProxyInstanceProfile
         BlockDeviceMappings:
         - DeviceName: /dev/sda1


### PR DESCRIPTION
## Why are you doing this?

It's still unclear if we're going to reserve instances for Kibana, but in any case it's the only setup in our estate that uses a t2 instance. Everything else uses t3, so this brings it more inline with our standard infrastructure.
