### PR TITLE
replaces contact mailto address in philanthropic ask

### DIFF
--- a/support-frontend/assets/components/legal/termsPrivacy/termsPrivacy.jsx
+++ b/support-frontend/assets/components/legal/termsPrivacy/termsPrivacy.jsx
@@ -39,7 +39,7 @@ function TermsPrivacy(props: PropTypes) {
   };
 
   const patronsLink = <a href="https://patrons.theguardian.com/join?INTCMP=gdnwb_copts_support_contributions_referral">Find out more today</a>;
-  const americasContactLink = <a href={"mailto:northamerica.help@guardian.co.uk"}>contact us</a>
+  const americasContactLink = <a href={"mailto:us.philanthropy@theguardian.com"}>contact us</a>
 
   const patronText = (
     <div className="patrons">


### PR DESCRIPTION
Replaces contact mailto address in USA philanthropic ask. Now uses "us.philanthropy@theguardian.com".