### PR TITLE
Fix layout issue in redemption form

### DIFF
--- a/support-frontend/assets/components/subscriptionCheckouts/layout.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/layout.jsx
@@ -9,14 +9,18 @@ type AsideWrapPosition = 'top' | 'bottom';
 
 type PropTypes = {
   children: Node,
-  aside: ?Node,
+  aside: Node,
   wrapPosition: ?AsideWrapPosition,
 };
 const CheckoutLayout = ({ children, aside, wrapPosition }: PropTypes) => {
-  const mainClass = [styles.root, aside ? styles.withAside : null].join(' ');
+  const mainClass = [
+    styles.root,
+    wrapPosition === 'bottom' ? styles.asideBottom : styles.asideTop,
+  ].join(' ');
+
   return (
     <div className={mainClass}>
-      {aside && wrapPosition === 'top' &&
+      {wrapPosition === 'top' &&
         <div className={`${styles.aside} ${styles.sticky}`}>
           {aside}
         </div>
@@ -24,7 +28,7 @@ const CheckoutLayout = ({ children, aside, wrapPosition }: PropTypes) => {
       <div className={styles.form}>
         {children}
       </div>
-      {aside && wrapPosition === 'bottom' &&
+      {wrapPosition === 'bottom' &&
         <div className={styles.aside}>
           {aside}
         </div>
@@ -34,7 +38,6 @@ const CheckoutLayout = ({ children, aside, wrapPosition }: PropTypes) => {
 };
 
 CheckoutLayout.defaultProps = {
-  aside: null,
   wrapPosition: 'top',
 };
 

--- a/support-frontend/assets/components/subscriptionCheckouts/layout.module.scss
+++ b/support-frontend/assets/components/subscriptionCheckouts/layout.module.scss
@@ -9,6 +9,14 @@
 
 .root {
   max-width: gu-span(14) + $gu-h-spacing;
+  @include mq($from:tablet) {
+    display: flex;
+    align-items: flex-start;
+  }
+  .form {
+    flex: 0 0 auto;
+    width: 100%;
+  }
 }
 
 .form {
@@ -21,16 +29,12 @@
   }
 }
 
-.withAside {
-  @include mq($from:tablet) {
-    display: flex;
-    flex-direction: row-reverse;
-    align-items: flex-start;
-  }
-  .form {
-    flex: 0 0 auto;
-    width: 100%;
-  }
+.asideTop {
+  flex-direction: row-reverse;
+}
+
+.asideBottom {
+  flex-direction: row;
 }
 
 .sticky {


### PR DESCRIPTION
## Why are you doing this?
I noticed that #2547 introduced a bug where the aside would show on the wrong side of the form in desktop layouts:
![Screen Shot 2020-06-18 at 14 01 28](https://user-images.githubusercontent.com/181371/85023169-49be1600-b16c-11ea-94e8-1029402a2258.png)

This PR fixes it:
![Screen Shot 2020-06-18 at 15 00 49](https://user-images.githubusercontent.com/181371/85029756-8988fb80-b174-11ea-87f9-9ed0a5085cd6.png)


I also noticed that the `CheckoutLayout` control is never used without an `aside` so I've made it non-optional as it simplifies the code.
