### PR TITLE
Mj update currencies on payment api

### DIFF
--- a/support-internationalisation/src/main/scala/com/gu/i18n/Currency.scala
+++ b/support-internationalisation/src/main/scala/com/gu/i18n/Currency.scala
@@ -43,21 +43,21 @@ object Currency {
   case object SEK extends Currency {
     override def glyph: String = "SEK"
     override def prefix: Option[String] = Some("SE")
-    override def iso: String = "SEK"
+    override def iso: String = "kr"
   }
   case object CHF extends Currency {
     override def glyph: String = "CHF"
     override def prefix: Option[String] = Some("CH")
-    override def iso: String = "CHF"
+    override def iso: String = "fr"
   }
   case object NOK extends Currency {
     override def glyph: String = "NOK"
     override def prefix: Option[String] = Some("NO")
-    override def iso: String = "NOK"
+    override def iso: String = "kr"
   }
   case object DKK extends Currency {
     override def glyph: String = "DKK"
     override def prefix: Option[String] = Some("DK")
-    override def iso: String = "DKK"
+    override def iso: String = "kr."
   }
 }

--- a/support-internationalisation/src/main/scala/com/gu/i18n/Currency.scala
+++ b/support-internationalisation/src/main/scala/com/gu/i18n/Currency.scala
@@ -41,23 +41,23 @@ object Currency {
     override def iso: String = "NZD"
   }
   case object SEK extends Currency {
-    override def glyph: String = "SEK"
+    override def glyph: String = "kr"
     override def prefix: Option[String] = Some("SE")
-    override def iso: String = "kr"
+    override def iso: String = "SEK"
   }
   case object CHF extends Currency {
-    override def glyph: String = "CHF"
+    override def glyph: String = "fr."
     override def prefix: Option[String] = Some("CH")
-    override def iso: String = "fr"
+    override def iso: String = "CHF"
   }
   case object NOK extends Currency {
-    override def glyph: String = "NOK"
+    override def glyph: String = "kr"
     override def prefix: Option[String] = Some("NO")
-    override def iso: String = "kr"
+    override def iso: String = "NOK"
   }
   case object DKK extends Currency {
-    override def glyph: String = "DKK"
+    override def glyph: String = "kr."
     override def prefix: Option[String] = Some("DK")
-    override def iso: String = "kr."
+    override def iso: String = "DKK"
   }
 }

--- a/support-internationalisation/src/main/scala/com/gu/i18n/Currency.scala
+++ b/support-internationalisation/src/main/scala/com/gu/i18n/Currency.scala
@@ -41,22 +41,22 @@ object Currency {
     override def iso: String = "NZD"
   }
   case object SEK extends Currency {
-    override def glyph: String = "kr"
+    override def glyph: String = "SEK"
     override def prefix: Option[String] = Some("SE")
     override def iso: String = "SEK"
   }
   case object CHF extends Currency {
-    override def glyph: String = "fr"
+    override def glyph: String = "CHF"
     override def prefix: Option[String] = Some("CH")
     override def iso: String = "CHF"
   }
   case object NOK extends Currency {
-    override def glyph: String = "kr"
+    override def glyph: String = "NOK"
     override def prefix: Option[String] = Some("NO")
     override def iso: String = "NOK"
   }
   case object DKK extends Currency {
-    override def glyph: String = "kr."
+    override def glyph: String = "DKK"
     override def prefix: Option[String] = Some("DK")
     override def iso: String = "DKK"
   }

--- a/support-internationalisation/src/main/scala/com/gu/i18n/Currency.scala
+++ b/support-internationalisation/src/main/scala/com/gu/i18n/Currency.scala
@@ -8,7 +8,7 @@ sealed trait Currency {
 }
 
 object Currency {
-  val all = List(GBP, USD, AUD, CAD, EUR, NZD)
+  val all = List(GBP, USD, AUD, CAD, EUR, NZD, SEK, CHF, NOK, DKK)
 
   def fromString(s: String): Option[Currency] = all.find(_.iso == s)
 
@@ -40,5 +40,24 @@ object Currency {
     override def prefix: Option[String] = Some("NZ")
     override def iso: String = "NZD"
   }
-
+  case object SEK extends Currency {
+    override def glyph: String = "kr"
+    override def prefix: Option[String] = Some("SE")
+    override def iso: String = "SEK"
+  }
+  case object CHF extends Currency {
+    override def glyph: String = "fr"
+    override def prefix: Option[String] = Some("CH")
+    override def iso: String = "CHF"
+  }
+  case object NOK extends Currency {
+    override def glyph: String = "kr"
+    override def prefix: Option[String] = Some("NO")
+    override def iso: String = "NOK"
+  }
+  case object DKK extends Currency {
+    override def glyph: String = "kr."
+    override def prefix: Option[String] = Some("DK")
+    override def iso: String = "DKK"
+  }
 }

