### PR TITLE
Update share image URL for Digital Subscriptions page

### DIFF
--- a/support-frontend/app/controllers/DigitalSubscriptionController.scala
+++ b/support-frontend/app/controllers/DigitalSubscriptionController.scala
@@ -71,7 +71,7 @@ class DigitalSubscriptionController(
 
     val readerType = if (orderIsAGift) Gift else Direct
     val productPrices = priceSummaryServiceProvider.forUser(false).getPrices(DigitalPack, promoCodes, readerType)
-    val shareImageUrl = Some("https://i.guim.co.uk/img/media/74422ad120c709448f433c34f5190e2465ffa65e/0_0_1200_1200/1200.png?width-1200&auto=format&fit=crop&quality=85&s=e86eccf1b764be15437b3ca93c542d92") // scalastyle:ignore
+    val shareImageUrl = Some("https://i.guim.co.uk/img/media/74422ad120c709448f433c34f5190e2465ffa65e/0_0_1200_1200/1200.png?width=1200&auto=format&fit=crop&quality=85&s=1407add4d016d15cc074b0f9de8f1433") // scalastyle:ignore
     if (settings.switches.enableDigitalSubGifting.isOn || !orderIsAGift) {
       Ok(views.html.main(
         title = title,

--- a/support-frontend/app/controllers/DigitalSubscriptionController.scala
+++ b/support-frontend/app/controllers/DigitalSubscriptionController.scala
@@ -71,7 +71,7 @@ class DigitalSubscriptionController(
 
     val readerType = if (orderIsAGift) Gift else Direct
     val productPrices = priceSummaryServiceProvider.forUser(false).getPrices(DigitalPack, promoCodes, readerType)
-    val shareImageUrl = Some("https://i.guim.co.uk/img/media/1033800a75851058d619bc0519b0b7b48a53dcf5/0_0_1200_1200/1200.jpg?width=1200&height=1200&quality=85&auto=format&fit=crop&s=0d50dd49d1fedeacff8a3e437332c2bf") // scalastyle:ignore
+    val shareImageUrl = Some("https://i.guim.co.uk/img/media/74422ad120c709448f433c34f5190e2465ffa65e/0_0_1200_1200/1200.png?width-1200&auto=format&fit=crop&quality=85&s=e86eccf1b764be15437b3ca93c542d92") // scalastyle:ignore
     if (settings.switches.enableDigitalSubGifting.isOn || !orderIsAGift) {
       Ok(views.html.main(
         title = title,


### PR DESCRIPTION
## What are you doing in this PR?

This PR updates the packshot used when sharing https://support.theguardian.com/uk/subscribe/digital via social media, as demoed here using https://cards-dev.twitter.com/validator.

### Before

<img width="523" alt="Screenshot 2020-12-03 at 17 45 47" src="https://user-images.githubusercontent.com/1590704/101067721-c6fd0c00-358f-11eb-989b-936168419b72.png">

### After

<img width="523" alt="Screenshot 2020-12-03 at 18 21 18" src="https://user-images.githubusercontent.com/1590704/101071352-66240280-3594-11eb-9855-31bad93f1581.png">

[**Trello Card**](https://trello.com/c/N0PrkK0G/3441-update-digital-sub-open-graph-with-new-rebrand-packshot)