### PR TITLE
Use correct campaignCode during Aus campaign, use switch

### DIFF
--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -110,7 +110,7 @@
   }
 
   window.guardian.forceCampaign = @settings.switches.experiments.get("forceCampaign").exists(_.isOn)
-  window.guardian.ausMomentEnabled = false
+  window.guardian.ausMomentEnabled = @settings.switches.experiments.get("ausMomentEnabled").exists(_.isOn)
 
   window.guardian.recaptchaEnabled = @settings.switches.enableRecaptchaFrontend.isOn
   window.guardian.v2recaptchaPublicKey = "@v2recaptchaConfigPublicKey"

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -110,7 +110,7 @@
   }
 
   window.guardian.forceCampaign = @settings.switches.experiments.get("forceCampaign").exists(_.isOn)
-  window.guardian.ausMomentEnabled = @settings.switches.experiments.get("ausMomentEnabled").exists(_.isOn)
+  window.guardian.ausMomentEnabled = false
 
   window.guardian.recaptchaEnabled = @settings.switches.enableRecaptchaFrontend.isOn
   window.guardian.v2recaptchaPublicKey = "@v2recaptchaConfigPublicKey"

--- a/support-frontend/assets/helpers/campaigns.jsx
+++ b/support-frontend/assets/helpers/campaigns.jsx
@@ -42,19 +42,19 @@ export const campaigns: Campaigns = {
 
 export type CampaignName = $Keys<typeof campaigns>
 
-export function getCampaignCode(): ?string {
-  const name = getCampaignName();
-  if (name) {
-    return campaigns[name].campaignCode;
-  }
-  return undefined;
-}
-
 export function getCampaignName(): ?CampaignName {
   if (currentCampaignName) {
     return window.guardian.forceCampaign || window.location.pathname.endsWith(`/${currentCampaignName}`) ?
       currentCampaignName :
       undefined;
+  }
+  return undefined;
+}
+
+export function getCampaignCode(): ?string {
+  const name = getCampaignName();
+  if (name) {
+    return campaigns[name].campaignCode;
   }
   return undefined;
 }

--- a/support-frontend/assets/helpers/campaigns.jsx
+++ b/support-frontend/assets/helpers/campaigns.jsx
@@ -21,7 +21,7 @@ export type Campaigns = {
   [string]: CampaignSettings,
 };
 
-const currentCampaignName = window.guardian.ausMomentEnabled ? 'au/contribute' : null;
+const currentCampaignName = window && window.guardian && window.guardian.ausMomentEnabled ? 'au/contribute' : null;
 
 export const campaigns: Campaigns = currentCampaignName ? {
   // TODO - the rest of the campaign settings

--- a/support-frontend/assets/helpers/campaigns.jsx
+++ b/support-frontend/assets/helpers/campaigns.jsx
@@ -4,6 +4,7 @@ import type { ContributionTypes } from 'helpers/contributions';
 import type { TickerSettings } from 'components/ticker/contributionTicker';
 
 export type CampaignSettings = {
+  campaignCode: string,
   headerCopy?: string | React$Element<string>,
   contributeCopy?: string | React$Element<string>,
   formMessage?: React$Element<string>,
@@ -20,26 +21,34 @@ export type Campaigns = {
   [string]: CampaignSettings,
 };
 
-const currentCampaignName = null;
-// const currentCampaignName = 'au/contribute';
+const currentCampaignName = window.guardian.ausMomentEnabled ? 'au/contribute' : null;
 
 export const campaigns: Campaigns = {
   // TODO - the rest of the campaign settings
-  // [currentCampaignName]: {
-  //   tickerSettings: {
-  //     tickerCountType: 'people',
-  //     tickerEndType: 'unlimited',
-  //     currencySymbol: '£',
-  //     copy: {
-  //       countLabel: 'supporters in Australia',
-  //       goalReachedPrimary: 'We\'ve hit our goal!',
-  //       goalReachedSecondary: 'but you can still support us',
-  //     },
-  //   },
-  // },
+  [currentCampaignName]: {
+    campaignCode: 'Aus_moment_2020',
+    tickerSettings: {
+      tickerCountType: 'people',
+      tickerEndType: 'unlimited',
+      currencySymbol: '£',
+      copy: {
+        countLabel: 'supporters in Australia',
+        goalReachedPrimary: 'We\'ve hit our goal!',
+        goalReachedSecondary: 'but you can still support us',
+      },
+    },
+  },
 };
 
 export type CampaignName = $Keys<typeof campaigns>
+
+export function getCampaignCode(): ?string {
+  const name = getCampaignName();
+  if (name) {
+    return campaigns[name].campaignCode;
+  }
+  return undefined;
+}
 
 export function getCampaignName(): ?CampaignName {
   if (currentCampaignName) {

--- a/support-frontend/assets/helpers/campaigns.jsx
+++ b/support-frontend/assets/helpers/campaigns.jsx
@@ -23,7 +23,7 @@ export type Campaigns = {
 
 const currentCampaignName = window.guardian.ausMomentEnabled ? 'au/contribute' : null;
 
-export const campaigns: Campaigns = {
+export const campaigns: Campaigns = currentCampaignName ? {
   // TODO - the rest of the campaign settings
   [currentCampaignName]: {
     campaignCode: 'Aus_moment_2020',
@@ -38,7 +38,7 @@ export const campaigns: Campaigns = {
       },
     },
   },
-};
+} : {};
 
 export type CampaignName = $Keys<typeof campaigns>
 

--- a/support-frontend/assets/helpers/tracking/acquisitions.js
+++ b/support-frontend/assets/helpers/tracking/acquisitions.js
@@ -10,7 +10,7 @@ import { deserialiseJsonObject } from 'helpers/utilities';
 import type { Participations } from 'helpers/abTests/abtest';
 import * as storage from 'helpers/storage';
 import { getAllQueryParamsWithExclusions } from 'helpers/url';
-import { getCampaignName } from 'helpers/campaigns';
+import { getCampaignCode } from 'helpers/campaigns';
 
 // ----- Types ----- //
 
@@ -176,7 +176,7 @@ function buildReferrerAcquisitionData(acquisitionData: Object = {}): ReferrerAcq
 
   // This was how referrer pageview id used to be passed.
   const campaignCode =
-    getCampaignName() || acquisitionData.campaignCode || getQueryParameter('INTCMP');
+    getCampaignCode() || acquisitionData.campaignCode || getQueryParameter('INTCMP');
 
   const parameterExclusions =
     ['REFPVID', 'INTCMP', 'acquisitionData', 'contributionValue', 'contribType', 'currency'];


### PR DESCRIPTION
We can configure campaign-specific landing pages.
This is done by matching on the path of the url, and in the upcoming moment this will be /au/contribute.
In the past, the `campaignCode` has been set based on the path. Instead, we want to configure the `campaignCode` - in this case it is `Aus_moment_2020`.

Also, the campaign is now enabled based on the `ausMomentEnabled` switch, so no need for commented out code!

Redux store now has correct campaignCode:
![Screen Shot 2020-06-17 at 13 19 00](https://user-images.githubusercontent.com/1513454/84897401-6e978800-b09d-11ea-81d0-97e7069cf2dd.png)
