### PR TITLE
Digital Subscription gift code expiry

### DIFF
--- a/support-models/src/main/scala/com/gu/support/zuora/api/response/QueryResponse.scala
+++ b/support-models/src/main/scala/com/gu/support/zuora/api/response/QueryResponse.scala
@@ -6,6 +6,8 @@ import com.gu.support.encoding.JsonHelpers.JsonObjectExtensions
 import com.gu.support.redemptions.RedemptionCode
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
+import org.joda.time.LocalDate
+import com.gu.support.encoding.CustomCodecs._
 
 object AccountQueryResponse {
   implicit val codec: Codec[AccountQueryResponse] = deriveCodec
@@ -45,4 +47,9 @@ case class PaymentMethodRecord(DefaultPaymentMethodId: String)
 
 case class SubscriptionRedemptionQueryResponse(records: List[SubscriptionRedemptionFields])
 
-case class SubscriptionRedemptionFields(id: String, createdRequestId: String, gifteeIdentityId: Option[String])
+case class SubscriptionRedemptionFields(
+  id: String,
+  contractEffectiveDate: LocalDate,
+  createdRequestId: String,
+  gifteeIdentityId: Option[String]
+)

--- a/support-models/src/test/scala/com/gu/support/zuora/api/SerialisationSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/zuora/api/SerialisationSpec.scala
@@ -174,4 +174,25 @@ class SerialisationSpec extends AsyncFlatSpec with SerialisationTestHelpers with
     })
   }
 
