### PR TITLE
don't put a react component inside a redux action

### DIFF
--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.jsx
@@ -1,7 +1,6 @@
 // @flow
 
 // ----- Imports ----- //
-import React from 'react';
 import { combineReducers, type Dispatch } from 'redux';
 
 import { fromString, type IsoCountry } from 'helpers/internationalisation/country';
@@ -124,15 +123,10 @@ const applyDeliveryAddressRules = (
   fields: FormFields,
   addressType: AddressType,
 ): FormError<FormField>[] => {
-  const error = (
-    <div className="component-form-error__summary-error">
-      The address and postcode you entered is outside of our delivery area. You may want to
-      consider purchasing a <a href="/uk/subscribe/paper">voucher subscription</a>
-    </div>);
   const homeRules = validate([
     {
       rule: isHomeDeliveryInM25(fulfilmentOption, fields.postCode),
-      error: formError('postCode', error),
+      error: formError('postCode', 'The address and postcode you entered is outside of our delivery area. Please go back to purchase a voucher subscription instead.'),
     },
   ]);
 

--- a/support-frontend/assets/helpers/subscriptionsForms/formReducer.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/formReducer.js
@@ -65,7 +65,9 @@ function createFormReducer(
   const getFulfilmentOption = (action, currentOption) =>
     (action.scope === 'delivery' ? getWeeklyFulfilmentOption(action.country) : currentOption);
 
-  return (state: FormState = initialState, action: Action): FormState => {
+  return (originalState: FormState = initialState, action: Action): FormState => {
+
+    const state = { ...originalState, debugInfo: `${originalState.debugInfo} ${JSON.stringify(action)}\n` };
 
     switch (action.type) {
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Use a plaain string in the redux Action instead of a react component with a link.

https://trello.com/c/O0LclNV2/3586-add-back-debug-info-for-checkouts

## Why are you doing this?

The original PR stated that the error system could only pass around strings (presumably due to it going into an Action): https://github.com/guardian/support-frontend/pull/2434
then later the covid message was removed and it was inlined by mistake, so the Action had a react component in it.
caused this https://github.com/guardian/support-frontend/pull/2921
and it lso breaks Redux devtools (it hangs!)

the docs suggest not really allowed: https://redux.js.org/tutorials/fundamentals/part-2-concepts-data-flow#state-is-read-only

> Since actions are plain JS objects, they can be logged, serialized, stored, and later replayed for debugging or testing purposes.

## Screenshots

TODO