### PR TITLE
improve the /cookies diagnostics page

### DIFF
--- a/support-frontend/app/controllers/DiagnosticsController.scala
+++ b/support-frontend/app/controllers/DiagnosticsController.scala
@@ -29,12 +29,16 @@ class DiagnosticsController(
     val cookies = request.cookies.filter { cookie =>
       relevantCookies.contains(cookie.name)
     }
-    Ok(cookies.map { cookie =>
-      "* " + cookie.name + "\n" +
-        " ( domain: " + cookie.domain + ", httpOnly: " + cookie.httpOnly + ", path: " + cookie.path + ", maxAge: " + cookie.maxAge + ", sameSite: " +
-        cookie.sameSite + ", secure: " + cookie.secure + " )\n" +
-        " = " + cookie.value
-    }.mkString("\n\n"))
+    val humanReadableCookies =
+      "Please make sure you are logged in and have visited https://www.theguardian.com and seen the issue, immediately before sending the information from this page" ::
+        s"you have ${cookies.size} cookie(s)." ::
+        cookies.map { cookie =>
+          "* " + cookie.name + "\n" +
+            " ( domain: " + cookie.domain + ", httpOnly: " + cookie.httpOnly + ", path: " + cookie.path + ", maxAge: " + cookie.maxAge + ", sameSite: " +
+            cookie.sameSite + ", secure: " + cookie.secure + " )\n" +
+            " = " + cookie.value
+        }.toList
+    Ok(humanReadableCookies.mkString("\n\n"))
   }
 
 }

--- a/support-frontend/app/controllers/DiagnosticsController.scala
+++ b/support-frontend/app/controllers/DiagnosticsController.scala
@@ -30,7 +30,8 @@ class DiagnosticsController(
       relevantCookies.contains(cookie.name)
     }
     val humanReadableCookies =
-      "Please make sure you are logged in and have visited https://www.theguardian.com and seen the issue, immediately before sending the information from this page" ::
+      "Please make sure you are logged in and have visited https://www.theguardian.com and seen the issue," +
+        " immediately before sending the information from this page" ::
         s"you have ${cookies.size} cookie(s)." ::
         cookies.map { cookie =>
           "* " + cookie.name + "\n" +


### PR DESCRIPTION
## What are you doing in this PR?

add a zero cookies screen for when there are no cookies, to make it not a blank page!

Also added some other useful info
![image](https://user-images.githubusercontent.com/7304387/104306782-47375b00-54c6-11eb-80d1-c31f40066a65.png)

