### PR TITLE
Update HD postcode delivery error - remove customer service phone number

### DIFF
--- a/support-frontend/assets/components/forms/customFields/error.scss
+++ b/support-frontend/assets/components/forms/customFields/error.scss
@@ -4,7 +4,7 @@
   @include gu-fontset-explainer;
   color: gu-colour(state-error);
   display: block;
-  
+
   @include mq($from: mobileMedium) {
     width: 80%;
   }
@@ -16,6 +16,9 @@
 
 .component-form-error__summary-error {
   margin-top: $gu-v-spacing / 2;
+  a, a:visited {
+    color: inherit;
+  }
   &:first-of-type {
     margin-top: $gu-v-spacing;
   }
@@ -28,7 +31,7 @@
 .component-form-error {
   .StripeElement--invalid, .StripeElement--empty {
     border: 1px solid #c70000;
-  }  
+  }
 }
 
 .component-form-error__heading {

--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.js
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.js
@@ -126,7 +126,7 @@ const applyDeliveryAddressRules = (
   const homeRules = validate([
     {
       rule: isHomeDeliveryInM25(fulfilmentOption, fields.postCode),
-      error: formError('postCode', 'Sorry, we cannot deliver a paper to an address with this postcode. Please call Customer Services on: 0330 333 6767 or press Back to purchase a voucher subscription.'),
+      error: formError('postCode', 'Temporary COVID message'),
     },
   ]);
 

--- a/support-frontend/assets/components/subscriptionCheckouts/submitFormErrorSummary.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/submitFormErrorSummary.jsx
@@ -6,7 +6,6 @@ import React from 'react';
 import Heading from 'components/heading/heading';
 
 import 'components/forms/customFields/error.scss';
-import './subscriptionSubmitButton.scss';
 
 // ----- Types ----- //
 
@@ -20,11 +19,19 @@ export const ErrorSummary = (props: PropTypes) => (
   <div className="component-form-error__border">
     <Heading className="component-form-error__heading" size={2}>There is a problem</Heading>
     <ul>
-      {props.errors.map(error => (
-        <li className="component-form-error__summary-error">
-          {error.message}
-        </li>
-      ))}
+      {props.errors.map((error) => {
+        if (error.message === 'Temporary COVID message') {
+          return (
+            <li className="component-form-error__summary-error">
+              The address and postcode you entered is outside of our delivery area. You may want to
+              consider purchasing a <a href="/uk/subscribe/paper">voucher subscription</a>
+            </li>);
+        }
+        return (
+          <li className="component-form-error__summary-error">
+            {error.message}
+          </li>);
+      })}
     </ul>
   </div>
 );


### PR DESCRIPTION
## Why are you doing this?
During the COVID-19 crisis, the customer service centre is getting a lot of calls, so we are removing the number from our postcode lookup form error.

[**Trello Card**](https://trello.com/c/YFxWjmc8/2953-remove-contact-centre-phone-number-from-error-message-update-error-copy)

## New error
![Screen Shot 2020-04-03 at 12 48 02](https://user-images.githubusercontent.com/16781258/78357854-15de4600-75aa-11ea-913f-e02d1c4c5e67.png)

## Old error
![Screen Shot 2020-04-03 at 12 56 08](https://user-images.githubusercontent.com/16781258/78358095-838a7200-75aa-11ea-981b-2be5f7aa08c1.png)
