### PR TITLE
Fix indent of faqs and reinstate terms on DS landing page

### DIFF
--- a/support-frontend/assets/components/content/content.scss
+++ b/support-frontend/assets/components/content/content.scss
@@ -154,11 +154,6 @@
   margin: 0;
 }
 
-.component-content__narrowContent,
-.component-content .component-text {
-  @include narrow-content;
-}
-
 // ----- Vertical rhythm ------ //
 
 .component-content {

--- a/support-frontend/assets/components/footer/footer.scss
+++ b/support-frontend/assets/components/footer/footer.scss
@@ -9,7 +9,6 @@
 .component-content.component-content--feature.component-content--faqs {
   .component-content__content {
     padding-top: 6px;
-    max-width: gu-span(8);
   }
 }
 

--- a/support-frontend/assets/components/subscriptionFaq/subscriptionFaq.jsx
+++ b/support-frontend/assets/components/subscriptionFaq/subscriptionFaq.jsx
@@ -26,32 +26,13 @@ function faqLink(props: PropTypes) {
 // ----- Component ----- //
 
 function SubscriptionFaq(props: PropTypes) {
-
-  switch (props.subscriptionProduct) {
-    case 'DigitalPack':
-      return (
-        <div className="component-subscription-faq">
-          <div className="component-subscription-faq__text">
-            You may also find help in our
-            <a className="component-subscription-faq__href" href={faqLink(props)} onClick={sendTrackingEventsOnClick('onward_faq', 'DigitalPack', null)}> Frequently Asked Questions</a> and
-            in the&nbsp;
-            <a className="component-subscription-faq__href" href={subscriptionsTermsLinks.DigitalPack} onClick={sendTrackingEventsOnClick('onward_tos', 'DigitalPack', null)}>
-            Digital Subscription terms and conditions
-            </a>.
-          </div>
-        </div>
-      );
-
-    default:
-      return (
-        <div className="component-subscription-faq">
-          <div className="component-subscription-faq__text">
-            You may also find help in our
-            <a className="component-subscription-faq__href" href={faqLink(props)} onClick={sendTrackingEventsOnClick('onward_faq', props.subscriptionProduct, null)}> Frequently Asked Questions</a>.
-          </div>
-        </div>
-      );
-  }
+  return (
+    <div className="component-subscription-faq">
+      <div className="component-subscription-faq__text">
+        You may also find help in our <a className="component-subscription-faq__href" href={faqLink(props)} onClick={sendTrackingEventsOnClick('onward_faq', props.subscriptionProduct, null)}>Frequently Asked Questions</a>.
+      </div>
+    </div>
+  );
 }
 
 

--- a/support-frontend/assets/components/subscriptionFaq/subscriptionFaq.jsx
+++ b/support-frontend/assets/components/subscriptionFaq/subscriptionFaq.jsx
@@ -3,7 +3,6 @@
 // ----- Imports ----- //
 
 import React from 'react';
-import { subscriptionsTermsLinks } from 'helpers/legal';
 import type { SubscriptionProduct } from 'helpers/subscriptions';
 import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
 

--- a/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLanding.scss
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/digitalSubscriptionLanding.scss
@@ -64,9 +64,6 @@ $teal-green: #006d67;
     padding-left: 0px;
   }
 
-}
-
-.hope-is-power--centered {
   @include mq($from: phablet) {
     padding-left: 20px;
     align-self: center;
@@ -87,6 +84,14 @@ $teal-green: #006d67;
   @include mq($from: leftCol) {
     width: calc(100% - 80px);
     max-width: 80.625rem;
+  }
+}
+
+.component-base-rows.component-base-rows--normal {
+  .component-customer-service {
+    @include mq($from: phablet) {
+      padding-left: 0px;
+    }
   }
 }
 
@@ -1031,7 +1036,8 @@ div.call-to-action__container {
   }
 
   h2, h3, p,
-  .component-subscription-faq__text {
+  .component-subscription-faq__text,
+  .component-subscription-terms-privacy__text {
     max-width: calc(100% - 20px);
 
     @include mq($from: mobileMedium) {

--- a/support-frontend/assets/pages/digital-subscription-landing/components/faqsAndHelp.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/faqsAndHelp.jsx
@@ -17,6 +17,8 @@ import {
   useDotcomContactPage,
 } from 'helpers/dotcomContactPage';
 import SubscriptionFaq from 'components/subscriptionFaq/subscriptionFaq';
+import SubscriptionTermsPrivacy
+  from 'components/legal/subscriptionTermsPrivacy/subscriptionTermsPrivacy';
 
 import 'pages/digital-subscription-landing/components/digitalSubscriptionLanding.scss';
 
@@ -75,6 +77,8 @@ function FaqsAndHelp(props: PropTypes) {
     (
       <div className="hope-is-power__faqs">
         <div className="component-customer-service" id="qa-component-customer-service">
+          <h2>Terms and conditions</h2>
+          <SubscriptionTermsPrivacy subscriptionProduct="DigitalPack" />
           <h2>FAQs and Help</h2>
           <p className="component-customer-service__text">
             {children}

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.scss
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.scss
@@ -19,7 +19,6 @@
 }
 
 .component-content--faqs .component-text {
-  max-width: gu-span(5);
   a {
     white-space: nowrap;
   }


### PR DESCRIPTION
## Why are you doing this?
This fixes some small issues with the indentation of a shared FAQs section in the digital subscriptions landing page and checkout, and reinstates general terms and conditions and privacy info on the landing page.

I've also fixed the incorrect text wrapping mentioned in the footer audit (see link in [trello card](https://trello.com/c/W784hkRq/2979-fix-position-of-faqs-on-desktop-for-product-and-checkout-pages-add-back-tc-privacy-copy-digital)).

## Changes
* Fix broken indentation on DS landing page
* Add general T&Cs and privacy info on DS landing page
* Fix text wrap in print landing page footer

## Screenshot: DS landing page footer
![Screen Shot 2020-05-29 at 17 00 25](https://user-images.githubusercontent.com/16781258/83280183-2e479700-a1ce-11ea-890e-eea776817a50.png)

## Screenshot: print landing page footer
![Screen Shot 2020-05-29 at 16 09 18](https://user-images.githubusercontent.com/16781258/83275248-d22d4480-a1c6-11ea-8dd8-fa98bc09dc3d.png)
