### PR TITLE
Fix overlapping styles on roundel

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-landing/components/hero/campaignHeaderStyles.js
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/hero/campaignHeaderStyles.js
@@ -111,7 +111,6 @@ export const graphic = css`
   }
 `;
 
-
 export const badge = css`
   position: relative;
   margin-bottom: -2rem;
@@ -124,10 +123,11 @@ export const badge = css`
   color: ${brand[400]};
   text-align: center;
   border-radius: 50%;
-  line-height: 1;
-  ${body.small({ fontWeight: 'bold' })};
+  ${body.small()};
+  font-weight: bold;
   width: 7.5rem;
   height: 7.5rem;
+  padding-top: ${space[1]}px;
 
   ${from.mobileMedium} {
     margin-bottom: -3rem;
@@ -135,7 +135,8 @@ export const badge = css`
 
   ${from.desktop} {
     justify-content: flex-end;
-    ${headline.xxsmall({ fontWeight: 'bold' })};
+    ${headline.xxsmall()};
+    font-weight: bold;
     width: 10rem;
     height: 10rem;
     padding-bottom: ${space[6]}px;
@@ -150,34 +151,30 @@ export const badge = css`
 
   span {
     display: block;
-    line-height: 0.5;
   }
 
   span:first-of-type {
-    margin-bottom: ${space[2]}px;
-
-    ${from.leftCol} {
-      margin-bottom: 0;
-    }
+    margin-bottom: 0.3rem;
   }
 
   span:nth-child(2) {
-    ${headline.large({ fontWeight: 'bold' })}
+    ${headline.large()}
+    font-weight: bold;
+    line-height: 65%;
     position: relative;
-    font-variant-numeric: lining-nums;
-    -moz-font-feature-settings: "lnum";
-    -webkit-font-feature-settings: "lnum";
-    font-feature-settings: "lnum";
-    margin-top: ${space[1]}px;
+    margin-bottom: 0.2rem;
 
     ${from.desktop} {
-      ${headline.xlarge({ fontWeight: 'bold' })}
+      ${headline.xlarge()}
+      line-height: 75%;
+      font-weight: bold;
       font-size: 3rem;
+      margin-bottom: 0.2rem;
     }
 
     ${from.leftCol} {
       font-size: 4rem;
-      top: 0.3rem;
+      margin-bottom: 0.4rem;
     }
   }
 `;

--- a/support-frontend/assets/pages/paper-subscription-landing/components/hero/campaignHeaderStyles.js
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/hero/campaignHeaderStyles.js
@@ -37,28 +37,33 @@ export const campaignCopy = css`
 `;
 
 export const heading = css`
-  ${headline.small({ fontWeight: 'bold' })};
+  ${headline.small()};
+  font-weight: bold;
   color: ${brand[400]};
   margin-bottom: ${space[3]}px;
 
   ${from.desktop} {
-    ${headline.medium({ fontWeight: 'bold' })};
+    ${headline.medium()};
+    font-weight: bold;
   }
 
   ${from.leftCol} {
-    ${headline.large({ fontWeight: 'bold' })};
+    ${headline.large()};
+    font-weight: bold;
   }
 `;
 
 export const subheading = css`
-  ${headline.xxxsmall({ fontWeight: 'bold' })};
+  ${headline.xxxsmall()};
+  font-weight: bold;
 
   ${from.phablet} {
     max-width: 80%;
   }
 
   ${from.desktop} {
-    ${headline.xsmall({ fontWeight: 'bold' })};
+    ${headline.xsmall()};
+    font-weight: bold;
   }
 
   ${from.leftCol} {


### PR DESCRIPTION
## Why are you doing this?
The [print landing page hero refresh](https://github.com/guardian/support-frontend/pull/2570) had a font issue with the roundel. It should have looked like this:

![Screen Shot 2020-06-26 at 13 28 36](https://user-images.githubusercontent.com/16781258/85864949-1a875480-b7bd-11ea-8d12-7ab39ab17f99.png)

But unfortunately in many cases it was looking like this:

![Screen Shot 2020-06-26 at 11 31 07](https://user-images.githubusercontent.com/16781258/85864991-296e0700-b7bd-11ea-9f0f-5446e7a0cb42.png)

It turns out that the issue was with some css that is supposed to align numbers to a baseline (so they all line up neatly and don't make the spacing ragged). This css prop only works if you are explicitly loading full subset of fonts, which would be around another ~20KB+, and we would prefer not to do this.

The solution was to remove this css and make the alignment work with a more ragged numerical line of text so the visual is consistent.

The PR that introduced this issue is this one: https://github.com/guardian/support-frontend/pull/2570

[**Trello Card**](https://trello.com/c/xQQhqXj1/3152-fix-broken-roundel-spacing-on-print-landing-page)

## Screenshots
![Screen Shot 2020-06-26 at 14 51 38](https://user-images.githubusercontent.com/16781258/85866000-ab126480-b7be-11ea-8b6c-db37c79bc0e9.png)

![Screen Shot 2020-06-26 at 14 52 07](https://user-images.githubusercontent.com/16781258/85866028-b1a0dc00-b7be-11ea-8086-18ad24acbc26.png)

![Screen Shot 2020-06-26 at 14 52 31](https://user-images.githubusercontent.com/16781258/85866042-b5ccf980-b7be-11ea-8e5c-cc5c14963530.png)
