### PR TITLE
Enable stripe fraud detection only if we have required consents

### DIFF
--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -172,7 +172,7 @@ class Application(
       classes = Some(classes)
     )
 
-    val serversideTests = generateParticipations(List("stripeFraudDetection"))
+    val serversideTests = generateParticipations(List())
 
     views.html.contributions(
       title = "Support the Guardian | Make a Contribution",

--- a/support-frontend/app/controllers/Application.scala
+++ b/support-frontend/app/controllers/Application.scala
@@ -172,7 +172,7 @@ class Application(
       classes = Some(classes)
     )
 
-    val serversideTests = generateParticipations(List())
+    val serversideTests = generateParticipations(Nil)
 
     views.html.contributions(
       title = "Support the Guardian | Make a Contribution",

--- a/support-frontend/app/views/contributions.scala.html
+++ b/support-frontend/app/views/contributions.scala.html
@@ -121,5 +121,4 @@
     uat: "@v2recaptchaConfigPublicKeyUat"
   }
   </script>
-  <script defer id="stripe-js" src=@{s"https://js.stripe.com/v3/${if (serversideTests.get("stripeFraudDetection").contains(Variant)) "?advancedFraudSignals=false" else ""}"}></script>
 }

--- a/support-frontend/assets/helpers/stripe.js
+++ b/support-frontend/assets/helpers/stripe.js
@@ -3,27 +3,9 @@
 import { useEffect, useState } from 'react';
 import { loadStripe, type Stripe as StripeSDK } from '@stripe/stripe-js/pure';
 import { onConsentChange } from '@guardian/consent-management-platform';
-import { logException } from 'helpers/logger';
 import { type PaymentMethod, Stripe } from 'helpers/paymentMethods';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { ContributionType } from 'helpers/contributions';
