### PR TITLE
Digital subs copy update

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/hero/hero.jsx
@@ -42,7 +42,8 @@ const HeroCopy = () => (
     </p>
     <p css={paragraph}>
       With two innovative apps and ad-free reading, a digital subscription gives
-      you the richest experience of Guardian journalism.
+      you the richest experience of Guardian journalism. Plus, for a limited time,
+      you can read our latest special edition - The books of&nbsp;2021
     </p>
   </>
 );


### PR DESCRIPTION
## What are you doing in this PR?

This adds an extra line about the 'books of 2021' special edition to the digital subs landing page.

[**Trello Card**](https://trello.com/c/6XYK5hYb)

## Screenshots

![Screenshot_2021-03-17 Support the Guardian The Guardian Digital Subscription](https://user-images.githubusercontent.com/29146931/111500257-b38b4080-873b-11eb-907e-00ac40535fa8.png)

