### PR TITLE
add gifting emails - with dummy data

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -37,6 +37,7 @@ inThisBuild(Seq(
   // https://www.scala-sbt.org/1.x/docs/Cached-Resolution.html
   updateOptions := updateOptions.value.withCachedResolution(true),
   resolvers ++= Seq(Resolver.sonatypeRepo("releases")), // libraries that haven't yet synced to maven central
+  scalacOptions += "-Ypartial-unification",
 ))
 
 lazy val releaseSettings = Seq(

--- a/support-lambdas/stripe-intent/build.sbt
+++ b/support-lambdas/stripe-intent/build.sbt
@@ -3,8 +3,6 @@ import LibraryVersions.{awsClientVersion, jacksonVersion, circeVersion, okhttpVe
 name := "stripe-intent"
 description:= "Returns a stripe setup intent token so we can get authorisation of a recurring payment on the client side"
 
-scalacOptions += "-Ypartial-unification"
-
 assemblyJarName := "stripe-intent.jar"
 riffRaffPackageType := assembly.value
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")

--- a/support-modules/aws/src/main/scala/com/gu/aws/AwsCloudWatchMetricPut.scala
+++ b/support-modules/aws/src/main/scala/com/gu/aws/AwsCloudWatchMetricPut.scala
@@ -45,7 +45,7 @@ object AwsCloudWatchMetricPut {
     metricDatum1.setValue(request.value)
     metricDatum1.setUnit(StandardUnit.Count)
     putMetricDataRequest.getMetricData.add(metricDatum1)
-    Try(client.putMetricData(putMetricDataRequest)).map(_ => Unit)
+    Try(client.putMetricData(putMetricDataRequest)).map(_ => ())
   }
 
 }

--- a/support-payment-api/build.sbt
+++ b/support-payment-api/build.sbt
@@ -5,7 +5,6 @@ name := "payment-api"
 version := "0.1"
 scalaVersion := "2.12.4"
 scalacOptions ++= Seq(
-  "-Ypartial-unification",
   "-Ywarn-unused:imports"
 )
 

--- a/support-workers/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
@@ -1,78 +1,242 @@
 package com.gu.emailservices
 
+import cats.implicits._
+import com.gu.emailservices.DigitalSubscriptionEmailAttributes.PaymentFieldsAttributes
+import com.gu.emailservices.DigitalSubscriptionEmailAttributes.PaymentFieldsAttributes.{CCAttributes, DDAttributes, PPAttributes}
 import com.gu.emailservices.SubscriptionEmailFieldHelpers._
-import com.gu.i18n.Currency
-import com.gu.support.promotions.Promotion
 import com.gu.support.workers._
 import com.gu.support.workers.states.PaymentMethodWithSchedule
+import com.gu.support.zuora.api.ReaderType
+import io.circe._
+import io.circe.generic.semiauto.deriveEncoder
+import io.circe.syntax._
+
+sealed trait DigitalSubscriptionEmailAttributes extends Product with Serializable
+object DigitalSubscriptionEmailAttributes {
+
+  implicit val e1: Encoder.AsObject[BasicDSAttributes] = deriveEncoder
+  implicit val e2: Encoder.AsObject[DirectDSAttributes] = deriveEncoder
+  implicit val e3: Encoder.AsObject[GifteeRedemptionAttributes] = deriveEncoder
+  implicit val e4: Encoder.AsObject[GifterPurchaseAttributes] = deriveEncoder
+  implicit val e5: Encoder.AsObject[GifteeNotificationAttributes] = deriveEncoder
+
+  implicit val encoder: Encoder.AsObject[DigitalSubscriptionEmailAttributes] = Encoder.AsObject.instance {
+    case v: BasicDSAttributes => v.asJsonObject
+    case v: DirectDSAttributes => v.asJsonObject
+    case v: GifteeRedemptionAttributes => v.asJsonObject
+    case v: GifterPurchaseAttributes => v.asJsonObject
+    case v: GifteeNotificationAttributes => v.asJsonObject
+  }
+
+
+  sealed trait PaymentFieldsAttributes extends Product with Serializable {
+    val default_payment_method: String
+  }
+  object PaymentFieldsAttributes {
+
+    implicit val e1: Encoder.AsObject[DDAttributes] = deriveEncoder
+    implicit val e2: Encoder.AsObject[CCAttributes] = deriveEncoder
+    implicit val e3: Encoder.AsObject[PPAttributes] = deriveEncoder
+
+    implicit val encoder: Encoder.AsObject[PaymentFieldsAttributes] = Encoder.AsObject.instance {
+      case v: DDAttributes => v.asJsonObject
+      case v: CCAttributes => v.asJsonObject
+      case v: PPAttributes => v.asJsonObject
+    }
+
+    case class DDAttributes(
+      account_number: String,
+      sort_code: String,
+      account_name: String,
+      mandateid: String,
+      default_payment_method: String = "Direct Debit",
+    ) extends PaymentFieldsAttributes
+
+    case class CCAttributes(
+      default_payment_method: String = "Credit/Debit Card",
+    ) extends PaymentFieldsAttributes
+
+    case class PPAttributes(
+      default_payment_method: String = "PayPal",
+    ) extends PaymentFieldsAttributes
+
+  }
+
+
+  case class BasicDSAttributes(
+    zuorasubscriberid: String,
+    emailaddress: String,
+    first_name: String,
+    last_name: String,
+    subscription_details: String,
+  ) extends DigitalSubscriptionEmailAttributes
+
+  case class DirectDSAttributes(
+    directCorp: BasicDSAttributes,
+    subscription_term: String,
+    payment_amount: String,
+    country: String,
+    date_of_first_payment: String,
+    currency: String,
+    trial_period: String,
+    paymentFieldsAttributes: PaymentFieldsAttributes,
+  ) extends DigitalSubscriptionEmailAttributes
+
+  case class GifteeRedemptionAttributes(
+    gift_recipient_first_name: String,
+    subscription_details: String,
+    gift_start_date: String,
+    gift_recipient_email: String,
+  ) extends DigitalSubscriptionEmailAttributes
+
+  case class GifterPurchaseAttributes(
+    gifter_first_name: String,
+    gifter_last_name: String,
+    gift_recipient_first_name: String,
+    gift_recipient_last_name: String,
+    gift_recipient_email: String,
+    gift_personal_message: String,
+    gift_code: String,
+    gift_delivery_date: String,
+    subscription_details: String,
+    paymentAttributes: PaymentFieldsAttributes,
+    date_of_first_payment: String,
+  ) extends DigitalSubscriptionEmailAttributes
+
+  case class GifteeNotificationAttributes(
+    gifter_first_name: String,
+    gift_personal_message: String,
+    gift_code: String,
+  ) extends DigitalSubscriptionEmailAttributes
+
+}
+class DigitalPackEmailFields(
+  subscriptionEmailFields: SubscriptionEmailFields,
+) {
+
+  import DigitalPackEmailFields._
+  import DigitalSubscriptionEmailAttributes._
+  import subscriptionEmailFields._
+  import allProductsEmailFields._
+
+  private def directOrCorpFields(details: String) = BasicDSAttributes(
+    zuorasubscriberid = subscriptionNumber,
+    emailaddress = user.primaryEmailAddress,
+    first_name = user.firstName,
+    last_name = user.lastName,
+    subscription_details = details
+  )
+
+  def build(
+    paidSubPaymentData: Option[PaymentMethodWithSchedule],
+    readerType: ReaderType
+  ): Either[String, List[EmailFields]] =
+    (paidSubPaymentData, readerType) match {
+      case (Some(PaymentMethodWithSchedule(pm, paymentSchedule)), ReaderType.Gift) =>
+        List(
+          wrap("digipack-gift-purchase", buildGiftPurchaseAttributes(pm)),
+          wrap("digipack-gift-notification", buildGiftNotificationAttributes)
+        ).sequence
+      case (Some(PaymentMethodWithSchedule(pm, paymentSchedule)), _) => wrap("digipack", directAttributes(pm, paymentSchedule)).map(List(_))
+      case (None, ReaderType.Corporate) => wrap("digipack-corp", buildCorpRedemptionAttributes).map(List(_))
+      case (None, ReaderType.Gift) => wrap("digipack-gift-redemption", buildGiftRedemptionAttributes).map(List(_))
+      case (None, _) => Left("can only redeem gift and corporate subs")
+    }
+
+  private def wrap(dataExtensionName: String, fields: DigitalSubscriptionEmailAttributes) = for {
+    attributePairs <- asFlattenedPairs(fields.asJsonObject)
+  } yield EmailFields(attributePairs, Left(sfContactId), user.primaryEmailAddress, dataExtensionName)
+
+  private def buildGiftNotificationAttributes =
+    GifteeNotificationAttributes(
+      gifter_first_name = user.firstName,
+      gift_personal_message = "gift_personal_message",
+      gift_code = "gift_code"
+    )
+
+  private def buildGiftPurchaseAttributes(pm: PaymentMethod) =
+    GifterPurchaseAttributes(
+      gifter_first_name = user.firstName,
+      gifter_last_name = user.lastName,
+      gift_recipient_first_name = "gift recipient first name placeholder",
+      gift_recipient_last_name = "gift recipient last name placeholder",
+      gift_recipient_email = "gift recipient email placeholder",
+      gift_personal_message = "gift personal message placeholder",
+      gift_code = "gift code placeholder",
+      gift_delivery_date = "gift delivery date placeholder",
+      subscription_details = "subscription details placeholder",
+      date_of_first_payment = "date_of_first_payment",
+      paymentAttributes = paymentFields(pm, directDebitMandateId)
+    )
+
+  private def buildGiftRedemptionAttributes =
+    GifteeRedemptionAttributes(
+      gift_recipient_first_name = user.firstName,
+      subscription_details = "subscription_details placeholder",
+      gift_start_date = "gift start date placeholder",
+      gift_recipient_email = user.primaryEmailAddress
+    )
+
+  private def buildCorpRedemptionAttributes =
+    directOrCorpFields("Group subscription")
+
+  private def directAttributes(pm: PaymentMethod, paymentSchedule: PaymentSchedule) =
+    DirectDSAttributes(
+      directOrCorpFields(SubscriptionEmailFieldHelpers.describe(paymentSchedule, billingPeriod, currency, promotion)),
+      subscription_term = billingPeriod.noun,
+      payment_amount = SubscriptionEmailFieldHelpers.formatPrice(SubscriptionEmailFieldHelpers.firstPayment(paymentSchedule).amount),
+      country = user.billingAddress.country.name,
+      date_of_first_payment = formatDate(SubscriptionEmailFieldHelpers.firstPayment(paymentSchedule).date),
+      currency = currency.glyph,
+      trial_period = "14", //TODO: depends on Promo code or zuora config
+      paymentFields(pm, directDebitMandateId)
+    )
+
+}
 
 object DigitalPackEmailFields {
 
-  def build(
-    subscriptionEmailFields: SubscriptionEmailFields,
-    paidSubPaymentData: Option[PaymentMethodWithSchedule]
-  ): EmailFields = {
-    import subscriptionEmailFields._
-    import allProductsEmailFields._
+  type Failable[A] = Either[String, A]
+  def asFlattenedPairs(value: JsonObject): Failable[List[(String, String)]] = {
+    def flattenToPairs(value: JsonObject, failablePairsSoFar: Failable[Map[String, String]]): Failable[Map[String, String]] =
+      value.toList.foldLeft(failablePairsSoFar) {
+          case (failablePairsSoFar, (fieldName, jValue)) =>
+            failablePairsSoFar.flatMap { pairsSoFar =>
+              jValue.asString match {
+                case None =>
+                  jValue.asObject match {
+                    case None => Left(s"all values should be string or object: ${fieldName} -> $value")
+                    case Some(obj) =>
+                      flattenToPairs(obj, Right(pairsSoFar))
+                  }
+                case Some(string) =>
+                  if (pairsSoFar.contains(fieldName))
+                    Left(s"found duplicate key ${fieldName} in case classes")
+                  else
+                    Right(pairsSoFar + (fieldName -> string))
+              }
+          }
+        }
 
-    val fieldsForReaderType =
-      paidSubPaymentData match {
-        case Some(PaymentMethodWithSchedule(pm, paymentSchedule)) =>
-          paymentFields(pm, directDebitMandateId) ++
-            directReaderFields(promotion, billingPeriod, user, currency, paymentSchedule)
-        case None /*Corporate*/ => List(
-          "subscription_details" -> "Group subscription"
-        )
-      }
-
-    val fields = List(
-      "zuorasubscriberid" -> subscriptionNumber,
-      "emailaddress" -> user.primaryEmailAddress,
-      "first_name" -> user.firstName,
-      "last_name" -> user.lastName,
-    ) ++ fieldsForReaderType
-
-    val dataExtensionName = if (paidSubPaymentData.isDefined) "digipack" else "digipack-corp"
-
-    EmailFields(fields, Left(sfContactId), user.primaryEmailAddress, dataExtensionName)
+    flattenToPairs(value, Right(Map.empty)).map(_.toList)
   }
 
-  def paymentFields(paymentMethod: PaymentMethod, directDebitMandateId: Option[String]): Seq[(String, String)] =
+  def paymentFields(paymentMethod: PaymentMethod, directDebitMandateId: Option[String]): PaymentFieldsAttributes =
     paymentMethod match {
-      case dd: DirectDebitPaymentMethod => List(
-        "account_number" -> mask(dd.bankTransferAccountNumber),
-        "sort_code" -> hyphenate(dd.bankCode),
-        "account_name" -> dd.bankTransferAccountName,
-        "default_payment_method" -> "Direct Debit",
-        "mandateid" -> directDebitMandateId.getOrElse("")
+      case dd: DirectDebitPaymentMethod => DDAttributes(
+        account_number = mask(dd.bankTransferAccountNumber),
+        sort_code = hyphenate(dd.bankCode),
+        account_name = dd.bankTransferAccountName,
+        mandateid = directDebitMandateId.getOrElse("")
       )
-      case dd: ClonedDirectDebitPaymentMethod => List(
-        "sort_code" -> hyphenate(dd.bankCode),
-        "account_number" -> mask(dd.bankTransferAccountNumber),
-        "account_name" -> dd.bankTransferAccountName,
-        "default_payment_method" -> "Direct Debit",
-        "mandateid" -> dd.mandateId
+      case dd: ClonedDirectDebitPaymentMethod => DDAttributes(
+        sort_code = hyphenate(dd.bankCode),
+        account_number = mask(dd.bankTransferAccountNumber),
+        account_name = dd.bankTransferAccountName,
+        mandateid = dd.mandateId
       )
-      case _: CreditCardReferenceTransaction => List("default_payment_method" -> "Credit/Debit Card")
-      case _: PayPalReferenceTransaction => Seq("default_payment_method" -> "PayPal")
+      case _: CreditCardReferenceTransaction => CCAttributes()
+      case _: PayPalReferenceTransaction => PPAttributes()
     }
-
-  def directReaderFields(
-    promotion: Option[Promotion],
-    billingPeriod: BillingPeriod,
-    user: User,
-    currency: Currency,
-    paymentSchedule: PaymentSchedule
-  ): Seq[(String, String)] = {
-    List(
-      "subscription_term" -> billingPeriod.noun,
-      "payment_amount" -> SubscriptionEmailFieldHelpers.formatPrice(SubscriptionEmailFieldHelpers.firstPayment(paymentSchedule).amount),
-      "country" -> user.billingAddress.country.name,
-      "date_of_first_payment" -> formatDate(SubscriptionEmailFieldHelpers.firstPayment(paymentSchedule).date),
-      "currency" -> currency.glyph,
-      "trial_period" -> "14", //TODO: depends on Promo code or zuora config
-      "subscription_details" -> SubscriptionEmailFieldHelpers.describe(paymentSchedule, billingPeriod, currency, promotion)
-    )
-  }
 
 }

--- a/support-workers/src/main/scala/com/gu/emailservices/EmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/EmailFields.scala
@@ -36,7 +36,7 @@ case class EmailFields(
       DataExtensionName = dataExtensionName,
       SfContactId = userId.left.toOption.map(_.id),
       IdentityUserId = userId.right.toOption.map(_.id)
-    ).asJson.toString
+    ).asJson.spaces2
   }
 
 }

--- a/support-workers/src/main/scala/com/gu/emailservices/EmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/EmailFields.scala
@@ -4,13 +4,18 @@ import com.gu.i18n.Currency
 import com.gu.salesforce.Salesforce.SfContactId
 import com.gu.support.promotions.Promotion
 import com.gu.support.workers.{BillingPeriod, User}
-import io.circe.generic.auto._
+import io.circe.Encoder
+import io.circe.generic.semiauto._
 import io.circe.syntax._
 
 case class EmailPayloadContactAttributes(SubscriberAttributes: Map[String, String])
 case class EmailPayloadTo(Address: String, ContactAttributes: EmailPayloadContactAttributes)
-case class EmailPayload(To: EmailPayloadTo, DataExtensionName: String, SfContactId: Option[String], IdentityUserId: Option[String]) {
-  lazy val jsonString: String = this.asJson.toString
+case class EmailPayload(To: EmailPayloadTo, DataExtensionName: String, SfContactId: Option[String], IdentityUserId: Option[String])
+
+object EmailPayload {
+  implicit val e1: Encoder[EmailPayload] = deriveEncoder
+  implicit val e2: Encoder[EmailPayloadTo] = deriveEncoder
+  implicit val e3: Encoder[EmailPayloadContactAttributes] = deriveEncoder
 }
 
 case class IdentityUserId(id: String)
@@ -31,7 +36,7 @@ case class EmailFields(
       DataExtensionName = dataExtensionName,
       SfContactId = userId.left.toOption.map(_.id),
       IdentityUserId = userId.right.toOption.map(_.id)
-    ).jsonString
+    ).asJson.toString
   }
 
 }

