### PR TITLE
write gift notification date to zuora, when DS is purchased

### DIFF
--- a/support-models/src/main/scala/com/gu/support/zuora/api/PreviewSubscribeRequest.scala
+++ b/support-models/src/main/scala/com/gu/support/zuora/api/PreviewSubscribeRequest.scala
@@ -2,9 +2,11 @@ package com.gu.support.zuora.api
 
 import com.gu.support.encoding.Codec
 import com.gu.support.encoding.Codec._
+import io.circe.Encoder
+import io.circe.generic.semiauto.deriveEncoder
 
 object PreviewSubscribeItem {
-  implicit val codec: Codec[PreviewSubscribeItem] = capitalizingCodec
+  implicit val encoder: Encoder[PreviewSubscribeItem] = capitalizingEncoder
 }
 
 case class PreviewSubscribeItem(
@@ -17,7 +19,7 @@ case class PreviewSubscribeItem(
 
 object PreviewSubscribeRequest {
 
-  implicit val codec: Codec[PreviewSubscribeRequest] = deriveCodec
+  implicit val encoder: Encoder[PreviewSubscribeRequest] = deriveEncoder
 
   def fromSubscribe(subscribeItem: SubscribeItem, numberOfBillingPeriodsToPreview: Int): PreviewSubscribeRequest = {
     val initialTerm = subscribeItem.subscriptionData.subscription.initialTerm

--- a/support-models/src/main/scala/com/gu/support/zuora/api/SubscribeRequest.scala
+++ b/support-models/src/main/scala/com/gu/support/zuora/api/SubscribeRequest.scala
@@ -10,7 +10,7 @@ import io.circe.generic.semiauto.deriveEncoder
 import org.joda.time.LocalDate
 
 object SubscribeItem {
-  implicit val codec: Codec[SubscribeItem] = capitalizingCodec
+  implicit val encoder: Encoder[SubscribeItem] = capitalizingEncoder
 }
 
 case class SubscribeItem(
@@ -23,7 +23,7 @@ case class SubscribeItem(
 )
 
 object SubscribeRequest {
-  implicit val codec: Codec[SubscribeRequest] = deriveCodec
+  implicit val encoder: Encoder[SubscribeRequest] = deriveEncoder
 }
 
 //The subscribe request documented here: https://www.zuora.com/developer/api-reference/#operation/Action_POSTsubscribe

--- a/support-models/src/main/scala/com/gu/support/zuora/api/SubscriptionData.scala
+++ b/support-models/src/main/scala/com/gu/support/zuora/api/SubscriptionData.scala
@@ -152,10 +152,6 @@ object SubscriptionProductFeature {
 case class SubscriptionProductFeature(featureId: String)
 
 object Subscription {
-  implicit val decoder: Decoder[Subscription] = decapitalizingDecoder[Subscription].prepare(
-    _.withFocus(_.mapObject(_.renameField("PromotionCode__c", "promoCode")))
-      .withFocus(_.mapObject(_.renameField("ReaderType__c", "readerType")))
-  )
 
   implicit val encoder: Encoder[Subscription] = capitalizingEncoder[Subscription].mapJsonObject(_
     .copyField("PromoCode", "PromotionCode__c")
@@ -163,6 +159,8 @@ object Subscription {
     .renameField("ReaderType", "ReaderType__c")
     .renameField("RedemptionCode", "RedemptionCode__c")
     .renameField("CorporateAccountId", "CorporateAccountId__c")
+    .renameField("CreatedRequestId", "CreatedRequestId__c")
+    .renameField("GiftNotificationEmailDate", "GiftNotificationEmailDate__c")
   )
 }
 
@@ -170,7 +168,7 @@ case class Subscription(
   contractEffectiveDate: LocalDate,
   contractAcceptanceDate: LocalDate,
   termStartDate: LocalDate,
-  createdRequestId__c: String,
+  createdRequestId: String,
   autoRenew: Boolean = true,
   initialTermPeriodType: PeriodType = Month,
   initialTerm: Int = 12,
@@ -180,7 +178,7 @@ case class Subscription(
   promoCode: Option[PromoCode] = None,
   redemptionCode: Option[RawRedemptionCode] = None,
   corporateAccountId: Option[String] = None,
-  giftNotificationEmailDate__c: Option[LocalDate] = None,
+  giftNotificationEmailDate: Option[LocalDate] = None,
 )
 
 object RatePlanChargeData {
@@ -200,7 +198,7 @@ case class RatePlanData(
 )
 
 object SubscriptionData {
-  implicit val codec: Codec[SubscriptionData] = capitalizingCodec
+  implicit val encoder: Encoder[SubscriptionData] = capitalizingEncoder
 }
 
 case class SubscriptionData(ratePlanData: List[RatePlanData], subscription: Subscription)

--- a/support-models/src/main/scala/com/gu/support/zuora/api/SubscriptionData.scala
+++ b/support-models/src/main/scala/com/gu/support/zuora/api/SubscriptionData.scala
@@ -179,7 +179,8 @@ case class Subscription(
   readerType: ReaderType = ReaderType.Direct,
   promoCode: Option[PromoCode] = None,
   redemptionCode: Option[RawRedemptionCode] = None,
-  corporateAccountId: Option[String] = None
+  corporateAccountId: Option[String] = None,
+  giftNotificationEmailDate__c: Option[LocalDate] = None,
 )
 
 object RatePlanChargeData {

--- a/support-models/src/test/scala/com/gu/support/zuora/api/Fixtures.scala
+++ b/support-models/src/test/scala/com/gu/support/zuora/api/Fixtures.scala
@@ -157,6 +157,38 @@ object Fixtures {
     subscription
   )
 
+  val dsSubscriptionData = SubscriptionData(
+    List(RatePlanData(RatePlan(productRatePlanId), Nil, Nil)),
+    Subscription(
+      contractEffectiveDate = new LocalDate(2020, 12, 1),
+      contractAcceptanceDate = new LocalDate(2020, 12, 1),
+      termStartDate = new LocalDate(2020, 12, 1),
+      createdRequestId = "requestId",
+      readerType = ReaderType.Direct,
+      autoRenew = true,
+      initialTerm = 12,
+      initialTermPeriodType = Month,
+      redemptionCode = None,
+      giftNotificationEmailDate = None,
+    )
+  )
+
+  val dsGiftSubscriptionData = SubscriptionData(
+    List(RatePlanData(RatePlan(productRatePlanId), Nil, Nil)),
+    Subscription(
+      contractEffectiveDate = new LocalDate(2020, 12, 1),
+      contractAcceptanceDate = new LocalDate(2020, 12, 1),
+      termStartDate = new LocalDate(2020, 12, 1),
+      createdRequestId = "requestId",
+      readerType = ReaderType.Gift,
+      autoRenew = false,
+      initialTerm = 3,
+      initialTermPeriodType = Month,
+      redemptionCode = Some("gd03-asdfghjq"),
+      giftNotificationEmailDate = Some(new LocalDate(2020, 12, 25)),
+    )
+  )
+
   val accountJson =
     """
       {

--- a/support-workers/src/main/scala/com/gu/emailservices/EmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/EmailFields.scala
@@ -50,7 +50,7 @@ case class EmailFields(
       DataExtensionName = dataExtensionName,
       SfContactId = userId.left.toOption.map(_.id),
       IdentityUserId = userId.right.toOption.map(_.id),
-      deliveryDate.map(_.toDateTime(new LocalTime(8, 0), DateTimeZone.UTC)),
+      deliveryDate.map(_.toDateTime(LocalTime.now().plusSeconds(90))),//new LocalTime(8, 0), DateTimeZone.UTC)),
       userAttributes
     ).asJson.printWith(Printer.spaces2.copy(dropNullValues = true))
 

--- a/support-workers/src/main/scala/com/gu/emailservices/EmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/EmailFields.scala
@@ -50,7 +50,7 @@ case class EmailFields(
       DataExtensionName = dataExtensionName,
       SfContactId = userId.left.toOption.map(_.id),
       IdentityUserId = userId.right.toOption.map(_.id),
-      deliveryDate.map(_.toDateTime(LocalTime.now().plusSeconds(90))),//new LocalTime(8, 0), DateTimeZone.UTC)),
+      deliveryDate.map(_.toDateTime(new LocalTime(8, 0), DateTimeZone.UTC)),
       userAttributes
     ).asJson.printWith(Printer.spaces2.copy(dropNullValues = true))
 

--- a/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionPurchaseBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionPurchaseBuilder.scala
@@ -49,13 +49,13 @@ class DigitalSubscriptionPurchaseBuilder(
         contractEffectiveDate = todaysDate,
         contractAcceptanceDate = contractAcceptanceDate,
         termStartDate = todaysDate,
-        createdRequestId__c = requestId.toString,
+        createdRequestId = requestId.toString,
         readerType = digitalPack.readerType,
         autoRenew = autoRenew,
         initialTerm = initialTerm,
         initialTermPeriodType = Month,
         redemptionCode = maybeRedemptionCode.map(_.value),
-        giftNotificationEmailDate__c = deliveryDate,
+        giftNotificationEmailDate = deliveryDate,
       )
     )
 

--- a/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/ProductSubscriptionBuilders.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/ProductSubscriptionBuilders.scala
@@ -59,7 +59,7 @@ object ProductSubscriptionBuilders {
         contractEffectiveDate = contractEffectiveDate,
         contractAcceptanceDate = contractAcceptanceDate,
         termStartDate = contractEffectiveDate,
-        createdRequestId__c = createdRequestId.toString,
+        createdRequestId = createdRequestId.toString,
         readerType = readerType,
         autoRenew = autoRenew,
         initialTerm = initialTerm,

--- a/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/SubscriptionDataBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/SubscriptionDataBuilder.scala
@@ -77,6 +77,7 @@ class SubscriptionDataBuilder(
           state.requestId,
           environment,
           maybeGeneratedGiftCode,
+          state.giftRecipient.flatMap(_.asDigitalSubscriptionGiftRecipient).map(_.deliveryDate),
         ).leftMap(BuildSubscribePromoError))
       case (Redemption(rd: RedemptionData), ReaderType.Corporate) =>
         digitalSubscriptionCorporateRedemptionBuilder.build(rd,

--- a/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilderSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilderSpec.scala
@@ -36,7 +36,7 @@ class DigitalSubscriptionBuilderSpec extends AsyncFlatSpec with Matchers {
           contractAcceptanceDate = saleDate,
           contractEffectiveDate = saleDate,
           termStartDate = saleDate,
-          createdRequestId__c = "f7651338-5d94-4f57-85fd-262030de9ad5",
+          createdRequestId = "f7651338-5d94-4f57-85fd-262030de9ad5",
           autoRenew = true,
           initialTermPeriodType = Month,
           initialTerm = 12,
@@ -57,7 +57,7 @@ class DigitalSubscriptionBuilderSpec extends AsyncFlatSpec with Matchers {
         contractAcceptanceDate = saleDate.plusDays(16),
         contractEffectiveDate = saleDate,
         termStartDate = saleDate,
-        createdRequestId__c = "f7651338-5d94-4f57-85fd-262030de9ad5",
+        createdRequestId = "f7651338-5d94-4f57-85fd-262030de9ad5",
         autoRenew = true,
         initialTermPeriodType = Month,
         initialTerm = 12,
@@ -83,7 +83,7 @@ class DigitalSubscriptionBuilderSpec extends AsyncFlatSpec with Matchers {
       initialTermPeriodType shouldBe Month
       promoCode shouldBe None
       corporateAccountId shouldBe None
-      giftNotificationEmailDate__c shouldBe Some(new LocalDate(2020, 12, 1))
+      giftNotificationEmailDate shouldBe Some(new LocalDate(2020, 12, 1))
     }
 
   "Attempting to build a subscribe request for a gift redemptions" should "return an error" in {

--- a/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilderSpec.scala
+++ b/support-workers/src/test/scala/com/gu/zuora/subscriptionBuilders/DigitalSubscriptionBuilderSpec.scala
@@ -83,6 +83,7 @@ class DigitalSubscriptionBuilderSpec extends AsyncFlatSpec with Matchers {
       initialTermPeriodType shouldBe Month
       promoCode shouldBe None
       corporateAccountId shouldBe None
+      giftNotificationEmailDate__c shouldBe Some(new LocalDate(2020, 12, 1))
     }
 
   "Attempting to build a subscribe request for a gift redemptions" should "return an error" in {
@@ -127,6 +128,7 @@ class DigitalSubscriptionBuilderSpec extends AsyncFlatSpec with Matchers {
       UUID.fromString("f7651338-5d94-4f57-85fd-262030de9ad5"),
       SANDBOX,
       None,
+      None,
     ).right.get
 
   lazy val threeMonthGiftPurchase =
@@ -135,7 +137,8 @@ class DigitalSubscriptionBuilderSpec extends AsyncFlatSpec with Matchers {
       DigitalPack(GBP, Quarterly, Gift),
       UUID.fromString("f7651338-5d94-4f57-85fd-262030de9ad5"),
       SANDBOX,
-      Some(GeneratedGiftCode("gd03-23456789").get)// code for Quarterly ie Gift3Month
+      Some(GeneratedGiftCode("gd03-23456789").get),// code for Quarterly ie Gift3Month
+      Some(new LocalDate(2020, 12, 1)),
     ).right.get
 
   lazy val threeMonthGiftRedemption: Future[Throwable] =


### PR DESCRIPTION
## What are you doing in this PR?

This PR makes the step functions write the gift notification date to zuora when a DS gift is purchased.

This field will end up in the DL, so we can do a one off report on this in a couple of weeks.

https://trello.com/c/gRopJsmH/3498-write-gift-delivery-date-to-zuora

## Why are you doing this?

CEX team are concerned that if a lot of gifts are scheduled for e.g. christmas day, it might cause a risk to support, as the call centre is not open over christmas/boxing day.

## Screenshots

Tested in DEV:
https://apisandbox.zuora.com/apps/Subscription.do?method=view&id=2c92c0f975e5ba1e01761e9e1109498d
![image](https://user-images.githubusercontent.com/7304387/100750946-a3df2a80-33de-11eb-98b1-c26defc6ce91.png)


Tested in UAT:
https://apisandbox.zuora.com/apps/Subscription.do?method=view&id=2c92c0f975e5ba2601761e9f907d5bcb
![image](https://user-images.githubusercontent.com/7304387/100750802-72fef580-33de-11eb-9db0-e0d3e99339b0.png)

I also tested a normal Direct DS in UAT.


PROD field name:
![image](https://user-images.githubusercontent.com/7304387/100749989-53b39880-33dd-11eb-9eef-db9a14db92f6.png)
