### PR TITLE
Remove zip code ab test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -3,7 +3,6 @@ import type { Tests } from './abtest';
 
 // ----- Tests ----- //
 
-const usLandingPage = '/us/contribute(/.*)?$';
 const allLandingPagesAndThankyouPages = '/contribute|thankyou(/.*)?$';
 const notUkLandingPage = '/us|au|eu|int|nz|ca/contribute(/.*)?$';
 export const subsShowcaseAndDigiSubPages = '(/??/subscribe(\\?.*)?$|/??/subscribe/digital(\\?.*)?$)';
@@ -71,30 +70,6 @@ export const tests: Tests = {
     referrerControlled: false,
     targetPage: allLandingPagesAndThankyouPages,
     seed: 12,
-  },
-
-  usLandingPageZipCodeFieldTest: {
-    variants: [
-      {
-        id: 'control',
-      },
-      {
-        id: 'zip-optional',
-      },
-      {
-        id: 'zip-required',
-      },
-    ],
-    audiences: {
-      ALL: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: true,
-    referrerControlled: false,
-    targetPage: usLandingPage,
-    seed: 13,
   },
 
   landingPagePriceBreakdownTest: {

--- a/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripeCardForm/StripeCardForm.jsx
@@ -44,21 +44,6 @@ import { isValidZipCode } from 'helpers/formValidation';
 
 // ----- Types -----//
 
-type ZipCodeFieldMode = "NONE" | "OPTIONAL" | "REQUIRED";
-
-const getZipCodeMode = (state: State): ZipCodeFieldMode => {
-  const variant = state.common.abParticipations.usLandingPageZipCodeFieldTest;
-  if (variant === 'zip-optional') {
-    return 'OPTIONAL';
-  } else if (variant === 'zip-required') {
-    return 'REQUIRED';
-  }
-  return 'NONE';
-};
-
-const shouldShowZipCodeField = (mode: ZipCodeFieldMode): boolean =>
-  mode === 'OPTIONAL' || mode === 'REQUIRED';
-
 /* eslint-disable react/no-unused-prop-types */
 type PropTypes = {|
   onPaymentAuthorised: (paymentMethodId: string) => Promise<PaymentResult>,
@@ -82,7 +67,6 @@ type PropTypes = {|
   setOneOffRecaptchaToken: string => Action,
   oneOffRecaptchaToken: string,
   isTestUser: boolean,
-  zipCodeFieldMode: ZipCodeFieldMode,
 |};
 
 const mapStateToProps = (state: State) => ({
@@ -96,7 +80,6 @@ const mapStateToProps = (state: State) => ({
   recurringRecaptchaVerified: state.page.form.stripeCardFormData.recurringRecaptchaVerified,
   formIsSubmittable: state.page.form.formIsSubmittable,
   oneOffRecaptchaToken: state.page.form.oneOffRecaptchaToken,
-  zipCodeFieldMode: getZipCodeMode(state),
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -177,6 +160,7 @@ const CardForm = (props: PropTypes) => {
   const [calledRecaptchaRender, setCalledRecaptchaRender] = useState<boolean>(false);
 
   const [zipCode, setZipCode] = useState('');
+  const showZipCodeField = props.country === 'US';
 
   const updateZipCode = event => setZipCode(event.target.value);
 
@@ -392,14 +376,7 @@ const CardForm = (props: PropTypes) => {
     }
   }, [props.setupIntentClientSecret]);
 
-  const isZipCodeFieldValid = () => {
-    // if required we always run validation
-    if (props.zipCodeFieldMode === 'REQUIRED') {
-      return isValidZipCode(zipCode);
-    }
-    // else we only run validation if non-empty
-    return zipCode !== '' ? isValidZipCode(zipCode) : true;
-  };
+  const isZipCodeFieldValid = () => (showZipCodeField ? isValidZipCode(zipCode) : true);
 
 
   useEffect(() => {
@@ -577,7 +554,7 @@ const CardForm = (props: PropTypes) => {
 
       </div>
 
-      { shouldShowZipCodeField(props.zipCodeFieldMode) && (
+      { showZipCodeField && (
         <div css={zipCodeContainerStyles}>
           <TextInput
             id="contributionZipCode"
@@ -585,7 +562,6 @@ const CardForm = (props: PropTypes) => {
             label="ZIP code"
             value={zipCode}
             onChange={updateZipCode}
-            optional={props.zipCodeFieldMode === 'OPTIONAL'}
             error={showZipCodeError ? 'Please enter a valid ZIP code' : null}
           />
         </div>)


### PR DESCRIPTION
## What are you doing in this PR?
Remove the zip code ab test we were running in the US. There was no significant difference so we're going ahead with requiring the field to reduce transactions fees.