### PR TITLE
throw an exception if the IT test metrics don't succeed

### DIFF
--- a/support-lambdas/it-test-runner/src/main/scala/com/gu/RunITTests.scala
+++ b/support-lambdas/it-test-runner/src/main/scala/com/gu/RunITTests.scala
@@ -83,13 +83,13 @@ class ITTestReporter extends Reporter {
     event match {
       case _: TestFailed =>
         log(s"TEST FAILED - sending metric: $event")
-        putMetric(MetricName("it-test-failed"), 1.0)
+        putMetric(MetricName("it-test-failed"), 1.0).get
       case _: RunAborted =>
         log(s"RUN ABORTED - sending metric: $event")
-        putMetric(MetricName("it-test-failed"), 999999.0)
+        putMetric(MetricName("it-test-failed"), 999999.0).get
       case runCompleted: RunCompleted =>
         log(s"RUN COMPLETED - sending metric: $event")
-        putMetric(MetricName("it-test-succeeded"), runCompleted.summary.map(_.testsSucceededCount.toDouble).getOrElse(0.0))
+        putMetric(MetricName("it-test-succeeded"), runCompleted.summary.map(_.testsSucceededCount.toDouble).getOrElse(0.0)).get
       case _ =>
         log(s"event: $event")
     }


### PR DESCRIPTION
## What are you doing in this PR?

This will make the put metric request throw an exception if the metric isn't sent.


## Why are you doing this?

There seems to be an issue where metrics for the IT tests are not always getting sent.  This means we get alarms going off, but reading the logs, the tests all ran as they should.

I noticed in the code, if the put metric call throws an exception, this will be ignored.
