### PR TITLE
Digital Subscription gift checkout - server side work

### DIFF
--- a/support-frontend/test/utils/CheckoutValidationRulesTest.scala
+++ b/support-frontend/test/utils/CheckoutValidationRulesTest.scala
@@ -5,7 +5,7 @@ import com.gu.acquisition.model.{OphanIds, ReferrerAcquisitionData}
 import com.gu.i18n.Currency.GBP
 import com.gu.i18n.{Country, Currency}
 import com.gu.support.catalog.{Everyday, HomeDelivery}
-import com.gu.support.redemptions.{CorporateRedemption, RedemptionCode}
+import com.gu.support.redemptions.{RedemptionCode, RedemptionData}
 import com.gu.support.workers._
 import com.gu.support.zuora.api.ReaderType.Corporate
 import org.joda.time.LocalDate
@@ -141,7 +141,7 @@ class DigitalPackValidationTest extends AnyFlatSpec with Matchers {
   it should "succeed when there is a valid corporate sub" ignore {
     val corporateSub = validDigitalPackRequest.copy(
       product = DigitalPack(GBP, Monthly, Corporate),
-      paymentFields = Right(CorporateRedemption(RedemptionCode("test-code").right.get))
+      paymentFields = Right(RedemptionData(RedemptionCode("test-code").right.get))
     )
 
     DigitalPackValidation.passes(corporateSub) shouldBe true
@@ -187,7 +187,7 @@ class PaperValidationTest extends AnyFlatSpec with Matchers {
   }
 
   it should "not allow corporate redemptions for paper products" in {
-    val requestWithCorporateRedemption = validPaperRequest.copy(paymentFields = Right(CorporateRedemption(RedemptionCode("TEST-CODE").right.get)))
+    val requestWithCorporateRedemption = validPaperRequest.copy(paymentFields = Right(RedemptionData(RedemptionCode("TEST-CODE").right.get)))
     PaperValidation.passes(requestWithCorporateRedemption) shouldBe false
   }
 

--- a/support-models/src/main/scala/com/gu/support/redemptions/RedemptionData.scala
+++ b/support-models/src/main/scala/com/gu/support/redemptions/RedemptionData.scala
@@ -1,24 +1,11 @@
 package com.gu.support.redemptions
 
-import cats.syntax.functor._
 import com.gu.support.encoding.Codec
-import io.circe.syntax._
-import io.circe.{Decoder, Encoder}
 
-sealed abstract class RedemptionData(val redemptionCode: RedemptionCode)
+case class RedemptionData(redemptionCode: RedemptionCode)
 
-case class CorporateRedemption(override val redemptionCode: RedemptionCode) extends RedemptionData(redemptionCode)
 
 object RedemptionData {
   import Codec.deriveCodec
-  implicit val corporateCodec: Codec[CorporateRedemption] = deriveCodec
-
-  implicit val encoder: Encoder[RedemptionData] = Encoder.instance {
-    case c: CorporateRedemption => c.asJson
-  }
-
-  implicit val decoder: Decoder[RedemptionData] =
-    List[Decoder[RedemptionData]](
-      Decoder[CorporateRedemption].widen
-    ).reduceLeft(_ or _)
+  implicit val codec: Codec[RedemptionData] = deriveCodec
 }

--- a/support-services/src/main/scala/com/gu/support/redemption/GetCodeStatus.scala
+++ b/support-services/src/main/scala/com/gu/support/redemption/GetCodeStatus.scala
@@ -13,6 +13,7 @@ object GetCodeStatus {
   sealed abstract class RedemptionInvalid(val clientCode: String)
   case object NoSuchCode extends RedemptionInvalid("NO_SUCH_CODE")
   case object CodeAlreadyUsed extends RedemptionInvalid("CODE_ALREADY_USED")
+  case object InvalidReaderType extends RedemptionInvalid("INVALID_READER_TYPE")
 
   private def statusFromDynamoAttr(attrs: Map[String, DynamoLookup.DynamoValue]): Either[String, RedemptionTable.AvailableField] =
     for {

--- a/support-services/src/main/scala/com/gu/support/redemption/generator/GiftCodeGenerator.scala
+++ b/support-services/src/main/scala/com/gu/support/redemption/generator/GiftCodeGenerator.scala
@@ -28,11 +28,6 @@ object GiftDuration {
 
   case object Gift12Month extends GiftDuration("12")
 
-  def fromBillingPeriod = (billingPeriod: BillingPeriod) => billingPeriod match {
-    case Quarterly => Gift3Month
-    case Annual => Gift12Month
-  }
-
 }
 
 object CodeBuilder {

--- a/support-services/src/main/scala/com/gu/support/redemption/generator/GiftCodeGenerator.scala
+++ b/support-services/src/main/scala/com/gu/support/redemption/generator/GiftCodeGenerator.scala
@@ -3,6 +3,7 @@ package com.gu.support.redemption.generator
 import java.security.SecureRandom
 
 import com.gu.support.redemption.generator.CodeBuilder.GenerateGiftCode
+import com.gu.support.workers.{Annual, BillingPeriod, Quarterly}
 
 object GiftCodeGenerator {
 
@@ -26,6 +27,11 @@ object GiftDuration {
   case object Gift6Month extends GiftDuration("06")
 
   case object Gift12Month extends GiftDuration("12")
+
+  def fromBillingPeriod = (billingPeriod: BillingPeriod) => billingPeriod match {
+    case Quarterly => Gift3Month
+    case Annual => Gift12Month
+  }
 
 }
 

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -18,7 +18,7 @@ import com.gu.support.zuora.api.response._
 import com.gu.support.zuora.domain.DomainSubscription
 import com.gu.zuora.ZuoraSubscribeService
 import com.gu.zuora.subscriptionBuilders.ProductSubscriptionBuilders.buildContributionSubscription
-import com.gu.zuora.subscriptionBuilders.{DigitalSubscriptionBuilder, GuardianWeeklySubscriptionBuilder, PaperSubscriptionBuilder, ProductSubscriptionBuilders, SubscriptionPaymentCorporate, SubscriptionPaymentDirect}
+import com.gu.zuora.subscriptionBuilders.{DigitalSubscriptionBuilder, GuardianWeeklySubscriptionBuilder, PaperSubscriptionBuilder, ProductSubscriptionBuilders, SubscriptionRedemption, SubscriptionPurchase}
 import org.joda.time.{DateTime, DateTimeZone, LocalDate}
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -155,8 +155,8 @@ object CreateZuoraSubscription {
         d,
         state.requestId,
         state.paymentMethod match {
-          case Left(_: PaymentMethod) => SubscriptionPaymentDirect(config.digitalPack, state.promoCode, state.user.billingAddress.country, promotionService)
-          case Right(rd: RedemptionData) => SubscriptionPaymentCorporate(rd, getCodeStatus)
+          case Left(_: PaymentMethod) => SubscriptionPurchase(config.digitalPack, state.promoCode, state.user.billingAddress.country, promotionService)
+          case Right(rd: RedemptionData) => SubscriptionRedemption(rd, getCodeStatus)
         },
         environment,
         today

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -155,7 +155,13 @@ object CreateZuoraSubscription {
         d,
         state.requestId,
         state.paymentMethod match {
-          case Left(_: PaymentMethod) => SubscriptionPurchase(config.digitalPack, state.promoCode, state.user.billingAddress.country, promotionService)
+          case Left(_: PaymentMethod) => SubscriptionPurchase(
+            config.digitalPack,
+            state.promoCode,
+            state.product.billingPeriod,
+            state.user.billingAddress.country,
+            promotionService
+          )
           case Right(rd: RedemptionData) => SubscriptionRedemption(rd, getCodeStatus)
         },
         environment,

--- a/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilder.scala
@@ -12,6 +12,7 @@ import com.gu.support.redemption.GetCodeStatus
 import com.gu.support.redemptions.{CorporateRedemption, RedemptionData}
 import com.gu.support.workers.DigitalPack
 import com.gu.support.workers.ProductTypeRatePlans._
+import com.gu.support.zuora.api.ReaderType.Direct
 import com.gu.support.zuora.api.{ReaderType, Subscription, SubscriptionData}
 import com.gu.zuora.subscriptionBuilders.ProductSubscriptionBuilders.{applyPromoCode, buildProductSubscription, validateRatePlan}
 import org.joda.time.LocalDate
@@ -41,7 +42,10 @@ object DigitalSubscriptionBuilder {
     readerType: ReaderType,
     purchase: SubscriptionPurchase
   )(implicit ec: ExecutionContext): EitherT[Future, Either[PromoError, GetCodeStatus.RedemptionInvalid], SubscriptionData] = {
-    val delay = purchase.config.defaultFreeTrialPeriod + purchase.config.paymentGracePeriod
+    val delay = if(readerType == Direct)
+      purchase.config.defaultFreeTrialPeriod + purchase.config.paymentGracePeriod
+    else 0 // Gift purchases don't have a free trial period
+
     val contractAcceptanceDate = contractEffectiveDate.plusDays(delay)
 
     val subscriptionData = buildProductSubscription(

--- a/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilder.scala
@@ -89,14 +89,14 @@ object DigitalSubscriptionBuilder {
     EitherT.fromEither[Future](withPromoApplied.left.map(Left.apply))
   }
 
-  def fromBillingPeriod(billingPeriod: BillingPeriod): GiftDuration = billingPeriod match {
+  def toDuration(billingPeriod: BillingPeriod): GiftDuration = billingPeriod match {
     case Annual => Gift12Month
     case _ => Gift3Month
   }
 
   def addRedemptionCodeIfGift(readerType: ReaderType, billingPeriod: BillingPeriod, subscriptionData: SubscriptionData) = {
     if (readerType == Gift) {
-      val code = GiftCodeGenerator.randomGiftCodes.next().withDuration(fromBillingPeriod(billingPeriod))
+      val code = GiftCodeGenerator.randomGiftCodes.next().withDuration(toDuration(billingPeriod))
       subscriptionData.copy(
         subscription = subscriptionData.subscription.copy(redemptionCode = Some(code.value))
       )

--- a/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilder.scala
@@ -9,6 +9,7 @@ import com.gu.support.catalog.ProductRatePlanId
 import com.gu.support.config.{TouchPointEnvironment, ZuoraDigitalPackConfig}
 import com.gu.support.promotions.{PromoCode, PromoError, PromotionService}
 import com.gu.support.redemption.GetCodeStatus
+import com.gu.support.redemption.GetCodeStatus.{InvalidReaderType, RedemptionInvalid}
 import com.gu.support.redemptions.{RedemptionCode, RedemptionData}
 import com.gu.support.workers.DigitalPack
 import com.gu.support.workers.ProductTypeRatePlans._
@@ -35,7 +36,7 @@ case class SubscriptionRedemption(
 
 object DigitalSubscriptionBuilder {
 
-  type BuildResult = EitherT[Future, Either[PromoError, GetCodeStatus.RedemptionInvalid], SubscriptionData]
+  type BuildResult = EitherT[Future, Either[PromoError, RedemptionInvalid], SubscriptionData]
 
   def build(
     digitalPack: DigitalPack,
@@ -107,13 +108,8 @@ object DigitalSubscriptionBuilder {
         redemption.redemptionData.redemptionCode,
         redemption.getCodeStatus
       )
-      case _ => buildCorporateRedemption( //TODO: error
-        contractEffectiveDate,
-        productRatePlanId,
-        requestId,
-        redemption.redemptionData.redemptionCode,
-        redemption.getCodeStatus
-      )
+      case _ => val errorType: Either[PromoError, RedemptionInvalid] = Right(InvalidReaderType)
+        EitherT.leftT(errorType)
     }
 
   }

--- a/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/GuardianWeeklySubscriptionBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/GuardianWeeklySubscriptionBuilder.scala
@@ -5,13 +5,13 @@ import java.util.UUID
 import com.gu.i18n.Country
 import com.gu.support.config.TouchPointEnvironment
 import com.gu.support.promotions.{DefaultPromotions, PromoCode, PromoError, PromotionService}
-import com.gu.support.workers.{BillingPeriod, GuardianWeekly, SixWeekly}
-import com.gu.support.workers.exceptions.BadRequestException
-import com.gu.support.zuora.api.{ReaderType, SubscriptionData}
-import com.gu.zuora.subscriptionBuilders.ProductSubscriptionBuilders.{applyPromoCode, buildProductSubscription, validateRatePlan}
-import org.joda.time.{DateTimeZone, LocalDate}
-import com.gu.support.workers.ProductTypeRatePlans._
 import com.gu.support.workers.GuardianWeeklyExtensions._
+import com.gu.support.workers.ProductTypeRatePlans._
+import com.gu.support.workers.exceptions.BadRequestException
+import com.gu.support.workers.{BillingPeriod, GuardianWeekly, SixWeekly}
+import com.gu.support.zuora.api.{Day, Month, ReaderType, SubscriptionData}
+import com.gu.zuora.subscriptionBuilders.ProductSubscriptionBuilders.{applyPromoCode, buildProductSubscription, validateRatePlan}
+import org.joda.time.{DateTimeZone, Days, LocalDate}
 
 import scala.util.{Failure, Success, Try}
 
@@ -39,13 +39,20 @@ object GuardianWeeklySubscriptionBuilder {
       guardianWeekly.introductoryRatePlan(environment).map(_.id).getOrElse(recurringProductRatePlanId)
     } else recurringProductRatePlanId
 
+    val (initialTerm, autoRenew, initialTermPeriodType) = if (readerType == ReaderType.Gift)
+      (initialTermInDays(contractEffectiveDate, contractAcceptanceDate, guardianWeekly.billingPeriod.monthsInPeriod), false, Day)
+    else
+      (12, true, Month)
+
     val subscriptionData = buildProductSubscription(
       requestId,
       recurringProductRatePlanId,
       contractAcceptanceDate = contractAcceptanceDate,
       contractEffectiveDate = contractEffectiveDate,
       readerType = readerType,
-      initialTermMonths = guardianWeekly.billingPeriod.monthsInPeriod
+      autoRenew = autoRenew,
+      initialTerm = initialTerm,
+      initialTermPeriodType = initialTermPeriodType
     )
 
     applyPromoCode(promotionService, maybePromoCode, country, promotionProductRatePlanId, subscriptionData)
@@ -53,4 +60,9 @@ object GuardianWeeklySubscriptionBuilder {
 
   private[this] def isIntroductoryPromotion(billingPeriod: BillingPeriod, maybePromoCode: Option[PromoCode]) =
     maybePromoCode.contains(DefaultPromotions.GuardianWeekly.NonGift.sixForSix) && billingPeriod == SixWeekly
+
+  def initialTermInDays(contractEffectiveDate: LocalDate, contractAcceptanceDate: LocalDate, termLengthMonths: Int): Int = {
+    val termEnd = contractAcceptanceDate.plusMonths(termLengthMonths)
+    Days.daysBetween(contractEffectiveDate, termEnd).getDays
+  }
 }

--- a/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/GuardianWeeklySubscriptionBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/GuardianWeeklySubscriptionBuilder.scala
@@ -10,7 +10,7 @@ import com.gu.support.workers.ProductTypeRatePlans._
 import com.gu.support.workers.exceptions.BadRequestException
 import com.gu.support.workers.{BillingPeriod, GuardianWeekly, SixWeekly}
 import com.gu.support.zuora.api.{Day, Month, ReaderType, SubscriptionData}
-import com.gu.zuora.subscriptionBuilders.ProductSubscriptionBuilders.{applyPromoCode, buildProductSubscription, validateRatePlan}
+import com.gu.zuora.subscriptionBuilders.ProductSubscriptionBuilders.{applyPromoCodeIfPresent, buildProductSubscription, validateRatePlan}
 import org.joda.time.{DateTimeZone, Days, LocalDate}
 
 import scala.util.{Failure, Success, Try}
@@ -55,7 +55,7 @@ object GuardianWeeklySubscriptionBuilder {
       initialTermPeriodType = initialTermPeriodType
     )
 
-    applyPromoCode(promotionService, maybePromoCode, country, promotionProductRatePlanId, subscriptionData)
+    applyPromoCodeIfPresent(promotionService, maybePromoCode, country, promotionProductRatePlanId, subscriptionData)
   }
 
   private[this] def isIntroductoryPromotion(billingPeriod: BillingPeriod, maybePromoCode: Option[PromoCode]) =

--- a/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/PaperSubscriptionBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/PaperSubscriptionBuilder.scala
@@ -9,7 +9,7 @@ import com.gu.support.workers.Paper
 import com.gu.support.workers.exceptions.BadRequestException
 import com.gu.support.zuora.api.ReaderType.Direct
 import com.gu.support.zuora.api.SubscriptionData
-import com.gu.zuora.subscriptionBuilders.ProductSubscriptionBuilders.{applyPromoCode, buildProductSubscription, validateRatePlan}
+import com.gu.zuora.subscriptionBuilders.ProductSubscriptionBuilders.{applyPromoCodeIfPresent, buildProductSubscription, validateRatePlan}
 import org.joda.time.{DateTimeZone, LocalDate}
 import com.gu.support.workers.ProductTypeRatePlans._
 
@@ -43,6 +43,6 @@ object PaperSubscriptionBuilder {
       readerType = Direct
     )
 
-    applyPromoCode(promotionService, maybePromoCode, country, productRatePlanId, subscriptionData)
+    applyPromoCodeIfPresent(promotionService, maybePromoCode, country, productRatePlanId, subscriptionData)
   }
 }

--- a/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/ProductSubscriptionBuilders.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/ProductSubscriptionBuilders.scala
@@ -42,12 +42,14 @@ object ProductSubscriptionBuilders {
     contractEffectiveDate: LocalDate = LocalDate.now(DateTimeZone.UTC),
     contractAcceptanceDate: LocalDate = LocalDate.now(DateTimeZone.UTC),
     readerType: ReaderType,
-    initialTermMonths: Int = 12
+    autoRenew: Boolean = true,
+    initialTerm: Int = 12,
+    initialTermPeriodType: PeriodType = Month
   ): SubscriptionData = {
-    val (initialTerm, autoRenew, initialTermPeriodType) = if (readerType == ReaderType.Gift)
-      (initialTermInDays(contractEffectiveDate, contractAcceptanceDate, initialTermMonths), false, Day)
-    else
-      (12, true, Month)
+//    val (initialTerm, autoRenew, initialTermPeriodType) = if (readerType == ReaderType.Gift)
+//      (initialTermInDays(contractEffectiveDate, contractAcceptanceDate, initialTermMonths), false, Day)
+//    else
+//      (12, true, Month)
 
     SubscriptionData(
       List(
@@ -68,11 +70,6 @@ object ProductSubscriptionBuilders {
         initialTermPeriodType = initialTermPeriodType,
       )
     )
-  }
-
-  def initialTermInDays(contractEffectiveDate: LocalDate, contractAcceptanceDate: LocalDate, termLengthMonths: Int): Int = {
-    val termEnd = contractAcceptanceDate.plusMonths(termLengthMonths)
-    Days.daysBetween(contractEffectiveDate, termEnd).getDays
   }
 
   def applyPromoCode(

--- a/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/ProductSubscriptionBuilders.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/ProductSubscriptionBuilders.scala
@@ -46,10 +46,6 @@ object ProductSubscriptionBuilders {
     initialTerm: Int = 12,
     initialTermPeriodType: PeriodType = Month
   ): SubscriptionData = {
-//    val (initialTerm, autoRenew, initialTermPeriodType) = if (readerType == ReaderType.Gift)
-//      (initialTermInDays(contractEffectiveDate, contractAcceptanceDate, initialTermMonths), false, Day)
-//    else
-//      (12, true, Month)
 
     SubscriptionData(
       List(

--- a/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/ProductSubscriptionBuilders.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/ProductSubscriptionBuilders.scala
@@ -68,7 +68,7 @@ object ProductSubscriptionBuilders {
     )
   }
 
-  def applyPromoCode(
+  def applyPromoCodeIfPresent(
     promotionService: PromotionService,
     maybePromoCode: Option[PromoCode],
     country: Country,

--- a/support-workers/src/test/scala/com/gu/support/workers/CreateZuoraSubscriptionStepsSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/CreateZuoraSubscriptionStepsSpec.scala
@@ -8,7 +8,7 @@ import com.gu.support.config.{ZuoraConfig, ZuoraDigitalPackConfig}
 import com.gu.support.redemption.DynamoLookup.{DynamoBoolean, DynamoString}
 import com.gu.support.redemption.DynamoUpdate.DynamoFieldUpdate
 import com.gu.support.redemption.{DynamoLookup, DynamoUpdate}
-import com.gu.support.redemptions.{CorporateRedemption, RedemptionCode}
+import com.gu.support.redemptions.{RedemptionCode, RedemptionData}
 import com.gu.support.workers.lambdas.CreateZuoraSubscription
 import com.gu.support.workers.states.CreateZuoraSubscriptionState
 import com.gu.support.zuora.api.ReaderType.Corporate
@@ -32,7 +32,7 @@ class CreateZuoraSubscriptionStepsSpec extends AsyncFlatSpec with Matchers {
       giftRecipient = None,
       product = DigitalPack(Currency.GBP, null /* !*/, Corporate),
       RedemptionNoProvider,
-      paymentMethod = Right(CorporateRedemption(RedemptionCode("TESTCODE").right.get)),
+      paymentMethod = Right(RedemptionData(RedemptionCode("TESTCODE").right.get)),
       firstDeliveryDate = None,
       promoCode = None,
       salesforceContacts = SalesforceContactRecords(

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
@@ -4,14 +4,12 @@ import java.io.ByteArrayOutputStream
 
 import com.amazonaws.services.sqs.model.SendMessageResult
 import com.gu.config.Configuration
-import com.gu.emailservices
 import com.gu.emailservices._
 import com.gu.i18n.Country
 import com.gu.i18n.Country.UK
 import com.gu.i18n.Currency.GBP
 import com.gu.salesforce.Salesforce.SfContactId
-import com.gu.support.catalog.{Collection, Domestic, Saturday}
-import com.gu.support.redemptions.{CorporateRedemption, RedemptionCode}
+import com.gu.support.catalog.{Collection, Saturday}
 import com.gu.support.workers.JsonFixtures.{thankYouEmailJson, wrapFixture}
 import com.gu.support.workers._
 import com.gu.support.workers.encoding.Conversions.FromOutputStream

--- a/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilderSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilderSpec.scala
@@ -19,6 +19,7 @@ import org.scalatestplus.mockito.MockitoSugar._
 
 import scala.concurrent.Future
 
+//noinspection RedundantDefaultArgument
 class DigitalSubscriptionBuilderSpec extends AsyncFlatSpec with Matchers {
 
   "SubscriptionData for a corporate subscription" should "be correct" in
@@ -86,7 +87,7 @@ class DigitalSubscriptionBuilderSpec extends AsyncFlatSpec with Matchers {
   lazy val monthly = DigitalSubscriptionBuilder.build(
     DigitalPack(GBP, Monthly),
     UUID.fromString("f7651338-5d94-4f57-85fd-262030de9ad5"),
-    SubscriptionPurchase(ZuoraDigitalPackConfig(14, 2), None, Country.UK, promotionService),
+    SubscriptionPurchase(ZuoraDigitalPackConfig(14, 2), None, Monthly, Country.UK, promotionService),
     SANDBOX,
     () => saleDate
   ).value.map(_.right.get)

--- a/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilderSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilderSpec.scala
@@ -91,4 +91,6 @@ class DigitalSubscriptionBuilderSpec extends AsyncFlatSpec with Matchers {
     () => saleDate
   ).value.map(_.right.get)
 
+  //TODO: test all cases
+
 }

--- a/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilderSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilderSpec.scala
@@ -8,7 +8,7 @@ import com.gu.support.config.TouchPointEnvironments.SANDBOX
 import com.gu.support.config.ZuoraDigitalPackConfig
 import com.gu.support.promotions.PromotionService
 import com.gu.support.redemption.{DynamoLookup, GetCodeStatus}
-import com.gu.support.redemptions.{CorporateRedemption, RedemptionCode}
+import com.gu.support.redemptions.{RedemptionCode, RedemptionData}
 import com.gu.support.workers.{DigitalPack, Monthly}
 import com.gu.support.zuora.api.ReaderType.Corporate
 import com.gu.support.zuora.api._
@@ -72,7 +72,7 @@ class DigitalSubscriptionBuilderSpec extends AsyncFlatSpec with Matchers {
     DigitalPack(GBP, null /* FIXME should be Option-al for a corp sub */ , Corporate),
     UUID.fromString("f7651338-5d94-4f57-85fd-262030de9ad5"),
     SubscriptionRedemption(
-      CorporateRedemption(RedemptionCode("CODE").right.get),
+      RedemptionData(RedemptionCode("CODE").right.get),
       new GetCodeStatus({
         case "CODE" => Future.successful(Some(Map(
           "available" -> DynamoLookup.DynamoBoolean(true),

--- a/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilderSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilderSpec.scala
@@ -71,7 +71,7 @@ class DigitalSubscriptionBuilderSpec extends AsyncFlatSpec with Matchers {
   lazy val corporate = DigitalSubscriptionBuilder.build(
     DigitalPack(GBP, null /* FIXME should be Option-al for a corp sub */ , Corporate),
     UUID.fromString("f7651338-5d94-4f57-85fd-262030de9ad5"),
-    SubscriptionPaymentCorporate(
+    SubscriptionRedemption(
       CorporateRedemption(RedemptionCode("CODE").right.get),
       new GetCodeStatus({
         case "CODE" => Future.successful(Some(Map(
@@ -86,7 +86,7 @@ class DigitalSubscriptionBuilderSpec extends AsyncFlatSpec with Matchers {
   lazy val monthly = DigitalSubscriptionBuilder.build(
     DigitalPack(GBP, Monthly),
     UUID.fromString("f7651338-5d94-4f57-85fd-262030de9ad5"),
-    SubscriptionPaymentDirect(ZuoraDigitalPackConfig(14, 2), None, Country.UK, promotionService),
+    SubscriptionPurchase(ZuoraDigitalPackConfig(14, 2), None, Country.UK, promotionService),
     SANDBOX,
     () => saleDate
   ).value.map(_.right.get)

--- a/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/GuardianWeeklySubscriptionBuildersSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/GuardianWeeklySubscriptionBuildersSpec.scala
@@ -9,13 +9,14 @@ import com.gu.support.config.TouchPointEnvironments.SANDBOX
 import com.gu.support.promotions.PromotionService
 import com.gu.support.workers.{GuardianWeekly, Quarterly}
 import com.gu.support.zuora.api.{Day, Month, ReaderType, SubscriptionData}
+import com.gu.zuora.subscriptionBuilders.GuardianWeeklySubscriptionBuilder.initialTermInDays
 import com.gu.zuora.subscriptionBuilders.ProductSubscriptionBuilders._
 import org.joda.time.LocalDate
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar._
 
-class ProductSubscriptionBuildersSpec extends AnyFlatSpec with Matchers {
+class GuardianWeeklySubscriptionBuildersSpec extends AnyFlatSpec with Matchers {
 
   "InitialTermLength" should "be correct" in {
     val termStart = new LocalDate(2019, 2, 3)


### PR DESCRIPTION
## Why are you doing this?

This is the server side work to support purchasing and redeeming Digital Subscription gifts.

Digital Subscription gifts are the first product we have which requires two separate checkouts, one to purchase the gift and one to redeem it. The table below shows the types of checkout which are required by the different reader types (Direct, Gift or Corporate)

### Mapping of ReaderTypes to checkout types for Digital Subscription
|          | Direct | Gift | Corporate |
|----------|--------|------|-----------|
| Purchase |    ✔    |   ✔  (gifter) |           |
| Redemption   |        |   ✔  (giftee) |     ✔      |

Most of this PR focuses on changes to the `DigitalSubscriptionBuilder` class to handle the two different checkout types, there are now two separate methods `buildPurchase` and `buildRedemption` to make the branching in the logic clearer. 

I have converted the ADT `RedemptionData` to a plain case class as the two usages we envisioned for it are actually identical and so don't require subclassing.

## Changes

* Remove separate subclass for CorporateRedemption - gifting can share the RedemptionData subclass
* Separate out build methods on DigitalSubscriptionBuilder into those which deal with redemption and those which deal with purchases
* Add code to DigitalSubscriptionBuilder to handle purchase of gift subscriptions
* Add placeholder to DigitalSubscriptionBuilder for handling redemption of gift subscriptions


[**Trello Card**](https://trello.com/c/TcVj29Ji/3175-gifting-checkout-spike-server-side)

### TODO
- [ ] Implement DS giftee redemption
- [ ] More tests