### PR TITLE
Pass additional vendors in vendorConsentsLookup to GTM

### DIFF
--- a/support-frontend/assets/helpers/tracking/googleTagManager.js
+++ b/support-frontend/assets/helpers/tracking/googleTagManager.js
@@ -30,8 +30,8 @@ type GaEventData = {
 }
 
 // these values match the keys used by @guardian/consent-management-platform
-const googleAnalyticsKey = 'google-analytics';
 const googleTagManagerKey = 'google-tag-manager';
+const googleAnalyticsKey = 'google-analytics';
 const googleRemarketingId = 'remarketing';
 const facebookKey = 'fb';
 const twitterKey = 'twitter';
@@ -40,8 +40,8 @@ const bingKey = 'bing';
 const vendorIds: {
   [key: string]: string
 } = {
-  [googleAnalyticsKey]: '5e542b3a4cd8884eb41b5a72',
   [googleTagManagerKey]: '5e952f6107d9d20c88e7c975',
+  [googleAnalyticsKey]: '5e542b3a4cd8884eb41b5a72',
   [googleRemarketingId]: '5ed0eb688a76503f1016578f',
   [facebookKey]: '5e7e1298b8e05c54a85c52d2',
   [twitterKey]: '5e71760b69966540e4554f01',

--- a/support-frontend/assets/helpers/tracking/googleTagManager.js
+++ b/support-frontend/assets/helpers/tracking/googleTagManager.js
@@ -32,12 +32,20 @@ type GaEventData = {
 // these values match the keys used by @guardian/consent-management-platform
 const googleAnalyticsKey = 'google-analytics';
 const googleTagManagerKey = 'google-tag-manager';
+const googleRemarketingId = 'remarketing';
+const facebookKey = 'fb';
+const twitterKey = 'twitter';
+const bingKey = 'bing';
 
 const vendorIds: {
   [key: string]: string
 } = {
   [googleAnalyticsKey]: '5e542b3a4cd8884eb41b5a72',
   [googleTagManagerKey]: '5e952f6107d9d20c88e7c975',
+  [googleRemarketingId]: '5ed0eb688a76503f1016578f',
+  [facebookKey]: '5e7e1298b8e05c54a85c52d2',
+  [twitterKey]: '5e71760b69966540e4554f01',
+  [bingKey]: '5f353ea3f8baf8390b95ffd4',
 };
 
 const gaPropertyId = 'UA-51507017-5';

--- a/support-frontend/assets/helpers/tracking/googleTagManager.js
+++ b/support-frontend/assets/helpers/tracking/googleTagManager.js
@@ -32,7 +32,7 @@ type GaEventData = {
 // these values match the keys used by @guardian/consent-management-platform
 const googleTagManagerKey = 'google-tag-manager';
 const googleAnalyticsKey = 'google-analytics';
-const googleRemarketingId = 'remarketing';
+const googleRemarketingKey = 'remarketing';
 const facebookKey = 'fb';
 const twitterKey = 'twitter';
 const bingKey = 'bing';
@@ -42,7 +42,7 @@ const vendorIds: {
 } = {
   [googleTagManagerKey]: '5e952f6107d9d20c88e7c975',
   [googleAnalyticsKey]: '5e542b3a4cd8884eb41b5a72',
-  [googleRemarketingId]: '5ed0eb688a76503f1016578f',
+  [googleRemarketingKey]: '5ed0eb688a76503f1016578f',
   [facebookKey]: '5e7e1298b8e05c54a85c52d2',
   [twitterKey]: '5e71760b69966540e4554f01',
   [bingKey]: '5f353ea3f8baf8390b95ffd4',


### PR DESCRIPTION
## What are you doing in this PR?

This PR is a follow up to https://github.com/guardian/support-frontend/pull/2864. This PR ensures the consent state for the tags below is made available to Google Tag Manager (GTM) via the `vendorConsentsLookup` variable:

- Google Ads Remarketing
- Facebook
- Twitter
- Bing

This `vendorConsentsLookup` variable is pushed to GTM, and looks something like "google-analytics,twitter,bing".

I've prepared and tested the GTM configuration update to query this `vendorConsentsLookup` for the tags listed above and it works as expected, eg. only enabling a tag if it is matched in the `vendorConsentsLookup` comma delimited list.

[**Trello Card**](https://trello.com/c/ounKMMqR/3511-granular-vendor-consent-checks-for-tags-within-google-tag-manager)

### Next step

Once this is merged I'll publish the configuration changes in GTM. Then I'll raise a follow-up PR that removes GA check from `userConsentsToGTM` assignment.