### PR TITLE
Dotcom contact page

### DIFF
--- a/support-frontend/app/admin/settings/Switches.scala
+++ b/support-frontend/app/admin/settings/Switches.scala
@@ -6,6 +6,7 @@ import com.gu.support.encoding.Codec.deriveCodec
 case class Switches(
   oneOffPaymentMethods: PaymentMethodsSwitch,
   recurringPaymentMethods: PaymentMethodsSwitch,
+  useDotcomContactPage: SwitchState,
   experiments: Map[String, ExperimentSwitch]
 )
 

--- a/support-frontend/app/admin/settings/Switches.scala
+++ b/support-frontend/app/admin/settings/Switches.scala
@@ -6,7 +6,7 @@ import com.gu.support.encoding.Codec.deriveCodec
 case class Switches(
   oneOffPaymentMethods: PaymentMethodsSwitch,
   recurringPaymentMethods: PaymentMethodsSwitch,
-  useDotcomContactPage: SwitchState,
+  useDotcomContactPage: Option[SwitchState],
   experiments: Map[String, ExperimentSwitch]
 )
 

--- a/support-frontend/assets/components/content/content.jsx
+++ b/support-frontend/assets/components/content/content.jsx
@@ -74,46 +74,6 @@ Content.defaultProps = {
   border: null,
 };
 
