### PR TITLE
run IT tests hourly instead of daily

### DIFF
--- a/support-lambdas/it-test-runner/cfn.yaml
+++ b/support-lambdas/it-test-runner/cfn.yaml
@@ -40,7 +40,7 @@ Resources:
         RerunTests:
           Type: Schedule
           Properties:
-            Schedule: 'rate(1 day)'
+            Schedule: 'rate(1 hour)'
             Description: run the tests regularly so we know if they're broken
       EventInvokeConfig:
         MaximumRetryAttempts: 0

--- a/support-workers/src/test/scala/com/gu/salesforce/SalesforceSpec.scala
+++ b/support-workers/src/test/scala/com/gu/salesforce/SalesforceSpec.scala
@@ -106,7 +106,7 @@ class SalesforceSpec extends AsyncFlatSpec with Matchers with LazyLogging {
     }
   }
 
-  it should "be able to add a related contact record" ignore {
+  it should "be able to add a related contact record" in {
     val service = new SalesforceService(Configuration.load().salesforceConfigProvider.get(), configurableFutureRunner(10.seconds))
 
     val name = "integration-test-recipient"

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/CreateSalesforceContactSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/CreateSalesforceContactSpec.scala
@@ -28,7 +28,7 @@ class CreateSalesforceContactSpec extends AsyncLambdaSpec with MockContext {
     }
   }
 
-  it should "upsert a gift SalesforceContactRecord" ignore {
+  it should "upsert a gift SalesforceContactRecord" in {
     val createContact = new CreateSalesforceContact()
 
     val outStream = new ByteArrayOutputStream()


### PR DESCRIPTION
## Why are you doing this?

We reduced the frequency of running IT tests because SF DEV was filling up quickly and eventually tests were failing  and it was blocking SX team.  Now that we have a PR to clean it up, we can bring it back to higher frequency. PR here to be merged also: https://github.com/guardian/support-service-lambdas/pull/700

This PR is also reverted in this change set, as these are the tests which were failing: https://github.com/guardian/support-frontend/pull/2636

The changes mean we are likely to find out about breakages within the working day, rather than a subsequent day.  This means we can either fix the tests or find potential issues quickly.

[**Trello Card**](https://trello.com/c/LKwe8ApH/3241-auto-clean-it-test-data-from-sf-dev)

## Did you enjoy your PR experience?

 - [x] [PR experience rated](https://forms.gle/N6FsTGG8JQFGV4Ha9)

