### PR TITLE
override jackson-databind version in module-aws

### DIFF
--- a/support-modules/aws/build.sbt
+++ b/support-modules/aws/build.sbt
@@ -1,4 +1,4 @@
-import LibraryVersions.awsClientVersion
+import LibraryVersions._
 
 name := "module-aws"
 
@@ -8,3 +8,5 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-s3" % awsClientVersion,
 )
+
+dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % jacksonVersion


### PR DESCRIPTION
snyk has flagged this, so we need to override the dependency version