### PR TITLE
Add post-deployment tests for digital subscription gifting

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.jsx
@@ -22,7 +22,7 @@ import CheckoutStage from 'components/subscriptionCheckouts/stage';
 import './digitalSubscriptionCheckout.scss';
 import { getQueryParameter } from 'helpers/url';
 import type { DigitalBillingPeriod, DigitalGiftBillingPeriod } from 'helpers/billingPeriods';
-import { Monthly } from 'helpers/billingPeriods';
+import { Monthly, Annual, Quarterly } from 'helpers/billingPeriods';
 import { createCheckoutReducer } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
 import type { CommonState } from 'helpers/page/commonReducer';
 import { DigitalPack } from 'helpers/subscriptions';
@@ -31,10 +31,26 @@ import MarketingConsent from 'components/subscriptionCheckouts/thankYou/marketin
 import MarketingConsentGift from 'components/subscriptionCheckouts/thankYou/marketingConsentContainerGift';
 
 // ----- Redux Store ----- //
+
+function getInitialBillingPeriod(periodInUrl?: string): DigitalBillingPeriod | DigitalGiftBillingPeriod {
+  const { orderIsAGift } = window.guardian;
+  switch (periodInUrl) {
+    case 'Monthly':
+      return Monthly;
+    case 'Quarterly':
+      return Quarterly;
+    case 'Annual':
+      return Annual;
+    default:
+      if (orderIsAGift) {
+        return Quarterly;
+      }
+      return Monthly;
+  }
+}
+
 const billingPeriodInUrl = getQueryParameter('period');
-const initialBillingPeriod: DigitalBillingPeriod | DigitalGiftBillingPeriod = billingPeriodInUrl === 'Monthly' || billingPeriodInUrl === 'Annual' || billingPeriodInUrl === 'Quarterly'
-  ? billingPeriodInUrl
-  : Monthly;
+const initialBillingPeriod = getInitialBillingPeriod(billingPeriodInUrl || '');
 
 const reducer = (commonState: CommonState) => createCheckoutReducer(
   commonState.internationalisation.countryId,

--- a/support-frontend/test/selenium/subscriptions/CheckoutsSpec.scala
+++ b/support-frontend/test/selenium/subscriptions/CheckoutsSpec.scala
@@ -40,7 +40,7 @@ class CheckoutsSpec extends AnyFeatureSpec
   }
 
   Feature("Digital Pack gift checkout") {
-    Scenario("User already logged in - DirectDebit checkout") {
+    Scenario("User already logged in - Direct Debit checkout") {
       testCheckout("Digital Pack gift", new DigitalPackGiftCheckout, new DigitalPackGiftProductPage, payWithDirectDebit)
     }
   }

--- a/support-frontend/test/selenium/subscriptions/CheckoutsSpec.scala
+++ b/support-frontend/test/selenium/subscriptions/CheckoutsSpec.scala
@@ -39,6 +39,12 @@ class CheckoutsSpec extends AnyFeatureSpec
     }
   }
 
+  Feature("Digital Pack gift checkout") {
+    Scenario("User already logged in - DirectDebit checkout") {
+      testCheckout("Digital Pack gift", new DigitalPackGiftCheckout, new DigitalPackGiftProductPage, payWithDirectDebit)
+    }
+  }
+
   Feature("Paper checkout") {
     Scenario("User already logged in - Direct Debit checkout") {
       testCheckout("Paper", new PaperCheckout, new PaperProductPage, payWithDirectDebit)

--- a/support-frontend/test/selenium/subscriptions/ProductPagesSpec.scala
+++ b/support-frontend/test/selenium/subscriptions/ProductPagesSpec.scala
@@ -59,6 +59,12 @@ class ProductPagesSpec extends AnyFeatureSpec
     }
   }
 
+  Feature("Digital Pack gift product page") {
+    Scenario("Basic loading") {
+      testPageLoads(new DigitalPackGiftProductPage())
+    }
+  }
+
 
   def testPageLoads(page: ProductPage): Unit ={
     Given("that a user goes to the page")

--- a/support-frontend/test/selenium/subscriptions/pages/DigitalPackGiftCheckout.scala
+++ b/support-frontend/test/selenium/subscriptions/pages/DigitalPackGiftCheckout.scala
@@ -4,7 +4,7 @@ import org.openqa.selenium.WebDriver
 import selenium.util.Config
 
 class DigitalPackGiftCheckout(implicit val webDriver: WebDriver) extends CheckoutPage {
-  val url = s"${Config.supportFrontendUrl}/subscribe/digital/checkout/gift?period=Quarterly"
+  val url = s"${Config.supportFrontendUrl}/subscribe/digital/checkout/gift"
 
   private val giftRecipientFirstName = id("firstNameGiftRecipient")
   private val giftRecipientLastName = id("lastNameGiftRecipient")

--- a/support-frontend/test/selenium/subscriptions/pages/DigitalPackGiftCheckout.scala
+++ b/support-frontend/test/selenium/subscriptions/pages/DigitalPackGiftCheckout.scala
@@ -1,0 +1,25 @@
+package selenium.subscriptions.pages
+
+import org.openqa.selenium.WebDriver
+import selenium.util.Config
+
+class DigitalPackGiftCheckout(implicit val webDriver: WebDriver) extends CheckoutPage {
+  val url = s"${Config.supportFrontendUrl}/subscribe/digital/checkout/gift?period=Quarterly"
+
+  private val giftRecipientFirstName = id("firstNameGiftRecipient")
+  private val giftRecipientLastName = id("lastNameGiftRecipient")
+  private val giftRecipientEmail = id("emailGiftRecipient")
+
+  private val addressLineOne = id("billing-lineOne")
+  private val city = id("billing-city")
+  private val postcode = id("billing-postcode")
+
+  def fillForm(): Unit = {
+    setValue(giftRecipientFirstName, "CP")
+    setValue(giftRecipientLastName, "Scott")
+    setValue(giftRecipientEmail, "cp.scott@gu.com")
+    setValue(addressLineOne, "Kings Place")
+    setValue(city, "London")
+    setValue(postcode, "N19GU")
+  }
+}

--- a/support-frontend/test/selenium/subscriptions/pages/DigitalPackGiftProductPage.scala
+++ b/support-frontend/test/selenium/subscriptions/pages/DigitalPackGiftProductPage.scala
@@ -1,0 +1,13 @@
+package selenium.subscriptions.pages
+
+import org.openqa.selenium.WebDriver
+import org.scalatestplus.selenium.Page
+import selenium.util.Browser
+
+class DigitalPackGiftProductPage(implicit val webDriver: WebDriver) extends Page with Browser with ProductPage {
+
+  override def path = "/uk/subscribe/digital/gift"
+
+  override def elementQuery = id("qa-component-customer-service")
+
+}


### PR DESCRIPTION
## What are you doing in this PR?

This adds post-deployment Selenium tests for the digital subscription gift landing page and checkout. It also updates the way we determine the billing period in the digital subs checkout in order to enable the tests to run without being dependent on a query string in the URL.

[**Trello Card**](https://trello.com/c/GbmnFfY0)