### PR TITLE
Update Weekly gifting-related CTAs

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -215,7 +215,7 @@ const content = (
         </ProductPageInfoChip>
       </Content>
       <Content>
-        <Text title={orderIsAGift ? 'Looking for a personal subscription?' : 'Gift subscriptions'}>
+        <Text title={orderIsAGift ? 'Looking for a subscription for yourself?' : 'Gift subscriptions'}>
           {!orderIsAGift && <LargeParagraph>A Guardian Weekly subscription makes a great gift.</LargeParagraph>}
         </Text>
         <AnchorButton
@@ -223,7 +223,7 @@ const content = (
           appearance="blue"
           href={orderIsAGift ? routes.guardianWeeklySubscriptionLanding : routes.guardianWeeklySubscriptionLandingGift}
         >
-          {orderIsAGift ? 'See all subscriptions' : 'See all gift subscriptions'}
+          {orderIsAGift ? 'See personal subscriptions' : 'See gift subscriptions'}
         </AnchorButton>
       </Content>
       <ConsentBanner />


### PR DESCRIPTION
## Why are you doing this?

Small update to clarify the text on the CTAs that take you back and forth between gifted and personal Guardian Weekly subscriptions.

[**Trello Card**](https://trello.com/c/HBAPYBQ7)

## Changes

* Amended text in the title and CTA buttons of this section on the GW landing page

## Screenshots

### Main landing page

**Mobile**
![Screenshot 2020-09-04 at 13 03 23](https://user-images.githubusercontent.com/29146931/92237390-312de400-eeaf-11ea-896e-f3698987c500.png)

**Tablet**
![Screenshot 2020-09-04 at 13 03 38](https://user-images.githubusercontent.com/29146931/92237392-325f1100-eeaf-11ea-91a3-2edc00285d77.png)

**Desktop**
![Screenshot 2020-09-04 at 11 43 22](https://user-images.githubusercontent.com/29146931/92237398-33903e00-eeaf-11ea-9ac7-10ec852faf2a.png)

### Gifting landing page

**Mobile**
![Screenshot 2020-09-04 at 12 11 00](https://user-images.githubusercontent.com/29146931/92237405-35f29800-eeaf-11ea-8360-4f3f3ca6e9a1.png)

**Tablet**
![Screenshot 2020-09-04 at 13 03 49](https://user-images.githubusercontent.com/29146931/92237411-3854f200-eeaf-11ea-8e63-cf10ab042f32.png)

**Desktop**
![Screenshot 2020-09-04 at 13 02 09](https://user-images.githubusercontent.com/29146931/92237416-3a1eb580-eeaf-11ea-8662-cd017de30901.png)