### PR TITLE
Synchronise travis and prout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,5 @@ cache:
 before_cache:
   - find $HOME/.sbt -name "*.lock" -type f -delete -print
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" -type f -delete -print
-script: travis_retry 1 sbt ++$TRAVIS_SCALA_VERSION selenium:test
+script: sbt ++$TRAVIS_SCALA_VERSION selenium:test || sbt ++$TRAVIS_SCALA_VERSION selenium:test
 after_failure: ./support-frontend/scripts/post_test_results_to_chat.sh


### PR DESCRIPTION
## Why are you doing this?

`travis_retry` does not take an argument, so manually triggering a build in travis fails. This could be fixed by removing the argument, but actually I think the desired behaviour is for builds triggered by prout and builds triggered manually to run the exact same command. See #2409