### PR TITLE
Updating lodash and marked for Snyk issues

### DIFF
--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -88,7 +88,7 @@
     "es-to-primitive": "^1.2.1",
     "fast-sass-loader": "^1.5.0",
     "framer-motion": "^1.11.1",
-    "marked": "^0.7.0",
+    "marked": "^1.1.0",
     "ophan-tracker-js": "^1.3.17",
     "react-axe": "^3.3.0",
     "react-redux": "^5.1.1",
@@ -136,7 +136,7 @@
     "flow-typed": "^2.4.0",
     "jest": "^24.9.0",
     "json-sass-vars": "^3.0.0",
-    "lodash": "^4.17.13",
+    "lodash": "^4.17.19",
     "madge": "^3.9.1",
     "mini-css-extract-plugin": "^0.4.0",
     "node-sass": "^4.13.1",
@@ -163,6 +163,7 @@
   "resolutions": {
     "cssnano/cosmiconfig/js-yaml": "3.13.1",
     "optimize-css-assets-webpack-plugin/**/js-yaml": "3.13.1",
-    "postcss-load-config/cosmiconfig/js-yaml": "3.13.1"
+    "postcss-load-config/cosmiconfig/js-yaml": "3.13.1",
+    "lodash": "^4.17.19"
   }
 }

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -10409,35 +10409,10 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.13.1, lodash@~4.17.4:
-  version "4.17.4"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
-  integrity sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=
-
-lodash@^4.0.1:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
-
-lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15:
+"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.0.1, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.4, lodash@^4.17.5, lodash@~2.4.1, lodash@~4.17.4:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
-
-lodash@^4.17.12, lodash@^4.17.13:
-  version "4.17.15"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
-
-lodash@^4.17.4, lodash@^4.17.5:
-  version "4.17.5"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
-  integrity sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==
-
-lodash@~2.4.1:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-2.4.2.tgz#fadd834b9683073da179b3eae6d9c0d15053f73e"
-  integrity sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4=
 
 log-symbols@^3.0.0:
   version "3.0.0"
@@ -10605,10 +10580,10 @@ markdown-to-jsx@^6.11.4:
     prop-types "^15.6.2"
     unquote "^1.1.0"
 
-marked@^0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.7.0.tgz#b64201f051d271b1edc10a04d1ae9b74bb8e5c0e"
-  integrity sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==
+marked@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-1.1.1.tgz#e5d61b69842210d5df57b05856e0c91572703e6a"
+  integrity sha512-mJzT8D2yPxoPh7h0UXkB+dBj4FykPJ2OIfxAWeIHrvoHDkFxukV/29QxoFQoPM6RLEwhIFdJpmKBlqVM3s2ZIw==
 
 material-colors@^1.2.1:
   version "1.2.6"


### PR DESCRIPTION
## Why are you doing this?

* lodash issue: https://app.snyk.io/vuln/SNYK-JS-LODASH-567746
* marked issue: https://app.snyk.io/vuln/SNYK-JS-MARKED-584281 

The marked issue requires a major version change, but there are no breaking changes that will affect our usage of it (it's only used in one place, to format additional promotion copy on the Weekly subscription landing page).