### PR TITLE
fix: fix the cancellation policy showing on gifting

### DIFF
--- a/support-frontend/assets/components/subscriptionCheckouts/cancellationPolicy.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/cancellationPolicy.jsx
@@ -8,13 +8,11 @@ export const cancellationCopy = {
   body: 'There is no set time on your agreement with us so you can end your subscription whenever you wish',
 };
 
-const CancellationPolicy = ({ orderIsAGift }: {orderIsAGift?: boolean}) => (
+const CancellationPolicy = () => (
   <Text>
-    {!orderIsAGift && (
-      <p>
-        <strong>{cancellationCopy.title}</strong> {cancellationCopy.body}
-      </p>
-      )}
+    <p>
+      <strong>{cancellationCopy.title}</strong> {cancellationCopy.body}
+    </p>
   </Text>
 );
 

--- a/support-frontend/assets/components/subscriptionCheckouts/paymentTerms.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/paymentTerms.jsx
@@ -13,7 +13,7 @@ export default function PaymentTerms(props: {
 }) {
   return (
     <FormSection>
-      {props.orderIsAGift && <CancellationPolicy />}
+      {!props.orderIsAGift && <CancellationPolicy />}
       {(props.paymentMethod === DirectDebit) && <DirectDebitTerms />}
     </FormSection>
   );

--- a/support-frontend/assets/components/subscriptionCheckouts/paymentTerms.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/paymentTerms.jsx
@@ -9,11 +9,16 @@ import CancellationPolicy from 'components/subscriptionCheckouts/cancellationPol
 
 export default function PaymentTerms(props: {
   paymentMethod: Option<PaymentMethod>,
+  orderIsAGift?: boolean,
 }) {
   return (
     <FormSection>
-      <CancellationPolicy />
+      {props.orderIsAGift && <CancellationPolicy />}
       {(props.paymentMethod === DirectDebit) && <DirectDebitTerms />}
     </FormSection>
   );
 }
+
+PaymentTerms.defaultProps = {
+  orderIsAGift: false,
+};


### PR DESCRIPTION
## Why are you doing this?
The cancellation policy should not show on gifting this commit fixes that

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com)

## Changes

* hide cancellation policy on gifting
* Change 2

## Accessibility test checklist
 - [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
 - [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
 - [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

## Screenshots

