### PR TITLE
use new name for paymentProvider field

### DIFF
--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala
@@ -81,7 +81,7 @@ class SendAcquisitionEvent(serviceProvider: ServiceProvider = ServiceProvider)
 
   def sendPaymentSuccessMetric(state: SendAcquisitionEventState) = {
     // Used for Cloudwatch alarms: https://github.com/guardian/support-frontend/blob/920e638c35430cc260acdb1878f37bffa1d12fae/support-workers/cloud-formation/src/templates/cfn-template.yaml#L210
-    val cloudwatchEvent = paymentSuccessRequest(Configuration.stage, state.paymentProvider, state.product)
+    val cloudwatchEvent = paymentSuccessRequest(Configuration.stage, state.analyticsInfo.paymentProvider, state.product)
     AwsCloudWatchMetricPut(AwsCloudWatchMetricPut.client)(cloudwatchEvent)
   }
 }


### PR DESCRIPTION
## Why are you doing this?

main support-workers build is broken
```
[error] /Users/john_duffell/code/support-frontend/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendAcquisitionEvent.scala:84:76: value paymentProvider is not a member of com.gu.support.workers.states.SendAcquisitionEventState
[error]     val cloudwatchEvent = paymentSuccessRequest(Configuration.stage, state.paymentProvider, state.product)
```
because of a conflict between #2788 and with this change in #2773  - `paymentProvider` is now grouped with `isGiftPurchase` https://github.com/guardian/support-frontend/pull/2773/files#diff-1f62dcdc137f8cc0b96da16641da83da52faa0b7757b5c7cd4b5df0cb6e41d7eR40
![image](https://user-images.githubusercontent.com/7304387/96720015-20bfc300-13a2-11eb-9846-d44f6f08d3f0.png)