-export const ContentCentered = ({
-  appearance, children, id, modifierClasses, image, needsHigherZindex, border,
-}: PropTypes) => (
-  <div
-    id={id}
-    className={classNameWithModifiers(
-      'component-content',
-      [
-        appearance,
-        image ? 'overflow-hidden' : null,
-        needsHigherZindex ? 'higher' : null,
-        border === false ? 'no-border' : null,
-        border === true ? 'force-border' : null,
-        ...modifierClasses,
-      ],
-  )}
-  >
-    <div className="component-content__container--full-width">
-      <div className="component-content__content--centered">
-        <div className="component-content__content--centered-handler">
-          {children}
-          {image &&
-            <div className="component-content__image">{image}</div>
-          }
-        </div>
-      </div>
-    </div>
-  </div>
-);
-
-ContentCentered.defaultProps = {
-  appearance: 'white',
-  id: null,
-  image: null,
-  modifierClasses: [],
-  needsHigherZindex: false,
-  border: null,
-};
-
-
 // ---- Children ----- //
 
 /*

--- a/support-frontend/assets/components/content/content.scss
+++ b/support-frontend/assets/components/content/content.scss
@@ -101,68 +101,6 @@
   padding: ($gu-v-spacing/2) ($gu-h-spacing / 2) 0;
 }
 
-.component-content__container--full-width {
-  @include mq($from: wide) {
-    width: 100%;
-    max-width: 100%;
-    display: flex;
-    padding-left: 70px;
-  }
-
-  @include mq($from: 1395px) {
-    justify-content: center;
-    padding-left: 0;
-    margin-left: -275px;
-  }
-
-  .component-content__content--centered {
-    max-width: gu-span(4);
-    padding: $gu-v-spacing / 2 0 $gu-v-spacing * 3 10px;
-
-    @include mq($from: mobileLandscape) {
-      padding-left: 10px;
-    }
-
-    @include mq($from: phablet) {
-      max-width: gu-span(6);
-      padding-left: 22px;
-    }
-
-    @include mq($from: tablet) {
-      padding-left: 30px;
-    }
-
-    @include mq($from: desktop) {
-      max-width: gu-span(8);
-      padding-left: 70px;
-    }
-
-    @include mq($from: leftCol) {
-      padding-left: 90px;
-    }
-
-    @include mq($from: wide) {
-      padding-left: 20px;
-      max-width: 1170px;
-    }
-
-    @include mq($from: 1396px) {
-      padding-left: 50px;
-    }
-
-    .component-content__content--centered-handler {
-      background-color: gu-colour(brand-main);
-      padding-left: 0;
-
-      .component-footer__content {
-        @include mq($from: wide) {
-          max-width: 75%;
-        }
-      }
-    }
-  }
-}
-
 
 .component-content__outset {
   @include outset;

--- a/support-frontend/assets/components/content/content.scss
+++ b/support-frontend/assets/components/content/content.scss
@@ -36,8 +36,8 @@
     }
   }
   &.component-content--no-border  .component-left-margin-section__content {
-    border-top: 0 !important;  
-  }    
+    border-top: 0 !important;
+  }
 }
 
 
@@ -107,22 +107,22 @@
     max-width: 100%;
     display: flex;
     padding-left: 70px;
-  } 
-  
+  }
+
   @include mq($from: 1395px) {
     justify-content: center;
     padding-left: 0;
-    margin-left: -35px;
+    margin-left: -275px;
   }
 
   .component-content__content--centered {
     max-width: gu-span(4);
     padding: $gu-v-spacing / 2 0 $gu-v-spacing * 3 10px;
-  
+
     @include mq($from: mobileLandscape) {
       padding-left: 10px;
     }
-  
+
     @include mq($from: phablet) {
       max-width: gu-span(6);
       padding-left: 22px;
@@ -131,7 +131,7 @@
     @include mq($from: tablet) {
       padding-left: 30px;
     }
-  
+
     @include mq($from: desktop) {
       max-width: gu-span(8);
       padding-left: 70px;
@@ -140,7 +140,7 @@
     @include mq($from: leftCol) {
       padding-left: 90px;
     }
-  
+
     @include mq($from: wide) {
       padding-left: 20px;
       max-width: 1170px;
@@ -149,7 +149,7 @@
     @include mq($from: 1396px) {
       padding-left: 50px;
     }
-  
+
     .component-content__content--centered-handler {
       background-color: gu-colour(brand-main);
       padding-left: 0;
@@ -198,7 +198,7 @@
 
 .component-content {
   .component-content__narrowContent,
-  .component-text, 
+  .component-text,
   .component-product-page-plan-form,
   .component-product-page-info-chip {
     margin-bottom: ($gu-v-spacing*2)
@@ -238,12 +238,12 @@
   }
   /*
   If you are implementing an image in a page and you want
-  it to look just a teeny tiny bit bigger or smaller or plain move it, 
-  try to avoid overriding `left` to do fine positioning and 
+  it to look just a teeny tiny bit bigger or smaller or plain move it,
+  try to avoid overriding `left` to do fine positioning and
   instead use transforms and max-width.
 
-  `left` here is built to put images to the right of the max grid width. 
-  This width might change in the future and ideally tweaking these global 
+  `left` here is built to put images to the right of the max grid width.
+  This width might change in the future and ideally tweaking these global
   values should not break any images on any page.
 
   If your image is not grid aligned feel free to override these values

--- a/support-frontend/assets/components/customerService/customerService.jsx
+++ b/support-frontend/assets/components/customerService/customerService.jsx
@@ -13,7 +13,10 @@ import { type Option } from 'helpers/types/option';
 import { type SubscriptionProduct } from 'helpers/subscriptions';
 import { type PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import { promotionTermsUrl } from 'helpers/routes';
-import { useDotcomContactPage } from 'helpers/dotcomContactPage';
+import {
+  ContactPageLink,
+  useDotcomContactPage,
+} from 'helpers/dotcomContactPage';
 
 // ----- Props ----- //
 
@@ -93,15 +96,12 @@ function CustomerService(props: PropTypes) {
       </div>
     );
 
-  const DotcomContactPage = () => (
-    <Faqs>
-        For help with Guardian and Observer subscription services please&nbsp;
-      <a href="https://www.theguardian.com/help/contact-us">contact us</a>.
-    </Faqs>
-  );
-
   if (useDotcomContactPage() === true) {
-    return <DotcomContactPage />;
+    return (
+      <Faqs>
+        For help with Guardian and Observer subscription services please <ContactPageLink />.
+      </Faqs>
+    );
   }
 
   switch (props.selectedCountryGroup) {

--- a/support-frontend/assets/components/customerService/customerService.jsx
+++ b/support-frontend/assets/components/customerService/customerService.jsx
@@ -96,10 +96,10 @@ function CustomerService(props: PropTypes) {
       </div>
     );
 
-  if (useDotcomContactPage() === true) {
+  if (useDotcomContactPage()) {
     return (
       <Faqs>
-        For help with Guardian and Observer subscription services please <ContactPageLink />.
+        For help with Guardian and Observer subscription services please <ContactPageLink linkText="contact us" />.
       </Faqs>
     );
   }

--- a/support-frontend/assets/components/customerService/customerService.jsx
+++ b/support-frontend/assets/components/customerService/customerService.jsx
@@ -13,6 +13,7 @@ import { type Option } from 'helpers/types/option';
 import { type SubscriptionProduct } from 'helpers/subscriptions';
 import { type PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import { promotionTermsUrl } from 'helpers/routes';
+import { useDotcomContactPage } from 'helpers/dotcomContactPage';
 
 // ----- Props ----- //
 
@@ -91,6 +92,17 @@ function CustomerService(props: PropTypes) {
         </div>
       </div>
     );
+
+  const DotcomContactPage = () => (
+    <Faqs>
+        For help with Guardian and Observer subscription services please&nbsp;
+      <a href="https://www.theguardian.com/help/contact-us">contact us</a>.
+    </Faqs>
+  );
+
+  if (useDotcomContactPage() === true) {
+    return <DotcomContactPage />;
+  }
 
   switch (props.selectedCountryGroup) {
     case UnitedStates:

--- a/support-frontend/assets/components/footer/footer.jsx
+++ b/support-frontend/assets/components/footer/footer.jsx
@@ -12,6 +12,7 @@ import Content, { ContentCentered, type Appearance } from 'components/content/co
 
 import './footer.scss';
 import Rows from '../base/rows';
+import 'pages/digital-subscription-landing/components/digitalSubscriptionLanding.scss';
 
 // ----- Props ----- //
 
@@ -34,7 +35,7 @@ function Footer({
     <footer className="component-footer" role="contentinfo">
       {(disclaimer || privacyPolicy || Children.count(children) > 0) &&
         <Content appearance={appearance}>
-          <div className="component-footer__content">
+          <div className="component-footer__content ">
             <Rows>
               {privacyPolicy &&
               <div className="component-footer__privacy-policy-text">
@@ -60,46 +61,6 @@ function Footer({
 // ----- Default Props ----- //
 
 Footer.defaultProps = {
-  privacyPolicy: false,
-  disclaimer: false,
-  appearance: 'feature',
-  countryGroupId: GBPCountries,
-  children: [],
-};
-
-// ----- Component Centered ----- //
-
-export function FooterCentered({
-  disclaimer, privacyPolicy, children, countryGroupId, appearance,
-}: PropTypes) {
-
-  return (
-    <footer className="component-footer" role="contentinfo">
-      {(disclaimer || privacyPolicy || Children.count(children) > 0) &&
-        <ContentCentered appearance={appearance}>
-          <div className="component-footer__content">
-            <Rows>
-              {privacyPolicy &&
-              <div className="component-footer__privacy-policy-text">
-                To find out what personal data we collect and how we use it, please visit our
-                <a className="component-footer__privacy-policy" href={privacyLink}> Privacy Policy</a>.
-              </div>
-              }
-              {children}
-              {disclaimer && <ContribLegal countryGroupId={countryGroupId} />}
-            </Rows>
-          </div>
-        </ContentCentered>
-      }
-    </footer>
-  );
-
-}
-
-
-// ----- Default Props ----- //
-
-FooterCentered.defaultProps = {
   privacyPolicy: false,
   disclaimer: false,
   appearance: 'feature',

--- a/support-frontend/assets/components/footer/footer.jsx
+++ b/support-frontend/assets/components/footer/footer.jsx
@@ -8,7 +8,7 @@ import ContribLegal from 'components/legal/contribLegal/contribLegal';
 import { privacyLink, copyrightNotice } from 'helpers/legal';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { GBPCountries } from 'helpers/internationalisation/countryGroup';
-import Content, { ContentCentered, type Appearance } from 'components/content/content';
+import Content, { type Appearance } from 'components/content/content';
 
 import './footer.scss';
 import Rows from '../base/rows';

--- a/support-frontend/assets/components/legal/contribLegal/contribLegal.jsx
+++ b/support-frontend/assets/components/legal/contribLegal/contribLegal.jsx
@@ -7,6 +7,10 @@ import React from 'react';
 import { contributionsEmail } from 'helpers/legal';
 
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import {
+  ContactPageLink,
+  useDotcomContactPage,
+} from 'helpers/dotcomContactPage';
 
 
 // ---- Types ----- //
@@ -19,7 +23,8 @@ type PropTypes = {|
 // ----- Component ----- //
 
 export default function ContribLegal(props: PropTypes) {
-
+  const contactUs = useDotcomContactPage() ? <ContactPageLink />
+    : <a href={contributionsEmail[props.countryGroupId]}>contact us here</a>;
   return (
     <p className="component-contrib-legal">
       The ultimate owner of the Guardian is The Scott Trust Limited,
@@ -29,7 +34,7 @@ export default function ContribLegal(props: PropTypes) {
       journalism does not constitute a charitable donation, as such your
       contribution is not eligible for Gift Aid in the UK nor a tax-deduction
       elsewhere. If you have any questions about contributing to the Guardian,
-      please <a href={contributionsEmail[props.countryGroupId]}>contact us here</a>.
+      please {contactUs}.
     </p>
   );
 

--- a/support-frontend/assets/components/legal/contribLegal/contribLegal.jsx
+++ b/support-frontend/assets/components/legal/contribLegal/contribLegal.jsx
@@ -23,7 +23,7 @@ type PropTypes = {|
 // ----- Component ----- //
 
 export default function ContribLegal(props: PropTypes) {
-  const contactUs = useDotcomContactPage() ? <ContactPageLink />
+  const contactUs = useDotcomContactPage() ? <ContactPageLink linkText="contact us here" />
     : <a href={contributionsEmail[props.countryGroupId]}>contact us here</a>;
   return (
     <p className="component-contrib-legal">

--- a/support-frontend/assets/components/questionsContact/questionsContact.jsx
+++ b/support-frontend/assets/components/questionsContact/questionsContact.jsx
@@ -24,7 +24,7 @@ type PropTypes = {|
 // ----- Component ----- //
 
 function QuestionsContact(props: PropTypes) {
-  const contactUs = useDotcomContactPage() ? <ContactPageLink /> : (
+  const contactUs = useDotcomContactPage() ? <ContactPageLink linkText="contact us" /> : (
     <a
       className="component-questions-contact__link"
       href={contributionsEmail[props.countryGroupId]}

--- a/support-frontend/assets/components/questionsContact/questionsContact.jsx
+++ b/support-frontend/assets/components/questionsContact/questionsContact.jsx
@@ -8,6 +8,10 @@ import PageSection from 'components/pageSection/pageSection';
 import { contributionsEmail } from 'helpers/legal';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { GBPCountries } from 'helpers/internationalisation/countryGroup';
+import {
+  ContactPageLink,
+  useDotcomContactPage,
+} from 'helpers/dotcomContactPage';
 
 
 // ---- Types ----- //
@@ -20,7 +24,13 @@ type PropTypes = {|
 // ----- Component ----- //
 
 function QuestionsContact(props: PropTypes) {
-
+  const contactUs = useDotcomContactPage() ? <ContactPageLink /> : (
+    <a
+      className="component-questions-contact__link"
+      href={contributionsEmail[props.countryGroupId]}
+    >
+      contact us
+    </a>);
   return (
     <div className="component-questions-contact">
       <PageSection
@@ -30,12 +40,7 @@ function QuestionsContact(props: PropTypes) {
         <p className="component-questions-contact__description">
           If you have any questions about contributing to The&nbsp;Guardian,
           please&nbsp;
-          <a
-            className="component-questions-contact__link"
-            href={contributionsEmail[props.countryGroupId]}
-          >
-            contact us
-          </a>
+          {contactUs}
         </p>
       </PageSection>
     </div>

--- a/support-frontend/assets/helpers/dotcomContactPage.jsx
+++ b/support-frontend/assets/helpers/dotcomContactPage.jsx
@@ -4,9 +4,9 @@ import React from 'react';
 
 import { isSwitchOn } from 'helpers/globals';
 
-const ContactPageLink = () => <a href="https://www.theguardian.com/help/contact-us">contact us</a>;
+const ContactPageLink = (props: {linkText: string}) =>
+  <a href="https://www.theguardian.com/help/contact-us">{props.linkText}</a>;
 
 const useDotcomContactPage = (): boolean => isSwitchOn('useDotcomContactPage');
-
 
 export { ContactPageLink, useDotcomContactPage };

--- a/support-frontend/assets/helpers/dotcomContactPage.jsx
+++ b/support-frontend/assets/helpers/dotcomContactPage.jsx
@@ -1,0 +1,10 @@
+// @flow
+
+import { isSwitchOn } from 'helpers/globals';
+
+const ContactPageLink = () => <a href="https://www.theguardian.com/help/contact-us">contact us</a>;
+
+const useDotcomContactPage = (): boolean => isSwitchOn('useDotcomContactPage');
+
+
+export { ContactPageLink, useDotcomContactPage };

--- a/support-frontend/assets/helpers/dotcomContactPage.jsx
+++ b/support-frontend/assets/helpers/dotcomContactPage.jsx
@@ -1,5 +1,7 @@
 // @flow
 
+import React from 'react';
+
 import { isSwitchOn } from 'helpers/globals';
 
 const ContactPageLink = () => <a href="https://www.theguardian.com/help/contact-us">contact us</a>;

--- a/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLanding.scss
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLanding.scss
@@ -47,12 +47,16 @@
 
 }
 
+.hope-is-power--centered {
+  background-color: #ffffff;
+}
+
+
 .hope-is-power--centered,
-.component-content__content--centered-handler {
+.component-customer-service {
   align-self: flex-start;
   padding-left: 0px;
   width: 100%;
-  background-color: #ffffff;
 
   @include mq($from: mobileLandscape) {
     padding-left: 0px;
@@ -1002,7 +1006,8 @@ div.call-to-action__container {
   }
 }
 
-.hope-is-power__terms {
+.hope-is-power__terms,
+.hope-is-power__faqs {
   display: flex;
   justify-content: center;
   @include gu-fontset-body-sans;
@@ -1017,7 +1022,8 @@ div.call-to-action__container {
     font-weight: 600;
   }
 
-  h3, p {
+  h2, h3, p,
+  .component-subscription-faq__text {
     max-width: calc(100% - 20px);
 
     @include mq($from: mobileMedium) {
@@ -1054,5 +1060,19 @@ div.call-to-action__container {
 
   a, a:visited {
     color: #121212;
+  }
+
+}
+
+.hope-is-power__faqs {
+  background-color: gu-colour(brand-main);
+  color: gu-colour(neutral-100);
+
+  a, a:visited {
+    color: gu-colour(neutral-100);
+  }
+
+  .component-subscription-faq__text {
+    margin-top: 10px;
   }
 }

--- a/support-frontend/assets/pages/digital-subscription-landing/components/faqsAndHelp.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/faqsAndHelp.jsx
@@ -16,6 +16,9 @@ import {
   ContactPageLink,
   useDotcomContactPage,
 } from 'helpers/dotcomContactPage';
+import SubscriptionFaq from 'components/subscriptionFaq/subscriptionFaq';
+
+import 'pages/digital-subscription-landing/components/digitalSubscriptionLanding.scss';
 
 // ----- Props ----- //
 
@@ -70,10 +73,13 @@ function FaqsAndHelp(props: PropTypes) {
 
   const Faqs = ({ children }: { children: React.Node }) =>
     (
-      <div className="component-customer-service">
-        <h2>FAQs and Help</h2>
-        <div className="component-customer-service__text">
-          {children}
+      <div className="hope-is-power__faqs">
+        <div className="component-customer-service">
+          <h2>FAQs and Help</h2>
+          <p className="component-customer-service__text">
+            {children}
+          </p>
+          <SubscriptionFaq subscriptionProduct="DigitalPack" />
         </div>
       </div>
     );

--- a/support-frontend/assets/pages/digital-subscription-landing/components/faqsAndHelp.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/faqsAndHelp.jsx
@@ -84,10 +84,10 @@ function FaqsAndHelp(props: PropTypes) {
       </div>
     );
 
-  if (useDotcomContactPage() === true) {
+  if (useDotcomContactPage()) {
     return (
       <Faqs>
-        For help with Guardian and Observer subscription services please <ContactPageLink />
+        For help with Guardian and Observer subscription services please <ContactPageLink linkText="contact us" />
       </Faqs>
     );
   }

--- a/support-frontend/assets/pages/digital-subscription-landing/components/faqsAndHelp.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/faqsAndHelp.jsx
@@ -12,6 +12,10 @@ import {
 import { type Option } from 'helpers/types/option';
 import { type SubscriptionProduct } from 'helpers/subscriptions';
 import { type PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
+import {
+  ContactPageLink,
+  useDotcomContactPage,
+} from 'helpers/dotcomContactPage';
 
 // ----- Props ----- //
 
@@ -73,6 +77,14 @@ function FaqsAndHelp(props: PropTypes) {
         </div>
       </div>
     );
+
+  if (useDotcomContactPage() === true) {
+    return (
+      <Faqs>
+        For help with Guardian and Observer subscription services please <ContactPageLink />
+      </Faqs>
+    );
+  }
 
   switch (props.selectedCountryGroup) {
     case UnitedStates:

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -21,14 +21,8 @@ import { init as pageInit } from 'helpers/page/page';
 import Page from 'components/page/page';
 import headerWithCountrySwitcherContainer
   from 'components/headers/header/headerWithCountrySwitcher';
-import SubscriptionFaq from 'components/subscriptionFaq/subscriptionFaq';
-import { FooterCentered } from 'components/footer/footer';
-
-import 'stylesheets/skeleton/skeleton.scss';
-
 import { CampaignHeader } from './components/digitalSubscriptionLandingHeader';
 import ProductBlock from './components/productBlock';
-
 import './digitalSubscriptionLanding.scss';
 import ConsentBanner from 'components/consentBanner/consentBanner';
 import digitalSubscriptionLandingReducer
@@ -37,7 +31,9 @@ import CallToAction from './components/cta';
 import TermsAndConditions from './components/termsAndConditions';
 import FaqsAndHelp from './components/faqsAndHelp';
 // ----- Styles ----- //
+
 import './components/digitalSubscriptionLanding.scss';
+import 'stylesheets/skeleton/skeleton.scss';
 
 // ----- Redux Store ----- //
 
@@ -79,18 +75,12 @@ function LandingPage() {
   return (
     <Page
       header={<CountrySwitcherHeader />}
-      footer={
-        <FooterCentered>
-          <FaqsAndHelp
-            selectedCountryGroup={countryGroupId}
-          />
-          <SubscriptionFaq subscriptionProduct="DigitalPack" />
-        </FooterCentered>}
     >
       <CampaignHeader countryGroupId={countryGroupId} />
       <ProductBlock countryGroupId={countryGroupId} />
       <CallToAction />
       <TermsAndConditions />
+      <FaqsAndHelp selectedCountryGroup={countryGroupId} />
       <ConsentBanner />
     </Page>
   );

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/helpers.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/helpers.jsx
@@ -6,29 +6,21 @@ import React, { type Element, type Node } from 'react';
 
 import { type Option } from 'helpers/types/option';
 import Content from 'components/content/content';
-import Text, { Callout, SansParagraph } from 'components/text/text';
-import ProductPageInfoChip
-  from 'components/productPage/productPageInfoChip/productPageInfoChip';
-import { paperSubsUrl, promotionTermsUrl } from 'helpers/routes';
-import {
-  flashSaleIsActive,
-  getDiscount,
-  getDuration,
-  getPromoCode,
-} from 'helpers/flashSale';
+import Text, { SansParagraph, Callout } from 'components/text/text';
+import ProductPageInfoChip from 'components/productPage/productPageInfoChip/productPageInfoChip';
+import { paperSubsUrl } from 'helpers/routes';
+import { flashSaleIsActive, getDiscount, getDuration, getPromoCode } from 'helpers/flashSale';
 
 import { type ActiveTabState } from '../../paperSubscriptionLandingPageReducer';
 import { setTab } from '../../paperSubscriptionLandingPageActions';
 
 import Form from './form';
-import {
-  Collection,
-  HomeDelivery,
-} from 'helpers/productPrice/fulfilmentOptions';
+import { Collection, HomeDelivery } from 'helpers/productPrice/fulfilmentOptions';
 import { paperHasDeliveryEnabled } from 'helpers/subscriptions';
 import { GBPCountries } from 'helpers/internationalisation/countryGroup';
 
 import { promoQueryParam } from 'helpers/productPrice/promotions';
+import { promotionTermsUrl } from 'helpers/routes';
 import { getQueryParameter } from 'helpers/url';
 import {
   ContactPageLink,
@@ -46,8 +38,7 @@ export type ContentTabPropTypes = {|
   getRef: (?HTMLElement)=> void
 |};
 
-const promoTermsUrl = promotionTermsUrl(getQueryParameter(promoQueryParam) ||
-  getPromoCode('Paper', GBPCountries, 'SEP2512VHD'));
+const promoTermsUrl = promotionTermsUrl(getQueryParameter(promoQueryParam) || getPromoCode('Paper', GBPCountries, 'SEP2512VHD'));
 
 // Helper functions
 const getPageInfoChip = (): string => {
@@ -64,15 +55,14 @@ const DiscountCalloutMaybe = () => {
     getDuration('Paper', 'GBPCountries'),
   ];
   if (discount && duration) {
-    return (<Callout>Save up to {Math.round(discount * 100)}%
-      for {duration}
-            </Callout>);
+    return <Callout>Save up to {Math.round(discount * 100)}% for {duration}</Callout>;
   } else if (discount) {
     return <Callout>Save up to {Math.round(discount * 100)}% </Callout>;
   }
   return null;
 
 };
+
 
 // ----- Auxiliary Components ----- //
 const ContentHelpBlock = ({
@@ -90,14 +80,7 @@ const ContentHelpBlock = ({
       {flashSaleIsActive('Paper', GBPCountries) &&
       <Text title="Promotion terms and conditions">
         <SansParagraph>
-          Offer subject to availability. Guardian News and Media Limited
-          (&ldquo;GNM&rdquo;) reserves the right to withdraw this promotion at
-          any time. For full promotion terms and conditions, see <a
-            target="_blank"
-            rel="noopener noreferrer"
-            href={promoTermsUrl}
-          >here
-          </a>.
+          Offer subject to availability. Guardian News and Media Limited (&ldquo;GNM&rdquo;) reserves the right to withdraw this promotion at any time. For full promotion terms and conditions, see <a target="_blank" rel="noopener noreferrer" href={promoTermsUrl}>here</a>.
         </SansParagraph>
       </Text>
       }
@@ -151,19 +134,15 @@ const ContentForm = ({
     </Text>
     <Form />
     {paperHasDeliveryEnabled() &&
-    <Text>
-      <SansParagraph>
-        {
-          selectedTab === Collection
-            ? <LinkTo tab={HomeDelivery} setTabAction={setTabAction}>Switch to
-              Delivery
-            </LinkTo>
-            : <LinkTo tab={Collection} setTabAction={setTabAction}>Switch to
-              Vouchers
-            </LinkTo>
-        }
-      </SansParagraph>
-    </Text>
+      <Text>
+        <SansParagraph>
+          {
+            selectedTab === Collection
+              ? <LinkTo tab={HomeDelivery} setTabAction={setTabAction}>Switch to Delivery</LinkTo>
+              : <LinkTo tab={Collection} setTabAction={setTabAction}>Switch to Vouchers</LinkTo>
+          }
+        </SansParagraph>
+      </Text>
     }
     <ProductPageInfoChip>
       {getPageInfoChip()}

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/helpers.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/helpers.jsx
@@ -6,22 +6,34 @@ import React, { type Element, type Node } from 'react';
 
 import { type Option } from 'helpers/types/option';
 import Content from 'components/content/content';
-import Text, { SansParagraph, Callout } from 'components/text/text';
-import ProductPageInfoChip from 'components/productPage/productPageInfoChip/productPageInfoChip';
-import { paperSubsUrl } from 'helpers/routes';
-import { flashSaleIsActive, getDiscount, getDuration, getPromoCode } from 'helpers/flashSale';
+import Text, { Callout, SansParagraph } from 'components/text/text';
+import ProductPageInfoChip
+  from 'components/productPage/productPageInfoChip/productPageInfoChip';
+import { paperSubsUrl, promotionTermsUrl } from 'helpers/routes';
+import {
+  flashSaleIsActive,
+  getDiscount,
+  getDuration,
+  getPromoCode,
+} from 'helpers/flashSale';
 
 import { type ActiveTabState } from '../../paperSubscriptionLandingPageReducer';
 import { setTab } from '../../paperSubscriptionLandingPageActions';
 
 import Form from './form';
-import { Collection, HomeDelivery } from 'helpers/productPrice/fulfilmentOptions';
+import {
+  Collection,
+  HomeDelivery,
+} from 'helpers/productPrice/fulfilmentOptions';
 import { paperHasDeliveryEnabled } from 'helpers/subscriptions';
 import { GBPCountries } from 'helpers/internationalisation/countryGroup';
 
 import { promoQueryParam } from 'helpers/productPrice/promotions';
-import { promotionTermsUrl } from 'helpers/routes';
 import { getQueryParameter } from 'helpers/url';
+import {
+  ContactPageLink,
+  useDotcomContactPage,
+} from 'helpers/dotcomContactPage';
 
 // Types
 export type ContentPropTypes = {|
@@ -34,7 +46,8 @@ export type ContentTabPropTypes = {|
   getRef: (?HTMLElement)=> void
 |};
 
-const promoTermsUrl = promotionTermsUrl(getQueryParameter(promoQueryParam) || getPromoCode('Paper', GBPCountries, 'SEP2512VHD'));
+const promoTermsUrl = promotionTermsUrl(getQueryParameter(promoQueryParam) ||
+  getPromoCode('Paper', GBPCountries, 'SEP2512VHD'));
 
 // Helper functions
 const getPageInfoChip = (): string => {
@@ -51,7 +64,9 @@ const DiscountCalloutMaybe = () => {
     getDuration('Paper', 'GBPCountries'),
   ];
   if (discount && duration) {
-    return <Callout>Save up to {Math.round(discount * 100)}% for {duration}</Callout>;
+    return (<Callout>Save up to {Math.round(discount * 100)}%
+      for {duration}
+            </Callout>);
   } else if (discount) {
     return <Callout>Save up to {Math.round(discount * 100)}% </Callout>;
   }
@@ -59,32 +74,45 @@ const DiscountCalloutMaybe = () => {
 
 };
 
-
 // ----- Auxiliary Components ----- //
 const ContentHelpBlock = ({
   faqLink, telephoneLink,
 }: {|
   faqLink: Element<string>,
   telephoneLink: Element<string>
-|}) => (
-  <Content appearance="feature" modifierClasses={['faqs']}>
-    {flashSaleIsActive('Paper', GBPCountries) &&
+|}) => {
+
+  const contactUs = useDotcomContactPage() ? <ContactPageLink /> :
+  <span>call our customer services team on {telephoneLink}</span>;
+
+  return (
+    <Content appearance="feature" modifierClasses={['faqs']}>
+      {flashSaleIsActive('Paper', GBPCountries) &&
       <Text title="Promotion terms and conditions">
         <SansParagraph>
-          Offer subject to availability. Guardian News and Media Limited (&ldquo;GNM&rdquo;) reserves the right to withdraw this promotion at any time. For full promotion terms and conditions, see <a target="_blank" rel="noopener noreferrer" href={promoTermsUrl}>here</a>.
+          Offer subject to availability. Guardian News and Media Limited
+          (&ldquo;GNM&rdquo;) reserves the right to withdraw this promotion at
+          any time. For full promotion terms and conditions, see <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href={promoTermsUrl}
+          >here
+          </a>.
         </SansParagraph>
       </Text>
-    }
-    <Text title="FAQ and help">
-      <SansParagraph>
-        If you’ve got any more questions, you might well find the answers in the {faqLink}.
-      </SansParagraph>
-      <SansParagraph>
-        If you can’t find the answer to your question here, please call our customer services team on {telephoneLink}.
-      </SansParagraph>
-    </Text>
-  </Content>
-);
+      }
+      <Text title="FAQ and help">
+        <SansParagraph>
+          If you’ve got any more questions, you might well find the answers in
+          the {faqLink}.
+        </SansParagraph>
+        <SansParagraph>
+          If you can’t find the answer to your question here, please {contactUs}.
+        </SansParagraph>
+      </Text>
+    </Content>
+  );
+};
 
 const LinkTo = ({
   setTabAction, tab, children,
@@ -123,15 +151,19 @@ const ContentForm = ({
     </Text>
     <Form />
     {paperHasDeliveryEnabled() &&
-      <Text>
-        <SansParagraph>
-          {
-            selectedTab === Collection
-              ? <LinkTo tab={HomeDelivery} setTabAction={setTabAction}>Switch to Delivery</LinkTo>
-              : <LinkTo tab={Collection} setTabAction={setTabAction}>Switch to Vouchers</LinkTo>
-          }
-        </SansParagraph>
-      </Text>
+    <Text>
+      <SansParagraph>
+        {
+          selectedTab === Collection
+            ? <LinkTo tab={HomeDelivery} setTabAction={setTabAction}>Switch to
+              Delivery
+            </LinkTo>
+            : <LinkTo tab={Collection} setTabAction={setTabAction}>Switch to
+              Vouchers
+            </LinkTo>
+        }
+      </SansParagraph>
+    </Text>
     }
     <ProductPageInfoChip>
       {getPageInfoChip()}

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/helpers.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/helpers.jsx
@@ -72,7 +72,7 @@ const ContentHelpBlock = ({
   telephoneLink: Element<string>
 |}) => {
 
-  const contactUs = useDotcomContactPage() ? <ContactPageLink /> :
+  const contactUs = useDotcomContactPage() ? <ContactPageLink linkText="contact us" /> :
   <span>call our customer services team on {telephoneLink}</span>;
 
   return (

--- a/support-frontend/test/codecs/CirceDecodersTest.scala
+++ b/support-frontend/test/codecs/CirceDecodersTest.scala
@@ -118,7 +118,8 @@ class CirceDecodersTest extends AnyWordSpec with Matchers {
           |        "description": "Redesign of the payment flow UI",
           |        "state": "On"
           |      }
-          |    }
+          |    },
+          |    "useDotcomContactPage": "Off"
           |  },
           |  "amounts": {
           |    "GBPCountries": {
@@ -285,7 +286,8 @@ class CirceDecodersTest extends AnyWordSpec with Matchers {
               description = "Redesign of the payment flow UI",
               state = On
             )
-          )
+          ),
+          useDotcomContactPage = Some(Off)
         ),
         amountsRegions,
         contributionTypes,

--- a/support-frontend/test/controllers/SubscriptionsTest.scala
+++ b/support-frontend/test/controllers/SubscriptionsTest.scala
@@ -69,7 +69,7 @@ class SubscriptionsTest extends AnyWordSpec with Matchers with TestCSRFComponent
       Switches(
         oneOffPaymentMethods = PaymentMethodsSwitch(On, On, On, On, None, None, None, None),
         recurringPaymentMethods = PaymentMethodsSwitch(On, On, On, On, Some(On), Some(On), Some(On), None),
-        experiments = Map.empty
+        experiments = Map.empty, useDotcomContactPage = Some(SwitchState.Off)
       ),
       AmountsRegions(amounts, amounts, amounts, amounts, amounts, amounts, amounts),
       ContributionTypes(Nil, Nil, Nil, Nil, Nil, Nil, Nil),

--- a/support-services/src/test/scala/com/gu/support/catalog/CatalogServiceIntegrationSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/catalog/CatalogServiceIntegrationSpec.scala
@@ -31,7 +31,7 @@ class CatalogServiceIntegrationSpec extends AsyncFlatSpec with Matchers with Ins
     forAll(product.ratePlans(environment))(
       ratePlan =>
         service.getPriceList(ratePlan).fold {
-          Console.println(s"Failed to find a catalog price list for $environment > $product > ${ratePlan.id}")
+          Console.println(s"Failed to find a catalog price list for $environment > $product > ${ratePlan.billingPeriod} > ${ratePlan.id}")
           fail()
         }(_ => succeed)
     )


### PR DESCRIPTION
## Why are you doing this?
During the Corona virus outbreak we may need to change our contact details at short notice. 
this PR uses a new switch `useDotcomContactPage' which when enabled will change all the contact us information to point to a single page on dotcom which can be easily updated by central production.

[**Trello Card**](https://trello.com/c/dwy3Ir7I/2925-update-contact-us-details-to-point-to-a-webpage-in-event-of-customer-service-outage)

## TODO
 - [x] Fix layout issue on digisub page
 - [x] Contributions page?
 - [ ] Deploy new switch

