### PR TITLE
scroll to element on page load

### DIFF
--- a/support-frontend/assets/components/page/page.jsx
+++ b/support-frontend/assets/components/page/page.jsx
@@ -1,8 +1,8 @@
 // @flow
 
 // ----- Imports ----- //
-
-import React, { type Node } from 'react';
+// $FlowIgnore - required for hooks
+import React, { type Node, useEffect } from 'react';
 
 import { classNameWithModifiers } from 'helpers/utilities';
 
@@ -31,7 +31,7 @@ export default function Page(props: PropTypes) {
     </div>
   ) : null;
 
-  React.useEffect(() => {
+  useEffect(() => {
     requestAnimationFrame(() => {
       if (window.location.hash) {
         const hashElement = document.getElementById(window.location.hash.substr(1));

--- a/support-frontend/assets/components/page/page.jsx
+++ b/support-frontend/assets/components/page/page.jsx
@@ -31,14 +31,14 @@ export default function Page(props: PropTypes) {
     </div>
   ) : null;
 
-    React.useEffect(() => {
-      // setTimeout(() => {
-        if (window.location.hash) {
-          const hashElement = document.getElementById(window.location.hash.substr(1));
-          if (hashElement) { hashElement.scrollIntoView(); }
-        }
-      // }, 1);
-    }, []);
+  React.useEffect(() => {
+    requestAnimationFrame(() => {
+      if (window.location.hash) {
+        const hashElement = document.getElementById(window.location.hash.substr(1));
+        if (hashElement) { hashElement.scrollIntoView(); }
+      }
+    });
+  }, []);
 
   return (
     <div id={props.id} className={classNameWithModifiers('gu-content', props.classModifiers)}>

--- a/support-frontend/assets/components/page/page.jsx
+++ b/support-frontend/assets/components/page/page.jsx
@@ -31,6 +31,15 @@ export default function Page(props: PropTypes) {
     </div>
   ) : null;
 
+    React.useEffect(() => {
+      // setTimeout(() => {
+        if (window.location.hash) {
+          const hashElement = document.getElementById(window.location.hash.substr(1));
+          if (hashElement) { hashElement.scrollIntoView(); }
+        }
+      // }, 1);
+    }, []);
+
   return (
     <div id={props.id} className={classNameWithModifiers('gu-content', props.classModifiers)}>
       <TimeTravelBanner />

--- a/support-frontend/assets/helpers/render.js
+++ b/support-frontend/assets/helpers/render.js
@@ -60,6 +60,12 @@ const renderPage = (content: Object, id: string, callBack?: () => void) => {
       } else {
         ReactDOM.render(content, element, callBack);
       }
+      setTimeout(function () {
+        if (window.location.hash) {
+          const hashElement = document.getElementById(window.location.hash.substr(1));
+          hashElement && hashElement.scrollIntoView();
+        }
+      }, 1000);
     } catch (e) {
       renderError(e, id);
     }

--- a/support-frontend/assets/helpers/render.js
+++ b/support-frontend/assets/helpers/render.js
@@ -60,10 +60,10 @@ const renderPage = (content: Object, id: string, callBack?: () => void) => {
       } else {
         ReactDOM.render(content, element, callBack);
       }
-      setTimeout(function () {
+      setTimeout(() => {
         if (window.location.hash) {
           const hashElement = document.getElementById(window.location.hash.substr(1));
-          hashElement && hashElement.scrollIntoView();
+          if (hashElement) { hashElement.scrollIntoView(); }
         }
       }, 1000);
     } catch (e) {

--- a/support-frontend/assets/helpers/render.js
+++ b/support-frontend/assets/helpers/render.js
@@ -60,12 +60,6 @@ const renderPage = (content: Object, id: string, callBack?: () => void) => {
       } else {
         ReactDOM.render(content, element, callBack);
       }
-      setTimeout(() => {
-        if (window.location.hash) {
-          const hashElement = document.getElementById(window.location.hash.substr(1));
-          if (hashElement) { hashElement.scrollIntoView(); }
-        }
-      }, 1000);
     } catch (e) {
       renderError(e, id);
     }

--- a/support-frontend/assets/pages/digital-subscription-landing/components/cta.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/cta.jsx
@@ -7,7 +7,7 @@ import PaymentSelection
 import './digitalSubscriptionLanding.scss';
 
 const CallToAction = () => (
-  <div className="call-to-action__container">
+  <div id="subscribe" className="call-to-action__container">
     <div className="hope-is-power--centered">
       <h2>Choose one of our special offers and subscribe today</h2>
       <h3>After your <strong>14-day free trial</strong>, your


### PR DESCRIPTION
## Why are you doing this?

banner acquisition optimisation team want to be able to link people straight to the CTA once they have read the epic, rather than dropping them at the top of the landing page.  This will prove whether that is why people are dropping off at that stage because they dont know what to click then.

[**Trello Card**](https://trello.com/c/oadRglcp/3240-anchor-text-for-ds-landing-page-epic-test)

This code has been implemented in useEffect.  a requestAnimationFrame is needed to get the scroll to work properly, otherwise it doesn't scroll far enough.

## Changes

* add id to the container div
* add scroll code to the useEffect of the central page component

## Screenshots
see comments below