### PR TITLE
Track "pricing options" CTA on Digital Subs landing page

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/hero/hero.jsx
@@ -9,6 +9,7 @@ import { Button, buttonBrand } from '@guardian/src-button';
 import { SvgArrowDownStraight } from '@guardian/src-icons';
 import { type CountryGroupId, AUDCountries } from 'helpers/internationalisation/countryGroup';
 import { promotionHTML, type PromotionCopy } from 'helpers/productPrice/promotions';
+import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
 
 import GridImage from 'components/gridImage/gridImage';
 import {
@@ -88,7 +89,15 @@ function CampaignHeader({ promotionCopy, countryGroupId }: PropTypes) {
                 size="default"
                 icon={<SvgArrowDownStraight />}
                 iconSide="right"
-                onClick={() => window.scrollTo(0, 1500)}
+                onClick={() => {
+                  sendTrackingEventsOnClick({
+                    id: 'options_cta_click',
+                    product: 'DigitalPack',
+                    componentType: 'ACQUISITIONS_BUTTON',
+                  })();
+
+                  window.scrollTo(0, 1500);
+                }}
               >
             See pricing options
               </Button>

--- a/support-frontend/assets/pages/digital-subscription-landing/components/heroGift/hero.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/heroGift/hero.jsx
@@ -11,6 +11,7 @@ import { type CountryGroupId, AUDCountries } from 'helpers/internationalisation/
 import { promotionHTML, type PromotionCopy } from 'helpers/productPrice/promotions';
 import GridImage from 'components/gridImage/gridImage';
 import GiftHeadingAnimation from 'components/animations/giftHeadingAnimation';
+import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
 import {
   wrapper,
   pageTitle,
@@ -53,7 +54,15 @@ function CampaignHeaderGift({ countryGroupId, promotionCopy }: PropTypes) {
               size="default"
               icon={<SvgArrowDownStraight />}
               iconSide="right"
-              onClick={() => window.scrollTo(0, 1500)}
+              onClick={() => {
+                sendTrackingEventsOnClick({
+                  id: 'options_cta_click',
+                  product: 'DigitalPack',
+                  componentType: 'ACQUISITIONS_BUTTON',
+                })();
+
+                window.scrollTo(0, 1500);
+              }}
             >
             See pricing options
             </Button>


### PR DESCRIPTION
## What are you doing in this PR?

We're not tracking clicks on the "pricing options" CTA on the Digital Subs landing page, this PR adds a tracking call in the click handler (for both the gifting and non-gifting landing pages).