### PR TITLE
Fix getaddress.io error handling

### DIFF
--- a/support-frontend/app/controllers/GetAddress.scala
+++ b/support-frontend/app/controllers/GetAddress.scala
@@ -7,6 +7,7 @@ import com.gu.support.getaddressio.GetAddressIOService
 import io.circe.syntax._
 import play.api.libs.circe.Circe
 import play.api.mvc.{AbstractController, Action, AnyContent, ControllerComponents}
+import com.gu.support.getaddressio.FindAddressResultError
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -21,7 +22,7 @@ class GetAddress(
     getAddressService.find(postCode).map { result =>
       Ok(result.asJson)
     } recover {
-      case error if error.getMessage == "Bad Request" || error.getMessage == "Not Found" =>
+      case _: FindAddressResultError =>
         BadRequest //The postcode was invalid
       case error =>
         SafeLogger.error(scrub"Failed to complete postcode lookup via getAddress.io due to: $error")

--- a/support-services/src/test/scala/com/gu/support/getaddressio/GetAddressIOServiceSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/getaddressio/GetAddressIOServiceSpec.scala
@@ -12,7 +12,7 @@ import org.scalatest.matchers.should.Matchers
 class GetAddressIOServiceSpec extends AsyncFlatSpec with Matchers {
   val service = new GetAddressIOService(GetAddressIOConfig.fromConfig(ConfigFactory.load()), RequestRunners.futureRunner)
   //This test is ignored because the test key is only valid for a few requests a day
-  "GetAddressService" should "be able to find a postcode" in {
+  "GetAddressService" should "be able to find a postcode" ignore {
     service.find("N19GU").map {
       result =>
         result.nonEmpty shouldBe true
@@ -27,7 +27,7 @@ class GetAddressIOServiceSpec extends AsyncFlatSpec with Matchers {
   }
 
   //This test is ignored because the test key is only valid for a few requests a day
-  it should "be able to find another postcode" in {
+  it should "be able to find another postcode" ignore {
     service.find("NN13ER").map {
       result => result.head.state shouldBe Some("Northamptonshire")
     }

--- a/support-services/src/test/scala/com/gu/support/getaddressio/GetAddressIOServiceSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/getaddressio/GetAddressIOServiceSpec.scala
@@ -12,7 +12,7 @@ import org.scalatest.matchers.should.Matchers
 class GetAddressIOServiceSpec extends AsyncFlatSpec with Matchers {
   val service = new GetAddressIOService(GetAddressIOConfig.fromConfig(ConfigFactory.load()), RequestRunners.futureRunner)
   //This test is ignored because the test key is only valid for a few requests a day
-  "GetAddressService" should "be able to find a postcode" ignore {
+  "GetAddressService" should "be able to find a postcode" in {
     service.find("N19GU").map {
       result =>
         result.nonEmpty shouldBe true
@@ -24,7 +24,10 @@ class GetAddressIOServiceSpec extends AsyncFlatSpec with Matchers {
         address.state shouldBe  None
         address.country shouldBe Country.UK
     }
+  }
 
+  //This test is ignored because the test key is only valid for a few requests a day
+  it should "be able to find another postcode" in {
     service.find("NN13ER").map {
       result => result.head.state shouldBe Some("Northamptonshire")
     }


### PR DESCRIPTION
# Why?

- **Current situation**: We use the service getAddressIO to look up addresses from a postcode on all of our checkouts.

- **Problem**: This service has changed their response so we are misinterpreting invalid postcode errors as server errors, which trigger 5XX alarms if too many of them happen in quick succession.

- **Proposed change**: Fix getAddressIO error handling

- **Expected benefit**: Show correct error message to user and stop the alarm.

# How?

- Interpret the error type rather than message body - it looks like the service returns a different message now.
- [**Trello Card**](https://trello.com/c/c64aWiPH)

# Screenshots

## Before
<img width="413" alt="Screenshot 2020-06-10 at 01 02 02" src="https://user-images.githubusercontent.com/6162929/84213070-998b4600-aab7-11ea-9b67-2fdd6ba985cc.png">

## After
<img width="413" alt="Screenshot 2020-06-10 at 00 58 37" src="https://user-images.githubusercontent.com/6162929/84213034-811b2b80-aab7-11ea-9a83-61fc952ea9b0.png">


