### PR TITLE
Update contributions.scala.html

### DIFF
--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -116,5 +116,5 @@
   window.guardian.recaptchaEnabled = @settings.switches.enableRecaptchaFrontend.isOn
   window.guardian.v2recaptchaPublicKey = "@v2recaptchaConfigPublicKey";
   </script>
-  <script defer id="stripe-js" src=@{s"https://js.stripe.com/v3/${if (serversideTests.get("stripeFraudDetection").contains(Variant)) "?advancedFraudSignals=false" else ""}"}></script>"
+  <script defer id="stripe-js" src=@{s"https://js.stripe.com/v3/${if (serversideTests.get("stripeFraudDetection").contains(Variant)) "?advancedFraudSignals=false" else ""}"}></script>
 }


### PR DESCRIPTION
You left an extra " and when you go to https://support.theguardian.com/uk/contribute its all the way at the bottom

## Why are you doing this?

Make @paperboyo proud

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](alert:haha no lol im a free woman no trello for me)


## Changes

* Just the quote thanks

## Did you enjoy your PR experience?

Lxds* this owns this rules i can type whatever i want here and its not going in my quarterly feedback
```
(* lxds is a gender neutral form of 'lads' that has become weirdly popular among my friends)
```

## Accessibility test checklist
 - [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
 - [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
 - [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

## Screenshots

<img width="273" alt="Screen Shot 2020-09-16 at 6 31 11 PM" src="https://user-images.githubusercontent.com/11539094/93371777-cedbc880-f84a-11ea-9d90-1fdd4a595294.png">

No after shot because life is too short to learn scala 🏎🔥