### PR TITLE
Track country dropdown clicks/interactions

### DIFF
--- a/support-frontend/assets/components/countryGroupSwitcher/countryGroupSwitcherContainer.js
+++ b/support-frontend/assets/components/countryGroupSwitcher/countryGroupSwitcherContainer.js
@@ -21,13 +21,11 @@ export default function (
 ) {
 
   function onCountryGroupSelect(cgId: CountryGroupId): void {
-    if (trackProduct) {
-      sendTrackingEventsOnClick({
-        id: `toggle_country_${cgId}`,
-        product: trackProduct,
-        componentType: 'ACQUISITIONS_BUTTON',
-      })();
-    }
+    sendTrackingEventsOnClick({
+      id: `toggle_country_${cgId}`,
+      ...(trackProduct ? { product: trackProduct } : {}),
+      componentType: 'ACQUISITIONS_OTHER',
+    })();
   }
 
   function mapStateToProps(state: { common: CommonState }): PropTypes {

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -77,6 +77,7 @@ const CountrySwitcherHeader = headerWithCountrySwitcherContainer({
     Canada,
     International,
   ],
+  trackProduct: 'DigitalPack',
 });
 
 // ----- Render ----- //

--- a/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
+++ b/support-frontend/assets/pages/subscriptions-landing/subscriptionsLanding.jsx
@@ -35,7 +35,6 @@ const Header = headerWithCountrySwitcherContainer({
     NZDCountries,
     International,
   ],
-  trackProduct: 'GuardianWeekly',
 });
 
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->

This PR fixes a couple small issues with the tracking on our country dropdown list. 

1. If `trackProduct` was undefined in `onCountryGroupSelect` we'd never track the interactions, this meant we would't track interactions from our `/support` and `/subscribe` routes, however we're now able to remove the `if { ... }` block around the `sendTrackingEventsOnClick` call as this takes an optional `product` argument.

2. Specify the correct value for `trackProduct` from the `/subscribe/digital` route: 'DigitalPack'

3. Remove the incorrect value for `trackProduct` from the `/subscribe` route: 'GuardianWeekly'

[**Trello Card**](https://trello.com/c/AZDrxIgG/3566-fix-ophan-click-tracking-on-the-country-dropdown-toggle)

