### PR TITLE
Moving subscriptions to a new stripe intent endpoint behind auth

### DIFF
--- a/support-frontend/app/controllers/StripeController.scala
+++ b/support-frontend/app/controllers/StripeController.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import actions.CustomActionBuilders
+import actions.CustomActionBuilders.AuthRequest
 import com.typesafe.scalalogging.StrictLogging
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
@@ -68,13 +69,14 @@ class StripeController(
   }
 
   def createSetupIntentWithAuth: Action[SetupIntentRequest] =
-    authenticatedAction(subscriptionsClientId).async(circe.json[SetupIntentRequest]) { implicit request =>
-    stripeService(request.body.stripePublicKey).fold(
-      error => {
-        logger.error(error)
-        InternalServerError("")
-      },
-      response => Ok(response.asJson)
-    )
-  }
+    authenticatedAction(subscriptionsClientId).async(circe.json[SetupIntentRequest]) {
+      implicit request: AuthRequest[SetupIntentRequest] =>
+        stripeService(request.body.stripePublicKey).fold(
+          error => {
+            logger.error(error)
+            InternalServerError("")
+          },
+          response => Ok(response.asJson)
+        )
+    }
 }

--- a/support-frontend/app/controllers/StripeController.scala
+++ b/support-frontend/app/controllers/StripeController.scala
@@ -66,4 +66,15 @@ class StripeController(
       response => Ok(response.asJson)
     )
   }
+
+  def createSetupIntentWithAuth: Action[SetupIntentRequest] =
+    authenticatedAction(subscriptionsClientId).async(circe.json[SetupIntentRequest]) { implicit request =>
+    stripeService(request.body.stripePublicKey).fold(
+      error => {
+        logger.error(error)
+        InternalServerError("")
+      },
+      response => Ok(response.asJson)
+    )
+  }
 }

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -113,7 +113,7 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
     // is handled in the callback below by checking the value of paymentWaiting.
     fetchJson(
       this.props.stripeSetupIntentEndpoint,
-      requestOptions({ stripePublicKey: this.props.stripeKey }, 'omit', 'POST', this.props.csrf),
+      requestOptions({ stripePublicKey: this.props.stripeKey },  'same-origin','POST', this.props.csrf),
     ).then((result) => {
       if (result.client_secret) {
         this.setState({ setupIntentClientSecret: result.client_secret });

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeProviderForCountry.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeProviderForCountry.jsx
@@ -6,7 +6,7 @@ import StripeForm from 'components/subscriptionCheckouts/stripeForm/stripeForm';
 import { type StripeFormPropTypes } from 'components/subscriptionCheckouts/stripeForm/stripeForm';
 import { getStripeKey } from 'helpers/paymentIntegrations/stripeCheckout';
 import type { IsoCountry } from 'helpers/internationalisation/country';
-import {routes} from "helpers/routes";
+import { routes } from 'helpers/routes';
 
 // Types
 
@@ -27,7 +27,7 @@ function StripeProviderForCountry(props: PropTypes) {
           allErrors={props.allErrors}
           stripeKey={stripeKey}
           setStripePaymentMethod={props.setStripePaymentMethod}
-          stripeSetupIntentEndpoint={routes.stripeSetupIntent}
+          stripeSetupIntentEndpoint={routes.stripeSetupIntentWithAuth}
           validateForm={props.validateForm}
           buttonText={props.buttonText}
           csrf={props.csrf}

--- a/support-frontend/assets/helpers/routes.js
+++ b/support-frontend/assets/helpers/routes.js
@@ -39,6 +39,7 @@ const routes: {
   postcodeLookup: '/postcode-lookup',
   createSignInUrl: '/identity/signin-url',
   stripeSetupIntent: '/stripe/create-setup-intent',
+  stripeSetupIntentWithAuth: '/stripe/create-setup-intent/auth',
 };
 
 const createReminderEndpoint = isProd() ?

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
@@ -232,7 +232,7 @@ function DigitalCheckoutForm(props: PropTypes) {
               submitForm={props.submitForm}
               allErrors={[...props.addressErrors]}
               setStripePaymentMethod={props.setStripePaymentMethod}
-              stripeSetupIntentEndpoint={routes.stripeSetupIntent}
+              stripeSetupIntentEndpoint={routes.stripeSetupIntentWithAuth}
               name={`${props.firstName} ${props.lastName}`}
               validateForm={props.validateForm}
               buttonText="Start your free trial now"

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
@@ -320,7 +320,7 @@ function PaperCheckoutForm(props: PropTypes) {
               submitForm={props.submitForm}
               allErrors={[...props.billingAddressErrors, ...props.deliveryAddressErrors, ...props.formErrors]}
               setStripePaymentMethod={props.setStripePaymentMethod}
-              stripeSetupIntentEndpoint={routes.stripeSetupIntent}
+              stripeSetupIntentEndpoint={routes.stripeSetupIntentWithAuth}
               name={`${props.firstName} ${props.lastName}`}
               validateForm={props.validateForm}
               buttonText="Pay now"

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -313,7 +313,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
               submitForm={props.submitForm}
               allErrors={[...props.billingAddressErrors, ...props.deliveryAddressErrors, ...props.formErrors]}
               setStripePaymentMethod={props.setStripePaymentMethod}
-              stripeSetupIntentEndpoint={routes.stripeSetupIntent}
+              stripeSetupIntentEndpoint={routes.stripeSetupIntentWithAuth}
               name={`${props.firstName} ${props.lastName}`}
               validateForm={props.validateForm}
               buttonText="Pay now"

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.jsx
@@ -341,7 +341,7 @@ function WeeklyCheckoutFormGifting(props: PropTypes) {
               submitForm={props.submitForm}
               allErrors={[...props.billingAddressErrors, ...props.deliveryAddressErrors, ...props.formErrors]}
               setStripePaymentMethod={props.setStripePaymentMethod}
-              stripeSetupIntentEndpoint={routes.stripeSetupIntent}
+              stripeSetupIntentEndpoint={routes.stripeSetupIntentWithAuth}
               name={`${props.firstName} ${props.lastName}`}
               validateForm={props.validateForm}
               buttonText="Pay now"

--- a/support-frontend/conf/routes
+++ b/support-frontend/conf/routes
@@ -64,6 +64,7 @@ GET  /support-workers/status                                       controllers.S
 
 
 POST  /stripe/create-setup-intent/recaptcha                        controllers.StripeController.createSetupIntentRecaptcha()
+POST  /stripe/create-setup-intent/auth                             controllers.StripeController.createSetupIntentWithAuth()
 POST  /stripe/create-setup-intent                                  controllers.StripeController.createSetupIntent()
 
 # this endpoint should be removed once identity remove


### PR DESCRIPTION
## Why are you doing this?

We are putting the setup intent creation behind auth on subs to protect the endpoint from being exploited.

[**Trello Card**](https://trello.com/c/bpGeqnyZ/1970-improve-security-of-stripe-setup-intent-creation-follow-up)


