### PR TITLE
prevent direct navigation to contribution thank you page

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.jsx
@@ -5,6 +5,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { Redirect } from 'react-router-dom';
+import * as storage from 'helpers/storage';
 import { type CountryGroupId, countryGroups } from 'helpers/internationalisation/countryGroup';
 import { type PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
 import DirectDebitPopUpForm from 'components/directDebit/directDebitPopUpForm/directDebitPopUpForm';
@@ -96,6 +97,7 @@ function withProps(props: PropTypes) {
     // This is because going 'back' to the /contribute page is not helpful, and the client-side routing would redirect
     // back to /thankyou given the current state of the redux store.
     // The effect is that clicking back in the browser will take the user to the page before they arrived at /contribute
+    storage.setSession('isPaymentComplete', 'true');
     return (<Redirect to={props.thankYouRoute} push={false} />);
   }
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionFormContainer.jsx
@@ -5,7 +5,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { Redirect } from 'react-router-dom';
-import * as storage from 'helpers/storage';
 import { type CountryGroupId, countryGroups } from 'helpers/internationalisation/countryGroup';
 import { type PaymentAuthorisation } from 'helpers/paymentIntegrations/readerRevenueApis';
 import DirectDebitPopUpForm from 'components/directDebit/directDebitPopUpForm/directDebitPopUpForm';
@@ -97,7 +96,6 @@ function withProps(props: PropTypes) {
     // This is because going 'back' to the /contribute page is not helpful, and the client-side routing would redirect
     // back to /thankyou given the current state of the redux store.
     // The effect is that clicking back in the browser will take the user to the page before they arrived at /contribute
-    storage.setSession('isPaymentComplete', 'true');
     return (<Redirect to={props.thankYouRoute} push={false} />);
   }
 

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
@@ -128,8 +128,7 @@ const router = (
           exact
           path="/:countryId(uk|us|au|eu|int|nz|ca)/thankyou"
           render={(props) => {
-            const { pathname } = props.location;
-            const { search } = props.location;
+            const { pathname, search } = props.location;
             const queryParams = new URLSearchParams(search);
 
             if (!storage.getSession('isPaymentComplete') && !queryParams.has('no-redirect')) {

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
@@ -4,8 +4,7 @@
 
 import React from 'react';
 import { Provider } from 'react-redux';
-import { BrowserRouter, Route } from 'react-router-dom';
-
+import { BrowserRouter, Redirect, Route } from 'react-router-dom';
 import { isDetailsSupported, polyfillDetails } from 'helpers/details';
 import { init as pageInit } from 'helpers/page/page';
 import { renderPage } from 'helpers/render';
@@ -128,7 +127,16 @@ const router = (
         <Route
           exact
           path="/:countryId(uk|us|au|eu|int|nz|ca)/thankyou"
-          render={() => {
+          render={(props) => {
+            const { pathname } = props.location;
+            const { search } = props.location;
+            const queryParams = new URLSearchParams(search);
+
+            if (!storage.getSession('isPaymentComplete') && !queryParams.has('no-redirect')) {
+              const redirectPath = pathname.replace('thankyou', 'contribute') + search;
+              return <Redirect to={redirectPath} push={false} />;
+            }
+
             // we set the recurring cookie server side
             if (storage.getSession('selectedContributionType') === 'ONE_OFF') {
               setOneOffContributionCookie();

--- a/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLanding.jsx
@@ -128,10 +128,13 @@ const router = (
           exact
           path="/:countryId(uk|us|au|eu|int|nz|ca)/thankyou"
           render={(props) => {
+            const paymentMethod = storage.getSession('selectedPaymentMethod');
+            const isPaymentMethodSelected = paymentMethod && paymentMethod !== 'None';
+
             const { pathname, search } = props.location;
             const queryParams = new URLSearchParams(search);
 
-            if (!storage.getSession('isPaymentComplete') && !queryParams.has('no-redirect')) {
+            if (!isPaymentMethodSelected && !queryParams.has('no-redirect')) {
               const redirectPath = pathname.replace('thankyou', 'contribute') + search;
               return <Redirect to={redirectPath} push={false} />;
             }

--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -2929,7 +2929,7 @@
   resolved "https://registry.yarnpkg.com/@guardian/src-foundations/-/src-foundations-2.4.0.tgz#e87d935881b5554e35c00a5b054ced948ac1b5c7"
   integrity sha512-yShUGqULr7joOxWW+sUq9uziXC9WfIv/S05Tmi8QxevYpkgrSyLK0jSUY3S2ZRg+SfXSyX1g30qvOI+NuhSKfA==
 
-"@guardian/src-helpers@^2.0.0", "@guardian/src-helpers@^2.1.0", "@guardian/src-helpers@^2.4.0":
+"@guardian/src-helpers@^2.0.0", "@guardian/src-helpers@^2.1.0", "@guardian/src-helpers@^2.3.0", "@guardian/src-helpers@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@guardian/src-helpers/-/src-helpers-2.4.0.tgz#b21bd49554fef5826bdf3663dc08927e8a0ad9f6"
   integrity sha512-/x96RAKoH6DTox024mipSdZA7zJJmLRKPn8KMwKx1t+W+Cy9W3tsh/Jdw8YYVkeRdURjCtvTBG374Mr6fyqVyA==
@@ -2952,11 +2952,6 @@
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@guardian/src-icons/-/src-icons-2.2.0.tgz#c4cc2f8a96dbba1ca0aa9f9ab379f6a4e0a3be16"
   integrity sha512-WBIv2Z/aw/jnxUMbZaJ/+cnlfLrqRdSakZsDbopJnSospKZiaphVHAOEkA+5tQaAP1M4C0Z+PpfrEf7iKfsO2w==
-
-"@guardian/src-icons@^2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@guardian/src-icons/-/src-icons-2.3.0.tgz#6fb09b37616ebd075ed1ab7a3363412e2f852b9e"
-  integrity sha512-V/qgRZ+bRIkbyhLF45DY8hSiOwyHIxdkNQ6mq0HMxlGkdqg3MPEfrOHes17VQTPT6NJxwD5S2qHcEKxTs7XDIA==
 
 "@guardian/src-icons@^2.4.0":
   version "2.4.0"
@@ -2991,7 +2986,7 @@
   resolved "https://registry.yarnpkg.com/@guardian/src-svgs/-/src-svgs-2.4.0.tgz#76a3834b745ad481254c7a6b238fbe660fd8caa6"
   integrity sha512-EgfvO6mUCLSKAklifIPBpAMYPO2/Z14ieZjfXia1dZELqVnqHLn6hAmt/zZz5/9RrnL7oeZfFp16zdMsxxc2Sg==
 
-"@guardian/src-text-input@^2.0.0":
+"@guardian/src-text-input@^2.1.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@guardian/src-text-input/-/src-text-input-2.4.0.tgz#c64d7b28ce7f4d96c80ba0507da729342165ccda"
   integrity sha512-KFwoMA4rAMeHKIIMaYMZf+rUQiQl+73+OCIc3IM51QA/cyJV7Ak2rmJ6jBTo63U0OIiAckb8i0owULz4gvZ8bQ==
@@ -2999,7 +2994,7 @@
     "@guardian/src-helpers" "^2.4.0"
     "@guardian/src-user-feedback" "^2.4.0"
 
-"@guardian/src-user-feedback@^2.0.0", "@guardian/src-user-feedback@^2.4.0":
+"@guardian/src-user-feedback@^2.0.0", "@guardian/src-user-feedback@^2.3.0", "@guardian/src-user-feedback@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@guardian/src-user-feedback/-/src-user-feedback-2.4.0.tgz#26594c27c5b0f5394a34e6e6c8194a0386399c72"
   integrity sha512-9DOdFpvr03RdJI0peHsoKq1UJmc/eqPWvEzaaXfv9qYl5B7qMerKrjYLNjuQ0nwu6tT7bHeElpLSMcQf+w9hrw==


### PR DESCRIPTION
## What does this PR do?

Per [this ticket](https://trello.com/c/LBpPmGmy), this PR adds some additional conditional logic to the React Router components on the contributions landing page. If a user points their browser directly to `https://support.theguardian.com/uk/thankyou`, they'll be redirected to `https://support.theguardian.com/uk/contribute`. This doesn't affect the post-contribution redirect to the thank you page.

_n.b. for testing purposes etc. we can directly navigate to the thank you page by appending the_ `no-redirect` _param to the query string, eg._ `https://support.theguardian.com/uk/thankyou?no-redirect`.