### PR TITLE
return list of interesting cookies for diagnostics purposes

### DIFF
--- a/support-frontend/app/controllers/DiagnosticsController.scala
+++ b/support-frontend/app/controllers/DiagnosticsController.scala
@@ -1,0 +1,39 @@
+package controllers
+
+import actions.CustomActionBuilders
+import play.api.mvc._
+import Results.Ok
+
+class DiagnosticsController(
+  actionRefiners: CustomActionBuilders,
+) {
+
+  val relevantCookies = List(
+    "gu_user_features_expiry",
+    "gu_paying_member",
+    "GU_AF1",
+    "gu_action_required_for",
+    "gu_digital_subscriber",
+    "gu_hide_support_messaging",
+    "gu_recurring_contributor",
+    "gu_one_off_contribution_date",
+    "gu.contributions.recurring.contrib-timestamp.Monthly",
+    "gu.contributions.recurring.contrib-timestamp.Annual",
+    "gu.contributions.contrib-timestamp",
+    "gu_article_count_opt_out",
+    "gu_contributions_reminder_signed_up",
+  )
+
+  import actionRefiners._
+  def cookies(): Action[AnyContent] = NoCacheAction() { request =>
+    val cookies = request.cookies.filter { cookie =>
+      relevantCookies.contains(cookie.name)
+    }
+    Ok(cookies.map { cookie =>
+      "* " + cookie.name + "\n" +
+        " ( domain: " + cookie.domain + ", httpOnly: " + cookie.httpOnly + ", path: " + cookie.path + ", maxAge: " + cookie.maxAge + ", sameSite: " + cookie.sameSite + ", secure: " + cookie.secure + " )\n" +
+        " = " + cookie.value
+    }.mkString("\n\n"))
+  }
+
+}

--- a/support-frontend/app/controllers/DiagnosticsController.scala
+++ b/support-frontend/app/controllers/DiagnosticsController.scala
@@ -5,7 +5,7 @@ import play.api.mvc._
 import Results.Ok
 
 class DiagnosticsController(
-  actionRefiners: CustomActionBuilders,
+  actionRefiners: CustomActionBuilders
 ) {
 
   val relevantCookies = List(
@@ -21,7 +21,7 @@ class DiagnosticsController(
     "gu.contributions.recurring.contrib-timestamp.Annual",
     "gu.contributions.contrib-timestamp",
     "gu_article_count_opt_out",
-    "gu_contributions_reminder_signed_up",
+    "gu_contributions_reminder_signed_up"
   )
 
   import actionRefiners._
@@ -31,7 +31,8 @@ class DiagnosticsController(
     }
     Ok(cookies.map { cookie =>
       "* " + cookie.name + "\n" +
-        " ( domain: " + cookie.domain + ", httpOnly: " + cookie.httpOnly + ", path: " + cookie.path + ", maxAge: " + cookie.maxAge + ", sameSite: " + cookie.sameSite + ", secure: " + cookie.secure + " )\n" +
+        " ( domain: " + cookie.domain + ", httpOnly: " + cookie.httpOnly + ", path: " + cookie.path + ", maxAge: " + cookie.maxAge + ", sameSite: " +
+        cookie.sameSite + ", secure: " + cookie.secure + " )\n" +
         " = " + cookie.value
     }.mkString("\n\n"))
   }

--- a/support-frontend/app/wiring/AppComponents.scala
+++ b/support-frontend/app/wiring/AppComponents.scala
@@ -47,6 +47,7 @@ trait AppComponents extends PlayComponents
     httpErrorHandler,
     applicationController,
     errorController,
+    diagnosticsController,
     siteMapController,
     articleShareController,
     regularContributionsController,

--- a/support-frontend/app/wiring/Controllers.scala
+++ b/support-frontend/app/wiring/Controllers.scala
@@ -39,6 +39,10 @@ trait Controllers {
     fontLoader
   )
 
+  lazy val diagnosticsController = new DiagnosticsController(
+    actionRefiners
+  )
+
   lazy val articleShareController = new ArticleShare(
     actionRefiners,
     controllerComponents,

--- a/support-frontend/conf/routes
+++ b/support-frontend/conf/routes
@@ -2,6 +2,7 @@
 
 GET /healthcheck                                                   controllers.Application.healthcheck
 GET /error500                                                      lib.ErrorController.error500
+GET /cookies                                                       controllers.DiagnosticsController.cookies
 
 # ----- Unsupported Browsers ----- #
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This PR adds a diagnostics endpoint to return several useful cookies in the response.  The user can then forward to us for debugging reasons.
We do have to be careful, as we are turning cookies from the server side into a response, so we don't want to make anything accsible via XSS or other JS that wouldn't otherwise be.  Therefore I have hard coded a list of allowed cookies which should not contain anything sensisive.  For example, it would be a very bad idea to return all cookies, because that would include the SC_GU_U identity log in cookie in the list allowing someone to impersonate the user if they got hold of it.

## Why are you doing this?

There seem to be a lot of strange issues with ad free and support asks.  Members data api generally seems to be ok, so there may be some client side issue or cookies issue.
This will give us more visibility of the cookies so we can help users a bit more.
They can send the output to userhelp and we can have a look from our end.

## Screenshots
```
* gu.contributions.recurring.contrib-timestamp.Monthly
 ( domain: None, httpOnly: true, path: /, maxAge: None, sameSite: None, secure: false )
 = 1607002648056
```
