### PR TITLE
Update Australia Weekend copy on digital subs landing page

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-landing/components/australianEditions/productBlockAus.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/australianEditions/productBlockAus.jsx
@@ -181,6 +181,10 @@ class ProductBlockAus extends Component<PropTypes, StateTypes> {
                   boldText: 'A new way to read',
                   explainer: 'The weekend paper, reimagined for mobile and tablet. Each new edition available to read Saturday at 6am (AEST)',
                 },
+                {
+                  boldText: 'Start your weekend informed',
+                  explainer: 'Enjoy early access to the best journalism planned for the weekend',
+                },
                 { boldText: 'Easy to navigate', explainer: 'Read the complete edition, or swipe to the sections you care about' },
                 { boldText: 'Read offline', explainer: 'Download and read whenever it suits you' },
               ]}


### PR DESCRIPTION
## Why are you doing this?

This adds an additional bullet point to the copy in the accordion about the Australia Weekend edition now that adjustments to the text have been agreed.

[**Trello Card**](https://trello.com/c/MQAxz6mU)

## Changes

* Add 'Start your weekend informed' bullet point

## Screenshots

**Mobile**
![Screenshot 2020-10-20 at 15 49 02](https://user-images.githubusercontent.com/29146931/96607420-42f90880-12f0-11eb-89bb-a12e3685f308.png)

**Tablet**
![Screenshot 2020-10-20 at 15 54 12](https://user-images.githubusercontent.com/29146931/96607433-45f3f900-12f0-11eb-9161-a479965b4232.png)

**Desktop**
![Screenshot_2020-10-20 Support the Guardian The Guardian Digital Subscription](https://user-images.githubusercontent.com/29146931/96607453-4a201680-12f0-11eb-9a57-81e9ff6625d8.png)