### PR TITLE
Add `giftRedemptionDate` to the `UpdateRedemptionDataRequest` class

### DIFF
--- a/support-models/src/main/scala/com/gu/support/zuora/api/SubscribeRequest.scala
+++ b/support-models/src/main/scala/com/gu/support/zuora/api/SubscribeRequest.scala
@@ -7,6 +7,7 @@ import com.gu.support.encoding.JsonHelpers.JsonObjectExtensions
 import com.gu.support.workers.PaymentMethod
 import io.circe.Encoder
 import io.circe.generic.semiauto.deriveEncoder
+import org.joda.time.LocalDate
 
 object SubscribeItem {
   implicit val codec: Codec[SubscribeItem] = capitalizingCodec
@@ -35,8 +36,15 @@ object UpdateRedemptionDataRequest {
   implicit val encoder: Encoder[UpdateRedemptionDataRequest] = deriveEncoder[UpdateRedemptionDataRequest].mapJsonObject(
     _.renameField("gifteeIdentityId", "GifteeIdentityId__c")
       .renameField("requestId", "CreatedRequestId__c")
+      .renameField("giftRedemptionDate", "GiftRedemptionDate__c")
   )
 }
 
-case class UpdateRedemptionDataRequest(requestId: String, gifteeIdentityId: String, currentTerm: Int, currentTermPeriodType: PeriodType)
+case class UpdateRedemptionDataRequest(
+  requestId: String,
+  gifteeIdentityId: String,
+  giftRedemptionDate: LocalDate,
+  currentTerm: Int,
+  currentTermPeriodType: PeriodType
+)
 

--- a/support-services/src/main/scala/com/gu/zuora/ZuoraGiftService.scala
+++ b/support-services/src/main/scala/com/gu/zuora/ZuoraGiftService.scala
@@ -8,6 +8,7 @@ import com.gu.support.touchpoint.TouchpointService
 import com.gu.support.zuora.api.{Day, QueryData, UpdateRedemptionDataRequest}
 import com.gu.support.zuora.api.response.{Subscription, SubscriptionRedemptionQueryResponse, UpdateRedemptionDataResponse, ZuoraErrorResponse}
 import io.circe.syntax.EncoderOps
+import org.joda.time.LocalDate
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -41,9 +42,10 @@ class ZuoraGiftService(val config: ZuoraConfig, client: FutureHttpClient)(implic
     subscriptionId: String,
     requestId: String,
     gifteeIdentityId: String,
+    giftRedemptionDate: LocalDate,
     newTermLength: Int
   ): Future[UpdateRedemptionDataResponse] = {
-    val requestData = UpdateRedemptionDataRequest(requestId, gifteeIdentityId, newTermLength, Day)
+    val requestData = UpdateRedemptionDataRequest(requestId, gifteeIdentityId, giftRedemptionDate, newTermLength, Day)
     putJson[UpdateRedemptionDataResponse](s"subscriptions/${subscriptionId}", requestData.asJson, authHeaders)
   }
 }

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -326,7 +326,7 @@ object DigitalSubscriptionGiftRedemption {
       subIdUpdateAction <- codeValidation match {
         case ValidGiftCode(subscriptionId) => Future.successful((
           subscriptionId,
-          zuoraService.updateSubscriptionRedemptionData(subscriptionId, state.requestId.toString, state.user.id, _)
+          zuoraService.updateSubscriptionRedemptionData(subscriptionId, state.requestId.toString, state.user.id, LocalDate.now(), _)
         ))
         case CodeRedeemedInThisRequest(subscriptionId) => Future.successful(subscriptionId, (_: Int) => Future.successful(UpdateRedemptionDataResponse(true)))
         case otherState: CodeStatus => Future.failed(new RuntimeException(otherState.clientCode))


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
We want to be able to record the date a gift subscription was redeemed in a custom field in Zuora so that it is available to analysts in the Data Lake. 

This PR updates the `GifteeRedemptionDate` custom field with the current date when a gift code is redeemed.


[**Trello Card**](https://trello.com/c/wSuf5u9V/3453-add-redemption-date-field)

