### PR TITLE
Upgrade Play from v2.6.23 to v2.7.5

### DIFF
--- a/project/LibraryVersions.scala
+++ b/project/LibraryVersions.scala
@@ -6,4 +6,5 @@ object LibraryVersions {
   val jacksonVersion = "2.10.5"
   val okhttpVersion = "3.10.0"
   val scalaUriVersion = "2.2.2"
+  val playCirceVersion = "2712.0"
 }

--- a/project/LibraryVersions.scala
+++ b/project/LibraryVersions.scala
@@ -7,4 +7,6 @@ object LibraryVersions {
   val okhttpVersion = "3.10.0"
   val scalaUriVersion = "2.2.2"
   val playCirceVersion = "2712.0"
+  val AWSJavaSDKVersion = "1.11.568"
+  val stripeVersion = "10.12.0" // Supports API version 2019-05-16
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.5")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.5") // when updating major version, also update play-circe version
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,7 +6,7 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
 
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.23")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.5")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
 

--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -22,7 +22,7 @@ libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-s3" % awsClientVersion,
   "com.amazonaws" % "aws-java-sdk-lambda" % awsClientVersion,
   "org.typelevel" %% "cats-core" % "1.0.1",
-  "com.dripower" %% "play-circe" % "2609.1",
+  "com.dripower" %% "play-circe" % playCirceVersion,
   "com.gu" %% "fezziwig" % "1.3",
   "io.circe" %% "circe-core" % circeVersion,
   "io.circe" %% "circe-generic" % circeVersion,

