### PR TITLE
Add a helper for timed release of new landing page copy, and copy for G200 special edition

### DIFF
--- a/support-frontend/assets/helpers/timeBoundedCopy/timeBoundedCopy.jsx
+++ b/support-frontend/assets/helpers/timeBoundedCopy/timeBoundedCopy.jsx
@@ -1,0 +1,47 @@
+// @flow
+
+import React, { type Node } from 'react';
+
+type LandingPage = 'digitalSubscription' | 'newspaper' | 'guardianWeekly';
+
+type TimeBoundCopy = {|
+  start: string;
+  end?: string;
+  copy: Node;
+|}
+
+type TimedCopyCollection = { [LandingPage]: TimeBoundCopy[] }
+
+const timedCopy: TimedCopyCollection = {
+  digitalSubscription: [
+    {
+      start: '2021-05-08',
+      copy: <>
+        <p>
+          <strong>With two innovative apps and ad-free reading,</strong> a digital subscription gives
+          you the richest experience of Guardian journalism. It also sustains the independent reporting you love.
+        </p>
+        <p>
+          Plus celebrate our 200th birthday with our special edition, We were there, available for a limited time.
+        </p>
+      </>,
+    },
+  ],
+};
+
+export function getTimeboundCopy(
+  page: LandingPage,
+  currentDate: Date,
+  timedCopyData: TimedCopyCollection = timedCopy,
+): Node {
+  const copyListForPage = timedCopyData[page];
+  if (copyListForPage) {
+    const copyToUse = copyListForPage.find((copyForPage) => {
+      const startDate = new Date(copyForPage.start);
+      const endDate = copyForPage.end ? new Date(copyForPage.end) : null;
+      return startDate <= currentDate && (!endDate || endDate >= currentDate);
+    });
+    return copyToUse ? copyToUse.copy : null;
+  }
+  return null;
+}

--- a/support-frontend/assets/helpers/timeBoundedCopy/timeBoundedCopy.jsx
+++ b/support-frontend/assets/helpers/timeBoundedCopy/timeBoundedCopy.jsx
@@ -1,12 +1,13 @@
 // @flow
 
 import React, { type Node } from 'react';
+import { type Option } from 'helpers/types/option';
 
 type LandingPage = 'digitalSubscription' | 'newspaper' | 'guardianWeekly';
 
 type TimeBoundCopy = {|
-  start: string;
-  end?: string;
+  startShowingOn: string;
+  stopShowingOn?: string;
   copy: Node;
 |}
 
