### PR TITLE
Add AB test for having no default payment method selected

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -7,6 +7,7 @@ import { USV1, AusAmounts, UkAmountsV1 } from './data/testAmountsData';
 const usOnlyLandingPage = '/us/contribute(/.*)?$';
 const auOnlyLandingPage = '/au/contribute(/.*)?$';
 const ukOnlyLandingPage = '/uk/contribute(/.*)?$';
+const allLandingPages = '/??/contribute(/.*)?$';
 export const subsShowcaseAndDigiSubPages = '(/??/subscribe(\\?.*)?$|/??/subscribe/digital(\\?.*)?$)';
 
 export const tests: Tests = {
@@ -77,5 +78,27 @@ export const tests: Tests = {
     referrerControlled: false,
     targetPage: ukOnlyLandingPage,
     seed: 9,
+  },
+
+  defaultPaymentMethodTest: {
+    type: 'OTHER',
+    variants: [
+      {
+        id: 'control',
+      },
+      {
+        id: 'noDefault',
+      },
+    ],
+    audiences: {
+      ALL: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: true,
+    referrerControlled: false,
+    targetPage: allLandingPages,
+    seed: 1,
   },
 };

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionSubmit.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionSubmit.jsx
@@ -87,68 +87,64 @@ const mapDispatchToProps = (dispatch: Function) => ({
 
 function withProps(props: PropTypes) {
 
-  if (props.paymentMethod !== 'None') {
-    // if all payment methods are switched off, do not display the button
-    const formClassName = 'form--contribution';
-    const showPayPalRecurringButton = props.paymentMethod === PayPal && props.contributionType !== 'ONE_OFF';
-    const amazonPaymentReady = () =>
-      !props.amazonPayData.fatalError && props.amazonPayData.orderReferenceId && props.amazonPayData.paymentSelected;
+  // if all payment methods are switched off, do not display the button
+  const formClassName = 'form--contribution';
+  const showPayPalRecurringButton = props.paymentMethod === PayPal && props.contributionType !== 'ONE_OFF';
+  const amazonPaymentReady = () =>
+    !props.amazonPayData.fatalError && props.amazonPayData.orderReferenceId && props.amazonPayData.paymentSelected;
 
-    const submitButtonCopy = getContributeButtonCopyWithPaymentType(
-      props.contributionType,
-      props.otherAmount,
-      props.selectedAmounts,
-      props.currency,
-      props.paymentMethod,
-    );
+  const submitButtonCopy = getContributeButtonCopyWithPaymentType(
+    props.contributionType,
+    props.otherAmount,
+    props.selectedAmounts,
+    props.currency,
+    props.paymentMethod,
+  );
 
-    const getAmazonPayComponent = () => (props.amazonPayData.hasAccessToken ?
-      <AmazonPayWallet isTestUser={props.isTestUser} /> :
-      <AmazonPayLoginButton />);
+  const getAmazonPayComponent = () => (props.amazonPayData.hasAccessToken ?
+    <AmazonPayWallet isTestUser={props.isTestUser} /> :
+    <AmazonPayLoginButton />);
 
-    // We have to show/hide PayPalExpressButton rather than conditionally rendering it
-    // because we don't want to destroy and replace the iframe each time.
-    // See PayPalExpressButton for more info.
-    return (
+  // We have to show/hide PayPalExpressButton rather than conditionally rendering it
+  // because we don't want to destroy and replace the iframe each time.
+  // See PayPalExpressButton for more info.
+  return (
+    <div
+      className="form__submit"
+    >
+      {showPayPalRecurringButton && (
       <div
-        className="form__submit"
+        id="component-paypal-button-checkout"
+        className={hiddenIf(!showPayPalRecurringButton, 'component-paypal-button-checkout')}
       >
-        {showPayPalRecurringButton && (
-          <div
-            id="component-paypal-button-checkout"
-            className={hiddenIf(!showPayPalRecurringButton, 'component-paypal-button-checkout')}
-          >
-            <PayPalExpressButton
-              onPaymentAuthorisation={props.onPaymentAuthorisation}
-              csrf={props.csrf}
-              currencyId={props.currencyId}
-              hasLoaded={props.payPalHasLoaded}
-              canOpen={() => props.formIsSubmittable}
-              onClick={() => props.sendFormSubmitEventForPayPalRecurring()}
-              formClassName={formClassName}
-              isTestUser={props.isTestUser}
-              setupRecurringPayPalPayment={props.setupRecurringPayPalPayment}
-              amount={props.amount}
-              billingPeriod={props.billingPeriod}
-            />
-          </div>
-        )}
-        { !props.amazonPayData.fatalError && props.paymentMethod === AmazonPay && getAmazonPayComponent() }
-
-        {!showPayPalRecurringButton && (props.paymentMethod !== AmazonPay || amazonPaymentReady()) ?
-          <Button
-            type="submit"
-            aria-label={submitButtonCopy}
-            disabled={props.isWaiting}
-            postDeploymentTestID="contributions-landing-submit-contribution-button"
-          >
-            {submitButtonCopy}
-          </Button> : null }
+        <PayPalExpressButton
+          onPaymentAuthorisation={props.onPaymentAuthorisation}
+          csrf={props.csrf}
+          currencyId={props.currencyId}
+          hasLoaded={props.payPalHasLoaded}
+          canOpen={() => props.formIsSubmittable}
+          onClick={() => props.sendFormSubmitEventForPayPalRecurring()}
+          formClassName={formClassName}
+          isTestUser={props.isTestUser}
+          setupRecurringPayPalPayment={props.setupRecurringPayPalPayment}
+          amount={props.amount}
+          billingPeriod={props.billingPeriod}
+        />
       </div>
-    );
-  }
+        )}
+      { !props.amazonPayData.fatalError && props.paymentMethod === AmazonPay && getAmazonPayComponent() }
 
-  return null;
+      {!showPayPalRecurringButton && (props.paymentMethod !== AmazonPay || amazonPaymentReady()) ?
+        <Button
+          type="submit"
+          aria-label={submitButtonCopy}
+          disabled={props.isWaiting}
+          postDeploymentTestID="contributions-landing-submit-contribution-button"
+        >
+          {submitButtonCopy}
+        </Button> : null }
+    </div>
+  );
 }
 
 function withoutProps() {

--- a/support-frontend/assets/pages/contributions-landing/components/PaymentMethodSelector.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/PaymentMethodSelector.jsx
@@ -3,7 +3,6 @@
 // ----- Imports ----- //
 
 import React from 'react';
-import { css } from '@emotion/core';
 
 import { connect } from 'react-redux';
 
@@ -224,37 +223,24 @@ function withProps(props: PropTypes) {
           }
           {contributionTypeIsRecurring(props.contributionType) &&
           fullExistingPaymentMethods.map((existingPaymentMethod: RecentlySignedInExistingPaymentMethod) => (
-            <>
-              <Radio
-                id={`paymentMethodSelector-existing${existingPaymentMethod.billingAccountId}`}
-                name="paymentMethodSelector"
-                type="radio"
-                value={existingPaymentMethod}
-                onChange={() => {
+            <Radio
+              id={`paymentMethodSelector-existing${existingPaymentMethod.billingAccountId}`}
+              name="paymentMethodSelector"
+              type="radio"
+              value={existingPaymentMethod}
+              onChange={() => {
                   props.updatePaymentMethod(mapExistingPaymentMethodToPaymentMethod(existingPaymentMethod));
                   props.updateSelectedExistingPaymentMethod(existingPaymentMethod);
                 }}
-                checked={
+              checked={
                   props.paymentMethod === mapExistingPaymentMethodToPaymentMethod(existingPaymentMethod) &&
                   props.existingPaymentMethod === existingPaymentMethod
                 }
-                arial-labelledby="payment_method"
-                label={renderExistingLabelAndLogo(existingPaymentMethod)}
-                cssOverrides={radioCss}
-              />
-              <div css={css`
-                  font-size: small;
-                  font-style: italic;
-                  margin-left: 40px;
-                  padding-bottom: 6px;
-                  color: #767676;
-                  padding-right: 40px;
-                `}
-              >
-                Used for your{' '}
-                {subscriptionsToExplainerList(existingPaymentMethod.subscriptions.map(subscriptionToExplainerPart))}
-              </div>
-            </>
+              arial-labelledby="payment_method"
+              label={renderExistingLabelAndLogo(existingPaymentMethod)}
+              cssOverrides={radioCss}
+              supporting={`Used for your ${subscriptionsToExplainerList(existingPaymentMethod.subscriptions.map(subscriptionToExplainerPart))}`}
+            />
           ))}
           {paymentMethods.map(paymentMethod => (
             <Radio

--- a/support-frontend/assets/pages/contributions-landing/components/PaymentMethodSelector.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/PaymentMethodSelector.jsx
@@ -72,6 +72,7 @@ type PropTypes = {|
   amazonPayHasBegunLoading: boolean,
   loadPayPalExpressSdk: (contributionType: ContributionType) => (dispatch: Function) => void,
   loadAmazonPaySdk: (countryGroupId: CountryGroupId, isTestUser: boolean) => (dispatch: Function) => void,
+  checkoutFormHasBeenSubmitted: boolean,
 |};
 /* eslint-enable react/no-unused-prop-types */
 
@@ -87,6 +88,7 @@ const mapStateToProps = (state: State) => ({
   switches: state.common.settings.switches,
   payPalHasBegunLoading: state.page.form.payPalData.hasBegunLoading,
   amazonPayHasBegunLoading: state.page.form.amazonPayData.hasBegunLoading,
+  checkoutFormHasBeenSubmitted: state.page.form.formData.checkoutFormHasBeenSubmitted,
 });
 
 const mapDispatchToProps = {
@@ -205,13 +207,15 @@ function withProps(props: PropTypes) {
 
   const fullExistingPaymentMethods = getFullExistingPaymentMethods(props);
 
+  const showErrorMessage = props.checkoutFormHasBeenSubmitted && props.paymentMethod === 'None';
+
   return (
     <div
       className={classNameWithModifiers('form__radio-group', ['buttons', 'contribution-pay'])}
     >
       {legend}
       { paymentMethods.length ?
-        <RadioGroup className="form__radio-group-list">
+        <RadioGroup className="form__radio-group-list" error={showErrorMessage && 'Please select a payment method'}>
           {contributionTypeIsRecurring(props.contributionType) && !props.existingPaymentMethods && (
             <div className="awaiting-existing-payment-options">
               <AnimatedDots appearance="medium" />
@@ -220,6 +224,7 @@ function withProps(props: PropTypes) {
           }
           {contributionTypeIsRecurring(props.contributionType) &&
           fullExistingPaymentMethods.map((existingPaymentMethod: RecentlySignedInExistingPaymentMethod) => (
+            // TODO: check is this gets error state.
             <>
               <Radio
                 id={`paymentMethodSelector-existing${existingPaymentMethod.billingAccountId}`}
@@ -253,20 +258,18 @@ function withProps(props: PropTypes) {
             </>
           ))}
           {paymentMethods.map(paymentMethod => (
-            <>
-              <Radio
-                id={`paymentMethodSelector-${paymentMethod}`}
-                name="paymentMethodSelector"
-                type="radio"
-                value={paymentMethod}
-                onChange={() => {
+            <Radio
+              id={`paymentMethodSelector-${paymentMethod}`}
+              name="paymentMethodSelector"
+              type="radio"
+              value={paymentMethod}
+              onChange={() => {
                   onPaymentMethodUpdate(paymentMethod, props);
                 }}
-                checked={props.paymentMethod === paymentMethod}
-                label={renderLabelAndLogo(paymentMethod)}
-                cssOverrides={radioCss}
-              />
-            </>
+              checked={props.paymentMethod === paymentMethod}
+              label={renderLabelAndLogo(paymentMethod)}
+              cssOverrides={radioCss}
+            />
           ))}
           {
             contributionTypeIsRecurring(props.contributionType) &&

--- a/support-frontend/assets/pages/contributions-landing/components/PaymentMethodSelector.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/PaymentMethodSelector.jsx
@@ -3,6 +3,7 @@
 // ----- Imports ----- //
 
 import React from 'react';
+import { css } from '@emotion/core';
 
 import { connect } from 'react-redux';
 
@@ -223,24 +224,37 @@ function withProps(props: PropTypes) {
           }
           {contributionTypeIsRecurring(props.contributionType) &&
           fullExistingPaymentMethods.map((existingPaymentMethod: RecentlySignedInExistingPaymentMethod) => (
-            <Radio
-              id={`paymentMethodSelector-existing${existingPaymentMethod.billingAccountId}`}
-              name="paymentMethodSelector"
-              type="radio"
-              value={existingPaymentMethod}
-              onChange={() => {
+            <>
+              <Radio
+                id={`paymentMethodSelector-existing${existingPaymentMethod.billingAccountId}`}
+                name="paymentMethodSelector"
+                type="radio"
+                value={existingPaymentMethod}
+                onChange={() => {
                   props.updatePaymentMethod(mapExistingPaymentMethodToPaymentMethod(existingPaymentMethod));
                   props.updateSelectedExistingPaymentMethod(existingPaymentMethod);
                 }}
-              checked={
+                checked={
                   props.paymentMethod === mapExistingPaymentMethodToPaymentMethod(existingPaymentMethod) &&
                   props.existingPaymentMethod === existingPaymentMethod
                 }
-              arial-labelledby="payment_method"
-              label={renderExistingLabelAndLogo(existingPaymentMethod)}
-              cssOverrides={radioCss}
-              supporting={`Used for your ${subscriptionsToExplainerList(existingPaymentMethod.subscriptions.map(subscriptionToExplainerPart))}`}
-            />
+                arial-labelledby="payment_method"
+                label={renderExistingLabelAndLogo(existingPaymentMethod)}
+                cssOverrides={radioCss}
+              />
+              <div css={css`
+                  font-size: small;
+                  font-style: italic;
+                  margin-left: 40px;
+                  padding-bottom: 6px;
+                  color: #767676;
+                  padding-right: 40px;
+                `}
+              >
+                Used for your{' '}
+                {subscriptionsToExplainerList(existingPaymentMethod.subscriptions.map(subscriptionToExplainerPart))}
+              </div>
+            </>
           ))}
           {paymentMethods.map(paymentMethod => (
             <Radio

--- a/support-frontend/assets/pages/contributions-landing/components/PaymentMethodSelector.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/PaymentMethodSelector.jsx
@@ -224,7 +224,6 @@ function withProps(props: PropTypes) {
           }
           {contributionTypeIsRecurring(props.contributionType) &&
           fullExistingPaymentMethods.map((existingPaymentMethod: RecentlySignedInExistingPaymentMethod) => (
-            // TODO: check is this gets error state.
             <>
               <Radio
                 id={`paymentMethodSelector-existing${existingPaymentMethod.billingAccountId}`}

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.js
@@ -45,15 +45,20 @@ function getInitialPaymentMethod(
   contributionType: ContributionType,
   countryId: IsoCountry,
   switches: Switches,
+  state: State,
 ): PaymentMethod {
   const paymentMethodFromSession = getPaymentMethodFromSession();
   const validPaymentMethods = getValidPaymentMethods(contributionType, switches, countryId);
 
-  return (
-    paymentMethodFromSession && validPaymentMethods.includes(getPaymentMethodFromSession())
-      ? paymentMethodFromSession
-      : validPaymentMethods[0] || 'None'
-  );
+  if (state.common.abParticipations.defaultPaymentMethodTest === 'control') {
+    return (
+      paymentMethodFromSession && validPaymentMethods.includes(getPaymentMethodFromSession())
+        ? paymentMethodFromSession
+        : validPaymentMethods[0] || 'None'
+    );
+  }
+
+  return 'None';
 }
 
 function getInitialContributionType(
@@ -140,7 +145,7 @@ function selectInitialContributionTypeAndPaymentMethod(
   const { switches } = state.common.settings;
   const { countryGroupId } = state.common.internationalisation;
   const contributionType = getInitialContributionType(countryGroupId, contributionTypes);
-  const paymentMethod = getInitialPaymentMethod(contributionType, countryId, switches);
+  const paymentMethod = getInitialPaymentMethod(contributionType, countryId, switches, state);
   dispatch(updateContributionTypeAndPaymentMethod(contributionType, paymentMethod));
 
   switch (paymentMethod) {

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.js
@@ -101,7 +101,13 @@ function initialisePaymentMethods(
         ));
         dispatch(setExistingPaymentMethods(switchedOnExistingPaymentMethods));
         const firstExistingPaymentMethod = (switchedOnExistingPaymentMethods[0]: any);
-        if (firstExistingPaymentMethod && isUsableExistingPaymentMethod(firstExistingPaymentMethod)) {
+        const allowDefaultSelectedPaymentMethod = state.common.abParticipations.defaultPaymentMethodTest === 'control';
+
+        if (
+          allowDefaultSelectedPaymentMethod &&
+          firstExistingPaymentMethod &&
+          isUsableExistingPaymentMethod(firstExistingPaymentMethod)
+        ) {
           dispatch(updatePaymentMethod(mapExistingPaymentMethodToPaymentMethod(firstExistingPaymentMethod)));
           dispatch(updateSelectedExistingPaymentMethod(firstExistingPaymentMethod));
         }


### PR DESCRIPTION
## Why are you doing this?

Add an AB test for having no payment method selected by default - as per [this card.](https://trello.com/c/3yiuecm4/2220-tcfv2-compliance-a-b-test-having-no-preselected-radio-button)

## Screenshots

control: 
<img width="1309" alt="Screenshot 2020-08-04 at 11 40 29" src="https://user-images.githubusercontent.com/17720442/89286418-12d38f00-d64a-11ea-87fc-e3f4171ea5f9.png">

noDefault - initial:
<img width="1309" alt="Screenshot 2020-08-04 at 11 40 17" src="https://user-images.githubusercontent.com/17720442/89286444-2121ab00-d64a-11ea-9279-09c5abe5b369.png">

noDefault - error message:
<img width="581" alt="Screenshot 2020-08-04 at 11 49 40" src="https://user-images.githubusercontent.com/17720442/89286479-31398a80-d64a-11ea-967b-2ad87028fb61.png">


