### PR TITLE
Prevent double submission of Stripe payment form

### DIFF
--- a/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/stripeForm/stripeForm.jsx
@@ -263,6 +263,9 @@ const StripeForm = (props: StripeFormPropTypes) => {
     .then(() => {
       setDisableButton(false);
       props.submitForm();
+    })
+    .catch(() => {
+      setDisableButton(false);
     });
 
   const requestSCAPaymentMethod = (event) => {


### PR DESCRIPTION
## What are you doing in this PR?

On hitting the 'Pay Now' button when paying by credit card, the button will now be disabled while we retrieve the token from Stripe. The button will be re-enabled on any error, and at the point where the 'Processing' overlay is shown.

[**Trello Card**](https://trello.com/c/eMuYMAnH)

## Why are you doing this?

This fixes an issue where users were occasionally repeatedly clicking the subscribe button before the 'Processing' overlay appeared, causing errors in processing the payment.

