### PR TITLE
Fix payment-api switches permission

### DIFF
--- a/support-payment-api/src/main/resources/cloud-formation.yaml
+++ b/support-payment-api/src/main/resources/cloud-formation.yaml
@@ -260,7 +260,11 @@ Resources:
               - Effect: Allow
                 Action: s3:GetObject
                 Resource:
-                  - !Sub arn:aws:s3:::support-admin-console/${Stage}/*
+                  - !If [CreateProdResources,
+                     # PROD needs both stages for test mode
+                    !Sub arn:aws:s3:::support-admin-console/*/*,
+                    !Sub arn:aws:s3:::support-admin-console/CODE/*
+                  ]
 
 
 


### PR DESCRIPTION
We're getting a lot of ERROR logs for payment-api:
`Error udpating cache for recaptchaSwitch:. com.amazonaws.services.s3.model.AmazonS3Exception: Access Denied`
This particular error isn't actually causing any problems, but we shouldn't have ERRORs!

This is because the cloudformation grants permission to s3 objects under `/support-admin-console/PROD/*`, but PROD actually requires the CODE object as well.