### PR TITLE
Fix price presentation in print+

### DIFF
--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
@@ -194,8 +194,9 @@ function PaperCheckoutForm(props: PropTypes) {
   }
   const [digiSubPriceString, setDigiSubPriceString] = useState<string>('');
   const [includesDigiSub, setIncludesDigiSub] = useState<boolean>(false);
-  const simplePrice = digiSubPriceString.replace(/\/(.*)/, ''); // removes anything after the /
-  const cleanedPrice = simplePrice.replace(/\.(.*)/, ''); // removes decimal point if there is one
+  const simplePrice = digiSubPriceString.replace(/\/(.*)/, ''); // removes anything after the forward slas
+  const priceHasRedundantFloat = simplePrice.split('.')[1] === '00'; // checks whether price is something like '£10.00'
+  const cleanedPrice = priceHasRedundantFloat ? simplePrice.replace(/\.(.*)/, '') : simplePrice; // removes decimal point if there are no pence
   const expandedPricingText = `${cleanedPrice} per month`;
 
   function addDigitalSubscription(event: SyntheticInputEvent<HTMLInputElement>) {

--- a/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
+++ b/support-frontend/assets/pages/paper-subscription-checkout/components/paperCheckoutForm.jsx
@@ -194,7 +194,7 @@ function PaperCheckoutForm(props: PropTypes) {
   }
   const [digiSubPriceString, setDigiSubPriceString] = useState<string>('');
   const [includesDigiSub, setIncludesDigiSub] = useState<boolean>(false);
-  const simplePrice = digiSubPriceString.replace(/\/(.*)/, ''); // removes anything after the forward slas
+  const simplePrice = digiSubPriceString.replace(/\/(.*)/, ''); // removes anything after the /
   const priceHasRedundantFloat = simplePrice.split('.')[1] === '00'; // checks whether price is something like '£10.00'
   const cleanedPrice = priceHasRedundantFloat ? simplePrice.replace(/\.(.*)/, '') : simplePrice; // removes decimal point if there are no pence
   const expandedPricingText = `${cleanedPrice} per month`;


### PR DESCRIPTION
## What are you doing in this PR?
This work is to reinstate the floating point numbers in the digital add-ons in the print checkout.

[**Trello Card**](https://trello.com/c/QBCMK6dh/3705-print-campaign-print-checkout-paper-accordion-and-order-summary-shows-incorrect-additional-charge-for-the-paper-add-on)

## Why are you doing this?
When digital add-on prices include pence (eg £1.80) the pence are getting chopped off. This adds an additional line of code to check whether the float is redundant or not.

