### PR TITLE
Update "Premium App" copy on subscriptions landing page

### DIFF
--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
@@ -209,9 +209,9 @@ const paperAndDigital = (
 };
 
 const premiumApp = (countryGroupId: CountryGroupId): ProductCopy => ({
-  title: 'Premium App',
+  title: 'Premium access to the Guardian Live app',
   subtitle: getPrice(countryGroupId, PremiumTier, '7-day free Trial'),
-  description: 'The ad-free, Premium App, designed especially for your smartphone and tablet',
+  description: 'Ad-free live news, as it happens',
   buttons: [{
     ctaButtonText: 'Buy in App Store',
     link: getIosAppUrl(countryGroupId),


### PR DESCRIPTION
## Why are you doing this?

This PR updates the "Premium App" copy on subscriptions landing page, as requested: https://trello.com/c/hvGtnhya/3099-update-premium-app-reference-copy-on-showcase-pag

## Screenshots

### Before
<img width="406" alt="Screenshot 2020-06-09 at 16 06 16" src="https://user-images.githubusercontent.com/1590704/84165092-2b209680-aa6b-11ea-94e0-357adcc8baf7.png">

### After
<img width="406" alt="Screenshot 2020-06-09 at 15 55 58" src="https://user-images.githubusercontent.com/1590704/84165010-117f4f00-aa6b-11ea-8181-5be49190f37a.png">