### PR TITLE
Fix broken error message in postcode lookup

### DIFF
--- a/support-frontend/assets/components/forms/customFields/error.jsx
+++ b/support-frontend/assets/components/forms/customFields/error.jsx
@@ -32,7 +32,13 @@ function Error({ error, htmlFor, children }: Props) {
         htmlFor={htmlFor}
         className="component-form-error__error"
       >
-        {error}
+        {(error === 'Temporary COVID message') && (
+          <li className="component-form-error__summary-error">
+            The address and postcode you entered is outside of our delivery area. You may want to
+            consider purchasing a <a href="/uk/subscribe/paper">voucher subscription</a>
+          </li>)
+        }
+        {(error !== 'Temporary COVID message') && error}
       </Element>
     </div>
   );


### PR DESCRIPTION
## Why are you doing this?
This is a fix for an error introduced by a previous PR: https://github.com/guardian/support-frontend/pull/2434

[**Trello Card**](https://trello.com/c/u9mWQrXG/2967-postcode-lookup-error-message-broken-arising-from-the-change-to-the-message-for-the-error-summary)

## Problem
![image (2)](https://user-images.githubusercontent.com/16781258/78675827-83a5ad00-78dd-11ea-91b6-b4657c8758ec.png)

## Fix
![Screen Shot 2020-04-07 at 14 45 17](https://user-images.githubusercontent.com/16781258/78676519-73420200-78de-11ea-98d7-d43ed20d79aa.png)

