### PR TITLE
mark redemption code as redeemed after sub created

### DIFF
--- a/support-workers/src/test/scala/com/gu/support/workers/CreateZuoraSubscriptionStepsSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/CreateZuoraSubscriptionStepsSpec.scala
@@ -59,7 +59,10 @@ class CreateZuoraSubscriptionStepsSpec extends AsyncFlatSpec with Matchers {
       // should not do a preview against zuora for corp/free subs
       override def previewSubscribe(previewSubscribeRequest: PreviewSubscribeRequest): Future[List[PreviewSubscribeResponse]] = ???
       override def subscribe(subscribeRequest: SubscribeRequest): Future[List[SubscribeResponseAccount]] =
-        Future.successful(List(SubscribeResponseAccount("accountcorp", "subcorp", 135.67f, "ididcorp", 246.67f, "acidcorp", true)))
+        subscribeRequest.subscribes.head.subscriptionData.subscription.redemptionCode match {
+          case Some("TESTCODE") => Future.successful(List(SubscribeResponseAccount("accountcorp", "subcorp", 135.67f, "ididcorp", 246.67f, "acidcorp", true)))
+          case _ => ???
+        }
     }
 
     val result = CreateZuoraSubscription(
@@ -111,9 +114,13 @@ class CreateZuoraSubscriptionStepsSpec extends AsyncFlatSpec with Matchers {
         )
       ))
       // ideally should also check we called zuora with the right post data
-      override def subscribe(subscribeRequest: SubscribeRequest): Future[List[SubscribeResponseAccount]] = Future.successful(List(
-        SubscribeResponseAccount("accountdigi", "subdigi", 135.67f, "ididdigi", 246.67f, "aciddigi", true)
-      ))
+      override def subscribe(subscribeRequest: SubscribeRequest): Future[List[SubscribeResponseAccount]] =
+        subscribeRequest.subscribes.head.subscriptionData.subscription.redemptionCode match {
+          case None => Future.successful(List(
+            SubscribeResponseAccount("accountdigi", "subdigi", 135.67f, "ididdigi", 246.67f, "aciddigi", true)
+          ))
+          case _ => ???
+        }
     }
 
     val result = CreateZuoraSubscription(


### PR DESCRIPTION
## Why are you doing this?

Part of corporate subs, we want to make sure once the subscription is created, we mark the code as successfully redeemed.
If there is a failure marking the sub as redeemed, the step will fail and retry, the repeat execution will check the code again and find it's not redeemed, but it should find the existing sub, skipSubscribe, and then successfully mark as redeemed on the retry hopefully.

[**Trello Card**](https://trello.com/c/YHcNJ2yF/3105-mark-corporate-codes-as-redeemed-when-checkout-done)
