### PR TITLE
Add build-github-action script to package.json

### DIFF
--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -22,7 +22,8 @@
     "cache-ssr": "node scripts/ssrScript.js",
     "jest-update-snapshot": "echo 'Updating JS tests' && jest -u",
     "flow-typed-install": "flow-typed install -s -o --ignoreDeps peer bundle",
-    "orphans": "echo 'Checking for orphan modules' && node scripts/orphans.js"
+    "orphans": "echo 'Checking for orphan modules' && node scripts/orphans.js",
+    "compressed-size-action": "yarn clean && CI_ENV=github webpack --config webpack.prod.js --env.prod"
   },
   "browserslist": [
     "Chrome >= 49",

--- a/support-frontend/package.json
+++ b/support-frontend/package.json
@@ -10,6 +10,7 @@
     "build-dev": "webpack --config webpack.dev.js",
     "build-ssr": "webpack --config webpack.ssr.js && node scripts/ssrScript.js",
     "build-prod": "npm-run-all clean validate test storybook-static 'webpack --config webpack.prod.js --env.prod'",
+    "build-github-action": "yarn clean && CI_ENV=github webpack --config webpack.prod.js --env.prod",
     "webpack": "webpack",
     "webpack-dev-server": "webpack-dev-server --config webpack.dev.js --port 9211 --public support.thegulocal.com --disable-host-check",
     "devrun": "npm-run-all clean webpack-dev-server",
@@ -22,8 +23,7 @@
     "cache-ssr": "node scripts/ssrScript.js",
     "jest-update-snapshot": "echo 'Updating JS tests' && jest -u",
     "flow-typed-install": "flow-typed install -s -o --ignoreDeps peer bundle",
-    "orphans": "echo 'Checking for orphan modules' && node scripts/orphans.js",
-    "compressed-size-action": "yarn clean && CI_ENV=github webpack --config webpack.prod.js --env.prod"
+    "orphans": "echo 'Checking for orphan modules' && node scripts/orphans.js"
   },
   "browserslist": [
     "Chrome >= 49",

--- a/support-frontend/webpack.common.js
+++ b/support-frontend/webpack.common.js
@@ -61,7 +61,7 @@ class CleanUpStatsPlugin {
   }
 }
 
-module.exports = (cssFilename, outputFilename, minimizeCss) => ({
+module.exports = (cssFilename, jsFilename, minimizeCss) => ({
   plugins: [
     new ManifestPlugin({
       fileName: '../../conf/assets.map',
@@ -90,8 +90,8 @@ module.exports = (cssFilename, outputFilename, minimizeCss) => ({
 
   output: {
     path: path.resolve(__dirname, 'public/compiled-assets'),
-    chunkFilename: 'webpack/[chunkhash].js',
-    filename: `javascripts/${outputFilename}`,
+    chunkFilename: `webpack/${jsFilename}`,
+    filename: `javascripts/${jsFilename}`,
     publicPath: '/assets/',
   },
 

--- a/support-frontend/webpack.prod.js
+++ b/support-frontend/webpack.prod.js
@@ -3,7 +3,7 @@ const { merge } = require('webpack-merge');
 const common = require('./webpack.common.js');
 const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
 
-const jsFileName = process.env.CI_ENV !== 'github' ? '[name].[chunkhash].js' : '[name].js';
+const jsFileName = process.env.CI_ENV === 'github' ? '[name].js' : '[name].[chunkhash].js';
 
 module.exports = merge(common('[name].[chunkhash].css', jsFileName, true), {
   mode: 'production',

--- a/support-frontend/webpack.prod.js
+++ b/support-frontend/webpack.prod.js
@@ -3,7 +3,9 @@ const { merge } = require('webpack-merge');
 const common = require('./webpack.common.js');
 const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
 
-module.exports = merge(common('[name].[chunkhash].css', '[name].[chunkhash].js', true), {
+const jsFileName = process.env.CI_ENV !== 'github' ? '[name].[chunkhash].js' : '[name].js';
+
+module.exports = merge(common('[name].[chunkhash].css', jsFileName, true), {
   mode: 'production',
   devtool: 'source-map',
   plugins: [


### PR DESCRIPTION
This PR introduces a new `yarn` script `build-github-action` to the `package.json`. This script builds the production assets without hashing the filenames. The script is to be used by a new "Compressed Size" Github Action: https://github.com/guardian/support-frontend/pull/3079

I'm submitting the change that introduces the script in this advance-PR, and I'll introduce the action in a follow-up PR: https://github.com/guardian/support-frontend/pull/3079. I'm doing this as in order for the action to work the target branch needs to have the build script specified in the action's `.yml` file already in place. 

The weback configuration has been updated so when so the process environment variable `CI_ENV === "github"` is true we omit hashes from the generated filenames, and when `CI_ENV !== "github"` we include hashes for cache busting purposes. I've done this as it makes the incoming action's output easier to read when I posts the results to any PR it runs on.

I've tested the output of the updated build steps on `CODE` and this all works as expected.