### PR TITLE
add gift delivery date from client side to email

### DIFF
--- a/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
+++ b/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
@@ -43,7 +43,7 @@ object CreateSupportWorkersRequest {
     lastName: String,
     email: Option[String],
     message: Option[String],
-    deliveryDate: Option[LocalDate],
+    deliveryDate: Option[LocalDate]
   )
 }
 

--- a/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
+++ b/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
@@ -42,7 +42,8 @@ object CreateSupportWorkersRequest {
     firstName: String,
     lastName: String,
     email: Option[String],
-    message: Option[String]
+    message: Option[String],
+    deliveryDate: Option[LocalDate],
   )
 }
 
@@ -125,14 +126,16 @@ class SupportWorkersClient(
           )
         )
       case _: DigitalPack =>
-        giftRecipient.email.toRight("email address is required for DS gifts").map { email =>
-          GiftRecipient.DigitalSubGiftRecipient(
-            giftRecipient.firstName,
-            giftRecipient.lastName,
-            email,
-            giftRecipient.message
-          )
-        }
+        for {
+          email <- giftRecipient.email.toRight("email address is required for DS gifts")
+          deliveryDate <- giftRecipient.deliveryDate.toRight("delivery date is required for DS gifts")
+        } yield GiftRecipient.DigitalSubGiftRecipient(
+          giftRecipient.firstName,
+          giftRecipient.lastName,
+          email,
+          giftRecipient.message,
+          deliveryDate
+        )
       case _ =>
         Left(s"gifting is not supported for $product")
     }

