### PR TITLE
Restore content-box sizing on contributions pages

### DIFF
--- a/support-frontend/assets/pages/aus-moment-map/ausMomentMap.scss
+++ b/support-frontend/assets/pages/aus-moment-map/ausMomentMap.scss
@@ -11,6 +11,10 @@ body {
   padding: 0;
 }
 
+.map-page, .map-page * {
+  box-sizing: content-box;
+}
+
 .map-page {
   display: flex;
   flex-shrink: 0;

--- a/support-frontend/assets/pages/contributions-landing/newContributionsLandingTemplate.scss
+++ b/support-frontend/assets/pages/contributions-landing/newContributionsLandingTemplate.scss
@@ -1,5 +1,9 @@
 @import '~stylesheets/gu-sass/gu-sass';
 
+.gu-content--new-template, .gu-content--new-template * {
+  box-sizing: content-box;
+}
+
 .gu-content--new-template {
   overflow: initial;
 


### PR DESCRIPTION
## Why are you doing this?

Because I broke the contributions pages 🤦‍♀️ Setting `box-sizing: border-box;` globally altered sizing and alignment on the landing page, so this restores the old `content-box` setting for both contributions pages.

## Screenshots

**Landing page**
![Screenshot 2020-08-27 at 11 38 45](https://user-images.githubusercontent.com/29146931/91433351-13330480-e85b-11ea-86f7-ad15227e9bde.png)

**Moment map**
![Screenshot 2020-08-27 at 11 39 46](https://user-images.githubusercontent.com/29146931/91433362-14fcc800-e85b-11ea-9c6a-6957fe4c852b.png)
