### PR TITLE
Fix DigitalPackProductPage selenium test

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-landing/components/faqsAndHelp.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/faqsAndHelp.jsx
@@ -74,7 +74,7 @@ function FaqsAndHelp(props: PropTypes) {
   const Faqs = ({ children }: { children: React.Node }) =>
     (
       <div className="hope-is-power__faqs">
-        <div className="component-customer-service">
+        <div className="component-customer-service" id="qa-component-customer-service">
           <h2>FAQs and Help</h2>
           <p className="component-customer-service__text">
             {children}

--- a/support-frontend/test/selenium/subscriptions/pages/DigitalPackProductPage.scala
+++ b/support-frontend/test/selenium/subscriptions/pages/DigitalPackProductPage.scala
@@ -8,6 +8,6 @@ class DigitalPackProductPage(implicit val webDriver: WebDriver) extends Page wit
 
   override def path = "/uk/subscribe/digital"
 
-  override def elementQuery = className("component-footer")
+  override def elementQuery = id("qa-component-customer-service")
 
 }


### PR DESCRIPTION
## Why are you doing this?

#2407 broke the Digital Subscription product page selenium test by removing a footer class, this PR fixes it by adding a qa id onto the footer component.