### PR TITLE
get milliseconds into cloudwatch logs

### DIFF
--- a/support-frontend/cloud-formation/cfn.yaml
+++ b/support-frontend/cloud-formation/cfn.yaml
@@ -92,7 +92,7 @@ Resources:
           mkdir /etc/gu
           aws --region ${AWS::Region} s3 cp s3://membership-dist/${Stack}/${Stage}/${App}/support-frontend_1.0-SNAPSHOT_all.deb /tmp
           dpkg -i /tmp/support-frontend_1.0-SNAPSHOT_all.deb
-          /opt/cloudwatch-logs/configure-logs application ${Stack} ${Stage} ${App} /var/log/support-frontend/application.log
+          /opt/cloudwatch-logs/configure-logs application ${Stack} ${Stage} ${App} /var/log/support-frontend/application.log '%Y-%m-%dT%H:%M:%S,%f%z'
   AppRole:
     Type: AWS::IAM::Role
     Properties:

--- a/support-frontend/conf/logback.xml
+++ b/support-frontend/conf/logback.xml
@@ -19,7 +19,7 @@
     </rollingPolicy>
 
     <encoder>
-        <pattern>%date{"yyyy-MM-dd'T'HH:mm:ss,SSSXXX", UTC} [%thread] %-5level %logger{36} - %msg%n%xException</pattern>
+        <pattern>%date{"yyyy-MM-dd'T'HH:mm:ss,SSSZ", UTC} [%thread] %-5level %logger{36} - %msg%n%xException</pattern>
     </encoder>
 </appender>
 

--- a/support-frontend/conf/logback.xml
+++ b/support-frontend/conf/logback.xml
@@ -19,7 +19,7 @@
     </rollingPolicy>
 
     <encoder>
-        <pattern>{"yyyy-MM-dd'T'HH:mm:ss,SSSXXX", UTC} [%thread] %-5level %logger{36} - %msg%n%xException</pattern>
+        <pattern>%date{"yyyy-MM-dd'T'HH:mm:ss,SSSXXX", UTC} [%thread] %-5level %logger{36} - %msg%n%xException</pattern>
     </encoder>
 </appender>
 

--- a/support-frontend/conf/logback.xml
+++ b/support-frontend/conf/logback.xml
@@ -19,7 +19,7 @@
     </rollingPolicy>
 
     <encoder>
-        <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException</pattern>
+        <pattern>{"yyyy-MM-dd'T'HH:mm:ss,SSSXXX", UTC} [%thread] %-5level %logger{36} - %msg%n%xException</pattern>
     </encoder>
 </appender>
 


### PR DESCRIPTION
## Why are you doing this?

The cloudwatch logs don't have the millis part, so often sometimes the log messages are out of order.  Seems cloudwatch can mostly make sense of the timestamp apart from that, and assumes UTC.

![image](https://user-images.githubusercontent.com/7304387/83412951-e8c7db80-a412-11ea-8f2e-cca799b018f5.png)

This PR makes sure it's all explicit including the millis.
![image](https://user-images.githubusercontent.com/7304387/83413053-16ad2000-a413-11ea-85ef-7951cbb92913.png)

