### PR TITLE
Make corporate redemption codes lower case 

### DIFF
--- a/support-frontend/app/controllers/RedemptionController.scala
+++ b/support-frontend/app/controllers/RedemptionController.scala
@@ -66,7 +66,7 @@ class RedemptionController(
       for {
         isTestUser <- testUserFromRequest.isTestUser(request)
         codeValidator = new CodeValidator(zuoraLookupServiceProvider.forUser(isTestUser), dynamoTableProvider.forUser(isTestUser))
-        normalisedCode = redemptionCode.toUpperCase(Locale.UK)
+        normalisedCode = redemptionCode.toLowerCase(Locale.UK)
         form <- codeValidator.validate(redemptionCode).value.map(
           validationResult =>
             Ok(subscriptionRedemptionForm(

--- a/support-frontend/test/utils/CheckoutValidationRulesTest.scala
+++ b/support-frontend/test/utils/CheckoutValidationRulesTest.scala
@@ -141,7 +141,7 @@ class DigitalPackValidationTest extends AnyFlatSpec with Matchers {
   it should "succeed when there is a valid corporate sub" ignore {
     val corporateSub = validDigitalPackRequest.copy(
       product = DigitalPack(GBP, Monthly, Corporate),
-      paymentFields = Right(RedemptionData(RedemptionCode("test-code").right.get))
+      paymentFields = Right(RedemptionData(RedemptionCode("test-code-123").right.get))
     )
 
     DigitalPackValidation.passes(corporateSub) shouldBe true
@@ -187,7 +187,7 @@ class PaperValidationTest extends AnyFlatSpec with Matchers {
   }
 
   it should "not allow corporate redemptions for paper products" in {
-    val requestWithCorporateRedemption = validPaperRequest.copy(paymentFields = Right(RedemptionData(RedemptionCode("TEST-CODE").right.get)))
+    val requestWithCorporateRedemption = validPaperRequest.copy(paymentFields = Right(RedemptionData(RedemptionCode("test-code-123").right.get)))
     PaperValidation.passes(requestWithCorporateRedemption) shouldBe false
   }
 

--- a/support-models/src/main/scala/com/gu/support/config/Stages.scala
+++ b/support-models/src/main/scala/com/gu/support/config/Stages.scala
@@ -18,7 +18,7 @@ object Stages {
 object Stage {
   def fromString(s: String): Option[Stage] = condOpt(s) {
     case "DEV" => DEV
-    case "code" => CODE
+    case "CODE" => CODE
     case "PROD" => PROD
   }
 }

--- a/support-models/src/main/scala/com/gu/support/config/Stages.scala
+++ b/support-models/src/main/scala/com/gu/support/config/Stages.scala
@@ -18,7 +18,7 @@ object Stages {
 object Stage {
   def fromString(s: String): Option[Stage] = condOpt(s) {
     case "DEV" => DEV
-    case "CODE" => CODE
+    case "code" => CODE
     case "PROD" => PROD
   }
 }

--- a/support-models/src/main/scala/com/gu/support/redemptions/RedemptionCode.scala
+++ b/support-models/src/main/scala/com/gu/support/redemptions/RedemptionCode.scala
@@ -9,14 +9,14 @@ object RedemptionCode {
   val length = 13
 
   def apply(value: String): Either[String, RedemptionCode] = {
-    val upper = value.toUpperCase(Locale.UK)
+    val lower = value.toLowerCase(Locale.UK)
     // make sure no one can inject anything bad
-    val validChars = List('A' -> 'Z', '0' -> '9', '-' -> '-')
+    val validChars = List('a' -> 'z', '0' -> '9', '-' -> '-')
     val validCharsSet = validChars.flatMap { case (from, to) => (from to to) }.toSet
-    if (upper.forall(validCharsSet.contains))
-      Right(new RedemptionCode(upper))
+    if (lower.forall(validCharsSet.contains))
+      Right(new RedemptionCode(lower))
     else
-      Left(s"redemption code must only include A-Z, 0-9 and '-'")
+      Left(s"redemption code must only include a-z, 0-9 and '-'")
   }
 
   implicit val encoder: Encoder[RedemptionCode] = Encoder.encodeString.contramap(_.value)

--- a/support-models/src/main/scala/com/gu/support/redemptions/RedemptionCode.scala
+++ b/support-models/src/main/scala/com/gu/support/redemptions/RedemptionCode.scala
@@ -7,16 +7,17 @@ import io.circe.{Decoder, Encoder}
 
 object RedemptionCode {
   val length = 13
+  // make sure no one can inject anything bad
+  val validChars = List('a' -> 'z', '0' -> '9', '-' -> '-')
+  val validCharsSet = validChars.flatMap { case (from, to) => (from to to) }.toSet
 
   def apply(value: String): Either[String, RedemptionCode] = {
     val lower = value.toLowerCase(Locale.UK)
-    // make sure no one can inject anything bad
-    val validChars = List('a' -> 'z', '0' -> '9', '-' -> '-')
-    val validCharsSet = validChars.flatMap { case (from, to) => (from to to) }.toSet
-    if (lower.forall(validCharsSet.contains))
+
+    if (lower.length == length && lower.forall(validCharsSet.contains))
       Right(new RedemptionCode(lower))
     else
-      Left(s"redemption code must only include a-z, 0-9 and '-'")
+      Left(s"redemption code must be ${length} characters and only include a-z, 0-9 and '-'")
   }
 
   implicit val encoder: Encoder[RedemptionCode] = Encoder.encodeString.contramap(_.value)

--- a/support-models/src/test/scala/com/gu/support/redemptions/RedemptionCodeSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/redemptions/RedemptionCodeSpec.scala
@@ -5,17 +5,19 @@ import org.scalatest.matchers.should.Matchers
 
 class RedemptionCodeSpec extends AnyFlatSpec with Matchers {
 
+  val codePrefix = "code-123456-"
+
   "RedemptionCode" should "disallow invalid chars" in {
     val badCodes = """ !"#$%&'()*+,./:;<=>?@[\]^_`{|}~"""
     badCodes.foreach { char =>
-      RedemptionCode(s"code-123456-$char").isLeft should be(true)
+      RedemptionCode(s"$codePrefix$char").isLeft should be(true)
     }
   }
 
   it should "allow valid chars" in {
     val codes = """-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"""
     codes.foreach { char =>
-      RedemptionCode(s"code-123456-$char").isRight should be(true)
+      RedemptionCode(s"$codePrefix$char").isRight should be(true)
     }
   }
 

--- a/support-models/src/test/scala/com/gu/support/redemptions/RedemptionCodeSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/redemptions/RedemptionCodeSpec.scala
@@ -8,14 +8,14 @@ class RedemptionCodeSpec extends AnyFlatSpec with Matchers {
   "RedemptionCode" should "disallow invalid chars" in {
     val badCodes = """ !"#$%&'()*+,./:;<=>?@[\]^_`{|}~"""
     badCodes.foreach { char =>
-      RedemptionCode(s"CODE$char").isLeft should be(true)
+      RedemptionCode(s"code-123456-$char").isLeft should be(true)
     }
   }
 
   it should "allow valid chars" in {
     val codes = """-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"""
     codes.foreach { char =>
-      RedemptionCode(s"CODE$char").isRight should be(true)
+      RedemptionCode(s"code-123456-$char").isRight should be(true)
     }
   }
 

--- a/support-models/src/test/scala/com/gu/support/workers/Fixtures.scala
+++ b/support-models/src/test/scala/com/gu/support/workers/Fixtures.scala
@@ -288,7 +288,7 @@ object Fixtures {
             $userJson,
             "product": $digitalPackJson,
             "paymentProvider": "PayPal",
-            "paymentMethod": {"redemptionCode": "fakecode"},
+            "paymentMethod": {"redemptionCode": "fake-code-123"},
             "salesForceContact": $salesforceContactJson,
             "salesforceContacts": $salesforceContactsJson
             }

--- a/support-models/src/test/scala/com/gu/support/workers/Fixtures.scala
+++ b/support-models/src/test/scala/com/gu/support/workers/Fixtures.scala
@@ -288,7 +288,7 @@ object Fixtures {
             $userJson,
             "product": $digitalPackJson,
             "paymentProvider": "PayPal",
-            "paymentMethod": {"redemptionCode": "FAKECODE"},
+            "paymentMethod": {"redemptionCode": "fakecode"},
             "salesForceContact": $salesforceContactJson,
             "salesforceContacts": $salesforceContactsJson
             }

--- a/support-models/src/test/scala/com/gu/support/workers/SerialisationSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/workers/SerialisationSpec.scala
@@ -46,7 +46,7 @@ class SerialisationSpec extends AnyFlatSpec with SerialisationTestHelpers with L
     testDecoding[CreateZuoraSubscriptionState](createContributionZuoraSubscriptionJson(Annual))
     testDecoding[CreateZuoraSubscriptionState](createDigiPackZuoraSubscriptionJson)
     testDecoding[CreateZuoraSubscriptionState](createCorporateDigiPackZuoraSubscriptionJson,
-      state => state.paymentMethod.right.value.redemptionCode.value shouldBe "fakecode"
+      state => state.paymentMethod.right.value.redemptionCode.value shouldBe "fake-code-123"
     )
   }
 

--- a/support-models/src/test/scala/com/gu/support/workers/SerialisationSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/workers/SerialisationSpec.scala
@@ -46,7 +46,7 @@ class SerialisationSpec extends AnyFlatSpec with SerialisationTestHelpers with L
     testDecoding[CreateZuoraSubscriptionState](createContributionZuoraSubscriptionJson(Annual))
     testDecoding[CreateZuoraSubscriptionState](createDigiPackZuoraSubscriptionJson)
     testDecoding[CreateZuoraSubscriptionState](createCorporateDigiPackZuoraSubscriptionJson,
-      state => state.paymentMethod.right.value.redemptionCode.value shouldBe "FAKECODE"
+      state => state.paymentMethod.right.value.redemptionCode.value shouldBe "fakecode"
     )
   }
 

--- a/support-services/src/test/scala/com/gu/support/redemption/corporate/CorporateCodeValidatorITSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/redemption/corporate/CorporateCodeValidatorITSpec.scala
@@ -15,19 +15,19 @@ class CorporateCodeValidatorITSpec extends AsyncFlatSpec with Matchers {
     CorporateCodeValidator.withDynamoLookup(RedemptionTable.forEnvAsync(TouchPointEnvironments.SANDBOX))
 
   "codeValidator" should "handle an available code" in {
-    codeValidator.getStatus(RedemptionCode("ITTEST-AVAILABLE").right.get).map {
+    codeValidator.getStatus(RedemptionCode("it-available1").right.get).map {
       _ should be(ValidCorporateCode(CorporateId("1")))
     }
   }
 
   it should "handle an NOT available code" in {
-    codeValidator.getStatus(RedemptionCode("ITTEST-USED").right.get).map {
+    codeValidator.getStatus(RedemptionCode("it-test-used1").right.get).map {
       _ should be(CodeAlreadyUsed)
     }
   }
 
   it should "handle an NOT valid code" in {
-    codeValidator.getStatus(RedemptionCode("ITTEST-MISSING").right.get).map {
+    codeValidator.getStatus(RedemptionCode("it-missing123").right.get).map {
       _ should be(CodeNotFound)
     }
   }

--- a/support-services/src/test/scala/com/gu/support/redemption/corporate/CorporateCodeValidatorSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/redemption/corporate/CorporateCodeValidatorSpec.scala
@@ -13,91 +13,91 @@ class CorporateCodeValidatorSpec extends AsyncFlatSpec with Matchers {
 
   "codeValidator" should "handle an available code" in {
     val codeValidator = CorporateCodeValidator.withDynamoLookup {
-      case "code" => Future.successful(Some(Map(
+      case "test-code-123" => Future.successful(Some(Map(
         "available" -> DynamoBoolean(true),
         "corporateId" -> DynamoString("1")
       )))
     }
-    codeValidator.getStatus(RedemptionCode("code").right.get).map {
+    codeValidator.getStatus(RedemptionCode("test-code-123").right.get).map {
       _ should be(ValidCorporateCode(CorporateId("1")))
     }
   }
 
   it should "handle an NON available code" in {
     val codeValidator = CorporateCodeValidator.withDynamoLookup {
-      case "code" => Future.successful(Some(Map(
+      case "test-code-123" => Future.successful(Some(Map(
         "available" -> DynamoBoolean(false),
         "corporateId" -> DynamoString("1")
       )))
     }
-    codeValidator.getStatus(RedemptionCode("code").right.get).map {
+    codeValidator.getStatus(RedemptionCode("test-code-123").right.get).map {
       _ should be(CodeAlreadyUsed)
     }
   }
 
   it should "handle an NON EXISTENT code" in {
     val codeValidator = CorporateCodeValidator.withDynamoLookup {
-      case "code" => Future.successful(None)
+      case "test-code-123" => Future.successful(None)
     }
-    codeValidator.getStatus(RedemptionCode("code").right.get).map {
+    codeValidator.getStatus(RedemptionCode("test-code-123").right.get).map {
       _ should be(CodeNotFound)
     }
   }
 
   it should "handle an code with invalid available type " in {
     val codeValidator = CorporateCodeValidator.withDynamoLookup {
-      case "code" => Future.successful(Some(Map(
+      case "test-code-123" => Future.successful(Some(Map(
         "available" -> DynamoString("haha not a boolean"),
         "corporateId" -> DynamoString("1")
       )))
     }
     recoverToSucceededIf[RuntimeException] {
-      codeValidator.getStatus(RedemptionCode("code").right.get)
+      codeValidator.getStatus(RedemptionCode("test-code-123").right.get)
     }
   }
 
   it should "handle an code with invalid corporate id type " in {
     val codeValidator = CorporateCodeValidator.withDynamoLookup {
-      case "code" => Future.successful(Some(Map(
+      case "test-code-123" => Future.successful(Some(Map(
         "available" -> DynamoBoolean(true),
         "corporateId" -> DynamoBoolean(false)
       )))
     }
     recoverToSucceededIf[RuntimeException] {
-      codeValidator.getStatus(RedemptionCode("code").right.get)
+      codeValidator.getStatus(RedemptionCode("test-code-123").right.get)
     }
   }
 
   it should "handle a missing attribute code - available" in {
     val codeValidator = CorporateCodeValidator.withDynamoLookup {
-      case "code" => Future.successful(Some(Map(
+      case "test-code-123" => Future.successful(Some(Map(
         "asdfnqweoidnsdknfnakndaknskansdknasdaksnd" -> DynamoBoolean(true),
         "corporateId" -> DynamoString("1")
       )))
     }
     recoverToSucceededIf[RuntimeException] {
-      codeValidator.getStatus(RedemptionCode("code").right.get)
+      codeValidator.getStatus(RedemptionCode("test-code-123").right.get)
     }
   }
 
   it should "handle a missing attribute code - corporate id" in {
     val codeValidator = CorporateCodeValidator.withDynamoLookup {
-      case "code" => Future.successful(Some(Map(
+      case "test-code-123" => Future.successful(Some(Map(
         "asdfnqweoidnsdknfnakndaknskansdknasdaksnd" -> DynamoString("1"),
         "available" -> DynamoBoolean(true)
       )))
     }
     recoverToSucceededIf[RuntimeException] {
-      codeValidator.getStatus(RedemptionCode("code").right.get)
+      codeValidator.getStatus(RedemptionCode("test-code-123").right.get)
     }
   }
 
   it should "be sure to fail if there is an overall dynamo failure" in {
     val codeValidator = CorporateCodeValidator.withDynamoLookup {
-      case "code" => Future.failed(new RuntimeException("test exception"))
+      case "test-code-123" => Future.failed(new RuntimeException("test exception"))
     }
     recoverToSucceededIf[RuntimeException] {
-      codeValidator.getStatus(RedemptionCode("code").right.get)
+      codeValidator.getStatus(RedemptionCode("test-code-123").right.get)
     }
   }
 

--- a/support-services/src/test/scala/com/gu/support/redemption/corporate/CorporateCodeValidatorSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/redemption/corporate/CorporateCodeValidatorSpec.scala
@@ -11,93 +11,95 @@ import scala.concurrent.Future
 
 class CorporateCodeValidatorSpec extends AsyncFlatSpec with Matchers {
 
+  val testCode = "test-code-123"
+
   "codeValidator" should "handle an available code" in {
     val codeValidator = CorporateCodeValidator.withDynamoLookup {
-      case "test-code-123" => Future.successful(Some(Map(
+      case `testCode` => Future.successful(Some(Map(
         "available" -> DynamoBoolean(true),
         "corporateId" -> DynamoString("1")
       )))
     }
-    codeValidator.getStatus(RedemptionCode("test-code-123").right.get).map {
+    codeValidator.getStatus(RedemptionCode(testCode).right.get).map {
       _ should be(ValidCorporateCode(CorporateId("1")))
     }
   }
 
   it should "handle an NON available code" in {
     val codeValidator = CorporateCodeValidator.withDynamoLookup {
-      case "test-code-123" => Future.successful(Some(Map(
+      case `testCode` => Future.successful(Some(Map(
         "available" -> DynamoBoolean(false),
         "corporateId" -> DynamoString("1")
       )))
     }
-    codeValidator.getStatus(RedemptionCode("test-code-123").right.get).map {
+    codeValidator.getStatus(RedemptionCode(testCode).right.get).map {
       _ should be(CodeAlreadyUsed)
     }
   }
 
   it should "handle an NON EXISTENT code" in {
     val codeValidator = CorporateCodeValidator.withDynamoLookup {
-      case "test-code-123" => Future.successful(None)
+      case `testCode` => Future.successful(None)
     }
-    codeValidator.getStatus(RedemptionCode("test-code-123").right.get).map {
+    codeValidator.getStatus(RedemptionCode(testCode).right.get).map {
       _ should be(CodeNotFound)
     }
   }
 
   it should "handle an code with invalid available type " in {
     val codeValidator = CorporateCodeValidator.withDynamoLookup {
-      case "test-code-123" => Future.successful(Some(Map(
+      case `testCode` => Future.successful(Some(Map(
         "available" -> DynamoString("haha not a boolean"),
         "corporateId" -> DynamoString("1")
       )))
     }
     recoverToSucceededIf[RuntimeException] {
-      codeValidator.getStatus(RedemptionCode("test-code-123").right.get)
+      codeValidator.getStatus(RedemptionCode(testCode).right.get)
     }
   }
 
   it should "handle an code with invalid corporate id type " in {
     val codeValidator = CorporateCodeValidator.withDynamoLookup {
-      case "test-code-123" => Future.successful(Some(Map(
+      case `testCode` => Future.successful(Some(Map(
         "available" -> DynamoBoolean(true),
         "corporateId" -> DynamoBoolean(false)
       )))
     }
     recoverToSucceededIf[RuntimeException] {
-      codeValidator.getStatus(RedemptionCode("test-code-123").right.get)
+      codeValidator.getStatus(RedemptionCode(testCode).right.get)
     }
   }
 
   it should "handle a missing attribute code - available" in {
     val codeValidator = CorporateCodeValidator.withDynamoLookup {
-      case "test-code-123" => Future.successful(Some(Map(
+      case `testCode` => Future.successful(Some(Map(
         "asdfnqweoidnsdknfnakndaknskansdknasdaksnd" -> DynamoBoolean(true),
         "corporateId" -> DynamoString("1")
       )))
     }
     recoverToSucceededIf[RuntimeException] {
-      codeValidator.getStatus(RedemptionCode("test-code-123").right.get)
+      codeValidator.getStatus(RedemptionCode(testCode).right.get)
     }
   }
 
   it should "handle a missing attribute code - corporate id" in {
     val codeValidator = CorporateCodeValidator.withDynamoLookup {
-      case "test-code-123" => Future.successful(Some(Map(
+      case `testCode` => Future.successful(Some(Map(
         "asdfnqweoidnsdknfnakndaknskansdknasdaksnd" -> DynamoString("1"),
         "available" -> DynamoBoolean(true)
       )))
     }
     recoverToSucceededIf[RuntimeException] {
-      codeValidator.getStatus(RedemptionCode("test-code-123").right.get)
+      codeValidator.getStatus(RedemptionCode(testCode).right.get)
     }
   }
 
   it should "be sure to fail if there is an overall dynamo failure" in {
     val codeValidator = CorporateCodeValidator.withDynamoLookup {
-      case "test-code-123" => Future.failed(new RuntimeException("test exception"))
+      case `testCode` => Future.failed(new RuntimeException("test exception"))
     }
     recoverToSucceededIf[RuntimeException] {
-      codeValidator.getStatus(RedemptionCode("test-code-123").right.get)
+      codeValidator.getStatus(RedemptionCode(testCode).right.get)
     }
   }
 

--- a/support-services/src/test/scala/com/gu/support/redemption/corporate/CorporateCodeValidatorSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/redemption/corporate/CorporateCodeValidatorSpec.scala
@@ -13,91 +13,91 @@ class CorporateCodeValidatorSpec extends AsyncFlatSpec with Matchers {
 
   "codeValidator" should "handle an available code" in {
     val codeValidator = CorporateCodeValidator.withDynamoLookup {
-      case "CODE" => Future.successful(Some(Map(
+      case "code" => Future.successful(Some(Map(
         "available" -> DynamoBoolean(true),
         "corporateId" -> DynamoString("1")
       )))
     }
-    codeValidator.getStatus(RedemptionCode("CODE").right.get).map {
+    codeValidator.getStatus(RedemptionCode("code").right.get).map {
       _ should be(ValidCorporateCode(CorporateId("1")))
     }
   }
 
   it should "handle an NON available code" in {
     val codeValidator = CorporateCodeValidator.withDynamoLookup {
-      case "CODE" => Future.successful(Some(Map(
+      case "code" => Future.successful(Some(Map(
         "available" -> DynamoBoolean(false),
         "corporateId" -> DynamoString("1")
       )))
     }
-    codeValidator.getStatus(RedemptionCode("CODE").right.get).map {
+    codeValidator.getStatus(RedemptionCode("code").right.get).map {
       _ should be(CodeAlreadyUsed)
     }
   }
 
   it should "handle an NON EXISTENT code" in {
     val codeValidator = CorporateCodeValidator.withDynamoLookup {
-      case "CODE" => Future.successful(None)
+      case "code" => Future.successful(None)
     }
-    codeValidator.getStatus(RedemptionCode("CODE").right.get).map {
+    codeValidator.getStatus(RedemptionCode("code").right.get).map {
       _ should be(CodeNotFound)
     }
   }
 
   it should "handle an code with invalid available type " in {
     val codeValidator = CorporateCodeValidator.withDynamoLookup {
-      case "CODE" => Future.successful(Some(Map(
+      case "code" => Future.successful(Some(Map(
         "available" -> DynamoString("haha not a boolean"),
         "corporateId" -> DynamoString("1")
       )))
     }
     recoverToSucceededIf[RuntimeException] {
-      codeValidator.getStatus(RedemptionCode("CODE").right.get)
+      codeValidator.getStatus(RedemptionCode("code").right.get)
     }
   }
 
   it should "handle an code with invalid corporate id type " in {
     val codeValidator = CorporateCodeValidator.withDynamoLookup {
-      case "CODE" => Future.successful(Some(Map(
+      case "code" => Future.successful(Some(Map(
         "available" -> DynamoBoolean(true),
         "corporateId" -> DynamoBoolean(false)
       )))
     }
     recoverToSucceededIf[RuntimeException] {
-      codeValidator.getStatus(RedemptionCode("CODE").right.get)
+      codeValidator.getStatus(RedemptionCode("code").right.get)
     }
   }
 
   it should "handle a missing attribute code - available" in {
     val codeValidator = CorporateCodeValidator.withDynamoLookup {
-      case "CODE" => Future.successful(Some(Map(
-        "ASDFNQWEOIDNSDKNFNAKNDAKNSKANSDKNASDAKSND" -> DynamoBoolean(true),
+      case "code" => Future.successful(Some(Map(
+        "asdfnqweoidnsdknfnakndaknskansdknasdaksnd" -> DynamoBoolean(true),
         "corporateId" -> DynamoString("1")
       )))
     }
     recoverToSucceededIf[RuntimeException] {
-      codeValidator.getStatus(RedemptionCode("CODE").right.get)
+      codeValidator.getStatus(RedemptionCode("code").right.get)
     }
   }
 
   it should "handle a missing attribute code - corporate id" in {
     val codeValidator = CorporateCodeValidator.withDynamoLookup {
-      case "CODE" => Future.successful(Some(Map(
-        "ASDFNQWEOIDNSDKNFNAKNDAKNSKANSDKNASDAKSND" -> DynamoString("1"),
+      case "code" => Future.successful(Some(Map(
+        "asdfnqweoidnsdknfnakndaknskansdknasdaksnd" -> DynamoString("1"),
         "available" -> DynamoBoolean(true)
       )))
     }
     recoverToSucceededIf[RuntimeException] {
-      codeValidator.getStatus(RedemptionCode("CODE").right.get)
+      codeValidator.getStatus(RedemptionCode("code").right.get)
     }
   }
 
   it should "be sure to fail if there is an overall dynamo failure" in {
     val codeValidator = CorporateCodeValidator.withDynamoLookup {
-      case "CODE" => Future.failed(new RuntimeException("test exception"))
+      case "code" => Future.failed(new RuntimeException("test exception"))
     }
     recoverToSucceededIf[RuntimeException] {
-      codeValidator.getStatus(RedemptionCode("CODE").right.get)
+      codeValidator.getStatus(RedemptionCode("code").right.get)
     }
   }
 

--- a/support-services/src/test/scala/com/gu/support/redemption/corporate/IT_testdata.sh
+++ b/support-services/src/test/scala/com/gu/support/redemption/corporate/IT_testdata.sh
@@ -13,7 +13,7 @@ fi
 function create {
   code=$1
   echo $code
-  if [[ "$code" == 'ITTEST-USED' ]]; then
+  if [[ "$code" == 'it-test-used1' ]]; then
     value='false'
   else
     value='true'

--- a/support-services/src/test/scala/com/gu/support/redemption/corporate/IT_testdata.sh
+++ b/support-services/src/test/scala/com/gu/support/redemption/corporate/IT_testdata.sh
@@ -34,7 +34,7 @@ function create {
 
 create 'ITTEST- !\"#$%&'"'"'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~'
 create 'ITTEST-MUTABLE- !\"#$%&'"'"'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~'
-create 'ITTEST-AVAILABLE'
-create 'ITTEST-USED'
-#create 'ITTEST-MISSING'
-create 'ITTEST-MUTABLE'
+create 'it-available1'
+create 'it-test-used1'
+#create 'it-missing123'
+create 'it-mutable123'

--- a/support-services/src/test/scala/com/gu/support/redemption/corporate/SetCodeStatusITSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/redemption/corporate/SetCodeStatusITSpec.scala
@@ -37,7 +37,7 @@ class SetCodeStatusITSpec extends AsyncFlatSpec with Matchers {
   }
 
   "setCodeStatus" should "not set a code that doesn't exist" in {
-    val missingCode = RedemptionCode("ittest-missing").right.get
+    val missingCode = RedemptionCode("it-missing123").right.get
     for {
       _ <- recoverToSucceededIf[ConditionalCheckFailedException] {
         setCodeStatus(missingCode, RedemptionTable.AvailableField.CodeIsAvailable)

--- a/support-services/src/test/scala/com/gu/support/redemption/corporate/SetCodeStatusITSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/redemption/corporate/SetCodeStatusITSpec.scala
@@ -18,7 +18,7 @@ class SetCodeStatusITSpec extends AsyncFlatSpec with Matchers {
 
   // this is one test because it depends on external state which may not be in a particular state
   "setCodeStatus" should "set a code available and used" in {
-    val mutableCode: RedemptionCode = RedemptionCode("ittest-mutable").right.get
+    val mutableCode: RedemptionCode = RedemptionCode("it-mutable123").right.get
     for {
       _ <- setCodeStatus(mutableCode, RedemptionTable.AvailableField.CodeIsUsed) // get in known state
       _ <- setCodeStatus(mutableCode, RedemptionTable.AvailableField.CodeIsAvailable).map {

--- a/support-services/src/test/scala/com/gu/support/redemption/corporate/SetCodeStatusITSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/redemption/corporate/SetCodeStatusITSpec.scala
@@ -18,7 +18,7 @@ class SetCodeStatusITSpec extends AsyncFlatSpec with Matchers {
 
   // this is one test because it depends on external state which may not be in a particular state
   "setCodeStatus" should "set a code available and used" in {
-    val mutableCode: RedemptionCode = RedemptionCode("ITTEST-MUTABLE").right.get
+    val mutableCode: RedemptionCode = RedemptionCode("ittest-mutable").right.get
     for {
       _ <- setCodeStatus(mutableCode, RedemptionTable.AvailableField.CodeIsUsed) // get in known state
       _ <- setCodeStatus(mutableCode, RedemptionTable.AvailableField.CodeIsAvailable).map {
@@ -37,7 +37,7 @@ class SetCodeStatusITSpec extends AsyncFlatSpec with Matchers {
   }
 
   "setCodeStatus" should "not set a code that doesn't exist" in {
-    val missingCode = RedemptionCode("ITTEST-MISSING").right.get
+    val missingCode = RedemptionCode("ittest-missing").right.get
     for {
       _ <- recoverToSucceededIf[ConditionalCheckFailedException] {
         setCodeStatus(missingCode, RedemptionTable.AvailableField.CodeIsAvailable)

--- a/support-services/src/test/scala/com/gu/support/redemption/corporate/SetCodeStatusSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/redemption/corporate/SetCodeStatusSpec.scala
@@ -11,31 +11,31 @@ class SetCodeStatusSpec extends AsyncFlatSpec with Matchers {
 
   "setCodeStatus" should "mark a code as used" in {
     val setCodeStatus = SetCodeStatus.withDynamoLookup {
-      case ("code", DynamoFieldUpdate("available", false)) => Future.successful(())
+      case ("test-code-123", DynamoFieldUpdate("available", false)) => Future.successful(())
       case _ => Future.failed(new Throwable)
     }
-    setCodeStatus(RedemptionCode("code").right.get, RedemptionTable.AvailableField.CodeIsUsed).map {
+    setCodeStatus(RedemptionCode("test-code-123").right.get, RedemptionTable.AvailableField.CodeIsUsed).map {
       _ should be(())
     }
   }
 
   it should "mark a code as available" in {
     val setCodeStatus = SetCodeStatus.withDynamoLookup {
-      case ("code", DynamoFieldUpdate("available", true)) => Future.successful(())
+      case ("test-code-123", DynamoFieldUpdate("available", true)) => Future.successful(())
       case _ => Future.failed(new Throwable)
     }
-    setCodeStatus(RedemptionCode("code").right.get, RedemptionTable.AvailableField.CodeIsAvailable).map {
+    setCodeStatus(RedemptionCode("test-code-123").right.get, RedemptionTable.AvailableField.CodeIsAvailable).map {
       _ should be(())
     }
   }
 
   it should "be sure to fail if there is an overall dynamo failure" in {
     val setCodeStatus = SetCodeStatus.withDynamoLookup {
-      case ("code", DynamoFieldUpdate("available", false)) => Future.failed(new RuntimeException("test exception"))
+      case ("test-code-123", DynamoFieldUpdate("available", false)) => Future.failed(new RuntimeException("test exception"))
       case _ => Future.failed(new Throwable)
     }
     recoverToSucceededIf[RuntimeException] {
-      setCodeStatus(RedemptionCode("code").right.get, RedemptionTable.AvailableField.CodeIsUsed)
+      setCodeStatus(RedemptionCode("test-code-123").right.get, RedemptionTable.AvailableField.CodeIsUsed)
     }
   }
 

--- a/support-services/src/test/scala/com/gu/support/redemption/corporate/SetCodeStatusSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/redemption/corporate/SetCodeStatusSpec.scala
@@ -11,31 +11,31 @@ class SetCodeStatusSpec extends AsyncFlatSpec with Matchers {
 
   "setCodeStatus" should "mark a code as used" in {
     val setCodeStatus = SetCodeStatus.withDynamoLookup {
-      case ("CODE", DynamoFieldUpdate("available", false)) => Future.successful(())
+      case ("code", DynamoFieldUpdate("available", false)) => Future.successful(())
       case _ => Future.failed(new Throwable)
     }
-    setCodeStatus(RedemptionCode("CODE").right.get, RedemptionTable.AvailableField.CodeIsUsed).map {
+    setCodeStatus(RedemptionCode("code").right.get, RedemptionTable.AvailableField.CodeIsUsed).map {
       _ should be(())
     }
   }
 
   it should "mark a code as available" in {
     val setCodeStatus = SetCodeStatus.withDynamoLookup {
-      case ("CODE", DynamoFieldUpdate("available", true)) => Future.successful(())
+      case ("code", DynamoFieldUpdate("available", true)) => Future.successful(())
       case _ => Future.failed(new Throwable)
     }
-    setCodeStatus(RedemptionCode("CODE").right.get, RedemptionTable.AvailableField.CodeIsAvailable).map {
+    setCodeStatus(RedemptionCode("code").right.get, RedemptionTable.AvailableField.CodeIsAvailable).map {
       _ should be(())
     }
   }
 
   it should "be sure to fail if there is an overall dynamo failure" in {
     val setCodeStatus = SetCodeStatus.withDynamoLookup {
-      case ("CODE", DynamoFieldUpdate("available", false)) => Future.failed(new RuntimeException("test exception"))
+      case ("code", DynamoFieldUpdate("available", false)) => Future.failed(new RuntimeException("test exception"))
       case _ => Future.failed(new Throwable)
     }
     recoverToSucceededIf[RuntimeException] {
-      setCodeStatus(RedemptionCode("CODE").right.get, RedemptionTable.AvailableField.CodeIsUsed)
+      setCodeStatus(RedemptionCode("code").right.get, RedemptionTable.AvailableField.CodeIsUsed)
     }
   }
 

--- a/support-services/src/test/scala/com/gu/support/redemption/corporate/SetCodeStatusSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/redemption/corporate/SetCodeStatusSpec.scala
@@ -9,33 +9,35 @@ import scala.concurrent.Future
 
 class SetCodeStatusSpec extends AsyncFlatSpec with Matchers {
 
+  val testCode = "test-code-123"
+
   "setCodeStatus" should "mark a code as used" in {
     val setCodeStatus = SetCodeStatus.withDynamoLookup {
-      case ("test-code-123", DynamoFieldUpdate("available", false)) => Future.successful(())
+      case (`testCode`, DynamoFieldUpdate("available", false)) => Future.successful(())
       case _ => Future.failed(new Throwable)
     }
-    setCodeStatus(RedemptionCode("test-code-123").right.get, RedemptionTable.AvailableField.CodeIsUsed).map {
+    setCodeStatus(RedemptionCode(testCode).right.get, RedemptionTable.AvailableField.CodeIsUsed).map {
       _ should be(())
     }
   }
 
   it should "mark a code as available" in {
     val setCodeStatus = SetCodeStatus.withDynamoLookup {
-      case ("test-code-123", DynamoFieldUpdate("available", true)) => Future.successful(())
+      case (`testCode`, DynamoFieldUpdate("available", true)) => Future.successful(())
       case _ => Future.failed(new Throwable)
     }
-    setCodeStatus(RedemptionCode("test-code-123").right.get, RedemptionTable.AvailableField.CodeIsAvailable).map {
+    setCodeStatus(RedemptionCode(testCode).right.get, RedemptionTable.AvailableField.CodeIsAvailable).map {
       _ should be(())
     }
   }
 
   it should "be sure to fail if there is an overall dynamo failure" in {
     val setCodeStatus = SetCodeStatus.withDynamoLookup {
-      case ("test-code-123", DynamoFieldUpdate("available", false)) => Future.failed(new RuntimeException("test exception"))
+      case (`testCode`, DynamoFieldUpdate("available", false)) => Future.failed(new RuntimeException("test exception"))
       case _ => Future.failed(new Throwable)
     }
     recoverToSucceededIf[RuntimeException] {
-      setCodeStatus(RedemptionCode("test-code-123").right.get, RedemptionTable.AvailableField.CodeIsUsed)
+      setCodeStatus(RedemptionCode(testCode).right.get, RedemptionTable.AvailableField.CodeIsUsed)
     }
   }
 

--- a/support-workers/src/test/scala/com/gu/support/workers/CreateZuoraSubscriptionStepsSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/CreateZuoraSubscriptionStepsSpec.scala
@@ -33,7 +33,7 @@ class CreateZuoraSubscriptionStepsSpec extends AsyncFlatSpec with Matchers {
       giftRecipient = None,
       product = DigitalPack(Currency.GBP, null /* !*/, Corporate),
       RedemptionNoProvider,
-      paymentMethod = Right(RedemptionData(RedemptionCode("testcode").right.get)),
+      paymentMethod = Right(RedemptionData(RedemptionCode("test-code-123").right.get)),
       firstDeliveryDate = None,
       promoCode = None,
       salesforceContacts = SalesforceContactRecords(
@@ -47,7 +47,7 @@ class CreateZuoraSubscriptionStepsSpec extends AsyncFlatSpec with Matchers {
     var dynamoUpdates: List[(String, DynamoUpdate.DynamoFieldUpdate)] = Nil
     val dyanmoDb = new DynamoLookup with DynamoUpdate {
       override def lookup(key: String): Future[Option[Map[String, DynamoLookup.DynamoValue]]] = key match {
-        case "testcode" => Future.successful(Some(Map("available" -> DynamoBoolean(true), "corporateId" -> DynamoString("1"))))
+        case "test-code-123" => Future.successful(Some(Map("available" -> DynamoBoolean(true), "corporateId" -> DynamoString("1"))))
       }
       override def update(key: String, dynamoFieldUpdate: DynamoUpdate.DynamoFieldUpdate): Future[Unit] = {
         dynamoUpdates = (key, dynamoFieldUpdate) :: dynamoUpdates
@@ -68,7 +68,7 @@ class CreateZuoraSubscriptionStepsSpec extends AsyncFlatSpec with Matchers {
         val ratePlan = subscribeRequest.subscribes.head.subscriptionData.ratePlanData.head.ratePlan.productRatePlanId
         val actual = (maybeRedemptionCode, paymentType, autoPay, readerType, ratePlan)
         actual match {
-          case (Some("testcode"), false, false, ReaderType.Corporate, "2c92c0f971c65dfe0171c6c1f86e603c") =>
+          case (Some("test-code-123"), false, false, ReaderType.Corporate, "2c92c0f971c65dfe0171c6c1f86e603c") =>
             Future.successful(List(SubscribeResponseAccount("accountcorp", "subcorp", 135.67f, "ididcorp", 246.67f, "acidcorp", true)))
           case _ => Future.failed(new Throwable(s"subscribe request: $actual"))
         }
@@ -91,7 +91,7 @@ class CreateZuoraSubscriptionStepsSpec extends AsyncFlatSpec with Matchers {
 
     result.map { handlerResult =>
       withClue(handlerResult) {
-        dynamoUpdates should be(List("testcode" -> DynamoFieldUpdate("available", false)))
+        dynamoUpdates should be(List("test-code-123" -> DynamoFieldUpdate("available", false)))
         handlerResult.value.accountNumber should be("accountcorp")
         handlerResult.value.subscriptionNumber should be("subcorp")
         handlerResult.value.paymentOrRedemptionData.isRight should be(true) // it's still a corp sub!

--- a/support-workers/src/test/scala/com/gu/support/workers/CreateZuoraSubscriptionStepsSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/CreateZuoraSubscriptionStepsSpec.scala
@@ -33,7 +33,7 @@ class CreateZuoraSubscriptionStepsSpec extends AsyncFlatSpec with Matchers {
       giftRecipient = None,
       product = DigitalPack(Currency.GBP, null /* !*/, Corporate),
       RedemptionNoProvider,
-      paymentMethod = Right(RedemptionData(RedemptionCode("TESTCODE").right.get)),
+      paymentMethod = Right(RedemptionData(RedemptionCode("testcode").right.get)),
       firstDeliveryDate = None,
       promoCode = None,
       salesforceContacts = SalesforceContactRecords(
@@ -47,7 +47,7 @@ class CreateZuoraSubscriptionStepsSpec extends AsyncFlatSpec with Matchers {
     var dynamoUpdates: List[(String, DynamoUpdate.DynamoFieldUpdate)] = Nil
     val dyanmoDb = new DynamoLookup with DynamoUpdate {
       override def lookup(key: String): Future[Option[Map[String, DynamoLookup.DynamoValue]]] = key match {
-        case "TESTCODE" => Future.successful(Some(Map("available" -> DynamoBoolean(true), "corporateId" -> DynamoString("1"))))
+        case "testcode" => Future.successful(Some(Map("available" -> DynamoBoolean(true), "corporateId" -> DynamoString("1"))))
       }
       override def update(key: String, dynamoFieldUpdate: DynamoUpdate.DynamoFieldUpdate): Future[Unit] = {
         dynamoUpdates = (key, dynamoFieldUpdate) :: dynamoUpdates
@@ -68,7 +68,7 @@ class CreateZuoraSubscriptionStepsSpec extends AsyncFlatSpec with Matchers {
         val ratePlan = subscribeRequest.subscribes.head.subscriptionData.ratePlanData.head.ratePlan.productRatePlanId
         val actual = (maybeRedemptionCode, paymentType, autoPay, readerType, ratePlan)
         actual match {
-          case (Some("TESTCODE"), false, false, ReaderType.Corporate, "2c92c0f971c65dfe0171c6c1f86e603c") =>
+          case (Some("testcode"), false, false, ReaderType.Corporate, "2c92c0f971c65dfe0171c6c1f86e603c") =>
             Future.successful(List(SubscribeResponseAccount("accountcorp", "subcorp", 135.67f, "ididcorp", 246.67f, "acidcorp", true)))
           case _ => Future.failed(new Throwable(s"subscribe request: $actual"))
         }
@@ -91,7 +91,7 @@ class CreateZuoraSubscriptionStepsSpec extends AsyncFlatSpec with Matchers {
 
     result.map { handlerResult =>
       withClue(handlerResult) {
-        dynamoUpdates should be(List("TESTCODE" -> DynamoFieldUpdate("available", false)))
+        dynamoUpdates should be(List("testcode" -> DynamoFieldUpdate("available", false)))
         handlerResult.value.accountNumber should be("accountcorp")
         handlerResult.value.subscriptionNumber should be("subcorp")
         handlerResult.value.paymentOrRedemptionData.isRight should be(true) // it's still a corp sub!

--- a/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
@@ -419,7 +419,7 @@ object JsonFixtures {
             "product": $digitalPackCorporateJson,
             "paymentProvider": "RedemptionNoProvider",
             "paymentMethod": {
-              "redemptionCode": "ITTEST-MUTABLE"
+              "redemptionCode": "it-mutable123"
             },
             "salesForceContact": $salesforceContactJson,
             $salesforceContactsJson

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
@@ -50,7 +50,7 @@ class CreateZuoraSubscriptionSpec extends AsyncLambdaSpec with MockServicesCreat
     val dynamoTableAsync: DynamoTableAsync = RedemptionTable.forEnvAsync(TouchPointEnvironments.SANDBOX)
     val setCodeStatus = SetCodeStatus.withDynamoLookup(dynamoTableAsync)
     val codeValidator = CorporateCodeValidator.withDynamoLookup(dynamoTableAsync)
-    val mutableCode: RedemptionCode = RedemptionCode("ITTEST-MUTABLE").right.get
+    val mutableCode: RedemptionCode = RedemptionCode("ITTEST-MUTABLE").right.get //TODO: RB make this work
     for {
       _ <- setCodeStatus(mutableCode, RedemptionTable.AvailableField.CodeIsAvailable)
       _ <- createZuoraHelper.createSubscription(createDigiPackCorporateSubscriptionJson)

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
@@ -50,7 +50,7 @@ class CreateZuoraSubscriptionSpec extends AsyncLambdaSpec with MockServicesCreat
     val dynamoTableAsync: DynamoTableAsync = RedemptionTable.forEnvAsync(TouchPointEnvironments.SANDBOX)
     val setCodeStatus = SetCodeStatus.withDynamoLookup(dynamoTableAsync)
     val codeValidator = CorporateCodeValidator.withDynamoLookup(dynamoTableAsync)
-    val mutableCode: RedemptionCode = RedemptionCode("ITTEST-MUTABLE").right.get //TODO: RB make this work
+    val mutableCode: RedemptionCode = RedemptionCode("it-mutable123").right.get
     for {
       _ <- setCodeStatus(mutableCode, RedemptionTable.AvailableField.CodeIsAvailable)
       _ <- createZuoraHelper.createSubscription(createDigiPackCorporateSubscriptionJson)

--- a/support-workers/src/test/scala/com/gu/zuora/ZuoraITSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/ZuoraITSpec.scala
@@ -43,7 +43,7 @@ class ZuoraITSpec extends AsyncFlatSpec with Matchers {
   }
 
   it should "retrieve subscription redemption information from a redemption code" in {
-    val redemptionCode = "gd12-integration-test" //TODO: RB make this work
+    val redemptionCode = "gd12-it-test1"
     uatGiftService.getSubscriptionFromRedemptionCode(RedemptionCode(redemptionCode).right.get).map {
       response =>
         response.records.size shouldBe 1

--- a/support-workers/src/test/scala/com/gu/zuora/ZuoraITSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/ZuoraITSpec.scala
@@ -43,7 +43,7 @@ class ZuoraITSpec extends AsyncFlatSpec with Matchers {
   }
 
   it should "retrieve subscription redemption information from a redemption code" in {
-    val redemptionCode = "gd12-integration-test"
+    val redemptionCode = "gd12-integration-test" //TODO: RB make this work
     uatGiftService.getSubscriptionFromRedemptionCode(RedemptionCode(redemptionCode).right.get).map {
       response =>
         response.records.size shouldBe 1
@@ -52,7 +52,7 @@ class ZuoraITSpec extends AsyncFlatSpec with Matchers {
   }
 
   it should "handle invalid redemption codes" in {
-    val invalidRedemptionCode = "xxxx-0000"
+    val invalidRedemptionCode = "xxxx-0000-111"
     uatGiftService.getSubscriptionFromRedemptionCode(RedemptionCode(invalidRedemptionCode).right.get).map {
       response =>
         response.records.size shouldBe 0

--- a/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilderSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilderSpec.scala
@@ -94,13 +94,15 @@ class DigitalSubscriptionBuilderSpec extends AsyncFlatSpec with Matchers {
   lazy val saleDate = new LocalDate(2020, 6, 5)
   lazy val giftCodeGeneratorService = new GiftCodeGeneratorService
 
+  val testCode = "test-code-123"
+
   lazy val corporate = DigitalSubscriptionBuilder.build(
     DigitalPack(GBP, null /* FIXME should be Option-al for a corp sub */ , Corporate),
     UUID.fromString("f7651338-5d94-4f57-85fd-262030de9ad5"),
     SubscriptionRedemption(
-      RedemptionData(RedemptionCode("code-12345678").right.get),
+      RedemptionData(RedemptionCode(testCode).right.get),
       new CorporateCodeValidator({
-        case "code-12345678" => Future.successful(Some(Map(
+        case `testCode` => Future.successful(Some(Map(
           "available" -> DynamoLookup.DynamoBoolean(true),
           "corporateId" -> DynamoLookup.DynamoString("1")
         )))
@@ -131,9 +133,9 @@ class DigitalSubscriptionBuilderSpec extends AsyncFlatSpec with Matchers {
   lazy val threeMonthGiftRedemption: Future[Either[PromoError, InvalidCode]] = DigitalSubscriptionBuilder.build(
     DigitalPack(GBP, Quarterly, Gift),
     UUID.fromString("f7651338-5d94-4f57-85fd-262030de9ad5"),
-    SubscriptionRedemption(RedemptionData(RedemptionCode("code-12345678").right.get),
+    SubscriptionRedemption(RedemptionData(RedemptionCode(testCode).right.get),
       new CorporateCodeValidator({
-        case "code-12345678" => Future.successful(Some(Map(
+        case `testCode` => Future.successful(Some(Map(
           "available" -> DynamoLookup.DynamoBoolean(true),
           "corporateId" -> DynamoLookup.DynamoString("1")
         )))

--- a/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilderSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilderSpec.scala
@@ -42,7 +42,7 @@ class DigitalSubscriptionBuilderSpec extends AsyncFlatSpec with Matchers {
           termType = "TERMED",
           readerType = ReaderType.Corporate,
           promoCode = None,
-          redemptionCode = Some("code"),
+          redemptionCode = Some("code-12345678"),
           corporateAccountId = Some("1")
         )
       )
@@ -98,9 +98,9 @@ class DigitalSubscriptionBuilderSpec extends AsyncFlatSpec with Matchers {
     DigitalPack(GBP, null /* FIXME should be Option-al for a corp sub */ , Corporate),
     UUID.fromString("f7651338-5d94-4f57-85fd-262030de9ad5"),
     SubscriptionRedemption(
-      RedemptionData(RedemptionCode("code").right.get),
+      RedemptionData(RedemptionCode("code-12345678").right.get),
       new CorporateCodeValidator({
-        case "code" => Future.successful(Some(Map(
+        case "code-12345678" => Future.successful(Some(Map(
           "available" -> DynamoLookup.DynamoBoolean(true),
           "corporateId" -> DynamoLookup.DynamoString("1")
         )))
@@ -131,9 +131,9 @@ class DigitalSubscriptionBuilderSpec extends AsyncFlatSpec with Matchers {
   lazy val threeMonthGiftRedemption: Future[Either[PromoError, InvalidCode]] = DigitalSubscriptionBuilder.build(
     DigitalPack(GBP, Quarterly, Gift),
     UUID.fromString("f7651338-5d94-4f57-85fd-262030de9ad5"),
-    SubscriptionRedemption(RedemptionData(RedemptionCode("any-code").right.get),
+    SubscriptionRedemption(RedemptionData(RedemptionCode("code-12345678").right.get),
       new CorporateCodeValidator({
-        case "code" => Future.successful(Some(Map(
+        case "code-12345678" => Future.successful(Some(Map(
           "available" -> DynamoLookup.DynamoBoolean(true),
           "corporateId" -> DynamoLookup.DynamoString("1")
         )))

--- a/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilderSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilderSpec.scala
@@ -42,7 +42,7 @@ class DigitalSubscriptionBuilderSpec extends AsyncFlatSpec with Matchers {
           termType = "TERMED",
           readerType = ReaderType.Corporate,
           promoCode = None,
-          redemptionCode = Some("CODE"),
+          redemptionCode = Some("code"),
           corporateAccountId = Some("1")
         )
       )
@@ -98,9 +98,9 @@ class DigitalSubscriptionBuilderSpec extends AsyncFlatSpec with Matchers {
     DigitalPack(GBP, null /* FIXME should be Option-al for a corp sub */ , Corporate),
     UUID.fromString("f7651338-5d94-4f57-85fd-262030de9ad5"),
     SubscriptionRedemption(
-      RedemptionData(RedemptionCode("CODE").right.get),
+      RedemptionData(RedemptionCode("code").right.get),
       new CorporateCodeValidator({
-        case "CODE" => Future.successful(Some(Map(
+        case "code" => Future.successful(Some(Map(
           "available" -> DynamoLookup.DynamoBoolean(true),
           "corporateId" -> DynamoLookup.DynamoString("1")
         )))
@@ -133,7 +133,7 @@ class DigitalSubscriptionBuilderSpec extends AsyncFlatSpec with Matchers {
     UUID.fromString("f7651338-5d94-4f57-85fd-262030de9ad5"),
     SubscriptionRedemption(RedemptionData(RedemptionCode("any-code").right.get),
       new CorporateCodeValidator({
-        case "CODE" => Future.successful(Some(Map(
+        case "code" => Future.successful(Some(Map(
           "available" -> DynamoLookup.DynamoBoolean(true),
           "corporateId" -> DynamoLookup.DynamoString("1")
         )))

--- a/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilderSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilderSpec.scala
@@ -42,7 +42,7 @@ class DigitalSubscriptionBuilderSpec extends AsyncFlatSpec with Matchers {
           termType = "TERMED",
           readerType = ReaderType.Corporate,
           promoCode = None,
-          redemptionCode = Some("code-12345678"),
+          redemptionCode = Some(testCode),
           corporateAccountId = Some("1")
         )
       )


### PR DESCRIPTION
## Why are you doing this?
We currently have inconsistent casing conventions between gift and corporate codes, gift uses lowercase whereas corporate uses uppercase.

This PR changes corporate codes to use lowercase, I have also reintroduced the code length check when constructing a `RedemptionCode`.

### TODO: 

- [ ] Fix two integration tests which rely on values in Dynamo and Zuora

[**Trello Card**](https://trello.com/c/vuOwsdwq/3189-make-corporate-sub-codes-lowercase)
