### PR TITLE
PRB A/B test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -34,6 +34,28 @@ export const tests: Tests = {
     seed: 1,
   },
 
+  stripePaymentRequestButtonDec2020: {
+    type: 'OTHER',
+    variants: [
+      {
+        id: 'control',
+      },
+      {
+        id: 'PRB',
+      },
+    ],
+    audiences: {
+      ALL: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: true,
+    referrerControlled: false,
+    targetPage: landingPage,
+    seed: 2,
+  },
+
   usThankyouPageLargeDonationTest: {
     type: 'OTHER',
     variants: [

--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -9,6 +9,7 @@ const usOnlyLandingPage = '/us/contribute(/.*)?$';
 const usLandingPageAndThankyouPage = '/us/contribute|thankyou(/.*)?$';
 const auOnlyLandingPage = '/au/contribute(/.*)?$';
 const ukOnlyLandingPage = '/uk/contribute(/.*)?$';
+const notUkLandingPage = '/us|au|eu|int|nz|ca/contribute(/.*)?$';
 export const subsShowcaseAndDigiSubPages = '(/??/subscribe(\\?.*)?$|/??/subscribe/digital(\\?.*)?$)';
 
 export const tests: Tests = {
@@ -52,7 +53,7 @@ export const tests: Tests = {
     },
     isActive: true,
     referrerControlled: false,
-    targetPage: landingPage,
+    targetPage: notUkLandingPage,
     seed: 2,
   },
 

--- a/support-frontend/assets/helpers/checkouts.js
+++ b/support-frontend/assets/helpers/checkouts.js
@@ -198,17 +198,11 @@ function getPaymentLabel(paymentMethod: PaymentMethod): string {
 function getAvailablePaymentRequestButtonPaymentMethod(
   result: Object,
   contributionType: ContributionType,
-  stripePaymentRequestButtonVariant: boolean,
 ): StripePaymentMethod | null {
   const switchKey = switchKeyForContributionType(contributionType);
   if (result && result.applePay === true && isSwitchOn(`${switchKey}.stripeApplePay`)) {
     return 'StripeApplePay';
-  } else if (
-    result &&
-    result.applePay === false &&
-    isSwitchOn(`${switchKey}.stripePaymentRequestButton`) &&
-    stripePaymentRequestButtonVariant
-  ) {
+  } else if (result && result.applePay === false && isSwitchOn(`${switchKey}.stripePaymentRequestButton`)) {
     return 'StripePaymentRequestButton';
   }
   return null;

--- a/support-frontend/assets/helpers/checkouts.js
+++ b/support-frontend/assets/helpers/checkouts.js
@@ -198,11 +198,17 @@ function getPaymentLabel(paymentMethod: PaymentMethod): string {
 function getAvailablePaymentRequestButtonPaymentMethod(
   result: Object,
   contributionType: ContributionType,
+  stripePaymentRequestButtonVariant: boolean,
 ): StripePaymentMethod | null {
   const switchKey = switchKeyForContributionType(contributionType);
   if (result && result.applePay === true && isSwitchOn(`${switchKey}.stripeApplePay`)) {
     return 'StripeApplePay';
-  } else if (result && result.applePay === false && isSwitchOn(`${switchKey}.stripePaymentRequestButton`)) {
+  } else if (
+    result &&
+    result.applePay === false &&
+    isSwitchOn(`${switchKey}.stripePaymentRequestButton`) &&
+    stripePaymentRequestButtonVariant
+  ) {
     return 'StripePaymentRequestButton';
   }
   return null;

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -345,16 +345,16 @@ function initialisePaymentRequest(props: PropTypes, stripe: stripeJs.Stripe) {
   });
 
   paymentRequest.canMakePayment().then((result) => {
-    const paymentMethod = getAvailablePaymentRequestButtonPaymentMethod(
-      result,
-      props.contributionType,
-      props.stripePaymentRequestButtonVariant,
-    );
-
+    const paymentMethod = getAvailablePaymentRequestButtonPaymentMethod(result, props.contributionType);
     if (paymentMethod) {
-      trackComponentLoad(`${paymentMethod}-displayed`);
-      props.setPaymentRequestButtonPaymentMethod(paymentMethod, props.stripeAccount);
-      setUpPaymentListenerSca(props, stripe, paymentRequest, paymentMethod);
+      // Track the fact that it loaded, even if the user is in the control for the PRB test
+      trackComponentLoad(`${paymentMethod}-loaded`);
+
+      if (paymentMethod === 'StripeApplePay' || props.stripePaymentRequestButtonVariant) {
+        trackComponentLoad(`${paymentMethod}-displayed`);
+        props.setPaymentRequestButtonPaymentMethod(paymentMethod, props.stripeAccount);
+        setUpPaymentListenerSca(props, stripe, paymentRequest, paymentMethod);
+      }
     } else {
       props.setPaymentRequestButtonPaymentMethod('none', props.stripeAccount);
     }

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -84,6 +84,7 @@ type PropTypes = {
   setError: (error: ErrorReason, stripeAccount: StripeAccount) => Action,
   setHandleStripe3DS: ((clientSecret: string) => Promise<Stripe3DSResult>) => Action,
   csrf: CsrfState,
+  stripePaymentRequestButtonVariant: boolean,
 };
 
 const mapStateToProps = (state: State, ownProps: PropTypes) => ({
@@ -99,6 +100,7 @@ const mapStateToProps = (state: State, ownProps: PropTypes) => ({
   paymentMethod: state.page.form.paymentMethod,
   switches: state.common.settings.switches,
   csrf: state.page.csrf,
+  stripePaymentRequestButtonVariant: state.common.abParticipations.stripePaymentRequestButtonDec2020 === 'PRB',
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -343,7 +345,12 @@ function initialisePaymentRequest(props: PropTypes, stripe: stripeJs.Stripe) {
   });
 
   paymentRequest.canMakePayment().then((result) => {
-    const paymentMethod = getAvailablePaymentRequestButtonPaymentMethod(result, props.contributionType);
+    const paymentMethod = getAvailablePaymentRequestButtonPaymentMethod(
+      result,
+      props.contributionType,
+      props.stripePaymentRequestButtonVariant,
+    );
+
     if (paymentMethod) {
       trackComponentLoad(`${paymentMethod}-displayed`);
       props.setPaymentRequestButtonPaymentMethod(paymentMethod, props.stripeAccount);


### PR DESCRIPTION
We are bringing back the Payment Request button (the purple button in chrome).
We want to find out if it competes with Paypal, and if it impacts retention as well as AV.

Only some users are able to see the button because it depends on their browser and if they have payments set up. So for the test analysis we need the ability to filter both the control and the variant for only people who can see the button.
We do this by emitting a special `payment-request-button-loaded` event to ophan, to indicate that the user _could_ see it.
This cannot be done at the time that they're assigned to the test, because we do not know until later on if their browser supports the button.


### control
<img width="518" alt="Screen Shot 2020-12-09 at 13 58 40" src="https://user-images.githubusercontent.com/1513454/101638983-ab2db600-3a26-11eb-8a29-844f5c5482bf.png">

### variant
<img width="518" alt="Screen Shot 2020-12-09 at 13 58 22" src="https://user-images.githubusercontent.com/1513454/101638989-ae28a680-3a26-11eb-9bff-ce29ae7da0d4.png">
