### PR TITLE
Stripe is only needed on the subs and contributions checkout pages

### DIFF
--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -115,4 +115,5 @@
   window.guardian.recaptchaEnabled = @settings.switches.enableRecaptchaFrontend.isOn
   window.guardian.v2recaptchaPublicKey = "@v2recaptchaConfigPublicKey"
   </script>
+  <script defer id="stripe-js" src="https://js.stripe.com/v3/"></script>
 }

--- a/support-frontend/app/views/main.scala.html
+++ b/support-frontend/app/views/main.scala.html
@@ -159,8 +159,6 @@
 
     @body
 
-    <script defer id="stripe-js" src="https://js.stripe.com/v3/"></script>
-
     @mainJsBundle.fold(asyncLinkedJs, inlineJs)
 
     <script defer type="text/javascript" src="@assets("googleTagManagerScript.js")"></script>

--- a/support-frontend/app/views/subscriptionCheckout.scala.html
+++ b/support-frontend/app/views/subscriptionCheckout.scala.html
@@ -74,5 +74,5 @@
       window.guardian.recaptchaEnabled = @settings.switches.enableRecaptchaFrontend.isOn
 
   </script>
-
+  <script defer id="stripe-js" src="https://js.stripe.com/v3/"></script>
   }


### PR DESCRIPTION
#2308  Why are you doing this?
<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->
The Stripe SDK is only needed on the subs and contributions checkout pages, so moving it out of @main.

[**Trello Card**](https://trello.com/c/UC1I10FB)

## Testing
- [x] Tested locally
- [x] Tested on CODE
