### PR TITLE
add ophan event for recording stripe prb wallet payments

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -51,6 +51,7 @@ import GeneralErrorMessage from 'components/generalErrorMessage/generalErrorMess
 import { toHumanReadableContributionType, getAvailablePaymentRequestButtonPaymentMethod } from 'helpers/checkouts';
 import type { Option } from 'helpers/types/option';
 import type { Csrf as CsrfState } from '../../../../helpers/csrf/csrfReducer';
+import {trackComponentEvents} from "../../../../helpers/tracking/ophan";
 
 // ----- Types -----//
 
@@ -285,6 +286,16 @@ function setUpPaymentListenerSca(
   paymentRequest.on('paymentmethod', ({ complete, paymentMethod, ...data }) => {
 
     const processPayment = () => {
+      if (paymentMethod && paymentMethod.card && paymentMethod.card.wallet) {
+        trackComponentEvents({
+          component: {
+            componentType: 'ACQUISITIONS_OTHER',
+          },
+          action: 'CLICK',
+          id: 'stripe-prb-wallet',
+          value: paymentMethod.card.wallet.type
+        })
+      }
       if (props.contributionType === 'ONE_OFF') {
         props.onPaymentAuthorised({
           paymentMethod: Stripe,

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -51,7 +51,7 @@ import GeneralErrorMessage from 'components/generalErrorMessage/generalErrorMess
 import { toHumanReadableContributionType, getAvailablePaymentRequestButtonPaymentMethod } from 'helpers/checkouts';
 import type { Option } from 'helpers/types/option';
 import type { Csrf as CsrfState } from '../../../../helpers/csrf/csrfReducer';
-import {trackComponentEvents} from "../../../../helpers/tracking/ophan";
+import { trackComponentEvents } from "../../../../helpers/tracking/ophan";
 
 // ----- Types -----//
 


### PR DESCRIPTION
This PR adds an Ophan event to record the wallet type if a transaction using the Stripe payment request button uses a wallet.