### PR TITLE
New digisub monthly offer

### DIFF
--- a/support-frontend/app/controllers/DigitalSubscription.scala
+++ b/support-frontend/app/controllers/DigitalSubscription.scala
@@ -55,7 +55,8 @@ class DigitalSubscription(
     val css = Left(RefPath("digitalSubscriptionLandingPage.css"))
     val description = stringsConfig.digitalPackLandingDescription
     val canonicalLink = Some(buildCanonicalDigitalSubscriptionLink("uk"))
-    val september2019SalePromo = "DK0NT24WG"
+    val september2019SalePromo = "DK0NT24WG" //Not using this during the one for one test
+    val oneForOnePromo = "ONE-FOR-ONE"
     val annualIntroCodes: List[PromoCode] = List(
       "ANNUAL-INTRO-EU",
       "ANNUAL-INTRO-UK",
@@ -64,7 +65,7 @@ class DigitalSubscription(
       "ANNUAL-INTRO-CA",
       "ANNUAL-INTRO-AU"
     )
-    val promoCodes: List[PromoCode] = request.queryString.get("promoCode").map(_.toList).getOrElse(Nil) ++ annualIntroCodes :+ september2019SalePromo
+    val promoCodes: List[PromoCode] = request.queryString.get("promoCode").map(_.toList).getOrElse(Nil) ++ annualIntroCodes :+ oneForOnePromo
     val hrefLangLinks = Map(
       "en-us" -> buildCanonicalDigitalSubscriptionLink("us"),
       "en-gb" -> buildCanonicalDigitalSubscriptionLink("uk"),

--- a/support-frontend/app/controllers/Subscriptions.scala
+++ b/support-frontend/app/controllers/Subscriptions.scala
@@ -48,13 +48,11 @@ class Subscriptions(
     implicit val codec : com.gu.support.encoding.Codec[PriceCopy] = deriveCodec
   }
 
-  def pricingCopy(priceSummary: PriceSummary): PriceCopy = {
-    val discountCopy = for {
-      promotion <- priceSummary.promotions.headOption
-      discountedPrice <- promotion.discountedPrice
-    } yield PriceCopy(discountedPrice, promotion.description)
-    discountCopy.getOrElse(PriceCopy(priceSummary.price, ""))
-  }
+  def pricingCopy(priceSummary: PriceSummary): PriceCopy =
+    PriceCopy(
+      priceSummary.price,
+      priceSummary.promotions.headOption.map(_.description).getOrElse("")
+    )
 
   def getLandingPrices(countryGroup: CountryGroup): Map[String, PriceCopy] = {
     val service = priceSummaryServiceProvider.forUser(false)
@@ -69,7 +67,7 @@ class Subscriptions(
     val weekly = service.getPrices(GuardianWeekly, Nil)(countryGroup)(Domestic)(NoProductOptions)(Quarterly)(countryGroup.currency)
 
     val digitalSubscription = service
-      .getPrices(DigitalPack, List("DK0NT24WG"))(countryGroup)(NoFulfilmentOptions)(NoProductOptions)(Monthly)(countryGroup.currency)
+      .getPrices(DigitalPack, List("ONE-FOR-ONE"))(countryGroup)(NoFulfilmentOptions)(NoProductOptions)(Monthly)(countryGroup.currency)
 
     Map(GuardianWeekly.toString -> pricingCopy(weekly), DigitalPack.toString -> pricingCopy(digitalSubscription)) ++ paperMap
   }

--- a/support-frontend/assets/components/subscriptionsProductDescription/subscriptionsProductDescription.jsx
+++ b/support-frontend/assets/components/subscriptionsProductDescription/subscriptionsProductDescription.jsx
@@ -33,8 +33,9 @@ const SubscriptionsProductDescription = ({
 }: PropTypes) => (
   <div>
     <h2 className="subscriptions__product-title">{title}</h2>
-    <h3 className="subscriptions__product-subtitle">{subtitle}</h3>
-    {offer && <h4 className="subscriptions__sales">{offer}</h4>}
+    {offer && <h3 className="subscriptions__sales">{offer}</h3>}
+    {offer && <h3 className="subscriptions__product-subtitle--small">{subtitle}</h3>}
+    {!offer && <h3 className="subscriptions__product-subtitle--large">{subtitle}</h3>}
     <p className="subscriptions__description">{description}</p>
     <div className={isFeature ? 'subscriptions__button-container--feature' : 'subscriptions__button-container'}>
       {buttons.map((button, index) => (
@@ -46,7 +47,7 @@ const SubscriptionsProductDescription = ({
         >
           {button.ctaButtonText}
         </AnchorButton>
-      ))}
+        ))}
     </div>
   </div>
 );

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
@@ -105,7 +105,10 @@ const mapStateToProps = (state: State): { paymentOptions: Array<PaymentOption> }
     const promotion = getAppliedPromo(productPrice.promotions);
     const promoCode = promotion ? promotion.promoCode : null;
     const promotionalPrice = promotion && promotion.discountedPrice ? promotion.discountedPrice : null;
-    const offer = promotion ? promotion.description : BILLING_PERIOD[digitalBillingPeriod].offer;
+    const offer = promotion &&
+    promotion.landingPage &&
+    promotion.landingPage.roundel ? promotion.landingPage.roundel :
+      BILLING_PERIOD[digitalBillingPeriod].offer;
 
     return {
       title: BILLING_PERIOD[digitalBillingPeriod].title,

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.scss
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.scss
@@ -365,7 +365,33 @@
   }
 }
 
-.subscriptions__product-subtitle {
+.subscriptions__sales {
+  font-size: 28px;
+  line-height: 30px;
+  font-weight: 300;
+  display: inline-block;
+  background-color: gu-colour('highlight-main');
+  vertical-align: middle;
+  padding: 0px 7px 3px;
+  margin: 6px 0px;
+
+  @include mq($until: desktop) {
+    font-size: 24px;
+  }
+
+  @include mq($until: tablet) {
+    font-size: 24px;
+    line-height: 30px;
+  }
+
+  @include mq($until: mobileLandscape) {
+    font-size: 20px;
+    line-height: 24px;
+  }
+
+}
+
+.subscriptions__product-subtitle--large {
   font-size: 28px;
   line-height: 30px;
   font-weight: 300;
@@ -383,6 +409,27 @@
   @include mq($until: mobileLandscape) {
     font-size: 20px;
     line-height: 24px;
+  }
+}
+
+.subscriptions__product-subtitle--small {
+  font-size: 24px;
+  line-height: 27px;
+  font-weight: 300;
+  font-family: $gu-headline;
+
+  @include mq($until: desktop) {
+    font-size: 20px;
+  }
+
+  @include mq($until: mobileLandscape) {
+    font-size: 18px;
+    line-height: 24px;
+  }
+
+  @include mq($until: mobileMedium) {
+    font-size: 16px;
+    line-height: 20px;
   }
 }
 
@@ -427,31 +474,6 @@
   @include mq($until: tablet) {
     border-top: none;
   }
-}
-
-.subscriptions__sales {
-  font-size: 24px;
-  line-height: 27px;
-  display: inline-block;
-  background-color: gu-colour('highlight-main');
-  vertical-align: middle;
-  padding: 0px 7px 3px;
-  margin-top: 6px;
-
-  @include mq($until: desktop) {
-    font-size: 20px;
-  }
-
-  @include mq($until: mobileLandscape) {
-    font-size: 18px;
-    line-height: 24px;
-  }
-
-  @include mq($until: mobileMedium) {
-    font-size: 16px;
-    line-height: 20px;
-  }
-
 }
 
 .subscriptions__product--feature .subscriptions__sales {

--- a/support-frontend/webpack.dev.js
+++ b/support-frontend/webpack.dev.js
@@ -4,7 +4,7 @@ const common = require('./webpack.common.js');
 
 module.exports = merge(common('[name].css', '[name].js', false), {
   mode: 'development',
-  devtool: 'cheap-module-eval-source-map',
+  devtool: 'inline-source-map',
   devServer: {
     disableHostCheck: true,
     proxy: {


### PR DESCRIPTION
## Why are you doing this?
We are introducing a new introductory offer for purchasers of monthly digital subscriptions.

[**Trello Card**](https://trello.com/c/5B4X1GVc/2960-digital-pack-new-monthly-offer)

## Changes

* Change the default monthly promotion to 'one for one'
* The product card on digisub page was using the wrong field for promotional copy
* Flip the ordering of the promotion price and regular price on the showcase page so that the offer comes first

## Screenshots

<img width="1303" alt="Screen Shot 2020-04-03 at 10 42 16" src="https://user-images.githubusercontent.com/181371/78348680-5cc43f80-759a-11ea-8db3-a0357c2d10a0.png">
<img width="358" alt="Screen Shot 2020-04-03 at 11 01 22" src="https://user-images.githubusercontent.com/181371/78349237-3357e380-759b-11ea-883b-f9bef253dd1d.png">
