### PR TITLE
Use reCAPTCHA special key for test users

### DIFF
--- a/support-frontend/app/config/Configuration.scala
+++ b/support-frontend/app/config/Configuration.scala
@@ -50,7 +50,7 @@ class Configuration(config: TypesafeConfig) {
 
   lazy val promotionsConfigProvider = new PromotionsConfigProvider(config, stage)
 
-  lazy val recaptchaConfigProvider = RecaptchaConfigProvider(config, stage)
+  lazy val recaptchaConfigProvider = new RecaptchaConfigProvider(config, stage)
 
   lazy val capiKey = config.getString("capi-key")
 

--- a/support-frontend/app/config/RecaptchaConfigProvider.scala
+++ b/support-frontend/app/config/RecaptchaConfigProvider.scala
@@ -1,9 +1,18 @@
 package config
 
-import com.gu.support.config.Stage
+import com.gu.support.config.{Stage, TouchpointConfig, TouchpointConfigProvider}
 import com.typesafe.config.Config
 
-case class RecaptchaConfigProvider(config: Config, stage: Stage) {
-  lazy val v2SecretKey = config.getString("v2.recaptcha.secretKey")
-  lazy val v2PublicKey = config.getString("v2.recaptcha.publicKey")
+case class RecaptchaConfig(
+  v2SecretKey: String,
+  v2PublicKey: String
+) extends TouchpointConfig
+
+class RecaptchaConfigProvider(config: Config, stage: Stage) extends TouchpointConfigProvider[RecaptchaConfig](config, stage) {
+  def fromConfig(config: Config): RecaptchaConfig = {
+    RecaptchaConfig(
+      config.getString("v2.recaptcha.secretKey"),
+      config.getString("v2.recaptcha.publicKey")
+    )
+  }
 }

--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -200,7 +200,8 @@ class Application(
       geoData = geoData,
       shareImageUrl = shareImageUrl(settings),
       shareUrl = "https://support.theguardian.com/contribute",
-      v2recaptchaConfigPublicKey = recaptchaConfigProvider.get().v2PublicKey,
+      v2recaptchaConfigPublicKeyDefault = recaptchaConfigProvider.get().v2PublicKey,
+      v2recaptchaConfigPublicKeyUat = recaptchaConfigProvider.get(true).v2PublicKey,
       serversideTests = serversideTests
     )
   }

--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -200,7 +200,7 @@ class Application(
       geoData = geoData,
       shareImageUrl = shareImageUrl(settings),
       shareUrl = "https://support.theguardian.com/contribute",
-      v2recaptchaConfigPublicKey = recaptchaConfigProvider.v2PublicKey,
+      v2recaptchaConfigPublicKey = recaptchaConfigProvider.get().v2PublicKey,
       serversideTests = serversideTests
     )
   }

