### PR TITLE
allow ssm tunnel for ssh into elk kibana logs proxy server

### DIFF
--- a/support-logs/cfn.yaml
+++ b/support-logs/cfn.yaml
@@ -51,6 +51,10 @@ Resources:
           - ssm:ListInstanceAssociations
           - ssm:DescribeInstanceProperties
           - ssm:DescribeDocumentParameters
+          - ssmmessages:CreateControlChannel
+          - ssmmessages:CreateDataChannel
+          - ssmmessages:OpenControlChannel
+          - ssmmessages:OpenDataChannel
       Roles:
       - !Ref KibanaProxyRole
   KibanaProxyInstanceProfile:


### PR DESCRIPTION
## Why are you doing this?

So we can SSH into elk proxy without using the bastion, which is more secure and works off VPN.
https://github.com/guardian/ssm-scala/blob/master/README.md#in-aws
