### PR TITLE
Show frequency buttons in all regions

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
@@ -158,7 +158,7 @@ function withProps(props: PropTypes) {
         showOther={showOther}
         selectedAmounts={props.selectedAmounts}
         selectAmount={props.selectAmount}
-        shouldShowFrequencyButtons={props.countryGroupId !== 'GBPCountries' && props.contributionType !== 'ONE_OFF'}
+        shouldShowFrequencyButtons={props.contributionType !== 'ONE_OFF'}
       />
 
       {showOther && renderOtherField()}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Show frequency buttons in all regions (before `GBCountries` was excluded), as per [this card](https://trello.com/c/0cT2L6dC/2449-update-uk-landing-page).

## Screenshots

<img width="636" alt="Screenshot 2020-11-30 at 08 50 09" src="https://user-images.githubusercontent.com/17720442/100588152-6b115980-32e9-11eb-89ce-f7c7c98cced6.png">

<img width="635" alt="Screenshot 2020-11-30 at 08 50 20" src="https://user-images.githubusercontent.com/17720442/100588157-6cdb1d00-32e9-11eb-8d20-f62c95d249d3.png">
