### PR TITLE
Set options prop on Stripe Elements

### DIFF
--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeProviderForCountry.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeProviderForCountry.jsx
@@ -35,8 +35,12 @@ function StripeProviderForCountry(props: PropTypes) {
     }
   }, []);
 
+  // `options` must be set even if it's empty, otherwise we get 'Unsupported prop change on Elements' warnings
+  // in the console
+  const elementsOptions = {};
+
   return (
-    <Elements stripe={stripeObject}>
+    <Elements stripe={stripeObject} options={elementsOptions}>
       <StripeForm
         submitForm={props.submitForm}
         allErrors={props.allErrors}

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardFormContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardFormContainer.jsx
@@ -60,13 +60,17 @@ const StripeCardFormContainer = (props: PropTypes) => {
   if (props.paymentMethod === Stripe) {
     if (stripeObjects[stripeAccount]) {
 
+      // `options` must be set even if it's empty, otherwise we get 'Unsupported prop change on Elements' warnings
+      // in the console
+      const elementsOptions = {};
+
       /**
        * The `key` attribute is necessary here because you cannot update the stripe object on the Elements.
        * Instead, we create separate instances for ONE_OFF and REGULAR
        */
       return (
         <div className="stripe-card-element-container" key={stripeAccount}>
-          <Elements stripe={stripeObjects[stripeAccount]}>
+          <Elements stripe={stripeObjects[stripeAccount]} options={elementsOptions}>
             <StripeCardForm stripeKey={stripeKey} />
           </Elements>
         </div>

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
@@ -74,13 +74,17 @@ const StripePaymentRequestButtonContainer = (props: PropTypes) => {
   if (showStripePaymentRequestButton && stripeObjects[stripeAccount]) {
     const amount = getAmount(props.selectedAmounts, props.otherAmounts, props.contributionType);
 
+    // `options` must be set even if it's empty, otherwise we get 'Unsupported prop change on Elements' warnings
+    // in the console
+    const elementsOptions = {};
+
     /**
      * The `key` attribute is necessary here because you cannot update the stripe object on the Elements.
      * Instead, we create separate instances for ONE_OFF and REGULAR
      */
     return (
       <div className="stripe-payment-request-button" key={stripeAccount}>
-        <Elements stripe={stripeObjects[stripeAccount]}>
+        <Elements stripe={stripeObjects[stripeAccount]} options={elementsOptions}>
           <StripePaymentRequestButton
             stripeAccount={stripeAccount}
             amount={amount}


### PR DESCRIPTION
## Why are you doing this?
card https://trello.com/c/EyeJ64OO/2226-react-stripe-elements-console-warning
When the user first clicks on a Stripe Elements field, the following warning message appears in the console:

```breadcrumbs.js:58 Unsupported prop change on Elements: You cannot change the `options` prop after setting the `stripe` prop.```

It doesn't cause any problems.

The solution is to always pass the `options` prop to `Elements`, otherwise you hit [this warning](https://github.com/stripe/react-stripe-js/blob/e13fae556b1a667a5dfa1130c00d5ec4c2bc154e/src/components/Elements.tsx#L125).
All fields in the `options` type are optional: https://stripe.com/docs/js/elements_object/create
