### PR TITLE
don't use apply method in gift code generator

### DIFF
--- a/support-services/src/main/scala/com/gu/support/redemption/generator/GiftCodeGenerator.scala
+++ b/support-services/src/main/scala/com/gu/support/redemption/generator/GiftCodeGenerator.scala
@@ -2,18 +2,18 @@ package com.gu.support.redemption.generator
 
 import java.security.SecureRandom
 
-import com.gu.support.redemption.generator.ConstructCode.GenerateGiftCode
+import com.gu.support.redemption.generator.CodeBuilder.GenerateGiftCode
 
 object GiftCodeGenerator {
 
   lazy val randomGiftCodes: Iterator[GenerateGiftCode] = {
     val gen = new SecureRandom()
     val ints = Iterator.continually(gen.nextInt())
-    apply(ints)
+    fromRandom(ints)
   }
 
-  def apply(random: Iterator[Int]): Iterator[GenerateGiftCode] =
-    CodeSuffixGenerator(random).map(ConstructCode.apply)
+  def fromRandom(random: Iterator[Int]): Iterator[GenerateGiftCode] =
+    CodeSuffixGenerator.generate(random).map(CodeBuilder.build)
 
 }
 
@@ -29,7 +29,7 @@ object GiftDuration {
 
 }
 
-object ConstructCode {
+object CodeBuilder {
 
   private val prefix = "gd"
 
@@ -46,7 +46,7 @@ object ConstructCode {
     def withDuration(duration: GiftDuration): GiftCode
   }
 
-  def apply(code: CodeSuffixGenerator.CodeSuffix): GenerateGiftCode =
+  def build(code: CodeSuffixGenerator.CodeSuffix): GenerateGiftCode =
     (duration: GiftDuration) => {
       val init = prefix + duration.code + "-"
       GiftCode(init + code.value).get
@@ -64,10 +64,10 @@ object CodeSuffixGenerator {
         .map(new CodeSuffix(_))
   }
 
-  def apply(random: Iterator[Int]): Iterator[CodeSuffix] =
+  def generate(random: Iterator[Int]): Iterator[CodeSuffix] =
     random.grouped(6).map(codeFromGroup).map(CodeSuffix.apply).map(_.get)
 
-  def codeFromGroup(groupedInts: Seq[Int]): String = {
+  private[generator] def codeFromGroup(groupedInts: Seq[Int]): String = {
     val chars = groupedInts
       .map(int => java.lang.Integer.toString(int, 34).last)
       .map {

--- a/support-services/src/main/scala/com/gu/support/redemption/generator/GiftCodeGenerator.scala
+++ b/support-services/src/main/scala/com/gu/support/redemption/generator/GiftCodeGenerator.scala
@@ -9,10 +9,10 @@ object GiftCodeGenerator {
   lazy val randomGiftCodes: Iterator[GenerateGiftCode] = {
     val gen = new SecureRandom()
     val ints = Iterator.continually(gen.nextInt())
-    fromRandom(ints)
+    fromInts(ints)
   }
 
-  def fromRandom(random: Iterator[Int]): Iterator[GenerateGiftCode] =
+  def fromInts(random: Iterator[Int]): Iterator[GenerateGiftCode] =
     CodeSuffixGenerator.generate(random).map(CodeBuilder.build)
 
 }

--- a/support-services/src/test/scala/com/gu/support/redemption/generator/GiftCodeGeneratorSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/redemption/generator/GiftCodeGeneratorSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.matchers.should.Matchers
 class GiftCodeGeneratorSpec extends AnyFlatSpec with Matchers {
 
   it should "work in the basic case" in {
-    val giftCode = GiftCodeGenerator.fromRandom(Iterator.continually(0)).next.withDuration(GiftDuration.Gift3Month)
+    val giftCode = GiftCodeGenerator.fromInts(Iterator.continually(0)).next.withDuration(GiftDuration.Gift3Month)
     giftCode.value should be("gd03-000000")
   }
 

--- a/support-services/src/test/scala/com/gu/support/redemption/generator/GiftCodeGeneratorSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/redemption/generator/GiftCodeGeneratorSpec.scala
@@ -6,7 +6,7 @@ import org.scalatest.matchers.should.Matchers
 class GiftCodeGeneratorSpec extends AnyFlatSpec with Matchers {
 
   it should "work in the basic case" in {
-    val giftCode = GiftCodeGenerator(Iterator.continually(0)).next.withDuration(GiftDuration.Gift3Month)
+    val giftCode = GiftCodeGenerator.fromRandom(Iterator.continually(0)).next.withDuration(GiftDuration.Gift3Month)
     giftCode.value should be("gd03-000000")
   }
 
@@ -22,16 +22,16 @@ class GiftCodeGeneratorSpec extends AnyFlatSpec with Matchers {
 
 }
 
-class ConstructCodeSpec  extends AnyFlatSpec with Matchers {
+class CodeBuilderSpec  extends AnyFlatSpec with Matchers {
 
   it should "get the durations right for the codes" in {
-    ConstructCode(CodeSuffixGenerator.CodeSuffix("000000").get).withDuration(GiftDuration.Gift3Month).value should be("gd03-000000")
-    ConstructCode(CodeSuffixGenerator.CodeSuffix("000000").get).withDuration(GiftDuration.Gift6Month).value should be("gd06-000000")
-    ConstructCode(CodeSuffixGenerator.CodeSuffix("000000").get).withDuration(GiftDuration.Gift12Month).value should be("gd12-000000")
+    CodeBuilder.build(CodeSuffixGenerator.CodeSuffix("000000").get).withDuration(GiftDuration.Gift3Month).value should be("gd03-000000")
+    CodeBuilder.build(CodeSuffixGenerator.CodeSuffix("000000").get).withDuration(GiftDuration.Gift6Month).value should be("gd06-000000")
+    CodeBuilder.build(CodeSuffixGenerator.CodeSuffix("000000").get).withDuration(GiftDuration.Gift12Month).value should be("gd12-000000")
   }
 
   it should "not allow invalid codes to be constructed" in {
-    ConstructCode.GiftCode("invalid") should be(None)
+    CodeBuilder.GiftCode("invalid") should be(None)
   }
 
 }
@@ -48,7 +48,7 @@ class CodeSuffixGeneratorSpec extends AnyFlatSpec with Matchers {
 
   it should "cycle through all the possiblities" in {
     val seq = Stream.from(0).iterator
-    CodeSuffixGenerator(seq).take(7).toList.map(_.value) should be(
+    CodeSuffixGenerator.generate(seq).take(7).toList.map(_.value) should be(
       List("0y2345", "6789ab", "cdefgh", "ijkzmn", "opqrst", "uvwx0y", "234567")
     )
   }


### PR DESCRIPTION
## Why are you doing this?

Following a discussion on RR dev channel, we agreed that the apply method behaviour is non-obvious, especially for client side engineers.

This PR removes the places we use it for normal code.

We also use it for case class smart constructors. 
We probably prefer "parse" but you need more tricks (until we update to 2.13 - https://github.com/scala/scala/pull/7702 ) to get rid of the built in `apply` and not defeat the point of the constructor.  Some options:
![image](https://user-images.githubusercontent.com/7304387/89207067-1582a580-d5b2-11ea-8e41-9a37823d4968.png)
or
![image](https://user-images.githubusercontent.com/7304387/89207336-77dba600-d5b2-11ea-8e95-81988de62a37.png)
or
![image](https://user-images.githubusercontent.com/7304387/89207513-c4bf7c80-d5b2-11ea-8450-879c21d852ea.png)
or
keep it as apply.
