### PR TITLE
Reduce period of no digipack alarm from 12 to 3h

### DIFF
--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -288,13 +288,13 @@ Resources:
   #     cloudwatch handles that is to create a new metric for every value dimension value
 
 
-  NoDigipackAcquisitionInTwelveHoursAlarm:
+  NoDigipackAcquisitionInThreeHoursAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: CreateProdResources
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
-      AlarmName: !Sub URGENT 9-5 - ${Stage} support-workers No successful digipack checkouts in 12h
+      AlarmName: !Sub URGENT 9-5 - ${Stage} support-workers No successful digipack checkouts in 3h
       Metrics:
         - Id: e1
           Expression: "SUM([FILL(m1,0),FILL(m2,0),FILL(m3,0)])"
@@ -352,7 +352,7 @@ Resources:
           ReturnData: false
       ComparisonOperator: LessThanOrEqualToThreshold
       Threshold: 0
-      EvaluationPeriods: 144
+      EvaluationPeriods: 36
       TreatMissingData: breaching
     DependsOn: SupportWorkersPROD
 


### PR DESCRIPTION
## Why are you doing this?

**Current situation**: An alarm shoots if there are no new digipack subscriptions in the last 12h.

**Potential problem**: An error in the morning would fire an alarm only in the evening.

**Why is the change possible**: New traffic pattern seems to suggest it is reasonable to expect new digipack subscriptions in a shorter period of time (see screenshot below for data of last week, one data point per hour).

**Proposed change**: Reduce evaluation period of alarm to 3h.

**Expected benefit**: An error in the morning can be caught within the same day.

## Screenshots

![image](https://user-images.githubusercontent.com/6162929/79246685-6dfe2d80-7e71-11ea-95a0-11c7842c6339.png)

## Links

[Link to AWS metric used for screenshot
](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#metricsV2:graph=~(metrics~(~(~(id~'e1~expression~'SUM*28*5bFILL*28m1*2c0*29*2cFILL*28m2*2c0*29*2cFILL*28m3*2c0*29*5d*29~label~'AllDigiPackConversions~region~'eu-west-1~period~3600))~(~'support-frontend~'PaymentSuccess~'Stage~'PROD~'PaymentProvider~'Stripe~'ProductType~'DigitalPack~(id~'m1~label~'String~visible~false~unit~'Count))~(~'...~'Gocardless~'.~'.~(id~'m2~label~'String~visible~false~unit~'Count))~(~'...~'Paypal~'.~'.~(id~'m3~label~'String~visible~false~unit~'Count)))~region~'eu-west-1~view~'timeSeries~stacked~false~start~'-P7D~end~'P0D~period~3600~annotations~(horizontal~(~(label~'AllDigiPackConversions*20*3c*3d*200*20for*20144*20datapoints*20within*2012*20hours~value~0)))~title~'URGENT*209-5*20-*20PROD*20support-workers*20No*20successful*20digipack*20checkouts*20in*2012h~stat~'Sum))
[Link to AWS alarm](https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#alarmsV2:alarm/URGENT+9-5+-+PROD+support-workers+No+successful+digipack+checkouts+in+12h?~(search~'support-workers*20No*20successful*20digipack*20checkouts*20in*2012h))


