### PR TITLE
Mj landing page aus moment ab test

### DIFF
--- a/support-frontend/Brewfile.lock.json
+++ b/support-frontend/Brewfile.lock.json
@@ -25,22 +25,22 @@
     "brew": {
       "guardian/devtools/dev-nginx": null,
       "awscli": {
-        "version": "2.0.10",
+        "version": "2.0.19",
         "bottle": {
           "cellar": "/usr/local/Cellar",
           "prefix": "/usr/local",
           "files": {
             "catalina": {
-              "url": "https://homebrew.bintray.com/bottles/awscli-2.0.10.catalina.bottle.tar.gz",
-              "sha256": "05bd63ee4669aac00204a4606273875654655efe37a40bbfe0f4c5cc3f7b069d"
+              "url": "https://homebrew.bintray.com/bottles/awscli-2.0.19.catalina.bottle.tar.gz",
+              "sha256": "01440c5c930f7359393dac61df4654c08ebd50b8e75a9236afc9443a114d1be9"
             },
             "mojave": {
-              "url": "https://homebrew.bintray.com/bottles/awscli-2.0.10.mojave.bottle.tar.gz",
-              "sha256": "4ddd6d30c56eee7991cf14069d97d70896959f01c05a22782aabe861da3f7e62"
+              "url": "https://homebrew.bintray.com/bottles/awscli-2.0.19.mojave.bottle.tar.gz",
+              "sha256": "f52319e5e2fa4574710a24ae0fb142dc8b69a0e1d62f5b08f85d0bf47e32da36"
             },
             "high_sierra": {
-              "url": "https://homebrew.bintray.com/bottles/awscli-2.0.10.high_sierra.bottle.tar.gz",
-              "sha256": "004bfcc8b0f71d49ac7ae1764191faefe9c91eaa3fe2c11d5baaec957e445889"
+              "url": "https://homebrew.bintray.com/bottles/awscli-2.0.19.high_sierra.bottle.tar.gz",
+              "sha256": "ab9215620e96017257a88a0fbfeaeaba898bdaca0885c2afef1608daea3fdb35"
             }
           }
         }
@@ -54,9 +54,9 @@
   "system": {
     "macos": {
       "mojave": {
-        "HOMEBREW_VERSION": "2.2.14-31-gcdae58f",
+        "HOMEBREW_VERSION": "2.3.0-63-g92fc47b",
         "HOMEBREW_PREFIX": "/usr/local",
-        "Homebrew/homebrew-core": "433cedc2bd5e83f07ea826fefc90685dbb11a4b6",
+        "Homebrew/homebrew-core": "a5f631c198aefdebe4900a8969f43c452a278bca",
         "CLT": "10.3.0.0.1.1562985497",
         "Xcode": "11.3.1",
         "macOS": "10.14.6"

--- a/support-frontend/assets/components/page/page.jsx
+++ b/support-frontend/assets/components/page/page.jsx
@@ -18,6 +18,7 @@ type PropTypes = {|
   children: Node,
   classModifiers: Array<?string>,
   backgroundImageSrc: ?string,
+  isAusMomentVariant: boolean,
 |};
 
 
@@ -34,7 +35,13 @@ export default function Page(props: PropTypes) {
     <div id={props.id} className={classNameWithModifiers('gu-content', props.classModifiers)}>
       <TimeTravelBanner />
       {props.header}
-      <main role="main" className="gu-content__main">
+      <main
+        role="main"
+        className={props.isAusMomentVariant
+          ? 'gu-content__main aus-moment'
+          : 'gu-content__main'
+        }
+      >
         {backgroundImage}
         {props.children}
       </main>
@@ -52,4 +59,5 @@ Page.defaultProps = {
   footer: null,
   classModifiers: [],
   backgroundImageSrc: null,
+  isAusMomentVariant: false,
 };

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -5,9 +5,11 @@ import { USV1 } from './data/testAmountsData';
 // ----- Tests ----- //
 export type StripePaymentRequestButtonTestVariants = 'control' | 'button';
 export type LandingPageDesignSystemTestVariants = 'control' | 'ds';
+export type AusMomentLandingPageBackgroundVariants = 'control' | 'stripes';
 
 const contributionsLandingPageMatch = '/(uk|us|eu|au|ca|nz|int)/contribute(/.*)?$';
 const usOnlyLandingPage = '/us/contribute(/.*)?$';
+const auOnlyLandingPage = '/au/contribute(/.*)?$';
 export const subsShowcaseAndDigiSubPages = '(/??/subscribe(\\?.*)?$|/??/subscribe/digital(\\?.*)?$)';
 const digitalCheckout = '/subscribe/digital/checkout';
 
@@ -100,5 +102,27 @@ export const tests: Tests = {
     referrerControlled: false,
     seed: 3,
     targetPage: contributionsLandingPageMatch,
+  },
+
+  ausMomentLandingPageBackgroundTest: {
+    type: 'OTHER',
+    variants: [
+      {
+        id: 'control',
+      },
+      {
+        id: 'stripes',
+      },
+    ],
+    audiences: {
+      ALL: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: false,
+    referrerControlled: false,
+    seed: 3,
+    targetPage: auOnlyLandingPage,
   },
 };

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -5,7 +5,7 @@ import { USV1 } from './data/testAmountsData';
 // ----- Tests ----- //
 export type StripePaymentRequestButtonTestVariants = 'control' | 'button';
 export type LandingPageDesignSystemTestVariants = 'control' | 'ds';
-export type AusMomentLandingPageBackgroundVariants = 'control' | 'stripes';
+export type AusMomentLandingPageBackgroundVariants = 'control' | 'ausColoursVariant';
 
 const contributionsLandingPageMatch = '/(uk|us|eu|au|ca|nz|int)/contribute(/.*)?$';
 const usOnlyLandingPage = '/us/contribute(/.*)?$';
@@ -111,7 +111,7 @@ export const tests: Tests = {
         id: 'control',
       },
       {
-        id: 'stripes',
+        id: 'ausColoursVariant',
       },
     ],
     audiences: {
@@ -122,7 +122,7 @@ export const tests: Tests = {
     },
     isActive: false,
     referrerControlled: false,
-    seed: 3,
+    seed: 6,
     targetPage: auOnlyLandingPage,
   },
 };

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
@@ -33,7 +33,6 @@ import ConsentBanner from 'components/consentBanner/consentBanner';
 import './contributionsLanding.scss';
 import './newContributionsLandingTemplate.scss';
 import { FocusStyleManager } from '@guardian/src-utilities';
-import type { AusMomentLandingPageBackgroundVariants } from 'helpers/abTests/abtestDefinitions';
 
 
 if (!isDetailsSupported) {
@@ -91,8 +90,9 @@ const setOneOffContributionCookie = () => {
 
 const campaignName = getCampaignName();
 
-const ausMomentLandingPageBackgroundVariant = store.getState().common.abParticipations.ausMomentLandingPageBackgroundTest
-const isAusMomentVariant = ausMomentLandingPageBackgroundVariant === 'ausColoursVariant'
+const state = store.getState();
+const ausMomentLandingPageBackgroundVariant = state.common.abParticipations.ausMomentLandingPageBackgroundTest;
+const isAusMomentVariant = ausMomentLandingPageBackgroundVariant === 'ausColoursVariant';
 
 const cssModifiers = campaignName && campaigns[campaignName] && campaigns[campaignName].cssModifiers ?
   campaigns[campaignName].cssModifiers : [];

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
@@ -33,6 +33,7 @@ import ConsentBanner from 'components/consentBanner/consentBanner';
 import './contributionsLanding.scss';
 import './newContributionsLandingTemplate.scss';
 import { FocusStyleManager } from '@guardian/src-utilities';
+import type { AusMomentLandingPageBackgroundVariants } from 'helpers/abTests/abtestDefinitions';
 
 
 if (!isDetailsSupported) {
@@ -90,6 +91,9 @@ const setOneOffContributionCookie = () => {
 
 const campaignName = getCampaignName();
 
+const ausMomentLandingPageBackgroundVariant = store.getState().common.abParticipations.ausMomentLandingPageBackgroundTest
+const isAusMomentVariant = ausMomentLandingPageBackgroundVariant === 'ausColoursVariant'
+
 const cssModifiers = campaignName && campaigns[campaignName] && campaigns[campaignName].cssModifiers ?
   campaigns[campaignName].cssModifiers : [];
 
@@ -104,6 +108,7 @@ const contributionsLandingPage = (campaignCodeParameter: ?string) => (
     header={<RoundelHeader selectedCountryGroup={selectedCountryGroup} />}
     footer={<Footer disclaimer countryGroupId={countryGroupId} />}
     backgroundImageSrc={backgroundImageSrc}
+    isAusMomentVariant={isAusMomentVariant}
   >
     <ContributionFormContainer
       thankYouRoute={`/${countryGroups[countryGroupId].supportInternationalisationId}/thankyou`}

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.scss
@@ -47,6 +47,16 @@ body {
   background-color: gu-colour(sport-faded);
 }
 
+.gu-content__main.aus-moment {
+  position: relative;
+  background: linear-gradient(
+      #FFE500 50%,
+      #F3C100 50%,
+      #F3C100 80%,
+      #FF7F0F 80%
+  ) !important;
+}
+
 /*= HEADER */
 
 header[role="banner"] {

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.scss
@@ -57,6 +57,11 @@ body {
   ) !important;
 }
 
+// This selects div.gu-content__blurb and overrides the default sticky positioning
+.gu-content__main.aus-moment > :first-child > :first-child {
+  position: static !important;
+}
+
 /*= HEADER */
 
 header[role="banner"] {

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.scss
@@ -57,8 +57,7 @@ body {
   ) !important;
 }
 
-// This selects div.gu-content__blurb and overrides the default sticky positioning
-.gu-content__main.aus-moment > :first-child > :first-child {
+.gu-content__main.aus-moment > .gu-content__content > .gu-content__blurb {
   position: static !important;
 }
 

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -1925,6 +1925,11 @@
   resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-0.18.1.tgz#b49f74c650eccaf33c05413e0c192102dc939ad0"
   integrity sha512-745xKtD818+dkHxoROgL+0y3NWIUaMBUxZWEa6cNOlDBgU/oj2WrNSVAEKojMiwii2AA5GODXxFfoSNXyVWZUg==
 
+"@guardian/src-foundations@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-1.1.0.tgz#1955a3933c3aecfae46d4688a43f331866386b94"
+  integrity sha512-XGZSbHuHf20kewajdIAOPk7jb6mB6+wPYFj+CUuKcEPXXjNLQ4K5WVIzu0xQ9Fa5aO1wG/s0ek0ii9KbpDcbNA==
+
 "@guardian/src-helpers@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@guardian/src-helpers/-/src-helpers-0.14.0.tgz#9999aa24074060373b079eb37ca9768d47e277c3"
@@ -1946,6 +1951,13 @@
   dependencies:
     "@guardian/src-foundations" "^0.18.1"
 
+"@guardian/src-helpers@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/src-helpers/-/src-helpers-1.1.0.tgz#6fe6843835f51fe86aeb5fb4566a673de2a61d91"
+  integrity sha512-+TVCJ4wvDAcGk/eS66aUzsrna/7KvIno8XDFvzrkqdI2S2GLIpZpc7e6H65d4CCH6ib/HLoNd/xx5/BFKVWcYw==
+  dependencies:
+    "@guardian/src-foundations" "^1.1.0"
+
 "@guardian/src-inline-error@^0.17.0":
   version "0.17.0"
   resolved "https://registry.yarnpkg.com/@guardian/src-inline-error/-/src-inline-error-0.17.0.tgz#fb31aca092bd7e2033e4c82887c5a24122b7bfc8"
@@ -1961,6 +1973,14 @@
   dependencies:
     "@guardian/src-helpers" "^0.18.1"
     "@guardian/src-svgs" "^0.18.1"
+
+"@guardian/src-inline-error@^1.0.1":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/src-inline-error/-/src-inline-error-1.1.0.tgz#5b04c24b0fa115855b085d4ec3b70952c5e5de43"
+  integrity sha512-jtnkBtxGWlQklo5BfwOHX7gnfcDqpnjbHE9Vv8tYMMWMgmEefLUI+/qQbZs3M1KpQ2/Of2qRIZoWyrxUTyM4Sw==
+  dependencies:
+    "@guardian/src-helpers" "^1.1.0"
+    "@guardian/src-svgs" "^1.1.0"
 
 "@guardian/src-radio@^0.18.1":
   version "0.18.1"
@@ -1980,6 +2000,11 @@
   version "0.18.1"
   resolved "https://registry.yarnpkg.com/@guardian/src-svgs/-/src-svgs-0.18.1.tgz#c0935fc54cb30db78a9f59e2292328fe88637663"
   integrity sha512-2IVZRWrpwq51yHSABMMQzHwu3IHtd1wurCV0Mc6Z8Eyo02J+BB8oxU3yFI4dEJ3ChQWpKPChuLZscar9eGUsxA==
+
+"@guardian/src-svgs@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@guardian/src-svgs/-/src-svgs-1.1.0.tgz#de52c09359f8b5122e652f35a9c1b8a4402560b4"
+  integrity sha512-24S1S9spRGtz50OMJ0gOGXSYIuoqM7wme+yaYVvCav/ppcrpB1yU49tfqgkWZmo4VUf8BlW8CTEWjm0cO0H3SQ==
 
 "@guardian/src-text-input@^0.17.0":
   version "0.17.0"


### PR DESCRIPTION
This PR sets-up an A/B test for use during the Aus moment. The variant shows Aus moment colours on the background of the contribs landing page. Please see [this Trello card](https://trello.com/c/xxSSnIp8) for more details.

**Tablet**
<img width="394" alt="Screenshot 2020-06-08 at 09 18 44" src="https://user-images.githubusercontent.com/25020231/84010565-bd8e4080-a96c-11ea-99ec-3a8900e25173.png">
<br>
**13" Laptop**
<br>
*Top*
<img width="1440" alt="1" src="https://user-images.githubusercontent.com/25020231/84012278-3a221e80-a96f-11ea-8675-b69fa41eb8ff.png">
<br>
*Bottom*
<img width="1440" alt="2" src="https://user-images.githubusercontent.com/25020231/84012296-4017ff80-a96f-11ea-8c88-1f85a5b044ec.png">
