### PR TITLE
aus moment landing page ab test is active if ausMomentEnabled

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -12,6 +12,9 @@ const usOnlyLandingPage = '/us/contribute(/.*)?$';
 const auOnlyLandingPage = '/au/contribute(/.*)?$';
 export const subsShowcaseAndDigiSubPages = '(/??/subscribe(\\?.*)?$|/??/subscribe/digital(\\?.*)?$)';
 const digitalCheckout = '/subscribe/digital/checkout';
+const ausMomentEnabled = (
+  window && window.guardian && window.guardian.ausMomentEnabled
+) || false;
 
 export const tests: Tests = {
   usAmountsTest: {
@@ -120,7 +123,7 @@ export const tests: Tests = {
         size: 1,
       },
     },
-    isActive: false,
+    isActive: ausMomentEnabled,
     referrerControlled: false,
     seed: 6,
     targetPage: auOnlyLandingPage,


### PR DESCRIPTION
A tiny change to automatically tie the on/off state of the Aus moment landing page A/B test to the state of the master switch for the moment.