### PR TITLE
Add patron info after T&Cs

### DIFF
--- a/support-frontend/assets/components/legal/termsPrivacy/termsPrivacy.jsx
+++ b/support-frontend/assets/components/legal/termsPrivacy/termsPrivacy.jsx
@@ -25,33 +25,22 @@ type PropTypes = {|
 function TermsPrivacy(props: PropTypes) {
   const terms = <a href={contributionsTermsLinks[props.countryGroupId]}>Terms and Conditions</a>;
   const privacy = <a href={privacyLink}>Privacy Policy</a>;
-
-  const getRegionalAmount = (countryGroupId: CountryGroupId): number => {
-    const isoCurrency: IsoCurrency = fromCountryGroupId(countryGroupId);
-    switch (isoCurrency) {
-      case 'GBP':
-        return 100;
-      case 'USD':
-        return 135;
-      case 'EUR':
-        return 117;
-      case 'AUD':
-        return 185;
-      case 'CAD':
-        return 167;
-      case 'NZD':
-        return 200;
-      default:
-        return 100;
-    }
-  };
-  const regionalAmount = `${currencies[fromCountryGroupId(props.countryGroupId)].glyph}${getRegionalAmount(props.countryGroupId)}`;
+  const regionalAmounts = {
+    'GBP': 100,
+    'USD': 135,
+    'EUR': 117,
+    'AUD': 185,
+    'CAD': 167,
+    'NZD': 200
+  }
+  const getRegionalAmount = (countryGroupId: CountryGroupId): number => regionalAmounts[fromCountryGroupId(countryGroupId)];
+  const regionalAmountString = `${currencies[fromCountryGroupId(props.countryGroupId)].glyph}${getRegionalAmount(props.countryGroupId)}`;
   const patronsLink = <a href="https://patrons.theguardian.com/join">Find out more today</a>;
   const patronText = (
     <div className="patrons">
       <h4>Guardian Patrons programme</h4>
       <p>
-        If you would like to support us at a higher level, from {regionalAmount} a month,
+        If you would like to support us at a higher level, from {regionalAmountString} a month,
         you can join us as a Guardian Patron. {patronsLink}
       </p>
     </div>

--- a/support-frontend/assets/components/legal/termsPrivacy/termsPrivacy.jsx
+++ b/support-frontend/assets/components/legal/termsPrivacy/termsPrivacy.jsx
@@ -26,12 +26,12 @@ function TermsPrivacy(props: PropTypes) {
   const terms = <a href={contributionsTermsLinks[props.countryGroupId]}>Terms and Conditions</a>;
   const privacy = <a href={privacyLink}>Privacy Policy</a>;
   const regionalAmounts = {
-    'GBP': 100,
-    'USD': 135,
-    'EUR': 117,
-    'AUD': 185,
-    'CAD': 167,
-    'NZD': 200
+    GBP: 100,
+    USD: 135,
+    EUR: 117,
+    AUD: 185,
+    CAD: 167,
+    NZD: 200,
   }
   const getRegionalAmount = (countryGroupId: CountryGroupId): number => regionalAmounts[fromCountryGroupId(countryGroupId)];
   const regionalAmountString = `${currencies[fromCountryGroupId(props.countryGroupId)].glyph}${getRegionalAmount(props.countryGroupId)}`;

--- a/support-frontend/assets/components/legal/termsPrivacy/termsPrivacy.jsx
+++ b/support-frontend/assets/components/legal/termsPrivacy/termsPrivacy.jsx
@@ -34,10 +34,7 @@ function TermsPrivacy(props: PropTypes) {
     NZD: 200,
   };
   const getRegionalAmountString = (): string => {
-    let currency: ?IsoCurrency = fromCountryGroupId(props.countryGroupId);
-    if (!currency) {
-      currency = 'GBP';
-    }
+    const currency: IsoCurrency = fromCountryGroupId(props.countryGroupId) || 'GBP';
     return `${currencies[currency].glyph}${regionalAmounts[currency]}`;
   };
   const patronsLink = <a href="https://patrons.theguardian.com/join">Find out more today</a>;

--- a/support-frontend/assets/components/legal/termsPrivacy/termsPrivacy.jsx
+++ b/support-frontend/assets/components/legal/termsPrivacy/termsPrivacy.jsx
@@ -32,20 +32,24 @@ function TermsPrivacy(props: PropTypes) {
     AUD: 185,
     CAD: 167,
     NZD: 200,
-  }
-  const getRegionalAmount = (countryGroupId: CountryGroupId): number => regionalAmounts[fromCountryGroupId(countryGroupId)];
-  const regionalAmountString = `${currencies[fromCountryGroupId(props.countryGroupId)].glyph}${getRegionalAmount(props.countryGroupId)}`;
+  };
+  const getRegionalAmountString = (): string => {
+    let currency: ?IsoCurrency = fromCountryGroupId(props.countryGroupId);
+    if (!currency) {
+      currency = 'GBP';
+    }
+    return `${currencies[currency].glyph}${regionalAmounts[currency]}`;
+  };
   const patronsLink = <a href="https://patrons.theguardian.com/join">Find out more today</a>;
   const patronText = (
     <div className="patrons">
       <h4>Guardian Patrons programme</h4>
       <p>
-        If you would like to support us at a higher level, from {regionalAmountString} a month,
+        If you would like to support us at a higher level, from {getRegionalAmountString()} a month,
         you can join us as a Guardian Patron. {patronsLink}
       </p>
     </div>
   );
-
 
   if (props.campaignName && campaigns[props.campaignName] && campaigns[props.campaignName].termsAndConditions) {
     return campaigns[props.campaignName].termsAndConditions(

--- a/support-frontend/assets/components/legal/termsPrivacy/termsPrivacy.jsx
+++ b/support-frontend/assets/components/legal/termsPrivacy/termsPrivacy.jsx
@@ -6,9 +6,11 @@ import React from 'react';
 
 import { privacyLink, contributionsTermsLinks, philanthropyContactEmail } from 'helpers/legal';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
-
+import { type IsoCurrency, fromCountryGroupId, currencies } from 'helpers/internationalisation/currency';
 import type { ContributionType } from 'helpers/contributions';
 import { type CampaignName, campaigns } from 'helpers/campaigns';
+import './termsPrivacy.scss';
+
 
 // ---- Types ----- //
 
@@ -18,12 +20,43 @@ type PropTypes = {|
   campaignName: ?CampaignName,
 |};
 
-
 // ----- Component ----- //
 
 function TermsPrivacy(props: PropTypes) {
   const terms = <a href={contributionsTermsLinks[props.countryGroupId]}>Terms and Conditions</a>;
   const privacy = <a href={privacyLink}>Privacy Policy</a>;
+
+  const getRegionalAmount = (countryGroupId: CountryGroupId): number => {
+    const isoCurrency: IsoCurrency = fromCountryGroupId(countryGroupId);
+    switch (isoCurrency) {
+      case 'GBP':
+        return 100;
+      case 'USD':
+        return 135;
+      case 'EUR':
+        return 117;
+      case 'AUD':
+        return 185;
+      case 'CAD':
+        return 167;
+      case 'NZD':
+        return 200;
+      default:
+        return 100;
+    }
+  };
+  const regionalAmount = `${currencies[fromCountryGroupId(props.countryGroupId)].glyph}${getRegionalAmount(props.countryGroupId)}`;
+  const patronsLink = <a href="https://patrons.theguardian.com/join">Find out more today</a>;
+  const patronText = (
+    <div className="patrons">
+      <h4>Guardian Patrons programme</h4>
+      <p>
+        If you would like to support us at a higher level, from {regionalAmount} a month,
+        you can join us as a Guardian Patron. {patronsLink}
+      </p>
+    </div>
+  );
+
 
   if (props.campaignName && campaigns[props.campaignName] && campaigns[props.campaignName].termsAndConditions) {
     return campaigns[props.campaignName].termsAndConditions(
@@ -33,19 +66,22 @@ function TermsPrivacy(props: PropTypes) {
   }
 
   return (
-    <div className="component-terms-privacy">
-      {props.contributionType !== 'ONE_OFF' ?
-        <div className="component-terms-privacy__change">
-          Monthly contributions are billed each month and annual contributions are billed once a year.
-          You can change how much you give or cancel your contributions at any time.
+    <>
+      <div className="component-terms-privacy">
+        {props.contributionType !== 'ONE_OFF' ?
+          <div className="component-terms-privacy__change">
+            Monthly contributions are billed each month and annual contributions are billed once a year.
+            You can change how much you give or cancel your contributions at any time.
+          </div>
+          : null
+        }
+        <div className="component-terms-privacy__terms">
+          By proceeding, you are agreeing to our {terms}. To find out what personal data we collect and how we use it,
+          please visit our {privacy}.
         </div>
-        : null
-      }
-      <div className="component-terms-privacy__terms">
-        By proceeding, you are agreeing to our {terms}. To find out what personal data we collect and how we use it,
-        please visit our {privacy}.
       </div>
-    </div>
+      <div>{props.contributionType !== 'ONE_OFF' && patronText}</div>
+    </>
   );
 }
 

--- a/support-frontend/assets/components/legal/termsPrivacy/termsPrivacy.scss
+++ b/support-frontend/assets/components/legal/termsPrivacy/termsPrivacy.scss
@@ -1,5 +1,33 @@
+// -----  gu-sass ----- //
+@import '~stylesheets/gu-sass/gu-sass';
+
+
 .component-terms-privacy {
 	font-size: 14px;
+
+  a {
+    color: inherit;
+  }
+}
+
+.patrons {
+
+  margin-top: $gu-v-spacing;
+  margin-bottom: $gu-v-spacing;
+
+  h4 {
+    font-family: $gu-headline;
+    font-size: 16px;
+    font-weight: bold;
+    line-height: 20px;
+  }
+
+  p {
+    margin-top: $gu-v-spacing * 0.5;
+    font-family: $gu-text-sans-web;
+    font-size: 14px;
+    line-height: 17px;
+  }
 
   a {
     color: inherit;

--- a/support-frontend/assets/components/legal/termsPrivacy/termsPrivacy.scss
+++ b/support-frontend/assets/components/legal/termsPrivacy/termsPrivacy.scss
@@ -12,8 +12,8 @@
 
 .patrons {
 
-  margin-top: $gu-v-spacing;
-  margin-bottom: $gu-v-spacing;
+  margin-top: $gu-v-spacing * 0.5;
+  margin-bottom: $gu-v-spacing * 2;
 
   h4 {
     font-family: $gu-headline;


### PR DESCRIPTION
## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/FGxNlXZd/1967-add-patrons-to-the-tcs-on-recurring-only)

## Changes

* Add patron info to T&Cs on recurring

## Screenshots

### Before
<img width="598" alt="image" src="https://user-images.githubusercontent.com/15648334/78890514-b4145500-7a5d-11ea-8352-848ee9cc6f73.png">

### After (full page)
![image](https://user-images.githubusercontent.com/15648334/78900262-808df680-7a6e-11ea-963f-7ac58f8ed89f.png)

### UK
<img width="571" alt="image" src="https://user-images.githubusercontent.com/15648334/78890554-c42c3480-7a5d-11ea-8299-d46b736157e4.png">

### US
<img width="537" alt="image" src="https://user-images.githubusercontent.com/15648334/78890594-d4441400-7a5d-11ea-85e8-ddc03e2c8478.png">

###  AU
<img width="605" alt="image" src="https://user-images.githubusercontent.com/15648334/78890635-e920a780-7a5d-11ea-87b9-b1c3097b742f.png">

### EU
<img width="620" alt="image" src="https://user-images.githubusercontent.com/15648334/78890669-f76ec380-7a5d-11ea-84ec-cec294dfd92e.png">

### INT
<img width="577" alt="image" src="https://user-images.githubusercontent.com/15648334/78890691-02295880-7a5e-11ea-8be1-4e465156fb54.png">

### NZ
<img width="588" alt="image" src="https://user-images.githubusercontent.com/15648334/78890722-11100b00-7a5e-11ea-9e2e-27696308582e.png">

### CA
<img width="599" alt="image" src="https://user-images.githubusercontent.com/15648334/78890759-1cfbcd00-7a5e-11ea-9924-c3c3e5948495.png">

