### PR TITLE
Make support-models use v 2.10.1 of Jackson

### DIFF
--- a/support-models/build.sbt
+++ b/support-models/build.sbt
@@ -1,4 +1,4 @@
-import LibraryVersions.{catsVersion, circeVersion}
+import LibraryVersions.{catsVersion, circeVersion, jacksonVersion}
 
 name := "support-models"
 
@@ -11,5 +11,8 @@ libraryDependencies ++= Seq(
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,
   "io.circe" %% "circe-generic-extras" % circeVersion,
-  "io.circe" %% "circe-parser" % circeVersion
+  "io.circe" %% "circe-parser" % circeVersion,
+  // This is required to force aws libraries to use the latest version of jackson
+  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
+  "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
 )


### PR DESCRIPTION
## Why are you doing this?
Despite us setting a Jackson version of 2.10.1 in most of the projects within support-frontend, this wasn't actually being used (I tested this by by running `sbt evicted`).

Forcing support-models to use version 2.10.1 fixes the issue.
