### PR TITLE
Track all thank you page clicks

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/AustraliaMapLink.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/AustraliaMapLink.jsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { ThemeProvider } from 'emotion-theming';
 import { LinkButton, buttonBrandAlt } from '@guardian/src-button';
 import { SvgArrowRightStraight } from '@guardian/src-icons';
+import { trackComponentClick } from 'helpers/tracking/behaviour';
 
 const AustraliaMapLink = () => (
   <section className="contribution-thank-you-block">
@@ -19,6 +20,7 @@ const AustraliaMapLink = () => (
         iconSide="right"
         nudgeIcon
         href="https://support.theguardian.com/aus-2020-map?INTCMP=thankyou-page-aus-map-cta"
+        onClick={() => trackComponentClick('contribution-thankyou-aus-map')}
       >
         View the map
       </LinkButton>

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionSurvey/ContributionsSurvey.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionSurvey/ContributionsSurvey.jsx
@@ -5,6 +5,7 @@
 import React from 'react';
 import AnchorButton from 'components/button/anchorButton';
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
+import { trackComponentClick } from 'helpers/tracking/behaviour';
 
 // ----- Component ----- //
 
@@ -35,8 +36,10 @@ export default function ContributionsSurvey(props: PropTypes) {
       </p>
       <AnchorButton
         href={surveyLink}
+        target="_blank"
         appearance="secondary"
         aria-label="Link to contribution survey"
+        onClick={() => trackComponentClick('contribution-thankyou-survey')}
       >
           Share your thoughts
       </AnchorButton>

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionSurvey/ContributionsSurvey.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionSurvey/ContributionsSurvey.jsx
@@ -37,6 +37,7 @@ export default function ContributionsSurvey(props: PropTypes) {
       <AnchorButton
         href={surveyLink}
         target="_blank"
+        rel="noopener"
         appearance="secondary"
         aria-label="Link to contribution survey"
         onClick={() => trackComponentClick('contribution-thankyou-survey')}

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
@@ -202,6 +202,7 @@ function ContributionThankYou(props: PropTypes) {
             aria-label="Return to The Guardian"
             icon={<SvgArrowLeft />}
             iconSide="left"
+            onClick={() => trackComponentClick('contribution-thankyou-return-to-guardian')}
           >
             Return to The Guardian
           </AnchorButton>


### PR DESCRIPTION
There are 3 CTAs in the thank you page that are not currently tracked:
- ContributionSurvey
- AustraliaMapLink
- Return to The Guardian

This is in preparation for testing against the new thank you page.

I also made the survey link open in a new tab.