### PR TITLE
Update yarn.lock to refer to v6.7.4 of CMP library

### DIFF
--- a/support-frontend/yarn.lock
+++ b/support-frontend/yarn.lock
@@ -2869,10 +2869,10 @@
     camelcase "^5.0.0"
     prettier "^1.13.7"
 
-"@guardian/consent-management-platform@^6.7.3":
-  version "6.7.3"
-  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.7.3.tgz#46a3f137430190bfaad192f82b6898d89bd4cc44"
-  integrity sha512-Vfb4zQrl0zDASVjeQ/6M+MkeRHCnVJhoN8dr99JKlU9rYG9Rk7WICJa3cpMk2vz7QBox8i6SaZlegjcleGsm2w==
+"@guardian/consent-management-platform@^6.7.4":
+  version "6.7.4"
+  resolved "https://registry.yarnpkg.com/@guardian/consent-management-platform/-/consent-management-platform-6.7.4.tgz#ae75775c40f8234a2e2774c126a688e9a98f5df4"
+  integrity sha512-f/XieB0dOyGYZDhP/UmyrHiyuehETt2L1GKqacsySFdcD/++fKe7LLcXbza4NE54MHyS0wbvd+Qh4avjG4IPLg==
 
 "@guardian/paparazzi@^0.3.1":
   version "0.3.1"
@@ -12378,10 +12378,10 @@ opener@^1.5.1:
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.1.tgz#6d2f0e77f1a0af0032aca716c2c1fbb8e7e8abed"
   integrity sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==
 
-ophan-tracker-js@^1.3.17:
-  version "1.3.17"
-  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.17.tgz#49bf3984978356f0c5fc719592d1300347311785"
-  integrity sha512-22x+66NntYxML1YGFkJmOc8eErXnhkQg4hKAY1egsjQjJNWHDvT/YGuyMSIz2gl7nZYFLH5nZTCeP3AqZxJRCw==
+ophan-tracker-js@^1.3.23:
+  version "1.3.23"
+  resolved "https://registry.yarnpkg.com/ophan-tracker-js/-/ophan-tracker-js-1.3.23.tgz#e63ca951370b98f265ba654ec4c0db86c15cd822"
+  integrity sha512-MfNMDKUJ0uv9tq3j2B2ISjht8EPs73No8r0NH+H9D3ExrHi8wL9SlPcuVC/Ma2vI7quibduko2RzzuhvAX3BIQ==
 
 opn@^5.5.0:
   version "5.5.0"


### PR DESCRIPTION
Update yarn.lock to refer to v6.7.4 of CMP library. Linked to https://github.com/guardian/support-frontend/pull/2819.

