### PR TITLE
Remove redux debug information

### DIFF
--- a/support-frontend/assets/helpers/subscriptionsForms/formReducer.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/formReducer.js
@@ -65,9 +65,7 @@ function createFormReducer(
   const getFulfilmentOption = (action, currentOption) =>
     (action.scope === 'delivery' ? getWeeklyFulfilmentOption(action.country) : currentOption);
 
-  return (originalState: FormState = initialState, action: Action): FormState => {
-
-    const state = { ...originalState, debugInfo: `${originalState.debugInfo} ${JSON.stringify(action)}\n` };
+  return (state: FormState = initialState, action: Action): FormState => {
 
     switch (action.type) {
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
We have discovered that trying to stringify the state when it contains an error can cause the following exception:
```
Uncaught TypeError: Converting circular structure to JSON
    --> starting at object with constructor 'Object'
    --- property '__v' closes the circle
    at JSON.stringify (<anonymous>)
    at formReducer.js:70
    at redux.js:435
    at redux.js:435
    at p (<anonymous>:1:36402)
    at v (<anonymous>:1:36684)
    at <anonymous>:1:40069
    at Object.h [as dispatch] (redux.js:213)
    at e (<anonymous>:1:40553)
    at index.js:11
    at dispatch (redux.js:563)
    at formValidation.js:81
    at Array.forEach (<anonymous>)
    at b (formValidation.js:80)
    at h (formValidation.js:99)
    at paperCheckoutForm.jsx:148
    at Object.dispatch (index.js:8)
    at dispatch (<anonymous>:1:28545)
    at Object.validateForm (redux.js:449)
    at Object.onClick [as click] (stripeForm.jsx:273)
    at HTMLButtonElement.k (preact.module.js:1)
    at HTMLButtonElement.r (helpers.js:70)
```

Steps to reproduce are:
- Go to paper home delivery checkout
- Put in an address outside of the M25
- Submit the form

No error message will be shown but the form will not submit.

This PR removed the redux debugging information until we can investigate this further.
