### PR TITLE
Payment api: Patch in necessary permissions for wazuh

### DIFF
--- a/support-payment-api/src/main/resources/cloud-formation.yaml
+++ b/support-payment-api/src/main/resources/cloud-formation.yaml
@@ -392,6 +392,7 @@ Resources:
   WazuhSecurityGroup:
     Type: AWS::EC2::SecurityGroup
     Properties:
+      GroupDescription: Allow outbound traffic from wazuh agent to manager
       VpcId:
         Ref: VpcId
       SecurityGroupEgress:

--- a/support-payment-api/src/main/resources/cloud-formation.yaml
+++ b/support-payment-api/src/main/resources/cloud-formation.yaml
@@ -161,7 +161,9 @@ Resources:
     Type: AWS::AutoScaling::LaunchConfiguration
     Properties:
       ImageId: !Ref AMI
-      SecurityGroups: [!Ref InstanceSecurityGroup]
+      SecurityGroups:
+        - !Ref InstanceSecurityGroup
+        - !Ref WazuhSecurityGroup
       InstanceType: !FindInMap [ StageVariables, !Ref Stage, InstanceType ]
       IamInstanceProfile: !Ref InstanceProfile
       AssociatePublicIpAddress: false
@@ -273,7 +275,21 @@ Resources:
                     !Sub arn:aws:s3:::support-admin-console/CODE/*
                   ]
 
-
+  DescribeEC2Policy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: describe-ec2-policy
+      PolicyDocument:
+        Statement:
+        - Effect: Allow
+          Resource: "*"
+          Action:
+          - ec2:DescribeTags
+          - ec2:DescribeInstances
+          - autoscaling:DescribeAutoScalingGroups
+          - autoscaling:DescribeAutoScalingInstances
+      Roles:
+      - !Ref AppRole
 
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile
@@ -371,6 +387,17 @@ Resources:
         - IpProtocol: tcp
           FromPort: 5432
           ToPort: 5432
+          CidrIp: 0.0.0.0/0
+
+  WazuhSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      VpcId:
+        Ref: VpcId
+      SecurityGroupEgress:
+        - IpProtocol: tcp
+          FromPort: 1514
+          ToPort: 1515
           CidrIp: 0.0.0.0/0
 
   PaymentAPILogGroup:


### PR DESCRIPTION
## What are you doing in this PR?

* Open ports 1514 and 1515 for outbound traffic
* Give permission to the instance to call describe-tags,
   so the agent can identify itself in a human readable way with 
   the wazuh server.

## Why are you doing this?

There's currently a major review of the guardian's security practices under the cyber security programme. One of the projects in this programme is to install a vulnerability scanner called Wazuh in guardian ec2 instances.

The scanner has already been installed in the ami image, but it's attempt to connect with the central server is being block by the instance security group. Hopefully this will fix it, otherwise I'll have to review network ACLs!

## Testing

Works in code ✅
