### PR TITLE
Remove second bullet point in end summary for HD paper checkout

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-checkout/components/endSummary/endSummary.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/endSummary/endSummary.jsx
@@ -8,7 +8,7 @@ import { textSans } from '@guardian/src-foundations/typography/obj';
 import { space } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { text, border, background } from '@guardian/src-foundations/palette';
-import { type PaperFulfilmentOptions, HomeDelivery } from 'helpers/productPrice/fulfilmentOptions';
+import { type PaperFulfilmentOptions, Collection } from 'helpers/productPrice/fulfilmentOptions';
 
 const list = css`
   ${from.desktop} {
@@ -71,13 +71,6 @@ function EndSummary({
     </li>
   );
 
-  const homeDeliveryPoint = (
-    <li css={listItem}>
-      <Dot /><div css={listMain}>Choose a start date that suits you</div>
-      <span css={subText}>Your papers will be delivered to your home from the date you&apos;ve chosen</span>
-    </li>
-  );
-
   return (
     <ul css={list}>
       {promotion ? (
@@ -90,7 +83,7 @@ function EndSummary({
           <Dot /><div css={listMain}>You&apos;ll pay {priceDescription}</div>
         </li>
       )}
-      {fulfilmentOption === HomeDelivery ? homeDeliveryPoint : subsCardPoint}
+      {fulfilmentOption === Collection && subsCardPoint}
       <li css={listItem}>
         <Dot /><div css={listMain}>You can cancel any time</div>
       </li>

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/endSummary/endSummary.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/endSummary/endSummary.jsx
@@ -8,6 +8,7 @@ import { textSans } from '@guardian/src-foundations/typography/obj';
 import { space } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { text, border, background } from '@guardian/src-foundations/palette';
+import { type PaperFulfilmentOptions, HomeDelivery } from 'helpers/productPrice/fulfilmentOptions';
 
 const list = css`
   ${from.desktop} {
@@ -57,9 +58,26 @@ type EndSummaryProps = {
   paymentStartDate: string,
   priceDescription: string,
   promotion: string | null,
+  fulfilmentOption: PaperFulfilmentOptions,
 }
 
-function EndSummary({ priceDescription, paymentStartDate, promotion }: EndSummaryProps) {
+function EndSummary({
+  priceDescription, paymentStartDate, promotion, fulfilmentOption,
+}: EndSummaryProps) {
+  const subsCardPoint = (
+    <li css={listItem}>
+      <Dot /><div css={listMain}>Your first payment will be on <span css={bold}>{paymentStartDate}</span></div>
+      <span css={subText}>Your subscription card will arrive in the post before the payment date</span>
+    </li>
+  );
+
+  const homeDeliveryPoint = (
+    <li css={listItem}>
+      <Dot /><div css={listMain}>Choose a start date that suits you</div>
+      <span css={subText}>Your papers will be delivered to your home from the date you&apos;ve chosen</span>
+    </li>
+  );
+
   return (
     <ul css={list}>
       {promotion ? (
@@ -72,10 +90,7 @@ function EndSummary({ priceDescription, paymentStartDate, promotion }: EndSummar
           <Dot /><div css={listMain}>You&apos;ll pay {priceDescription}</div>
         </li>
       )}
-      <li css={listItem}>
-        <Dot /><div css={listMain}>Your first payment will be on <span css={bold}>{paymentStartDate}</span></div>
-        <span css={subText}>Your subscription card will arrive in the post before the payment date</span>
-      </li>
+      {fulfilmentOption === HomeDelivery ? homeDeliveryPoint : subsCardPoint}
       <li css={listItem}>
         <Dot /><div css={listMain}>You can cancel any time</div>
       </li>

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/endSummary/endSummarySelector.js
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/endSummary/endSummarySelector.js
@@ -26,6 +26,7 @@ function mapStateToProps(state: CheckoutState) {
   return {
     priceDescription: getPriceDescription(productPrice, billingPeriod),
     promotion: getPromotion(productPrice),
+    fulfilmentOption,
   };
 }
 

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
@@ -381,9 +381,7 @@ function PaperCheckoutForm(props: PropTypes) {
             errorReason={props.submissionError}
             errorHeading={submissionErrorHeading}
           />
-          {isSubscriptionCard ? (
-            <EndSummaryMobile paymentStartDate={subsCardStartDates.formattedStartDate} />
-          ) : null}
+          <EndSummaryMobile paymentStartDate={subsCardStartDates.formattedStartDate} />
           <DirectDebitPaymentTerms paymentMethod={props.paymentMethod} />
         </Form>
       </Layout>

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
@@ -26,10 +26,7 @@ import Layout, { Content } from 'components/subscriptionCheckouts/layout';
 import type { ErrorReason } from 'helpers/errorReasons';
 import type { ProductPrices } from 'helpers/productPrice/productPrices';
 import { getProductPrice } from 'helpers/productPrice/paperProductPrices';
-import {
-  getShortDescription,
-  getTitle,
-} from '../../paper-subscription-landing/helpers/products';
+import { getTitle } from '../../paper-subscription-landing/helpers/products';
 import { HomeDelivery, Collection } from 'helpers/productPrice/fulfilmentOptions';
 import { titles } from 'helpers/user/details';
 import { formatMachineDate, formatUserDate } from 'helpers/dateConversions';
@@ -172,12 +169,10 @@ function PaperCheckoutForm(props: PropTypes) {
   const collectionOptionDescription = props.useDigitalVoucher ? 'subscription card' : 'vouchers';
   const days = getDays(props.fulfilmentOption, props.productOption);
   const fulfilmentOptionDescriptor = props.fulfilmentOption === HomeDelivery ? 'Paper' : collectionOption;
-  const fulfilmentOptionName = props.fulfilmentOption === HomeDelivery ? 'Home delivery' : collectionOption;
   const deliveryTitle = props.fulfilmentOption === HomeDelivery ? 'Where should we deliver your newspaper?' : `Where should we deliver your ${collectionOptionDescription}?`;
   const submissionErrorHeading = props.submissionError === 'personal_details_incorrect' ? 'Sorry there was a problem' :
     'Sorry we could not process your payment';
   const title = `${getTitle(props.productOption)} ${fulfilmentOptionDescriptor.toLowerCase()}`;
-  const description = getShortDescription(props.productOption);
   const productPrice = getProductPrice(
     props.productPrices,
     props.fulfilmentOption,
@@ -219,14 +214,7 @@ function PaperCheckoutForm(props: PropTypes) {
       />
     }
     title={title}
-    description={description}
     productPrice={productPrice}
-    dataList={[
-      {
-        title: 'Delivery method',
-        value: fulfilmentOptionName,
-      },
-    ]}
     billingPeriod="Monthly"
     changeSubscription={routes.paperSubscriptionDeliveryProductChoices}
     product={Paper}


### PR DESCRIPTION
## Why are you doing this?
We recently updated the paper subscription checkouts to include the new order/end summary for both home delivery and collection options, but missed a bit of text that needed to be removed for the home delivery option. Also, we needed to include the end summary at the bottom of the page for mobile.

This work is just to update that text so it works for HD, and include the end summary on mobile.

Related to https://trello.com/c/OEI7qsZL/3386-post-subs-card-launch-clean-up-minor-post-launch-tweaks
And https://github.com/guardian/support-frontend/pull/2777

## Changes
* Change text of second bullet point in end summary for home delivery so it works for this option
* Include end summary for mobile for HD option

## Screenshots
![Screen Shot 2020-10-20 at 11 39 39](https://user-images.githubusercontent.com/16781258/96575746-11b91200-12c9-11eb-82d3-4da947118db8.png)

![Screen Shot 2020-10-20 at 11 39 58](https://user-images.githubusercontent.com/16781258/96575757-17165c80-12c9-11eb-8299-d88d9f76add6.png)
