### PR TITLE
Open "find your nearest participating retailer" link in new tab

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/subsCardTab.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/subsCardTab.jsx
@@ -25,7 +25,7 @@ const accordionContainer = css`
   }
 `;
 
-const LinkToImovo = () => <a href="https://imovo.org/guardianstorefinder">Find your nearest participating retailer</a>;
+const LinkToImovo = () => <a href="https://imovo.org/guardianstorefinder" target="_blank">Find your nearest participating retailer</a>;
 
 // ----- Content ----- //
 const SubsCardFaqBlock = () => (

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/subsCardTab.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/subsCardTab.jsx
@@ -25,7 +25,7 @@ const accordionContainer = css`
   }
 `;
 
-const LinkToImovo = () => <a href="https://imovo.org/guardianstorefinder" target="_blank">Find your nearest participating retailer</a>;
+const LinkToImovo = () => <a href="https://imovo.org/guardianstorefinder" target="_blank" rel="noopener noreferrer">Find your nearest participating retailer</a>;
 
 // ----- Content ----- //
 const SubsCardFaqBlock = () => (


### PR DESCRIPTION
## Why are you doing this?

The "find your nearest participating retailer" link on https://support.theguardian.com/uk/subscribe/paper takes you off the support site when clicked, it'd be better to open this in a new tab. This PR does this be adding, `target="_blank"` to open the new tab and `rel="noopener noreferrer"` to prevent unsafe linking to cross-origin destinations, as described here: https://web.dev/external-anchors-use-rel-noopener/
