### PR TITLE
Fix issue with the roundel on the paper subs landing page

### DIFF
--- a/support-frontend/assets/components/page/heroRoundel.jsx
+++ b/support-frontend/assets/components/page/heroRoundel.jsx
@@ -9,6 +9,7 @@ import { headline } from '@guardian/src-foundations/typography';
 import { digitalSubscriptionsBlue } from 'stylesheets/emotion/colours';
 
 export const roundelSizeMob = 100;
+export const roundelMaxMob = 120;
 export const roundelSize = 180;
 
 
@@ -21,13 +22,14 @@ const heroRoundelStyles = css`
   float: left;
   transform: translateY(-67%);
   min-width: ${roundelSizeMob}px;
-  max-width: ${roundelSize}px;
+  max-width: ${roundelMaxMob}px;
   width: calc(100% + ${space[3]}px);
   padding: ${space[1]}px;
   border-radius: 50%;
   ${headline.xxsmall({ fontWeight: 'bold' })};
 
   ${from.tablet} {
+    max-width: ${roundelSize}px;
     width: calc(100% + ${space[6]}px);
     transform: translateY(-50%);
     ${headline.small({ fontWeight: 'bold' })};

--- a/support-frontend/assets/components/page/heroRoundel.jsx
+++ b/support-frontend/assets/components/page/heroRoundel.jsx
@@ -9,7 +9,6 @@ import { headline } from '@guardian/src-foundations/typography';
 import { digitalSubscriptionsBlue } from 'stylesheets/emotion/colours';
 
 export const roundelSizeMob = 100;
-export const roundelMaxMob = 120;
 export const roundelSize = 180;
 
 
@@ -22,14 +21,13 @@ const heroRoundelStyles = css`
   float: left;
   transform: translateY(-67%);
   min-width: ${roundelSizeMob}px;
