### PR TITLE
Introduce artificial ContributionsService test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtest.js
+++ b/support-frontend/assets/helpers/abTests/abtest.js
@@ -287,6 +287,9 @@ function getParticipations(
   const acquisitionDataTest: ?AcquisitionABTest = getTestFromAcquisitionData();
   const isRemote = getIsRemoteFromAcquisitionData();
 
+  // This is a temporary addition to help us compare remote and locally rendered
+  // epics on Frontend (as part of testing out the new Contributions Service).
+  // It will be removed once the new service is shown to be working correctly.
   if (isRemote) {
     participations['ContributionsService'] = 'remote';
   }

--- a/support-frontend/assets/helpers/abTests/abtest.js
+++ b/support-frontend/assets/helpers/abTests/abtest.js
@@ -137,6 +137,22 @@ function getParticipationsFromUrl(): ?Participations {
   return null;
 }
 
+function getIsRemoteFromAcquisitionData(): boolean {
+  const queryString = getQueryParameter('acquisitionData');
+
+  if (!queryString) {
+    return false;
+  }
+
+  try {
+    const data = JSON.parse(queryString);
+    return data ? data.isRemote === 'true' : false;
+  } catch {
+    console.error('Cannot parse acquisition data from query string');
+    return false;
+  }
+}
+
 function getTestFromAcquisitionData(): ?AcquisitionABTest {
   const acquisitionDataParam = getQueryParameter('acquisitionData');
 
@@ -269,6 +285,11 @@ function getParticipations(
   const participations: Participations = {};
 
   const acquisitionDataTest: ?AcquisitionABTest = getTestFromAcquisitionData();
+  const isRemote = getIsRemoteFromAcquisitionData();
+
+  if (isRemote) {
+    participations['ContributionsService'] = 'remote';
+  }
 
   Object.keys(abTests).forEach((testId) => {
     const test = abTests[testId];


### PR DESCRIPTION
**WIP**

## Why are you doing this?

The aim is to indicate in Ophan/Data Lake whether a request was served locally in Frontend or by a remote epic (from the new Contributions Service).

This is a temporary solution while we validate and migrate the Contributions Service, at which point it will no longer be needed.

https://trello.com/c/VLxYd8go/115-full-variants-test-only-on-frontend

## Changes

To do this, we pass an `isRemote` flag in the query param and then convert that into a fake `ContributionsService` test.