### PR TITLE
Make getReferrerAcquisitionData safer

### DIFF
--- a/support-frontend/assets/helpers/tracking/acquisitions.js
+++ b/support-frontend/assets/helpers/tracking/acquisitions.js
@@ -169,7 +169,7 @@ const participationsToAcquisitionABTest = (participations: Participations): Acqu
 };
 
 // Builds the acquisition object from data and other sources.
-function buildReferrerAcquisitionData(acquisitionData: Object = {}): ReferrerAcquisitionData {
+function buildReferrerAcquisitionData(acquisitionData: Object): ReferrerAcquisitionData {
 
   // This was how referrer pageview id used to be passed.
   const referrerPageviewId = acquisitionData.referrerPageviewId ||
@@ -285,7 +285,7 @@ function getReferrerAcquisitionData(): ReferrerAcquisitionData {
     : deserialiseJsonObject(getQueryParameter(ACQUISITIONS_PARAM) || '');
 
   // Read from param, or read from sessionStorage, or build minimal version.
-  const referrerAcquisitionData = buildReferrerAcquisitionData(paramData || readReferrerAcquisitionData() || undefined);
+  const referrerAcquisitionData = buildReferrerAcquisitionData(paramData || readReferrerAcquisitionData() || {});
   storeReferrerAcquisitionData(referrerAcquisitionData);
 
   return referrerAcquisitionData;

--- a/support-frontend/assets/helpers/tracking/ophan.js
+++ b/support-frontend/assets/helpers/tracking/ophan.js
@@ -113,12 +113,14 @@ const trackAbTests = (participations: Participations): void =>
 // Note - the localstorage item is deleted by tracker-js as soon as it's read, see:
 // https://github.com/guardian/ophan/blob/75b86abcce07369c8998521399327d436246c016/tracker-js/assets/coffee/ophan/core.coffee#L72
 const setReferrerDataInLocalStorage = (acquisitionData: ReferrerAcquisitionData): void => {
-  const { referrerUrl, referrerPageviewId } = acquisitionData;
-  if (!localStorage.getItem('ophan_follow') && referrerUrl && referrerPageviewId) {
-    localStorage.setItem('ophan_follow', JSON.stringify({
-      refViewId: referrerPageviewId,
-      ref: referrerUrl,
-    }));
+  if (acquisitionData) {
+    const {referrerUrl, referrerPageviewId} = acquisitionData;
+    if (!localStorage.getItem('ophan_follow') && referrerUrl && referrerPageviewId) {
+      localStorage.setItem('ophan_follow', JSON.stringify({
+        refViewId: referrerPageviewId,
+        ref: referrerUrl,
+      }));
+    }
   }
 };
 


### PR DESCRIPTION
An increase in client-side errors coincided with the 18th March.
The only deploy that day which could potentially cause problems is this:
https://github.com/guardian/support-frontend/pull/2987

I'm not sure what the cause is yet. One possibility is that the `ReferrerAcquisitionData` value is `undefined`. This PR makes things a bit safer