### PR TITLE
Update copy and packshot on the redemption page

### DIFF
--- a/support-frontend/assets/pages/subscriptions-redemption/components/productSummary/productSummary.jsx
+++ b/support-frontend/assets/pages/subscriptions-redemption/components/productSummary/productSummary.jsx
@@ -12,7 +12,7 @@ function ProductSummary() {
       <div css={styles.contentBlock}>
         <div css={styles.imageContainer}>
           <GridImage
-            gridId="subscriptionDailyPackshot"
+            gridId="editionsPackshotShort"
             srcSizes={[1000, 500]}
             sizes="(max-width: 740px) 50vw, 500"
             imgType="png"
@@ -27,8 +27,10 @@ function ProductSummary() {
       <div>
         <ul css={styles.list}>
           <li>
-            <Dot /><div css={styles.listMain}>The Guardian Daily</div>
-            <span css={styles.subText}>Each day&apos;s edition in one simple, elegant app</span>
+            <Dot /><div css={styles.listMain}>The Guardian Editions app</div>
+            <span css={styles.subText}>Access the UK Daily, Australia Weekend and other special editions.
+              Read offline and ad-free across multiple devices
+            </span>
           </li>
           <li>
             <Dot /><div css={styles.listMain}>Premium access to The Guardian Live app</div>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->


[**Trello Card**](https://trello.com/c/qYSOwugn/3428-gifting-redemption-page)

## Why are you doing this?

We have new packshots for the Digital Subscription so we need to use these on the redemption form page. Also this page does not have separate copy for AUS/ROW so we need to make the copy that is there work for both.


## Accessibility test checklist
 - [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
 - [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
 - [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

## Screenshots

### Mobile
![Screen Shot 2020-11-06 at 14 31 45](https://user-images.githubusercontent.com/181371/98385485-ebc09b00-2046-11eb-937a-efc806eb240a.png)

### Desktop
![Screen Shot 2020-11-06 at 14 31 03](https://user-images.githubusercontent.com/181371/98385501-ed8a5e80-2046-11eb-91e9-5bcc3bcc7b2d.png)
