### PR TITLE
Recaptcha Feature Switch

### DIFF
--- a/support-frontend/app/admin/settings/Switches.scala
+++ b/support-frontend/app/admin/settings/Switches.scala
@@ -7,6 +7,8 @@ case class Switches(
   oneOffPaymentMethods: PaymentMethodsSwitch,
   recurringPaymentMethods: PaymentMethodsSwitch,
   useDotcomContactPage: Option[SwitchState],
+  enableRecaptchaBackend: SwitchState,
+  enableRecaptchaFrontend: SwitchState,
   experiments: Map[String, ExperimentSwitch]
 )
 

--- a/support-frontend/app/controllers/StripeController.scala
+++ b/support-frontend/app/controllers/StripeController.scala
@@ -58,12 +58,13 @@ class StripeController(
     val testPublicKeys = Set(testStripeConfig.australiaAccount.publicKey,
       testStripeConfig.defaultAccount.publicKey)
 
+    // Requests against the test account do not require verification
     val verified =
       if (recaptchaEnabled && !testPublicKeys(request.body.stripePublicKey))
         recaptchaService.verify(v2RecaptchaToken, v2RecaptchaKey).map(_.success)
       else
         EitherT.rightT[Future, String](true)
-    // Requests against the test account do not require verification
+
 
     val result = for {
       v <- verified

--- a/support-frontend/app/controllers/StripeController.scala
+++ b/support-frontend/app/controllers/StripeController.scala
@@ -47,7 +47,8 @@ class StripeController(
     val recaptchaBackendEnabled = settingsProvider.getAllSettings().switches.enableRecaptchaBackend.isOn
     val recaptchaFrontendEnabled = settingsProvider.getAllSettings().switches.enableRecaptchaFrontend.isOn
 
-    val recaptchaEnabled = recaptchaBackendEnabled && recaptchaFrontendEnabled
+    // We never validate on backend unless frontend validation is Enabled
+    val recaptchaEnabled = recaptchaFrontendEnabled && recaptchaBackendEnabled
 
     val v2RecaptchaToken = request.body.token
 
@@ -63,7 +64,6 @@ class StripeController(
       else
         EitherT.rightT[Future, String](true)
     // Requests against the test account do not require verification
-
 
     val result = for {
       v <- verified

--- a/support-frontend/app/controllers/StripeController.scala
+++ b/support-frontend/app/controllers/StripeController.scala
@@ -1,6 +1,7 @@
 package controllers
 
 import actions.CustomActionBuilders
+import admin.settings.AllSettingsProvider
 import com.gu.aws.AwsCloudWatchMetricPut
 import com.gu.aws.AwsCloudWatchMetricPut.{client, createSetupIntentRequest}
 import com.gu.support.config.{Stage, StripeConfig}
@@ -32,6 +33,7 @@ class StripeController(
   identityService: IdentityService,
   v2RecaptchaKey: String,
   testStripeConfig: StripeConfig,
+  settingsProvider: AllSettingsProvider,
   stage: Stage
 )(implicit ec: ExecutionContext) extends AbstractController(components) with Circe with StrictLogging {
 
@@ -42,6 +44,11 @@ class StripeController(
   import services.SetupIntent.encoder
 
   def createSetupIntentRecaptcha: Action[SetupIntentRequestRecaptcha] = PrivateAction.async(circe.json[SetupIntentRequestRecaptcha]) { implicit request =>
+    val recaptchaBackendEnabled = settingsProvider.getAllSettings().switches.enableRecaptchaBackend.isOn
+    val recaptchaFrontendEnabled = settingsProvider.getAllSettings().switches.enableRecaptchaFrontend.isOn
+
+    val recaptchaEnabled = recaptchaBackendEnabled && recaptchaFrontendEnabled
+
     val v2RecaptchaToken = request.body.token
 
     val cloudwatchEvent = createSetupIntentRequest(stage, "v2Recaptcha")
@@ -51,11 +58,12 @@ class StripeController(
       testStripeConfig.defaultAccount.publicKey)
 
     val verified =
-      if (testPublicKeys(request.body.stripePublicKey))
-        // Requests against the test account do not require verification
-        EitherT.rightT[Future, String](true)
-      else
+      if (recaptchaEnabled && !testPublicKeys(request.body.stripePublicKey))
         recaptchaService.verify(v2RecaptchaToken, v2RecaptchaKey).map(_.success)
+      else
+        EitherT.rightT[Future, String](true)
+    // Requests against the test account do not require verification
+
 
     val result = for {
       v <- verified

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -111,6 +111,7 @@
 
   window.guardian.forceCampaign = @settings.switches.experiments.get("forceCampaign").exists(_.isOn)
 
+  window.guardian.recaptchaEnabled = @settings.switches.enableRecaptchaFrontend.isOn
   window.guardian.v2recaptchaPublicKey = "@v2recaptchaConfigPublicKey"
   </script>
 }

--- a/support-frontend/app/views/subscriptionCheckout.scala.html
+++ b/support-frontend/app/views/subscriptionCheckout.scala.html
@@ -66,7 +66,8 @@
 
       window.guardian.checkoutPostcodeLookup = "@settings.switches.experiments.get("checkoutPostcodeLookup").exists(_.isOn)"
       window.guardian.v2recaptchaPublicKey = "@v2recaptchaConfigPublicKey"
-      
+      window.guardian.recaptchaEnabled = @settings.switches.enableRecaptchaFrontend.isOn
+
   </script>
 
   }

--- a/support-frontend/app/wiring/Controllers.scala
+++ b/support-frontend/app/wiring/Controllers.scala
@@ -128,6 +128,7 @@ trait Controllers {
     identityService = identityService,
     v2RecaptchaKey = appConfig.recaptchaConfigProvider.v2SecretKey,
     testStripeConfig = appConfig.regularStripeConfigProvider.get(true),
+    allSettingsProvider,
     appConfig.stage
   )
 

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -130,7 +130,7 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
   };
 
   setupRecurringHandlers(): void {
-    if (isPostDeployUser()) {
+    if (!window.guardian.recaptchaEnabled || isPostDeployUser()) {
       this.fetchPaymentIntent('dummy');
     } else if (window.grecaptcha && window.grecaptcha.render) {
       this.setupRecurringRecaptchaCallback();
@@ -246,7 +246,8 @@ class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
   }
 
   checkRecaptcha() {
-    if (!isPostDeployUser() &&
+    if (window.guardian.recaptchaEnabled &&
+      !isPostDeployUser() &&
       !this.state.recaptchaCompleted &&
       !this.props.allErrors.find(error => error.field === 'recaptcha')) {
       this.props.allErrors.push({

--- a/support-frontend/assets/pages/contributions-landing/checkoutFormIsSubmittableActions.js
+++ b/support-frontend/assets/pages/contributions-landing/checkoutFormIsSubmittableActions.js
@@ -117,8 +117,10 @@ function enableOrDisableForm() {
     const formIsValid = getFormIsValid(formIsValidParameters(state));
     dispatch(setFormIsValid(formIsValid));
 
-    const recaptchaRequired = state.page.user.isPostDeploymentTestUser ? false
-      : state.page.form.paymentMethod === 'Stripe';
+    const disabledIfPostDeploy =
+      state.page.user.isPostDeploymentTestUser ? false : state.page.form.paymentMethod === 'Stripe';
+
+    const recaptchaRequired = window.guardian.recaptchaEnabled ? disabledIfPostDeploy : false;
 
     const recaptchaVerified =
       state.page.form.contributionType !== 'ONE_OFF' ?
@@ -129,7 +131,7 @@ function enableOrDisableForm() {
       formIsValid
       && !(shouldBlockExistingRecurringContributor)
       && userCanContributeWithoutSigningIn
-      && (recaptchaVerified || !recaptchaRequired);
+      && (!recaptchaRequired || recaptchaVerified);
 
     dispatch(setFormIsSubmittable(shouldEnable, state.page.form.payPalButtonReady));
   };

--- a/support-frontend/assets/pages/contributions-landing/checkoutFormIsSubmittableActions.js
+++ b/support-frontend/assets/pages/contributions-landing/checkoutFormIsSubmittableActions.js
@@ -117,10 +117,10 @@ function enableOrDisableForm() {
     const formIsValid = getFormIsValid(formIsValidParameters(state));
     dispatch(setFormIsValid(formIsValid));
 
-    const disabledIfPostDeploy =
-      state.page.user.isPostDeploymentTestUser ? false : state.page.form.paymentMethod === 'Stripe';
-
-    const recaptchaRequired = window.guardian.recaptchaEnabled ? disabledIfPostDeploy : false;
+    const recaptchaRequired =
+      window.guardian.recaptchaEnabled &&
+      state.page.form.paymentMethod === 'Stripe' &&
+      !state.page.user.isPostDeploymentTestUser;
 
     const recaptchaVerified =
       state.page.form.contributionType !== 'ONE_OFF' ?

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
@@ -235,17 +235,19 @@ class CardForm extends Component<PropTypes, StateTypes> {
     // Note - because this value is requested asynchronously when the component loads,
     // it's possible for it to arrive after the user clicks 'Contribute'.
     // This is handled in the callback below by checking the value of paymentWaiting.
-    if (window.grecaptcha && window.grecaptcha.render) {
-      this.setupRecurringRecaptchaCallback();
-    } else {
-      window.v2OnloadCallback = this.setupRecurringRecaptchaCallback;
+    if (window.guardian.recaptchaEnabled) {
+      if (window.grecaptcha && window.grecaptcha.render) {
+        this.setupRecurringRecaptchaCallback();
+      } else {
+        window.v2OnloadCallback = this.setupRecurringRecaptchaCallback;
+      }
     }
 
     this.props.setCreateStripePaymentMethod(() => {
       this.props.setPaymentWaiting(true);
 
       // Post-deploy tests bypass recaptcha, and no verification happens server-side for the test Stripe account
-      if (this.props.postDeploymentTestUser) {
+      if (!window.guardian.recaptchaEnabled || this.props.postDeploymentTestUser) {
         fetchJson(
           routes.stripeSetupIntentRecaptcha,
           requestOptions(
@@ -274,10 +276,12 @@ class CardForm extends Component<PropTypes, StateTypes> {
   }
 
   setupOneOffHandlers(): void {
-    if (window.grecaptcha && window.grecaptcha.render) {
-      this.setupRecaptchaTokenForOneOff();
-    } else {
-      window.v2OnloadCallback = this.setupRecaptchaTokenForOneOff;
+    if (window.guardian.recaptchaEnabled) {
+      if (window.grecaptcha && window.grecaptcha.render) {
+        this.setupRecaptchaTokenForOneOff();
+      } else {
+        window.v2OnloadCallback = this.setupRecaptchaTokenForOneOff;
+      }
     }
 
     this.props.setCreateStripePaymentMethod(() => {
@@ -423,18 +427,20 @@ class CardForm extends Component<PropTypes, StateTypes> {
           </div>
         </div>
         {errorMessage ? <div className="form__error">{errorMessage}</div> : null}
+        { window.guardian.recaptchaEnabled ?
+          <div className="form__field">
 
-        <div className="form__field">
-          <label className="form__label" htmlFor="robot_checkbox">
-            <span>Security check</span>
-          </label>
-          <Recaptcha />
-          {
-            this.props.checkoutFormHasBeenSubmitted
-            && !recaptchaVerified ?
-              renderVerificationCopy(this.props.countryGroupId, this.props.contributionType) : null
-          }
-        </div>
+            <label className="form__label" htmlFor="robot_checkbox">
+              <span>Security check</span>
+            </label>
+            <Recaptcha />
+            {
+              this.props.checkoutFormHasBeenSubmitted
+              && !recaptchaVerified ?
+                renderVerificationCopy(this.props.countryGroupId, this.props.contributionType) : null
+            }
+          </div>
+          : null }
       </div>
     );
   }

--- a/support-frontend/test/codecs/CirceDecodersTest.scala
+++ b/support-frontend/test/codecs/CirceDecodersTest.scala
@@ -287,7 +287,9 @@ class CirceDecodersTest extends AnyWordSpec with Matchers {
               state = On
             )
           ),
-          useDotcomContactPage = Some(Off)
+          useDotcomContactPage = Some(Off),
+          enableRecaptchaBackend = Off,
+          enableRecaptchaFrontend = Off
         ),
         amountsRegions,
         contributionTypes,

--- a/support-frontend/test/codecs/CirceDecodersTest.scala
+++ b/support-frontend/test/codecs/CirceDecodersTest.scala
@@ -119,7 +119,9 @@ class CirceDecodersTest extends AnyWordSpec with Matchers {
           |        "state": "On"
           |      }
           |    },
-          |    "useDotcomContactPage": "Off"
+          |    "useDotcomContactPage": "Off",
+          |    "enableRecaptchaFrontend": "Off",
+          |    "enableRecaptchaBackend": "Off"
           |  },
           |  "amounts": {
           |    "GBPCountries": {

--- a/support-frontend/test/controllers/SubscriptionsTest.scala
+++ b/support-frontend/test/controllers/SubscriptionsTest.scala
@@ -1,7 +1,7 @@
 package controllers
 
 import actions.CustomActionBuilders
-import admin.settings.SwitchState.On
+import admin.settings.SwitchState.{Off, On}
 import admin.settings._
 import assets.RefPath
 import cats.data.EitherT
@@ -69,7 +69,9 @@ class SubscriptionsTest extends AnyWordSpec with Matchers with TestCSRFComponent
       Switches(
         oneOffPaymentMethods = PaymentMethodsSwitch(On, On, On, On, None, None, None, None),
         recurringPaymentMethods = PaymentMethodsSwitch(On, On, On, On, Some(On), Some(On), Some(On), None),
-        experiments = Map.empty, useDotcomContactPage = Some(SwitchState.Off)
+        experiments = Map.empty, useDotcomContactPage = Some(SwitchState.Off),
+        enableRecaptchaBackend = Off,
+        enableRecaptchaFrontend = Off
       ),
       AmountsRegions(amounts, amounts, amounts, amounts, amounts, amounts, amounts),
       ContributionTypes(Nil, Nil, Nil, Nil, Nil, Nil, Nil),


### PR DESCRIPTION
## Why are you doing this?

We want to be able to disable recaptcha quickly in order to reduce dependency on external partners.

This change allows us to have a feature switch to disable recaptcha when necessary.

https://trello.com/c/uaO1tOSE/2012-add-recaptcha-feature-switch-in-the-support-admin-console
https://github.com/guardian/support-admin-console/pull/117
https://github.com/guardian/payment-api/pull/200

Note both switches must be on for recaptcha to work correctly! The backend should always be turned off first to allow any in flight users through the system.
