### PR TITLE
bump models version

### DIFF
--- a/support-models/version.sbt
+++ b/support-models/version.sbt
@@ -1,1 +1,1 @@
-version := "0.67-SNAPSHOT"
+version := "0.68-SNAPSHOT"


### PR DESCRIPTION
This gives us APPLE_NEWS and GOOGLE_AMP as sources
https://github.com/guardian/support-frontend/pull/2496