### PR TITLE
use bionic / arm AMI for support-logs proxy

### DIFF
--- a/support-logs/cfn.yaml
+++ b/support-logs/cfn.yaml
@@ -73,7 +73,7 @@ Resources:
     Type: AWS::EC2::Instance
     Properties:
         ImageId: !Ref AMI
-        InstanceType: t3.micro
+        InstanceType: t4g.micro
         IamInstanceProfile: !Ref KibanaProxyInstanceProfile
         BlockDeviceMappings:
         - DeviceName: /dev/sda1
@@ -119,7 +119,7 @@ Resources:
                     proxy_buffers 4 256k;
                     proxy_busy_buffers_size 256k;
                 }
-             
+
                 location ~ \/(log|sign|error|fav|forgot|change) {
                     # Forward requests to Cognito
                     proxy_pass https://subscription-logs.auth.eu-west-1.amazoncognito.com;

--- a/support-logs/riff-raff.yaml
+++ b/support-logs/riff-raff.yaml
@@ -8,4 +8,4 @@ deployments:
       templatePath: cfn.yaml
       amiTags:
         AmigoStage: PROD
-        Recipe: ubuntu-xenial-with-nginx
+        Recipe: ubuntu-bionic-arm-with-nginx


### PR DESCRIPTION
This PR adds ARM instance and uses bionic ubuntu for support-logs proxy.

This is needed because ubuntu xenial isn't supported by AWS any more so the amigo bakes don't work.  Also we might as well use ARM instances because they are cheaper.

Wait for the result of https://amigo.gutools.co.uk/recipes/ubuntu-bionic-arm-with-nginx/bakes/1 before merging.