### PR TITLE
Update social share url for enviro moment

### DIFF
--- a/support-frontend/app/admin/settings/Switches.scala
+++ b/support-frontend/app/admin/settings/Switches.scala
@@ -10,7 +10,9 @@ case class Switches(
   useDotcomContactPage: Option[SwitchState],
   enableRecaptchaBackend: SwitchState,
   enableRecaptchaFrontend: SwitchState,
-  experiments: Map[String, ExperimentSwitch]
+  experiments: Map[String, ExperimentSwitch],
+  enableContributionsCampaign: SwitchState,
+  forceContributionsCampaign: SwitchState
 )
 
 object Switches {

--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -142,15 +142,15 @@ class Application(
   }
 
   private def shareImageUrl(settings: AllSettings): String = {
-    val ausMomentEnabled =
+    val contributionsMomentEnabled =
       settings
         .switches
         .experiments
-        .get("ausMomentEnabled")
+        .get("contributionsMomentEnabled")
         .exists(switch => switch.state.isOn)
 
-      if (ausMomentEnabled)
-        "https://i.guim.co.uk/img/media/32cd8c7234c391a7b96c8e91945af9b2e9711631/0_0_1000_525/1000.jpg?quality=85&s=5d69b3ed574a58361e1bce4f4a121b45"
+      if (contributionsMomentEnabled)
+        "https://media.guim.co.uk/0ab154e35cff7a4e6ff6b5ee0d7cd13b9df32959/0_0_2000_1050/1000.png"
       else
         "https://i.guim.co.uk/img/media/74b15a65c479bfe53151fceeb7d948f125a66af2/0_0_2400_1260/1000.png?quality=85&s=4b52891c0a86da6c08f2dc6e8308d211"
   }
@@ -218,7 +218,7 @@ class Application(
       canonicalLink = Some(buildCanonicalShowcaseLink("uk"))
     )()).withSettingsSurrogateKey
   }
-  
+
   val ausMomentMapSocialImageUrl =
     "https://i.guim.co.uk/img/media/84bf6a5c9535827ff4c307941cf3147fb2fb63c8/0_0_2000_1050/1000.png?width=1000&quality=85&s=2f7dc4ee733fee7117358fbbb1fa057f"
 

--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -145,9 +145,8 @@ class Application(
     val contributionsMomentEnabled =
       settings
         .switches
-        .experiments
-        .get("contributionsMomentEnabled")
-        .exists(switch => switch.state.isOn)
+        .enableContributionsCampaign
+        .isOn
 
       if (contributionsMomentEnabled)
         "https://media.guim.co.uk/0ab154e35cff7a4e6ff6b5ee0d7cd13b9df32959/0_0_2000_1050/1000.png"

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -111,7 +111,8 @@
     window.guardian.guestAccountCreationToken = "@guestAccountCreationToken";
   }
 
-  window.guardian.forceCampaign = @settings.switches.experiments.get("forceCampaign").exists(_.isOn)
+  window.guardian.forceContributionsCampaign = @settings.switches.forceContributionsCampaign.isOn
+  window.guardian.enableContributionsCampaign = @settings.switches.enableContributionsCampaign.isOn
 
   window.guardian.recaptchaEnabled = @settings.switches.enableRecaptchaFrontend.isOn
   window.guardian.v2recaptchaPublicKey = "@v2recaptchaConfigPublicKey";

--- a/support-frontend/assets/helpers/campaigns.jsx
+++ b/support-frontend/assets/helpers/campaigns.jsx
@@ -30,8 +30,8 @@ export const campaign: CampaignSettings = ({
 });
 
 function campaignEnabledForUser(campaignCode: ?string): boolean {
-  if (currentCampaignPath) {
-    return window.guardian.forceCampaign ||
+  if (currentCampaignPath && window.guardian.enableContributionsCampaign) {
+    return window.guardian.forceContributionsCampaign ||
       window.location.pathname.endsWith(`/${currentCampaignPath}`) ||
       campaign.campaignCode === campaignCode;
   }

--- a/support-frontend/test/codecs/CirceDecodersTest.scala
+++ b/support-frontend/test/codecs/CirceDecodersTest.scala
@@ -122,7 +122,9 @@ class CirceDecodersTest extends AnyWordSpec with Matchers {
           |    "enableDigitalSubGifting": "On",
           |    "useDotcomContactPage": "Off",
           |    "enableRecaptchaFrontend": "Off",
-          |    "enableRecaptchaBackend": "Off"
+          |    "enableRecaptchaBackend": "Off",
+          |    "enableContributionsCampaign": "On",
+          |    "forceContributionsCampaign": "On"
           |  },
           |  "amounts": {
           |    "GBPCountries": {
@@ -293,7 +295,9 @@ class CirceDecodersTest extends AnyWordSpec with Matchers {
           enableDigitalSubGifting = On,
           useDotcomContactPage = Some(Off),
           enableRecaptchaBackend = Off,
-          enableRecaptchaFrontend = Off
+          enableRecaptchaFrontend = Off,
+          enableContributionsCampaign = On,
+          forceContributionsCampaign = On
         ),
         amountsRegions,
         contributionTypes,

--- a/support-frontend/test/controllers/SubscriptionsTest.scala
+++ b/support-frontend/test/controllers/SubscriptionsTest.scala
@@ -75,7 +75,9 @@ class SubscriptionsTest extends AnyWordSpec with Matchers with TestCSRFComponent
         enableDigitalSubGifting = On,
         useDotcomContactPage = Some(SwitchState.Off),
         enableRecaptchaBackend = Off,
-        enableRecaptchaFrontend = Off
+        enableRecaptchaFrontend = Off,
+        enableContributionsCampaign = On,
+        forceContributionsCampaign = On
       ),
       AmountsRegions(amounts, amounts, amounts, amounts, amounts, amounts, amounts),
       ContributionTypes(Nil, Nil, Nil, Nil, Nil, Nil, Nil),


### PR DESCRIPTION
## Why are you doing this?
Update the social share url for the environment moment, as per [this card](https://trello.com/c/hMZCsiJp/2301-enviro-moment-replace-the-social-share-image-with-a-campaign-specific). Additionally, add two switches to `Switch` model: `enableContributionsCampaign` and `forceContributionsCampaign`. Before these were both `ExperimentSwitch`es but now we've formalised them as proper switches.

## Changes
* formalise two contributions campaign switches
* update social share url for campaign


