### PR TITLE
Turn off postcontribution reminder test and add feature to automate postcontribution reminder dates + tests

### DIFF
--- a/support-frontend/assets/components/contributionsReminder/__tests__/contributionsReminderTest.js
+++ b/support-frontend/assets/components/contributionsReminder/__tests__/contributionsReminderTest.js
@@ -1,0 +1,48 @@
+// @flow
+
+// ----- Imports ----- //
+import { createReminderChoiceSet } from '../contributionsReminder';
+
+// ----- Tests ----- //
+describe('createReminderChoiceSet test', () => {
+  const december2024 = new Date('2024-12-09');
+  const reminderDatesWhenDecember2024 = [
+    { dateName: 'March 2025', extendedCopy: 'Three months (March 2025)', timestamp: '2025-03-01 00:00:00' },
+    { dateName: 'June 2025', extendedCopy: 'Six months (June 2025)', timestamp: '2025-06-01 00:00:00' },
+    { dateName: 'September 2025', extendedCopy: 'Nine months (September 2025)', timestamp: '2025-09-01 00:00:00' },
+    { dateName: 'December 2025', extendedCopy: 'Next year (December 2025)', timestamp: '2025-12-01 00:00:00' },
+  ];
+
+  const may1985 = new Date('1985-07-20');
+  const reminderDatesWhenMay1985 = [
+    { dateName: 'August 1985', extendedCopy: 'Three months (August)', timestamp: '1985-08-01 00:00:00' },
+    { dateName: 'November 1985', extendedCopy: 'Six months (November)', timestamp: '1985-11-01 00:00:00' },
+    { dateName: 'February 1986', extendedCopy: 'Nine months (February 1986)', timestamp: '1986-02-01 00:00:00' },
+    { dateName: 'May 1986', extendedCopy: 'Next year (May 1986)', timestamp: '1986-05-01 00:00:00' },
+  ];
+
+  const y2k = new Date('2000-01-01');
+  const reminderDatesWhenY2k = [
+    { dateName: 'April 2000', extendedCopy: 'Three months (April)', timestamp: '2025-04-01 00:00:00' },
+    { dateName: 'July 2000', extendedCopy: 'Six months (July)', timestamp: '2025-07-01 00:00:00' },
+    { dateName: 'October 2000', extendedCopy: 'Nine months (October)', timestamp: '2025-10-01 00:00:00' },
+    { dateName: 'January 2001', extendedCopy: 'Next year (January 2001)', timestamp: '2025-01-01 00:00:00' },
+  ];
+
+  it('should create create the right dates for December 2024', () => {
+    expect(createReminderChoiceSet(december2024.getMonth(), december2024.getFullYear()))
+      .toEqual(reminderDatesWhenDecember2024);
+  });
+
+  it('should create create the right dates for May 1985', () => {
+    expect(createReminderChoiceSet(may1985.getMonth(), may1985.getFullYear())).toEqual(reminderDatesWhenMay1985);
+  });
+
+  it('should create create the right dates for Y2K', () => {
+    expect(createReminderChoiceSet(y2k.getMonth(), y2k.getFullYear())).toEqual(reminderDatesWhenY2k);
+  });
+
+  it('should not create create the wrong dates for Y2K', () => {
+    expect(createReminderChoiceSet(y2k.getMonth(), y2k.getFullYear())).not.toEqual(reminderDatesWhenDecember2024);
+  });
+});

--- a/support-frontend/assets/components/contributionsReminder/__tests__/contributionsReminderTest.js
+++ b/support-frontend/assets/components/contributionsReminder/__tests__/contributionsReminderTest.js
@@ -1,32 +1,32 @@
 // @flow
 
 // ----- Imports ----- //
