### PR TITLE
Landing page retention A/B test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -7,6 +7,8 @@ import { USV1, AusAmounts, UkAmountsV1 } from './data/testAmountsData';
 const usOnlyLandingPage = '/us/contribute(/.*)?$';
 const auOnlyLandingPage = '/au/contribute(/.*)?$';
 const ukOnlyLandingPage = '/uk/contribute(/.*)?$';
+// TODO: replace this with correct regex
+const allBarUkLandingPages = '/us/contribute(/.*)?$';
 const allLandingPages = '/??/contribute(/.*)?$';
 export const subsShowcaseAndDigiSubPages = '(/??/subscribe(\\?.*)?$|/??/subscribe/digital(\\?.*)?$)';
 
@@ -100,5 +102,33 @@ export const tests: Tests = {
     referrerControlled: false,
     targetPage: allLandingPages,
     seed: 1,
+  },
+
+  landingPageRetentionR1: {
+    type: 'OTHER',
+    variants: [
+      {
+        id: 'control',
+      },
+      {
+        id: 'variant 1',
+      },
+      {
+        id: 'variant 2',
+      },
+      {
+        id: 'variant 3',
+      },
+    ],
+    audiences: {
+      ALL: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: true,
+    referrerControlled: false,
+    targetPage: allBarUkLandingPages,
+    seed: 2,
   },
 };

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -7,8 +7,7 @@ import { USV1, AusAmounts, UkAmountsV1 } from './data/testAmountsData';
 const usOnlyLandingPage = '/us/contribute(/.*)?$';
 const auOnlyLandingPage = '/au/contribute(/.*)?$';
 const ukOnlyLandingPage = '/uk/contribute(/.*)?$';
-// TODO: replace this with correct regex
-const allBarUkLandingPages = '/us/contribute(/.*)?$';
+const allBarUkLandingPages = '/((?!uk).)*/contribute(/.*)?$';
 const allLandingPages = '/??/contribute(/.*)?$';
 export const subsShowcaseAndDigiSubPages = '(/??/subscribe(\\?.*)?$|/??/subscribe/digital(\\?.*)?$)';
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
@@ -18,6 +18,7 @@ import { trackComponentClick } from 'helpers/tracking/behaviour';
 import { formatAmount } from 'helpers/checkouts';
 import { selectAmount, updateOtherAmount } from '../contributionsLandingActions';
 import { type State } from '../contributionsLandingReducer';
+import ContributionChoicesHeader from './ContributionChoicesHeader';
 import ContributionTextInputDs from './ContributionTextInputDs';
 import ContributionAmountChoices from './ContributionAmountChoices';
 import ContributionAmountRecurringNotification from './ContributionAmountRecurringNotification';
@@ -38,6 +39,7 @@ type PropTypes = {|
   stripePaymentRequestButtonClicked: boolean,
   shouldShowRecurringNotification: boolean,
   shouldShowFrequencyButtons: boolean,
+  shouldShowChoiceHeader: boolean,
 |};
 
 
