### PR TITLE
Don't require a state for DS gift redemptions

### DIFF
--- a/support-frontend/app/utils/CheckoutValidationRules.scala
+++ b/support-frontend/app/utils/CheckoutValidationRules.scala
@@ -117,7 +117,7 @@ object DigitalPackValidation {
       case (Purchase(paymentFields), ReaderType.Gift, Some(GiftRecipientRequest(_, _, _, Some(_), _, _))) =>
         isValidPaidSub(paymentFields)
       case (_: Redemption[_, _], ReaderType.Corporate, None) => isValidRedemption
-      case (_: Redemption[_, _], ReaderType.Gift, None) => isValidRedemption
+      case (_: Redemption[_, _], ReaderType.Gift, None) => SimpleCheckoutFormValidation.passes(createSupportWorkersRequest)
       case _ => false
     }
   }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
There is a bug in the validation for Digital Subscription gift redemption for users in AU, US & CA because the validation was making state a required field in these countries and it is impossible to set it via the form.
This PR removes that validation
