### PR TITLE
New order summary component for subscriptions checkouts

### DIFF
--- a/support-frontend/assets/components/orderSummary/orderSummary.jsx
+++ b/support-frontend/assets/components/orderSummary/orderSummary.jsx
@@ -1,6 +1,7 @@
 // @flow
 
 import React, { type Node } from 'react';
+import { SvgInfo } from '@guardian/src-icons';
 import typeof GridImageType from 'components/gridImage/gridImage';
 import { type GridImg } from 'components/gridImage/gridImage';
 import * as styles from './orderSummaryStyles';
@@ -9,21 +10,35 @@ type PropTypes = {
   children: Node,
   changeSubscription?: string | null,
   image: $Call<GridImageType, GridImg>,
+  total: string,
 };
 
 function OrderSummary(props: PropTypes) {
   return (
     <aside css={styles.wrapper}>
       <div css={styles.topLine}>
-        <h3 css={styles.title}>Order summary</h3>
-        <a href={props.changeSubscription}>Change</a>
+        <div css={styles.topLineBorder}>
+          <h3 css={styles.title}>Order summary</h3>
+          <a href={props.changeSubscription}>Change</a>
+        </div>
       </div>
       <div css={styles.contentBlock}>
         <div css={styles.imageContainer}>{props.image}</div>
       </div>
       <div css={styles.products}>
-        {props.children}
-        <div>You can cancel any time</div>
+        <div>
+          {props.children}
+        </div>
+        <div css={styles.infoContainer}>
+          <div css={styles.info}>
+            <SvgInfo />
+            <span>You can cancel any time</span>
+          </div>
+        </div>
+        <div css={styles.total}>
+          <span>Total:</span>
+          <span>{props.total}</span>
+        </div>
       </div>
     </aside>
   );

--- a/support-frontend/assets/components/orderSummary/orderSummary.jsx
+++ b/support-frontend/assets/components/orderSummary/orderSummary.jsx
@@ -25,7 +25,7 @@ function OrderSummary(props: PropTypes) {
       <div css={styles.topLine}>
         <div css={styles.topLineBorder}>
           <h3 css={styles.title}>Order summary</h3>
-          <a href={props.changeSubscription}>Change</a>
+          {props.changeSubscription && <a href={props.changeSubscription}>Change</a>}
         </div>
       </div>
       <div css={styles.contentBlock}>

--- a/support-frontend/assets/components/orderSummary/orderSummary.jsx
+++ b/support-frontend/assets/components/orderSummary/orderSummary.jsx
@@ -6,10 +6,16 @@ import typeof GridImageType from 'components/gridImage/gridImage';
 import { type GridImg } from 'components/gridImage/gridImage';
 import * as styles from './orderSummaryStyles';
 
+type MobileOrderSummary = {
+  title: string,
+  price: string,
+}
+
 type PropTypes = {
   children: Node,
   changeSubscription?: string | null,
   image: $Call<GridImageType, GridImg>,
+  mobileSummary: MobileOrderSummary,
   total: string,
 };
 
@@ -24,6 +30,10 @@ function OrderSummary(props: PropTypes) {
       </div>
       <div css={styles.contentBlock}>
         <div css={styles.imageContainer}>{props.image}</div>
+        <div css={styles.mobileSummary}>
+          <h4>{props.mobileSummary.title}</h4>
+          <p>{props.mobileSummary.price}</p>
+        </div>
       </div>
       <div css={styles.products}>
         <div>

--- a/support-frontend/assets/components/orderSummary/orderSummary.jsx
+++ b/support-frontend/assets/components/orderSummary/orderSummary.jsx
@@ -1,0 +1,36 @@
+// @flow
+
+import React, { type Node } from 'react';
+import typeof GridImageType from 'components/gridImage/gridImage';
+import { type GridImg } from 'components/gridImage/gridImage';
+import * as styles from './orderSummaryStyles';
+
+type PropTypes = {
+  children: Node,
+  changeSubscription?: string | null,
+  image: $Call<GridImageType, GridImg>,
+};
+
+function OrderSummary(props: PropTypes) {
+  return (
+    <aside css={styles.wrapper}>
+      <div css={styles.topLine}>
+        <h3 css={styles.title}>Order summary</h3>
+        <a href={props.changeSubscription}>Change</a>
+      </div>
+      <div css={styles.contentBlock}>
+        <div css={styles.imageContainer}>{props.image}</div>
+      </div>
+      <div css={styles.products}>
+        {props.children}
+        <div>You can cancel any time</div>
+      </div>
+    </aside>
+  );
+}
+
+OrderSummary.defaultProps = {
+  changeSubscription: '',
+};
+
+export default OrderSummary;

--- a/support-frontend/assets/components/orderSummary/orderSummaryProduct.jsx
+++ b/support-frontend/assets/components/orderSummary/orderSummaryProduct.jsx
@@ -1,0 +1,70 @@
+// @flow
+import React from 'react';
+import { css } from '@emotion/core';
+import { headline, textSans } from '@guardian/src-foundations/typography';
+import { space } from '@guardian/src-foundations';
+import { brand, neutral } from '@guardian/src-foundations/palette';
+
+const title = css`
+  ${headline.xsmall({ fontWeight: 'bold' })};
+  background-color: ${neutral[97]};
+  padding: ${space[2]}px;
+  border-top: 1px solid ${neutral[60]};
+`;
+
+const list = css`
+  padding-top: ${space[2]}px;
+  padding-bottom: ${space[9]}px;
+`;
+
+const listItem = css`
+  margin: 0 ${space[9]}px;
+
+  &:not(:last-of-type) {
+    margin-bottom: ${space[4]}px;
+  }
+`;
+
+const listItemMain = css`
+  ${textSans.medium({ fontWeight: 'bold' })};
+
+  &::before {
+    display: inline-block;
+    content: '';
+    width: ${space[3]}px;
+    height: ${space[3]}px;
+    margin-right: -${space[3]}px;
+    border-radius: 50%;
+    background-color: ${brand[400]};
+    transform: translateX(-${space[6]}px);
+  }
+`;
+
+
+type ProductInfoItem = {
+  mainText: string,
+  subText?: string
+}
+
+type OrderSummaryProductProps = {
+  productName: string,
+  productInfo: ProductInfoItem[]
+}
+
+function OrderSummaryProduct(props: OrderSummaryProductProps) {
+  return (
+    <div>
+      <h4 css={title}>{props.productName}</h4>
+      <ul css={list}>
+        {props.productInfo.map(infoItem => (
+          <li css={listItem}>
+            <div css={listItemMain}>{infoItem.mainText}</div>
+            <span>{infoItem.subText}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default OrderSummaryProduct;

--- a/support-frontend/assets/components/orderSummary/orderSummaryProduct.jsx
+++ b/support-frontend/assets/components/orderSummary/orderSummaryProduct.jsx
@@ -5,11 +5,16 @@ import { headline, textSans } from '@guardian/src-foundations/typography';
 import { space } from '@guardian/src-foundations';
 import { brand, neutral } from '@guardian/src-foundations/palette';
 
+const container = css`
+  &:not(:last-of-type) {
+    border-bottom: 1px solid ${neutral[86]};
+  }
+`;
+
 const title = css`
   ${headline.xsmall({ fontWeight: 'bold' })};
   background-color: ${neutral[97]};
   padding: ${space[2]}px;
-  border-top: 1px solid ${neutral[60]};
 `;
 
 const list = css`
@@ -53,7 +58,7 @@ type OrderSummaryProductProps = {
 
 function OrderSummaryProduct(props: OrderSummaryProductProps) {
   return (
-    <div>
+    <div css={container}>
       <h4 css={title}>{props.productName}</h4>
       <ul css={list}>
         {props.productInfo.map(infoItem => (

--- a/support-frontend/assets/components/orderSummary/orderSummaryStyles.js
+++ b/support-frontend/assets/components/orderSummary/orderSummaryStyles.js
@@ -1,7 +1,7 @@
 import { css } from '@emotion/core';
 import { headline, body, textSans } from '@guardian/src-foundations/typography/obj';
 import { space } from '@guardian/src-foundations';
-import { background, brandAltBackground, text, border, neutral } from '@guardian/src-foundations/palette';
+import { background, brandAltBackground, brand, text, border, neutral } from '@guardian/src-foundations/palette';
 import { from, between, until } from '@guardian/src-foundations/mq';
 
 export const wrapper = css`
@@ -16,12 +16,8 @@ export const wrapper = css`
 `;
 
 export const topLine = css`
-  display: flex;
-  justify-content: space-between;
   width: calc(100%-${space[3]}px * 2);
-  align-items: center;
-  padding: ${space[3]}px;
-  border-bottom: 1px solid ${neutral[86]};
+  padding: 0 ${space[3]}px;
 
   ${until.desktop} {
     border-top: 1px solid ${neutral['93']};
@@ -43,6 +39,15 @@ export const topLine = css`
   }
 `;
 
+export const topLineBorder = css`
+  padding: ${space[3]}px 0;
+  border-bottom: 1px solid ${neutral[86]};
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
 export const title = css`
   ${headline.xsmall({ fontWeight: 'bold' })}
 `;
@@ -50,6 +55,7 @@ export const title = css`
 export const contentBlock = css`
   display: flex;
   width: 100%;
+  border-bottom: 1px solid ${neutral[60]};
 
   ${from.tablet} {
     display: block;
@@ -124,4 +130,31 @@ export const products = css`
   ${from.desktop} {
     display: block;
   }
+`;
+
+export const infoContainer = css`
+  padding: 0 ${space[2]}px;
+`;
+
+export const info = css`
+  ${textSans.xsmall()};
+  line-height: 22px;
+  display: flex;
+  padding: ${space[2]}px 0;
+  border-top: 1px solid ${neutral[86]};
+
+  svg {
+    max-width: 22px;
+    fill: ${brand[400]};
+    margin-right: ${space[2]}px;
+  }
+`;
+
+export const total = css`
+  ${headline.xsmall({ fontWeight: 'bold' })};
+  background-color: ${neutral[97]};
+  padding: ${space[2]}px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 `;

--- a/support-frontend/assets/components/orderSummary/orderSummaryStyles.js
+++ b/support-frontend/assets/components/orderSummary/orderSummaryStyles.js
@@ -1,0 +1,127 @@
+import { css } from '@emotion/core';
+import { headline, body, textSans } from '@guardian/src-foundations/typography/obj';
+import { space } from '@guardian/src-foundations';
+import { background, brandAltBackground, text, border, neutral } from '@guardian/src-foundations/palette';
+import { from, between, until } from '@guardian/src-foundations/mq';
+
+export const wrapper = css`
+  background-color: ${background.primary};
+  color: ${text.primary};
+  ${until.desktop} {
+    padding: ${space[3]}px;
+  }
+  ${until.tablet} {
+    box-shadow: 0 4px 4px ${border.secondary};
+  }
+`;
+
+export const topLine = css`
+  display: flex;
+  justify-content: space-between;
+  width: calc(100%-${space[3]}px * 2);
+  align-items: center;
+  padding: ${space[3]}px;
+  border-bottom: 1px solid ${neutral[86]};
+
+  ${until.desktop} {
+    border-top: 1px solid ${neutral['93']};
+    padding: ${space[1]}px 0 ${space[2]}px;
+  }
+
+
+  a, a:visited {
+    display: block;
+    ${textSans.small()};
+    color: ${text.primary};
+    ${from.desktop} {
+      ${textSans.medium({ fontWeight: 'bold' })};
+    }
+  }
+
+  ${between.phablet.and.desktop} {
+    display: block;
+  }
+`;
+
+export const title = css`
+  ${headline.xsmall({ fontWeight: 'bold' })}
+`;
+
+export const contentBlock = css`
+  display: flex;
+  width: 100%;
+
+  ${from.tablet} {
+    display: block;
+  }
+`;
+
+export const imageContainer = css`
+  display: inline-flex;
+  align-items: flex-start;
+  padding: ${space[9]}px 0;
+  background-color: ${neutral[100]};
+
+  img {
+    width: 100%;
+    height: auto;
+  }
+
+  ${until.tablet} {
+    padding: 0;
+    width: 75px;
+    height: 45px;
+    overflow: hidden;
+    img {
+      align-items: flex-end;
+    }
+  }
+`;
+
+export const textBlock = css`
+  margin-left: ${space[3]}px;
+
+  ${from.desktop} {
+    display: flex;
+    justify-content: space-between;
+    width: calc(100%-${space[3]}px * 2);
+    margin: ${space[3]}px;
+    align-items: baseline;
+  }
+
+  h3 {
+    ${body.medium({ fontWeight: 'bold' })};
+    margin: -5px 0 -3px;
+    ${from.desktop} {
+      ${headline.xxsmall({ fontWeight: 'bold' })};
+      margin-top: 0;
+    }
+  }
+  p, span {
+    max-width: 240px;
+  }
+  span {
+    background-color: ${brandAltBackground.primary};
+    padding: 2px;
+    ${textSans.small({ fontWeight: 'bold' })};
+    ${from.desktop} {
+      padding: ${space[1]}px;
+      ${textSans.medium()};
+    }
+  }
+  p {
+    ${body.small({ fontWeight: 'normal' })};
+    line-height: 135%;
+    ${from.desktop} {
+      display: none;
+    }
+  }
+`;
+
+export const products = css`
+  display: none;
+
+  ${from.desktop} {
+    display: block;
+  }
+`;

--- a/support-frontend/assets/components/orderSummary/orderSummaryStyles.js
+++ b/support-frontend/assets/components/orderSummary/orderSummaryStyles.js
@@ -1,14 +1,14 @@
 import { css } from '@emotion/core';
-import { headline, body, textSans } from '@guardian/src-foundations/typography/obj';
+import { headline, textSans } from '@guardian/src-foundations/typography/obj';
 import { space } from '@guardian/src-foundations';
-import { background, brandAltBackground, brand, text, border, neutral } from '@guardian/src-foundations/palette';
+import { background, brand, text, border, neutral } from '@guardian/src-foundations/palette';
 import { from, between, until } from '@guardian/src-foundations/mq';
 
 export const wrapper = css`
   background-color: ${background.primary};
   color: ${text.primary};
   ${until.desktop} {
-    padding: ${space[3]}px;
+    padding: ${space[2]}px ${space[3]}px;
   }
   ${until.tablet} {
     box-shadow: 0 4px 4px ${border.secondary};
@@ -20,7 +20,7 @@ export const topLine = css`
   padding: 0 ${space[3]}px;
 
   ${until.desktop} {
-    border-top: 1px solid ${neutral['93']};
+    /* border-top: 1px solid ${neutral['93']}; */
     padding: ${space[1]}px 0 ${space[2]}px;
   }
 
@@ -29,6 +29,7 @@ export const topLine = css`
     display: block;
     ${textSans.small()};
     color: ${text.primary};
+    text-decoration: none;
     ${from.desktop} {
       ${textSans.medium({ fontWeight: 'bold' })};
     }
@@ -40,32 +41,57 @@ export const topLine = css`
 `;
 
 export const topLineBorder = css`
-  padding: ${space[3]}px 0;
-  border-bottom: 1px solid ${neutral[86]};
   width: 100%;
   display: flex;
   justify-content: space-between;
   align-items: center;
+
+  ${from.tablet} {
+    padding-bottom: ${space[3]}px;
+    border-bottom: 1px solid ${neutral[86]};
+  }
+
+  ${from.desktop} {
+    padding-top: ${space[3]}px;
+  }
 `;
 
 export const title = css`
-  ${headline.xsmall({ fontWeight: 'bold' })}
+  ${headline.xxxsmall({ fontWeight: 'bold', lineHeight: 'loose' })};
+
+  ${from.desktop} {
+    ${headline.xsmall({ fontWeight: 'bold' })}
+  }
 `;
 
 export const contentBlock = css`
   display: flex;
   width: 100%;
-  border-bottom: 1px solid ${neutral[60]};
 
   ${from.tablet} {
     display: block;
+  }
+
+  ${from.desktop} {
+    border-bottom: 1px solid ${neutral[60]};
+  }
+`;
+
+export const mobileSummary = css`
+  ${headline.xxxsmall()};
+
+  h4 {
+    font-weight: 700;
+  }
+
+  ${from.desktop} {
+    display: none;
   }
 `;
 
 export const imageContainer = css`
   display: inline-flex;
   align-items: flex-start;
-  padding: ${space[9]}px 0;
   background-color: ${neutral[100]};
 
   img {
@@ -82,45 +108,13 @@ export const imageContainer = css`
       align-items: flex-end;
     }
   }
-`;
 
-export const textBlock = css`
-  margin-left: ${space[3]}px;
+  ${from.tablet} {
+    padding: ${space[3]}px 0;
+  }
 
   ${from.desktop} {
-    display: flex;
-    justify-content: space-between;
-    width: calc(100%-${space[3]}px * 2);
-    margin: ${space[3]}px;
-    align-items: baseline;
-  }
-
-  h3 {
-    ${body.medium({ fontWeight: 'bold' })};
-    margin: -5px 0 -3px;
-    ${from.desktop} {
-      ${headline.xxsmall({ fontWeight: 'bold' })};
-      margin-top: 0;
-    }
-  }
-  p, span {
-    max-width: 240px;
-  }
-  span {
-    background-color: ${brandAltBackground.primary};
-    padding: 2px;
-    ${textSans.small({ fontWeight: 'bold' })};
-    ${from.desktop} {
-      padding: ${space[1]}px;
-      ${textSans.medium()};
-    }
-  }
-  p {
-    ${body.small({ fontWeight: 'normal' })};
-    line-height: 135%;
-    ${from.desktop} {
-      display: none;
-    }
+    padding: ${space[9]}px 0;
   }
 `;
 

--- a/support-frontend/stories/checkouts.jsx
+++ b/support-frontend/stories/checkouts.jsx
@@ -61,12 +61,8 @@ stories.add('Order Summary', () => {
             altText=""
           />
         }
-        // title="Hello"
-        // productPrice={productPrice}
-        // billingPeriod="Monthly"
         changeSubscription="/"
-        // product="Paper"
-        // fulfilmentOption="HomeDelivery"
+        total="£62.99/month"
       >
         <OrderSummaryProduct
           productName="Sixday paper"

--- a/support-frontend/stories/checkouts.jsx
+++ b/support-frontend/stories/checkouts.jsx
@@ -49,6 +49,11 @@ stories.add('Order Summary', () => {
     },
   ];
 
+  const mobileSummary = {
+    title: 'Sixday paper + Digital',
+    price: 'You\'ll pay £62.99/month',
+  };
+
   return (
     <div style={{ maxWidth: '470px', border: '1px solid #DCDCDC' }}>
       <OrderSummary
@@ -63,6 +68,7 @@ stories.add('Order Summary', () => {
         }
         changeSubscription="/"
         total="£62.99/month"
+        mobileSummary={mobileSummary}
       >
         <OrderSummaryProduct
           productName="Sixday paper"

--- a/support-frontend/stories/checkouts.jsx
+++ b/support-frontend/stories/checkouts.jsx
@@ -6,6 +6,9 @@ import { storiesOf } from '@storybook/react';
 import { FormSection } from 'components/checkoutForm/checkoutForm';
 import CheckoutExpander from 'components/checkoutExpander/checkoutExpander';
 import DatePicker from 'components/datePicker/datePicker';
+import OrderSummary from 'components/orderSummary/orderSummary';
+import OrderSummaryProduct from 'components/orderSummary/orderSummaryProduct';
+import GridImage from 'components/gridImage/gridImage';
 
 const stories = storiesOf('Checkouts', module);
 
@@ -26,5 +29,54 @@ stories.add('Date Picker', () => {
     <FormSection>
       <DatePicker value={date} onChange={setDate} />
     </FormSection>
+  );
+});
+
+stories.add('Order Summary', () => {
+  const productInfoPaper = [
+    {
+      mainText: 'You\'ll pay £57.99/month',
+    },
+    {
+      mainText: 'Your first payment will be on 04 February 2021',
+      subText: 'Your subscription card will arrive in the post before the payment date',
+    },
+  ];
+
+  const productInfoDigiSub = [
+    {
+      mainText: 'You\'ll pay £5/month',
+    },
+  ];
+
+  return (
+    <div style={{ maxWidth: '470px', border: '1px solid #DCDCDC' }}>
+      <OrderSummary
+        image={
+          <GridImage
+            gridId="printCampaignHDdigitalVoucher"
+            srcSizes={[500]}
+            sizes="(max-width: 740px) 50vw, 696"
+            imgType="png"
+            altText=""
+          />
+        }
+        // title="Hello"
+        // productPrice={productPrice}
+        // billingPeriod="Monthly"
+        changeSubscription="/"
+        // product="Paper"
+        // fulfilmentOption="HomeDelivery"
+      >
+        <OrderSummaryProduct
+          productName="Sixday paper"
+          productInfo={productInfoPaper}
+        />
+        <OrderSummaryProduct
+          productName="Digital subscription"
+          productInfo={productInfoDigiSub}
+        />
+      </OrderSummary>
+    </div>
   );
 });


### PR DESCRIPTION
## What are you doing in this PR?

The designs for adding the new print & digital option in the print checkouts include an updated version of the order summary which needs to be able to handle the display of more than one product. Also currently all our checkouts have their own, slightly different order summaries.

This adds an initial version of a new, generic order summary component, developed in Storybook and decoupled from Redux state.

[**Trello Card**](https://trello.com/c/OSsIhbE0)

## Why are you doing this?

Separating the presentational aspect of the order summary from the product-specific logic that determines what we display in it means this component should be reusable across all our checkouts in the future.

This is also a part of the print & digital work that's easy to break out into a separate PR, rather than having one giant PR with everything in it once all the work is done.

## Accessibility test checklist
 - [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
 - [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
 - [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

## Screenshots

I'm showing the component in the checkout for context- it's not been added yet!

**Mobile**
![Screenshot 2021-01-29 at 16 41 56](https://user-images.githubusercontent.com/29146931/106307452-4c7efe80-6257-11eb-8f57-34e10d73bd41.png)

**Tablet**
![Screenshot 2021-01-29 at 16 46 25](https://user-images.githubusercontent.com/29146931/106307487-56086680-6257-11eb-8d52-9fc223c62abb.png)

**Desktop**
![Screenshot_2021-01-29 Support the Guardian Newspaper Subscription](https://user-images.githubusercontent.com/29146931/106307524-60c2fb80-6257-11eb-9c1e-53234e8fcf12.png)