### PR TITLE
Update `sendTrackingEvent` component event data: "products" to "products"

### DIFF
--- a/support-frontend/assets/helpers/subscriptions.js
+++ b/support-frontend/assets/helpers/subscriptions.js
@@ -139,7 +139,7 @@ const sendTrackingEvent = (trackingProperties: TrackingProperties & {
     component: {
       componentType,
       id,
-      ...(product ? { product: [ophanProductFromSubscriptionProduct(product)] } : {}),
+      products: product ? [ophanProductFromSubscriptionProduct(product)] : [],
     },
     action,
     id,


### PR DESCRIPTION
## What are you doing in this PR?

This PR update the "component event" data model we send via Ophan. The model for a component event listed in the [Thrift definition](https://dashboard.ophan.co.uk/docs/thrift/componentevent.html#Struct_ComponentEvent) states there should be a non optional key `products`, wjich could be an empty list. In the component event data we were sending the list with the key `product`, this PR corrects that. Interestingly I've checked the pageview table in the lake and the affected component events have been registered using the current incorrect model.



