### PR TITLE
Send ophan event for 'return to guardian' link in new thankyou page

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/new-flow/ContributionThankYou.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/new-flow/ContributionThankYou.jsx
@@ -20,7 +20,8 @@ import ContributionThankYouSupportReminder from './ContributionThankYouSupportRe
 import ContributionThankYouSurvey from './ContributionThankYouSurvey';
 import ContributionThankYouSocialShare from './ContributionThankYouSocialShare';
 import ContributionThankYouAusMap from './ContributionThankYouAusMap';
-import { trackUserData } from '../utils/ophan';
+import { trackUserData, OPHAN_COMPONENT_ID_RETURN_TO_GUARDIAN } from '../utils/ophan';
+import { trackComponentClick } from 'helpers/tracking/behaviour';
 
 const container = css`
   background: white;
@@ -214,7 +215,11 @@ const ContributionThankYou = ({
       </div>
 
       <div css={buttonContainer}>
-        <LinkButton href="https://www.theguardian.com" priority="tertiary">
+        <LinkButton
+          href="https://www.theguardian.com"
+          priority="tertiary"
+          onClick={() => trackComponentClick(OPHAN_COMPONENT_ID_RETURN_TO_GUARDIAN)}
+        >
           Return to the Guardian
         </LinkButton>
       </div>

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/utils/ophan.js
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/utils/ophan.js
@@ -17,6 +17,7 @@ export const OPHAN_COMPONENT_ID_SOCIAL_LINKED_IN =
 export const OPHAN_COMPONENT_ID_SOCIAL_EMAIL =
   'contribution-thankyou-social-email';
 export const OPHAN_COMPONENT_ID_AUS_MAP = 'contribution-thankyou-aus-map';
+export const OPHAN_COMPONENT_ID_RETURN_TO_GUARDIAN = 'contribution-thankyou-return-to-guardian';
 
 export const OPHAN_COMPONENT_ID_READ_MORE_SIGN_IN =
   'contribution-thankyou-read-more-sign-in';


### PR DESCRIPTION
We're comparing the conversion rate for each action on the page.
The 'return to the guardian' link tracking was missed on the new page.

_(just to prove it's the same on both now)_
New thankyou page event:
![Screen Shot 2020-09-18 at 13 28 39](https://user-images.githubusercontent.com/1513454/93597565-28f79d80-f9b3-11ea-9737-380f5d520cdc.png)

Old thankyou page event:
![Screen Shot 2020-09-18 at 13 29 08](https://user-images.githubusercontent.com/1513454/93597575-2ac16100-f9b3-11ea-8d6b-758b43518fc7.png)
