### PR TITLE
End summary mobile design tweaks

### DIFF
--- a/support-frontend/assets/components/content/content.scss
+++ b/support-frontend/assets/components/content/content.scss
@@ -101,6 +101,13 @@
   padding: ($gu-v-spacing/2) ($gu-h-spacing / 2) 0;
 }
 
+.component-footer {
+  .component-content__content,
+  .component-content__content--grey {
+    padding: ($gu-h-spacing / 2);
+  }
+}
+
 .component-content__content {
   max-width: gu-span(12);
 

--- a/support-frontend/assets/components/subscriptionCheckouts/directDebitTerms.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/directDebitTerms.jsx
@@ -2,10 +2,14 @@
 
 import React from 'react';
 import { css } from '@emotion/core';
+import { textSans } from '@guardian/src-foundations/typography/obj';
+import { text } from '@guardian/src-foundations/palette';
 
 const directDebitTerms = css`
+  ${textSans.xsmall()};
+
   a, a:visited {
-    color: #121212;
+    color: ${text.primary};
   }
   p {
     margin-top: 10px;
@@ -15,15 +19,17 @@ const directDebitTerms = css`
 const DirectDebitTerms = () => (
   <div css={directDebitTerms}>
     <p>
-      <strong>Payments by GoCardless</strong> read the <a href="https://gocardless.com/privacy">GoCardless privacy notice</a>
+      <strong>Payments by GoCardless</strong><br />
+      Read the <a href="https://gocardless.com/privacy">GoCardless privacy notice</a>
     </p>
     <p>
-      <strong>Advance notice</strong> The details of your Direct Debit instruction including
-      payment schedule, due date, frequency and amount will be sent to you within three working
-      days. All the normal Direct Debit safeguards and guarantees apply.
+      Advance notice<br />
+      The details of your Direct Debit instruction including payment schedule, due date,
+      frequency and amount will be sent to you within three working days. All
+      the normal Direct Debit safeguards and guarantees apply.
     </p>
     <p>
-      <strong>Direct Debit</strong><br />
+      Direct Debit<br />
       The Guardian, Unit 16, Coalfield Way, Ashby Park, Ashby-De-La-Zouch, LE65 1TJ United
       Kingdom<br />
       Tel: 0330 333 6767 (within UK). Lines are open 8am-8pm on weekdays, 8am-6pm at weekends

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/digitalPaymentTerms.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/digitalPaymentTerms.jsx
@@ -11,7 +11,9 @@ import { DirectDebit } from 'helpers/paymentMethods';
 import DirectDebitTerms from 'components/subscriptionCheckouts/directDebitTerms';
 
 const directDebitSection = css`
-  padding: 0 ${space[3]}px ${space[3]}px;
+  display: block;
+  padding: ${space[3]}px;
+  padding-top: 0;
   background-color: #F6F6F6;
   border: none;
 
@@ -21,7 +23,7 @@ const directDebitSection = css`
 `;
 
 const borderTop = css`
-  width: 100%;
+  display: block;
   border-top: 1px solid ${border.secondary};
 
   ${from.desktop} {
@@ -34,11 +36,11 @@ export default function DigitalPaymentTerms(props: {
 }) {
   return props.paymentMethod === DirectDebit
     ? (
-      <div css={directDebitSection}>
-        <div css={borderTop}>
+      <span css={directDebitSection}>
+        <span css={borderTop}>
           <DirectDebitTerms />
-        </div>
-      </div>)
+        </span>
+      </span>)
     : null;
 
 }

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/digitalPaymentTerms.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/digitalPaymentTerms.jsx
@@ -1,19 +1,34 @@
 // @flow
 import React from 'react';
-import { FormSection } from 'components/checkoutForm/checkoutForm';
+import { css } from '@emotion/core';
+import { space } from '@guardian/src-foundations';
+import { border } from '@guardian/src-foundations/palette';
+
 import { type Option } from 'helpers/types/option';
 import type { PaymentMethod } from 'helpers/paymentMethods';
 import { DirectDebit } from 'helpers/paymentMethods';
 import DirectDebitTerms from 'components/subscriptionCheckouts/directDebitTerms';
+
+const directDebitSection = css`
+  padding: 0 ${space[3]}px ${space[3]}px;
+  background-color: #F6F6F6;
+`;
+
+const borderTop = css`
+  width: 100%;
+  border-top: 1px solid ${border.secondary};
+`;
 
 export default function DigitalPaymentTerms(props: {
   paymentMethod: Option<PaymentMethod>,
 }) {
   return props.paymentMethod === DirectDebit
     ? (
-      <FormSection>
-        <DirectDebitTerms />
-      </FormSection>)
+      <div css={directDebitSection}>
+        <div css={borderTop}>
+          <DirectDebitTerms />
+        </div>
+      </div>)
     : null;
 
 }

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/digitalPaymentTerms.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/digitalPaymentTerms.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { css } from '@emotion/core';
 import { space } from '@guardian/src-foundations';
 import { border } from '@guardian/src-foundations/palette';
+import { from } from '@guardian/src-foundations/mq';
 
 import { type Option } from 'helpers/types/option';
 import type { PaymentMethod } from 'helpers/paymentMethods';
@@ -12,11 +13,20 @@ import DirectDebitTerms from 'components/subscriptionCheckouts/directDebitTerms'
 const directDebitSection = css`
   padding: 0 ${space[3]}px ${space[3]}px;
   background-color: #F6F6F6;
+  border: none;
+
+  ${from.desktop} {
+    border-top: 1px solid ${border.secondary};
+  }
 `;
 
 const borderTop = css`
   width: 100%;
   border-top: 1px solid ${border.secondary};
+
+  ${from.desktop} {
+    border-top: none;
+  }
 `;
 
 export default function DigitalPaymentTerms(props: {

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/endSummary/endSummaryMobile.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/endSummary/endSummaryMobile.jsx
@@ -4,14 +4,14 @@ import React from 'react';
 import { css } from '@emotion/core';
 import { from } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
-import { border } from '@guardian/src-foundations/palette';
+import { border, background } from '@guardian/src-foundations/palette';
 import EndSummary from 'pages/digital-subscription-checkout/components/endSummary/endSummary';
 
 const endSummaryMobile = css`
   display: block;
   padding:${space[3]}px;
   border-top: 1px solid ${border.secondary};
-  border-bottom: 1px solid ${border.secondary};
+  background-color: #f6f6f6; /* Using the hex code as ${background.secondary} isn't exposed in the API yet */
 
   ${from.desktop} {
     display: none;

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/endSummary/endSummaryMobile.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/endSummary/endSummaryMobile.jsx
@@ -8,6 +8,7 @@ import { border, background } from '@guardian/src-foundations/palette';
 import EndSummary from 'pages/digital-subscription-checkout/components/endSummary/endSummary';
 
 const endSummaryMobile = css`
+  display: block;
   padding: ${space[3]}px;
   border-top: 1px solid ${border.secondary};
   background-color: #f6f6f6; /* Using the hex code as ${background.secondary} isn't exposed in the API yet */
@@ -23,9 +24,9 @@ const endSummaryMobile = css`
 
 function EndSummaryMobile() {
   return (
-    <div css={endSummaryMobile}>
+    <span css={endSummaryMobile}>
       <EndSummary />
-    </div>
+    </span>
   );
 }
 

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/endSummary/endSummaryMobile.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/endSummary/endSummaryMobile.jsx
@@ -8,10 +8,13 @@ import { border, background } from '@guardian/src-foundations/palette';
 import EndSummary from 'pages/digital-subscription-checkout/components/endSummary/endSummary';
 
 const endSummaryMobile = css`
-  display: block;
-  padding:${space[3]}px;
+  padding: ${space[3]}px;
   border-top: 1px solid ${border.secondary};
   background-color: #f6f6f6; /* Using the hex code as ${background.secondary} isn't exposed in the API yet */
+
+  li:last-of-type {
+    margin-bottom: 0;
+  }
 
   ${from.desktop} {
     display: none;
@@ -20,9 +23,9 @@ const endSummaryMobile = css`
 
 function EndSummaryMobile() {
   return (
-    <span css={endSummaryMobile}>
+    <div css={endSummaryMobile}>
       <EndSummary />
-    </span>
+    </div>
   );
 }
 

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/endSummary/endSummaryStyles.js
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/endSummary/endSummaryStyles.js
@@ -2,7 +2,7 @@ import { css } from '@emotion/core';
 import { textSans } from '@guardian/src-foundations/typography/obj';
 import { space } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
-import { text, border } from '@guardian/src-foundations/palette';
+import { text, border, background } from '@guardian/src-foundations/palette';
 
 export const list = css`
   ${from.desktop} {
@@ -37,7 +37,7 @@ export const dot = css`
   height: 9px;
   width: 9px;
   border-radius: 50%;
-  background-color: #63717A;
+  background-color: ${background.ctaPrimary};
   vertical-align: top;
   margin-top: ${space[2]}px;
 `;

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/endSummary/endSummaryStyles.js
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/endSummary/endSummaryStyles.js
@@ -27,7 +27,7 @@ export const listMain = css`
 
 export const subText = css`
   display: block;
-  ${textSans.medium()};
+  ${textSans.small()};
   margin-left: ${space[5]}px;
   line-height: 135%;
 `;


### PR DESCRIPTION
## Why are you doing this?
This is picking up some aspects of the end summary and other mobile design tweaks that were previously missed.

[**Trello Card**](https://trello.com/c/HMDFH839/3026-review-design-of-end-summary-mobile-direct-debit)

## Changes
* Grey background for end summary and direct debit terms
* Shorter top border for dd terms
* Font size for dd terms 
* Fix bullet dot colour in end summary

## Screenshots

![Screen Shot 2020-05-11 at 22 41 22](https://user-images.githubusercontent.com/16781258/81614915-a9403d80-93d8-11ea-9617-f5bd04d69982.png)

![Screen Shot 2020-05-11 at 22 18 19](https://user-images.githubusercontent.com/16781258/81614929-af361e80-93d8-11ea-8932-c584ece3a47d.png)
