### PR TITLE
Fix validation issues with the date picker in timezones outside of the UK

### DIFF
--- a/support-frontend/assets/helpers/formValidation.js
+++ b/support-frontend/assets/helpers/formValidation.js
@@ -19,8 +19,6 @@ export const isEmpty: (string | null) => boolean = input =>
 
 export const isNotEmpty: (string | null) => boolean = input => !isEmpty(input);
 
-export const isNotInThePast: (Date | null) => boolean = date => !DateUtils.isPastDay(date);
-
 export const isNotTooFarInTheFuture: (Date | null) => boolean = (date) => {
   const rangeDate = new Date();
   rangeDate.setDate(rangeDate.getDate() + daysFromNowForGift);

--- a/support-frontend/assets/helpers/formValidation.js
+++ b/support-frontend/assets/helpers/formValidation.js
@@ -43,7 +43,7 @@ export const checkOptionalEmail: (string | null) => boolean = input => isEmpty(i
 
 export const checkGiftStartDate: (string | null) => boolean = (rawDate) => {
   const date = rawDate ? new Date(rawDate) : null;
-  return isNotEmpty(rawDate) && isNotInThePast(date) && isNotTooFarInTheFuture(date);
+  return isNotEmpty(rawDate) && isNotTooFarInTheFuture(date);
 };
 
 export const checkAmount: (string, CountryGroupId, ContributionType) =>

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/datePicker/datePicker.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/datePicker/datePicker.jsx
@@ -96,7 +96,9 @@ class DatePickerFields extends Component<PropTypes, StateTypes> {
     // Specifying midnight means that the Date object will always be the selected date in the user's time zone
     // A date instantiated with just new Date('2021-01-01') will be in UTC and causes time zone issues
     const valueDate = new Date(`${value}T00:00:00`);
-    return `${valueDate.getDate()} ${monthText[valueDate.getMonth()]} ${valueDate.getFullYear()}`;
+    const today = new Date();
+    const confirmedDate = today > valueDate ? today : valueDate;
+    return `${confirmedDate.getDate()} ${monthText[confirmedDate.getMonth()]} ${confirmedDate.getFullYear()}`;
   }
 
   checkDateIsValid = (e: Object) => {

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/datePicker/datePicker.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/datePicker/datePicker.jsx
@@ -16,7 +16,6 @@ import { Error } from 'components/forms/customFields/error';
 import {
   getLatestAvailableDateText,
   getRange,
-  // dateIsPast,
   dateIsOutsideRange,
 } from './helpers';
 

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/datePicker/datePicker.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/datePicker/datePicker.jsx
@@ -16,7 +16,7 @@ import { Error } from 'components/forms/customFields/error';
 import {
   getLatestAvailableDateText,
   getRange,
-  dateIsPast,
+  // dateIsPast,
   dateIsOutsideRange,
 } from './helpers';
 
@@ -99,8 +99,6 @@ class DatePickerFields extends Component<PropTypes, StateTypes> {
       this.handleError('No date has been selected as the date is not valid. Please try again');
     } else if (dateIsOutsideRange(date)) {
       this.handleError(`No date has been recorded as the date entered was not available. Please enter a date up to ${latestAvailableDate}`);
-    } else if (dateIsPast(date)) {
-      this.handleError(`No date has been recorded as the date was in the past. Please enter a date between today and ${latestAvailableDate}`);
     }
   }
 
@@ -115,7 +113,7 @@ class DatePickerFields extends Component<PropTypes, StateTypes> {
   }
 
   handleCalendarDate = (date: Date) => {
-    if (dateIsPast(date) || dateIsOutsideRange(date)) {
+    if (dateIsOutsideRange(date)) {
       return;
     }
     const dateArray = formatMachineDate(date).split('-');

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/datePicker/datePicker.jsx
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/datePicker/datePicker.jsx
@@ -88,6 +88,17 @@ class DatePickerFields extends Component<PropTypes, StateTypes> {
 
   getDateString = () => `${this.state.year}-${this.state.month}-${this.state.day}`;
 
+  getDateConfirmationText = () => {
+    const { value } = this.props;
+    if (!value) {
+      return '';
+    }
+    // Specifying midnight means that the Date object will always be the selected date in the user's time zone
+    // A date instantiated with just new Date('2021-01-01') will be in UTC and causes time zone issues
+    const valueDate = new Date(`${value}T00:00:00`);
+    return `${valueDate.getDate()} ${monthText[valueDate.getMonth()]} ${valueDate.getFullYear()}`;
+  }
+
   checkDateIsValid = (e: Object) => {
     e.preventDefault();
     const date = new Date(this.getDateString());
@@ -144,11 +155,9 @@ class DatePickerFields extends Component<PropTypes, StateTypes> {
 
   render() {
     const { state } = this;
-    const { value } = this.props;
     const today = Date.now();
     const currentMonth = new Date(today);
     const threeMonthRange = DateUtils.addMonths(currentMonth, 3);
-    const valueDate = value ? new Date(value) : null;
 
     return (
       <div>
@@ -227,7 +236,7 @@ class DatePickerFields extends Component<PropTypes, StateTypes> {
         </span>
         <span>{!state.dateError && state.dateValidated && (
           <div role="status" aria-live="assertive" css={marginTop}>
-            {`Your gift will be delivered on ${valueDate ? valueDate.getDate() : ''} ${valueDate ? monthText[valueDate.getMonth()] : ''} ${valueDate ? valueDate.getFullYear() : ''}`}
+            {`Your gift will be delivered on ${this.getDateConfirmationText()}`}
           </div>)}
         </span>
       </div>

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/datePicker/datePickerHelpers.test.js
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/datePicker/datePickerHelpers.test.js
@@ -1,7 +1,6 @@
 // flow
 
 import {
-  dateIsPast,
   dateIsOutsideRange,
   getRange,
   getLatestAvailableDateText,
@@ -24,20 +23,6 @@ describe('datePickerHelpers', () => {
 
   afterEach(() => {
     global.Date = RealDate;
-  });
-
-  describe('dateIsPast', () => {
-    it('should be able to indicate if a selected date is in the past', () => {
-      const pastDate = new RealDate('05/13/2020');
-      const resultPast = dateIsPast(pastDate);
-      console.log('past', pastDate);
-      expect(resultPast).toBe(true);
-
-      const todaysDate = new RealDate('05/14/2020');
-      const resultToday = dateIsPast(todaysDate);
-      expect(resultToday).toBe(false);
-    });
-
   });
 
   describe('dateIsOutsideRange', () => {

--- a/support-frontend/assets/pages/digital-subscription-checkout/components/datePicker/helpers.js
+++ b/support-frontend/assets/pages/digital-subscription-checkout/components/datePicker/helpers.js
@@ -15,15 +15,12 @@ const getLatestAvailableDateText = () => {
   return `${rangeDate.getDate()} ${monthText[rangeDate.getMonth()]} ${rangeDate.getFullYear()}`;
 };
 
-const dateIsPast = (date: Date) => DateUtils.isPastDay(date);
-
 const dateIsOutsideRange = (date: Date) => {
   const rangeDate = getRange();
   return DateUtils.isDayAfter(date, rangeDate);
 };
 
 export {
-  dateIsPast,
   dateIsOutsideRange,
   getRange,
   getLatestAvailableDateText,


### PR DESCRIPTION
## What are you doing in this PR?

This fixes the issue where the date picker in the digital subs gift checkout is failing validation when left on today's date if the user is in a location where midnight UTC is the previous day in their timezone.

It removes all validation regarding whether the date is 'too early', and amends the way we confirm the date to the user so it will always show the correct date relative to their timezone.

[**Trello Card**](https://trello.com/c/TCZHMVV0)

## Why are you doing this?

This has been causing the Selenium tests for the gift checkout to fail as the CI server is located in the US, and may have been preventing gift checkouts for users outside of the UK.

The backend doesn't care if a date that the user selects is in the past- the gift will always be sent immediately if the delivery date is not in the future- so there's no practical requirement for client-side validation outside of making sure the user sees something sensible if they click 'Check date'