### PR TITLE
Add `GeneralErrorMessage` component to GW checkouts

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -77,6 +77,7 @@ import { withDeliveryFormIsValid } from 'helpers/subscriptionsForms/formValidati
 import { setupSubscriptionPayPalPayment } from 'helpers/paymentIntegrations/payPalRecurringCheckout';
 import DirectDebitForm from 'components/directDebit/directDebitProgressiveDisclosure/directDebitForm';
 import Total from 'components/subscriptionCheckouts/total/total';
+import GeneralErrorMessage from 'components/generalErrorMessage/generalErrorMessage';
 
 // ----- Types ----- //
 
@@ -330,6 +331,10 @@ function WeeklyCheckoutForm(props: PropTypes) {
               submissionErrorHeading={submissionErrorHeading}
             />
           </FormSectionHiddenUntilSelected>
+          <GeneralErrorMessage
+            errorReason={props.submissionError}
+            errorHeading={submissionErrorHeading}
+          />
           <Total
             price={price.price}
             currency={props.currencyId}

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.jsx
@@ -79,6 +79,7 @@ import { setupSubscriptionPayPalPayment } from 'helpers/paymentIntegrations/payP
 import DirectDebitForm from 'components/directDebit/directDebitProgressiveDisclosure/directDebitForm';
 import PaymentTerms from 'components/subscriptionCheckouts/paymentTerms';
 import Total from 'components/subscriptionCheckouts/total/total';
+import GeneralErrorMessage from 'components/generalErrorMessage/generalErrorMessage';
 
 // ----- Styles ----- //
 
@@ -360,6 +361,10 @@ function WeeklyCheckoutFormGifting(props: PropTypes) {
               submissionErrorHeading={submissionErrorHeading}
             />
           </FormSectionHiddenUntilSelected>
+          <GeneralErrorMessage
+            errorReason={props.submissionError}
+            errorHeading={submissionErrorHeading}
+          />
           <Total
             price={price.price}
             currency={props.currencyId}


### PR DESCRIPTION
## Why are you doing this?

When I was fixing the GW country selection error (#2613) I noticed that there is no `GeneralErrorMessage` component on either of the GW checkouts which means that if there is a support-workers failure the user doesn't see an error message but is just dumped back on the checkout with no indication of what went wrong.

This PR adds 

[**Trello Card**](https://trello.com/c/I2faV0m9/3182-guardian-weekly-checkout-has-no-error-summary)
## Screenshots
**The checkout now has an error message**
<img width="1157" alt="Screen Shot 2020-07-16 at 14 30 38" src="https://user-images.githubusercontent.com/181371/87677880-2a69d700-c772-11ea-85b5-58e0deae4a22.png">
