### PR TITLE
Move PRB object out of redux

### DIFF
--- a/support-frontend/assets/helpers/stripe.js
+++ b/support-frontend/assets/helpers/stripe.js
@@ -38,6 +38,7 @@ function getStripeKey(stripeAccount: StripeAccount, country: IsoCountry, isTestU
         window.guardian.stripeKeyDefaultCurrencies[stripeAccount].default;
   }
 }
+
 //  this is required as useStripeObjects is used in multiple components
 //  but we only want to call setLoadParameters once.
 const stripeScriptHasBeenAddedToPage = (): boolean =>

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButton.jsx
@@ -369,11 +369,11 @@ function initialisePaymentRequest(props: PropTypes, stripe: stripeJs.Stripe): Pa
       // Track the fact that it loaded, even if the user is in the control for the PRB test
       trackComponentLoad(`${paymentMethod}-loaded`);
 
-      // if (paymentMethod === 'StripeApplePay' || props.stripePaymentRequestButtonVariant) {
-      trackComponentLoad(`${paymentMethod}-displayed`);
-      props.setPaymentRequestButtonPaymentMethod(paymentMethod, props.stripeAccount);
-      setUpPaymentListenerSca(props, stripe, paymentRequestObject, paymentMethod);
-      // }
+      if (paymentMethod === 'StripeApplePay' || props.stripePaymentRequestButtonVariant) {
+        trackComponentLoad(`${paymentMethod}-displayed`);
+        props.setPaymentRequestButtonPaymentMethod(paymentMethod, props.stripeAccount);
+        setUpPaymentListenerSca(props, stripe, paymentRequestObject, paymentMethod);
+      }
     } else {
       props.setPaymentRequestButtonPaymentMethod('none', props.stripeAccount);
     }

--- a/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/StripePaymentRequestButton/StripePaymentRequestButtonContainer.jsx
@@ -6,13 +6,14 @@
 
 // We import from preact/compat here rather than react because flow doesn't like it if the child component uses redux
 // $FlowIgnore - required for hooks
