### PR TITLE
Lower payment-api alarm period to 60seconds

### DIFF
--- a/support-payment-api/src/main/resources/cloud-formation.yaml
+++ b/support-payment-api/src/main/resources/cloud-formation.yaml
@@ -521,7 +521,7 @@ Resources:
                   Value: Paypal
         ComparisonOperator: GreaterThanThreshold
         Threshold: 1
-        Period: 900
+        Period: 60
         EvaluationPeriods: 1
         Statistic: Sum
         TreatMissingData: notBreaching
@@ -540,7 +540,7 @@ Resources:
                   Value: Stripe
         ComparisonOperator: GreaterThanThreshold
         Threshold: 1
-        Period: 900
+        Period: 60
         EvaluationPeriods: 1
         Statistic: Sum
         TreatMissingData: notBreaching
@@ -559,7 +559,7 @@ Resources:
           Value: AmazonPay
       ComparisonOperator: GreaterThanThreshold
       Threshold: 1
-      Period: 900
+      Period: 60
       EvaluationPeriods: 1
       Statistic: Sum
       TreatMissingData: notBreaching
@@ -575,7 +575,7 @@ Resources:
       Namespace: support-payment-api-PROD
       ComparisonOperator: GreaterThanThreshold
       Threshold: 1
-      Period: 900
+      Period: 60
       EvaluationPeriods: 1
       Statistic: Sum
       TreatMissingData: notBreaching

--- a/support-payment-api/src/main/resources/cloud-formation.yaml
+++ b/support-payment-api/src/main/resources/cloud-formation.yaml
@@ -513,7 +513,7 @@ Resources:
       Properties:
         AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:contributions-dev
-        AlarmName: !Sub ${App} ${Stage} Paypal payment error in the last fifteen minutes for one-off contributions via the payment-api
+        AlarmName: !Sub ${App} ${Stage} Paypal payment error for one-off contribution via the payment-api
         MetricName: payment-error
         Namespace: support-payment-api-PROD
         Dimensions:
@@ -532,7 +532,7 @@ Resources:
       Properties:
         AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:contributions-dev
-        AlarmName: !Sub ${App} ${Stage} Stripe payment error in the last fifteen minutes for one-off contributions via the payment-api
+        AlarmName: !Sub ${App} ${Stage} Stripe payment error for one-off contribution via the payment-api
         MetricName: payment-error
         Namespace: support-payment-api-PROD
         Dimensions:
@@ -551,7 +551,7 @@ Resources:
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:contributions-dev
-      AlarmName: !Sub ${App} ${Stage} Amazon Pay payment error in the last fifteen minutes for one-off contributions via the payment-api
+      AlarmName: !Sub ${App} ${Stage} Amazon Pay payment error for one-off contribution via the payment-api
       MetricName: payment-error
       Namespace: support-payment-api-PROD
       Dimensions:


### PR DESCRIPTION
The threshold for these alarms was recently lowered to 1 - https://github.com/guardian/support-frontend/pull/2919/files
@johnduffell pointed out that the period can be lower.