### PR TITLE
Copy update and packshot fix on thank you page for existing subscribers

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-checkout/components/thankYou/hero.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/thankYou/hero.jsx
@@ -22,12 +22,12 @@ const defaultHeroes: GridImages = {
     },
     tablet: {
       gridId: 'editionsPackshotShort',
-      srcSizes: [500, 1000, 1825],
+      srcSizes: [500, 1000, 1800],
       imgType: 'png',
     },
     desktop: {
       gridId: 'editionsPackshotShort',
-      srcSizes: [500, 1000, 1825],
+      srcSizes: [500, 1000, 1800],
       imgType: 'png',
     },
   },

--- a/support-frontend/assets/pages/digital-subscription-checkout/thankYouExisting.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/thankYouExisting.jsx
@@ -45,7 +45,7 @@ const content = (
         <HeroWrapper appearance="custom">
           <ThankYouContent countryGroupId={countryGroupId} />
           <HeadingBlock>
-            Your digital subscription is already live
+            You already have an active digital subscription
           </HeadingBlock>
         </HeroWrapper>
         <ThankYouExistingContent countryGroupId={countryGroupId} />

--- a/support-frontend/assets/pages/digital-subscription-checkout/thankYouExistingContent.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/thankYouExistingContent.jsx
@@ -25,7 +25,7 @@ function ThankYouExistingContent({ countryGroupId }: PropTypes) {
       <Content>
         <Text>
           <LargeParagraph>
-            You have access to the following products:
+            To see your subscriptions go to <a href="https://manage.theguardian.com" target="_blank" rel="noopener noreferrer">My Account</a>. You have access to the following products:
           </LargeParagraph>
         </Text>
         <AppsSection countryGroupId={countryGroupId} />


### PR DESCRIPTION
## What are you doing in this PR?

You can only have 1 digital sub per identity account. The current message when you try to register a second, is "Your digital subscription is already live". This is not very helpful to the user. This PR updates the main title and first sentence to use clearer messaging.

This PR also fixes a broken packshot image on the same page, currently the packshot image is trying to load a crop of the image which 1825px wide, whilst the maximum available is 1800px.

https://trello.com/c/k88wBrxe/3491-fix-broken-packshot-image-on-digital-subscriptions-thank-you-page
https://trello.com/c/HZ7Jzbi4/3470-improve-copy-for-duplicate-digital-subs-thank-you-page-message

**Before**
![support theguardian com_subscribe_digital_checkout_thankyou-existing (1)](https://user-images.githubusercontent.com/1590704/100248845-da76fa00-2f33-11eb-85e9-51192778fbe2.png)

**After**
![localhost_9210_subscribe_digital_checkout_thankyou-existing](https://user-images.githubusercontent.com/1590704/100248871-e1057180-2f33-11eb-9d8c-cfa6216c93fe.png)
