### PR TITLE
remove unused DS email fields

### DIFF
--- a/support-workers/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
@@ -73,11 +73,8 @@ object DigitalSubscriptionEmailAttributes {
 
   case class DirectDSAttributes(
     directCorp: BasicDSAttributes,
-    subscription_term: String,
-    payment_amount: String,
     country: String,
     date_of_first_payment: String,
-    currency: String,
     trial_period: String,
     paymentFieldsAttributes: PaymentFieldsAttributes,
   ) extends DigitalSubscriptionEmailAttributes
@@ -188,11 +185,8 @@ class DigitalPackEmailFields(
   private def directThankYou(paymentMethodWithSchedule: PaymentMethodWithSchedule) =
     wrap("digipack", DirectDSAttributes(
       directOrCorpFields(SubscriptionEmailFieldHelpers.describe(paymentMethodWithSchedule.paymentSchedule, billingPeriod, currency, promotion)),
-      subscription_term = billingPeriod.noun,
-      payment_amount = SubscriptionEmailFieldHelpers.formatPrice(SubscriptionEmailFieldHelpers.firstPayment(paymentMethodWithSchedule.paymentSchedule).amount),
       country = user.billingAddress.country.name,
       date_of_first_payment = formatDate(SubscriptionEmailFieldHelpers.firstPayment(paymentMethodWithSchedule.paymentSchedule).date),
-      currency = currency.glyph,
       trial_period = "14", //TODO: depends on Promo code or zuora config
       paymentFields(paymentMethodWithSchedule.paymentMethod, directDebitMandateId)
     ))

--- a/support-workers/src/test/scala/com/gu/emailservices/EmailFieldsSpec.scala
+++ b/support-workers/src/test/scala/com/gu/emailservices/EmailFieldsSpec.scala
@@ -66,10 +66,7 @@ class DigitalPackEmailFieldsSpec extends AnyFlatSpec with Matchers with Inside {
         |      "zuorasubscriberid" : "A-S00045678",
         |      "sort_code" : "20-20-20",
         |      "last_name" : "Mouse",
-        |      "subscription_term" : "year",
         |      "account_name" : "Mickey Mouse",
-        |      "currency" : "£",
-        |      "payment_amount" : "119.90",
         |      "default_payment_method" : "Direct Debit"
         |    }
         |  }

--- a/support-workers/src/test/scala/com/gu/emailservices/JsonToAttributesSpec.scala
+++ b/support-workers/src/test/scala/com/gu/emailservices/JsonToAttributesSpec.scala
@@ -18,11 +18,8 @@ class JsonToAttributesSpec extends AnyFlatSpec with Matchers {
         last_name = "4",
         subscription_details = "5"
       ),
-      subscription_term = "6",
-      payment_amount = "7",
       country = "8",
       date_of_first_payment = "9",
-      currency = "0",
       trial_period = "a",
       paymentFieldsAttributes = PPAttributes()
     ).asJsonObject
@@ -33,11 +30,8 @@ class JsonToAttributesSpec extends AnyFlatSpec with Matchers {
       "first_name" -> "3",
       "last_name" -> "4",
       "subscription_details" -> "5",
-      "subscription_term" -> "6",
-      "payment_amount" -> "7",
       "country" -> "8",
       "date_of_first_payment" -> "9",
-      "currency" -> "0",
       "trial_period" -> "a",
       "default_payment_method" -> "PayPal",
     )))

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
@@ -84,7 +84,7 @@ class SendThankYouEmailSpec extends LambdaSpec {
 
 object SendThankYouEmailManualTest {
 
-  //This test will send a thank you email to the address below - useful for quickly testing changes
+  //This test will send a thank you email to the address/SF contact below - useful for quickly testing changes
   val addressToSendTo = "john.duffell@guardian.co.uk"
   val salesforceContactId = SfContactId("0033E00001DTBHJQA5")
 


### PR DESCRIPTION
## Why are you doing this?

Rupert mentioned in https://github.com/guardian/support-frontend/pull/2717#discussion_r494334861 that some of the existing email fields are probably not used.
I have done a check of the DS emails and found 3 fields, which I removed, and the emails still seem to send fine in PROD and TEST.
This PR removes the relevant fields.

## sc reenshots
This is the PROD email after removing the fields
![image](https://user-images.githubusercontent.com/7304387/94182029-3c65a580-fe98-11ea-9a9f-55bf9c60bc3c.png)
