### PR TITLE
Fix info icon on chrome (and tweak styles)

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmountRecurringNotification.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmountRecurringNotification.jsx
@@ -15,7 +15,7 @@ type ContributionAmountLabelProps = {
 
 const container = css`
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   margin-top: ${space[3]}px;
   padding: ${space[1]}px ${space[3]}px;
   ${textSans.medium()}
@@ -30,12 +30,17 @@ const container = css`
 `;
 
 const svgContainer = css`
-  width: 22px;
-  height: 22px;
   display: flex;
   svg {
+    display: inline-block;
+    width: 30px;
+    height: 30px;
     fill: ${brand[400]};
   }
+`;
+
+const textContainer = css`
+  margin-top: 2px;
 `;
 
 const ContributionAmountRecurringNotification = ({
@@ -55,7 +60,7 @@ const ContributionAmountRecurringNotification = ({
       <div css={svgContainer}>
         <SvgInfo />
       </div>
-      <div>
+      <div css={textContainer}>
         Every {frequency} you&apos;ll contribute {formattedAmount}.
       </div>
     </div>


### PR DESCRIPTION
## Why are you doing this?

The info icon for the second variant wasn't showing in chrome. This has now been fixed. Additionally, tweaked the alignment to match the design. 

## Screenshots

before:
<img width="560" alt="Screenshot 2020-08-12 at 15 03 36" src="https://user-images.githubusercontent.com/17720442/90027824-e0144100-dcb0-11ea-9b6a-4478bc7df424.png">

after:
<img width="560" alt="Screenshot 2020-08-12 at 15 26 17" src="https://user-images.githubusercontent.com/17720442/90027841-e3a7c800-dcb0-11ea-84e0-7b086be4d253.png">



