### PR TITLE
Fix click tracking on the accordions

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-checkout/components/addDigiSubCta.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/addDigiSubCta.jsx
@@ -78,14 +78,20 @@ const listCopy = [
 ];
 
 function AddDigiSubCta({ addDigitalSubscription, digiSubPrice }: PropTypes) {
+  const initialRender = React.useRef(true);
   const [expanded, setExpanded] = React.useState<boolean>(false);
 
   React.useEffect(() => {
-    sendTrackingEventsOnClick({
-      id: `Paper_Checkout_DigiPlus_Accordion-${expanded ? 'expand' : 'minimize'}`,
-      product: 'Paper',
-      componentType: 'ACQUISITIONS_OTHER',
-    })();
+    // don't call sendTrackingEventsOnClick on initialRender
+    if (initialRender.current) {
+      initialRender.current = false;
+    } else {
+      sendTrackingEventsOnClick({
+        id: `Paper_Checkout_DigiPlus_Accordion-${expanded ? 'expand' : 'minimize'}`,
+        product: 'Paper',
+        componentType: 'ACQUISITIONS_OTHER',
+      })();
+    }
   }, [expanded]);
 
   return (

--- a/support-frontend/assets/pages/paper-subscription-landing/components/content/tabAccordionRow.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/content/tabAccordionRow.jsx
@@ -15,14 +15,20 @@ type TabAccordionRowPropTypes = {|
 export const TabAccordionRow = ({
   trackingId, label, children,
 }: TabAccordionRowPropTypes) => {
+  const initialRender = React.useRef(true);
   const [expanded, setExpanded] = React.useState<boolean>(false);
 
   React.useEffect(() => {
-    sendTrackingEventsOnClick({
-      id: `${trackingId}-${expanded ? 'expand' : 'minimize'}`,
-      product: 'Paper',
-      componentType: 'ACQUISITIONS_BUTTON',
-    })();
+    // don't call sendTrackingEventsOnClick on initialRender
+    if (initialRender.current) {
+      initialRender.current = false;
+    } else {
+      sendTrackingEventsOnClick({
+        id: `${trackingId}-${expanded ? 'expand' : 'minimize'}`,
+        product: 'Paper',
+        componentType: 'ACQUISITIONS_BUTTON',
+      })();
+    }
   }, [expanded]);
 
   return (


### PR DESCRIPTION
## What are you doing in this PR?

This fixes an issue where `sendTrackingEventsOnClick` was being called on the initial render of an accordion component. This was happening as we'd made use of `useEffect` to call `sendTrackingEventsOnClick` when the `expanded` state of the accordion was updated (via a click event). `useEffect` however is called on initial render too. 

To prevent this I'm making use  of `useRef` as it can be used to store a mutable value (`initialRender`) that persists across re-renders, the value of this is `true` at first, and on initial render we set it to `false`, so any subsequent change to the `expanded` state will result in `sendTrackingEventsOnClick` being called.
