### PR TITLE
Adding new copy for digital voucher thank you page

### DIFF
--- a/support-frontend/assets/helpers/productPrice/fulfilmentOptions.js
+++ b/support-frontend/assets/helpers/productPrice/fulfilmentOptions.js
@@ -6,7 +6,6 @@ import { countryGroups } from 'helpers/internationalisation/countryGroup';
 
 const HomeDelivery: 'HomeDelivery' = 'HomeDelivery';
 const Collection: 'Collection' = 'Collection';
-const DigitalVoucher: 'DigitalVoucher' = 'DigitalVoucher';
 const Domestic: 'Domestic' = 'Domestic';
 const RestOfWorld: 'RestOfWorld' = 'RestOfWorld';
 const NoFulfilmentOptions: 'NoFulfilmentOptions' = 'NoFulfilmentOptions';
@@ -23,9 +22,8 @@ export type FulfilmentOptions =
   | typeof Domestic
   | typeof RestOfWorld
   | typeof NoFulfilmentOptions
-  | typeof DigitalVoucher
 
-export { HomeDelivery, Collection, DigitalVoucher, Domestic, RestOfWorld, NoFulfilmentOptions };
+export { HomeDelivery, Collection, Domestic, RestOfWorld, NoFulfilmentOptions };
 
 const getWeeklyFulfilmentOption = (country: IsoCountry) =>
   (countryGroups.International.countries.includes(country)

--- a/support-frontend/assets/helpers/productPrice/fulfilmentOptions.js
+++ b/support-frontend/assets/helpers/productPrice/fulfilmentOptions.js
@@ -6,6 +6,7 @@ import { countryGroups } from 'helpers/internationalisation/countryGroup';
 
 const HomeDelivery: 'HomeDelivery' = 'HomeDelivery';
 const Collection: 'Collection' = 'Collection';
+const DigitalVoucher: 'DigitalVoucher' = 'DigitalVoucher';
 const Domestic: 'Domestic' = 'Domestic';
 const RestOfWorld: 'RestOfWorld' = 'RestOfWorld';
 const NoFulfilmentOptions: 'NoFulfilmentOptions' = 'NoFulfilmentOptions';
@@ -22,8 +23,9 @@ export type FulfilmentOptions =
   | typeof Domestic
   | typeof RestOfWorld
   | typeof NoFulfilmentOptions
+  | typeof DigitalVoucher
 
-export { HomeDelivery, Collection, Domestic, RestOfWorld, NoFulfilmentOptions };
+export { HomeDelivery, Collection, DigitalVoucher, Domestic, RestOfWorld, NoFulfilmentOptions };
 
 const getWeeklyFulfilmentOption = (country: IsoCountry) =>
   (countryGroups.International.countries.includes(country)

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/thankYou.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/thankYou.jsx
@@ -8,9 +8,10 @@ import { connect } from 'react-redux';
 
 import { HeroPicture } from 'pages/paper-subscription-landing/components/hero/heroPicture';
 import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
-import { Collection, HomeDelivery } from 'helpers/productPrice/fulfilmentOptions';
+import { Collection, HomeDelivery, DigitalVoucher } from 'helpers/productPrice/fulfilmentOptions';
 import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
 
+import type { WithDeliveryCheckoutState } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
 import OrderedList from 'components/list/orderedList';
 import Asyncronously from 'components/asyncronously/asyncronously';
 import Content from 'components/content/content';
@@ -32,8 +33,17 @@ import { type FormFields, getFormFields } from 'helpers/subscriptionsForms/formF
 type PropTypes = {
     ...FormFields,
     isPending: boolean,
+    useDigitalVoucher: boolean,
 };
 
+// ----- Map State/Props ----- //
+
+function mapStateToProps(state: WithDeliveryCheckoutState) {
+  return {
+    ...getFormFields(state),
+    useDigitalVoucher: state.common.settings.useDigitalVoucher,
+  };
+}
 
 // ----- Component ----- //
 
@@ -73,12 +83,42 @@ const whatNext: {[FulfilmentOptions]: Element<*>} = {
       </p>
     </Text>
   ),
+  [DigitalVoucher]: (
+    <Text title="What happens next?">
+      <p>
+        <OrderedList items={[
+          <span>
+            Keep an eye on your inbox. You should receive an email confirming the details of your subscription,
+            and another email shortly afterwards that contains details of how you can pick up your papers from today!
+          </span>,
+          <span>
+            You will receive your Subscription Card in your subscriber pack in the post, along with your home
+            delivery letter.
+          </span>,
+          <span>
+            Visit your chosen participating newsagent to pick up your paper using your Subscription Card, or
+            arrange a delivery using home your delivery letter.
+          </span>,
+          ]}
+        />
+
+      </p>
+    </Text>
+  ),
 };
+
+function WhatNext(fulfilmentOption, useDigitalVoucher = false) {
+  if (useDigitalVoucher && fulfilmentOption === Collection) {
+    return whatNext[DigitalVoucher];
+  }
+  return whatNext[fulfilmentOption];
+}
 
 
 function ThankYouContent({
-  fulfilmentOption, productOption, startDate, isPending, product,
+  fulfilmentOption, productOption, startDate, isPending, product, useDigitalVoucher,
 }: PropTypes) {
+  const hideStartDate = fulfilmentOption === Collection && useDigitalVoucher;
   return (
     <div className="thank-you-stage">
       <HeroWrapper appearance="custom" className={styles.hero}>
@@ -104,12 +144,12 @@ function ThankYouContent({
             </Text>
           )
         }
-        {startDate &&
+        {(startDate && !hideStartDate) &&
           <Text title={fulfilmentOption === HomeDelivery ? 'You will receive your newspapers from' : 'You can start using your vouchers from'}>
             <LargeParagraph>{formatUserDate(new Date(startDate))}</LargeParagraph>
           </Text>
         }
-        {whatNext[fulfilmentOption]}
+        {WhatNext(fulfilmentOption, useDigitalVoucher)}
       </Content>
       <Content>
         <Text>
@@ -137,4 +177,4 @@ function ThankYouContent({
 // ----- Export ----- //
 
 
-export default connect(state => ({ ...getFormFields(state) }))(ThankYouContent);
+export default connect(mapStateToProps)(ThankYouContent);

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/thankYou.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/thankYou.jsx
@@ -2,13 +2,13 @@
 
 // ----- Imports ----- //
 
-import React, { type Element } from 'react';
+import React from 'react';
 
 import { connect } from 'react-redux';
 
 import { HeroPicture } from 'pages/paper-subscription-landing/components/hero/heroPicture';
 import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
-import { Collection, HomeDelivery, DigitalVoucher } from 'helpers/productPrice/fulfilmentOptions';
+import { Collection, HomeDelivery } from 'helpers/productPrice/fulfilmentOptions';
 import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
 
 import type { WithDeliveryCheckoutState } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
@@ -47,71 +47,47 @@ function mapStateToProps(state: WithDeliveryCheckoutState) {
 
 // ----- Component ----- //
 
-const whatNext: {[FulfilmentOptions]: Element<*>} = {
-  [HomeDelivery]: (
-    <Text title="What happens next?">
-      <OrderedList items={[
-        <span>
-          Look out for an email from us confirming your subscription.
-          It has everything you need to know about how manage it in the future.
-        </span>,
-        <span>
-          Your newspaper will be delivered to your door.
-        </span>,
-        ]}
-      />
-
-    </Text>
-  ),
-  [Collection]: (
-    <Text title="What happens next?">
-      <p>
-        <OrderedList items={[
-          <span>
-            Look out for an email from us confirming your subscription.
-            It has everything you need to know about how to manage it in the future.
-          </span>,
-          <span>
-            You will receive your personalised book of vouchers.
-          </span>,
-          <span>
-            Exchange your voucher for a newspaper at your newsagent or wherever you buy your paper
-          </span>,
-          ]}
-        />
-
-      </p>
-    </Text>
-  ),
-  [DigitalVoucher]: (
-    <Text title="What happens next?">
-      <p>
-        <OrderedList items={[
-          <span>
-            Keep an eye on your inbox. You should receive an email confirming the details of your subscription,
-            and another email shortly afterwards that contains details of how you can pick up your papers from today!
-          </span>,
-          <span>
-            You will receive your Subscription Card in your subscriber pack in the post, along with your home
-            delivery letter.
-          </span>,
-          <span>
-            Visit your chosen participating newsagent to pick up your paper using your Subscription Card, or
-            arrange a home delivery using your delivery letter.
-          </span>,
-          ]}
-        />
-
-      </p>
-    </Text>
-  ),
+const whatNextText: { [FulfilmentOptions]: { [key: string]: Array<string> } } = {
+  [HomeDelivery]: {
+    default: [
+      `Look out for an email from us confirming your subscription.
+        It has everything you need to know about how manage it in the future.`,
+      'Your newspaper will be delivered to your door.',
+    ],
+  },
+  [Collection]: {
+    default: [
+      `Look out for an email from us confirming your subscription.
+        It has everything you need to know about how to manage it in the future.`,
+      'You will receive your personalised book of vouchers.',
+      'Exchange your voucher for a newspaper at your newsagent or wherever you buy your paper',
+    ],
+    digitalVoucher: [
+      `Keep an eye on your inbox. You should receive an email confirming the details of your subscription,
+        and another email shortly afterwards that contains details of how you can pick up your papers from today!`,
+      `You will receive your Subscription Card in your subscriber pack in the post, along with your home
+        delivery letter.`,
+      `Visit your chosen participating newsagent to pick up your paper using your Subscription Card, or
+        arrange a home delivery using your delivery letter.`,
+    ],
+  },
 };
 
+function whatNextElement(textItems) {
+  return (
+    <Text title="What happens next?">
+      <p>
+        <OrderedList items={textItems.map(item => <span>{item}</span>)} />
+      </p>
+    </Text>
+  );
+}
+
 function WhatNext(fulfilmentOption, useDigitalVoucher = false) {
-  if (useDigitalVoucher && fulfilmentOption === Collection) {
-    return whatNext[DigitalVoucher];
+  if (fulfilmentOption === Collection && useDigitalVoucher) {
+    return whatNextElement(whatNextText[Collection].digitalVoucher);
   }
-  return whatNext[fulfilmentOption];
+  return whatNextElement(whatNextText[fulfilmentOption].default);
 }
 
 

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/thankYou.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/thankYou.jsx
@@ -97,7 +97,7 @@ const whatNext: {[FulfilmentOptions]: Element<*>} = {
           </span>,
           <span>
             Visit your chosen participating newsagent to pick up your paper using your Subscription Card, or
-            arrange a delivery using home your delivery letter.
+            arrange a home delivery using your delivery letter.
           </span>,
           ]}
         />

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/thankYou.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/thankYou.jsx
@@ -84,10 +84,11 @@ function whatNextElement(textItems) {
 }
 
 function WhatNext(fulfilmentOption, useDigitalVoucher = false) {
+  let textItems = whatNextText[fulfilmentOption].default;
   if (fulfilmentOption === Collection && useDigitalVoucher) {
-    return whatNextElement(whatNextText[Collection].digitalVoucher);
+    textItems = whatNextText[Collection].digitalVoucher;
   }
-  return whatNextElement(whatNextText[fulfilmentOption].default);
+  return whatNextElement(textItems);
 }
 
 


### PR DESCRIPTION
## Why are you doing this?

When the user is buying a digital voucher we have different copy for the 'What's next' bullet points and will no longer show the date the vouchers are valid from.

[**Trello Card**](https://trello.com/c/Bp69nPoG)

## Changes

* Added the new copy behind the existing useDigitalVoucher switch
* Removed the date if the fulfilment type is collection and useDigitalVoucher is true

## Screenshots

**Paper voucher thank you page**
![Screenshot 2020-07-22 at 17 03 35](https://user-images.githubusercontent.com/29146931/88200641-55569e00-cc3e-11ea-8f90-2a54e5b5e4ad.png)

**Digital voucher thank you page**
![Screenshot 2020-07-22 at 17 04 36](https://user-images.githubusercontent.com/29146931/88200678-630c2380-cc3e-11ea-873f-e570f18e81c4.png)
