### PR TITLE
Do not use localstorage for AB tests

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtest.js
+++ b/support-frontend/assets/helpers/abTests/abtest.js
@@ -104,18 +104,6 @@ function getMvtId(): number {
   return mvtId;
 }
 
-function getLocalStorageParticipations(): Participations {
-
-  const abTests = storage.getLocal('gu.support.abTests');
-
-  return abTests ? JSON.parse(abTests) : {};
-
-}
-
-function setLocalStorageParticipations(participations: Participations): void {
-  storage.setLocal('gu.support.abTests', JSON.stringify(participations));
-}
-
 function getParticipationsFromUrl(): ?Participations {
 
   const hashUrl = (new URL(document.URL)).hash;
@@ -325,8 +313,12 @@ function getParticipations(
   return participations;
 }
 
+const allLandingPagesAndThankyouPages = '/??/contribute|thankyou(/.*)?$';
 function getAmountsTestParticipations(countryGroupId: CountryGroupId, settings: Settings): ?Participations {
   if (!settings.amounts) {
+    return null;
+  }
+  if (!targetPageMatches(window.location.pathname, allLandingPagesAndThankyouPages)) {
     return null;
   }
   const { test } = settings.amounts[countryGroupId];
@@ -353,17 +345,12 @@ const init = (
   const urlParticipations: ?Participations = getParticipationsFromUrl();
   const serverSideParticipations: ?Participations = getServerSideParticipations();
   const amountsTestParticipations: ?Participations = getAmountsTestParticipations(countryGroupId, settings);
-  const localStorageParticipations: Participations = getLocalStorageParticipations();
-  const combinedParticipations: Participations = {
+  return  {
     ...participations,
     ...serverSideParticipations,
     ...amountsTestParticipations,
-    ...localStorageParticipations,
     ...urlParticipations,
   };
-  setLocalStorageParticipations(combinedParticipations);
-
-  return combinedParticipations;
 };
 
 const getVariantsAsString = (participation: Participations): string => {
@@ -376,13 +363,10 @@ const getVariantsAsString = (participation: Participations): string => {
   return variants.join('; ');
 };
 
-const getCurrentParticipations = (): Participations => getLocalStorageParticipations();
-
 // ----- Exports ----- //
 
 export {
   init,
   getVariantsAsString,
-  getCurrentParticipations,
   targetPageMatches,
 };

--- a/support-frontend/assets/helpers/abTests/abtest.js
+++ b/support-frontend/assets/helpers/abTests/abtest.js
@@ -7,7 +7,6 @@ import type { IsoCountry } from 'helpers/internationalisation/country';
 import seedrandom from 'seedrandom';
 
 import * as cookie from 'helpers/cookie';
-import * as storage from 'helpers/storage';
 import { type Settings } from 'helpers/settings';
 import { type CountryGroupId } from 'helpers/internationalisation/countryGroup';
 
@@ -345,7 +344,7 @@ const init = (
   const urlParticipations: ?Participations = getParticipationsFromUrl();
   const serverSideParticipations: ?Participations = getServerSideParticipations();
   const amountsTestParticipations: ?Participations = getAmountsTestParticipations(countryGroupId, settings);
-  return  {
+  return {
     ...participations,
     ...serverSideParticipations,
     ...amountsTestParticipations,

--- a/support-frontend/test/selenium/contributions/OneOffContributionsSpec.scala
+++ b/support-frontend/test/selenium/contributions/OneOffContributionsSpec.scala
@@ -22,11 +22,6 @@ class OneOffContributionsSpec extends AnyFeatureSpec
 
   before {
     driverConfig.reset()
-    // TODO - change tests to support new Stripe Elements UI
-    webDriver.asInstanceOf[JavascriptExecutor].executeScript(
-      """window.localStorage.setItem('gu.support.abTests',""" +
-        """'{"stripeElements":"control"}')"""
-    )
   }
 
   override def beforeAll(): Unit = {


### PR DESCRIPTION
Currently we're storing AB test participations in local storage, and reading them for every page view. This is actually wrong as it may bring back tests that are no longer running.
There is no reason for storing the participations in local storage, as we can recompute on each page load, and it should be deterministic because it's based on mvt value.

This PR also ensures only contributions pages are assigned an amounts test variant.