### PR TITLE
Fix broken selenium test

### DIFF
--- a/support-frontend/assets/components/footerCompliant/DigitalFooter.jsx
+++ b/support-frontend/assets/components/footerCompliant/DigitalFooter.jsx
@@ -77,7 +77,12 @@ function DigitalFooter(props: PropTypes) {
       faqsLink="https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions"
       termsConditionsLink="https://www.theguardian.com/info/2014/aug/06/guardian-observer-digital-subscriptions-terms-conditions"
     >
-      <h3 css={footerTextHeading}>Promotion terms and conditions</h3>
+      <h3
+        id="qa-component-customer-service"
+        css={footerTextHeading}
+      >
+          Promotion terms and conditions
+      </h3>
       <p>Offer subject to availability. Guardian News and Media Ltd
           (&quot;GNM&quot;) reserves the right to withdraw this promotion at any
           time. Full promotion terms and conditions for our&nbsp;


### PR DESCRIPTION
## Why are you doing this?
After merging in the new digital gift subs landing page, there was a selenium error, which seems to be due to a missing id that the test is looking for. This was removed inadvertently when we replaced the footer in this page, and thus the FAQs for the page, which contained the id that was being looked for.

I have reinstated this to the new digital footer.

The PR that introduced this error is this one: https://github.com/guardian/support-frontend/pull/2775
