### PR TITLE
Revert "Upgrade Play from v2.6.23 to v2.7.5"

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.5")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.23")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
 

--- a/support-frontend/test/fixtures/TestCSRFComponents.scala
+++ b/support-frontend/test/fixtures/TestCSRFComponents.scala
@@ -13,7 +13,14 @@ trait TestCSRFComponents {
 
   private lazy val appComponents = {
     val env = Environment.simple(new File("."))
-    val context = ApplicationLoader.Context.create(env)
+    val configuration = Configuration.load(env)
+    val context = ApplicationLoader.Context(
+      environment = env,
+      sourceMapper = None,
+      webCommands = new DefaultWebCommands(),
+      initialConfiguration = configuration,
+      lifecycle = new DefaultApplicationLifecycle()
+    )
     new BuiltInComponentsFromContext(context) with CSRFComponents {
       override def router: Router = ???
 


### PR DESCRIPTION
Reverts guardian/support-frontend#2683

There were conflicts with the payment api merging into the mono repo, reverting in order to resolve them at our leisure rather than with a broken main build!