### PR TITLE
Ignore subs checkouts selenium tests

### DIFF
--- a/support-frontend/test/selenium/subscriptions/CheckoutsSpec.scala
+++ b/support-frontend/test/selenium/subscriptions/CheckoutsSpec.scala
@@ -4,10 +4,11 @@ import org.openqa.selenium.WebDriver
 import org.scalatest.concurrent.Eventually
 import org.scalatest.featurespec.AnyFeatureSpec
 import org.scalatest.time.{Minute, Seconds, Span}
-import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, GivenWhenThen}
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll, GivenWhenThen, Ignore}
 import selenium.subscriptions.pages._
 import selenium.util._
 
+@Ignore
 class CheckoutsSpec extends AnyFeatureSpec
   with GivenWhenThen
   with BeforeAndAfter


### PR DESCRIPTION
## Why are you doing this?

[This Identity PR](https://github.com/guardian/identity-frontend/pull/593) has broken the subscriptions checkout post-deployment tests because it introduces a captcha into the register flow. Discussions are ongoing about how to resolve this but in the meantime we should prevent the failing tests from running as it is just creating noise.