### PR TITLE
Only write address details to Salesforce for GW gifts, not DS

### DIFF
--- a/support-workers/src/main/scala/com/gu/salesforce/SalesforceService.scala
+++ b/support-workers/src/main/scala/com/gu/salesforce/SalesforceService.scala
@@ -58,7 +58,7 @@ class SalesforceService(config: SalesforceConfig, client: FutureHttpClient)(impl
 
   private def deliveryAddressForGiftRecipientType(giftRecipient: GiftRecipient, user: User) =
     giftRecipient match {
-      case _: GiftRecipient.WeeklyGiftRecipient => Some(user.deliveryAddress.getOrElse(user.billingAddress))
+      case _: GiftRecipient.WeeklyGiftRecipient => user.deliveryAddress
       case _: GiftRecipient.DigitalSubscriptionGiftRecipient  => None
     }
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->


[**Trello Card**](https://trello.com)

## Why are you doing this?

Currently for Digital Subscription gifts we are writing the billing address of the gifter into the giftee's Salesforce contact record. This is because for Guardian Weekly gifts we want to add the delivery address to the contact however for DS gifts this does not apply.