### PR TITLE
use correct term months for gift recipient thank you email

### DIFF
--- a/support-models/src/main/scala/com/gu/support/workers/states/SendThankYouEmailState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/SendThankYouEmailState.scala
@@ -1,6 +1,7 @@
 package com.gu.support.workers.states
 
 import com.gu.salesforce.Salesforce.SfContactId
+import com.gu.support.encoding.Codec.deriveCodec
 import com.gu.support.encoding.DiscriminatedType
 import com.gu.support.encoding.CustomCodecs._
 import com.gu.support.promotions.PromoCode
@@ -63,8 +64,7 @@ object SendThankYouEmailState {
     user: User,
     sfContactId: SfContactId,
     product: DigitalPack,
-    giftStartDate: LocalDate,
-    giftEndDate: LocalDate,
+    termDates: TermDates,
   ) extends SendThankYouEmailDigitalSubscriptionState
 
   case class SendThankYouEmailPaperState(
@@ -91,6 +91,14 @@ object SendThankYouEmailState {
     subscriptionNumber: String,
     firstDeliveryDate: LocalDate,
   ) extends SendThankYouEmailState
+
+  case class TermDates(
+    giftStartDate: LocalDate,
+    giftEndDate: LocalDate,
+    months: Int,
+  )
+
+  implicit val codedTermDates = deriveCodec[TermDates]
 
   implicit val encodeSFContactId = Encoder.encodeString.contramap[SfContactId](_.id)
   implicit val decodeSFContactId = Decoder.decodeString.map(SfContactId.apply)

--- a/support-models/src/test/scala/com/gu/support/workers/SendThankYouEmailStateSerialisationSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/workers/SendThankYouEmailStateSerialisationSpec.scala
@@ -71,8 +71,11 @@ object ProductTypeCreatedTestData {
     user = User("111222", "email@blah.com", None, "bertha", "smith", Address(None, None, None, None, None, Country.UK)),
     sfContactId = SfContactId("sfbuy"),
     DigitalPack(GBP, Monthly, ReaderType.Gift),
-    new LocalDate(2020, 10, 24),
-    new LocalDate(2021, 1, 24),
+    TermDates(
+      new LocalDate(2020, 10, 24),
+      new LocalDate(2021, 1, 24),
+      3,
+    )
   )
   val paperCreated = SendThankYouEmailPaperState(
     user = User("111222", "email@blah.com", None, "bertha", "smith", Address(None, None, None, None, None, Country.UK)),

--- a/support-workers/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
@@ -198,10 +198,10 @@ class DigitalPackEmailFields(
   private def giftRedemption(state: SendThankYouEmailDigitalSubscriptionGiftRedemptionState) =
     wrap("digipack-gift-redemption", GifteeRedemptionAttributes(
       gift_recipient_first_name = state.user.firstName,
-      subscription_details = state.product.billingPeriod.monthsInPeriod + " month digital subscription",
-      gift_start_date = formatDate(state.giftStartDate),
+      subscription_details = state.termDates.months + " month digital subscription",
+      gift_start_date = formatDate(state.termDates.giftStartDate),
       gift_recipient_email = state.user.primaryEmailAddress,
-      gift_end_date = formatDate(state.giftEndDate),
+      gift_end_date = formatDate(state.termDates.giftEndDate),
     ), state.sfContactId, state.user.primaryEmailAddress)
 
   private def corpRedemption(state: SendThankYouEmailDigitalSubscriptionCorporateRedemptionState) =

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -352,18 +352,13 @@ object DigitalSubscriptionGiftRedemption {
 
   }
 
-  case class TermDates(
-    giftStartDate: LocalDate,
-    giftEndDate: LocalDate,
-  )
-
   private def getStartEndDates(months: Int) = {
     val startDate = LocalDate.now()
     val newEndDate = startDate
       .toDateTimeAtStartOfDay
       .plusMonths(months)
       .toLocalDate
-    TermDates(startDate, newEndDate)
+    TermDates(startDate, newEndDate, months)
   }
 
   private def buildHandlerResult(
@@ -385,8 +380,7 @@ object DigitalSubscriptionGiftRedemption {
             state.user,
             SfContactId(state.salesforceContacts.buyer.Id),
             product,
-            termDates.giftStartDate,
-            termDates.giftEndDate,
+            termDates,
           ),
           acquisitionData = state.acquisitionData
         ), requestInfo)

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/SendThankYouEmailSpec.scala
@@ -195,8 +195,11 @@ object SendDigitalPackGiftRedemptionEmail extends App {
       billingOnlyUser,
       integrationSFContactId,
       DigitalPack(GBP, Annual, ReaderType.Gift),
-      new LocalDate(2020, 10, 24),
-      new LocalDate(2021, 1, 24),
+      TermDates(
+        new LocalDate(2020, 10, 24),
+        new LocalDate(2021, 1, 24),
+        3,
+      )
     )
   ))
 


### PR DESCRIPTION
## What are you doing in this PR?

This PR passes the number of months term through from the create subscription step into the email step,  then this is used for the thank you recipient email.


## Why are you doing this?

Otherwise it gets the default value of 1 month
![image](https://user-images.githubusercontent.com/7304387/98837114-7257ec80-243a-11eb-9475-f27cd76c5403.png)

