### PR TITLE
Make the 'add digital' CTA in the print checkout stand out more

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-checkout/components/addDigiSubCta.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/addDigiSubCta.jsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { css } from '@emotion/core';
 import { headline } from '@guardian/src-foundations/typography';
 import { space } from '@guardian/src-foundations';
-import { neutral } from '@guardian/src-foundations/palette';
+import { brandAlt, neutral } from '@guardian/src-foundations/palette';
 import { from } from '@guardian/src-foundations/mq';
 import { Accordion, AccordionRow } from '@guardian/src-accordion';
 import { Checkbox } from '@guardian/src-checkbox';
@@ -30,10 +30,15 @@ const rowOverrides = css`
 `;
 
 const ctaContainer = css`
-  background-color: ${neutral[97]};
+  background-color: ${brandAlt[400]};
   padding: 0 ${space[6]}px;
   border-top: 1px solid ${neutral[86]};
   border-bottom: 1px solid ${neutral[86]};
+  transition: background-color 0.2s ease-out;
+`;
+
+const ctaContainerOpen = css`
+  background-color: ${neutral[97]};
 `;
 
 const lightBorder = css`
@@ -95,7 +100,7 @@ function AddDigiSubCta({ addDigitalSubscription, digiSubPrice }: PropTypes) {
   }, [expanded]);
 
   return (
-    <Accordion cssOverrides={ctaContainer} hideToggleLabel>
+    <Accordion cssOverrides={[ctaContainer, expanded ? ctaContainerOpen : '']} hideToggleLabel>
       <AccordionRow
         cssOverrides={rowOverrides}
         label={`Would you like to add a digital subscription for ${digiSubPrice}?`}


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This makes the background of the CTA yellow while it's closed, transitioning to the original light grey when opened.

[**Trello Card**](https://trello.com/c/HpPLNioV)

## Why are you doing this?

The grey colour is easy to miss in the checkout, whereas the yellow is more eye-catching and (hopefully) more tempting to click on.

## Accessibility test checklist
 - [x] [Tested with screen reader](https://accessibility.gutools.co.uk/testing/web/screen-readers/)
 - [x] [Navigable with keyboard](https://accessibility.gutools.co.uk/testing/web/keyboard-navigation/)
 - [x] [Colour contrast passed](https://accessibility.gutools.co.uk/testing/web/colour-contrast/)

## Screenshots

![Screenshot 2021-05-13 at 16-04-58 Support the Guardian Newspaper Subscription](https://user-images.githubusercontent.com/29146931/118147440-7a9fdd00-b407-11eb-9da7-93c43822dbea.png)

![ds_cta](https://user-images.githubusercontent.com/29146931/118147454-7f649100-b407-11eb-98ba-6b4a1dcf26f7.gif)