### PR TITLE
Fix field width (design systems)

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/ContributionTextInputDs.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionTextInputDs.jsx
@@ -74,7 +74,6 @@ export default function ContributionTextInputDs(props: PropTypes) {
           error={showError && props.errorMessage}
           supporting={props.supporting}
           cssOverrides={{
-            width: 'calc(100% - 20px)',
             ...cssInvalid,
           }}
         />


### PR DESCRIPTION
The latest update of the source dependency caused the field width to change on the contributions landing page.

### Before
![Screen Shot 2020-06-18 at 08 21 15](https://user-images.githubusercontent.com/1513454/84990332-e36dcf00-b13c-11ea-9324-40eff964440b.png)


### After
![Screen Shot 2020-06-18 at 08 21 33](https://user-images.githubusercontent.com/1513454/84990344-e668bf80-b13c-11ea-82ef-58d7d8d00c2c.png)