-import { createReminderChoiceSet } from '../contributionsReminder';
+import { createReminderChoiceSet } from '../contributionsReminderAutomation';
 
 // ----- Tests ----- //
 describe('createReminderChoiceSet test', () => {
   const december2024 = new Date('2024-12-09');
   const reminderDatesWhenDecember2024 = [
-    { dateName: 'March 2025', extendedCopy: 'Three months (March 2025)', timestamp: '2025-03-01 00:00:00' },
-    { dateName: 'June 2025', extendedCopy: 'Six months (June 2025)', timestamp: '2025-06-01 00:00:00' },
-    { dateName: 'September 2025', extendedCopy: 'Nine months (September 2025)', timestamp: '2025-09-01 00:00:00' },
-    { dateName: 'December 2025', extendedCopy: 'Next year (December 2025)', timestamp: '2025-12-01 00:00:00' },
+    { dateName: 'March 2025', extendedCopy: 'Three months (March 2025)', timeStamp: '2025-03-01 00:00:00' },
+    { dateName: 'June 2025', extendedCopy: 'Six months (June 2025)', timeStamp: '2025-06-01 00:00:00' },
+    { dateName: 'September 2025', extendedCopy: 'Nine months (September 2025)', timeStamp: '2025-09-01 00:00:00' },
+    { dateName: 'December 2025', extendedCopy: 'Next year (December 2025)', timeStamp: '2025-12-01 00:00:00' },
   ];
 
-  const may1985 = new Date('1985-07-20');
+  const may1985 = new Date('1985-05-20');
   const reminderDatesWhenMay1985 = [
-    { dateName: 'August 1985', extendedCopy: 'Three months (August)', timestamp: '1985-08-01 00:00:00' },
-    { dateName: 'November 1985', extendedCopy: 'Six months (November)', timestamp: '1985-11-01 00:00:00' },
-    { dateName: 'February 1986', extendedCopy: 'Nine months (February 1986)', timestamp: '1986-02-01 00:00:00' },
-    { dateName: 'May 1986', extendedCopy: 'Next year (May 1986)', timestamp: '1986-05-01 00:00:00' },
+    { dateName: 'August 1985', extendedCopy: 'Three months (August)', timeStamp: '1985-08-01 00:00:00' },
+    { dateName: 'November 1985', extendedCopy: 'Six months (November)', timeStamp: '1985-11-01 00:00:00' },
+    { dateName: 'February 1986', extendedCopy: 'Nine months (February 1986)', timeStamp: '1986-02-01 00:00:00' },
+    { dateName: 'May 1986', extendedCopy: 'Next year (May 1986)', timeStamp: '1986-05-01 00:00:00' },
   ];
 
   const y2k = new Date('2000-01-01');
   const reminderDatesWhenY2k = [
-    { dateName: 'April 2000', extendedCopy: 'Three months (April)', timestamp: '2025-04-01 00:00:00' },
-    { dateName: 'July 2000', extendedCopy: 'Six months (July)', timestamp: '2025-07-01 00:00:00' },
-    { dateName: 'October 2000', extendedCopy: 'Nine months (October)', timestamp: '2025-10-01 00:00:00' },
-    { dateName: 'January 2001', extendedCopy: 'Next year (January 2001)', timestamp: '2025-01-01 00:00:00' },
+    { dateName: 'April 2000', extendedCopy: 'Three months (April)', timeStamp: '2000-04-01 00:00:00' },
+    { dateName: 'July 2000', extendedCopy: 'Six months (July)', timeStamp: '2000-07-01 00:00:00' },
+    { dateName: 'October 2000', extendedCopy: 'Nine months (October)', timeStamp: '2000-10-01 00:00:00' },
+    { dateName: 'January 2001', extendedCopy: 'Next year (January 2001)', timeStamp: '2001-01-01 00:00:00' },
   ];
 
   it('should create create the right dates for December 2024', () => {

--- a/support-frontend/assets/components/contributionsReminder/contributionsReminder.jsx
+++ b/support-frontend/assets/components/contributionsReminder/contributionsReminder.jsx
@@ -11,18 +11,11 @@ import { logException } from 'helpers/logger';
 import { Fieldset } from 'components/forms/fieldset';
 import { RadioInput } from 'components/forms/customFields/radioInput';
 import { Label as FormLabel } from 'components/forms/label';
+import { createReminderChoiceSet } from 'components/contributionsReminder/contributionsReminderAutomation';
 
 // ----- Types ----- //
 type PropTypes = {
   email: string | null,
-}
-
-// JTL: NB "control" and "extendedCopy" are only for
-// postContributionReminderCopyTest and should be removed after this test
-type ReminderDate = {
-  dateName: string,
-  extendedCopy: string,
-  timeStamp: string,
 }
 
 type ButtonState = 'initial' | 'pending' | 'success' | 'fail';
@@ -36,50 +29,6 @@ type StateTypes = {
 const mapStateToProps = state => ({
   email: state.page.form.formData.email,
 });
-
-const getReminderCopy = (index: number): string => {
-  switch (index) {
-    case 0:
-      return 'Three months';
-    case 1:
-      return 'Six months';
-    case 2:
-      return 'Nine months';
-    case 3:
-      return 'Next year';
-    default:
-      return '';
-  }
-};
-
-export const createReminderChoiceSet = (month: number, year: number): Array<ReminderDate> => {
-  const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
-  const reminderMonthIdxs = [month + 3, month + 6, month + 9, month];
-  const reminderChoiceSet = [];
-
-  for (let i = 0; i < reminderMonthIdxs.length; i += 1) {
-    let reminderMonthAsIdx; let reminderYear;
-
-    if (reminderMonthIdxs[i] <= 11) {
-      reminderMonthAsIdx = reminderMonthIdxs[i];
-      reminderYear = year;
-    } else {
-      reminderMonthAsIdx = reminderMonthIdxs[i] - months.length;
-      reminderYear = year + 1;
-    }
-
-    const reminderMonthForTimestamp = reminderMonthAsIdx + 1 < 10 ? `0${reminderMonthAsIdx + 1}` : reminderMonthAsIdx + 1;
-    const reminderMonthAsWord = months[reminderMonthAsIdx];
-
-    reminderChoiceSet.push({
-      dateName: `${reminderMonthAsWord} ${reminderYear}`,
-      extendedCopy: `${getReminderCopy(i)} (${reminderMonthAsWord}${reminderYear !== year ? ` ${reminderYear}` : ''})`,
-      timeStamp: `${reminderYear}-${reminderMonthForTimestamp}-01 00:00:00`,
-    });
-  }
-
-  return reminderChoiceSet;
-};
 
 const currentDate = new Date();
 

--- a/support-frontend/assets/components/contributionsReminder/contributionsReminder.jsx
+++ b/support-frontend/assets/components/contributionsReminder/contributionsReminder.jsx
@@ -37,30 +37,53 @@ const mapStateToProps = state => ({
   email: state.page.form.formData.email,
 });
 
-// JTL: NB "control" and "extendedCopy" are only for
-// postContributionReminderCopyTest and should be removed after this test
-const reminderDates: Array<ReminderDate> = [
-  {
-    dateName: 'July 2020',
-    extendedCopy: 'Three months (July)',
-    timeStamp: '2020-07-01 00:00:00',
-  },
-  {
-    dateName: 'October 2020',
-    extendedCopy: 'Six months (October)',
-    timeStamp: '2020-10-01 00:00:00',
-  },
-  {
-    dateName: 'January 2021',
-    extendedCopy: 'Nine months (January 2021)',
-    timeStamp: '2021-01-01 00:00:00',
-  },
-  {
-    dateName: 'April 2021',
-    extendedCopy: 'One year (April 2021)',
-    timeStamp: '2021-04-01 00:00:00',
-  },
-];
+const getReminderCopy = (index: number): string => {
+  switch (index) {
+    case 0:
+      return 'Three months';
+    case 1:
+      return 'Six months';
+    case 2:
+      return 'Nine months';
+    case 3:
+      return 'Next year';
+    default:
+      return '';
+  }
+};
+
+const createReminderChoiceSet = (month: number, year: number): Array<ReminderDate> => {
+  const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+  const reminderMonthIdxs = [month + 3, month + 6, month + 9, month];
+  const reminderChoiceSet = [];
+
+  for (let i = 0; i < reminderMonthIdxs.length; i += 1) {
+    let reminderMonthAsIdx; let reminderYear;
+
+    if (reminderMonthIdxs[i] <= 11) {
+      reminderMonthAsIdx = reminderMonthIdxs[i];
+      reminderYear = year;
+    } else {
+      reminderMonthAsIdx = reminderMonthIdxs[i] - months.length;
+      reminderYear = year + 1;
+    }
+
+    const reminderMonthForTimestamp = reminderMonthAsIdx + 1 < 10 ? `0${reminderMonthAsIdx + 1}` : reminderMonthAsIdx + 1;
+    const reminderMonthAsWord = months[reminderMonthAsIdx];
+
+    reminderChoiceSet.push({
+      dateName: `${reminderMonthAsWord} ${reminderYear}`,
+      extendedCopy: `${getReminderCopy(i)} (${reminderMonthAsWord}${reminderYear !== year ? ` ${reminderYear}` : ''})`,
+      timeStamp: `${reminderYear}-${reminderMonthForTimestamp}-01 00:00:00`,
+    });
+  }
+
+  return reminderChoiceSet;
+};
+
+const currentDate = new Date();
+
+const reminderDates = createReminderChoiceSet(currentDate.getMonth(), currentDate.getFullYear());
 
 const trimAndDowncase = (word: string) => word.replace(/\s+/g, '').toLowerCase();
 // ----- Render ----- //

--- a/support-frontend/assets/components/contributionsReminder/contributionsReminder.jsx
+++ b/support-frontend/assets/components/contributionsReminder/contributionsReminder.jsx
@@ -52,7 +52,7 @@ const getReminderCopy = (index: number): string => {
   }
 };
 
-const createReminderChoiceSet = (month: number, year: number): Array<ReminderDate> => {
+export const createReminderChoiceSet = (month: number, year: number): Array<ReminderDate> => {
   const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
   const reminderMonthIdxs = [month + 3, month + 6, month + 9, month];
   const reminderChoiceSet = [];

--- a/support-frontend/assets/components/contributionsReminder/contributionsReminder.jsx
+++ b/support-frontend/assets/components/contributionsReminder/contributionsReminder.jsx
@@ -11,19 +11,16 @@ import { logException } from 'helpers/logger';
 import { Fieldset } from 'components/forms/fieldset';
 import { RadioInput } from 'components/forms/customFields/radioInput';
 import { Label as FormLabel } from 'components/forms/label';
-import type { PostContributionReminderCopyTestVariants } from 'helpers/abTests/abtestDefinitions';
 
 // ----- Types ----- //
 type PropTypes = {
   email: string | null,
-  postContributionReminderCopyTestVariant: PostContributionReminderCopyTestVariants,
 }
 
 // JTL: NB "control" and "extendedCopy" are only for
 // postContributionReminderCopyTest and should be removed after this test
 type ReminderDate = {
   dateName: string,
-  control: string,
   extendedCopy: string,
   timeStamp: string,
 }
@@ -38,35 +35,30 @@ type StateTypes = {
 
 const mapStateToProps = state => ({
   email: state.page.form.formData.email,
-  postContributionReminderCopyTestVariant: state.common.abParticipations.postContributionReminderCopyTest,
 });
 
 // JTL: NB "control" and "extendedCopy" are only for
 // postContributionReminderCopyTest and should be removed after this test
 const reminderDates: Array<ReminderDate> = [
   {
-    dateName: 'June 2020',
-    control: 'June',
-    extendedCopy: 'Three months (June)',
-    timeStamp: '2020-06-01 00:00:00',
+    dateName: 'July 2020',
+    extendedCopy: 'Three months (July)',
+    timeStamp: '2020-07-01 00:00:00',
   },
   {
-    dateName: 'September 2020',
-    control: 'September',
-    extendedCopy: 'Six months (September)',
-    timeStamp: '2020-09-01 00:00:00',
+    dateName: 'October 2020',
+    extendedCopy: 'Six months (October)',
+    timeStamp: '2020-10-01 00:00:00',
   },
   {
-    dateName: 'December 2020',
-    control: 'December',
-    extendedCopy: 'Nine months (December)',
-    timeStamp: '2020-12-01 00:00:00',
+    dateName: 'January 2021',
+    extendedCopy: 'Nine months (January 2021)',
+    timeStamp: '2021-01-01 00:00:00',
   },
   {
-    dateName: 'March 2021',
-    control: 'March 2021',
-    extendedCopy: 'One year (March 2021)',
-    timeStamp: '2021-03-01 00:00:00',
+    dateName: 'April 2021',
+    extendedCopy: 'One year (April 2021)',
+    timeStamp: '2021-04-01 00:00:00',
   },
 ];
 
@@ -139,9 +131,9 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
   }
 
   render() {
-    const { email, postContributionReminderCopyTestVariant } = this.props;
+    const { email } = this.props;
 
-    if (email && postContributionReminderCopyTestVariant !== 'notintest') {
+    if (email) {
       const isClicked = this.state.buttonState !== 'initial';
 
       return (
@@ -160,7 +152,7 @@ class ContributionsReminder extends Component<PropTypes, StateTypes> {
                 return (
                   <RadioInput
                     id={dateWithoutSpace}
-                    text={reminderDate[postContributionReminderCopyTestVariant]}
+                    text={reminderDate.extendedCopy}
                     name="reminder"
                     onChange={evt => this.setDateState(evt, reminderDate.timeStamp, dateWithoutSpace)}
                     defaultChecked={index === 0}

--- a/support-frontend/assets/components/contributionsReminder/contributionsReminderAutomation.js
+++ b/support-frontend/assets/components/contributionsReminder/contributionsReminderAutomation.js
@@ -1,0 +1,51 @@
+// @flow
+
+type ReminderDate = {
+  dateName: string,
+  extendedCopy: string,
+  timeStamp: string,
+}
+
+const getReminderCopy = (index: number): string => {
+  switch (index) {
+    case 0:
+      return 'Three months';
+    case 1:
+      return 'Six months';
+    case 2:
+      return 'Nine months';
+    case 3:
+      return 'Next year';
+    default:
+      return '';
+  }
+};
+
+export const createReminderChoiceSet = (month: number, year: number): Array<ReminderDate> => {
+  const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+  const reminderMonthIdxs = [month + 3, month + 6, month + 9, month + 12];
+  const reminderChoiceSet = [];
+
+  for (let i = 0; i < reminderMonthIdxs.length; i += 1) {
+    let reminderMonthAsIdx; let reminderYear;
+
+    if (reminderMonthIdxs[i] <= 11) {
+      reminderMonthAsIdx = reminderMonthIdxs[i];
+      reminderYear = year;
+    } else {
+      reminderMonthAsIdx = reminderMonthIdxs[i] - months.length;
+      reminderYear = year + 1;
+    }
+
+    const reminderMonthForTimestamp = reminderMonthAsIdx + 1 < 10 ? `0${reminderMonthAsIdx + 1}` : reminderMonthAsIdx + 1;
+    const reminderMonthAsWord = months[reminderMonthAsIdx];
+
+    reminderChoiceSet.push({
+      dateName: `${reminderMonthAsWord} ${reminderYear}`,
+      extendedCopy: `${getReminderCopy(i)} (${reminderMonthAsWord}${reminderYear !== year ? ` ${reminderYear}` : ''})`,
+      timeStamp: `${reminderYear}-${reminderMonthForTimestamp}-01 00:00:00`,
+    });
+  }
+
+  return reminderChoiceSet;
+};

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -7,7 +7,6 @@ export type StripePaymentRequestButtonScaTestVariants = 'control' | 'sca' | 'not
 
 export type ChoiceCardsProductSetTestR3Variants = 'control' | 'yellow';
 export type PersonalisedThankYouPageTestVariants = 'control' | 'personalised' | 'notintest';
-export type PostContributionReminderCopyTestVariants = 'control' | 'extendedCopy' | 'notintest';
 export type recaptchaPresenceTestVariants = 'control' | 'recaptchaPresent';
 
 const contributionsLandingPageMatch = '/(uk|us|eu|au|ca|nz|int)/contribute(/.*)?$';
@@ -80,28 +79,6 @@ export const tests: Tests = {
     referrerControlled: false,
     targetPage: usOnlyLandingPage,
     seed: 5,
-  },
-
-  postContributionReminderCopyTest: {
-    type: 'OTHER',
-    variants: [
-      {
-        id: 'control',
-      },
-      {
-        id: 'extendedCopy',
-      },
-    ],
-    audiences: {
-      ALL: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: true,
-    referrerControlled: false,
-    seed: 4,
-    targetPage: contributionsLandingPageMatch,
   },
 
   stripePaymentRequestButtonSca: {


### PR DESCRIPTION
## Why are you doing this?
New month.... now we don't need to update the postcontribution reminder every month!

This feature will automatically update the postcontribution reminder to give options 3, 6, 9, and 12 months out from the current month.

We are also ending the current test as we ran it long enough to have confidence the copy was not affecting outcomes, so we are ending it with individual preference for the longer, editorialised copy.
<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/2BZWwUm3/1929-update-the-post-contribution-reminder)


