### PR TITLE
New footer added to subscriptions & print subs landing pages

### DIFF
--- a/support-frontend/assets/components/footerCompliant/Footer.jsx
+++ b/support-frontend/assets/components/footerCompliant/Footer.jsx
@@ -45,8 +45,8 @@ function Footer({
             <Rows>
               {privacyPolicy &&
               <div className="component-footer__privacy-policy-text">
-                To find out what personal data we collect and how we use it, please visit our
-                <a href={privacyLink}> Privacy Policy</a>.
+                To find out what personal data we collect and how we use it, please visit our{' '}
+                <a href={privacyLink}>Privacy Policy</a>.
               </div>
               }
               {children}

--- a/support-frontend/assets/components/footerCompliant/Footer.jsx
+++ b/support-frontend/assets/components/footerCompliant/Footer.jsx
@@ -21,6 +21,7 @@ import { BackToTop } from './BackToTop';
 // ----- Props ----- //
 
 type PropTypes = {|
+  centred: boolean,
   privacyPolicy: boolean,
   disclaimer: boolean,
   faqsLink: string,
@@ -33,12 +34,13 @@ type PropTypes = {|
 // ----- Component ----- //
 
 function Footer({
-  disclaimer, privacyPolicy, children, countryGroupId, faqsLink, termsConditionsLink,
+  centred, disclaimer, privacyPolicy, children, countryGroupId, faqsLink, termsConditionsLink,
 }: PropTypes) {
   return (
     <footer css={componentFooter} role="contentinfo">
-      {(disclaimer || privacyPolicy || Children.count(children) > 0) &&
-        <FooterContent border paddingTop>
+      <ThemeProvider theme={linkBrand}>
+        {(disclaimer || privacyPolicy || Children.count(children) > 0) &&
+        <FooterContent border paddingTop centred={centred}>
           <div>
             <Rows>
               {privacyPolicy &&
@@ -53,8 +55,7 @@ function Footer({
           </div>
         </FooterContent>
       }
-      <FooterContent border>
-        <ThemeProvider theme={linkBrand}>
+        <FooterContent border centred={centred}>
           <ul css={linksList}>
             <li css={link}>
               <Link subdued href="https://www.theguardian.com/help/privacy-policy">Privacy Policy</Link>
@@ -66,19 +67,19 @@ function Footer({
               <Link subdued href={faqsLink}>FAQs</Link>
             </li>
             {termsConditionsLink &&
-              <li css={link}>
-                <Link subdued href={termsConditionsLink}>Terms & Conditions</Link>
-              </li>
+            <li css={link}>
+              <Link subdued href={termsConditionsLink}>Terms & Conditions</Link>
+            </li>
             }
           </ul>
-        </ThemeProvider>
-      </FooterContent>
-      <FooterContent paddingTop>
-        <div css={backToTopLink}>
-          <BackToTop />
-        </div>
-        <span css={copyright}>{copyrightNotice}</span>
-      </FooterContent>
+        </FooterContent>
+        <FooterContent paddingTop centred={centred}>
+          <div css={backToTopLink}>
+            <BackToTop />
+          </div>
+          <span css={copyright}>{copyrightNotice}</span>
+        </FooterContent>
+      </ThemeProvider>
     </footer>
   );
 
@@ -88,6 +89,7 @@ function Footer({
 // ----- Default Props ----- //
 
 Footer.defaultProps = {
+  centred: false,
   privacyPolicy: false,
   disclaimer: false,
   faqsLink: 'https://www.theguardian.com/help',

--- a/support-frontend/assets/components/footerCompliant/Footer.jsx
+++ b/support-frontend/assets/components/footerCompliant/Footer.jsx
@@ -40,7 +40,7 @@ function Footer({
     <footer css={componentFooter} role="contentinfo">
       <ThemeProvider theme={linkBrand}>
         {(disclaimer || privacyPolicy || Children.count(children) > 0) &&
-        <FooterContent border paddingTop centred={centred}>
+        <FooterContent appearance={{ border: true, paddingTop: true, centred }}>
           <div>
             <Rows>
               {privacyPolicy &&
@@ -55,7 +55,7 @@ function Footer({
           </div>
         </FooterContent>
       }
-        <FooterContent border centred={centred}>
+        <FooterContent appearance={{ border: true, centred }}>
           <ul css={linksList}>
             <li css={link}>
               <Link subdued href={faqsLink}>FAQs</Link>
@@ -73,7 +73,7 @@ function Footer({
             }
           </ul>
         </FooterContent>
-        <FooterContent centred={centred}>
+        <FooterContent appearance={{ centred }}>
           <div css={backToTopLink}>
             <BackToTop />
           </div>

--- a/support-frontend/assets/components/footerCompliant/Footer.jsx
+++ b/support-frontend/assets/components/footerCompliant/Footer.jsx
@@ -73,7 +73,7 @@ function Footer({
             }
           </ul>
         </FooterContent>
-        <FooterContent paddingTop centred={centred}>
+        <FooterContent centred={centred}>
           <div css={backToTopLink}>
             <BackToTop />
           </div>

--- a/support-frontend/assets/components/footerCompliant/Footer.jsx
+++ b/support-frontend/assets/components/footerCompliant/Footer.jsx
@@ -57,11 +57,6 @@ function Footer({
       }
         <FooterContent border centred={centred}>
           <ul css={linksList}>
-            {termsConditionsLink &&
-            <li css={link}>
-              <Link subdued href={termsConditionsLink}>Terms & Conditions</Link>
-            </li>
-            }
             <li css={link}>
               <Link subdued href={faqsLink}>FAQs</Link>
             </li>
@@ -71,6 +66,11 @@ function Footer({
             <li css={link}>
               <Link subdued href="https://www.theguardian.com/help/privacy-policy">Privacy Policy</Link>
             </li>
+            {termsConditionsLink &&
+              <li css={link}>
+                <Link subdued href={termsConditionsLink}>Terms & Conditions</Link>
+              </li>
+            }
           </ul>
         </FooterContent>
         <FooterContent centred={centred}>

--- a/support-frontend/assets/components/footerCompliant/Footer.jsx
+++ b/support-frontend/assets/components/footerCompliant/Footer.jsx
@@ -57,20 +57,20 @@ function Footer({
       }
         <FooterContent border centred={centred}>
           <ul css={linksList}>
-            <li css={link}>
-              <Link subdued href="https://www.theguardian.com/help/privacy-policy">Privacy Policy</Link>
-            </li>
-            <li css={link}>
-              <Link subdued href="https://www.theguardian.com/help/contact-us">Contact us</Link>
-            </li>
-            <li css={link}>
-              <Link subdued href={faqsLink}>FAQs</Link>
-            </li>
             {termsConditionsLink &&
             <li css={link}>
               <Link subdued href={termsConditionsLink}>Terms & Conditions</Link>
             </li>
             }
+            <li css={link}>
+              <Link subdued href={faqsLink}>FAQs</Link>
+            </li>
+            <li css={link}>
+              <Link subdued href="https://www.theguardian.com/help/contact-us">Contact us</Link>
+            </li>
+            <li css={link}>
+              <Link subdued href="https://www.theguardian.com/help/privacy-policy">Privacy Policy</Link>
+            </li>
           </ul>
         </FooterContent>
         <FooterContent centred={centred}>

--- a/support-frontend/assets/components/footerCompliant/containers/Content.jsx
+++ b/support-frontend/assets/components/footerCompliant/containers/Content.jsx
@@ -10,9 +10,11 @@ import { space } from '@guardian/src-foundations';
 
 type PropTypes = {|
   className: string,
-  centred?: boolean,
-  paddingTop?: boolean,
-  border?: boolean,
+  appearance: {
+    centred?: boolean,
+    paddingTop?: boolean,
+    border?: boolean,
+  },
   children: Node,
 |}
 
@@ -43,8 +45,9 @@ function getBorderStyling(centred = false) {
 }
 
 export function Content({
-  className, centred, border, paddingTop, children,
+  className, appearance, children,
 }: PropTypes) {
+  const { centred, border, paddingTop } = appearance;
   return (
     <div
       className={className}
@@ -60,7 +63,9 @@ export function Content({
 }
 
 Content.defaultProps = {
-  centred: false,
-  border: false,
-  paddingTop: false,
+  appearance: {
+    centred: false,
+    border: false,
+    paddingTop: false,
+  },
 };

--- a/support-frontend/assets/components/footerCompliant/containers/Content.jsx
+++ b/support-frontend/assets/components/footerCompliant/containers/Content.jsx
@@ -20,18 +20,6 @@ const paddingStyle = css`
   padding-top: ${space[4]}px;
 `;
 
-const borderStyle = css`
-  ${from.tablet} {
-    border-left: 1px solid ${brand[600]}; border-right: 1px solid ${brand[600]};
-  }
-`;
-
-const borderStyleCentred = css`
-  ${from.wide} {
-    border-left: 1px solid ${brand[600]}; border-right: 1px solid ${brand[600]};
-  }
-`;
-
 const contentStyle = css`
   position: relative;
   display: flex;
@@ -42,22 +30,25 @@ const contentStyle = css`
   border-bottom: 1px solid ${brand[600]};
 `;
 
+function getBorderStyling(centred = false) {
+  const breakpoint = centred ? from.wide : from.tablet;
+  return css`
+    ${breakpoint} {
+      border-left: 1px solid ${brand[600]}; border-right: 1px solid ${brand[600]};
+    }
+  `;
+}
+
 export function Content({
   className, centred, border, paddingTop, children,
 }: PropTypes) {
-  let borderStylesToApply = '';
-  if (border && centred) {
-    borderStylesToApply = borderStyleCentred;
-  } else if (border) {
-    borderStylesToApply = borderStyle;
-  }
   return (
     <div
       className={className}
       css={[
       contentStyle,
       paddingTop ? paddingStyle : '',
-      borderStylesToApply,
+      border ? getBorderStyling(centred) : '',
     ]}
     >
       {children}

--- a/support-frontend/assets/components/footerCompliant/containers/Content.jsx
+++ b/support-frontend/assets/components/footerCompliant/containers/Content.jsx
@@ -10,8 +10,9 @@ import { space } from '@guardian/src-foundations';
 
 type PropTypes = {|
   className: string,
-  paddingTop: boolean,
-  border: boolean,
+  centred?: boolean,
+  paddingTop?: boolean,
+  border?: boolean,
   children: Node,
 |}
 
@@ -21,6 +22,12 @@ const paddingStyle = css`
 
 const borderStyle = css`
   ${from.tablet} {
+    border-left: 1px solid ${brand[600]}; border-right: 1px solid ${brand[600]};
+  }
+`;
+
+const borderStyleCentred = css`
+  ${from.wide} {
     border-left: 1px solid ${brand[600]}; border-right: 1px solid ${brand[600]};
   }
 `;
@@ -36,18 +43,30 @@ const contentStyle = css`
 `;
 
 export function Content({
-  className, border, paddingTop, children,
+  className, centred, border, paddingTop, children,
 }: PropTypes) {
+  let borderStylesToApply = '';
+  if (border && centred) {
+    borderStylesToApply = borderStyleCentred;
+  } else if (border) {
+    borderStylesToApply = borderStyle;
+  }
   return (
     <div
       className={className}
       css={[
       contentStyle,
       paddingTop ? paddingStyle : '',
-      border ? borderStyle : '',
+      borderStylesToApply,
     ]}
     >
       {children}
     </div>
   );
 }
+
+Content.defaultProps = {
+  centred: false,
+  border: false,
+  paddingTop: false,
+};

--- a/support-frontend/assets/components/footerCompliant/containers/Content.jsx
+++ b/support-frontend/assets/components/footerCompliant/containers/Content.jsx
@@ -9,6 +9,7 @@ import { brand } from '@guardian/src-foundations/palette';
 import { space } from '@guardian/src-foundations';
 
 type PropTypes = {|
+  className: string,
   paddingTop: boolean,
   border: boolean,
   children: Node,
@@ -19,7 +20,7 @@ const paddingStyle = css`
 `;
 
 const borderStyle = css`
-  ${from.leftCol} {
+  ${from.tablet} {
     border-left: 1px solid ${brand[600]}; border-right: 1px solid ${brand[600]};
   }
 `;
@@ -34,9 +35,13 @@ const contentStyle = css`
   border-bottom: 1px solid ${brand[600]};
 `;
 
-export function Content({ border, paddingTop, children }: PropTypes) {
+export function Content({
+  className, border, paddingTop, children,
+}: PropTypes) {
   return (
-    <div css={[
+    <div
+      className={className}
+      css={[
       contentStyle,
       paddingTop ? paddingStyle : '',
       border ? borderStyle : '',

--- a/support-frontend/assets/components/footerCompliant/containers/Content.jsx
+++ b/support-frontend/assets/components/footerCompliant/containers/Content.jsx
@@ -17,7 +17,7 @@ type PropTypes = {|
 |}
 
 const paddingStyle = css`
-  padding-top: ${space[4]}px;
+  padding-top: ${space[2]}px;
 `;
 
 const contentStyle = css`
@@ -25,9 +25,12 @@ const contentStyle = css`
   display: flex;
   flex-grow: 1;
   flex-basis: ${space[24] * 10}px;
-  padding: 0 ${space[5]}px;
-  padding-bottom: ${space[4]}px;
-  border-bottom: 1px solid ${brand[600]};
+  padding: 0 ${space[5]}px ${space[4]}px;
+  /* padding-bottom: ${space[4]}px; */
+
+  .component-left-margin-section:not(:last-of-type) & {
+    border-bottom: 1px solid ${brand[600]};
+  }
 `;
 
 function getBorderStyling(centred = false) {

--- a/support-frontend/assets/components/footerCompliant/containers/FooterContent.jsx
+++ b/support-frontend/assets/components/footerCompliant/containers/FooterContent.jsx
@@ -7,16 +7,19 @@ import React, { type Node } from 'react';
 import { Content } from './Content';
 
 type PropTypes = {|
-  border: boolean,
-  paddingTop: boolean,
+  centred?: boolean,
+  border?: boolean,
+  paddingTop?: boolean,
   children: Node
 |}
 
-function FooterContent({ border, paddingTop, children }: PropTypes) {
+function FooterContent({
+  centred, border, paddingTop, children,
+}: PropTypes) {
   return (
     <div className="component-left-margin-section">
       <div className="component-left-margin-section__content">
-        <Content className="component-content__content" border={border} paddingTop={paddingTop}>
+        <Content className="component-content__content" centred={centred} border={border} paddingTop={paddingTop}>
           {children}
         </Content>
       </div>
@@ -25,6 +28,7 @@ function FooterContent({ border, paddingTop, children }: PropTypes) {
 }
 
 FooterContent.defaultProps = {
+  centred: false,
   border: false,
   paddingTop: false,
 };

--- a/support-frontend/assets/components/footerCompliant/containers/FooterContent.jsx
+++ b/support-frontend/assets/components/footerCompliant/containers/FooterContent.jsx
@@ -3,7 +3,6 @@
 // ----- Imports ----- //
 
 import React, { type Node } from 'react';
-// import { WithMargins } from './WithMargins';
 import { Content } from './Content';
 
 type PropTypes = {|

--- a/support-frontend/assets/components/footerCompliant/containers/FooterContent.jsx
+++ b/support-frontend/assets/components/footerCompliant/containers/FooterContent.jsx
@@ -3,7 +3,7 @@
 // ----- Imports ----- //
 
 import React, { type Node } from 'react';
-import { WithMargins } from './WithMargins';
+// import { WithMargins } from './WithMargins';
 import { Content } from './Content';
 
 type PropTypes = {|
@@ -14,11 +14,13 @@ type PropTypes = {|
 
 function FooterContent({ border, paddingTop, children }: PropTypes) {
   return (
-    <WithMargins before after>
-      <Content border={border} paddingTop={paddingTop}>
-        {children}
-      </Content>
-    </WithMargins>
+    <div className="component-left-margin-section">
+      <div className="component-left-margin-section__content">
+        <Content className="component-content__content" border={border} paddingTop={paddingTop}>
+          {children}
+        </Content>
+      </div>
+    </div>
   );
 }
 

--- a/support-frontend/assets/components/footerCompliant/containers/FooterContent.jsx
+++ b/support-frontend/assets/components/footerCompliant/containers/FooterContent.jsx
@@ -6,19 +6,21 @@ import React, { type Node } from 'react';
 import { Content } from './Content';
 
 type PropTypes = {|
-  centred?: boolean,
-  border?: boolean,
-  paddingTop?: boolean,
+  appearance: {
+    centred?: boolean,
+    border?: boolean,
+    paddingTop?: boolean,
+  },
   children: Node
 |}
 
 function FooterContent({
-  centred, border, paddingTop, children,
+  appearance, children,
 }: PropTypes) {
   return (
     <div className="component-left-margin-section">
       <div className="component-left-margin-section__content">
-        <Content className="component-content__content" centred={centred} border={border} paddingTop={paddingTop}>
+        <Content className="component-content__content" appearance={appearance}>
           {children}
         </Content>
       </div>
@@ -27,9 +29,11 @@ function FooterContent({
 }
 
 FooterContent.defaultProps = {
-  centred: false,
-  border: false,
-  paddingTop: false,
+  appearance: {
+    centred: false,
+    border: false,
+    paddingTop: false,
+  },
 };
 
 export default FooterContent;

--- a/support-frontend/assets/components/footerCompliant/footerStyles.js
+++ b/support-frontend/assets/components/footerCompliant/footerStyles.js
@@ -12,7 +12,8 @@ export const componentFooter = css`
   font-weight: 400;
   color: ${neutral[100]};
 
-  /* TODO: Check if we can remove this; depends on styles applied to the legal text passed in */
+  /* TODO: Check if we can remove this; depends on styles applied to the legal text passed in
+    Preferably switch to the Link component in Source for all links- current display property means we can't use it as of 2.0 */
   a {
     color: ${brandText.anchorPrimary};
     :hover {
@@ -32,13 +33,16 @@ export const copyright = css`
 export const linksList = css`
   width: 100%;
   list-style: none;
-  columns: 2;
-  column-rule: 1px solid ${brand[600]};
-  column-gap: ${space[12]}px;
+  display: grid;
+  grid-column-gap: ${space[5]}px;
+  grid-template: repeat(2, 1fr) / repeat(2, 1fr);
+  grid-auto-flow: column;
+
+  ${until.tablet} {
+    padding-bottom: ${space[9]}px;
+  }
 
   ${from.tablet} {
-    columns: none;
-    column-gap: 0;
     display: flex;
   }
 `;
@@ -47,8 +51,11 @@ export const link = css`
   padding: ${space[2]}px ${space[1]}px;
 
   ${until.tablet} {
-    &:nth-of-type(2n) {
-      padding-bottom: ${space[9]}px;
+    /* Select only the first two elements
+    https://css-tricks.com/useful-nth-child-recipies/#select-only-the-first-five */
+    &:nth-of-type(-n+2) {
+      padding-right: ${space[5]}px;
+      border-right: 1px solid ${brand[600]};
     }
   }
 

--- a/support-frontend/assets/components/footerCompliant/footerStyles.js
+++ b/support-frontend/assets/components/footerCompliant/footerStyles.js
@@ -7,6 +7,10 @@ import { from, until } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
 
 export const componentFooter = css`
+  &, & *, & *:before, & *:after {
+    box-sizing: border-box;
+  }
+
   background-color: ${brandBackground.primary};
   ${textSans.small()};
   font-weight: 400;
@@ -24,9 +28,9 @@ export const componentFooter = css`
 `;
 
 export const copyright = css`
-  font-size: 12px;
+  font-size: ${textSans.xsmall()};
   ${until.tablet} {
-    padding-top: ${space[3]}px;
+    padding-top: ${space[5]}px;
   }
 `;
 
@@ -37,10 +41,7 @@ export const linksList = css`
   grid-column-gap: ${space[5]}px;
   grid-template: repeat(2, 1fr) / repeat(2, 1fr);
   grid-auto-flow: column;
-
-  ${until.tablet} {
-    padding-bottom: ${space[9]}px;
-  }
+  padding-bottom: ${space[1]}px;
 
   ${from.tablet} {
     display: flex;
@@ -77,7 +78,7 @@ export const link = css`
 export const backToTopLink = css`
   background-color: ${brandBackground.primary};
   position: absolute;
-  padding: ${space[1]}px;
+  padding: 0 ${space[1]}px;
   right: ${space[2]}px;
   top: 0;
   transform: translateY(-50%);

--- a/support-frontend/assets/components/footerCompliant/footerStyles.js
+++ b/support-frontend/assets/components/footerCompliant/footerStyles.js
@@ -44,6 +44,7 @@ export const linksList = css`
 
   ${from.tablet} {
     display: flex;
+    grid-column-gap: 0;
   }
 `;
 

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/collectionTab.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/collectionTab.jsx
@@ -71,7 +71,7 @@ const CollectionTab = ({ getRef, setTabAction, selectedTab }: ContentTabPropType
   <div className="paper-subscription-landing-content__focusable" tabIndex={-1} ref={(r) => { getRef(r); }}>
     <ContentVoucherFaqBlock />
     <ContentForm selectedTab={selectedTab} setTabAction={setTabAction} title="Pick your voucher subscription package below" />
-    <ContentHelpBlock
+    {/* <ContentHelpBlock
       faqLink={
         <a
           href="https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions"
@@ -87,7 +87,7 @@ const CollectionTab = ({ getRef, setTabAction, selectedTab }: ContentTabPropType
         >0330 333 6767
         </a>
       }
-    />
+    /> */}
   </div>
 );
 export default CollectionTab;

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/collectionTab.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/collectionTab.jsx
@@ -7,7 +7,6 @@ import React from 'react';
 import Content from 'components/content/content';
 import Text from 'components/text/text';
 import GridImage from 'components/gridImage/gridImage';
-// import { sendClickedEvent } from 'helpers/tracking/clickTracking';
 import { paperHasDeliveryEnabled } from 'helpers/subscriptions';
 
 import { ContentForm, type ContentTabPropTypes } from './helpers';

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/collectionTab.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/collectionTab.jsx
@@ -71,23 +71,6 @@ const CollectionTab = ({ getRef, setTabAction, selectedTab }: ContentTabPropType
   <div className="paper-subscription-landing-content__focusable" tabIndex={-1} ref={(r) => { getRef(r); }}>
     <ContentVoucherFaqBlock />
     <ContentForm selectedTab={selectedTab} setTabAction={setTabAction} title="Pick your voucher subscription package below" />
-    {/* <ContentHelpBlock
-      faqLink={
-        <a
-          href="https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions"
-          onClick={sendClickedEvent('paper_subscription_collection_page-subscription_faq_link')}
-        >
-        Subscriptions FAQs
-        </a>
-      }
-      telephoneLink={
-        <a
-          href="tel:+4403303336767"
-          onClick={sendClickedEvent('paper_subscription_collection_page-telephone_link')}
-        >0330 333 6767
-        </a>
-      }
-    /> */}
   </div>
 );
 export default CollectionTab;

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/collectionTab.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/collectionTab.jsx
@@ -7,10 +7,10 @@ import React from 'react';
 import Content from 'components/content/content';
 import Text from 'components/text/text';
 import GridImage from 'components/gridImage/gridImage';
-import { sendClickedEvent } from 'helpers/tracking/clickTracking';
+// import { sendClickedEvent } from 'helpers/tracking/clickTracking';
 import { paperHasDeliveryEnabled } from 'helpers/subscriptions';
 
-import { ContentHelpBlock, ContentForm, type ContentTabPropTypes } from './helpers';
+import { ContentForm, type ContentTabPropTypes } from './helpers';
 import { Accordion, AccordionRow } from '@guardian/src-accordion';
 import { css } from '@emotion/core';
 import { neutral } from '@guardian/src-foundations/palette';

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/deliveryTab.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/deliveryTab.jsx
@@ -6,13 +6,10 @@ import React from 'react';
 import Content from 'components/content/content';
 import Text from 'components/text/text';
 import GridImage from 'components/gridImage/gridImage';
-import { sendClickedEvent } from 'helpers/tracking/clickTracking';
-
 import { setTab } from '../../paperSubscriptionLandingPageActions';
 
 import {
   ContentForm,
-  ContentHelpBlock,
   type ContentTabPropTypes,
   LinkTo,
 } from './helpers';
@@ -95,24 +92,6 @@ const DeliveryTab = ({
       setTabAction={setTabAction}
       title="Pick your home delivery subscription package below"
       useDigitalVoucher={useDigitalVoucher}
-    />
-    <ContentHelpBlock
-      faqLink={
-        <a
-          href="https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions"
-          onClick={sendClickedEvent('paper_subscription_delivery_page-subscription_faq_link')}
-        >
-        Subscriptions FAQs
-        </a>
-      }
-      telephoneLink={
-        <a
-          href="tel:+4403303336767" // yes, we're using a phone number as a link
-          onClick={sendClickedEvent('paper_subscription_delivery_page-telephone_link')}
-        >
-          0330 333 6767
-        </a>
-      }
     />
   </div>
 );

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/subsCardTab.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/subsCardTab.jsx
@@ -7,7 +7,6 @@ import React from 'react';
 import Content from 'components/content/content';
 import Text from 'components/text/text';
 import GridImage from 'components/gridImage/gridImage';
-import { sendClickedEvent } from 'helpers/tracking/clickTracking';
 import { paperHasDeliveryEnabled } from 'helpers/subscriptions';
 import { Accordion, AccordionRow } from '@guardian/src-accordion';
 import { css } from '@emotion/core';
@@ -15,7 +14,7 @@ import { neutral } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 import { space } from '@guardian/src-foundations';
 
-import { ContentHelpBlock, ContentForm, type ContentTabPropTypes } from './helpers';
+import { ContentForm, type ContentTabPropTypes } from './helpers';
 
 const accordionContainer = css`
   background-color: ${neutral['97']};
@@ -75,23 +74,6 @@ const SubscriptionCardTab = ({ getRef, setTabAction, selectedTab }: ContentTabPr
   <div className="paper-subscription-landing-content__focusable" tabIndex={-1} ref={(r) => { getRef(r); }}>
     <SubsCardFaqBlock />
     <ContentForm selectedTab={selectedTab} setTabAction={setTabAction} title="Pick your subscription package below" />
-    <ContentHelpBlock
-      faqLink={
-        <a
-          href="https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions"
-          onClick={sendClickedEvent('paper_subscription_collection_page-subscription_faq_link')}
-        >
-        Subscriptions FAQs
-        </a>
-      }
-      telephoneLink={
-        <a
-          href="tel:+4403303336767"
-          onClick={sendClickedEvent('paper_subscription_collection_page-telephone_link')}
-        >0330 333 6767
-        </a>
-      }
-    />
   </div>
 );
 export default SubscriptionCardTab;

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
@@ -39,13 +39,18 @@ const store = pageInit(() => reducer(fulfilment), true);
 const state = store.getState();
 const { useDigitalVoucher } = state.common.settings;
 
+const paperSubsFooter = (
+  <Footer privacyPolicy faqsLink="https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions">
+    <p>For full Guardian and Observer voucher and home delivery terms and conditions, see <a target="_blank" rel="noopener noreferrer" href="https://www.theguardian.com/subscriber-direct/subscription-terms-and-conditions">here</a>.</p>
+  </Footer>);
+
 // ----- Render ----- //
 
 const content = (
   <Provider store={store}>
     <Page
       header={<Header countryGroupId={GBPCountries} />}
-      footer={<Footer privacyPolicy />}
+      footer={paperSubsFooter}
     >
       <CampaignHeader />
       {paperHasDeliveryEnabled() &&

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
@@ -7,7 +7,7 @@ import { Provider } from 'react-redux';
 
 import Page from 'components/page/page';
 import Header from 'components/headers/header/header';
-import Footer from 'components/footer/footer';
+import Footer from 'components/footerCompliant/Footer';
 import Content from 'components/content/content';
 import Text, { LargeParagraph } from 'components/text/text';
 
@@ -45,7 +45,7 @@ const content = (
   <Provider store={store}>
     <Page
       header={<Header countryGroupId={GBPCountries} />}
-      footer={<Footer />}
+      footer={<Footer privacyPolicy />}
     >
       <CampaignHeader />
       {paperHasDeliveryEnabled() &&

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
@@ -40,9 +40,10 @@ const state = store.getState();
 const { useDigitalVoucher } = state.common.settings;
 
 const paperSubsFooter = (
-  <Footer privacyPolicy faqsLink="https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions">
-    <p>For full Guardian and Observer voucher and home delivery terms and conditions, see <a target="_blank" rel="noopener noreferrer" href="https://www.theguardian.com/subscriber-direct/subscription-terms-and-conditions">here</a>.</p>
-  </Footer>);
+  <Footer
+    faqsLink="https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions"
+    termsConditionsLink="https://www.theguardian.com/subscriber-direct/subscription-terms-and-conditions"
+  />);
 
 // ----- Render ----- //
 

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
@@ -47,7 +47,7 @@ const content = (
     <Page
       header={<Header />}
       footer={
-        <FooterContainer faqsLink="https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions" centred disclaimer privacyPolicy />
+        <FooterContainer faqsLink="https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions" centred privacyPolicy />
       }
     >
       <SubscriptionLandingContent />

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
@@ -47,7 +47,7 @@ const content = (
     <Page
       header={<Header />}
       footer={
-        <FooterContainer faqsLink="https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions" centred privacyPolicy />
+        <FooterContainer faqsLink="https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions" centred />
       }
     >
       <SubscriptionLandingContent />

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
@@ -6,7 +6,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 
 import Page from 'components/page/page';
-import FooterContainer from 'components/footer/footerContainer';
+import FooterContainer from 'components/footerCompliant/footerContainer';
 import { detect, type CountryGroupId, AUDCountries, Canada, EURCountries, GBPCountries, International, NZDCountries, UnitedStates } from 'helpers/internationalisation/countryGroup';
 import headerWithCountrySwitcherContainer from 'components/headers/header/headerWithCountrySwitcher';
 

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
@@ -46,7 +46,9 @@ const content = (
   <Provider store={store}>
     <Page
       header={<Header />}
-      footer={<FooterContainer disclaimer privacyPolicy />}
+      footer={
+        <FooterContainer faqsLink="https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions" centred disclaimer privacyPolicy />
+      }
     >
       <SubscriptionLandingContent />
       <ConsentBanner />

--- a/support-frontend/assets/stylesheets/skeleton/reset-src.scss
+++ b/support-frontend/assets/stylesheets/skeleton/reset-src.scss
@@ -21,6 +21,7 @@ time, mark, audio, video {
   font-size: 100%;
   font: inherit;
   vertical-align: baseline;
+  box-sizing: border-box;
 }
 // HTML5 display-role reset for older browsers
 article, aside, details, figcaption, figure,

--- a/support-frontend/assets/stylesheets/skeleton/reset-src.scss
+++ b/support-frontend/assets/stylesheets/skeleton/reset-src.scss
@@ -21,7 +21,6 @@ time, mark, audio, video {
   font-size: 100%;
   font: inherit;
   vertical-align: baseline;
-  box-sizing: border-box;
 }
 // HTML5 display-role reset for older browsers
 article, aside, details, figcaption, figure,


### PR DESCRIPTION
## Why are you doing this?

Adding the new footer to a page with a centred layout, and a page with a left column layout, for design/product review before rolling it out onto other pages.

[**Trello Card**](https://trello.com/c/m1SSOQiq)

## Changes

* Added the new footer component to subscriptions and print subs landing pages
* Adjusted styling on the footer component to account for existing layout needs

## Screenshots

(Upddated 7/8/20)

### Subscriptions landing page

**Mobile**

![Screenshot 2020-08-07 at 10 46 25](https://user-images.githubusercontent.com/29146931/89637920-e5355280-d8a2-11ea-8b41-367e1636a84b.png)

**Tablet (vertical)**

![Screenshot 2020-08-07 at 10 51 43](https://user-images.githubusercontent.com/29146931/89637952-f0887e00-d8a2-11ea-885d-105fde26c7cd.png)

**Tablet (horizontal)**

![Screenshot 2020-08-07 at 10 51 59](https://user-images.githubusercontent.com/29146931/89637980-f9794f80-d8a2-11ea-9ace-5c90b39aa895.png)

**Desktop**

![Screenshot 2020-08-07 at 10 45 13](https://user-images.githubusercontent.com/29146931/89638000-0138f400-d8a3-11ea-952d-73d06acd83e7.png)

### Paper subs landing page

**Mobile**

![Screenshot 2020-08-07 at 10 27 18](https://user-images.githubusercontent.com/29146931/89638027-0c8c1f80-d8a3-11ea-9bf8-6e2f6f389ff0.png)

**Tablet (vertical)**

![Screenshot 2020-08-07 at 10 28 36](https://user-images.githubusercontent.com/29146931/89638056-16ae1e00-d8a3-11ea-9253-2a111bcb3218.png)

**Tablet (horizontal)**

![Screenshot 2020-08-07 at 10 29 14](https://user-images.githubusercontent.com/29146931/89638084-1f9eef80-d8a3-11ea-9834-eadc8229c894.png)

**Desktop**

![Screenshot 2020-08-07 at 10 23 48](https://user-images.githubusercontent.com/29146931/89638122-2f1e3880-d8a3-11ea-8096-7690769bc761.png)
