### PR TITLE
Roll back changes made to support accordion AB test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -12,7 +12,6 @@ import type { Tests } from './abtest';
 const allLandingPagesAndThankyouPages = '/contribute|thankyou(/.*)?$';
 const notUkLandingPage = '/us|au|eu|int|nz|ca/contribute(/.*)?$';
 export const subsShowcaseAndDigiSubPages = '(/??/subscribe(\\?.*)?$|/??/subscribe/digital(\\?.*)?$)';
-const digiSubLandingPages = '(/??/subscribe/digital/gift(\\?.*)?$|/??/subscribe/digital(\\?.*)?$)';
 
 export const tests: Tests = {
   thankyouPageHeadingTest: {
@@ -76,28 +75,6 @@ export const tests: Tests = {
     referrerControlled: false,
     targetPage: allLandingPagesAndThankyouPages,
     seed: 12,
-  },
-
-  accordionTest: {
-    variants: [
-      {
-        id: 'control',
-      },
-      {
-        id: 'accordionOpen',
-      },
-    ],
-    audiences: {
-      ALL: {
-        offset: 0,
-        size: 1,
-      },
-    },
-    isActive: true,
-    referrerControlled: false,
-    targetPage: digiSubLandingPages,
-    seed: 16,
-    optimizeId: 'oeDqGqpqT4OLrAaMJjYz6A',
   },
 
   thankyouPageMarketingConsentTestR2: {

--- a/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/paymentSelection/helpers/paymentSelection.jsx
@@ -28,7 +28,6 @@ import { getAppliedPromo } from 'helpers/productPrice/promotions';
 import { getFirstValidPrice, isNumeric } from 'helpers/productPrice/productPrices';
 
 import { type PropTypes } from '../paymentSelection';
-import { gaEvent } from 'helpers/tracking/googleTagManager';
 
 export type PaymentOption = {
   title: string,
@@ -139,21 +138,12 @@ const mapStateToProps = (state: State): PropTypes => {
       componentType: 'ACQUISITIONS_BUTTON',
     };
 
-    const trackClick = () => {
-      gaEvent({
-        category: 'click',
-        action: 'DigitalPack',
-        label: trackingProperties.id,
-      });
-      sendTrackingEventsOnClick(trackingProperties)();
-    };
-
     return orderIsAGift ?
       {
         title: BILLING_PERIOD_GIFT[digitalBillingPeriodGift].title,
         price: getDisplayPrice(currencyId, fullPrice),
         href: getDigitalCheckout(countryGroupId, billingPeriodForHref, promoCode, orderIsAGift),
-        onClick: trackClick,
+        onClick: sendTrackingEventsOnClick(trackingProperties),
         onView: sendTrackingEventsOnView(trackingProperties),
         priceCopy: BILLING_PERIOD_GIFT[digitalBillingPeriodGift].salesCopy(),
         offerCopy: '',
@@ -164,7 +154,7 @@ const mapStateToProps = (state: State): PropTypes => {
         title: BILLING_PERIOD[digitalBillingPeriod].title,
         price: getDisplayPrice(currencyId, getFirstValidPrice(promotionalPrice, fullPrice)),
         href: getDigitalCheckout(countryGroupId, billingPeriodForHref, promoCode, orderIsAGift),
-        onClick: trackClick,
+        onClick: sendTrackingEventsOnClick(trackingProperties),
         onView: sendTrackingEventsOnView(trackingProperties),
         priceCopy: BILLING_PERIOD[digitalBillingPeriod].salesCopy(currencyId, fullPrice, promotionalPrice),
         offerCopy,

--- a/support-frontend/assets/pages/digital-subscription-landing/components/productBlock/productBlock.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/productBlock/productBlock.jsx
@@ -140,15 +140,14 @@ type StateTypes = {
 type PropTypes = {
   // eslint-ignore no-unused-prop-types
   countryGroupId: CountryGroupId,
-  accordionOpen: boolean,
 }
 
 class ProductBlock extends Component<PropTypes, StateTypes> {
   constructor(props: PropTypes) {
     super(props);
     this.state = {
-      showDropDownDaily: props.accordionOpen,
-      showDropDownApp: props.accordionOpen,
+      showDropDownDaily: false,
+      showDropDownApp: false,
     };
   }
 

--- a/support-frontend/assets/pages/digital-subscription-landing/components/productBlock/productBlockAus.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/productBlock/productBlockAus.jsx
@@ -136,15 +136,14 @@ type StateTypes = {
 type PropTypes = {
   // eslint-ignore no-unused-prop-types
   countryGroupId: CountryGroupId,
-  accordionOpen: boolean,
 }
 
 class ProductBlockAus extends Component<PropTypes, StateTypes> {
   constructor(props: PropTypes) {
     super(props);
     this.state = {
-      showDropDownDaily: props.accordionOpen,
-      showDropDownApp: props.accordionOpen,
+      showDropDownDaily: false,
+      showDropDownApp: false,
     };
   }
 

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -46,11 +46,8 @@ import FeedbackWidget from 'pages/digital-subscription-landing/components/feedba
 
 const store = pageInit(() => digitalSubscriptionLandingReducer, true);
 
-const { common, page } = store.getState();
-const { orderIsAGift, productPrices, promotionCopy } = page;
-const { abParticipations } = common;
+const { orderIsAGift, productPrices, promotionCopy } = store.getState().page;
 const sanitisedPromoCopy = getPromotionCopy(promotionCopy);
-const accordionOpen = abParticipations.accordionTest === 'accordionOpen';
 
 // ----- Internationalisation ----- //
 
@@ -112,11 +109,9 @@ function LandingPage() {
       {countryGroupId === AUDCountries ?
         <ProductBlockAus
           countryGroupId={countryGroupId}
-          accordionOpen={accordionOpen}
         /> :
         <ProductBlock
           countryGroupId={countryGroupId}
-          accordionOpen={accordionOpen}
         />
       }
       <FullWidthContainer theme="dark" hasOverlap>


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This PR rolls back the changes put in place in https://github.com/guardian/support-frontend/pull/2994 to support the Accordion AB test. The original aim of the test is to see whether having the information accordions open by default will result in an increase in checkout starts. The results show the original implementation (closed by default) was 61% probability to be best, so we can roll back to that now.