### PR TITLE
Error tidy up

### DIFF
--- a/support-frontend/assets/components/directDebit/directDebitProgressiveDisclosure/components/form.jsx
+++ b/support-frontend/assets/components/directDebit/directDebitProgressiveDisclosure/components/form.jsx
@@ -43,7 +43,7 @@ type PropTypes = {
   onSubmit: EventHandler,
 }
 
-const InputWithError = compose(withError, withLabel)(Input);
+const InputWithError = compose(withLabel, withError)(Input);
 const CheckBoxWithError = withError(CheckboxInput);
 
 function Form(props: PropTypes) {

--- a/support-frontend/assets/components/forms/customFields/error.jsx
+++ b/support-frontend/assets/components/forms/customFields/error.jsx
@@ -5,41 +5,35 @@
 import React, { type Node } from 'react';
 
 import { type Option } from 'helpers/types/option';
+import { InlineError } from '@guardian/src-inline-error';
 
 import './error.scss';
 
 // ----- Types ----- //
 export type PropsForHoc = {
-  error: Option<string>,
+  error: Option<string> | Option<Node>,
 };
 
 type Props = PropsForHoc & {
-  htmlFor: Option<string>,
   children?: Option<Node>,
 };
 
 // ----- Component ----- //
 
-function Error({ error, htmlFor, children }: Props) {
-  const Element = htmlFor ? 'label' : 'div';
+function Error({ error, children }: Props) {
+  const errorNode = error === 'Temporary COVID message' ? (
+    <div className="component-form-error__summary-error">
+      The address and postcode you entered is outside of our delivery area. You may want to
+      consider purchasing a <a href="/uk/subscribe/paper">voucher subscription</a>
+    </div>) : (
+      <InlineError>
+        {error}
+      </InlineError>);
+
   return (
     <div className={error ? 'component-form-error' : null}>
+      {error && errorNode}
       {children && children}
-      <Element
-        aria-hidden={!error}
-        aria-atomic="true"
-        aria-live="polite"
-        htmlFor={htmlFor}
-        className="component-form-error__error"
-      >
-        {(error === 'Temporary COVID message') && (
-          <div className="component-form-error__summary-error">
-            The address and postcode you entered is outside of our delivery area. You may want to
-            consider purchasing a <a href="/uk/subscribe/paper">voucher subscription</a>
-          </div>)
-        }
-        {(error !== 'Temporary COVID message') && error}
-      </Element>
     </div>
   );
 }

--- a/support-frontend/assets/components/forms/customFields/error.jsx
+++ b/support-frontend/assets/components/forms/customFields/error.jsx
@@ -7,6 +7,7 @@ import React, { type Node } from 'react';
 import { type Option } from 'helpers/types/option';
 
 import './error.scss';
+import { InlineError } from '@guardian/src-inline-error';
 
 // ----- Types ----- //
 export type PropsForHoc = {
@@ -22,8 +23,8 @@ type Props = PropsForHoc & {
 function Error({ error, children }: Props) {
   return (
     <div className={error ? 'component-form-error' : null}>
-      {error && error}
-      {children && children}
+      {error && <InlineError>{error}</InlineError>}
+      {children}
     </div>
   );
 }

--- a/support-frontend/assets/components/forms/customFields/error.jsx
+++ b/support-frontend/assets/components/forms/customFields/error.jsx
@@ -8,10 +8,11 @@ import { type Option } from 'helpers/types/option';
 
 import './error.scss';
 import { InlineError } from '@guardian/src-inline-error';
+import type { ErrorMessage } from 'helpers/subscriptionsForms/validation';
 
 // ----- Types ----- //
 export type PropsForHoc = {
-  error: Option<string> | Option<Node>,
+  error: Option<ErrorMessage>,
 };
 
 type Props = PropsForHoc & {

--- a/support-frontend/assets/components/forms/customFields/error.jsx
+++ b/support-frontend/assets/components/forms/customFields/error.jsx
@@ -5,7 +5,6 @@
 import React, { type Node } from 'react';
 
 import { type Option } from 'helpers/types/option';
-import { InlineError } from '@guardian/src-inline-error';
 
 import './error.scss';
 
@@ -21,18 +20,9 @@ type Props = PropsForHoc & {
 // ----- Component ----- //
 
 function Error({ error, children }: Props) {
-  const errorNode = error === 'Temporary COVID message' ? (
-    <div className="component-form-error__summary-error">
-      The address and postcode you entered is outside of our delivery area. You may want to
-      consider purchasing a <a href="/uk/subscribe/paper">voucher subscription</a>
-    </div>) : (
-      <InlineError>
-        {error}
-      </InlineError>);
-
   return (
     <div className={error ? 'component-form-error' : null}>
-      {error && errorNode}
+      {error && error}
       {children && children}
     </div>
   );

--- a/support-frontend/assets/components/forms/customFields/validated.jsx
+++ b/support-frontend/assets/components/forms/customFields/validated.jsx
@@ -38,22 +38,6 @@ function Validated({
 
   return (
     <div className={getClassName(error, valid)}>
-      {children && children}
-      <Element
-        aria-hidden={!error}
-        aria-atomic="true"
-        aria-live="polite"
-        htmlFor={htmlFor}
-        className="component-form-error__error"
-      >
-        {(error === 'Temporary COVID message') && (
-          <div className="component-form-error__summary-error">
-            The address and postcode you entered is outside of our delivery area. You may want to
-            consider purchasing a <a href="/uk/subscribe/paper">voucher subscription</a>
-          </div>)
-        }
-        {(error !== 'Temporary COVID message') && error}
-      </Element>
       <Element
         aria-hidden={!valid}
         aria-atomic="true"
@@ -63,6 +47,7 @@ function Validated({
       >
         {valid}
       </Element>
+      {children && children}
     </div>
   );
 }

--- a/support-frontend/assets/components/forms/customFields/validated.jsx
+++ b/support-frontend/assets/components/forms/customFields/validated.jsx
@@ -8,7 +8,6 @@ import { type Option } from 'helpers/types/option';
 
 // ----- Types ----- //
 export type PropsForHoc = {
-  error: Option<string>,
   valid: Option<string>,
 };
 
@@ -19,17 +18,7 @@ type Props = PropsForHoc & {
 
 // ----- Component ----- //
 
-const getClassName = (error: Option<string>, valid: Option<string>) => {
-  if (error) {
-    return 'component-form-error';
-  } else if (valid) {
-    return 'component-form-valid';
-  }
-  return null;
-};
-
 function Validated({
-  error,
   valid,
   htmlFor,
   children,
@@ -37,7 +26,7 @@ function Validated({
   const Element = htmlFor ? 'label' : 'div';
 
   return (
-    <div className={getClassName(error, valid)}>
+    <div className={valid ? 'component-form-valid' : null}>
       <Element
         aria-hidden={!valid}
         aria-atomic="true"
@@ -47,7 +36,7 @@ function Validated({
       >
         {valid}
       </Element>
-      {children && children}
+      {children}
     </div>
   );
 }

--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFields.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFields.jsx
@@ -53,9 +53,7 @@ type PropTypes<GlobalState> = {|
   ...StatePropTypes<GlobalState>,
 |}
 
-const StaticInputWithLabel = withLabel(Input);
-const InputWithLabel = asControlled(StaticInputWithLabel);
-const InputWithError = withError(InputWithLabel);
+const InputWithError = compose(asControlled, withLabel, withError)(Input);
 const SelectWithLabel = compose(asControlled, withLabel)(Select);
 const SelectWithError = withError(SelectWithLabel);
 const MaybeSelect = canShow(SelectWithError);

--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.jsx
@@ -1,6 +1,7 @@
 // @flow
 
 // ----- Imports ----- //
+import React from 'react';
 import { combineReducers, type Dispatch } from 'redux';
 
 import { fromString, type IsoCountry } from 'helpers/internationalisation/country';
@@ -123,10 +124,15 @@ const applyDeliveryAddressRules = (
   fields: FormFields,
   addressType: AddressType,
 ): FormError<FormField>[] => {
+  const error = (
+    <div className="component-form-error__summary-error">
+      The address and postcode you entered is outside of our delivery area. You may want to
+      consider purchasing a <a href="/uk/subscribe/paper">voucher subscription</a>
+    </div>);
   const homeRules = validate([
     {
       rule: isHomeDeliveryInM25(fulfilmentOption, fields.postCode),
-      error: formError('postCode', 'Temporary COVID message'),
+      error: formError('postCode', error),
     },
   ]);
 

--- a/support-frontend/assets/components/subscriptionCheckouts/address/postcodeFinderStore.js
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/postcodeFinderStore.js
@@ -9,12 +9,13 @@ import {
   getAddressesForPostcode,
   type PostcodeFinderResult,
 } from 'components/subscriptionCheckouts/address/postcodeLookup';
+import type { ErrorMessage } from 'helpers/subscriptionsForms/validation';
 
 export type PostcodeFinderState = {|
   results: PostcodeFinderResult[],
   isLoading: boolean,
   postcode: Option<string>,
-  error: Option<string>,
+  error: Option<ErrorMessage>,
 |}
 
 export type PostcodeFinderActions =

--- a/support-frontend/assets/components/subscriptionCheckouts/addressSearch/addressComponentStore.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/addressSearch/addressComponentStore.jsx
@@ -1,6 +1,7 @@
 // @flow
 
 // ----- Imports ----- //
+import React from 'react';
 import { combineReducers, type Dispatch } from 'redux';
 
 import { fromString, type IsoCountry } from 'helpers/internationalisation/country';
@@ -122,10 +123,15 @@ const applyDeliveryAddressRules = (
   fields: FormFields,
   addressType: AddressType,
 ): FormError<FormField>[] => {
+  const error = (
+    <div className="component-form-error__summary-error">
+      The address and postcode you entered is outside of our delivery area. You may want to
+      consider purchasing a <a href="/uk/subscribe/paper">voucher subscription</a>
+    </div>);
   const homeRules = validate([
     {
       rule: isHomeDeliveryInM25(fulfilmentOption, fields.postCode),
-      error: formError('postCode', 'Temporary COVID message'),
+      error: formError('postCode', error),
     },
   ]);
 

--- a/support-frontend/assets/components/subscriptionCheckouts/paymentMethodSelector.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/paymentMethodSelector.jsx
@@ -18,13 +18,14 @@ import { PayPalSubmitButton } from 'components/subscriptionCheckouts/payPalSubmi
 import { type BillingPeriod } from 'helpers/billingPeriods';
 import type { Csrf } from 'helpers/csrf/csrfReducer';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
+import type { ErrorMessage } from 'helpers/subscriptionsForms/validation';
 
 type PropTypes = {|
   country: IsoCountry,
   paymentMethod: Option<PaymentMethod>,
   onPaymentAuthorised: Function,
   setPaymentMethod: Function,
-  validationError: Option<string>,
+  validationError: Option<ErrorMessage>,
   allErrors: Array<Object>,
   billingPeriod: BillingPeriod,
   amount: number,

--- a/support-frontend/assets/components/subscriptionCheckouts/personalDetails.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/personalDetails.jsx
@@ -25,7 +25,7 @@ export type PropTypes = {
 }
 
 const InputWithLabel = withLabel(Input);
-const InputWithError = compose(asControlled, withError)(InputWithLabel);
+const InputWithError = compose(asControlled, withLabel, withError)(Input);
 
 export default function PersonalDetails(props: PropTypes) {
   const emailFooter = (

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -20,9 +20,9 @@ import { fetchJson, requestOptions } from 'helpers/fetch';
 import { logException } from 'helpers/logger';
 import type { Option } from 'helpers/types/option';
 import { appropriateErrorMessage } from 'helpers/errorReasons';
-import type { Csrf } from '../../../helpers/csrf/csrfReducer';
-import { trackComponentLoad } from '../../../helpers/tracking/behaviour';
-import { loadRecaptchaV2 } from '../../../helpers/recaptcha';
+import type { Csrf } from 'helpers/csrf/csrfReducer';
+import { trackComponentLoad } from 'helpers/tracking/behaviour';
+import { loadRecaptchaV2 } from 'helpers/recaptcha';
 import { isPostDeployUser } from 'helpers/user/user';
 import { routes } from 'helpers/routes';
 import { Recaptcha } from 'components/recaptcha/recaptcha';
@@ -66,10 +66,10 @@ const invalidStyles = {
 
 // Main component
 
-const CardNumberWithError = compose(withError, withLabel)(CardNumberElement);
-const CardExpiryWithError = compose(withError, withLabel)(CardExpiryElement);
-const CardCvcWithError = compose(withError, withLabel)(CardCvcElement);
-const RecaptchaWithError = compose(withError, withLabel)(Recaptcha);
+const CardNumberWithError = compose(withLabel, withError)(CardNumberElement);
+const CardExpiryWithError = compose(withLabel, withError)(CardExpiryElement);
+const CardCvcWithError = compose(withLabel, withError)(CardCvcElement);
+const RecaptchaWithError = compose(withLabel, withError)(Recaptcha);
 
 class StripeForm extends Component<StripeFormPropTypes, StateTypes> {
   constructor(props) {

--- a/support-frontend/assets/components/subscriptionCheckouts/submitFormErrorSummary.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/submitFormErrorSummary.jsx
@@ -19,19 +19,10 @@ export const ErrorSummary = (props: PropTypes) => (
   <div className="component-form-error__border">
     <Heading className="component-form-error__heading" size={2}>There is a problem</Heading>
     <ul>
-      {props.errors.map((error) => {
-        if (error.message === 'Temporary COVID message') {
-          return (
-            <li className="component-form-error__summary-error">
-              The address and postcode you entered is outside of our delivery area. You may want to
-              consider purchasing a <a href="/uk/subscribe/paper">voucher subscription</a>
-            </li>);
-        }
-        return (
-          <li className="component-form-error__summary-error">
-            {error.message}
-          </li>);
-      })}
+      {props.errors.map(error => (
+        <li className="component-form-error__summary-error">
+          {error.message}
+        </li>))}
     </ul>
   </div>
 );

--- a/support-frontend/assets/helpers/subscriptionsForms/validation.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/validation.js
@@ -1,17 +1,19 @@
 // @flow
 
 // ----- Imports ----- //
-
+import { type Node } from 'react';
 import { headOption, type Option } from 'helpers/types/option';
 
 
 // ----- Types ----- //
 
+export type ErrorMessage = string | Node;
+
 type Rule<Err> = { rule: boolean, error: Err };
 
 export type FormError<FieldType> = {
   field: FieldType,
-  message: string,
+  message: ErrorMessage,
 };
 
 
@@ -25,7 +27,7 @@ function notNull<A>(value: A): boolean {
 
 // ----- Functions ----- //
 
-function firstError<FieldType>(field: FieldType, errors: FormError<FieldType>[]): Option<string> {
+function firstError<FieldType>(field: FieldType, errors: FormError<FieldType>[]): Option<ErrorMessage> {
   const msgs = errors.filter(err => err.field === field).map(err => err.message);
   return headOption(msgs);
 }
@@ -34,7 +36,7 @@ function removeError<FieldType>(field: FieldType, formErrors: FormError<FieldTyp
   return formErrors.filter(error => error.field !== field);
 }
 
-function formError<FieldType>(field: FieldType, message: string): FormError<FieldType> {
+function formError<FieldType>(field: FieldType, message: ErrorMessage): FormError<FieldType> {
   return { field, message };
 }
 

--- a/support-frontend/assets/hocs/withValidation.jsx
+++ b/support-frontend/assets/hocs/withValidation.jsx
@@ -19,8 +19,8 @@ type Out<Props> = React$ComponentType<AugmentedProps<Props>>;
 
 function withValidation<Props: { id: Option<string> }>(Component: In<Props>): Out<Props> {
 
-  return ({ error, valid, ...props }: AugmentedProps<Props>) => (
-    <Validated htmlFor={props.id} error={error} valid={valid}>
+  return ({ valid, ...props }: AugmentedProps<Props>) => (
+    <Validated htmlFor={props.id} valid={valid}>
       <Component {...props} />
     </Validated>
   );

--- a/support-frontend/assets/pages/subscriptions-redemption/components/redemptionForm.jsx
+++ b/support-frontend/assets/pages/subscriptions-redemption/components/redemptionForm.jsx
@@ -17,10 +17,11 @@ import { doesUserAppearToBeSignedIn } from 'helpers/user/user';
 import { withValidation } from 'hocs/withValidation';
 import { withError } from 'hocs/withError';
 import { withLabel } from 'hocs/withLabel';
+import type { ErrorMessage } from 'helpers/subscriptionsForms/validation';
 
 type PropTypes = {
   userCode: Option<string>,
-  error: Option<string>,
+  error: Option<ErrorMessage>,
   setUserCode: string => void,
   submit: string => void,
 }

--- a/support-frontend/assets/pages/subscriptions-redemption/components/redemptionForm.jsx
+++ b/support-frontend/assets/pages/subscriptions-redemption/components/redemptionForm.jsx
@@ -15,6 +15,8 @@ import { submitCode, validateUserCode } from 'pages/subscriptions-redemption/api
 import type { Option } from 'helpers/types/option';
 import { doesUserAppearToBeSignedIn } from 'helpers/user/user';
 import { withValidation } from 'hocs/withValidation';
+import { withError } from 'hocs/withError';
+import { withLabel } from 'hocs/withLabel';
 
 type PropTypes = {
   userCode: Option<string>,
@@ -37,7 +39,7 @@ function mapDispatchToProps(dispatch: Dispatch<Action>) {
   };
 }
 
-const InputWithValidated = compose(asControlled, withValidation)(Input);
+const InputWithValidated = compose(asControlled, withLabel, withError, withValidation)(Input);
 
 function RedemptionForm(props: PropTypes) {
   const formCss = css`
@@ -75,6 +77,7 @@ function RedemptionForm(props: PropTypes) {
                   setValue={props.setUserCode}
                   error={props.error}
                   valid={validationText}
+                  label="Insert code"
                 />
                 <p css={paraCss}>
                   {signinInstructions}


### PR DESCRIPTION
## Why are you doing this?
This PR change the `error` component used on the subs checkouts to use the `InlineError` component from [Source](https://github.com/guardian/source) which provides us with the correct icon and styling.

It also moves the error message above the form field with the error in line with design system guidelines.

Finally I have refactored to remove the 'Temporary Covid message' hack which we had in place.

## Screenshots
### Previous error component
<img width="434" alt="Screen Shot 2020-06-09 at 17 57 52" src="https://user-images.githubusercontent.com/181371/84177465-d127cd00-aa7a-11ea-8711-1daf297f97d8.png">

### New error component
<img width="434" alt="Screen Shot 2020-06-09 at 17 55 35" src="https://user-images.githubusercontent.com/181371/84177473-d258fa00-aa7a-11ea-9923-9dc5ea96226c.png">

