### PR TITLE
Add new Digital Sub gift purchase fields into the checkout

### DIFF
--- a/support-frontend/assets/helpers/formValidation.js
+++ b/support-frontend/assets/helpers/formValidation.js
@@ -42,8 +42,7 @@ export const checkEmail: (string | null) => boolean = input => isNotEmpty(input)
 export const checkOptionalEmail: (string | null) => boolean = input => isEmpty(input) || isValidEmail(input);
 
 export const checkGiftStartDate: (string | null) => boolean = (rawDate) => {
-  const dateArray = rawDate ? rawDate.split('/') : null;
-  const date = dateArray ? new Date(`${dateArray[1]} ${dateArray[0]} ${dateArray[2]}`) : null;
+  const date = rawDate ? new Date(rawDate) : null;
   return isNotEmpty(rawDate) && isNotInThePast(date) && isNotTooFarInTheFuture(date);
 };
 

--- a/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
+++ b/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
@@ -102,8 +102,8 @@ type GiftRecipientType = {|
   firstName: string,
   lastName: string,
   email?: Option<string>,
-  // message: Option<string>,
-  // deliveryDate: Option<string>,
+  message: Option<string>,
+  deliveryDate: Option<string>,
 |};
 
 // The model that is sent to support-workers

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.js
@@ -138,6 +138,8 @@ function buildRegularPaymentRequest(
     firstNameGiftRecipient,
     lastNameGiftRecipient,
     emailGiftRecipient,
+    giftMessage,
+    giftDeliveryDate,
     billingPeriod,
     fulfilmentOption,
     productOption,
@@ -167,8 +169,8 @@ function buildRegularPaymentRequest(
       firstName: firstNameGiftRecipient,
       lastName: lastNameGiftRecipient,
       email: emailGiftRecipient,
-      // message: giftMessage,
-      // deliveryDate: giftDeliveryDate,
+      message: giftMessage,
+      deliveryDate: giftDeliveryDate,
     },
   } : {};
 

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/datePicker/datePicker.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/datePicker/datePicker.jsx
@@ -95,9 +95,11 @@ class DatePickerFields extends Component<PropTypes, StateTypes> {
     this.handleCalendarDate(new Date(Date.now()));
   }
 
+  getDateString = () => `${this.state.year}-${this.state.month}-${this.state.day}`;
+
   checkDateIsValid = (e: Object) => {
     e.preventDefault();
-    const date = new Date(`${this.state.month}/${this.state.day}/${this.state.year}`);
+    const date = new Date(this.getDateString());
     const dateIsNotADate = !DateUtils.isDate(date);
     const latestAvailableDate = getLatestAvailableDateText();
 
@@ -143,7 +145,13 @@ class DatePickerFields extends Component<PropTypes, StateTypes> {
     }
   }
 
-  updateStartDate = () => this.props.onChange(`${this.state.year}-${this.state.month}-${this.state.day}`)
+  updateStartDate = () => {
+    const dateString = this.getDateString();
+    if (DateUtils.isDate(new Date(dateString))) {
+      return this.props.onChange(dateString);
+    }
+    return this.props.onChange('');
+  }
 
   render() {
     const { state } = this;

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/datePicker/datePicker.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/datePicker/datePicker.jsx
@@ -143,7 +143,7 @@ class DatePickerFields extends Component<PropTypes, StateTypes> {
     }
   }
 
-  updateStartDate = () => this.props.onChange(`${this.state.day}/${this.state.month}/${this.state.year}`)
+  updateStartDate = () => this.props.onChange(`${this.state.year}-${this.state.month}-${this.state.day}`)
 
   render() {
     const { state } = this;
@@ -151,8 +151,7 @@ class DatePickerFields extends Component<PropTypes, StateTypes> {
     const today = Date.now();
     const currentMonth = new Date(today);
     const threeMonthRange = DateUtils.addMonths(currentMonth, 3);
-    const valueArray = value ? value.split('/') : [];
-    const valueDate = valueArray.length ? new Date(`${valueArray[1]}/${valueArray[0]}/${valueArray[2]}`) : null;
+    const valueDate = value ? new Date(value) : null;
 
     return (
       <div>

--- a/support-frontend/assets/pages/digital-subscription-checkout/thankYouGift.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/thankYouGift.jsx
@@ -186,9 +186,8 @@ const GreenCheckMark = () => (
 
 
 function ThankYouGift(props: PropTypes) {
-  const dateArray = props.giftDeliveryDate ? props.giftDeliveryDate.split('/') : [];
-  const date = dateArray.length && new Date(`${dateArray[1]} ${dateArray[0]} ${dateArray[2]}`);
-  const fullDate = formatUserDate(new Date(date));
+  const date = props.giftDeliveryDate ? new Date(props.giftDeliveryDate) : null;
+  const fullDate = date ? formatUserDate(date) : 'Invalid date';
 
   return (
     <div className="thank-you-stage">


### PR DESCRIPTION
## Why are you doing this?

Following on from #2730 we need to pass two new fields through to the backend when completing a Digital Subscription gift purchase - `giftMessage` and `giftDeliveryDate`.

I have also changed the way that the gift delivery date is formatted in the Redux data store from `dd\MM\yyyy` to `yyyy-MM-dd`. This is consistent with how all other dates are represented in the checkouts and is the expected format for the deserialiser code in the backend.

[**Trello Card**](https://trello.com/c/7N8rZbzM/3396-pass-gift-message-gift-delivery-date-to-server-on-gift-purchase)
