### PR TITLE
Prevent duplicated promocodes being used

### DIFF
--- a/support-frontend/app/controllers/PaperSubscription.scala
+++ b/support-frontend/app/controllers/PaperSubscription.scala
@@ -59,7 +59,7 @@ class PaperSubscription(
     val css = Left(RefPath("paperSubscriptionLandingPage.css"))
     val canonicalLink = Some(buildCanonicalPaperSubscriptionLink())
     val description = stringsConfig.paperLandingDescription
-    val promoCodes = request.queryString.get("promoCode").map(_.toList).getOrElse(Nil) :+ "SEP2512VHD"
+    val promoCodes = request.queryString.get("promoCode").map(_.toList).getOrElse(Nil)
     val productPrices = priceSummaryServiceProvider.forUser(false).getPrices(Paper, promoCodes)
     val shareImageUrl = Some("https://i.guim.co.uk/img/media/0a1ffb0ec7e4dbbab40421b74e4bcf5d628f4708/0_0_1200_1200/1200.jpg?width=1200&height=1200&quality=85&auto=format&fit=crop&s=c6c7f5b373a1ae54bc66c876a9a60031") // scalastyle:ignore
 

--- a/support-models/src/main/scala/com/gu/support/promotions/PromoError.scala
+++ b/support-models/src/main/scala/com/gu/support/promotions/PromoError.scala
@@ -13,11 +13,15 @@ case object InvalidProductRatePlan extends PromoError {
 }
 
 case object NotApplicable extends PromoError {
-  override  val msg = "This promotion is not applicable"
+  override val msg = "This promotion is not applicable"
 }
 
 case object NoSuchCode extends PromoError {
-  override  val msg = "Unknown or expired promo code"
+  override val msg = "Unknown or expired promo code"
+}
+
+case class DuplicateCode(debug: String) extends PromoError {
+  override val msg = s"Duplicate promo codes: $debug"
 }
 
 case object ExpiredPromotion extends PromoError {

--- a/support-services/src/main/scala/com/gu/support/promotions/ProductPromotionCopy.scala
+++ b/support-services/src/main/scala/com/gu/support/promotions/ProductPromotionCopy.scala
@@ -10,6 +10,7 @@ class ProductPromotionCopy(promotionService: PromotionService, touchPointEnviron
     val productRatePlanIds = product.getProductRatePlanIds(touchPointEnvironment)
     val promotion = promotionService.findPromotion(promoCode)
     promotion
+      .toOption // if promo code not valid, just ignore
       .find(_.promotion.validForAnyProductRatePlan(productRatePlanIds, country, isRenewal = false).nonEmpty)
       .flatMap(_.promotion.landingPage)
   }

--- a/support-services/src/main/scala/com/gu/support/promotions/PromotionTerms.scala
+++ b/support-services/src/main/scala/com/gu/support/promotions/PromotionTerms.scala
@@ -22,7 +22,7 @@ object PromotionTerms {
   implicit val codec: Codec[PromotionTerms] = Codec.deriveCodec
 
   def fromPromoCode(promotionService: PromotionService, stage: Stage, promoCode: PromoCode): Option[PromotionTerms] =
-    promotionService.findPromotion(promoCode).map(promotionTermsFromPromotion(stage))
+    promotionService.findPromotion(promoCode).toOption.map(promotionTermsFromPromotion(stage))
 
 
   def promotionTermsFromPromotion(stage: Stage)(promotion: PromotionWithCode): PromotionTerms = {

--- a/support-services/src/test/scala/com/gu/support/promotions/PromotionServiceIntegrationSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/promotions/PromotionServiceIntegrationSpec.scala
@@ -13,13 +13,13 @@ class PromotionServiceIntegrationSpec extends AsyncFlatSpec with Matchers {
   "PromotionService" should "apply a real promo code" in {
     val realPromoCode = "DJP8L27FY"
     val digipackMonthlyProductRatePlanId = "2c92c0f84bbfec8b014bc655f4852d9d"
-    val promotionWithCode = serviceWithDynamo.findPromotion(realPromoCode).get
-    val result = serviceWithDynamo.applyPromotion(promotionWithCode, UK, digipackMonthlyProductRatePlanId, subscriptionData, isRenewal = false)
+    val promotionWithCode = serviceWithDynamo.findPromotion(realPromoCode).right.get
+    val result = serviceWithDynamo.applyPromotion(promotionWithCode, UK, digipackMonthlyProductRatePlanId, subscriptionData, isRenewal = false).right.get
     result.ratePlanData.length shouldBe 2
   }
 
   it should "find a promotion" in {
     val promotion = serviceWithDynamo.findPromotion("DK0NT24WG")
-    promotion.isDefined shouldBe true
+    promotion.isRight shouldBe true
   }
 }

--- a/support-services/src/test/scala/com/gu/support/promotions/PromotionServiceSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/promotions/PromotionServiceSpec.scala
@@ -15,8 +15,10 @@ import org.scalatest.matchers.should.Matchers
 class PromotionServiceSpec extends AsyncFlatSpec with Matchers {
 
   "PromotionService" should "find a PromoCode" in {
-    serviceWithFixtures.findPromotion(freeTrialPromoCode) should be(Some(freeTrialWithCode))
-    serviceWithFixtures.findPromotion(invalidPromoCode) should be(None)
+    serviceWithFixtures.findPromotion(freeTrialPromoCode) should be(Right(freeTrialWithCode))
+    serviceWithFixtures.findPromotion(invalidPromoCode) should be(Left(NoSuchCode))
+    serviceWithFixtures.findPromotion(duplicatedPromoCode)
+      .left.map({case code: DuplicateCode => code.copy(debug = "")}) should be(Left(DuplicateCode("")))
   }
 
   it should "find multiple promo codes" in {
@@ -48,19 +50,19 @@ class PromotionServiceSpec extends AsyncFlatSpec with Matchers {
   }
 
   it should "apply a discount PromoCode" in {
-    val result = serviceWithFixtures.applyPromotion(discountWithCode, UK, validProductRatePlanId, subscriptionData, false)
+    val result = serviceWithFixtures.applyPromotion(discountWithCode, UK, validProductRatePlanId, subscriptionData, false).right.get
     result.ratePlanData.length shouldBe 2
     result.subscription.promoCode shouldBe Some(discountPromoCode)
   }
 
   it should "apply a FreeTrial PromoCode" in {
-    val result = serviceWithFixtures.applyPromotion(freeTrialWithCode, UK, validProductRatePlanId, subscriptionData, false)
+    val result = serviceWithFixtures.applyPromotion(freeTrialWithCode, UK, validProductRatePlanId, subscriptionData, false).right.get
     result.subscription.contractAcceptanceDate shouldBe subscriptionData.subscription.contractAcceptanceDate.plusDays(freeTrialBenefit.get.duration.getDays)
     result.subscription.promoCode shouldBe Some(freeTrialPromoCode)
   }
 
   it should "apply a double PromoCode" in {
-    val result = serviceWithFixtures.applyPromotion(doubleWithCode, UK, validProductRatePlanId, subscriptionData, false)
+    val result = serviceWithFixtures.applyPromotion(doubleWithCode, UK, validProductRatePlanId, subscriptionData, false).right.get
     result.subscription.contractAcceptanceDate shouldBe subscriptionData.subscription.contractAcceptanceDate.plusDays(freeTrialBenefit.get.duration.getDays)
     result.ratePlanData.length shouldBe 2
     result.subscription.promoCode shouldBe Some(doublePromoCode)
@@ -68,20 +70,20 @@ class PromotionServiceSpec extends AsyncFlatSpec with Matchers {
 
   it should "add any valid promo code to the subscription data" in {
     serviceWithFixtures
-      .applyPromotion(tracking, UK, validProductRatePlanId, subscriptionData, false)
+      .applyPromotion(tracking, UK, validProductRatePlanId, subscriptionData, false).right.get
       .subscription.promoCode shouldBe Some(trackingPromoCode)
   }
 
   it should "not apply a renewal code to a new subscription" in {
-    serviceWithFixtures.applyPromotion(renewal, UK, validProductRatePlanId, subscriptionData, false) shouldBe subscriptionData
+    serviceWithFixtures.applyPromotion(renewal, UK, validProductRatePlanId, subscriptionData, false) shouldBe Left(NotApplicable)
   }
 
   it should "not apply a non renewal code to a renewal" in {
-    serviceWithFixtures.applyPromotion(discountWithCode, UK, validProductRatePlanId, subscriptionData, true) shouldBe subscriptionData
+    serviceWithFixtures.applyPromotion(discountWithCode, UK, validProductRatePlanId, subscriptionData, true) shouldBe Left(NotApplicable)
   }
 
   it should "apply a renewal code to a renewal" in {
-    val result = serviceWithFixtures.applyPromotion(renewal, UK, validProductRatePlanId, subscriptionData, true)
+    val result = serviceWithFixtures.applyPromotion(renewal, UK, validProductRatePlanId, subscriptionData, true).right.get
     result.ratePlanData.length shouldBe 2
     result.subscription.promoCode shouldBe Some(renewalPromoCode)
   }
@@ -91,7 +93,7 @@ object PromotionServiceSpec {
   val config = new PromotionsConfigProvider(ConfigFactory.load(), Stages.DEV).get()
   val serviceWithFixtures = new PromotionService(
     config,
-    Some(new SimplePromotionCollection(List(freeTrial, discount, double, tracking.promotion, renewal.promotion, guardianWeeklyAnnual)))
+    Some(new SimplePromotionCollection(List(freeTrial, discount, double, tracking.promotion, renewal.promotion, guardianWeeklyAnnual, duplicate1, duplicate2)))
   )
 
   val serviceWithDynamo = new PromotionService(

--- a/support-services/src/test/scala/com/gu/support/promotions/ServicesFixtures.scala
+++ b/support-services/src/test/scala/com/gu/support/promotions/ServicesFixtures.scala
@@ -20,6 +20,7 @@ object ServicesFixtures {
   val invalidPromoCode = "INVALID_CODE"
   val renewalPromoCode = "RENEWAL_CODE"
   val trackingPromoCode = "TRACKING_CODE"
+  val duplicatedPromoCode = "DUPLICATED_CODE"
 
   val validProductRatePlanIds = Product.allProducts.flatMap(_.ratePlans(PROD).map(_.id))
   val validProductRatePlanId = validProductRatePlanIds.head
@@ -50,6 +51,12 @@ object ServicesFixtures {
     )
   )
   val guardianWeeklyWithCode = PromotionWithCode(NonGift.tenAnnual, guardianWeeklyAnnual)
+  val duplicate1 = promotion(validProductRatePlanIds, duplicatedPromoCode, discountBenefit)
+  val duplicate2 = promotion(validProductRatePlanIds, duplicatedPromoCode, freeTrial = freeTrialBenefit)
+  val duplicatedWithCode = List(
+    PromotionWithCode(duplicatedPromoCode, duplicate1),
+    PromotionWithCode(duplicatedPromoCode, duplicate1)
+  )
 
   val now = LocalDate.now()
   val subscriptionData = SubscriptionData(

--- a/support-services/src/test/scala/com/gu/support/promotions/ServicesFixtures.scala
+++ b/support-services/src/test/scala/com/gu/support/promotions/ServicesFixtures.scala
@@ -53,10 +53,6 @@ object ServicesFixtures {
   val guardianWeeklyWithCode = PromotionWithCode(NonGift.tenAnnual, guardianWeeklyAnnual)
   val duplicate1 = promotion(validProductRatePlanIds, duplicatedPromoCode, discountBenefit)
   val duplicate2 = promotion(validProductRatePlanIds, duplicatedPromoCode, freeTrial = freeTrialBenefit)
-  val duplicatedWithCode = List(
-    PromotionWithCode(duplicatedPromoCode, duplicate1),
-    PromotionWithCode(duplicatedPromoCode, duplicate1)
-  )
 
   val now = LocalDate.now()
   val subscriptionData = SubscriptionData(

--- a/support-workers/src/main/scala/com/gu/support/workers/exceptions/ErrorHandler.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/exceptions/ErrorHandler.scala
@@ -7,6 +7,7 @@ import com.gu.paypal.PayPalError
 import com.gu.salesforce.Salesforce.SalesforceErrorResponse
 import com.gu.stripe.StripeError
 import com.gu.support.workers.exceptions.RetryImplicits._
+import com.gu.support.workers.lambdas.BuildSubscribePromoError
 import com.gu.support.zuora.api.response.ZuoraErrorResponse
 /**
  * Maps exceptions from the application to either fatal or non fatal exceptions
@@ -25,6 +26,8 @@ object ErrorHandler {
     case e: SalesforceErrorResponse => logAndRethrow(e.asRetryException)
     // Ophan
     case e: AnalyticsServiceError => logAndRethrow(e.asRetryException)
+    // promo code issues
+    case e: BuildSubscribePromoError => logAndRethrow(e.asRetryException)
     //Any Exception that we haven't specifically handled
     case e: Throwable => logAndRethrow(e.asRetryException)
   }

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -7,7 +7,7 @@ import com.gu.config.Configuration
 import com.gu.config.Configuration.zuoraConfigProvider
 import com.gu.monitoring.SafeLogger
 import com.gu.services.{ServiceProvider, Services}
-import com.gu.support.promotions.PromotionService
+import com.gu.support.promotions.{PromoError, PromotionService}
 import com.gu.support.workers._
 import com.gu.support.workers.states.{CreateZuoraSubscriptionState, SendThankYouEmailState}
 import com.gu.support.zuora.api._
@@ -34,8 +34,8 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
     services: Services
   ): FutureHandlerResult = {
     val now = () => OffsetDateTime.now
-    val subscribeItem = buildSubscribeItem(state, services.promotionService)
     for {
+      subscribeItem <- Future.fromTry(buildSubscribeItem(state, services.promotionService).left.map(err => new RuntimeException(err.toString)).toTry)
       identityId <- Future.fromTry(IdentityId(state.user.id))
         .withLogging("identity id")
       maybeDomainSubscription <- GetSubscriptionWithCurrentRequestId(services.zuoraService, state.requestId, identityId, state.product.billingPeriod, now)
@@ -110,17 +110,19 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
       state.acquisitionData
     )
 
-  private def buildSubscribeItem(state: CreateZuoraSubscriptionState, promotionService: PromotionService): SubscribeItem = {
+  private def buildSubscribeItem(state: CreateZuoraSubscriptionState, promotionService: PromotionService): Either[PromoError, SubscribeItem] = {
     val billingEnabled = state.paymentMethod.isLeft
-    //Documentation for this request is here: https://www.zuora.com/developer/api-reference/#operation/Action_POSTsubscribe
-    SubscribeItem(
-      account = buildAccount(state),
-      billToContact = buildContactDetails(state.user, None, state.user.billingAddress),
-      soldToContact = state.user.deliveryAddress map (buildContactDetails(state.user, state.giftRecipient, _, state.user.deliveryInstructions)),
-      paymentMethod = state.paymentMethod.left.toOption,
-      subscriptionData = buildSubscriptionData(state, promotionService),
-      subscribeOptions = SubscribeOptions(billingEnabled, billingEnabled)
-    )
+    buildSubscriptionData(state, promotionService).map { subscriptionData =>
+      //Documentation for this request is here: https://www.zuora.com/developer/api-reference/#operation/Action_POSTsubscribe
+      SubscribeItem(
+        account = buildAccount(state),
+        billToContact = buildContactDetails(state.user, None, state.user.billingAddress),
+        soldToContact = state.user.deliveryAddress map (buildContactDetails(state.user, state.giftRecipient, _, state.user.deliveryInstructions)),
+        paymentMethod = state.paymentMethod.left.toOption,
+        subscriptionData = subscriptionData,
+        subscribeOptions = SubscribeOptions(billingEnabled, billingEnabled)
+      )
+    }
   }
 
   private def buildSubscriptionData(state: CreateZuoraSubscriptionState, promotionService: PromotionService) = {
@@ -133,7 +135,7 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
     val stage = Configuration.stage
 
     state.product match {
-      case c: Contribution => c.build(state.requestId, config)
+      case c: Contribution => Right(c.build(state.requestId, config))
       case d: DigitalPack => d.build(
         state.requestId,
         config,
@@ -144,7 +146,15 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
         stage,
         isTestUser
       )
-      case p: Paper => p.build(state.requestId, state.user.billingAddress.country, state.promoCode, state.firstDeliveryDate, promotionService, stage, isTestUser)
+      case p: Paper => p.build(
+        state.requestId,
+        state.user.billingAddress.country,
+        state.promoCode,
+        state.firstDeliveryDate,
+        promotionService,
+        stage,
+        isTestUser
+      )
       case w: GuardianWeekly => w.build(
         state.requestId,
         state.user.billingAddress.country,

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -39,7 +39,7 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
   ): FutureHandlerResult = {
     val now = () => OffsetDateTime.now
     for {
-      subscribeItem <- Future.fromTry(buildSubscribeItem(state, services.promotionService).left.map(err => new BuildSubscribePromoError(err)).toTry)
+      subscribeItem <- Future.fromTry(buildSubscribeItem(state, services.promotionService).left.map(BuildSubscribePromoError).toTry)
       identityId <- Future.fromTry(IdentityId(state.user.id))
         .withLogging("identity id")
       maybeDomainSubscription <- GetSubscriptionWithCurrentRequestId(services.zuoraService, state.requestId, identityId, state.product.billingPeriod, now)

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
@@ -125,7 +125,7 @@ class SendThankYouEmail(thankYouEmailService: EmailService, servicesProvider: Se
    ): Option[Promotion] =
     for {
       promoCode <- maybePromoCode
-      promotionWithCode <- promotionService.findPromotion(promoCode)
+      promotionWithCode <- promotionService.findPromotion(promoCode).toOption
       validPromotion <- promotionService.validatePromotion(promotionWithCode, country, productRatePlanId, isRenewal = false).toOption
     } yield validPromotion.promotion
 

--- a/support-workers/src/main/scala/com/gu/zuora/ProductSubscriptionBuilders.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/ProductSubscriptionBuilders.scala
@@ -7,7 +7,7 @@ import com.gu.support.catalog
 import com.gu.support.catalog.{ProductRatePlan, ProductRatePlanId}
 import com.gu.support.config.TouchPointEnvironments.fromStage
 import com.gu.support.config.{Stage, ZuoraConfig}
-import com.gu.support.promotions.{DefaultPromotions, PromoCode, PromotionService}
+import com.gu.support.promotions.{DefaultPromotions, PromoCode, PromoError, PromotionService}
 import com.gu.support.workers.GuardianWeeklyExtensions._
 import com.gu.support.workers.ProductTypeRatePlans._
 import com.gu.support.workers._
@@ -51,7 +51,7 @@ object ProductSubscriptionBuilders {
       promotionService: PromotionService,
       stage: Stage,
       isTestUser: Boolean
-    ): SubscriptionData = {
+    ): Either[PromoError, SubscriptionData] = {
 
       val contractEffectiveDate = LocalDate.now(DateTimeZone.UTC)
       val contractAcceptanceDate = contractEffectiveDate
@@ -91,7 +91,7 @@ object ProductSubscriptionBuilders {
       promotionService: PromotionService,
       stage: Stage,
       isTestUser: Boolean
-    ): SubscriptionData = {
+    ): Either[PromoError, SubscriptionData] = {
 
       val contractEffectiveDate = LocalDate.now(DateTimeZone.UTC)
 
@@ -124,7 +124,7 @@ object ProductSubscriptionBuilders {
       stage: Stage,
       isTestUser: Boolean,
       contractEffectiveDate: LocalDate = LocalDate.now(DateTimeZone.UTC)
-    ): SubscriptionData = {
+    ): Either[PromoError, SubscriptionData] = {
 
       val contractAcceptanceDate = Try(firstDeliveryDate.get) match {
         case Success(value) => value
@@ -207,11 +207,13 @@ trait ProductSubscriptionBuilder {
     productRatePlanId: ProductRatePlanId,
     subscriptionData: SubscriptionData
   ) = {
-    val withPromotion = for {
-      promoCode <- maybePromoCode
-      promotionWithCode <- promotionService.findPromotion(promoCode)
-    } yield promotionService.applyPromotion(promotionWithCode, country, productRatePlanId, subscriptionData, isRenewal = false)
+    val withPromotion = maybePromoCode.map { promoCode =>
+      for {
+        promotionWithCode <- promotionService.findPromotion(promoCode)
+        subscriptionWithPromotion <- promotionService.applyPromotion(promotionWithCode, country, productRatePlanId, subscriptionData, isRenewal = false)
+      } yield subscriptionWithPromotion
+    }
 
-    withPromotion.getOrElse(subscriptionData)
+    withPromotion.getOrElse(Right(subscriptionData))
   }
 }

--- a/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
@@ -150,6 +150,14 @@ object JsonFixtures {
     """
       {
         "currency": "GBP",
+        "billingPeriod" : "Annual"
+      }
+    """
+
+  val digitalPackCorporateJson =
+    """
+      {
+        "currency": "GBP",
         "billingPeriod" : "Annual",
         "productOptions" : "Corporate"
       }
@@ -386,7 +394,7 @@ object JsonFixtures {
           {
             $requestIdJson,
             $userJsonNoAddress,
-            "product": $digitalPackJson,
+            "product": $digitalPackCorporateJson,
             "paymentMethod": {
               "redemptionCode": "123abc",
               "corporateAccountId": "00001"

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
@@ -65,7 +65,7 @@ class CreateZuoraSubscriptionSpec extends AsyncLambdaSpec with MockServicesCreat
   }
 
   it should "create a 6 for 6 Guardian Weekly subscription" in {
-    createSubscription(createGuardianWeeklySubscriptionJson(Quarterly, Some(DefaultPromotions.GuardianWeekly.NonGift.sixForSix)))
+    createSubscription(createGuardianWeeklySubscriptionJson(SixWeekly, Some(DefaultPromotions.GuardianWeekly.NonGift.sixForSix)))
   }
 
   it should "create an Guardian Weekly gift subscription" in {

--- a/support-workers/src/test/scala/com/gu/zuora/ProductSubscriptionBuildersSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/ProductSubscriptionBuildersSpec.scala
@@ -82,7 +82,7 @@ class ProductSubscriptionBuildersSpec extends AnyFlatSpec with Matchers with Pro
       ReaderType.Gift,
       DEV,
       isTestUser = false,
-      contractEffectiveDate = saleDate)
+      contractEffectiveDate = saleDate).right.get
 
   lazy val nonGift = weekly.build(
     UUID.randomUUID(),
@@ -92,6 +92,6 @@ class ProductSubscriptionBuildersSpec extends AnyFlatSpec with Matchers with Pro
     ReaderType.Direct,
     DEV,
     isTestUser = false,
-    contractEffectiveDate = saleDate)
+    contractEffectiveDate = saleDate).right.get
 
 }


### PR DESCRIPTION
## Why are you doing this?

As part of the one for one retro we wanted to prevent duplicate promo codes from being used.  This PR is a quick fix to block anyone from subscribing if the code is on muliple promotions.
It also fails on any other promo error rather than continue without.

[**Trello Card**](https://trello.com/c/BHWF8wW3/3056-enforce-promo-code-uniqueness-in-support-workers)

support workers will fail with the following:

```
{
  "error": "com.gu.support.workers.exceptions.RetryNone",
  "cause": {
    "errorMessage": "DuplicateCode(PromotionWithCode(DUPLICATED,Promotion(duplicate1,duplicate promo code for testing,AppliesTo(Set(2c92c0f855c9f4b20155d9f1d3d4512a),Set(Country(GB,United Kingdom,Map()))),C_KA8K8Z0X,Map(Channel 0 -> Set(DUPLICATED)),2020-05-15T00:00:00.000+01:00,None,Some(DiscountBenefit(10.0,Some(P2M))),None,None,None,false,false,Some(PromotionCopy(None,None,None)))), PromotionWithCode(DUPLICATED,Promotion(duplicate2,duplicate promo code for testing,AppliesTo(Set(2c92c0f855c9f4b20155d9f1d3d4512a),Set(Country(GB,United Kingdom,Map()))),C_KA8K8Z0X,Map(Channel 0 -> Set(DUPLICATED)),2020-05-15T00:00:00.000+01:00,None,Some(DiscountBenefit(50.0,Some(P3M))),None,None,None,false,false,Some(PromotionCopy(None,None,None)))))",
    "errorType": "com.gu.support.workers.exceptions.RetryNone",
    "stackTrace": [
      "com.gu.support.workers.lambdas.BuildSubscribePromoError.asRetryException(CreateZuoraSubscription.scala:24)",
      "com.gu.support.workers.exceptions.ErrorHandler$.$anonfun$handleException$1(ErrorHandler.scala:30)",
      "com.gu.support.workers.lambdas.Handler$$anonfun$handleRequestFuture$6.applyOrElse(Handler.scala:48)",
      "com.gu.support.workers.lambdas.Handler$$anonfun$handleRequestFuture$6.applyOrElse(Handler.scala:47)",
      "scala.runtime.AbstractPartialFunction.apply(AbstractPartialFunction.scala:38)",
      "scala.util.Failure.recover(Try.scala:234)",
      "scala.concurrent.Future.$anonfun$recover$1(Future.scala:395)",
      "scala.concurrent.impl.Promise.liftedTree1$1(Promise.scala:33)",
      "scala.concurrent.impl.Promise.$anonfun$transform$1(Promise.scala:33)",
      "scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)",
      "java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1402)",
      "java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)",
      "java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)",
      "java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)",
      "java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)"
    ],
    "cause": {
      "errorMessage": "com.gu.support.workers.lambdas.BuildSubscribePromoError",
      "errorType": "com.gu.support.workers.lambdas.BuildSubscribePromoError",
      "stackTrace": [
        "com.gu.support.workers.lambdas.CreateZuoraSubscription.$anonfun$servicesHandler$2(CreateZuoraSubscription.scala:42)",
        "scala.util.Either$LeftProjection.map(Either.scala:573)",
        "com.gu.support.workers.lambdas.CreateZuoraSubscription.servicesHandler(CreateZuoraSubscription.scala:42)",
        "com.gu.support.workers.lambdas.CreateZuoraSubscription.servicesHandler(CreateZuoraSubscription.scala:27)",
        "com.gu.support.workers.lambdas.ServicesHandler.handlerFuture(ServicesHandler.scala:20)",
        "com.gu.support.workers.lambdas.ServicesHandler.handlerFuture(ServicesHandler.scala:12)",
        "com.gu.support.workers.lambdas.Handler.$anonfun$handleRequestFuture$2(Handler.scala:43)",
        "scala.concurrent.Future.$anonfun$flatMap$1(Future.scala:307)",
        "scala.concurrent.impl.Promise.$anonfun$transformWith$1(Promise.scala:41)",
        "scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)",
        "java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1402)",
        "java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)",
        "java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)",
        "java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)",
        "java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)"
      ]
    }
  }
}
```