### PR TITLE
send product discriminator when creating a subscription

### DIFF
--- a/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
+++ b/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
@@ -47,7 +47,7 @@ type RegularContribution = {|
 |};
 
 export type DigitalSubscription = {|
-  productType: 'DigitalSubscription',
+  productType: 'DigitalPack',
   currency: string,
   billingPeriod: BillingPeriod,
   readerType: ReaderType,

--- a/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
+++ b/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
@@ -40,27 +40,37 @@ export type StripePaymentMethod = 'StripeCheckout' | 'StripeApplePay' | 'StripeP
 export type StripePaymentRequestButtonMethod = 'none' | StripePaymentMethod;
 
 type RegularContribution = {|
+  productType: 'Contribution',
   amount: number,
   currency: string,
   billingPeriod: BillingPeriod,
 |};
 
 export type DigitalSubscription = {|
+  productType: 'DigitalSubscription',
   currency: string,
   billingPeriod: BillingPeriod,
   readerType: ReaderType,
-  giftMessage?: string | null,
-  giftDeliveryDate?: string | null,
 |};
 
 export type PaperSubscription = {|
+  productType: 'Paper',
   currency: string,
   billingPeriod: BillingPeriod,
   fulfilmentOptions: FulfilmentOptions,
   productOptions: ProductOptions,
 |};
 
-type ProductFields = RegularContribution | DigitalSubscription | PaperSubscription
+export type WeeklySubscription = {|
+  productType: 'GuardianWeekly',
+  currency: string,
+  billingPeriod: BillingPeriod,
+  fulfilmentOptions: FulfilmentOptions,
+|};
+
+export type SubscriptionProductFields = DigitalSubscription | PaperSubscription | WeeklySubscription
+
+type ProductFields = RegularContribution | SubscriptionProductFields
 
 type RegularPayPalPaymentFields = {| baid: string |};
 

--- a/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
+++ b/support-frontend/assets/helpers/paymentIntegrations/readerRevenueApis.js
@@ -7,6 +7,9 @@ import {
 } from 'helpers/tracking/acquisitions';
 import { type ErrorReason } from 'helpers/errorReasons';
 import { type Csrf as CsrfState } from 'helpers/csrf/csrfReducer';
+import {
+  DigitalPack, GuardianWeekly, Paper,
+} from 'helpers/subscriptions';
 import { type BillingPeriod } from 'helpers/billingPeriods';
 import { type Participations } from 'helpers/abTests/abtest';
 import {
@@ -47,28 +50,28 @@ type RegularContribution = {|
 |};
 
 export type DigitalSubscription = {|
-  productType: 'DigitalPack',
+  productType: typeof DigitalPack,
   currency: string,
   billingPeriod: BillingPeriod,
   readerType: ReaderType,
 |};
 
 export type PaperSubscription = {|
-  productType: 'Paper',
+  productType: typeof Paper,
   currency: string,
   billingPeriod: BillingPeriod,
   fulfilmentOptions: FulfilmentOptions,
   productOptions: ProductOptions,
 |};
 
-export type WeeklySubscription = {|
-  productType: 'GuardianWeekly',
+export type GuardianWeeklySubscription = {|
+  productType: typeof GuardianWeekly,
   currency: string,
   billingPeriod: BillingPeriod,
   fulfilmentOptions: FulfilmentOptions,
 |};
 
-export type SubscriptionProductFields = DigitalSubscription | PaperSubscription | WeeklySubscription
+export type SubscriptionProductFields = DigitalSubscription | PaperSubscription | GuardianWeeklySubscription
 
 type ProductFields = RegularContribution | SubscriptionProductFields
 

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.js
@@ -4,9 +4,9 @@
 
 import { type Dispatch } from 'redux';
 import type {
-  DigitalSubscription, PaperSubscription,
   PaymentResult,
   RegularPaymentRequest,
+  SubscriptionProductFields,
 } from 'helpers/paymentIntegrations/readerRevenueApis';
 import {
   type PaymentAuthorisation,
@@ -40,16 +40,12 @@ import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import type { Option } from 'helpers/types/option';
 import type { PaymentMethod } from 'helpers/paymentMethods';
 import { DirectDebit, PayPal, Stripe } from 'helpers/paymentMethods';
-import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
-import { NoFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
-import type { ProductOptions } from 'helpers/productPrice/productOptions';
-import { NoProductOptions } from 'helpers/productPrice/productOptions';
 import {
   validateCheckoutForm,
   validateWithDeliveryForm,
 } from 'helpers/subscriptionsForms/formValidation';
 import {
-  DigitalPack,
+  DigitalPack, GuardianWeekly,
   isPhysicalProduct,
   type SubscriptionProduct,
 } from 'helpers/subscriptions';
@@ -80,42 +76,40 @@ function getAddresses(state: AnyCheckoutState) {
   };
 }
 
-const getOptions = (
-  fulfilmentOptions: FulfilmentOptions,
-  productOptions: ProductOptions,
-): {fulfilmentOptions: FulfilmentOptions, productOptions: ProductOptions} =>
-  ({
-    ...(fulfilmentOptions !== NoFulfilmentOptions ? { fulfilmentOptions } : {}),
-    ...(productOptions !== NoProductOptions ? { productOptions } : {}),
-  });
-
 const getProduct =
-  (state: AnyCheckoutState, currencyId?: Option<IsoCurrency>): DigitalSubscription | PaperSubscription => {
+  (state: AnyCheckoutState, currencyId?: Option<IsoCurrency>): SubscriptionProductFields => {
     const {
       billingPeriod,
       fulfilmentOption,
       productOption,
       orderIsAGift,
       product,
-      giftMessage,
-      giftDeliveryDate,
     } = state.page.checkout;
 
     const readerType = orderIsAGift ? Gift : Direct;
     if (product === DigitalPack) {
       return {
+        productType: 'DigitalSubscription',
         currency: currencyId || state.common.internationalisation.currencyId,
         billingPeriod,
         readerType,
-        giftMessage,
-        giftDeliveryDate,
       };
-    }
+    } else if (product === GuardianWeekly) {
+      return {
+        productType: 'GuardianWeekly',
+        currency: currencyId || state.common.internationalisation.currencyId,
+        billingPeriod,
+        fulfilmentOptions: fulfilmentOption,
+      };
+    } /* Paper or PaperAndDigital */
     return {
+      productType: 'Paper',
       currency: currencyId || state.common.internationalisation.currencyId,
       billingPeriod,
-      ...getOptions(fulfilmentOption, productOption),
+      fulfilmentOptions: fulfilmentOption,
+      productOptions: productOption,
     };
+
   };
 
 const getPromoCode = (promotions: ?Promotion[]) => {

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.js
@@ -89,7 +89,7 @@ const getProduct =
     const readerType = orderIsAGift ? Gift : Direct;
     if (product === DigitalPack) {
       return {
-        productType: 'DigitalSubscription',
+        productType: 'DigitalPack',
         currency: currencyId || state.common.internationalisation.currencyId,
         billingPeriod,
         readerType,

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.js
@@ -45,7 +45,7 @@ import {
   validateWithDeliveryForm,
 } from 'helpers/subscriptionsForms/formValidation';
 import {
-  DigitalPack, GuardianWeekly,
+  DigitalPack, GuardianWeekly, Paper,
   isPhysicalProduct,
   type SubscriptionProduct,
 } from 'helpers/subscriptions';
@@ -89,21 +89,21 @@ const getProduct =
     const readerType = orderIsAGift ? Gift : Direct;
     if (product === DigitalPack) {
       return {
-        productType: 'DigitalPack',
+        productType: DigitalPack,
         currency: currencyId || state.common.internationalisation.currencyId,
         billingPeriod,
         readerType,
       };
     } else if (product === GuardianWeekly) {
       return {
-        productType: 'GuardianWeekly',
+        productType: GuardianWeekly,
         currency: currencyId || state.common.internationalisation.currencyId,
         billingPeriod,
         fulfilmentOptions: fulfilmentOption,
       };
     } /* Paper or PaperAndDigital */
     return {
-      productType: 'Paper',
+      productType: Paper,
       currency: currencyId || state.common.internationalisation.currencyId,
       billingPeriod,
       fulfilmentOptions: fulfilmentOption,

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -437,6 +437,7 @@ function regularPaymentRequestFromAuthorisation(
     },
     deliveryAddress: null,
     product: {
+      productType: 'Contribution',
       amount: getAmount(
         state.page.form.selectedAmounts,
         state.page.form.formData.otherAmounts,

--- a/support-frontend/assets/pages/subscriptions-redemption/api.js
+++ b/support-frontend/assets/pages/subscriptions-redemption/api.js
@@ -89,7 +89,7 @@ function buildRegularPaymentRequest(
   } = user;
 
   const product = {
-    productType: 'DigitalSubscription',
+    productType: 'DigitalPack',
     currency: currencyId,
     billingPeriod: Monthly,
     readerType,

--- a/support-frontend/assets/pages/subscriptions-redemption/api.js
+++ b/support-frontend/assets/pages/subscriptions-redemption/api.js
@@ -89,6 +89,7 @@ function buildRegularPaymentRequest(
   } = user;
 
   const product = {
+    productType: 'DigitalSubscription',
     currency: currencyId,
     billingPeriod: Monthly,
     readerType,
@@ -117,7 +118,7 @@ function buildRegularPaymentRequest(
     ophanIds: getOphanIds(),
     referrerAcquisitionData: getReferrerAcquisitionData(),
     supportAbTests: getSupportAbTests(participations),
-    debugInfo: 'no form/redux for corporate subs',
+    debugInfo: 'no form/redux for redemption page',
   };
 }
 

--- a/support-frontend/assets/pages/subscriptions-redemption/api.js
+++ b/support-frontend/assets/pages/subscriptions-redemption/api.js
@@ -18,6 +18,7 @@ import { getOrigin } from 'helpers/url';
 import { appropriateErrorMessage } from 'helpers/errorReasons';
 import { getGlobal } from 'helpers/globals';
 import type { ReaderType } from 'helpers/productPrice/readerType';
+import { DigitalPack } from 'helpers/subscriptions';
 
 type ValidationResult = {
   valid: boolean,
@@ -89,7 +90,7 @@ function buildRegularPaymentRequest(
   } = user;
 
   const product = {
-    productType: 'DigitalPack',
+    productType: DigitalPack,
     currency: currencyId,
     billingPeriod: Monthly,
     readerType,


### PR DESCRIPTION
## What are you doing in this PR?

This PR gets the client side to send a discriminator field when creating a subscription.  This means that it is explicit about which product the user is signing up for, rather than just looking at the shape of the data.

The next PR will actually use the PR on the server side.

https://trello.com/c/Mwb7aMda/3379-add-discriminator-to-producttype

## Why are you doing this?

We had a contribution that came through a few months without an amount, so the system tried to put it through as a digital subscription.  Luckily it failed for other reasons (payment) but this is a flaky situation to be in, so we decided to make things more explicit in case it breaks as we refactor things or add a new product.

## Testing
part of the POST request from testing locally, per product
```
product: {productType: "Contribution", amount: 5, currency: "GBP", billingPeriod: "Monthly"}
product: {productType: "DigitalPack", currency: "GBP", billingPeriod: "Quarterly", readerType: "Gift"}
product: {productType: "DigitalPack", currency: "GBP", billingPeriod: "Monthly", readerType: "Direct"}
six day paper:
product: {
billingPeriod: "Monthly"
currency: "GBP"
fulfilmentOptions: "Collection"
productOptions: "Sixday"
productType: "Paper"
}
GW gift:
product: {
billingPeriod: "Quarterly"
currency: "GBP"
fulfilmentOptions: "Domestic"
productType: "GuardianWeekly"
}
```