### PR TITLE
Fix for safari recaptcha bug (recurring contributions)

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
@@ -184,7 +184,7 @@ const CardForm = (props: PropTypes) => {
     }
   };
 
-  const recaptchaElementEmpty = (): boolean => {
+  const recaptchaElementNotEmpty = (): boolean => {
     const el = document.getElementById('robot_checkbox');
     if (el) {
       return el.children.length > 0;
@@ -196,7 +196,7 @@ const CardForm = (props: PropTypes) => {
   const setupRecurringRecaptchaCallback = () => {
     setCalledRecaptchaRender(true);
     // Fix for safari, where the calledRecaptchaRender state handling does not work. TODO - find a better solution
-    if (recaptchaElementEmpty()) {
+    if (recaptchaElementNotEmpty()) {
       return;
     }
 

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
@@ -187,6 +187,11 @@ const CardForm = (props: PropTypes) => {
   // Creates a new setupIntent upon recaptcha verification
   const setupRecurringRecaptchaCallback = () => {
     setCalledRecaptchaRender(true);
+    // Fix for safari, where the calledRecaptchaRender state handling does not work. TODO - find a better solution
+    if (document.getElementById('robot_checkbox').children.length > 0) {
+      return;
+    }
+
     window.grecaptcha.render('robot_checkbox', {
       sitekey: window.guardian.v2recaptchaPublicKey,
       callback: (token) => {

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
@@ -184,11 +184,19 @@ const CardForm = (props: PropTypes) => {
     }
   };
 
+  const recaptchaElementEmpty = (): boolean => {
+    const el = document.getElementById('robot_checkbox');
+    if (el) {
+      return el.children.length > 0;
+    }
+    return true;
+  };
+
   // Creates a new setupIntent upon recaptcha verification
   const setupRecurringRecaptchaCallback = () => {
     setCalledRecaptchaRender(true);
     // Fix for safari, where the calledRecaptchaRender state handling does not work. TODO - find a better solution
-    if (document.getElementById('robot_checkbox').children.length > 0) {
+    if (recaptchaElementEmpty()) {
       return;
     }
 


### PR DESCRIPTION
- safari only
- recurring only

The bug:
1. select card
2. select paypal. It gets stuck on card.

It is caused by recaptcha being loaded twice.
It uses some state called `calledRecaptchaRender` to ensure this doesn't happen, and this works in other browsers but not safari for some reason.

This fix is not ideal, and we should try to understand it better.
But it does at least work, by ensuring the recaptcha div is empty before trying to load it.