### PR TITLE
Switch useDigitalVoucher to true

### DIFF
--- a/support-models/src/main/scala/com/gu/support/catalog/Product.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/Product.scala
@@ -79,7 +79,7 @@ case object Paper extends Product {
   private def homeDelivery(productRatePlanId: ProductRatePlanId, productOptions: ProductOptions, description: String): ProductRatePlan[Paper.type] =
     ProductRatePlan(productRatePlanId, Monthly, HomeDelivery, productOptions, description, List(CountryGroup.UK))
 
-  val useDigitalVoucher = false
+  val useDigitalVoucher = true
 
   private val prodCollection: List[ProductRatePlan[Paper.type]] = if(useDigitalVoucher) {
     List(


### PR DESCRIPTION
## Why are you doing this?
In preparation for a production end-to-end test of the digital subscriptions card for print (aka iMovo), this is a PR to update the variable `useDigitalVoucher`, so it's true. This means that we can test the digital subscriptions card purchase process is working correctly. 

[**Trello Card**](https://trello.com/c/RwCVUP46/3194-preparation-work-for-imovo-test)

I have deployed this to `CODE` and it works correctly except that the thank you page isn't merged in yet (see: https://github.com/guardian/support-frontend/pull/2622) and the email (I think @johnduffell is working on this). 