-  max-width: ${roundelMaxMob}px;
+  max-width: ${roundelSize}px;
   width: calc(100% + ${space[3]}px);
   padding: ${space[1]}px;
   border-radius: 50%;
   ${headline.xxsmall({ fontWeight: 'bold' })};
 
   ${from.tablet} {
-    max-width: ${roundelSize}px;
     width: calc(100% + ${space[6]}px);
     transform: translateY(-50%);
     ${headline.small({ fontWeight: 'bold' })};

--- a/support-frontend/assets/pages/paper-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/hero/hero.jsx
@@ -8,7 +8,7 @@ import { css } from '@emotion/core';
 import { LinkButton, buttonBrand } from '@guardian/src-button';
 import { SvgArrowDownStraight } from '@guardian/src-icons';
 import { space } from '@guardian/src-foundations';
-import { from } from '@guardian/src-foundations/mq';
+import { between, from, until } from '@guardian/src-foundations/mq';
 import { body, headline } from '@guardian/src-foundations/typography';
 import { brandAlt } from '@guardian/src-foundations/palette';
 
@@ -16,6 +16,7 @@ import CentredContainer from 'components/containers/centredContainer';
 import GridImage from 'components/gridImage/gridImage';
 import PageTitle from 'components/page/pageTitle';
 import Hero from 'components/page/hero';
+import HeroRoundel, { roundelMaxMob } from 'components/page/heroRoundel';
 
 import { type ProductPrices } from 'helpers/productPrice/productPrices';
 import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
@@ -27,6 +28,14 @@ type PropTypes = {|
   productPrices: ProductPrices,
   promotionCopy: PromotionCopy,
 |}
+
+const fitHeadline = css`
+  h1 {
+    ${between.mobileMedium.and.tablet} {
+      max-width: calc(100% - ${roundelMaxMob}px);
+    }
+  }
+`;
 
 const heroCopy = css`
   padding: 0 ${space[3]}px ${space[3]}px;
@@ -41,6 +50,10 @@ const heroCopy = css`
 const heroTitle = css`
   ${headline.medium({ fontWeight: 'bold' })};
   margin-bottom: ${space[3]}px;
+
+  ${between.mobileMedium.and.tablet} {
+    margin-right: ${roundelMaxMob}px;
+  }
 
   ${from.tablet} {
     ${headline.large({ fontWeight: 'bold' })};
@@ -78,6 +91,12 @@ const roundelCentreLine = css`
   ${headline.medium({ fontWeight: 'bold' })}
   ${from.tablet} {
     ${headline.xlarge({ fontWeight: 'bold' })}
+  }
+`;
+
+const roundelOffset = css`
+  ${until.tablet} {
+    transform: translateY(-34%);
   }
 `;
 
@@ -136,6 +155,7 @@ function PaperHero({ productPrices, promotionCopy }: PropTypes) {
     <PageTitle
       title="Newspaper subscription"
       theme="paper"
+      cssOverrides={fitHeadline}
     >
       <CentredContainer>
         <Hero
@@ -148,9 +168,12 @@ function PaperHero({ productPrices, promotionCopy }: PropTypes) {
             imgType="png"
             altText="Newspapers"
           />}
-          roundelText={roundelText}
-          roundelNudgeDirection="down"
           hideRoundelBelow="mobileMedium"
+          roundelElement={
+            <HeroRoundel cssOverrides={roundelOffset}>
+              {roundelText}
+            </HeroRoundel>
+          }
         >
           <section css={heroCopy}>
             <h2 css={heroTitle}>

--- a/support-frontend/assets/pages/paper-subscription-landing/components/hero/hero.jsx
+++ b/support-frontend/assets/pages/paper-subscription-landing/components/hero/hero.jsx
@@ -16,7 +16,7 @@ import CentredContainer from 'components/containers/centredContainer';
 import GridImage from 'components/gridImage/gridImage';
 import PageTitle from 'components/page/pageTitle';
 import Hero from 'components/page/hero';
-import HeroRoundel, { roundelMaxMob } from 'components/page/heroRoundel';
+import HeroRoundel, { roundelSizeMob } from 'components/page/heroRoundel';
 
 import { type ProductPrices } from 'helpers/productPrice/productPrices';
 import { sendTrackingEventsOnClick } from 'helpers/subscriptions';
@@ -32,7 +32,7 @@ type PropTypes = {|
 const fitHeadline = css`
   h1 {
     ${between.mobileMedium.and.tablet} {
-      max-width: calc(100% - ${roundelMaxMob}px);
+      max-width: calc(100% - ${roundelSizeMob}px);
     }
   }
 `;
@@ -52,7 +52,7 @@ const heroTitle = css`
   margin-bottom: ${space[3]}px;
 
   ${between.mobileMedium.and.tablet} {
-    margin-right: ${roundelMaxMob}px;
+    margin-right: ${roundelSizeMob}px;
   }
 
   ${from.tablet} {


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This fixes an issue with the roundel on the paper landing page when using a promo code- the headline was getting covered by the roundel on smaller screens.

[**Trello Card**](https://trello.com/c/QkA2DBG7)

## Screenshots

### Breakpoints

**Mobile**
![Screenshot 2021-05-24 at 12 06 21](https://user-images.githubusercontent.com/29146931/119340311-468bae00-bc8a-11eb-9479-90f6246a6c3e.png)

**Mobile Medium**
![Screenshot 2021-05-24 at 12 06 37](https://user-images.githubusercontent.com/29146931/119340337-4db2bc00-bc8a-11eb-8b0a-422ec1b9cff9.png)

**Mobile Landscape**
![Screenshot 2021-05-24 at 12 06 46](https://user-images.githubusercontent.com/29146931/119340365-573c2400-bc8a-11eb-8f5b-c38ff91f15e5.png)

**Phablet**
![Screenshot 2021-05-24 at 12 07 01](https://user-images.githubusercontent.com/29146931/119340406-60c58c00-bc8a-11eb-9921-2d8bef4a87e8.png)

###Devices

**iPhone SE**
![Screenshot 2021-05-24 at 12 16 14](https://user-images.githubusercontent.com/29146931/119340435-6ae78a80-bc8a-11eb-872f-541badf65cae.png)

**Pixel 5**
![Screenshot 2021-05-24 at 12 17 43](https://user-images.githubusercontent.com/29146931/119340459-733fc580-bc8a-11eb-8953-6af2dbbf8200.png)

**iPhone 12**
![Screenshot 2021-05-24 at 12 18 27](https://user-images.githubusercontent.com/29146931/119340481-79ce3d00-bc8a-11eb-97b7-6abc96fcdb3a.png)
