### PR TITLE
Fix issues with price cards incorrectly displaying content from promo codes

### DIFF
--- a/support-frontend/assets/helpers/productPrice/productPrices.js
+++ b/support-frontend/assets/helpers/productPrice/productPrices.js
@@ -58,6 +58,10 @@ const isNumeric = (num: ?number): boolean %checks =>
   num !== undefined &&
   !Number.isNaN(num);
 
+function getFirstValidPrice(...prices: Array<?number>) {
+  return prices.find(isNumeric) || 0;
+}
+
 function getCountryGroup(country: IsoCountry): CountryGroup {
   return countryGroups[fromCountry(country) || GBPCountries];
 }
@@ -126,6 +130,7 @@ function getCurrency(country: IsoCountry): IsoCurrency {
 
 export {
   getProductPrice,
+  getFirstValidPrice,
   finalPrice,
   getCurrency,
   getCountryGroup,

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
@@ -25,7 +25,7 @@ import type {
 import type { CountryGroupId } from 'helpers/internationalisation/countryGroup';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import { getAppliedPromo } from 'helpers/productPrice/promotions';
-import { isNumeric } from 'helpers/productPrice/productPrices';
+import { getFirstValidPrice, isNumeric } from 'helpers/productPrice/productPrices';
 
 import { type PropTypes } from '../paymentSelection';
 
@@ -146,7 +146,7 @@ const mapStateToProps = (state: State): PropTypes => {
       } :
       {
         title: BILLING_PERIOD[digitalBillingPeriod].title,
-        price: getDisplayPrice(currencyId, isNumeric(promotionalPrice) ? promotionalPrice : fullPrice),
+        price: getDisplayPrice(currencyId, getFirstValidPrice(promotionalPrice, fullPrice)),
         href: getDigitalCheckout(countryGroupId, billingPeriodForHref, promoCode, orderIsAGift),
         onClick: sendTrackingEventsOnClick('subscribe_now_cta', 'DigitalPack', null, billingPeriod),
         priceCopy: BILLING_PERIOD[digitalBillingPeriod].salesCopy(currencyId, fullPrice, promotionalPrice),

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
@@ -146,7 +146,7 @@ const mapStateToProps = (state: State): PropTypes => {
       } :
       {
         title: BILLING_PERIOD[digitalBillingPeriod].title,
-        price: getDisplayPrice(currencyId, promotionalPrice || fullPrice),
+        price: getDisplayPrice(currencyId, isNumeric(promotionalPrice) ? promotionalPrice : fullPrice),
         href: getDigitalCheckout(countryGroupId, billingPeriodForHref, promoCode, orderIsAGift),
         onClick: sendTrackingEventsOnClick('subscribe_now_cta', 'DigitalPack', null, billingPeriod),
         priceCopy: BILLING_PERIOD[digitalBillingPeriod].salesCopy(currencyId, fullPrice, promotionalPrice),

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyProductPrices.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyProductPrices.jsx
@@ -13,7 +13,7 @@ import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
 import Prices, { type PropTypes } from './content/prices';
 
 import { type State } from '../weeklySubscriptionLandingReducer';
-import { getProductPrice } from 'helpers/productPrice/productPrices';
+import { getProductPrice, getFirstValidPrice } from 'helpers/productPrice/productPrices';
 import {
   getSimplifiedPriceDescription,
 } from 'helpers/productPrice/priceDescriptions';
@@ -52,7 +52,7 @@ const getRelevantPromotion = ({ promotions }: ProductPrice) => {
 const getMainDisplayPrice = (productPrice: ProductPrice, promotion?: Promotion | null): number => {
   if (promotion) {
     const introductoryPrice = promotion.introductoryPrice && promotion.introductoryPrice.price;
-    return promotion.discountedPrice || introductoryPrice || productPrice.price;
+    return getFirstValidPrice(promotion.discountedPrice, introductoryPrice, productPrice.price);
   }
   return productPrice.price;
 };

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyProductPrices.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/weeklyProductPrices.jsx
@@ -9,6 +9,9 @@ import {
   type WeeklyBillingPeriod,
 } from 'helpers/billingPeriods';
 import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
+import {
+  getAppliedPromo,
+} from 'helpers/productPrice/promotions';
 
 import Prices, { type PropTypes } from './content/prices';
 
@@ -42,13 +45,6 @@ const getPromotionLabel = (promotion: Promotion | null) => {
   return `Save ${Math.round(promotion.discount.amount)}%`;
 };
 
-const getRelevantPromotion = ({ promotions }: ProductPrice) => {
-  if (promotions && promotions.length) {
-    return promotions[0];
-  }
-  return null;
-};
-
 const getMainDisplayPrice = (productPrice: ProductPrice, promotion?: Promotion | null): number => {
   if (promotion) {
     const introductoryPrice = promotion.introductoryPrice && promotion.introductoryPrice.price;
@@ -58,7 +54,7 @@ const getMainDisplayPrice = (productPrice: ProductPrice, promotion?: Promotion |
 };
 
 const weeklyProductProps = (billingPeriod: WeeklyBillingPeriod, productPrice: ProductPrice, orderIsAGift = false) => {
-  const promotion = getRelevantPromotion(productPrice);
+  const promotion = getAppliedPromo(productPrice.promotions);
   const mainDisplayPrice = getMainDisplayPrice(productPrice, promotion);
 
   const offerCopy = (promotion && promotion.landingPage && promotion.landingPage.roundel) || '';


### PR DESCRIPTION
## What are you doing in this PR?

This fixes two issues relating to the price cards when promo codes were used:

- Promo codes applying a 100% discount will now show the £0 price correctly, instead of defaulting back to the base price
- Where more than one promo code is applied for a specific product, the Guardian Weekly landing page will no longer always show the first one regardless of the query string.

[**Trello Card**](https://trello.com/c/TpBHm3KU)