### PR TITLE
make thank you email it test run in the hourly test run

### DIFF
--- a/support-workers/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
@@ -25,7 +25,7 @@ import io.circe.generic.auto._
 import io.circe.parser._
 import org.joda.time.{DateTime, LocalDate}
 
-class SendThankYouEmailIT extends AsyncLambdaSpec with MockContext {
+class SendThankYouEmailITSpec extends AsyncLambdaSpec with MockContext {
 
   "SendThankYouEmail lambda" should "add message to sqs queue" taggedAs IntegrationTest in {
     val sendThankYouEmail = new SendThankYouEmail()


### PR DESCRIPTION
## Why are you doing this?

The SendThankYouEmailIT was failing but somehow wasn't picked up by the automated IT test runs.

Turned out it was because the runner requires all the test names to end in "Spec" https://github.com/guardian/support-frontend/blob/596a3ed349ed085dcfd13ded6b44a768fd128f41/support-lambdas/it-test-runner/src/main/scala/com/gu/RunITTests.scala#L47

I have renamed the test to suit.

there are 204 that run in the automated run (now 205).  When I run support-workers it:test locally it runs 291 tests.  So we might need to check this a bit more generally.
