### PR TITLE
Revert url encode 

### DIFF
--- a/acquisition-event-producer/src/main/scala/com/gu/acquisition/services/OphanService.scala
+++ b/acquisition-event-producer/src/main/scala/com/gu/acquisition/services/OphanService.scala
@@ -1,7 +1,5 @@
 package com.gu.acquisition.services
 
-import java.net.URLEncoder
-
 import cats.data.EitherT
 import cats.implicits._
 import com.gu.acquisition.model.errors.AnalyticsServiceError.BuildError
@@ -33,7 +31,7 @@ private [acquisition] class OphanService(endpointOverride: Option[HttpUrl] = Non
     val url = endpoint.newBuilder()
       .addPathSegment("a.gif")
       .addQueryParameter("viewId", ophanIds.pageviewId.getOrElse(SyntheticPageviewId.generate))
-      .addQueryParameter("acquisition" , URLEncoder.encode(acquisition.asJson.noSpaces, "UTF-8"))
+      .addQueryParameter("acquisition" , acquisition.asJson.noSpaces)
       .build()
 
     val request = new Request.Builder()


### PR DESCRIPTION
Revert #2893  

This is because the request was indeed double URL encoded:

```
message:Unable to decode Acquisition Event - expected json value got '%7B%22...' (line 1, column 1) @timestamp:Dec 17, 2020 @ 11:46:43.192 app:the-slab level_value:40,000 buildNumber:14558 source_stream:ophan logger_name:extractors.AcquisitionExtractor$ stage:PROD stack:ophan @version:1 level:ERROR thread_name:RecordProcessor-0015 _id:3MWGcHYBX3IuK76qFZFF _type:_doc _index:logstash-ophan-2020.12.17 _score: -
```

Instead to fix the acquisitions data issue, the Ophan team will tweak their app's Play configuration: 
https://github.com/guardian/ophan/pull/3986