### PR TITLE
Add ccpaEnabled switch to Switches.scala

### DIFF
--- a/support-frontend/app/admin/settings/Switches.scala
+++ b/support-frontend/app/admin/settings/Switches.scala
@@ -9,7 +9,8 @@ case class Switches(
   useDotcomContactPage: Option[SwitchState],
   enableRecaptchaBackend: SwitchState,
   enableRecaptchaFrontend: SwitchState,
-  experiments: Map[String, ExperimentSwitch]
+  experiments: Map[String, ExperimentSwitch],
+  ccpaEnabled: SwitchState
 )
 
 object Switches {

--- a/support-frontend/test/codecs/CirceDecodersTest.scala
+++ b/support-frontend/test/codecs/CirceDecodersTest.scala
@@ -121,7 +121,8 @@ class CirceDecodersTest extends AnyWordSpec with Matchers {
           |    },
           |    "useDotcomContactPage": "Off",
           |    "enableRecaptchaFrontend": "Off",
-          |    "enableRecaptchaBackend": "Off"
+          |    "enableRecaptchaBackend": "Off",
+          |    "ccpaEnabled": "Off"
           |  },
           |  "amounts": {
           |    "GBPCountries": {
@@ -291,7 +292,8 @@ class CirceDecodersTest extends AnyWordSpec with Matchers {
           ),
           useDotcomContactPage = Some(Off),
           enableRecaptchaBackend = Off,
-          enableRecaptchaFrontend = Off
+          enableRecaptchaFrontend = Off,
+          ccpaEnabled = Off
         ),
         amountsRegions,
         contributionTypes,

--- a/support-frontend/test/controllers/SubscriptionsTest.scala
+++ b/support-frontend/test/controllers/SubscriptionsTest.scala
@@ -73,7 +73,8 @@ class SubscriptionsTest extends AnyWordSpec with Matchers with TestCSRFComponent
         recurringPaymentMethods = PaymentMethodsSwitch(On, On, On, On, Some(On), Some(On), Some(On), None),
         experiments = Map.empty, useDotcomContactPage = Some(SwitchState.Off),
         enableRecaptchaBackend = Off,
-        enableRecaptchaFrontend = Off
+        enableRecaptchaFrontend = Off,
+        ccpaEnabled = Off
       ),
       AmountsRegions(amounts, amounts, amounts, amounts, amounts, amounts, amounts),
       ContributionTypes(Nil, Nil, Nil, Nil, Nil, Nil, Nil),


### PR DESCRIPTION
## Why are you doing this?

Add `ccpaEnabled` switch to `Switches.scala` so it gets surfaced on `window.guardian.settings.switches`.
