### PR TITLE
Bump acquisition-event-producer to 4.0.27

### DIFF
--- a/support-models/build.sbt
+++ b/support-models/build.sbt
@@ -5,7 +5,7 @@ name := "support-models"
 description := "Scala library to provide shared step-function models to Guardian Support projects."
 
 libraryDependencies ++= Seq(
-  "com.gu" %% "acquisition-event-producer-play26" % "4.0.26", //this should really be split into models and producer
+  "com.gu" %% "acquisition-event-producer-play26" % "4.0.27", //this should really be split into models and producer
                                                               // so we don't have to pull in thrift binary compression libs etc
   "org.typelevel" %% "cats-core" % catsVersion,
   "io.circe" %% "circe-core" % circeVersion,


### PR DESCRIPTION
to get the latest ophan models, for APPLE_NEWS and GOOGLE_AMP as acquisition sources
https://github.com/guardian/acquisition-event-producer/pull/60