### PR TITLE
Copy for new digital subscription campaign

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/hero/hero.jsx
@@ -32,9 +32,8 @@ type PropTypes = {
 const HeroCopy = () => (
   <>
     <p css={paragraph}>
-      With two innovative apps and ad-free reading, a digital subscription
-      gives you the richest experience of Guardian journalism. It also sustains the independent
-      reporting you love.
+      We’re free to give voice to the voiceless. The unheard. The powerless.
+      Become a digital subscriber today and help to fund our vital work.
     </p>
   </>
 );
@@ -59,8 +58,8 @@ function CampaignHeader(props: PropTypes) {
       <h1 css={pageTitle}>Digital subscription</h1>
       <div css={featureContainer}>
         <div css={textSection}>
-          <h2 css={heroHeading}>Progressive journalism<br />
-            <span css={yellowHeading}>powered by you</span>
+          <h2 css={heroHeading}>Subscribe for stories<br />
+            <span css={yellowHeading}>that must be told</span>
           </h2>
           {props.countryGroupId === AUDCountries ? <HeroCopyAus /> : <HeroCopy />}
           <div css={props.countryGroupId !== AUDCountries ? spaceAfter : {}}>

--- a/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroStyles.js
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroStyles.js
@@ -96,6 +96,7 @@ export const featureContainer = css`
     justify-content: space-between;
     max-width: calc(100% - 110px);
     max-width: 1100px;
+    min-height: 365px;
   }
 
   ${from.leftCol} {


### PR DESCRIPTION
## What are you doing in this PR?

This adds new copy on the digital subscriptions landing page for the campaign launching on 8th Feb.

[**Trello Card**](https://trello.com/c/sRRjYm1h)

## Accessibility test checklist
 - [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
 - [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
 - [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

## Screenshots

Note that colours may look slightly different due to device/OS/browser differences. Devices are:

- Mobile: Galaxy S20/Android/Chrome
- Tablet: iPad 8th gen/iOS/Safari
- Desktop: Macbook Pro/macOS/Firefox

**Mobile**
![Screenshot 2021-02-04 at 17 16 11](https://user-images.githubusercontent.com/29146931/106930592-a37c4c00-670d-11eb-9517-4ca203966050.png)

**Tablet**
![Screenshot 2021-02-04 at 17 17 38](https://user-images.githubusercontent.com/29146931/106930625-ab3bf080-670d-11eb-8f6a-44852650ffa7.png)

**Desktop**
![Screenshot 2021-02-04 at 15 48 13](https://user-images.githubusercontent.com/29146931/106930658-b4c55880-670d-11eb-89d0-68fc4aa9b1ae.png)
