### PR TITLE
Digital Subscription gift revenue recognition

### DIFF
--- a/support-models/src/main/scala/com/gu/support/zuora/api/SubscribeRequest.scala
+++ b/support-models/src/main/scala/com/gu/support/zuora/api/SubscribeRequest.scala
@@ -5,7 +5,7 @@ import com.gu.support.encoding.Codec._
 import com.gu.support.encoding.CustomCodecs._
 import com.gu.support.encoding.JsonHelpers.JsonObjectExtensions
 import com.gu.support.workers.PaymentMethod
-import io.circe.Encoder
+import io.circe.{Encoder, Json}
 import io.circe.generic.semiauto.deriveEncoder
 import org.joda.time.LocalDate
 
@@ -46,5 +46,17 @@ case class UpdateRedemptionDataRequest(
   giftRedemptionDate: LocalDate,
   currentTerm: Int,
   currentTermPeriodType: PeriodType
+)
+
+object DistributeRevenueRequest {
+  implicit val encoder: Encoder[DistributeRevenueRequest] = deriveEncoder[DistributeRevenueRequest].mapJsonObject(
+    _.add("distributionType", Json.fromString("Daily distribution"))
+      .add("eventTypeSystemId", Json.fromString("DigitalSubscriptionGiftRedeemed"))
+  )
+}
+
+case class DistributeRevenueRequest(
+  recognitionStart: LocalDate,
+  recognitionEnd: LocalDate
 )
 

--- a/support-models/src/main/scala/com/gu/support/zuora/api/response/Responses.scala
+++ b/support-models/src/main/scala/com/gu/support/zuora/api/response/Responses.scala
@@ -206,4 +206,12 @@ object ZuoraSuccessOrFailureResponse {
   implicit val codec: Codec[ZuoraSuccessOrFailureResponse] = deriveCodec
 }
 
-case class ZuoraSuccessOrFailureResponse(success: Boolean)
+case class ZuoraSuccessOrFailureResponse(success: Boolean, reasons: Option[List[ZuoraErrorReason]]){
+  def errorMessage = reasons.flatMap(_.headOption).map(_.message)
+}
+
+object ZuoraErrorReason {
+  implicit val codec: Codec[ZuoraErrorReason] = deriveCodec
+}
+
+case class ZuoraErrorReason(code: String, message: String)

--- a/support-models/src/main/scala/com/gu/support/zuora/api/response/Responses.scala
+++ b/support-models/src/main/scala/com/gu/support/zuora/api/response/Responses.scala
@@ -12,6 +12,7 @@ import io.circe.syntax._
 import io.circe.{Decoder, Encoder, HCursor, Json}
 import org.joda.time.LocalDate
 
+
 sealed trait ZuoraResponse {
   def success: Boolean
 }
