### PR TITLE
use separated event model/event client

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -55,7 +55,8 @@ lazy val commonSettings = Seq(
 
 lazy val commonDependencies = Seq(
   "com.typesafe" % "config" % "1.3.2",
-  "org.scalatest" %% "scalatest" % "3.2.0-M1" % "it, test"
+  "org.scalatest" %% "scalatest" % "3.2.0-M1" % "it, test",
+  "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"
 )
 
 lazy val root = (project in file("."))

--- a/project/LibraryVersions.scala
+++ b/project/LibraryVersions.scala
@@ -5,4 +5,5 @@ object LibraryVersions {
   val catsVersion = "1.4.0"
   val jacksonVersion = "2.10.1"
   val okhttpVersion = "3.10.0"
+  val scalaUriVersion = "2.2.2"
 }

--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -20,6 +20,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-stepfunctions" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-sts" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-s3" % awsClientVersion,
+  "com.amazonaws" % "aws-java-sdk-lambda" % awsClientVersion,
   "org.typelevel" %% "cats-core" % "1.0.1",
   "com.dripower" %% "play-circe" % "2609.1",
   "com.gu" %% "fezziwig" % "1.3",

--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -1,4 +1,5 @@
 import SeleniumTestConfig._
+import LibraryVersions._
 
 version := "1.0-SNAPSHOT"
 
@@ -7,8 +8,6 @@ packageSummary := "Support Play APP"
 testOptions in SeleniumTest := Seq(Tests.Filter(seleniumTestFilter))
 
 testOptions in Test := Seq(Tests.Filter(unitTestFilter))
-
-import LibraryVersions.{circeVersion, awsClientVersion, jacksonVersion}
 
 resolvers += "Guardian Platform Bintray" at "https://dl.bintray.com/guardian/platforms"
 
@@ -32,7 +31,7 @@ libraryDependencies ++= Seq(
   "com.gu.identity" %% "identity-auth-play" % "3.195",
   "com.gu" %% "identity-test-users" % "0.6",
   "com.google.guava" % "guava" % "25.0-jre",
-  "io.lemonlabs" %% "scala-uri" % "2.2.0",
+  "io.lemonlabs" %% "scala-uri" % scalaUriVersion,
   "com.gu" %% "play-googleauth" % "0.7.6",
   "io.github.bonigarcia" % "webdrivermanager" % "3.3.0" % "test",
   "org.seleniumhq.selenium" % "selenium-java" % "3.8.1" % "test",

--- a/support-models/build.sbt
+++ b/support-models/build.sbt
@@ -5,8 +5,8 @@ name := "support-models"
 description := "Scala library to provide shared step-function models to Guardian Support projects."
 
 libraryDependencies ++= Seq(
-  "com.gu" %% "acquisition-event-producer-play26" % "4.0.27", //this should really be split into models and producer
-                                                              // so we don't have to pull in thrift binary compression libs etc
+  "com.gu" %% "acquisition-event-models-play26" % "4.0.29-SNAPSHOT",
+  "joda-time" % "joda-time" % "2.10.1",
   "org.typelevel" %% "cats-core" % catsVersion,
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,

--- a/support-models/build.sbt
+++ b/support-models/build.sbt
@@ -5,7 +5,7 @@ name := "support-models"
 description := "Scala library to provide shared step-function models to Guardian Support projects."
 
 libraryDependencies ++= Seq(
-  "com.gu" %% "acquisition-event-models-play26" % "4.0.29-SNAPSHOT",
+  "com.gu" %% "acquisition-event-models-play26" % "4.0.29",
   "joda-time" % "joda-time" % "2.10.1",
   "org.typelevel" %% "cats-core" % catsVersion,
   "io.circe" %% "circe-core" % circeVersion,

--- a/support-workers/build.sbt
+++ b/support-workers/build.sbt
@@ -38,7 +38,8 @@ libraryDependencies ++= Seq(
   "org.scala-stm" %% "scala-stm" % "0.8",
   "io.sentry" % "sentry-logback" % "1.7.4",
   "com.google.code.findbugs" % "jsr305" % "3.0.2",
-  "com.gocardless" % "gocardless-pro" % "2.8.0"
+  "com.gocardless" % "gocardless-pro" % "2.8.0",
+  "com.gu" %% "acquisition-event-client-play26" % "4.0.29-SNAPSHOT"
 )
 
 riffRaffPackageType := assembly.value

--- a/support-workers/build.sbt
+++ b/support-workers/build.sbt
@@ -14,12 +14,12 @@ setupGitHook := {
 
 libraryDependencies ++= Seq(
   "org.joda" % "joda-convert" % "2.0.1",
-  "org.typelevel" %% "cats" % "0.9.0",
+  "org.typelevel" %% "cats-core" % catsVersion,
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.0",
   "ch.qos.logback" % "logback-classic" % "1.2.3",
   "io.symphonia" % "lambda-logging" % "1.0.1",
   "com.squareup.okhttp3" % "okhttp" % okhttpVersion,
-  "io.lemonlabs" %% "scala-uri" % "1.5.1",
+  "io.lemonlabs" %% "scala-uri" % scalaUriVersion,
   "com.amazonaws" % "aws-java-sdk-s3" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-sqs" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-stepfunctions" % awsClientVersion,

--- a/support-workers/build.sbt
+++ b/support-workers/build.sbt
@@ -39,7 +39,7 @@ libraryDependencies ++= Seq(
   "io.sentry" % "sentry-logback" % "1.7.4",
   "com.google.code.findbugs" % "jsr305" % "3.0.2",
   "com.gocardless" % "gocardless-pro" % "2.8.0",
-  "com.gu" %% "acquisition-event-client-play26" % "4.0.29-SNAPSHOT"
+  "com.gu" %% "acquisition-event-client-play26" % "4.0.29"
 )
 
 riffRaffPackageType := assembly.value


### PR DESCRIPTION
## Why are you doing this?

See https://github.com/guardian/acquisition-event-producer/pull/62

[**Trello Card**](https://trello.com/c/PXslLgrv/3060-split-up-acquisition-event-producer-to-reduce-jar-sizes)
