### PR TITLE
Add iMovo campaign images and fix thank you page

### DIFF
--- a/support-frontend/assets/helpers/theGrid.js
+++ b/support-frontend/assets/helpers/theGrid.js
@@ -108,6 +108,9 @@ export const imageCatalogue: {
   printFeaturePackshot: '017a2f5c27394635b53c414962bbb775ce9b131d/5_39_1572_861',
   printCampaign2020: 'e50943f03b58caf6fde78d81eb65c92c048701c9/1844_0_1674_1006',
   printCampaignHero: 'fff86e98dbe83b36892baf7942f30fd3bcbcaee6/286_215_714_285',
+  printCampaigniMovo: 'f257e33b922f09ca180cc9205e0c766c2c2d529c/28_0_694_694',
+  printCampaignHD: '817936f0d1a2755c778b523b5ac5daa2d2f27449/10_0_716_694',
+  printCheckoutiMovo: '15677cf8f82a5690bec39bf73b2c098c8f79b24f/15_0_667_400',
 };
 
 // Utility type: https://flow.org/en/docs/types/utilities/#toc-keys

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/orderSummary/orderSummaryStyles.js
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/orderSummary/orderSummaryStyles.js
@@ -61,24 +61,19 @@ export const contentBlock = css`
 export const imageContainer = css`
   display: inline-flex;
   align-items: flex-start;
-  width: calc(100% - 30px);
-  padding: ${space[4]}px ${space[3]}px 0;
+  padding: 0;
   background-color: ${neutral['97']};
 
   img {
     width: 100%;
     height: auto;
-
   }
 
   ${until.tablet} {
-    width: 65px;
-    height: 73px;
-    padding-top: 8px;
-    padding-left: 8px;
+    width: 75px;
+    height: 45px;
     overflow: hidden;
     img {
-      width: 200%;
       align-items: flex-end;
     }
   }

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
@@ -195,8 +195,8 @@ function PaperCheckoutForm(props: PropTypes) {
   const subsCardOrderSummary = (<OrderSummary
     image={
       <GridImage
-        gridId="checkoutPackshotPaperGraunVoucher"
-        srcSizes={[696, 500]}
+        gridId="printCheckoutiMovo"
+        srcSizes={[500]}
         sizes="(max-width: 740px) 50vw, 696"
         imgType="png"
         altText=""

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/thankYou.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/thankYou.jsx
@@ -64,7 +64,7 @@ const whatNextText: { [FulfilmentOptions]: { [key: string]: Array<string> } } = 
     ],
     digitalVoucher: [
       `Keep an eye on your inbox. You should receive an email confirming the details of your subscription,
-        and another email shortly afterwards that contains details of how you can pick up your papers from today!`,
+        and another email shortly afterwards that contains details of how you can pick up your papers from tomorrow!`,
       `You will receive your Subscription Card in your subscriber pack in the post, along with your home
         delivery letter.`,
       `Visit your chosen participating newsagent to pick up your paper using your Subscription Card, or

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/deliveryTab.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/deliveryTab.jsx
@@ -40,7 +40,7 @@ const ContentDeliveryFaqBlock = ({
   <Content
     border={paperHasDeliveryEnabled()}
     image={<GridImage
-      gridId="paperDeliveryFeature"
+      gridId="printCampaignHD"
       srcSizes={[920, 500, 140]}
       sizes="(max-width: 740px) 100vw, 500px"
       imgType="png"

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/subsCardTab.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/subsCardTab.jsx
@@ -32,7 +32,7 @@ const SubsCardFaqBlock = () => (
   <Content
     border={paperHasDeliveryEnabled()}
     image={<GridImage
-      gridId="paperVoucherFeature"
+      gridId="printCampaigniMovo"
       srcSizes={[750, 500, 140]}
       sizes="(max-width: 740px) 100vw, 400px"
       imgType="png"


### PR DESCRIPTION
## Why are you doing this?
This is (🤞 ) the last part of the Newspaper subscriptions card work that was outstanding. The images on the landing page and the order summary image needed updating, and the thank you page had a piece of text that needed to be changed.

[**Trello Card**](https://trello.com/c/Fp3BY2yz/3269-corrections-for-subscriptions-card-checkout-post-prod-test)

## Changes
* Replace paper landing page HD tab to show new campaign image
* Add paper landing page subscriptions card image
* Replace order summary image in checkout with subscriptions card image
* Update thank you page with 'tomorrow' rather than 'today' as the day you can collect your first papers

## Did you enjoy your PR experience
 - [ ] [PR experience rated](https://forms.gle/N6FsTGG8JQFGV4Ha9)

## Screenshots
![support thegulocal com_uk_subscribe_paper_delivery(wide) (3)](https://user-images.githubusercontent.com/16781258/91874593-4ec23a00-ec72-11ea-8a40-45979b0c557c.png)

![support thegulocal com_uk_subscribe_paper_delivery(wide) (4)](https://user-images.githubusercontent.com/16781258/91874620-55e94800-ec72-11ea-9a07-27810200a7b2.png)

![support thegulocal com_subscribe_paper_checkout_fulfilment=Collection product=Weekend(wide) (1)](https://user-images.githubusercontent.com/16781258/91874731-7d401500-ec72-11ea-8577-ca324fee4aa5.png)

### Mobile order summary

![Screen Shot 2020-09-01 at 17 20 57](https://user-images.githubusercontent.com/16781258/91878732-a57e4280-ec77-11ea-85a5-3d234d400b54.png)
