### PR TITLE
Extra validation

### DIFF
--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFields.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFields.jsx
@@ -157,6 +157,7 @@ class AddressFields<GlobalState> extends Component<PropTypes<GlobalState>> {
           id={`${scope}-city`}
           label="Town/City"
           type="text"
+          maxlength={40}
           value={props.city}
           setValue={props.setTownCity}
           error={firstError('city', props.formErrors)}

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
@@ -223,6 +223,7 @@ function PaperCheckoutForm(props: PropTypes) {
                 <TextAreaWithLabel
                   id="delivery-instructions"
                   label="Delivery instructions"
+                  maxlength={250}
                   value={props.deliveryInstructions}
                   setValue={props.setDeliveryInstructions}
                 />


### PR DESCRIPTION
## Why are you doing this?

We have had several failed checkouts recently caused by a user entering either a city name or delivery instructions which are too long and cause validation errors in Salesforce. 

This PR adds a `maxlength` attribute to both of those fields.

[**Trello Card**](https://trello.com/c/SvZwZrTB/2936-billing-city-delivery-instructions-length-restrictions)
