### PR TITLE
SEPA backend support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ lazy val integrationTestSettings: Seq[Def.Setting[_]] = Defaults.itSettings ++ S
   scalaSource in IntegrationTest := baseDirectory.value / "src" / "test" / "scala",
   javaSource in IntegrationTest := baseDirectory.value / "src" / "test" / "java",
   resourceDirectory in IntegrationTest := baseDirectory.value / "src" / "test" / "resources",
-  testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-l", "com.gu.test.tags.annotations.IntegrationTest"),
+  testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-l", "com.gu.test.tags.annotations.IntegrationTest", "-oI"),
   libraryDependencies += scalatest % "it",
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -210,7 +210,7 @@ lazy val `acquisition-event-producer` = (project in file("acquisition-event-prod
     publishMavenStyle := true,
     scalacOptions += "-Ymacro-annotations",
     libraryDependencies ++= Seq(
-      "com.gu" %% "ophan-event-model" % "0.0.17" excludeAll ExclusionRule(organization = "com.typesafe.play"),
+      "com.gu" %% "ophan-event-model" % "0.0.23" excludeAll ExclusionRule(organization = "com.typesafe.play"),
       "com.gu" %% "fezziwig" % "1.3",
       "com.typesafe.play" %% "play-json" % "2.7.4",
       "io.circe" %% "circe-core" % "0.12.1",

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -82,11 +82,6 @@
    <parameter name="doubleLineAllowed"><![CDATA[false]]></parameter>
   </parameters>
  </check>
- <check level="error" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="true">
-  <parameters>
-   <parameter name="maxLength"><![CDATA[50]]></parameter>
-  </parameters>
- </check>
  <check level="error" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="true">
   <parameters>
    <parameter name="regex"><![CDATA[^[`]?[a-z][A-Za-z0-9]*[`]?$]]></parameter>

--- a/support-frontend/app/admin/settings/Settings.scala
+++ b/support-frontend/app/admin/settings/Settings.scala
@@ -116,7 +116,8 @@ case class PaymentMethodsSwitch(
   directDebit: Option[SwitchState],
   existingCard: Option[SwitchState],
   existingDirectDebit: Option[SwitchState],
-  amazonPay: Option[SwitchState]
+  amazonPay: Option[SwitchState],
+  sepa: Option[SwitchState]
 )
 case class ExperimentSwitch(name: String, description: String, state: SwitchState) {
   def isOn: Boolean = state == SwitchState.On
@@ -139,7 +140,8 @@ object PaymentMethodsSwitch {
       SwitchState.optionFromConfig(config, "directDebit"),
       SwitchState.optionFromConfig(config, "existingCard"),
       SwitchState.optionFromConfig(config, "existingDirectDebit"),
-      SwitchState.optionFromConfig(config, "amazonPay")
+      SwitchState.optionFromConfig(config, "amazonPay"),
+      SwitchState.optionFromConfig(config, "sepa")
     )
   implicit val paymentMethodsSwitchCodec: Codec[PaymentMethodsSwitch] = deriveCodec
 }

--- a/support-frontend/app/monitoring/Tip.scala
+++ b/support-frontend/app/monitoring/Tip.scala
@@ -46,6 +46,7 @@ object PathVerification {
   case object Card extends MonitoredPaymentMethod { val tipString = "Card" }
   case object ExistingPaymentMethod extends MonitoredPaymentMethod { val tipString = "Existing Payment Method" }
   case object AmazonPay extends MonitoredPaymentMethod { val tipString = "AmazonPay" }
+  case object Sepa extends MonitoredPaymentMethod { val tipString = "Sepa" }
 
   case class TipPath(
       region: MonitoredRegion,
@@ -77,6 +78,7 @@ object PathVerification {
     case _: StripePaymentFields => Card
     case ExistingPaymentFields(_) => ExistingPaymentMethod
     case AmazonPayPaymentFields(_) => AmazonPay
+    case SepaPaymentFields(_, _) => Sepa
   }
 
   def verify(tipPath: TipPath, verifier: VerifyPath): Future[TipResponse] = {

--- a/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
+++ b/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
@@ -162,7 +162,9 @@ class SupportWorkersClient(
           supportAbTests = request.body.supportAbTests
         )),
         promoCode = request.body.promoCode,
-        firstDeliveryDate = request.body.firstDeliveryDate
+        firstDeliveryDate = request.body.firstDeliveryDate,
+        userAgent = request.headers.get("user-agent").getOrElse("Unknown"),
+        ipAddress = request.remoteAddress
       )
       isExistingAccount = createPaymentMethodState.paymentFields.left.exists(_.isInstanceOf[ExistingPaymentFields])
       executionResult <- underlying.triggerExecution(createPaymentMethodState, user.isTestUser, isExistingAccount).bimap(

--- a/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
+++ b/support-frontend/app/services/stepfunctions/SupportWorkersClient.scala
@@ -164,7 +164,7 @@ class SupportWorkersClient(
         promoCode = request.body.promoCode,
         firstDeliveryDate = request.body.firstDeliveryDate,
         userAgent = request.headers.get("user-agent").getOrElse("Unknown"),
-        ipAddress = request.remoteAddress
+        ipAddress = request.headers.get("X-Forwarded-For").flatMap(_.split(',').headOption).getOrElse(request.remoteAddress)
       )
       isExistingAccount = createPaymentMethodState.paymentFields.left.exists(_.isInstanceOf[ExistingPaymentFields])
       executionResult <- underlying.triggerExecution(createPaymentMethodState, user.isTestUser, isExistingAccount).bimap(

--- a/support-frontend/test/codecs/CirceDecodersTest.scala
+++ b/support-frontend/test/codecs/CirceDecodersTest.scala
@@ -101,7 +101,6 @@ class CirceDecodersTest extends AnyWordSpec with Matchers {
           |      "stripeApplePay": "On",
           |      "stripePaymentRequestButton": "On",
           |      "payPal": "On",
-          |      "sepa": "On",
           |      "amazonPay": "On"
           |    },
           |    "recurringPaymentMethods": {

--- a/support-frontend/test/codecs/CirceDecodersTest.scala
+++ b/support-frontend/test/codecs/CirceDecodersTest.scala
@@ -101,6 +101,7 @@ class CirceDecodersTest extends AnyWordSpec with Matchers {
           |      "stripeApplePay": "On",
           |      "stripePaymentRequestButton": "On",
           |      "payPal": "On",
+          |      "sepa": "On",
           |      "amazonPay": "On"
           |    },
           |    "recurringPaymentMethods": {
@@ -110,6 +111,7 @@ class CirceDecodersTest extends AnyWordSpec with Matchers {
           |      "payPal": "On",
           |      "directDebit": "On",
           |      "existingCard": "On",
+          |      "sepa": "On",
           |      "existingDirectDebit": "On"
           |    },
           |    "experiments": {
@@ -313,6 +315,7 @@ class CirceDecodersTest extends AnyWordSpec with Matchers {
             directDebit = None,
             existingCard = None,
             existingDirectDebit = None,
+            sepa = None,
             amazonPay = Some(On)
           ),
           recurringPaymentMethods = PaymentMethodsSwitch(
@@ -323,6 +326,7 @@ class CirceDecodersTest extends AnyWordSpec with Matchers {
             directDebit = Some(On),
             existingCard = Some(On),
             existingDirectDebit = Some(On),
+            sepa = Some(On),
             amazonPay = None
           ),
           experiments = Map(

--- a/support-frontend/test/controllers/SubscriptionsTest.scala
+++ b/support-frontend/test/controllers/SubscriptionsTest.scala
@@ -105,8 +105,8 @@ class SubscriptionsTest extends AnyWordSpec with Matchers with TestCSRFComponent
 
     val allSettings = AllSettings(
       Switches(
-        oneOffPaymentMethods = PaymentMethodsSwitch(On, On, On, On, None, None, None, None),
-        recurringPaymentMethods = PaymentMethodsSwitch(On, On, On, On, Some(On), Some(On), Some(On), None),
+        oneOffPaymentMethods = PaymentMethodsSwitch(On, On, On, On, None, None, None, None, None),
+        recurringPaymentMethods = PaymentMethodsSwitch(On, On, On, On, Some(On), Some(On), Some(On), None, None),
         experiments = Map.empty,
         enableDigitalSubGifting = On,
         useDotcomContactPage = Some(SwitchState.Off),

--- a/support-models/src/main/scala/com/gu/support/workers/PaymentFields.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/PaymentFields.scala
@@ -52,6 +52,11 @@ case class DirectDebitPaymentFields(
   accountNumber: String
 ) extends PaymentFields
 
+case class SepaPaymentFields(
+  accountHolderName: String,
+  iban: String
+) extends PaymentFields
+
 case class ExistingPaymentFields(billingAccountId: String) extends PaymentFields
 
 case class AmazonPayPaymentFields(amazonPayBillingAgreementId: String) extends PaymentFields
@@ -62,6 +67,7 @@ object PaymentFields {
   implicit val stripeSourcePaymentFieldsCodec: Codec[StripeSourcePaymentFields] = deriveCodec
   implicit val stripePaymentMethodPaymentFieldsCodec: Codec[StripePaymentMethodPaymentFields] = deriveCodec
   implicit val directDebitPaymentFieldsCodec: Codec[DirectDebitPaymentFields] = deriveCodec
+  implicit val sepaPaymentFieldsCodec: Codec[SepaPaymentFields] = deriveCodec
   implicit val existingPaymentFieldsCodec: Codec[ExistingPaymentFields] = deriveCodec
   implicit val amazonPayPaymentFieldsCodec: Codec[AmazonPayPaymentFields] = deriveCodec
 
@@ -70,6 +76,7 @@ object PaymentFields {
     case s: StripeSourcePaymentFields => s.asJson
     case s: StripePaymentMethodPaymentFields => s.asJson
     case d: DirectDebitPaymentFields => d.asJson
+    case s: SepaPaymentFields => s.asJson
     case e: ExistingPaymentFields => e.asJson
     case a: AmazonPayPaymentFields => a.asJson
   }
@@ -80,6 +87,7 @@ object PaymentFields {
       Decoder[StripeSourcePaymentFields].widen,
       Decoder[StripePaymentMethodPaymentFields].widen,
       Decoder[DirectDebitPaymentFields].widen,
+      Decoder[SepaPaymentFields].widen,
       Decoder[ExistingPaymentFields].widen,
       Decoder[AmazonPayPaymentFields].widen
     ).reduceLeft(or(_,_))

--- a/support-models/src/main/scala/com/gu/support/workers/PaymentProvider.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/PaymentProvider.scala
@@ -14,6 +14,8 @@ case object PayPal extends PaymentProvider("PayPal")
 
 case object DirectDebit extends PaymentProvider("DirectDebit")
 
+case object Sepa extends PaymentProvider("Sepa")
+
 case object Existing extends PaymentProvider("Existing")
 
 case object RedemptionNoProvider extends PaymentProvider("Redemption")
@@ -27,6 +29,7 @@ object PaymentProvider {
     StripeApplePay,
     PayPal,
     DirectDebit,
+    Sepa,
     Existing,
     RedemptionNoProvider,
     AmazonPay
@@ -48,6 +51,7 @@ object PaymentProvider {
     }
     case Some(_: PayPalPaymentFields) => PayPal
     case Some(_: DirectDebitPaymentFields) => DirectDebit
+    case Some(_: SepaPaymentFields) => Sepa
     case Some(_: ExistingPaymentFields) => Existing
     case Some(_: AmazonPayPaymentFields) => AmazonPay
     case None /* Corporate*/ => RedemptionNoProvider

--- a/support-models/src/main/scala/com/gu/support/workers/states/CreatePaymentMethodState.scala
+++ b/support-models/src/main/scala/com/gu/support/workers/states/CreatePaymentMethodState.scala
@@ -17,7 +17,9 @@ case class CreatePaymentMethodState(
   paymentFields: Either[PaymentFields, RedemptionData],
   firstDeliveryDate: Option[LocalDate],
   promoCode: Option[PromoCode],
-  acquisitionData: Option[AcquisitionData]
+  acquisitionData: Option[AcquisitionData],
+  ipAddress: String,
+  userAgent: String
 ) extends FailureHandlerState
 
 import com.gu.support.encoding.Codec

--- a/support-models/src/main/scala/com/gu/support/zuora/api/PaymentGateway.scala
+++ b/support-models/src/main/scala/com/gu/support/zuora/api/PaymentGateway.scala
@@ -20,6 +20,7 @@ object PaymentGateway {
     case StripeGatewayAUD.name => StripeGatewayAUD
     case PayPalGateway.name => PayPalGateway
     case DirectDebitGateway.name => DirectDebitGateway
+    case SepaGateway.name => SepaGateway
     case ZuoraInstanceDirectDebitGateway.name => ZuoraInstanceDirectDebitGateway
     case StripeGatewayPaymentIntentsDefault.name => StripeGatewayPaymentIntentsDefault
     case StripeGatewayPaymentIntentsAUD.name => StripeGatewayPaymentIntentsAUD
@@ -55,6 +56,10 @@ case object PayPalGateway extends PaymentGateway {
 
 case object DirectDebitGateway extends PaymentGateway {
   val name = "GoCardless"
+}
+
+case object SepaGateway extends PaymentGateway {
+  val name = "Stripe Bank Transfer - GNM Membership"
 }
 
 case object ZuoraInstanceDirectDebitGateway extends PaymentGateway {

--- a/support-models/src/test/scala/com/gu/support/SerialisationTestHelpers.scala
+++ b/support-models/src/test/scala/com/gu/support/SerialisationTestHelpers.scala
@@ -1,7 +1,7 @@
 package com.gu.support
 
 import io.circe.{Decoder, Encoder, Error}
-import io.circe.parser.decode
+import io.circe.parser.{decode, parse}
 import io.circe.syntax._
 import org.scalatest.Assertion
 import org.scalatest.matchers.should.Matchers
@@ -10,6 +10,14 @@ trait SerialisationTestHelpers extends Matchers {
   def testDecoding[T : Decoder](fixture: String, objectChecks: T => Assertion = (_: T) => succeed): Assertion = {
     val decodeResult = decode[T](fixture)
     assertDecodingSucceeded(decodeResult, objectChecks)
+  }
+
+  def testEncoding[T : Encoder](t: T, expectedJson: String): Assertion = {
+    val json = t.asJson
+    parse(expectedJson).fold(
+      err => fail(err.getMessage),
+      expected => json should be(expected)
+    )
   }
 
   def assertDecodingSucceeded[T](decodeResult: Either[Error, T], objectChecks: T => Assertion = (_: T) => succeed): Assertion =

--- a/support-models/src/test/scala/com/gu/support/encoding/PaymentMethodEncoderSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/encoding/PaymentMethodEncoderSpec.scala
@@ -2,7 +2,7 @@ package com.gu.support.encoding
 
 import com.gu.support.SerialisationTestHelpers
 import com.gu.support.encoding.Codec._
-import com.gu.support.workers.{ClonedDirectDebitPaymentMethod, DirectDebitPaymentMethod, PaymentMethod}
+import com.gu.support.workers.{ClonedDirectDebitPaymentMethod, DirectDebitPaymentMethod, GatewayOption, GatewayOptionData, PaymentMethod, SepaPaymentMethod}
 import com.typesafe.scalalogging.LazyLogging
 import io.circe._
 import org.scalatest.flatspec.AsyncFlatSpec
@@ -55,6 +55,37 @@ class PaymentMethodEncoderSpec extends AsyncFlatSpec with Matchers with LazyLogg
       case _ : ClonedDirectDebitPaymentMethod => succeed
       case x => fail(s"Expected ClonedDirectDebitPaymentMethod, got $x")
     })
+  }
+
+  it should "encode SepaPaymentMethod" in {
+    val pm = SepaPaymentMethod(
+      BankTransferAccountName = "Mr Test",
+      BankTransferAccountNumber = "DE89370400440532013000",
+      Email = "mr.test@guardian.co.uk",
+      IPAddress = "127.0.0.1",
+      GatewayOptionData = GatewayOptionData(List(GatewayOption(name = "UserAgent", value = "IE11"))),
+    )
+
+    val expected =
+      s"""{
+         |"BankTransferAccountName": "Mr Test",
+         |"BankTransferAccountNumber": "DE89370400440532013000",
+         |"Email": "mr.test@guardian.co.uk",
+         |"IPAddress": "127.0.0.1",
+         |"GatewayOptionData": {
+         |    "GatewayOption": [
+         |        {
+         |            "name": "UserAgent",
+         |            "value": "IE11"
+         |        }
+         |    ]
+         |},
+         |"BankTransferType": "SEPA",
+         |"Type": "BankTransfer",
+         |"PaymentGateway": "Stripe Bank Transfer - GNM Membership"
+         |}""".stripMargin
+
+    testEncoding[PaymentMethod](pm, expected)
   }
 
 }

--- a/support-models/src/test/scala/com/gu/support/workers/Fixtures.scala
+++ b/support-models/src/test/scala/com/gu/support/workers/Fixtures.scala
@@ -152,7 +152,9 @@ object Fixtures {
             "isGiftPurchase": false
           },
           "paymentFields": $payPalJson,
-          "acquisitionData": $acquisitionData
+          "acquisitionData": $acquisitionData,
+          "ipAddress": "127.0.0.1",
+          "userAgent": "TestAgent"
         }"""
 
   def createStripePaymentMethodContributionJson(billingPeriod: BillingPeriod = Monthly, amount: BigDecimal = 5): String =
@@ -166,7 +168,9 @@ object Fixtures {
           },
           "paymentFields": $stripeJson,
           "sessionId": "testingToken",
-          "acquisitionData": $acquisitionData
+          "acquisitionData": $acquisitionData,
+          "ipAddress": "127.0.0.1",
+          "userAgent": "TestAgent"
         }"""
 
   val createPayPalPaymentMethodDigitalPackJson =
@@ -179,7 +183,9 @@ object Fixtures {
             "isGiftPurchase": false
           },
           "paymentFields": $payPalJson,
-          "acquisitionData": $acquisitionData
+          "acquisitionData": $acquisitionData,
+          "ipAddress": "127.0.0.1",
+          "userAgent": "TestAgent"
         }"""
 
   val createDirectDebitDigitalPackJson =
@@ -192,7 +198,9 @@ object Fixtures {
             "isGiftPurchase": false
           },
           "paymentFields": $directDebitJson,
-          "acquisitionData": $acquisitionData
+          "acquisitionData": $acquisitionData,
+          "ipAddress": "127.0.0.1",
+          "userAgent": "TestAgent"
         }"""
 
   val createDirectDebitGuardianWeeklyJson =
@@ -205,7 +213,9 @@ object Fixtures {
             "isGiftPurchase": false
           },
           "paymentFields": $directDebitJson,
-          "acquisitionData": $acquisitionData
+          "acquisitionData": $acquisitionData,
+          "ipAddress": "127.0.0.1",
+          "userAgent": "TestAgent"
         }"""
 
   val createSalesforceContactJson =

--- a/support-models/src/test/scala/com/gu/support/workers/SerialisationSpec.scala
+++ b/support-models/src/test/scala/com/gu/support/workers/SerialisationSpec.scala
@@ -76,7 +76,9 @@ object StatesTestData {
     paymentFields = Left(PayPalPaymentFields("baid")),
     firstDeliveryDate = None,
     promoCode = None,
-    acquisitionData = None
+    acquisitionData = None,
+    ipAddress = "127.0.0.1",
+    userAgent = "TestAgent"
   )
 
   val createSalesforceContactState = CreateSalesforceContactState(

--- a/support-modules/bigquery/src/main/scala/com/gu/support/acquisitions/AcquisitionDataRow.scala
+++ b/support-modules/bigquery/src/main/scala/com/gu/support/acquisitions/AcquisitionDataRow.scala
@@ -135,6 +135,8 @@ object PaymentProvider{
 
   case object StripePaymentRequestButton extends PaymentProvider("STRIPE_PAYMENT_REQUEST_BUTTON")
 
+  case object StripeSepa extends PaymentProvider("STRIPE_SEPA")
+
   case object PayPal extends PaymentProvider("PAYPAL")
 
   case object DirectDebit extends PaymentProvider("GOCARDLESS")

--- a/support-workers/src/main/scala/com/gu/acquisitions/AcquisitionDataRowBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/acquisitions/AcquisitionDataRowBuilder.scala
@@ -10,7 +10,7 @@ import com.gu.support.zuora.api.ReaderType.{Corporate, Direct, Gift}
 import org.joda.time.{DateTime, DateTimeZone}
 import com.gu.support.acquisitions
 import com.gu.support.acquisitions.AcquisitionType.{Purchase, Redemption}
-import com.gu.support.acquisitions.PaymentProvider.{DirectDebit, PayPal, Stripe, StripeApplePay, StripePaymentRequestButton, AmazonPay}
+import com.gu.support.acquisitions.PaymentProvider.{DirectDebit, PayPal, Stripe, StripeApplePay, StripePaymentRequestButton, StripeSepa, AmazonPay}
 import com.gu.support.acquisitions.PrintProduct._
 import com.gu.support.acquisitions.{AcquisitionDataRow, AcquisitionProduct, AcquisitionType, PaymentFrequency, PaymentProvider, PrintOptions, PrintProduct}
 import com.gu.support.zuora.api.ReaderType
@@ -73,7 +73,7 @@ object AcquisitionDataRowBuilder {
         }
       case _: PayPalReferenceTransaction => PayPal
       case _: DirectDebitPaymentMethod | _: ClonedDirectDebitPaymentMethod => DirectDebit
-      case _: SepaPaymentMethod => DirectDebit  //TODO - new PaymentProvider?
+      case _: SepaPaymentMethod => StripeSepa
       case _: AmazonPayPaymentMethod => AmazonPay
     }
 

--- a/support-workers/src/main/scala/com/gu/acquisitions/AcquisitionDataRowBuilder.scala
+++ b/support-workers/src/main/scala/com/gu/acquisitions/AcquisitionDataRowBuilder.scala
@@ -5,7 +5,7 @@ import com.gu.support.catalog._
 import com.gu.support.promotions.{DefaultPromotions, PromoCode}
 import com.gu.support.workers.states.SendThankYouEmailState._
 import com.gu.support.workers.states.{SendAcquisitionEventState, SendThankYouEmailState}
-import com.gu.support.workers.{AcquisitionData, AmazonPayPaymentMethod, Annual, BillingPeriod, ClonedDirectDebitPaymentMethod, Contribution, CreditCardReferenceTransaction, DigitalPack, DirectDebitPaymentMethod, GuardianWeekly, Monthly, Paper, PayPalReferenceTransaction, PaymentMethod, ProductType, Quarterly, RequestInfo, SixWeekly, StripePaymentType}
+import com.gu.support.workers.{AcquisitionData, AmazonPayPaymentMethod, Annual, BillingPeriod, ClonedDirectDebitPaymentMethod, Contribution, CreditCardReferenceTransaction, DigitalPack, DirectDebitPaymentMethod, SepaPaymentMethod, GuardianWeekly, Monthly, Paper, PayPalReferenceTransaction, PaymentMethod, ProductType, Quarterly, RequestInfo, SixWeekly, StripePaymentType}
 import com.gu.support.zuora.api.ReaderType.{Corporate, Direct, Gift}
 import org.joda.time.{DateTime, DateTimeZone}
 import com.gu.support.acquisitions
@@ -73,6 +73,7 @@ object AcquisitionDataRowBuilder {
         }
       case _: PayPalReferenceTransaction => PayPal
       case _: DirectDebitPaymentMethod | _: ClonedDirectDebitPaymentMethod => DirectDebit
+      case _: SepaPaymentMethod => DirectDebit  //TODO - new PaymentProvider?
       case _: AmazonPayPaymentMethod => AmazonPay
     }
 

--- a/support-workers/src/main/scala/com/gu/emailservices/ContributionEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/ContributionEmailFields.scala
@@ -53,6 +53,7 @@ class ContributionEmailFields(
       ))
       case _: PayPalReferenceTransaction => Future.successful(List("payment method" -> "PayPal"))
       case _: CreditCardReferenceTransaction => Future.successful(List("payment method" -> "credit / debit card"))
+      case _: SepaPaymentMethod => Future.successful(List("payment method" -> "Sepa"))  // TODO
       case _: AmazonPayPaymentMethod => Future.successful(List("payment method" -> "AmazonPay"))
     }
   }

--- a/support-workers/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
@@ -2,7 +2,7 @@ package com.gu.emailservices
 
 import cats.implicits._
 import com.gu.emailservices.DigitalSubscriptionEmailAttributes.PaymentFieldsAttributes
-import com.gu.emailservices.DigitalSubscriptionEmailAttributes.PaymentFieldsAttributes.{APAttributes, CCAttributes, DDAttributes, PPAttributes}
+import com.gu.emailservices.DigitalSubscriptionEmailAttributes.PaymentFieldsAttributes.{APAttributes, CCAttributes, DDAttributes, PPAttributes, SepaAttributes}
 import com.gu.emailservices.SubscriptionEmailFieldHelpers._
 import com.gu.salesforce.Salesforce.SfContactId
 import com.gu.support.config.TouchPointEnvironment
@@ -43,12 +43,14 @@ object DigitalSubscriptionEmailAttributes {
     implicit val e2: Encoder.AsObject[CCAttributes] = deriveEncoder
     implicit val e3: Encoder.AsObject[PPAttributes] = deriveEncoder
     implicit val e4: Encoder.AsObject[APAttributes] = deriveEncoder
+    implicit val e5: Encoder.AsObject[SepaAttributes] = deriveEncoder
 
     implicit val encoder: Encoder.AsObject[PaymentFieldsAttributes] = Encoder.AsObject.instance {
       case v: DDAttributes => v.asJsonObject
       case v: CCAttributes => v.asJsonObject
       case v: PPAttributes => v.asJsonObject
       case v: APAttributes => v.asJsonObject
+      case v: SepaAttributes => v.asJsonObject
     }
 
     case class DDAttributes(
@@ -57,6 +59,12 @@ object DigitalSubscriptionEmailAttributes {
       account_name: String,
       mandateid: String,
       default_payment_method: String = "Direct Debit",
+    ) extends PaymentFieldsAttributes
+
+    case class SepaAttributes(
+      // TODO
+      iban: String,
+      default_payment_method: String = "Sepa"
     ) extends PaymentFieldsAttributes
 
     case class CCAttributes(
@@ -290,6 +298,7 @@ class DigitalPackPaymentEmailFields(getMandate: String => Future[Option[String]]
       case _: CreditCardReferenceTransaction => Future.successful(CCAttributes())
       case _: PayPalReferenceTransaction => Future.successful(PPAttributes())
       case _: AmazonPayPaymentMethod => Future.successful(APAttributes())
+      case sepa: SepaPaymentMethod => Future.successful(SepaAttributes(sepa.BankTransferAccountNumber))
     }
 
 }

--- a/support-workers/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/DigitalPackEmailFields.scala
@@ -62,7 +62,6 @@ object DigitalSubscriptionEmailAttributes {
     ) extends PaymentFieldsAttributes
 
     case class SepaAttributes(
-      // TODO
       iban: String,
       default_payment_method: String = "Sepa"
     ) extends PaymentFieldsAttributes

--- a/support-workers/src/main/scala/com/gu/emailservices/PaperFieldsGenerator.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/PaperFieldsGenerator.scala
@@ -105,7 +105,7 @@ class PaperFieldsGenerator(
     case _: CreditCardReferenceTransaction => Future.successful(List("payment_method" -> "Credit/Debit Card"))
     case _: PayPalReferenceTransaction => Future.successful(List("payment_method" -> "PayPal"))
     case _: AmazonPayPaymentMethod => Future.successful(List("payment_method" -> "AmazonPay"))
-    case _: SepaPaymentMethod => Future.successful(List("payment_method" -> "Sepa"))  // TODO
+    case _: SepaPaymentMethod => Future.successful(List("payment_method" -> "Sepa"))
   }
 
 }

--- a/support-workers/src/main/scala/com/gu/emailservices/PaperFieldsGenerator.scala
+++ b/support-workers/src/main/scala/com/gu/emailservices/PaperFieldsGenerator.scala
@@ -105,6 +105,7 @@ class PaperFieldsGenerator(
     case _: CreditCardReferenceTransaction => Future.successful(List("payment_method" -> "Credit/Debit Card"))
     case _: PayPalReferenceTransaction => Future.successful(List("payment_method" -> "PayPal"))
     case _: AmazonPayPaymentMethod => Future.successful(List("payment_method" -> "AmazonPay"))
+    case _: SepaPaymentMethod => Future.successful(List("payment_method" -> "Sepa"))  // TODO
   }
 
 }

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreatePaymentMethod.scala
@@ -56,6 +56,8 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
         createPayPalPaymentMethod(paypal, services.payPalService)
       case dd: DirectDebitPaymentFields =>
         createDirectDebitPaymentMethod(dd, user)
+      case sepa: SepaPaymentFields =>
+        createSepaPaymentMethod(sepa, user)
       case _: ExistingPaymentFields =>
         Future.failed(new RuntimeException("Existing payment methods should never make their way to this lambda"))
       case amazonPay: AmazonPayPaymentFields =>
@@ -138,6 +140,16 @@ class CreatePaymentMethod(servicesProvider: ServiceProvider = ServiceProvider)
       State = user.billingAddress.state,
       StreetName = addressLine.map(_.streetName),
       StreetNumber = addressLine.flatMap(_.streetNumber)
+    ))
+  }
+
+  def createSepaPaymentMethod(sepa: SepaPaymentFields, user: User): Future[SepaPaymentMethod] = {
+    Future.successful(SepaPaymentMethod(
+      BankTransferAccountName = sepa.accountHolderName,
+      BankTransferAccountNumber = sepa.iban,
+      Email = user.primaryEmailAddress,
+      IPAddress = "127.0.0.1",
+      GatewayOptionData = GatewayOptionData(List(GatewayOption("UserAgent", "TestUserAgent")))
     ))
   }
 

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/CreateZuoraSubscription.scala
@@ -85,6 +85,8 @@ class ZuoraSubscriptionCreator(
         .withLogging("gift recipient with code")
     } yield digitalSubscriptionGiftCreationDetails
     val maybeGeneratedGiftCode = maybeDigitalSubscriptionGiftCreationDetails.map(_.giftCode)
+
+
     for {
       subscriptionData <- subscriptionDataBuilder.build(state, maybeGeneratedGiftCode).value.map(_.toTry).flatMap(Future.fromTry)
         .withEventualLogging("subscription data")

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/PaymentMethodExtensions.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/PaymentMethodExtensions.scala
@@ -8,6 +8,7 @@ object PaymentMethodExtensions {
       case _: CreditCardReferenceTransaction => "Stripe"
       case _: PayPalReferenceTransaction => "PayPal"
       case _: DirectDebitPaymentMethod | _: ClonedDirectDebitPaymentMethod => "DirectDebit"
+      case _: SepaPaymentMethod => "Sepa"
       case _: AmazonPayPaymentMethod => "AmazonPay"
     }
   }

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendOldAcquisitionEvent.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendOldAcquisitionEvent.scala
@@ -89,7 +89,7 @@ object SendOldAcquisitionEvent {
         }
       case _: PayPalReferenceTransaction => thrift.PaymentProvider.Paypal
       case _: DirectDebitPaymentMethod | _: ClonedDirectDebitPaymentMethod => thrift.PaymentProvider.Gocardless
-      case _: SepaPaymentMethod => thrift.PaymentProvider.Gocardless  // TODO
+      case _: SepaPaymentMethod => thrift.PaymentProvider.StripeSepa
       case _: AmazonPayPaymentMethod => thrift.PaymentProvider.AmazonPay
     }
 

--- a/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendOldAcquisitionEvent.scala
+++ b/support-workers/src/main/scala/com/gu/support/workers/lambdas/SendOldAcquisitionEvent.scala
@@ -89,6 +89,7 @@ object SendOldAcquisitionEvent {
         }
       case _: PayPalReferenceTransaction => thrift.PaymentProvider.Paypal
       case _: DirectDebitPaymentMethod | _: ClonedDirectDebitPaymentMethod => thrift.PaymentProvider.Gocardless
+      case _: SepaPaymentMethod => thrift.PaymentProvider.Gocardless  // TODO
       case _: AmazonPayPaymentMethod => thrift.PaymentProvider.AmazonPay
     }
 

--- a/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
+++ b/support-workers/src/test/scala/com/gu/support/workers/JsonFixtures.scala
@@ -267,7 +267,9 @@ object JsonFixtures {
             "isGiftPurchase": false
           },
           "paymentFields": $payPalJson,
-          "acquisitionData": $acquisitionData
+          "acquisitionData": $acquisitionData,
+          "ipAddress": "127.0.0.1",
+          "userAgent": "Test"
         }"""
 
   def createStripeSourcePaymentMethodContributionJson(billingPeriod: BillingPeriod = Monthly, amount: BigDecimal = 5, currency: Currency = GBP): String =
@@ -281,7 +283,9 @@ object JsonFixtures {
           },
           "paymentFields": $stripeJson,
           "sessionId": "testingToken",
-          "acquisitionData": $acquisitionData
+          "acquisitionData": $acquisitionData,
+          "ipAddress": "127.0.0.1",
+          "userAgent": "Test"
         }"""
 
   def createStripePaymentMethodPaymentMethodContributionJson(billingPeriod: BillingPeriod = Monthly, amount: BigDecimal = 5, currency: Currency = GBP): String =
@@ -295,7 +299,9 @@ object JsonFixtures {
           },
           "paymentFields": $stripePaymentMethodJson,
           "sessionId": "testingToken",
-          "acquisitionData": $acquisitionData
+          "acquisitionData": $acquisitionData,
+          "ipAddress": "127.0.0.1",
+          "userAgent": "Test"
         }"""
 
   val createPayPalPaymentMethodDigitalPackJson =
@@ -307,7 +313,9 @@ object JsonFixtures {
             "paymentProvider": "PayPal",
             "isGiftPurchase": false
           },
-          "paymentFields": $payPalJson
+          "paymentFields": $payPalJson,
+          "ipAddress": "127.0.0.1",
+          "userAgent": "Test"
         }"""
 
   val createDirectDebitDigitalPackJson =


### PR DESCRIPTION
With @TomPretty 

Adds Stripe SEPA as a payment method for recurring contributions.
Stripe requires the client's IP address and user agent, so we pass this through from support-frontend's backend.