@@ -54,6 +56,7 @@ const mapStateToProps = (state: State) => ({
     state.page.form.stripePaymentRequestButtonData.REGULAR.stripePaymentRequestButtonClicked,
   shouldShowRecurringNotification: state.common.abParticipations.landingPageRetentionR1 === 'variant 1',
   shouldShowFrequencyButtons: state.common.abParticipations.landingPageRetentionR1 === 'variant 2',
+  shouldShowChoiceHeader: state.common.abParticipations.landingPageRetentionR1 === 'variant 3',
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -169,6 +172,10 @@ function withProps(props: PropTypes) {
   return (
     <fieldset className={classNameWithModifiers('form__radio-group', ['pills', 'contribution-amount'])}>
       <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>How much would you like to give?</legend>
+
+      {props.shouldShowChoiceHeader && (
+        <ContributionChoicesHeader>Amount</ContributionChoicesHeader>
+      )}
 
       <ContributionAmountChoices
         countryGroupId={props.countryGroupId}

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmountChoices.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmountChoices.jsx
@@ -1,0 +1,175 @@
+// @flow
+
+// ----- Imports ----- //
+import React from 'react';
+import { type SelectedAmounts } from 'helpers/contributions';
+import {
+  type Amount,
+  type ContributionType,
+} from 'helpers/contributions';
+import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import {
+  type IsoCurrency,
+  currencies,
+  spokenCurrencies,
+} from 'helpers/internationalisation/currency';
+import { formatAmount } from 'helpers/checkouts';
+import { ChoiceCardGroup, ChoiceCard } from '@guardian/src-choice-card';
+import ContributionAmountChoicesChoiceLabel from './ContributionAmountChoicesChoiceLabel';
+import { from, until } from '@guardian/src-foundations/mq';
+import { css } from '@emotion/core';
+
+const choiceCardGroupOverrides = css`
+  > div {
+    ${until.leftCol} {
+      flex-wrap: wrap;
+    }
+    margin-top: -8px;
+  }
+
+  > div > label {
+    ${from.tablet} {
+      max-width: 100px;
+    }
+    margin-top: 8px !important;
+  }
+`;
+
+const choiceCardGrid = css`
+  ${from.mobileLandscape} {
+    width: 100%;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-gap: 8px;
+  }
+`;
+
+type ContributionAmountChoicesProps = {|
+  countryGroupId: CountryGroupId,
+  currency: IsoCurrency,
+  contributionType: ContributionType,
+  validAmounts: Amount[],
+  showOther: boolean,
+  selectedAmounts: SelectedAmounts,
+  selectAmount: (
+    Amount | "other",
+    CountryGroupId,
+    ContributionType
+  ) => () => void,
+  shouldShowFrequencyButtons: boolean
+|};
+
+const isSelected = (
+  amount: Amount,
+  selectedAmounts: SelectedAmounts,
+  contributionType: ContributionType,
+) => {
+  if (selectedAmounts[contributionType]) {
+    return (
+      selectedAmounts[contributionType] !== 'other' &&
+      amount.value === selectedAmounts[contributionType].value
+    );
+  }
+  return amount.isDefault;
+};
+
+const ContributionAmountChoices = (props: ContributionAmountChoicesProps) =>
+  (props.shouldShowFrequencyButtons ? (
+    <ContributionAmountChoicesTwoColumnAfterMobile {...props} />
+  ) : (
+    <ContributionAmountChoicesDefault {...props} />
+  ));
+
+const ContributionAmountChoicesDefault = ({
+  validAmounts,
+  countryGroupId,
+  contributionType,
+  showOther,
+  selectAmount,
+  selectedAmounts,
+  currency,
+  shouldShowFrequencyButtons,
+}: ContributionAmountChoicesProps) => (
+  <ChoiceCardGroup name="amounts" css={choiceCardGroupOverrides}>
+    {validAmounts.map((amount: Amount) => (
+      <ChoiceCard
+        id={`contributionAmount-${amount.value}`}
+        name="contributionAmount"
+        value={amount.value}
+        checked={isSelected(amount, selectedAmounts, contributionType)}
+        onChange={selectAmount(amount, countryGroupId, contributionType)}
+        label={
+          <ContributionAmountChoicesChoiceLabel
+            formattedAmount={formatAmount(
+              currencies[currency],
+              spokenCurrencies[currency],
+              amount,
+              false,
+            )}
+            shouldShowFrequencyButtons={shouldShowFrequencyButtons}
+            contributionType={contributionType}
+          />
+        }
+      />
+    ))}
+    <ChoiceCard
+      id="contributionAmount-other"
+      name="contributionAmount"
+      value="other"
+      checked={showOther}
+      onChange={selectAmount('other', countryGroupId, contributionType)}
+      label="Other"
+    />
+  </ChoiceCardGroup>
+);
+
+const ContributionAmountChoicesTwoColumnAfterMobile = ({
+  validAmounts,
+  countryGroupId,
+  contributionType,
+  showOther,
+  selectAmount,
+  selectedAmounts,
+  currency,
+  shouldShowFrequencyButtons,
+}: ContributionAmountChoicesProps) => (
+  <ChoiceCardGroup name="amounts">
+    <div css={choiceCardGrid}>
+      {validAmounts.map((amount: Amount) => (
+        <div>
+          <ChoiceCard
+            id={`contributionAmount-${amount.value}`}
+            name="contributionAmount"
+            value={amount.value}
+            checked={isSelected(amount, selectedAmounts, contributionType)}
+            onChange={selectAmount(amount, countryGroupId, contributionType)}
+            label={
+              <ContributionAmountChoicesChoiceLabel
+                formattedAmount={formatAmount(
+                  currencies[currency],
+                  spokenCurrencies[currency],
+                  amount,
+                  false,
+                )}
+                shouldShowFrequencyButtons={shouldShowFrequencyButtons}
+                contributionType={contributionType}
+              />
+            }
+          />
+        </div>
+      ))}
+      <div>
+        <ChoiceCard
+          id="contributionAmount-other"
+          name="contributionAmount"
+          value="other"
+          checked={showOther}
+          onChange={selectAmount('other', countryGroupId, contributionType)}
+          label="Other"
+        />
+      </div>
+    </div>
+  </ChoiceCardGroup>
+);
+
+export default ContributionAmountChoices;

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmountChoicesChoiceLabel.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmountChoicesChoiceLabel.jsx
@@ -1,0 +1,35 @@
+// @flow
+
+import React from 'react';
+import { type ContributionType } from 'helpers/contributions';
+import { css } from '@emotion/core';
+
+type ContributionAmountLabelProps = {
+  formattedAmount: string,
+  shouldShowFrequencyButtons: boolean,
+  contributionType: ContributionType
+};
+
+const ContributionAmountChoicesChoiceLabel = ({
+  formattedAmount,
+  shouldShowFrequencyButtons,
+  contributionType,
+}: ContributionAmountLabelProps) => {
+  let frequencyLabel = '';
+  if (shouldShowFrequencyButtons) {
+    if (contributionType === 'MONTHLY') {
+      frequencyLabel = ' per month';
+    }
+    if (contributionType === 'ANNUAL') {
+      frequencyLabel = ' per year';
+    }
+  }
+
+  return (
+    <div css={css`white-space: nowrap`}>
+      {formattedAmount}{frequencyLabel}
+    </div>
+  );
+};
+
+export default ContributionAmountChoicesChoiceLabel;

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmountRecurringNotification.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmountRecurringNotification.jsx
@@ -1,0 +1,65 @@
+// @flow
+
+import React from 'react';
+import { type ContributionType } from 'helpers/contributions';
+import { textSans } from '@guardian/src-foundations/typography';
+import { brand } from '@guardian/src-foundations/palette';
+import { space } from '@guardian/src-foundations';
+import { SvgInfo } from '@guardian/src-icons';
+import { css } from '@emotion/core';
+
+type ContributionAmountLabelProps = {
+  formattedAmount: string,
+  contributionType: ContributionType
+};
+
+const container = css`
+  display: flex;
+  align-items: center;
+  margin-top: ${space[3]}px;
+  padding: ${space[1]}px ${space[3]}px;
+  ${textSans.medium()}
+  font-weight: bold;
+  color: ${brand[400]};
+  border: 4px solid ${brand[400]};
+  border-radius: 4px;
+
+  * + * {
+    margin-left: ${space[1]}px;
+  }
+`;
+
+const svgContainer = css`
+  width: 22px;
+  height: 22px;
+  display: flex;
+  svg {
+    fill: ${brand[400]};
+  }
+`;
+
+const ContributionAmountRecurringNotification = ({
+  formattedAmount,
+  contributionType,
+}: ContributionAmountLabelProps) => {
+  let frequency = '';
+  if (contributionType === 'MONTHLY') {
+    frequency = 'month';
+  }
+  if (contributionType === 'ANNUAL') {
+    frequency = 'year';
+  }
+
+  return (
+    <div css={container}>
+      <div css={svgContainer}>
+        <SvgInfo />
+      </div>
+      <div>
+        Every {frequency} you&apos;ll contribute {formattedAmount}.
+      </div>
+    </div>
+  );
+};
+
+export default ContributionAmountRecurringNotification;

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionChoicesHeader.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionChoicesHeader.jsx
@@ -1,0 +1,31 @@
+// @flow
+
+import * as React from 'react';
+import { headline } from '@guardian/src-foundations/typography';
+import { space } from '@guardian/src-foundations';
+import { from } from '@guardian/src-foundations/mq';
+import { css } from '@emotion/core';
+
+type ContributionAmountLabelProps = {
+  children: React.Node
+};
+
+const container = css`
+  margin-bottom: ${space[3]}px;
+  ${headline.xxxsmall()}
+  font-weight: bold;
+
+  ${from.desktop} {
+    font-size: 20px;
+  }
+`;
+
+const ContributionAmountRecurringNotification = ({
+  children,
+}: ContributionAmountLabelProps) => (
+  <div css={container} >
+    {children}
+  </div>
+);
+
+export default ContributionAmountRecurringNotification;

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
@@ -23,6 +23,7 @@ import type {
   ContributionTypeSetting,
 } from 'helpers/contributions';
 import { ChoiceCardGroup, ChoiceCard } from '@guardian/src-choice-card';
+import ContributionChoicesHeader from './ContributionChoicesHeader';
 
 // ----- Types ----- //
 
@@ -33,6 +34,7 @@ type PropTypes = {|
   switches: Switches,
   contributionTypes: ContributionTypes,
   onSelectContributionType: (ContributionType, Switches, IsoCountry, CountryGroupId) => void,
+  shouldShowChoiceHeader: boolean,
 |};
 
 const mapStateToProps = (state: State) => ({
@@ -41,6 +43,7 @@ const mapStateToProps = (state: State) => ({
   countryId: state.common.internationalisation.countryId,
   switches: state.common.settings.switches,
   contributionTypes: state.common.settings.contributionTypes,
+  shouldShowChoiceHeader: state.common.abParticipations.landingPageRetentionR1 === 'variant 3',
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -128,6 +131,10 @@ function withProps(props: PropTypes) {
   return (
     <fieldset className={classNameWithModifiers('form__radio-group', ['tabs', 'contribution-type'])}>
       <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>How often would you like to contribute?</legend>
+      {props.shouldShowChoiceHeader && (
+        <ContributionChoicesHeader>Frequency</ContributionChoicesHeader>
+      )}
+
       {renderChoiceCards()}
     </fieldset>
   );

--- a/support-frontend/assets/pages/contributions-landing/components/PaymentMethodSelector.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/PaymentMethodSelector.jsx
@@ -52,6 +52,7 @@ import SvgDirectDebitSymbolDs from 'components/svgs/directDebitSymbolDs';
 import SvgAmazonPayLogoDs from 'components/svgs/amazonPayLogoDs';
 import SvgNewCreditCardDs from 'components/svgs/newCreditCardDs';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import ContributionChoicesHeader from './ContributionChoicesHeader';
 
 // ----- Types ----- //
 
@@ -135,7 +136,7 @@ const getPaymentMethodLogoDs = (paymentMethod: PaymentMethod) => {
 
 const legend = (
   <div className="secure-transaction">
-    <legend id="payment_method" className="form__legend"><h3>Payment method</h3></legend>
+    <legend id="payment_method"><ContributionChoicesHeader>Payment Method</ContributionChoicesHeader></legend>
     <SecureTransactionIndicator modifierClasses={['middle']} />
   </div>
 );


### PR DESCRIPTION
## Why are you doing this?

Adds the landing page retention A/B test as per [this card](https://trello.com/c/fNGvyJYN/2210-ab-test-to-decrease-the-volume-of-cancelations-coming-from-people-picking-monthly-instead-of-single)

## Screenshots

control - mobile
<img width="403" alt="Screenshot 2020-08-11 at 09 21 49" src="https://user-images.githubusercontent.com/17720442/89875184-da393580-dbb4-11ea-80d8-5222ed6e4497.png">

control - desktop
<img width="942" alt="Screenshot 2020-08-11 at 09 23 56" src="https://user-images.githubusercontent.com/17720442/89875518-4156ea00-dbb5-11ea-8d99-7491dc207bbf.png">


variant 1 - mobile
<img width="403" alt="Screenshot 2020-08-11 at 09 22 09" src="https://user-images.githubusercontent.com/17720442/89875349-0d7bc480-dbb5-11ea-8d53-a5b03d3f31f9.png">

variant 1 - desktop
<img width="942" alt="Screenshot 2020-08-11 at 09 23 36" src="https://user-images.githubusercontent.com/17720442/89875566-516ec980-dbb5-11ea-9073-2c9c09837372.png">


variant 2 - mobile
<img width="416" alt="Screenshot 2020-08-10 at 16 03 23" src="https://user-images.githubusercontent.com/17720442/89875128-c2fa4800-dbb4-11ea-9cb1-f06fb646e23a.png">

variant 2 - desktop 
<img width="942" alt="Screenshot 2020-08-11 at 09 23 23" src="https://user-images.githubusercontent.com/17720442/89875633-68152080-dbb5-11ea-8c07-fa2454b45bf6.png">

variant 3 - mobile
<img width="403" alt="Screenshot 2020-08-11 at 09 22 38" src="https://user-images.githubusercontent.com/17720442/89875421-25534880-dbb5-11ea-9306-e0dc5ae2181c.png">

variant 3 - desktop
<img width="942" alt="Screenshot 2020-08-11 at 09 23 09" src="https://user-images.githubusercontent.com/17720442/89875682-75320f80-dbb5-11ea-8161-9f5f43042444.png">


