### PR TITLE
Copy changes for 'The best of a bad year' special Edition

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/hero/hero.jsx
@@ -30,11 +30,18 @@ type PropTypes = {
 }
 
 const HeroCopy = () => (
-  <p css={paragraph}>
-    With two innovative apps and ad-free reading, a digital subscription
-    gives you the richest experience of Guardian journalism. It also sustains the independent
-    reporting you love.
-  </p>);
+  <>
+    <p css={paragraph}>
+      With two innovative apps and ad-free reading, a digital subscription
+      gives you the richest experience of Guardian journalism. It also sustains the independent
+      reporting you love.
+    </p>
+    <p css={paragraph}>
+      For a few weeks only, read <strong>The best of a bad year</strong>, a new and exclusive look at the cultural,
+      scientific, environmental and political high points that stand out from a year dominated by the pandemic.
+    </p>
+  </>
+);
 
 const HeroCopyAus = () => (
   <span>

--- a/support-frontend/assets/pages/digital-subscription-landing/components/productBlock/productBlock.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/productBlock/productBlock.jsx
@@ -167,7 +167,7 @@ class ProductBlock extends Component<PropTypes, StateTypes> {
           <div className="product-block__container__label--top">What&apos;s included?</div>
           <ProductCard
             title="UK Daily in The Guardian Editions app"
-            subtitle="+ The best of a bad year- limited time only, ending 23 January"
+            subtitle="The best of a bad year- limited time only, ending 23 January"
             image={dailyImage}
             second={false}
           />

--- a/support-frontend/assets/pages/digital-subscription-landing/components/productBlock/productBlock.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/productBlock/productBlock.jsx
@@ -167,7 +167,7 @@ class ProductBlock extends Component<PropTypes, StateTypes> {
           <div className="product-block__container__label--top">What&apos;s included?</div>
           <ProductCard
             title="UK Daily in The Guardian Editions app"
-            subtitle="Each day's edition, in one simple, elegant app"
+            subtitle="+ The best of a bad year- limited time only, ending 23 January"
             image={dailyImage}
             second={false}
           />


### PR DESCRIPTION
## What are you doing in this PR?

This adds in special copy on the non-Aus digital subscriptions landing page referring to the end of year special edition.

[**Trello Card**](https://trello.com/c/EzXWkvR0)

## Screenshots

![Screenshot 2020-12-22 at 12 34 54](https://user-images.githubusercontent.com/29146931/102890191-f1860a80-4453-11eb-8ae7-c289d2489ef6.png)
![Screenshot 2020-12-22 at 12 35 06](https://user-images.githubusercontent.com/29146931/102890195-f3e86480-4453-11eb-8ad0-fe36792c7df9.png)
