### PR TITLE
Allow outbound traffic from Wazuh scanner

### DIFF
--- a/support-frontend/cloud-formation/cfn.yaml
+++ b/support-frontend/cloud-formation/cfn.yaml
@@ -96,6 +96,7 @@ Resources:
       ImageId: !Ref AMI
       SecurityGroups:
         - !Ref InstanceSecurityGroup
+        - !Ref WazuhSecurityGroup
       InstanceType: !FindInMap [ StageVariables, !Ref Stage, InstanceType ]
       IamInstanceProfile: !Ref InstanceProfile
       AssociatePublicIpAddress: false
@@ -308,6 +309,17 @@ Resources:
           FromPort: 443
           ToPort: 443
           CidrIp: 0.0.0.0/0
+
+  WazuhSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId:
+        Ref: VpcId
+      SecurityGroupEgress:
+      - IpProtocol: tcp
+        FromPort: 1514
+        ToPort: 1515
+        CidrIp: 0.0.0.0/0
 
   NoHealthyInstancesAlarm:
     Type: AWS::CloudWatch::Alarm

--- a/support-frontend/cloud-formation/cfn.yaml
+++ b/support-frontend/cloud-formation/cfn.yaml
@@ -313,6 +313,7 @@ Resources:
   WazuhSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
+      GroupDescription: Allow outbound traffic from wazuh agent to manager
       VpcId:
         Ref: VpcId
       SecurityGroupEgress:


### PR DESCRIPTION
## What are you doing in this PR?

This is opening ports 1514 and 1515 for outbound traffic, which is currently restricted to port 443.

## Why are you doing this?

There's currently a major review of the guardian's security practices under the cyber security programme. One of the projects in this programme is to install a vulnerability scanner called Wazuh in guardian ec2 instances.

The scanner has already been installed in the ami image, but it's attempt to connect with the central server is being block by the instance security group. Hopefully this will fix it, otherwise I'll have to review network ACLs!

## Testing

Works in code ✅