### PR TITLE
use default heap size for JVM

### DIFF
--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -83,9 +83,7 @@ riffRaffArtifactResources ++= getFiles(file("support-frontend/storybook-static")
 
 javaOptions in Universal ++= Seq(
   "-Dpidfile.path=/dev/null",
-  "-J-XX:MaxRAMFraction=2",
-  "-J-XX:InitialRAMFraction=2",
-  "-J-XX:MaxMetaspaceSize=500m",
+  "-J-XX:MaxMetaspaceSize=256m",
   "-J-XX:+PrintGCDetails",
   "-J-XX:+PrintGCDateStamps",
   s"-J-Xloggc:/var/log/${packageName.value}/gc.log"


### PR DESCRIPTION
## What are you doing in this PR?

Change the default heap size to the default (1/4 of physical memory) to free up more space for non heap.

https://trello.com/c/Zmb4UJdM/3553-investigate-out-of-memory-errors-on-support-frontend-instances

## Why are you doing this?

The support-frontend instances are kiling their JVMs after around 5 days due to the JVM process becoming too big for physical memory.
It looks like the heap size is 1gb and the t3.small have 2gb memory.  After 20 hours or so the process is using about 50% of memory, 
```
  PID USER      PR  NI    VIRT    RES    SHR S  %CPU %MEM     TIME+ COMMAND                                                                                                                              
 7746 support+  20   0 3717404 1.022g  19040 S   0.7 53.3  19:10.91 java
```
but after 5 days it is up to around 80%
```
  PID USER      PR  NI    VIRT    RES    SHR S  %CPU %MEM     TIME+ COMMAND                                                                                                                                              
 1655 support+  20   0 3855584 1.512g      0 S   2.1 78.9 137:13.82 java    
```
 before being killed.
```
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848723] C1 CompilerThre invoked oom-killer: gfp_mask=0x24201ca, order=0, oom_score_adj=0
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848726] C1 CompilerThre cpuset=/ mems_allowed=0
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848732] CPU: 0 PID: 1756 Comm: C1 CompilerThre Not tainted 4.4.0-1118-aws #132-Ubuntu
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848733] Hardware name: Amazon EC2 t3.small/, BIOS 1.0 10/16/2017
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848735]  0000000000000286 1bad5d57b4433231 ffff8800797a39c0 ffffffff8140b03b
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848738]  ffff8800797a3b78 ffff8800785c1540 ffff8800797a3a30 ffffffff81216ff7
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848740]  0000000000000000 ffff880079a903c0 ffff880036965500 ffff8800797a3a18
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848742] Call Trace:
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848750]  [<ffffffff8140b03b>] dump_stack+0x6d/0x92
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848755]  [<ffffffff81216ff7>] dump_header+0x5a/0x1c3
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848759]  [<ffffffff813a2961>] ? apparmor_capable+0x131/0x1b0
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848763]  [<ffffffff8119b3db>] oom_kill_process+0x20b/0x3d0
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848765]  [<ffffffff8119b7e8>] out_of_memory+0x1f8/0x470
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848768]  [<ffffffff811a1b13>] __alloc_pages_slowpath.constprop.89+0x943/0xaf0
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848770]  [<ffffffff811a1f5f>] __alloc_pages_nodemask+0x29f/0x2b0
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848774]  [<ffffffff811ed3fc>] alloc_pages_current+0x8c/0x110
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848776]  [<ffffffff811974fb>] __page_cache_alloc+0xab/0xc0
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848779]  [<ffffffff81199e40>] filemap_fault+0x160/0x440
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848782]  [<ffffffff812b0ad6>] ext4_filemap_fault+0x36/0x50
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848785]  [<ffffffff811c7877>] __do_fault+0x77/0x110
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848788]  [<ffffffff811cb819>] handle_mm_fault+0x1259/0x1b80
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848792]  [<ffffffff818423b1>] ? __schedule+0x301/0x810
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848794]  [<ffffffff818423b1>] ? __schedule+0x301/0x810
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848798]  [<ffffffff8106de84>] __do_page_fault+0x1a4/0x410
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848800]  [<ffffffff8106e157>] trace_do_page_fault+0x37/0xe0
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848804]  [<ffffffff810660d9>] do_async_page_fault+0x19/0x70
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848807]  [<ffffffff81849ea8>] async_page_fault+0x28/0x30
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848808] Mem-Info:
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848812] active_anon:464463 inactive_anon:5684 isolated_anon:0
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848812]  active_file:108 inactive_file:190 isolated_file:0
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848812]  unevictable:913 dirty:0 writeback:0 unstable:0
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848812]  slab_reclaimable:3484 slab_unreclaimable:4527
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848812]  mapped:879 shmem:5841 pagetables:1754 bounce:0
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848812]  free:13150 free_pcp:133 free_cma:0
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848822] Node 0 DMA free:8048kB min:356kB low:444kB high:532kB active_anon:7424kB inactive_anon:0kB active_file:0kB inactive_file:24kB unevictable:96kB isolated(anon):0kB isolated(file):0kB present:15992kB managed:15904kB mlocked:96kB dirty:0kB writeback:0kB mapped:0kB shmem:4kB slab_reclaimable:40kB slab_unreclaimable:72kB kernel_stack:0kB pagetables:36kB unstable:0kB bounce:0kB free_pcp:0kB local_pcp:0kB free_cma:0kB writeback_tmp:0kB pages_scanned:284 all_unreclaimable? yes
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848828] lowmem_reserve[]: 0 1931 1931 1931 1931
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848831] Node 0 DMA32 free:44552kB min:44696kB low:55868kB high:67044kB active_anon:1850428kB inactive_anon:22736kB active_file:432kB inactive_file:736kB unevictable:3556kB isolated(anon):0kB isolated(file):0kB present:2041832kB managed:1993504kB mlocked:3556kB dirty:0kB writeback:0kB mapped:3516kB shmem:23360kB slab_reclaimable:13896kB slab_unreclaimable:18036kB kernel_stack:4432kB pagetables:6980kB unstable:0kB bounce:0kB free_pcp:532kB local_pcp:344kB free_cma:0kB writeback_tmp:0kB pages_scanned:8828 all_unreclaimable? yes
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848836] lowmem_reserve[]: 0 0 0 0 0
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848839] Node 0 DMA: 6*4kB (UE) 9*8kB (UME) 7*16kB (UME) 5*32kB (UE) 4*64kB (UME) 2*128kB (U) 2*256kB (UE) 3*512kB (UME) 1*1024kB (E) 2*2048kB (ME) 0*4096kB = 8048kB
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848850] Node 0 DMA32: 1396*4kB (UE) 677*8kB (UE) 497*16kB (UME) 348*32kB (UME) 174*64kB (UME) 26*128kB (UME) 0*256kB 0*512kB 0*1024kB 0*2048kB 0*4096kB = 44552kB
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848859] Node 0 hugepages_total=0 hugepages_free=0 hugepages_surp=0 hugepages_size=1048576kB
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848861] Node 0 hugepages_total=0 hugepages_free=0 hugepages_surp=0 hugepages_size=2048kB
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848862] 6779 total pagecache pages
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848863] 0 pages in swap cache
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848865] Swap cache stats: add 0, delete 0, find 0/0
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848866] Free swap  = 0kB
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848867] Total swap = 0kB
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848868] 514456 pages RAM
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848869] 0 pages HighMem/MovableOnly
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848869] 12104 pages reserved
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848870] 0 pages cma reserved
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848871] 0 pages hwpoisoned
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848872] [ pid ]   uid  tgid total_vm      rss nr_ptes nr_pmds swapents oom_score_adj name
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848879] [  409]     0   409     9547     1228      21       3        0             0 systemd-journal
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848881] [  423]     0   423    23692      144      16       3        0             0 lvmetad
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848884] [  461]     0   461    10722      379      21       3        0         -1000 systemd-udevd
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848886] [  875]     0   875     4030      534      11       3        0             0 dhclient
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848888] [ 1125]     0  1125    68941      569      37       4        0             0 accounts-daemon
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848891] [ 1128]   107  1128    10721      466      24       3        0          -900 dbus-daemon
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848893] [ 1132]     0  1132     1304       29       8       3        0             0 iscsid
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848895] [ 1133]     0  1133     1429      880       8       3        0           -17 iscsid
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848897] [ 1138]     0  1138     5024      251      14       3        0             0 systemd-logind
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848899] [ 1140]     0  1140     6510      411      19       3        0             0 atd
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848901] [ 1155]   104  1155    65156      303      29       3        0             0 rsyslogd
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848903] [ 1165]     0  1165     1098      318       8       3        0             0 acpid
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848905] [ 1167]     0  1167   151044      455      28       4        0             0 lxcfs
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848907] [ 1192]     0  1192     7251      496      18       3        0             0 cron
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848910] [ 1201]     0  1201    69294      243      40       3        0             0 polkitd
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848912] [ 1217]     0  1217    16377      420      36       3        0         -1000 sshd
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848914] [ 1226]     0  1226    43657     2436      53       3        0             0 unattended-upgr
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848916] [ 1241]     0  1241     3342       62      11       3        0             0 mdadm
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848918] [ 1310]     0  1310   140375     2212      81       3        0             0 awsagent
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848920] [ 1317]   112  1317    26446      257      23       4        0             0 chronyd
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848922] [ 1319]     0  1319     3937      406      13       3        0             0 agetty
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848925] [ 1333]     0  1333     3983      320      13       3        0             0 agetty
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848927] [ 1334]     0  1334     4867      274      13       3        0             0 irqbalance
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848929] [ 1659]   999  1659   966635   405460     916       8        0             0 java
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848931] [ 1760]     0  1760   121179     4541      48       6        0          -900 snapd
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848933] [ 1824]     0  1824     1125      177       8       3        0             0 awslogs-agent-l
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848935] [ 1830]     0  1830   104772    16192      74       3        0             0 aws
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848937] [ 2152]     0  2152    83710     2191      36       4        0             0 amazon-ssm-agen
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848939] [ 2198]     0  2198   122984     4847      48       4        0             0 ssm-agent-worke
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848941] [ 7464]     0  7464    25736    22606      55       4        0          -900 ld-2.23.so
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.848943] Out of memory: Kill process 1659 (java) score 808 or sacrifice child
Jan  5 21:40:44 ip-10-248-133-125 kernel: [454833.851620] Killed process 1659 (java) total-vm:3866540kB, anon-rss:1621840kB, file-rss:0kB
Jan  5 21:40:44 ip-10-248-133-125 systemd[1]: support-frontend.service: Main process exited, code=killed, status=9/KILL
Jan  5 21:40:44 ip-10-248-133-125 systemd[1]: support-frontend.service: Unit entered failed state.
Jan  5 21:40:44 ip-10-248-133-125 systemd[1]: support-frontend.service: Failed with result 'signal'.
.........
Jan  5 21:41:44 ip-10-248-133-125 systemd[1]: support-frontend.service: Service hold-off time over, scheduling restart.
Jan  5 21:41:44 ip-10-248-133-125 systemd[1]: Stopped Support Frontend Play App.
Jan  5 21:41:44 ip-10-248-133-125 systemd[1]: Starting Support Frontend Play App...
Jan  5 21:41:44 ip-10-248-133-125 systemd[1]: Started Support Frontend Play App.
```

  This causes some 5xx errors and also causes an unscheduled fresh instance.  If there is an issue starting new instances or a broken deploy, this could break things very quickly as has happened in the past with membership-frontend.
It looks like the metaspace is about 100MB and it is not clear where the rest of the memory has gone.  It could be stack space or native memory e.g. we are not closing our input streams or sockets correctly.

However after investigation we hardly need any heap space, it seems a full GC only happens after many hours, and the residual abmount left is only about 70MB.  So we can easily drop the heap size to 512MB (the default 25% of memory) 

`2021-01-01T01:11:47.233+0000: 35478.114: [Full GC (Ergonomics) [PSYoungGen: 9722K->0K(54272K)] [ParOldGen: 670125K->68860K(670720K)] 679848K->68860K(724992K), [Metaspace: 123606K->123524K(1167360K)], 0.3532964 secs] [Times: user=0.51 sys=0.01, real=0.35 secs] `

This should cause a shorter time between full GC, but there would be a lot more memory outside the heap.

This will also give plenty of space for MaxDirectMemorySize which is the same as the heap size, meaning that we might see an OOM exception rather than a killed process if that is the issue.  Perhaps this is why the default is 25% of memory for the heap and 25% for the direct memory.

I think in the end this fix is likely to be a slowing down of seeing the issue, and there may be a longer time before things die.  But I think it is low risk on its own as we really don't need much memory for the instances heap.  Hopefully if things do go wrong in the JVM rather than in the OS, we will see proper error explaining what was exhausted.

If there are still problems and we want to understand where the memory is building up outside of the heap, we would need to start the JVM with `-XX:NativeMemoryTracking=[summary | detail]` which will cause a slight performance decrease but should shed more light on it https://docs.oracle.com/javase/8/docs/technotes/guides/troubleshoot/tooldescr007.html