### PR TITLE
use the correct scala version in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 scala:
-- 2.12.10
+- 2.13.5
 jdk:
 - openjdk8
 sudo: false


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

following on from https://github.com/guardian/support-frontend/pull/2881

This makes sure travis uses the right version of scala also.

## Why are you doing this?

The tests are failing with a version mismatch
