### PR TITLE
remove thank you page test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -8,7 +8,6 @@ const usOnlyLandingPage = '/us/contribute(/.*)?$';
 const auOnlyLandingPage = '/au/contribute(/.*)?$';
 const ukOnlyLandingPage = '/uk/contribute(/.*)?$';
 const allBarUkLandingPages = '/((?!uk).)*/contribute(/.*)?$';
-const allThankYouAndLandingPages = '/??/(thankyou|contribute)(/.*)?$';
 export const subsShowcaseAndDigiSubPages = '(/??/subscribe(\\?.*)?$|/??/subscribe/digital(\\?.*)?$)';
 
 export const tests: Tests = {
@@ -104,27 +103,5 @@ export const tests: Tests = {
     referrerControlled: false,
     targetPage: allBarUkLandingPages,
     seed: 2,
-  },
-
-  newThankYouFlowR1: {
-    type: 'OTHER',
-    variants: [
-      {
-        id: 'control',
-      },
-      {
-        id: 'newFlow',
-      },
-    ],
-    audiences: {
-      ALL: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: true,
-    referrerControlled: false,
-    targetPage: allThankYouAndLandingPages,
-    seed: 3,
   },
 };

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
@@ -1,42 +1,23 @@
 // @flow
 import React from 'react';
-import { connect } from 'react-redux';
-import { type State } from '../../contributionsLandingReducer';
 import Page from 'components/page/page';
 import Footer from 'components/footer/footer';
 import { RoundelHeader } from 'components/headers/roundelHeader/header';
-import OldContributionThankYou from './old-flow/ContributionThankYouContainer';
-import NewContribtuionThankYou from './new-flow/ContributionThankYou';
+import NewContributionThankYou from './new-flow/ContributionThankYou';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
 type ContributionThankYouProps = {|
   countryGroupId: CountryGroupId,
-  shouldShowNewFlow: boolean
 |};
-
-const mapStateToProps = (state: State) => ({
-  shouldShowNewFlow:
-    state.common.abParticipations.newThankYouFlowR1 === 'newFlow',
-});
 
 const ContributionThankYou = ({
   countryGroupId,
-  shouldShowNewFlow,
-}: ContributionThankYouProps) => {
-  const oldFlowClassModifiers = ['contribution-thankyou'];
-
-  return (
-    <Page
-      classModifiers={shouldShowNewFlow ? [] : oldFlowClassModifiers}
-      header={<RoundelHeader />}
-      footer={<Footer disclaimer countryGroupId={countryGroupId} />}
-    >
-      {shouldShowNewFlow ? (
-        <NewContribtuionThankYou />
-      ) : (
-        <OldContributionThankYou />
-      )}
-    </Page>
-  );
-};
-export default connect(mapStateToProps)(ContributionThankYou);
+}: ContributionThankYouProps) => (
+  <Page
+    header={<RoundelHeader />}
+    footer={<Footer disclaimer countryGroupId={countryGroupId} />}
+  >
+    <NewContributionThankYou />
+  </Page>
+);
+export default ContributionThankYou;


### PR DESCRIPTION
The new thank you page is performing much better than the old, so this change removes the test.

TODO later - remove all code for the old thank you page.