### PR TITLE
Order summary mobile: design review changes

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-checkout/components/orderSummary/orderSummaryStyles.js
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/orderSummary/orderSummaryStyles.js
@@ -1,21 +1,22 @@
 import { css } from '@emotion/core';
 import { headline, body, textSans } from '@guardian/src-foundations/typography/obj';
 import { space } from '@guardian/src-foundations';
-import { background, brandAltBackground, text } from '@guardian/src-foundations/palette';
+import { background, brandAltBackground, text, border } from '@guardian/src-foundations/palette';
 import { from, between, until } from '@guardian/src-foundations/mq';
 
 export const wrapper = css`
   background-color: ${background.primary};
   color: ${text.primary};
-  padding-bottom: ${space[3]}px;
+  padding: ${space[3]}px;
 `;
 
 export const topLine = css`
   display: flex;
   justify-content: space-between;
   width: calc(100%-${space[3]}px * 2);
-  margin: ${space[3]}px;
   align-items: center;
+  border-top: 1px solid ${border.secondary};
+  padding: ${space[1]}px 0 ${space[2]}px;
 
   a, a:visited {
     display: block;
@@ -53,7 +54,7 @@ export const imageContainer = css`
   align-items: flex-start;
   width: calc(100%-30px);
   padding: 15px 10px 0 15px;
-  background-color: #63717A;
+  background-color: #F6F6F6;
 
   img {
     width: 100%;
@@ -67,7 +68,6 @@ export const imageContainer = css`
     padding-top: 8px;
     padding-left: 8px;
     overflow: hidden;
-    margin-left: ${space[3]}px;
     img {
       width: 200%;
       align-items: flex-end;

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/orderSummary/orderSummaryStyles.js
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/orderSummary/orderSummaryStyles.js
@@ -1,7 +1,7 @@
 import { css } from '@emotion/core';
 import { headline, body, textSans } from '@guardian/src-foundations/typography/obj';
 import { space } from '@guardian/src-foundations';
-import { background, brandAltBackground, text, border } from '@guardian/src-foundations/palette';
+import { background, brandAltBackground, text, border, neutral } from '@guardian/src-foundations/palette';
 import { from, between, until } from '@guardian/src-foundations/mq';
 
 export const wrapper = css`
@@ -23,7 +23,7 @@ export const topLine = css`
   padding: ${space[3]}px;
 
   ${until.desktop} {
-    border-top: 1px solid #EDEDED;
+    border-top: 1px solid ${neutral['93']};
     padding: ${space[1]}px 0 ${space[2]}px;
   }
 
@@ -63,7 +63,7 @@ export const imageContainer = css`
   align-items: flex-start;
   width: calc(100%-30px);
   padding: 15px 10px 0 15px;
-  background-color: #F6F6F6;
+  background-color: ${neutral['97']};
 
   img {
     width: 100%;

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/orderSummary/orderSummaryStyles.js
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/orderSummary/orderSummaryStyles.js
@@ -9,6 +9,8 @@ export const wrapper = css`
   color: ${text.primary};
   ${until.desktop} {
     padding: ${space[3]}px;
+  }
+  ${until.tablet} {
     box-shadow: 0px 4px 4px ${border.secondary};
   }
 `;
@@ -50,7 +52,6 @@ export const sansTitle = css`
 export const contentBlock = css`
   display: flex;
   width: 100%;
-  margin-bottom: ${space[3]}px;
 
   ${from.tablet} {
     display: block;

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/orderSummary/orderSummaryStyles.js
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/orderSummary/orderSummaryStyles.js
@@ -23,7 +23,7 @@ export const topLine = css`
   padding: ${space[3]}px;
 
   ${until.desktop} {
-    border-top: 1px solid ${border.secondary};
+    border-top: 1px solid #EDEDED;
     padding: ${space[1]}px 0 ${space[2]}px;
   }
 

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/orderSummary/orderSummaryStyles.js
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/orderSummary/orderSummaryStyles.js
@@ -97,7 +97,7 @@ export const textBlock = css`
 
   h3 {
     ${body.medium({ fontWeight: 'bold' })};
-    margin-top: -5px;
+    margin: -5px 0 -3px;
     ${from.desktop} {
       ${headline.xxsmall({ fontWeight: 'bold' })};
       margin-top: 0;

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/orderSummary/orderSummaryStyles.js
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/orderSummary/orderSummaryStyles.js
@@ -7,7 +7,10 @@ import { from, between, until } from '@guardian/src-foundations/mq';
 export const wrapper = css`
   background-color: ${background.primary};
   color: ${text.primary};
-  padding: ${space[3]}px;
+  ${until.desktop} {
+    padding: ${space[3]}px;
+    box-shadow: 0px 4px 4px ${border.secondary};
+  }
 `;
 
 export const topLine = css`
@@ -15,8 +18,13 @@ export const topLine = css`
   justify-content: space-between;
   width: calc(100%-${space[3]}px * 2);
   align-items: center;
-  border-top: 1px solid ${border.secondary};
-  padding: ${space[1]}px 0 ${space[2]}px;
+  padding: ${space[3]}px;
+
+  ${until.desktop} {
+    border-top: 1px solid ${border.secondary};
+    padding: ${space[1]}px 0 ${space[2]}px;
+  }
+
 
   a, a:visited {
     display: block;


### PR DESCRIPTION
## Why are you doing this?
This corrects some outstanding issues with the order summary for the digital checkout, mostly relating to the mobile view.

[**Trello Card**](https://trello.com/c/tHNFw8NC/2978-top-order-summary-design-tweaks)

## Changes
* Add a line at the top of the order summary
* Fix the price info text font
* Add a drop shadow to the box 
* Fix the background colour in the image container
* Reduce space between content and bottom of box (where drop shadow is)

## Screenshots - before
![Screen Shot 2020-05-12 at 17 31 25](https://user-images.githubusercontent.com/16781258/81738321-73ab5b00-9491-11ea-8a11-288d5b435530.png)

## Screenshots - after
![Screen Shot 2020-05-14 at 11 22 49](https://user-images.githubusercontent.com/16781258/81923279-52538780-95d5-11ea-97b0-f9f4bfb121cd.png)
