### PR TITLE
Remove Guardian auth from the redemption page

### DIFF
--- a/support-frontend/app/controllers/RedemptionController.scala
+++ b/support-frontend/app/controllers/RedemptionController.scala
@@ -61,7 +61,7 @@ class RedemptionController(
 
   val testUserFromRequest = new TestUserFromRequest(identityService, testUsers)
 
-  def displayForm(redemptionCode: RawRedemptionCode): Action[AnyContent] = (googleAuthAction andThen maybeAuthenticatedAction()).async {
+  def displayForm(redemptionCode: RawRedemptionCode): Action[AnyContent] = maybeAuthenticatedAction().async {
     implicit request =>
       for {
         isTestUser <- testUserFromRequest.isTestUser(request)

--- a/support-frontend/app/controllers/RedemptionController.scala
+++ b/support-frontend/app/controllers/RedemptionController.scala
@@ -8,7 +8,6 @@ import admin.settings.{AllSettings, AllSettingsProvider}
 import assets.{AssetsResolver, RefPath, StyleContent}
 import cats.data.EitherT
 import cats.implicits._
-import com.gu.googleauth.AuthAction
 import com.gu.identity.model.{User => IdUser}
 import com.gu.monitoring.SafeLogger
 import com.gu.monitoring.SafeLogger._
@@ -42,7 +41,6 @@ class RedemptionController(
   testUsers: TestUserService,
   components: ControllerComponents,
   fontLoaderBundle: Either[RefPath, StyleContent],
-  googleAuthAction: AuthAction[AnyContent],
   dynamoTableProvider: DynamoTableAsyncProvider,
   zuoraLookupServiceProvider: ZuoraGiftLookupServiceProvider
 )(

--- a/support-frontend/app/wiring/Controllers.scala
+++ b/support-frontend/app/wiring/Controllers.scala
@@ -83,7 +83,6 @@ trait Controllers {
     testUsers,
     controllerComponents,
     fontLoader,
-    authAction,
     dynamoTableAsyncProvider,
     zuoraGiftLookupServiceProvider
   )


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

We don't need to limit access to the redemption form to Guardian employees anymore
