### PR TITLE
Honour consent state in personalisedAdvertising flag in Australia

### DIFF
--- a/support-frontend/assets/helpers/tracking/thirdPartyTrackingConsent.js
+++ b/support-frontend/assets/helpers/tracking/thirdPartyTrackingConsent.js
@@ -15,6 +15,9 @@ type ConsentState = {
     ccpa?: {
         doNotSell: boolean;
     };
+    aus?: {
+      personalisedAdvertising: boolean;
+    }
 }
 
 const onConsentChangeEvent =
@@ -52,6 +55,11 @@ const onConsentChangeEvent =
               consentGranted = Object.keys(vendorIds).reduce((accumulator, vendorKey) => ({
                 ...accumulator,
                 [vendorKey]: state.ccpa ? !state.ccpa.doNotSell : false,
+              }), {});
+            } else if (state.aus) {
+              consentGranted = Object.keys(vendorIds).reduce((accumulator, vendorKey) => ({
+                ...accumulator,
+                [vendorKey]: state.aus ? state.aus.personalisedAdvertising : false,
               }), {});
             } else if (state.tcfv2) {
               /**


### PR DESCRIPTION
Now we're using the latest version of `@guardian/consent-management-platform` @ `v6.7.4` we need to check Australian consent state's `personalisedAdvertising` flag if available.

