### PR TITLE
Fix support-internationalisation publishing

### DIFF
--- a/support-internationalisation/build.sbt
+++ b/support-internationalisation/build.sbt
@@ -1,6 +1,7 @@
 import sbtrelease.ReleaseStateTransformations._
 
 name := "support-internationalisation"
+organization := "com.gu"
 
 crossScalaVersions := Seq("2.11.8", "2.12.7", "2.13.3")
 

--- a/support-internationalisation/build.sbt
+++ b/support-internationalisation/build.sbt
@@ -2,10 +2,14 @@ import sbtrelease.ReleaseStateTransformations._
 
 name := "support-internationalisation"
 
-crossScalaVersions := Seq("2.11.8", "2.12.7")
+crossScalaVersions := Seq("2.11.8", "2.12.7", "2.13.3")
 
 description := "Scala library to provide internationalisation classes to Guardian Membership/Subscriptions/support projects."
 
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.1.1" % "test"
+
+sources in doc in Compile := List()
+releasePublishArtifactsAction := PgpKeys.publishSigned.value
 releaseCrossBuild := true
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
@@ -15,10 +19,9 @@ releaseProcess := Seq[ReleaseStep](
   setReleaseVersion,
   commitReleaseVersion,
   tagRelease,
-  ReleaseStep(action = Command.process("publishSigned", _), enableCrossBuild = true),
+  publishArtifacts,
   setNextVersion,
   commitNextVersion,
-  ReleaseStep(action = Command.process("sonatypeReleaseAll", _), enableCrossBuild = true),
+  releaseStepCommand("sonatypeReleaseAll"),
   pushChanges
 )
-

--- a/support-internationalisation/build.sbt
+++ b/support-internationalisation/build.sbt
@@ -19,9 +19,9 @@ releaseProcess := Seq[ReleaseStep](
   setReleaseVersion,
   commitReleaseVersion,
   tagRelease,
-  publishArtifacts,
+  releaseStepCommandAndRemaining("+publishSigned"),
+  releaseStepCommand("sonatypeBundleRelease"),
   setNextVersion,
   commitNextVersion,
-  releaseStepCommand("sonatypeReleaseAll"),
   pushChanges
 )

--- a/support-internationalisation/project/build.properties
+++ b/support-internationalisation/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.3.13

--- a/support-internationalisation/project/plugins.sbt
+++ b/support-internationalisation/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.github.gseitz"        %   "sbt-release"                 % "1.0.11")
+addSbtPlugin("com.jsuereth"             %   "sbt-pgp"                     % "2.0.0")
+addSbtPlugin("org.xerial.sbt"           %   "sbt-sonatype"                % "2.5")

--- a/support-internationalisation/project/plugins.sbt
+++ b/support-internationalisation/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("com.github.gseitz"        %   "sbt-release"                 % "1.0.11")
-addSbtPlugin("com.jsuereth"             %   "sbt-pgp"                     % "2.0.0")
-addSbtPlugin("org.xerial.sbt"           %   "sbt-sonatype"                % "2.5")
+addSbtPlugin("com.github.gseitz"        %   "sbt-release"                 % "1.0.13")
+addSbtPlugin("com.jsuereth"             %   "sbt-pgp"                     % "2.0.1")
+addSbtPlugin("org.xerial.sbt"           %   "sbt-sonatype"                % "3.9.4")

--- a/support-internationalisation/sonatype.sbt
+++ b/support-internationalisation/sonatype.sbt
@@ -1,13 +1,11 @@
 sonatypeProfileName := "com.gu"
-
-pomExtra := <url>https://github.com/guardian/support-internationalisation</url>
-    <developers>
-      <developer>
-        <id>rbates</id>
-        <name>Rupert Bates</name>
-        <url>https://github.com/rupertbates</url>
-      </developer>
-    </developers>
+publishMavenStyle := true
+homepage := Some(url("https://github.com/guardian/support-frontend/tree/master/support-internationalisation"))
+scmInfo := Some(ScmInfo(url("https://github.com/guardian/support-frontend/tree/master/support-internationalisation"), "scm:git@github.com:guardian/support-frontend.git"))
+developers := List(
+  Developer(id="rbates", name="Rupert Bates", email="", url=url("https://github.com/rupertbates")),
+)
+publishTo := sonatypePublishTo.value
 
 
 

--- a/support-internationalisation/sonatype.sbt
+++ b/support-internationalisation/sonatype.sbt
@@ -1,11 +1,12 @@
 sonatypeProfileName := "com.gu"
 publishMavenStyle := true
+licenses := Seq("APL2" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt"))
 homepage := Some(url("https://github.com/guardian/support-frontend/tree/master/support-internationalisation"))
 scmInfo := Some(ScmInfo(url("https://github.com/guardian/support-frontend/tree/master/support-internationalisation"), "scm:git@github.com:guardian/support-frontend.git"))
 developers := List(
   Developer(id="rbates", name="Rupert Bates", email="", url=url("https://github.com/rupertbates")),
 )
-publishTo := sonatypePublishTo.value
+publishTo := sonatypePublishToBundle.value
 
 
 

--- a/support-internationalisation/src/main/scala/com/gu/i18n/Country.scala
+++ b/support-internationalisation/src/main/scala/com/gu/i18n/Country.scala
@@ -106,7 +106,7 @@ object Country {
       "WA" -> "Western Australia",
       "QLD" -> "Queensland",
       "ACT" -> "Australian Capital Territory",
-      "NT" -> "Northern Territory",
+      "NT" -> "Northern Territory"
     ).toMap
   )
 

--- a/support-internationalisation/version.sbt
+++ b/support-internationalisation/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.13"
+version in ThisBuild := "0.14-SNAPSHOT"

--- a/support-internationalisation/version.sbt
+++ b/support-internationalisation/version.sbt
@@ -1,1 +1,1 @@
-version := "0.13"
+version in ThisBuild := "0.13"

--- a/support-internationalisation/version.sbt
+++ b/support-internationalisation/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.12.1"
+version := "0.13"

--- a/support-internationalisation/version.sbt
+++ b/support-internationalisation/version.sbt
@@ -1,1 +1,1 @@
-version := "0.12"
+version in ThisBuild := "0.12.1"


### PR DESCRIPTION
## Why are you doing this?

support-service-lambdas requires Scala 2.13 build

## Changes

* It was syntactically broken and missing sbt plugins for publishing
* update to latest release process
* The release was successful https://repo.maven.apache.org/maven2/com/gu/support-internationalisation_2.13/ 
