### PR TITLE
remove references to bintray

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -192,8 +192,6 @@ lazy val `support-internationalisation` = (project in file("support-internationa
 lazy val `acquisition-event-producer` = (project in file("acquisition-event-producer"))
   .settings(
     licenses += ("MIT", url("http://opensource.org/licenses/MIT")),
-    bintrayOrganization := Some("guardian"),
-    bintrayRepository := "ophan",
     publishMavenStyle := true,
     scalacOptions += "-Ymacro-annotations",
     libraryDependencies ++= Seq(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,4 @@
 logLevel := Level.Warn
-addSbtPlugin("org.foundweekends" % "sbt-bintray" % "0.5.1")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
 

--- a/support-frontend/app/wiring/AppLoader.scala
+++ b/support-frontend/app/wiring/AppLoader.scala
@@ -1,15 +1,22 @@
 package wiring
 
-import java.io.File
-
-import com.gu.aws.CredentialsProvider
-import com.gu.{AppIdentity, AwsIdentity, DevIdentity}
+import com.gu.aws.ProfileName
 import com.gu.conf._
+import com.gu.{AppIdentity, AwsIdentity, DevIdentity}
 import com.typesafe.scalalogging.StrictLogging
 import play.api.ApplicationLoader.Context
 import play.api._
+import software.amazon.awssdk.auth.credentials._
+
+import java.io.File
 
 class AppLoader extends ApplicationLoader with StrictLogging {
+
+  lazy val CredentialsProvider = AwsCredentialsProviderChain.builder.credentialsProviders(
+    ProfileCredentialsProvider.builder.profileName(ProfileName).build,
+    InstanceProfileCredentialsProvider.builder.asyncCredentialUpdateEnabled(false).build,
+    EnvironmentVariableCredentialsProvider.create()
+  ).build
 
   private def getParameterStoreConfig(initialConfiguration: Configuration): Configuration = {
     val identity = AppIdentity.whoAmI(defaultAppName = "support-frontend", CredentialsProvider)

--- a/support-frontend/build.sbt
+++ b/support-frontend/build.sbt
@@ -9,11 +9,9 @@ testOptions in SeleniumTest := Seq(Tests.Filter(seleniumTestFilter))
 
 testOptions in Test := Seq(Tests.Filter(unitTestFilter))
 
-resolvers += "Guardian Platform Bintray" at "https://dl.bintray.com/guardian/platforms"
-
 libraryDependencies ++= Seq(
   "com.typesafe" % "config" % "1.3.2",
-  "com.gu" %% "simple-configuration-ssm" % "1.5.3",
+  "com.gu" %% "simple-configuration-ssm" % "1.5.5",
   "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0" % Test,
   "org.mockito" % "mockito-core" % "2.28.2" % Test,
   "io.sentry" % "sentry-logback" % "1.7.5",

--- a/support-models/build.sbt
+++ b/support-models/build.sbt
@@ -16,5 +16,3 @@ libraryDependencies ++= Seq(
   "com.fasterxml.jackson.core" % "jackson-annotations" % jacksonVersion,
   "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % jacksonVersion
 )
-
-resolvers ++= Seq(Resolver.bintrayRepo("guardian", "ophan")) //event producer library

--- a/support-payment-api/build.sbt
+++ b/support-payment-api/build.sbt
@@ -53,7 +53,6 @@ libraryDependencies ++= Seq(
   "org.scala-lang.modules" %% "scala-xml" % "1.2.0"
 )
 
-resolvers += Resolver.bintrayRepo("guardian", "ophan")
 resolvers += Resolver.sonatypeRepo("releases")
 
 debianPackageDependencies := Seq("openjdk-8-jre-headless")

--- a/support-workers/build.sbt
+++ b/support-workers/build.sbt
@@ -1,7 +1,6 @@
-import scala.sys.process._
 import LibraryVersions._
 import com.gu.riffraff.artifact.RiffRaffArtifact.autoImport.riffRaffManifestProjectName
-import sbt.Keys.{libraryDependencies, resolvers}
+import sbt.Keys.libraryDependencies
 
 version := "0.1-SNAPSHOT"
 scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked", "-target:jvm-1.8", "-Xfatal-warnings")


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This PR removes references to bintray, and also updates the SSM configuration library to use one that is in normal sonatyle.

https://trello.com/c/cyWdxhry/3659-remove-support-frontend-dependency-on-bintray

## Why are you doing this?

Bintray is going away on 1st may https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/
