### PR TITLE
Reinstate 'best deal' on gift price cards

### DIFF
--- a/support-frontend/assets/components/productOption/productOption.jsx
+++ b/support-frontend/assets/components/productOption/productOption.jsx
@@ -24,7 +24,6 @@ type WrappedProps = {
 
 type ProductOptionType = {
   children: Node,
-  orderIsAGift?: boolean,
 }
 
 type ProductOptionOfferType = {
@@ -75,15 +74,11 @@ export const ProductOptionPrice = ({ children }: { children: Node}) => (
 
 export const ProductOptionButton = withProductOptionsStyle(LinkButtonPayment);
 
-const ProductOption = ({ children, orderIsAGift }: ProductOptionType) => (
-  <div className={orderIsAGift ? 'product-option' : 'product-option--non-gift'}>
+const ProductOption = ({ children }: ProductOptionType) => (
+  <div className="product-option">
     { children }
   </div>
 );
-
-ProductOption.defaultProps = {
-  orderIsAGift: false,
-};
 
 // default props
 ProductOptionCopy.defaultProps = {

--- a/support-frontend/assets/components/productOption/productOption.scss
+++ b/support-frontend/assets/components/productOption/productOption.scss
@@ -45,7 +45,7 @@
 
 .product-option__title {
   @include gu-fontset-heading;
-  margin-bottom: 24px;
+  margin-bottom: 16px;
   position: relative;
 
   @include mq(tablet) {
@@ -65,8 +65,7 @@
   font-family: $gu-headline;
   font-weight: bold;
   font-size: 32px;
-  padding-top: 4px;
-  min-height: 63px;
+  padding: 4px 0 12px;
 
   @include mq(tablet) {
     font-size: 42px;
@@ -75,7 +74,6 @@
 
 .product-option__price-detail {
   padding: 4px 0 10px;
-  border-top: 1px solid gu-colour(neutral-86);
   min-height: 48px;
 }
 
@@ -116,7 +114,6 @@
   margin-top: 20px;
   color: gu-colour(neutral-7);
   line-height: 1.4;
-  font-weight: bold;
 }
 
 .product-option__button {

--- a/support-frontend/assets/components/productOption/productOption.scss
+++ b/support-frontend/assets/components/productOption/productOption.scss
@@ -1,7 +1,6 @@
 @import '~stylesheets/gu-sass/gu-sass';
 
-.product-option,
-.product-option--non-gift {
+.product-option {
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -20,6 +19,14 @@
     z-index: 2;
   }
 
+  &:last-of-type {
+    margin-top: 20px;
+
+    @include mq(tablet) {
+      margin-top: 0;
+    }
+  }
+
   &:hover,
   &:focus {
     box-shadow: 0px 2px 10px 0px rgba(153,153,153,0.3);
@@ -32,16 +39,6 @@
           transform: translateX(20%);
         }
       }
-    }
-  }
-}
-
-.product-option--non-gift {
-  &:last-of-type {
-    margin-top: 20px;
-
-    @include mq(tablet) {
-      margin-top: 0;
     }
   }
 }

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
@@ -118,7 +118,7 @@ const BILLING_PERIOD_GIFT = {
         </span>);
     },
     offer: null,
-    label: null,
+    label: 'Best Deal',
   },
 };
 

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/paymentSelection.jsx
@@ -37,11 +37,10 @@ const PaymentSelection = ({ paymentOptions, orderIsAGift }: PropTypes) =>
           return -1;
         }).map(paymentOption => (
           <div css={paymentSelectionCard}>
-            {!orderIsAGift && (
             <span css={productOptionLabel}>
               {paymentOption.label}
-            </span>)}
-            <ProductOption orderIsAGift={orderIsAGift}>
+            </span>
+            <ProductOption>
               <ProductOptionContent>
                 <ProductOptionTitle>{paymentOption.title}</ProductOptionTitle>
                 <ProductOptionOffer>


### PR DESCRIPTION
## What are you doing in this PR?
The 'best deal' yellow label had gone missing from the gift price cards. The work done here is to reinstate this feature.

## Why are you doing this?
Because it will help users to identify that they would pay less money per month for 12 months worth of a gift subscription than for 3 months.

## Screenshots
![Screen Shot 2020-11-24 at 13 50 22](https://user-images.githubusercontent.com/16781258/100102847-0e7eec00-2e5c-11eb-9ee8-da901fe99d38.png)

![Screen Shot 2020-11-24 at 13 50 05](https://user-images.githubusercontent.com/16781258/100102864-12ab0980-2e5c-11eb-9e54-581e30f19b33.png)
