### PR TITLE
removes Jervis Bay territory as option on AUS state picker, per reque…

### DIFF
--- a/support-frontend/assets/helpers/internationalisation/country.js
+++ b/support-frontend/assets/helpers/internationalisation/country.js
@@ -104,7 +104,6 @@ const auStates: {
   [string]: string,
 } = {
   ACT: 'Australian Capital Territory',
-  JBT: 'Jervis Bay Territory',
   NSW: 'New South Wales',
   NT: 'Northern Territory',
   QLD: 'Queensland',

--- a/support-internationalisation/src/main/scala/com/gu/i18n/Country.scala
+++ b/support-internationalisation/src/main/scala/com/gu/i18n/Country.scala
@@ -107,7 +107,6 @@ object Country {
       "QLD" -> "Queensland",
       "ACT" -> "Australian Capital Territory",
       "NT" -> "Northern Territory",
-      "JBT" -> "Jervis Bay Territory",
     ).toMap
   )
 


### PR DESCRIPTION
Removes Jervis Bay Territory from the Australia state dropdown menu, per a request from the Aus team. Please see [this Trello card](https://trello.com/c/7BiiyXHC) for more details.

Screenshot
<img width="1440" alt="Screenshot 2020-06-01 at 15 29 25" src="https://user-images.githubusercontent.com/25020231/83419543-20d41c00-a41d-11ea-9788-8e14323b1d8e.png">
