### PR TITLE
Mj update aus moment social sharing copy

### DIFF
--- a/support-frontend/Brewfile.lock.json
+++ b/support-frontend/Brewfile.lock.json
@@ -54,9 +54,9 @@
   "system": {
     "macos": {
       "mojave": {
-        "HOMEBREW_VERSION": "2.4.0-53-g748af98",
+        "HOMEBREW_VERSION": "2.4.0-67-gb37520c",
         "HOMEBREW_PREFIX": "/usr/local",
-        "Homebrew/homebrew-core": "d96c1d25e4891d50dd831118e06ba914be7714ea",
+        "Homebrew/homebrew-core": "811984539e971173637abc4e67d22dbd1c88c2af",
         "CLT": "10.3.0.0.1.1562985497",
         "Xcode": "11.3.1",
         "macOS": "10.14.6"

--- a/support-frontend/assets/components/socialShare/socialShare.jsx
+++ b/support-frontend/assets/components/socialShare/socialShare.jsx
@@ -62,7 +62,7 @@ const socialMedia: {
   linkedin: {
     link: referralCodeQueryParameter =>
       (referralCodeQueryParameter
-          ? `https://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute%3FausAcquisitionData%3Dthankyou_linkedin_${referralCodeQueryParameter || ''}`
+        ? `https://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute%3FausAcquisitionData%3Dthankyou_linkedin_${referralCodeQueryParameter || ''}`
         : 'http://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute'
       ),
     svg: <SvgLinkedin />,

--- a/support-frontend/assets/components/socialShare/socialShare.jsx
+++ b/support-frontend/assets/components/socialShare/socialShare.jsx
@@ -52,7 +52,7 @@ const socialMedia: {
   twitter: {
     link: referralCodeQueryParameter =>
       (referralCodeQueryParameter
-        ? `https://twitter.com/intent/tweet?url=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute%3FausAcquisitionData%3Dthankyou_twitter_${referralCodeQueryParameter || ''}&text=Join%20me%20and%20over%20one%20million%20others%20in%20supporting%20a%20different%20model%20for%20open%2C%20independent%20journalism.%20Together%20we%20can%20help%20safeguard%20The%20Guardian%E2%80%99s%20future%20%E2%80%93%20so%20more%20people%2C%20across%20the%20world%2C%20can%20keep%20accessing%20factual%20information%20for%20free`
+        ? `https://twitter.com/intent/tweet?url=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute%3FausAcquisitionData%3Dthankyou_twitter_${referralCodeQueryParameter || ''}&hashtags=supporttheguardian&text=Guardian%20Australia%20supporters%20are%20doing%20something%20powerful.%20I%20support%20the%20Guardian%20because%20I%20believe%20their%20vital%2C%20independent%20journalism%20should%20be%20open%20and%20free%20to%20all.%20Join%20me.%20With%20your%20support%2C%20we%20can%20do%20more.`
         : 'https://twitter.com/intent/tweet?url=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute?INTCMP=component-social-twitter&text=Join%20me%20and%20over%20one%20million%20others%20in%20supporting%20a%20different%20model%20for%20open%2C%20independent%20journalism.%20Together%20we%20can%20help%20safeguard%20The%20Guardian%E2%80%99s%20future%20%E2%80%93%20so%20more%20people%2C%20across%20the%20world%2C%20can%20keep%20accessing%20factual%20information%20for%20free'
       ),
     svg: <SvgTwitter />,
@@ -62,7 +62,7 @@ const socialMedia: {
   linkedin: {
     link: referralCodeQueryParameter =>
       (referralCodeQueryParameter
-        ? `https://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute%3FausAcquisitionData%3Dthankyou_linkedin_${referralCodeQueryParameter || ''}`
+          ? `https://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute%3FausAcquisitionData%3Dthankyou_linkedin_${referralCodeQueryParameter || ''}`
         : 'http://www.linkedin.com/shareArticle?mini=true&url=https%3A%2F%2Fsupport.theguardian.com%2Fcontribute'
       ),
     svg: <SvgLinkedin />,
@@ -72,7 +72,7 @@ const socialMedia: {
   email: {
     link: referralCodeQueryParameter =>
       (referralCodeQueryParameter
-        ? `mailto:?subject=Join%20me%20in%20supporting%20open%2C%20independent%20journalism&body=Join%20me%20and%20over%20one%20million%20others%20in%20supporting%20a%20different%20model%20for%20open%2C%20independent%20journalism.%20Together%20we%20can%20help%20safeguard%20The%20Guardian%E2%80%99s%20future%20%E2%80%93%20so%20more%20people%2C%20across%20the%20world%2C%20can%20keep%20accessing%20factual%20information%20for%20free%3A%20https%3A%2F%2Fsupport.theguardian.com%2Fcontribute%3FausAcquisitionData%3Dthankyou_email_${referralCodeQueryParameter || ''}`
+        ? `mailto:?subject=Guardian%20Australia%20supporters%20are%20doing%20something%20powerful&body=I%20support%20the%20Guardian%20because%20I%20believe%20their%20vital%2C%20independent%20journalism%20should%20be%20open%20and%20free%20to%20all.%20Join%20me.%20With%20your%20support%2C%20we%20can%20do%20more.%20%23supporttheguardian%0A%0Ahttps%3A%2F%2Fsupport.theguardian.com%2Fcontribute%3FausAcquisitionData%3Dthankyou_email_${referralCodeQueryParameter || ''}`
         : 'mailto:?subject=Join%20me%20in%20supporting%20open%2C%20independent%20journalism&body=Join%20me%20and%20over%20one%20million%20others%20in%20supporting%20a%20different%20model%20for%20open%2C%20independent%20journalism.%20Together%20we%20can%20help%20safeguard%20The%20Guardian%E2%80%99s%20future%20%E2%80%93%20so%20more%20people%2C%20across%20the%20world%2C%20can%20keep%20accessing%20factual%20information%20for%20free%3A%20https%3A%2F%2Fsupport.theguardian.com%2Fcontribute?INTCMP=component-social-email'
       ),
     svg: <SvgEmail />,


### PR DESCRIPTION
<p>This PR updates the pre-populated social share copy, for email and Twitter, coming from the AU thank you page.</p>
<p>We are unable to do this for Facebook or LinkedIn, due to constraints from those platforms.</p>
<p>Please see screenshots below for a demo of how the copy will appear.</p>
<br>
<h2>Twitter</h2>
<img width="583" alt="Screenshot 2020-06-18 at 14 41 07" src="https://user-images.githubusercontent.com/25020231/85028999-b7ba0b80-b173-11ea-8892-fbc1d42349ab.png">
<br>
<h2>Email (GMail)</h2>
<img width="1222" alt="Screenshot 2020-06-18 at 14 42 03" src="https://user-images.githubusercontent.com/25020231/85029044-c7395480-b173-11ea-8b9f-41f8d86971ca.png">
