### PR TITLE
normalise email key names for braze

### DIFF
--- a/support-workers/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
@@ -21,15 +21,15 @@ object DigitalPackEmailFields {
           paymentFields(pm, directDebitMandateId) ++
             directReaderFields(promotion, billingPeriod, user, currency, paymentSchedule)
         case None /*Corporate*/ => List(
-          "Subscription details" -> "Group subscription"
+          "subscription_details" -> "Group subscription"
         )
       }
 
     val fields = List(
-      "ZuoraSubscriberId" -> subscriptionNumber,
-      "EmailAddress" -> user.primaryEmailAddress,
-      "First Name" -> user.firstName,
-      "Last Name" -> user.lastName,
+      "zuorasubscriberid" -> subscriptionNumber,
+      "emailaddress" -> user.primaryEmailAddress,
+      "first_name" -> user.firstName,
+      "last_name" -> user.lastName,
     ) ++ fieldsForReaderType
 
     val dataExtensionName = if (paidSubPaymentData.isDefined) "digipack" else "digipack-corp"
@@ -40,21 +40,21 @@ object DigitalPackEmailFields {
   def paymentFields(paymentMethod: PaymentMethod, directDebitMandateId: Option[String]): Seq[(String, String)] =
     paymentMethod match {
       case dd: DirectDebitPaymentMethod => List(
-        "Account number" -> mask(dd.bankTransferAccountNumber),
-        "Sort Code" -> hyphenate(dd.bankCode),
-        "Account Name" -> dd.bankTransferAccountName,
-        "Default payment method" -> "Direct Debit",
-        "MandateID" -> directDebitMandateId.getOrElse("")
+        "account_number" -> mask(dd.bankTransferAccountNumber),
+        "sort_code" -> hyphenate(dd.bankCode),
+        "account_name" -> dd.bankTransferAccountName,
+        "default_payment_method" -> "Direct Debit",
+        "mandateid" -> directDebitMandateId.getOrElse("")
       )
       case dd: ClonedDirectDebitPaymentMethod => List(
-        "Sort Code" -> hyphenate(dd.bankCode),
-        "Account number" -> mask(dd.bankTransferAccountNumber),
-        "Account Name" -> dd.bankTransferAccountName,
-        "Default payment method" -> "Direct Debit",
-        "MandateID" -> dd.mandateId
+        "sort_code" -> hyphenate(dd.bankCode),
+        "account_number" -> mask(dd.bankTransferAccountNumber),
+        "account_name" -> dd.bankTransferAccountName,
+        "default_payment_method" -> "Direct Debit",
+        "mandateid" -> dd.mandateId
       )
-      case _: CreditCardReferenceTransaction => List("Default payment method" -> "Credit/Debit Card")
-      case _: PayPalReferenceTransaction => Seq("Default payment method" -> "PayPal")
+      case _: CreditCardReferenceTransaction => List("default_payment_method" -> "Credit/Debit Card")
+      case _: PayPalReferenceTransaction => Seq("default_payment_method" -> "PayPal")
     }
 
   def directReaderFields(
@@ -65,13 +65,13 @@ object DigitalPackEmailFields {
     paymentSchedule: PaymentSchedule
   ): Seq[(String, String)] = {
     List(
-      "Subscription term" -> billingPeriod.noun,
-      "Payment amount" -> SubscriptionEmailFieldHelpers.formatPrice(SubscriptionEmailFieldHelpers.firstPayment(paymentSchedule).amount),
-      "Country" -> user.billingAddress.country.name,
-      "Date of first payment" -> formatDate(SubscriptionEmailFieldHelpers.firstPayment(paymentSchedule).date),
-      "Currency" -> currency.glyph,
-      "Trial period" -> "14", //TODO: depends on Promo code or zuora config
-      "Subscription details" -> SubscriptionEmailFieldHelpers.describe(paymentSchedule, billingPeriod, currency, promotion)
+      "subscription_term" -> billingPeriod.noun,
+      "payment_amount" -> SubscriptionEmailFieldHelpers.formatPrice(SubscriptionEmailFieldHelpers.firstPayment(paymentSchedule).amount),
+      "country" -> user.billingAddress.country.name,
+      "date_of_first_payment" -> formatDate(SubscriptionEmailFieldHelpers.firstPayment(paymentSchedule).date),
+      "currency" -> currency.glyph,
+      "trial_period" -> "14", //TODO: depends on Promo code or zuora config
+      "subscription_details" -> SubscriptionEmailFieldHelpers.describe(paymentSchedule, billingPeriod, currency, promotion)
     )
   }
 

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
@@ -84,24 +84,110 @@ class SendThankYouEmailSpec extends LambdaSpec {
 object SendThankYouEmailManualTest {
 
   //This test will send a thank you email to the address below - useful for quickly testing changes
-  val addressToSendTo = "rupert.bates+unitTest@theguardian.com"
-  val salesforceContactId = SfContactId("0033E00001BRKTTQA5")
+  val addressToSendTo = "john.duffell@guardian.co.uk"
+  val salesforceContactId = SfContactId("0033E00001DTBHJQA5")
 
   def main(args: Array[String]): Unit = {
-    sendContributionEmail()
-    sendDigitalPackEmail()
-    sendDigitalPackCorpEmail()
-    sendPaperSubscriptionEmail()
-    sendWeeklySubscriptionEmail()
-    sendWeeklySubscriptionGiftEmail()
+    SendContributionEmail.main(args)
+    SendDigitalPackEmail.main(args)
+    SendDigitalPackCorpEmail.main(args)
+    SendPaperSubscriptionEmail.main(args)
+    SendWeeklySubscriptionEmail.main(args)
+    SendWeeklySubscriptionGiftEmail.main(args)
   }
 
   val realConfig = Configuration.load()
 
-  def sendContributionEmail() {
-    val mandateId = "65HK26E"
-    val user = User("1234", addressToSendTo, None, "", "Mouse", billingAddress = Address(None, None, None, None, None, Country.UK))
-    val ef = ContributionEmailFields.build(
+}
+import SendThankYouEmailManualTest._
+object SendContributionEmail extends App {
+
+  val mandateId = "65HK26E"
+  val user = User("1234", addressToSendTo, None, "", "Mouse", billingAddress = Address(None, None, None, None, None, Country.UK))
+  val ef = ContributionEmailFields.build(
+    AllProductsEmailFields(
+      Monthly,
+      user,
+      GBP,
+      salesforceContactId,
+      Some(mandateId)
+    ),
+    new DateTime(1999, 12, 31, 11, 59),
+    20,
+    directDebitPaymentMethod
+  )
+  val service = new EmailService(realConfig.contributionThanksQueueName)
+  service.send(ef)
+
+}
+object SendDigitalPackEmail extends App {
+
+  val mandateId = "65HK26E"
+  val billingAddressWithCountry = Address(lineOne = None, lineTwo = None, city = None, state = None, postCode = None, country = UK)
+  val user = User("1234", addressToSendTo, None, "Mickey", "Mouse", billingAddress = billingAddressWithCountry)
+  val ef = DigitalPackEmailFields.build(
+    SubscriptionEmailFields(
+      AllProductsEmailFields(
+        Annual,
+        user,
+        GBP,
+        salesforceContactId,
+        Some(mandateId)
+      ),
+      "A-S00045678",
+      None
+    ),
+    paidSubPaymentData = Some(PaymentMethodWithSchedule(directDebitPaymentMethod, PaymentSchedule(List(Payment(new LocalDate(2019, 1, 14), 119.90)))))
+  )
+  val service = new EmailService(realConfig.contributionThanksQueueName)
+  service.send(ef)
+
+}
+object SendDigitalPackCorpEmail extends App {
+
+  val mandateId = "65HK26E"
+  val billingAddressWithCountry = Address(lineOne = None, lineTwo = None, city = None, state = None, postCode = None, country = UK)
+  val user = User("1234", addressToSendTo, None, "Mickey", "Mouse", billingAddress = billingAddressWithCountry)
+  val ef = DigitalPackEmailFields.build(
+    SubscriptionEmailFields(
+      AllProductsEmailFields(
+        Annual,
+        user,
+        GBP,
+        salesforceContactId,
+        Some(mandateId)
+      ),
+      "A-S00045678",
+      None
+    ),
+    paidSubPaymentData = None
+  )
+  val service = new EmailService(realConfig.contributionThanksQueueName)
+  service.send(ef)
+
+}
+object SendPaperSubscriptionEmail extends App {
+
+  val mandateId = "65HK26E"
+  val billingAddressWithCountry = Address(
+    lineOne = Some("90 York Way"),
+    lineTwo = None,
+    city = Some("London"),
+    state = None,
+    postCode = Some("N1 9AG"),
+    country = UK
+  )
+  val user = User(
+    "1234",
+    addressToSendTo,
+    None,
+    "Mickey",
+    "Mouse",
+    billingAddress = billingAddressWithCountry,
+    deliveryAddress = Some(billingAddressWithCountry)
+  )
+  val ef = PaperEmailFields.build(
+    SubscriptionEmailFields(
       AllProductsEmailFields(
         Monthly,
         user,
@@ -109,178 +195,99 @@ object SendThankYouEmailManualTest {
         salesforceContactId,
         Some(mandateId)
       ),
-      new DateTime(1999, 12, 31, 11, 59),
-      20,
-      directDebitPaymentMethod
-    )
-    val service = new EmailService(realConfig.contributionThanksQueueName)
-    service.send(ef)
-  }
+      "A-S00045678",
+      None
+    ),
+    Collection,
+    Saturday,
+    Some(new LocalDate(2019, 3, 26)),
+    PaymentMethodWithSchedule(directDebitPaymentMethod, PaymentSchedule(List(Payment(new LocalDate(2019, 3, 25), 62.79)))),
+  )
+  val service = new EmailService(realConfig.contributionThanksQueueName)
+  service.send(ef)
 
-  def sendDigitalPackEmail() {
-    val mandateId = "65HK26E"
-    val billingAddressWithCountry = Address(lineOne = None, lineTwo = None, city = None, state = None, postCode = None, country = UK)
-    val user = User("1234", addressToSendTo, None, "Mickey", "Mouse", billingAddress = billingAddressWithCountry)
-    val ef = DigitalPackEmailFields.build(
-      SubscriptionEmailFields(
-        AllProductsEmailFields(
-          Annual,
-          user,
-          GBP,
-          salesforceContactId,
-          Some(mandateId)
-        ),
-        "A-S00045678",
-        None
+}
+object SendWeeklySubscriptionEmail extends App {
+
+  val mandateId = "65HK26E"
+  val billingAddressWithCountry = Address(
+    lineOne = Some("90 York Way"),
+    lineTwo = None,
+    city = Some("London"),
+    state = None,
+    postCode = Some("N1 9AG"),
+    country = UK
+  )
+  val user = User(
+    "1234",
+    addressToSendTo,
+    None,
+    "Mickey",
+    "Mouse",
+    billingAddress = billingAddressWithCountry,
+    deliveryAddress = Some(billingAddressWithCountry)
+  )
+  val ef = GuardianWeeklyEmailFields.build(
+    SubscriptionEmailFields(
+      AllProductsEmailFields(
+        Quarterly,
+        user,
+        GBP,
+        salesforceContactId,
+        Some(mandateId)
       ),
-      paidSubPaymentData = Some(PaymentMethodWithSchedule(directDebitPaymentMethod, PaymentSchedule(List(Payment(new LocalDate(2019, 1, 14), 119.90)))))
-    )
-    val service = new EmailService(realConfig.contributionThanksQueueName)
-    service.send(ef)
-  }
+      "A-S00045678",
+      None
+    ),
+    Some(new LocalDate(2019, 3, 26)),
+    PaymentMethodWithSchedule(directDebitPaymentMethod, PaymentSchedule(List(
+      Payment(new LocalDate(2019, 3, 25), 37.50),
+      Payment(new LocalDate(2019, 6, 25), 37.50)
+    ))),
+  )
+  val service = new EmailService(realConfig.contributionThanksQueueName)
+  service.send(ef)
 
-  def sendDigitalPackCorpEmail() {
-    val mandateId = "65HK26E"
-    val billingAddressWithCountry = Address(lineOne = None, lineTwo = None, city = None, state = None, postCode = None, country = UK)
-    val user = User("1234", addressToSendTo, None, "Mickey", "Mouse", billingAddress = billingAddressWithCountry)
-    val ef = DigitalPackEmailFields.build(
-      SubscriptionEmailFields(
-        AllProductsEmailFields(
-          Annual,
-          user,
-          GBP,
-          salesforceContactId,
-          Some(mandateId)
-        ),
-        "A-S00045678",
-        None
+}
+object SendWeeklySubscriptionGiftEmail extends App {
+
+  val mandateId = "65HK26E"
+  val billingAddressWithCountry = Address(
+    lineOne = Some("90 York Way"),
+    lineTwo = None,
+    city = Some("London"),
+    state = None,
+    postCode = Some("N1 9AG"),
+    country = UK
+  )
+  val user = User(
+    "1234",
+    addressToSendTo,
+    None,
+    "Mickey",
+    "Mouse",
+    billingAddress = billingAddressWithCountry,
+    deliveryAddress = Some(billingAddressWithCountry)
+  )
+  val ef = GuardianWeeklyEmailFields.build(
+    SubscriptionEmailFields(
+      AllProductsEmailFields(
+        Quarterly,
+        user,
+        GBP,
+        salesforceContactId,
+        Some(mandateId)
       ),
-      paidSubPaymentData = None
-    )
-    val service = new EmailService(realConfig.contributionThanksQueueName)
-    service.send(ef)
-  }
+      "A-S00045678",
+      None
+    ),
+    Some(new LocalDate(2019, 3, 26)),
+    PaymentMethodWithSchedule(directDebitPaymentMethod, PaymentSchedule(List(Payment(new LocalDate(2019, 3, 25), 37.50)))),
+    giftRecipient = Some(GiftRecipient(None, "Earl", "Palmer", None))
+  )
 
-  def sendPaperSubscriptionEmail() {
-    val mandateId = "65HK26E"
-    val billingAddressWithCountry = Address(
-      lineOne = Some("90 York Way"),
-      lineTwo = None,
-      city = Some("London"),
-      state = None,
-      postCode = Some("N1 9AG"),
-      country = UK
-    )
-    val user = User(
-      "1234",
-      addressToSendTo,
-      None,
-      "Mickey",
-      "Mouse",
-      billingAddress = billingAddressWithCountry,
-      deliveryAddress = Some(billingAddressWithCountry)
-    )
-    val ef = PaperEmailFields.build(
-      SubscriptionEmailFields(
-        AllProductsEmailFields(
-          Monthly,
-          user,
-          GBP,
-          salesforceContactId,
-          Some(mandateId)
-        ),
-        "A-S00045678",
-        None
-      ),
-      Collection,
-      Saturday,
-      Some(new LocalDate(2019, 3, 26)),
-      PaymentMethodWithSchedule(directDebitPaymentMethod, PaymentSchedule(List(Payment(new LocalDate(2019, 3, 25), 62.79)))),
-    )
-    val service = new EmailService(realConfig.contributionThanksQueueName)
-    service.send(ef)
-  }
-
-  def sendWeeklySubscriptionEmail() {
-    val mandateId = "65HK26E"
-    val billingAddressWithCountry = Address(
-      lineOne = Some("90 York Way"),
-      lineTwo = None,
-      city = Some("London"),
-      state = None,
-      postCode = Some("N1 9AG"),
-      country = UK
-    )
-    val user = User(
-      "1234",
-      addressToSendTo,
-      None,
-      "Mickey",
-      "Mouse",
-      billingAddress = billingAddressWithCountry,
-      deliveryAddress = Some(billingAddressWithCountry)
-    )
-    val ef = GuardianWeeklyEmailFields.build(
-      SubscriptionEmailFields(
-        AllProductsEmailFields(
-          Quarterly,
-          user,
-          GBP,
-          salesforceContactId,
-          Some(mandateId)
-        ),
-        "A-S00045678",
-        None
-      ),
-      Some(new LocalDate(2019, 3, 26)),
-      PaymentMethodWithSchedule(directDebitPaymentMethod, PaymentSchedule(List(
-        Payment(new LocalDate(2019, 3, 25), 37.50),
-        Payment(new LocalDate(2019, 6, 25), 37.50)
-      ))),
-    )
-    val service = new EmailService(realConfig.contributionThanksQueueName)
-    service.send(ef)
-  }
-
-  def sendWeeklySubscriptionGiftEmail() {
-    val mandateId = "65HK26E"
-    val billingAddressWithCountry = Address(
-      lineOne = Some("90 York Way"),
-      lineTwo = None,
-      city = Some("London"),
-      state = None,
-      postCode = Some("N1 9AG"),
-      country = UK
-    )
-    val user = User(
-      "1234",
-      addressToSendTo,
-      None,
-      "Mickey",
-      "Mouse",
-      billingAddress = billingAddressWithCountry,
-      deliveryAddress = Some(billingAddressWithCountry)
-    )
-    val ef = GuardianWeeklyEmailFields.build(
-      SubscriptionEmailFields(
-        AllProductsEmailFields(
-          Quarterly,
-          user,
-          GBP,
-          salesforceContactId,
-          Some(mandateId)
-        ),
-        "A-S00045678",
-        None
-      ),
-      Some(new LocalDate(2019, 3, 26)),
-      PaymentMethodWithSchedule(directDebitPaymentMethod, PaymentSchedule(List(Payment(new LocalDate(2019, 3, 25), 37.50)))),
-      giftRecipient = Some(GiftRecipient(None, "Earl", "Palmer", None))
-    )
-
-    val service = new EmailService(realConfig.contributionThanksQueueName)
-    service.send(ef)
-  }
+  val service = new EmailService(realConfig.contributionThanksQueueName)
+  service.send(ef)
 
 }
 


### PR DESCRIPTION
## Why are you doing this?

Membership workflow lowercases and replaces spaces with _. 
See https://github.com/guardian/membership-workflow/blob/2eea2601b284519e67dbcdb2226ce89b3c81c6cc/app/model/BrazeCampaignTriggerPayload.scala#L11

This is presumably because just the old ET system allowed those and we used them, but braze doesn't, and membership workflow is a convenient place where everything passes through, microservice style.

However it doesn't make sense to retain that intenitonally, as it's just confusing when disucssing things between braze users and devs.

I have only done this for digital pack, because that is the one I'm touching, but it really should be done to them all.  Should I do them at the same time?

I have tested using the manual email tests and it works okay still.

## Did you enjoy your PR experience?

 - [x] [PR experience rated](https://forms.gle/N6FsTGG8JQFGV4Ha9)
