### PR TITLE
make the gift date tests more determinstic

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-checkout/components/datePicker/datePicker.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/datePicker/datePicker.jsx
@@ -99,14 +99,15 @@ class DatePickerFields extends Component<PropTypes, StateTypes> {
 
   checkDateIsValid = (e: Object) => {
     e.preventDefault();
+    const now = new Date();
     const date = new Date(this.getDateString());
     const dateIsNotADate = !DateUtils.isDate(date);
-    const latestAvailableDate = getLatestAvailableDateText();
+    const latestAvailableDate = getLatestAvailableDateText(now);
 
     this.setState({ dateValidated: true, dateError: '' });
     if (dateIsNotADate) {
       this.handleError('No date has been selected as the date is not valid. Please try again');
-    } else if (dateIsOutsideRange(date)) {
+    } else if (dateIsOutsideRange(date, now)) {
       this.handleError(`No date has been recorded as the date entered was not available. Please enter a date up to ${latestAvailableDate}`);
     } else if (dateIsPast(date)) {
       this.handleError(`No date has been recorded as the date was in the past. Please enter a date between today and ${latestAvailableDate}`);
@@ -124,7 +125,8 @@ class DatePickerFields extends Component<PropTypes, StateTypes> {
   }
 
   handleCalendarDate = (date: Date) => {
-    if (dateIsPast(date) || dateIsOutsideRange(date)) {
+    const now = new Date();
+    if (dateIsPast(date) || dateIsOutsideRange(date, now)) {
       return;
     }
     const dateArray = formatMachineDate(date).split('-');
@@ -165,7 +167,7 @@ class DatePickerFields extends Component<PropTypes, StateTypes> {
       <div>
         <fieldset css={startDateGroup} role="group" aria-describedby="date-hint">
           <legend id="date-hint">
-            {`Please choose a date up to ${getLatestAvailableDateText()} for your gift to be emailed to the recipient.`}
+            {`Please choose a date up to ${getLatestAvailableDateText(currentMonth)} for your gift to be emailed to the recipient.`}
           </legend>
           <div css={startDateFields}>
             <div css={inputLayoutWithMargin}>
@@ -214,7 +216,7 @@ class DatePickerFields extends Component<PropTypes, StateTypes> {
         {state.showCalendar && (
           <DayPicker
             onDayClick={day => this.handleCalendarDate(day)}
-            disabledDays={[{ before: new Date(today) }, { after: getRange() }]}
+            disabledDays={[{ before: new Date(today) }, { after: getRange(currentMonth) }]}
             weekdaysShort={['S', 'M', 'T', 'W', 'T', 'F', 'S']}
             fromMonth={currentMonth}
             toMonth={threeMonthRange}

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/datePicker/datePickerHelpers.test.js
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/datePicker/datePickerHelpers.test.js
@@ -12,11 +12,11 @@ import { monthText } from 'pages/paper-subscription-checkout/helpers/subsCardDay
 describe('dateIsPast', () => {
   it('should be able to indicate if a selected date is in the past', () => {
     const pastDate = new Date('09/23/2020');
-    const today = Date.now();
-    const resultPast = dateIsPast(pastDate);
+    const now = new Date();
+    const resultPast = dateIsPast(pastDate, now);
     expect(resultPast).toBe(true);
 
-    const resultToday = dateIsPast(new Date(today));
+    const resultToday = dateIsPast(now, now);
     expect(resultToday).toBe(false);
   });
 
@@ -24,12 +24,13 @@ describe('dateIsPast', () => {
 
 describe('dateIsOutsideRange', () => {
   it('should be able to indicate if a selected date is too far in advance', () => {
-    const dateWithinRange = !dateIsOutsideRange(new Date(Date.now()));
+    const now = new Date();
+    const dateWithinRange = !dateIsOutsideRange(now, now);
     expect(dateWithinRange).toBe(true);
 
     const rangeDate = new Date();
     rangeDate.setDate(rangeDate.getDate() + 93);
-    const dateOutsideRange = dateIsOutsideRange(rangeDate);
+    const dateOutsideRange = dateIsOutsideRange(rangeDate, now);
 
     expect(dateOutsideRange).toBe(true);
 
@@ -39,7 +40,8 @@ describe('dateIsOutsideRange', () => {
 
 describe('getRange', () => {
   it('should be able to get the latest available date from now', () => {
-    const latestAvailable = getRange();
+    const now = new Date();
+    const latestAvailable = getRange(now);
     const rangeDate = new Date();
     rangeDate.setDate(rangeDate.getDate() + 89);
 
@@ -51,8 +53,9 @@ describe('getRange', () => {
 
 describe('getLatestAvailableText', () => {
   it('should be able to get the latest available date from now', () => {
-    const latestAvailable = getRange();
-    const latestAvailableText = getLatestAvailableDateText();
+    const now = new Date();
+    const latestAvailable = getRange(now);
+    const latestAvailableText = getLatestAvailableDateText(now);
 
     expect(latestAvailableText).toBe(`${latestAvailable.getDate()} ${monthText[latestAvailable.getMonth()]} ${latestAvailable.getFullYear()}`);
 

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/datePicker/helpers.js
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/datePicker/helpers.js
@@ -4,21 +4,21 @@ import { DateUtils } from 'react-day-picker';
 import { monthText } from 'pages/paper-subscription-checkout/helpers/subsCardDays';
 import { daysFromNowForGift } from 'pages/digital-subscription-checkout/components/helpers';
 
-const getRange = () => {
-  const rangeDate = new Date();
+const getRange = (now: Date) => {
+  const rangeDate = new Date(now);
   rangeDate.setDate(rangeDate.getDate() + daysFromNowForGift);
   return rangeDate;
 };
 
-const getLatestAvailableDateText = () => {
-  const rangeDate = getRange();
+const getLatestAvailableDateText = (now: Date) => {
+  const rangeDate = getRange(now);
   return `${rangeDate.getDate()} ${monthText[rangeDate.getMonth()]} ${rangeDate.getFullYear()}`;
 };
 
 const dateIsPast = (date: Date) => DateUtils.isPastDay(date);
 
-const dateIsOutsideRange = (date: Date) => {
-  const rangeDate = getRange();
+const dateIsOutsideRange = (date: Date, now: Date) => {
+  const rangeDate = getRange(now);
   return DateUtils.isDayAfter(date, rangeDate);
 };
 


### PR DESCRIPTION
## What are you doing in this PR?

This PR passes in a specific date to the date range code so that the tests don't compare two separately acquired dates.
This means they will not fail occasionally due to a millisecond having passed while the test was running.

```
17:09:00
  FAIL assets/pages/digital-subscription-checkout/components/datePicker/datePickerHelpers.test.js
17:09:00
    ● getRange › should be able to get the latest available date from now
17:09:00
  17:09:00
      expect(received).toEqual(expected) // deep equality
17:09:00
  17:09:00
      Expected: 2021-01-06T17:08:59.555Z
17:09:00
      Received: 2021-01-06T17:08:59.554Z
```

https://trello.com/c/4l2cBx52/3393-fix-non-deterministic-test

## Why are you doing this?

Unreliable tests can cause us to have to rebuild and can delay changes going out.
