### PR TITLE
Digital Subs - updating LP with product information

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/hero/hero.jsx
@@ -39,6 +39,10 @@ const HeroCopy = () => (
       We’re free to give voice to the voiceless. The unheard. The powerless.
       Become a digital subscriber today and help to fund our vital work.
     </p>
+    <p css={paragraph}>
+      With two innovative apps and ad-free reading, a digital subscription gives
+      you the richest experience of Guardian journalism.
+    </p>
   </>
 );
 
@@ -67,6 +71,7 @@ function CampaignHeader({ promotionCopy, countryGroupId }: PropTypes) {
 
   const defaultCopy = countryGroupId === AUDCountries ? <HeroCopyAus /> : <HeroCopy />;
   const copy = promoCopy || defaultCopy;
+  console.log({ promoCopy });
 
   return (
     <div css={wrapper}>

--- a/support-frontend/assets/pages/digital-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/hero/hero.jsx
@@ -71,7 +71,6 @@ function CampaignHeader({ promotionCopy, countryGroupId }: PropTypes) {
 
   const defaultCopy = countryGroupId === AUDCountries ? <HeroCopyAus /> : <HeroCopy />;
   const copy = promoCopy || defaultCopy;
-  console.log({ promoCopy });
 
   return (
     <div css={wrapper}>

--- a/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroStyles.js
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroStyles.js
@@ -154,10 +154,9 @@ export const yellowHeading = css`
 export const paragraph = css`
   ${body.small()};
   max-width: 100%;
-  margin-bottom: ${space[9]}px;
+  margin-bottom: ${space[5]}px;
 
-  /* apply the same margin to paragraphs parsed from markdown from promo codes */
-  & p:not(:last-of-type) {
+  :last-of-type {
     margin-bottom: ${space[9]}px;
   }
 


### PR DESCRIPTION
## What are you doing in this PR?
This is a small copy change on the hero of the digital subscriptions landing page. The change is for copy for all regions except Australia.

[**Trello Card**](https://trello.com/c/IiYiFqQN/3602-digital-subs-updating-lp-with-product-information)

## Why are you doing this?
To support the February campaign we need to update the digital subscriptions LP with product information.  

## Screenshots
![Screen Shot 2021-03-01 at 18 19 43](https://user-images.githubusercontent.com/16781258/109540694-bee33880-7aba-11eb-82b8-07b6b84cac8d.png)

