### PR TITLE
tweak Redemption DB IT test and add test data scipt

### DIFF
--- a/support-services/src/test/scala/com/gu/support/redemption/DynamoTableAsyncITSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/redemption/DynamoTableAsyncITSpec.scala
@@ -18,7 +18,8 @@ class DynamoTableAsyncITSpec extends AsyncFlatSpec with Matchers {
       lookedup should be(Some(Map(
         "redemptionCode" -> DynamoString(allCharsCode),
         "available" -> DynamoBoolean(true),
-        "corporateId" -> DynamoString("1")
+        "corporateId" -> DynamoString("1"),
+        "type" -> DynamoString("Corporate")
       )))
     }
   }

--- a/support-services/src/test/scala/com/gu/support/redemption/IT_testdata.sh
+++ b/support-services/src/test/scala/com/gu/support/redemption/IT_testdata.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# To populate the required test data, run this script.
+set -e
+set -v
+
+table=$1
+if [ -z "$table" ]
+  then
+    echo syntax: $0 tablename
+    exit 1
+fi
+
+function create {
+  code=$1
+  echo $code
+  if [[ "$code" == 'ITTEST-USED' ]]; then
+    value='false'
+  else
+    value='true'
+  fi
+  itemL='{"redemptionCode": {"S": "'
+  itemM='"}, "available": {"BOOL": '
+  itemR='}, "type": {"S": "Corporate"}, "corporateId": {"S": "1"}}'
+  item="$itemL$code$itemM$value$itemR"
+  echo item: $item
+  echo $code|hexdump -C
+  aws dynamodb put-item --profile membership --table-name $table --item "$item"
+  err=$?
+  if [[ err -ne 0 ]]; then
+    echo Failed with $err
+    exit 1
+  fi
+}
+
+create 'ITTEST- !\"#$%&'"'"'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~'
+create 'ITTEST-MUTABLE- !\"#$%&'"'"'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~'
+create 'ITTEST-AVAILABLE'
+create 'ITTEST-USED'
+#create 'ITTEST-MISSING'
+create 'ITTEST-MUTABLE'


### PR DESCRIPTION
## Why are you doing this?

Having update the dynamo tables in https://github.com/guardian/support-frontend/pull/2581
the tables were wiped by being renamed/recreated.

I had to put back all the DEV data again, but it was all created manually.  SO I wrote a quick script to do so in a repeatable way.
I also found an inconsistency in the test data which I fixed in the test.
