### PR TITLE
Make the default date for reminders the 15th

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSupportReminder.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSupportReminder.jsx
@@ -96,12 +96,12 @@ const BOTH: ReminderDate = {
 };
 
 const IN_THREE_MONTHS: ReminderDate = {
-  date: new Date(2021, 2),
+  date: new Date(2021, 2, DAY_OF_MONTH_OF_DEFAULT_REMINDER),
   label: 'in three months (March 2021)', // slightly custom copy over default (three vs 3)
 };
 
 const NEXT_US_EOY_APPEAL: ReminderDate = {
-  date: new Date(2021, 11),
+  date: new Date(2021, 11, 1),
   label: 'this time next year (December 2021)',
 };
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSupportReminder.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSupportReminder.jsx
@@ -54,9 +54,11 @@ type ReminderDate = {
   isUsEoyAppealSpecialReminder?: boolean,
 };
 
+const DAY_OF_MONTH_OF_DEFAULT_REMINDER = 15;
+
 const getReminderDateWithDefaultLabel = (monthsUntilDate: number) => {
   const now = new Date();
-  const date = new Date(now.getFullYear(), now.getMonth() + monthsUntilDate);
+  const date = new Date(now.getFullYear(), now.getMonth() + monthsUntilDate, DAY_OF_MONTH_OF_DEFAULT_REMINDER);
 
   const month = date.toLocaleDateString('default', { month: 'long' });
   const year =
@@ -140,7 +142,9 @@ const ContributionThankYouSupportReminder = ({
     const year = selectedDate.getFullYear();
     const month = selectedDate.getMonth() + 1; // javascript dates run from 0-11, we want 1-12
     const paddedMonth = month.toString().padStart(2, '0');
-    return `${year}-${paddedMonth}-01 00:00:00`;
+    const day = selectedDate.getDate();
+    const paddedDay = day.toString().padStart(2, '0');
+    return `${year}-${paddedMonth}-${paddedDay} 00:00:00`;
   };
 
   const setReminder = () => {

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSupportReminder.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSupportReminder.jsx
@@ -101,7 +101,7 @@ const IN_THREE_MONTHS: ReminderDate = {
 };
 
 const NEXT_US_EOY_APPEAL: ReminderDate = {
-  date: new Date(2021, 11, 1),
+  date: new Date(2021, 11, 31),
   label: 'this time next year (December 2021)',
 };
 


### PR DESCRIPTION
## Why are you doing this?

Make the default date for post contribution reminders the 15th of the month, as per [this card](https://trello.com/c/ql304o5j/2361-update-the-post-contribution-reminder-date-to-be-the-15th-of-each-month-from-nov-instead-of-the-1st-to-be-able-to-send-the-email)

**FOLLOW UP**
- manually update reminders after from November onwards to be on the 15th (in braze + contribution_reminders) (BUT NOT THE ONES FOR GIVING TUESDAY)

**NB**: I uncovered a bug whilst implementing this that means all reminders set for the last day of the year were actually set to the 1st of December