### PR TITLE
Fix digital subscriptions hero styling

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroStyles.js
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroStyles.js
@@ -154,10 +154,16 @@ export const yellowHeading = css`
 export const paragraph = css`
   ${body.small()};
   max-width: 100%;
-  margin-bottom: ${space[5]}px;
+  margin-bottom: ${space[9]}px;
 
-  :last-of-type {
-    margin-bottom: ${space[9]}px;
+  // This applies to paras coming from the promo tool
+  & p:not(:last-of-type) {
+    margin-bottom: ${space[5]}px;
+  }
+
+  // This applies to default paragraphs in the hero
+  :not(:last-of-type) {
+    margin-bottom: ${space[5]}px;
   }
 
   ${from.mobileMedium} {


### PR DESCRIPTION
## What are you doing in this PR?
Fixing some spacing that went awry in this PR: https://github.com/guardian/support-frontend/pull/2966

## Why are you doing this?
This adds css that will work for text that comes in from the promo tool and also for the default text that's in support-frontend.

## Screenshots
### Text from the promo tool
![Screen Shot 2021-03-09 at 10 47 05](https://user-images.githubusercontent.com/16781258/110460823-9e246f80-80c6-11eb-8573-85845f434794.png)

### Default text
![Screen Shot 2021-03-09 at 11 00 37](https://user-images.githubusercontent.com/16781258/110460927-bac0a780-80c6-11eb-92e8-176b619fef0e.png)


