### PR TITLE
Decode encoded characters in ab test name/variant

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtest.js
+++ b/support-frontend/assets/helpers/abTests/abtest.js
@@ -127,7 +127,7 @@ function getParticipationsFromUrl(): ?Participations {
 
   if (hashUrl.startsWith('#ab-')) {
 
-    const [testId, variant] = hashUrl.substr(4).split('=');
+    const [testId, variant] = decodeURI(hashUrl.substr(4)).split('=');
     const test = {};
     test[testId] = variant;
 


### PR DESCRIPTION
## Why are you doing this?

Tiny PR that updates the logic for grabbing the ab test variant from url to also decode any special characters. This allows you to use variants with spaces in their names! e.g `#ab-my%20test=my%20variant`