### PR TITLE
bump scalatest to fix reporting issue

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,15 +4,13 @@ import sbtrelease.ReleaseStateTransformations._
 
 import scala.sys.process._
 
-val scalatest = "org.scalatest" %% "scalatest" % "3.2.0"// if the following PR is merged in v3.2.1, remove "-eU" parameter from options above - PR https://github.com/scalatest/scalatest/pull/1842
+val scalatest = "org.scalatest" %% "scalatest" % "3.2.1"
 
 lazy val integrationTestSettings: Seq[Def.Setting[_]] = Defaults.itSettings ++ Seq(
   scalaSource in IntegrationTest := baseDirectory.value / "src" / "test" / "scala",
   javaSource in IntegrationTest := baseDirectory.value / "src" / "test" / "java",
   resourceDirectory in IntegrationTest := baseDirectory.value / "src" / "test" / "resources",
   testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-l", "com.gu.test.tags.annotations.IntegrationTest"),
-  testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-eU"),
-  testOptions in IntegrationTest += Tests.Argument(TestFrameworks.ScalaTest, "-eU"),
   libraryDependencies += scalatest % "it",
 )
 

--- a/support-lambdas/it-test-runner/build.sbt
+++ b/support-lambdas/it-test-runner/build.sbt
@@ -14,7 +14,7 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor" % jacksonVersion,
   "ch.qos.logback" % "logback-classic" % "1.2.3",
   "io.symphonia" % "lambda-logging" % "1.0.3",
-  "org.scalatest" %% "scalatest" % "3.2.0" // not a "Test" dependency, it's an actual one
+  "org.scalatest" %% "scalatest" % "3.2.1" // not a "Test" dependency, it's an actual one
 )
 
 riffRaffPackageType := assembly.value


### PR DESCRIPTION
## Why are you doing this?

scalatest had a bug in the reporting that meant there was a lot of output happening after the tests completed.  Also some output was missing from the reported tests.
These two bugs have been fixed and released in 3.2.1.

I have bumped to that version and removed the workaround added in https://github.com/guardian/support-frontend/pull/2555
