### PR TITLE
Use delivery address country to determine currency in GW checkout

### DIFF
--- a/support-frontend/assets/components/subscriptionCheckouts/billingPeriodSelector.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/billingPeriodSelector.jsx
@@ -20,7 +20,7 @@ type PropTypes = {|
   productPrices: ProductPrices,
   billingPeriods: BillingPeriod[],
   fulfilmentOption?: FulfilmentOptions,
-  billingCountry: IsoCountry,
+  pricingCountry: IsoCountry,
   selected: BillingPeriod,
   onChange: (BillingPeriod) => Action,
 |}
@@ -32,7 +32,7 @@ function BillingPeriodSelector(props: PropTypes) {
         {props.billingPeriods.map((billingPeriod) => {
           const productPrice = getProductPrice(
             props.productPrices,
-            props.billingCountry,
+            props.pricingCountry,
             billingPeriod,
             props.fulfilmentOption,
           );

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.js
@@ -290,22 +290,28 @@ function trackSubmitAttempt(
   trackCheckoutSubmitAttempt(componentId, productType, paymentMethod, productType);
 }
 
+function getPricingCountry(product, addresses) {
+  if (product === GuardianWeekly)
+    return addresses.deliveryAddress.country;
+  return addresses.billingAddress.country;
+}
+
 function submitForm(
   dispatch: Dispatch<Action>,
   state: AnyCheckoutState,
 ) {
-  const addresses = getAddresses(state);
-  const billingCountry = addresses.billingAddress.country;
-
   const {
     paymentMethod, product, productOption, isTestUser,
   } = state.page.checkout;
+
+  const addresses = getAddresses(state);
+  const pricingCountry = getPricingCountry(product, addresses);
 
   trackSubmitAttempt(paymentMethod, product, productOption);
 
   let priceDetails = finalPrice(
     state.page.checkout.productPrices,
-    billingCountry,
+    pricingCountry,
     state.page.checkout.billingPeriod,
     state.page.checkout.fulfilmentOption,
     state.page.checkout.productOption,
@@ -315,7 +321,7 @@ function submitForm(
   if (state.page.checkout.billingPeriod === Quarterly && priceDetails.price === 6) {
     priceDetails = getProductPrice(
       state.page.checkout.productPrices,
-      billingCountry,
+      pricingCountry,
       state.page.checkout.billingPeriod,
       state.page.checkout.fulfilmentOption,
       state.page.checkout.productOption,
@@ -323,7 +329,7 @@ function submitForm(
   }
 
   const { price, currency } = priceDetails;
-  const currencyId = getCurrency(billingCountry);
+  const currencyId = getCurrency(pricingCountry);
   const stripePaymentMethod = paymentMethod === Stripe ? state.page.checkout.stripePaymentMethod : null;
 
   const onAuthorised = (paymentAuthorisation: PaymentAuthorisation) =>
@@ -340,7 +346,7 @@ function submitForm(
     isTestUser,
     price,
     currency,
-    billingCountry,
+    pricingCountry,
     paymentMethod,
     stripePaymentMethod,
     state,

--- a/support-frontend/assets/helpers/subscriptionsForms/submit.js
+++ b/support-frontend/assets/helpers/subscriptionsForms/submit.js
@@ -291,8 +291,9 @@ function trackSubmitAttempt(
 }
 
 function getPricingCountry(product, addresses) {
-  if (product === GuardianWeekly)
+  if (product === GuardianWeekly && addresses.deliveryAddress) {
     return addresses.deliveryAddress.country;
+  }
   return addresses.billingAddress.country;
 }
 

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -168,7 +168,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
     props.setBillingAddressIsSame(newState);
     props.setBillingCountry(props.deliveryCountry);
   };
-  const paymentMethods = supportedPaymentMethods(props.billingCountry);
+  const paymentMethods = supportedPaymentMethods(props.deliveryCountry);
 
   return (
     <Content modifierClasses={['your-details']}>
@@ -311,7 +311,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
           {paymentMethods.length > 1 ?
             <FormSection title="How would you like to pay?">
               <PaymentMethodSelector
-                country={props.billingCountry}
+                country={props.deliveryCountry}
                 paymentMethod={props.paymentMethod}
                 setPaymentMethod={props.setPaymentMethod}
                 validationError={firstError('paymentMethod', props.formErrors)}
@@ -324,7 +324,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
             title="Your card details"
           >
             <StripeProviderForCountry
-              country={props.billingCountry}
+              country={props.deliveryCountry}
               isTestUser={props.isTestUser}
               submitForm={props.submitForm}
               allErrors={[...props.billingAddressErrors, ...props.deliveryAddressErrors, ...props.formErrors]}

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -160,7 +160,7 @@ const days = getWeeklyDays();
 
 function WeeklyCheckoutForm(props: PropTypes) {
   const fulfilmentOption = getWeeklyFulfilmentOption(props.deliveryCountry);
-  const price = getProductPrice(props.productPrices, props.billingCountry, props.billingPeriod, fulfilmentOption);
+  const price = getProductPrice(props.productPrices, props.deliveryCountry, props.billingPeriod, fulfilmentOption);
   const submissionErrorHeading = props.submissionError === 'personal_details_incorrect' ? 'Sorry there was a problem' :
     'Sorry we could not process your payment';
 
@@ -304,7 +304,7 @@ function WeeklyCheckoutForm(props: PropTypes) {
             fulfilmentOption={fulfilmentOption}
             onChange={billingPeriod => props.setBillingPeriod(billingPeriod)}
             billingPeriods={weeklyBillingPeriods}
-            billingCountry={props.billingCountry}
+            pricingCountry={props.deliveryCountry}
             productPrices={props.productPrices}
             selected={props.billingPeriod}
           />

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.jsx
@@ -163,7 +163,7 @@ const days = getWeeklyDays();
 
 function WeeklyCheckoutFormGifting(props: PropTypes) {
   const fulfilmentOption = getWeeklyFulfilmentOption(props.deliveryCountry);
-  const price = getProductPrice(props.productPrices, props.billingCountry, props.billingPeriod, fulfilmentOption);
+  const price = getProductPrice(props.productPrices, props.deliveryCountry, props.billingPeriod, fulfilmentOption);
   const submissionErrorHeading = props.submissionError === 'personal_details_incorrect' ? 'Sorry there was a problem' :
     'Sorry we could not process your payment';
 
@@ -171,7 +171,7 @@ function WeeklyCheckoutFormGifting(props: PropTypes) {
     props.setBillingAddressIsSame(newState);
     props.setBillingCountry(props.deliveryCountry);
   };
-  const paymentMethods = supportedPaymentMethods(props.billingCountry);
+  const paymentMethods = supportedPaymentMethods(props.deliveryCountry);
 
   return (
     <Content modifierClasses={['your-details']}>
@@ -337,7 +337,7 @@ function WeeklyCheckoutFormGifting(props: PropTypes) {
           {paymentMethods.length > 1 ?
             <FormSection title="How would you like to pay?">
               <PaymentMethodSelector
-                country={props.billingCountry}
+                country={props.deliveryCountry}
                 paymentMethod={props.paymentMethod}
                 setPaymentMethod={props.setPaymentMethod}
                 validationError={firstError('paymentMethod', props.formErrors)}

--- a/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/SubscriptionDataBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/zuora/subscriptionBuilders/SubscriptionDataBuilder.scala
@@ -50,7 +50,8 @@ class SubscriptionDataBuilder(
         EitherT.fromEither[Future](GuardianWeeklySubscriptionBuilder.build(
           w,
           state.requestId,
-          state.user.billingAddress.country,
+          // There will always be a delivery address for GW
+          state.user.deliveryAddress.map(_.country).getOrElse(state.user.billingAddress.country),
           state.promoCode,
           state.firstDeliveryDate,
           promotionService,


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
The Guardian weekly checkout currently decides which currency a user will pay in based on their billing address. 

However the current pricing structure uses currency as a proxy for delivery cost - so for instance the price in New Zealand dollars is nearly twice the price in GBP to reflect the higher cost of delivery to New Zealand.

This means that we need to customers to pay in the currency of the country they want their sub delivered to, even if this is not the same as their billing country.

[**Trello Card**](https://trello.com/c/MGzDyodg/3649-gw-should-use-pricing-for-delivery-address-country-not-billing-address)
