### PR TITLE
Fix Apple Pay for single contributions

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -318,6 +318,14 @@ const sendFormSubmitEventForPayPalRecurring = () =>
     onFormSubmit(formSubmitParameters);
   };
 
+const stripeOneOffRecaptchaToken = (stripePaymentMethod: StripePaymentMethod, state: State): string => {
+  if (state.page.user.isPostDeploymentTestUser) {
+    return 'post-deploy-token';
+  }
+
+  return state.page.form.oneOffRecaptchaToken || '';
+};
+
 const buildStripeChargeDataFromAuthorisation = (
   stripePaymentMethod: StripePaymentMethod,
   token: string,
@@ -343,7 +351,7 @@ const buildStripeChargeDataFromAuthorisation = (
     state.common.internationalisation.countryId,
     state.page.user.isTestUser || false,
   ),
-  recaptchaToken: state.page.user.isPostDeploymentTestUser ? 'post-deploy-token' : state.page.form.oneOffRecaptchaToken,
+  recaptchaToken: stripeOneOffRecaptchaToken(stripePaymentMethod, state),
 });
 
 const stripeChargeDataFromCheckoutAuthorisation = (

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -318,7 +318,7 @@ const sendFormSubmitEventForPayPalRecurring = () =>
     onFormSubmit(formSubmitParameters);
   };
 
-const stripeOneOffRecaptchaToken = (stripePaymentMethod: StripePaymentMethod, state: State): string => {
+const stripeOneOffRecaptchaToken = (state: State): string => {
   if (state.page.user.isPostDeploymentTestUser) {
     return 'post-deploy-token';
   }

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -323,6 +323,7 @@ const stripeOneOffRecaptchaToken = (stripePaymentMethod: StripePaymentMethod, st
     return 'post-deploy-token';
   }
 
+  // see https://github.com/guardian/payment-api/pull/195
   return state.page.form.oneOffRecaptchaToken || '';
 };
 

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -352,7 +352,7 @@ const buildStripeChargeDataFromAuthorisation = (
     state.common.internationalisation.countryId,
     state.page.user.isTestUser || false,
   ),
-  recaptchaToken: stripeOneOffRecaptchaToken(stripePaymentMethod, state),
+  recaptchaToken: stripeOneOffRecaptchaToken(state),
 });
 
 const stripeChargeDataFromCheckoutAuthorisation = (


### PR DESCRIPTION
We have some special handling for Apple Pay one-off contributions so no token required, see https://github.com/guardian/payment-api/pull/195