### PR TITLE
Temporary fix to stop the tests failing on direct debit subscription payments

### DIFF
--- a/support-frontend/assets/components/directDebit/directDebitProgressiveDisclosure/components/form.jsx
+++ b/support-frontend/assets/components/directDebit/directDebitProgressiveDisclosure/components/form.jsx
@@ -26,6 +26,15 @@ const spaceBetween = css`
   margin-bottom: 20px;
 `;
 
+// Quick & dirty fix for the <span> that overlays the checkbox for animation purposes intercepting click
+// events and thus breaking our Selenium tests
+// TODO: Remove this once a PR to Source has been made to fix this on the component itself
+const passThroughClicksToInput = css`
+  & span {
+    pointer-events: none;
+  }
+`;
+
 type EventHandler = (e: SyntheticInputEvent<HTMLInputElement>) => void;
 
 type PropTypes = {
@@ -99,7 +108,7 @@ function Form(props: PropTypes) {
         />
       </div>
 
-      <div css={spaceBetween}>
+      <div css={[spaceBetween, passThroughClicksToInput]}>
         <Checkbox
           id="account-holder-confirmation"
           onChange={e => props.onChange('accountHolderConfirmation', props.updateAccountHolderConfirmation, e)}


### PR DESCRIPTION
## What are you doing in this PR?

This stops click events aimed at the Source checkbox component used to confirm that the user can authorise a direct debit from getting intercepted by a `<span>` element that overlays the input to provide the nice ticking animation.

This is a **temporary** fix- this ought to be fixed in Source itself and I'll be raising a PR to that effect- but will stop the post-deploy tests from constantly failing.