@@ -201,8 +202,8 @@ object PreviewSubscribeResponse {
 
 case class PreviewSubscribeResponse(invoiceData: List[InvoiceDataItem], success: Boolean) extends ZuoraResponse
 
-object UpdateRedemptionDataResponse {
-  implicit val codec: Codec[UpdateRedemptionDataResponse] = deriveCodec
+object ZuoraSuccessOrFailureResponse {
+  implicit val codec: Codec[ZuoraSuccessOrFailureResponse] = deriveCodec
 }
 
-case class UpdateRedemptionDataResponse(success: Boolean)
+case class ZuoraSuccessOrFailureResponse(success: Boolean)

--- a/support-models/src/main/scala/com/gu/support/zuora/api/response/SubscriptionsResponse.scala
+++ b/support-models/src/main/scala/com/gu/support/zuora/api/response/SubscriptionsResponse.scala
@@ -50,5 +50,9 @@ case class RevenueSchedulesResponse(revenueSchedules: List[RevenueSchedule])
 object RevenueSchedule {
   implicit val codec: Codec[RevenueSchedule] = deriveCodec
 }
-case class RevenueSchedule(number: String, recognitionRuleName: String)
+case class RevenueSchedule(
+  number: String,
+  amount: BigDecimal,
+  undistributedUnrecognizedRevenue: BigDecimal
+)
 

--- a/support-models/src/main/scala/com/gu/support/zuora/api/response/SubscriptionsResponse.scala
+++ b/support-models/src/main/scala/com/gu/support/zuora/api/response/SubscriptionsResponse.scala
@@ -9,17 +9,46 @@ object SubscriptionsResponse {
   implicit val codec: Codec[SubscriptionsResponse] = deriveCodec
 }
 
+case class SubscriptionsResponse(subscriptions: List[Subscription])
+
 object Subscription {
   implicit val codec: Codec[Subscription] = deriveCodec
 }
+
+case class Subscription(
+  customerAcceptanceDate: LocalDate,
+  accountNumber: String,
+  subscriptionNumber: String,
+  status: String,
+  CreatedRequestId__c: Option[String],
+  ratePlans: List[RatePlan]
+)
 
 object RatePlan {
   implicit val codec: Codec[RatePlan] = deriveCodec
 }
 
-case class SubscriptionsResponse(subscriptions: List[Subscription])
+case class RatePlan(
+  productId: String,
+  productName: String,
+  productRatePlanId: String,
+  ratePlanCharges: List[RatePlanCharge]
+)
 
-case class Subscription(customerAcceptanceDate: LocalDate, accountNumber: String, subscriptionNumber: String, status: String, CreatedRequestId__c: Option[String], ratePlans: List[RatePlan])
+object RatePlanCharge {
+  implicit val codec: Codec[RatePlanCharge] = deriveCodec
+}
 
-case class RatePlan(productId: String, productName: String, productRatePlanId: String)
+case class RatePlanCharge(id: String, name: String)
+
+object RevenueSchedulesResponse {
+  implicit val codec: Codec[RevenueSchedulesResponse] = deriveCodec
+}
+
+case class RevenueSchedulesResponse(revenueSchedules: List[RevenueSchedule])
+
+object RevenueSchedule {
+  implicit val codec: Codec[RevenueSchedule] = deriveCodec
+}
+case class RevenueSchedule(number: String, recognitionRuleName: String)
 

--- a/support-services/src/main/scala/com/gu/zuora/ZuoraGiftService.scala
+++ b/support-services/src/main/scala/com/gu/zuora/ZuoraGiftService.scala
@@ -1,12 +1,15 @@
 package com.gu.zuora
 
+import cats.data.OptionT
+import cats.implicits.catsStdInstancesForFuture
 import com.gu.okhttp.RequestRunners.FutureHttpClient
 import com.gu.rest.WebServiceHelper
 import com.gu.support.config.ZuoraConfig
 import com.gu.support.redemptions.RedemptionCode
 import com.gu.support.touchpoint.TouchpointService
-import com.gu.support.zuora.api.{Day, QueryData, UpdateRedemptionDataRequest}
-import com.gu.support.zuora.api.response.{Subscription, SubscriptionRedemptionQueryResponse, UpdateRedemptionDataResponse, ZuoraErrorResponse}
+import com.gu.support.workers.states.SendThankYouEmailState.TermDates
+import com.gu.support.zuora.api.{Day, DistributeRevenueRequest, QueryData, UpdateRedemptionDataRequest}
+import com.gu.support.zuora.api.response.{RevenueSchedulesResponse, Subscription, SubscriptionRedemptionQueryResponse, ZuoraErrorResponse, ZuoraResponse, ZuoraSuccessOrFailureResponse}
 import io.circe.syntax.EncoderOps
 import org.joda.time.LocalDate
 
@@ -44,8 +47,37 @@ class ZuoraGiftService(val config: ZuoraConfig, client: FutureHttpClient)(implic
     gifteeIdentityId: String,
     giftRedemptionDate: LocalDate,
     newTermLength: Int
-  ): Future[UpdateRedemptionDataResponse] = {
+  ): Future[ZuoraSuccessOrFailureResponse] = {
     val requestData = UpdateRedemptionDataRequest(requestId, gifteeIdentityId, giftRedemptionDate, newTermLength, Day)
-    putJson[UpdateRedemptionDataResponse](s"subscriptions/${subscriptionId}", requestData.asJson, authHeaders)
+    putJson[ZuoraSuccessOrFailureResponse](s"subscriptions/${subscriptionId}", requestData.asJson, authHeaders)
+  }
+
+  def setupRevenueRecognition(
+    subscription: Subscription,
+    termDates: TermDates
+  ) = {
+    //This doc describes what this method is doing: https://docs.google.com/document/d/1yNeaR2l1Ss_unXygntuntmRX-GicDelryuK25vmqToc/edit
+    (for {
+      ratePlan <- OptionT.fromOption(subscription.ratePlans.headOption)
+      ratePlanChargeId <- OptionT.fromOption(ratePlan.ratePlanCharges.headOption.map(_.id))
+      revenueSchedule <- OptionT.liftF(getRevenueSchedule(ratePlanChargeId))
+      revenueScheduleNumber <- OptionT.fromOption(revenueSchedule.revenueSchedules.headOption.map(_.number))
+      successOrFailureResponse <- OptionT.liftF(distributeRevenueByStartAndEndDates(revenueScheduleNumber, termDates))
+    } yield successOrFailureResponse).value
+  }
+
+  def getRevenueSchedule(ratePlanChargeId: String): Future[RevenueSchedulesResponse] =
+    get[RevenueSchedulesResponse](s"revenue-schedules/subscription-charges/${ratePlanChargeId}", authHeaders)
+
+  def distributeRevenueByStartAndEndDates(
+    revenueScheduleNumber: String,
+    termDates: TermDates
+  ) = {
+    val data = DistributeRevenueRequest(termDates.giftStartDate, termDates.giftEndDate)
+    putJson[ZuoraSuccessOrFailureResponse](
+      s"revenue-schedules/${revenueScheduleNumber}/distribute-revenue-with-date-range",
+      data.asJson,
+      authHeaders
+    )
   }
 }

--- a/support-services/src/main/scala/com/gu/zuora/ZuoraGiftService.scala
+++ b/support-services/src/main/scala/com/gu/zuora/ZuoraGiftService.scala
@@ -117,6 +117,7 @@ class ZuoraGiftService(val config: ZuoraConfig, client: FutureHttpClient)(implic
       revenueSchedule.amount > revenueSchedule.undistributedUnrecognizedRevenue
     )
 
+  // https://www.zuora.com/developer/api-reference/#operation/PUT_RevenueByRecognitionStartandEndDates
   private def distributeRevenueByStartAndEndDates(
     revenueScheduleNumber: String,
     termDates: TermDates


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

For Digital Subscription gifts we want a different revenue recognition model than for normal subscriptions. Whereas for normal subs we begin to recognise the revenue from the point of purchase, for gift subscriptions we want to recognise the revenue from the point at which the giftee redeems their gift code.

To do this we have set up a 'Billing Manual' revenue recognition rule which we use in the charge attached to the gift subscription rate plans.

When subscriptions with this rate plan are created a Revenue Schedule is created but all revenue remains ‘Undistributed’ until it is manually distributed either through the Zuora UI or via an api call.

There are more details in [this document](https://docs.google.com/document/d/1yNeaR2l1Ss_unXygntuntmRX-GicDelryuK25vmqToc/edit#heading=h.15hbk4mzmzt0)

[**Trello Card**](https://trello.com)



