### PR TITLE
Add 'Support The Guardian' to the digitalSubscriptionLandingHeader

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLanding.scss
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLanding.scss
@@ -1076,3 +1076,7 @@ div.call-to-action__container {
     margin-top: 10px;
   }
 }
+
+.nobr {
+  white-space: nowrap;
+}

--- a/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLandingHeader.jsx
@@ -181,7 +181,7 @@ function CampaignHeader() {
       <div className="hope-is-power-hero__marketing-message hope-is-power--centered">
         <h1>The Digital Subscription</h1>
         <h2>
-          <span className="hope-is-power--heavy-text">Two innovative apps and ad-free reading</span> on theguardian.com. The complete digital experience from The Guardian.
+          <span className="hope-is-power--heavy-text">Support The Guardian</span> and enjoy two innovative apps and <span className="nobr">ad-free reading</span> on theguardian.com. The complete digital experience from The Guardian.
         </h2>
         <div className="hope-is-power__circle">
           <span className="hope-is-power__circle-text--large">14 day</span>


### PR DESCRIPTION
## Why are you doing this?

We currently have a big First impression take over on the front that drives people directly to the digital subs landing page in UK and ROW (yay).

The issue is that there is a big, abrupt jump from the message on the banner, which is all about trust and support, and the landing page where it's very product-oriented.

As a quick fix we are going to adjust the language on the page header (the yellow thing below) to be "The digital subscription. Support The Guardian and enjoy two innovative apps and ad-free"
### Old Version
![image (7)](https://user-images.githubusercontent.com/181371/77525490-0744b000-6e81-11ea-9b55-e3c28704ba00.png)

### New Version
<img width="1310" alt="Screen Shot 2020-03-25 at 10 04 08" src="https://user-images.githubusercontent.com/181371/77525397-e0867980-6e80-11ea-88fa-0d216bee3b99.png">
