### PR TITLE
use released version of scalatest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,7 @@ lazy val commonSettings = Seq(
 
 lazy val commonDependencies = Seq(
   "com.typesafe" % "config" % "1.3.2",
-  "org.scalatest" %% "scalatest" % "3.2.0-M1" % "it, test",
+  "org.scalatest" %% "scalatest" % "3.2.0" % "it, test",// if the following PR is merged in v3.2.1, remove "-eU" parameter from options above - PR https://github.com/scalatest/scalatest/pull/1842
   "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"
 )
 


### PR DESCRIPTION
## Why are you doing this?

So far we have been using a pre-release version of scalatest.  Now that it's officially released, we should use the proper version.

There is a bug in all versions back to 3.0 at least which there is a PR open to fix it at scalatest repo. I have left a note in our build.sbt to remove our workaround - https://github.com/guardian/support-frontend/pull/2555 - when that is released, perhaps in 3.2.1. 