### PR TITLE
Set httpOnly and secure flags on csrf cookie

### DIFF
--- a/support-frontend/conf/application.conf
+++ b/support-frontend/conf/application.conf
@@ -2,7 +2,10 @@ play.application.loader = "wiring.AppLoader"
 
 googleAuth.domain = "guardian.co.uk"
 
-play.filters.csrf.cookie.name = "GU_support_csrf"
+play.filters.csrf.cookie {
+  name = "GU_support_csrf"
+  httpOnly = true
+}
 
 # cache hashed assets for one year
 play.assets.cache."/public/compiled-assets/" = "public, max-age=31536000"

--- a/support-frontend/conf/application.conf
+++ b/support-frontend/conf/application.conf
@@ -5,6 +5,7 @@ googleAuth.domain = "guardian.co.uk"
 play.filters.csrf.cookie {
   name = "GU_support_csrf"
   httpOnly = true
+  secure = true
 }
 
 # cache hashed assets for one year


### PR DESCRIPTION
This was a recommendation from the security audit of our site.

"The GU_support_csrf (https://support.theguardian.com) was identified as being set without the Secure flag. The Secure flag set forces a browser to only send the cookie in requests to sites protected with SSL (HTTPS sites). The HttpOnly flag forces the cookie to not be accessible via any client-side script (example: JavaScript using document.cookie)."

![Screen Shot 2020-11-24 at 13 52 05](https://user-images.githubusercontent.com/1513454/100103004-4423d500-2e5c-11eb-9344-a4d47f884d58.png)
