### PR TITLE
Add ReaderType to ProductRatePlans

### DIFF
--- a/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
+++ b/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
@@ -32,6 +32,7 @@ import {
   AmazonPay,
 } from 'helpers/paymentMethods';
 import type { Title } from 'helpers/user/details';
+import type { ReaderType } from 'helpers/productPrice/readerType';
 
 // ----- Types ----- //
 
@@ -47,7 +48,7 @@ type RegularContribution = {|
 type DigitalSubscription = {|
   currency: string,
   billingPeriod: BillingPeriod,
-  productOptions: ProductOptions,
+  readerType: ReaderType,
 |};
 
 type PaperSubscription = {|

--- a/support-frontend/assets/helpers/productPrice/productOptions.js
+++ b/support-frontend/assets/helpers/productPrice/productOptions.js
@@ -3,7 +3,6 @@
 // describes options relating to a product itself - only relevant for paper currently
 
 const NoProductOptions: 'NoProductOptions' = 'NoProductOptions';
-const Corporate: 'Corporate' = 'Corporate';
 const Saturday: 'Saturday' = 'Saturday';
 const SaturdayPlus: 'SaturdayPlus' = 'SaturdayPlus';
 const Sunday: 'Sunday' = 'Sunday';
@@ -17,7 +16,6 @@ const EverydayPlus: 'EverydayPlus' = 'EverydayPlus';
 
 export type ProductOptions =
   typeof NoProductOptions
-  | typeof Corporate
   | typeof Saturday
   | typeof SaturdayPlus
   | typeof Sunday
@@ -36,16 +34,11 @@ export type PaperProductOptions =
   | typeof Sixday
   | typeof Everyday;
 
-export type DigitalProductOptions =
-  | typeof Corporate
-  | typeof NoProductOptions
-
 
 const ActivePaperProductTypes = [Everyday, Sixday, Weekend, Sunday];
 
 export {
   NoProductOptions,
-  Corporate,
   Saturday,
   SaturdayPlus,
   Sunday,

--- a/support-frontend/assets/helpers/productPrice/readerType.js
+++ b/support-frontend/assets/helpers/productPrice/readerType.js
@@ -1,0 +1,13 @@
+// @flow
+
+const Direct: 'Direct' = 'Direct';
+const Gift: 'Gift' = 'Gift';
+const Corporate: 'Corporate' = 'Corporate';
+
+export type ReaderType = typeof Direct | typeof Gift | typeof Corporate;
+
+export {
+  Direct,
+  Gift,
+  Corporate,
+};

--- a/support-frontend/assets/pages/subscriptions-redemption/api.js
+++ b/support-frontend/assets/pages/subscriptions-redemption/api.js
@@ -11,7 +11,7 @@ import { getOphanIds, getReferrerAcquisitionData, getSupportAbTests } from 'help
 import { routes } from 'helpers/routes';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import { Monthly } from 'helpers/billingPeriods';
-import { Corporate } from 'helpers/productPrice/productOptions';
+import { Corporate } from 'helpers/productPrice/readerType';
 import type { User } from 'helpers/subscriptionsForms/user';
 import type { Participations } from 'helpers/abTests/abtest';
 import type { Csrf } from 'helpers/csrf/csrfReducer';
@@ -79,7 +79,7 @@ function buildRegularPaymentRequest(
   const product = {
     currency: currencyId,
     billingPeriod: Monthly,
-    productOptions: Corporate,
+    readerType: Corporate,
   };
 
   return {

--- a/support-frontend/test/controllers/SubscriptionsTest.scala
+++ b/support-frontend/test/controllers/SubscriptionsTest.scala
@@ -103,7 +103,7 @@ class SubscriptionsTest extends AnyWordSpec with Matchers with TestCSRFComponent
           Map(NoFulfilmentOptions ->
             Map(NoProductOptions ->
               Map(Monthly ->
-                Map(GBP -> PriceSummary(10, None, GBP, Direct, Nil))))))
+                Map(GBP -> PriceSummary(10, None, GBP, fixedTerm = false, Nil))))))
       val priceSummaryServiceProvider = mock[PriceSummaryServiceProvider]
       val priceSummaryService = mock[PriceSummaryService]
       when(priceSummaryService.getPrices(any[com.gu.support.catalog.Product], any[List[PromoCode]], any[ReaderType])).thenReturn(prices)

--- a/support-frontend/test/controllers/SubscriptionsTest.scala
+++ b/support-frontend/test/controllers/SubscriptionsTest.scala
@@ -13,6 +13,8 @@ import com.gu.support.config._
 import com.gu.support.pricing.{PriceSummary, PriceSummaryService, PriceSummaryServiceProvider, ProductPrices}
 import com.gu.support.promotions.PromoCode
 import com.gu.support.workers.Monthly
+import com.gu.support.zuora.api.ReaderType
+import com.gu.support.zuora.api.ReaderType.Direct
 import com.gu.tip.Tip
 import com.typesafe.config.ConfigFactory
 import config.Configuration.MetricUrl
@@ -101,10 +103,10 @@ class SubscriptionsTest extends AnyWordSpec with Matchers with TestCSRFComponent
           Map(NoFulfilmentOptions ->
             Map(NoProductOptions ->
               Map(Monthly ->
-                Map(GBP -> PriceSummary(10, None, GBP, fixedTerm = false, Nil))))))
+                Map(GBP -> PriceSummary(10, None, GBP, Direct, Nil))))))
       val priceSummaryServiceProvider = mock[PriceSummaryServiceProvider]
       val priceSummaryService = mock[PriceSummaryService]
