### PR TITLE
Add click tracking to subscription CTAs

### DIFF
--- a/support-frontend/assets/components/product/giftNonGiftCta.jsx
+++ b/support-frontend/assets/components/product/giftNonGiftCta.jsx
@@ -6,6 +6,7 @@ import { space } from '@guardian/src-foundations';
 import { body, headline } from '@guardian/src-foundations/typography';
 import { LinkButton } from '@guardian/src-button';
 import { SvgArrowRightStraight } from '@guardian/src-icons';
+import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
 
 type GiftableProduct = 'digital' | 'Guardian Weekly'
 
@@ -41,6 +42,12 @@ function GiftOrPersonal({ href, product, orderIsAGift }: PropTypes) {
         priority="tertiary"
         nudgeIcon
         href={href}
+        onClick={() => {
+          sendTrackingEventsOnClick({
+            id: `${orderIsAGift ? 'personal' : 'gift'}_subscriptions_cta`,
+            componentType: 'ACQUISITIONS_BUTTON',
+          })();
+        }}
       >
         {orderIsAGift ? 'See personal subscriptions' : 'See gift subscriptions'}
       </LinkButton>

--- a/support-frontend/assets/pages/showcase/components/otherProduct.jsx
+++ b/support-frontend/assets/pages/showcase/components/otherProduct.jsx
@@ -5,12 +5,14 @@ import Heading from 'components/heading/heading';
 import AnchorButton from 'components/button/anchorButton';
 import ArrowRightStraight from 'components/svgs/arrowRightStraight';
 import { classNameWithModifiers } from 'helpers/utilities';
+import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
 
 type PropTypes = {|
   title: string,
   description: string,
   destination: string,
   modifierClass: string,
+  trackingId: string,
 |};
 
 export default function OtherProduct(props: PropTypes) {
@@ -22,6 +24,12 @@ export default function OtherProduct(props: PropTypes) {
         icon={<ArrowRightStraight />}
         appearance="greyHollow"
         href={props.destination}
+        onClick={() => {
+          sendTrackingEventsOnClick({
+            id: props.trackingId,
+            componentType: 'ACQUISITIONS_BUTTON',
+          })();
+        }}
       >
         Find out more
       </AnchorButton>

--- a/support-frontend/assets/pages/showcase/components/otherProducts.jsx
+++ b/support-frontend/assets/pages/showcase/components/otherProducts.jsx
@@ -17,12 +17,14 @@ export default function OtherProducts() {
           description="Support from our Patrons is crucial to ensure that generations to come will be able to enjoy The Guardian"
           destination={getPatronsLink()}
           modifierClass="patrons"
+          trackingId="patrons_cta"
         />
         <OtherProduct
           title="Masterclasses &amp; Live Events"
           description="Meet Guardian journalists and readers at our events, debates, interviews and festivals"
           destination={getMemLink('events')}
           modifierClass="masterclass"
+          trackingId="masterclass_cta"
         />
       </Text>
     </Content>


### PR DESCRIPTION
## What are you doing in this PR?

Adds click tracking to CTAs which didn't have. These include the "patrons" and "masterclasses" buttons on https://support.theguardian.com/uk/support ([Trello card](https://trello.com/c/mHHfUHpJ/3563-add-missing-ophan-click-tracking-on-https-supporttheguardiancom-uk-support-ctas)) and the "See gift/personal subscription" buttons on https://support.theguardian.com/uk/subscribe/weekly and https://support.theguardian.com/uk/subscribe/digital ([Trello card](https://trello.com/c/CMuWYWfE/3568-track-clicks-on-the-see-gift-subscriptions-see-personal-subscriptions-ctas-in-ophan)).

## Why are you doing this?

More tracking capabilities on our components