### PR TITLE
Update logic for showing philanthropic ask

### DIFF
--- a/support-frontend/assets/components/legal/termsPrivacy/termsPrivacy.jsx
+++ b/support-frontend/assets/components/legal/termsPrivacy/termsPrivacy.jsx
@@ -10,6 +10,7 @@ import { type IsoCurrency, fromCountryGroupId, currencies } from 'helpers/intern
 import type { ContributionType } from 'helpers/contributions';
 import './termsPrivacy.scss';
 import type { CampaignSettings } from 'helpers/campaigns';
+import { getReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 
 
 // ---- Types ----- //
@@ -79,6 +80,19 @@ function TermsPrivacy(props: PropTypes) {
     );
   }
 
+  const isUSContributor = props.countryGroupId === 'UnitedStates';
+  const isNotOneOffContribution = props.contributionType !== 'ONE_OFF';
+  const referrerAcquisitionData = getReferrerAcquisitionData();
+  const sourceIsNotAppleNews = referrerAcquisitionData.source !== 'APPLE_NEWS';
+  const sourceIsNotGoogleAMP = referrerAcquisitionData.source !== 'GOOGLE_AMP';
+
+  const shouldShowPhilanthropicAsk = (
+    isUSContributor &&
+    isNotOneOffContribution &&
+    sourceIsNotAppleNews &&
+    sourceIsNotGoogleAMP
+  );
+
   return (
     <>
       <div className="component-terms-privacy">
@@ -96,10 +110,7 @@ function TermsPrivacy(props: PropTypes) {
       </div>
       <br />
       <div>
-        {
-          props.contributionType !== 'ONE_OFF' &&
-          (props.countryGroupId === 'UnitedStates') ? patronAndPhilanthropicAskText : patronText
-        }
+        { shouldShowPhilanthropicAsk ? patronAndPhilanthropicAskText : patronText }
       </div>
     </>
   );

--- a/support-frontend/assets/components/legal/termsPrivacy/termsPrivacy.jsx
+++ b/support-frontend/assets/components/legal/termsPrivacy/termsPrivacy.jsx
@@ -10,7 +10,6 @@ import { type IsoCurrency, fromCountryGroupId, currencies } from 'helpers/intern
 import type { ContributionType } from 'helpers/contributions';
 import './termsPrivacy.scss';
 import type { CampaignSettings } from 'helpers/campaigns';
-import { getReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 
 
 // ---- Types ----- //
@@ -19,6 +18,7 @@ type PropTypes = {|
   countryGroupId: CountryGroupId,
   contributionType: ContributionType,
   campaignSettings: CampaignSettings | null,
+  referrerSource: ?string,
 |};
 
 // ----- Component ----- //
@@ -82,9 +82,8 @@ function TermsPrivacy(props: PropTypes) {
 
   const isUSContributor = props.countryGroupId === 'UnitedStates';
   const isNotOneOffContribution = props.contributionType !== 'ONE_OFF';
-  const referrerAcquisitionData = getReferrerAcquisitionData();
-  const sourceIsNotAppleNews = referrerAcquisitionData.source !== 'APPLE_NEWS';
-  const sourceIsNotGoogleAMP = referrerAcquisitionData.source !== 'GOOGLE_AMP';
+  const sourceIsNotAppleNews = props.referrerSource !== 'APPLE_NEWS';
+  const sourceIsNotGoogleAMP = props.referrerSource !== 'GOOGLE_AMP';
 
   const shouldShowPhilanthropicAsk = (
     isUSContributor &&

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
@@ -84,6 +84,7 @@ type PropTypes = {|
   amazonPayOrderReferenceId: string | null,
   checkoutFormHasBeenSubmitted: boolean,
   campaignSettings: CampaignSettings | null,
+  referrerSource: ?string,
 |};
 
 // We only want to use the user state value if the form state value has not been changed since it was initialised,
@@ -116,6 +117,7 @@ const mapStateToProps = (state: State) => ({
   stripeV3HasLoaded: state.page.form.stripeV3HasLoaded,
   amazonPayOrderReferenceId: state.page.form.amazonPayData.orderReferenceId,
   checkoutFormHasBeenSubmitted: state.page.form.formData.checkoutFormHasBeenSubmitted,
+  referrerSource: state.common.referrerAcquisitionData.source,
 });
 
 
@@ -270,6 +272,7 @@ function withProps(props: PropTypes) {
         countryGroupId={props.countryGroupId}
         contributionType={props.contributionType}
         campaignSettings={props.campaignSettings}
+        referrerSource={props.referrerSource}
       />
       {props.isWaiting ? <ProgressMessage message={['Processing transaction', 'Please wait']} /> : null}
     </form>


### PR DESCRIPTION
## Why are you doing this?

Remove the philanthropic ask from the contributions LP when a user comes via Apple News or Google AMP as per [this card](https://trello.com).
