### PR TITLE
Don't show CCPA CMP if isPostDeployUser

### DIFF
--- a/support-frontend/assets/helpers/page/page.js
+++ b/support-frontend/assets/helpers/page/page.js
@@ -44,6 +44,7 @@ import { getSettings } from 'helpers/globals';
 import { doNotTrack } from 'helpers/tracking/doNotTrack';
 import { ccpaEnabled } from 'helpers/tracking/ccpa';
 import { getGlobal } from 'helpers/globals';
+import { isPostDeployUser } from 'helpers/user/user';
 
 if (process.env.NODE_ENV === 'DEV') {
   // $FlowIgnore
@@ -138,7 +139,7 @@ function init<S, A>(
      * on condition we're not server side rendering (ssr) the page.
      * @guardian/consent-management-platform breaks ssr otherwise.
      */
-    if (!getGlobal('ssr') && ccpaEnabled()) {
+    if (!getGlobal('ssr') && ccpaEnabled() && !isPostDeployUser()) {
       import('@guardian/consent-management-platform').then((cmp) => {
         cmp.init({
           useCcpa: true,


### PR DESCRIPTION
## Why are you doing this?

Don't show the CCPA CMP if `isPostDeployUser`. We do this for the old-CMP: https://github.com/guardian/support-frontend/blob/master/support-frontend/assets/components/consentBanner/consentBanner.jsx#L37

This is because the CCPA CMP intercepts the click event during the test:

<img width="949" alt="Screenshot 2020-08-05 at 16 16 36" src="https://user-images.githubusercontent.com/1590704/89430832-11cc5b80-d737-11ea-8322-73c3a1b0033e.png">
