### PR TITLE
Fix squashed and missing images on iOS for Editions on DS landing page

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/hero/hero.jsx
@@ -82,7 +82,7 @@ function CampaignHeader(props: PropTypes) {
         <div css={packShot}>
           <GridImage
             gridId={props.countryGroupId === AUDCountries ? 'editionsPackshotAus' : 'editionsPackshot'}
-            srcSizes={[1000, 750, 500, 140]}
+            srcSizes={[1000, 500, 140]}
             sizes="(max-width: 480px) 200px,
             (max-width: 740px) 100%,
             (max-width: 1067px) 150%,

--- a/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroStyles.js
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroStyles.js
@@ -187,20 +187,21 @@ export const heavyText = css`
 `;
 
 export const packShot = css`
-  display: flex;
-  align-self: flex-end;
+  display: block;
   width: 100%;
   margin-top: ${space[5]}px;
+  margin-bottom: -5px;
 
   img {
     width: 100%;
   }
 
   ${from.phablet} {
-    display: inline-flex;
+    position: absolute;
+    bottom: -5px;
+    right: 20px;
     max-width: 40%;
-    margin-top: 0;
-    margin-left: -20px;
+    margin: 0 0 0 -20px;
 
     img {
       width: 110%;
@@ -215,8 +216,18 @@ export const packShot = css`
     }
   }
 
+  ${from.desktop} {
+    right: 0;
+    max-width: 45%;
+    margin-bottom: 0;
+  }
+
   ${from.leftCol} {
-    max-width: 540px;
+    max-width: 490px;
+  }
+
+  ${from.wide} {
+    right: 20px;
   }
 `;
 


### PR DESCRIPTION
## Why are you doing this?
There were squashed (SE through iPhone 8) and missing (iPhone x and up) images on the relaunched digital subscriptions landing page.

Related to [**Trello Card**](https://trello.com/c/H5IACOaE/3290-editions-digital-subs-pages-subs-landing-page-9999)
And a fix for this PR: https://github.com/guardian/support-frontend/pull/2734

The are screenshots of the broken images in the trello card in case you'd like to see them - they were giant when I pasted them into this PR!

## Changes
* Replace display flex with position absolute for this image
* Remove the 750 image size for mobile as this was awol

## Screenshots - iPhone 6S
![Screen Shot 2020-10-06 at 13 17 10](https://user-images.githubusercontent.com/16781258/95200510-64c59c00-07d6-11eb-9a4e-099d450aca0f.png)

## Screenshots - iPhone X
![Screen Shot 2020-10-06 at 13 15 47](https://user-images.githubusercontent.com/16781258/95200428-4790cd80-07d6-11eb-80ab-87768821769f.png)

