### PR TITLE
Two small improvements to the SendAcquisitionEvent lambda

### DIFF
--- a/support-models/src/main/scala/com/gu/support/workers/PaymentProvider.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/PaymentProvider.scala
@@ -1,21 +1,20 @@
 package com.gu.support.workers
 
-import com.gu.support.redemptions.RedemptionData
 import io.circe.{Decoder, Encoder}
 
-sealed trait PaymentProvider
+sealed abstract class PaymentProvider(val name: String)
 
-case object Stripe extends PaymentProvider
+case object Stripe extends PaymentProvider("Stripe")
 
-case object StripeApplePay extends PaymentProvider
+case object StripeApplePay extends PaymentProvider("StripeApplePay")
 
-case object PayPal extends PaymentProvider
+case object PayPal extends PaymentProvider("PayPal")
 
-case object DirectDebit extends PaymentProvider
+case object DirectDebit extends PaymentProvider("DirectDebit")
 
-case object Existing extends PaymentProvider
+case object Existing extends PaymentProvider("Existing")
 
-case object RedemptionNoProvider extends PaymentProvider
+case object RedemptionNoProvider extends PaymentProvider("Redemption")
 
 object PaymentProvider {
 

--- a/support-services/src/main/scala/com/gu/aws/AwsCloudWatchMetricSetup.scala
+++ b/support-services/src/main/scala/com/gu/aws/AwsCloudWatchMetricSetup.scala
@@ -2,8 +2,7 @@ package com.gu.aws
 
 import com.gu.aws.AwsCloudWatchMetricPut._
 import com.gu.support.config.{Stage, TouchPointEnvironment}
-import com.gu.support.workers.ProductType
-import ophan.thrift.event.PaymentProvider
+import com.gu.support.workers.{PaymentProvider, ProductType}
 
 object AwsCloudWatchMetricSetup {
   def setupWarningRequest(stage: Stage): MetricRequest =
@@ -19,11 +18,11 @@ object AwsCloudWatchMetricSetup {
         MetricDimensionName("Environment") -> MetricDimensionValue(environment.toString)
       ))
 
-  def paymentSuccessRequest(stage: Stage, paymentProvider: Option[PaymentProvider], productType: ProductType): MetricRequest =
+  def paymentSuccessRequest(stage: Stage, paymentProvider: PaymentProvider, productType: ProductType): MetricRequest =
     getMetricRequest(
       MetricName("PaymentSuccess"),
       Map(
-        MetricDimensionName("PaymentProvider") -> MetricDimensionValue(paymentProvider.map(_.name).getOrElse("None")),
+        MetricDimensionName("PaymentProvider") -> MetricDimensionValue(paymentProvider.name),
         MetricDimensionName("ProductType") -> MetricDimensionValue(productType.toString),
         MetricDimensionName("Stage") -> MetricDimensionValue(stage.toString)
       )

--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -218,7 +218,7 @@ Resources:
       Namespace: support-frontend
       Dimensions:
         - Name: PaymentProvider
-          Value: Paypal
+          Value: PayPal
         - Name: ProductType
           Value: Contribution
         - Name: Stage
@@ -277,7 +277,7 @@ Resources:
       Namespace: support-frontend
       Dimensions:
         - Name: PaymentProvider
-          Value: Gocardless
+          Value: DirectDebit
         - Name: ProductType
           Value: Contribution
         - Name: Stage
@@ -336,7 +336,7 @@ Resources:
             Metric:
               Dimensions:
                 - Name: PaymentProvider
-                  Value: Gocardless
+                  Value: DirectDebit
                 - Name: ProductType
                   Value: DigitalPack
                 - Name: Stage
@@ -353,7 +353,7 @@ Resources:
             Metric:
               Dimensions:
                 - Name: PaymentProvider
-                  Value: Paypal
+                  Value: PayPal
                 - Name: ProductType
                   Value: DigitalPack
                 - Name: Stage
@@ -408,7 +408,7 @@ Resources:
             Metric:
               Dimensions:
                 - Name: PaymentProvider
-                  Value: Gocardless
+                  Value: DirectDebit
                 - Name: ProductType
                   Value: Paper
                 - Name: Stage
@@ -425,7 +425,7 @@ Resources:
             Metric:
               Dimensions:
                 - Name: PaymentProvider
-                  Value: Paypal
+                  Value: PayPal
                 - Name: ProductType
                   Value: Paper
                 - Name: Stage

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
@@ -58,7 +58,7 @@ class SendAcquisitionEvent(serviceProvider: ServiceProvider = ServiceProvider)
     )
 
     state.product match {
-      case d:DigitalPack if d.readerType == Gift && state.paymentOrRedemptionData.isRight =>
+      case d: DigitalPack if d.readerType == Gift && state.paymentOrRedemptionData.isRight =>
         // We don't want to send an acquisition event for Digital subscription gift redemptions as we have already done so on purchase
         Future.successful(HandlerResult((), requestInfo))
       case _ =>
@@ -68,19 +68,21 @@ class SendAcquisitionEvent(serviceProvider: ServiceProvider = ServiceProvider)
   }
 
   def sendAcquisitionEvent(state: SendAcquisitionEventState, requestInfo: RequestInfo, services: Services) = {
+    sendPaymentSuccessMetric(state)
+
     // Throw any error in the EitherT monad so that it can be processed by ErrorHandler.handleException
-    val result: Future[HandlerResult[Unit]] = services.acquisitionService.submit(
+    services.acquisitionService.submit(
       SendAcquisitionEventStateAndRequestInfo(state, requestInfo)
     ).fold(
       errors => throw AnalyticsServiceErrorList(errors),
       _ => HandlerResult((), requestInfo)
     )
+  }
 
-    val maybePaymentProvider = state.paymentOrRedemptionData.left.toOption.map(_.paymentMethod).map(paymentProviderFromPaymentMethod)
-    val cloudwatchEvent = paymentSuccessRequest(Configuration.stage, maybePaymentProvider, state.product)
+  def sendPaymentSuccessMetric(state: SendAcquisitionEventState) = {
+    // Used for Cloudwatch alarms: https://github.com/guardian/support-frontend/blob/920e638c35430cc260acdb1878f37bffa1d12fae/support-workers/cloud-formation/src/templates/cfn-template.yaml#L210
+    val cloudwatchEvent = paymentSuccessRequest(Configuration.stage, state.paymentProvider, state.product)
     AwsCloudWatchMetricPut(AwsCloudWatchMetricPut.client)(cloudwatchEvent)
-
-    result
   }
 }
 


### PR DESCRIPTION
## Why are you doing this?

There are a couple of small improvements in this PR

- Add a `name` val to the `PaymentProvider` class rather than relying on `toString` as this is in line with our coding guidelines
- Use this `PaymentProvider` class when firing the `paymentSuccess` Cloudwatch metric rather than the identically named class from Ophan. This allows us to avoid having to deal with an Option and also makes it easier to remove the Thrift dependency in future.
