### PR TITLE
Remove control variant from landing page DS test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -89,9 +89,6 @@ export const tests: Tests = {
     type: 'OTHER',
     variants: [
       {
-        id: 'control',
-      },
-      {
         id: 'ds',
       },
     ],
@@ -110,6 +107,9 @@ export const tests: Tests = {
   ausMomentLandingPageBackgroundTest: {
     type: 'OTHER',
     variants: [
+      {
+        id: 'control',
+      },
       {
         id: 'ausColoursVariant',
       },

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -4,7 +4,7 @@ import { USV1 } from './data/testAmountsData';
 
 // ----- Tests ----- //
 export type StripePaymentRequestButtonTestVariants = 'control' | 'button';
-export type LandingPageDesignSystemTestVariants = 'control' | 'ds';
+export type LandingPageDesignSystemTestVariants = 'ds';
 export type AusMomentLandingPageBackgroundVariants = 'control' | 'ausColoursVariant';
 
 const contributionsLandingPageMatch = '/(uk|us|eu|au|ca|nz|int)/contribute(/.*)?$';
@@ -110,9 +110,6 @@ export const tests: Tests = {
   ausMomentLandingPageBackgroundTest: {
     type: 'OTHER',
     variants: [
-      {
-        id: 'control',
-      },
       {
         id: 'ausColoursVariant',
       },


### PR DESCRIPTION
The variant is doing at least as well as the control.
In this change I am simply removing the control. We will remove the test and clean up the old code soon, when we have more time!