--- a/support-frontend/test/fixtures/TestCSRFComponents.scala
+++ b/support-frontend/test/fixtures/TestCSRFComponents.scala
@@ -13,14 +13,7 @@ trait TestCSRFComponents {
 
   private lazy val appComponents = {
     val env = Environment.simple(new File("."))
-    val configuration = Configuration.load(env)
-    val context = ApplicationLoader.Context(
-      environment = env,
-      sourceMapper = None,
-      webCommands = new DefaultWebCommands(),
-      initialConfiguration = configuration,
-      lifecycle = new DefaultApplicationLifecycle()
-    )
+    val context = ApplicationLoader.Context.create(env)
     new BuiltInComponentsFromContext(context) with CSRFComponents {
       override def router: Router = ???
 

--- a/support-payment-api/build.sbt
+++ b/support-payment-api/build.sbt
@@ -14,6 +14,7 @@ val circeVersion = "0.11.1"
 val AWSJavaSDKVersion = "1.11.568"
 val jacksonVersion = "2.10.0"
 val stripeVersion = "10.12.0" // Supports API version 2019-05-16
+val playCirceVersion = "2712.0"
 
 libraryDependencies ++= Seq(
   "ch.qos.logback" % "logback-classic" % "1.2.3",
@@ -26,7 +27,7 @@ libraryDependencies ++= Seq(
   "com.amazon.pay" % "amazon-pay-java-sdk" % "3.6.2",
   "com.beachape" %% "enumeratum" % "1.5.12",
   "com.beachape" %% "enumeratum-circe" % "1.5.12",
-  "com.dripower" %% "play-circe" % "2611.0",
+  "com.dripower" %% "play-circe" % playCirceVersion,
   "com.github.mpilquist" %% "simulacrum" % "0.11.0",
   "com.stripe" % "stripe-java" % stripeVersion,
   "com.gocardless" % "gocardless-pro" % "2.8.0",

--- a/support-payment-api/build.sbt
+++ b/support-payment-api/build.sbt
@@ -1,3 +1,5 @@
+import LibraryVersions._
+
 name := "payment-api"
 
 version := "0.1"
@@ -9,12 +11,6 @@ scalacOptions ++= Seq(
 
 addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.6")
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
-
-val circeVersion = "0.11.1"
-val AWSJavaSDKVersion = "1.11.568"
-val jacksonVersion = "2.10.0"
-val stripeVersion = "10.12.0" // Supports API version 2019-05-16
-val playCirceVersion = "2712.0"
 
 libraryDependencies ++= Seq(
   "ch.qos.logback" % "logback-classic" % "1.2.3",

--- a/support-payment-api/src/test/scala/controllers/AmazonPayControllerSpec.scala
+++ b/support-payment-api/src/test/scala/controllers/AmazonPayControllerSpec.scala
@@ -85,13 +85,7 @@ class AmazonPayControllerSpec extends AnyWordSpec with Status with Matchers {
   implicit val materializer: Materializer = ActorMaterializer()
   implicit val executionContext: ExecutionContext = ExecutionContext.global
 
-  val context = ApplicationLoader.Context(
-    environment = Environment.simple(),
-    sourceMapper = None,
-    webCommands = new DefaultWebCommands(),
-    initialConfiguration = Configuration.load(Environment.simple()),
-    lifecycle = new DefaultApplicationLifecycle()
-  )
+  val context = ApplicationLoader.Context.create(Environment.simple())
 
   "AmazonPayController" when {
 

--- a/support-payment-api/src/test/scala/controllers/GoCardlessControllerSpec.scala
+++ b/support-payment-api/src/test/scala/controllers/GoCardlessControllerSpec.scala
@@ -86,13 +86,7 @@ class GoCardlessControllerSpec extends AnyWordSpec with Status with Matchers {
   implicit val materializer: Materializer = ActorMaterializer()
   implicit val executionContext: ExecutionContext = ExecutionContext.global
 
-  val context = ApplicationLoader.Context(
-    environment = Environment.simple(),
-    sourceMapper = None,
-    webCommands = new DefaultWebCommands(),
-    initialConfiguration = Configuration.load(Environment.simple()),
-    lifecycle = new DefaultApplicationLifecycle()
-  )
+  val context = ApplicationLoader.Context.create(Environment.simple())
 
   "GoCardless Controller" when {
 

--- a/support-payment-api/src/test/scala/controllers/PaypalControllerSpec.scala
+++ b/support-payment-api/src/test/scala/controllers/PaypalControllerSpec.scala
@@ -95,13 +95,7 @@ class PaypalControllerSpec extends AnyWordSpec with Status with Matchers {
   implicit val materializer: Materializer = ActorMaterializer()
   implicit val executionContext: ExecutionContext = ExecutionContext.global
 
-  val context = ApplicationLoader.Context(
-    environment = Environment.simple(),
-    sourceMapper = None,
-    webCommands = new DefaultWebCommands(),
-    initialConfiguration = Configuration.load(Environment.simple()),
-    lifecycle = new DefaultApplicationLifecycle()
-  )
+  val context = ApplicationLoader.Context.create(Environment.simple())
 
   "Paypal Controller" when {
 

--- a/support-payment-api/src/test/scala/controllers/StripeControllerSpec.scala
+++ b/support-payment-api/src/test/scala/controllers/StripeControllerSpec.scala
@@ -103,13 +103,7 @@ class StripeControllerSpec extends AnyWordSpec with Status with Matchers {
   implicit val materializer: Materializer = ActorMaterializer()
   implicit val executionContext: ExecutionContext = ExecutionContext.global
 
-  val context = ApplicationLoader.Context(
-    environment = Environment.simple(),
-    sourceMapper = None,
-    webCommands = new DefaultWebCommands(),
-    initialConfiguration = Configuration.load(Environment.simple()),
-    lifecycle = new DefaultApplicationLifecycle()
-  )
+  val context = ApplicationLoader.Context.create(Environment.simple())
 
   "StripeController" when {
 

--- a/support-payment-api/src/test/scala/controllers/SubscribeWithGoogleControllerSpec.scala
+++ b/support-payment-api/src/test/scala/controllers/SubscribeWithGoogleControllerSpec.scala
@@ -90,14 +90,7 @@ class SubscribeWithGoogleControllerSpec extends AnyWordSpec with Matchers with S
   implicit val materializer: Materializer = ActorMaterializer()
   implicit val executionContext: ExecutionContext = ExecutionContext.global
 
-  implicit val context = ApplicationLoader.Context(
-    environment = Environment.simple(),
-    sourceMapper = None,
-    webCommands = new DefaultWebCommands(),
-    initialConfiguration = Configuration.load(Environment.simple()),
-    lifecycle = new DefaultApplicationLifecycle()
-  )
-
+  implicit val context = ApplicationLoader.Context.create(Environment.simple())
 
   "Subscribe with Google Controller" must {
     "process a refund" in {


### PR DESCRIPTION
## Why are you doing this?

Play 2.6 is no longer supported. Security updates are now only being released for Play 2.7 and 2.8. Under our cyber essentials obligations we must only use supported software and apply all critical and high severity security updates. Play security is particularly important due to the external facing nature and the duty we have to protect our readers and business.

Following up after reverting #2683 

[**Trello Card**](https://trello.com/c/YMmpPNB3)

## Changes

* Upgrade Play version and fix breaking API changes
* Update circe libs from v0.11.1 to v0.12.1 (support-payment-api only, to match rest of monorepo)
* Update jackson libs from v2.10.0 to v2.10.5 (support-payment-api only)

## Manual tests

* Manual DS credit card checkout failing in DEV because of a Stripe failure. Error messages:
```
api.stripe.com/v1/setup_intents/seti_0HRffVItVxyc3Q6nAeHObOTQ/confirm:1 Failed to load resource: the server responded with a status of 400 ()
```
* Manual DS credit card checkout passing in CODE. Checked that the same checkout fails in CODE for the old PR #2683.

## Did you enjoy your PR experience?

 - [ ] [PR experience rated](https://forms.gle/N6FsTGG8JQFGV4Ha9)

## Accessibility test checklist
 - [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
 - [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
 - [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)


