### PR TITLE
Quick fix for LP layout bug

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/PaymentMethodSelector.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/PaymentMethodSelector.jsx
@@ -167,17 +167,17 @@ const noPaymentMethodsErrorMessage =
   />);
 
 const radioCss = {
-  '& + div': {
+  '& + span': {
     display: 'flex',
     width: '100%',
     margin: 0,
     justifyContent: 'space-between',
   },
-  '& + div svg': {
+  '& + span svg': {
     width: '36px',
     height: '24px',
   },
-  '&:not(:checked) + div svg': {
+  '&:not(:checked) + span svg': {
     filter: 'grayscale(100%)',
   },
 };


### PR DESCRIPTION
## What are you doing in this PR?

Quick fix for a visual bug on the LP. This was caused by an update to source. The css we're using is a little hacky - it assumes knowledge of the internal structure of the `Radio` component. This css broke when source swapped out a `div` element for a `span` element. 

We should come up with a proper fix for this, but as it stands I don't think we can quite replicate the current behaviour without this hacky css. The tricky part to replicate is having the whole area between the label text and the image being clickable. That might require a change to source. In the mean time I think this quick fix will work. This is also potentially an argument for having some sort of visual regression testing (chromatic?).

## Screenshots

### current (broken)
<img width="577" alt="Screenshot 2020-12-17 at 15 01 16" src="https://user-images.githubusercontent.com/17720442/102505673-2ec85200-407a-11eb-9244-7c57b2a024fd.png">

### fixed
<img width="577" alt="Screenshot 2020-12-17 at 15 01 22" src="https://user-images.githubusercontent.com/17720442/102505679-2ff97f00-407a-11eb-9722-bd2c36530455.png">


