### PR TITLE
Update scala-uri dependency

### DIFF
--- a/support-frontend/app/actions/CustomActionBuilders.scala
+++ b/support-frontend/app/actions/CustomActionBuilders.scala
@@ -1,6 +1,6 @@
 package actions
 
-import com.netaporter.uri.dsl._
+import io.lemonlabs.uri.typesafe.dsl._
 import config.Configuration.IdentityUrl
 import play.api.mvc.Results._
 import play.api.mvc.Security.AuthenticatedRequest
@@ -39,11 +39,11 @@ class CustomActionBuilders(
   private val idSkipValidationReturn: (String, String) = "skipValidationReturn" -> "true"
 
   private def idWebAppRegisterUrl(path: String, clientId: String, idWebAppRegisterPath: String): String =
-    idWebAppUrl.value / idWebAppRegisterPath ?
+    (idWebAppUrl.value / idWebAppRegisterPath ?
       ("returnUrl" -> s"$supportUrl$path") &
       idSkipConfirmation &
       idSkipValidationReturn &
-      "clientId" -> clientId
+      "clientId" -> clientId).toString
 
   def onUnauthenticated(identityClientId: String): RequestHeader => Result = request => {
     SeeOther(idWebAppRegisterUrl(request.uri, identityClientId, "signin"))

--- a/support-frontend/app/actions/CustomActionBuilders.scala
+++ b/support-frontend/app/actions/CustomActionBuilders.scala
@@ -38,15 +38,15 @@ class CustomActionBuilders(
   // Prevents the identity validation email sending users back to our checkout.
   private val idSkipValidationReturn: (String, String) = "skipValidationReturn" -> "true"
 
-  private def idWebAppRegisterUrl(path: String, clientId: String, idWebAppRegisterPath: String): String =
-    (idWebAppUrl.value / idWebAppRegisterPath ?
+  private def idWebAppRegisterUrl(path: String, clientId: String): String =
+    (idWebAppUrl.value / "signin" ?
       ("returnUrl" -> s"$supportUrl$path") &
       idSkipConfirmation &
       idSkipValidationReturn &
       "clientId" -> clientId).toString
 
   def onUnauthenticated(identityClientId: String): RequestHeader => Result = request => {
-    SeeOther(idWebAppRegisterUrl(request.uri, identityClientId, "signin"))
+    SeeOther(idWebAppRegisterUrl(request.uri, identityClientId))
   }
 
   private def maybeAuthenticated(onUnauthenticated: RequestHeader => Result): ActionBuilder[OptionalAuthRequest, AnyContent] =

--- a/support-frontend/app/services/PayPalNvpService.scala
+++ b/support-frontend/app/services/PayPalNvpService.scala
@@ -41,7 +41,7 @@ class PayPalNvpService(apiConfig: PayPalConfig, wsClient: WSClient) extends Touc
     val responseBody = response.body
     val parsedResponse = parseQuery(responseBody)
 
-    parsedResponse.map(logNVPResponse)
+    parsedResponse.foreach(logNVPResponse)
     parsedResponse
   }
 

--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -32,7 +32,7 @@ libraryDependencies ++= Seq(
   "com.gu.identity" %% "identity-auth-play" % "3.195",
   "com.gu" %% "identity-test-users" % "0.6",
   "com.google.guava" % "guava" % "25.0-jre",
-  "com.netaporter" %% "scala-uri" % "0.4.16",
+  "io.lemonlabs" %% "scala-uri" % "2.2.0",
   "com.gu" %% "play-googleauth" % "0.7.6",
   "io.github.bonigarcia" % "webdrivermanager" % "3.3.0" % "test",
   "org.seleniumhq.selenium" % "selenium-java" % "3.8.1" % "test",


### PR DESCRIPTION
Snyk is reporting a vulnerability in spray-json, a dependency of scala-uri:
`com.netaporter:scala-uri_2.12@0.4.16 › io.spray:spray-json_2.12@1.3.2`

Newer versions of scala-uri do not depend on spray-json.