### PR TITLE
Hide digi subs feedback widget until user has scrolled past the hero

### DIFF
--- a/support-frontend/assets/pages/digital-subscription-landing/components/feedbackWidget/feedbackWidget.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/feedbackWidget/feedbackWidget.jsx
@@ -8,18 +8,18 @@ import { ThemeProvider } from 'emotion-theming';
 
 import { Button, LinkButton, buttonBrand } from '@guardian/src-button';
 import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
-import { clickedCss, wrapper, widgetTitle, buttonStyles, feedbackLink, header } from './feedbackWidgetStyles';
+import { clickedCss, hideWidget, wrapper, widgetTitle, buttonStyles, feedbackLink, header } from './feedbackWidgetStyles';
 import { SvgThumbsUp } from './thumbsUp';
 import { SvgThumbsDown } from './thumbsDown';
 
-function FeedbackWidget() {
+function FeedbackWidget({ display }: { display: boolean }) {
 
   const [clicked, setClicked] = useState({ positive: false, negative: false, open: false });
   const positiveButtonCss = clicked.positive ? clickedCss : null;
   const negativeButtonCss = clicked.negative ? clickedCss : null;
 
   return (
-    <aside css={wrapper}>
+    <aside css={[wrapper, display ? '' : hideWidget]}>
       <fieldset role="group" >
         <div css={header}>
           <p css={widgetTitle}>

--- a/support-frontend/assets/pages/digital-subscription-landing/components/feedbackWidget/feedbackWidgetStyles.js
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/feedbackWidget/feedbackWidgetStyles.js
@@ -10,11 +10,19 @@ import { textSans } from '@guardian/src-foundations/typography';
 
 // ----- Constants ----- //
 
+export const hideWidget = css`
+  visibility: hidden;
+  max-height: 0;
+`;
+
 export const wrapper = css`
+  visibility: visible;
   position: fixed;
   z-index: 10;
   bottom: 0;
   width: 100%;
+  max-height: 200px;
+  transition: max-height 0.5s ease;
 
   ${from.phablet} {
     width: 300px;

--- a/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/digitalSubscriptionLanding.jsx
@@ -18,6 +18,7 @@ import {
 } from 'helpers/internationalisation/countryGroup';
 import { init as pageInit } from 'helpers/page/page';
 import { routes } from 'helpers/routes';
+import { useHasBeenSeen } from 'helpers/useHasBeenSeen';
 
 import Page from 'components/page/page';
 import FullWidthContainer from 'components/containers/fullWidthContainer';
@@ -85,6 +86,11 @@ const CountrySwitcherHeader = headerWithCountrySwitcherContainer({
 
 // ----- Render ----- //
 function LandingPage() {
+  const [widgetShouldDisplay, setElementToObserve] = useHasBeenSeen({
+    threshold: 0.3,
+    debounce: true,
+  });
+
   const footer = (
     <div className="footer-container">
       <div className="footer-alignment">
@@ -106,14 +112,16 @@ function LandingPage() {
         <CampaignHeaderGift countryGroupId={countryGroupId} promotionCopy={sanitisedPromoCopy} /> :
         <CampaignHeader countryGroupId={countryGroupId} promotionCopy={sanitisedPromoCopy} />
       }
-      {countryGroupId === AUDCountries ?
-        <ProductBlockAus
-          countryGroupId={countryGroupId}
-        /> :
-        <ProductBlock
-          countryGroupId={countryGroupId}
-        />
-      }
+      <div ref={setElementToObserve}>
+        {countryGroupId === AUDCountries ?
+          <ProductBlockAus
+            countryGroupId={countryGroupId}
+          /> :
+          <ProductBlock
+            countryGroupId={countryGroupId}
+          />
+        }
+      </div>
       <FullWidthContainer theme="dark" hasOverlap>
         <CentredContainer>
           <Prices orderIsAGift={orderIsAGift} />
@@ -124,7 +132,7 @@ function LandingPage() {
           <GiftNonGiftCta product="digital" href={giftNonGiftLink} orderIsAGift={orderIsAGift} />
         </CentredContainer>
       </FullWidthContainer>
-      <FeedbackWidget />
+      <FeedbackWidget display={widgetShouldDisplay} />
     </Page>
   );
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This ensures the feedback widget on the digital subs landing page won't display until the user has scrolled part way through the product information block, at which point it will gently animate in.

## Why are you doing this?

The feedback widget takes up a lot of above-the-fold space on small mobile devices. It also seems a bit odd to be asking users how helpful they find the page when they've barely seen any of it!

## Screenshots

Apologies for low gif quality!

**Mobile - iPhone SE**
![feedback-widget-iphoneSE](https://user-images.githubusercontent.com/29146931/115596816-71bc5f80-a2d0-11eb-8228-41ecf8ca57cf.gif)

**Tablet - Samsung Galaxy Tab S7**
![feedback-widget-galaxyTabS7](https://user-images.githubusercontent.com/29146931/115596922-944e7880-a2d0-11eb-9f04-2d62dfa35982.gif)

**Desktop - Firefox/macOS**
![feedback-widget-desktop](https://user-images.githubusercontent.com/29146931/115596993-a6301b80-a2d0-11eb-8178-aeb87a8e34a3.gif)
