### PR TITLE
Extend existing list component for use in print & digital checkout

### DIFF
--- a/support-frontend/assets/components/list/list.jsx
+++ b/support-frontend/assets/components/list/list.jsx
@@ -15,6 +15,7 @@ export type ListItemText = {
 type ListBulletSize = 'small' | 'large';
 
 type ListBulletColour = 'light' | 'dark';
+
 type ListProps = {
   items: ListItemText[],
   bulletSize?: ListBulletSize,
@@ -97,6 +98,7 @@ const bulletSizes: { [key: ListBulletSize]: string } = {
   large: listItemBulletLarge,
   small: listItemBulletSmall,
 };
+
 function ListItem({ item, colour, size }: ListItemProps) {
   return (
     <li key={item.explainer} css={listItem}>

--- a/support-frontend/assets/components/list/list.jsx
+++ b/support-frontend/assets/components/list/list.jsx
@@ -8,7 +8,7 @@ import { from } from '@guardian/src-foundations/mq';
 import { body } from '@guardian/src-foundations/typography';
 
 export type ListItemText = {
-  explainer: string,
+  content: string,
   subText?: string
 }
 
@@ -101,14 +101,14 @@ const bulletSizes: { [key: ListBulletSize]: string } = {
 
 function ListItem({ item, colour, size }: ListItemProps) {
   return (
-    <li key={item.explainer} css={listItem}>
+    <li key={item.content} css={listItem}>
       <span css={[
         listItemBullet,
         bulletColours[colour],
         bulletSizes[size],
       ]}
       />
-      <span css={listItemContent}>{item.explainer}</span>
+      <span css={listItemContent}>{item.content}</span>
     </li>
   );
 }
@@ -120,7 +120,7 @@ ListItem.defaultProps = {
 
 function ListItemWithSubtext({ item, colour, size }: ListItemProps) {
   return (
-    <li key={item.explainer} css={listItem}>
+    <li key={item.content} css={listItem}>
       <span css={[
         listItemBullet,
         bulletColours[colour],
@@ -128,7 +128,7 @@ function ListItemWithSubtext({ item, colour, size }: ListItemProps) {
       ]}
       />
       <div css={listItemContent}>
-        <span css={listItemMainText}>{item.explainer}</span>
+        <span css={listItemMainText}>{item.content}</span>
         {item.subText && <span>{item.subText}</span>}
       </div>
     </li>

--- a/support-frontend/assets/components/list/list.jsx
+++ b/support-frontend/assets/components/list/list.jsx
@@ -15,7 +15,7 @@ export type ListItemText = {
 type ListBulletSize = 'small' | 'large';
 
 type ListBulletColour = 'light' | 'dark';
-type ListPropTypes = {
+type ListProps = {
   items: ListItemText[],
   bulletSize?: ListBulletSize,
   bulletColour?: ListBulletColour,
@@ -23,7 +23,7 @@ type ListPropTypes = {
 }
 
 type ListItemProps = {
-  item: Object,
+  item: ListItemText,
   size: ListBulletSize,
   colour: ListBulletColour,
 }
@@ -138,36 +138,28 @@ ListItemWithSubtext.defaultProps = {
   colour: 'light',
 };
 
-function List(props: ListPropTypes) {
-  return (
-    <ul css={[list, props.cssOverrides]}>
-      {props.items.map(item => (
-        <ListItem item={item} colour={props.bulletColour} size={props.bulletSize} />
-    ))}
-    </ul>
-  );
+function ListWith(ListItemComponent: React$ComponentType<ListItemProps>) {
+  function ListComponent(props: ListProps) {
+    return (
+      <ul css={[list, props.cssOverrides]}>
+        {props.items.map(item => (
+          <ListItemComponent item={item} colour={props.bulletColour || 'light'} size={props.bulletSize || 'large'} />
+        ))}
+      </ul>
+    );
+  }
+
+  ListComponent.defaultProps = {
+    bulletSize: 'large',
+    bulletColour: 'light',
+    cssOverrides: '',
+  };
+
+  return ListComponent;
 }
 
-List.defaultProps = {
-  bulletSize: 'large',
-  bulletColour: 'light',
-  cssOverrides: '',
-};
+const List = ListWith(ListItem);
 
-function ListWithSubText(props: ListPropTypes) {
-  return (
-    <ul css={[list, props.cssOverrides]}>
-      {props.items.map(item => (
-        <ListItemWithSubtext item={item} colour={props.bulletColour} size={props.bulletSize} />
-    ))}
-    </ul>
-  );
-}
-
-ListWithSubText.defaultProps = {
-  bulletSize: 'large',
-  bulletColour: 'light',
-  cssOverrides: '',
-};
+const ListWithSubText = ListWith(ListItemWithSubtext);
 
 export { List, ListWithSubText };

--- a/support-frontend/assets/components/list/list.jsx
+++ b/support-frontend/assets/components/list/list.jsx
@@ -2,13 +2,29 @@
 
 import React from 'react';
 import { css } from '@emotion/core';
-import { brandAlt } from '@guardian/src-foundations/palette';
+import { brand, brandAlt } from '@guardian/src-foundations/palette';
 import { space } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
-import { body } from '@guardian/src-foundations/typography';
+import { body, textSans } from '@guardian/src-foundations/typography';
 
+type ListItemText = {
+  explainer: string,
+  subText?: string
+}
+
+type ListBulletSize = 'small' | 'large';
+
+type ListBulletColour = 'light' | 'dark';
 type ListPropTypes = {
-  items: Array<Object>,
+  items: ListItemText[],
+  bulletSize?: ListBulletSize,
+  bulletColour?: ListBulletColour,
+}
+
+type ListItemProps = {
+  item: Object,
+  size: ListBulletSize,
+  colour: ListBulletColour,
 }
 
 const list = css`
@@ -31,16 +47,33 @@ const listItem = css`
 
 const listItemBullet = css`
   display: inline-block;
+  border-radius: 50%;
+  /* Sit the bullet in the vertical centre of the first line */
+  margin-top: calc((1.5em - ${space[3]}px) / 2);
+`;
+
+const listItemBulletLarge = css`
   width: ${space[3]}px;
   height: ${space[3]}px;
-  border-radius: 50%;
-  background-color: ${brandAlt[400]};
-  margin-top: ${space[1]}px;
 
   ${from.tablet} {
+    margin-top: calc((1.5em - ${space[4]}px) / 2);
     width: ${space[4]}px;
     height: ${space[4]}px;
   }
+`;
+
+const listItemBulletSmall = css`
+  width: ${space[3]}px;
+  height: ${space[3]}px;
+`;
+
+const listItemBulletLight = css`
+  background-color: ${brandAlt[400]};
+`;
+
+const listItemBulletDark = css`
+  background-color: ${brand[400]};
 `;
 
 const listItemContent = css`
@@ -49,17 +82,93 @@ const listItemContent = css`
   max-width: 90%;
 `;
 
-function List({ items }: ListPropTypes) {
+const listItemContentSans = css`
+  ${textSans.medium()};
+`;
+
+const listItemMainText = css`
+  display: block;
+  font-weight: 700;
+`;
+
+const bulletColours: { [key: ListBulletColour]: string } = {
+  light: listItemBulletLight,
+  dark: listItemBulletDark,
+};
+
+const bulletSizes: { [key: ListBulletSize]: string } = {
+  large: listItemBulletLarge,
+  small: listItemBulletSmall,
+};
+function ListItem({ item, colour, size }: ListItemProps) {
+  return (
+    <li key={item.explainer} css={listItem}>
+      <span css={[
+        listItemBullet,
+        bulletColours[colour],
+        bulletSizes[size],
+      ]}
+      />
+      <span css={listItemContent}>{item.explainer}</span>
+    </li>
+  );
+}
+
+ListItem.defaultProps = {
+  size: 'large',
+  colour: 'light',
+};
+
+function ListItemWithSubtext({ item, colour, size }: ListItemProps) {
+  return (
+    <li key={item.explainer} css={listItem}>
+      <span css={[
+        listItemBullet,
+        bulletColours[colour],
+        bulletSizes[size],
+      ]}
+      />
+      <div css={[listItemContent, listItemContentSans]}>
+        <span css={listItemMainText}>{item.explainer}</span>
+        {item.subText && <span>{item.subText}</span>}
+      </div>
+    </li>
+  );
+}
+
+ListItemWithSubtext.defaultProps = {
+  size: 'large',
+  colour: 'light',
+};
+
+function List(props: ListPropTypes) {
   return (
     <ul css={list}>
-      {items.map(item => (
-        <li css={listItem}>
-          <span css={listItemBullet} />
-          <span css={listItemContent}>{item.explainer}</span>
-        </li>
+      {props.items.map(item => (
+        <ListItem item={item} colour={props.bulletColour} size={props.bulletSize} />
     ))}
     </ul>
   );
 }
 
-export default List;
+List.defaultProps = {
+  bulletSize: 'large',
+  bulletColour: 'light',
+};
+
+function ListWithSubText(props: ListPropTypes) {
+  return (
+    <ul css={list}>
+      {props.items.map(item => (
+        <ListItemWithSubtext item={item} colour={props.bulletColour} size={props.bulletSize} />
+    ))}
+    </ul>
+  );
+}
+
+ListWithSubText.defaultProps = {
+  bulletSize: 'large',
+  bulletColour: 'light',
+};
+
+export { List, ListWithSubText };

--- a/support-frontend/assets/components/list/list.jsx
+++ b/support-frontend/assets/components/list/list.jsx
@@ -5,9 +5,9 @@ import { css } from '@emotion/core';
 import { brand, brandAlt } from '@guardian/src-foundations/palette';
 import { space } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
-import { body, textSans } from '@guardian/src-foundations/typography';
+import { body } from '@guardian/src-foundations/typography';
 
-type ListItemText = {
+export type ListItemText = {
   explainer: string,
   subText?: string
 }
@@ -19,6 +19,7 @@ type ListPropTypes = {
   items: ListItemText[],
   bulletSize?: ListBulletSize,
   bulletColour?: ListBulletColour,
+  cssOverrides?: string,
 }
 
 type ListItemProps = {
@@ -28,6 +29,7 @@ type ListItemProps = {
 }
 
 const list = css`
+  ${body.medium()};
   margin: 0 0 20px;
 
   ${from.desktop} {
@@ -77,13 +79,8 @@ const listItemBulletDark = css`
 `;
 
 const listItemContent = css`
-  ${body.medium()};
   margin-left: ${space[2]}px;
   max-width: 90%;
-`;
-
-const listItemContentSans = css`
-  ${textSans.medium()};
 `;
 
 const listItemMainText = css`
@@ -128,7 +125,7 @@ function ListItemWithSubtext({ item, colour, size }: ListItemProps) {
         bulletSizes[size],
       ]}
       />
-      <div css={[listItemContent, listItemContentSans]}>
+      <div css={listItemContent}>
         <span css={listItemMainText}>{item.explainer}</span>
         {item.subText && <span>{item.subText}</span>}
       </div>
@@ -143,7 +140,7 @@ ListItemWithSubtext.defaultProps = {
 
 function List(props: ListPropTypes) {
   return (
-    <ul css={list}>
+    <ul css={[list, props.cssOverrides]}>
       {props.items.map(item => (
         <ListItem item={item} colour={props.bulletColour} size={props.bulletSize} />
     ))}
@@ -154,11 +151,12 @@ function List(props: ListPropTypes) {
 List.defaultProps = {
   bulletSize: 'large',
   bulletColour: 'light',
+  cssOverrides: '',
 };
 
 function ListWithSubText(props: ListPropTypes) {
   return (
-    <ul css={list}>
+    <ul css={[list, props.cssOverrides]}>
       {props.items.map(item => (
         <ListItemWithSubtext item={item} colour={props.bulletColour} size={props.bulletSize} />
     ))}
@@ -169,6 +167,7 @@ function ListWithSubText(props: ListPropTypes) {
 ListWithSubText.defaultProps = {
   bulletSize: 'large',
   bulletColour: 'light',
+  cssOverrides: '',
 };
 
 export { List, ListWithSubText };

--- a/support-frontend/assets/components/orderSummary/orderSummaryProduct.jsx
+++ b/support-frontend/assets/components/orderSummary/orderSummaryProduct.jsx
@@ -1,10 +1,9 @@
 // @flow
 import React from 'react';
 import { css } from '@emotion/core';
-import { headline } from '@guardian/src-foundations/typography';
+import { headline, textSans } from '@guardian/src-foundations/typography';
 import { space } from '@guardian/src-foundations';
 import { neutral } from '@guardian/src-foundations/palette';
-import { textSans } from '@guardian/src-foundations/typography';
 import { ListWithSubText, type ListItemText } from 'components/list/list';
 
 const container = css`

--- a/support-frontend/assets/components/orderSummary/orderSummaryProduct.jsx
+++ b/support-frontend/assets/components/orderSummary/orderSummaryProduct.jsx
@@ -1,9 +1,11 @@
 // @flow
 import React from 'react';
 import { css } from '@emotion/core';
-import { headline, textSans } from '@guardian/src-foundations/typography';
+import { headline } from '@guardian/src-foundations/typography';
 import { space } from '@guardian/src-foundations';
-import { brand, neutral } from '@guardian/src-foundations/palette';
+import { neutral } from '@guardian/src-foundations/palette';
+import { textSans } from '@guardian/src-foundations/typography';
+import { ListWithSubText, type ListItemText } from 'components/list/list';
 
 const container = css`
   &:not(:last-of-type) {
@@ -19,55 +21,20 @@ const title = css`
 
 const list = css`
   padding-top: ${space[2]}px;
-  padding-bottom: ${space[9]}px;
+  padding-left: ${space[2]}px;
+  ${textSans.medium()};
 `;
-
-const listItem = css`
-  margin: 0 ${space[9]}px;
-
-  &:not(:last-of-type) {
-    margin-bottom: ${space[4]}px;
-  }
-`;
-
-const listItemMain = css`
-  ${textSans.medium({ fontWeight: 'bold' })};
-
-  &::before {
-    display: inline-block;
-    content: '';
-    width: ${space[3]}px;
-    height: ${space[3]}px;
-    margin-right: -${space[3]}px;
-    border-radius: 50%;
-    background-color: ${brand[400]};
-    transform: translateX(-${space[6]}px);
-  }
-`;
-
-
-type ProductInfoItem = {
-  mainText: string,
-  subText?: string
-}
 
 type OrderSummaryProductProps = {
   productName: string,
-  productInfo: ProductInfoItem[]
+  productInfo: ListItemText[]
 }
 
 function OrderSummaryProduct(props: OrderSummaryProductProps) {
   return (
     <div css={container}>
       <h4 css={title}>{props.productName}</h4>
-      <ul css={list}>
-        {props.productInfo.map(infoItem => (
-          <li css={listItem}>
-            <div css={listItemMain}>{infoItem.mainText}</div>
-            <span>{infoItem.subText}</span>
-          </li>
-        ))}
-      </ul>
+      <ListWithSubText cssOverrides={list} items={props.productInfo} bulletSize="small" bulletColour="dark" />
     </div>
   );
 }

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.jsx
@@ -15,10 +15,10 @@ function Benefits() {
             <>
               <BenefitsHeading text="As a subscriber you’ll enjoy" />
               <List items={[
-                { explainer: 'Every issue delivered with up to 35% off the cover price' },
-                { explainer: 'Access to the magazine\'s digital archive' },
-                { explainer: 'A weekly email newsletter from the editor' },
-                { explainer: 'The very best of The Guardian\'s puzzles' },
+                { content: 'Every issue delivered with up to 35% off the cover price' },
+                { content: 'Access to the magazine\'s digital archive' },
+                { content: 'A weekly email newsletter from the editor' },
+                { content: 'The very best of The Guardian\'s puzzles' },
               ]}
               />
             </>

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/benefits.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react';
-import List from 'components/list/list';
+import { List } from 'components/list/list';
 import BenefitsContainer from './benefitsContainer';
 import BenefitsHeading from './benefitsHeading';
 

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/giftBenefits.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/giftBenefits.jsx
@@ -17,9 +17,9 @@ function GiftBenefits() {
             <>
               <BenefitsHeading text="What they'll get" />
               <List items={[
-                { explainer: 'The Guardian Weekly delivered, wherever they are in the world' },
-                { explainer: 'The Guardian\'s global journalism to keep them informed' },
-                { explainer: 'The very best of The Guardian\'s puzzles' },
+                { content: 'The Guardian Weekly delivered, wherever they are in the world' },
+                { content: 'The Guardian\'s global journalism to keep them informed' },
+                { content: 'The very best of The Guardian\'s puzzles' },
               ]}
               />
             </>
@@ -31,9 +31,9 @@ function GiftBenefits() {
             <>
               <BenefitsHeading text="What you'll get" />
               <List items={[
-                { explainer: 'Your gift supports The Guardian\'s independent journalism' },
-                { explainer: 'Access to the magazine\'s digital archive' },
-                { explainer: '35% off the cover price' },
+                { content: 'Your gift supports The Guardian\'s independent journalism' },
+                { content: 'Access to the magazine\'s digital archive' },
+                { content: '35% off the cover price' },
               ]}
               />
             </>

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/content/giftBenefits.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/content/giftBenefits.jsx
@@ -1,7 +1,7 @@
 // @flow
 
 import React from 'react';
-import List from 'components/list/list';
+import { List } from 'components/list/list';
 
 import BenefitsContainer from './benefitsContainer';
 import BenefitsHeading from './benefitsHeading';

--- a/support-frontend/stories/checkouts.jsx
+++ b/support-frontend/stories/checkouts.jsx
@@ -35,17 +35,17 @@ stories.add('Date Picker', () => {
 stories.add('Order Summary', () => {
   const productInfoPaper = [
     {
-      explainer: 'You\'ll pay £57.99/month',
+      content: 'You\'ll pay £57.99/month',
     },
     {
-      explainer: 'Your first payment will be on 04 February 2021',
+      content: 'Your first payment will be on 04 February 2021',
       subText: 'Your subscription card will arrive in the post before the payment date',
     },
   ];
 
   const productInfoDigiSub = [
     {
-      explainer: 'You\'ll pay £5/month',
+      content: 'You\'ll pay £5/month',
     },
   ];
 

--- a/support-frontend/stories/checkouts.jsx
+++ b/support-frontend/stories/checkouts.jsx
@@ -35,17 +35,17 @@ stories.add('Date Picker', () => {
 stories.add('Order Summary', () => {
   const productInfoPaper = [
     {
-      mainText: 'You\'ll pay £57.99/month',
+      explainer: 'You\'ll pay £57.99/month',
     },
     {
-      mainText: 'Your first payment will be on 04 February 2021',
+      explainer: 'Your first payment will be on 04 February 2021',
       subText: 'Your subscription card will arrive in the post before the payment date',
     },
   ];
 
   const productInfoDigiSub = [
     {
-      mainText: 'You\'ll pay £5/month',
+      explainer: 'You\'ll pay £5/month',
     },
   ];
 

--- a/support-frontend/stories/content.jsx
+++ b/support-frontend/stories/content.jsx
@@ -4,18 +4,30 @@
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 
-import List from 'components/list/list';
+import { List, ListWithSubText } from 'components/list/list';
 import Tabs from 'components/tabs/tabs';
 
 const stories = storiesOf('Content components', module);
 
 stories.add('List', () => (
-  <List items={[
-    { explainer: 'This is a list' },
-    { explainer: 'You can put items in it, even if they\'re long sentences that will definitely overflow and wrap on mobile' },
-    { explainer: 'It\'s very nice' },
-  ]}
-  />
+  <div style={{ padding: '8px' }}>
+    <List items={[
+      { explainer: 'This is a list' },
+      { explainer: 'You can put items in it, even if they\'re long sentences that will definitely overflow and wrap on mobile' },
+      { explainer: 'It\'s very nice' },
+    ]}
+    />
+
+    <ListWithSubText
+      bulletColour="dark"
+      bulletSize="small"
+      items={[
+      { explainer: 'This is a list', subText: 'With optional sub text' },
+      { explainer: 'It\'s useful in several situations', subText: 'Like when you want to add extra information for each list item' },
+      { explainer: 'But you don\'t have to use it' },
+    ]}
+    />
+  </div>
 ));
 
 stories.add('Tabs', () => {

--- a/support-frontend/stories/content.jsx
+++ b/support-frontend/stories/content.jsx
@@ -12,9 +12,9 @@ const stories = storiesOf('Content components', module);
 stories.add('List', () => (
   <div style={{ padding: '8px' }}>
     <List items={[
-      { explainer: 'This is a list' },
-      { explainer: 'You can put items in it, even if they\'re long sentences that will definitely overflow and wrap on mobile' },
-      { explainer: 'It\'s very nice' },
+      { content: 'This is a list' },
+      { content: 'You can put items in it, even if they\'re long sentences that will definitely overflow and wrap on mobile' },
+      { content: 'It\'s very nice' },
     ]}
     />
 
@@ -22,9 +22,9 @@ stories.add('List', () => (
       bulletColour="dark"
       bulletSize="small"
       items={[
-      { explainer: 'This is a list', subText: 'With optional sub text' },
-      { explainer: 'It\'s useful in several situations', subText: 'Like when you want to add extra information for each list item' },
-      { explainer: 'But you don\'t have to use it' },
+      { content: 'This is a list', subText: 'With optional sub text' },
+      { content: 'It\'s useful in several situations', subText: 'Like when you want to add extra information for each list item' },
+      { content: 'But you don\'t have to use it' },
     ]}
     />
   </div>


### PR DESCRIPTION
## What are you doing in this PR?

This is an extension/improvement of the List component built for the Guardian Weekly page, to be able to re-use it in the print and digital checkout.

[**Trello Card**](https://trello.com/c/OSsIhbE0)

## Why are you doing this?

The new checkout design calls for bulleted lists in both the order summary and the 'add the digital subscription' CTA that have the same style and use of a secondary line of text, so it makes sense to have this be a single component. We already had a list component; this PR simply adds the ability to adjust the colour and size of the bullets, and inject a different component as the list item.

## Accessibility test checklist
 - [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
 - [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
 - [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

## Screenshots

**In Storybook - mobile**
![Screenshot 2021-02-04 at 10 47 54](https://user-images.githubusercontent.com/29146931/106882452-ac9df680-66d6-11eb-97cc-115d0f26a3de.png)

**In Storybook - desktop**
![Screenshot 2021-02-04 at 10 47 29](https://user-images.githubusercontent.com/29146931/106882484-b7588b80-66d6-11eb-950f-5b800ae98690.png)

**In the OrderSummary component**
![Screenshot 2021-02-04 at 10 48 14](https://user-images.githubusercontent.com/29146931/106882524-c2132080-66d6-11eb-8254-d9ac1dfb6f75.png)

**On Guardian Weekly landing page (no regression from what's currently there)**
![Screenshot 2021-02-04 at 10 48 31](https://user-images.githubusercontent.com/29146931/106882587-d6efb400-66d6-11eb-9dd7-dc87b31a97fd.png)