### PR TITLE
fix: hero image on thank-you page

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-checkout/components/thankYou/hero.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/thankYou/hero.jsx
@@ -22,12 +22,12 @@ const defaultHeroes: GridImages = {
     },
     tablet: {
       gridId: 'subscriptionDailyPackshot',
-      srcSizes: [500, 1000, 1584],
+      srcSizes: [500, 1000, 1825],
       imgType: 'png',
     },
     desktop: {
       gridId: 'subscriptionDailyPackshot',
-      srcSizes: [500, 1000, 1584],
+      srcSizes: [500, 1000, 1825],
       imgType: 'png',
     },
   },


### PR DESCRIPTION
## Why are you doing this?

The digital subscriptions image was changed on the showcase page, when this change was made it had different dimensions to the previous image, because this image also appeared on the thank you page the dimensions needed to be changed on the thank you page, unfortunately they were missed, which resulted in the image link being broken on the thank you page

This PR updates those dimensions and fixes the broken image

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/QUO8RmZI/3000-thank-you-page-image-for-digi-subs-broken)

## Changes

* Changed image dimensions

## Accessibility test checklist
 - [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
 - [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
 - [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

## Screenshots

### broken image link
![Screen Shot 2020-04-23 at 13 39 02](https://user-images.githubusercontent.com/45875444/80101380-3a09c300-8569-11ea-815a-9353cf283231.png)

### working image link
![Screen Shot 2020-04-23 at 13 39 35](https://user-images.githubusercontent.com/45875444/80101391-3ece7700-8569-11ea-955f-315735ec29e8.png)


