### PR TITLE
handle optional fields in emails

### DIFF
--- a/support-workers/src/test/scala/com/gu/emailservices/JsonToAttributesSpec.scala
+++ b/support-workers/src/test/scala/com/gu/emailservices/JsonToAttributesSpec.scala
@@ -80,4 +80,15 @@ class JsonToAttributesSpec extends AnyFlatSpec with Matchers {
     actual.map(_.toMap) should matchPattern { case Left(_) => }
   }
 
+  it should "handle a null ok" in {
+    val data = JsonObject(
+      ("shouldExist1" -> Json.fromString("value1")),
+      "test" -> Json.Null
+    )
+    val actual = JsonToAttributes.asFlattenedPairs(data)
+    actual.map(_.toMap) should be(Right(Map(
+      "shouldExist1" -> "value1"
+    )))
+  }
+
 }


### PR DESCRIPTION
## What are you doing in this PR?

This PR adds code to handle None Options in the email builder code.

It also adds a test to make sure it is working.

## Why are you doing this?

during gifting testing there were errors in the logs if somoene didn't fill in a gift message.
```
coding error: all values should be string or object: gift_personal_message -> object[gifter_first_name -> "n0ZoXIrKEPrtpPjgBvc",gift_personal_message -> null,gift_code -> "gd12-blahblah",last_redemption_date -> "Tuesday, 9 November 2021",duration -> "12 months"]
```
This is because an Option[String] that is None, is treated as null rather than String or Object.

This situation wasn't in any of the tests.
