### PR TITLE
Enable onlyShowFocusOnTabs on subscription checkout

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/digitalSubscriptionCheckout.jsx
@@ -29,6 +29,7 @@ import { DigitalPack } from 'helpers/subscriptions';
 import HeaderWrapper from 'components/subscriptionCheckouts/headerWrapper';
 import MarketingConsent from 'components/subscriptionCheckouts/thankYou/marketingConsentContainer';
 import MarketingConsentGift from 'components/subscriptionCheckouts/thankYou/marketingConsentContainerGift';
+import { FocusStyleManager } from '@guardian/src-utilities';
 
 // ----- Redux Store ----- //
 const billingPeriodInUrl = getQueryParameter('period');
@@ -53,6 +54,8 @@ const thankyouProps = {
   countryGroupId,
   marketingConsent: (orderIsAGift ? <MarketingConsentGift /> : <MarketingConsent />),
 };
+
+FocusStyleManager.onlyShowFocusOnTabs();
 
 // ----- Render ----- //
 

--- a/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckout.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckout.jsx
@@ -26,6 +26,7 @@ import type { CommonState } from 'helpers/page/commonReducer';
 import { Monthly } from 'helpers/billingPeriods';
 import { Paper } from 'helpers/subscriptions';
 import HeaderWrapper from 'components/subscriptionCheckouts/headerWrapper';
+import { FocusStyleManager } from '@guardian/src-utilities';
 
 // ----- Redux Store ----- //
 
@@ -48,6 +49,8 @@ const store = pageInit(
 );
 
 const { useDigitalVoucher } = store.getState().common.settings;
+
+FocusStyleManager.onlyShowFocusOnTabs();
 
 // ----- Render ----- //
 

--- a/support-frontend/assets/pages/weekly-subscription-checkout/weeklySubscriptionCheckout.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/weeklySubscriptionCheckout.jsx
@@ -30,6 +30,7 @@ import {
 import { getAppliedPromo } from 'helpers/productPrice/promotions';
 import { formatMachineDate } from 'helpers/dateConversions';
 import { promotionTermsUrl } from 'helpers/routes';
+import { FocusStyleManager } from '@guardian/src-utilities';
 
 import HeaderWrapper from 'components/subscriptionCheckouts/headerWrapper';
 
@@ -64,6 +65,8 @@ const productPrice = getProductPrice(productPrices, countryId, billingPeriod, fu
 const appliedPromo = getAppliedPromo(productPrice.promotions);
 const defaultPromo = orderIsAGift ? 'GW20GIFT1Y' : '10ANNUAL';
 const promoTermsLink = promotionTermsUrl(appliedPromo ? appliedPromo.promoCode : defaultPromo);
+
+FocusStyleManager.onlyShowFocusOnTabs();
 
 // ----- Render ----- //
 


### PR DESCRIPTION
## What are you doing in this PR?

- Disable Source's Focus Manager on subscription checkout page


[**Trello Card**](https://trello.com)

## Why are you doing this?

In Source, there is a blue "halo" around interactive components. This is intended for when users tab into, for instance, a text input field. However, by default clicking on an interactive element also triggers the focus state, applying focus styles inappropriately.

By running [`FocusStyleManager.onlyShowFocusOnTabs()`](https://www.theguardian.design/2a1e5182b/p/6691bb-accessibility/t/32e9fb), we can ensure the focus state only applies when the user presses the tab key, not when they click on the element.

A similar change was made to the contributions landing page in #2384

**Note:** I haven't tested this locally as I don't have the right Janus credentials 😖 

## Accessibility test checklist
 - [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
 - [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
 - [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

## Screenshots

![2021-01-08 11 55 24](https://user-images.githubusercontent.com/5931528/104012852-712c0d00-51a8-11eb-9919-fcf1084b2016.gif)
