### PR TITLE
Add "US" prefix to price breakdown for International

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
@@ -102,7 +102,9 @@ const getAmountBreakdown = (
   selectedAmounts: SelectedAmounts,
   otherAmounts: OtherAmounts,
 ): string => {
-  const currencyString = currencies[detect(countryGroupId)].glyph;
+  const currencyStringPrefix = countryGroupId === 'International' ? 'US' : '';
+  const currencyString = currencyStringPrefix + currencies[detect(countryGroupId)].glyph;
+
   const amount = getAmount(selectedAmounts, otherAmounts, contributionType);
 
   const breakdownIntervalsPerYear = breakdownMode === 'WEEKLY' ? 52.0 : 365.0;


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Add "US" prefix to price breakdown for International to highlight that we charge US dollars on the international page.

[**Trello Card**](https://trello.com/c/CcV0J6af/2564-highlight-we-charge-us-dollars-on-international-landing-page)

## Screenshots

<img width="637" alt="Screenshot 2021-03-23 at 11 23 01" src="https://user-images.githubusercontent.com/17720442/112139250-75be6a00-8bca-11eb-94a3-0051741acffe.png">