### PR TITLE
fix list of requestable image sizes on home delivery tab

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/deliveryTab.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/deliveryTab.jsx
@@ -41,7 +41,7 @@ const ContentDeliveryFaqBlock = ({
     border={paperHasDeliveryEnabled()}
     image={<GridImage
       gridId="printCampaignHDdigitalVoucher"
-      srcSizes={[716, 500, 140]}
+      srcSizes={[750, 500, 140]}
       sizes="(max-width: 740px) 100vw, 400px"
       imgType="png"
     />


### PR DESCRIPTION
## Why are you doing this?

Fixes an issue where we are requesting an image at a size which we do not have a crop for.

## Changes

* Adjust the requested sizes of the image on the home delivery tab to match the sizes we actually have