### PR TITLE
add last name to gift recipient notification email

### DIFF
--- a/support-workers/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
@@ -108,6 +108,7 @@ object DigitalSubscriptionEmailAttributes {
 
   case class GifteeNotificationAttributes(
     gifter_first_name: String,
+    gifter_last_name: String,
     gift_personal_message: Option[String],
     gift_code: String,
     last_redemption_date: String,
@@ -164,6 +165,7 @@ class DigitalPackEmailFields(
   private def giftRecipientNotification(giftPurchase: SendThankYouEmailDigitalSubscriptionGiftPurchaseState) =
     wrap("digipack-gift-notification", GifteeNotificationAttributes(
       gifter_first_name = giftPurchase.user.firstName,
+      gifter_last_name = giftPurchase.user.lastName,
       gift_personal_message = giftPurchase.giftRecipient.message,
       gift_code = giftPurchase.giftCode.value,
       last_redemption_date = formatDate(giftPurchase.lastRedemptionDate),


### PR DESCRIPTION
## What are you doing in this PR?

This PR adds a last name field to the email payload for gift recipient notification

## Why are you doing this?

In the current gift notification, it says "A gift from John" but nothing about the surname.
We need to it be clear who it came from, so the surname will be needed.

Existing:
![image](https://user-images.githubusercontent.com/7304387/98973302-7c95eb80-250b-11eb-82e4-5c69b92f0054.png)

Added field to payload: ` "gifter_last_name" : "Mouse"`

```
{
        "duration" : "12 months",
        "last_redemption_date" : "Wednesday, 14 October 2020",
        "gifter_last_name" : "Mouse",
        "gift_personal_message" : "gift message",
        "gifter_first_name" : "Mickey",
        "gift_code" : "gd12-02345678"
      }
```
