### PR TITLE
Add `enableDigitalSubGifting` into Switches

### DIFF
--- a/support-frontend/app/admin/settings/Switches.scala
+++ b/support-frontend/app/admin/settings/Switches.scala
@@ -6,6 +6,7 @@ import com.gu.support.encoding.Codec.deriveCodec
 case class Switches(
   oneOffPaymentMethods: PaymentMethodsSwitch,
   recurringPaymentMethods: PaymentMethodsSwitch,
+  enableDigitalSubGifting: SwitchState,
   useDotcomContactPage: Option[SwitchState],
   enableRecaptchaBackend: SwitchState,
   enableRecaptchaFrontend: SwitchState,

--- a/support-frontend/test/codecs/CirceDecodersTest.scala
+++ b/support-frontend/test/codecs/CirceDecodersTest.scala
@@ -119,6 +119,7 @@ class CirceDecodersTest extends AnyWordSpec with Matchers {
           |        "state": "On"
           |      }
           |    },
+          |    "enableDigitalSubGifting": "On",
           |    "useDotcomContactPage": "Off",
           |    "enableRecaptchaFrontend": "Off",
           |    "enableRecaptchaBackend": "Off"
@@ -289,6 +290,7 @@ class CirceDecodersTest extends AnyWordSpec with Matchers {
               state = On
             )
           ),
+          enableDigitalSubGifting = On,
           useDotcomContactPage = Some(Off),
           enableRecaptchaBackend = Off,
           enableRecaptchaFrontend = Off

--- a/support-frontend/test/controllers/SubscriptionsTest.scala
+++ b/support-frontend/test/controllers/SubscriptionsTest.scala
@@ -71,7 +71,9 @@ class SubscriptionsTest extends AnyWordSpec with Matchers with TestCSRFComponent
       Switches(
         oneOffPaymentMethods = PaymentMethodsSwitch(On, On, On, On, None, None, None, None),
         recurringPaymentMethods = PaymentMethodsSwitch(On, On, On, On, Some(On), Some(On), Some(On), None),
-        experiments = Map.empty, useDotcomContactPage = Some(SwitchState.Off),
+        experiments = Map.empty,
+        enableDigitalSubGifting = On,
+        useDotcomContactPage = Some(SwitchState.Off),
         enableRecaptchaBackend = Off,
         enableRecaptchaFrontend = Off
       ),


### PR DESCRIPTION
## Why are you doing this?
To add the `enableDigitalSubGifting` switch into the Switches object

Follows on from the admin console PR https://github.com/guardian/support-admin-console/pull/157