### PR TITLE
send the gift notification to the giftee rather than gifter

### DIFF
--- a/support-models/src/main/scala/com/gu/support/workers/states/SendThankYouEmailState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/SendThankYouEmailState.scala
@@ -1,10 +1,12 @@
 package com.gu.support.workers.states
 
+import com.gu.salesforce.Salesforce.SfContactId
 import com.gu.support.encoding.DiscriminatedType
 import com.gu.support.encoding.CustomCodecs._
 import com.gu.support.promotions.PromoCode
 import com.gu.support.workers.GiftRecipient.{DigitalSubscriptionGiftRecipient, WeeklyGiftRecipient}
 import com.gu.support.workers.{PaymentMethod, SalesforceContactRecord, User, _}
+import io.circe.{Decoder, Encoder}
 import org.joda.time.LocalDate
 
 sealed trait SendThankYouEmailState extends StepFunctionUserState {
@@ -27,7 +29,7 @@ object SendThankYouEmailState {
 
   case class SendThankYouEmailDigitalSubscriptionDirectPurchaseState(
     user: User,
-    salesForceContact: SalesforceContactRecord,
+    sfContactId: SfContactId,
     product: DigitalPack,
     paymentMethod: PaymentMethod,
     paymentSchedule: PaymentSchedule,
@@ -38,7 +40,8 @@ object SendThankYouEmailState {
 
   case class SendThankYouEmailDigitalSubscriptionGiftPurchaseState(
     user: User,
-    salesForceContact: SalesforceContactRecord,
+    purchaserSFContactId: SfContactId,
+    recipientSFContactId: SfContactId,
     product: DigitalPack,
     giftRecipient: DigitalSubscriptionGiftRecipient,
     giftCode: GeneratedGiftCode,
@@ -51,14 +54,14 @@ object SendThankYouEmailState {
 
   case class SendThankYouEmailDigitalSubscriptionCorporateRedemptionState(
     user: User,
-    salesForceContact: SalesforceContactRecord,
+    sfContactId: SfContactId,
     product: DigitalPack,
     subscriptionNumber: String,
   ) extends SendThankYouEmailDigitalSubscriptionState
 
   case class SendThankYouEmailDigitalSubscriptionGiftRedemptionState(
     user: User,
-    salesForceContact: SalesforceContactRecord,
+    sfContactId: SfContactId,
     product: DigitalPack,
     giftStartDate: LocalDate,
     giftEndDate: LocalDate,
@@ -88,6 +91,9 @@ object SendThankYouEmailState {
     subscriptionNumber: String,
     firstDeliveryDate: LocalDate,
   ) extends SendThankYouEmailState
+
+  implicit val encodeSFContactId = Encoder.encodeString.contramap[SfContactId](_.id)
+  implicit val decodeSFContactId = Decoder.decodeString.map(SfContactId.apply)
 
   private val discriminatedType = new DiscriminatedType[SendThankYouEmailState]("productType")
   implicit val codec = discriminatedType.codec(List(

--- a/support-models/src/test/scala/com/gu/support/workers/SendThankYouEmailStateSerialisationSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/workers/SendThankYouEmailStateSerialisationSpec.scala
@@ -2,6 +2,7 @@ package com.gu.support.workers
 
 import com.gu.i18n.Country
 import com.gu.i18n.Currency.GBP
+import com.gu.salesforce.Salesforce.SfContactId
 import com.gu.support.SerialisationTestHelpers.testRoundTripSerialisation
 import com.gu.support.catalog.{Collection, Domestic, Saturday}
 import com.gu.support.workers.ProductTypeCreatedTestData._
@@ -38,7 +39,7 @@ object ProductTypeCreatedTestData {
 
   val digitalSubscriptionDirectPurchaseCreated = SendThankYouEmailDigitalSubscriptionDirectPurchaseState(
     user = User("111222", "email@blah.com", None, "bertha", "smith", Address(None, None, None, None, None, Country.UK)),
-    salesForceContact = SalesforceContactRecord("sfbuy", "sfbuyacid"),
+    sfContactId = SfContactId("sfbuy"),
     DigitalPack(GBP, Monthly, ReaderType.Direct),
     PayPalReferenceTransaction("baid", "email@emaail.com"),
     PaymentSchedule(List(Payment(new LocalDate(2020, 6, 16), 1.49))),
@@ -49,7 +50,8 @@ object ProductTypeCreatedTestData {
 
   val digitalSubscriptionGiftPurchaseCreated = SendThankYouEmailDigitalSubscriptionGiftPurchaseState(
     user = User("111222", "email@blah.com", None, "bertha", "smith", Address(None, None, None, None, None, Country.UK)),
-    salesForceContact = SalesforceContactRecord("sfbuy", "sfbuyacid"),
+    purchaserSFContactId = SfContactId("sfbuy"),
+    recipientSFContactId = SfContactId("sfrecip"),
     DigitalPack(GBP, Monthly, ReaderType.Gift),
     GiftRecipient.DigitalSubscriptionGiftRecipient("bob", "builder", "bob@gu.com", Some("message"), new LocalDate(2020, 10, 2)),
     GeneratedGiftCode("gd12-23456789").get,
@@ -61,13 +63,13 @@ object ProductTypeCreatedTestData {
   )
   val digitalSubscriptionCorporateRedemptionCreated = SendThankYouEmailDigitalSubscriptionCorporateRedemptionState(
     user = User("111222", "email@blah.com", None, "bertha", "smith", Address(None, None, None, None, None, Country.UK)),
-    salesForceContact = SalesforceContactRecord("sfbuy", "sfbuyacid"),
+    sfContactId = SfContactId("sfbuy"),
     DigitalPack(GBP, Monthly, ReaderType.Corporate),
     "subno"
   )
   val digitalSubscriptionGiftRedemptionCreated = SendThankYouEmailDigitalSubscriptionGiftRedemptionState(
     user = User("111222", "email@blah.com", None, "bertha", "smith", Address(None, None, None, None, None, Country.UK)),
-    salesForceContact = SalesforceContactRecord("sfbuy", "sfbuyacid"),
+    sfContactId = SfContactId("sfbuy"),
     DigitalPack(GBP, Monthly, ReaderType.Gift),
     new LocalDate(2020, 10, 24),
     new LocalDate(2021, 1, 24),

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -4,6 +4,7 @@ import cats.implicits._
 import com.amazonaws.services.lambda.runtime.Context
 import com.gu.config.Configuration
 import com.gu.monitoring.SafeLogger
+import com.gu.salesforce.Salesforce.SfContactId
 import com.gu.services.{ServiceProvider, Services}
 import com.gu.support.catalog
 import com.gu.support.catalog._
@@ -233,12 +234,17 @@ class NextState(
       case (product: GuardianWeekly, Purchase(purchase)) =>
         weekly(product, purchase)
       case (product: DigitalPack, _: Redemption) if product.readerType == ReaderType.Corporate =>
-        SendThankYouEmailDigitalSubscriptionCorporateRedemptionState(state.user, state.salesforceContacts.buyer, product, subscriptionNumber.value)
+        dsCorp(product)
       case (product: DigitalPack, _: Redemption) if product.readerType == ReaderType.Gift =>
         throw new RuntimeException("wrong code path for gift redemption")
       case _ => throw new RuntimeException("could not create value state")
     }
   // scalastyle:on cyclomatic.complexity
+
+  private def dsCorp(product: DigitalPack) =
+    SendThankYouEmailDigitalSubscriptionCorporateRedemptionState(
+      state.user, SfContactId(state.salesforceContacts.buyer.Id), product, subscriptionNumber.value
+    )
 
   private def weekly(product: GuardianWeekly, purchase: PaymentMethodWithSchedule) =
     SendThankYouEmailGuardianWeeklyState(
@@ -270,7 +276,8 @@ class NextState(
   private def dsGift(product: DigitalPack, purchase: PaymentMethodWithSchedule, giftPurchase: DigitalSubscriptionGiftPurchaseDetails) =
     SendThankYouEmailDigitalSubscriptionGiftPurchaseState(
       state.user,
-      state.salesforceContacts.buyer,
+      SfContactId(state.salesforceContacts.buyer.Id),
+      SfContactId(state.salesforceContacts.giftRecipient.get.Id),
       product,
       giftPurchase.giftRecipient,
       giftPurchase.giftCode,
@@ -284,7 +291,7 @@ class NextState(
   private def dsDirect(product: DigitalPack, purchase: PaymentMethodWithSchedule) =
     SendThankYouEmailDigitalSubscriptionDirectPurchaseState(
       state.user,
-      state.salesforceContacts.buyer,
+      SfContactId(state.salesforceContacts.buyer.Id),
       product,
       purchase.paymentMethod,
       purchase.paymentSchedule,
@@ -376,7 +383,7 @@ object DigitalSubscriptionGiftRedemption {
           analyticsInfo = state.analyticsInfo,
           sendThankYouEmailState = SendThankYouEmailDigitalSubscriptionGiftRedemptionState(
             state.user,
-            state.salesforceContacts.buyer,
+            SfContactId(state.salesforceContacts.buyer.Id),
             product,
             termDates.giftStartDate,
             termDates.giftEndDate,

--- a/support-workers/src/test/scala/com/gu/emailservices/EmailFieldsSpec.scala
+++ b/support-workers/src/test/scala/com/gu/emailservices/EmailFieldsSpec.scala
@@ -3,7 +3,7 @@ package com.gu.emailservices
 import com.gu.i18n.Currency.GBP
 import com.gu.support.config.TouchPointEnvironments.SANDBOX
 import com.gu.support.workers.integration.TestData
-import com.gu.support.workers.integration.TestData.{countryOnlyAddress, directDebitPaymentMethod, sfContactRecord}
+import com.gu.support.workers.integration.TestData.{countryOnlyAddress, directDebitPaymentMethod, sfContactRecord, sfContactId}
 import com.gu.support.workers.states.SendThankYouEmailState._
 import com.gu.support.workers._
 import io.circe.parser._
@@ -92,7 +92,7 @@ class DigitalPackEmailFieldsSpec extends AsyncFlatSpec with Matchers with Inside
     ).build(
       SendThankYouEmailDigitalSubscriptionDirectPurchaseState(
         User("1234", "test@gu.com", None, "Mickey", "Mouse", billingAddress = countryOnlyAddress),
-        sfContactRecord,
+        sfContactId,
         DigitalPack(GBP, Annual),
         directDebitPaymentMethod,
         PaymentSchedule(List(Payment(new LocalDate(2019, 1, 14), 119.90))),
@@ -134,7 +134,7 @@ class DigitalPackEmailFieldsSpec extends AsyncFlatSpec with Matchers with Inside
     ).build(
       SendThankYouEmailDigitalSubscriptionCorporateRedemptionState(
         User("1234", "test@gu.com", None, "Mickey", "Mouse", billingAddress = countryOnlyAddress),
-        sfContactRecord,
+        sfContactId,
         DigitalPack(GBP, Annual),
         "A-S00045678",
       )

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
@@ -18,7 +18,7 @@ import com.gu.support.workers.JsonFixtures.{sendAcquisitionEventJson, wrapFixtur
 import com.gu.support.workers._
 import com.gu.support.workers.encoding.Conversions.FromOutputStream
 import com.gu.support.workers.encoding.Encoding
-import com.gu.support.workers.integration.SendThankYouEmailManualTest.integrationSFContactRecord
+import com.gu.support.workers.integration.SendThankYouEmailManualTest.integrationSFContactId
 import com.gu.support.workers.integration.TestData.{billingOnlyUser, directDebitPaymentMethod, sfContactRecord}
 import com.gu.support.workers.lambdas.SendThankYouEmail
 import com.gu.support.workers.states.SendThankYouEmailState._
@@ -96,7 +96,9 @@ object SendThankYouEmailManualTest {
 
   //This test will send a thank you email to the address/SF contact below - useful for quickly testing changes
   val addressToSendTo = "john.duffell@guardian.co.uk"
-  val integrationSFContactRecord = SalesforceContactRecord(SfContactId("0039E000018EoTHQA0").id, "accountID")
+  val integrationSFContactId = SfContactId("0039E000018EoTHQA0")
+  // deprecated as accountId is not relevant for emails
+  val integrationSFContactRecord = SalesforceContactRecord(integrationSFContactId.id, "accountID")
 
   def main(args: Array[String]): Unit = {
     SendContributionEmail.main(args)
@@ -144,7 +146,7 @@ object SendDigitalPackEmail extends App {
   send(digitalPackEmailFields.build(
     SendThankYouEmailDigitalSubscriptionDirectPurchaseState(
       billingOnlyUser,
-      integrationSFContactRecord,
+      integrationSFContactId,
       DigitalPack(GBP, Annual),
       directDebitPaymentMethod,
       paymentSchedule,
@@ -160,7 +162,7 @@ object SendDigitalPackCorpEmail extends App {
   send(digitalPackEmailFields.build(
     SendThankYouEmailDigitalSubscriptionCorporateRedemptionState(
       billingOnlyUser,
-      integrationSFContactRecord,
+      integrationSFContactId,
       DigitalPack(GBP, Annual, ReaderType.Corporate),
       subno
     )
@@ -172,7 +174,8 @@ object SendDigitalPackGiftPurchaseEmails extends App {
   send(digitalPackEmailFields.build(
     SendThankYouEmailDigitalSubscriptionGiftPurchaseState(
       billingOnlyUser,
-      integrationSFContactRecord,
+      integrationSFContactId, // purchaser
+      integrationSFContactId, // recipient
       DigitalPack(GBP, Annual, ReaderType.Gift),
       DigitalSubscriptionGiftRecipient("first", "last", addressToSendTo, Some("gift message"), LocalDate.now()),
       GeneratedGiftCode("gd12-02345678").get,
@@ -190,7 +193,7 @@ object SendDigitalPackGiftRedemptionEmail extends App {
   send(digitalPackEmailFields.build(
     SendThankYouEmailDigitalSubscriptionGiftRedemptionState(
       billingOnlyUser,
-      integrationSFContactRecord,
+      integrationSFContactId,
       DigitalPack(GBP, Annual, ReaderType.Gift),
       new LocalDate(2020, 10, 24),
       new LocalDate(2021, 1, 24),
@@ -260,7 +263,9 @@ object SendWeeklySubscriptionGiftEmail extends App {
 
 object TestData {
 
-  val sfContactRecord = SalesforceContactRecord(SfContactId("contactID").id, "accountID")
+  val sfContactId: SfContactId = SfContactId("contactID")
+  // deprecated as account id is not relevant to emails
+  val sfContactRecord = SalesforceContactRecord(sfContactId.id, "accountID")
 
   val paymentSchedule = PaymentSchedule(List(Payment(new LocalDate(2019, 3, 25), 37.50)))
   val subno = "A-S00045678"


### PR DESCRIPTION
## What are you doing in this PR?

This PR passes the gift recipient SF contact id from the zuora step through to the email step, so that we can send the notification email to the correct person.


## Why are you doing this?

During testing we noticed the gift purchase TY email and notification email both went to the purchaser.