-import React from 'preact/compat';
+import React, { useState } from 'preact/compat';
 import { Elements } from '@stripe/react-stripe-js';
 import type { IsoCurrency } from 'helpers/internationalisation/currency';
 import {
   getStripeKey,
   stripeAccountForContributionType,
   useStripeObjects,
+  type StripeAccount,
 } from 'helpers/stripe';
 import type {
   ContributionType,
@@ -38,6 +39,12 @@ type PropTypes = {|
 // ----- Component ----- //
 
 const StripePaymentRequestButtonContainer = (props: PropTypes) => {
+  // Maintain the PRB objects here because we must not re-create them when user switches between regular/one-off.
+  // We have to create the PRB object inside the Elements component.
+  const [prbObjects, setPrbObjects] = useState<{ [StripeAccount]: Object | null }>({
+    ONE_OFF: null,
+    REGULAR: null,
+  });
   const stripeAccount = stripeAccountForContributionType[props.contributionType];
   const stripeKey = getStripeKey(
     stripeAccount,
@@ -67,6 +74,11 @@ const StripePaymentRequestButtonContainer = (props: PropTypes) => {
             stripeAccount={stripeAccount}
             amount={amount}
             stripeKey={stripeKey}
+            paymentRequestObject={prbObjects[stripeAccount]}
+            setPaymentRequestObject={prbObject => setPrbObjects({
+              ...prbObjects,
+              [stripeAccount]: prbObject,
+            })}
           />
         </Elements>
       </div>

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingActions.js
@@ -89,7 +89,6 @@ export type Action =
   | { type: 'SET_GUEST_ACCOUNT_CREATION_TOKEN', guestAccountCreationToken: string }
   | { type: 'SET_FORM_IS_SUBMITTABLE', formIsSubmittable: boolean }
   | { type: 'SET_THANK_YOU_PAGE_STAGE', thankYouPageStage: ThankYouPageStage }
-  | { type: 'SET_STRIPE_PAYMENT_REQUEST_OBJECT', stripePaymentRequestObject: Object, stripeAccount: StripeAccount }
   | { type: 'SET_PAYMENT_REQUEST_BUTTON_PAYMENT_METHOD', paymentMethod: StripePaymentRequestButtonMethod, stripeAccount: StripeAccount }
   | { type: 'SET_STRIPE_PAYMENT_REQUEST_BUTTON_CLICKED', stripeAccount: StripeAccount }
   | { type: 'SET_STRIPE_PAYMENT_REQUEST_ERROR', paymentError: ErrorReason, stripeAccount: StripeAccount }
@@ -164,11 +163,6 @@ const updateRecaptchaToken = (recaptchaToken: string): ((Function) => void) =>
 const setPaymentRequestButtonPaymentMethod =
   (paymentMethod: 'none' | StripePaymentMethod, stripeAccount: StripeAccount): Action =>
     ({ type: 'SET_PAYMENT_REQUEST_BUTTON_PAYMENT_METHOD', paymentMethod, stripeAccount });
-
-
-const setStripePaymentRequestObject =
-  (stripePaymentRequestObject: Object, stripeAccount: StripeAccount): Action =>
-    ({ type: 'SET_STRIPE_PAYMENT_REQUEST_OBJECT', stripePaymentRequestObject, stripeAccount });
 
 const setStripePaymentRequestButtonClicked = (stripeAccount: StripeAccount): Action =>
   ({ type: 'SET_STRIPE_PAYMENT_REQUEST_BUTTON_CLICKED', stripeAccount });
@@ -798,7 +792,6 @@ export {
   setFormIsValid,
   sendFormSubmitEventForPayPalRecurring,
   setPaymentRequestButtonPaymentMethod,
-  setStripePaymentRequestObject,
   setStripePaymentRequestButtonClicked,
   setStripePaymentRequestButtonError,
   setTickerGoalReached,

--- a/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
+++ b/support-frontend/assets/pages/contributions-landing/contributionsLandingReducer.js
@@ -57,8 +57,7 @@ type SetPasswordData = {
 }
 
 export type StripePaymentRequestButtonData = {
-  paymentMethod: 'none' | StripePaymentMethod | null,
-  stripePaymentRequestObject: Object | null,
+  paymentMethod: 'none' | StripePaymentMethod,
   stripePaymentRequestButtonClicked: boolean,
   paymentError: ErrorReason | null,
 }
@@ -198,14 +197,12 @@ function createFormReducer() {
     },
     stripePaymentRequestButtonData: {
       ONE_OFF: {
-        paymentMethod: null,
-        stripePaymentRequestObject: null,
+        paymentMethod: 'none',
         stripePaymentRequestButtonClicked: false,
         paymentError: null,
       },
       REGULAR: {
-        paymentMethod: null,
-        stripePaymentRequestObject: null,
+        paymentMethod: 'none',
         stripePaymentRequestButtonClicked: false,
         paymentError: null,
       },
@@ -451,18 +448,6 @@ function createFormReducer() {
             [action.stripeAccount]: {
               ...state.stripePaymentRequestButtonData[action.stripeAccount],
               paymentMethod: action.paymentMethod,
-            },
-          },
-        };
-
-      case 'SET_STRIPE_PAYMENT_REQUEST_OBJECT':
-        return {
-          ...state,
-          stripePaymentRequestButtonData: {
-            ...state.stripePaymentRequestButtonData,
-            [action.stripeAccount]: {
-              ...state.stripePaymentRequestButtonData[action.stripeAccount],
-              stripePaymentRequestObject: action.stripePaymentRequestObject,
             },
           },
         };


### PR DESCRIPTION
This is the object returned by the Stripe SDK.
This type of thing doesn't really belong in redux, and we're trying to tidy up/remove redux use in support-frontend.
I had hoped to do this as a custom hook but it's fiddly because it has to happen inside an `Elements` component.