### PR TITLE
Fix the check for discounted prices to take account of 0

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
@@ -77,7 +77,7 @@ const BILLING_PERIOD = {
     title: 'Annual',
     salesCopy: (currencyId: IsoCurrency, displayPrice: number, promotionalPrice: Option<number>) => {
       const display = price => getDisplayPrice(currencyId, price);
-      return promotionalPrice ?
+      return typeof promotionalPrice === 'number' ?
         <span>
           <span className="product-option__price">{display(promotionalPrice)}</span>
           <span className="product-option__price-detail">then {display(displayPrice)}/year</span>
@@ -134,7 +134,7 @@ const mapStateToProps = (state: State): { paymentOptions: Array<PaymentOption> }
     const fullPrice = productPrice.price;
     const promotion = getPromotion(productPrice.promotions, state.common.abParticipations.digitalPackMonthlyOfferTest);
     const promoCode = promotion ? promotion.promoCode : null;
-    const promotionalPrice = promotion && promotion.discountedPrice ? promotion.discountedPrice : null;
+    const promotionalPrice = promotion && typeof promotion.discountedPrice === 'number' ? promotion.discountedPrice : null;
     const offer = promotion &&
     promotion.landingPage &&
     promotion.landingPage.roundel ? promotion.landingPage.roundel :

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
@@ -25,6 +25,7 @@ import type { DigitalBillingPeriod } from 'helpers/billingPeriods';
 import { promoQueryParam } from 'helpers/productPrice/promotions';
 import type { Promotion } from 'helpers/productPrice/promotions';
 import { getQueryParameter } from 'helpers/url';
+import { isNumeric } from 'helpers/productPrice/productPrices';
 
 export type PaymentOption = {
   title: string,
@@ -77,7 +78,7 @@ const BILLING_PERIOD = {
     title: 'Annual',
     salesCopy: (currencyId: IsoCurrency, displayPrice: number, promotionalPrice: Option<number>) => {
       const display = price => getDisplayPrice(currencyId, price);
-      return typeof promotionalPrice === 'number' ?
+      return isNumeric(promotionalPrice) ?
         <span>
           <span className="product-option__price">{display(promotionalPrice)}</span>
           <span className="product-option__price-detail">then {display(displayPrice)}/year</span>
@@ -134,7 +135,7 @@ const mapStateToProps = (state: State): { paymentOptions: Array<PaymentOption> }
     const fullPrice = productPrice.price;
     const promotion = getPromotion(productPrice.promotions, state.common.abParticipations.digitalPackMonthlyOfferTest);
     const promoCode = promotion ? promotion.promoCode : null;
-    const promotionalPrice = promotion && typeof promotion.discountedPrice === 'number' ? promotion.discountedPrice : null;
+    const promotionalPrice = promotion && isNumeric(promotion.discountedPrice) ? promotion.discountedPrice : null;
     const offer = promotion &&
     promotion.landingPage &&
     promotion.landingPage.roundel ? promotion.landingPage.roundel :


### PR DESCRIPTION
## Why are you doing this?

100% discounts are currently rendering incorrectly on the site. This is because 
of a boolean check we do to see whether there is a promotional price or not:
```javascript
const promotionalPrice = promotion && promotion.discountedPrice ? promotion.discountedPrice : null;
```

for a 100% discount `promotion.discountedPrice` 0 and so is falsey meaning we end up with no promotion applied. 

[**Trello Card**](https://trello.com/c/vC7yyXnz/3002-fix-100-discounts)

### Before
![Screen Shot 2020-04-23 at 17 11 45](https://user-images.githubusercontent.com/181371/80195817-53b41480-8614-11ea-846d-291e7028c713.png)

### After
![Screen Shot 2020-04-23 at 17 09 33](https://user-images.githubusercontent.com/181371/80195855-60386d00-8614-11ea-8ace-1d81f050011b.png)
