### PR TITLE
Fix paper checkout country change bug

### DIFF
--- a/support-frontend/assets/helpers/subscriptionsForms/formReducer.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/formReducer.js
@@ -65,7 +65,9 @@ function createFormReducer(
   };
 
   const getFulfilmentOption = (action, currentOption) =>
-    (action.scope === 'delivery' ? getWeeklyFulfilmentOption(action.country) : currentOption);
+    // For GuardianWeekly subs, when the country changes we need to update the fulfilment option
+    // because it may mean a switch between domestic and rest of the world
+    (product === GuardianWeekly && action.scope === 'delivery' ? getWeeklyFulfilmentOption(action.country) : currentOption);
 
   return (originalState: FormState = initialState, action: Action): FormState => {
 
@@ -107,16 +109,10 @@ function createFormReducer(
         return { ...state, billingPeriod: action.billingPeriod };
 
       case 'SET_COUNTRY_CHANGED':
-        // For GuardianWeekly subs, when the country changes we need to update the fulfilment option
-        // because it may mean a switch between domestic and rest of the world
-        const fulfilmentOption = state.product === GuardianWeekly ?
-          getFulfilmentOption(action, state.fulfilmentOption) :
-          state.fulfilmentOption;
-
         return {
           ...state,
           paymentMethod: null,
-          fulfilmentOption,
+          fulfilmentOption: getFulfilmentOption(action, state.fulfilmentOption),
         };
 
       case 'SET_PAYMENT_METHOD':

--- a/support-frontend/assets/helpers/subscriptionsForms/formReducer.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/formReducer.js
@@ -19,6 +19,7 @@ import {
 } from 'helpers/productPrice/fulfilmentOptions';
 import type { FormState } from 'helpers/subscriptionsForms/formFields';
 import type { Option } from 'helpers/types/option';
+import { GuardianWeekly } from 'helpers/subscriptions';
 
 function createFormReducer(
   initialCountry: IsoCountry,
@@ -106,12 +107,16 @@ function createFormReducer(
         return { ...state, billingPeriod: action.billingPeriod };
 
       case 'SET_COUNTRY_CHANGED':
+        // For GuardianWeekly subs, when the country changes we need to update the fulfilment option
+        // because it may mean a switch between domestic and rest of the world
+        const fulfilmentOption = state.product === GuardianWeekly ?
+          getFulfilmentOption(action, state.fulfilmentOption) :
+          state.fulfilmentOption;
+
         return {
           ...state,
           paymentMethod: null,
-          // When the country changes we need to update the fulfilment option because it may mean
-          // a switch between domestic and rest of the world
-          fulfilmentOption: getFulfilmentOption(action, state.fulfilmentOption),
+          fulfilmentOption,
         };
 
       case 'SET_PAYMENT_METHOD':


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
There was a bug in the newspaper checkout where if you changed the country drop down to Isle of Man it ended up setting the fulfilment options to a value which is not applicable to newspaper and this broke things. This was because of some code which only applies to Guardian Weekly but was being run on the paper checkout as well.

<!--
This pr adds a widget to the doogle so that we can buy a sub from any page in one click
For detailed changes see the inline self-review comments.
-->


[**Trello Card**](https://trello.com/c/sMfwCmXm/3671-country-dropdown-bug-on-newspaper)

## Why are you doing this?

<!--
Remember, PRs are documentation for future contributors.
-->

## Accessibility test checklist
 - [ ] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
 - [ ] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
 - [ ] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

## Screenshots

