### PR TITLE
fix for failing test

### DIFF
--- a/support-frontend/test/selenium/contributions/pages/ContributionsLanding.scala
+++ b/support-frontend/test/selenium/contributions/pages/ContributionsLanding.scala
@@ -21,7 +21,7 @@ case class ContributionsLanding(region: String, testUser: TestUser)(implicit val
   private val otherAmount = id("contributionOther")
 
   private val stripeSelector = cssSelector(".form__radio-group-label[for='paymentMethodSelector-Stripe']")
-  private val payPalSelector = cssSelector(".form__radio-group-label[for='paymentMethodSelector-PayPal']")
+  private val payPalSelector = id("paymentMethodSelector-PayPal")
   private val stateSelector = id("contributionState")
 
   private val stripeOverlayIframe = cssSelector(".stripe_checkout_app")


### PR DESCRIPTION
## Why are you doing this?

Since the change to DS selenium no longer finds the paypal radio.

```
[info]   Scenario: Check browser navigates to paypal *** FAILED ***
[info]   selenium.util.Browser$MissingPageElementException: Could not find WebElement with locator: .form__radio-group-label[for='paymentMethodSelector-PayPal']
[info]   at selenium.util.Browser.clickOn(Browser.scala:54)
[info]   at selenium.util.Browser.clickOn$(Browser.scala:50)
[info]   at selenium.contributions.pages.ContributionsLanding.clickOn(ContributionsLanding.scala:7)
[info]   at selenium.contributions.pages.ContributionsLanding.selectPayPalPayment(ContributionsLanding.scala:88)
[info]   at selenium.contributions.OneOffContributionsSpec.$anonfun$new$5(OneOffContributionsSpec.scala:102)
[info]   at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
[info]   at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
[info]   at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
[info]   at org.scalatest.Transformer.apply(Transformer.scala:22)
[info]   at org.scalatest.Transformer.apply(Transformer.scala:20)
```

https://travis-ci.org/github/guardian/support-frontend/builds/700949230