### PR TITLE
make the test users page more useful

### DIFF
--- a/support-frontend/app/controllers/TestUsersManagement.scala
+++ b/support-frontend/app/controllers/TestUsersManagement.scala
@@ -19,9 +19,9 @@ class TestUsersManagement(
 
   private val cookieDomain = guardianDomain
 
-  def createTestUser: Action[AnyContent] = authAction {
+  def createTestUser: Action[AnyContent] = authAction { request =>
     val testUser = testUsers.testUsers.generate()
-    Ok(testUsersView(testUser))
+    Ok(testUsersView(testUser, request.user.email.replace("@", s"+$testUser@")))
       .withHeaders(CacheControl.noCache)
       .withCookies(Cookie("_test_username", testUser, httpOnly = false, domain = Some(cookieDomain.value)))
   }

--- a/support-frontend/app/views/testUsers.scala.html
+++ b/support-frontend/app/views/testUsers.scala.html
@@ -29,7 +29,8 @@
                 <li>If you DO want to receive emails: @{email}</li>
             </ul>
             <h2>Redemption of corporate or gift subscriptions</h2>
-            <p>You do not have to use any details, just make sure you have visited this page before hand and the red flash is visible.</p>
+            <p>You do not have to use any details, just make sure you are logged out, have visited this page before hand and the red flash is visible.</p>
+            <p>Alternatively, register an identity account as per a recurring product purchase, and make sure you are logged in.</p>
         </div>
         <!-- build-commit-id: @app.BuildInfo.gitCommitId -->
     </body>

--- a/support-frontend/app/views/testUsers.scala.html
+++ b/support-frontend/app/views/testUsers.scala.html
@@ -1,5 +1,6 @@
 @(
-        key: String
+    key: String,
+    email: String
 )
 
 <!DOCTYPE html>
@@ -10,16 +11,26 @@
         <title>Test Users</title>
     </head>
     <body>
-        <h1>New Test User key: @key</h1>
-        Your user will be valid for the next 48H.<br/>
-        When registering please populate the following fields with your new test user key.<br/>
-        This test username has also been added as the session cookie _test_username for the client side and for testing one-off paypal contributions.<br/>
-        You must have the cookie present on the client side for the payment providers otherwise the client and server side will use different keys and cause a support workers failure
-        <ul>
-            <li><strong>First Name:</strong> @key (only field checked by recurring contributions)</li>
-            <li><strong>Username:</strong> @key (if applicable?)</li>
-            <li><strong>Email:</strong> @{key}@@gu.com (for one off contributions)<li>or alternatively yourname+@{key}@@guardian.co.uk</li>
-        </ul>
+        <h1>Test User generator.</h1>
+        <p>This is for testing without using real payment details</p>
+        <p>@key</p>
+        <p><a href="https://github.com/guardian/support-frontend/wiki/Test-users">Read this to learn about test users</a></p>
+        <div>When registering please populate the following fields with your new test user key.<br/>
+            All other fields can be populated as you wish.
+            <h2>All recurring product purchases</h2>
+            <ul>
+                <li><strong>First Name:</strong> @key</li>
+                <br><strong>(Optional) Recommended Email (if you do not want to receive emails):</strong> @{key}@@gu.com<br>
+                <li>If you DO want to receive emails: @{email}</li>
+            </ul>
+            <h2>Single contributions</h2>
+            <ul>
+                <li><strong>Email (if you do not want to receive emails):</strong> @{key}@@gu.com</li>
+                <li>If you DO want to receive emails: @{email}</li>
+            </ul>
+            <h2>Redemption of corporate or gift subscriptions</h2>
+            <p>You do not have to use any details, just make sure you have visited this page before hand and the red flash is visible.</p>
+        </div>
         <!-- build-commit-id: @app.BuildInfo.gitCommitId -->
     </body>
 </html>


### PR DESCRIPTION
## What are you doing in this PR?

This PR adds a nice link to the test users Wiki page.  Also makes it a bit clearer what to use for what.

Ideally it could just have a list of links with the details prefilled for each product, but that might be a job for another day!

https://trello.com/c/Og2MS2Ts/3450-add-link-from-test-users-page-to-test-users-wiki-page

## Why are you doing this?

When we were testing gift DS throughout the whole subs team, a lot of us were having trouble!  Devs and non devs alike.

## Screenshots

![image](https://user-images.githubusercontent.com/7304387/101095094-4e10ab00-35b5-11eb-9339-12045239fe65.png)

