### PR TITLE
Don't send an acquisition event for gift redemptions

### DIFF
--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
@@ -58,7 +58,7 @@ class SendAcquisitionEvent(serviceProvider: ServiceProvider = ServiceProvider)
     )
 
     state.product match {
-      case d:DigitalPack if d.readerType == Gift && state.paymentOrRedemptionData.isRight =>
+      case d: DigitalPack if d.readerType == Gift && state.paymentOrRedemptionData.isRight =>
         // We don't want to send an acquisition event for Digital subscription gift redemptions as we have already done so on purchase
         Future.successful(HandlerResult((), requestInfo))
       case _ =>


### PR DESCRIPTION
## Why are you doing this?

We don't want to send the standard acquisition event when a user redeems a gift subscription. This is because we have already sent this event when the gift was originally bought so to send it again would be a duplication.

[**Trello Card**](https://trello.com/c/FfFZ8IEk/3322-update-sendacquisitionevent-lambda-to-ignore-redemptions-1u-25)
