### PR TITLE
Make the recaptcha policy links open a new tab

### DIFF
--- a/support-frontend/assets/components/recaptcha/recaptcha.jsx
+++ b/support-frontend/assets/components/recaptcha/recaptcha.jsx
@@ -7,8 +7,8 @@ export function Recaptcha() {
   return (
     <>
       <div id="robot_checkbox" className="robot_checkbox" />
-      <p className="recaptcha-terms ">
-        By ticking this box, you agree to let Google perform a security check to confirm you are a human. Please refer to their <a href='https://policies.google.com/terms'>Terms</a> and <a href='https://policies.google.com/privacy'>Privacy</a> policies.
+      <p className="recaptcha-terms">
+        By ticking this box, you agree to let Google perform a security check to confirm you are a human. Please refer to their <a target="_blank" rel="noopener noreferrer" href="https://policies.google.com/terms">Terms</a> and <a target="_blank" rel="noopener noreferrer" href="https://policies.google.com/privacy">Privacy</a> policies.
       </p>
     </>
   );


### PR DESCRIPTION
## Why are you doing this?
Make the recaptcha policy links open a new tab instead of replacing the checkout and the user losing their card details if they click on one of them. 

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/3f9Kn7ls)

## Accessibility test checklist
 - [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
 - [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
 - [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

## Screenshots
No change.
