### PR TITLE
Hide option to start subscribing to Guardian Weekly on Christmas day

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -253,6 +253,13 @@ function WeeklyCheckoutForm(props: PropTypes) {
               <FieldsetWithError id="startDate" error={firstError('startDate', props.formErrors)} legend="When would you like your subscription to start?">
                 {days.map((day) => {
                   const [userDate, machineDate] = [formatUserDate(day), formatMachineDate(day)];
+                  const hideDate = new RegExp('-12-25$').test(machineDate);
+
+                  // Don't render input if Christmas day
+                  if (hideDate) {
+                    return null;
+                  }
+
                   return (
                     <RadioInput
                       appearance="group"


### PR DESCRIPTION
Remove the 25 December date from the Guardian Weekly checkout. Customers who select this date will not receive a paper until the week after.

## Screenshots

<img width="381" alt="Screenshot 2020-12-01 at 10 31 04" src="https://user-images.githubusercontent.com/1590704/100730188-a3846680-33c1-11eb-9433-19455932bb98.png">
