### PR TITLE
allow new email ittest to access sqs queue

### DIFF
--- a/support-lambdas/it-test-runner/cfn.yaml
+++ b/support-lambdas/it-test-runner/cfn.yaml
@@ -77,6 +77,12 @@ Resources:
                 - dynamodb:GetItem
                 - dynamodb:UpdateItem
               Resource: arn:aws:dynamodb:*:*:table/redemption-codes-DEV
+        - Statement:
+            - Effect: Allow
+              Action:
+                - sqs:SendMessage
+                - sqs:GetQueueUrl
+              Resource: arn:aws:sqs:*:*:contributions-thanks-dev
 
   LambdaLogGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
## Why are you doing this?

Having added an IT test that wasn't actually running https://github.com/guardian/support-frontend/pull/2737 , it was failing because it relies on writing to an SQS queue.

This PR adds the relevant permission.

tested in "PROD" with the result: `after: succeeded 208, failed 0, canceled 0, ignored 4, pending 0`
