### PR TITLE
Fix paragraph spacing on copy coming from promo codes

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/hero/hero.jsx
@@ -59,7 +59,7 @@ function CampaignHeader({ promotionCopy, countryGroupId }: PropTypes) {
   const title = promotionCopy.title || <>Subscribe for stories<br />
     <span css={yellowHeading}>that must be told</span></>;
 
-  const promoCopy = promotionHTML(promotionCopy.description, { css: paragraph, tag: 'p' });
+  const promoCopy = promotionHTML(promotionCopy.description, { css: paragraph, tag: 'div' });
 
   const roundelText = promotionHTML(promotionCopy.roundel, { css: circleTextGeneric }) ||
   <><span css={circleTextTop}>14 day</span>

--- a/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroStyles.js
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroStyles.js
@@ -156,6 +156,11 @@ export const paragraph = css`
   max-width: 100%;
   margin-bottom: ${space[9]}px;
 
+  /* apply the same margin to paragraphs parsed from markdown from promo codes */
+  & p:not(:last-of-type) {
+    margin-bottom: ${space[9]}px;
+  }
+
   ${from.mobileMedium} {
     ${body.medium()};
   }

--- a/support-frontend/assets/pages/paper-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/hero/hero.jsx
@@ -54,6 +54,12 @@ const heroTitleHighlight = css`
 const heroParagraph = css`
   ${body.medium({ lineHeight: 'loose' })}
   margin-bottom: ${space[6]}px;
+
+  /* apply the same margin to paragraphs parsed from markdown from promo codes */
+  & p:not(:last-of-type) {
+    margin-bottom: ${space[9]}px;
+  }
+  
   ${from.desktop} {
     max-width: 75%;
     margin-bottom: ${space[9]}px;

--- a/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-landing/components/hero/hero.jsx
@@ -48,6 +48,11 @@ const weeklyHeroTitle = css`
 const weeklyHeroParagraph = css`
   ${body.medium({ lineHeight: 'loose' })}
   margin-bottom: ${space[9]}px;
+
+  /* apply the same margin to paragraphs parsed from markdown from promo codes */
+  & p:not(:last-of-type) {
+    margin-bottom: ${space[9]}px;
+  }
 `;
 
 const roundelCentreLine = css`


### PR DESCRIPTION
## What are you doing in this PR?

This fixes the issue where paragraphs parsed from the markdown generated by the promo code tool did not show up with proper spacing in the hero on the digital subs landing page.

I've also applied the same fix across the other product landing pages.

## Screenshots

**Before**
![Screenshot_2021-02-26 Support the Guardian The Guardian Digital Subscription(1)](https://user-images.githubusercontent.com/29146931/109323808-c6e97100-784b-11eb-889a-6216ee8677b9.png)

**After**
![Screenshot_2021-02-26 Support the Guardian The Guardian Digital Subscription](https://user-images.githubusercontent.com/29146931/109323840-cf41ac00-784b-11eb-8dd6-cf89c94c4c16.png)

