### PR TITLE
Remove retention test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -7,7 +7,6 @@ import { USV1, AusAmounts, UkAmountsV1 } from './data/testAmountsData';
 const usOnlyLandingPage = '/us/contribute(/.*)?$';
 const auOnlyLandingPage = '/au/contribute(/.*)?$';
 const ukOnlyLandingPage = '/uk/contribute(/.*)?$';
-const allBarUkLandingPages = '/((?!uk).)*/contribute(/.*)?$';
 export const subsShowcaseAndDigiSubPages = '(/??/subscribe(\\?.*)?$|/??/subscribe/digital(\\?.*)?$)';
 
 export const tests: Tests = {
@@ -78,30 +77,5 @@ export const tests: Tests = {
     referrerControlled: false,
     targetPage: ukOnlyLandingPage,
     seed: 9,
-  },
-
-  landingPageRetentionR2: {
-    type: 'OTHER',
-    variants: [
-      {
-        id: 'control',
-      },
-      {
-        id: 'variant 2',
-      },
-      {
-        id: 'variant 3',
-      },
-    ],
-    audiences: {
-      ALL: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: true,
-    referrerControlled: false,
-    targetPage: allBarUkLandingPages,
-    seed: 2,
   },
 };

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
@@ -18,7 +18,6 @@ import { trackComponentClick } from 'helpers/tracking/behaviour';
 import { formatAmount } from 'helpers/checkouts';
 import { selectAmount, updateOtherAmount } from '../contributionsLandingActions';
 import { type State } from '../contributionsLandingReducer';
-import ContributionChoicesHeader from './ContributionChoicesHeader';
 import ContributionTextInputDs from './ContributionTextInputDs';
 import ContributionAmountChoices from './ContributionAmountChoices';
 
@@ -36,8 +35,6 @@ type PropTypes = {|
   updateOtherAmount: (string, CountryGroupId, ContributionType) => void,
   checkoutFormHasBeenSubmitted: boolean,
   stripePaymentRequestButtonClicked: boolean,
-  shouldShowFrequencyButtons: boolean,
-  shouldShowChoiceHeader: boolean,
 |};
 
 
@@ -52,8 +49,6 @@ const mapStateToProps = (state: State) => ({
   stripePaymentRequestButtonClicked:
     state.page.form.stripePaymentRequestButtonData.ONE_OFF.stripePaymentRequestButtonClicked ||
     state.page.form.stripePaymentRequestButtonData.REGULAR.stripePaymentRequestButtonClicked,
-  shouldShowFrequencyButtons: state.common.abParticipations.landingPageRetentionR2 === 'variant 2',
-  shouldShowChoiceHeader: state.common.abParticipations.landingPageRetentionR2 === 'variant 3',
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -155,10 +150,6 @@ function withProps(props: PropTypes) {
     <fieldset className={classNameWithModifiers('form__radio-group', ['pills', 'contribution-amount'])}>
       <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>How much would you like to give?</legend>
 
-      {props.shouldShowChoiceHeader && (
-        <ContributionChoicesHeader>Amount</ContributionChoicesHeader>
-      )}
-
       <ContributionAmountChoices
         countryGroupId={props.countryGroupId}
         currency={props.currency}
@@ -167,7 +158,7 @@ function withProps(props: PropTypes) {
         showOther={showOther}
         selectedAmounts={props.selectedAmounts}
         selectAmount={props.selectAmount}
-        shouldShowFrequencyButtons={props.shouldShowFrequencyButtons}
+        shouldShowFrequencyButtons={props.countryGroupId !== 'GBPCountries' && props.contributionType !== 'ONE_OFF'}
       />
 
       {showOther && renderOtherField()}

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionTypeTabs.jsx
@@ -23,7 +23,6 @@ import type {
   ContributionTypeSetting,
 } from 'helpers/contributions';
 import { ChoiceCardGroup, ChoiceCard } from '@guardian/src-choice-card';
-import ContributionChoicesHeader from './ContributionChoicesHeader';
 
 // ----- Types ----- //
 
@@ -34,7 +33,6 @@ type PropTypes = {|
   switches: Switches,
   contributionTypes: ContributionTypes,
   onSelectContributionType: (ContributionType, Switches, IsoCountry, CountryGroupId) => void,
-  shouldShowChoiceHeader: boolean,
 |};
 
 const mapStateToProps = (state: State) => ({
@@ -43,7 +41,7 @@ const mapStateToProps = (state: State) => ({
   countryId: state.common.internationalisation.countryId,
   switches: state.common.settings.switches,
   contributionTypes: state.common.settings.contributionTypes,
-  shouldShowChoiceHeader: state.common.abParticipations.landingPageRetentionR2 === 'variant 3',
+
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -131,10 +129,6 @@ function withProps(props: PropTypes) {
   return (
     <fieldset className={classNameWithModifiers('form__radio-group', ['tabs', 'contribution-type'])}>
       <legend className={classNameWithModifiers('form__legend', ['radio-group'])}>How often would you like to contribute?</legend>
-      {props.shouldShowChoiceHeader && (
-        <ContributionChoicesHeader>Frequency</ContributionChoicesHeader>
-      )}
-
       {renderChoiceCards()}
     </fieldset>
   );


### PR DESCRIPTION
This test has reached significance.

1. UK should still see the old control
2. Non-UK should see variant 2, which adds 'per month' or 'per year' to the amounts buttons for recurring contributions

Also, I noticed we were using 2 columns for one-off contributions as well, which is unnecessary.

### UK recurring
![Screen Shot 2020-10-14 at 08 21 06](https://user-images.githubusercontent.com/1513454/95956467-3b1ffc80-0df6-11eb-8256-a813433c3057.png)


### Non-UK recurring
![Screen Shot 2020-10-14 at 08 20 56](https://user-images.githubusercontent.com/1513454/95956479-4115dd80-0df6-11eb-91dd-2f0e59b9ab17.png)


### Non-UK one-off
![Screen Shot 2020-10-14 at 08 21 00](https://user-images.githubusercontent.com/1513454/95956495-46732800-0df6-11eb-8856-fec6a901426e.png)
