### PR TITLE
Version bump for jackson-datatype-jsr310

### DIFF
--- a/support-models/build.sbt
+++ b/support-models/build.sbt
@@ -15,4 +15,5 @@ libraryDependencies ++= Seq(
   // This is required to force aws libraries to use the latest version of jackson
   "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion,
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
+  "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion
 )


### PR DESCRIPTION
## Why are you doing this?

Forcing the app to use a newer version of `jackson-datatype-jsr310` to fix a [security vulnerability](https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONDATATYPE-173759)