### PR TITLE
HD: update 7am delivery time to 8am

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/deliveryTab.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/deliveryTab.jsx
@@ -48,7 +48,7 @@ const ContentDeliveryFaqBlock = ({ setTabAction }: {setTabAction: typeof setTab}
     <Divider small />
     <Text title="Giving you peace of mind">
       <UnorderedList items={[
-        'Your paper will arrive before 7am from Monday to Saturday and before 8.30am on Sunday',
+        'Your paper will arrive before 8am from Monday to Saturday and before 8.30am on Sunday',
         'We can’t deliver to individual flats, or apartments within blocks because we need access to your post box to deliver your paper',
         'You can pause your subscription for up to 36 days a year. So if you’re going away anywhere, you won’t have to pay for the papers that you miss',
         ]}


### PR DESCRIPTION
## Why are you doing this?
This is a change to the promised delivery time due to unprecedented demand for home delivery. It gives the providers a bit more time to get all those papers delivered.

[**Trello Card**](https://trello.com/c/EIfl3jde/2948-update-delivery-times-on-hd-checkout)

## Screenshots
![Screen Shot 2020-04-02 at 19 01 21](https://user-images.githubusercontent.com/16781258/78282587-715df480-7514-11ea-9465-7a2136576965.png)

