### PR TITLE
use DigitalPack instead of DigitalSubscription for alarm

### DIFF
--- a/support-workers/cloud-formation/src/templates/cfn-template.yaml
+++ b/support-workers/cloud-formation/src/templates/cfn-template.yaml
@@ -314,7 +314,7 @@ Resources:
 
 
   # This alarm is for the PaymentSuccess metric where
-  # ProductType == DigitalSubscription AND PaymentProvider in [Stripe, Gocardless, Paypal]
+  # ProductType == DigitalPack AND PaymentProvider in [Stripe, Gocardless, Paypal]
   #
   # The general idea here is
   # a) Have a calculated metric which is a sum of all the payment method metrics for digipack [1]
@@ -343,7 +343,7 @@ Resources:
                 - Name: PaymentProvider
                   Value: Stripe
                 - Name: ProductType
-                  Value: DigitalSubscription
+                  Value: DigitalPack
                 - Name: Stage
                   Value: !Ref Stage
               MetricName: PaymentSuccess
@@ -360,7 +360,7 @@ Resources:
                 - Name: PaymentProvider
                   Value: DirectDebit
                 - Name: ProductType
-                  Value: DigitalSubscription
+                  Value: DigitalPack
                 - Name: Stage
                   Value: !Ref Stage
               MetricName: PaymentSuccess
@@ -377,7 +377,7 @@ Resources:
                 - Name: PaymentProvider
                   Value: PayPal
                 - Name: ProductType
-                  Value: DigitalSubscription
+                  Value: DigitalPack
                 - Name: Stage
                   Value: !Ref Stage
               MetricName: PaymentSuccess


### PR DESCRIPTION
## What are you doing in this PR?

This PR reverts one of the changes in https://github.com/guardian/support-frontend/pull/2891 as we still use the old name for the metric, so the alarm also needs to do the same.


## Why are you doing this?

[New exectutions](https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/executions/details/arn:aws:states:eu-west-1:865473395570:execution:support-workers-PROD:6b38cfef-a4de-4b6c-a453-17df87503431) still use the old name 

![Uploading image.png…]()
