### PR TITLE
remove survey from corp subs thank you pages

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.jsx
@@ -72,7 +72,7 @@ const content = (
     >
       <CheckoutStage
         checkoutForm={<CheckoutForm />}
-        thankYouContentPending={<ThankYouPendingContent {...thankyouProps} />}
+        thankYouContentPending={<ThankYouPendingContent includePaymentCopy={true} {...thankyouProps} />}
         thankYouContent={<ThankYouContent {...thankyouProps} />}
         subscriptionProduct="DigitalPack"
       />

--- a/support-frontend/assets/pages/digital-subscription-checkout/thankYouContent.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/thankYouContent.jsx
@@ -66,7 +66,10 @@ function ThankYouContent(props: PropTypes) {
         </Text>
         <AppsSection countryGroupId={props.countryGroupId} />
       </Content>
-      <SubscriptionsSurvey product={DigitalPack} />
+      {props.includePaymentCopy ?
+        <SubscriptionsSurvey product={DigitalPack}/>
+        : null
+      }
       <Content>
         {props.marketingConsent}
         <OptInCopy subscriptionProduct={DigitalPack} />

--- a/support-frontend/assets/pages/digital-subscription-checkout/thankYouPendingContent.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/thankYouPendingContent.jsx
@@ -20,6 +20,7 @@ import { SubscriptionsSurvey } from 'components/subscriptionCheckouts/subscripti
 type PropTypes = {
   countryGroupId: CountryGroupId,
   marketingConsent: React.Node,
+  includePaymentCopy: boolean,
 };
 
 // ----- Component ----- //
@@ -63,7 +64,10 @@ function ThankYouPendingContent(props: PropTypes) {
           </p>
         </Text>
       </Content>
-      <SubscriptionsSurvey product={DigitalPack} />
+      {props.includePaymentCopy ?
+        <SubscriptionsSurvey product={DigitalPack}/>
+        : null
+      }
       <Content>
         {props.marketingConsent}
         <OptInCopy subscriptionProduct={DigitalPack} />

--- a/support-frontend/assets/pages/subscriptions-redemption/subscriptionsRedemption.jsx
+++ b/support-frontend/assets/pages/subscriptions-redemption/subscriptionsRedemption.jsx
@@ -52,7 +52,7 @@ const content = (
     >
       <CheckoutStage
         checkoutForm={<RedemptionForm />}
-        thankYouContentPending={<ThankYouPendingContent {...thankyouProps} />}
+        thankYouContentPending={<ThankYouPendingContent includePaymentCopy={false} {...thankyouProps} />}
         thankYouContent={<ThankYouContent {...thankyouProps} />}
       />
       <ConsentBanner />


### PR DESCRIPTION
## Why are you doing this?

The digi sub thank you page survey is designed for people who have made a purchase decision, not for corporate recipients.

This PR removes the digi sub survey from anyone who hasn't paid for their subscription at checkout time.

[**Trello Card**](https://trello.com/c/3JbmYsrN/3157-remove-survey-link-from-corporate-thank-you-page)

Tested in DEV on the thankyou, thankyou-pending (not present) and the normal paid thankyou (present)
