### PR TITLE
Hide name if it's too long

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/new-flow/ContributionThankYouHeader.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/new-flow/ContributionThankYouHeader.jsx
@@ -42,31 +42,38 @@ type ContributionThankYouHeaderProps = {|
   showDirectDebitMessage: boolean
 |};
 
+const MAX_DISPLAY_NAME_LENGTH = 10;
+
 const ContributionThankYouHeader = ({
   name,
   showDirectDebitMessage,
-}: ContributionThankYouHeaderProps) => (
-  <header css={header}>
-    <h1 css={headerTitleText}>
-      Thank you {name} for your valuable contribution
-    </h1>
-    <p css={headerSupportingText}>
-      {showDirectDebitMessage && (
-        <>
-          <span css={directDebitSetupText}>
-            Your Direct Debit has been set up.{' '}
-          </span>
-          Look out for an email within three business days confirming your
-          recurring payment. This will appear as &apos;Guardian Media
-          Group&apos; on your bank statements.
-          <br />
-          <br />
-        </>
-      )}
-      To support us further, and enhance your experience with the Guardian,
-      select the add-ons that suit you best.
-    </p>
-  </header>
-);
+}: ContributionThankYouHeaderProps) => {
+  const shouldShowName = name.length < MAX_DISPLAY_NAME_LENGTH;
+  return (
+    <header css={header}>
+      <h1 css={headerTitleText}>
+        {shouldShowName
+          ? `Thank you ${name} for your valuable contribution`
+          : 'Thank you for your valuable contribution'}
+      </h1>
+      <p css={headerSupportingText}>
+        {showDirectDebitMessage && (
+          <>
+            <span css={directDebitSetupText}>
+              Your Direct Debit has been set up.{' '}
+            </span>
+            Look out for an email within three business days confirming your
+            recurring payment. This will appear as &apos;Guardian Media
+            Group&apos; on your bank statements.
+            <br />
+            <br />
+          </>
+        )}
+        To support us further, and enhance your experience with the Guardian,
+        select the add-ons that suit you best.
+      </p>
+    </header>
+  );
+};
 
 export default ContributionThankYouHeader;


### PR DESCRIPTION
## Why are you doing this?

Hide a users name on the thank you page if it's too long (more than 10 characters).

