### PR TITLE
Send 'other' amount ophan event onBlur

### DIFF
--- a/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
+++ b/support-frontend/assets/pages/contributions-landing/components/ContributionAmount.jsx
@@ -60,7 +60,6 @@ const mapDispatchToProps = (dispatch: Function) => ({
     dispatch(selectAmount(amount, contributionType));
   },
   updateOtherAmount: (amount, countryGroupId, contributionType) => {
-    trackComponentClick(`npf-contribution-amount-toggle-${countryGroupId}-${contributionType}-${amount}`);
     dispatch(updateOtherAmount(amount, contributionType));
   },
 });
@@ -132,6 +131,7 @@ function withProps(props: PropTypes) {
               props.countryGroupId,
               props.contributionType,
             )}
+            onBlur={() => trackComponentClick(`npf-contribution-amount-toggle-${props.countryGroupId}-${props.contributionType}-${otherAmount}`)}
             error={otherAmountErrorMessage}
             autoComplete="off"
             autoFocus


### PR DESCRIPTION
Currently we're sending an event to ophan each time the 'other' amount input field changes. We should only send it for the `onBlur` event.