### PR TITLE
add a deployToCode task for support-workers

### DIFF
--- a/support-workers/build.sbt
+++ b/support-workers/build.sbt
@@ -70,3 +70,24 @@ assemblyMergeStrategy in (IntegrationTest, assembly) := {
 }
 IntegrationTest / assembly / test := {}
 IntegrationTest / assembly / aggregate := false
+
+lazy val deployToCode = inputKey[Unit]("Directly update AWS lambda code from DEV instead of via RiffRaff for faster feedback loop")
+
+deployToCode := {
+  import scala.sys.process._
+  val s3Bucket = "support-workers-dist"
+  val s3Path = "support/CODE/support-workers/support-workers.jar"
+  (s"aws s3 cp ${assembly.value} s3://" + s3Bucket + "/" + s3Path + " --profile membership --region eu-west-1").!!
+  List(
+    "-CreatePaymentMethodLambda-",
+    "-CreateSalesforceContactLambda-",
+    "-CreateZuoraSubscriptionLambda-",
+    "-SendThankYouEmailLambda-",
+    "-FailureHandlerLambda-",
+    "-SendAcquisitionEventLambda-",
+    "-PreparePaymentMethodForReuseLambda-",
+  ).foreach(functionPartial =>
+    s"aws lambda update-function-code --function-name support${functionPartial}CODE --s3-bucket $s3Bucket --s3-key $s3Path --profile membership --region eu-west-1".!!
+  )
+
+}


### PR DESCRIPTION
## What are you doing in this PR?

This PR adds a deployToCode task so we can deploy support workers to code from sbt without having to go through a push/build/deploy cycle.

```
$ sbt "support-workers / deployToCode"
[info] welcome to sbt 1.4.4 (AdoptOpenJDK Java 1.8.0_265)
[info] loading global plugins from /Users/john_duffell/.sbt/1.0/plugins
[info] loading settings for project support-frontend-build from plugins.sbt ...
[info] loading project definition from /Users/john_duffell/code/support-frontend/project
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[info] loading settings for project root from build.sbt ...
[info] loading settings for project support-frontend from build.sbt ...
[info] loading settings for project support-workers from build.sbt ...
[info] loading settings for project support-payment-api from build.sbt ...
[info] loading settings for project support-models from build.sbt,sonatype.sbt,version.sbt ...
[info] loading settings for project support-config from build.sbt,sonatype.sbt,version.sbt ...
[info] loading settings for project support-services from build.sbt,sonatype.sbt,version.sbt ...
[info] loading settings for project module-rest from build.sbt ...
[info] loading settings for project module-aws from build.sbt ...
[info] loading settings for project support-internationalisation from build.sbt,sonatype.sbt,version.sbt ...
[info] loading settings for project acquisition-event-producer from version.sbt ...
[info] loading settings for project stripe-intent from build.sbt ...
[info] loading settings for project support-redemptiondb from build.sbt ...
[info] loading settings for project it-test-runner from build.sbt ...
[info] resolving key references (15147 settings) ...
[info] set current project to support-frontend-root (in build file:/Users/john_duffell/code/support-frontend/)
[info] ZuoraSpec:
[info] zuora service
[info] - should correctly format dates
12:48:36,666 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback-test.xml]
12:48:36,669 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback.groovy]
................
[info] CreateZuoraSubscriptionSpec:
[info] CreateZuoraSubscription lambda
[info] Run completed in 6 seconds, 952 milliseconds.
[info] Total number of tests run: 100
[info] Suites: completed 39, aborted 0
[info] Tests: succeeded 100, failed 0, canceled 0, ignored 0, pending 0
[info] All tests passed.
[info] Checking every *.class/*.jar file's SHA-1.
[info] Merging files...
[warn] Merging 'META-INF/DEPENDENCIES' with strategy 'discard'
..................
[warn] Strategy 'filterDistinctLines' was applied to 3 files
[warn] Strategy 'first' was applied to 2 files
[info] Assembly up to date: /Users/john_duffell/code/support-frontend/support-workers/target/scala-2.12/support-workers.jar
[success] Total time: 153 s (02:33), completed 07-Dec-2020 12:51:04
$ 
```

https://trello.com/c/l7qsivNp/3156-allow-local-deploy-to-code-directly

## Why are you doing this?

We don't want to have to spend so long to test something in CODE.