### PR TITLE
Removed personalised thank you page test, defaulting to personalised variant

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -6,36 +6,11 @@ import { V1 } from './data/testAmountsData';
 export type StripePaymentRequestButtonScaTestVariants = 'control' | 'sca' | 'notintest';
 
 export type ChoiceCardsProductSetTestR3Variants = 'control' | 'yellow';
-export type PersonalisedThankYouPageTestVariants = 'control' | 'personalised' | 'notintest';
 
 const contributionsLandingPageMatch = '/(uk|us|eu|au|ca|nz|int)/contribute(/.*)?$';
-const contributionsLandingPageWithoutAU = '/(uk|us|eu|ca|nz|int)/contribute(/.*)?$';
 const usOnlyLandingPage = '/us/contribute(/.*)?$';
 
 export const tests: Tests = {
-
-  personalisedThankYouPageTest: {
-    type: 'OTHER',
-    variants: [
-      {
-        id: 'control',
-      },
-      {
-        id: 'personalised',
-      },
-    ],
-    audiences: {
-      ALL: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: true,
-    referrerControlled: false,
-    seed: 1,
-    targetPage: contributionsLandingPageWithoutAU,
-  },
-
   recaptchaPresenceTest: {
     type: 'OTHER',
     variants: [

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouBlurb.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouBlurb.jsx
@@ -4,7 +4,6 @@
 
 import React from 'react';
 import { connect } from 'react-redux';
-import type { PersonalisedThankYouPageTestVariants } from 'helpers/abTests/abtestDefinitions';
 import type { ThankYouPageStage } from 'pages/contributions-landing/contributionsLandingReducer';
 
 // ----- Types ----- //
@@ -12,7 +11,6 @@ import type { ThankYouPageStage } from 'pages/contributions-landing/contribution
 /* eslint-disable react/no-unused-prop-types */
 type PropTypes = {|
   firstName: string,
-  personalisedThankYouPageTestVariant: PersonalisedThankYouPageTestVariants,
   thankYouPageStage: ThankYouPageStage
 |};
 /* eslint-enable react/no-unused-prop-types */
@@ -22,15 +20,14 @@ type PropTypes = {|
 
 const mapStateToProps = state => ({
   firstName: state.page.form.formData.firstName,
-  personalisedThankYouPageTestVariant: state.common.abParticipations.personalisedThankYouPageTest,
   thankYouPageStage: state.page.form.thankYouPageStage,
 });
 
 // ----- Render ----- //
 
 const ContributionThankYouBlurb = (props: PropTypes) => {
-  const { firstName, personalisedThankYouPageTestVariant, thankYouPageStage } = props;
-  const headerText = (firstName && firstName !== '' && personalisedThankYouPageTestVariant === 'personalised') ?
+  const { firstName, thankYouPageStage } = props;
+  const headerText = (firstName && firstName.trim() !== '') ?
     `Thank\xa0you\xa0${firstName}\nfor\xa0your\xa0valuable\ncontribution` : 'Thank\xa0you\xa0for\na\xa0valuable\ncontribution';
 
   return (


### PR DESCRIPTION
## Why are you doing this?
We didn't see any significant difference (small, statistically insignificant changes only) in running the personalisation on the thank you page, but have a preference for the personalised option. 

Analysis can be found here: https://docs.google.com/spreadsheets/d/1e9rOENi_cFE8FyLpT7awdxakZU2SMer8scvTYIgZ6Qg/edit?usp=drive_web&ouid=106205001663870675496

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/4tjZkEER/1949-turn-off-the-ab-test-on-the-thank-you-page)
