### PR TITLE
add sub number to the IT test data

### DIFF
--- a/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
@@ -673,7 +673,8 @@ object JsonFixtures {
             },
             "product": ${contribution(currency = GBP)},
             "paymentMethod": $stripePaymentMethod,
-            "accountNumber": "accountnumber123"
+            "accountNumber": "accountnumber123",
+            "subscriptionNumber": "subno123"
           },
           "acquisitionData": $acquisitionData
         }"""


### PR DESCRIPTION
## What are you doing in this PR?

This adds the sub number field to the test data for 
SendThankYouEmailITSpec
SendOldAcquisitionEventSpec


## Why are you doing this?

The IT tests are failing due to missing field that is now required in 
https://github.com/guardian/support-frontend/pull/2891
