### PR TITLE
make range tests use mocked date

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-checkout/components/datePicker/datePickerHelpers.test.js
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/datePicker/datePickerHelpers.test.js
@@ -8,53 +8,73 @@ import {
 } from './helpers';
 import { monthText } from 'pages/paper-subscription-checkout/helpers/subsCardDays';
 
+describe('datePickerHelpers', () => {
 
-describe('dateIsPast', () => {
-  it('should be able to indicate if a selected date is in the past', () => {
-    const pastDate = new Date('09/23/2020');
-    const today = Date.now();
-    const resultPast = dateIsPast(pastDate);
-    expect(resultPast).toBe(true);
+  const RealDate = Date;
 
-    const resultToday = dateIsPast(new Date(today));
-    expect(resultToday).toBe(false);
+  class MockDate extends Date {
+    constructor(param) {
+      super(param || "2020-05-14T11:01:58.135Z");
+    }
+  }
+
+  beforeEach(() => {
+    global.Date = MockDate;
   });
 
-});
-
-describe('dateIsOutsideRange', () => {
-  it('should be able to indicate if a selected date is too far in advance', () => {
-    const dateWithinRange = !dateIsOutsideRange(new Date(Date.now()));
-    expect(dateWithinRange).toBe(true);
-
-    const rangeDate = new Date();
-    rangeDate.setDate(rangeDate.getDate() + 93);
-    const dateOutsideRange = dateIsOutsideRange(rangeDate);
-
-    expect(dateOutsideRange).toBe(true);
-
+  afterEach(() => {
+    global.Date = RealDate;
   });
 
-});
+  describe('dateIsPast', () => {
+    it('should be able to indicate if a selected date is in the past', () => {
+      const pastDate = new RealDate('05/13/2020');
+      const resultPast = dateIsPast(pastDate);
+      console.log('past', pastDate);
+      expect(resultPast).toBe(true);
 
-describe('getRange', () => {
-  it('should be able to get the latest available date from now', () => {
-    const latestAvailable = getRange();
-    const rangeDate = new Date();
-    rangeDate.setDate(rangeDate.getDate() + 89);
-
-    expect(latestAvailable).toEqual(rangeDate);
+      const todaysDate = new RealDate('05/14/2020');
+      const resultToday = dateIsPast(todaysDate);
+      expect(resultToday).toBe(false);
+    });
 
   });
 
-});
+  describe('dateIsOutsideRange', () => {
+    it('should be able to indicate if a selected date is too far in advance', () => {
+      const dateWithinRange = !dateIsOutsideRange(new Date());
+      expect(dateWithinRange).toBe(true);
 
-describe('getLatestAvailableText', () => {
-  it('should be able to get the latest available date from now', () => {
-    const latestAvailable = getRange();
-    const latestAvailableText = getLatestAvailableDateText();
+      const rangeDate = new Date();
+      rangeDate.setDate(rangeDate.getDate() + 93);
+      const dateOutsideRange = dateIsOutsideRange(rangeDate);
 
-    expect(latestAvailableText).toBe(`${latestAvailable.getDate()} ${monthText[latestAvailable.getMonth()]} ${latestAvailable.getFullYear()}`);
+      expect(dateOutsideRange).toBe(true);
+
+    });
+
+  });
+
+  describe('getRange', () => {
+    it('should be able to get the latest available date from now', () => {
+      const latestAvailable = getRange();
+      const rangeDate = new Date();
+      rangeDate.setDate(rangeDate.getDate() + 89);
+
+      expect(latestAvailable).toEqual(rangeDate);
+
+    });
+
+  });
+
+  describe('getLatestAvailableText', () => {
+    it('should be able to get the latest available date from now', () => {
+      const latestAvailable = getRange();
+      const latestAvailableText = getLatestAvailableDateText();
+
+      expect(latestAvailableText).toBe(`${latestAvailable.getDate()} ${monthText[latestAvailable.getMonth()]} ${latestAvailable.getFullYear()}`);
+
+    });
 
   });
 


### PR DESCRIPTION
## What are you doing in this PR?

Supersedes https://github.com/guardian/support-frontend/pull/2806 which used a more fp-centric method rather than mocking.

This PR mocks a specific date for the date range tests so that the tests don't compare two separately acquired dates.
This means they will not fail occasionally due to a millisecond having passed while the test was running.

```
17:09:00
  FAIL assets/pages/digital-subscription-checkout/components/datePicker/datePickerHelpers.test.js
17:09:00
    ● getRange › should be able to get the latest available date from now
17:09:00
  17:09:00
      expect(received).toEqual(expected) // deep equality
17:09:00
  17:09:00
      Expected: 2021-01-06T17:08:59.555Z
17:09:00
      Received: 2021-01-06T17:08:59.554Z
```

https://trello.com/c/4l2cBx52/3393-fix-non-deterministic-test

## Why are you doing this?

Unreliable tests can cause us to have to rebuild and can delay changes going out.
