### PR TITLE
Stop making unnecessary validation requests when checking direct debit form for errors 

### DIFF
--- a/support-frontend/assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.jsx
+++ b/support-frontend/assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.jsx
@@ -189,41 +189,72 @@ class DirectDebitForm extends Component<PropTypes, StateTypes> {
   handleErrorsAndCheckAccount = (event) => {
     event.preventDefault();
     const { props } = this;
-    let accountErrorsLength = 0;
-    fieldNames.forEach((field) => {
-      // The following line is checking that the field value matches the validation rule
-      if (!this.state[field].rule(props[field])) {
-        // If not, an error is set in state
-        this.setState(
-          state => ({
-            [field]: {
-              ...state[field],
-              error: this.state[field].message,
-            },
-          }),
-          // And then the error count in state is updated
-          () => {
-            this.getAccountErrors();
-            accountErrorsLength = this.getAccountErrorsLength();
-            this.setState({
-              accountErrorsLength,
-            });
+
+    const fieldsWithErrors = fieldNames.reduce((updatedFields, fieldName) => {
+      const hasError = !this.state[fieldName].rule(props[fieldName]);
+
+      if (hasError) {
+        return {
+          ...updatedFields,
+          accountErrorsLength: updatedFields.accountErrorsLength + 1,
+          [fieldName]: {
+            ...this.state[fieldName],
+            error: this.state[fieldName].message,
           },
-        );
-      } else {
-        // If the field is fine, the number of errors is updated
-        accountErrorsLength = this.getAccountErrorsLength();
-        this.setState(
-          { accountErrorsLength },
-          // And then all the error count is checked before an action is dispatched to check the account
-          () => {
-            if (this.state.accountErrorsLength === 0) {
-              props.payDirectDebitClicked();
-            }
-          },
-        );
+        };
       }
-    });
+      return {
+        ...updatedFields,
+        [fieldName]: {
+          ...this.state[fieldName],
+        },
+      };
+    }, { accountErrorsLength: 0 });
+
+    this.setState(
+      { ...fieldsWithErrors },
+      // And then all the error count is checked before an action is dispatched to check the account
+      () => {
+        if (this.state.accountErrorsLength === 0) {
+          props.payDirectDebitClicked();
+        }
+      },
+    );
+
+    // fieldNames.forEach((field) => {
+    //   // The following line is checking that the field value matches the validation rule
+    //   if (!this.state[field].rule(props[field])) {
+    //     // If not, an error is set in state
+    //     this.setState(
+    //       state => ({
+    //         [field]: {
+    //           ...state[field],
+    //           error: this.state[field].message,
+    //         },
+    //       }),
+    //       // And then the error count in state is updated
+    //       () => {
+    //         this.getAccountErrors();
+    //         accountErrorsLength = this.getAccountErrorsLength();
+    //         this.setState({
+    //           accountErrorsLength,
+    //         });
+    //       },
+    //     );
+    //   } else {
+    //     // If the field is fine, the number of errors is updated
+    //     accountErrorsLength = this.getAccountErrorsLength();
+    //     this.setState(
+    //       { accountErrorsLength },
+    //       // And then all the error count is checked before an action is dispatched to check the account
+    //       () => {
+    //         if (this.state.accountErrorsLength === 0) {
+    //           props.payDirectDebitClicked();
+    //         }
+    //       },
+    //     );
+    //   }
+    // });
   }
 
   render() {

--- a/support-frontend/assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.jsx
+++ b/support-frontend/assets/components/directDebit/directDebitProgressiveDisclosure/directDebitForm.jsx
@@ -190,13 +190,14 @@ class DirectDebitForm extends Component<PropTypes, StateTypes> {
     event.preventDefault();
     const { props } = this;
 
-    const fieldsWithErrors = fieldNames.reduce((updatedFields, fieldName) => {
+    // Build up a new state for the fields and the error count
+    const updatedStateWithErrors = fieldNames.reduce((updatedState, fieldName) => {
       const hasError = !this.state[fieldName].rule(props[fieldName]);
 
       if (hasError) {
         return {
-          ...updatedFields,
-          accountErrorsLength: updatedFields.accountErrorsLength + 1,
+          ...updatedState,
+          accountErrorsLength: updatedState.accountErrorsLength + 1,
           [fieldName]: {
             ...this.state[fieldName],
             error: this.state[fieldName].message,
@@ -204,7 +205,7 @@ class DirectDebitForm extends Component<PropTypes, StateTypes> {
         };
       }
       return {
-        ...updatedFields,
+        ...updatedState,
         [fieldName]: {
           ...this.state[fieldName],
         },
@@ -212,49 +213,13 @@ class DirectDebitForm extends Component<PropTypes, StateTypes> {
     }, { accountErrorsLength: 0 });
 
     this.setState(
-      { ...fieldsWithErrors },
-      // And then all the error count is checked before an action is dispatched to check the account
+      updatedStateWithErrors,
       () => {
         if (this.state.accountErrorsLength === 0) {
           props.payDirectDebitClicked();
         }
       },
     );
-
-    // fieldNames.forEach((field) => {
-    //   // The following line is checking that the field value matches the validation rule
-    //   if (!this.state[field].rule(props[field])) {
-    //     // If not, an error is set in state
-    //     this.setState(
-    //       state => ({
-    //         [field]: {
-    //           ...state[field],
-    //           error: this.state[field].message,
-    //         },
-    //       }),
-    //       // And then the error count in state is updated
-    //       () => {
-    //         this.getAccountErrors();
-    //         accountErrorsLength = this.getAccountErrorsLength();
-    //         this.setState({
-    //           accountErrorsLength,
-    //         });
-    //       },
-    //     );
-    //   } else {
-    //     // If the field is fine, the number of errors is updated
-    //     accountErrorsLength = this.getAccountErrorsLength();
-    //     this.setState(
-    //       { accountErrorsLength },
-    //       // And then all the error count is checked before an action is dispatched to check the account
-    //       () => {
-    //         if (this.state.accountErrorsLength === 0) {
-    //           props.payDirectDebitClicked();
-    //         }
-    //       },
-    //     );
-    //   }
-    // });
   }
 
   render() {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This fixes the issue where doing client-side validation checks on the fields in the direct debit form was making a validation request to the back end for every error-free field.

[**Trello Card**](https://trello.com/c/Iv9CZL3I)