### PR TITLE
Add corporate-subscription label to acquisition event tracking

### DIFF
--- a/support-workers/build.sbt
+++ b/support-workers/build.sbt
@@ -39,7 +39,7 @@ libraryDependencies ++= Seq(
   "io.sentry" % "sentry-logback" % "1.7.4",
   "com.google.code.findbugs" % "jsr305" % "3.0.2",
   "com.gocardless" % "gocardless-pro" % "2.8.0",
-  "com.gu" %% "acquisition-event-client-play26" % "4.0.29"
+  "com.gu" %% "acquisition-event-client-play26" % "4.0.31"
 )
 
 riffRaffPackageType := assembly.value

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
@@ -197,7 +197,8 @@ object SendAcquisitionEvent {
         Some(Set(
           if (stateAndInfo.requestInfo.accountExists) Some("REUSED_EXISTING_PAYMENT_METHOD") else None,
           if (isSixForSix(stateAndInfo)) Some("guardian-weekly-six-for-six") else None,
-          stateAndInfo.state.giftRecipient.map(_ => "gift-subscription")
+          stateAndInfo.state.giftRecipient.map(_ => "gift-subscription"),
+          stateAndInfo.state.paymentMethod.right.map(_ => "corporate-subscription").toOption
         ).flatten)
 
       def isSixForSix(stateAndInfo: SendAcquisitionEventStateAndRequestInfo) =


### PR DESCRIPTION
## Why are you doing this?
We want to be able to identify corporate subscriptions in the Acquisitions data lake table and Google Analytics data.

[**Trello Card**](https://trello.com)

## Changes

* Change 1
* Change 2

## Accessibility test checklist
 - [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
 - [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
 - [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

## Screenshots

