### PR TITLE
rename dynamo lookup types and add pre-zuora gift code validation

### DIFF
--- a/support-frontend/app/controllers/RedemptionController.scala
+++ b/support-frontend/app/controllers/RedemptionController.scala
@@ -12,7 +12,7 @@ import com.gu.googleauth.AuthAction
 import com.gu.identity.model.{User => IdUser}
 import com.gu.monitoring.SafeLogger
 import com.gu.monitoring.SafeLogger._
-import com.gu.support.redemption.corporate.{CorporateCodeValidator, DynamoTableAsync}
+import com.gu.support.redemption.corporate.{CorporateCodeValidator, DynamoTableAsync, DynamoTableAsyncProvider}
 import com.gu.support.redemption.gifting.GiftCodeValidator
 import com.gu.support.redemption._
 import com.gu.support.redemptions.RedemptionCode
@@ -33,10 +33,6 @@ import views.html.subscriptionRedemptionForm
 
 import scala.concurrent.{ExecutionContext, Future}
 
-trait DynamoTableAsyncForUser {
-  def apply(isTestUser: Boolean): DynamoTableAsync
-}
-
 class RedemptionController(
   val actionRefiners: CustomActionBuilders,
   val assets: AssetsResolver,
@@ -47,7 +43,7 @@ class RedemptionController(
   components: ControllerComponents,
   fontLoaderBundle: Either[RefPath, StyleContent],
   googleAuthAction: AuthAction[AnyContent],
-  dynamoLookup: DynamoTableAsyncForUser,
+  dynamoLookupProvider: DynamoTableAsyncProvider,
   zuoraLookupServiceProvider: ZuoraGiftLookupServiceProvider
 )(
   implicit val ec: ExecutionContext
@@ -69,9 +65,9 @@ class RedemptionController(
     implicit request =>
       for {
         isTestUser <- testUserFromRequest.isTestUser(request)
-        codeValidator = new CodeValidator(zuoraLookupServiceProvider.forUser(isTestUser), dynamoLookup)
+        codeValidator = new CodeValidator(zuoraLookupServiceProvider.forUser(isTestUser), dynamoLookupProvider.forUser(isTestUser))
         normalisedCode = redemptionCode.toUpperCase(Locale.UK)
-        form <- codeValidator.validate(redemptionCode, isTestUser).value.map(
+        form <- codeValidator.validate(redemptionCode).value.map(
           validationResult =>
             Ok(subscriptionRedemptionForm(
               title = title,
@@ -159,8 +155,8 @@ class RedemptionController(
     val processingPage: EitherT[Future, (String, Boolean), Result] = for {
       user <- identityService.getUser(request.user.minimalUser).leftMap((_, false))
       isTestUser = testUserFromRequest.fromIdUser(user)
-      codeValidator = new CodeValidator(zuoraLookupServiceProvider.forUser(isTestUser), dynamoLookup)
-      readerType <- codeValidator.validate(redemptionCode, isTestUser).leftMap((_, isTestUser))
+      codeValidator = new CodeValidator(zuoraLookupServiceProvider.forUser(isTestUser), dynamoLookupProvider.forUser(isTestUser))
+      readerType <- codeValidator.validate(redemptionCode).leftMap((_, isTestUser))
     } yield showProcessing(redemptionCode, readerType, user)
 
     processingPage.leftMap {
@@ -191,8 +187,8 @@ class RedemptionController(
 
   def validateCode(redemptionCode: RawRedemptionCode, isTestUser: Option[Boolean]): Action[AnyContent] = CachedAction().async {
     val testUser = isTestUser.getOrElse(false)
-    val codeValidator = new CodeValidator(zuoraLookupServiceProvider.forUser(testUser), dynamoLookup)
-    codeValidator.validate(redemptionCode, testUser).value.map {
+    val codeValidator = new CodeValidator(zuoraLookupServiceProvider.forUser(testUser), dynamoLookupProvider.forUser(testUser))
+    codeValidator.validate(redemptionCode).value.map {
       validationResult =>
       SafeLogger.info(s"Validating code ${redemptionCode}: ${validationResult}")
       Ok(RedemptionValidationResult(
@@ -237,10 +233,10 @@ class TestUserFromRequest(identityService: IdentityService, testUsers: TestUserS
 
 }
 
-class CodeValidator(zuoraLookupService: ZuoraGiftLookupService, dynamoLookup: DynamoTableAsyncForUser) {
+class CodeValidator(zuoraLookupService: ZuoraGiftLookupService, dynamoLookup: DynamoTableAsync) {
 
-  def validate(inputCode: String, isTestUser: Boolean)(implicit ec: ExecutionContext): EitherT[Future, String, ReaderType] =
-    EitherT(getValidationResult(inputCode, isTestUser).map {
+  def validate(inputCode: String)(implicit ec: ExecutionContext): EitherT[Future, String, ReaderType] =
+    EitherT(getValidationResult(inputCode).map {
       case ValidCorporateCode(_) => Right(Corporate)
       case ValidGiftCode(_) => Right(Gift)
       case CodeAlreadyUsed => Left("This code has already been redeemed")
@@ -248,8 +244,8 @@ class CodeValidator(zuoraLookupService: ZuoraGiftLookupService, dynamoLookup: Dy
       case _: InvalidCode | CodeNotFound | CodeRedeemedInThisRequest => Left("Please check the code and try again")
     })
 
-  private def getValidationResult(inputCode: String, isTestUser: Boolean)(implicit ec: ExecutionContext): Future[CodeStatus] = {
-    val corporateValidator = CorporateCodeValidator.withDynamoLookup(dynamoLookup(isTestUser))
+  private def getValidationResult(inputCode: String)(implicit ec: ExecutionContext): Future[CodeStatus] = {
+    val corporateValidator = CorporateCodeValidator.withDynamoLookup(dynamoLookup)
     val giftValidator = new GiftCodeValidator(zuoraLookupService)
 
     RedemptionCode(inputCode)

--- a/support-frontend/app/views/subscriptionRedemptionForm.scala.html
+++ b/support-frontend/app/views/subscriptionRedemptionForm.scala.html
@@ -10,6 +10,7 @@
 @import io.circe.Json
 @import views.JsStringLiteral
 @import com.gu.support.zuora.api.ReaderType
+@import com.gu.support.redemptions.RedemptionCode
 @(
   title: String,
   mainElement: ReactDiv,
@@ -40,6 +41,7 @@
         email: @JsStringLiteral.fromOption(user.map(_.primaryEmailAddress)),
       };
       window.guardian.isTestUser = @isTestUser;
+      window.guardian.codeLength = @{RedemptionCode.length};
   </script>
 
   }

--- a/support-frontend/app/wiring/Controllers.scala
+++ b/support-frontend/app/wiring/Controllers.scala
@@ -78,7 +78,7 @@ trait Controllers {
     controllerComponents,
     fontLoader,
     authAction,
-    dynamoTableAsync,
+    dynamoTableAsyncProvider,
     zuoraGiftLookupServiceProvider
   )
 

--- a/support-frontend/app/wiring/Services.scala
+++ b/support-frontend/app/wiring/Services.scala
@@ -8,9 +8,8 @@ import com.gu.support.config.TouchPointEnvironments
 import com.gu.support.getaddressio.GetAddressIOService
 import com.gu.support.pricing.PriceSummaryServiceProvider
 import com.gu.support.promotions.PromotionServiceProvider
-import com.gu.support.redemption.corporate.RedemptionTable
+import com.gu.support.redemption.corporate.{DynamoTableAsyncProvider, RedemptionTable}
 import com.gu.zuora.ZuoraGiftLookupServiceProvider
-import controllers.DynamoTableAsyncForUser
 import play.api.BuiltInComponentsFromContext
 import play.api.libs.ws.ahc.AhcWSComponents
 import services._
@@ -60,7 +59,7 @@ trait Services {
 
   lazy val promotionServiceProvider = new PromotionServiceProvider(appConfig.promotionsConfigProvider)
 
-  val dynamoTableAsync: DynamoTableAsyncForUser = { isTestUser =>
+  val dynamoTableAsyncProvider: DynamoTableAsyncProvider = { isTestUser =>
     RedemptionTable.forEnvAsync(TouchPointEnvironments.fromStage(appConfig.stage, isTestUser))
   }
 

--- a/support-frontend/assets/pages/subscriptions-redemption/api.js
+++ b/support-frontend/assets/pages/subscriptions-redemption/api.js
@@ -42,7 +42,7 @@ function dispatchReaderType(dispatch: Dispatch<Action>, readerType: Option<Reade
   dispatch({ type: 'SET_READER_TYPE', readerType });
 }
 
-function doValidation(userCode: string, dispatch: Dispatch<Action>) {
+function validateWithServer(userCode: string, dispatch: Dispatch<Action>) {
   validate(userCode).then((result: ValidationResult) => {
     dispatchError(dispatch, result.errorMessage);
     dispatchReaderType(dispatch, result.readerType);
@@ -53,7 +53,11 @@ function doValidation(userCode: string, dispatch: Dispatch<Action>) {
 
 function validateUserCode(userCode: string, dispatch: Dispatch<Action>) {
   dispatch({ type: 'SET_USER_CODE', userCode });
-  doValidation(userCode, dispatch);
+  if (userCode.length === 13) {
+    validateWithServer(userCode, dispatch);
+  } else {
+    dispatchError(dispatch, 'Please check the code and try again');
+  }
 }
 
 function submitCode(userCode: string, dispatch: Dispatch<Action>) {

--- a/support-frontend/assets/pages/subscriptions-redemption/api.js
+++ b/support-frontend/assets/pages/subscriptions-redemption/api.js
@@ -53,7 +53,8 @@ function validateWithServer(userCode: string, dispatch: Dispatch<Action>) {
 
 function validateUserCode(userCode: string, dispatch: Dispatch<Action>) {
   dispatch({ type: 'SET_USER_CODE', userCode });
-  if (userCode.length === 13) {
+  const codeLength = getGlobal('codeLength') || 13;
+  if (userCode.length === codeLength) {
     validateWithServer(userCode, dispatch);
   } else {
     dispatchError(dispatch, 'Please check the code and try again');

--- a/support-models/src/main/scala/com/gu/support/redemptions/RedemptionCode.scala
+++ b/support-models/src/main/scala/com/gu/support/redemptions/RedemptionCode.scala
@@ -13,7 +13,7 @@ object RedemptionCode {
     // make sure no one can inject anything bad
     val validChars = List('A' -> 'Z', '0' -> '9', '-' -> '-')
     val validCharsSet = validChars.flatMap { case (from, to) => (from to to) }.toSet
-    if (upper.length == length && upper.forall(validCharsSet.contains))
+    if (upper.forall(validCharsSet.contains))
       Right(new RedemptionCode(upper))
     else
       Left(s"redemption code must only include A-Z, 0-9 and '-'")

--- a/support-models/src/main/scala/com/gu/support/redemptions/RedemptionCode.scala
+++ b/support-models/src/main/scala/com/gu/support/redemptions/RedemptionCode.scala
@@ -6,12 +6,14 @@ import com.gu.support.encoding.Codec
 import io.circe.{Decoder, Encoder}
 
 object RedemptionCode {
+  val length = 13
+
   def apply(value: String): Either[String, RedemptionCode] = {
     val upper = value.toUpperCase(Locale.UK)
     // make sure no one can inject anything bad
     val validChars = List('A' -> 'Z', '0' -> '9', '-' -> '-')
     val validCharsSet = validChars.flatMap { case (from, to) => (from to to) }.toSet
-    if (upper.forall(validCharsSet.contains))
+    if (upper.length == length && upper.forall(validCharsSet.contains))
       Right(new RedemptionCode(upper))
     else
       Left(s"redemption code must only include A-Z, 0-9 and '-'")

--- a/support-services/src/main/scala/com/gu/support/redemption/corporate/DynamoTableAsync.scala
+++ b/support-services/src/main/scala/com/gu/support/redemption/corporate/DynamoTableAsync.scala
@@ -97,3 +97,7 @@ class DynamoTableAsync(
     eventualUpdateItemResponse.map(_ => ())
   }
 }
+
+trait DynamoTableAsyncProvider {
+  def forUser(isTestUser: Boolean): DynamoTableAsync
+}


### PR DESCRIPTION
## Why are you doing this?

Some small tidy up stuff following on from #2693 

## Changes

* Only validate redemption codes with the server when they are of the correct length - this is because we are now validating with Zuora which can be slow and has a rate limit so we don't want to do this any more than we have to. NB. This means that we will now need to ensure that corporate codes are the same length or change this code to take account of the difference.
* Rework the way that dynamo table lookups are managed for test/non-test users to be consistent with the 'ServiceProvider' pattern used for other services.


[**Trello Card**](https://trello.com/c/Eh9zlzCT/3321-giftee-redemption-flow-working-for-gifting)
