### PR TITLE
Update the copy from 'a month/year' to 'per month/year'

### DIFF
--- a/support-frontend/assets/helpers/contributions.js
+++ b/support-frontend/assets/helpers/contributions.js
@@ -388,10 +388,10 @@ function getFrequency(contributionType: ContributionType): string {
   if (contributionType === 'ONE_OFF') {
     return '';
   } else if (contributionType === 'MONTHLY') {
-    return 'a month';
+    return 'per month';
   }
 
-  return 'a year';
+  return 'per year';
 
 }
 


### PR DESCRIPTION
## What are you doing in this PR?
Update the copy for the monthly/annual price breakdown from 'a (month/year)' to 'per (month/year)' to be consistent with the other parts of the landing page

[**Trello Card**](https://trello.com/c/A4iF30AB/2609-change-landing-page-cta-copy)

## Screenshots
<img width="484" alt="Screenshot 2021-04-19 at 15 48 02" src="https://user-images.githubusercontent.com/47318984/115255932-adb3c100-a126-11eb-9778-ca0c49fdefdc.png">
<img width="484" alt="Screenshot 2021-04-19 at 15 48 10" src="https://user-images.githubusercontent.com/47318984/115255947-b1474800-a126-11eb-9f51-4bbd738bf5cb.png">

