### PR TITLE
Fix issue with image container overlapping the 'Choose a subscription' button on the support page

### DIFF
--- a/support-frontend/assets/pages/showcase/showcase.scss
+++ b/support-frontend/assets/pages/showcase/showcase.scss
@@ -90,7 +90,10 @@
         right: 0;
         height: 100%;
         float: right;
-        margin-right: -($gu-v-spacing * 1.5)
+        margin-right: -($gu-v-spacing * 1.5);
+        @include mq($until: tablet) {
+          display: none;
+        }
       }
 
       @include mq($from: tablet) {


### PR DESCRIPTION
## Why are you doing this?

This is a bug fix for an issue where the container for the image in the 'Subscribe' section on the support showcase page was still present in the DOM at mobile breakpoints, even when the image is not being shown, and was overlapping the button and breaking its interactivity.
![image](https://user-images.githubusercontent.com/7304387/96451427-76179b00-120f-11eb-8afd-bf2e9091fa7f.png)


## Changes

* Make the image container `display: none` below the tablet breakpoint