### PR TITLE
Fix thank you email wording

### DIFF
--- a/support-workers/src/main/scala/com/gu/emailservices/SubscriptionEmailFieldHelpers.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/SubscriptionEmailFieldHelpers.scala
@@ -82,7 +82,7 @@ object SubscriptionEmailFieldHelpers {
           case SixWeekly => throw new RuntimeException("Six for six is currently unsupported")
         }
       }
-      s"${priceWithCurrency(currency, initialPrice)} for $introductoryTimespan, " +
+      s"${priceWithCurrency(currency, initialPrice)} every ${billingPeriod.noun} for $introductoryTimespan, " +
         s"then ${priceWithCurrency(currency, paymentsWithDifferentPrice.head.amount)} every ${billingPeriod.noun}"
     }
 

--- a/support-workers/src/main/scala/com/gu/support/workers/PreviewPaymentSchedule.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/PreviewPaymentSchedule.scala
@@ -27,11 +27,13 @@ object PreviewPaymentSchedule {
     ).map(response => paymentSchedule(response.invoiceData.flatMap(_.invoiceItem)))
   }
 
+  def round(d: Double) = BigDecimal(d).setScale(2, BigDecimal.RoundingMode.HALF_UP).toDouble
+
   def paymentSchedule(charges: List[Charge]): PaymentSchedule = {
     val dateChargeMap = charges.groupBy(_.serviceStartDate)
     val payments = dateChargeMap.map { dateAndCharge =>
       val (paymentDate, charges) = dateAndCharge
-      Payment(paymentDate, charges.map(charge => charge.chargeAmount + charge.taxAmount).sum)
+      Payment(paymentDate, charges.map(charge => round(charge.chargeAmount) + round(charge.taxAmount)).sum)
     }
     implicit def localDateOrdering: Ordering[LocalDate] = Ordering.fromLessThan(_ isBefore _)
     PaymentSchedule(payments.toList.sortBy(_.date))

--- a/support-workers/src/test/scala/com/gu/emailservices/SubscriptionEmailFieldHelpersSpec.scala
+++ b/support-workers/src/test/scala/com/gu/emailservices/SubscriptionEmailFieldHelpersSpec.scala
@@ -50,7 +50,7 @@ class SubscriptionEmailFieldHelpersSpec extends AnyFlatSpec with Matchers {
     val firstDiscountedPayment = Payment(referenceDate, 5.99)
     val firstFullPricePayment = Payment(referenceDate.plusMonths(3), 11.99)
     val schedule: List[Payment] = payments(firstDiscountedPayment, List(1, 2)) ++ payments(firstFullPricePayment, List(1, 2, 3, 4, 5, 6, 7, 8, 9))
-    val expected = "£5.99 for 3 months, then £11.99 every month"
+    val expected = "£5.99 every month for 3 months, then £11.99 every month"
     assert(SubscriptionEmailFieldHelpers.describe(PaymentSchedule(schedule), Monthly, GBP, None) == expected)
   }
 
@@ -58,7 +58,7 @@ class SubscriptionEmailFieldHelpersSpec extends AnyFlatSpec with Matchers {
     val firstDiscountedPayment = Payment(referenceDate, 30.00)
     val firstFullPricePayment = Payment(referenceDate.plusMonths(6), 37.50)
     val schedule: List[Payment] = payments(firstDiscountedPayment, List(3)) ++ payments(firstFullPricePayment, List(3, 6))
-    val expected = "£30.00 for 2 quarters, then £37.50 every quarter"
+    val expected = "£30.00 every quarter for 2 quarters, then £37.50 every quarter"
     assert(SubscriptionEmailFieldHelpers.describe(PaymentSchedule(schedule), Quarterly, GBP, None) == expected)
   }
 

--- a/support-workers/src/test/scala/com/gu/support/workers/PreviewPaymentScheduleSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/PreviewPaymentScheduleSpec.scala
@@ -30,4 +30,15 @@ class PreviewPaymentScheduleSpec extends AnyFlatSpec with Matchers {
     assert(schedule == expected)
   }
 
+  "paymentSchedule" should "round charge amounts to two decimal places" in {
+    val taxExclusiveCharge = Charge(firstPaymentDate, firstPaymentDate.plusMonths(1), 0, 5.9901)
+    val charges = List(
+      taxExclusiveCharge,
+      taxExclusiveCharge.copy(serviceStartDate = firstPaymentDate.plusMonths(1), serviceEndDate = firstPaymentDate.plusMonths(2), chargeAmount = 5.99)
+    )
+    val expected = PaymentSchedule(List(Payment(firstPaymentDate, 5.99), Payment(firstPaymentDate.plusMonths(1), 5.99)))
+    val schedule = PreviewPaymentSchedule.paymentSchedule(charges)
+    assert(schedule == expected)
+  }
+
 }


### PR DESCRIPTION
## Why are you doing this?
We have two issues with the thank you email at the moment:

### First issue
Because the payment schedule we get back from Zuora uses doubles for the price, sometimes we get rounding issues where a charge will be £52.9900000001 per month for the first few months and then £52.99 thereafter. 

This then causes the code which generates the pricing copy in the email to conclude that the first price is an introductory period and come up with the copy "£52.99 for 4 months, then £52.99 every month". To fix this we just need to round the charge amount to 2 decimal places.

### Second issue
The wording of the pricing summary is ambiguous even without the previous bug: "£5.99 for 3 months, then £11.99 every month" could be taken to mean that £5.99 is the total price for the first 3 months. To fix this the copy should read "£5.99 every month for 3 months, then £11.99 every month".

[**Trello Card**](https://trello.com/c/xedRJ0Tc/3053-stop-rounding-errors-causing-weird-non-offers)

