### PR TITLE
Prevent users from starting GW gift on Dec 25

### DIFF
--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.jsx
@@ -230,6 +230,13 @@ function WeeklyCheckoutFormGifting(props: PropTypes) {
               <FieldsetWithError id="startDate" error={firstError('startDate', props.formErrors)} legend="Gift delivery date">
                 {days.map((day) => {
                   const [userDate, machineDate] = [formatUserDate(day), formatMachineDate(day)];
+                  const hideDate = new RegExp('-12-25$').test(machineDate);
+
+                  // Don't render input if Christmas day
+                  if (hideDate) {
+                    return null;
+                  }
+
                   return (
                     <RadioInput
                       appearance="group"


### PR DESCRIPTION
## What are you doing in this PR?

Remove the 25 December date from the Guardian Weekly **Gifting** checkout. Customers who select this date will not receive a paper until the week after.

Non-gifting PR previously merged: https://github.com/guardian/support-frontend/pull/2862
