### PR TITLE
Remove use digital flag

### DIFF
--- a/support-frontend/app/controllers/PaperSubscription.scala
+++ b/support-frontend/app/controllers/PaperSubscription.scala
@@ -59,7 +59,6 @@ class PaperSubscription(
         s"""<script type="text/javascript">
       window.guardian.productPrices = ${outputJson(priceSummaryServiceProvider.forUser(false).getPrices(Paper, queryPromos))}
       window.guardian.promotionCopy = ${outputJson(maybePromotionCopy)}
-      window.guardian.useDigitalVoucher = ${Paper.useDigitalVoucher}
       </script>"""
       )
     }

--- a/support-frontend/app/views/subscriptionCheckout.scala.html
+++ b/support-frontend/app/views/subscriptionCheckout.scala.html
@@ -68,8 +68,6 @@
 
       window.guardian.checkoutPostcodeLookup = "@settings.switches.experiments.get("checkoutPostcodeLookup").exists(_.isOn)"
 
-      window.guardian.useDigitalVoucher = @{Paper.useDigitalVoucher}
-
       window.guardian.v2recaptchaPublicKey = "@v2recaptchaConfigPublicKey"
 
       window.guardian.recaptchaEnabled = @settings.switches.enableRecaptchaFrontend.isOn

--- a/support-frontend/assets/components/legal/termsPrivacy/termsPrivacy.jsx
+++ b/support-frontend/assets/components/legal/termsPrivacy/termsPrivacy.jsx
@@ -58,10 +58,10 @@ function TermsPrivacy(props: PropTypes) {
       <div className="philanthropic-ask">
         <h4>Contribute another way</h4>
         <p>
-          To contribute by mail, please make your check payable to:<br/>
-          Guardian News<br/>
-          Church Street Station<br/>
-          PO Box 3403<br/>
+          To contribute by mail, please make your check payable to:<br />
+          Guardian News<br />
+          Church Street Station<br />
+          PO Box 3403<br />
           New York, NY 10008-3403.
         </p>
         <p>

--- a/support-frontend/assets/helpers/globals.js
+++ b/support-frontend/assets/helpers/globals.js
@@ -40,11 +40,8 @@ const emptyConfiguredRegionAmounts: ConfiguredRegionAmounts = {
 
 const getSettings = (): Settings => {
   const globalSettings = getGlobal('settings');
-  if (globalSettings) {
-    const useDigitalVoucher = getGlobal('useDigitalVoucher');
-    return { ...globalSettings, useDigitalVoucher };
-  }
-  return {
+
+  return globalSettings || {
     switches: {
       experiments: {},
     },
@@ -67,7 +64,6 @@ const getSettings = (): Settings => {
       Canada: [],
     },
     metricUrl: '',
-    useDigitalVoucher: null,
   };
 };
 

--- a/support-frontend/assets/helpers/settings.js
+++ b/support-frontend/assets/helpers/settings.js
@@ -1,7 +1,6 @@
 // @flow
 
 import { type ConfiguredAmounts, type ContributionTypes } from 'helpers/contributions';
-import { type Option } from 'helpers/types/option';
 
 export type Status = 'On' | 'Off';
 
@@ -25,5 +24,4 @@ export type Settings = {
   amounts: ConfiguredAmounts,
   contributionTypes: ContributionTypes,
   metricUrl: string,
-  useDigitalVoucher: Option<boolean>,
 };

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
@@ -146,7 +146,7 @@ const mapStateToProps = (state: State): PropTypes => {
         label: trackingProperties.id,
       });
       sendTrackingEventsOnClick(trackingProperties)();
-    }
+    };
 
     return orderIsAGift ?
       {

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/thankYou.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/thankYou.jsx
@@ -34,7 +34,6 @@ import { type FormFields, getFormFields } from 'helpers/subscriptionsForms/formF
 type PropTypes = {
     ...FormFields,
     isPending: boolean,
-    useDigitalVoucher: boolean,
 };
 
 // ----- Map State/Props ----- //
@@ -42,39 +41,29 @@ type PropTypes = {
 function mapStateToProps(state: WithDeliveryCheckoutState) {
   return {
     ...getFormFields(state),
-    useDigitalVoucher: state.common.settings.useDigitalVoucher,
   };
 }
 
 // ----- Component ----- //
 
-const whatNextText: { [FulfilmentOptions]: { [key: string]: Array<string> } } = {
-  [HomeDelivery]: {
-    default: [
-      `Look out for an email from us confirming your subscription.
-        It has everything you need to know about how manage it in the future.`,
-      'Your newspaper will be delivered to your door.',
-    ],
-  },
-  [Collection]: {
-    default: [
-      `Look out for an email from us confirming your subscription.
-        It has everything you need to know about how to manage it in the future.`,
-      'You will receive your personalised book of vouchers.',
-      'Exchange your voucher for a newspaper at your newsagent or wherever you buy your paper',
-    ],
-    digitalVoucher: [
-      `Keep an eye on your inbox. You should receive an email confirming the details of your subscription,
-        and another email shortly afterwards that contains details of how you can pick up your newspapers from tomorrow!`,
-      `You will receive your Subscription Card in your subscriber pack in the post, along with your home
-        delivery letter.`,
-      `Visit your chosen participating newsagent to pick up your newspaper using your Subscription Card, or
-        arrange a home delivery using your delivery letter.`,
-    ],
-  },
+const whatNextText: { [FulfilmentOptions]: Array<string> } = {
+  [HomeDelivery]: [
+    `Look out for an email from us confirming your subscription.
+      It has everything you need to know about how manage it in the future.`,
+    'Your newspaper will be delivered to your door.',
+  ],
+  [Collection]: [
+    `Keep an eye on your inbox. You should receive an email confirming the details of your subscription,
+      and another email shortly afterwards that contains details of how you can pick up your newspapers from tomorrow!`,
+    `You will receive your Subscription Card in your subscriber pack in the post, along with your home
+      delivery letter.`,
+    `Visit your chosen participating newsagent to pick up your newspaper using your Subscription Card, or
+      arrange a home delivery using your delivery letter.`,
+  ],
 };
 
-function whatNextElement(textItems) {
+function WhatNext(fulfilmentOption) {
+  const textItems = whatNextText[fulfilmentOption];
   return (
     <Text title="What happens next?">
       <p>
@@ -84,19 +73,11 @@ function whatNextElement(textItems) {
   );
 }
 
-function WhatNext(fulfilmentOption, useDigitalVoucher = false) {
-  let textItems = whatNextText[fulfilmentOption].default;
-  if (fulfilmentOption === Collection && useDigitalVoucher) {
-    textItems = whatNextText[Collection].digitalVoucher;
-  }
-  return whatNextElement(textItems);
-}
-
 
 function ThankYouContent({
-  fulfilmentOption, productOption, startDate, isPending, product, useDigitalVoucher,
+  fulfilmentOption, productOption, startDate, isPending, product,
 }: PropTypes) {
-  const hideStartDate = fulfilmentOption === Collection && useDigitalVoucher;
+  const hideStartDate = fulfilmentOption === Collection;
   const cleanProductOption = getTitle(productOption);
   return (
     <div className="thank-you-stage">
@@ -128,7 +109,7 @@ function ThankYouContent({
             <LargeParagraph>{formatUserDate(new Date(startDate))}</LargeParagraph>
           </Text>
         }
-        {WhatNext(fulfilmentOption, useDigitalVoucher)}
+        {WhatNext(fulfilmentOption)}
       </Content>
       <Content>
         <Text>

--- a/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckout.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/paperSubscriptionCheckout.jsx
@@ -48,8 +48,6 @@ const store = pageInit(
   true,
 );
 
-const { useDigitalVoucher } = store.getState().common.settings;
-
 FocusStyleManager.onlyShowFocusOnTabs();
 
 // ----- Render ----- //
@@ -63,12 +61,11 @@ const content = (
           faqsLink="https://www.theguardian.com/subscriber-direct/subscription-frequently-asked-questions"
           termsConditionsLink="https://www.theguardian.com/subscriber-direct/subscription-terms-and-conditions"
         >
-          {useDigitalVoucher &&
-            <p>By proceeding, you agree to our{' '}
-              <a href="https://www.theguardian.com/subscriber-direct/subscription-terms-and-conditions">Terms &amp; Conditions</a>.{' '}
-              We will share your contact and subscription details with our fulfilment partners to provide you with your subscription card.{' '}
-              To find out more about what personal data we collect and how we use it, please visit our <a href="https://www.theguardian.com/help/privacy-policy">Privacy&nbsp;Policy</a>.
-            </p>}
+          <p>By proceeding, you agree to our{' '}
+            <a href="https://www.theguardian.com/subscriber-direct/subscription-terms-and-conditions">Terms &amp; Conditions</a>.{' '}
+            We will share your contact and subscription details with our fulfilment partners to provide you with your subscription card.{' '}
+            To find out more about what personal data we collect and how we use it, please visit our <a href="https://www.theguardian.com/help/privacy-policy">Privacy&nbsp;Policy</a>.
+          </p>
         </Footer>
       }
     >

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/deliveryTab.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/deliveryTab.jsx
@@ -62,15 +62,15 @@ export const accordionContainer = css`
 const accordionTrackingId = 'Paper_HomeDelivery-tab_Delivery-accordion';
 
 export const ContentDeliveryFaqBlock = ({
-  useDigitalVoucher,
   setTabAction,
-}: {useDigitalVoucher?: boolean, setTabAction: typeof setTab,
+}: {setTabAction: typeof setTab,
 }) => (
   <FlexContainer cssOverrides={flexContainerOverride}>
     <div css={faqsContainer}>
       <p css={paragraph}>
         If you live in Greater London (within the M25), you can use The Guardian’s home delivery
-        service. If not, you can use our <LinkTo tab={Collection} setTabAction={setTabAction}>{useDigitalVoucher ? 'subscription cards' : 'voucher scheme'}</LinkTo>.
+        service. If not, you can use our{' '}
+        <LinkTo tab={Collection} setTabAction={setTabAction}>subscription cards</LinkTo>.
       </p>
       <p css={paragraph}>
         Select your subscription below and checkout. You&apos;ll receive your first newspaper
@@ -104,6 +104,3 @@ export const ContentDeliveryFaqBlock = ({
 
 );
 
-ContentDeliveryFaqBlock.defaultProps = {
-  useDigitalVoucher: true,
-};

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/prices.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/prices.jsx
@@ -22,7 +22,6 @@ export type PropTypes = {|
   activeTab: ActiveTabState,
   setTabAction: typeof setTab,
   products: Product[],
-  useDigitalVoucher: boolean,
 |};
 
 const pricesSection = css`
@@ -94,7 +93,7 @@ const DiscountCalloutMaybe = () => {
 };
 
 function Prices({
-  activeTab, setTabAction, products, useDigitalVoucher,
+  activeTab, setTabAction, products,
 }: PropTypes) {
   const infoText = `${activeTab === HomeDelivery ? 'Delivery is included. ' : ''}You can cancel your subscription at any time`;
   return (
@@ -122,7 +121,7 @@ function Prices({
             activeTab === Collection ?
               <LinkTo tab={HomeDelivery} setTabAction={setTabAction}>Switch to Delivery</LinkTo> :
               <LinkTo tab={Collection} setTabAction={setTabAction}>
-                  Switch to {useDigitalVoucher ? 'Subscription card' : 'Vouchers'}
+                  Switch to Subscription card
               </LinkTo>
           }
       </div>

--- a/support-frontend/assets/pages/paper-subscription-landing/components/paperPrices.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/paperPrices.jsx
@@ -110,13 +110,11 @@ const getPlans = (
 type StateProps = {|
   activeTab: PaperFulfilmentOptions,
   products: Product[],
-  useDigitalVoucher: boolean
 |}
 
 const mapStateToProps = (state: State): StateProps => ({
   activeTab: state.page.tab,
   products: state.page.productPrices ? getPlans(state.page.tab, state.page.productPrices) : [],
-  useDigitalVoucher: state.common.settings.useDigitalVoucher || false,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch<TabActions>) =>

--- a/support-frontend/assets/pages/paper-subscription-landing/components/tabs.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/tabs.jsx
@@ -13,7 +13,6 @@ import { paperSubsUrl } from 'helpers/routes';
 import { type State } from '../paperSubscriptionLandingPageReducer';
 import { setTab, type TabActions } from '../paperSubscriptionLandingPageActions';
 import type { PaperFulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
-import { type Option } from 'helpers/types/option';
 
 import { SubsCardFaqBlock } from './content/subsCardTab';
 import { ContentDeliveryFaqBlock } from './content/deliveryTab';
@@ -50,31 +49,19 @@ type DispatchPropTypes = {|
 type PropTypes = {|
   ...StatePropTypes,
   ...DispatchPropTypes,
-  useDigitalVoucher: Option<boolean>,
 |};
-
-// This is a temporary workaround while we have both iMovo and vouchers
-// We can get rid of this when we drop vouchers
-const getTabTitle = (useDigitalVoucher, fulfilmentMethod) => {
-  if (fulfilmentMethod === 'HomeDelivery' || useDigitalVoucher) {
-    return tabs[fulfilmentMethod].name;
-  }
-  return 'Voucher Booklet';
-};
 
 // ----- Component ----- //
 
-function PaperTabs({ selectedTab, setTabAction, useDigitalVoucher }: PropTypes) {
+function PaperTabs({ selectedTab, setTabAction }: PropTypes) {
   const tabItems = Object.keys(tabs).map((fulfilmentMethod) => {
     const TabContent = tabs[fulfilmentMethod].content;
     return {
       id: fulfilmentMethod,
-      // The following line is a workaround for iMovo and vouchers
-      // Once we drop vouchers, we can reinstate: name: tabs[fulfilmentMethod].name,
-      text: getTabTitle(useDigitalVoucher, fulfilmentMethod),
+      text: tabs[fulfilmentMethod].name,
       href: tabs[fulfilmentMethod].href,
       selected: fulfilmentMethod === selectedTab,
-      content: <TabContent useDigitalVoucher={useDigitalVoucher} setTabAction={setTabAction} />,
+      content: <TabContent setTabAction={setTabAction} />,
     };
   });
   return (
@@ -96,7 +83,6 @@ function PaperTabs({ selectedTab, setTabAction, useDigitalVoucher }: PropTypes) 
 
 const mapStateToProps = (state: State) => ({
   selectedTab: state.page.tab,
-  useDigitalVoucher: state.common.settings.useDigitalVoucher,
 });
 
 const mapDispatchToProps = (dispatch: Dispatch<TabActions>) =>

--- a/support-frontend/assets/pages/paper-subscription-landing/helpers/products.js
+++ b/support-frontend/assets/pages/paper-subscription-landing/helpers/products.js
@@ -1,6 +1,6 @@
 // @flow
 import type { ProductOptions } from 'helpers/productPrice/productOptions';
-import { Everyday, Sixday, Sunday, Weekend } from 'helpers/productPrice/productOptions';
+import { Everyday, Sixday } from 'helpers/productPrice/productOptions';
 
 
 export const getTitle = (productOption: ProductOptions) => {
@@ -14,14 +14,3 @@ export const getTitle = (productOption: ProductOptions) => {
   }
 };
 
-export const getShortDescription = (productOption: ProductOptions): ?string => {
-  switch (productOption) {
-    case Everyday:
-    case Weekend:
-      return 'The Guardian + The Observer';
-    case Sunday:
-      return 'The Observer';
-    default:
-      return null;
-  }
-};

--- a/support-models/src/main/scala/com/gu/support/catalog/Product.scala
+++ b/support-models/src/main/scala/com/gu/support/catalog/Product.scala
@@ -90,9 +90,7 @@ case object Paper extends Product {
   private def homeDelivery(productRatePlanId: ProductRatePlanId, productOptions: ProductOptions, description: String): ProductRatePlan[Paper.type] =
     ProductRatePlan(productRatePlanId, Monthly, HomeDelivery, productOptions, description, List(CountryGroup.UK))
 
-  val useDigitalVoucher = true
-
-  private val prodCollection: List[ProductRatePlan[Paper.type]] = if (useDigitalVoucher) {
+  private val prodCollection: List[ProductRatePlan[Paper.type]] =
     List(
       collection("2c92a00870ec598001710740ce702ff0", SaturdayPlus, "Voucher Saturday+"),
       collection("2c92a00870ec598001710740cdd02fbd", Saturday, "Voucher Saturday"),
@@ -105,23 +103,8 @@ case object Paper extends Product {
       collection("2c92a00870ec598001710740d3d03035", EverydayPlus, "Voucher Everyday+"),
       collection("2c92a00870ec598001710740c78d2f13", Everyday, "Voucher Everyday")
     )
-  } else {
-    List(
-      collection("2c92a0fd6205707201621fa1350710e3", SaturdayPlus, "Voucher Saturday+"),
-      collection("2c92a0fd6205707201621f9f6d7e0116", Saturday, "Voucher Saturday"),
-      collection("2c92a0fe56fe33ff0157040d4b824168", SundayPlus, "Voucher Sunday+"),
-      collection("2c92a0fe5af9a6b9015b0fe1ecc0116c", Sunday, "Voucher Sunday"),
-      collection("2c92a0fd56fe26b60157040cdd323f76", WeekendPlus, "Voucher Weekend+"),
-      collection("2c92a0ff56fe33f00157040f9a537f4b", Weekend, "Voucher Weekend"),
-      collection("2c92a0fc56fe26ba0157040c5ea17f6a", SixdayPlus, "Voucher Sixday+"),
-      collection("2c92a0fd56fe270b0157040e42e536ef", Sixday, "Voucher Sixday"),
-      collection("2c92a0ff56fe33f50157040bbdcf3ae4", EverydayPlus, "Voucher Everyday+"),
-      collection("2c92a0fd56fe270b0157040dd79b35da", Everyday, "Voucher Everyday")
-    )
-  }
 
-  private val uatCollection: List[ProductRatePlan[Paper.type]] = if (useDigitalVoucher) {
-    List(
+  private val uatCollection: List[ProductRatePlan[Paper.type]] = List(
       collection("2c92c0f870f682820171070489d542da", SaturdayPlus, "Voucher Saturday+"),
       collection("2c92c0f870f682820171070488df42ce", Saturday, "Voucher Saturday"),
       collection("2c92c0f870f68282017107047b214214", SundayPlus, "Voucher Sunday+"),
@@ -133,23 +116,8 @@ case object Paper extends Product {
       collection("2c92c0f870f682820171070481bf4264", EverydayPlus, "Voucher Everyday+"),
       collection("2c92c0f870f682820171070474ee419d", Everyday, "Voucher Everyday"),
     )
-  } else {
-    List(
-      collection("2c92c0f961f9cf350161fc0454283f3e", SaturdayPlus, "Voucher Saturday+"),
-      collection("2c92c0f961f9cf300161fc02a7d805c9", Saturday, "Voucher Saturday"),
-      collection("2c92c0f858aa38af0158b9dae19110a3", SundayPlus, "Voucher Sunday+"),
-      collection("2c92c0f95aff3b54015b0ee0eb500b2e", Sunday, "Voucher Sunday"),
-      collection("2c92c0f855c9f4b20155d9f1dd0651ab", WeekendPlus, "Voucher Weekends+"),
-      collection("2c92c0f855c9f4b20155d9f1db9b5199", Weekend, "Voucher Weekend"),
-      collection("2c92c0f855c9f4540155da2607db6402", SixdayPlus, "Voucher Sixday+"),
-      collection("2c92c0f955ca02910155da254a641fb3", Sixday, "Voucher Sixday"),
-      collection("2c92c0f955ca02920155da240cdb4399", EverydayPlus, "Voucher Everyday+"),
-      collection("2c92c0f855c9f4b20155d9f1d3d4512a", Everyday, "Voucher Everyday"),
-    )
-  }
 
-  private val sandboxCollection: List[ProductRatePlan[Paper.type]] = if (useDigitalVoucher) {
-    List(
+  private val sandboxCollection: List[ProductRatePlan[Paper.type]] = List(
       collection("2c92c0f86fa49142016fa49eb1732a39", SaturdayPlus, "Voucher Saturday paper+"),
       collection("2c92c0f86fa49142016fa49ea442291b", Saturday, "Voucher Saturday paper"),
       collection("2c92c0f86fa49142016fa49ea90e2976", SundayPlus, "Voucher Sunday paper+"),
@@ -161,20 +129,6 @@ case object Paper extends Product {
       collection("2c92c0f86fa49142016fa49eaa492988", EverydayPlus, "Voucher Everyday+"),
       collection("2c92c0f86fa49142016fa49ea56a2938", Everyday, "Voucher Everyday"),
     )
-  } else {
-    List(
-      collection("2c92c0f961f9cf300161fc44f2661258", SaturdayPlus, "Voucher Saturday paper+"),
-      collection("2c92c0f861f9c26d0161fc434bfe004c", Saturday, "Voucher Saturday paper"),
-      collection("2c92c0f955a0b5bf0155b62623846fc8", SundayPlus, "Voucher Sunday paper+"),
-      collection("2c92c0f95aff3b56015b1045fb9332d2", Sunday, "Voucher Sunday paper"),
-      collection("2c92c0f95aff3b54015b1047efaa2ac3", WeekendPlus, "Voucher Weekend+"),
-      collection("2c92c0f8555ce5cf01556e7f01b81b94", Weekend, "Voucher Weekend"),
-      collection("2c92c0f855c3b8190155c585a95e6f5a", SixdayPlus, "Voucher Sixday+"),
-      collection("2c92c0f8555ce5cf01556e7f01771b8a", Sixday, "Voucher Sixday"),
-      collection("2c92c0f95aff3b53015b10469bbf5f5f", EverydayPlus, "Voucher Everyday+"),
-      collection("2c92c0f9555cf10501556e84a70440e2", Everyday, "Voucher Everyday"),
-    )
-  }
 
   lazy val ratePlans: Map[TouchPointEnvironment, List[ProductRatePlan[Paper.type]]] =
     Map(

--- a/support-workers/src/main/scala/com/gu/emailservices/PaperEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/PaperEmailFields.scala
@@ -20,7 +20,7 @@ class PaperEmailFields(
 
     val dataExtension: String = paper.product.fulfilmentOptions match {
       case HomeDelivery => "paper-delivery"
-      case _ => if (Paper.useDigitalVoucher) "paper-subscription-card" else "paper-voucher"
+      case _ => "paper-subscription-card"
     }
 
     paperFieldsGenerator.fieldsFor(


### PR DESCRIPTION
## Why are you doing this?

Now that Subscription Card (AKA digital voucher or iMovo) is live we no longer need a flag for whether to use it or not. This PR removes that flag.

[**Trello Card**](https://trello.com/c/qMSYti7t/3400-post-subs-card-launch-remove-usedigitalvoucher-switch)

This PR is an update of https://github.com/guardian/support-frontend/pull/2794 - that had hung around for so long that it was easier to start again than update it.
