### PR TITLE
Prevent users with an existing Digital Subscription signing up for a corporate subscription

### DIFF
--- a/support-frontend/app/controllers/DigitalSubscriptionController.scala
+++ b/support-frontend/app/controllers/DigitalSubscriptionController.scala
@@ -13,6 +13,7 @@ import com.gu.support.encoding.CustomCodecs._
 import com.gu.support.pricing.PriceSummaryServiceProvider
 import com.gu.support.promotions.{DefaultPromotions, PromoCode}
 import config.{RecaptchaConfigProvider, StringsConfig}
+import controllers.UserDigitalSubscription.{redirectToExistingThankYouPage, userHasDigitalSubscription}
 import play.api.libs.circe.Circe
 import play.api.mvc._
 import play.twirl.api.Html
@@ -41,7 +42,7 @@ class DigitalSubscriptionController(
   recaptchaConfigProvider: RecaptchaConfigProvider
 )(
   implicit val ec: ExecutionContext
-) extends AbstractController(components) with GeoRedirect with CanonicalLinks with Circe with SettingsSurrogateKeySyntax with UserDigitalSubscription {
+) extends AbstractController(components) with GeoRedirect with CanonicalLinks with Circe with SettingsSurrogateKeySyntax {
 
   import actionRefiners._
 

--- a/support-frontend/app/controllers/DigitalSubscriptionController.scala
+++ b/support-frontend/app/controllers/DigitalSubscriptionController.scala
@@ -24,7 +24,7 @@ import views.html.subscriptionCheckout
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class DigitalSubscription(
+class DigitalSubscriptionController(
   priceSummaryServiceProvider: PriceSummaryServiceProvider,
   val assets: AssetsResolver,
   val actionRefiners: CustomActionBuilders,
@@ -41,7 +41,7 @@ class DigitalSubscription(
   recaptchaConfigProvider: RecaptchaConfigProvider
 )(
   implicit val ec: ExecutionContext
-) extends AbstractController(components) with GeoRedirect with CanonicalLinks with Circe with SettingsSurrogateKeySyntax {
+) extends AbstractController(components) with GeoRedirect with CanonicalLinks with Circe with SettingsSurrogateKeySyntax with UserDigitalSubscription {
 
   import actionRefiners._
 
@@ -84,17 +84,6 @@ class DigitalSubscription(
 
   def digitalGeoRedirect: Action[AnyContent] = geoRedirect("subscribe/digital")
 
-  private def userHasDigipack(user: AuthenticatedIdUser): Future[Boolean] = {
-    user.credentials match {
-      case cookies: AccessCredentials.Cookies =>
-        membersDataService.userAttributes(cookies).value map {
-          case Left(_) => false
-          case Right(response: MembersDataService.UserAttributes) => response.contentAccess.digitalPack
-        }
-      case _ => Future.successful(false)
-    }
-  }
-
   def displayForm(): Action[AnyContent] =
     authenticatedAction(subscriptionsClientId).async { implicit request =>
       implicit val settings: AllSettings = settingsProvider.getAllSettings()
@@ -104,8 +93,8 @@ class DigitalSubscription(
           Future.successful(InternalServerError)
         },
         user => {
-          userHasDigipack(request.user) map {
-            case true => Redirect(routes.DigitalSubscription.displayThankYouExisting().url, request.queryString, status = FOUND)
+          userHasDigitalSubscription(membersDataService, request.user) map {
+            case true => redirectToExistingThankYouPage
             case _ => Ok(digitalSubscriptionFormHtml(user))
           }
         }

--- a/support-frontend/app/controllers/Promotions.scala
+++ b/support-frontend/app/controllers/Promotions.scala
@@ -38,7 +38,7 @@ class Promotions(
     ) { promotionTerms =>
       val productLandingPage = promotionTerms.product match {
         case GuardianWeekly => routes.WeeklySubscription.weeklyGeoRedirect(promotionTerms.isGift).url
-        case DigitalPack => routes.DigitalSubscription.digitalGeoRedirect().url
+        case DigitalPack => routes.DigitalSubscriptionController.digitalGeoRedirect().url
         case Paper => routes.PaperSubscription.paper(false).url
       }
       val queryString = request.queryString + ("promoCode" -> Seq(promoCode))

--- a/support-frontend/app/controllers/RedemptionController.scala
+++ b/support-frontend/app/controllers/RedemptionController.scala
@@ -122,7 +122,7 @@ class RedemptionController(
   def displayProcessing(redemptionCode: String): Action[AnyContent] =
     authenticatedAction(subscriptionsClientId).async {
       implicit request: AuthRequest[Any] =>
-        val processingPage: EitherT[Future, String, Result] = for {
+        val processingPage = for {
           user <- identityService.getUser(request.user.minimalUser)
           corporateCustomer <- getCorporateCustomer(redemptionCode)
           hasDigipack <- EitherT.right(userHasDigitalSubscription(membersDataService, request.user))

--- a/support-frontend/app/controllers/RedemptionController.scala
+++ b/support-frontend/app/controllers/RedemptionController.scala
@@ -122,7 +122,7 @@ class RedemptionController(
   def displayProcessing(redemptionCode: String): Action[AnyContent] =
     authenticatedAction(subscriptionsClientId).async {
       implicit request: AuthRequest[Any] =>
-        val processingPage = for {
+        val processingPage: EitherT[Future, String, Result] = for {
           user <- identityService.getUser(request.user.minimalUser)
           corporateCustomer <- getCorporateCustomer(redemptionCode)
           hasDigipack <- EitherT.right(userHasDigitalSubscription(membersDataService, request.user))

--- a/support-frontend/app/controllers/RedemptionController.scala
+++ b/support-frontend/app/controllers/RedemptionController.scala
@@ -20,6 +20,7 @@ import views.html.subscriptionRedemptionForm
 import cats.implicits._
 import com.gu.monitoring.SafeLogger
 import SafeLogger._
+import controllers.UserDigitalSubscription.{redirectToExistingThankYouPage, userHasDigitalSubscription}
 import lib.RedirectWithEncodedQueryString
 import play.twirl.api.Html
 
@@ -36,7 +37,7 @@ class RedemptionController(
   fontLoaderBundle: Either[RefPath, StyleContent]
 )(
   implicit val ec: ExecutionContext
-) extends AbstractController(components) with Circe with UserDigitalSubscription {
+) extends AbstractController(components) with Circe {
 
   import actionRefiners._
 
@@ -122,24 +123,31 @@ class RedemptionController(
   def displayProcessing(redemptionCode: String): Action[AnyContent] =
     authenticatedAction(subscriptionsClientId).async {
       implicit request: AuthRequest[Any] =>
-        val processingPage: EitherT[Future, String, Result] = for {
-          user <- identityService.getUser(request.user.minimalUser)
-          corporateCustomer <- getCorporateCustomer(redemptionCode)
-          hasDigipack <- EitherT.right(userHasDigitalSubscription(membersDataService, request.user))
-        } yield if (hasDigipack)
-          redirectToExistingThankYouPage
-        else
-          showProcessing(redemptionCode, corporateCustomer, user)
-
-        processingPage.value.map(
-          _.fold(
-            error => displayError(redemptionCode, error),
-            result => result
-          )
+        userHasDigitalSubscription(membersDataService, request.user).flatMap(
+          userHasSub =>
+            if (userHasSub)
+              Future.successful(redirectToExistingThankYouPage)
+            else
+              tryToShowProcessingPage(redemptionCode)
         )
     }
 
-  def showProcessing(
+  private def tryToShowProcessingPage(redemptionCode: RedemptionCode)(implicit request: AuthRequest[Any]) = {
+    val processingPage: EitherT[Future, String, Result] = for {
+      user <- identityService.getUser(request.user.minimalUser)
+      corporateCustomer <- getCorporateCustomer(redemptionCode)
+    } yield showProcessing(redemptionCode, corporateCustomer, user)
+
+    processingPage.value.map(
+      maybeResult =>
+        maybeResult.fold(
+          error => displayError(redemptionCode, error),
+          result => result
+        )
+    )
+  }
+
+  private def showProcessing(
     redemptionCode: RedemptionCode,
     corporateCustomer: CorporateCustomer,
     user: IdUser

--- a/support-frontend/app/controllers/UserDigitalSubscription.scala
+++ b/support-frontend/app/controllers/UserDigitalSubscription.scala
@@ -9,7 +9,7 @@ import services.{AccessCredentials, AuthenticatedIdUser, MembersDataService}
 import SafeLogger._
 import scala.concurrent.{ExecutionContext, Future}
 
-trait UserDigitalSubscription {
+object UserDigitalSubscription {
   def userHasDigitalSubscription(
     membersDataService: MembersDataService,
     user: AuthenticatedIdUser

--- a/support-frontend/app/controllers/UserDigitalSubscription.scala
+++ b/support-frontend/app/controllers/UserDigitalSubscription.scala
@@ -1,0 +1,27 @@
+package controllers
+
+import actions.CustomActionBuilders.AuthRequest
+import play.api.mvc.Result
+import play.api.mvc.Results._
+import play.mvc.Http.Status.FOUND
+import services.{AccessCredentials, AuthenticatedIdUser, MembersDataService}
+import scala.concurrent.{ExecutionContext, Future}
+
+trait UserDigitalSubscription {
+  def userHasDigitalSubscription(
+    membersDataService: MembersDataService,
+    user: AuthenticatedIdUser
+  )(implicit executionContext: ExecutionContext): Future[Boolean] = {
+    user.credentials match {
+      case cookies: AccessCredentials.Cookies =>
+        membersDataService.userAttributes(cookies).value map {
+          case Left(_) => false
+          case Right(response: MembersDataService.UserAttributes) => response.contentAccess.digitalPack
+        }
+      case _ => Future.successful(false)
+    }
+  }
+
+  def redirectToExistingThankYouPage(implicit request: AuthRequest[Any]): Result =
+    Redirect(routes.DigitalSubscriptionController.displayThankYouExisting().url, request.queryString, status = FOUND)
+}

--- a/support-frontend/app/services/MembersDataService.scala
+++ b/support-frontend/app/services/MembersDataService.scala
@@ -53,7 +53,7 @@ class MembersDataService(apiUrl: String)(implicit val ec: ExecutionContext, wsCl
     wsClient
       .url(url)
       .withHttpHeaders("Cookie" -> credentials.cookies.map(c => s"${c.name}=${c.value}").mkString("; "))
-      .withRequestTimeout(2.second)
+      .withRequestTimeout(5.second)
       .get()
       .map(responseAsJson[T])
       .recover {

--- a/support-frontend/app/wiring/Controllers.scala
+++ b/support-frontend/app/wiring/Controllers.scala
@@ -52,7 +52,7 @@ trait Controllers {
     fontLoader
   )
 
-  lazy val digitalPackController = new DigitalSubscription(
+  lazy val digitalPackController = new DigitalSubscriptionController(
     priceSummaryServiceProvider,
     assetsResolver,
     actionRefiners,
@@ -74,6 +74,7 @@ trait Controllers {
     assetsResolver,
     allSettingsProvider,
     identityService,
+    membersDataService,
     testUsers,
     controllerComponents,
     fontLoader

--- a/support-frontend/assets/helpers/errorReasons.js
+++ b/support-frontend/assets/helpers/errorReasons.js
@@ -25,7 +25,7 @@ export type ErrorReason =
 
 // ----- Functions ----- //
 
-function appropriateErrorMessage(errorReason: ?ErrorReason | string): ?string {
+function appropriateErrorMessage(errorReason: ErrorReason | string): string {
   switch (errorReason) {
     case 'insufficient_funds':
       return 'The transaction was declined due to insufficient funds in your account. Please use a different card or contact your bank.';

--- a/support-frontend/assets/pages/subscriptions-redemption/api.js
+++ b/support-frontend/assets/pages/subscriptions-redemption/api.js
@@ -16,6 +16,7 @@ import type { User } from 'helpers/subscriptionsForms/user';
 import type { Participations } from 'helpers/abTests/abtest';
 import type { Csrf } from 'helpers/csrf/csrfReducer';
 import { getOrigin } from 'helpers/url';
+import { appropriateErrorMessage } from 'helpers/errorReasons';
 
 type ValidationResult = {
   valid: boolean,
@@ -27,11 +28,15 @@ function validate(userCode: string) {
   return fetchJson(validationUrl, {});
 }
 
+function dispatchError(dispatch: Dispatch<Action>, error: Option<string>) {
+  dispatch({ type: 'SET_ERROR', error });
+}
+
 function doValidation(userCode: string, dispatch: Dispatch<Action>) {
   validate(userCode).then((result: ValidationResult) => {
-    dispatch({ type: 'SET_ERROR', error: result.errorMessage });
+    dispatchError(dispatch, result.errorMessage);
   }).catch((error) => {
-    dispatch({ type: 'SET_ERROR', error: `An error occurred while validating this code: ${error}` });
+    dispatchError(dispatch, `An error occurred while validating this code: ${error}`);
   });
 }
 
@@ -46,10 +51,10 @@ function submitCode(userCode: string, dispatch: Dispatch<Action>) {
       const submitUrl = `${getOrigin()}/subscribe/redeem/create/${userCode}`;
       window.location.assign(submitUrl);
     } else {
-      dispatch({ type: 'SET_ERROR', error: result.errorMessage });
+      dispatchError(dispatch, result.errorMessage);
     }
   }).catch((error) => {
-    dispatch({ type: 'SET_ERROR', error: `An error occurred while validating this code: ${error}` });
+    dispatchError(dispatch, `An error occurred while redeeming this code: ${error}`);
   });
 }
 
@@ -110,6 +115,7 @@ function createSubscription(
   countryId: IsoCountry,
   participations: Participations,
   csrf: Csrf,
+  dispatch: Dispatch<Action>,
 ) {
   const data = buildRegularPaymentRequest(corporateCustomer, user, currencyId, countryId, participations);
 
@@ -122,7 +128,10 @@ function createSubscription(
         const thankyouUrl = `${getOrigin()}/subscribe/redeem/thankyou`;
         window.location.replace(thankyouUrl);
       }
-    } // else { dispatch(setSubmissionError(result.error)); } // TODO: deal with this
+    } else {
+      dispatchError(dispatch, appropriateErrorMessage(result.error));
+      dispatch({ type: 'SET_STAGE', stage: 'form' });
+    }
   };
 
   postRegularPaymentRequest(

--- a/support-frontend/assets/pages/subscriptions-redemption/api.js
+++ b/support-frontend/assets/pages/subscriptions-redemption/api.js
@@ -54,7 +54,7 @@ function submitCode(userCode: string, dispatch: Dispatch<Action>) {
       dispatchError(dispatch, result.errorMessage);
     }
   }).catch((error) => {
-    dispatchError(dispatch, `An error occurred while redeeming this code: ${error}`);
+    dispatchError(dispatch, `An error occurred while validating this code: ${error}`);
   });
 }
 

--- a/support-frontend/assets/pages/subscriptions-redemption/components/stage.jsx
+++ b/support-frontend/assets/pages/subscriptions-redemption/components/stage.jsx
@@ -9,6 +9,7 @@ import ProgressMessage from 'components/progressMessage/progressMessage';
 
 import ReturnSection from 'components/subscriptionCheckouts/thankYou/returnSection';
 import type {
+  Action,
   CorporateCustomer,
   RedemptionPageState,
   Stage,
@@ -35,6 +36,7 @@ type PropTypes = {|
   countryId: IsoCountry,
   participations: Participations,
   csrf: Option<Csrf>,
+  createSub: (PropTypes) => void,
 |};
 
 // ----- State/Props Maps ----- //
@@ -51,15 +53,20 @@ function mapStateToProps(state: RedemptionPageState) {
   };
 }
 
-function createSub(props: PropTypes) {
-  createSubscription(
+function mapDispatchToProps(dispatch: Dispatch<Action>) {
+  const createSub = (props: PropTypes) => createSubscription(
     props.corporateCustomer,
     props.user,
     props.currencyId,
     props.countryId,
     props.participations,
     props.csrf || { token: '' },
+    dispatch,
   );
+
+  return {
+    createSub,
+  };
 }
 
 // ----- Component ----- //
@@ -83,7 +90,7 @@ function CheckoutStage(props: PropTypes) {
       );
 
     case 'processing':
-      createSub(props);
+      props.createSub(props);
       return (
         <div className="checkout-content">
           {props.checkoutForm}
@@ -102,4 +109,4 @@ function CheckoutStage(props: PropTypes) {
 
 // ----- Export ----- //
 
-export default connect(mapStateToProps)(CheckoutStage);
+export default connect(mapStateToProps, mapDispatchToProps)(CheckoutStage);

--- a/support-frontend/assets/pages/subscriptions-redemption/subscriptionsRedemptionReducer.js
+++ b/support-frontend/assets/pages/subscriptions-redemption/subscriptionsRedemptionReducer.js
@@ -37,6 +37,7 @@ export type RedemptionPageState = {
 export type Action =
   | { type: 'SET_USER_CODE', userCode: string }
   | { type: 'SET_ERROR', error: Option<string> }
+  | { type: 'SET_STAGE', stage: Stage }
 
 const initialState: RedemptionFormState = {
   corporateCustomer: getGlobal('corporateCustomer'),
@@ -57,6 +58,8 @@ const redemptionFormReducer = (
       return { ...previousState, userCode: action.userCode };
     case 'SET_ERROR':
       return { ...previousState, error: action.error };
+    case 'SET_STAGE':
+      return { ...previousState, stage: action.stage };
     default:
       return previousState;
   }

--- a/support-frontend/conf/routes
+++ b/support-frontend/conf/routes
@@ -84,14 +84,14 @@ GET  /$country<(uk|us|au|eu|int|nz|ca)>/subscribe                  controllers.S
 # subscribe route. We just redirect to the subscriptions site and let its geolocation handle it.
 GET  /:country/subscribe                                           controllers.Subscriptions.legacyRedirect(country: String)
 
-GET  /digital                                                      controllers.DigitalSubscription.digitalGeoRedirect()
-GET  /subscribe/digital                                            controllers.DigitalSubscription.digitalGeoRedirect()
-GET  /$country<(uk|us|au|eu|int|nz|ca)>/subscribe/digital          controllers.DigitalSubscription.digital(country: String)
+GET  /digital                                                      controllers.DigitalSubscriptionController.digitalGeoRedirect()
+GET  /subscribe/digital                                            controllers.DigitalSubscriptionController.digitalGeoRedirect()
+GET  /$country<(uk|us|au|eu|int|nz|ca)>/subscribe/digital          controllers.DigitalSubscriptionController.digital(country: String)
 
 # redirect from old checkout urls
 GET  /$country<(uk|us|au|eu|int|nz|ca)>/subscribe/digital/checkout controllers.Application.permanentRedirectWithCountry(country, location="/subscribe/digital/checkout")
-GET  /subscribe/digital/checkout                                   controllers.DigitalSubscription.displayForm()
-GET  /subscribe/digital/checkout/thankyou-existing                 controllers.DigitalSubscription.displayThankYouExisting()
+GET  /subscribe/digital/checkout                                   controllers.DigitalSubscriptionController.displayForm()
+GET  /subscribe/digital/checkout/thankyou-existing                 controllers.DigitalSubscriptionController.displayThankYouExisting()
 
 GET  /weekly                                                       controllers.WeeklySubscription.weeklyGeoRedirect(orderIsAGift: Boolean = false)
 GET  /subscribe/weekly                                             controllers.WeeklySubscription.weeklyGeoRedirect(orderIsAGift: Boolean = false)

--- a/support-frontend/test/controllers/SubscriptionsTest.scala
+++ b/support-frontend/test/controllers/SubscriptionsTest.scala
@@ -82,7 +82,7 @@ class SubscriptionsTest extends AnyWordSpec with Matchers with TestCSRFComponent
       actionRefiner: CustomActionBuilders = loggedInActionRefiner,
       identityService: IdentityService = mockedIdentityService(authenticatedIdUser.minimalUser -> idUser.asRight[String]),
       membersDataService: MembersDataService = mockedMembersDataService(hasFailed = false, hasDp = false)
-    ): DigitalSubscription = {
+    ): DigitalSubscriptionController = {
       val settingsProvider = mock[AllSettingsProvider]
       when(settingsProvider.getAllSettings()).thenReturn(allSettings)
       val client = mock[SupportWorkersClient]
@@ -107,7 +107,7 @@ class SubscriptionsTest extends AnyWordSpec with Matchers with TestCSRFComponent
       when(priceSummaryService.getPrices(any[com.gu.support.catalog.Product], any[List[PromoCode]], any[Boolean])).thenReturn(prices)
       when(priceSummaryServiceProvider.forUser(any[Boolean])).thenReturn(priceSummaryService)
 
-      new DigitalSubscription(
+      new DigitalSubscriptionController(
         priceSummaryServiceProvider = priceSummaryServiceProvider,
         assets = assetResolver,
         actionRefiners = actionRefiner,


### PR DESCRIPTION
## Why are you doing this?
We want to prevent users who already have a live Digital Subscription from also signing up for a corporate subscription. 

This PR takes the same approach as a regular digisub which is to redirect the user to this page:

<img width="931" alt="Screen Shot 2020-06-11 at 17 35 19" src="https://user-images.githubusercontent.com/181371/84415058-1fb7a180-ac0a-11ea-9701-90fb72b1ce7c.png">

We may want to do something more tailored to redemptions at some point but this is what we have agreed on for the proof of concept.

[**Trello Card**](https://trello.com/c/DH2PVZ9U/3097-handle-users-with-existing-digital-subscriptions)

