### PR TITLE
add test for CreateZuoraSubscription digipack

### DIFF
--- a/support-services/src/test/scala/com/gu/support/redemption/SetCodeStatusITSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/redemption/SetCodeStatusITSpec.scala
@@ -11,8 +11,7 @@ import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedExce
 class SetCodeStatusITSpec extends AsyncFlatSpec with Matchers {
 
   private val dynamoTableAsync: DynamoTableAsync = RedemptionTable.forEnvAsync(TouchPointEnvironments.SANDBOX)
-  val setCodeStatus =
-    SetCodeStatus.withDynamoLookup(dynamoTableAsync)
+  val setCodeStatus = SetCodeStatus.withDynamoLookup(dynamoTableAsync)
   val getCodeStatus = GetCodeStatus.withDynamoLookup(dynamoTableAsync)
 
   // this is one test because it depends on external state which may not be in a particular state

--- a/support-workers/src/main/scala/com/gu/support/workers/GetSubscriptionWithCurrentRequestId.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/GetSubscriptionWithCurrentRequestId.scala
@@ -5,7 +5,7 @@ import java.util.UUID
 import cats.implicits._
 import com.gu.FutureLogging.LogImplicitFuture
 import com.gu.support.zuora.domain.{CreatedRequestId, DomainSubscription}
-import com.gu.zuora.{ZuoraService, ZuoraSubscribeService}
+import com.gu.zuora.ZuoraSubscribeService
 import org.joda.time.DateTime
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/support-workers/src/main/scala/com/gu/support/workers/GetSubscriptionWithCurrentRequestId.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/GetSubscriptionWithCurrentRequestId.scala
@@ -5,7 +5,7 @@ import java.util.UUID
 import cats.implicits._
 import com.gu.FutureLogging.LogImplicitFuture
 import com.gu.support.zuora.domain.{CreatedRequestId, DomainSubscription}
-import com.gu.zuora.ZuoraService
+import com.gu.zuora.{ZuoraService, ZuoraSubscribeService}
 import org.joda.time.DateTime
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -13,7 +13,7 @@ import scala.concurrent.{ExecutionContext, Future}
 object GetSubscriptionWithCurrentRequestId {
 
   def apply(
-    zuoraService: ZuoraService,
+    zuoraService: ZuoraSubscribeService,
     requestId: UUID,
     identityId: IdentityId,
     billingPeriod: BillingPeriod,

--- a/support-workers/src/main/scala/com/gu/support/workers/PreviewPaymentSchedule.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/PreviewPaymentSchedule.scala
@@ -3,6 +3,7 @@ package com.gu.support.workers
 import com.gu.services.Services
 import com.gu.support.zuora.api.response.{Charge, PreviewSubscribeResponse}
 import com.gu.support.zuora.api.{PreviewSubscribeRequest, SubscribeItem}
+import com.gu.zuora.{ZuoraService, ZuoraSubscribeService}
 import org.joda.time.LocalDate
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -13,7 +14,7 @@ object PreviewPaymentSchedule {
   def apply(
     subscribeItem: SubscribeItem,
     billingPeriod: BillingPeriod,
-    services: Services,
+    zuoraService: ZuoraSubscribeService,
     singleResponseCheck: Future[List[PreviewSubscribeResponse]] => Future[PreviewSubscribeResponse]
   ): Future[PaymentSchedule] = {
     val numberOfInvoicesToPreview: Int = billingPeriod match {
@@ -23,7 +24,7 @@ object PreviewPaymentSchedule {
       case SixWeekly => 2
     }
     singleResponseCheck(
-      services.zuoraService.previewSubscribe(PreviewSubscribeRequest.fromSubscribe(subscribeItem, numberOfInvoicesToPreview))
+      zuoraService.previewSubscribe(PreviewSubscribeRequest.fromSubscribe(subscribeItem, numberOfInvoicesToPreview))
     ).map(response => paymentSchedule(response.invoiceData.flatMap(_.invoiceItem)))
   }
 

--- a/support-workers/src/main/scala/com/gu/support/workers/PreviewPaymentSchedule.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/PreviewPaymentSchedule.scala
@@ -1,9 +1,8 @@
 package com.gu.support.workers
 
-import com.gu.services.Services
 import com.gu.support.zuora.api.response.{Charge, PreviewSubscribeResponse}
 import com.gu.support.zuora.api.{PreviewSubscribeRequest, SubscribeItem}
-import com.gu.zuora.{ZuoraService, ZuoraSubscribeService}
+import com.gu.zuora.ZuoraSubscribeService
 import org.joda.time.LocalDate
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -32,8 +32,6 @@ case class BuildSubscribeRedemptionError(cause: RedemptionInvalid) extends Runti
 class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvider)
     extends ServicesHandler[CreateZuoraSubscriptionState, SendThankYouEmailState](servicesProvider) {
 
-  import CreateZuoraSubscription._
-
   def this() = this(ServiceProvider)
 
   override protected def servicesHandler(
@@ -49,13 +47,13 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
     val zuoraService = services.zuoraService
     val isTestUser = state.user.isTestUser
     val config: ZuoraConfig = zuoraConfigProvider.get(isTestUser)
-    doStepsFromDeps(state, requestInfo, now, today, promotionService, redemptionService, zuoraService, config)
+    CreateZuoraSubscription(state, requestInfo, now, today, promotionService, redemptionService, zuoraService, config)
   }
 }
 object CreateZuoraSubscription {
   import com.gu.FutureLogging._
 
-  def doStepsFromDeps(
+  def apply(
     state: CreateZuoraSubscriptionState,
     requestInfo: RequestInfo,
     now: () => DateTime,

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -7,9 +7,9 @@ import com.gu.config.Configuration
 import com.gu.config.Configuration.zuoraConfigProvider
 import com.gu.monitoring.SafeLogger
 import com.gu.services.{ServiceProvider, Services}
-import com.gu.support.config.TouchPointEnvironments
+import com.gu.support.config.{TouchPointEnvironments, ZuoraConfig}
 import com.gu.support.promotions.{PromoError, PromotionService}
-import com.gu.support.redemption.GetCodeStatus
+import com.gu.support.redemption.{DynamoLookup, DynamoUpdate, GetCodeStatus}
 import com.gu.support.redemption.GetCodeStatus.RedemptionInvalid
 import com.gu.support.redemptions.RedemptionData
 import com.gu.support.workers._
@@ -19,6 +19,7 @@ import com.gu.support.zuora.api.response._
 import com.gu.support.zuora.domain.DomainSubscription
 import com.gu.zuora.ProductSubscriptionBuilders._
 import com.gu.zuora.ProductSubscriptionBuilders.buildDigitalPackSubscription.{SubscriptionPaymentCorporate, SubscriptionPaymentDirect}
+import com.gu.zuora.ZuoraSubscribeService
 import org.joda.time.{DateTime, DateTimeZone, LocalDate}
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -31,7 +32,7 @@ case class BuildSubscribeRedemptionError(cause: RedemptionInvalid) extends Runti
 class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvider)
     extends ServicesHandler[CreateZuoraSubscriptionState, SendThankYouEmailState](servicesProvider) {
 
-  import com.gu.FutureLogging._
+  import CreateZuoraSubscription._
 
   def this() = this(ServiceProvider)
 
@@ -43,19 +44,43 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
   ): FutureHandlerResult = {
     val now = () => DateTime.now(DateTimeZone.UTC)
     val today = () => LocalDate.now(DateTimeZone.UTC)
+    val promotionService = services.promotionService
+    val redemptionService = services.redemptionService
+    val zuoraService = services.zuoraService
+    val isTestUser = state.user.isTestUser
+    val config: ZuoraConfig = zuoraConfigProvider.get(isTestUser)
+    doStepsFromDeps(state, requestInfo, now, today, promotionService, redemptionService, zuoraService, config)
+  }
+}
+object CreateZuoraSubscription {
+  import com.gu.FutureLogging._
+
+  def doStepsFromDeps(
+    state: CreateZuoraSubscriptionState,
+    requestInfo: RequestInfo,
+    now: () => DateTime,
+    today: () => LocalDate,
+    promotionService: PromotionService,
+    redemptionService: DynamoLookup with DynamoUpdate,
+    zuoraService: ZuoraSubscribeService,
+    config: ZuoraConfig
+  ): Future[HandlerResult[SendThankYouEmailState]] = {
     for {
-      subscriptionData <- buildSubscriptionData(state, services.promotionService, GetCodeStatus.withDynamoLookup(services.redemptionService), today)
+      subscriptionData <- buildSubscriptionData(state, promotionService, GetCodeStatus.withDynamoLookup(redemptionService), today, config)
       subscribeItem = buildSubscribeItem(state, subscriptionData)
       identityId <- Future.fromTry(IdentityId(state.user.id))
         .withLogging("identity id")
-      maybeDomainSubscription <- GetSubscriptionWithCurrentRequestId(services.zuoraService, state.requestId, identityId, state.product.billingPeriod, now)
-          .withLogging("GetSubscriptionWithCurrentRequestId")
-      previewPaymentSchedule <- PreviewPaymentSchedule(subscribeItem, state.product.billingPeriod, services, checkSingleResponse)
-          .withLogging("PreviewPaymentSchedule")
+      maybeDomainSubscription <- GetSubscriptionWithCurrentRequestId(zuoraService, state.requestId, identityId, state.product.billingPeriod, now)
+        .withLogging("GetSubscriptionWithCurrentRequestId")
+      paymentMethodWithPaymentSchedule <-
+        state.paymentMethod.leftMap(pm =>
+          PreviewPaymentSchedule(subscribeItem, state.product.billingPeriod, zuoraService, checkSingleResponse)
+            .withLogging("PreviewPaymentSchedule").map(ps => (pm, ps))
+        ).leftSequence
       thankYouState <- maybeDomainSubscription match {
-        case Some(domainSubscription) => skipSubscribe(state, requestInfo, previewPaymentSchedule, domainSubscription)
-            .withLogging("skipSubscribe")
-        case None => subscribe(state, subscribeItem, services).map(response => toHandlerResult(state, response, previewPaymentSchedule, requestInfo))
+        case Some(domainSubscription) => skipSubscribe(state, requestInfo, paymentMethodWithPaymentSchedule, domainSubscription)
+          .withLogging("skipSubscribe")
+        case None => subscribe(subscribeItem, zuoraService).map(response => toHandlerResult(state, response, paymentMethodWithPaymentSchedule, requestInfo))
           .withLogging("subscribe")
       }
     } yield thankYouState
@@ -64,13 +89,13 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
   def skipSubscribe(
     state: CreateZuoraSubscriptionState,
     requestInfo: RequestInfo,
-    previewedPaymentSchedule: PaymentSchedule,
+    paymentMethodWithPaymentSchedule: Either[(PaymentMethod, PaymentSchedule), RedemptionData],
     subscription: DomainSubscription
-  ): FutureHandlerResult = {
+  ): Future[HandlerResult[SendThankYouEmailState]] = {
     val message = "Skipping subscribe for user because a subscription has already been created for this request"
     SafeLogger.info(message)
     Future.successful(HandlerResult(
-      getEmailState(state, subscription.accountNumber, subscription.subscriptionNumber, previewedPaymentSchedule),
+      getEmailState(state, subscription.accountNumber, subscription.subscriptionNumber, paymentMethodWithPaymentSchedule),
       requestInfo.appendMessage(message)
     ))
   }
@@ -88,35 +113,36 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
     }
   }
 
-  def subscribe(state: CreateZuoraSubscriptionState, subscribeItem: SubscribeItem, services: Services): Future[SubscribeResponseAccount] =
-    singleSubscribe(services.zuoraService.subscribe)(subscribeItem)
+  def subscribe(subscribeItem: SubscribeItem, zuoraService: ZuoraSubscribeService): Future[SubscribeResponseAccount] =
+    singleSubscribe(zuoraService.subscribe)(subscribeItem)
 
   def toHandlerResult(
     state: CreateZuoraSubscriptionState,
     response: SubscribeResponseAccount,
-    previewedPaymentSchedule: PaymentSchedule,
+    paymentMethodWithPaymentSchedule: Either[(PaymentMethod, PaymentSchedule), RedemptionData],
     requestInfo: RequestInfo
   ): HandlerResult[SendThankYouEmailState] =
-    HandlerResult(getEmailState(state, response.domainAccountNumber, response.domainSubscriptionNumber, previewedPaymentSchedule), requestInfo)
+    HandlerResult(getEmailState(state, response.domainAccountNumber, response.domainSubscriptionNumber, paymentMethodWithPaymentSchedule), requestInfo)
 
   private def getEmailState(
     state: CreateZuoraSubscriptionState,
     accountNumber: ZuoraAccountNumber,
     subscriptionNumber: ZuoraSubscriptionNumber,
-    paymentSchedule: PaymentSchedule
+    paymentMethodWithPaymentSchedule: Either[(PaymentMethod, PaymentSchedule), RedemptionData]
   ) =
     SendThankYouEmailState(
       state.requestId,
       state.user,
       state.giftRecipient,
       state.product,
-      state.paymentMethod,
+      paymentMethodWithPaymentSchedule.left.map(_._1),
       state.firstDeliveryDate,
       state.promoCode,
       state.salesforceContacts.buyer,
       accountNumber.value,
       subscriptionNumber.value,
-      paymentSchedule,
+      paymentMethodWithPaymentSchedule
+        .left.toOption.map(_._2).getOrElse(PaymentSchedule(List())),//TODO SendThankYou email will only need payment schedule for paid subs
       state.acquisitionData
     )
 
@@ -137,10 +163,10 @@ class CreateZuoraSubscription(servicesProvider: ServiceProvider = ServiceProvide
     state: CreateZuoraSubscriptionState,
     promotionService: => PromotionService,
     getCodeStatus: => GetCodeStatus,
-    today: () => LocalDate
+    today: () => LocalDate,
+    config: ZuoraConfig
   ): Future[SubscriptionData] = {
     val isTestUser = state.user.isTestUser
-    val config = zuoraConfigProvider.get(isTestUser)
     val environment = TouchPointEnvironments.fromStage(Configuration.stage, isTestUser)
 
     val eventualErrorOrSubscriptionData = state.product match {

--- a/support-workers/src/test/scala/com/gu/support/workers/CreateZuoraSubscriptionStepsSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/CreateZuoraSubscriptionStepsSpec.scala
@@ -4,15 +4,10 @@ import java.util.UUID
 
 import com.gu.i18n.{Country, Currency}
 import com.gu.salesforce.Salesforce.SalesforceContactRecords
-import com.gu.support.catalog.Corporate
 import com.gu.support.config.{ZuoraConfig, ZuoraDigitalPackConfig}
-import com.gu.support.redemption.DynamoLookup.{DynamoBoolean, DynamoString}
-import com.gu.support.redemption.DynamoUpdate.DynamoFieldUpdate
-import com.gu.support.redemption.{DynamoLookup, DynamoUpdate}
-import com.gu.support.redemptions.CorporateRedemption
 import com.gu.support.workers.lambdas.CreateZuoraSubscription
 import com.gu.support.workers.states.CreateZuoraSubscriptionState
-import com.gu.support.zuora.api.response.{Charge, InvoiceDataItem, PreviewSubscribeResponse, SubscribeResponseAccount, ZuoraAccountNumber}
+import com.gu.support.zuora.api.response._
 import com.gu.support.zuora.api.{PreviewSubscribeRequest, SubscribeRequest}
 import com.gu.support.zuora.domain
 import com.gu.zuora.ZuoraSubscribeService

--- a/support-workers/src/test/scala/com/gu/support/workers/CreateZuoraSubscriptionStepsSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/CreateZuoraSubscriptionStepsSpec.scala
@@ -1,0 +1,80 @@
+package com.gu.support.workers
+
+import java.util.UUID
+
+import com.gu.i18n.{Country, Currency}
+import com.gu.salesforce.Salesforce.SalesforceContactRecords
+import com.gu.support.catalog.Corporate
+import com.gu.support.config.{ZuoraConfig, ZuoraDigitalPackConfig}
+import com.gu.support.redemption.DynamoLookup.{DynamoBoolean, DynamoString}
+import com.gu.support.redemption.DynamoUpdate.DynamoFieldUpdate
+import com.gu.support.redemption.{DynamoLookup, DynamoUpdate}
+import com.gu.support.redemptions.CorporateRedemption
+import com.gu.support.workers.lambdas.CreateZuoraSubscription
+import com.gu.support.workers.states.CreateZuoraSubscriptionState
+import com.gu.support.zuora.api.response.{Charge, InvoiceDataItem, PreviewSubscribeResponse, SubscribeResponseAccount, ZuoraAccountNumber}
+import com.gu.support.zuora.api.{PreviewSubscribeRequest, SubscribeRequest}
+import com.gu.support.zuora.domain
+import com.gu.zuora.ZuoraSubscribeService
+import org.joda.time.{DateTime, LocalDate}
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.Future
+
+class CreateZuoraSubscriptionStepsSpec extends AsyncFlatSpec with Matchers {
+
+  it should "create a Digital Pack standard (paid) subscription" in {
+
+    val state = CreateZuoraSubscriptionState(
+      requestId = UUID.fromString("f7651338-5d94-4f57-85fd-262030de9ad5"),
+      user = User("111222", "email@blah.com", None, "bertha", "smith", Address(None, None, None, None, None, Country.UK)),
+      giftRecipient = None,
+      product = DigitalPack(Currency.GBP, Monthly),
+      paymentMethod = Left(PayPalReferenceTransaction("baid", "me@somewhere.com")),
+      firstDeliveryDate = None,
+      promoCode = None,
+      salesforceContacts = SalesforceContactRecords(
+        buyer = SalesforceContactRecord("sfbuy", "sfbuyacid"),
+        giftRecipient = None
+      ),
+      acquisitionData = None
+    )
+
+    val zuora = new ZuoraSubscribeService {
+      // not testing retries - these two are empty lists
+      override def getAccountFields(identityId: IdentityId, now: DateTime): Future[List[domain.DomainAccount]] = Future(List())
+      override def getSubscriptions(accountNumber: ZuoraAccountNumber): Future[List[domain.DomainSubscription]] = Future(List())
+      override def previewSubscribe(previewSubscribeRequest: PreviewSubscribeRequest): Future[List[PreviewSubscribeResponse]] = Future(List(
+        PreviewSubscribeResponse(
+          List(InvoiceDataItem(List(Charge(new LocalDate(2020, 6, 15), new LocalDate(2020, 6, 15), 1.24, 4.56)))),
+          true
+        )
+      ))
+      // ideally should also check we called zuora with the right post data
+      override def subscribe(subscribeRequest: SubscribeRequest): Future[List[SubscribeResponseAccount]] = Future.successful(List(
+        SubscribeResponseAccount("accountdigi", "subdigi", 135.67f, "ididdigi", 246.67f, "aciddigi", true)
+      ))
+    }
+
+    val result = CreateZuoraSubscription.doStepsFromDeps(
+      state = state,
+      requestInfo = RequestInfo(false, false, Nil, false),
+      now = () => new DateTime(2020, 6, 15, 16, 28, 57),
+      today = () => new LocalDate(2020, 6, 15),
+      promotionService = null,// shouldn't be called for subs with no promo code
+      redemptionService = null,// shouldn't be called for paid subs
+      zuoraService = zuora,
+      config = ZuoraConfig(url = null, username = null, password = null, monthlyContribution = null, annualContribution = null, digitalPack = ZuoraDigitalPackConfig(14, 2))
+    )
+
+    result.map { handlerResult =>
+      withClue(handlerResult) {
+        handlerResult.value.accountNumber should be("accountdigi")
+        handlerResult.value.subscriptionNumber should be("subdigi")
+        handlerResult.value.paymentMethod.isLeft should be(true) // it's still marked as a paid sub!
+      }
+    }
+  }
+
+}

--- a/support-workers/src/test/scala/com/gu/support/workers/CreateZuoraSubscriptionStepsSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/CreateZuoraSubscriptionStepsSpec.scala
@@ -52,7 +52,7 @@ class CreateZuoraSubscriptionStepsSpec extends AsyncFlatSpec with Matchers {
       ))
     }
 
-    val result = CreateZuoraSubscription.doStepsFromDeps(
+    val result = CreateZuoraSubscription(
       state = state,
       requestInfo = RequestInfo(false, false, Nil, false),
       now = () => new DateTime(2020, 6, 15, 16, 28, 57),

--- a/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
@@ -396,7 +396,7 @@ object JsonFixtures {
             $userJsonNoAddress,
             "product": $digitalPackCorporateJson,
             "paymentMethod": {
-              "redemptionCode": "ITTEST-AVAILABLE",
+              "redemptionCode": "ITTEST-MUTABLE",
               "corporateAccountId": "1"
             },
             "salesForceContact": $salesforceContactJson,

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
@@ -6,7 +6,7 @@ import com.gu.config.Configuration.{promotionsConfigProvider, zuoraConfigProvide
 import com.gu.okhttp.RequestRunners.configurableFutureRunner
 import com.gu.support.config.{Stages, TouchPointEnvironments}
 import com.gu.support.promotions.{DefaultPromotions, PromotionService}
-import com.gu.support.redemption.RedemptionTable
+import com.gu.support.redemption.{DynamoTableAsync, RedemptionCode, RedemptionTable, SetCodeStatus}
 import com.gu.support.workers.JsonFixtures.{createEverydayPaperSubscriptionJson, _}
 import com.gu.support.workers._
 import com.gu.support.workers.encoding.Conversions.FromOutputStream
@@ -42,7 +42,12 @@ class CreateZuoraSubscriptionSpec extends AsyncLambdaSpec with MockServicesCreat
   }
 
   it should "create a Digital Pack corporate subscription" in {
-    createSubscription(createDigiPackCorporateSubscriptionJson)
+    val dynamoTableAsync: DynamoTableAsync = RedemptionTable.forEnvAsync(TouchPointEnvironments.SANDBOX)
+    val setCodeStatus = SetCodeStatus.withDynamoLookup(dynamoTableAsync)
+    val mutableCode: RedemptionCode = RedemptionCode("ITTEST-MUTABLE").right.get
+    setCodeStatus(mutableCode, RedemptionTable.AvailableField.CodeIsAvailable).flatMap { _ =>
+      createSubscription(createDigiPackCorporateSubscriptionJson)
+    }
   }
 
   it should "create a Digital Pack subscription with a discount" in {


### PR DESCRIPTION
## Why are you doing this?

This PR adds a more comprehensive test for the create zuora subscription logic, this is in preparation for adding a test that checks the redemption code is correctly marked as used, which would not be possible otherwise without being an IT test.
