### PR TITLE
Defer loading of paypal + amazon pay

### DIFF
--- a/support-frontend/assets/components/paypalExpressButton/PayPalExpressButton.jsx
+++ b/support-frontend/assets/components/paypalExpressButton/PayPalExpressButton.jsx
@@ -13,6 +13,7 @@ import { type PayPalAuthorisation } from 'helpers/paymentIntegrations/readerReve
 import type { BillingPeriod } from 'helpers/billingPeriods';
 import { PayPal } from 'helpers/paymentMethods';
 import { type Action, updatePayPalButtonReady } from 'pages/contributions-landing/contributionsLandingActions';
+import AnimatedDots from 'components/spinners/animatedDots';
 
 type PropTypes = {|
   onPaymentAuthorisation: Function,
@@ -47,7 +48,7 @@ const PayPalExpressButtonComponent = (props: PropTypes) => {
 
   // hasLoaded determines whether window.paypal is available
   if (!props.hasLoaded) {
-    return null;
+    return <AnimatedDots appearance="dark" />;
   }
 
   // This element contains an iframe which contains the actual button

--- a/support-frontend/assets/pages/contributions-landing/checkoutFormIsSubmittableActions.js
+++ b/support-frontend/assets/pages/contributions-landing/checkoutFormIsSubmittableActions.js
@@ -133,7 +133,7 @@ function enableOrDisableForm() {
       && userCanContributeWithoutSigningIn
       && (!recaptchaRequired || recaptchaVerified);
 
-    dispatch(setFormIsSubmittable(shouldEnable, state.page.form.payPalButtonReady));
+    dispatch(setFormIsSubmittable(shouldEnable, state.page.form.payPalData.buttonReady));
   };
 }
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionSubmit.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionSubmit.jsx
@@ -57,7 +57,7 @@ function mapStateToProps(state: State) {
     otherAmount: state.page.form.formData.otherAmounts[contributionType].amount,
     currencyId: state.common.internationalisation.currencyId,
     csrf: state.page.csrf,
-    payPalHasLoaded: state.page.form.payPalHasLoaded,
+    payPalHasLoaded: state.page.form.payPalData.hasLoaded,
     isTestUser: state.page.user.isTestUser,
     formIsSubmittable: state.page.form.formIsSubmittable,
     amount: getAmount(

--- a/support-frontend/assets/pages/contributions-landing/components/PaymentMethodSelector.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/PaymentMethodSelector.jsx
@@ -183,12 +183,12 @@ const onPaymentMethodUpdate = (paymentMethod: PaymentMethod, props: PropTypes) =
   switch (paymentMethod) {
     case PayPal:
       if (!props.payPalHasBegunLoading) {
-        loadPayPalExpressSdk(props.contributionType);
+        props.loadPayPalExpressSdk(props.contributionType);
       }
       break;
     case AmazonPay:
       if (!props.amazonPayHasBegunLoading) {
-        loadAmazonPaySdk(props.countryGroupId, props.isTestUser);
+        props.loadAmazonPaySdk(props.countryGroupId, props.isTestUser);
       }
       break;
     default:

--- a/support-frontend/assets/pages/contributions-landing/components/PaymentMethodSelector.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/PaymentMethodSelector.jsx
@@ -27,7 +27,7 @@ import {
   type Action,
   updatePaymentMethod,
   updateSelectedExistingPaymentMethod,
-  loadPaymentSdkIfNecessary,
+  loadPayPalExpressSdk, loadAmazonPaySdk,
 } from '../contributionsLandingActions';
 import { isUsableExistingPaymentMethod } from 'helpers/existingPaymentMethods/existingPaymentMethods';
 import type {
@@ -70,14 +70,8 @@ type PropTypes = {|
   switches: Switches,
   payPalHasBegunLoading: boolean,
   amazonPayHasBegunLoading: boolean,
-  loadPaymentSdkIfNecessary: (
-    paymentMethod: PaymentMethod,
-    contributionType: ContributionType,
-    countryGroupId: CountryGroupId,
-    isTestUser: boolean,
-    payPalHasBegunLoading: boolean,
-    amazonPayHasBegunLoading: boolean,
-  ) => (dispatch: Function) => void
+  loadPayPalExpressSdk: (contributionType: ContributionType) => (dispatch: Function) => void,
+  loadAmazonPaySdk: (countryGroupId: CountryGroupId, isTestUser: boolean) => (dispatch: Function) => void,
 |};
 /* eslint-enable react/no-unused-prop-types */
 
@@ -98,7 +92,8 @@ const mapStateToProps = (state: State) => ({
 const mapDispatchToProps = {
   updatePaymentMethod,
   updateSelectedExistingPaymentMethod,
-  loadPaymentSdkIfNecessary,
+  loadPayPalExpressSdk,
+  loadAmazonPaySdk,
 };
 
 // ----- Render ----- //
@@ -185,14 +180,20 @@ const radioCss = {
 };
 
 const onPaymentMethodUpdate = (paymentMethod: PaymentMethod, props: PropTypes) => {
-  props.loadPaymentSdkIfNecessary(
-    paymentMethod,
-    props.contributionType,
-    props.countryGroupId,
-    props.isTestUser,
-    props.payPalHasBegunLoading,
-    props.amazonPayHasBegunLoading,
-  );
+  switch (paymentMethod) {
+    case PayPal:
+      if (!props.payPalHasBegunLoading) {
+        loadPayPalExpressSdk(props.contributionType);
+      }
+      break;
+    case AmazonPay:
+      if (!props.amazonPayHasBegunLoading) {
+        loadAmazonPaySdk(props.countryGroupId, props.isTestUser);
+      }
+      break;
+    default:
+  }
+
   props.updatePaymentMethod(paymentMethod);
   props.updateSelectedExistingPaymentMethod(undefined);
 };

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -46,11 +46,15 @@ import type { Action as PayPalAction } from 'helpers/paymentIntegrations/payPalA
 import { setFormSubmissionDependentValue } from './checkoutFormIsSubmittableActions';
 import { type State, type ThankYouPageStage, type UserFormData, type Stripe3DSResult } from './contributionsLandingReducer';
 import type { PaymentMethod } from 'helpers/paymentMethods';
-import { AmazonPay, DirectDebit, Stripe } from 'helpers/paymentMethods';
+import { AmazonPay, DirectDebit, PayPal, Stripe } from 'helpers/paymentMethods';
 import type { RecentlySignedInExistingPaymentMethod } from 'helpers/existingPaymentMethods/existingPaymentMethods';
 import { ExistingCard, ExistingDirectDebit } from 'helpers/paymentMethods';
 import { getStripeKey, stripeAccountForContributionType, type StripeAccount } from 'helpers/stripe';
 import type { Option } from 'helpers/types/option';
+import { loadPayPalRecurring } from 'helpers/paymentIntegrations/payPalRecurringCheckout';
+import { setupAmazonPay } from 'helpers/paymentIntegrations/amazonPay';
+import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { setPayPalHasLoaded } from 'helpers/paymentIntegrations/payPalActions';
 
 export type Action =
   | { type: 'UPDATE_CONTRIBUTION_TYPE', contributionType: ContributionType }
@@ -64,6 +68,7 @@ export type Action =
   | { type: 'UPDATE_BILLING_COUNTRY', billingCountry: IsoCountry | null }
   | { type: 'UPDATE_USER_FORM_DATA', userFormData: UserFormData }
   | { type: 'UPDATE_PAYMENT_READY', thirdPartyPaymentLibraryByContrib: { [ContributionType]: { [PaymentMethod]: ThirdPartyPaymentLibrary } } }
+  | { type: 'SET_AMAZON_PAY_HAS_BEGUN_LOADING' }
   | { type: 'SET_AMAZON_PAY_LOGIN_OBJECT', amazonLoginObject: Object }
   | { type: 'SET_AMAZON_PAY_PAYMENTS_OBJECT', amazonPaymentsObject: Object }
   | { type: 'SET_AMAZON_PAY_WALLET_WIDGET_READY', isReady: boolean }
@@ -93,6 +98,7 @@ export type Action =
   | { type: 'SET_STRIPE_CARD_FORM_COMPLETE', isComplete: boolean }
   | { type: 'SET_STRIPE_SETUP_INTENT_CLIENT_SECRET', setupIntentClientSecret: string }
   | { type: 'SET_STRIPE_RECURRING_RECAPTCHA_VERIFIED', recaptchaVerified: boolean }
+  | { type: 'SET_PAYPAL_HAS_BEGUN_LOADING' }
   | PayPalAction
   | { type: 'SET_HAS_SEEN_DIRECT_DEBIT_THANK_YOU_COPY' }
   | { type: 'PAYMENT_SUCCESS' }
@@ -102,6 +108,8 @@ export type Action =
   | { type: 'UPDATE_PAYPAL_BUTTON_READY', ready: boolean }
 
 const setFormIsValid = (isValid: boolean): Action => ({ type: 'SET_FORM_IS_VALID', isValid });
+
+const setPayPalHasBegunLoading = (): Action => ({ type: 'SET_PAYPAL_HAS_BEGUN_LOADING' });
 
 const updatePayPalButtonReady = (ready: boolean): Action =>
   ({ type: 'UPDATE_PAYPAL_BUTTON_READY', ready });
@@ -222,6 +230,8 @@ const setThirdPartyPaymentLibrary =
     thirdPartyPaymentLibraryByContrib: thirdPartyPaymentLibraryByContrib || null,
   });
 
+const setAmazonPayHasBegunLoading = (): Action => ({ type: 'SET_AMAZON_PAY_HAS_BEGUN_LOADING' });
+
 const setAmazonPayLoginObject = (amazonLoginObject: Object): Action => ({
   type: 'SET_AMAZON_PAY_LOGIN_OBJECT',
   amazonLoginObject,
@@ -251,6 +261,29 @@ const setUserTypeFromIdentityResponse =
         ({ type: 'SET_USER_TYPE_FROM_IDENTITY_RESPONSE', userTypeFromIdentityResponse })));
     };
 
+// We defer loading 3rd party payment SDKs until the user selects one, or one is selected by default
+const loadPaymentSdkIfNecessary = (
+  paymentMethod: PaymentMethod,
+  contributionType: ContributionType,
+  countryGroupId: CountryGroupId,
+  isTestUser: boolean,
+  payPalHasBegunLoading: boolean,
+  amazonPayHasBegunLoading: boolean,
+) => (dispatch: Function): void => {
+  if (
+    paymentMethod === PayPal &&
+    contributionType !== 'ONE_OFF' &&
+    !payPalHasBegunLoading
+  ) {
+    dispatch(setPayPalHasBegunLoading());
+    loadPayPalRecurring().then(() => dispatch(setPayPalHasLoaded()));
+  }
+
+  if (paymentMethod === AmazonPay && !amazonPayHasBegunLoading) {
+    dispatch(setAmazonPayHasBegunLoading());
+    setupAmazonPay(countryGroupId, dispatch, isTestUser);
+  }
+};
 
 const updateContributionTypeAndPaymentMethod =
   (contributionType: ContributionType, paymentMethodToSelect: PaymentMethod) =>
@@ -731,6 +764,7 @@ export {
   updateBillingCountry,
   updateUserFormData,
   setThirdPartyPaymentLibrary,
+  setAmazonPayHasBegunLoading,
   setAmazonPayLoginObject,
   setAmazonPayPaymentsObject,
   setAmazonPayWalletWidgetReady,
@@ -766,6 +800,8 @@ export {
   setStripeCardFormComplete,
   setStripeSetupIntentClientSecret,
   setStripeRecurringRecaptchaVerified,
+  setPayPalHasBegunLoading,
   updatePayPalButtonReady,
   updateRecaptchaToken,
+  loadPaymentSdkIfNecessary,
 };

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -270,18 +270,20 @@ const loadPaymentSdkIfNecessary = (
   payPalHasBegunLoading: boolean,
   amazonPayHasBegunLoading: boolean,
 ) => (dispatch: Function): void => {
-  if (
-    paymentMethod === PayPal &&
-    contributionType !== 'ONE_OFF' &&
-    !payPalHasBegunLoading
-  ) {
-    dispatch(setPayPalHasBegunLoading());
-    loadPayPalRecurring().then(() => dispatch(setPayPalHasLoaded()));
-  }
-
-  if (paymentMethod === AmazonPay && !amazonPayHasBegunLoading) {
-    dispatch(setAmazonPayHasBegunLoading());
-    setupAmazonPay(countryGroupId, dispatch, isTestUser);
+  switch (paymentMethod) {
+    case PayPal:
+      if (contributionType !== 'ONE_OFF' && !payPalHasBegunLoading) {
+        dispatch(setPayPalHasBegunLoading());
+        loadPayPalRecurring().then(() => dispatch(setPayPalHasLoaded()));
+      }
+      break;
+    case AmazonPay:
+      if (!amazonPayHasBegunLoading) {
+        dispatch(setAmazonPayHasBegunLoading());
+        setupAmazonPay(countryGroupId, dispatch, isTestUser);
+      }
+      break;
+    default:
   }
 };
 

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -46,7 +46,7 @@ import type { Action as PayPalAction } from 'helpers/paymentIntegrations/payPalA
 import { setFormSubmissionDependentValue } from './checkoutFormIsSubmittableActions';
 import { type State, type ThankYouPageStage, type UserFormData, type Stripe3DSResult } from './contributionsLandingReducer';
 import type { PaymentMethod } from 'helpers/paymentMethods';
-import { AmazonPay, DirectDebit, PayPal, Stripe } from 'helpers/paymentMethods';
+import { AmazonPay, DirectDebit, Stripe } from 'helpers/paymentMethods';
 import type { RecentlySignedInExistingPaymentMethod } from 'helpers/existingPaymentMethods/existingPaymentMethods';
 import { ExistingCard, ExistingDirectDebit } from 'helpers/paymentMethods';
 import { getStripeKey, stripeAccountForContributionType, type StripeAccount } from 'helpers/stripe';
@@ -262,29 +262,15 @@ const setUserTypeFromIdentityResponse =
     };
 
 // We defer loading 3rd party payment SDKs until the user selects one, or one is selected by default
-const loadPaymentSdkIfNecessary = (
-  paymentMethod: PaymentMethod,
-  contributionType: ContributionType,
-  countryGroupId: CountryGroupId,
-  isTestUser: boolean,
-  payPalHasBegunLoading: boolean,
-  amazonPayHasBegunLoading: boolean,
-) => (dispatch: Function): void => {
-  switch (paymentMethod) {
-    case PayPal:
-      if (contributionType !== 'ONE_OFF' && !payPalHasBegunLoading) {
-        dispatch(setPayPalHasBegunLoading());
-        loadPayPalRecurring().then(() => dispatch(setPayPalHasLoaded()));
-      }
-      break;
-    case AmazonPay:
-      if (!amazonPayHasBegunLoading) {
-        dispatch(setAmazonPayHasBegunLoading());
-        setupAmazonPay(countryGroupId, dispatch, isTestUser);
-      }
-      break;
-    default:
+const loadPayPalExpressSdk = (contributionType: ContributionType) => (dispatch: Function): void => {
+  if (contributionType !== 'ONE_OFF') {
+    dispatch(setPayPalHasBegunLoading());
+    loadPayPalRecurring().then(() => dispatch(setPayPalHasLoaded()));
   }
+};
+const loadAmazonPaySdk = (countryGroupId: CountryGroupId, isTestUser: boolean) => (dispatch: Function): void => {
+  dispatch(setAmazonPayHasBegunLoading());
+  setupAmazonPay(countryGroupId, dispatch, isTestUser);
 };
 
 const updateContributionTypeAndPaymentMethod =
@@ -805,5 +791,6 @@ export {
   setPayPalHasBegunLoading,
   updatePayPalButtonReady,
   updateRecaptchaToken,
-  loadPaymentSdkIfNecessary,
+  loadPayPalExpressSdk,
+  loadAmazonPaySdk,
 };

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.js
@@ -22,7 +22,7 @@ import {
   updateContributionTypeAndPaymentMethod, updatePaymentMethod, updateSelectedExistingPaymentMethod,
   updateUserFormData,
   setThankYouPageStage,
-  loadPaymentSdkIfNecessary,
+  loadPayPalExpressSdk, loadAmazonPaySdk,
 } from './contributionsLandingActions';
 import { type State } from './contributionsLandingReducer';
 import type { PaymentMethod } from 'helpers/paymentMethods';
@@ -37,6 +37,7 @@ import { isSwitchOn } from 'helpers/globals';
 import type { ContributionTypes } from 'helpers/contributions';
 import { getCampaignSettings } from 'helpers/campaigns';
 import { loadRecaptchaV2 } from '../../helpers/recaptcha';
+import { AmazonPay, PayPal } from 'helpers/paymentMethods';
 
 // ----- Functions ----- //
 
@@ -141,14 +142,16 @@ function selectInitialContributionTypeAndPaymentMethod(
   const contributionType = getInitialContributionType(countryGroupId, contributionTypes);
   const paymentMethod = getInitialPaymentMethod(contributionType, countryId, switches);
   dispatch(updateContributionTypeAndPaymentMethod(contributionType, paymentMethod));
-  dispatch(loadPaymentSdkIfNecessary(
-    paymentMethod,
-    contributionType,
-    countryGroupId,
-    state.page.user.isTestUser || false,
-    false,
-    false,
-  ));
+
+  switch (paymentMethod) {
+    case PayPal:
+      dispatch(loadPayPalExpressSdk(contributionType));
+      break;
+    case AmazonPay:
+      dispatch(loadAmazonPaySdk(countryGroupId, state.page.user.isTestUser || false));
+      break;
+    default:
+  }
 }
 
 const init = (store: Store<State, Action, Function>) => {

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.js
@@ -3,9 +3,6 @@
 // ----- Imports ----- //
 
 import { type Store } from 'redux';
-import { loadPayPalRecurring } from 'helpers/paymentIntegrations/payPalRecurringCheckout';
-import { setPayPalHasLoaded } from 'helpers/paymentIntegrations/payPalActions';
-import { setupAmazonPay } from 'helpers/paymentIntegrations/amazonPay';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { Switches } from 'helpers/settings';
 import { getQueryParameter } from 'helpers/url';
@@ -16,7 +13,7 @@ import {
   getValidPaymentMethods,
   getValidContributionTypesFromUrlOrElse,
 } from 'helpers/checkouts';
-import { type ContributionType, contributionTypeAvailable } from 'helpers/contributions';
+import { type ContributionType } from 'helpers/contributions';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import {
   type Action,
@@ -25,6 +22,7 @@ import {
   updateContributionTypeAndPaymentMethod, updatePaymentMethod, updateSelectedExistingPaymentMethod,
   updateUserFormData,
   setThankYouPageStage,
+  loadPaymentSdkIfNecessary,
 } from './contributionsLandingActions';
 import { type State } from './contributionsLandingReducer';
 import type { PaymentMethod } from 'helpers/paymentMethods';
@@ -79,13 +77,8 @@ function getInitialContributionType(
 function initialisePaymentMethods(
   state: State,
   dispatch: Function,
-  contributionTypes: ContributionTypes,
 ) {
-
-  const { currencyId, countryGroupId } = state.common.internationalisation;
-  const isTestUser = !!state.page.user.isTestUser;
-
-  setupAmazonPay(countryGroupId, dispatch, isTestUser);
+  const { currencyId } = state.common.internationalisation;
 
   // initiate fetch of existing payment methods
   const userAppearsLoggedIn = doesUserAppearToBeSignedIn();
@@ -110,13 +103,6 @@ function initialisePaymentMethods(
     );
   } else {
     dispatch(setExistingPaymentMethods([]));
-  }
-
-  const recurringContributionsAvailable = contributionTypeAvailable('MONTHLY', countryGroupId, contributionTypes)
-    || contributionTypeAvailable('ANNUAL', countryGroupId, contributionTypes);
-
-  if (getQueryParameter('paypal-js') !== 'no' && recurringContributionsAvailable) {
-    loadPayPalRecurring().then(() => dispatch(setPayPalHasLoaded()));
   }
 }
 
@@ -155,6 +141,14 @@ function selectInitialContributionTypeAndPaymentMethod(
   const contributionType = getInitialContributionType(countryGroupId, contributionTypes);
   const paymentMethod = getInitialPaymentMethod(contributionType, countryId, switches);
   dispatch(updateContributionTypeAndPaymentMethod(contributionType, paymentMethod));
+  dispatch(loadPaymentSdkIfNecessary(
+    paymentMethod,
+    contributionType,
+    countryGroupId,
+    state.page.user.isTestUser || false,
+    false,
+    false,
+  ));
 }
 
 const init = (store: Store<State, Action, Function>) => {
@@ -166,7 +160,7 @@ const init = (store: Store<State, Action, Function>) => {
   const contributionTypes = getContributionTypes(state);
   dispatch(setContributionTypes(contributionTypes));
 
-  initialisePaymentMethods(state, dispatch, contributionTypes);
+  initialisePaymentMethods(state, dispatch);
 
   // This will be in window.guardian if it has come from a PayPal one-off contribution,
   // where it is returned by the Payment API to the backend, flashed into the session to preserve

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
@@ -85,6 +85,7 @@ export type AmazonPayLibrary = {
 }
 
 export type AmazonPayData = {
+  hasBegunLoading: boolean,
   amazonPayLibrary: AmazonPayLibrary,
   walletWidgetReady: boolean,
   orderReferenceId: string | null,
@@ -93,12 +94,19 @@ export type AmazonPayData = {
   fatalError: boolean,
 }
 
+export type PayPalData = {
+  hasBegunLoading: boolean,
+  hasLoaded: boolean,
+  buttonReady: boolean,
+}
+
 type FormState = {
   contributionType: ContributionType,
   paymentMethod: PaymentMethod,
   existingPaymentMethod?: RecentlySignedInExistingPaymentMethod,
   thirdPartyPaymentLibraries: ThirdPartyPaymentLibraries, // TODO clean up when rest of Stripe Checkout is removed
   amazonPayData: AmazonPayData,
+  payPalData: PayPalData,
   selectedAmounts: SelectedAmounts,
   isWaiting: boolean,
   formData: FormData,
@@ -114,8 +122,6 @@ type FormState = {
   guestAccountCreationToken: ?string,
   thankYouPageStage: ThankYouPageStage,
   hasSeenDirectDebitThankYouCopy: boolean,
-  payPalHasLoaded: boolean,
-  payPalButtonReady: boolean,
   userTypeFromIdentityResponse: UserTypeFromIdentityResponse,
   formIsValid: boolean,
   formIsSubmittable: boolean,
@@ -158,6 +164,7 @@ function createFormReducer() {
       },
     },
     amazonPayData: {
+      hasBegunLoading: false,
       amazonPayLibrary: {
         amazonLoginObject: null,
         amazonPaymentsObject: null,
@@ -168,6 +175,11 @@ function createFormReducer() {
       paymentSelected: false,
       hasAccessToken: false,
       fatalError: false,
+    },
+    payPalData: {
+      hasBegunLoading: false,
+      hasLoaded: false,
+      buttonReady: false,
     },
     formData: {
       firstName: null,
@@ -216,8 +228,6 @@ function createFormReducer() {
     paymentError: null,
     guestAccountCreationToken: null,
     thankYouPageStage: 'thankYou',
-    payPalHasLoaded: false,
-    payPalButtonReady: false,
     hasSeenDirectDebitThankYouCopy: false,
     userTypeFromIdentityResponse: 'noRequestSent',
     formIsValid: true,
@@ -258,6 +268,15 @@ function createFormReducer() {
               ...state.thirdPartyPaymentLibraries.ANNUAL,
               ...action.thirdPartyPaymentLibraryByContrib.ANNUAL,
             },
+          },
+        };
+
+      case 'SET_AMAZON_PAY_HAS_BEGUN_LOADING':
+        return {
+          ...state,
+          amazonPayData: {
+            ...state.amazonPayData,
+            hasBegunLoading: true,
           },
         };
 
@@ -462,11 +481,32 @@ function createFormReducer() {
       case 'UPDATE_USER_FORM_DATA':
         return { ...state, formData: { ...state.formData, ...action.userFormData } };
 
+      case 'SET_PAYPAL_HAS_BEGUN_LOADING':
+        return {
+          ...state,
+          payPalData: {
+            ...state.payPalData,
+            hasBegunLoading: true,
+          },
+        };
+
       case 'SET_PAYPAL_HAS_LOADED':
-        return { ...state, payPalHasLoaded: true };
+        return {
+          ...state,
+          payPalData: {
+            ...state.payPalData,
+            hasLoaded: true,
+          },
+        };
 
       case 'UPDATE_PAYPAL_BUTTON_READY':
-        return { ...state, payPalButtonReady: action.ready };
+        return {
+          ...state,
+          payPalData: {
+            ...state.payPalData,
+            buttonReady: action.ready,
+          },
+        };
 
       case 'SET_TICKER_GOAL_REACHED':
         return { ...state, tickerGoalReached: true };


### PR DESCRIPTION
## Why are you doing this?
For TCFv2 compliance we must only load these SDKs once the user has shown intent.
So we will now only load them when the user selects the relevant payment method.
This change only affects:
1. PayPal Express, which is only used for recurring,
2. Amazon pay, which is only for single.

Unaffected by this change:
1. PayPal for single, because it does not use an SDK
2. Gocardless
3. Stripe - we are trying a separate solution for this

This may result in a short delay in seeing the button when the user selects the payment method, as we are no longer initialising the SDKs on page load.
I have added a progress 'spinner' for the paypal express button, e.g.:
<img width="522" alt="Screen Shot 2020-08-03 at 11 54 52" src="https://user-images.githubusercontent.com/1513454/89175693-29151880-d580-11ea-86b0-6f3e6e5a5887.png">

And we are already using one for the amazon pay button:
<img width="522" alt="Screen Shot 2020-08-03 at 12 00 13" src="https://user-images.githubusercontent.com/1513454/89176141-ea339280-d580-11ea-847d-3636da504414.png">

### Testing
Does not affect the 'existing payment method' feature, for when you arrive via MMA:
![Screen Shot 2020-08-03 at 13 16 08](https://user-images.githubusercontent.com/1513454/89181411-94181c80-d58b-11ea-92d0-0f400decb57a.png)

