### PR TITLE
Fix some mapping bugs in AcquisitionDataRowMapper

### DIFF
--- a/support-modules/bigquery/src/main/scala/com/gu/support/acquisitions/AcquisitionDataRowMapper.scala
+++ b/support-modules/bigquery/src/main/scala/com/gu/support/acquisitions/AcquisitionDataRowMapper.scala
@@ -14,9 +14,9 @@ object AcquisitionDataRowMapper {
       acquisition.promoCode.map("promo_code" -> _),
       acquisition.paymentProvider.map("payment_provider" -> paymentProviderName(_)),
       acquisition.printOptions.map(p => "print_options" -> Map(
-        "product" -> p.product,
+        "product" -> p.product.value,
         "delivery_country_code" -> p.deliveryCountry.alpha2
-      )),
+      ).asJava),
       acquisition.amount.map("amount" -> _),
       acquisition.identityId.map("identity_id" -> _),
       acquisition.pageViewId.map("page_view_id" -> _),
@@ -27,6 +27,9 @@ object AcquisitionDataRowMapper {
       acquisition.componentType.map("component_type" -> _),
       acquisition.source.map("source" -> _),
       acquisition.campaignCode.map("campaign_codes" -> List(_).asJava),
+      acquisition.zuoraAccountNumber.map("zuora_account_number" -> _),
+      acquisition.zuoraSubscriptionNumber.map("zuora_subscription_number" -> _),
+      acquisition.contributionId.map("contribution_id" -> _)
     ).flatten.toMap
 
     (Map(

--- a/support-workers/src/test/scala/com/gu/acquisitions/BigQuerySpec.scala
+++ b/support-workers/src/test/scala/com/gu/acquisitions/BigQuerySpec.scala
@@ -6,7 +6,7 @@ import com.gu.config.Configuration
 import com.gu.i18n.{Country, Currency}
 import com.gu.salesforce.Salesforce.{Authentication, DeliveryContact, NewContact, SalesforceContactResponse}
 import com.gu.support.acquisitions.AcquisitionType.Purchase
-import com.gu.support.acquisitions.{AbTest, AcquisitionDataRow, AcquisitionProduct, BigQueryService, QueryParameter}
+import com.gu.support.acquisitions.{AbTest, AcquisitionDataRow, AcquisitionProduct, BigQueryService, PrintOptions, PrintProduct, QueryParameter}
 import com.gu.support.workers.{Monthly, PayPal}
 import com.gu.support.zuora.api.ReaderType.Direct
 import com.gu.test.tags.annotations.IntegrationTest
@@ -53,24 +53,25 @@ class BigQuerySpec extends AsyncFlatSpec with Matchers with LazyLogging {
 
     val dataRow = AcquisitionDataRow(
       DateTime.now(),
-      AcquisitionProduct.RecurringContribution,
+      AcquisitionProduct.Paper,
       Some(9999),
       Country.UK,
       Currency.GBP,
-      None, None, None, None, None,
+      Some("componentId"), Some("componentType"), Some("campaignCode"), Some("source"), Some("referrerUrl"),
       List(
         AbTest("test_test", "Hello"),
         AbTest("payment_method_test", "variant1")
       ),
       Monthly,
       Some(PayPal),
-      None, None,
+      Some(PrintOptions(PrintProduct.HomeDeliveryEveryday, Country.UK)),
+      Some("browserId"),
       Some("9999"),
-      None, None, Nil, None,
+      Some("pageViewId"), Some("referrerPageViewId"), List("TEST_LABEL"), Some("test_promocode"),
       reusedExistingPaymentMethod = false,
       Direct,
       Purchase,
-      None, None, None,
+      Some("subscription number"), Some("account number"), Some("contributionId"),
       List(QueryParameter("foo", "bar"))
     )
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
#2891 started sending subscription acquisition data to BigQuery, however there were a couple of mapping bugs which means that some data isn't being be saved to BigQuery correctly. This PR fixes this.