### PR TITLE
fix: remove svg error

### DIFF
--- a/support-frontend/assets/components/svgs/dropdownArrow.jsx
+++ b/support-frontend/assets/components/svgs/dropdownArrow.jsx
@@ -10,7 +10,7 @@ export default function SvgDropdownArrow() {
       viewBox="0 0 10 10"
       width={10}
       height={10}
-      preserveAspectRatio
+      preserveAspectRatio="xMidYMid"
       aria-hidden="true"
       focusable="false"
     >


### PR DESCRIPTION
## Why are you doing this?

This error shows in the console 
```
Error: <svg> attribute preserveAspectRatio: Unrecognized enumerated value, "true".
```

This appears because preserveAspectRatio has no attribute for one of the svg's which preact defaults to true as though it is a jsx parameter

This PR adds a default attribute
<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

## Changes

* Add a default attribute to preserveAspectRatio

## Accessibility test checklist
 - [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
 - [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
 - [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

## Screenshots

### Error in the console which is now removed
![Screen Shot 2020-04-23 at 16 20 28](https://user-images.githubusercontent.com/45875444/80117984-bc04e680-857f-11ea-889c-80064ddc00ff.png)


