### PR TITLE
roll back to sbt 1.3.13 due to intermittent dev assertion failure

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.1
+sbt.version=1.3.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,6 +20,9 @@ addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0" excludeAll Ex
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "1.1.3")
 
+// dependency tracker plugin - needed for snyk cli integration	
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.10.0-RC1")
+
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.4.1")
 
 // needed for riffraff as it uses AWS S3 SDK 1.11 which uses some base64 methods that were removed in JDK11


### PR DESCRIPTION
## What are you doing in this PR?

This reverts sbt back to 1.3.13.

Previous PR to update: https://github.com/guardian/support-frontend/pull/2803

## Why are you doing this?

Some people were getting  a duplicate compllations error.  It seems to be a common problem online https://github.com/sbt/sbt/issues/5911
It seems that there is a new assertion against more than one compilation start time for a subproject being in the same millisecond,  but this situation can occur (rightly or wrongly) during play compilation.

Reverting until there is a solution either from play or sbt.
