### PR TITLE
cope with missing stripe.elements()

### DIFF
--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -219,7 +219,12 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
   render() {
     const { stripe } = this.props;
     if (stripe) {
-      stripe.elements();
+      if (stripe.elements) {
+        stripe.elements();
+      } else {
+        // eslint-disable-next-line no-underscore-dangle
+        stripe._elements();
+      }
     }
 
     return (


### PR DESCRIPTION
## Why are you doing this?
We are seeing stripe set up failing because a function `elements` is missing from the stripe object, however there is a function called `_elements` which does seem to work so try calling this if `elements` is not available.