### PR TITLE
Remove live app price

### DIFF
--- a/support-frontend/assets/helpers/subscriptions.js
+++ b/support-frontend/assets/helpers/subscriptions.js
@@ -66,35 +66,8 @@ export const subscriptionPricesForDefaultBillingPeriod: {
     [CountryGroupId]: number,
   }
 } = {
-  PremiumTier: {
-    GBPCountries: 5.99,
-    UnitedStates: 6.99,
-    AUDCountries: 7.99,
-    International: 5.99,
-  },
-  DigitalPack: {
-    GBPCountries: 11.99,
-    UnitedStates: 19.99,
-    AUDCountries: 21.50,
-    International: 19.99,
-  },
-  GuardianWeekly: {
-    GBPCountries: 37.50,
-    EURCountries: 61.30,
-    UnitedStates: 75,
-    Canada: 80,
-    AUDCountries: 97.50,
-    NZDCountries: 123,
-    International: 81.30,
-  },
-  Paper: {
-    GBPCountries: 10.79,
-  },
   PaperAndDigital: {
     GBPCountries: 21.99,
-  },
-  DailyEdition: {
-    GBPCountries: 11.99,
   },
 };
 

--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
@@ -82,7 +82,7 @@ export type ProductCopy = {
 
 const abTest = null;
 
-const getPrice = (countryGroupId: CountryGroupId, product: SubscriptionProduct, alternativeText: string) => {
+const getPrice = (countryGroupId: CountryGroupId, product: SubscriptionProduct) => {
 
   if (flashSaleIsActive(product, countryGroupId)) {
     return getDisplayFlashSalePrice(product, countryGroupId, Monthly);
@@ -92,7 +92,7 @@ const getPrice = (countryGroupId: CountryGroupId, product: SubscriptionProduct, 
     return `${displayPrice(product, countryGroupId)}`;
   }
 
-  return alternativeText;
+  return '';
 };
 
 const getDisplayPrice = (
@@ -196,7 +196,7 @@ const paperAndDigital = (
   ).PaperAndDigital;
   return {
     title: 'Paper+Digital',
-    subtitle: `from ${getPrice(countryGroupId, PaperAndDigital, '')}`,
+    subtitle: `from ${getPrice(countryGroupId, PaperAndDigital)}`,
     description: 'All the benefits of a paper subscription, plus access to the digital subscription',
     buttons: [{
       ctaButtonText: 'Find out more',
@@ -210,7 +210,7 @@ const paperAndDigital = (
 
 const premiumApp = (countryGroupId: CountryGroupId): ProductCopy => ({
   title: 'Premium access to the Guardian Live app',
-  subtitle: getPrice(countryGroupId, PremiumTier, '7-day free Trial'),
+  subtitle: '7-day free Trial',
   description: 'Ad-free live news, as it happens',
   buttons: [{
     ctaButtonText: 'Buy in App Store',

--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
@@ -7,7 +7,6 @@ import {
   GuardianWeekly,
   Paper,
   PaperAndDigital,
-  PremiumTier,
   sendTrackingEventsOnClick,
   subscriptionPricesForDefaultBillingPeriod,
   type SubscriptionProduct,


### PR DESCRIPTION
## Why are you doing this?

## Problem 

1) Premium app prices in non-uk countries are out of date (due to app stores changing prices when the exchange rate changes)

2) In EU, Canada, and NZ, the price is not shown, instead a '7 day free trial' message is shown. 

## Solution

1) remove price from all regions
2) only show trial offer in all regions . ie: '7 day free trial' 

## Definition of Success

No prices, and only 7 day free trial offer

[**Trello Card**](https://trello.com/c/9959HmKl/3116-update-showcase-page-remove-prices-only-show-trial-offer-consistent-in-all-regions)

## Screenshots
![support thegulocal com_uk_subscribe(iPhone X)](https://user-images.githubusercontent.com/181371/87319118-1ed3a180-c521-11ea-9160-3808610ecf4c.png)

