### PR TITLE
BUGFIX: Remove whitespace in and around a name for payment request button

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -151,7 +151,8 @@ function updatePayerEmail(data: Object, setEmail: string => void) {
 }
 
 function updatePayerName(data: Object, setFirstName: string => void, setLastName: string => void): boolean {
-  const nameParts = data.payerName.split(' ');
+  // NB: This turns "    jean    claude    van    damme     " into ["jean", "claude", "van", "damme"]
+  const nameParts = data.payerName.trim().replace(/\s+/g, ' ').split(' ');
   if (nameParts.length > 2) {
     setFirstName(nameParts[0]);
     setLastName(nameParts.slice(1).join(' '));


### PR DESCRIPTION
#1104  

## Why are you doing this?
We had an error where a first name was not getting set due to insufficient whitespace handling on the data we get when a user uses the payment request or apple pay button. This fixes that problem.

Before:
"     jean   claude   van     damme     " => `["","","","", "jean","",...etc ]`
After:
"     jean   claude   van      damme     " => `["jean","claude","van","damme"]`

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->
