### PR TITLE
Fix link to gift page from subs landing page

### DIFF
--- a/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/copy/subscriptionCopy.jsx
@@ -134,7 +134,7 @@ const digital = (countryGroupId: CountryGroupId, priceCopy: PriceCopy, isTop: bo
   },
   {
     ctaButtonText: 'See gift options',
-    link: guardianWeeklyLanding(countryGroupId, true),
+    link: digitalSubscriptionLanding(countryGroupId, true),
     analyticsTracking: sendTrackingEventsOnClick('digipack_cta_gift', 'DigitalPack', abTest, 'digital-subscription'),
     modifierClasses: '',
   }],


### PR DESCRIPTION
## What are you doing in this PR?
To fix a link that was pointing to the incorrect page.

## Why are you doing this?
This was an error introduced by: https://github.com/guardian/support-frontend/pull/2847
