### PR TITLE
Always take currencyId from delivery address in weeklyCheckoutForm.jsx

### DIFF
--- a/support-frontend/assets/helpers/internationalisation/currency.js
+++ b/support-frontend/assets/helpers/internationalisation/currency.js
@@ -8,6 +8,7 @@ import {
   type CountryGroup,
   type CountryGroupId,
   countryGroups,
+  fromCountry,
 } from './countryGroup';
 import type { IsoCountry } from './country';
 
@@ -179,14 +180,9 @@ function fromString(s: string): ?IsoCurrency {
   }
 }
 
-function localCurrencyFromCountryCode(countryCode: IsoCountry): ?IsoCurrency {
-  switch (countryCode.toLowerCase()) {
-    case 'se': return 'SEK';
-    case 'ch': return 'CHF';
-    case 'no': return 'NOK';
-    case 'dk': return 'DKK';
-    default: return null;
-  }
+function currencyFromCountryCode(countryCode: IsoCountry): ?IsoCurrency {
+  const countryGroupId = fromCountry(countryCode);
+  return countryGroupId ? fromCountryGroupId(countryGroupId) : null;
 }
 
 function fromQueryParameter(): ?IsoCurrency {
@@ -212,7 +208,7 @@ export {
   detect,
   spokenCurrencies,
   fromCountryGroupId,
-  localCurrencyFromCountryCode,
+  currencyFromCountryCode,
   currencies,
   glyph,
   extendedGlyph,

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutForm.jsx
@@ -78,6 +78,7 @@ import { supportedPaymentMethods } from 'helpers/subscriptionsForms/countryPayme
 import { titles } from 'helpers/user/details';
 import { Select, Option as OptionForSelect } from '@guardian/src-select';
 import { options } from 'components/forms/customFields/options';
+import { currencyFromCountryCode } from 'helpers/internationalisation/currency';
 
 
 // ----- Styles ----- //
@@ -126,7 +127,7 @@ function mapStateToProps(state: WithDeliveryCheckoutState) {
     billingAddressErrors: state.page.billingAddress.fields.formErrors,
     isTestUser: state.page.checkout.isTestUser,
     csrf: state.page.csrf,
-    currencyId: state.common.internationalisation.currencyId,
+    currencyId: currencyFromCountryCode(deliveryAddress.fields.country),
     payPalHasLoaded: state.page.checkout.payPalHasLoaded,
   };
 }

--- a/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.jsx
+++ b/support-frontend/assets/pages/weekly-subscription-checkout/components/weeklyCheckoutFormGifting.jsx
@@ -80,6 +80,7 @@ import { supportedPaymentMethods } from 'helpers/subscriptionsForms/countryPayme
 import { titles } from 'helpers/user/details';
 import { Select, Option as OptionForSelect } from '@guardian/src-select';
 import { options } from 'components/forms/customFields/options';
+import { currencyFromCountryCode } from 'helpers/internationalisation/currency';
 
 // ----- Styles ----- //
 
@@ -129,7 +130,7 @@ function mapStateToProps(state: WithDeliveryCheckoutState) {
     isTestUser: state.page.checkout.isTestUser,
     country: state.common.internationalisation.countryId,
     csrf: state.page.csrf,
-    currencyId: state.common.internationalisation.currencyId,
+    currencyId: currencyFromCountryCode(deliveryAddress.fields.country),
     payPalHasLoaded: state.page.checkout.payPalHasLoaded,
   };
 }


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
I've noticed a bug in the way that the Guardian Weekly checkout works now that it uses currencyId to work out which payment methods to allow - the currencyId is updated in the state when **either** of the billing or delivery address is changed, whereas we always want to use the currency associated with the delivery address as this is the currency we will ultimately charge the customer in.

[**Trello Card**](https://trello.com/c/MGzDyodg/3649-gw-should-use-pricing-for-delivery-address-country-not-billing-address-99)
