### PR TITLE
Comment out supporter product data updates for gift redemptions

### DIFF
--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/UpdateSupporterProductData.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/UpdateSupporterProductData.scala
@@ -90,17 +90,19 @@ object UpdateSupporterProductData {
           .toRight(())
           .map(Some(_))
       case SendThankYouEmailDigitalSubscriptionGiftRedemptionState(user, product, subscriptionNumber, _) =>
-        catalogService
-          .getProductRatePlan(DigitalPack, product.billingPeriod, NoFulfilmentOptions, NoProductOptions, Gift)
-          .map(productRatePlan =>
-            supporterRatePlanItem(
-              subscriptionName = subscriptionNumber,
-              identityId = user.id,
-              productRatePlanId = productRatePlan.id,
-              productRatePlanName = s"support-workers added ${product.describe}",
-            ))
-          .toRight(())
-          .map(Some(_))
+//        catalogService
+//          .getProductRatePlan(DigitalPack, product.billingPeriod, NoFulfilmentOptions, NoProductOptions, Gift)
+//          .map(productRatePlan =>
+//            supporterRatePlanItem(
+//              subscriptionName = subscriptionNumber,
+//              identityId = user.id,
+//              productRatePlanId = productRatePlan.id,
+//              productRatePlanName = s"support-workers added ${product.describe}",
+//            ))
+//          .toRight(())
+//          .map(Some(_))
+//      TODO: Fix this for gift redemptions
+        Right(None)
       case SendThankYouEmailGuardianWeeklyState(user, product, giftRecipient, _, _, _, _, subscriptionNumber, _) =>
         val readerType = if(giftRecipient.isDefined) Gift else Direct
         catalogService


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
The UpdateSupporterProductData lambda is failing for all digital subscription redemptions at the moment because the billing period is incorrect in the state. This is triggering 'support-workers execution failed' alarms on a regular basis which is wasting developers time so I'm commenting out the part of the lambda that is failing until a proper fix can be put in place.