### PR TITLE
Fix redemption of gift subs with recurring charge

### DIFF
--- a/support-services/src/main/scala/com/gu/support/catalog/CatalogService.scala
+++ b/support-services/src/main/scala/com/gu/support/catalog/CatalogService.scala
@@ -4,7 +4,8 @@ import com.gu.aws.{AwsCloudWatchMetricPut, AwsCloudWatchMetricSetup}
 import com.gu.i18n.Currency
 import com.gu.support.catalog.GuardianWeekly.getProductRatePlan
 import com.gu.support.config.TouchPointEnvironment
-import com.gu.support.workers.{BillingPeriod, Quarterly, SixWeekly}
+import com.gu.support.workers.{Annual, BillingPeriod, Quarterly, SixWeekly}
+import com.gu.support.zuora.api.ReaderType.Gift
 import com.typesafe.scalalogging.LazyLogging
 
 object CatalogService {
@@ -62,8 +63,14 @@ class CatalogService(val environment: TouchPointEnvironment, jsonProvider: Catal
     }
   }
 
-  def getProductRatePlanFromId[T <: Product](product: T, id: ProductRatePlanId): Option[ProductRatePlan[Product]] =
-    product.ratePlans(environment).find(_.id == id)
+  def getProductRatePlanFromId[T <: Product](product: T, id: ProductRatePlanId): Option[ProductRatePlan[Product]] = {
+    // These can be removed when all gift subs have been switched over from the recurring charge to the one-time charge
+    val legacyDigitalGiftRatePlans = List(
+      ProductRatePlan("2c92a0ff73add07f0173b99f14390afc", Quarterly, NoFulfilmentOptions, NoProductOptions, "Digital Subscription Three Month Gift", readerType = Gift),
+      ProductRatePlan("2c92a00773adc09d0173b99e4ded7f45", Annual, NoFulfilmentOptions, NoProductOptions, "Digital Subscription One Year Gift", readerType = Gift)
+    )
+    (product.ratePlans(environment) ++ legacyDigitalGiftRatePlans).find(_.id == id)
+  }
 
   def getPrice[T <: Product](
     product: T,


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

We have had a number of failed redemptions for digital subscriptions since #2952. This is because during the redemption step support-workers needs to find the product rate plan by id to work out the length of the sub and since the old product rate plan ids were removed it can no longer do that. 

This PR just adds the old ids back in for the PROD environment in the method that does the lookup. As that method is only used for this one purpose there is minimal risk of confusion with the new product rate plans.

There is an example of a [failed execution here](https://eu-west-1.console.aws.amazon.com/states/home?region=eu-west-1#/executions/details/arn:aws:states:eu-west-1:865473395570:execution:support-workers-PROD:054a7a9b-b86b-4283-825c-5c86f6b6eb64)
