### PR TITLE
Switch off Loqate test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -72,7 +72,7 @@ export const tests: Tests = {
         size: 1,
       },
     },
-    isActive: true,
+    isActive: false,
     referrerControlled: false,
     seed: 3,
     targetPage: digitalCheckout,


### PR DESCRIPTION
## Why are you doing this?
Our trial period with Loqate has finished and the test was inconclusive so we are turning it off.