### PR TITLE
Adding recaptcha to Subscription Endpoint & deprecating authorised endpoint

### DIFF
--- a/support-frontend/app/controllers/DigitalSubscription.scala
+++ b/support-frontend/app/controllers/DigitalSubscription.scala
@@ -136,7 +136,7 @@ class DigitalSubscription(
       payPalConfigProvider.get(),
       payPalConfigProvider.get(true),
       v2recaptchaConfigPublicKey = recaptchaConfigProvider.v2PublicKey,
-      true,
+      orderIsAGift = true,
     )
   }
 

--- a/support-frontend/app/controllers/DigitalSubscription.scala
+++ b/support-frontend/app/controllers/DigitalSubscription.scala
@@ -135,8 +135,7 @@ class DigitalSubscription(
       stripeConfigProvider.get(true),
       payPalConfigProvider.get(),
       payPalConfigProvider.get(true),
-      v2recaptchaConfigPublicKey = recaptchaConfigProvider.v2PublicKey,
-      orderIsAGift = true,
+      v2recaptchaConfigPublicKey = recaptchaConfigProvider.v2PublicKey
     )
   }
 

--- a/support-frontend/app/controllers/DigitalSubscription.scala
+++ b/support-frontend/app/controllers/DigitalSubscription.scala
@@ -12,7 +12,7 @@ import com.gu.support.config.{PayPalConfigProvider, Stage, Stages, StripeConfigP
 import com.gu.support.encoding.CustomCodecs._
 import com.gu.support.pricing.PriceSummaryServiceProvider
 import com.gu.support.promotions.{DefaultPromotions, PromoCode}
-import config.StringsConfig
+import config.{RecaptchaConfigProvider, StringsConfig}
 import play.api.libs.circe.Circe
 import play.api.mvc._
 import play.twirl.api.Html
@@ -37,7 +37,8 @@ class DigitalSubscription(
   stringsConfig: StringsConfig,
   settingsProvider: AllSettingsProvider,
   val supportUrl: String,
-  fontLoaderBundle: Either[RefPath, StyleContent]
+  fontLoaderBundle: Either[RefPath, StyleContent],
+  recaptchaConfigProvider: RecaptchaConfigProvider
 )(
   implicit val ec: ExecutionContext
 ) extends AbstractController(components) with GeoRedirect with CanonicalLinks with Circe with SettingsSurrogateKeySyntax {
@@ -133,7 +134,9 @@ class DigitalSubscription(
       stripeConfigProvider.get(),
       stripeConfigProvider.get(true),
       payPalConfigProvider.get(),
-      payPalConfigProvider.get(true)
+      payPalConfigProvider.get(true),
+      v2recaptchaConfigPublicKey = recaptchaConfigProvider.v2PublicKey,
+      true,
     )
   }
 

--- a/support-frontend/app/controllers/PaperSubscription.scala
+++ b/support-frontend/app/controllers/PaperSubscription.scala
@@ -9,7 +9,7 @@ import com.gu.support.config.{PayPalConfigProvider, Stage, Stages, StripeConfigP
 import com.gu.support.pricing.PriceSummaryServiceProvider
 import com.gu.tip.Tip
 import config.Configuration.GuardianDomain
-import config.StringsConfig
+import config.{RecaptchaConfigProvider, StringsConfig}
 import play.api.mvc._
 import play.twirl.api.Html
 import services.stepfunctions.SupportWorkersClient
@@ -39,7 +39,8 @@ class PaperSubscription(
   stringsConfig: StringsConfig,
   settingsProvider: AllSettingsProvider,
   val supportUrl: String,
-  fontLoaderBundle: Either[RefPath, StyleContent]
+  fontLoaderBundle: Either[RefPath, StyleContent],
+  recaptchaConfigProvider: RecaptchaConfigProvider
 )(implicit val ec: ExecutionContext) extends AbstractController(components) with GeoRedirect with Circe with CanonicalLinks with SettingsSurrogateKeySyntax {
 
   import actionRefiners._
@@ -113,7 +114,8 @@ class PaperSubscription(
       stripeConfigProvider.get(false),
       stripeConfigProvider.get(true),
       payPalConfigProvider.get(false),
-      payPalConfigProvider.get(true)
+      payPalConfigProvider.get(true),
+      recaptchaConfigProvider.v2PublicKey
     )
   }
 

--- a/support-frontend/app/controllers/WeeklySubscription.scala
+++ b/support-frontend/app/controllers/WeeklySubscription.scala
@@ -15,7 +15,7 @@ import com.gu.support.config.{PayPalConfigProvider, Stage, StripeConfigProvider}
 import com.gu.support.encoding.CustomCodecs._
 import com.gu.support.pricing.PriceSummaryServiceProvider
 import com.gu.support.promotions.{DefaultPromotions, ProductPromotionCopy, PromotionServiceProvider}
-import config.StringsConfig
+import config.{RecaptchaConfigProvider, StringsConfig}
 import play.api.libs.circe.Circe
 import play.api.mvc._
 import play.twirl.api.Html
@@ -42,7 +42,8 @@ class WeeklySubscription(
   settingsProvider: AllSettingsProvider,
   val supportUrl: String,
   fontLoaderBundle: Either[RefPath, StyleContent],
-  stage: Stage
+  stage: Stage,
+  recaptchaConfigProvider: RecaptchaConfigProvider
 )(implicit val ec: ExecutionContext) extends AbstractController(components) with GeoRedirect with Circe with CanonicalLinks with SettingsSurrogateKeySyntax {
 
   import actionRefiners._
@@ -157,6 +158,7 @@ class WeeklySubscription(
       stripeConfigProvider.get(true),
       payPalConfigProvider.get(),
       payPalConfigProvider.get(true),
+      recaptchaConfigProvider.v2PublicKey,
       orderIsAGift
     )
   }

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -26,7 +26,6 @@
   shareImageUrl: String,
   shareUrl: String,
   v2recaptchaConfigPublicKey: String,
-
 )(implicit assets: AssetsResolver, request: RequestHeader, settings: AllSettings)
 
 @main(title = title, mainJsBundle = js, fontLoaderBundle = fontLoaderBundle, description = description, mainElement = mainElement, mainStyleBundle = css, shareImageUrl = Some(shareImageUrl), shareUrl = Some(shareUrl)) {

--- a/support-frontend/app/views/subscriptionCheckout.scala.html
+++ b/support-frontend/app/views/subscriptionCheckout.scala.html
@@ -68,4 +68,5 @@
       window.guardian.v2recaptchaPublicKey = "@v2recaptchaConfigPublicKey"
       
   </script>
+
   }

--- a/support-frontend/app/views/subscriptionCheckout.scala.html
+++ b/support-frontend/app/views/subscriptionCheckout.scala.html
@@ -27,6 +27,7 @@
   uatStripeConfig: StripeConfig,
   defaultPayPalConfig: PayPalConfig,
   uatPayPalConfig: PayPalConfig,
+  v2recaptchaConfigPublicKey: String,
   orderIsAGift: Boolean = false,
 )(implicit assets: AssetsResolver, requestHeader: RequestHeader, settings: AllSettings)
 
