### PR TITLE
Remove the `userDigitalVoucher` flag

### DIFF
--- a/support-frontend/app/controllers/PaperSubscription.scala
+++ b/support-frontend/app/controllers/PaperSubscription.scala
@@ -76,7 +76,6 @@ class PaperSubscription(
     ){
       Html(s"""<script type="text/javascript">
       window.guardian.productPrices = ${outputJson(productPrices)}
-      window.guardian.useDigitalVoucher = ${Paper.useDigitalVoucher}
       </script>""")
     }).withSettingsSurrogateKey
   }

--- a/support-frontend/app/views/subscriptionCheckout.scala.html
+++ b/support-frontend/app/views/subscriptionCheckout.scala.html
@@ -67,8 +67,6 @@
 
       window.guardian.checkoutPostcodeLookup = "@settings.switches.experiments.get("checkoutPostcodeLookup").exists(_.isOn)"
 
-      window.guardian.useDigitalVoucher = @{Paper.useDigitalVoucher}
-
       window.guardian.v2recaptchaPublicKey = "@v2recaptchaConfigPublicKey"
 
       window.guardian.recaptchaEnabled = @settings.switches.enableRecaptchaFrontend.isOn

--- a/support-frontend/assets/helpers/globals.js
+++ b/support-frontend/assets/helpers/globals.js
@@ -28,10 +28,8 @@ const emptyAmountsSettings = {
 
 const getSettings = (): Settings => {
   const globalSettings = getGlobal('settings');
-  if (globalSettings) {
-    return { ...globalSettings };
-  }
-  return {
+
+  return globalSettings || {
     switches: {
       experiments: {},
     },

--- a/support-frontend/assets/helpers/globals.js
+++ b/support-frontend/assets/helpers/globals.js
@@ -29,8 +29,7 @@ const emptyAmountsSettings = {
 const getSettings = (): Settings => {
   const globalSettings = getGlobal('settings');
   if (globalSettings) {
-    const useDigitalVoucher = getGlobal('useDigitalVoucher');
-    return { ...globalSettings, useDigitalVoucher };
+    return { ...globalSettings };
   }
   return {
     switches: {
@@ -55,7 +54,6 @@ const getSettings = (): Settings => {
       Canada: [],
     },
     metricUrl: '',
-    useDigitalVoucher: null,
   };
 };
 

--- a/support-frontend/assets/helpers/settings.js
+++ b/support-frontend/assets/helpers/settings.js
@@ -1,7 +1,6 @@
 // @flow
 
 import { type AmountsRegions, type ContributionTypes } from 'helpers/contributions';
-import { type Option } from 'helpers/types/option';
 
 export type Status = 'On' | 'Off';
 
@@ -25,5 +24,4 @@ export type Settings = {
   amounts: AmountsRegions,
   contributionTypes: ContributionTypes,
   metricUrl: string,
-  useDigitalVoucher: Option<boolean>,
 };

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
@@ -164,7 +164,6 @@ const BillingAddress = withStore(newspaperCountries, 'billing', getBillingAddres
 function PaperCheckoutForm(props: PropTypes) {
   const days = getDays(props.fulfilmentOption, props.productOption);
   const isHomeDelivery = props.fulfilmentOption === HomeDelivery;
-  const isSubscard = !isHomeDelivery;
   const fulfilmentOptionDescriptor = isHomeDelivery ? 'Paper' : 'Subscription card';
   const deliveryTitle = isHomeDelivery ? 'Where should we deliver your newspaper?' : 'Where should we deliver your subscription card?';
   const submissionErrorHeading = props.submissionError === 'personal_details_incorrect' ? 'Sorry there was a problem' :
@@ -175,7 +174,7 @@ function PaperCheckoutForm(props: PropTypes) {
     props.fulfilmentOption,
     props.productOption,
   );
-  const subsCardStartDate = isSubscard ?
+  const subsCardStartDate = !isHomeDelivery ?
     getAndSetStartDateForSubsCard(props.productOption, props.setStartDate).formattedStartDate
     : '';
 

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
@@ -27,7 +27,7 @@ import type { ErrorReason } from 'helpers/errorReasons';
 import type { ProductPrices } from 'helpers/productPrice/productPrices';
 import { getProductPrice } from 'helpers/productPrice/paperProductPrices';
 import { getTitle } from '../../paper-subscription-landing/helpers/products';
-import { HomeDelivery, Collection } from 'helpers/productPrice/fulfilmentOptions';
+import { HomeDelivery } from 'helpers/productPrice/fulfilmentOptions';
 import { titles } from 'helpers/user/details';
 import { formatMachineDate, formatUserDate } from 'helpers/dateConversions';
 import {
@@ -67,7 +67,6 @@ import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import { withDeliveryFormIsValid } from 'helpers/subscriptionsForms/formValidation';
 import { setupSubscriptionPayPalPayment } from 'helpers/paymentIntegrations/payPalRecurringCheckout';
 import DirectDebitForm from 'components/directDebit/directDebitProgressiveDisclosure/directDebitForm';
-import { type Option } from 'helpers/types/option';
 import { Paper } from 'helpers/subscriptions';
 import OrderSummary from 'pages/paper-subscription-checkout/components/orderSummary/orderSummary';
 import type { ActivePaperProducts } from 'helpers/productPrice/productOptions';
@@ -97,7 +96,6 @@ type PropTypes = {|
   formIsValid: Function,
   setupRecurringPayPalPayment: Function,
   amount: number,
-  useDigitalVoucher: Option<boolean>,
   productOption: ActivePaperProducts,
   fulfilmentOption: FulfilmentOptions,
 |};
@@ -117,7 +115,6 @@ function mapStateToProps(state: WithDeliveryCheckoutState) {
     csrf: state.page.csrf,
     currencyId: state.common.internationalisation.currencyId,
     payPalHasLoaded: state.page.checkout.payPalHasLoaded,
-    useDigitalVoucher: state.common.settings.useDigitalVoucher,
     amount: getProductPrice(
       state.page.checkout.productPrices,
       state.page.checkout.fulfilmentOption,
@@ -165,11 +162,11 @@ const BillingAddress = withStore(newspaperCountries, 'billing', getBillingAddres
 // ----- Component ----- //
 
 function PaperCheckoutForm(props: PropTypes) {
-  const collectionOption = props.useDigitalVoucher ? 'Subscription card' : 'Voucher booklet';
-  const collectionOptionDescription = props.useDigitalVoucher ? 'subscription card' : 'vouchers';
   const days = getDays(props.fulfilmentOption, props.productOption);
-  const fulfilmentOptionDescriptor = props.fulfilmentOption === HomeDelivery ? 'Paper' : collectionOption;
-  const deliveryTitle = props.fulfilmentOption === HomeDelivery ? 'Where should we deliver your newspaper?' : `Where should we deliver your ${collectionOptionDescription}?`;
+  const isHomeDelivery = props.fulfilmentOption === HomeDelivery;
+  const isSubscard = !isHomeDelivery;
+  const fulfilmentOptionDescriptor = isHomeDelivery ? 'Paper' : 'Subscription card';
+  const deliveryTitle = isHomeDelivery ? 'Where should we deliver your newspaper?' : 'Where should we deliver your subscription card?';
   const submissionErrorHeading = props.submissionError === 'personal_details_incorrect' ? 'Sorry there was a problem' :
     'Sorry we could not process your payment';
   const title = `${getTitle(props.productOption)} ${fulfilmentOptionDescriptor.toLowerCase()}`;
@@ -178,51 +175,48 @@ function PaperCheckoutForm(props: PropTypes) {
     props.fulfilmentOption,
     props.productOption,
   );
-  const isSubscriptionCard = props.useDigitalVoucher && props.fulfilmentOption === Collection;
-  const subsCardStartDates = isSubscriptionCard ?
-    getAndSetStartDateForSubsCard(props.productOption, props.setStartDate) :
-    {
-      subsCardStartDate: '',
-      formattedStartDate: '',
-    };
+  const subsCardStartDate = isSubscard ?
+    getAndSetStartDateForSubsCard(props.productOption, props.setStartDate).formattedStartDate
+    : '';
 
-  const subsCardOrderSummary = (<OrderSummary
-    image={
-      <GridImage
-        gridId="printCampaignDigitalVoucher"
-        srcSizes={[500]}
-        sizes="(max-width: 740px) 50vw, 696"
-        imgType="png"
-        altText=""
-      />}
-    title={title}
-    productPrice={productPrice}
-    billingPeriod="Monthly"
-    changeSubscription={routes.paperSubscriptionProductChoices}
-    productType={Paper}
-    paymentStartDate={subsCardStartDates.formattedStartDate}
-  />);
-
-  const homeDeliveryOrderSummary = (<OrderSummary
-    image={
-      <GridImage
-        gridId="printCampaignHDdigitalVoucher"
-        srcSizes={[500]}
-        sizes="(max-width: 740px) 50vw, 696"
-        imgType="png"
-        altText=""
-      />
-    }
-    title={title}
-    productPrice={productPrice}
-    billingPeriod="Monthly"
-    changeSubscription={routes.paperSubscriptionDeliveryProductChoices}
-    product={Paper}
-  />);
+  const orderSummary = isHomeDelivery ?
+    (<OrderSummary
+      image={
+        <GridImage
+          gridId="printCampaignDigitalVoucher"
+          srcSizes={[500]}
+          sizes="(max-width: 740px) 50vw, 696"
+          imgType="png"
+          altText=""
+        />
+      }
+      title={title}
+      productPrice={productPrice}
+      billingPeriod="Monthly"
+      changeSubscription={routes.paperSubscriptionDeliveryProductChoices}
+      product={Paper}
+    />)
+    :
+    (<OrderSummary
+      image={
+        <GridImage
+          gridId="printCampaignHDdigitalVoucher"
+          srcSizes={[500]}
+          sizes="(max-width: 740px) 50vw, 696"
+          imgType="png"
+          altText=""
+        />}
+      title={title}
+      productPrice={productPrice}
+      billingPeriod="Monthly"
+      changeSubscription={routes.paperSubscriptionProductChoices}
+      productType={Paper}
+      paymentStartDate={subsCardStartDate}
+    />);
 
   return (
     <Content modifierClasses={['your-details']}>
-      <Layout aside={isSubscriptionCard ? subsCardOrderSummary : homeDeliveryOrderSummary}>
+      <Layout aside={orderSummary}>
         <Form onSubmit={(ev) => {
           ev.preventDefault();
           props.submitForm();
@@ -255,7 +249,7 @@ function PaperCheckoutForm(props: PropTypes) {
           <FormSection title={deliveryTitle}>
             <DeliveryAddress />
             {
-              props.fulfilmentOption === HomeDelivery ?
+              isHomeDelivery ?
                 <TextAreaWithLabel
                   id="delivery-instructions"
                   label="Delivery instructions"
@@ -298,7 +292,7 @@ function PaperCheckoutForm(props: PropTypes) {
               </FormSection>
               : null
           }
-          {!isSubscriptionCard ? (
+          {isHomeDelivery ? (
             <FormSection title="When would you like your subscription to start?">
               <Rows>
                 <FieldsetWithError
@@ -381,7 +375,7 @@ function PaperCheckoutForm(props: PropTypes) {
             errorReason={props.submissionError}
             errorHeading={submissionErrorHeading}
           />
-          <EndSummaryMobile paymentStartDate={subsCardStartDates.formattedStartDate} />
+          <EndSummaryMobile paymentStartDate={subsCardStartDate} />
           <DirectDebitPaymentTerms paymentMethod={props.paymentMethod} />
         </Form>
       </Layout>

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/thankYou.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/thankYou.jsx
@@ -33,7 +33,6 @@ import { type FormFields, getFormFields } from 'helpers/subscriptionsForms/formF
 type PropTypes = {
     ...FormFields,
     isPending: boolean,
-    useDigitalVoucher: boolean,
 };
 
 // ----- Map State/Props ----- //
@@ -41,39 +40,29 @@ type PropTypes = {
 function mapStateToProps(state: WithDeliveryCheckoutState) {
   return {
     ...getFormFields(state),
-    useDigitalVoucher: state.common.settings.useDigitalVoucher,
   };
 }
 
 // ----- Component ----- //
 
-const whatNextText: { [FulfilmentOptions]: { [key: string]: Array<string> } } = {
-  [HomeDelivery]: {
-    default: [
-      `Look out for an email from us confirming your subscription.
-        It has everything you need to know about how manage it in the future.`,
-      'Your newspaper will be delivered to your door.',
-    ],
-  },
-  [Collection]: {
-    default: [
-      `Look out for an email from us confirming your subscription.
-        It has everything you need to know about how to manage it in the future.`,
-      'You will receive your personalised book of vouchers.',
-      'Exchange your voucher for a newspaper at your newsagent or wherever you buy your paper',
-    ],
-    digitalVoucher: [
-      `Keep an eye on your inbox. You should receive an email confirming the details of your subscription,
-        and another email shortly afterwards that contains details of how you can pick up your papers from tomorrow!`,
-      `You will receive your Subscription Card in your subscriber pack in the post, along with your home
-        delivery letter.`,
-      `Visit your chosen participating newsagent to pick up your paper using your Subscription Card, or
-        arrange a home delivery using your delivery letter.`,
-    ],
-  },
+const whatNextText: { [FulfilmentOptions]: Array<string> } = {
+  [HomeDelivery]: [
+    `Look out for an email from us confirming your subscription.
+      It has everything you need to know about how manage it in the future.`,
+    'Your newspaper will be delivered to your door.',
+  ],
+  [Collection]: [
+    `Keep an eye on your inbox. You should receive an email confirming the details of your subscription,
+      and another email shortly afterwards that contains details of how you can pick up your papers from tomorrow!`,
+    `You will receive your Subscription Card in your subscriber pack in the post, along with your home
+      delivery letter.`,
+    `Visit your chosen participating newsagent to pick up your paper using your Subscription Card, or
+      arrange a home delivery using your delivery letter.`,
+  ],
 };
 
-function whatNextElement(textItems) {
+function WhatNext(fulfilmentOption) {
+  const textItems = whatNextText[fulfilmentOption];
   return (
     <Text title="What happens next?">
       <p>
@@ -83,19 +72,11 @@ function whatNextElement(textItems) {
   );
 }
 
-function WhatNext(fulfilmentOption, useDigitalVoucher = false) {
-  let textItems = whatNextText[fulfilmentOption].default;
-  if (fulfilmentOption === Collection && useDigitalVoucher) {
-    textItems = whatNextText[Collection].digitalVoucher;
-  }
-  return whatNextElement(textItems);
-}
-
 
 function ThankYouContent({
-  fulfilmentOption, productOption, startDate, isPending, product, useDigitalVoucher,
+  fulfilmentOption, productOption, startDate, isPending, product,
 }: PropTypes) {
-  const hideStartDate = fulfilmentOption === Collection && useDigitalVoucher;
+  const hideStartDate = fulfilmentOption === Collection;
   return (
     <div className="thank-you-stage">
       <HeroWrapper appearance="custom" className={styles.hero}>
@@ -126,7 +107,7 @@ function ThankYouContent({
             <LargeParagraph>{formatUserDate(new Date(startDate))}</LargeParagraph>
           </Text>
         }
-        {WhatNext(fulfilmentOption, useDigitalVoucher)}
+        {WhatNext(fulfilmentOption)}
       </Content>
       <Content>
         <Text>

--- a/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckout.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckout.jsx
@@ -47,8 +47,6 @@ const store = pageInit(
   true,
 );
 
-const { useDigitalVoucher } = store.getState().common.settings;
-
 // ----- Render ----- //
 
 const content = (
@@ -60,7 +58,7 @@ const content = (
           faqsLink="https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions"
           termsConditionsLink="https://www.theguardian.com/subscriber-direct/subscription-terms-and-conditions"
         >
-          {useDigitalVoucher &&
+          {
             <p>By proceeding, you agree to our{' '}
               <a href="https://www.theguardian.com/subscriber-direct/subscription-terms-and-conditions">Terms &amp; Conditions</a>.{' '}
               We will share your contact and subscription details with our fulfilment partners to provide you with your subscription card.{' '}

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/content.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/content.jsx
@@ -12,7 +12,6 @@ import { setTab, type TabActions } from '../../paperSubscriptionLandingPageActio
 import { type ContentPropTypes } from './helpers';
 import DeliveryTab from './deliveryTab';
 import SubscriptionCardTab from './subsCardTab';
-import CollectionTab from './collectionTab';
 import './content.scss';
 import { Collection } from 'helpers/productPrice/fulfilmentOptions';
 
@@ -32,23 +31,18 @@ class Content extends Component<ContentPropTypes> {
   tabRef: ?HTMLElement;
 
   render() {
-    const { selectedTab, setTabAction, useDigitalVoucher } = this.props;
+    const { selectedTab, setTabAction } = this.props;
 
     if (selectedTab === Collection) {
-      return useDigitalVoucher
-        ? <SubscriptionCardTab
+      return (
+        <SubscriptionCardTab
           {...{ selectedTab, setTabAction }}
           getRef={(r) => { if (r) { this.tabRef = r; } }}
-        />
-
-        : <CollectionTab
-          {...{ selectedTab, setTabAction }}
-          getRef={(r) => { if (r) { this.tabRef = r; } }}
-        />;
+        />);
     }
     return (
       <DeliveryTab
-        {...{ selectedTab, setTabAction, useDigitalVoucher }}
+        {...{ selectedTab, setTabAction }}
         getRef={(r) => { if (r) { this.tabRef = r; } }}
       />);
   }
@@ -59,7 +53,6 @@ class Content extends Component<ContentPropTypes> {
 
 const mapStateToProps = (state: State) => ({
   selectedTab: state.page.tab,
-  useDigitalVoucher: state.common.settings.useDigitalVoucher,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch<TabActions>) =>

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/deliveryTab.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/deliveryTab.jsx
@@ -19,7 +19,6 @@ import { css } from '@emotion/core';
 import { neutral } from '@guardian/src-foundations/palette';
 import { textSans } from '@guardian/src-foundations/typography';
 import { space } from '@guardian/src-foundations';
-import { type Option } from 'helpers/types/option';
 
 export const accordionContainer = css`
   background-color: ${neutral['97']};
@@ -38,8 +37,7 @@ export const accordionContainer = css`
 // ----- Content ----- //
 const ContentDeliveryFaqBlock = ({
   setTabAction,
-  useDigitalVoucher,
-}: {setTabAction: typeof setTab, useDigitalVoucher?: Option<boolean>}) => (
+}: {setTabAction: typeof setTab}) => (
   <Content
     border={paperHasDeliveryEnabled()}
     image={<GridImage
@@ -52,7 +50,7 @@ const ContentDeliveryFaqBlock = ({
   >
     <Text>
       If you live in Greater London (within the M25), you can use The Guardian’s home delivery
-      service. If not, you can use our <LinkTo tab={Collection} setTabAction={setTabAction}>{useDigitalVoucher ? 'subscription cards' : 'voucher scheme'}</LinkTo>.
+      service. If not, you can use our <LinkTo tab={Collection} setTabAction={setTabAction}>subscription cards</LinkTo>.
     </Text>
     <Text>
       Select your subscription below and checkout. You&apos;ll receive your first newspaper
@@ -81,24 +79,19 @@ const ContentDeliveryFaqBlock = ({
 
 );
 
-ContentDeliveryFaqBlock.defaultProps = {
-  useDigitalVoucher: null,
-};
-
 const DeliveryTab = ({
-  getRef, setTabAction, selectedTab, useDigitalVoucher,
+  getRef, setTabAction, selectedTab,
 }: ContentTabPropTypes) => (
   <div
     className="paper-subscription-landing-content__focusable"
     tabIndex={-1}
     ref={(r) => { getRef(r); }}
   >
-    <ContentDeliveryFaqBlock setTabAction={setTabAction} useDigitalVoucher={useDigitalVoucher} />
+    <ContentDeliveryFaqBlock setTabAction={setTabAction} />
     <ContentForm
       selectedTab={selectedTab}
       setTabAction={setTabAction}
       title="Pick your home delivery subscription package below"
-      useDigitalVoucher={useDigitalVoucher}
     />
   </div>
 );

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/helpers.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/helpers.jsx
@@ -23,7 +23,6 @@ import InfoSvg from './info.svg';
 export type ContentPropTypes = {|
   selectedTab: ActiveTabState,
   setTabAction: typeof setTab,
-  useDigitalVoucher?: Option<boolean>,
 |};
 
 export type ContentTabPropTypes = {|
@@ -75,13 +74,12 @@ const LinkTo = ({
 );
 
 const ContentForm = ({
-  title, text, setTabAction, selectedTab, useDigitalVoucher,
+  title, text, setTabAction, selectedTab,
 }: {|
   title: string,
   text?: Option<string>,
   selectedTab: ActiveTabState,
   setTabAction: typeof setTab,
-  useDigitalVoucher?: Option<boolean>,
 |}) => (
   <Content id="subscribe" border={false}>
     <Text
@@ -100,7 +98,7 @@ const ContentForm = ({
             selectedTab === Collection ?
               <LinkTo tab={HomeDelivery} setTabAction={setTabAction}>Switch to Delivery</LinkTo> :
               <LinkTo tab={Collection} setTabAction={setTabAction}>
-                  Switch to {useDigitalVoucher ? 'Subscription card' : 'Vouchers'}
+                  Switch to Subscription card
               </LinkTo>
           }
         </SansParagraph>
@@ -111,6 +109,6 @@ const ContentForm = ({
     </ProductPageInfoChip>
   </Content>
 );
-ContentForm.defaultProps = { text: null, useDigitalVoucher: null };
+ContentForm.defaultProps = { text: null };
 
 export { LinkTo, ContentForm };

--- a/support-frontend/assets/pages/paper-subscription-landing/components/tabs.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/tabs.jsx
@@ -13,7 +13,6 @@ import { paperSubsUrl } from 'helpers/routes';
 import { type State } from '../paperSubscriptionLandingPageReducer';
 import { setTab, type TabActions } from '../paperSubscriptionLandingPageActions';
 import type { PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
-import { type Option } from 'helpers/types/option';
 
 // ----- Tabs ----- //
 
@@ -40,21 +39,11 @@ type DispatchPropTypes = {|
 type PropTypes = {|
   ...StatePropTypes,
   ...DispatchPropTypes,
-  useDigitalVoucher: Option<boolean>,
 |};
-
-// This is a temporary workaround while we have both iMovo and vouchers
-// We can get rid of this when we drop vouchers
-const getTabTitle = (useDigitalVoucher, fulfilmentMethod) => {
-  if (fulfilmentMethod === 'HomeDelivery' || useDigitalVoucher) {
-    return tabs[fulfilmentMethod].name;
-  }
-  return 'Voucher Booklet';
-};
 
 // ----- Component ----- //
 
-function Tabs({ selectedTab, setTabAction, useDigitalVoucher }: PropTypes) {
+function Tabs({ selectedTab, setTabAction }: PropTypes) {
   return (
     <Outset>
       <ProductPageTabs
@@ -63,7 +52,7 @@ function Tabs({ selectedTab, setTabAction, useDigitalVoucher }: PropTypes) {
         tabs={Object.keys(tabs).map(fulfilmentMethod => ({
           // The following line is a workaround for iMovo and vouchers
           // Once we drop vouchers, we can reinstate: name: tabs[fulfilmentMethod].name,
-        name: getTabTitle(useDigitalVoucher, fulfilmentMethod),
+        name: tabs[fulfilmentMethod].name,
         href: tabs[fulfilmentMethod].href,
       }))}
       />
@@ -75,7 +64,6 @@ function Tabs({ selectedTab, setTabAction, useDigitalVoucher }: PropTypes) {
 
 const mapStateToProps = (state: State) => ({
   selectedTab: Object.keys(tabs).indexOf(state.page.tab),
-  useDigitalVoucher: state.common.settings.useDigitalVoucher,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch<TabActions>) =>

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
@@ -35,8 +35,6 @@ const reactElementId = 'paper-subscription-landing-page';
 // ----- Redux Store ----- //
 
 const store = pageInit(() => reducer(fulfilment), true);
-const state = store.getState();
-const { useDigitalVoucher } = state.common.settings;
 
 const paperSubsFooter = (
   <Footer
@@ -57,9 +55,7 @@ const content = (
         <Content needsHigherZindex innerBackground="grey">
           <Text>
             <LargeParagraph>
-              {!useDigitalVoucher
-              ? 'We offer two different subscription types: voucher booklets and home delivery'
-              : 'We offer two different subscription types: subscription cards and home delivery. Pick the most convenient option available in your area.'}
+              {'We offer two different subscription types: subscription cards and home delivery. Pick the most convenient option available in your area.'}
             </LargeParagraph>
           </Text>
           <Tabs />

--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
@@ -55,7 +55,8 @@ const content = (
         <Content needsHigherZindex innerBackground="grey">
           <Text>
             <LargeParagraph>
-              {'We offer two different subscription types: subscription cards and home delivery. Pick the most convenient option available in your area.'}
+              We offer two different subscription types: subscription cards and home delivery.
+              Pick the most convenient option available in your area.
             </LargeParagraph>
           </Text>
           <Tabs />

--- a/support-models/src/main/scala/com/gu/support/catalog/Product.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/Product.scala
@@ -90,9 +90,7 @@ case object Paper extends Product {
   private def homeDelivery(productRatePlanId: ProductRatePlanId, productOptions: ProductOptions, description: String): ProductRatePlan[Paper.type] =
     ProductRatePlan(productRatePlanId, Monthly, HomeDelivery, productOptions, description, List(CountryGroup.UK))
 
-  val useDigitalVoucher = true
-
-  private val prodCollection: List[ProductRatePlan[Paper.type]] = if (useDigitalVoucher) {
+  private val prodCollection: List[ProductRatePlan[Paper.type]] =
     List(
       collection("2c92a00870ec598001710740ce702ff0", SaturdayPlus, "Voucher Saturday+"),
       collection("2c92a00870ec598001710740cdd02fbd", Saturday, "Voucher Saturday"),
@@ -105,22 +103,8 @@ case object Paper extends Product {
       collection("2c92a00870ec598001710740d3d03035", EverydayPlus, "Voucher Everyday+"),
       collection("2c92a00870ec598001710740c78d2f13", Everyday, "Voucher Everyday")
     )
-  } else {
-    List(
-      collection("2c92a0fd6205707201621fa1350710e3", SaturdayPlus, "Voucher Saturday+"),
-      collection("2c92a0fd6205707201621f9f6d7e0116", Saturday, "Voucher Saturday"),
-      collection("2c92a0fe56fe33ff0157040d4b824168", SundayPlus, "Voucher Sunday+"),
-      collection("2c92a0fe5af9a6b9015b0fe1ecc0116c", Sunday, "Voucher Sunday"),
-      collection("2c92a0fd56fe26b60157040cdd323f76", WeekendPlus, "Voucher Weekend+"),
-      collection("2c92a0ff56fe33f00157040f9a537f4b", Weekend, "Voucher Weekend"),
-      collection("2c92a0fc56fe26ba0157040c5ea17f6a", SixdayPlus, "Voucher Sixday+"),
-      collection("2c92a0fd56fe270b0157040e42e536ef", Sixday, "Voucher Sixday"),
-      collection("2c92a0ff56fe33f50157040bbdcf3ae4", EverydayPlus, "Voucher Everyday+"),
-      collection("2c92a0fd56fe270b0157040dd79b35da", Everyday, "Voucher Everyday")
-    )
-  }
 
-  private val uatCollection: List[ProductRatePlan[Paper.type]] = if (useDigitalVoucher) {
+  private val uatCollection: List[ProductRatePlan[Paper.type]] =
     List(
       collection("2c92c0f870f682820171070489d542da", SaturdayPlus, "Voucher Saturday+"),
       collection("2c92c0f870f682820171070488df42ce", Saturday, "Voucher Saturday"),
@@ -133,22 +117,8 @@ case object Paper extends Product {
       collection("2c92c0f870f682820171070481bf4264", EverydayPlus, "Voucher Everyday+"),
       collection("2c92c0f870f682820171070474ee419d", Everyday, "Voucher Everyday"),
     )
-  } else {
-    List(
-      collection("2c92c0f961f9cf350161fc0454283f3e", SaturdayPlus, "Voucher Saturday+"),
-      collection("2c92c0f961f9cf300161fc02a7d805c9", Saturday, "Voucher Saturday"),
-      collection("2c92c0f858aa38af0158b9dae19110a3", SundayPlus, "Voucher Sunday+"),
-      collection("2c92c0f95aff3b54015b0ee0eb500b2e", Sunday, "Voucher Sunday"),
-      collection("2c92c0f855c9f4b20155d9f1dd0651ab", WeekendPlus, "Voucher Weekends+"),
-      collection("2c92c0f855c9f4b20155d9f1db9b5199", Weekend, "Voucher Weekend"),
-      collection("2c92c0f855c9f4540155da2607db6402", SixdayPlus, "Voucher Sixday+"),
-      collection("2c92c0f955ca02910155da254a641fb3", Sixday, "Voucher Sixday"),
-      collection("2c92c0f955ca02920155da240cdb4399", EverydayPlus, "Voucher Everyday+"),
-      collection("2c92c0f855c9f4b20155d9f1d3d4512a", Everyday, "Voucher Everyday"),
-    )
-  }
 
-  private val sandboxCollection: List[ProductRatePlan[Paper.type]] = if (useDigitalVoucher) {
+  private val sandboxCollection: List[ProductRatePlan[Paper.type]] =
     List(
       collection("2c92c0f86fa49142016fa49eb1732a39", SaturdayPlus, "Voucher Saturday paper+"),
       collection("2c92c0f86fa49142016fa49ea442291b", Saturday, "Voucher Saturday paper"),
@@ -161,20 +131,6 @@ case object Paper extends Product {
       collection("2c92c0f86fa49142016fa49eaa492988", EverydayPlus, "Voucher Everyday+"),
       collection("2c92c0f86fa49142016fa49ea56a2938", Everyday, "Voucher Everyday"),
     )
-  } else {
-    List(
-      collection("2c92c0f961f9cf300161fc44f2661258", SaturdayPlus, "Voucher Saturday paper+"),
-      collection("2c92c0f861f9c26d0161fc434bfe004c", Saturday, "Voucher Saturday paper"),
-      collection("2c92c0f955a0b5bf0155b62623846fc8", SundayPlus, "Voucher Sunday paper+"),
-      collection("2c92c0f95aff3b56015b1045fb9332d2", Sunday, "Voucher Sunday paper"),
-      collection("2c92c0f95aff3b54015b1047efaa2ac3", WeekendPlus, "Voucher Weekend+"),
-      collection("2c92c0f8555ce5cf01556e7f01b81b94", Weekend, "Voucher Weekend"),
-      collection("2c92c0f855c3b8190155c585a95e6f5a", SixdayPlus, "Voucher Sixday+"),
-      collection("2c92c0f8555ce5cf01556e7f01771b8a", Sixday, "Voucher Sixday"),
-      collection("2c92c0f95aff3b53015b10469bbf5f5f", EverydayPlus, "Voucher Everyday+"),
-      collection("2c92c0f9555cf10501556e84a70440e2", Everyday, "Voucher Everyday"),
-    )
-  }
 
   lazy val ratePlans: Map[TouchPointEnvironment, List[ProductRatePlan[Paper.type]]] =
     Map(

--- a/support-workers/src/main/scala/com/gu/emailservices/PaperEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/PaperEmailFields.scala
@@ -20,7 +20,7 @@ class PaperEmailFields(
 
     val dataExtension: String = paper.product.fulfilmentOptions match {
       case HomeDelivery => "paper-delivery"
-      case _ => if (Paper.useDigitalVoucher) "paper-subscription-card" else "paper-voucher"
+      case _ => "paper-subscription-card"
     }
 
     paperFieldsGenerator.fieldsFor(


### PR DESCRIPTION
## Why are you doing this?

Now that Subscription Card (AKA digital voucher or iMovo) is live we no longer need a flag for whether to use it or not. This PR removes that flag.

[**Trello Card**](https://trello.com/c/qMSYti7t/3400-post-subs-card-launch-remove-usedigitalvoucher-switch)


### NB. Do not merge until after discussion with SX on Dec 10th