### PR TITLE
Update `localCurrencyTest` test name to `localCurrencyTestV2`

### DIFF
--- a/support-frontend/assets/helpers/abTests/abtestDefinitions.js
+++ b/support-frontend/assets/helpers/abTests/abtestDefinitions.js
@@ -64,7 +64,7 @@ export const tests: Tests = {
     optimizeId: '8oNvN_m2QP6U7KeAHP_lsQ',
   },
 
-  localCurrencyTest: {
+  localCurrencyTestV2: {
     variants: [
       {
         id: 'control',

--- a/support-frontend/assets/helpers/page/page.js
+++ b/support-frontend/assets/helpers/page/page.js
@@ -81,7 +81,7 @@ function getLocalCurrencyCountry(
     return localCurrencyCountries[queryParam.toUpperCase()];
   }
 
-  if (abParticipations.localCurrencyTest === 'variant') {
+  if (abParticipations.localCurrencyTestV2 === 'variant') {
     return localCurrencyCountries[countryId];
   }
 


### PR DESCRIPTION
### What does this PR do?
Because the local currency values have been updated the test parameters have changed, therefore it makes sense to update the test name and run queries using the updated name _only_.