### PR TITLE
Test contribution type and amount in the thankyou page header

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -4,12 +4,35 @@ import { USV1, AusAmounts, UkAmountsV1 } from './data/testAmountsData';
 
 // ----- Tests ----- //
 
+const landingPage = '/??/contribute|thankyou(/.*)?$';
 const usOnlyLandingPage = '/us/contribute(/.*)?$';
 const auOnlyLandingPage = '/au/contribute(/.*)?$';
 const ukOnlyLandingPage = '/uk/contribute(/.*)?$';
 export const subsShowcaseAndDigiSubPages = '(/??/subscribe(\\?.*)?$|/??/subscribe/digital(\\?.*)?$)';
 
 export const tests: Tests = {
+  thankyouPageHeadingTest: {
+    type: 'OTHER',
+    variants: [
+      {
+        id: 'control',
+      },
+      {
+        id: 'V1',
+      },
+    ],
+    audiences: {
+      ALL: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: true,
+    referrerControlled: false,
+    targetPage: landingPage,
+    seed: 1,
+  },
+
   usAmountsTest: {
     type: 'AMOUNTS',
     variants: [

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
@@ -24,6 +24,8 @@ import { trackUserData, OPHAN_COMPONENT_ID_RETURN_TO_GUARDIAN } from './utils/op
 import { trackComponentClick } from 'helpers/tracking/behaviour';
 import { getCampaignSettings } from 'helpers/campaigns';
 import type { CampaignSettings } from 'helpers/campaigns';
+import { getAmount } from 'helpers/contributions';
+import type {IsoCurrency} from "helpers/internationalisation/currency";
 
 const container = css`
   background: white;
@@ -109,24 +111,34 @@ type ContributionThankYouProps = {|
   csrf: Csrf,
   email: string,
   contributionType: ContributionType,
+  amount: string,
+  currency: IsoCurrency,
   name: string,
   user: User,
   guestAccountCreationToken: string,
   paymentMethod: PaymentMethod,
   countryId: IsoCountry,
   campaignCode: ?string,
+  thankyouPageHeadingTestVariant: boolean,
 |};
 
 const mapStateToProps = state => ({
   email: state.page.form.formData.email,
   name: state.page.form.formData.firstName,
   contributionType: state.page.form.contributionType,
+  amount: getAmount(
+    state.page.form.selectedAmounts,
+    state.page.form.formData.otherAmounts,
+    state.page.form.contributionType,
+  ),
+  currency: state.common.internationalisation.currencyId,
   csrf: state.page.csrf,
   user: state.page.user,
   guestAccountCreationToken: state.page.form.guestAccountCreationToken,
   paymentMethod: state.page.form.paymentMethod,
   countryId: state.common.internationalisation.countryId,
   campaignCode: state.common.referrerAcquisitionData.campaignCode,
+  thankyouPageHeadingTestVariant: state.common.abParticipations.thankyouPageHeadingTest === 'V1',
 });
 
 const ContributionThankYou = ({
@@ -134,11 +146,14 @@ const ContributionThankYou = ({
   email,
   name,
   contributionType,
+  amount,
+  currency,
   user,
   guestAccountCreationToken,
   paymentMethod,
   countryId,
   campaignCode,
+  thankyouPageHeadingTestVariant
 }: ContributionThankYouProps) => {
   const isKnownEmail = guestAccountCreationToken === null;
   const campaignSettings = useMemo<CampaignSettings | null>(() => getCampaignSettings(campaignCode));
@@ -229,6 +244,11 @@ const ContributionThankYou = ({
         <ContributionThankYouHeader
           name={name}
           showDirectDebitMessage={paymentMethod === DirectDebit}
+          paymentMethod={paymentMethod}
+          contributionType={contributionType}
+          amount={amount}
+          currency={currency}
+          thankyouPageHeadingTestVariant={thankyouPageHeadingTestVariant}
         />
       </div>
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouHeader.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouHeader.jsx
@@ -71,7 +71,7 @@ const ContributionThankYouHeader = ({
     if (thankyouPageHeadingTestVariant && !payPalOneOff && amount) {
       switch (contributionType) {
         case 'ONE_OFF':
-          return `Thank you for supporting us with ${currencies[currency].glyph}${amount} today`;
+          return `Thank you for supporting us today with ${currencies[currency].glyph}${amount}`;
         case 'MONTHLY':
           return `Thank you ${nameAndTrailingSpace}for choosing to contribute ${currencies[currency].glyph}${amount} each month`;
         case 'ANNUAL':

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouHeader.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouHeader.jsx
@@ -4,6 +4,10 @@ import { css } from '@emotion/core';
 import { titlepiece, body } from '@guardian/src-foundations/typography';
 import { space } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
+import type {ContributionType} from "helpers/contributions";
+import { currencies } from 'helpers/internationalisation/currency';
+import type {IsoCurrency} from "helpers/internationalisation/currency";
+import type {PaymentMethod} from "helpers/paymentMethods";
 
 const header = css`
   background: white;
@@ -39,7 +43,12 @@ const directDebitSetupText = css`
 
 type ContributionThankYouHeaderProps = {|
   name: string | null,
-  showDirectDebitMessage: boolean
+  showDirectDebitMessage: boolean,
+  paymentMethod: PaymentMethod,
+  contributionType: ContributionType,
+  amount: string,
+  currency: IsoCurrency,
+  thankyouPageHeadingTestVariant: boolean,
 |};
 
 const MAX_DISPLAY_NAME_LENGTH = 10;
@@ -47,14 +56,38 @@ const MAX_DISPLAY_NAME_LENGTH = 10;
 const ContributionThankYouHeader = ({
   name,
   showDirectDebitMessage,
+  paymentMethod,
+  contributionType,
+  amount,
+  currency,
+  thankyouPageHeadingTestVariant,
 }: ContributionThankYouHeaderProps) => {
-  const shouldShowName = name && name.length < MAX_DISPLAY_NAME_LENGTH;
+
+  const title = (): string => {
+    const nameAndTrailingSpace: string = name && name.length < MAX_DISPLAY_NAME_LENGTH ? `${name} ` : '';
+    // Do not show special header to paypal/one-off as we don't have the relevant info after the redirect
+    const payPalOneOff = paymentMethod === 'PayPal' && contributionType === 'ONE_OFF';
+
+    if (thankyouPageHeadingTestVariant && !payPalOneOff && amount) {
+      switch (contributionType) {
+        case 'ONE_OFF':
+          return `Thank you for supporting us with ${currencies[currency].glyph}${amount} today`;
+        case 'MONTHLY':
+          return `Thank you ${nameAndTrailingSpace}for choosing to contribute ${currencies[currency].glyph}${amount} each month`;
+        case 'ANNUAL':
+          return `Thank you ${nameAndTrailingSpace}for choosing to contribute ${currencies[currency].glyph}${amount} each year`;
+        default:
+          return `Thank you ${nameAndTrailingSpace}for your valuable contribution`;
+      }
+    } else {
+      return `Thank you ${nameAndTrailingSpace}for your valuable contribution`
+    }
+  };
+
   return (
     <header css={header}>
       <h1 css={headerTitleText}>
-        {shouldShowName && name
-          ? `Thank you ${name} for your valuable contribution`
-          : 'Thank you for your valuable contribution'}
+        {title()}
       </h1>
       <p css={headerSupportingText}>
         {showDirectDebitMessage && (


### PR DESCRIPTION
### One-off with card
![Screen Shot 2020-11-17 at 15 13 09](https://user-images.githubusercontent.com/1513454/99407894-82af1200-28e7-11eb-9567-e88947d720de.png)

### One-off paypal (not supported because we lose the required info in the redirect)
![Screen Shot 2020-11-17 at 15 12 33](https://user-images.githubusercontent.com/1513454/99407905-85aa0280-28e7-11eb-8984-190a67b23ba7.png)

### 'other' amount
![Screen Shot 2020-11-17 at 15 13 41](https://user-images.githubusercontent.com/1513454/99407918-893d8980-28e7-11eb-9f19-14020cc79518.png)

### Monthly
![Screen Shot 2020-11-17 at 15 15 28](https://user-images.githubusercontent.com/1513454/99408250-eafdf380-28e7-11eb-8f7b-eb6809edf9c8.png)

### Annual
![Screen Shot 2020-11-17 at 15 16 54](https://user-images.githubusercontent.com/1513454/99408285-f3eec500-28e7-11eb-96e5-c6b3a417171d.png)
