### PR TITLE
Add og:image for Aus moment

### DIFF
--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -155,7 +155,6 @@ class Application(
         "https://i.guim.co.uk/img/media/74b15a65c479bfe53151fceeb7d948f125a66af2/0_0_2400_1260/1000.png?quality=85&s=4b52891c0a86da6c08f2dc6e8308d211"
   }
 
-  //noinspection ScalaStyle
   private def contributionsHtml(countryCode: String, geoData: GeoData, idUser: Option[IdUser],
                                 campaignCode: Option[String], guestAccountCreationToken: Option[String])
                                (implicit request: RequestHeader, settings: AllSettings) = {

--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -141,41 +141,19 @@ class Application(
     ).map(_.withSettingsSurrogateKey)
   }
 
-  val ausMomentEnabled =
-    settingsProvider
-      .getAllSettings()
-      .switches
-      .experiments
-      .get("ausMomentEnabled")
-      .exists(switch => switch.state.isOn)
-
-  private def title(geoData: GeoData): String = {
-    if (geoData.countryGroup.contains(UK) && ausMomentEnabled) //TODO: change UK to Australia
-      "Guardian Australia supporters are doing something powerful"
-    else
-      "Support the Guardian | Make a Contribution"
-  }
-
-  private def description(geoData: GeoData): Option[String] = {
-    if (geoData.countryGroup.contains(UK) && ausMomentEnabled) //TODO: change UK to Australia
-      Some("Why am I supporting the Guardian? Because I believe their vital, " +
-        "independent journalism should be open and free to all. \nJoin me. With your support, we can do more.")
-    else
-      stringsConfig.contributionsLandingDescription
-  }
-
   private def shareImageUrl(geoData: GeoData): String = {
+    val ausMomentEnabled =
+      settingsProvider
+        .getAllSettings()
+        .switches
+        .experiments
+        .get("ausMomentEnabled")
+        .exists(switch => switch.state.isOn)
+
       if (geoData.countryGroup.contains(UK) && ausMomentEnabled) //TODO: change UK to Australia
         "aus moment shareimageurl" //TODO: replace with correct URL
       else
         "https://i.guim.co.uk/img/media/74b15a65c479bfe53151fceeb7d948f125a66af2/0_0_2400_1260/1000.png?quality=85&s=4b52891c0a86da6c08f2dc6e8308d211"
-  }
-
-  private def shareUrl(geoData: GeoData): String = {
-    if (geoData.countryGroup.contains(UK) && ausMomentEnabled) //TODO: change UK to Australia
-      "https://support.theguardian.com/au/contribute"
-    else
-      "https://support.theguardian.com/contribute"
   }
 
   //noinspection ScalaStyle
