### PR TITLE
send custom attributes to workflow to be inserted into braze

### DIFF
--- a/support-workers/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
@@ -12,6 +12,7 @@ import io.circe._
 import io.circe.generic.semiauto.deriveEncoder
 import io.circe.syntax._
 import org.joda.time.LocalDate
+import org.joda.time.format.ISODateTimeFormat
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -154,11 +155,22 @@ class DigitalPackEmailFields(
     sfContactId: SfContactId,
     emailAddress: String,
     deliveryDate: Option[LocalDate] = None,
+    userAttributes: Option[JsonObject] = None,
   ): EmailFields = {
     val attributePairs = JsonToAttributes.asFlattenedPairs(fields.asJsonObject).left.map(
       error => throw new RuntimeException(s"coding error: $error")
     ).merge
-    EmailFields(attributePairs, Left(sfContactId), emailAddress, dataExtensionName, deliveryDate)
+    EmailFields(attributePairs, Left(sfContactId), emailAddress, dataExtensionName, deliveryDate, userAttributes)
+  }
+
+  private def wrap2[UserAttributes: Encoder.AsObject](
+    dataExtensionName: String,
+    fields: DigitalSubscriptionEmailAttributes,
+    sfContactId: SfContactId,
+    emailAddress: String,
+    userAttributes: Option[UserAttributes] = None,
+  ): EmailFields = {
+    wrap(dataExtensionName, fields, sfContactId, emailAddress, None, userAttributes.map(_.asJsonObject))
   }
 
   private def giftRecipientNotification(giftPurchase: SendThankYouEmailDigitalSubscriptionGiftPurchaseState) =
@@ -195,14 +207,27 @@ class DigitalPackEmailFields(
       ), purchaserSFContactId, user.primaryEmailAddress))
   }
 
+  case class GifteeRedemptionUserAttributes(
+    unmanaged_digital_subscription_gift_duration_months: Int,
+    unmanaged_digital_subscription_gift_start_date: String,
+    unmanaged_digital_subscription_gift_end_date: String,
+  )
+  object GifteeRedemptionUserAttributes {
+    implicit val encoder = deriveEncoder[GifteeRedemptionUserAttributes]
+  }
+
   private def giftRedemption(state: SendThankYouEmailDigitalSubscriptionGiftRedemptionState) =
