### PR TITLE
Add gifting url info to sharing links

### DIFF
--- a/support-frontend/app/controllers/CanonicalLinks.scala
+++ b/support-frontend/app/controllers/CanonicalLinks.scala
@@ -8,11 +8,13 @@ trait CanonicalLinks {
     if (withDelivery) s"${supportUrl}/uk/subscribe/paper/delivery"
     else s"${supportUrl}/uk/subscribe/paper"
 
-  def buildCanonicalDigitalSubscriptionLink(countryCode: String): String =
-    s"${supportUrl}/${countryCode}/subscribe/digital"
+  def buildCanonicalDigitalSubscriptionLink(countryCode: String, orderIsAGift: Boolean): String =
+    if (orderIsAGift) s"${supportUrl}/${countryCode}/subscribe/digital/gift"
+    else s"${supportUrl}/${countryCode}/subscribe/digital"
 
-  def buildCanonicalWeeklySubscriptionLink(countryCode: String): String =
-    s"${supportUrl}/${countryCode}/subscribe/weekly"
+  def buildCanonicalWeeklySubscriptionLink(countryCode: String, orderIsAGift: Boolean): String =
+    if (orderIsAGift) s"${supportUrl}/${countryCode}/subscribe/weekly/gift"
+    else s"${supportUrl}/${countryCode}/subscribe/weekly"
 
   def buildCanonicalShowcaseLink(countryCode: String): String =
     s"${supportUrl}/${countryCode}/support"

--- a/support-frontend/app/controllers/DigitalSubscriptionController.scala
+++ b/support-frontend/app/controllers/DigitalSubscriptionController.scala
@@ -60,13 +60,13 @@ class DigitalSubscriptionController(
     val js = Left(RefPath("digitalSubscriptionLandingPage.js"))
     val css = Left(RefPath("digitalSubscriptionLandingPage.css"))
     val description = stringsConfig.digitalPackLandingDescription
-    val canonicalLink = Some(buildCanonicalDigitalSubscriptionLink("uk"))
+    val canonicalLink = Some(buildCanonicalDigitalSubscriptionLink("uk", orderIsAGift))
     val promoCodes: List[PromoCode] = request.queryString.get("promoCode").map(_.toList).getOrElse(Nil) ++ DefaultPromotions.DigitalSubscription.all
     val hrefLangLinks = Map(
-      "en-us" -> buildCanonicalDigitalSubscriptionLink("us"),
-      "en-gb" -> buildCanonicalDigitalSubscriptionLink("uk"),
-      "en-au" -> buildCanonicalDigitalSubscriptionLink("au"),
-      "en" -> buildCanonicalDigitalSubscriptionLink("int")
+      "en-us" -> buildCanonicalDigitalSubscriptionLink("us", orderIsAGift),
+      "en-gb" -> buildCanonicalDigitalSubscriptionLink("uk", orderIsAGift),
+      "en-au" -> buildCanonicalDigitalSubscriptionLink("au", orderIsAGift),
+      "en" -> buildCanonicalDigitalSubscriptionLink("int", orderIsAGift)
     )
 
     val readerType = if (orderIsAGift) Gift else Direct

--- a/support-frontend/app/controllers/WeeklySubscription.scala
+++ b/support-frontend/app/controllers/WeeklySubscription.scala
@@ -55,6 +55,16 @@ class WeeklySubscription(
     if (orderIsAGift) "subscribe/weekly/gift" else "subscribe/weekly"
   )
 
+  def getWeeklyHrefLangLinks(orderIsAGift: Boolean): Map[String, String] = Map(
+      "en-us" -> buildCanonicalWeeklySubscriptionLink("us", orderIsAGift),
+      "en-gb" -> buildCanonicalWeeklySubscriptionLink("uk", orderIsAGift),
+      "en-au" -> buildCanonicalWeeklySubscriptionLink("au", orderIsAGift),
+      "en-nz" -> buildCanonicalWeeklySubscriptionLink("nz", orderIsAGift),
+      "en-ca" -> buildCanonicalWeeklySubscriptionLink("ca", orderIsAGift),
+      "en" -> buildCanonicalWeeklySubscriptionLink("int", orderIsAGift),
+      "en" -> buildCanonicalWeeklySubscriptionLink("eu", orderIsAGift)
+    )
+
   def weekly(countryCode: String, orderIsAGift: Boolean): Action[AnyContent] = CachedAction() { implicit request =>
     implicit val settings: AllSettings = settingsProvider.getAllSettings()
     val title = if (orderIsAGift) "The Guardian Weekly Gift Subscription | The Guardian" else "The Guardian Weekly Subscriptions | The Guardian"
@@ -78,17 +88,7 @@ class WeeklySubscription(
       countryGroup <- CountryGroup.byId(countryCode)
       country <- countryGroup.countries.headOption
     } yield country).getOrElse(UK)
-    val weeklyHrefLangLinks: Map[String, String] =
-    Map(
-      "en-us" -> buildCanonicalWeeklySubscriptionLink("us", orderIsAGift),
-      "en-gb" -> buildCanonicalWeeklySubscriptionLink("uk", orderIsAGift),
-      "en-au" -> buildCanonicalWeeklySubscriptionLink("au", orderIsAGift),
-      "en-nz" -> buildCanonicalWeeklySubscriptionLink("nz", orderIsAGift),
-      "en-ca" -> buildCanonicalWeeklySubscriptionLink("ca", orderIsAGift),
-      "en" -> buildCanonicalWeeklySubscriptionLink("int", orderIsAGift),
-      "en" -> buildCanonicalWeeklySubscriptionLink("eu", orderIsAGift)
-    )
-
+    val weeklyHrefLangLinks = getWeeklyHrefLangLinks(orderIsAGift)
     val maybePromotionCopy = queryPromos.headOption.flatMap(promoCode =>
       ProductPromotionCopy(promotionServiceProvider
         .forUser(false), stage)

--- a/support-frontend/app/controllers/WeeklySubscription.scala
+++ b/support-frontend/app/controllers/WeeklySubscription.scala
@@ -51,17 +51,6 @@ class WeeklySubscription(
 
   implicit val a: AssetsResolver = assets
 
-  val weeklyHrefLangLinks: Map[String, String] =
-    Map(
-      "en-us" -> buildCanonicalWeeklySubscriptionLink("us"),
-      "en-gb" -> buildCanonicalWeeklySubscriptionLink("uk"),
-      "en-au" -> buildCanonicalWeeklySubscriptionLink("au"),
-      "en-nz" -> buildCanonicalWeeklySubscriptionLink("nz"),
-      "en-ca" -> buildCanonicalWeeklySubscriptionLink("ca"),
-      "en" -> buildCanonicalWeeklySubscriptionLink("int"),
-      "en" -> buildCanonicalWeeklySubscriptionLink("eu")
-    )
-
   def weeklyGeoRedirect(orderIsAGift: Boolean = false): Action[AnyContent] = geoRedirect(
     if (orderIsAGift) "subscribe/weekly/gift" else "subscribe/weekly"
   )
@@ -73,7 +62,7 @@ class WeeklySubscription(
     val js = Left(RefPath("weeklySubscriptionLandingPage.js"))
     val css = Left(RefPath("weeklySubscriptionLandingPage.css"))
     val description = stringsConfig.weeklyLandingDescription
-    val canonicalLink = Some(buildCanonicalWeeklySubscriptionLink("uk"))
+    val canonicalLink = Some(buildCanonicalWeeklySubscriptionLink("uk", orderIsAGift))
     val defaultPromos = if (orderIsAGift)
       DefaultPromotions.GuardianWeekly.Gift.all
      else
@@ -89,6 +78,16 @@ class WeeklySubscription(
       countryGroup <- CountryGroup.byId(countryCode)
       country <- countryGroup.countries.headOption
     } yield country).getOrElse(UK)
+    val weeklyHrefLangLinks: Map[String, String] =
+    Map(
+      "en-us" -> buildCanonicalWeeklySubscriptionLink("us", orderIsAGift),
+      "en-gb" -> buildCanonicalWeeklySubscriptionLink("uk", orderIsAGift),
+      "en-au" -> buildCanonicalWeeklySubscriptionLink("au", orderIsAGift),
+      "en-nz" -> buildCanonicalWeeklySubscriptionLink("nz", orderIsAGift),
+      "en-ca" -> buildCanonicalWeeklySubscriptionLink("ca", orderIsAGift),
+      "en" -> buildCanonicalWeeklySubscriptionLink("int", orderIsAGift),
+      "en" -> buildCanonicalWeeklySubscriptionLink("eu", orderIsAGift)
+    )
 
     val maybePromotionCopy = queryPromos.headOption.flatMap(promoCode =>
       ProductPromotionCopy(promotionServiceProvider


### PR DESCRIPTION
## What are you doing in this PR?
This is an update to the url builder for sharing links. This function wasn't taking gifting into account, so if someone tried to share the GW or DS gifting pages (using the share button on the browser on mobile) they would share the non-gift version of the page.

## Why are you doing this?
So people can share the gifting pages.

![Screen Shot 2020-11-30 at 11 42 06](https://user-images.githubusercontent.com/16781258/100606312-25608b00-3301-11eb-8b89-c8fba084be7d.png)

![Screen Shot 2020-11-30 at 11 41 36](https://user-images.githubusercontent.com/16781258/100606286-1f6aaa00-3301-11eb-9366-d5ef92180139.png)
