### PR TITLE
Correct crops of packshots in Hero Component

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-checkout/components/thankYou/hero.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/thankYou/hero.jsx
@@ -17,7 +17,7 @@ const defaultHeroes: GridImages = {
   breakpoints: {
     mobile: {
       gridId: 'editionsPackshotShort',
-      srcSizes: [242, 484, 568],
+      srcSizes: [500],
       imgType: 'png',
     },
     tablet: {
@@ -38,17 +38,17 @@ const australiaHeroes: GridImages = {
   breakpoints: {
     mobile: {
       gridId: 'editionsPackshotAusShort',
-      srcSizes: [242, 484, 568],
+      srcSizes: [500],
       imgType: 'png',
     },
     tablet: {
       gridId: 'editionsPackshotAusShort',
-      srcSizes: [500, 1000, 1825],
+      srcSizes: [500, 1000, 1800],
       imgType: 'png',
     },
     desktop: {
       gridId: 'editionsPackshotAusShort',
-      srcSizes: [500, 1000, 1825],
+      srcSizes: [500, 1000, 1800],
       imgType: 'png',
     },
   },


### PR DESCRIPTION
## What are you doing in this PR?

This PR fixes broken packshot images used by the `hero.jsx` component, specifically linked to `editionsPackshotShort` and `editionsPackshotAusShort`, both images support a limited set of crops in the Grid: 500 x 300, 1000 x 600, 1800 x 1080.

Because our srcSizes contained crop dimensions that weren't on offer we were attempting to render crops that didn't exist, leading to instances of a broken packshot images. This PR switches to using supported crops.

## Screenshots

### Before

![IMG_2175](https://user-images.githubusercontent.com/1590704/100375440-b1bf3500-3005-11eb-91fc-b9f576c38457.jpg)

### After

<img width="438" alt="Screenshot 2020-11-26 at 16 21 39" src="https://user-images.githubusercontent.com/1590704/100375455-b84dac80-3005-11eb-8a37-bce5e3315da0.png">