--- a/support-workers/src/main/scala/com/gu/emailservices/EmailService.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/EmailService.scala
@@ -21,7 +21,9 @@ class EmailService(contributionThanksQueueName: String)(implicit val executionCo
 
   def send(fields: EmailFields): Future[SendMessageResult] = {
     SafeLogger.info(s"Sending message to SQS queue $queueUrl")
-    val messageResult = AwsAsync(sqsClient.sendMessageAsync, new SendMessageRequest(queueUrl, fields.payload))
+    val payload = fields.payload
+    SafeLogger.info(s"message content is: $payload")
+    val messageResult = AwsAsync(sqsClient.sendMessageAsync, new SendMessageRequest(queueUrl, payload))
     messageResult.recover {
       case throwable =>
         SafeLogger.error(scrub"Failed to send message due to $queueUrl due to:", throwable)

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendThankYouEmail.scala
@@ -26,7 +26,7 @@ import scala.concurrent.Future
 case class StateNotValidException(message: String) extends RuntimeException(message)
 
 class SendThankYouEmail(servicesProvider: ServiceProvider = ServiceProvider)
-    extends ServicesHandler[SendThankYouEmailState, SendMessageResult](servicesProvider) {
+    extends ServicesHandler[SendThankYouEmailState, List[SendMessageResult]](servicesProvider) {
 
   def this() = this(ServiceProvider)
 
@@ -41,7 +41,7 @@ class SendThankYouEmail(servicesProvider: ServiceProvider = ServiceProvider)
       mandateId <- fetchDirectDebitMandateId(state, services.zuoraService)
       emailFields <- Future.fromTry(buildEmail(state, mandateId)
         .left.map(error => new StateNotValidException(s"State was not valid, $error")).toTry)
-      emailResult <- thankYouEmailService.send(emailFields)
+      emailResult <- Future.sequence(emailFields.map(thankYouEmailService.send))
     } yield HandlerResult(emailResult, requestInfo)
   }
 
@@ -51,7 +51,7 @@ class SendThankYouEmail(servicesProvider: ServiceProvider = ServiceProvider)
     case _ => Future.successful(None)
   }
 
-  def buildEmail(state: SendThankYouEmailState, directDebitMandateId: Option[String] = None): Either[String, EmailFields] =
+  def buildEmail(state: SendThankYouEmailState, directDebitMandateId: Option[String] = None): Either[String, List[EmailFields]] =
     state.product match {
       case c: Contribution =>
         state.paymentOrRedemptionData.left.toOption.toRight("can't have a corporate/gift contribution").map(paymentMethodWithSchedule =>
@@ -61,11 +61,11 @@ class SendThankYouEmail(servicesProvider: ServiceProvider = ServiceProvider)
             amount = c.amount,
             paymentMethod = paymentMethodWithSchedule.paymentMethod
           )
-        )
-      case _: DigitalPack => Right(DigitalPackEmailFields.build(
-        getSubscriptionEmailFields(state, directDebitMandateId),
+        ).map(List(_))
+      case d: DigitalPack => new DigitalPackEmailFields(getSubscriptionEmailFields(state, directDebitMandateId)).build(
         paidSubPaymentData = state.paymentOrRedemptionData.left.toOption,
-      ))
+        readerType = d.readerType
+      )
       case p: Paper =>
         state.paymentOrRedemptionData.left.toOption.toRight("can't have a corporate/gift paper yet").map(paymentMethodWithSchedule =>
           PaperEmailFields.build(
@@ -76,7 +76,7 @@ class SendThankYouEmail(servicesProvider: ServiceProvider = ServiceProvider)
             paymentMethodWithSchedule = paymentMethodWithSchedule,
             state.giftRecipient
           )
-        )
+        ).map(List(_))
       case _: GuardianWeekly =>
         state.paymentOrRedemptionData.left.toOption.toRight("can't have a corporate/gift GW yet").map(paymentMethodWithSchedule =>
           GuardianWeeklyEmailFields.build(
@@ -85,7 +85,7 @@ class SendThankYouEmail(servicesProvider: ServiceProvider = ServiceProvider)
             paymentMethodWithSchedule = paymentMethodWithSchedule,
             state.giftRecipient
           )
-        )
+        ).map(List(_))
     }
 
   private def getAllProductEmailFields(state: SendThankYouEmailState, directDebitMandateId: Option[String]) = {

--- a/support-workers/src/test/scala/com/gu/emailservices/DigitalPackEmailFieldsSpec.scala
+++ b/support-workers/src/test/scala/com/gu/emailservices/DigitalPackEmailFieldsSpec.scala
@@ -1,0 +1,92 @@
+package com.gu.emailservices
+
+import com.gu.emailservices.DigitalPackEmailFields.Failable
+import com.gu.emailservices.DigitalSubscriptionEmailAttributes.PaymentFieldsAttributes.PPAttributes
+import com.gu.emailservices.DigitalSubscriptionEmailAttributes.{BasicDSAttributes, DirectDSAttributes}
+import io.circe.Json.{JArray, JObject}
+import io.circe.{Json, JsonObject}
+import io.circe.syntax._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.EitherValues._
+
+class DigitalPackEmailFieldsSpec extends AnyFlatSpec with Matchers {
+
+  "asFlattenedPairs" should "handle a real object" in {
+    val data = DirectDSAttributes(
+      directCorp = BasicDSAttributes(
+        zuorasubscriberid = "1",
+        emailaddress = "2",
+        first_name = "3",
+        last_name = "4",
+        subscription_details = "5"
+      ),
+      subscription_term = "6",
+      payment_amount = "7",
+      country = "8",
+      date_of_first_payment = "9",
+      currency = "0",
+      trial_period = "a",
+      paymentFieldsAttributes = PPAttributes()
+    ).asJsonObject
+    val actual = DigitalPackEmailFields.asFlattenedPairs(data)
+    actual.map(_.toMap) should be(Right(Map(
+      "zuorasubscriberid" -> "1",
+      "emailaddress" -> "2",
+      "first_name" -> "3",
+      "last_name" -> "4",
+      "subscription_details" -> "5",
+      "subscription_term" -> "6",
+      "payment_amount" -> "7",
+      "country" -> "8",
+      "date_of_first_payment" -> "9",
+      "currency" -> "0",
+      "trial_period" -> "a",
+      "default_payment_method" -> "PayPal",
+    )))
+  }
+
+  it should "fail if there are any top level non string" in {
+    val data = JsonObject(
+      "test" -> Json.arr()
+    )
+    val actual = DigitalPackEmailFields.asFlattenedPairs(data)
+    actual.map(_.toMap) should matchPattern { case Left(_) => }
+  }
+
+  it should "fail if there are any non string lower down" in {
+    val data = JsonObject(
+      "test1" -> Json.obj(
+      "test2" -> Json.arr()
+      )
+    )
+    val actual = DigitalPackEmailFields.asFlattenedPairs(data)
+    actual.map(_.toMap) should matchPattern { case Left(_) => }
+  }
+
+  it should "merge a valid nested" in {
+    val data = JsonObject(
+      ("shouldExist1" -> Json.fromString("value1")),
+      "test" -> Json.obj(
+        ("shouldExist2" -> Json.fromString("value2"))
+      )
+    )
+    val actual = DigitalPackEmailFields.asFlattenedPairs(data)
+    actual.map(_.toMap) should be(Right(Map(
+      "shouldExist1" -> "value1",
+      "shouldExist2" -> "value2",
+    )))
+  }
+
+  it should "complain about a key clash" in {
+    val data = JsonObject(
+      ("clash" -> Json.fromString("value1")),
+      "test" -> Json.obj(
+        ("clash" -> Json.fromString("value2"))
+      )
+    )
+    val actual = DigitalPackEmailFields.asFlattenedPairs(data)
+    actual.map(_.toMap) should matchPattern { case Left(_) => }
+  }
+
+}

--- a/support-workers/src/test/scala/com/gu/emailservices/EmailFieldsSpec.scala
+++ b/support-workers/src/test/scala/com/gu/emailservices/EmailFieldsSpec.scala
@@ -1,7 +1,13 @@
 package com.gu.emailservices
 
+import com.gu.support.workers.integration.TestData.{countryOnlyAddress, directDebitPaymentMethod, subsFields}
+import com.gu.support.workers.states.PaymentMethodWithSchedule
+import com.gu.support.workers.{Annual, Payment, PaymentSchedule, User}
+import com.gu.support.zuora.api.ReaderType
 import io.circe.parser._
 import io.circe.syntax._
+import org.joda.time.LocalDate
+import org.scalatest.Inside
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -37,5 +43,87 @@ class EmailFieldsSpec extends AnyFlatSpec with Matchers {
     ).asJson
 
     serializedJson shouldBe expectedJson
+  }
+}
+
+class DigitalPackEmailFieldsSpec extends AnyFlatSpec with Matchers with Inside {
+
+  it should "generate the right json for direct subs" in {
+    val expectedJson = parse(
+      """{
+        |"To" : {
+        |  "Address" : "test@gu.com",
+        |  "ContactAttributes" : {
+        |    "SubscriberAttributes" : {
+        |      "first_name" : "Mickey",
+        |      "emailaddress" : "test@gu.com",
+        |      "mandateid" : "65HK26E",
+        |      "subscription_details" : "£119.90 for the first year",
+        |      "date_of_first_payment" : "Monday, 14 January 2019",
+        |      "country" : "United Kingdom",
+        |      "trial_period" : "14",
+        |      "account_number" : "******11",
+        |      "zuorasubscriberid" : "A-S00045678",
+        |      "sort_code" : "20-20-20",
+        |      "last_name" : "Mouse",
+        |      "subscription_term" : "year",
+        |      "account_name" : "Mickey Mouse",
+        |      "currency" : "£",
+        |      "payment_amount" : "119.90",
+        |      "default_payment_method" : "Direct Debit"
+        |    }
+        |  }
+        |},
+        |"DataExtensionName" : "digipack",
+        |"SfContactId" : "0033E00001DTBHJQA5",
+        |"IdentityUserId" : null
+        |}
+        |""".stripMargin)
+    val actual = new DigitalPackEmailFields(
+      subsFields(Annual, User("1234", "test@gu.com", None, "Mickey", "Mouse", billingAddress = countryOnlyAddress))
+    ).build(
+      paidSubPaymentData = Some(PaymentMethodWithSchedule(
+        directDebitPaymentMethod,
+        PaymentSchedule(List(Payment(new LocalDate(2019, 1, 14), 119.90)))
+      )),
+      ReaderType.Direct
+    ).map(_.map(ef => parse(ef.payload)))
+    inside(actual) {
+      case Right(actualJson :: Nil) =>
+        actualJson should be(expectedJson)
+    }
+  }
+
+
+  it should "generate the right json for corporate subs" in {
+    val expectedJson = parse(
+      """{
+        |"To" : {
+        |  "Address" : "test@gu.com",
+        |  "ContactAttributes" : {
+        |    "SubscriberAttributes" : {
+        |      "first_name" : "Mickey",
+        |      "emailaddress" : "test@gu.com",
+        |      "subscription_details" : "Group subscription",
+        |      "zuorasubscriberid" : "A-S00045678",
+        |      "last_name" : "Mouse"
+        |    }
+        |  }
+        |},
+        |"DataExtensionName" : "digipack-corp",
+        |"SfContactId" : "0033E00001DTBHJQA5",
+        |"IdentityUserId" : null
+        |}
+        |""".stripMargin)
+    val actual = new DigitalPackEmailFields(
+      subsFields(Annual, User("1234", "test@gu.com", None, "Mickey", "Mouse", billingAddress = countryOnlyAddress))
+    ).build(
+      paidSubPaymentData = None,
+      ReaderType.Corporate
+    ).map(_.map(ef => parse(ef.payload)))
+    inside(actual) {
+      case Right(actualJson :: Nil) =>
+        actualJson should be(expectedJson)
+    }
   }
 }

