### PR TITLE
Hide consent banner during OneOffContributionsSpec

### DIFF
--- a/support-frontend/test/selenium/contributions/OneOffContributionsSpec.scala
+++ b/support-frontend/test/selenium/contributions/OneOffContributionsSpec.scala
@@ -81,7 +81,7 @@ class OneOffContributionsSpec extends AnyFeatureSpec
     Scenario("Check browser navigates to paypal") {
       val testUser = new TestUser {
         val username = "test-stripe-pop-up"
-        driverConfig.addCookie(name = "GU_TK", value = "1.1") //To avoid consent banner, which messes with selenium
+        driverConfig.addCookie(name = "_post_deploy_user", value = "true") //To avoid consent banner, which messes with selenium
       }
 
       val landingPage = ContributionsLanding("au", testUser)


### PR DESCRIPTION
## Why are you doing this?

The OneOffContributionsSpec selenium test was not adding the `_post_deploy_user` cookie correctly which was causing the consent banner to interfere with its execution. This PR fixes that.
