### PR TITLE
Change subscriptions to use the new Stripe Setup Intents endpoint

### DIFF
--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -105,7 +105,6 @@
   window.guardian.paymentApiUrl = "@paymentApiUrl";
   window.guardian.paymentApiPayPalEndpoint = "@paymentApiPayPalEndpoint";
   window.guardian.existingPaymentOptionsEndpoint = "@existingPaymentOptionsEndpoint";
-  window.guardian.stripeSetupIntentEndpoint = "@stripeSetupIntentEndpoint";
   window.guardian.csrf = { token: "@CSRF.getToken.value" };
 
   @guestAccountCreationToken.map { guestAccountCreationToken =>

--- a/support-frontend/app/views/subscriptionCheckout.scala.html
+++ b/support-frontend/app/views/subscriptionCheckout.scala.html
@@ -63,7 +63,7 @@
         uat: "@uatPayPalConfig.payPalEnvironment"
       };
       window.guardian.csrf = { token: "@CSRF.getToken.value" };
-      window.guardian.stripeSetupIntentEndpoint = "@stripeSetupIntentEndpoint";
+      window.guardian.stripeSetupIntentEndpoint = "/stripe/create-setup-intent";
 
       window.guardian.checkoutPostcodeLookup = "@settings.switches.experiments.get("checkoutPostcodeLookup").exists(_.isOn)"
   </script>

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -17,6 +17,7 @@ import { fetchJson, requestOptions } from 'helpers/fetch';
 import { logException } from 'helpers/logger';
 import type { Option } from 'helpers/types/option';
 import { appropriateErrorMessage } from 'helpers/errorReasons';
+import type {Csrf} from "../../../helpers/csrf/csrfReducer";
 
 // Types
 
@@ -30,6 +31,7 @@ export type StripeFormPropTypes = {
   validateForm: Function,
   buttonText: string,
   stripeSetupIntentEndpoint: string,
+  csrf: Csrf,
 }
 
 type StateTypes = {
@@ -111,7 +113,7 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
     // is handled in the callback below by checking the value of paymentWaiting.
     fetchJson(
       this.props.stripeSetupIntentEndpoint,
-      requestOptions({ publicKey: this.props.stripeKey }, 'omit', 'POST', null),
+      requestOptions({ stripePublicKey: this.props.stripeKey }, 'omit', 'POST', this.props.csrf),
     ).then((result) => {
       if (result.client_secret) {
         this.setState({ setupIntentClientSecret: result.client_secret });

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -17,7 +17,7 @@ import { fetchJson, requestOptions } from 'helpers/fetch';
 import { logException } from 'helpers/logger';
 import type { Option } from 'helpers/types/option';
 import { appropriateErrorMessage } from 'helpers/errorReasons';
-import type {Csrf} from "../../../helpers/csrf/csrfReducer";
+import type { Csrf } from '../../../helpers/csrf/csrfReducer';
 
 // Types
 

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeProviderForCountry.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeProviderForCountry.jsx
@@ -29,6 +29,7 @@ function StripeProviderForCountry(props: PropTypes) {
           stripeSetupIntentEndpoint={props.stripeSetupIntentEndpoint}
           validateForm={props.validateForm}
           buttonText={props.buttonText}
+          csrf={props.csrf}
         />
       </Elements>
     </StripeProvider>

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
@@ -239,6 +239,7 @@ function DigitalCheckoutForm(props: PropTypes) {
               name={`${props.firstName} ${props.lastName}`}
               validateForm={props.validateForm}
               buttonText="Start your free trial now"
+              csrf={props.csrf}
             />
           </FormSectionHiddenUntilSelected>
           <FormSectionHiddenUntilSelected

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
@@ -327,6 +327,7 @@ function PaperCheckoutForm(props: PropTypes) {
               name={`${props.firstName} ${props.lastName}`}
               validateForm={props.validateForm}
               buttonText="Pay now"
+              csrf={props.csrf}
             />
           </FormSectionHiddenUntilSelected>
           <FormSectionHiddenUntilSelected

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -320,6 +320,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
               name={`${props.firstName} ${props.lastName}`}
               validateForm={props.validateForm}
               buttonText="Pay now"
+              csrf={props.csrf}
             />
           </FormSectionHiddenUntilSelected>
           <FormSectionHiddenUntilSelected

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.jsx
@@ -349,6 +349,7 @@ function WeeklyCheckoutFormGifting(props: PropTypes) {
               name={`${props.firstName} ${props.lastName}`}
               validateForm={props.validateForm}
               buttonText="Pay now"
+              csrf={props.csrf}
             />
           </FormSectionHiddenUntilSelected>
           <FormSectionHiddenUntilSelected


### PR DESCRIPTION
## Why are you doing this?
The old api-gateway endpoint is about to be removed.
This changes it to use a new endpoint on the Play backend.

https://trello.com/c/1nR0l7gx/1947-improve-security-of-stripe-setup-intent-creation-1