### PR TITLE
Update reminder copy

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSupportReminder.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSupportReminder.jsx
@@ -194,13 +194,14 @@ const ContributionThankYouSupportReminder = ({
           <p>
             <span css={styles.hideAfterTablet}>
               Choose a time when we can invite you to support our journalism
-              again. We’ll send you a single email, with no obligation.
+              again. We’ll send you a maximum of two reminder emails, with no
+              obligation.
             </span>
             <span css={styles.hideBeforeTablet}>
-              Lots of readers chose to make single contributions at various
-              points in the year. Opt in to receive a reminder in case you would
-              like to support our journalism again. This will be a single email
-              with no obligation.
+              Many readers choose to support Guardian journalism by making
+              single contributions at various points in the year. Opt in to
+              whichever time suits you best, and we’ll send you a maximum of two
+              reminder emails, with no obligation.
             </span>
           </p>
           <form css={form}>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Update the support reminder copy on the TY page, as per [this card](https://trello.com/c/VDVEcAbq/2406-update-the-reminders-copy-to-advertise-the-fact-were-going-to-send-up-to-2-emails-from-now)

## Screenshots

### desktop
<img width="637" alt="Screenshot 2020-11-09 at 12 07 45" src="https://user-images.githubusercontent.com/17720442/98539520-64f90180-2284-11eb-9606-cd3bd8512b74.png">

### mobile
<img width="449" alt="Screenshot 2020-11-09 at 12 08 14" src="https://user-images.githubusercontent.com/17720442/98539522-66c2c500-2284-11eb-98b4-ccfb0db418ad.png">
