### PR TITLE
Fix bug with promo code prices not appearing in Paper checkout

### DIFF
--- a/support-frontend/assets/helpers/productPrice/paperProductPrices.js
+++ b/support-frontend/assets/helpers/productPrice/paperProductPrices.js
@@ -17,6 +17,8 @@ import {
   finalPrice as genericFinalPrice,
   getProductPrice as genericGetProductPrice,
 } from 'helpers/productPrice/productPrices';
+import { applyDiscount, getAppliedPromo } from 'helpers/productPrice/promotions';
+
 
 const country = 'GB';
 const billingPeriod = Monthly;
@@ -66,4 +68,13 @@ function getMaxSavingVsRetail(productPrices: ProductPrices): number {
   return Math.max(...allSavings);
 }
 
-export { getProductPrice, finalPrice, getMaxSavingVsRetail };
+function getPriceWithDiscount(
+  productPrices: ProductPrices,
+  fulfilmentOption: FulfilmentOptions,
+  productOption: ProductOptions,
+) {
+  const basePrice = getProductPrice(productPrices, fulfilmentOption, productOption);
+  return applyDiscount(basePrice, getAppliedPromo(basePrice.promotions));
+}
+
+export { getProductPrice, finalPrice, getMaxSavingVsRetail, getPriceWithDiscount };

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.jsx
@@ -44,18 +44,11 @@ function getMobileSummaryTitle(
 }
 
 function mapStateToProps(state: WithDeliveryCheckoutState) {
-  const totalWithoutDiscount = getProductPrice(
-    state.page.checkout.productPrices,
-    state.page.checkout.fulfilmentOption,
-    state.page.checkout.productOption,
-  );
-
   return {
     fulfilmentOption: state.page.checkout.fulfilmentOption,
     productOption: state.page.checkout.productOption,
     billingPeriod: state.page.checkout.billingPeriod,
     productPrices: state.page.checkout.productPrices,
-    total: applyDiscount(totalWithoutDiscount, getAppliedPromo(totalWithoutDiscount.promotions)),
   };
 }
 

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.jsx
@@ -11,8 +11,7 @@ import { paperProductsWithoutDigital, type ProductOptions } from 'helpers/produc
 import { Collection, type FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import type { ActivePaperProducts } from 'helpers/productPrice/productOptions';
 import type { WithDeliveryCheckoutState } from 'helpers/subscriptionsForms/subscriptionCheckoutReducer';
-import { getProductPrice } from 'helpers/productPrice/paperProductPrices';
-import { applyDiscount, getAppliedPromo } from 'helpers/productPrice/promotions';
+import { getPriceWithDiscount } from 'helpers/productPrice/paperProductPrices';
 
 import { showPrice, type ProductPrices, type ProductPrice } from 'helpers/productPrice/productPrices';
 import type { BillingPeriod } from 'helpers/billingPeriods';
@@ -52,30 +51,20 @@ function mapStateToProps(state: WithDeliveryCheckoutState) {
   };
 }
 
