### PR TITLE
Inline the request to generate a SetupIntent token when the Contribute button is pressed

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -93,7 +93,6 @@ export type Action =
   | { type: 'SET_CREATE_STRIPE_PAYMENT_METHOD', createStripePaymentMethod: (email: string) => void }
   | { type: 'SET_HANDLE_STRIPE_3DS', handleStripe3DS: (clientSecret: string) => Promise<Stripe3DSResult> }
   | { type: 'SET_STRIPE_CARD_FORM_COMPLETE', isComplete: boolean }
-  | { type: 'SET_STRIPE_SETUP_INTENT_CLIENT_SECRET', setupIntentClientSecret: string }
   | PayPalAction
   | { type: 'SET_HAS_SEEN_DIRECT_DEBIT_THANK_YOU_COPY' }
   | { type: 'PAYMENT_SUCCESS' }
@@ -303,9 +302,6 @@ const setStripeCardFormComplete = (isComplete: boolean): ((Function) => void) =>
   (dispatch: Function): void => {
     dispatch(setFormSubmissionDependentValue(() => ({ type: 'SET_STRIPE_CARD_FORM_COMPLETE', isComplete })));
   };
-
-const setSetupIntentClientSecret = (setupIntentClientSecret: string): Action =>
-  ({ type: 'SET_STRIPE_SETUP_INTENT_CLIENT_SECRET', setupIntentClientSecret });
 
 const sendFormSubmitEventForPayPalRecurring = () =>
   (dispatch: Function, getState: () => State): void => {
@@ -794,6 +790,5 @@ export {
   setCreateStripePaymentMethod,
   setHandleStripe3DS,
   setStripeCardFormComplete,
-  setSetupIntentClientSecret,
   updatePayPalButtonReady,
 };

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
@@ -72,7 +72,6 @@ export type Stripe3DSResult = {
 
 export type StripeCardFormData = {
   formComplete: boolean,
-  setupIntentClientSecret: string | null, // For recurring only
   // These callbacks must be initialised after the StripeCardForm component has been created
   createPaymentMethod: ((email: string) => void) | null,
   handle3DS: ((clientSecret: string) => Promise<Stripe3DSResult>) | null, // For single only
@@ -201,7 +200,6 @@ function createFormReducer() {
       formComplete: false,
       createPaymentMethod: null,
       handle3DS: null,
-      setupIntentClientSecret: null,
     },
     setPasswordData: {
       password: '',
@@ -354,15 +352,6 @@ function createFormReducer() {
           stripeCardFormData: {
             ...state.stripeCardFormData,
             formComplete: action.isComplete,
-          },
-        };
-
-      case 'SET_STRIPE_SETUP_INTENT_CLIENT_SECRET':
-        return {
-          ...state,
-          stripeCardFormData: {
-            ...state.stripeCardFormData,
-            setupIntentClientSecret: action.setupIntentClientSecret,
           },
         };
 

--- a/support-lambdas/stripe-intent/cfn.yaml
+++ b/support-lambdas/stripe-intent/cfn.yaml
@@ -47,7 +47,7 @@ Resources:
       CodeUri:
         Bucket: support-workers-dist
         Key: !Sub support/${Stage}/stripe-intent/stripe-intent.jar
-      MemorySize: 1536
+      MemorySize: 2048
       Runtime: java8
       Timeout: 300
       Environment:


### PR DESCRIPTION
Inline the request to generate a SetupIntent token when the Contribute button is pressed.

## Why are you doing this?
Fraudsters are using the generated SetupIntent to do card testing.

## Checklist ##
- [x] Tested Locally
- [x] Tested on CODE (API Gateway call now takes ~6s rather than 7s)
- [x] CODE CloudFormation
- [ ] PROD CloudFormation
- [ ] Post-deployment tests pass

<img width="1421" alt="Screen Shot 2020-03-30 at 09 24 08" src="https://user-images.githubusercontent.com/1515970/77891058-4e0f1d00-7268-11ea-89fa-14251b916bf3.png">

<img width="1469" alt="Screen Shot 2020-03-30 at 09 26 06" src="https://user-images.githubusercontent.com/1515970/77891200-84e53300-7268-11ea-8f78-05ff184b2eb5.png">
