### PR TITLE
make support frontend use SSM tunnel for SSH access

### DIFF
--- a/support-frontend/README.md
+++ b/support-frontend/README.md
@@ -1,8 +1,8 @@
 Frontend for the new [supporter platform](https://support.theguardian.com/).
 
 ### SSH
-You must ssh via the bastion, e.g. using [ssm-scala](https://github.com/guardian/ssm-scala):
+Use SSM Tunnel - [ssm-scala](https://github.com/guardian/ssm-scala#enabling-ssm-tunnel):
 
 ```
-ssm ssh --profile membership --bastion-tags contributions-store-bastion,support,PROD --tags frontend,support,CODE -a -x --newest
+ssm ssh --profile membership --tags frontend,support,CODE -a -x --newest --ssm-tunnel
 ```

--- a/support-frontend/cloud-formation/cfn.yaml
+++ b/support-frontend/cloud-formation/cfn.yaml
@@ -140,13 +140,18 @@ Resources:
                 Action: s3:GetObject
                 Resource:
                   - !Sub arn:aws:s3:::support-admin-console/${Stage}/*
-        - PolicyName: UpdateSSHKeys
+        - PolicyName: SSMTunnel
           PolicyDocument:
             Version: 2012-10-17
             Statement:
               - Effect: Allow
-                Action: s3:GetObject
-                Resource: arn:aws:s3:::github-public-keys/Membership-and-Subscriptions/*
+                Action:
+                - ssm:UpdateInstanceInformation
+                - ssmmessages:CreateControlChannel
+                - ssmmessages:CreateDataChannel
+                - ssmmessages:OpenControlChannel
+                - ssmmessages:OpenDataChannel
+                Resource: '*'
         - PolicyName: SSMGet
           PolicyDocument:
             Version: 2012-10-17


### PR DESCRIPTION
Co authored with @i-hardy and @lucymonie 

## What are you doing in this PR?

This PR updates support-frontend to use SSM Tunnel
https://github.com/guardian/ssm-scala#enabling-ssm-tunnel


https://trello.com/c/mr8yEEdp/3634-switch-support-frontend-to-ssm

## Why are you doing this?

It's latest security best practice, it only relies on built in AWS infrastructure and AWS credentials.
