### PR TITLE
Fix image issue in safari

### DIFF
--- a/support-frontend/assets/components/subscriptionCheckouts/orderSummary/orderSummaryStyles.js
+++ b/support-frontend/assets/components/subscriptionCheckouts/orderSummary/orderSummaryStyles.js
@@ -47,14 +47,15 @@ export const contentBlock = css`
 
 export const imageContainer = css`
   display: inline-flex;
+  align-items: flex-start;
   width: calc(100%-30px);
-  height: auto;
   padding: 15px 10px 0 15px;
   background-color: #63717A;
 
   img {
     width: 100%;
-    align-items: flex-end;
+    height: auto;
+
   }
 
   ${until.tablet} {


### PR DESCRIPTION
## Why are you doing this?
Fixing a problem in some browsers where the order summary image was getting stretched.

The issue was introduced in this PR: https://github.com/guardian/support-frontend/pull/2417

## The problem
![image (1)](https://user-images.githubusercontent.com/16781258/78175511-e79a2280-7452-11ea-93e4-a1e1273b12d4.png)

## The fix
![Screen Shot 2020-04-01 at 19 58 31](https://user-images.githubusercontent.com/16781258/78175696-31830880-7453-11ea-895a-9e7820cc0548.png)

