### PR TITLE
email lambda returns a list rather than a single item

### DIFF
--- a/support-workers/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
@@ -34,7 +34,7 @@ class SendThankYouEmailIT extends AsyncLambdaSpec with MockContext {
 
     sendThankYouEmail.handleRequestFuture(wrapFixture(thankYouEmailJson()), outStream, context).map { _ =>
 
-      val result = Encoding.in[SendMessageResult](outStream.toInputStream)
+      val result = Encoding.in[List[SendMessageResult]](outStream.toInputStream)
       result.isSuccess should be(true)
     }
   }


### PR DESCRIPTION
## Why are you doing this?

this is a followup fix to https://github.com/guardian/support-frontend/pull/2717/files#diff-681c59db0de6db865fe598c3f08c823eR29
Where it was changed to be a List, I should have changed the deserialiser to also use a list.  I didn't expect the result was used anywhere and I forgot to run the IT tests.

This suggests that the IT test runner is not working correctly, as it should have detected this issue.
