### PR TITLE
Add marketing consent ab test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -4,6 +4,7 @@ import type { Tests } from './abtest';
 // ----- Tests ----- //
 
 const allLandingPagesAndThankyouPages = '/contribute|thankyou(/.*)?$';
+const allThankYouPages = '/thankyou(/.*)?$';
 const notUkLandingPage = '/us|au|eu|int|nz|ca/contribute(/.*)?$';
 export const subsShowcaseAndDigiSubPages = '(/??/subscribe(\\?.*)?$|/??/subscribe/digital(\\?.*)?$)';
 const digiSubLandingPages = '(/??/subscribe/digital/gift(\\?.*)?$|/??/subscribe/digital(\\?.*)?$)';
@@ -116,5 +117,29 @@ export const tests: Tests = {
     targetPage: digiSubLandingPages,
     seed: 16,
     optimizeId: 'oeDqGqpqT4OLrAaMJjYz6A',
+  },
+
+  thankyouPageMarketingConsentTest: {
+    variants: [
+      {
+        id: 'control',
+      },
+      {
+        id: 'v1',
+      },
+      {
+        id: 'v2',
+      },
+    ],
+    audiences: {
+      ALL: {
+        offset: 0,
+        size: 1,
+      },
+    },
+    isActive: true,
+    referrerControlled: false,
+    targetPage: allThankYouPages,
+    seed: 17,
   },
 };

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouMarketingConsent.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouMarketingConsent.jsx
@@ -37,7 +37,14 @@ const buttonContainer = css`
 
 const ERROR_MESSAGE = 'Please tick the box below, then click \'subscribe\'';
 
-const mapStateToProps = () => ({
+
+const CONTROL_COPY = 'Get related news and offers - whether you are a contributor, subscriber, member or would like to become one.';
+const V1_COPY = 'Stay up-to-date with our latest offers and the aims of the organisation, as well as the ways to enjoy and support our journalism.';
+const V2_COPY = 'Stay up-to-date with ways to enjoy and support our journalism, the aims of the organisation and our latest offers.';
+
+const mapStateToProps = state => ({
+  thankyouPageMarketingConsentTestVariant:
+    state.common.abParticipations.thankyouPageMarketingConsentTest,
 });
 
 
@@ -60,6 +67,7 @@ type ContributionThankYouMarketingConsentProps = {|
   csrf: Csrf,
   subscribeToNewsLetter: (email: string, csrf: Csrf) => void,
   thankyouPageHeadingTestVariant: boolean,
+  thankyouPageMarketingConsentTestVariant: string,
 |};
 
 const ContributionThankYouMarketingConsent = ({
@@ -67,6 +75,7 @@ const ContributionThankYouMarketingConsent = ({
   csrf,
   subscribeToNewsLetter,
   thankyouPageHeadingTestVariant,
+  thankyouPageMarketingConsentTestVariant,
 }: ContributionThankYouMarketingConsentProps) => {
   const [hasConsented, setHasConsented] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -89,6 +98,15 @@ const ContributionThankYouMarketingConsent = ({
       setHasBeenCompleted(true);
       subscribeToNewsLetter(email, csrf);
     }
+  };
+
+  const getCheckboxCopy = () => {
+    if (thankyouPageMarketingConsentTestVariant === 'v1') {
+      return V1_COPY;
+    } else if (thankyouPageMarketingConsentTestVariant === 'v2') {
+      return V2_COPY;
+    }
+    return CONTROL_COPY;
   };
 
   const actionIcon = <SvgNotification />;
@@ -118,24 +136,13 @@ const ContributionThankYouMarketingConsent = ({
             </span>
           </p>
           <div css={checkboxContainer}>
-            <div css={styles.hideAfterTablet}>
-              <CheckboxGroup error={errorMessage}>
-                <Checkbox
-                  checked={hasConsented}
-                  onChange={() => setHasConsented(!hasConsented)}
-                  supporting="Get related news and offers - whether you are a contributor, subscriber, member or would like to become one."
-                />
-              </CheckboxGroup>
-            </div>
-            <div css={styles.hideBeforeTablet}>
-              <CheckboxGroup error={errorMessage}>
-                <Checkbox
-                  checked={hasConsented}
-                  onChange={() => setHasConsented(!hasConsented)}
-                  supporting="Contributions, subscriptions and membership: get related news and offers - whether you are a contributor, subscriber, member or would like to become one."
-                />
-              </CheckboxGroup>
-            </div>
+            <CheckboxGroup error={errorMessage}>
+              <Checkbox
+                checked={hasConsented}
+                onChange={() => setHasConsented(!hasConsented)}
+                supporting={getCheckboxCopy()}
+              />
+            </CheckboxGroup>
           </div>
           <div css={buttonContainer}>
             {


### PR DESCRIPTION
## What are you doing in this PR?
Add marketing consent AB test. Additionally, for the control we now use the same copy across all breakpoints.

[**Trello Card**](https://trello.com/c/oho2SEP6/2582-marketing-opt-in-copy-a-b-test-ty-page)

## Screenshots
#### control
<img width="752" alt="Screenshot 2021-03-29 at 13 43 48" src="https://user-images.githubusercontent.com/17720442/112838811-62f9d880-9095-11eb-89d8-92b266e76166.png">

#### v1
<img width="752" alt="Screenshot 2021-03-29 at 13 44 08" src="https://user-images.githubusercontent.com/17720442/112838819-655c3280-9095-11eb-8bbd-efe7427ccd05.png">

#### v2
<img width="752" alt="Screenshot 2021-03-29 at 13 44 19" src="https://user-images.githubusercontent.com/17720442/112838823-668d5f80-9095-11eb-8b2f-a4d108a472d1.png">