-      when(priceSummaryService.getPrices(any[com.gu.support.catalog.Product], any[List[PromoCode]], any[Boolean])).thenReturn(prices)
+      when(priceSummaryService.getPrices(any[com.gu.support.catalog.Product], any[List[PromoCode]], any[ReaderType])).thenReturn(prices)
       when(priceSummaryServiceProvider.forUser(any[Boolean])).thenReturn(priceSummaryService)
 
       new DigitalSubscriptionController(

--- a/support-frontend/test/utils/CheckoutValidationRulesTest.scala
+++ b/support-frontend/test/utils/CheckoutValidationRulesTest.scala
@@ -4,9 +4,10 @@ package utils
 import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
 import com.gu.i18n.Currency.GBP
 import com.gu.i18n.{Country, Currency}
-import com.gu.support.catalog.{Corporate, Everyday, HomeDelivery}
+import com.gu.support.catalog.{Everyday, HomeDelivery}
 import com.gu.support.redemptions.{CorporateRedemption, RedemptionCode}
 import com.gu.support.workers._
+import com.gu.support.zuora.api.ReaderType.Corporate
 import org.joda.time.LocalDate
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers

--- a/support-models/src/main/scala/com/gu/support/catalog/Product.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/Product.scala
@@ -4,7 +4,8 @@ import com.gu.i18n.CountryGroup
 import com.gu.support.config.TouchPointEnvironment
 import com.gu.support.config.TouchPointEnvironments.{PROD, SANDBOX, UAT}
 import com.gu.support.workers._
-import com.gu.support.zuora.api.ReaderType.{Corporate, Gift}
+import com.gu.support.zuora.api.ReaderType
+import com.gu.support.zuora.api.ReaderType.{Corporate, Direct, Gift}
 import io.circe.{Decoder, Encoder}
 
 import scala.collection.immutable
@@ -35,28 +36,25 @@ sealed trait Product {
 }
 
 case object DigitalPack extends Product {
+  private def productRatePlan(id: String, billingPeriod: BillingPeriod, description: String, readerType: ReaderType = Direct) =
+    ProductRatePlan(id, billingPeriod, NoFulfilmentOptions, NoProductOptions, description, readerType = readerType)
+
   lazy val ratePlans: Map[TouchPointEnvironment, List[ProductRatePlan[DigitalPack.type]]] =
     Map(
       PROD -> List(
-        ProductRatePlan("2c92a0fb4edd70c8014edeaa4eae220a", Monthly, NoFulfilmentOptions, NoProductOptions, "Digital Subscription Monthly"),
-        ProductRatePlan("2c92a0fb4edd70c8014edeaa4e972204", Annual, NoFulfilmentOptions, NoProductOptions, "Digital Subscription Annual"),
-        ProductRatePlan("2c92a00d71c96bac0171df3a5622740f", Monthly, NoFulfilmentOptions, NoProductOptions, "Digital Subscription Redemption Code",
-          readerType = Corporate
-        ),
+        productRatePlan("2c92a0fb4edd70c8014edeaa4eae220a", Monthly, "Digital Subscription Monthly"),
+        productRatePlan("2c92a0fb4edd70c8014edeaa4e972204", Annual, "Digital Subscription Annual"),
+        productRatePlan("2c92a00d71c96bac0171df3a5622740f", Monthly, "Digital Subscription Redemption Code", Corporate)
       ),
       UAT -> List(
-        ProductRatePlan("2c92c0f94f2acf73014f2c908f671591", Monthly, NoFulfilmentOptions, NoProductOptions, "Digital Subscription Monthly"),
-        ProductRatePlan("2c92c0f84f2ac59d014f2c94aea9199e", Annual, NoFulfilmentOptions, NoProductOptions, "Digital Subscription Annual"),
-        ProductRatePlan("2c92c0f971c65df50171dfabef87093d", Monthly, NoFulfilmentOptions, NoProductOptions, "Digital Subscription Redemption Code",
-          readerType = Corporate
-        ),
+        productRatePlan("2c92c0f94f2acf73014f2c908f671591", Monthly, "Digital Subscription Monthly"),
+        productRatePlan("2c92c0f84f2ac59d014f2c94aea9199e", Annual, "Digital Subscription Annual"),
+        productRatePlan("2c92c0f971c65df50171dfabef87093d", Monthly, "Digital Subscription Redemption Code", Corporate)
       ),
       SANDBOX -> List(
-        ProductRatePlan("2c92c0f84bbfec8b014bc655f4852d9d", Monthly, NoFulfilmentOptions, NoProductOptions, "Digital Subscription Monthly"),
-        ProductRatePlan("2c92c0f94bbffaaa014bc6a4212e205b", Annual, NoFulfilmentOptions, NoProductOptions, "Digital Subscription Annual"),
-        ProductRatePlan("2c92c0f971c65dfe0171c6c1f86e603c", Monthly, NoFulfilmentOptions, NoProductOptions, "Digital Subscription Redemption Code",
-          readerType = Corporate
-        ),
+        productRatePlan("2c92c0f84bbfec8b014bc655f4852d9d", Monthly, "Digital Subscription Monthly"),
+        productRatePlan("2c92c0f94bbffaaa014bc6a4212e205b", Annual, "Digital Subscription Annual"),
+        productRatePlan("2c92c0f971c65dfe0171c6c1f86e603c", Monthly, "Digital Subscription Redemption Code", Corporate)
       ))
 }
 
@@ -88,7 +86,7 @@ case object Paper extends Product {
 
   val useDigitalVoucher = false
 
-  private val prodCollection: List[ProductRatePlan[Paper.type]] = if(useDigitalVoucher) {
+  private val prodCollection: List[ProductRatePlan[Paper.type]] = if (useDigitalVoucher) {
     List(
       collection("2c92a00870ec598001710740ce702ff0", SaturdayPlus, "Voucher Saturday+"),
       collection("2c92a00870ec598001710740cdd02fbd", Saturday, "Voucher Saturday"),
@@ -116,7 +114,7 @@ case object Paper extends Product {
     )
   }
 
-  private val uatCollection: List[ProductRatePlan[Paper.type]] = if(useDigitalVoucher) {
+  private val uatCollection: List[ProductRatePlan[Paper.type]] = if (useDigitalVoucher) {
     List(
       collection("2c92c0f870f682820171070489d542da", SaturdayPlus, "Voucher Saturday+"),
       collection("2c92c0f870f682820171070488df42ce", Saturday, "Voucher Saturday"),
@@ -144,7 +142,7 @@ case object Paper extends Product {
     )
   }
 
-  private val sandboxCollection: List[ProductRatePlan[Paper.type]] = if(useDigitalVoucher) {
+  private val sandboxCollection: List[ProductRatePlan[Paper.type]] = if (useDigitalVoucher) {
     List(
       collection("2c92c0f86fa49142016fa49eb1732a39", SaturdayPlus, "Voucher Saturday paper+"),
       collection("2c92c0f86fa49142016fa49ea442291b", Saturday, "Voucher Saturday paper"),
@@ -214,63 +212,224 @@ case object Paper extends Product {
 }
 
 case object GuardianWeekly extends Product {
+  private def productRatePlan(
+    id: String,
+    billingPeriod:
+    BillingPeriod,
+    fulfilmentOptions: FulfilmentOptions,
+    description: String,
+    productRatePlanChargeId: Option[String] = None,
+    readerType: ReaderType = Direct
+  ) = ProductRatePlan(
+    id, billingPeriod, fulfilmentOptions, NoProductOptions, description,
+    productRatePlanChargeId = productRatePlanChargeId, readerType = readerType
+  )
 
   lazy val ratePlans: Map[TouchPointEnvironment, List[ProductRatePlan[GuardianWeekly.type]]] =
     Map(
       PROD -> List(
-        ProductRatePlan("2c92a0086619bf8901661ab545f51b21", SixWeekly, RestOfWorld, NoProductOptions, "Guardian Weekly 6 for 6, rest of world delivery",
-          productRatePlanChargeId = Some("2c92a0086619bf8901661ab546091b23")),
-        ProductRatePlan("2c92a0fe6619b4b601661ab300222651", Annual, RestOfWorld, NoProductOptions, "Guardian Weekly annual, rest of world delivery"),
-        ProductRatePlan("2c92a0ff67cebd140167f0a2f66a12eb", Annual, RestOfWorld, NoProductOptions, "Guardian Weekly one year, rest of world delivery",
-          readerType = Gift),
-        ProductRatePlan("2c92a0086619bf8901661ab02752722f", Quarterly, RestOfWorld, NoProductOptions, "Guardian Weekly quarterly, rest of world delivery"),
-        ProductRatePlan("2c92a0076dd9892e016df8503e7c6c48", Quarterly, RestOfWorld, NoProductOptions, "Guardian Weekly three month, rest of world delivery",
-          readerType = Gift),
-        ProductRatePlan("2c92a0086619bf8901661aaac94257fe", SixWeekly, Domestic, NoProductOptions, "Guardian Weekly 6 for 6, domestic delivery",
+        productRatePlan(
+          "2c92a0086619bf8901661ab545f51b21",
+          SixWeekly,
+          RestOfWorld,
+          "Guardian Weekly 6 for 6, rest of world delivery",
+          productRatePlanChargeId = Some("2c92a0086619bf8901661ab546091b23")
+        ),
+        productRatePlan(
+          "2c92a0fe6619b4b601661ab300222651",
+          Annual,
+          RestOfWorld,
+          "Guardian Weekly annual, rest of world delivery"
+        ),
+        productRatePlan(
+          "2c92a0ff67cebd140167f0a2f66a12eb",
+          Annual,
+          RestOfWorld,
+          "Guardian Weekly one year, rest of world delivery",
+          readerType = Gift
+        ),
+        productRatePlan(
+          "2c92a0086619bf8901661ab02752722f",
+          Quarterly,
+          RestOfWorld,
+          "Guardian Weekly quarterly, rest of world delivery"
+        ),
+        productRatePlan(
+          "2c92a0076dd9892e016df8503e7c6c48",
+          Quarterly,
+          RestOfWorld,
+          "Guardian Weekly three month, rest of world delivery",
+          readerType = Gift
+        ),
+        productRatePlan(
+          "2c92a0086619bf8901661aaac94257fe",
+          SixWeekly,
+          Domestic,
+          "Guardian Weekly 6 for 6, domestic delivery",
           productRatePlanChargeId = Some("2c92a0086619bf8901661aaac95d5800")
         ),
-        ProductRatePlan("2c92a0fe6619b4b901661aa8e66c1692", Annual, Domestic, NoProductOptions, "Guardian Weekly annual, domestic delivery"),
-        ProductRatePlan("2c92a0ff67cebd0d0167f0a1a834234e", Annual, Domestic, NoProductOptions, "Guardian Weekly one year, domestic delivery",
-          readerType = Gift),
-        ProductRatePlan("2c92a0fe6619b4b301661aa494392ee2", Quarterly, Domestic, NoProductOptions, "Guardian Weekly quarterly, domestic delivery"),
-        ProductRatePlan("2c92a00e6dd988e2016df85387417498", Quarterly, Domestic, NoProductOptions, "Guardian Weekly three months, domestic delivery",
+        productRatePlan(
+          "2c92a0fe6619b4b901661aa8e66c1692",
+          Annual,
+          Domestic,
+          "Guardian Weekly annual, domestic delivery"
+        ),
+        productRatePlan(
+          "2c92a0ff67cebd0d0167f0a1a834234e",
+          Annual,
+          Domestic,
+          "Guardian Weekly one year, domestic delivery",
+          readerType = Gift
+        ),
+        productRatePlan(
+          "2c92a0fe6619b4b301661aa494392ee2",
+          Quarterly,
+          Domestic,
+          "Guardian Weekly quarterly, domestic delivery"
+        ),
+        productRatePlan(
+          "2c92a00e6dd988e2016df85387417498",
+          Quarterly,
+          Domestic,
+          "Guardian Weekly three months, domestic delivery",
           readerType = Gift)
+
       ),
       UAT -> List(
-        ProductRatePlan("2c92c0f9660fc4c70166109dfd08092c", SixWeekly, RestOfWorld, NoProductOptions, "Guardian Weekly 6 for 6, rest of world delivery",
-          productRatePlanChargeId = Some("2c92c0f9660fc4c70166109dfd17092e")),
-        ProductRatePlan("2c92c0f9660fc4d70166109a2eb0607c", Annual, RestOfWorld, NoProductOptions, "Guardian Weekly annual, rest of world delivery"),
-        ProductRatePlan("2c92c0f967caee360167f044cd0d4adc", Annual, RestOfWorld, NoProductOptions, "Guardian Weekly one year, rest of world delivery",
-          readerType = Gift),
-        ProductRatePlan("2c92c0f9660fc4d70166109c01465f10", Quarterly, RestOfWorld, NoProductOptions, "Guardian Weekly quarterly, rest of world delivery"),
-        ProductRatePlan("2c92c0f96df75b5a016df84084fb356d", Quarterly, RestOfWorld, NoProductOptions, "Guardian Weekly three months, rest of world delivery",
-          readerType = Gift),
-        ProductRatePlan("2c92c0f8660fb5dd016610858eb90658", SixWeekly, Domestic, NoProductOptions, "Guardian Weekly 6 for 6, domestic delivery",
-          productRatePlanChargeId = Some("2c92c0f8660fb5dd016610858ed3065a")),
-        ProductRatePlan("2c92c0f9660fc4d70166107fa5412641", Annual, Domestic, NoProductOptions, "Guardian Weekly annual, domestic delivery"),
-        ProductRatePlan("2c92c0f867cae0700167f043870d6d0e", Annual, Domestic, NoProductOptions, "Guardian Weekly one year, domestic delivery",
-          readerType = Gift),
-        ProductRatePlan("2c92c0f8660fb5d601661081ea010391", Quarterly, Domestic, NoProductOptions, "Guardian Weekly quarterly, domestic delivery"),
-        ProductRatePlan("2c92c0f96df75b51016df8444f36362f", Quarterly, Domestic, NoProductOptions, "Guardian Weekly three months, domestic delivery",
+        productRatePlan(
+          "2c92c0f9660fc4c70166109dfd08092c",
+          SixWeekly,
+          RestOfWorld,
+          "Guardian Weekly 6 for 6, rest of world delivery",
+          productRatePlanChargeId = Some("2c92c0f9660fc4c70166109dfd17092e")
+        ),
+        productRatePlan(
+          "2c92c0f9660fc4d70166109a2eb0607c",
+          Annual,
+          RestOfWorld,
+          "Guardian Weekly annual, rest of world delivery"
+        ),
+        productRatePlan(
+          "2c92c0f967caee360167f044cd0d4adc",
+          Annual,
+          RestOfWorld,
+          "Guardian Weekly one year, rest of world delivery",
+          readerType = Gift
+        ),
+        productRatePlan(
+          "2c92c0f9660fc4d70166109c01465f10",
+          Quarterly,
+          RestOfWorld,
+          "Guardian Weekly quarterly, rest of world delivery"
+        ),
+        productRatePlan(
+          "2c92c0f96df75b5a016df84084fb356d",
+          Quarterly,
+          RestOfWorld,
+          "Guardian Weekly three months, rest of world delivery",
+          readerType = Gift
+        ),
+        productRatePlan(
+          "2c92c0f8660fb5dd016610858eb90658",
+          SixWeekly,
+          Domestic,
+          "Guardian Weekly 6 for 6, domestic delivery",
+          productRatePlanChargeId = Some("2c92c0f8660fb5dd016610858ed3065a")
+        ),
+        productRatePlan(
+          "2c92c0f9660fc4d70166107fa5412641",
+          Annual,
+          Domestic,
+          "Guardian Weekly annual, domestic delivery"
+        ),
+        productRatePlan(
+          "2c92c0f867cae0700167f043870d6d0e",
+          Annual,
+          Domestic,
+          "Guardian Weekly one year, domestic delivery",
+          readerType = Gift
+        ),
+        productRatePlan(
+          "2c92c0f8660fb5d601661081ea010391",
+          Quarterly,
+          Domestic,
+          "Guardian Weekly quarterly, domestic delivery"
+        ),
+        productRatePlan(
+          "2c92c0f96df75b51016df8444f36362f",
+          Quarterly,
+          Domestic,
+          "Guardian Weekly three months, domestic delivery",
           readerType = Gift)
+
       ),
       SANDBOX -> List(
-        ProductRatePlan("2c92c0f965f2122101660fbc75a16c38", SixWeekly, RestOfWorld, NoProductOptions, "Guardian Weekly 6 for 6, rest of world delivery",
-          productRatePlanChargeId = Some("2c92c0f965f2122101660fbc75ba6c3c")),
-        ProductRatePlan("2c92c0f965f2122101660fb33ed24a45", Annual, RestOfWorld, NoProductOptions, "Guardian Weekly annual, rest of world delivery"),
-        ProductRatePlan("2c92c0f967caee410167eff78e7b5244", Annual, RestOfWorld, NoProductOptions, "Guardian Weekly one year, rest of world delivery",
-          readerType = Gift),
-        ProductRatePlan("2c92c0f965f2122101660fb81b745a06", Quarterly, RestOfWorld, NoProductOptions, "Guardian Weekly quarterly, rest of world delivery"),
-        ProductRatePlan("2c92c0f96df75b5a016df81ba1c62609", Quarterly, RestOfWorld, NoProductOptions, "Guardian Weekly three months, rest of world delivery",
-          readerType = Gift),
-        ProductRatePlan("2c92c0f965f212210165f69b94c92d66", SixWeekly, Domestic, NoProductOptions, "Guardian Weekly 6 for 6, domestic delivery",
-          productRatePlanChargeId = Some("2c92c0f865f204440165f69f407d66f1")),
-        ProductRatePlan("2c92c0f965d280590165f16b1b9946c2", Annual, Domestic, NoProductOptions, "Guardian Weekly annual, domestic delivery"),
-        ProductRatePlan("2c92c0f867cae0700167eff921734f7b", Annual, Domestic, NoProductOptions, "Guardian Weekly one year, domestic delivery",
-          readerType = Gift),
-        ProductRatePlan("2c92c0f965dc30640165f150c0956859", Quarterly, Domestic, NoProductOptions, "Guardian Weekly quarterly, domestic delivery"),
-        ProductRatePlan("2c92c0f96ded216a016df491134d4091", Quarterly, Domestic, NoProductOptions, "Guardian Weekly three months, domestic delivery",
-          readerType = Gift),
+        productRatePlan(
+          "2c92c0f965f2122101660fbc75a16c38",
+          SixWeekly,
+          RestOfWorld,
+          "Guardian Weekly 6 for 6, rest of world delivery",
+          productRatePlanChargeId = Some("2c92c0f965f2122101660fbc75ba6c3c")
+        ),
+        productRatePlan(
+          "2c92c0f965f2122101660fb33ed24a45",
+          Annual,
+          RestOfWorld,
+          "Guardian Weekly annual, rest of world delivery"
+        ),
+        productRatePlan(
+          "2c92c0f967caee410167eff78e7b5244",
+          Annual,
+          RestOfWorld,
+          "Guardian Weekly one year, rest of world delivery",
+          readerType = Gift
+        ),
+        productRatePlan(
+          "2c92c0f965f2122101660fb81b745a06",
+          Quarterly,
+          RestOfWorld,
+          "Guardian Weekly quarterly, rest of world delivery"
+        ),
+        productRatePlan(
+          "2c92c0f96df75b5a016df81ba1c62609",
+          Quarterly,
+          RestOfWorld,
+          "Guardian Weekly three months, rest of world delivery",
+          readerType = Gift
+        ),
+        productRatePlan(
+          "2c92c0f965f212210165f69b94c92d66",
+          SixWeekly,
+          Domestic,
+          "Guardian Weekly 6 for 6, domestic delivery",
+          productRatePlanChargeId = Some("2c92c0f865f204440165f69f407d66f1")
+        ),
+        productRatePlan(
+          "2c92c0f965d280590165f16b1b9946c2",
+          Annual,
+          Domestic,
+          "Guardian Weekly annual, domestic delivery"
+        ),
+        productRatePlan(
+          "2c92c0f867cae0700167eff921734f7b",
+          Annual,
+          Domestic,
+          "Guardian Weekly one year, domestic delivery",
+          readerType = Gift
+        ),
+        productRatePlan(
+          "2c92c0f965dc30640165f150c0956859",
+          Quarterly,
+          Domestic,
+          "Guardian Weekly quarterly, domestic delivery"
+        ),
+        productRatePlan(
+          "2c92c0f96ded216a016df491134d4091",
+          Quarterly,
+          Domestic,
+          "Guardian Weekly three months, domestic delivery",
+          readerType = Gift
+        ),
       )
     )
 }

--- a/support-models/src/main/scala/com/gu/support/catalog/Product.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/Product.scala
@@ -4,6 +4,7 @@ import com.gu.i18n.CountryGroup
 import com.gu.support.config.TouchPointEnvironment
 import com.gu.support.config.TouchPointEnvironments.{PROD, SANDBOX, UAT}
 import com.gu.support.workers._
+import com.gu.support.zuora.api.ReaderType.{Corporate, Gift}
 import io.circe.{Decoder, Encoder}
 
 import scala.collection.immutable
@@ -39,17 +40,23 @@ case object DigitalPack extends Product {
       PROD -> List(
         ProductRatePlan("2c92a0fb4edd70c8014edeaa4eae220a", Monthly, NoFulfilmentOptions, NoProductOptions, "Digital Subscription Monthly"),
         ProductRatePlan("2c92a0fb4edd70c8014edeaa4e972204", Annual, NoFulfilmentOptions, NoProductOptions, "Digital Subscription Annual"),
-        ProductRatePlan("2c92a00d71c96bac0171df3a5622740f", Monthly, NoFulfilmentOptions, Corporate, "Digital Subscription Redemption Code"),
+        ProductRatePlan("2c92a00d71c96bac0171df3a5622740f", Monthly, NoFulfilmentOptions, NoProductOptions, "Digital Subscription Redemption Code",
+          readerType = Corporate
+        ),
       ),
       UAT -> List(
         ProductRatePlan("2c92c0f94f2acf73014f2c908f671591", Monthly, NoFulfilmentOptions, NoProductOptions, "Digital Subscription Monthly"),
         ProductRatePlan("2c92c0f84f2ac59d014f2c94aea9199e", Annual, NoFulfilmentOptions, NoProductOptions, "Digital Subscription Annual"),
-        ProductRatePlan("2c92c0f971c65df50171dfabef87093d", Monthly, NoFulfilmentOptions, Corporate, "Digital Subscription Redemption Code"),
+        ProductRatePlan("2c92c0f971c65df50171dfabef87093d", Monthly, NoFulfilmentOptions, NoProductOptions, "Digital Subscription Redemption Code",
+          readerType = Corporate
+        ),
       ),
       SANDBOX -> List(
         ProductRatePlan("2c92c0f84bbfec8b014bc655f4852d9d", Monthly, NoFulfilmentOptions, NoProductOptions, "Digital Subscription Monthly"),
         ProductRatePlan("2c92c0f94bbffaaa014bc6a4212e205b", Annual, NoFulfilmentOptions, NoProductOptions, "Digital Subscription Annual"),
-        ProductRatePlan("2c92c0f971c65dfe0171c6c1f86e603c", Monthly, NoFulfilmentOptions, Corporate, "Digital Subscription Redemption Code"),
+        ProductRatePlan("2c92c0f971c65dfe0171c6c1f86e603c", Monthly, NoFulfilmentOptions, NoProductOptions, "Digital Subscription Redemption Code",
+          readerType = Corporate
+        ),
       ))
 }
 
@@ -215,55 +222,55 @@ case object GuardianWeekly extends Product {
           productRatePlanChargeId = Some("2c92a0086619bf8901661ab546091b23")),
         ProductRatePlan("2c92a0fe6619b4b601661ab300222651", Annual, RestOfWorld, NoProductOptions, "Guardian Weekly annual, rest of world delivery"),
         ProductRatePlan("2c92a0ff67cebd140167f0a2f66a12eb", Annual, RestOfWorld, NoProductOptions, "Guardian Weekly one year, rest of world delivery",
-          fixedTerm = true),
+          readerType = Gift),
         ProductRatePlan("2c92a0086619bf8901661ab02752722f", Quarterly, RestOfWorld, NoProductOptions, "Guardian Weekly quarterly, rest of world delivery"),
         ProductRatePlan("2c92a0076dd9892e016df8503e7c6c48", Quarterly, RestOfWorld, NoProductOptions, "Guardian Weekly three month, rest of world delivery",
-          fixedTerm = true),
+          readerType = Gift),
         ProductRatePlan("2c92a0086619bf8901661aaac94257fe", SixWeekly, Domestic, NoProductOptions, "Guardian Weekly 6 for 6, domestic delivery",
           productRatePlanChargeId = Some("2c92a0086619bf8901661aaac95d5800")
         ),
         ProductRatePlan("2c92a0fe6619b4b901661aa8e66c1692", Annual, Domestic, NoProductOptions, "Guardian Weekly annual, domestic delivery"),
         ProductRatePlan("2c92a0ff67cebd0d0167f0a1a834234e", Annual, Domestic, NoProductOptions, "Guardian Weekly one year, domestic delivery",
-          fixedTerm = true),
+          readerType = Gift),
         ProductRatePlan("2c92a0fe6619b4b301661aa494392ee2", Quarterly, Domestic, NoProductOptions, "Guardian Weekly quarterly, domestic delivery"),
         ProductRatePlan("2c92a00e6dd988e2016df85387417498", Quarterly, Domestic, NoProductOptions, "Guardian Weekly three months, domestic delivery",
-          fixedTerm = true)
+          readerType = Gift)
       ),
       UAT -> List(
         ProductRatePlan("2c92c0f9660fc4c70166109dfd08092c", SixWeekly, RestOfWorld, NoProductOptions, "Guardian Weekly 6 for 6, rest of world delivery",
           productRatePlanChargeId = Some("2c92c0f9660fc4c70166109dfd17092e")),
         ProductRatePlan("2c92c0f9660fc4d70166109a2eb0607c", Annual, RestOfWorld, NoProductOptions, "Guardian Weekly annual, rest of world delivery"),
         ProductRatePlan("2c92c0f967caee360167f044cd0d4adc", Annual, RestOfWorld, NoProductOptions, "Guardian Weekly one year, rest of world delivery",
-          fixedTerm = true),
+          readerType = Gift),
         ProductRatePlan("2c92c0f9660fc4d70166109c01465f10", Quarterly, RestOfWorld, NoProductOptions, "Guardian Weekly quarterly, rest of world delivery"),
         ProductRatePlan("2c92c0f96df75b5a016df84084fb356d", Quarterly, RestOfWorld, NoProductOptions, "Guardian Weekly three months, rest of world delivery",
-          fixedTerm = true),
+          readerType = Gift),
         ProductRatePlan("2c92c0f8660fb5dd016610858eb90658", SixWeekly, Domestic, NoProductOptions, "Guardian Weekly 6 for 6, domestic delivery",
           productRatePlanChargeId = Some("2c92c0f8660fb5dd016610858ed3065a")),
         ProductRatePlan("2c92c0f9660fc4d70166107fa5412641", Annual, Domestic, NoProductOptions, "Guardian Weekly annual, domestic delivery"),
         ProductRatePlan("2c92c0f867cae0700167f043870d6d0e", Annual, Domestic, NoProductOptions, "Guardian Weekly one year, domestic delivery",
-          fixedTerm = true),
+          readerType = Gift),
         ProductRatePlan("2c92c0f8660fb5d601661081ea010391", Quarterly, Domestic, NoProductOptions, "Guardian Weekly quarterly, domestic delivery"),
         ProductRatePlan("2c92c0f96df75b51016df8444f36362f", Quarterly, Domestic, NoProductOptions, "Guardian Weekly three months, domestic delivery",
-          fixedTerm = true)
+          readerType = Gift)
       ),
       SANDBOX -> List(
         ProductRatePlan("2c92c0f965f2122101660fbc75a16c38", SixWeekly, RestOfWorld, NoProductOptions, "Guardian Weekly 6 for 6, rest of world delivery",
           productRatePlanChargeId = Some("2c92c0f965f2122101660fbc75ba6c3c")),
         ProductRatePlan("2c92c0f965f2122101660fb33ed24a45", Annual, RestOfWorld, NoProductOptions, "Guardian Weekly annual, rest of world delivery"),
         ProductRatePlan("2c92c0f967caee410167eff78e7b5244", Annual, RestOfWorld, NoProductOptions, "Guardian Weekly one year, rest of world delivery",
-          fixedTerm = true),
+          readerType = Gift),
         ProductRatePlan("2c92c0f965f2122101660fb81b745a06", Quarterly, RestOfWorld, NoProductOptions, "Guardian Weekly quarterly, rest of world delivery"),
         ProductRatePlan("2c92c0f96df75b5a016df81ba1c62609", Quarterly, RestOfWorld, NoProductOptions, "Guardian Weekly three months, rest of world delivery",
-          fixedTerm = true),
+          readerType = Gift),
         ProductRatePlan("2c92c0f965f212210165f69b94c92d66", SixWeekly, Domestic, NoProductOptions, "Guardian Weekly 6 for 6, domestic delivery",
           productRatePlanChargeId = Some("2c92c0f865f204440165f69f407d66f1")),
         ProductRatePlan("2c92c0f965d280590165f16b1b9946c2", Annual, Domestic, NoProductOptions, "Guardian Weekly annual, domestic delivery"),
         ProductRatePlan("2c92c0f867cae0700167eff921734f7b", Annual, Domestic, NoProductOptions, "Guardian Weekly one year, domestic delivery",
-          fixedTerm = true),
+          readerType = Gift),
         ProductRatePlan("2c92c0f965dc30640165f150c0956859", Quarterly, Domestic, NoProductOptions, "Guardian Weekly quarterly, domestic delivery"),
         ProductRatePlan("2c92c0f96ded216a016df491134d4091", Quarterly, Domestic, NoProductOptions, "Guardian Weekly three months, domestic delivery",
-          fixedTerm = true),
+          readerType = Gift),
       )
     )
 }

