### PR TITLE
Tp make header fit on two lines

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/new-flow/ContributionThankYou.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/new-flow/ContributionThankYou.jsx
@@ -9,7 +9,7 @@ import type { Csrf } from 'helpers/csrf/csrfReducer';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import { css } from '@emotion/core';
 import { space } from '@guardian/src-foundations';
-import { from, between, until } from '@guardian/src-foundations/mq';
+import { from, between, until, breakpoints } from '@guardian/src-foundations/mq';
 import { neutral } from '@guardian/src-foundations/palette';
 import { LinkButton } from '@guardian/src-button';
 import ContributionThankYouHeader from './ContributionThankYouHeader';
@@ -33,15 +33,19 @@ const container = css`
 
   ${from.tablet} {
     background: none;
-    max-width: 740px;
+    max-width: ${breakpoints.tablet}px;
   }
 
   ${from.desktop} {
-    max-width: 980px;
+    max-width: ${breakpoints.desktop}px;
+  }
+
+  ${from.leftCol} {
+    max-width: ${breakpoints.leftCol}px;
   }
 
   ${from.wide} {
-    max-width: 1300px;
+    max-width: ${breakpoints.wide}px;
   }
 `;
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/new-flow/ContributionThankYou.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/new-flow/ContributionThankYou.jsx
@@ -51,6 +51,9 @@ const container = css`
 
 const headerContainer = css`
   ${from.desktop} {
+    width: 60%;
+  }
+  ${from.leftCol} {
     width: calc(50% - ${space[3]}px);
   }
 `;


### PR DESCRIPTION
## Why are you doing this?

Prevent the header wrapping onto 3 lines. Added a leftCol break point, and made the header slightly wider between desktop and leftCol. 

## images

before 
<img width="1000" alt="Screenshot 2020-10-05 at 09 51 04" src="https://user-images.githubusercontent.com/17720442/95059597-01ae0980-06f1-11eb-98d2-7933d7b195be.png">

after
<img width="1000" alt="Screenshot 2020-10-05 at 09 53 19" src="https://user-images.githubusercontent.com/17720442/95059604-04106380-06f1-11eb-8db8-aa8f2c4ce79e.png">
