### PR TITLE
Fix PRB bugs

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
@@ -115,7 +115,7 @@ function withProps(props: PropTypes) {
             id="contributionOther"
             label={`Other amount (${otherLabelSymbol})`}
             value={otherAmount}
-            onBlur={e => props.updateOtherAmount(
+            onChange={e => props.updateOtherAmount(
               (e.target: any).value,
               props.countryGroupId,
               props.contributionType,

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -397,10 +397,10 @@ const PaymentRequestButton = (props: PropTypes) => {
 
   useEffect(() => {
     // Call canMakePayment on the paymentRequest object only once, once the stripe object is ready
-    if (stripe) {
+    if (stripe && !props.stripePaymentRequestButtonData.stripePaymentRequestObject) {
       initialisePaymentRequest({ ...props }, stripe);
     }
-  }, [stripe]);
+  }, [stripe, props.stripePaymentRequestButtonData.stripePaymentRequestObject]);
 
   if (
     !props.stripePaymentRequestButtonData.paymentMethod ||


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Fix a couple of bugs with the stripe PRB:

1. the `otherAmount` field was only updating the redux state `onBlur` this meant there was a race condition when clicking on the PRB after updating the amount, meaning the previous value was shown in the PRB window.
2. when swapping between single and recurring contributions, the `stripePaymentRequestObject` was being recreated, which caused a bug in which updating the selected amount wouldn't update the amount shown in the PRB window.

[**Trello Card**](https://trello.com/c/l3S3VLnX/2602-prb-apple-pay-amount-sometimes-does-not-update)

**NB**: This *does* affect the UX of the page slightly. Error messages are now shown immediately on the `otherAmount` field. Whilst this isn't ideal, we decided to wait on the full UX audit of the LP before spending too much time coming up with a better solution. 