--- a/support-payment-api/src/main/scala/model/Currency.scala
+++ b/support-payment-api/src/main/scala/model/Currency.scala
@@ -23,6 +23,14 @@ object Currency extends Enum[Currency] with CirceEnum[Currency] {
 
   case object NZD extends Currency
 
+  case object SEK extends Currency
+
+  case object CHF extends Currency
+
+  case object NOK extends Currency
+
+  case object DKK extends Currency
+
   def exceedsMaxAmount(amount: BigDecimal, currency: Currency): Boolean = {
     val maxAmount = currency match {
       case AUD => 16000

--- a/support-payment-api/src/main/scala/model/acquisition/AcquisitionDataRowBuilder.scala
+++ b/support-payment-api/src/main/scala/model/acquisition/AcquisitionDataRowBuilder.scala
@@ -7,7 +7,18 @@ import com.gu.support.acquisitions.PaymentProvider.{AmazonPay, PayPal, Stripe, S
 import com.gu.support.acquisitions._
 import com.gu.support.zuora.api.ReaderType
 import model.{Currency => ModelCurrency}
-import model.Currency.{AUD => ModelAUD, CAD => ModelCAD, EUR => ModelEUR, GBP => ModelGBP, NZD => ModelNZD, USD => ModelUSD}
+import model.Currency.{
+  AUD => ModelAUD,
+  CAD => ModelCAD,
+  EUR => ModelEUR,
+  GBP => ModelGBP,
+  NZD => ModelNZD,
+  USD => ModelUSD,
+  SEK => ModelSEK,
+  CHF => ModelCHF,
+  NOK => ModelNOK,
+  DKK => ModelDKK,
+}
 import model.db.ContributionData
 import model.stripe.StripePaymentMethod
 import ophan.thrift.event.{AbTest, QueryParameter => ThriftQueryParam}
@@ -151,6 +162,10 @@ object AcquisitionDataRowBuilder {
       case ModelAUD => AUD
       case ModelCAD => CAD
       case ModelNZD => NZD
+      case ModelSEK => SEK
+      case ModelCHF => CHF
+      case ModelNOK => NOK
+      case ModelDKK => DKK
     }
 
   def mapQueryParams(maybeThriftParameters: Option[Set[ThriftQueryParam]]) =

--- a/support-payment-api/src/main/scala/model/email/ContributorRow.scala
+++ b/support-payment-api/src/main/scala/model/email/ContributorRow.scala
@@ -75,6 +75,10 @@ case class ContributorRow(
     case "AUD" => "AU$"
     case "CAD" => "CA$"
     case "NZD" => "NZ$"
+    case "SEK" => "kr"
+    case "CHF" => "fr"
+    case "NOK" => "kr"
+    case "DKK" => "kr."
     case _ => "$"
   }
 

--- a/support-payment-api/src/main/scala/model/email/ContributorRow.scala
+++ b/support-payment-api/src/main/scala/model/email/ContributorRow.scala
@@ -76,7 +76,7 @@ case class ContributorRow(
     case "CAD" => "CA$"
     case "NZD" => "NZ$"
     case "SEK" => "kr"
-    case "CHF" => "fr"
+    case "CHF" => "fr."
     case "NOK" => "kr"
     case "DKK" => "kr."
     case _ => "$"


### PR DESCRIPTION
### What does this PR do?
Adds four European currencies to the api
- Swedish Krona (SEK)
- Swiss Franc (CHF)
- Norwegian Krone (NOK)
- Danish Krone (DKK)

These are the top four European countries, which don't use Euros as their nation currency, from which we receive contributions. This PR is laying groundwork for us to run A/B tests to assess the effectiveness of offering local currencies.