### PR TITLE
Honour vendor consent state with TCFv2

### DIFF
--- a/support-frontend/assets/helpers/tracking/__tests__/thirdPartyTrackingConsentTest.js
+++ b/support-frontend/assets/helpers/tracking/__tests__/thirdPartyTrackingConsentTest.js
@@ -36,8 +36,14 @@ describe('thirdPartyTrackingConsent', () => {
       throw new Error('fail');
     });
 
-    return onConsentChangeEvent(dummyCallback).then(() => {
-      expect(dummyCallback).toBeCalledWith(false);
+    return onConsentChangeEvent(dummyCallback, {
+      foo: 12345,
+      bar: 54321,
+    }).then(() => {
+      expect(dummyCallback).toBeCalledWith({
+        foo: false,
+        bar: false,
+      });
     });
   });
 
@@ -49,8 +55,14 @@ describe('thirdPartyTrackingConsent', () => {
         },
       }));
 
-      return onConsentChangeEvent(dummyCallback).then(() => {
-        expect(dummyCallback).toBeCalledWith(false);
+      return onConsentChangeEvent(dummyCallback, {
+        foo: 12345,
+        bar: 54321,
+      }).then(() => {
+        expect(dummyCallback).toBeCalledWith({
+          foo: false,
+          bar: false,
+        });
       });
     });
 
@@ -61,8 +73,14 @@ describe('thirdPartyTrackingConsent', () => {
         },
       }));
 
-      return onConsentChangeEvent(dummyCallback).then(() => {
-        expect(dummyCallback).toBeCalledWith(true);
+      return onConsentChangeEvent(dummyCallback, {
+        foo: 12345,
+        bar: 54321,
+      }).then(() => {
+        expect(dummyCallback).toBeCalledWith({
+          foo: true,
+          bar: true,
+        });
       });
     });
   });
@@ -142,57 +160,6 @@ describe('thirdPartyTrackingConsent', () => {
             foo: true,
             bar: false,
           });
-        });
-      });
-    });
-
-
-    describe('when NO sourcepointVendorIds provided', () => {
-      it('calls dummyCallback with false if all consents are false', () => {
-        onConsentChange.mockImplementation(callback => callback({
-          tcfv2: {
-            consents: {
-              0: false,
-              1: false,
-              2: false,
-            },
-          },
-        }));
-
-        return onConsentChangeEvent(dummyCallback).then(() => {
-          expect(dummyCallback).toBeCalledWith(false);
-        });
-      });
-
-      it('calls dummyCallback with false if some consents are false', () => {
-        onConsentChange.mockImplementation(callback => callback({
-          tcfv2: {
-            consents: {
-              0: true,
-              1: true,
-              2: false,
-            },
-          },
-        }));
-
-        return onConsentChangeEvent(dummyCallback).then(() => {
-          expect(dummyCallback).toBeCalledWith(false);
-        });
-      });
-
-      it('calls dummyCallback with true if all consents are true', () => {
-        onConsentChange.mockImplementation(callback => callback({
-          tcfv2: {
-            consents: {
-              0: true,
-              1: true,
-              2: true,
-            },
-          },
-        }));
-
-        return onConsentChangeEvent(dummyCallback).then(() => {
-          expect(dummyCallback).toBeCalledWith(true);
         });
       });
     });

--- a/support-frontend/assets/helpers/tracking/googleTagManager.js
+++ b/support-frontend/assets/helpers/tracking/googleTagManager.js
@@ -274,24 +274,17 @@ function init(participations: Participations) {
     * The callback will receive the user's consent as the parameter
     * "thirdPartyTrackingConsent".
   */
-  onConsentChangeEvent((thirdPartyTrackingConsent: boolean | {
+  onConsentChangeEvent((thirdPartyTrackingConsent: {
     [key: string]: boolean
   }) => {
-    console.log('thirdPartyTrackingConsent --->', thirdPartyTrackingConsent);
     /**
       * Update userHasGrantedConsent value when
       * consent changes via the CMP library.
+      * For now userHasGrantedConsent will be true only
+      * if user has consented to BOTH GoogleTagManager and GoogleAnalytics
     */
-    if (typeof thirdPartyTrackingConsent === 'boolean') {
-      userHasGrantedConsent = thirdPartyTrackingConsent;
-    } else {
-      /**
-       * For now userHasGrantedConsent will be true only
-       * if user has consented to BOTH GoogleTagManager and GoogleAnalytics
-       */
-      userHasGrantedConsent =
+    userHasGrantedConsent =
         thirdPartyTrackingConsent[googleAnalyticsKey] && thirdPartyTrackingConsent[googleTagManagerKey];
-    }
 
     if (userHasGrantedConsent) {
       if (!scriptAdded) {


### PR DESCRIPTION
Proposed changes to TCFv2 implementation. We only load Google Tag Manager and Google Analytics if a user has granted consent to both vendors. 

I've updated `onConsentChangeEvent` to take a 2nd parameter `sourcePointVendorIds` that looks something like:

```js
{
 foo: '54321'
 bar: '12345'
}
```

`onConsentChangeEvent` processes the state returned by `@guardian/consent-management-platform` and looks up whether a user has granted access to each of the vendors in `sourcePointVendorIds`, it builds up an object like:

```js
{
 foo: true // user has consented to foo
 bar: false // user has not consented to bar
}
```