### PR TITLE
Fix the Selenium tests for the paper landing page

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/paperSubscriptionLandingPage.jsx
@@ -50,9 +50,13 @@ const paperSubsFooter = (
 
 // ----- Render ----- //
 
+// ID for Selenium tests
+const pageQaId = 'qa-paper-subscriptions';
+
 const content = (
   <Provider store={store}>
     <Page
+      id={pageQaId}
       header={<Header countryGroupId={GBPCountries} />}
       footer={paperSubsFooter}
     >

--- a/support-frontend/test/selenium/subscriptions/pages/PaperProductPage.scala
+++ b/support-frontend/test/selenium/subscriptions/pages/PaperProductPage.scala
@@ -7,6 +7,6 @@ class PaperProductPage(implicit val webDriver: WebDriver) extends Browser with P
 
   override def path = s"/uk/subscribe/paper"
 
-  override def elementQuery = className("component-heading-block")
+  override def elementQuery = id("qa-paper-subscriptions")
 
 }


### PR DESCRIPTION
## What are you doing in this PR?

This adds an ID to the main element on the paper landing page for the tests to select, as we're now styling with Emotion and the old class name is obsolete.