@@ -64,6 +65,7 @@
       window.guardian.csrf = { token: "@CSRF.getToken.value" };
 
       window.guardian.checkoutPostcodeLookup = "@settings.switches.experiments.get("checkoutPostcodeLookup").exists(_.isOn)"
-  </script>
+      window.guardian.v2recaptchaPublicKey = "@v2recaptchaConfigPublicKey"
+</script>
 
   }

--- a/support-frontend/app/views/subscriptionCheckout.scala.html
+++ b/support-frontend/app/views/subscriptionCheckout.scala.html
@@ -66,5 +66,6 @@
 
       window.guardian.checkoutPostcodeLookup = "@settings.switches.experiments.get("checkoutPostcodeLookup").exists(_.isOn)"
       window.guardian.v2recaptchaPublicKey = "@v2recaptchaConfigPublicKey"
+      
   </script>
   }

--- a/support-frontend/app/views/subscriptionCheckout.scala.html
+++ b/support-frontend/app/views/subscriptionCheckout.scala.html
@@ -66,6 +66,5 @@
 
       window.guardian.checkoutPostcodeLookup = "@settings.switches.experiments.get("checkoutPostcodeLookup").exists(_.isOn)"
       window.guardian.v2recaptchaPublicKey = "@v2recaptchaConfigPublicKey"
-</script>
-
+  </script>
   }

