### PR TITLE
Pass comma delimited string of vendors with consent to GTM

### DIFF
--- a/support-frontend/assets/helpers/tracking/googleTagManager.js
+++ b/support-frontend/assets/helpers/tracking/googleTagManager.js
@@ -51,8 +51,8 @@ const gaPropertyId = 'UA-51507017-5';
 */
 let vendorConsentsLookup = '';
 
-// Default userHasGrantedConsent to false
-let userHasGrantedConsent: boolean = false;
+// Default userConsentsToGTM to false
+let userConsentsToGTM: boolean = false;
 
 // Default scriptAdded to false
 let scriptAdded: boolean = false;
@@ -60,7 +60,7 @@ let scriptAdded: boolean = false;
 // Default scriptReady to false
 let scriptReady: boolean = false;
 
-// We store tracking events in these queues when userHasGrantedConsent is false
+// We store tracking events in these queues when userConsentsToGTM is false
 const googleTagManagerDataQueue: Array<() => void> = [];
 const googleAnalyticsEventQueue: Array<() => void> = [];
 
@@ -219,10 +219,10 @@ function sendData(
   };
 
   /**
-   * If userHasGrantedConsent and scriptReady process event immediately,
+   * If userConsentsToGTM and scriptReady process event immediately,
    * else add to googleTagManagerDataQueue.
    */
-  if (userHasGrantedConsent && scriptReady) {
+  if (userConsentsToGTM && scriptReady) {
     pushDataToGTM();
   } else {
     googleTagManagerDataQueue.push(pushDataToGTM);
@@ -271,7 +271,7 @@ function addTagManagerScript() {
   /**
    * After Google Tag Manager has loaded we can
    * process pending events in googleAnalyticsEventQueue and
-   * googleTagManagerDataQueue if userHasGrantedConsent.
+   * googleTagManagerDataQueue if userConsentsToGTM.
    * This also clears the queues as it executes each function in them.
   */
   googleTagManagerScript.onload = () => {
@@ -305,15 +305,12 @@ function init(participations: Participations) {
     }, []).join(',');
 
     /**
-      * Update userHasGrantedConsent value when
+      * Update userConsentsToGTM value when
       * consent changes via the CMP library.
-      * For now userHasGrantedConsent will be true only
-      * if user has consented to BOTH GoogleTagManager and GoogleAnalytics
     */
-    userHasGrantedConsent =
-        thirdPartyTrackingConsent[googleAnalyticsKey] && thirdPartyTrackingConsent[googleTagManagerKey];
+    userConsentsToGTM = thirdPartyTrackingConsent[googleTagManagerKey];
 
-    if (userHasGrantedConsent) {
+    if (userConsentsToGTM) {
       if (!scriptAdded) {
         /**
          * Instruction for Google Analytics
@@ -355,10 +352,10 @@ function gaEvent(gaEventData: GaEventData, additionalFields: ?Object) {
   };
 
   /**
-   * If userHasGrantedConsent and scriptReady then process event immediately,
+   * If userConsentsToGTM and scriptReady then process event immediately,
    * else add to googleAnalyticsEventQueue.
    */
-  if (userHasGrantedConsent && scriptReady) {
+  if (userConsentsToGTM && scriptReady) {
     pushEventToGA();
   } else {
     googleAnalyticsEventQueue.push(pushEventToGA);

--- a/support-frontend/assets/helpers/tracking/googleTagManager.js
+++ b/support-frontend/assets/helpers/tracking/googleTagManager.js
@@ -297,12 +297,7 @@ function init(participations: Participations) {
   }) => {
 
     // Update vendorConsentsLookup value based on thirdPartyTrackingConsent
-    vendorConsentsLookup = Object.keys(thirdPartyTrackingConsent).reduce((accumulator, vendorKey) => {
-      if (thirdPartyTrackingConsent[vendorKey]) {
-        return [...accumulator, vendorKey];
-      }
-      return [...accumulator];
-    }, []).join(',');
+    vendorConsentsLookup = Object.keys(thirdPartyTrackingConsent).filter(vendorKey => thirdPartyTrackingConsent[vendorKey]).join(',');
 
     /**
       * Update userConsentsToGTM value when

--- a/support-frontend/assets/helpers/tracking/googleTagManager.js
+++ b/support-frontend/assets/helpers/tracking/googleTagManager.js
@@ -204,7 +204,7 @@ function getData(
     internalCampaignCode: getQueryParameter('INTCMP') || undefined,
     experience: getVariantsAsString(participations),
     paymentRequestApiStatus,
-    vendorConsentsLookup, // eg. "googleAnalytics,googleTagManager"
+    vendorConsentsLookup, // eg. "google-analytics,twitter"
   };
 }
 
@@ -303,7 +303,7 @@ function init(participations: Participations) {
       * Update userConsentsToGTM value when
       * consent changes via the CMP library.
     */
-    userConsentsToGTM = thirdPartyTrackingConsent[googleTagManagerKey];
+    userConsentsToGTM = thirdPartyTrackingConsent[googleTagManagerKey] && thirdPartyTrackingConsent[googleAnalyticsKey];
 
     if (userConsentsToGTM) {
       if (!scriptAdded) {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This PR updates `googleTagManager.js`, I've created a new string variable `vendorConsentsLookup` in this module. Whenever a user updates their consent via the CMP we set the value of `vendorConsentsLookup` to be a comma delimited string of vendor names (eg. "google-analytics") that have had consent granted to them.

This variable `vendorConsentsLookup` is now pushed to Google Tag Manager (GTM), and will look something like "google-analytics,twitter,bing".

In GTM we can set a conditional check for each tag that must be met for the tag to be enabled. We have the ability to use a regular expression as part of this condition. I therefore propose for each tag we query `vendorConsentsLookup` in GTM using a regular expression. Eg. For Google Analytics to run we check the condition `vendorConsentsLookup.match(new RegExp("(?:^|,)"+"google-analytics"+"(?:,|$)"))`. GTM uses javascript regular expression syntax.

### Next steps

In GTM you can create changes to tag rules which are in a draft state. You can also target Dev/Staging environments in GTM (support.thegulocal.com, support.code.dev-theguardian.com) with the draft rules. I need to do this to confirm the regex lookup is working as expected. Once I've done this I can publish the changes in GTM once this PR has been merged.

[**Trello Card**](https://trello.com/c/NKVX4rAT/3267-tcfv2-google-tag-manager-granular-vendor-controls)

## Why are you doing this?

This will allow us to continue to use GTM (if a user has consented to GTM) but enable/disable tags within it based on a user's consent at a vendor level.