### PR TITLE
Use CC checkout instead of DD for DS gift post deploy test

### DIFF
--- a/support-frontend/test/selenium/subscriptions/CheckoutsSpec.scala
+++ b/support-frontend/test/selenium/subscriptions/CheckoutsSpec.scala
@@ -41,7 +41,7 @@ class CheckoutsSpec extends AnyFeatureSpec
 
   Feature("Digital Pack gift checkout") {
     Scenario("User already logged in - Direct Debit checkout") {
-      testCheckout("Digital Pack gift", new DigitalPackGiftCheckout, new DigitalPackGiftProductPage, payWithDirectDebit)
+      testCheckout("Digital Pack gift", new DigitalPackGiftCheckout, new DigitalPackGiftProductPage, payWithStripe)
     }
   }
 
@@ -120,8 +120,6 @@ class CheckoutsSpec extends AnyFeatureSpec
 
     Given("the playback of the user's details has loaded")
     assert(checkoutPage.directDebitPlaybackHasLoaded)
-
-    Thread.sleep(1000) // for some reason in travis we need this sleep otherwise it doesn't click the pay button
 
     When("they click Pay")
     checkoutPage.clickDirectDebitPay()


### PR DESCRIPTION
## What are you doing in this PR?

Change DS gift checkout post deploy test to use CC instead of DD

https://trello.com/c/GHM1Ib1W/3570-fix-selenium-tests

## Why are you doing this?

 there seems to be a weird bug that only affects gift+DD combination!
When it clicks on the confirm DD button, the Pay button is there, but clicking it doesn't seem to have much effect (at least the first click).

We tried a 1s delay in this PR: https://github.com/guardian/support-frontend/pull/2915 but this is a backup PR in case that doesn't work enough.  We prefer to add a delay and still have the testing, rather than not testing the DD at all with DS.