### PR TITLE
add a short delay before trying to pay with DD

### DIFF
--- a/support-frontend/test/selenium/subscriptions/CheckoutsSpec.scala
+++ b/support-frontend/test/selenium/subscriptions/CheckoutsSpec.scala
@@ -115,14 +115,16 @@ class CheckoutsSpec extends AnyFeatureSpec
     Given("they fill in the direct debit form")
     checkoutPage.fillDirectDebitForm()
 
-    When("they click to process payment")
-    checkoutPage.clickDirectDebitSubmit()
+    When("they click Confirm")
+    checkoutPage.clickDirectDebitConfirm()
 
     Given("the playback of the user's details has loaded")
     assert(checkoutPage.directDebitPlaybackHasLoaded)
 
-    When("they click to confirm their details are correct")
-    checkoutPage.clickDirectDebitConfirm()
+    Thread.sleep(1000) // for some reason in travis we need this sleep otherwise it doesn't click the pay button
+
+    When("they click Pay")
+    checkoutPage.clickDirectDebitPay()
 
     thankYouPage(checkoutPage)
   }

--- a/support-frontend/test/selenium/subscriptions/pages/CheckoutPage.scala
+++ b/support-frontend/test/selenium/subscriptions/pages/CheckoutPage.scala
@@ -77,9 +77,9 @@ trait CheckoutPage extends Page with Browser {
 
   def clickStripeSubmit(): Unit = clickOn(stripeSubmitButton)
 
-  def clickDirectDebitSubmit(): Unit = clickOn(directDebitSubmitButton)
+  def clickDirectDebitConfirm(): Unit = clickOn(directDebitSubmitButton)
 
-  def clickDirectDebitConfirm(): Unit = clickOn(directDebitPlaybackSubmit)
+  def clickDirectDebitPay(): Unit = clickOn(directDebitPlaybackSubmit)
 
   def fillForm(): Unit
 }


### PR DESCRIPTION
## What are you doing in this PR?

This adds a short sleep to DD checkouts to make sure the button really is available.

https://trello.com/c/GHM1Ib1W/3570-fix-selenium-tests

## Why are you doing this?

WE  are not sure why this is failing in the automated run but not locally.  It is thinking it clicked the button but it doesn't actually seem to click it.  Perhaps there's a race condition there.
