### PR TITLE
Stripe country problem

### DIFF
--- a/support-frontend/assets/helpers/subscriptionsForms/formActions.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/formActions.js
@@ -95,7 +95,6 @@ const formActionCreators = {
     return dispatch({
       type: 'SET_PAYMENT_METHOD',
       paymentMethod,
-      country: state.common.internationalisation.countryId,
     });
   },
   setBillingAddressIsSame: (isSame: boolean): Action => ({

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -93,7 +93,6 @@ type PropTypes = {|
   setBillingCountry: Function,
   billingAddressErrors: Array<Object>,
   deliveryAddressErrors: Array<Object>,
-  country: IsoCountry,
   isTestUser: boolean,
   validateForm: () => Function,
   csrf: Csrf,
@@ -118,7 +117,6 @@ function mapStateToProps(state: WithDeliveryCheckoutState) {
     deliveryAddressErrors: state.page.deliveryAddress.fields.formErrors,
     billingAddressErrors: state.page.billingAddress.fields.formErrors,
     isTestUser: state.page.checkout.isTestUser,
-    country: state.common.internationalisation.countryId,
     csrf: state.page.csrf,
     currencyId: state.common.internationalisation.currencyId,
     payPalHasLoaded: state.page.checkout.payPalHasLoaded,
@@ -308,7 +306,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
             title="Your card details"
           >
             <StripeProviderForCountry
-              country={props.country}
+              country={props.billingCountry}
               isTestUser={props.isTestUser}
               submitForm={props.submitForm}
               allErrors={[...props.billingAddressErrors, ...props.deliveryAddressErrors, ...props.formErrors]}


### PR DESCRIPTION
## Why are you doing this?
Since we moved to using Stripe elements inline we have been initialising the country with the standard internationalisation country from `state.common.internationalisation.countryId`. 

For Guardian Weekly however, we should be using the billing country as this can be different from the internationalisation country and is needed to work out the correct Stripe account to use.

[**Trello Card**](https://trello.com/c/Z5cL7KSf/3177-gw-gifts-sometimes-use-wrong-stripe-account-client-side)
