### PR TITLE
Track no wallet with PRB

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -51,7 +51,7 @@ import GeneralErrorMessage from 'components/generalErrorMessage/generalErrorMess
 import { toHumanReadableContributionType, getAvailablePaymentRequestButtonPaymentMethod } from 'helpers/checkouts';
 import type { Option } from 'helpers/types/option';
 import type { Csrf as CsrfState } from '../../../../helpers/csrf/csrfReducer';
-import { trackComponentEvents } from "../../../../helpers/tracking/ophan";
+import { trackComponentEvents } from '../../../../helpers/tracking/ophan';
 
 // ----- Types -----//
 
@@ -286,16 +286,16 @@ function setUpPaymentListenerSca(
   paymentRequest.on('paymentmethod', ({ complete, paymentMethod, ...data }) => {
 
     const processPayment = () => {
-      if (paymentMethod && paymentMethod.card && paymentMethod.card.wallet) {
-        trackComponentEvents({
-          component: {
-            componentType: 'ACQUISITIONS_OTHER',
-          },
-          action: 'CLICK',
-          id: 'stripe-prb-wallet',
-          value: paymentMethod.card.wallet.type
-        })
-      }
+      const walletType = paymentMethod && paymentMethod.card && paymentMethod.card.wallet ? paymentMethod.card.wallet.type : 'no-wallet';
+      trackComponentEvents({
+        component: {
+          componentType: 'ACQUISITIONS_OTHER',
+        },
+        action: 'CLICK',
+        id: 'stripe-prb-wallet',
+        value: walletType,
+      });
+
       if (props.contributionType === 'ONE_OFF') {
         props.onPaymentAuthorised({
           paymentMethod: Stripe,


### PR DESCRIPTION
We're tracking the type of wallet used for each PRB contribution.
But - we also need to track the case where no wallet is used, i.e. the user has set up a card in their browser.

<img width="899" alt="Screen Shot 2021-03-24 at 09 47 42" src="https://user-images.githubusercontent.com/1513454/112289250-0c039600-8c86-11eb-90b4-e3cd68713d4c.png">
