### PR TITLE
Highlighting on thank you page

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYou.jsx
@@ -25,7 +25,7 @@ import { trackComponentClick } from 'helpers/tracking/behaviour';
 import { getCampaignSettings } from 'helpers/campaigns';
 import type { CampaignSettings } from 'helpers/campaigns';
 import { getAmount } from 'helpers/contributions';
-import type {IsoCurrency} from "helpers/internationalisation/currency";
+import type { IsoCurrency } from 'helpers/internationalisation/currency';
 
 const container = css`
   background: white;
@@ -153,7 +153,7 @@ const ContributionThankYou = ({
   paymentMethod,
   countryId,
   campaignCode,
-  thankyouPageHeadingTestVariant
+  thankyouPageHeadingTestVariant,
 }: ContributionThankYouProps) => {
   const isKnownEmail = guestAccountCreationToken === null;
   const campaignSettings = useMemo<CampaignSettings | null>(() => getCampaignSettings(campaignCode));
@@ -178,7 +178,11 @@ const ContributionThankYou = ({
   };
   const marketingConsentAction = {
     component: (
-      <ContributionThankYouHearMarketingConsent email={email} csrf={csrf} />
+      <ContributionThankYouHearMarketingConsent
+        email={email}
+        csrf={csrf}
+        thankyouPageHeadingTestVariant={thankyouPageHeadingTestVariant}
+      />
     ),
     shouldShow: true,
   };

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouHeader.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouHeader.jsx
@@ -1,5 +1,5 @@
 // @flow
-import React from 'react';
+import * as React from 'react';
 import { css } from '@emotion/core';
 import { titlepiece, body } from '@guardian/src-foundations/typography';
 import { space } from '@guardian/src-foundations';
@@ -68,7 +68,7 @@ const ContributionThankYouHeader = ({
   thankyouPageHeadingTestVariant,
 }: ContributionThankYouHeaderProps) => {
 
-  const title = (): string => {
+  const title = (): React.Node => {
     const nameAndTrailingSpace: string = name && name.length < MAX_DISPLAY_NAME_LENGTH ? `${name} ` : '';
     // Do not show special header to paypal/one-off as we don't have the relevant info after the redirect
     const payPalOneOff = paymentMethod === 'PayPal' && contributionType === 'ONE_OFF';
@@ -91,7 +91,7 @@ const ContributionThankYouHeader = ({
           return <div>Thank you {nameAndTrailingSpace}for your valuable contribution</div>;
       }
     } else {
-      return `Thank you ${nameAndTrailingSpace}for your valuable contribution`;
+      return <div>Thank you {nameAndTrailingSpace}for your valuable contribution</div>;
     }
   };
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouHeader.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouHeader.jsx
@@ -4,10 +4,10 @@ import { css } from '@emotion/core';
 import { titlepiece, body } from '@guardian/src-foundations/typography';
 import { space } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
-import type {ContributionType} from "helpers/contributions";
+import type { ContributionType } from 'helpers/contributions';
 import { currencies } from 'helpers/internationalisation/currency';
-import type {IsoCurrency} from "helpers/internationalisation/currency";
-import type {PaymentMethod} from "helpers/paymentMethods";
+import type { IsoCurrency } from 'helpers/internationalisation/currency';
+import type { PaymentMethod } from 'helpers/paymentMethods';
 
 const header = css`
   background: white;
@@ -41,6 +41,11 @@ const directDebitSetupText = css`
   font-weight: bold;
 `;
 
