### PR TITLE
Ds remove address test

### DIFF
--- a/support-frontend/app/utils/CheckoutValidationRules.scala
+++ b/support-frontend/app/utils/CheckoutValidationRules.scala
@@ -102,9 +102,9 @@ object DigitalPackValidation {
     def isValidPaidSub(paymentFields: PaymentFields) =
       SimpleCheckoutFormValidation.passes(createSupportWorkersRequest) &&
         hasStateIfRequired(country, state) &&
-        hasPostcodeIfRequired(country, postCode) &&
+        //hasAddressLine1AndCity(billingAddress) &&
+        //hasPostcodeIfRequired(country, postCode) &&
         currencyIsSupportedForCountry(country, currency) &&
-        hasAddressLine1AndCity(billingAddress) &&
         PaidProductValidation.noEmptyPaymentFields(paymentFields)
 
     paymentFields.fold(

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -2,6 +2,7 @@
 import type { Tests } from './abtest';
 import { USV1 } from './data/testAmountsData';
 import ausMomentEnabled from 'helpers/ausMoment';
+import { detect as detectCountryGroupId, GBPCountries } from 'helpers/internationalisation/countryGroup';
 
 // ----- Tests ----- //
 export type StripePaymentRequestButtonTestVariants = 'control' | 'button';
@@ -143,6 +144,7 @@ export const tests: Tests = {
     isActive: true,
     referrerControlled: false,
     seed: 7,
+    canRun: () => detectCountryGroupId() === GBPCountries,
     targetPage: digitalCheckout,
     optimizeId: 'tdBE5yqdR0aQ19E06j1zRA',
   },

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -144,6 +144,6 @@ export const tests: Tests = {
     referrerControlled: false,
     seed: 7,
     targetPage: digitalCheckout,
-    optimizeId: '',
+    optimizeId: 'tdBE5yqdR0aQ19E06j1zRA',
   },
 };

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -123,4 +123,27 @@ export const tests: Tests = {
     seed: 6,
     targetPage: auOnlyLandingPage,
   },
+
+  removeDigiSubAddressTest: {
+    type: 'OTHER',
+    variants: [
+      {
+        id: 'control',
+      },
+      {
+        id: 'noAddress',
+      },
+    ],
+    audiences: {
+      ALL: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: true,
+    referrerControlled: false,
+    seed: 7,
+    targetPage: digitalCheckout,
+    optimizeId: '',
+  },
 };

--- a/support-frontend/assets/helpers/subscriptionsForms/formValidation.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/formValidation.js
@@ -38,13 +38,15 @@ type Error<T> = {
 type AnyErrorType = Error<AddressFormField> | Error<FormField>;
 
 function checkoutValidation(state: CheckoutState): AnyErrorType[] {
+  const shouldValidateAddress = state.common.abParticipations.removeDigiSubAddressTest !== 'noAddress';
+  const addressErrors = shouldValidateAddress ? applyBillingAddressRules(getBillingAddressFields(state), 'billing') : [];
   return [
     ({
       errors: applyCheckoutRules(getFormFields(state)),
       errorAction: setFormErrors,
     }: Error<FormField>),
     ({
-      errors: applyBillingAddressRules(getBillingAddressFields(state), 'billing'),
+      errors: addressErrors,
       errorAction: setAddressFormErrorsFor('billing'),
     }: Error<AddressFormField>),
   ].filter(({ errors }) => errors.length > 0);

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
@@ -39,8 +39,7 @@ import {
 } from 'helpers/subscriptionsForms/formFields';
 import PersonalDetails from 'components/subscriptionCheckouts/personalDetails';
 import DigitalPaymentTerms from './digitalPaymentTerms';
-import { withStore as withStoreLoqate } from 'components/subscriptionCheckouts/addressSearch/addressComponent';
-import { withStore as withStoreControl } from 'components/subscriptionCheckouts/address/addressFields';
+import { withStore } from 'components/subscriptionCheckouts/address/addressFields';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import { countries } from 'helpers/internationalisation/country';
 import { DigitalPack } from 'helpers/subscriptions';
@@ -134,8 +133,7 @@ function mapDispatchToProps() {
   };
 }
 
-const LocateAddress = withStoreLoqate(countries, 'billing', getBillingAddress);
-const ControlAddress = withStoreControl(countries, 'billing', getBillingAddress);
+const Address = withStore(countries, 'billing', getBillingAddress);
 
 // ----- Component ----- //
 
@@ -149,7 +147,14 @@ function DigitalCheckoutForm(props: PropTypes) {
   const submissionErrorHeading = props.submissionError === 'personal_details_incorrect' ? 'Sorry there was a problem' :
     'Sorry we could not process your payment';
 
-  const Address = props.participations.fancyAddressTest === 'loqate' ? LocateAddress : ControlAddress;
+  const maybeAddress = props.participations.removeDigiSubAddressTest === 'noAddress' ?
+    null :
+    (
+      <FormSection title="Address">
+        <Address />
+      </FormSection>
+    );
+
 
   return (
     <Content>
@@ -189,9 +194,7 @@ function DigitalCheckoutForm(props: PropTypes) {
               signOut={props.signOut}
             />
           </FormSection>
-          <FormSection title="Address">
-            <Address />
-          </FormSection>
+          {maybeAddress}
           <PaymentMethodSelector
             country={props.country}
             paymentMethod={props.paymentMethod}

--- a/support-frontend/test/utils/CheckoutValidationRulesTest.scala
+++ b/support-frontend/test/utils/CheckoutValidationRulesTest.scala
@@ -63,37 +63,37 @@ class DigitalPackValidationTest extends AnyFlatSpec with Matchers {
     DigitalPackValidation.passes(requestMissingState) shouldBe false
   }
 
-  it should "also fail if the country is Australia and there is no postcode" in {
-    val requestMissingPostcode = validDigitalPackRequest.copy(
-      billingAddress = validDigitalPackRequest.billingAddress.copy(country = Country.Australia, postCode = None),
-      product = DigitalPack(Currency.AUD, Monthly)
-    )
-    DigitalPackValidation.passes(requestMissingPostcode) shouldBe false
-  }
-
-  it should "also fail if the country is United Kingdom and there is no postcode" in {
-    val requestMissingPostcode = validDigitalPackRequest.copy(
-      billingAddress = validDigitalPackRequest.billingAddress.copy(country = Country.UK, postCode = None),
-      product = DigitalPack(Currency.GBP, Monthly)
-    )
-    DigitalPackValidation.passes(requestMissingPostcode) shouldBe false
-  }
-
-  it should "also fail if the country is United States and there is no postcode" in {
-    val requestMissingPostcode = validDigitalPackRequest.copy(
-      billingAddress = validDigitalPackRequest.billingAddress.copy(postCode = None),
-      product = DigitalPack(Currency.USD, Monthly)
-    )
-    DigitalPackValidation.passes(requestMissingPostcode) shouldBe false
-  }
-
-  it should "also fail if the country is Canada and there is no postcode" in {
-    val requestMissingPostcode = validDigitalPackRequest.copy(
-      billingAddress = validDigitalPackRequest.billingAddress.copy(country = Country.Canada, postCode = None),
-      product = DigitalPack(Currency.CAD, Monthly)
-    )
-    DigitalPackValidation.passes(requestMissingPostcode) shouldBe false
-  }
+//  it should "also fail if the country is Australia and there is no postcode" in {
+//    val requestMissingPostcode = validDigitalPackRequest.copy(
+//      billingAddress = validDigitalPackRequest.billingAddress.copy(country = Country.Australia, postCode = None),
+//      product = DigitalPack(Currency.AUD, Monthly)
+//    )
+//    DigitalPackValidation.passes(requestMissingPostcode) shouldBe false
+//  }
+//
+//  it should "also fail if the country is United Kingdom and there is no postcode" in {
+//    val requestMissingPostcode = validDigitalPackRequest.copy(
+//      billingAddress = validDigitalPackRequest.billingAddress.copy(country = Country.UK, postCode = None),
+//      product = DigitalPack(Currency.GBP, Monthly)
+//    )
+//    DigitalPackValidation.passes(requestMissingPostcode) shouldBe false
+//  }
+//
+//  it should "also fail if the country is United States and there is no postcode" in {
+//    val requestMissingPostcode = validDigitalPackRequest.copy(
+//      billingAddress = validDigitalPackRequest.billingAddress.copy(postCode = None),
+//      product = DigitalPack(Currency.USD, Monthly)
+//    )
+//    DigitalPackValidation.passes(requestMissingPostcode) shouldBe false
+//  }
+//
+//  it should "also fail if the country is Canada and there is no postcode" in {
+//    val requestMissingPostcode = validDigitalPackRequest.copy(
+//      billingAddress = validDigitalPackRequest.billingAddress.copy(country = Country.Canada, postCode = None),
+//      product = DigitalPack(Currency.CAD, Monthly)
+//    )
+//    DigitalPackValidation.passes(requestMissingPostcode) shouldBe false
+//  }
 
   it should "also allow a missing postcode in other countries" in {
     val requestMissingPostcode = validDigitalPackRequest.copy(


### PR DESCRIPTION
## Why are you doing this?
We want to test removing the address fields from Digital Subscriptions to see if it results in an increase in conversion.

Note that this PR removes server side validation of address fields for all digisub checkouts. I think this is acceptable as we are happy to accept subs without an address for those in the 'no address' variant, so it is not a disaster if somehow those in the other variant manage to submit a purchase without a valid address.

[**Trello Card**](https://trello.com/c/x0iBur2v/3090-ab-test-does-removing-address-fields-from-ds-checkout-increase-conversion-rate)