### PR TITLE
Remove ds address test

### DIFF
--- a/support-frontend/app/utils/CheckoutValidationRules.scala
+++ b/support-frontend/app/utils/CheckoutValidationRules.scala
@@ -102,8 +102,8 @@ object DigitalPackValidation {
     def isValidPaidSub(paymentFields: PaymentFields) =
       SimpleCheckoutFormValidation.passes(createSupportWorkersRequest) &&
         hasStateIfRequired(country, state) &&
-        //hasAddressLine1AndCity(billingAddress) &&
-        //hasPostcodeIfRequired(country, postCode) &&
+        hasAddressLine1AndCity(billingAddress) &&
+        hasPostcodeIfRequired(country, postCode) &&
         currencyIsSupportedForCountry(country, currency) &&
         PaidProductValidation.noEmptyPaymentFields(paymentFields)
 

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -35,53 +35,6 @@ export const tests: Tests = {
     seed: 5,
   },
 
-  fancyAddressTest: {
-    type: 'OTHER',
-    variants: [
-      {
-        id: 'control',
-      },
-      {
-        id: 'loqate',
-      },
-    ],
-    audiences: {
-      ALL: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: false,
-    referrerControlled: false,
-    seed: 3,
-    targetPage: digitalCheckout,
-    optimizeId: '3sSS81FKT6SXawegvxyK-A',
-  },
-
-  removeDigiSubAddressTest: {
-    type: 'OTHER',
-    variants: [
-      {
-        id: 'control',
-      },
-      {
-        id: 'noAddress',
-      },
-    ],
-    audiences: {
-      ALL: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: true,
-    referrerControlled: false,
-    seed: 7,
-    canRun: () => detectCountryGroupId() === GBPCountries,
-    targetPage: digitalCheckout,
-    optimizeId: 'tdBE5yqdR0aQ19E06j1zRA',
-  },
-
   auAmountsTest: {
     type: 'AMOUNTS',
     variants: [

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -1,7 +1,6 @@
 // @flow
 import type { Tests } from './abtest';
 import { USV1, AusAmounts, UkAmountsV1 } from './data/testAmountsData';
-import { detect as detectCountryGroupId, GBPCountries } from 'helpers/internationalisation/countryGroup';
 
 // ----- Tests ----- //
 
@@ -9,7 +8,6 @@ const usOnlyLandingPage = '/us/contribute(/.*)?$';
 const auOnlyLandingPage = '/au/contribute(/.*)?$';
 const ukOnlyLandingPage = '/uk/contribute(/.*)?$';
 export const subsShowcaseAndDigiSubPages = '(/??/subscribe(\\?.*)?$|/??/subscribe/digital(\\?.*)?$)';
-const digitalCheckout = '/subscribe/digital/checkout';
 
 export const tests: Tests = {
   usAmountsTest: {

--- a/support-frontend/assets/helpers/subscriptionsForms/formValidation.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/formValidation.js
@@ -38,15 +38,13 @@ type Error<T> = {
 type AnyErrorType = Error<AddressFormField> | Error<FormField>;
 
 function checkoutValidation(state: CheckoutState): AnyErrorType[] {
-  const shouldValidateAddress = state.common.abParticipations.removeDigiSubAddressTest !== 'noAddress';
-  const addressErrors = shouldValidateAddress ? applyBillingAddressRules(getBillingAddressFields(state), 'billing') : [];
   return [
     ({
       errors: applyCheckoutRules(getFormFields(state)),
       errorAction: setFormErrors,
     }: Error<FormField>),
     ({
-      errors: addressErrors,
+      errors: applyBillingAddressRules(getBillingAddressFields(state), 'billing'),
       errorAction: setAddressFormErrorsFor('billing'),
     }: Error<AddressFormField>),
   ].filter(({ errors }) => errors.length > 0);

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutForm.jsx
@@ -147,15 +147,6 @@ function DigitalCheckoutForm(props: PropTypes) {
   const submissionErrorHeading = props.submissionError === 'personal_details_incorrect' ? 'Sorry there was a problem' :
     'Sorry we could not process your payment';
 
-  const maybeAddress = props.participations.removeDigiSubAddressTest === 'noAddress' ?
-    null :
-    (
-      <FormSection title="Address">
-        <Address />
-      </FormSection>
-    );
-
-
   return (
     <Content>
       <CheckoutLayout aside={(
@@ -194,7 +185,9 @@ function DigitalCheckoutForm(props: PropTypes) {
               signOut={props.signOut}
             />
           </FormSection>
-          {maybeAddress}
+          <FormSection title="Address">
+            <Address />
+          </FormSection>
           <PaymentMethodSelector
             country={props.country}
             paymentMethod={props.paymentMethod}

--- a/support-frontend/test/utils/CheckoutValidationRulesTest.scala
+++ b/support-frontend/test/utils/CheckoutValidationRulesTest.scala
@@ -63,37 +63,37 @@ class DigitalPackValidationTest extends AnyFlatSpec with Matchers {
     DigitalPackValidation.passes(requestMissingState) shouldBe false
   }
 
-//  it should "also fail if the country is Australia and there is no postcode" in {
-//    val requestMissingPostcode = validDigitalPackRequest.copy(
-//      billingAddress = validDigitalPackRequest.billingAddress.copy(country = Country.Australia, postCode = None),
-//      product = DigitalPack(Currency.AUD, Monthly)
-//    )
-//    DigitalPackValidation.passes(requestMissingPostcode) shouldBe false
-//  }
-//
-//  it should "also fail if the country is United Kingdom and there is no postcode" in {
-//    val requestMissingPostcode = validDigitalPackRequest.copy(
-//      billingAddress = validDigitalPackRequest.billingAddress.copy(country = Country.UK, postCode = None),
-//      product = DigitalPack(Currency.GBP, Monthly)
-//    )
-//    DigitalPackValidation.passes(requestMissingPostcode) shouldBe false
-//  }
-//
-//  it should "also fail if the country is United States and there is no postcode" in {
-//    val requestMissingPostcode = validDigitalPackRequest.copy(
-//      billingAddress = validDigitalPackRequest.billingAddress.copy(postCode = None),
-//      product = DigitalPack(Currency.USD, Monthly)
-//    )
-//    DigitalPackValidation.passes(requestMissingPostcode) shouldBe false
-//  }
-//
-//  it should "also fail if the country is Canada and there is no postcode" in {
-//    val requestMissingPostcode = validDigitalPackRequest.copy(
-//      billingAddress = validDigitalPackRequest.billingAddress.copy(country = Country.Canada, postCode = None),
-//      product = DigitalPack(Currency.CAD, Monthly)
-//    )
-//    DigitalPackValidation.passes(requestMissingPostcode) shouldBe false
-//  }
+  it should "also fail if the country is Australia and there is no postcode" in {
+    val requestMissingPostcode = validDigitalPackRequest.copy(
+      billingAddress = validDigitalPackRequest.billingAddress.copy(country = Country.Australia, postCode = None),
+      product = DigitalPack(Currency.AUD, Monthly)
+    )
+    DigitalPackValidation.passes(requestMissingPostcode) shouldBe false
+  }
+
+  it should "also fail if the country is United Kingdom and there is no postcode" in {
+    val requestMissingPostcode = validDigitalPackRequest.copy(
+      billingAddress = validDigitalPackRequest.billingAddress.copy(country = Country.UK, postCode = None),
+      product = DigitalPack(Currency.GBP, Monthly)
+    )
+    DigitalPackValidation.passes(requestMissingPostcode) shouldBe false
+  }
+
+  it should "also fail if the country is United States and there is no postcode" in {
+    val requestMissingPostcode = validDigitalPackRequest.copy(
+      billingAddress = validDigitalPackRequest.billingAddress.copy(postCode = None),
+      product = DigitalPack(Currency.USD, Monthly)
+    )
+    DigitalPackValidation.passes(requestMissingPostcode) shouldBe false
+  }
+
+  it should "also fail if the country is Canada and there is no postcode" in {
+    val requestMissingPostcode = validDigitalPackRequest.copy(
+      billingAddress = validDigitalPackRequest.billingAddress.copy(country = Country.Canada, postCode = None),
+      product = DigitalPack(Currency.CAD, Monthly)
+    )
+    DigitalPackValidation.passes(requestMissingPostcode) shouldBe false
+  }
 
   it should "also allow a missing postcode in other countries" in {
     val requestMissingPostcode = validDigitalPackRequest.copy(


### PR DESCRIPTION
## Why are you doing this?
We are finishing the Digital Subscription address test. There is no significant difference in conversion rate between the control and the 'no address' version so we are reverting to the control.

[**Trello Card**](https://trello.com/c/LNJ6clbg/3160-turn-off-ab-test-for-no-address)
