### PR TITLE
Remove default payment ab test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -8,7 +8,6 @@ const usOnlyLandingPage = '/us/contribute(/.*)?$';
 const auOnlyLandingPage = '/au/contribute(/.*)?$';
 const ukOnlyLandingPage = '/uk/contribute(/.*)?$';
 const allBarUkLandingPages = '/((?!uk).)*/contribute(/.*)?$';
-const allLandingPages = '/??/contribute(/.*)?$';
 export const subsShowcaseAndDigiSubPages = '(/??/subscribe(\\?.*)?$|/??/subscribe/digital(\\?.*)?$)';
 
 export const tests: Tests = {
@@ -79,28 +78,6 @@ export const tests: Tests = {
     referrerControlled: false,
     targetPage: ukOnlyLandingPage,
     seed: 9,
-  },
-
-  defaultPaymentMethodTest: {
-    type: 'OTHER',
-    variants: [
-      {
-        id: 'control',
-      },
-      {
-        id: 'noDefault',
-      },
-    ],
-    audiences: {
-      ALL: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: true,
-    referrerControlled: false,
-    targetPage: allLandingPages,
-    seed: 1,
   },
 
   landingPageRetentionR1: {

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingInit.js
@@ -41,8 +41,6 @@ import { AmazonPay, PayPal } from 'helpers/paymentMethods';
 
 // ----- Functions ----- //
 
-const isThankYouPage = () => window.location.href.includes('thankyou');
-
 function getInitialPaymentMethod(
   contributionType: ContributionType,
   countryId: IsoCountry,
@@ -51,18 +49,12 @@ function getInitialPaymentMethod(
   const paymentMethodFromSession = getPaymentMethodFromSession();
   const validPaymentMethods = getValidPaymentMethods(contributionType, switches, countryId);
 
-  // The most likely reason for this being called on the thankyou page is that the user
-  // is getting redirected back from a paypal payment. Regardless, here we want to grab
-  // the payment method from the session.
-  if (isThankYouPage()) {
-    if (
-      paymentMethodFromSession &&
-      validPaymentMethods.includes(paymentMethodFromSession)
-    ) {
-      return paymentMethodFromSession;
-    }
+  if (
+    paymentMethodFromSession &&
+    validPaymentMethods.includes(paymentMethodFromSession)
+  ) {
+    return paymentMethodFromSession;
   }
-  // Otherwise, we wan't nothing selected by default (data compliance)
   return 'None';
 }
 


### PR DESCRIPTION
## Why are you doing this?
Remove default payment test and roll variant out as the default. Also fixes a bug where the paymentMethod was being set to "None" after a one-off contribution with paypal (as it leaves then redirects back to the site). 