### PR TITLE
fix post deploy test for thankyou page

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
@@ -14,6 +14,7 @@ const ContributionThankYou = ({
   countryGroupId,
 }: ContributionThankYouProps) => (
   <Page
+    classModifiers={['contribution-thankyou']}
     header={<RoundelHeader />}
     footer={<Footer disclaimer countryGroupId={countryGroupId} />}
   >

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.scss
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.scss
@@ -33,15 +33,6 @@ body {
   overflow: hidden;
 }
 
-.gu-content--contribution-thankyou {
-  background: gu-colour(highlight-main);
-
-  .gu-content__main {
-    position: relative;
-    background-color: transparent;
-  }
-}
-
 .gu-content__main {
   position: relative;
   background-color: gu-colour(sport-faded);


### PR DESCRIPTION
it looks for this class when checking to see if the thankyou page has loaded, so I've added it back in (and removed the styling, as it was for the old page only)
(test was broken here https://github.com/guardian/support-frontend/pull/2731)

Now works locally:
![Screen Shot 2020-09-30 at 10 33 31](https://user-images.githubusercontent.com/1513454/94668910-86bbac00-0308-11eb-84b1-0617acc2fc4e.png)
