### PR TITLE
Update links for the GW and paper surveys on the thank you pages

### DIFF
--- a/support-frontend/assets/components/subscriptionCheckouts/subscriptionsSurvey/SubscriptionsSurvey.jsx
+++ b/support-frontend/assets/components/subscriptionCheckouts/subscriptionsSurvey/SubscriptionsSurvey.jsx
@@ -17,8 +17,8 @@ type PropTypes = {|
 
 const surveyLinks: {[key: SubscriptionProduct]: string} = {
   DigitalPack: 'https://www.surveymonkey.com/r/PQMWMHW',
-  GuardianWeekly: 'https://www.surveymonkey.co.uk/r/QFNYV5G',
-  Paper: 'https://www.surveymonkey.co.uk/r/Q37XNTV',
+  GuardianWeekly: 'https://www.surveymonkey.co.uk/r/9DRKP78',
+  Paper: 'https://www.surveymonkey.co.uk/r/99PGHSX',
 };
 
 export const SubscriptionsSurvey = ({ product }: PropTypes) => {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This updates the survey links on the thank you pages for the Guardian Weekly and Paper checkouts to direct users to the new surveys.

[**Trello Card**](https://trello.com/c/ecjeiEZW)