### PR TITLE
Remove nudge from CTA digital subscriptions landing pages

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/hero/hero.jsx
@@ -67,7 +67,6 @@ function CampaignHeader(props: PropTypes) {
                 size="default"
                 icon={<SvgArrowDownStraight />}
                 iconSide="right"
-                nudgeIcon
                 onClick={() => window.scrollTo(0, 1500)}
               >
             See pricing options

--- a/support-frontend/assets/pages/digital-subscription-landing/components/heroGift/hero.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/heroGift/hero.jsx
@@ -49,7 +49,6 @@ function CampaignHeaderGift(props: PropTypes) {
               size="default"
               icon={<SvgArrowDownStraight />}
               iconSide="right"
-              nudgeIcon
               onClick={() => window.scrollTo(0, 1500)}
             >
             See pricing options

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.jsx
@@ -6,7 +6,7 @@ import React, { type Node } from 'react';
 import { ThemeProvider } from 'emotion-theming';
 import { css } from '@emotion/core';
 import { LinkButton, buttonBrand } from '@guardian/src-button';
-import { SvgChevronDownSingle } from '@guardian/src-icons';
+import { SvgArrowDownStraight } from '@guardian/src-icons';
 import { space } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import { body, headline } from '@guardian/src-foundations/typography';
@@ -99,7 +99,7 @@ function WeeklyHero({ orderIsAGift, currencyId, copy }: PropTypes) {
                 onClick={sendTrackingEventsOnClick('options_cta_click', 'GuardianWeekly', null)}
                 priority="tertiary"
                 iconSide="right"
-                icon={<SvgChevronDownSingle />}
+                icon={<SvgArrowDownStraight />}
                 href="#subscribe"
               >
                 See pricing options


### PR DESCRIPTION
## What are you doing in this PR?
Removing the nudge from the CTA icon in the hero on the digisubs landing pages (gift and non-gift).

## Why are you doing this?
Because it looks silly. 

Thanks @jesseyuen!
