### PR TITLE
Ensure the captcha only applies to Card payment methods

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/checkoutFormIsSubmittableActions.js
+++ b/support-frontend/assets/pages/contributions-landing/checkoutFormIsSubmittableActions.js
@@ -25,6 +25,7 @@ import {
   type Action as ContributionsLandingAction,
   setFormIsValid,
 } from './contributionsLandingActions';
+import { ExistingCard, Stripe } from 'helpers/paymentMethods';
 
 
 // ----- Types ----- //
@@ -119,6 +120,7 @@ function enableOrDisableForm() {
 
     const v2RecaptchaCheck =
       window.guardian.recaptchaV2
+      && [Stripe, ExistingCard].includes(state.page.form.paymentMethod)
       && state.common.abParticipations.recaptchaPresenceTest === 'recaptchaPresent'
       && !state.page.user.isPostDeploymentTestUser
         ? state.page.form.v2IsLowRisk

--- a/support-frontend/assets/pages/contributions-landing/checkoutFormIsSubmittableActions.js
+++ b/support-frontend/assets/pages/contributions-landing/checkoutFormIsSubmittableActions.js
@@ -25,8 +25,6 @@ import {
   type Action as ContributionsLandingAction,
   setFormIsValid,
 } from './contributionsLandingActions';
-import { ExistingCard, Stripe } from 'helpers/paymentMethods';
-
 
 // ----- Types ----- //
 

--- a/support-frontend/assets/pages/contributions-landing/checkoutFormIsSubmittableActions.js
+++ b/support-frontend/assets/pages/contributions-landing/checkoutFormIsSubmittableActions.js
@@ -120,7 +120,7 @@ function enableOrDisableForm() {
 
     const v2RecaptchaCheck =
       window.guardian.recaptchaV2
-      && [Stripe, ExistingCard].includes(state.page.form.paymentMethod)
+      && state.page.form.stripeCardFormData.formComplete
       && state.common.abParticipations.recaptchaPresenceTest === 'recaptchaPresent'
       && !state.page.user.isPostDeploymentTestUser
         ? state.page.form.v2IsLowRisk

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
@@ -264,7 +264,7 @@ function withProps(props: PropTypes) {
 
         <div>
           <div id="robot_checkbox" className={props.paymentMethod === 'Stripe' ? 'robot_checkbox' : 'hidden'} />
-          { props.checkoutFormHasBeenSubmitted && !props.v2IsLowRisk &&
+          { props.paymentMethod === 'Stripe' && props.checkoutFormHasBeenSubmitted && !props.v2IsLowRisk &&
           (<div className="form__error"> {'Please tick to verify you\'re a human'} </div>) }
         </div>
         {/*


### PR DESCRIPTION
## Why are you doing this?
This change ensure the captcha (introduced in https://github.com/guardian/support-frontend/pull/2392) only applies when using the Stripe payment method.