@@ -198,12 +176,12 @@ class Application(
     )
 
     views.html.contributions(
-      title = title(geoData),
+      title = "Support the Guardian | Make a Contribution",
       id = s"contributions-landing-page-$countryCode",
       mainElement = mainElement,
       js = js,
       css = css,
-      description = description(geoData),
+      description = stringsConfig.contributionsLandingDescription,
       paymentMethodConfigs = ContributionsPaymentMethodConfigs(
         oneOffDefaultStripeConfig = oneOffStripeConfigProvider.get(false),
         oneOffUatStripeConfig = oneOffStripeConfigProvider.get(true),

--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -141,6 +141,21 @@ class Application(
     ).map(_.withSettingsSurrogateKey)
   }
 
+  private def shareImageUrl(geoData: GeoData, settings: AllSettings): String = {
+    val ausMomentEnabled =
+      settingsProvider
+        .getAllSettings()
+        .switches
+        .experiments
+        .get("ausMomentEnabled")
+        .exists(switch => switch.state.isOn)
+
+      if (geoData.countryGroup.contains(UK) && ausMomentEnabled)
+        "https://media.guim.co.uk/661978f14a1cbdd64361e429f058e9b20c8db5bb/0_0_2400_1260/1000.png"
+      else
+        "https://i.guim.co.uk/img/media/74b15a65c479bfe53151fceeb7d948f125a66af2/0_0_2400_1260/1000.png?quality=85&s=4b52891c0a86da6c08f2dc6e8308d211"
+  }
+
   //noinspection ScalaStyle
   private def contributionsHtml(countryCode: String, geoData: GeoData, idUser: Option[IdUser],
                                 campaignCode: Option[String], guestAccountCreationToken: Option[String])
@@ -153,20 +168,6 @@ class Application(
 
     val classes = "gu-content--contribution-form--placeholder" +
       campaignCode.map(code => s" gu-content--campaign-landing gu-content--$code").getOrElse("")
-
-    val ausMomentEnabled =
-        settingsProvider
-          .getAllSettings()
-          .switches
-          .experiments
-          .get("ausMomentEnabled")
-          .exists(switch => switch.state.isOn)
-
-    val shareImageUrl =
-      if (geoData.countryGroup.contains(UK) && ausMomentEnabled)
-        "https://media.guim.co.uk/661978f14a1cbdd64361e429f058e9b20c8db5bb/0_0_2400_1260/1000.png"
-      else
-        "https://i.guim.co.uk/img/media/74b15a65c479bfe53151fceeb7d948f125a66af2/0_0_2400_1260/1000.png?quality=85&s=4b52891c0a86da6c08f2dc6e8308d211"
 
     val mainElement = assets.getSsrCacheContentsAsHtml(
       divId = s"contributions-landing-page-$countryCode",
@@ -198,7 +199,7 @@ class Application(
       guestAccountCreationToken = guestAccountCreationToken,
       fontLoaderBundle = fontLoaderBundle,
       geoData = geoData,
-      shareImageUrl = shareImageUrl,
+      shareImageUrl = shareImageUrl(geoData, settings),
       shareUrl = "https://support.theguardian.com/contribute",
       v2recaptchaConfigPublicKey = recaptchaConfigProvider.v2PublicKey
     )

--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -150,8 +150,8 @@ class Application(
         .get("ausMomentEnabled")
         .exists(switch => switch.state.isOn)
 
-      if (geoData.countryGroup.contains(UK) && ausMomentEnabled) //TODO: change UK to Australia
-        "aus moment shareimageurl" //TODO: replace with correct URL
+       if (geoData.countryGroup.contains(Australia) && ausMomentEnabled)
+        " https://i.guim.co.uk/img/media/32cd8c7234c391a7b96c8e91945af9b2e9711631/0_0_1000_525/1000.jpg?quality=85&s=5d69b3ed574a58361e1bce4f4a121b45"
       else
         "https://i.guim.co.uk/img/media/74b15a65c479bfe53151fceeb7d948f125a66af2/0_0_2400_1260/1000.png?quality=85&s=4b52891c0a86da6c08f2dc6e8308d211"
   }

--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -141,16 +141,15 @@ class Application(
     ).map(_.withSettingsSurrogateKey)
   }
 
-  private def shareImageUrl(geoData: GeoData): String = {
+  private def shareImageUrl(geoData: GeoData, settings: AllSettings): String = {
     val ausMomentEnabled =
-      settingsProvider
-        .getAllSettings()
+      settings
         .switches
         .experiments
         .get("ausMomentEnabled")
         .exists(switch => switch.state.isOn)
 
-       if (geoData.countryGroup.contains(Australia) && ausMomentEnabled)
+      if (geoData.countryGroup.contains(Australia) && ausMomentEnabled)
         " https://i.guim.co.uk/img/media/32cd8c7234c391a7b96c8e91945af9b2e9711631/0_0_1000_525/1000.jpg?quality=85&s=5d69b3ed574a58361e1bce4f4a121b45"
       else
         "https://i.guim.co.uk/img/media/74b15a65c479bfe53151fceeb7d948f125a66af2/0_0_2400_1260/1000.png?quality=85&s=4b52891c0a86da6c08f2dc6e8308d211"
@@ -199,7 +198,7 @@ class Application(
       guestAccountCreationToken = guestAccountCreationToken,
       fontLoaderBundle = fontLoaderBundle,
       geoData = geoData,
-      shareImageUrl = shareImageUrl(geoData),
+      shareImageUrl = shareImageUrl(geoData, settings),
       shareUrl = "https://support.theguardian.com/contribute",
       v2recaptchaConfigPublicKey = recaptchaConfigProvider.v2PublicKey
     )

--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -141,19 +141,41 @@ class Application(
     ).map(_.withSettingsSurrogateKey)
   }
 
-  private def shareImageUrl(geoData: GeoData, settings: AllSettings): String = {
-    val ausMomentEnabled =
-      settingsProvider
-        .getAllSettings()
-        .switches
-        .experiments
-        .get("ausMomentEnabled")
-        .exists(switch => switch.state.isOn)
+  val ausMomentEnabled =
+    settingsProvider
+      .getAllSettings()
+      .switches
+      .experiments
+      .get("ausMomentEnabled")
+      .exists(switch => switch.state.isOn)
 
-      if (geoData.countryGroup.contains(UK) && ausMomentEnabled)
-        "https://media.guim.co.uk/661978f14a1cbdd64361e429f058e9b20c8db5bb/0_0_2400_1260/1000.png"
+  private def title(geoData: GeoData): String = {
+    if (geoData.countryGroup.contains(UK) && ausMomentEnabled) //TODO: change UK to Australia
+      "Guardian Australia supporters are doing something powerful"
+    else
+      "Support the Guardian | Make a Contribution"
+  }
+
+  private def description(geoData: GeoData): Option[String] = {
+    if (geoData.countryGroup.contains(UK) && ausMomentEnabled) //TODO: change UK to Australia
+      Some("Why am I supporting the Guardian? Because I believe their vital, " +
+        "independent journalism should be open and free to all. \nJoin me. With your support, we can do more.")
+    else
+      stringsConfig.contributionsLandingDescription
+  }
+
+  private def shareImageUrl(geoData: GeoData): String = {
+      if (geoData.countryGroup.contains(UK) && ausMomentEnabled) //TODO: change UK to Australia
+        "aus moment shareimageurl" //TODO: replace with correct URL
       else
         "https://i.guim.co.uk/img/media/74b15a65c479bfe53151fceeb7d948f125a66af2/0_0_2400_1260/1000.png?quality=85&s=4b52891c0a86da6c08f2dc6e8308d211"
+  }
+
+  private def shareUrl(geoData: GeoData): String = {
+    if (geoData.countryGroup.contains(UK) && ausMomentEnabled) //TODO: change UK to Australia
+      "https://support.theguardian.com/au/contribute"
+    else
+      "https://support.theguardian.com/contribute"
   }
 
   //noinspection ScalaStyle
@@ -176,12 +198,12 @@ class Application(
     )
 
     views.html.contributions(
-      title = "Support the Guardian | Make a Contribution",
+      title = title(geoData),
       id = s"contributions-landing-page-$countryCode",
       mainElement = mainElement,
       js = js,
       css = css,
-      description = stringsConfig.contributionsLandingDescription,
+      description = description(geoData),
       paymentMethodConfigs = ContributionsPaymentMethodConfigs(
         oneOffDefaultStripeConfig = oneOffStripeConfigProvider.get(false),
         oneOffUatStripeConfig = oneOffStripeConfigProvider.get(true),
@@ -199,7 +221,7 @@ class Application(
       guestAccountCreationToken = guestAccountCreationToken,
       fontLoaderBundle = fontLoaderBundle,
       geoData = geoData,
-      shareImageUrl = shareImageUrl(geoData, settings),
+      shareImageUrl = shareImageUrl(geoData),
       shareUrl = "https://support.theguardian.com/contribute",
       v2recaptchaConfigPublicKey = recaptchaConfigProvider.v2PublicKey
     )

--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -141,9 +141,10 @@ class Application(
     ).map(_.withSettingsSurrogateKey)
   }
 
+  //noinspection ScalaStyle
   private def contributionsHtml(countryCode: String, geoData: GeoData, idUser: Option[IdUser],
-    campaignCode: Option[String], guestAccountCreationToken: Option[String])
-    (implicit request: RequestHeader, settings: AllSettings) = {
+                                campaignCode: Option[String], guestAccountCreationToken: Option[String])
+                               (implicit request: RequestHeader, settings: AllSettings) = {
 
     val elementForStage = CSSElementForStage(assets.getFileContentsAsHtml, stage) _
     val css = elementForStage(RefPath("contributionsLandingPage.css"))
@@ -153,8 +154,19 @@ class Application(
     val classes = "gu-content--contribution-form--placeholder" +
       campaignCode.map(code => s" gu-content--campaign-landing gu-content--$code").getOrElse("")
 
+    val ausMomentEnabled =
+        settingsProvider
+          .getAllSettings()
+          .switches
+          .experiments
+          .get("ausMomentEnabled")
+          .exists(switch => switch.state.isOn)
+
     val shareImageUrl =
-      "https://i.guim.co.uk/img/media/74b15a65c479bfe53151fceeb7d948f125a66af2/0_0_2400_1260/1000.png?quality=85&s=4b52891c0a86da6c08f2dc6e8308d211"
+      if (geoData.countryGroup.contains(UK) && ausMomentEnabled)
+        "https://media.guim.co.uk/661978f14a1cbdd64361e429f058e9b20c8db5bb/0_0_2400_1260/1000.png"
+      else
+        "https://i.guim.co.uk/img/media/74b15a65c479bfe53151fceeb7d948f125a66af2/0_0_2400_1260/1000.png?quality=85&s=4b52891c0a86da6c08f2dc6e8308d211"
 
     val mainElement = assets.getSsrCacheContentsAsHtml(
       divId = s"contributions-landing-page-$countryCode",


### PR DESCRIPTION
## Why are you doing this?
The OG image will be displayed to users in Australia during the Aus moment. The image will be displayed in social share links.

Australia during Aus moment
<img width="1004" alt="image" src="https://user-images.githubusercontent.com/15648334/84678539-0c694680-af28-11ea-9bc5-e3266fc0ae94.png">

Rest of world/original image
<img width="502" alt="image" src="https://user-images.githubusercontent.com/15648334/84678650-2d319c00-af28-11ea-8e1a-e415727a72f1.png">

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/AilQGrjm/2114-update-the-ogimage-on-the-aus-thank-youpage)
