### PR TITLE
Adding a CloudWatch metric to track the number of requests to the setup intent endpoints

### DIFF
--- a/support-frontend/app/controllers/StripeController.scala
+++ b/support-frontend/app/controllers/StripeController.scala
@@ -51,19 +51,20 @@ class StripeController(
         response <- if (recaptchaResponse.success) {
           stripeService(request.body.stripePublicKey).map(response => Ok(response.asJson))
         } else {
-          logger.info(s"Returning status Forbidden for Stripe Intent request because Recaptcha verification failed")
+          logger.warn(s"Returning status Forbidden for Create Stripe Intent Recaptcha request because Recaptcha verification failed")
           EitherT.rightT[Future, String](Forbidden(""))
         }
       } yield response
 
       result.fold(
         error => {
-          logger.error(error)
+          logger.error(s"Returning status InternalServerError for Create Stripe Intent Recaptcha request because: $error")
           InternalServerError("")
         },
         identity
       )
     } else {
+      logger.warn(s"Returning status BadRequest for Create Stripe Intent Recaptcha request because user provided no one-time-token value")
       Future.successful(BadRequest("reCAPTCHA one-time-token required"))
     }
   }
@@ -75,7 +76,7 @@ class StripeController(
 
     stripeService(request.body.stripePublicKey).fold(
       error => {
-        logger.error(error)
+        logger.error(s"Returning status InternalServerError for Create Stripe Intent request because: $error")
         InternalServerError("")
       },
       response => Ok(response.asJson)

--- a/support-frontend/app/wiring/Controllers.scala
+++ b/support-frontend/app/wiring/Controllers.scala
@@ -122,7 +122,8 @@ trait Controllers {
     actionRefiners = actionRefiners,
     recaptchaService = recaptchaService,
     stripeService = stripeService,
-    v2RecaptchaKey = appConfig.recaptchaConfigProvider.v2SecretKey
+    v2RecaptchaKey = appConfig.recaptchaConfigProvider.v2SecretKey,
+    appConfig.stage
   )
 
   lazy val regularContributionsController = new RegularContributions(

--- a/support-services/src/main/scala/com/gu/aws/AwsCloudWatchMetricPut.scala
+++ b/support-services/src/main/scala/com/gu/aws/AwsCloudWatchMetricPut.scala
@@ -73,7 +73,16 @@ object AwsCloudWatchMetricPut {
       )
     )
 
-  def getMetricRequest(name: MetricName, dimensions: Map[MetricDimensionName, MetricDimensionValue]) : MetricRequest =
+  def createSetupIntentRequest(stage: Stage, mode: String): MetricRequest =
+    getMetricRequest(
+      MetricName("CreateSetupIntent"),
+      Map(
+        MetricDimensionName("Mode") -> MetricDimensionValue(mode),
+        MetricDimensionName("Stage") -> MetricDimensionValue(stage.toString)
+      )
+    )
+
+  private def getMetricRequest(name: MetricName, dimensions: Map[MetricDimensionName, MetricDimensionValue]) : MetricRequest =
     MetricRequest(
       MetricNamespace(s"support-frontend"),
       name,


### PR DESCRIPTION
Adding a CloudWatch metric to track the number of requests to the setup intent endpoints. Also added a tiny bit of validation to the recaptcha version to ensure the client actually passes a token value.

## Why are you doing this?
So we can see the volume of traffic using these endpoints.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/1nR0l7gx)

## Accessibility test checklist - NA
## Screenshots - NA
## Testing
- [x] CODE
![Screen Shot 2020-04-08 at 11 37 58](https://user-images.githubusercontent.com/1515970/78775001-70eab100-798d-11ea-83c2-c4dc5fce7b15.png)
