### PR TITLE
Remove non-DS rendering of landing page

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -6,7 +6,6 @@ import { detect as detectCountryGroupId, GBPCountries } from 'helpers/internatio
 
 // ----- Tests ----- //
 export type StripePaymentRequestButtonTestVariants = 'control' | 'button';
-export type LandingPageDesignSystemTestVariants = 'ds';
 export type AusMomentLandingPageBackgroundVariants = 'control' | 'ausColoursVariant';
 
 const contributionsLandingPageMatch = '/(uk|us|eu|au|ca|nz|int)/contribute(/.*)?$';
@@ -82,25 +81,6 @@ export const tests: Tests = {
     seed: 3,
     targetPage: digitalCheckout,
     optimizeId: '3sSS81FKT6SXawegvxyK-A',
-  },
-
-  landingPageDesignSystemTest: {
-    type: 'OTHER',
-    variants: [
-      {
-        id: 'ds',
-      },
-    ],
-    audiences: {
-      ALL: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: true,
-    referrerControlled: false,
-    seed: 3,
-    targetPage: contributionsLandingPageMatch,
   },
 
   ausMomentLandingPageBackgroundTest: {

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
@@ -8,8 +8,6 @@ import { connect } from 'react-redux';
 import { config, type AmountsRegions, type Amount, type ContributionType, getAmount } from 'helpers/contributions';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import {
-  type Currency,
-  type SpokenCurrency,
   type IsoCurrency,
   currencies,
   spokenCurrencies,
@@ -17,13 +15,8 @@ import {
 } from 'helpers/internationalisation/currency';
 import { classNameWithModifiers } from 'helpers/utilities';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
-import { EURCountries, GBPCountries } from 'helpers/internationalisation/countryGroup';
 import { formatAmount } from 'helpers/checkouts';
-import SvgDollar from 'components/svgs/dollar';
-import SvgEuro from 'components/svgs/euro';
-import SvgPound from 'components/svgs/pound';
 import { selectAmount, updateOtherAmount } from '../contributionsLandingActions';
-import ContributionTextInput from './ContributionTextInput';
 import { ChoiceCardGroup, ChoiceCard } from '@guardian/src-choice-card';
 import ContributionTextInputDs from './ContributionTextInputDs';
 
@@ -99,31 +92,6 @@ const isSelected = (amount: Amount, props: PropTypes) => {
   return amount.isDefault;
 };
 
-const renderAmount = (
-  currency: Currency,
-  spokenCurrency: SpokenCurrency,
-  props: PropTypes,
-) =>
-  (amount: Amount) => (
-    <li className="form__radio-group-item">
-      <input
-        id={`contributionAmount-${amount.value}`}
-        className="form__radio-group-input"
-        type="radio"
-        name="contributionAmount"
-        value={amount.value}
-        /* eslint-disable react/prop-types */
-        checked={isSelected(amount, props)}
-        onChange={
-          props.selectAmount(amount, props.countryGroupId, props.contributionType)
-        }
-      />
-      <label htmlFor={`contributionAmount-${amount.value}`} className="form__radio-group-label" aria-label={formatAmount(currency, spokenCurrency, amount, true)}>
-        {formatAmount(currency, spokenCurrency, amount, false)}
-      </label>
-    </li>
-  );
-
 const renderEmptyAmount = (id: string) => (
   <li className="form__radio-group-item amounts__placeholder">
     <input
@@ -135,14 +103,6 @@ const renderEmptyAmount = (id: string) => (
     <label htmlFor={`contributionAmount-${id}`} className="form__radio-group-label">&nbsp;</label>
   </li>
 );
-
-const iconForCountryGroup = (countryGroupId: CountryGroupId): React$Element<*> => {
-  switch (countryGroupId) {
-    case GBPCountries: return <SvgPound />;
-    case EURCountries: return <SvgEuro />;
-    default: return <SvgDollar />;
-  }
-};
 
 const amountFormatted = (amount: number, currencyString: string, countryGroupId: CountryGroupId) => {
   if (amount < 1 && countryGroupId === 'GBPCountries') {

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
@@ -26,7 +26,6 @@ import { selectAmount, updateOtherAmount } from '../contributionsLandingActions'
 import ContributionTextInput from './ContributionTextInput';
 import { ChoiceCardGroup, ChoiceCard } from '@guardian/src-choice-card';
 import ContributionTextInputDs from './ContributionTextInputDs';
-import type { LandingPageDesignSystemTestVariants } from 'helpers/abTests/abtestDefinitions';
 
 import { from, until } from '@guardian/src-foundations/mq';
 import { css } from '@emotion/core';
@@ -46,7 +45,6 @@ type PropTypes = {|
   updateOtherAmount: (string, CountryGroupId, ContributionType) => void,
   checkoutFormHasBeenSubmitted: boolean,
   stripePaymentRequestButtonClicked: boolean,
-  designSystemTestVariant: LandingPageDesignSystemTestVariants,
 |};
 
 
@@ -61,7 +59,6 @@ const mapStateToProps = state => ({
   stripePaymentRequestButtonClicked:
     state.page.form.stripePaymentRequestButtonData.ONE_OFF.stripePaymentRequestButtonClicked ||
     state.page.form.stripePaymentRequestButtonData.REGULAR.stripePaymentRequestButtonClicked,
-  designSystemTestVariant: state.common.abParticipations.landingPageDesignSystemTest,
 
 });
 
@@ -223,32 +220,7 @@ function withProps(props: PropTypes) {
   </>
   );
 
-  const renderControlOtherField = () => (
-    <ContributionTextInput
-      id="contributionOther"
-      name="contribution-other-amount"
-      type="number"
-      label="Other amount"
-      value={otherAmount}
-      icon={iconForCountryGroup(props.countryGroupId)}
-      onInput={e => updateAmount(
-      (e.target: any).value,
-      props.countryGroupId,
-      props.contributionType,
-    )}
-      isValid={checkOtherAmount(otherAmount || '', props.countryGroupId, props.contributionType)}
-      formHasBeenSubmitted={(checkoutFormHasBeenSubmitted || stripePaymentRequestButtonClicked)}
-      errorMessage={`Please provide an amount between ${minAmount} and ${maxAmount}`}
-      autoComplete="off"
-      step={0.01}
-      min={min}
-      max={max}
-      autoFocus
-      required
-    />
-  );
-
-  const renderDsOtherField = () => (
+  const renderOtherField = () => (
     <ContributionTextInputDs
       id="contributionOther"
       name="contribution-other-amount"
@@ -272,45 +244,13 @@ function withProps(props: PropTypes) {
     />
   );
 
-  const renderOther = () => {
-    if (props.designSystemTestVariant === 'ds') {
-      return renderDsOtherField();
-    }
-    return renderControlOtherField();
-  };
-
-  /* eslint-disable no-unused-vars */
-  // leaving in place as this is still in active development:
-  const renderControl = () => (
-    <ul className="form__radio-group-list">
-      {validAmounts.map(renderAmount(
-        currencies[props.currency],
-        spokenCurrencies[props.currency],
-        props,
-      ))}
-      <li className="form__radio-group-item">
-        <input
-          id="contributionAmount-other"
-          className="form__radio-group-input"
-          type="radio"
-          name="contributionAmount"
-          value="other"
-          checked={showOther}
-          onChange={props.selectAmount('other', props.countryGroupId, props.contributionType)}
-        />
-        <label htmlFor="contributionAmount-other" className="form__radio-group-label">Other</label>
-      </li>
-    </ul>
-  );
-  /* eslint-enable no-unused-vars */
-
   return (
     <fieldset className={classNameWithModifiers('form__radio-group', ['pills', 'contribution-amount'])}>
       <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>How much would you like to give?</legend>
 
       {renderChoiceCards()}
 
-      {showOther && renderOther()}
+      {showOther && renderOtherField()}
 
       {showWeeklyBreakdown ? (
         <p className="amount-per-week-breakdown">

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionFormFields.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionFormFields.jsx
@@ -154,7 +154,6 @@ function withProps(props: PropTypes) {
           selectedState={billingState}
           isValid={checkBillingState(billingState)}
           formHasBeenSubmitted={checkoutFormHasBeenSubmitted}
-          isDesignSystemTest
         />
       </>
     </div>

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionFormFields.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionFormFields.jsx
@@ -28,7 +28,6 @@ import {
   updateBillingState,
   checkIfEmailHasPassword,
 } from '../contributionsLandingActions';
-import type { LandingPageDesignSystemTestVariants } from 'helpers/abTests/abtestDefinitions';
 import ContributionTextInputDs from './ContributionTextInputDs';
 
 
@@ -49,7 +48,6 @@ type PropTypes = {|
   updateBillingState: Event => void,
   checkIfEmailHasPassword: Event => void,
   contributionType: ContributionType,
-  designSystemTestVariant: LandingPageDesignSystemTestVariants,
 |};
 
 // We only want to use the user state value if the form state value has not been changed since it was initialised,
@@ -69,7 +67,6 @@ const mapStateToProps = (state: State) => ({
   isRecurringContributor: state.page.user.isRecurringContributor,
   userTypeFromIdentityResponse: state.page.form.userTypeFromIdentityResponse,
   contributionType: state.page.form.contributionType,
-  designSystemTestVariant: state.common.abParticipations.landingPageDesignSystemTest,
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -93,147 +90,73 @@ function withProps(props: PropTypes) {
     checkoutFormHasBeenSubmitted,
   } = props;
 
-  const renderControl = () => (
-    <>
-      <ContributionTextInput
-        id="contributionEmail"
-        name="contribution-email"
-        label="Email address"
-        value={email}
-        type="email"
-        autoComplete="email"
-        placeholder="example@domain.com"
-        icon={<SvgEnvelope />}
-        onInput={props.updateEmail}
-        onChange={props.checkIfEmailHasPassword}
-        isValid={checkEmail(email)}
-        pattern={emailRegexPattern}
-        formHasBeenSubmitted={checkoutFormHasBeenSubmitted}
-        errorMessage="Please provide a valid email address"
-        required
-        disabled={isSignedIn}
-      />
-      <Signout isSignedIn />
-      <MustSignIn
-        isSignedIn={props.isSignedIn}
-        userTypeFromIdentityResponse={props.userTypeFromIdentityResponse}
-        contributionType={props.contributionType}
-        checkoutFormHasBeenSubmitted={props.checkoutFormHasBeenSubmitted}
-        email={props.email}
-      />
-      {props.contributionType !== 'ONE_OFF' ?
-        <div>
-          <ContributionTextInput
-            id="contributionFirstName"
-            name="contribution-fname"
-            label="First name"
-            value={firstName}
-            icon={<SvgUser />}
-            autoComplete="given-name"
-            autoCapitalize="words"
-            onInput={props.updateFirstName}
-            isValid={checkFirstName(firstName)}
-            formHasBeenSubmitted={checkoutFormHasBeenSubmitted}
-            errorMessage="Please provide your first name"
-            required
-          />
-          <ContributionTextInput
-            id="contributionLastName"
-            name="contribution-lname"
-            label="Last name"
-            value={lastName}
-            icon={<SvgUser />}
-            autoComplete="family-name"
-            autoCapitalize="words"
-            onInput={props.updateLastName}
-            isValid={checkLastName(lastName)}
-            formHasBeenSubmitted={checkoutFormHasBeenSubmitted}
-            errorMessage="Please provide your last name"
-            required
-          />
-        </div> : null
-      }
-      <ContributionState
-        onChange={props.updateBillingState}
-        selectedState={billingState}
-        isValid={checkBillingState(billingState)}
-        formHasBeenSubmitted={checkoutFormHasBeenSubmitted}
-        isDesignSystemTest={false}
-      />
-    </>
-  );
-
-  const renderDesignSystemFields = () => (
-    <>
-      <ContributionTextInputDs
-        id="contributionEmail"
-        name="contribution-email"
-        label="Email address"
-        value={email}
-        type="email"
-        autoComplete="email"
-        supporting="example@domain.com"
-        onInput={props.updateEmail}
-        onChange={props.checkIfEmailHasPassword}
-        isValid={checkEmail(email)}
-        pattern={emailRegexPattern}
-        formHasBeenSubmitted={checkoutFormHasBeenSubmitted}
-        errorMessage="Please provide a valid email address"
-        required
-        disabled={isSignedIn}
-      />
-      <Signout isSignedIn />
-      <MustSignIn
-        isSignedIn={props.isSignedIn}
-        userTypeFromIdentityResponse={props.userTypeFromIdentityResponse}
-        contributionType={props.contributionType}
-        checkoutFormHasBeenSubmitted={props.checkoutFormHasBeenSubmitted}
-        email={props.email}
-      />
-      {props.contributionType !== 'ONE_OFF' ?
-        <div>
-          <ContributionTextInputDs
-            id="contributionFirstName"
-            name="contribution-fname"
-            label="First name"
-            value={firstName}
-            autoComplete="given-name"
-            autoCapitalize="words"
-            onInput={props.updateFirstName}
-            isValid={checkFirstName(firstName)}
-            formHasBeenSubmitted={checkoutFormHasBeenSubmitted}
-            errorMessage="Please provide your first name"
-            required
-          />
-          <ContributionTextInputDs
-            id="contributionLastName"
-            name="contribution-lname"
-            label="Last name"
-            value={lastName}
-            autoComplete="family-name"
-            autoCapitalize="words"
-            onInput={props.updateLastName}
-            isValid={checkLastName(lastName)}
-            formHasBeenSubmitted={checkoutFormHasBeenSubmitted}
-            errorMessage="Please provide your last name"
-            required
-          />
-        </div> : null
-      }
-      <ContributionState
-        onChange={props.updateBillingState}
-        selectedState={billingState}
-        isValid={checkBillingState(billingState)}
-        formHasBeenSubmitted={checkoutFormHasBeenSubmitted}
-        isDesignSystemTest
-      />
-    </>
-  );
-
   return (
     <div className="form-fields">
       <h3 className="hidden-heading">Your details</h3>
-      {this.props.designSystemTestVariant === 'ds' ? renderDesignSystemFields() : renderControl()}
+      <>
+        <ContributionTextInputDs
+          id="contributionEmail"
+          name="contribution-email"
+          label="Email address"
+          value={email}
+          type="email"
+          autoComplete="email"
+          supporting="example@domain.com"
+          onInput={props.updateEmail}
+          onChange={props.checkIfEmailHasPassword}
+          isValid={checkEmail(email)}
+          pattern={emailRegexPattern}
+          formHasBeenSubmitted={checkoutFormHasBeenSubmitted}
+          errorMessage="Please provide a valid email address"
+          required
+          disabled={isSignedIn}
+        />
+        <Signout isSignedIn />
+        <MustSignIn
+          isSignedIn={props.isSignedIn}
+          userTypeFromIdentityResponse={props.userTypeFromIdentityResponse}
+          contributionType={props.contributionType}
+          checkoutFormHasBeenSubmitted={props.checkoutFormHasBeenSubmitted}
+          email={props.email}
+        />
+        {props.contributionType !== 'ONE_OFF' ?
+          <div>
+            <ContributionTextInputDs
+              id="contributionFirstName"
+              name="contribution-fname"
+              label="First name"
+              value={firstName}
+              autoComplete="given-name"
+              autoCapitalize="words"
+              onInput={props.updateFirstName}
+              isValid={checkFirstName(firstName)}
+              formHasBeenSubmitted={checkoutFormHasBeenSubmitted}
+              errorMessage="Please provide your first name"
+              required
+            />
+            <ContributionTextInputDs
+              id="contributionLastName"
+              name="contribution-lname"
+              label="Last name"
+              value={lastName}
+              autoComplete="family-name"
+              autoCapitalize="words"
+              onInput={props.updateLastName}
+              isValid={checkLastName(lastName)}
+              formHasBeenSubmitted={checkoutFormHasBeenSubmitted}
+              errorMessage="Please provide your last name"
+              required
+            />
+          </div> : null
+        }
+        <ContributionState
+          onChange={props.updateBillingState}
+          selectedState={billingState}
+          isValid={checkBillingState(billingState)}
+          formHasBeenSubmitted={checkoutFormHasBeenSubmitted}
+          isDesignSystemTest
+        />
+      </>
     </div>
   );
 }

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionFormFields.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionFormFields.jsx
@@ -93,69 +93,67 @@ function withProps(props: PropTypes) {
   return (
     <div className="form-fields">
       <h3 className="hidden-heading">Your details</h3>
-      <>
-        <ContributionTextInputDs
-          id="contributionEmail"
-          name="contribution-email"
-          label="Email address"
-          value={email}
-          type="email"
-          autoComplete="email"
-          supporting="example@domain.com"
-          onInput={props.updateEmail}
-          onChange={props.checkIfEmailHasPassword}
-          isValid={checkEmail(email)}
-          pattern={emailRegexPattern}
-          formHasBeenSubmitted={checkoutFormHasBeenSubmitted}
-          errorMessage="Please provide a valid email address"
-          required
-          disabled={isSignedIn}
-        />
-        <Signout isSignedIn />
-        <MustSignIn
-          isSignedIn={props.isSignedIn}
-          userTypeFromIdentityResponse={props.userTypeFromIdentityResponse}
-          contributionType={props.contributionType}
-          checkoutFormHasBeenSubmitted={props.checkoutFormHasBeenSubmitted}
-          email={props.email}
-        />
-        {props.contributionType !== 'ONE_OFF' ?
-          <div>
-            <ContributionTextInputDs
-              id="contributionFirstName"
-              name="contribution-fname"
-              label="First name"
-              value={firstName}
-              autoComplete="given-name"
-              autoCapitalize="words"
-              onInput={props.updateFirstName}
-              isValid={checkFirstName(firstName)}
-              formHasBeenSubmitted={checkoutFormHasBeenSubmitted}
-              errorMessage="Please provide your first name"
-              required
-            />
-            <ContributionTextInputDs
-              id="contributionLastName"
-              name="contribution-lname"
-              label="Last name"
-              value={lastName}
-              autoComplete="family-name"
-              autoCapitalize="words"
-              onInput={props.updateLastName}
-              isValid={checkLastName(lastName)}
-              formHasBeenSubmitted={checkoutFormHasBeenSubmitted}
-              errorMessage="Please provide your last name"
-              required
-            />
-          </div> : null
-        }
-        <ContributionState
-          onChange={props.updateBillingState}
-          selectedState={billingState}
-          isValid={checkBillingState(billingState)}
-          formHasBeenSubmitted={checkoutFormHasBeenSubmitted}
-        />
-      </>
+      <ContributionTextInputDs
+        id="contributionEmail"
+        name="contribution-email"
+        label="Email address"
+        value={email}
+        type="email"
+        autoComplete="email"
+        supporting="example@domain.com"
+        onInput={props.updateEmail}
+        onChange={props.checkIfEmailHasPassword}
+        isValid={checkEmail(email)}
+        pattern={emailRegexPattern}
+        formHasBeenSubmitted={checkoutFormHasBeenSubmitted}
+        errorMessage="Please provide a valid email address"
+        required
+        disabled={isSignedIn}
+      />
+      <Signout isSignedIn />
+      <MustSignIn
+        isSignedIn={props.isSignedIn}
+        userTypeFromIdentityResponse={props.userTypeFromIdentityResponse}
+        contributionType={props.contributionType}
+        checkoutFormHasBeenSubmitted={props.checkoutFormHasBeenSubmitted}
+        email={props.email}
+      />
+      {props.contributionType !== 'ONE_OFF' ?
+        <div>
+          <ContributionTextInputDs
+            id="contributionFirstName"
+            name="contribution-fname"
+            label="First name"
+            value={firstName}
+            autoComplete="given-name"
+            autoCapitalize="words"
+            onInput={props.updateFirstName}
+            isValid={checkFirstName(firstName)}
+            formHasBeenSubmitted={checkoutFormHasBeenSubmitted}
+            errorMessage="Please provide your first name"
+            required
+          />
+          <ContributionTextInputDs
+            id="contributionLastName"
+            name="contribution-lname"
+            label="Last name"
+            value={lastName}
+            autoComplete="family-name"
+            autoCapitalize="words"
+            onInput={props.updateLastName}
+            isValid={checkLastName(lastName)}
+            formHasBeenSubmitted={checkoutFormHasBeenSubmitted}
+            errorMessage="Please provide your last name"
+            required
+          />
+        </div> : null
+      }
+      <ContributionState
+        onChange={props.updateBillingState}
+        selectedState={billingState}
+        isValid={checkBillingState(billingState)}
+        formHasBeenSubmitted={checkoutFormHasBeenSubmitted}
+      />
     </div>
   );
 }

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionState.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionState.jsx
@@ -10,7 +10,6 @@ import { usStates, caStates, type StateProvince, auStates } from 'helpers/intern
 import { type CountryGroupId, type CountryGroup, countryGroups, AUDCountries } from 'helpers/internationalisation/countryGroup';
 import { classNameWithModifiers } from 'helpers/utilities';
 import { Canada, UnitedStates } from 'helpers/internationalisation/countryGroup';
-import SvgGlobe from 'components/svgs/globe';
 import { InlineError } from '@guardian/src-user-feedback';
 import DownChevronDs from 'components/svgs/downChevronDs';
 import { focusHalo } from '@guardian/src-foundations/accessibility';
@@ -26,7 +25,6 @@ type PropTypes = {|
   isValid: boolean,
   formHasBeenSubmitted: boolean,
   contributionType: string,
-  isDesignSystemTest: boolean,
 |};
 
 const mapStateToProps = (state: State) => ({
@@ -81,10 +79,6 @@ const chevronErrorCss = css`
 `;
 
 const renderState = (selectedState: StateProvince | null) => (state: {abbreviation: string, name: string}) => (
-  <option value={state.abbreviation} selected={selectedState === state.abbreviation}>{state.name}</option>
-);
-
-const renderStateDs = (selectedState: StateProvince | null) => (state: {abbreviation: string, name: string}) => (
   <option value={state.abbreviation} selected={selectedState === state.abbreviation}>&nbsp;&nbsp;{state.name}</option>
 );
 
@@ -94,34 +88,8 @@ const renderStatesField = (
   onChange: (Event => void) | false,
   showError: boolean,
   label: string,
-  isDesignSystemTest: boolean,
 ) => {
-
-  const renderStatesFieldControl = (
-    <div className={classNameWithModifiers('form__field', ['contribution-state'])}>
-      <label className="form__label" htmlFor="contributionState">
-        {label}
-      </label>
-      <span className="form__input-with-icon">
-        <select id="contributionState" className={classNameWithModifiers('form__input', selectedState ? [] : ['placeholder'])} onChange={onChange} required>
-          <option value="">Please select your {label.toLowerCase()}</option>
-          {Object.keys(states)
-            .map(key => ({ abbreviation: key, name: states[key] }))
-            .map(renderState(selectedState))}
-        </select>
-        <span className="form__icon">
-          <SvgGlobe />
-        </span>
-      </span>
-      {showError ? (
-        <div className="form__error">
-          Please provide a {label.toLowerCase()}
-        </div>
-        ) : null}
-    </div>
-  );
-
-  const renderStatesFieldDs = (
+  return (
     <div
       css={css`
         margin-top: 12px;
@@ -171,7 +139,7 @@ const renderStatesField = (
           <option value="">&nbsp;</option>
           {Object.keys(states)
               .map(key => ({ abbreviation: key, name: states[key] }))
-              .map(renderStateDs(selectedState))}
+              .map(renderState(selectedState))}
         </select>
         <div
           css={showError ? [chevronErrorCss, chevronCss] : chevronCss}
@@ -181,8 +149,6 @@ const renderStatesField = (
       </div>
     </div>
   );
-
-  return (isDesignSystemTest ? renderStatesFieldDs : renderStatesFieldControl);
 };
 
 function ContributionState(props: PropTypes) {
@@ -190,9 +156,9 @@ function ContributionState(props: PropTypes) {
   if (props.contributionType !== 'ONE_OFF') {
     switch (props.countryGroupId) {
       case UnitedStates:
-        return renderStatesField(usStates, props.selectedState, props.onChange, showError, 'State', props.isDesignSystemTest);
+        return renderStatesField(usStates, props.selectedState, props.onChange, showError, 'State');
       case Canada:
-        return renderStatesField(caStates, props.selectedState, props.onChange, showError, 'Province', props.isDesignSystemTest);
+        return renderStatesField(caStates, props.selectedState, props.onChange, showError, 'Province');
       case AUDCountries: {
         // Don't show states if the user is GEO-IP'd to one of the non AU countries that use AUD.
         if (window.guardian && window.guardian.geoip) {
@@ -202,7 +168,7 @@ function ContributionState(props: PropTypes) {
             return null;
           }
         }
-        return renderStatesField(auStates, props.selectedState, props.onChange, showError, 'State / Territory', props.isDesignSystemTest);
+        return renderStatesField(auStates, props.selectedState, props.onChange, showError, 'State / Territory');
       }
       default:
         return null;

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionState.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionState.jsx
@@ -8,7 +8,6 @@ import { connect } from 'react-redux';
 
 import { usStates, caStates, type StateProvince, auStates } from 'helpers/internationalisation/country';
 import { type CountryGroupId, type CountryGroup, countryGroups, AUDCountries } from 'helpers/internationalisation/countryGroup';
-import { classNameWithModifiers } from 'helpers/utilities';
 import { Canada, UnitedStates } from 'helpers/internationalisation/countryGroup';
 import { InlineError } from '@guardian/src-user-feedback';
 import DownChevronDs from 'components/svgs/downChevronDs';
@@ -88,68 +87,66 @@ const renderStatesField = (
   onChange: (Event => void) | false,
   showError: boolean,
   label: string,
-) => {
-  return (
-    <div
-      css={css`
+) => (
+  <div
+    css={css`
         margin-top: 12px;
         margin-bottom: 4px;
         position: relative;
       `}
-    >
-      <label
-        htmlFor="contributionState"
-        css={css`
+  >
+    <label
+      htmlFor="contributionState"
+      css={css`
           font-family: $gu-text-sans-web;
           font-weight: 700;
           line-height: 1.5;
           font-size: 17px;
         `}
-      >
-        {label}
-      </label>
-      <div
-        css={css`
+    >
+      {label}
+    </label>
+    <div
+      css={css`
           font-size: 15px;
           color: #767676;
           margin-bottom: ${space[1]}px;
         `}
-      >Select your {label.toLowerCase()}
-      </div>
-      {showError ? (
-        <InlineError
-          cssOverrides={css`
+    >Select your {label.toLowerCase()}
+    </div>
+    {showError ? (
+      <InlineError
+        cssOverrides={css`
             margin-bottom: 4px;
           `}
-        >
+      >
           Please select your {label.toLowerCase()}
-        </InlineError>
+      </InlineError>
         ) : null}
-      <div
-        css={css`
+    <div
+      css={css`
           position: relative;
         `}
+    >
+      <select
+        css={showError ? [selectCss, errorBorderCss] : selectCss}
+        id="contributionState"
+        onChange={onChange}
+        required
       >
-        <select
-          css={showError ? [selectCss, errorBorderCss] : selectCss}
-          id="contributionState"
-          onChange={onChange}
-          required
-        >
-          <option value="">&nbsp;</option>
-          {Object.keys(states)
+        <option value="">&nbsp;</option>
+        {Object.keys(states)
               .map(key => ({ abbreviation: key, name: states[key] }))
               .map(renderState(selectedState))}
-        </select>
-        <div
-          css={showError ? [chevronErrorCss, chevronCss] : chevronCss}
-        >
-          <DownChevronDs />
-        </div>
+      </select>
+      <div
+        css={showError ? [chevronErrorCss, chevronCss] : chevronCss}
+      >
+        <DownChevronDs />
       </div>
     </div>
-  );
-};
+  </div>
+);
 
 function ContributionState(props: PropTypes) {
   const showError = !props.isValid && props.formHasBeenSubmitted;

--- a/support-frontend/assets/pages/contributions-landing/components/PaymentMethodSelector.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/PaymentMethodSelector.jsx
@@ -44,7 +44,6 @@ import {
 } from 'helpers/existingPaymentMethods/existingPaymentMethods';
 import SecureTransactionIndicator from 'components/secureTransactionIndicator/secureTransactionIndicator';
 import SvgAmazonPayLogo from 'components/svgs/amazonPayLogo';
-import type { LandingPageDesignSystemTestVariants } from 'helpers/abTests/abtestDefinitions';
 import { RadioGroup, Radio } from '@guardian/src-radio';
 
 import SvgPayPalDs from 'components/svgs/paypalDs';
@@ -66,7 +65,6 @@ type PropTypes = {|
   updateSelectedExistingPaymentMethod: (RecentlySignedInExistingPaymentMethod | typeof undefined) => Action,
   isTestUser: boolean,
   switches: Switches,
-  designSystemTestVariant: LandingPageDesignSystemTestVariants,
 |};
 /* eslint-enable react/no-unused-prop-types */
 
@@ -79,7 +77,6 @@ const mapStateToProps = (state: State) => ({
   existingPaymentMethod: state.page.form.existingPaymentMethod,
   isTestUser: state.page.user.isTestUser || false,
   switches: state.common.settings.switches,
-  designSystemTestVariant: state.common.abParticipations.landingPageDesignSystemTest,
 });
 
 const mapDispatchToProps = {
@@ -154,99 +151,6 @@ const noPaymentMethodsErrorMessage =
     errorReason="all_payment_methods_unavailable"
   />);
 
-const renderControl = (props: PropTypes) => {
-
-  const paymentMethods: PaymentMethod[] =
-    getValidPaymentMethods(props.contributionType, props.switches, props.countryId);
-
-  const fullExistingPaymentMethods = getFullExistingPaymentMethods(props);
-
-  return (
-    <fieldset className={classNameWithModifiers('form__radio-group', ['buttons', 'contribution-pay'])}>
-      {legend}
-      { paymentMethods.length ?
-        <ul className="form__radio-group-list">
-          {contributionTypeIsRecurring(props.contributionType) && !props.existingPaymentMethods && (
-          <div className="awaiting-existing-payment-options">
-            <AnimatedDots appearance="medium" />
-          </div>
-              )
-            }
-          {contributionTypeIsRecurring(props.contributionType) &&
-            fullExistingPaymentMethods.map((existingPaymentMethod: RecentlySignedInExistingPaymentMethod) => (
-              <li className="form__radio-group-item">
-                <input
-                  id={`paymentMethodSelector-existing${existingPaymentMethod.billingAccountId}`}
-                  className="form__radio-group-input"
-                  name="paymentMethodSelector"
-                  type="radio"
-                  value={existingPaymentMethod}
-                  onChange={() => {
-                      props.updatePaymentMethod(mapExistingPaymentMethodToPaymentMethod(existingPaymentMethod));
-                      props.updateSelectedExistingPaymentMethod(existingPaymentMethod);
-                    }}
-                  checked={
-                      props.paymentMethod === mapExistingPaymentMethodToPaymentMethod(existingPaymentMethod) &&
-                      props.existingPaymentMethod === existingPaymentMethod
-                    }
-                  arial-labelledby="payment_method"
-                />
-                <label
-                  htmlFor={`paymentMethodSelector-existing${existingPaymentMethod.billingAccountId}`}
-                  className="form__radio-group-label has-existing-payment-option-explainer"
-                >
-                  <span className="radio-ui" />
-                  <span className="radio-ui__label">{getExistingPaymentMethodLabel(existingPaymentMethod)}</span>
-                  {getPaymentMethodLogo(mapExistingPaymentMethodToPaymentMethod(existingPaymentMethod))}
-                </label>
-                <div className="existing-payment-option-explainer">
-                    Used for your{' '}
-                  {subscriptionsToExplainerList(existingPaymentMethod.subscriptions.map(subscriptionToExplainerPart))}
-                </div>
-              </li>
-              ))}
-          {paymentMethods.map(paymentMethod => (
-            <li className="form__radio-group-item">
-              <input
-                id={`paymentMethodSelector-${paymentMethod}`}
-                className="form__radio-group-input"
-                name="paymentMethodSelector"
-                type="radio"
-                value={paymentMethod}
-                onChange={() => {
-                    props.updatePaymentMethod(paymentMethod);
-                    props.updateSelectedExistingPaymentMethod(undefined);
-                  }}
-                checked={props.paymentMethod === paymentMethod}
-              />
-              <label htmlFor={`paymentMethodSelector-${paymentMethod}`} className="form__radio-group-label">
-                <span className="radio-ui" />
-                <span className="radio-ui__label">{getPaymentLabel(paymentMethod)}</span>
-                {getPaymentMethodLogo(paymentMethod)}
-              </label>
-            </li>
-            ))}
-          {
-              contributionTypeIsRecurring(props.contributionType) &&
-              props.existingPaymentMethods &&
-              props.existingPaymentMethods.length > 0 &&
-              fullExistingPaymentMethods.length === 0 && (
-                <li className="form__radio-group-item">
-                  ...or
-                  <a className="reauthenticate-link" href={getReauthenticateUrl()}>re-enter your
-    password
-                  </a> to use one of your existing payment methods.
-                </li>
-              )
-            }
-        </ul>
-          : noPaymentMethodsErrorMessage
-        }
-
-    </fieldset>
-  );
-};
-
 const radioCss = {
   '& + div': {
     display: 'flex',
@@ -263,8 +167,8 @@ const radioCss = {
   },
 };
 
-const renderDesignSystemRadios = (props: PropTypes) => {
 
+function withProps(props: PropTypes) {
   const paymentMethods: PaymentMethod[] =
     getValidPaymentMethods(props.contributionType, props.switches, props.countryId);
 
@@ -278,10 +182,10 @@ const renderDesignSystemRadios = (props: PropTypes) => {
       { paymentMethods.length ?
         <RadioGroup className="form__radio-group-list">
           {contributionTypeIsRecurring(props.contributionType) && !props.existingPaymentMethods && (
-          <div className="awaiting-existing-payment-options">
-            <AnimatedDots appearance="medium" />
-          </div>
-            )
+            <div className="awaiting-existing-payment-options">
+              <AnimatedDots appearance="medium" />
+            </div>
+          )
           }
           {contributionTypeIsRecurring(props.contributionType) &&
           fullExistingPaymentMethods.map((existingPaymentMethod: RecentlySignedInExistingPaymentMethod) => (
@@ -292,13 +196,13 @@ const renderDesignSystemRadios = (props: PropTypes) => {
                 type="radio"
                 value={existingPaymentMethod}
                 onChange={() => {
-                      props.updatePaymentMethod(mapExistingPaymentMethodToPaymentMethod(existingPaymentMethod));
-                      props.updateSelectedExistingPaymentMethod(existingPaymentMethod);
-                    }}
+                  props.updatePaymentMethod(mapExistingPaymentMethodToPaymentMethod(existingPaymentMethod));
+                  props.updateSelectedExistingPaymentMethod(existingPaymentMethod);
+                }}
                 checked={
-                      props.paymentMethod === mapExistingPaymentMethodToPaymentMethod(existingPaymentMethod) &&
-                      props.existingPaymentMethod === existingPaymentMethod
-                    }
+                  props.paymentMethod === mapExistingPaymentMethodToPaymentMethod(existingPaymentMethod) &&
+                  props.existingPaymentMethod === existingPaymentMethod
+                }
                 arial-labelledby="payment_method"
                 label={renderExistingLabelAndLogo(existingPaymentMethod)}
                 cssOverrides={radioCss}
@@ -312,11 +216,11 @@ const renderDesignSystemRadios = (props: PropTypes) => {
                   padding-right: 40px;
                 `}
               >
-                    Used for your{' '}
+                Used for your{' '}
                 {subscriptionsToExplainerList(existingPaymentMethod.subscriptions.map(subscriptionToExplainerPart))}
               </div>
             </>
-            ))}
+          ))}
           {paymentMethods.map(paymentMethod => (
             <>
               <Radio
@@ -332,7 +236,7 @@ const renderDesignSystemRadios = (props: PropTypes) => {
                 label={renderLabelAndLogo(paymentMethod)}
                 cssOverrides={radioCss}
               />
-          </>
+            </>
           ))}
           {
             contributionTypeIsRecurring(props.contributionType) &&
@@ -348,12 +252,6 @@ const renderDesignSystemRadios = (props: PropTypes) => {
         : noPaymentMethodsErrorMessage
       }
     </div>);
-};
-
-function withProps(props: PropTypes) {
-
-
-  return this.props.designSystemTestVariant === 'ds' ? renderDesignSystemRadios(props) : renderControl(props);
 }
 
 function withoutProps() {

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
@@ -32,7 +32,6 @@ import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import { updateRecaptchaToken } from '../../contributionsLandingActions';
 import { routes } from 'helpers/routes';
 import { Recaptcha } from 'components/recaptcha/recaptcha';
-import type { LandingPageDesignSystemTestVariants } from 'helpers/abTests/abtestDefinitions';
 import { InlineError } from '@guardian/src-user-feedback';
 import { StripeCardFormField } from './StripeCardFormField';
 import './stripeCardForm.scss';
@@ -65,7 +64,6 @@ type PropTypes = {|
   setOneOffRecaptchaToken: string => Action,
   oneOffRecaptchaToken: string,
   postDeploymentTestUser: string,
-  designSystemTestVariant: LandingPageDesignSystemTestVariants,
 |};
 
 const mapStateToProps = (state: State) => ({
@@ -80,7 +78,6 @@ const mapStateToProps = (state: State) => ({
   formIsSubmittable: state.page.form.formIsSubmittable,
   oneOffRecaptchaToken: state.page.form.oneOffRecaptchaToken,
   postDeploymentTestUser: state.page.user.isPostDeploymentTestUser,
-  designSystemTestVariant: state.common.abParticipations.landingPageDesignSystemTest,
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -137,11 +134,6 @@ const fieldStyleDS = {
 };
 
 const renderVerificationCopy = (countryGroupId: CountryGroupId, contributionType: ContributionType) => {
-  trackComponentLoad(`recaptchaV2-verification-warning-${countryGroupId}-${contributionType}-loaded`);
-  return (<div className="form__error"> {'Please tick to verify you\'re a human'} </div>);
-};
-
-const renderVerificationCopyDs = (countryGroupId: CountryGroupId, contributionType: ContributionType) => {
   trackComponentLoad(`recaptchaV2-verification-warning-${countryGroupId}-${contributionType}-loaded`);
   return (<InlineError>Please tick to verify you&apos;re a human</InlineError>);
 };
@@ -324,15 +316,6 @@ class CardForm extends Component<PropTypes, StateTypes> {
     });
   }
 
-  getFieldBorderClass = (fieldName: CardFieldName): string => {
-    if (this.state.currentlySelected === fieldName) {
-      return 'form__input-enabled';
-    } else if (this.state[fieldName].name === 'Error') {
-      return 'form__input--invalid';
-    }
-    return '';
-  };
-
   handleStripeError(errorData: any): void {
     this.props.setPaymentWaiting(false);
 
@@ -385,17 +368,7 @@ class CardForm extends Component<PropTypes, StateTypes> {
 
     const errorMessage: ?string = fieldError || incompleteMessage();
 
-    const getClasses = (fieldName: CardFieldName): string =>
-      `form__input ${this.getFieldBorderClass(fieldName)}`;
-
     const showCards = (country: IsoCountry) => {
-      if (country === 'US') {
-        return <CreditCardsUS className="form__credit-card-icons" />;
-      }
-      return <CreditCardsROW className="form__credit-card-icons" />;
-    };
-
-    const showCardsDs = (country: IsoCountry) => {
       if (country === 'US') {
         return <CreditCardsUS />;
       }
@@ -406,74 +379,7 @@ class CardForm extends Component<PropTypes, StateTypes> {
       this.props.contributionType === 'ONE_OFF' ?
         this.props.oneOffRecaptchaToken : this.props.recurringRecaptchaVerified;
 
-    const renderControl = () => (
-      <div className="form__fields">
-        <legend className="form__legend"><h3>Your card details</h3></legend>
-        <div className="form__field">
-          <label className="form__label" htmlFor="stripeCardNumberElement">
-            Card number
-          </label>
-          {showCards(this.props.country)}
-          <span className={getClasses('CardNumber')}>
-            <CardNumberElement
-              id="stripeCardNumberElement"
-              style={fieldStyleControl}
-              onChange={this.onChange('CardNumber')}
-              onFocus={() => this.onFocus('CardNumber')}
-              onBlur={this.onBlur}
-            />
-          </span>
-        </div>
-        <div className="stripe-card-element-container__inline-fields">
-          <div className="form__field">
-            <label className="form__label" htmlFor="stripeCardExpiryElement">
-              Expiry date
-            </label>
-            <span className={getClasses('Expiry')}>
-              <CardExpiryElement
-                id="stripeCardExpiryElement"
-                style={fieldStyleControl}
-                onChange={this.onChange('Expiry')}
-                onFocus={() => this.onFocus('Expiry')}
-                onBlur={this.onBlur}
-              />
-            </span>
-          </div>
-          <div className="form__field">
-            <label className="form__label" htmlFor="stripeCardCVCElement">
-              CVC
-            </label>
-            <span className={getClasses('CVC')}>
-              <CardCVCElement
-                id="stripeCardCVCElement"
-                style={fieldStyleControl}
-                placeholder=""
-                onChange={this.onChange('CVC')}
-                onFocus={() => this.onFocus('CVC')}
-                onBlur={this.onBlur}
-              />
-            </span>
-          </div>
-        </div>
-        {errorMessage ? <div className="form__error">{errorMessage}</div> : null}
-        { window.guardian.recaptchaEnabled ?
-          <div className="form__field">
-
-            <label className="form__label" htmlFor="robot_checkbox">
-              Security check
-            </label>
-            <Recaptcha />
-            {
-              this.props.checkoutFormHasBeenSubmitted
-              && !recaptchaVerified ?
-                renderVerificationCopy(this.props.countryGroupId, this.props.contributionType) : null
-            }
-          </div>
-          : null }
-      </div>
-    );
-
-    const renderDesignSystemStyleForm = () => (
+    return (
       <div>
         <legend className="form__legend"><h3>Your card details</h3></legend>
         {errorMessage ?
@@ -488,7 +394,7 @@ class CardForm extends Component<PropTypes, StateTypes> {
               >
                 Card number
               </label>
-              {showCardsDs(this.props.country)}
+              {showCards(this.props.country)}
             </>
           }
           input={
@@ -606,7 +512,7 @@ class CardForm extends Component<PropTypes, StateTypes> {
             {
               this.props.checkoutFormHasBeenSubmitted
               && !recaptchaVerified ?
-                renderVerificationCopyDs(this.props.countryGroupId, this.props.contributionType) : null
+                renderVerificationCopy(this.props.countryGroupId, this.props.contributionType) : null
             }
             <Recaptcha />
           </div>
@@ -614,8 +520,6 @@ class CardForm extends Component<PropTypes, StateTypes> {
         }
       </div>
     );
-
-    return this.props.designSystemTestVariant === 'ds' ? renderDesignSystemStyleForm() : renderControl();
   }
 }
 

--- a/support-frontend/test/selenium/contributions/pages/ContributionsLanding.scala
+++ b/support-frontend/test/selenium/contributions/pages/ContributionsLanding.scala
@@ -20,7 +20,7 @@ case class ContributionsLanding(region: String, testUser: TestUser)(implicit val
 
   private val otherAmount = id("contributionOther")
 
-  private val stripeSelector = cssSelector(".form__radio-group-label[for='paymentMethodSelector-Stripe']")
+  private val stripeSelector = id("paymentMethodSelector-Stripe")
   private val payPalSelector = id("paymentMethodSelector-PayPal")
   private val stateSelector = id("contributionState")
 


### PR DESCRIPTION
We have finished the A/B test for the Design System in the contributions landing page.
The old 'control' rendering can now be removed.
This is tidying up https://github.com/guardian/support-frontend/pull/2515/files
