### PR TITLE
Fix image overlapping text on paper subs page

### DIFF
--- a/support-frontend/assets/components/content/content.scss
+++ b/support-frontend/assets/components/content/content.scss
@@ -199,7 +199,7 @@
   top: ($gu-v-spacing*2)*-1;
   .component-grid-image {
     display: none;
-    @include mq($from: tablet) {
+    @include mq($from: desktop) {
       display: block;
       width: 100%;
     }

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/deliveryTab.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/deliveryTab.jsx
@@ -41,8 +41,8 @@ const ContentDeliveryFaqBlock = ({
     border={paperHasDeliveryEnabled()}
     image={<GridImage
       gridId="printCampaignHD"
-      srcSizes={[920, 500, 140]}
-      sizes="(max-width: 740px) 100vw, 500px"
+      srcSizes={[716, 500, 140]}
+      sizes="(max-width: 740px) 100vw, 400px"
       imgType="png"
     />
     }


### PR DESCRIPTION
## Why are you doing this?

This fixes a bug where the image is appearing and overlapping text on the tabs on the paper subscriptions landing page, at the tablet breakpoint.

[**Trello Card**](https://trello.com/c/rX0wrtop)

## Changes

* Have images display from the desktop breakpoint instead of from the tablet breakpoint
* Fix sizes provided for the new home delivery image

## Did you enjoy your PR experience?

 - [ ] [PR experience rated](https://forms.gle/N6FsTGG8JQFGV4Ha9)

## Screenshots

**Before**
![Screenshot 2020-09-09 at 17 02 34](https://user-images.githubusercontent.com/29146931/92624625-a4749300-f2bf-11ea-9424-685037fdc6b0.png)

**After**
![Screenshot 2020-09-09 at 17 02 52](https://user-images.githubusercontent.com/29146931/92624636-a76f8380-f2bf-11ea-9198-13243d306a75.png)
