### PR TITLE
Add 40 character limit to state field in billing and delivery address form

### DIFF
--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.jsx
@@ -127,7 +127,7 @@ const applyBillingAddressRules = (fields: FormFields, addressType: AddressType):
     rule: checkStateFieldLength(fields.state),
     error: formError(
       'state',
-      fields.country === 'CA' ? 'Please enter a province/territory no longer than 40 characters' : 'Please enter a state name no longer than 40 characters',
+      fields.country === 'CA' ? `Please enter a ${addressType} province/territory no longer than 40 characters` : `Please enter a ${addressType} state name no longer than 40 characters`,
     ),
   },
 ]);

--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.jsx
@@ -82,7 +82,7 @@ const isStateNullable = (country: Option<IsoCountry>): boolean =>
   country !== 'AU' && country !== 'US' && country !== 'CA';
 
 const checkStateFieldLength = (state: string | null): boolean =>
-  state.length <= 40;
+  ((state == null) || (state.length <= 40));
 
 export const isHomeDeliveryInM25 = (
   fulfilmentOption: Option<FulfilmentOptions>,

--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.jsx
@@ -76,13 +76,11 @@ const getFormFields = (state: State): FormFields => ({
 const isPostcodeOptional = (country: Option<IsoCountry>): boolean =>
   country !== 'GB' && country !== 'AU' && country !== 'US' && country !== 'CA';
 
-const checkpostCodeLength = (input: string | null): boolean => ((input == null) || (input.length <= 20));
+const checkLength = (input: string | null, maxLength: number): boolean =>
+  ((input == null) || (input.length <= maxLength));
 
 const isStateNullable = (country: Option<IsoCountry>): boolean =>
   country !== 'AU' && country !== 'US' && country !== 'CA';
-
-const checkStateFieldLength = (state: string | null): boolean =>
-  ((state == null) || (state.length <= 40));
 
 export const isHomeDeliveryInM25 = (
   fulfilmentOption: Option<FulfilmentOptions>,
@@ -109,7 +107,7 @@ const applyBillingAddressRules = (fields: FormFields, addressType: AddressType):
     error: formError('postCode', `Please enter a ${addressType} postcode.`),
   },
   {
-    rule: checkpostCodeLength(fields.postCode),
+    rule: checkLength(fields.postCode, 20),
     error: formError('postCode', `Please enter a ${addressType} postcode no longer than 20 characters.`),
   },
   {
@@ -124,7 +122,7 @@ const applyBillingAddressRules = (fields: FormFields, addressType: AddressType):
     ),
   },
   {
-    rule: checkStateFieldLength(fields.state),
+    rule: checkLength(fields.state, 40),
     error: formError(
       'state',
       fields.country === 'CA' ? `Please enter a ${addressType} province/territory no longer than 40 characters` : `Please enter a ${addressType} state name no longer than 40 characters`,

--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.jsx
@@ -81,6 +81,9 @@ const checkpostCodeLength = (input: string | null): boolean => ((input == null) 
 const isStateNullable = (country: Option<IsoCountry>): boolean =>
   country !== 'AU' && country !== 'US' && country !== 'CA';
 
+const notMoreThan40Chars = (state: string | null): boolean =>
+  state.length <= 40;
+
 export const isHomeDeliveryInM25 = (
   fulfilmentOption: Option<FulfilmentOptions>,
   postcode: Option<string>,
@@ -118,6 +121,13 @@ const applyBillingAddressRules = (fields: FormFields, addressType: AddressType):
     error: formError(
       'state',
       fields.country === 'CA' ? `Please select a ${addressType} province/territory.` : `Please select a ${addressType} state.`,
+    ),
+  },
+  {
+    rule: notMoreThan40Chars(fields.state),
+    error: formError(
+      'state',
+      fields.country === 'CA' ? 'The province/territory name must be 40 characters or fewer' : 'The state name must be 40 characters or fewer',
     ),
   },
 ]);

--- a/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/address/addressFieldsStore.jsx
@@ -81,7 +81,7 @@ const checkpostCodeLength = (input: string | null): boolean => ((input == null) 
 const isStateNullable = (country: Option<IsoCountry>): boolean =>
   country !== 'AU' && country !== 'US' && country !== 'CA';
 
-const notMoreThan40Chars = (state: string | null): boolean =>
+const checkStateFieldLength = (state: string | null): boolean =>
   state.length <= 40;
 
 export const isHomeDeliveryInM25 = (
@@ -124,10 +124,10 @@ const applyBillingAddressRules = (fields: FormFields, addressType: AddressType):
     ),
   },
   {
-    rule: notMoreThan40Chars(fields.state),
+    rule: checkStateFieldLength(fields.state),
     error: formError(
       'state',
-      fields.country === 'CA' ? 'The province/territory name must be 40 characters or fewer' : 'The state name must be 40 characters or fewer',
+      fields.country === 'CA' ? 'Please enter a province/territory no longer than 40 characters' : 'Please enter a state name no longer than 40 characters',
     ),
   },
 ]);


### PR DESCRIPTION
## What are you doing in this PR?
Adding validation to the state / province / territory address field for billing and delivery addresses so they can't be longer than 40 characters.

[**Trello Card**](https://trello.com/c/Xn0mmPUu/3601-add-40-character-limit-to-state-field-in-billing-and-delivery-address-form-25)

## Why are you doing this?
There have been a number of issues with customer payments recently, in which state names that are longer than we can store have been submitted. We'd like to prevent this from happening.

## Accessibility test checklist
 - [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
 - [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
 - [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

## Screenshots
![Screen Shot 2021-03-10 at 12 51 19](https://user-images.githubusercontent.com/16781258/110633502-bbc60780-81a0-11eb-9e44-d9e720010e80.png)

![Screen Shot 2021-03-10 at 12 50 20](https://user-images.githubusercontent.com/16781258/110633519-c2547f00-81a0-11eb-93b8-80662a42be3b.png)

![Screen Shot 2021-03-10 at 12 54 10](https://user-images.githubusercontent.com/16781258/110633540-c8e2f680-81a0-11eb-8ca9-2604fda0bd9e.png)

![Screen Shot 2021-03-10 at 12 50 08](https://user-images.githubusercontent.com/16781258/110633554-cd0f1400-81a0-11eb-9010-d92ecd6efc9c.png)