--- a/support-frontend/app/controllers/DigitalSubscriptionController.scala
+++ b/support-frontend/app/controllers/DigitalSubscriptionController.scala
@@ -122,6 +122,7 @@ class DigitalSubscriptionController(
     val csrf = CSRF.getToken.value
     val uatMode = testUsers.isTestUser(idUser.publicFields.displayName)
     val promoCodes = request.queryString.get("promoCode").map(_.toList).getOrElse(Nil)
+    val v2recaptchaConfigPublicKey = recaptchaConfigProvider.get(uatMode).v2PublicKey
     val readerType = if (orderIsAGift) Gift else Direct
 
     subscriptionCheckout(
@@ -138,7 +139,7 @@ class DigitalSubscriptionController(
       stripeConfigProvider.get(true),
       payPalConfigProvider.get(),
       payPalConfigProvider.get(true),
-      v2recaptchaConfigPublicKey = recaptchaConfigProvider.v2PublicKey,
+      v2recaptchaConfigPublicKey,
       orderIsAGift
     )
   }

--- a/support-frontend/app/controllers/PaperSubscription.scala
+++ b/support-frontend/app/controllers/PaperSubscription.scala
@@ -103,7 +103,7 @@ class PaperSubscription(
     val csrf = CSRF.getToken.value
     val uatMode = testUsers.isTestUser(idUser.publicFields.displayName)
     val promoCodes = request.queryString.get("promoCode").map(_.toList).getOrElse(Nil)
-    val v2recaptchaConfigPublicKey = if (uatMode) recaptchaConfigProvider.get(true).v2PublicKey else recaptchaConfigProvider.get().v2PublicKey
+    val v2recaptchaConfigPublicKey = recaptchaConfigProvider.get(isTestUser = uatMode).v2PublicKey
 
     subscriptionCheckout(
       title,

--- a/support-frontend/app/controllers/PaperSubscription.scala
+++ b/support-frontend/app/controllers/PaperSubscription.scala
@@ -103,6 +103,7 @@ class PaperSubscription(
     val csrf = CSRF.getToken.value
     val uatMode = testUsers.isTestUser(idUser.publicFields.displayName)
     val promoCodes = request.queryString.get("promoCode").map(_.toList).getOrElse(Nil)
+    val v2recaptchaConfigPublicKey = if (uatMode) recaptchaConfigProvider.get(true).v2PublicKey else recaptchaConfigProvider.get().v2PublicKey
 
     subscriptionCheckout(
       title,
@@ -118,7 +119,7 @@ class PaperSubscription(
       stripeConfigProvider.get(true),
       payPalConfigProvider.get(false),
       payPalConfigProvider.get(true),
-      recaptchaConfigProvider.v2PublicKey
+      v2recaptchaConfigPublicKey
     )
   }
 

--- a/support-frontend/app/controllers/StripeController.scala
+++ b/support-frontend/app/controllers/StripeController.scala
@@ -11,6 +11,7 @@ import io.circe.generic.semiauto.deriveDecoder
 import play.api.libs.circe.Circe
 import play.api.mvc.{AbstractController, Action, AnyContent, ControllerComponents}
 import services.{IdentityService, RecaptchaService, StripeSetupIntentService}
+import config.RecaptchaConfigProvider
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -31,7 +32,7 @@ class StripeController(
   recaptchaService: RecaptchaService,
   stripeService: StripeSetupIntentService,
   identityService: IdentityService,
-  v2RecaptchaKey: String,
+  recaptchaConfigProvider: RecaptchaConfigProvider,
   testStripeConfig: StripeConfig,
   settingsProvider: AllSettingsProvider,
   stage: Stage
@@ -52,6 +53,8 @@ class StripeController(
 
     val v2RecaptchaToken = request.body.token
 
+    val v2RecaptchaSecretKey = recaptchaConfigProvider.get().v2SecretKey
+
     val cloudwatchEvent = AwsCloudWatchMetricSetup.createSetupIntentRequest(stage, "v2Recaptcha")
     AwsCloudWatchMetricPut(client)(cloudwatchEvent)
 
@@ -61,7 +64,7 @@ class StripeController(
     // Requests against the test account do not require verification
     val verified =
       if (recaptchaEnabled && !testPublicKeys(request.body.stripePublicKey))
-        recaptchaService.verify(v2RecaptchaToken, v2RecaptchaKey).map(_.success)
+        recaptchaService.verify(v2RecaptchaToken, v2RecaptchaSecretKey).map(_.success)
       else
         EitherT.rightT[Future, String](true)
 

--- a/support-frontend/app/controllers/WeeklySubscription.scala
+++ b/support-frontend/app/controllers/WeeklySubscription.scala
@@ -146,6 +146,7 @@ class WeeklySubscription(
       DefaultPromotions.GuardianWeekly.NonGift.all
     val promoCodes = request.queryString.get("promoCode").map(_.toList).getOrElse(Nil) ++ defaultPromos
     val readerType = if (orderIsAGift) Gift else Direct
+    val v2recaptchaConfigPublicKey = if (uatMode) recaptchaConfigProvider.get(true).v2PublicKey else recaptchaConfigProvider.get().v2PublicKey
 
     subscriptionCheckout(
       title,
@@ -161,7 +162,7 @@ class WeeklySubscription(
       stripeConfigProvider.get(true),
       payPalConfigProvider.get(),
       payPalConfigProvider.get(true),
-      recaptchaConfigProvider.v2PublicKey,
+      v2recaptchaConfigPublicKey,
       orderIsAGift
     )
   }

--- a/support-frontend/app/controllers/WeeklySubscription.scala
+++ b/support-frontend/app/controllers/WeeklySubscription.scala
@@ -146,7 +146,7 @@ class WeeklySubscription(
       DefaultPromotions.GuardianWeekly.NonGift.all
     val promoCodes = request.queryString.get("promoCode").map(_.toList).getOrElse(Nil) ++ defaultPromos
     val readerType = if (orderIsAGift) Gift else Direct
-    val v2recaptchaConfigPublicKey = if (uatMode) recaptchaConfigProvider.get(true).v2PublicKey else recaptchaConfigProvider.get().v2PublicKey
+    val v2recaptchaConfigPublicKey = recaptchaConfigProvider.get(isTestUser = uatMode).v2PublicKey
 
     subscriptionCheckout(
       title,

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -26,7 +26,8 @@
   geoData: GeoData,
   shareImageUrl: String,
   shareUrl: String,
-  v2recaptchaConfigPublicKey: String,
+  v2recaptchaConfigPublicKeyDefault: String,
+  v2recaptchaConfigPublicKeyUat: String,
   serversideTests: Map[String, Participation] = Map()
 )(implicit assets: AssetsResolver, request: RequestHeader, settings: AllSettings)
 
@@ -115,7 +116,10 @@
   window.guardian.enableContributionsCampaign = @settings.switches.enableContributionsCampaign.isOn
 
   window.guardian.recaptchaEnabled = @settings.switches.enableRecaptchaFrontend.isOn
-  window.guardian.v2recaptchaPublicKey = "@v2recaptchaConfigPublicKey";
+  window.guardian.v2recaptchaPublicKey = {
+    default: "@v2recaptchaConfigPublicKeyDefault",
+    uat: "@v2recaptchaConfigPublicKeyUat"
+  }
   </script>
   <script defer id="stripe-js" src=@{s"https://js.stripe.com/v3/${if (serversideTests.get("stripeFraudDetection").contains(Variant)) "?advancedFraudSignals=false" else ""}"}></script>
 }

--- a/support-frontend/app/wiring/Controllers.scala
+++ b/support-frontend/app/wiring/Controllers.scala
@@ -145,7 +145,7 @@ trait Controllers {
     recaptchaService = recaptchaService,
     stripeService = stripeService,
     identityService = identityService,
-    v2RecaptchaKey = appConfig.recaptchaConfigProvider.v2SecretKey,
+    recaptchaConfigProvider = appConfig.recaptchaConfigProvider,
     testStripeConfig = appConfig.regularStripeConfigProvider.get(true),
     allSettingsProvider,
     appConfig.stage

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -149,7 +149,7 @@ const StripeForm = (props: StripeFormPropTypes) => {
     fetchJson(
       routes.stripeSetupIntentRecaptcha,
       requestOptions(
-        { token, stripePublicKey: props.stripeKey },
+        { token, stripePublicKey: props.stripeKey, isTestUser: window.guardian.isTestUser},
         'same-origin',
         'POST',
         props.csrf,

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -34,6 +34,7 @@ export type StripeFormPropTypes = {
   validateForm: Function,
   buttonText: string,
   csrf: Csrf,
+  isTestUser: boolean,
 }
 
 type CardFieldData = {
@@ -149,7 +150,7 @@ const StripeForm = (props: StripeFormPropTypes) => {
     fetchJson(
       routes.stripeSetupIntentRecaptcha,
       requestOptions(
-        { token, stripePublicKey: props.stripeKey, isTestUser: window.guardian.isTestUser},
+        { token, stripePublicKey: props.stripeKey, isTestUser: props.isTestUser },
         'same-origin',
         'POST',
         props.csrf,

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -21,7 +21,6 @@ import { appropriateErrorMessage } from 'helpers/errorReasons';
 import type { Csrf } from 'helpers/csrf/csrfReducer';
 import { trackComponentLoad } from 'helpers/tracking/behaviour';
 import { loadRecaptchaV2 } from 'helpers/recaptcha';
-import { isPostDeployUser } from 'helpers/user/user';
 import { routes } from 'helpers/routes';
 import { Recaptcha } from 'components/recaptcha/recaptcha';
 

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -183,7 +183,7 @@ const StripeForm = (props: StripeFormPropTypes) => {
   };
 
   const setupRecurringHandlers = (): void => {
-    if (!window.guardian.recaptchaEnabled || isPostDeployUser()) {
+    if (!window.guardian.recaptchaEnabled) {
       fetchPaymentIntent('dummy');
     } else if (window.grecaptcha && window.grecaptcha.render) {
       setupRecurringRecaptchaCallback();
@@ -239,7 +239,6 @@ const StripeForm = (props: StripeFormPropTypes) => {
 
   const checkRecaptcha = () => {
     if (window.guardian.recaptchaEnabled &&
-      !isPostDeployUser() &&
       !recaptchaCompleted &&
       recaptchaError === null) {
       setRecaptchaError({

--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeProviderForCountry.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeProviderForCountry.jsx
@@ -49,6 +49,7 @@ function StripeProviderForCountry(props: PropTypes) {
         validateForm={props.validateForm}
         buttonText={props.buttonText}
         csrf={props.csrf}
+        isTestUser={props.isTestUser}
       />
     </Elements>
   );

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
@@ -77,7 +77,6 @@ const mapStateToProps = (state: State) => ({
   recurringRecaptchaVerified: state.page.form.stripeCardFormData.recurringRecaptchaVerified,
   formIsSubmittable: state.page.form.formIsSubmittable,
   oneOffRecaptchaToken: state.page.form.oneOffRecaptchaToken,
-  isTestUser: state.page.user.isTestUser,
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
@@ -79,7 +79,6 @@ const mapStateToProps = (state: State) => ({
   formIsSubmittable: state.page.form.formIsSubmittable,
   oneOffRecaptchaToken: state.page.form.oneOffRecaptchaToken,
   postDeploymentTestUser: state.page.user.isPostDeploymentTestUser,
-  isTestUser: state.page.user.isTestUser
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
@@ -63,7 +63,6 @@ type PropTypes = {|
   formIsSubmittable: boolean,
   setOneOffRecaptchaToken: string => Action,
   oneOffRecaptchaToken: string,
-  postDeploymentTestUser: string,
   isTestUser: boolean,
 |};
 
@@ -78,7 +77,7 @@ const mapStateToProps = (state: State) => ({
   recurringRecaptchaVerified: state.page.form.stripeCardFormData.recurringRecaptchaVerified,
   formIsSubmittable: state.page.form.formIsSubmittable,
   oneOffRecaptchaToken: state.page.form.oneOffRecaptchaToken,
-  postDeploymentTestUser: state.page.user.isPostDeploymentTestUser,
+  isTestUser: state.page.user.isTestUser,
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -202,7 +201,7 @@ const CardForm = (props: PropTypes) => {
     }
 
     window.grecaptcha.render('robot_checkbox', {
-      sitekey: props.postDeploymentTestUser ?
+      sitekey: props.isTestUser ?
         window.guardian.v2recaptchaPublicKey.uat :
         window.guardian.v2recaptchaPublicKey.default,
       callback: (token) => {
@@ -212,7 +211,7 @@ const CardForm = (props: PropTypes) => {
         fetchJson(
           routes.stripeSetupIntentRecaptcha,
           requestOptions(
-            { token, stripePublicKey: props.stripeKey, isTestUser: props.postDeploymentTestUser},
+            { token, stripePublicKey: props.stripeKey, isTestUser: props.isTestUser },
             'same-origin',
             'POST',
             props.csrf,
@@ -237,8 +236,9 @@ const CardForm = (props: PropTypes) => {
   };
 
   const setupRecaptchaTokenForOneOff = () => {
+
     window.grecaptcha.render('robot_checkbox', {
-      sitekey: props.postDeploymentTestUser ?
+      sitekey: props.isTestUser ?
         window.guardian.v2recaptchaPublicKey.uat :
         window.guardian.v2recaptchaPublicKey.default,
       callback: (token) => {

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
@@ -203,7 +203,9 @@ const CardForm = (props: PropTypes) => {
     }
 
     window.grecaptcha.render('robot_checkbox', {
-      sitekey: props.postDeploymentTestUser ? window.guardian.v2recaptchaPublicKey.uat : window.guardian.v2recaptchaPublicKey.default,
+      sitekey: props.postDeploymentTestUser ?
+        window.guardian.v2recaptchaPublicKey.uat :
+        window.guardian.v2recaptchaPublicKey.default,
       callback: (token) => {
         trackComponentLoad('contributions-recaptcha-client-token-received');
         props.setStripeRecurringRecaptchaVerified(true);
@@ -237,7 +239,9 @@ const CardForm = (props: PropTypes) => {
 
   const setupRecaptchaTokenForOneOff = () => {
     window.grecaptcha.render('robot_checkbox', {
-      sitekey: props.postDeploymentTestUser ? window.guardian.v2recaptchaPublicKey.uat : window.guardian.v2recaptchaPublicKey.default,
+      sitekey: props.postDeploymentTestUser ?
+        window.guardian.v2recaptchaPublicKey.uat :
+        window.guardian.v2recaptchaPublicKey.default,
       callback: (token) => {
         trackComponentLoad('contributions-recaptcha-client-token-received');
         props.setOneOffRecaptchaToken(token);

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardFormContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardFormContainer.jsx
@@ -71,7 +71,10 @@ const StripeCardFormContainer = (props: PropTypes) => {
       return (
         <div className="stripe-card-element-container" key={stripeAccount}>
           <Elements stripe={stripeObjects[stripeAccount]} options={elementsOptions}>
-            <StripeCardForm stripeKey={stripeKey} />
+            <StripeCardForm 
+              stripeKey={stripeKey}
+              isTestUser={props.isTestUser}
+            />
           </Elements>
         </div>
       );

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardFormContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardFormContainer.jsx
@@ -71,7 +71,7 @@ const StripeCardFormContainer = (props: PropTypes) => {
       return (
         <div className="stripe-card-element-container" key={stripeAccount}>
           <Elements stripe={stripeObjects[stripeAccount]} options={elementsOptions}>
-            <StripeCardForm 
+            <StripeCardForm
               stripeKey={stripeKey}
               isTestUser={props.isTestUser}
             />

--- a/support-frontend/test/controllers/SubscriptionsTest.scala
+++ b/support-frontend/test/controllers/SubscriptionsTest.scala
@@ -18,7 +18,7 @@ import com.gu.support.zuora.api.ReaderType.Direct
 import com.gu.tip.Tip
 import com.typesafe.config.ConfigFactory
 import config.Configuration.MetricUrl
-import config.{RecaptchaConfigProvider, StringsConfig}
+import config.{RecaptchaConfigProvider, RecaptchaConfig, StringsConfig}
 import fixtures.TestCSRFComponents
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
@@ -101,6 +101,7 @@ class SubscriptionsTest extends AnyWordSpec with Matchers with TestCSRFComponent
       val payPal = mock[PayPalConfigProvider]
       when(payPal.get(any[Boolean])).thenReturn(PayPalConfig("", "", "", "", "", ""))
       val recaptchaConfigProvider = mock[RecaptchaConfigProvider]
+      when(recaptchaConfigProvider.get(any[Boolean])).thenReturn(RecaptchaConfig("",""))
 
       val prices: ProductPrices = Map(
         CountryGroup.UK ->

--- a/support-frontend/test/selenium/contributions/OneOffContributionsSpec.scala
+++ b/support-frontend/test/selenium/contributions/OneOffContributionsSpec.scala
@@ -68,6 +68,9 @@ class OneOffContributionsSpec extends AnyFeatureSpec
       And("enter card details")
       landingPage.fillInCardDetails
 
+      And("click the recaptcha")
+      landingPage.clickRecaptcha
+
       When("they click contribute")
       landingPage.clickContribute
 

--- a/support-frontend/test/selenium/contributions/RecurringContributionsSpec.scala
+++ b/support-frontend/test/selenium/contributions/RecurringContributionsSpec.scala
@@ -51,6 +51,9 @@ class RecurringContributionsSpec extends AnyFeatureSpec with GivenWhenThen with 
       And("enter card details")
       landingPage.fillInCardDetails
 
+      And("click the recaptcha")
+      landingPage.clickRecaptcha
+
       When("they click contribute")
       landingPage.clickContribute
 
@@ -87,6 +90,9 @@ class RecurringContributionsSpec extends AnyFeatureSpec with GivenWhenThen with 
 
       And("enter card details")
       landingPage.fillInCardDetails
+      
+      And("click the recaptcha")
+      landingPage.clickRecaptcha
 
       When("they click contribute")
       landingPage.clickContribute

--- a/support-frontend/test/selenium/contributions/pages/ContributionsLanding.scala
+++ b/support-frontend/test/selenium/contributions/pages/ContributionsLanding.scala
@@ -26,6 +26,8 @@ case class ContributionsLanding(region: String, testUser: TestUser)(implicit val
 
   private val stripeOverlayIframe = cssSelector(".stripe_checkout_app")
 
+  private val stripeRecaptchaButton = id("robot_checkbox")
+
   private object RegisterFields {
     private val firstName = id("contributionFirstName")
     private val lastName = id("contributionLastName")
@@ -91,6 +93,13 @@ case class ContributionsLanding(region: String, testUser: TestUser)(implicit val
     pageHasElement(contributeButton)
     elementIsClickable(contributeButton)
   }
+
+  def clickRecaptcha: Unit = {
+    clickOn(stripeRecaptchaButton)
+    waitForTestRecaptchaToComplete
+  }
+
+  def waitForTestRecaptchaToComplete: Unit = Thread.sleep(1000)
 
   def clickContribute: Unit = clickOn(contributeButton)
 

--- a/support-frontend/test/selenium/subscriptions/pages/CheckoutPage.scala
+++ b/support-frontend/test/selenium/subscriptions/pages/CheckoutPage.scala
@@ -13,6 +13,7 @@ trait CheckoutPage extends Page with Browser {
   private val cardNumber = name("cardnumber")
   private val expiry = name("exp-date")
   private val cvc = name("cvc")
+  private val stripeRecaptchaButton = id("robot_checkbox")
 
   // Direct debit
   private val directDebitButton = id("qa-direct-debit")
@@ -55,6 +56,12 @@ trait CheckoutPage extends Page with Browser {
     switchToFrame(2)
     setValue(cvc, "123")
     switchToParentFrame
+    clickOn(stripeRecaptchaButton)
+    waitForTestRecaptchaToComplete
+  }
+
+  def waitForTestRecaptchaToComplete: Unit = {
+    Thread.sleep(1000)
   }
 
   def fillDirectDebitForm(): Unit = {

--- a/support-frontend/test/selenium/subscriptions/pages/CheckoutPage.scala
+++ b/support-frontend/test/selenium/subscriptions/pages/CheckoutPage.scala
@@ -60,9 +60,7 @@ trait CheckoutPage extends Page with Browser {
     waitForTestRecaptchaToComplete
   }
 
-  def waitForTestRecaptchaToComplete: Unit = {
-    Thread.sleep(1000)
-  }
+  def waitForTestRecaptchaToComplete: Unit = Thread.sleep(1000)
 
   def fillDirectDebitForm(): Unit = {
     setValue(accountName, "Test user")


### PR DESCRIPTION
## Why are you doing this?

* **Problem**: The automated Selenium post-deploy tests used to bypass the No CAPTCHA reCAPTCHA on the Subscriptions Checkouts Stripe form by checking for a `_post_deploy_user` cookie and ignoring the result from the reCAPTCHA verification if the cookie is set. This resulted in a reCAPTCHA-related error being missed by the post-deploy tests and slipping in PROD. See the [Thu 27 Aug 2020 outage retro doc](https://docs.google.com/document/d/1vuBWgmCvp64Mbw5X8Snpg5Gcb_jOkKLw3gRLG5EbRbY/edit?usp=sharing) for more info.
* **Solution**: This PR implements the [recommended way for running automated tests](https://developers.google.com/recaptcha/docs/faq#id-like-to-run-automated-tests-with-recaptcha.-what-should-i-do) with a v2 reCAPTCHA. Test users will now see a special No CAPTCHA for testing purposes (see screenshot below) on the Subscriptions checkouts when the Credit/Debit card option is selected.

<!--
Remember, PRs are documentation for future contributors.

If this PR is a fix, please include a link to the original PR that introduced
the breakage for reference.
-->

[**Trello Card**](https://trello.com/c/kJ5pqNoG)

## Changes

* RecaptchaConfigProvider now extends TouchpointConfigProvider to differentiate between UAT, SANDBOX and PROD [touchpoint environments](https://github.com/guardian/support-frontend/tree/main/support-config#touchpoint-environment). Files affected:
  * [`support-frontend/app/config/Configuration.scala`](https://github.com/guardian/support-frontend/pull/2728/files#diff-953c40ee2a8cee77f2b43109b1e5f47e)
  * [`support-frontend/app/config/RecaptchaConfigProvider.scala`](https://github.com/guardian/support-frontend/pull/2728/files#diff-904d153b6c600d812124d9ae1f28890c)
  * [`support-frontend/test/controllers/SubscriptionsTest.scala`](https://github.com/guardian/support-frontend/pull/2728/files#diff-630f120273a3ad8cba1f88bb234d5802)
* As a result, controllers now decide whether to use UAT or SANDBOX/PROD value for the reCAPTCHA public key. Files affected:
  * [`support-frontend/app/controllers/Application.scala`](https://github.com/guardian/support-frontend/pull/2728/files#diff-04600d093ee81c82983e9c9f0a0ef971)
  * [`support-frontend/app/controllers/DigitalSubscriptionController.scala`](https://github.com/guardian/support-frontend/pull/2728/files#diff-2dd7c04477b936158b9cd8b8c9b48f61)
  * [`support-frontend/app/controllers/PaperSubscription.scala`](https://github.com/guardian/support-frontend/pull/2728/files#diff-ccba6c5f6c4141484e7cdca2add29512)
  * [`support-frontend/app/controllers/WeeklySubscription.scala`](https://github.com/guardian/support-frontend/pull/2728/files#diff-e34d74356072e905437eeac127df90cb)
  * [`support-frontend/app/controllers/StripeController.scala`](https://github.com/guardian/support-frontend/pull/2728/files#diff-e6aaa9407346a5c85b813d891204bfde)
  * [`support-frontend/app/wiring/Controllers.scala`](https://github.com/guardian/support-frontend/pull/2728/files#diff-7f10b054bf1610fe2add888091689d41)
* Making the distinction between UAT and SANDBOX/PROD values of the reCAPTCHA secret key requires a change in the `/stripe/create-setup-intent/recaptcha` endpoint, so that the controller knows whether the request is coming from a test user or a normal user. Files affected:
  * [`support-frontend/app/controllers/StripeController.scala`](https://github.com/guardian/support-frontend/pull/2728/files#diff-e6aaa9407346a5c85b813d891204bfde)
* This allows the Subs Stripe form to no longer skip over reCAPTCHA confirmation for automated selenium post-deploy test users. Files affected:
  * [`support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx`](https://github.com/guardian/support-frontend/pull/2728/files#diff-9d1c23b30ea23dfe7d448518b3530726)
  * [`support-frontend/test/selenium/subscriptions/pages/CheckoutPage.scala`](https://github.com/guardian/support-frontend/pull/2728/files#diff-c99e942072b05ca5537c4efae248dfbb)
* And similarly for the Stripe form on the Contributions landing page. Files affected:
  * [`support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx`](https://github.com/guardian/support-frontend/pull/2728/files#diff-cdb1961760ecf781ee6e5361ae58ad9e)
  * [`support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardFormContainer.jsx`](https://github.com/guardian/support-frontend/pull/2728/files#diff-7ab2d8754f00ca2506342cbb66deacf2)
  * [`support-frontend/app/views/contributions.scala.html`](https://github.com/guardian/support-frontend/pull/2728/files#diff-91c4f5f073cf395b107dd7245340b20f)
  * [`support-frontend/test/selenium/contributions/OneOffContributionsSpec.scala`](https://github.com/guardian/support-frontend/pull/2728/files#diff-5c209993882985e7525637d128a659fc)
  * [`support-frontend/test/selenium/contributions/RecurringContributionsSpec.scala`](https://github.com/guardian/support-frontend/pull/2728/files#diff-9755895294cdd85bcb42c138b726e76d)
  * [`support-frontend/test/selenium/contributions/pages/ContributionsLanding.scala`](https://github.com/guardian/support-frontend/pull/2728/files#diff-9e567a7778607e6b49f5a1e3cd835437)


## TODO

- [x] Update AWS Parameter Store
- [ ] Test in CODE
- [ ] Check this PR would have caught the error that caused the outage 

## Did you enjoy your PR experience?

 - [ ] [PR experience rated](https://forms.gle/N6FsTGG8JQFGV4Ha9)

## Accessibility test checklist
 - [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
 - [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
 - [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

## Screenshots

Special No CAPTCHA for testing purposes
![image](https://user-images.githubusercontent.com/6162929/94557312-4e5b9580-0256-11eb-983f-64436b2e1ca6.png)

## Recaptcha lingo

CAPTCHA - the one with deciphering letters / numbers
reCAPTCHA - the one with selecting images. Term also used as a catch-all for the other types
No CAPTCHA - the one with just a checkbox