### PR TITLE
Fix selenium selector for GW product page tests

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/weeklySubscriptionLanding.jsx
@@ -156,9 +156,13 @@ const copy = getCopy(promotionCopy);
 const defaultPromo = orderIsAGift ? 'GW20GIFT1Y' : '10ANNUAL';
 const promoTermsLink = promotionTermsUrl(getQueryParameter(promoQueryParam) || defaultPromo);
 
+// ID for Selenium tests
+const pageQaId = `qa-guardian-weekly${orderIsAGift ? '-gift' : ''}`;
+
 const content = (
   <Provider store={store}>
     <Page
+      id={pageQaId}
       header={<Header />}
       footer={<WeeklyFooter centred promoTermsLink={promoTermsLink} />}
     >

--- a/support-frontend/test/selenium/subscriptions/pages/WeeklyGiftProductPage.scala
+++ b/support-frontend/test/selenium/subscriptions/pages/WeeklyGiftProductPage.scala
@@ -7,6 +7,6 @@ class WeeklyGiftProductPage(implicit val webDriver: WebDriver) extends Browser w
 
   override def path = "/uk/subscribe/weekly/gift"
 
-  override def elementQuery = className("weekly-campaign-hero")
+  override def elementQuery = id("qa-guardian-weekly-gift")
 
 }

--- a/support-frontend/test/selenium/subscriptions/pages/WeeklyProductPage.scala
+++ b/support-frontend/test/selenium/subscriptions/pages/WeeklyProductPage.scala
@@ -7,6 +7,6 @@ class WeeklyProductPage(implicit val webDriver: WebDriver) extends Browser with 
 
   override def path = "/uk/subscribe/weekly"
 
-  override def elementQuery = className("component-heading-block")
+  override def elementQuery = id("qa-guardian-weekly")
 
 }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This adds a page ID and uses that as the selector for the Selenium tests verifying that the Guardian Weekly product pages load in prod, replacing the usage of a class name as a selector now we've mostly migrated the page to Emotion.