### PR TITLE
Blue choice cards to 100% on landing page

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -77,26 +77,4 @@ export const tests: Tests = {
     seed: 2,
     targetPage: contributionsLandingPageMatch,
   },
-
-  choiceCardsProductSetTestR3: {
-    type: 'OTHER',
-    variants: [
-      {
-        id: 'control',
-      },
-      {
-        id: 'yellow',
-      },
-    ],
-    audiences: {
-      ALL: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: true,
-    referrerControlled: false,
-    seed: 3,
-    targetPage: contributionsLandingPageMatch,
-  },
 };

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
@@ -163,8 +163,7 @@ function withProps(props: PropTypes) {
     formatAmount(currencies[props.currency], spokenCurrencies[props.currency], { value: max.toString() }, false);
   const otherAmount = props.otherAmounts[props.contributionType].amount;
 
-  /* eslint-disable no-unused-vars */
-  // leaving in place as this is still in active development:
+
   const renderChoiceCards = () => (
     <>
       <ChoiceCardGroup
@@ -175,7 +174,6 @@ function withProps(props: PropTypes) {
             id={`contributionAmount-${amount.value}`}
             name="contributionAmount"
             value={amount.value}
-        /* eslint-disable react/prop-types */
             checked={isSelected(amount, props)}
             onChange={props.selectAmount(amount, props.countryGroupId, props.contributionType)}
             label={formatAmount(currencies[props.currency], spokenCurrencies[props.currency], amount, false)}
@@ -193,8 +191,9 @@ function withProps(props: PropTypes) {
       </ChoiceCardGroup>
   </>
   );
-  /* eslint-enable no-unused-vars */
 
+  /* eslint-disable no-unused-vars */
+  // leaving in place as this is still in active development:
   const renderControl = () => (
     <ul className="form__radio-group-list">
       {validAmounts.map(renderAmount(
@@ -216,12 +215,13 @@ function withProps(props: PropTypes) {
       </li>
     </ul>
   );
+  /* eslint-enable no-unused-vars */
 
   return (
     <fieldset className={classNameWithModifiers('form__radio-group', ['pills', 'contribution-amount'])}>
       <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>How much would you like to give?</legend>
 
-      {renderControl()}
+      {renderChoiceCards()}
 
       {showOther ? (
         <ContributionTextInput

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
@@ -67,8 +67,7 @@ function withProps(props: PropTypes) {
   const contributionTypes = props.contributionTypes[props.countryGroupId];
   const isStripeEnabled = props.isPostDeploymentTestUser ? true : props.v3isLowRisk;
 
-  /* eslint-disable no-unused-vars */
-  // leaving in place as this is still in active development:
+
   const renderChoiceCards = () => (
     <ChoiceCardGroup
       name="contributionTypes"
@@ -96,8 +95,9 @@ function withProps(props: PropTypes) {
     })}
     </ChoiceCardGroup>
   );
-  /* eslint-enable no-unused-vars */
 
+  /* eslint-disable no-unused-vars */
+  // leaving in place as this is still in active development:
   const renderControl = () => (
     <ul className="form__radio-group-list form__radio-group-list--border">
       {contributionTypes.map((contributionTypeSetting: ContributionTypeSetting) => {
@@ -128,6 +128,7 @@ function withProps(props: PropTypes) {
       })}
     </ul>
   );
+  /* eslint-enable no-unused-vars */
 
   if (contributionTypes.length === 1 && contributionTypes[0].contributionType === 'ONE_OFF') {
     return null;
@@ -136,7 +137,7 @@ function withProps(props: PropTypes) {
   return (
     <fieldset className={classNameWithModifiers('form__radio-group', ['tabs', 'contribution-type'])}>
       <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>How often would you like to contribute?</legend>
-      {renderControl()}
+      {renderChoiceCards()}
     </fieldset>
   );
 }

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
@@ -23,9 +23,6 @@ import type {
   ContributionTypeSetting,
 } from 'helpers/contributions';
 import { ChoiceCardGroup, ChoiceCard } from '@guardian/src-choice-card';
-import type { ChoiceCardsProductSetTestR3Variants } from 'helpers/abTests/abtestDefinitions';
-import type { SerializedStyles } from '@emotion/utils';
-import { yellowChoiceCard } from './choiceCardStyles';
 
 // ----- Types ----- //
 
@@ -36,7 +33,6 @@ type PropTypes = {|
   switches: Switches,
   contributionTypes: ContributionTypes,
   onSelectContributionType: (ContributionType, Switches, IsoCountry, CountryGroupId, boolean) => void,
-  choiceCardsVariant: ChoiceCardsProductSetTestR3Variants,
   v3isLowRisk: boolean,
   isPostDeploymentTestUser: boolean,
 |};
@@ -47,7 +43,6 @@ const mapStateToProps = (state: State) => ({
   countryId: state.common.internationalisation.countryId,
   switches: state.common.settings.switches,
   contributionTypes: state.common.settings.contributionTypes,
-  choiceCardsVariant: state.common.abParticipations.choiceCardsProductSetTestR3,
   v3isLowRisk: state.page.form.v3IsLowRisk,
   isPostDeploymentTestUser: state.page.user.isPostDeploymentTestUser,
 });
@@ -70,19 +65,19 @@ const mapDispatchToProps = (dispatch: Function) => ({
 
 function withProps(props: PropTypes) {
   const contributionTypes = props.contributionTypes[props.countryGroupId];
+  const isStripeEnabled = props.isPostDeploymentTestUser ? true : props.v3isLowRisk;
 
-
-  const renderChoiceCards = (cssOverrides: SerializedStyles | null) => (
+  /* eslint-disable no-unused-vars */
+  // leaving in place as this is still in active development:
+  const renderChoiceCards = () => (
     <ChoiceCardGroup
       name="contributionTypes"
       orientation="horizontal"
     >
       {contributionTypes.map((contributionTypeSetting: ContributionTypeSetting) => {
       const { contributionType } = contributionTypeSetting;
-      const isStripeEnabled = props.isPostDeploymentTestUser ? true : props.v3isLowRisk;
       return (
         <ChoiceCard
-          cssOverrides={cssOverrides}
           id={`contributionType-${contributionType}`}
           value={contributionType}
           label={toHumanReadableContributionType(contributionType)}
@@ -101,6 +96,38 @@ function withProps(props: PropTypes) {
     })}
     </ChoiceCardGroup>
   );
+  /* eslint-enable no-unused-vars */
+
+  const renderControl = () => (
+    <ul className="form__radio-group-list form__radio-group-list--border">
+      {contributionTypes.map((contributionTypeSetting: ContributionTypeSetting) => {
+        const { contributionType } = contributionTypeSetting;
+        return (
+          <li className="form__radio-group-item">
+            <input
+              id={`contributionType-${contributionType}`}
+              className="form__radio-group-input"
+              type="radio"
+              name="contributionType"
+              value={contributionType}
+              onChange={() =>
+                props.onSelectContributionType(
+                  contributionType,
+                  props.switches,
+                  props.countryId,
+                  props.countryGroupId,
+                  isStripeEnabled,
+                )
+              }
+              checked={props.contributionType === contributionType}
+            />
+            <label htmlFor={`contributionType-${contributionType}`} className="form__radio-group-label">
+              {toHumanReadableContributionType(contributionType)}
+            </label>
+          </li>);
+      })}
+    </ul>
+  );
 
   if (contributionTypes.length === 1 && contributionTypes[0].contributionType === 'ONE_OFF') {
     return null;
@@ -109,7 +136,7 @@ function withProps(props: PropTypes) {
   return (
     <fieldset className={classNameWithModifiers('form__radio-group', ['tabs', 'contribution-type'])}>
       <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>How often would you like to contribute?</legend>
-      {props.choiceCardsVariant === 'yellow' ? renderChoiceCards(yellowChoiceCard) : renderChoiceCards()}
+      {renderControl()}
     </fieldset>
   );
 }


### PR DESCRIPTION
## Why are you doing this?
Victoria requested ~~to institute the old UI~~ to institute the blue choice cards to 100% of the audience until we are ready to test the full design system form

This PR removes choice cards from the UI for the time being
<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/hlQECVG3/1938-remove-choice-cards-test-and-institute-pre-choice-card-ui-on-landing-page)