### PR TITLE
add paymentid field to data that we send to bigquery in real time

### DIFF
--- a/support-modules/bigquery/src/main/scala/com/gu/support/acquisitions/AcquisitionDataRow.scala
+++ b/support-modules/bigquery/src/main/scala/com/gu/support/acquisitions/AcquisitionDataRow.scala
@@ -31,6 +31,7 @@ case class AcquisitionDataRow(
   zuoraSubscriptionNumber: Option[String],
   zuoraAccountNumber: Option[String],
   contributionId: Option[String],
+  paymentId: Option[String],
   queryParameters: List[QueryParameter],
   platform: Option[String]
 )

--- a/support-modules/bigquery/src/main/scala/com/gu/support/acquisitions/AcquisitionDataRowMapper.scala
+++ b/support-modules/bigquery/src/main/scala/com/gu/support/acquisitions/AcquisitionDataRowMapper.scala
@@ -29,7 +29,8 @@ object AcquisitionDataRowMapper {
       acquisition.campaignCode.map("campaign_codes" -> List(_).asJava),
       acquisition.zuoraAccountNumber.map("zuora_account_number" -> _),
       acquisition.zuoraSubscriptionNumber.map("zuora_subscription_number" -> _),
-      acquisition.contributionId.map("contribution_id" -> _)
+      acquisition.contributionId.map("contribution_id" -> _),
+      acquisition.paymentId.map("payment_id" -> _)
     ).flatten.toMap
 
     (Map(

--- a/support-payment-api/src/main/scala/model/acquisition/AcquisitionDataRowBuilder.scala
+++ b/support-payment-api/src/main/scala/model/acquisition/AcquisitionDataRowBuilder.scala
@@ -46,6 +46,7 @@ object AcquisitionDataRowBuilder {
       zuoraSubscriptionNumber = None,
       zuoraAccountNumber = None,
       contributionId = Some(contributionData.contributionId.toString),
+      paymentId = Some(contributionData.paymentId),
       queryParameters = mapQueryParams(acquisitionData.queryParameters),
       platform = acquisitionData.platform
     )
@@ -82,6 +83,7 @@ object AcquisitionDataRowBuilder {
       zuoraSubscriptionNumber = None,
       zuoraAccountNumber = None,
       contributionId = Some(contributionData.contributionId.toString),
+      paymentId = Some(contributionData.paymentId),
       queryParameters = mapQueryParams(acquisitionData.flatMap(_.queryParameters)),
       platform = acquisitionData.flatMap(_.platform)
     )
@@ -119,6 +121,7 @@ object AcquisitionDataRowBuilder {
       zuoraSubscriptionNumber = None,
       zuoraAccountNumber = None,
       contributionId = Some(contributionData.contributionId.toString),
+      paymentId = Some(contributionData.paymentId),
       queryParameters = mapQueryParams(acquisitionData.queryParameters),
       platform = acquisitionData.platform
     )

--- a/support-workers/src/main/scala/com/gu/acquisitions/AcquisitionDataRowBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/acquisitions/AcquisitionDataRowBuilder.scala
@@ -50,6 +50,7 @@ object AcquisitionDataRowBuilder {
       zuoraSubscriptionNumber = acquisitionTypeDetails.zuoraSubscriptionNumber,
       zuoraAccountNumber = acquisitionTypeDetails.zuoraAccountNumber,
       contributionId = None,
+      paymentId = None,
       queryParameters = state.acquisitionData.map(getQueryParameters).getOrElse(Nil),
       platform = None
     )

--- a/support-workers/src/test/scala/com/gu/acquisitions/BigQuerySpec.scala
+++ b/support-workers/src/test/scala/com/gu/acquisitions/BigQuerySpec.scala
@@ -72,7 +72,7 @@ class BigQuerySpec extends AsyncFlatSpec with Matchers with LazyLogging {
       reusedExistingPaymentMethod = false,
       Direct,
       Purchase,
-      Some("subscription number"), Some("account number"), Some("contributionId"),
+      Some("subscription number"), Some("account number"), Some("contributionId"), Some("paymentId1234"),
       List(QueryParameter("foo", "bar")),
       None
     )


### PR DESCRIPTION


## What are you doing in this PR?

This PR adds the new payment_id field to the data we send to the real time acquisitions data store.

Data tech team had to  the field to the PROD datatech-platform-prod.datalake.fact_acquisition_event - Mike has done that.

https://trello.com/c/qgzqat0H/3579-add-paymentid-into-factacquisitionevent-for-single-contributions

## Why are you doing this?

This is needed to join to some other data stores.  Not totally sure what, but it has been requested by @jranks123 

