### PR TITLE
Remove Google Analytics conditional check in-front of Tag Manager

### DIFF
--- a/support-frontend/assets/helpers/tracking/googleTagManager.js
+++ b/support-frontend/assets/helpers/tracking/googleTagManager.js
@@ -311,7 +311,7 @@ function init(participations: Participations) {
       * Update userConsentsToGTM value when
       * consent changes via the CMP library.
     */
-    userConsentsToGTM = thirdPartyTrackingConsent[googleTagManagerKey] && thirdPartyTrackingConsent[googleAnalyticsKey];
+    userConsentsToGTM = thirdPartyTrackingConsent[googleTagManagerKey];
 
     if (userConsentsToGTM) {
       if (!scriptAdded) {


### PR DESCRIPTION
## What are you doing in this PR?

This PR simplifies the conditional that checks whether we can use Google Tag Manager by removing the part that checks whether Google Analytics has been granted user consent. We can do this as we're now passing Google Analytics consent state to Tag Manager and making that conditional check in tag manager.