### PR TITLE
make the IT tests run daily rather than hourly

### DIFF
--- a/support-lambdas/it-test-runner/cfn.yaml
+++ b/support-lambdas/it-test-runner/cfn.yaml
@@ -40,7 +40,7 @@ Resources:
         RerunTests:
           Type: Schedule
           Properties:
-            Schedule: 'rate(1 hour)'
+            Schedule: 'rate(1 day)'
             Description: run the tests regularly so we know if they're broken
       EventInvokeConfig:
         MaximumRetryAttempts: 0


### PR DESCRIPTION
## Why are you doing this?

The IT tests are putting too many records into SF dev, until this is resolved we will make them run daily instead of hourly

[**Trello Card**](https://trello.com/c/LKwe8ApH/3241-auto-clean-it-test-data-from-sf-dev)
