### PR TITLE
Always show general error message on landing page

### DIFF
--- a/support-frontend/assets/components/generalErrorMessage/generalErrorMessage.scss
+++ b/support-frontend/assets/components/generalErrorMessage/generalErrorMessage.scss
@@ -17,11 +17,6 @@
   margin-bottom: -$gu-v-spacing;
   color: gu-colour(news-main);
   background-color: gu-colour(news-faded);
-
-  // point at you can see the all the individual invalid field error messages
-  @include mq($from: mobileMedium) {
-    display: none;
-  }
 }
 
 .component-general-error-message--marketing_consent_api_error {


### PR DESCRIPTION
When a user clicks Contribute but there is an issue with the form (e.g. missing email address), we have a generic error message above the Contribute button. But - this message is hidden above mobileMedium, which is most users. This is very confusing UX because the error message next to the specific field is often out of view.

E.g. clicking Contribute with an empty email address field:

### Before
![Screen Shot 2021-05-10 at 09 41 59](https://user-images.githubusercontent.com/1513454/117631638-59738e00-b174-11eb-93d5-0c6b24840277.png)


### After
![Screen Shot 2021-05-10 at 09 41 29](https://user-images.githubusercontent.com/1513454/117631647-5d9fab80-b174-11eb-9942-b9a9b85b709d.png)
