### PR TITLE
alarm when two IT test runs fail in a row

### DIFF
--- a/support-lambdas/it-test-runner/cfn.yaml
+++ b/support-lambdas/it-test-runner/cfn.yaml
@@ -99,16 +99,27 @@ Resources:
         - ' '
         - - 'Impact - There may be improperly tested code in PROD or DEV test data is broken.'
           - !FindInMap [ Constants, Alarm, Process ]
-      Namespace: support-frontend
-      MetricName: it-test-failed
-      Dimensions:
-        - Name: Stage
-          Value: !Ref Stage
-      Statistic: Sum
+      Metrics:
+        - Id: total
+          Expression: "FILL(m1,0)"
+          Label: ITTestsCount
+        - Id: m1
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: support-frontend
+              MetricName: it-test-failed
+              Dimensions:
+                - Name: Stage
+                  Value: !Ref Stage
+            Stat: Sum
+            Period: 60
+            Unit: Count
       ComparisonOperator: GreaterThanThreshold
       Threshold: 0
-      EvaluationPeriods: 1
-      Period: 60
+      EvaluationPeriods: 70
+      DatapointsToAlarm: 2
+      TreatMissingData: breaching
 
   ITTestNotRunningAlarm:
     Type: AWS::CloudWatch::Alarm
@@ -138,7 +149,7 @@ Resources:
                 - Name: Stage
                   Value: !Ref Stage
             Stat: Sum
-            Period: 3600
+            Period: 60
             Unit: Count
         - Id: m2
           ReturnData: false
@@ -150,9 +161,10 @@ Resources:
                 - Name: Stage
                   Value: !Ref Stage
             Stat: Sum
-            Period: 3600
+            Period: 60
             Unit: Count
       ComparisonOperator: LessThanThreshold
       Threshold: 100
-      EvaluationPeriods: 24
+      EvaluationPeriods: 70
+      DatapointsToAlarm: 69
       TreatMissingData: breaching

--- a/support-lambdas/it-test-runner/cfn.yaml
+++ b/support-lambdas/it-test-runner/cfn.yaml
@@ -102,7 +102,7 @@ Resources:
       Metrics:
         - Id: total
           Expression: "FILL(m1,0)"
-          Label: ITTestsCount
+          Label: ITTestsFailed
         - Id: m1
           ReturnData: false
           MetricStat:

--- a/support-lambdas/it-test-runner/cfn.yaml
+++ b/support-lambdas/it-test-runner/cfn.yaml
@@ -166,5 +166,5 @@ Resources:
       ComparisonOperator: LessThanThreshold
       Threshold: 100
       EvaluationPeriods: 70
-      DatapointsToAlarm: 69
+      DatapointsToAlarm: 70
       TreatMissingData: breaching


### PR DESCRIPTION
## Why are you doing this?

The IT tests are noisy because there are random failures from network issues.  This updates the alarm to be quieter hopefully as it will need two failures in a row.

[**Trello Card**](https://trello.com/c/of5WhYtb/3357-change-ittestfailurealarm-to-trigger-on-failing-tests-if-there-were-also-failing-tests-in-the-previous-run-1u-33)
