### PR TITLE
Remove timed wording that now refers to an event in the past.

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouUsElectionNewsletter.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouUsElectionNewsletter.jsx
@@ -63,8 +63,7 @@ const ContributionThankYouUsElectionNewsletter = ({
         <>
           <p>
             With First Thing, our morning newsletter, you get a global
-            perspective on the US delivered to your inbox. Until 3 November,
-            we&apos;ll be focusing on the latest in the presidential race.
+            perspective on the US delivered to your inbox.
           </p>
           <div css={buttonContainer}>
             <Button


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Remove timed wording that now refers to an event in the past.
![unnamed](https://user-images.githubusercontent.com/1515970/98121063-b2512980-1ea6-11eb-87bb-c54ace4cb9ba.png)

[**Trello Card**](https://trello.com)

## Why are you doing this?
<!--
Remember, PRs are documentation for future contributors.
-->
The Election is over

## Accessibility test checklist
 - [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
 - [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
 - [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

## Screenshots

