### PR TITLE
Remove copy relating to the end of year special edition

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/hero/hero.jsx
@@ -36,10 +36,6 @@ const HeroCopy = () => (
       gives you the richest experience of Guardian journalism. It also sustains the independent
       reporting you love.
     </p>
-    <p css={paragraph}>
-      For a few weeks only, read <strong>The best of a bad year</strong>, a new and exclusive look at the cultural,
-      scientific, environmental and political high points that stand out from a year dominated by the pandemic.
-    </p>
   </>
 );
 

--- a/support-frontend/assets/pages/digital-subscription-landing/components/productBlock/productBlock.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/productBlock/productBlock.jsx
@@ -167,7 +167,7 @@ class ProductBlock extends Component<PropTypes, StateTypes> {
           <div className="product-block__container__label--top">What&apos;s included?</div>
           <ProductCard
             title="UK Daily in The Guardian Editions app"
-            subtitle="The best of a bad year- limited time only, ending 23 January"
+            subtitle="Each day&apos;s edition, in one simple, elegant app"
             image={dailyImage}
             second={false}
           />


### PR DESCRIPTION

## What are you doing in this PR?
This removes the copy relating to the 'best of a bad year' end of year special edition from the digi subs landing pages.

[**Trello Card**](https://trello.com/c/bZNL5kUC)

**DO NOT MERGE** until Tuesday evening at the earliest