### PR TITLE
Fix isRemote handling - is a boolean

### DIFF
--- a/support-frontend/assets/helpers/abTests/__tests__/abtestTest.js
+++ b/support-frontend/assets/helpers/abTests/__tests__/abtestTest.js
@@ -384,6 +384,25 @@ describe('basic behaviour of init', () => {
     deleteCookie();
   });
 
+  it('Does not allocate a locally rendered epic user into the ContributionsService AB test', () => {
+    const url = `/test.html?acquisitionData=${encodeURI(JSON.stringify(acquisitionDataMockTestControl))}`;
+    window.history.pushState({}, 'Test Title', url);
+
+    const participations: Participations = abInit('GB', GBPCountries, emptySettings, {});
+
+    expect(participations.ContributionsService).toBe(undefined);
+  });
+
+  it('Allocates a remotely rendered epic user into the ContributionsService AB test', () => {
+    const data = { isRemote: true, ...acquisitionDataMockTestControl };
+    const url = `/test.html?acquisitionData=${encodeURI(JSON.stringify(data))}`;
+    window.history.pushState({}, 'Test Title', url);
+
+    const participations: Participations = abInit('GB', GBPCountries, emptySettings, {});
+
+    expect(participations.ContributionsService).toBe('remote');
+  });
+
 });
 
 describe('Correct allocation in a multi test environment', () => {

--- a/support-frontend/assets/helpers/abTests/abtest.js
+++ b/support-frontend/assets/helpers/abTests/abtest.js
@@ -146,7 +146,7 @@ function getIsRemoteFromAcquisitionData(): boolean {
 
   try {
     const data = JSON.parse(queryString);
-    return data ? data.isRemote === 'true' : false;
+    return data && !!data.isRemote;
   } catch {
     console.error('Cannot parse acquisition data from query string');
     return false;


### PR DESCRIPTION
## Why are you doing this?

This is a fix for https://github.com/guardian/support-frontend/pull/2480.

The actual query param (once JSONified) looks like:

`{..."isRemote":true}`

