### PR TITLE
Upgrade Play from v2.6.23 to v2.7.5

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.23")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.5")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
 

--- a/support-frontend/test/fixtures/TestCSRFComponents.scala
+++ b/support-frontend/test/fixtures/TestCSRFComponents.scala
@@ -13,14 +13,7 @@ trait TestCSRFComponents {
 
   private lazy val appComponents = {
     val env = Environment.simple(new File("."))
-    val configuration = Configuration.load(env)
-    val context = ApplicationLoader.Context(
-      environment = env,
-      sourceMapper = None,
-      webCommands = new DefaultWebCommands(),
-      initialConfiguration = configuration,
-      lifecycle = new DefaultApplicationLifecycle()
-    )
+    val context = ApplicationLoader.Context.create(env)
     new BuiltInComponentsFromContext(context) with CSRFComponents {
       override def router: Router = ???
 


### PR DESCRIPTION
## Why are you doing this?

Play 2.6 is no longer supported. Security updates are now only being released for Play 2.7 and 2.8. Under our cyber essentials obligations we must only use supported software and apply all critical and high severity security updates. Play security is particularly important due to the external facing nature and the duty we have to protect our readers and business.

[**Trello Card**](https://trello.com/c/YMmpPNB3)

## Changes

- Upgrade Play version and fix breaking API changes

## Tests

- Unit tests pass
- Selenium tests pass

## Did you enjoy your PR experience?

 - [x] [PR experience rated](https://forms.gle/N6FsTGG8JQFGV4Ha9)