+  "SubscriptionRedemptionQueryResponse" should "deserialise correctly" in {
+    val jsonResponse = """
+        {
+        "records": [
+            {
+                "CreatedRequestId__c": "35b4c314-d982-4386-983e-2e8c453f50be",
+                "Id": "2c92c0f8742dcaf5017434d002e73a56",
+                "ContractEffectiveDate": "2020-08-09"
+            }
+        ],
+        "done": true,
+        "size": 1
+    }
+    """
+
+    testDecoding[SubscriptionRedemptionQueryResponse](
+      jsonResponse,
+      subResponse => subResponse.records.head.contractEffectiveDate.getDayOfMonth shouldBe 9
+    )
+  }
+
 }

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -254,6 +254,8 @@ object CreateZuoraSubscription {
 
 object DigitalSubscriptionGiftRedemption {
 
+  val expirationTimeInMonths = 12
+
   sealed abstract class SubscriptionRedemptionState(val clientCode: String)
 
   object Unredeemed {
@@ -298,7 +300,7 @@ object DigitalSubscriptionGiftRedemption {
 
   def getSubscriptionState(existingSub: SubscriptionRedemptionQueryResponse, requestId: String) =
     existingSub.records match {
-      case existingSubFields :: Nil if existingSubFields.contractEffectiveDate.plusYears(1).isBefore(LocalDate.now()) =>
+      case existingSubFields :: Nil if existingSubFields.contractEffectiveDate.plusMonths(expirationTimeInMonths).isBefore(LocalDate.now()) =>
         Expired
       case existingSubFields :: Nil if existingSubFields.gifteeIdentityId.isEmpty =>
         Unredeemed(existingSubFields.id)

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -254,18 +254,24 @@ object CreateZuoraSubscription {
 
 object DigitalSubscriptionGiftRedemption {
 
-  sealed trait SubscriptionState
+  sealed abstract class SubscriptionState(val clientCode: String)
 
-  case class Unredeemed(subscriptionId: String) extends SubscriptionState
+  object Unredeemed {
+    val clientCode = "unredeemed"
+  }
+
+  case class Unredeemed(subscriptionId: String) extends SubscriptionState(Unredeemed.clientCode)
 
   // This can happen if Zuora is responding very slowly - a redemption request may succeed but not return a response
   // until after the CreateZuoraSubscription lambda has timed out meaning that the redemption will be retried with the
   // same requestId. In this case we want the lambda to succeed so that we progress to the next lambda
-  case object RedeemedInThisRequest extends SubscriptionState
+  case object RedeemedInThisRequest extends SubscriptionState("redeemed_in_this_request")
 
-  case object Redeemed extends SubscriptionState
+  case object Redeemed extends SubscriptionState("redeemed")
 
-  case object NotFound extends SubscriptionState
+  case object Expired extends SubscriptionState("expired")
+
+  case object NotFound extends SubscriptionState("not_found")
 
   def maybeDigitalSubscriptionGiftRedemption(product: ProductType, paymentMethod: Either[PaymentMethod, RedemptionData]) = {
     product match {
@@ -286,13 +292,14 @@ object DigitalSubscriptionGiftRedemption {
         getSubscriptionState(redemptionQueryResponse, state.requestId.toString) match {
           case Unredeemed(subscriptionId) => redeemInZuora(subscriptionId, state, redemptionData, requestInfo, zuoraService, catalogService)
           case RedeemedInThisRequest => Future.fromTry(buildHandlerResult(UpdateRedemptionDataResponse(true), state, redemptionData, requestInfo))
-          case Redeemed => Future.failed(new RuntimeException(GetCodeStatus.CodeAlreadyUsed.clientCode))
-          case NotFound => Future.failed(new RuntimeException(GetCodeStatus.NoSuchCode.clientCode))
+          case otherState: SubscriptionState => Future.failed(new RuntimeException(otherState.clientCode))
         }
     )
 
-  private def getSubscriptionState(existingSub: SubscriptionRedemptionQueryResponse, requestId: String) =
+  def getSubscriptionState(existingSub: SubscriptionRedemptionQueryResponse, requestId: String) =
     existingSub.records match {
+      case existingSubFields :: Nil if existingSubFields.contractEffectiveDate.plusYears(1).isBefore(LocalDate.now()) =>
+        Expired
       case existingSubFields :: Nil if existingSubFields.gifteeIdentityId.isEmpty =>
         Unredeemed(existingSubFields.id)
       case existingSubFields :: Nil if existingSubFields.createdRequestId == requestId =>

--- a/support-workers/src/main/scala/com/gu/zuora/ZuoraService.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/ZuoraService.scala
@@ -91,8 +91,10 @@ class ZuoraService(val config: ZuoraConfig, client: FutureHttpClient, baseUrl: O
 
   def getSubscriptionFromRedemptionCode(redemptionCode: RedemptionCode): Future[SubscriptionRedemptionQueryResponse] = {
     val queryData = QueryData(
-      //TODO RB expire codes
-      s"select id, CreatedRequestId__c, GifteeIdentityId__c from subscription where RedemptionCode__c = '${redemptionCode.value}' and status = 'Active'"
+      s"""
+        select id, contractEffectiveDate, CreatedRequestId__c, GifteeIdentityId__c
+        from subscription
+        where RedemptionCode__c = '${redemptionCode.value}' and status = 'Active'"""
     )
     postJson[SubscriptionRedemptionQueryResponse](s"action/query", queryData.asJson, authHeaders)
   }

--- a/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilder.scala
@@ -15,6 +15,7 @@ import com.gu.support.redemption.generator.CodeBuilder.GiftCode
 import com.gu.support.redemption.generator.GiftCodeGeneratorService
 import com.gu.support.redemptions.{RedemptionCode, RedemptionData}
 import com.gu.support.workers.ProductTypeRatePlans._
+import com.gu.support.workers.lambdas.DigitalSubscriptionGiftRedemption
 import com.gu.support.workers.{Annual, BillingPeriod, DigitalPack, Quarterly}
 import com.gu.support.zuora.api.ReaderType.{Corporate, Direct, Gift}
 import com.gu.support.zuora.api.{ReaderType, SubscriptionData}
@@ -70,7 +71,7 @@ object DigitalSubscriptionBuilder {
   )(implicit ec: ExecutionContext): BuildResult = {
 
     val (contractAcceptanceDelay, autoRenew, initialTerm) = if (readerType == Gift)
-      (0, false, 13) // Expiry for gift redemption codes is 12 months so set the initial term to 13 to allow for this
+      (0, false, DigitalSubscriptionGiftRedemption.expirationTimeInMonths + 1)
     else
       (purchase.config.defaultFreeTrialPeriod + purchase.config.paymentGracePeriod, true, 12)
 

--- a/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilder.scala
@@ -70,7 +70,7 @@ object DigitalSubscriptionBuilder {
   )(implicit ec: ExecutionContext): BuildResult = {
 
     val (contractAcceptanceDelay, autoRenew, initialTerm) = if (readerType == Gift)
-      (0, false, purchase.billingPeriod.monthsInPeriod)
+      (0, false, 13) // Expiry for gift redemption codes is 12 months so set the initial term to 13 to allow for this
     else
       (purchase.config.defaultFreeTrialPeriod + purchase.config.paymentGracePeriod, true, 12)
 

--- a/support-workers/src/test/scala/com/gu/support/workers/DigitalSubscriptionGiftRedemptionSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/DigitalSubscriptionGiftRedemptionSpec.scala
@@ -1,0 +1,75 @@
+package com.gu.support.workers
+
+import com.gu.support.SerialisationTestHelpers
+import com.gu.support.workers.lambdas.DigitalSubscriptionGiftRedemption
+import com.gu.support.workers.lambdas.DigitalSubscriptionGiftRedemption.{Expired, Redeemed, RedeemedInThisRequest, Unredeemed}
+import com.gu.support.zuora.api.response.{SubscriptionRedemptionFields, SubscriptionRedemptionQueryResponse}
+import org.joda.time.LocalDate
+import org.scalatest.flatspec.AnyFlatSpec
+
+class DigitalSubscriptionGiftRedemptionSpec extends AnyFlatSpec with SerialisationTestHelpers {
+  "SubscriptionRedemptionQueryResponse" should "deserialise correctly" in {
+    val jsonResponse = """
+        {
+        "records": [
+            {
+                "CreatedRequestId__c": "35b4c314-d982-4386-983e-2e8c453f50be",
+                "Id": "2c92c0f8742dcaf5017434d002e73a56",
+                "ContractEffectiveDate": "2020-08-09"
+            }
+        ],
+        "done": true,
+        "size": 1
+    }
+    """
+
+    testDecoding[SubscriptionRedemptionQueryResponse](
+      jsonResponse,
+      subResponse => subResponse.records.head.contractEffectiveDate.getDayOfMonth shouldBe 9
+    )
+  }
+
+  "DigitalSubscriptionGiftRedemption" should "identify an unredeemed subscription from a SubscriptionRedemptionQueryResponse" in {
+    val response = SubscriptionRedemptionQueryResponse(List(SubscriptionRedemptionFields("1", LocalDate.now(), "123", None)))
+    val state = DigitalSubscriptionGiftRedemption.getSubscriptionState(response, "123")
+    state.clientCode shouldBe Unredeemed.clientCode
+  }
+
+  it should "identify a redeemed subscription from a SubscriptionRedemptionQueryResponse" in {
+    val createdRequestId = "123"
+    val thisRequestId = "456"
+    val response = SubscriptionRedemptionQueryResponse(
+      List(SubscriptionRedemptionFields(
+        id = "1",
+        contractEffectiveDate = LocalDate.now(),
+        createdRequestId = createdRequestId,
+        gifteeIdentityId = Some("123456789")
+      )))
+    val state = DigitalSubscriptionGiftRedemption.getSubscriptionState(response, thisRequestId)
+    state.clientCode shouldBe Redeemed.clientCode
+  }
+
+  it should "identify a 'redeemed in this response' subscription from a SubscriptionRedemptionQueryResponse" in {
+    val response = SubscriptionRedemptionQueryResponse(
+      List(SubscriptionRedemptionFields(
+        id = "1",
+        contractEffectiveDate = LocalDate.now(),
+        createdRequestId = "123",
+        gifteeIdentityId = Some("123456789"))
+      ))
+    val state = DigitalSubscriptionGiftRedemption.getSubscriptionState(response, "123")
+    state.clientCode shouldBe RedeemedInThisRequest.clientCode
+  }
+
+  it should "identify an expired subscription code from a SubscriptionRedemptionQueryResponse" in {
+    val response = SubscriptionRedemptionQueryResponse(
+      List(SubscriptionRedemptionFields(
+        id = "1",
+        contractEffectiveDate = new LocalDate(1999, 12, 31),
+        createdRequestId = "123",
+        gifteeIdentityId = None)
+      ))
+    val state = DigitalSubscriptionGiftRedemption.getSubscriptionState(response, "456")
+    state.clientCode shouldBe Expired.clientCode
+  }
+}

--- a/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilderSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilderSpec.scala
@@ -78,7 +78,7 @@ class DigitalSubscriptionBuilderSpec extends AsyncFlatSpec with Matchers {
       readerType shouldBe Gift
       redemptionCode.isDefined shouldBe true
       redemptionCode.get.substring(0, 4) shouldBe "gd03"
-      initialTerm shouldBe 3 //TODO: RB check that this is correct
+      initialTerm shouldBe 13
       initialTermPeriodType shouldBe Month
       promoCode shouldBe None
       corporateAccountId shouldBe None

--- a/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilderSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilderSpec.scala
@@ -11,6 +11,7 @@ import com.gu.support.redemption.GetCodeStatus.InvalidReaderType
 import com.gu.support.redemption.generator.GiftCodeGeneratorService
 import com.gu.support.redemption.{DynamoLookup, GetCodeStatus}
 import com.gu.support.redemptions.{RedemptionCode, RedemptionData}
+import com.gu.support.workers.lambdas.DigitalSubscriptionGiftRedemption
 import com.gu.support.workers.{DigitalPack, Monthly, Quarterly}
 import com.gu.support.zuora.api.ReaderType.{Corporate, Gift}
 import com.gu.support.zuora.api._
@@ -78,7 +79,7 @@ class DigitalSubscriptionBuilderSpec extends AsyncFlatSpec with Matchers {
       readerType shouldBe Gift
       redemptionCode.isDefined shouldBe true
       redemptionCode.get.substring(0, 4) shouldBe "gd03"
-      initialTerm shouldBe 13
+      initialTerm shouldBe DigitalSubscriptionGiftRedemption.expirationTimeInMonths + 1
       initialTermPeriodType shouldBe Month
       promoCode shouldBe None
       corporateAccountId shouldBe None


### PR DESCRIPTION
## Why are you doing this?

We want Digital Subscription gift codes to expire if they haven't been redeemed within one year. This PR does that

[**Trello Card**](https://trello.com)

## Changes
* Rename `SubscriptionState` to `SubscriptionRedemptionState`
* introduces a new `Expired` `SubscriptionRedemptionState`
* Update the length of the initial term for gifts to 13 months so that it is longer than the expiry period - this will get set to the correct length upon redemption



