### PR TITLE
remove gzip/substitution parameters from support-logs nginx

### DIFF
--- a/support-logs/cfn.yaml
+++ b/support-logs/cfn.yaml
@@ -114,11 +114,6 @@ Resources:
                     # Update cookie domain and path
                     proxy_cookie_domain vpc-support-elk-domain-vcesheatvi6xspmp4sd6dnfkq4.eu-west-1.es.amazonaws.com $host;
 
-                    proxy_set_header Accept-Encoding "";
-                    sub_filter_types *;
-                    sub_filter vpc-support-elk-domain-vcesheatvi6xspmp4sd6dnfkq4.eu-west-1.es.amazonaws.com $host;
-                    sub_filter_once off;
-
                     # Response buffer settings
                     proxy_buffer_size 128k;
                     proxy_buffers 4 256k;


### PR DESCRIPTION
## Why are you doing this?

I noticed kibana was always very slow to load on my home internet connection.
This was because there were large JS files that were not gzipped or cacheable that had to be downloaded in full every time.
![image](https://user-images.githubusercontent.com/7304387/87057444-c76ec200-c1fe-11ea-848b-1595a6402562.png)

I checked the main logs.gutools and it doesn't have that issue.
After debugging,I found that the headers were changing before/after nginx, even with gzip disabled in both cases
```
DIRECT
< Content-Length: 11977436
< ETag: "29b3d390d27baf451de74e83a0a9a2e79c56ddf4-/_plugin/kibana/built_assets/dlls/"

VIA NGINX
< Server: nginx/1.10.3 (Ubuntu)
< Transfer-Encoding: chunked
```
 and then checking the nginx config, there were lines in there to remove the encoding and cache headers, which I tried removing temporarily, and everything still seemed to work fine.
After checking with AWS support, it seems the parameters aren't really needed:
https://console.aws.amazon.com/support/home?#/case/?displayId=7158117471&language=en

So this PR removes them.
