### PR TITLE
Tidy up stripeSetupIntentEndpoint configuration in subs

### DIFF
--- a/support-frontend/app/config/Configuration.scala
+++ b/support-frontend/app/config/Configuration.scala
@@ -11,7 +11,6 @@ import com.typesafe.config.{Config => TypesafeConfig}
 class Configuration(config: TypesafeConfig) {
 
   lazy val stage = Stage.fromString(config.getString("stage")).get
-  lazy val stripeIntentUrl = config.getString("stripe.intent.url")
 
   lazy val sentryDsn = config.getOptionalString("sentry.dsn")
 

--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -51,7 +51,6 @@ class Application(
   settingsProvider: AllSettingsProvider,
   guardianDomain: GuardianDomain,
   stage: Stage,
-  stripeIntentUrl: String,
   val supportUrl: String,
   fontLoaderBundle: Either[RefPath, StyleContent]
 )(implicit val ec: ExecutionContext) extends AbstractController(components)
@@ -180,7 +179,6 @@ class Application(
       paymentApiUrl = paymentAPIService.paymentAPIUrl,
       paymentApiPayPalEndpoint = paymentAPIService.payPalCreatePaymentEndpoint,
       existingPaymentOptionsEndpoint = membersDataService.existingPaymentOptionsEndpoint,
-      stripeSetupIntentEndpoint = stripeIntentUrl,
       idUser = idUser,
       guestAccountCreationToken = guestAccountCreationToken,
       fontLoaderBundle = fontLoaderBundle,

--- a/support-frontend/app/controllers/DigitalSubscription.scala
+++ b/support-frontend/app/controllers/DigitalSubscription.scala
@@ -37,8 +37,7 @@ class DigitalSubscription(
   stringsConfig: StringsConfig,
   settingsProvider: AllSettingsProvider,
   val supportUrl: String,
-  fontLoaderBundle: Either[RefPath, StyleContent],
-  stripeSetupIntentEndpoint: String
+  fontLoaderBundle: Either[RefPath, StyleContent]
 )(
   implicit val ec: ExecutionContext
 ) extends AbstractController(components) with GeoRedirect with CanonicalLinks with Circe with SettingsSurrogateKeySyntax {
@@ -143,8 +142,7 @@ class DigitalSubscription(
       stripeConfigProvider.get(),
       stripeConfigProvider.get(true),
       payPalConfigProvider.get(),
-      payPalConfigProvider.get(true),
-      stripeSetupIntentEndpoint
+      payPalConfigProvider.get(true)
     )
   }
 

--- a/support-frontend/app/controllers/PaperSubscription.scala
+++ b/support-frontend/app/controllers/PaperSubscription.scala
@@ -39,8 +39,7 @@ class PaperSubscription(
   stringsConfig: StringsConfig,
   settingsProvider: AllSettingsProvider,
   val supportUrl: String,
-  fontLoaderBundle: Either[RefPath, StyleContent],
-  stripeSetupIntentEndpoint: String
+  fontLoaderBundle: Either[RefPath, StyleContent]
 )(implicit val ec: ExecutionContext) extends AbstractController(components) with GeoRedirect with Circe with CanonicalLinks with SettingsSurrogateKeySyntax {
 
   import actionRefiners._
@@ -114,8 +113,7 @@ class PaperSubscription(
       stripeConfigProvider.get(false),
       stripeConfigProvider.get(true),
       payPalConfigProvider.get(false),
-      payPalConfigProvider.get(true),
-      stripeSetupIntentEndpoint
+      payPalConfigProvider.get(true)
     )
   }
 

--- a/support-frontend/app/controllers/WeeklySubscription.scala
+++ b/support-frontend/app/controllers/WeeklySubscription.scala
@@ -42,7 +42,6 @@ class WeeklySubscription(
   settingsProvider: AllSettingsProvider,
   val supportUrl: String,
   fontLoaderBundle: Either[RefPath, StyleContent],
-  stripeSetupIntentEndpoint: String,
   stage: Stage
 )(implicit val ec: ExecutionContext) extends AbstractController(components) with GeoRedirect with Circe with CanonicalLinks with SettingsSurrogateKeySyntax {
 
@@ -152,7 +151,6 @@ class WeeklySubscription(
       stripeConfigProvider.get(true),
       payPalConfigProvider.get(),
       payPalConfigProvider.get(true),
-      stripeSetupIntentEndpoint,
       orderIsAGift
     )
   }

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -19,7 +19,6 @@
   paymentApiUrl: String,
   paymentApiPayPalEndpoint: String,
   existingPaymentOptionsEndpoint: String,
-  stripeSetupIntentEndpoint: String,
   idUser: Option[IdUser],
   guestAccountCreationToken: Option[String],
   fontLoaderBundle: Either[RefPath, StyleContent],

--- a/support-frontend/app/views/subscriptionCheckout.scala.html
+++ b/support-frontend/app/views/subscriptionCheckout.scala.html
@@ -27,7 +27,6 @@
   uatStripeConfig: StripeConfig,
   defaultPayPalConfig: PayPalConfig,
   uatPayPalConfig: PayPalConfig,
-  stripeSetupIntentEndpoint: String,
   orderIsAGift: Boolean = false,
 )(implicit assets: AssetsResolver, requestHeader: RequestHeader, settings: AllSettings)
 
@@ -63,7 +62,6 @@
         uat: "@uatPayPalConfig.payPalEnvironment"
       };
       window.guardian.csrf = { token: "@CSRF.getToken.value" };
