### PR TITLE
Remove UK amounts test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -1,6 +1,6 @@
 // @flow
 import type { Tests } from './abtest';
-import { USV1, UKV1Lower, UKV2Higher } from './data/testAmountsData';
+import { USV1 } from './data/testAmountsData';
 
 // ----- Tests ----- //
 export type StripePaymentRequestButtonScaTestVariants = 'control' | 'sca' | 'notintest';
@@ -9,7 +9,6 @@ export type ChoiceCardsProductSetTestR3Variants = 'control' | 'yellow';
 
 const contributionsLandingPageMatch = '/(uk|us|eu|au|ca|nz|int)/contribute(/.*)?$';
 const usOnlyLandingPage = '/us/contribute(/.*)?$';
-const ukOnlyLandingPage = '/uk/contribute(/.*)?$';
 
 export const tests: Tests = {
   usAmountsTest: {
@@ -55,33 +54,6 @@ export const tests: Tests = {
     referrerControlled: false,
     seed: 2,
     targetPage: contributionsLandingPageMatch,
-  },
-
-  ukAmountsTest: {
-    type: 'AMOUNTS',
-    variants: [
-      {
-        id: 'control',
-      },
-      {
-        id: 'lower',
-        amountsRegions: UKV1Lower,
-      },
-      {
-        id: 'higher',
-        amountsRegions: UKV2Higher,
-      },
-    ],
-    audiences: {
-      ALL: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: true,
-    referrerControlled: false,
-    targetPage: ukOnlyLandingPage,
-    seed: 3,
   },
 
 };

--- a/support-frontend/assets/helpers/abTests/data/testAmountsData.js
+++ b/support-frontend/assets/helpers/abTests/data/testAmountsData.js
@@ -5,18 +5,3 @@ export const USV1 = {
     MONTHLY: [{ value: '5' }, { value: '10', isDefault: true }, { value: '20' }],
   },
 };
-
-export const UKV1Lower = {
-  GBPCountries: {
-    ONE_OFF: [{ value: '10' }, { value: '25', isDefault: true }, { value: '50' }, { value: '100' }],
-    ANNUAL: [{ value: '40', isDefault: true }, { value: '80' }, { value: '120' }, { value: '240' }],
-  },
-};
-
-export const UKV2Higher = {
-  GBPCountries: {
-    ONE_OFF: [{ value: '30' }, { value: '60', isDefault: true }, { value: '120' }, { value: '240' }],
-    MONTHLY: [{ value: '3' }, { value: '7', isDefault: true }, { value: '12' }],
-    ANNUAL: [{ value: '60' }, { value: '120', isDefault: true }, { value: '240' }, { value: '480' }],
-  },
-};


### PR DESCRIPTION
## Why are you doing this?

We are removing the UK amounts test and will replace the default amount with the winning variant (higher amounts).

[**Trello Card**](https://trello.com/c/AEACCigx/1974-uk-default-amounts-test-make-the-higher-variant-the-default-and-remove-test)

## Changes

* Remove ukAmountsTest
