### PR TITLE
use new email identifier for imovo thank you email

### DIFF
--- a/support-workers/src/main/scala/com/gu/emailservices/PaperEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/PaperEmailFields.scala
@@ -2,7 +2,7 @@ package com.gu.emailservices
 
 import com.gu.i18n.Currency
 import com.gu.salesforce.Salesforce.SfContactId
-import com.gu.support.catalog.{FulfilmentOptions, HomeDelivery, ProductOptions}
+import com.gu.support.catalog.{FulfilmentOptions, HomeDelivery, Paper, ProductOptions}
 import com.gu.support.promotions.Promotion
 import com.gu.support.workers._
 import com.gu.support.workers.states.PaymentMethodWithSchedule
@@ -33,7 +33,7 @@ case class PaperEmailFields(
 
       val dataExtension: String = fulfilmentOptions match {
         case HomeDelivery => "paper-delivery"
-        case _ => "paper-voucher"
+        case _ => if (Paper.useDigitalVoucher) "paper-subscription-card" else "paper-voucher"
       }
 
       override val fields: List[(String, String)] = PaperFieldsGenerator.fieldsFor(


### PR DESCRIPTION
## Why are you doing this?

This PR makes paper voucher use the new subscription card email identifier once the switch has been turned on.

Depends on https://github.com/guardian/membership-workflow/pull/266

[**Trello Card**](https://trello.com/c/pEUPHrCF/3171-print-thank-you-email-for-imovo-subs-card)

This means that once the switch is on we will send the new email, meaning that new customers will get information about the subscription card rather than about the old paper voucher.

I will test by shipping the workflow change and then run this PR in DEV with the switch turned on, or at least an if statement