### PR TITLE
make a read timeout cause a retry unlimited

### DIFF
--- a/support-workers/src/main/scala/com/gu/support/workers/exceptions/ErrorHandler.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/exceptions/ErrorHandler.scala
@@ -1,7 +1,5 @@
 package com.gu.support.workers.exceptions
 
-import java.net.{SocketException, SocketTimeoutException}
-
 import com.gu.acquisition.model.errors.AnalyticsServiceError
 import com.gu.monitoring.SafeLogger
 import com.gu.monitoring.SafeLogger._
@@ -14,6 +12,9 @@ import com.gu.support.zuora.api.response.ZuoraErrorResponse
 import com.gu.zuora.subscriptionBuilders.{BuildSubscribePromoError, BuildSubscribeRedemptionError}
 import io.circe.syntax._
 import io.circe.{DecodingFailure, ParsingFailure}
+
+import java.net.{SocketException, SocketTimeoutException}
+import javax.net.ssl.SSLException
 
 /**
  * Maps exceptions from the application to either fatal or non fatal exceptions
@@ -43,7 +44,7 @@ object ErrorHandler {
         new RetryNone(message = wshe.getMessage, cause = wshe.cause)
 
       //Timeouts/connection issues and 500s
-      case e@(_: SocketTimeoutException | _: SocketException | _: WebServiceHelperError[_]) =>
+      case e@(_: SocketTimeoutException | _: SocketException | _: WebServiceHelperError[_] | _: SSLException) =>
         new RetryUnlimited(message = e.getMessage, cause = throwable)
 
       //WebServiceClientError


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

Fix the step functions so they will retry unlimited on an SSL error

https://trello.com/c/RmyRUx0V/3589-fix-stripeerrorsspec-test

## Why are you doing this?

The stripe errors spec was failing intermittently.  This is because we were expecting a Socket timeout on connect, but sometimes the connection was quicker than 1ms (presumably already open).  This meant we had a read timeout instead, which is returned as an SSL exception.

There is a point to be made about whether some SSL exceptions should fail straight away.  Otherwise it might be 24 hours before we find out about an issue with the hostname (e.g. salesforce migrates to a new URL?)  We could check the string of the exception as well perhaps?

