### PR TITLE
check it test runner over a day

### DIFF
--- a/support-lambdas/it-test-runner/cfn.yaml
+++ b/support-lambdas/it-test-runner/cfn.yaml
@@ -154,5 +154,5 @@ Resources:
             Unit: Count
       ComparisonOperator: LessThanThreshold
       Threshold: 100
-      EvaluationPeriods: 25
+      EvaluationPeriods: 24
       TreatMissingData: breaching


### PR DESCRIPTION
## Why are you doing this?

I tried to wing it in the previous PR https://github.com/guardian/support-frontend/pull/2640
 but "Metrics cannot be checked across more than a day"
https://riffraff.gutools.co.uk/deployment/view/9176b2a8-d2db-44e6-ba12-b43e8746e8f1?verbose=true

I think a day would be ok unless it runs exactly on the hour.  This is only temporary anyway.