-
-
-const setupStripe = (setStripeHasLoaded: () => void) => {
-  if (window.Stripe) {
-    setStripeHasLoaded();
-  } else {
-    const htmlElement = document.getElementById('stripe-js');
-    if (htmlElement !== null) {
-      htmlElement.addEventListener(
-        'load',
-        setStripeHasLoaded,
-      );
-    } else {
-      logException('Failed to find stripe-js element, cannot initialise Stripe Elements');
-    }
-  }
-};
 
 const stripeCardFormIsIncomplete = (
   paymentMethod: PaymentMethod,
@@ -97,7 +79,6 @@ export const useStripeObjects = (stripeAccount: StripeAccount, stripeKey: string
 
 
 export {
-  setupStripe,
   stripeCardFormIsIncomplete,
   stripeAccountForContributionType,
   getStripeKey,

--- a/support-frontend/assets/helpers/stripe.js
+++ b/support-frontend/assets/helpers/stripe.js
@@ -56,7 +56,8 @@ function getStripeKey(stripeAccount: StripeAccount, country: IsoCountry, isTestU
         window.guardian.stripeKeyDefaultCurrencies[stripeAccount].default;
   }
 }
-
+//  this is required as useStripeObjects is used in multiple components
+//  but we only want to call setLoadParameters once.
 const stripeScriptHasBeenAddedToPage = (): boolean =>
   !!document.querySelector('script[src^=\'https://js.stripe.com\']');
 
@@ -65,11 +66,9 @@ export const useStripeObjects = (stripeAccount: StripeAccount, stripeKey: string
     REGULAR: null,
     ONE_OFF: null,
   });
-  (useEffect(
+  useEffect(
     () => {
       if (stripeObjects[stripeAccount] === null) {
-        console.log('card form');
-
         new Promise((resolve) => {
           onConsentChange(({ ccpa, tcfv2 }) => {
             if (ccpa) {
@@ -91,7 +90,7 @@ export const useStripeObjects = (stripeAccount: StripeAccount, stripeKey: string
       }
     },
     [stripeAccount],
-  ));
+  );
 
   return stripeObjects;
 };

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionForm.jsx
@@ -42,7 +42,6 @@ import {
   paymentWaiting,
   setCheckoutFormHasBeenSubmitted,
   createOneOffPayPalPayment,
-  setStripeV3HasLoaded,
 } from 'pages/contributions-landing/contributionsLandingActions';
 import ContributionErrorMessage from './ContributionErrorMessage';
 import StripePaymentRequestButtonContainer from './StripePaymentRequestButton/StripePaymentRequestButtonContainer';
@@ -69,8 +68,6 @@ type PropTypes = {|
   setPaymentIsWaiting: boolean => void,
   openDirectDebitPopUp: () => void,
   createOneOffPayPalPayment: (data: CreatePaypalPaymentData) => void,
-  setStripeV3HasLoaded: () => void,
-  stripeV3HasLoaded: boolean,
   setCheckoutFormHasBeenSubmitted: () => void,
   onPaymentAuthorisation: PaymentAuthorisation => void,
   userTypeFromIdentityResponse: UserTypeFromIdentityResponse,
@@ -116,7 +113,6 @@ const mapStateToProps = (state: State) => ({
   formIsSubmittable: state.page.form.formIsSubmittable,
   isTestUser: state.page.user.isTestUser || false,
   country: state.common.internationalisation.countryId,
-  stripeV3HasLoaded: state.page.form.stripeV3HasLoaded,
   amazonPayOrderReferenceId: state.page.form.amazonPayData.orderReferenceId,
   checkoutFormHasBeenSubmitted: state.page.form.formData.checkoutFormHasBeenSubmitted,
   referrerSource: state.common.referrerAcquisitionData.source,
@@ -128,7 +124,6 @@ const mapDispatchToProps = (dispatch: Function) => ({
   openDirectDebitPopUp: () => { dispatch(openDirectDebitPopUp()); },
   setCheckoutFormHasBeenSubmitted: () => { dispatch(setCheckoutFormHasBeenSubmitted()); },
   createOneOffPayPalPayment: (data: CreatePaypalPaymentData) => { dispatch(createOneOffPayPalPayment(data)); },
-  setStripeV3HasLoaded: () => { dispatch(setStripeV3HasLoaded()); },
 });
 
 // Bizarrely, adding a type to this object means the type-checking on the
@@ -239,8 +234,6 @@ function withProps(props: PropTypes) {
         />
       </div>
       <StripePaymentRequestButtonContainer
-        setStripeHasLoaded={props.setStripeV3HasLoaded}
-        stripeHasLoaded={props.stripeV3HasLoaded}
         currency={props.currency}
         contributionType={props.contributionType}
         isTestUser={props.isTestUser}
@@ -253,8 +246,6 @@ function withProps(props: PropTypes) {
         <PaymentMethodSelector />
 
         <StripeCardFormContainer
-          setStripeHasLoaded={props.setStripeV3HasLoaded}
-          stripeHasLoaded={props.stripeV3HasLoaded}
           currency={props.currency}
           contributionType={props.contributionType}
           paymentMethod={props.paymentMethod}

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardFormContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardFormContainer.jsx
@@ -21,8 +21,6 @@ type PropTypes = {|
   isTestUser: boolean,
   contributionType: ContributionType,
   paymentMethod: PaymentMethod,
-  setStripeHasLoaded: () => void,
-  stripeHasLoaded: boolean,
 |};
 
 const StripeCardFormContainer = (props: PropTypes) => {

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardFormContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardFormContainer.jsx
@@ -1,19 +1,14 @@
 // @flow
 
 // ----- Imports ----- //
-
-// $FlowIgnore - required for hooks
 import * as React from 'react';
 import { Elements } from '@stripe/react-stripe-js';
-import * as stripeJs from '@stripe/stripe-js';
-
 import StripeCardForm from './StripeCardForm';
-import { getStripeKey, stripeAccountForContributionType, type StripeAccount } from 'helpers/stripe';
+import { getStripeKey, stripeAccountForContributionType, useStripeObjects } from 'helpers/stripe';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import type { IsoCountry } from 'helpers/internationalisation/country';
 import type { ContributionType } from 'helpers/contributions';
 import { type PaymentMethod, Stripe } from 'helpers/paymentMethods';
-import { setupStripe } from 'helpers/stripe';
 import AnimatedDots from 'components/spinners/animatedDots';
 import './stripeCardForm.scss';
 
@@ -31,12 +26,6 @@ type PropTypes = {|
 |};
 
 const StripeCardFormContainer = (props: PropTypes) => {
-  // Create separate Stripe objects for REGULAR and ONE_OFF
-  const [stripeObjects, setStripeObjects] = React.useState<{[StripeAccount]: stripeJs.Stripe | null}>({
-    REGULAR: null,
-    ONE_OFF: null,
-  });
-
   const stripeAccount = stripeAccountForContributionType[props.contributionType];
   const stripeKey = getStripeKey(
     stripeAccount,
@@ -44,18 +33,7 @@ const StripeCardFormContainer = (props: PropTypes) => {
     props.isTestUser,
   );
 
-  React.useEffect(() => {
-    if (!props.stripeHasLoaded) {
-      setupStripe(props.setStripeHasLoaded);
-    } else if (stripeObjects[stripeAccount] === null) {
-
-      stripeJs.loadStripe(stripeKey).then(newStripe =>
-        setStripeObjects(prevData => ({
-          ...prevData,
-          [stripeAccount]: newStripe,
-        })));
-    }
-  }, [props.stripeHasLoaded, props.contributionType]);
+  const stripeObjects = useStripeObjects(stripeAccount, stripeKey);
 
   if (props.paymentMethod === Stripe) {
     if (stripeObjects[stripeAccount]) {

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
@@ -31,8 +31,6 @@ type PropTypes = {|
   currency: IsoCurrency,
   isTestUser: boolean,
   contributionType: ContributionType,
-  setStripeHasLoaded: () => void,
-  stripeHasLoaded: boolean,
   selectedAmounts: SelectedAmounts,
   otherAmounts: OtherAmounts,
 |};

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -169,8 +169,6 @@ const setStripePaymentRequestObject =
   (stripePaymentRequestObject: Object, stripeAccount: StripeAccount): Action =>
     ({ type: 'SET_STRIPE_PAYMENT_REQUEST_OBJECT', stripePaymentRequestObject, stripeAccount });
 
-const setStripeV3HasLoaded = (): Action => ({ type: 'SET_STRIPE_V3_HAS_LOADED' });
-
 const setStripePaymentRequestButtonClicked = (stripeAccount: StripeAccount): Action =>
   ({ type: 'SET_STRIPE_PAYMENT_REQUEST_BUTTON_CLICKED', stripeAccount });
 
@@ -782,7 +780,6 @@ export {
   setStripePaymentRequestObject,
   setStripePaymentRequestButtonClicked,
   setStripePaymentRequestButtonError,
-  setStripeV3HasLoaded,
   setTickerGoalReached,
   setCreateStripePaymentMethod,
   setHandleStripe3DS,

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
@@ -110,7 +110,6 @@ type FormState = {
   selectedAmounts: SelectedAmounts,
   isWaiting: boolean,
   formData: FormData,
-  stripeV3HasLoaded: boolean,
   stripePaymentRequestButtonData: {
     ONE_OFF: StripePaymentRequestButtonData,
     REGULAR: StripePaymentRequestButtonData,
@@ -194,7 +193,6 @@ function createFormReducer() {
       billingCountry: null,
       checkoutFormHasBeenSubmitted: false,
     },
-    stripeV3HasLoaded: false,
     stripePaymentRequestButtonData: {
       ONE_OFF: {
         paymentMethod: null,
@@ -470,12 +468,6 @@ function createFormReducer() {
               paymentError: action.paymentError,
             },
           },
-        };
-
-      case 'SET_STRIPE_V3_HAS_LOADED':
-        return {
-          ...state,
-          stripeV3HasLoaded: true,
         };
 
       case 'UPDATE_USER_FORM_DATA':


### PR DESCRIPTION
## Why are you doing this?
We want to only load stripe with fraud detection if we have the required user consents (fraud detections drops a couple of cookies) as per [this card](https://trello.com/c/Owz6zkeD/2278-stripefraud-ab-test-remove-the-test-and-make-the-fraud-tool-available-only-when-we-get-the-users-consent).
