### PR TITLE
Fix issue with spacing on the pricing cards on the print landing page

### DIFF
--- a/support-frontend/assets/components/product/productOption.jsx
+++ b/support-frontend/assets/components/product/productOption.jsx
@@ -29,7 +29,7 @@ const productOption = css`
   ${textSans.medium()}
   position: relative;
   display: grid;
-  grid-template-rows: 48px minmax(66px, 1fr) 100px 86px;
+  grid-template-rows: 48px minmax(66px, max-content) minmax(100px, 1fr) 72px;
   width: 100%;
   background-color: ${neutral[100]};
   color: ${neutral[7]};
@@ -51,6 +51,7 @@ const productOptionTitle = css`
 `;
 
 const productOptionOfferCopy = css`
+  width: 100%;
   height: 100%;
   padding-bottom: ${space[2]}px;
 `;
@@ -61,6 +62,7 @@ const productOptionPrice = css`
 `;
 
 const productOptionPriceCopy = css`
+  width: 100%;
   height: 100%;
   margin-bottom: ${space[4]}px;
 `;
@@ -102,18 +104,16 @@ function ProductOption(props: Product) {
         {props.label && <span css={productOptionHighlight}>{props.label}</span>}
         {props.children && props.children}
       </div>
+      <p css={[productOptionOfferCopy, productOptionUnderline]}>
+        {props.offerCopy}
+      </p>
+      {/* role="text" is non-standardised but works in Safari. Reads the whole section as one text element */}
+      {/* eslint-disable-next-line jsx-a11y/aria-role */}
+      <p role="text" css={productOptionPriceCopy}>
+        <span css={productOptionPrice}>{props.price}</span>
+        {props.priceCopy}
+      </p>
       <div>
-        <p css={[productOptionOfferCopy, productOptionUnderline]}>
-          {props.offerCopy}
-        </p>
-      </div>
-      <div>
-        {/* role="text" is non-standardised but works in Safari. Reads the whole section as one text element */}
-        {/* eslint-disable-next-line jsx-a11y/aria-role */}
-        <p role="text" css={productOptionPriceCopy}>
-          <span css={productOptionPrice}>{props.price}</span>
-          {props.priceCopy}
-        </p>
         <ThemeProvider theme={buttonReaderRevenue}>
           <LinkButton
             href={props.href}

--- a/support-frontend/assets/components/product/productOption.jsx
+++ b/support-frontend/assets/components/product/productOption.jsx
@@ -51,7 +51,6 @@ const productOptionTitle = css`
 `;
 
 const productOptionOfferCopy = css`
-  width: 100%;
   height: 100%;
   padding-bottom: ${space[2]}px;
 `;
@@ -62,7 +61,6 @@ const productOptionPrice = css`
 `;
 
 const productOptionPriceCopy = css`
-  width: 100%;
   height: 100%;
   margin-bottom: ${space[4]}px;
 `;


### PR DESCRIPTION
<!-- all sections optional, delete any you don't need -->
## What are you doing in this PR?

This fixes an issue where text running over too many lines would become hidden by the pricing card CTA at the tablet breakpoint. As the fix is on the shared `ProductOption` component, I've included screenshots of the other product pages below to demonstrate that there's no regression.

[**Trello Card**](https://trello.com/c/ZwRqNcnw)

## Screenshots

### Paper landing page

**iPad 8th gen**
![Screenshot 2021-05-24 at 15 02 46](https://user-images.githubusercontent.com/29146931/119360936-071d8b80-bca3-11eb-9e69-0dd5b531964c.png)

**Google Nexus 9**
![Screenshot 2021-05-24 at 15 08 18](https://user-images.githubusercontent.com/29146931/119360968-10a6f380-bca3-11eb-9d8e-b153bd4f4386.png)

### Other landing pages (on iPad 8th gen)

**Digital subscription**
![Screenshot 2021-05-24 at 15 06 12](https://user-images.githubusercontent.com/29146931/119361053-23b9c380-bca3-11eb-9ec0-9c83688ee57b.png)

**Guardian Weekly**
![Screenshot 2021-05-24 at 15 03 28](https://user-images.githubusercontent.com/29146931/119361106-33390c80-bca3-11eb-847d-fb2dd8e03de5.png)
