### PR TITLE
Rename remote epic test

### DIFF
--- a/support-frontend/assets/helpers/abTests/__tests__/abtestTest.js
+++ b/support-frontend/assets/helpers/abTests/__tests__/abtestTest.js
@@ -384,23 +384,23 @@ describe('basic behaviour of init', () => {
     deleteCookie();
   });
 
-  it('Does not allocate a locally rendered epic user into the ContributionsService AB test', () => {
+  it('Does not allocate a locally rendered epic user into the RemoteEpicVariants AB test', () => {
     const url = `/test.html?acquisitionData=${encodeURI(JSON.stringify(acquisitionDataMockTestControl))}`;
     window.history.pushState({}, 'Test Title', url);
 
     const participations: Participations = abInit('GB', GBPCountries, emptySettings, {});
 
-    expect(participations.ContributionsService).toBe(undefined);
+    expect(participations.RemoteEpicVariants).toBe(undefined);
   });
 
-  it('Allocates a remotely rendered epic user into the ContributionsService AB test', () => {
+  it('Allocates a remotely rendered epic user into the RemoteEpicVariants AB test', () => {
     const data = { isRemote: true, ...acquisitionDataMockTestControl };
     const url = `/test.html?acquisitionData=${encodeURI(JSON.stringify(data))}`;
     window.history.pushState({}, 'Test Title', url);
 
     const participations: Participations = abInit('GB', GBPCountries, emptySettings, {});
 
-    expect(participations.ContributionsService).toBe('remote');
+    expect(participations.RemoteEpicVariants).toBe('remote');
   });
 
 });

--- a/support-frontend/assets/helpers/abTests/abtest.js
+++ b/support-frontend/assets/helpers/abTests/abtest.js
@@ -291,7 +291,7 @@ function getParticipations(
   // epics on Frontend (as part of testing out the new Contributions Service).
   // It will be removed once the new service is shown to be working correctly.
   if (isRemote) {
-    participations.ContributionsService = 'remote';
+    participations.RemoteEpicVariants = 'remote';
   }
 
   Object.keys(abTests).forEach((testId) => {


### PR DESCRIPTION
The equivalent test in Frontend is named RemoteEpicVariants so
that name is now used here too so as to avoid confusion.