### PR TITLE
Only retry once

### DIFF
--- a/.prout.json
+++ b/.prout.json
@@ -9,7 +9,7 @@
             "afterSeen": {
                 "travis": {
                     "config": {
-                        "script": "travis_retry sbt ++$TRAVIS_SCALA_VERSION selenium:test"
+                        "script": "sbt ++$TRAVIS_SCALA_VERSION selenium:test || sbt ++$TRAVIS_SCALA_VERSION selenium:test"
                     }
                 }
             }


### PR DESCRIPTION
## Why are you doing this?

We recently added retry logic to the post deployment test execution to mitigate false negatives. See #2377 

This has reduced the number of false negatives, but it's had the side effect of greatly increasing the latency between the PR being merged and the alert being raised. It's taking about 30 minutes now. This both increases the impact of issues in production, but is also a source of confusion as it severs the immediate cause and effect relationship between merging and getting an alert.   

## Changes

Instead of using travis_retry, which is built in but is hardcoded to 3 retries ([literally hardcoded](https://github.com/travis-ci/travis-build/blob/75dba2e42e50811827a9f8691b1d4f55eefe268d/lib/travis/build/bash/travis_retry.bash#L4)), this PR implements basic retry logic by using the bash OR operator

- If the first sbt call is successful, the second one won't run.
- If the first sbt call fails, the second one will run 