### PR TITLE
Redemption code db tables

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -105,7 +105,7 @@ lazy val `support-workers` = (project in file("support-workers"))
     integrationTestSettings,
     libraryDependencies ++= commonDependencies
   ).dependsOn(`support-services`, `support-models` % "test->test;it->test;compile->compile", `support-config`, `support-internationalisation`)
-  .aggregate(`support-services`, `support-models`, `support-config`, `support-internationalisation`, `stripe-intent`)
+  .aggregate(`support-services`, `support-models`, `support-config`, `support-internationalisation`, `stripe-intent`, `support-redemptiondb`)
 
 
 lazy val `support-models` = (project in file("support-models"))

--- a/build.sbt
+++ b/build.sbt
@@ -70,7 +70,8 @@ lazy val root = (project in file("."))
     `support-config`,
     `support-internationalisation`,
     `support-services`,
-    `stripe-intent`
+    `stripe-intent`,
+    `support-redemptiondb`
   )
 
 lazy val testScalastyle = taskKey[Unit]("testScalastyle")
@@ -158,3 +159,6 @@ lazy val `stripe-intent` = (project in file("support-lambdas/stripe-intent"))
     integrationTestSettings,
     libraryDependencies ++= commonDependencies,
   ).dependsOn(`support-rest`, `support-config`)
+
+lazy val `support-redemptiondb` = (project in file("support-redemptiondb"))
+  .enablePlugins(RiffRaffArtifact)

--- a/support-redemptiondb/build.sbt
+++ b/support-redemptiondb/build.sbt
@@ -1,0 +1,12 @@
+
+name := "support-redemptiondb"
+description:= "packages the database cfn for the redemption code db"
+
+assemblyJarName := "dummy.jar"
+riffRaffPackageType := assembly.value
+riffRaffUploadArtifactBucket := Option("riffraff-artifact")
+riffRaffUploadManifestBucket := Option("riffraff-builds")
+riffRaffManifestProjectName := "support:db:redemptiondb"
+riffRaffArtifactResources += (file("support-redemptiondb/cfn.yaml"), "cfn/cfn.yaml")
+riffRaffManifestBranch := Option(System.getenv("BRANCH_NAME")).getOrElse("unknown_branch")
+riffRaffBuildIdentifier := Option(System.getenv("BUILD_NUMBER")).getOrElse("DEV")

--- a/support-redemptiondb/cfn.yaml
+++ b/support-redemptiondb/cfn.yaml
@@ -4,11 +4,10 @@ Parameters:
     Type: String
     Description: Stage for the tables
     AllowedValues:
-      - DEV
-      - UAT
+      - CODE
       - PROD
 Resources:
-  RedemptionCodeDynamoTable:
+  RedemptionCodeDynamoTableDEV:
     Type: AWS::DynamoDB::Table
     Properties:
       AttributeDefinitions:
@@ -18,10 +17,42 @@ Resources:
       KeySchema:
         - AttributeName: "redemptionCode"
           KeyType: "HASH"
-      TableName: !Sub redemption-codes-${Stage}
+      TableName: !Sub redemption-codes-DEV-${Stage}
+  RedemptionCodeDynamoTableUAT:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: "redemptionCode"
+          AttributeType: "S"
+      BillingMode: "PAY_PER_REQUEST"
+      KeySchema:
+        - AttributeName: "redemptionCode"
+          KeyType: "HASH"
+      TableName: !Sub redemption-codes-UAT-${Stage}
+  RedemptionCodeDynamoTablePROD:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: "redemptionCode"
+          AttributeType: "S"
+      BillingMode: "PAY_PER_REQUEST"
+      KeySchema:
+        - AttributeName: "redemptionCode"
+          KeyType: "HASH"
+      TableName: !Sub redemption-codes-PROD-${Stage}
 Outputs:
-  PreviewDynamoArnOut:
-    Description: ARN for dynamo table
-    Value: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${RedemptionCodeDynamoTable}
+  DynamoArnOutDEV:
+    Description: ARN for DEV dynamo table
+    Value: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${RedemptionCodeDynamoTableDEV}
     Export:
-      Name: !Sub ${AWS::StackName}-DynamoTableArn
+      Name: !Sub ${AWS::StackName}-DynamoTableArnDEV
+  DynamoArnOutUAT:
+    Description: ARN for UAT dynamo table
+    Value: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${RedemptionCodeDynamoTableUAT}
+    Export:
+      Name: !Sub ${AWS::StackName}-DynamoTableArnUAT
+  DynamoArnOut:
+    Description: ARN for PROD dynamo table
+    Value: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${RedemptionCodeDynamoTablePROD}
+    Export:
+      Name: !Sub ${AWS::StackName}-DynamoTableArnPROD

--- a/support-redemptiondb/cfn.yaml
+++ b/support-redemptiondb/cfn.yaml
@@ -1,0 +1,27 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Parameters:
+  Stage:
+    Type: String
+    Description: Stage for the tables
+    AllowedValues:
+      - DEV
+      - UAT
+      - PROD
+Resources:
+  RedemptionCodeDynamoTable:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: "redemptionCode"
+          AttributeType: "S"
+      BillingMode: "PAY_PER_REQUEST"
+      KeySchema:
+        - AttributeName: "redemptionCode"
+          KeyType: "HASH"
+      TableName: !Sub redemption-codes-${Stage}
+Outputs:
+  PreviewDynamoArnOut:
+    Description: ARN for dynamo table
+    Value: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${RedemptionCodeDynamoTable}
+    Export:
+      Name: !Sub ${AWS::StackName}-DynamoTableArn

--- a/support-redemptiondb/riff-raff.yaml
+++ b/support-redemptiondb/riff-raff.yaml
@@ -1,0 +1,8 @@
+stacks: [support]
+regions: [eu-west-1]
+deployments:
+  cfn:
+    app: support-redemptiondb
+    type: cloud-formation
+    parameters:
+      templatePath: cfn.yaml

--- a/support-redemptiondb/riff-raff.yaml
+++ b/support-redemptiondb/riff-raff.yaml
@@ -2,7 +2,7 @@ stacks: [support]
 regions: [eu-west-1]
 deployments:
   cfn:
-    app: support-redemptiondb
+    app: redemptiondb
     type: cloud-formation
     parameters:
       templatePath: cfn.yaml


### PR DESCRIPTION
## Why are you doing this?

For various forms of redemption e.g. gifting/corporate we want a db to store the codes so we can keep track of which codes exist (and possibly other data such as which product and how many licences in total.
The tables have the code as the primary key, and can have further data as needed, probably total available redemptions, and possibly a cache of active code usage from zuora (so we can still check whether any codes are available independently of zuora being up)

[**Trello Card**](https://trello.com/c/lZcb6e4F/3049-create-data-store-for-corporate-codes)
