### PR TITLE
Fix Recaptcha error when switching between monthly and annual

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
@@ -150,6 +150,8 @@ const CardForm = (props: PropTypes) => {
   });
   const stripe = stripeJs.useStripe();
   const elements = stripeJs.useElements();
+  // Used to avoid calling grecaptcha.render twice when switching between monthly + annual
+  const [calledRecaptchaRender, setCalledRecaptchaRender] = useState<boolean>(false);
 
   /**
    * Handlers
@@ -184,6 +186,7 @@ const CardForm = (props: PropTypes) => {
 
   // Creates a new setupIntent upon recaptcha verification
   const setupRecurringRecaptchaCallback = () => {
+    setCalledRecaptchaRender(true);
     window.grecaptcha.render('robot_checkbox', {
       sitekey: window.guardian.v2recaptchaPublicKey,
       callback: (token) => {
@@ -320,7 +323,7 @@ const CardForm = (props: PropTypes) => {
     if (stripe && elements) {
       if (props.contributionType === 'ONE_OFF') {
         setupOneOffHandlers();
-      } else {
+      } else if (!calledRecaptchaRender) {
         setupRecurringHandlers();
       }
     }


### PR DESCRIPTION
## Why are you doing this?
Fixes a bug which can occur if:
1. Stripe is the default payment method
2. User switches between monthly and annual

It breaks the form and the user has to refresh before they can complete a payment.

So currently this can affect non-UK users who are not in the `noDefault` test variant.

The issue is that we try to call `grecaptcha.render` again when the user switches between monthly/annual. This happens because the form does not re-create the stripe component when switching between monthly/annual. The error is:
<img width="566" alt="Screen Shot 2020-08-17 at 09 19 56" src="https://user-images.githubusercontent.com/1513454/90374216-0fd59700-e06b-11ea-842d-2d8c3590b5b2.png">

Tested monthly/annual/single/PRB