### PR TITLE
don't use PROD in the name of the Redemption tables

### DIFF
--- a/support-frontend/cloud-formation/cfn.yaml
+++ b/support-frontend/cloud-formation/cfn.yaml
@@ -43,8 +43,8 @@ Mappings:
       - arn:aws:dynamodb:*:*:table/MembershipSub-Promotions-DEV
       - arn:aws:dynamodb:*:*:table/MembershipSub-Promotions-UAT
       RedemptionTables:
-      - arn:aws:dynamodb:*:*:table/redemption-codes-DEV-PROD
-      - arn:aws:dynamodb:*:*:table/redemption-codes-UAT-PROD
+      - arn:aws:dynamodb:*:*:table/redemption-codes-DEV
+      - arn:aws:dynamodb:*:*:table/redemption-codes-UAT
     PROD:
       MaxInstances: 6
       MinInstances: 3
@@ -55,8 +55,8 @@ Mappings:
       - arn:aws:dynamodb:*:*:table/MembershipSub-Promotions-PROD
       - arn:aws:dynamodb:*:*:table/MembershipSub-Promotions-UAT
       RedemptionTables:
-      - arn:aws:dynamodb:*:*:table/redemption-codes-UAT-PROD
-      - arn:aws:dynamodb:*:*:table/redemption-codes-PROD-PROD
+      - arn:aws:dynamodb:*:*:table/redemption-codes-UAT
+      - arn:aws:dynamodb:*:*:table/redemption-codes-PROD
   Constants:
     Alarm:
       Process: Follow the process in https://docs.google.com/document/d/1_3El3cly9d7u_jPgTcRjLxmdG2e919zCLvmcFCLOYAk/edit

--- a/support-redemptiondb/cfn.yaml
+++ b/support-redemptiondb/cfn.yaml
@@ -6,6 +6,18 @@ Parameters:
     AllowedValues:
       - CODE
       - PROD
+
+Mappings:
+  StageMap:
+    CODE:
+      TableDEV: "redemption-codes-DEV-CODE"
+      TableUAT: "redemption-codes-UAT-CODE"
+      TablePROD: "redemption-codes-PROD-CODE"
+    PROD:
+      TableDEV: "redemption-codes-DEV"
+      TableUAT: "redemption-codes-UAT"
+      TablePROD: "redemption-codes-PROD"
+
 Resources:
   RedemptionCodeDynamoTableDEV:
     Type: AWS::DynamoDB::Table
@@ -17,7 +29,7 @@ Resources:
       KeySchema:
         - AttributeName: "redemptionCode"
           KeyType: "HASH"
-      TableName: !Sub redemption-codes-DEV-${Stage}
+      TableName: !FindInMap [ StageMap, !Ref Stage, TableDEV ]
   RedemptionCodeDynamoTableUAT:
     Type: AWS::DynamoDB::Table
     Properties:
@@ -28,7 +40,7 @@ Resources:
       KeySchema:
         - AttributeName: "redemptionCode"
           KeyType: "HASH"
-      TableName: !Sub redemption-codes-UAT-${Stage}
+      TableName: !FindInMap [ StageMap, !Ref Stage, TableUAT ]
   RedemptionCodeDynamoTablePROD:
     Type: AWS::DynamoDB::Table
     Properties:
@@ -39,7 +51,7 @@ Resources:
       KeySchema:
         - AttributeName: "redemptionCode"
           KeyType: "HASH"
-      TableName: !Sub redemption-codes-PROD-${Stage}
+      TableName: !FindInMap [ StageMap, !Ref Stage, TablePROD ]
 Outputs:
   DynamoArnOutDEV:
     Description: ARN for DEV dynamo table

--- a/support-services/src/main/scala/com/gu/support/redemption/RedemptionTable.scala
+++ b/support-services/src/main/scala/com/gu/support/redemption/RedemptionTable.scala
@@ -22,7 +22,7 @@ object RedemptionTable {
   }
 
   def forEnvAsync(env: TouchPointEnvironment)(implicit e: ExecutionContext): DynamoTableAsync =
-    DynamoTableAsync(s"redemption-codes-${env.envValue}-PROD", primaryKey)
+    DynamoTableAsync(s"redemption-codes-${env.envValue}", primaryKey)
 
 }
 

--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -29,16 +29,16 @@ Mappings:
       - arn:aws:dynamodb:*:*:table/MembershipSub-Promotions-DEV
       - arn:aws:dynamodb:*:*:table/MembershipSub-Promotions-UAT
       RedemptionTables:
-      - arn:aws:dynamodb:*:*:table/redemption-codes-DEV-PROD
-      - arn:aws:dynamodb:*:*:table/redemption-codes-UAT-PROD
+      - arn:aws:dynamodb:*:*:table/redemption-codes-DEV
+      - arn:aws:dynamodb:*:*:table/redemption-codes-UAT
       KinesisStreamArn: arn:aws:kinesis:eu-west-1:865473395570:stream/acquisitions-stream-CODE
     PROD:
       DynamoDBTables:
       - arn:aws:dynamodb:*:*:table/MembershipSub-Promotions-PROD
       - arn:aws:dynamodb:*:*:table/MembershipSub-Promotions-UAT
       RedemptionTables:
-      - arn:aws:dynamodb:*:*:table/redemption-codes-UAT-PROD
-      - arn:aws:dynamodb:*:*:table/redemption-codes-PROD-PROD
+      - arn:aws:dynamodb:*:*:table/redemption-codes-UAT
+      - arn:aws:dynamodb:*:*:table/redemption-codes-PROD
       KinesisStreamArn: arn:aws:kinesis:eu-west-1:865473395570:stream/acquisitions-stream-PROD
 Resources:
   LambdaExecutionRole:


### PR DESCRIPTION
## Why are you doing this?

We called the redemption tables redemption-codes-((tpstage))-((gustage))
This got a bit silly with redemption-codes-PROD-PROD
So this PR takes out the stage if it's gu:PROD

[**Trello Card**](https://trello.com/c/02NsmWw6/3081-update-redemption-tables-to-not-have-a-code-prod-stage)

When we ship this, we need to manually deploy the tables with riffraff.
Support frontend/workers will be temporarily not working for corporate subs in between the deploys.
The IT tests are broken in this branch until the tables are updated in gu:PROD (as we use the gu:PROD tp:DEV table for the tests)