### PR TITLE
Add permissions to describe tags

### DIFF
--- a/support-logs/cfn.yaml
+++ b/support-logs/cfn.yaml
@@ -53,6 +53,21 @@ Resources:
           - ssmmessages:OpenDataChannel
       Roles:
       - !Ref KibanaProxyRole
+  DescribeEC2Policy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: describe-ec2-policy
+      PolicyDocument:
+        Statement:
+        - Effect: Allow
+          Resource: "*"
+          Action:
+          - ec2:DescribeTags
+          - ec2:DescribeInstances
+          - autoscaling:DescribeAutoScalingGroups
+          - autoscaling:DescribeAutoScalingInstances
+      Roles:
+      - !Ref KibanaProxyRole
   KibanaProxyInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:


### PR DESCRIPTION
## What are you doing in this PR?

Letting the kibana proxy instance query for tags!

## Why are you doing this?

There's currently a major review of the guardian's security practices under the cyber security programme. One of the projects in this programme is to install a vulnerability scanner called Wazuh in guardian ec2 instances.

The scanner has already been installed and connecting properly to the wazuh server, but it's only identifying itself with an instance id rather than app/stack/stage tags.