--- a/support-workers/src/test/scala/com/gu/emailservices/EmailFieldsSpec.scala
+++ b/support-workers/src/test/scala/com/gu/emailservices/EmailFieldsSpec.scala
@@ -1,6 +1,7 @@
 package com.gu.emailservices
 
 import io.circe.parser._
+import io.circe.syntax._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -22,7 +23,7 @@ class EmailFieldsSpec extends AnyFlatSpec with Matchers {
       """.stripMargin
     )
 
-    val Right(serializedJson) = parse(
+    val serializedJson =
       EmailPayload(
       EmailPayloadTo(
         "email@email.com",
@@ -33,8 +34,7 @@ class EmailFieldsSpec extends AnyFlatSpec with Matchers {
       "dataExtensionName",
       Some("sfContactId"),
       Some("identityUserId")
-    ).jsonString
-    )
+    ).asJson
 
     serializedJson shouldBe expectedJson
   }

--- a/support-workers/src/test/scala/com/gu/emailservices/JsonToAttributesSpec.scala
+++ b/support-workers/src/test/scala/com/gu/emailservices/JsonToAttributesSpec.scala
@@ -1,16 +1,13 @@
 package com.gu.emailservices
 
-import com.gu.emailservices.DigitalPackEmailFields.Failable
 import com.gu.emailservices.DigitalSubscriptionEmailAttributes.PaymentFieldsAttributes.PPAttributes
 import com.gu.emailservices.DigitalSubscriptionEmailAttributes.{BasicDSAttributes, DirectDSAttributes}
-import io.circe.Json.{JArray, JObject}
-import io.circe.{Json, JsonObject}
 import io.circe.syntax._
+import io.circe.{Json, JsonObject}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.EitherValues._
 
-class DigitalPackEmailFieldsSpec extends AnyFlatSpec with Matchers {
+class JsonToAttributesSpec extends AnyFlatSpec with Matchers {
 
   "asFlattenedPairs" should "handle a real object" in {
     val data = DirectDSAttributes(
@@ -29,7 +26,7 @@ class DigitalPackEmailFieldsSpec extends AnyFlatSpec with Matchers {
       trial_period = "a",
       paymentFieldsAttributes = PPAttributes()
     ).asJsonObject
-    val actual = DigitalPackEmailFields.asFlattenedPairs(data)
+    val actual = JsonToAttributes.asFlattenedPairs(data)
     actual.map(_.toMap) should be(Right(Map(
       "zuorasubscriberid" -> "1",
       "emailaddress" -> "2",
@@ -50,7 +47,7 @@ class DigitalPackEmailFieldsSpec extends AnyFlatSpec with Matchers {
     val data = JsonObject(
       "test" -> Json.arr()
     )
-    val actual = DigitalPackEmailFields.asFlattenedPairs(data)
+    val actual = JsonToAttributes.asFlattenedPairs(data)
     actual.map(_.toMap) should matchPattern { case Left(_) => }
   }
 
@@ -60,7 +57,7 @@ class DigitalPackEmailFieldsSpec extends AnyFlatSpec with Matchers {
       "test2" -> Json.arr()
       )
     )
-    val actual = DigitalPackEmailFields.asFlattenedPairs(data)
+    val actual = JsonToAttributes.asFlattenedPairs(data)
     actual.map(_.toMap) should matchPattern { case Left(_) => }
   }
 
@@ -71,7 +68,7 @@ class DigitalPackEmailFieldsSpec extends AnyFlatSpec with Matchers {
         ("shouldExist2" -> Json.fromString("value2"))
       )
     )
-    val actual = DigitalPackEmailFields.asFlattenedPairs(data)
+    val actual = JsonToAttributes.asFlattenedPairs(data)
     actual.map(_.toMap) should be(Right(Map(
       "shouldExist1" -> "value1",
       "shouldExist2" -> "value2",
@@ -85,7 +82,7 @@ class DigitalPackEmailFieldsSpec extends AnyFlatSpec with Matchers {
         ("clash" -> Json.fromString("value2"))
       )
     )
-    val actual = DigitalPackEmailFields.asFlattenedPairs(data)
+    val actual = JsonToAttributes.asFlattenedPairs(data)
     actual.map(_.toMap) should matchPattern { case Left(_) => }
   }
 

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
@@ -230,13 +230,9 @@ object TestData {
     )
   }
 
-  //
-
   val countryOnlyAddress = Address(lineOne = None, lineTwo = None, city = None, state = None, postCode = None, country = UK)
 
   val billingOnlyUser = User("1234", addressToSendTo, None, "Mickey", "Mouse", billingAddress = countryOnlyAddress)
-
-  //
 
   val officeAddress = Address(
     lineOne = Some("90 York Way"),
@@ -256,8 +252,6 @@ object TestData {
     billingAddress = officeAddress,
     deliveryAddress = Some(officeAddress)
   )
-
-  //
 
   val mandateId = "65HK26E"
 


### PR DESCRIPTION
## Why are you doing this?

As part of the DS gifting work, we need to trigger a pair of emails at purchase time (thank you email and giftee notification email) and a separate one at redemption time for the giftee when they redeem.

[**Trello Card**](https://trello.com/c/RvP8A1nw/3192-gifting-email-api-triggers-for-the-gifter-giftee-emails-generated)

## Changes

* make the email builder return a List rather than a single email
* model the attributes as an ADT rather than building a list of key/value pairs (for Digi sub only at the moment)
* add logic to send the three new emails (as placeholder data only)
