### PR TITLE
Fix Stripe form validation check

### DIFF
--- a/support-frontend/assets/helpers/stripe.js
+++ b/support-frontend/assets/helpers/stripe.js
@@ -18,13 +18,3 @@ export const setupStripe = (setStripeHasLoaded: () => void) => {
     }
   }
 };
-
-export const stripeCardFormIsIncomplete = (
-  contributionType: ContributionType,
-  paymentMethod: PaymentMethod,
-  stripeCardFormComplete: boolean,
-  stripeElementsRecurringTestVariant: string,
-): boolean =>
-  (contributionType === 'ONE_OFF' || stripeElementsRecurringTestVariant === 'stripeElements') &&
-  paymentMethod === Stripe &&
-  !(stripeCardFormComplete);

--- a/support-frontend/assets/helpers/stripe.js
+++ b/support-frontend/assets/helpers/stripe.js
@@ -1,7 +1,5 @@
 // @flow
 import { logException } from 'helpers/logger';
-import type { ContributionType } from 'helpers/contributions';
-import { type PaymentMethod, Stripe } from 'helpers/paymentMethods';
 
 export const setupStripe = (setStripeHasLoaded: () => void) => {
   if (window.Stripe) {

--- a/support-frontend/assets/pages/contributions-landing/checkoutFormIsSubmittableActions.js
+++ b/support-frontend/assets/pages/contributions-landing/checkoutFormIsSubmittableActions.js
@@ -19,12 +19,12 @@ import {
 } from 'helpers/contributions';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { StateProvince } from 'helpers/internationalisation/country';
-import { stripeCardFormIsIncomplete } from 'helpers/stripe';
 import type { State } from './contributionsLandingReducer';
 import {
   type Action as ContributionsLandingAction,
   setFormIsValid,
 } from './contributionsLandingActions';
+import {Stripe} from "helpers/paymentMethods";
 
 // ----- Types ----- //
 
@@ -93,12 +93,7 @@ const formIsValidParameters = (state: State) => ({
   firstName: state.page.form.formData.firstName,
   lastName: state.page.form.formData.lastName,
   email: state.page.form.formData.email,
-  stripeCardFormOk: !stripeCardFormIsIncomplete(
-    state.page.form.contributionType,
-    state.page.form.paymentMethod,
-    state.page.form.stripeCardFormData.formComplete,
-    state.common.abParticipations.stripeElementsRecurring,
-  ),
+  stripeCardFormOk: state.page.form.paymentMethod !== Stripe || state.page.form.stripeCardFormData.formComplete,
 });
 
 function enableOrDisableForm() {


### PR DESCRIPTION
When the user clicks Contribute but has not completed the Stripe card form, it should block the action using the `formComplete` in the redux store.
This is currently broken because of some old logic from when the Stripe card form was first introduced (for one-offs only, as an a/b test)