### PR TITLE
remove commas

### DIFF
--- a/support-frontend/assets/components/legal/termsPrivacy/termsPrivacy.jsx
+++ b/support-frontend/assets/components/legal/termsPrivacy/termsPrivacy.jsx
@@ -59,9 +59,9 @@ function TermsPrivacy(props: PropTypes) {
         <h4>Contribute another way</h4>
         <p>
           To contribute by mail, please make your check payable to:<br/>
-          Guardian News,<br/>
-          Church Street Station,<br/>
-          PO Box 3403,<br/>
+          Guardian News<br/>
+          Church Street Station<br/>
+          PO Box 3403<br/>
           New York, NY 10008-3403.
         </p>
         <p>


### PR DESCRIPTION
This PR removes the commas after each line in our US postal address for checks.