### PR TITLE
Set referrer url

### DIFF
--- a/support-frontend/assets/helpers/page/page.js
+++ b/support-frontend/assets/helpers/page/page.js
@@ -38,11 +38,12 @@ import {
   type CountryGroupId,
   detect as detectCountryGroup,
 } from 'helpers/internationalisation/countryGroup';
-import { trackAbTests, setRefViewId } from 'helpers/tracking/ophan';
+import { trackAbTests, setReferrerDataInLocalStorage } from 'helpers/tracking/ophan';
 import { getSettings } from 'helpers/globals';
 import { getGlobal } from 'helpers/globals';
 import { isPostDeployUser } from 'helpers/user/user';
 import { getAmounts } from 'helpers/abTests/helpers';
+import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 
 if (process.env.NODE_ENV === 'DEV') {
   // $FlowIgnore
@@ -60,8 +61,8 @@ export type ReduxState<PageState> = {|
 // ----- Functions ----- //
 
 // Sets up GA and logging.
-function analyticsInitialisation(participations: Participations): void {
-  setRefViewId();
+function analyticsInitialisation(participations: Participations, acquisitionData: ReferrerAcquisitionData): void {
+  setReferrerDataInLocalStorage(acquisitionData);
   googleTagManager.init(participations);
   ophan.init();
   trackAbTests(participations);
@@ -76,8 +77,8 @@ function buildInitialState(
   countryId: IsoCountry,
   currencyId: IsoCurrency,
   settings: Settings,
+  acquisitionData: ReferrerAcquisitionData,
 ): CommonState {
-  const acquisition = getReferrerAcquisitionData();
   const excludedParameters = ['REFPVID', 'INTCMP', 'acquisitionData'];
   const otherQueryParams = getAllQueryParamsWithExclusions(excludedParameters);
   const internationalisation = {
@@ -89,8 +90,8 @@ function buildInitialState(
   const amounts = getAmounts(settings, abParticipations, countryGroupId);
 
   return {
-    campaign: acquisition ? getCampaign(acquisition) : null,
-    referrerAcquisitionData: acquisition,
+    campaign: acquisitionData ? getCampaign(acquisitionData) : null,
+    referrerAcquisitionData: acquisitionData,
     otherQueryParams,
     internationalisation,
     abParticipations,
@@ -105,7 +106,8 @@ function statelessInit() {
   const country: IsoCountry = detectCountry();
   const countryGroupId: CountryGroupId = detectCountryGroup();
   const participations: Participations = abTest.init(country, countryGroupId, window.guardian.settings);
-  analyticsInitialisation(participations);
+  const acquisitionData = getReferrerAcquisitionData();
+  analyticsInitialisation(participations, acquisitionData);
 }
 
 // Enables redux devtools extension and optional redux-thunk.
@@ -145,11 +147,13 @@ function init<S, A>(
       });
     }
 
+    const acquisitionData = getReferrerAcquisitionData();
+
     const settings = getSettings();
     const countryGroupId: CountryGroupId = detectCountryGroup();
     const currencyId: IsoCurrency = detectCurrency(countryGroupId);
     const participations: Participations = abTest.init(countryId, countryGroupId, settings);
-    analyticsInitialisation(participations);
+    analyticsInitialisation(participations, acquisitionData);
 
     const initialState: CommonState = buildInitialState(
       participations,
@@ -157,6 +161,7 @@ function init<S, A>(
       countryId,
       currencyId,
       settings,
+      acquisitionData,
     );
     const commonReducer = createCommonReducer(initialState);
 

--- a/support-frontend/assets/helpers/tracking/ophan.js
+++ b/support-frontend/assets/helpers/tracking/ophan.js
@@ -3,7 +3,7 @@
 
 import * as ophan from 'ophan';
 import type { Participations, TestId } from 'helpers/abTests/abtest';
-import { getQueryParameter } from 'helpers/url';
+import type { ReferrerAcquisitionData } from 'helpers/tracking/acquisitions';
 
 // ----- Types ----- //
 
@@ -108,15 +108,16 @@ const trackAbTests = (participations: Participations): void =>
     abTestRegister: buildOphanPayload(participations),
   });
 
-// Set referring pageViewId in localstorage if it's not already there. This is picked up by ophan, see:
+// Set referring pageview data in localstorage if it's not already there. This is picked up by ophan, see:
 // https://github.com/guardian/ophan/blob/75b86abcce07369c8998521399327d436246c016/tracker-js/assets/coffee/ophan/click-path-capture.coffee#L41
 // Note - the localstorage item is deleted by tracker-js as soon as it's read, see:
 // https://github.com/guardian/ophan/blob/75b86abcce07369c8998521399327d436246c016/tracker-js/assets/coffee/ophan/core.coffee#L72
-const setRefViewId = (): void => {
-  const REFPVID = getQueryParameter('REFPVID');
-  if (REFPVID && !localStorage.getItem('ophan_follow')) {
+const setReferrerDataInLocalStorage = (acquisitionData: ReferrerAcquisitionData): void => {
+  const { referrerUrl, referrerPageviewId } = acquisitionData;
+  if (!localStorage.getItem('ophan_follow') && referrerUrl && referrerPageviewId) {
     localStorage.setItem('ophan_follow', JSON.stringify({
-      refViewId: REFPVID,
+      refViewId: referrerPageviewId,
+      ref: referrerUrl,
     }));
   }
 };
@@ -125,5 +126,5 @@ export {
   trackComponentEvents,
   pageView,
   trackAbTests,
-  setRefViewId,
+  setReferrerDataInLocalStorage,
 };


### PR DESCRIPTION
Previous attempt: https://github.com/guardian/support-frontend/pull/2979

We're now sending `refViewId` with the initial ophan event.
However, we also need to send `ref` (which has the url), otherwise ophan ignores it. See here:
https://github.com/guardian/ophan/blob/75b86abcce07369c8998521399327d436246c016/the-slab/app/extractors/ReferrerExtractor.scala#L180

This change uses the `referrerAcquisitionData` object to get referrerUrl + referrerPageviewId, which we already construct for the acquisition event.

Example event in CODE:
![Screen Shot 2021-03-17 at 10 07 52](https://user-images.githubusercontent.com/1513454/111450866-b91b6300-8708-11eb-8e28-d82f30319787.png)
