### PR TITLE
use identity id instead of sf contact id for most emails

### DIFF
--- a/support-models/src/main/scala/com/gu/support/workers/states/SendThankYouEmailState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/SendThankYouEmailState.scala
@@ -22,7 +22,6 @@ object SendThankYouEmailState {
 
   case class SendThankYouEmailContributionState(
     user: User,
-    salesForceContact: SalesforceContactRecord,
     product: Contribution,
     paymentMethod: PaymentMethod,
     accountNumber: String,
@@ -30,7 +29,6 @@ object SendThankYouEmailState {
 
   case class SendThankYouEmailDigitalSubscriptionDirectPurchaseState(
     user: User,
-    sfContactId: SfContactId,
     product: DigitalPack,
     paymentMethod: PaymentMethod,
     paymentSchedule: PaymentSchedule,
@@ -41,7 +39,6 @@ object SendThankYouEmailState {
 
   case class SendThankYouEmailDigitalSubscriptionGiftPurchaseState(
     user: User,
-    purchaserSFContactId: SfContactId,
     recipientSFContactId: SfContactId,
     product: DigitalPack,
     giftRecipient: DigitalSubscriptionGiftRecipient,
@@ -55,21 +52,18 @@ object SendThankYouEmailState {
 
   case class SendThankYouEmailDigitalSubscriptionCorporateRedemptionState(
     user: User,
-    sfContactId: SfContactId,
     product: DigitalPack,
     subscriptionNumber: String,
   ) extends SendThankYouEmailDigitalSubscriptionState
 
   case class SendThankYouEmailDigitalSubscriptionGiftRedemptionState(
     user: User,
-    sfContactId: SfContactId,
     product: DigitalPack,
     termDates: TermDates,
   ) extends SendThankYouEmailDigitalSubscriptionState
 
   case class SendThankYouEmailPaperState(
     user: User,
-    salesForceContact: SalesforceContactRecord,
     product: Paper,
     paymentMethod: PaymentMethod,
     paymentSchedule: PaymentSchedule,
@@ -81,7 +75,6 @@ object SendThankYouEmailState {
 
   case class SendThankYouEmailGuardianWeeklyState(
     user: User,
-    salesForceContact: SalesforceContactRecord,
     product: GuardianWeekly,
     giftRecipient: Option[WeeklyGiftRecipient],
     paymentMethod: PaymentMethod,

--- a/support-models/src/test/scala/com/gu/support/workers/SendThankYouEmailStateSerialisationSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/workers/SendThankYouEmailStateSerialisationSpec.scala
@@ -31,7 +31,6 @@ object ProductTypeCreatedTestData {
 
   val contributionCreated = SendThankYouEmailContributionState(
     user = User("111222", "email@blah.com", None, "bertha", "smith", Address(None, None, None, None, None, Country.UK)),
-    salesForceContact = SalesforceContactRecord("sfbuy", "sfbuyacid"),
     Contribution(1, GBP, Monthly),
     PayPalReferenceTransaction("baid", "email@emaail.com"),
     "acno",
@@ -39,7 +38,6 @@ object ProductTypeCreatedTestData {
 
   val digitalSubscriptionDirectPurchaseCreated = SendThankYouEmailDigitalSubscriptionDirectPurchaseState(
     user = User("111222", "email@blah.com", None, "bertha", "smith", Address(None, None, None, None, None, Country.UK)),
-    sfContactId = SfContactId("sfbuy"),
     DigitalPack(GBP, Monthly, ReaderType.Direct),
     PayPalReferenceTransaction("baid", "email@emaail.com"),
     PaymentSchedule(List(Payment(new LocalDate(2020, 6, 16), 1.49))),
@@ -50,7 +48,6 @@ object ProductTypeCreatedTestData {
 
   val digitalSubscriptionGiftPurchaseCreated = SendThankYouEmailDigitalSubscriptionGiftPurchaseState(
     user = User("111222", "email@blah.com", None, "bertha", "smith", Address(None, None, None, None, None, Country.UK)),
-    purchaserSFContactId = SfContactId("sfbuy"),
     recipientSFContactId = SfContactId("sfrecip"),
     DigitalPack(GBP, Monthly, ReaderType.Gift),
     GiftRecipient.DigitalSubscriptionGiftRecipient("bob", "builder", "bob@gu.com", Some("message"), new LocalDate(2020, 10, 2)),
@@ -63,13 +60,11 @@ object ProductTypeCreatedTestData {
   )
   val digitalSubscriptionCorporateRedemptionCreated = SendThankYouEmailDigitalSubscriptionCorporateRedemptionState(
     user = User("111222", "email@blah.com", None, "bertha", "smith", Address(None, None, None, None, None, Country.UK)),
-    sfContactId = SfContactId("sfbuy"),
     DigitalPack(GBP, Monthly, ReaderType.Corporate),
     "subno"
   )
   val digitalSubscriptionGiftRedemptionCreated = SendThankYouEmailDigitalSubscriptionGiftRedemptionState(
     user = User("111222", "email@blah.com", None, "bertha", "smith", Address(None, None, None, None, None, Country.UK)),
-    sfContactId = SfContactId("sfbuy"),
     DigitalPack(GBP, Monthly, ReaderType.Gift),
     TermDates(
       new LocalDate(2020, 10, 24),
@@ -79,7 +74,6 @@ object ProductTypeCreatedTestData {
   )
   val paperCreated = SendThankYouEmailPaperState(
     user = User("111222", "email@blah.com", None, "bertha", "smith", Address(None, None, None, None, None, Country.UK)),
-    salesForceContact = SalesforceContactRecord("sfbuy", "sfbuyacid"),
     Paper(fulfilmentOptions = Collection, productOptions = Saturday),
     PayPalReferenceTransaction("baid", "email@emaail.com"),
     PaymentSchedule(List(Payment(new LocalDate(2020, 6, 16), 1.49))),
@@ -91,7 +85,6 @@ object ProductTypeCreatedTestData {
 
   val guardianWeeklyCreated = SendThankYouEmailGuardianWeeklyState(
     user = User("111222", "email@blah.com", None, "bertha", "smith", Address(None, None, None, None, None, Country.UK)),
-    salesForceContact = SalesforceContactRecord("sfbuy", "sfbuyacid"),
     GuardianWeekly(GBP, Monthly, Domestic),
     Some(GiftRecipient.WeeklyGiftRecipient(None, "bob", "builder", Some("bob@gu.com"))),
     PayPalReferenceTransaction("baid", "email@emaail.com"),

--- a/support-workers/src/main/scala/com/gu/emailservices/ContributionEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/ContributionEmailFields.scala
@@ -29,12 +29,7 @@ class ContributionEmailFields(
         "product" -> s"${contributionProcessedInfo.product.billingPeriod.toString.toLowerCase}-contribution"
       ) ++ paymentFields
 
-      EmailFields(
-        fields,
-        Left(SfContactId(contributionProcessedInfo.salesForceContact.Id)),
-        contributionProcessedInfo.user.primaryEmailAddress,
-        "regular-contribution-thank-you"
-      )
+      EmailFields(fields, contributionProcessedInfo.user, "regular-contribution-thank-you")
     }
   }
 

--- a/support-workers/src/main/scala/com/gu/emailservices/EmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/EmailFields.scala
@@ -16,7 +16,7 @@ case class EmailPayloadTo(Address: String, ContactAttributes: EmailPayloadContac
 case class EmailPayload(
   To: EmailPayloadTo,
   DataExtensionName: String,
-  SfContactId: Option[String], // TODO delete this and make IdentityId non Option
+  SfContactId: Option[String], // this should only be used where no identity account exists e.g. giftee notification
   IdentityUserId: Option[String],
   ScheduledTime: Option[DateTime], // None means immediate
   UserAttributes: Option[JsonObject],
@@ -37,8 +37,8 @@ case class EmailFields(
   userId: Either[SfContactId, IdentityUserId],
   email: String,
   dataExtensionName: String,
-  deliveryDate: Option[LocalDate] = None,
-  userAttributes: Option[JsonObject] = None,
+  deliveryDate: Option[LocalDate],
+  userAttributes: Option[JsonObject],
 ) {
 
   def payload: String =
@@ -54,4 +54,9 @@ case class EmailFields(
       userAttributes
     ).asJson.printWith(Printer.spaces2.copy(dropNullValues = true))
 
+}
+
+object EmailFields {
+  def apply(fields: List[(String, String)], user: User, dataExtensionName: String, userAttributes: Option[JsonObject] = None): EmailFields =
+    new EmailFields(fields, Right(IdentityUserId(user.id)), user.primaryEmailAddress, dataExtensionName, None, userAttributes = userAttributes)
 }

--- a/support-workers/src/main/scala/com/gu/emailservices/FailedContributionEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/FailedContributionEmailFields.scala
@@ -15,6 +15,6 @@ object FailedEmailFields {
     failedEmailFields("paper-failed", email, identityUserId)
 
   private def failedEmailFields(dataExtensionName: String, email: String, identityUserId: IdentityUserId): EmailFields =
-    EmailFields(Nil, Right(identityUserId), email, dataExtensionName)
+    EmailFields(Nil, Right(identityUserId), email, dataExtensionName, None, None)
 
 }

--- a/support-workers/src/main/scala/com/gu/emailservices/GuardianWeeklyEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/GuardianWeeklyEmailFields.scala
@@ -38,8 +38,7 @@ class GuardianWeeklyEmailFields(
     ).map(fields =>
       EmailFields(
         fields ++ additionalFields ++ giftRecipientFields,
-        Left(SfContactId(gw.salesForceContact.Id)),
-        gw.user.primaryEmailAddress,
+        gw.user,
         "guardian-weekly"
       ))
   }

--- a/support-workers/src/main/scala/com/gu/emailservices/PaperEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/PaperEmailFields.scala
@@ -31,7 +31,7 @@ class PaperEmailFields(
       fixedTerm = false,
       paper.firstDeliveryDate,
     ).map(fields =>
-      EmailFields(fields ++ additionalFields, Left(SfContactId(paper.salesForceContact.Id)), paper.user.primaryEmailAddress, dataExtension)
+      EmailFields(fields ++ additionalFields, paper.user, dataExtension)
     )
   }
 }

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -224,7 +224,7 @@ class NextState(
   ) =
     (state.product, paymentOrRedemptionData) match {
       case (product: Contribution, Purchase(purchase)) =>
-        SendThankYouEmailContributionState(state.user, state.salesforceContacts.buyer, product, purchase.paymentMethod, accountNumber.value)
+        SendThankYouEmailContributionState(state.user, product, purchase.paymentMethod, accountNumber.value)
       case (product: DigitalPack, Purchase(purchase)) if product.readerType == ReaderType.Direct =>
         dsDirect(product, purchase)
       case (product: DigitalPack, Purchase(purchase)) if product.readerType == ReaderType.Gift =>
@@ -243,13 +243,12 @@ class NextState(
 
   private def dsCorporate(product: DigitalPack) =
     SendThankYouEmailDigitalSubscriptionCorporateRedemptionState(
-      state.user, SfContactId(state.salesforceContacts.buyer.Id), product, subscriptionNumber.value
+      state.user, product, subscriptionNumber.value
     )
 
   private def weekly(product: GuardianWeekly, purchase: PaymentMethodWithSchedule) =
     SendThankYouEmailGuardianWeeklyState(
       state.user,
-      state.salesforceContacts.buyer,
       product,
       state.giftRecipient.map(_.asWeekly.get),
       purchase.paymentMethod,
@@ -263,7 +262,6 @@ class NextState(
   private def paper(product: Paper, purchase: PaymentMethodWithSchedule) =
     SendThankYouEmailPaperState(
       state.user,
-      state.salesforceContacts.buyer,
       product,
       purchase.paymentMethod,
       purchase.paymentSchedule,
@@ -276,7 +274,6 @@ class NextState(
   private def dsGift(product: DigitalPack, purchase: PaymentMethodWithSchedule, giftPurchase: DigitalSubscriptionGiftPurchaseDetails) =
     SendThankYouEmailDigitalSubscriptionGiftPurchaseState(
       state.user,
-      SfContactId(state.salesforceContacts.buyer.Id),
       SfContactId(state.salesforceContacts.giftRecipient.get.Id),
       product,
       giftPurchase.giftRecipient,
@@ -291,7 +288,6 @@ class NextState(
   private def dsDirect(product: DigitalPack, purchase: PaymentMethodWithSchedule) =
     SendThankYouEmailDigitalSubscriptionDirectPurchaseState(
       state.user,
-      SfContactId(state.salesforceContacts.buyer.Id),
       product,
       purchase.paymentMethod,
       purchase.paymentSchedule,
@@ -354,7 +350,6 @@ object DigitalSubscriptionGiftRedemption {
         analyticsInfo = state.analyticsInfo,
         sendThankYouEmailState = SendThankYouEmailDigitalSubscriptionGiftRedemptionState(
           state.user,
-          SfContactId(state.salesforceContacts.buyer.Id),
           product,
           termDates,
         ),

--- a/support-workers/src/test/scala/com/gu/emailservices/EmailFieldsSpec.scala
+++ b/support-workers/src/test/scala/com/gu/emailservices/EmailFieldsSpec.scala
@@ -3,7 +3,7 @@ package com.gu.emailservices
 import com.gu.i18n.Currency.GBP
 import com.gu.support.config.TouchPointEnvironments.SANDBOX
 import com.gu.support.workers.integration.TestData
-import com.gu.support.workers.integration.TestData.{countryOnlyAddress, directDebitPaymentMethod, sfContactRecord, sfContactId}
+import com.gu.support.workers.integration.TestData.{countryOnlyAddress, directDebitPaymentMethod}
 import com.gu.support.workers.states.SendThankYouEmailState._
 import com.gu.support.workers._
 import io.circe.parser._
@@ -83,7 +83,7 @@ class DigitalPackEmailFieldsSpec extends AsyncFlatSpec with Matchers with Inside
         |  }
         |},
         |"DataExtensionName" : "digipack",
-        |"SfContactId" : "contactID"
+        |"IdentityUserId" : "1234"
         |}
         |""".stripMargin)
     val actual = new DigitalPackEmailFields(
@@ -93,7 +93,6 @@ class DigitalPackEmailFieldsSpec extends AsyncFlatSpec with Matchers with Inside
     ).build(
       SendThankYouEmailDigitalSubscriptionDirectPurchaseState(
         User("1234", "test@gu.com", None, "Mickey", "Mouse", billingAddress = countryOnlyAddress),
-        sfContactId,
         DigitalPack(GBP, Annual),
         directDebitPaymentMethod,
         PaymentSchedule(List(Payment(new LocalDate(2019, 1, 14), 119.90))),
@@ -125,7 +124,7 @@ class DigitalPackEmailFieldsSpec extends AsyncFlatSpec with Matchers with Inside
         |  }
         |},
         |"DataExtensionName" : "digipack-corporate-redemption",
-        |"SfContactId" : "contactID"
+        |"IdentityUserId" : "1234"
         |}
         |""".stripMargin)
     val actual = new DigitalPackEmailFields(
@@ -135,7 +134,6 @@ class DigitalPackEmailFieldsSpec extends AsyncFlatSpec with Matchers with Inside
     ).build(
       SendThankYouEmailDigitalSubscriptionCorporateRedemptionState(
         User("1234", "test@gu.com", None, "Mickey", "Mouse", billingAddress = countryOnlyAddress),
-        sfContactId,
         DigitalPack(GBP, Annual),
         "A-S00045678",
       )
@@ -162,7 +160,7 @@ class DigitalPackEmailFieldsSpec extends AsyncFlatSpec with Matchers with Inside
         |    }
         |  },
         |  "DataExtensionName" : "digipack-gift-redemption",
-        |  "SfContactId" : "contactID",
+        |  "IdentityUserId" : "1234",
         |  "UserAttributes" : {
         |    "unmanaged_digital_subscription_gift_duration_months" : 3,
         |    "unmanaged_digital_subscription_gift_start_date" : "2020-11-18",
@@ -177,7 +175,6 @@ class DigitalPackEmailFieldsSpec extends AsyncFlatSpec with Matchers with Inside
     ).build(
       SendThankYouEmailDigitalSubscriptionGiftRedemptionState(
         User("1234", "test@gu.com", None, "Mickey", "Mouse", billingAddress = countryOnlyAddress),
-        sfContactId,
         DigitalPack(GBP, Annual),
         TermDates(
           new LocalDate(2020, 11, 18),


### PR DESCRIPTION
## What are you doing in this PR?

This PR removes SF contact where it is not needed, for sending emails.  It only remains for gift notification for DS, as we do not have an identity id for the giftee notification email address.

https://trello.com/c/IfG3s7tM/3505-user-identity-id-instead-of-email-address-for-sending-emails

## Why are you doing this?

This is because when the email gets to braze, it somehow messes things up if we send using an SF contact id instead of identity ID. @paulbrown1982 has requested we use identity id where possible.

## Testing

tested with the IT tests, also running the manual email send, all 9 emails arrived successfully.
ToDO, test in CODE manually once it's approved.