### PR TITLE
Mj local currency follow up

### DIFF
--- a/support-frontend/assets/helpers/contributions.js
+++ b/support-frontend/assets/helpers/contributions.js
@@ -94,7 +94,7 @@ export type ParsedContribution = {|
   error: ParseError,
 |};
 
-type Config = {
+export type Config = {
   [ContributionType]: {
     min: number,
     minInWords: string,

--- a/support-frontend/assets/helpers/formValidation.js
+++ b/support-frontend/assets/helpers/formValidation.js
@@ -11,6 +11,7 @@ import type { ContributionType, OtherAmounts, SelectedAmounts } from 'helpers/co
 import { Canada, UnitedStates, AUDCountries, countryGroups } from './internationalisation/countryGroup';
 import { DateUtils } from 'react-day-picker';
 import { daysFromNowForGift } from 'pages/digital-subscription-checkout/components/helpers';
+import type {LocalCurrencyCountry} from "./internationalisation/localCurrencyCountry";
 
 export const emailRegexPattern = '^[a-zA-Z0-9\\.!#$%&\'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$';
 
@@ -61,6 +62,7 @@ export const amountOrOtherAmountIsValid = (
   otherAmounts: OtherAmounts,
   contributionType: ContributionType,
   countryGroupId: CountryGroupId,
+  localCurrencyCountry?: LocalCurrencyCountry,
 ): boolean => {
   let amt = '';
   if (selectedAmounts[contributionType] && selectedAmounts[contributionType] === 'other') {

--- a/support-frontend/assets/helpers/formValidation.js
+++ b/support-frontend/assets/helpers/formValidation.js
@@ -51,13 +51,13 @@ export const amountIsValid = (
   countryGroupId: CountryGroupId,
   contributionType: ContributionType,
   localCurrencyCountry?: LocalCurrencyCountry,
-  useLocalCurrencyCountry?: boolean,
+  useLocalCurrency?: boolean,
 ): boolean => {
-  const min = useLocalCurrencyCountry
+  const min = useLocalCurrency
     ? localCurrencyCountry.config[contributionType].min
     : config[countryGroupId][contributionType].min;
 
-  const max = useLocalCurrencyCountry
+  const max = useLocalCurrency
     ? localCurrencyCountry.config[contributionType].max
     : config[countryGroupId][contributionType].max;
 
@@ -67,14 +67,13 @@ export const amountIsValid = (
     && maxTwoDecimals(input);
 }
 
-
 export const amountOrOtherAmountIsValid = (
   selectedAmounts: SelectedAmounts,
   otherAmounts: OtherAmounts,
   contributionType: ContributionType,
   countryGroupId: CountryGroupId,
   localCurrencyCountry?: LocalCurrencyCountry,
-  useLocalCurrencyCountry?: boolean,
+  useLocalCurrency?: boolean,
 ): boolean => {
   let amt = '';
   if (selectedAmounts[contributionType] && selectedAmounts[contributionType] === 'other') {
@@ -89,7 +88,7 @@ export const amountOrOtherAmountIsValid = (
     countryGroupId,
     contributionType,
     localCurrencyCountry,
-    useLocalCurrencyCountry,
+    useLocalCurrency,
   );
 };
 

--- a/support-frontend/assets/helpers/formValidation.js
+++ b/support-frontend/assets/helpers/formValidation.js
@@ -50,11 +50,22 @@ export const amountIsValid = (
   input: string,
   countryGroupId: CountryGroupId,
   contributionType: ContributionType,
-): boolean =>
-  isNotEmpty(input)
-    && isLargerOrEqual(config[countryGroupId][contributionType].min, input)
-    && isSmallerOrEqual(config[countryGroupId][contributionType].max, input)
+  localCurrencyCountry?: LocalCurrencyCountry,
+  useLocalCurrencyCountry?: boolean,
+): boolean => {
+  const min = useLocalCurrencyCountry
+    ? localCurrencyCountry.config[contributionType].min
+    : config[countryGroupId][contributionType].min;
+
+  const max = useLocalCurrencyCountry
+    ? localCurrencyCountry.config[contributionType].max
+    : config[countryGroupId][contributionType].max;
+
+  return isNotEmpty(input)
+    && isLargerOrEqual(min, input)
+    && isSmallerOrEqual(max, input)
     && maxTwoDecimals(input);
+}
 
 
 export const amountOrOtherAmountIsValid = (
@@ -63,6 +74,7 @@ export const amountOrOtherAmountIsValid = (
   contributionType: ContributionType,
   countryGroupId: CountryGroupId,
   localCurrencyCountry?: LocalCurrencyCountry,
+  useLocalCurrencyCountry?: boolean,
 ): boolean => {
   let amt = '';
   if (selectedAmounts[contributionType] && selectedAmounts[contributionType] === 'other') {
@@ -72,7 +84,13 @@ export const amountOrOtherAmountIsValid = (
   } else if (selectedAmounts[contributionType]) {
     amt = selectedAmounts[contributionType].toString();
   }
-  return amountIsValid(amt, countryGroupId, contributionType);
+  return amountIsValid(
+    amt,
+    countryGroupId,
+    contributionType,
+    localCurrencyCountry,
+    useLocalCurrencyCountry,
+  );
 };
 
 export const checkStateIfApplicable: ((string | null), CountryGroupId, ContributionType) => boolean = (

--- a/support-frontend/assets/helpers/formValidation.js
+++ b/support-frontend/assets/helpers/formValidation.js
@@ -11,7 +11,7 @@ import type { ContributionType, OtherAmounts, SelectedAmounts } from 'helpers/co
 import { Canada, UnitedStates, AUDCountries, countryGroups } from './internationalisation/countryGroup';
 import { DateUtils } from 'react-day-picker';
 import { daysFromNowForGift } from 'pages/digital-subscription-checkout/components/helpers';
-import type {LocalCurrencyCountry} from "./internationalisation/localCurrencyCountry";
+import type { LocalCurrencyCountry } from './internationalisation/localCurrencyCountry';
 
 export const emailRegexPattern = '^[a-zA-Z0-9\\.!#$%&\'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)+$';
 
@@ -50,14 +50,14 @@ export const amountIsValid = (
   input: string,
   countryGroupId: CountryGroupId,
   contributionType: ContributionType,
-  localCurrencyCountry?: LocalCurrencyCountry,
-  useLocalCurrency?: boolean,
+  localCurrencyCountry?: LocalCurrencyCountry | null,
+  useLocalCurrency?: boolean | null,
 ): boolean => {
-  const min = useLocalCurrency
+  const min = (useLocalCurrency && localCurrencyCountry)
     ? localCurrencyCountry.config[contributionType].min
     : config[countryGroupId][contributionType].min;
 
-  const max = useLocalCurrency
+  const max = (useLocalCurrency && localCurrencyCountry)
     ? localCurrencyCountry.config[contributionType].max
     : config[countryGroupId][contributionType].max;
 
@@ -65,15 +65,15 @@ export const amountIsValid = (
     && isLargerOrEqual(min, input)
     && isSmallerOrEqual(max, input)
     && maxTwoDecimals(input);
-}
+};
 
 export const amountOrOtherAmountIsValid = (
   selectedAmounts: SelectedAmounts,
   otherAmounts: OtherAmounts,
   contributionType: ContributionType,
   countryGroupId: CountryGroupId,
-  localCurrencyCountry?: LocalCurrencyCountry,
-  useLocalCurrency?: boolean,
+  localCurrencyCountry?: LocalCurrencyCountry | null,
+  useLocalCurrency?: boolean | null,
 ): boolean => {
   let amt = '';
   if (selectedAmounts[contributionType] && selectedAmounts[contributionType] === 'other') {

--- a/support-frontend/assets/helpers/internationalisation/localCurrencyCountry.js
+++ b/support-frontend/assets/helpers/internationalisation/localCurrencyCountry.js
@@ -13,7 +13,7 @@ export type LocalCurrencyCountry = {
 };
 
 export const localCurrencyCountries: {
-  [?string]: LocalCurrencyCountry
+  [?IsoCountry]: LocalCurrencyCountry
 } = {
   SE: {
     countryCode: 'SE',

--- a/support-frontend/assets/helpers/internationalisation/localCurrencyCountry.js
+++ b/support-frontend/assets/helpers/internationalisation/localCurrencyCountry.js
@@ -2,13 +2,14 @@
 
 import type { IsoCountry } from './country';
 import type { IsoCurrency } from './currency';
-import type { ContributionAmounts } from '../contributions';
+import type {Config, ContributionAmounts} from '../contributions';
 
 export type LocalCurrencyCountry = {
   countryCode: IsoCountry,
   countryName: string,
   currency: IsoCurrency,
   amounts: ContributionAmounts,
+  config: Config,
 };
 
 export const localCurrencyCountries: {
@@ -24,6 +25,14 @@ export const localCurrencyCountries: {
         defaultAmount: 50,
       },
     },
+    config: {
+      ONE_OFF: {
+        min: 10,
+        minInWords: 'ten',
+        max: 23_000,
+        maxInWords: 'twenty three thousand',
+      },
+    },
   },
   CH: {
     countryCode: 'CH',
@@ -33,6 +42,14 @@ export const localCurrencyCountries: {
       ONE_OFF: {
         amounts: [5, 10, 15, 20],
         defaultAmount: 5,
+      },
+    },
+    config: {
+      ONE_OFF: {
+        min: 2,
+        minInWords: 'two',
+        max: 2_200,
+        maxInWords: 'two thousand and two hundred',
       },
     },
   },
@@ -46,6 +63,14 @@ export const localCurrencyCountries: {
         defaultAmount: 50,
       },
     },
+    config: {
+      ONE_OFF: {
+        min: 10,
+        minInWords: 'ten',
+        max: 23_000,
+        maxInWords: 'twenty three thousand',
+      },
+    },
   },
   DK: {
     countryCode: 'DK',
@@ -55,6 +80,14 @@ export const localCurrencyCountries: {
       ONE_OFF: {
         amounts: [50, 100, 150, 200],
         defaultAmount: 50,
+      },
+    },
+    config: {
+      ONE_OFF: {
+        min: 10,
+        minInWords: 'ten',
+        max: 23_000,
+        maxInWords: 'twenty three thousand',
       },
     },
   },

--- a/support-frontend/assets/helpers/internationalisation/localCurrencyCountry.js
+++ b/support-frontend/assets/helpers/internationalisation/localCurrencyCountry.js
@@ -2,7 +2,7 @@
 
 import type { IsoCountry } from './country';
 import type { IsoCurrency } from './currency';
-import type {Config, ContributionAmounts} from '../contributions';
+import type { Config, ContributionAmounts } from '../contributions';
 
 export type LocalCurrencyCountry = {
   countryCode: IsoCountry,
@@ -31,6 +31,7 @@ export const localCurrencyCountries: {
         minInWords: 'ten',
         max: 23_000,
         maxInWords: 'twenty three thousand',
+        default: 50,
       },
     },
   },
@@ -50,6 +51,7 @@ export const localCurrencyCountries: {
         minInWords: 'two',
         max: 2_200,
         maxInWords: 'two thousand and two hundred',
+        default: 5,
       },
     },
   },
@@ -69,6 +71,7 @@ export const localCurrencyCountries: {
         minInWords: 'ten',
         max: 23_000,
         maxInWords: 'twenty three thousand',
+        default: 50,
       },
     },
   },
@@ -88,6 +91,7 @@ export const localCurrencyCountries: {
         minInWords: 'ten',
         max: 23_000,
         maxInWords: 'twenty three thousand',
+        default: 50,
       },
     },
   },

--- a/support-frontend/assets/pages/contributions-landing/checkoutFormIsSubmittableActions.js
+++ b/support-frontend/assets/pages/contributions-landing/checkoutFormIsSubmittableActions.js
@@ -26,6 +26,9 @@ import {
 } from './contributionsLandingActions';
 import { stripeCardFormIsIncomplete } from 'helpers/stripe';
 import { AmazonPay } from 'helpers/paymentMethods';
+import type {LocalCurrencyCountry} from "../../helpers/internationalisation/localCurrencyCountry";
+import {localCurrencyCountries} from "../../helpers/internationalisation/localCurrencyCountry";
+import {setUseLocalAmounts} from "../../helpers/page/commonActions";
 
 // ----- Types ----- //
 
@@ -59,6 +62,8 @@ export type FormIsValidParameters = {
   email: string | null,
   stripeCardFormOk: boolean,
   amazonPayFormOk: boolean,
+  localCurrencyCountry?: LocalCurrencyCountry,
+  useLocalCurrency?: boolean,
 }
 
 const getFormIsValid = (formIsValidParameters: FormIsValidParameters) => {
@@ -73,6 +78,8 @@ const getFormIsValid = (formIsValidParameters: FormIsValidParameters) => {
     email,
     stripeCardFormOk,
     amazonPayFormOk,
+    localCurrencyCountry,
+    useLocalCurrency,
   } = formIsValidParameters;
 
   const hasNameFields = contributionType !== 'ONE_OFF';
@@ -85,7 +92,14 @@ const getFormIsValid = (formIsValidParameters: FormIsValidParameters) => {
     && stripeCardFormOk
     && amazonPayFormOk
     && checkStateIfApplicable(billingState, countryGroupId, contributionType)
-    && amountOrOtherAmountIsValid(selectedAmounts, otherAmounts, contributionType, countryGroupId);
+    && amountOrOtherAmountIsValid(
+      selectedAmounts,
+      otherAmounts,
+      contributionType,
+      countryGroupId,
+      localCurrencyCountry,
+      useLocalCurrency,
+    );
 };
 
 const amazonPayFormOk = (state: State): boolean => {
@@ -119,6 +133,8 @@ const formIsValidParameters = (state: State) => ({
     state.page.form.stripeCardFormData.formComplete,
   ),
   amazonPayFormOk: amazonPayFormOk(state),
+  localCurrencyCountry: state.common.internationalisation.localCurrencyCountry,
+  useLocalCurrency: state.common.internationalisation.useLocalCurrency,
 });
 
 function enableOrDisableForm() {

--- a/support-frontend/assets/pages/contributions-landing/checkoutFormIsSubmittableActions.js
+++ b/support-frontend/assets/pages/contributions-landing/checkoutFormIsSubmittableActions.js
@@ -26,9 +26,7 @@ import {
 } from './contributionsLandingActions';
 import { stripeCardFormIsIncomplete } from 'helpers/stripe';
 import { AmazonPay } from 'helpers/paymentMethods';
-import type {LocalCurrencyCountry} from "../../helpers/internationalisation/localCurrencyCountry";
-import {localCurrencyCountries} from "../../helpers/internationalisation/localCurrencyCountry";
-import {setUseLocalAmounts} from "../../helpers/page/commonActions";
+import type { LocalCurrencyCountry } from '../../helpers/internationalisation/localCurrencyCountry';
 
 // ----- Types ----- //
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
@@ -20,6 +20,7 @@ import { selectAmount, updateOtherAmount } from '../contributionsLandingActions'
 import { type State } from '../contributionsLandingReducer';
 import ContributionAmountChoices from './ContributionAmountChoices';
 import { TextInput } from '@guardian/src-text-input';
+import type { LocalCurrencyCountry } from 'helpers/internationalisation/localCurrencyCountry';
 
 // ----- Types ----- //
 
@@ -34,6 +35,8 @@ type PropTypes = {|
   updateOtherAmount: (string, CountryGroupId, ContributionType) => void,
   checkoutFormHasBeenSubmitted: boolean,
   stripePaymentRequestButtonClicked: boolean,
+  localCurrencyCountry: ?LocalCurrencyCountry,
+  useLocalCurrency: boolean,
 |};
 
 const mapStateToProps = (state: State) => ({
@@ -47,6 +50,8 @@ const mapStateToProps = (state: State) => ({
   stripePaymentRequestButtonClicked:
     state.page.form.stripePaymentRequestButtonData.ONE_OFF.stripePaymentRequestButtonClicked ||
     state.page.form.stripePaymentRequestButtonData.REGULAR.stripePaymentRequestButtonClicked,
+  localCurrencyCountry: state.common.internationalisation.localCurrencyCountry,
+  useLocalCurrency: state.common.internationalisation.useLocalCurrency,
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -75,7 +80,9 @@ const renderEmptyAmount = (id: string) => (
 function withProps(props: PropTypes) {
   const { amounts: validAmounts, defaultAmount } = props.amounts[props.contributionType];
   const showOther: boolean = props.selectedAmounts[props.contributionType] === 'other';
-  const { min, max } = config[props.countryGroupId][props.contributionType]; // eslint-disable-line react/prop-types
+  const { min, max } = props.useLocalCurrency
+    ? props.localCurrencyCountry.config[props.contributionType]
+    : config[props.countryGroupId][props.contributionType]
   const minAmount: string =
     formatAmount(currencies[props.currency], spokenCurrencies[props.currency], min, false);
   const maxAmount: string =
@@ -88,7 +95,13 @@ function withProps(props: PropTypes) {
   const canShowOtherAmountErrorMessage =
     checkoutFormHasBeenSubmitted || stripePaymentRequestButtonClicked || !!otherAmount;
   const otherAmountErrorMessage: string | null =
-    canShowOtherAmountErrorMessage && !amountIsValid(otherAmount || '', props.countryGroupId, props.contributionType) ?
+    canShowOtherAmountErrorMessage && !amountIsValid(
+      otherAmount || '',
+      props.countryGroupId,
+      props.contributionType,
+      props.localCurrencyCountry,
+      props.useLocalCurrency,
+    ) ?
       `Please provide an amount between ${minAmount} and ${maxAmount}` :
       null;
 

--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
@@ -80,9 +80,9 @@ const renderEmptyAmount = (id: string) => (
 function withProps(props: PropTypes) {
   const { amounts: validAmounts, defaultAmount } = props.amounts[props.contributionType];
   const showOther: boolean = props.selectedAmounts[props.contributionType] === 'other';
-  const { min, max } = props.useLocalCurrency
+  const { min, max } = (props.useLocalCurrency && props.localCurrencyCountry)
     ? props.localCurrencyCountry.config[props.contributionType]
-    : config[props.countryGroupId][props.contributionType]
+    : config[props.countryGroupId][props.contributionType];
   const minAmount: string =
     formatAmount(currencies[props.currency], spokenCurrencies[props.currency], min, false);
   const maxAmount: string =

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -52,7 +52,7 @@ import { toHumanReadableContributionType, getAvailablePaymentRequestButtonPaymen
 import type { Option } from 'helpers/types/option';
 import type { Csrf as CsrfState } from '../../../../helpers/csrf/csrfReducer';
 import { trackComponentEvents } from '../../../../helpers/tracking/ophan';
-import type {LocalCurrencyCountry} from "../../../../helpers/internationalisation/localCurrencyCountry";
+import type { LocalCurrencyCountry } from '../../../../helpers/internationalisation/localCurrencyCountry';
 
 // ----- Types -----//
 

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -52,6 +52,7 @@ import { toHumanReadableContributionType, getAvailablePaymentRequestButtonPaymen
 import type { Option } from 'helpers/types/option';
 import type { Csrf as CsrfState } from '../../../../helpers/csrf/csrfReducer';
 import { trackComponentEvents } from '../../../../helpers/tracking/ophan';
+import type {LocalCurrencyCountry} from "../../../../helpers/internationalisation/localCurrencyCountry";
 
 // ----- Types -----//
 
@@ -86,6 +87,8 @@ type PropTypes = {
   setHandleStripe3DS: ((clientSecret: string) => Promise<Stripe3DSResult>) => Action,
   csrf: CsrfState,
   stripePaymentRequestButtonVariant: boolean,
+  localCurrencyCountry: ?LocalCurrencyCountry,
+  useLocalCurrency: boolean,
 };
 
 const mapStateToProps = (state: State, ownProps: PropTypes) => ({
@@ -102,6 +105,8 @@ const mapStateToProps = (state: State, ownProps: PropTypes) => ({
   switches: state.common.settings.switches,
   csrf: state.page.csrf,
   stripePaymentRequestButtonVariant: state.common.abParticipations.stripePaymentRequestButtonDec2020 === 'PRB',
+  localCurrencyCountry: state.common.internationalisation.localCurrencyCountry,
+  useLocalCurrency: state.common.internationalisation.useLocalCurrency,
 });
 
 const mapDispatchToProps = (dispatch: Function) => ({
@@ -197,6 +202,8 @@ function onClick(event, props: PropTypes) {
       props.otherAmounts,
       props.contributionType,
       props.countryGroupId,
+      props.localCurrencyCountry,
+      props.useLocalCurrency,
     );
 
   if (!amountIsValid) {


### PR DESCRIPTION
### What does this PR do?
This is a follow up for [this PR](https://github.com/guardian/support-frontend/pull/3020). This improves the way currency amounts are displayed on the post-contribution thank you page, eg. `10 kr` instead of `kr10`.

Also allows local currency min and max values to override defaults, without altering existing functionality.