### PR TITLE
display raw output from test runs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,9 @@ lazy val integrationTestSettings: Seq[Def.Setting[_]] = Defaults.itSettings ++ S
   scalaSource in IntegrationTest := baseDirectory.value / "src" / "test" / "scala",
   javaSource in IntegrationTest := baseDirectory.value / "src" / "test" / "java",
   resourceDirectory in IntegrationTest := baseDirectory.value / "src" / "test" / "resources",
-  testOptions in Test := Seq(Tests.Argument(TestFrameworks.ScalaTest, "-l", "com.gu.test.tags.annotations.IntegrationTest"))
+  testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-l", "com.gu.test.tags.annotations.IntegrationTest"),
+  testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-eU"),
+  testOptions in IntegrationTest += Tests.Argument(TestFrameworks.ScalaTest, "-eU")
 )
 
 lazy val release = Seq[ReleaseStep](
@@ -160,6 +162,7 @@ lazy val `stripe-intent` = (project in file("support-lambdas/stripe-intent"))
     integrationTestSettings,
     libraryDependencies ++= commonDependencies,
   ).dependsOn(`support-rest`, `support-config`)
+  .aggregate(`support-rest`, `support-config`)
 
 lazy val `support-redemptiondb` = (project in file("support-redemptiondb"))
   .enablePlugins(RiffRaffArtifact)


### PR DESCRIPTION
## Why are you doing this?

There's an annoying issue where when you run the tests, a load of extra output appears after the tests finish, meaning you have to scroll up to see if they are finished and whether anything went wrong.

This is caused by a bug in SBT https://github.com/sbt/sbt/issues/5245 which somehow loses events after an async ignored/excluded test.  It doesn't look like it is going to be fixed soon.

Adding the -eU parameter makes the tests output raw events as they are produced rather than the nicer looking ones grouped by test.  The reason some of the messages are delayed is because it is waiting for the previos test to "finish" before starting output for the next one.  Eventually it gives up waiting and spits it out anyway.

The test output is a bit less friendly, now it looks more like a sequence of events, and it could be mixed up.
```
Suite Starting - CirceEncodingBehaviourSpec
Scope Opened - CirceEncodingBehaviourSpec: Circe
Test Starting - CirceEncodingBehaviourSpec: Circe should be able to decode PaymentMethod from PaymentMethod
Test Succeeded - CirceEncodingBehaviourSpec: Circe should be able to decode PaymentMethod from PaymentMethod
Test Starting - CirceEncodingBehaviourSpec: Circe should be able to decode PayPalReferenceTransaction from PayPalReferenceTransaction
Test Succeeded - CirceEncodingBehaviourSpec: Circe should be able to decode PayPalReferenceTransaction from PayPalReferenceTransaction
Test Starting - CirceEncodingBehaviourSpec: Circe should be able to decode PayPalReferenceTransaction from PaymentMethod
Test Succeeded - CirceEncodingBehaviourSpec: Circe should be able to decode PayPalReferenceTransaction from PaymentMethod
Test Starting - CirceEncodingBehaviourSpec: Circe should be able to decode PaymentMethod from PayPalReferenceTransaction
Test Succeeded - CirceEncodingBehaviourSpec: Circe should be able to decode PaymentMethod from PayPalReferenceTransaction
Test Starting - CirceEncodingBehaviourSpec: Circe should be able to decode a stripe error
Test Succeeded - CirceEncodingBehaviourSpec: Circe should be able to decode a stripe error
Scope Closed - CirceEncodingBehaviourSpec: Circe
Suite Completed - CirceEncodingBehaviourSpec
```
rather than
```
[info] CirceEncodingBehaviourSpec:
[info] Circe
[info] - should be able to decode PaymentMethod from PaymentMethod
[info] - should be able to decode PayPalReferenceTransaction from PayPalReferenceTransaction
[info] - should be able to decode PayPalReferenceTransaction from PaymentMethod
[info] - should be able to decode PaymentMethod from PayPalReferenceTransaction
[info] - should be able to decode a stripe error
```