-function getPrintOnlyPricePlusDiscount(
-  productPrices: ProductPrices,
-  productOption: ProductOptions,
-  fulfilmentOption: ?FulfilmentOptions,
-) {
-  const printPlusPrice = getProductPrice(productPrices, fulfilmentOption, paperProductsWithoutDigital[productOption]);
-  return applyDiscount(printPlusPrice, getAppliedPromo(printPlusPrice.promotions));
-}
-
 function PaperOrderSummary(props: PropTypes) {
   const rawTotal = getPriceSummary(showPrice(props.total, false), props.billingPeriod);
   const cleanedTotal = rawTotal.replace(/\/(.*)/, ''); // removes anything after the /
   const total = `${cleanedTotal} per month`;
   // If the user has added a digi sub, we need to know the price of their selected base paper product separately
   const basePaperPrice = props.includesDigiSub ?
-    getPrintOnlyPricePlusDiscount(
+    getPriceWithDiscount(
       props.productPrices,
-      props.productOption,
       props.fulfilmentOption,
+      paperProductsWithoutDigital[props.productOption],
     )
     : props.total;
-  const priceWithDiscount = applyDiscount(basePaperPrice, getAppliedPromo(basePaperPrice.promotions));
 
-  const rawPrice = getPriceSummary(showPrice(priceWithDiscount, false), props.billingPeriod);
+  const rawPrice = getPriceSummary(showPrice(basePaperPrice, false), props.billingPeriod);
   const cleanedPrice = rawPrice.replace(/\/(.*)/, ''); // removes anything after the /
   const accessiblePriceString = `${cleanedPrice} per month`;
 

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/orderSummary/orderSummary.test.jsx
@@ -70,6 +70,7 @@ describe('Paper order summary', () => {
         imgType="png"
         altText=""
       />,
+      total: paperProducts['United Kingdom'].Collection[productOption].Monthly.GBP,
       includesDigiSub: true,
       digiSubPrice: '£5 per month',
       changeSubscription: '/page',
@@ -87,7 +88,7 @@ describe('Paper order summary', () => {
   });
 
   it('displays the correct total price', async () => {
-    const mockPrice = paperProducts['United Kingdom'].Collection[productOption].Monthly.GBP.price.toFixed(2);
+    const mockPrice = props.total.price.toFixed(2);
     expect(await screen.findByText(findTextAcrossElements(`Total:£${mockPrice} per month`))).toBeInTheDocument();
   });
 

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
@@ -22,7 +22,7 @@ import Form, { FormSection, FormSectionHiddenUntilSelected } from 'components/ch
 import Layout, { Content } from 'components/subscriptionCheckouts/layout';
 import type { ErrorReason } from 'helpers/errorReasons';
 import { showPrice, type ProductPrices, type ProductPrice } from 'helpers/productPrice/productPrices';
-import { getProductPrice } from 'helpers/productPrice/paperProductPrices';
+import { getProductPrice, getPriceWithDiscount } from 'helpers/productPrice/paperProductPrices';
 import { HomeDelivery, Collection } from 'helpers/productPrice/fulfilmentOptions';
 import { formatMachineDate, formatUserDate } from 'helpers/dateConversions';
 import {
@@ -61,8 +61,7 @@ import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import { withDeliveryFormIsValid } from 'helpers/subscriptionsForms/formValidation';
 import { setupSubscriptionPayPalPayment } from 'helpers/paymentIntegrations/payPalRecurringCheckout';
 import DirectDebitForm from 'components/directDebit/directDebitProgressiveDisclosure/directDebitForm';
-import { paperProductsWithDigital, paperProductsWithoutDigital, type ActivePaperProducts, type ProductOptions } from 'helpers/productPrice/productOptions';
-import { applyDiscount, getAppliedPromo } from 'helpers/productPrice/promotions';
+import { paperProductsWithDigital, paperProductsWithoutDigital, type ActivePaperProducts } from 'helpers/productPrice/productOptions';
 import { Paper } from 'helpers/subscriptions';
 import type { FulfilmentOptions } from 'helpers/productPrice/fulfilmentOptions';
 import DirectDebitPaymentTerms from 'components/subscriptionCheckouts/directDebit/directDebitPaymentTerms';
@@ -117,16 +116,6 @@ type PropTypes = {|
   fulfilmentOption: FulfilmentOptions,
 |};
 
-
-function getPricePlusDiscount(
-  productPrices: ProductPrices,
-  fulfilmentOption: FulfilmentOptions,
-  productOption: ProductOptions,
-) {
-  const basePrice = getProductPrice(productPrices, fulfilmentOption, productOption);
-  return applyDiscount(basePrice, getAppliedPromo(basePrice.promotions));
-}
-
 // ----- Map State/Props ----- //
 
 function mapStateToProps(state: WithDeliveryCheckoutState) {
@@ -142,7 +131,7 @@ function mapStateToProps(state: WithDeliveryCheckoutState) {
     csrf: state.page.csrf,
     currencyId: state.common.internationalisation.currencyId,
     payPalHasLoaded: state.page.checkout.payPalHasLoaded,
-    total: getPricePlusDiscount(
+    total: getPriceWithDiscount(
       state.page.checkout.productPrices,
       state.page.checkout.fulfilmentOption,
       state.page.checkout.productOption,
@@ -218,10 +207,10 @@ function PaperCheckoutForm(props: PropTypes) {
     // Price of the 'Plus' product that corresponds to the selected product option
     const plusPrice = includesDigiSub ?
       props.total :
-      getPricePlusDiscount(props.productPrices, props.fulfilmentOption, paperProductsWithDigital[props.productOption]);
+      getPriceWithDiscount(props.productPrices, props.fulfilmentOption, paperProductsWithDigital[props.productOption]);
     // Price of the standard paper-only product that corresponds to the selected product option
     const paperPrice = includesDigiSub ?
-      getPricePlusDiscount(
+      getPriceWithDiscount(
         props.productPrices,
         props.fulfilmentOption,
         paperProductsWithoutDigital[props.productOption],


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?
This fixes the bug where, when using a promo code, the correct promotion price was not being shown in the paper checkout order summary, and the 'add-on' cost of a digital subscription was not correctly calculated.

[**Trello Card**](https://trello.com/c/dme03frP)

## Screenshots
![Screenshot 2021-05-06 at 18-41-45 Support the Guardian Newspaper Subscription](https://user-images.githubusercontent.com/29146931/117342213-debc2180-ae9a-11eb-930f-967ed50317b1.png)

