### PR TITLE
Special US election thank you page

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -7,6 +7,7 @@ import { USV1, AusAmounts, UkAmountsV1 } from './data/testAmountsData';
 const usOnlyLandingPage = '/us/contribute(/.*)?$';
 const auOnlyLandingPage = '/au/contribute(/.*)?$';
 const ukOnlyLandingPage = '/uk/contribute(/.*)?$';
+const usThankYouAndLandingPages = '/us/(thankyou|contribute)(/.*)?$';
 export const subsShowcaseAndDigiSubPages = '(/??/subscribe(\\?.*)?$|/??/subscribe/digital(\\?.*)?$)';
 
 export const tests: Tests = {
@@ -77,5 +78,27 @@ export const tests: Tests = {
     referrerControlled: false,
     targetPage: ukOnlyLandingPage,
     seed: 9,
+  },
+
+  usElectionNewsletter: {
+    type: 'OTHER',
+    variants: [
+      {
+        id: 'control',
+      },
+      {
+        id: 'showNewsletter',
+      },
+    ],
+    audiences: {
+      ALL: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: true,
+    referrerControlled: false,
+    targetPage: usThankYouAndLandingPages,
+    seed: 10,
   },
 };

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
@@ -20,6 +20,7 @@ import ContributionThankYouSupportReminder from './ContributionThankYouSupportRe
 import ContributionThankYouSurvey from './ContributionThankYouSurvey';
 import ContributionThankYouSocialShare from './ContributionThankYouSocialShare';
 import ContributionThankYouAusMap from './ContributionThankYouAusMap';
+import ContributionThankYouUsElectionNewsletter from './ContributionThankYouUsElectionNewsletter';
 import { trackUserData, OPHAN_COMPONENT_ID_RETURN_TO_GUARDIAN } from './utils/ophan';
 import { trackComponentClick } from 'helpers/tracking/behaviour';
 import { getCampaignSettings } from 'helpers/campaigns';
@@ -115,6 +116,7 @@ type ContributionThankYouProps = {|
   paymentMethod: PaymentMethod,
   countryId: IsoCountry,
   campaignCode: ?string,
+  shouldShowUsElectionNewsletter: boolean,
 |};
 
 const mapStateToProps = state => ({
@@ -127,6 +129,7 @@ const mapStateToProps = state => ({
   paymentMethod: state.page.form.paymentMethod,
   countryId: state.common.internationalisation.countryId,
   campaignCode: state.common.referrerAcquisitionData.campaignCode,
+  shouldShowUsElectionNewsletter: state.common.abParticipations.usElectionNewsletter === 'showNewsletter',
 });
 
 const ContributionThankYou = ({
@@ -139,6 +142,7 @@ const ContributionThankYou = ({
   paymentMethod,
   countryId,
   campaignCode,
+  shouldShowUsElectionNewsletter,
 }: ContributionThankYouProps) => {
   const isKnownEmail = guestAccountCreationToken === null;
   const campaignSettings = useMemo<CampaignSettings | null>(() => getCampaignSettings(campaignCode));
@@ -192,12 +196,17 @@ const ContributionThankYou = ({
     component: <ContributionThankYouAusMap />,
     shouldShow: countryId === 'AU',
   };
+  const usElectionNewsLetter = {
+    component: <ContributionThankYouUsElectionNewsletter email={email} />,
+    shouldShow: shouldShowUsElectionNewsletter,
+  };
 
   const defaultActions = [
     signUpAction,
     signInAction,
     marketingConsentAction,
     supportReminderAction,
+    usElectionNewsLetter,
     surveyAction,
     socialShareAction,
   ];

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouUsElectionNewsletter.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouUsElectionNewsletter.jsx
@@ -32,7 +32,7 @@ type ContributionThankYouUsElectionNewsletterProps = {|
   email: string
 |};
 
-const ContributionThankYouUsElectionNewsletternsent = ({
+const ContributionThankYouUsElectionNewsletter = ({
   email,
 }: ContributionThankYouUsElectionNewsletterProps) => {
   const [hasBeenCompleted, setHasBeenCompleted] = useState(false);
@@ -92,4 +92,4 @@ const ContributionThankYouUsElectionNewsletternsent = ({
   );
 };
 
-export default ContributionThankYouUsElectionNewsletternsent;
+export default ContributionThankYouUsElectionNewsletter;

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouUsElectionNewsletter.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouUsElectionNewsletter.jsx
@@ -19,7 +19,7 @@ const buttonContainer = css`
 const signUpToNewsLetter = (email: string) => {
   const formData = new FormData();
   formData.append('email', email);
-  formData.append('listName', 'minute-us');
+  formData.append('listName', 'us-morning-newsletter');
   formData.append('name', '');
 
   fetch('https://www.theguardian.com/email', {

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouUsElectionNewsletter.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouUsElectionNewsletter.jsx
@@ -1,0 +1,95 @@
+// @flow
+// $FlowIgnore - required for hooks
+import React, { useState } from 'react';
+import { css } from '@emotion/core';
+import { space } from '@guardian/src-foundations';
+import { Button } from '@guardian/src-button';
+import { SvgArrowRightStraight } from '@guardian/src-icons';
+import ActionContainer from './components/ActionContainer';
+import ActionHeader from './components/ActionHeader';
+import ActionBody from './components/ActionBody';
+import SvgNotification from './components/SvgNotification';
+import { OPHAN_COMPONENT_ID_US_ELECTION_NEWSLETTER } from './utils/ophan';
+import { trackComponentClick } from 'helpers/tracking/behaviour';
+
+const buttonContainer = css`
+  margin-top: ${space[6]}px;
+`;
+
+const signUpToNewsLetter = (email: string) => {
+  const formData = new FormData();
+  formData.append('email', email);
+  formData.append('listName', 'minute-us');
+  formData.append('name', '');
+
+  fetch('https://www.theguardian.com/email', {
+    method: 'POST',
+    body: new URLSearchParams(formData),
+  });
+};
+
+type ContributionThankYouUsElectionNewsletterProps = {|
+  email: string
+|};
+
+const ContributionThankYouUsElectionNewsletternsent = ({
+  email,
+}: ContributionThankYouUsElectionNewsletterProps) => {
+  const [hasBeenCompleted, setHasBeenCompleted] = useState(false);
+
+  const onSubmit = () => {
+    trackComponentClick(OPHAN_COMPONENT_ID_US_ELECTION_NEWSLETTER);
+    setHasBeenCompleted(true);
+    signUpToNewsLetter(email);
+  };
+
+  const actionIcon = <SvgNotification />;
+  const actionHeader = (
+    <ActionHeader
+      title={
+        hasBeenCompleted ? 'You\'re signed up' : 'First Thing: election special'
+      }
+    />
+  );
+  const actionBody = (
+    <ActionBody>
+      {hasBeenCompleted ? (
+        <p>
+          Please check your inbox for a confirmation link. Soon after, you’ll
+          receive your first email from the Guardian newsroom. You can
+          unsubscribe at any time.
+        </p>
+      ) : (
+        <>
+          <p>
+            With First Thing, our morning newsletter, you get a global
+            perspective on America delivered to your inbox. Until 3 November,
+            we&apos;ll be focusing on the latest in the presidential race.
+          </p>
+          <div css={buttonContainer}>
+            <Button
+              onClick={onSubmit}
+              priority="primary"
+              size="default"
+              icon={<SvgArrowRightStraight />}
+              iconSide="right"
+              nudgeIcon
+            >
+              Sign up to the newsletter
+            </Button>
+          </div>
+        </>
+      )}
+    </ActionBody>
+  );
+
+  return (
+    <ActionContainer
+      icon={actionIcon}
+      header={actionHeader}
+      body={actionBody}
+    />
+  );
+};
+
+export default ContributionThankYouUsElectionNewsletternsent;

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/utils/ophan.js
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/utils/ophan.js
@@ -7,6 +7,7 @@ export const OPHAN_COMPONENT_ID_SIGN_IN = 'sign-into-the-guardian-link';
 export const OPHAN_COMPONENT_ID_SIGN_UP = 'set-password';
 export const OPHAN_COMPONENT_ID_SET_REMINDER = 'reminder-test-link-clicked';
 export const OPHAN_COMPONENT_ID_MARKETING = 'marketing-permissions';
+export const OPHAN_COMPONENT_ID_US_ELECTION_NEWSLETTER = 'contribution-thankyou-us-election-newsletter';
 export const OPHAN_COMPONENT_ID_SURVEY = 'contribution-thankyou-survey';
 export const OPHAN_COMPONENT_ID_SOCIAL_FACEBOOK =
   'contribution-thankyou-social-facebook';


### PR DESCRIPTION
## Why are you doing this?

Implement the special US election thank you page newsletter sign up as an ab test. As per [this card](https://trello.com/c/e65OkQs6/2365-us-election-special-thank-you-page).

## Screenshots
desktop:
<img width="641" alt="Screenshot 2020-10-27 at 11 37 24" src="https://user-images.githubusercontent.com/17720442/97296954-4a1c9b00-1849-11eb-9df6-e04cd2390464.png">

mobile: 
<img width="418" alt="Screenshot 2020-10-27 at 11 38 31" src="https://user-images.githubusercontent.com/17720442/97296968-4f79e580-1849-11eb-9292-725484323038.png">