HOwever, we will then avoid this problem
```
[info] Run completed in 3 seconds, 460 milliseconds.
[info] Total number of tests run: 82
[info] Suites: completed 34, aborted 0
[info] Tests: succeeded 82, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[success] Total time: 5 s, completed 18 Jun 2020, 11:19:12
[IJ]sbt:support-workers> [info] RedemptionCodeSpec:
[info] RedemptionCode
[info] - should disallow invalid chars
[info] - should allow valid chars
[info] PaymentConfigSpec:
[info] Config
[info] - should load correctly
[info] ErrorHandlerSpec:
[info] ErrorHandler
[info] - should throw an RetryLimited when it handles an unknown error
[info] ErrorHandler
[info] - should throw an RetryUnlimited when it handles a timeout
[info] ErrorHandler
[info] - should throw an RetryUnlimited when the connection is reset
[info] ErrorHandler
[info] - should throw an RetryUnlimited when it handles a Salesforce expired auth token
[info] ErrorHandler
[info] - should throw an RetryNone when it handles any other Salesforce error
[info] ErrorHandler
[info] - should throw an RetryLimited when it handles a 401 authentication error
[info] ErrorHandler
[info] - should throw an RetryNone when it handles a 403 unauthorized error
[info] asRetryException method
[info] - should allow us to work out retries
[info] SerialisationSpec:
[info] UpsertData
[info] - should serialise to correct UK json
[info] UpsertData
[info] - should serialise to correct US json
[info] UpsertData
[info] - should serialise to correct json when telephoneNumber provided
[info] UpsertData
[info] - should serialise to correct json when billing address provided
[info] UpsertData
[info] - should serialise to correct json when billing address and delivery address provided
[info] Gift recipient upsert data
[info] - should serialise to correct json
[info] Authentication
[info] - should deserialize correctly
[info] CreatePaymentMethodStateDecoderSpec:
[info] Monthly Contribution Product
[info] - should be decodable
[info] Annual DigitalPackProduct
[info] - should be decodable
[info] CreatePaymentMethodStateDecoder
[info] - should be able to decode a contribution with PayPal payment fields
[info] - should be able to decode a contribution with Stripe source payment fields
[info] - should be able to decode a contribution with Stripe payment method payment fields
[info] - should be able to decode a DigtalBundle with PayPal payment fields
[info] - should be able to decode a DigitalPack with Direct Debit payment fields
[info] ZuoraErrorsSpec:
[info] JsonWrapped error
[info] - should deserialise correctly
[info] AwsCloudWatchMetricPutSpec:
[info] CatalogFailures
[info] SendThankYouEmailIT:
[info] SendThankYouEmail lambda
[info] CatalogServiceIntegrationSpec:
[info] CatalogService
[info] CreatePaymentMethodSpec:
[info] CreatePaymentMethod
[info] - should retrieve a valid CreditCardReferenceTransaction when given a valid stripe token
[info] - should fail when passed invalid json
[info] StripeService
[info] SendThankYouEmailSpec:
[info] EmailFields
[info] - should include Direct Debit fields in the payload
[info] DynamoServiceSpec:
[info] DynamoService
[info] ZuoraITSpec:
[info] ZuoraService
[info] Preview request
[info] Subscribe request
[info] SubscriptionEmailFieldHelpersSpec:
[info] describe
[info] - should explain a simple annual payment schedule correctly
[info] describe
[info] - should explain a simple quarterly payment schedule correctly
[info] describe
[info] - should explain a simple monthly payment schedule correctly
[info] describe
[info] - should explain a payment schedule truthfully if we only get information about the first payment
[info] describe
[info] - should explain a payment schedule correctly if the first 3 months are discounted
[info] describe
[info] - should explain a payment schedule correctly if the first 2 quarters are discounted
[info] describe
[info] - should explain a 6 for 6 subscription correctly
[info] GetAddressIOServiceSpec:
[info] GetAddressService
[info] FailureHandlerIT:
[info] FailureHandler lambda
[info] SetCodeStatusITSpec:
[info] setCodeStatus
[info] setCodeStatus
[info] SendAcquisitionEventSpec:
[info] SendAcquisitionEvent
[info] DynamoTableAsyncITSpec:
[info] lookup
[info] update
[info] EndToEndSpec:
[info] PreviewPaymentScheduleSpec:
[info] paymentSchedule
[info] - should calculate a payment schedule correctly for products without tax
[info] - should calculate a payment schedule correctly for products with tax
[info] - should round Payment amounts to two decimal places
[info] ProductSubscriptionBuildersSpec:
[info] InitialTermLength
[info] - should be correct
[info] SubscriptionData for a gift subscription
[info] - should have autoRenew set to false
[info] - should have the contractAcceptanceDate set to the first delivery date
[info] - should have the contractEffectiveDate and the termStartDate set to the date it was sold
[info] - should have an initial term of 95 days
[info] - should have the correct productRatePlanId
[info] SubscriptionData for a non-gift subscription
[info] - should have autoRenew set to true
[info] - should have the contractAcceptanceDate set to the first delivery date
[info] - should have the contractEffectiveDate and the termStartDate set to the date it was sold
[info] - should have an initial term of 12 months
[info] - should have the correct productRatePlanId
[info] AddressLineTransformerTest:
[info] combinedAddressLine
[info] - should return an AddressLine when there is only a lineOne
[info] combinedAddressLine
[info] - should return an AddressLine when there is lineOne and a lineTwo
[info] combinedAddressLine
[info] - should None when there is neither a lineOne nor a lineTwo
[info] combinedAddressLine
[info] - should still return an AddressLine when there are two address lines and the second line has the street number
[info] clipForZuoraStreetNameLimit
[info] - should clip street name to 100 characters
[info] asFormattedString
[info] - should combine a street number and a street name
[info] asFormattedString
[info] - should just return street name if there is no street number
[info] GetCodeStatusITSpec:
[info] getCodeStatus
[info] CreateSalesforceContactSpec:
[info] CreateSalesforceContact lambda
[info] ZuoraSpec:
[info] zuora service
[info] - should correctly format dates
[info] PriceSummaryServiceIntegrationSpec:
[info] PriceSummaryService
[info] SalesforceSpec:
[info] AuthService
[info] SalesforceService
[info] NewContact
[info] StepFunctionsSpec:
[info] StepFunctionsService
[info] ZuoraErrorsITSpec:
[info] Subscribe request with invalid term type
[info] Subscribe request with incorrect PaymentMethod
[info] Timeouts from Zuora
[info] 500s from Zuora
[info] 200s with success = false from Zuora and a transient error
[info] 200s with success = false from Zuora and a permanent error
[info] 200s with wrong content type
[info] PreparePaymentMethodForReuseSpec:
[info] ClonePaymentMethod lambda
[info] CreateZuoraSubscriptionSpec:
[info] CreateZuoraSubscription lambda
```

Interested in whether people think this is better than the current, as a workaround until the bug is fixed upstream.