### PR TITLE
Run `nvm use` in the foreground

### DIFF
--- a/support-frontend/devrun.sh
+++ b/support-frontend/devrun.sh
@@ -16,7 +16,7 @@ source_nvm() {
 
 source_nvm
 
-nvm use &
+nvm use
 yarn devrun &
 yarn storybook &
 cd ..; sbt -mem 2048 "project support-frontend" devrun


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Run `nvm use` in the foreground. I think by running it in the backgroud, we don't actually use the correct node version for the `yarn devrun` and `yarn storybook` commands - this fixes that! 
