### PR TITLE
Hide supporter count on Aus map

### DIFF
--- a/support-frontend/assets/pages/aus-moment-map/components/blurb.jsx
+++ b/support-frontend/assets/pages/aus-moment-map/components/blurb.jsx
@@ -5,15 +5,18 @@
 import * as React from 'preact/compat';
 import { SocialLinks } from 'pages/aus-moment-map/components/socialLinks';
 
+const enableSupporterCount = false;
 
 const useSupportersCount = () => {
   const [supportersCount, setSupportersCount] = React.useState(0);
   const supportersCountEndpoint = '/supporters-ticker.json';
 
   React.useEffect(() => {
-    fetch(supportersCountEndpoint)
-      .then(response => response.json())
-      .then(data => setSupportersCount(data.total));
+    if (enableSupporterCount) {
+      fetch(supportersCountEndpoint)
+        .then(response => response.json())
+        .then(data => setSupportersCount(data.total));
+    }
   }, []);
 
   return supportersCount;
@@ -37,8 +40,12 @@ export const Blurb = (props: PropTypes) => {
             their reasons with us – and here is a selection. You can become a supporter right now and add to the
             conversation.
           </p>
-          <p className="supporters-total">{supportersCount.toLocaleString()}</p>
-          <p className="supporters-total-caption">Total supporters in Australia</p>
+          {enableSupporterCount &&
+            <>
+              <p className="supporters-total">{supportersCount.toLocaleString()}</p>
+              <p className="supporters-total-caption">Total supporters in Australia</p>
+            </>
+          }
         </div>}
       </div>
       <SocialLinks />


### PR DESCRIPTION
## Why are you doing this?
The Aus campaign is over and we are no longer updating the supporter count value.
But we do still want to link to this map.

#### Before
![Screen Shot 2020-08-19 at 11 43 41](https://user-images.githubusercontent.com/1513454/90625669-dc813c80-e211-11ea-8ad5-f94276e3796f.png)

#### After
![Screen Shot 2020-08-19 at 11 43 53](https://user-images.githubusercontent.com/1513454/90625676-e014c380-e211-11ea-8c47-102201b7c810.png)
