### PR TITLE
Use sudo for nginx setup-cert

### DIFF
--- a/support-frontend/setup.sh
+++ b/support-frontend/setup.sh
@@ -104,7 +104,7 @@ setup_nginx() {
   )
 
   for domain in ${DOMAINS[@]}; do
-    dev-nginx setup-cert $domain
+    sudo dev-nginx setup-cert $domain
   done
 
   dev-nginx link-config ${SITE_CONFIG}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This PR changed the `dev-nginx setup-cert` step to use sudo instead.

## Why are you doing this?
To avoid errors such as one below when installing. Not having this forces the developer to have to run all the setup commands manually from that point onwards.

## Screenshots
![image](https://user-images.githubusercontent.com/48949546/108196679-4a4ee800-7111-11eb-8457-40808abdc32e.png)

