### PR TITLE
Add breakdown ab test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -3,9 +3,8 @@ import type { Tests } from './abtest';
 
 // ----- Tests ----- //
 
-const landingPage = '/??/contribute|thankyou(/.*)?$';
 const usLandingPage = '/us/contribute(/.*)?$';
-const allLandingPagesAndThankyouPages = '/??/contribute|thankyou(/.*)?$';
+const allLandingPagesAndThankyouPages = '/contribute|thankyou(/.*)?$';
 const notUkLandingPage = '/us|au|eu|int|nz|ca/contribute(/.*)?$';
 export const subsShowcaseAndDigiSubPages = '(/??/subscribe(\\?.*)?$|/??/subscribe/digital(\\?.*)?$)';
 
@@ -27,7 +26,7 @@ export const tests: Tests = {
     },
     isActive: true,
     referrerControlled: false,
-    targetPage: landingPage,
+    targetPage: allLandingPagesAndThankyouPages,
     seed: 1,
   },
 
@@ -95,5 +94,29 @@ export const tests: Tests = {
     referrerControlled: false,
     targetPage: usLandingPage,
     seed: 13,
+  },
+
+  landingPagePriceBreakdownTest: {
+    variants: [
+      {
+        id: 'control',
+      },
+      {
+        id: 'daily',
+      },
+      {
+        id: 'none',
+      },
+    ],
+    audiences: {
+      ALL: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: true,
+    referrerControlled: false,
+    targetPage: allLandingPagesAndThankyouPages,
+    seed: 14,
   },
 };

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
@@ -24,6 +24,8 @@ import { TextInput } from '@guardian/src-text-input';
 
 // ----- Types ----- //
 
+type BreakdownMode = "WEEKLY" | "DAILY" | "NONE";
+
 type PropTypes = {|
   countryGroupId: CountryGroupId,
   currency: IsoCurrency,
@@ -35,7 +37,18 @@ type PropTypes = {|
   updateOtherAmount: (string, CountryGroupId, ContributionType) => void,
   checkoutFormHasBeenSubmitted: boolean,
   stripePaymentRequestButtonClicked: boolean,
+  breakdownMode: BreakdownMode,
 |};
+
+const getBreakdownMode = (state: State): BreakdownMode => {
+  const variant = state.common.abParticipations.landingPagePriceBreakdownTest;
+  if (variant === 'control') {
+    return 'WEEKLY';
+  } else if (variant === 'daily') {
+    return 'DAILY';
+  }
+  return 'NONE';
+};
 
 
 const mapStateToProps = (state: State) => ({
@@ -49,6 +62,7 @@ const mapStateToProps = (state: State) => ({
   stripePaymentRequestButtonClicked:
     state.page.form.stripePaymentRequestButtonData.ONE_OFF.stripePaymentRequestButtonClicked ||
     state.page.form.stripePaymentRequestButtonData.REGULAR.stripePaymentRequestButtonClicked,
+  breakdownMode: getBreakdownMode(state),
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -81,7 +95,8 @@ const amountFormatted = (amount: number, currencyString: string, countryGroupId:
   return `${currencyString}${(amount).toFixed(2)}`;
 };
 
-export const getAmountPerWeekBreakdown = (
+const getAmountBreakdown = (
+  breakdownMode: BreakdownMode,
   contributionType: ContributionType,
   countryGroupId: CountryGroupId,
   selectedAmounts: SelectedAmounts,
@@ -90,15 +105,20 @@ export const getAmountPerWeekBreakdown = (
   const currencyString = currencies[detect(countryGroupId)].glyph;
   const amount = getAmount(selectedAmounts, otherAmounts, contributionType);
 
-  let weeklyAmount: number;
+  const breakdownIntervalsPerYear = breakdownMode === 'WEEKLY' ? 52.0 : 365.0;
+  let breakdownAmount: number;
   if (contributionType === 'ANNUAL') {
-    weeklyAmount = amount / 52.0;
+    breakdownAmount = amount / breakdownIntervalsPerYear;
   } else if (contributionType === 'MONTHLY') {
-    weeklyAmount = (amount * 12) / 52.0;
+    breakdownAmount = (amount * 12) / breakdownIntervalsPerYear;
   }
 
-  if (amount && weeklyAmount) {
-    return `Contributing ${currencyString}${amount} works out as ${amountFormatted(weeklyAmount, currencyString, countryGroupId)} each week`;
+  if ((amount && breakdownAmount)) {
+    return (`Contributing ${currencyString}${amount} works out as ${amountFormatted(
+      breakdownAmount,
+      currencyString,
+      countryGroupId,
+    )} ${breakdownMode === 'WEEKLY' ? 'each week' : 'a day'}`);
   }
 
   return '';
@@ -119,7 +139,7 @@ function withProps(props: PropTypes) {
   } = props;
 
   const showWeeklyBreakdown =
-    props.contributionType !== 'ONE_OFF';
+    props.contributionType !== 'ONE_OFF' && props.breakdownMode !== 'NONE';
 
   const canShowOtherAmountErrorMessage =
     checkoutFormHasBeenSubmitted || stripePaymentRequestButtonClicked || !!otherAmount;
@@ -164,7 +184,8 @@ function withProps(props: PropTypes) {
 
       {showWeeklyBreakdown ? (
         <p className="amount-per-week-breakdown">
-          {getAmountPerWeekBreakdown(
+          {getAmountBreakdown(
+            props.breakdownMode,
             props.contributionType,
             props.countryGroupId,
             props.selectedAmounts,


### PR DESCRIPTION
**DO NOT MERGE** before EOW (03/19)
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Add an ab test for messaging of price breakdown.

[**Trello Card**](https://trello.com/c/NqjaV1Xq/2574-landing-page-copy-test-x2)

## Screenshots

### control
<img width="636" alt="Screenshot 2021-03-15 at 12 16 19" src="https://user-images.githubusercontent.com/17720442/111152391-9104f600-8588-11eb-97eb-9869ba0e7c90.png">

### daily
<img width="636" alt="Screenshot 2021-03-15 at 15 10 01" src="https://user-images.githubusercontent.com/17720442/111175733-9e2ddf00-85a0-11eb-8386-ae277ee903cf.png">

### none
<img width="636" alt="Screenshot 2021-03-15 at 12 16 33" src="https://user-images.githubusercontent.com/17720442/111152395-92362300-8588-11eb-9bb7-554243495fe3.png">