@@ -15,7 +16,7 @@ type TimedCopyCollection = { [LandingPage]: TimeBoundCopy[] }
 const timedCopy: TimedCopyCollection = {
   digitalSubscription: [
     {
-      start: '2021-05-08',
+      startShowingOn: '2021-05-08',
       copy: <>
         <p>
           <strong>With two innovative apps and ad-free reading,</strong> a digital subscription gives
@@ -29,6 +30,19 @@ const timedCopy: TimedCopyCollection = {
   ],
 };
 
+const forceQueryKey = 'forceTimeboundCopy';
+
+export function getTimeboundQuery(): Option<Date> {
+  const { search } = window.location;
+
+  if (search) {
+    const queryList = search.replace('?', '').split('&');
+    const overrideQuery = queryList.find(keyValPair => keyValPair.startsWith(forceQueryKey));
+    return overrideQuery ? new Date(overrideQuery.replace(`${forceQueryKey}=`, '')) : null;
+  }
+  return null;
+}
+
 export function getTimeboundCopy(
   page: LandingPage,
   currentDate: Date,
@@ -37,9 +51,9 @@ export function getTimeboundCopy(
   const copyListForPage = timedCopyData[page];
   if (copyListForPage) {
     const copyToUse = copyListForPage.find((copyForPage) => {
-      const startDate = new Date(copyForPage.start);
-      const endDate = copyForPage.end ? new Date(copyForPage.end) : null;
-      return startDate <= currentDate && (!endDate || endDate >= currentDate);
+      const startShowingOnDate = new Date(copyForPage.startShowingOn);
+      const stopShowingOnDate = copyForPage.stopShowingOn ? new Date(copyForPage.stopShowingOn) : null;
+      return startShowingOnDate <= currentDate && (!stopShowingOnDate || stopShowingOnDate >= currentDate);
     });
     return copyToUse ? copyToUse.copy : null;
   }

--- a/support-frontend/assets/helpers/timeBoundedCopy/timeBoundedCopy.jsx
+++ b/support-frontend/assets/helpers/timeBoundedCopy/timeBoundedCopy.jsx
@@ -15,7 +15,7 @@ type TimedCopyCollection = { [LandingPage]: TimeBoundCopy[] }
 const timedCopy: TimedCopyCollection = {
   digitalSubscription: [
     {
-      start: '2021-05-08',
+      start: '2021-05-04',
       copy: <>
         <p>
           <strong>With two innovative apps and ad-free reading,</strong> a digital subscription gives

--- a/support-frontend/assets/helpers/timeBoundedCopy/timeBoundedCopy.jsx
+++ b/support-frontend/assets/helpers/timeBoundedCopy/timeBoundedCopy.jsx
@@ -15,7 +15,7 @@ type TimedCopyCollection = { [LandingPage]: TimeBoundCopy[] }
 const timedCopy: TimedCopyCollection = {
   digitalSubscription: [
     {
-      start: '2021-05-04',
+      start: '2021-05-08',
       copy: <>
         <p>
           <strong>With two innovative apps and ad-free reading,</strong> a digital subscription gives

--- a/support-frontend/assets/helpers/timeBoundedCopy/timeBoundedCopy.test.jsx
+++ b/support-frontend/assets/helpers/timeBoundedCopy/timeBoundedCopy.test.jsx
@@ -1,0 +1,44 @@
+import { getTimeboundCopy } from './timeBoundedCopy';
+
+describe('Time bounded copy', () => {
+  const copy = 'Hello this is a test';
+  let testCopy;
+
+  beforeEach(() => {
+    testCopy = {
+      newspaper: [
+        {
+          start: '2021-01-01',
+          end: '2021-12-31',
+          copy,
+        },
+      ],
+    };
+  });
+
+  describe('Getting copy within the date bounds', () => {
+    it('returns copy for the specified page when the passed date matches a copy item', () => {
+      expect(getTimeboundCopy('newspaper', new Date('2021-05-05'), testCopy)).toBe(copy);
+    });
+
+    it('returns the first copy item in the list where the passed date matches', () => {
+      testCopy.newspaper.unshift({
+        start: '2020-01-01',
+        copy: 'I am some more prominent copy',
+      });
+      expect(getTimeboundCopy('newspaper', new Date('2021-05-05'), testCopy)).toBe('I am some more prominent copy');
+    });
+  });
+
+  describe('Getting copy too early', () => {
+    it('returns null if the passed date is too early', () => {
+      expect(getTimeboundCopy('newspaper', new Date('2020-05-05'), testCopy)).toBeNull();
+    });
+  });
+
+  describe('Getting copy too late', () => {
+    it('returns null if the passed date is too late', () => {
+      expect(getTimeboundCopy('newspaper', new Date('2022-05-05'), testCopy)).toBeNull();
+    });
+  });
+});

--- a/support-frontend/assets/helpers/timeBoundedCopy/timeBoundedCopy.test.jsx
+++ b/support-frontend/assets/helpers/timeBoundedCopy/timeBoundedCopy.test.jsx
@@ -8,8 +8,8 @@ describe('Time bounded copy', () => {
     testCopy = {
       newspaper: [
         {
-          start: '2021-01-01',
-          end: '2021-12-31',
+          startShowingOn: '2021-01-01',
+          stopShowingOn: '2021-12-31',
           copy,
         },
       ],
@@ -23,7 +23,7 @@ describe('Time bounded copy', () => {
 
     it('returns the first copy item in the list where the passed date matches', () => {
       testCopy.newspaper.unshift({
-        start: '2020-01-01',
+        startShowingOn: '2020-01-01',
         copy: 'I am some more prominent copy',
       });
       expect(getTimeboundCopy('newspaper', new Date('2021-05-05'), testCopy)).toBe('I am some more prominent copy');

--- a/support-frontend/assets/pages/digital-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/hero/hero.jsx
@@ -19,7 +19,7 @@ import {
 } from 'helpers/internationalisation/countryGroup';
 import { promotionHTML, type PromotionCopy } from 'helpers/productPrice/promotions';
 import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
-import { getTimeboundCopy } from 'helpers/timeBoundedCopy/timeBoundedCopy';
+import { getTimeboundQuery, getTimeboundCopy } from 'helpers/timeBoundedCopy/timeBoundedCopy';
 import { HeroPriceCards } from './heroPriceCards';
 import {
   heroCopy,
@@ -95,7 +95,7 @@ function DigitalHero({
 
   const roundelText = promotionHTML(promotionCopy.roundel, { css: circleTextGeneric }) || defaultRoundel;
 
-  const nonAusCopy = getTimeboundCopy('digitalSubscription', new Date()) || <HeroCopy />;
+  const nonAusCopy = getTimeboundCopy('digitalSubscription', getTimeboundQuery() || new Date()) || <HeroCopy />;
   const nonGiftCopy = countryGroupId === AUDCountries ? <HeroCopyAus /> : nonAusCopy;
   const defaultCopy = orderIsAGift ? <GiftCopy /> : nonGiftCopy;
   const copy = promoCopy || defaultCopy;

--- a/support-frontend/assets/pages/digital-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/hero/hero.jsx
@@ -19,12 +19,12 @@ import {
 } from 'helpers/internationalisation/countryGroup';
 import { promotionHTML, type PromotionCopy } from 'helpers/productPrice/promotions';
 import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
+import { getTimeboundCopy } from 'helpers/timeBoundedCopy/timeBoundedCopy';
 import { HeroPriceCards } from './heroPriceCards';
 import {
   heroCopy,
   heroTitle,
-  paragraph,
-  heavyText,
+  paragraphs,
   yellowHeading,
   circleTextTop,
   circleTextBottom,
@@ -46,11 +46,11 @@ type PropTypes = {
 
 const HeroCopy = () => (
   <>
-    <p css={paragraph}>
-      <span css={heavyText}>With two innovative apps and ad-free reading,</span> a digital subscription gives
+    <p>
+      <strong>With two innovative apps and ad-free reading,</strong> a digital subscription gives
       you the richest experience of Guardian journalism. It also sustains the independent reporting you love.
     </p>
-    <p css={paragraph}>
+    <p>
       Plus, for a limited time, you can read our latest special edition - The books of&nbsp;2021.
     </p>
   </>
@@ -58,22 +58,22 @@ const HeroCopy = () => (
 
 const HeroCopyAus = () => (
   <>
-    <p css={paragraph}>
+    <p>
       With two innovative apps and ad-free reading, a digital subscription gives you the richest experience
       of Guardian Australia journalism. It also sustains the independent reporting you love.
     </p>
-    <p css={paragraph}>
-      You&apos;ll gain exclusive access to <span css={heavyText}>Australia Weekend</span>, the new digital
+    <p>
+      You&apos;ll gain exclusive access to <strong>Australia Weekend</strong>, the new digital
       edition, providing you with a curated view of the week&apos;s biggest stories, plus early access to
       essential weekend news.
     </p>
   </>);
 
 const GiftCopy = () => (
-  <p css={paragraph}>
-    <span css={heavyText}>Share what matters most,<br css={mobileLineBreak} /> even when apart</span><br />
-        Show that you care with the gift of a digital gift subscription. Your loved ones will get the
-        richest, ad-free experience of our independent journalism and your gift will help fund our work.
+  <p>
+    <strong>Share what matters most,<br css={mobileLineBreak} /> even when apart</strong><br />
+    Show that you care with the gift of a digital gift subscription. Your loved ones will get the
+    richest, ad-free experience of our independent journalism and your gift will help fund our work.
   </p>
 );
 
@@ -91,11 +91,12 @@ function DigitalHero({
   const title = promotionCopy.title || <>Subscribe for stories<br />
     <span css={yellowHeading}>that must be told</span></>;
 
-  const promoCopy = promotionHTML(promotionCopy.description, { css: paragraph, tag: 'div' });
+  const promoCopy = promotionHTML(promotionCopy.description, { tag: 'div' });
 
   const roundelText = promotionHTML(promotionCopy.roundel, { css: circleTextGeneric }) || defaultRoundel;
 
-  const nonGiftCopy = countryGroupId === AUDCountries ? <HeroCopyAus /> : <HeroCopy />;
+  const nonAusCopy = getTimeboundCopy('digitalSubscription', new Date()) || <HeroCopy />;
+  const nonGiftCopy = countryGroupId === AUDCountries ? <HeroCopyAus /> : nonAusCopy;
   const defaultCopy = orderIsAGift ? <GiftCopy /> : nonGiftCopy;
   const copy = promoCopy || defaultCopy;
 
@@ -139,7 +140,7 @@ function DigitalHero({
               <GiftHeadingAnimation /> :
               <h2 css={heroTitle}>{title}</h2>
             }
-            <div>
+            <div css={paragraphs}>
               {copy}
             </div>
             {!showPriceCards &&

--- a/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroStyles.js
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroStyles.js
@@ -25,42 +25,6 @@ export const yellowHeading = css`
   color: ${brandAlt[400]};
 `;
 
-export const paragraph = css`
-  ${body.small()};
-  max-width: 100%;
-  margin-bottom: ${space[6]}px;
-
-  & strong {
-    font-weight: 600;
-  }
-
-  // This applies to paras coming from the promo tool
-  & p:not(:last-of-type) {
-    margin-bottom: ${space[5]}px;
-  }
-
-  // This applies to default paragraphs in the hero
-  :not(:last-of-type) {
-    margin-bottom: ${space[5]}px;
-  }
-
-  ${from.mobileMedium} {
-    ${body.medium()};
-  }
-
-  ${from.phablet} {
-    ${body.medium()};
-    max-width: 85%;
-    margin-bottom: ${space[9]}px;
-  }
-
-  ${from.desktop} {
-    ${headline.xxsmall()};
-    line-height: 135%;
-    max-width: 90%;
-  }
-`;
-
 export const paragraphs = css`
   p {
     ${body.small()};
@@ -91,10 +55,6 @@ export const paragraphs = css`
   strong {
     font-weight: 600;
   }
-`;
-
-export const heavyText = css`
-  font-weight: 600;
 `;
 
 export const circleTextContainer = css`

--- a/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroStyles.js
+++ b/support-frontend/assets/pages/digital-subscription-landing/components/hero/heroStyles.js
@@ -30,6 +30,10 @@ export const paragraph = css`
   max-width: 100%;
   margin-bottom: ${space[6]}px;
 
+  & strong {
+    font-weight: 600;
+  }
+
   // This applies to paras coming from the promo tool
   & p:not(:last-of-type) {
     margin-bottom: ${space[5]}px;
@@ -54,6 +58,38 @@ export const paragraph = css`
     ${headline.xxsmall()};
     line-height: 135%;
     max-width: 90%;
+  }
+`;
+
+export const paragraphs = css`
+  p {
+    ${body.small()};
+    max-width: 100%;
+    margin-bottom: ${space[6]}px;
+
+    ${from.mobileMedium} {
+      ${body.medium()};
+    }
+
+    ${from.phablet} {
+      ${body.medium()};
+      max-width: 85%;
+      margin-bottom: ${space[9]}px;
+    }
+
+    ${from.desktop} {
+      ${headline.xxsmall()};
+      line-height: 135%;
+      max-width: 90%;
+    }
+  }
+
+  p:not(:last-of-type) {
+    margin-bottom: ${space[5]}px;
+  }
+
+  strong {
+    font-weight: 600;
   }
 `;
 


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
In order to both release new copy on the digital subs landing page on Saturday morning, when the G200 special edition is released, and yet also avoid having to do work on a Saturday, this adds a small helper to enable us to set up copy to be displayed only after a certain date and time, and potentially with a pre-set end date.

The helper has been set up with the G200 copy to release on Saturday.

[**Trello Card**](https://trello.com/c/uVEdjCyp)

## Why are you doing this?

This specific copy is intended to be released on Satuday, but having new hero copy that should go out on a certain day is a common requirement and this should save us having to sit around with un-merged PRs that have a specific go-live date.

## Screenshots

**System time set to current date - existing copy**
![Screenshot 2021-05-05 at 16 18 03](https://user-images.githubusercontent.com/29146931/117166302-25881980-adbe-11eb-8d8a-3832a3ebbd7e.png)

**System time set to Saturday afternoon - new G200 copy**
![Screenshot 2021-05-08 at 16 16 27](https://user-images.githubusercontent.com/29146931/117166503-57997b80-adbe-11eb-8be0-22ffb9837e26.png)

**Mobile - Google Pixel 5**
![Screenshot 2021-05-05 at 16 27 51](https://user-images.githubusercontent.com/29146931/117167290-08a01600-adbf-11eb-9201-e53bdca2037d.png)

**Tablet - iPad Mini**
![Screenshot 2021-05-05 at 16 28 39](https://user-images.githubusercontent.com/29146931/117167345-15bd0500-adbf-11eb-8bfc-09286dbb5580.png)
