### PR TITLE
Gifting: digital subs landing page - fixes

### DIFF
--- a/support-frontend/app/controllers/Promotions.scala
+++ b/support-frontend/app/controllers/Promotions.scala
@@ -30,7 +30,7 @@ class Promotions(
 
   implicit val a: AssetsResolver = assets
 
-  def promo(promoCode: String, orderIsAGift: Boolean = false): Action[AnyContent] = CachedAction() { implicit request =>
+  def promo(promoCode: String): Action[AnyContent] = CachedAction() { implicit request =>
     val promotionService = promotionServiceProvider.forUser(false)
     val maybePromotionTerms = PromotionTerms.fromPromoCode(promotionService, stage, promoCode)
 
@@ -38,7 +38,7 @@ class Promotions(
     ) { promotionTerms =>
       val productLandingPage = promotionTerms.product match {
         case GuardianWeekly => routes.WeeklySubscription.weeklyGeoRedirect(promotionTerms.isGift).url
-        case DigitalPack => routes.DigitalSubscriptionController.digitalGeoRedirect(orderIsAGift).url
+        case DigitalPack => routes.DigitalSubscriptionController.digitalGeoRedirect(false).url
         case Paper => routes.PaperSubscription.paper(false).url
         case Contribution => routes.Application.contributeGeoRedirect("").url
       }

--- a/support-frontend/assets/helpers/routes.js
+++ b/support-frontend/assets/helpers/routes.js
@@ -37,7 +37,6 @@ const routes: {
   postcodeLookup: '/postcode-lookup',
   createSignInUrl: '/identity/signin-url',
   stripeSetupIntentRecaptcha: '/stripe/create-setup-intent/recaptcha',
-  signInUrl: 'https://profile.theguardian.com/signin',
 };
 
 const createReminderEndpoint = isProd() ?

--- a/support-frontend/assets/helpers/routes.js
+++ b/support-frontend/assets/helpers/routes.js
@@ -37,6 +37,7 @@ const routes: {
   postcodeLookup: '/postcode-lookup',
   createSignInUrl: '/identity/signin-url',
   stripeSetupIntentRecaptcha: '/stripe/create-setup-intent/recaptcha',
+  signInUrl: 'https://profile.theguardian.com/signin',
 };
 
 const createReminderEndpoint = isProd() ?

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/digitalCheckoutFormGift.jsx
@@ -172,7 +172,7 @@ function DigitalCheckoutFormGift(props: PropTypes) {
           description="Premium App + The Guardian Daily + Ad-free"
           productPrice={productPrice}
           billingPeriod={props.billingPeriod}
-          changeSubscription={routes.digitalSubscriptionLanding}
+          changeSubscription={routes.digitalSubscriptionLandingGift}
           orderIsAGift
         />)}
       >

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/thankYou/appsSection.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/thankYou/appsSection.jsx
@@ -17,7 +17,6 @@ import {
   androidDailyUrl,
   getDailyEditionUrl,
 } from 'helpers/externalLinks';
-import { routes } from 'helpers/routes';
 
 
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
@@ -145,7 +144,7 @@ const AppsSection = ({ countryGroupId }: PropTypes) => (
           iconSide="right"
           nudgeIcon
           aria-label="Click to sign in to the website"
-          href={routes.signInUrl}
+          href="https://www.theguardian.com/"
           onClick={sendTrackingEventsOnClick('checkout_thankyou_sign_in', 'DigitalPack', null)}
         >
           <span css={largerFormatText}>Sign into the website</span>

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/thankYou/appsSection.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/thankYou/appsSection.jsx
@@ -17,6 +17,7 @@ import {
   androidDailyUrl,
   getDailyEditionUrl,
 } from 'helpers/externalLinks';
+import { routes } from 'helpers/routes';
 
 
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
@@ -129,6 +130,28 @@ const AppsSection = ({ countryGroupId }: PropTypes) => (
           </LinkButton>
         </ThemeProvider>
       </div>
+    </Text>
+    <Text title="Sign into theguardian.com">
+      <p>
+        Never be interrupted or distracted by ads again by signing in. Just use your subscriber email
+        and password when you next visit.
+      </p>
+      <ThemeProvider theme={buttonReaderRevenueBrandAlt}>
+        <LinkButton
+          css={marginForFirstButton}
+          priority="tertiary"
+          size="default"
+          icon={<SvgArrowRightStraight />}
+          iconSide="right"
+          nudgeIcon
+          aria-label="Click to sign in to the website"
+          href={routes.signInUrl}
+          onClick={sendTrackingEventsOnClick('checkout_thankyou_sign_in', 'DigitalPack', null)}
+        >
+          <span css={largerFormatText}>Sign into the website</span>
+          <span css={smallFormatText}>Sign in</span>
+        </LinkButton>
+      </ThemeProvider>
     </Text>
   </div>
 );

--- a/support-frontend/assets/pages/digital-subscription-checkout/thankYouGift.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/thankYouGift.jsx
@@ -187,7 +187,7 @@ const GreenCheckMark = () => (
 
 function ThankYouGift(props: PropTypes) {
   const date = props.giftDeliveryDate ? new Date(props.giftDeliveryDate) : null;
-  const fullDate = date ? formatUserDate(date) : 'Invalid date';
+  const fullDate = date ? formatUserDate(date) : 'Date chosen by you at checkout';
 
   return (
     <div className="thank-you-stage">
@@ -246,7 +246,7 @@ function ThankYouGift(props: PropTypes) {
             <ul>
               <li css={detailsWithIconList}>
                 <div css={iconContainer}><img src={gift} alt="" /></div>
-                <div css={giftStep}>{props.giftRecipient ? props.giftRecipient : 'Your recipient'} will receive an email on the date you&apos;ve chosen with
+                <div css={giftStep}>{props.giftRecipient || 'Your recipient'} will receive an email on the date you&apos;ve chosen with
                 the link to redeem the gift.
                 </div>
               </li>
@@ -255,7 +255,7 @@ function ThankYouGift(props: PropTypes) {
               </li>
               <li css={detailsWithIconList}>
                 <div css={iconContainer}><img src={person} alt="" /></div>
-                <div css={giftStep}>After redemption, {props.giftRecipient ? props.giftRecipient : 'your recipient'} will have to register or sign into their
+                <div css={giftStep}>After redemption, {props.giftRecipient || 'your recipient'} will have to register or sign into their
                 account and the subscription will be activated.
                 </div>
               </li>
@@ -264,7 +264,7 @@ function ThankYouGift(props: PropTypes) {
               </li>
               <li css={detailsWithIconList}>
                 <div css={iconContainer}><img src={phone} alt="" /></div>
-                <div css={giftStep}>{props.giftRecipient ? props.giftRecipient : 'Your recipient'} will download the smartphone and tablet apps and can sign
+                <div css={giftStep}>{props.giftRecipient || 'Your recipient'} will download the smartphone and tablet apps and can sign
                 in on the web to enjoy all the benefits of being a subscriber.
                 </div>
               </li>

--- a/support-frontend/assets/pages/digital-subscription-checkout/thankYouGift.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/thankYouGift.jsx
@@ -209,8 +209,8 @@ function ThankYouGift(props: PropTypes) {
         >
           <div css={topPageSection}>
             <GreenCheckMark /><h1 css={pageHeading}>Thank you for your order</h1>
-            <div css={blueSans}>{props.pending ? 'Your Digital subscription order has been placed and is pending confirmation' :
-            'Your Digital subscription order has been placed successfully'}
+            <div css={blueSans}>{props.pending ? `Your digital subscription order for ${props.giftRecipient} has been placed and is pending confirmation` :
+            `Your digital subscription order for ${props.giftRecipient} has been placed successfully`}
             </div>
             <div css={mobileImage}>
               <GridImage

--- a/support-frontend/assets/pages/digital-subscription-checkout/thankYouGift.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/thankYouGift.jsx
@@ -209,8 +209,8 @@ function ThankYouGift(props: PropTypes) {
         >
           <div css={topPageSection}>
             <GreenCheckMark /><h1 css={pageHeading}>Thank you for your order</h1>
-            <div css={blueSans}>{props.pending ? `Your digital subscription order for ${props.giftRecipient} has been placed and is pending confirmation` :
-            `Your digital subscription order for ${props.giftRecipient} has been placed successfully`}
+            <div css={blueSans}>{props.pending ? `Your digital subscription order ${props.giftRecipient ? `for ${props.giftRecipient}` : ''} has been placed and is pending confirmation` :
+            `Your digital subscription order ${props.giftRecipient ? `for ${props.giftRecipient}` : ''} has been placed successfully`}
             </div>
             <div css={mobileImage}>
               <GridImage
@@ -246,7 +246,7 @@ function ThankYouGift(props: PropTypes) {
             <ul>
               <li css={detailsWithIconList}>
                 <div css={iconContainer}><img src={gift} alt="" /></div>
-                <div css={giftStep}>{props.giftRecipient} will receive an email on the date you&apos;ve chosen with
+                <div css={giftStep}>{props.giftRecipient ? props.giftRecipient : 'Your recipient'} will receive an email on the date you&apos;ve chosen with
                 the link to redeem the gift.
                 </div>
               </li>
@@ -255,7 +255,7 @@ function ThankYouGift(props: PropTypes) {
               </li>
               <li css={detailsWithIconList}>
                 <div css={iconContainer}><img src={person} alt="" /></div>
-                <div css={giftStep}>After redemption, {props.giftRecipient} will have to register or sign into their
+                <div css={giftStep}>After redemption, {props.giftRecipient ? props.giftRecipient : 'your recipient'} will have to register or sign into their
                 account and the subscription will be activated.
                 </div>
               </li>
@@ -264,14 +264,14 @@ function ThankYouGift(props: PropTypes) {
               </li>
               <li css={detailsWithIconList}>
                 <div css={iconContainer}><img src={phone} alt="" /></div>
-                <div css={giftStep}>{props.giftRecipient} will download the smartphone and tablet apps and can sign
+                <div css={giftStep}>{props.giftRecipient ? props.giftRecipient : 'Your recipient'} will download the smartphone and tablet apps and can sign
                 in on the web to enjoy all the benefits of being a subscriber.
                 </div>
               </li>
             </ul>
           </PageSection>
           <PageSection>
-            <h3 css={minorHeading}>Tell us about your subscription</h3>
+            <h3 css={minorHeading}>Tell us about your experience</h3>
             <LinkButton
               href="https://www.surveymonkey.co.uk/r/QF9ZGQR"
               priority="secondary"

--- a/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroStyles.js
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroStyles.js
@@ -12,7 +12,7 @@ import { digitalSubscriptionsBlue } from 'stylesheets/emotion/colours';
 
 export const wrapper = css`
   position: relative;
-  background: #ededed;
+  background: ${neutral[93]};
   display: flex;
   flex-direction: column;
   padding-top: ${space[3]}px;

--- a/support-frontend/assets/pages/digital-subscription-landing/components/heroGift/hero.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/heroGift/hero.jsx
@@ -23,6 +23,7 @@ import {
   heroHeading,
   paragraph,
   heavyText,
+  mobileLineBreak,
   packShot,
 } from './heroStyles';
 
@@ -33,10 +34,9 @@ type PropTypes = {
 const GiftCopy = () => (
   <span>
     <p css={paragraph}>
-      <span css={heavyText}>A gift that matters</span><br />
-      With two innovative apps and ad-free reading, a digital gift subscription not only funds The Guardian&apos;s
-      independent reporting but also shares the richest experience of our journalism with the people you care about
-      the most.
+      <span css={heavyText}>Share what matters most,<br css={mobileLineBreak} /> even when apart</span><br />
+      Show that you care with the gift of a digital gift subscription. Your loved ones will get the
+      richest, ad-free experience of our independent journalism and your gift will help fund our work.
     </p>
   </span>);
 

--- a/support-frontend/assets/pages/digital-subscription-landing/components/heroGift/heroStyles.js
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/heroGift/heroStyles.js
@@ -10,6 +10,10 @@ import { from } from '@guardian/src-foundations/mq';
 import { space } from '@guardian/src-foundations';
 import { digitalSubscriptionsBlue } from 'stylesheets/emotion/colours';
 
+// ----- Constants ----- //
+
+const allowsAnimation = '@media (prefers-reduced-motion: no-preference)';
+
 export const wrapper = css`
   position: relative;
   background: ${neutral[93]};
@@ -137,246 +141,245 @@ export const toFromLines = css`
 `;
 
 export const toYouTyping = css`
-  overflow: hidden; /* Ensures the content is not revealed until the animation */
-  white-space: nowrap; /* Keeps the content on a single line */
-  letter-spacing: 0.01em; /* Adjust as needed */
-  margin-left: ${space[2]}px;
-  animation:
-    typing-to 0.7s steps(3, end);
+  animation: none;
+  -webkit-animation: none;
 
-  /* This is to make it work on iPhones */
-  -webkit-animation-name: typing-to;
-  -webkit-animation-duration: 0.7s;
-  -webkit-animation-timing-function: steps(3, end);
+  ${allowsAnimation} {
+    overflow: hidden; /* Ensures the content is not revealed until the animation */
+    white-space: nowrap; /* Keeps the content on a single line */
+    letter-spacing: 0.01em; /* Adjust as needed */
+    margin-left: ${space[2]}px;
+    animation:
+      typing-to 0.7s steps(3, end);
 
-  @keyframes typing-to {
-    from { width: 0 }
-    to { width: 17.5% }
-  }
+    /* This is to make it work on iPhones */
+    -webkit-animation-name: typing-to;
+    -webkit-animation-duration: 0.7s;
+    -webkit-animation-timing-function: steps(3, end);
 
-  @-webkit-keyframes typing-to {
-    from { width: 0 }
-    to { width: 17.5% }
-  }
-
-  animation-fill-mode: both;
-  -webkit-animation-fill-mode: both;
-  animation-delay: 1s;
-  -webkit-animation-delay: 1s;
-
-  @media (prefers-reduced-motion) {
-    animation: none;
-    -webkit-animation: none;
-    border-right: none;
-    -webkit-border-right: none;
-  }
-
-  @keyframes typing-to {
-    from { width: 0 }
-    to { width: 17.5% }
-  }
-
-  color: ${brandAltBackground.primary};
-  ${headline.small({ fontWeight: 'bold' })};
-
-  ${from.mobileMedium} {
     @keyframes typing-to {
       from { width: 0 }
-      to { width: 15% }
+      to { width: 17.5% }
     }
-  }
 
-  ${from.mobileLandscape} {
-    ${headline.medium({ fontWeight: 'bold' })};
-    @keyframes typing-to {
+    @-webkit-keyframes typing-to {
       from { width: 0 }
-      to { width: 14% }
+      to { width: 17.5% }
     }
-  }
 
-  ${from.phablet} {
+    animation-fill-mode: both;
+    -webkit-animation-fill-mode: both;
+    animation-delay: 1s;
+    -webkit-animation-delay: 1s;
+
     @keyframes typing-to {
       from { width: 0 }
-      to { width: 10% }
+      to { width: 17.5% }
     }
-  }
 
-  ${from.tablet} {
-    @keyframes typing-to {
-      from { width: 0 }
-      to { width: 17% }
+    color: ${brandAltBackground.primary};
+    ${headline.small({ fontWeight: 'bold' })};
+
+    ${from.mobileMedium} {
+      @keyframes typing-to {
+        from { width: 0 }
+        to { width: 15% }
+      }
     }
-  }
 
-  ${from.desktop} {
-    ${headline.large({ fontWeight: 'bold' })};
-    margin-left: 8px;
-    @keyframes typing-to {
-      from { width: 0 }
-      to { width: 16% }
+    ${from.mobileLandscape} {
+      ${headline.medium({ fontWeight: 'bold' })};
+      @keyframes typing-to {
+        from { width: 0 }
+        to { width: 14% }
+      }
     }
-  }
 
-  ${from.leftCol} {
-    @keyframes typing-to {
-      from { width: 0 }
-      to { width: 18.5% }
+    ${from.phablet} {
+      @keyframes typing-to {
+        from { width: 0 }
+        to { width: 10% }
+      }
     }
-  }
 
-  ${from.wide} {
-    @keyframes typing-to {
-      from { width: 0 }
-      to { width: 16.5% }
+    ${from.tablet} {
+      @keyframes typing-to {
+        from { width: 0 }
+        to { width: 17% }
+      }
+    }
+
+    ${from.desktop} {
+      ${headline.large({ fontWeight: 'bold' })};
+      margin-left: 8px;
+      @keyframes typing-to {
+        from { width: 0 }
+        to { width: 16% }
+      }
+    }
+
+    ${from.leftCol} {
+      @keyframes typing-to {
+        from { width: 0 }
+        to { width: 18.5% }
+      }
+    }
+
+    ${from.wide} {
+      @keyframes typing-to {
+        from { width: 0 }
+        to { width: 16.5% }
+      }
     }
   }
 `;
 
 export const toYouCursor = css`
-  overflow: hidden; /* Ensures the content is not revealed until the animation */
-  border-right: 1px solid white; /* The typwriter cursor */
-  white-space: nowrap; /* Keeps the content on a single line */
-  animation:
-    blink-caret-to 0.7s steps(3, jump-both);
+  animation: none;
+  -webkit-animation: none;
+  border-right: none;
+  -webkit-border-right: none;
 
-  /* This is to make it work on iPhones */
-  -webkit-animation-name: blink-caret-to;
-  -webkit-animation-duration: 0.7s;
-  -webkit-animation-timing-function: steps(3, jump-both);
-  animation-fill-mode: both;
-  -webkit-animation-fill-mode: both;
-  animation-delay: 1s;
-  -webkit-animation-delay: 1s;
+  ${allowsAnimation} {
+    overflow: hidden; /* Ensures the content is not revealed until the animation */
+    border-right: 1px solid white; /* The typwriter cursor */
+    white-space: nowrap; /* Keeps the content on a single line */
+    animation:
+      blink-caret-to 0.7s steps(3, jump-both);
 
-  animation-fill-mode: both;
-  -webkit-animation-fill-mode: both;
-  animation-delay: 1s;
-  -webkit-animation-delay: 1s;
+    /* This is to make it work on iPhones */
+    -webkit-animation-name: blink-caret-to;
+    -webkit-animation-duration: 0.7s;
+    -webkit-animation-timing-function: steps(3, jump-both);
+    animation-fill-mode: both;
+    -webkit-animation-fill-mode: both;
+    animation-delay: 1s;
+    -webkit-animation-delay: 1s;
 
-  @media (prefers-reduced-motion) {
-    animation: none;
-    -webkit-animation: none;
-    border-right: none;
-    -webkit-border-right: none;
-  }
+    animation-fill-mode: both;
+    -webkit-animation-fill-mode: both;
+    animation-delay: 1s;
+    -webkit-animation-delay: 1s;
 
-  @keyframes blink-caret-to {
-    from, to { border-color: transparent }
-    50% { border-color: white; }
+    @keyframes blink-caret-to {
+      from, to { border-color: transparent }
+      50% { border-color: white; }
+    }
   }
 `;
 
 export const fromMeTyping = css`
-  overflow: hidden; /* Ensures the content is not revealed until the animation */
-  white-space: nowrap; /* Keeps the content on a single line */
-  letter-spacing: 0.01em; /* Adjust as needed */
-  margin-left: ${space[2]}px;
-  animation:
-    typing-from 0.5s steps(2, end);
+  animation: none;
+  -webkit-animation: none;
 
-  /* This is to make it work on iPhones */
-  -webkit-animation-name: typing-from;
-  -webkit-animation-duration: 0.5s;
-  -webkit-animation-timing-function: steps(2, end);
+  ${allowsAnimation} {
+    overflow: hidden; /* Ensures the content is not revealed until the animation */
+    white-space: nowrap; /* Keeps the content on a single line */
+    letter-spacing: 0.01em; /* Adjust as needed */
+    margin-left: ${space[2]}px;
+    animation:
+      typing-from 0.5s steps(2, end);
 
-  animation-fill-mode: both;
-  -webkit-animation-fill-mode: both;
-  animation-delay: 2.4s;
-  -webkit-animation-delay: 2.4s;
+    /* This is to make it work on iPhones */
+    -webkit-animation-name: typing-from;
+    -webkit-animation-duration: 0.5s;
+    -webkit-animation-timing-function: steps(2, end);
 
-  color: ${brandAltBackground.primary};
+    animation-fill-mode: both;
+    -webkit-animation-fill-mode: both;
+    animation-delay: 2.4s;
+    -webkit-animation-delay: 2.4s;
 
-  @media (prefers-reduced-motion) {
-    animation: none;
-    border-right: none;
-  }
+    color: ${brandAltBackground.primary};
 
-  @keyframes typing-from {
-    from { width: 0 }
-    to { width: 14% }
-  }
-
-  @-webkit-keyframes typing-from {
-    from { width: 0 }
-    to { width: 14% }
-  }
-
-  ${headline.small({ fontWeight: 'bold' })};
-
-  ${from.mobileMedium} {
-    @keyframes typing-from {
-      from { width: 0 }
-      to { width: 12% }
-    }
-  }
-
-  ${from.mobileLandscape} {
-    ${headline.medium({ fontWeight: 'bold' })};
-    @keyframes typing-from {
-      from { width: 0 }
-      // Looks like a repetition but seems only to work at this size if specified
-      to { width: 12% }
-    }
-  }
-
-  ${from.tablet} {
     @keyframes typing-from {
       from { width: 0 }
       to { width: 14% }
     }
-  }
 
-  ${from.desktop} {
-    ${headline.large({ fontWeight: 'bold' })};
-    margin-left: 8px;
-    @keyframes typing-from {
+    @-webkit-keyframes typing-from {
       from { width: 0 }
-      to { width: 13% }
+      to { width: 14% }
     }
-  }
 
-  ${from.leftCol} {
-    @keyframes typing-from {
-      from { width: 0 }
-      to { width: 15.5% }
+    ${headline.small({ fontWeight: 'bold' })};
+
+    ${from.mobileMedium} {
+      @keyframes typing-from {
+        from { width: 0 }
+        to { width: 12% }
+      }
     }
-  }
 
-  ${from.wide} {
-    @keyframes typing-from {
-      from { width: 0 }
-      to { width: 13.25% }
+    ${from.mobileLandscape} {
+      ${headline.medium({ fontWeight: 'bold' })};
+      @keyframes typing-from {
+        from { width: 0 }
+        // Looks like a repetition but seems only to work at this size if specified
+        to { width: 12% }
+      }
+    }
+
+    ${from.tablet} {
+      @keyframes typing-from {
+        from { width: 0 }
+        to { width: 14% }
+      }
+    }
+
+    ${from.desktop} {
+      ${headline.large({ fontWeight: 'bold' })};
+      margin-left: 8px;
+      @keyframes typing-from {
+        from { width: 0 }
+        to { width: 13% }
+      }
+    }
+
+    ${from.leftCol} {
+      @keyframes typing-from {
+        from { width: 0 }
+        to { width: 15.5% }
+      }
+    }
+
+    ${from.wide} {
+      @keyframes typing-from {
+        from { width: 0 }
+        to { width: 13.25% }
+      }
     }
   }
 
 `;
 
 export const fromMeCursor = css`
-  overflow: hidden; /* Ensures the content is not revealed until the animation */
-  border-right: 1px solid white; /* The typwriter cursor */
-  animation:
-    blink-caret-from 0.7s steps(2, jump-end);
+  animation: none;
+  -webkit-animation: none;
+  border-right: none;
+  -webkit-border-right: none;
 
-  /* This is to make it work on iPhones */
-  -webkit-animation-name: blink-caret-from;
-  -webkit-animation-duration: 0.7s;
-  -webkit-animation-timing-function: steps(2, jump-end);
+  ${allowsAnimation} {
+    overflow: hidden; /* Ensures the content is not revealed until the animation */
+    border-right: 1px solid white; /* The typwriter cursor */
+    animation:
+      blink-caret-from 0.7s steps(2, jump-end);
 
-  animation-fill-mode: both;
-  -webkit-animation-fill-mode: both;
-  animation-delay: 2.4s;
-  -webkit-animation-delay: 2.4s;
+    /* This is to make it work on iPhones */
+    -webkit-animation-name: blink-caret-from;
+    -webkit-animation-duration: 0.7s;
+    -webkit-animation-timing-function: steps(2, jump-end);
 
-  @media (prefers-reduced-motion) {
-    animation: none;
-    border-right: none;
+    animation-fill-mode: both;
+    -webkit-animation-fill-mode: both;
+    animation-delay: 2.4s;
+    -webkit-animation-delay: 2.4s;
+
+    @keyframes blink-caret-from {
+      from, to { border-color: transparent }
+      50% { border-color: white; }
+    }
   }
-
-  @keyframes blink-caret-from {
-    from, to { border-color: transparent }
-    50% { border-color: white; }
-  }
-
 `;
 
 export const heroHeading = css`

--- a/support-frontend/assets/pages/digital-subscription-landing/components/heroGift/heroStyles.js
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/heroGift/heroStyles.js
@@ -126,7 +126,11 @@ export const textSection = css`
 
   ${from.leftCol} {
     width: 40%;
-    padding-bottom: 40px;
+    padding-bottom: 60px;
+  }
+
+  ${from.wide} {
+    padding-bottom: 80px;
   }
 `;
 
@@ -404,7 +408,7 @@ export const heroHeading = css`
 export const paragraph = css`
   ${body.small()};
   max-width: 100%;
-  margin: ${space[5]}px 0;
+  margin: ${space[2]}px 0 ${space[5]}px;
 
   ${from.mobileMedium} {
     ${body.medium()};
@@ -412,24 +416,31 @@ export const paragraph = css`
 
   ${from.tablet} {
     ${body.medium()};
-    max-width: 90%;
+    max-width: 83%;
   }
 
   ${from.desktop} {
     ${headline.xxsmall()};
     line-height: 135%;
     max-width: 87%;
-    margin-top: 20px;
+    margin-bottom: ${space[9]}px;
   }
 
   ${from.leftCol} {
     max-width: 100%;
-    margin-top: ${space[12]}px;
   }
 `;
 
 export const heavyText = css`
   font-weight: bold;
+`;
+
+export const mobileLineBreak = css`
+  display: block;
+
+  ${from.desktop} {
+    display: none;
+  }
 `;
 
 export const packShot = css`

--- a/support-frontend/assets/pages/digital-subscription-landing/components/heroGift/heroStyles.js
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/heroGift/heroStyles.js
@@ -19,27 +19,23 @@ export const wrapper = css`
   background: ${neutral[93]};
   display: flex;
   flex-direction: column;
-  padding: 0 0 ${space[3]}px;
+  padding-top: ${space[3]}px;
 
   :before {
     position: absolute;
     top: 0;
     left: 0;
     width: 100%;
-    height: 120px;
+    height: 170px;
     background: ${digitalSubscriptionsBlue};
     content: '';
   }
 
   ${from.mobileLandscape} {
+    padding-top: ${space[4]}px;
     :before {
+      margin-top: -1px;
       height: 200px;
-    }
-  }
-
-  ${from.tablet} {
-    :before {
-      top: -1px;
     }
   }
 `;
@@ -49,28 +45,27 @@ export const pageTitle = css`
   color: ${neutral[97]};
   z-index: 10;
   background-color: transparent;
-  padding: ${space[3]}px;
-  align-self: center;
+  padding: 0 ${space[3]}px ${space[3]}px;
+  width: 100%;
 
   ${from.mobileLandscape} {
-    ${headline.large({ fontWeight: 'bold' })};
+    padding-bottom: ${space[4]}px;
   }
 
   ${from.phablet} {
     width: 100%;
-    padding: ${space[5]}px ${space[3]}px;
+    align-self: center;
   }
 
   ${from.tablet} {
     width: calc(100% - 40px);
-    align-self: center;
   }
 
   ${from.desktop} {
     ${titlepiece.medium()}
     max-width: calc(100% - 110px);
     max-width: 1100px;
-    padding: ${space[5]}px ${space[4]}px;
+    padding: ${space[3]}px ${space[4]}px ${space[9]}px;
   }
 
   ${from.leftCol} {


### PR DESCRIPTION
## What are you doing in this PR?
These are fixes from the [digital gift subscriptions landing page PR](https://github.com/guardian/support-frontend/pull/2775). This pull request needed to be merged because we wanted to begin end-to-end testing, but there were a couple of things that were outstanding from feedback on the PR.

* Remove orderIsAGift param from Promotions.scala
* Make no animations the default behaviour in gifting
* Update the text for the gifting hero (screenshot below)

The details of these fixes are in this [trello Card](https://trello.com/c/ElhMe2AO/3433-digital-subscriptions-gift-landing-page-follow-up-work-90)

In addition, this PR contains fixes for issues that were picked up in end-to-end testing:
* The change link in the gift checkout order summary was pointing to the non-gift landing page
* The copy on the gift thank you page reads: "Your Digital subscription order has been placed successfully" and it should read: "Your Digital subscription gift for [firstname] has been placed successfully" (screenshot below)
* The heading on the gift thank you page that reads: "Tell us about your subscription" should read: "Tell us about your experience" (screenshot below)
* There should be a sign-in for ad-free reading section on the regular DS thank you page (screenshot of what's been added, below)

### Updated hero text

![Screen Shot 2020-11-18 at 11 43 19](https://user-images.githubusercontent.com/16781258/99526560-53ee7580-2993-11eb-87d1-779332a033fb.png)

### Giftee name included in first paragraph

![Screen Shot 2020-11-17 at 12 44 00](https://user-images.githubusercontent.com/16781258/99391974-e418b600-28d2-11eb-99df-07749f2c3ef0.png)

### Tell us about your experience

![Screen Shot 2020-11-17 at 12 44 18](https://user-images.githubusercontent.com/16781258/99392008-ee3ab480-28d2-11eb-9c44-533b14eb3821.png)

### Add sign-in for ad-free to thank you page

![Screen Shot 2020-11-17 at 12 53 14](https://user-images.githubusercontent.com/16781258/99392727-137bf280-28d4-11eb-932a-37c18f818bdd.png)
