### PR TITLE
bump event producer to get updated libthrift

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.2
+sbt.version=1.3.9

--- a/support-models/build.sbt
+++ b/support-models/build.sbt
@@ -5,7 +5,7 @@ name := "support-models"
 description := "Scala library to provide shared step-function models to Guardian Support projects."
 
 libraryDependencies ++= Seq(
-  "com.gu" %% "acquisition-event-producer-play26" % "4.0.26-SNAPSHOT", //this should really be split into models and producer
+  "com.gu" %% "acquisition-event-producer-play26" % "4.0.26", //this should really be split into models and producer
                                                               // so we don't have to pull in thrift binary compression libs etc
   "org.typelevel" %% "cats-core" % catsVersion,
   "io.circe" %% "circe-core" % circeVersion,

--- a/support-models/build.sbt
+++ b/support-models/build.sbt
@@ -5,7 +5,7 @@ name := "support-models"
 description := "Scala library to provide shared step-function models to Guardian Support projects."
 
 libraryDependencies ++= Seq(
-  "com.gu" %% "acquisition-event-producer-play26" % "4.0.25", //this should really be split into models and producer
+  "com.gu" %% "acquisition-event-producer-play26" % "4.0.26-SNAPSHOT", //this should really be split into models and producer
                                                               // so we don't have to pull in thrift binary compression libs etc
   "org.typelevel" %% "cats-core" % catsVersion,
   "io.circe" %% "circe-core" % circeVersion,


### PR DESCRIPTION
## Why are you doing this?

We are using a vulnerable libthrift via acquisition event producer and thrift serialiser.
https://app.snyk.io/vuln/SNYK-JAVA-ORGAPACHETHRIFT-474610

This PR bumps the library that bumps the library that pulls in the right code!
