### PR TITLE
Add an alarm for failures in the Zuora distribute revenue api call

### DIFF
--- a/support-frontend/app/wiring/Services.scala
+++ b/support-frontend/app/wiring/Services.scala
@@ -65,6 +65,6 @@ trait Services {
     RedemptionTable.forEnvAsync(TouchPointEnvironments.fromStage(appConfig.stage, isTestUser))
   }
 
-  lazy val zuoraGiftLookupServiceProvider: ZuoraGiftLookupServiceProvider = new ZuoraGiftLookupServiceProvider(appConfig.zuoraConfigProvider)
+  lazy val zuoraGiftLookupServiceProvider: ZuoraGiftLookupServiceProvider = new ZuoraGiftLookupServiceProvider(appConfig.zuoraConfigProvider, appConfig.stage)
 
 }

--- a/support-services/src/main/scala/com/gu/aws/AwsCloudWatchMetricSetup.scala
+++ b/support-services/src/main/scala/com/gu/aws/AwsCloudWatchMetricSetup.scala
@@ -18,8 +18,12 @@ object AwsCloudWatchMetricSetup {
         MetricDimensionName("Environment") -> MetricDimensionValue(environment.envValue)
       ))
 
-  def revenueDistributionFailureRequest: MetricRequest =
-    getMetricRequest(MetricName("RevenueDistributionFailure"), Map())
+  def revenueDistributionFailureRequest(stage: Stage): MetricRequest =
+    getMetricRequest(MetricName("RevenueDistributionFailure"),
+      Map(
+        MetricDimensionName("Stage") -> MetricDimensionValue(stage.toString)
+      )
+    )
 
   def paymentSuccessRequest(stage: Stage, paymentProvider: PaymentProvider, productType: ProductType): MetricRequest =
     getMetricRequest(

--- a/support-services/src/main/scala/com/gu/aws/AwsCloudWatchMetricSetup.scala
+++ b/support-services/src/main/scala/com/gu/aws/AwsCloudWatchMetricSetup.scala
@@ -15,8 +15,11 @@ object AwsCloudWatchMetricSetup {
   def catalogFailureRequest(environment: TouchPointEnvironment): MetricRequest =
     getMetricRequest(MetricName("CatalogLoadingFailure"),
       Map(
-        MetricDimensionName("Environment") -> MetricDimensionValue(environment.toString)
+        MetricDimensionName("Environment") -> MetricDimensionValue(environment.envValue)
       ))
+
+  def revenueDistributionFailureRequest: MetricRequest =
+    getMetricRequest(MetricName("RevenueDistributionFailure"), Map())
 
   def paymentSuccessRequest(stage: Stage, paymentProvider: PaymentProvider, productType: ProductType): MetricRequest =
     getMetricRequest(

--- a/support-services/src/main/scala/com/gu/zuora/ZuoraGiftLookupServiceProvider.scala
+++ b/support-services/src/main/scala/com/gu/zuora/ZuoraGiftLookupServiceProvider.scala
@@ -1,14 +1,14 @@
 package com.gu.zuora
 
 import com.gu.okhttp.RequestRunners.configurableFutureRunner
-import com.gu.support.config.{ZuoraConfig, ZuoraConfigProvider}
+import com.gu.support.config.{Stage, ZuoraConfig, ZuoraConfigProvider}
 import com.gu.support.touchpoint.TouchpointServiceProvider
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.DurationInt
 
-class ZuoraGiftLookupServiceProvider(configProvider: ZuoraConfigProvider)(implicit ec: ExecutionContext)
+class ZuoraGiftLookupServiceProvider(configProvider: ZuoraConfigProvider, stage: Stage)(implicit ec: ExecutionContext)
   extends TouchpointServiceProvider[ZuoraGiftLookupService, ZuoraConfig](configProvider){
 
-  override protected def createService(config: ZuoraConfig) = new ZuoraGiftService(config, configurableFutureRunner(60.seconds))
+  override protected def createService(config: ZuoraConfig) = new ZuoraGiftService(config, stage, configurableFutureRunner(60.seconds))
 }

--- a/support-services/src/main/scala/com/gu/zuora/ZuoraGiftService.scala
+++ b/support-services/src/main/scala/com/gu/zuora/ZuoraGiftService.scala
@@ -2,6 +2,7 @@ package com.gu.zuora
 
 import cats.data.OptionT
 import cats.implicits.catsStdInstancesForFuture
+import com.gu.aws.{AwsCloudWatchMetricPut, AwsCloudWatchMetricSetup}
 import com.gu.monitoring.SafeLogger
 import com.gu.monitoring.SafeLogger.Sanitizer
 import com.gu.okhttp.RequestRunners.FutureHttpClient
@@ -87,7 +88,8 @@ class ZuoraGiftService(val config: ZuoraConfig, client: FutureHttpClient)(implic
         Success(())
       case failed =>
         val errorMessage = scrub"Failed to set up revenue recognition for Digital Subscription gift $subscriptionNumber. Error was $failed"
-        SafeLogger.error(errorMessage) //TODO: Add an alarm
+        SafeLogger.error(errorMessage)
+        AwsCloudWatchMetricPut(AwsCloudWatchMetricPut.client)(AwsCloudWatchMetricSetup.revenueDistributionFailureRequest)
         // For the revenue recognition we want to continue even if there is a failure because by this point
         // the redemption will have succeeded so we need to let the user know about that and then sort out the
         // revenue recognition separately

--- a/support-services/src/main/scala/com/gu/zuora/ZuoraGiftService.scala
+++ b/support-services/src/main/scala/com/gu/zuora/ZuoraGiftService.scala
@@ -7,7 +7,7 @@ import com.gu.monitoring.SafeLogger
 import com.gu.monitoring.SafeLogger.Sanitizer
 import com.gu.okhttp.RequestRunners.FutureHttpClient
 import com.gu.rest.WebServiceHelper
-import com.gu.support.config.ZuoraConfig
+import com.gu.support.config.{Stage, ZuoraConfig}
 import com.gu.support.redemptions.RedemptionCode
 import com.gu.support.touchpoint.TouchpointService
 import com.gu.support.workers.states.SendThankYouEmailState.TermDates
@@ -23,7 +23,7 @@ trait ZuoraGiftLookupService extends TouchpointService {
   def getSubscriptionFromRedemptionCode(redemptionCode: RedemptionCode): Future[SubscriptionRedemptionQueryResponse]
 }
 
-class ZuoraGiftService(val config: ZuoraConfig, client: FutureHttpClient)(implicit ec: ExecutionContext)
+class ZuoraGiftService(val config: ZuoraConfig, stage: Stage, client: FutureHttpClient)(implicit ec: ExecutionContext)
   extends WebServiceHelper[ZuoraErrorResponse] with ZuoraGiftLookupService {
 
   override val wsUrl: String = config.url
@@ -89,7 +89,7 @@ class ZuoraGiftService(val config: ZuoraConfig, client: FutureHttpClient)(implic
       case failed =>
         val errorMessage = scrub"Failed to set up revenue recognition for Digital Subscription gift $subscriptionNumber. Error was $failed"
         SafeLogger.error(errorMessage)
-        AwsCloudWatchMetricPut(AwsCloudWatchMetricPut.client)(AwsCloudWatchMetricSetup.revenueDistributionFailureRequest)
+        AwsCloudWatchMetricPut(AwsCloudWatchMetricPut.client)(AwsCloudWatchMetricSetup.revenueDistributionFailureRequest(stage))
         // For the revenue recognition we want to continue even if there is a failure because by this point
         // the redemption will have succeeded so we need to let the user know about that and then sort out the
         // revenue recognition separately

--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -207,22 +207,22 @@ Resources:
       Statistic: Sum
     DependsOn: SupportWorkersPROD
 
-    RevenueRecognitionSetupFailureAlarm:
-      Type: AWS::CloudWatch::Alarm
-      Condition: CreateProdResources
-      Properties:
-        AlarmActions:
-          - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
-        AlarmName: !Sub Revenue distribution for Digital Subscription gift failed in ${Stage}
-        AlarmDescription: There was a failure whilst calling Zuora to distribute revenue during a Digital Subscription gift redemption. Check logs for error details.
-        MetricName: RevenueDistributionFailure
-        Namespace: support-frontend
-        ComparisonOperator: GreaterThanOrEqualToThreshold
-        Threshold: 1
-        Period: 60
-        EvaluationPeriods: 1
-        Statistic: Sum
-      DependsOn: SupportWorkersPROD
+  RevenueRecognitionSetupFailureAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: CreateProdResources
+    Properties:
+      AlarmActions:
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
+      AlarmName: !Sub Revenue distribution for Digital Subscription gift failed in ${Stage}
+      AlarmDescription: There was a failure whilst calling Zuora to distribute revenue during a Digital Subscription gift redemption. Check logs for error details.
+      MetricName: RevenueDistributionFailure
+      Namespace: support-frontend
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Threshold: 1
+      Period: 60
+      EvaluationPeriods: 1
+      Statistic: Sum
+    DependsOn: SupportWorkersPROD
 
   NoPaypalContributionsInTwoHoursAlarm:
     Type: AWS::CloudWatch::Alarm

--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -213,8 +213,10 @@ Resources:
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
-      AlarmName: !Sub Revenue distribution for Digital Subscription gift failed in ${Stage}
-      AlarmDescription: There was a failure whilst calling Zuora to distribute revenue during a Digital Subscription gift redemption. Check logs for error details.
+      AlarmName: !Sub Data Corruption - Revenue distribution for Digital Subscription gift failed in ${Stage}
+      AlarmDescription: >
+        There was a failure whilst calling Zuora to distribute revenue during a Digital Subscription gift redemption.
+        Follow the steps in https://docs.google.com/document/d/1yNeaR2l1Ss_unXygntuntmRX-GicDelryuK25vmqToc/edit#bookmark=id.hz2dy29e5qip to debug.
       MetricName: RevenueDistributionFailure
       Namespace: support-frontend
       Dimensions:

--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -207,6 +207,23 @@ Resources:
       Statistic: Sum
     DependsOn: SupportWorkersPROD
 
+    RevenueRecognitionSetupFailureAlarm:
+      Type: AWS::CloudWatch::Alarm
+      Condition: CreateProdResources
+      Properties:
+        AlarmActions:
+          - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:reader-revenue-dev
+        AlarmName: !Sub Revenue distribution for Digital Subscription gift failed in ${Stage}
+        AlarmDescription: There was a failure whilst calling Zuora to distribute revenue during a Digital Subscription gift redemption. Check logs for error details.
+        MetricName: RevenueDistributionFailure
+        Namespace: support-frontend
+        ComparisonOperator: GreaterThanOrEqualToThreshold
+        Threshold: 1
+        Period: 60
+        EvaluationPeriods: 1
+        Statistic: Sum
+      DependsOn: SupportWorkersPROD
+
   NoPaypalContributionsInTwoHoursAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: CreateProdResources

--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -217,6 +217,9 @@ Resources:
       AlarmDescription: There was a failure whilst calling Zuora to distribute revenue during a Digital Subscription gift redemption. Check logs for error details.
       MetricName: RevenueDistributionFailure
       Namespace: support-frontend
+      Dimensions:
+        - Name: Stage
+          Value: !Ref Stage
       ComparisonOperator: GreaterThanOrEqualToThreshold
       Threshold: 1
       Period: 60

--- a/support-workers/src/main/scala/com/gu/services/Services.scala
+++ b/support-workers/src/main/scala/com/gu/services/Services.scala
@@ -34,7 +34,7 @@ class Services(isTestUser: Boolean, val config: Configuration) {
   lazy val payPalService: PayPalService = new PayPalService(payPalConfigProvider.get(isTestUser), configurableFutureRunner(40.seconds))
   lazy val salesforceService = new SalesforceService(salesforceConfigProvider.get(isTestUser), configurableFutureRunner(40.seconds))
   lazy val zuoraService = new ZuoraService(zuoraConfigProvider.get(isTestUser), configurableFutureRunner(60.seconds))
-  lazy val zuoraGiftService = new ZuoraGiftService(zuoraConfigProvider.get(isTestUser), configurableFutureRunner(60.seconds))
+  lazy val zuoraGiftService = new ZuoraGiftService(zuoraConfigProvider.get(isTestUser), Configuration.stage, configurableFutureRunner(60.seconds))
   lazy val acquisitionService = AcquisitionServiceBuilder.build(config.kinesisStreamName, isTestUser)
   lazy val promotionService = new PromotionService(promotionsConfigProvider.get(isTestUser))
   lazy val goCardlessService = GoCardlessWorkersService(goCardlessConfigProvider.get(isTestUser))

--- a/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/integration/CreateZuoraSubscriptionSpec.scala
@@ -147,7 +147,7 @@ class CreateZuoraSubscriptionHelper(implicit executionContext: ExecutionContext)
 
   val realZuoraService = new ZuoraService(realConfig.zuoraConfigProvider.get(), configurableFutureRunner(60.seconds))
 
-  val realZuoraGiftService = new ZuoraGiftService(realConfig.zuoraConfigProvider.get(), configurableFutureRunner(60.seconds))
+  val realZuoraGiftService = new ZuoraGiftService(realConfig.zuoraConfigProvider.get(), Stages.DEV, configurableFutureRunner(60.seconds))
 
   val realPromotionService = new PromotionService(realConfig.promotionsConfigProvider.get())
 

--- a/support-workers/src/test/scala/com/gu/zuora/ZuoraITSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/ZuoraITSpec.scala
@@ -5,6 +5,7 @@ import java.util.UUID
 import com.gu.config.Configuration
 import com.gu.i18n.Currency.{AUD, EUR, GBP, USD}
 import com.gu.okhttp.RequestRunners
+import com.gu.support.config.{Stage, Stages}
 import com.gu.support.redemptions.RedemptionCode
 import com.gu.support.workers.{GetSubscriptionWithCurrentRequestId, IdentityId, Monthly}
 import com.gu.support.zuora.api.response.{ZuoraAccountNumber, ZuoraErrorResponse}
@@ -22,7 +23,7 @@ class ZuoraITSpec extends AsyncFlatSpec with Matchers {
 
   def uatService: ZuoraService = new ZuoraService(Configuration.load().zuoraConfigProvider.get(true), RequestRunners.configurableFutureRunner(30.seconds))
 
-  def uatGiftService: ZuoraGiftService = new ZuoraGiftService(Configuration.load().zuoraConfigProvider.get(true), RequestRunners.configurableFutureRunner(30.seconds))
+  def uatGiftService: ZuoraGiftService = new ZuoraGiftService(Configuration.load().zuoraConfigProvider.get(true), Stages.DEV, RequestRunners.configurableFutureRunner(30.seconds))
 
   // actual sub "CreatedDate": "2017-12-07T15:47:21.000+00:00",
   val earlyDate = new DateTime(2010, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC)


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Following from #2830 we want to add an alarm when the calls to Zuora to set up revenue distribution fail.