### PR TITLE
Add t&cs to print page

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/helpers.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/helpers.jsx
@@ -74,16 +74,24 @@ const ContentHelpBlock = ({
 
   const contactUs = useDotcomContactPage() ? <ContactPageLink linkText="contact us" /> :
   <span>call our customer services team on {telephoneLink}</span>;
-
-  return (
-    <Content appearance="feature" modifierClasses={['faqs']}>
-      {flashSaleIsActive('Paper', GBPCountries) &&
+  const tAndCs = flashSaleIsActive('Paper', GBPCountries) ?
+    (
       <Text title="Promotion terms and conditions">
         <SansParagraph>
           Offer subject to availability. Guardian News and Media Limited (&ldquo;GNM&rdquo;) reserves the right to withdraw this promotion at any time. For full promotion terms and conditions, see <a target="_blank" rel="noopener noreferrer" href={promoTermsUrl}>here</a>.
         </SansParagraph>
       </Text>
-      }
+    ) :
+    (
+      <Text title="Terms and conditions">
+        <SansParagraph>
+          For full Guardian and Observer voucher and home delivery terms and conditions, see <a target="_blank" rel="noopener noreferrer" href="https://www.theguardian.com/subscriber-direct/subscription-terms-and-conditions">here</a>.
+        </SansParagraph>
+      </Text>
+    );
+  return (
+    <Content appearance="feature" modifierClasses={['faqs']}>
+      {tAndCs}
       <Text title="FAQ and help">
         <SansParagraph>
           If you’ve got any more questions, you might well find the answers in


### PR DESCRIPTION
## Why are you doing this?
The paper product page has been missing a terms and conditions section since the last flash sale finished, this PR adds it back in.


[**Trello Card**](https://trello.com/c/Bcmb1GRU/2908-tc-missing-from-print-landing-page-footer)

## Screenshots

<img width="717" alt="Screen Shot 2020-04-07 at 15 40 49" src="https://user-images.githubusercontent.com/181371/78684771-c8831100-78e8-11ea-8275-d52cd1bbf99b.png">
