### PR TITLE
use acquisition-event-producer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -123,8 +123,8 @@ lazy val `support-payment-api` = (project in file("support-payment-api"))
     buildInfoPackage := "app",
     buildInfoOptions += BuildInfoOption.ToMap,
     libraryDependencies ++= commonDependencies
-  ).dependsOn(`support-models`, `support-internationalisation`)
-  .aggregate(`support-models`, `support-internationalisation`)
+  ).dependsOn(`support-models`, `support-internationalisation`, `acquisition-event-producer`)
+  .aggregate(`support-models`, `support-internationalisation`, `acquisition-event-producer`)
 
 lazy val `support-models` = (project in file("support-models"))
   .configs(IntegrationTest)

--- a/support-payment-api/build.sbt
+++ b/support-payment-api/build.sbt
@@ -44,7 +44,6 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion,
   "com.google.guava" % "guava" % "25.0-jre", //-- added explicitly - snyk report avoid logback vulnerability
   "com.paypal.sdk" % "rest-api-sdk" % "1.13.0" exclude("org.apache.logging.log4j", "log4j-slf4j-impl"),
-//  "com.gu" %% "acquisition-event-client-play26" % "4.0.31",
   "org.apache.thrift" % "libthrift" % "0.12.0",// needed for snyk deps https://app.snyk.io/vuln/SNYK-JAVA-ORGAPACHETHRIFT-173706
   akkaHttpServer, // or use nettyServer for Netty
   logback, // add Play logging support

--- a/support-payment-api/build.sbt
+++ b/support-payment-api/build.sbt
@@ -44,7 +44,7 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion,
   "com.google.guava" % "guava" % "25.0-jre", //-- added explicitly - snyk report avoid logback vulnerability
   "com.paypal.sdk" % "rest-api-sdk" % "1.13.0" exclude("org.apache.logging.log4j", "log4j-slf4j-impl"),
-  "com.gu" %% "acquisition-event-client-play26" % "4.0.31",
+//  "com.gu" %% "acquisition-event-client-play26" % "4.0.31",
   "org.apache.thrift" % "libthrift" % "0.12.0",// needed for snyk deps https://app.snyk.io/vuln/SNYK-JAVA-ORGAPACHETHRIFT-173706
   akkaHttpServer, // or use nettyServer for Netty
   logback, // add Play logging support


### PR DESCRIPTION
ophan is now returning 400s since a play upgrade.
This change makes payment-api use the same dependency as support-workers, which is still working

I cannot test the actual ophan integration until it's in PROD, but have confirmed it still creates the correct payload in CODE