### PR TITLE
tidy zuora subscription lambda 1 of 2

### DIFF
--- a/support-services/src/main/scala/com/gu/support/redemption/corporate/CorporateCodeStatusUpdater.scala
+++ b/support-services/src/main/scala/com/gu/support/redemption/corporate/CorporateCodeStatusUpdater.scala
@@ -5,15 +5,15 @@ import com.gu.support.redemptions.RedemptionCode
 
 import scala.concurrent.{ExecutionContext, Future}
 
-object SetCodeStatus {
+object CorporateCodeStatusUpdater {
 
-  def withDynamoLookup(dynamoLookup: DynamoUpdate): SetCodeStatus = new SetCodeStatus(dynamoLookup)
+  def withDynamoUpdate(dynamoLookup: DynamoUpdate): CorporateCodeStatusUpdater = new CorporateCodeStatusUpdater(dynamoLookup)
 
 }
 
-class SetCodeStatus(dynamoUpdate: DynamoUpdate) extends WithLogging {
+class CorporateCodeStatusUpdater(dynamoUpdate: DynamoUpdate) extends WithLogging {
 
-  def apply(code: RedemptionCode, codeStatus: RedemptionTable.AvailableField)(implicit e: ExecutionContext): Future[Unit] =
+  def setStatus(code: RedemptionCode, codeStatus: RedemptionTable.AvailableField)(implicit e: ExecutionContext): Future[Unit] =
     dynamoUpdate.update(code.value, DynamoFieldUpdate(RedemptionTable.AvailableField.name, codeStatus.encoded))
       .withLoggingAsync(s"marked redemption status of $code to $codeStatus")
 

--- a/support-services/src/test/scala/com/gu/support/redemption/corporate/CorporateCodeStatusUpdaterITSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/redemption/corporate/CorporateCodeStatusUpdaterITSpec.scala
@@ -10,24 +10,24 @@ import org.scalatest.matchers.should.Matchers
 import software.amazon.awssdk.services.dynamodb.model.ConditionalCheckFailedException
 
 @IntegrationTest
-class SetCodeStatusITSpec extends AsyncFlatSpec with Matchers {
+class CorporateCodeStatusUpdaterITSpec extends AsyncFlatSpec with Matchers {
 
   private val dynamoTableAsync: DynamoTableAsync = RedemptionTable.forEnvAsync(TouchPointEnvironments.SANDBOX)
-  val setCodeStatus = SetCodeStatus.withDynamoLookup(dynamoTableAsync)
+  val corporateCodeStatusUpdater = CorporateCodeStatusUpdater.withDynamoUpdate(dynamoTableAsync)
   val codeValidator = CorporateCodeValidator.withDynamoLookup(dynamoTableAsync)
 
   // this is one test because it depends on external state which may not be in a particular state
-  "setCodeStatus" should "set a code available and used" in {
+  "corporateCodeStatusUpdater" should "set a code available and used" in {
     val mutableCode: RedemptionCode = RedemptionCode("ITTEST-MUTABLE").right.get
     for {
-      _ <- setCodeStatus(mutableCode, RedemptionTable.AvailableField.CodeIsUsed) // get in known state
-      _ <- setCodeStatus(mutableCode, RedemptionTable.AvailableField.CodeIsAvailable).map {
+      _ <- corporateCodeStatusUpdater.setStatus(mutableCode, RedemptionTable.AvailableField.CodeIsUsed) // get in known state
+      _ <- corporateCodeStatusUpdater.setStatus(mutableCode, RedemptionTable.AvailableField.CodeIsAvailable).map {
         _ should be(())
       }
       _ <- codeValidator.getStatus(mutableCode).map {
         _ should be(ValidCorporateCode(CorporateId("1")))
       }
-      _ <- setCodeStatus(mutableCode, RedemptionTable.AvailableField.CodeIsUsed).map {
+      _ <- corporateCodeStatusUpdater.setStatus(mutableCode, RedemptionTable.AvailableField.CodeIsUsed).map {
         _ should be(())
       }
       a <- codeValidator.getStatus(mutableCode).map {
@@ -36,11 +36,11 @@ class SetCodeStatusITSpec extends AsyncFlatSpec with Matchers {
     } yield a
   }
 
-  "setCodeStatus" should "not set a code that doesn't exist" in {
+  "corporateCodeStatusUpdater" should "not set a code that doesn't exist" in {
     val missingCode = RedemptionCode("ITTEST-MISSING").right.get
     for {
       _ <- recoverToSucceededIf[ConditionalCheckFailedException] {
-        setCodeStatus(missingCode, RedemptionTable.AvailableField.CodeIsAvailable)
+        corporateCodeStatusUpdater.setStatus(missingCode, RedemptionTable.AvailableField.CodeIsAvailable)
       }
       a <- codeValidator.getStatus(missingCode).map {
         _ should be(CodeNotFound)

--- a/support-services/src/test/scala/com/gu/support/redemption/corporate/CorporateCodeStatusUpdaterSpec.scala
+++ b/support-services/src/test/scala/com/gu/support/redemption/corporate/CorporateCodeStatusUpdaterSpec.scala
@@ -7,35 +7,35 @@ import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.Future
 
-class SetCodeStatusSpec extends AsyncFlatSpec with Matchers {
+class CorporateCodeStatusUpdaterSpec extends AsyncFlatSpec with Matchers {
 
-  "setCodeStatus" should "mark a code as used" in {
-    val setCodeStatus = SetCodeStatus.withDynamoLookup {
+  "corporateCodeStatusUpdater" should "mark a code as used" in {
+    val corporateCodeStatusUpdater = CorporateCodeStatusUpdater.withDynamoUpdate {
       case ("CODE", DynamoFieldUpdate("available", false)) => Future.successful(())
       case _ => Future.failed(new Throwable)
     }
-    setCodeStatus(RedemptionCode("CODE").right.get, RedemptionTable.AvailableField.CodeIsUsed).map {
+    corporateCodeStatusUpdater.setStatus(RedemptionCode("CODE").right.get, RedemptionTable.AvailableField.CodeIsUsed).map {
       _ should be(())
     }
   }
 
   it should "mark a code as available" in {
-    val setCodeStatus = SetCodeStatus.withDynamoLookup {
+    val corporateCodeStatusUpdater = CorporateCodeStatusUpdater.withDynamoUpdate {
       case ("CODE", DynamoFieldUpdate("available", true)) => Future.successful(())
       case _ => Future.failed(new Throwable)
     }
-    setCodeStatus(RedemptionCode("CODE").right.get, RedemptionTable.AvailableField.CodeIsAvailable).map {
+    corporateCodeStatusUpdater.setStatus(RedemptionCode("CODE").right.get, RedemptionTable.AvailableField.CodeIsAvailable).map {
       _ should be(())
     }
   }
 
   it should "be sure to fail if there is an overall dynamo failure" in {
-    val setCodeStatus = SetCodeStatus.withDynamoLookup {
+    val corporateCodeStatusUpdater = CorporateCodeStatusUpdater.withDynamoUpdate {
       case ("CODE", DynamoFieldUpdate("available", false)) => Future.failed(new RuntimeException("test exception"))
       case _ => Future.failed(new Throwable)
     }
     recoverToSucceededIf[RuntimeException] {
-      setCodeStatus(RedemptionCode("CODE").right.get, RedemptionTable.AvailableField.CodeIsUsed)
+      corporateCodeStatusUpdater.setStatus(RedemptionCode("CODE").right.get, RedemptionTable.AvailableField.CodeIsUsed)
     }
   }
 

--- a/support-workers/src/test/scala/com/gu/support/workers/CreateZuoraSubscriptionStepsSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/CreateZuoraSubscriptionStepsSpec.scala
@@ -11,6 +11,7 @@ import com.gu.support.redemption.gifting.generator.GiftCodeGeneratorService
 import com.gu.support.redemption.corporate.{DynamoLookup, DynamoUpdate}
 import com.gu.support.redemptions.{RedemptionCode, RedemptionData}
 import com.gu.support.workers.lambdas.CreateZuoraSubscription
+import com.gu.support.workers.lambdas.CreateZuoraSubscription.Impure
 import com.gu.support.workers.states.CreateZuoraSubscriptionState
 import com.gu.support.zuora.api.ReaderType.Corporate
 import com.gu.support.zuora.api.response._
@@ -80,13 +81,15 @@ class CreateZuoraSubscriptionStepsSpec extends AsyncFlatSpec with Matchers {
     val result = CreateZuoraSubscription.createSubscription(
       state,
       RequestInfo(false, false, Nil, false),
-      () => new DateTime(2020, 6, 15, 16, 28, 57),
-      () => new LocalDate(2020, 6, 15),
-      null,
-      dyanmoDb,
-      zuora,
-      giftCodeGeneratorService,
-      ZuoraConfig(null, null, null, null, null, null)
+      ZuoraConfig(null, null, null, null, null, null),
+      Impure(
+        () => new DateTime(2020, 6, 15, 16, 28, 57),
+        () => new LocalDate(2020, 6, 15),
+        null,
+        dyanmoDb,
+        zuora,
+        giftCodeGeneratorService,
+      )
     )
 
     result.map { handlerResult =>
@@ -146,13 +149,15 @@ class CreateZuoraSubscriptionStepsSpec extends AsyncFlatSpec with Matchers {
     val result = CreateZuoraSubscription.createSubscription(
       state = state,
       requestInfo = RequestInfo(false, false, Nil, false),
-      now = () => new DateTime(2020, 6, 15, 16, 28, 57),
-      today = () => new LocalDate(2020, 6, 15),
-      promotionService = null,// shouldn't be called for subs with no promo code
-      redemptionService = null,// shouldn't be called for paid subs
-      zuoraService = zuora,
       config = ZuoraConfig(url = null, username = null, password = null, monthlyContribution = null, annualContribution = null, digitalPack = ZuoraDigitalPackConfig(14, 2)),
-      giftCodeGenerator = new GiftCodeGeneratorService
+      Impure(
+        now = () => new DateTime(2020, 6, 15, 16, 28, 57),
+        today = () => new LocalDate(2020, 6, 15),
+        promotionService = null,// shouldn't be called for subs with no promo code
+        redemptionService = null,// shouldn't be called for paid subs
+        zuoraService = zuora,
+        giftCodeGenerator = new GiftCodeGeneratorService
+      )
     )
 
     result.map { handlerResult =>


### PR DESCRIPTION
## Why are you doing this?

This ia  nit of pre tidying of the zuora subscription lambda, so that the way is clearer to get the code and date into the email lambda.

Part 1 (this one) is to update the redemption code stuff to match the consistent naming convention.  Also a bit of tidy up.

Part 2 will be getting rid of the warnings of the CreateZuoraSubscription file especially this one: 
![image](https://user-images.githubusercontent.com/7304387/95229478-86d01600-07f8-11eb-9822-0275685bf1ad.png)
this is pretty similar to the issue that SendThankYouEmail had, with the varying logic for contribution/DS/GW/Paper, so hopefully I can apply a similar technique to remove the excessive method length here.  But that will be the next PR.


[**Trello Card**](https://trello.com/c/RvP8A1nw/3192-gifting-email-api-triggers-for-the-gifter-giftee-emails-generated-80)

