### PR TITLE
use joda time most places for consistency

### DIFF
--- a/support-workers/src/main/scala/com/gu/support/workers/GetSubscriptionWithCurrentRequestId.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/GetSubscriptionWithCurrentRequestId.scala
@@ -1,15 +1,14 @@
 package com.gu.support.workers
 
-import java.time.OffsetDateTime
 import java.util.UUID
 
 import cats.implicits._
 import com.gu.FutureLogging.LogImplicitFuture
 import com.gu.support.zuora.domain.{CreatedRequestId, DomainSubscription}
 import com.gu.zuora.ZuoraService
+import org.joda.time.DateTime
 
 import scala.concurrent.{ExecutionContext, Future}
-
 
 object GetSubscriptionWithCurrentRequestId {
 
@@ -18,7 +17,7 @@ object GetSubscriptionWithCurrentRequestId {
     requestId: UUID,
     identityId: IdentityId,
     billingPeriod: BillingPeriod,
-    now: () => OffsetDateTime
+    now: () => DateTime
   )(implicit ec: ExecutionContext): Future[Option[DomainSubscription]] = for {
     accountNumbers <- zuoraService.getAccountFields(identityId, now())
       .withLogging("getAccountFields")

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
@@ -1,7 +1,6 @@
 package com.gu.support.workers.integration
 
 import java.io.ByteArrayOutputStream
-import java.time.OffsetDateTime
 
 import com.gu.config.Configuration.{promotionsConfigProvider, zuoraConfigProvider}
 import com.gu.okhttp.RequestRunners.configurableFutureRunner
@@ -19,6 +18,7 @@ import com.gu.support.zuora.api.response.ZuoraAccountNumber
 import com.gu.support.zuora.api.{PreviewSubscribeRequest, SubscribeRequest}
 import com.gu.test.tags.annotations.IntegrationTest
 import com.gu.zuora.ZuoraService
+import org.joda.time.DateTime
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.mockito.invocation.InvocationOnMock
@@ -96,7 +96,7 @@ class CreateZuoraSubscriptionSpec extends AsyncLambdaSpec with MockServicesCreat
     // Need to return None from the Zuora service `getRecurringSubscription`
     // method or the subscribe step gets skipped
     // if these methods weren't coupled into one class then we could pass them separately and avoid reflection
-    when(mockZuora.getAccountFields(any[IdentityId], any[OffsetDateTime]))
+    when(mockZuora.getAccountFields(any[IdentityId], any[DateTime]))
       .thenReturn(Future.successful(Nil))
     when(mockZuora.getSubscriptions(any[ZuoraAccountNumber]))
       .thenReturn(Future.successful(Nil))

--- a/support-workers/src/test/scala/com/gu/zuora/ZuoraITSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/ZuoraITSpec.scala
@@ -1,0 +1,147 @@
+package com.gu.zuora
+
+import java.util.UUID
+
+import com.gu.config.Configuration.zuoraConfigProvider
+import com.gu.i18n.Currency.{AUD, EUR, GBP, USD}
+import com.gu.okhttp.RequestRunners
+import com.gu.support.workers.{GetSubscriptionWithCurrentRequestId, IdentityId, Monthly}
+import com.gu.support.zuora.api.response.{ZuoraAccountNumber, ZuoraErrorResponse}
+import com.gu.support.zuora.api.{PreviewSubscribeRequest, SubscribeRequest}
+import com.gu.test.tags.annotations.IntegrationTest
+import com.gu.zuora.Fixtures._
+import org.joda.time.{DateTime, DateTimeZone}
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration._
+
+@IntegrationTest
+class ZuoraITSpec extends AsyncFlatSpec with Matchers {
+
+  def uatService: ZuoraService = new ZuoraService(zuoraConfigProvider.get(true), RequestRunners.configurableFutureRunner(30.seconds))
+
+  // actual sub "CreatedDate": "2017-12-07T15:47:21.000+00:00",
+  val earlyDate = new DateTime(2010, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC)
+
+  "ZuoraService" should "retrieve an account" in {
+    uatService.getAccount(Fixtures.accountNumber).map {
+      response =>
+        response.success should be(true)
+        response.basicInfo.accountNumber should be(Fixtures.accountNumber)
+    }
+  }
+
+  it should "retrieve account ids from an Identity id" in {
+    uatService.getAccountFields(IdentityId("30001758").get, earlyDate).map {
+      response =>
+        response.nonEmpty should be(true)
+    }
+  }
+
+  it should "be resistant to 'ZOQL injection'" in {
+    // try https://github.com/guardian/zuora-auto-cancel/blob/master/lib/zuora/src/main/scala/com/gu/util/zuora/SafeQueryBuilder.scala
+    IdentityId("30000701' or status = 'Active").isFailure should be(true)
+  }
+
+  it should "retrieve subscriptions from an account id" in {
+    uatService.getSubscriptions(ZuoraAccountNumber("A00071408")).map {
+      response =>
+        response.nonEmpty should be(true)
+        response.head.ratePlans.head.productRatePlanId should be(zuoraConfigProvider.get(true).monthlyContribution.productRatePlanId)
+    }
+  }
+
+  it should "be able to find a monthly recurring subscription" in {
+    GetSubscriptionWithCurrentRequestId(
+      uatService,
+      UUID.fromString("cac90497-3001-4dbc-88c3-1f47d54c511c"),
+      IdentityId("30001758").get,
+      Monthly,
+      () => earlyDate
+    ).map {
+      _.flatMap(_.ratePlans.headOption.map(_.productName)) should be(Some("Contributor"))
+    }
+  }
+
+  it should "ignore a subscription with wrong session id" in {
+    GetSubscriptionWithCurrentRequestId(
+      uatService,
+      UUID.fromString("00000000-3001-4dbc-88c3-1f47d54c511c"),
+      IdentityId("30001758").get,
+      Monthly,
+      () => earlyDate
+    ).map {
+      _ should be(None)
+    }
+  }
+
+  it should "retrieve a default paymentMethodId from an account number" in {
+    val accountNumber = "A00072689"
+    val defaultPaymentMethodId = Some("2c92c0f9624bbc6c01624eac30f86724")
+    uatService.getDefaultPaymentMethodId(accountNumber).map {
+      response =>
+        response should be(defaultPaymentMethodId)
+    }
+  }
+
+  it should "retrieve a Direct Debit mandateId from a valid paymentMethodId" in {
+    val defaultPaymentMethodId = "2c92c0f9624bbc6c01624eac30f86724"
+    val mandateId = "65HK26E"
+    uatService.getDirectDebitMandateId(defaultPaymentMethodId).map {
+      response =>
+        response should be(Some(mandateId))
+    }
+  }
+
+  it should "return None when given an invalid paymentMethodId" in {
+    val invalidPaymentMethodId = "xxxx"
+    uatService.getDirectDebitMandateId(invalidPaymentMethodId).map {
+      response =>
+        response should be(None)
+    }
+  }
+
+  it should "retrieve a Direct Debit mandateId from a valid account number" in {
+    val accountNumber = "A00072689"
+    val mandateId = Some("65HK26E")
+    uatService.getMandateIdFromAccountNumber(accountNumber).map {
+      response =>
+        response should be(mandateId)
+    }
+  }
+
+  it should "return None when given an invalid account number" in {
+    val invalidAccountNumber = "xxxx"
+    uatService.getMandateIdFromAccountNumber(invalidAccountNumber).map {
+      response =>
+        response should be(None)
+    }
+  }
+
+  "Preview request" should "succeed" in doRequest(Left(PreviewSubscribeRequest.fromSubscribe(creditCardSubscriptionRequest(GBP).subscribes.head, 13)))
+
+  "Subscribe request" should "succeed" in doRequest(Right(creditCardSubscriptionRequest(GBP)))
+
+  it should "work for $USD contributions" in doRequest(Right(creditCardSubscriptionRequest(USD)))
+
+  it should "work for €Euro contributions" in doRequest(Right(creditCardSubscriptionRequest(EUR)))
+
+  it should "work for AUD contributions" in doRequest(Right(creditCardSubscriptionRequest(AUD)))
+
+  it should "work with Direct Debit" in doRequest(Right(directDebitSubscriptionRequest))
+
+  it should "work for a paper subscription" in doRequest(Right(directDebitSubscriptionRequestPaper))
+
+  def doRequest(request: Either[PreviewSubscribeRequest, SubscribeRequest]) = {
+    //Accounts will be created (or previewed) in Sandbox
+    val zuoraService = new ZuoraService(zuoraConfigProvider.get(), RequestRunners.configurableFutureRunner(30.seconds))
+    val futureResponse = request.fold(zuoraService.previewSubscribe, zuoraService.subscribe)
+    futureResponse.map {
+      response =>
+        response.head.success should be(true)
+    }.recover {
+      case e: ZuoraErrorResponse => fail(e)
+    }
+  }
+}

--- a/support-workers/src/test/scala/com/gu/zuora/ZuoraSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/ZuoraSpec.scala
@@ -1,146 +1,17 @@
 package com.gu.zuora
 
-import java.time.{OffsetDateTime, ZoneOffset}
-import java.util.UUID
-
-import com.gu.config.Configuration.zuoraConfigProvider
-import com.gu.i18n.Currency.{AUD, EUR, GBP, USD}
-import com.gu.okhttp.RequestRunners
-import com.gu.support.workers.{GetSubscriptionWithCurrentRequestId, IdentityId, Monthly}
-import com.gu.support.zuora.api.{PreviewSubscribeRequest, SubscribeRequest}
-import com.gu.support.zuora.api.response.{ZuoraAccountNumber, ZuoraErrorResponse}
-import com.gu.test.tags.annotations.IntegrationTest
-import com.gu.zuora.Fixtures._
+import org.joda.time.{DateTime, DateTimeZone}
+import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.flatspec.AsyncFlatSpec
 
-import scala.concurrent.duration._
+class ZuoraSpec extends AnyFlatSpec with Matchers {
 
-@IntegrationTest
-class ZuoraSpec extends AsyncFlatSpec with Matchers {
-
-  def uatService: ZuoraService = new ZuoraService(zuoraConfigProvider.get(true), RequestRunners.configurableFutureRunner(30.seconds))
-
-  val earlyDate = OffsetDateTime.of(2010, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
-
-  "ZuoraService" should "retrieve an account" in {
-    uatService.getAccount(Fixtures.accountNumber).map {
-      response =>
-        response.success should be(true)
-        response.basicInfo.accountNumber should be(Fixtures.accountNumber)
-    }
+  "zuora service" should "correctly format dates" in {
+    // https://knowledgecenter.zuora.com/Central_Platform/Query/ZOQL
+    // 2015-02-28T23:54:01-08:00
+    val now = new DateTime(2020, 1, 27, 12, 21, 30, DateTimeZone.UTC)
+    val queryString = ZuoraService.updatedClause(now)
+    queryString should be("UpdatedDate > '2019-12-30T12:21:30Z'")
   }
 
-  it should "retrieve account ids from an Identity id" in {
-    uatService.getAccountFields(IdentityId("30001758").get, earlyDate).map {
-      response =>
-        response.nonEmpty should be(true)
-    }
-  }
-
-  it should "be resistant to 'ZOQL injection'" in {
-    // try https://github.com/guardian/zuora-auto-cancel/blob/master/lib/zuora/src/main/scala/com/gu/util/zuora/SafeQueryBuilder.scala
-    IdentityId("30000701' or status = 'Active").isFailure should be(true)
-  }
-
-  it should "retrieve subscriptions from an account id" in {
-    uatService.getSubscriptions(ZuoraAccountNumber("A00071408")).map {
-      response =>
-        response.nonEmpty should be(true)
-        response.head.ratePlans.head.productRatePlanId should be(zuoraConfigProvider.get(true).monthlyContribution.productRatePlanId)
-    }
-  }
-
-  it should "be able to find a monthly recurring subscription" in {
-    GetSubscriptionWithCurrentRequestId(
-      uatService,
-      UUID.fromString("cac90497-3001-4dbc-88c3-1f47d54c511c"),
-      IdentityId("30001758").get,
-      Monthly,
-      () => earlyDate
-    ).map {
-      _.flatMap(_.ratePlans.headOption.map(_.productName)) should be(Some("Contributor"))
-    }
-  }
-
-  it should "ignore a subscription with wrong session id" in {
-    GetSubscriptionWithCurrentRequestId(
-      uatService,
-      UUID.fromString("00000000-3001-4dbc-88c3-1f47d54c511c"),
-      IdentityId("30001758").get,
-      Monthly,
-      () => earlyDate
-    ).map {
-      _ should be(None)
-    }
-  }
-
-  it should "retrieve a default paymentMethodId from an account number" in {
-    val accountNumber = "A00072689"
-    val defaultPaymentMethodId = Some("2c92c0f9624bbc6c01624eac30f86724")
-    uatService.getDefaultPaymentMethodId(accountNumber).map {
-      response =>
-        response should be(defaultPaymentMethodId)
-    }
-  }
-
-  it should "retrieve a Direct Debit mandateId from a valid paymentMethodId" in {
-    val defaultPaymentMethodId = "2c92c0f9624bbc6c01624eac30f86724"
-    val mandateId = "65HK26E"
-    uatService.getDirectDebitMandateId(defaultPaymentMethodId).map {
-      response =>
-        response should be(Some(mandateId))
-    }
-  }
-
-  it should "return None when given an invalid paymentMethodId" in {
-    val invalidPaymentMethodId = "xxxx"
-    uatService.getDirectDebitMandateId(invalidPaymentMethodId).map {
-      response =>
-        response should be(None)
-    }
-  }
-
-  it should "retrieve a Direct Debit mandateId from a valid account number" in {
-    val accountNumber = "A00072689"
-    val mandateId = Some("65HK26E")
-    uatService.getMandateIdFromAccountNumber(accountNumber).map {
-      response =>
-        response should be(mandateId)
-    }
-  }
-
-  it should "return None when given an invalid account number" in {
-    val invalidAccountNumber = "xxxx"
-    uatService.getMandateIdFromAccountNumber(invalidAccountNumber).map {
-      response =>
-        response should be(None)
-    }
-  }
-
-  "Preview request" should "succeed" in doRequest(Left(PreviewSubscribeRequest.fromSubscribe(creditCardSubscriptionRequest(GBP).subscribes.head, 13)))
-
-  "Subscribe request" should "succeed" in doRequest(Right(creditCardSubscriptionRequest(GBP)))
-
-  it should "work for $USD contributions" in doRequest(Right(creditCardSubscriptionRequest(USD)))
-
-  it should "work for €Euro contributions" in doRequest(Right(creditCardSubscriptionRequest(EUR)))
-
-  it should "work for AUD contributions" in doRequest(Right(creditCardSubscriptionRequest(AUD)))
-
-  it should "work with Direct Debit" in doRequest(Right(directDebitSubscriptionRequest))
-
-  it should "work for a paper subscription" in doRequest(Right(directDebitSubscriptionRequestPaper))
-
-  def doRequest(request: Either[PreviewSubscribeRequest, SubscribeRequest]) = {
-    //Accounts will be created (or previewed) in Sandbox
-    val zuoraService = new ZuoraService(zuoraConfigProvider.get(), RequestRunners.configurableFutureRunner(30.seconds))
-    val futureResponse = request.fold(zuoraService.previewSubscribe, zuoraService.subscribe)
-    futureResponse.map {
-      response =>
-        response.head.success should be(true)
-    }.recover {
-      case e: ZuoraErrorResponse => fail(e)
-    }
-  }
 }


### PR DESCRIPTION
## Why are you doing this?

We noticed that joda and java time were mixed in the same codebase.
It makes sense to be consistent.
It would be slightly better to choose java time, as joda time has been superseded from java 8, but that would be a health task for another day.

There are two other places we use java time `ofDays`, but they are to call the test users library
https://github.com/guardian/support-frontend/blob/9cf8941e823860e17f409a1d12577ce7aa770fb4/support-frontend/test/selenium/util/PostDeployTestUser.scala#L15
https://github.com/guardian/support-frontend/blob/f00be2f4a2a495fb87025e34476125357e71984e/support-frontend/app/services/TestUserService.scala#L13
calling this function
https://github.com/guardian/identity-test-users/blob/461286656b7443b8b0e43e10b89426b68138f756/src/main/scala/com/gu/identity/testing/usernames/TestUsernames.scala#L27
which is probably owned by us but hasn't been touched in over 2 years.  Those can stay as they are.