### PR TITLE
Mj aus moment thank you page

### DIFF
--- a/support-frontend/Brewfile.lock.json
+++ b/support-frontend/Brewfile.lock.json
@@ -54,9 +54,9 @@
   "system": {
     "macos": {
       "mojave": {
-        "HOMEBREW_VERSION": "2.3.0-63-g92fc47b",
+        "HOMEBREW_VERSION": "2.3.0-65-g82e3dea",
         "HOMEBREW_PREFIX": "/usr/local",
-        "Homebrew/homebrew-core": "a5f631c198aefdebe4900a8969f43c452a278bca",
+        "Homebrew/homebrew-core": "3704ee2b2c516b58c669d7e057b88ca322fc26b5",
         "CLT": "10.3.0.0.1.1562985497",
         "Xcode": "11.3.1",
         "macOS": "10.14.6"

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -110,6 +110,7 @@
   }
 
   window.guardian.forceCampaign = @settings.switches.experiments.get("forceCampaign").exists(_.isOn)
+  window.guardian.ausMomentEnabled = @settings.switches.experiments.get("ausMomentEnabled").exists(_.isOn)
 
   window.guardian.recaptchaEnabled = @settings.switches.enableRecaptchaFrontend.isOn
   window.guardian.v2recaptchaPublicKey = "@v2recaptchaConfigPublicKey"

--- a/support-frontend/assets/components/spreadTheWord/ausMomentSpreadTheWord.jsx
+++ b/support-frontend/assets/components/spreadTheWord/ausMomentSpreadTheWord.jsx
@@ -1,0 +1,28 @@
+// @flow
+
+// ----- Imports ----- //
+
+import React from 'react';
+import SocialShare from 'components/socialShare/socialShare';
+
+
+// ----- Component ----- //
+
+export default function AusMomentSpreadTheWord() {
+  const title = 'Share your support';
+  const message = 'We need more people like you. Invite your friends, family and colleagues in Australia and beyond to support the Guardian. We’ll email you to let you know if one or more people make a contribution from your post or message. You’re doing something powerful to help sustain our open, independent journalism – thank you.';
+
+  return (
+    <div className="contribution-thank-you-block">
+      <h3 className="contribution-thank-you-block__title">{title}</h3>
+      <p className="contribution-thank-you-block__message">{message}</p>
+      <div className="component-spread-the-word__share">
+        <SocialShare name="facebook" />
+        <SocialShare name="twitter" />
+        <SocialShare name="linkedin" />
+        <SocialShare name="email" />
+      </div>
+    </div>
+  );
+
+}

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
@@ -178,7 +178,7 @@ function ContributionThankYou(props: PropTypes) {
     return null;
   };
 
-  const ausMomentEnabled = window.guardian.ausMomentEnabled
+  const ausMomentEnabled = window.guardian.ausMomentEnabled || false;
   const showRecurringMessage = props.contributionType !== 'ONE_OFF' && props.paymentComplete;
 
   return (

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
@@ -27,8 +27,6 @@ import TrackableButton from 'components/button/trackableButton';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import AusMomentSpreadTheWord from 'components/spreadTheWord/ausMomentSpreadTheWord';
-import { init as pageInit } from 'helpers/page/page';
-import { initReducer } from 'pages/contributions-landing/contributionsLandingReducer';
 
 // ----- Types ----- //
 
@@ -180,10 +178,7 @@ function ContributionThankYou(props: PropTypes) {
     return null;
   };
 
-  const store = pageInit(() => initReducer(), true);
-  const state = store.getState();
-  const { countryId } = state.common.internationalisation;
-  const ausMomentEnabled = window.guardian.ausMomentEnabled && countryId === 'AU';
+  const ausMomentEnabled = window.guardian.ausMomentEnabled && props.countryId === 'AU';
 
   const showRecurringMessage = props.contributionType !== 'ONE_OFF' && props.paymentComplete;
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
@@ -27,6 +27,8 @@ import TrackableButton from 'components/button/trackableButton';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import AusMomentSpreadTheWord from 'components/spreadTheWord/ausMomentSpreadTheWord';
+import { init as pageInit } from 'helpers/page/page';
+import { initReducer } from 'pages/contributions-landing/contributionsLandingReducer';
 
 // ----- Types ----- //
 
@@ -178,7 +180,11 @@ function ContributionThankYou(props: PropTypes) {
     return null;
   };
 
-  const ausMomentEnabled = window.guardian.ausMomentEnabled || false;
+  const store = pageInit(() => initReducer(), true);
+  const state = store.getState();
+  const { countryId } = state.common.internationalisation;
+  const ausMomentEnabled = window.guardian.ausMomentEnabled && countryId === 'AU';
+
   const showRecurringMessage = props.contributionType !== 'ONE_OFF' && props.paymentComplete;
 
   return (

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
@@ -26,6 +26,7 @@ import {
 import TrackableButton from 'components/button/trackableButton';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import AusMomentSpreadTheWord from 'components/spreadTheWord/ausMomentSpreadTheWord';
 
 // ----- Types ----- //
 
@@ -177,6 +178,7 @@ function ContributionThankYou(props: PropTypes) {
     return null;
   };
 
+  const ausMomentEnabled = window.guardian.ausMomentEnabled
   const showRecurringMessage = props.contributionType !== 'ONE_OFF' && props.paymentComplete;
 
   return (
@@ -189,10 +191,11 @@ function ContributionThankYou(props: PropTypes) {
             </h3>
           </section>
         ) : null}
+        { ausMomentEnabled && <AusMomentSpreadTheWord /> }
         { renderIdentityCTA() }
         <ContributionSurvey isRunning countryGroupId={props.countryGroupId} />
         <MarketingConsent />
-        <SpreadTheWord />
+        { !ausMomentEnabled && <SpreadTheWord /> }
         <div className="gu-content__return-link">
           <AnchorButton
             href="https://www.theguardian.com"

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouPasswordSet.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouPasswordSet.jsx
@@ -11,6 +11,8 @@ import SpreadTheWord from 'components/spreadTheWord/spreadTheWord';
 import ContributionSurvey from '../ContributionSurvey/ContributionsSurvey';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import AusMomentSpreadTheWord from 'components/spreadTheWord/ausMomentSpreadTheWord';
+import { init as pageInit } from 'helpers/page/page';
+import { initReducer } from 'pages/contributions-landing/contributionsLandingReducer';
 
 // ----- Types ----- //
 type PropTypes = {
@@ -19,7 +21,11 @@ type PropTypes = {
 
 // ----- Render ----- //
 function ContributionThankYouPasswordSet(props: PropTypes) {
-  const ausMomentEnabled = window.guardian.ausMomentEnabled || false;
+  const store = pageInit(() => initReducer(), true);
+  const state = store.getState();
+  const { countryId } = state.common.internationalisation;
+  const ausMomentEnabled = window.guardian.ausMomentEnabled && countryId === 'AU';
+
   const title = 'You now have a Guardian account';
   const body = 'Please check your inbox to validate your email address – it only takes a minute. And then sign in on each of the devices you use to access The Guardian.';
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouPasswordSet.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouPasswordSet.jsx
@@ -12,18 +12,12 @@ import ContributionSurvey from '../ContributionSurvey/ContributionsSurvey';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import AusMomentSpreadTheWord from 'components/spreadTheWord/ausMomentSpreadTheWord';
 import type { IsoCountry } from 'helpers/internationalisation/country';
-import { connect } from 'react-redux';
 
 // ----- Types ----- //
 type PropTypes = {
   countryId: IsoCountry,
   countryGroupId: CountryGroupId
 }
-
-const mapStateToProps = state => ({
-  countryId: state.common.internationalisation.countryId,
-  countryGroupId: state.common.internationalisation.countryGroupId,
-});
 
 // ----- Render ----- //
 function ContributionThankYouPasswordSet(props: PropTypes) {
@@ -64,4 +58,4 @@ function ContributionThankYouPasswordSet(props: PropTypes) {
 }
 
 
-export default connect(mapStateToProps)(ContributionThankYouPasswordSet);
+export default ContributionThankYouPasswordSet;

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouPasswordSet.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouPasswordSet.jsx
@@ -11,20 +11,23 @@ import SpreadTheWord from 'components/spreadTheWord/spreadTheWord';
 import ContributionSurvey from '../ContributionSurvey/ContributionsSurvey';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import AusMomentSpreadTheWord from 'components/spreadTheWord/ausMomentSpreadTheWord';
-import { init as pageInit } from 'helpers/page/page';
-import { initReducer } from 'pages/contributions-landing/contributionsLandingReducer';
+import type { IsoCountry } from 'helpers/internationalisation/country';
+import { connect } from 'react-redux';
 
 // ----- Types ----- //
 type PropTypes = {
+  countryId: IsoCountry,
   countryGroupId: CountryGroupId
 }
 
+const mapStateToProps = state => ({
+  countryId: state.common.internationalisation.countryId,
+  countryGroupId: state.common.internationalisation.countryGroupId,
+});
+
 // ----- Render ----- //
 function ContributionThankYouPasswordSet(props: PropTypes) {
-  const store = pageInit(() => initReducer(), true);
-  const state = store.getState();
-  const { countryId } = state.common.internationalisation;
-  const ausMomentEnabled = window.guardian.ausMomentEnabled && countryId === 'AU';
+  const ausMomentEnabled = window.guardian.ausMomentEnabled && props.countryId === 'AU';
 
   const title = 'You now have a Guardian account';
   const body = 'Please check your inbox to validate your email address – it only takes a minute. And then sign in on each of the devices you use to access The Guardian.';
@@ -60,4 +63,5 @@ function ContributionThankYouPasswordSet(props: PropTypes) {
   );
 }
 
-export default ContributionThankYouPasswordSet;
+
+export default connect(mapStateToProps)(ContributionThankYouPasswordSet);

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouPasswordSet.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouPasswordSet.jsx
@@ -10,6 +10,7 @@ import ContributionThankYouBlurb from './ContributionThankYouBlurb';
 import SpreadTheWord from 'components/spreadTheWord/spreadTheWord';
 import ContributionSurvey from '../ContributionSurvey/ContributionsSurvey';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import AusMomentSpreadTheWord from 'components/spreadTheWord/ausMomentSpreadTheWord';
 
 // ----- Types ----- //
 type PropTypes = {
@@ -18,6 +19,7 @@ type PropTypes = {
 
 // ----- Render ----- //
 function ContributionThankYouPasswordSet(props: PropTypes) {
+  const ausMomentEnabled = window.guardian.ausMomentEnabled
   const title = 'You now have a Guardian account';
   const body = 'Please check your inbox to validate your email address – it only takes a minute. And then sign in on each of the devices you use to access The Guardian.';
 
@@ -30,9 +32,10 @@ function ContributionThankYouPasswordSet(props: PropTypes) {
             {body}
           </p>
         </section>
+        { ausMomentEnabled && <AusMomentSpreadTheWord /> }
         <ContributionSurvey isRunning countryGroupId={props.countryGroupId} />
         <MarketingConsent />
-        <SpreadTheWord />
+        { !ausMomentEnabled && <SpreadTheWord /> }
         <div className="gu-content__return-link">
           <AnchorButton
             href="https://www.theguardian.com"

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouPasswordSet.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouPasswordSet.jsx
@@ -19,7 +19,7 @@ type PropTypes = {
 
 // ----- Render ----- //
 function ContributionThankYouPasswordSet(props: PropTypes) {
-  const ausMomentEnabled = window.guardian.ausMomentEnabled
+  const ausMomentEnabled = window.guardian.ausMomentEnabled || false;
   const title = 'You now have a Guardian account';
   const body = 'Please check your inbox to validate your email address – it only takes a minute. And then sign in on each of the devices you use to access The Guardian.';
 

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
@@ -43,12 +43,8 @@ if (!isDetailsSupported) {
 
 const countryGroupId: CountryGroupId = detect();
 
-const thankYouClassModifiers = ['contribution-thankyou'];
-if (window.guardian.ausMomentEnabled) {
-  thankYouClassModifiers.push('aus-moment');
-}
-
 const store = pageInit(() => initReducer(), true);
+const state = store.getState();
 
 if (!window.guardian.polyfillScriptLoaded) {
   gaEvent({
@@ -92,12 +88,17 @@ const setOneOffContributionCookie = () => {
   );
 };
 
-
 const campaignName = getCampaignName();
 
-const state = store.getState();
 const ausMomentLandingPageBackgroundVariant = state.common.abParticipations.ausMomentLandingPageBackgroundTest;
 const isAusMomentVariant = ausMomentLandingPageBackgroundVariant === 'ausColoursVariant';
+const { countryId } = state.common.internationalisation;
+const ausMomentEnabled = window.guardian.ausMomentEnabled && countryId === 'AU';
+
+const thankYouClassModifiers = [
+  'contribution-thankyou',
+  ausMomentEnabled ? 'aus-moment' : null,
+];
 
 const cssModifiers = campaignName && campaigns[campaignName] && campaigns[campaignName].cssModifiers ?
   campaigns[campaignName].cssModifiers : [];

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
@@ -44,7 +44,9 @@ if (!isDetailsSupported) {
 const countryGroupId: CountryGroupId = detect();
 
 const thankYouClassModifiers = ['contribution-thankyou'];
-window.guardian.ausMomentEnabled ? thankYouClassModifiers.push(['aus-moment']) : null
+if (window.guardian.ausMomentEnabled) {
+  thankYouClassModifiers.push('aus-moment');
+}
 
 const store = pageInit(() => initReducer(), true);
 

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
@@ -43,6 +43,9 @@ if (!isDetailsSupported) {
 
 const countryGroupId: CountryGroupId = detect();
 
+const thankYouClassModifiers = ['contribution-thankyou'];
+window.guardian.ausMomentEnabled ? thankYouClassModifiers.push(['aus-moment']) : null
+
 const store = pageInit(() => initReducer(), true);
 
 if (!window.guardian.polyfillScriptLoaded) {
@@ -144,7 +147,7 @@ const router = (
             }
             return (
               <Page
-                classModifiers={['contribution-thankyou']}
+                classModifiers={thankYouClassModifiers}
                 header={<RoundelHeader />}
                 footer={<Footer disclaimer countryGroupId={countryGroupId} />}
               >

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.scss
@@ -42,27 +42,12 @@ body {
   }
 }
 
-.gu-content--contribution-thankyou.gu-content--aus-moment {
-  background: linear-gradient(
-      #FFE500 50%,
-      #F3C100 50%,
-      #F3C100 80%,
-      #FF7F0F 80%
-  ) !important;
-
-  .gu-content__main {
-    position: relative;
-    background-color: transparent;
-  }
-}
-
 .gu-content__main {
   position: relative;
   background-color: gu-colour(sport-faded);
 }
 
-.gu-content__main.aus-moment {
-  position: relative;
+.gu-content--aus-moment, .aus-moment {
   background: linear-gradient(
       #FFE500 50%,
       #F3C100 50%,

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.scss
@@ -42,6 +42,20 @@ body {
   }
 }
 
+.gu-content--contribution-thankyou.gu-content--aus-moment {
+  background: linear-gradient(
+      #FFE500 50%,
+      #F3C100 50%,
+      #F3C100 80%,
+      #FF7F0F 80%
+  ) !important;
+
+  .gu-content__main {
+    position: relative;
+    background-color: transparent;
+  }
+}
+
 .gu-content__main {
   position: relative;
   background-color: gu-colour(sport-faded);


### PR DESCRIPTION
Adds Aus moment styling and copy to post-contribution thank you page, as per [this Trello card](https://trello.com/c/UET0gZue). See screenshots below.

This PR also introduces a switch to enable toggling all Aus moment features on/off from the admin console.
<br>
<h2>Tablet</h2>
<img width="520" alt="Screenshot 2020-06-08 at 15 10 55" src="https://user-images.githubusercontent.com/25020231/84067036-b8f27800-a9be-11ea-9dd5-3a2e44b8db89.png">
<br>
<h2>13" Laptop</h2>
<strong>Top</strong>
<img width="1440" alt="Screenshot 2020-06-08 at 15 11 05" src="https://user-images.githubusercontent.com/25020231/84067074-c9a2ee00-a9be-11ea-87d0-e942c6da621a.png">
<br>
<strong>Bottom</strong>
<img width="1440" alt="Screenshot 2020-06-08 at 15 11 09" src="https://user-images.githubusercontent.com/25020231/84067099-d32c5600-a9be-11ea-97c4-a15698854a8e.png">