### PR TITLE
Enable test user red banner for subs checkouts

### DIFF
--- a/support-frontend/app/views/subscriptionCheckout.scala.html
+++ b/support-frontend/app/views/subscriptionCheckout.scala.html
@@ -73,6 +73,8 @@
 
       window.guardian.recaptchaEnabled = @settings.switches.enableRecaptchaFrontend.isOn
 
+      window.guardian.isTestUser = @uatMode
+
   </script>
   <script defer id="stripe-js" src="https://js.stripe.com/v3/"></script>
   }


### PR DESCRIPTION
## Why are you doing this?

To make it obvious whether one is logged in as a test user or not when developing locally (see screenshot below). This builds on #2566.

## Changes

* The boolean isTestUser is now set in the subscriptionCheckout view

## Did you enjoy your PR experience?

 - [ ] [PR experience rated](https://forms.gle/N6FsTGG8JQFGV4Ha9)

## Accessibility test checklist
 - [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
 - [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
 - [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

## Screenshots

![image](https://user-images.githubusercontent.com/6162929/94368908-acfe0380-00de-11eb-98f5-1b0104441066.png)


