### PR TITLE
reinstate Direct Debit to subs payment methods

### DIFF
--- a/support-frontend/assets/helpers/subscriptionsForms/countryPaymentMethods.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/countryPaymentMethods.js
@@ -2,10 +2,10 @@
 
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { PaymentMethod } from 'helpers/paymentMethods';
-import { Stripe, PayPal } from 'helpers/paymentMethods';
+import { DirectDebit, Stripe, PayPal } from 'helpers/paymentMethods';
 
 function supportedPaymentMethods(country: IsoCountry): PaymentMethod[] {
-  const countrySpecific: PaymentMethod[] = country === 'GB' ? [Stripe, PayPal] : [Stripe, PayPal];
+  const countrySpecific: PaymentMethod[] = country === 'GB' ? [DirectDebit, Stripe, PayPal] : [Stripe, PayPal];
 
   return countrySpecific;
 }


### PR DESCRIPTION
Reverts guardian/support-frontend#2471

Direct debit is working, it was an issue at gocardless, @paulbrown1982 has tested and it's working okay for recurring contributions.  So enable for subs.