### PR TITLE
Guardian Weekly copy amendments due to delivery days

### DIFF
--- a/support-frontend/assets/helpers/externalLinks.js
+++ b/support-frontend/assets/helpers/externalLinks.js
@@ -50,7 +50,7 @@ const androidAppUrl = 'https://play.google.com/store/apps/details?id=com.guardia
 const androidDailyUrl = 'https://play.google.com/store/apps/details?id=com.guardian.editions';
 const myAccountUrl = `${profileUrl}/account/edit`;
 const manageSubsUrl = `${manageUrl}/subscriptions`;
-
+const helpCentreUrl = `${manageUrl}/help-centre`;
 
 const memUrls: {
   [MemProduct]: string,
@@ -279,4 +279,5 @@ export {
   myAccountUrl,
   manageSubsUrl,
   homeDeliveryUrl,
+  helpCentreUrl,
 };

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/thankYou.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/thankYou.jsx
@@ -130,7 +130,8 @@ function ThankYouContent({
       </span>,
       <span>
         Your magazine will be delivered to your door.
-        Please allow 1 to 7 days after publication date for your magazine to arrive, depending on national post services.
+        Please allow 1 to 7 days after publication date for your magazine to arrive, depending on national
+        post services.
       </span>,
     ];
 

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/thankYou.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/thankYou.jsx
@@ -130,7 +130,7 @@ function ThankYouContent({
       </span>,
       <span>
         Your magazine will be delivered to your door.
-        Please allow 1-7 days after publication date for your magazine to arrive, depending on national post services.
+        Please allow 1 to 7 days after publication date for your magazine to arrive, depending on national post services.
       </span>,
     ];
 

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/thankYou.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/thankYou.jsx
@@ -17,7 +17,7 @@ import HeadingBlock from 'components/headingBlock/headingBlock';
 import {
   homeDeliveryUrl,
   manageSubsUrl,
-  myAccountUrl,
+  helpCentreUrl,
 } from 'helpers/externalLinks';
 import typeof MarketingConsent
   from 'components/subscriptionCheckouts/thankYou/marketingConsentContainer';
@@ -72,8 +72,8 @@ const getHeading = (billingPeriod, isPending, orderIsGift) => {
 const StartDateCopy = ({ startDate, orderIsGift }: {startDate: Option<string>, orderIsGift: boolean}) => {
   if (startDate) {
     const title = orderIsGift ?
-      'The gift recipient will receive their first issue on' :
-      'You will receive your first issue on';
+      'The gift recipient\'s first issue will be published on' :
+      'Your first issue will be published on';
     return (
       <Text title={title}>
         <LargeParagraph>{formatUserDate(new Date(startDate))}</LargeParagraph>
@@ -126,12 +126,11 @@ function ThankYouContent({
     ] :
     [
       <span>
-        Look out for an email from us confirming your subscription.
-        It has everything you need to know about how to manage it in the future.
+        Look out for an email from us confirming your subscription. It will contain everything you need to know.
       </span>,
       <span>
-        Your magazine will be delivered to your door.{' '}
-        <a className="thank-you-link" href={homeDeliveryUrl}>Here&apos;s a reminder of how home delivery works</a>.
+        Your magazine will be delivered to your door.
+        Please allow 1-7 days after publication date for your magazine to arrive, depending on national post services.
       </span>,
     ];
 
@@ -162,8 +161,7 @@ function ThankYouContent({
       <Content>
         <Text>
           <SansParagraph>
-            You can manage your subscription by visiting our <a href={manageSubsUrl} onClick={sendTrackingEventsOnClick({ id: 'checkout_my_account', product: 'Paper', componentType: 'ACQUISITIONS_BUTTON' })}>Manage section</a> or accessing
-            it via <a href={myAccountUrl} onClick={sendTrackingEventsOnClick({ id: 'checkout_mma', product: 'Paper', componentType: 'ACQUISITIONS_BUTTON' })}>your Guardian account</a>.
+          You can manage your subscription by visiting <a href={manageSubsUrl} onClick={sendTrackingEventsOnClick({ id: 'checkout_my_account', product: 'Paper', componentType: 'ACQUISITIONS_BUTTON' })}>Manage My Account</a>. For any other queries please visit the <a href={helpCentreUrl} onClick={sendTrackingEventsOnClick({ id: 'checkout_help_centre', product: 'Paper', componentType: 'ACQUISITIONS_BUTTON' })}>Help Centre</a>.
           </SansParagraph>
         </Text>
       </Content>

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -261,12 +261,12 @@ function WeeklyCheckoutForm(props: PropTypes) {
               </FormSection>
             : null
           }
-          <FormSection title="When would you like your subscription to start?">
+          <FormSection title="Please select the first publication you’d like to receive">
             <Rows>
               <RadioGroup
                 id="startDate"
                 error={firstError('startDate', props.formErrors)}
-                legend="When would you like your subscription to start?"
+                legend="Please select the first publication you’d like to receive"
               >
                 {days.map((day) => {
                   const [userDate, machineDate] = [formatUserDate(day), formatMachineDate(day)];
@@ -291,11 +291,11 @@ function WeeklyCheckoutForm(props: PropTypes) {
               </RadioGroup>
               <Text className="component-text__paddingTop">
                 <p className="component-text__sans">
-                We will take the first payment on the
-                date you receive your first Guardian Weekly.
+                  We will take the first payment on the date of your first publication.
                 </p>
                 <p className="component-text__sans">
-                Subscription start dates are automatically selected to be the earliest we can fulfil your order.
+                  Please allow 1-7 days after publication date for your magazine to arrive,
+                  depending on national post services.
                 </p>
               </Text>
             </Rows>

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -294,7 +294,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
                   We will take the first payment on the date of your first publication.
                 </p>
                 <p className="component-text__sans">
-                  Please allow 1-7 days after publication date for your magazine to arrive,
+                  Please allow 1 to 7 days after publication date for your magazine to arrive,
                   depending on national post services.
                 </p>
               </Text>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This amends the copy in the checkout and thank you page for Guardian Weekly to clarify timing of payment and delivery, due to current delivery issues.

[**Trello Card**](https://trello.com/c/3yFFt9VP)

## Screenshots

**Checkout**
![Screenshot_2021-03-29 Support the Guardian Guardian Weekly Subscription(1)](https://user-images.githubusercontent.com/29146931/112865622-df4de500-90b0-11eb-8947-757176629ecd.png)

**Thank You page**
![Screenshot_2021-03-29 Support the Guardian Guardian Weekly Subscription](https://user-images.githubusercontent.com/29146931/112865697-e96fe380-90b0-11eb-9c55-b2a997caf3a5.png)
