### PR TITLE
make product subscription builders into normal functions

### DIFF
--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -2,19 +2,22 @@ package com.gu.support.workers.lambdas
 
 import java.time.OffsetDateTime
 
+import cats.data.EitherT
+import cats.implicits._
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.config.Configuration
 import com.gu.config.Configuration.zuoraConfigProvider
 import com.gu.monitoring.SafeLogger
 import com.gu.services.{ServiceProvider, Services}
+import com.gu.support.config.TouchPointEnvironments
 import com.gu.support.promotions.{PromoError, PromotionService}
 import com.gu.support.workers._
-import com.gu.support.workers.exceptions.{RetryException, RetryNone}
 import com.gu.support.workers.states.{CreateZuoraSubscriptionState, SendThankYouEmailState}
 import com.gu.support.zuora.api._
 import com.gu.support.zuora.api.response._
 import com.gu.support.zuora.domain.DomainSubscription
 import com.gu.zuora.ProductSubscriptionBuilders._
+import org.joda.time.{DateTimeZone, LocalDate}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
@@ -35,8 +38,10 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
     services: Services
   ): FutureHandlerResult = {
     val now = () => OffsetDateTime.now
+    val now2 = () => LocalDate.now(DateTimeZone.UTC)
     for {
-      subscribeItem <- Future.fromTry(buildSubscribeItem(state, services.promotionService).left.map(BuildSubscribePromoError).toTry)
+      subscriptionData <- buildSubscriptionData(state, services.promotionService, now2)
+      subscribeItem = buildSubscribeItem(state, subscriptionData)
       identityId <- Future.fromTry(IdentityId(state.user.id))
         .withLogging("identity id")
       maybeDomainSubscription <- GetSubscriptionWithCurrentRequestId(services.zuoraService, state.requestId, identityId, state.product.billingPeriod, now)
@@ -111,61 +116,64 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
       state.acquisitionData
     )
 
-  private def buildSubscribeItem(state: CreateZuoraSubscriptionState, promotionService: PromotionService): Either[PromoError, SubscribeItem] = {
+  private def buildSubscribeItem(state: CreateZuoraSubscriptionState, subscriptionData: SubscriptionData): SubscribeItem = {
     val billingEnabled = state.paymentMethod.isLeft
-    buildSubscriptionData(state, promotionService).map { subscriptionData =>
-      //Documentation for this request is here: https://www.zuora.com/developer/api-reference/#operation/Action_POSTsubscribe
-      SubscribeItem(
-        account = buildAccount(state),
-        billToContact = buildContactDetails(state.user, None, state.user.billingAddress),
-        soldToContact = state.user.deliveryAddress map (buildContactDetails(state.user, state.giftRecipient, _, state.user.deliveryInstructions)),
-        paymentMethod = state.paymentMethod.left.toOption,
-        subscriptionData = subscriptionData,
-        subscribeOptions = SubscribeOptions(billingEnabled, billingEnabled)
-      )
-    }
+    //Documentation for this request is here: https://www.zuora.com/developer/api-reference/#operation/Action_POSTsubscribe
+    SubscribeItem(
+      account = buildAccount(state),
+      billToContact = buildContactDetails(state.user, None, state.user.billingAddress),
+      soldToContact = state.user.deliveryAddress map (buildContactDetails(state.user, state.giftRecipient, _, state.user.deliveryInstructions)),
+      paymentMethod = state.paymentMethod.left.toOption,
+      subscriptionData = subscriptionData,
+      subscribeOptions = SubscribeOptions(generateInvoice = billingEnabled, processPayments = billingEnabled)
+    )
   }
 
-  private def buildSubscriptionData(state: CreateZuoraSubscriptionState, promotionService: PromotionService) = {
+  private def buildSubscriptionData(
+    state: CreateZuoraSubscriptionState,
+    promotionService: => PromotionService,
+    now: () => LocalDate
+  ): Future[SubscriptionData] = {
     val isTestUser = state.user.isTestUser
     val config = zuoraConfigProvider.get(isTestUser)
-    val readerType: ReaderType = state.giftRecipient match  {
-      case _: Some[GiftRecipient] => ReaderType.Gift
-      case _ => ReaderType.Direct
-    }
-    val stage = Configuration.stage
+    val environment = TouchPointEnvironments.fromStage(Configuration.stage, isTestUser)
 
-    state.product match {
-      case c: Contribution => Right(c.build(state.requestId, config))
-      case d: DigitalPack => d.build(
+    val eventualErrorOrSubscriptionData = state.product match {
+      case c: Contribution => EitherT.pure[Future, Throwable](buildContributionSubscription(c, state.requestId, config))
+      case d: DigitalPack => buildDigitalPackSubscription(
+        d,
         state.requestId,
-        config,
+        config.digitalPack,
         state.user.billingAddress.country,
         state.promoCode,
         state.paymentMethod,
         promotionService,
-        stage,
-        isTestUser
-      )
-      case p: Paper => p.build(
+        environment,
+        now
+      ).leftMap(BuildSubscribePromoError)
+      case p: Paper => EitherT.fromEither[Future](buildPaperSubscription(
+        p,
         state.requestId,
         state.user.billingAddress.country,
         state.promoCode,
         state.firstDeliveryDate,
         promotionService,
-        stage,
-        isTestUser
-      )
-      case w: GuardianWeekly => w.build(
-        state.requestId,
-        state.user.billingAddress.country,
-        state.promoCode,
-        state.firstDeliveryDate,
-        promotionService,
-        readerType,
-        stage,
-        isTestUser
-      )
+        environment
+      ).leftMap(BuildSubscribePromoError))
+      case w: GuardianWeekly =>
+        EitherT.fromEither[Future](buildGuardianWeeklySubscription(
+          w,
+          state.requestId,
+          state.user.billingAddress.country,
+          state.promoCode,
+          state.firstDeliveryDate,
+          promotionService,
+          if (state.giftRecipient.isDefined) ReaderType.Gift else ReaderType.Direct,
+          environment
+        ).leftMap(BuildSubscribePromoError))
+    }
+    eventualErrorOrSubscriptionData.value.flatMap { errorOrSubscriptionData =>
+      Future.fromTry(errorOrSubscriptionData.toTry)
     }
   }
 

--- a/support-workers/src/main/scala/com/gu/zuora/ProductSubscriptionBuilders.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/ProductSubscriptionBuilders.scala
@@ -2,11 +2,12 @@ package com.gu.zuora
 
 import java.util.UUID
 
+import cats.data.EitherT
+import cats.implicits._
 import com.gu.i18n.Country
 import com.gu.support.catalog
 import com.gu.support.catalog.{ProductRatePlan, ProductRatePlanId}
-import com.gu.support.config.TouchPointEnvironments.fromStage
-import com.gu.support.config.{Stage, ZuoraConfig}
+import com.gu.support.config.{TouchPointEnvironment, ZuoraConfig, ZuoraDigitalPackConfig}
 import com.gu.support.promotions.{DefaultPromotions, PromoCode, PromoError, PromotionService}
 import com.gu.support.redemptions.RedemptionData
 import com.gu.support.workers.GuardianWeeklyExtensions._
@@ -16,6 +17,7 @@ import com.gu.support.workers.exceptions.{BadRequestException, CatalogDataNotFou
 import com.gu.support.zuora.api._
 import org.joda.time.{DateTimeZone, Days, LocalDate}
 
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
 object ProductSubscriptionBuilders {
@@ -26,40 +28,39 @@ object ProductSubscriptionBuilders {
       case None => throw new CatalogDataNotFoundException(s"RatePlanId not found for $productDescription")
     }
 
-  implicit class ContributionSubscriptionBuilder(val contribution: Contribution) extends ProductSubscriptionBuilder {
-    def build(requestId: UUID, config: ZuoraConfig): SubscriptionData = {
-      val contributionConfig = config.contributionConfig(contribution.billingPeriod)
-      buildProductSubscription(
-        requestId,
-        contributionConfig.productRatePlanId,
-        List(
-          RatePlanChargeData(
-            ContributionRatePlanCharge(contributionConfig.productRatePlanChargeId, price = contribution.amount) //Pass the amount the user selected into Zuora
-          )
+  def buildContributionSubscription(contribution: Contribution, requestId: UUID, config: ZuoraConfig): SubscriptionData = {
+    val contributionConfig = config.contributionConfig(contribution.billingPeriod)
+    buildProductSubscription(
+      requestId,
+      contributionConfig.productRatePlanId,
+      List(
+        RatePlanChargeData(
+          ContributionRatePlanCharge(contributionConfig.productRatePlanChargeId, price = contribution.amount) //Pass the amount the user selected into Zuora
         )
       )
-    }
+    )
   }
 
-  implicit class DigitalPackSubscriptionBuilder(val digitalPack: DigitalPack) extends ProductSubscriptionBuilder {
-    def build(
+  object buildDigitalPackSubscription {
+
+    def apply(
+      digitalPack: DigitalPack,
       requestId: UUID,
-      config: ZuoraConfig,
+      zuoraDigitalPackConfig: ZuoraDigitalPackConfig,
       country: Country,
       maybePromoCode: Option[PromoCode],
       paymentMethod: Either[PaymentMethod, RedemptionData],
       promotionService: PromotionService,
-      stage: Stage,
-      isTestUser: Boolean
-    ): Either[PromoError, SubscriptionData] = {
+      environment: TouchPointEnvironment,
+      now: () => LocalDate
+    )(implicit ec: ExecutionContext): EitherT[Future, PromoError, SubscriptionData] = {
 
       val contractEffectiveDate = LocalDate.now(DateTimeZone.UTC)
       val contractAcceptanceDate = contractEffectiveDate
-        .plusDays(config.digitalPack.defaultFreeTrialPeriod)
-        .plusDays(config.digitalPack.paymentGracePeriod)
+        .plusDays(zuoraDigitalPackConfig.defaultFreeTrialPeriod)
+        .plusDays(zuoraDigitalPackConfig.paymentGracePeriod)
 
-
-      val productRatePlanId = validateRatePlan(digitalPack.productRatePlan(fromStage(stage, isTestUser), fixedTerm = false), digitalPack.describe)
+      val productRatePlanId = validateRatePlan(digitalPack.productRatePlan(environment, fixedTerm = false), digitalPack.describe)
 
       val subscriptionData = buildProductSubscription(
         requestId,
@@ -73,56 +74,52 @@ object ProductSubscriptionBuilders {
         redemptionData => redemptionData.redeem(subscriptionData.subscription)
       )
 
+      EitherT.fromEither[Future](
       applyPromoCode(promotionService, maybePromoCode, country, productRatePlanId, subscriptionData.copy(subscription = redeemedSub))
-    }
-
-    def maybeRedeemCode(maybeRedemptionData: Option[RedemptionData], subscriptionData: SubscriptionData): SubscriptionData = {
-      val redeemedSub = maybeRedemptionData.map(_.redeem(subscriptionData.subscription)).getOrElse(subscriptionData.subscription)
-      subscriptionData.copy(subscription = redeemedSub)
-    }
-  }
-
-  implicit class PaperSubscriptionBuilder(val paper: Paper) extends ProductSubscriptionBuilder {
-    def build(
-      requestId: UUID,
-      country: Country,
-      maybePromoCode: Option[PromoCode],
-      firstDeliveryDate: Option[LocalDate],
-      promotionService: PromotionService,
-      stage: Stage,
-      isTestUser: Boolean
-    ): Either[PromoError, SubscriptionData] = {
-
-      val contractEffectiveDate = LocalDate.now(DateTimeZone.UTC)
-
-      val contractAcceptanceDate = Try(firstDeliveryDate.get) match {
-        case Success(value) => value
-        case Failure(e) => throw new BadRequestException(s"First delivery date was not provided. It is required for a print subscription.", e)
-      }
-
-      val productRatePlanId = validateRatePlan(paper.productRatePlan(fromStage(stage, isTestUser), fixedTerm = false), paper.describe)
-
-      val subscriptionData = buildProductSubscription(
-        requestId,
-        productRatePlanId,
-        contractAcceptanceDate = contractAcceptanceDate,
-        contractEffectiveDate = contractEffectiveDate,
       )
-
-      applyPromoCode(promotionService, maybePromoCode, country, productRatePlanId, subscriptionData)
     }
+
   }
 
-  implicit class GuardianWeeklySubscriptionBuilder(val guardianWeekly: GuardianWeekly) extends ProductSubscriptionBuilder {
-    def build(
+  def buildPaperSubscription(
+    paper: Paper,
+    requestId: UUID,
+    country: Country,
+    maybePromoCode: Option[PromoCode],
+    firstDeliveryDate: Option[LocalDate],
+    promotionService: PromotionService,
+    environment: TouchPointEnvironment
+  ): Either[PromoError, SubscriptionData] = {
+
+    val contractEffectiveDate = LocalDate.now(DateTimeZone.UTC)
+
+    val contractAcceptanceDate = Try(firstDeliveryDate.get) match {
+      case Success(value) => value
+      case Failure(e) => throw new BadRequestException(s"First delivery date was not provided. It is required for a print subscription.", e)
+    }
+
+    val productRatePlanId = validateRatePlan(paper.productRatePlan(environment, fixedTerm = false), paper.describe)
+
+    val subscriptionData = buildProductSubscription(
+      requestId,
+      productRatePlanId,
+      contractAcceptanceDate = contractAcceptanceDate,
+      contractEffectiveDate = contractEffectiveDate,
+    )
+
+    applyPromoCode(promotionService, maybePromoCode, country, productRatePlanId, subscriptionData)
+  }
+
+  object buildGuardianWeeklySubscription {
+    def apply(
+      guardianWeekly: GuardianWeekly,
       requestId: UUID,
       country: Country,
       maybePromoCode: Option[PromoCode],
       firstDeliveryDate: Option[LocalDate],
       promotionService: PromotionService,
       readerType: ReaderType,
-      stage: Stage,
-      isTestUser: Boolean,
+      environment: TouchPointEnvironment,
       contractEffectiveDate: LocalDate = LocalDate.now(DateTimeZone.UTC)
     ): Either[PromoError, SubscriptionData] = {
 
@@ -131,12 +128,11 @@ object ProductSubscriptionBuilders {
         case Failure(e) => throw new BadRequestException(s"First delivery date was not provided. It is required for a Guardian Weekly subscription.", e)
       }
 
-      val environment = fromStage(stage, isTestUser)
       val gift = readerType == ReaderType.Gift
 
       val recurringProductRatePlanId = validateRatePlan(guardianWeekly.productRatePlan(environment, fixedTerm = gift), guardianWeekly.describe)
 
-      val promotionProductRatePlanId = if(isIntroductoryPromotion(maybePromoCode)) {
+      val promotionProductRatePlanId = if (isIntroductoryPromotion(guardianWeekly.billingPeriod, maybePromoCode)) {
         guardianWeekly.introductoryRatePlan(environment).map(_.id).getOrElse(recurringProductRatePlanId)
       } else recurringProductRatePlanId
 
@@ -152,13 +148,9 @@ object ProductSubscriptionBuilders {
       applyPromoCode(promotionService, maybePromoCode, country, promotionProductRatePlanId, subscriptionData)
     }
 
-    private[this] def isIntroductoryPromotion(maybePromoCode: Option[PromoCode]) =
-      maybePromoCode.contains(DefaultPromotions.GuardianWeekly.NonGift.sixForSix) && guardianWeekly.billingPeriod == SixWeekly
+    private[this] def isIntroductoryPromotion(billingPeriod: BillingPeriod, maybePromoCode: Option[PromoCode]) =
+      maybePromoCode.contains(DefaultPromotions.GuardianWeekly.NonGift.sixForSix) && billingPeriod == SixWeekly
   }
-
-}
-
-trait ProductSubscriptionBuilder {
 
   protected def buildProductSubscription(
     createdRequestId: UUID,
@@ -169,7 +161,7 @@ trait ProductSubscriptionBuilder {
     readerType: ReaderType = ReaderType.Direct,
     initialTermMonths: Int = 12
   ): SubscriptionData = {
-    val (initialTerm, autoRenew, initialTermPeriodType) = if(readerType == ReaderType.Gift)
+    val (initialTerm, autoRenew, initialTermPeriodType) = if (readerType == ReaderType.Gift)
       (initialTermInDays(contractEffectiveDate, contractAcceptanceDate, initialTermMonths), false, Day)
     else
       (12, true, Month)
@@ -216,4 +208,5 @@ trait ProductSubscriptionBuilder {
 
     withPromotion.getOrElse(Right(subscriptionData))
   }
+
 }

--- a/support-workers/src/main/scala/com/gu/zuora/ProductSubscriptionBuilders.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/ProductSubscriptionBuilders.scala
@@ -52,10 +52,10 @@ object ProductSubscriptionBuilders {
       paymentMethod: Either[PaymentMethod, RedemptionData],
       promotionService: PromotionService,
       environment: TouchPointEnvironment,
-      now: () => LocalDate
+      today: () => LocalDate
     )(implicit ec: ExecutionContext): EitherT[Future, PromoError, SubscriptionData] = {
 
-      val contractEffectiveDate = LocalDate.now(DateTimeZone.UTC)
+      val contractEffectiveDate = today()
       val contractAcceptanceDate = contractEffectiveDate
         .plusDays(zuoraDigitalPackConfig.defaultFreeTrialPeriod)
         .plusDays(zuoraDigitalPackConfig.paymentGracePeriod)

--- a/support-workers/src/test/scala/com/gu/zuora/ProductSubscriptionBuildersSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/ProductSubscriptionBuildersSpec.scala
@@ -5,18 +5,17 @@ import java.util.UUID
 import com.gu.i18n.Country
 import com.gu.i18n.Currency.GBP
 import com.gu.support.catalog.Domestic
-import com.gu.support.config.Stages.DEV
+import com.gu.support.config.TouchPointEnvironments.SANDBOX
 import com.gu.support.promotions.PromotionService
 import com.gu.support.workers.{GuardianWeekly, Quarterly}
 import com.gu.support.zuora.api.{Day, Month, ReaderType, SubscriptionData}
 import com.gu.zuora.ProductSubscriptionBuilders._
 import org.joda.time.LocalDate
-import org.scalatest.Assertion
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar._
 
-class ProductSubscriptionBuildersSpec extends AnyFlatSpec with Matchers with ProductSubscriptionBuilder {
+class ProductSubscriptionBuildersSpec extends AnyFlatSpec with Matchers {
 
   "InitialTermLength" should "be correct" in {
     val termStart = new LocalDate(2019, 2, 3)
@@ -74,24 +73,24 @@ class ProductSubscriptionBuildersSpec extends AnyFlatSpec with Matchers with Pro
   lazy val firstDeliveryDate = saleDate.plusDays(3)
 
   lazy val gift: SubscriptionData =
-    weekly.build(
+    buildGuardianWeeklySubscription(
+      weekly,
       UUID.randomUUID(),
       Country.UK, None,
       Some(firstDeliveryDate),
       promotionService,
       ReaderType.Gift,
-      DEV,
-      isTestUser = false,
+      SANDBOX,
       contractEffectiveDate = saleDate).right.get
 
-  lazy val nonGift = weekly.build(
+  lazy val nonGift = buildGuardianWeeklySubscription(
+    weekly,
     UUID.randomUUID(),
     Country.UK, None,
     Some(firstDeliveryDate),
     promotionService,
     ReaderType.Direct,
-    DEV,
-    isTestUser = false,
+    SANDBOX,
     contractEffectiveDate = saleDate).right.get
 
 }


### PR DESCRIPTION
## Why are you doing this?

The subscription builders are using implicit classes and traits which adds boilerplate and difficulty in navigating outside of an IDE.  This PR turns them into normal functions, and injects the date rather than depending on it directly, to make the code more testable.

precursor to https://github.com/guardian/support-frontend/pull/2526