### PR TITLE
Remove Direct Debit from payment methods

### DIFF
--- a/support-frontend/assets/helpers/subscriptionsForms/countryPaymentMethods.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/countryPaymentMethods.js
@@ -2,10 +2,10 @@
 
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { PaymentMethod } from 'helpers/paymentMethods';
-import { DirectDebit, Stripe, PayPal } from 'helpers/paymentMethods';
+import { Stripe, PayPal } from 'helpers/paymentMethods';
 
 function supportedPaymentMethods(country: IsoCountry): PaymentMethod[] {
-  const countrySpecific: PaymentMethod[] = country === 'GB' ? [DirectDebit, Stripe, PayPal] : [Stripe, PayPal];
+  const countrySpecific: PaymentMethod[] = country === 'GB' ? [Stripe, PayPal] : [Stripe, PayPal];
 
   return countrySpecific;
 }


### PR DESCRIPTION
## Why are you doing this?

Direct Debit is currently broken

[**Trello Card**](https://trello.com)
