### PR TITLE
update terms copy for US contribs landing page

### DIFF
--- a/support-frontend/assets/components/legal/termsPrivacy/termsPrivacy.jsx
+++ b/support-frontend/assets/components/legal/termsPrivacy/termsPrivacy.jsx
@@ -58,9 +58,16 @@ function TermsPrivacy(props: PropTypes) {
       <div className="philanthropic-ask">
         <h4>Contribute another way</h4>
         <p>
-          Please {americasContactLink} if you would like to: make a larger single contribution
-          as an individual, contribute as a company or foundation, or would like
-          to discuss legacy gifting.
+          To contribute by mail, please make your check payable to:<br/>
+          Guardian News,<br/>
+          Church Street Station,<br/>
+          PO Box 3403,<br/>
+          New York, NY 10008-3403.
+        </p>
+        <p>
+          Please {americasContactLink} if you would like to: make a larger single contribution as an individual,
+          contribute as a company or foundation, learn about options for tax-exempt support or would
+          like to discuss legacy gifting.
         </p>
         <p>
           To contribute at a higher level on a recurring basis, you can join as a


### PR DESCRIPTION
### What does this PR do?
Makes a small copy change to the US contributions landing page, per [this Trello card](https://trello.com/c/8zFv9ARK/2573-add-copy-how-to-send-checks-to-us-landing-page).

### Screenshot
<img width="1440" alt="Screenshot 2021-03-23 at 12 33 18" src="https://user-images.githubusercontent.com/25020231/112147386-8c69be80-8bd4-11eb-9e9b-526714c744dc.png">
