### PR TITLE
Remove Bolivia from Guardian Weekly delivery list

### DIFF
--- a/support-frontend/assets/helpers/internationalisation/weeklyDeliverableCountries.js
+++ b/support-frontend/assets/helpers/internationalisation/weeklyDeliverableCountries.js
@@ -98,7 +98,7 @@ const weeklyDeliverableCountries: {
   BI: 'Burundi',
   BJ: 'Benin',
   BN: 'Brunei Darussalam',
-  BO: 'Bolivia',
+  // BO: 'Bolivia',
   BQ: 'Bonaire, Saint Eustatius and Saba',
   BR: 'Brazil',
   BS: 'Bahamas',


### PR DESCRIPTION
## What are you doing in this PR?

Remove Bolivia from GW weekly delivery listRemove Bolivia from GW weekly delivery list.

The card also requested reinstating Cuba, but Cuba was already present, and removing Haiti, but Haiti was not actually present on the list. So no additional changes were required.

[**Trello Card**](https://trello.com/c/HQny6odY/3516-update-gw-delivery-countries)