### PR TITLE
make debugInfo all one message, add placeholders

### DIFF
--- a/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
+++ b/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
@@ -63,7 +63,7 @@ case class CreateSupportWorkersRequest(
   email: String,
   telephoneNumber: Option[String],
   deliveryInstructions: Option[String],
-  debugInfo: Option[String] = None
+  debugInfo: Option[String]
 )
 
 object SupportWorkersClient {
@@ -133,6 +133,8 @@ class SupportWorkersClient(
             giftRecipient.message
           )
         }
+      case _ =>
+        Left(s"gifting is not supported for $product")
     }
 
   def createSubscription(

--- a/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
+++ b/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
@@ -121,7 +121,7 @@ export type RegularPaymentRequest = {|
   telephoneNumber: Option<string>,
   promoCode?: Option<string>,
   deliveryInstructions?: Option<string>,
-  debugInfo?: string,
+  debugInfo: string,
 |};
 
 export type StripePaymentIntentAuthorisation = {|

--- a/support-frontend/assets/helpers/subscriptionsForms/formReducer.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/formReducer.js
@@ -65,7 +65,7 @@ function createFormReducer(
 
   return (originalState: FormState = initialState, action: Action): FormState => {
 
-    const state = { ...originalState, debugInfo: `${originalState.debugInfo}${JSON.stringify(action)}\n` };
+    const state = { ...originalState, debugInfo: `${originalState.debugInfo} ${JSON.stringify(action)}\n` };
 
     switch (action.type) {
 

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -453,6 +453,7 @@ function regularPaymentRequestFromAuthorisation(
     referrerAcquisitionData: state.common.referrerAcquisitionData,
     supportAbTests: getSupportAbTests(state.common.abParticipations),
     telephoneNumber: null,
+    debugInfo: 'contributions does not collect redux state',
   };
 }
 

--- a/support-frontend/assets/pages/subscriptions-redemption/api.js
+++ b/support-frontend/assets/pages/subscriptions-redemption/api.js
@@ -117,6 +117,7 @@ function buildRegularPaymentRequest(
     ophanIds: getOphanIds(),
     referrerAcquisitionData: getReferrerAcquisitionData(),
     supportAbTests: getSupportAbTests(participations),
+    debugInfo: 'no form/redux for corporate subs',
   };
 }
 

--- a/support-frontend/test/utils/CheckoutValidationRulesTest.scala
+++ b/support-frontend/test/utils/CheckoutValidationRulesTest.scala
@@ -237,7 +237,8 @@ object TestData {
     ),
     deliveryAddress = None,
     giftRecipient = None,
-    deliveryInstructions = None
+    deliveryInstructions = None,
+    debugInfo = None
   )
 
   val someDateNextMonth = new LocalDate().plusMonths(1)
@@ -265,7 +266,8 @@ object TestData {
     billingAddress = paperAddress,
     deliveryAddress = Some(paperAddress),
     giftRecipient = None,
-    deliveryInstructions = None
+    deliveryInstructions = None,
+    debugInfo = None
   )
 
 }


### PR DESCRIPTION
## Why are you doing this?

At the moment the debugInfo goes into the logs as one line for each state change.  This makes it hard to find and hard to copy/paste.  E.G.

![image](https://user-images.githubusercontent.com/7304387/94927251-e9a07500-04b9-11eb-9779-f4f5b7b1fefa.png)

This PR makes it come in as one log message by indenting the first character on each line
see 
https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AgentReference.html#agent-configuration-file:~:text=so%20any%20line%20that%20begins%20with,and%20starts%20a%20new%20log%20message.

![image](https://user-images.githubusercontent.com/7304387/94927422-24a2a880-04ba-11eb-8f41-089757dd838f.png)


Also I added placeholder messages for corporate redemption and subscriptions so that we positively know what it is when looking at the logs.

Tested locally Digi sub, plus annual contribution.