### PR TITLE
Send refViewId to ophan

### DIFF
--- a/support-frontend/assets/helpers/page/page.js
+++ b/support-frontend/assets/helpers/page/page.js
@@ -38,7 +38,7 @@ import {
   type CountryGroupId,
   detect as detectCountryGroup,
 } from 'helpers/internationalisation/countryGroup';
-import { trackAbTests } from 'helpers/tracking/ophan';
+import { trackAbTests, setRefViewId } from 'helpers/tracking/ophan';
 import { getSettings } from 'helpers/globals';
 import { getGlobal } from 'helpers/globals';
 import { isPostDeployUser } from 'helpers/user/user';
@@ -61,6 +61,7 @@ export type ReduxState<PageState> = {|
 
 // Sets up GA and logging.
 function analyticsInitialisation(participations: Participations): void {
+  setRefViewId();
   googleTagManager.init(participations);
   ophan.init();
   trackAbTests(participations);

--- a/support-frontend/assets/helpers/tracking/ophan.js
+++ b/support-frontend/assets/helpers/tracking/ophan.js
@@ -110,6 +110,8 @@ const trackAbTests = (participations: Participations): void =>
 
 // Set referring pageViewId in localstorage if it's not already there. This is picked up by ophan, see:
 // https://github.com/guardian/ophan/blob/75b86abcce07369c8998521399327d436246c016/tracker-js/assets/coffee/ophan/click-path-capture.coffee#L41
+// Note - the localstorage item is deleted by tracker-js as soon as it's read, see:
+// https://github.com/guardian/ophan/blob/75b86abcce07369c8998521399327d436246c016/tracker-js/assets/coffee/ophan/core.coffee#L72
 const setRefViewId = (): void => {
   const REFPVID = getQueryParameter('REFPVID');
   if (REFPVID && !localStorage.getItem('ophan_follow')) {

--- a/support-frontend/assets/helpers/tracking/ophan.js
+++ b/support-frontend/assets/helpers/tracking/ophan.js
@@ -3,6 +3,7 @@
 
 import * as ophan from 'ophan';
 import type { Participations, TestId } from 'helpers/abTests/abtest';
+import { getQueryParameter } from 'helpers/url';
 
 // ----- Types ----- //
 
@@ -107,8 +108,20 @@ const trackAbTests = (participations: Participations): void =>
     abTestRegister: buildOphanPayload(participations),
   });
 
+// Set referring pageViewId in localstorage if it's not already there. This is picked up by ophan, see:
+// https://github.com/guardian/ophan/blob/75b86abcce07369c8998521399327d436246c016/tracker-js/assets/coffee/ophan/click-path-capture.coffee#L41
+const setRefViewId = (): void => {
+  const REFPVID = getQueryParameter('REFPVID');
+  if (REFPVID && !localStorage.getItem('ophan_follow')) {
+    localStorage.setItem('ophan_follow', JSON.stringify({
+      refViewId: REFPVID,
+    }));
+  }
+};
+
 export {
   trackComponentEvents,
   pageView,
   trackAbTests,
+  setRefViewId,
 };


### PR DESCRIPTION
The pageview table in datalake has a `referrerPageViewId` column, but it is rarely populated for support pageviews.
This is because the existing mechanism in tracker-js relies on attaching an event listener to links, and adding the id to localstorage, see:
https://github.com/guardian/ophan/blob/75b86abcce07369c8998521399327d436246c016/tracker-js/assets/coffee/ophan/click-path-capture.coffee#L41

We reliably add the REFPVID param to the querystring, so this PR uses that to set the localstorage item if it's not already set.

Using localstorage isn't ideal, but it works and I'd prefer not to make changes in ophan.

Now the initial ophan event includes `refViewId`:
![Screen Shot 2021-03-10 at 11 01 09](https://user-images.githubusercontent.com/1513454/110620331-cd9fae80-8190-11eb-86aa-203fd0ae3d44.png)