+const amountText = css`
+  background-color: #ffe500;
+  padding: 0 5px;
+`;
+
 type ContributionThankYouHeaderProps = {|
   name: string | null,
   showDirectDebitMessage: boolean,
@@ -69,20 +74,24 @@ const ContributionThankYouHeader = ({
     const payPalOneOff = paymentMethod === 'PayPal' && contributionType === 'ONE_OFF';
 
     if (thankyouPageHeadingTestVariant && !payPalOneOff && amount) {
-      const currencyAndAmount = `${currencies[currency].glyph}${amount}`;
+      const currencyAndAmount = <span css={amountText}>{currencies[currency].glyph}{amount}</span>;
 
       switch (contributionType) {
         case 'ONE_OFF':
-          return `Thank you for supporting us today with ${currencyAndAmount} ❤️`;
+          return <div>Thank you for supporting us today with {currencyAndAmount} ❤️</div>;
         case 'MONTHLY':
-          return `Thank you ${nameAndTrailingSpace}for choosing to contribute ${currencyAndAmount} each month ❤️`;
+          return (
+            <div>
+              Thank you {nameAndTrailingSpace}for choosing to contribute {currencyAndAmount} each month ❤️
+            </div>
+          );
         case 'ANNUAL':
-          return `Thank you ${nameAndTrailingSpace}for choosing to contribute ${currencyAndAmount} each year ❤️`;
+          return <div>Thank you {nameAndTrailingSpace}for choosing to contribute {currencyAndAmount} each year ❤️</div>;
         default:
-          return `Thank you ${nameAndTrailingSpace}for your valuable contribution`;
+          return <div>Thank you {nameAndTrailingSpace}for your valuable contribution</div>;
       }
     } else {
-      return `Thank you ${nameAndTrailingSpace}for your valuable contribution`
+      return `Thank you ${nameAndTrailingSpace}for your valuable contribution`;
     }
   };
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouHearMarketingConsent.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouHearMarketingConsent.jsx
@@ -10,8 +10,9 @@ import { css } from '@emotion/core';
 import { space } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { Checkbox, CheckboxGroup } from '@guardian/src-checkbox';
-import { Button } from '@guardian/src-button';
+import { Button, buttonReaderRevenue } from '@guardian/src-button';
 import { SvgArrowRightStraight } from '@guardian/src-icons';
+import { ThemeProvider } from 'emotion-theming';
 import ActionContainer from './components/ActionContainer';
 import ActionHeader from './components/ActionHeader';
 import ActionBody from './components/ActionBody';
@@ -57,13 +58,15 @@ function mapDispatchToProps(dispatch: Dispatch<Action>) {
 type ContributionThankYouMarketingConsentProps = {|
   email: string,
   csrf: Csrf,
-  subscribeToNewsLetter: (email: string, csrf: Csrf) => void
+  subscribeToNewsLetter: (email: string, csrf: Csrf) => void,
+  thankyouPageHeadingTestVariant: boolean,
 |};
 
 const ContributionThankYouMarketingConsent = ({
   email,
   csrf,
   subscribeToNewsLetter,
+  thankyouPageHeadingTestVariant,
 }: ContributionThankYouMarketingConsentProps) => {
   const [hasConsented, setHasConsented] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -131,16 +134,31 @@ const ContributionThankYouMarketingConsent = ({
             </div>
           </div>
           <div css={buttonContainer}>
-            <Button
-              onClick={onSubmit}
-              priority="primary"
-              size="default"
-              icon={<SvgArrowRightStraight />}
-              iconSide="right"
-              nudgeIcon
-            >
-              Subscribe
-            </Button>
+            {
+              thankyouPageHeadingTestVariant ?
+                <ThemeProvider theme={buttonReaderRevenue}>
+                  <Button
+                    onClick={onSubmit}
+                    size="default"
+                    icon={<SvgArrowRightStraight />}
+                    iconSide="right"
+                    nudgeIcon
+                    css={css`color: black;`}
+                  >
+                    Subscribe
+                  </Button>
+                </ThemeProvider> :
+                <Button
+                  onClick={onSubmit}
+                  priority={thankyouPageHeadingTestVariant ? 'secondary' : 'primary'}
+                  size="default"
+                  icon={<SvgArrowRightStraight />}
+                  iconSide="right"
+                  nudgeIcon
+                >
+                  Subscribe
+                </Button>
+            }
           </div>
         </>
       )}

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/datePicker/datePickerHelpers.test.js
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/datePicker/datePickerHelpers.test.js
@@ -14,7 +14,7 @@ describe('datePickerHelpers', () => {
 
   class MockDate extends Date {
     constructor(param) {
-      super(param || "2020-05-14T11:01:58.135Z");
+      super(param || '2020-05-14T11:01:58.135Z');
     }
   }
 


### PR DESCRIPTION
Updates the A/B test on the thankyou page heading.
1. Highlights the amount
2. Changes the cta to yellow on the marketing consent component

(also picked up some linting fixes)

### Variant heading
![Screen Shot 2020-11-18 at 14 35 20](https://user-images.githubusercontent.com/1513454/99545951-cb310300-29ad-11eb-9416-1f5dbd9593ea.png)
### Variant cta
![Screen Shot 2020-11-18 at 14 35 26](https://user-images.githubusercontent.com/1513454/99545958-cbc99980-29ad-11eb-9608-a80a3e8a650e.png)
### Control heading
![Screen Shot 2020-11-18 at 14 53 00](https://user-images.githubusercontent.com/1513454/99545961-ccfac680-29ad-11eb-8a3d-3733596178e2.png)
### Control cta
![Screen Shot 2020-11-18 at 14 53 07](https://user-images.githubusercontent.com/1513454/99545962-ccfac680-29ad-11eb-8566-e767a2df58d8.png)