-      window.guardian.stripeSetupIntentEndpoint = "/stripe/create-setup-intent";
 
       window.guardian.checkoutPostcodeLookup = "@settings.switches.experiments.get("checkoutPostcodeLookup").exists(_.isOn)"
   </script>

--- a/support-frontend/app/wiring/Controllers.scala
+++ b/support-frontend/app/wiring/Controllers.scala
@@ -36,7 +36,6 @@ trait Controllers {
     allSettingsProvider,
     appConfig.guardianDomain,
     appConfig.stage,
-    appConfig.stripeIntentUrl,
     appConfig.supportUrl,
     fontLoader
   )
@@ -66,8 +65,7 @@ trait Controllers {
     stringsConfig,
     allSettingsProvider,
     appConfig.supportUrl,
-    fontLoader,
-    appConfig.stripeIntentUrl
+    fontLoader
   )
 
   lazy val paperController = new PaperSubscription(
@@ -82,8 +80,7 @@ trait Controllers {
     stringsConfig,
     allSettingsProvider,
     appConfig.supportUrl,
-    fontLoader,
-    appConfig.stripeIntentUrl
+    fontLoader
   )
 
   lazy val weeklyController = new WeeklySubscription(
@@ -101,7 +98,6 @@ trait Controllers {
     allSettingsProvider,
     appConfig.supportUrl,
     fontLoader,
-    appConfig.stripeIntentUrl,
     appConfig.stage
   )
 

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeProviderForCountry.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeProviderForCountry.jsx
@@ -6,6 +6,7 @@ import StripeForm from 'components/subscriptionCheckouts/stripeForm/stripeForm';
 import { type StripeFormPropTypes } from 'components/subscriptionCheckouts/stripeForm/stripeForm';
 import { getStripeKey } from 'helpers/paymentIntegrations/stripeCheckout';
 import type { IsoCountry } from 'helpers/internationalisation/country';
+import {routes} from "helpers/routes";
 
 // Types
 
@@ -26,7 +27,7 @@ function StripeProviderForCountry(props: PropTypes) {
           allErrors={props.allErrors}
           stripeKey={stripeKey}
           setStripePaymentMethod={props.setStripePaymentMethod}
-          stripeSetupIntentEndpoint={props.stripeSetupIntentEndpoint}
+          stripeSetupIntentEndpoint={routes.stripeSetupIntent}
           validateForm={props.validateForm}
           buttonText={props.buttonText}
           csrf={props.csrf}

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
@@ -64,7 +64,6 @@ import {
 import GeneralErrorMessage
   from 'components/generalErrorMessage/generalErrorMessage';
 import { StripeProviderForCountry } from 'components/subscriptionCheckouts/stripeForm/stripeProviderForCountry';
-import { getGlobal } from 'helpers/globals';
 import DirectDebitForm from 'components/directDebit/directDebitProgressiveDisclosure/directDebitForm';
 import { routes } from 'helpers/routes';
 

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
@@ -89,7 +89,6 @@ type PropTypes = {|
   validateForm: () => Function,
   formIsValid: Function,
   addressErrors: Array<Object>,
-  stripeSetupIntentEndpoint: string,
 |};
 
 // ----- Map State/Props ----- //
@@ -113,7 +112,6 @@ function mapStateToProps(state: CheckoutState) {
     ).price,
     billingPeriod: state.page.checkout.billingPeriod,
     addressErrors: state.page.billingAddress.fields.formErrors,
-    stripeSetupIntentEndpoint: getGlobal('stripeSetupIntentEndpoint'),
   };
 }
 
@@ -235,7 +233,7 @@ function DigitalCheckoutForm(props: PropTypes) {
               submitForm={props.submitForm}
               allErrors={[...props.addressErrors]}
               setStripePaymentMethod={props.setStripePaymentMethod}
-              stripeSetupIntentEndpoint={props.stripeSetupIntentEndpoint}
+              stripeSetupIntentEndpoint={routes.stripeSetupIntent}
               name={`${props.firstName} ${props.lastName}`}
               validateForm={props.validateForm}
               buttonText="Start your free trial now"

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
@@ -68,7 +68,6 @@ import { validateWithDeliveryForm } from 'helpers/subscriptionsForms/formValidat
 import GeneralErrorMessage
   from 'components/generalErrorMessage/generalErrorMessage';
 import { StripeProviderForCountry } from 'components/subscriptionCheckouts/stripeForm/stripeProviderForCountry';
-import { getGlobal } from 'helpers/globals';
 import type { Csrf } from 'helpers/csrf/csrfReducer';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import { withDeliveryFormIsValid } from 'helpers/subscriptionsForms/formValidation';

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
@@ -90,7 +90,6 @@ type PropTypes = {|
   country: IsoCountry,
   isTestUser: boolean,
   validateForm: () => Function,
-  stripeSetupIntentEndpoint: string,
   csrf: Csrf,
   currencyId: IsoCurrency,
   payPalHasLoaded: boolean,
@@ -111,7 +110,6 @@ function mapStateToProps(state: WithDeliveryCheckoutState) {
     deliveryAddressErrors: state.page.billingAddress.fields.formErrors,
     isTestUser: state.page.checkout.isTestUser,
     country: state.common.internationalisation.countryId,
-    stripeSetupIntentEndpoint: getGlobal('stripeSetupIntentEndpoint'),
     csrf: state.page.csrf,
     currencyId: state.common.internationalisation.currencyId,
     payPalHasLoaded: state.page.checkout.payPalHasLoaded,
@@ -323,7 +321,7 @@ function PaperCheckoutForm(props: PropTypes) {
               submitForm={props.submitForm}
               allErrors={[...props.billingAddressErrors, ...props.deliveryAddressErrors, ...props.formErrors]}
               setStripePaymentMethod={props.setStripePaymentMethod}
-              stripeSetupIntentEndpoint={props.stripeSetupIntentEndpoint}
+              stripeSetupIntentEndpoint={routes.stripeSetupIntent}
               name={`${props.firstName} ${props.lastName}`}
               validateForm={props.validateForm}
               buttonText="Pay now"

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -97,7 +97,6 @@ type PropTypes = {|
   country: IsoCountry,
   isTestUser: boolean,
   validateForm: () => Function,
-  stripeSetupIntentEndpoint: string,
   csrf: Csrf,
   currencyId: IsoCurrency,
   payPalHasLoaded: boolean,
@@ -121,7 +120,6 @@ function mapStateToProps(state: WithDeliveryCheckoutState) {
     billingAddressErrors: state.page.billingAddress.fields.formErrors,
     isTestUser: state.page.checkout.isTestUser,
     country: state.common.internationalisation.countryId,
-    stripeSetupIntentEndpoint: getGlobal('stripeSetupIntentEndpoint'),
     csrf: state.page.csrf,
     currencyId: state.common.internationalisation.currencyId,
     payPalHasLoaded: state.page.checkout.payPalHasLoaded,
@@ -316,7 +314,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
               submitForm={props.submitForm}
               allErrors={[...props.billingAddressErrors, ...props.deliveryAddressErrors, ...props.formErrors]}
               setStripePaymentMethod={props.setStripePaymentMethod}
-              stripeSetupIntentEndpoint={props.stripeSetupIntentEndpoint}
+              stripeSetupIntentEndpoint={routes.stripeSetupIntent}
               name={`${props.firstName} ${props.lastName}`}
               validateForm={props.validateForm}
               buttonText="Pay now"

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -72,7 +72,6 @@ import { type SetCountryAction } from 'helpers/page/commonActions';
 import { Stripe, DirectDebit } from 'helpers/paymentMethods';
 import { validateWithDeliveryForm } from 'helpers/subscriptionsForms/formValidation';
 import { StripeProviderForCountry } from 'components/subscriptionCheckouts/stripeForm/stripeProviderForCountry';
-import { getGlobal } from 'helpers/globals';
 import type { Csrf } from 'helpers/csrf/csrfReducer';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import { withDeliveryFormIsValid } from 'helpers/subscriptionsForms/formValidation';

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.jsx
@@ -101,8 +101,6 @@ type PropTypes = {|
   country: IsoCountry,
   isTestUser: boolean,
   validateForm: () => Function,
-  stripeSetupIntentEndpoint: string,
-  stripeSetupIntentEndpoint: string,
   csrf: Csrf,
   currencyId: IsoCurrency,
   payPalHasLoaded: boolean,
@@ -126,7 +124,6 @@ function mapStateToProps(state: WithDeliveryCheckoutState) {
     billingAddressErrors: state.page.billingAddress.fields.formErrors,
     isTestUser: state.page.checkout.isTestUser,
     country: state.common.internationalisation.countryId,
-    stripeSetupIntentEndpoint: getGlobal('stripeSetupIntentEndpoint'),
     csrf: state.page.csrf,
     currencyId: state.common.internationalisation.currencyId,
     payPalHasLoaded: state.page.checkout.payPalHasLoaded,
@@ -345,7 +342,7 @@ function WeeklyCheckoutFormGifting(props: PropTypes) {
               submitForm={props.submitForm}
               allErrors={[...props.billingAddressErrors, ...props.deliveryAddressErrors, ...props.formErrors]}
               setStripePaymentMethod={props.setStripePaymentMethod}
-              stripeSetupIntentEndpoint={props.stripeSetupIntentEndpoint}
+              stripeSetupIntentEndpoint={routes.stripeSetupIntent}
               name={`${props.firstName} ${props.lastName}`}
               validateForm={props.validateForm}
               buttonText="Pay now"

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.jsx
@@ -72,7 +72,6 @@ import { validateWithDeliveryForm } from 'helpers/subscriptionsForms/formValidat
 import { StripeProviderForCountry } from 'components/subscriptionCheckouts/stripeForm/stripeProviderForCountry';
 import Heading from 'components/heading/heading';
 import './weeklyCheckout.scss';
-import { getGlobal } from 'helpers/globals';
 import type { Csrf } from 'helpers/csrf/csrfReducer';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import { withDeliveryFormIsValid } from 'helpers/subscriptionsForms/formValidation';

--- a/support-frontend/conf/CODE.public.conf
+++ b/support-frontend/conf/CODE.public.conf
@@ -23,7 +23,3 @@ play.filters.headers.contentSecurityPolicy = "default-src 'self' https://contrib
 settingsSource {
   s3.bucket = "support-admin-console"
 }
-
-stripe.intent.url="https://stripe-intent-code.support.guardianapis.com/stripe-intent"
-
-

--- a/support-frontend/conf/DEV.public.conf
+++ b/support-frontend/conf/DEV.public.conf
@@ -31,5 +31,3 @@ settingsSource {
 
   contributionTypes.local.path="~/.gu/support-admin-console/contributionTypes.json"
 }
-
-stripe.intent.url="https://stripe-intent-code.support.guardianapis.com/stripe-intent"

--- a/support-frontend/conf/PROD.public.conf
+++ b/support-frontend/conf/PROD.public.conf
@@ -22,5 +22,3 @@ play.filters.headers.contentSecurityPolicy = "default-src 'self' https://contrib
 settingsSource {
   s3.bucket = "support-admin-console"
 }
-
-stripe.intent.url="https://stripe-intent.support.guardianapis.com/stripe-intent"

--- a/support-frontend/test/controllers/ApplicationTest.scala
+++ b/support-frontend/test/controllers/ApplicationTest.scala
@@ -51,7 +51,6 @@ class ApplicationTest extends AnyWordSpec with Matchers with TestCSRFComponents 
         mock[AllSettingsProvider],
         mock[GuardianDomain],
         mock[Stage],
-        "stripe.intent.url",
         "support.thegulocal.com",
         mock[Either[RefPath, StyleContent]],
       )(mock[ExecutionContext]).healthcheck.apply(FakeRequest())
@@ -75,7 +74,6 @@ class ApplicationTest extends AnyWordSpec with Matchers with TestCSRFComponents 
         mock[AllSettingsProvider],
         mock[GuardianDomain],
         mock[Stage],
-        "stripe.intent.url",
         "support.thegulocal.com",
         mock[Either[RefPath, StyleContent]]
       )(mock[ExecutionContext]).healthcheck.apply(FakeRequest())

--- a/support-frontend/test/controllers/SubscriptionsTest.scala
+++ b/support-frontend/test/controllers/SubscriptionsTest.scala
@@ -118,8 +118,7 @@ class SubscriptionsTest extends AnyWordSpec with Matchers with TestCSRFComponent
         stringsConfig = new StringsConfig(),
         settingsProvider = settingsProvider,
         supportUrl = "support.thegulocal.com",
-        fontLoaderBundle = Left(RefPath("test")),
-        stripeSetupIntentEndpoint = appConf.getString("stripe.intent.url")
+        fontLoaderBundle = Left(RefPath("test"))
       )
     }
 


### PR DESCRIPTION
A follow up to [this PR](https://github.com/guardian/support-frontend/pull/2439) which changed the endpoint for creating Setup Intents.
Removes unused config, does not pass the path through from the controller, and shares the same value as the Contributions form (`routes.stripeSetupIntent`)