### PR TITLE
improve currency display on thankyou page

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouHeader.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionThankYou/ContributionThankYouHeader.jsx
@@ -5,9 +5,10 @@ import { titlepiece, body } from '@guardian/src-foundations/typography';
 import { space } from '@guardian/src-foundations';
 import { from } from '@guardian/src-foundations/mq';
 import type { ContributionType } from 'helpers/contributions';
-import { currencies } from 'helpers/internationalisation/currency';
+import { currencies, spokenCurrencies } from 'helpers/internationalisation/currency';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import type { PaymentMethod } from 'helpers/paymentMethods';
+import { formatAmount } from 'helpers/checkouts';
 
 const header = css`
   background: white;
@@ -77,8 +78,12 @@ const ContributionThankYouHeader = ({
     if (!payPalOneOff && amount) {
       const currencyAndAmount = (
         <span css={amountText}>
-          {currencies[currency].glyph}
-          {amount}
+          { formatAmount(
+            currencies[currency],
+            spokenCurrencies[currency],
+            parseFloat(amount),
+            false,
+          ) }
         </span>
       );
 


### PR DESCRIPTION
### What does this PR do?
This is a follow up for [this PR](https://github.com/guardian/support-frontend/pull/3020). This improves the display of currencies on the post-contribution thank you page, eg. `10 kr` instead of `kr10`.