### PR TITLE
Recurring reminders on the thank you page

### DIFF
--- a/support-frontend/assets/helpers/routes.js
+++ b/support-frontend/assets/helpers/routes.js
@@ -41,6 +41,8 @@ const routes: {
 
 const createOneOffReminderEndpoint = isProd() ?
   'https://support.theguardian.com/reminders/create/one-off' : 'https://support.code.dev-theguardian.com/reminders/create/one-off';
+const createRecurringReminderEndpoint = isProd() ?
+  'https://support.theguardian.com/reminders/create/recurring' : 'https://support.code.dev-theguardian.com/reminders/create/recurring';
 
 const countryPath = (countryGroupId: CountryGroupId) =>
   countryGroups[countryGroupId].supportInternationalisationId;
@@ -87,6 +89,7 @@ function payPalReturnUrl(cgId: CountryGroupId, email: string): string {
 export {
   routes,
   createOneOffReminderEndpoint,
+  createRecurringReminderEndpoint,
   postcodeLookupUrl,
   payPalCancelUrl,
   payPalReturnUrl,

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSupportReminder.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSupportReminder.jsx
@@ -92,7 +92,7 @@ const getDefaultLabel = (date: Date, monthsUntilDate: number, now: Date) => {
 
 const getRecurringReminderChoice = (): ReminderChoice => {
   const now = new Date();
-  const startMonth = now.getMonth() + (now.getDate() >= 20 ? 1 : 0); // TODO - is this right?
+  const startMonth = now.getMonth() + (now.getDate() >= 20 ? 2 : 1);
   const date = new Date(
     now.getFullYear(),
     startMonth,

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSupportReminder.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouSupportReminder.jsx
@@ -92,7 +92,7 @@ const getDefaultLabel = (date: Date, monthsUntilDate: number, now: Date) => {
 
 const getRecurringReminderChoice = (): ReminderChoice => {
   const now = new Date();
-  const startMonth = now.getMonth() + (now.getDate() >= 20 ? 2 : 1);
+  const startMonth = now.getMonth() + 1;
   const date = new Date(
     now.getFullYear(),
     startMonth,


### PR DESCRIPTION
Currently all users see this, even if they have signed up.
If a user is signed in then we could find out from MDAPI if they already have a reminder, but I'm leaving this to a follow up task.

A new option for monthly:
![Screen Shot 2021-03-10 at 11 32 26](https://user-images.githubusercontent.com/1513454/110623148-5d932780-8194-11eb-8092-16c8f017f2aa.png)


The recurring request:
![Screen Shot 2021-03-10 at 11 32 44](https://user-images.githubusercontent.com/1513454/110623158-608e1800-8194-11eb-9ca1-43d42e05eaad.png)


The single request still works:
![Screen Shot 2021-03-08 at 11 10 42](https://user-images.githubusercontent.com/1513454/110313906-09a30a00-7fff-11eb-95ae-2deeeda3e20c.png)
