### PR TITLE
Remove references to Edition Earth from digital subscriptions landing page

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/hero/hero.jsx
@@ -22,6 +22,7 @@ import {
   circle,
   circleTextTop,
   circleTextBottom,
+  spaceAfter,
 } from './heroStyles';
 
 type PropTypes = {
@@ -29,18 +30,11 @@ type PropTypes = {
 }
 
 const HeroCopy = () => (
-  <span>
-    <p css={paragraph}>
-      With two innovative apps and ad-free reading, a digital subscription
-      gives you the richest experience of Guardian journalism. It also sustains the independent
-      reporting you love.
-    </p>
-    <p css={paragraph}>
-      For a few weeks only, read <span css={heavyText}>Edition Earth</span>, a new and exclusive
-      showcase of the best Guardian journalism on the climate, wildlife, air pollution, environmental
-      justice &mdash; and solutions.
-    </p>
-  </span>);
+  <p css={paragraph}>
+    With two innovative apps and ad-free reading, a digital subscription
+    gives you the richest experience of Guardian journalism. It also sustains the independent
+    reporting you love.
+  </p>);
 
 const HeroCopyAus = () => (
   <span>
@@ -66,18 +60,20 @@ function CampaignHeader(props: PropTypes) {
             <span css={yellowHeading}>powered by you</span>
           </h2>
           {props.countryGroupId === AUDCountries ? <HeroCopyAus /> : <HeroCopy />}
-          <ThemeProvider theme={buttonBrand}>
-            <Button
-              priority="tertiary"
-              size="default"
-              icon={<SvgArrowDownStraight />}
-              iconSide="right"
-              nudgeIcon
-              onClick={() => window.scrollTo(0, 1500)}
-            >
+          <div css={props.countryGroupId !== AUDCountries ? spaceAfter : {}}>
+            <ThemeProvider theme={buttonBrand}>
+              <Button
+                priority="tertiary"
+                size="default"
+                icon={<SvgArrowDownStraight />}
+                iconSide="right"
+                nudgeIcon
+                onClick={() => window.scrollTo(0, 1500)}
+              >
             See pricing options
-            </Button>
-          </ThemeProvider>
+              </Button>
+            </ThemeProvider>
+          </div>
         </div>
         <div css={packShot}>
           <GridImage

--- a/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroStyles.js
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroStyles.js
@@ -80,7 +80,7 @@ export const featureContainer = css`
   align-self: flex-start;
   background-color: #00568D;
   color: ${neutral[97]};
-  padding: ${space[4]}px ${space[4]}px 0;
+  padding: ${space[2]}px ${space[4]}px 0;
   width: 100%;
 
   ${from.phablet} {

--- a/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroStyles.js
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroStyles.js
@@ -80,8 +80,7 @@ export const featureContainer = css`
   align-self: flex-start;
   background-color: #00568D;
   color: ${neutral[97]};
-  padding: ${space[4]}px;
-  padding-bottom: 0;
+  padding: ${space[4]}px ${space[4]}px 0;
   width: 100%;
 
   ${from.phablet} {
@@ -112,7 +111,7 @@ export const textSection = css`
   width: 100%;
 
   ${from.phablet} {
-    padding: ${space[4]}px 0;
+    padding: ${space[1]}px 0 ${space[4]}px;
     width: 60%;
   }
 
@@ -128,7 +127,7 @@ export const textSection = css`
 export const heroHeading = css`
   ${headline.xsmall({ fontWeight: 'bold' })};
   max-width: 100%;
-  margin-bottom: ${space[5]}px;
+  margin-bottom: ${space[2]}px;
 
   ${from.mobileMedium} {
     ${headline.small({ fontWeight: 'bold' })};
@@ -140,12 +139,12 @@ export const heroHeading = css`
 
   ${from.desktop} {
     ${headline.large({ fontWeight: 'bold' })};
-    margin-bottom: 20px;
+    margin-bottom: ${space[2]}px;
   }
 
   ${from.leftCol} {
     margin-top: 0;
-    margin-bottom: 30px;
+    margin-bottom: ${space[2]}px;
   }
 `;
 
@@ -156,7 +155,7 @@ export const yellowHeading = css`
 export const paragraph = css`
   ${body.small()};
   max-width: 100%;
-  margin-bottom: ${space[5]}px;
+  margin-bottom: ${space[9]}px;
 
   ${from.mobileMedium} {
     ${body.medium()};
@@ -218,16 +217,16 @@ export const packShot = css`
 
   ${from.desktop} {
     right: 0;
-    max-width: 45%;
+    max-width: 40%;
     margin-bottom: 0;
   }
 
   ${from.leftCol} {
-    max-width: 490px;
+    max-width: 430px;
   }
 
   ${from.wide} {
-    right: 20px;
+    right: 40px;
   }
 `;
 
@@ -251,7 +250,7 @@ export const circle = css`
   }
 
   ${from.phablet} {
-    top: 20px;
+    top: -65px;
   }
 
   ${from.desktop} {
@@ -267,4 +266,15 @@ export const circleTextTop = css`
 export const circleTextBottom = css`
   ${headline.xsmall({ fontWeight: 'bold' })};
   color: ${brand[300]};
+`;
+
+export const spaceAfter = css`
+  ${from.desktop} {
+    margin-bottom: 70px;
+  }
+
+  ${from.leftCol} {
+    margin-bottom: 80px;
+  }
+
 `;

--- a/support-frontend/assets/pages/digital-subscription-landing/components/productBlock.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/productBlock.jsx
@@ -111,19 +111,17 @@ const appImage = (
 type ProductCardPropTypes = {
   title: string,
   subtitle: string,
-  shortSubTitle?: string,
   image: Node,
   second: boolean,
 }
 
 const ProductCard = ({
-  title, subtitle, shortSubTitle, image, second = false,
+  title, subtitle, image, second = false,
 }: ProductCardPropTypes) => (
   <section className="product-block__item">
     <h2 className="product-block__item__title">{title}</h2>
     <p className="product-block__item__subtitle">
       <span className={`product-block__item__subtitle--desktop${second ? '--second' : ''}`}>{subtitle}</span>
-      {!second && shortSubTitle && <span className="product-block__item__subtitle--mobile">{shortSubTitle}</span>}
     </p>
     <span className={`product-block__item__image${second ? '--second' : '--first-row'}`}>{image}</span>
   </section>
@@ -169,8 +167,7 @@ class ProductBlock extends Component<PropTypes, StateTypes> {
           <div className="product-block__container__label--top">What&apos;s included?</div>
           <ProductCard
             title="UK Daily in The Guardian Editions app"
-            subtitle="+ Edition Earth &mdash; Limited time only, ending 7 November"
-            shortSubTitle="+ Edition Earth"
+            subtitle="Each day's edition, in one simple, elegant app"
             image={dailyImage}
             second={false}
           />


### PR DESCRIPTION
## What are you doing in this PR?
The purpose here is to remove references to Edition Earth from the digital subscriptions landing page.

[**Trello Card**](https://trello.com)

## Why are you doing this?
The end date for Edition Earth is 7 November, which is on Saturday.

## Screenshots
![support thegulocal com_uk_subscribe_digital(wide) (4)](https://user-images.githubusercontent.com/16781258/98248440-d5dea780-1f6c-11eb-9356-368de1ce7239.png)

![support thegulocal com_uk_subscribe_digital(mobileMedium) (4)](https://user-images.githubusercontent.com/16781258/98248482-e727b400-1f6c-11eb-9680-ac365b246fbe.png)

