### PR TITLE
Show active navigation link even with query params in url 

### DIFF
--- a/support-frontend/assets/components/headers/links/links.jsx
+++ b/support-frontend/assets/components/headers/links/links.jsx
@@ -92,10 +92,14 @@ function internationalisationID(countryGroupId: ?CountryGroupId = null): ?string
 
 // Export
 
-const Links = ({ location, getRef, countryGroupId }: PropTypes) => (
-  <nav className={classNameWithModifiers('component-header-links', [location])}>
-    <ul className="component-header-links__ul" ref={getRef}>
-      {
+const Links = ({ location, getRef, countryGroupId }: PropTypes) => {
+  const { protocol, host, pathname } = window.location;
+  const urlWithoutParams = `${protocol}//${host}${pathname}`;
+
+  return (
+    <nav className={classNameWithModifiers('component-header-links', [location])}>
+      <ul className="component-header-links__ul" ref={getRef}>
+        {
         links.filter(({ include }) => {
 
         // If there is no country group ID for the link, return true and include the link in the rendering.
@@ -119,34 +123,30 @@ const Links = ({ location, getRef, countryGroupId }: PropTypes) => (
         return { ...link, href: `/${internationalisationIDValue}${link.href}` };
       }).map(({
         href, text, trackAs, opensInNewWindow, additionalClasses,
-      }) => {
-        const { protocol, host, pathname } = window.location;
-        const urlWithoutParams = `${protocol}//${host}${pathname}`;
-
-        return (
-          <li
-            className={cx(classNameWithModifiers(
+      }) => (
+        <li
+          className={cx(classNameWithModifiers(
                 'component-header-links__li',
                 [urlWithoutParams.endsWith(href) ? 'active' : null],
               ), additionalClasses)}
-          >
-            <a
-              onClick={sendTrackingEventsOnClick({
+        >
+          <a
+            onClick={sendTrackingEventsOnClick({
               id: ['header-link', trackAs, location].join(' - '),
               componentType: 'ACQUISITIONS_OTHER',
             })}
-              className="component-header-links__link"
-              href={href}
-              target={opensInNewWindow ? '_blank' : null}
-            >
-              {text}
-            </a>
-          </li>
-        );
-})}
-    </ul>
-  </nav>
-);
+            className="component-header-links__link"
+            href={href}
+            target={opensInNewWindow ? '_blank' : null}
+          >
+            {text}
+          </a>
+        </li>
+        ))}
+      </ul>
+    </nav>
+  );
+};
 
 Links.defaultProps = {
   getRef: null,

--- a/support-frontend/assets/components/headers/links/links.jsx
+++ b/support-frontend/assets/components/headers/links/links.jsx
@@ -119,26 +119,31 @@ const Links = ({ location, getRef, countryGroupId }: PropTypes) => (
         return { ...link, href: `/${internationalisationIDValue}${link.href}` };
       }).map(({
         href, text, trackAs, opensInNewWindow, additionalClasses,
-      }) => (
-        <li
-          className={cx(classNameWithModifiers(
+      }) => {
+        const { protocol, host, pathname } = window.location;
+        const urlWithoutParams = `${protocol}//${host}${pathname}`;
+
+        return (
+          <li
+            className={cx(classNameWithModifiers(
                 'component-header-links__li',
-                [window.location.href.endsWith(href) ? 'active' : null],
+                [urlWithoutParams.endsWith(href) ? 'active' : null],
               ), additionalClasses)}
-        >
-          <a
-            onClick={sendTrackingEventsOnClick({
+          >
+            <a
+              onClick={sendTrackingEventsOnClick({
               id: ['header-link', trackAs, location].join(' - '),
               componentType: 'ACQUISITIONS_OTHER',
             })}
-            className="component-header-links__link"
-            href={href}
-            target={opensInNewWindow ? '_blank' : null}
-          >
-            {text}
-          </a>
-        </li>
-        ))}
+              className="component-header-links__link"
+              href={href}
+              target={opensInNewWindow ? '_blank' : null}
+            >
+              {text}
+            </a>
+          </li>
+        );
+})}
     </ul>
   </nav>
 );


### PR DESCRIPTION
## What are you doing in this PR?

I noticed when clicking on traffic drivers (eg. Banners) from the main site to the Support site that the navigation didn't indicate the initial active page on which I had landed. This is because the logic to set the active state on a navigation link doesn't take into account query string parameters, which all our traffic driving CTAs use for tracking purposes. This PR addresses that so when you click on a traffic driving CTA the nav will show the active state (the yellow bar) on the appropriate link.

## Why are you doing this?

Gives users landing on our site a better indication of where they are in relation to the navigation.

## Screenshots

<img width="847" alt="Screenshot 2021-03-16 at 12 09 18" src="https://user-images.githubusercontent.com/1590704/111306835-9ded1c80-8650-11eb-9246-33bede541a8f.png">