### PR TITLE
Fix image overlapping text in subscription CTA

### DIFF
--- a/support-frontend/assets/pages/showcase/showcase.scss
+++ b/support-frontend/assets/pages/showcase/showcase.scss
@@ -115,7 +115,7 @@
 
       @include mq($from: tablet, $until: leftCol) {
         .component-text {
-          max-width: 80%;
+          max-width: 75%;
         }
 
         .component-content__image {

--- a/support-frontend/assets/pages/showcase/showcase.scss
+++ b/support-frontend/assets/pages/showcase/showcase.scss
@@ -113,19 +113,23 @@
         }
       }
 
-      @include mq($from: tablet, $until: desktop) {
+      @include mq($from: tablet, $until: leftCol) {
+        .component-text {
+          max-width: 80%;
+        }
+
         .component-content__image {
           right: -200px;
         }
-
+        
         .component-left-margin-section__content .component-grid-image {
           height: 120%;
         }
       }
 
-      @include mq($from: desktop, $until: leftCol) {
-        .component-content__image {
-          right: -200px;
+      @include mq($from: leftCol) {
+        .component-text {
+          max-width: 60%;
         }
       }
     }

--- a/support-frontend/assets/pages/showcase/showcase.scss
+++ b/support-frontend/assets/pages/showcase/showcase.scss
@@ -121,7 +121,7 @@
         .component-content__image {
           right: -200px;
         }
-        
+
         .component-left-margin-section__content .component-grid-image {
           height: 120%;
         }


### PR DESCRIPTION
## Why are you doing this?

From the tablet breakpoint to screens about 1700px wide, the image in the 'Subscribe' CTA overlaps the text and cuts it off to varying degrees

[**Trello Card**](https://trello.com/c/Pay20ZIg)

## Changes

* Added a max-width rule for the text in the CTA. I experimented with a couple of other approaches but they all required much more significant overriding of the Content component CSS or creating new components; this was the simplest fix.

## Screenshots

**Tablet - Vertical**

![Screenshot 2020-07-21 at 11 17 35](https://user-images.githubusercontent.com/29146931/88047794-13e4c680-cb4a-11ea-8442-87d3e5765656.png)

**Tablet - Horizontal**

![Screenshot 2020-07-21 at 11 17 51](https://user-images.githubusercontent.com/29146931/88047864-324ac200-cb4a-11ea-9fc0-aa3c6e6794c0.png)

**Mobile (large) - Horizontal**

![Screenshot 2020-07-21 at 11 20 14](https://user-images.githubusercontent.com/29146931/88047898-41ca0b00-cb4a-11ea-9b2a-225cbb1f0c9b.png)

**Desktop**

![Screenshot 2020-07-21 at 11 56 58](https://user-images.githubusercontent.com/29146931/88047914-4c84a000-cb4a-11ea-82d3-11ccf4041c13.png)