--- a/support-frontend/app/utils/CheckoutValidationRules.scala
+++ b/support-frontend/app/utils/CheckoutValidationRules.scala
@@ -114,7 +114,7 @@ object DigitalPackValidation {
 
     (paymentFields, d.readerType, createSupportWorkersRequest.giftRecipient) match {
       case (Purchase(paymentFields), ReaderType.Direct, None) => isValidPaidSub(paymentFields)
-      case (Purchase(paymentFields), ReaderType.Gift, Some(GiftRecipientRequest(_, _, _, Some(_), _))) =>
+      case (Purchase(paymentFields), ReaderType.Gift, Some(GiftRecipientRequest(_, _, _, Some(_), _, _))) =>
         isValidPaidSub(paymentFields)
       case (_: Redemption[_, _], ReaderType.Corporate, None) => isValidRedemption
       case (_: Redemption[_, _], ReaderType.Gift, None) => isValidRedemption

--- a/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
+++ b/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
@@ -101,6 +101,7 @@ type GiftRecipientType = {|
   lastName: string,
   email?: Option<string>,
   // message: Option<string>,
+  // deliveryDate: Option<string>,
 |};
 
 // The model that is sent to support-workers

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.js
@@ -140,6 +140,7 @@ function buildRegularPaymentRequest(
       lastName: lastNameGiftRecipient,
       email: emailGiftRecipient,
       // message: giftMessage,
+      // deliveryDate: giftDeliveryDate,
     },
   } : {};
 

--- a/support-frontend/test/utils/CheckoutValidationRulesTest.scala
+++ b/support-frontend/test/utils/CheckoutValidationRulesTest.scala
@@ -151,7 +151,7 @@ class DigitalPackValidationTest extends AnyFlatSpec with Matchers {
   it should "succeed when there is a valid gift sub purchase" in {
     val giftPurchase = validDigitalPackRequest.copy(
       product = DigitalPack(USD, Monthly, Gift),
-      giftRecipient = Some(GiftRecipientRequest(None, "bob", "builder", Some("bob@gu.com"), Some("have a nice sub")))
+      giftRecipient = Some(GiftRecipientRequest(None, "bob", "builder", Some("bob@gu.com"), Some("have a nice sub"), Some(new LocalDate(2020, 10, 2))))
     )
 
     DigitalPackValidation.passes(giftPurchase.product.asInstanceOf[DigitalPack])(giftPurchase) shouldBe true

--- a/support-models/src/main/scala/com/gu/support/workers/GiftRecipient.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/GiftRecipient.scala
@@ -7,6 +7,7 @@ import com.gu.support.workers.GiftRecipient.{DigitalSubGiftRecipient, WeeklyGift
 import io.circe._
 import io.circe.generic.semiauto._
 import io.circe.syntax._
+import org.joda.time.LocalDate
 
 sealed trait GiftRecipient {
   val firstName: String
@@ -28,6 +29,7 @@ object GiftRecipient {
     lastName: String,
     email: String,
     message: Option[String],
+    deliveryDate: LocalDate,
   ) extends GiftRecipient
 
   val circeDiscriminator = new CirceDiscriminator("giftRecipientType")

--- a/support-models/src/test/scala/com/gu/support/workers/GiftRecipientSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/workers/GiftRecipientSpec.scala
@@ -5,6 +5,7 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import io.circe.syntax._
 import io.circe.parser._
+import org.joda.time.LocalDate
 
 class GiftRecipientSpec extends AnyFlatSpec with Matchers {
 
@@ -15,11 +16,12 @@ class GiftRecipientSpec extends AnyFlatSpec with Matchers {
         |  "giftRecipientType": "DigiSub",
         |  "firstName": "bob",
         |  "lastName": "builder",
-        |  "email": "bob@gu.com"
+        |  "email": "bob@gu.com",
+        |  "deliveryDate": "2020-10-02"
         |}
         |""".stripMargin
     val actual = decode[GiftRecipient](json)
-    actual should be(Right(GiftRecipient.DigitalSubGiftRecipient("bob", "builder", "bob@gu.com", None)))
+    actual should be(Right(GiftRecipient.DigitalSubGiftRecipient("bob", "builder", "bob@gu.com", None, new LocalDate(2020, 10, 2))))
   }
 
   it should "deserialise weekly ok" in {
@@ -50,7 +52,7 @@ class GiftRecipientSpec extends AnyFlatSpec with Matchers {
   }
 
   it should "serialise DS" in {
-    val data = GiftRecipient.DigitalSubGiftRecipient("bob", "builder", "bob@gu.com", Some("message"))
+    val data = GiftRecipient.DigitalSubGiftRecipient("bob", "builder", "bob@gu.com", Some("message"), new LocalDate(2020, 10, 2))
     val expected =
       """
         |{
@@ -58,7 +60,8 @@ class GiftRecipientSpec extends AnyFlatSpec with Matchers {
         |  "firstName": "bob",
         |  "lastName": "builder",
         |  "email": "bob@gu.com",
-        |  "message": "message"
+        |  "message": "message",
+        |  "deliveryDate" : "2020-10-02"
         |}
         |""".stripMargin
     data.asJson should be(parse(expected).right.get)

--- a/support-workers/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
@@ -138,7 +138,7 @@ class DigitalPackEmailFields(
         for {
           giftRecipient <- maybeGiftRecipient.toRight("Gift redemption must have a gift recipient")
           emails <- List(
-            giftPurchaserConfirmation(paymentInfo.paymentMethod),
+            giftPurchaserConfirmation(paymentInfo.paymentMethod, giftRecipient),
             giftRecipientNotification(giftRecipient)
           ).sequence
         } yield emails
@@ -160,7 +160,7 @@ class DigitalPackEmailFields(
       gift_code = "gift_code"
     ))
 
-  private def giftPurchaserConfirmation(pm: PaymentMethod) =
+  private def giftPurchaserConfirmation(pm: PaymentMethod, giftRecipient: GiftRecipient.DigitalSubGiftRecipient) =
     wrap("digipack-gift-purchase", GifterPurchaseAttributes(
       gifter_first_name = user.firstName,
       gifter_last_name = user.lastName,
@@ -169,7 +169,7 @@ class DigitalPackEmailFields(
       gift_recipient_email = "gift recipient email placeholder",
       gift_personal_message = "gift personal message placeholder",
       gift_code = "gift code placeholder",
-      gift_delivery_date = "gift delivery date placeholder",
+      gift_delivery_date = formatDate(giftRecipient.deliveryDate),
       subscription_details = "subscription details placeholder",
       date_of_first_payment = "date_of_first_payment",
       paymentAttributes = paymentFields(pm, directDebitMandateId)

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
@@ -165,7 +165,7 @@ object SendDigitalPackGiftPurchaseEmails extends App {
       PaymentSchedule(List(Payment(new LocalDate(2019, 1, 14), 119.90)))
     )),
     ReaderType.Gift,
-    Some(GiftRecipient.DigitalSubGiftRecipient("first", "last", addressToSendTo, Some("gift message")))
+    Some(GiftRecipient.DigitalSubGiftRecipient("first", "last", addressToSendTo, Some("gift message"), new LocalDate(2020, 10, 2)))
   ))
 
 }


### PR DESCRIPTION
## Why are you doing this?

This PR adds the gift delivery date field all the way from the client side (as a placeholder) through to the email send.

[**Trello Card**](https://trello.com/c/RvP8A1nw/3192-gifting-email-api-triggers-for-the-gifter-giftee-emails-generated)