--- a/support-models/src/main/scala/com/gu/support/catalog/ProductOptions.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/ProductOptions.scala
@@ -8,11 +8,7 @@ sealed trait ProductOptions
 
 sealed trait PaperProductOptions extends ProductOptions
 
-sealed trait DigitalProductOptions extends ProductOptions
-
-case object NoProductOptions extends ProductOptions with DigitalProductOptions
-
-case object Corporate extends DigitalProductOptions
+case object NoProductOptions extends ProductOptions
 
 case object Saturday extends PaperProductOptions
 
@@ -35,7 +31,7 @@ case object EverydayPlus extends PaperProductOptions
 case object Everyday extends PaperProductOptions
 
 object ProductOptions {
-  val allProductOptions = DigitalProductOptions.productOptions ++ PaperProductOptions.productOptions
+  val allProductOptions = NoProductOptions :: PaperProductOptions.productOptions
 
   def fromString[T](code: String, productOptions: List[T]): Option[T] = productOptions.find(_.getClass.getSimpleName == s"$code$$")
 
@@ -49,18 +45,9 @@ object ProductOptions {
   implicit val keyDecoder: KeyDecoder[ProductOptions] = (key: String) => fromString(key, allProductOptions)
 }
 
-object DigitalProductOptions {
-  val productOptions: List[catalog.DigitalProductOptions] = List(Corporate, NoProductOptions)
-
-  implicit val decoder: Decoder[DigitalProductOptions] =
-    Decoder.decodeString.emap(code => fromString(code, productOptions).toRight(s"unrecognised product options '$code'"))
-
-  implicit val encode: Encoder[DigitalProductOptions] = Encoder.encodeString.contramap[DigitalProductOptions](_.toString)
-
-}
-
 object PaperProductOptions {
-  val productOptions: List[PaperProductOptions] = List(Saturday, SaturdayPlus, Sunday, SundayPlus, Weekend, WeekendPlus, Sixday, SixdayPlus, Everyday, EverydayPlus)
+  val productOptions: List[PaperProductOptions] =
+    List(Saturday, SaturdayPlus, Sunday, SundayPlus, Weekend, WeekendPlus, Sixday, SixdayPlus, Everyday, EverydayPlus)
 
   implicit val decoder: Decoder[PaperProductOptions] =
     Decoder.decodeString.emap(code => fromString(code, productOptions).toRight(s"unrecognised product options '$code'"))

--- a/support-models/src/main/scala/com/gu/support/catalog/ProductRatePlan.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/ProductRatePlan.scala
@@ -2,6 +2,8 @@ package com.gu.support.catalog
 
 import com.gu.i18n.CountryGroup
 import com.gu.support.workers.BillingPeriod
+import com.gu.support.zuora.api.ReaderType
+import com.gu.support.zuora.api.ReaderType.Direct
 
 case class ProductRatePlan[+T <: Product](
   id: ProductRatePlanId,
@@ -13,5 +15,5 @@ case class ProductRatePlan[+T <: Product](
   // productRatePlanChargeId is only needed for GW 6 for 6. If we implemented 6 for 6 in the same way as
   // we do discounts we wouldn't need this and we would be able to apply 6 for 6 to other products
   productRatePlanChargeId: Option[ProductRatePlanChargeId] = None,
-  fixedTerm: Boolean = false
+  readerType: ReaderType = Direct
 )

--- a/support-models/src/main/scala/com/gu/support/workers/ProductTypeRatePlans.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/ProductTypeRatePlans.scala
@@ -1,46 +1,48 @@
 package com.gu.support.workers
 
-import com.gu.support.catalog.{Corporate, NoProductOptions, Product, ProductRatePlan}
+import com.gu.support.catalog.{Product, ProductRatePlan}
 import com.gu.support.config.TouchPointEnvironment
+import com.gu.support.zuora.api.ReaderType
+import com.gu.support.zuora.api.ReaderType.Corporate
 
 
 trait ProductTypeRatePlans[P] {
-  def productRatePlan(product: P, environment: TouchPointEnvironment, fixedTerm: Boolean): Option[ProductRatePlan[Product]]
+  def productRatePlan(product: P, environment: TouchPointEnvironment, readerType: ReaderType): Option[ProductRatePlan[Product]]
 }
 
 object ProductTypeRatePlans {
 
   def apply[P](implicit p: ProductTypeRatePlans[P]): ProductTypeRatePlans[P] = p
 
-  def productRatePlan[P: ProductTypeRatePlans](p: P, environment: TouchPointEnvironment, fixedTerm: Boolean): Option[ProductRatePlan[Product]] =
-    ProductTypeRatePlans[P].productRatePlan(p, environment, fixedTerm)
+  def productRatePlan[P: ProductTypeRatePlans](p: P, environment: TouchPointEnvironment, readerType: ReaderType): Option[ProductRatePlan[Product]] =
+    ProductTypeRatePlans[P].productRatePlan(p, environment, readerType)
 
   implicit class Ops[P: ProductTypeRatePlans](p: P) {
-    def productRatePlan(environment: TouchPointEnvironment, fixedTerm: Boolean): Option[ProductRatePlan[Product]] =
-      ProductTypeRatePlans[P].productRatePlan(p, environment, fixedTerm)
+    def productRatePlan(environment: TouchPointEnvironment, readerType: ReaderType): Option[ProductRatePlan[Product]] =
+      ProductTypeRatePlans[P].productRatePlan(p, environment, readerType)
   }
 
-  implicit val productTypeRatePlan: ProductTypeRatePlans[ProductType] = (product: ProductType, environment: TouchPointEnvironment, fixedTerm: Boolean) =>
+  implicit val productTypeRatePlan: ProductTypeRatePlans[ProductType] = (product: ProductType, environment: TouchPointEnvironment, readerType: ReaderType) =>
     product match {
-      case d: DigitalPack => d.productRatePlan(environment, fixedTerm)
-      case p: Paper => p.productRatePlan(environment, fixedTerm)
-      case w: GuardianWeekly => w.productRatePlan(environment, fixedTerm)
+      case d: DigitalPack => d.productRatePlan(environment, readerType)
+      case p: Paper => p.productRatePlan(environment, readerType)
+      case w: GuardianWeekly => w.productRatePlan(environment, readerType)
       case _ => None
     }
 
-  implicit val weeklyRatePlan: ProductTypeRatePlans[GuardianWeekly] = (product: GuardianWeekly, environment: TouchPointEnvironment, fixedTerm) => {
+  implicit val weeklyRatePlan: ProductTypeRatePlans[GuardianWeekly] = (product: GuardianWeekly, environment: TouchPointEnvironment, readerType) => {
     val postIntroductoryBillingPeriod = if (product.billingPeriod == SixWeekly) Quarterly else product.billingPeriod
     product.catalogType.ratePlans.getOrElse(environment, Nil).find(productRatePlan =>
       productRatePlan.fulfilmentOptions == product.fulfilmentOptions &&
         productRatePlan.billingPeriod == postIntroductoryBillingPeriod &&
-      productRatePlan.fixedTerm == fixedTerm
+      productRatePlan.readerType == readerType
     )
   }
 
   implicit val digitalRatePlan: ProductTypeRatePlans[DigitalPack] = (product: DigitalPack, environment: TouchPointEnvironment, fixedTerm) =>
     product.catalogType.ratePlans.getOrElse(environment, Nil).find(productRatePlan =>
-      (productRatePlan.billingPeriod == product.billingPeriod && productRatePlan.productOptions == product.productOptions) ||
-        (productRatePlan.productOptions == Corporate && product.productOptions == Corporate) // We don't care about the billing period for corporates
+      (productRatePlan.billingPeriod == product.billingPeriod && productRatePlan.readerType == product.readerType) ||
+        (productRatePlan.readerType == Corporate && product.readerType == Corporate) // We don't care about the billing period for corporates
     )
 
   implicit val paperRatePlan: ProductTypeRatePlans[Paper] = (product: Paper, environment: TouchPointEnvironment, fixedTerm) =>

--- a/support-models/src/main/scala/com/gu/support/workers/ProductTypeRatePlans.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/ProductTypeRatePlans.scala
@@ -39,13 +39,13 @@ object ProductTypeRatePlans {
     )
   }
 
-  implicit val digitalRatePlan: ProductTypeRatePlans[DigitalPack] = (product: DigitalPack, environment: TouchPointEnvironment, fixedTerm) =>
+  implicit val digitalRatePlan: ProductTypeRatePlans[DigitalPack] = (product: DigitalPack, environment: TouchPointEnvironment, readerType) =>
     product.catalogType.ratePlans.getOrElse(environment, Nil).find(productRatePlan =>
       (productRatePlan.billingPeriod == product.billingPeriod && productRatePlan.readerType == product.readerType) ||
         (productRatePlan.readerType == Corporate && product.readerType == Corporate) // We don't care about the billing period for corporates
     )
 
-  implicit val paperRatePlan: ProductTypeRatePlans[Paper] = (product: Paper, environment: TouchPointEnvironment, fixedTerm) =>
+  implicit val paperRatePlan: ProductTypeRatePlans[Paper] = (product: Paper, environment: TouchPointEnvironment, readerType) =>
     product.catalogType.ratePlans.getOrElse(environment, Nil).find(productRatePlan =>
       productRatePlan.productOptions == product.productOptions &&
         productRatePlan.fulfilmentOptions == product.fulfilmentOptions

--- a/support-models/src/main/scala/com/gu/support/workers/Products.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/Products.scala
@@ -3,13 +3,15 @@ package com.gu.support.workers
 import cats.syntax.functor._
 import com.gu.i18n.Currency
 import com.gu.i18n.Currency.GBP
-import com.gu.support.catalog.{DigitalProductOptions, FulfilmentOptions, NoProductOptions, PaperProductOptions, ProductOptions}
+import com.gu.support.catalog.{FulfilmentOptions, PaperProductOptions}
 import com.gu.support.encoding.Codec
 import com.gu.support.encoding.Codec.deriveCodec
+import com.gu.support.encoding.JsonHelpers._
+import com.gu.support.zuora.api.ReaderType
+import com.gu.support.zuora.api.ReaderType.Direct
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.syntax._
 import io.circe.{Decoder, Encoder, Json}
-import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
-import com.gu.support.encoding.JsonHelpers._
 
 
 sealed trait ProductType {
@@ -33,7 +35,7 @@ case class Contribution(
 case class DigitalPack(
   currency: Currency,
   billingPeriod: BillingPeriod,
-  productOptions: DigitalProductOptions = NoProductOptions
+  readerType: ReaderType = Direct
 ) extends ProductType {
   override val catalogType = com.gu.support.catalog.DigitalPack
   override def describe: String = s"$billingPeriod-DigitalPack-$currency"
@@ -61,7 +63,7 @@ case class GuardianWeekly(
 object ProductType {
   import com.gu.support.encoding.CustomCodecs._
   implicit val decoderDigital: Decoder[DigitalPack] = deriveDecoder[DigitalPack]
-    .prepare(_.withFocus(_.mapObject(_.checkKeyExists("productOptions", Json.fromString("NoProductOptions")))))
+    .prepare(_.withFocus(_.mapObject(_.checkKeyExists("readerType", Json.fromString("Direct")))))
   implicit val encoderDigital: Encoder[DigitalPack] = deriveEncoder
   implicit val codecContribution: Codec[Contribution] = deriveCodec
   implicit val codecPaper: Codec[Paper] = deriveCodec

--- a/support-models/src/test/scala/com/gu/support/workers/ProductTypeRatePlansSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/workers/ProductTypeRatePlansSpec.scala
@@ -4,6 +4,7 @@ import com.gu.i18n.Currency.{GBP, USD}
 import com.gu.support.catalog.{Domestic, Everyday, HomeDelivery}
 import com.gu.support.config.TouchPointEnvironments.SANDBOX
 import com.gu.support.workers.ProductTypeRatePlans._
+import com.gu.support.zuora.api.ReaderType.{Direct, Gift}
 import org.scalatest.OptionValues._
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -13,14 +14,14 @@ class ProductTypeRatePlansSpec extends AsyncFlatSpec with Matchers{
 
   "ProductTypeRatePlans type class" should "return the correct product rate plan for a given product type" in {
     val weekly = GuardianWeekly(GBP, Annual, Domestic)
-    weekly.productRatePlan(SANDBOX, fixedTerm = false).value.description shouldBe "Guardian Weekly annual, domestic delivery"
+    weekly.productRatePlan(SANDBOX, Direct).value.description shouldBe "Guardian Weekly annual, domestic delivery"
 
     val paper = Paper(USD, Monthly, HomeDelivery, Everyday)
-    paper.productRatePlan(SANDBOX, fixedTerm = false).value.id shouldBe "2c92c0f955c3cf0f0155c5d9e2493c43"
+    paper.productRatePlan(SANDBOX, Direct).value.id shouldBe "2c92c0f955c3cf0f0155c5d9e2493c43"
 
     val product: ProductType = weekly
 
-    product.productRatePlan(SANDBOX, fixedTerm = true).value.description shouldBe "Guardian Weekly one year, domestic delivery"
+    product.productRatePlan(SANDBOX, Gift).value.description shouldBe "Guardian Weekly one year, domestic delivery"
   }
 
 }

--- a/support-services/src/main/scala/com/gu/support/pricing/PriceSummary.scala
+++ b/support-services/src/main/scala/com/gu/support/pricing/PriceSummary.scala
@@ -9,7 +9,7 @@ case class PriceSummary(
   price: BigDecimal,
   savingVsRetail: Option[Int],
   currency: Currency,
-  readerType: ReaderType,
+  fixedTerm: Boolean,
   promotions: List[PromotionSummary]
 )
 

--- a/support-services/src/main/scala/com/gu/support/pricing/PriceSummary.scala
+++ b/support-services/src/main/scala/com/gu/support/pricing/PriceSummary.scala
@@ -2,13 +2,14 @@ package com.gu.support.pricing
 
 import com.gu.i18n.Currency
 import com.gu.support.promotions._
+import com.gu.support.zuora.api.ReaderType
 
 
 case class PriceSummary(
   price: BigDecimal,
   savingVsRetail: Option[Int],
   currency: Currency,
-  fixedTerm: Boolean,
+  readerType: ReaderType,
   promotions: List[PromotionSummary]
 )
 

--- a/support-services/src/main/scala/com/gu/support/pricing/PriceSummaryService.scala
+++ b/support-services/src/main/scala/com/gu/support/pricing/PriceSummaryService.scala
@@ -7,7 +7,7 @@ import com.gu.support.promotions._
 import com.gu.support.touchpoint.TouchpointService
 import com.gu.support.workers.BillingPeriod
 import com.gu.support.zuora.api.ReaderType
-import com.gu.support.zuora.api.ReaderType.Direct
+import com.gu.support.zuora.api.ReaderType.{Direct, Gift}
 import org.joda.time.Months
 
 import scala.math.BigDecimal.RoundingMode
@@ -73,7 +73,7 @@ class PriceSummaryService(promotionService: PromotionService, catalogService: Ca
       price.value,
       saving,
       price.currency,
-      productRatePlan.readerType,
+      productRatePlan.readerType == Gift,
       promotionSummaries
     )
   }

--- a/support-services/src/main/scala/com/gu/support/pricing/PriceSummaryService.scala
+++ b/support-services/src/main/scala/com/gu/support/pricing/PriceSummaryService.scala
@@ -6,6 +6,8 @@ import com.gu.support.pricing.PriceSummaryService.{getDiscountedPrice, getNumber
 import com.gu.support.promotions._
 import com.gu.support.touchpoint.TouchpointService
 import com.gu.support.workers.BillingPeriod
+import com.gu.support.zuora.api.ReaderType
+import com.gu.support.zuora.api.ReaderType.Direct
 import org.joda.time.Months
 
 import scala.math.BigDecimal.RoundingMode
@@ -13,11 +15,11 @@ import scala.math.BigDecimal.RoundingMode
 class PriceSummaryService(promotionService: PromotionService, catalogService: CatalogService) extends TouchpointService {
   private type GroupedPriceList = Map[(FulfilmentOptions, ProductOptions, BillingPeriod), Map[Currency, PriceSummary]]
 
-  def getPrices[T <: Product](product: T, promoCodes: List[PromoCode], fixedTerm: Boolean = false): ProductPrices = {
+  def getPrices[T <: Product](product: T, promoCodes: List[PromoCode], readerType: ReaderType = Direct): ProductPrices = {
     val promotions = promotionService.findPromotions(promoCodes)
     product.supportedCountries(catalogService.environment).map(
       countryGroup =>
-        countryGroup -> getPricesForCountryGroup(product, countryGroup, promotions, fixedTerm)
+        countryGroup -> getPricesForCountryGroup(product, countryGroup, promotions, readerType)
     ).toMap
   }
 
@@ -26,9 +28,9 @@ class PriceSummaryService(promotionService: PromotionService, catalogService: Ca
     product: T,
     countryGroup: CountryGroup,
     promotions: List[PromotionWithCode],
-    fixedTerm: Boolean = false
+    readerType: ReaderType = Direct
   ): CountryGroupPrices = {
-    val ratePlans = product.ratePlans(catalogService.environment).filter(_.fixedTerm == fixedTerm)
+    val ratePlans = product.ratePlans(catalogService.environment).filter(_.readerType == readerType)
     val grouped = ratePlans.groupBy(p => (p.fulfilmentOptions, p.productOptions, p.billingPeriod)).map {
       case (keys, productRatePlans) =>
         val priceSummaries = for {
@@ -71,7 +73,7 @@ class PriceSummaryService(promotionService: PromotionService, catalogService: Ca
       price.value,
       saving,
       price.currency,
-      productRatePlan.fixedTerm,
+      productRatePlan.readerType,
       promotionSummaries
     )
   }

--- a/support-services/src/main/scala/com/gu/support/promotions/PromotionTerms.scala
+++ b/support-services/src/main/scala/com/gu/support/promotions/PromotionTerms.scala
@@ -3,6 +3,7 @@ package com.gu.support.promotions
 import com.gu.support.catalog.{DigitalPack, Product}
 import com.gu.support.config.{Stage, TouchPointEnvironments}
 import com.gu.support.encoding.Codec
+import com.gu.support.zuora.api.ReaderType.Gift
 import org.joda.time.DateTime
 
 case class PromotionTerms(
@@ -43,7 +44,7 @@ object PromotionTerms {
     val isGift = product
       .getProductRatePlans(environment)
       .filter(productRatePlan => includedProductRatePlanIds.contains(productRatePlan.id))
-      .forall(_.fixedTerm)
+      .forall(_.readerType == Gift)
 
     PromotionTerms(
       promotion.promoCode,

--- a/support-services/src/test/scala/com/gu/support/pricing/PriceSummaryServiceIntegrationSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/pricing/PriceSummaryServiceIntegrationSpec.scala
@@ -5,6 +5,7 @@ import com.gu.support.catalog._
 import com.gu.support.config.TouchPointEnvironments
 import com.gu.support.promotions.PromotionServiceSpec
 import com.gu.support.workers.{Annual, Quarterly}
+import com.gu.support.zuora.api.ReaderType.Gift
 import com.gu.test.tags.annotations.IntegrationTest
 import com.typesafe.scalalogging.LazyLogging
 import org.scalatest.flatspec.AsyncFlatSpec
@@ -21,11 +22,11 @@ class PriceSummaryServiceIntegrationSpec  extends AsyncFlatSpec with Matchers wi
     result(UK)(Domestic)(NoProductOptions).size shouldBe 3
   }
 
-  it should "return fixed term prices" in {
-    val fixed = service.getPrices(GuardianWeekly, Nil, fixedTerm = true)
-    fixed.size shouldBe 7
-    fixed(US)(RestOfWorld)(NoProductOptions).size shouldBe 2 // Annual and three month
-    fixed(US)(RestOfWorld)(NoProductOptions).find(_._1 == Annual) shouldBe defined
-    fixed(US)(RestOfWorld)(NoProductOptions).find(_._1 == Quarterly) shouldBe defined
+  it should "return gift prices" in {
+    val gift = service.getPrices(GuardianWeekly, Nil, Gift)
+    gift.size shouldBe 7
+    gift(US)(RestOfWorld)(NoProductOptions).size shouldBe 2 // Annual and three month
+    gift(US)(RestOfWorld)(NoProductOptions).find(_._1 == Annual) shouldBe defined
+    gift(US)(RestOfWorld)(NoProductOptions).find(_._1 == Quarterly) shouldBe defined
   }
 }

--- a/support-services/src/test/scala/com/gu/support/promotions/ServicesFixtures.scala
+++ b/support-services/src/test/scala/com/gu/support/promotions/ServicesFixtures.scala
@@ -5,6 +5,7 @@ import com.gu.support.config.TouchPointEnvironments
 import com.gu.support.config.TouchPointEnvironments.PROD
 import com.gu.support.promotions.DefaultPromotions.GuardianWeekly.NonGift
 import com.gu.support.workers.Annual
+import com.gu.support.zuora.api.ReaderType.{Direct, Gift}
 import com.gu.support.zuora.api.{RatePlan, RatePlanData, Subscription, SubscriptionData}
 import org.joda.time.{DateTime, Days, LocalDate, Months}
 
@@ -39,14 +40,17 @@ object ServicesFixtures {
   val tracking = PromotionWithCode(trackingPromoCode, promotion(validProductRatePlanIds, trackingPromoCode, tracking = true))
   val renewal = PromotionWithCode(renewalPromoCode, promotion(validProductRatePlanIds, renewalPromoCode, discountBenefit, renewal = true))
   val guardianWeeklyAnnual = promotion(
-    GuardianWeekly.getProductRatePlans(TouchPointEnvironments.PROD).filter(ratePlan => ratePlan.billingPeriod == Annual && !ratePlan.fixedTerm).map(_.id),
+    GuardianWeekly
+      .getProductRatePlans(TouchPointEnvironments.PROD)
+      .filter(ratePlan => ratePlan.billingPeriod == Annual && ratePlan.readerType == Direct)
+      .map(_.id),
     NonGift.tenAnnual,
     Some(DiscountBenefit(10, Some(Months.TWELVE)))
   )
   val guardianWeeklyAnnualGift = guardianWeeklyAnnual.copy(
     appliesTo = AppliesTo.ukOnly(
       GuardianWeekly.getProductRatePlans(TouchPointEnvironments.PROD)
-        .filter(ratePlan => ratePlan.billingPeriod == Annual && ratePlan.fixedTerm)
+        .filter(ratePlan => ratePlan.billingPeriod == Annual && ratePlan.readerType == Gift)
         .map(_.id).toSet
     )
   )

--- a/support-workers/src/main/scala/com/gu/zuora/ProductSubscriptionBuilders.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/ProductSubscriptionBuilders.scala
@@ -16,6 +16,7 @@ import com.gu.support.workers.GuardianWeeklyExtensions._
 import com.gu.support.workers.ProductTypeRatePlans._
 import com.gu.support.workers._
 import com.gu.support.workers.exceptions.{BadRequestException, CatalogDataNotFoundException}
+import com.gu.support.zuora.api.ReaderType.Direct
 import com.gu.support.zuora.api._
 import org.joda.time.{DateTimeZone, Days, LocalDate}
 
@@ -74,7 +75,7 @@ object ProductSubscriptionBuilders {
       }
       val contractAcceptanceDate = contractEffectiveDate.plusDays(delay)
 
-      val productRatePlanId = validateRatePlan(digitalPack.productRatePlan(environment, fixedTerm = false), digitalPack.describe)
+      val productRatePlanId = validateRatePlan(digitalPack.productRatePlan(environment, Direct), digitalPack.describe)
 
       val subscriptionData = buildProductSubscription(
         requestId,
@@ -135,7 +136,7 @@ object ProductSubscriptionBuilders {
       case Failure(e) => throw new BadRequestException(s"First delivery date was not provided. It is required for a print subscription.", e)
     }
 
-    val productRatePlanId = validateRatePlan(paper.productRatePlan(environment, fixedTerm = false), paper.describe)
+    val productRatePlanId = validateRatePlan(paper.productRatePlan(environment, Direct), paper.describe)
 
     val subscriptionData = buildProductSubscription(
       requestId,
@@ -165,9 +166,7 @@ object ProductSubscriptionBuilders {
         case Failure(e) => throw new BadRequestException(s"First delivery date was not provided. It is required for a Guardian Weekly subscription.", e)
       }
 
-      val gift = readerType == ReaderType.Gift
-
-      val recurringProductRatePlanId = validateRatePlan(guardianWeekly.productRatePlan(environment, fixedTerm = gift), guardianWeekly.describe)
+      val recurringProductRatePlanId = validateRatePlan(guardianWeekly.productRatePlan(environment, readerType), guardianWeekly.describe)
 
       val promotionProductRatePlanId = if (isIntroductoryPromotion(guardianWeekly.billingPeriod, maybePromoCode)) {
         guardianWeekly.introductoryRatePlan(environment).map(_.id).getOrElse(recurringProductRatePlanId)

--- a/support-workers/src/test/scala/com/gu/support/workers/CreateZuoraSubscriptionStepsSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/CreateZuoraSubscriptionStepsSpec.scala
@@ -4,7 +4,6 @@ import java.util.UUID
 
 import com.gu.i18n.{Country, Currency}
 import com.gu.salesforce.Salesforce.SalesforceContactRecords
-import com.gu.support.catalog.Corporate
 import com.gu.support.config.{ZuoraConfig, ZuoraDigitalPackConfig}
 import com.gu.support.redemption.DynamoLookup.{DynamoBoolean, DynamoString}
 import com.gu.support.redemption.DynamoUpdate.DynamoFieldUpdate
@@ -12,6 +11,7 @@ import com.gu.support.redemption.{DynamoLookup, DynamoUpdate}
 import com.gu.support.redemptions.{CorporateRedemption, RedemptionCode}
 import com.gu.support.workers.lambdas.CreateZuoraSubscription
 import com.gu.support.workers.states.CreateZuoraSubscriptionState
+import com.gu.support.zuora.api.ReaderType.Corporate
 import com.gu.support.zuora.api.response._
 import com.gu.support.zuora.api.{PreviewSubscribeRequest, ReaderType, SubscribeRequest}
 import com.gu.support.zuora.domain

--- a/support-workers/src/test/scala/com/gu/zuora/BuildDigitalPackSubscriptionSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/BuildDigitalPackSubscriptionSpec.scala
@@ -4,13 +4,13 @@ import java.util.UUID
 
 import com.gu.i18n.Country
 import com.gu.i18n.Currency.GBP
-import com.gu.support.catalog.Corporate
 import com.gu.support.config.TouchPointEnvironments.SANDBOX
 import com.gu.support.config.ZuoraDigitalPackConfig
 import com.gu.support.promotions.PromotionService
 import com.gu.support.redemption.{DynamoLookup, GetCodeStatus}
 import com.gu.support.redemptions.{CorporateRedemption, RedemptionCode}
 import com.gu.support.workers.{DigitalPack, Monthly}
+import com.gu.support.zuora.api.ReaderType.Corporate
 import com.gu.support.zuora.api._
 import com.gu.zuora.ProductSubscriptionBuilders._
 import com.gu.zuora.ProductSubscriptionBuilders.buildDigitalPackSubscription.{SubscriptionPaymentCorporate, SubscriptionPaymentDirect}


### PR DESCRIPTION
## Why are you doing this?
Up until now [Product Rate Plans](https://knowledgecenter.zuora.com/Central_Platform/API/G_SOAP_API/E1_SOAP_API_Object_Reference/ProductRatePlan) as modelled in the support stack have been made up of `billingPeriod`, `fulfilmentOptions` and `productOptions` where: 
- `fulfilmentOptions` relates to how the product is distributed to the customer (eg. `HomeDelivery` or `Collection` for paper) 
- `productOptions` relates to variations in the product offering (eg. `Weekend` or `EveryDay` for paper).

To model gift subscriptions for Guardian Weekly an additional boolean `fixedTerm` was then added as all the gift rate plans were fixed term.  

After that to support corporate Digital Subscriptions a new `ProductOption` was added - `Corporate` which applied to Digisubs only.

There are a couple of problems with these two additions:
- It is not certain that all gift rate plans will continue to be fixed term going forward, and even if they are the relationship between whether a rate plan is fixed term and whether it is a gift is non-obvious.
- By making `Corporate` a `ProductOption` it becomes difficult to model corporate subscriptions for paper should that become necessary as for paper the `productOption` is already used to determine the frequency of the subscription.
- Corporate subs and Gift subs are actually very similar concepts but are modelled in very different ways (an additional boolean vs a new `ProductOption`).

The solution to all of these issues is to remove the corporate product option and the fixedTerm boolean and replace them with the concept of a `ReaderType` which can be either `Direct` - standard user, `Corporate` or `Gift`. `ReaderType` already exists in the domain model for exactly this purpose so this change is just to introduce it as a field on the `ProductRatePlan` case class and to use it when creating subscriptions.

[**Trello Card**](https://trello.com/c/EVYAhPNK/3173-gifting-system-integration-zuora-create-new-limit-term-products)
