### PR TITLE
Twitter Preview Card

### DIFF
--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -153,6 +153,9 @@ class Application(
     val classes = "gu-content--contribution-form--placeholder" +
       campaignCode.map(code => s" gu-content--campaign-landing gu-content--$code").getOrElse("")
 
+    val shareImageUrl =
+      "https://i.guim.co.uk/img/media/74b15a65c479bfe53151fceeb7d948f125a66af2/0_0_2400_1260/1000.png?quality=85&s=4b52891c0a86da6c08f2dc6e8308d211"
+
     val mainElement = assets.getSsrCacheContentsAsHtml(
       divId = s"contributions-landing-page-$countryCode",
       file = "contributions-landing.html",
@@ -183,7 +186,7 @@ class Application(
       guestAccountCreationToken = guestAccountCreationToken,
       fontLoaderBundle = fontLoaderBundle,
       geoData = geoData,
-      shareImageUrl = "https://media.guim.co.uk/74b15a65c479bfe53151fceeb7d948f125a66af2/0_0_2400_1260/1000.png",
+      shareImageUrl = shareImageUrl,
       shareUrl = "https://support.theguardian.com/contribute",
       v2recaptchaConfigPublicKey = recaptchaConfigProvider.v2PublicKey
     )

--- a/support-frontend/app/views/main.scala.html
+++ b/support-frontend/app/views/main.scala.html
@@ -43,7 +43,7 @@
     }
 
     @shareImageUrl.map { imageUrl =>
-      <meta property="twitter:card" content="@imageUrl" />
+      <meta property="twitter:image" content="@imageUrl" />
       <meta property="og:image" content="@imageUrl" />
       <meta property="og:image:secure_url" content="@imageUrl" />
     }

--- a/support-frontend/app/views/main.scala.html
+++ b/support-frontend/app/views/main.scala.html
@@ -43,7 +43,7 @@
     }
 
     @shareImageUrl.map { imageUrl =>
-      <meta property="twitter:image" content="@imageUrl" />
+      <meta property="twitter:card" content="@imageUrl" />
       <meta property="og:image" content="@imageUrl" />
       <meta property="og:image:secure_url" content="@imageUrl" />
     }

--- a/support-frontend/app/views/main.scala.html
+++ b/support-frontend/app/views/main.scala.html
@@ -33,7 +33,7 @@
     }
 
     <meta property="og:type" content="website" />
-    <meta property="twitter:card" content="summary" />
+    <meta property="twitter:card" content="summary_large_image" />
     <meta property="fb:app_id" content="180444840287" />
 
 

--- a/support-frontend/public/robots.txt
+++ b/support-frontend/public/robots.txt
@@ -8,5 +8,6 @@ Disallow: /int/subscribe/premium-tier
 Disallow: /contribute/recurring-guest
 
 Allow: /
+Allow: https://media.guim.co.uk/74b15a65c479bfe53151fceeb7d948f125a66af2/0_0_2400_1260/1000.png
 
 Sitemap: https://support.theguardian.com/sitemap.xml

--- a/support-frontend/public/robots.txt
+++ b/support-frontend/public/robots.txt
@@ -8,6 +8,5 @@ Disallow: /int/subscribe/premium-tier
 Disallow: /contribute/recurring-guest
 
 Allow: /
-Allow: https://media.guim.co.uk/74b15a65c479bfe53151fceeb7d948f125a66af2/0_0_2400_1260/1000.png
 
 Sitemap: https://support.theguardian.com/sitemap.xml


### PR DESCRIPTION
## Why are you doing this?

The tweet site preview was broken due to some changes in the way twitter works.

https://trello.com/c/7bR9ExNI/2088-enable-displaying-the-guardian-image-when-sharing-https-supporttheguardiancom-contribute-page-on-twitter
<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com)

## Changes

* Image loaded from i.guim domain as this is accessible for twitter bots to read from
* Using large format card


## Screenshots
![image](https://user-images.githubusercontent.com/30600967/83750561-6121dd00-a65d-11ea-956f-12f1d1f3139a.png)

