### PR TITLE
Restart marketing consent test

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -77,7 +77,7 @@ export const tests: Tests = {
     seed: 12,
   },
 
-  thankyouPageMarketingConsentTestR2: {
+  thankyouPageMarketingConsentTestR3: {
     variants: [
       {
         id: 'control',
@@ -98,6 +98,6 @@ export const tests: Tests = {
     isActive: true,
     referrerControlled: false,
     targetPage: allLandingPagesAndThankyouPages,
-    seed: 17,
+    seed: 18,
   },
 };

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouMarketingConsent.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouMarketingConsent.jsx
@@ -44,7 +44,7 @@ const V2_COPY = 'Stay up-to-date with ways to enjoy and support our journalism, 
 
 const mapStateToProps = state => ({
   thankyouPageMarketingConsentTestVariant:
-    state.common.abParticipations.thankyouPageMarketingConsentTest,
+    state.common.abParticipations.thankyouPageMarketingConsentTestR3,
 });
 
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
Restart marketing consent test to start collecting data again. We had updated the name of the test `thankyouPageMarketingConsentTest` -> `thankyouPageMarketingConsentTestR2` in the definition, but not where it was being used (in the `ContributionThankYouMarketingConsent` component). This meant that users we segmented into different variants, but would have all seen the control copy. I think when we upgrade to typescript we should try and catch this sort of error.

## Screenshots

### control
<img width="648" alt="Screenshot 2021-04-16 at 11 46 12" src="https://user-images.githubusercontent.com/17720442/115014320-15a9a380-9eaa-11eb-9151-d097f339268e.png">

### v1
<img width="648" alt="Screenshot 2021-04-16 at 11 46 27" src="https://user-images.githubusercontent.com/17720442/115014325-17736700-9eaa-11eb-9a45-86cdcf5d410b.png">

### v2
<img width="648" alt="Screenshot 2021-04-16 at 11 46 38" src="https://user-images.githubusercontent.com/17720442/115014328-18a49400-9eaa-11eb-9897-b8415a7aaeee.png">
