### PR TITLE
Make countryGroupId required on subs header

### DIFF
--- a/support-frontend/assets/components/headers/header/header.jsx
+++ b/support-frontend/assets/components/headers/header/header.jsx
@@ -19,7 +19,7 @@ import './header.scss';
 
 export type PropTypes = {|
   utility: Option<Node>,
-  countryGroupId: ?CountryGroupId,
+  countryGroupId: CountryGroupId,
   display?: 'navigation' | 'checkout' | 'guardianLogo' | void,
 |};
 export type State = {|
@@ -78,7 +78,6 @@ const TopNav = ({ display, getLogoRef, utility }: TopNavPropTypes) => (
 export default class Header extends Component<PropTypes, State> {
   static defaultProps = {
     utility: null,
-    countryGroupId: null,
     display: 'navigation',
   };
 

--- a/support-frontend/assets/components/headers/header/headerWithCountrySwitcher.jsx
+++ b/support-frontend/assets/components/headers/header/headerWithCountrySwitcher.jsx
@@ -21,7 +21,7 @@ export default function ({
   trackProduct,
 }: {
   path: string,
-  countryGroupId?: CountryGroupId,
+  countryGroupId: CountryGroupId,
   listOfCountryGroups: CountryGroupId[],
   trackProduct?: Option<SubscriptionProduct>,
 }) {

--- a/support-frontend/assets/components/subscriptionCheckouts/headerWrapper.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/headerWrapper.jsx
@@ -8,11 +8,13 @@ import { connect } from 'react-redux';
 import type { WithDeliveryCheckoutState } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
 import { type Stage } from 'helpers/subscriptionsForms/formFields';
 import Header from 'components/headers/header/header';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 // ----- Types ----- //
 
 type PropTypes = {|
   stage: Stage,
+  countryGroupId: CountryGroupId,
 |};
 
 // ----- State/Props Maps ----- //
@@ -20,13 +22,18 @@ type PropTypes = {|
 function mapStateToProps(state: WithDeliveryCheckoutState) {
   return {
     stage: state.page.checkout.stage,
+    countryGroupId: state.common.internationalisation.countryGroupId,
   };
 }
 
 // ----- Component ----- //
 
 function HeaderWrapper(props: PropTypes) {
-  return <Header display={props.stage === 'checkout' ? 'checkout' : 'guardianLogo'} />;
+  return (
+    <Header
+      display={props.stage === 'checkout' ? 'checkout' : 'guardianLogo'}
+      countryGroupId={props.countryGroupId}
+    />);
 }
 
 // ----- Export ----- //

--- a/support-frontend/assets/pages/digital-subscription-checkout/thankYouExisting.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/thankYouExisting.jsx
@@ -37,7 +37,7 @@ const { countryGroupId } = store.getState().common.internationalisation;
 const content = (
   <Provider store={store}>
     <Page
-      header={<Header />}
+      header={<Header countryGroupId={countryGroupId} />}
       footer={
         <Footer>
           <SubscriptionTermsPrivacy subscriptionProduct="DigitalPack" />

--- a/support-frontend/assets/pages/error/components/errorPage.jsx
+++ b/support-frontend/assets/pages/error/components/errorPage.jsx
@@ -14,6 +14,7 @@ import AnchorButton from 'components/button/anchorButton';
 import { contributionsEmail } from 'helpers/legal';
 import Text, { LargeParagraph } from 'components/text/text';
 import '../error.scss';
+import { detect } from 'helpers/internationalisation/countryGroup';
 
 // ----- Types ----- //
 
@@ -31,7 +32,7 @@ export default function ErrorPage(props: PropTypes) {
 
   return (
     <Page
-      header={<Header />}
+      header={<Header countryGroupId={detect()} />}
       footer={<Footer />}
     >
       <SquaresIntroduction

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
@@ -25,6 +25,7 @@ import type { PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOpti
 import { Collection, HomeDelivery } from 'helpers/productPrice/fulfilmentOptions';
 import { paperHasDeliveryEnabled } from 'helpers/subscriptions';
 import ConsentBanner from 'components/consentBanner/consentBanner';
+import { GBPCountries } from 'helpers/internationalisation/countryGroup';
 
 // ----- Collection or delivery ----- //
 
@@ -42,7 +43,7 @@ const store = pageInit(() => reducer(fulfilment), true);
 const content = (
   <Provider store={store}>
     <Page
-      header={<Header />}
+      header={<Header countryGroupId={GBPCountries} />}
       footer={<Footer />}
     >
       <CampaignHeader />

--- a/support-frontend/assets/pages/paypal-error/payPalError.jsx
+++ b/support-frontend/assets/pages/paypal-error/payPalError.jsx
@@ -14,6 +14,7 @@ import SpreadTheWord from 'components/spreadTheWord/spreadTheWord';
 
 import { statelessInit as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
+import { detect } from 'helpers/internationalisation/countryGroup';
 
 
 // ----- Page Startup ----- //
@@ -25,7 +26,7 @@ pageInit();
 
 const content = (
   <Page
-    header={<Header />}
+    header={<Header countryGroupId={detect()} />}
     footer={<Footer />}
   >
     <div className="paypal-error">

--- a/support-frontend/assets/pages/promotion-terms/promotionTerms.jsx
+++ b/support-frontend/assets/pages/promotion-terms/promotionTerms.jsx
@@ -12,6 +12,7 @@ import Header from 'components/headers/header/header';
 import { Provider } from 'react-redux';
 import PromoDetails from 'pages/promotion-terms/promoDetails';
 import LegalTerms from 'pages/promotion-terms/legalTerms';
+import { detect } from 'helpers/internationalisation/countryGroup';
 
 // ----- Redux Store ----- //
 
@@ -23,7 +24,7 @@ const store = pageInit(() => reducer, true);
 const PromotionTermsPage = (props: State) => (
   <Provider store={store}>
     <Page
-      header={<Header />}
+      header={<Header countryGroupId={detect()} />}
       footer={<Footer />}
     >
       <PromoDetails {...props.page.promotionTerms} />

--- a/support-frontend/stories/header.jsx
+++ b/support-frontend/stories/header.jsx
@@ -5,13 +5,14 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import Header from 'components/headers/header/header';
+import { GBPCountries } from 'helpers/internationalisation/countryGroup';
 
 const stories = storiesOf('Header', module);
 
 stories.add('Header (navigation)', () => (
-  <Header display="navigation" />
+  <Header display="navigation" countryGroupId={GBPCountries} />
 ));
 
 stories.add('Header (checkout)', () => (
-  <Header display="checkout" />
+  <Header display="checkout" countryGroupId={GBPCountries} />
 ));


### PR DESCRIPTION
## Why are you doing this?
The header component needs a `countryGroupId` or the links it renders do not have the country in them and go via the geolocation endpoint. In DEV this results in /int/ urls which can be annoying.

However the `countryGroupId` was not required and so several pages including the paper landing page were not passing a value in meaning it defaulted to null.

This PR makes the prop required and passes in a value everywhere the component is used.

[**Trello Card**](https://trello.com/c/oDbZ8P9l/2944-fix-missing-countrygroupid-on-paper-landing-page)