-    wrap("digipack-gift-redemption", GifteeRedemptionAttributes(
+    wrap2("digipack-gift-redemption", GifteeRedemptionAttributes(
       gift_recipient_first_name = state.user.firstName,
       subscription_details = state.termDates.months + " month digital subscription",
       gift_start_date = formatDate(state.termDates.giftStartDate),
       gift_recipient_email = state.user.primaryEmailAddress,
       gift_end_date = formatDate(state.termDates.giftEndDate),
-    ), state.sfContactId, state.user.primaryEmailAddress)
+    ), state.sfContactId, state.user.primaryEmailAddress, Some(GifteeRedemptionUserAttributes(
+      unmanaged_digital_subscription_gift_duration_months = state.termDates.months,
+      unmanaged_digital_subscription_gift_start_date = ISODateTimeFormat.date().print(state.termDates.giftStartDate),
+      unmanaged_digital_subscription_gift_end_date = ISODateTimeFormat.date().print(state.termDates.giftEndDate),
+    )))
 
   private def corpRedemption(state: SendThankYouEmailDigitalSubscriptionCorporateRedemptionState) =
     wrap(

--- a/support-workers/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
@@ -163,16 +163,6 @@ class DigitalPackEmailFields(
     EmailFields(attributePairs, Left(sfContactId), emailAddress, dataExtensionName, deliveryDate, userAttributes)
   }
 
-  private def wrap2[UserAttributes: Encoder.AsObject](
-    dataExtensionName: String,
-    fields: DigitalSubscriptionEmailAttributes,
-    sfContactId: SfContactId,
-    emailAddress: String,
-    userAttributes: Option[UserAttributes] = None,
-  ): EmailFields = {
-    wrap(dataExtensionName, fields, sfContactId, emailAddress, None, userAttributes.map(_.asJsonObject))
-  }
-
   private def giftRecipientNotification(giftPurchase: SendThankYouEmailDigitalSubscriptionGiftPurchaseState) =
     wrap("digipack-gift-notification", GifteeNotificationAttributes(
       gifter_first_name = giftPurchase.user.firstName,
@@ -217,17 +207,17 @@ class DigitalPackEmailFields(
   }
 
   private def giftRedemption(state: SendThankYouEmailDigitalSubscriptionGiftRedemptionState) =
-    wrap2("digipack-gift-redemption", GifteeRedemptionAttributes(
+    wrap("digipack-gift-redemption", GifteeRedemptionAttributes(
       gift_recipient_first_name = state.user.firstName,
       subscription_details = state.termDates.months + " month digital subscription",
       gift_start_date = formatDate(state.termDates.giftStartDate),
       gift_recipient_email = state.user.primaryEmailAddress,
       gift_end_date = formatDate(state.termDates.giftEndDate),
-    ), state.sfContactId, state.user.primaryEmailAddress, Some(GifteeRedemptionUserAttributes(
+    ), state.sfContactId, state.user.primaryEmailAddress, None, Some(GifteeRedemptionUserAttributes(
       unmanaged_digital_subscription_gift_duration_months = state.termDates.months,
       unmanaged_digital_subscription_gift_start_date = ISODateTimeFormat.date().print(state.termDates.giftStartDate),
       unmanaged_digital_subscription_gift_end_date = ISODateTimeFormat.date().print(state.termDates.giftEndDate),
-    )))
+    ).asJsonObject))
 
   private def corpRedemption(state: SendThankYouEmailDigitalSubscriptionCorporateRedemptionState) =
     wrap(

--- a/support-workers/src/main/scala/com/gu/emailservices/EmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/EmailFields.scala
@@ -4,7 +4,7 @@ import com.gu.i18n.Currency
 import com.gu.salesforce.Salesforce.SfContactId
 import com.gu.support.promotions.Promotion
 import com.gu.support.workers.{BillingPeriod, User}
-import io.circe.{Encoder, Printer}
+import io.circe.{Encoder, JsonObject, Printer}
 import io.circe.generic.semiauto._
 import io.circe.syntax._
 import org.joda.time.{DateTime, DateTimeZone, LocalDate, LocalTime}
@@ -19,6 +19,7 @@ case class EmailPayload(
   SfContactId: Option[String], // TODO delete this and make IdentityId non Option
   IdentityUserId: Option[String],
   ScheduledTime: Option[DateTime], // None means immediate
+  UserAttributes: Option[JsonObject],
 )
 
 object EmailPayload {
@@ -37,6 +38,7 @@ case class EmailFields(
   email: String,
   dataExtensionName: String,
   deliveryDate: Option[LocalDate] = None,
+  userAttributes: Option[JsonObject] = None,
 ) {
 
   def payload: String =
@@ -49,6 +51,7 @@ case class EmailFields(
       SfContactId = userId.left.toOption.map(_.id),
       IdentityUserId = userId.right.toOption.map(_.id),
       deliveryDate.map(_.toDateTime(new LocalTime(8, 0), DateTimeZone.UTC)),
+      userAttributes
     ).asJson.printWith(Printer.spaces2.copy(dropNullValues = true))
 
 }


### PR DESCRIPTION
## What are you doing in this PR?

depends on https://github.com/guardian/membership-workflow/pull/275

This pushes the unmanaged gift start/end date attributes and term length into the membership workflow email queue.
This means they will arrive in braze as user custom attributes once the above is merged.


https://trello.com/c/EZlDR9wB/3429-gifting-braze-custom-data-attribute-5

## Why are you doing this?

The marketing and retention teams need to be able to target gift recipients in the days after redemption and before expiry, for onboarding and renewal comms.
Normally they get these dates from the DL subscriptions extract from zuora, but we don't extract those details from zuora into the DL/braze at present.  This is a quick bypass, as the data is write only (you can't aamend a gift redemption at present.)