--- a/support-frontend/app/wiring/Controllers.scala
+++ b/support-frontend/app/wiring/Controllers.scala
@@ -65,7 +65,8 @@ trait Controllers {
     stringsConfig,
     allSettingsProvider,
     appConfig.supportUrl,
-    fontLoader
+    fontLoader,
+    appConfig.recaptchaConfigProvider
   )
 
   lazy val paperController = new PaperSubscription(
@@ -80,7 +81,8 @@ trait Controllers {
     stringsConfig,
     allSettingsProvider,
     appConfig.supportUrl,
-    fontLoader
+    fontLoader,
+    appConfig.recaptchaConfigProvider
   )
 
   lazy val weeklyController = new WeeklySubscription(
@@ -98,7 +100,8 @@ trait Controllers {
     allSettingsProvider,
     appConfig.supportUrl,
     fontLoader,
-    appConfig.stage
+    appConfig.stage,
+    appConfig.recaptchaConfigProvider
   )
 
   lazy val createSubscriptionController = new CreateSubscription(

--- a/support-frontend/assets/components/checkoutForm/checkoutForm.jsx
+++ b/support-frontend/assets/components/checkoutForm/checkoutForm.jsx
@@ -55,6 +55,7 @@ const FormSectionHiddenUntilSelected = ({
     <div className="component-checkout-form-section__wrap">
       {title && <Heading className="component-checkout-form-section__heading" size={headingSize}>{title}</Heading>}
       {children}
+      <div id="robot_checkbox" className="robot_checkbox" />
     </div>)}
   </div>
 );

--- a/support-frontend/assets/components/checkoutForm/checkoutForm.jsx
+++ b/support-frontend/assets/components/checkoutForm/checkoutForm.jsx
@@ -55,7 +55,6 @@ const FormSectionHiddenUntilSelected = ({
     <div className="component-checkout-form-section__wrap">
       {title && <Heading className="component-checkout-form-section__heading" size={headingSize}>{title}</Heading>}
       {children}
-      <div id="robot_checkbox" className="robot_checkbox" />
     </div>)}
   </div>
 );

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/recaptcha.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/recaptcha.jsx
@@ -1,0 +1,15 @@
+// @flow
+
+import React from 'react';
+import { withError } from 'hocs/withError';
+
+
+const Recaptcha = props =>
+  (<div
+    className="robot_checkbox"
+    {...props}
+  />);
+
+const RecaptchaWithError = withError(Recaptcha);
+
+export { RecaptchaWithError };

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -269,6 +269,7 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
             style={{ base: { ...baseStyles }, invalid: { ...invalidStyles } }}
             onChange={e => this.handleChange(e)}
           />
+          <div id="robot_checkbox" className="robot_checkbox" />
           <div className="component-stripe-submit-button">
             <Button id="qa-stripe-submit-button" onClick={event => this.requestSCAPaymentMethod(event)}>
               {this.props.buttonText}

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-unused-state */
 // @flow
 
-import React, { Component, div, type Node } from 'react';
+import React, { Component, type Node } from 'react';
 import { compose } from 'redux';
 import { injectStripe } from 'react-stripe-elements';
 import Button from 'components/button/button';
@@ -64,12 +64,20 @@ const invalidStyles = {
   color: '#c70000',
 };
 
+
+const Recaptcha = props =>
+  (<div
+    className="robot_checkbox"
+    {...props}
+  />);
+
+
 // Main component
 
 const CardNumberWithError = compose(withError, withLabel)(CardNumberElement);
 const CardExpiryWithError = compose(withError, withLabel)(CardExpiryElement);
 const CardCvcWithError = compose(withError, withLabel)(CardCvcElement);
-const DivWithError = withError(div);
+const RecaptchaWithError = withError(Recaptcha);
 
 class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
   constructor(props) {
@@ -300,9 +308,8 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
             style={{ base: { ...baseStyles }, invalid: { ...invalidStyles } }}
             onChange={e => this.handleChange(e)}
           />
-          <DivWithError
+          <RecaptchaWithError
             id="robot_checkbox"
-            className="robot_checkbox"
             error={firstError('recaptcha', this.props.allErrors)}
           />
           <div className="component-stripe-submit-button">

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -111,7 +111,7 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
   // Creates a new setupIntent upon recaptcha verification
   setupRecurringRecaptchaCallback = () => {
     window.grecaptcha.render('robot_checkbox', {
-      sitekey: window.guardian.v2recaptchaPublicKey, // To Do this needs to be the site key
+      sitekey: window.guardian.v2recaptchaPublicKey,
       callback: (token) => {
         trackComponentLoad('subscriptions-recaptcha-client-token-received');
         fetchJson(
@@ -127,7 +127,7 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
             if (result.client_secret) {
               this.setState({ setupIntentClientSecret: result.client_secret });
 
-              // If user has already clicked contribute then handle card setup now
+              // If user has already clicked submit then handle card setup now
               if (this.state.paymentWaiting) {
                 this.handleCardSetup(result.client_secret);
               }
@@ -135,7 +135,7 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
               throw new Error(`Missing client_secret field in response from ${this.props.stripeSetupIntentEndpoint}`);
             }
           }).catch((error) => {
-            logException(`Error getting Stripe client secret for recurring contribution: ${error}`);
+            logException(`Error getting Stripe client secret for subscription: ${error}`);
 
             this.setState({
               cardErrors: [...this.state.cardErrors, { field: 'cardNumber', message: appropriateErrorMessage('internal_error') }],

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -25,6 +25,7 @@ import { trackComponentLoad } from '../../../helpers/tracking/behaviour';
 import { loadRecaptchaV2 } from '../../../helpers/recaptcha';
 import { isPostDeployUser } from 'helpers/user/user';
 import { routes } from 'helpers/routes';
+import { RecaptchaWithError } from 'components/subscriptionCheckouts/stripeForm/recaptcha';
 
 // Types
 
@@ -64,20 +65,11 @@ const invalidStyles = {
   color: '#c70000',
 };
 
-
-const Recaptcha = props =>
-  (<div
-    className="robot_checkbox"
-    {...props}
-  />);
-
-
 // Main component
 
 const CardNumberWithError = compose(withError, withLabel)(CardNumberElement);
 const CardExpiryWithError = compose(withError, withLabel)(CardExpiryElement);
 const CardCvcWithError = compose(withError, withLabel)(CardCvcElement);
-const RecaptchaWithError = withError(Recaptcha);
 
 class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
   constructor(props) {
@@ -255,7 +247,9 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
   }
 
   checkRecaptcha() {
-    if (!isPostDeployUser() && !this.state.recaptchaCompleted) {
+    if (!isPostDeployUser() &&
+      !this.state.recaptchaCompleted &&
+      !this.props.allErrors.find(error => error.field === 'recaptcha')) {
       this.props.allErrors.push({
         field: 'recaptcha',
         message: 'Please check the \'I am not a robot\' checkbox',

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -118,22 +118,20 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
 
   // Creates a new setupIntent upon recaptcha verification
   setupRecurringRecaptchaCallback = () => {
-    if (isPostDeployUser()) {
-      this.fetchPaymentIntent('dummy');
-    } else {
-      window.grecaptcha.render('robot_checkbox', {
-        sitekey: window.guardian.v2recaptchaPublicKey,
-        callback: (token) => {
-          trackComponentLoad('subscriptions-recaptcha-client-token-received');
-          this.recaptchaCompleted();
-          this.fetchPaymentIntent(token);
-        },
-      });
-    }
+    window.grecaptcha.render('robot_checkbox', {
+      sitekey: window.guardian.v2recaptchaPublicKey,
+      callback: (token) => {
+        trackComponentLoad('subscriptions-recaptcha-client-token-received');
+        this.recaptchaCompleted();
+        this.fetchPaymentIntent(token);
+      },
+    });
   };
 
   setupRecurringHandlers(): void {
-    if (window.grecaptcha && window.grecaptcha.render) {
+    if (isPostDeployUser()) {
+      this.fetchPaymentIntent('dummy');
+    } else if (window.grecaptcha && window.grecaptcha.render) {
       this.setupRecurringRecaptchaCallback();
     } else {
       window.v2OnloadCallback = this.setupRecurringRecaptchaCallback;

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -20,6 +20,7 @@ import { appropriateErrorMessage } from 'helpers/errorReasons';
 import type { Csrf } from '../../../helpers/csrf/csrfReducer';
 import { trackComponentLoad } from '../../../helpers/tracking/behaviour';
 import { loadRecaptchaV2 } from '../../../helpers/recaptcha';
+import { routes } from 'helpers/routes';
 
 // Types
 
@@ -32,7 +33,6 @@ export type StripeFormPropTypes = {
   submitForm: Function,
   validateForm: Function,
   buttonText: string,
-  stripeSetupIntentEndpoint: string,
   csrf: Csrf,
 }
 
@@ -115,7 +115,7 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
       callback: (token) => {
         trackComponentLoad('subscriptions-recaptcha-client-token-received');
         fetchJson(
-          '/stripe/create-setup-intent/recaptcha',
+          routes.stripeSetupIntentRecaptcha,
           requestOptions(
             { token, stripePublicKey: this.props.stripeKey },
             'same-origin',
@@ -132,7 +132,7 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
                 this.handleCardSetup(result.client_secret);
               }
             } else {
-              throw new Error(`Missing client_secret field in response from ${this.props.stripeSetupIntentEndpoint}`);
+              throw new Error(`Missing client_secret field in response from ${routes.stripeSetupIntentRecaptcha}`);
             }
           }).catch((error) => {
             logException(`Error getting Stripe client secret for subscription: ${error}`);

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -114,8 +114,6 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
       sitekey: window.guardian.v2recaptchaPublicKey, // To Do this needs to be the site key
       callback: (token) => {
         trackComponentLoad('subscriptions-recaptcha-client-token-received');
-        // this.props.setStripeRecurringRecaptchaVerified(true);
-
         fetchJson(
           '/stripe/create-setup-intent/recaptcha',
           requestOptions(
@@ -215,7 +213,7 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
     }
   }
 
-  handleCardSetup(clientSecret: Option<string>): Promise<string> {
+   handleCardSetup(clientSecret: Option<string>): Promise<string> {
     return this.props.stripe.handleCardSetup(clientSecret).then((result) => {
       if (result.error) {
         this.handleStripeError(result.error);

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -213,7 +213,7 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
     }
   }
 
-   handleCardSetup(clientSecret: Option<string>): Promise<string> {
+  handleCardSetup(clientSecret: Option<string>): Promise<string> {
     return this.props.stripe.handleCardSetup(clientSecret).then((result) => {
       if (result.error) {
         this.handleStripeError(result.error);

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.scss
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.scss
@@ -26,3 +26,8 @@
 div#card-expiry.StripeElement, div#cvc.StripeElement {
   width: 30%;
 }
+
+.robot_checkbox {
+  margin-top: 24px;
+  margin-bottom: 10px;
+}

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeProviderForCountry.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeProviderForCountry.jsx
@@ -6,7 +6,6 @@ import StripeForm from 'components/subscriptionCheckouts/stripeForm/stripeForm';
 import { type StripeFormPropTypes } from 'components/subscriptionCheckouts/stripeForm/stripeForm';
 import { getStripeKey } from 'helpers/paymentIntegrations/stripeCheckout';
 import type { IsoCountry } from 'helpers/internationalisation/country';
-import { routes } from 'helpers/routes';
 
 // Types
 
@@ -27,7 +26,6 @@ function StripeProviderForCountry(props: PropTypes) {
           allErrors={props.allErrors}
           stripeKey={stripeKey}
           setStripePaymentMethod={props.setStripePaymentMethod}
-          stripeSetupIntentEndpoint={routes.stripeSetupIntentWithAuth}
           validateForm={props.validateForm}
           buttonText={props.buttonText}
           csrf={props.csrf}

--- a/support-frontend/assets/helpers/routes.js
+++ b/support-frontend/assets/helpers/routes.js
@@ -34,7 +34,7 @@ const routes: {
   guardianWeeklySubscriptionLandingGift: '/subscribe/weekly/gift',
   postcodeLookup: '/postcode-lookup',
   createSignInUrl: '/identity/signin-url',
-  stripeSetupIntentWithAuth: '/stripe/create-setup-intent/auth',
+  stripeSetupIntentRecaptcha: '/stripe/create-setup-intent/recaptcha',
 };
 
 const createReminderEndpoint = isProd() ?

--- a/support-frontend/assets/helpers/subscriptionsForms/formFields.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/formFields.js
@@ -36,10 +36,9 @@ export type FormFields = {|
   productOption: ProductOptions,
   orderIsAGift: Option<boolean>,
   deliveryInstructions: Option<string>,
-  recaptcha: Option<boolean>,
 |};
 
-export type FormField = $Keys<FormFields>;
+export type FormField = $Keys<FormFields> | 'recaptcha';
 
 export type FormState = {|
   stage: Stage,

--- a/support-frontend/assets/helpers/subscriptionsForms/formFields.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/formFields.js
@@ -36,6 +36,7 @@ export type FormFields = {|
   productOption: ProductOptions,
   orderIsAGift: Option<boolean>,
   deliveryInstructions: Option<string>,
+  recaptcha: Option<boolean>,
 |};
 
 export type FormField = $Keys<FormFields>;

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
@@ -239,7 +239,7 @@ class CardForm extends Component<PropTypes, StateTypes> {
       this.props.setPaymentWaiting(true);
 
       // Post-deploy tests bypass recaptcha, and no verification happens server-side for the test Stripe account
-      if (this.props.postDeploymentTestUser){
+      if (this.props.postDeploymentTestUser) {
         fetchJson(
           '/stripe/create-setup-intent/recaptcha',
           requestOptions(
@@ -255,7 +255,7 @@ class CardForm extends Component<PropTypes, StateTypes> {
             } else {
               throw new Error(`Missing client_secret field in server response: ${JSON.stringify(json)}`);
             }
-          })
+          });
       }
 
       /* Recaptcha verification is required for setupIntent creation.

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
@@ -230,6 +230,10 @@ class CardForm extends Component<PropTypes, StateTypes> {
   };
 
   setupRecurringHandlers(): void {
+    // Start by requesting the client_secret for a new Payment Method.
+    // Note - because this value is requested asynchronously when the component loads,
+    // it's possible for it to arrive after the user clicks 'Contribute'.
+    // This is handled in the callback below by checking the value of paymentWaiting.
     if (window.grecaptcha && window.grecaptcha.render) {
       this.setupRecurringRecaptchaCallback();
     } else {

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
@@ -30,6 +30,7 @@ import CreditCardsUS from './creditCardsUS.svg';
 import type { Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { updateRecaptchaToken } from '../../contributionsLandingActions';
+import { routes } from 'helpers/routes';
 
 // ----- Types -----//
 
@@ -192,7 +193,7 @@ class CardForm extends Component<PropTypes, StateTypes> {
         this.props.setStripeRecurringRecaptchaVerified(true);
 
         fetchJson(
-          '/stripe/create-setup-intent/recaptcha',
+          routes.stripeSetupIntentRecaptcha,
           requestOptions(
             { token, stripePublicKey: this.props.stripeKey },
             'same-origin',
@@ -210,7 +211,7 @@ class CardForm extends Component<PropTypes, StateTypes> {
             }
           })
           .catch((err) => {
-            logException(`Error getting Setup Intent client_secret from /stripe/create-setup-intent/recaptcha: ${err}`);
+            logException(`Error getting Setup Intent client_secret from ${routes.stripeSetupIntentRecaptcha}: ${err}`);
             this.props.paymentFailure('internal_error');
             this.props.setPaymentWaiting(false);
           });
@@ -241,7 +242,7 @@ class CardForm extends Component<PropTypes, StateTypes> {
       // Post-deploy tests bypass recaptcha, and no verification happens server-side for the test Stripe account
       if (this.props.postDeploymentTestUser) {
         fetchJson(
-          '/stripe/create-setup-intent/recaptcha',
+          routes.stripeSetupIntentRecaptcha,
           requestOptions(
             { token: 'post-deploy-token', stripePublicKey: this.props.stripeKey },
             'same-origin',

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -211,7 +211,7 @@ function fetchClientSecret(props: PropTypes): Promise<string> {
     if (result.client_secret) {
       return Promise.resolve(result.client_secret);
     }
-    return Promise.reject(new Error(`Missing client_secret field in response for PRB`));
+    return Promise.reject(new Error('Missing client_secret field in response for PRB'));
 
   });
 }

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
@@ -232,7 +232,6 @@ function DigitalCheckoutForm(props: PropTypes) {
               submitForm={props.submitForm}
               allErrors={[...props.addressErrors]}
               setStripePaymentMethod={props.setStripePaymentMethod}
-              stripeSetupIntentEndpoint={routes.stripeSetupIntentWithAuth}
               name={`${props.firstName} ${props.lastName}`}
               validateForm={props.validateForm}
               buttonText="Start your free trial now"

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
@@ -320,7 +320,6 @@ function PaperCheckoutForm(props: PropTypes) {
               submitForm={props.submitForm}
               allErrors={[...props.billingAddressErrors, ...props.deliveryAddressErrors, ...props.formErrors]}
               setStripePaymentMethod={props.setStripePaymentMethod}
-              stripeSetupIntentEndpoint={routes.stripeSetupIntentWithAuth}
               name={`${props.firstName} ${props.lastName}`}
               validateForm={props.validateForm}
               buttonText="Pay now"

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -313,7 +313,6 @@ function WeeklyCheckoutForm(props: PropTypes) {
               submitForm={props.submitForm}
               allErrors={[...props.billingAddressErrors, ...props.deliveryAddressErrors, ...props.formErrors]}
               setStripePaymentMethod={props.setStripePaymentMethod}
-              stripeSetupIntentEndpoint={routes.stripeSetupIntentWithAuth}
               name={`${props.firstName} ${props.lastName}`}
               validateForm={props.validateForm}
               buttonText="Pay now"

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.jsx
@@ -341,7 +341,6 @@ function WeeklyCheckoutFormGifting(props: PropTypes) {
               submitForm={props.submitForm}
               allErrors={[...props.billingAddressErrors, ...props.deliveryAddressErrors, ...props.formErrors]}
               setStripePaymentMethod={props.setStripePaymentMethod}
-              stripeSetupIntentEndpoint={routes.stripeSetupIntentWithAuth}
               name={`${props.firstName} ${props.lastName}`}
               validateForm={props.validateForm}
               buttonText="Pay now"

--- a/support-frontend/conf/routes
+++ b/support-frontend/conf/routes
@@ -64,7 +64,6 @@ GET  /support-workers/status                                       controllers.S
 
 
 POST  /stripe/create-setup-intent/recaptcha                        controllers.StripeController.createSetupIntentRecaptcha()
-POST  /stripe/create-setup-intent/auth                             controllers.StripeController.createSetupIntentWithAuth()
 POST  /stripe/create-setup-intent/prb                              controllers.StripeController.createSetupIntentPRB()
 
 # this endpoint should be removed once identity remove

--- a/support-frontend/test/controllers/SubscriptionsTest.scala
+++ b/support-frontend/test/controllers/SubscriptionsTest.scala
@@ -16,7 +16,7 @@ import com.gu.support.workers.Monthly
 import com.gu.tip.Tip
 import com.typesafe.config.ConfigFactory
 import config.Configuration.MetricUrl
-import config.StringsConfig
+import config.{RecaptchaConfigProvider, StringsConfig}
 import fixtures.TestCSRFComponents
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
@@ -92,6 +92,7 @@ class SubscriptionsTest extends AnyWordSpec with Matchers with TestCSRFComponent
         StripeConfig(stripeAccountConfig, stripeAccountConfig, stripeAccountConfig, None))
       val payPal = mock[PayPalConfigProvider]
       when(payPal.get(any[Boolean])).thenReturn(PayPalConfig("", "", "", "", "", ""))
+      val recaptchaConfigProvider = mock[RecaptchaConfigProvider]
 
       val prices: ProductPrices = Map(
         CountryGroup.UK ->
@@ -117,7 +118,8 @@ class SubscriptionsTest extends AnyWordSpec with Matchers with TestCSRFComponent
         stringsConfig = new StringsConfig(),
         settingsProvider = settingsProvider,
         supportUrl = "support.thegulocal.com",
-        fontLoaderBundle = Left(RefPath("test"))
+        fontLoaderBundle = Left(RefPath("test")),
+        recaptchaConfigProvider
       )
     }
 


### PR DESCRIPTION
## Why are you doing this?
Since adding recaptcha to contributions the card testers have moved to the subscriptions endpoint. 
This PR adds the google recaptcha to subs checkout (see below) and deprecates the authorised endpoint on the backend.

![image](https://user-images.githubusercontent.com/30600967/79745217-b4370f00-82ff-11ea-9d4f-85f2f6ad859e.png)

