### PR TITLE
Github action to measure compressed size changes to JS on PRs

### DIFF
--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -33,4 +33,4 @@ jobs:
             cwd: './support-frontend'
             pattern: './public/compiled-assets/{javascripts,webpack}/*.js'
             build-script: 'compressed-size-action'
-            minimum-change-threshold: 1000
+            minimum-change-threshold: 500

--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -32,5 +32,5 @@ jobs:
             repo-token: '${{ secrets.GITHUB_TOKEN }}'
             cwd: './support-frontend'
             pattern: './public/compiled-assets/{javascripts,webpack}/*.js'
-            build-script: 'compressed-size-action'
+            build-script: 'build-github-action'
             minimum-change-threshold: 500

--- a/.github/workflows/compressed-size.yml
+++ b/.github/workflows/compressed-size.yml
@@ -1,0 +1,36 @@
+name: Compressed Size
+
+on: [pull_request]
+
+jobs:
+    compressed_size:
+        name: Compressed Size
+        defaults:
+          run:
+            working-directory: support-frontend
+        runs-on: ubuntu-latest
+        steps:
+
+        - name: Checkout code
+          uses: actions/checkout@v2
+
+        - name: Install Node
+          uses: guardian/actions-setup-node@main
+
+        # Cache npm dependencies using https://github.com/bahmutov/npm-install
+        - name: Cache dependencies
+          uses: bahmutov/npm-install@v1
+          with:
+            working-directory: support-frontend
+
+        - name: Install
+          run: yarn
+
+        - name: Check compressed size of JS
+          uses: preactjs/compressed-size-action@v2
+          with:
+            repo-token: '${{ secrets.GITHUB_TOKEN }}'
+            cwd: './support-frontend'
+            pattern: './public/compiled-assets/{javascripts,webpack}/*.js'
+            build-script: 'compressed-size-action'
+            minimum-change-threshold: 1000


### PR DESCRIPTION
This PR introduces a new Github action, "Compressed Size", to `support-frontend`.

Compressed Size runs on every pull request and uses the action https://github.com/preactjs/compressed-size-action. This action checkouts the Pull Request's target branch, runs a build and records the file sizes of the generated JS, it then does the same to the branch under review and generates a comparison of the sizes which it adds to the Pull Request.

To enable this I introduced new `yarn` script `build-github-action` to the `package.json` in this PR: https://github.com/guardian/support-frontend/pull/3082