### PR TITLE
Remove gift button from digital subs card on subs landing page

### DIFF
--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
@@ -131,12 +131,6 @@ const digital = (countryGroupId: CountryGroupId, priceCopy: PriceCopy, isTop: bo
     ctaButtonText: 'Find out more',
     link: digitalSubscriptionLanding(countryGroupId, false),
     analyticsTracking: sendTrackingEventsOnClick('digipack_cta', 'DigitalPack', abTest, 'digital-subscription'),
-  },
-  {
-    ctaButtonText: 'See gift options',
-    link: guardianWeeklyLanding(countryGroupId, true),
-    analyticsTracking: sendTrackingEventsOnClick('digipack_cta_gift', 'DigitalPack', abTest, 'digital-subscription'),
-    modifierClasses: '',
   }],
 });
 


### PR DESCRIPTION
## What are you doing in this PR?
There was a 'See gift options button on the subs landing page where there should not be one (yet!)

## Why are you doing this?
We are not ready to add this button yet:

<img width="1231" alt="Screenshot 2020-11-11 at 16 02 01" src="https://user-images.githubusercontent.com/16781258/98836114-3a9c7500-2439-11eb-8be0-b2c0af037c63.png">
